### PR TITLE
test/incus perf tooling: evidence-integrity cohort (#4907)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45644,3 +45644,13 @@ top.
 - **File(s)**: test/incus/step2-sched-switch-reduce.py,
   test/incus/step2-sched-switch-classify.py,
   test/incus/step2-sched-switch-classify_test.py
+- **Timestamp**: 2026-07-10
+- **Action**: HC-070 — reducer main() HALTs (exit 2) on zero-event perf
+  (drift-halt still wins); classifier emits INSUFFICIENT (exit 2) on the
+  all-zero/all-WARN no-evidence shape instead of a definitive OUT exit 0.
+  Updated drift-warning test to a non-empty capture; added empty-perf +
+  insufficient-evidence tests.
+- **File(s)**: test/incus/step2-sched-switch-reduce.py,
+  test/incus/step2-sched-switch-reduce_test.py,
+  test/incus/step2-sched-switch-classify.py,
+  test/incus/step2-sched-switch-classify_test.py

--- a/_Log.md
+++ b/_Log.md
@@ -45674,3 +45674,11 @@ top.
   empty. Deterministic-seed behavior preserved. New test file.
 - **File(s)**: test/incus/step1-rss-multinomial.py,
   test/incus/step1-rss-multinomial_test.py (new)
+- **Timestamp**: 2026-07-10
+- **Action**: HC-083 — RG 1 Hz poller now writes a POLL_FAILED sentinel per
+  failed/empty tick; cmd_rg_state_flapped returns 2 (undetermined) on any
+  POLL_FAILED marker or --expected-samples shortfall when no drift is seen
+  (drift still wins). Added 3 orchestrate tests.
+- **File(s)**: test/incus/mouse_latency_orchestrate.py,
+  test/incus/test-mouse-latency.sh,
+  test/incus/mouse_latency_orchestrate_test.py

--- a/_Log.md
+++ b/_Log.md
@@ -45682,3 +45682,10 @@ top.
 - **File(s)**: test/incus/mouse_latency_orchestrate.py,
   test/incus/test-mouse-latency.sh,
   test/incus/mouse_latency_orchestrate_test.py
+- **Timestamp**: 2026-07-10
+- **Action**: HC-072 — cold-path-flooder bounded cohort now enumerates a
+  disjoint per-worker slice sequentially (worker_slice + decompose_tuple_index
+  helpers) so first-pass packets are genuine installs (no birthday collisions,
+  no cross-worker overlap). Unbounded keeps random draws. Summary emits
+  tuple_space (fresh-install budget), version bumped 2->3. 4 cargo tests.
+- **File(s)**: test/incus/cold-path-flooder/src/main.rs

--- a/_Log.md
+++ b/_Log.md
@@ -45668,3 +45668,9 @@ top.
   New test file with fail-on-revert partial/missing cases.
 - **File(s)**: test/incus/step1-rate-spread-analysis.py,
   test/incus/step1-rate-spread-analysis_test.py (new)
+- **Timestamp**: 2026-07-10
+- **Action**: HC-130 — step1-rss-multinomial simulate() is now a generator
+  (O(1) memory); tail_probabilities streams + counts trials and raises on
+  empty. Deterministic-seed behavior preserved. New test file.
+- **File(s)**: test/incus/step1-rss-multinomial.py,
+  test/incus/step1-rss-multinomial_test.py (new)

--- a/_Log.md
+++ b/_Log.md
@@ -45623,3 +45623,9 @@ top.
   exit_status_for_verdict: PASS=0, FAIL=1, else=2) + fail-on-revert test
 - **File(s)**: test/incus/mouse_latency_aggregate.py,
   test/incus/mouse_latency_aggregate_test.py
+- **Timestamp**: 2026-07-10
+- **Action**: HC-084 — fairness_multi_sample summarize() now fails a sample
+  whose sub-harness exit_code != 0 even if its JSON verdict says PASS
+  (exit status is authoritative) + fail-on-revert test
+- **File(s)**: test/incus/fairness_multi_sample.py,
+  test/incus/fairness_multi_sample_test.py

--- a/_Log.md
+++ b/_Log.md
@@ -45637,3 +45637,10 @@ top.
   added 3 regression tests.
 - **File(s)**: test/incus/step2-sched-switch-reduce.py,
   test/incus/step2-sched-switch-reduce_test.py
+- **Timestamp**: 2026-07-10
+- **Action**: HC-092 — reducer stamps block_span_ns; classifier computes
+  duty-cycle over the actual summed window (fallback 60s for legacy JSONL)
+  instead of a fixed 60s. Added window tests + diag window_ns.
+- **File(s)**: test/incus/step2-sched-switch-reduce.py,
+  test/incus/step2-sched-switch-classify.py,
+  test/incus/step2-sched-switch-classify_test.py

--- a/_Log.md
+++ b/_Log.md
@@ -45616,3 +45616,10 @@ top.
   green; RED-on-revert proven (flipping `ones > bestLen` to pick the shortest
   prefix fails the selection assertions; reverted, production file clean).
 - **File(s)**: pkg/cli/cli_request_testrouting_4832_test.go, _Log.md
+
+## 2026-07-10 — #4907 perf-tooling evidence-integrity cohort
+- **Timestamp**: 2026-07-10
+- **Action**: HC-029 — mouse_latency_aggregate FAIL must exit non-zero (add
+  exit_status_for_verdict: PASS=0, FAIL=1, else=2) + fail-on-revert test
+- **File(s)**: test/incus/mouse_latency_aggregate.py,
+  test/incus/mouse_latency_aggregate_test.py

--- a/_Log.md
+++ b/_Log.md
@@ -45654,3 +45654,10 @@ top.
   test/incus/step2-sched-switch-reduce_test.py,
   test/incus/step2-sched-switch-classify.py,
   test/incus/step2-sched-switch-classify_test.py
+- **Timestamp**: 2026-07-10
+- **Action**: HC-132 — step1-histogram-classify tracks failed_cells; --only-cell
+  returns non-zero if the target cell produced no hist-blocks; full run returns
+  2 when no valid cells (kills "k_D1 = 0 of 0" exit 0) and 1 on missing/corrupt
+  cells. Added --only-cell missing-target fail-on-revert test.
+- **File(s)**: test/incus/step1-histogram-classify.py,
+  test/incus/step1-histogram-classify_test.py

--- a/_Log.md
+++ b/_Log.md
@@ -45661,3 +45661,10 @@ top.
   cells. Added --only-cell missing-target fail-on-revert test.
 - **File(s)**: test/incus/step1-histogram-classify.py,
   test/incus/step1-histogram-classify_test.py
+- **Timestamp**: 2026-07-10
+- **Action**: HC-128 — rate-spread analyzer validates exact-16 streams +
+  positive finite sender bps (RateSpreadError), and main() hard-fails on any
+  missing requested cell instead of WARN+continue. Added --expected-streams.
+  New test file with fail-on-revert partial/missing cases.
+- **File(s)**: test/incus/step1-rate-spread-analysis.py,
+  test/incus/step1-rate-spread-analysis_test.py (new)

--- a/_Log.md
+++ b/_Log.md
@@ -45629,3 +45629,11 @@ top.
   (exit status is authoritative) + fail-on-revert test
 - **File(s)**: test/incus/fairness_multi_sample.py,
   test/incus/fairness_multi_sample_test.py
+- **Timestamp**: 2026-07-10
+- **Action**: HC-026 — step2 reducer closes off-CPU intervals at schedule-in
+  (sched_switch next_pid=worker), parses next_pid; wakeup no longer closes.
+  Involuntary preemption (prev_state=R, no wakeup) is now measured.
+  Rewrote synthetic + invariant tests to kernel-realistic switch-in fixtures;
+  added 3 regression tests.
+- **File(s)**: test/incus/step2-sched-switch-reduce.py,
+  test/incus/step2-sched-switch-reduce_test.py

--- a/test/incus/cold-path-flooder/src/main.rs
+++ b/test/incus/cold-path-flooder/src/main.rs
@@ -1048,6 +1048,46 @@ struct WorkerCtx {
     warmup_baseline: Arc<AtomicU64>,
 }
 
+/// Total number of unique 5-tuples a run can generate, given the span
+/// arguments. u64 is wide enough for the unbounded default (4.29e9).
+fn tuple_space(args: &Args) -> u64 {
+    (args.src_ip_span as u64)
+        * (args.src_port_span as u64)
+        * (args.dst_port_span as u64)
+}
+
+/// C175-HC-072: the half-open tuple-index slice `[base, end)` that
+/// worker `thread_id` of `threads` owns. Slices partition `[0, space)`
+/// exactly (floor division; `base_0 = 0`, `base_threads = space`), so no
+/// two workers ever emit the same bounded tuple — the cross-worker
+/// collision source under the old shared-random scheme.
+fn worker_slice(thread_id: u32, threads: u32, space: u64) -> (u64, u64) {
+    let n = threads.max(1) as u64;
+    let t = thread_id as u64;
+    (t * space / n, (t + 1) * space / n)
+}
+
+/// C175-HC-072: decompose a monotonic tuple index into its
+/// (src_ip_off, src_port_v, dst_port_v) components. Enumerating indices
+/// `base..end` visits every distinct tuple in a worker's slice exactly
+/// once before wrapping, so the first pass installs a fresh session per
+/// packet (a genuine cache_miss -> install -> replicate) instead of the
+/// birthday-colliding random draws that measured warm hits. Spans are
+/// validated >= 1 (see validate()), so the divisions never trap.
+fn decompose_tuple_index(
+    idx: u64,
+    src_port_span: u32,
+    dst_port_span: u32,
+) -> (u32, u32, u32) {
+    let dsp = dst_port_span as u64;
+    let ssp = src_port_span as u64;
+    let dst_port_v = (idx % dsp) as u32;
+    let tmp = idx / dsp;
+    let src_port_v = (tmp % ssp) as u32;
+    let src_ip_off = (tmp / ssp) as u32;
+    (src_ip_off, src_port_v, dst_port_v)
+}
+
 /// Per-worker hot loop. Publishes per-batch deltas into self.stats
 /// via fetch_add(Relaxed). Returns Ok on graceful shutdown; the
 /// first fatal error (EPERM/EACCES from sendmmsg, pin failure) is
