### PR TITLE
deploy: refuse in-place overwrite of an in-use libvirt golden (#5043)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45475,3 +45475,25 @@ top.
 - **File(s)**: scripts/deploy/xpf-deploy.py,
   scripts/deploy/test_xpf_deploy_image_roll_identity.py,
   docs/in-place-upgrade.md, _Log.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: #5043 — refuse in-place overwrite of a libvirt golden qcow2 that
+  has dependent overlays. `fetch --install-libvirt` did
+  `shutil.copyfile(srcq, golden)` straight over the stable alias
+  `/var/lib/libvirt/images/{image}.qcow2` — an IMMUTABLE shared backing store
+  (per-VM overlays are `qemu-img create -b <golden>`), so a re-fetch over an
+  in-use golden shifted the backing bytes under every overlay and corrupted
+  both HA nodes' disks. Added `_qcow2_backing_file()` (parses `qemu-img info
+  --output=json`) and `_dependent_overlays()` (scans sibling `*.qcow2` for
+  backers of the golden); `_install_libvirt_golden()` now fails closed with a
+  clear operator message (destroy dependents, or install under a fresh
+  `--alias`) when the golden exists AND has dependents. First install and a
+  re-fetch with no dependents still copy. Added 5 tests to
+  test_xpf_deploy_disk.py (RED on revert: the overwrite-refused test loses its
+  SystemExit when the guard is removed). Documented the golden-immutability
+  contract in docs/distribution.md.
+  Validation: `python3 -m py_compile scripts/deploy/xpf-deploy.py` clean;
+  `bash scripts/run-selftests.sh` green (38 passed, 0 failed); RED-on-revert
+  proven (monkeypatched pre-fix copy -> overwrite-refused test FAILs).
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_disk.py, docs/distribution.md, _Log.md

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -206,6 +206,27 @@ per-VM copy-on-write overlay backed read-only by the golden. `--install-libvirt`
 is the one step that moves the *verified* qcow2 to the shared golden path; both
 sides derive that path from the same helper so they cannot drift.
 
+**Golden immutability — re-fetch over an in-use golden is REFUSED (#5043).**
+The golden is a *shared, read-only backing store*: each per-VM overlay is
+`qemu-img create -b <golden>` and depends on the golden's bytes never changing.
+Overwriting it in place while overlays back onto it shifts the backing bytes
+under every live overlay and corrupts them — and because an HA pair usually
+shares one golden, a single re-fetch would poison *both* nodes' disks. So
+`fetch --install-libvirt` refuses to overwrite a golden that still has
+dependent overlays (it scans `/var/lib/libvirt/images/*.qcow2` and checks each
+one's `qemu-img info` backing file). First install (no golden yet) and a
+re-fetch after the dependents are gone both proceed normally. To roll a new
+image onto hosts with live VMs, EITHER:
+
+- destroy the dependent VM(s) first so no overlay references the old golden —
+  `xpf-deploy.py --hypervisor libvirt destroy <appliance.yaml>` per VM — then
+  re-run `fetch --install-libvirt`; OR
+- install the new image under a *fresh tag* so existing overlays keep their
+  immutable backing —
+  `fetch --install-libvirt --alias xpf-<newver>` — and point the deploy YAML at
+  `image: xpf-<newver>`. New VMs boot from the new golden; already-deployed VMs
+  keep running on the old one until you redeploy them.
+
 ### CAUTION — interface takeover (#1879)
 
 `xpfd` owns and renames every interface on the host. A bare-metal `apt install

--- a/scripts/deploy/test_xpf_deploy_disk.py
+++ b/scripts/deploy/test_xpf_deploy_disk.py
@@ -27,6 +27,9 @@ path and it IS the golden.
 from __future__ import annotations
 
 import importlib.util
+import os
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -163,6 +166,110 @@ class LibvirtPerVmDiskTests(unittest.TestCase):
         r = RecordingRunner()
         with self.assertRaises(SystemExit):
             xpf_deploy.deploy_libvirt(ap, r, start=False)
+
+
+class LibvirtGoldenOverwriteGuardTests(unittest.TestCase):
+    """#5043: `fetch --install-libvirt` must NOT overwrite a golden qcow2 in
+    place while per-VM overlays back onto it — that shifts the immutable
+    backing bytes under every overlay and corrupts them (both HA nodes commonly
+    share one golden). First install (no golden yet) and a re-fetch with no
+    dependent overlays stay allowed; the dangerous in-place overwrite of an
+    in-use golden fails closed.
+
+    On revert (drop the guard so `_install_libvirt_golden` copies over any
+    existing golden unconditionally) the refuse/no-clobber assertions in
+    test_overwrite_with_dependent_overlay_is_refused go RED.
+    """
+
+    def setUp(self):
+        # A private temp dir stands in for /var/lib/libvirt/images so the copy
+        # path is writable (no sudo) and the scan sees only our fixtures.
+        self._imgdir = tempfile.mkdtemp(prefix="xpf-golden-images-")
+        self._srcdir = tempfile.mkdtemp(prefix="xpf-golden-src-")
+        self._orig_images = xpf_deploy.LIBVIRT_IMAGES
+        self._orig_backing = xpf_deploy._qcow2_backing_file
+        xpf_deploy.LIBVIRT_IMAGES = self._imgdir
+        # Fake the qemu-img backing probe so the test is hermetic (no qemu-img
+        # required): a {realpath: backing-or-None} map drives the classifier.
+        self._backing = {}
+
+        def fake_backing(path):
+            return self._backing.get(os.path.realpath(path))
+
+        xpf_deploy._qcow2_backing_file = fake_backing
+
+    def tearDown(self):
+        xpf_deploy.LIBVIRT_IMAGES = self._orig_images
+        xpf_deploy._qcow2_backing_file = self._orig_backing
+        shutil.rmtree(self._imgdir, ignore_errors=True)
+        shutil.rmtree(self._srcdir, ignore_errors=True)
+
+    def _write(self, path, content):
+        with open(path, "wb") as f:
+            f.write(content)
+        return path
+
+    def _src(self, content=b"VERIFIED-NEW-GOLDEN"):
+        # Source lives OUTSIDE the images dir so it is never scanned as an
+        # overlay (mirrors the real fetch out-dir).
+        return self._write(os.path.join(self._srcdir, "verified.qcow2"), content)
+
+    def _golden_path(self, image="xpf-appliance"):
+        return os.path.join(self._imgdir, f"{image}.qcow2")
+
+    def test_first_install_copies_the_golden(self):
+        # No golden present yet -> the copy proceeds (first-install path).
+        src = self._src(b"GOLDEN-V1")
+        dst = xpf_deploy._install_libvirt_golden(src, "xpf-appliance")
+        self.assertEqual(os.path.realpath(dst),
+                         os.path.realpath(self._golden_path()))
+        with open(dst, "rb") as f:
+            self.assertEqual(f.read(), b"GOLDEN-V1")
+
+    def test_refetch_without_dependent_overlays_replaces(self):
+        # Golden exists, but nothing backs onto it -> legitimate re-fetch is
+        # allowed and the golden is replaced with the new verified bytes.
+        golden = self._write(self._golden_path(), b"GOLDEN-V1")
+        # An unrelated image in the same dir (its own full image, no backing).
+        other = self._write(os.path.join(self._imgdir, "some-other.qcow2"), b"x")
+        self._backing[os.path.realpath(other)] = None
+        xpf_deploy._install_libvirt_golden(self._src(b"GOLDEN-V2"), "xpf-appliance")
+        with open(golden, "rb") as f:
+            self.assertEqual(f.read(), b"GOLDEN-V2")
+
+    def test_overwrite_with_dependent_overlay_is_refused(self):
+        # Golden exists AND a per-VM overlay backs onto it -> refuse, and the
+        # golden bytes must be UNCHANGED (no partial clobber before the die).
+        golden = self._write(self._golden_path(), b"GOLDEN-V1")
+        overlay = self._write(os.path.join(self._imgdir, "ha-fw0.qcow2"), b"ovl")
+        self._backing[os.path.realpath(overlay)] = os.path.realpath(golden)
+        with self.assertRaises(SystemExit):
+            xpf_deploy._install_libvirt_golden(self._src(b"GOLDEN-V2"),
+                                               "xpf-appliance")
+        with open(golden, "rb") as f:
+            self.assertEqual(f.read(), b"GOLDEN-V1",
+                             "golden must not be touched when overwrite refused")
+
+    def test_dependent_overlays_lists_only_true_backers(self):
+        golden = self._write(self._golden_path(), b"G")
+        dep0 = self._write(os.path.join(self._imgdir, "ha-fw0.qcow2"), b"a")
+        dep1 = self._write(os.path.join(self._imgdir, "ha-fw1.qcow2"), b"b")
+        indep = self._write(os.path.join(self._imgdir, "unrelated.qcow2"), b"c")
+        self._backing[os.path.realpath(dep0)] = os.path.realpath(golden)
+        self._backing[os.path.realpath(dep1)] = os.path.realpath(golden)
+        # Backs onto a DIFFERENT golden -> not a dependent of this one.
+        self._backing[os.path.realpath(indep)] = "/var/lib/libvirt/images/other.qcow2"
+        deps = {os.path.realpath(d)
+                for d in xpf_deploy._dependent_overlays(golden)}
+        self.assertEqual(deps,
+                         {os.path.realpath(dep0), os.path.realpath(dep1)})
+
+    def test_golden_is_not_its_own_overlay(self):
+        # A golden whose own backing (spuriously) resolves to itself must never
+        # be reported as a dependent overlay of itself.
+        golden = self._write(self._golden_path(), b"G")
+        self._backing[os.path.realpath(golden)] = os.path.realpath(golden)
+        self.assertEqual(xpf_deploy._dependent_overlays(golden), [])
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -671,11 +671,90 @@ def libvirt_overlay_path(name):
     return contained_join(LIBVIRT_IMAGES, f"{name}.qcow2", "per-VM overlay")
 
 
+def _qcow2_backing_file(path):
+    """Absolute (realpath) backing-file of a qcow2 image, or None.
+
+    Parses `qemu-img info --output=json` and returns the resolved
+    `full-backing-filename` (falling back to `backing-filename`), or None when
+    the image has no backing file, is unreadable, or qemu-img is absent.
+    qemu-img is a hard dependency of the libvirt overlay-create path
+    (`libvirt_disk` -> `qemu-img create`), so its absence means this tool
+    never created an overlay here — treating "unknown" as "no backing" is
+    therefore safe for the overwrite guard below (#5043)."""
+    try:
+        r = subprocess.run(["qemu-img", "info", "--output=json", path],
+                           capture_output=True, text=True)
+    except FileNotFoundError:
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        info = json.loads(r.stdout)
+    except (ValueError, TypeError):
+        return None
+    bf = info.get("full-backing-filename") or info.get("backing-filename")
+    return os.path.realpath(bf) if bf else None
+
+
+def _dependent_overlays(golden):
+    """Per-VM overlay qcow2 files in the golden's directory that back onto it.
+
+    `libvirt_disk` creates each VM's overlay as `qemu-img create -b <golden>`,
+    so the overlay depends on the golden's bytes being IMMUTABLE. Overwriting
+    the golden in place shifts the backing bytes under every one of these
+    overlays and corrupts them (#5043) — commonly BOTH HA nodes at once, since
+    a cluster pair shares one golden. Scans sibling `*.qcow2` files and returns
+    the sorted absolute paths whose backing file resolves to `golden` (empty
+    when none, or when the images dir is missing/unreadable)."""
+    golden_real = os.path.realpath(golden)
+    imgdir = os.path.dirname(golden_real)
+    deps = []
+    try:
+        entries = sorted(os.listdir(imgdir))
+    except OSError:
+        return deps
+    for entry in entries:
+        if not entry.endswith(".qcow2"):
+            continue
+        cand = os.path.join(imgdir, entry)
+        if os.path.realpath(cand) == golden_real:
+            continue  # the golden is not its own overlay
+        if not os.path.isfile(cand):
+            continue
+        if _qcow2_backing_file(cand) == golden_real:
+            deps.append(os.path.abspath(cand))
+    return deps
+
+
 def _install_libvirt_golden(srcq, image):
     """Install a verified qcow2 to the libvirt golden path deploy reads
     (fable-165 H-30). Falls back to `sudo install` when the images dir is
-    root-owned (the common case). Returns the destination path."""
+    root-owned (the common case). Returns the destination path.
+
+    Golden-immutability contract (#5043): the golden is a SHARED read-only
+    backing store — every per-VM overlay is `qemu-img create -b <golden>` and
+    depends on its bytes NEVER changing. Overwriting it in place while overlays
+    back onto it shifts the backing bytes under live/created overlays and
+    corrupts EVERY one (both HA nodes commonly share one golden — a single
+    re-fetch would poison both disks). First install (no golden yet) and a
+    legitimate re-fetch with no dependent overlays are safe; the dangerous
+    in-place overwrite of an in-use golden fails closed with a clear operator
+    message."""
     golden = libvirt_golden_path(image)
+    if os.path.isfile(golden):
+        deps = _dependent_overlays(golden)
+        if deps:
+            listing = "\n    - ".join(deps)
+            die(f"refusing to overwrite golden {golden} in place: "
+                f"{len(deps)} per-VM overlay(s) back onto it and would be "
+                f"corrupted (the qcow2 backing bytes would shift under a live "
+                f"disk — HA-pair disk corruption, #5043):\n    - {listing}\n"
+                f"  Fix by EITHER destroying the dependent VM(s) first "
+                f"(xpf-deploy.py --hypervisor libvirt destroy <appliance.yaml> "
+                f"for each), OR installing the new image under a fresh tag so "
+                f"existing overlays keep their immutable backing "
+                f"(fetch --install-libvirt --alias <new-name>, then reference "
+                f"image: <new-name> in the deploy YAML).")
     print(f"==> installing verified qcow2 -> {golden} (libvirt golden)")
     try:
         os.makedirs(os.path.dirname(golden), exist_ok=True)


### PR DESCRIPTION
Closes #5043

## Problem

`fetch --install-libvirt` installed the verified qcow2 by copying it straight over the stable alias `/var/lib/libvirt/images/{image}.qcow2` (`_install_libvirt_golden`: `shutil.copyfile(srcq, golden)`, with a `sudo install` fallback). That golden is an **immutable shared backing store** — `deploy --hypervisor libvirt` gives each VM a copy-on-write overlay created `qemu-img create -b <golden>`, so the overlay depends on the golden's bytes never changing.

Overwriting the golden in place while overlays back onto it shifts the backing bytes under every live/created overlay and corrupts them. Because an HA pair commonly shares one golden, a single re-fetch would poison **both** nodes' disks on the next I/O — one management action breaking HA failure independence.

## Fix

Fail closed on the dangerous case (issue option (a)):

- `_qcow2_backing_file(path)` — resolves a qcow2's backing file via `qemu-img info --output=json`.
- `_dependent_overlays(golden)` — scans sibling `*.qcow2` in the images dir for any that back onto the golden.
- `_install_libvirt_golden()` now **refuses** the overwrite when the golden already exists **AND** has dependent overlays, with an operator message pointing at the two safe paths:
  - destroy the dependent VM(s) first (`--hypervisor libvirt destroy <yaml>` per VM), then re-fetch; or
  - install the new image under a **fresh `--alias`** so existing overlays keep their immutable backing and only new VMs use the new golden.

First install (no golden yet) and a legitimate re-fetch with no dependents still copy as before; the `sudo install` permission fallback is preserved. qemu-img is a hard dependency of the overlay-create path, so its absence means no overlay was ever created here — treating an unreadable backing as "no backing" cannot silently disable the guard for a real overlay.

**Overwrite guard:** `scripts/deploy/xpf-deploy.py` `_install_libvirt_golden()` (the `if os.path.isfile(golden): deps = _dependent_overlays(golden); if deps: die(...)` block).

## Tests (RED on revert)

Added 5 tests to `scripts/deploy/test_xpf_deploy_disk.py`:
- `test_first_install_copies_the_golden` — no golden yet → copy proceeds.
- `test_refetch_without_dependent_overlays_replaces` — golden with no backers → replace.
- `test_overwrite_with_dependent_overlay_is_refused` — golden + dependent overlay → `SystemExit`, golden bytes **unchanged**.
- `test_dependent_overlays_lists_only_true_backers` — classifier lists only true backers.
- `test_golden_is_not_its_own_overlay` — a golden is never its own dependent.

**RED-on-revert proven:** monkeypatching `_install_libvirt_golden` back to the pre-fix unconditional copy makes `test_overwrite_with_dependent_overlay_is_refused` fail (`SystemExit not raised`); the first-install/re-fetch/classifier tests correctly stay green.

## Docs

Documented the golden-immutability contract + the two safe roll-forward workflows in `docs/distribution.md` (the `--install-libvirt` section).

## Validation

- `python3 -m py_compile scripts/deploy/xpf-deploy.py` — clean
- `bash scripts/run-selftests.sh` — green (38 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)