### PR TITLE
logging: reject unknown syslog transport, fail closed (#5581)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-11 — #5581 syslog unknown transport fails closed (no plaintext-UDP downgrade)
+- **Timestamp**: 2026-07-11 (fix/5581-logging-unknown-transport)
+- **Action**: `NewSyslogClientTransport` (pkg/logging/syslog.go) accepted any
+  transport token and `dial()`'s `default` arm mapped every unrecognized value
+  to `dialUDP()`, so a security-log stream configured (or persisted / HA-synced)
+  with a typo'd / unsupported transport shipped audit records as plaintext UDP
+  while config/status still named a non-UDP transport (#5581, security
+  fail-open). Added `ErrUnsupportedTransport` + `supportedTransport()`; the
+  constructor now returns `(nil, ErrUnsupportedTransport)` for any token that is
+  not empty(→udp)/udp/tcp/tls, and `dial()` fails closed on an unknown
+  `s.protocol` (defense-in-depth for the reconnect path). The daemon's existing
+  `client==nil` branch skips the stream with a visible `failed to create syslog
+  client` warning — no plaintext client installed. Runtime backstop for the
+  tolerant load path that bypasses the strict #2008 commit enum.
+- **File(s)**: pkg/logging/syslog.go, pkg/logging/README.md,
+  pkg/logging/syslog_unknown_transport_5581_test.go (new),
+  pkg/daemon/syslog_unknown_transport_5581_test.go (new)
+- **Validation**: `go build ./...`; `go test ./pkg/logging/... ./pkg/config/...
+  ./pkg/daemon/...` green. RED-on-revert proven at both the logging (constructor
+  returns a usable plaintext-UDP client; dial() returns a live UDP conn) and
+  daemon (`SyslogClientCount`==1, INFO "syslog stream configured protocol=
+  tls-typo") levels. `gofmt -w` on touched files.
+
 ## 2026-07-11 — #5570 clear security policies hit-count arity fail-closed
 - **Timestamp**: 2026-07-11 (fix/5570-clear-hitcount-arity)
 - **Action**: `cmd/cli/clear.go` `case "policies"` recognized only the first

--- a/pkg/daemon/syslog_unknown_transport_5581_test.go
+++ b/pkg/daemon/syslog_unknown_transport_5581_test.go
@@ -1,0 +1,74 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// TestApplySyslogConfigUnknownTransportInstallsNoClient is the daemon-side
+// #5581 RED-on-revert proof. The strict commit schema rejects an unknown
+// `transport protocol` (enum udp|tcp|tls), but the tolerant persisted /
+// HA-synced load path does not — so applySyslogConfig can be handed a stream
+// carrying a typo'd or unsupported transport token. Before the fix,
+// NewSyslogClientTransport accepted the token and dial()'s default arm mapped
+// it to UDP, so the daemon installed a live client shipping security/audit
+// records as plaintext UDP while config/status still named a non-UDP transport.
+//
+// The fix makes the constructor return (nil, ErrUnsupportedTransport), so the
+// daemon's `client == nil` guard skips the stream (a visible "failed to create
+// syslog client" apply warning) and installs NO client — the records are not
+// silently downgraded to plaintext. Reverting the fix installs one plaintext
+// client here, so this test fails.
+func TestApplySyslogConfigUnknownTransportInstallsNoClient(t *testing.T) {
+	er := logging.NewEventReader(nil, nil)
+
+	d := &Daemon{}
+	cfg := &config.Config{}
+	cfg.Security.Log.Mode = "stream"
+	cfg.Security.Log.Streams = map[string]*config.SyslogStream{
+		"s1": {
+			Name: "s1",
+			Host: "127.0.0.1",
+			Port: 514,
+			Transport: config.SyslogTransport{
+				Protocol: "tls-typo", // survives tolerant load; never passed a strict commit
+			},
+		},
+	}
+
+	d.applySyslogConfig(er, cfg)
+
+	if got := er.SyslogClientCount(); got != 0 {
+		t.Fatalf("a stream with an unknown transport must install NO client "+
+			"(fail closed), got %d — security records silently downgraded to "+
+			"plaintext UDP (#5581)", got)
+	}
+}
+
+// TestApplySyslogConfigKnownTransportInstallsClient guards against
+// over-rejection: a stream with a valid (default UDP) transport must still
+// install exactly one client, so the fail-closed guard does not break normal
+// syslog forwarding.
+func TestApplySyslogConfigKnownTransportInstallsClient(t *testing.T) {
+	er := logging.NewEventReader(nil, nil)
+
+	d := &Daemon{}
+	cfg := &config.Config{}
+	cfg.Security.Log.Mode = "stream"
+	cfg.Security.Log.Streams = map[string]*config.SyslogStream{
+		"s1": {
+			Name: "s1",
+			Host: "127.0.0.1",
+			Port: 514,
+			// Transport.Protocol empty → UDP default (valid).
+		},
+	}
+
+	d.applySyslogConfig(er, cfg)
+
+	if got := er.SyslogClientCount(); got != 1 {
+		t.Fatalf("a stream with a valid transport must install one client, got %d", got)
+	}
+}

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -201,6 +201,28 @@ connectionless and exempt:
   audit logs to a deleted receiver once it recovered.
   `EventReader.SyslogClientCount()` exposes the installed count for that
   teardown assertion.
+- **Unknown transport fails CLOSED — no silent plaintext-UDP downgrade
+  (#5581).** `NewSyslogClientTransport` accepts only the empty default
+  (→ `udp`), `udp`, `tcp`, and `tls`; any other token (a typo like
+  `tls-typo`, a newer/unsupported value, wrong case) returns
+  `(nil, ErrUnsupportedTransport)`. Previously the constructor accepted
+  any token and `dial()`'s `default` arm mapped every unrecognized value
+  to `dialUDP()`, so a security-log stream configured with a bad
+  transport shipped audit records as **plaintext UDP** while config and
+  status still named a non-UDP transport. The strict commit schema
+  (`security log stream <s> transport protocol`, enum `udp|tcp|tls`,
+  #2008) already refutes bad tokens at a normal commit, but the tolerant
+  persisted / HA-synced load path does not — so this runtime guard is the
+  fail-closed backstop for a token that never passed a current strict
+  commit. `dial()` also fails closed on an unrecognized `s.protocol`
+  (defense-in-depth for the reconnect path) instead of downgrading to
+  UDP. The daemon (`applySyslogConfig`) hits the existing `client==nil`
+  branch, logs `failed to create syslog client` with the bad token, and
+  installs NO client — the operator sees a visible apply error rather
+  than a stream that silently forwards nowhere-secure. This differs from
+  the #3351 lazy-connect case: a down-at-apply TCP/TLS receiver returns a
+  *non-nil* reconnecting client (transient reachability), whereas an
+  unknown transport is a *configuration* error that yields a nil client.
 - **Daemon syslog-apply CLOSES superseded clients (#3579).**
   `applySyslogConfig` (pkg/daemon) rebuilds every `SyslogClient` from
   config on each apply, so the prior set is always fully superseded

--- a/pkg/logging/syslog.go
+++ b/pkg/logging/syslog.go
@@ -176,9 +176,42 @@ func NewSyslogClientWithSource(host string, port int, sourceAddr string) (*Syslo
 	return NewSyslogClientTransport(host, port, sourceAddr, "udp", nil)
 }
 
+// ErrUnsupportedTransport is returned when a syslog client is asked to use a
+// transport token the dialer cannot honor. It exists so the runtime refuses to
+// silently downgrade an unknown/typo'd transport to plaintext UDP. The strict
+// commit schema (`security log stream <s> transport protocol`, enum
+// udp|tcp|tls, #2008) rejects bad tokens at a normal commit, but the tolerant
+// persisted / HA-synced load path does not — so a typo or a newer transport
+// value could reach NewSyslogClientTransport with a token that dial()'s old
+// default arm mapped to UDP, sending security/audit records in plaintext while
+// config and status still name a non-UDP transport (#5581). Callers use
+// errors.Is to distinguish this fail-closed configuration error from a
+// transient dial failure.
+var ErrUnsupportedTransport = errors.New("syslog: unsupported transport protocol")
+
+// supportedTransport reports whether protocol is a transport the dialer can
+// actually establish. Empty is NOT accepted here: NewSyslogClientTransport
+// normalizes "" to "udp" (the documented default) BEFORE validation, so an
+// empty token never reaches this check; a caller building a client another way
+// must pass an explicit token.
+func supportedTransport(protocol string) bool {
+	switch protocol {
+	case "udp", "tcp", "tls":
+		return true
+	default:
+		return false
+	}
+}
+
 // NewSyslogClientTransport creates a syslog client with the specified transport
 // protocol ("udp", "tcp", or "tls"). For TLS, a *tls.Config is used; if nil,
 // system CA roots are used.
+//
+// An unknown/unsupported transport token is REJECTED here (returns
+// (nil, ErrUnsupportedTransport)) instead of silently falling back to UDP.
+// Empty is the documented UDP default and is normalized to "udp" before this
+// check. This is the runtime fail-closed guard for the tolerant persisted /
+// HA-synced load path that bypasses the strict commit enum (#5581).
 //
 // A TCP/TLS receiver that is unreachable at construction (down at config-apply
 // or boot) does NOT fail the stream (#3351). The returned client is usable but
@@ -193,6 +226,13 @@ func NewSyslogClientWithSource(host string, port int, sourceAddr string) (*Syslo
 func NewSyslogClientTransport(host string, port int, sourceAddr, protocol string, tlsCfg *tls.Config) (*SyslogClient, error) {
 	if protocol == "" {
 		protocol = "udp"
+	}
+	// Fail closed on an unknown transport instead of dial()'s old default-to-UDP
+	// path: a security-log stream configured (or persisted / HA-synced) with a
+	// typo'd or unsupported transport must NOT silently ship audit records in
+	// plaintext UDP while config/status still name a non-UDP transport (#5581).
+	if !supportedTransport(protocol) {
+		return nil, fmt.Errorf("%w %q", ErrUnsupportedTransport, protocol)
 	}
 	remoteAddr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 	hostname, _ := os.Hostname()
@@ -259,14 +299,24 @@ func NewSyslogClientWithConn(conn net.Conn, protocol string) *SyslogClient {
 }
 
 // dial establishes a connection based on the configured protocol.
+//
+// An unknown protocol fails closed here (returns ErrUnsupportedTransport)
+// rather than falling back to UDP. NewSyslogClientTransport already rejects
+// bad tokens, so in production s.protocol is always udp/tcp/tls; this is
+// defense-in-depth for any client built another way (and for the reconnect
+// path) so an unrecognized transport can never silently downgrade a
+// stream/secure syslog to plaintext UDP (#5581). "" is treated as UDP for
+// parity with the constructors, which default an empty token to UDP.
 func (s *SyslogClient) dial() (net.Conn, error) {
 	switch s.protocol {
 	case "tcp":
 		return s.dialTCP()
 	case "tls":
 		return s.dialTLS()
-	default:
+	case "udp", "":
 		return s.dialUDP()
+	default:
+		return nil, fmt.Errorf("%w %q", ErrUnsupportedTransport, s.protocol)
 	}
 }
 

--- a/pkg/logging/syslog_unknown_transport_5581_test.go
+++ b/pkg/logging/syslog_unknown_transport_5581_test.go
@@ -1,0 +1,110 @@
+package logging
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+// TestUnknownTransportRejectedAtConstruction is the #5581 fix-on-revert proof
+// for the constructor. A security-log stream configured (or persisted /
+// HA-synced) with a typo'd or unsupported transport token must be REJECTED at
+// construction with ErrUnsupportedTransport, NOT silently downgraded to
+// plaintext UDP.
+//
+// Before the fix, NewSyslogClientTransport accepted any token and dial()'s
+// `default: return s.dialUDP()` arm mapped every unrecognized value to UDP, so
+// the constructor returned a live client that shipped audit records as
+// plaintext UDP while config/status still named a non-UDP transport. Reverting
+// the constructor guard makes every case below return a non-nil client with a
+// nil (or non-ErrUnsupportedTransport) error, failing these assertions.
+func TestUnknownTransportRejectedAtConstruction(t *testing.T) {
+	// A real UDP listener so the reverted (buggy) code path would actually
+	// succeed at dialing it — proving the RED case is a genuine plaintext-UDP
+	// downgrade, not merely a dial failure against a dead address.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	defer pc.Close()
+	addr := pc.LocalAddr().(*net.UDPAddr)
+	host := addr.IP.String()
+	port := addr.Port
+
+	for _, proto := range []string{"tls-typo", "sctp", "tcp6", "TLS", "relp", "http", "udp "} {
+		t.Run(proto, func(t *testing.T) {
+			client, err := NewSyslogClientTransport(host, port, "", proto, nil)
+			if client != nil {
+				// Fail closed: an unknown transport must never yield a usable
+				// client. A non-nil client here is the silent plaintext-UDP
+				// downgrade (#5581) — a security-log fail-open.
+				client.Close()
+				t.Fatalf("transport %q: expected nil client (fail closed), got a usable client "+
+					"— unknown transport silently downgraded to plaintext UDP", proto)
+			}
+			if err == nil {
+				t.Fatalf("transport %q: expected ErrUnsupportedTransport, got nil error", proto)
+			}
+			if !errors.Is(err, ErrUnsupportedTransport) {
+				t.Fatalf("transport %q: expected ErrUnsupportedTransport, got %v", proto, err)
+			}
+		})
+	}
+}
+
+// TestSupportedTransportsStillConstruct guards against over-rejection: the
+// documented transports (empty→udp, udp, tcp, tls) must still build a client.
+// UDP is exercised against a live loopback listener (so the dial succeeds and
+// the client is fully connected); tcp/tls are #3351 lazy-reconnect clients even
+// when the receiver is down, so they are only required to be non-nil.
+func TestSupportedTransportsStillConstruct(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	defer pc.Close()
+	addr := pc.LocalAddr().(*net.UDPAddr)
+	host := addr.IP.String()
+	port := addr.Port
+
+	for _, proto := range []string{"", "udp"} {
+		t.Run("udp/"+proto, func(t *testing.T) {
+			client, err := NewSyslogClientTransport(host, port, "", proto, nil)
+			if err != nil {
+				t.Fatalf("transport %q: unexpected error: %v", proto, err)
+			}
+			if client == nil {
+				t.Fatalf("transport %q: expected a usable client, got nil", proto)
+			}
+			client.Close()
+		})
+	}
+}
+
+// TestDialFailsClosedOnUnknownProtocol is the defense-in-depth proof for the
+// reconnect path: even if a client somehow holds an unrecognized protocol
+// (built another way, or a future field mutation), dial() must fail closed with
+// ErrUnsupportedTransport instead of falling back to UDP. Before the fix,
+// dial()'s `default` arm returned s.dialUDP() for any token, so this would
+// return a live UDP conn to a non-UDP-named transport.
+func TestDialFailsClosedOnUnknownProtocol(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	defer pc.Close()
+	addr := pc.LocalAddr().(*net.UDPAddr)
+
+	s := &SyslogClient{
+		protocol:   "tls-typo",
+		remoteAddr: addr.String(),
+	}
+	conn, err := s.dial()
+	if conn != nil {
+		conn.Close()
+		t.Fatalf("dial() with an unknown protocol returned a live conn — silent UDP downgrade (#5581)")
+	}
+	if !errors.Is(err, ErrUnsupportedTransport) {
+		t.Fatalf("dial() unknown protocol: expected ErrUnsupportedTransport, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #5581

## Problem
`SyslogClient.dial()` dispatched only `tcp` and `tls` explicitly and treated **every other** protocol token as UDP via the `default` arm; `NewSyslogClientTransport` accepted the token without validation. The strict commit schema (`security log stream <s> transport protocol`, enum `udp|tcp|tls`, #2008) rejects unknown values at a normal commit, but the tolerant **persisted / HA-synced** load path does not — so a typo (`tls-typo`) or a newer transport value could reach the constructor and be shipped as **plaintext UDP** while config and status still name a non-UDP transport.

This is a crypto/audit **fail-open**: policy names, zones, addresses, NAT tuples, and session metadata can leak in cleartext while operators believe secure (TLS) logging is configured.

Verified vs origin/master:
- `pkg/logging/syslog.go` `dial()`: `switch s.protocol { case "tcp": …; case "tls": …; default: return s.dialUDP() }`.
- `pkg/daemon/daemon_system.go` passed `stream.Transport.Protocol` straight to the exported constructor.

## Fix (fail closed — reject-at-construction)
Chose **reject** over warn-and-continue, matching the existing fail-closed discipline for a clear config error (#1960 balance): the strict schema already rejects bad tokens at commit, so this runtime guard is the backstop for the tolerant load path, and rejecting there yields a *visible* apply error instead of a silently-dead stream.

- Added `ErrUnsupportedTransport` + `supportedTransport()` (`pkg/logging/syslog.go`).
- `NewSyslogClientTransport` returns `(nil, ErrUnsupportedTransport)` for any token that is not empty (→ `udp`), `udp`, `tcp`, or `tls`. Empty still means UDP (documented default, unchanged).
- `dial()` now fails closed on an unrecognized `s.protocol` instead of defaulting to UDP — defense-in-depth for the reconnect path / any client built another way.
- The daemon's existing `client == nil` branch skips the stream, logging `failed to create syslog client` with the bad token, and installs **no** client — the operator is told, records are not downgraded.
- The #3351 down-at-apply TCP/TLS lazy-reconnect path (a transient-reachability, *non-nil* client) is untouched; an unknown transport is a *configuration* error (nil client), a deliberately different case.

## Tests (RED-on-revert proven)
- `pkg/logging/syslog_unknown_transport_5581_test.go`: constructor rejects `tls-typo`/`sctp`/`tcp6`/`TLS`/`relp`/… with `ErrUnsupportedTransport` against a **live** UDP listener (so the revert case is a genuine plaintext downgrade, not a dial failure); valid `""`/`udp` still construct; `dial()` fails closed on an unknown protocol.
- `pkg/daemon/syslog_unknown_transport_5581_test.go`: a stream with an unknown transport installs **0** clients (`SyslogClientCount`); a valid stream installs 1.
- Reverting the constructor guard + `dial()` arm turns every new assertion RED: the constructor returns a usable plaintext-UDP client, and the daemon installs one client while logging the `tls-typo` stream as `syslog stream configured`.

## Docs
`pkg/logging/README.md` gains a "Unknown transport fails CLOSED" bullet documenting the contract and its relationship to the #2008 strict enum and the #3351 lazy-connect case.

## Validation
- `go build ./...`
- `go test ./pkg/logging/... ./pkg/config/... ./pkg/daemon/...` — green
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)