### PR TITLE
feeds: fail closed for a deny feed before its first fetch

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46664,3 +46664,32 @@ top.
   SyncApply leaves ConfigPersistDegraded()==true (the exact M30 symptom).
   Restoring → GREEN. Normal single active supported-PRF config is
   bit-identical (zero-allocation fast path).
+
+## 2026-07-11 — #5645 feeds first-fetch deny fail-open (codex-review-181)
+- **Timestamp**: 2026-07-11
+- **Action**: Fix fail-open where a direct feed-bound DENY name published as an
+  empty (match-none) overlay entry BEFORE the first successful fetch — the deny
+  compiled to match-none so denied traffic was PERMITTED for the whole
+  pre-first-fetch window. SnapshotForBindings now OMITS a binding whose feeds
+  all lack an installed snapshot (len(merged)==0), leaving the name UNRESOLVED
+  so the policy lowering fails CLOSED (unrepresentable -> __unsupported_address__
+  -> whole-snapshot preflight reject, the #3261 contract). Integrates with the
+  #5282 re-fetch window: a persisted feed carries its last-good snapshot forward
+  and still resolves to prefixes, so it stays published.
+- **File(s)**: pkg/feeds/feeds.go (SnapshotForBindings omit-unready + docstrings
+  + Apply cold-start comment), pkg/feeds/feeds_firstfetch_failopen_5645_test.go
+  (new fail-on-revert tests), pkg/feeds/feeds_bindings_test.go
+  (TestSnapshotForBindingsEmptyForUnloadedFeed -> ...OmitsUnresolvedFeed),
+  pkg/dataplane/userspace/policies_addrbook.go (buildAddressBookTableWithFeeds
+  doc corrected), pkg/dataplane/userspace/feed_enforcement_test.go
+  (TestEmptyFeedSnapshotYieldsNoPrefixes docstring corrected),
+  pkg/feeds/README.md (#5645 first-fetch fail-closed section + cold-start line).
+- **Validation**: `go build ./...` clean; `go test ./pkg/feeds/...
+  ./pkg/config/... ./pkg/dataplane/userspace/... ./pkg/daemon/...` green; gofmt
+  clean. RED-on-revert proven: reverting the SnapshotForBindings omission guard
+  makes TestSnapshotForBindingsOmitsUnresolvedFeed,
+  TestFirstFetchFailedDenyFeedNotPublishedMatchNone, and
+  TestPermitFeedNoMembersOmittedNotFailOpen FAIL (binding published as
+  match-none = deny fail-open); the resolved-feed test stays green. Restoring ->
+  GREEN. Permit-none and the #5282 re-fetch window are unaffected
+  (TestFirstFetchSuccessPublishesFeed, TestReFetchWindowStillPublishesLastGood).

--- a/pkg/config/compiler_validate_strict_observability.go
+++ b/pkg/config/compiler_validate_strict_observability.go
@@ -390,14 +390,16 @@ func validateDynamicAddressFeedNameUniquenessStrict(cfg *Config) error {
 // AddressBinding.FeedNames with no cross-reference against the configured
 // feed-servers (compileDynamicAddress in compiler_services.go), and at
 // runtime an unknown feed name contributes nothing: feeds.Manager.
-// SnapshotForBindings skips a feed it never registered and still publishes
-// a non-nil EMPTY prefix set for the binding (feeds.go SnapshotForBindings),
-// so the AF_XDP address book gets a book ID that matches nothing
-// (fail-closed). The runtime fail-closed posture is correct for "feed
-// declared but not yet fetched", but a TYPO in the feed-name is
-// indistinguishable from that and arms a silent match-none book: a
-// feed-backed deny policy referencing the dynamic-address denies nothing,
-// with no commit error. Junos rejects an address-name whose profile
+// SnapshotForBindings OMITS a binding whose feeds have no installed snapshot
+// (an unregistered/unfetched feed name) rather than publishing an empty
+// prefix set (#5645), so the binding name stays UNRESOLVED and the policy
+// lowering compiles it to __unsupported_address__ → whole-snapshot preflight
+// reject → fail-closed (previous-good retained, or fresh-boot default-deny).
+// The runtime fail-closed posture is correct for "feed declared but not yet
+// fetched", but a TYPO in the feed-name is indistinguishable from that at
+// runtime — it too fails closed (the referencing deny is enforced via
+// default-deny, not silently ignored), with no commit error. Junos rejects
+// an address-name whose profile
 // feed-name does not resolve to a declared feed at commit; this gate
 // restores that behavior.
 //
@@ -415,9 +417,10 @@ func validateDynamicAddressFeedNameUniquenessStrict(cfg *Config) error {
 // On the tolerant load / peer-sync paths the call site downgrades this to a
 // warning (opts.lenientDynamicAddressFeedRef) so an already-persisted config
 // (older binaries never validated the reference) or a peer-synced config
-// still boots — the runtime is already fail-closed (match-none) for an
-// unknown feed, so a leniently-loaded typo denies nothing rather than
-// bricking the load (#1960 / #3261 class). Commit / commit-check stay strict
+// still boots — the runtime is already fail-closed for an unknown feed
+// (#5645: the name is omitted → whole-snapshot reject → previous-good /
+// fresh-boot default-deny), so a leniently-loaded typo fails closed rather
+// than bricking the load (#1960 / #3261 class). Commit / commit-check stay strict
 // so the operator's next edit fails loudly. Mirrors
 // validateLogProfileStreamReferencesStrict.
 func validateDynamicAddressFeedReferencesStrict(cfg *Config) error {

--- a/pkg/dataplane/userspace/feed_enforcement_test.go
+++ b/pkg/dataplane/userspace/feed_enforcement_test.go
@@ -180,11 +180,16 @@ func TestFeedBackedPolicyDestinationRoutesAsBookReference(t *testing.T) {
 	}
 }
 
-// TestEmptyFeedSnapshotYieldsNoPrefixes is the documented empty-feed case
-// (#2049 §3a): an overlay entry with no prefixes (startup before first fetch /
-// operator hold-interval drop) produces a row with no concrete prefixes — the
-// rule matches nothing (fail-closed for an allowlist; the documented
-// operator-opted fail-open for a denylist). No panic, no compile error.
+// TestEmptyFeedSnapshotYieldsNoPrefixes exercises the consumer's DEFENSIVE
+// handling of an explicit present-but-empty overlay entry: it produces a row
+// with no concrete prefixes (a match-none book reference) without panicking or
+// erroring. NOTE (#5645): the daemon no longer PRODUCES this shape for an
+// unready feed — feeds.Manager.SnapshotForBindings OMITS an unresolved feed
+// name so the referencing policy fails CLOSED (see
+// TestFeedBackedPolicyRoutesAsBookReference's no-overlay branch:
+// absent name -> __unsupported_address__ sentinel). This test now only pins the
+// consumer's no-panic behavior for a hand-supplied empty entry, NOT a reachable
+// denylist fail-open.
 func TestEmptyFeedSnapshotYieldsNoPrefixes(t *testing.T) {
 	cfg := feedPolicyCfg("bad-actors", "any")
 	overlay := map[string][]string{

--- a/pkg/dataplane/userspace/policies_addrbook.go
+++ b/pkg/dataplane/userspace/policies_addrbook.go
@@ -142,12 +142,18 @@ func buildAddressBookTable(cfg *config.Config) ([]AddressBookSnapshot, map[strin
 //     → the duplicate-publish gate (snapshotContentHash) lets the refresh
 //     through. This is why the join MUST live in the snapshot builder.
 //
-// An overlay name with no prefixes (startup before first fetch, or an
-// operator-opted hold-interval drop) still produces a (possibly empty) bucket
-// and a nameToID entry, so the policy token is routed as a book reference that
-// matches nothing (fail-closed) rather than a no-match literal — either way it
-// matches nothing, but routing it as a book keeps the wire shape consistent
-// and lets a later refresh populate the same name without re-classifying.
+// An overlay name that IS present but carries no prefixes still produces a
+// (possibly empty) bucket and a nameToID entry, so the policy token routes as a
+// book reference to an empty set (match-none). NOTE (#5645): the daemon's
+// feeds.Manager.SnapshotForBindings no longer EMITS such a present-but-empty
+// entry for an UNREADY feed (before its first successful fetch / after a
+// hold-interval drop) — it OMITS the name so the token is unresolved and the
+// referencing policy fails CLOSED (unrepresentable -> __unsupported_address__
+// -> whole-snapshot reject; see buildPolicySnapshots' addrRepresentable and
+// #3261). Publishing an empty entry was a DENY fail-open (match-none = the deny
+// never fires). This empty-bucket path is therefore now only reachable for a
+// non-daemon caller that hands in an explicit empty slice; it is retained as
+// defensive, no-panic handling, not a live fail-open.
 //
 // When the static AddressBook is nil but a feed overlay is present, the table
 // is still built from the overlay alone (the pre-#2049 early-return only fired

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -54,8 +54,9 @@ replaces them (`installSnapshot`). Distinctions:
   carried set installed indefinitely (never reverts to empty — #2050 preserved),
 - **removed feed** (deleted from config) → no plan entry, no replacement, its
   snapshot is dropped (correct — the operator removed it),
-- **brand-new feed** → no prior snapshot, starts empty until its first fetch
-  (the documented fail-closed cold-start, not a regression of an existing feed).
+- **brand-new feed** → no prior snapshot to carry; until its first successful
+  fetch its binding is **omitted** from the enforcement overlay (#5645, below),
+  so a referencing policy fails **closed**, not a match-none fail-open.
 
 The atomic swap on a successful new fetch is unchanged, so the overlay compiler
 never sees a torn prefix set. Retained FAILURE markers (`LastError`/`StaleSince`)
@@ -63,6 +64,32 @@ are intentionally NOT carried: the new endpoint gets a clean slate and the first
 post-Apply fetch re-derives stale state, which also gives an opt-in
 `hold-interval` a fresh window on the new endpoint rather than a partially-elapsed
 one (strictly more conservative for the fail-open guard).
+
+## First-fetch fail-closed — no match-none deny window (#5645)
+
+`#5282` closes the fail-open window on a **reconfigure** (a persisted feed keeps
+its last-good prefixes). `#5645` closes the sibling window on **first fetch**,
+where there is no prior snapshot to keep. Before the fix, `SnapshotForBindings`
+published a binding whose feeds had no installed snapshot as a **present-but-empty**
+slice. The daemon compiled that direct feed-bound name into a **match-none**
+address-book row — correct for a `permit` (permit-none), but a `deny` policy
+referencing the name then **never fired**, so traffic it must block was PERMITTED
+for the whole window until the first fetch succeeded (a firewall **fail-open**).
+A blocked/failed first fetch (`retainForever` has nothing to retain) held that
+window open indefinitely.
+
+`SnapshotForBindings` now **omits** a binding whose feeds all lack an installed
+snapshot (before the first successful fetch, an unknown/typo'd feed name, or
+after a hold-interval drop) rather than publishing an empty slice. A ready feed
+always installs ≥ 1 prefix (a zero-prefix fetch is rejected — see below), so
+"resolves to zero prefixes" is exactly "no backing feed has a snapshot". Leaving
+the name **unresolved** makes the policy lowering treat it as unrepresentable
+(`addrRepresentable` → `__unsupported_address__` → whole-snapshot preflight
+reject), so the referencing policy fails **closed** (previous-good retained /
+fresh-boot default-deny) — the same action-agnostic contract `#3261` gives an
+empty static book. A **persisted** feed carries its last-good snapshot forward
+(`#5282`), so it still resolves to prefixes here and is still published; the
+omission fires only for a feed with no prior good fetch.
 
 ## Refresh correctness & fail-safe behavior (#2050)
 

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -311,8 +311,10 @@ func (m *Manager) Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)
 	//
 	// A feed GENUINELY REMOVED from config has no entry in the new plan, so it
 	// gets no replacement and its snapshot is dropped (correct — the operator
-	// removed it). A brand-NEW feed has no prior snapshot and starts empty until
-	// its first fetch (the documented fail-closed cold-start, not a regression).
+	// removed it). A brand-NEW feed has no prior snapshot to carry, so until its
+	// first successful fetch SnapshotForBindings OMITS its binding (#5645) — the
+	// referencing policy then fails CLOSED (unresolved name), not fail-open
+	// match-none. This is the first-fetch analogue of the carry-forward below.
 	old := m.feeds
 	for _, fs := range old {
 		if fs.cancel != nil {
@@ -428,18 +430,30 @@ func (m *Manager) GetPrefixes(name string) []string {
 // Resolution semantics:
 //   - A binding's FeedNames are unioned (a binding may aggregate several
 //     feeds). Prefixes are deduped across feeds and returned sorted.
-//   - A feed with no installed snapshot (before first fetch, or after an
-//     explicit hold-interval drop) contributes nothing; if NONE of a
-//     binding's feeds have prefixes the entry maps to a non-nil empty slice,
-//     so the caller can tell "bound but empty" (fail-closed: matches nothing)
-//     from "not a feed binding" (absent from the map).
+//   - A feed with no installed snapshot (before the first successful fetch, or
+//     after an explicit hold-interval drop) contributes nothing. If NONE of a
+//     binding's feeds has an installed snapshot the binding is UNRESOLVED and
+//     its name is OMITTED from the returned map entirely (#5645) — it is NOT
+//     published as a present-but-empty slice. Publishing an empty slice made
+//     the daemon compile a direct feed-bound name to a match-none address book
+//     row: correct for a PERMIT (permit-none), but a DENY policy referencing
+//     that name then never fired and the traffic it must block was PERMITTED
+//     for the whole pre-first-fetch window (fail-OPEN). Omitting the name
+//     leaves it unresolved, so the policy lowering treats it as
+//     unrepresentable (addrRepresentable -> __unsupported_address__ -> whole-
+//     snapshot preflight reject) and the referencing policy fails CLOSED —
+//     the same action-agnostic contract #3261 gives an empty static book, and
+//     the first-fetch analogue of the #5282 re-fetch window.
 //   - An unknown feed-name (binding references a feed that was never started)
-//     contributes nothing — it is treated the same as an empty feed.
+//     contributes nothing — it is treated the same as an unready feed, so a
+//     binding backed only by unknown names is also omitted (unresolved).
 //
 // Reading the live last-good snapshot here means a persistent fetch failure
-// keeps enforcing the retained prefixes (the #2050 fail-safe), and the
-// startup window before the first fetch enforces an empty set — both are the
-// caller's responsibility to surface; this accessor only joins the data.
+// keeps enforcing the retained prefixes (the #2050 fail-safe). A persisted
+// feed carries its last-good snapshot across a reconfigure (#5282), so it still
+// has prefixes here and is still published — the omission above only fires for
+// a feed with NO prior good fetch. The caller surfaces the enforced set; this
+// accessor only joins the data.
 func (m *Manager) SnapshotForBindings(daCfg *config.DynamicAddressConfig) map[string][]string {
 	if daCfg == nil || len(daCfg.AddressBindings) == 0 {
 		return nil
@@ -468,6 +482,20 @@ func (m *Manager) SnapshotForBindings(daCfg *config.DynamicAddressConfig) map[st
 			}
 		}
 		sort.Strings(merged)
+		// #5645: a binding whose feeds ALL lack an installed snapshot resolves to
+		// no enforceable prefixes. A ready feed always installs >= 1 prefix (a
+		// zero-prefix fetch is rejected as suspect — see readFeed), so
+		// len(merged) == 0 is EXACTLY "no backing feed has an installed snapshot"
+		// (before the first successful fetch, an unknown/typo'd feed name, or after
+		// an explicit hold-interval drop) — never a legitimately-empty successful
+		// fetch. Do NOT publish it as a present-but-empty (match-none) entry: for a
+		// DENY policy match-none is fail-OPEN. Omit the name so it stays UNRESOLVED
+		// and the referencing policy fails CLOSED (see the doc comment). A
+		// persisted feed carried forward across a reconfigure (#5282) still has its
+		// last-good prefixes here, so this never re-opens the re-fetch window.
+		if len(merged) == 0 {
+			continue
+		}
 		out[name] = merged
 	}
 	return out

--- a/pkg/feeds/feeds_bindings_test.go
+++ b/pkg/feeds/feeds_bindings_test.go
@@ -58,23 +58,22 @@ func TestSnapshotForBindingsUnionsAndDedupsMultipleFeeds(t *testing.T) {
 	}
 }
 
-func TestSnapshotForBindingsEmptyForUnloadedFeed(t *testing.T) {
+func TestSnapshotForBindingsOmitsUnresolvedFeed(t *testing.T) {
 	m := New(nil)
-	// "missing-feed" was never started/fetched; the binding still produces an
-	// entry, but a non-nil empty slice (fail-closed: matches nothing). This is
-	// the documented startup-before-first-fetch / unknown-feed case (#2049).
+	// "missing-feed" was never started/fetched, so the binding resolves to no
+	// enforceable prefixes. #5645: the binding name is OMITTED from the overlay
+	// entirely (unresolved) rather than published as a present-but-empty
+	// (match-none) slice — publishing match-none made a DENY policy referencing
+	// the name fail OPEN before the first fetch. Omitting it leaves the name
+	// unresolved so the policy lowering fails CLOSED (unrepresentable ->
+	// __unsupported_address__ -> whole-snapshot reject). This also covers the
+	// unknown/typo'd-feed case (an unknown name is treated like an unready feed).
 	got := m.SnapshotForBindings(bindingCfg(map[string][]string{
 		"pending": {"missing-feed"},
 	}))
-	prefixes, ok := got["pending"]
-	if !ok {
-		t.Fatalf("a feed-backed binding must be present in the overlay even when empty")
-	}
-	if prefixes == nil {
-		t.Fatalf("empty binding must be a non-nil slice, got nil")
-	}
-	if len(prefixes) != 0 {
-		t.Fatalf("unloaded feed must contribute no prefixes, got %v", prefixes)
+	if _, ok := got["pending"]; ok {
+		t.Fatalf("an unresolved feed-backed binding must be OMITTED from the overlay "+
+			"(fail-closed), not published as match-none; got %v", got)
 	}
 }
 

--- a/pkg/feeds/feeds_firstfetch_failopen_5645_test.go
+++ b/pkg/feeds/feeds_firstfetch_failopen_5645_test.go
@@ -1,0 +1,155 @@
+package feeds
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// feeds_firstfetch_failopen_5645_test.go: #5645 (codex-review-181) — a DIRECT
+// feed-bound name published as an empty (match-none) slice BEFORE the first
+// successful fetch is a firewall fail-open. A policy that DENIES a direct
+// feed-bound address compiles the empty set to a match-none address-book row, so
+// the deny never fires and traffic that must be blocked is PERMITTED for the
+// whole window until the first fetch succeeds. (#5282 already closes the
+// RE-FETCH window by carrying a persisted feed's last-good snapshot forward;
+// #5645 is the FIRST-fetch case, where there is no prior good snapshot to keep.)
+//
+// The fix: SnapshotForBindings OMITS a binding whose feeds all lack an installed
+// snapshot, leaving the name UNRESOLVED so the policy lowering fails CLOSED
+// (unrepresentable -> __unsupported_address__ -> whole-snapshot preflight
+// reject; see pkg/dataplane/userspace TestFeedBackedPolicyRoutesAsBookReference,
+// whose no-overlay branch proves the absent-name -> sentinel fail-closed path).
+
+// denyBindingCfg wires a feed-server whose first fetch hits url, plus a
+// direct feed-bound address binding "denylist" -> feedName, matching the
+// SnapshotForBindings input a deny policy referencing "denylist" produces.
+func denyBindingCfg(feedName, url string) *config.DynamicAddressConfig {
+	return &config.DynamicAddressConfig{
+		FeedServers: map[string]*config.FeedServer{
+			"srv": {Name: "srv", URL: url, FeedName: feedName, UpdateInterval: 3600},
+		},
+		AddressBindings: map[string]*config.AddressBinding{
+			"denylist": {Name: "denylist", FeedNames: []string{feedName}},
+		},
+	}
+}
+
+// TestFirstFetchFailedDenyFeedNotPublishedMatchNone is the core #5645
+// fail-on-revert. A direct feed-bound DENY binding whose FIRST fetch is blocked
+// (HTTP 500) must NOT publish a present-but-empty (match-none) overlay entry —
+// the deny must not fail open. Reverting the SnapshotForBindings omission
+// publishes "denylist" as a non-nil empty slice, turning both assertions RED.
+func TestFirstFetchFailedDenyFeedNotPublishedMatchNone(t *testing.T) {
+	m := New(func() {})
+
+	// First (and only) fetch fails: the endpoint is DOWN (500). There is NO
+	// prior good snapshot — this is the first-fetch case, not the re-fetch window.
+	down := &bodyServer{}
+	down.set("hijacked-or-error", http.StatusInternalServerError)
+	ts := httptest.NewServer(down.handler())
+	defer ts.Close()
+
+	const feedName = "threat"
+	daCfg := denyBindingCfg(feedName, ts.URL)
+	m.Apply(context.Background(), daCfg)
+	defer m.StopAll()
+
+	// Let the first (failing) fetch resolve so we assert the STEADY state, not a
+	// pre-fetch race: after the failure there is still no installed snapshot.
+	waitFor(t, 2*time.Second, func() bool {
+		return m.AllFeeds()[feedName].LastError != ""
+	}, "first fetch never recorded a failure")
+
+	// The feed has no installed snapshot (first fetch failed, nothing to retain).
+	if got := m.GetPrefixes(feedName); len(got) != 0 {
+		t.Fatalf("precondition: a failed first fetch must leave no snapshot; got %v", got)
+	}
+
+	// THE FAIL-OPEN SURFACE: the enforcement overlay the daemon hands to the
+	// dataplane must OMIT "denylist" — an unresolved name (fail-closed), NOT a
+	// present-but-empty (match-none) entry that a deny compiles to fail-open.
+	overlay := m.SnapshotForBindings(daCfg)
+	if _, published := overlay["denylist"]; published {
+		t.Fatalf("fail-open: a direct feed-bound DENY binding was published as "+
+			"match-none before the first successful fetch; overlay=%v", overlay)
+	}
+}
+
+// TestFirstFetchSuccessPublishesFeed is the non-tautological companion: once the
+// first fetch SUCCEEDS, the binding IS published with its prefixes. This proves
+// the omission is scoped to the unready window and does not suppress a resolved
+// feed (a PERMIT feed that fetches non-empty enforces those prefixes, and a
+// resolved DENY feed enforces its denylist).
+func TestFirstFetchSuccessPublishesFeed(t *testing.T) {
+	m := New(func() {})
+
+	good := &bodyServer{}
+	good.set("203.0.113.0/24\n", http.StatusOK)
+	ts := httptest.NewServer(good.handler())
+	defer ts.Close()
+
+	const feedName = "threat"
+	daCfg := denyBindingCfg(feedName, ts.URL)
+	m.Apply(context.Background(), daCfg)
+	defer m.StopAll()
+
+	waitFor(t, 2*time.Second, func() bool {
+		got := m.SnapshotForBindings(daCfg)["denylist"]
+		return len(got) == 1 && got[0] == "203.0.113.0/24"
+	}, "first successful fetch never published the binding")
+}
+
+// TestPermitFeedNoMembersOmittedNotFailOpen guards the PERMIT direction. A
+// permit feed with no members must NOT start matching anything (that would be a
+// permit fail-open). Before the first fetch the binding is omitted (unresolved
+// -> the referencing policy fails closed); it never resolves to match-ANY. This
+// asserts the fix does not invert the permit case into a fail-open.
+func TestPermitFeedNoMembersOmittedNotFailOpen(t *testing.T) {
+	m := New(nil)
+	// No feed ever started: the binding is unresolved.
+	overlay := m.SnapshotForBindings(bindingCfg(map[string][]string{
+		"allowlist": {"never-fetched"},
+	}))
+	if _, published := overlay["allowlist"]; published {
+		t.Fatalf("a permit feed with no members must stay unresolved (omitted), never "+
+			"resolve to a match-any/empty entry; overlay=%v", overlay)
+	}
+}
+
+// TestReFetchWindowStillPublishesLastGood proves the #5645 first-fetch omission
+// does NOT regress the #5282 re-fetch window: once a feed has a good snapshot, a
+// later FAILED refresh keeps the last-good prefixes published (retainForever) —
+// the binding stays present, never dropping to the omitted/match-none state.
+func TestReFetchWindowStillPublishesLastGood(t *testing.T) {
+	m := New(func() {})
+
+	srv := &bodyServer{}
+	srv.set("203.0.113.0/24\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	const feedName = "threat"
+	// Directly install a last-good snapshot via a single successful fetch.
+	fs := m.newFeed(feedName, ts.URL, retainForever)
+	m.fetchFeed(context.Background(), fs)
+	daCfg := denyBindingCfg(feedName, ts.URL)
+	if got := m.SnapshotForBindings(daCfg)["denylist"]; len(got) != 1 {
+		t.Fatalf("precondition: last-good not published: %v", got)
+	}
+
+	// A subsequent refresh FAILS; retainForever keeps the last-good installed.
+	srv.set("boom", http.StatusInternalServerError)
+	m.fetchFeed(context.Background(), fs)
+
+	overlay := m.SnapshotForBindings(daCfg)
+	got, published := overlay["denylist"]
+	if !published || len(got) != 1 || got[0] != "203.0.113.0/24" {
+		t.Fatalf("re-fetch window regressed: a failed refresh must retain the last-good "+
+			"overlay (never omit/match-none); got published=%v value=%v", published, got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a firewall **fail-open** (#5645, codex-review-181): a direct feed-bound address name was published to the enforcement overlay as a **present-but-empty** slice **before its first successful fetch**. The daemon compiled that name into a **match-none** address-book row — correct for a `permit` (permit-none), but a `deny` policy referencing the name then **never fired**, so traffic it must block was PERMITTED for the whole window until the first fetch succeeded. A blocked/failed first fetch (`retainForever` has nothing to retain) held that window open indefinitely.

This is the **first-fetch** sibling of the #5282 **re-fetch** window:
- #5282 carries a persisted feed's last-good snapshot forward so a *reconfigure* never opens a match-none deny window.
- #5645 is the case where there is **no prior good snapshot** to keep.

## Semantics chosen (first-fetch fail-closed)

`SnapshotForBindings` now **omits** a binding whose feeds all lack an installed snapshot (before the first successful fetch, an unknown/typo'd feed name, or after a hold-interval drop) instead of publishing an empty slice — option (b) from the issue.

A ready feed always installs ≥ 1 prefix (a zero-prefix fetch is rejected as suspect in `readFeed`), so a binding resolving to zero prefixes is **exactly** the unready/unknown case, never a legitimately-empty successful fetch. Leaving the name **unresolved** makes the policy lowering treat it as unrepresentable (`addrRepresentable` → `__unsupported_address__` → whole-snapshot preflight reject), so the referencing policy fails **closed** (previous-good retained / fresh-boot default-deny) — the **same action-agnostic contract #3261 already gives an empty static book**. The existing `TestFeedBackedPolicyRoutesAsBookReference` (no-overlay branch) already proves *absent name → sentinel → fail-closed*; this change routes an unready feed onto that proven path.

- **Integrates with #5282**: a persisted feed carries its last-good snapshot forward, still resolves to prefixes here, and stays published. The omission fires only for a feed with no prior good fetch.
- **Permit unaffected in the safe direction**: permit-none stays fail-closed; the fix never inverts a permit to match-any.

## Tests / RED-on-revert

New `pkg/feeds/feeds_firstfetch_failopen_5645_test.go`:
- `TestFirstFetchFailedDenyFeedNotPublishedMatchNone` — deny binding whose **first fetch is blocked (HTTP 500)** → binding OMITTED (not match-none). **Core fail-on-revert.**
- `TestFirstFetchSuccessPublishesFeed` — resolved feed IS published (non-tautological).
- `TestPermitFeedNoMembersOmittedNotFailOpen` — permit feed with no members never resolves to match-any.
- `TestReFetchWindowStillPublishesLastGood` — a failed refresh after a good fetch keeps last-good published (#5282 unaffected).
- `feeds_bindings_test.go`: `TestSnapshotForBindingsEmptyForUnloadedFeed` → `...OmitsUnresolvedFeed`.

**RED-on-revert proven**: reverting the `SnapshotForBindings` omission guard makes the three fail-open assertions FAIL (binding published as match-none = deny fail-open); the resolved-feed test stays green. Restoring → GREEN.

`go build ./...` clean; `go test ./pkg/feeds/... ./pkg/config/... ./pkg/dataplane/userspace/... ./pkg/daemon/...` green; gofmt clean.

## Docs
Updated `pkg/feeds/README.md` (new #5645 first-fetch fail-closed section + cold-start line), plus corrected two now-misleading doc comments that described the old match-none as "fail-closed"/"documented operator-opted fail-open" (`policies_addrbook.go`, `feed_enforcement_test.go`).

Closes #5645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLPUqMxV4baiRzQraHcX2J