### PR TITLE
config: fail closed on lenient permit-widening (#5575)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45906,3 +45906,38 @@ top.
   **File(s)**: pkg/upgrade/runner.go, pkg/upgrade/cutover.go,
   cmd/xpfd/upgrade.go, docs/in-place-upgrade.md,
   pkg/upgrade/cutover_cluster_gate_indeterminate_5573_test.go, _Log.md
+
+- **Timestamp**: 2026-07-11
+  **Action**: #5575 fix — lenient policy compilation no longer publishes a
+  missing/dropped match constraint as a wildcard permit (permit-widening on
+  lenient/HA load). `CompileConfigLenient` downgrades the #3044 missing-match /
+  #3113 unsupported-match-leaf / #3114 unsupported-then-permit rejects to
+  warnings but `compilePolicy` then dropped the constraint, leaving the
+  dimension EMPTY → the userspace matcher read empty as match-ANY → a permit
+  broader than configured (fail-open). Extracted the three per-policy predicates
+  the strict gates use into shared SSOT helpers
+  (`policyMissingRequiredMatchDimensions`, `policyUnsupportedMatchLeafFindings`,
+  `policyUnsupportedThenPermitModifiers`); `compilePolicy` (now taking
+  `isGlobal`) sets a new `Policy.LenientContentDropped` flag for exactly the
+  policies a strict commit would reject; `buildOneRuleSnapshot` poisons such a
+  rule with the `__unsupported__` application sentinel → Rust integrity preflight
+  rejects the WHOLE snapshot (previous-good retained / fresh-boot default-deny),
+  action-agnostic fail-CLOSED. Preserves the intentional-empty (explicit `any`)
+  case (non-empty slice → match-any, flag false). Go-only (reuses the existing
+  #2124/#3261 sentinel; no Rust change). Regenerated golden_4406 baseline (new
+  typed field; only `strict-violations/lenient` policy p1 flags true). Added
+  config-layer + userspace end-to-end fail-on-revert tests; proved RED-on-revert
+  by neutralizing the snapshot poison. Updated pkg/config/README.md (new #5575
+  section) + field/helper/const doc comments. Gates: go build ./... green;
+  go test ./pkg/config/... ./pkg/dataplane/... ./pkg/policymatch/... ./pkg/api/...
+  ./pkg/grpcapi/... ./pkg/configstore/... ./pkg/cluster/... ./cmd/cli/... green;
+  go vet clean; gofmt clean.
+  **File(s)**: pkg/config/types_security.go,
+  pkg/config/compiler_security_policy.go,
+  pkg/config/compiler_policy_missing_match.go,
+  pkg/config/compiler_policy_match.go, pkg/config/compiler_policy_then.go,
+  pkg/config/README.md, pkg/config/testdata/golden_4406.json,
+  pkg/config/lenient_permit_widening_5575_test.go,
+  pkg/dataplane/userspace/policies.go,
+  pkg/dataplane/userspace/policies_lower.go,
+  pkg/dataplane/userspace/lenient_permit_widening_5575_test.go, _Log.md

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -670,6 +670,35 @@ follow-up. The tolerant load/peer-sync path downgrades to a warning
 binary silently accepted still boots — the modifier stays dropped (the
 pre-existing behaviour), now flagged (#1960 no-brick doctrine, same as #3113).
 
+**The tolerant-path downgrade of #3044/#3113/#3114 must NOT widen the permit
+(#5575):** the #1960 lenient downgrade keeps the daemon booting, but the compiler
+then SILENTLY DROPS the offending constraint — a missing required match dimension
+(#3044) leaves the match slice EMPTY; an unsupported `match` leaf (#3113) or an
+unsupported `then permit` modifier (#3114) is never read. The userspace matcher
+reads an empty dimension as match-ANY (`expandUserspacePolicyApplications`
+returns `(nil, true)` for an empty slice; the address/literal sides default to
+match-any when empty), so the leniently-loaded policy silently widens to a permit
+BROADER than the operator configured — a security fail-OPEN on exactly the
+persisted-load / HA-sync path `CompileConfigLenient` serves. `compilePolicy` now
+records this on the typed policy: `Policy.LenientContentDropped` is set (via the
+SAME per-policy predicates the three strict gates use —
+`policyMissingRequiredMatchDimensions`, `policyUnsupportedMatchLeafFindings`,
+`policyUnsupportedThenPermitModifiers` — so the flag fires for EXACTLY the
+policies a strict commit would reject). The userspace snapshot builder
+(`buildOneRuleSnapshot`) then poisons such a rule with the `__unsupported__`
+application sentinel, so the Rust integrity preflight rejects the WHOLE snapshot
+(previous-good retained; fresh-boot default-deny) — an action-agnostic fail-CLOSED
+that turns the widened permit (and a symmetric over-broad deny) into never-match
+instead of match-any. Because the strict path hard-rejects all three BEFORE
+`compilePolicy` runs, a clean strict-committed policy always leaves the flag
+false and its snapshot is byte-identical. The flag is derived at compile time
+(never serialized), so it is recomputed identically on both HA peers. The
+distinction between an INTENTIONAL wildcard (`match application any` → a non-empty
+`["any"]` slice → legitimate match-any, flag false) and a DROPPED / MISSING
+constraint (empty slice, flag true) is made on the AST: an omitted leaf is treated
+differently from an explicit `any`, so a legitimate `any→any:any` permit is NOT
+poisoned.
+
 **Unsupported security-policy `then reject` children are rejected at commit
 (#3115, interim — codex-review-066 finding 066-03):** the sibling of #3114 for the
 `reject` arm. Junos SRX `then reject` accepts a custom reject-response `profile

--- a/pkg/config/compiler_policy_match.go
+++ b/pkg/config/compiler_policy_match.go
@@ -159,6 +159,70 @@ var swallowedStructuralMatchTokens = map[string]bool{
 	"to-zone":   true,
 }
 
+// policyMatchLeafFinding describes one unsupported / swallowed policy `match`
+// leaf violation (#3113/#3142/#3673). For a plain unsupported leaf (or an
+// unsupported keyword collapsed onto a multi-value leaf's tail), swallowed is
+// false and leaf names the offending leaf/keyword. For a #3673 structural
+// keyword absorbed as an operand, swallowed is true, leaf names the multi-value
+// leaf that absorbed it, and tok names the reserved keyword.
+type policyMatchLeafFinding struct {
+	swallowed bool
+	leaf      string
+	tok       string
+}
+
+// policyUnsupportedMatchLeafFindings returns every unsupported / swallowed
+// `match` leaf violation in a policy node's UNION of `match {}` blocks, in
+// declaration order. It is the single source of truth shared by the #3113
+// strict gate (validatePolicyMatchLeavesStrict) and compilePolicy's #5575
+// fail-closed LenientContentDropped flag: the strict gate turns each finding
+// into a reject/warning while compilePolicy only needs to know a policy has ANY
+// finding (so its dropped-leaf-widened match compiles fail-closed). Sharing one
+// walk keeps the reject gate and the runtime poison decision from diverging on
+// the #3142 collapsed-tail and #3673 swallowed-keyword escapes.
+//
+// #3842: inspects EVERY `match {}` block (policyMatchChildren), not just the
+// first via FindChild — a duplicate inner match block (load merge/override
+// appends a second `match` child) is compiled by compilePolicy and can carry an
+// unsupported leaf.
+func policyUnsupportedMatchLeafFindings(polNode *Node, isGlobal bool) []policyMatchLeafFinding {
+	var out []policyMatchLeafFinding
+	for _, m := range policyMatchChildren(polNode) {
+		leaf := m.Name()
+		// #3148: from-zone/to-zone are supported match context for a global
+		// policy only; under a zone-pair policy they fall through to the
+		// unsupported finding below.
+		if isGlobal && globalOnlyPolicyMatchLeaves[leaf] {
+			continue
+		}
+		if supportedPolicyMatchLeaves[leaf] {
+			// #3142: a multi:true match leaf (application/source-address/
+			// destination-address) absorbs trailing non-sibling tokens onto its
+			// own node (Keys[1:] + child sub-nodes — the #2419 collapse). An
+			// unsupported match-leaf keyword written after the supported leaf's
+			// value lands in this tail, invisible to a direct-child scan. Flag
+			// any known unsupported match-leaf keyword found in the collapsed
+			// tail (a real value is never one of these keywords, so legit
+			// `application [ junos-http junos-https ]` is not over-flagged).
+			for _, tok := range firewallMatchValues(m) {
+				if unsupportedPolicyMatchLeaves[tok] {
+					out = append(out, policyMatchLeafFinding{leaf: tok})
+				}
+				// #3673: from-zone/to-zone are not zone-pair match siblings, so
+				// they collapse onto this multi-value leaf's tail and are
+				// consumed as bogus application/address operands. Flag them as a
+				// reserved keyword masquerading as a value.
+				if swallowedStructuralMatchTokens[tok] {
+					out = append(out, policyMatchLeafFinding{swallowed: true, leaf: leaf, tok: tok})
+				}
+			}
+			continue
+		}
+		out = append(out, policyMatchLeafFinding{leaf: leaf})
+	}
+	return out
+}
+
 // validatePolicyMatchLeavesStrict walks the `security policies` subtree of
 // the group-expanded AST and rejects any policy whose `match` clause
 // carries a leaf the compiler does not enforce (see file header). Covers
@@ -207,51 +271,14 @@ func validatePolicyMatchLeavesStrict(nodes []*Node, lenient bool) ([]string, err
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node, isGlobal bool) error {
-		// #3842: inspect EVERY `match {}` block (policyMatchChildren), not just
-		// the first via FindChild. A duplicate inner match block (load merge/
-		// override appends a second `match` child) is compiled by compilePolicy
-		// and can carry an unsupported leaf; a FindChild-first walk here never
-		// validated it, so the second block's leaf was silently dropped and the
-		// policy widened with a clean commit.
-		for _, m := range policyMatchChildren(polNode) {
-			leaf := m.Name()
-			// #3148: from-zone/to-zone are supported match context for a
-			// global policy only; under a zone-pair policy they fall through
-			// to the unsupported reject below.
-			if isGlobal && globalOnlyPolicyMatchLeaves[leaf] {
-				continue
-			}
-			if supportedPolicyMatchLeaves[leaf] {
-				// #3142: a multi:true match leaf (application/source-address/
-				// destination-address) absorbs trailing non-sibling tokens
-				// onto its own node (Keys[1:] + child sub-nodes — the #2419
-				// collapse). An unsupported match-leaf keyword written after
-				// the supported leaf's value lands in this tail, invisible to
-				// the direct-child scan above. Re-apply the reject to any
-				// known unsupported match-leaf keyword found in the collapsed
-				// tail (a real value is never one of these keywords, so legit
-				// `application [ junos-http junos-https ]` is not over-rejected).
-				for _, tok := range firewallMatchValues(m) {
-					if unsupportedPolicyMatchLeaves[tok] {
-						if err := emit(scope, policyName, tok); err != nil {
-							return err
-						}
-					}
-					// #3673: from-zone/to-zone are not zone-pair match siblings,
-					// so they collapse onto this multi-value leaf's tail and are
-					// consumed as bogus application/address operands. Reject them
-					// as a reserved keyword masquerading as a value — the sibling
-					// of the #3142 unsupported-leaf tail escape for the
-					// zone-context tokens.
-					if swallowedStructuralMatchTokens[tok] {
-						if err := emitSwallowed(scope, policyName, leaf, tok); err != nil {
-							return err
-						}
-					}
+		for _, f := range policyUnsupportedMatchLeafFindings(polNode, isGlobal) {
+			if f.swallowed {
+				if err := emitSwallowed(scope, policyName, f.leaf, f.tok); err != nil {
+					return err
 				}
 				continue
 			}
-			if err := emit(scope, policyName, leaf); err != nil {
+			if err := emit(scope, policyName, f.leaf); err != nil {
 				return err
 			}
 		}

--- a/pkg/config/compiler_policy_missing_match.go
+++ b/pkg/config/compiler_policy_missing_match.go
@@ -80,6 +80,36 @@ var requiredPolicyMatchLeaves = []string{
 	"application",
 }
 
+// policyMissingRequiredMatchDimensions returns the Junos-mandatory match
+// dimensions (source-address, destination-address, application) ABSENT from a
+// policy node's UNION of `match {}` blocks, in declaration order; an empty
+// result means every required dimension is present. It is the single source of
+// truth shared by the #3044 strict gate (validatePolicyRequiredMatchStrict) and
+// compilePolicy's #5575 fail-closed LenientContentDropped flag, so the reject
+// gate and the runtime poison decision can never diverge on which policies omit
+// a dimension.
+//
+// #3842: it unions the dimensions across EVERY `match {}` block
+// (policyMatchChildren), not just the first via FindChild. Junos merges
+// duplicate match blocks, so a policy whose required dimensions are split
+// across two blocks (e.g. source/destination-address in one, application in a
+// load-merged second) is complete once merged — a FindChild-first read saw only
+// the first block and would either spuriously flag a complete policy or,
+// symmetrically, let a widened one through depending on block order.
+func policyMissingRequiredMatchDimensions(polNode *Node) []string {
+	present := map[string]bool{}
+	for _, m := range policyMatchChildren(polNode) {
+		present[m.Name()] = true
+	}
+	var missing []string
+	for _, req := range requiredPolicyMatchLeaves {
+		if !present[req] {
+			missing = append(missing, req)
+		}
+	}
+	return missing
+}
+
 // validatePolicyRequiredMatchStrict walks the `security policies` subtree of
 // the group-expanded AST and rejects any policy whose `match` clause omits a
 // required dimension (source-address, destination-address, application) or
@@ -106,24 +136,7 @@ func validatePolicyRequiredMatchStrict(nodes []*Node, lenient bool) ([]string, e
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node) error {
-		// #3842: union the dimensions across EVERY `match {}` block
-		// (policyMatchChildren), not just the first via FindChild. Junos merges
-		// duplicate match blocks, so a policy whose required dimensions are
-		// split across two blocks (e.g. source/destination-address in one,
-		// application in a load-merged second) is complete once merged — a
-		// FindChild-first read saw only the first block and would either
-		// spuriously reject a complete policy or, symmetrically, let a widened
-		// one through depending on which block came first.
-		present := map[string]bool{}
-		for _, m := range policyMatchChildren(polNode) {
-			present[m.Name()] = true
-		}
-		var missing []string
-		for _, req := range requiredPolicyMatchLeaves {
-			if !present[req] {
-				missing = append(missing, req)
-			}
-		}
+		missing := policyMissingRequiredMatchDimensions(polNode)
 		if len(missing) == 0 {
 			return nil
 		}

--- a/pkg/config/compiler_policy_then.go
+++ b/pkg/config/compiler_policy_then.go
@@ -72,6 +72,37 @@ import "fmt"
 // rejected.
 var supportedPolicyThenPermitChildren = map[string]bool{}
 
+// policyUnsupportedThenPermitModifiers returns the unsupported `then permit`
+// modifier tokens a policy carries — at most one per `then permit` action node
+// (matching the strict gate's report-first-per-node behavior). It is the single
+// source of truth shared by the #3114 strict gate (validatePolicyThenPermitStrict)
+// and compilePolicy's #5575 fail-closed LenientContentDropped flag, so the
+// reject gate and the runtime poison decision never diverge on which permits
+// carry a silently-dropped inspection/service-chain modifier.
+//
+// A bare `then permit` (a `permit` node with no modifier tokens) is fully
+// supported and contributes nothing. ALL `then permit` nodes across ALL
+// `then {}` blocks are inspected (policyThenActionNodes): a flat-set
+// `set ... then permit` followed by `set ... then permit application-services X`
+// produces TWO separate `permit` nodes (the #3377 two-node split), and #3842
+// adds the DUPLICATE inner `then {}` block case. collapsedThenActionTokens
+// flattens each node's modifier tokens across all three parser groupings
+// (flat-onto-permit, collapsed-child, nested). The supported permit-modifier set
+// is empty (supportedPolicyThenPermitChildren), so any token is unsupported.
+func policyUnsupportedThenPermitModifiers(polNode *Node) []string {
+	var out []string
+	for _, permitNode := range policyThenActionNodes(polNode, "permit") {
+		for _, tok := range collapsedThenActionTokens(permitNode) {
+			if supportedPolicyThenPermitChildren[tok] {
+				continue
+			}
+			out = append(out, tok)
+			break
+		}
+	}
+	return out
+}
+
 // validatePolicyThenPermitStrict walks the `security policies` subtree of
 // the group-expanded AST and rejects any policy whose `then permit` action
 // arm carries a child the compiler does not enforce (see file header).
@@ -98,29 +129,9 @@ func validatePolicyThenPermitStrict(nodes []*Node, lenient bool) ([]string, erro
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node) error {
-		// A bare `then permit` (a `permit` node with no modifier tokens) is
-		// fully supported. Only `then permit <modifier>` carries an
-		// unsupported modifier. ALL `then permit` nodes across ALL `then {}`
-		// blocks are inspected (policyThenActionNodes): a flat-set
-		// `set ... then permit` followed by `set ... then permit
-		// application-services X` produces TWO separate `permit` nodes (the
-		// #3377 two-node split), and #3842 adds the DUPLICATE inner `then {}`
-		// block case (load merge/override appends a second `then` child) — a
-		// FindChild-first gate saw only the first then block / bare node and
-		// missed the unsupported modifier on the second. collapsedThenAction-
-		// Tokens flattens each node's modifier tokens across all three parser
-		// groupings (flat-onto-permit, collapsed-child, nested). The supported
-		// permit-modifier set is empty (supportedPolicyThenPermitChildren), so
-		// any token is unsupported; report the first per offending node.
-		for _, permitNode := range policyThenActionNodes(polNode, "permit") {
-			for _, tok := range collapsedThenActionTokens(permitNode) {
-				if supportedPolicyThenPermitChildren[tok] {
-					continue
-				}
-				if err := emit(scope, policyName, tok); err != nil {
-					return err
-				}
-				break
+		for _, tok := range policyUnsupportedThenPermitModifiers(polNode) {
+			if err := emit(scope, policyName, tok); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/pkg/config/compiler_security_policy.go
+++ b/pkg/config/compiler_security_policy.go
@@ -75,7 +75,7 @@ func compilePolicies(node *Node, sec *SecurityConfig) error {
 		// "global { policy ... }" - global policies applied to all zone pairs
 		if child.Name() == "global" {
 			for _, polInst := range namedInstances(child.FindChildren("policy")) {
-				pol := compilePolicy(polInst)
+				pol := compilePolicy(polInst, true)
 				sec.GlobalPolicies = append(sec.GlobalPolicies, pol)
 			}
 			continue
@@ -111,7 +111,7 @@ func compilePolicies(node *Node, sec *SecurityConfig) error {
 				}
 
 				for _, polInst := range namedInstances(zp.policyNode.FindChildren("policy")) {
-					zpp.Policies = append(zpp.Policies, compilePolicy(polInst))
+					zpp.Policies = append(zpp.Policies, compilePolicy(polInst, false))
 				}
 
 				sec.Policies = append(sec.Policies, zpp)
@@ -202,11 +202,14 @@ func policyThenActionNodes(polNode *Node, action string) []*Node {
 	return out
 }
 
-// compilePolicy extracts a Policy from a named policy instance.
+// compilePolicy extracts a Policy from a named policy instance. isGlobal marks
+// a `security policies global` policy (vs a zone-pair policy) so the #5575
+// unsupported-match-leaf detection honors the global-only from-zone/to-zone
+// match context (#3148) exactly as validatePolicyMatchLeavesStrict does.
 func compilePolicy(polInst struct {
 	name string
 	node *Node
-}) *Policy {
+}, isGlobal bool) *Policy {
 	pol := &Policy{Name: polInst.name}
 
 	// #3842: accumulate across ALL `match {}` blocks (policyMatchChildren) —
@@ -368,6 +371,35 @@ func compilePolicy(polInst struct {
 	// nil (never populated).
 	pol.Match.FromZones = sortDedupZones(pol.Match.FromZones)
 	pol.Match.ToZones = sortDedupZones(pol.Match.ToZones)
+
+	// #5575: fail-CLOSED on the tolerant load / peer-sync path. A policy the
+	// #3044 / #3113 / #3114 strict gates would REJECT (a missing required match
+	// dimension, an unsupported `match` leaf, or an unsupported `then permit`
+	// modifier) is downgraded to a WARNING by CompileConfigLenient — but the
+	// compiler then SILENTLY DROPS the offending constraint: a missing dimension
+	// leaves the corresponding match slice empty, an unsupported match leaf /
+	// then-permit modifier is never read. The userspace matcher reads an empty
+	// dimension as match-ANY, so the leniently-loaded policy silently widens to
+	// a permit BROADER than configured (a fail-open on the persisted-load /
+	// HA-sync path). Record the invalidation on the typed Policy so the
+	// userspace snapshot builder can poison the rule with the __unsupported__
+	// sentinel (never-match) instead of publishing the widened permit.
+	//
+	// This uses the SAME per-policy predicates the three strict gates use
+	// (single source of truth), so the flag is set for EXACTLY the policies a
+	// strict commit would reject. On the strict path those policies never reach
+	// compilePolicy — runPreWalkGates hard-rejects them first — so a clean
+	// strict-committed policy always leaves the flag false and its snapshot is
+	// byte-identical to before. The distinction between an INTENTIONAL wildcard
+	// (`match application any` → a non-empty ["any"] slice → match-any, flag
+	// false) and a DROPPED / MISSING constraint (empty slice, flag true) is made
+	// here on the AST: policyMissingRequiredMatchDimensions treats an omitted
+	// leaf differently from an explicit `any`.
+	if len(policyMissingRequiredMatchDimensions(polInst.node)) > 0 ||
+		len(policyUnsupportedMatchLeafFindings(polInst.node, isGlobal)) > 0 ||
+		len(policyUnsupportedThenPermitModifiers(polInst.node)) > 0 {
+		pol.LenientContentDropped = true
+	}
 
 	return pol
 }

--- a/pkg/config/lenient_permit_widening_5575_test.go
+++ b/pkg/config/lenient_permit_widening_5575_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"testing"
+)
+
+// lenient_permit_widening_5575_test.go is the config-layer fail-on-revert guard
+// for #5575: a policy the TOLERANT compile path (CompileConfigLenient) accepts
+// only by DOWNGRADING a #3044 missing-match / #3113 unsupported-match-leaf /
+// #3114 unsupported-then-permit reject to a WARNING must carry
+// Policy.LenientContentDropped == true, so the userspace snapshot builder can
+// poison the rule with the __unsupported__ sentinel instead of silently
+// widening the dropped dimension to match-ANY (a permit-widening fail-open on
+// the persisted-load / HA-sync path).
+//
+// Reverting compilePolicy's flag-set (or the shared predicate helpers) leaves
+// the flag false on a leniently-loaded partial/invalid policy → the snapshot
+// builder compiles the empty dimension to match-any → the widened permit ships.
+// The lenient-flag subtests here flip RED on that revert; the clean subtests
+// pin that an INTENTIONAL wildcard (explicit `any`) is NOT flagged (the
+// empty-vs-dropped distinction).
+
+func lenientCompilePolicy5575(t *testing.T, cmds []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on a tolerated policy: %v", err)
+	}
+	return cfg
+}
+
+// firstPolicy5575 returns the single compiled policy (zone-pair or global) so a
+// subtest can assert its LenientContentDropped flag without threading scope.
+func firstPolicy5575(t *testing.T, cfg *Config) *Policy {
+	t.Helper()
+	for _, zpp := range cfg.Security.Policies {
+		for _, p := range zpp.Policies {
+			return p
+		}
+	}
+	for _, p := range cfg.Security.GlobalPolicies {
+		return p
+	}
+	t.Fatal("no compiled policy found")
+	return nil
+}
+
+func TestLenientContentDroppedFlagsWidenedPolicies5575(t *testing.T) {
+	zones := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+	}
+	zp := "set security policies from-zone trust to-zone untrust policy p "
+	cases := []struct {
+		name string
+		cmds []string
+		want bool
+	}{
+		{
+			// #3044 missing destination-address + application on a PERMIT: the
+			// #5575 core permit-widening repro. Pre-fix apps=[]/dst=[] → match-any.
+			name: "permit missing destination+application",
+			cmds: append(append([]string{}, zones...),
+				zp+"match source-address any",
+				zp+"then permit",
+			),
+			want: true,
+		},
+		{
+			// #3113 unsupported match leaf (dynamic-application) on an otherwise
+			// complete PERMIT: the leaf is dropped, widening the L3/L4 match.
+			name: "permit with unsupported match leaf",
+			cmds: append(append([]string{}, zones...),
+				zp+"match source-address any",
+				zp+"match destination-address any",
+				zp+"match application any",
+				zp+"match dynamic-application junos:FTP",
+				zp+"then permit",
+			),
+			want: true,
+		},
+		{
+			// #3114 unsupported then-permit modifier (application-services): the
+			// service chain is dropped, turning permit-with-inspection into an
+			// unconditional permit.
+			name: "permit with unsupported then-permit modifier",
+			cmds: append(append([]string{}, zones...),
+				zp+"match source-address any",
+				zp+"match destination-address any",
+				zp+"match application any",
+				zp+"then permit application-services utm-policy strict",
+			),
+			want: true,
+		},
+		{
+			// Deny cases must be flagged too (action-agnostic): the sentinel
+			// whole-snapshot reject prevents a malformed deny from silently
+			// falling through to a broader default-permit.
+			name: "deny missing destination+application",
+			cmds: append(append([]string{}, zones...),
+				zp+"match source-address any",
+				zp+"then deny",
+			),
+			want: true,
+		},
+		{
+			// Intentional wildcard: all three dimensions present as explicit
+			// `any`. This is a LEGITIMATE match-any permit and must NOT be
+			// flagged — the empty-vs-dropped distinction. A revert that keys the
+			// poison on "empty dimension" instead of "dropped constraint" would
+			// wrongly flag this and RED here.
+			name: "complete permit with explicit any not flagged",
+			cmds: append(append([]string{}, zones...),
+				zp+"match source-address any",
+				zp+"match destination-address any",
+				zp+"match application any",
+				zp+"then permit",
+			),
+			want: false,
+		},
+		{
+			// Fully-constrained permit: no dropped content, not flagged.
+			name: "complete constrained permit not flagged",
+			cmds: append(append([]string{}, zones...),
+				zp+"match source-address 10.0.0.0/8",
+				zp+"match destination-address any",
+				zp+"match application junos-http",
+				zp+"then permit",
+			),
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := lenientCompilePolicy5575(t, tc.cmds)
+			pol := firstPolicy5575(t, cfg)
+			if pol.LenientContentDropped != tc.want {
+				t.Fatalf("policy %q LenientContentDropped = %v, want %v", pol.Name, pol.LenientContentDropped, tc.want)
+			}
+		})
+	}
+}
+
+// TestLenientContentDroppedGlobalPolicy5575 covers the global-policy scope,
+// including that the global-only from-zone/to-zone match context is NOT
+// mistaken for an unsupported match leaf (it is legitimate under global).
+func TestLenientContentDroppedGlobalPolicy5575(t *testing.T) {
+	t.Run("global missing application flagged", func(t *testing.T) {
+		cfg := lenientCompilePolicy5575(t, []string{
+			"set security policies global policy g match source-address any",
+			"set security policies global policy g match destination-address any",
+			"set security policies global policy g then permit",
+		})
+		pol := firstPolicy5575(t, cfg)
+		if !pol.LenientContentDropped {
+			t.Fatalf("global policy missing application must be flagged; LenientContentDropped=false")
+		}
+	})
+	t.Run("global with from-zone/to-zone scope not flagged", func(t *testing.T) {
+		cfg := lenientCompilePolicy5575(t, []string{
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies global policy g match source-address any",
+			"set security policies global policy g match destination-address any",
+			"set security policies global policy g match application any",
+			"set security policies global policy g match from-zone trust",
+			"set security policies global policy g match to-zone untrust",
+			"set security policies global policy g then permit",
+		})
+		pol := firstPolicy5575(t, cfg)
+		if pol.LenientContentDropped {
+			t.Fatalf("a global policy with a legitimate from-zone/to-zone scope must NOT be flagged as content-dropped")
+		}
+	})
+}
+
+// TestStrictStillRejectsWidenedPolicies5575 confirms the lenient flag is a
+// tolerant-path artifact only: the strict commit path still HARD-REJECTS the
+// same widened policies (so LenientContentDropped can never be set on a
+// clean strict-committed policy — the snapshot stays byte-identical).
+func TestStrictStillRejectsWidenedPolicies5575(t *testing.T) {
+	strictRejects := func(t *testing.T, cmds []string) {
+		t.Helper()
+		tree := &ConfigTree{}
+		for _, cmd := range cmds {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%q): %v", cmd, err)
+			}
+		}
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("strict commit accepted a policy the lenient path flags as content-dropped; want a hard reject")
+		}
+	}
+	zp := "set security policies from-zone trust to-zone untrust policy p "
+	strictRejects(t, []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		zp + "match source-address any",
+		zp + "then permit",
+	})
+}

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -132,7 +132,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           },
@@ -165,7 +166,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -1379,7 +1381,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           },
@@ -1412,7 +1415,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -2625,7 +2629,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           },
@@ -2658,7 +2663,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -3871,7 +3877,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           },
@@ -3904,7 +3911,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -5118,7 +5126,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           },
@@ -5151,7 +5160,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -6364,7 +6374,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           },
@@ -6397,7 +6408,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -7593,7 +7605,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -8558,7 +8571,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -9522,7 +9536,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -10486,7 +10501,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -11451,7 +11467,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -12415,7 +12432,8 @@
                 },
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": false
               }
             ]
           }
