### PR TITLE
dataplane/verify: stale-pin remediation for live-pin ABI mismatch (#5363)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-11 — #5363 dataplane/verify: stale-pin remediation for live-pin ABI mismatch
+- **Timestamp**: 2026-07-11 (fix/5363-stalepin-remediation)
+- **Action**: `validateUserspaceShimLivePins` (pkg/dataplane/loader_userspace_shim.go)
+  appended the FIXED `userspaceShimGenerateRemediation` ("Re-run `make
+  generate-userspace-xdp`.") on a live-pin ABI mismatch. That is MISLEADING for
+  the live-pin case: the live pin is the OLD daemon's map and the embedded shim is
+  the intended, un-broken deploy target — telling the operator to rebuild the shim
+  is wrong; the fix is a full dataplane reload so the stale pin is released and the
+  new map ABI can be pinned. This is the exact scenario blocking a real cluster
+  (`userspace_cpumap` embedded=256 vs pinned=16). Added constant
+  `userspaceShimStalePinRemediation` (full-reload guidance) and switched the
+  live-pin mismatch branch to it — the ONLY behavioral change site. The live-pin
+  check inherently compares "new build's shim" vs "old daemon's pin", so the pin
+  is ALWAYS the stale side, in BOTH the upgrade direction (embedded MaxEntries >
+  pinned) AND a downgrade — the fix is direction-INDEPENDENT (no >-vs-<
+  heuristic). Left the embedded-vs-Go-SSOT drift sites
+  (`validateUserspaceShimSpecWith` expected-shape arms,
+  `validateSharedMapExpectedABI`, the bindings/ingress-ifaces drift errors) on
+  `userspaceShimGenerateRemediation` — a mismatch there means the embedded shim
+  drifted from its Go contract, which IS a `make generate` situation. Updated the
+  two existing live-pin tests (userspace_shim_loader_test.go,
+  livepin_abi_inventory_5484_test.go) to expect the stale-pin remediation, added
+  stalepin_remediation_5363_test.go (cpumap up/down + dnat_table live-pin → stale
+  remediation; SSOT-drift → keeps make-generate), updated pkg/dataplane/README.md
+  ABI-check section with the remediation split. Verified RED-on-revert (live-pin
+  tests fail with the old constant; the SSOT-drift test stays green, proving the
+  drift sites are unchanged). Diagnostic-message-only — no cluster smoke needed.
+- **File(s)**: pkg/dataplane/loader_userspace_shim.go,
+  pkg/dataplane/stalepin_remediation_5363_test.go,
+  pkg/dataplane/userspace_shim_loader_test.go,
+  pkg/dataplane/livepin_abi_inventory_5484_test.go, pkg/dataplane/README.md, _Log.md
+
 ## 2026-07-11 — #5484 dataplane/shim: ABI-check all required pins incl v6 + HA maps in live-pin preflight
 - **Timestamp**: 2026-07-11 (fix/5484-livepin-abi-inventory)
 - **Action**: `userspaceABICheckedPinnedMaps` (pkg/dataplane/loader_userspace_shim.go)

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -114,6 +114,25 @@ Guard layers (`build-userspace-xdp.sh`):
    `reconcileDisposableCollectionPin` resets it on an intended shape
    change (#4113), so ABI-checking it here would re-brick that upgrade.
 
+   **Remediation message split (#5363):** the two ABI arms print
+   *different* operator guidance because they diagnose different faults.
+   An **embedded-vs-Go-SSOT drift** (`validateUserspaceShimSpecWith`
+   expected-shape arms + `validateSharedMapExpectedABI` +
+   the `userspace_bindings`/`userspace_ingress_ifaces` drift errors) means
+   the embedded shim binary drifted from its Go-side source contract, so
+   it prints `userspaceShimGenerateRemediation` — "Re-run `make
+   generate-userspace-xdp`." A **live-pin mismatch**
+   (`validateUserspaceShimLivePins`) is the OPPOSITE situation: it compares
+   this build's embedded shim against the RUNNING (old) daemon's pinned
+   map, so the pin is ALWAYS the stale side — in the upgrade direction
+   (embedded `MaxEntries` > pinned, e.g. the `userspace_cpumap` 16→256
+   bump) AND in a downgrade. The embedded shim is the intended, un-broken
+   target, so `make generate` is the WRONG action; instead it prints
+   `userspaceShimStalePinRemediation`, directing a FULL dataplane reload
+   (stop xpfd so the old pin is released, then start it to load the new
+   shim). A rolling deploy cannot cross a shim-map ABI change because the
+   new map can only be pinned after the stale pin is released.
+
    **Residual (documented, not caught here):** a *same-size* Go/Rust
    value **field reorder** — identical `KeySize`/`ValueSize`/`Type`/
    `Flags` but a different field layout — is invisible to this

--- a/pkg/dataplane/livepin_abi_inventory_5484_test.go
+++ b/pkg/dataplane/livepin_abi_inventory_5484_test.go
@@ -266,10 +266,16 @@ func TestValidateUserspaceShimSpecSharedMapLivePinABI(t *testing.T) {
 			if err == nil {
 				t.Fatalf("want %s live-pin ABI mismatch, got nil (would brick post-stop after ErrMapIncompatible)", target)
 			}
-			for _, want := range []string{target, "MaxEntries", "ABI-incompatible", userspaceShimGenerateRemediation} {
+			// #5363: the live pin is always the STALE side (the running daemon's
+			// pin predates this build's shim ABI), so the remediation is a full
+			// reload, not `make generate`.
+			for _, want := range []string{target, "MaxEntries", "ABI-incompatible", userspaceShimStalePinRemediation} {
 				if !strings.Contains(err.Error(), want) {
 					t.Fatalf("err = %v, want substring %q", err, want)
 				}
+			}
+			if strings.Contains(err.Error(), "make generate-userspace-xdp") {
+				t.Fatalf("err = %v, live-pin mismatch must NOT tell the operator to rebuild the shim", err)
 			}
 		})
 	}

--- a/pkg/dataplane/loader_userspace_shim.go
+++ b/pkg/dataplane/loader_userspace_shim.go
@@ -26,8 +26,24 @@ import (
 )
 
 const (
-	bpfPinPath                         = "/sys/fs/bpf/xpf"
-	userspaceShimGenerateRemediation   = "Re-run `make generate-userspace-xdp`."
+	bpfPinPath                       = "/sys/fs/bpf/xpf"
+	userspaceShimGenerateRemediation = "Re-run `make generate-userspace-xdp`."
+	// userspaceShimStalePinRemediation is the remediation for a LIVE-PIN ABI
+	// mismatch (validateUserspaceShimLivePins): the running daemon's pinned map
+	// predates this build's shim-map ABI. That is NOT an embedded-vs-Go SSOT
+	// drift — the embedded shim is the intended deploy target and is not broken
+	// — so `make generate` is the WRONG action. A rolling deploy cannot cross a
+	// shim-map ABI change because the new map can only be pinned after the stale
+	// pin is released; the fix is a full dataplane reload. This is the exact
+	// scenario that blocks a cluster stuck on an old cpumap=16 pin vs an
+	// embedded cpumap=256 shim (#5363).
+	userspaceShimStalePinRemediation = "The RUNNING daemon's pinned map predates " +
+		"this build's shim-map ABI. A rolling deploy CANNOT cross a shim-map ABI " +
+		"change: the new map can only be pinned after the stale pin is released. " +
+		"Do a FULL dataplane reload (stop xpfd so the old pin is released, then " +
+		"start it to load the new shim), accepting brief downtime — do NOT `make " +
+		"generate` (the embedded shim is the intended target, not broken). See " +
+		"pkg/dataplane/README.md (#1864)."
 	userspaceBindingsMapName           = "userspace_bindings"
 	userspaceIngressIfacesMapName      = "userspace_ingress_ifaces"
 	userspaceShimCompatibilityDNATName = "dnat_table"
@@ -414,7 +430,7 @@ func validateUserspaceShimLivePins(userspaceSpec *ebpf.CollectionSpec, readPin u
 					"Loading the new dataplane would fail with ErrMapIncompatible AFTER the running "+
 					"daemon is stopped, stranding the node fail-closed; refusing so the current "+
 					"dataplane keeps forwarding. %s",
-				name, pinPath, diff, userspaceShimGenerateRemediation,
+				name, pinPath, diff, userspaceShimStalePinRemediation,
 			)
 		}
 	}

