### PR TITLE
daemon: reconcile rib-group leak on final removal (#5642)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46618,3 +46618,22 @@ top.
   validateIPsecEndpointsStrict → all reject cases FAIL; (B) reverting the
   isPlausibleHostname hardening (validator kept) → the 10.0.0.999 / 1.2.3.4.5
   cases FAIL while structurally-malformed FQDNs stay caught. Restoring → GREEN.
+
+- **Timestamp**: 2026-07-11
+  **Action**: #5642 (codex-review-181 M34, High/security-adjacent) — final
+    rib-group removal left a stale inter-VRF route-leak on both forwarding
+    planes. Part (a): removed the `len(cfg.RoutingOptions.RibGroups) > 0` gate
+    in `applyRoutingRules` step 3c so `ApplyRibGroupRules` runs unconditionally;
+    `ribGroupManager.Apply` runs clear() before its empty-desired early return,
+    so the zero-transition still deletes the stale `ip rule to <prefix> lookup
+    <table>` leak rule (no churn when no rule exists). Part (b): added
+    `reconcileRouteLeakSnapshot` — a routes-only republish after the ip-rule
+    reconcile — so the userspace snapshot (built by the earlier ApplyConfig from
+    the pre-reconcile ip-rule table) is rebuilt leak-free; duplicate-skips when
+    unchanged. Added `routing.NewManagerWithRuleOpsForTest` seam. Fail-on-revert
+    proven: gate revert → stale rule survives (RED); reconcile no-op → publish
+    never fires (RED). Build + pkg/daemon+routing+userspace tests green.
+  **File(s)**: pkg/daemon/daemon_apply.go, pkg/routing/test_seams.go,
+    pkg/daemon/ribgroup_zero_leak_5642_test.go,
+    pkg/dataplane/userspace/routes_ribgroup_zero_5642_test.go,
+    docs/rib-group-route-leaking.md

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -72,6 +72,37 @@ band, and the original `[200, 300)` band. An in-place binary upgrade therefore
 **removes the stale pref-33000 blanket rule** so the box is never left with the
 broken blanket rule alongside the new per-prefix rules.
 
+### Final rib-group removal (zero-transition, #5642)
+
+The daemon's config-apply reconciler (`applyRoutingRules`,
+`pkg/daemon/daemon_apply.go`) calls `ApplyRibGroupRules`
+**unconditionally** — there is no `len(RibGroups) > 0` gate. `ribGroupManager.Apply`
+runs `clear()` **before** its own empty-desired early return, so the transition
+that removes the **final** rib-group (`RoutingOptions.RibGroups` → empty) still
+deletes the previously-installed per-prefix leak ip-rules. A config that never
+carried a rib-group finds nothing in the scanned bands, so `clear()` issues no
+`RuleDel` (no churn).
+
+Before #5642 the `len(RibGroups) > 0` gate skipped the whole block on that
+zero-transition, so the stale Linux `ip rule to <prefix> lookup <table>`
+survived indefinitely. Because the userspace snapshot builder derives its
+`NextTable` leak from the **live** ip-rule table (`buildRouteSnapshots` →
+`netlink.RuleList`), the stale rule also kept republishing into the **userspace
+FIB** — a deleted-VRF leak on both forwarding planes that kernel-forwarded /
+local / route-based-IPsec plaintext could follow, despite a successful commit.
+
+**Snapshot ordering (why the gate fix alone is not enough).** The full dataplane
+apply (`d.dp.ApplyConfig`) runs **before** `applyRoutingRules`, so it builds and
+publishes the userspace route snapshot from the *pre-reconcile* ip-rule table —
+it captures the stale leak. After `applyRoutingRules` deletes the rule, the
+daemon runs a routes-only republish (`reconcileRouteLeakSnapshot`,
+`pkg/daemon/daemon_apply.go`) that rebuilds `buildRouteSnapshots` against the
+now-reconciled kernel rules and publishes the leak-free FIB (bumping the FIB
+generation so established flows re-resolve). It reuses the ip-monitoring
+routes-only publish surface (no `Compile`, no helper restart) and duplicate-skips
+an unchanged route set, so a steady-state commit and a never-had-a-rib-group
+config publish nothing.
+
 ## Fail-loud diagnostics (commit-time warnings)
 
 `config.ValidateConfig` (`validateRibGroupLeakWarnings`) warns — rather than

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -758,6 +758,18 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 
 	d.applyRoutingRules(cfg, commitOverlay)
 