@@ -14113,7 +14131,8 @@
                 "Log": null,
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": true
               }
             ]
           }
@@ -14443,7 +14462,8 @@
                 "Log": null,
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": true
               }
             ]
           }
@@ -14773,7 +14793,8 @@
                 "Log": null,
                 "Count": false,
                 "SchedulerName": "",
-                "UnknownChildren": null
+                "UnknownChildren": null,
+                "LenientContentDropped": true
               }
             ]
           }

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -386,6 +386,30 @@ type Policy struct {
 	// emit an accepted-but-inert / probable-typo advisory. Recorded in config
 	// order so the warning is deterministic.
 	UnknownChildren []string
+	// LenientContentDropped marks a policy the TOLERANT compile path
+	// (CompileConfigLenient / CompileConfigForNodeLenient) accepted only by
+	// DOWNGRADING a hard reject to a warning for a match / then-permit
+	// constraint the compiler then SILENTLY DROPPED — a MISSING required match
+	// dimension (#3044), an UNSUPPORTED `match` leaf (#3113, incl. the #3142
+	// collapsed-tail and #3673 swallowed-keyword escapes), or an UNSUPPORTED
+	// `then permit` modifier (#3114). In each case the dropped constraint
+	// leaves the corresponding dimension EMPTY / the permit UNCONDITIONAL, and
+	// the userspace matcher reads an empty dimension as match-ANY — a permit
+	// BROADER than the operator configured (a security fail-OPEN on the
+	// persisted-load / peer-sync path, #5575). The strict commit path
+	// hard-rejects all three before compilePolicy runs, so this flag is only
+	// ever set on the tolerant load / peer-sync path; a clean strict-committed
+	// policy always leaves it false (byte-identical snapshots).
+	//
+	// compilePolicy derives it (never the raw AST / wire), so it is recomputed
+	// identically on both HA peers and needs no serialization. The userspace
+	// snapshot builder (buildOneRuleSnapshot) poisons such a policy with the
+	// __unsupported__ application sentinel so the Rust integrity preflight
+	// rejects the WHOLE snapshot (previous-good retained; fresh-boot
+	// default-deny) — an action-agnostic fail-CLOSED that turns the widened
+	// permit (and a symmetric over-broad deny) into never-match instead of
+	// match-any.
+	LenientContentDropped bool
 }
 
 // PolicyMatch defines what traffic a policy matches.

