### PR TITLE
cli: zeroize the configured config root, not hardcoded /etc/xpf

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-11 — #5554 CLI `request system zeroize` configured-root resolution
+- **Timestamp**: 2026-07-11 (fix/5554-cli-zeroize-configured-root)
+- **Action**: The interactive-CLI `request system zeroize` handler hardcoded
+  `configDir := "/etc/xpf"` (+ `"xpf.conf"` base) for the factory-reset wipe.
+  On a daemon started with a non-default `-config` root, that wiped the WRONG
+  directory and LEFT the real `.configdb`/`master.key`/TLS material/rollback
+  slots on disk — the local-CLI twin of #5280 (gRPC path, fixed by #5552).
+  Resolved the wipe target from `c.store.ConfigPath()` (`filepath.Dir/Base`),
+  fail-CLOSED if store/path undeterminable, mirroring grpcapi
+  `(*Server).zeroizeConfigRoot`. Extracted `zeroizeConfigRoot()` +
+  `zeroizeConfigState()` on `*CLI`; handler now calls the latter before the
+  BPF-pin/networkd/systemctl-stop cleanup. Added a fail-on-revert test
+  (resolver + fail-closed + end-to-end wipe of a seeded temp root); verified
+  RED-on-revert. Updated `pkg/cli/README.md` with the zeroize-root contract.
+- **File(s)**: pkg/cli/cli_request_system.go,
+  pkg/cli/cli_zeroize_configured_root_5554_test.go, pkg/cli/README.md
+
 ## 2026-07-10 — #5077 submit-latency classifier K3 monotonicity (I14) mirror
 - **Timestamp**: 2026-07-10 (fix/5077-classifier-submit-monotonicity)
 - **Action**: Mirror the #827 kick-side K3 cross-snapshot monotonicity guard

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -35,6 +35,21 @@ sibling files (same package, so unexported helpers stay reachable):
   `data-plane`.
 - `cli_request_system.go` — `request system reboot|halt|power-off|zeroize`
   and `software` / `configuration` / `dynamic-dns`.
