### PR TITLE
grpcapi: zeroize the configured config root, not /etc/xpf

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45616,3 +45616,41 @@ top.
   green; RED-on-revert proven (flipping `ones > bestLen` to pick the shortest
   prefix fails the selection assertions; reverted, production file clean).
 - **File(s)**: pkg/cli/cli_request_testrouting_4832_test.go, _Log.md
+
+- **Timestamp**: 2026-07-10
+- **Action**: #5280 zeroize wipes the CONFIGURED config root, not a hardcoded
+  /etc/xpf. `performZeroizeWipe` was `func() error` calling
+  `zeroizeConfigDir(defaultConfigDir="/etc/xpf", defaultConfigBase="xpf.conf")`
+  — a daemon started with a non-default `-config` (e.g. /srv/xpf/site.conf)
+  wiped /etc/xpf while the real .configdb SSOT + master.key, rollback slots and
+  journal survived under the actual root: a false-success factory reset that
+  retained the prior tenant's secrets. Fix: added
+  `configstore.Store.ConfigPath()` (returns the store's immutable `-config`
+  filePath — same path xpfd loads/persists config from), parameterized
+  `performZeroizeWipe(configDir, configBase)`, and resolved the root in
+  `runZeroize` via a new `zeroizeConfigRoot()` that derives
+  filepath.Dir/Base of `s.store.ConfigPath()`. Fail-CLOSED: an undeterminable
+  root (nil store / empty path) returns an error BEFORE the apply gate, never
+  wiping the wrong path or nothing. Only the config-root leg is parameterized;
+  rendered-config/login/archive/BPF/networkd legs stay at fixed system paths.
+  #5281's gate → wipe → stop + fail-closed behavior preserved. Updated the
+  #5281 gate test (dropped now-stale pointer-identity assert; the closure now
+  wraps performZeroizeWipe to bind the root) and the other perZeroizeWipe fakes
+  to the new signature. New RED-on-revert test
+  zeroize_configured_root_5280_test.go: (1) targets the CONFIGURED root not
+  /etc/xpf, (2) fails closed with no config root. Doc: pkg/grpcapi/README.md
+  zeroize-root contract.
+  Validation: `GOCACHE=/tmp/gocache-5280 GOTMPDIR=/tmp go build ./...` +
+  `go test -race ./pkg/grpcapi/... ./pkg/configstore/...` green. RED-on-revert
+  proven: reverting runZeroize to pass defaultConfigDir/Base makes both new
+  tests fail (wiped "/etc/xpf" not the temp root; reported clean reset with no
+  root); restored, all green. NOTE: the CLI `request system zeroize` path
+  (pkg/cli/cli_request_system.go:80 `configDir := "/etc/xpf"`) has the SAME
+  hardcoded-root shape — a SEPARATE defect out of #5280's grpcapi scope, to be
+  filed as a follow-up issue.
+- **File(s)**: pkg/configstore/store.go, pkg/grpcapi/server_diag_zeroize.go,
+  pkg/grpcapi/server_diag_system_action.go, pkg/grpcapi/README.md,
+  pkg/grpcapi/zeroize_configured_root_5280_test.go,
+  pkg/grpcapi/zeroize_gate_stop_5281_test.go,
+  pkg/grpcapi/system_action_journal_4108_test.go,
+  pkg/grpcapi/zeroize_configdb_4576_test.go, _Log.md

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -226,6 +226,22 @@ func New(filePath string) (*Store, error) {
 	}, nil
 }
 
+// ConfigPath returns the absolute path of the primary config file this Store
+// loads from and persists to — the daemon's `-config` path (New's filePath).
+// Its DIRECTORY is the configuration ROOT that holds the on-disk state a factory
+// reset must erase: the `.configdb` SSOT + master.key (built at
+// filepath.Join(filepath.Dir(filePath), ".configdb")), the numbered text
+// rollback slots (`<base>.N`), and the audit journal
+// (filepath.Join(filepath.Dir(filePath), ".config.journal")). The grpcapi
+// zeroize handler reads it so the wipe targets the ACTUAL configured root rather
+// than a hardcoded /etc/xpf (#5280): a daemon started with
+// `-config /srv/xpf/site.conf` must have /srv/xpf erased, not /etc/xpf. filePath
+// is set once by New and never mutated, so this needs no lock. Empty only on a
+// zero-value Store never constructed via New.
+func (s *Store) ConfigPath() string {
+	return s.filePath
+}
+
 // SetConfigDBWriterVersion sets the xpf build version stamped into the
 // config-DB compatibility-envelope header on write (#1917 increment B).
 // Call once at startup before any Commit/Save; the daemon's single init

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -110,6 +110,24 @@ contract.
   action-journal write still happens BEFORE the wipe. `ZeroizeFn` is nil
   only in a NoDataplane / no-daemon build, where the handler falls back to
   an ungated direct wipe (there is no running reconcile loop to race).