--- a/pkg/dataplane/stalepin_remediation_5363_test.go
+++ b/pkg/dataplane/stalepin_remediation_5363_test.go
@@ -1,0 +1,147 @@
+package dataplane
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+)
+
+// TestLivePinABIMismatchUsesStalePinRemediation is the #5363 core: when the
+// embedded shim's map ABI differs from the RUNNING daemon's LIVE pinned map,
+// the live pin is ALWAYS the stale side — it is the OLD daemon's map, while the
+// embedded shim is the intended (and un-broken) deploy target. So the
+// remediation must be the full-dataplane-reload guidance, NEVER `make generate`
+// (which would tell the operator to rebuild a shim that is not broken).
+//
+// This is direction-INDEPENDENT: it holds both in the upgrade direction
+// (embedded MaxEntries > pinned — the userspace_cpumap 16→256 bump that blocked
+// a real cluster) AND in a downgrade (embedded < pinned). Both cases exercise
+// the SAME live-pin mismatch branch, so a single stale-pin remediation is
+// correct for the whole branch — no MaxEntries >-vs-< heuristic.
+//
+// RED-on-revert: with the pre-#5363 code the live-pin error appended
+// userspaceShimGenerateRemediation ("Re-run `make generate-userspace-xdp`."),
+// so this test's "must NOT contain make generate-userspace-xdp" and "must
+// contain the stale-pin phrase" assertions both flip red.
+func TestLivePinABIMismatchUsesStalePinRemediation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		mapName      string
+		embedded     *ebpf.MapSpec   // added to the shim spec (nil => already present)
+		pinnedShape  userspaceMapABI // live pin the fake reader reports
+		wantDiffFrag string          // substring naming the offending field
+	}{
+		{
+			// The exact #5363 scenario: an old daemon pinned userspace_cpumap
+			// with 16 entries; this build's shim embeds 256. Upgrade direction
+			// (embedded > pinned).
+			name:         "cpumap-upgrade-embedded-gt-pinned",
+			mapName:      "userspace_cpumap",
+			embedded:     &ebpf.MapSpec{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 256},
+			pinnedShape:  userspaceMapABI{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 16},
+			wantDiffFrag: "MaxEntries embedded=256 pinned=16",
+		},
+		{
+			// Downgrade direction (embedded < pinned): the pin is STILL the
+			// stale side, so the remediation is STILL a full reload — proving
+			// the fix is direction-independent (no >-vs-< heuristic).
+			name:         "cpumap-downgrade-embedded-lt-pinned",
+			mapName:      "userspace_cpumap",
+			embedded:     &ebpf.MapSpec{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 16},
+			pinnedShape:  userspaceMapABI{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 256},
+			wantDiffFrag: "MaxEntries embedded=16 pinned=256",
+		},
+		{
+			// A shim-declared shared map (dnat_table): embedded shape is the
+			// correct one (so the earlier expected-shape arm passes); only the
+			// LIVE pin drifts, so the mismatch is caught by the live-pin arm.
+			name:         "dnat-table-live-pin-drift",
+			mapName:      "dnat_table",
+			embedded:     nil,
+			pinnedShape:  userspaceMapABI{Type: ebpf.Hash, KeySize: 12, ValueSize: 8, MaxEntries: 16, Flags: unix.BPF_F_NO_PREALLOC},
+			wantDiffFrag: "MaxEntries",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := validABIBaseSpec()
+			if tt.embedded != nil {
+				base.Maps[tt.mapName] = tt.embedded
+			}
+
+			// RED-on-revert guard: the base spec passes the legacy
+			// presence+MaxEntries validator, so the ONLY reject signal is the
+			// live-pin ABI comparison whose remediation we are asserting.
+			if err := legacyPresenceMaxEntriesValidate(base); err != nil {
+				t.Fatalf("legacy validator rejected base (%v); cannot prove RED-on-revert", err)
+			}
+
+			reader := pinReaderWithOverride(base, map[string]userspaceMapABI{tt.mapName: tt.pinnedShape})
+			err := validateUserspaceShimSpecWith(base, reader)
+			if err == nil {
+				t.Fatalf("want live-pin ABI mismatch on %s, got nil", tt.mapName)
+			}
+
+			msg := err.Error()
+			// The mismatch is still reported, naming the map and the field.
+			for _, want := range []string{tt.mapName, "ABI-incompatible", tt.wantDiffFrag} {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("err = %v, want substring %q", err, want)
+				}
+			}
+			// The remediation is the full-reload / stale-pin guidance...
+			if !strings.Contains(msg, userspaceShimStalePinRemediation) {
+				t.Fatalf("err = %v, want stale-pin remediation constant", err)
+			}
+			for _, phrase := range []string{"FULL dataplane reload", "stale pin", "released"} {
+				if !strings.Contains(msg, phrase) {
+					t.Fatalf("err = %v, want distinctive stale-pin phrase %q", err, phrase)
+				}
+			}
+			// ...and NEVER the "rebuild the shim" remediation.
+			if strings.Contains(msg, "make generate-userspace-xdp") {
+				t.Fatalf("err = %v, live-pin mismatch must NOT tell the operator to rebuild the shim", err)
+			}
+		})
+	}
+}
+
+// TestSSOTDriftKeepsGenerateRemediation proves the #5363 fix is SURGICAL: the
+// embedded-vs-Go-SSOT drift sites are UNCHANGED and still emit the `make
+// generate-userspace-xdp` remediation. Here an embedded dnat_table value_size
+// drifts from the Go single source of truth on a FRESH node (no live pin), so
+// the reject comes from validateSharedMapExpectedABI, not the live-pin arm — a
+// genuine "the embedded shim binary drifted from its Go contract" situation
+// where rebuilding the shim IS the right action.
+//
+// RED-on-revert direction: if someone globally swapped the constant (applying
+// the stale-pin remediation to the SSOT-drift sites too), this test flips red.
+func TestSSOTDriftKeepsGenerateRemediation(t *testing.T) {
+	t.Parallel()
+
+	base := validABIBaseSpec()
+	base.Maps["dnat_table"].ValueSize = 16 // drift from the Go SSOT (sizeOf[DNATValue]()==8)
+
+	err := validateUserspaceShimSpecWith(base, noPinReader())
+	if err == nil {
+		t.Fatal("want dnat_table value_size drift error on fresh node, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"dnat_table", "value_size", "make generate-userspace-xdp"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("err = %v, want substring %q (SSOT-drift site must keep make-generate)", err, want)
+		}
+	}
+	// The SSOT-drift remediation must NOT be the stale-pin one.
+	if strings.Contains(msg, "FULL dataplane reload") {
+		t.Fatalf("err = %v, embedded-vs-Go SSOT drift must NOT use the stale-pin remediation", err)
+	}
+}