--- a/pkg/dataplane/userspace/lenient_permit_widening_5575_test.go
+++ b/pkg/dataplane/userspace/lenient_permit_widening_5575_test.go
@@ -1,0 +1,161 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// lenient_permit_widening_5575_test.go is the end-to-end fail-on-revert guard
+// for #5575: a policy the TOLERANT compile path (CompileConfigLenient — the
+// persisted-load / HA-sync path) accepts only by DOWNGRADING a #3044
+// missing-match / #3113 unsupported-match-leaf / #3114 unsupported-then-permit
+// reject to a WARNING must lower to a NEVER-MATCH rule — it must carry the
+// __unsupported__ application sentinel so the Rust integrity preflight rejects
+// the WHOLE snapshot (previous-good retained; fresh-boot default-deny) — NOT a
+// wildcard permit.
+//
+// Pre-fix the compiler dropped the offending match/permit constraint and left
+// the dimension EMPTY, which expandUserspacePolicyApplications /
+// expandUserspacePolicyAddresses lower to match-ANY: the leniently-loaded
+// permit widened to permit-more-than-configured (a security fail-open). The
+// sentinel subtests here flip RED if either the compilePolicy
+// LenientContentDropped flag OR the buildOneRuleSnapshot poison is reverted (the
+// rule collapses back to match-any → no sentinel → empty PolicyContentRejected).
+// The clean subtest pins that an INTENTIONAL wildcard (explicit `any`) stays
+// match-any (no sentinel), preserving the empty-vs-dropped distinction.
+
+func lenientSnapshot5575(t *testing.T, cmds [][]string) *ConfigSnapshot {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		if err := tree.SetPath(cmd); err != nil {
+			t.Fatalf("SetPath(%v): %v", cmd, err)
+		}
+	}
+	// The tolerant load / peer-sync path — the exact path #5575 fails open on.
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: %v", err)
+	}
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	return snap
+}
+
+func snapshotHasAppSentinel5575(snap *ConfigSnapshot) bool {
+	for _, pol := range snap.Policies {
+		for _, term := range pol.ApplicationTerms {
+			if term.Protocol == unsupportedApplicationSentinel || term.Name == unsupportedApplicationSentinel {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestLenientWidenedPolicyLowersToSentinel5575(t *testing.T) {
+	zones := [][]string{
+		{"security", "zones", "security-zone", "trust"},
+		{"security", "zones", "security-zone", "untrust"},
+	}
+	p := func(rest ...string) []string {
+		return append([]string{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "match"}, rest...)
+	}
+	then := func(rest ...string) []string {
+		return append([]string{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "then"}, rest...)
+	}
+	cases := []struct {
+		name string
+		cmds [][]string
+	}{
+		{
+			// #3044 — the core permit-widening repro: a permit with only
+			// source-address any. Pre-fix dst=[]/apps=[] → match-any → permits
+			// EVERYTHING trust->untrust. Must now carry the sentinel.
+			name: "permit missing destination+application",
+			cmds: append(append([][]string{}, zones...),
+				p("source-address", "any"),
+				then("permit"),
+			),
+		},
+		{
+			// #3113 — unsupported match leaf (dynamic-application) dropped.
+			name: "permit with unsupported match leaf",
+			cmds: append(append([][]string{}, zones...),
+				p("source-address", "any"),
+				p("destination-address", "any"),
+				p("application", "any"),
+				p("dynamic-application", "junos:FTP"),
+				then("permit"),
+			),
+		},
+		{
+			// #3114 — unsupported then-permit service chain dropped.
+			name: "permit with unsupported then-permit modifier",
+			cmds: append(append([][]string{}, zones...),
+				p("source-address", "any"),
+				p("destination-address", "any"),
+				p("application", "any"),
+				then("permit", "application-services", "utm-policy", "strict"),
+			),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := lenientSnapshot5575(t, tc.cmds)
+			if !snapshotHasAppSentinel5575(snap) {
+				t.Fatalf("no __unsupported__ sentinel term: the leniently-loaded widened permit lowered to match-any — the Rust preflight would NOT reject it (permit-widening fail-open, #5575)")
+			}
+			if len(snap.Capabilities.PolicyContentRejected) == 0 {
+				t.Fatal("PolicyContentRejected empty: the fail-closed whole-snapshot reject diagnostic must be recorded for a lenient-dropped policy")
+			}
+		})
+	}
+}
+
+// TestLenientMalformedDenyLowersToSentinel5575 covers the deny case the issue
+// calls out: a malformed deny (missing match dimensions) over a DEFAULT-PERMIT
+// rulebase must NOT be silently turned into a broader default-permit. The
+// __unsupported__ sentinel rejects the whole snapshot (default-deny / last-good)
+// instead of collapsing the deny to a match-any (or, worse under a per-rule
+// never-match, letting it fall through to default-permit).
+func TestLenientMalformedDenyLowersToSentinel5575(t *testing.T) {
+	snap := lenientSnapshot5575(t, [][]string{
+		{"security", "policies", "default-policy", "permit-all"},
+		{"security", "zones", "security-zone", "trust"},
+		{"security", "zones", "security-zone", "untrust"},
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "match", "source-address", "any"},
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "then", "deny"},
+	})
+	if !snapshotHasAppSentinel5575(snap) {
+		t.Fatal("malformed deny did not lower to the __unsupported__ sentinel: without the whole-snapshot reject it would collapse to match-any and, over a default-permit rulebase, risk widening to permit (#5575 deny guard)")
+	}
+	if len(snap.Capabilities.PolicyContentRejected) == 0 {
+		t.Fatal("PolicyContentRejected empty for a malformed deny; want the fail-closed diagnostic")
+	}
+}
+
+// TestLenientCompleteAnyPermitStaysMatchAny5575 is the empty-vs-dropped
+// boundary: a permit that names all three dimensions as explicit `any` is a
+// legitimate match-any permit and must NOT be poisoned — no sentinel, no
+// content rejection. A revert that keys the fail-close on "empty dimension"
+// rather than "dropped constraint" would over-poison this and RED here.
+func TestLenientCompleteAnyPermitStaysMatchAny5575(t *testing.T) {
+	snap := lenientSnapshot5575(t, [][]string{
+		{"security", "zones", "security-zone", "trust"},
+		{"security", "zones", "security-zone", "untrust"},
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "match", "source-address", "any"},
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "match", "destination-address", "any"},
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "match", "application", "any"},
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "then", "permit"},
+	})
+	if snapshotHasAppSentinel5575(snap) {
+		t.Fatal("an explicit any->any:any permit must stay match-any, not be poisoned with the sentinel (empty-vs-dropped distinction, #5575)")
+	}
+	if len(snap.Capabilities.PolicyContentRejected) != 0 {
+		t.Fatalf("PolicyContentRejected = %v, want empty for a legitimate match-any permit", snap.Capabilities.PolicyContentRejected)
+	}
+}

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -18,6 +18,16 @@ import (
 // by both appid.ProtocolNumber and userspace-dp parse_protocol.
 const unsupportedApplicationSentinel = "__unsupported__"
 
+// lenientDroppedConstraintToken is the synthetic offending-token label recorded
+// for a rule the lenient / HA-sync compile path poisons because the compiler
+// SILENTLY DROPPED a match / then-permit constraint (#5575) — a missing required
+// match dimension, an unsupported `match` leaf, or an unsupported `then permit`
+// modifier (config.Policy.LenientContentDropped). There is no single
+// unrepresentable token to name (the offending constraint was dropped, not left
+// behind), so this label stands in for collectPolicyContentRejections' #3376
+// per-side reason. It is a build-time diagnostic only, never emitted on the wire.
+const lenientDroppedConstraintToken = "lenient-dropped-match-or-then-permit-constraint"
+
 // unsupportedAddressSentinel is the reserved address literal emitted in a policy
 // rule's source/destination address fields (#3261) when the userspace matcher
 // cannot represent the rule's configured addresses — an undefined address-book

--- a/pkg/dataplane/userspace/policies_lower.go
+++ b/pkg/dataplane/userspace/policies_lower.go
@@ -156,6 +156,30 @@ func buildOneRuleSnapshot(
 			Protocol: unsupportedApplicationSentinel,
 		}}
 	}
