### PR TITLE
cli: reject scoped-looking global-only request clears

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46517,3 +46517,7 @@ top.
 - **Timestamp**: 2026-07-11
 - **Action**: Fix parseNextTableInstance dotted-instance truncation (#5632) — strings.Index → strings.LastIndex so a routing-instance name containing ".inet" keeps its full identity; add fail-on-revert unit test.
 - **File(s)**: pkg/config/compiler_routing.go, pkg/config/compiler_routing_nexttable_5632_test.go
+
+- **Timestamp**: 2026-07-11
+  - **Action**: #5647 (M40, codex-review-181) — reject scoped-looking OSPF/BGP/IPsec `request ... clear` suffixes instead of silently widening to a global reset. `request protocols ospf clear`, `... bgp clear`, and `request security ipsec sa clear` map to selector-FREE global daemon actions (vtysh `clear ip ospf process` / `clear bgp * soft` / strongSwan TerminateAllSAs). A trailing selector token (`... clear neighbor 10.0.0.1`, `... sa clear 42`) was silently dropped while the global reset still ran. Chose option (b) — reject at the CLI before the RPC — because no per-neighbor/per-SA plumbing exists (genuinely global-only actions; option (a) would be a new feature across FRR + strongSwan wiring). Fail-on-revert test proven RED (all 4 scoped cases fall through to global SystemAction when the guards are removed).
+  - **File(s)**: cmd/cli/request.go, cmd/cli/request_scope_5647_test.go, docs/phases.md

--- a/cmd/cli/request.go
+++ b/cmd/cli/request.go
@@ -319,6 +319,18 @@ func (c *ctl) handleRequestProtocols(args []string) error {
 			printRemoteTreeHelp("request protocols ospf:", "request", "protocols", "ospf")
 			return nil
 		}
+		// #5647: `ospf-clear` is a selector-free global reset (vtysh
+		// `clear ip ospf process`). A scoped-looking suffix such as
+		// `... clear neighbor 10.0.0.1` used to be silently dropped and
+		// still reset the WHOLE process. Junos never widens scope
+		// silently, so reject any trailing token BEFORE the RPC rather
+		// than perform an untargeted global mutation.
+		if len(args) > 2 {
+			return fmt.Errorf("request protocols ospf clear does not accept a "+
+				"selector (%q); it resets the entire OSPF process. Re-run "+
+				"without a selector to confirm the global clear",
+				strings.Join(args[2:], " "))
+		}
 		resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 			Action: "ospf-clear",
 		})
