### PR TITLE
appid/nat: expand predefined app bundles via shared resolver

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46637,3 +46637,28 @@ top.
     pkg/daemon/ribgroup_zero_leak_5642_test.go,
     pkg/dataplane/userspace/routes_ribgroup_zero_5642_test.go,
     docs/rib-group-route-leaking.md
+
+- **Timestamp**: 2026-07-11
+  **Action**: #5629 — route predefined application bundles through the shared
+    predefined-set-aware resolver on the AppID-disabled catalog + both NAT
+    builders. `pkg/appid/runtime.go:CatalogNames.addAppRef`, source-NAT
+    `buildSourceNATAppTerms`, and destination-NAT `buildDestinationNATSnapshots`
+    all gated set expansion on a bare `cfg.Applications.ApplicationSets[name]`
+    membership test (user-defined sets ONLY), so a strict predefined bundle
+    (junos-ms-rpc/junos-sun-rpc/junos-cifs/junos-routing-inbound) referenced by
+    a policy or a SNAT/DNAT `match application` was recorded as a bare app name
+    in the catalog and resolved to ZERO NAT terms (SNAT → natProtoNever, DNAT →
+    #3434 never-match sentinel), silently never translating. Fixed all three to
+    resolve app-first (user then predefined) then via `config.ResolveApplication
+    Set` (user then predefined table, #4102), matching the policy path
+    `resolveUserspaceApplicationNames`. Preserved the #5179 nil-user-set
+    fail-closed error (raw user-map membership retained alongside the
+    predefined-aware lookup) and the app-first shadowing precedence. RED-on-
+    revert proven for all 4 bug tests (catalog bare-name + SNAT/DNAT sentinels);
+    2 bit-identical guards (user-set, user-app-shadow) stay green on both sides.
+    Build + pkg/appid + pkg/config + pkg/dataplane/userspace tests green.
+  **File(s)**: pkg/appid/runtime.go, pkg/dataplane/userspace/nat_source.go,
+    pkg/dataplane/userspace/nat_destination.go,
+    pkg/appid/catalog_predefined_set_5629_test.go,
+    pkg/dataplane/userspace/nat_predefined_set_5629_test.go,
+    docs/services-application-identification.md

--- a/docs/services-application-identification.md
+++ b/docs/services-application-identification.md
@@ -331,6 +331,25 @@ runtime effect is the L3/L4 catalog classification above
   parent set also matches applications defined only in a nested
   child set. (Before #2068 the compiler silently dropped nested
   `application-set` members, so such a policy under-matched.)
+  A referenced set is resolved through `config.ResolveApplicationSet`
+  (user-defined sets first, then the built-in `junos-defaults`
+  bundle table `PredefinedApplicationSets` — junos-ms-rpc,
+  junos-sun-rpc, junos-cifs, junos-routing-inbound, #4102).
+  `CatalogNames` (AppID-disabled catalog) and BOTH NAT snapshot
+  builders (`buildSourceNATAppTerms` / `buildDestinationNATSnapshots`,
+  `pkg/dataplane/userspace/nat_source.go` / `nat_destination.go`)
+  go through that same predefined-set-aware lookup, so a strict
+  predefined bundle named in a security policy OR a source/destination
+  NAT `match application` expands to the SAME member applications on
+  every path. (Before #5629 the catalog and the two NAT builders gated
+  set expansion on a bare `cfg.Applications.ApplicationSets[name]` map
+  membership test, which only sees user-defined sets: a predefined
+  bundle was recorded as a bare app name in the catalog and resolved to
+  ZERO terms in NAT — the SNAT rule failed closed to `natProtoNever`
+  and the DNAT rule to the #3434 never-match sentinel, silently never
+  translating. A user application whose name shadows a predefined-set
+  name still wins — the application is resolved first, matching the
+  policy path `resolveUserspaceApplicationNames`.)
 
 These config paths are accepted with NO runtime effect today
 (parse-only):

--- a/pkg/appid/catalog_predefined_set_5629_test.go
+++ b/pkg/appid/catalog_predefined_set_5629_test.go
@@ -1,0 +1,139 @@
+// #5629: with AppID DISABLED, appid.CatalogNames must expand a strict
+// PREDEFINED application-set bundle (junos-ms-rpc, junos-sun-rpc, junos-cifs,
+// junos-routing-inbound) to its member applications — the SAME members the
+// shared resolver (config.ResolveApplicationSet + config.ExpandApplicationSet,
+// #4102) yields, and the SAME members the AppID-enabled full catalog carries.
+//
+// Before this fix the per-reference resolver (addAppRef) gated set expansion on
+// a bare cfg.Applications.ApplicationSets map membership test, which only sees
+// USER-defined sets. A predefined bundle name therefore fell through and was
+// recorded as if the bundle NAME were itself an application, so the dataplane
+// catalog carried a set name with no resolvable port/proto — diverging from the
+// resolver's member expansion.
+//
+// RED-on-revert: restore the `cfg.Applications.ApplicationSets[appName]` guard
+// (drop the config.ResolveApplication/ResolveApplicationSet reorder) and
+// CatalogNames records the bare "junos-ms-rpc" token instead of its members,
+// failing the containment and resolver-parity asserts below.
+package appid
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func hasName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// A predefined bundle referenced by a security policy must expand in the
+// AppID-disabled catalog to exactly the resolver's members.
+func TestCatalogNamesPredefinedSetPolicyReference_5629(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = false // AppID DISABLED
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		{Name: "p1", Match: config.PolicyMatch{Applications: []string{"junos-ms-rpc"}}},
+	}
+
+	names, err := CatalogNames(cfg, false)
+	if err != nil {
+		t.Fatalf("CatalogNames() error = %v", err)
+	}
+
+	// (1) The bundle NAME must NOT be recorded as an application.
+	if hasName(names, "junos-ms-rpc") {
+		t.Fatalf("catalog recorded the bare bundle name %q as an application "+
+			"(the #5629 bypass): %v", "junos-ms-rpc", names)
+	}
+	// (2) The members must be present.
+	for _, member := range []string{"junos-ms-rpc-tcp", "junos-ms-rpc-udp"} {
+		if !hasName(names, member) {
+			t.Fatalf("catalog missing predefined-bundle member %q: %v", member, names)
+		}
+	}
+	// (3) Resolver parity: the disabled-path catalog must equal the shared
+	// resolver's expansion (config.ExpandApplicationSet), sorted.
+	expanded, err := config.ExpandApplicationSet("junos-ms-rpc", &cfg.Applications)
+	if err != nil {
+		t.Fatalf("ExpandApplicationSet: %v", err)
+	}
+	sort.Strings(expanded)
+	sortedNames := append([]string(nil), names...)
+	sort.Strings(sortedNames)
+	if !reflect.DeepEqual(sortedNames, expanded) {
+		t.Fatalf("AppID-disabled catalog %v != resolver expansion %v", sortedNames, expanded)
+	}
+	// (4) AppID-enabled-path parity: every member is present in the full
+	// (includeAll) catalog, which compiles every predefined application.
+	full, err := CatalogNames(cfg, true)
+	if err != nil {
+		t.Fatalf("CatalogNames(includeAll) error = %v", err)
+	}
+	for _, member := range expanded {
+		if !hasName(full, member) {
+			t.Fatalf("member %q missing from the AppID-enabled full catalog", member)
+		}
+	}
+}
+
+// The same expansion must hold when the predefined bundle is referenced ONLY by
+// a NAT rule (the #3626 NAT-reference walk shares addAppRef).
+func TestCatalogNamesPredefinedSetNATReference_5629(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = false
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name: "rs", FromZone: "trust", ToZone: "untrust",
+		Rules: []*config.NATRule{{
+			Name:  "r1",
+			Match: config.NATMatch{SourceAddress: "10.0.0.0/24", Application: "junos-sun-rpc"},
+		}},
+	}}
+
+	names, err := CatalogNames(cfg, false)
+	if err != nil {
+		t.Fatalf("CatalogNames() error = %v", err)
+	}
+	if hasName(names, "junos-sun-rpc") {
+		t.Fatalf("catalog recorded the bare NAT-referenced bundle name: %v", names)
+	}
+	for _, member := range []string{"junos-sun-rpc-tcp", "junos-sun-rpc-udp"} {
+		if !hasName(names, member) {
+			t.Fatalf("catalog missing NAT-referenced bundle member %q: %v", member, names)
+		}
+	}
+}
+
+// A user application whose name collides with a predefined-set name must keep
+// application semantics (user definitions win, matching resolveUserspace
+// ApplicationNames). This guards the app-first precedence of the fix.
+func TestCatalogNamesUserAppShadowsPredefinedSet_5629(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = false
+	cfg.Applications.Applications = map[string]*config.Application{
+		"junos-ms-rpc": {Name: "junos-ms-rpc", Protocol: "tcp", DestinationPort: "9999"},
+	}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		{Name: "p1", Match: config.PolicyMatch{Applications: []string{"junos-ms-rpc"}}},
+	}
+
+	names, err := CatalogNames(cfg, false)
+	if err != nil {
+		t.Fatalf("CatalogNames() error = %v", err)
+	}
+	// The user application wins: the token stays recorded as the application,
+	// NOT expanded to the predefined bundle's members.
+	if !hasName(names, "junos-ms-rpc") {
+		t.Fatalf("user application shadowing a predefined-set name was dropped: %v", names)
+	}
+	if hasName(names, "junos-ms-rpc-tcp") || hasName(names, "junos-ms-rpc-udp") {
+		t.Fatalf("predefined bundle wrongly shadowed the user application: %v", names)
+	}
+}

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -63,7 +63,35 @@ func CatalogNames(cfg *config.Config, includeAll bool) ([]string, error) {
 		if appName == "" || appName == "any" {
 			return nil
 		}
-		if _, isSet := cfg.Applications.ApplicationSets[appName]; isSet {
+		// Resolve a reference the SAME way the userspace policy path does
+		// (resolveUserspaceApplicationNames, #4102): an application FIRST (user
+		// then predefined), then an application-SET (user then predefined). The
+		// set test MUST go through config.ResolveApplicationSet, which is
+		// predefined-set-aware — a bare cfg.Applications.ApplicationSets map
+		// membership check only sees USER-defined sets, so a strict predefined
+		// bundle (junos-ms-rpc, junos-sun-rpc, junos-cifs,
+		// junos-routing-inbound) referenced by a policy OR a NAT rule was
+		// recorded as if the bundle NAME were itself an application (#5629). The
+		// dataplane catalog then carried a set name with no resolvable
+		// port/proto, diverging from the resolver's member expansion. Resolving
+		// the application first keeps a user application that shadows a
+		// predefined-set name winning (user definitions win, matching the policy
+		// path); an unknown token still falls through to a bare record so the
+		// catalog and the dataplane agree on the reference.
+		if _, isApp := config.ResolveApplication(appName, cfg.Applications.Applications); isApp {
+			names[appName] = struct{}{}
+			return nil
+		}
+		// A present-but-nil USER set slot (#5179: the tolerant-load / peer-sync
+		// path admits a null value) must still be treated as a set reference so
+		// it fails CLOSED with a deterministic ExpandApplicationSet error rather
+		// than being silently recorded as a bare app name. config.Resolve
+		// ApplicationSet SKIPS a nil slot (returns false), so the raw user-map
+		// membership test is kept for that case; ResolveApplicationSet ADDS the
+		// predefined bundle awareness (#5629) a bare membership test misses.
+		_, inUserSetMap := cfg.Applications.ApplicationSets[appName]
+		_, isSet := config.ResolveApplicationSet(appName, cfg.Applications.ApplicationSets)
+		if inUserSetMap || isSet {
 			expanded, err := config.ExpandApplicationSet(appName, &cfg.Applications)
 			if err != nil {
 				return fmt.Errorf("expand application-set %q: %w", appName, err)

--- a/pkg/dataplane/userspace/nat_destination.go
+++ b/pkg/dataplane/userspace/nat_destination.go
@@ -298,7 +298,16 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 					app, found := config.ResolveApplication(appName, userApps)
 					if found {
 						appTerms = append(appTerms, appTermFor(app))
-					} else if _, isSet := cfg.Applications.ApplicationSets[appName]; isSet {
+					} else if _, isSet := config.ResolveApplicationSet(appName, cfg.Applications.ApplicationSets); isSet {
+						// #5629: resolve the SET through the #4102
+						// predefined-set-aware config.ResolveApplicationSet, NOT a
+						// bare cfg.Applications.ApplicationSets membership test
+						// (USER sets only). A strict predefined bundle
+						// (junos-ms-rpc, junos-sun-rpc, ...) referenced by a
+						// destination-NAT rule otherwise resolved to zero terms and
+						// fell through to the #3434 never-match sentinel — the DNAT
+						// rule silently disabled. ExpandApplicationSet falls back to
+						// the predefined table, so a user set stays bit-identical.
 						expanded, err := config.ExpandApplicationSet(appName, &cfg.Applications)
 						if err == nil {
 							for _, termName := range expanded {

--- a/pkg/dataplane/userspace/nat_predefined_set_5629_test.go
+++ b/pkg/dataplane/userspace/nat_predefined_set_5629_test.go
@@ -1,0 +1,190 @@
+// #5629: a strict PREDEFINED application-set bundle (junos-ms-rpc,
+// junos-sun-rpc, junos-cifs, junos-routing-inbound) referenced by a source-NAT
+// or destination-NAT `match application` MUST expand to its member
+// applications, exactly as the #4102 shared resolver (config.ResolveApplication
+// Set + config.ExpandApplicationSet) does. Before this fix both NAT snapshot
+// builders gated set expansion on a bare cfg.Applications.ApplicationSets map
+// membership test, which only sees USER-defined sets. A predefined bundle
+// matched neither the application branch nor the (user-only) set branch, so:
+//   - source NAT resolved zero terms and failed CLOSED to natProtoNever, so the
+//     rule silently never translated;
+//   - destination NAT resolved zero terms, fell through to the #3434 never-match
+//     sentinel, and silently disabled the rule.
+//
+// RED-on-revert: restore the `cfg.Applications.ApplicationSets[appName]` guard
+// (drop the config.ResolveApplicationSet call) and both builders stop expanding
+// junos-ms-rpc — the SNAT term collapses to the single natProtoNever sentinel
+// and the DNAT rule collapses to one Protocol="" never-match snapshot, failing
+// the member-expansion asserts below.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// protoPort is a compact (protocol, destination-port) pair used to compare the
+// expanded NAT terms against the expected predefined-bundle members regardless
+// of member ordering.
+type protoPort struct {
+	proto uint16
+	port  uint16
+}
+
+func TestSourceNATPredefinedApplicationSetExpands_5629(t *testing.T) {
+	cfg := &config.Config{}
+	// AppID disabled — the NAT expansion must be predefined-set-aware anyway.
+	cfg.Services.ApplicationIdentification = false
+	// NOTE: junos-ms-rpc is NOT defined in cfg.Applications.ApplicationSets. It
+	// is a PREDEFINED bundle (config.PredefinedApplicationSets) referenced by
+	// name only, which is exactly the #5629 bypass condition.
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"sp1": {Name: "sp1", Address: "203.0.113.5"},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name:     "rs",
+		FromZone: "trust",
+		ToZone:   "untrust",
+		Rules: []*config.NATRule{{
+			Name: "r1",
+			Match: config.NATMatch{
+				SourceAddress: "10.0.0.0/24",
+				Application:   "junos-ms-rpc",
+			},
+			Then: config.NATThen{Type: config.NATSource, PoolName: "sp1"},
+		}},
+	}}
+
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	terms := snaps[0].MatchApplications
+	// junos-ms-rpc = { junos-ms-rpc-tcp (tcp/135), junos-ms-rpc-udp (udp/135) }.
+	// tcp=6, udp=17 per appid.ProtocolNumber.
+	want := map[protoPort]bool{
+		{proto: 6, port: 135}:  true,
+		{proto: 17, port: 135}: true,
+	}
+	if len(terms) != len(want) {
+		t.Fatalf("MatchApplications = %+v (len %d), want %d terms (tcp/135 + udp/135); "+
+			"the predefined bundle silently failed CLOSED to the natProtoNever "+
+			"sentinel on the pre-fix bypass", terms, len(terms), len(want))
+	}
+	for _, term := range terms {
+		if term.Protocol == natProtoNever {
+			t.Fatalf("MatchApplications carries the natProtoNever sentinel %+v — "+
+				"the predefined bundle resolved to no terms (the #5629 bypass)", term)
+		}
+		if len(term.Ports) != 1 {
+			t.Fatalf("term %+v: want exactly one destination-port range", term)
+		}
+		pp := protoPort{proto: term.Protocol, port: term.Ports[0].Low}
+		if term.Ports[0].Low != term.Ports[0].High {
+			t.Fatalf("term %+v: want an exact port (Low==High)", term)
+		}
+		if !want[pp] {
+			t.Fatalf("unexpected term %+v (proto %d port %d)", term, pp.proto, pp.port)
+		}
+		delete(want, pp)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing expected predefined-bundle terms: %+v", want)
+	}
+}
+
+func TestDestinationNATPredefinedApplicationSetExpands_5629(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = false
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"p1": {Name: "p1", Address: "192.168.1.10", Port: 8080},
+		},
+		RuleSets: []*config.NATRuleSet{{
+			Name:     "rs",
+			FromZone: "untrust",
+			Rules: []*config.NATRule{{
+				Name: "r1",
+				Match: config.NATMatch{
+					DestinationAddress: "203.0.113.10",
+					Application:        "junos-ms-rpc", // PREDEFINED bundle
+				},
+				Then: config.NATThen{Type: config.NATDestination, PoolName: "p1"},
+			}},
+		}},
+	}
+
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	// One snapshot per resolved member (tcp/135, udp/135) × one destination.
+	if len(snaps) != 2 {
+		t.Fatalf("snapshots = %d, want 2 (tcp/135 + udp/135); the predefined "+
+			"bundle collapsed to the #3434 never-match sentinel on the pre-fix "+
+			"bypass: %+v", len(snaps), snaps)
+	}
+	want := map[protoPort]bool{
+		{proto: 6, port: 135}:  true, // "tcp" resolved below
+		{proto: 17, port: 135}: true, // "udp"
+	}
+	protoNum := func(s string) uint16 {
+		switch s {
+		case "tcp":
+			return 6
+		case "udp":
+			return 17
+		}
+		return 0xFFFF
+	}
+	for _, s := range snaps {
+		if s.Protocol == "" {
+			t.Fatalf("snapshot %+v carries an empty protocol — the never-match "+
+				"sentinel of the #5629 bypass", s)
+		}
+		pp := protoPort{proto: protoNum(s.Protocol), port: s.DestinationPort}
+		if !want[pp] {
+			t.Fatalf("unexpected snapshot proto=%q port=%d (%+v)", s.Protocol, s.DestinationPort, s)
+		}
+		delete(want, pp)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing expected predefined-bundle DNAT snapshots: %+v", want)
+	}
+}
+
+// A USER-defined application-set must stay bit-identical: the fix only widened
+// the SET lookup to be predefined-aware, so a user set still resolves through
+// exactly the same expansion path. This guards against a precedence regression.
+func TestSourceNATUserApplicationSetUnaffected_5629(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = false
+	cfg.Applications.Applications = map[string]*config.Application{
+		"my-tcp": {Name: "my-tcp", Protocol: "tcp", DestinationPort: "4444"},
+		"my-udp": {Name: "my-udp", Protocol: "udp", DestinationPort: "5555"},
+	}
+	cfg.Applications.ApplicationSets = map[string]*config.ApplicationSet{
+		"my-set": {Name: "my-set", Applications: []string{"my-tcp", "my-udp"}},
+	}
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"sp1": {Name: "sp1", Address: "203.0.113.5"},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{{
+		Name: "rs", FromZone: "trust", ToZone: "untrust",
+		Rules: []*config.NATRule{{
+			Name:  "r1",
+			Match: config.NATMatch{SourceAddress: "10.0.0.0/24", Application: "my-set"},
+			Then:  config.NATThen{Type: config.NATSource, PoolName: "sp1"},
+		}},
+	}}
+
+	terms := buildSourceNATSnapshots(cfg, nil)[0].MatchApplications
+	want := map[protoPort]bool{{proto: 6, port: 4444}: true, {proto: 17, port: 5555}: true}
+	if len(terms) != len(want) {
+		t.Fatalf("user application-set expansion changed: got %+v, want tcp/4444 + udp/5555", terms)
+	}
+	for _, term := range terms {
+		pp := protoPort{proto: term.Protocol, port: term.Ports[0].Low}
+		if !want[pp] {
+			t.Fatalf("unexpected user-set term %+v", term)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/nat_source.go
+++ b/pkg/dataplane/userspace/nat_source.go
@@ -407,7 +407,16 @@ func buildSourceNATAppTerms(cfg *config.Config, appNames []string) []NatAppTermW
 		}
 		if app, found := config.ResolveApplication(appName, userApps); found {
 			addApp(app)
-		} else if _, isSet := cfg.Applications.ApplicationSets[appName]; isSet {
+		} else if _, isSet := config.ResolveApplicationSet(appName, cfg.Applications.ApplicationSets); isSet {
+			// #5629: resolve the SET through config.ResolveApplicationSet (the
+			// #4102 predefined-set-aware lookup), NOT a bare
+			// cfg.Applications.ApplicationSets membership test which only sees
+			// USER-defined sets. A strict predefined bundle (junos-ms-rpc,
+			// junos-sun-rpc, ...) referenced by a source-NAT rule otherwise
+			// matched neither branch, resolved to zero terms, and failed CLOSED
+			// to natProtoNever (never-match) — the rule silently never
+			// translated. ExpandApplicationSet already falls back to the
+			// predefined set table, so a user-defined set stays bit-identical.
 			if expanded, err := config.ExpandApplicationSet(appName, &cfg.Applications); err == nil {
 				for _, termName := range expanded {
 					if a, ok := config.ResolveApplication(termName, userApps); ok {


### PR DESCRIPTION
## Summary

A strict **predefined application-set bundle** (`junos-ms-rpc`, `junos-sun-rpc`, `junos-cifs`, `junos-routing-inbound`) referenced by a security policy or a source/destination-NAT `match application` resolved **differently** on the AppID-disabled catalog path and the two NAT snapshot builders than it did through the #4102 shared resolver.

All three sites gated application-set expansion on a bare `cfg.Applications.ApplicationSets[name]` map membership test, which only sees **user-defined** sets. A predefined bundle matched neither the application branch nor the (user-only) set branch:

- **`pkg/appid/runtime.go` `CatalogNames`** recorded the bundle NAME as if it were an application → the dataplane catalog carried a set name with no resolvable port/proto.
- **source NAT (`buildSourceNATAppTerms`)** resolved zero terms → failed CLOSED to the `natProtoNever` sentinel → the SNAT rule silently never translated.
- **destination NAT (`buildDestinationNATSnapshots`)** resolved zero terms → fell through to the #3434 never-match sentinel → the DNAT rule was silently disabled.

## Fix

Route all three through `config.ResolveApplicationSet` (user-defined sets first, then the predefined `PredefinedApplicationSets` table, #4102), resolving an application **first** so a user application shadowing a predefined-set name still wins — matching the userspace policy path `resolveUserspaceApplicationNames`.

The catalog resolver keeps its raw user-map membership check **alongside** the predefined-aware lookup so a present-but-nil user set slot still fails CLOSED with a deterministic expansion error (#5179) instead of being recorded as a bare app name.

## Not changed (bit-identical)

- User-defined application-sets and the AppID-**enabled** full catalog — the change only widens the SET lookup to be predefined-aware.
- Static NAT (carries no `match application`).

## Validation

New fail-on-revert tests assert a predefined bundle referenced by a policy, a SNAT rule, and a DNAT rule expands to its member applications (`junos-ms-rpc` → tcp/135 + udp/135) on every path, equal to the resolver expansion and present in the AppID-enabled catalog.

RED-on-revert proven for all 4 bug tests (catalog bare-name; SNAT `natProtoNever`; DNAT never-match sentinel); GREEN after. Two bit-identical guards (user-set unaffected, user-app-shadow precedence) stay green on both sides. `go build ./...` + `pkg/appid` + `pkg/config` + `pkg/dataplane/userspace` suites pass.

Closes #5629

🤖 Generated with [Claude Code](https://claude.com/claude-code)