### PR TITLE
host-inbound: admit the WireGuard listen port for passive listeners (#5582)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46149,3 +46149,9 @@ top.
   flag false. Gates: go build ./... + go test ./pkg/api/... green; gofmt -w.
 - **File(s)**: pkg/api/types.go, pkg/api/security.go,
   pkg/api/security_policy_counter_availability_5580_test.go, _Log.md
+
+## #5582 host-inbound WireGuard listen-port admission
+- **Timestamp**: 2026-07-11T10:33:04Z
+- **Action**: Add automatic dynamic host-inbound admission for the configured WireGuard UDP listen port(s) so a fresh passive (responder-only) handshake to a restricted zoned address is admitted (was dropped by the per-zone catch-all). Chose an automatic dynamic exception tied to config.WireGuardListenPorts() over a static system-services token (WG port is operator-configured, does not fit the static token->port SSOT). Emitted as a single coarse `udp dport <wg-port(s)> accept` on the input hook, placed after the #4146/#5565 fine junos-host DROP subchain.
+- **File(s)**: pkg/config/wireguard_ports.go (new: (*Config).WireGuardListenPorts), pkg/daemon/daemon_nft.go (emitHostInboundWireGuardAccept + renderWireGuardPortSpec + buildHostInboundFilterPayload 5th param + call site), pkg/config/wireguard_listen_ports_5582_test.go (new), pkg/daemon/host_inbound_wireguard_5582_test.go (new, RED-on-revert + live-nft parse), docs/wireguard-interop.md, docs/host-inbound-service-matrix.md; updated existing buildHostInboundFilterPayload test call sites (host_inbound_nft_test.go, host_inbound_unzoned_4420_test.go, host_inbound_per_iface_3362_test.go, host_inbound_junos_host_4146_test.go, nft_chain_priority_test.go).
+- **Validation**: go build ./... green; go vet + go test ./pkg/config/... ./pkg/daemon/... green; RED-on-revert proven (neutered emit -> TestHostInboundFilterAdmitsWireGuardListenPort fails); live nft -c parse of single-port and set forms clean.

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -770,6 +770,21 @@ port numbers (only the token set is guarded by #3486) — the fail-on-revert
 assertions in `host_inbound_parity_test.go` plus this matrix are the contract
 that keeps the nft and Rust port numbers aligned.
 
+## WireGuard listen port: a dynamic exception, NOT a token (#5582)
+
+WireGuard is deliberately **not** a `system-services` token. Its UDP listen port
+is operator-configured (`interfaces <wg> tunnel wireguard listen-port <n>`), so
+it does not fit the static token→port SSOT above (a token like `ssh` maps to a
+fixed port on all three surfaces). Instead, the kernel host-inbound builder emits
+an **automatic, dynamic** `udp dport <configured-wg-port(s)> accept` on the input
+hook whenever a WG tunnel is configured (`emitHostInboundWireGuardAccept`,
+`pkg/daemon/daemon_nft.go`; port set from `config.WireGuardListenPorts()`). This
+mirrors the shim's steer-to-kernel of that exact port so a fresh passive handshake
+to a restricted zoned address is admitted rather than dropped. See
+`docs/wireguard-interop.md` → "Host-inbound admission of the WG listen port". Do
+NOT add a `wireguard` token to `KnownHostInboundSystemServices` — the port is
+dynamic and the automatic exception already covers it.
+
 ## Junos references
 
 - SIP ALG — default SIP signaling on port 5060; TCP support added in

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -676,3 +676,66 @@ cluster + perf + `make test-failover` before merge). Until Increment 2
 lands, only the first configured WG listen port is steered, so a second
 tunnel on a different port will not receive inbound transport packets.
 Design of record: `docs/research/1434-multi-tunnel-wireguard/plan.md`.
+
+## Host-inbound admission of the WG listen port (#5582)
+
+The shim steers local-destination UDP on the configured WG listen port to
+the kernel (`wg_steer_to_kernel`, `userspace-xdp/src/lib.rs`) so the
+userspace WireGuard control socket receives the outer transport. But the
+kernel input path is also guarded by the host-inbound nftables chain
+(`inet xpf_hostinbound`, `pkg/daemon/daemon_nft.go`): on a **restricted**
+security zone (a zone with a `host-inbound-traffic` set that does not open
+the WG port, or no stanza at all — Junos default-deny) the per-zone
+catch-all silently DROPs everything not explicitly admitted.
+
+A returning packet for an xpf-**initiated** handshake is `ct state
+established` and passes, which is why interop where xpf dials out first
+succeeded. But a **fresh passive (responder-only) handshake** — the
+supported "external peer initiates, xpf listens" config — is conntrack
+`NEW`: it misses the service accepts and hits the catch-all drop, so a
+responder-only listener on a restricted zoned address could never come up
+after boot / conntrack expiry.
+
+**Fix (#5582): a dynamic, automatic host-inbound admission tied to the
+configured listen port(s) — not a static `system-services` token.** When
+any WG tunnel is configured, `buildHostInboundFilterPayload` emits a
+single coarse `udp dport <configured-wg-port(s)> accept` on the input
+hook (`emitHostInboundWireGuardAccept`). Rationale:
+
+- **Automatic, not a manual token.** The shim *already* steers the port
+  unconditionally; requiring the operator to separately open it would let
+  the shim steer a packet the kernel then drops. A configured WireGuard
+  listener therefore *implies* host admission of exactly its listen port.
+- **Dynamic port, so no static SSOT token.** WireGuard's port is
+  operator-configured, so it does not fit the static token→port SSOT
+  (`config.HostInboundServiceMatch`, e.g. `ssh`→22) that the nft mirror
+  and the Rust classifier render from; a `system-services wireguard`
+  token would need a fake fixed port and would break the token-parity
+  tests. The port set is the compile-time SSOT
+  `config.WireGuardListenPorts()` (all configured WG tunnels).
+- **Scoped to the shim's steering, not widened.** The rule is a single
+  global accept, but the nft `input` hook only ever sees host-destined
+  packets, so a bare `udp dport <port>` admits the WG port to **every
+  firewall-local address** — exactly the shim's `is_local_destination`
+  scope — while transit/forward UDP (which traverses the `forward` hook,
+  never this chain) is untouched, so transit/DNAT UDP on the WG port is
+  never shunted around policy. Only the WG port is opened; every other
+  host-bound service stays under the per-zone default-deny.
+- **Composes with the #5565 per-interface host-inbound scoping.** With a
+  `to-zone junos-host` DENY program present, the WG accept is placed
+  AFTER the fine iifname-scoped DROP subchain, so an explicit operator
+  junos-host deny of a WG source still wins; it is a coarse admit like
+  the ND/PMTUD accepts.
+
+**Runtime-vs-config nuance:** the admission uses the CONFIGURED listen
+port (the compile-time SSOT), which is also what the shim packs into the
+ctrl block, so kernel filter and shim steering agree. The shim's
+single-port WG-RX steering (S2a) only steers the FIRST configured port
+today (see "Multi-tunnel status" above); the host-inbound filter admits
+ALL configured WG ports, so a second-tunnel rule is currently a no-op at
+the kernel (nothing steers that port up) but is correct-in-intent and
+ready for the deferred multi-tunnel steering (#1434 Increment 2).
+
+Fail-on-revert guards: `TestHostInboundFilterAdmitsWireGuardListenPort`
+and `TestHostInboundFilterWireGuardPayloadParses` (`pkg/daemon`),
+`TestWireGuardListenPorts_5582` (`pkg/config`).

--- a/pkg/config/wireguard_listen_ports_5582_test.go
+++ b/pkg/config/wireguard_listen_ports_5582_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"testing"
+)
+
+// TestWireGuardListenPorts_5582 proves the compile-time SSOT the host-inbound
+// kernel filter consumes to admit the WireGuard listen port(s). The XDP shim
+// steers local-destination UDP on the configured WG listen port to the kernel;
+// the daemon host-inbound builder must know those ports to admit them (else a
+// fresh passive handshake to a restricted zoned address is dropped, #5582).
+//
+// It compiles two WG tunnels on distinct listen ports plus a GRE tunnel, and
+// asserts WireGuardListenPorts() returns exactly the two WG ports, sorted and
+// de-duplicated, ignoring the non-WireGuard tunnel.
+//
+// Fail-on-revert: drop the WgListenPort collection (or return nil) and this goes
+// RED, mirroring the loss of the host-inbound WG admission.
+func TestWireGuardListenPorts_5582(t *testing.T) {
+	lines := []string{
+		// wg1 on the HIGHER port, declared FIRST — proves sort, not authoring order.
+		"set interfaces wg1 tunnel mode wireguard",
+		"set interfaces wg1 tunnel wireguard listen-port 51900",
+		"set interfaces wg1 tunnel wireguard private-key " + wgKeyA,
+		"set interfaces wg1 tunnel wireguard peer " + wgKeyB + " allowed-ips 10.2.0.0/24",
+		// wg0 on the LOWER port.
+		"set interfaces wg0 tunnel mode wireguard",
+		"set interfaces wg0 tunnel wireguard listen-port 51820",
+		"set interfaces wg0 tunnel wireguard private-key " + wgKeyB,
+		"set interfaces wg0 tunnel wireguard peer " + wgKeyA + " allowed-ips 10.1.0.0/24",
+		// A GRE tunnel — NOT WireGuard, must not contribute a port.
+		"set interfaces gr-0/0/0 unit 0 tunnel source 172.16.50.8",
+		"set interfaces gr-0/0/0 unit 0 tunnel destination 172.16.60.9",
+		"set system dataplane-type userspace",
+	}
+	tree := buildTree4953(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+
+	got := cfg.WireGuardListenPorts()
+	want := []uint16{51820, 51900}
+	if len(got) != len(want) {
+		t.Fatalf("WireGuardListenPorts() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("WireGuardListenPorts() = %v, want %v (sorted, deduped)", got, want)
+		}
+	}
+}
+
+// TestWireGuardListenPorts_5582_None proves the no-WireGuard case returns nil
+// (a cheap len()==0 test at the call site), so a config with no WG tunnel emits
+// no host-inbound WG accept and the restricted-default posture is unchanged.
+func TestWireGuardListenPorts_5582_None(t *testing.T) {
+	lines := []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+		"set system dataplane-type userspace",
+	}
+	tree := buildTree4953(t, lines)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if ports := cfg.WireGuardListenPorts(); len(ports) != 0 {
+		t.Fatalf("WireGuardListenPorts() with no WG tunnel = %v, want empty", ports)
+	}
+}

--- a/pkg/config/wireguard_ports.go
+++ b/pkg/config/wireguard_ports.go
@@ -1,0 +1,60 @@
+package config
+
+import "sort"
+
+// WireGuardListenPorts returns the sorted, de-duplicated set of non-zero
+// WireGuard UDP listen ports configured across every interface-level and
+// per-unit tunnel whose Mode is "wireguard" (#5582). It is the compile-time
+// SSOT for the host-inbound kernel filter's DYNAMIC WireGuard admission.
+//
+// The XDP shim deliberately steers local-destination UDP on the configured WG
+// listen port to the kernel (userspace-xdp wg_steer_to_kernel), so the
+// userspace WireGuard control socket can receive the outer transport. Without a
+// matching host-inbound admission, a FRESH passive (responder-only) handshake to
+// a restricted zoned address is conntrack NEW, misses the per-zone service
+// accepts, and is dropped by the host-inbound catch-all — so a supported
+// responder-only WireGuard listener can never come up (#5582). The daemon
+// host-inbound builder consumes this set to emit exactly one coarse
+// `udp dport <ports> accept` on the input hook (buildHostInboundFilterPayload),
+// admitting the configured WG port(s) to every firewall-local address — the
+// same local-destination scope the shim steers — while leaving every other
+// host-bound service under the per-zone default-deny.
+//
+// A Mode=="wireguard" tunnel with WgListenPort==0 is skipped: the WireGuard
+// compiler hard-rejects a zero/out-of-range listen-port at commit
+// (compiler_validate_wireguard.go, #3863), so a zero here only arises on a
+// partially-built or tolerant-load config, and admitting UDP/0 would be
+// meaningless. Returns nil (not an empty slice) when no WG tunnel is
+// configured, so callers can treat "no WG" as a cheap len()==0 test.
+func (c *Config) WireGuardListenPorts() []uint16 {
+	if c == nil {
+		return nil
+	}
+	seen := map[uint16]bool{}
+	add := func(tc *TunnelConfig) {
+		if tc == nil || tc.Mode != "wireguard" || tc.WgListenPort == 0 {
+			return
+		}
+		seen[tc.WgListenPort] = true
+	}
+	for _, ifc := range c.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
+		add(ifc.Tunnel)
+		for _, unit := range ifc.Units {
+			if unit != nil {
+				add(unit.Tunnel)
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]uint16, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -300,7 +300,14 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 		}
 		return nil
 	}
-	nftConf := buildHostInboundFilterPayload(views, unzonedV4, unzonedV6, programs)
+	// #5582: the configured WireGuard listen port(s). The XDP shim steers
+	// local-destination UDP on the WG listen port to the kernel WG socket, so the
+	// host-inbound filter must admit that port or a fresh passive handshake to a
+	// restricted zoned address is dropped by the per-zone catch-all. Empty (nil)
+	// when no WG tunnel is configured — buildHostInboundFilterPayload then emits
+	// no WG accept, so the restricted-default posture is unchanged.
+	wgListenPorts := cfg.WireGuardListenPorts()
+	nftConf := buildHostInboundFilterPayload(views, unzonedV4, unzonedV6, programs, wgListenPorts)
 	if out, err := nftApplyPayload(nftConf); err != nil {
 		slog.Warn("failed to apply host-inbound filter", "err", err, "output", string(out))
 		return fmt.Errorf("apply host-inbound nftables filter: %w", err)
@@ -497,6 +504,14 @@ func hostInboundHasEnforceableView(views []dpuserspace.ZoneHostInboundView) bool
 //     set omitting `ping` does not black-hole PMTUD/ND/error delivery. This set
 //     is mirrored by the userspace host-inbound exemption (#3171) so kernel and
 //     XSK LocalDelivery agree. Echo-request stays gated on the `ping` service.
+//     3b. #5582: when WireGuard is configured, a coarse
+//     `udp dport <configured-wg-listen-port(s)> accept` (emitHostInbound
+//     WireGuardAccept). The shim steers local-destination UDP on the WG listen
+//     port to the kernel WG socket, so the host-inbound filter must admit it or a
+//     fresh passive handshake to a restricted zoned address is dropped by the
+//     per-zone catch-all. A single global input-hook rule (input = host-destined
+//     only), so it mirrors the shim's local-destination scope without touching
+//     transit UDP; only the WG port is opened, so the restricted default holds.
 //  4. Per host-inbound-configured zone, per family with addresses:
 //     - if `system-services all` / `any-service`: <fam> daddr <addrs> accept
 //     (and no deny — the operator opened the zone to all services).
@@ -508,7 +523,7 @@ func hostInboundHasEnforceableView(views []dpuserspace.ZoneHostInboundView) bool
 //     the table body and scraped per zone/family into the
 //     xpf_host_inbound_kernel_denies_total metric (#3361) — distinct from the
 //     userspace-dp xpf_host_inbound_denies_total path (#3326).
-func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, programs []dpuserspace.JunosHostProgram) string {
+func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, programs []dpuserspace.JunosHostProgram, wgListenPorts []uint16) string {
 	// Pre-pass: collect the named DROP counters the chain will reference, so they
 	// can be declared at the top of the table body BEFORE the chain. A counter is
 	// emitted exactly when emitHostInboundZone emits a catch-all drop
@@ -620,6 +635,11 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView, unzo
 		}
 		// (4) ND/PMTUD/ICMP-error accepts for NON-denied sources.
 		emitHostInboundICMPAccepts(&rules)
+		// (4b) #5582: coarse WireGuard listen-port admission. Placed AFTER the
+		// fine junos-host DROP subchain so an explicit operator `to-zone
+		// junos-host` deny of a WG source still wins; it is a coarse admit like
+		// the ND/PMTUD accepts.
+		emitHostInboundWireGuardAccept(&rules, wgListenPorts)
 		// (5) Residual full established accept (non-denied established inbound).
 		rules = append(rules, "    ct state established,related accept")
 	} else {
@@ -637,6 +657,11 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView, unzo
 		// enforcement.
 		rules = append(rules, "    meta l4proto { 50, 51 } accept")
 		emitHostInboundICMPAccepts(&rules)
+		// #5582: coarse WireGuard listen-port admission (see
+		// emitHostInboundWireGuardAccept). A single global accept on the input
+		// hook, so the shim-steered outer transport reaches the userspace WG
+		// socket regardless of which zone's address it is destined to.
+		emitHostInboundWireGuardAccept(&rules, wgListenPorts)
 	}
 
 	for _, v := range views {
@@ -676,6 +701,57 @@ func emitHostInboundICMPAccepts(rules *[]string) {
 	*rules = append(*rules, "    icmpv6 type { 1, 2, 3, 4 } counter name \""+xnft.HostInboundAcceptCounterName(xnft.HostInboundAcceptICMP6Error)+"\" accept")
 	*rules = append(*rules, "    icmpv6 type { 133, 134, 135, 136, 137 } counter name \""+xnft.HostInboundAcceptCounterName(xnft.HostInboundAcceptICMP6ND)+"\" accept")
 	*rules = append(*rules, "    icmp type { destination-unreachable, time-exceeded, parameter-problem } counter name \""+xnft.HostInboundAcceptCounterName(xnft.HostInboundAcceptICMP4Error)+"\" accept")
+}
+
+// emitHostInboundWireGuardAccept appends the #5582 dynamic WireGuard listen-port
+// admission: a single coarse `udp dport <configured-wg-port(s)> accept` on the
+// host-inbound input hook.
+//
+// The XDP shim deliberately steers local-destination UDP on the configured WG
+// listen port to the kernel (userspace-xdp wg_steer_to_kernel) so the userspace
+// WireGuard control socket receives the outer transport. Without this accept a
+// FRESH passive (responder-only) handshake — conntrack NEW, so the leading
+// `ct state established,related accept` does not cover it — misses the per-zone
+// service accepts and is dropped by the host-inbound catch-all (or the #4420
+// addressed-but-unzoned catch-all), so a supported responder-only WireGuard
+// listener can never come up on a restricted zoned address.
+//
+// The rule is emitted ONCE, not per zone. The nft input hook only ever sees
+// host-destined packets, so a bare `udp dport <port>` admits the WG port to
+// EVERY firewall-local address — exactly the shim's `is_local_destination`
+// steering scope — while transit/forward UDP (which traverses the forward hook,
+// never this input chain) is untouched, so transit/DNAT UDP on the WG port is
+// never shunted around policy. Only the configured WG port(s) are opened; every
+// other host-bound service stays governed by the per-zone default-deny, so the
+// restricted-default posture is preserved.
+//
+// The port set is the compile-time SSOT config.WireGuardListenPorts() (all
+// configured WG tunnels). The shim's single-port WG-RX steering (S2a) only
+// steers the FIRST configured listen port today, so for a config with a second
+// WG tunnel on a different port that second rule is currently a no-op at the
+// kernel (nothing steers that port up), but admitting all configured ports keeps
+// the kernel filter correct-in-intent and ready for the deferred multi-tunnel
+// steering (#1434 Increment 2). No-op when WG is not configured.
+func emitHostInboundWireGuardAccept(rules *[]string, wgListenPorts []uint16) {
+	if len(wgListenPorts) == 0 {
+		return
+	}
+	*rules = append(*rules, "    udp dport "+renderWireGuardPortSpec(wgListenPorts)+" accept")
+}
+
+// renderWireGuardPortSpec renders the WireGuard listen-port set as an nft
+// destination-port value: a single port ("51820") or an anonymous set
+// ("{ 51820, 51821 }"). Ports arrive sorted+deduped from
+// config.WireGuardListenPorts().
+func renderWireGuardPortSpec(ports []uint16) string {
+	if len(ports) == 1 {
+		return strconv.Itoa(int(ports[0]))
+	}
+	parts := make([]string, len(ports))
+	for i, p := range ports {
+		parts[i] = strconv.Itoa(int(p))
+	}
+	return "{ " + strings.Join(parts, ", ") + " }"
 }
 
 // emitJunosHostDenyProgram appends one ingress zone's fine `to-zone junos-host`

--- a/pkg/daemon/host_inbound_junos_host_4146_test.go
+++ b/pkg/daemon/host_inbound_junos_host_4146_test.go
@@ -86,7 +86,7 @@ func junosHostPayload(t *testing.T, cfg *config.Config) (string, []dpuserspace.J
 	t.Helper()
 	views := dpuserspace.BuildZoneHostInboundViews(cfg)
 	programs := dpuserspace.BuildJunosHostPrograms(cfg)
-	return buildHostInboundFilterPayload(views, nil, nil, programs), programs
+	return buildHostInboundFilterPayload(views, nil, nil, programs, nil), programs
 }
 
 // junosHostSection returns the payload lines from the junos-host DROP subchain

--- a/pkg/daemon/host_inbound_nft_test.go
+++ b/pkg/daemon/host_inbound_nft_test.go
@@ -81,7 +81,7 @@ func hostInboundTestConfig() *config.Config {
 func TestHostInboundFilterAcceptsListedDeniesRest(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	mustContain := []string{
 		"table inet xpf_hostinbound",
@@ -131,7 +131,7 @@ func TestHostInboundFilterAcceptsListedDeniesRest(t *testing.T) {
 func TestHostInboundFilterDropRulesCounted(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	for _, fam := range []struct{ family, addr string }{
 		{"ip", "172.16.50.8"},
@@ -187,7 +187,7 @@ func TestHostInboundFilterDropRulesCounted(t *testing.T) {
 func TestHostInboundFilterExemptsIPsecAndV6Errors(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	espAH := "meta l4proto { 50, 51 } accept"
 	if !strings.Contains(payload, espAH) {
@@ -254,7 +254,7 @@ func TestHostInboundFilterExemptsIPsecAndV6Errors(t *testing.T) {
 func TestHostInboundFilterNoStanzaDefaultDeny(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// lan's reth1 address must now be scoped by a catch-all drop.
 	wantDrop := hiDrop("ip", "10.0.61.1", "lan")
@@ -276,7 +276,7 @@ func TestHostInboundFilterNoStanzaDefaultDeny(t *testing.T) {
 func TestHostInboundFilterLifelineNeverDenied(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// em0's address (cluster control plane) must never be denied/scoped, even
 	// though the control zone declares a host-inbound stanza.
@@ -308,7 +308,7 @@ func TestHostInboundFilterAllOpensZoneNoDeny(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 	if !strings.Contains(payload, "ip daddr 10.1.1.1 accept") {
 		t.Errorf("`all` zone must accept everything to its addr:\n%s", payload)
 	}
@@ -339,7 +339,7 @@ func TestHostInboundFilterProtocolsAllScopedToRouting(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// Routing protocols must be accepted: ospf (proto 89), bgp (tcp/179),
 	// vrrp (proto 112).
@@ -393,7 +393,7 @@ func TestHostInboundFilterExplicitSshStillAdmitted(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	if !strings.Contains(payload, "ip daddr 10.3.3.1 tcp dport 22 accept") {
 		t.Errorf("system-services ssh must accept tcp/22:\n%s", payload)
@@ -430,7 +430,7 @@ func TestHostInboundFilterFamilyAware(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// v4-only tokens accepted under ip, dual-family ssh under both.
 	mustContain := []string{
@@ -499,7 +499,7 @@ func TestHostInboundFilterConfiguredControlInterfaceLifeline(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// fxp1's control-link address must NEVER appear (accept or drop): it is the
 	// configured cluster control-interface and so a lifeline (#3277).
@@ -679,7 +679,7 @@ func identResetTestConfig() *config.Config {
 func TestHostInboundFilterIdentResetEmitsReset(t *testing.T) {
 	cfg := identResetTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// The ident-reset rule must be a reject-with-tcp-reset on TCP/113, per family.
 	mustContain := []string{
@@ -742,7 +742,7 @@ func TestHostInboundFilterAllSuppressesIdentReset(t *testing.T) {
 		},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	if !strings.Contains(payload, "ip daddr 10.1.1.1 accept") {
 		t.Errorf("`all` zone must accept everything to its addr:\n%s", payload)
@@ -815,7 +815,7 @@ func TestHostInboundFilterIdentResetPayloadParses(t *testing.T) {
 		HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
 	}
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// Sanity: the raw payload must still carry the #3310 reject rule and the
 	// #3361 named-counter declaration — otherwise the parse check is vacuous.
@@ -860,7 +860,7 @@ func TestHostInboundFilterIdentResetPayloadParses(t *testing.T) {
 func TestHostInboundFilterCounterDeclarationUnquoted(t *testing.T) {
 	cfg := hostInboundTestConfig()
 	views := buildAndCheckViews(t, cfg)
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// No QUOTED counter declaration may appear (a reference is `counter name
 	// "<n>"`, never `counter "<n>" {`).

--- a/pkg/daemon/host_inbound_per_iface_3362_test.go
+++ b/pkg/daemon/host_inbound_per_iface_3362_test.go
@@ -38,7 +38,7 @@ func Test_3362_NftScopesPerInterfaceOverride(t *testing.T) {
 		},
 	}
 
-	payload := buildHostInboundFilterPayload(buildAndCheckViews(t, cfg), nil, nil, nil)
+	payload := buildHostInboundFilterPayload(buildAndCheckViews(t, cfg), nil, nil, nil, nil)
 
 	corpDropV4 := "counter name \"" + xnft.HostInboundDenyCounterName("corp", "ip") + "\" drop"
 	mustContain := []string{
@@ -104,7 +104,7 @@ func Test_3362_NftDeclaresEachCounterOnce(t *testing.T) {
 		t.Fatalf("expected >=2 views for zone corp (override + default), got %d", corpViews)
 	}
 
-	payload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 
 	// Each named DROP counter for the zone must be DECLARED exactly once.
 	for _, fam := range []string{"ip", "ip6"} {

--- a/pkg/daemon/host_inbound_unzoned_4420_test.go
+++ b/pkg/daemon/host_inbound_unzoned_4420_test.go
@@ -42,7 +42,7 @@ func TestHostInboundUnzonedInterfaceDenied(t *testing.T) {
 	cfg := hostInboundUnzonedTestConfig()
 	views := dpuserspace.BuildZoneHostInboundViews(cfg)
 	v4, v6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
-	payload := buildHostInboundFilterPayload(views, v4, v6, nil)
+	payload := buildHostInboundFilterPayload(views, v4, v6, nil, nil)
 
 	sentinel := dpuserspace.UnzonedHostInboundZoneLabel
 	wantV4 := hiDrop("ip", "192.0.2.1", sentinel)

--- a/pkg/daemon/host_inbound_wireguard_5582_test.go
+++ b/pkg/daemon/host_inbound_wireguard_5582_test.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// hostInboundWireGuardTestConfig extends the restricted-zone fixture
+// (hostInboundTestConfig: wan = host-inbound { ssh; ping; } on reth0.50, a
+// RESTRICTED zone with a v4+v6 static address) with a passive WireGuard
+// listener: a wg0 tunnel, Mode="wireguard", listen-port 51820, one peer with NO
+// endpoint (responder-only). The wan address is where the outer WG transport
+// arrives; the shim steers UDP/51820 to the kernel, so the host-inbound filter
+// must admit it or the fresh handshake is dropped by wan's catch-all (#5582).
+func hostInboundWireGuardTestConfig() *config.Config {
+	cfg := hostInboundTestConfig()
+	cfg.Interfaces.Interfaces["wg0"] = &config.InterfaceConfig{
+		Name: "wg0",
+		Tunnel: &config.TunnelConfig{
+			Name:         "wg0",
+			Mode:         "wireguard",
+			WgListenPort: 51820,
+			WgPeers: []config.WgPeerConfig{
+				// Responder-only: no Endpoint -> passive listener (the #5582 case).
+				{PublicKeyHex: "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+					AllowedIPs: []string{"10.9.0.0/24"}},
+			},
+		},
+	}
+	return cfg
+}
+
+// TestHostInboundFilterAdmitsWireGuardListenPort is the #5582 fail-on-revert
+// proof. With a WireGuard listener configured, buildHostInboundFilterPayload
+// emits a coarse `udp dport <listen-port> accept` on the input hook, admitting a
+// fresh passive handshake (conntrack NEW) to a RESTRICTED zoned address that
+// would otherwise hit the per-zone catch-all drop. The WG accept precedes the
+// wan catch-all drop, so the handshake to the wan address:51820 is admitted, not
+// dropped. Reverting the emitHostInboundWireGuardAccept emission removes the
+// accept -> a NEW WG handshake falls to the drop -> this goes RED.
+func TestHostInboundFilterAdmitsWireGuardListenPort(t *testing.T) {
+	cfg := hostInboundWireGuardTestConfig()
+	wgPorts := cfg.WireGuardListenPorts()
+	if len(wgPorts) != 1 || wgPorts[0] != 51820 {
+		t.Fatalf("WireGuardListenPorts() = %v, want [51820]", wgPorts)
+	}
+	views := buildAndCheckViews(t, cfg)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, wgPorts)
+
+	wgAccept := "udp dport 51820 accept"
+	if !strings.Contains(payload, wgAccept) {
+		t.Fatalf("payload missing WireGuard listen-port admission %q\n---\n%s", wgAccept, payload)
+	}
+
+	// The WG accept must precede the wan v4 catch-all drop: a NEW inbound
+	// handshake to the wan address on 51820 is admitted, not dropped.
+	wanDropV4 := hiDrop("ip", "172.16.50.8", "wan")
+	idxAccept := strings.Index(payload, wgAccept)
+	idxDrop := strings.Index(payload, wanDropV4)
+	if idxDrop < 0 {
+		t.Fatalf("payload missing wan v4 catch-all drop %q\n---\n%s", wanDropV4, payload)
+	}
+	if idxAccept < 0 || idxAccept > idxDrop {
+		t.Errorf("WG accept must precede the wan v4 catch-all drop so a fresh "+
+			"handshake is admitted:\n%s", payload)
+	}
+
+	// Restricted-default posture preserved: the wan catch-all drop still exists
+	// (both families), and an unlisted service (telnet tcp/23) is NOT admitted —
+	// only the WG port was opened.
+	if !strings.Contains(payload, hiDrop("ip6", "2001:db8:50::8", "wan")) {
+		t.Errorf("wan v6 catch-all drop must remain (restricted posture):\n%s", payload)
+	}
+	if strings.Contains(payload, "tcp dport 23") {
+		t.Errorf("WG admission must not widen the zone to other services (telnet leaked):\n%s", payload)
+	}
+	// Only ONE WG accept rule is emitted (a single coarse global rule), not one
+	// per zone/family.
+	if n := strings.Count(payload, wgAccept); n != 1 {
+		t.Errorf("expected exactly one global WG accept rule, got %d:\n%s", n, payload)
+	}
+}
+
+// TestHostInboundFilterWireGuardPayloadParses runs the EXACT payload carrying
+// the #5582 WireGuard accept (both the single-port and the multi-port anonymous
+// set forms) through the appliance nft binary, so the emitted
+// `udp dport <spec> accept` is validated against real nft syntax — not just
+// asserted as a substring. Mirrors TestHostInboundFilterIdentResetPayloadParses:
+// a `syntax error` fails; a netlink/permission error (no CAP_NET_ADMIN) after a
+// clean parse is a pass; nft absent skips.
+func TestHostInboundFilterWireGuardPayloadParses(t *testing.T) {
+	nftPath := findNft()
+	if nftPath == "" {
+		t.Skip("nft not found; substring coverage in TestHostInboundFilterAdmitsWireGuardListenPort")
+	}
+	for _, tc := range []struct {
+		name  string
+		ports []uint16
+		want  string
+	}{
+		{"single", []uint16{51820}, "udp dport 51820 accept"},
+		{"set", []uint16{51820, 51821}, "udp dport { 51820, 51821 } accept"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := hostInboundWireGuardTestConfig()
+			views := buildAndCheckViews(t, cfg)
+			payload := buildHostInboundFilterPayload(views, nil, nil, nil, tc.ports)
+			if !strings.Contains(payload, tc.want) {
+				t.Fatalf("payload missing %q:\n%s", tc.want, payload)
+			}
+			cmd := exec.Command(nftPath, "-c", "-f", "-")
+			cmd.Stdin = strings.NewReader(payload)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				return
+			}
+			if strings.Contains(string(out), "syntax error") {
+				t.Fatalf("nft -c rejected the WireGuard host-inbound payload:\n%s\npayload:\n%s", out, payload)
+			}
+			t.Logf("nft -c parsed the payload; non-syntax error (expected without CAP_NET_ADMIN): %v\n%s", err, out)
+		})
+	}
+}
+
+// TestHostInboundFilterNoWireGuardNoAccept proves the negative: with NO
+// WireGuard configured (wgListenPorts empty), no WG accept is emitted, so the
+// restricted-default posture is bit-identical to the pre-#5582 payload.
+func TestHostInboundFilterNoWireGuardNoAccept(t *testing.T) {
+	cfg := hostInboundTestConfig()
+	if ports := cfg.WireGuardListenPorts(); len(ports) != 0 {
+		t.Fatalf("fixture unexpectedly has WG ports: %v", ports)
+	}
+	views := buildAndCheckViews(t, cfg)
+	payload := buildHostInboundFilterPayload(views, nil, nil, nil, cfg.WireGuardListenPorts())
+	if strings.Contains(payload, "udp dport") && strings.Contains(payload, "51820") {
+		t.Errorf("no WG accept must be emitted when WireGuard is unconfigured:\n%s", payload)
+	}
+}

--- a/pkg/daemon/nft_chain_priority_test.go
+++ b/pkg/daemon/nft_chain_priority_test.go
@@ -54,7 +54,7 @@ func TestNftLocalDeliveryChainsDistinctPriority(t *testing.T) {
 	// views. Use a representative enforced config so the rendered table is the
 	// real commit-time shape.
 	views := buildAndCheckViews(t, hostInboundTestConfig())
-	hiPayload := buildHostInboundFilterPayload(views, nil, nil, nil)
+	hiPayload := buildHostInboundFilterPayload(views, nil, nil, nil, nil)
 	hiPri := nftHookInputPriority(t, "host-inbound", hiPayload)
 
 	if lo0Pri == hiPri {


### PR DESCRIPTION
Closes #5582

## Problem
The XDP shim deliberately steers local-destination UDP on the configured WireGuard listen port to the kernel (`wg_steer_to_kernel`, `userspace-xdp/src/lib.rs`) so the userspace WireGuard control socket receives the outer transport. But the kernel input path is also guarded by the host-inbound nftables chain (`inet xpf_hostinbound`, `pkg/daemon/daemon_nft.go`): on a **restricted** security zone the per-zone catch-all silently DROPs everything not explicitly admitted, and the host-inbound service SSOT has no WireGuard tuple.

A returning packet for an xpf-**initiated** handshake is `ct state established` and passes — which is why prior interop (xpf dials out first) succeeded. But a **fresh passive (responder-only) handshake** — the supported "external peer initiates, xpf listens" config — is conntrack `NEW`: it misses the service accepts and hits the catch-all drop. So a responder-only WireGuard listener on a restricted zoned address could never come up after boot / conntrack expiry.

## Fix — token vs. dynamic exception
**An automatic, dynamic host-inbound admission tied to the configured listen port(s), NOT a static `system-services` token.**

The issue itself poses the question "whether a configured WireGuard listener implies host admission or requires an explicit dynamic `wireguard` service". This PR decides: **it implies host admission, automatically.** Rationale:

- **Automatic, not manual.** The shim *already* steers the port unconditionally; requiring the operator to separately open it would let the shim steer a packet the kernel then drops. A configured WireGuard listener therefore implies host admission of exactly its listen port.
- **Dynamic port ⇒ no static SSOT token.** WireGuard's port is operator-configured, so it does not fit the static token→port SSOT (`config.HostInboundServiceMatch`, e.g. `ssh`→22) that the nft mirror and the Rust classifier render from. A `system-services wireguard` token would need a fake fixed port and would break the token-parity tests (`TestHostInboundRustClassifierMatchesGoSSOT`, `#3486`). So no new token was added; `docs/host-inbound-service-matrix.md` records "do NOT add a `wireguard` token — the port is dynamic".

## Implementation
- **`config.(*Config).WireGuardListenPorts()`** (`pkg/config/wireguard_ports.go`) — the compile-time SSOT: the sorted, de-duplicated non-zero listen ports across every interface- and per-unit tunnel with `Mode=="wireguard"` (nil when no WG configured).
- **`emitHostInboundWireGuardAccept`** (`pkg/daemon/daemon_nft.go`) — emits a single coarse `udp dport <configured-wg-port(s)> accept` on the input hook when WG is configured. The nft `input` hook only ever sees host-destined packets, so a bare `udp dport <port>` admits the WG port to **every firewall-local address** — exactly the shim's `is_local_destination` scope — while transit/forward UDP (which traverses the `forward` hook, never this chain) is untouched, so **transit/DNAT UDP on the WG port is never shunted around policy**. Only the WG port is opened; every other host-bound service stays under the per-zone default-deny (restricted default preserved).

## How it composes with #5565 (per-interface host-inbound scoping)
This builds on #5565 (host-inbound per-interface exception, merged as the current base). With a `to-zone junos-host` DENY program present, `buildHostInboundFilterPayload` restructures the chain into coarse-then-fine order. The WG accept is placed **AFTER** the fine iifname-scoped DROP subchain (`emitJunosHostDenyProgram`), so an explicit operator junos-host deny of a WG source still wins — the WG admit is a *coarse* admit like the ND/PMTUD accepts, and #5565's per-interface IKE/ident shields are unaffected. The WG accept does not widen any per-interface scope; it is a single global input-hook rule mirroring the shim.

## Runtime-vs-config nuance
The admission uses the **configured** listen port (the compile-time SSOT), the same value the shim packs into its ctrl block, so kernel filter and shim steering agree. The shim's single-port WG-RX steering (S2a) steers only the FIRST configured port today; the host-inbound filter admits ALL configured WG ports, so a second-tunnel rule is currently a kernel no-op but is correct-in-intent and ready for the deferred multi-tunnel steering (#1434 Increment 2).

## Validation
- `go build ./...` and `go vet ./pkg/config/... ./pkg/daemon/...` green.
- `go test ./pkg/config/... ./pkg/daemon/...` green.
- **RED-on-revert proven**: neutering `emitHostInboundWireGuardAccept` drops the `udp dport 51820 accept`, and `TestHostInboundFilterAdmitsWireGuardListenPort` fails (the fresh handshake to the wan IP:51820 falls to the wan catch-all drop).
- **Live `nft -c -f -` parse** of both the single-port and anonymous-set payload forms is clean (syntax accepted; only netlink cache-init needs root — the expected pass path).
- New tests: `TestHostInboundFilterAdmitsWireGuardListenPort`, `TestHostInboundFilterWireGuardPayloadParses`, `TestHostInboundFilterNoWireGuardNoAccept` (`pkg/daemon`); `TestWireGuardListenPorts_5582`, `TestWireGuardListenPorts_5582_None` (`pkg/config`).
- Docs updated: `docs/wireguard-interop.md` (host-inbound admission section) and `docs/host-inbound-service-matrix.md` (dynamic-exception note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWYEhw8RaZcFoUKiwnnnHq