### PR TITLE
configstore: constrain master-password PRF to effective supported scope (#5638)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46618,3 +46618,30 @@ top.
   validateIPsecEndpointsStrict → all reject cases FAIL; (B) reverting the
   isPlausibleHostname hardening (validator kept) → the 10.0.0.999 / 1.2.3.4.5
   cases FAIL while structurally-malformed FQDNs stay caught. Restoring → GREEN.
+
+## 2026-07-11 — #5638: constrain master-password PRF to effective/supported scope (codex-review-181 M30)
+- **Timestamp**: 2026-07-11
+- **Action**: Fixed masterPasswordPRF accepting an inactive/unapplied
+  dormant or unsupported master-password PRF through the tolerant/HA
+  persistence path → deterministic HA non-durability. Split it into two
+  separable questions: (1) is encryption required? — fail-closed broad
+  scan (masterPasswordConfigured), preserving #4705/#5231; (2) which PRF
+  algorithm? — effective/applied scope only (effectiveMasterPasswordPRF:
+  strip inactive + expand applied groups on a clone), accepting only a
+  prfHash-supported selector, else the fixed supported default (sha256).
+  A dormant/unsupported PRF can no longer reach prfHash and
+  deterministically fail writeActive on HA config-sync.
+- **File(s)**: pkg/configstore/crypto.go (masterPasswordPRF rewrite +
+  masterPasswordConfigured/effectiveMasterPasswordPRF/prfSupported helpers +
+  defaultMasterPasswordPRF const), pkg/configstore/masterpw_dormant_prf_5638_test.go
+  (new fail-on-revert tests), pkg/configstore/masterpw_apply_groups_5231_test.go
+  (clarify unapplied-group comment for new effective-scope semantics),
+  pkg/configstore/README.md (crypto hardening note).
+- **Validation**: `go build ./...` clean; `go test ./pkg/configstore/...
+  ./pkg/config/...` green; gofmt clean. RED-on-revert proven: reverting
+  masterPasswordPRF to the pre-fix over-broad superset makes all four new
+  tests FAIL — masterPasswordPRF returns "bogus"/"sha512", WriteActive fails
+  with "unsupported master-password pseudorandom-function \"bogus\"", and
+  SyncApply leaves ConfigPersistDegraded()==true (the exact M30 symptom).
+  Restoring → GREEN. Normal single active supported-PRF config is
+  bit-identical (zero-allocation fast path).

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -138,7 +138,7 @@ inline archive-site passwords).
   configstore directory. The "master-password" naming is an HKDF
   info string only — it isn't a user-supplied password.
 
-### At-rest crypto hardening notes (#4579 A4-05/A4-06, #4705, #5231)
+### At-rest crypto hardening notes (#4579 A4-05/A4-06, #4705, #5231, #5638)
 
 - **Split `system` stanza resolution (#4705).** "The tree declares a
   master-password" is decided by `masterPasswordPRF`, which scans **every**
@@ -182,9 +182,34 @@ inline archive-site passwords).
   `apply-groups` only *copies* existing leaves, so a PRF active after expansion
   physically exists somewhere under a group body here. The walk is read-only and
   total (nil-safe, never errors on a malformed group) because the write path must