@@ -1078,6 +1118,19 @@ fn worker_loop(args: &Args, mut ctx: WorkerCtx) {
     let mut prng = Xorshift64(ctx.seed);
     let mut warmup_baseline_published = false;
 
+    // C175-HC-072: in bounded (diagnostic) mode this worker enumerates a
+    // disjoint slice of the tuple space sequentially, so every packet in
+    // the first pass over its slice is a genuinely new 5-tuple (real
+    // session install), not a birthday-colliding random draw that lands
+    // on an already-installed session. Unbounded mode keeps random draws
+    // over its ~4.3 B space (session table fills in ~26 ms by design and
+    // the rest measures the policy-eval cold path). ip_id stays random in
+    // both modes — it is not part of the session key.
+    let bounded = !args.cohort_unbounded;
+    let (slice_base, slice_end) =
+        worker_slice(ctx.thread_id, args.threads, tuple_space(args));
+    let mut seq_idx = slice_base;
+
     loop {
         // Shutdown check at top of each batch (#1615 plan-v4 §3.9).
         if ctx.shutdown_flag.load(Ordering::Relaxed) {
@@ -1097,14 +1150,31 @@ fn worker_loop(args: &Args, mut ctx: WorkerCtx) {
             warmup_baseline_published = true;
         }
 
-        // Refill all batch slots with fresh PRNG values.
+        // Refill all batch slots with fresh tuples.
         for slot in ctx.ring.slots.iter_mut() {
             let s = prng.next();
-            let src_ip_off = (s as u32) % args.src_ip_span;
-            let src_port_v = (((s >> 16) as u32) % args.src_port_span) as u16;
-            let src_port = args.src_port_base.wrapping_add(src_port_v);
-            let dst_port_v = (((s >> 32) as u32) % args.dst_port_span) as u16;
-            let dst_port = args.dst_port_base.wrapping_add(dst_port_v);
+            let (src_ip_off, src_port_v, dst_port_v) = if bounded {
+                // Sequential non-repeating sweep of this worker's slice.
+                let (ip_off, sp_v, dp_v) = decompose_tuple_index(
+                    seq_idx, args.src_port_span, args.dst_port_span,
+                );
+                seq_idx += 1;
+                // Wrap at the slice end so reuse is deterministic and only
+                // begins after a full pass (an honest table refill), never
+                // the birthday collisions of shared random draws.
+                if seq_idx >= slice_end {
+                    seq_idx = slice_base;
+                }
+                (ip_off, sp_v, dp_v)
+            } else {
+                (
+                    (s as u32) % args.src_ip_span,
+                    (s >> 16) as u32 % args.src_port_span,
+                    (s >> 32) as u32 % args.dst_port_span,
+                )
+            };
+            let src_port = args.src_port_base.wrapping_add(src_port_v as u16);
+            let dst_port = args.dst_port_base.wrapping_add(dst_port_v as u16);
             let src_ip = args.src_ip_base.wrapping_add(src_ip_off);
             let ip_id = (s >> 48) as u16;
             slot.fill_packet(src_ip, ip_id, src_port, dst_port);
@@ -1199,9 +1269,10 @@ fn emit_summary(args: &Args, agg: &RunStats, per_thread: &[RunStats]) {
     per_thread_json.push(']');
 
     println!(
-        "{{\"version\":2,\
+        "{{\"version\":3,\
          \"threads\":{},\
          \"cohort\":\"{}\",\
+         \"tuple_space\":{},\
          \"duration_secs\":{},\
          \"warmup_secs\":{},\
          \"frame_bytes\":{},\
@@ -1226,6 +1297,7 @@ fn emit_summary(args: &Args, agg: &RunStats, per_thread: &[RunStats]) {
          \"clock_source\":\"monotonic\"}}",
         args.threads,
         if args.cohort_unbounded { "unbounded" } else { "bounded" },
+        tuple_space(args),
         args.duration.as_secs(),
         args.warmup.as_secs(),
         args.frame_bytes,
@@ -1603,6 +1675,76 @@ mod tests {
             no_cpu_pin: false,
             allow_oversubscribe: false,
         }
+    }
+
+    // --- C175-HC-072: bounded cohort sequential enumeration ---------------
+
+    #[test]
+    fn hc072_tuple_space_matches_spans() {
+        let mut a = build_default_args();
+        a.src_ip_span = BOUNDED_SRC_IP_SPAN;
+        a.src_port_span = BOUNDED_SRC_PORT_SPAN;
+        a.dst_port_span = BOUNDED_DST_PORT_SPAN;
+        assert_eq!(tuple_space(&a), 131_072);
+    }
+
+    #[test]
+    fn hc072_worker_slices_partition_space_disjointly() {
+        let space = 131_072u64;
+        for threads in [1u32, 3, 4, 6, 7, 64] {
+            let mut prev_end = 0u64;
+            let mut covered = 0u64;
+            for t in 0..threads {
+                let (base, end) = worker_slice(t, threads, space);
+                assert_eq!(base, prev_end, "threads={threads}: slice {t} gap/overlap");
+                assert!(end >= base);
+                covered += end - base;
+                prev_end = end;
+            }
+            assert_eq!(prev_end, space, "threads={threads}: did not reach space");
+            assert_eq!(covered, space, "threads={threads}: coverage != space");
+        }
+    }
+
+    #[test]
+    fn hc072_bounded_enumeration_first_pass_is_distinct() {
+        // One worker sweeping the whole bounded space visits every 5-tuple
+        // exactly once — a clean table fill, zero collisions. The old
+        // random draws hit birthday collisions long before 131_072 draws.
+        let space = 131_072u64;
+        let (base, end) = worker_slice(0, 1, space);
+        assert_eq!((base, end), (0, space));
+        let mut seen = std::collections::HashSet::with_capacity(space as usize);
+        for idx in base..end {
+            let t = decompose_tuple_index(
+                idx, BOUNDED_SRC_PORT_SPAN, BOUNDED_DST_PORT_SPAN,
+            );
+            assert!(t.0 < BOUNDED_SRC_IP_SPAN);
+            assert!(t.1 < BOUNDED_SRC_PORT_SPAN);
+            assert!(t.2 < BOUNDED_DST_PORT_SPAN);
+            assert!(seen.insert(t), "duplicate tuple at idx {idx}: {t:?}");
+        }
+        assert_eq!(seen.len() as u64, space);
+    }
+
+    #[test]
+    fn hc072_bounded_multiworker_tuples_globally_distinct() {
+        // Across 4 workers each sweeping its slice once, the union is the
+        // whole space with no cross-worker overlap (the shared-random
+        // scheme let two workers emit the same tuple).
+        let space = 131_072u64;
+        let threads = 4u32;
+        let mut seen = std::collections::HashSet::with_capacity(space as usize);
+        for t in 0..threads {
+            let (base, end) = worker_slice(t, threads, space);
+            for idx in base..end {
+                let tup = decompose_tuple_index(
+                    idx, BOUNDED_SRC_PORT_SPAN, BOUNDED_DST_PORT_SPAN,
+                );
+                assert!(seen.insert(tup), "cross-worker duplicate at idx {idx}");
+            }
+        }
+        assert_eq!(seen.len() as u64, space);
     }
 
     #[test]

--- a/test/incus/fairness_multi_sample.py
+++ b/test/incus/fairness_multi_sample.py
@@ -181,6 +181,21 @@ def summarize(
     failing_samples = [s["sample"] for s in samples if s.get("verdict") != "PASS"]
     if failing_samples:
         failure_reasons.append(f"sample verdicts failed: {failing_samples}")
+    # C175-HC-084: the sub-harness process exit code is the authoritative
+    # per-sample pass/fail signal. A sample whose harness exited non-zero
+    # is a measured FAIL even if the emitted JSON claims verdict=PASS
+    # (exit status and verdict object disagree — trust the exit status).
+    # Without this, a run that exited 1 after printing a final PASS object
+    # aggregated to PASS, painting a real failure green.
+    bad_exit_samples = [
+        s["sample"]
+        for s in samples
+        if isinstance(s.get("exit_code"), int) and s.get("exit_code") != 0
+    ]
+    if bad_exit_samples:
+        failure_reasons.append(
+            f"samples with non-zero harness exit: {bad_exit_samples}"
+        )
     if mean_gap > max_mean_gap:
         failure_reasons.append(
             f"mean gap {mean_gap:.6f} exceeds threshold {max_mean_gap:.6f}"

--- a/test/incus/fairness_multi_sample_test.py
+++ b/test/incus/fairness_multi_sample_test.py
@@ -199,6 +199,70 @@ class FairnessMultiSampleTest(unittest.TestCase):
         self.assertEqual(summary["aggregate_mbps"]["min"], 900.0)
         self.assertEqual(summary["aggregate_mbps"]["max"], 1100.0)
 
+    def test_summary_fails_when_sample_exit_code_nonzero_despite_pass_json(self) -> None:
+        # C175-HC-084 fail-on-revert: the sub-harness exited 1 (measured
+        # FAIL) but printed a PASS verdict object. The aggregate MUST be
+        # FAIL — the process exit status wins over the JSON verdict.
+        summary = fairness_multi_sample.summarize(
+            [
+                {
+                    "sample": 1,
+                    "verdict": "PASS",
+                    "observed_cov": 0.10,
+                    "cstruct": 0.50,
+                    "gap": -0.40,
+                    "exit_code": 0,
+                },
+                {
+                    "sample": 2,
+                    "verdict": "PASS",
+                    "observed_cov": 0.11,
+                    "cstruct": 0.50,
+                    "gap": -0.39,
+                    "exit_code": 1,
+                },
+            ],
+            max_mean_gap=0.05,
+            max_run_gap=0.05,
+            max_mean_cov=None,
+            max_stdev_cov=None,
+            max_run_cov=None,
+        )
+        self.assertEqual(summary["verdict"], "FAIL")
+        self.assertTrue(
+            any("non-zero harness exit" in r for r in summary["failure_reasons"]),
+            summary["failure_reasons"],
+        )
+
+    def test_summary_passes_when_all_exit_codes_zero(self) -> None:
+        # Guard the positive path: PASS verdicts + exit_code 0 aggregate PASS.
+        summary = fairness_multi_sample.summarize(
+            [
+                {
+                    "sample": 1,
+                    "verdict": "PASS",
+                    "observed_cov": 0.10,
+                    "cstruct": 0.50,
+                    "gap": -0.40,
+                    "exit_code": 0,
+                },
+                {
+                    "sample": 2,
+                    "verdict": "PASS",
+                    "observed_cov": 0.11,
+                    "cstruct": 0.50,
+                    "gap": -0.39,
+                    "exit_code": 0,
+                },
+            ],
+            max_mean_gap=0.05,
+            max_run_gap=0.05,
+            max_mean_cov=None,
+            max_stdev_cov=None,
+            max_run_cov=None,
+        )
+        self.assertEqual(summary["verdict"], "PASS")
+
     def test_summary_fails_gap_thresholds(self) -> None:
         summary = fairness_multi_sample.summarize(
             [

--- a/test/incus/mouse_latency_aggregate.py
+++ b/test/incus/mouse_latency_aggregate.py
@@ -347,6 +347,25 @@ def render_markdown(summaries: Dict[CellKey, dict], verdict: dict) -> str:
     return "\n".join(lines)
 
 
+def exit_status_for_verdict(verdict: str) -> int:
+    """Map a gate verdict to a process exit status.
+
+    0 = PASS (gate satisfied), 1 = measured FAIL (gate violated),
+    2 = insufficient / undetermined evidence (no confident verdict).
+
+    A measured FAIL MUST exit non-zero so CI treats it as a failure.
+    The prior ``return 0 if verdict in ("PASS", "FAIL") else 2`` painted a
+    real FAIL green (C175-HC-029) — a latency regression that violated the
+    gate read as success in CI.
+    """
+    if verdict == "PASS":
+        return 0
+    if verdict == "FAIL":
+        return 1
+    # INSUFFICIENT-DATA and any unexpected value: undetermined, not a pass.
+    return 2
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--root", required=True)
@@ -386,7 +405,7 @@ def main() -> int:
         )
 
     print(render_markdown(summaries, verdict))
-    return 0 if verdict["verdict"] in ("PASS", "FAIL") else 2
+    return exit_status_for_verdict(verdict["verdict"])
 
 
 if __name__ == "__main__":

--- a/test/incus/mouse_latency_aggregate_test.py
+++ b/test/incus/mouse_latency_aggregate_test.py
@@ -5,6 +5,7 @@ import unittest
 
 from mouse_latency_aggregate import (
     decide,
+    exit_status_for_verdict,
     has_invalid_marker,
     load_cell_reps,
     median_rep_by_percentile,
@@ -238,6 +239,27 @@ class DecideTests(unittest.TestCase):
         v = decide({(0, 10): idle, (128, 10): loaded})
         self.assertEqual(v["verdict"], "INSUFFICIENT-DATA")
         self.assertIn("probe config mismatch", v["reason"])
+
+
+class ExitStatusForVerdictTests(unittest.TestCase):
+    """C175-HC-029: a measured FAIL must exit non-zero, not 0.
+
+    Fail-on-revert guard: the pre-fix ``return 0 if verdict in
+    ("PASS", "FAIL") else 2`` returned 0 for FAIL, so this asserts 1.
+    """
+
+    def test_pass_is_zero(self):
+        self.assertEqual(exit_status_for_verdict("PASS"), 0)
+
+    def test_fail_is_nonzero(self):
+        self.assertEqual(exit_status_for_verdict("FAIL"), 1)
+        self.assertNotEqual(exit_status_for_verdict("FAIL"), 0)
+
+    def test_insufficient_is_two(self):
+        self.assertEqual(exit_status_for_verdict("INSUFFICIENT-DATA"), 2)
+
+    def test_unknown_verdict_is_not_a_pass(self):
+        self.assertNotEqual(exit_status_for_verdict("SOMETHING-ELSE"), 0)
 
 
 class LoadCellRepsInvalidMarkerTests(unittest.TestCase):

--- a/test/incus/mouse_latency_orchestrate.py
+++ b/test/incus/mouse_latency_orchestrate.py
@@ -619,21 +619,38 @@ def cmd_parse_cluster_state(args: argparse.Namespace) -> int:
     return 0
 
 
+POLL_FAILED_STATE = "state=POLL_FAILED"
+
+
 def cmd_rg_state_flapped(args: argparse.Namespace) -> int:
-    """Exit 0 if state drifted from initial; 1 if stable; 2 if no data.
+    """Exit 0 if state drifted from initial; 1 if stable; 2 if undetermined.
 
     R1 HIGH 5: an empty poll file means the orchestrator never got a
     successful cli sample. Returning 1 ("stable") would silently pass
     a contaminated rep. Return 2 instead so the orchestrator can
     invalidate.
+
+    C175-HC-083: the 1 Hz poller pipes each `cli` sample with `|| true`,
+    so a failed poll (cli error or empty status) appended nothing and the
+    gap was invisible. A failover that happened entirely inside such a
+    gap left the surrounding successful samples looking identical, so the
+    rep passed "stable" even though the RG flapped. The poller now writes
+    a `state=POLL_FAILED` sentinel line for every failed tick; any such
+    marker means a failover-in-gap cannot be ruled out, so a
+    no-drift result becomes undetermined (2), not stable (1). An optional
+    `--expected-samples` floor catches missing ticks even without markers.
     """
     by_ts: "dict[str, set]" = {}
+    failed_ts: "set[str]" = set()
     with open(args.poll_file) as f:
         for line in f:
             parts = line.strip().split("\t")
             if len(parts) != 4:
                 continue
             ts, rg_part, node_part, state_part = parts
+            if state_part == POLL_FAILED_STATE:
+                failed_ts.add(ts)
+                continue
             triple = (rg_part, node_part, state_part)
             by_ts.setdefault(ts, set()).add(triple)
     if not by_ts:
@@ -653,6 +670,24 @@ def cmd_rg_state_flapped(args: argparse.Namespace) -> int:
             for t in initial - triples:
                 print(f"DRIFT at {ts}: disappeared {t}")
             return 0
+    # No drift in the successful samples. But a failover could hide in a
+    # poll gap, so failed ticks or a shortfall vs the expected cadence
+    # make "stable" unprovable — return undetermined instead.
+    if failed_ts:
+        print(
+            f"{len(failed_ts)} RG poll(s) failed (POLL_FAILED); cannot "
+            "certify stable — a failover in the gap cannot be ruled out",
+            file=sys.stderr,
+        )
+        return 2
+    expected_samples = getattr(args, "expected_samples", None)
+    if expected_samples is not None and len(by_ts) < expected_samples:
+        print(
+            f"only {len(by_ts)} of {expected_samples} expected RG samples; "
+            "poll coverage too sparse to certify stable",
+            file=sys.stderr,
+        )
+        return 2
     return 1
 
 
@@ -704,6 +739,18 @@ def main() -> int:
 
     p4 = sub.add_parser("rg-state-flapped")
     p4.add_argument("poll_file")
+    p4.add_argument(
+        "--expected-samples",
+        type=int,
+        default=None,
+        help=(
+            "Minimum number of successful 1 Hz RG samples expected for the "
+            "poll window. If fewer distinct samples were collected, poll "
+            "coverage is too sparse to certify stable and the result is "
+            "undetermined (exit 2). Optional; POLL_FAILED markers already "
+            "force undetermined regardless of this floor."
+        ),
+    )
     p4.set_defaults(func=cmd_rg_state_flapped)
 
     args = parser.parse_args()

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -302,6 +302,50 @@ class RGStateFlappedTests(unittest.TestCase):
             poll = _write(t, "rg.txt", "")
             self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 2)
 
+    def test_poll_failed_marker_forces_undetermined(self):
+        # C175-HC-083 fail-on-revert: surrounding samples look stable but
+        # a poll FAILED in the gap (POLL_FAILED sentinel). A failover
+        # could hide there, so the result must be undetermined (2), not
+        # stable (1). Before the fix the marker line would have been read
+        # as a differing triple and reported as a (spurious) DRIFT (0).
+        with tempfile.TemporaryDirectory() as t:
+            content = "\n".join([
+                "1000\trg=1\tnode=0\tstate=primary",
+                "1000\trg=1\tnode=1\tstate=secondary",
+                "1500\trg=?\tnode=?\tstate=POLL_FAILED",
+                "2000\trg=1\tnode=0\tstate=primary",
+                "2000\trg=1\tnode=1\tstate=secondary",
+            ]) + "\n"
+            poll = _write(t, "rg.txt", content)
+            self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 2)
+
+    def test_real_drift_still_wins_over_poll_failed(self):
+        # A genuine flap is still a DRIFT (0) even if a later poll failed.
+        with tempfile.TemporaryDirectory() as t:
+            content = "\n".join([
+                "1000\trg=1\tnode=0\tstate=primary",
+                "1000\trg=1\tnode=1\tstate=secondary",
+                "2000\trg=1\tnode=0\tstate=secondary",
+                "2000\trg=1\tnode=1\tstate=primary",
+                "3000\trg=?\tnode=?\tstate=POLL_FAILED",
+            ]) + "\n"
+            poll = _write(t, "rg.txt", content)
+            self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 0)
+
+    def test_expected_samples_shortfall_returns_2(self):
+        class A:
+            pass
+        a = A()
+        a.expected_samples = 5
+        with tempfile.TemporaryDirectory() as t:
+            content = "\n".join([
+                "1000\trg=1\tnode=0\tstate=primary",
+                "2000\trg=1\tnode=0\tstate=primary",
+            ]) + "\n"
+            a.poll_file = _write(t, "rg.txt", content)
+            # Only 2 of 5 expected samples -> coverage too sparse.
+            self.assertEqual(orch.cmd_rg_state_flapped(a), 2)
+
 
 class CoSFixtureParseTests(unittest.TestCase):
     def test_parses_exact_class_cap_from_scheduler_rate(self):

--- a/test/incus/step1-histogram-classify.py
+++ b/test/incus/step1-histogram-classify.py
@@ -524,16 +524,19 @@ def main() -> int:
         cell_iter = list(POOL_BY_CELL.items())
 
     summary_rows = []
+    failed_cells: list[str] = []
     for rel_dir, pool in cell_iter:
         cell_dir = args.evidence_root / rel_dir
         if not cell_dir.is_dir():
-            print(f"WARN: cell dir missing {cell_dir}", file=sys.stderr)
+            print(f"ERROR: cell dir missing {cell_dir}", file=sys.stderr)
+            failed_cells.append(rel_dir)
             continue
         try:
             snaps = load_snapshots(cell_dir)
             blocks = compute_blocks(snaps)
         except Exception as e:
             print(f"ERROR: cell {rel_dir} failed: {e}", file=sys.stderr)
+            failed_cells.append(rel_dir)
             continue
 
         with (cell_dir / "hist-blocks.jsonl").open("w") as f:
@@ -578,6 +581,18 @@ def main() -> int:
 
     if args.only_cell is not None:
         # #821 §3.6: --only-cell skips summary-table.csv.
+        # C175-HC-132: a missing/corrupt target cell previously WARN'd and
+        # still returned 0, so step2's `--only-cell` reduction ran against
+        # a cell that produced no hist-blocks and the failure read as
+        # success. Fail loud when the requested cell did not classify.
+        if failed_cells:
+            print(
+                f"ERROR: --only-cell {args.only_cell!r} did not produce "
+                "hist-blocks (cell missing or failed to load/compute); "
+                "not a successful run",
+                file=sys.stderr,
+            )
+            return 1
         return 0
 
     if summary_rows:
@@ -596,6 +611,27 @@ def main() -> int:
     k_D2 = sum(1 for r in valid if r["D2_fire"])
     print(f"k_D1 = {k_D1} of {len(valid)}  (gate: k_v >= 2)")
     print(f"k_D2 = {k_D2} of {len(valid)}  (gate: k_v >= 2)")
+
+    # C175-HC-132: with every cell missing/corrupt, `valid` is empty and
+    # the gate printed a hollow "k_D1 = 0 of 0" then exited 0 — a false
+    # step-1 success (no fires) from zero measurement. Fail loud instead:
+    # an empty valid set cannot evaluate the k_v >= 2 gate, and any
+    # missing/corrupt cell means the gate ran on partial evidence.
+    if not valid:
+        print(
+            "ERROR: no valid (non-suspect) cells classified — cannot "
+            "evaluate the k_v >= 2 gate; insufficient evidence",
+            file=sys.stderr,
+        )
+        return 2
+    if failed_cells:
+        print(
+            f"ERROR: {len(failed_cells)} cell(s) missing/corrupt "
+            f"({failed_cells}); the k_v gate was evaluated on partial "
+            "evidence — not a clean pass",
+            file=sys.stderr,
+        )
+        return 1
 
     return 0
 

--- a/test/incus/step1-histogram-classify_test.py
+++ b/test/incus/step1-histogram-classify_test.py
@@ -446,6 +446,36 @@ def test_i14_monotonic_submit_still_classifies():
         assert all(x >= 0.0 for x in blk["shape"]), blk["shape"]
 
 
+# ------------------------------------------------- 28 (C175-HC-132) ---
+def test_only_cell_missing_target_returns_nonzero(tmp_path, monkeypatch):
+    """--only-cell on a missing/failed cell must NOT exit 0.
+
+    Fail-on-revert: the pre-fix main() only WARN'd on a missing target
+    cell dir and still returned 0 in --only-cell mode, so step2's
+    single-cell reduction ran against a cell that produced no
+    hist-blocks.jsonl and the failure read as success.
+    """
+    import sys as _sys
+
+    root = tmp_path / "evidence"
+    root.mkdir()
+    cell = "with-cos/p5201-fwd"  # a valid POOL_BY_CELL key; dir absent
+    assert cell in step1.POOL_BY_CELL
+    monkeypatch.setattr(
+        _sys,
+        "argv",
+        [
+            "step1-histogram-classify.py",
+            "--evidence-root",
+            str(root),
+            "--only-cell",
+            cell,
+        ],
+    )
+    rc = step1.main()
+    assert rc != 0
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-v"]))

--- a/test/incus/step1-rate-spread-analysis.py
+++ b/test/incus/step1-rate-spread-analysis.py
@@ -48,16 +48,50 @@ from pathlib import Path
 from typing import List, Tuple
 
 
-def load_per_flow_rates(path: Path) -> List[float]:
+DEFAULT_STREAMS = 16
+
+
+class RateSpreadError(Exception):
+    """A cell's iperf3 JSON is incomplete/malformed for spread analysis."""
+
+
+def load_per_flow_rates(
+    path: Path, expected_streams: int | None = DEFAULT_STREAMS
+) -> List[float]:
+    """Extract per-flow sender rates, validating input completeness.
+
+    C175-HC-128: the prior loader silently dropped any stream whose
+    sender.bits_per_second was missing/zero and never checked the stream
+    count. A cell that captured only a couple of valid streams (a
+    truncated or partly-failed iperf3 run) still produced a max/min ratio
+    that fed the Verdict-B threshold Y — a threshold derived from partial
+    evidence. Require exactly `expected_streams` streams (16 by default),
+    each with a positive finite sender rate; anything else raises so the
+    caller fails loud instead of computing Y from a fragment.
+    """
     with path.open() as f:
         data = json.load(f)
     streams = data.get("end", {}).get("streams", [])
+    if expected_streams is not None and len(streams) != expected_streams:
+        raise RateSpreadError(
+            f"{path.name}: expected {expected_streams} streams, "
+            f"found {len(streams)}"
+        )
     rates: List[float] = []
-    for s in streams:
+    for i, s in enumerate(streams):
         sender = s.get("sender") or {}
         bps = sender.get("bits_per_second")
-        if bps and bps > 0:
-            rates.append(float(bps))
+        if (
+            isinstance(bps, bool)
+            or not isinstance(bps, (int, float))
+            or not math.isfinite(bps)
+            or bps <= 0
+        ):
+            raise RateSpreadError(
+                f"{path.name}: stream {i} has invalid "
+                f"sender.bits_per_second={bps!r}"
+            )
+        rates.append(float(bps))
     return rates
 
 
@@ -99,6 +133,16 @@ def main(argv: List[str] | None = None) -> int:
     )
     p.add_argument("--floor-ratio", type=float, default=0.5)
     p.add_argument(
+        "--expected-streams",
+        type=int,
+        default=DEFAULT_STREAMS,
+        help=(
+            "Exact per-cell iperf3 stream count to require (default 16). "
+            "A cell with a different count is rejected as partial evidence. "
+            "Pass 0 to disable the exact-count check."
+        ),
+    )
+    p.add_argument(
         "--bootstrap-trials",
         type=int,
         default=10000,
@@ -125,15 +169,33 @@ def main(argv: List[str] | None = None) -> int:
     print(f"# Slow-start floor: < {args.floor_ratio}x median dropped before min()")
     print()
 
+    # C175-HC-128: every requested cell must be present. Silently
+    # skipping a missing cell let Y be derived from whichever cells
+    # happened to exist (as few as two), i.e. from partial evidence.
+    expected_streams = args.expected_streams if args.expected_streams > 0 else None
+    missing = [
+        name
+        for name in args.cells
+        if not (args.evidence_dir / f"{name}.json").is_file()
+    ]
+    if missing:
+        print(
+            f"error: missing cell file(s): {missing} in {args.evidence_dir}; "
+            "refusing to derive Y from partial evidence",
+            file=sys.stderr,
+        )
+        return 2
+
     print(f"{'cell':<12}  {'n':>3}  {'max_gbps':>10}  "
           f"{'min_gbps':>10}  {'ratio':>7}")
     ratios: List[float] = []
     for name in args.cells:
         path = args.evidence_dir / f"{name}.json"
-        if not path.is_file():
-            print(f"# WARN: missing {path}", file=sys.stderr)
-            continue
-        rates = load_per_flow_rates(path)
+        try:
+            rates = load_per_flow_rates(path, expected_streams=expected_streams)
+        except RateSpreadError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 2
         ratio, mx, mn, n = cell_spread(rates)
         print(f"{name:<12}  {n:>3}  {mx/1e9:>10.4f}  {mn/1e9:>10.4f}  {ratio:>7.4f}")
         ratios.append(ratio)

--- a/test/incus/step1-rate-spread-analysis_test.py
+++ b/test/incus/step1-rate-spread-analysis_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for step1-rate-spread-analysis.py (#4907 / C175-HC-128).
+
+Guards the evidence-completeness checks: Threshold Y must not be derived
+from a cell with the wrong stream count, from a cell with malformed
+sender rates, or from a run where some requested cells are missing.
+
+Run:
+    python3 test/incus/step1-rate-spread-analysis_test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve().parent
+_MOD_PATH = _HERE / "step1-rate-spread-analysis.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "step1_rate_spread_analysis", str(_MOD_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+RS = _load()
+
+
+def _iperf3_json(rates: list) -> dict:
+    return {"end": {"streams": [{"sender": {"bits_per_second": r}} for r in rates]}}
+
+
+def _write_cell(d: Path, name: str, rates: list) -> Path:
+    p = d / f"{name}.json"
+    p.write_text(json.dumps(_iperf3_json(rates)))
+    return p
+
+
+class LoadPerFlowRatesTests(unittest.TestCase):
+    def test_exact_16_loads(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            p = _write_cell(d, "p5201-fwd", [1e9] * 16)
+            rates = RS.load_per_flow_rates(p)
+            self.assertEqual(len(rates), 16)
+
+    def test_partial_stream_count_raises(self):
+        # C175-HC-128 fail-on-revert: a truncated cell (2 of 16 streams)
+        # previously computed a ratio; now it must raise.
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            p = _write_cell(d, "p5201-fwd", [1e9, 2e9])
+            with self.assertRaises(RS.RateSpreadError):
+                RS.load_per_flow_rates(p)
+
+    def test_malformed_sender_bps_raises(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            # 16 streams but one has a zero/None sender rate (partly failed).
+            rates = [1e9] * 15 + [0]
+            p = _write_cell(d, "p5201-fwd", rates)
+            with self.assertRaises(RS.RateSpreadError):
+                RS.load_per_flow_rates(p)
+
+    def test_expected_streams_none_disables_count_check(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            p = _write_cell(d, "p5201-fwd", [1e9, 2e9, 3e9])
+            rates = RS.load_per_flow_rates(p, expected_streams=None)
+            self.assertEqual(len(rates), 3)
+
+
+class MainTests(unittest.TestCase):
+    def _run(self, cells: list, evidence_dir: Path) -> int:
+        argv = [
+            "--evidence-dir",
+            str(evidence_dir),
+            "--cells",
+            *cells,
+            "--bootstrap-trials",
+            "0",
+        ]
+        return RS.main(argv)
+
+    def test_missing_cell_fails(self):
+        # C175-HC-128 fail-on-revert: a missing requested cell previously
+        # WARN'd and Y was derived from whichever cells existed. Now the
+        # run must exit non-zero.
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            _write_cell(d, "p5201-fwd", [1e9] * 16)
+            _write_cell(d, "p5202-fwd", [1e9] * 16)
+            # p5203-fwd and p5204-fwd are absent.
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = self._run(
+                    ["p5201-fwd", "p5202-fwd", "p5203-fwd", "p5204-fwd"], d
+                )
+            self.assertEqual(rc, 2)
+            self.assertIn("missing cell file", err.getvalue())
+
+    def test_partial_cell_fails(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            _write_cell(d, "p5201-fwd", [1e9] * 16)
+            _write_cell(d, "p5202-fwd", [1e9] * 2)  # truncated
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = self._run(["p5201-fwd", "p5202-fwd"], d)
+            self.assertEqual(rc, 2)
+
+    def test_all_present_and_complete_succeeds(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = Path(t)
+            _write_cell(d, "p5201-fwd", [1e9 + i * 1e8 for i in range(16)])
+            _write_cell(d, "p5202-fwd", [1e9 + i * 1e8 for i in range(16)])
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                # Suppress stdout chatter by redirecting it too.
+                real = sys.stdout
+                sys.stdout = io.StringIO()
+                try:
+                    rc = self._run(["p5201-fwd", "p5202-fwd"], d)
+                finally:
+                    sys.stdout = real
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/step1-rss-multinomial.py
+++ b/test/incus/step1-rss-multinomial.py
@@ -32,7 +32,7 @@ import argparse
 import random
 import sys
 from collections import Counter
-from typing import Dict, List, Sequence, Tuple
+from typing import Dict, Iterable, Iterator, List, Sequence, Tuple
 
 
 def simulate(
@@ -41,8 +41,17 @@ def simulate(
     n_workers: int,
     seed: int,
     probs: Sequence[float] | None = None,
-) -> List[Tuple[int, int]]:
-    """Return list of (max_count, min_count) per trial.
+) -> Iterator[Tuple[int, int]]:
+    """Yield (max_count, min_count) per trial, streaming (O(1) memory).
+
+    C175-HC-130: the prior implementation appended one (max, min) tuple
+    per trial into a list and returned it, so a 10^7-trial run held ~10M
+    tuples (hundreds of MB, and GB-scale for larger runs) even though the
+    downstream statistics need only O(1) sufficient counters. This is a
+    generator: each trial is produced and consumed one at a time, so
+    tail_probabilities aggregates in constant memory and a large run can
+    no longer OOM CI. The RNG is created once and advanced in trial
+    order, so the deterministic-seed contract is preserved.
 
     If ``probs`` is None, workers are drawn uniformly (fair RSS).
     Otherwise ``probs`` is a sequence of length ``n_workers`` that
@@ -65,7 +74,6 @@ def simulate(
     else:
         cum = None
 
-    out: List[Tuple[int, int]] = []
     for _ in range(trials):
         counts = [0] * n_workers
         for _f in range(n_flows):
@@ -77,19 +85,26 @@ def simulate(
                 while w < n_workers - 1 and u > cum[w]:
                     w += 1
             counts[w] += 1
-        out.append((max(counts), min(counts)))
-    return out
+        yield (max(counts), min(counts))
 
 
-def tail_probabilities(samples: List[Tuple[int, int]], n_flows: int) -> Dict[str, float]:
-    """Compute the FP tails the plan references plus union events."""
-    total = len(samples)
+def tail_probabilities(
+    samples: Iterable[Tuple[int, int]], n_flows: int
+) -> Dict[str, float]:
+    """Compute the FP tails the plan references plus union events.
+
+    Consumes ``samples`` as a stream, counting trials as it goes so a
+    generator (see ``simulate``) can be aggregated without materializing
+    every trial (C175-HC-130).
+    """
+    total = 0
     max_counter: Counter[int] = Counter()
     min_counter: Counter[int] = Counter()
     union_8_or_0 = 0
     union_9_or_0 = 0
     union_7_or_1 = 0
     for mx, mn in samples:
+        total += 1
         max_counter[mx] += 1
         min_counter[mn] += 1
         if mx >= 8 or mn <= 0:
@@ -98,6 +113,9 @@ def tail_probabilities(samples: List[Tuple[int, int]], n_flows: int) -> Dict[str
             union_9_or_0 += 1
         if mx >= 7 or mn <= 1:
             union_7_or_1 += 1
+
+    if total == 0:
+        raise ValueError("no trials to aggregate")
 
     def ge(counter: Counter[int], threshold: int) -> float:
         return sum(c for k, c in counter.items() if k >= threshold) / total

--- a/test/incus/step1-rss-multinomial_test.py
+++ b/test/incus/step1-rss-multinomial_test.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Tests for step1-rss-multinomial.py (#4907 / C175-HC-130).
+
+Guards that the Monte Carlo streams trials instead of retaining every
+one, while preserving the deterministic-seed statistics.
+
+Run:
+    python3 test/incus/step1-rss-multinomial_test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve().parent
+_MOD_PATH = _HERE / "step1-rss-multinomial.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "step1_rss_multinomial", str(_MOD_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+M = _load()
+
+
+class SimulateStreamingTests(unittest.TestCase):
+    def test_simulate_is_a_generator_not_a_list(self):
+        # C175-HC-130 fail-on-revert: the old simulate() built and
+        # returned a list holding one tuple per trial (GB-scale for 10M
+        # trials). Streaming yields a generator instead.
+        gen = M.simulate(trials=10, n_flows=16, n_workers=4, seed=42)
+        self.assertIsInstance(gen, types.GeneratorType)
+        self.assertNotIsInstance(gen, list)
+
+    def test_seed_is_deterministic(self):
+        a = M.tail_probabilities(
+            M.simulate(trials=2000, n_flows=16, n_workers=4, seed=7), 16
+        )
+        b = M.tail_probabilities(
+            M.simulate(trials=2000, n_flows=16, n_workers=4, seed=7), 16
+        )
+        self.assertEqual(a, b)
+
+    def test_probabilities_are_well_formed(self):
+        probs = M.tail_probabilities(
+            M.simulate(trials=5000, n_flows=16, n_workers=4, seed=42), 16
+        )
+        for key, val in probs.items():
+            self.assertGreaterEqual(val, 0.0, key)
+            self.assertLessEqual(val, 1.0, key)
+        # A perfectly fair split of 16 over 4 has max 4; P(max>=8) is a
+        # small tail but must be strictly less than P(max>=7).
+        self.assertGreaterEqual(probs["P(max>=7)"], probs["P(max>=8)"])
+        self.assertGreaterEqual(probs["P(max>=8)"], probs["P(max>=9)"])
+
+    def test_tail_probabilities_rejects_empty(self):
+        with self.assertRaises(ValueError):
+            M.tail_probabilities(iter([]), 16)
+
+    def test_skewed_worker0_power_is_high(self):
+        # Sanity: with worker0 taking 56% of flows, the max is large, so
+        # the Verdict-A union fires almost always.
+        probs = M.simulate(
+            trials=3000,
+            n_flows=16,
+            n_workers=4,
+            seed=1,
+            probs=[0.56, 0.44 / 3, 0.44 / 3, 0.44 / 3],
+        )
+        tp = M.tail_probabilities(probs, 16)
+        self.assertGreater(tp["FP_union_max9_or_min0"], 0.5)
+
+
+class MainSmokeTests(unittest.TestCase):
+    def test_cli_runs_small(self):
+        result = subprocess.run(
+            [sys.executable, str(_MOD_PATH), "--trials", "1000", "--seed", "42"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Monte Carlo", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/incus/step2-sched-switch-classify.py
+++ b/test/incus/step2-sched-switch-classify.py
@@ -17,6 +17,11 @@ T3 verdict (per plan §3.3):
     rho <= 0.3  or   duty_cycle_pct <  1.0   -> OUT
     else                                     -> INCONCLUSIVE
 
+No-evidence guard (C175-HC-070): an empty/truncated perf capture reduces to
+12 all-zero blocks; that is classified INSUFFICIENT (exit 2), never a
+definitive OUT.  Exit status: INSUFFICIENT -> 2; IN/OUT/INCONCLUSIVE/SUSPECT
+-> 0.
+
 Writes:
     --out                                  markdown report
     <out>.meta.json (sibling)              machine-readable summary
@@ -306,6 +311,27 @@ def main(argv: list[str] | None = None) -> int:
 
     verdict, reason = verdict_from(rho, duty_cycle_pct, suspect_reason)
 
+    # C175-HC-070: an empty/truncated perf capture reduces to 12 all-zero
+    # blocks — every bucket 0 and every stat_runtime_check WARN (zero
+    # runtime vs a non-zero expected). Classifying that as a definitive
+    # OUT (duty 0 < 1%) rules the scheduler out from a measurement that
+    # never happened. Detect the no-evidence shape and emit INSUFFICIENT
+    # with a non-zero exit instead. A real capture always has either
+    # non-zero off-CPU buckets or at least one passing stat_runtime block.
+    no_off_cpu = all(
+        sum(int(x) for x in b.get("buckets", [])) == 0 for b in off_cpu_blocks
+    )
+    no_runtime = all(
+        b.get("stat_runtime_check") == "WARN" for b in off_cpu_blocks
+    )
+    if suspect_reason is None and no_off_cpu and no_runtime:
+        verdict = "INSUFFICIENT"
+        reason = (
+            "no scheduler evidence: all 12 blocks have zero off-CPU buckets "
+            "and no passing stat_runtime accounting — the perf capture was "
+            "empty or truncated; refusing a definitive OUT"
+        )
+
     voluntary_total = sum(int(b.get("voluntary_3to6", 0)) for b in off_cpu_blocks)
     involuntary_total = sum(
         int(b.get("involuntary_3to6", 0)) for b in off_cpu_blocks
@@ -377,7 +403,10 @@ def main(argv: list[str] | None = None) -> int:
         + (f" suspect_reason={suspect_reason}" if suspect_reason else ""),
         file=sys.stderr,
     )
-    return 0
+    # C175-HC-070: INSUFFICIENT (no measurement) must exit non-zero so a
+    # missing/truncated capture cannot pass as a definitive verdict. IN /
+    # OUT / INCONCLUSIVE / SUSPECT keep their historical exit-0 semantics.
+    return 2 if verdict == "INSUFFICIENT" else 0
 
 
 if __name__ == "__main__":

--- a/test/incus/step2-sched-switch-classify.py
+++ b/test/incus/step2-sched-switch-classify.py
@@ -287,7 +287,22 @@ def main(argv: list[str] | None = None) -> int:
 
     rho, pvalue = spearman_rho(T_D1, [float(x) for x in off_times])
 
-    duty_cycle_pct = 100.0 * sum(off_times) / NOMINAL_WINDOW_NS
+    # C175-HC-092: divide off-CPU time by the ACTUAL capture window, not a
+    # fixed 60 s. The reducer accepts [1, 30] s snapshot blocks, so 12
+    # blocks can span 12-360 s; dividing by a hard-coded 60 s flipped the
+    # IN/OUT duty verdict purely on collection cadence. When every block
+    # carries `block_span_ns` (current reducer output) sum them for the
+    # true window; fall back to the 60 s nominal only for legacy JSONL
+    # that predates the field.
+    block_spans = [b.get("block_span_ns") for b in off_cpu_blocks]
+    if off_cpu_blocks and all(
+        isinstance(s, (int, float)) and s > 0 for s in block_spans
+    ):
+        window_ns = float(sum(block_spans))
+    else:
+        window_ns = float(NOMINAL_WINDOW_NS)
+
+    duty_cycle_pct = 100.0 * sum(off_times) / window_ns
 
     verdict, reason = verdict_from(rho, duty_cycle_pct, suspect_reason)
 
@@ -348,6 +363,7 @@ def main(argv: list[str] | None = None) -> int:
         "duty_in_pct": DUTY_IN_PCT,
         "duty_out_pct": DUTY_OUT_PCT,
         "nominal_window_ns": NOMINAL_WINDOW_NS,
+        "window_ns": window_ns,
     }
     # Sibling files: <report>.md -> <report>.meta.json + <report>.diag.json.
     meta_path = args.out.parent / (args.out.stem + ".meta.json")

--- a/test/incus/step2-sched-switch-classify_test.py
+++ b/test/incus/step2-sched-switch-classify_test.py
@@ -74,11 +74,14 @@ def _off_cpu_blocks(
     off_times: list[int],
     stat: list[str] | None = None,
     vol_of: float = 0.5,
+    block_span_ns: int | None = None,
 ) -> list[dict]:
     """Synthesize 12 off-cpu reducer dicts.
 
     `stat[b]` is "PASS" or "WARN"; defaults to all PASS.  The off time
     is placed entirely in bucket 3 (so the reducer invariant holds).
+    When `block_span_ns` is given each block carries it (C175-HC-092
+    real-window duty); otherwise the field is omitted (legacy JSONL).
     """
     assert len(off_times) == 12
     if stat is None:
@@ -89,16 +92,17 @@ def _off_cpu_blocks(
         buckets[3] = t
         vol = int(t * vol_of)
         invol = t - vol
-        out.append(
-            {
-                "b": b,
-                "buckets": buckets,
-                "off_cpu_time_3to6": t,
-                "voluntary_3to6": vol,
-                "involuntary_3to6": invol,
-                "stat_runtime_check": stat[b],
-            }
-        )
+        blk = {
+            "b": b,
+            "buckets": buckets,
+            "off_cpu_time_3to6": t,
+            "voluntary_3to6": vol,
+            "involuntary_3to6": invol,
+            "stat_runtime_check": stat[b],
+        }
+        if block_span_ns is not None:
+            blk["block_span_ns"] = block_span_ns
+        out.append(blk)
     return out
 
 
@@ -221,6 +225,37 @@ class TestClassifyVerdicts(unittest.TestCase):
         self.assertGreater(rho, 0.3)
         self.assertLess(rho, 0.8)
         self.assertEqual(meta["verdict"], "INCONCLUSIVE")
+
+
+class TestClassifyDutyWindow(unittest.TestCase):
+    """C175-HC-092: duty-cycle uses the actual capture window."""
+
+    def test_duty_uses_summed_block_span_not_fixed_60s(self):
+        # Total off-CPU = 0.6 s. Blocks are 7 s each -> 84 s window ->
+        # duty = 0.6 / 84 = 0.714 %.  Against the old fixed 60 s
+        # denominator it would read 0.6 / 60 = 1.0 %.  The two land on
+        # opposite sides of the 1.0 % IN/OUT threshold, so the real
+        # window MUST be used.
+        off_times = [50_000_000 for _ in range(12)]  # 12 * 50 ms = 0.6 s
+        shape_vals = [float(b + 1) for b in range(12)]
+        hist = _hist_blocks_with_shape3to6(shape_vals)
+        off = _off_cpu_blocks(off_times, block_span_ns=7_000_000_000)
+        rc, meta, diag = _run_classifier_with_diag(hist, off)
+        self.assertEqual(rc, 0)
+        # 84 s window -> ~0.714 %, NOT the 1.0 % a fixed 60 s would give.
+        self.assertAlmostEqual(meta["duty_cycle_pct"], 100.0 * 0.6 / 84.0, places=4)
+        self.assertLess(meta["duty_cycle_pct"], 1.0)
+        self.assertEqual(diag["window_ns"], 84_000_000_000)
+
+    def test_missing_block_span_falls_back_to_nominal_60s(self):
+        # Legacy JSONL without block_span_ns keeps the 60 s nominal window.
+        off_times = [50_000_000 for _ in range(12)]  # 0.6 s
+        shape_vals = [float(b + 1) for b in range(12)]
+        hist = _hist_blocks_with_shape3to6(shape_vals)
+        off = _off_cpu_blocks(off_times)  # no block_span_ns
+        rc, meta = _run_classifier(hist, off)
+        self.assertEqual(rc, 0)
+        self.assertAlmostEqual(meta["duty_cycle_pct"], 100.0 * 0.6 / 60.0, places=4)
 
 
 class TestClassifyMetaSchema(unittest.TestCase):

--- a/test/incus/step2-sched-switch-classify_test.py
+++ b/test/incus/step2-sched-switch-classify_test.py
@@ -258,6 +258,33 @@ class TestClassifyDutyWindow(unittest.TestCase):
         self.assertAlmostEqual(meta["duty_cycle_pct"], 100.0 * 0.6 / 60.0, places=4)
 
 
+class TestClassifyInsufficientEvidence(unittest.TestCase):
+    """C175-HC-070: no-evidence input is INSUFFICIENT, not a definitive OUT."""
+
+    def test_all_zero_blocks_are_insufficient_not_out(self):
+        # Mirror empty-reducer output: every bucket 0, every
+        # stat_runtime_check WARN. Fail-on-revert: the pre-fix classifier
+        # computed duty 0 < 1% -> OUT, exit 0.
+        off_times = [0] * 12
+        shape_vals = [0.0] * 12
+        hist = _hist_blocks_with_shape3to6(shape_vals)
+        off = _off_cpu_blocks(off_times, stat=["WARN"] * 12)
+        rc, meta = _run_classifier(hist, off)
+        self.assertEqual(rc, 2)
+        self.assertEqual(meta["verdict"], "INSUFFICIENT")
+
+    def test_legit_low_duty_with_runtime_passes_still_out(self):
+        # A real capture with some passing stat_runtime blocks and small
+        # off-CPU is a genuine OUT (not insufficient) and stays exit 0.
+        off_times = [1_000_000 for _ in range(12)]  # tiny but non-zero
+        shape_vals = [float(b + 1) for b in range(12)]
+        hist = _hist_blocks_with_shape3to6(shape_vals)
+        off = _off_cpu_blocks(off_times, stat=["PASS"] * 12)
+        rc, meta = _run_classifier(hist, off)
+        self.assertEqual(rc, 0)
+        self.assertEqual(meta["verdict"], "OUT")
+
+
 class TestClassifyMetaSchema(unittest.TestCase):
     def test_meta_json_schema(self):
         """LOW-5 R4: top-level keys are EXACTLY the plan §3.1 step 11

--- a/test/incus/step2-sched-switch-reduce.py
+++ b/test/incus/step2-sched-switch-reduce.py
@@ -117,7 +117,9 @@ def bucket_index_for_ns(ns: int) -> int:
 # We only need:
 #   - the event name (sched_switch / sched_wakeup / sched_stat_runtime)
 #   - the timestamp (float seconds, absolute unix wall-clock — see below)
-#   - for sched_switch: prev_pid, prev_state
+#   - for sched_switch: prev_pid, prev_state, next_pid (next_pid closes a
+#     worker's off-CPU interval at schedule-in; prev_pid opens one at
+#     schedule-out — see C175-HC-026 in reduce_events)
 #   - for sched_wakeup: the target pid (field `pid=`, not `target_cpu=`)
 #   - for sched_stat_runtime: the tid (column 2) and `runtime=<ns>`
 #
@@ -157,6 +159,7 @@ LINE_HEADER_RE = re.compile(
 # Field pulls from `rest`.
 SWITCH_PREV_PID_RE = re.compile(r"\bprev_pid=(\d+)\b")
 SWITCH_PREV_STATE_RE = re.compile(r"\bprev_state=(\S+)")
+SWITCH_NEXT_PID_RE = re.compile(r"\bnext_pid=(\d+)\b")
 WAKEUP_PID_RE = re.compile(r"\bpid=(\d+)\b")
 STAT_RUNTIME_NS_RE = re.compile(r"\bruntime=(\d+)\b")
 
@@ -198,10 +201,13 @@ def parse_perf_script(path: Path) -> Iterator[tuple[str, int, int, dict]]:
             if event == "sched:sched_switch":
                 pm = SWITCH_PREV_PID_RE.search(rest)
                 sm = SWITCH_PREV_STATE_RE.search(rest)
+                nm = SWITCH_NEXT_PID_RE.search(rest)
                 if pm:
                     fields["prev_pid"] = int(pm.group(1))
                 if sm:
                     fields["prev_state"] = sm.group(1)
+                if nm:
+                    fields["next_pid"] = int(nm.group(1))
             elif event == "sched:sched_wakeup":
                 wm = WAKEUP_PID_RE.search(rest)
                 if wm:
@@ -417,40 +423,63 @@ def reduce_events(
         if event == "sched:sched_switch":
             prev_pid = fields.get("prev_pid")
             prev_state = fields.get("prev_state", "")
+            next_pid = fields.get("next_pid")
+            # C175-HC-026: an off-CPU interval ends when the worker is
+            # scheduled back IN (sched_switch with next_pid=worker), NOT
+            # at sched_wakeup.  A worker preempted while still runnable
+            # (prev_state=R) never sleeps, so the kernel emits no
+            # sched_wakeup for it; closing intervals on wakeup meant that
+            # interval was never closed and involuntary preemption time
+            # was silently dropped — the exact signature this harness is
+            # meant to measure.  Closing on schedule-in captures both
+            # voluntary sleeps (woken, then scheduled) and involuntary
+            # preemptions (runnable the whole time, later rescheduled).
+            if next_pid in worker_tids and next_pid in off_start_ns:
+                t_off = off_start_ns[next_pid]
+                delta_ns = t_event_wall_ns - t_off
+                state = off_state.get(next_pid, "")
+                # Defensive: the outer monotonicity guard already rejects
+                # rewound timestamps, so a schedule-in earlier than its
+                # own schedule-out should be unreachable under ordered
+                # perf input.
+                if delta_ns < 0:
+                    msg = (
+                        f"negative off-CPU delta for tid={next_pid} "
+                        f"(t_off={t_off}, t_in={t_event_wall_ns}); skipped"
+                    )
+                    warnings.append(msg)
+                    print(f"WARN: {msg}", file=warn_stream)
+                    off_start_ns.pop(next_pid, None)
+                    off_state.pop(next_pid, None)
+                else:
+                    b = block_for_timestamp(t_off, boundaries_ns)
+                    if 0 <= b < N_BLOCKS:
+                        bi = bucket_index_for_ns(delta_ns)
+                        buckets_by_block[b][bi] += delta_ns
+                        total_off_cpu_by_block[b] += delta_ns
+                        # prev_state captured at switch-OUT classifies the
+                        # interval: startswith("R") -> involuntary.
+                        if state.startswith("R"):
+                            if D1_LO <= bi <= D1_HI:
+                                involuntary_by_block[b] += delta_ns
+                        else:
+                            if D1_LO <= bi <= D1_HI:
+                                voluntary_by_block[b] += delta_ns
+                    off_start_ns.pop(next_pid, None)
+                    off_state.pop(next_pid, None)
+            # A worker being scheduled OUT opens a new off-CPU interval,
+            # tagged with its exit state (S/D/... = voluntary, R/R+ =
+            # involuntary preemption).
             if prev_pid in worker_tids:
                 off_start_ns[prev_pid] = t_event_wall_ns
                 off_state[prev_pid] = prev_state
         elif event == "sched:sched_wakeup":
-            pid = fields.get("pid")
-            if pid in worker_tids and pid in off_start_ns:
-                t_off = off_start_ns[pid]
-                delta_ns = t_event_wall_ns - t_off
-                state = off_state.get(pid, "")
-                # Monotonicity check per §3.2 / test case 4.
-                if delta_ns < 0:
-                    msg = (
-                        f"negative off-CPU delta for tid={pid} "
-                        f"(t_off={t_off}, t_wake={t_event_wall_ns}); skipped"
-                    )
-                    warnings.append(msg)
-                    print(f"WARN: {msg}", file=warn_stream)
-                    off_start_ns.pop(pid, None)
-                    off_state.pop(pid, None)
-                    continue
-                b = block_for_timestamp(t_off, boundaries_ns)
-                if 0 <= b < N_BLOCKS:
-                    bi = bucket_index_for_ns(delta_ns)
-                    buckets_by_block[b][bi] += delta_ns
-                    total_off_cpu_by_block[b] += delta_ns
-                    # prev_state classification: startswith("R") -> involuntary
-                    if state.startswith("R"):
-                        if D1_LO <= bi <= D1_HI:
-                            involuntary_by_block[b] += delta_ns
-                    else:
-                        if D1_LO <= bi <= D1_HI:
-                            voluntary_by_block[b] += delta_ns
-                off_start_ns.pop(pid, None)
-                off_state.pop(pid, None)
+            # Wakeup marks a task runnable but NOT yet on-CPU.  The off-CPU
+            # interval is closed at schedule-in (handled above), so a
+            # wakeup no longer ends it.  Retained as a consumed tracepoint
+            # (wake->schedule-in is run-queue latency) but it does not
+            # affect off-CPU duration accounting.
+            pass
         elif event == "sched:sched_stat_runtime":
             rn = fields.get("runtime_ns", 0)
             if tid in worker_tids:

--- a/test/incus/step2-sched-switch-reduce.py
+++ b/test/incus/step2-sched-switch-reduce.py
@@ -640,7 +640,17 @@ def main(argv: list[str] | None = None) -> int:
         print("HALT: --worker-tids produced empty set", file=sys.stderr)
         return 2
 
-    events = parse_perf_script(args.perf_script)
+    # C175-HC-070: count sched events as they stream so an empty or
+    # truncated perf capture (zero events) cannot be reduced to 12
+    # all-zero blocks and read downstream as a definitive scheduler OUT.
+    event_count = [0]
+
+    def _counting(gen):
+        for e in gen:
+            event_count[0] += 1
+            yield e
+
+    events = _counting(parse_perf_script(args.perf_script))
     reduce_events(
         events=events,
         boundaries_ns=boundaries_ns,
@@ -649,7 +659,21 @@ def main(argv: list[str] | None = None) -> int:
         mono_wall_offset_ns=args.mono_wall_offset_ns,
         suspect_reason=suspect_reason,
     )
-    return EXIT_DRIFT_HALT if drift_halt else 0
+    if drift_halt:
+        # Drift halt already emitted suspect-stamped forensics; its exit
+        # code takes precedence over the emptiness check.
+        return EXIT_DRIFT_HALT
+    if event_count[0] == 0:
+        print(
+            "HALT: perf script produced zero sched events "
+            f"({args.perf_script}); the capture is empty or truncated. "
+            "Refusing to certify a scheduler histogram from no data — a "
+            "definitive OUT here would rule the scheduler out from a "
+            "measurement that never happened.",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
 
 
 if __name__ == "__main__":

--- a/test/incus/step2-sched-switch-reduce.py
+++ b/test/incus/step2-sched-switch-reduce.py
@@ -530,6 +530,12 @@ def reduce_events(
             "voluntary_3to6": vol,
             "involuntary_3to6": invol,
             "stat_runtime_check": stat_runtime_check,
+            # C175-HC-092: stamp the actual span of this block so the
+            # classifier computes duty-cycle against the real capture
+            # window (sum of block spans) instead of a hard-coded 60 s.
+            # Blocks may legitimately be [1, 30] s (see load_boundaries_ns),
+            # so 12 blocks can span far more or less than 60 s.
+            "block_span_ns": block_duration_ns,
         }
         # HIGH-2: stamp every emitted line with the drift-halt sentinel
         # so the classifier can emit SUSPECT without a separate marker.

--- a/test/incus/step2-sched-switch-reduce_test.py
+++ b/test/incus/step2-sched-switch-reduce_test.py
@@ -623,6 +623,54 @@ class TestReducerEmpty(unittest.TestCase):
             self.assertEqual(obj["stat_runtime_check"], "WARN")
 
 
+class TestReducerEmptyPerfHalts(unittest.TestCase):
+    """C175-HC-070: an empty/truncated perf capture must fail loud."""
+
+    def test_reducer_halts_on_empty_perf(self):
+        """main() returns non-zero when the perf script has zero events.
+
+        Fail-on-revert: the pre-fix main() always returned 0 (or 5 on
+        drift), so an empty capture emitted 12 all-zero blocks and exited
+        0 — the classifier then ruled the scheduler definitively OUT from
+        a measurement that never happened.
+        """
+        cold = {"_sample_ts": "1000000000"}
+        cold_path = _write_inline(json.dumps(cold), ".json")
+        warm_lines = [
+            json.dumps({"_sample_ts": str(1000000000 + (i + 1) * 5)})
+            for i in range(12)
+        ]
+        samples_path = _write_inline("\n".join(warm_lines) + "\n", ".jsonl")
+        perf_path = _write_inline("", ".txt")  # empty capture
+        step1_start_ns = 1_000_000_000 * 1_000_000_000
+        perf_start_ns = step1_start_ns  # zero drift -> not a drift halt
+
+        real_stderr = sys.stderr
+        real_stdout = sys.stdout
+        cap_err = io.StringIO()
+        cap_out = io.StringIO()
+        try:
+            sys.stderr = cap_err
+            sys.stdout = cap_out
+            rc = R.main(
+                [
+                    "--perf-script", str(perf_path),
+                    "--step1-cold", str(cold_path),
+                    "--step1-samples", str(samples_path),
+                    "--worker-tids", "1",
+                    "--perf-start-ns", str(perf_start_ns),
+                ]
+            )
+        finally:
+            sys.stderr = real_stderr
+            sys.stdout = real_stdout
+            cold_path.unlink()
+            samples_path.unlink()
+            perf_path.unlink()
+        self.assertEqual(rc, 2, f"expected exit 2 on empty perf, got {rc}")
+        self.assertIn("zero sched events", cap_err.getvalue())
+
+
 class TestReducerInvariant(unittest.TestCase):
     def test_reducer_invariant_sum_buckets_3to6(self):
         """V3: sum(buckets[3:7]) == off_cpu_time_3to6 on every block.
@@ -687,7 +735,14 @@ class TestReducerDrift(unittest.TestCase):
                 json.dumps({"_sample_ts": str(1000000000 + (i + 1) * 5)})
             )
         samples_path = _write_inline("\n".join(warm_lines) + "\n", ".jsonl")
-        perf_path = _write_inline("", ".txt")
+        # One valid sched event so the capture is non-empty (the empty
+        # capture path is exercised by test_reducer_halts_on_empty_perf).
+        perf_line = (
+            "xpf 1 [000] 1000000001.000000000: sched:sched_switch: "
+            "prev_comm=xpf prev_pid=1 prev_prio=120 prev_state=S ==> "
+            "next_comm=y next_pid=0 next_prio=120\n"
+        )
+        perf_path = _write_inline(perf_line, ".txt")
         step1_start_ns = 1_000_000_000 * 1_000_000_000
         perf_start_ns = step1_start_ns + 2_000_000_000  # +2 s
 

--- a/test/incus/step2-sched-switch-reduce_test.py
+++ b/test/incus/step2-sched-switch-reduce_test.py
@@ -162,14 +162,23 @@ def _make_boundaries(start_s: int = 1_000_000_000) -> list[int]:
 
 class TestReducerSynthetic(unittest.TestCase):
     def test_reducer_synthetic_three_switches_two_durations(self):
-        """§3.4 test case 3.
+        """§3.4 test case 3 (C175-HC-026: closed at schedule-in).
 
-        Two (switch, wake) pairs at t=1.000008 s (prev_state=S, 8 us,
-        voluntary) and t=2.500032 s (prev_state=R, 32 us, involuntary)
-        relative to STEP1_START.  Both land in block b=0.
+        Two off-CPU intervals in block 0, each opened by a sched_switch
+        that moves the worker OFF-CPU and closed by a later sched_switch
+        that moves it back ON-CPU (next_pid=worker):
+
+          * voluntary: switch-out prev_state=S at +1.000000 s, scheduled
+            back in at +1.000008 s -> 8 us off-CPU (bucket 3).  A
+            sched_wakeup fires in between; it is informational and does
+            NOT close the interval.
+          * involuntary: switch-out prev_state=R at +2.500000 s (the
+            worker stays runnable — the kernel emits NO wakeup for a
+            preempted-runnable task), scheduled back in at +2.500032 s
+            -> 32 us off-CPU (bucket 5).
 
         HIGH-3: perf timestamps are absolute unix wall-clock ns
-        (perf-record uses `-k CLOCK_REALTIME`); reducer applies them
+        (perf-record uses `-k CLOCK_REALTIME`); the reducer applies them
         directly to `block_for_timestamp()` with no PERF_START_NS
         offsetting.  So the perf_ts values here are `step1_start_ns +
         <offset>`, not bare offsets.
@@ -188,39 +197,47 @@ class TestReducerSynthetic(unittest.TestCase):
         perf_start_ns = step1_start_ns  # zero drift
 
         events = [
-            # First switch: tid goes off-CPU at wall = step1_start + 1.000008 s
+            # Voluntary sleep: worker switched OUT (S) at +1.000000 s.
             (
                 "sched:sched_switch",
                 tid,
+                step1_start_ns + 1_000_000_000,
+                {"prev_pid": tid, "prev_state": "S", "next_pid": 0},
+            ),
+            # Wakeup 4 us later — informational; does NOT close the interval.
+            (
+                "sched:sched_wakeup",
+                tid,
+                step1_start_ns + 1_000_004_000,
+                {"pid": tid},
+            ),
+            # Worker scheduled back IN 8 us after switch-out -> 8 us off-CPU.
+            (
+                "sched:sched_switch",
+                0,
                 step1_start_ns + 1_000_008_000,
-                {"prev_pid": tid, "prev_state": "S"},
+                {"prev_pid": 0, "prev_state": "R", "next_pid": tid},
             ),
-            # Wake 8 us later.
-            (
-                "sched:sched_wakeup",
-                tid,
-                step1_start_ns + 1_000_016_000,
-                {"pid": tid},
-            ),
-            # Second switch at +2.500032 s with prev_state=R (involuntary).
+            # Involuntary preemption: switched OUT (R) at +2.500000 s.  No
+            # wakeup follows — a runnable-preempted task never sleeps.
             (
                 "sched:sched_switch",
                 tid,
-                step1_start_ns + 2_500_032_000,
-                {"prev_pid": tid, "prev_state": "R"},
+                step1_start_ns + 2_500_000_000,
+                {"prev_pid": tid, "prev_state": "R", "next_pid": 0},
             ),
-            # Wake 32 us later.
+            # Worker scheduled back IN 32 us later -> 32 us off-CPU (invol).
             (
-                "sched:sched_wakeup",
-                tid,
-                step1_start_ns + 2_500_064_000,
-                {"pid": tid},
+                "sched:sched_switch",
+                0,
+                step1_start_ns + 2_500_032_000,
+                {"prev_pid": 0, "prev_state": "R", "next_pid": tid},
             ),
             # A stat_runtime event in block 0 — enough runtime to pass the
             # ±1% accounting check.  Expected on-CPU for this block:
             #   block_duration = 5 s
             #   n_workers = 1
-            #   total_off_cpu = 40000 ns (the two wakeups above)
+            #   total_off_cpu = 40000 ns (the two intervals above)
             #   expected_on_cpu = 5e9 - 40000 ≈ 5e9
             # We feed 5e9 exactly so rel_err = 40000/5e9 ≈ 8e-6 << 1%.
             (
@@ -265,6 +282,100 @@ class TestReducerSynthetic(unittest.TestCase):
             self.assertEqual(sum(bi["buckets"]), 0)
             self.assertEqual(bi["off_cpu_time_3to6"], 0)
             self.assertEqual(bi["stat_runtime_check"], "WARN")
+
+
+class TestReducerScheduleInClose(unittest.TestCase):
+    """C175-HC-026: off-CPU intervals close at schedule-in, not wakeup."""
+
+    def test_involuntary_preemption_without_wakeup_is_measured(self):
+        """A runnable-preempted worker (prev_state=R, NO wakeup) that is
+        later rescheduled must have its off-CPU interval measured.
+
+        Fail-on-revert: the pre-fix reducer closed intervals on
+        sched_wakeup.  A preempted-runnable task emits no wakeup, so its
+        interval was never closed and involuntary_3to6 stayed 0 — the
+        exact signal this harness exists to detect went silently
+        unmeasured.
+        """
+        boundaries = _make_boundaries()
+        step1_start_ns = boundaries[0]
+        tid = 4242
+        worker_tids = {tid}
+        events = [
+            # Preempted while runnable at +1.000000 s (block 0). No wakeup.
+            ("sched:sched_switch", tid, step1_start_ns + 1_000_000_000,
+             {"prev_pid": tid, "prev_state": "R", "next_pid": 0}),
+            # Rescheduled 16 us later -> 16 us off-CPU (bucket 4, in D1).
+            ("sched:sched_switch", 0, step1_start_ns + 1_000_016_000,
+             {"prev_pid": 0, "prev_state": "R", "next_pid": tid}),
+        ]
+        buf = io.StringIO()
+        warn = io.StringIO()
+        warnings = R.reduce_events(
+            events=events,
+            boundaries_ns=boundaries,
+            worker_tids=worker_tids,
+            perf_start_ns=step1_start_ns,
+            out_stream=buf,
+            warn_stream=warn,
+        )
+        self.assertEqual(warnings, [], f"unexpected warnings: {warnings}")
+        b0 = json.loads(buf.getvalue().strip().split("\n")[0])
+        self.assertEqual(b0["buckets"][4], 16000)
+        self.assertEqual(b0["off_cpu_time_3to6"], 16000)
+        self.assertEqual(b0["involuntary_3to6"], 16000)
+        self.assertEqual(b0["voluntary_3to6"], 0)
+
+    def test_wakeup_alone_does_not_close_interval(self):
+        """A wakeup with NO following schedule-in must not accumulate.
+
+        Fail-on-revert: the pre-fix reducer treated sched_wakeup as the
+        interval end, so a switch-out + wakeup (no schedule-in) closed
+        and accumulated off-CPU time. Under schedule-in semantics the
+        interval stays open (unclosed) and nothing is accumulated.
+        """
+        boundaries = _make_boundaries()
+        step1_start_ns = boundaries[0]
+        tid = 55
+        worker_tids = {tid}
+        events = [
+            ("sched:sched_switch", tid, step1_start_ns + 1_000_000_000,
+             {"prev_pid": tid, "prev_state": "S", "next_pid": 0}),
+            # Wakeup 8 us later, but the worker is never scheduled back in.
+            ("sched:sched_wakeup", tid, step1_start_ns + 1_000_008_000,
+             {"pid": tid}),
+        ]
+        buf = io.StringIO()
+        warn = io.StringIO()
+        warnings = R.reduce_events(
+            events=events,
+            boundaries_ns=boundaries,
+            worker_tids=worker_tids,
+            perf_start_ns=step1_start_ns,
+            out_stream=buf,
+            warn_stream=warn,
+        )
+        self.assertEqual(warnings, [])
+        blocks = [json.loads(l) for l in buf.getvalue().strip().split("\n")]
+        self.assertEqual(sum(sum(b["buckets"]) for b in blocks), 0)
+        self.assertEqual(sum(b["off_cpu_time_3to6"] for b in blocks), 0)
+
+    def test_parser_extracts_next_pid(self):
+        """The perf-script parser must surface next_pid for sched_switch."""
+        txt = (
+            "xpf-userspace-w 12345 [003] 1234.567890123: "
+            "sched:sched_switch: prev_comm=xpf-userspace-w prev_pid=12345 "
+            "prev_prio=120 prev_state=R ==> next_comm=other next_pid=678 "
+            "next_prio=120\n"
+        )
+        path = _write_inline(txt, ".txt")
+        try:
+            events = list(R.parse_perf_script(path))
+        finally:
+            path.unlink()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0][3]["prev_pid"], 12345)
+        self.assertEqual(events[0][3]["next_pid"], 678)
 
 
 class TestReducerOutOfOrder(unittest.TestCase):
@@ -535,12 +646,15 @@ class TestReducerInvariant(unittest.TestCase):
         for b in range(12):
             off_ts = boundaries[b] + 1_000_000_000
             d = durations[b % len(durations)]
+            # Switch OUT (opens interval) then switch IN (next_pid=tid,
+            # closes interval d ns later) — C175-HC-026 schedule-in close.
             events.append(
                 ("sched:sched_switch", tid, off_ts,
-                 {"prev_pid": tid, "prev_state": "S"})
+                 {"prev_pid": tid, "prev_state": "S", "next_pid": 0})
             )
             events.append(
-                ("sched:sched_wakeup", tid, off_ts + d, {"pid": tid})
+                ("sched:sched_switch", 0, off_ts + d,
+                 {"prev_pid": 0, "prev_state": "R", "next_pid": tid})
             )
 
         buf = io.StringIO()

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -290,10 +290,23 @@ RG_POLL_FILE="${OUT_DIR}/rg-state-poll.txt"
     end_t=$(($(date +%s) + DURATION + SETTLE_BUDGET + SLACK + 5))
     while [[ $(date +%s) -lt $end_t ]]; do
         ts=$(date +%s%3N)
-        incus_exec "$PRIMARY" cli -c "show chassis cluster status" 2>/dev/null \
-            | python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
-                  parse-cluster-state "$ts" \
-            >> "$RG_POLL_FILE" 2>/dev/null || true
+        # C175-HC-083: record every tick. A failed cli poll or an empty
+        # parse must leave a POLL_FAILED sentinel so rg-state-flapped can
+        # see the gap (a failover hiding in a dropped poll must not read
+        # as "stable"). The old `... | ... >> file || true` appended
+        # nothing on failure, making the gap invisible.
+        if status_out=$(incus_exec "$PRIMARY" cli -c "show chassis cluster status" 2>/dev/null); then
+            parsed=$(printf '%s\n' "$status_out" \
+                | python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" \
+                      parse-cluster-state "$ts" 2>/dev/null || true)
+            if [[ -n "$parsed" ]]; then
+                printf '%s\n' "$parsed" >> "$RG_POLL_FILE"
+            else
+                printf '%s\trg=?\tnode=?\tstate=POLL_FAILED\n' "$ts" >> "$RG_POLL_FILE"
+            fi
+        else
+            printf '%s\trg=?\tnode=?\tstate=POLL_FAILED\n' "$ts" >> "$RG_POLL_FILE"
+        fi
         sleep 1
     done
 ) &


### PR DESCRIPTION
Closes #4907

Fixes the whole C175 evidence-integrity cohort in the `test/incus` perf /
scheduler / fairness / latency analysis tooling. Each defect let a gate
emit a confident PASS / negative verdict / exit 0 from missing, partial,
or impossible input. Every defect now **fails loud** (non-zero exit /
raise / no confident verdict) on bad input, and each has a fail-on-revert
test proven RED against the reverted fix.

All ten cited defects are fixed (none deferred). One logical commit per
defect for bisectability.

## False-PASS / wrong exit status
- **HC-029** `mouse_latency_aggregate.py:388` — a measured FAIL exited 0
  (`return 0 if verdict in ("PASS","FAIL")`). New `exit_status_for_verdict`:
  PASS=0, FAIL=1, INSUFFICIENT/other=2. *RED-on-revert: `0 != 1`.*
- **HC-084** `fairness_multi_sample.py:180/353` — `summarize()` ignored
  `exit_code`; rc=1 after a final PASS object aggregated PASS. A sample
  with a non-zero harness exit now forces the aggregate FAIL. *RED: `PASS != FAIL`.*
- **HC-070** `step2-sched-switch-reduce.py:492` + `...-classify.py:128` —
  empty/truncated perf reduced to 12 zero blocks → definitive scheduler
  OUT, exit 0. Reducer now HALTs (exit 2) on zero events (drift-halt still
  wins, exit 5); classifier emits INSUFFICIENT (exit 2) on the
  all-zero/all-WARN no-evidence shape. *RED: reduce `0 != 2`, classify `0 != 2`.*
- **HC-132** `step1-histogram-classify.py:484/535` — missing/corrupt cells
  only WARN'd; `--only-cell` returned 0 even when its cell failed, and a
  fully-missing tree printed `k_D1 = 0 of 0` then exited 0. Now tracks
  `failed_cells`: `--only-cell` non-zero if the target produced no
  hist-blocks; full run exits 2 with no valid cells and 1 on any
  missing/corrupt cell. *RED: `--only-cell` missing returned 0.*
- **HC-083** `mouse_latency_orchestrate.py:630/642` — the 1 Hz RG poller
  piped each `cli` sample with `|| true`, so failed polls appended nothing
  and a failover-in-gap read as "stable". Poller now writes a
  `POLL_FAILED` sentinel per failed tick; `rg-state-flapped` returns
  undetermined (2) on any marker or `--expected-samples` shortfall when no
  drift is seen (a real flap still wins as DRIFT). *RED: `0 != 2`.*

## Miscomputed thresholds / partial evidence
- **HC-026** `step2-sched-switch-reduce.py:417` — off-CPU intervals closed
  at `sched_wakeup`; a preempted-runnable worker (`prev_state=R`) emits no
  wakeup, so involuntary preemption was never closed/measured, and no
  `next_pid` was parsed. Now parses `next_pid` and closes intervals at
  schedule-in. Kernel-impossible wakeup-after-R fixtures rewritten to
  switch-out/switch-in pairs. *RED: involuntary time `0 != 16000`.*
- **HC-092** `step2-sched-switch-classify.py:39/285` — duty divided by a
  fixed 60 s while blocks may be [1,30] s. Reducer stamps `block_span_ns`;
  classifier divides by the summed real window (60 s fallback for legacy
  JSONL). *RED: `1.0 != 0.714` for a 12×7 s=84 s window.*
- **HC-072** `cold-path-flooder/src/main.rs:9/1101` — bounded cohort drew
  tuples with a per-worker random PRNG over a 131,072-tuple space, so
  birthday collisions (and cross-worker overlap) measured warm session
  hits as install cost. Bounded mode now enumerates a disjoint per-worker
  slice sequentially (`worker_slice` + `decompose_tuple_index`): the first
  pass installs a fresh session per packet, reuse only after a clean full
  pass. Summary reports `tuple_space` (fresh-install budget); schema
  version 2→3. Unbounded mode unchanged. *cargo tests pin distinct
  first-pass + globally-disjoint tuples.*
- **HC-128** `step1-rate-spread-analysis.py:54/131` — dropped malformed
  sender values and skipped missing cells, deriving Y from a fragment.
  `load_per_flow_rates` now requires exactly `--expected-streams` (16)
  positive-finite streams; `main()` hard-fails on any missing requested
  cell. *RED: partial cell no longer raises.*
- **HC-130** `step1-rss-multinomial.py:71` — retained one tuple per trial
  (GB-scale for 10M trials). `simulate()` is now a generator;
  `tail_probabilities()` streams with O(1) counters. Deterministic-seed
  results unchanged. *RED: returns a list, not a generator.*

## Validation
- `python3 -m py_compile` clean on all 8 touched `.py`; `bash -n` clean on
  `test-mouse-latency.sh`.
- Test suites green: mouse_latency_aggregate (31), fairness_multi_sample
  (44), step2 reduce (18), step2 classify (15), step1-histogram pytest
  (17), step1-rate-spread (7, new), step1-rss-multinomial (6, new),
  mouse_latency_orchestrate (34), cold-path-flooder `cargo test` (43).
- RED-on-revert proven for all 10 defects (see per-defect notes above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
