### PR TITLE
cli: fail closed on scoped clear-policy-counters

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-11 — #5570 clear security policies hit-count arity fail-closed
+- **Timestamp**: 2026-07-11 (fix/5570-clear-hitcount-arity)
+- **Action**: `cmd/cli/clear.go` `case "policies"` recognized only the first
+  two tokens (`len(args) >= 2 && args[1] == "hit-count"`) and issued the
+  UNSCOPED global `clear-policy-counters` while ignoring any trailing
+  selector, so `clear security policies hit-count from-zone trust` returned
+  success and wiped EVERY policy hit counter — a destructive-command
+  fail-closed violation. Now requires EXACT arity: the bare two-token form
+  clears all (documented global behavior); ANY trailing token is REJECTED
+  with a usage/selector error and issues no clear. Added a fail-on-revert
+  test (RED-on-revert proven: buggy version returns nil + issues the global
+  clear for the trailing-token form). Documented the invariant in the CLI
+  reference alongside the #5066 `clear security flow session` note. go build
+  ./... + go test ./cmd/cli/... ./pkg/grpcapi/... ./pkg/cli/... green; gofmt
+  clean.
+- **File(s)**: cmd/cli/clear.go, cmd/cli/clear_policies_hitcount_5570_test.go,
+  docs/junos-cli-reference.md, _Log.md
+
 ## 2026-07-11 — #5554 CLI `request system zeroize` configured-root resolution
 - **Timestamp**: 2026-07-11 (fix/5554-cli-zeroize-configured-root)
 - **Action**: The interactive-CLI `request system zeroize` handler hardcoded

--- a/cmd/cli/clear.go
+++ b/cmd/cli/clear.go
@@ -190,17 +190,31 @@ func (c *ctl) handleClearSecurity(args []string) error {
 		return nil
 
 	case "policies":
-		if len(args) >= 2 && args[1] == "hit-count" {
-			resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
-				Action: "clear-policy-counters",
-			})
-			if err != nil {
-				return fmt.Errorf("%v", err)
-			}
-			fmt.Println(resp.Message)
-			return nil
+		// Fail CLOSED for this destructive command. `clear security
+		// policies hit-count` resets EVERY policy hit counter globally —
+		// the backend `clear-policy-counters` action carries no zone or
+		// policy selector. Any trailing token (e.g. `... from-zone
+		// trust`) means the operator intended a SCOPED clear the command
+		// cannot honor; silently issuing the global wipe would erase
+		// counters they meant to keep and destroy policy evidence during
+		// incident response. So require EXACT arity and reject any
+		// trailing selector instead of clearing all (#5570).
+		if len(args) < 2 || args[1] != "hit-count" {
+			return fmt.Errorf("usage: clear security policies hit-count")
 		}
-		return fmt.Errorf("usage: clear security policies hit-count")
+		if len(args) > 2 {
+			return fmt.Errorf("unknown/unsupported selector %q for "+
+				"clear security policies hit-count; per-scope clear is not "+
+				"supported (this command clears ALL policy hit counters)", args[2])
+		}
+		resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
+			Action: "clear-policy-counters",
+		})
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		fmt.Println(resp.Message)
+		return nil
 
 	case "counters":
 		_, err := c.client.ClearCounters(c.ctx(), &pb.ClearCountersRequest{})

