### PR TITLE
api: mark REST policy hit counters unavailable when dataplane unloaded

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46089,3 +46089,26 @@ top.
   policymatch/cmd-cli/grpcapi/api green; gofmt -w.
   **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/README.md,
   pkg/policymatch/fragment_5572_test.go, _Log.md
+
+- **Timestamp**: 2026-07-11 (fix/5580-rest-counter-availability)
+- **Action**: #5580 — add a hit-counter availability discriminator to the REST
+  security-policies inventory so a monitor can tell a real idle 0 from "no
+  counter source". Added `PolicyRule.HitCountersUnavailable bool`
+  (`json:"hit_counters_unavailable,omitempty"`) in pkg/api/types.go, following
+  the InterfaceStats.Unavailable (#3464) / HostInboundKernelDeniesUnavailable
+  (#3681) idiom + #3345 "counter-unavailable != zero" contract. In
+  policiesHandler the three counter-read sites (zone-pair rules, global rules,
+  implicit default-policy row) now set the flag when a rule is counter-ELIGIBLE
+  (`policy-stats` on OR `then count`; default row gates on `policy-stats`) but
+  `readPolicy == nil` (dataplane UNLOADED). A NOT-counter-enabled rule
+  (Count=false, stats off) stays flag-omitted — a legitimate honest zero,
+  distinct from counter-enabled-but-source-unavailable. Loaded read FAILURE is
+  still HTTP 500 (#3408), never this in-body flag. HTTP stays 200. Response
+  schema is documented in-code (Go struct doc comment) matching the #3464/#3681
+  precedent — no separate markdown API schema doc exists to update. Added 3
+  fail-on-revert tests (unloaded/system-wide, unloaded/then-count-only,
+  loaded). RED-on-revert PROVEN: stashing only security.go (keeping the struct
+  field) makes the two unloaded tests fail — eligible rules return 0/0 with the
+  flag false. Gates: go build ./... + go test ./pkg/api/... green; gofmt -w.
+- **File(s)**: pkg/api/types.go, pkg/api/security.go,
+  pkg/api/security_policy_counter_availability_5580_test.go, _Log.md

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -235,24 +235,34 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				pr.Applications = []string{}
 			}
 
-			if (statsEnabled || rule.Count) && readPolicy != nil {
-				// #3474: the counter read handle MUST use the RAW slice index i,
-				// not len(pi.Rules) (the compacted, nil-skipped count). The
-				// resolver (policyRuleIDForCounter) and every other caller —
-				// metrics_counters.go's policyCounterID(policySetID, i),
-				// cli_show_security*.go, server_show_policies_text.go, and this
-				// function's OWN global-policy loop below (+ uint32(i)) — key off
-				// the raw slice index. With a nil rule before a real rule
-				// len(pi.Rules) would lag i and mis-resolve this rule's counter;
-				// using i keeps every counter handle on the one raw-slice-index
-				// SSOT. (Nil rules are not reachable via any production config
-				// path today; this is defensive SSOT-alignment, like #3476/#3494.)
-				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-				if ctrs, err := readPolicy(policyID); err == nil {
-					pr.HitPackets = ctrs.Packets
-					pr.HitBytes = ctrs.Bytes
-				} else if readErr == nil {
-					readErr = err
+			if statsEnabled || rule.Count {
+				if readPolicy != nil {
+					// #3474: the counter read handle MUST use the RAW slice
+					// index i, not len(pi.Rules) (the compacted, nil-skipped
+					// count). The resolver (policyRuleIDForCounter) and every
+					// other caller — metrics_counters.go's
+					// policyCounterID(policySetID, i), cli_show_security*.go,
+					// server_show_policies_text.go, and this function's OWN
+					// global-policy loop below (+ uint32(i)) — key off the raw
+					// slice index. With a nil rule before a real rule
+					// len(pi.Rules) would lag i and mis-resolve this rule's
+					// counter; using i keeps every counter handle on the one
+					// raw-slice-index SSOT. (Nil rules are not reachable via any
+					// production config path today; this is defensive
+					// SSOT-alignment, like #3476/#3494.)
+					policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+					if ctrs, err := readPolicy(policyID); err == nil {
+						pr.HitPackets = ctrs.Packets
+						pr.HitBytes = ctrs.Bytes
+					} else if readErr == nil {
+						readErr = err
+					}
+				} else {
+					// #5580: the rule is counter-eligible but no runtime counter
+					// source exists (dataplane unloaded — readPolicy was not
+					// built). Mark the 0/0 counts non-authoritative so a monitor
+					// does not read them as "rule matched no traffic".
+					pr.HitCountersUnavailable = true
 				}
 			}
 			pi.Rules = append(pi.Rules, pr)
@@ -326,13 +336,19 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				pr.Applications = []string{}
 			}
 
-			if (statsEnabled || rule.Count) && readPolicy != nil {
-				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-				if ctrs, err := readPolicy(policyID); err == nil {
-					pr.HitPackets = ctrs.Packets
-					pr.HitBytes = ctrs.Bytes
-				} else if readErr == nil {
-					readErr = err
+			if statsEnabled || rule.Count {
+				if readPolicy != nil {
+					policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+					if ctrs, err := readPolicy(policyID); err == nil {
+						pr.HitPackets = ctrs.Packets
+						pr.HitBytes = ctrs.Bytes
+					} else if readErr == nil {
+						readErr = err
+					}
+				} else {
+					// #5580: counter-eligible global rule, dataplane unloaded —
+					// mark the zero counts non-authoritative (see zone-pair loop).
+					pr.HitCountersUnavailable = true
 				}
 			}
 			pi.Rules = append(pi.Rules, pr)
@@ -376,12 +392,21 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 		// implies the dataplane is loaded (built above under that guard); the
 		// bulk snapshot already includes the DefaultPolicySentinelID handle
 		// (ReadAllPolicyCounters puts it), so the value is identical.
-		if statsEnabled && readPolicy != nil {
-			if ctrs, err := readPolicy(dataplane.DefaultPolicySentinelID); err == nil {
-				defRule.HitPackets = ctrs.Packets
-				defRule.HitBytes = ctrs.Bytes
-			} else if readErr == nil {
-				readErr = err
+		if statsEnabled {
+			if readPolicy != nil {
+				if ctrs, err := readPolicy(dataplane.DefaultPolicySentinelID); err == nil {
+					defRule.HitPackets = ctrs.Packets
+					defRule.HitBytes = ctrs.Bytes
+				} else if readErr == nil {
+					readErr = err
+				}
+			} else {
+				// #5580: the implicit default-policy row is counter-eligible
+				// whenever system-wide policy-stats is on; with the dataplane
+				// unloaded there is no counter source, so its 0/0 is not
+				// authoritative. (The default row has no `then count`, so
+				// eligibility gates on statsEnabled alone.)
+				defRule.HitCountersUnavailable = true
 			}
 		}
 		result = append(result, PolicyInfo{

--- a/pkg/api/security_policy_counter_availability_5580_test.go
+++ b/pkg/api/security_policy_counter_availability_5580_test.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// unloadedPolicyAPIDP models a degraded / config-only boot: the dataplane
+// object exists but is NOT loaded, so the policies handler never builds its
+// per-policy counter reader (#5580). Embeds *dataplane.Manager to satisfy the
+// apiRuntimeDataPlane interface and forces IsLoaded()=false.
+type unloadedPolicyAPIDP struct {
+	*dataplane.Manager
+}
+
+func (d *unloadedPolicyAPIDP) IsLoaded() bool { return false }
+
+// fetchPolicies drives the REST security-policies inventory handler and
+// returns the decoded rows.
+func fetchPolicies(t *testing.T, s *Server) []PolicyInfo {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	return resp.Data
+}
+
+func findRule(rows []PolicyInfo, name string) (PolicyRule, bool) {
+	for _, pi := range rows {
+		for _, r := range pi.Rules {
+			if r.Name == name {
+				return r, true
+			}
+		}
+	}
+	return PolicyRule{}, false
+}
+
+// TestPoliciesHandlerCounterAvailabilityUnloadedSystemWide is the #5580
+// fail-on-revert guard. With system-wide `policy-stats` ENABLED and the
+// dataplane UNLOADED, every counter-eligible rule (and the implicit
+// default-policy row) MUST mark hit_counters_unavailable=true with 0/0 counts,
+// NOT emit authoritative-looking zeroes. Reverting the security.go guard makes
+// HitCountersUnavailable default to false while the handler still returns
+// HTTP 200 with 0/0 — a monitor could not tell "no counter source" from "rule
+// matched 0 packets" — so this test goes RED.
+func TestPoliciesHandlerCounterAvailabilityUnloadedSystemWide(t *testing.T) {
+	store := newSchedulerCounterAPIStore(t)
+	enablePolicyStatsAPI(t, store)
+	s := &Server{
+		store: store,
+		dp:    &unloadedPolicyAPIDP{Manager: dataplane.New()},
+	}
+
+	rows := fetchPolicies(t, s)
+
+	// Both authored rules are counter-eligible when policy-stats is on.
+	for _, name := range []string{"plain-allow", "scheduled-allow"} {
+		rule, ok := findRule(rows, name)
+		if !ok {
+			t.Fatalf("%s rule missing from response", name)
+		}
+		if !rule.HitCountersUnavailable {
+			t.Errorf("%s: HitCountersUnavailable = false, want true (dataplane unloaded, counter-eligible)", name)
+		}
+		if rule.HitPackets != 0 || rule.HitBytes != 0 {
+			t.Errorf("%s: counters = %d/%d, want 0/0 when unavailable", name, rule.HitPackets, rule.HitBytes)
+		}
+	}
+
+	// The implicit default-policy row is counter-eligible whenever policy-stats
+	// is on; unloaded -> its 0/0 must be marked unavailable too.
+	defRule, ok := findRule(rows, dataplane.DefaultPolicyName)
+	if !ok {
+		t.Fatalf("default-policy row missing from response")
+	}
+	if !defRule.HitCountersUnavailable {
+		t.Errorf("default-policy: HitCountersUnavailable = false, want true (dataplane unloaded, policy-stats on)")
+	}
+}
+
+// TestPoliciesHandlerCounterAvailabilityUnloadedThenCountOnly proves the
+// "not counter-enabled" vs "counter-enabled but source unavailable"
+// distinction (#5580). With policy-stats OFF and the dataplane UNLOADED:
+//   - a rule WITHOUT `then count` (plain-allow) is legitimately no-counter:
+//     Count=false and hit_counters_unavailable is OMITTED (false) — a real,
+//     honest zero, not a degraded one.
+//   - a rule WITH `then count` (scheduled-allow) is counter-eligible but has
+//     no runtime source, so hit_counters_unavailable=true.
+//   - the default-policy row is not eligible with the knob off -> not
+//     unavailable.
+func TestPoliciesHandlerCounterAvailabilityUnloadedThenCountOnly(t *testing.T) {
+	store := newPolicyCounterAPIStoreNoStats(t)
+	s := &Server{
+		store: store,
+		dp:    &unloadedPolicyAPIDP{Manager: dataplane.New()},
+	}
+
+	rows := fetchPolicies(t, s)
+
+	plain, ok := findRule(rows, "plain-allow")
+	if !ok {
+		t.Fatal("plain-allow rule missing from response")
+	}
+	if plain.Count {
+		t.Fatal("plain-allow Count = true, want false (no then count)")
+	}
+	if plain.HitCountersUnavailable {
+		t.Error("plain-allow: HitCountersUnavailable = true, want false (not counter-enabled is not 'unavailable')")
+	}
+
+	scheduled, ok := findRule(rows, "scheduled-allow")
+	if !ok {
+		t.Fatal("scheduled-allow rule missing from response")
+	}
+	if !scheduled.Count {
+		t.Fatal("scheduled-allow Count = false, want true (then count)")
+	}
+	if !scheduled.HitCountersUnavailable {
+		t.Error("scheduled-allow: HitCountersUnavailable = false, want true (then count eligible, dataplane unloaded)")
+	}
+	if scheduled.HitPackets != 0 || scheduled.HitBytes != 0 {
+		t.Errorf("scheduled-allow: counters = %d/%d, want 0/0 when unavailable", scheduled.HitPackets, scheduled.HitBytes)
+	}
+
+	defRule, ok := findRule(rows, dataplane.DefaultPolicyName)
+	if !ok {
+		t.Fatal("default-policy row missing from response")
+	}
+	if defRule.HitCountersUnavailable {
+		t.Error("default-policy: HitCountersUnavailable = true, want false (policy-stats off -> not eligible)")
+	}
+}
+
+// TestPoliciesHandlerCounterAvailabilityLoaded is the opposite pole: with the
+// dataplane LOADED and policy-stats on, real counts serialize and availability
+// is true (hit_counters_unavailable omitted/false) — the discriminator does not
+// falsely flag a healthy read.
+func TestPoliciesHandlerCounterAvailabilityLoaded(t *testing.T) {
+	store := newSchedulerCounterAPIStore(t)
+	enablePolicyStatsAPI(t, store)
+	policyID := scheduledCounterPolicyID(t, store)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterAPIDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				policyID: {Packets: 17, Bytes: 1700},
+			},
+		},
+	}
+
+	rows := fetchPolicies(t, s)
+
+	scheduled, ok := findRule(rows, "scheduled-allow")
+	if !ok {
+		t.Fatal("scheduled-allow rule missing from response")
+	}
+	if scheduled.HitCountersUnavailable {
+		t.Error("scheduled-allow: HitCountersUnavailable = true, want false (dataplane loaded, read ok)")
+	}
+	if scheduled.HitPackets != 17 || scheduled.HitBytes != 1700 {
+		t.Errorf("scheduled-allow: counters = %d/%d, want 17/1700 (real counts)", scheduled.HitPackets, scheduled.HitBytes)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -201,6 +201,24 @@ type PolicyRule struct {
 	Count        bool     `json:"count"`
 	HitPackets   uint64   `json:"hit_packets"`
 	HitBytes     uint64   `json:"hit_bytes"`
+	// HitCountersUnavailable marks HitPackets/HitBytes as NOT authoritative
+	// because the rule is counter-ELIGIBLE (system-wide `policy-stats` on, or
+	// this rule carries `then count`) but there is no runtime counter source:
+	// the userspace dataplane is UNLOADED (config-only / degraded boot), so the
+	// handler never built its per-policy counter reader and the fields stay 0
+	// without reflecting real traffic (#5580). Mirrors the
+	// InterfaceStats.Unavailable (#3464) /
+	// GlobalStats.HostInboundKernelDeniesUnavailable (#3681) idiom and the
+	// #3345 "counter-unavailable != zero" contract: a monitoring consumer must
+	// be able to tell a real idle 0 (rule matched no traffic) from "counter
+	// source absent". Omitted (false) when the counters read successfully AND
+	// when the rule is NOT counter-enabled (no `then count` with policy-stats
+	// off) — that rule is legitimately no-counter, signalled by Count=false,
+	// which is DISTINCT from counter-enabled-but-source-unavailable. A loaded
+	// read FAILURE is still surfaced fail-loud as HTTP 500 (#3408), never as
+	// this in-body flag. Old consumers keep reading the numeric fields
+	// unchanged; new consumers check this flag before trusting a 0.
+	HitCountersUnavailable bool `json:"hit_counters_unavailable,omitempty"`
 	// MatchFromZone / MatchToZone carry the optional from-zone/to-zone
 	// match context of a scoped GLOBAL policy (#3148, #3286). The global
 	// PolicyInfo group still reports from_zone="*"/to_zone="*" (all-zones


### PR DESCRIPTION
Closes #5580

## Problem
The REST security-policies inventory (`GET /api/v1/security/policies`)
always serialized `hit_packets`/`hit_bytes` with **no availability
marker**, even though `count` (or system-wide `policy-stats`) says the
rule is counter-enabled. The handler builds its per-policy counter
reader only when the dataplane `IsLoaded()`; on a config-only / degraded
boot the reader is `nil`, so every counter-eligible row returned **HTTP
200 with authoritative-looking numeric ZEROES**. A monitoring consumer
could not distinguish a **real idle 0** (rule matched no traffic) from
**"no counter source"** (dataplane unloaded) — a false-zero
observability gap that conflicts with the API's established
counter-unavailable-≠-zero contract (`InterfaceStats.Unavailable` #3464,
`HostInboundKernelDeniesUnavailable` #3681, #3345).

## Fix — availability discriminator
Added `PolicyRule.HitCountersUnavailable`
(`json:"hit_counters_unavailable,omitempty"`) — `pkg/api/types.go:205`.
An **explicit boolean** was chosen over nulling `hit_packets`/`hit_bytes`
because the response struct is flat: the flag is additive + `omitempty`,
so **old consumers keep reading the numeric fields unchanged** while new
ones check availability before trusting a `0` (backward compatible).

The three counter-read sites in `policiesHandler` (`pkg/api/security.go`)
now set the flag when a rule is counter-**eligible** but `readPolicy ==
nil` (dataplane unloaded):
- zone-pair rules — `security.go:262`
- global rules — `security.go:349`
- implicit default-policy row — `security.go:406`

## not-counter-enabled vs counter-enabled-but-source-unavailable
This is the key distinction the fix preserves:
- A rule **WITHOUT** `then count` while `policy-stats` is **off** is
  legitimately no-counter (`Count=false`) → flag **omitted** (an honest
  zero, not a degraded one). The default-policy row is not eligible with
  the knob off, so it stays flag-false too.
- A rule **WITH** `then count` (or any rule when `policy-stats` is on) is
  counter-eligible → when unloaded the flag is **true**.
- Eligibility for the default row gates on `policy-stats` alone (it has
  no `then count`).

A **loaded** read *failure* remains fail-loud as HTTP 500 (#3408), never
this in-body flag. HTTP status stays **200** — a data-availability signal
in the body, not an error.

## Docs
The REST `PolicyRule` response schema is documented in-code via the Go
struct doc comment — the same convention the #3464/#3681 availability
fields use. There is **no separate markdown API-schema doc** enumerating
these JSON fields to update (verified: `grep` for
`host_inbound_kernel_denies_unavailable` / the interface `unavailable`
field across `docs/` returns nothing; those precedents live only in the
struct comments). A comprehensive doc comment was added on the new field.

## Validation
- Added three fail-on-revert tests in
  `pkg/api/security_policy_counter_availability_5580_test.go`:
  unloaded/system-wide-enabled, unloaded/`then count`-only (proves the
  not-enabled-vs-unavailable distinction), and loaded/real-counts.
- **RED-on-revert proven**: stashing only the `security.go` handler
  change (keeping the struct field so it compiles) makes the two
  *unloaded* tests fail — eligible rules return `0/0` with the flag
  `false` (authoritative-looking zeroes), exactly the bug.
- `GOCACHE=... go build ./...` and `go test ./pkg/api/...` green;
  `gofmt -w` applied.

## Scope note
Mirroring the discriminator into the gRPC / text policy surfaces (the
issue's optional "or a shared projection type") is left as a follow-up —
this PR is scoped to the REST inventory per the reported endpoint. The
NAT-rule `hit_packets`/`hit_bytes` (`NATRuleStatsInfo`) is a distinct
endpoint and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rddkaq14amB9y9ut8UAXEg
