### PR TITLE
snmp/v3: prefix DES privacy salt with engineBoots (#5544, RFC 3414 §8.1.1.1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-11 — #5544 snmp/v3: prefix DES privacy salt with engineBoots (RFC 3414 §8.1.1.1)
+- **Timestamp**: 2026-07-11 (fix/5544-snmp-des-salt-boots)
+- **Action**: `encryptPDU` (pkg/snmp/v3.go) allocated an 8-byte monotonic-counter
+  privacy salt via `nextPrivSalt` and passed it verbatim to BOTH the DES and AES
+  paths. RFC 3414 §8.1.1.1 RECOMMENDS the DES salt be
+  `snmpEngineBoots(4) || local-integer(4)` (big-endian) so cross-REBOOT DES-CBC
+  IV uniqueness is DETERMINISTIC, not merely probabilistic. Overlaid engineBoots
+  onto the counter's high 32 bits in the `case "des"` branch
+  (`desSalt = engineBoots(4) || salt[4:8]`), passed desSalt to encryptDES AND
+  returned it as privParams (wire salt must equal IV salt or decryptDES rebuilds
+  a wrong IV). Low 32 bits stay the monotonic counter → within-boot uniqueness
+  preserved for 2^32 PDUs (does NOT reopen #5032). AES path UNCHANGED
+  (encryptAES128 already embeds boots in its own IV). Updated encryptPDU DES-branch
+  + encryptDES doc comments. Added test/verified RED-on-revert.
+- **File(s)**: pkg/snmp/v3.go, pkg/snmp/des_salt_boots_5544_test.go, _Log.md
+
 ## 2026-07-11 — #5577 dataplane/userspace: prune quarantined member from scoped-global deny (fail-open fix)
 - **Timestamp**: 2026-07-11 (fix/5577-quarantine-scoped-global-member)
 - **Action**: `quarantineCollidingZones` (pkg/dataplane/userspace/zones_quarantine.go)

--- a/pkg/snmp/des_salt_boots_5544_test.go
+++ b/pkg/snmp/des_salt_boots_5544_test.go
@@ -1,0 +1,184 @@
+package snmp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// #5544 — SNMPv3 DES privacy salt must carry the engineBoots prefix
+// (RFC 3414 §8.1.1.1).
+//
+// RFC 3414 §8.1.1.1 RECOMMENDS the DES msgPrivacyParameters be
+// snmpEngineBoots(4) || local-integer(4), big-endian, so the DES-CBC IV
+// (key-derived preIV XOR salt) is DETERMINISTICALLY unique across a REBOOT: a
+// fresh boot advances the high 32 salt bytes no matter where the local
+// monotonic counter re-randomizes its start. Before #5544 encryptPDU passed the
+// raw 8-byte counter (Agent.nextPrivSalt) verbatim for DES, so salt[0:4] was the
+// counter's high bytes, not engineBoots — cross-boot IV uniqueness was only
+// probabilistic.
+//
+// #5544 overlays engineBoots onto salt[0:4] in encryptPDU's DES branch and
+// returns THAT salt as privParams (the wire salt MUST equal the IV salt or the
+// receiver rebuilds a wrong IV and decodes garbage). The low 32 bits (salt[4:8])
+// remain the monotonic counter, so within-boot uniqueness holds for 2^32 PDUs —
+// this does NOT reopen #5032 (which was about birthday-bound random salts; the
+// counter model is untouched).
+//
+// The AES path is deliberately UNCHANGED: encryptAES128 already embeds
+// engineBoots in its own IV (boots||time||salt), so its returned salt stays the
+// raw counter and must NOT be forced to engineBoots.
+//
+// RED-on-revert: with the boots overlay removed (returning the raw `salt` for
+// DES), assertion (1) in TestDESSaltCarriesEngineBoots5544 fails — salt[0:4]
+// becomes the monotonic counter's high bytes, not engineBoots.
+
+// newDESPrivAgent builds an agent with one authPriv (SHA / DES) user, a fixed
+// engineID, and a controlled engineBoots. Mirrors newAuthPrivAgent but selects
+// the DES privacy protocol. Returns the agent and the DES user.
+func newDESPrivAgent(t *testing.T, boots int) (*Agent, *usmUser) {
+	t.Helper()
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0xDE, 0x5A, 0x17, 0x00}
+	hashFn, hashLen := authHashFunc("sha")
+	authKey := passwordToKey("authpw-des-5544-123456", engineID, hashFn, hashLen)
+	privKey := passwordToKey("privpw-des-5544-123456", engineID, hashFn, hashLen)
+	a := &Agent{
+		engineID:    engineID,
+		engineBoots: boots,
+		v3Users:     map[string]*usmUser{},
+		startTime:   nowMinus(1000),
+	}
+	user := &usmUser{
+		name:      "duser",
+		authProto: "sha",
+		authKey:   authKey,
+		privProto: "des",
+		privKey:   privKey,
+	}
+	a.v3Users["duser"] = user
+	return a, user
+}
+
+// TestDESSaltCarriesEngineBoots5544 is the fail-on-revert guard for #5544. It
+// drives the production encryptPDU DES branch with a known engineBoots and
+// asserts the returned privParams (the wire salt): (1) carries engineBoots in
+// its high 32 bits, (2) is 8 bytes, (3) a second call keeps the boots prefix
+// while advancing the low-32 monotonic counter, and (4) round-trips through
+// decryptDES back to the original scopedPDU (IV/salt consistency).
+func TestDESSaltCarriesEngineBoots5544(t *testing.T) {
+	const boots = 7
+	a, user := newDESPrivAgent(t, boots)
+	scoped := []byte("scopedPDU-des-salt-boots-5544-roundtrip-check!!")
+
+	enc, salt, err := a.encryptPDU(user, scoped)
+	if err != nil {
+		t.Fatalf("encryptPDU(des) error: %v", err)
+	}
+
+	// (2) salt is 8 bytes.
+	if len(salt) != 8 {
+		t.Fatalf("DES privParams must be 8 bytes, got %d", len(salt))
+	}
+	// (1) engineBoots prefix present in the high 32 bits (RED-on-revert: without
+	// the overlay this is the monotonic counter's high bytes, not boots).
+	if got := binary.BigEndian.Uint32(salt[0:4]); got != boots {
+		t.Fatalf("DES salt[0:4] = %d, want engineBoots = %d "+
+			"(RFC 3414 §8.1.1.1 boots prefix missing — #5544 reverted?)", got, boots)
+	}
+	low1 := binary.BigEndian.Uint32(salt[4:8])
+
+	// (4) round-trip: decryptDES with the RETURNED salt recovers the scopedPDU.
+	// encryptDES pads to the DES block size, so the plaintext is a prefix of the
+	// decrypted block-aligned buffer.
+	dec := decryptDES(user.privKey, salt, enc)
+	if dec == nil {
+		t.Fatal("decryptDES returned nil (IV/salt inconsistency — wire salt must equal IV salt)")
+	}
+	if !bytes.HasPrefix(dec, scoped) {
+		t.Fatalf("decryptDES round-trip mismatch:\n got  %q\n want prefix %q", dec, scoped)
+	}
+
+	// (3) a second encrypt keeps the boots prefix and strictly advances the
+	// low-32 monotonic counter.
+	_, salt2, err := a.encryptPDU(user, scoped)
+	if err != nil {
+		t.Fatalf("encryptPDU(des) second call error: %v", err)
+	}
+	if got := binary.BigEndian.Uint32(salt2[0:4]); got != boots {
+		t.Fatalf("second DES salt[0:4] = %d, want engineBoots = %d", got, boots)
+	}
+	low2 := binary.BigEndian.Uint32(salt2[4:8])
+	if low2 <= low1 {
+		t.Fatalf("DES salt low32 not strictly increasing: first=%d second=%d "+
+			"(monotonic counter low half broken)", low1, low2)
+	}
+}
+
+// TestDESvsAESSaltDivergence5544 proves #5544 touched ONLY the DES path. Using a
+// deterministic counter seed (injected via the randRead seam so the assertions
+// do not depend on crypto/rand), it encrypts under a DES user then an AES user
+// on the SAME agent and asserts:
+//   - the DES salt's high 32 bits are OVERLAID with engineBoots, and
+//   - the AES salt's high 32 bits are NOT — they stay the raw monotonic
+//     counter's high bytes (AES gets cross-boot IV uniqueness from its own
+//     boots||time||salt IV, so encryptAES128 must remain unchanged).
+func TestDESvsAESSaltDivergence5544(t *testing.T) {
+	const boots = 7
+
+	// Deterministic seed: high32 = 0x11223344 (!= boots), low32 = 0. nextPrivSalt
+	// stores the seed and returns seed+n for the n-th allocation, so the first
+	// counter value is 0x1122334400000001 and the second is 0x1122334400000002.
+	saved := randRead
+	randRead = func(b []byte) (int, error) {
+		return copy(b, []byte{0x11, 0x22, 0x33, 0x44, 0x00, 0x00, 0x00, 0x00}), nil
+	}
+	defer func() { randRead = saved }()
+
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0xDE, 0x5A, 0x17, 0x01}
+	hashFn, hashLen := authHashFunc("sha")
+	authKey := passwordToKey("authpw-div-5544-123456", engineID, hashFn, hashLen)
+	privKey := passwordToKey("privpw-div-5544-123456", engineID, hashFn, hashLen)
+	a := &Agent{
+		engineID:    engineID,
+		engineBoots: boots,
+		v3Users:     map[string]*usmUser{},
+		startTime:   nowMinus(1000),
+	}
+	desUser := &usmUser{name: "duser", authProto: "sha", authKey: authKey, privProto: "des", privKey: privKey}
+	aesUser := &usmUser{name: "auser", authProto: "sha", authKey: authKey, privProto: "aes128", privKey: privKey}
+	a.v3Users["duser"] = desUser
+	a.v3Users["auser"] = aesUser
+
+	scoped := []byte("divergence scopedPDU bytes")
+
+	// First encrypt: DES. Counter = seed+1 = 0x1122334400000001. The DES branch
+	// overlays engineBoots onto the high 32 bits.
+	_, desSalt, err := a.encryptPDU(desUser, scoped)
+	if err != nil {
+		t.Fatalf("encryptPDU(des): %v", err)
+	}
+	if got := binary.BigEndian.Uint32(desSalt[0:4]); got != boots {
+		t.Fatalf("DES salt[0:4] = %d, want engineBoots = %d", got, boots)
+	}
+	if got := binary.BigEndian.Uint32(desSalt[4:8]); got != 1 {
+		t.Fatalf("DES salt low32 = %d, want 1 (monotonic counter low half)", got)
+	}
+
+	// Second encrypt: AES. Counter = seed+2 = 0x1122334400000002. The AES branch
+	// returns the counter RAW — salt[0:4] stays the counter's high bytes
+	// (0x11223344) and is NOT forced to engineBoots.
+	_, aesSalt, err := a.encryptPDU(aesUser, scoped)
+	if err != nil {
+		t.Fatalf("encryptPDU(aes): %v", err)
+	}
+	if got := binary.BigEndian.Uint32(aesSalt[0:4]); got == boots {
+		t.Fatalf("AES salt[0:4] must NOT be forced to engineBoots (%d); the AES path "+
+			"must stay unchanged — its IV embeds boots separately", boots)
+	}
+	if got := binary.BigEndian.Uint32(aesSalt[0:4]); got != 0x11223344 {
+		t.Fatalf("AES salt[0:4] = %#x, want raw counter high bytes %#x", got, uint32(0x11223344))
+	}
+	if got := binary.BigEndian.Uint32(aesSalt[4:8]); got != 2 {
+		t.Fatalf("AES salt low32 = %d, want 2 (raw counter low half)", got)
+	}
+}

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -832,11 +832,31 @@ func (a *Agent) encryptPDU(user *usmUser, scopedPDU []byte) ([]byte, []byte, err
 	}
 	switch user.privProto {
 	case "des":
-		enc, err := encryptDES(user.privKey, scopedPDU, salt)
+		// RFC 3414 §8.1.1.1 RECOMMENDS the DES privacy salt be
+		// snmpEngineBoots(4) || local-integer(4) (big-endian) so the DES-CBC IV
+		// (key-derived preIV XOR salt) is DETERMINISTICALLY unique across a
+		// REBOOT: a fresh boot advances the high 32 salt bytes regardless of
+		// where the monotonic counter re-randomizes its start. Overlay
+		// engineBoots onto the counter's high 32 bits; keep the counter's low 32
+		// bits (salt[4:8]) as the per-message local-integer. That low half still
+		// increments monotonically per PDU and repeats only every 2^32 messages,
+		// so within-boot IV uniqueness is preserved for 2^32 PDUs — this does NOT
+		// reopen #5032 (that defect was birthday-bound random salts; the counter
+		// model is unchanged). The overlaid salt is what we build the IV from AND
+		// what we return as privParams: the wire salt MUST equal the IV salt or
+		// the manager's decryptDES rebuilds a different IV and decodes garbage.
+		//
+		// The AES path is intentionally left with the raw counter — encryptAES128
+		// embeds engineBoots in its own IV (boots||time||salt), so its cross-boot
+		// uniqueness is already deterministic without touching the salt.
+		desSalt := make([]byte, 8)
+		copy(desSalt, salt)
+		binary.BigEndian.PutUint32(desSalt[0:4], uint32(a.engineBoots))
+		enc, err := encryptDES(user.privKey, scopedPDU, desSalt)
 		if err != nil {
 			return nil, nil, err
 		}
-		return enc, salt, nil
+		return enc, desSalt, nil
 	case "aes128":
 		enc, err := encryptAES128(user.privKey, scopedPDU, salt, a.engineBoots, a.engineTime())
 		if err != nil {
@@ -850,11 +870,14 @@ func (a *Agent) encryptPDU(user *usmUser, scopedPDU []byte) ([]byte, []byte, err
 
 // encryptDES encrypts data using DES-CBC per RFC 3414 §8.1.1.1. The caller
 // supplies the 8-octet privacy salt (msgPrivacyParameters); the CBC IV is the
-// key-derived pre-IV XORed with that salt. RFC 3414 §8.1.1.1 requires the salt
-// to differ for each message within an engineBoots domain — the agent allocates
-// it from a monotonic counter (Agent.nextPrivSalt), guaranteeing a distinct IV
-// per message so DES-CBC never repeats first-block structure (RFC 3414 §8.2.1).
-// The salt is returned to the wire unchanged as privParams by the caller.
+// key-derived pre-IV XORed with that salt. RFC 3414 §8.1.1.1 RECOMMENDS the salt
+// be snmpEngineBoots(4) || local-integer(4) (big-endian): encryptPDU builds it
+// as engineBoots(4) || counter32(4), where counter32 is the low half of the
+// monotonic Agent.nextPrivSalt counter. The engineBoots prefix makes the IV
+// deterministically unique across a reboot; the counter32 makes it distinct for
+// each of up to 2^32 messages within a boot, so DES-CBC never repeats
+// first-block structure (RFC 3414 §8.2.1). The salt is returned to the wire
+// unchanged as privParams by the caller so the receiver rebuilds the same IV.
 func encryptDES(privKey, data, salt []byte) ([]byte, error) {
 	if len(privKey) < 16 {
 		return nil, fmt.Errorf("snmpv3: DES privacy key too short: %d bytes", len(privKey))


### PR DESCRIPTION
## Summary

`encryptPDU` (pkg/snmp/v3.go) allocated an 8-byte monotonic-counter privacy
salt via `nextPrivSalt` and passed it **verbatim** to both the DES and AES
cipher paths. RFC 3414 §8.1.1.1 **RECOMMENDS** the DES `msgPrivacyParameters`
be `snmpEngineBoots(4) || local-integer(4)` (big-endian) so the DES-CBC IV
(key-derived preIV XOR salt) is **deterministically** unique across a reboot —
a fresh boot advances the high 32 salt bytes regardless of where the local
counter re-randomizes its start. With the raw counter, `salt[0:4]` was the
counter's high bytes, so cross-boot IV uniqueness was only probabilistic.

## Fix (DES path only)

In `encryptPDU`'s `case "des":` branch, overlay `engineBoots` onto the
counter's high 32 bits:

```go
desSalt := make([]byte, 8)
copy(desSalt, salt)
binary.BigEndian.PutUint32(desSalt[0:4], uint32(a.engineBoots))
```

`desSalt` is passed to `encryptDES` **and** returned as `privParams` — the wire
salt must equal the IV salt or the manager's `decryptDES` rebuilds a different
IV and decodes garbage. `decryptDES` reconstructs the IV directly from the 8
transmitted salt bytes and does not validate any boots-prefix structure, so
**interop is unaffected**.

- `salt[4:8]` stays the low 32 bits of the monotonic counter → within-boot IV
  uniqueness preserved for 2^32 PDUs (the exact RFC 3414 model). This does **not**
  reopen #5032 (that defect was birthday-bound random salts; the counter model
  and `nextPrivSalt` are untouched — AES still gets the full 8-byte counter).
- **AES is unchanged**: `encryptAES128` already embeds `engineBoots` in its own
  IV (`boots || time || salt`), so AES cross-boot uniqueness is already
  deterministic. `encryptDES`/`decryptDES` signatures are unchanged.

## Validation

New `pkg/snmp/des_salt_boots_5544_test.go`:
- `TestDESSaltCarriesEngineBoots5544` — returned DES salt carries engineBoots in
  `salt[0:4]`, is 8 bytes, advances the low-32 counter across calls, and
  round-trips through `decryptDES` back to the scopedPDU.
- `TestDESvsAESSaltDivergence5544` — deterministic counter seed (via the
  `randRead` seam) proves the AES salt keeps the raw counter high bytes and is
  **not** forced to engineBoots.

RED-on-revert verified: removing the overlay makes assertion (1) fail
(`salt[0:4]` becomes the counter high bytes, not engineBoots).

`go build ./...` and `go test ./pkg/snmp/... -count=1` both green.

Closes #5544

🤖 Generated with [Claude Code](https://claude.com/claude-code)