--- a/pkg/dataplane/userspace_shim_loader_test.go
+++ b/pkg/dataplane/userspace_shim_loader_test.go
@@ -254,10 +254,17 @@ func TestValidateUserspaceShimSpecLivePinABI(t *testing.T) {
 			if err == nil {
 				t.Fatalf("want ABI mismatch on %s, got nil (would brick post-stop after ErrMapIncompatible)", tt.wantMap)
 			}
-			for _, want := range []string{tt.wantMap, tt.wantField, "ABI-incompatible", userspaceShimGenerateRemediation} {
+			// #5363: a live-pin mismatch is a STALE-PIN case (the running
+			// daemon's pin predates this build's shim ABI), so the remediation
+			// must be the full-reload guidance, NOT `make generate` — the
+			// embedded shim is the intended target, not broken.
+			for _, want := range []string{tt.wantMap, tt.wantField, "ABI-incompatible", userspaceShimStalePinRemediation} {
 				if !strings.Contains(err.Error(), want) {
 					t.Fatalf("err = %v, want substring %q", err, want)
 				}
+			}
+			if strings.Contains(err.Error(), "make generate-userspace-xdp") {
+				t.Fatalf("err = %v, live-pin mismatch must NOT tell the operator to rebuild the shim", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The verify-dataplane ABI pre-flight printed a single fixed remediation — `userspaceShimGenerateRemediation` = "Re-run \`make generate-userspace-xdp\`." — on **every** ABI mismatch, including a **live-pin** mismatch. That message is misleading for the live-pin case.

`validateUserspaceShimLivePins` compares **this build's embedded shim** map ABI against the **RUNNING (old) daemon's live pinned maps**. The live pin is the *old daemon's* map; the embedded shim is the intended deploy target and is **not broken**. Telling the operator to rebuild the shim (`make generate`) is wrong — the correct action is a **full dataplane reload** so the stale pin is released and the new shim's map ABI can be pinned.

This is the exact scenario blocking a real cluster: `userspace_cpumap` **embedded=256 vs pinned=16**, where the running pin predates the current shim's cpumap 16→256 bump.

## Key insight (direction-independent)

The live-pin check inherently compares *"new build's shim"* vs *"old daemon's pin"*, so the pin is **always** the stale side — in **both** the upgrade direction (embedded `MaxEntries` > pinned, the common case) **and** a downgrade (embedded < pinned). In every live-pin mismatch the right remediation is a full reload, never `make generate`. The fix is therefore **direction-independent** for the live-pin site — no `MaxEntries` `>`-vs-`<` heuristic; the stale-pin remediation covers the whole live-pin mismatch branch.

## Change

- Add `userspaceShimStalePinRemediation` (full-reload guidance) and append it instead of `userspaceShimGenerateRemediation` in `validateUserspaceShimLivePins` — the **only** behavioral change site.
- The embedded-vs-Go-SSOT drift sites (`validateUserspaceShimSpecWith` expected-shape arms, `validateSharedMapExpectedABI`, the `userspace_bindings` / `userspace_ingress_ifaces` drift errors) **keep** `userspaceShimGenerateRemediation`: a mismatch there means the embedded shim binary drifted from its Go-side source contract, which **is** a `make generate` situation.
- Updated `pkg/dataplane/README.md` with the remediation split.

## Validation

- `go build ./...` and `go test ./pkg/dataplane/...` green; `gofmt` clean.
- Updated the two existing live-pin tests to expect the stale-pin remediation; added `stalepin_remediation_5363_test.go` (cpumap up/down + dnat_table live-pin → stale remediation and no make-generate; embedded-vs-Go-SSOT drift → keeps make-generate).
- **RED-on-revert verified**: restoring the old constant at the live-pin site turns the live-pin tests red while the SSOT-drift test stays green (proving the drift sites are unchanged).
- **Diagnostic-message-only change** — no forwarding or ABI-logic change, so **no cluster smoke required**.

Closes #5363

🤖 Generated with [Claude Code](https://claude.com/claude-code)