### PR TITLE
test/incus: add submit-side K3 monotonicity guard (I14) to histogram classifier

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-10 — #5077 submit-latency classifier K3 monotonicity (I14) mirror
+- **Timestamp**: 2026-07-10 (fix/5077-classifier-submit-monotonicity)
+- **Action**: Mirror the #827 kick-side K3 cross-snapshot monotonicity guard
+  onto the submit side of the step1 histogram classifier. The submit delta
+  loop normalized whenever `count_delta > 0` without checking `buckets_delta
+  < 0` or cumulative-count monotonicity, so a counter RESET (daemon restart,
+  wrap) — total count 10000->12000 while a low-frequency bucket goes
+  1000->0 — emitted NEGATIVE bucket deltas and fed a non-probability shape
+  (negative bucket fractions) into the D1/D2 permutation stats: a false
+  PASS in the perf gate. Added the I14 guard (submit-side analog of K3):
+  pre-delta cross-snapshot monotonicity on tx_submit_latency_count / _sum_ns,
+  tx_packets, and every submit histogram bucket; any non-monotonic cumulative
+  value H-STOPs the cell instead of classifying. Updated `compute_blocks`
+  docstring to document the I14 monotonicity contract. Added 5 tests (count/
+  sum_ns/tx_packets/hist-bucket backwards + the exact reset-and-recover
+  scenario, plus a positive monotonic-still-classifies pin).
+  Validation: `python3 -m py_compile` clean; `pytest
+  step1-histogram-classify_test.py` 16 passed; RED-on-revert proven — the 4
+  I14 negative tests all "DID NOT RAISE" against the origin/master pre-fix
+  source, positive test still passes.
+- **File(s)**: test/incus/step1-histogram-classify.py,
+  test/incus/step1-histogram-classify_test.py, _Log.md
+
 ## 2026-07-10 — #5283 SNMPv3 EngineID per-device uniqueness (cross-clone USM auth-bypass fix)
 - **Timestamp**: 2026-07-10 (fix/5283-snmp-engineid-unique)
 - **Action**: Fix #5283 cross-device USM auth bypass. buildEngineID/initEngine

--- a/test/incus/step1-histogram-classify.py
+++ b/test/incus/step1-histogram-classify.py
@@ -199,14 +199,20 @@ def compute_blocks(snaps: list[dict]) -> list[dict]:
 
     I13 is enforced inside `sum_per_binding_hist` on each raw snapshot
     BEFORE any delta is taken, so a compensating corruption across
-    snapshots cannot sneak past a delta-only check.  Here we only
-    compute arithmetic deltas on already-validated aggregates.
+    snapshots cannot sneak past a delta-only check.  I14 (below) then
+    enforces cross-snapshot monotonicity on the cumulative submit
+    counters + histogram — the submit-side analog of the #827 K3 kick
+    guard — so a counter RESET (daemon restart, wrap) cannot produce a
+    negative bucket delta that escapes into the classified shape.  The
+    per-block loop then computes arithmetic deltas on already-validated,
+    monotonic aggregates.
 
     #827 P3 extension: also aggregates kick counters per snapshot via
     `sum_per_binding_kick` (which enforces K0 + K1) and cross-snapshot
     monotonicity (K3) pre-delta. K2 is enforced below alongside the