+  - **`zeroize` erases the CONFIGURED config root, not a hardcoded `/etc/xpf`
+    (#5554).** `zeroizeConfigRoot` resolves the wipe target from
+    `configstore.Store.ConfigPath()` — the daemon's `-config` path, the SAME
+    file the store loads from and persists the `.configdb` SSOT + `master.key`
+    / numbered text rollback slots / `.config.journal` to — and threads
+    `filepath.Dir/Base` of it into the shared `configstore.FactoryResetConfigDir`
+    /`FactoryResetArchiveDir` primitives (`zeroizeConfigState`). The interactive
+    CLI runs in-process with the daemon and shares its store, so this is the
+    local twin of the gRPC `runZeroize`/`zeroizeConfigRoot` fix (#5280): a daemon
+    started with a non-default `-config` (e.g. `/srv/xpf/site.conf`) erases
+    `/srv/xpf`, not `/etc/xpf`. Resolution is fail-CLOSED — an undeterminable
+    store / config path returns an error rather than wiping the wrong path (or
+    nothing) while reporting a clean factory reset. The pre-fix wipe hardcoded
+    `/etc/xpf` and left the real root's `.configdb`/`master.key`/TLS material/
+    rollback slots on disk.
 - `cli_request_security.go` — `request security ipsec|policies|wireguard`.
 
 The security-sensitive `--` end-of-options separators in the diagcmd/tcpdump

--- a/pkg/cli/cli_request_system.go
+++ b/pkg/cli/cli_request_system.go
@@ -70,28 +70,15 @@ func (c *CLI) handleRequestSystem(args []string) error {
 			return nil
 		}
 
-		// Securely erase the config-DB SSOT + master.key + audit journal +
-		// rollback history (#4858). The pre-fix wipe removed only top-level
-		// .conf / rollback* files and LEFT .configdb/{active,candidate,
-		// rollback.N}.json + master.key + .config.journal behind, so the daemon
-		// reloaded the "erased" config and secrets on the next boot (a false
-		// factory reset). Route through the shared configstore primitive and
-		// refuse to report success if the erasure did not complete.
-		configDir := "/etc/xpf"
-		if err := configstore.FactoryResetConfigDir(configDir, "xpf.conf"); err != nil {
-			return fmt.Errorf("zeroize: configuration state not fully erased: %w", err)
-		}
-
-		// Erase the local config archive (#5186): /var/lib/xpf/archive holds
-		// 0600 config-<ts>.conf snapshots — full config TEXT with cleartext
-		// secret leaves (PSK/keys/community). The pre-#5186 zeroize left it
-		// behind, so a prior tenant's secrets survived a factory reset.
-		// Ownership-guarded to the xpf-owned default path (a custom, remote, or
-		// compliance archive destination is skipped with a warning, never
-		// blindly deleted). Routes through the same shared configstore primitive
-		// as the gRPC factory-reset path so both wipe exactly the same archive.
-		if err := configstore.FactoryResetArchiveDir(configstore.DefaultArchiveDir); err != nil {
-			return fmt.Errorf("zeroize: config archive not fully erased: %w", err)
+		// Erase the config-DB SSOT + master.key + audit journal + rollback
+		// history + local config archive at the CONFIGURED config root, failing
+		// closed if that root cannot be determined (#5554). The pre-fix wipe
+		// hardcoded /etc/xpf, so a daemon started with a non-default `-config`
+		// root wiped the WRONG directory and LEFT the real .configdb / master.key
+		// / TLS material / rollback slots on disk — the same secret-retention
+		// hole #5280 fixed on the gRPC path.
+		if err := c.zeroizeConfigState(); err != nil {
+			return err
 		}
 
 		// Remove BPF pins (no secret material)
@@ -103,12 +90,6 @@ func (c *CLI) handleRequestSystem(args []string) error {
 			if strings.HasPrefix(f.Name(), "10-xpf-") {
 				os.Remove("/etc/systemd/network/" + f.Name())
 			}
-		}
-
-		// Verify the config DB SSOT is gone before reporting success — a
-		// zeroize that leaves it behind must not print "erased".
-		if _, err := os.Stat(filepath.Join(configDir, ".configdb")); !os.IsNotExist(err) {
-			return fmt.Errorf("zeroize: config DB still present after wipe (stat err=%v)", err)
 		}
 
 		// Stop the daemon so it releases interface/dataplane state; the reboot
@@ -131,6 +112,71 @@ func (c *CLI) handleRequestSystem(args []string) error {
 	default:
 		return fmt.Errorf("unknown request system command: %s", args[0])
 	}
+}
+
+// zeroizeConfigRoot resolves the CONFIGURED config root the CLI factory-reset
+// wipe must erase — the directory and base name of the store's `-config` path
+// (configstore.Store.ConfigPath), the SAME path the daemon loads config from
+// and persists the .configdb SSOT / master.key / numbered text rollback slots /
+// audit journal to. This is the local-CLI twin of grpcapi (*Server).
+// zeroizeConfigRoot (#5280): the interactive CLI runs in-process with the daemon
+// and shares its store, so it resolves the root the same way instead of
+// hardcoding /etc/xpf (#5554) — a daemon started with `-config /srv/xpf/site.conf`
+// then erases /srv/xpf, not /etc/xpf.
+//
+// Fail CLOSED: if the store is absent or carries no config path we cannot know
+// which root holds the prior tenant's secrets, so return an error rather than
+// wiping the wrong directory (or nothing) while reporting a clean factory reset.
+func (c *CLI) zeroizeConfigRoot() (configDir, configBase string, err error) {
+	if c.store == nil {
+		return "", "", fmt.Errorf("zeroize: config store unavailable; cannot determine configured config root to erase")
+	}
+	p := c.store.ConfigPath()
+	if p == "" {
+		return "", "", fmt.Errorf("zeroize: config store has no config path; cannot determine configured config root to erase")
+	}
+	return filepath.Dir(p), filepath.Base(p), nil
+}
+
+// zeroizeConfigState erases the on-disk configuration STATE for a factory reset:
+// the config-DB SSOT + master.key + numbered text rollback slots + audit journal
+// under the CONFIGURED config root, plus the local config archive. It resolves
+// the wipe target from the store (not a hardcoded /etc/xpf, #5554) and routes
+// through the shared configstore primitives (FactoryResetConfigDir /
+// FactoryResetArchiveDir) so the CLI and the gRPC path erase exactly the same
+// artifacts, refusing to report success if the config DB SSOT survives.
+func (c *CLI) zeroizeConfigState() error {
+	configDir, configBase, err := c.zeroizeConfigRoot()
+	if err != nil {
+		return err
+	}
+
+	// Securely erase the config-DB SSOT + master.key + audit journal + rollback
+	// history (#4858). The pre-fix wipe removed only top-level .conf / rollback*
+	// files and LEFT .configdb/{active,candidate,rollback.N}.json + master.key +
+	// .config.journal behind, so the daemon reloaded the "erased" config and
+	// secrets on the next boot (a false factory reset).
+	if err := configstore.FactoryResetConfigDir(configDir, configBase); err != nil {
+		return fmt.Errorf("zeroize: configuration state not fully erased: %w", err)
+	}
+
+	// Erase the local config archive (#5186): /var/lib/xpf/archive holds 0600
+	// config-<ts>.conf snapshots — full config TEXT with cleartext secret leaves
+	// (PSK/keys/community). Ownership-guarded to the xpf-owned default path (a
+	// custom, remote, or compliance archive destination is skipped with a
+	// warning, never blindly deleted). Routes through the same shared configstore
+	// primitive as the gRPC factory-reset path so both wipe exactly the same
+	// archive.
+	if err := configstore.FactoryResetArchiveDir(configstore.DefaultArchiveDir); err != nil {
+		return fmt.Errorf("zeroize: config archive not fully erased: %w", err)
+	}
+
+	// Verify the config DB SSOT is gone before reporting success — a zeroize that
+	// leaves it behind must not print "erased".
+	if _, err := os.Stat(filepath.Join(configDir, ".configdb")); !os.IsNotExist(err) {
+		return fmt.Errorf("zeroize: config DB still present after wipe (stat err=%v)", err)
+	}
+	return nil
 }
 
 // handleRequestSystemDynamicDNS implements `request system dynamic-dns

--- a/pkg/cli/cli_zeroize_configured_root_5554_test.go
+++ b/pkg/cli/cli_zeroize_configured_root_5554_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// TestCLIZeroizeResolvesConfiguredRoot pins #5554: the interactive-CLI
+// `request system zeroize` path must resolve the wipe target from the daemon's
+// ACTUAL configured config root — the directory + base name of the store's
+// `-config` path (configstore.Store.ConfigPath) — NOT a hardcoded /etc/xpf.
+// This is the local-CLI twin of the gRPC fix (#5280): when xpfd runs with a
+// non-default `-config` (e.g. /srv/xpf/site.conf), the .configdb SSOT +
+// master.key, rollback slots and journal live under THAT root; resolving to a
+// hardcoded /etc/xpf would leave the prior tenant's secrets on disk.
+//
+// RED on revert: restoring `configDir := "/etc/xpf"` (and the "xpf.conf" base)
+// makes zeroizeConfigRoot return /etc/xpf + xpf.conf instead of the store's
+// temp root — so the gotDir/gotBase assertions (and the explicit /etc/xpf
+// guard) fail.
+func TestCLIZeroizeResolvesConfiguredRoot(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "site.conf")
+	store := newConfigStore(t, configPath)
+	c := &CLI{store: store}
+
+	gotDir, gotBase, err := c.zeroizeConfigRoot()
+	if err != nil {
+		t.Fatalf("zeroizeConfigRoot: unexpected error %v", err)
+	}
+	if gotDir != dir {
+		t.Fatalf("zeroize resolved configDir %q, want the CONFIGURED root %q (not hardcoded /etc/xpf)", gotDir, dir)
+	}
+	if gotBase != "site.conf" {
+		t.Fatalf("zeroize resolved configBase %q, want the CONFIGURED base %q", gotBase, "site.conf")
+	}
+	// Explicit revert-shape guard: a hardcoded wipe would resolve /etc/xpf.
+	if gotDir == "/etc/xpf" {
+		t.Fatalf("zeroize resolved the hardcoded default /etc/xpf instead of the configured root %q", dir)
+	}
+}
+
+// TestCLIZeroizeFailsClosedWithoutConfigRoot pins the fail-CLOSED half of
+// #5554: if the configured config root cannot be determined (no store, or a
+// store with an empty config path), the CLI zeroize must NOT silently wipe the
+// wrong path or nothing — it must surface an error so the operator knows the
+// device is not safe to re-tenant.
+func TestCLIZeroizeFailsClosedWithoutConfigRoot(t *testing.T) {
+	// No store => config root undeterminable.
+	c := &CLI{store: nil}
+	if _, _, err := c.zeroizeConfigRoot(); err == nil {
+		t.Fatal("zeroizeConfigRoot with no store must fail closed; got nil error")
+	}
+
+	// A store with an empty config path is equally undeterminable.
+	c = &CLI{store: &configstore.Store{}}
+	if _, _, err := c.zeroizeConfigRoot(); err == nil {
+		t.Fatal("zeroizeConfigRoot with an empty config path must fail closed; got nil error")
+	}
+}
+
+// TestCLIZeroizeWipesConfiguredRootNotHardcoded drives the full CLI
+// config-state wipe (zeroizeConfigState) against a NON-default configured root
+// seeded with the on-disk secret artifacts a factory reset must erase, and
+// asserts they are gone. It is the end-to-end revert guard for #5554: with the
+// hardcoded `configDir := "/etc/xpf"` restored, FactoryResetConfigDir wipes
+// /etc/xpf (absent in the test => nil) while the temp root's .configdb +
+// rollback slots SURVIVE — so the "removed" assertions below fail.
+func TestCLIZeroizeWipesConfiguredRootNotHardcoded(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "site.conf")
+	// newConfigStore -> configstore.New creates dir/.configdb (the SSOT the wipe
+	// must erase) and sets the store's ConfigPath to configPath.
+	store := newConfigStore(t, configPath)
+
+	// Point the archive wipe at an xpf-owned-default that is safe in the test:
+	// FactoryResetArchiveDir only touches DefaultArchiveDir, so aim it at an
+	// absent temp path (parent exists) => it no-ops cleanly instead of trying to
+	// erase the real /var/lib/xpf/archive.
+	origArchive := configstore.DefaultArchiveDir
+	configstore.DefaultArchiveDir = filepath.Join(t.TempDir(), "archive")
+	t.Cleanup(func() { configstore.DefaultArchiveDir = origArchive })
+
+	// Seed the secret-bearing artifacts under the CONFIGURED root: master.key,
+	// the live config text, and a numbered text rollback slot.
+	if err := os.WriteFile(filepath.Join(dir, ".configdb", "master.key"), []byte("KEY"), 0o600); err != nil {
+		t.Fatalf("seed master.key: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("system { host-name fw; }\n"), 0o600); err != nil {
+		t.Fatalf("seed site.conf: %v", err)
+	}
+	rollbackSlot := configPath + ".1"
+	if err := os.WriteFile(rollbackSlot, []byte("system { host-name old; }\n"), 0o600); err != nil {
+		t.Fatalf("seed rollback slot: %v", err)
+	}
+
+	c := &CLI{store: store}
+	if err := c.zeroizeConfigState(); err != nil {
+		t.Fatalf("zeroizeConfigState: %v", err)
+	}
+
+	// The config-DB SSOT under the CONFIGURED root must be gone.
+	if _, err := os.Stat(filepath.Join(dir, ".configdb")); !os.IsNotExist(err) {
+		t.Fatalf(".configdb under the configured root %q survived zeroize (stat err=%v); "+
+			"the wipe hit the wrong (hardcoded) directory", dir, err)
+	}
+	// The numbered text rollback slot (full config text w/ secret leaves) too.
+	if _, err := os.Stat(rollbackSlot); !os.IsNotExist(err) {
+		t.Fatalf("rollback slot %q survived zeroize (stat err=%v)", rollbackSlot, err)
+	}
+	// And the live config text.
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("config file %q survived zeroize (stat err=%v)", configPath, err)
+	}
+}


