### PR TITLE
ddns: bound ownership-state read before buffering (CWE-770)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -45992,3 +45992,17 @@ top.
   pkg/dataplane/userspace/policies.go,
   pkg/dataplane/userspace/policies_lower.go,
   pkg/dataplane/userspace/lenient_permit_widening_5575_test.go, _Log.md
+
+- **Timestamp**: 2026-07-11
+  **Action**: #5571 — bound the DDNS ownership-state read before loading it all
+  into memory (CWE-770). Added `readBoundedStateFile` (os.Stat pre-check +
+  io.LimitReader(maxDDNSStateBytes+1) sentinel) and the derived cap constants
+  `maxDDNSStateRecords`/`maxDDNSStateRecordBytes`/`maxDDNSStateBytes` (~128 MiB)
+  plus the `errDDNSStateTooLarge` sentinel (wraps errDDNSStateCorrupt) so an
+  over-bound file engages the existing fail-closed quarantine + durable
+  `.degraded` marker posture. `loadDDNSState` now reads via the bounded helper.
+  Added fail-on-revert tests (sparse oversized file rejected by the size bound;
+  end-to-end degrade/quarantine; normal file still loads; missing = not-exist).
+  Updated pkg/ddns/README.md size-bound contract. RED-on-revert verified.
+  **File(s)**: pkg/ddns/state.go, pkg/ddns/state_readbound_5571_test.go,
+  pkg/ddns/README.md, _Log.md

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -16,7 +16,7 @@ moved with its assertions intact.
 | File | Contents |
 |------|----------|
 | `manager.go` | `Manager` (the DDNS reconcile engine — moved from `dhcpserver/ddns.go`): `policyFromConfig`, `Reconcile`, `reconcileOnceLocked`, `upsertLocked`/`deleteOwnedLocked`, `withdrawAllLocked`, `ownerWatermark`, `dhcidSharedWithOther` (#2700 shared-DHCID guard), `Stats` (incl. `PTRPendingNow`, #2708), `OwnedRecordView(s)`, the `errDDNSNoBackendToWithdraw` keep-ownership sentinel (#2699), the write-ahead durability + never-delete-non-owned boundary. Also the `Lease` record + `LeaseParser` seam. |
-| `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. Also the fail-closed load classifiers `errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion` + `quarantineBadState` (#2650) + the durable `<path>.degraded` marker helpers `readDegradedMarker` / `writeDegradedMarker` (#4873) that keep the fail-closed posture across restart. |
+| `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. Also the fail-closed load classifiers `errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion` + `quarantineBadState` (#2650) + the durable `<path>.degraded` marker helpers `readDegradedMarker` / `writeDegradedMarker` (#4873) that keep the fail-closed posture across restart. The load is SIZE-BOUNDED via `readBoundedStateFile` (`os.Stat` pre-check + `io.LimitReader` sentinel) against the derived `maxDDNSStateBytes` cap; an over-bound file is classified `errDDNSStateTooLarge` (wraps `errDDNSStateCorrupt`) so it fails closed like a corrupt file (#5571, CWE-770). |
 | `backend.go` | `DNSUpdater` interface, `LeaseDNSRecord`, `nopUpdater`, the record + reverse-PTR-name helpers — moved from `dhcpserver/ddns_dns.go`. |
 | `backend_rfc2136.go` | The LIVE RFC 2136 backend (`rfc2136Updater`): exact-RR adds/deletes, TSIG, RFC 4701 DHCID + RFC 4703 replace-owned two-attempt, the `errDDNSConflictRefused` / `errDDNSPTRPending` sentinels — moved from `dhcpserver/ddns_rfc2136.go`. `sendRemoveForward(..., keepDHCID)` keeps a shared DHCID on a partial dual-stack teardown (#2700); `dnsCanonicalFQDN` mirrors the DHCID FQDN canonicalization. |
 | `hostname.go` | Deterministic hostname → DNS-label normalization (pure) — moved from `dhcpserver/ddns_hostname.go`. |
@@ -301,6 +301,24 @@ no change in those packages:
     WITHOUT persisting, so the stale RR was uncleanable and oscillated across
     restart; that drop path now also persists (`state.save()`) as defense in
     depth so it can never re-oscillate.
+  - **The load is SIZE-BOUNDED before any allocation (#5571, CWE-770).**
+    `loadDDNSState` no longer `os.ReadFile`s the whole file before validating it.
+    A very large canonical file — left by a prior crash, filesystem corruption,
+    an administrative restore, or a future producer defect — would otherwise drive
+    input-proportional heap growth / GC pressure / OOM during daemon STARTUP,
+    exactly when the control plane must recover and BEFORE the fail-closed posture
+    can engage. `readBoundedStateFile` opens and `os.Stat`s the file, rejecting an
+    over-bound size before any read (so an arbitrarily large corrupt file costs one
+    stat, not a full read), then reads through `io.LimitReader(f, maxDDNSStateBytes+1)`
+    with a sentinel byte so a file that grew after the stat, or whose stat size is
+    unreliable, still cannot be buffered past the cap. The cap is DERIVED, not a
+    magic number: `maxDDNSStateBytes = maxDDNSStateRecords (65,536 — one full /16
+    fully leased, far beyond any realistic deployment) * maxDDNSStateRecordBytes
+    (2 KiB — a worst-case pretty-printed record with every optional field at its
+    protocol maximum, ~33% headroom) + a small JSON envelope` ≈ 128 MiB. An
+    over-bound file is classified `errDDNSStateTooLarge` (which WRAPS
+    `errDDNSStateCorrupt`), so it engages the SAME quarantine + durable
+    `.degraded` marker posture as an unparseable/bad-version file.
   - **The fail-closed posture is DURABLE across restart (#4873).** Quarantine
     renames the corrupt canonical file away, so a naive reload on the next boot
     would find no file, load an EMPTY store with a nil error, and NOT degrade —

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/netip"
 	"os"
 	"sort"
@@ -26,6 +27,16 @@ import (
 var (
 	errDDNSStateCorrupt            = errors.New("ddns: ownership state file is corrupt")
 	errDDNSStateUnsupportedVersion = errors.New("ddns: ownership state file has an unsupported version")
+	// errDDNSStateTooLarge classifies an ownership file whose on-disk size
+	// exceeds maxDDNSStateBytes (#5571, CWE-770 unbounded resource consumption).
+	// It WRAPS errDDNSStateCorrupt so an over-bound file engages the EXACT
+	// fail-closed posture the loader already uses for an unparseable/bad-version
+	// file (quarantine aside + durable degraded marker via loadStateOrDegrade) —
+	// an oversized/corrupt canonical file is no more trustworthy than a malformed
+	// one. Keeping it a DISTINCT sentinel (matched separately with errors.Is) lets
+	// a test prove the read was refused by the SIZE bound BEFORE buffering the
+	// whole file, not merely by a JSON parse error after a full read.
+	errDDNSStateTooLarge = fmt.Errorf("ddns: ownership state file exceeds the maximum size: %w", errDDNSStateCorrupt)
 )
 
 // state.go (moved verbatim from pkg/dhcpserver/ddns_state.go in #2691 P1a):
@@ -334,6 +345,79 @@ type ddnsStateFile struct {
 
 const ddnsStateVersion = 1
 
+// The read bound below (#5571, CWE-770) caps how much of the durable ownership
+// file loadDDNSState will pull into memory BEFORE any JSON/version/semantic
+// validation runs. Without it a single os.ReadFile of a very large canonical
+// file — left by a prior crash, filesystem corruption, an administrative
+// restore, or a future producer defect — drives input-proportional heap growth,
+// GC pressure, or OOM during daemon STARTUP, exactly when the control plane must
+// recover, and BEFORE the fail-closed corruption posture can engage. The bound
+// is DERIVED (not a magic number) from the legitimate maximum ownership state:
+//
+//   maxDDNSStateBytes = maxDDNSStateRecords * maxDDNSStateRecordBytes + envelope
+//
+// so a legitimate store always loads while an oversized/corrupt one is refused
+// before it is buffered whole.
+
+// maxDDNSStateRecords is the generous legitimate ceiling on ownership records.
+// The store carries at most one record per DDNS-published DHCP lease (Surface B)
+// plus a handful of per-interface router records (Surface A), so its record
+// count tracks the DHCP lease count. 65,536 is one ENTIRE /16 subnet fully
+// leased with a DDNS record for every lease — already far beyond any realistic
+// vSRX-class DDNS deployment (production stores hold tens to low thousands). It
+// is the record-count anchor for the byte bound below, not an enforced count cap.
+const maxDDNSStateRecords = 1 << 16 // 65,536
+
+// maxDDNSStateRecordBytes is the generous per-record ceiling on the pretty-
+// printed (2-space-indented, the save() format) JSON of one ownedRecord. A
+// worst-case record with every optional field at its protocol maximum — FQDN
+// 253, PTR name ~255, DUID-hex client-id ~260, identity/subnet/owner-id, a
+// nested scope carrying its own 253-octet FQDN, the backend fingerprint — plus
+// all JSON keys and indentation serializes to ~1.5 KiB; 2 KiB carries ~33%
+// headroom so no legitimate record is ever over-counted.
+const maxDDNSStateRecordBytes = 2 << 10 // 2 KiB
+
+// maxDDNSStateBytes is the hard cap on the ownership file loadDDNSState will read
+// into memory (#5571). It is maxDDNSStateRecords * maxDDNSStateRecordBytes plus a
+// small envelope for the "version" field, the JSON array brackets, and top-level
+// indentation. A file larger than this cannot be a legitimate store, so it is
+// refused (classified errDDNSStateTooLarge -> fail-closed corrupt) before being
+// buffered — converting an unbounded, input-proportional allocation into a
+// bounded, constant one.
+const maxDDNSStateBytes = maxDDNSStateRecords*maxDDNSStateRecordBytes + 4<<10 // 128 MiB + 4 KiB
+
+// readBoundedStateFile reads the ownership store at path but REFUSES to buffer
+// more than maxDDNSStateBytes (#5571, CWE-770). It opens the file and stats it
+// first, rejecting an over-bound size BEFORE any allocation (so an arbitrarily
+// large — GiB/TiB — corrupt file costs one stat, not a full read). It then reads
+// through io.LimitReader(f, maxDDNSStateBytes+1) with a sentinel byte so a file
+// that GREW after the stat, or whose stat size is unreliable (a pipe / special
+// file), still cannot be buffered past the cap. An over-bound file returns an
+// error wrapping errDDNSStateTooLarge (which wraps errDDNSStateCorrupt) so the
+// caller fails closed and quarantines it exactly like an unparseable store. A
+// not-exist error is returned verbatim (wrapping os.ErrNotExist) so the caller
+// treats a missing file as a clean first-run empty store.
+func readBoundedStateFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err // includes os.ErrNotExist, classified by the caller
+	}
+	defer f.Close()
+	if fi, serr := f.Stat(); serr == nil && fi.Size() > maxDDNSStateBytes {
+		return nil, fmt.Errorf("ddns state %s size %d exceeds max %d bytes: %w",
+			path, fi.Size(), maxDDNSStateBytes, errDDNSStateTooLarge)
+	}
+	data, err := io.ReadAll(io.LimitReader(f, maxDDNSStateBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxDDNSStateBytes {
+		return nil, fmt.Errorf("ddns state %s exceeds max %d bytes: %w",
+			path, maxDDNSStateBytes, errDDNSStateTooLarge)
+	}
+	return data, nil
+}
+
 // loadDDNSState reads the ownership store from path. A missing file yields an
 // empty store (first run, error nil). A CORRUPT or UNKNOWN-VERSION file is
 // FAIL-CLOSED (#2650): the returned store is empty, but the returned error is
@@ -355,12 +439,28 @@ const ddnsStateVersion = 1
 // one — but it is NOT classified corrupt/unsupported (no quarantine: the bytes
 // may be fine and re-readable, so do not move the file out from under a transient
 // fault).
+//
+// The read is BOUNDED (#5571, CWE-770): an ownership file larger than
+// maxDDNSStateBytes is refused BEFORE it is buffered whole (via
+// readBoundedStateFile: an os.Stat pre-check plus an io.LimitReader sentinel) so
+// a very large / corrupt canonical file cannot drive input-proportional heap
+// growth or OOM during startup. Over-bound is classified errDDNSStateTooLarge —
+// which wraps errDDNSStateCorrupt — so it engages the SAME fail-closed quarantine
+// posture as an unparseable file.
 func loadDDNSState(path string) (*ddnsState, error) {
 	s := &ddnsState{path: path, records: map[string]ownedRecord{}}
-	data, err := os.ReadFile(path)
+	data, err := readBoundedStateFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return s, nil
+		}
+		// An over-bound file is classified corrupt (errDDNSStateTooLarge wraps
+		// errDDNSStateCorrupt) so the manager fails closed and quarantines it,
+		// exactly like an unparseable store — a huge/corrupt canonical file is no
+		// more trustworthy than a malformed one and must never be buffered whole
+		// or acted on. Return it unwrapped so the classification survives.
+		if errors.Is(err, errDDNSStateCorrupt) {
+			return s, err
 		}
 		return s, fmt.Errorf("read ddns state %s: %w", path, err)
 	}

--- a/pkg/ddns/state_readbound_5571_test.go
+++ b/pkg/ddns/state_readbound_5571_test.go
@@ -1,0 +1,138 @@
+package ddns
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeSparseOversizedState creates a SPARSE ownership file whose reported size
+// exceeds maxDDNSStateBytes without allocating that many real bytes: f.Truncate
+// extends the file with zero bytes that most filesystems (tmpfs/ext4 under
+// t.TempDir) keep unbacked. loadDDNSState's os.Stat pre-check must reject it by
+// SIZE before ever reading it — so this test costs a stat, not a 128 MiB read,
+// on the FIXED path. (Only a REVERT that restores the unbounded os.ReadFile would
+// pull the whole sparse file into memory, which is the vulnerability #5571 fixes.)
+func writeSparseOversizedState(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create sparse state: %v", err)
+	}
+	if err := f.Truncate(maxDDNSStateBytes + 1); err != nil {
+		f.Close()
+		t.Fatalf("truncate sparse state: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close sparse state: %v", err)
+	}
+	if fi, err := os.Stat(path); err != nil || fi.Size() != maxDDNSStateBytes+1 {
+		t.Fatalf("sparse state size = %v (err %v), want %d", fi, err, maxDDNSStateBytes+1)
+	}
+}
+
+// TestLoadDDNSStateRejectsOversizedFile is the #5571 (CWE-770) fail-on-revert
+// test: an ownership file larger than maxDDNSStateBytes must be REFUSED by the
+// size bound BEFORE it is buffered whole, and classified fail-closed corrupt so
+// the manager quarantines it and degrades rather than OOMing at startup.
+//
+// RED on revert: restore the unbounded `data, err := os.ReadFile(path)` (drop
+// readBoundedStateFile and the errDDNSStateCorrupt branch) and the whole sparse
+// file is read into memory; json.Unmarshal then fails, so the load is classified
+// errDDNSStateCorrupt but NOT errDDNSStateTooLarge — the errDDNSStateTooLarge
+// assertion below fails, proving the read was no longer bounded by size.
+func TestLoadDDNSStateRejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	writeSparseOversizedState(t, path)
+
+	s, err := loadDDNSState(path)
+	if err == nil {
+		t.Fatal("loadDDNSState accepted an oversized file; want a size-bound error")
+	}
+	// The over-bound file is refused by the SIZE bound (not by a downstream JSON
+	// parse error after a full read) — this is what distinguishes bounded from
+	// unbounded and gives the RED on revert.
+	if !errors.Is(err, errDDNSStateTooLarge) {
+		t.Fatalf("oversized file not refused by the size bound (errDDNSStateTooLarge): %v", err)
+	}
+	// It engages the SAME fail-closed classification as an unparseable/bad-version
+	// store, so loadStateOrDegrade quarantines it and marks the manager degraded.
+	if !errors.Is(err, errDDNSStateCorrupt) {
+		t.Fatalf("oversized error must wrap errDDNSStateCorrupt (fail-closed), got %v", err)
+	}
+	if s == nil || len(s.records) != 0 {
+		t.Fatalf("oversized load must return an empty store, got %+v", s)
+	}
+}
+
+// TestLoadStateOrDegradeOversizedFileFailsClosed proves the oversized file drives
+// the SAME startup fail-closed posture the loader uses for a corrupt file: the
+// manager is degraded, the bad file is quarantined aside (renamed to
+// <path>.corrupt-<stamp>, preserved for inspection), and a durable <path>.degraded
+// marker is written so a restart does not silently resume with ownership
+// forgotten. RED on revert: an unbounded read reads+parses the sparse zeros, which
+// is still corrupt, so degrade+quarantine still fire — but the loadDDNSState test
+// above is the load-bearing RED. This test pins the end-to-end posture.
+func TestLoadStateOrDegradeOversizedFileFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	writeSparseOversizedState(t, path)
+
+	fixed := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	st, degraded, reason := loadStateOrDegrade(path, func() time.Time { return fixed })
+	if !degraded {
+		t.Fatal("oversized ownership file must put the manager into the degraded (fail-closed) state")
+	}
+	if reason == "" {
+		t.Fatal("degraded reason must be populated for an oversized file")
+	}
+	if st == nil || len(st.records) != 0 {
+		t.Fatalf("oversized load must yield an empty store, got %+v", st)
+	}
+	// The oversized file is quarantined (renamed away), not left in place.
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("oversized file was not quarantined (still present at %s): %v", path, err)
+	}
+	stamp := fixed.UTC().Format("20060102T150405Z")
+	quarantined := path + ".corrupt-" + stamp
+	if _, err := os.Stat(quarantined); err != nil {
+		t.Fatalf("quarantined copy missing at %s: %v", quarantined, err)
+	}
+	// A durable degraded marker keeps the fail-closed posture across restart.
+	if _, err := os.Stat(path + degradedMarkerSuffix); err != nil {
+		t.Fatalf("durable degraded marker missing: %v", err)
+	}
+}
+
+// TestLoadDDNSStateAcceptsNormalSizedFile guards against a false positive: a
+// well-formed, normal-sized store must still load cleanly under the bound.
+func TestLoadDDNSStateAcceptsNormalSizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	good := `{"version":1,"records":[{"family":4,"identity":"mac:aa","address":"203.0.113.5",` +
+		`"fqdn":"host.example.net","forward_type":"A","ptr_name":"5.113.0.203.in-addr.arpa","ttl":300}]}`
+	if err := os.WriteFile(path, []byte(good), 0o644); err != nil {
+		t.Fatalf("write good state: %v", err)
+	}
+	s, err := loadDDNSState(path)
+	if err != nil {
+		t.Fatalf("loadDDNSState rejected a valid normal-sized store: %v", err)
+	}
+	if len(s.records) != 1 {
+		t.Fatalf("valid store: want 1 record, got %d", len(s.records))
+	}
+}
+
+// TestReadBoundedStateFileMissingIsNotExist pins that a missing file returns an
+// os.ErrNotExist-classified error (so loadDDNSState treats first boot as a clean
+// empty store, not a corrupt one).
+func TestReadBoundedStateFileMissingIsNotExist(t *testing.T) {
+	_, err := readBoundedStateFile(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing file must classify as os.ErrNotExist, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #5571

## Problem
`loadDDNSState` (`pkg/ddns/state.go`) read the entire durable ownership file via a single `os.ReadFile` **before any** JSON / version / semantic validation. A very large or corrupted canonical file — left by a prior crash, filesystem corruption, an administrative restore, or a future producer defect — drove input-proportional heap growth / GC pressure / OOM during daemon **startup**, exactly when the control plane must recover and **before** the fail-closed corruption posture could engage (CWE-770, unbounded resource consumption). A 16 MiB malformed file already allocated ~16 MiB before the parse error returned; an arbitrarily large file scaled without bound.

## Fix
Read through a new `readBoundedStateFile`:
- **`os.Stat` pre-check** rejects an over-bound size **before any allocation** — an arbitrarily large (GiB/TiB) corrupt file now costs one stat, not a full read.
- Then reads via `io.LimitReader(f, maxDDNSStateBytes+1)` with a **sentinel byte** so a file that grew after the stat, or whose stat size is unreliable (pipe / special file), still cannot be buffered past the cap.

This mirrors the existing `pkg/feeds` body-size guard (`io.LimitReader(r, maxFeedBodyBytes+1)`).

## Bound derivation (not a magic number)
`maxDDNSStateBytes = maxDDNSStateRecords * maxDDNSStateRecordBytes + JSON envelope` ≈ **128 MiB**:
- **`maxDDNSStateRecords = 65,536`** — one **entire /16 subnet fully leased** with a DDNS record per lease. The store holds at most one record per DDNS-published DHCP lease (Surface B) plus a handful of per-interface router records (Surface A), so its count tracks the DHCP lease count; 65,536 is far beyond any realistic vSRX-class deployment (production stores hold tens to low thousands).
- **`maxDDNSStateRecordBytes = 2 KiB`** — a worst-case pretty-printed `ownedRecord` with every optional field at its protocol maximum (FQDN 253, PTR name ~255, DUID-hex client-id ~260, identity/subnet/owner-id, a nested scope carrying its own 253-octet FQDN, backend fingerprint) is ~1.5 KiB; 2 KiB carries ~33% headroom so no legitimate record is over-counted.

A file above this cannot be a legitimate store.

## Fail-closed handling (mirrors existing corruption posture)
An over-bound file is classified **`errDDNSStateTooLarge`**, which **wraps `errDDNSStateCorrupt`** (`pkg/ddns/state.go`). So `loadStateOrDegrade` (`pkg/ddns/manager.go`) engages the **same** posture it already uses for an unparseable / bad-version file: return an empty store, mark the manager degraded, **quarantine** the bad file aside (`<path>.corrupt-<stamp>`), and write the durable **`<path>.degraded`** marker — keeping publish/withdraw suspended across restart until the operator resolves it. A missing file still yields a clean first-run empty store; a normal-sized valid file still loads.

## Validation
- `GOCACHE=… go build ./...` and `go test ./pkg/ddns/...` **green**; `gofmt` clean.
- **Fail-on-revert test** (`pkg/ddns/state_readbound_5571_test.go`): a **sparse** file reporting `maxDDNSStateBytes+1` (via `Truncate`, no real 128 MiB write) is refused by the size bound (`errors.Is errDDNSStateTooLarge`) with an empty store; `loadStateOrDegrade` degrades + quarantines it + writes the durable marker; a normal file still loads; a missing file classifies `os.ErrNotExist`.
- **RED-on-revert verified**: restoring the unbounded `os.ReadFile` reads the whole sparse file, `json.Unmarshal` then fails on `'\x00'`, so the load is classified `errDDNSStateCorrupt` but **not** `errDDNSStateTooLarge` → the size-bound assertion fails, proving the read is no longer bounded by size.
- Updated `pkg/ddns/README.md` with the size-bound contract.