### PR TITLE
userspace-dp/snapshot: monotonicity-guard the full apply_snapshot generation (#5169)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-11 — #5169 review fold: admit exact-equal generation re-apply (#4036 idempotent retry)
+- **Timestamp**: 2026-07-11 (fix/5169-apply-snapshot-gen-monotonicity, rev-5604 fold)
+- **Action**: Hostile review (rev-5604, MERGE-NEEDS-MINOR) found the exact-equal
+  refusal fail-closes the #4036 "timeout-but-landed" idempotent retry: the
+  partial-republish Go paths (Compile, PublishRouteOverlaySnapshot,
+  retryDeferredWorkerArmLocked) commit `m.generation` only on Go-observed
+  success and do NOT consult `lastStatus.LastSnapshotGeneration`, so a
+  timed-out-but-landed apply of gen G leaves `m.generation` at G-1 and the retry
+  re-sends the IDENTICAL (G, fib) pair — refusing it → non-converging loop.
+  Refusing exact-equal also buys ZERO security: an equal pair equality-matches
+  only the CURRENT published pair, whose cache entries are already valid, so it
+  revives nothing (revival requires re-publishing a SUPERSEDED strictly-less
+  pair). Changed the fib disjunct from `>` to `>=` (guard
+  `server/handlers/snapshot.rs`): admit iff `generation > cur` OR (`generation
+  == cur && fib_generation >= cur_fib`). Now ADMITS exact-equal + config-advance
+  + fib-advance; still REFUSES both rollback axes — config rollback
+  (`generation < cur`) AND fib rollback under a reused config (`generation ==
+  cur && fib_generation < cur_fib`). This is the exact `<`-not-`<=` semantics
+  `bump_fib` already uses. Error string updated ("... rollback rejected: (c,f) <
+  current"). Flipped `apply_snapshot_rejects_generation_reuse_5169` →
+  `apply_snapshot_admits_generation_reuse_5169` (exact-equal now ok=true); added
+  `apply_snapshot_rejects_fib_rollback_5169` (config==cur, fib<cur → refused);
+  kept the config-rollback, config-advance, and fib-only-advance tests. Updated
+  the doc note (admit-exact-equal, both rollback axes).
+- **File(s)**: userspace-dp/src/server/handlers/snapshot.rs (`>` → `>=` + comment
+  + error string), userspace-dp/src/server/tests.rs (reuse test flipped to admit,
+  fib-rollback-refused test added), docs/flow-cache-simplification.md
+- **Validation**: `cargo build` clean; full `cargo test --release` green
+  (CARGO_EXIT=0); 5 `_5169` tests 5x flake-free; RED-on-revert confirmed — with
+  the guard disabled BOTH rollback tests (config + fib) FAIL, the three admit
+  tests still pass.
+
 ## 2026-07-11 — #5169 userspace-dp/snapshot: monotonicity-guard the full apply_snapshot generation
 - **Timestamp**: 2026-07-11 (fix/5169-apply-snapshot-gen-monotonicity)
 - **Action**: Added a pair-monotonicity gate to the FULL `apply_snapshot`

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-11 — #5169 userspace-dp/snapshot: monotonicity-guard the full apply_snapshot generation
+- **Timestamp**: 2026-07-11 (fix/5169-apply-snapshot-gen-monotonicity)
+- **Action**: Added a pair-monotonicity gate to the FULL `apply_snapshot`
+  handler, mirroring the #3767 H5 rollback guard on `bump_fib`. The full path
+  published the incoming `(generation, fib_generation)` pair VERBATIM (into
+  `status.last_snapshot_generation`/`last_fib_generation` and `ValidationState`)
+  with NO monotonicity check. Flow-cache validation is EQUALITY based on the
+  pair (`flow_cache.rs` lookup), so a reused/rolled-back pair equality-matches
+  prior cache stamps and revives a lazily-unevicted cached ALLOW a later
+  generation already invalidated — a fail-OPEN. The guard refuses fail-CLOSED
+  (before any mutation/preflight/side-effect) any pair that is not a
+  LEXICOGRAPHIC strict increase over the last PUBLISHED pair in `guard.status`:
+  admit iff `generation > cur` OR (`generation == cur && fib_generation >
+  cur_fib`). Admits a config advance (any fib) AND a route-only fib-only advance
+  (config reused); refuses only equal-or-preceding pairs. Compares against
+  `guard.status` (not `ValidationState`: config_generation has no coordinator
+  accessor, and disarmed applies advance `guard.status` but not
+  `ValidationState`). Gated on `guard.snapshot.is_some()` so the first apply is
+  never falsely refused. Documented in `docs/flow-cache-simplification.md`
+  (new #5169 section after the #3767 gating section).
+- **File(s)**: userspace-dp/src/server/handlers/snapshot.rs (guard),
+  userspace-dp/src/server/tests.rs (4 new tests:
+  `apply_snapshot_rejects_generation_rollback_5169` [RED-on-revert],
+  `apply_snapshot_rejects_generation_reuse_5169`,
+  `apply_snapshot_monotonic_config_advance_applies_5169`,
+  `apply_snapshot_fib_only_advance_admitted_5169`),
+  docs/flow-cache-simplification.md
+- **Validation**: `cargo build` clean; full `cargo test --release` green; 4 new
+  tests 5x flake-free; RED-on-revert confirmed (disabling the gate FAILs both
+  refusal tests, positive tests still pass).
+
 ## 2026-07-11 — #5363 dataplane/verify: stale-pin remediation for live-pin ABI mismatch
 - **Timestamp**: 2026-07-11 (fix/5363-stalepin-remediation)
 - **Action**: `validateUserspaceShimLivePins` (pkg/dataplane/loader_userspace_shim.go)

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -552,6 +552,60 @@ the last accepted value), and `bump_fib_generation_persists_bumped_generation`
 (M2 — fail-on-revert; the persisted state a restart boots from carries the
 bumped generation).
 
+## apply_snapshot generation monotonicity (#5169)
+
+The #3767 H5 gate covered only the lightweight `bump_fib` verb. The FULL
+`apply_snapshot` handler (`server/handlers/snapshot.rs::apply`) published the
+incoming `(generation, fib_generation)` pair VERBATIM into
+`status.last_snapshot_generation` / `status.last_fib_generation` (and, on the
+armed legs, into `ValidationState` via `refresh_runtime_snapshot` / reconcile)
+with NO monotonicity gate. Because flow-cache validation is equality based on
+the WHOLE pair (`entry.stamp.config_generation != lookup.config_generation ||
+entry.stamp.fib_generation != lookup.fib_generation` in `flow_cache.rs`), a
+REUSED / ROLLED-BACK pair equal to a prior published pair makes the cache
+entries that a later generation logically invalidated MATCH validation again —
+reviving a lazily-unevicted cached ALLOW after the config/route that authorized
+it was withdrawn. That is a fail-OPEN, the exact defect #3767 H5 closed for
+`bump_fib`, left open on the full path.
+
+- **Pair-monotonicity gate (#5169).** The handler now refuses a full apply
+  whose `(generation, fib_generation)` pair is not a LEXICOGRAPHIC strict
+  increase over the currently-published `(last_snapshot_generation,
+  last_fib_generation)` pair: admit iff `generation > cur_generation` OR
+  (`generation == cur_generation` AND `fib_generation > cur_fib_generation`).
+  The Go control plane assigns `generation` from a monotone commit counter
+  (`Manager.bumpGeneration`, only ever ++, never resets) and `fib_generation`
+  from the monotone shim FIB counter (`readFIBGeneration`), so this admits both
+  legitimate transitions — a full apply advancing config (any fib; a strictly
+  greater config value was, under this same guard, never published, so no
+  stamped entry can equality-match it) and a route-only overlay advancing fib
+  with config reused — and refuses only a pair that equals or precedes the
+  published pair (the reuse/rollback fail-open). The check compares against the
+  last PUBLISHED pair in `guard.status` (not `ValidationState`: `config_
+  generation` has no coordinator accessor and a disarmed apply advances
+  `guard.status` but not `ValidationState`; `guard.status` is the authoritative
+  published pair the armed flow-cache's `ValidationState` is derived from, so
+  guard and cache agree). It is gated on a prior published snapshot
+  (`guard.snapshot.is_some()`) so the first apply — no baseline, no cache
+  entries to revive — always applies, matching `bump_fib` admitting the first
+  bump against generation 0. Refusal is fail-CLOSED before any guard mutation,
+  integrity preflight, or side effect: `ok = false`, nothing advances, nothing
+  persists — the live prior forwarding / generation / flow-cache stay untouched
+  (mirroring the #3766 / #3789 capture-restore legs). The coordinator's
+  `refresh_runtime_snapshot` / reconcile still assign `self.validation` directly
+  and remain intentionally ungated at the coordinator layer; the monotonicity
+  invariant for the full path is now enforced ONE layer up, at the handler.
+
+Validation (`server/tests.rs`): `apply_snapshot_rejects_generation_rollback_5169`
+(fail-on-revert; published pair, stored snapshot, and persisted state all stay
+at the last accepted generation — asserts the flow-cache revival is prevented
+because the published pair never rolls back to the stale entry's stamp),
+`apply_snapshot_rejects_generation_reuse_5169` (an exact-pair replay is
+refused), `apply_snapshot_monotonic_config_advance_applies_5169` (a config
+advance still applies), and `apply_snapshot_fib_only_advance_admitted_5169` (a
+fib-only advance with config reused is admitted, guarding against an over-strict
+gate that would break route-only overlays).
+
 ## Recommended Next Step
 
 Implement Phase 1 next:

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -569,42 +569,58 @@ it was withdrawn. That is a fail-OPEN, the exact defect #3767 H5 closed for
 `bump_fib`, left open on the full path.
 
 - **Pair-monotonicity gate (#5169).** The handler now refuses a full apply
-  whose `(generation, fib_generation)` pair is not a LEXICOGRAPHIC strict
-  increase over the currently-published `(last_snapshot_generation,
+  whose `(generation, fib_generation)` pair is STRICTLY LESS than (rolls back
+  below) the currently-published `(last_snapshot_generation,
   last_fib_generation)` pair: admit iff `generation > cur_generation` OR
-  (`generation == cur_generation` AND `fib_generation > cur_fib_generation`).
+  (`generation == cur_generation` AND `fib_generation >= cur_fib_generation`).
   The Go control plane assigns `generation` from a monotone commit counter
   (`Manager.bumpGeneration`, only ever ++, never resets) and `fib_generation`
-  from the monotone shim FIB counter (`readFIBGeneration`), so this admits both
-  legitimate transitions — a full apply advancing config (any fib; a strictly
+  from the monotone shim FIB counter (`readFIBGeneration`), so this admits every
+  legitimate transition — a full apply advancing config (any fib; a strictly
   greater config value was, under this same guard, never published, so no
-  stamped entry can equality-match it) and a route-only overlay advancing fib
-  with config reused — and refuses only a pair that equals or precedes the
-  published pair (the reuse/rollback fail-open). The check compares against the
-  last PUBLISHED pair in `guard.status` (not `ValidationState`: `config_
-  generation` has no coordinator accessor and a disarmed apply advances
-  `guard.status` but not `ValidationState`; `guard.status` is the authoritative
-  published pair the armed flow-cache's `ValidationState` is derived from, so
-  guard and cache agree). It is gated on a prior published snapshot
-  (`guard.snapshot.is_some()`) so the first apply — no baseline, no cache
-  entries to revive — always applies, matching `bump_fib` admitting the first
-  bump against generation 0. Refusal is fail-CLOSED before any guard mutation,
-  integrity preflight, or side effect: `ok = false`, nothing advances, nothing
-  persists — the live prior forwarding / generation / flow-cache stay untouched
-  (mirroring the #3766 / #3789 capture-restore legs). The coordinator's
-  `refresh_runtime_snapshot` / reconcile still assign `self.validation` directly
-  and remain intentionally ungated at the coordinator layer; the monotonicity
-  invariant for the full path is now enforced ONE layer up, at the handler.
+  stamped entry can equality-match it), a route-only overlay advancing fib with
+  config reused, AND an EXACT-EQUAL re-apply — and refuses only a SUPERSEDED
+  (strictly-less) pair: a config rollback (`generation < cur`) or a fib rollback
+  under a reused config (`generation == cur && fib_generation < cur_fib`). Both
+  are the revival fail-open. Exact-equal is admitted because it revives nothing
+  (an equal pair equality-matches only the CURRENT published pair, whose cache
+  entries are already valid), and refusing it would break the #4036
+  "timeout-but-landed" IDEMPOTENT RETRY: the partial-republish Go paths
+  (`Compile`, `PublishRouteOverlaySnapshot`, `retryDeferredWorkerArmLocked`)
+  commit `m.generation` only on Go-observed success and do not consult
+  `lastStatus.LastSnapshotGeneration`, so a timed-out-but-landed apply of gen G
+  leaves `m.generation` at G-1 and the retry re-sends the IDENTICAL (G, fib)
+  pair, which must be ACKed ok rather than fail-closed into a non-converging
+  loop. This is the exact `<`-not-`<=` semantics `bump_fib` already uses
+  (`Coordinator::bump_fib_generation` refuses a strictly-less fib, admits an
+  equal one). The check compares against the last PUBLISHED pair in
+  `guard.status` (not `ValidationState`: `config_generation` has no coordinator
+  accessor and a disarmed apply advances `guard.status` but not
+  `ValidationState`; `guard.status` is the authoritative published pair the
+  armed flow-cache's `ValidationState` is derived from, so guard and cache
+  agree). It is gated on a prior published snapshot (`guard.snapshot.is_some()`)
+  so the first apply — no baseline, no cache entries to revive — always applies,
+  matching `bump_fib` admitting the first bump against generation 0. Refusal is
+  fail-CLOSED before any guard mutation, integrity preflight, or side effect:
+  `ok = false`, nothing advances, nothing persists — the live prior forwarding /
+  generation / flow-cache stay untouched (mirroring the #3766 / #3789
+  capture-restore legs). The coordinator's `refresh_runtime_snapshot` /
+  reconcile still assign `self.validation` directly and remain intentionally
+  ungated at the coordinator layer; the monotonicity invariant for the full path
+  is now enforced ONE layer up, at the handler.
 
 Validation (`server/tests.rs`): `apply_snapshot_rejects_generation_rollback_5169`
-(fail-on-revert; published pair, stored snapshot, and persisted state all stay
-at the last accepted generation — asserts the flow-cache revival is prevented
-because the published pair never rolls back to the stale entry's stamp),
-`apply_snapshot_rejects_generation_reuse_5169` (an exact-pair replay is
-refused), `apply_snapshot_monotonic_config_advance_applies_5169` (a config
-advance still applies), and `apply_snapshot_fib_only_advance_admitted_5169` (a
-fib-only advance with config reused is admitted, guarding against an over-strict
-gate that would break route-only overlays).
+(fail-on-revert; a strictly-less CONFIG rollback is refused — published pair,
+stored snapshot, and persisted state all stay at the last accepted generation;
+asserts the flow-cache revival is prevented because the published pair never
+rolls back to the stale entry's stamp), `apply_snapshot_rejects_fib_rollback_5169`
+(fail-on-revert; the second rollback axis — a strictly-less FIB under a reused
+config is refused), `apply_snapshot_admits_generation_reuse_5169` (an exact-equal
+re-apply is ADMITTED — the #4036 idempotent-retry path),
+`apply_snapshot_monotonic_config_advance_applies_5169` (a config advance still
+applies), and `apply_snapshot_fib_only_advance_admitted_5169` (a fib-only advance
+with config reused is admitted, guarding against an over-strict gate that would
+break route-only overlays).
 
 ## Recommended Next Step
 

--- a/userspace-dp/src/server/handlers/snapshot.rs
+++ b/userspace-dp/src/server/handlers/snapshot.rs
@@ -45,14 +45,30 @@ pub(super) fn apply(
     // fib_generation from the monotone shim FIB counter (`readFIBGeneration`,
     // only ever ++). A full apply strictly advances config (fib carried
     // forward), a route-only overlay advances fib with config reused (that path
-    // is `bump_fib`). So the legitimate transition for the PUBLISHED pair is a
-    // LEXICOGRAPHIC strict increase: (generation, fib_generation) must be
-    // strictly greater than the currently-published (last_snapshot_generation,
-    // last_fib_generation). That ADMITS a config advance (any fib — a strictly
-    // greater config was, by the global monotonicity this guard enforces, never
-    // published, so no cache entry can equality-match it) AND a same-config fib
-    // advance (the route-only overlay); it REFUSES only a pair that equals or
-    // precedes the published pair — the reuse/rollback fail-open.
+    // is `bump_fib`). So the guard REFUSES only a STRICTLY-LESS (superseded)
+    // pair — one whose config rolls back (`generation < cur`) OR whose fib rolls
+    // back under a reused config (`generation == cur && fib_generation <
+    // cur_fib`) — and ADMITS everything else:
+    //   * a config advance (any fib — a strictly greater config was, by the
+    //     global monotonicity this guard enforces, never published, so no cache
+    //     entry can equality-match it),
+    //   * a same-config fib advance (the route-only overlay), and
+    //   * an EXACT-EQUAL re-apply (`generation == cur && fib_generation ==
+    //     cur_fib`).
+    // Exact-equal is admitted because it revives NOTHING: an equal pair
+    // equality-matches only the CURRENT published pair, whose cache entries are
+    // already valid, so re-publishing it changes no validity. The revival
+    // fail-open requires re-publishing a SUPERSEDED (strictly-less) pair, which
+    // the `<` refusal still catches. Admitting exact-equal also restores the
+    // #4036 "timeout-but-landed" IDEMPOTENT RETRY: the partial-republish Go
+    // paths (Compile, PublishRouteOverlaySnapshot, retryDeferredWorkerArmLocked)
+    // commit `m.generation` only on Go-observed success and do NOT consult
+    // `lastStatus.LastSnapshotGeneration`, so a timeout-but-landed apply of gen
+    // G leaves `m.generation` at G-1 and the retry re-sends the IDENTICAL
+    // (G, fib) pair — which must be ACKed ok, not fail-closed into a
+    // non-converging loop. This mirrors `bump_fib`, which refuses a
+    // STRICTLY-less fib and admits an equal one
+    // (`Coordinator::bump_fib_generation`, `<` not `<=`).
     //
     // Compare against the last PUBLISHED pair in `guard.status`, not the afxdp
     // ValidationState: config_generation has no coordinator accessor (only fib
@@ -69,18 +85,18 @@ pub(super) fn apply(
         let cur_fib_generation = guard.status.last_fib_generation;
         let monotonic = snapshot.generation > cur_generation
             || (snapshot.generation == cur_generation
-                && snapshot.fib_generation > cur_fib_generation);
+                && snapshot.fib_generation >= cur_fib_generation);
         if !monotonic {
             response.ok = false;
             response.error = format!(
-                "snapshot generation rollback/reuse rejected: ({}, {}) <= current ({}, {})",
+                "snapshot generation rollback rejected: ({}, {}) < current ({}, {})",
                 snapshot.generation,
                 snapshot.fib_generation,
                 cur_generation,
                 cur_fib_generation
             );
             eprintln!(
-                "CTRL_REQ: apply_snapshot rejected (generation rollback/reuse): ({}, {}) <= current ({}, {})",
+                "CTRL_REQ: apply_snapshot rejected (generation rollback): ({}, {}) < current ({}, {})",
                 snapshot.generation,
                 snapshot.fib_generation,
                 cur_generation,

--- a/userspace-dp/src/server/handlers/snapshot.rs
+++ b/userspace-dp/src/server/handlers/snapshot.rs
@@ -30,6 +30,65 @@ pub(super) fn apply(
         );
         return;
     }
+    // #5169: monotonicity gate for the FULL apply_snapshot path, mirroring the
+    // #3767 H5 rollback guard on `bump_fib` below. Flow-cache validation is
+    // EQUALITY based on the (config_generation, fib_generation) PAIR — an entry
+    // is a HIT only when its stamped pair equals the currently-published pair
+    // (afxdp/flow_cache.rs `lookup`; see `stale_config_generation_causes_miss`).
+    // So re-publishing a pair that a later apply already superseded makes the
+    // cache entries that later generation logically invalidated MATCH again,
+    // reviving a stale permit decision (a lazily-unevicted cached ALLOW) after
+    // the config/route that authorized it was withdrawn — a fail-OPEN.
+    //
+    // The Go control plane assigns config_generation from a monotone commit
+    // counter (`Manager.bumpGeneration`, only ever ++, never resets) and
+    // fib_generation from the monotone shim FIB counter (`readFIBGeneration`,
+    // only ever ++). A full apply strictly advances config (fib carried
+    // forward), a route-only overlay advances fib with config reused (that path
+    // is `bump_fib`). So the legitimate transition for the PUBLISHED pair is a
+    // LEXICOGRAPHIC strict increase: (generation, fib_generation) must be
+    // strictly greater than the currently-published (last_snapshot_generation,
+    // last_fib_generation). That ADMITS a config advance (any fib — a strictly
+    // greater config was, by the global monotonicity this guard enforces, never
+    // published, so no cache entry can equality-match it) AND a same-config fib
+    // advance (the route-only overlay); it REFUSES only a pair that equals or
+    // precedes the published pair — the reuse/rollback fail-open.
+    //
+    // Compare against the last PUBLISHED pair in `guard.status`, not the afxdp
+    // ValidationState: config_generation has no coordinator accessor (only fib
+    // does), and a disarmed apply advances `guard.status` but NOT
+    // ValidationState — `guard.status` is the authoritative published pair the
+    // armed flow-cache's ValidationState is derived from, so guard and cache
+    // agree. Gate on a prior published snapshot: the first apply
+    // (`guard.snapshot` == None) has no baseline and no cache entries to revive,
+    // so it always applies (matching `bump_fib` admitting the first bump against
+    // generation 0). Refuse fail-CLOSED before ANY guard mutation / preflight /
+    // side effect, mirroring the #3766/#3789 capture-restore legs below.
+    if guard.snapshot.is_some() {
+        let cur_generation = guard.status.last_snapshot_generation;
+        let cur_fib_generation = guard.status.last_fib_generation;
+        let monotonic = snapshot.generation > cur_generation
+            || (snapshot.generation == cur_generation
+                && snapshot.fib_generation > cur_fib_generation);
+        if !monotonic {
+            response.ok = false;
+            response.error = format!(
+                "snapshot generation rollback/reuse rejected: ({}, {}) <= current ({}, {})",
+                snapshot.generation,
+                snapshot.fib_generation,
+                cur_generation,
+                cur_fib_generation
+            );
+            eprintln!(
+                "CTRL_REQ: apply_snapshot rejected (generation rollback/reuse): ({}, {}) <= current ({}, {})",
+                snapshot.generation,
+                snapshot.fib_generation,
+                cur_generation,
+                cur_fib_generation
+            );
+            return;
+        }
+    }
     // #1606 (AGY r2 finding 4.1): preflight policy-state validation
     // BEFORE any guard.status mutation. If the snapshot has
     // duplicate / zero / unknown book IDs, reject WITHOUT touching

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1174,7 +1174,7 @@ fn apply_snapshot_rejects_generation_rollback_5169() {
     assert!(
         response
             .error
-            .contains("snapshot generation rollback/reuse rejected"),
+            .contains("snapshot generation rollback rejected"),
         "unexpected error: {}",
         response.error
     );
@@ -1235,12 +1235,16 @@ fn apply_snapshot_rejects_generation_rollback_5169() {
     let _ = std::fs::remove_file(&state_file);
 }
 
-/// #5169: an EXACT-REUSE apply_snapshot (the new (config, fib) pair equals the
-/// last published pair — a duplicate/replayed control message) must be refused.
-/// This is the pure fail-open: an equal pair equality-matches every prior
-/// cache stamp at that generation, reviving all of them.
+/// #5169 (review fold): an EXACT-EQUAL apply_snapshot (the new (config, fib)
+/// pair equals the last published pair) must be ADMITTED, not refused. An equal
+/// pair equality-matches only the CURRENT published pair, whose cache entries
+/// are already valid, so re-publishing it revives NOTHING — refusing it buys no
+/// security and breaks the #4036 "timeout-but-landed" idempotent retry (the
+/// partial-republish Go paths recompute the SAME generation after a timed-out
+/// apply that actually landed and must be ACKed ok, not fail-closed into a
+/// non-converging loop). This mirrors `bump_fib`, which admits an equal fib.
 #[test]
-fn apply_snapshot_rejects_generation_reuse_5169() {
+fn apply_snapshot_admits_generation_reuse_5169() {
     use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
     let state = new_state(ProcessStatus::default());
 
@@ -1256,7 +1260,7 @@ fn apply_snapshot_rejects_generation_reuse_5169() {
         });
         assert!(run_request(state.clone(), request).ok);
     }
-    // Re-apply the identical pair (6, 5): must be refused.
+    // Re-apply the identical pair (6, 5) — the idempotent-retry path: admitted.
     let mut request = req("apply_snapshot");
     request.snapshot = Some(ConfigSnapshot {
         version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
@@ -1266,17 +1270,82 @@ fn apply_snapshot_rejects_generation_reuse_5169() {
         ..ConfigSnapshot::default()
     });
     let response = run_request(state.clone(), request);
-    assert!(!response.ok, "reused-pair apply_snapshot must be rejected");
     assert!(
-        response
-            .error
-            .contains("snapshot generation rollback/reuse rejected"),
-        "unexpected error: {}",
+        response.ok,
+        "an exact-equal re-apply (idempotent retry) must be admitted: {}",
         response.error
     );
     let guard = state.lock().expect("state");
     assert_eq!(guard.status.last_snapshot_generation, 6);
     assert_eq!(guard.status.last_fib_generation, 5);
+    assert_eq!(guard.snapshot.as_ref().map(|s| s.generation), Some(6));
+}
+
+/// #5169 (review fold): a FIB ROLLBACK under a reused config (config == cur,
+/// fib < cur_fib) must be REFUSED. This is the second rollback axis — the fib
+/// half of the pair rolling back re-publishes a superseded pair whose stale
+/// flow-cache entries would be revived, exactly the fail-open on the fib
+/// dimension (the full-apply analogue of the #3767 H5 bump_fib rollback).
+///
+/// RED-on-revert: neutralize the guard and the (6, 6) rollback publishes over
+/// the (6, 7) baseline — the assertions below flip.
+#[test]
+fn apply_snapshot_rejects_fib_rollback_5169() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+
+    // Baseline (config=6, fib=5).
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 6,
+            fib_generation: 5,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    // Fib advances 5 -> 7 (config reused at 6): admitted.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 6,
+            fib_generation: 7,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    // Fib rolls back 7 -> 6 under the reused config 6: must be refused.
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 6,
+        fib_generation: 6,
+        generated_at: chrono::Utc::now(),
+        ..ConfigSnapshot::default()
+    });
+    let response = run_request(state.clone(), request);
+    assert!(!response.ok, "a fib rollback under a reused config must be rejected");
+    assert!(
+        response
+            .error
+            .contains("snapshot generation rollback rejected"),
+        "unexpected error: {}",
+        response.error
+    );
+    let guard = state.lock().expect("state");
+    assert_eq!(
+        guard.status.last_snapshot_generation, 6,
+        "rejected fib rollback keeps the published config generation"
+    );
+    assert_eq!(
+        guard.status.last_fib_generation, 7,
+        "rejected fib rollback must not lower last_fib_generation"
+    );
+    assert_eq!(guard.snapshot.as_ref().map(|s| s.fib_generation), Some(7));
 }
 
 /// #5169: a strictly-monotonic apply_snapshot whose CONFIG generation advances

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1114,6 +1114,262 @@ fn apply_snapshot_same_plan_needs_reconcile_build_failure_rejects_and_keeps_prio
     );
 }
 
+// --- apply_snapshot generation monotonicity (#5169) ---------------------
+
+/// #5169 fail-CLOSED: a ROLLED-BACK apply_snapshot generation must be refused.
+/// The FULL apply path published (config_generation, fib_generation) VERBATIM
+/// with no monotonicity gate, so re-publishing a pair a later apply already
+/// superseded revived flow-cache entries that later generation invalidated —
+/// a stale cached ALLOW (fail-open), because flow-cache validation is EQUALITY
+/// based on the pair. This mirrors the #3767 H5 rollback guard on bump_fib.
+///
+/// RED-on-revert: without the guard the rollback publishes (5, 5) — the stored
+/// snapshot, last_snapshot_generation, and persisted state all roll back to the
+/// prior generation, so an entry stamped by that generation equality-matches
+/// the published pair again and the cached ALLOW is revived. Every assertion
+/// below flips.
+#[test]
+fn apply_snapshot_rejects_generation_rollback_5169() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+    let state_file = unique_state_file("apply-rollback-5169");
+
+    // Apply gen (config=5, fib=5): first apply, publishes the baseline pair.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 5,
+            fib_generation: 5,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    // Advance to gen (config=6, fib=5): strictly monotonic, applies — this is
+    // the apply that logically invalidates any (5, 5)-stamped flow-cache entry.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 6,
+            fib_generation: 5,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    // Rollback to gen (config=5, fib=5) — a reused/rolled-back pair equal to a
+    // prior published pair. Must be refused fail-closed.
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 5,
+        fib_generation: 5,
+        generated_at: chrono::Utc::now(),
+        ..ConfigSnapshot::default()
+    });
+    let response = run_request_on_file(state.clone(), request, &state_file);
+    assert!(!response.ok, "rolled-back apply_snapshot must be rejected");
+    assert!(
+        response
+            .error
+            .contains("snapshot generation rollback/reuse rejected"),
+        "unexpected error: {}",
+        response.error
+    );
+
+    let guard = state.lock().expect("state");
+    // The published pair must NOT roll back.
+    assert_eq!(
+        guard.status.last_snapshot_generation, 6,
+        "rejected rollback must not lower last_snapshot_generation"
+    );
+    assert_eq!(
+        guard.status.last_fib_generation, 5,
+        "rejected rollback must not lower last_fib_generation"
+    );
+    // The stored snapshot (boot baseline) must NOT roll back.
+    assert_eq!(
+        guard.snapshot.as_ref().map(|s| s.generation),
+        Some(6),
+        "rejected rollback must not overwrite the stored snapshot"
+    );
+
+    // Assert the ACTUAL defect via the flow-cache equality contract: an entry
+    // stamped by the prior generation is a HIT only when the published pair
+    // equals its stamp (afxdp/flow_cache.rs `lookup`; see
+    // `stale_config_generation_causes_miss`). A lazily-unevicted cached ALLOW
+    // stamped (5, 5) is revived iff the published pair rolls back to (5, 5).
+    // The guard keeps the published pair at the post-invalidation (6, 5), so
+    // the stale (5, 5)-stamped entry can NEVER equality-match — it stays
+    // evicted and the cached ALLOW is not revived (no fail-open).
+    let stale_entry_stamp = (5u64, 5u32);
+    let published_pair = (
+        guard.status.last_snapshot_generation,
+        guard.status.last_fib_generation,
+    );
+    assert_ne!(
+        published_pair, stale_entry_stamp,
+        "published pair must NOT roll back to the stale entry's stamp — else the \
+         flow-cache equality check revives the cached ALLOW (fail-open)"
+    );
+    drop(guard);
+
+    // persist_state must NOT have been set by the rejected rollback: the
+    // on-disk state a restart boots from stays at the last accepted (6, 5),
+    // not the rolled-back (5, 5).
+    let bytes = std::fs::read(&state_file).expect("read persisted state file");
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("parse persisted state file");
+    assert_eq!(
+        persisted["snapshot"]["generation"].as_u64(),
+        Some(6),
+        "rejected rollback must not persist the rolled-back generation"
+    );
+    assert_eq!(
+        persisted["status"]["last_snapshot_generation"].as_u64(),
+        Some(6),
+        "rejected rollback must not persist a rolled-back last_snapshot_generation"
+    );
+    let _ = std::fs::remove_file(&state_file);
+}
+
+/// #5169: an EXACT-REUSE apply_snapshot (the new (config, fib) pair equals the
+/// last published pair — a duplicate/replayed control message) must be refused.
+/// This is the pure fail-open: an equal pair equality-matches every prior
+/// cache stamp at that generation, reviving all of them.
+#[test]
+fn apply_snapshot_rejects_generation_reuse_5169() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+
+    // Apply gen (config=6, fib=5).
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 6,
+            fib_generation: 5,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    // Re-apply the identical pair (6, 5): must be refused.
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 6,
+        fib_generation: 5,
+        generated_at: chrono::Utc::now(),
+        ..ConfigSnapshot::default()
+    });
+    let response = run_request(state.clone(), request);
+    assert!(!response.ok, "reused-pair apply_snapshot must be rejected");
+    assert!(
+        response
+            .error
+            .contains("snapshot generation rollback/reuse rejected"),
+        "unexpected error: {}",
+        response.error
+    );
+    let guard = state.lock().expect("state");
+    assert_eq!(guard.status.last_snapshot_generation, 6);
+    assert_eq!(guard.status.last_fib_generation, 5);
+}
+
+/// #5169: a strictly-monotonic apply_snapshot whose CONFIG generation advances
+/// (the normal full-apply path) must apply exactly as before — the guard must
+/// not regress legitimate applies.
+#[test]
+fn apply_snapshot_monotonic_config_advance_applies_5169() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+
+    // Baseline (config=5, fib=5).
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 5,
+            fib_generation: 5,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    // Config advances 5 -> 6 (fib carried forward at 5): admitted.
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 6,
+        fib_generation: 5,
+        generated_at: chrono::Utc::now(),
+        ..ConfigSnapshot::default()
+    });
+    let response = run_request(state.clone(), request);
+    assert!(
+        response.ok,
+        "strictly-monotonic config advance must apply: {}",
+        response.error
+    );
+    let guard = state.lock().expect("state");
+    assert_eq!(guard.status.last_snapshot_generation, 6);
+    assert_eq!(guard.status.last_fib_generation, 5);
+    assert_eq!(guard.snapshot.as_ref().map(|s| s.generation), Some(6));
+}
+
+/// #5169: a FIB-ONLY advance via apply_snapshot (config REUSED, fib
+/// incremented) is LEGITIMATE — the route-only overlay case that `bump_fib`
+/// handles — and must be ADMITTED, not falsely refused by an over-strict
+/// guard. The pair-monotonicity relation is lexicographic strict-greater, so
+/// (config==cur && fib>cur.fib) applies. Any advance of either generation
+/// changes the flow-cache equality key and correctly invalidates the cache.
+#[test]
+fn apply_snapshot_fib_only_advance_admitted_5169() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+
+    // Baseline (config=6, fib=5).
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 6,
+            fib_generation: 5,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    // Config REUSED at 6, fib advances 5 -> 6: admitted (route-only overlay).
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 6,
+        fib_generation: 6,
+        generated_at: chrono::Utc::now(),
+        ..ConfigSnapshot::default()
+    });
+    let response = run_request(state.clone(), request);
+    assert!(
+        response.ok,
+        "a fib-only advance (config reused, fib incremented) must be admitted: {}",
+        response.error
+    );
+    let guard = state.lock().expect("state");
+    assert_eq!(
+        guard.status.last_snapshot_generation, 6,
+        "fib-only advance keeps the reused config generation"
+    );
+    assert_eq!(
+        guard.status.last_fib_generation, 6,
+        "fib-only advance publishes the incremented fib generation"
+    );
+    assert_eq!(guard.snapshot.as_ref().map(|s| s.fib_generation), Some(6));
+}
+
 // --- set_binding_state / set_queue_state error arms ---------------------
 
 #[test]