-  not fail. Reusing the compiler's `ExpandGroups` was rejected: it would mutate
-  the tree being persisted and pull `${node}`/undefined-group error handling into
-  that write path, for no security gain.
+  not fail.
+- **Dormant / unsupported PRF isolation (#5638, codex-review-181 M30).**
+  `masterPasswordPRF` now answers TWO separable questions instead of one. **(1)
+  Is encryption required?** — the fail-closed broad scan above
+  (`masterPasswordConfigured`): ANY master-password anywhere (active stanza,
+  applied OR unapplied group, `<*>` wildcard, inactive node) means encrypt.
+  **(2) Which PRF algorithm?** — resolved from the EFFECTIVE/APPLIED scope only
+  (`effectiveMasterPasswordPRF`: strip inactive **then** expand applied groups
+  on a clone, the same semantics the compiler and `schemaValidateExpandedTree`
+  use), accepting **only** a selector `prfHash` supports; otherwise the fixed
+  supported default (`defaultMasterPasswordPRF`, `sha256`). The old resolver
+  conflated the two: its fail-closed superset returned whatever value a dormant
+  subtree carried, so an **unsupported** PRF (`bogus`) hidden in an inactive
+  node or an unapplied group — invisible to the #4578 commit gate, which
+  validates the effective tree — was handed to `prfHash`, which rejects it.
+  On the tolerant HA config-sync / upgrade-load path this made the persistence
+  write fail **deterministically**: the standby promotes the peer tree in
+  memory (Option B), `writeActive` fails, and the singleton retry re-selects the
+  same bad value forever, leaving the node `/health`-503 with its authoritative
+  generation permanently off disk (non-durable across restart). Constraining the
+  ALGORITHM to a supported effective value (default fallback) keeps the DB
+  encrypted while guaranteeing the write only ever receives a value `prfHash`
+  accepts — deterministic and durable across active↔standby. The effective
+  resolution runs on a clone and swallows every apply-groups expansion error
+  (degrading to the default), so the "this write path must not fail" contract —
+  which originally motivated NOT calling `ExpandGroups` here — still holds. A
+  normal single active supported-PRF config takes a zero-allocation fast path
+  and is bit-identical to the pre-#5638 resolver.
 - **Unexpected-plaintext warning (A4-06).** Every write path encrypts the
   body when the tree declares a master-password, so `readTreeMeta` reading
   a config back as *plaintext* while its tree still declares a

--- a/pkg/configstore/crypto.go
+++ b/pkg/configstore/crypto.go
@@ -35,72 +35,159 @@ func (db *DB) masterKeyPath() string {
 	return filepath.Join(db.dir, "master.key")
 }
 
+// defaultMasterPasswordPRF is the supported PRF used to key at-rest encryption
+// when encryption is required (a master-password is configured somewhere) but
+// no SUPPORTED effective PRF can be resolved from the applied config — e.g. the
+// encryption belt is triggered only by a dormant (inactive / unapplied-group)
+// master-password, or the effective declaration carries an unsupported selector
+// that slipped past the #4578 commit gate on a tolerant HA/upgrade path. It
+// MUST be a value prfHash accepts so the persistence write never fails
+// deterministically. See masterPasswordPRF (#5638 / codex-review-181 M30).
+const defaultMasterPasswordPRF = "sha256"
+
 // masterPasswordPRF resolves the master-password pseudorandom-function that
-// decides whether the config DB is written encrypted (maybeEncryptTreeJSON)
-// and whether the #4579 A4-06 plaintext-downgrade warning fires (db.go
-// readTreeMeta). It MUST consider every surface that activates encryption at
-// runtime: every top-level `system` stanza (#4705) AND any `master-password`
-// anywhere under a `groups { ... }` block reachable via apply-groups (#5231).
+// keys at-rest encryption (maybeEncryptTreeJSON) and gates the #4579 A4-06
+// plaintext-downgrade warning (db.go readTreeMeta). It answers TWO separable
+// questions — conflating them caused #5638 (codex-review-181 M30):
 //
-// Top-level split stanzas (#4705): the Junos parser does not merge duplicate
-// top-level stanzas — parseStatements appends each `system { ... }` block as
-// its own child, and neither LoadOverride nor SyncApply (both raw
-// NewParser().Parse()) coalesce them. The compiler already treats a split
-// config as one system — compileSections loops over ALL top-level nodes and
-// folds every `system` node into the same cfg.System — so a `master-password`
-// living in a SECOND system stanza is semantically active. A single-first-match
-// tree.FindChild("system") would then miss it and write the whole DB (secrets
-// included) in PLAINTEXT despite encryption being configured.
+//  1. IS ENCRYPTION REQUIRED?  Conservative, fail-closed. ANY master-password
+//     anywhere — an active top-level `system` stanza (#4705), or any
+//     `master-password` under any `groups { ... }` block including an
+//     UNAPPLIED or `<*>`-wildcard group (#5231) — means "encrypt, never leak
+//     plaintext." Over-encrypting a dormant/unapplied master-password is a
+//     harmless false-positive; under-encrypting leaks secrets to disk. This is
+//     masterPasswordConfigured.
 //
-// Groups / apply-groups (#5231): a `master-password` declared inside a
-// `groups { ... }` body and pulled in with `apply-groups <name>` is ACTIVE at
-// runtime — compileConfigWithOpts expands apply-groups (tree.ExpandGroups)
-// BEFORE compileSystem reads master-password (compiler_system.go), so the
-// effective config carries the PRF. But this at-rest write path runs on the
-// UNEXPANDED persisted candidate tree (apply-groups expansion happens only on
-// a compile clone), so the group-declared master-password is INVISIBLE to
-// systemBlocksOf, the encrypt gate returns "", and active.json (IKE PSKs,
-// WireGuard keys, SNMP communities, user secrets) is written PLAINTEXT despite
-// encryption being configured via a group.
+//  2. WHICH PRF ALGORITHM?  Must be a SUPPORTED, DETERMINISTIC selector so the
+//     write path never fails and an active↔standby pair reproduces the same
+//     key. Resolve it from the EFFECTIVE/APPLIED scope only — the same
+//     inactive-strip + apply-groups expansion the compiler applies
+//     (effectiveMasterPasswordPRF) — and accept only a selector prfHash
+//     understands. A dormant or unsupported PRF must NOT reach prfHash.
 //
-// Fail CLOSED — err toward encrypting. The group scan is a RECURSIVE walk of
-// the entire `groups { ... }` subtree that treats ANY `master-password`
-// descendant as encryption-configured, regardless of the intervening node
-// name. It deliberately does NOT require a node literally named `system`
-// between the group and the master-password, because a group's children can be
-// authored under a `<*>` wildcard node whose body Junos merges into the
-// top-level `system` stanza at apply-groups expansion (walkGroupToContext /
-// mergeNodes, ast_groups.go). A literal `system`-only scan MISSES that
-// wildcard shape and leaks plaintext end-to-end (the residual this walk
-// closes). The invariant is now: any master-password anywhere under any
-// `groups` block triggers encryption. This over-encrypts on a defined-but-
-// unapplied group (a harmless FALSE-POSITIVE — encrypting when unnecessary is
-// always safe) and can NEVER FALSE-NEGATIVE relative to runtime: apply-groups
-// only COPIES existing leaves, so any PRF active after expansion physically
-// exists somewhere under a group body here. Reusing the compiler's
-// ExpandGroups would instead mutate the very tree we are about to persist and
-// drag ${node}/undefined-group error handling into a write path that must not
-// fail, for no security gain.
+// Why the split matters (M30): the #4578 commit gate (ValidateMasterPasswordPRF)
+// validates the EFFECTIVE tree (inactive stripped, groups expanded), so an
+// UNSUPPORTED PRF hidden in an inactive node or an unapplied group is never
+// rejected at commit. The old resolver's fail-closed SUPERSET, however, scanned
+// every group regardless of application state and returned that unsupported
+// value. On HA config-sync the standby promotes the peer tree in memory
+// (Option B) and then persists it: masterPasswordPRF returned the dormant
+// `bogus`, prfHash rejected it, writeActive failed, and the singleton retry
+// re-selected `bogus` forever — a DETERMINISTIC, non-transient persistence
+// failure that keeps the node /health-503 and its authoritative generation off
+// disk (non-durable across restart). The fix keeps the encryption belt broad
+// (question 1) but constrains the ALGORITHM to a supported effective value,
+// falling back to defaultMasterPasswordPRF rather than poisoning the write with
+// an unsupported selector. Encryption still happens; only a value prfHash
+// accepts ever reaches it.
+//
+// The effective resolution is error-tolerant (any apply-groups expansion error
+// falls through to the supported default), so the "this write path must not
+// fail" contract that originally motivated NOT calling ExpandGroups here still
+// holds — it runs on a clone and never propagates an error.
 func masterPasswordPRF(tree *config.ConfigTree) string {
 	if tree == nil {
 		return ""
 	}
 
-	// Surface 1: every top-level `system { ... }` stanza (#4705).
-	if prf := masterPasswordPRFInSystems(systemBlocksOf(tree)); prf != "" {
+	// Question 1: is at-rest encryption required at all? Fail-closed broad
+	// scan (dormant/unapplied/wildcard included). Empty means plaintext.
+	if !masterPasswordConfigured(tree) {
+		return ""
+	}
+
+	// Question 2: choose a SUPPORTED, DETERMINISTIC algorithm from the
+	// effective/applied scope. A dormant or unsupported effective value must
+	// not reach prfHash on the persistence write path.
+	if prf := effectiveMasterPasswordPRF(tree); prf != "" && prfSupported(prf) {
 		return prf
 	}
 
+	// Encryption is required but the applied config resolves no supported PRF
+	// (belt triggered by dormant content, or an unsupported effective value):
+	// fall back to a fixed supported selector so the DB is still encrypted and
+	// the write stays durable and deterministic across active↔standby.
+	return defaultMasterPasswordPRF
+}
+
+// masterPasswordConfigured reports whether ANY master-password is present in
+// the tree — the fail-closed "must we encrypt?" decision (#4705 split stanzas +
+// #5231 groups/wildcard). It intentionally does NOT strip inactive nodes or
+// require apply-groups: a master-password that exists anywhere (even dormant)
+// means secrets have been or may be configured, and erring toward encryption is
+// always safe. Read-only and total (nil-safe, never errors) — it runs on the
+// config write path, which must not fail.
+func masterPasswordConfigured(tree *config.ConfigTree) bool {
+	if tree == nil {
+		return false
+	}
+	// Surface 1: every top-level `system { ... }` stanza (#4705).
+	if masterPasswordPRFInSystems(systemBlocksOf(tree)) != "" {
+		return true
+	}
 	// Surface 2: any `master-password` anywhere under any `groups { ... }`
 	// block (#5231) — recursive so it catches a master-password nested under a
 	// `<*>` wildcard (or any other intervening node), not only a literal
 	// `system` child.
 	for _, groupsRoot := range groupsBlocksOf(tree) {
-		if prf := masterPasswordPRFInSubtree(groupsRoot); prf != "" {
-			return prf
+		if masterPasswordPRFInSubtree(groupsRoot) != "" {
+			return true
 		}
 	}
-	return ""
+	return false
+}
+
+// effectiveMasterPasswordPRF resolves the master-password PRF from the
+// EFFECTIVE/APPLIED config only — the value the compiler would activate — so
+// the algorithm chosen for at-rest encryption matches the running config and
+// never comes from a dormant (inactive / unapplied-group) subtree. It mirrors
+// the compile/schema path (schemaValidateExpandedTreeForNode): strip inactive
+// THEN expand applied groups, on a CLONE, then scan the resulting top-level
+// `system` stanzas. Returns "" when no active master-password resolves (the
+// caller then uses the supported default).
+//
+// This runs on the config write path, which MUST NOT fail: it operates on a
+// clone (never the persisted tree) and swallows every apply-groups expansion
+// error (returning ""), so a ${node}/undefined-group condition degrades to the
+// default rather than failing the write.
+func effectiveMasterPasswordPRF(tree *config.ConfigTree) string {
+	if tree == nil {
+		return ""
+	}
+	// Fast path: with no groups to expand and no inactive nodes to strip, the
+	// effective scope is exactly the raw top-level `system` stanzas. Scan
+	// directly with zero extra allocation — this covers every normal active
+	// config, keeping it bit-identical to the pre-#5638 resolver.
+	if len(groupsBlocksOf(tree)) == 0 && !tree.HasInactiveNodes() {
+		return masterPasswordPRFInSystems(systemBlocksOf(tree))
+	}
+	stripped := tree.WithoutInactive()
+	expanded := stripped.Clone()
+	if err := expanded.ExpandGroups(); err != nil {
+		// A cluster ${node} group can only be expanded with the node var; the
+		// write path is node-agnostic and the envelope is self-describing
+		// (decrypt reads env.PRF), so a deterministic node0 substitution is
+		// enough to resolve a supported selector. Any residual error degrades
+		// to "" → the caller's supported default (the write must not fail).
+		if strings.Contains(err.Error(), `undefined group "${node}"`) {
+			vars := map[string]string{"node": "node0"}
+			if err2 := expanded.ExpandGroupsWithVars(vars); err2 != nil {
+				return ""
+			}
+		} else {
+			return ""
+		}
+	}
+	return masterPasswordPRFInSystems(systemBlocksOf(expanded))
+}
+
+// prfSupported reports whether prf is a selector prfHash can key encryption
+// with. It is the single gate that keeps an unsupported PRF — one that slipped
+// past the #4578 commit gate through a tolerant HA/upgrade load — off the
+// deterministic persistence-retry path (#5638).
+func prfSupported(prf string) bool {
+	_, err := prfHash(prf)
+	return err == nil
 }
 
 // masterPasswordPRFInSystems returns the first non-empty master-password

--- a/pkg/configstore/masterpw_apply_groups_5231_test.go
+++ b/pkg/configstore/masterpw_apply_groups_5231_test.go
@@ -133,6 +133,13 @@ func TestMasterPasswordPRFSurfaces(t *testing.T) {
 
 	// A group that defines master-password but is NOT applied still triggers
 	// encryption (fail-closed superset — a harmless false-positive encrypt).
+	// Post-#5638 the encryption belt still fires (masterPasswordConfigured sees
+	// the group), but the PRF ALGORITHM is now resolved from the EFFECTIVE scope
+	// only: the group is unapplied, so it contributes no effective master-
+	// password and the resolver falls back to the supported default
+	// (defaultMasterPasswordPRF == "sha256"). The value is the same here only
+	// because the group also declared sha256; the point is the DB is encrypted
+	// with a SUPPORTED selector, never a dormant one.
 	unappliedTree, errs := config.NewParser(`groups {
     enc {
         system {

--- a/pkg/configstore/masterpw_dormant_prf_5638_test.go
+++ b/pkg/configstore/masterpw_dormant_prf_5638_test.go
@@ -1,0 +1,227 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5638 (codex-review-181 M30): masterPasswordPRF must never hand a DORMANT
+// (inactive / unapplied-group) or UNSUPPORTED pseudorandom-function to the
+// at-rest persistence write path. The #4578 commit gate validates the EFFECTIVE
+// tree (inactive stripped, apply-groups expanded), so an unsupported PRF hidden
+// in an inactive node or an unapplied group is never rejected at commit. The
+// pre-fix fail-closed SUPERSET, however, scanned every group regardless of
+// application state and returned that unsupported value; on the HA config-sync
+// / tolerant-load path prfHash then rejected it, writeActive failed, and the
+// singleton retry re-selected the same bad value forever — a deterministic,
+// non-durable persistence failure (node stuck /health-503, authoritative
+// generation never reaches disk).
+//
+// The fix separates "encryption is required" (broad, fail-closed) from "which
+// PRF algorithm" (effective scope only, supported selector only, else the
+// supported default). These tests fail on pre-fix code:
+//   - the value tests: pre-fix masterPasswordPRF returns "bogus"/"sha512".
+//   - the durability tests: pre-fix WriteActive/SyncApply cannot persist a
+//     "bogus" selector (prfHash rejects it), leaving the store persist-degraded.
+
+// unappliedGroupUnsupportedPRFText declares master-password ONLY inside an
+// UNAPPLIED group body carrying an UNSUPPORTED selector `bogus`. No
+// `apply-groups enc` references it, so it is dormant: the effective config has
+// no master-password at all. This is the exact M30 shape a pre-#5231 build (or
+// an inactive edit) could persist, then load after upgrade and push over HA
+// config-sync.
+const unappliedGroupUnsupportedPRFText = `groups {
+    enc {
+        system {
+            master-password {
+                pseudorandom-function bogus;
+            }
+        }
+    }
+}
+system {
+    host-name dormant-unsupported-fw;
+}
+`
+
+// inactiveSupportedPRFText carries an INACTIVE master-password with a SUPPORTED
+// but non-default selector `sha512`. The effective (inactive-stripped) config
+// has no master-password, so the resolved algorithm must come from the default,
+// not the dormant `sha512` — proving the effective-scope constraint
+// independently of the unsupported-value path.
+const inactiveSupportedPRFText = `system {
+    host-name inactive-mp-fw;
+    inactive: master-password {
+        pseudorandom-function sha512;
+    }
+}
+`
+
+// TestMasterPasswordPRF_DormantUnsupportedResolvesSupported: a dormant
+// (unapplied-group) UNSUPPORTED PRF still triggers encryption (fail-closed) but
+// resolves to a SUPPORTED selector, never the raw `bogus` value. Pre-fix
+// returns "bogus" (RED — both the not-bogus and prfSupported assertions fail).
+func TestMasterPasswordPRF_DormantUnsupportedResolvesSupported(t *testing.T) {
+	tree, errs := config.NewParser(unappliedGroupUnsupportedPRFText).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse error: %v", errs[0])
+	}
+
+	// Premise: the unsupported PRF is reachable ONLY through the group body;
+	// no active top-level system carries it.
+	for _, sys := range systemBlocksOf(tree) {
+		if sys.FindChild("master-password") != nil {
+			t.Fatalf("test premise broken: a top-level system stanza carries master-password")
+		}
+	}
+	if len(groupsBlocksOf(tree)) == 0 {
+		t.Fatalf("test premise broken: expected a top-level groups stanza")
+	}
+
+	// Encryption is still required (fail-closed): the belt must fire even for a
+	// dormant master-password.
+	if !masterPasswordConfigured(tree) {
+		t.Fatal("masterPasswordConfigured = false, want true (a dormant master-password must still require encryption)")
+	}
+
+	prf := masterPasswordPRF(tree)
+	if prf == "bogus" {
+		t.Fatal("masterPasswordPRF returned the dormant UNSUPPORTED selector \"bogus\" — it would " +
+			"deterministically fail the persistence write (#5638 M30)")
+	}
+	if !prfSupported(prf) {
+		t.Fatalf("masterPasswordPRF = %q, which prfHash rejects — the write path must only ever "+
+			"receive a supported selector", prf)
+	}
+	if prf != defaultMasterPasswordPRF {
+		t.Fatalf("masterPasswordPRF = %q, want the supported default %q (dormant/unsupported PRF must "+
+			"resolve to the default)", prf, defaultMasterPasswordPRF)
+	}
+}
+
+// TestMasterPasswordPRF_IgnoresInactiveSupportedValue proves the effective-scope
+// constraint: an INACTIVE master-password's supported selector (`sha512`) is
+// ignored; the resolver returns the default because the effective config has no
+// master-password. Pre-fix Surface-1 scan returns "sha512" (RED).
+func TestMasterPasswordPRF_IgnoresInactiveSupportedValue(t *testing.T) {
+	tree, errs := config.NewParser(inactiveSupportedPRFText).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse error: %v", errs[0])
+	}
+
+	// Premise: the master-password node parsed as inactive.
+	sys := tree.FindChild("system")
+	if sys == nil {
+		t.Fatal("test premise broken: no system stanza")
+	}
+	mp := sys.FindChild("master-password")
+	if mp == nil {
+		t.Fatal("test premise broken: no master-password node")
+	}
+	if !mp.Inactive {
+		t.Fatalf("test premise broken: master-password node is not inactive (Inactive=%v)", mp.Inactive)
+	}
+
+	// Fail-closed: an inactive master-password still triggers encryption.
+	if !masterPasswordConfigured(tree) {
+		t.Fatal("masterPasswordConfigured = false, want true (an inactive master-password must still require encryption)")
+	}
+
+	if prf := masterPasswordPRF(tree); prf != defaultMasterPasswordPRF {
+		t.Fatalf("masterPasswordPRF = %q, want %q — the dormant inactive `sha512` must be ignored and "+
+			"the effective scope resolves to the supported default (#5638)", prf, defaultMasterPasswordPRF)
+	}
+}
+
+// TestWriteActive_DormantUnsupportedPRFDurable: DB.WriteActive of the
+// dormant-unsupported config must SUCCEED, encrypt the body, and round-trip.
+// Pre-fix WriteActive fails with an "unsupported master-password
+// pseudorandom-function" error from prfHash (RED).
+func TestWriteActive_DormantUnsupportedPRFDurable(t *testing.T) {
+	tree, errs := config.NewParser(unappliedGroupUnsupportedPRFText).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse error: %v", errs[0])
+	}
+
+	dir := t.TempDir()
+	db, err := NewDB(dir)
+	if err != nil {
+		t.Fatalf("NewDB() error = %v", err)
+	}
+	if err := db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive() error = %v (a dormant unsupported PRF must not fail the write)", err)
+	}
+
+	raw, err := os.ReadFile(db.activePath())
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.Contains(string(raw), "dormant-unsupported-fw") {
+		t.Fatalf("config leaked plaintext to disk despite a configured master-password: %s", string(raw))
+	}
+	if !strings.Contains(string(raw), encryptedTreeFormat) {
+		t.Fatalf("config was not encrypted (missing envelope marker): %s", string(raw))
+	}
+
+	got, err := db.ReadActive()
+	if err != nil {
+		t.Fatalf("ReadActive() error = %v", err)
+	}
+	if got.FormatJSON() != tree.FormatJSON() {
+		t.Fatalf("ReadActive() mismatch\ngot:\n%s\nwant:\n%s", got.FormatJSON(), tree.FormatJSON())
+	}
+}
+
+// TestSyncApply_DormantUnsupportedPRFStaysDurable is the strongest M30
+// reproduction: an HA config-sync of a config whose ONLY master-password is a
+// dormant unsupported PRF must persist durably — NOT leave the store
+// persist-degraded on an endless retry. It also verifies the persisted config
+// survives a restart (a fresh Store loads and round-trips it).
+//
+// Pre-fix: SyncApply promotes the tree in memory (Option B) but writeActive
+// fails (prfHash rejects "bogus"), so ConfigPersistDegraded() stays TRUE
+// forever (RED). Post-fix the write lands with the supported default.
+func TestSyncApply_DormantUnsupportedPRFStaysDurable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	store := newTestStoreAt(t, path)
+
+	if _, err := store.SyncApply(unappliedGroupUnsupportedPRFText, nil); err != nil {
+		t.Fatalf("SyncApply() error = %v", err)
+	}
+
+	if store.ConfigPersistDegraded() {
+		t.Fatal("ConfigPersistDegraded = true after SyncApply — the dormant unsupported PRF put " +
+			"persistence on a deterministic retry loop; the peer's authoritative config never reaches disk (#5638 M30)")
+	}
+
+	// The persisted body must be encrypted (a master-password is configured).
+	raw, err := os.ReadFile(store.db.activePath())
+	if err != nil {
+		t.Fatalf("ReadFile(active) error = %v", err)
+	}
+	if !strings.Contains(string(raw), encryptedTreeFormat) {
+		t.Fatalf("synced config not encrypted (missing envelope marker): %s", string(raw))
+	}
+	if strings.Contains(string(raw), "dormant-unsupported-fw") {
+		t.Fatalf("synced config leaked plaintext host-name to disk: %s", string(raw))
+	}
+
+	// Durable across restart: a fresh store at the same path loads the
+	// persisted (encrypted) config without error and recovers the host-name.
+	reloaded := newTestStoreAt(t, path)
+	if err := reloaded.Load(); err != nil {
+		t.Fatalf("reload Load() error = %v (persisted config is not durable)", err)
+	}
+	active := reloaded.ActiveConfig()
+	if active == nil {
+		t.Fatal("reloaded ActiveConfig is nil — the synced config did not survive restart")
+	}
+	if active.System.HostName != "dormant-unsupported-fw" {
+		t.Fatalf("reloaded host-name = %q, want %q", active.System.HostName, "dormant-unsupported-fw")
+	}
+}


### PR DESCRIPTION
## Summary

`masterPasswordPRF` (`pkg/configstore/crypto.go`) resolved the at-rest
encryption PRF with a single fail-closed superset scan over every group and
every top-level `system` stanza — **regardless of application state**. That
conflated two distinct questions and let a **dormant** (inactive /
unapplied-group) or **unsupported** master-password `pseudorandom-function`
reach the persistence write path.

The #4578 commit gate (`ValidateMasterPasswordPRF`) validates the **effective**
tree (inactive stripped, apply-groups expanded), so an unsupported PRF (e.g.
`bogus`) hidden in an inactive node or an unapplied group is never rejected at
commit — yet the old resolver returned it. On the tolerant HA config-sync /
upgrade-load path this is a **deterministic durability defect**: the standby
promotes the peer tree in memory (Option B degrade-not-fail), `writeActive`
calls `prfHash` which rejects the unsupported selector, the write fails, and the
singleton retry re-selects the same value forever — node stuck `/health`-503,
authoritative generation permanently off disk, non-durable across restart
(codex-review-181 **M30** / A4-b00-F002).

## Fix

Split `masterPasswordPRF` into two separable decisions:

1. **Is encryption required?** — `masterPasswordConfigured`: the fail-closed
   broad scan (any master-password anywhere, dormant included). Preserves the
   #4705 split-stanza and #5231 groups/`<*>`-wildcard plaintext-leak fixes.
2. **Which PRF algorithm?** — `effectiveMasterPasswordPRF`: resolved from the
   **effective/applied** scope only (strip inactive **then** expand applied
   groups on a clone, mirroring the compiler / `schemaValidateExpandedTree`
   path), accepting only a `prfHash`-supported selector; otherwise a fixed
   supported default (`sha256`).

A dormant/unsupported PRF can no longer reach `prfHash`: encryption still
happens, but only a value `prfHash` accepts ever keys it — deterministic and
durable across active↔standby. The effective resolution runs on a clone and
swallows every apply-groups expansion error (degrading to the default), so the
"this write path must not fail" contract still holds. A normal single active
supported-PRF config takes a **zero-allocation fast path** and is bit-identical
to the pre-fix resolver.

Adjacent-but-distinct from #5231 (under-scanned groups → plaintext) and #4578
(active typo disables encryption): this is the unowned mismatch between
crypto-selector scope and effective-validation scope, plus the unsupported-PRF
error class on the HA retry path.

## Validation

- `go build ./...` clean; `go test ./pkg/configstore/... ./pkg/config/...` green; `gofmt` clean.
- New fail-on-revert tests (`masterpw_dormant_prf_5638_test.go`): value path
  (dormant/unsupported + dormant/inactive-supported both resolve to a supported
  selector), `DB.WriteActive` durability, and `Store.SyncApply` + reload
  durability.
- **RED-on-revert proven**: reverting `masterPasswordPRF` to the pre-fix
  superset makes all four FAIL — returns `"bogus"`/`"sha512"`, `WriteActive`
  errors with `unsupported master-password pseudorandom-function "bogus"`, and
  `SyncApply` leaves `ConfigPersistDegraded()==true` (the exact M30 symptom).
  Restoring → GREEN.

Closes #5638

🤖 Generated with [Claude Code](https://claude.com/claude-code)