+- **Zeroize erases the CONFIGURED config root, not a hardcoded `/etc/xpf`
+  (#5280).** `runZeroize` resolves the config root from
+  `configstore.Store.ConfigPath()` — the daemon's `-config` path, the SAME
+  file the store loads from and persists the `.configdb` SSOT / rollback
+  slots / `.config.journal` to — and threads `filepath.Dir/Base` of it into
+  the `performZeroizeWipe(configDir, configBase)` primitive. A daemon
+  started with a non-default `-config` (e.g. `/srv/xpf/site.conf`) therefore
+  erases `/srv/xpf`, not `/etc/xpf`; the pre-fix wipe hardcoded `/etc/xpf`
+  and left the real root's secrets on disk while reporting a clean reset.
+  Resolution runs BEFORE the apply gate and is fail-CLOSED: if the store /
+  config path is undeterminable, `runZeroize` returns an error (surfaced as
+  `Internal`) rather than wiping the wrong path or nothing — it never
+  enters the terminal reset generation on an unknown root. Only the
+  config-root leg is parameterized; the rendered-config (frr/swanctl/kea),
+  login-account, config-archive, BPF-pin and networkd legs live at fixed
+  system paths independent of `-config`. `defaultConfigDir` /
+  `defaultConfigBase` remain only as the documented standard-appliance
+  default and the RED-on-revert reference, not as the wipe target.
 - Tab completion (`Complete` RPC) and `?` help come from `pkg/cmdtree` —
   add commands there once and they show up in every CLI surface.
 - Session show and clear share ONE matcher: `ClearSessions` builds the

--- a/pkg/grpcapi/server_diag_system_action.go
+++ b/pkg/grpcapi/server_diag_system_action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -83,6 +84,31 @@ var scheduleStopDaemon = func() {
 	}()
 }
 
+// zeroizeConfigRoot resolves the CONFIGURED config root the factory-reset wipe
+// must erase — the directory and base name of the store's `-config` path
+// (configstore.Store.ConfigPath), the SAME path the daemon loads config from and
+// persists the .configdb SSOT / rollback slots / journal to (#5280). Deriving it
+// from the store (rather than a hardcoded /etc/xpf) guarantees the wipe targets
+// exactly the root the running daemon uses: a daemon started with
+// `-config /srv/xpf/site.conf` erases /srv/xpf, not /etc/xpf.
+//
+// Fail CLOSED: if the store is absent or carries no config path we CANNOT know
+// which root holds the prior tenant's secrets, so we return an error rather than
+// silently wiping the wrong/nothing (which would report a clean reset while
+// secrets survive). In production the daemon always wires a store built from a
+// non-empty `-config` path (daemon.New / configstore.New), so this guard only
+// trips in a degenerate build.
+func (s *Server) zeroizeConfigRoot() (configDir, configBase string, err error) {
+	if s.store == nil {
+		return "", "", fmt.Errorf("zeroize: config store unavailable; cannot determine configured config root to erase")
+	}
+	p := s.store.ConfigPath()
+	if p == "" {
+		return "", "", fmt.Errorf("zeroize: config store has no config path; cannot determine configured config root to erase")
+	}
+	return filepath.Dir(p), filepath.Base(p), nil
+}
+
 // runZeroize erases on-disk state for a factory reset. It routes through the
 // daemon-owned apply gate (ZeroizeFn) when wired (#5281): the daemon acquires
 // its apply semaphore, enters the terminal reset generation, and runs the