### PR DESCRIPTION
## Summary

Fail-closed **security fix** — closes a flow-cache permit **fail-open** on generation reuse/rollback in the full `apply_snapshot` path.

The FULL `apply_snapshot` handler (`userspace-dp/src/server/handlers/snapshot.rs`) published the incoming `(generation, fib_generation)` pair **verbatim** into `status.last_snapshot_generation` / `status.last_fib_generation` (and, on the armed legs, into `ValidationState`) with **no** monotonicity gate. Flow-cache validation is **equality** based on the whole pair (`flow_cache.rs` lookup: `entry.stamp.config_generation != lookup.config_generation || entry.stamp.fib_generation != lookup.fib_generation` → invalidate), so a **reused / rolled-back** pair equal to a prior published pair equality-matches the cache stamps a later generation already invalidated — reviving a lazily-unevicted cached **ALLOW** after the config/route that authorized it was withdrawn. That is a **fail-open** — the exact defect the [#3767 H5 guard](../blob/master/userspace-dp/src/server/handlers/snapshot.rs) closed for the lightweight `bump_fib` verb, left open on the full apply path.

## Fix

Mirror the #3767 H5 rollback guard on the full path. Refuse **fail-closed** any apply whose `(generation, fib_generation)` pair is not a **lexicographic strict increase** over the currently-published pair, before any guard mutation / integrity preflight / side effect (mirroring the #3766 / #3789 capture-restore legs):

```
admit iff  generation > cur_generation
        OR (generation == cur_generation && fib_generation > cur_fib_generation)
```

### Pair-monotonicity relation and why it is correct

The Go control plane assigns `generation` from a monotone commit counter (`Manager.bumpGeneration`, only ever `++`, never resets) and `fib_generation` from the monotone shim FIB counter (`readFIBGeneration`). A full apply strictly advances config (fib carried forward); a route-only overlay advances fib with config reused (that path is `bump_fib`). Lexicographic strict-greater on the pair admits both legitimate transitions and refuses only reuse/rollback:

- **Config advance (any fib)** applies: a strictly greater config value was — under this guard's own invariant — never published, so no stamped cache entry can equality-match it; no revival regardless of fib.
- **Fib-only advance (config reused, fib incremented)** applies: the route-only overlay case. Any advance of *either* generation changes the flow-cache equality key and correctly invalidates the cache. **Confirmed admitted** by `apply_snapshot_fib_only_advance_admitted_5169` (config reused at 6, fib 5→6, `ok=true`).
- **Equal-or-preceding pair** (duplicate / replayed / rolled-back message) is refused — the fail-open case.

### Which reference the guard compares against (task item #4)

Compares against the last **published** pair in `guard.status`, **not** the afxdp `ValidationState`: `config_generation` has **no** coordinator accessor (only `fib_generation()` exists), and a **disarmed** apply advances `guard.status` but **not** `ValidationState` (`helpers.rs::reconcile_status_bindings` short-circuits when forwarding is not armed). `guard.status` is the authoritative published pair the armed flow-cache's `ValidationState` is derived from at apply time, so **guard and cache agree**. Gated on `guard.snapshot.is_some()` so the first apply — no baseline, no cache entries to revive — always applies (matching `bump_fib` admitting the first bump against generation 0).

## Tests (`userspace-dp/src/server/tests.rs`)

- `apply_snapshot_rejects_generation_rollback_5169` — **RED-on-revert**: a rolled-back apply is refused; published pair, stored snapshot, and persisted state all stay at the last accepted generation; asserts the flow-cache revival is prevented because the published pair never rolls back to the stale entry's stamp.
- `apply_snapshot_rejects_generation_reuse_5169` — an exact-pair replay is refused.
- `apply_snapshot_monotonic_config_advance_applies_5169` — a config advance still applies (no regression).
- `apply_snapshot_fib_only_advance_admitted_5169` — a fib-only advance with config reused is admitted (guards against an over-strict gate).

Documented in `docs/flow-cache-simplification.md` (new #5169 section after the #3767 FIB-generation bump gating section).

## Validation

Non-forwarding config-application path, gated on the FULL cargo suite (dataplane-merge gate):

- `cargo build` — clean.
- `cargo test --release` — **green**, `CARGO_EXIT=0` (main lib 3829 passed, 0 failed, 2 ignored; all other binaries pass).
- New tests **5× flake-free** (`4 passed; 0 failed` every run).
- **RED-on-revert confirmed**: disabling the gate FAILs both refusal tests (`_rollback_5169`, `_reuse_5169`) while the two positive tests still pass.
- Loss-cluster iperf smoke **deferred** under the #1864 shim-ABI wall (this is a control-plane config-application path, not a forwarding change).

Closes #5169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
