### PR TITLE
host-inbound: scope junos-host IKE/ident shield per interface (#5565)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46040,3 +46040,20 @@ top.
   Updated pkg/ddns/README.md size-bound contract. RED-on-revert verified.
   **File(s)**: pkg/ddns/state.go, pkg/ddns/state_readbound_5571_test.go,
   pkg/ddns/README.md, _Log.md
+
+- **Timestamp**: 2026-07-11
+  **Action**: #5565 host-inbound — scope the fine junos-host IKE/ident
+  exemption shield to the SPECIFIC interfaces that configured it, not the
+  whole zone. Previously a per-interface `ike`/`ident-reset` override was
+  unioned into a single zone-wide `CoarseAdmitsIKE`/`CoarseIdentResets` bit
+  and emitted across the zone's whole iifname set, falsely admitting IKE /
+  RSTing ident on sibling interfaces. Added `IKEExemptNetdevs`/
+  `IdentResetNetdevs` (subsets of IngressNetdevs) computed per effective
+  interface view; the daemon scopes each shield to its subset. Zone-level
+  exceptions still cover every interface (subset == IngressNetdevs). The
+  zone-wide `application any` DROP is unchanged. Added RED-on-revert daemon
+  tests + updated docs/host-inbound-service-matrix.md.
+  **File(s)**: pkg/config/junos_host_deny.go,
+  pkg/dataplane/userspace/junos_host_deny.go, pkg/daemon/daemon_nft.go,
+  pkg/daemon/host_inbound_junos_host_iface_scope_5565_test.go,
+  docs/host-inbound-service-matrix.md, _Log.md

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -620,9 +620,26 @@ helper never sees it, so a helper crash cannot lock management out).
   BEFORE the ND/PMTUD accepts and the residual full established accept, so a denied
   source's NEW *and* original-direction-established inbound (including its
   ND/PMTUD) are dropped — matching Rust's per-hit re-eval/teardown. ESP/AH (proto