-    submit-side §9 guard. Step1 is the sole writer of the per-block
-    `tx_kick_*_delta` fields consumed by `step3-tx-kick-classify.py`.
+    submit-side §9 guard, and I14 mirrors K3 for the submit side. Step1
+    is the sole writer of the per-block `tx_kick_*_delta` fields consumed
+    by `step3-tx-kick-classify.py`.
     """
     aggregated = [sum_per_binding_hist(s) for s in snaps]
     kick_aggregated = [sum_per_binding_kick(s, i) for i, s in enumerate(snaps)]
@@ -252,6 +258,44 @@ def compute_blocks(snaps: list[dict]) -> list[dict]:
             bad = int(np.argmin(bucket_diff))
             raise ValueError(
                 f"K3 violation: non-monotonic tx_kick_latency_hist[{bad}] "
+                f"between snap[{i - 1}]={int(h_prev[bad])} and "
+                f"snap[{i}]={int(h_cur[bad])}"
+            )
+    # #5077 I14 — submit-side cross-snapshot monotonicity, the direct analog
+    # of the #827 K3 kick guard. `aggregated` carries the cumulative submit
+    # counters (tx_submit_latency_count / _sum_ns, tx_packets) and the
+    # cumulative 16-bucket submit histogram. A counter RESET (daemon restart,
+    # wrap) can move the total count 10000->12000 while a low-frequency bucket
+    # drops 1000->0, so the per-block `buckets_delta` below would go NEGATIVE
+    # and feed a non-probability `shape` (negative bucket fractions) into the
+    # D1/D2 permutation stats — a false PASS. Enforced pre-delta so a
+    # reset-and-recover cell H-STOPs instead of classifying, exactly as K3
+    # does on the kick side. Before #5077 the submit delta loop only checked
+    # `count_delta > 0`, never `buckets_delta < 0` or cumulative-count
+    # monotonicity, so a reset silently emitted negative deltas.
+    for i in range(1, len(aggregated)):
+        h_prev, c_prev, s_prev, txp_prev = aggregated[i - 1]
+        h_cur, c_cur, s_cur, txp_cur = aggregated[i]
+        if c_cur < c_prev:
+            raise ValueError(
+                f"I14 violation: non-monotonic tx_submit_latency_count "
+                f"between snap[{i - 1}]={c_prev} and snap[{i}]={c_cur}"
+            )
+        if s_cur < s_prev:
+            raise ValueError(
+                f"I14 violation: non-monotonic tx_submit_latency_sum_ns "
+                f"between snap[{i - 1}]={s_prev} and snap[{i}]={s_cur}"
+            )
+        if txp_cur < txp_prev:
+            raise ValueError(
+                f"I14 violation: non-monotonic tx_packets "
+                f"between snap[{i - 1}]={txp_prev} and snap[{i}]={txp_cur}"
+            )
+        bucket_diff = h_cur - h_prev
+        if np.any(bucket_diff < 0):
+            bad = int(np.argmin(bucket_diff))
+            raise ValueError(
+                f"I14 violation: non-monotonic tx_submit_latency_hist[{bad}] "
                 f"between snap[{i - 1}]={int(h_prev[bad])} and "
                 f"snap[{i}]={int(h_cur[bad])}"
             )

--- a/test/incus/step1-histogram-classify_test.py
+++ b/test/incus/step1-histogram-classify_test.py
@@ -313,6 +313,139 @@ def test_kick_delta_fields_emitted_correctly():
         assert len(blk["tx_kick_hist_delta"]) == 16
 
 
+# ------------------------------------------------- 23 (#5077 I14) ------
+def test_i14_submit_count_backwards_caught():
+    """Submit cumulative count goes backwards across snaps → I14 (mirrors K3)."""
+    cumulative = [
+        {
+            "submit_count": 100 * i,
+            "submit_sum_ns": 1000 * i,
+            "tx_packets": 2000 * i,
+            "kick_count": 50 * i,
+            "kick_sum_ns": 10 * i,
+            "kick_retry": i,
+        }
+        for i in range(13)
+    ]
+    cumulative[6]["submit_count"] = 100  # reset below snap 5's 500
+    snaps = make_13_snaps(cumulative)
+    with pytest.raises(ValueError, match="non-monotonic tx_submit_latency_count"):
+        step1.compute_blocks(snaps)
+
+
+# ------------------------------------------------- 24 (#5077 I14) ------
+def test_i14_submit_sum_ns_backwards_caught():
+    cumulative = [
+        {
+            "submit_count": 100 * i,
+            "submit_sum_ns": 1000 * i,
+            "tx_packets": 2000 * i,
+            "kick_count": 50 * i,
+            "kick_sum_ns": 10 * i,
+            "kick_retry": i,
+        }
+        for i in range(13)
+    ]
+    cumulative[6]["submit_sum_ns"] = 100  # reset below prior
+    snaps = make_13_snaps(cumulative)
+    with pytest.raises(ValueError, match="non-monotonic tx_submit_latency_sum_ns"):
+        step1.compute_blocks(snaps)
+
+
+# ------------------------------------------------- 25 (#5077 I14) ------
+def test_i14_tx_packets_backwards_caught():
+    cumulative = [
+        {
+            "submit_count": 100 * i,
+            "submit_sum_ns": 1000 * i,
+            "tx_packets": 2000 * i,
+            "kick_count": 50 * i,
+            "kick_sum_ns": 10 * i,
+            "kick_retry": i,
+        }
+        for i in range(13)
+    ]
+    cumulative[6]["tx_packets"] = 100  # reset below prior
+    snaps = make_13_snaps(cumulative)
+    with pytest.raises(ValueError, match="non-monotonic tx_packets"):
+        step1.compute_blocks(snaps)
+
+
+# ------------------------------------------------- 26 (#5077 I14) ------
+def test_i14_submit_hist_reset_and_recover_caught():
+    """The #5077 core: a counter RESET drives a submit bucket negative.
+
+    A low-frequency bucket drops 600->0 while the total submit count still
+    RISES (6600->7700->8800), exactly the "count 10000->12000 while a bucket
+    goes 1000->0" scenario in the issue. The pre-#5077 delta loop only
+    checked `count_delta > 0`, so it normalized a NEGATIVE bucket delta into
+    a non-probability shape (negative bucket fractions) and classified the
+    cell as non-suspect — a false PASS. I14 must H-STOP instead.
+    """
+    snaps = []
+    for i in range(13):
+        hist = [0] * 16
+        hist[0] = 1000 * i  # high-frequency bucket, cumulative
+        hist[5] = 100 * i  # low-frequency bucket, cumulative
+        count = hist[0] + hist[5]
+        snaps.append(
+            make_snap(
+                [
+                    make_binding(
+                        submit_count=count,
+                        submit_sum_ns=5000 * i,
+                        tx_packets=2000 * i,
+                        submit_hist=hist,
+                        kick_count=500 * i,  # nonzero → no K2 false-trip
+                    )
+                ]
+            )
+        )
+    # Simulate a daemon restart at snap 7: the low-frequency bucket 5 resets
+    # to 0 while total count still rises (bucket 0 absorbs it, keeping count
+    # monotonic and I13 intact so I14's histogram check is what fires).
+    reset = snaps[7]["status"]["per_binding"][0]
+    new_hist = [0] * 16
+    new_hist[0] = reset["tx_submit_latency_count"]  # 7700
+    new_hist[5] = 0  # backwards from snap 6's cumulative 600
+    reset["tx_submit_latency_hist"] = new_hist
+    reset["tx_submit_latency_count"] = sum(new_hist)  # keep I13 (== bucket 0)
+    with pytest.raises(
+        ValueError, match=r"non-monotonic tx_submit_latency_hist\[5\]"
+    ):
+        step1.compute_blocks(snaps)
+
+
+# ------------------------------------------------- 27 (#5077 I14) ------
+def test_i14_monotonic_submit_still_classifies():
+    """Positive path: a clean monotonic submit stream is NOT flagged by I14."""
+    snaps = []
+    for i in range(13):
+        hist = [0] * 16
+        hist[0] = 1000 * i
+        hist[5] = 100 * i
+        count = hist[0] + hist[5]
+        snaps.append(
+            make_snap(
+                [
+                    make_binding(
+                        submit_count=count,
+                        submit_sum_ns=5000 * i,
+                        tx_packets=2000 * i,
+                        submit_hist=hist,
+                        kick_count=500 * i,
+                    )
+                ]
+            )
+        )
+    blocks = step1.compute_blocks(snaps)
+    assert len(blocks) == 12
+    # No negative bucket delta escaped into any classified block.
+    for blk in blocks:
+        assert all(x >= 0 for x in blk["buckets"]), blk["buckets"]
+        assert all(x >= 0.0 for x in blk["shape"]), blk["shape"]
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #5077

## Problem
The step1 submit-latency histogram classifier's delta loop
(`test/incus/step1-histogram-classify.py`) normalized a block whenever
`count_delta > 0`, **without** checking `buckets_delta < 0` or
cumulative-count monotonicity. The kick side already has the full #827
**K3** cross-snapshot monotonicity guard; the submit side did not.

After a counter **RESET** (daemon restart, wrap) the total submit count can
rise `10000 -> 12000` while a low-frequency bucket drops `1000 -> 0`. The
arithmetic bucket delta then goes negative and, divided by a positive
`count_delta`, produces a non-probability `shape` (negative bucket fractions
like `-0.5` / `1.5`). Those feed the D1/D2 Fisher-Pitman permutation stats and
let a reset-and-recover cell pass as **non-suspect** — a false PASS in a perf
gate.

## Fix
Mirror K3 onto the submit side as **I14** (next in the submit-side
`I11`/`I12`/`I13` invariant series, explicitly noted as the analog of the
kick-side K3). A pre-delta cross-snapshot monotonicity check on:
- `tx_submit_latency_count`
- `tx_submit_latency_sum_ns`
- `tx_packets`
- every submit histogram bucket (`np.any(bucket_diff < 0)`)

Any decrease in a cumulative counter H-STOPs the cell (`ValueError: I14
violation: non-monotonic ...`) rather than emitting a negative bucket delta —
byte-for-byte the same policy the kick side uses. The two sides are now
symmetric. The `compute_blocks` docstring is updated to document the I14
monotonicity contract.

## Validation
- `python3 -m py_compile test/incus/step1-histogram-classify.py` — clean
- `pytest test/incus/step1-histogram-classify_test.py` — **16 passed**
- **RED-on-revert:** the four I14 negative tests (count / sum_ns / tx_packets /
  hist-bucket backwards, including the exact reset-and-recover scenario from
  the issue) all fail with `DID NOT RAISE ValueError` against the
  origin/master pre-fix source; the positive `monotonic-still-classifies` pin
  still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)