+	// #5575: a policy the tolerant load / peer-sync compile path accepted only
+	// by DOWNGRADING a hard reject to a warning (a missing required match
+	// dimension #3044, an unsupported `match` leaf #3113, or an unsupported
+	// `then permit` modifier #3114) had that constraint SILENTLY DROPPED by the
+	// compiler, leaving the dimension EMPTY / the permit UNCONDITIONAL. The
+	// matcher reads an empty dimension as match-ANY, so the leniently-loaded
+	// policy would otherwise arm a permit BROADER than the operator configured
+	// (a fail-open). Poison the rule with the SAME __unsupported__ application
+	// sentinel the #2124/#3261 unrepresentable-content path uses so the Rust
+	// integrity preflight rejects the WHOLE snapshot (previous-good retained;
+	// fresh-boot default-deny) — an action-agnostic fail-CLOSED that turns the
+	// widened permit (and a symmetric over-broad deny) into never-match instead
+	// of match-any. A strict commit rejects such a policy outright, so this only
+	// ever fires on the tolerant load / peer-sync path (LenientContentDropped is
+	// never set for a clean strict-committed policy).
+	if pol.LenientContentDropped {
+		if len(rejectedApps) == 0 {
+			rejectedApps = []string{lenientDroppedConstraintToken}
+		}
+		applicationTerms = []PolicyApplicationSnapshot{{
+			Name:     unsupportedApplicationSentinel,
+			Protocol: unsupportedApplicationSentinel,
+		}}
+	}
 	// #1606 v3 fields: classify each address token as "named book
 	// reference" vs "free-form literal".
 	srcBookIDs, srcLiterals := classifyPolicyAddresses(cfg, nameToID, pol.Match.SourceAddresses)