+	// #5642: the full dataplane apply (applyDataplaneAndHACore → d.dp.ApplyConfig)
+	// ran BEFORE applyRoutingRules and built its userspace route snapshot from the
+	// PRE-reconcile kernel ip-rule table (buildRouteSnapshots enumerates the live
+	// ip-rules via netlink.RuleList). On a rib-group / next-table transition —
+	// notably the final rib-group removal handled just above — applyRoutingRules
+	// has now deleted (or added) the synthetic leak ip-rule, so the snapshot
+	// ApplyConfig already published is stale. Rebuild + republish the routes-only
+	// snapshot against the now-reconciled kernel rules so the userspace FIB does
+	// not retain a deleted-VRF inter-VRF leak. A no-op (content-hash duplicate
+	// skip) when the route set did not move.
+	d.reconcileRouteLeakSnapshot(cfg, commitOverlay)
+
 	ipsecErr, dhcpServerErr := d.applyServicesReconcile(cfg)
 
 	// Steps 8–21: tail reconcile dispatches (VRRP, system config, syslog,
@@ -1398,7 +1410,21 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 	// default route. The connected prefixes are derived from the config
 	// addresses on each source instance's member interface units, using the
 	// same derivation the userspace FIB uses for connected routes.
-	if d.routing != nil && len(cfg.RoutingOptions.RibGroups) > 0 {
+	//
+	// #5642: the reconcile runs UNCONDITIONALLY (no `len(RibGroups) > 0`
+	// gate). ribGroupManager.Apply calls clear() BEFORE its own empty-desired
+	// early return, so an EMPTY rib-group set — the transition that removes
+	// the FINAL rib-group — still deletes the previously-installed synthetic
+	// `ip rule to <prefix> lookup <sourceTable>` leak rules. The old gate
+	// skipped the whole block on that zero-transition, so the stale Linux
+	// ip-rule (and, because buildRouteSnapshots derives the userspace
+	// NextTable leak from the live ip-rule table, the stale userspace FIB
+	// entry) kept routing a deleted-VRF prefix into its table indefinitely — a
+	// route-leak that kernel-forwarded / local / route-based-IPsec plaintext
+	// could follow. A config that never had a rib-group finds no rule in the
+	// scanned bands, so clear() issues no RuleDel (no churn); a steady-state
+	// non-empty commit reconciles the exact same set as before.
+	if d.routing != nil {
 		connectedPrefixes := config.RibGroupConnectedPrefixes(cfg)
 		if err := d.routing.ApplyRibGroupRules(cfg.RoutingOptions.RibGroups, cfg.RoutingInstances, connectedPrefixes); err != nil {
 			slog.Warn("failed to apply rib-group rules", "err", err)
@@ -1423,6 +1449,62 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 		if err := d.routing.ApplyPBRRules(pbrRules); err != nil {
 			slog.Warn("failed to apply PBR rules", "err", err)
 		}
+	}
+}
+
+// reconcileRouteLeakSnapshot republishes the userspace route snapshot after
+// applyRoutingRules has reconciled the kernel policy-routing (ip rule) table
+// (#5642). The full dataplane apply (applyDataplaneAndHACore → d.dp.ApplyConfig)
+// runs BEFORE applyRoutingRules and derives its route snapshot from the LIVE
+// kernel ip-rules (buildRouteSnapshots → netlink.RuleList). On an inter-VRF
+// route-leak transition — most importantly the final-rib-group removal that
+// takes RoutingOptions.RibGroups to zero — applyRoutingRules has just deleted
+// (or added) the synthetic `ip rule to <prefix> lookup <table>` leak rule, so
+// the snapshot ApplyConfig already published still mirrors the PRE-reconcile
+// rule table and keeps (or omits) a NextTable leak that no longer matches the
+// kernel. Without this reconcile a removed rib-group's deleted-VRF leak would
+// survive in the userspace FIB indefinitely (until some later apply happened to
+// rebuild it).
+//
+// This reuses the ip-monitoring routes-only publish surface — no Compile, no
+// helper restart — rebuilding buildRouteSnapshots against the now-reconciled
+// kernel rules and, only when the content actually changed, publishing the
+// leak-free FIB and bumping the FIB generation so established flows re-resolve.
+// PublishRouteOverlaySnapshot duplicate-skips an unchanged route set (returns
+// published=false), so a steady-state commit and a config that never carried a
+// rib-group publish nothing and churn nothing. A nil scheduler-state argument
+// keeps the manager's current policy-scheduler view (the one the full apply just
+// published) so the unchanged-content hash matches and the skip fires.
+func (d *Daemon) reconcileRouteLeakSnapshot(cfg *config.Config, overlay []config.RouteOverlayEntry) {
+	if cfg == nil {
+		return
+	}
+	pub, ok := d.dp.(routeOverlayPublisher)
+	if !ok {
+		// Helperless (no userspace dataplane publisher): the kernel ip-rule
+		// reconcile above is the only route-leak consumer and it already ran.
+		return
+	}
+	published, err := pub.PublishRouteOverlaySnapshot(cfg, overlay, nil)
+	if err != nil {
+		slog.Warn("route-leak snapshot reconcile: routes-only republish failed; the "+
+			"userspace FIB may retain a stale inter-VRF leak until the next apply",
+			"err", err)
+		return
+	}
+	if !published {
+		// Duplicate-skip (route set unchanged) or no published snapshot yet /
+		// helper not running: nothing moved, so do not bump the FIB generation
+		// (would needlessly churn established-flow route caches).
+		return
+	}
+	// Ordering (mirrors the ip-monitoring actuator, #1827 AGY r2-1): bump the
+	// FIB generation ONLY after a real publish so established flows re-resolve
+	// onto the reconciled routes; bumping before/without a publish would leave
+	// flows pinned to the stale leak route.
+	if _, err := pub.BumpFIBGeneration(); err != nil {
+		slog.Warn("route-leak snapshot reconcile: FIB generation bump unconfirmed after "+
+			"republish; established flows may re-resolve on a later sweep", "err", err)
 	}
 }
 

--- a/pkg/daemon/ribgroup_zero_leak_5642_test.go
+++ b/pkg/daemon/ribgroup_zero_leak_5642_test.go
@@ -1,0 +1,169 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/routing"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// fakeRuleOps5642 is a minimal in-memory ip-rule table implementing the routing
+// package's ruleOps surface (RuleAdd/RuleDel/RuleList) so a pkg/daemon test can
+// drive applyRoutingRules' rib-group reconcile against a fake netlink handle via
+// routing.NewManagerWithRuleOpsForTest — no root, no live kernel.
+type fakeRuleOps5642 struct {
+	rules map[int][]netlink.Rule
+	dels  int
+}
+
+func newFakeRuleOps5642() *fakeRuleOps5642 {
+	return &fakeRuleOps5642{rules: map[int][]netlink.Rule{
+		unix.AF_INET:  {},
+		unix.AF_INET6: {},
+	}}
+}
+
+func (f *fakeRuleOps5642) RuleAdd(r *netlink.Rule) error {
+	f.rules[r.Family] = append(f.rules[r.Family], *r)
+	return nil
+}
+
+func (f *fakeRuleOps5642) RuleDel(r *netlink.Rule) error {
+	f.dels++
+	list := f.rules[r.Family]
+	out := list[:0:0]
+	for _, e := range list {
+		if e.Priority == r.Priority {
+			continue
+		}
+		out = append(out, e)
+	}
+	f.rules[r.Family] = out
+	return nil
+}
+
+func (f *fakeRuleOps5642) RuleList(family int) ([]netlink.Rule, error) {
+	return f.rules[family], nil
+}
+
+func (f *fakeRuleOps5642) hasPriority(family, prio int) bool {
+	for _, r := range f.rules[family] {
+		if r.Priority == prio {
+			return true
+		}
+	}
+	return false
+}
+
+// TestApplyRoutingRulesClearsRibGroupLeakOnZeroTransition is the #5642 (M34)
+// fail-on-revert guard for part (a): when a config transition removes the FINAL
+// rib-group (RoutingOptions.RibGroups becomes empty), applyRoutingRules must
+// STILL run the rib-group reconcile so the previously-installed synthetic
+// per-prefix leak ip-rule (`ip rule to <prefix> lookup <sourceTable>`, the
+// #3876 leak band at priority 30000-30999) is deleted from the kernel.
+//
+// RED-on-revert: restoring the pre-fix `len(cfg.RoutingOptions.RibGroups) > 0`
+// gate skips ApplyRibGroupRules entirely on the zero-transition, so the stale
+// rule survives and this test fails. That stale rule would keep routing the
+// deleted VRF's prefix into its table indefinitely — a route-leak that
+// kernel-forwarded / local / route-based-IPsec plaintext could follow.
+func TestApplyRoutingRulesClearsRibGroupLeakOnZeroTransition(t *testing.T) {
+	// pkg/routing ribGroupLeakRulePriority (#3876 per-prefix leak band). Kept as
+	// a literal because the constant is package-private to pkg/routing.
+	const ribGroupLeakPrio = 30000
+
+	ops := newFakeRuleOps5642()
+	// Seed the stale C1 rib-group leak rule: `ip rule to 10.0.30.0/24 lookup 101`.
+	_, dst, err := net.ParseCIDR("10.0.30.0/24")
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+	ops.rules[unix.AF_INET] = append(ops.rules[unix.AF_INET], netlink.Rule{
+		Family:   unix.AF_INET,
+		Priority: ribGroupLeakPrio,
+		Table:    101,
+		Dst:      dst,
+	})
+
+	d := &Daemon{routing: routing.NewManagerWithRuleOpsForTest(ops)}
+
+	// C2: the final rib-group has been removed. The instance still exists but
+	// carries no interface-routes rib-group, and RoutingOptions.RibGroups is empty.
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101},
+	}
+
+	d.applyRoutingRules(cfg, nil)
+
+	if ops.hasPriority(unix.AF_INET, ribGroupLeakPrio) {
+		t.Fatalf("zero-transition must delete the stale rib-group leak ip-rule at "+
+			"priority %d; rules=%v", ribGroupLeakPrio, ops.rules[unix.AF_INET])
+	}
+	if ops.dels == 0 {
+		t.Fatal("expected a RuleDel for the stale rib-group leak rule; none issued")
+	}
+}
+
+// TestApplyRoutingRulesNoRibGroupNoChurn pins the no-spurious-churn contract for
+// a config that never carried a rib-group: with no rule in the scanned bands,
+// the unconditional reconcile issues no RuleDel. Guards against a regression
+// where the gate removal starts churning ip-rules on every plain commit.
+func TestApplyRoutingRulesNoRibGroupNoChurn(t *testing.T) {
+	ops := newFakeRuleOps5642()
+	d := &Daemon{routing: routing.NewManagerWithRuleOpsForTest(ops)}
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101},
+	}
+
+	d.applyRoutingRules(cfg, nil)
+
+	if ops.dels != 0 {
+		t.Fatalf("a never-had-a-rib-group config must issue no RuleDel; got %d", ops.dels)
+	}
+}
+
+// TestReconcileRouteLeakSnapshotRepublishesOnChange is the #5642 part-(b) guard:
+// after applyRoutingRules reconciles the kernel ip-rule table, the daemon
+// republishes the routes-only userspace snapshot so a stale inter-VRF leak
+// (published by the earlier full dataplane apply from the pre-reconcile rule
+// table) is rebuilt leak-free. A real publish (route set changed) MUST be
+// followed by a FIB-generation bump so established flows re-resolve.
+//
+// RED-on-revert: reverting reconcileRouteLeakSnapshot to a no-op leaves the
+// published snapshot stale and this test fails (publish/bump never fire).
+func TestReconcileRouteLeakSnapshotRepublishesOnChange(t *testing.T) {
+	dp := &fakeOverlayDP{}
+	d := &Daemon{dp: dp}
+
+	d.reconcileRouteLeakSnapshot(&config.Config{}, nil)
+
+	if len(dp.calls) != 2 || dp.calls[0] != "publish" || dp.calls[1] != "bump" {
+		t.Fatalf("calls = %v, want [publish bump]", dp.calls)
+	}
+}
+
+// TestReconcileRouteLeakSnapshotSkipsBumpOnDuplicate: an unchanged route set
+// (PublishRouteOverlaySnapshot duplicate-skip → published=false) must NOT bump
+// the FIB generation — a steady-state commit and a never-had-a-rib-group config
+// publish nothing and churn nothing.
+func TestReconcileRouteLeakSnapshotSkipsBumpOnDuplicate(t *testing.T) {
+	dp := &fakeOverlayDP{publishSkipped: true}
+	d := &Daemon{dp: dp}
+
+	d.reconcileRouteLeakSnapshot(&config.Config{}, nil)
+
+	if len(dp.calls) != 1 || dp.calls[0] != "publish" {
+		t.Fatalf("calls = %v, want exactly [publish]", dp.calls)
+	}
+	for _, c := range dp.calls {
+		if c == "bump" {
+			t.Fatalf("calls = %v: FIB generation bumped after a duplicate-skip", dp.calls)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/routes_ribgroup_zero_5642_test.go
+++ b/pkg/dataplane/userspace/routes_ribgroup_zero_5642_test.go
@@ -1,0 +1,43 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// TestBuildRouteSnapshotsNoLeakAfterRuleCleared is the #5642 userspace half of
+// the fix: once the synthetic rib-group leak ip-rule has been cleared from the
+// kernel (the final-rib-group-removal reconcile in pkg/routing, driven by the
+// daemon's now-unconditional ApplyRibGroupRules call), a rebuilt route snapshot
+// carries NO NextTable leak into the (now un-leaked) instance table.
+//
+// This is the invariant the daemon's post-reconcile routes-only republish
+// (reconcileRouteLeakSnapshot) relies on: delete the Linux ip-rule ⇒ the
+// republished userspace FIB is leak-free. It complements
+// TestBuildRouteSnapshotsCapturesRibGroupPerPrefixLeak (#3876), which proves the
+// leak IS captured while the rule is still live — together they show the leak
+// tracks the kernel ip-rule table in both directions.
+func TestBuildRouteSnapshotsNoLeakAfterRuleCleared(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	// The rib-group has been removed; clear() deleted its per-prefix leak
+	// rules, so the kernel ip-rule table no longer lists them.
+	ruleListFn = func(family int) ([]netlink.Rule, error) { return nil, nil }
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+	for _, r := range routes {
+		if r.NextTable == "dmz-vr.inet.0" || r.NextTable == "dmz-vr.inet6.0" {
+			t.Fatalf("a cleared rib-group must leave NO NextTable leak into dmz-vr, got %+v", r)
+		}
+	}
+}

--- a/pkg/routing/test_seams.go
+++ b/pkg/routing/test_seams.go
@@ -34,6 +34,29 @@ func NewManagerWithLinkOpsForTest(ops linkOps) *Manager {
 	return m
 }
 
+// NewManagerWithRuleOpsForTest builds a *Manager whose policy-routing rule
+// domains (nextTbl, ribGroup, pbr — every domain whose ops field is the narrow
+// ruleOps surface) are backed by the supplied ruleOps instead of a live
+// *netlink.Handle. It exists so tests in dependent packages (e.g. pkg/daemon)
+// can drive applyRoutingRules' ip-rule reconcile — notably the #5642
+// final-rib-group removal, which must STILL run the rib-group clear() so the
+// stale per-prefix leak ip-rule is deleted on the zero-transition — against an
+// in-memory fake (no root, no netlink handle, no host side effects).
+//
+// Only the three rule domains are wired; every other domain is left nil (these
+// tests exercise the rule reconcile only). nlHandle stays nil (Close nil-guards it).
+//
+// Callers pass any value whose method set matches ruleOps (RuleAdd / RuleDel /
+// RuleList — all exported, so a fake defined in another package satisfies it
+// structurally).
+func NewManagerWithRuleOpsForTest(ops ruleOps) *Manager {
+	m := &Manager{}
+	m.nextTbl = &nextTableManager{ops: ops}
+	m.ribGroup = &ribGroupManager{ops: ops}
+	m.pbr = &pbrManager{ops: ops}
+	return m
+}
+
 // NewManagerWithRouteListerForTest builds a *Manager whose route-read domain
 // (routeReader) is backed by the supplied routeLister instead of a live
 // *netlink.Handle. It exists so tests in dependent packages (e.g. pkg/grpcapi)


### PR DESCRIPTION
## Summary
Fixes **#5642** (codex-review-181 root **M34**, High, security-adjacent): removing the FINAL rib-group left a stale inter-VRF route-leak on **both** forwarding planes.

`applyRoutingRules` gated the rib-group reconcile behind `len(cfg.RoutingOptions.RibGroups) > 0`, so a transition that takes `RibGroups` to **zero** skipped `ApplyRibGroupRules` entirely — the synthetic `ip rule to <prefix> lookup <sourceTable>` leak rule (#3876 band) was never cleared. Because `buildRouteSnapshots` derives its `NextTable` leak from the **live** ip-rule table (`netlink.RuleList`), the stale kernel rule also kept republishing into the userspace FIB. The deleted VRF stayed reachable indefinitely despite a successful commit — a leak that kernel-forwarded / local / **route-based-IPsec plaintext** could follow.

## Fix
**Part (a) — delete the stale Linux ip-rule.** Drop the `len(RibGroups) > 0` gate so `ApplyRibGroupRules` runs unconditionally. `ribGroupManager.Apply` runs `clear()` **before** its own empty-desired early return, so an empty set still deletes the stale leak rules. Never-had-a-rib-group configs find nothing in the scanned bands → no `RuleDel` (no churn); a steady-state non-empty commit reconciles the same set as before.

**Part (b) — reconcile the userspace snapshot leak-free.** The full dataplane apply (`d.dp.ApplyConfig`) runs **before** `applyRoutingRules` and publishes its snapshot from the *pre-reconcile* ip-rule table, so deleting the kernel rule alone leaves the published userspace FIB stale. New `reconcileRouteLeakSnapshot` does a routes-only republish (reuses the ip-monitoring publish surface — no `Compile`, no helper restart) that rebuilds `buildRouteSnapshots` against the now-reconciled kernel rules and, only when content changed, publishes the leak-free FIB + bumps the FIB generation. `PublishRouteOverlaySnapshot` duplicate-skips an unchanged route set, so steady-state / never-had-a-rib-group commits publish nothing.

## Validation
- Added `routing.NewManagerWithRuleOpsForTest` seam so `pkg/daemon` drives the ip-rule reconcile against an in-memory fake (no root/kernel).
- **Fail-on-revert proven:**
  - Restore the `len>0` gate → `TestApplyRoutingRulesClearsRibGroupLeakOnZeroTransition` fails (stale rule survives). ✅ RED
  - Revert `reconcileRouteLeakSnapshot` to a no-op → `TestReconcileRouteLeakSnapshotRepublishesOnChange` fails (publish/bump never fire). ✅ RED
- `TestBuildRouteSnapshotsNoLeakAfterRuleCleared` pins that a cleared ip-rule yields a leak-free snapshot.
- Non-zero + never-had-a-rib-group cases: no spurious `RuleDel` / no publish (guarded by `TestApplyRoutingRulesNoRibGroupNoChurn` + duplicate-skip test).
- `go build ./...`, `pkg/daemon` + `pkg/routing` + `pkg/dataplane/userspace` tests green; gofmt + `go vet` clean.
- Config-apply / daemon change only (not session-sync/failover) — no `test-failover` gate required.

Closes #5642

🤖 Generated with [Claude Code](https://claude.com/claude-code)