### PR TITLE
config: validate IPsec gateway endpoints at strict commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46558,3 +46558,32 @@ top.
   all six config tests FAIL (empty secret commits with nil error / no lenient
   warning); reverting the two middleware guards makes the three api tests FAIL
   (empty password → 200, empty api-key matched). Restoring each → GREEN.
+
+## #5630 — IPsec typed endpoints bypass IP/FQDN validation (codex-181 M20)
+- **Timestamp**: 2026-07-11
+- **Action**: Add strict-commit validation for every effective IPsec endpoint
+  (IKE gateway address / dynamic hostname / local-address, and VPN
+  local-address). A printable-but-invalid endpoint (a malformed IP octet like
+  10.0.0.999, or a malformed FQDN) used to pass strict commit and be
+  interpolated verbatim into swanctl remote_addrs/local_addrs, where
+  `swanctl --load-all` rejects/mishandles it — a config that commits but never
+  loads (silently broken tunnel). New validateIPsecEndpointsStrict reuses the
+  existing IsUsableIPsecEndpoint predicate (same one #2074 applies to the inline
+  literal); hardened isPlausibleHostname to reject an all-numeric rightmost
+  label (RFC 3696 §2) so a botched IP like 10.0.0.999 no longer masquerades as a
+  hostname. Strict on commit/commit-check, warn on lenient load/peer-sync
+  (lenientIPsecEndpoints, #1960 doctrine). Valid IPv4/IPv6/FQDN endpoints still
+  commit + render.
+- **File(s)**: pkg/config/compiler_validate_strict_ipsec.go
+  (validateIPsecEndpointsStrict), pkg/config/compiler_ipsec.go
+  (isPlausibleHostname all-numeric-TLD gate), pkg/config/compiler.go
+  (lenientIPsecEndpoints opt + set at both tolerant sites),
+  pkg/config/compiler_uniformgates.go (wire strict/lenient gate),
+  pkg/config/compiler_ipsec_endpoint_5630_test.go,
+  pkg/ipsec/endpoint_render_5630_test.go,
+  docs/pr/5630-ipsec-endpoint-validate/plan.md.
+- **Validation**: `go build ./...` clean; `go test ./pkg/config/... ./pkg/ipsec/...`
+  green; gofmt clean. RED-on-revert proven two ways: (A) neutralizing
+  validateIPsecEndpointsStrict → all reject cases FAIL; (B) reverting the
+  isPlausibleHostname hardening (validator kept) → the 10.0.0.999 / 1.2.3.4.5
+  cases FAIL while structurally-malformed FQDNs stay caught. Restoring → GREEN.

--- a/docs/pr/5630-ipsec-endpoint-validate/plan.md
+++ b/docs/pr/5630-ipsec-endpoint-validate/plan.md
@@ -1,0 +1,96 @@
+# #5630 — IPsec typed endpoints bypass IP/FQDN validation
+
+**Status:** IMPLEMENTED. codex-review-181 root M20 (`A3-b01-F002`,
+Medium, CONFIRMED MATERIAL). Companion to #2074, which validates the
+VPN→gateway *reference* but never the typed endpoint *values*.
+
+## Problem
+
+`compileIKE` / `compileIPsec` (`pkg/config/compiler_ipsec.go`) copy the
+IKE-gateway endpoint leaves verbatim from a one-argument schema slot:
+
+- gateway `address`          → `gw.Address`      → swanctl `remote_addrs`
+- gateway `dynamic hostname` → `gw.DynamicHostname` → swanctl `remote_addrs`
+- gateway `local-address`    → `gw.LocalAddress` → swanctl `local_addrs`
+- vpn `local-address`        → `vpn.LocalAddr`   → swanctl `local_addrs`
+
+`renderConfig` (`pkg/ipsec/policy.go`, `resolveRemoteAddr`) interpolates
+those values straight into the generated swanctl.conf. The only
+commit-time gate, `validateIPsecGatewayReferencesStrict` (#2074), checked
+that a referenced gateway is *nonempty* — never that its endpoint value
+is a usable IP or hostname. A printable-but-invalid endpoint therefore
+passed strict commit and reached strongSwan, where `swanctl --load-all`
+rejects or mishandles the connection: **a config that commits but never
+loads is a silently broken tunnel.**
+
+The `IsUsableIPsecEndpoint` predicate already existed but was applied
+*only* to an inline `vpn.Gateway` literal, not to the typed object
+fields or the local endpoints.
+
+> Scope: this is the endpoint *outage / invalid-value* class only (per
+> the coordinator's narrowed M20 wording). It is **not** a newline /
+> config-injection claim — control characters are already handled by the
+> global control-char gate + `sanitizeSwanctlValue` render belt.
+
+## Fix
+
+Two changes, both in `pkg/config`:
+
+1. **`validateIPsecEndpointsStrict(cfg)`** (`compiler_validate_strict_ipsec.go`):
+   a strict-accumulator validator on the fully-compiled `*Config` that
+   runs the four effective endpoint fields through `IsUsableIPsecEndpoint`
+   (the same predicate #2074 uses for the inline literal). Wired into the
+   strict-validator chain in `compiler_uniformgates.go` right after the
+   gateway-reference gate, with a `lenientIPsecEndpoints` downgrade — hard
+   reject on commit / commit-check, warn on the tolerant load / peer-sync
+   paths (#1960 fail-closed-on-load doctrine). Exactly the
+   `validateIPsecGatewayReferencesStrict` template.
+
+2. **`isPlausibleHostname` hardening** (`compiler_ipsec.go`): reject a
+   hostname whose rightmost (top-level) label is entirely numeric (RFC
+   3696 §2 / RFC 1123 §2.1). Without this, a botched IPv4 literal such as
+   `10.0.0.999` (fails `net.ParseIP` because 999 > 255) was otherwise a
+   run of digit-only labels and masqueraded as a "plausible hostname",
+   slipping past `IsUsableIPsecEndpoint`. This is the exact issue repro.
+   A valid IPv4/IPv6 literal is accepted by the `net.ParseIP` branch
+   *before* the hostname scan, so real address literals are unaffected;
+   this also closes the same `10.0.0.999`-as-inline-gateway hole in
+   `validateIPsecGatewayReferencesStrict`.
+
+## What is accepted / rejected (matches strongSwan)
+
+- **Accepted:** literal IPv4 (`203.0.113.1`), literal IPv6 (`2001:db8::1`),
+  dotted FQDN (`peer.example.com`), absolute FQDN with a trailing root dot
+  (`peer.example.com.`). These are exactly the forms strongSwan's
+  `remote_addrs`/`local_addrs` resolve, so a legitimate hostname or v6
+  gateway still commits and renders unchanged.
+- **Rejected:** a value that is neither a parseable IP nor a
+  syntactically valid hostname — a malformed IP octet (`10.0.0.999`),
+  too many octets (`1.2.3.4.5`), or a malformed FQDN (`bad..host`,
+  `-bad.example.com`, an underscore, an all-numeric TLD). strongSwan
+  itself would reject or fail to resolve these, so this does not invent a
+  stricter rule than the downstream parser enforces.
+
+Single-label bare hostnames (`vpnpeer`) remain rejected — unchanged,
+intentional, and documented #2074 behavior (define a proper gateway
+`address`/`dynamic hostname` instead).
+
+## Tests
+
+- `pkg/config/compiler_ipsec_endpoint_5630_test.go` —
+  `TestValidateIPsecEndpoints_{Reject,Accept,Lenient}`: malformed
+  endpoints (bad IP octet, five octets, bad FQDN, bad dynamic hostname,
+  bad gateway/vpn local-address) are rejected at strict commit; valid
+  IPv4/IPv6/FQDN remote + local endpoints still commit; the tolerant
+  paths warn instead of failing. Flat-set `ParseSetCommand` + `SetPath`
+  per CLAUDE.md.
+- `pkg/ipsec/endpoint_render_5630_test.go` —
+  `TestRenderValidEndpoints_5630`: valid IPv4/IPv6/FQDN endpoints render
+  into `remote_addrs`/`local_addrs` unchanged.
+
+RED-on-revert verified two ways: neutralizing
+`validateIPsecEndpointsStrict` turns every reject case RED; reverting the
+`isPlausibleHostname` all-numeric-TLD hardening (validator kept) turns the
+`10.0.0.999` / `1.2.3.4.5` cases RED while the structurally-malformed FQDN
+cases stay caught — proving the hostname hardening is load-bearing for the
+exact repro.

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -324,6 +324,21 @@ type compileOpts struct {
 	// lenientIPsecPolicyProposalRef.
 	lenientIKEPolicyChainRef bool
 
+	// lenientIPsecEndpoints (#5630) downgrades the IPsec endpoint value gate
+	// (validateIPsecEndpointsStrict) from a hard compile error to a
+	// cfg.Warnings entry on the tolerant load / peer-sync paths. An IKE
+	// gateway `address` / `dynamic hostname` / `local-address`, or a VPN
+	// `local-address`, that is printable but not a usable strongSwan endpoint
+	// (neither a literal IP nor a valid dotted hostname/FQDN — e.g. a
+	// malformed IP octet 10.0.0.999 or a malformed FQDN) is copied verbatim
+	// into swanctl `remote_addrs` / `local_addrs`, where `swanctl --load-all`
+	// rejects or mishandles it — a config that commits but never loads (a
+	// silently broken tunnel). Commit / commit-check hard-reject it so a new
+	// operator edit fails loudly; an already-persisted or peer-synced config
+	// an older binary accepted must still BOOT (warn) per the #1960
+	// fail-closed-on-load doctrine. Same doctrine as lenientIPsecGatewayRefs.
+	lenientIPsecEndpoints bool
+
 	// lenientIPsecTrafficSelectors (#4098) downgrades the IPsec
 	// `traffic-selector local-ip / remote-ip` value gate
 	// (validateIPsecTrafficSelectorsStrict) from a hard compile error to a
@@ -1760,6 +1775,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientCoSForwardingClassQueue:         true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
+		lenientIPsecEndpoints:                  true,
 		lenientIPsecTrafficSelectors:           true,
 		lenientReservedProposalSetNames:        true,
 		lenientIPsecProposalProtocol:           true,
@@ -2104,6 +2120,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientCoSForwardingClassQueue:         true,
 		lenientIPsecGatewayRefs:                true,
 		lenientIKEPolicyChainRef:               true,
+		lenientIPsecEndpoints:                  true,
 		lenientIPsecTrafficSelectors:           true,
 		lenientReservedProposalSetNames:        true,
 		lenientIPsecProposalProtocol:           true,

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -677,5 +677,28 @@ func isPlausibleHostname(s string) bool {
 	if s[len(s)-1] == '-' {
 		return false
 	}
+	// RFC 3696 §2 / RFC 1123 §2.1: the rightmost (top-level) label of a
+	// hostname must not be entirely numeric — that is the rule that
+	// disambiguates a hostname from a dotted-decimal IPv4 literal. A botched
+	// IP such as "10.0.0.999" fails net.ParseIP (999 > 255) yet is otherwise
+	// a run of digit-only labels, so without this gate it masquerades as a
+	// "plausible hostname", passes endpoint validation, and then fails to
+	// resolve when strongSwan loads the generated remote_addrs — a config
+	// that commits but never establishes the tunnel (#5630). Reject an
+	// all-numeric last label. A valid IPv4/IPv6 literal is already accepted
+	// by the net.ParseIP branch in IsUsableIPsecEndpoint before this scan is
+	// reached, so real address literals are unaffected.
+	lastDot := strings.LastIndexByte(s, '.')
+	tld := s[lastDot+1:]
+	allNumeric := true
+	for i := 0; i < len(tld); i++ {
+		if tld[i] < '0' || tld[i] > '9' {
+			allNumeric = false
+			break
+		}
+	}
+	if allNumeric {
+		return false
+	}
 	return true
 }

--- a/pkg/config/compiler_ipsec_endpoint_5630_test.go
+++ b/pkg/config/compiler_ipsec_endpoint_5630_test.go
@@ -1,0 +1,225 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree5630 compiles a set-command list into a ConfigTree for the #5630
+// IPsec endpoint-validation tests. It deliberately uses the flat-set
+// ParseSetCommand + SetPath path (never NewParser) per CLAUDE.md.
+func buildTree5630(t *testing.T, setCommands []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestValidateIPsecEndpoints_Reject covers #5630 (codex-review-181 M20 /
+// A3-b01-F002): a printable-but-invalid IPsec endpoint — a malformed IP
+// octet (10.0.0.999) or a malformed FQDN — used to pass strict commit and
+// then be interpolated verbatim into the swanctl remote_addrs / local_addrs
+// settings, where strongSwan's `swanctl --load-all` rejects or mishandles
+// it (a config that commits but never loads = a silently broken tunnel).
+//
+// Each case defines a gateway with an OTHERWISE-valid reference so the #2074
+// gateway-cross-reference gate passes, isolating the new endpoint gate. Every
+// case here compiles cleanly against pre-fix code (the endpoint was never
+// validated), so reverting validateIPsecEndpointsStrict (or the all-numeric-
+// TLD hardening in isPlausibleHostname) makes these go RED.
+func TestValidateIPsecEndpoints_Reject(t *testing.T) {
+	cases := []struct {
+		name    string
+		cmds    []string
+		wantSub string // substring the error must name
+	}{
+		{
+			name: "malformed remote gateway address (botched IP)",
+			cmds: []string{
+				"set security ike gateway gw address 10.0.0.999",
+				"set security ipsec vpn tun gateway gw",
+			},
+			wantSub: "10.0.0.999",
+		},
+		{
+			name: "malformed remote gateway address (five octets)",
+			cmds: []string{
+				"set security ike gateway gw address 1.2.3.4.5",
+				"set security ipsec vpn tun gateway gw",
+			},
+			wantSub: "1.2.3.4.5",
+		},
+		{
+			name: "malformed remote gateway address (bad FQDN)",
+			cmds: []string{
+				"set security ike gateway gw address bad..host",
+				"set security ipsec vpn tun gateway gw",
+			},
+			wantSub: "bad..host",
+		},
+		{
+			name: "malformed dynamic hostname",
+			cmds: []string{
+				"set security ike gateway gw dynamic hostname -bad.example.com",
+				"set security ipsec vpn tun gateway gw",
+			},
+			wantSub: "-bad.example.com",
+		},
+		{
+			name: "malformed gateway local-address",
+			cmds: []string{
+				"set security ike gateway gw address 203.0.113.1",
+				"set security ike gateway gw local-address 10.0.0.999",
+				"set security ipsec vpn tun gateway gw",
+			},
+			wantSub: "local-address",
+		},
+		{
+			name: "malformed vpn local-address",
+			cmds: []string{
+				"set security ike gateway gw address 203.0.113.1",
+				"set security ipsec vpn tun gateway gw",
+				"set security ipsec vpn tun local-address 10.0.0.999",
+			},
+			wantSub: "local-address",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := buildTree5630(t, c.cmds)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("strict compile should REJECT a printable-invalid endpoint")
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Fatalf("error should name %q, got: %v", c.wantSub, err)
+			}
+		})
+	}
+}
+
+// TestValidateIPsecEndpoints_Accept pins that every VALID endpoint form — a
+// literal IPv4, a literal IPv6, and a valid dotted FQDN, for both the remote
+// gateway address and the local addresses — still commits cleanly. This is
+// the over-rejection guard: the fix must not turn away a legitimate hostname
+// or v6 gateway.
+func TestValidateIPsecEndpoints_Accept(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{
+			name: "valid IPv4 remote address",
+			cmds: []string{
+				"set security ike gateway gw address 203.0.113.1",
+				"set security ipsec vpn tun gateway gw",
+			},
+		},
+		{
+			name: "valid IPv6 remote address",
+			cmds: []string{
+				"set security ike gateway gw address 2001:db8::1",
+				"set security ipsec vpn tun gateway gw",
+			},
+		},
+		{
+			name: "valid FQDN remote address",
+			cmds: []string{
+				"set security ike gateway gw address peer.example.com",
+				"set security ipsec vpn tun gateway gw",
+			},
+		},
+		{
+			name: "valid FQDN dynamic hostname",
+			cmds: []string{
+				"set security ike gateway gw dynamic hostname vpn.example.com",
+				"set security ipsec vpn tun gateway gw",
+			},
+		},
+		{
+			name: "valid IPv4 local-addresses (gateway + vpn)",
+			cmds: []string{
+				"set security ike gateway gw address 203.0.113.1",
+				"set security ike gateway gw local-address 198.51.100.7",
+				"set security ipsec vpn tun gateway gw",
+				"set security ipsec vpn tun local-address 198.51.100.8",
+			},
+		},
+		{
+			name: "valid IPv6 local-address",
+			cmds: []string{
+				"set security ike gateway gw address 2001:db8::1",
+				"set security ike gateway gw local-address 2001:db8::2",
+				"set security ipsec vpn tun gateway gw",
+			},
+		},
+		{
+			name: "valid absolute FQDN (trailing dot)",
+			cmds: []string{
+				"set security ike gateway gw address peer.example.com.",
+				"set security ipsec vpn tun gateway gw",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := buildTree5630(t, c.cmds)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("valid endpoint should COMMIT, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateIPsecEndpoints_Lenient covers the #1960 fail-closed-on-load
+// doctrine: a config carrying a printable-invalid endpoint that an older
+// binary persisted (or a peer synced) must still BOOT under the tolerant
+// compile paths — the strict path rejects, the lenient path warns and loads.
+func TestValidateIPsecEndpoints_Lenient(t *testing.T) {
+	cmds := []string{
+		"set security ike gateway gw address 10.0.0.999",
+		"set security ipsec vpn tun gateway gw",
+	}
+	tree := buildTree5630(t, cmds)
+
+	// Strict rejects.
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("strict compile should reject the malformed endpoint")
+	}
+
+	// Lenient boots with a warning (both entry points).
+	for _, tc := range []struct {
+		name    string
+		compile func() (*Config, error)
+	}{
+		{"lenient", func() (*Config, error) { return CompileConfigLenient(tree) }},
+		{"lenient-for-node", func() (*Config, error) { return CompileConfigForNodeLenient(tree, 0) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := tc.compile()
+			if err != nil {
+				t.Fatalf("lenient compile should BOOT a malformed-endpoint config, got: %v", err)
+			}
+			found := false
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, "ipsec endpoint") && strings.Contains(w, "10.0.0.999") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("lenient compile should record an ipsec endpoint warning, got: %v", cfg.Warnings)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1080,6 +1080,28 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5630 IPsec endpoint value gate. An IKE gateway `address` /
+	// `dynamic hostname` / `local-address`, or a VPN `local-address`, is
+	// copied verbatim from a one-argument schema slot into swanctl
+	// `remote_addrs` / `local_addrs`. A printable-but-invalid value (a
+	// malformed IP octet like 10.0.0.999, or a malformed FQDN) is neither a
+	// usable IP nor a valid hostname, so `swanctl --load-all` rejects or
+	// mishandles the generated connection — a config that commits but never
+	// loads (a silently broken tunnel). Strict on commit / commit-check (hard
+	// reject so the operator gets a diagnostic); lenient on load / peer-sync
+	// (warn so a pre-fix or peer-synced config still boots — #1960 fail-
+	// closed-on-load class). Runs on the fully-compiled *Config so both ike{}
+	// and ipsec{} gateway definitions are present regardless of stanza
+	// authoring order. Mirrors validateIPsecGatewayReferencesStrict.
+	if err := validateIPsecEndpointsStrict(cfg); err != nil {
+		if opts.lenientIPsecEndpoints {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("ipsec endpoint (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2270 IKE (Phase 1) gateway -> ike-policy -> ike-proposal cross-
 	// reference. A gateway that names an ike-policy whose chain does not
 	// resolve (the policy is undefined, or its `proposals` reference

--- a/pkg/config/compiler_validate_strict_ipsec.go
+++ b/pkg/config/compiler_validate_strict_ipsec.go
@@ -334,3 +334,95 @@ func validateIPsecManualKeyStrict(cfg *Config) error {
 	}
 	return nil
 }
+
+// validateIPsecEndpointsStrict (#5630) rejects an IKE gateway or IPsec VPN
+// whose typed endpoint leaves are printable but not a usable strongSwan
+// endpoint — neither a literal IP address nor a syntactically valid dotted
+// hostname/FQDN. compileIKE / compileIPsec copy these leaves verbatim (a
+// one-argument schema slot accepts any single token), and renderConfig
+// (pkg/ipsec/policy.go, resolveRemoteAddr) interpolates them straight into
+// the swanctl `remote_addrs` / `local_addrs` settings. A printable-but-
+// invalid value — a malformed IP octet like 10.0.0.999, or a malformed FQDN
+// — therefore passes strict commit and reaches strongSwan, where
+// `swanctl --load-all` rejects or mishandles the generated connection: a
+// config that commits but never loads is a silently broken tunnel (#5630,
+// codex-review-181 M20 / A3-b01-F002).
+//
+// The four effective endpoint fields are:
+//   - gateway `address`         -> remote_addrs
+//   - gateway `dynamic hostname`-> remote_addrs
+//   - gateway `local-address`   -> local_addrs
+//   - vpn `local-address`       -> local_addrs
+//
+// Each is held to the same IsUsableIPsecEndpoint predicate the gateway
+// cross-reference gate (validateIPsecGatewayReferencesStrict) already
+// applies to an inline vpn.Gateway literal, so every effective endpoint —
+// object field or inline literal — obeys one grammar and cannot drift.
+// Valid IPv4, IPv6, and dotted-FQDN endpoints are preserved; only a value
+// strongSwan itself would reject is caught, so a legitimate hostname or
+// v6 gateway still commits.
+//
+// A gateway whose LocalAddress is empty but derives from external-interface
+// is not checked here: the address is resolved from a live interface at
+// render time, not from operator text. Gateway and VPN names are sorted so
+// a multi-object config reports a deterministic first failure. On the
+// tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientIPsecEndpoints) so a config an older binary
+// persisted, or a peer synced, still boots (#1960 fail-closed-on-load
+// class). Commit / commit-check stay strict. Mirrors
+// validateIPsecGatewayReferencesStrict.
+func validateIPsecEndpointsStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	ipsec := &cfg.Security.IPsec
+
+	gwNames := make([]string, 0, len(ipsec.Gateways))
+	for name := range ipsec.Gateways {
+		gwNames = append(gwNames, name)
+	}
+	sort.Strings(gwNames)
+	for _, name := range gwNames {
+		gw := ipsec.Gateways[name]
+		if gw == nil {
+			continue
+		}
+		if gw.Address != "" && !IsUsableIPsecEndpoint(gw.Address) {
+			return fmt.Errorf("security ike gateway %q address %q is not a "+
+				"valid IP address or hostname; strongSwan would reject the "+
+				"generated remote_addrs and the tunnel would never load",
+				name, gw.Address)
+		}
+		if gw.DynamicHostname != "" && !IsUsableIPsecEndpoint(gw.DynamicHostname) {
+			return fmt.Errorf("security ike gateway %q dynamic hostname %q is "+
+				"not a valid hostname or IP address; strongSwan would reject "+
+				"the generated remote_addrs and the tunnel would never load",
+				name, gw.DynamicHostname)
+		}
+		if gw.LocalAddress != "" && !IsUsableIPsecEndpoint(gw.LocalAddress) {
+			return fmt.Errorf("security ike gateway %q local-address %q is not "+
+				"a valid IP address or hostname; strongSwan would reject the "+
+				"generated local_addrs and the tunnel would never load",
+				name, gw.LocalAddress)
+		}
+	}
+
+	vpnNames := make([]string, 0, len(ipsec.VPNs))
+	for name := range ipsec.VPNs {
+		vpnNames = append(vpnNames, name)
+	}
+	sort.Strings(vpnNames)
+	for _, name := range vpnNames {
+		vpn := ipsec.VPNs[name]
+		if vpn == nil {
+			continue
+		}
+		if vpn.LocalAddr != "" && !IsUsableIPsecEndpoint(vpn.LocalAddr) {
+			return fmt.Errorf("security ipsec vpn %q local-address %q is not a "+
+				"valid IP address or hostname; strongSwan would reject the "+
+				"generated local_addrs and the tunnel would never load",
+				name, vpn.LocalAddr)
+		}
+	}
+	return nil
+}

--- a/pkg/ipsec/endpoint_render_5630_test.go
+++ b/pkg/ipsec/endpoint_render_5630_test.go
@@ -1,0 +1,74 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestRenderValidEndpoints_5630 is the render-side companion to the #5630
+// commit-time endpoint gate: it pins that a VALID IPv4 / IPv6 / FQDN remote
+// gateway address, and a valid local-address, still render into the swanctl
+// `remote_addrs` / `local_addrs` settings unchanged. The commit-time gate
+// (validateIPsecEndpointsStrict, pkg/config) rejects only endpoints strongSwan
+// would refuse; this test guards that the fix does not disturb the render of
+// endpoints it accepts.
+func TestRenderValidEndpoints_5630(t *testing.T) {
+	cases := []struct {
+		name       string
+		gwAddr     string
+		gwLocal    string
+		wantRemote string
+		wantLocal  string
+	}{
+		{
+			name:       "IPv4 remote + IPv4 local",
+			gwAddr:     "203.0.113.1",
+			gwLocal:    "198.51.100.7",
+			wantRemote: "remote_addrs = 203.0.113.1",
+			wantLocal:  "local_addrs = 198.51.100.7",
+		},
+		{
+			name:       "IPv6 remote + IPv6 local",
+			gwAddr:     "2001:db8::1",
+			gwLocal:    "2001:db8::2",
+			wantRemote: "remote_addrs = 2001:db8::1",
+			wantLocal:  "local_addrs = 2001:db8::2",
+		},
+		{
+			name:       "FQDN remote",
+			gwAddr:     "peer.example.com",
+			gwLocal:    "",
+			wantRemote: "remote_addrs = peer.example.com",
+			wantLocal:  "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+			cfg := &config.IPsecConfig{
+				Gateways: map[string]*config.IPsecGateway{
+					"gw": {Name: "gw", Address: c.gwAddr, LocalAddress: c.gwLocal},
+				},
+				VPNs: map[string]*config.IPsecVPN{
+					"tun": {Name: "tun", Gateway: "gw", IPsecPolicy: "ipsec-pol"},
+				},
+				Policies: map[string]*config.IPsecPolicyDef{
+					"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+				},
+				Proposals: map[string]*config.IPsecProposal{
+					"prop1": {Name: "prop1", EncryptionAlg: "aes256", AuthAlg: "sha256"},
+				},
+			}
+			got := m.generateConfig(cfg)
+			if !strings.Contains(got, c.wantRemote) {
+				t.Fatalf("rendered config missing %q:\n%s", c.wantRemote, got)
+			}
+			if c.wantLocal != "" && !strings.Contains(got, c.wantLocal) {
+				t.Fatalf("rendered config missing %q:\n%s", c.wantLocal, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #5630 (codex-review-181 root **M20** / `A3-b01-F002`, Medium, CONFIRMED MATERIAL): a printable-but-invalid IPsec gateway endpoint passed strict commit and then broke the strongSwan render.

An IKE gateway `address` / `dynamic hostname` / `local-address`, and a VPN `local-address`, were copied verbatim from a one-argument schema slot into swanctl `remote_addrs` / `local_addrs`. The only commit-time gate (`validateIPsecGatewayReferencesStrict`, #2074) checked that a referenced gateway was *nonempty* — never that the value was a usable IP or hostname. A printable-but-invalid endpoint (a malformed IP octet like `10.0.0.999`, or a malformed FQDN) therefore passed strict commit and reached strongSwan, where `swanctl --load-all` rejects/mishandles the connection — **a config that commits but never loads is a silently broken tunnel.**

> Endpoint outage / invalid-value class only. **Not** a newline / config-injection claim — control chars are already handled by the global control-char gate + the render-side `sanitizeSwanctlValue` belt.

## What changed

1. **`validateIPsecEndpointsStrict(cfg)`** (`compiler_validate_strict_ipsec.go`) — runs the four effective endpoint fields through `IsUsableIPsecEndpoint`, the same predicate #2074 applies to the inline `vpn.Gateway` literal. Wired into the strict chain in `compiler_uniformgates.go` right after the gateway-reference gate, with a `lenientIPsecEndpoints` downgrade: hard-reject on commit / commit-check, warn on the tolerant load / peer-sync paths (#1960 fail-closed-on-load doctrine).
2. **`isPlausibleHostname` hardening** (`compiler_ipsec.go`) — reject an all-numeric rightmost label (RFC 3696 §2 / RFC 1123 §2.1). Without it, a botched IPv4 like `10.0.0.999` (fails `net.ParseIP`) masqueraded as a "plausible hostname" and slipped past validation — the exact repro. Valid IP literals hit the `net.ParseIP` branch first, so they're unaffected; this also closes the same `10.0.0.999`-as-inline-gateway hole in the #2074 reference validator.

## Accept / reject (matches strongSwan; no invented strictness)

- **Accept:** literal IPv4 (`203.0.113.1`), literal IPv6 (`2001:db8::1`), dotted FQDN (`peer.example.com`), absolute FQDN trailing dot (`peer.example.com.`).
- **Reject:** neither parseable IP nor valid hostname — `10.0.0.999`, `1.2.3.4.5`, `bad..host`, `-bad.example.com`, all-numeric TLD.
- Single-label bare hostnames (`vpnpeer`) stay rejected — unchanged #2074 behavior.

## Tests / validation

- `pkg/config/compiler_ipsec_endpoint_5630_test.go` — `TestValidateIPsecEndpoints_{Reject,Accept,Lenient}` (flat-set `ParseSetCommand`+`SetPath`).
- `pkg/ipsec/endpoint_render_5630_test.go` — valid IPv4/IPv6/FQDN endpoints render into `remote_addrs`/`local_addrs` unchanged.
- `go build ./...` clean; `go test ./pkg/config/... ./pkg/ipsec/...` green; gofmt clean.
- **RED-on-revert (two ways):** (A) neutralizing `validateIPsecEndpointsStrict` → every reject case FAILs; (B) reverting the `isPlausibleHostname` hardening (validator kept) → the `10.0.0.999` / `1.2.3.4.5` cases FAIL while structurally-malformed FQDNs stay caught — proving the hostname hardening is load-bearing for the exact repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)