### PR TITLE
userspace-dp: read inner packet_frame post-GRE-decap, not outer raw_frame (#5140)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-11 — #5140 (security): post-GRE-decap ICMP/host-inbound/TTL reads use packet_frame, not outer raw_frame
+- **Timestamp**: 2026-07-11 (fix/5140-gre-decap-packet-frame)
+- **Action**: `stage_native_gre_decap` returns a synthetic inner frame
+  (`owned_packet_frame`) whose meta offsets are inner-relative, while
+  `raw_frame` stays the OUTER frame. Several post-decap INNER reads indexed
+  the outer `raw_frame` with the inner `meta.l4_offset`/`l3_offset` — reading
+  wrong (and, on an untagged underlay, attacker-controllable GRE-flags) bytes.
+  On untagged, inner `l4_offset` (14+20=34) lands EXACTLY on the outer GRE
+  flags byte, whose low bits (Recur/reserved) the decap ignores — so a crafted
+  GRE frame wrapping an ICMP echo could seed `raw_frame[34]` with an ICMP-error
+  type and (mis)classify the echo as an exempt error → host-inbound admission
+  bypass on a ping-less zone / `allow-embedded-icmp` policy-check exemption.
+  Swapped `raw_frame`→`packet_frame` at every post-decap inner read; kept
+  `raw_frame` only for genuinely outer reads. Enumeration — CHANGED (7 inner
+  reads): host-inbound ICMP-type byte session-hit (mod.rs ~1185) + session-miss
+  (~2224); `is_embedded_icmp_error` ICMP-type (~2182); TTL/hop-limit
+  `build_local_time_exceeded_request` session-hit (~1352) + session-miss (~2905);
+  flow-cache-hit `packet_ttl_would_expire` (flow_cache_hit.rs ~154) +
+  `build_local_time_exceeded_request` (~158). LEFT as outer (verified): the
+  embedded-ICMP-NAT `build_nat_reversed_icmp_error_v4/v6` (~2504/2509) is paired
+  with `try_embedded_icmp_nat_match` which reads the outer UMEM via `desc` — both
+  must share the outer buffer; inert on GRE (match fails on outer bytes). The
+  `cfg!(debug-log)` wire-vs-meta diagnostic (~4001-4091) reads `raw_frame` by
+  design. `pending_neigh_flow_key` (~5372) and source-MAC learning are already
+  `owned_packet_frame.is_none()`-guarded. `desc` on the two TTL builders is only
+  the UMEM-recycle handle (the reply is a freshly built prebuilt frame), so the
+  buffer swap does not disturb recycling.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs (5 inner reads),
+  userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs (2 inner reads),
+  userspace-dp/src/afxdp/tests_gre_local_delivery.rs (fail-on-revert test),
+  docs/userspace-native-gre-plan.md (new §6d buffer-authority invariant), _Log.md
+- **Validation**: `cargo build` green; FULL `cargo test --release` green
+  (3935 passed / 0 failed). RED-on-revert PROVEN: new test
+  `gre_decap_inner_icmp_echo_denied_by_host_inbound_reads_inner_type` drives a
+  real GRE-tunnelled inner ICMP echo (outer GRE flags byte planted 0x0B = ICMPv4
+  time-exceeded) through `poll_binding_process_descriptor` and asserts the
+  host-inbound DENY (`host_inbound_denied_packets == 1`); swapping the session-miss
+  host-inbound read back to `raw_frame` makes it read the outer 0x0B error byte,
+  admit the echo as an exempt error, and the counter reads 0 (test FAILS). Drives
+  the REAL decap+classify path, not a synthetic leaf call. iperf loss-cluster
+  smoke deferred (classification/correctness fix, behind the #1864 shim-ABI wall).
+
 ## 2026-07-11 — #5141 (security): clamp TCP segmentation to the IP-declared datagram length
 - **Timestamp**: 2026-07-11 (fix/5141-tcpseg-iplen-clamp)
 - **Action**: TCP segmentation sliced the segmentable payload from the full

--- a/docs/userspace-native-gre-plan.md
+++ b/docs/userspace-native-gre-plan.md
@@ -383,6 +383,60 @@ The **Routing-Present (`R`) bit stays a drop** — the Source Route Entry
 list is variable-length with no fixed offset and is effectively dead on
 the modern Internet; parsing it is out of scope.
 
+### 6d. Post-Decap Single-Authoritative-Buffer Invariant (#5140)
+
+`stage_native_gre_decap` returns a **synthetic inner frame** (a fresh
+`owned_packet_frame: Vec<u8>` = 14-byte synthetic Ethernet + inner
+packet) together with an inner meta whose `l3_offset`/`l4_offset` are
+**inner-relative** (`l3_offset = 14`, `l4_offset = 14 + inner IHL`). The
+original `raw_frame` (the UMEM slice for `desc`) stays the **outer**
+encapsulated frame. The worker binds
+
+```
+let packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame);
+```
+
+so `packet_frame` is the inner frame after a GRE decap and the live
+`raw_frame` otherwise. **After decap, `meta` offsets are authoritative
+ONLY against `packet_frame`.** Indexing the outer `raw_frame` with an
+inner-relative offset reads the wrong bytes.
+
+This bites hardest on an UNTAGGED underlay: the inner `l4_offset`
+(`14 + 20 = 34` for a 20-byte inner IPv4 header) lands EXACTLY on the
+outer GRE flags byte (`eth 14 + outer IP 20 = 34`). The GRE flags low
+bits (Recur / reserved) are attacker-controllable and ignored by the
+decap parser (only C/R/K/S/version are checked), so `raw_frame[34]` is an
+attacker-seeded byte. Reading it as an "ICMP type" can misclassify an
+ordinary inner ICMP echo (type 8) as an exempt error/PMTUD control
+message — bypassing the host-inbound admission gate on a ping-less zone
+(`is_icmp_host_inbound_global_accept`, #3171) or the `allow-embedded-icmp`
+policy-check exemption.
+
+The rule, enforced in `poll_descriptor/mod.rs` +
+`poll_descriptor/flow_cache_hit.rs`: every post-decap INNER read uses
+`packet_frame` —
+
+- the host-inbound / lo0 ICMP-type byte (session-hit + session-miss),
+- the `is_embedded_icmp_error` ICMP-type classification,
+- the TTL/hop-limit test + generated Time Exceeded
+  (`packet_ttl_would_expire` / `build_local_time_exceeded_request`, in
+  the session-hit, session-miss, AND flow-cache-hit paths).
+
+`raw_frame` is retained ONLY for genuinely outer/live reads: source-MAC
+neighbour learning (`learn_from_live_frame` is gated on
+`owned_packet_frame.is_none()`), the `pending_neigh_flow_key` buffer
+(also `owned_packet_frame.is_none()`-guarded), the debug-log wire-vs-meta
+diagnostic, and the embedded-ICMP-NAT match/build pair
+(`try_embedded_icmp_nat_match` reads the outer UMEM via `desc`, so its
+sibling `build_nat_reversed_icmp_error_*` MUST stay on the same outer
+buffer — for a GRE inner the outer bytes at the inner offset do not parse
+as a matching ICMP error, so that path is inert on decap rather than
+mis-firing). Fail-on-revert coverage:
+`gre_decap_inner_icmp_echo_denied_by_host_inbound_reads_inner_type` drives
+a real GRE-tunnelled inner echo through `poll_binding_process_descriptor`
+and asserts the host-inbound DENY that only the `packet_frame` read
+produces.
+
 ## Policy-Based Routing Without A Tunnel Netdevice
 
 This is the most important control-plane question.

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -151,11 +151,16 @@ pub(super) fn stage_flow_cache_hit(
         if matches!(
             cached_decision.resolution.disposition,
             ForwardingDisposition::ForwardCandidate | ForwardingDisposition::FabricRedirect
-        ) && matches!(packet_ttl_would_expire(raw_frame, meta), Some(true))
+        ) && matches!(packet_ttl_would_expire(packet_frame, meta), Some(true))
         {
-            // #1145: reuse the line-50 raw_frame bind instead of re-slicing.
+            // #5140: the TTL/hop-limit test + the embedded original in the
+            // generated Time Exceeded read the INNER packet via `packet_frame`
+            // (decapped frame post native-GRE, else `raw_frame`); `meta.l3_offset`
+            // is inner-relative after `stage_native_gre_decap`, so the outer
+            // `raw_frame` would test the wrong TTL byte. `desc` is still passed to
+            // recycle the outer UMEM slot (the reply is a freshly built frame).
             if let Some(request) = build_local_time_exceeded_request(
-                raw_frame,
+                packet_frame,
                 desc,
                 meta,
                 &worker_ctx.ident,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1182,7 +1182,13 @@ pub(super) fn poll_binding_process_descriptor(
                                 // error/PMTUD control message stays admitted on a
                                 // ping-less zone (mirrors the kernel chain). 0
                                 // for non-ICMP (ignored by host_inbound_admits).
-                                raw_frame
+                                // #5140: read the INNER type via `packet_frame`
+                                // (= decapped frame post native-GRE, else
+                                // `raw_frame`); `meta.l4_offset` is inner-relative
+                                // after `stage_native_gre_decap`, so indexing the
+                                // outer `raw_frame` would read the wrong byte and
+                                // could admit an ordinary echo as an exempt error.
+                                packet_frame
                                     .get(meta.l4_offset as usize)
                                     .copied()
                                     .unwrap_or(0),
@@ -1349,9 +1355,15 @@ pub(super) fn poll_binding_process_descriptor(
                             resolved.decision.resolution.disposition,
                             ForwardingDisposition::ForwardCandidate
                         ) {
-                            // #1145: reuse line-50 raw_frame bind.
+                            // #5140: read the INNER packet via `packet_frame`
+                            // (decapped frame post native-GRE, else `raw_frame`).
+                            // The TTL/hop-limit test + the embedded original in
+                            // the generated Time Exceeded are keyed on the
+                            // inner-relative `meta` offsets; `desc` is carried
+                            // only to recycle the outer UMEM slot (the reply is a
+                            // freshly built prebuilt frame).
                             let local_icmp_te = build_local_time_exceeded_request(
-                                raw_frame,
+                                packet_frame,
                                 desc,
                                 meta,
                                 &worker_ctx.ident,
@@ -2178,8 +2190,14 @@ pub(super) fn poll_binding_process_descriptor(
                         let is_embedded_icmp_error = if worker_ctx.forwarding.allow_embedded_icmp
                             && matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6)
                         {
-                            // #1145: reuse line-50 raw_frame bind.
-                            raw_frame
+                            // #5140: classify on the INNER ICMP type via
+                            // `packet_frame` (decapped frame post native-GRE, else
+                            // `raw_frame`). `meta.l4_offset` is inner-relative
+                            // after `stage_native_gre_decap`; indexing the outer
+                            // `raw_frame` could read an arbitrary outer byte and
+                            // misclassify an ordinary echo as an exempt embedded
+                            // error (permitted without policy check).
+                            packet_frame
                                 .get(meta.l4_offset as usize)
                                 .copied()
                                 .map(|icmp_type| is_icmp_error(meta.protocol, icmp_type))
@@ -2221,7 +2239,13 @@ pub(super) fn poll_binding_process_descriptor(
                                 // error/PMTUD control messages are admitted on a
                                 // ping-less zone (mirrors the kernel chain). 0
                                 // for non-ICMP (ignored by host_inbound_admits).
-                                raw_frame
+                                // #5140: read the INNER type via `packet_frame`
+                                // (decapped frame post native-GRE, else
+                                // `raw_frame`) — `meta.l4_offset` is inner-relative
+                                // after `stage_native_gre_decap`, so the outer
+                                // `raw_frame` would read the wrong byte and could
+                                // host-admit an ordinary echo as an exempt error.
+                                packet_frame
                                     .get(meta.l4_offset as usize)
                                     .copied()
                                     .unwrap_or(0),
@@ -2902,9 +2926,16 @@ pub(super) fn poll_binding_process_descriptor(
                                     }
                                     None
                                 };
-                                // #1145: reuse line-50 raw_frame bind.
+                                // #5140: read the INNER packet via `packet_frame`
+                                // (decapped frame post native-GRE, else
+                                // `raw_frame`). The TTL/hop-limit test + the
+                                // embedded original in the generated Time Exceeded
+                                // are keyed on the inner-relative `meta` offsets;
+                                // `desc` is carried only to recycle the outer UMEM
+                                // slot (the reply is a freshly built prebuilt
+                                // frame).
                                 let local_icmp_te = build_local_time_exceeded_request(
-                                    raw_frame,
+                                    packet_frame,
                                     desc,
                                     meta,
                                     &worker_ctx.ident,

--- a/userspace-dp/src/afxdp/tests_gre_local_delivery.rs
+++ b/userspace-dp/src/afxdp/tests_gre_local_delivery.rs
@@ -1262,3 +1262,97 @@ fn unknown_tunnel_mode_classifies_as_unknown_not_gre() {
     }
 }
 
+
+/// #5140 LITERAL fail-on-revert (security): the post-GRE-decap host-inbound
+/// admission gate MUST read the ICMP/ICMPv6 type from the decapped inner
+/// `packet_frame`, NOT the outer `raw_frame`. After `stage_native_gre_decap`
+/// the inner meta's `l4_offset` is inner-relative (14 + inner IHL = 34 for a
+/// 20-byte inner IPv4 header). For an UNTAGGED GRE underlay that offset lands
+/// EXACTLY on the outer GRE flags byte (eth 14 + outer IP 20 = 34 = the GRE
+/// header). The GRE flags low bits (Recur / reserved) are attacker-controllable
+/// and ignored by the decap (only C/R/K/S/version are checked), so an attacker
+/// can seed `raw_frame[34]` with an ICMP-error type value (11 = time-exceeded).
+///
+/// The trigger here is a GRE-tunnelled inner ICMP ECHO (type 8) to the firewall-
+/// local gr- address on a PING-LESS zone (empty host-inbound set → Junos deny-all
+/// posture for ping). The correct disposition is DENY: an echo is not an
+/// error/PMTUD control message, so the #3171 global-accept exemption does not
+/// apply and the empty zone set drops it.
+///
+/// - FIXED (`packet_frame[34]` = inner type 8 = echo): NOT globally accepted →
+///   empty zone set → DENIED → `host_inbound_denied_packets == 1`.
+/// - BUGGY (`raw_frame[34]` = outer GRE flags 0x0B = 11 = time-exceeded): the
+///   #3171 `is_icmp_host_inbound_global_accept` exemption ADMITS it before the
+///   zone lookup → `host_inbound_denied_packets == 0` — an ordinary echo bypasses
+///   host-inbound admission (the security misclassification #5140 fixes).
+///
+/// Swap `packet_frame` back to `raw_frame` at the session-MISS host-inbound
+/// ICMP-type read (`poll_descriptor/mod.rs`, the `host_inbound_gated_lo0_action`
+/// icmp_type argument) and this test goes RED. Drives the REAL decap+classify
+/// path via `poll_binding_process_descriptor` (not a synthetic leaf call).
+#[test]
+fn gre_decap_inner_icmp_echo_denied_by_host_inbound_reads_inner_type() {
+    let mut forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    // Ping-less posture: a present-but-EMPTY host-inbound set on every zone so
+    // an inner ICMP echo to the firewall-local gr- address is denied (Junos
+    // deny-all), while ICMP ERROR types stay globally admitted (#3171). This is
+    // what makes the outer-vs-inner read observable: outer flags 0x0B decodes to
+    // error type 11 (admit-exempt); inner type 8 is echo (deny).
+    let zone_ids: Vec<u16> = forwarding.zone_id_to_name.keys().copied().collect();
+    assert!(!zone_ids.is_empty(), "fixture must define at least one zone");
+    for id in zone_ids {
+        forwarding
+            .zone_host_inbound
+            .insert(id, crate::afxdp::types::ZoneHostInbound::default());
+    }
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 11, 0);
+    binding.interface = Arc::<str>::from("ge-0-0-0");
+    let mut sessions = SessionTable::new();
+
+    // Inner: ICMP echo request (type 8) 10.255.0.2 -> 10.255.0.1 (gr-local).
+    let inner = build_gre_inner_icmp_packet_v4();
+    assert_eq!(inner[20], 8, "inner must be an ICMP echo request (type 8)");
+    // Untagged GRE-to-self outer frame; then plant an ICMP-error type value in
+    // the outer GRE flags byte (frame[34], the byte the buggy read indexes).
+    // 0x0B sets only Recur/reserved low bits (no C/R/K/S) so decap is unaffected.
+    let mut frame = build_gre_to_self_outer_frame_with_inner(0x0800, &inner);
+    assert_eq!(
+        frame[34], 0x00,
+        "untagged frame[34] is the GRE flags byte (eth14 + outerIP20)"
+    );
+    frame[34] = 0x0B; // ICMPv4 time-exceeded (11) — an error type in the #3171 set
+    let meta = gre_to_self_outer_meta(0, frame.len());
+
+    let (batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.local, 1,
+        "the decapped inner echo to the gr-local address must take the \
+         LocalDelivery arm"
+    );
+    assert_eq!(
+        batch.host_inbound_denied_packets, 1,
+        "#5140: the host-inbound gate must read the INNER ICMP type (8 = echo) \
+         from packet_frame and DENY on the ping-less zone; the buggy raw_frame \
+         read sees the outer GRE flags byte (0x0B = 11 = time-exceeded) and \
+         admits the echo as an exempt error (host-inbound bypass)"
+    );
+    assert_eq!(
+        dbg.host_inbound_deny, 1,
+        "#3610/M07: the deny is accounted on dbg.host_inbound_deny"
+    );
+    assert_eq!(
+        sessions.len(),
+        0,
+        "a host-inbound-denied inner echo must not cache a host-local session"
+    );
+}
+


### PR DESCRIPTION
## Summary

Closes #5140 (bug, security).

`stage_native_gre_decap` returns a **synthetic inner frame**
(`owned_packet_frame`) whose `meta.l3_offset`/`l4_offset` are
**inner-relative**, while `raw_frame` stays the **outer** encapsulated
frame. Several post-decap **inner** reads indexed the outer `raw_frame`
with the inner `meta` offset, reading the wrong bytes for a GRE-decapped
inner packet. The correct buffer,
`packet_frame = owned_packet_frame.as_deref().unwrap_or(raw_frame)`, was
already in scope at every site.

### Why it's a security bug

On an **untagged** underlay the inner `l4_offset` (`14 + 20 = 34`) lands
**exactly** on the outer GRE flags byte (`eth 14 + outer IP 20 = 34`). The
GRE flags low bits (Recur / reserved) are **attacker-controllable** and
ignored by the decap parser (only C/R/K/S/version are checked), so
`raw_frame[34]` is an attacker-seeded byte. A crafted GRE frame wrapping an
ordinary ICMP **echo** (type 8) could plant an ICMP-**error** type value
there, and the buggy read would classify the echo as an exempt
error/PMTUD control message — **bypassing the host-inbound admission gate**
on a ping-less zone (`is_icmp_host_inbound_global_accept`, #3171) or the
`allow-embedded-icmp` policy-check exemption.

## The buffer swap — exhaustive site enumeration

Every `raw_frame` read in the poll loop was classified inner (fix) vs
outer-only (leave):

### Changed — 7 inner reads (`raw_frame` → `packet_frame`)
| Site | Read |
|------|------|
| `mod.rs` host-inbound ICMP-type byte, **session-hit** | `host_inbound_gated_lo0_action` icmp_type arg |
| `mod.rs` host-inbound ICMP-type byte, **session-miss** | `host_inbound_gated_lo0_action` icmp_type arg |
| `mod.rs` `is_embedded_icmp_error` | `is_icmp_error(meta.protocol, type)` |
| `mod.rs` TTL/hop-limit, **session-hit** | `build_local_time_exceeded_request` |
| `mod.rs` TTL/hop-limit, **session-miss** | `build_local_time_exceeded_request` |
| `flow_cache_hit.rs` TTL test | `packet_ttl_would_expire` |
| `flow_cache_hit.rs` TTL build | `build_local_time_exceeded_request` |

The `desc` arg on the two `build_local_time_exceeded_request` sites is only
the **UMEM-recycle handle** — the reply is a freshly built
`PendingForwardFrame::Prebuilt`, so the buffer swap does not disturb slot
recycling.

### Left as outer — verified NOT bugs
- **`build_nat_reversed_icmp_error_v4/v6`** — paired with
  `try_embedded_icmp_nat_match`, which reads the **outer UMEM** via `desc`;
  both must share the same buffer. For a GRE inner the outer bytes at the
  inner offset don't parse as a matching ICMP error, so the
  embedded-ICMP-NAT path is **inert** on decap rather than mis-firing.
  Swapping only the builder would break match/build buffer consistency.
- **`cfg!(debug-log)` wire-vs-meta diagnostic** — deliberately reads
  `raw_frame` to compare shim meta against the raw wire; compiled out in
  release, never affects disposition.
- **`pending_neigh_flow_key`** and **source-MAC neighbour learning** —
  already `owned_packet_frame.is_none()`-guarded (only reached when no
  decap happened, so `raw_frame == packet_frame`).

## Fail-on-revert test

`gre_decap_inner_icmp_echo_denied_by_host_inbound_reads_inner_type`
(in `tests_gre_local_delivery.rs`) drives a **real** GRE-tunnelled inner
ICMP echo through `poll_binding_process_descriptor` (not a synthetic leaf
call). The outer GRE flags byte is planted `0x0B` (= ICMPv4 time-exceeded,
type 11, an error type in the #3171 global-accept set), the inner is an
ICMP echo (type 8), and the ingress zone carries an empty (ping-less)
host-inbound set.

- **Fixed** (`packet_frame[34]` = inner type 8 = echo): not globally
  accepted → empty zone set → **DENIED** → `host_inbound_denied_packets == 1`.
- **Reverted** (`raw_frame[34]` = outer 0x0B = 11 = error): the #3171
  exemption **admits** the echo → `host_inbound_denied_packets == 0` → test
  fails.

Confirmed RED by reverting the session-miss host-inbound read to
`raw_frame` (counter reads 0).

## Validation
- `cargo build` green.
- Full `cargo test --release` green — **3935 passed, 0 failed**.
- iperf loss-cluster smoke **deferred**: this is a classification/
  correctness fix and the loss cluster is behind the #1864 shim-ABI wall.

## Docs
New section 6d in `docs/userspace-native-gre-plan.md` documenting the
post-decap single-authoritative-buffer invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3FXpqru8zPnwNqBmTxdMa