### PR TITLE
config/frr: validate route-filter slots positionally (#5576)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46040,3 +46040,25 @@ top.
   Updated pkg/ddns/README.md size-bound contract. RED-on-revert verified.
   **File(s)**: pkg/ddns/state.go, pkg/ddns/state_readbound_5571_test.go,
   pkg/ddns/README.md, _Log.md
+
+- **Timestamp**: 2026-07-11 02:55
+  **Action**: #5576 — route-filter validator made POSITION-AWARE. The args:2
+  `from route-filter <prefix> <match-type>` key validator was
+  position-agnostic (accepted the union of CIDRs and match-type keywords in
+  either slot), so `route-filter longer exact` committed with the keyword
+  `longer` in the CIDR slot; the FRR renderer's malformed-prefix belt then
+  emitted no prefix-list entry but kept the route-map match → a match-none
+  policy (silent false-deny). Added `PositionalKeyValidator` type +
+  `keyValidatorPos` schemaNode field + `validateKeySlot` walker helper
+  (both the packed-Keys and peeled nested-name paths thread the 0-based arg
+  index). Replaced `ValidateRouteFilterArg` with
+  `ValidateRouteFilterArgPositional` (slot 0 = CIDR, slot 1 = match-type
+  keyword). Added fail-on-revert tests (config + frr) and doc updates.
+  RED-on-revert verified (position-agnostic revert → swapped/keyword-in-CIDR
+  forms commit clean → test fails). Gates: build + vet + config/frr/
+  configstore/cmdtree tests green.
+  **File(s)**: pkg/config/schema.go, pkg/config/schema_walk.go,
+  pkg/config/schema_validators.go, pkg/config/schema_validators_routing.go,
+  pkg/config/schema_routing.go, pkg/config/schema_validate_route_filter_test.go,
+  pkg/frr/policy_render.go, pkg/frr/policy_route_filter_matchnone_5576_test.go,
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1810,6 +1810,22 @@ compiler reads via `routeFilterTrailingToken`. Proven by
 `TestPolicyTermMultiMatch_Hierarchical_2642`
 (`compiler_policy_term_multimatch_2642_test.go`).
 
+The two `route-filter` slots are validated **positionally** (#5576) via a
+`keyValidatorPos` (the position-aware sibling of `keyValidator`, see "Typed
+KEY slots" below): arg 0 (the prefix slot) must parse as a CIDR and arg 1
+(the match-type slot) must be one of `exact`/`longer`/`orlonger`/`upto`/
+`prefix-length-range`/`through`. Before #5576 the key validator was
+position-AGNOSTIC — it accepted the UNION of CIDRs and match-type keywords in
+EITHER slot, so `route-filter longer exact` committed with the keyword
+`longer` in the CIDR slot. The FRR renderer's malformed-prefix belt
+(`net.ParseCIDR("longer")` fails → `renderRouteFilterEntry` emits no
+prefix-list line) then produced an EMPTY prefix-list while the route-map
+retained its `match ip address prefix-list` reference — a **match-none**
+policy that silently dropped every route the term was authored to accept (a
+false-deny). Proven by `TestSchemaValidate_RouteFilter_PositionAware`
+(`schema_validate_route_filter_test.go`) and
+`TestRouteFilterMatchNoneFalseDeny_5576` (`pkg/frr`).
+
 ## Repeated definition blocks merge (prefix-list, community)
 
 A named policy-options DEFINITION can be authored across multiple separate
@@ -2111,7 +2127,14 @@ Rules:
   instead: the walker validates the identity arg token(s) in both the
   packed-Keys and the nested instance-name shapes (both of which
   `namedInstances` compiles), and `?` completion surfaces the key
-  placeholder + examples at the empty identity slot.
+  placeholder + examples at the empty identity slot. For a **multi-arg key
+  slot whose positions carry DISTINCT grammars** (`route-filter <prefix>
+  <match-type>`, args:2), set `keyValidatorPos` (the position-aware sibling of
+  `keyValidator`) instead: the walker passes each token's 0-based arg index
+  so slot 0 and slot 1 can be validated with different rules, closing the
+  #5576 "keyword accepted in the CIDR slot → match-none false-deny" hole. A
+  node sets EITHER `keyValidator` OR `keyValidatorPos`; both are honored in
+  the packed-Keys path AND the peeled nested-name path (`validateKeySlot`).
 - **Multi value-tail leaves accept the block-list spelling.** A
   `multi && children == nil` typed leaf is compiled from BOTH the packed
   Keys (`name-server 1.1.1.1`, ranges with the `to` separator) and the

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -165,6 +165,22 @@ type schemaNode struct {
 	keyValueDesc     string        // one-line key-slot description for `?` help
 	keyValueExamples []string      // illustrative key values surfaced in `?` help
 	keyValidator     LeafValidator // commit-check validator for identity arg tokens
+
+	// keyValidatorPos is the POSITION-AWARE alternative to keyValidator
+	// (#5576). When set, the walker validates each identity arg token with
+	// its 0-based arg index instead of the position-AGNOSTIC keyValidator,
+	// so a multi-arg key slot (args >= 2) can enforce a DISTINCT grammar
+	// per position. A node sets EITHER keyValidator OR keyValidatorPos,
+	// never both. route-filter (`from route-filter <prefix> <match-type>`,
+	// args:2) uses it: arg 0 (the prefix slot) must be a CIDR and arg 1
+	// (the match-type slot) must be a supported match-type keyword. The
+	// prior position-agnostic keyValidator accepted the union of CIDRs and
+	// match-type keywords in EITHER slot, so `route-filter longer exact`
+	// committed with the match keyword `longer` in the CIDR slot; the FRR
+	// renderer's malformed-prefix belt then emitted no prefix-list entry
+	// but kept the route-map match reference, turning an authored accept
+	// into an operational match-none (a silent false-deny).
+	keyValidatorPos PositionalKeyValidator
 }
 
 // isTypedLeaf reports whether the node carries typed-value metadata

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -190,7 +190,7 @@ var schemaPolicyOptions = &schemaNode{desc: "Policy options", children: map[stri
 				// arg lands as a fourth packed key via the multi value-tail
 				// absorber, matching the brace AST the compiler already reads.
 				"prefix-list":  {desc: "Prefix list", args: 1, multi: true, placeholder: "<list-name>", children: nil},
-				"route-filter": {desc: "Route filter", args: 2, multi: true, placeholder: "<prefix>", keyValidator: ValidateRouteFilterArg, children: nil},
+				"route-filter": {desc: "Route filter", args: 2, multi: true, placeholder: "<prefix>", keyValidatorPos: ValidateRouteFilterArgPositional, children: nil},
 				"community":    {desc: "Community", args: 1, multi: true, placeholder: "<community>", children: nil},
 				"as-path":      {desc: "AS path", args: 1, multi: true, placeholder: "<name>", children: nil},
 			}},

--- a/pkg/config/schema_validate_route_filter_test.go
+++ b/pkg/config/schema_validate_route_filter_test.go
@@ -1,11 +1,15 @@
 package config_test
 
-// #2105 — commit-time CIDR validation for the policy-options
-// route-filter prefix slot. The `from route-filter <prefix>
-// <match-type>` schema node is args:2, so its keyValidator
-// (ValidateRouteFilterArg) runs on BOTH the prefix token and the
-// match-type token; it must accept a valid CIDR (prefix slot) OR a
-// match-type keyword (match-type slot), and reject a malformed prefix.
+// #2105 / #5576 — commit-time POSITION-AWARE validation for the
+// policy-options route-filter slots. The `from route-filter <prefix>
+// <match-type>` schema node is args:2 and uses a position-aware key
+// validator (ValidateRouteFilterArgPositional): arg 0 (the prefix slot)
+// must be a CIDR and arg 1 (the match-type slot) must be a supported
+// match-type keyword. A match-type keyword in the CIDR slot, a CIDR in
+// the match-type slot, or a malformed prefix is REJECTED at commit — the
+// pre-#5576 position-agnostic validator accepted the union in either
+// slot, so `route-filter longer exact` committed as a match-none policy
+// (silent false-deny).
 //
 // Tests exercise both AST shapes: the flat-set path (ParseSetCommand +
 // SetPath, via flatSchemaCheck) — the project-mandated route for flat
@@ -128,5 +132,74 @@ func TestSchemaValidate_RouteFilter_UptoLengthNotRejected(t *testing.T) {
 	// and NOT a match-type keyword → rejected.
 	if err := flatSchemaCheck(t, rfSetPrefix+"24 exact"); err == nil {
 		t.Error("a bare length token in the prefix slot must be rejected, got nil")
+	}
+}
+
+// TestSchemaValidate_RouteFilter_PositionAware is the #5576 fail-on-revert
+// guard. The validator is POSITION-AWARE, so a match-type keyword in the
+// PREFIX (CIDR) slot — or a CIDR in the match-type slot — is REJECTED at
+// commit rather than committed as a match-none policy (a silent
+// false-deny). Before #5576 the validator accepted the union of CIDRs and
+// match-type keywords in EITHER slot, so `route-filter longer exact`
+// committed with `longer` in the CIDR slot; the FRR renderer then emitted
+// no prefix-list entry but kept the route-map match, turning an authored
+// accept into an operational match-none. Reverting the positional split
+// makes the swapped/keyword-in-CIDR-slot forms commit clean again → this
+// test fails RED.
+func TestSchemaValidate_RouteFilter_PositionAware(t *testing.T) {
+	// Each of these committed cleanly before #5576 (position-agnostic) and
+	// rendered a match-none policy; they must now be rejected at commit.
+	reject := []string{
+		rfSetPrefix + "longer exact",            // match keyword in the CIDR slot (the #5576 bug)
+		rfSetPrefix + "exact longer",            // two keywords, none a CIDR
+		rfSetPrefix + "orlonger orlonger",       // keyword in both slots
+		rfSetPrefix + "10.0.0.0/24 10.0.0.0/24", // CIDR in the match-type slot
+		rfSetPrefix + "10.0.0.0/24 bogus",       // valid CIDR, but slot 2 is not a match-type
+	}
+	for _, cmd := range reject {
+		err := flatSchemaCheck(t, cmd)
+		if err == nil {
+			t.Errorf("flat reject %q: expected commit-check error, got nil", cmd)
+			continue
+		}
+		if !strings.Contains(err.Error(), "route-filter") {
+			t.Errorf("flat reject %q: error should reference route-filter: %v", cmd, err)
+		}
+	}
+
+	// The keyword-in-CIDR-slot form must reject in the hierarchical shape too.
+	err := schemaCheck(t, `policy-options {
+    policy-statement P {
+        term T {
+            from {
+                route-filter longer exact;
+            }
+            then accept;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("#5576: hierarchical `route-filter longer exact` (keyword in CIDR slot) must be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "route-filter") {
+		t.Errorf("hierarchical reject error should reference route-filter: %v", err)
+	}
+
+	// Every LEGITIMATE positional form still commits: bare CIDR + each
+	// match-type, and the arg-carrying upto / prefix-length-range / through.
+	accept := []string{
+		rfSetPrefix + "10.0.0.0/24 exact",
+		rfSetPrefix + "10.0.0.0/24 longer",
+		rfSetPrefix + "10.0.0.0/24 orlonger",
+		rfSetPrefix + "10.0.0.0/8 upto /24",
+		rfSetPrefix + "10.0.0.0/8 prefix-length-range /16-/24",
+		rfSetPrefix + "10.0.0.0/8 through 10.1.0.0/16",
+		rfSetPrefix + "2001:db8::/32 orlonger",
+		rfSetPrefix + "2001:db8::/32 upto /48",
+	}
+	for _, cmd := range accept {
+		if err := flatSchemaCheck(t, cmd); err != nil {
+			t.Errorf("flat accept %q: unexpected error: %v", cmd, err)
+		}
 	}
 }

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -27,6 +27,16 @@ import (
 // import cycle.
 type LeafValidator func(raw string, cfg *Config) error
 
+// PositionalKeyValidator is the POSITION-AWARE variant of LeafValidator
+// used for a named-instance key slot with more than one identity arg
+// (#5576). The walker passes the 0-based arg index of each identity
+// token so a node whose args are POSITIONAL (each slot has a distinct
+// grammar) can validate them per-position instead of accepting the
+// union in every slot. route-filter (`from route-filter <prefix>
+// <match-type>`) is the motivating case: arg 0 must be a CIDR and arg 1
+// must be a supported match-type keyword.
+type PositionalKeyValidator func(argIdx int, raw string, cfg *Config) error
+
 // validateEnum returns a closure that accepts only one of the listed
 // names (case-sensitive, exact match).
 func ValidateEnum(allowed []string) LeafValidator {

--- a/pkg/config/schema_validators_routing.go
+++ b/pkg/config/schema_validators_routing.go
@@ -32,11 +32,13 @@ func ValidateBGPHoldTime(raw string, _ *Config) error {
 	return nil
 }
 
-// routeFilterMatchTypes are the match-type keywords accepted in a
-// `from route-filter <prefix> <match-type>` node. The schema node is
-// args:2, so the walker invokes ValidateRouteFilterArg for BOTH identity
-// tokens (the prefix AND the match-type — Keys[1:3]); the validator must
-// therefore accept a match-type keyword as well as a CIDR prefix.
+// routeFilterMatchTypes are the match-type keywords accepted in the
+// SECOND slot of a `from route-filter <prefix> <match-type>` node. The
+// schema node is args:2 and uses a POSITION-AWARE key validator
+// (ValidateRouteFilterArgPositional, #5576): arg 0 is the prefix slot
+// (must be a CIDR) and arg 1 is the match-type slot (must be one of
+// these keywords). A match-type keyword is NOT accepted in the prefix
+// slot — that was the #5576 silent-false-deny bug.
 //
 // exact/longer/orlonger/upto/prefix-length-range are the rendered
 // match-types (pkg/frr policy_render.go). `through` is ADMITTED as a
@@ -58,19 +60,30 @@ var routeFilterMatchTypes = map[string]bool{
 	"through":             true,
 }
 
-// ValidateRouteFilterArg is the #2105 commit-check validator for a
-// `policy-options policy-statement <p> term <t> from route-filter
-// <prefix> <match-type>` identity arg token. The node is args:2, so the
-// walker (schema_walk.go) calls this for the prefix token AND the
-// match-type token. The `upto /N` length token lands as a CHILD of the
-// route-filter node, never in Keys[1:3], so it does not reach here.
+// ValidateRouteFilterArgPositional is the #2105 + #5576 POSITION-AWARE
+// commit-check validator for a `policy-options policy-statement <p> term
+// <t> from route-filter <prefix> <match-type>` identity arg token. The
+// node is args:2, so the walker (schema_walk.go) calls this once for the
+// prefix token (argIdx 0) and once for the match-type token (argIdx 1).
+// The `upto /N` length token lands as a CHILD of the route-filter node
+// (or a fourth packed key past the args:2 span), never in the validated
+// Keys[1:3], so it does not reach here.
 //
-// A token is accepted when it is either a match-type keyword OR a
-// syntactically valid CIDR prefix (v4 or v6 — route-filter is
-// family-agnostic). A malformed prefix (no "/", non-numeric mask, or an
-// out-of-range mask) that is neither is REJECTED, so it never reaches
-// the FRR renderer where it would produce an FRR-invalid prefix-list
-// line and could fail the whole managed frr-reload.
+//   - argIdx 0 (prefix slot): MUST be a syntactically valid CIDR (v4 or
+//     v6 — route-filter is family-agnostic). A match-type keyword here is
+//     REJECTED: `route-filter longer exact` puts `longer` in the CIDR
+//     slot, which the FRR renderer's malformed-prefix belt then swallows
+//     into a match-none policy (a silent false-deny). A malformed prefix
+//     (no "/", non-numeric mask, out-of-range mask) is likewise rejected
+//     so it never reaches the renderer as an FRR-invalid prefix-list line.
+//
+//   - argIdx 1 (match-type slot): MUST be a supported match-type keyword
+//     (routeFilterMatchTypes). A CIDR or any other token here is REJECTED.
+//
+// The #5576 fix is the per-position split: the prior position-AGNOSTIC
+// validator accepted the UNION (a CIDR OR a keyword) in EITHER slot, so a
+// swapped or keyword-in-prefix-slot form committed clean and rendered a
+// match-none policy.
 //
 // Strictness is automatic: SchemaValidate is strict on the operator
 // commit / commit-check path and lenient (warn, not fail) on Store.Load
@@ -78,31 +91,34 @@ var routeFilterMatchTypes = map[string]bool{
 // prefix persisted by an older binary never blackouts boot. The renderer
 // carries a belt-and-suspenders skip for any malformed prefix that
 // reaches it via that lenient path.
-//
-// Known limitation: the validator is position-agnostic (the walker does
-// not tell it which slot a token came from), so a match-type keyword in
-// the prefix slot (e.g. `route-filter longer exact`) is accepted. This
-// is strictly better than the pre-#2105 state (any garbage committed)
-// and catches the real malformed-CIDR case; per-position validation
-// would require schema restructuring and is deferred.
-func ValidateRouteFilterArg(raw string, _ *Config) error {
+func ValidateRouteFilterArgPositional(argIdx int, raw string, _ *Config) error {
 	tok := strings.TrimSpace(raw)
-	if tok == "" {
-		return fmt.Errorf("missing route-filter prefix (expected CIDR, e.g. 10.0.0.0/24)")
+	if argIdx == 0 {
+		// Prefix slot — a CIDR, never a match-type keyword.
+		if tok == "" {
+			return fmt.Errorf("missing route-filter prefix (expected CIDR, e.g. 10.0.0.0/24)")
+		}
+		if routeFilterMatchTypes[tok] {
+			return fmt.Errorf("match-type keyword %q in the prefix slot; the FIRST route-filter token must be a CIDR (e.g. 10.0.0.0/24 or 2001:db8::/32) and the match-type must follow it (e.g. `route-filter 10.0.0.0/24 %s`)", tok, tok)
+		}
+		// Family-agnostic CIDR. parseCIDRStrict requires a /prefix-length
+		// and upgrades the common operator mistakes (bare IP, garbage) to
+		// targeted messages, matching the ValidateIPv4CIDR/ValidateIPv6CIDR
+		// convention; the returned IP is discarded because both families are
+		// valid here. Surface parseCIDRStrict's targeted message (e.g.
+		// "missing /prefix-length") so the commit-check failure is actionable.
+		if _, err := parseCIDRStrict(tok, "10.0.0.0/24"); err != nil {
+			return fmt.Errorf("not a valid route-filter prefix (expected a CIDR, e.g. 10.0.0.0/24 or 2001:db8::/32): %v", err)
+		}
+		return nil
 	}
+	// Match-type slot (argIdx >= 1) — a supported keyword, never a CIDR.
+	// The walker only reaches this when a token is actually present (the
+	// args:2 span caps at len(Keys)), so an empty tok cannot occur here.
 	if routeFilterMatchTypes[tok] {
 		return nil
 	}
-	// Family-agnostic CIDR. parseCIDRStrict requires a /prefix-length
-	// and upgrades the common operator mistakes (bare IP, garbage) to
-	// targeted messages, matching the ValidateIPv4CIDR/ValidateIPv6CIDR
-	// convention; the returned IP is discarded because both families are
-	// valid here. Surface parseCIDRStrict's targeted message (e.g.
-	// "missing /prefix-length") so the commit-check failure is actionable.
-	if _, err := parseCIDRStrict(tok, "10.0.0.0/24"); err != nil {
-		return fmt.Errorf("not a valid route-filter prefix (expected a CIDR, e.g. 10.0.0.0/24 or 2001:db8::/32, or a match-type keyword): %v", err)
-	}
-	return nil
+	return fmt.Errorf("not a valid route-filter match-type %q (expected one of: exact, longer, orlonger, upto, prefix-length-range, through)", tok)
 }
 
 // ValidateRouteDestination accepts a static-route destination prefix: a

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -395,15 +395,18 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 	// node's Keys (e.g. the 10.0.1.10/24 in `address 10.0.1.10/24 {
 	// primary; }`). Only the declared arg span is validated — a compound
 	// sub-token is a keyword, not a value, and tokens past the identity
-	// are ignored per the compiler-faithful contract.
-	if childSchema.keyValidator != nil {
+	// are ignored per the compiler-faithful contract. A POSITION-AWARE
+	// keyValidatorPos (#5576, route-filter) takes precedence and receives
+	// each token's 0-based arg index so a multi-arg slot can enforce a
+	// distinct grammar per position (prefix slot vs match-type slot).
+	if childSchema.keyValidatorPos != nil || childSchema.keyValidator != nil {
 		argEnd := declaredKeyTokens
 		if argEnd > len(node.Keys) {
 			argEnd = len(node.Keys)
 		}
 		keyPath := append(append([]string(nil), path...), keyword)
-		for _, tok := range node.Keys[1:argEnd] {
-			if err := childSchema.keyValidator(tok, vc.config()); err != nil {
+		for argIdx, tok := range node.Keys[1:argEnd] {
+			if err := validateKeySlot(childSchema, argIdx, tok, vc); err != nil {
 				return typedLeafInvalidErrorf(keyPath, tok, err)
 			}
 		}
@@ -424,8 +427,13 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 
 	missingArgs := declaredKeyTokens - consumed
 	if missingArgs > 0 && !childSchema.compoundKey {
+		// The already-consumed identity tokens are Keys[1:consumed]; the
+		// name levels peeled below supply args starting at 0-based index
+		// consumed-1 (arg 0 == Keys[1]). Thread that base so a
+		// position-aware keyValidatorPos sees the correct slot (#5576).
+		baseArgIdx := consumed - 1
 		for _, c := range node.Children {
-			if err := walkInstanceChildren(c, childSchema, missingArgs, newPath, vc, childClosed); err != nil {
+			if err := walkInstanceChildren(c, childSchema, missingArgs, baseArgIdx, newPath, vc, childClosed); err != nil {
 				return err
 			}
 		}
@@ -442,7 +450,7 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 // Keys; the leaves are the node's CHILDREN. Any extra tokens packed into the
 // instance node's Keys beyond the name are ignored (the compiler does not
 // compile them; see walkSchemaNode's container comment, Codex r7).
-func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int, path []string, vc *walkContext, closed bool) error {
+func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining, baseArgIdx int, path []string, vc *walkContext, closed bool) error {
 	if node == nil || len(node.Keys) == 0 {
 		return nil
 	}
@@ -452,10 +460,12 @@ func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int
 	}
 	// Typed KEY slot (#1319 PR 3): the peeled tokens ARE the instance
 	// name the compiler reads (namedInstances handles this nested shape
-	// too), so a key-typed container validates them here as well.
-	if containerSchema.keyValidator != nil {
-		for _, tok := range node.Keys[:consume] {
-			if err := containerSchema.keyValidator(tok, vc.config()); err != nil {
+	// too), so a key-typed container validates them here as well. A
+	// position-aware keyValidatorPos (#5576) takes precedence; baseArgIdx
+	// is the 0-based arg index of node.Keys[0] in this peel.
+	if containerSchema.keyValidatorPos != nil || containerSchema.keyValidator != nil {
+		for i, tok := range node.Keys[:consume] {
+			if err := validateKeySlot(containerSchema, baseArgIdx+i, tok, vc); err != nil {
 				return typedLeafInvalidErrorf(path, tok, err)
 			}
 		}
@@ -466,7 +476,7 @@ func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int
 		// inherited unchanged: containerSchema.closedWorld was already folded
 		// into it by the caller in walkSchemaNode (#4313).
 		for _, c := range node.Children {
-			if err := walkInstanceChildren(c, containerSchema, stillMissing, newPath, vc, closed); err != nil {
+			if err := walkInstanceChildren(c, containerSchema, stillMissing, baseArgIdx+consume, newPath, vc, closed); err != nil {
 				return err
 			}
 		}
@@ -475,6 +485,19 @@ func walkInstanceChildren(node *Node, containerSchema *schemaNode, remaining int
 	// Name fully consumed. The instance's leaves are its block children;
 	// any leftover Keys past the name are not compiled and are ignored.
 	return walkSchemaChildren(node.Children, containerSchema, newPath, vc, closed)
+}
+
+// validateKeySlot runs a named-instance container's identity-arg
+// validator on one token. It prefers the POSITION-AWARE keyValidatorPos
+// (#5576) — passing argIdx, the token's 0-based position within the
+// node's declared arg span — and falls back to the position-agnostic
+// keyValidator when only that is set. A node sets at most one of the two;
+// callers invoke this only when at least one is non-nil.
+func validateKeySlot(schema *schemaNode, argIdx int, tok string, vc *walkContext) error {
+	if schema.keyValidatorPos != nil {
+		return schema.keyValidatorPos(argIdx, tok, vc.config())
+	}
+	return schema.keyValidator(tok, vc.config())
 }
 
 // validateModifierChild validates one AST child of a typed leaf (e.g.

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -1357,13 +1357,15 @@ func renderRouteFilterEntry(b *strings.Builder, plName string, idx int, rf *conf
 	// line. Set by the #2103 max-length "longer" guard and the #2105
 	// malformed-prefix belt below.
 	skipEntry := false
-	// #2105 render-side belt-and-suspenders: a malformed prefix must
-	// NEVER reach an FRR line. The commit-time keyValidator
-	// (ValidateRouteFilterArg) rejects these on the strict path, but the
-	// lenient-on-load path (Store.Load / SyncApply, #1960) can still feed
-	// a stored pre-gate garbage prefix to the renderer. Use the SAME
-	// net.ParseCIDR check as the commit validator so the belt's coverage
-	// matches it exactly.
+	// #2105/#5576 render-side belt-and-suspenders: a malformed prefix must
+	// NEVER reach an FRR line. The commit-time key validator
+	// (ValidateRouteFilterArgPositional) rejects these on the strict path
+	// — including a match-type keyword mistakenly placed in the prefix
+	// slot (`route-filter longer exact`, #5576) — but the lenient-on-load
+	// path (Store.Load / SyncApply, #1960) can still feed a stored
+	// pre-gate garbage prefix to the renderer. Use the SAME net.ParseCIDR
+	// check as the commit validator so the belt's coverage matches it
+	// exactly.
 	if _, _, err := net.ParseCIDR(rf.Prefix); err != nil {
 		skipEntry = true
 	}

--- a/pkg/frr/policy_route_filter_matchnone_5576_test.go
+++ b/pkg/frr/policy_route_filter_matchnone_5576_test.go
@@ -1,0 +1,66 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// rf5576PolicyOptions builds a one-statement / one-term export policy
+// carrying a single route-filter whose Prefix and MatchType are supplied
+// verbatim, so a test can feed the #5576 keyword-in-CIDR-slot shape
+// (Prefix:"longer") the compiler produces from `route-filter longer
+// exact`, as well as a legitimate form.
+func rf5576PolicyOptions(prefix, matchType string) *config.PolicyOptionsConfig {
+	return &config.PolicyOptionsConfig{
+		PrefixLists: map[string]*config.PrefixList{},
+		Communities: map[string]*config.CommunityDef{},
+		ASPaths:     map[string]*config.ASPathDef{},
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"EXPORT": {
+				Name: "EXPORT",
+				Terms: []*config.PolicyTerm{
+					{
+						Name:         "t1",
+						RouteFilters: []*config.RouteFilter{{Prefix: prefix, MatchType: matchType}},
+						Action:       "accept",
+					},
+				},
+				DefaultAction: "reject",
+			},
+		},
+	}
+}
+
+// TestRouteFilterMatchNoneFalseDeny_5576 documents WHY the #5576 commit-time
+// rejection matters. If a match-type keyword reaches the renderer in the
+// prefix slot (`route-filter longer exact` → Prefix="longer",
+// MatchType="exact"), net.ParseCIDR("longer") fails, so the malformed-prefix
+// belt emits NO prefix-list entry — yet the route-map still carries `match
+// ip address prefix-list EXPORT-t1` against the now-EMPTY list. That is an
+// operational match-none: the term's authored `accept` matches nothing (a
+// silent false-deny). The positional commit validator
+// (ValidateRouteFilterArgPositional) rejects this at commit; this render
+// test locks the fail-closed belt that still guards the tolerant load /
+// peer-sync path, and confirms the legitimate form renders its entry.
+func TestRouteFilterMatchNoneFalseDeny_5576(t *testing.T) {
+	// (a) keyword-in-CIDR-slot renders match-none: no prefix-list entry.
+	bad := New().generatePolicyOptions(rf5576PolicyOptions("longer", "exact"))
+	if strings.Contains(bad, "permit longer") {
+		t.Errorf("#5576: malformed prefix `longer` must NOT render a prefix-list line, got:\n%s", bad)
+	}
+	if strings.Contains(bad, "prefix-list EXPORT-t1 seq") {
+		t.Errorf("#5576: no seq entry may exist for the match-none list, got:\n%s", bad)
+	}
+
+	// (b) the legitimate form renders the correct prefix-list entry AND
+	// keeps the route-map match reference.
+	good := New().generatePolicyOptions(rf5576PolicyOptions("10.0.0.0/24", "exact"))
+	if !strings.Contains(good, "ip prefix-list EXPORT-t1 seq 5 permit 10.0.0.0/24\n") {
+		t.Errorf("#5576: legitimate `10.0.0.0/24 exact` must render its prefix-list entry, got:\n%s", good)
+	}
+	if !strings.Contains(good, "match ip address prefix-list EXPORT-t1") {
+		t.Errorf("#5576: legitimate form must keep the route-map match, got:\n%s", good)
+	}
+}


### PR DESCRIPTION
Closes #5576

## Problem
`from route-filter <prefix> <match-type>` is an `args:2` schema node whose single key validator (`ValidateRouteFilterArg`) ran on **both** identity tokens without knowing which slot each came from. It accepted the **union** of CIDRs and match-type keywords, so a match keyword in the CIDR slot — `route-filter longer exact` — committed clean.

The FRR renderer then swallowed the malformed prefix: `net.ParseCIDR("longer")` fails, so `renderRouteFilterEntry` emits **no** prefix-list line, yet the route-map keeps its `match ip address prefix-list …` reference against the now-empty list → a **match-none** policy. The term's authored `accept` matches nothing, silently denying every route it was meant to permit (a false-deny on BGP import/export/redistribution — withdrawn reachability / suppressed advertisements, no commit-time diagnostic).

## Fix
Make the key validator **position-aware**:
- New `PositionalKeyValidator` type + `keyValidatorPos` `schemaNode` field (the position-aware sibling of `keyValidator`).
- The walker threads each identity token's 0-based arg index through a new `validateKeySlot` helper, in **both** the packed-Keys path (`walkSchemaNode`) and the peeled nested-name path (`walkInstanceChildren`).
- `route-filter` switches to `ValidateRouteFilterArgPositional`: **slot 0 must be a CIDR** (a match-type keyword here is now rejected with an actionable message), **slot 1 must be a supported match-type keyword** (a CIDR here is rejected).
- Every other key-typed node keeps the position-agnostic `keyValidator` unchanged.

The renderer's #2105 malformed-prefix belt is untouched and still fail-closes the tolerant load / peer-sync path.

## Legitimate forms preserved
- bare CIDR + `exact` / `longer` / `orlonger`
- `<cidr> upto /N`
- `<cidr> prefix-length-range /lo-/hi`
- `<cidr> through <cidr2>`
- IPv4 and IPv6

(the trailing length/range/prefix arg still lands past the validated `args:2` span, exactly as before).

## Now rejected at commit (previously committed as match-none)
- `route-filter longer exact` (keyword in the CIDR slot — the reported bug)
- `route-filter exact longer` / `orlonger orlonger` (keywords in both slots)
- `route-filter 10.0.0.0/24 10.0.0.0/24` (CIDR in the match-type slot)
- `route-filter 10.0.0.0/24 bogus` (unknown match-type)

## Validation
- `TestSchemaValidate_RouteFilter_PositionAware` (`pkg/config`) — flat + brace reject of keyword-in-CIDR-slot / swapped-slot forms; accept of every legitimate form.
- `TestRouteFilterMatchNoneFalseDeny_5576` (`pkg/frr`) — renders match-none for `longer/exact`, the correct prefix-list entry + route-map match for `10.0.0.0/24 exact`.
- **RED-on-revert verified**: restoring the position-agnostic validator makes the swapped/keyword-in-CIDR-slot forms commit clean and the test fails on exactly those cases.
- `go build ./...`, `go vet`, and `pkg/config` / `pkg/frr` / `pkg/configstore` / `pkg/cmdtree` tests green.
- `docs/config-schema.md` updated (route-filter positional contract + `keyValidatorPos` in the "Typed KEY slots" section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)