### PR TITLE
config: require exactly one NAT rule terminal action (#5628)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-11 — #5628 (security): NAT rule `then` must carry exactly one terminal translation action
+- **Timestamp**: 2026-07-11 (fix/5628-nat-terminal-action)
+- **Action**: codex-review-181 M16. A source/destination NAT rule's complete
+  `then {}` block could carry ZERO NAT-terminal actions (actionless — snapshot
+  builder installs no translation, so an intended `off` exemption silently
+  disappears and a later broader rule is revealed) or TWO+ mutually-exclusive
+  actions (`off`+`pool`, `interface`+`pool` — compiler silently picked one by
+  packed-key/child order, so an exemption could publish as a translation).
+  Added `validateNATTerminalActionCardinalityStrict` (counts the resolved
+  NATThen terminal fields; requires exactly one) wired in `runUniformGates`:
+  strict reject on commit, lenient warn (`lenientNATTerminalAction`, #1960) on
+  tolerant load/peer-sync. Changed the `compileNAT{Source,Destination}`
+  hierarchical setters from `else if` chains to independent `if`s so a
+  single-node contradiction (`source-nat { interface; pool p; }`) records both
+  fields instead of silently picking one. PRESERVES #3850 duplicate-`then`-
+  CONTAINER last-wins (per-block `rule.Then` reset → count reflects the winning
+  block, not a false conflict). Fail-on-revert test proven RED (flat +
+  hierarchical zero/two/valid + #3850 last-wins preservation + lenient warn).
+  Adjusted #3606 canonical-port test to give its DNAT rule a valid terminal
+  action. `go build ./...` + full `go test ./...` green; gofmt clean.
+- **File(s)**: pkg/config/compiler_nat_source.go,
+  pkg/config/compiler_nat_destination.go,
+  pkg/config/compiler_validate_strict_nat.go,
+  pkg/config/compiler_uniformgates.go, pkg/config/compiler.go,
+  pkg/config/compiler_nat_terminal_action_5628_test.go,
+  pkg/config/compiler_signed_port_3606_test.go, docs/config-schema.md
+
 ## 2026-07-11 — #5140 (security): post-GRE-decap ICMP/host-inbound/TTL reads use packet_frame, not outer raw_frame
 - **Timestamp**: 2026-07-11 (fix/5140-gre-decap-packet-frame)
 - **Action**: `stage_native_gre_decap` returns a synthetic inner frame

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1083,6 +1083,33 @@ false-reject that valid Junos config (the #4191 class). It is a follow-up:
 model the rule-level persistent-nat leaves (or make an accept-with-advisory
 decision) FIRST, then flip.
 
+**Terminal-action CARDINALITY — NAT rule `then` (codex-review-181 M16, #5628).**
+The closed-world keyword audit above validates WHICH keywords may appear under
+`then`, but not HOW MANY translation actions a rule carries. A malformed or
+mixed-version rule could still present a complete `then {}` block with ZERO
+NAT-terminal actions (actionless — the snapshot builder installs no
+translation, so an intended `off` exemption silently disappears and a later
+broader rule is revealed) or TWO+ mutually-exclusive actions (`off` + `pool`,
+`interface` + `pool` — the compiler silently picked one by packed-key / child
+order, so an exemption could publish as a translation). `security nat
+{source,destination} rule … then` must therefore carry EXACTLY ONE NAT-terminal
+action (SNAT: `source-nat` `interface` | `pool <p>` | `off`; DNAT:
+`destination-nat` `pool <p>` | `off`). This is a cross-cutting cardinality rule
+the per-leaf schema walk cannot express, so it lives in the strict-gate family
+as `validateNATTerminalActionCardinalityStrict`
+(`compiler_validate_strict_nat.go`, wired in `runUniformGates`): strict on
+commit / commit-check, lenient (warn — `lenientNATTerminalAction`, #1960
+no-brick) on the tolerant load / peer-sync path. It counts actions WITHIN one
+complete `then` block — duplicate `then` CONTAINERS remain #3850's intentional
+last-wins merge (`compileNAT{Source,Destination}` reset `rule.Then` per block,
+so the count reflects the winning block) and are NOT rejected. The
+`compileNAT{Source,Destination}` hierarchical setters were changed from an
+`else if` chain to independent `if`s so a single-node contradiction
+(`source-nat { interface; pool p; }`) records both fields rather than silently
+picking one. Production tests:
+`compiler_nat_terminal_action_5628_test.go` (RED on revert, flat + hierarchical
+zero/two/valid + #3850 last-wins preservation).
+
 **More production flips — IPsec leaf-complete option containers (PR-C, #4313).**
 Three additional `security` subtrees now set `closedWorld:true`
 (`schema_security.go`), each after the same leaf-completeness audit — the

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1656,6 +1656,26 @@ type compileOpts struct {
 	// lenientDNATToScope.
 	lenientNATMixedScope bool
 
+	// lenientNATTerminalAction (#5628, codex-review-181 M16) downgrades the
+	// source/destination NAT terminal-action cardinality gate
+	// (validateNATTerminalActionCardinalityStrict) from a hard compile error to
+	// a cfg.Warnings entry. A NAT rule whose complete `then {}` block carries
+	// ZERO terminal actions (actionless — the snapshot builder installs no
+	// translation, so an intended `off` exemption silently disappears and a
+	// later broader rule is revealed) or TWO+ mutually-exclusive actions inside
+	// one block (`off` + `pool`, `interface` + `pool` — the compiler silently
+	// picks one by packed-key / child order, so an exemption can publish as a
+	// translation) was previously accepted. The strict commit / commit-check
+	// path hard-rejects so the malformed rule is operator-visible; the tolerant
+	// load / peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config an older binary accepted still BOOTS (#1960 fail-
+	// closed-on-load class) — a leniently-loaded actionless rule is inert and a
+	// contradictory one keeps the pre-#5628 field-precedence pick, so the
+	// tolerant path is no worse than before the gate. Duplicate `then`
+	// CONTAINERS remain #3850 last-wins (the gate counts the winning block
+	// only). Same doctrine as lenientNATMixedScope.
+	lenientNATTerminalAction bool
+
 	// lenientEventWithinTrigger (#3751) downgrades the event-options
 	// within/trigger numeric gate (validateEventOptionsWithinAST) from a hard
 	// compile error to a cfg.Warnings entry. A non-numeric / negative / zero /
@@ -1847,6 +1867,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
 		lenientNATMixedScope:                   true,
+		lenientNATTerminalAction:               true,
 		lenientEventWithinTrigger:              true,
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,
@@ -2119,6 +2140,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientVRRPVirtualAddress:              true,
 		lenientDNATToScope:                     true,
 		lenientNATMixedScope:                   true,
+		lenientNATTerminalAction:               true,
 		lenientEventWithinTrigger:              true,
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1669,11 +1669,14 @@ type compileOpts struct {
 	// path hard-rejects so the malformed rule is operator-visible; the tolerant
 	// load / peer-sync paths downgrade to a warning so an already-persisted or
 	// peer-synced config an older binary accepted still BOOTS (#1960 fail-
-	// closed-on-load class) — a leniently-loaded actionless rule is inert and a
-	// contradictory one keeps the pre-#5628 field-precedence pick, so the
-	// tolerant path is no worse than before the gate. Duplicate `then`
-	// CONTAINERS remain #3850 last-wins (the gate counts the winning block
-	// only). Same doctrine as lenientNATMixedScope.
+	// closed-on-load class) — a leniently-loaded actionless rule is inert, and a
+	// contradictory one now records BOTH fields (the else-if→if setter change),
+	// so the Rust dataplane's off-precedence governs its resolution (off wins →
+	// exempt), unifying the hierarchical path with the pre-existing flat-set
+	// both-fields behavior rather than the old Go single-field child-order pick.
+	// Only a malformed rule reaches this — the strict commit path rejects it.
+	// Duplicate `then` CONTAINERS remain #3850 last-wins (the gate counts the
+	// winning block only). Same doctrine as lenientNATMixedScope.
 	lenientNATTerminalAction bool
 
 	// lenientEventWithinTrigger (#3751) downgrades the event-options

--- a/pkg/config/compiler_nat_destination.go
+++ b/pkg/config/compiler_nat_destination.go
@@ -207,12 +207,23 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 						} else if len(t.Keys) >= 3 && t.Keys[1] == "pool" {
 							rule.Then.Type = NATDestination
 							rule.Then.PoolName = t.Keys[2]
-						} else if poolNode := t.FindChild("pool"); poolNode != nil {
-							rule.Then.Type = NATDestination
-							rule.Then.PoolName = nodeVal(poolNode)
-						} else if t.FindChild("off") != nil {
-							rule.Then.Type = NATDestination
-							rule.Then.Off = true
+						} else {
+							// #5628: read EVERY hierarchical terminal child, not
+							// the first one only (see the source-NAT note). A valid
+							// single-child block (`destination-nat { pool P; }` or
+							// `{ off; }`) is bit-identical; a contradictory
+							// `destination-nat { pool P; off; }` now sets BOTH
+							// fields so validateNATTerminalActionCardinalityStrict
+							// can reject it instead of the compiler silently
+							// picking pool by child order.
+							if poolNode := t.FindChild("pool"); poolNode != nil {
+								rule.Then.Type = NATDestination
+								rule.Then.PoolName = nodeVal(poolNode)
+							}
+							if t.FindChild("off") != nil {
+								rule.Then.Type = NATDestination
+								rule.Then.Off = true
+							}
 						}
 					}
 				}

--- a/pkg/config/compiler_nat_source.go
+++ b/pkg/config/compiler_nat_source.go
@@ -730,15 +730,31 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 									rule.Then.PoolName = t.Keys[2]
 								}
 							}
-						} else if t.FindChild("interface") != nil {
-							rule.Then.Type = NATSource
-							rule.Then.Interface = true
-						} else if t.FindChild("off") != nil {
-							rule.Then.Type = NATSource
-							rule.Then.Off = true
-						} else if poolNode := t.FindChild("pool"); poolNode != nil {
-							rule.Then.Type = NATSource
-							rule.Then.PoolName = nodeVal(poolNode)
+						} else {
+							// #5628: read EVERY hierarchical terminal child, not
+							// the first one only (the former `else if` chain
+							// silently picked interface > off > pool by child
+							// order). A well-formed `source-nat { pool P; }` still
+							// sets exactly one field, so this is bit-identical for
+							// a valid single-child block. A CONTRADICTORY
+							// single-node block such as `source-nat { interface;
+							// pool P; }` now sets BOTH fields, so the resolved
+							// NATThen faithfully carries two terminal actions and
+							// validateNATTerminalActionCardinalityStrict rejects it
+							// (strict commit) / warns (tolerant load) instead of
+							// silently reinterpreting it.
+							if t.FindChild("interface") != nil {
+								rule.Then.Type = NATSource
+								rule.Then.Interface = true
+							}
+							if t.FindChild("off") != nil {
+								rule.Then.Type = NATSource
+								rule.Then.Off = true
+							}
+							if poolNode := t.FindChild("pool"); poolNode != nil {
+								rule.Then.Type = NATSource
+								rule.Then.PoolName = nodeVal(poolNode)
+							}
 						}
 					}
 				}

--- a/pkg/config/compiler_nat_terminal_action_5628_test.go
+++ b/pkg/config/compiler_nat_terminal_action_5628_test.go
@@ -1,0 +1,340 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5628 (codex-review-181 M16): a source- or destination-NAT rule's complete
+// `then {}` block must carry EXACTLY ONE NAT-terminal translation action —
+// SNAT: `source-nat interface` | `source-nat pool <p>` | `source-nat off`;
+// DNAT: `destination-nat pool <p>` | `destination-nat off`. Before the fix the
+// schema permitted a block with ZERO actions (actionless: the snapshot builder
+// installs no translation, so an intended `off` exemption silently disappears
+// and a later broader rule is revealed) or TWO+ mutually-exclusive actions (the
+// compiler silently picked one by packed-key / child order, so an exemption
+// could publish as a translation — the inverse of the authored action).
+//
+// validateNATTerminalActionCardinalityStrict hard-rejects both at strict commit
+// (CompileConfig); the tolerant load / peer-sync path (CompileConfigLenient)
+// downgrades to a warning (#1960 no-brick). Duplicate `then` CONTAINERS remain
+// #3850's intentional last-wins merge and must NOT be rejected.
+//
+// RED on revert: reverting the gate (validateNATTerminalActionCardinalityStrict
+// + its runUniformGates call) makes CompileConfig ACCEPT the zero/two-action
+// configs, so every "want reject" case fails; reverting the compiler_nat_source
+// / compiler_nat_destination hierarchical setter change (independent `if`s back
+// to the `else if` chain) makes a single-node `source-nat { interface; pool p }`
+// resolve to one field again, so the hierarchical two-action cases fail.
+
+// compileHier parses hierarchical Junos text and strict-compiles it.
+func compileHier5628(t *testing.T, cfgText string) (*Config, error) {
+	t.Helper()
+	p := NewParser(cfgText)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	return CompileConfig(tree)
+}
+
+// wantCardinalityReject asserts CompileConfig rejected with the #5628 message.
+func wantCardinalityReject5628(t *testing.T, name string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: CompileConfig ACCEPTED a malformed NAT `then` block; want a "+
+			"#5628 terminal-action-cardinality rejection (RED on revert: pre-fix "+
+			"accepted 0/2 actions)", name)
+	}
+	if !strings.Contains(err.Error(), "translation action") {
+		t.Fatalf("%s: CompileConfig rejected with the wrong error %q; want the #5628 "+
+			"terminal-action-cardinality message", name, err.Error())
+	}
+}
+
+// --- VALID single-action rules must COMPILE clean (flat + hierarchical) ------
+
+func TestNATTerminalActionValidSingle_5628(t *testing.T) {
+	// Flat SNAT: exactly one `source-nat interface`.
+	flatSNAT := buildTree(t, []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat interface",
+	})
+	if _, err := CompileConfig(flatSNAT); err != nil {
+		t.Fatalf("flat single-action SNAT rejected: %v", err)
+	}
+
+	// Flat DNAT: exactly one `destination-nat off`.
+	flatDNAT := buildTree(t, []string{
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 198.51.100.1/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat off",
+	})
+	if _, err := CompileConfig(flatDNAT); err != nil {
+		t.Fatalf("flat single-action DNAT rejected: %v", err)
+	}
+
+	// Hierarchical SNAT: exactly one `source-nat pool p`.
+	if _, err := compileHier5628(t, `
+security {
+    nat {
+        source {
+            pool p { address 5.6.7.8; }
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat pool p; }
+                }
+            }
+        }
+    }
+}`); err != nil {
+		t.Fatalf("hierarchical single-action SNAT rejected: %v", err)
+	}
+
+	// Hierarchical DNAT: exactly one `destination-nat pool p`.
+	if _, err := compileHier5628(t, `
+security {
+    nat {
+        destination {
+            pool p { address 10.0.30.100; }
+            rule-set RD {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 198.51.100.1/32; }
+                    then { destination-nat pool p; }
+                }
+            }
+        }
+    }
+}`); err != nil {
+		t.Fatalf("hierarchical single-action DNAT rejected: %v", err)
+	}
+}
+
+// --- ZERO-action rules must be REJECTED (flat + hierarchical) ----------------
+
+func TestNATTerminalActionZeroRejected_5628(t *testing.T) {
+	// Flat SNAT: a rule with a match but NO `then` action.
+	flatSNAT := buildTree(t, []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+	})
+	_, err := CompileConfig(flatSNAT)
+	wantCardinalityReject5628(t, "flat zero-action SNAT", err)
+
+	// Flat DNAT: a rule with a match but NO `then` action.
+	flatDNAT := buildTree(t, []string{
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 198.51.100.1/32",
+	})
+	_, err = CompileConfig(flatDNAT)
+	wantCardinalityReject5628(t, "flat zero-action DNAT", err)
+
+	// Hierarchical SNAT: an empty `then {}` block.
+	_, err = compileHier5628(t, `
+security {
+    nat {
+        source {
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { }
+                }
+            }
+        }
+    }
+}`)
+	wantCardinalityReject5628(t, "hierarchical zero-action SNAT", err)
+
+	// Hierarchical DNAT: a rule with a match but no `then`.
+	_, err = compileHier5628(t, `
+security {
+    nat {
+        destination {
+            rule-set RD {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 198.51.100.1/32; }
+                }
+            }
+        }
+    }
+}`)
+	wantCardinalityReject5628(t, "hierarchical zero-action DNAT", err)
+}
+
+// --- TWO-action rules must be REJECTED (flat + hierarchical) -----------------
+
+func TestNATTerminalActionTwoRejected_5628(t *testing.T) {
+	// Flat SNAT: `source-nat interface` + `source-nat off` in one rule. SetPath
+	// merges the two `then source-nat ...` lines into ONE source-nat node with
+	// two children (interface, off) — a single complete then-block carrying two
+	// mutually-exclusive actions.
+	flatSNAT := buildTree(t, []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat interface",
+		"set security nat source rule-set RS rule R1 then source-nat off",
+	})
+	_, err := CompileConfig(flatSNAT)
+	wantCardinalityReject5628(t, "flat two-action SNAT (interface+off)", err)
+
+	// Flat DNAT: `destination-nat off` + `destination-nat pool p1` in one rule.
+	flatDNAT := buildTree(t, []string{
+		"set security nat destination pool p1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 198.51.100.1/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat off",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool p1",
+	})
+	_, err = CompileConfig(flatDNAT)
+	wantCardinalityReject5628(t, "flat two-action DNAT (off+pool)", err)
+
+	// Hierarchical SNAT: a single `source-nat { interface; pool p; }` node. The
+	// pre-#5628 else-if setter silently picked interface; the independent-if
+	// setter now records both fields so the gate rejects.
+	_, err = compileHier5628(t, `
+security {
+    nat {
+        source {
+            pool p { address 5.6.7.8; }
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat { interface; pool p; } }
+                }
+            }
+        }
+    }
+}`)
+	wantCardinalityReject5628(t, "hierarchical two-action SNAT (interface+pool one node)", err)
+
+	// Hierarchical DNAT: a single `destination-nat { pool p; off; }` node.
+	_, err = compileHier5628(t, `
+security {
+    nat {
+        destination {
+            pool p { address 10.0.30.100; }
+            rule-set RD {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 198.51.100.1/32; }
+                    then { destination-nat { pool p; off; } }
+                }
+            }
+        }
+    }
+}`)
+	wantCardinalityReject5628(t, "hierarchical two-action DNAT (pool+off one node)", err)
+}
+
+// --- #3850 duplicate `then` CONTAINERS must NOT be false-rejected -----------
+
+// TestNATTerminalActionDup3850LastWins_5628 pins that the cardinality gate does
+// NOT reject a rule merely because it has two `then` CONTAINERS. Two `then`
+// blocks each naming ONE source-nat action resolve last-wins (#3850): the
+// compiler resets rule.Then per block, so the winning block carries exactly one
+// action. This must compile AND resolve to the LAST block's pool.
+func TestNATTerminalActionDup3850LastWins_5628(t *testing.T) {
+	cfg, err := compileHier5628(t, `
+security {
+    nat {
+        source {
+            pool poolB { address 5.6.7.8; }
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat interface; }
+                    then { source-nat pool poolB; }
+                }
+            }
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("#3850 duplicate-then-container rule FALSE-REJECTED by the #5628 gate "+
+			"(must be last-wins, not a conflict): %v", err)
+	}
+	if len(cfg.Security.NAT.Source) == 0 || len(cfg.Security.NAT.Source[0].Rules) == 0 {
+		t.Fatalf("no source NAT rule compiled")
+	}
+	r := cfg.Security.NAT.Source[0].Rules[0]
+	if r.Then.PoolName != "poolB" || r.Then.Interface {
+		t.Fatalf("#3850 last-wins broken: Then={Interface:%v PoolName:%q}, want "+
+			"{false poolB} (second then block wins, first block's interface cleared)",
+			r.Then.Interface, r.Then.PoolName)
+	}
+}
+
+// TestNATTerminalActionDupIdenticalPool3850_5628 pins that two `then` containers
+// naming the SAME pool also commit (last-wins to that pool, count one).
+func TestNATTerminalActionDupIdenticalPool3850_5628(t *testing.T) {
+	cfg, err := compileHier5628(t, `
+security {
+    nat {
+        destination {
+            pool p1 { address 10.0.30.100; }
+            rule-set RD {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 198.51.100.1/32; }
+                    then { destination-nat pool p1; }
+                    then { destination-nat pool p1; }
+                }
+            }
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("#3850 duplicate identical-pool then-containers false-rejected: %v", err)
+	}
+	r := cfg.Security.NAT.Destination.RuleSets[0].Rules[0]
+	if r.Then.PoolName != "p1" {
+		t.Fatalf("duplicate identical-pool: PoolName=%q, want p1", r.Then.PoolName)
+	}
+}
+
+// --- Tolerant load / peer-sync path WARNS, never bricks (#1960) --------------
+
+func TestNATTerminalActionLenientWarns_5628(t *testing.T) {
+	// A zero-action DNAT rule that strict-rejects must instead WARN-and-compile
+	// on the tolerant path so an already-persisted / peer-synced config boots.
+	flatDNAT := buildTree(t, []string{
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 198.51.100.1/32",
+	})
+	// Strict rejects.
+	if _, err := CompileConfig(flatDNAT); err == nil {
+		t.Fatal("strict CompileConfig must reject the zero-action DNAT rule")
+	}
+	// Lenient warns and compiles.
+	cfg, err := CompileConfigLenient(flatDNAT)
+	if err != nil {
+		t.Fatalf("tolerant CompileConfigLenient must NOT brick on a zero-action rule "+
+			"(#1960 no-brick): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "NAT terminal-action cardinality") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("tolerant path must record a NAT terminal-action-cardinality "+
+			"downgrade warning; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_signed_port_3606_test.go
+++ b/pkg/config/compiler_signed_port_3606_test.go
@@ -102,7 +102,13 @@ func TestCanonicalPortStillCompiles_3606(t *testing.T) {
 		{"set applications application a1 protocol tcp", "set applications application a1 destination-port http"},
 		{"set firewall family inet filter f1 term t1 from destination-port 22"},
 		{"set firewall family inet filter f1 term t1 from destination-port 1024-2048"},
-		{"set security nat destination rule-set RS rule R1 match destination-port 8080"},
+		// #5628: a DNAT rule now requires exactly one `then` terminal action;
+		// `then destination-nat off` keeps this a well-formed rule while still
+		// exercising canonical destination-port parsing.
+		{
+			"set security nat destination rule-set RS rule R1 match destination-port 8080",
+			"set security nat destination rule-set RS rule R1 then destination-nat off",
+		},
 		{
 			"set security nat destination pool p1 address 192.168.1.10",
 			"set security nat destination pool p1 port 8080",

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1497,6 +1497,26 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5628 (codex-review-181 M16): a source / destination NAT rule's complete
+	// `then` block must carry EXACTLY ONE NAT-terminal translation action. A
+	// rule with ZERO actions installs no translation (an intended `off`
+	// exemption silently disappears, revealing a later broader rule); a rule
+	// with TWO+ mutually-exclusive actions inside one block let the compiler
+	// silently pick one by packed-key/child order (an exemption can publish as a
+	// translation — the inverse of the authored action). Strict on commit /
+	// commit-check (hard reject so the malformed rule is operator-visible);
+	// lenient on load / peer-sync (warn — #1960 no-brick; the dataplane is no
+	// worse than before the gate). Preserves #3850 duplicate-`then`-CONTAINER
+	// last-wins (the count reflects the winning block only).
+	if err := validateNATTerminalActionCardinalityStrict(cfg); err != nil {
+		if opts.lenientNATTerminalAction {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("NAT terminal-action cardinality (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2217 Finding C: firewall-filter `then routing-instance <name>` (FBF)
 	// cross-reference. A term naming a routing-instance not defined under
 	// `routing-instances` compiled cleanly and the dataplane steered matched

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1523,9 +1523,12 @@ func natThenTerminalActionCount(then NATThen) int {
 // commits. Strict on commit / commit-check (hard reject so the malformed rule
 // is operator-visible); the caller downgrades to a warning on the tolerant load
 // / peer-sync path (opts.lenientNATTerminalAction, #1960 no-brick) — a
-// leniently-loaded actionless rule is inert (installs nothing) and a
-// contradictory one keeps the pre-#5628 field-precedence pick, so the tolerant
-// path is no worse than before the gate. Rule-sets are walked in sorted name
+// leniently-loaded actionless rule is inert (installs nothing), and a
+// contradictory one now records BOTH fields (the else-if→if setter change), so
+// the Rust dataplane's off-precedence governs (off wins → exempt) — unifying
+// the hierarchical path with the pre-existing flat-set both-fields behavior
+// rather than the old Go single-field pick; only a malformed rule reaches this
+// path (the strict commit path rejects it). Rule-sets are walked in sorted name
 // order for a deterministic first-reported offender.
 func validateNATTerminalActionCardinalityStrict(cfg *Config) error {
 	if cfg == nil {

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1472,3 +1472,114 @@ func validateStaticNATThenTargetStrict(cfg *Config) error {
 	}
 	return nil
 }
+
+// natThenTerminalActionCount returns how many mutually-exclusive NAT-terminal
+// translation actions a resolved NATThen carries: source-nat `interface`,
+// `off`, or a `pool <name>` for source NAT; `off` or a `pool <name>` for
+// destination NAT (destination NAT never sets Interface). Exactly one of these
+// is the well-formed case. Because compileNATSource/compileNATDestination RESET
+// `rule.Then` at the top of each complete `then {}` block (#3850 last-wins),
+// this count reflects only the WINNING (last) block — duplicate `then`
+// CONTAINERS that each carry a single action resolve to one action here, never
+// a false conflict. A count of two only arises when one complete then-block
+// carries contradictory actions (e.g. `off` + `pool`, or a single hierarchical
+// `source-nat { interface; pool P; }` node, which #5628's setter change now
+// records as two set fields rather than silently picking one by child order).
+func natThenTerminalActionCount(then NATThen) int {
+	n := 0
+	if then.Interface {
+		n++
+	}
+	if then.Off {
+		n++
+	}
+	if then.PoolName != "" {
+		n++
+	}
+	return n
+}
+
+// validateNATTerminalActionCardinalityStrict (#5628, codex-review-181 M16)
+// hard-rejects a source- or destination-NAT rule whose complete `then {}` block
+// does not carry EXACTLY ONE NAT-terminal translation action:
+//
+//   - ZERO actions (an actionless rule, or a `then {}` whose only child is not a
+//     recognized source-nat/destination-nat terminal): the rule commits but the
+//     snapshot builder installs no translation, so matching traffic falls
+//     through to a later, broader rule — an intended `off` exemption silently
+//     disappears (the #3844 fail-open class).
+//
+//   - TWO OR MORE actions (contradictory, mutually-exclusive translations such
+//     as `off` + `pool` or `interface` + `pool` inside ONE block): the actions
+//     are mutually exclusive and the compiler would otherwise pick one by
+//     packed-key / child order, so an intended exemption can publish as a
+//     translation (the inverse of the authored action — a security-boundary
+//     decision).
+//
+// This counts actions WITHIN one complete then-block only. Duplicate `then`
+// CONTAINERS are #3850's intentional last-wins merge (compileNAT resets
+// rule.Then per block, so the count reflects the winning block) and are NOT
+// rejected here — a rule with two `then` blocks each naming one action still
+// commits. Strict on commit / commit-check (hard reject so the malformed rule
+// is operator-visible); the caller downgrades to a warning on the tolerant load
+// / peer-sync path (opts.lenientNATTerminalAction, #1960 no-brick) — a
+// leniently-loaded actionless rule is inert (installs nothing) and a
+// contradictory one keeps the pre-#5628 field-precedence pick, so the tolerant
+// path is no worse than before the gate. Rule-sets are walked in sorted name
+// order for a deterministic first-reported offender.
+func validateNATTerminalActionCardinalityStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(kind, actions string, rulesets []*NATRuleSet) error {
+		sorted := append([]*NATRuleSet(nil), rulesets...)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			if sorted[i] == nil || sorted[j] == nil {
+				return sorted[i] != nil
+			}
+			return sorted[i].Name < sorted[j].Name
+		})
+		for _, rs := range sorted {
+			if rs == nil {
+				continue
+			}
+			for _, rule := range rs.Rules {
+				if rule == nil {
+					continue
+				}
+				switch n := natThenTerminalActionCount(rule.Then); {
+				case n == 0:
+					return fmt.Errorf(
+						"%s-nat rule-set %q rule %q: `then` carries no translation action "+
+							"(expected exactly one of %s); the rule would commit but installs no "+
+							"translation, so matching traffic falls through to a later broader "+
+							"rule — an intended exemption silently disappears",
+						kind, rs.Name, rule.Name, actions)
+				case n >= 2:
+					return fmt.Errorf(
+						"%s-nat rule-set %q rule %q: `then` carries %d mutually-exclusive "+
+							"translation actions (expected exactly one of %s); the compiler would "+
+							"silently pick one by packed-key/child order, so an intended exemption "+
+							"can publish as a translation. (Duplicate `then` CONTAINERS resolve "+
+							"last-wins per #3850; this rejects contradictory actions inside one "+
+							"block.)",
+						kind, rs.Name, rule.Name, n, actions)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("source",
+		"`source-nat interface`, `source-nat pool <p>`, or `source-nat off`",
+		cfg.Security.NAT.Source); err != nil {
+		return err
+	}
+	if cfg.Security.NAT.Destination != nil {
+		if err := check("destination",
+			"`destination-nat pool <p>` or `destination-nat off`",
+			cfg.Security.NAT.Destination.RuleSets); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #5628 (codex-review-181 M16, Medium — security-adjacent: NAT exemption/translation correctness).

## Problem
A source- or destination-NAT rule's complete `then {}` block could carry **ZERO** or **TWO+** NAT-terminal translation actions and still commit. The schema permitted the container; `compileNAT{Source,Destination}` then silently resolved the action by packed-key / child order, and the runtime first-match executed that pick.

- **ZERO actions** (actionless): the snapshot builder installs no translation, so an intended `off` exemption silently disappears and matching traffic falls through to a later, broader rule (the #3844 fail-open class).
- **TWO+ actions** (`off`+`pool`, `interface`+`pool`): the compiler published the inverse of the authored action — an exemption compiled to a translation, changing which internal/backend address is exposed. Translation vs exemption is a security-boundary decision.

## Fix
- **`validateNATTerminalActionCardinalityStrict`** (`compiler_validate_strict_nat.go`), wired in `runUniformGates`: counts the resolved `NATThen` terminal fields and requires **exactly one** per rule. Strict reject on commit / commit-check; lenient **warn** on the tolerant load / peer-sync path (`lenientNATTerminalAction`, #1960 no-brick).
- **Setter change**: `compileNAT{Source,Destination}` hierarchical then-child handling goes from an `else if` chain to independent `if`s, so a single-node contradiction (`source-nat { interface; pool p; }`) records *both* fields instead of silently picking the first by child order. A valid single-child block is bit-identical.

## Enumerated NAT-terminal actions (confirmed from code)
- **SNAT** (`source-nat`): `interface` | `pool <p>` | `off`
- **DNAT** (`destination-nat`): `pool <p>` | `off`

## #3850 duplicate-container last-wins — PRESERVED
`compileNAT` resets `rule.Then` at the top of each complete `then` block, so the cardinality count reflects only the **winning** block. Two `then` CONTAINERS each naming one action still commit (last-wins), never a false conflict — only contradictory actions **inside one block** are rejected. Covered by `TestNATTerminalActionDup3850LastWins_5628` (asserts `interface` → `pool` two-container rule compiles and resolves to `poolB`, `Interface=false`).

## Validation
- New fail-on-revert test `compiler_nat_terminal_action_5628_test.go` proven **RED on revert**: with the gate + setter change stashed, the zero-action, two-action, and lenient-warn cases FAIL (pre-fix accepts 0/2) while valid-single and #3850 last-wins stay green — in **both** flat (`ParseSetCommand`+`SetPath`) and hierarchical ASTs.
- Adjusted the #3606 canonical-port test (its DNAT rule previously relied on an actionless rule; now given a valid `then destination-nat off`).
- `go build ./...` + full `go test ./...` green (54 pkgs); `gofmt` clean; `TestEveryStrictCommitGateIsWired` canary passes.
- `docs/config-schema.md` updated (NAT then-action cardinality section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)