@@ -91,11 +117,20 @@ var scheduleStopDaemon = func() {
 // nil (NoDataplane / a bare unit-test Server with no daemon), it falls back to
 // an ungated direct wipe — the pre-#5281 behavior — which is acceptable because
 // there is no running reconcile loop to race in that build.
+//
+// The wipe target is the CONFIGURED config root (zeroizeConfigRoot), not a
+// hardcoded /etc/xpf (#5280). Resolution happens BEFORE the gate so a root we
+// cannot determine fails closed without entering the terminal reset generation.
 func (s *Server) runZeroize(ctx context.Context) error {
-	if s.zeroizeFn != nil {
-		return s.zeroizeFn(ctx, performZeroizeWipe)
+	configDir, configBase, err := s.zeroizeConfigRoot()
+	if err != nil {
+		return err
 	}
-	return performZeroizeWipe()
+	wipe := func() error { return performZeroizeWipe(configDir, configBase) }
+	if s.zeroizeFn != nil {
+		return s.zeroizeFn(ctx, wipe)
+	}
+	return wipe()
 }
 
 func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error) {

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -24,10 +24,14 @@ import (
 // mutate it.
 var zeroizeSyncDir = fsatomic.SyncDir
 
-// defaultConfigDir / defaultConfigBase mirror the daemon's config-path default
-// (cmd/xpfd `-config /etc/xpf/xpf.conf`, pkg/daemon). performZeroizeWipe erases
-// the fixed appliance paths; a non-default `-config` location is out of scope
-// (the pre-#4576 wipe already assumed /etc/xpf).
+// defaultConfigDir / defaultConfigBase are the STANDARD-APPLIANCE config root
+// (cmd/xpfd `-config /etc/xpf/xpf.conf`, pkg/daemon.New's default). They are the
+// values the store's ConfigPath resolves to in the default deployment, NOT a
+// hardcoded wipe target: performZeroizeWipe now takes the configured root
+// (filepath.Dir/Base of configstore.Store.ConfigPath) so a daemon started with a
+// non-default `-config` (e.g. /srv/xpf/site.conf) erases THAT root, not /etc/xpf
+// (#5280). They remain as the documented default and the RED-on-revert reference
+// (a reverted hardcoded wipe would target defaultConfigDir).
 const (
 	defaultConfigDir  = "/etc/xpf"
 	defaultConfigBase = "xpf.conf"
@@ -671,13 +675,24 @@ func readProvisionedMarkerUID(path string) (int, error) {
 // secrets, provisioned login accounts, BPF pins, and managed networkd files
 // (factory reset). It is a package var so a test can drive the `zeroize`
 // SystemAction verb (to assert the #4108 F8 journal wiring) WITHOUT wiping a
-// real /etc/xpf on the developer/appliance box. It returns a non-nil error when
-// a security-critical erasure did not fully complete (#4576/#4585/#4598).
-var performZeroizeWipe = func() error {
+// real config root on the developer/appliance box. It returns a non-nil error
+// when a security-critical erasure did not fully complete (#4576/#4585/#4598).
+//
+// configDir/configBase are the CONFIGURED config root — the directory and base
+// name of the store's `-config` path (configstore.Store.ConfigPath), threaded in
+// by runZeroize (#5280). Erasing a hardcoded /etc/xpf while the daemon actually
+// loads/persists config elsewhere (a non-default `-config`, e.g.
+// /srv/xpf/site.conf) would leave the real .configdb SSOT + master.key, rollback
+// slots and journal — the prior tenant's secrets — intact under the real root
+// while reporting a clean factory reset. Only the config-root leg is
+// parameterized: the rendered-config (frr/swanctl/kea), login-account,
+// config-archive, BPF-pin and networkd legs live at fixed system paths
+// independent of `-config` and stay as-is.
+var performZeroizeWipe = func(configDir, configBase string) error {
 	// Config state FIRST — the security-critical erasure. A failure here can
 	// leave prior-tenant config/secrets on disk, so it is surfaced to the
 	// caller (#4576).
-	err := zeroizeConfigDir(defaultConfigDir, defaultConfigBase)
+	err := zeroizeConfigDir(configDir, configBase)
 
 	// Rendered service configs (#4585): also security-critical — routing-auth
 	// keys in a world-readable frr.conf, IKE PSKs, Kea configs. A post-zeroize

--- a/pkg/grpcapi/system_action_journal_4108_test.go
+++ b/pkg/grpcapi/system_action_journal_4108_test.go
@@ -34,7 +34,7 @@ func TestSystemActionJournalsDestructiveVerbs(t *testing.T) {
 	var poweredArg string
 	var wiped bool
 	schedulePowerAction = func(arg string) { poweredArg = arg }
-	performZeroizeWipe = func() error { wiped = true; return nil }
+	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
 	scheduleStopDaemon = func() {}
 
 	cases := []struct {

--- a/pkg/grpcapi/zeroize_configdb_4576_test.go
+++ b/pkg/grpcapi/zeroize_configdb_4576_test.go
@@ -144,7 +144,7 @@ func TestIsTextRollbackFile(t *testing.T) {
 func TestZeroizeSurfacesWipeError(t *testing.T) {
 	orig := performZeroizeWipe
 	t.Cleanup(func() { performZeroizeWipe = orig })
-	performZeroizeWipe = func() error { return errors.New("simulated .configdb wipe failure") }
+	performZeroizeWipe = func(_, _ string) error { return errors.New("simulated .configdb wipe failure") }
 
 	dir := t.TempDir()
 	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))

--- a/pkg/grpcapi/zeroize_configured_root_5280_test.go
+++ b/pkg/grpcapi/zeroize_configured_root_5280_test.go
@@ -1,0 +1,107 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestZeroizeTargetsConfiguredRootNotHardcoded pins #5280: a gRPC `zeroize`
+// SystemAction must erase the daemon's ACTUAL configured config root — the
+// directory + base name of the store's `-config` path
+// (configstore.Store.ConfigPath) — NOT a hardcoded /etc/xpf. When xpfd is
+// started with a non-default `-config` (e.g. /srv/xpf/site.conf), the .configdb
+// SSOT + master.key, rollback slots and journal live under THAT root; wiping
+// /etc/xpf instead would report a clean factory reset while the prior tenant's
+// secrets survive under the real root.
+//
+// The store here is pointed at a NON-default root (a temp dir with base
+// "site.conf"), and the destructive wipe primitive is stubbed so the test
+// observes exactly which (configDir, configBase) the handler threads into it.
+//
+// RED on revert: restoring performZeroizeWipe to call
+// zeroizeConfigDir(defaultConfigDir, defaultConfigBase) (or making runZeroize
+// pass the hardcoded default) makes the handler wipe /etc/xpf — gotDir becomes
+// defaultConfigDir instead of the store's temp root — so the gotDir/gotBase
+// assertions (and the explicit defaultConfigDir guard) fail.
+func TestZeroizeTargetsConfiguredRootNotHardcoded(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	var gotDir, gotBase string
+	var called bool
+	performZeroizeWipe = func(configDir, configBase string) error {
+		called = true
+		gotDir, gotBase = configDir, configBase
+		return nil
+	}
+	scheduleStopDaemon = func() {}
+
+	// A configured root deliberately different from the hardcoded /etc/xpf
+	// default: a temp dir (never /etc/xpf) with a non-default config base name.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "site.conf")
+	store := newConfigStore(t, configPath)
+	s := &Server{store: store}
+
+	if _, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"}); err != nil {
+		t.Fatalf("SystemAction(zeroize): %v", err)
+	}
+	if !called {
+		t.Fatal("zeroize never invoked performZeroizeWipe")
+	}
+	if gotDir != dir {
+		t.Fatalf("zeroize wiped configDir %q, want the CONFIGURED root %q (not hardcoded /etc/xpf)", gotDir, dir)
+	}
+	if gotBase != "site.conf" {
+		t.Fatalf("zeroize wiped configBase %q, want the CONFIGURED base %q", gotBase, "site.conf")
+	}
+	// Explicit revert-shape guard: a hardcoded wipe would pass defaultConfigDir.
+	if gotDir == defaultConfigDir {
+		t.Fatalf("zeroize wiped the hardcoded default %q instead of the configured root %q", defaultConfigDir, dir)
+	}
+}
+
+// TestZeroizeFailsClosedWithoutConfigRoot pins the fail-CLOSED half of #5280: if
+// the configured config root cannot be determined (no store / empty config
+// path), the handler must NOT silently wipe the wrong path or nothing — it must
+// surface an error so the operator knows the device is not safe to re-tenant.
+//
+// A bare Server with a nil store cannot resolve ConfigPath, so runZeroize must
+// return an error BEFORE ever invoking performZeroizeWipe or scheduling a stop.
+func TestZeroizeFailsClosedWithoutConfigRoot(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	var wiped, stopped bool
+	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
+	scheduleStopDaemon = func() { stopped = true }
+
+	s := &Server{} // no store => config root undeterminable
+
+	resp, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"})
+	if err == nil {
+		t.Fatalf("SystemAction(zeroize) with no config root must fail closed; got resp=%+v", resp)
+	}
+	if status.Code(err) != codes.Internal {
+		t.Errorf("SystemAction(zeroize) fail-closed error code = %v, want Internal", status.Code(err))
+	}
+	if wiped {
+		t.Error("zeroize must NOT wipe when the configured root is undeterminable (fail-closed)")
+	}
+	if stopped {
+		t.Error("zeroize must NOT stop the daemon when it fails closed")
+	}
+}

--- a/pkg/grpcapi/zeroize_gate_stop_5281_test.go
+++ b/pkg/grpcapi/zeroize_gate_stop_5281_test.go
@@ -36,7 +36,7 @@ func TestZeroizeGoesThroughGateAndStopsDaemon(t *testing.T) {
 	// sequence is gate → wipe → stop (never stop-before-wipe, never a bypassed
 	// gate).
 	var seq []string
-	performZeroizeWipe = func() error { seq = append(seq, "wipe"); return nil }
+	performZeroizeWipe = func(_, _ string) error { seq = append(seq, "wipe"); return nil }
 	scheduleStopDaemon = func() { seq = append(seq, "stop") }
 
 	var gateWipeArg func() error
@@ -45,8 +45,9 @@ func TestZeroizeGoesThroughGateAndStopsDaemon(t *testing.T) {
 	s := &Server{
 		store: store,
 		// The gate fake records that the handler routed through it, captures the
-		// wipe closure the handler passed (must be performZeroizeWipe), and runs
-		// it — exactly as the real daemon factoryReset does under applySem.
+		// wipe closure the handler passed (which must, when run, invoke
+		// performZeroizeWipe), and runs it — exactly as the real daemon
+		// factoryReset does under applySem.
 		zeroizeFn: func(_ context.Context, wipe func() error) error {
 			seq = append(seq, "gate")
 			gateWipeArg = wipe
@@ -62,13 +63,13 @@ func TestZeroizeGoesThroughGateAndStopsDaemon(t *testing.T) {
 		t.Fatalf("SystemAction(zeroize) returned empty response: %+v", resp)
 	}
 
-	// The wipe ran through the gate (not directly): the handler passed
-	// performZeroizeWipe into ZeroizeFn.
+	// The wipe ran through the gate (not directly): the handler passed a wipe
+	// closure into ZeroizeFn. Since #5280 the handler wraps performZeroizeWipe in
+	// a closure that binds the CONFIGURED config root, so we no longer assert
+	// pointer identity — the "wipe" entry in seq below proves the gate's closure
+	// invoked performZeroizeWipe.
 	if gateWipeArg == nil {
 		t.Fatal("zeroize did not route the wipe through the apply gate (ZeroizeFn)")
-	}
-	if reflect.ValueOf(gateWipeArg).Pointer() != reflect.ValueOf(performZeroizeWipe).Pointer() {
-		t.Fatal("zeroize passed a different wipe closure to the gate than performZeroizeWipe")
 	}
 
 	// Exact sequence: gate first, wipe under it, daemon stop last.
@@ -90,7 +91,7 @@ func TestZeroizeFailClosedDoesNotStopDaemon(t *testing.T) {
 	})
 
 	wantErr := errors.New("configdb not fully erased")
-	performZeroizeWipe = func() error { return wantErr }
+	performZeroizeWipe = func(_, _ string) error { return wantErr }
 	var stopped bool
 	scheduleStopDaemon = func() { stopped = true }
 
@@ -130,7 +131,7 @@ func TestZeroizeFallsBackToDirectWipeWithoutGate(t *testing.T) {
 	})
 
 	var wiped, stopped bool
-	performZeroizeWipe = func() error { wiped = true; return nil }
+	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
 	scheduleStopDaemon = func() { stopped = true }
 
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #5280

## Problem
`performZeroizeWipe` hardcoded the factory-reset target as
`zeroizeConfigDir(defaultConfigDir="/etc/xpf", defaultConfigBase="xpf.conf")`.
A daemon started with a non-default `-config` (e.g. `-config /srv/xpf/site.conf`)
therefore wiped `/etc/xpf` while the **real** config root's `.configdb` SSOT +
`master.key`, numbered text rollback slots (`<base>.N`) and `.config.journal`
survived under the actual root. The RPC still returned *"System zeroized.
Configuration erased."* — a false-success factory reset that hands the prior
tenant's committed policy, IKE PSKs, WireGuard keys and SNMP communities to the
next owner.

The store is created from that same `-config` path (`configstore.New(opts.ConfigFile)`),
so the wipe target and the config-persistence root had silently diverged.

## Fix
Erase the **actual configured root**, resolved from the store the daemon already
loads/persists config through (`file:line` for the resolution below).

- **`pkg/configstore/store.go`** — new `Store.ConfigPath()` returns the immutable
  `filePath` set by `New` (the `-config` path). Its directory is the config root
  that holds `.configdb`, the rollback slots and `.config.journal`, so it is the
  authoritative source for what a reset must erase. `filePath` is set once and
  never mutated → no lock needed.
- **`pkg/grpcapi/server_diag_zeroize.go`** — `performZeroizeWipe(configDir, configBase string)`
  is now parameterized; only the config-root leg (`zeroizeConfigDir`) is
  threaded. The rendered-config (frr/swanctl/kea), login-account,
  config-archive, BPF-pin and networkd legs live at fixed system paths
  independent of `-config` and are unchanged.
- **`pkg/grpcapi/server_diag_system_action.go`** — `runZeroize` resolves the root
  via new `zeroizeConfigRoot()` = `filepath.Dir/Base(s.store.ConfigPath())`
  (server_diag_system_action.go, `zeroizeConfigRoot`), builds the wipe closure,
  and passes it through the gate. **Fail CLOSED**: an undeterminable root (nil
  store / empty config path) returns an error *before* the apply gate, so the
  handler surfaces `Internal` and never wipes the wrong path or nothing, and
  never enters the terminal reset generation on an unknown root.

Default case is unchanged: production always wires a store from a non-empty
`-config`, so `/etc/xpf` stays the target on a standard appliance.

### #5281 preserved
The gate → wipe → stop sequence and fail-closed behavior are intact — the
config-root wrap is the same closure the apply gate runs. `defaultConfigDir` /
`defaultConfigBase` remain only as the documented default + RED-on-revert
reference.

## Tests (RED-on-revert proven)
New `pkg/grpcapi/zeroize_configured_root_5280_test.go`:
1. `TestZeroizeTargetsConfiguredRootNotHardcoded` — store pointed at a temp dir
   with base `site.conf`; asserts the wipe receives THAT `(configDir, configBase)`,
   not `/etc/xpf`.
2. `TestZeroizeFailsClosedWithoutConfigRoot` — nil store ⇒ `Internal`, no wipe,
   no daemon stop.

**RED on revert:** reverting `runZeroize` to pass `defaultConfigDir/Base` makes
(1) observe `configDir == "/etc/xpf"` != the temp root and (2) report a clean
reset with no root → both fail. Restored → all green.

The #5281 gate test drops the now-stale `performZeroizeWipe` pointer-identity
assert (the handler now wraps it to bind the root; the gate→wipe→stop sequence
still proves the closure invokes it); the other wipe fakes take the new
signature.

## Docs
`pkg/grpcapi/README.md` — zeroize-root contract added.

## Validation
`GOCACHE=/tmp/gocache-5280 GOTMPDIR=/tmp go build ./...` and
`go test -race ./pkg/grpcapi/... ./pkg/configstore/...` green; `go vet` clean.

## Out of scope (follow-up)
The local CLI `request system zeroize` path (`pkg/cli/cli_request_system.go:80`,
`configDir := "/etc/xpf"`) has the **same** hardcoded-root shape — a separate
defect outside #5280's grpcapi scope. Should be filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)