### PR DESCRIPTION
Closes #5554

## Problem

The interactive-CLI `request system zeroize` handler
(`pkg/cli/cli_request_system.go`) hardcoded `configDir := "/etc/xpf"`
(and the `"xpf.conf"` base) for its factory-reset wipe. On a daemon
started with a non-default `-config` root (e.g. `-config
/srv/xpf/site.conf`), this wiped the WRONG directory and LEFT the real
config + secrets — the `.configdb` SSOT, `master.key`, TLS material,
numbered text rollback slots, and audit journal — on disk at the
configured root while printing "System zeroized. Configuration erased."

This is the local-CLI twin of the gRPC defect #5280 (fixed for the
`SystemAction` path by #5552): same secret-retention hole, different code
path.

## Fix approach — resolve the configured root locally (NOT gRPC-routed)

The interactive CLI is the daemon's own **in-process** shell
(`cli.New(d.store, ...)` in `pkg/daemon/daemon_run.go:677`) and holds the
daemon's `*configstore.Store` directly — it does not dial its own
loopback gRPC. So the correct, DRY seam is to resolve the wipe target the
SAME way the gRPC handler does, from the store:

- **Config-root source of truth:** `configstore.Store.ConfigPath()`
  (`pkg/configstore/store.go:241`) — the daemon's `-config` path — with
  `filepath.Dir/Base` threaded into the shared
  `configstore.FactoryResetConfigDir` / `FactoryResetArchiveDir`
  primitives.
