### PR TITLE
dataplane/userspace: fail closed on unresolved positive+except accept term (#5225)

### DIFF
--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -611,8 +611,19 @@ never lock an operator out of a remote box it manages.
   EXCEPT scope is match-all (no predicate); a non-empty except is the nft
   negated set `saddr != { ... }`; and a leniently-loaded MIXED positive+except
   in one direction is positive-wins (the except side is dropped, never folded —
-  mirroring `resolvePrefixListAddrs`, hard-rejected at commit by #3359). A
-  malformed or wrong-family literal is also an operator-visible commit error
+  mirroring `resolvePrefixListAddrs`, hard-rejected at commit by #3359). An
+  UNRESOLVED positive prefix-list ref combined with an `except` ref (both refs
+  unresolved, no resolved positive scope — reachable only on the tolerant /
+  peer-sync path, rejected twice at strict commit) is lowered ACTION-AWARE and
+  fail-CLOSED (#5225): the empty positive is NOT the match-any universe (it is a
+  specific scope that did not resolve), so the #4338 "any except X" compose is
+  refused — an `accept`/PBR/modifier term matches NOTHING (never admit an
+  unresolvable set; pre-#5225 it composed to match-ALL = admit every packet,
+  fail-OPEN), while a `discard`/`reject` term keeps match-ALL so the deny still
+  drops broadly (a deny that matched nothing would fall through to a later
+  permit — the #5097 concern). Because the lo0 mirror threads `term.Action`
+  through the shared resolver, its predicate matches the userspace verdict for
+  this shape too. A malformed or wrong-family literal is also an operator-visible commit error
   (`validateFilterAddressLiteralsStrict`, lenient-downgraded on the peer-sync /
   load path — #1960 no-brick). Pinned by `TestNftRuleFromTermAddressSemantics3433`,
   `TestNftRuleFromTermWrongFamilyMatchesNothing`, and (config side)

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -1315,7 +1315,7 @@ func nftRulesFromTerm(term *config.FirewallFilterTerm, family string, prefixList
 	// the term matches NOTHING (Junos empty-positive set) — skip the whole rule so
 	// the kernel mirror neither over-matches (fail-open) nor emits unloadable nft.
 	srcAddrs, srcExcept, srcConstrained := dpuserspace.ResolveFilterPrefixListAddrs(
-		term.SourceAddresses, term.SourcePrefixLists, prefixLists, "", term.Name, "source")
+		term.SourceAddresses, term.SourcePrefixLists, prefixLists, "", term.Name, "source", term.Action)
 	srcPred, srcMatchesNothing := nftAddrPredicate("saddr", family, srcAddrs, srcExcept, srcConstrained)
 	if srcMatchesNothing {
 		return nil
@@ -1325,7 +1325,7 @@ func nftRulesFromTerm(term *config.FirewallFilterTerm, family string, prefixList
 	}
 
 	dstAddrs, dstExcept, dstConstrained := dpuserspace.ResolveFilterPrefixListAddrs(
-		term.DestAddresses, term.DestPrefixLists, prefixLists, "", term.Name, "destination")
+		term.DestAddresses, term.DestPrefixLists, prefixLists, "", term.Name, "destination", term.Action)
 	dstPred, dstMatchesNothing := nftAddrPredicate("daddr", family, dstAddrs, dstExcept, dstConstrained)
 	if dstMatchesNothing {
 		return nil

--- a/pkg/dataplane/userspace/filters.go
+++ b/pkg/dataplane/userspace/filters.go
@@ -110,9 +110,9 @@ func buildFilterTermSnapshots(filterName string, filter *config.FirewallFilter, 
 		// dataplane with NO address constraint (fail-open for accept/PBR,
 		// fail-closed for discard/reject — either way wrong).
 		srcAddrs, srcExcept, srcConstrained := resolvePrefixListAddrs(
-			term.SourceAddresses, term.SourcePrefixLists, cfg, filterName, term.Name, "source")
+			term.SourceAddresses, term.SourcePrefixLists, cfg, filterName, term.Name, "source", term.Action)
 		dstAddrs, dstExcept, dstConstrained := resolvePrefixListAddrs(
-			term.DestAddresses, term.DestPrefixLists, cfg, filterName, term.Name, "destination")
+			term.DestAddresses, term.DestPrefixLists, cfg, filterName, term.Name, "destination", term.Action)
 		snap.SourceAddresses = srcAddrs
 		snap.DestAddresses = dstAddrs
 		snap.SourceExcept = srcExcept
@@ -374,17 +374,22 @@ func buildFilterTermSnapshots(filterName string, filter *config.FirewallFilter, 
 // because the reference still makes the direction `constrained`, the matcher
 // fails closed (positive) / match-all (except) per the empty-set semantics
 // above rather than collapsing to match-any.
+//
+// `action` is the term's terminating action ("accept"/"discard"/"reject"/"").
+// It only affects the #5225 action-aware fail-closed lowering of an UNRESOLVED
+// positive prefix-list ref combined with an `except` ref (see
+// ResolveFilterPrefixListAddrs); every other shape is action-independent.
 func resolvePrefixListAddrs(
 	literal []string,
 	refs []config.PrefixListRef,
 	cfg *config.Config,
-	filterName, termName, direction string,
+	filterName, termName, direction, action string,
 ) (addrs []string, except bool, constrained bool) {
 	var prefixLists map[string]*config.PrefixList
 	if cfg != nil {
 		prefixLists = cfg.PolicyOptions.PrefixLists
 	}
-	return ResolveFilterPrefixListAddrs(literal, refs, prefixLists, filterName, termName, direction)
+	return ResolveFilterPrefixListAddrs(literal, refs, prefixLists, filterName, termName, direction, action)
 }
 
 // filterAddrIsReal mirrors the Rust matcher's addr_is_real (userspace-dp
@@ -435,6 +440,21 @@ func portsHaveReal(ports []string) bool {
 	return false
 }
 
+// firewallFilterActionDenies reports whether a firewall-filter term's terminating
+// action DROPS the packet — Junos `discard` (silent drop) or `reject` (drop with
+// an ICMP/TCP-RST notification). It gates the #5225 action-aware fail-closed
+// lowering of an UNRESOLVED positive prefix-list ref combined with an `except`
+// ref (ResolveFilterPrefixListAddrs): a deny term fails closed by matching ALL
+// (drop broadly, so a later permit cannot leak the traffic the deny was written
+// to stop); every other action — `accept`, a routing-instance (PBR) redirect, or
+// a modifier-only fall-through (Action == "") — fails closed by matching NOTHING,
+// because an unresolvable positive scope must never be admitted, redirected, or
+// counted as a match. The action strings match FirewallFilterTerm.Action /
+// FirewallTermSnapshot.Action ("accept"/"discard"/"reject"/"").
+func firewallFilterActionDenies(action string) bool {
+	return action == "discard" || action == "reject"
+}
+
 // ResolveFilterPrefixListAddrs is the SHARED single source of truth for lowering
 // a firewall-filter term's source/destination address + prefix-list scope into
 // the (addrs, except, constrained) triple the matcher consumes. It is exported so
@@ -443,11 +463,16 @@ func portsHaveReal(ports []string) bool {
 // mixed term, and `any`-as-no-constraint — instead of a divergent raw string
 // concatenation (#3433). resolvePrefixListAddrs delegates here; see the doc on
 // resolvePrefixListAddrs for the full empty-set / except / mixed semantics.
+// `action` is the term's terminating action ("accept"/"discard"/"reject"/"").
+// It participates in exactly ONE decision: the #5225 action-aware fail-closed
+// lowering of an UNRESOLVED positive prefix-list ref combined with an `except`
+// ref (see the compose gate below). Every other shape is action-independent, so
+// callers that do not care (or lack an action) may pass "".
 func ResolveFilterPrefixListAddrs(
 	literal []string,
 	refs []config.PrefixListRef,
 	prefixLists map[string]*config.PrefixList,
-	filterName, termName, direction string,
+	filterName, termName, direction, action string,
 ) (addrs []string, except bool, constrained bool) {
 	// Drop the no-constraint placeholders ("any" / empty) from the literal list
 	// BEFORE deciding `constrained` so a bare `from source-address any` is
@@ -484,6 +509,14 @@ func ResolveFilterPrefixListAddrs(
 	var exceptPrefixes []string
 	hasExcept := false
 	hasPositiveRef := false
+	// hasUnresolvedPositiveRef records that a PLAIN (non-except) prefix-list ref
+	// failed to resolve (pl == nil) on the tolerant path. It is distinct from
+	// hasPositiveRef (a RESOLVED positive ref): an unresolved positive ref
+	// contributes no prefixes to `positive`, so the direction can LOOK match-any
+	// (empty positive) while the operator actually scoped it to a specific,
+	// now-unresolvable set. The #5225 compose gate uses this to refuse the
+	// "any except X" widening for that direction. (#5225)
+	hasUnresolvedPositiveRef := false
 
 	for _, ref := range refs {
 		pl := prefixLists[ref.Name]
@@ -505,14 +538,27 @@ func ResolveFilterPrefixListAddrs(
 			// matched no packet and traffic fell through to a later permit), a
 			// fail-OPEN for the deny it was written to enforce. Recording
 			// hasExcept keeps the empty except set matching broadly (fail
-			// CLOSED). A positive ref stays unrecorded: an unresolved positive
-			// scope correctly lowers to (nil, false, true) = match NOTHING, which
-			// is already fail-closed for positive membership.
+			// CLOSED). A positive ref contributes no prefixes: an unresolved
+			// positive scope with NO accompanying except correctly lowers to
+			// (nil, false, true) = match NOTHING, already fail-closed for positive
+			// membership.
+			//
+			// #5225: record an unresolved POSITIVE ref so the compose gate below
+			// can tell a genuine match-any positive (`0.0.0.0/0`, empty literal)
+			// apart from a positive set that is empty ONLY because a positive ref
+			// did not resolve. Without this the ref's absence from `positive` let
+			// addrsAllMatchAny return true and the `hasExcept` set (recorded above
+			// or by a sibling except ref) fired the "any except X" compose, which
+			// lowered the direction to match-ALL. For an `accept` term that is
+			// admit-ALL = fail-OPEN — the term admitted every packet instead of the
+			// intended (unresolvable, so empty) set.
 			slog.Warn("firewall filter prefix-list reference unresolved",
 				"filter", filterName, "term", termName, "direction", direction,
 				"prefix-list", ref.Name)
 			if ref.Except {
 				hasExcept = true
+			} else {
+				hasUnresolvedPositiveRef = true
 			}
 			continue
 		}
@@ -543,6 +589,26 @@ func ResolveFilterPrefixListAddrs(
 	// and only reaches here on the lenient path, where positive-wins keeps it
 	// fail-safe.
 	if hasExcept && !hasPositiveRef && addrsAllMatchAny(positive) {
+		// #5225: an UNRESOLVED positive prefix-list ref makes `positive` empty
+		// WITHOUT the operator having written the match-any universe — the empty
+		// set here is "a specific scope that did not resolve", NOT "any". The
+		// #4338 "any except X" compose (invert the empty positive to match-ALL)
+		// must NOT apply to it. Fail closed BY ACTION so the term never widens
+		// past the operator's (now unresolvable) intent:
+		//   - accept (and every non-deny terminating / fall-through / PBR action):
+		//     match NOTHING. Admitting, redirecting, or counting an unresolvable
+		//     positive set is fail-OPEN. Pre-#5225 this composed to match-ALL =
+		//     ADMIT every packet — the reported defect.
+		//   - discard/reject: match ALL (the sole-`except` complement, unchanged
+		//     from the #4338/#5097 path) so the deny still drops broadly; a deny
+		//     that matched nothing would fall through to a later permit term =
+		//     fail-OPEN for the deny it was written to enforce (the #5097 concern).
+		// Only the unresolved-positive-ref case is action-gated; a genuine
+		// match-any positive (no unresolved positive ref) keeps the #4338/#5097
+		// match-ALL compose verbatim for all actions.
+		if hasUnresolvedPositiveRef && !firewallFilterActionDenies(action) {
+			return nil, false, true
+		}
 		return exceptPrefixes, true, true
 	}
 

--- a/pkg/dataplane/userspace/filters_address_except_3359_test.go
+++ b/pkg/dataplane/userspace/filters_address_except_3359_test.go
@@ -31,7 +31,7 @@ func TestResolvePrefixListAddrsMixedPositiveExceptFailsSafe_3359(t *testing.T) {
 	addrs, except, constrained := resolvePrefixListAddrs(
 		[]string{"10.0.0.0/8"},
 		[]config.PrefixListRef{{Name: "trusted", Except: true}},
-		cfg, "f", "t", "source",
+		cfg, "f", "t", "source", "accept",
 	)
 
 	if except {
@@ -64,7 +64,7 @@ func TestResolvePrefixListAddrsCleanExceptUnchanged_3359(t *testing.T) {
 	addrs, except, constrained := resolvePrefixListAddrs(
 		nil,
 		[]config.PrefixListRef{{Name: "trusted", Except: true}},
-		cfg, "f", "t", "source",
+		cfg, "f", "t", "source", "accept",
 	)
 	if !except {
 		t.Fatalf("clean except case must resolve except=true, got false")

--- a/pkg/dataplane/userspace/filters_address_matchany_except_4338_test.go
+++ b/pkg/dataplane/userspace/filters_address_matchany_except_4338_test.go
@@ -28,7 +28,7 @@ func TestResolvePrefixListAddrsMatchAnyExceptComposes_4338(t *testing.T) {
 	addrs, except, constrained := resolvePrefixListAddrs(
 		[]string{"0.0.0.0/0"},
 		[]config.PrefixListRef{{Name: "mgmt", Except: true}},
-		cfg, "f", "t", "source",
+		cfg, "f", "t", "source", "accept",
 	)
 
 	if !except {
@@ -59,7 +59,7 @@ func TestResolvePrefixListAddrsMatchAnyExceptComposesV6_4338(t *testing.T) {
 	addrs, except, constrained := resolvePrefixListAddrs(
 		[]string{"::/0"},
 		[]config.PrefixListRef{{Name: "mgmt6", Except: true}},
-		cfg, "f6", "t", "source",
+		cfg, "f6", "t", "source", "accept",
 	)
 	if !except || !constrained {
 		t.Fatalf("::/0 + except must compose to except=true, constrained=true; got except=%v constrained=%v addrs=%v",
@@ -83,7 +83,7 @@ func TestResolvePrefixListAddrsSpecificPlusExceptStaysPositiveWins_4338(t *testi
 	addrs, except, _ := resolvePrefixListAddrs(
 		[]string{"0.0.0.0/0", "10.0.0.0/8"},
 		[]config.PrefixListRef{{Name: "mgmt", Except: true}},
-		cfg, "f", "t", "source",
+		cfg, "f", "t", "source", "accept",
 	)
 	if except {
 		t.Fatalf("match-any + SPECIFIC positive + except must NOT compose (positive-wins), got except=true addrs=%v", addrs)

--- a/pkg/dataplane/userspace/filters_mixed_unresolved_except_5225_test.go
+++ b/pkg/dataplane/userspace/filters_mixed_unresolved_except_5225_test.go
@@ -1,0 +1,183 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5225: a firewall-filter term that carries BOTH an UNRESOLVED positive
+// prefix-list ref AND an `except` ref (unresolved OR resolved-empty), with no
+// RESOLVED positive scope, must NOT compose to match-ALL on an `accept` term.
+//
+// The #4338 "any except X" compose (ResolveFilterPrefixListAddrs) fires on
+// `hasExcept && !hasPositiveRef && addrsAllMatchAny(positive)` and lowers the
+// direction to (exceptPrefixes, except=true, constrained=true) = match-ALL. That
+// gate is correct only when the positive side is GENUINELY the match-any
+// universe. An UNRESOLVED positive ref leaves `positive` empty WITHOUT the
+// operator having written `any` — addrsAllMatchAny then returns a FALSE positive,
+// the gate fires, and:
+//   - `accept` term  -> match-ALL = ADMIT every packet  = fail-OPEN (the bug),
+//   - `discard`/`reject` term -> match-ALL = DROP every packet = fail-CLOSED.
+//
+// hasPositiveRef is set only for RESOLVED positive refs (pl != nil), so an
+// unresolved positive ref never sets it and the gate cannot see the intended
+// specific scope. The fix records an UNRESOLVED positive ref separately
+// (hasUnresolvedPositiveRef) and, when it is present, lowers the direction fail
+// CLOSED BY ACTION: `accept` (and any non-deny action) -> match-NOTHING; only
+// `discard`/`reject` keep match-ALL.
+//
+// This term shape is hard-rejected at strict commit TWICE — undefined prefix-list
+// (validateFirewallPrefixListReferencesStrict) and mixed positive+except (#3359)
+// — so it only reaches the runtime lowering on the tolerant / peer-sync /
+// persisted-invalid load path (#1960 no-brick), same family as #5097/#5223.
+//
+// FAIL-ON-REVERT: drop the `hasUnresolvedPositiveRef && !firewallFilterActionDenies`
+// branch from the compose gate in ResolveFilterPrefixListAddrs (so it always
+// `return exceptPrefixes, true, true`) and the accept assertions below go RED —
+// the accept term composes back to except=true = admit-ALL.
+func TestResolvePrefixListAddrsUnresolvedPositivePlusExceptFailsClosedByAction_5225(t *testing.T) {
+	// Empty config: BOTH referenced prefix-lists are undefined -> unresolved on
+	// the tolerant path (pl == nil for each).
+	cfg := &config.Config{}
+
+	// refs order: positive first, then except (natural config order). The lowering
+	// is order-independent, but pin the realistic ordering.
+	refs4 := []config.PrefixListRef{
+		{Name: "undef_pos4", Except: false},
+		{Name: "undef_exc4", Except: true},
+	}
+	refs6 := []config.PrefixListRef{
+		{Name: "undef_pos6", Except: false},
+		{Name: "undef_exc6", Except: true},
+	}
+
+	acceptCases := []struct {
+		name      string
+		refs      []config.PrefixListRef
+		direction string
+		action    string
+	}{
+		{"accept-source-inet", refs4, "source", "accept"},
+		{"accept-dest-inet", refs4, "destination", "accept"},
+		{"accept-source-inet6", refs6, "source", "accept"},
+		{"accept-dest-inet6", refs6, "destination", "accept"},
+		// A modifier-only fall-through (Action == "") and a PBR redirect must ALSO
+		// fail closed to match-NOTHING — an unresolvable positive set must never be
+		// counted, logged, admitted, or redirected as a match.
+		{"fallthrough-source-inet", refs4, "source", ""},
+	}
+	for _, tc := range acceptCases {
+		t.Run(tc.name, func(t *testing.T) {
+			addrs, except, constrained := resolvePrefixListAddrs(
+				nil, tc.refs, cfg, "f", "t", tc.direction, tc.action,
+			)
+			if !constrained {
+				t.Fatalf("an unresolved positive+except term must stay constrained "+
+					"(fail closed), got constrained=false addrs=%v", addrs)
+			}
+			if except {
+				t.Fatalf("#5225 REGRESSION: an unresolved positive prefix-list ref + "+
+					"except on a non-deny term (%q) must lower to match-NOTHING "+
+					"(except=false), NOT the match-ALL compose (except=true = admit "+
+					"every packet = fail-OPEN). got except=true addrs=%v", tc.action, addrs)
+			}
+			if len(addrs) != 0 {
+				t.Fatalf("match-NOTHING contributes NO prefixes, got addrs=%v", addrs)
+			}
+		})
+	}
+
+	// Regression guard: a `discard`/`reject` term with the SAME shape must STAY
+	// fail-closed = match-ALL (except=true, empty set). A deny that matched nothing
+	// would fall through to a later permit term = fail-OPEN for the deny (#5097).
+	denyCases := []struct {
+		name   string
+		action string
+	}{
+		{"discard", "discard"},
+		{"reject", "reject"},
+	}
+	for _, tc := range denyCases {
+		t.Run("deny-"+tc.name, func(t *testing.T) {
+			addrs, except, constrained := resolvePrefixListAddrs(
+				nil, refs4, cfg, "f", "t", "source", tc.action,
+			)
+			if !except || !constrained {
+				t.Fatalf("a %q term with unresolved positive+except must stay fail-closed "+
+					"= match-ALL (except=true, constrained=true) so the deny drops "+
+					"broadly; got except=%v constrained=%v addrs=%v",
+					tc.action, except, constrained, addrs)
+			}
+			// The unresolved except ref contributes no prefixes, so the excepted set
+			// is empty; inverted = match ALL.
+			if len(addrs) != 0 {
+				t.Fatalf("unresolved except contributes NO prefixes, got addrs=%v", addrs)
+			}
+		})
+	}
+}
+
+// A RESOLVED positive prefix-list ref alongside an `except` ref is the mixed
+// positive+except shape (#3359). It is NOT the #5225 case (hasPositiveRef=true, so
+// the compose gate never fires) and must be UNCHANGED by the #5225 fix:
+// POSITIVE-WINS — the except side is dropped and the term lowers to the resolved
+// positive scope (except=false). This holds for EVERY action, so the action-gated
+// #5225 branch must never touch it.
+func TestResolvePrefixListAddrsResolvedPositivePlusExceptUnchanged_5225(t *testing.T) {
+	cfg := &config.Config{
+		PolicyOptions: config.PolicyOptionsConfig{
+			PrefixLists: map[string]*config.PrefixList{
+				"good": {Name: "good", Prefixes: []string{"10.0.0.0/8"}},
+			},
+		},
+	}
+	refs := []config.PrefixListRef{
+		{Name: "good", Except: false},
+		{Name: "undef_exc", Except: true},
+	}
+	for _, action := range []string{"accept", "discard", "reject", ""} {
+		t.Run("action="+action, func(t *testing.T) {
+			addrs, except, constrained := resolvePrefixListAddrs(
+				nil, refs, cfg, "f", "t", "source", action,
+			)
+			if except {
+				t.Fatalf("resolved positive + except must stay positive-wins "+
+					"(except=false), got except=true addrs=%v", addrs)
+			}
+			if !constrained {
+				t.Fatalf("a resolved positive scope must stay constrained, got constrained=false")
+			}
+			if len(addrs) != 1 || addrs[0] != "10.0.0.0/8" {
+				t.Fatalf("positive-wins must keep the resolved positive scope, got addrs=%v", addrs)
+			}
+		})
+	}
+}
+
+// A GENUINE match-any positive (`0.0.0.0/0` literal, NO unresolved positive ref)
+// alongside an unresolved except ref is the #4338/#5097 "any except X" lockdown
+// idiom, X unresolved. The #5225 action-gate must NOT touch it — it composes to
+// match-ALL (except=true) for EVERY action, including `accept` (admit any except
+// the — here empty — unresolved set). This is the discriminator proving the fix
+// keys off hasUnresolvedPositiveRef, not merely off "empty positive + except".
+func TestResolvePrefixListAddrsGenuineMatchAnyPlusUnresolvedExceptUnchanged_5225(t *testing.T) {
+	cfg := &config.Config{}
+	for _, action := range []string{"accept", "discard", "reject", ""} {
+		t.Run("action="+action, func(t *testing.T) {
+			addrs, except, constrained := resolvePrefixListAddrs(
+				[]string{"0.0.0.0/0"},
+				[]config.PrefixListRef{{Name: "undef_exc", Except: true}},
+				cfg, "f", "t", "source", action,
+			)
+			if !except || !constrained {
+				t.Fatalf("genuine match-any + unresolved except must compose to "+
+					"except=true, constrained=true for action=%q; got except=%v "+
+					"constrained=%v addrs=%v", action, except, constrained, addrs)
+			}
+			if len(addrs) != 0 {
+				t.Fatalf("compose prefixes = %v, want empty (unresolved except set)", addrs)
+			}
+		})
+	}
+}

--- a/pkg/dataplane/userspace/filters_unresolved_except_5097_test.go
+++ b/pkg/dataplane/userspace/filters_unresolved_except_5097_test.go
@@ -46,7 +46,7 @@ func TestResolvePrefixListAddrsUnresolvedSoleExceptFailsClosed_5097(t *testing.T
 			addrs, except, constrained := resolvePrefixListAddrs(
 				tc.literal,
 				[]config.PrefixListRef{{Name: tc.refName, Except: true}},
-				cfg, "f", "t", tc.direction,
+				cfg, "f", "t", tc.direction, "accept",
 			)
 			if !constrained {
 				t.Fatalf("an unresolved except reference must stay constrained "+
@@ -75,7 +75,7 @@ func TestResolvePrefixListAddrsMatchAnyPlusUnresolvedExceptFailsClosed_5097(t *t
 	addrs, except, constrained := resolvePrefixListAddrs(
 		[]string{"0.0.0.0/0"},
 		[]config.PrefixListRef{{Name: "undefined", Except: true}},
-		cfg, "f", "t", "source",
+		cfg, "f", "t", "source", "accept",
 	)
 	if !except || !constrained {
 		t.Fatalf("match-any + unresolved except must compose to except=true, "+
@@ -100,7 +100,7 @@ func TestResolvePrefixListAddrsSpecificPlusUnresolvedExceptStaysPositiveWins_509
 	addrs, except, constrained := resolvePrefixListAddrs(
 		[]string{"10.0.0.0/8"},
 		[]config.PrefixListRef{{Name: "undefined", Except: true}},
-		cfg, "f", "t", "source",
+		cfg, "f", "t", "source", "accept",
 	)
 	if except {
 		t.Fatalf("specific positive + unresolved except must NOT compose "+


### PR DESCRIPTION
## Defect (#5225, security)

Closes #5225.

On the tolerant / peer-sync load path a firewall-filter term carrying **both an UNRESOLVED positive prefix-list ref AND an `except` ref** (no resolved positive scope, empty/match-any literal) composed to **match-ALL on an `accept` term** — admit-ALL, a fail-**OPEN**. The term admitted every packet instead of the operator's intended (now unresolvable, so empty) set.

### Root cause

`ResolveFilterPrefixListAddrs` (`pkg/dataplane/userspace/filters.go`) sets `hasPositiveRef` **only for a RESOLVED positive ref** (`pl != nil`). An **unresolved** positive ref (`pl == nil`) contributes no prefixes and left `hasPositiveRef` false, so the #4338 "any except X" compose gate

```go
if hasExcept && !hasPositiveRef && addrsAllMatchAny(positive) {  // fires
    return exceptPrefixes, true, true                             // (nil, true, true) = match-ALL
}
```

saw an empty `positive`, read it as the match-any universe, and — with `hasExcept` set by the accompanying `except` ref (or, post-#5097, by an unresolved `except` ref) — inverted the empty set to `(nil, except=true, constrained=true)` = **match-ALL**. For `accept` that is admit-ALL. The gate's premise ("the positive side is genuinely `any`") was false: the positive was empty only because a specific-but-unresolvable ref produced no prefixes.

- `discard`/`reject` + match-ALL = drop-everything = fail-**closed** (fine).
- `accept` + match-ALL = admit-everything = fail-**open** (the bug).

### Reachability (narrow)

Strict commit rejects this shape **twice** — undefined prefix-lists (`validateFirewallPrefixListReferencesStrict`) and mixed positive/except (#3359). It reaches the runtime lowering only on the tolerant / peer-sync / persisted-invalid path (#1960 no-brick) — the same helper-boundary backstop family as #5097/#5223.

## Fix — action-aware fail-closed

Record an unresolved positive ref separately (`hasUnresolvedPositiveRef`) and lower the compose case **action-aware** when it is set:

- **accept** (and every non-deny action — routing-instance PBR, a modifier-only fall-through): **match NOTHING** `(nil, false, true)`. An unresolvable positive scope must never be admitted, redirected, or counted as a match.
- **discard/reject**: **match ALL** `(exceptPrefixes, true, true)` — unchanged from the #4338/#5097 path, so the deny still drops broadly. A deny that matched nothing would fall through to a later permit term = fail-open for the deny it was written to enforce (the #5097 concern).

A **genuine** match-any positive (no unresolved positive ref — `0.0.0.0/0`/`::/0` literal or empty literal) keeps the #4338/#5097 match-ALL compose **verbatim for all actions**; only the unresolved-positive-ref case is action-gated. `hasUnresolvedPositiveRef` is the sole discriminator.

The term action is threaded through the shared SSOT resolver (`ResolveFilterPrefixListAddrs` gains a trailing `action` parameter) so **both** consumers — the userspace snapshot builder and the daemon lo0 kernel-nft mirror (`nftRulesFromTerm`) — render the same fail-closed verdict. Every other lowering is action-independent; callers without an action may pass `""`.

## Relationship to #5223 / #5097

#5097 (merged as #5223) made an unresolved **sole** `except` ref record `hasExcept = true` so a deny fails closed. That recording is exactly what makes *this* bug reachable: the unresolved `except` now sets `hasExcept`, and an accompanying unresolved *positive* ref (which does **not** set `hasPositiveRef`) lets the compose gate fire on `accept`. #5225 completes the pattern by teaching the gate to distinguish "empty because genuinely `any`" from "empty because a positive ref did not resolve", and to fail closed by action.

## Fail-on-revert test

`pkg/dataplane/userspace/filters_mixed_unresolved_except_5225_test.go`:

- `TestResolvePrefixListAddrsUnresolvedPositivePlusExceptFailsClosedByAction_5225` — `accept` (+ modifier-only fall-through) → match-NOTHING (`except=false`) for source/dest inet/inet6; regression guard: `discard`/`reject` → match-ALL (`except=true`). **The accept assertions are RED on master** (compose to `except=true` = admit-ALL). Neutralization that reproduces RED: force the `hasUnresolvedPositiveRef && !firewallFilterActionDenies(action)` branch off so the gate always `return exceptPrefixes, true, true` — verified RED before commit, GREEN after.
- `TestResolvePrefixListAddrsResolvedPositivePlusExceptUnchanged_5225` — resolved positive + except stays positive-wins for every action (#3359 path untouched).
- `TestResolvePrefixListAddrsGenuineMatchAnyPlusUnresolvedExceptUnchanged_5225` — genuine `0.0.0.0/0` + unresolved except keeps match-ALL for every action (proves the fix keys off `hasUnresolvedPositiveRef`, not merely "empty positive + except").

## Docs

The runtime lowering contract lives in the `ResolveFilterPrefixListAddrs` / `resolvePrefixListAddrs` doc comments (updated) — the #5097 precedent; no separate markdown owns the compose gate. `pkg/daemon/README.md`'s shared-resolver section (which documents the empty-set / except / positive-wins / `any` semantics the lo0 mirror inherits) gains the #5225 action-aware fail-closed case.

## Validation

- `go build ./...` clean; `go vet ./pkg/dataplane/userspace ./pkg/daemon` clean.
- `go test ./pkg/...` green (full suite), including the updated #5097/#4338/#3359 contract tests (updated only mechanically for the new trailing `action` arg — their assertions are unchanged).
- Go-only change; no Rust/cargo touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uz7CSTxSA3Z3bbauRokgJ8