### PR TITLE
dataplane/shim: ABI-check v6 + HA shared pins in live-pin preflight (#5484)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-11 — #5484 dataplane/shim: ABI-check all required pins incl v6 + HA maps in live-pin preflight
+- **Timestamp**: 2026-07-11 (fix/5484-livepin-abi-inventory)
+- **Action**: `userspaceABICheckedPinnedMaps` (pkg/dataplane/loader_userspace_shim.go)
+  returned `userspacePinnedShimMaps()` minus the disposable
+  `userspace_fallback_stats`, OMITTING the Go-created/replaced shared maps
+  declared in `userspaceShimSharedMapSpecs` — `sessions_v6`, `dnat_table_v6`, and
+  the HA / per-CPU maps (`rg_active`, `ha_watchdog`, `session_id_gen`, the
+  `*_counters`). So `validateUserspaceShimLivePins` never ABI-checked them: an
+  incompatible v6/HA-map shim passed the deploy pre-flight, then failed
+  `ErrMapIncompatible` in `loadUserspaceShimSharedMaps` AFTER the old daemon was
+  stopped, stranding the node fail-closed. Part 1: rebuilt
+  `userspaceABICheckedPinnedMaps` as the deduplicated UNION of both required-pin
+  sources (`userspacePinnedShimMaps` + `userspaceShimSharedMapSpecs` names) minus
+  fallback stats, aligning the ABI-checked set with the required-pins set
+  `userspaceRequiredShimPins` already iterates for existence. Fail-safe by
+  construction: `validateUserspaceShimLivePins` skips maps the shim doesn't embed
+  and maps with no live pin, and diffs SPEC-derived shapes, so a healthy deploy
+  (live-pin == embedded == Go-created) yields NO diff — only a real ABI break is
+  caught. Part 2: generalized `validateDNATExpectedABI` → `validateSharedMapExpectedABI(embedded, name)`
+  and wired a `dnat_table_v6` expected-shape arm into `validateUserspaceShimSpecWith`
+  next to the v4 arm (guarded on the embedded spec declaring the v6 table), so a
+  fresh-node embedded v6 DNAT drift is caught even with no live pin. Updated
+  pkg/dataplane/README.md ABI-check section (no longer "PinByName maps only" /
+  "dnat_table only"). Added tests + verified RED-on-revert.
+- **File(s)**: pkg/dataplane/loader_userspace_shim.go,
+  pkg/dataplane/livepin_abi_inventory_5484_test.go, pkg/dataplane/README.md, _Log.md
+
 ## 2026-07-11 — #5544 snmp/v3: prefix DES privacy salt with engineBoots (RFC 3414 §8.1.1.1)
 - **Timestamp**: 2026-07-11 (fix/5544-snmp-des-salt-boots)
 - **Action**: `encryptPDU` (pkg/snmp/v3.go) allocated an 8-byte monotonic-counter

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -83,25 +83,36 @@ Guard layers (`build-userspace-xdp.sh`):
    REJECT refuses the deploy with the old dataplane still forwarding.
 
    The shared `validateUserspaceShimSpec` gate this runs also performs
-   an **ABI compatibility check** (#5307): for every PinByName shim map
+   an **ABI compatibility check** (#5307): for every required pinned map
    it compares the embedded shim's `Type`, `KeySize`, `ValueSize`,
    `MaxEntries`, and `Flags` — the exact fields cilium/ebpf's
    `MapSpec.Compatible` flags with `ErrMapIncompatible` at load —
-   against BOTH the Go-side expected shape (dnat_table only, from
-   `userspaceShimSharedMapSpecs`) AND the RUNNING daemon's **live
+   against BOTH the Go-side expected shape (dnat_table and dnat_table_v6,
+   from `userspaceShimSharedMapSpecs`) AND the RUNNING daemon's **live
    pinned maps** (read-only via `ebpf.LoadPinnedMap` + shape
-   accessors). Because this runs while the old daemon is still up (its
-   pins live), an ABI-incompatible map is caught HERE and the deploy is
-   refused — instead of the pre-#5307 behavior where a green pre-flight
-   let the deploy proceed, the old daemon was stopped, and the new
-   daemon's `NewCollectionWithOptions` then failed `ErrMapIncompatible`,
-   stranding the node fail-closed (config-only). A map with no pin yet
-   (fresh node / first load) skips the live-pin arm — only the
-   expected-value checks apply, so a clean node never false-fails. The
-   disposable counter map `userspace_fallback_stats` is intentionally
-   excluded: `reconcileDisposableCollectionPin` resets it on an
-   intended shape change (#4113), so ABI-checking it here would re-brick
-   that upgrade.
+   accessors). The ABI-checked inventory (`userspaceABICheckedPinnedMaps`)
+   is the UNION of the shim-declared PinByName maps
+   (`userspacePinnedShimMaps`) AND the Go-created/replaced shared maps
+   (`userspaceShimSharedMapSpecs`) — deduplicated — matching the
+   required-pins set (`userspaceRequiredShimPins`). Before #5484 it
+   covered only the PinByName group, so state-bearing shared maps the
+   shim does NOT declare — `sessions_v6`, `dnat_table_v6`, and the HA /
+   per-CPU maps (`rg_active`, `ha_watchdog`, `session_id_gen`, the
+   `*_counters`) — were never pre-flighted: an incompatible live pin for
+   one of them passed a green pre-flight and then failed
+   `ErrMapIncompatible` in `loadUserspaceShimSharedMaps` AFTER the old
+   daemon was stopped, stranding the node. Because this runs while the
+   old daemon is still up (its pins live), an ABI-incompatible map is
+   now caught HERE and the deploy is refused — instead of the pre-#5307
+   behavior where a green pre-flight let the deploy proceed, the old
+   daemon was stopped, and the new daemon's `NewCollectionWithOptions`
+   (or the shared-map load) then failed `ErrMapIncompatible`, stranding
+   the node fail-closed (config-only). A map with no pin yet (fresh
+   node / first load) skips the live-pin arm — only the expected-value
+   checks apply, so a clean node never false-fails. The disposable
+   counter map `userspace_fallback_stats` is intentionally excluded:
+   `reconcileDisposableCollectionPin` resets it on an intended shape
+   change (#4113), so ABI-checking it here would re-brick that upgrade.
 
    **Residual (documented, not caught here):** a *same-size* Go/Rust
    value **field reorder** — identical `KeySize`/`ValueSize`/`Type`/

--- a/pkg/dataplane/livepin_abi_inventory_5484_test.go
+++ b/pkg/dataplane/livepin_abi_inventory_5484_test.go
@@ -1,0 +1,276 @@
+package dataplane
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// TestUserspaceABICheckedPinnedMapsCoversAllRequiredPins is the #5484 core:
+// the live-pin ABI pre-flight inventory (userspaceABICheckedPinnedMaps) must
+// cover EVERY required pin — both the shim-declared PinByName maps
+// (userspacePinnedShimMaps) AND the Go-created/replaced shared maps
+// (userspaceShimSharedMapSpecs) — deduplicated, minus the disposable
+// userspace_fallback_stats counter.
+//
+// Before the fix the set was userspacePinnedShimMaps() minus fallback stats
+// only, so the state-bearing shared maps the shim does not declare —
+// sessions_v6, dnat_table_v6, and the HA/per-CPU maps (rg_active, ha_watchdog,
+// session_id_gen, the *_counters) — were never ABI-checked. An incompatible
+// live pin for one of those passed the deploy pre-flight and then failed
+// ErrMapIncompatible in loadUserspaceShimSharedMaps AFTER the old daemon was
+// stopped, stranding the node fail-closed. RED-on-revert: the pre-fix inventory
+// omits every shared-spec-only name asserted below.
+func TestUserspaceABICheckedPinnedMapsCoversAllRequiredPins(t *testing.T) {
+	t.Parallel()
+
+	got := userspaceABICheckedPinnedMaps()
+
+	set := make(map[string]int, len(got))
+	for _, n := range got {
+		set[n]++
+	}
+
+	// No duplicates: dnat_table / dnat_table_v6 appear in BOTH source lists and
+	// must be folded to a single entry.
+	for n, c := range set {
+		if c != 1 {
+			t.Fatalf("map %q appears %d times, want deduplicated single entry", n, c)
+		}
+	}
+
+	// The disposable counter map is deliberately excluded (#4113): ABI-checking
+	// it here would re-brick the very upgrade reconcileDisposableCollectionPin
+	// was written to unblock.
+	if _, ok := set[userspaceFallbackStatsMapName]; ok {
+		t.Fatalf("ABI-checked set must exclude disposable %s", userspaceFallbackStatsMapName)
+	}
+
+	// Spot-check the previously-omitted state-bearing shared maps that the #5484
+	// stranding scenario turns on.
+	for _, want := range []string{
+		"sessions_v6", "dnat_table_v6", "ha_watchdog", "rg_active",
+		"session_id_gen", "interface_counters", "nat_rule_counters",
+	} {
+		if _, ok := set[want]; !ok {
+			t.Fatalf("ABI-checked set omits %q (would strand node fail-closed on an incompatible live pin)", want)
+		}
+	}
+
+	// Completeness: the set must equal the union of both required-pin sources
+	// minus the disposable counter — the exact invariant the fix establishes and
+	// that userspaceRequiredShimPins already iterates for existence.
+	want := make(map[string]struct{})
+	for _, n := range userspacePinnedShimMaps() {
+		if n != userspaceFallbackStatsMapName {
+			want[n] = struct{}{}
+		}
+	}
+	for _, s := range userspaceShimSharedMapSpecs() {
+		if s.Name != userspaceFallbackStatsMapName {
+			want[s.Name] = struct{}{}
+		}
+	}
+	if len(set) != len(want) {
+		t.Fatalf("ABI-checked set has %d maps, want %d (union of both required-pin sources minus fallback stats)", len(set), len(want))
+	}
+	for n := range want {
+		if _, ok := set[n]; !ok {
+			t.Fatalf("ABI-checked set omits required pin %q", n)
+		}
+	}
+}
+
+// TestABICheckedMapProvenance documents HOW each newly covered map is confirmed
+// embedded+pinned, and that abiCheckedRefSpec resolves it to the right shape:
+//
+//   - dnat_table_v6 is DECLARED by the shim ELF (like dnat_table) and replaced
+//     at load, so its ABI reference is the embedded shim spec.
+//   - sessions_v6 and the HA/counter maps are Go-created shared maps (present in
+//     userspaceShimSharedMapSpecs, ABSENT from the shim ELF), so their reference
+//     is the Go SSOT spec — the shape loadUserspaceShimSharedMaps creates+pins.
+//
+// This is the production-accurate resolution: in production the shim never
+// declares sessions_v6/HA maps, so the fix MUST fall back to the Go SSOT.
+func TestABICheckedMapProvenance(t *testing.T) {
+	t.Parallel()
+
+	spec, err := loadRustUserspaceXDP()
+	if err != nil {
+		t.Fatalf("load Rust userspace XDP spec: %v", err)
+	}
+
+	// dnat_table_v6: shim-declared (#2406) and replaced at load, like dnat_table.
+	if spec.Maps[userspaceShimCompatibilityDNATV6Name] == nil {
+		t.Fatalf("embedded shim spec missing %s (expected shim-declared)", userspaceShimCompatibilityDNATV6Name)
+	}
+	if got := abiCheckedRefSpec(spec, userspaceShimCompatibilityDNATV6Name); got != spec.Maps[userspaceShimCompatibilityDNATV6Name] {
+		t.Errorf("abiCheckedRefSpec(%s) must resolve to the embedded shim spec", userspaceShimCompatibilityDNATV6Name)
+	}
+
+	shared := make(map[string]bool)
+	for _, s := range userspaceShimSharedMapSpecs() {
+		shared[s.Name] = true
+	}
+	// sessions_v6 + HA/counter maps: Go-created shared maps, NOT shim-declared.
+	for _, name := range []string{"sessions_v6", "rg_active", "ha_watchdog", "session_id_gen", "global_counters", "nat_port_counters"} {
+		if !shared[name] {
+			t.Errorf("%s not in userspaceShimSharedMapSpecs (Go SSOT)", name)
+		}
+		if spec.Maps[name] != nil {
+			t.Errorf("%s unexpectedly declared by the shim ELF; expected Go-created only", name)
+		}
+		// abiCheckedRefSpec must fall back to the Go SSOT (value-equal to
+		// sharedShimMapSpecByName; userspaceShimSharedMapSpecs rebuilds fresh
+		// pointers each call, so compare by name + ABI shape, not identity).
+		got := abiCheckedRefSpec(spec, name)
+		wantSpec := sharedShimMapSpecByName(name)
+		if got == nil || wantSpec == nil || got.Name != name || mapABIFromSpec(got) != mapABIFromSpec(wantSpec) {
+			t.Errorf("abiCheckedRefSpec(%s) must resolve to the Go SSOT shared spec (got %+v)", name, got)
+		}
+	}
+}
+
+// TestValidateUserspaceShimSpecDNATV6ExpectedABIDrift covers the #5484
+// expected-value arm for the IPv6 reverse-NAT steering table: an embedded
+// dnat_table_v6 whose Type/KeySize/ValueSize drifts from the Go single source
+// of truth (userspaceShimSharedMapSpecs) is rejected even on a fresh node with
+// no live pin, exactly as dnat_table already was. The correct shape is
+// accepted. RED-on-revert: without the v6 arm in validateUserspaceShimSpecWith
+// the drift is invisible until the post-stop load fails ErrMapIncompatible.
+func TestValidateUserspaceShimSpecDNATV6ExpectedABIDrift(t *testing.T) {
+	t.Parallel()
+
+	v6 := sharedShimMapSpecByName(userspaceShimCompatibilityDNATV6Name)
+	if v6 == nil {
+		t.Fatalf("Go SSOT missing %s spec", userspaceShimCompatibilityDNATV6Name)
+	}
+
+	// Accept: the correct embedded v6 shape passes on a fresh node.
+	base := validABIBaseSpec()
+	base.Maps[userspaceShimCompatibilityDNATV6Name] = v6.Copy()
+	if err := validateUserspaceShimSpecWith(base, noPinReader()); err != nil {
+		t.Fatalf("correct dnat_table_v6 shape rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*ebpf.MapSpec)
+		field  string
+	}{
+		{"value-size", func(m *ebpf.MapSpec) { m.ValueSize = v6.ValueSize + 8 }, "value_size"},
+		{"key-size", func(m *ebpf.MapSpec) { m.KeySize = v6.KeySize + 4 }, "key_size"},
+		{"type", func(m *ebpf.MapSpec) { m.Type = ebpf.LRUHash }, "type"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			drift := validABIBaseSpec()
+			mv6 := v6.Copy()
+			tt.mutate(mv6)
+			drift.Maps[userspaceShimCompatibilityDNATV6Name] = mv6
+
+			// RED-on-revert: the pre-#5484 validator accepts the base spec (it never
+			// inspects dnat_table_v6), so the ONLY reject signal is the new v6 arm.
+			if err := legacyPresenceMaxEntriesValidate(drift); err != nil {
+				t.Fatalf("legacy validator rejected base (%v); cannot prove RED-on-revert", err)
+			}
+
+			err := validateUserspaceShimSpecWith(drift, noPinReader())
+			if err == nil {
+				t.Fatalf("want dnat_table_v6 %s drift error on fresh node, got nil (would brick post-stop)", tt.field)
+			}
+			if !strings.Contains(err.Error(), "dnat_table_v6") || !strings.Contains(err.Error(), tt.field) {
+				t.Fatalf("err = %v, want dnat_table_v6 %s drift", err, tt.field)
+			}
+		})
+	}
+}
+
+// sharedMapLivePinReader returns a fake live-pin reader that reports one target
+// shared map's pinned shape as `drift` (exists=true) and every other map as its
+// base-spec shape (or absent for maps not in the base spec). It models a running
+// daemon whose shared-map pin drifted from the new dataplane's Go SSOT shape —
+// the production scenario, where the target map is NOT in the shim spec and so
+// abiCheckedRefSpec must fall back to the Go SSOT to find its reference shape.
+func sharedMapLivePinReader(base *ebpf.CollectionSpec, target string, drift userspaceMapABI) userspacePinnedMapABIReader {
+	return func(path string) (userspaceMapABI, bool, error) {
+		name := filepath.Base(path)
+		if name == target {
+			return drift, true, nil
+		}
+		if ms, ok := base.Maps[name]; ok {
+			return mapABIFromSpec(ms), true, nil
+		}
+		return userspaceMapABI{}, false, nil
+	}
+}
+
+// TestValidateUserspaceShimSpecSharedMapLivePinABI proves the Part-1 fix on the
+// production-accurate path: a Go-created shared map the shim does NOT declare
+// (sessions_v6, sessions, the HA maps, a per-CPU counter) whose live pin drifts
+// from the new dataplane's Go SSOT shape is now rejected at the pre-flight —
+// before the old daemon is stopped — instead of failing ErrMapIncompatible in
+// loadUserspaceShimSharedMaps AFTER the stop. The target map is deliberately
+// absent from the (synthetic) shim spec, so abiCheckedRefSpec resolves it via
+// the Go SSOT fallback, exactly as in production. A matching pin passes (no
+// false failure). RED-on-revert: the pre-#5484 inventory never iterates these
+// names, so the drifted pin is never read and the deploy passes.
+func TestValidateUserspaceShimSpecSharedMapLivePinABI(t *testing.T) {
+	t.Parallel()
+
+	targets := []string{
+		"sessions_v6",
+		"sessions",
+		"rg_active",
+		"ha_watchdog",
+		"session_id_gen",
+		"nat_port_counters",
+		"global_counters",
+		"interface_counters",
+	}
+	for _, target := range targets {
+		target := target
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+
+			base := validABIBaseSpec()
+			ref := sharedShimMapSpecByName(target)
+			if ref == nil {
+				t.Fatalf("no Go SSOT spec for %s", target)
+			}
+			// The target is NOT in the shim (base) spec — the production reality.
+			if base.Maps[target] != nil {
+				t.Fatalf("test invariant: %s must be absent from the base shim spec", target)
+			}
+			correct := mapABIFromSpec(ref)
+
+			// RED-on-revert guard: the pre-#5484 validator accepts the base spec, so
+			// the ONLY reject signal is the new shared-map live-pin comparison.
+			if err := legacyPresenceMaxEntriesValidate(base); err != nil {
+				t.Fatalf("legacy validator rejected base (%v); cannot prove RED-on-revert", err)
+			}
+
+			// A matching live pin passes (fail-safe: healthy deploy, no false fail).
+			if err := validateUserspaceShimSpecWith(base, sharedMapLivePinReader(base, target, correct)); err != nil {
+				t.Fatalf("matching %s live pin must pass, got: %v", target, err)
+			}
+
+			// A drifted live pin (MaxEntries bumped) is rejected, naming the map.
+			drift := correct
+			drift.MaxEntries++
+			err := validateUserspaceShimSpecWith(base, sharedMapLivePinReader(base, target, drift))
+			if err == nil {
+				t.Fatalf("want %s live-pin ABI mismatch, got nil (would brick post-stop after ErrMapIncompatible)", target)
+			}
+			for _, want := range []string{target, "MaxEntries", "ABI-incompatible", userspaceShimGenerateRemediation} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("err = %v, want substring %q", err, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/dataplane/loader_userspace_shim.go
+++ b/pkg/dataplane/loader_userspace_shim.go
@@ -31,6 +31,11 @@ const (
 	userspaceBindingsMapName           = "userspace_bindings"
 	userspaceIngressIfacesMapName      = "userspace_ingress_ifaces"
 	userspaceShimCompatibilityDNATName = "dnat_table"
+	// userspaceShimCompatibilityDNATV6Name is the IPv6 reverse-NAT steering
+	// table. Like dnat_table it is BOTH declared by the shim ELF and replaced at
+	// load (opts.MapReplacements["dnat_table_v6"]); #5484 pulls it into the same
+	// ABI arms dnat_table already had.
+	userspaceShimCompatibilityDNATV6Name = "dnat_table_v6"
 	// userspaceFallbackStatsMapName is the internal mixed-version compatibility
 	// name for the degraded-path counter map (operator surface:
 	// degraded_path_counters). #4113 changed its BPF type from Array to
@@ -201,11 +206,37 @@ func validateUserspaceShimSpecWith(userspaceSpec *ebpf.CollectionSpec, readPin u
 			"dnat_table flags drift: embedded=%d, expected BPF_F_NO_PREALLOC (userspace shim compatibility map). %s",
 			ms.Flags, userspaceShimGenerateRemediation,
 		)
-	} else if err := validateDNATExpectedABI(ms); err != nil {
+	} else if err := validateSharedMapExpectedABI(ms, userspaceShimCompatibilityDNATName); err != nil {
 		return err
 	}
-	// #5307: compare the embedded shim's map ABI against the RUNNING daemon's
-	// live pins so ErrMapIncompatible is caught pre-stop, not post-stop.
+	// #5484: dnat_table_v6 is declared by the shim AND replaced at load, exactly
+	// like dnat_table, but was omitted from every expected-shape arm — so an
+	// embedded v6 DNAT ABI drift was invisible on a fresh node (no live pin to
+	// compare against). Validate its embedded shape against the Go SSOT
+	// (userspaceShimSharedMapSpecs). Guarded on presence rather than mandatory so
+	// a synthetic/partial spec that omits the v6 table still exercises the other
+	// arms; the real embedded shim always declares dnat_table_v6 (#2406). The
+	// running-daemon case is covered by the live-pin arm below, which now
+	// includes dnat_table_v6 in its ABI-checked set.
+	if ms, ok := userspaceSpec.Maps[userspaceShimCompatibilityDNATV6Name]; ok {
+		if ms.MaxEntries != userspaceShimMaxSessions {
+			return fmt.Errorf(
+				"dnat_table_v6 max_entries drift: embedded=%d, expected=%d (userspace shim compatibility map). %s",
+				ms.MaxEntries, userspaceShimMaxSessions, userspaceShimGenerateRemediation,
+			)
+		}
+		if ms.Flags&unix.BPF_F_NO_PREALLOC == 0 {
+			return fmt.Errorf(
+				"dnat_table_v6 flags drift: embedded=%d, expected BPF_F_NO_PREALLOC (userspace shim compatibility map). %s",
+				ms.Flags, userspaceShimGenerateRemediation,
+			)
+		}
+		if err := validateSharedMapExpectedABI(ms, userspaceShimCompatibilityDNATV6Name); err != nil {
+			return err
+		}
+	}
+	// #5307/#5484: compare the embedded shim's map ABI against the RUNNING
+	// daemon's live pins so ErrMapIncompatible is caught pre-stop, not post-stop.
 	return validateUserspaceShimLivePins(userspaceSpec, readPin)
 }
 
@@ -254,34 +285,37 @@ func userspaceMapABIDiff(embedded, ref userspaceMapABI) string {
 	return ""
 }
 
-// validateDNATExpectedABI checks the embedded dnat_table against the Go-side
-// single source of truth (userspaceShimSharedMapSpecs) for the ABI fields
-// cilium/ebpf compares beyond MaxEntries/Flags already asserted by the caller:
-// Type, KeySize, ValueSize. This catches an embedded-vs-Go ABI drift even on a
-// fresh node that has no live pin to compare against (#5307 expected-value arm).
-// Only dnat_table has a Go-side expected shape here; the other pinned shim maps
-// are Rust-defined and are guarded by the live-pin comparison.
-func validateDNATExpectedABI(embedded *ebpf.MapSpec) error {
-	want := sharedShimMapSpecByName(userspaceShimCompatibilityDNATName)
+// validateSharedMapExpectedABI checks an embedded shim map (named by `name`)
+// against the Go-side single source of truth (userspaceShimSharedMapSpecs) for
+// the ABI fields cilium/ebpf compares beyond MaxEntries/Flags already asserted
+// by the caller: Type, KeySize, ValueSize. This catches an embedded-vs-Go ABI
+// drift even on a fresh node that has no live pin to compare against (#5307
+// expected-value arm; #5484 generalized so the v6 DNAT steering table gets the
+// same fresh-node protection as v4). Only maps with a Go-side expected shape
+// (dnat_table / dnat_table_v6) are validated here; the other pinned shim maps
+// are Rust-defined and are guarded by the live-pin comparison. A name with no
+// Go SSOT spec returns nil (nothing to compare against).
+func validateSharedMapExpectedABI(embedded *ebpf.MapSpec, name string) error {
+	want := sharedShimMapSpecByName(name)
 	if want == nil {
 		return nil
 	}
 	if embedded.Type != want.Type {
 		return fmt.Errorf(
-			"dnat_table type drift: embedded=%s, expected=%s (userspace shim compatibility map). %s",
-			embedded.Type, want.Type, userspaceShimGenerateRemediation,
+			"%s type drift: embedded=%s, expected=%s (userspace shim compatibility map). %s",
+			name, embedded.Type, want.Type, userspaceShimGenerateRemediation,
 		)
 	}
 	if embedded.KeySize != want.KeySize {
 		return fmt.Errorf(
-			"dnat_table key_size drift: embedded=%d, expected=%d (userspace shim compatibility map). %s",
-			embedded.KeySize, want.KeySize, userspaceShimGenerateRemediation,
+			"%s key_size drift: embedded=%d, expected=%d (userspace shim compatibility map). %s",
+			name, embedded.KeySize, want.KeySize, userspaceShimGenerateRemediation,
 		)
 	}
 	if embedded.ValueSize != want.ValueSize {
 		return fmt.Errorf(
-			"dnat_table value_size drift: embedded=%d, expected=%d (userspace shim compatibility map). %s",
-			embedded.ValueSize, want.ValueSize, userspaceShimGenerateRemediation,
+			"%s value_size drift: embedded=%d, expected=%d (userspace shim compatibility map). %s",
+			name, embedded.ValueSize, want.ValueSize, userspaceShimGenerateRemediation,
 		)
 	}
 	return nil
@@ -296,20 +330,44 @@ func sharedShimMapSpecByName(name string) *ebpf.MapSpec {
 	return nil
 }
 
-// userspaceABICheckedPinnedMaps is the set of PinByName shim maps whose live
-// pin must be ABI-compatible with the new shim before the collection load. It
-// is userspacePinnedShimMaps() minus the DISPOSABLE counter map
-// (userspace_fallback_stats): that map is deliberately reset on an intended
-// shape change by reconcileDisposableCollectionPin (#4113), so ABI-checking it
-// here would re-brick the very upgrade that reconcile was written to unblock.
+// userspaceABICheckedPinnedMaps is the full set of maps whose live pin must be
+// ABI-compatible with the new dataplane before the collection load — the ONE
+// production replacement inventory the #5484 fix consolidates. It is the union
+// of:
+//
+//   - the shim-declared PinByName maps (userspacePinnedShimMaps), which the
+//     shim ELF creates+pins via the collection load; and
+//   - the Go-created shared maps (userspaceShimSharedMapSpecs), which the Go
+//     loader creates+pins itself (loadUserspaceShimSharedMaps) and, for some,
+//     hands to the shim via MapReplacements.
+//
+// The pre-#5484 inventory covered only the first group, so state-bearing shared
+// maps the shim does NOT declare — sessions_v6, the HA maps (rg_active,
+// ha_watchdog, session_id_gen), and the per-CPU counter maps — were never
+// pre-flighted. An incompatible live pin for one of those passed the deploy
+// gate and then failed ErrMapIncompatible in loadUserspaceShimSharedMaps AFTER
+// the old daemon was stopped, stranding the node fail-closed (#5484). Adding
+// them here catches the drift pre-stop while the old dataplane still forwards.
+//
+// The DISPOSABLE counter map (userspace_fallback_stats) is excluded: it is
+// deliberately reset on an intended shape change by
+// reconcileDisposableCollectionPin (#4113), so ABI-checking it here would
+// re-brick the very upgrade that reconcile was written to unblock.
 func userspaceABICheckedPinnedMaps() []string {
-	names := userspacePinnedShimMaps()
-	out := make([]string, 0, len(names))
-	for _, n := range names {
-		if n == userspaceFallbackStatsMapName {
-			continue
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(userspacePinnedShimMaps())+len(userspaceShimSharedMapSpecs()))
+	add := func(n string) {
+		if n == userspaceFallbackStatsMapName || seen[n] {
+			return
 		}
+		seen[n] = true
 		out = append(out, n)
+	}
+	for _, n := range userspacePinnedShimMaps() {
+		add(n)
+	}
+	for _, s := range userspaceShimSharedMapSpecs() {
+		add(s.Name)
 	}
 	return out
 }
@@ -322,16 +380,25 @@ func userspaceABICheckedPinnedMaps() []string {
 // instead of bricking the node after the old daemon has been stopped (#5307).
 //
 // A map with no pin yet (fresh node / first load) is skipped, so this never
-// produces a false failure on a clean node. A map absent from the new shim is
-// skipped, since PinByName never loads it.
+// produces a false failure on a clean node. A map the new dataplane does not
+// create/pin at all (neither shim-declared nor a Go shared map) is skipped,
+// since nothing would ever fail ErrMapIncompatible for it.
+//
+// The reference shape is resolved per map by abiCheckedRefSpec: the embedded
+// shim's own MapSpec for a shim-declared map (dnat_table, dnat_table_v6, the
+// userspace_* maps), else the Go-side SSOT spec for a shared map the loader
+// creates itself (sessions_v6, the HA/counter family). Both are spec-derived
+// (userspaceMapABIDiff(mapABIFromSpec(ref), live)) — never a hardcoded live
+// shape — so a healthy deploy where live pin == the shape that created it
+// yields no diff and only a real cross-version ABI break is caught (#5484).
 func validateUserspaceShimLivePins(userspaceSpec *ebpf.CollectionSpec, readPin userspacePinnedMapABIReader) error {
 	if readPin == nil {
 		return nil
 	}
 	for _, name := range userspaceABICheckedPinnedMaps() {
-		ms, ok := userspaceSpec.Maps[name]
-		if !ok {
-			continue // absent from the new shim: PinByName never loads it
+		ref := abiCheckedRefSpec(userspaceSpec, name)
+		if ref == nil {
+			continue // new dataplane never creates/pins it: no ErrMapIncompatible risk
 		}
 		pinPath := filepath.Join(bpfPinPath, name)
 		live, exists, err := readPin(pinPath)
@@ -341,7 +408,7 @@ func validateUserspaceShimLivePins(userspaceSpec *ebpf.CollectionSpec, readPin u
 		if !exists {
 			continue // fresh node / first load: nothing pinned yet
 		}
-		if diff := userspaceMapABIDiff(mapABIFromSpec(ms), live); diff != "" {
+		if diff := userspaceMapABIDiff(mapABIFromSpec(ref), live); diff != "" {
 			return fmt.Errorf(
 				"userspace shim map %s is ABI-incompatible with the live pinned map at %s: %s. "+
 					"Loading the new dataplane would fail with ErrMapIncompatible AFTER the running "+
@@ -352,6 +419,21 @@ func validateUserspaceShimLivePins(userspaceSpec *ebpf.CollectionSpec, readPin u
 		}
 	}
 	return nil
+}
+
+// abiCheckedRefSpec resolves the authoritative ABI reference shape for a
+// live-pin comparison. A shim-declared map is compared against the embedded
+// shim's own MapSpec (the shape the collection load would pin by name); a
+// Go-created shared map the shim does NOT declare is compared against the Go
+// SSOT spec (userspaceShimSharedMapSpecs), the shape loadUserspaceShimSharedMaps
+// creates+pins it with. Returns nil when neither owns the name, so the caller
+// skips it — the new dataplane never loads such a map, so it can never fail
+// ErrMapIncompatible (fail-safe).
+func abiCheckedRefSpec(userspaceSpec *ebpf.CollectionSpec, name string) *ebpf.MapSpec {
+	if ms, ok := userspaceSpec.Maps[name]; ok {
+		return ms
+	}
+	return sharedShimMapSpecByName(name)
 }
 
 // userspacePinnedMapABIReader reads the ABI-relevant shape of a live pinned map
@@ -404,6 +486,12 @@ func userspaceIngressIfacesMaxEntriesDriftError(got uint32) error {
 func userspacePinnedShimMaps() []string {
 	return []string{
 		"dnat_table",
+		// #5484: dnat_table_v6 is the IPv6 twin of dnat_table — declared by the
+		// shim ELF and replaced at load (MapReplacements["dnat_table_v6"]) — but
+		// was omitted from this inventory, so the live-pin ABI arm never checked
+		// it. Listed here for parity with dnat_table (both replaced maps are
+		// re-pinned idempotently via userspaceRequiredShimPins).
+		"dnat_table_v6",
 		"userspace_ctrl",
 		"userspace_bindings",
 		"userspace_ingress_ifaces",


### PR DESCRIPTION
Closes #5484

## Problem

The deploy pre-flight (`xpfd verify-dataplane`, run BEFORE the old daemon is stopped) exists to catch a shim map ABI incompatibility while the current dataplane still forwards, so an incompatible upgrade is refused rather than stranding the node fail-closed after the old daemon is gone (the #5307 mechanism).

But the ABI-checked inventory was incomplete. `userspaceABICheckedPinnedMaps()` derived only from `userspacePinnedShimMaps()` — the shim-declared PinByName maps plus the single v4 `dnat_table`. It **omitted every state-bearing shared map the Go loader creates+pins itself** (`loadUserspaceShimSharedMaps`) and hands to the shim via `MapReplacements`:

- `sessions_v6`, `sessions`
- `dnat_table_v6` (shim-declared **and** replaced at load, exactly like `dnat_table`)
- the HA / per-CPU family: `rg_active`, `ha_watchdog`, `session_id_gen`, `global_counters`, `flood_counters`, `policy_counters`, `zone_counters`, `filter_counters`, `interface_counters`, `nat_port_counters`, `nat_rule_counters`, `fib_gen_map`, `fabric_fwd`

So `validateUserspaceShimLivePins` never compared those maps. An incompatible v6/HA-map ABI passed a **green** pre-flight, then failed `ErrMapIncompatible` in `loadUserspaceShimSharedMaps` (or `NewCollectionWithOptions`) **after** the old daemon was stopped — stranding the node fail-closed and risking HA capacity loss. Separately, the embedded-vs-Go expected-shape arm existed only for v4 `dnat_table`, so a fresh node (no live pin) could not catch a v6 DNAT drift.

## Fix (two parts, both fail-safe)

**1. One production replacement inventory.** `userspaceABICheckedPinnedMaps()` is now the deduplicated **union** of both required-pin sources — `userspacePinnedShimMaps()` (now including `dnat_table_v6`) **plus** every `userspaceShimSharedMapSpecs()` name — minus the disposable `userspace_fallback_stats` (still reset by `reconcileDisposableCollectionPin`, #4113). This matches the set `userspaceRequiredShimPins` already iterates for existence. `validateUserspaceShimLivePins` resolves each map's reference shape via the new `abiCheckedRefSpec`: the **embedded shim's** own `MapSpec` for a shim-declared map, else the **Go SSOT** spec (`userspaceShimSharedMapSpecs`) for a shared map the shim does not declare.

The comparison stays **spec-derived** — `userspaceMapABIDiff(mapABIFromSpec(ref), live)`, never a hardcoded live shape. It compares exactly the fields cilium/ebpf's `MapSpec.Compatible` enforces at load (Type/KeySize/ValueSize/MaxEntries/Flags), so the pre-flight rejects **exactly when — and only when —** the post-stop load would have failed. A healthy deploy (live pin == the shape that created it) yields no diff; only a real cross-version ABI break is caught. Maps with no live pin (fresh node) and names the new dataplane never creates/pins are skipped.

**2. `dnat_table_v6` expected-shape arm.** `validateDNATExpectedABI` → `validateSharedMapExpectedABI(embedded, name)`, with a `dnat_table_v6` arm wired into `validateUserspaceShimSpecWith` next to the v4 arm (MaxEntries/Flags + Type/KeySize/ValueSize), so an embedded v6 DNAT drift is caught on a fresh node with no live pin. Guarded on presence (the real embedded shim always declares `dnat_table_v6` since #2406) so a synthetic/partial spec still exercises the other arms.

## Map names added to the ABI-checked inventory

| Map | How confirmed embedded/pinned |
|-----|-------------------------------|
| `dnat_table_v6` | **Shim-declared** (`#[map(name = "dnat_table_v6")]` in `userspace-xdp/src/lib.rs`) **and** replaced at load (`opts.MapReplacements["dnat_table_v6"]`). Ref = embedded shim spec. Added to `userspacePinnedShimMaps()` for parity with `dnat_table`. |
| `sessions`, `sessions_v6` | Go-created shared maps in `userspaceShimSharedMapSpecs()`; **not** shim-declared. Ref = Go SSOT. Created+pinned by `loadUserspaceShimSharedMaps`. |
| `rg_active`, `ha_watchdog`, `session_id_gen`, `global_counters`, `flood_counters`, `policy_counters`, `zone_counters`, `filter_counters`, `interface_counters`, `nat_port_counters`, `nat_rule_counters`, `fib_gen_map`, `fabric_fwd` | Go-created shared maps in `userspaceShimSharedMapSpecs()`; **not** shim-declared. Ref = Go SSOT. |

Each shim-declared name was confirmed by inspecting the `#[map(name = ...)]` declarations in `userspace-xdp/src/lib.rs`; each Go-created name by its presence in `userspaceShimSharedMapSpecs()` and **absence** from the embedded spec (`loadRustUserspaceXDP().Maps`). `TestABICheckedMapProvenance` pins both facts and the `abiCheckedRefSpec` resolution.

## Tests (`pkg/dataplane/livepin_abi_inventory_5484_test.go`)

- `TestUserspaceABICheckedPinnedMapsCoversAllRequiredPins` — inventory == union of both sources minus fallback_stats, deduplicated; spot-checks the previously-omitted maps.
- `TestABICheckedMapProvenance` — `dnat_table_v6` is shim-declared (ref = shim spec); `sessions_v6`/HA maps are Go-created only (ref = Go SSOT).
- `TestValidateUserspaceShimSpecDNATV6ExpectedABIDrift` — v6 expected-shape arm rejects Type/KeySize/ValueSize drift on a fresh node; accepts the correct shape.
- `TestValidateUserspaceShimSpecSharedMapLivePinABI` — table of shared maps (sessions_v6, sessions, rg_active, ha_watchdog, session_id_gen, nat_port_counters, global_counters, interface_counters): a drifted live pin is rejected via the **Go-SSOT fallback** (production-accurate — the target is absent from the shim spec), a matching pin passes.

**RED-on-revert proven** by neutering the fix (revert the inventory union + drop the v6 arm): `TestUserspaceABICheckedPinnedMapsCoversAllRequiredPins`, `TestValidateUserspaceShimSpecDNATV6ExpectedABIDrift`, and `TestValidateUserspaceShimSpecSharedMapLivePinABI` all fail; restoring the fix returns green.

## Validation & smoke

- `TMPDIR=/tmp go build ./...` — green
- `TMPDIR=/tmp go test ./pkg/dataplane/... -count=1` — green (all 4 packages)
- `go vet ./pkg/dataplane/` — clean; `gofmt` clean

**No cluster smoke needed.** This is not a forwarding change — it is a fail-safe completeness fix to a **read-only** deploy pre-flight. It only ever *refuses* a deploy that would otherwise brick the node post-stop; a healthy deploy is unaffected (spec-derived diff yields nothing), and the full-reload / fresh-node path skips live-pin checks entirely. Docs updated: `pkg/dataplane/README.md` ABI-check section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QL271nTVSFMa7QgaxjpWU