### PR TITLE
test/xsk-repro: guard fork()/kill() against a host-wide SIGKILL (#4906 HC-001)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46509,3 +46509,7 @@ top.
 - **Timestamp**: 2026-07-11 (parent inline, roster full — no agent lane)
   - **Action**: #5102 — DNAT `match application any` now lowers to unconstrained (match-any-application), mirroring SNAT's buildSourceNATAppTerms "any"/empty short-circuit, instead of the #3434 never-match sentinel that silently disabled a valid strict-commit-accepted rule. Only the `appConfigured` predicate changed; the resolve loop is untouched (a real app alongside "any" is preserved; a typo / defined-but-empty app-set still fails closed). Fail-on-revert test + #3434 no-regression verified.
   - **File(s)**: pkg/dataplane/userspace/nat_destination.go, pkg/dataplane/userspace/nat_dnat_app_any_5102_test.go
+
+- **Timestamp**: 2026-07-11 (parent inline, roster full)
+  - **Action**: #4906 HC-001 (Critical) — guard the AF_XDP reproducer fork()/kill() against a host-wide SIGKILL. Unchecked fork() then unconditional kill(child,9): on fork()==-1 (RLIMIT_NPROC / PID exhaustion) child==-1 and kill(-1,SIGKILL) signals every process the root caller may signal (firewall daemon + host). Added an `if (child < 0)` warn-and-continue after fork and guarded every kill/waitpid with `if (child > 0)` in both reproducers. Test-tooling only; gcc -fsyntax-only clean. Remaining #4906 cohort defects (HC-025 /tmp symlink, XDP replace-detach, uninitialized-counter PASS, frame-recycle/shared-UMEM coverage) need the agent lane + runtime verification — issue kept open.
+  - **File(s)**: test/xsk-repro/libbpf_xsk_test.c, test/xsk-repro/libbpf_xsk_shared_test.c

--- a/test/xsk-repro/libbpf_xsk_shared_test.c
+++ b/test/xsk-repro/libbpf_xsk_shared_test.c
@@ -267,7 +267,13 @@ int main(int argc, char **argv)
 
     /* Start traffic */
     pid_t child = fork();
-    if (child == 0) {
+    if (child < 0) {
+        /* #4906 HC-001: fork() failed. Do NOT fall into the unguarded
+         * kill(child, 9) below — with child == -1 that is kill(-1, SIGKILL),
+         * a host-wide SIGKILL as root. Warn and run without background
+         * traffic; the guarded kill skips for child <= 0. */
+        perror("fork (background traffic)");
+    } else if (child == 0) {
         char ifarg[64];
         snprintf(ifarg, sizeof(ifarg), "-I%s", iface);
         execlp("ping", "ping", ifarg, "-i", "0.1", "-c", "50", "-q",
@@ -280,8 +286,12 @@ int main(int argc, char **argv)
         iface, queue, secondary_iface, secondary_queue, map_fd, use_copy, umem,
         &umem_fill, &umem_comp, umem_area);
 
-    kill(child, 9);
-    waitpid(child, NULL, 0);
+    /* #4906 HC-001: only signal a real child — guard against kill(-1, SIGKILL)
+     * on a fork() failure (child < 0). */
+    if (child > 0) {
+        kill(child, 9);
+        waitpid(child, NULL, 0);
+    }
 
     /* Detach */
     bpf_xdp_attach(ifindex, -1, 0, NULL);

--- a/test/xsk-repro/libbpf_xsk_test.c
+++ b/test/xsk-repro/libbpf_xsk_test.c
@@ -231,7 +231,15 @@ int main(int argc, char **argv)
 
     /* Start background traffic: ping own IP */
     pid_t child = fork();
-    if (child == 0) {
+    if (child < 0) {
+        /* #4906 HC-001: fork() failed (RLIMIT_NPROC / PID exhaustion / memory
+         * pressure). Do NOT fall into the unguarded kill(child, 9) at cleanup
+         * below — with child == -1 that is kill(-1, SIGKILL), which as root
+         * signals every process the caller may signal (the firewall daemon and
+         * the host). Warn and run without background traffic; the guarded
+         * cleanup skips the kill for child <= 0. */
+        perror("fork (background traffic)");
+    } else if (child == 0) {
         /* Child: send pings to self */
         char ifarg[64];
         snprintf(ifarg, sizeof(ifarg), "-I%s", iface);
@@ -271,8 +279,13 @@ int main(int argc, char **argv)
     destroy_xsk(&info, map_fd, queue);
 
 cleanup:
-    kill(child, 9);
-    waitpid(child, NULL, 0);
+    /* #4906 HC-001: only signal a real child. On fork() failure child < 0 and
+     * an unguarded kill(child, 9) becomes kill(-1, SIGKILL) — a host-wide
+     * SIGKILL when run as root. Guard on child > 0. */
+    if (child > 0) {
+        kill(child, 9);
+        waitpid(child, NULL, 0);
+    }
     bpf_xdp_attach(ifindex, -1, 0, NULL);
     printf("  XDP detached\n");
 


### PR DESCRIPTION
Refs #4906 (Critical HC-001; cohort stays open for the remaining defects).

## Defect (Critical, host-safety)
`libbpf_xsk_test.c` / `libbpf_xsk_shared_test.c` `fork()` a background ping then run `kill(child, 9); waitpid(child, ...)` at cleanup, with **no `fork()` return check**. On `fork() == -1` (RLIMIT_NPROC / PID-cgroup exhaustion / memory pressure) `child == -1`, so cleanup becomes `kill(-1, SIGKILL)`. These diagnostics run **as root** against the live firewall interface → SIGKILL to every process the caller may signal: the **xpfd daemon + host**.

## Fix
Both reproducers: `if (child < 0)` → `perror` + continue without the background ping; and guard every `kill`/`waitpid` with `if (child > 0)`. Success path unchanged.

## Scope + validation
- **Test-tooling only** — standalone diagnostic binaries, **zero firewall-runtime blast radius** → parent verification.
- `gcc -fsyntax-only` clean on both files; straight-line guard, verifiable by inspection.
- **Not closing #4906**: the remaining cohort defects (HC-025 predictable /tmp object, XDP replace-detach, uninitialized-counter false PASS, frame-recycle/shared-UMEM coverage) need runtime verification on a live interface + the (currently roster-blocked) agent lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)