- New `zeroizeConfigRoot()` on `*CLI` mirrors grpcapi
  `(*Server).zeroizeConfigRoot` (`pkg/grpcapi/server_diag_system_action.go:101`);
  new `zeroizeConfigState()` performs the resolve → wipe → archive-wipe →
  verify. The handler calls `zeroizeConfigState()` before the
  BPF-pin/networkd/`systemctl stop xpfd` cleanup.
- **Fail-CLOSED:** an absent store or empty config path returns an error
  rather than wiping the wrong path (or nothing) while claiming success.
- The operator confirmation (`yes`) gate and all user-visible messages
  are unchanged.

I deliberately did **not** route through a loopback gRPC
`SystemAction("zeroize")` call: the CLI is in-process with the daemon and
already shares the store, so a self-dial would add a socket round-trip
with no benefit. The gRPC zeroize path (apply gate + WIPE→STOP + #4108
journal) is untouched.

## Validation

- Added `pkg/cli/cli_zeroize_configured_root_5554_test.go` (fail-on-revert):
  1. resolver returns the configured temp root + base, not `/etc/xpf`;
  2. fail-closed on nil store / empty config path;
  3. end-to-end `zeroizeConfigState()` erases a seeded temp root
     (`.configdb`, `master.key`, live `.conf`, numbered rollback slot).
- **RED-on-revert proven:** restoring the hardcoded `/etc/xpf` makes all
  three tests FAIL (the temp root's `.configdb`/rollback slot survive).
- `GOCACHE=... go build ./...` and `go test ./pkg/cli/...` green; `gofmt`
  clean.
- Doc: `pkg/cli/README.md` updated with the zeroize-root contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HPRa4yi4DVWmHbSDbyX1r