-  50/51) are always exempt; IKE 500/4500 is shielded when the zone coarse-admits
-  `ike`; ident-reset TCP/113 keeps its RST when the zone's effective coarse verdict
-  is the RST (ident-reset set AND not `all`/`any-service`).
+  50/51) are always exempt; IKE 500/4500 is shielded when the ingress interface
+  coarse-admits `ike`; ident-reset TCP/113 keeps its RST when the interface's
+  effective coarse verdict is the RST (ident-reset set AND not `all`/`any-service`).
+  - **Per-interface scope of the IKE / ident shield (#5565).** The shield is
+    scoped to the SPECIFIC netdevs whose EFFECTIVE per-interface host-inbound set
+    (`InterfaceHostInboundEffective`, zone-level ∪ interface override) admits the
+    exemption — `JunosHostDenyProgram.IKEExemptNetdevs` / `IdentResetNetdevs`,
+    each a subset of the program's `IngressNetdevs`. A per-INTERFACE `ike` /
+    `ident-reset` override therefore shields only the interface(s) that configured
+    it (`iifname "<that-netdev>" ...`), never the whole zone iifname set — a
+    least-privilege override on one interface is not widened to a sibling that did
+    not configure it. A genuinely ZONE-LEVEL exception (authored on the zone's own
+    `host-inbound-traffic`) is folded into every interface's effective set, so its
+    subset equals `IngressNetdevs` and the shield stays zone-wide (no regression).
+    The zone-wide `application any` DROP itself is unaffected — the deny is a zone
+    policy and still scopes by the full zone iifname set; only the ACCEPT/RST
+    exemption ahead of it is narrowed. Before #5565 the shield used a single
+    zone-wide `CoarseAdmitsIKE` / `CoarseIdentResets` bit derived by unioning
+    every per-interface override, so one interface's `ike` falsely admitted IKE
+    on every interface in the zone.
   - **Operator note — exempt tuples survive an `application any` deny.** On an
     **IKE-admitting** zone, `from-zone Z to-zone junos-host { match source-address
     BAD; match application any; then deny; }` does **NOT** stop BAD's IKE / IPsec

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -111,9 +111,24 @@ type JunosHostDenyProgram struct {
 	RulesV4 []JunosHostDenyRule
 	RulesV6 []JunosHostDenyRule
 	// CoarseAdmitsIKE / CoarseIdentResets drive the daemon's fine-eligible-L4
-	// exemption rules ahead of an `application any` drop (§6.6).
+	// exemption rules ahead of an `application any` drop (§6.6). They are true
+	// iff at least one ingress netdev in the zone admits the exemption
+	// (len(IKEExemptNetdevs) / len(IdentResetNetdevs) > 0) — NOT a zone-wide
+	// union of every per-interface override (#5565).
 	CoarseAdmitsIKE   bool
 	CoarseIdentResets bool
+	// IKEExemptNetdevs / IdentResetNetdevs are the SUBSET of IngressNetdevs whose
+	// EFFECTIVE per-interface host-inbound set admits IKE (udp 500/4500) /
+	// answers TCP/113 with a RST (#5565). The daemon scopes the IKE / ident
+	// exemption shield to these netdevs instead of the whole zone iifname set, so
+	// a per-INTERFACE `ike` / `ident-reset` override is never widened to a sibling
+	// interface in the same zone that did not configure it. A genuinely
+	// zone-level exception (authored on the zone's own host-inbound-traffic)
+	// admits on every interface, so its subset equals IngressNetdevs and the
+	// shield stays zone-wide (no regression). Sorted; each a subset of
+	// IngressNetdevs.
+	IKEExemptNetdevs  []string
+	IdentResetNetdevs []string
 	// HasApplicationAnyDeny is true when the program contains a rendered
 	// `application any` drop, so the daemon knows to emit the IKE/ident exemption
 	// shields ahead of it.
@@ -223,11 +238,22 @@ func BuildJunosHostDenyProjection(cfg *Config) JunosHostDenyProjection {
 			// as a `saddr !=` subtraction — the whole program is un-representable
 			// (§5.1). junosHostProjectProgram reports this via ok=false.
 			var ok bool
-			prog, ok = junosHostProjectProgram(zoneName, ifaceRefs, terms, zone)
+			prog, ok = junosHostProjectProgram(zoneName, ifaceRefs, terms)
 			if !ok {
 				representable = false
 			}
 			prog.IngressNetdevs = netdevs
+			// #5565: scope the fine-eligible-L4 (IKE / ident) exemption to the
+			// SPECIFIC netdevs whose effective per-interface host-inbound set
+			// admits it, NOT the whole zone. A per-interface `ike`/`ident-reset`
+			// override then shields only the interface that configured it; a
+			// zone-level exception still covers every netdev (its subset equals
+			// netdevs). The CoarseAdmits* bits follow the subsets so the daemon
+			// never emits a shield with no scope.
+			prog.IKEExemptNetdevs, prog.IdentResetNetdevs =
+				junosHostZoneExemptNetdevs(cfg, zoneName, zone, netdevs)
+			prog.CoarseAdmitsIKE = len(prog.IKEExemptNetdevs) > 0
+			prog.CoarseIdentResets = len(prog.IdentResetNetdevs) > 0
 		}
 		// Bookkeeping for the warning.
 		for _, t := range terms {
@@ -363,13 +389,11 @@ func junosHostProjectTerm(cfg *Config, key string, p *Policy, feedBound map[stri
 // cross-dimension permit/deny subtraction that cannot be cleanly rendered (a
 // narrow-application or source-excluded permit ahead of a deny) — the whole
 // program is then un-representable and the caller warns (§5.1).
-func junosHostProjectProgram(zone string, ifaceRefs []string, terms []junosHostTerm, zc *ZoneConfig) (JunosHostDenyProgram, bool) {
+func junosHostProjectProgram(zone string, ifaceRefs []string, terms []junosHostTerm) (JunosHostDenyProgram, bool) {
 	prog := JunosHostDenyProgram{
-		Zone:              zone,
-		InterfaceRefs:     ifaceRefs,
-		Representable:     true,
-		CoarseAdmitsIKE:   zoneCoarseAdmitsIKE(zc),
-		CoarseIdentResets: zoneCoarseIdentResets(zc),
+		Zone:          zone,
+		InterfaceRefs: ifaceRefs,
+		Representable: true,
 	}
 	// Accumulated earlier-permit source sets (per family) that carve later
 	// denies via `saddr !=`. A permit that permits ALL sources shadows every
@@ -822,13 +846,10 @@ func junosHostParsePorts(spec string) ([]PortRange, bool) {
 	return out, true
 }
 
-// zoneCoarseAdmitsIKE reports whether the zone's coarse host-inbound gate admits
-// IKE/NAT-T (udp 500/4500) — the `ike`/`ipsec` token or a full admit.
-func zoneCoarseAdmitsIKE(zc *ZoneConfig) bool {
-	if zc == nil {
-		return false
-	}
-	svc := zoneEffectiveSystemServices(zc)
+// junosHostSvcAdmitsIKE reports whether an EFFECTIVE per-interface host-inbound
+// system-services set coarse-admits IKE/NAT-T (udp 500/4500) — the `ike`/`ipsec`
+// token or a full admit.
+func junosHostSvcAdmitsIKE(svc []string) bool {
 	for _, s := range svc {
 		if s == "ike" || s == "ipsec" || HostInboundFullAdmitService(s) {
 			return true
@@ -837,49 +858,113 @@ func zoneCoarseAdmitsIKE(zc *ZoneConfig) bool {
 	return false
 }
 
-// zoneCoarseIdentResets reports whether the zone's effective coarse verdict for
-// TCP/113 is a RST: `ident-reset` present AND the zone is not fully open (a
-// full-admit zone accepts 113, so ident-reset is shadowed — 113 stays
-// fine-eligible, §6.6 / Codex r4).
-func zoneCoarseIdentResets(zc *ZoneConfig) bool {
-	if zc == nil {
-		return false
+// junosHostZoneExemptNetdevs returns the subset of `netdevs` (a zone's rendered
+// ingress iifname scope from JunosHostZoneIngressNetdevs) whose EFFECTIVE
+// per-interface host-inbound set admits IKE (udp 500/4500) and, separately, the
+// subset that answers TCP/113 with a RST (ident-reset). It is the #5565 fix for
+// the earlier zone-wide projection, which unioned every per-interface override
+// into a single bit and widened a per-interface `ike`/`ident-reset` exception to
+// every interface in the zone.
+//
+// A netdev admits IKE / RSTs ident if ANY interface ref whose host-bound traffic
+// arrives on it (its own logical unit, or — for a VLAN subunit riding a physical
+// parent — the parent) admits it. The union mirrors the coarse host-inbound gate
+// (which keys on the interface's effective set, InterfaceHostInboundEffective) so
+// the shield never false-denies a configured per-interface override, while a
+// sibling interface that configured no exception is left out of the subset. A
+// genuinely zone-level exception (authored on the zone's own
+// host-inbound-traffic) is folded into every interface's effective set, so its
+// subset equals `netdevs` and the shield stays zone-wide.
+//
+// The netdev→ref row walk mirrors JunosHostZoneIngressNetdevs exactly (physical
+// row + one row per unit, plus the physical parent for a VLAN subunit) so the
+// two agree on which ref feeds which netdev; results are filtered to `netdevs`
+// so a cross-zone-ambiguous parent excluded from the iifname scope is never
+// shielded.
+func junosHostZoneExemptNetdevs(cfg *Config, zoneName string, zone *ZoneConfig, netdevs []string) (ikeNetdevs, identNetdevs []string) {
+	if cfg == nil || zone == nil || len(netdevs) == 0 {
+		return nil, nil
 	}
-	svc := zoneEffectiveSystemServices(zc)
-	hasIdent := false
-	for _, s := range svc {
-		if HostInboundFullAdmitService(s) {
-			return false
-		}
-		if s == "ident-reset" {
-			hasIdent = true
-		}
+	keep := make(map[string]bool, len(netdevs))
+	for _, nd := range netdevs {
+		keep[nd] = true
 	}
-	return hasIdent
-}
-
-// zoneEffectiveSystemServices returns the zone-level system-services union with
-// every per-interface override (the coarse-admit set that governs exemptions).
-func zoneEffectiveSystemServices(zc *ZoneConfig) []string {
-	seen := map[string]bool{}
-	var out []string
-	add := func(list []string) {
-		for _, s := range list {
-			if s != "" && !seen[s] {
-				seen[s] = true
-				out = append(out, s)
+	// Per-netdev accumulation of the effective coarse verdict across every
+	// interface ref whose host-bound traffic arrives on it.
+	type verdict struct{ ike, ident, fullAdmit bool }
+	byNetdev := make(map[string]*verdict, len(netdevs))
+	note := func(nd, ref string) {
+		if nd == "" || !keep[nd] {
+			return
+		}
+		svc, _, _ := zone.InterfaceHostInboundEffective(ref)
+		v := byNetdev[nd]
+		if v == nil {
+			v = &verdict{}
+			byNetdev[nd] = v
+		}
+		if junosHostSvcAdmitsIKE(svc) {
+			v.ike = true
+		}
+		for _, s := range svc {
+			if HostInboundFullAdmitService(s) {
+				v.fullAdmit = true
+			}
+			if s == "ident-reset" {
+				v.ident = true
 			}
 		}
 	}
-	if zc.HostInboundTraffic != nil {
-		add(zc.HostInboundTraffic.SystemServices)
-	}
-	for _, ov := range zc.InterfaceHostInbound {
-		if ov != nil {
-			add(ov.SystemServices)
+	zoneByIface := junosHostZoneByInterface(cfg)
+	addRow := func(name, own, parent string, vlan int) {
+		if zoneByIface[name] != zoneName {
+			return
+		}
+		note(own, name)
+		if vlan != 0 && parent != "" {
+			note(parent, name)
 		}
 	}
-	return out
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for n := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, n)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		iface := cfg.Interfaces.Interfaces[ifName]
+		if iface == nil {
+			continue
+		}
+		addRow(ifName, junosHostLinuxName(cfg, ifName, nil), "", 0)
+		unitNums := make([]int, 0, len(iface.Units))
+		for u := range iface.Units {
+			unitNums = append(unitNums, u)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := iface.Units[un]
+			if unit == nil {
+				continue
+			}
+			unitName := fmt.Sprintf("%s.%d", ifName, un)
+			addRow(unitName, junosHostLinuxName(cfg, ifName, unit),
+				junosHostLinuxName(cfg, ifName, nil), unit.VlanID)
+		}
+	}
+	// Emit subsets in the sorted netdevs order for a deterministic iifname set.
+	for _, nd := range netdevs {
+		v := byNetdev[nd]
+		if v == nil {
+			continue
+		}
+		if v.ike {
+			ikeNetdevs = append(ikeNetdevs, nd)
+		}
+		if v.ident && !v.fullAdmit {
+			identNetdevs = append(identNetdevs, nd)
+		}
+	}
+	return ikeNetdevs, identNetdevs
 }
 
 // JunosHostZoneIngressNetdevs returns, per security zone, the sorted set of

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -695,13 +695,21 @@ func emitJunosHostDenyProgram(rules *[]string, p dpuserspace.JunosHostProgram) {
 		if p.CoarseAdmitsIKE {
 			// The coarse gate admits IKE (udp 500/4500) from any source, and the
 			// userspace IPsec passthrough reinjects it before the fine policy, so
-			// the fine drop must not swallow it.
-			*rules = append(*rules, "    iifname "+iif+" udp dport { 500, 4500 } accept")
+			// the fine drop must not swallow it. #5565: scope the shield to the
+			// SPECIFIC netdevs whose effective per-interface host-inbound set admits
+			// IKE (IKEExemptNetdevs), NOT the whole zone iifname set — a per-
+			// interface `ike` override must not leak to a sibling interface. A
+			// zone-level `ike` yields the full IngressIfnames set (zone-wide).
+			ikeIif := nftIifnameSet(p.IKEExemptNetdevs)
+			*rules = append(*rules, "    iifname "+ikeIif+" udp dport { 500, 4500 } accept")
 		}
 		if p.CoarseIdentResets {
-			// The zone's effective coarse verdict for TCP/113 is a RST (ident-reset
-			// set AND not all/any-service); preserve it ahead of the silent drop.
-			*rules = append(*rules, "    iifname "+iif+" tcp dport 113 reject with tcp reset")
+			// The effective coarse verdict for TCP/113 is a RST (ident-reset set AND
+			// not all/any-service); preserve it ahead of the silent drop. #5565:
+			// scope to IdentResetNetdevs (the interfaces that configured
+			// ident-reset), never the whole zone.
+			identIif := nftIifnameSet(p.IdentResetNetdevs)
+			*rules = append(*rules, "    iifname "+identIif+" tcp dport 113 reject with tcp reset")
 		}
 	}
 	for _, r := range p.RulesV4 {

--- a/pkg/daemon/host_inbound_junos_host_iface_scope_5565_test.go
+++ b/pkg/daemon/host_inbound_junos_host_iface_scope_5565_test.go
@@ -1,0 +1,171 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// junosHostTwoIfaceZoneConfig builds an `untrust` ingress zone with TWO
+// non-lifeline dataplane interfaces (netdevs ge-0-0-1 and ge-0-0-2) that
+// coarse-admit only `ping` at the zone level, plus a static address book and
+// the lifeline mgmt zone. Callers add a per-interface host-inbound override on
+// ge-0/0/1.0 and a `to-zone junos-host` deny, so the #5565 per-interface
+// exemption scoping can be exercised against a sibling (ge-0/0/2.0) that
+// configured no exception.
+func junosHostTwoIfaceZoneConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.2.10/24"}},
+		}},
+		"ge-0/0/2": {Name: "ge-0/0/2", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.3.10/24"}},
+		}},
+		// fxp0 is a lifeline — never scoped by a junos-host deny.
+		"fxp0": {Name: "fxp0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.10/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"untrust": {
+			Name:               "untrust",
+			Interfaces:         []string{"ge-0/0/1.0", "ge-0/0/2.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ping"}},
+		},
+		"mgmt": {
+			Name:               "mgmt",
+			Interfaces:         []string{"fxp0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh", "ping"}},
+		},
+	}
+	cfg.Security.AddressBook = &config.AddressBook{
+		Addresses: map[string]*config.Address{
+			"bad-host": {Name: "bad-host", Value: "10.0.0.5/32"},
+		},
+	}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host",
+			Policies: zonePairDeny("untrust", "block-bad", "src:bad-host", "app:any")},
+	}
+	return cfg
+}
+
+// junosHostShieldLines returns the junos-host DROP-subchain lines that render an
+// exemption shield matching `match` (e.g. "udp dport { 500, 4500 } accept").
+func junosHostShieldLines(payload, match string) []string {
+	var out []string
+	for _, l := range junosHostSection(payload) {
+		if strings.Contains(l, match) {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// TestJunosHostIKEExemptionScopedToConfiguringInterface is the #5565 fail-on-
+// revert guard: a per-INTERFACE `ike` host-inbound override on ONE interface
+// (ge-0/0/1.0) must render the IKE 500/4500 exemption shield scoped to THAT
+// interface's netdev only (ge-0-0-1) — never the whole zone iifname set. The
+// sibling ge-0/0/2.0, which configured no `ike`, must NOT be exempted. The
+// zone-wide `application any` DROP still applies to BOTH netdevs (the deny is a
+// zone policy). Revert the fix (zone-wide CoarseAdmitsIKE + whole-zone iif) and
+// the shield widens to `{ "ge-0-0-1", "ge-0-0-2" }`, admitting IKE on the
+// sibling — the sibling-not-exempted assertion FAILS.
+func TestJunosHostIKEExemptionScopedToConfiguringInterface(t *testing.T) {
+	cfg := junosHostTwoIfaceZoneConfig()
+	cfg.Security.Zones["untrust"].InterfaceHostInbound = map[string]*config.HostInboundTraffic{
+		"ge-0/0/1.0": {SystemServices: []string{"ike"}},
+	}
+	payload, programs := junosHostPayload(t, cfg)
+	if len(programs) != 1 {
+		t.Fatalf("want 1 program, got %d: %+v", len(programs), programs)
+	}
+	p := programs[0]
+	if !p.CoarseAdmitsIKE {
+		t.Fatal("zone coarse-admits ike on ge-0/0/1.0, so the program must set CoarseAdmitsIKE")
+	}
+	if got := strings.Join(p.IKEExemptNetdevs, ","); got != "ge-0-0-1" {
+		t.Fatalf("IKEExemptNetdevs = %q, want ge-0-0-1 (only the interface that configured ike)", got)
+	}
+	// Exactly one IKE shield, scoped to ge-0-0-1 alone.
+	shields := junosHostShieldLines(payload, "udp dport { 500, 4500 } accept")
+	if len(shields) != 1 {
+		t.Fatalf("want exactly 1 IKE shield line, got %d:\n%s", len(shields), strings.Join(shields, "\n"))
+	}
+	if want := `iifname "ge-0-0-1" udp dport { 500, 4500 } accept`; strings.TrimSpace(shields[0]) != want {
+		t.Fatalf("IKE shield = %q, want %q", strings.TrimSpace(shields[0]), want)
+	}
+	// The sibling ge-0-0-2 must NOT appear on any IKE shield (the #5565 leak).
+	if strings.Contains(shields[0], "ge-0-0-2") {
+		t.Fatalf("per-interface ike override widened to sibling ge-0-0-2:\n%s", shields[0])
+	}
+	// The zone-wide `application any` DROP still covers BOTH interfaces.
+	cn := xnft.HostInboundJunosHostDenyCounterName("untrust", "ip")
+	wantDrop := `iifname { "ge-0-0-1", "ge-0-0-2" } ip saddr 10.0.0.5/32 counter name "` + cn + `" drop`
+	if !strings.Contains(payload, wantDrop) {
+		t.Fatalf("zone-wide DROP missing (deny must still apply to both interfaces):\nwant %q\n%s", wantDrop, payload)
+	}
+}
+
+// TestJunosHostIdentResetScopedToConfiguringInterface: a per-INTERFACE
+// `ident-reset` override on ge-0/0/1.0 RSTs TCP/113 only on ge-0-0-1; the
+// sibling ge-0/0/2.0 (no ident-reset) is NOT RST-shielded (it silently denies).
+// Reverting widens the RST shield to the whole zone — the sibling assertion
+// FAILS.
+func TestJunosHostIdentResetScopedToConfiguringInterface(t *testing.T) {
+	cfg := junosHostTwoIfaceZoneConfig()
+	cfg.Security.Zones["untrust"].InterfaceHostInbound = map[string]*config.HostInboundTraffic{
+		"ge-0/0/1.0": {SystemServices: []string{"ident-reset"}},
+	}
+	payload, programs := junosHostPayload(t, cfg)
+	if len(programs) != 1 {
+		t.Fatalf("want 1 program, got %d: %+v", len(programs), programs)
+	}
+	p := programs[0]
+	if !p.CoarseIdentResets {
+		t.Fatal("zone resets ident on ge-0/0/1.0, so the program must set CoarseIdentResets")
+	}
+	if got := strings.Join(p.IdentResetNetdevs, ","); got != "ge-0-0-1" {
+		t.Fatalf("IdentResetNetdevs = %q, want ge-0-0-1", got)
+	}
+	shields := junosHostShieldLines(payload, "tcp dport 113 reject with tcp reset")
+	if len(shields) != 1 {
+		t.Fatalf("want exactly 1 ident RST shield line, got %d:\n%s", len(shields), strings.Join(shields, "\n"))
+	}
+	if want := `iifname "ge-0-0-1" tcp dport 113 reject with tcp reset`; strings.TrimSpace(shields[0]) != want {
+		t.Fatalf("ident shield = %q, want %q", strings.TrimSpace(shields[0]), want)
+	}
+	if strings.Contains(shields[0], "ge-0-0-2") {
+		t.Fatalf("per-interface ident-reset widened to sibling ge-0-0-2:\n%s", shields[0])
+	}
+}
+
+// TestJunosHostZoneLevelIKEExemptionStaysZoneWide is the no-regression peer: an
+// exception authored at ZONE scope (on the zone's own host-inbound-traffic,
+// applying to every interface) must keep the shield zone-wide — scoped to the
+// full iifname set { ge-0-0-1, ge-0-0-2 } — because every interface genuinely
+// admits IKE. #5565 narrows only a PER-INTERFACE override, never a zone-level
+// one.
+func TestJunosHostZoneLevelIKEExemptionStaysZoneWide(t *testing.T) {
+	cfg := junosHostTwoIfaceZoneConfig()
+	cfg.Security.Zones["untrust"].HostInboundTraffic.SystemServices = []string{"ping", "ike"}
+	payload, programs := junosHostPayload(t, cfg)
+	if len(programs) != 1 {
+		t.Fatalf("want 1 program, got %d: %+v", len(programs), programs)
+	}
+	p := programs[0]
+	if got := strings.Join(p.IKEExemptNetdevs, ","); got != "ge-0-0-1,ge-0-0-2" {
+		t.Fatalf("IKEExemptNetdevs = %q, want ge-0-0-1,ge-0-0-2 (zone-level ike covers every interface)", got)
+	}
+	shields := junosHostShieldLines(payload, "udp dport { 500, 4500 } accept")
+	if len(shields) != 1 {
+		t.Fatalf("want exactly 1 IKE shield line, got %d:\n%s", len(shields), strings.Join(shields, "\n"))
+	}
+	want := `iifname { "ge-0-0-1", "ge-0-0-2" } udp dport { 500, 4500 } accept`
+	if strings.TrimSpace(shields[0]) != want {
+		t.Fatalf("zone-level IKE shield = %q, want zone-wide %q", strings.TrimSpace(shields[0]), want)
+	}
+}

--- a/pkg/dataplane/userspace/junos_host_deny.go
+++ b/pkg/dataplane/userspace/junos_host_deny.go
@@ -36,10 +36,19 @@ type JunosHostProgram struct {
 	RulesV6 []config.JunosHostDenyRule
 	// CoarseAdmitsIKE / CoarseIdentResets / HasApplicationAnyDeny drive the
 	// daemon's fine-eligible-L4 exemption rules ahead of an `application any`
-	// drop (§6.6).
+	// drop (§6.6). CoarseAdmitsIKE / CoarseIdentResets are true iff the
+	// corresponding netdev subset below is non-empty.
 	CoarseAdmitsIKE       bool
 	CoarseIdentResets     bool
 	HasApplicationAnyDeny bool
+	// IKEExemptNetdevs / IdentResetNetdevs are the SUBSET of IngressIfnames whose
+	// effective per-interface host-inbound set admits IKE / RSTs ident (#5565).
+	// The daemon scopes the IKE / ident exemption shield to these netdevs, so a
+	// per-interface `ike`/`ident-reset` override never widens to a sibling
+	// interface in the same zone. A zone-level exception yields the full
+	// IngressIfnames set (zone-wide, no regression). Sorted subsets.
+	IKEExemptNetdevs  []string
+	IdentResetNetdevs []string
 }
 
 // BuildJunosHostPrograms returns the per-ingress-zone junos-host DENY programs
@@ -79,6 +88,8 @@ func BuildJunosHostPrograms(cfg *config.Config) []JunosHostProgram {
 			CoarseAdmitsIKE:       p.CoarseAdmitsIKE,
 			CoarseIdentResets:     p.CoarseIdentResets,
 			HasApplicationAnyDeny: p.HasApplicationAnyDeny,
+			IKEExemptNetdevs:      p.IKEExemptNetdevs,
+			IdentResetNetdevs:     p.IdentResetNetdevs,
 		})
 	}
 	return out


### PR DESCRIPTION
Closes #5565

## Problem

A per-interface `host-inbound-traffic` IKE (or `ident-reset`) exception was projected into a single **zone-wide** bit (`CoarseAdmitsIKE` / `CoarseIdentResets`, derived by unioning every per-interface override in `zoneEffectiveSystemServices`) and then emitted as a terminal nft exemption across the **whole zone's iifname set**, ahead of the interface-scoped coarse drops. A least-privilege override on one interface (`allow IKE inbound only on ge-0/0/1`) was therefore widened to admit IKE — or actively RST TCP/113 — on **every sibling interface** in the zone that configured no such statement. Host-inbound false-allow / management-plane over-reach with no matching config statement (codex-review-180 C180-004, verified vs origin/master).

## Fix — preserve the per-interface scope through to the nft render

- **`pkg/config/junos_host_deny.go`**: new `JunosHostDenyProgram.IKEExemptNetdevs` / `IdentResetNetdevs` — the subset of `IngressNetdevs` whose **effective per-interface** host-inbound set (`InterfaceHostInboundEffective`, zone-level ∪ interface override) admits IKE / RSTs ident. `junosHostZoneExemptNetdevs` computes them by mirroring the `JunosHostZoneIngressNetdevs` row walk (physical row + one per unit, plus the physical parent for a VLAN subunit) and unioning each producing ref's verdict onto the netdev — the same effective-set resolution the coarse gate keys on, so a configured per-interface override is never false-denied. `CoarseAdmitsIKE` / `CoarseIdentResets` now follow the subsets (true iff non-empty). Removed the zone-wide `zoneCoarseAdmitsIKE` / `zoneCoarseIdentResets` / `zoneEffectiveSystemServices` union helpers.
- **`pkg/dataplane/userspace/junos_host_deny.go`**: forward the two netdev subsets on `JunosHostProgram`.
- **`pkg/daemon/daemon_nft.go`** (`emitJunosHostDenyProgram`): scope the IKE shield to `IKEExemptNetdevs` and the ident RST shield to `IdentResetNetdevs`, instead of the whole-zone `iif`.

### Per-interface vs zone distinction

The two are different config stanzas: a per-interface override lives in `zone.InterfaceHostInbound[ref]`, a zone-level exception on `zone.HostInboundTraffic`. A zone-level `ike`/`ident-reset` folds into **every** interface's effective set, so its subset equals `IngressNetdevs` and the shield stays **zone-wide (no regression)**. Only a per-interface override is narrowed. The zone-wide `application any` DROP is unchanged — the deny is a zone policy; only the ACCEPT/RST exemption ahead of it is scoped down.

## Scoping fix (file:line)

- `pkg/daemon/daemon_nft.go:699` / `:704` — shields now scoped to `IKEExemptNetdevs` / `IdentResetNetdevs`.
- `pkg/config/junos_host_deny.go` `junosHostZoneExemptNetdevs` + `BuildJunosHostDenyProjection` populate the subsets.

## Validation

- `go build ./...`, `go vet`, `go test ./pkg/config/... ./pkg/daemon/...` — pass.
- **RED-on-revert** (`pkg/daemon/host_inbound_junos_host_iface_scope_5565_test.go`): a per-interface `ike` / `ident-reset` override on `ge-0/0/1.0` renders a shield scoped to `ge-0-0-1` only; sibling `ge-0/0/2.0` is **not** exempted; the zone-wide DROP still covers both. A zone-level `ike` keeps the shield zone-wide. Reverting the render scoping widens both shields back to `iifname { "ge-0-0-1", "ge-0-0-2" }` and the sibling-not-exempted assertions **fail** (verified by temporarily reverting).
- The two pre-existing `pkg/dataplane/userspace` failures (`TestEventStreamDataplaneEventBeforeCallbackQueuesUntilCallback`, `TestUpdatePolicyScheduleStateRefusesOldHelperForScheduledPolicies`) reproduce **unchanged on clean origin/master** — not caused by this change.
- Updated `docs/host-inbound-service-matrix.md` with the per-interface shield-scope contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)