### PR TITLE
userspace: prune quarantined member from scoped-global deny (fail-open fix)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-11 — #5577 dataplane/userspace: prune quarantined member from scoped-global deny (fail-open fix)
+- **Timestamp**: 2026-07-11 (fix/5577-quarantine-scoped-global-member)
+- **Action**: `quarantineCollidingZones` (pkg/dataplane/userspace/zones_quarantine.go)
+  built `zones := {FromZone, ToZone, MatchFromZone, MatchToZone} + MatchFromZones
+  + MatchToZones` and DROPPED the WHOLE policy if ANY element was quarantined
+  (#4626 M03). For a SCOPED-GLOBAL policy whose match-zone context is a zone SET
+  (plural MatchFromZones/MatchToZones), dropping the whole rule because ONE member
+  collided is FAIL-OPEN: a global deny scoped from `[z174, z214]` where only
+  `z214` collides was dropped ENTIRELY, so surviving-zone (z174) traffic no longer
+  hit the deny and reached a later/default permit while the snapshot published
+  successfully (#5577). Replaced the any-member-drops logic with a prune-vs-drop
+  distinction: (1) a structurally-required zone quarantined -> DROP the rule (a
+  zone-pair singular FromZone/ToZone, or a scoped-global match side with NO
+  surviving member after pruning — leaving it empty would broaden to all zones);
+  (2) a scoped-global's plural match-zone SET has only the colliding member(s)
+  PRUNED and the deny SURVIVES scoped to the survivors. After pruning, the
+  singular MatchFromZone/MatchToZone is regenerated from the surviving set
+  (config.ScopeSingular) so an old Rust helper reading only the singular field
+  never sees the dropped zone. Prune allocates a NEW slice (MatchFromZones aliases
+  the source config's pol.Match slices — no in-place mutation). Go snapshot-builder
+  fix only; no userspace-dp/*.rs change (the Rust build_global_zone_scope already
+  consumes the pruned plural/singular set unchanged).
+- **Validation**: RED-on-revert proven (stash zones_quarantine.go → the two
+  #5577 prune tests fail: the multi-zone deny is dropped, fail-open; the zone-pair
+  drop guard stays green). `go build ./...` + `go test ./pkg/dataplane/userspace/...
+  ./pkg/config/...` green (pre-existing unrelated flake:
+  TestEventStreamDataplaneEventBeforeCallbackQueuesUntilCallback fails on clean
+  origin/master a86cc1351 too). gofmt -w applied.
+- **File(s)**: pkg/dataplane/userspace/zones_quarantine.go,
+  pkg/dataplane/userspace/zones_collision_3719_test.go, docs/config-schema.md,
+  _Log.md
+
 ## 2026-07-11 — #5574 config compiler: reject conflicting direct-scalar application leaves
 - **Timestamp**: 2026-07-11 (fix/5574-app-scalar-conflict-reject)
 - **Action**: `compileApplications` (pkg/config/compiler_applications.go)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4489,12 +4489,24 @@ zone-isolation failure the lenient warning falsely claimed was quarantined.
 by more than one name, keeps the **sorted-first** name (the survivor) and
 quarantines the rest. It is a pure function of the name set, so both HA nodes and
 a cold-booting node agree. The userspace builder's `quarantineCollidingZones`
-(`pkg/dataplane/userspace/zones.go`) applies it to the built snapshot BEFORE
-publish: it **drops** the quarantined `ZoneSnapshot`, **unzones** any interface
-bound to it (`Zone=""` → default-deny, fail closed), and **drops** any policy
-whose from/to zone is quarantined (leaving a dangling policy→zone reference would
+(`pkg/dataplane/userspace/zones_quarantine.go`) applies it to the built snapshot
+BEFORE publish: it **drops** the quarantined `ZoneSnapshot`, **unzones** any
+interface bound to it (`Zone=""` → default-deny, fail closed), and scrubs the
+quarantined zone out of policies (leaving a dangling policy→zone reference would
 trip the Rust `UnresolvableZoneReference` preflight and reject the WHOLE snapshot
-— a brick on a fresh boot). The rest of the config still loads (#1960 no-brick).
+— a brick on a fresh boot). The policy scrub distinguishes two cases (#5577):
+a rule whose **structurally-required** zone is quarantined is **dropped** — the
+singular `FromZone`/`ToZone` of a zone-pair rule, or a scoped-global match side
+left with **no** surviving member after pruning; but a scoped-global policy's
+plural match-zone SET (`MatchFromZones`/`MatchToZones`, #4626 M03) has only the
+colliding member(s) **pruned**, so a multi-zone deny scoped from `[z174, z214]`
+where only `z214` collides **survives** scoped to `[z174]`. Dropping the whole
+rule there would be **fail-open**: surviving-zone (`z174`) traffic would no longer
+hit the deny and would reach a later/default permit while the snapshot publishes
+successfully. After pruning, the singular `MatchFromZone`/`MatchToZone` is
+regenerated from the surviving set (`config.ScopeSingular`) so an old Rust helper
+that reads only the singular field also sees a surviving, non-quarantined zone.
+The rest of the config still loads (#1960 no-brick).
 The id→name reverse maps resolve a colliding id to the survivor deterministically
 (`config.StableZoneIDOwner`; `pkg/cli/apply.go:syslogZoneNameMap`,
 `pkg/dataplane/userspace/manager_ha.go:zoneNameByID`) rather than to whichever
@@ -4506,7 +4518,10 @@ is paged until one zone is renamed. Regression coverage:
 `TestStableZoneIDOwnerReturnsSurvivor`,
 `TestZoneIDCollisionLenientWarningStatesQuarantine`),
 `pkg/dataplane/userspace/zones_collision_3719_test.go`
-(`TestBuildSnapshotQuarantinesCollidingZone` — RED-on-revert), and
+(`TestBuildSnapshotQuarantinesCollidingZone`,
+`TestQuarantinePrunesScopedGlobalMemberNotWholeRule`,
+`TestBuildSnapshotPrunesScopedGlobalMemberFromRealPath` — the #5577
+prune-vs-drop guards, RED-on-revert), and
 `pkg/cli/apply_syslog_zonemap_3704_test.go`
 (`TestSyslogZoneNameMapCollisionResolvesToSurvivor`). A defense-in-depth Rust
 backstop `SnapshotIntegrityError::DuplicateZoneId` (`zones::reject_duplicate_zone_ids`,

--- a/pkg/dataplane/userspace/zones_collision_3719_test.go
+++ b/pkg/dataplane/userspace/zones_collision_3719_test.go
@@ -244,6 +244,218 @@ func TestBuildSnapshotDropsDanglingGlobalMatchZone(t *testing.T) {
 	}
 }
 
+// TestQuarantinePrunesScopedGlobalMemberNotWholeRule (#5577, fail-open): a scoped
+// global DENY whose match-zone SET carries several zones must keep protecting the
+// members that did NOT collide. A deny scoped from [z174, z214] where only z214 is
+// quarantined must SURVIVE, pruned to [z174] — NOT be dropped wholesale. Dropping
+// the whole rule is fail-open: z174 traffic would no longer hit the deny and would
+// reach a later/default permit while the snapshot publishes successfully.
+//
+// RED-on-revert: with the old any-member-drops-whole-rule logic the deny is
+// dropped entirely, so the g-deny-scoped assertion (deny survives for z174) fails.
+func TestQuarantinePrunesScopedGlobalMemberNotWholeRule(t *testing.T) {
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	snap := &ConfigSnapshot{
+		Zones: []ZoneSnapshot{
+			{Name: "untrust", ID: config.StableZoneID("untrust")},
+			{Name: "z174", ID: config.StableZoneID("z174")},
+			{Name: "z214", ID: config.StableZoneID("z214")},
+		},
+		Policies: []PolicyRuleSnapshot{
+			// A multi-zone scoped global deny: from {z174, z214} to {untrust}.
+			// Only z214 collides; the deny must survive scoped to {z174}.
+			{
+				Name: "g-deny-scoped", FromZone: "junos-global", ToZone: "junos-global",
+				Action:         "deny",
+				MatchFromZones: []string{"z174", "z214"},
+				MatchFromZone:  "z174",
+				MatchToZones:   []string{"untrust"},
+				MatchToZone:    "untrust",
+			},
+			// A middle-member collision: [untrust, z214, z174] -> [untrust, z174].
+			{
+				Name: "g-deny-middle", FromZone: "junos-global", ToZone: "junos-global",
+				Action:         "deny",
+				MatchFromZones: []string{"untrust", "z214", "z174"},
+				MatchFromZone:  "untrust",
+			},
+			// The to-side carries the collision: from {untrust} to {z174, z214}.
+			{
+				Name: "g-deny-to", FromZone: "junos-global", ToZone: "junos-global",
+				Action:         "deny",
+				MatchFromZones: []string{"untrust"},
+				MatchFromZone:  "untrust",
+				MatchToZones:   []string{"z174", "z214"},
+				MatchToZone:    "z174",
+			},
+			// EVERY match member collides -> the scope can no longer be honored;
+			// leaving it empty would broaden to all zones (fail-open), so DROP.
+			{
+				Name: "g-deny-all-quarantined", FromZone: "junos-global", ToZone: "junos-global",
+				Action:         "deny",
+				MatchFromZones: []string{"z214"},
+				MatchFromZone:  "z214",
+			},
+		},
+	}
+
+	quarantineCollidingZones(snap)
+
+	published := map[string]bool{}
+	for _, z := range snap.Zones {
+		published[z.Name] = true
+	}
+	byName := map[string]PolicyRuleSnapshot{}
+	for _, p := range snap.Policies {
+		byName[p.Name] = p
+		// No surviving rule may reference the quarantined zone in ANY zone slot —
+		// singular or plural — else the Rust preflight bricks the whole snapshot.
+		slots := append([]string{p.FromZone, p.ToZone, p.MatchFromZone, p.MatchToZone},
+			append(append([]string{}, p.MatchFromZones...), p.MatchToZones...)...)
+		for _, z := range slots {
+			if z == "" || z == "junos-global" {
+				continue
+			}
+			if !published[z] {
+				t.Fatalf("policy %q keeps dangling zone %q absent from published zones", p.Name, z)
+			}
+		}
+	}
+
+	// The core fail-open guard: the multi-zone deny SURVIVES, scoped to z174.
+	g, ok := byName["g-deny-scoped"]
+	if !ok {
+		t.Fatalf("multi-zone scoped global deny was dropped — fail-open: z174 traffic no longer hits the deny (#5577)")
+	}
+	if got := g.effectiveMatchFromZones(); len(got) != 1 || got[0] != "z174" {
+		t.Fatalf("g-deny-scoped from-scope = %v, want [z174] (z214 pruned)", got)
+	}
+	if g.MatchFromZone != "z174" {
+		t.Fatalf("g-deny-scoped singular MatchFromZone = %q, want z174 (regenerated from surviving set)", g.MatchFromZone)
+	}
+	if got := g.effectiveMatchToZones(); len(got) != 1 || got[0] != "untrust" {
+		t.Fatalf("g-deny-scoped to-scope = %v, want [untrust] (untouched)", got)
+	}
+
+	// Middle-member prune retains order of the survivors.
+	m, ok := byName["g-deny-middle"]
+	if !ok {
+		t.Fatalf("g-deny-middle was dropped, want pruned survivors")
+	}
+	if got := m.effectiveMatchFromZones(); len(got) != 2 || got[0] != "untrust" || got[1] != "z174" {
+		t.Fatalf("g-deny-middle from-scope = %v, want [untrust z174]", got)
+	}
+
+	// To-side collision pruned; from-side untouched.
+	t2, ok := byName["g-deny-to"]
+	if !ok {
+		t.Fatalf("g-deny-to was dropped, want to-side pruned to [z174]")
+	}
+	if got := t2.effectiveMatchToZones(); len(got) != 1 || got[0] != "z174" {
+		t.Fatalf("g-deny-to to-scope = %v, want [z174]", got)
+	}
+	if t2.MatchToZone != "z174" {
+		t.Fatalf("g-deny-to singular MatchToZone = %q, want z174", t2.MatchToZone)
+	}
+
+	// A rule whose every match member collided is dropped (would else broaden).
+	if _, ok := byName["g-deny-all-quarantined"]; ok {
+		t.Fatalf("scoped global whose ALL match members collided survived — would broaden to all zones (fail-open)")
+	}
+}
+
+// TestQuarantineDropsZonePairEndpointStillDrops guards the OTHER direction of the
+// #5577 distinction: a NON-scoped zone-pair rule whose singular FromZone/ToZone is
+// quarantined is STRUCTURALLY unapplicable and must STILL be dropped (unchanged
+// behavior — pruning does not apply to a required singular endpoint).
+func TestQuarantineDropsZonePairEndpointStillDrops(t *testing.T) {
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	snap := &ConfigSnapshot{
+		Zones: []ZoneSnapshot{
+			{Name: "untrust", ID: config.StableZoneID("untrust")},
+			{Name: "z174", ID: config.StableZoneID("z174")},
+			{Name: "z214", ID: config.StableZoneID("z214")},
+		},
+		Policies: []PolicyRuleSnapshot{
+			{Name: "zp-from-quarantined", FromZone: "z214", ToZone: "untrust", Action: "deny"},
+			{Name: "zp-to-quarantined", FromZone: "untrust", ToZone: "z214", Action: "deny"},
+			{Name: "zp-survivor", FromZone: "z174", ToZone: "untrust", Action: "deny"},
+		},
+	}
+	quarantineCollidingZones(snap)
+	kept := map[string]bool{}
+	for _, p := range snap.Policies {
+		kept[p.Name] = true
+	}
+	if kept["zp-from-quarantined"] || kept["zp-to-quarantined"] {
+		t.Fatalf("zone-pair rule with a quarantined endpoint survived: %v", kept)
+	}
+	if !kept["zp-survivor"] {
+		t.Fatalf("zone-pair survivor rule was wrongly dropped: %v", kept)
+	}
+}
+
+// TestBuildSnapshotPrunesScopedGlobalMemberFromRealPath drives the REAL publish
+// path (buildSnapshot) end-to-end: a config with a StableZoneID collision AND a
+// scoped global DENY whose `match from-zone [z174 z214]` includes both the
+// survivor and the quarantined zone must publish a deny that SURVIVES scoped to
+// [z174] and references no unpublished zone. RED-on-revert: the old whole-rule
+// drop removes the deny entirely, so the "deny present, scoped to z174" assertion
+// fails and z174 traffic would fall through to the default permit.
+func TestBuildSnapshotPrunesScopedGlobalMemberFromRealPath(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"untrust": {Name: "untrust"},
+		"z174":    {Name: "z174"},
+		"z214":    {Name: "z214"},
+	}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		{
+			Name: "g-multi-deny",
+			Match: config.PolicyMatch{
+				FromZones:    []string{"z174", "z214"},
+				ToZones:      []string{"untrust"},
+				Applications: []string{"any"},
+			},
+			Action: config.PolicyDeny,
+		},
+	}
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 0, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	published := map[string]bool{}
+	for _, z := range snap.Zones {
+		published[z.Name] = true
+	}
+	var deny *PolicyRuleSnapshot
+	for i := range snap.Policies {
+		p := &snap.Policies[i]
+		if p.Name == "g-multi-deny" {
+			deny = p
+		}
+		for _, z := range append([]string{p.FromZone, p.ToZone, p.MatchFromZone, p.MatchToZone},
+			append(append([]string{}, p.MatchFromZones...), p.MatchToZones...)...) {
+			if z == "" || z == "junos-global" {
+				continue
+			}
+			if !published[z] {
+				t.Fatalf("published policy %q references unpublished zone %q — Rust preflight would brick", p.Name, z)
+			}
+		}
+	}
+	if deny == nil {
+		t.Fatalf("multi-zone scoped global deny was dropped from the built snapshot — fail-open (#5577)")
+	}
+	if got := deny.effectiveMatchFromZones(); len(got) != 1 || got[0] != "z174" {
+		t.Fatalf("built deny from-scope = %v, want [z174] (z214 pruned, deny survives for z174)", got)
+	}
+}
+
 // TestBuildSnapshotNoCollisionPublishesAll: the common case is untouched — an
 // ordinary distinct-folding zone set publishes every zone and records no
 // collision (no false positive).

--- a/pkg/dataplane/userspace/zones_quarantine.go
+++ b/pkg/dataplane/userspace/zones_quarantine.go
@@ -28,9 +28,14 @@ func (c ZoneIDCollision) String() string {
 // quarantineCollidingZones enforces the StableZoneID zone-isolation invariant on
 // a built snapshot: it removes every zone whose numeric id collides with an
 // earlier-sorting zone's id, UNZONES any interface bound to a quarantined zone,
-// and DROPS any policy whose from/to zone is quarantined, so the published
-// snapshot is internally consistent and the dataplane never receives two zones
-// that share an id (#3719). Publishing both would merge two security zones — the
+// and scrubs quarantined zones out of policies — DROPPING a rule whose
+// structurally-required zone (a zone-pair FromZone/ToZone, or a scoped-global
+// match side left with no surviving member) is quarantined, but PRUNING only the
+// colliding member(s) from a scoped-global's plural match-zone SET so a deny
+// scoped to several zones SURVIVES for the members that did not collide (#5577,
+// fail-closed). The published snapshot is thus internally consistent and the
+// dataplane never receives two zones that share an id (#3719). Publishing both
+// would merge two security zones — the
 // Rust id-keyed maps (zone_id_to_name / zone_host_inbound / zone_tcp_rst) would
 // have the later zone overwrite the earlier's reverse name, host-inbound set,
 // and tcp-rst bit, and both zones' interfaces/policies would resolve to one id.
@@ -93,37 +98,81 @@ func quarantineCollidingZones(snap *ConfigSnapshot) []ZoneIDCollision {
 			snap.Interfaces[i].Zone = ""
 		}
 	}
-	// Drop policies whose from/to zone is quarantined so the snapshot carries no
-	// dangling policy->zone reference (which the Rust UnresolvableZoneReference
-	// preflight would reject wholesale — a whole-snapshot brick on a fresh boot,
-	// the exact failure this quarantine exists to prevent). This MUST include a
-	// scoped GLOBAL policy's out-of-band match-zone: a global rule keeps
-	// FromZone/ToZone == "junos-global" (never quarantined) but carries its
-	// concrete `match from-zone`/`to-zone` in MatchFromZone/MatchToZone (#3148,
-	// policies.go). The Rust build_global_zone_scope resolves those against the
-	// published zone table for EVERY rule, so a global policy scoped to a
-	// quarantined zone would leave a dangling match-zone and brick the snapshot
-	// (#3719 review). Empty ("" — the zone-pair case) and "junos-global" are
-	// never keys in the quarantine set, so they never match here.
+	// Scrub quarantined zones out of policies so the snapshot carries no dangling
+	// policy->zone reference (which the Rust UnresolvableZoneReference preflight
+	// would reject wholesale — a whole-snapshot brick on a fresh boot, the exact
+	// failure this quarantine exists to prevent). Two cases, treated differently:
+	//
+	//  1. A STRUCTURALLY-REQUIRED zone is quarantined -> DROP the whole rule. This
+	//     is the singular FromZone/ToZone of a zone-pair policy (a rule from/to a
+	//     quarantined zone can no longer be applied), OR a scoped-global match side
+	//     that is CONFIGURED but has NO surviving member after pruning (every
+	//     member collided — leaving the side empty would silently BROADEN the rule
+	//     to all zones, a fail-open in the opposite direction). Empty ("" — the
+	//     zone-pair case) and "junos-global" are never quarantine keys.
+	//
+	//  2. A scoped-GLOBAL policy's match-zone context is a zone SET (#4626 M03,
+	//     plural MatchFromZones/MatchToZones; singular kept for back-compat). When
+	//     only SOME members collide, PRUNE the quarantined member(s) and KEEP the
+	//     rule scoped to the survivors. Dropping the whole rule because one member
+	//     collides is FAIL-OPEN: a global deny scoped from [z174, z214] where only
+	//     z214 collides would vanish entirely, so still-valid z174 traffic no
+	//     longer hits the deny and reaches a later/default permit while the
+	//     snapshot publishes successfully (#5577). Unzoning z214 makes that member
+	//     irrelevant; it does not make retained-z174 traffic irrelevant. After
+	//     pruning we regenerate the SINGULAR MatchFromZone/MatchToZone from the
+	//     surviving set (config.ScopeSingular) so an old Rust helper that reads
+	//     only the singular field also sees a surviving, non-quarantined zone —
+	//     never the dropped one (which would re-introduce the dangling reference).
 	if len(snap.Policies) > 0 {
-		refsQuarantinedZone := func(p PolicyRuleSnapshot) bool {
-			// #4626 M03: a scoped global's match-zone context is now a zone SET
-			// carried in the plural MatchFromZones/MatchToZones (singular kept for
-			// back-compat). Check EVERY element so a global scoped to a
-			// quarantined zone anywhere in its set is dropped, not just its first.
-			zones := []string{p.FromZone, p.ToZone, p.MatchFromZone, p.MatchToZone}
-			zones = append(zones, p.MatchFromZones...)
-			zones = append(zones, p.MatchToZones...)
-			for _, z := range zones {
-				if _, drop := quarantined[z]; drop {
-					return true
+		isQuarantined := func(z string) bool {
+			_, drop := quarantined[z]
+			return drop
+		}
+		// pruneQuarantined returns a NEW slice with quarantined names removed. It
+		// must not compact in place: MatchFromZones/MatchToZones alias the source
+		// config's pol.Match slices (policies_lower.go), so in-place mutation would
+		// corrupt the live config. This path is a cold fail-closed backstop, so the
+		// per-rule allocation is immaterial.
+		pruneQuarantined := func(zs []string) []string {
+			out := make([]string, 0, len(zs))
+			for _, z := range zs {
+				if !isQuarantined(z) {
+					out = append(out, z)
 				}
 			}
-			return false
+			return out
 		}
 		keptPol := snap.Policies[:0]
 		for _, p := range snap.Policies {
-			if refsQuarantinedZone(p) {
+			// Case 1a: a zone-pair rule's required endpoint is quarantined.
+			if isQuarantined(p.FromZone) || isQuarantined(p.ToZone) {
+				continue
+			}
+			drop := false
+			// Case 2 / 1b: prune each configured scoped-global match side; drop the
+			// rule only if a configured side is emptied by the prune.
+			if from := p.effectiveMatchFromZones(); len(from) > 0 {
+				kept := pruneQuarantined(from)
+				if len(kept) == 0 {
+					drop = true
+				} else {
+					p.MatchFromZones = kept
+					p.MatchFromZone = config.ScopeSingular(kept)
+				}
+			}
+			if !drop {
+				if to := p.effectiveMatchToZones(); len(to) > 0 {
+					kept := pruneQuarantined(to)
+					if len(kept) == 0 {
+						drop = true
+					} else {
+						p.MatchToZones = kept
+						p.MatchToZone = config.ScopeSingular(kept)
+					}
+				}
+			}
+			if drop {
 				continue
 			}
 			keptPol = append(keptPol, p)


### PR DESCRIPTION
Closes #5577

## Problem (security — fail-open)
`quarantineCollidingZones` (`pkg/dataplane/userspace/zones_quarantine.go`, the Go
snapshot builder) scrubs StableZoneID-colliding zones out of a built snapshot
before publish. Its policy scrub built the set
`{FromZone, ToZone, MatchFromZone, MatchToZone}` + plural
`MatchFromZones`/`MatchToZones` and **dropped the whole policy** if ANY element
was quarantined (#4626 M03).

For a **scoped-global** policy whose match-zone context is a zone SET (plural
`MatchFromZones`/`MatchToZones`), dropping the whole rule because ONE member
collides is **fail-open**. A global deny scoped from `[z174, z214]` to
`[untrust]`, where only `z214` collides, was dropped entirely — so surviving-zone
(`z174`) traffic no longer hit the deny and reached a later/default **permit**,
while the snapshot published successfully and the alarm merely reported the
quarantine. Unzoning `z214` makes that member irrelevant; it does not make
retained-`z174` traffic irrelevant.

## Fix — prune-member vs drop-rule distinction
- **Structurally-required zone quarantined → DROP the rule.** The singular
  `FromZone`/`ToZone` of a zone-pair policy (unchanged behavior), OR a
  scoped-global match side that is configured but has **no surviving member**
  after pruning (every member collided — leaving the side empty would silently
  broaden the rule to all zones, fail-open in the opposite direction).
- **Scoped-global plural match-zone SET → PRUNE only the colliding member(s),** so
  the deny **survives** scoped to the members that did not collide. The singular
  `MatchFromZone`/`MatchToZone` is regenerated from the surviving set
  (`config.ScopeSingular`) so an old Rust helper that reads only the singular
  field also sees a surviving, non-quarantined zone — never the dropped one
  (which would re-introduce the dangling reference the quarantine removes).

The prune allocates a new slice rather than compacting in place —
`MatchFromZones`/`MatchToZones` alias the source config's `pol.Match` slices
(`policies_lower.go`), so in-place mutation would corrupt the live config. This is
a cold fail-closed backstop path, so the per-rule allocation is immaterial.

## Go-only
This is a **Go snapshot-builder fix**; **no `userspace-dp/*.rs` change**. The Rust
`build_global_zone_scope` already consumes the pruned plural/singular set unchanged
(prefers the plural set when non-empty, falls back to the singular). The data model
carries the pruned scope with no schema change.

## Validation
- `go build ./...` and `go test ./pkg/dataplane/userspace/... ./pkg/config/...`
  green. The one failure, `TestEventStreamDataplaneEventBeforeCallbackQueuesUntilCallback`,
  is a **pre-existing, unrelated** event-stream flake that fails on clean
  origin/master `a86cc1351` too (verified by stashing this diff).
- **RED-on-revert proven:** stashing `zones_quarantine.go` (restoring the old
  whole-rule-drop logic) makes both new #5577 tests fail — the multi-zone deny is
  dropped (fail-open) — while the zone-pair-endpoint drop guard stays green.
- New tests in `zones_collision_3719_test.go`:
  `TestQuarantinePrunesScopedGlobalMemberNotWholeRule` (deny scoped `[z174, z214]`,
  only `z214` quarantined → survives scoped to `[z174]`; first/middle/to-side/all-
  members-collide cases), `TestQuarantineDropsZonePairEndpointStillDrops` (singular
  endpoint quarantine still drops), `TestBuildSnapshotPrunesScopedGlobalMemberFromRealPath`
  (real `buildSnapshot` publish path).
- `docs/config-schema.md` quarantine-contract paragraph updated for the
  prune-vs-drop distinction; `_Log.md` logged; `gofmt -w` applied.

Loss-cluster smoke is shim-wall-deferred; since this is a Go snapshot-builder fix
in the **fail-closed** direction (a deny that was wrongly dropped now survives)
with no Rust / per-packet change, Go unit tests are the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)