### PR DESCRIPTION
## Summary
`CompileConfigLenient` downgrades the #3044 missing-match, #3113
unsupported-match-leaf, and #3114 unsupported-`then permit` rejects to warnings
(so a persisted / peer-synced config still boots — #1960 no-brick), but
`compilePolicy` then **silently dropped** the offending constraint. A missing
required dimension left the match slice EMPTY; an unsupported match leaf /
then-permit modifier was never read. The userspace matcher reads an empty
dimension as match-ANY (`expandUserspacePolicyApplications` returns `(nil, true)`
for an empty slice), so the leniently-loaded policy silently widened to a permit
**broader than configured** — a security fail-open on exactly the persisted-load
/ HA-sync path this compiler serves.

## Fix (fail-CLOSED: discarded/invalid constraint → never-match, not match-any)
- **Carry the downgrade evidence onto the typed policy.** New
  `Policy.LenientContentDropped` flag, set by `compilePolicy` (now taking
  `isGlobal`) using the **same per-policy predicates the three strict gates use**
  — extracted into shared SSOT helpers `policyMissingRequiredMatchDimensions`,
  `policyUnsupportedMatchLeafFindings`, `policyUnsupportedThenPermitModifiers`
  (covering the #3142 collapsed-tail and #3673 swallowed-keyword escapes). The
  flag fires for EXACTLY the policies a strict commit would reject.
- **Poison at snapshot lowering.** `buildOneRuleSnapshot` emits the established
  `__unsupported__` application sentinel (`pkg/dataplane/userspace/policies_lower.go`)
  for a flagged rule, so the Rust integrity preflight rejects the **whole
  snapshot** (previous-good retained; fresh-boot default-deny) — the same
  #2124/#3261 mechanism, action-agnostic fail-closed for both a widened permit
  and a symmetric over-broad deny.

## Empty-vs-dropped distinction (exactly right)
The distinction is made on the **AST**, not the empty typed slice: an
INTENTIONAL wildcard (`match application any` → a non-empty `["any"]` slice) stays
legitimate match-any (flag false), while an omitted/dropped constraint (empty
slice) is flagged. `policyMissingRequiredMatchDimensions` treats an omitted leaf
differently from an explicit `any`. Because the strict path hard-rejects all
three cases BEFORE `compilePolicy` runs, a clean strict-committed policy always
leaves the flag false and its snapshot is byte-identical to before.

## Sentinel fix location
`pkg/dataplane/userspace/policies_lower.go` `buildOneRuleSnapshot`:
`if pol.LenientContentDropped { applicationTerms = [{__unsupported__, __unsupported__}] }`.
Flag set in `pkg/config/compiler_security_policy.go` `compilePolicy`.

## RED-on-revert
Verified: neutralizing the `buildOneRuleSnapshot` poison flips the three
sentinel subtests + the malformed-deny subtest RED (the widened permit lowers
back to match-any → no sentinel → empty `PolicyContentRejected`), while the
clean explicit-`any` control stays green. Reverting the `compilePolicy`
flag-set is equivalent (flag false → no poison).

## Tests
- `pkg/config/lenient_permit_widening_5575_test.go` — typed-field flag across
  zone-pair + global, permit + deny, missing-match / unsupported-leaf /
  then-permit; explicit-`any` and fully-constrained permits NOT flagged; strict
  still hard-rejects.
- `pkg/dataplane/userspace/lenient_permit_widening_5575_test.go` — end-to-end
  `CompileConfigLenient` → `buildSnapshot` → `__unsupported__` sentinel +
  non-empty `PolicyContentRejected`; malformed-deny-over-default-permit guard;
  explicit-`any` stays match-any.

## Dataplane / smoke
**Go-only** — reuses the existing `__unsupported__` sentinel; no Rust change.
The change to the dataplane snapshot is strictly fail-CLOSED
(widened-permit → whole-snapshot reject / never-match), so loss-cluster smoke is
deferrable under the shim wall (#5364); the parent records the deferral.

## Validation
`go build ./...`; `go test ./pkg/config/... ./pkg/dataplane/... ./pkg/policymatch/...
./pkg/api/... ./pkg/grpcapi/... ./pkg/configstore/... ./pkg/cluster/... ./cmd/cli/...`
all green; `go vet` clean; `gofmt` clean. Regenerated `golden_4406` baseline for
the new typed field (only the `strict-violations/lenient` corpus policy `p1`
flags true — the permit-widening repro).

Closes #5575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mnJsbx483uDqvh42Bn6UE
