### PR TITLE
config/routing: anchor next-table instance parse on the trailing suffix (#5632)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46513,3 +46513,7 @@ top.
 - **Timestamp**: 2026-07-11 (parent inline, roster full)
   - **Action**: #4906 HC-001 (Critical) — guard the AF_XDP reproducer fork()/kill() against a host-wide SIGKILL. Unchecked fork() then unconditional kill(child,9): on fork()==-1 (RLIMIT_NPROC / PID exhaustion) child==-1 and kill(-1,SIGKILL) signals every process the root caller may signal (firewall daemon + host). Added an `if (child < 0)` warn-and-continue after fork and guarded every kill/waitpid with `if (child > 0)` in both reproducers. Test-tooling only; gcc -fsyntax-only clean. Remaining #4906 cohort defects (HC-025 /tmp symlink, XDP replace-detach, uninitialized-counter PASS, frame-recycle/shared-UMEM coverage) need the agent lane + runtime verification — issue kept open.
   - **File(s)**: test/xsk-repro/libbpf_xsk_test.c, test/xsk-repro/libbpf_xsk_shared_test.c
+
+- **Timestamp**: 2026-07-11
+- **Action**: Fix parseNextTableInstance dotted-instance truncation (#5632) — strings.Index → strings.LastIndex so a routing-instance name containing ".inet" keeps its full identity; add fail-on-revert unit test.
+- **File(s)**: pkg/config/compiler_routing.go, pkg/config/compiler_routing_nexttable_5632_test.go

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -382,8 +382,16 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 // parseNextTableInstance extracts the routing instance name from a Junos
 // next-table value like "Comcast-GigabitPro.inet.0" → "Comcast-GigabitPro".
 func parseNextTableInstance(table string) string {
-	// Strip .inet.0 or .inet6.0 suffix to get the routing instance name
-	if idx := strings.Index(table, ".inet"); idx > 0 {
+	// Strip the trailing .inet.N / .inet6.N table suffix to get the routing
+	// instance name. A next-table target is always "<instance>.<family>.<index>",
+	// so the family+index separator is the LAST ".inet" occurrence, not the
+	// first. strings.Index truncated a routing-instance NAME that itself
+	// contained ".inet" (an accepted dotted instance, e.g. "a.inet.b" whose
+	// table is "a.inet.b.inet.0") at the embedded ".inet", corrupting the
+	// emitted next-table identity to "a" and misrouting the leak (#5632). Anchor
+	// on the trailing suffix with LastIndex; for a single-".inet" table the two
+	// are identical, so ordinary names are unaffected.
+	if idx := strings.LastIndex(table, ".inet"); idx > 0 {
 		return table[:idx]
 	}
 	return table

--- a/pkg/config/compiler_routing_nexttable_5632_test.go
+++ b/pkg/config/compiler_routing_nexttable_5632_test.go
@@ -1,0 +1,42 @@
+package config
+
+import "testing"
+
+// TestParseNextTableInstanceDottedInstance_5632 pins the next-table identity
+// extraction for routing-instance names that themselves contain ".inet".
+//
+// A Junos next-table target is always "<instance>.<family>.<index>", so the
+// family+index suffix is the LAST ".inet" occurrence. The pre-#5632 code used
+// strings.Index (FIRST occurrence), which truncated an accepted dotted instance
+// name (e.g. "a.inet.b", table "a.inet.b.inet.0") at the embedded ".inet" and
+// emitted the wrong next-table instance ("a"), silently redirecting the route
+// leak to a different / non-existent routing instance.
+//
+// Fail-on-revert: swapping strings.LastIndex back to strings.Index turns the
+// dotted-instance cases from PASS to FAIL (they resolve to "a" / "test").
+func TestParseNextTableInstanceDottedInstance_5632(t *testing.T) {
+	cases := []struct {
+		name  string
+		table string
+		want  string
+	}{
+		// Ordinary single-".inet" targets — Index and LastIndex agree, so these
+		// guard against a regression in the common path.
+		{"plain-v4", "Comcast-GigabitPro.inet.0", "Comcast-GigabitPro"},
+		{"plain-v6", "blue.inet6.0", "blue"},
+		{"nonzero-index", "green.inet.2", "green"},
+		{"no-suffix", "plain", "plain"},
+		// Dotted-instance targets — the #5632 bug cases. strings.Index truncated
+		// at the first ".inet"; LastIndex keeps the full instance name.
+		{"dotted-instance", "a.inet.b.inet.0", "a.inet.b"},
+		{"inet-substring-name", "test.inet2.inet.0", "test.inet2"},
+		{"instance-named-like-table", "foo.inet.0.inet.0", "foo.inet.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseNextTableInstance(tc.table); got != tc.want {
+				t.Fatalf("parseNextTableInstance(%q) = %q, want %q", tc.table, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`parseNextTableInstance` (pkg/config/compiler_routing.go) extracted the routing-instance name from a Junos next-table target (`<instance>.<family>.<index>`) by truncating at the **first** `.inet` via `strings.Index`. Any accepted routing-instance name that itself contains `.inet` (e.g. `a.inet.b`, whose table is `a.inet.b.inet.0`) was truncated to `a` — the compiled next-table leak then pointed at the wrong or non-existent routing instance, silently misrouting/black-holing the leaked route while still passing the strict commit gate.

The family+index suffix is always trailing, so the fix anchors on the **last** `.inet` occurrence (`strings.LastIndex`). Ordinary single-`.inet` targets are unaffected (Index == LastIndex there); only multi-`.inet` dotted-instance names change, and they change to the correct full name.

## Change
- `strings.Index` → `strings.LastIndex` in `parseNextTableInstance` + expanded comment.
- New `TestParseNextTableInstanceDottedInstance_5632` (table-driven): ordinary v4/v6/nonzero-index/no-suffix regression guards + the dotted-instance bug cases.

## Validation
- **Fail-on-revert proven**: reverting to `strings.Index` flips the three dotted cases to FAIL (`a.inet.b.inet.0`→`a`, `test.inet2.inet.0`→`test`, `foo.inet.0.inet.0`→`foo`); `LastIndex` restores GREEN.
- Full `pkg/config` suite green; `go build ./...` clean; `gofmt` clean.
- No operator-facing contract changed (restores the documented next-table identity semantics) → no doc update needed.

Provenance: codex-review-181 root M24 (High), verified against origin/master cd1dea6ab.

Closes #5632