@@ -331,6 +343,16 @@ func (c *ctl) handleRequestProtocols(args []string) error {
 		if len(args) < 2 || args[1] != "clear" {
 			printRemoteTreeHelp("request protocols bgp:", "request", "protocols", "bgp")
 			return nil
+		}
+		// #5647: `bgp-clear` soft-clears EVERY BGP session (vtysh
+		// `clear bgp * soft`). Reject a scoped-looking suffix such as
+		// `... clear neighbor 10.0.0.1` instead of silently dropping the
+		// selector and soft-clearing all peers.
+		if len(args) > 2 {
+			return fmt.Errorf("request protocols bgp clear does not accept a "+
+				"selector (%q); it soft-clears every BGP session. Re-run "+
+				"without a selector to confirm the global clear",
+				strings.Join(args[2:], " "))
 		}
 		resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 			Action: "bgp-clear",
@@ -355,6 +377,16 @@ func (c *ctl) handleRequestSecurity(args []string) error {
 		if len(args) < 3 || args[1] != "sa" || args[2] != "clear" {
 			printRemoteTreeHelp("request security ipsec sa:", "request", "security", "ipsec", "sa")
 			return nil
+		}
+		// #5647: `ipsec-sa-clear` terminates EVERY IPsec SA
+		// (TerminateAllSAs). Reject a scoped-looking suffix such as
+		// `... sa clear 42` / `... sa clear tunnel foo` instead of
+		// silently dropping the selector and tearing down all SAs.
+		if len(args) > 3 {
+			return fmt.Errorf("request security ipsec sa clear does not accept a "+
+				"selector (%q); it terminates every IPsec SA. Re-run without a "+
+				"selector to confirm the global clear",
+				strings.Join(args[3:], " "))
 		}
 		resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 			Action: "ipsec-sa-clear",

--- a/cmd/cli/request_scope_5647_test.go
+++ b/cmd/cli/request_scope_5647_test.go
@@ -1,0 +1,139 @@
+// #5647: `request protocols ospf clear`, `request protocols bgp clear`, and
+// `request security ipsec sa clear` map to selector-FREE global mutations on
+// the daemon (vtysh `clear ip ospf process`, `clear bgp * soft`, and
+// strongSwan `TerminateAllSAs`). The server actions have no selector plumbing,
+// so a scoped-looking suffix (`... clear neighbor 10.0.0.1`, `... sa clear 42`)
+// used to be silently DROPPED while the global reset still ran — the operator
+// believed they scoped the action but every OSPF adjacency / BGP session / SA
+// was reset.
+//
+// Fix option (b) — reject the scoped-looking suffix at the CLI before the RPC,
+// because the downstream action is genuinely global-only (no per-neighbor /
+// per-SA plumbing exists in FRR/strongSwan wiring here). Junos never silently
+// widens scope.
+//
+// Goes RED on revert: delete the `len(args) > N` guards in
+// handleRequestProtocols / handleRequestSecurity and the scoped suffix falls
+// through to a global SystemAction (calls == 1, err == nil).
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// sysActionRecorder records SystemAction calls so a test can assert an
+// untargeted global reset was NOT issued.
+type sysActionRecorder struct {
+	pb.BpfrxServiceClient
+
+	calls   int
+	actions []string
+}
+
+func (f *sysActionRecorder) SystemAction(
+	_ context.Context, in *pb.SystemActionRequest, _ ...grpc.CallOption,
+) (*pb.SystemActionResponse, error) {
+	f.calls++
+	f.actions = append(f.actions, in.GetAction())
+	return &pb.SystemActionResponse{Message: "ok"}, nil
+}
+
+// A scoped-looking suffix on a global-only clear must ERROR before any RPC —
+// never fall through to a selector-free global mutation.
+func TestRequestScopedClearRejectedNotWidened_5647(t *testing.T) {
+	cases := []struct {
+		name string
+		// call dispatches the handler under test with the scoped-looking args.
+		call func(c *ctl) error
+	}{
+		{
+			name: "ospf clear neighbor",
+			call: func(c *ctl) error {
+				return c.handleRequestProtocols([]string{"ospf", "clear", "neighbor", "10.0.0.1"})
+			},
+		},
+		{
+			name: "bgp clear neighbor",
+			call: func(c *ctl) error {
+				return c.handleRequestProtocols([]string{"bgp", "clear", "neighbor", "10.0.0.1"})
+			},
+		},
+		{
+			name: "ipsec sa clear id",
+			call: func(c *ctl) error {
+				return c.handleRequestSecurity([]string{"ipsec", "sa", "clear", "42"})
+			},
+		},
+		{
+			name: "ipsec sa clear tunnel name",
+			call: func(c *ctl) error {
+				return c.handleRequestSecurity([]string{"ipsec", "sa", "clear", "tunnel", "gw-a"})
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &sysActionRecorder{}
+			c := &ctl{client: fake}
+
+			err := tc.call(c)
+			if err == nil {
+				t.Fatalf("%s: returned nil; expected a rejection error for a "+
+					"scoped-looking suffix on a global-only clear", tc.name)
+			}
+			if !strings.Contains(err.Error(), "does not accept a selector") {
+				t.Fatalf("%s: error %q missing the selector-rejection reason", tc.name, err)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("%s: SystemAction issued %d times (%v); expected 0 — a "+
+					"scoped-looking suffix must NOT trigger an untargeted global "+
+					"reset", tc.name, fake.calls, fake.actions)
+			}
+		})
+	}
+}
+
+// The well-formed global variants still send the correct action (no
+// regression): the bare, unscoped clears remain functional.
+func TestRequestUnscopedClearStillSends_5647(t *testing.T) {
+	cases := []struct {
+		name   string
+		call   func(c *ctl) error
+		action string
+	}{
+		{
+			name:   "ospf clear",
+			call:   func(c *ctl) error { return c.handleRequestProtocols([]string{"ospf", "clear"}) },
+			action: "ospf-clear",
+		},
+		{
+			name:   "bgp clear",
+			call:   func(c *ctl) error { return c.handleRequestProtocols([]string{"bgp", "clear"}) },
+			action: "bgp-clear",
+		},
+		{
+			name:   "ipsec sa clear",
+			call:   func(c *ctl) error { return c.handleRequestSecurity([]string{"ipsec", "sa", "clear"}) },
+			action: "ipsec-sa-clear",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &sysActionRecorder{}
+			c := &ctl{client: fake}
+			if err := tc.call(c); err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.name, err)
+			}
+			if fake.calls != 1 || fake.actions[0] != tc.action {
+				t.Fatalf("%s: calls=%d actions=%v; want 1 / [%s]",
+					tc.name, fake.calls, fake.actions, tc.action)
+			}
+		})
+	}
+}

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -379,6 +379,10 @@ Gap audit: `docs/archived/userspace-forwarding-and-failover-gap-audit.md` (PR #3
 - **CoS interface display:** `show class-of-service interface` shows per-interface filter bindings with term match/action
 - **BGP neighbor:** `show bgp neighbor <ip>` via FRR vtysh
 - **IPsec SA clear:** `request security ipsec sa clear` terminates all IKE SAs
+  (global-only; like `request protocols ospf clear` / `... bgp clear` these
+  reset the whole process and take NO selector. The CLI rejects a
+  scoped-looking suffix — e.g. `... sa clear <id>`, `... ospf clear neighbor
+  <ip>` — instead of silently widening it to a global reset, #5647)
 - **NAT counter clear:** `clear security nat statistics` zeros BPF nat_rule_counters
 - **Route summary enhanced:** Per-protocol breakdown (Direct/Local/Static/OSPF/BGP/IS-IS) with inet.0/inet6.0 sections
 - **ICMP type/code in CoS:** Filter terms now show icmp-type/icmp-code instead of "match any"


### PR DESCRIPTION
## Problem (#5647 / M40, codex-review-181)

`request protocols ospf clear`, `request protocols bgp clear`, and
`request security ipsec sa clear` map to **selector-free global** daemon
actions — vtysh `clear ip ospf process`, `clear bgp * soft`, and strongSwan
`TerminateAllSAs`. The CLI handlers (`cmd/cli/request.go`) validated only the
`clear` keyword and **ignored any trailing tokens**. A scoped-looking suffix
like:

- `request protocols ospf clear neighbor 10.0.0.1`
- `request protocols bgp clear neighbor 10.0.0.1`
- `request security ipsec sa clear 42` / `... sa clear tunnel gw-a`

was silently dropped while the **global** reset still ran. The operator
believed they targeted a single adjacency / peer / SA, but every OSPF
neighbor, BGP session, or IPsec SA was reset — a silent scope-widening on an
irreversible appliance action.

## Fix — option (b): reject at the CLI

The downstream actions are **genuinely global-only**: there is no
per-neighbor / per-SA plumbing in the proto (`SystemActionRequest`), the
server handlers (`server_diag_system_action.go`), or the FRR/strongSwan
wiring to honor a selector. Threading a selector through (option a) would be
a new feature spanning scoped vtysh clears and swanctl per-SA terminate —
out of scope for a scope-correctness fix.

So each handler now returns a clear `does not accept a selector` error naming
the dropped tokens and issues **no RPC**, instead of performing an untargeted
global mutation. Junos never silently widens scope. The bare, unscoped clears
are unchanged. This mirrors the #4883-C precedent (reject the malformed
scoped command before the SystemAction RPC).

## Validation

- `cmd/cli/request_scope_5647_test.go`: scoped cases now error with **0**
  `SystemAction` calls; unscoped clears still send `ospf-clear` / `bgp-clear`
  / `ipsec-sa-clear`.
- **RED-on-revert proven**: removing the `len(args) > N` guards lets all four
  scoped cases fall through to a global `SystemAction` (calls==1, err==nil).
- `go build ./...` and `go test ./cmd/cli/... ./pkg/grpcapi/...` green;
  touched files gofmt'd.
- `docs/phases.md` notes the global-only scope + selector rejection.

Closes #5647

🤖 Generated with [Claude Code](https://claude.com/claude-code)