### PR TITLE
api/cli match-policies: add ingress-interface host-inbound scope (#5579)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46184,3 +46184,26 @@ top.
   pkg/api/security_matchpolicies_ingress_iface_5579_test.go,
   pkg/cli/cli_show_security.go, pkg/cli/cli_request_testcmd.go,
   cmd/cli/show_security.go, cmd/cli/main.go, docs/junos-cli-reference.md, _Log.md
+
+- **Timestamp**: 2026-07-11 (#5579 review fold — bare-physical ingress-interface)
+- **Action**: Folded the #5595 hostile-review MINOR (bare-physical ref
+  namespace gap). ResolveHostInboundIngressInterface ACCEPTED a bare-physical
+  ingress-interface ref (e.g. `reth0`) while ClassifyHostInboundForInterface
+  keys the effective host-inbound set on the LOGICAL-UNIT ref
+  (buildInterfaceHostInboundMap[ifaceRef]); a unit-authored override lands only
+  on the `reth0.50` key, so a bare-physical ref silently dropped it → FALSE-DENY
+  (reth0 -> "denied" while reth0.50 -> token-admit ssh). Reconciled the
+  namespace by REJECTING a bare-physical ref that carries one-or-more units,
+  naming a representative logical unit in the fail-closed error (a unit-less
+  physical with only a physical-level override is still keyed correctly and is
+  not rejected). Added smallestUnitNumber helper. Deduped the gRPC test-policy
+  bridge double ResolveHostInboundIngressInterface call (compute ingressErr
+  once). Added Test_5579_ResolveIngressInterfaceRejectsBarePhysical with
+  RED-on-revert proof (revert reject -> reth0 accepted -> classifier false-deny;
+  test catches it). Gates: go build ./... + go test -race
+  (policymatch/api/grpcapi/cmd-cli/dataplane) green except the pre-existing
+  flaky TestEventStreamDataplaneEventBeforeCallbackQueuesUntilCallback
+  (fails at base too); gofmt clean.
+- **File(s)**: pkg/dataplane/userspace/host_inbound_classify.go,
+  pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go,
+  pkg/grpcapi/server_show_firewall.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -46133,3 +46133,38 @@ top.
   flag false. Gates: go build ./... + go test ./pkg/api/... green; gofmt -w.
 - **File(s)**: pkg/api/types.go, pkg/api/security.go,
   pkg/api/security_policy_counter_availability_5580_test.go, _Log.md
+
+- **Timestamp**: 2026-07-11 (#5579 api match-policies ingress-interface selector)
+- **Action**: Added an `ingress-interface` selector to the match-policies
+  policy simulator so a `to-zone junos-host` host-inbound query can be scoped to
+  ONE interface's effective host-inbound view instead of the zone-wide
+  first-admit fold (the #5579 false-admission). Refactored the host-inbound
+  classifier: `ClassifyHostInbound` now classifies each per-interface effective
+  view independently and reports the new `HostInboundAmbiguous` status when the
+  views disagree (instead of OR-ing to a first-admit); added
+  `ClassifyHostInboundForInterface` (scopes to one interface's effective token
+  set) and `ResolveHostInboundIngressInterface` (fail-closed validator:
+  rejects unknown / zone-mismatched / lifeline refs). Threaded the selector
+  through `policymatch.Query`/`SelectorArgs`/`ParseSelectorArgs`, the REST
+  `ingress_interface` query param (+ selector allowlist), the gRPC
+  `MatchPolicies` proto field 11 + `HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS`
+  enum (regenerated bindings), the gRPC `test-policy:` `iif=` bridge token, and
+  the local + remote CLI `show security match-policies` / `test policy`
+  surfaces. Added RED-on-revert tests (classifier + REST + gRPC): mixed zone
+  with an ssh override on one unit and a default-deny sibling; ingress-iface=B
+  reports DENY, ingress-iface=A admits, unqualified reports ambiguous.
+  Updated MatchPoliciesUsage help + docs/junos-cli-reference.md. Gates:
+  go build ./... + go test (policymatch/api/grpcapi/cli/cmd-cli + userspace
+  host-inbound) green; gofmt clean. (Pre-existing flaky
+  TestEventStreamDataplaneEventBeforeCallbackQueuesUntilCallback fails at base
+  4a1ca4e32 too — unrelated.)
+- **File(s)**: pkg/dataplane/userspace/host_inbound_classify.go,
+  pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go,
+  pkg/policymatch/policymatch.go, proto/xpf/v1/xpf.proto,
+  pkg/grpcapi/xpfv1/xpf.pb.go, pkg/grpcapi/server_cluster.go,
+  pkg/grpcapi/server_show_firewall.go,
+  pkg/grpcapi/server_matchpolicies_ingress_iface_5579_test.go,
+  pkg/api/security.go,
+  pkg/api/security_matchpolicies_ingress_iface_5579_test.go,
+  pkg/cli/cli_show_security.go, pkg/cli/cli_request_testcmd.go,
+  cmd/cli/show_security.go, cmd/cli/main.go, docs/junos-cli-reference.md, _Log.md

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -660,6 +660,13 @@ func (c *ctl) testPolicy(args []string) error {
 	if sel.NonFirstFragment {
 		topic += ",frag=1"
 	}
+	// #5579: forward the ingress-interface selector so the gRPC test-policy bridge
+	// scopes the host-inbound classifier to one interface's effective view. An
+	// interface ref (e.g. ge-0/0/0.0) never contains a comma or equals, so it
+	// round-trips through the delimiter-based topic; the server validates it.
+	if sel.IngressInterface != "" {
+		topic += ",iif=" + sel.IngressInterface
+	}
 	return c.showText(topic)
 }
 

--- a/cmd/cli/show_security.go
+++ b/cmd/cli/show_security.go
@@ -451,6 +451,10 @@ func (c *ctl) showMatchPolicies(args []string) error {
 		// discriminator so the typed MatchPolicies RPC reproduces the #4569
 		// fragment-associated deny; false is a normal L4 packet.
 		NonFirstFragment: sel.NonFirstFragment,
+		// #5579: forward the ingress-interface selector so the daemon scopes the
+		// host-inbound classifier to one interface's effective view (the server
+		// validates zone membership + lifeline reject). "" = zone-scoped.
+		IngressInterface: sel.IngressInterface,
 	}
 	if sel.ICMPType != nil {
 		u := uint32(*sel.ICMPType)

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -972,8 +972,41 @@ and `test policy from-zone <z> to-zone <z> [...]` (both local and remote CLI).
 The 5-tuple policy simulator answers "which policy does this flow match?" over
 the same precedence the dataplane enforces. Selectors: `source-ip`,
 `destination-ip`, `source-port`, `destination-port`, `protocol <name|number>`,
-`icmp-type`, `icmp-code`, and the valueless `non-first-fragment` (#5572).
-`from-zone` and `to-zone` are required; an OMITTED selector matches any.
+`icmp-type`, `icmp-code`, `ingress-interface` (#5579), and the valueless
+`non-first-fragment` (#5572). `from-zone` and `to-zone` are required; an OMITTED
+selector matches any.
+
+**Per-interface host-inbound scoping (#5579).** A security zone can carry
+MULTIPLE per-interface `host-inbound-traffic` effective views (#3362) — e.g. SSH
+exposed on one unit of a zone and default-denied on a sibling. For a `to-zone
+junos-host` query the host-inbound classifier used to OR every view in the zone
+and report on the FIRST admitting view, so it certified a zone-wide
+`token-admit`/permit even for a packet entering the sibling interface the runtime
+DENIES — a false-admission diagnosis. Two changes remove it:
+
+- `ingress-interface <if>` scopes the host-inbound classification to ONE
+  interface's EFFECTIVE view (zone-level ∪ that interface's override), so the
+  reported admission is that interface's TRUE posture (admit vs deny), not a
+  zone-wide fold. The ref must name an interface assigned to `from-zone`; an
+  unknown, zone-mismatched, or management/cluster lifeline (fxp0/em0/fab*) ref is
+  rejected fail-closed (the lifeline is served unconditionally, so a
+  per-interface verdict would itself be false). Example: `show security
+  match-policies from-zone trust to-zone junos-host protocol tcp destination-port
+  22 ingress-interface ge-0/0/1.0` reports the sibling's `denied`, not the
+  zone-wide `token-admit ssh`.
+- WITHOUT the selector, a zone-scoped query whose per-interface views DISAGREE now
+  reports `ambiguous` (naming the differing interface groups and directing the
+  operator at `ingress-interface`) instead of OR-ing them into a first-admit that
+  lies for the denying interfaces. A zone with no per-interface override yields a
+  single view, so it is unchanged.
+
+The selector threads through every surface: local + remote `show security
+match-policies` / `test policy`, the gRPC `MatchPolicies` RPC `ingress_interface`
+field (proto field 11), the gRPC `test-policy:` bridge `iif=` token, and the REST
+`match-policies` `ingress_interface` query parameter. The classifier reads the
+same host-inbound SSOT the kernel-nft builder renders from, so a scoped verdict
+cannot drift from the port the box actually opens. The gRPC/REST host-inbound
+status gains an `ambiguous` value (`HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS`).
 
 **Non-first fragment simulation (#5572).** The valueless `non-first-fragment`
 selector evaluates the query as a NON-FIRST IP fragment — the dataplane's

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -561,6 +561,12 @@ var matchPoliciesSelectorKeys = []string{
 	// #5572: non-first-fragment (l4_present == false) discriminator. A boolean
 	// param ("true"/"1"/"false"/"0"/absent); absent = a normal L4 packet.
 	"non_first_fragment",
+	// #5579: ingress-interface selector — scopes a `to-zone junos-host`
+	// host-inbound query to ONE interface's effective host-inbound view (admit vs
+	// deny) instead of the zone-wide first-admit fold. A free-form interface ref
+	// validated against the live config (zone membership + lifeline reject);
+	// absent = zone-scoped classification.
+	"ingress_interface",
 }
 
 // isMatchPoliciesSelector reports whether key is a recognized match-policies
@@ -742,6 +748,19 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #5579: validate the optional ingress-interface selector against the live
+	// config — it must name an interface assigned to from_zone and must not be a
+	// management/cluster lifeline (served unconditionally). An unknown /
+	// zone-mismatched / lifeline ref is a fail-closed 400, mirroring the src_ip /
+	// port / protocol validators above, so the host-inbound classifier is only
+	// ever scoped to a real interface of the queried zone. Reached after cfg !=
+	// nil so zone membership is resolvable.
+	ingressIface := q.Get("ingress_interface")
+	if err := dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, ingressIface); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	// #3042: delegate to the single shared simulator so REST agrees with the
 	// runtime evaluator (exact zone-pair -> wildcard-zone tiers (#3090) ->
 	// scoped global (#3148) -> default-policy, predefined + nested-app-set +
@@ -782,6 +801,9 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		ICMPType:         icmpType,
 		ICMPCode:         icmpCode,
 		NonFirstFragment: nonFirstFrag,
+		// #5579: scope the host-inbound classifier to this ingress interface's
+		// effective view (validated above). "" = zone-scoped, unchanged.
+		IngressInterface: ingressIface,
 		FeedOverlay:      overlay,
 		PolicyInactiveFn: inactiveFn,
 	})

--- a/pkg/api/security_matchpolicies_ingress_iface_5579_test.go
+++ b/pkg/api/security_matchpolicies_ingress_iface_5579_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// security_matchpolicies_ingress_iface_5579_test.go pins the #5579 REST
+// ingress-interface selector: a mixed `trust` zone exposes ssh host-inbound on
+// ge-0/0/0.0 only, with a sibling ge-0/0/1.0 that default-denies host SSH. Before
+// #5579 the REST match-policies host-inbound classifier OR-ed every effective
+// view in the zone and returned on the first admit, so it reported a zone-wide
+// `token-admit`/ssh even for a packet entering ge-0/0/1.0 — a FALSE admission for
+// the interface the runtime denies. The endpoint now (a) scopes to one
+// interface's TRUE posture when ingress_interface is supplied, and (b) reports
+// `ambiguous` for an unqualified query when the per-interface views disagree.
+
+// mixedHostInboundAPIStore builds the mixed-zone config via set commands: two
+// addressed units in zone `trust`, ge-0/0/0.0 with an ssh host-inbound override
+// and ge-0/0/1.0 with none (default-deny). No `to-zone junos-host` policy, so a
+// host-bound query resolves to the host-inbound classifier verdict.
+func mixedHostInboundAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(`set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.10/24
+set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.10/24
+set security zones security-zone trust interfaces ge-0/0/0.0 host-inbound-traffic system-services ssh
+set security zones security-zone trust interfaces ge-0/0/1.0
+set security policies default-policy deny-all`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestMatchPoliciesRESTIngressInterfaceScopesHostInbound is the REST
+// fail-on-revert for #5579.
+//
+// RED-on-revert: drop the ingress_interface plumbing (the IngressInterface field
+// on the Query, or the ClassifyHostInboundForInterface scoping) and the
+// ge-0/0/1.0 query folds back to the zone-wide first-admit — status becomes
+// `token-admit`/ssh instead of `denied`, so the deny assertion fails. Drop the
+// per-view ambiguity and the unqualified query reports `token-admit`/ssh instead
+// of `ambiguous`.
+func TestMatchPoliciesRESTIngressInterfaceScopesHostInbound(t *testing.T) {
+	store := mixedHostInboundAPIStore(t)
+	s := &Server{store: store}
+
+	base := func() url.Values {
+		return url.Values{
+			"from_zone": {"trust"}, "to_zone": {"junos-host"},
+			"protocol": {"tcp"}, "dst_port": {"22"},
+		}
+	}
+
+	// ge-0/0/0.0 (ssh override) — admits.
+	admit := base()
+	admit.Set("ingress_interface", "ge-0/0/0.0")
+	if r := matchHostInbound(t, s, admit); r.Data.HostInbound == nil || r.Data.HostInbound.Status != "token-admit" || r.Data.HostInbound.Token != "ssh" {
+		t.Errorf("ingress ge-0/0/0.0 host_inbound = %+v, want token-admit/ssh", r.Data.HostInbound)
+	}
+
+	// ge-0/0/1.0 (no override) — the TRUE posture is DENY, not the zone-wide
+	// first-admit ssh. This is the core #5579 fix.
+	deny := base()
+	deny.Set("ingress_interface", "ge-0/0/1.0")
+	if r := matchHostInbound(t, s, deny); r.Data.HostInbound == nil || r.Data.HostInbound.Status != "denied" {
+		t.Errorf("ingress ge-0/0/1.0 host_inbound = %+v, want denied (false-admission #5579)", r.Data.HostInbound)
+	}
+
+	// Unqualified (no ingress_interface) — the per-interface views disagree, so the
+	// endpoint reports ambiguity instead of the zone-wide first-admit ssh.
+	if r := matchHostInbound(t, s, base()); r.Data.HostInbound == nil || r.Data.HostInbound.Status != "ambiguous" {
+		t.Errorf("unqualified host_inbound = %+v, want ambiguous", r.Data.HostInbound)
+	}
+}
+
+// TestMatchPoliciesRESTIngressInterfaceRejectsBadRef pins the fail-closed
+// validation: an unknown / zone-mismatched / lifeline ingress_interface is a 400,
+// mirroring the src_ip / port / protocol validators, so the host-inbound
+// classifier is never scoped to a bogus interface.
+func TestMatchPoliciesRESTIngressInterfaceRejectsBadRef(t *testing.T) {
+	store := mixedHostInboundAPIStore(t)
+	s := &Server{store: store}
+
+	cases := []struct{ name, iface string }{
+		{"unknown", "ge-9/9/9.9"},
+		{"empty-value-is-not-error", ""}, // absent selector must NOT 400
+	}
+	for _, c := range cases {
+		q := url.Values{"from_zone": {"trust"}, "to_zone": {"junos-host"}, "protocol": {"tcp"}, "dst_port": {"22"}}
+		if c.iface != "" {
+			q.Set("ingress_interface", c.iface)
+		}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v1/security/match?"+q.Encode(), nil)
+		s.matchPoliciesHandler(rr, req)
+		switch c.name {
+		case "unknown":
+			if rr.Code != 400 {
+				t.Errorf("%s: status = %d, want 400; body: %s", c.name, rr.Code, rr.Body.String())
+			}
+		default:
+			if rr.Code != 200 {
+				t.Errorf("%s: status = %d, want 200; body: %s", c.name, rr.Code, rr.Body.String())
+			}
+		}
+	}
+}

--- a/pkg/cli/cli_request_testcmd.go
+++ b/pkg/cli/cli_request_testcmd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/policymatch"
 	"github.com/psaab/xpf/pkg/routing"
 )
@@ -71,6 +72,14 @@ func (c *CLI) testPolicy(args []string) error {
 	parsedSrc := net.ParseIP(srcIP)
 	parsedDst := net.ParseIP(dstIP)
 
+	// #5579: validate the optional ingress-interface selector against the live
+	// config (zone membership + lifeline reject) so the host-inbound classifier is
+	// scoped only to a real interface of the queried zone, failing closed on an
+	// unknown / zone-mismatched / lifeline ref exactly like the other surfaces.
+	if err := dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, sel.IngressInterface); err != nil {
+		return err
+	}
+
 	// #3042: delegate to the single shared simulator (exact zone-pair ->
 	// wildcard-zone tiers (#3090) -> scoped global (#3148) -> default-policy).
 	// The pre-#3042 loop hard-coded "Default deny" (ignoring default-policy
@@ -94,6 +103,9 @@ func (c *CLI) testPolicy(args []string) error {
 		// #5572: a non-first IP fragment (no L4 header) reproduces the #4569
 		// fragment-associated deny; false is a normal L4-present packet.
 		NonFirstFragment: nonFirstFrag,
+		// #5579: scope the host-inbound classifier to this ingress interface's
+		// effective view (validated above). "" = zone-scoped, unchanged.
+		IngressInterface: sel.IngressInterface,
 		FeedOverlay:      c.feedOverlay(),
 		// #3104: skip scheduler-inactive policies like the runtime does, so the
 		// simulator falls through to the next active rule / default-policy.

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -381,6 +381,14 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	parsedSrc := net.ParseIP(srcIP)
 	parsedDst := net.ParseIP(dstIP)
 
+	// #5579: validate the optional ingress-interface selector against the live
+	// config (zone membership + lifeline reject) so the host-inbound classifier is
+	// scoped only to a real interface of the queried zone, failing closed on an
+	// unknown / zone-mismatched / lifeline ref exactly like the REST/gRPC surfaces.
+	if err := dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, sel.IngressInterface); err != nil {
+		return err
+	}
+
 	// #3042: delegate to the single shared simulator so the CLI agrees with
 	// the runtime evaluator. The pre-#3042 loop scanned only zone-pair
 	// policies (never globals), hard-coded "default deny" (ignoring
@@ -404,6 +412,9 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		// #5572: a non-first IP fragment (no L4 header) reproduces the #4569
 		// fragment-associated deny; false is a normal L4-present packet.
 		NonFirstFragment: nonFirstFrag,
+		// #5579: scope the host-inbound classifier to this ingress interface's
+		// effective view (validated above). "" = zone-scoped, unchanged.
+		IngressInterface: sel.IngressInterface,
 		FeedOverlay:      c.feedOverlay(),
 		// #3104: skip scheduler-inactive policies like the runtime does, so the
 		// simulator falls through to the next active rule / default-policy.

--- a/pkg/dataplane/userspace/host_inbound_classify.go
+++ b/pkg/dataplane/userspace/host_inbound_classify.go
@@ -2,6 +2,7 @@ package userspace
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -26,12 +27,19 @@ import (
 // (#3171): ESP/AH raw data plane, ICMP error/PMTUD, and the IPv6 ND set.
 //
 // Faithful to the enforcement paths (plan §5): a zone can carry MULTIPLE
-// per-interface effective views (#3362) — the query has no ingress interface, so
-// admission is reported if ANY view for the ingress zone admits the tuple.
-// Post-#3405 a configured zone with no host-inbound-traffic stanza default-DENIES
-// (its view carries empty token sets), so "unmatched host policy" does NOT imply
-// delivery. Lifeline interfaces (fxp0/em0/fab*) are excluded from the views and
-// so are never classified here (their host traffic is served unconditionally).
+// per-interface effective views (#3362). A zone-scoped query (no ingress
+// interface) classifies EACH view independently and reports HostInboundAmbiguous
+// when they DISAGREE (one interface admits, a sibling default-denies) rather than
+// OR-ing them into a zone-wide first-admit that lies for the denying interfaces
+// (#5579); when the views agree — the common single-view case — it reports that
+// shared verdict. An ingress-interface-scoped query
+// (ClassifyHostInboundForInterface) evaluates ONLY that interface's effective
+// view, so an operator can certify one interface's TRUE posture. Post-#3405 a
+// configured zone with no host-inbound-traffic stanza default-DENIES (its view
+// carries empty token sets), so "unmatched host policy" does NOT imply delivery.
+// Lifeline interfaces (fxp0/em0/fab*) are excluded from the views and so are
+// never classified here (their host traffic is served unconditionally); the
+// ingress-interface selector rejects a lifeline ref for the same reason.
 
 // HostInboundStatus classifies how the ingress zone's host-inbound-traffic
 // admission gate treats a host-bound query tuple (#3627 B1a). It is presence-safe
@@ -57,6 +65,15 @@ const (
 	// HostInboundDenied: the ingress zone's host-inbound-traffic admits nothing
 	// matching this tuple — the box drops the packet (Junos default-deny).
 	HostInboundDenied
+	// HostInboundAmbiguous: the ingress zone carries MULTIPLE distinct effective
+	// host-inbound views (per-interface overrides, #3362) that would classify
+	// this tuple DIFFERENTLY — one interface admits it, another denies it (#5579).
+	// A zone-scoped query cannot answer for the whole zone without lying for the
+	// sibling interfaces, so the classifier reports ambiguity and names the
+	// differing interface groups (Ambiguous) instead of OR-ing them into a
+	// zone-wide first-admit. Supply an ingress-interface selector to get one
+	// interface's true admission.
+	HostInboundAmbiguous
 )
 
 func (s HostInboundStatus) String() string {
@@ -69,6 +86,8 @@ func (s HostInboundStatus) String() string {
 		return "token-admit"
 	case HostInboundDenied:
 		return "denied"
+	case HostInboundAmbiguous:
+		return "ambiguous"
 	default:
 		return "not-computed"
 	}
@@ -84,6 +103,27 @@ type HostInboundAdmission struct {
 	// Kind is the stanza the token belongs to: "system-services" or "protocols".
 	// Set only for HostInboundTokenAdmit.
 	Kind string
+	// Ambiguous carries, for Status == HostInboundAmbiguous, the per-effective-view
+	// verdicts that DISAGREE for this tuple (#5579) — one group of interfaces
+	// admits it, another denies it. It lets the operator see WHICH interfaces have
+	// which posture without re-querying each, and directs them to the
+	// ingress-interface selector for the interface-scoped truth. Empty for every
+	// other status.
+	Ambiguous []HostInboundViewVerdict
+}
+
+// HostInboundViewVerdict is one distinct per-interface host-inbound verdict in a
+// zone that has divergent per-interface effective views (#5579). It pairs the
+// interfaces sharing an effective host-inbound token set with the admission that
+// set produces for the query tuple.
+type HostInboundViewVerdict struct {
+	// Interfaces are the interface refs whose effective host-inbound token set
+	// yields this verdict (may be empty for the zone-default view that no
+	// addressed interface fell into). Sorted.
+	Interfaces []string
+	Status     HostInboundStatus
+	Token      string
+	Kind       string
 }
 
 // Describe renders the operator-facing one-line explanation of the admission,
@@ -102,6 +142,18 @@ func (a HostInboundAdmission) Describe() string {
 		return "DENIED by host-inbound-traffic — no system-service/protocol admits this tuple, so the box drops it"
 	case HostInboundIndeterminate:
 		return "indeterminate — specify protocol (and destination-port or icmp-type) to identify the admitting host-inbound-traffic token"
+	case HostInboundAmbiguous:
+		var parts []string
+		for _, g := range a.Ambiguous {
+			scope := "zone-default"
+			if len(g.Interfaces) > 0 {
+				scope = strings.Join(g.Interfaces, ", ")
+			}
+			parts = append(parts, fmt.Sprintf("[%s] %s", scope,
+				HostInboundAdmission{Status: g.Status, Token: g.Token, Kind: g.Kind}.Describe()))
+		}
+		return "AMBIGUOUS — per-interface host-inbound-traffic posture differs across this zone's interfaces; " +
+			"specify ingress-interface to get one interface's true admission: " + strings.Join(parts, "; ")
 	default:
 		return ""
 	}
@@ -120,15 +172,87 @@ func ClassifyHostInbound(cfg *config.Config, fromZone string, proto uint8, hasPr
 	}
 
 	views := viewsForZone(cfg, fromZone)
+	if len(views) == 0 {
+		// An undefined / unconfigured ingress zone has no effective view; classify
+		// against an empty view so an isolated global-accept (ESP/AH, ICMP error,
+		// IPv6 ND) or an indeterminate/denied verdict is reported exactly as
+		// before the #5579 per-view refactor.
+		return classifyOneView(ZoneHostInboundView{Zone: fromZone}, proto, hasProto, dstPort, icmpType, family)
+	}
 
+	// #5579: classify EACH effective view independently and only fold them into a
+	// single verdict when they AGREE. A zone with no per-interface override yields
+	// exactly one view (pre-#3362 shape), so the common case is byte-identical to
+	// the historical first-admit behavior. When a mixed zone's views DISAGREE
+	// (one interface admits, a sibling default-denies), report HostInboundAmbiguous
+	// with the differing interface groups rather than OR-ing them into a zone-wide
+	// first-admit that lies for the denying interfaces — the false-admission #5579
+	// removes. Supply an ingress-interface selector to resolve one interface.
+	first := classifyOneView(views[0], proto, hasProto, dstPort, icmpType, family)
+	groups := []HostInboundViewVerdict{verdictFor(views[0], first)}
+	agree := true
+	for _, v := range views[1:] {
+		a := classifyOneView(v, proto, hasProto, dstPort, icmpType, family)
+		groups = append(groups, verdictFor(v, a))
+		if a.Status != first.Status || a.Token != first.Token || a.Kind != first.Kind {
+			agree = false
+		}
+	}
+	if agree {
+		return first
+	}
+	return HostInboundAdmission{Status: HostInboundAmbiguous, Ambiguous: groups}
+}
+
+// verdictFor pairs a view's interfaces with the admission it produced (#5579).
+func verdictFor(v ZoneHostInboundView, a HostInboundAdmission) HostInboundViewVerdict {
+	return HostInboundViewVerdict{
+		Interfaces: v.Interfaces,
+		Status:     a.Status,
+		Token:      a.Token,
+		Kind:       a.Kind,
+	}
+}
+
+// ClassifyHostInboundForInterface classifies the host-inbound admission for a
+// SINGLE ingress interface's EFFECTIVE host-inbound view (#5579). Unlike
+// ClassifyHostInbound — which folds every view in the zone with a first-admit OR
+// — it evaluates ONLY ifaceRef's effective token set (zone-level ∪ the
+// per-interface override, #3362, with the same physical→unit inheritance the
+// enforcement view builder uses), so a mixed zone reports the interface's TRUE
+// posture (admit vs deny) instead of a zone-wide first-admit fold. ifaceRef is
+// expected to be a caller-validated interface assigned to fromZone (see
+// ResolveHostInboundIngressInterface); an unresolved zone/interface yields
+// HostInboundNotComputed defensively.
+func ClassifyHostInboundForInterface(cfg *config.Config, fromZone, ifaceRef string, proto uint8, hasProto bool, dstPort int, icmpType *uint8, family string) HostInboundAdmission {
+	if cfg == nil || fromZone == "" || ifaceRef == "" {
+		return HostInboundAdmission{Status: HostInboundNotComputed}
+	}
+	zone := cfg.Security.Zones[fromZone]
+	if zone == nil {
+		return HostInboundAdmission{Status: HostInboundNotComputed}
+	}
+	// Resolve THIS interface's effective host-inbound token set with the same SSOT
+	// the enforcement view builder uses (unionHostInboundTokens over the zone-level
+	// stanza and the per-interface override, physical→unit inheritance included),
+	// then classify that single view.
+	svc, prot := unionHostInboundTokens(zone.HostInboundTraffic, buildInterfaceHostInboundMap(cfg)[ifaceRef])
+	v := ZoneHostInboundView{Zone: fromZone, Interfaces: []string{ifaceRef}, SystemServices: svc, Protocols: prot}
+	return classifyOneView(v, proto, hasProto, dstPort, icmpType, family)
+}
+
+// classifyOneView classifies a host-bound query tuple against a SINGLE effective
+// host-inbound view — the shared per-view core of ClassifyHostInbound and
+// ClassifyHostInboundForInterface (#5579). It mirrors the original whole-zone
+// ordering (full-admit → global pre-accept → indeterminate short-circuits →
+// per-view token admit → default-deny) scoped to one view's token set.
+func classifyOneView(v ZoneHostInboundView, proto uint8, hasProto bool, dstPort int, icmpType *uint8, family string) HostInboundAdmission {
 	// Full-admit (`system-services all` / `any-service`) admits everything,
 	// independent of the tuple — report it even when the tuple is otherwise
 	// indeterminate.
-	for _, v := range views {
-		for _, s := range v.SystemServices {
-			if config.HostInboundFullAdmitService(s) {
-				return HostInboundAdmission{Status: HostInboundTokenAdmit, Token: s, Kind: "system-services"}
-			}
+	for _, s := range v.SystemServices {
+		if config.HostInboundFullAdmitService(s) {
+			return HostInboundAdmission{Status: HostInboundTokenAdmit, Token: s, Kind: "system-services"}
 		}
 	}
 
@@ -153,16 +277,48 @@ func ClassifyHostInbound(cfg *config.Config, fromZone string, proto uint8, hasPr
 	if family == "" {
 		fams = []string{"ip", "ip6"}
 	}
-	for _, v := range views {
-		for _, fam := range fams {
-			if tok, kind, ok := hostInboundViewAdmit(v, proto, dstPort, icmpType, fam); ok {
-				return HostInboundAdmission{Status: HostInboundTokenAdmit, Token: tok, Kind: kind}
-			}
+	for _, fam := range fams {
+		if tok, kind, ok := hostInboundViewAdmit(v, proto, dstPort, icmpType, fam); ok {
+			return HostInboundAdmission{Status: HostInboundTokenAdmit, Token: tok, Kind: kind}
 		}
 	}
 	// The zone is configured (post-#3405 every configured zone enforces) and
-	// nothing admits — default-deny.
+	// nothing in this view admits — default-deny.
 	return HostInboundAdmission{Status: HostInboundDenied}
+}
+
+// ResolveHostInboundIngressInterface validates an ingress-interface selector
+// (#5579) for a host-bound match-policies query: the ref must name an interface
+// assigned to fromZone. It is the SSOT reject used by every operator surface
+// (REST / gRPC / local CLI) so an unknown, zone-mismatched, or lifeline ref
+// fails the query CLOSED with a clear error instead of silently degrading to the
+// zone-wide fold. An empty ref (selector omitted) is not an error. cfg must be
+// non-nil (callers skip validation during the no-config boot window, which
+// returns the default-deny verdict regardless of any interface).
+//
+// A management/cluster lifeline interface (fxp0 / em0 / fab*) is rejected: its
+// host traffic is served UNCONDITIONALLY (excluded from the host-inbound deny),
+// so per-interface host-inbound classification does not describe it — reporting a
+// token/deny verdict for a lifeline would be a fresh false answer. The error
+// tells the operator the lifeline is always served.
+func ResolveHostInboundIngressInterface(cfg *config.Config, fromZone, ifaceRef string) error {
+	if ifaceRef == "" {
+		return nil
+	}
+	if cfg == nil {
+		return nil
+	}
+	if hostInboundLifelineInterface(ifaceRef, hostInboundLifelineSet(cfg)) {
+		return fmt.Errorf("ingress-interface %q is a management/cluster lifeline (fxp0/em0/fab*); its host traffic is served unconditionally and is not subject to per-interface host-inbound classification", ifaceRef)
+	}
+	zone := buildInterfaceZoneMap(cfg)[ifaceRef]
+	if zone == "" {
+		return fmt.Errorf("unknown ingress-interface %q (not assigned to any security zone)", ifaceRef)
+	}
+	if zone != fromZone {
+		return fmt.Errorf("ingress-interface %q is in zone %q, not from-zone %q", ifaceRef, zone, fromZone)
+	}
+	return nil
 }
 
 // viewsForZone returns the host-inbound effective views for the given ingress

--- a/pkg/dataplane/userspace/host_inbound_classify.go
+++ b/pkg/dataplane/userspace/host_inbound_classify.go
@@ -311,6 +311,24 @@ func ResolveHostInboundIngressInterface(cfg *config.Config, fromZone, ifaceRef s
 	if hostInboundLifelineInterface(ifaceRef, hostInboundLifelineSet(cfg)) {
 		return fmt.Errorf("ingress-interface %q is a management/cluster lifeline (fxp0/em0/fab*); its host traffic is served unconditionally and is not subject to per-interface host-inbound classification", ifaceRef)
 	}
+	// The classifier (ClassifyHostInboundForInterface) keys the effective
+	// host-inbound token set on the LOGICAL-UNIT ref via
+	// buildInterfaceHostInboundMap(cfg)[ifaceRef]. A bare-PHYSICAL ref (e.g.
+	// `reth0` / `ge-0/0/0`) is NOT that key: a UNIT-authored override
+	// (`set ... interfaces reth0.50 host-inbound-traffic ...`) lands on the
+	// `reth0.50` key, never on the physical `reth0` key, so classifying the
+	// physical ref would SILENTLY DROP the override and report a FALSE-DENY that
+	// disagrees with the true per-unit posture (#5579 review). Keep the validator's
+	// accepted namespace identical to what the classifier keys on: require a
+	// logical-unit ref, rejecting a bare physical that carries one-or-more units
+	// and pointing the operator at the unit form. (A unit-less physical carrying
+	// only a physical-level override is keyed correctly on the physical key, so it
+	// is not rejected here — it falls through to the zone-membership check.)
+	if !strings.Contains(ifaceRef, ".") {
+		if ic := cfg.Interfaces.Interfaces[ifaceRef]; ic != nil && len(ic.Units) > 0 {
+			return fmt.Errorf("ingress-interface %q is a physical interface; specify the logical unit, e.g. %s.%d", ifaceRef, ifaceRef, smallestUnitNumber(ic.Units))
+		}
+	}
 	zone := buildInterfaceZoneMap(cfg)[ifaceRef]
 	if zone == "" {
 		return fmt.Errorf("unknown ingress-interface %q (not assigned to any security zone)", ifaceRef)
@@ -319,6 +337,23 @@ func ResolveHostInboundIngressInterface(cfg *config.Config, fromZone, ifaceRef s
 		return fmt.Errorf("ingress-interface %q is in zone %q, not from-zone %q", ifaceRef, zone, fromZone)
 	}
 	return nil
+}
+
+// smallestUnitNumber returns the lowest configured unit number of an interface,
+// used to name a representative logical unit in the bare-physical reject message
+// so the operator can copy a ready-to-use ref. Units is never empty at the call
+// site.
+func smallestUnitNumber(units map[int]*config.InterfaceUnit) int {
+	min := -1
+	for u := range units {
+		if min == -1 || u < min {
+			min = u
+		}
+	}
+	if min == -1 {
+		return 0
+	}
+	return min
 }
 
 // viewsForZone returns the host-inbound effective views for the given ingress

--- a/pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go
+++ b/pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go
@@ -163,6 +163,40 @@ func Test_5579_ResolveIngressInterfaceRejectsLifeline(t *testing.T) {
 	}
 }
 
+// Test_5579_ResolveIngressInterfaceRejectsBarePhysical guards the review fold: a
+// bare-PHYSICAL ingress-interface ref (e.g. `reth0`, whose unit reth0.50 admits
+// ssh) must be REJECTED, because the classifier keys the effective host-inbound
+// set on the LOGICAL-UNIT ref — a bare physical would silently drop the
+// unit-authored override and report a FALSE-DENY. The validator's accepted
+// namespace must equal what the classifier keys on.
+//
+// RED-on-revert: drop the bare-physical reject and `reth0` is accepted, then
+// ClassifyHostInboundForInterface(cfg, "wan", "reth0", ...) keys on the physical
+// ref (no unit-level override) and returns HostInboundDenied — a false-deny that
+// disagrees with reth0.50's token-admit. Both assertions below then fail.
+func Test_5579_ResolveIngressInterfaceRejectsBarePhysical(t *testing.T) {
+	cfg := hostInboundCfg3362() // reth0 has unit 50 (ssh override); reth1 has unit 0.
+
+	err := ResolveHostInboundIngressInterface(cfg, "wan", "reth0")
+	if err == nil {
+		t.Fatal("bare-physical reth0 accepted, want reject (classifier keys on the logical unit)")
+	}
+	if !strings.Contains(err.Error(), "reth0.50") {
+		t.Errorf("bare-physical reject error = %q, want it to name the logical unit reth0.50", err)
+	}
+
+	// The false-deny the reject prevents: the physical ref, if classified, drops
+	// the unit-authored ssh override and denies, while the logical unit admits.
+	physical := ClassifyHostInboundForInterface(cfg, "wan", "reth0", hi5579TCP, true, 22, nil, "ip")
+	unit := ClassifyHostInboundForInterface(cfg, "wan", "reth0.50", hi5579TCP, true, 22, nil, "ip")
+	if unit.Status != HostInboundTokenAdmit || unit.Token != "ssh" {
+		t.Errorf("reth0.50 = %v/%q, want token-admit/ssh", unit.Status, unit.Token)
+	}
+	if physical.Status == unit.Status && physical.Token == unit.Token {
+		t.Errorf("physical reth0 classify (%v/%q) matched the unit — the namespace gap that the reject guards is gone; the reject is the load-bearing fix", physical.Status, physical.Token)
+	}
+}
+
 func ifaceInGroup(ifaces []string, want string) bool {
 	for _, i := range ifaces {
 		if i == want {

--- a/pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go
+++ b/pkg/dataplane/userspace/host_inbound_classify_iface_5579_test.go
@@ -1,0 +1,173 @@
+package userspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// host_inbound_classify_iface_5579_test.go guards the #5579 per-interface
+// host-inbound classification: the match-policies host-inbound classifier used to
+// OR every effective view in a zone and return on the FIRST admitting view, so a
+// MIXED zone (one interface with an ssh override, a sibling default-deny) reported
+// a zone-wide token-admit even for the sibling interface the runtime denies. The
+// classifier now (a) reports HostInboundAmbiguous for an unqualified zone-scoped
+// query when the per-interface views disagree, and (b) classifies ONLY the named
+// interface's effective view when an ingress interface is supplied.
+
+const (
+	hi5579TCP = uint8(6)
+)
+
+// Test_5579_ZoneScopedMixedZoneIsAmbiguous asserts an UNQUALIFIED (no ingress
+// interface) host-inbound classification of a mixed zone reports ambiguity rather
+// than folding the divergent per-interface views into a zone-wide first-admit.
+//
+// hostInboundCfg3362() builds a `wan` zone where reth0.50 admits ssh (override)
+// and reth1.0 default-denies (no override, no zone-level stanza). A tcp/22 query
+// therefore admits on reth0.50 and denies on reth1.0.
+//
+// RED-on-revert: revert ClassifyHostInbound to the pre-#5579 first-admit fold
+// (return on the first admitting view) and this query returns HostInboundTokenAdmit
+// ("ssh") — the false zone-wide admission — instead of HostInboundAmbiguous, so
+// the status assertion below fails.
+func Test_5579_ZoneScopedMixedZoneIsAmbiguous(t *testing.T) {
+	cfg := hostInboundCfg3362()
+
+	got := ClassifyHostInbound(cfg, "wan", hi5579TCP, true, 22, nil, "ip")
+	if got.Status != HostInboundAmbiguous {
+		t.Fatalf("zone-scoped tcp/22 status = %v, want ambiguous (reth0.50 admits ssh, reth1.0 denies)", got.Status)
+	}
+	// The ambiguity report must name BOTH divergent interface groups so the
+	// operator sees which admits and which denies.
+	if len(got.Ambiguous) < 2 {
+		t.Fatalf("ambiguous groups = %d, want >= 2 (the admit + deny views)", len(got.Ambiguous))
+	}
+	var sawAdmit, sawDeny bool
+	for _, g := range got.Ambiguous {
+		switch g.Status {
+		case HostInboundTokenAdmit:
+			if g.Token == "ssh" && ifaceInGroup(g.Interfaces, "reth0.50") {
+				sawAdmit = true
+			}
+		case HostInboundDenied:
+			if ifaceInGroup(g.Interfaces, "reth1.0") {
+				sawDeny = true
+			}
+		}
+	}
+	if !sawAdmit {
+		t.Errorf("ambiguous groups %+v missing the reth0.50 ssh token-admit", got.Ambiguous)
+	}
+	if !sawDeny {
+		t.Errorf("ambiguous groups %+v missing the reth1.0 deny", got.Ambiguous)
+	}
+	// Describe() must direct the operator at the ingress-interface selector.
+	if d := got.Describe(); !strings.Contains(d, "ingress-interface") {
+		t.Errorf("ambiguous Describe() = %q, want it to mention ingress-interface", d)
+	}
+}
+
+// Test_5579_IngressInterfaceScopesToTruePosture is the core fail-on-revert: a
+// query scoped to a SPECIFIC ingress interface reports THAT interface's true
+// host-inbound posture — admit for the ssh-override interface, DENY for the
+// sibling — not the zone-wide first-admit fold.
+//
+// RED-on-revert: revert ClassifyHostInboundForInterface to delegate to the
+// zone-wide ClassifyHostInbound (first-admit OR across all views) and the reth1.0
+// query folds to the zone's ssh admit — HostInboundTokenAdmit instead of
+// HostInboundDenied — so the deny assertion fails.
+func Test_5579_IngressInterfaceScopesToTruePosture(t *testing.T) {
+	cfg := hostInboundCfg3362()
+
+	admit := ClassifyHostInboundForInterface(cfg, "wan", "reth0.50", hi5579TCP, true, 22, nil, "ip")
+	if admit.Status != HostInboundTokenAdmit || admit.Token != "ssh" {
+		t.Errorf("reth0.50 tcp/22 = %v/%q, want token-admit/ssh", admit.Status, admit.Token)
+	}
+
+	deny := ClassifyHostInboundForInterface(cfg, "wan", "reth1.0", hi5579TCP, true, 22, nil, "ip")
+	if deny.Status != HostInboundDenied {
+		t.Errorf("reth1.0 tcp/22 = %v, want denied (sibling has no host-inbound override, default-deny)", deny.Status)
+	}
+}
+
+// Test_5579_IngressInterfaceUnionWithZoneLevel asserts the interface-scoped
+// classifier honors the zone-level ∪ per-interface UNION (Junos additive
+// semantics): a zone-level `ping` plus reth0.50's `ssh` override admits ssh on
+// reth0.50, while reth1.0 admits only the zone-level ping and denies ssh.
+func Test_5579_IngressInterfaceUnionWithZoneLevel(t *testing.T) {
+	cfg := hostInboundCfg3362()
+	cfg.Security.Zones["wan"].HostInboundTraffic = &config.HostInboundTraffic{SystemServices: []string{"ping"}}
+
+	// reth1.0 admits the zone-level ping (icmp echo type 8) but denies ssh.
+	if a := ClassifyHostInboundForInterface(cfg, "wan", "reth1.0", uint8(1), true, 0, u8ptr(8), "ip"); a.Status != HostInboundTokenAdmit || a.Token != "ping" {
+		t.Errorf("reth1.0 icmp echo = %v/%q, want token-admit/ping (zone-level)", a.Status, a.Token)
+	}
+	if a := ClassifyHostInboundForInterface(cfg, "wan", "reth1.0", hi5579TCP, true, 22, nil, "ip"); a.Status != HostInboundDenied {
+		t.Errorf("reth1.0 tcp/22 = %v, want denied (ssh only on reth0.50)", a.Status)
+	}
+	// reth0.50 admits ssh (override) AND ping (zone-level union).
+	if a := ClassifyHostInboundForInterface(cfg, "wan", "reth0.50", hi5579TCP, true, 22, nil, "ip"); a.Status != HostInboundTokenAdmit || a.Token != "ssh" {
+		t.Errorf("reth0.50 tcp/22 = %v/%q, want token-admit/ssh", a.Status, a.Token)
+	}
+}
+
+// Test_5579_ResolveIngressInterfaceValidation guards the fail-closed selector
+// validator: an unknown interface, a zone-mismatched interface, and a
+// management/cluster lifeline are all rejected; a real interface of the queried
+// zone and an empty (omitted) selector pass.
+func Test_5579_ResolveIngressInterfaceValidation(t *testing.T) {
+	cfg := hostInboundCfg3362()
+
+	if err := ResolveHostInboundIngressInterface(cfg, "wan", "reth0.50"); err != nil {
+		t.Errorf("valid reth0.50 rejected: %v", err)
+	}
+	if err := ResolveHostInboundIngressInterface(cfg, "wan", ""); err != nil {
+		t.Errorf("empty (omitted) selector rejected: %v", err)
+	}
+	if err := ResolveHostInboundIngressInterface(cfg, "wan", "ge-9/9/9.9"); err == nil {
+		t.Error("unknown interface accepted, want reject")
+	}
+
+	// Zone-mismatch: add a second zone owning a different interface.
+	cfg.Interfaces.Interfaces["reth2"] = &config.InterfaceConfig{Name: "reth2", Units: map[int]*config.InterfaceUnit{
+		0: {Number: 0, Addresses: []string{"10.0.99.1/24"}},
+	}}
+	cfg.Security.Zones["lan"] = &config.ZoneConfig{Name: "lan", Interfaces: []string{"reth2.0"}}
+	if err := ResolveHostInboundIngressInterface(cfg, "wan", "reth2.0"); err == nil {
+		t.Error("zone-mismatched reth2.0 (in lan) accepted for from-zone wan, want reject")
+	}
+}
+
+// Test_5579_ResolveIngressInterfaceRejectsLifeline asserts a management/cluster
+// lifeline (fxp0) is rejected — its host traffic is served unconditionally, so a
+// per-interface host-inbound verdict would be a fresh false answer.
+func Test_5579_ResolveIngressInterfaceRejectsLifeline(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"fxp0": {Name: "fxp0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.0.2/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"mgmt": {Name: "mgmt", Interfaces: []string{"fxp0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	err := ResolveHostInboundIngressInterface(cfg, "mgmt", "fxp0.0")
+	if err == nil {
+		t.Fatal("lifeline fxp0.0 accepted, want reject (served unconditionally)")
+	}
+	if !strings.Contains(err.Error(), "lifeline") {
+		t.Errorf("lifeline reject error = %q, want it to mention lifeline", err)
+	}
+}
+
+func ifaceInGroup(ifaces []string, want string) bool {
+	for _, i := range ifaces {
+		if i == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -210,6 +210,16 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		return nil, status.Errorf(codes.InvalidArgument, "invalid icmp-code: %v", err)
 	}
 
+	// #5579: validate the optional ingress-interface selector against the live
+	// config — it must name an interface assigned to from_zone, and must not be a
+	// management/cluster lifeline (served unconditionally). An unknown /
+	// zone-mismatched / lifeline ref is a fail-closed InvalidArgument, mirroring
+	// the src_ip / port / protocol validators above, so the host-inbound
+	// classifier is only ever scoped to a real interface of the queried zone.
+	if err := dpuserspace.ResolveHostInboundIngressInterface(cfg, req.FromZone, req.IngressInterface); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
 	// #3042: delegate to the single shared simulator so gRPC agrees with the
 	// runtime evaluator (exact zone-pair -> wildcard-zone tiers (#3090) ->
 	// scoped global (#3148) -> default-policy, predefined + nested-app-set +
@@ -235,6 +245,9 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		// reproduces the #4569 fragment-associated deny. false (default) is a
 		// normal L4-present packet, so an existing client is unchanged.
 		NonFirstFragment: req.NonFirstFragment,
+		// #5579: scope the host-inbound classifier to this ingress interface's
+		// effective view (validated above). "" = zone-scoped, unchanged.
+		IngressInterface: req.IngressInterface,
 		FeedOverlay:      overlay,
 		// #3104: skip scheduler-inactive policies like the runtime does, so the
 		// simulator falls through to the next active rule / default-policy.
@@ -406,6 +419,8 @@ func hostInboundStatusToProto(s dpuserspace.HostInboundStatus) pb.HostInboundAdm
 		return pb.HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_TOKEN_ADMIT
 	case dpuserspace.HostInboundDenied:
 		return pb.HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_DENIED
+	case dpuserspace.HostInboundAmbiguous:
+		return pb.HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS
 	default:
 		return pb.HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_NOT_COMPUTED
 	}

--- a/pkg/grpcapi/server_matchpolicies_ingress_iface_5579_test.go
+++ b/pkg/grpcapi/server_matchpolicies_ingress_iface_5579_test.go
@@ -1,0 +1,105 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// server_matchpolicies_ingress_iface_5579_test.go pins the #5579 gRPC
+// ingress-interface selector. A mixed `trust` zone exposes ssh host-inbound on
+// ge-0/0/0.0 only; the sibling ge-0/0/1.0 default-denies host SSH. Before #5579
+// the gRPC match-policies host-inbound classifier folded every effective view in
+// the zone with a first-admit OR, reporting a zone-wide TOKEN_ADMIT/ssh even for a
+// packet entering ge-0/0/1.0 — a false admission. It now scopes to one interface's
+// TRUE posture when ingress_interface is set, and reports AMBIGUOUS when the
+// per-interface views disagree.
+
+// mixedHostInboundGRPCStore builds the mixed-zone config via set commands.
+func mixedHostInboundGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(`set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.10/24
+set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.10/24
+set security zones security-zone trust interfaces ge-0/0/0.0 host-inbound-traffic system-services ssh
+set security zones security-zone trust interfaces ge-0/0/1.0
+set security policies default-policy deny-all`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestMatchPoliciesGRPCIngressInterfaceScopesHostInbound is the gRPC
+// fail-on-revert for #5579.
+//
+// RED-on-revert: drop the ingress_interface plumbing (Query.IngressInterface or
+// ClassifyHostInboundForInterface) and the ge-0/0/1.0 query folds to the zone-wide
+// first-admit — TOKEN_ADMIT/ssh instead of DENIED. Drop the per-view ambiguity and
+// the unqualified query returns TOKEN_ADMIT/ssh instead of AMBIGUOUS.
+func TestMatchPoliciesGRPCIngressInterfaceScopesHostInbound(t *testing.T) {
+	s := &Server{store: mixedHostInboundGRPCStore(t)}
+
+	base := func() *pb.MatchPoliciesRequest {
+		return &pb.MatchPoliciesRequest{FromZone: "trust", ToZone: "junos-host", Protocol: "tcp", DestinationPort: 22}
+	}
+
+	// ge-0/0/0.0 (ssh override) — admits.
+	admitReq := base()
+	admitReq.IngressInterface = "ge-0/0/0.0"
+	admit, err := s.MatchPolicies(context.Background(), admitReq)
+	if err != nil {
+		t.Fatalf("MatchPolicies(ge-0/0/0.0) error = %v", err)
+	}
+	if admit.HostInbound == nil ||
+		admit.HostInbound.Status != pb.HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_TOKEN_ADMIT ||
+		admit.HostInbound.Token != "ssh" {
+		t.Errorf("ge-0/0/0.0 host_inbound = %+v, want TOKEN_ADMIT/ssh", admit.HostInbound)
+	}
+
+	// ge-0/0/1.0 (no override) — TRUE posture is DENY, not the zone-wide ssh. Core fix.
+	denyReq := base()
+	denyReq.IngressInterface = "ge-0/0/1.0"
+	deny, err := s.MatchPolicies(context.Background(), denyReq)
+	if err != nil {
+		t.Fatalf("MatchPolicies(ge-0/0/1.0) error = %v", err)
+	}
+	if deny.HostInbound == nil ||
+		deny.HostInbound.Status != pb.HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_DENIED {
+		t.Errorf("ge-0/0/1.0 host_inbound = %+v, want DENIED (false-admission #5579)", deny.HostInbound)
+	}
+
+	// Unqualified — the per-interface views disagree, so report AMBIGUOUS.
+	amb, err := s.MatchPolicies(context.Background(), base())
+	if err != nil {
+		t.Fatalf("MatchPolicies(unqualified) error = %v", err)
+	}
+	if amb.HostInbound == nil ||
+		amb.HostInbound.Status != pb.HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS {
+		t.Errorf("unqualified host_inbound = %+v, want AMBIGUOUS", amb.HostInbound)
+	}
+}
+
+// TestMatchPoliciesGRPCIngressInterfaceRejectsBadRef pins the fail-closed
+// validation: an unknown / zone-mismatched ingress_interface is InvalidArgument.
+func TestMatchPoliciesGRPCIngressInterfaceRejectsBadRef(t *testing.T) {
+	s := &Server{store: mixedHostInboundGRPCStore(t)}
+
+	_, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "trust", ToZone: "junos-host", Protocol: "tcp", DestinationPort: 22,
+		IngressInterface: "ge-9/9/9.9",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("unknown ingress_interface error code = %v, want InvalidArgument", status.Code(err))
+	}
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -314,6 +314,10 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			}
 		}
 	}
+	// #5579: resolve the ingress-interface validation once (cfg==nil returns nil,
+	// so this is safe before the cfg==nil case; the switch surfaces it only after
+	// the cfg / grammar / zone checks below).
+	ingressErr := dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, ingressIface)
 	switch {
 	case cfg == nil:
 		buf.WriteString("No active configuration\n")
@@ -345,11 +349,12 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 		fmt.Fprintf(buf, "invalid src %q\n", srcIP)
 	case dstIP != "" && net.ParseIP(dstIP) == nil:
 		fmt.Fprintf(buf, "invalid dst %q\n", dstIP)
-	case dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, ingressIface) != nil:
-		// #5579: an unknown / zone-mismatched / lifeline ingress-interface fails
-		// the query closed, so the host-inbound classifier is only scoped to a real
-		// interface of the queried zone (parity with the REST/gRPC/local surfaces).
-		fmt.Fprintf(buf, "%v\n", dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, ingressIface))
+	case ingressErr != nil:
+		// #5579: an unknown / zone-mismatched / lifeline / bare-physical
+		// ingress-interface fails the query closed, so the host-inbound classifier
+		// is only scoped to a real logical-unit interface of the queried zone
+		// (parity with the REST/gRPC/local surfaces).
+		fmt.Fprintf(buf, "%v\n", ingressErr)
 	default:
 		// #3103: route the gRPC `test policy` diagnostic through the single
 		// shared simulator (pkg/policymatch) so it agrees with the runtime

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -207,7 +207,7 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 
 func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf *strings.Builder) (*pb.ShowTextResponse, error) {
 	params := strings.TrimPrefix(req.Topic, "test-policy:")
-	var fromZone, toZone, srcIP, dstIP, proto string
+	var fromZone, toZone, srcIP, dstIP, proto, ingressIface string
 	var srcPort, dstPort int
 	var icmpType, icmpCode *uint8
 	var nonFirstFrag bool
@@ -298,6 +298,12 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 				// selector. Parse as a bool; a malformed value errors like a bad
 				// port rather than silently degrading to a normal-packet query.
 				nonFirstFrag, fragErr = strconv.ParseBool(parts[1])
+			case "iif":
+				// #5579: ingress-interface selector — the remote CLI `test policy`
+				// emits `iif=<ref>` for the `ingress-interface` selector. The ref is
+				// validated against the live config (zone membership + lifeline
+				// reject) below, before evaluation.
+				ingressIface = parts[1]
 			default:
 				// #3696: an unknown selector key (e.g. `prot=tcp`, a plausible
 				// operator abbreviation of `proto`) must not be silently ignored,
@@ -339,6 +345,11 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 		fmt.Fprintf(buf, "invalid src %q\n", srcIP)
 	case dstIP != "" && net.ParseIP(dstIP) == nil:
 		fmt.Fprintf(buf, "invalid dst %q\n", dstIP)
+	case dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, ingressIface) != nil:
+		// #5579: an unknown / zone-mismatched / lifeline ingress-interface fails
+		// the query closed, so the host-inbound classifier is only scoped to a real
+		// interface of the queried zone (parity with the REST/gRPC/local surfaces).
+		fmt.Fprintf(buf, "%v\n", dpuserspace.ResolveHostInboundIngressInterface(cfg, fromZone, ingressIface))
 	default:
 		// #3103: route the gRPC `test policy` diagnostic through the single
 		// shared simulator (pkg/policymatch) so it agrees with the runtime
@@ -369,6 +380,9 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			// #5572: non-first-fragment (l4_present == false) reproduces the
 			// #4569 fragment-associated deny; false is a normal L4 packet.
 			NonFirstFragment: nonFirstFrag,
+			// #5579: scope the host-inbound classifier to this ingress interface's
+			// effective view (validated above). "" = zone-scoped, unchanged.
+			IngressInterface: ingressIface,
 			FeedOverlay:      overlay,
 			// #3104: skip scheduler-inactive policies like the runtime does, so
 			// the `test policy` diagnostic falls through to the next active rule

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -203,6 +203,13 @@ const (
 	// The ingress zone's host-inbound-traffic admits nothing matching this tuple
 	// — the box drops the packet (Junos default-deny).
 	HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_DENIED HostInboundAdmissionStatus = 4
+	// The ingress zone carries MULTIPLE distinct per-interface host-inbound
+	// effective views (#3362) that classify this tuple DIFFERENTLY — one interface
+	// admits it, another denies it (#5579). A zone-scoped query cannot answer for
+	// the whole zone without lying for the sibling interfaces; the differing
+	// interface groups are named in `description`. Supply ingress_interface to get
+	// one interface's true admission.
+	HostInboundAdmissionStatus_HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS HostInboundAdmissionStatus = 5
 )
 
 // Enum value maps for HostInboundAdmissionStatus.
@@ -213,6 +220,7 @@ var (
 		2: "HOST_INBOUND_ADMISSION_STATUS_GLOBAL_ACCEPT",
 		3: "HOST_INBOUND_ADMISSION_STATUS_TOKEN_ADMIT",
 		4: "HOST_INBOUND_ADMISSION_STATUS_DENIED",
+		5: "HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS",
 	}
 	HostInboundAdmissionStatus_value = map[string]int32{
 		"HOST_INBOUND_ADMISSION_STATUS_NOT_COMPUTED":  0,
@@ -220,6 +228,7 @@ var (
 		"HOST_INBOUND_ADMISSION_STATUS_GLOBAL_ACCEPT": 2,
 		"HOST_INBOUND_ADMISSION_STATUS_TOKEN_ADMIT":   3,
 		"HOST_INBOUND_ADMISSION_STATUS_DENIED":        4,
+		"HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS":     5,
 	}
 )
 
@@ -6581,6 +6590,18 @@ type MatchPoliciesRequest struct {
 	// fabricated port-0 permit. false (default) = a normal L4-present packet, so
 	// an existing client is unchanged.
 	NonFirstFragment bool `protobuf:"varint,10,opt,name=non_first_fragment,json=nonFirstFragment,proto3" json:"non_first_fragment,omitempty"`
+	// ingress_interface scopes a `to-zone junos-host` host-inbound query to ONE
+	// ingress interface's effective host-inbound view (#5579). A zone can carry
+	// multiple per-interface host-inbound views (#3362); without this selector the
+	// classifier reports "ambiguous" when they disagree. With it, only this
+	// interface's effective view (zone-level ∪ per-interface override) is
+	// classified, so an operator can certify one interface's TRUE host-inbound
+	// posture (admit vs deny) instead of a zone-wide first-admit fold. The ref must
+	// name an interface assigned to from_zone; an unknown / zone-mismatched /
+	// lifeline ref is InvalidArgument. "" (default) = zone-scoped, so an existing
+	// client is unchanged. It affects ONLY the host_inbound annotation, never the
+	// policy match verdict.
+	IngressInterface string `protobuf:"bytes,11,opt,name=ingress_interface,json=ingressInterface,proto3" json:"ingress_interface,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -6683,6 +6704,13 @@ func (x *MatchPoliciesRequest) GetNonFirstFragment() bool {
 		return x.NonFirstFragment
 	}
 	return false
+}
+
+func (x *MatchPoliciesRequest) GetIngressInterface() string {
+	if x != nil {
+		return x.IngressInterface
+	}
+	return ""
 }
 
 type MatchPoliciesResponse struct {
@@ -8684,7 +8712,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\x05state\x18\x03 \x01(\tR\x05state\x12\x1a\n" +
 	"\bpriority\x18\x04 \x01(\x05R\bpriority\x12+\n" +
 	"\x11virtual_addresses\x18\x05 \x03(\tR\x10virtualAddresses\x12\x18\n" +
-	"\apreempt\x18\x06 \x01(\bR\apreempt\"\x86\x03\n" +
+	"\apreempt\x18\x06 \x01(\bR\apreempt\"\xb3\x03\n" +
 	"\x14MatchPoliciesRequest\x12\x1b\n" +
 	"\tfrom_zone\x18\x01 \x01(\tR\bfromZone\x12\x17\n" +
 	"\ato_zone\x18\x02 \x01(\tR\x06toZone\x12\x1b\n" +
@@ -8697,7 +8725,8 @@ const file_xpf_proto_rawDesc = "" +
 	"\ticmp_type\x18\b \x01(\rH\x00R\bicmpType\x88\x01\x01\x12 \n" +
 	"\ticmp_code\x18\t \x01(\rH\x01R\bicmpCode\x88\x01\x01\x12,\n" +
 	"\x12non_first_fragment\x18\n" +
-	" \x01(\bR\x10nonFirstFragmentB\f\n" +
+	" \x01(\bR\x10nonFirstFragment\x12+\n" +
+	"\x11ingress_interface\x18\v \x01(\tR\x10ingressInterfaceB\f\n" +
 	"\n" +
 	"_icmp_typeB\f\n" +
 	"\n" +
@@ -8830,13 +8859,14 @@ const file_xpf_proto_rawDesc = "" +
 	"&MONITOR_INTERFACE_SUMMARY_MODE_PACKETS\x10\x01\x12(\n" +
 	"$MONITOR_INTERFACE_SUMMARY_MODE_BYTES\x10\x02\x12(\n" +
 	"$MONITOR_INTERFACE_SUMMARY_MODE_DELTA\x10\x03\x12'\n" +
-	"#MONITOR_INTERFACE_SUMMARY_MODE_RATE\x10\x04*\x87\x02\n" +
+	"#MONITOR_INTERFACE_SUMMARY_MODE_RATE\x10\x04*\xb4\x02\n" +
 	"\x1aHostInboundAdmissionStatus\x12.\n" +
 	"*HOST_INBOUND_ADMISSION_STATUS_NOT_COMPUTED\x10\x00\x12/\n" +
 	"+HOST_INBOUND_ADMISSION_STATUS_INDETERMINATE\x10\x01\x12/\n" +
 	"+HOST_INBOUND_ADMISSION_STATUS_GLOBAL_ACCEPT\x10\x02\x12-\n" +
 	")HOST_INBOUND_ADMISSION_STATUS_TOKEN_ADMIT\x10\x03\x12(\n" +
-	"$HOST_INBOUND_ADMISSION_STATUS_DENIED\x10\x04*\x97\x01\n" +
+	"$HOST_INBOUND_ADMISSION_STATUS_DENIED\x10\x04\x12+\n" +
+	"'HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS\x10\x05*\x97\x01\n" +
 	"\x0fPeerFetchStatus\x12!\n" +
 	"\x1dPEER_FETCH_STATUS_UNSPECIFIED\x10\x00\x12$\n" +
 	" PEER_FETCH_STATUS_NOT_APPLICABLE\x10\x01\x12\x18\n" +

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -208,6 +208,8 @@ const matchPoliciesUsageTail = ` from-zone <zone> to-zone <zone>
        [source-port <0-65535>] [destination-port <0-65535>]
        [protocol <name|number>]   tcp, udp, icmp, icmp6, gre, esp, ospf, ... or 0-255
        [icmp-type <0-255>] [icmp-code <0-255>]
+       [ingress-interface <if>]   scope host-inbound (to-zone junos-host) to one
+                                  interface's effective host-inbound view
        [non-first-fragment]       simulate a non-first IP fragment (no L4 header)
        from-zone and to-zone are required; an omitted selector matches any.
        an unknown selector, or a selector given without a value, is an error
@@ -244,6 +246,21 @@ type Query struct {
 	Protocol string // "tcp", "udp", "89", "ospf", ... ("" = unspecified)
 	SrcPort  int
 	DstPort  int
+
+	// IngressInterface scopes a `to-zone junos-host` query's host-inbound
+	// admission to ONE ingress interface's effective host-inbound view (#5579).
+	// A zone can carry multiple per-interface host-inbound effective views
+	// (#3362); without this selector the classifier reports HostInboundAmbiguous
+	// when they disagree. With it, the classifier evaluates ONLY this interface's
+	// effective view (zone-level ∪ per-interface override), so an operator can
+	// certify one interface's TRUE host-inbound posture (admit vs deny) instead of
+	// a zone-wide fold. The ref must name an interface assigned to FromZone; a
+	// caller validates it via dataplane/userspace.ResolveHostInboundIngressInterface
+	// before building the Query, so an invalid ref never reaches here. "" =
+	// unspecified (zone-scoped classification, unchanged for every existing
+	// caller). It affects ONLY the host-inbound classifier annotation, never the
+	// transit/host policy match verdict.
+	IngressInterface string
 
 	// ICMPType / ICMPCode carry the query packet's ICMP/ICMPv6 type and code
 	// (#3284). They mirror the dataplane's per-packet `packet_icmp` tuple
@@ -350,6 +367,13 @@ type SelectorArgs struct {
 	DstPort  int    // 0 = unspecified
 	ICMPType *uint8 // nil = unspecified
 	ICMPCode *uint8 // nil = unspecified
+
+	// IngressInterface scopes a `to-zone junos-host` host-inbound query to one
+	// ingress interface's effective host-inbound view (#5579). "" = unspecified
+	// (zone-scoped classification). The parser accepts any non-empty token; the
+	// ref is validated against the live config (zone membership, lifeline reject)
+	// at the surface that has cfg, not here.
+	IngressInterface string
 
 	// NonFirstFragment is the #5572 non-first-fragment / no-L4 discriminator.
 	// false (default) = a normal L4-present packet, unchanged for every existing
@@ -492,6 +516,19 @@ func ParseSelectorArgs(args []string) (SelectorArgs, error) {
 				return SelectorArgs{}, err
 			}
 			s.Protocol = v
+		case "ingress-interface":
+			// #5579: the ingress interface whose EFFECTIVE host-inbound view a
+			// `to-zone junos-host` query is classified against. Value-taking and
+			// duplicate-checked like every other selector; the token is a free-form
+			// interface ref (e.g. `ge-0/0/0.0`) validated against the live config at
+			// the surface that has cfg (zone membership + lifeline reject), so no
+			// per-value validation happens here beyond the shared present-but-empty
+			// / duplicate guards in takeValue.
+			v, err := takeValue(&i, "ingress-interface")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			s.IngressInterface = v
 		case "icmp-type":
 			v, err := takeValue(&i, "icmp-type")
 			if err != nil {
@@ -547,6 +584,7 @@ func (s SelectorArgs) Query() Query {
 		ICMPType:         s.ICMPType,
 		ICMPCode:         s.ICMPCode,
 		NonFirstFragment: s.NonFirstFragment,
+		IngressInterface: s.IngressInterface,
 	}
 }
 
@@ -1201,6 +1239,16 @@ func hostInboundAdmission(cfg *config.Config, q Query) *dpuserspace.HostInboundA
 		family = ipFamily(q.DstIP)
 	case q.SrcIP != nil:
 		family = ipFamily(q.SrcIP)
+	}
+	// #5579: when the query names an ingress interface, scope the host-inbound
+	// classification to THAT interface's effective view (admit vs deny for the
+	// interface, not a zone-wide first-admit fold). The ref is validated against
+	// the config at the operator surface before the Query is built. Without the
+	// selector, the zone-scoped classifier reports HostInboundAmbiguous if the
+	// zone's per-interface views disagree.
+	if q.IngressInterface != "" {
+		adm := dpuserspace.ClassifyHostInboundForInterface(cfg, q.FromZone, q.IngressInterface, proto, hasProto, q.DstPort, q.ICMPType, family)
+		return &adm
 	}
 	adm := dpuserspace.ClassifyHostInbound(cfg, q.FromZone, proto, hasProto, q.DstPort, q.ICMPType, family)
 	return &adm

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -756,6 +756,18 @@ message MatchPoliciesRequest {
   // fabricated port-0 permit. false (default) = a normal L4-present packet, so
   // an existing client is unchanged.
   bool non_first_fragment = 10;
+  // ingress_interface scopes a `to-zone junos-host` host-inbound query to ONE
+  // ingress interface's effective host-inbound view (#5579). A zone can carry
+  // multiple per-interface host-inbound views (#3362); without this selector the
+  // classifier reports "ambiguous" when they disagree. With it, only this
+  // interface's effective view (zone-level ∪ per-interface override) is
+  // classified, so an operator can certify one interface's TRUE host-inbound
+  // posture (admit vs deny) instead of a zone-wide first-admit fold. The ref must
+  // name an interface assigned to from_zone; an unknown / zone-mismatched /
+  // lifeline ref is InvalidArgument. "" (default) = zone-scoped, so an existing
+  // client is unchanged. It affects ONLY the host_inbound annotation, never the
+  // policy match verdict.
+  string ingress_interface = 11;
 }
 message MatchPoliciesResponse {
   string policy_name = 1;
@@ -937,6 +949,13 @@ enum HostInboundAdmissionStatus {
   // The ingress zone's host-inbound-traffic admits nothing matching this tuple
   // — the box drops the packet (Junos default-deny).
   HOST_INBOUND_ADMISSION_STATUS_DENIED = 4;
+  // The ingress zone carries MULTIPLE distinct per-interface host-inbound
+  // effective views (#3362) that classify this tuple DIFFERENTLY — one interface
+  // admits it, another denies it (#5579). A zone-scoped query cannot answer for
+  // the whole zone without lying for the sibling interfaces; the differing
+  // interface groups are named in `description`. Supply ingress_interface to get
+  // one interface's true admission.
+  HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS = 5;
 }
 
 // HostInboundAdmission is the structured host-inbound-traffic classifier verdict


### PR DESCRIPTION
Closes #5579

## Problem
The match-policies policy simulator (REST / gRPC / CLI) had **no ingress-interface selector**, while its shared host-inbound classifier iterated **every** effective view in the ingress zone and returned on the **first admitting** view. In a mixed zone — one unit with an SSH `host-inbound-traffic` override, a sibling unit default-denying host SSH — a `to-zone junos-host` query reported a zone-wide `token-admit`/permit **even for a packet entering the sibling interface the runtime denies**. That is a false-admission diagnosis on a security-verification endpoint (vSRX parity: operators/automation certify host-bound tuples with match-policies). It is the diagnostic-side twin of #5565.

## Fix
Two parts, both in the host-inbound classifier + its four operator surfaces:

1. **`ingress-interface <if>` selector** scopes a host-inbound query to **one** interface's EFFECTIVE view (zone-level ∪ that interface's override, same physical→unit inheritance as the enforcement view builder), so the reported admission is that interface's **true** posture (admit vs deny), not a first-admit fold.
   - `ClassifyHostInboundForInterface` (`pkg/dataplane/userspace/host_inbound_classify.go`) — per-interface classify.
   - `ResolveHostInboundIngressInterface` — fail-closed validator: rejects **unknown / zone-mismatched / management-cluster-lifeline** refs (a lifeline is served unconditionally, so a per-interface verdict would itself be false).
2. **Zone-scoped ambiguity**: without the selector, a query whose per-interface views **disagree** now reports the new `HostInboundAmbiguous` status (naming the differing interface groups, pointing at `ingress-interface`) instead of OR-ing to a first-admit. A zone with no per-interface override yields a single view → **byte-identical to before** (`ClassifyHostInbound` refactored to a shared `classifyOneView` core that folds only when the views agree).

## Selector plumbing (mirrors existing selectors)
| Surface | Wiring |
|---|---|
| Strict grammar | `policymatch.ParseSelectorArgs` + `Query.IngressInterface` |
| REST | `ingress_interface` query param (added to the #3709/#5316 selector allowlist); validate → 400 |
| gRPC RPC | `MatchPoliciesRequest.ingress_interface` = **proto field 11**; new `HOST_INBOUND_ADMISSION_STATUS_AMBIGUOUS` = 5; validate → InvalidArgument |
| gRPC `test-policy:` bridge | `iif=` token |
| Local + remote CLI | `show security match-policies` / `test policy` |

Proto bindings **regenerated** via `make proto` (protoc-gen-go v1.36.11 / -grpc v1.6.1, pinned), not hand-edited. **Go control-plane gRPC proto only — no dataplane wire / Rust change.**

Key file:line — classifier scoping: `pkg/dataplane/userspace/host_inbound_classify.go` `ClassifyHostInboundForInterface`, `ResolveHostInboundIngressInterface`, `classifyOneView`; REST: `pkg/api/security.go` (validate + `IngressInterface` on the Query); gRPC: `pkg/grpcapi/server_cluster.go`; proto: `proto/xpf/v1/xpf.proto` field 11 + AMBIGUOUS enum.

## Validation (RED-on-revert proven)
Added fail-on-revert tests at the classifier, REST, and gRPC layers. Mixed zone: `ge-0/0/0.0` SSH override, `ge-0/0/1.0` default-deny.
- `ingress-interface=ge-0/0/1.0` → **denied** (was the false zone-wide `token-admit ssh`)
- `ingress-interface=ge-0/0/0.0` → **token-admit ssh**
- unqualified → **ambiguous**

Temporarily reverting the interface-scoping + ambiguity (fold zone-wide first-admit) flips the sibling to the ssh admit and **all three suites go RED**; restoring makes them green.

`go build ./...` + `go test ./pkg/policymatch/... ./pkg/api/... ./pkg/grpcapi/... ./cmd/cli/... ./pkg/cli/...` + userspace host-inbound tests green; `gofmt` clean. (Pre-existing flaky `TestEventStreamDataplaneEventBeforeCallbackQueuesUntilCallback` fails at base `4a1ca4e32` too — unrelated.)

Docs: updated `MatchPoliciesUsage` help + `docs/junos-cli-reference.md` policy-simulator section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)