--- a/cmd/cli/clear_policies_hitcount_5570_test.go
+++ b/cmd/cli/clear_policies_hitcount_5570_test.go
@@ -1,0 +1,75 @@
+// #5570: `clear security policies hit-count` recognizes only the first two
+// tokens and issues an UNSCOPED GLOBAL clear (`clear-policy-counters`). Before
+// the fix any trailing selector — e.g. `... from-zone trust` — was silently
+// dropped and the command still wiped EVERY policy hit counter while returning
+// success. That is a destructive-command fail-closed violation: the operator
+// asked to scope the clear, the command cannot honor a scope, so it must ERROR
+// rather than silently clear everything. Only the exact two-token form (no
+// trailing selector) is the intentional global clear.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// clearPolicyCounterRecorder records SystemAction calls so a test can assert a
+// global clear-policy-counters was NOT issued for a scoped-looking request.
+type clearPolicyCounterRecorder struct {
+	pb.BpfrxServiceClient
+
+	calls      int
+	lastAction string
+}
+
+func (f *clearPolicyCounterRecorder) SystemAction(
+	_ context.Context, in *pb.SystemActionRequest, _ ...grpc.CallOption,
+) (*pb.SystemActionResponse, error) {
+	f.calls++
+	f.lastAction = in.GetAction()
+	return &pb.SystemActionResponse{Message: "ok"}, nil
+}
+
+// Trailing selectors must ERROR before any RPC — never fall through to the
+// unscoped global clear.
+//
+// Goes RED on revert: the old `len(args) >= 2` gate ignores trailing tokens and
+// issues clear-policy-counters, so calls would be 1 and err nil.
+func TestClearPoliciesHitCountTrailingSelectorNoRPC_5570(t *testing.T) {
+	for _, args := range [][]string{
+		{"policies", "hit-count", "from-zone", "trust"},  // scoped-looking selector
+		{"policies", "hit-count", "to-zone", "untrust"},  // scoped-looking selector
+		{"policies", "hit-count", "policy", "allow-web"}, // per-policy selector
+		{"policies", "hit-count", "extra"},               // stray extra token
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			fake := &clearPolicyCounterRecorder{}
+			c := &ctl{client: fake}
+			if err := c.handleClearSecurity(args); err == nil {
+				t.Fatalf("handleClearSecurity(%v) = nil; want a usage/selector error", args)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("SystemAction issued %d times (action=%q); expected 0 — a "+
+					"scoped-looking clear must not wipe ALL policy hit counters", fake.calls, fake.lastAction)
+			}
+		})
+	}
+}
+
+// The exact two-token form is the intentional global clear and still sends.
+func TestClearPoliciesHitCountExactStillClears_5570(t *testing.T) {
+	fake := &clearPolicyCounterRecorder{}
+	c := &ctl{client: fake}
+	if err := c.handleClearSecurity([]string{"policies", "hit-count"}); err != nil {
+		t.Fatalf("handleClearSecurity([policies hit-count]) unexpected error: %v", err)
+	}
+	if fake.calls != 1 || fake.lastAction != "clear-policy-counters" {
+		t.Fatalf("handleClearSecurity([policies hit-count]): calls=%d action=%q; want 1 / clear-policy-counters",
+			fake.calls, fake.lastAction)
+	}
+}

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -108,6 +108,19 @@ dropping the predicate (which would widen the inspected set):
   the entire session table on both HA nodes. The remote `cli` clear parser
   (`cmd/cli/clear.go`) already rejected them; the local interactive CLI
   now matches (`parseClearSessionFilter`, `pkg/cli/session_filter.go`).
+- **`clear security policies hit-count` is global-only and rejects
+  trailing selectors (#5570).** The backend `clear-policy-counters`
+  action carries no zone or policy selector, so the command resets
+  EVERY policy hit counter. The remote `cli` parser
+  (`cmd/cli/clear.go`) requires EXACT arity: `clear security policies
+  hit-count` with no trailing token clears all; any trailing token
+  (e.g. `... from-zone trust`, `... policy <name>`) is **rejected**
+  with an error and issues no clear. This is the same fail-closed
+  invariant as `clear security flow session` — an operator who types a
+  scope believing the clear is scoped must get an error, never a silent
+  global wipe that destroys policy evidence. Per-scope hit-count
+  clearing is not a supported feature; adding it would require a typed
+  RPC with explicit selectors.
 - Direct gRPC `GetSessions` (`pkg/grpcapi/server_sessions.go`) validates
   the `protocol` token and rejects a negative `offset` (centrally in
   `GetSessions`, covering both the cursor and legacy paths); both return


### PR DESCRIPTION
## Summary
`clear security policies hit-count` in `cmd/cli/clear.go` recognized only the first two tokens and issued the **unscoped global** `clear-policy-counters` action while silently ignoring any trailing selector. So `clear security policies hit-count from-zone trust` returned success while erasing **every** policy hit counter — a destructive-command fail-closed violation. During incident response an operator can type a scope believing the clear is scoped, get success, and wipe all policy evidence.

## Fix (fail CLOSED)
`cmd/cli/clear.go` `case "policies"` now requires **exact arity**:
- `clear security policies hit-count` (no trailing token) still clears all — the documented global behavior; the backend action carries no zone/policy selector.
- **Any** trailing token (e.g. `... from-zone trust`, `... policy <name>`, stray `extra`) is **rejected** with a usage/selector error and issues **no** clear.

This mirrors the sibling `clear security flow session` parser (#5066), which already rejects tokens that parse but select nothing so a scoped-looking input can never silently degrade to clear-all. Per-scope hit-count clearing remains an unsupported feature; adding it would require a typed RPC with explicit selectors (out of scope here).

## Fix location
- `cmd/cli/clear.go` — `case "policies"` arity check (`if len(args) > 2 { return ... }` rejects trailing selectors; global clear only on exact `policies hit-count`).

## Tests (RED on revert)
`cmd/cli/clear_policies_hitcount_5570_test.go`:
- `TestClearPoliciesHitCountTrailingSelectorNoRPC_5570` — trailing-token forms must error and issue **zero** `SystemAction` calls.
- `TestClearPoliciesHitCountExactStillClears_5570` — the exact two-token form still issues one `clear-policy-counters`.

Proven **RED on revert**: with the old `len(args) >= 2` gate the trailing-token test fails — the parser returns `nil` and issues the global clear — while the exact-form test still passes.

## Docs
Documented the invariant in `docs/junos-cli-reference.md` next to the #5066 `clear security flow session` fail-closed note.

## Validation
- `go build ./...` green
- `go test ./cmd/cli/... ./pkg/grpcapi/... ./pkg/cli/...` green
- `gofmt` clean

Closes #5570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PNVFLBz4TYtFJ6hN5etPz