### PR TITLE
upgrade: fail closed when cluster marker stat is indeterminate (#5573)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45864,3 +45864,27 @@ top.
   test ./pkg/grpcapi/... ./pkg/cli/... green; gofmt clean.
   **File(s)**: pkg/cli/session_filter.go, pkg/cli/cli_show_flow.go,
   pkg/cli/peer_sessions_total_5034_test.go, _Log.md
+
+- **Timestamp**: 2026-07-11
+  **Action**: #5573 fail-CLOSED HA-safety gate — `ClusterNodeIDPresent` now
+  classifies the cluster-identity marker into a tri-state instead of mapping
+  every `os.Stat` error to "standalone-absent". Signature changed from
+  `bool` to `(bool, error)`: `(true,nil)` present/clustered, `(false,nil)`
+  ONLY for `os.IsNotExist`/ENOENT (genuinely standalone → proceed),
+  `(false,err)` for every other stat failure (EACCES/EIO/ESTALE/LSM/mount
+  fault → INDETERMINATE). Both standalone-cut gates — the CLI
+  belt-and-suspenders check (cmd/xpfd/upgrade.go) and the privileged
+  `Runner.Run` cutover gate (pkg/upgrade/cutover.go) — now FAIL CLOSED on
+  indeterminate membership (`refuse-standalone-cut-indeterminate-cluster-
+  membership`, unit NOT stopped) rather than proceeding to the uncoordinated
+  STOP->FLIP->START path. Added a `statNodeID` os.Stat seam for injectable
+  non-root failure tests. New tests: tri-state classifier (EACCES/EIO/ESTALE)
+  + integration fail-closed via r.Run + ENOENT-still-proceeds no-regression;
+  RED-on-revert proven (revert to `return err==nil` → both new tests fail).
+  Updated docs/in-place-upgrade.md #5284 section with the #5573 fail-closed
+  contract. go build ./... + go test ./pkg/upgrade/... ./cmd/xpfd/... green;
+  gofmt clean. Error-classification only; no failover-timing/VRRP/session-sync
+  state-machine change.
+  **File(s)**: pkg/upgrade/runner.go, pkg/upgrade/cutover.go,
+  cmd/xpfd/upgrade.go, docs/in-place-upgrade.md,
+  pkg/upgrade/cutover_cluster_gate_indeterminate_5573_test.go, _Log.md

--- a/cmd/xpfd/upgrade.go
+++ b/cmd/xpfd/upgrade.go
@@ -64,7 +64,23 @@ func runUpgradeSubcommand(args []string) {
 	// Runner.Run (the final privileged boundary, which also catches the
 	// postinst / recovery-doc callers), but rejecting here gives the operator
 	// the earliest, clearest message and never even builds the Runner.
-	if upgrade.ClusterNodeIDPresent(cfg.NodeIDPath) {
+	present, cerr := upgrade.ClusterNodeIDPresent(cfg.NodeIDPath)
+	if cerr != nil {
+		// #5573: the cluster-identity marker exists-check failed with a
+		// non-ENOENT error (EACCES/EIO/ESTALE/LSM denial/mount fault). Fail
+		// CLOSED rather than assume standalone — an unreadable marker on a real
+		// HA node must not be misread as "standalone" and let the uncoordinated
+		// STOP->FLIP->START cut blackhole the node. The authoritative gate in
+		// Runner.Run also fails closed on this, but rejecting here gives the
+		// operator the earliest, clearest message and never builds the Runner.
+		fmt.Fprintf(os.Stderr, "upgrade: refusing an UNCOORDINATED standalone cut: cannot "+
+			"determine cluster membership (%v). Assuming standalone when the "+
+			"cluster-identity marker (%s) is unreadable could blackhole a real HA "+
+			"node. Resolve the marker lookup failure, or run `xpfd upgrade --rolling` "+
+			"for a coordinated per-node drain, then retry\n", cerr, upgrade.DefaultNodeIDFile)
+		os.Exit(1)
+	}
+	if present {
 		fmt.Fprintf(os.Stderr, "upgrade: refusing an UNCOORDINATED standalone cut on a "+
 			"cluster member (%s present); the standalone STOP->FLIP->START flow does "+
 			"NOT drain to the peer and would blackhole traffic if the peer is not "+

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -383,6 +383,24 @@ a BARE standalone cut from a rolling-driver-invoked local cut, so
 coordinated rolling upgrades are never blocked. A standalone node (no
 `/etc/xpf/node-id`) is entirely unaffected.
 
+**Indeterminate-membership fail-closed contract (#5573).** The
+presence test is a tri-state, not a boolean. `ClusterNodeIDPresent`
+returns `(true,nil)` when the marker exists (clustered), `(false,nil)`
+ONLY for `os.IsNotExist` / ENOENT (genuinely standalone → proceed), and
+`(false,err)` for EVERY other `os.Stat` failure — EACCES, EIO, ESTALE,
+LSM denial, mount fault. A non-ENOENT lookup error means HA membership
+is UNKNOWN, and BOTH the CLI belt-and-suspenders check and the
+`Runner.Run` privileged gate FAIL CLOSED on it
+(`refuse-standalone-cut-indeterminate-cluster-membership`): they refuse
+the uncoordinated cut and do NOT stop the unit, because assuming
+standalone when the marker is unreadable would let the
+STOP→FLIP→START flow blackhole a real HA node whose peer is not ready.
+Before #5573 the predicate returned `err == nil` for every error, so an
+unreadable marker on a clustered node collapsed to "standalone" and both
+gates were bypassed — a fail-OPEN HA-safety hole. The fix is
+error-classification only; failover timing and the VRRP/session-sync
+state machines are untouched.
+
 1. assert peer alive + session sync established + HA protocol compatible
    (`CurrentHAProtocolVersion`) — else ABORT to image-replace (Path C),
    never drop connections.

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -164,16 +164,37 @@ func (r *Runner) Run(opts Options) (err error) {
 	// with ClusterCoordinated=true; that is the only sanctioned path on a
 	// clustered node. Fail CLOSED with guidance (do NOT auto-reroute), and do
 	// NOT stop the unit. Standalone nodes (no node-id) are unaffected.
-	if !opts.ClusterCoordinated && r.clusterNodeIDPresent() {
-		return fmt.Errorf("refuse-standalone-cut-on-clustered-node: this node is a "+
-			"cluster member (%s present) but the upgrade was invoked as an "+
-			"UNCOORDINATED standalone cut (no --rolling). The standalone "+
-			"STOP->FLIP->START flow stops the local daemon WITHOUT draining to the "+
-			"peer or fencing on peer readiness, which blackholes traffic if the peer "+
-			"is not ready to take over. Use the coordinated rolling upgrade instead: "+
-			"`xpfd upgrade --rolling` (drains this node to its peer, cuts, then "+
-			"rejoins election so the cluster keeps forwarding). The unit was NOT "+
-			"stopped", r.cfg.NodeIDPath)
+	if !opts.ClusterCoordinated {
+		present, cerr := r.clusterNodeIDPresent()
+		if cerr != nil {
+			// #5573: the marker exists-check itself FAILED with a non-ENOENT
+			// error (EACCES/EIO/ESTALE/LSM denial/mount fault). We cannot prove
+			// this is a standalone node, so we CANNOT safely take the
+			// uncoordinated STOP->FLIP->START path — assuming standalone when
+			// the cluster-identity marker is unreadable would blackhole a real
+			// HA node whose peer is not ready to take over. Fail CLOSED here at
+			// the same pre-lock/pre-journal/pre-mutation boundary as the
+			// clustered refusal below; do NOT stop the unit.
+			return fmt.Errorf("refuse-standalone-cut-indeterminate-cluster-membership: "+
+				"cannot determine whether this node is a cluster member (%w). The "+
+				"UNCOORDINATED standalone STOP->FLIP->START cut is refused because "+
+				"assuming standalone when the cluster-identity marker is unreadable "+
+				"would blackhole traffic if this is in fact an HA node whose peer is "+
+				"not ready. Resolve the marker lookup failure, or run "+
+				"`xpfd upgrade --rolling` for a coordinated per-node drain, then "+
+				"retry. The unit was NOT stopped", cerr)
+		}
+		if present {
+			return fmt.Errorf("refuse-standalone-cut-on-clustered-node: this node is a "+
+				"cluster member (%s present) but the upgrade was invoked as an "+
+				"UNCOORDINATED standalone cut (no --rolling). The standalone "+
+				"STOP->FLIP->START flow stops the local daemon WITHOUT draining to the "+
+				"peer or fencing on peer readiness, which blackholes traffic if the peer "+
+				"is not ready to take over. Use the coordinated rolling upgrade instead: "+
+				"`xpfd upgrade --rolling` (drains this node to its peer, cuts, then "+
+				"rejoins election so the cluster keeps forwarding). The unit was NOT "+
+				"stopped", r.cfg.NodeIDPath)
+		}
 	}
 
 	// Acquire the host-wide upgrade lock BEFORE any journal read or live

--- a/pkg/upgrade/cutover_cluster_gate_indeterminate_5573_test.go
+++ b/pkg/upgrade/cutover_cluster_gate_indeterminate_5573_test.go
@@ -1,0 +1,159 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// injectStatNodeID points the ClusterNodeIDPresent stat seam at a fake that
+// returns err for wantPath and delegates to the real os.Stat for everything
+// else, restoring the production seam on cleanup. A package var (not a
+// mode-000 dir) is the only reliable way to reproduce a NON-ENOENT marker
+// lookup failure: the CI test uid is root, and root bypasses DAC — a mode-000
+// directory would still stat successfully and never exercise the #5573
+// fail-closed path.
+func injectStatNodeID(t *testing.T, wantPath string, err error) {
+	t.Helper()
+	prev := statNodeID
+	statNodeID = func(path string) (os.FileInfo, error) {
+		if path == wantPath {
+			return nil, err
+		}
+		return prev(path)
+	}
+	t.Cleanup(func() { statNodeID = prev })
+}
+
+// TestClusterNodeIDPresent_TriState pins the #5573 classification contract of
+// the exported predicate directly:
+//   - a present marker  -> (true,  nil)  [clustered]
+//   - ENOENT            -> (false, nil)  [genuinely standalone, proceed]
+//   - any other error   -> (false, err)  [indeterminate, caller must fail closed]
+//
+// RED-on-revert: restore the pre-fix body (`return err == nil, nil`) and the
+// EACCES/EIO/ESTALE sub-cases flip to (false,nil) — i.e. "standalone" — so the
+// wantErr assertions trip.
+func TestClusterNodeIDPresent_TriState(t *testing.T) {
+	// Present marker: real file on disk -> clustered.
+	dir := t.TempDir()
+	present := filepath.Join(dir, "node-id")
+	if err := os.WriteFile(present, []byte("0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := ClusterNodeIDPresent(present); !ok || err != nil {
+		t.Fatalf("present marker: got (%v,%v), want (true,nil)", ok, err)
+	}
+
+	// ENOENT: genuinely standalone -> proceed, no error.
+	absent := filepath.Join(dir, "does-not-exist")
+	if ok, err := ClusterNodeIDPresent(absent); ok || err != nil {
+		t.Fatalf("ENOENT marker: got (%v,%v), want (false,nil)", ok, err)
+	}
+
+	// Non-ENOENT stat failures: indeterminate -> propagate the error so the
+	// caller fails closed. Cover the concrete errnos the issue calls out.
+	for _, errno := range []syscall.Errno{syscall.EACCES, syscall.EIO, syscall.ESTALE} {
+		injectStatNodeID(t, present, &os.PathError{Op: "stat", Path: present, Err: errno})
+		ok, err := ClusterNodeIDPresent(present)
+		if ok {
+			t.Errorf("%v: marker reported present despite an unreadable stat", errno)
+		}
+		if err == nil {
+			t.Errorf("%v: indeterminate lookup must propagate an error, got nil (fail-OPEN)", errno)
+		}
+		// os.IsNotExist must NOT be true for these — that is the whole point.
+		if os.IsNotExist(err) {
+			t.Errorf("%v: classified as not-exist; only ENOENT may collapse to standalone", errno)
+		}
+	}
+}
+
+// TestClusterGate_IndeterminateMembershipFailsClosed is the #5573 core
+// invariant at the FINAL privileged boundary: when the cluster-identity marker
+// lookup fails with a NON-ENOENT error (EACCES/EIO/ESTALE/LSM/mount fault),
+// a BARE standalone cut (r.Run with no ClusterCoordinated flag) is REFUSED
+// BEFORE StopUnit — the daemon is never stopped, so an HA node whose marker is
+// transiently unreadable cannot be blackholed by an uncoordinated cut.
+//
+// RED-on-revert: change ClusterNodeIDPresent back to swallow errors
+// (`return err == nil, nil`) and the injected EACCES classifies as
+// "standalone, absent" -> the bare cut proceeds to StopUnit and completes
+// (current -> 2.0.0), tripping the "no live mutation" and "unit still running"
+// assertions.
+func TestClusterGate_IndeterminateMembershipFailsClosed(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0") // real rollback target => not the no-prev guard
+
+	// The marker lookup itself fails with a permission error (NOT ENOENT):
+	// HA membership is UNKNOWN, so the gate must fail closed rather than assume
+	// standalone. Inject for cfg.NodeIDPath only; all other stats are real.
+	injectStatNodeID(t, cfg.NodeIDPath,
+		&os.PathError{Op: "stat", Path: cfg.NodeIDPath, Err: syscall.EACCES})
+
+	err := r.Run(Options{}) // BARE cut, no ClusterCoordinated
+	if err == nil {
+		t.Fatal("expected the indeterminate-membership cut to be refused, got nil")
+	}
+	if !strings.Contains(err.Error(), "refuse-standalone-cut-indeterminate-cluster-membership") {
+		t.Fatalf("error is not the #5573 indeterminate-membership gate: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--rolling") {
+		t.Fatalf("indeterminate gate must direct the operator to the rolling driver: %v", err)
+	}
+
+	// No live mutation may have happened: the gate fires BEFORE the lock,
+	// journal, and any stop/start/drop-in/daemon-reload.
+	for _, c := range fs.calls {
+		if c == "stop" || c == "start" || c == "dropin" || c == "daemon-reload" {
+			t.Errorf("live mutation %q happened despite the indeterminate-membership refusal", c)
+		}
+	}
+	if !fs.unitRunning {
+		t.Error("the daemon was stopped despite the indeterminate-membership refusal (fail-OPEN)")
+	}
+	if _, serr := os.Stat(cfg.JournalPath); !os.IsNotExist(serr) {
+		t.Error("a journal was persisted despite the pre-lock indeterminate-membership refusal")
+	}
+	target, _ := os.Readlink(filepath.Join(cfg.VersionsDir, "current"))
+	if filepath.Base(target) != "1.0.0" {
+		t.Errorf("current moved off the seeded prior version: %q", target)
+	}
+}
+
+// TestClusterGate_ENOENTStandaloneStillProceeds is the no-regression companion:
+// an ENOENT marker lookup (the genuinely-standalone case) must still be
+// classified as "standalone, proceed" through the SAME seam the EACCES test
+// injects on — so the fix narrows ONLY non-ENOENT errors, not the legitimate
+// absent case. The bare cut runs to completion and stops the unit.
+func TestClusterGate_ENOENTStandaloneStillProceeds(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	// Explicit ENOENT through the seam (belt-and-suspenders: testEnv already
+	// points NodeIDPath at an absent path, but drive the seam so this asserts
+	// the classifier, not just a happens-to-be-missing file).
+	injectStatNodeID(t, cfg.NodeIDPath,
+		&os.PathError{Op: "stat", Path: cfg.NodeIDPath, Err: syscall.ENOENT})
+
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("standalone (ENOENT) bare cut must proceed unchanged: %v", err)
+	}
+	sawStop := false
+	for _, c := range fs.calls {
+		if c == "stop" {
+			sawStop = true
+		}
+	}
+	if !sawStop {
+		t.Error("standalone cut did not stop the unit — the ENOENT path regressed")
+	}
+	target, _ := os.Readlink(filepath.Join(cfg.VersionsDir, "current"))
+	if filepath.Base(target) != "2.0.0" {
+		t.Errorf("standalone cut did not flip to 2.0.0: current=%q", target)
+	}
+}

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -190,23 +190,54 @@ func NewRunner(cfg Config) (*Runner, error) {
 
 func (r *Runner) logf(format string, args ...any) { r.cfg.Logf(format, args...) }
 
-// ClusterNodeIDPresent reports whether the install-time-stable cluster
-// identity marker at path exists (#5284). PRESENCE — not content — is the
-// HA signal (mirrors pkg/daemon hasNodeIDFile; pkg/upgrade cannot import
-// pkg/daemon without an import cycle, so the stat is duplicated). An empty
-// path falls back to DefaultNodeIDFile so the CLI belt-and-suspenders check
-// and the Run gate agree even when the caller left Config.NodeIDPath unset.
-func ClusterNodeIDPresent(path string) bool {
+// statNodeID is the os.Stat seam used to classify the cluster-identity marker.
+// A package var so a test can inject a NON-ENOENT lookup failure (EACCES/EIO/
+// ESTALE/LSM/mount fault) and prove both standalone-cut safety gates fail
+// CLOSED (#5573) without depending on running as non-root — root bypasses DAC,
+// so a mode-000 directory would not reproduce the marker-unreadable case under
+// the CI's root test uid.
+var statNodeID = os.Stat
+
+// ClusterNodeIDPresent classifies the install-time-stable cluster-identity
+// marker at path into the HA-membership tri-state that BOTH standalone-cut
+// safety gates consume (#5284, #5573):
+//
+//	(true,  nil)  marker present   -> node is HA-managed (clustered)
+//	(false, nil)  marker ENOENT    -> genuinely standalone (safe to cut)
+//	(false, err)  any other error  -> INDETERMINATE membership; the caller MUST
+//	                                  fail CLOSED.
+//
+// PRESENCE — not content — is the HA signal (mirrors pkg/daemon hasNodeIDFile;
+// pkg/upgrade cannot import pkg/daemon without an import cycle, so the stat is
+// duplicated). An empty path falls back to DefaultNodeIDFile so the CLI
+// belt-and-suspenders check and the Run gate agree even when the caller left
+// Config.NodeIDPath unset.
+//
+// #5573 fail-closed contract: ONLY os.IsNotExist (ENOENT) collapses to
+// "standalone, proceed". EVERY other os.Stat failure (EACCES/EIO/ESTALE/LSM
+// denial/mount fault) is PROPAGATED, not swallowed as absent. The pre-fix
+// predicate returned `err == nil` for every error, so an unreadable marker on
+// a real HA node was misread as "standalone" and let an uncoordinated
+// STOP->FLIP->START cut proceed without proving the peer owns every RG — which
+// the gate's own threat statement says can blackhole traffic. Treating an
+// indeterminate lookup as absent is the fail-OPEN bug; propagating it lets the
+// caller refuse.
+func ClusterNodeIDPresent(path string) (bool, error) {
 	if path == "" {
 		path = DefaultNodeIDFile
 	}
-	_, err := os.Stat(path)
-	return err == nil
+	if _, err := statNodeID(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot determine cluster membership: stat %s: %w", path, err)
+	}
+	return true, nil
 }
 
-// clusterNodeIDPresent reports whether THIS runner's configured cluster
-// identity marker is present.
-func (r *Runner) clusterNodeIDPresent() bool {
+// clusterNodeIDPresent classifies THIS runner's configured cluster-identity
+// marker (see ClusterNodeIDPresent for the tri-state contract).
+func (r *Runner) clusterNodeIDPresent() (bool, error) {
 	return ClusterNodeIDPresent(r.cfg.NodeIDPath)
 }
 


### PR DESCRIPTION
Closes #5573

## Problem
`ClusterNodeIDPresent` (pkg/upgrade/runner.go) returned `err == nil`,
collapsing **every** `os.Stat` failure on `/etc/xpf/node-id`
(EACCES/EIO/ESTALE/LSM denial/mount fault, not just ENOENT) into
"standalone, node not HA-managed". Both standalone-cut safety gates —
the CLI belt-and-suspenders check (`cmd/xpfd/upgrade.go`) and the
privileged `Runner.Run` cutover gate (`pkg/upgrade/cutover.go`) — reuse
that boolean, so a transient/persistent lookup failure on the
cluster-identity marker let a bare `xpfd upgrade` proceed to the
UNCOORDINATED STOP→FLIP→START path without proving the peer owns every
RG. The gate's own threat statement says this can blackhole traffic when
the peer is not ready. This is a fail-**OPEN** HA-safety-gate bypass
(residual of #5284).

## Fix (fail-CLOSED)
`ClusterNodeIDPresent` is now a tri-state classifier;
signature `bool` → `(bool, error)`:

| return | meaning |
|--------|---------|
| `(true, nil)`  | marker present → HA-managed (clustered) |
| `(false, nil)` | marker **ENOENT only** → genuinely standalone (proceed) |
| `(false, err)` | any other `os.Stat` error → **INDETERMINATE** |

Only `os.IsNotExist` collapses to "standalone, proceed"; every other
stat error is propagated. Both gates now **fail CLOSED** on a non-ENOENT
error (`refuse-standalone-cut-indeterminate-cluster-membership`),
refusing the uncoordinated cut at the same pre-lock/pre-journal/
pre-mutation boundary as the clustered refusal and **NOT stopping the
unit**. The legitimate ENOENT standalone case proceeds unchanged; the
coordinated rolling driver (`ClusterCoordinated=true`) stays exempt.

### Call sites updated
- `cmd/xpfd/upgrade.go:67` — CLI belt-and-suspenders check
- `pkg/upgrade/cutover.go:167` — `Runner.Run` privileged cutover gate

A `statNodeID` `os.Stat` seam was added so tests can inject a non-ENOENT
failure without depending on a non-root uid (root bypasses DAC).

## Validation
- `go build ./...`; `go test ./pkg/upgrade/... ./cmd/xpfd/...` green; `gofmt` clean.
- New tests:
  - `TestClusterNodeIDPresent_TriState` — classifier over EACCES/EIO/ESTALE.
  - `TestClusterGate_IndeterminateMembershipFailsClosed` — drives `Runner.Run`
    with an injected EACCES; asserts the cut is refused with NO
    stop/start/drop-in/daemon-reload, unit stays running, no journal
    persisted, `current` never moves.
  - `TestClusterGate_ENOENTStandaloneStillProceeds` — no-regression: ENOENT
    still proceeds to a full cut.
- **RED-on-revert proven**: reverting `ClusterNodeIDPresent` to
  `return err == nil` flips the injected EACCES back to "standalone", so
  the bare cut runs to `StopUnit` and both new tests fail.
- Doc: updated `docs/in-place-upgrade.md` #5284 section with the #5573
  fail-closed contract.

## Scope
Error-classification change in the fail-CLOSED direction only. **No
VRRP/session-sync/failover-timing/state-machine change** — unit tests
are the correct validation; the loss-cluster `test-failover` gate is
shim-wall-deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk4tGh92Wdt4ctgSheF2xQ