### PR TITLE
feeds: retry a rejected feed apply instead of suppressing it (#5646)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46720,3 +46720,24 @@ top.
   match-none = deny fail-open); the resolved-feed test stays green. Restoring ->
   GREEN. Permit-none and the #5282 re-fetch window are unaffected
   (TestFirstFetchSuccessPublishesFeed, TestReFetchWindowStillPublishesLastGood).
+
+## 2026-07-11 — #5646 feeds publication-debt (rejected apply suppresses retry)
+
+- **Timestamp**: 2026-07-11
+- **Action**: Fix installSnapshot committing content hash before the void
+  onUpdate callback → a REJECTED apply suppressed retry of identical content
+  (publication debt / fail-open). Design (a): split published-hash from
+  installed-content hash; onUpdate void→error; publishedHash advances only on a
+  confirmed (nil) apply, so an identical refetch after a rejected apply re-fires
+  and retries on the normal refresh cadence (no thrash on success).
+- **File(s)**: pkg/feeds/feeds.go (Manager.onUpdate func()→func() error,
+  feedState.publishedHash/hasPublished, installSnapshot needsPublish gate,
+  carryForwardSnapshot carry, recordFailure drop-to-empty reset),
+  pkg/daemon/daemon_feeds.go (callback returns applyConfigResult),
+  pkg/daemon/daemon_apply.go (new applyConfigResult error-returning apply),
+  pkg/feeds/feeds_publication_debt_5646_test.go (fail-on-revert, RED proven),
+  pkg/feeds/README.md (Publication-debt retry section + New/change-detection
+  notes), plus mechanical func()→func() error in existing feeds tests.
+- **Validation**: go build ./...; go test ./pkg/feeds/... ./pkg/dataplane/
+  userspace/... ./pkg/daemon/... all green; RED-on-revert confirmed (pre-fix
+  hash-gate → fetch#2 calls=1 want 2).

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -124,7 +124,8 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 // manager advances its per-feed published-hash only on a nil return, so a
 // rejected apply leaves publication debt that the next identical refetch
 // retries (rather than committing the content hash and suppressing retry
-// forever, the pre-#5646 bug). The error is still logged by the callback path.
+// forever, the pre-#5646 bug). The returned error is still logged — by
+	// feeds.installSnapshot's reject branch (feeds side), not by this function.
 func (d *Daemon) applyConfigResult(cfg *config.Config) error {
 	_ = d.applySem.Acquire(context.Background(), 1)
 	defer d.applySem.Release(1)

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -117,6 +117,20 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 	}
 }
 
+// applyConfigResult applies cfg exactly like applyConfig — under the apply
+// semaphore with a non-cancellable context — but RETURNS the apply error
+// instead of only logging it. The feed onUpdate publication path (#5646) uses
+// the returned result to decide whether the feed content was ACCEPTED: the feed
+// manager advances its per-feed published-hash only on a nil return, so a
+// rejected apply leaves publication debt that the next identical refetch
+// retries (rather than committing the content hash and suppressing retry
+// forever, the pre-#5646 bug). The error is still logged by the callback path.
+func (d *Daemon) applyConfigResult(cfg *config.Config) error {
+	_ = d.applySem.Acquire(context.Background(), 1)
+	defer d.applySem.Release(1)
+	return d.applyConfigLocked(context.Background(), cfg)
+}
+
 // applyCancelCtx returns the context whose cancellation aborts the heavy apply
 // pipeline (applyConfigLocked) at its coarse step boundaries (#2926). It is the
 // dedicated DAEMON-STOP context (d.applyCancelContext), deliberately NOT the

--- a/pkg/daemon/daemon_feeds.go
+++ b/pkg/daemon/daemon_feeds.go
@@ -23,11 +23,22 @@ func (d *Daemon) ensureFeedManager() {
 	if d.feeds != nil {
 		return
 	}
-	d.feeds = feeds.New(func() {
+	d.feeds = feeds.New(func() error {
 		slog.Info("dynamic-address feed updated, recompiling dataplane")
-		if activeCfg := d.store.ActiveConfig(); activeCfg != nil {
-			d.applyConfig(activeCfg)
+		activeCfg := d.store.ActiveConfig()
+		if activeCfg == nil {
+			// No active config to apply the feed content against yet (pre-boot
+			// window). Treat as a vacuous success — there is no policy enforcing
+			// this feed, and the normal commit path re-reads the live feed
+			// snapshot when a config is committed. Returning nil lets the feed
+			// manager record the content as published so it does not spin.
+			return nil
 		}
+		// #5646: return the apply RESULT to the feed manager. A rejected apply
+		// (preflight reject, compile failure, control-socket error) must NOT be
+		// recorded as published, so the next identical feed refetch retries the
+		// apply instead of silently dropping the good content (publication debt).
+		return d.applyConfigResult(activeCfg)
 	})
 }
 

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -7,7 +7,9 @@ feed servers and triggers config recompile when the resolved set changes
 ## Entry points
 
 - `Manager` — `feeds.go`.
-- `New(updateFn)` — `feeds.go`.
+- `New(updateFn)` — `feeds.go`. `updateFn` is `func() error`: it applies the
+  fetched content to the dataplane and RETURNS the apply result. A rejected
+  apply (non-nil error) is retried on the next identical refetch (#5646, below).
 - `Apply(ctx context.Context, daCfg *config.DynamicAddressConfig)` — `feeds.go`. Reconciles the per-feed refresh goroutines; carries a persisted feed's last-good snapshot forward across the reconfigure (#5282, see below).
 - `GetPrefixes(name)` — `feeds.go`. Returns the current enforced (last-good) snapshot.
 - `StopAll()`, `FeedInfo`, `AllFeeds()` — surfaced to `show security dynamic-address`. `StopAll` is the shutdown path (cancels every producer, empties the map); `Apply` no longer routes through it (#5282).
@@ -91,6 +93,44 @@ empty static book. A **persisted** feed carries its last-good snapshot forward
 (`#5282`), so it still resolves to prefixes here and is still published; the
 omission fires only for a feed with no prior good fetch.
 
+## Publication-debt retry — a rejected apply is retried, not swallowed (#5646)
+
+The `onUpdate` callback drives the daemon to APPLY the fetched feed content to
+the dataplane, and that apply can be **rejected** — a whole-snapshot preflight
+reject (`#3261`/`#5645`), a compile failure, or a transient control-socket
+error. Before `#5646` `installSnapshot` committed the fetched content hash and
+then fired a **void** `onUpdate`, so a rejected apply left the hash committed:
+every later refetch of the (still-good, still-unapplied) **identical** content
+saw "unchanged hash" and **skipped** `onUpdate`. The good content then sat
+un-enforced indefinitely — **publication debt** — because the provider keeps
+serving the same body (hash never changes again) and the default refresh is
+hourly. The intended feed/policy silently failed open until an unrelated commit
+or a genuine content change happened to re-drive the apply.
+
+The fix decouples the **installed-content** hash from the **published** hash:
+
+- `onUpdate` now returns `error` (`func() error`). A nil return means the apply
+  was **accepted**; a non-nil return means it was **rejected**. The production
+  callback (`ensureFeedManager`, `daemon_feeds.go`) returns the result of
+  `applyConfigResult` (an error-returning sibling of `applyConfig`).
+- `feedState.publishedHash` / `hasPublished` track the hash last **confirmed
+  applied**. `installSnapshot` always commits `fs.hash` to the freshly-fetched
+  content (so the display/`#5282`-carry hash stays truthful), but fires
+  `onUpdate` whenever the fetched content differs from `publishedHash` — **not**
+  from `fs.hash`. `publishedHash` advances **only** on a nil (accepted) return.
+- A **rejected** apply therefore leaves `publishedHash` stale, so the next
+  identical refetch re-evaluates `needsPublish == true` and **retries** the
+  apply. The retry fires on the normal refresh cadence — one publish attempt per
+  fetch, never a tight loop.
+- A **successfully-applied** feed has `publishedHash == fs.hash`, so an
+  identical refetch is suppressed (`needsPublish == false`) — **no thrash** and
+  no busy-loop, preserving the `#5282` no-re-fire-on-carry-forward contract
+  (`carryForwardSnapshot` inherits `publishedHash`/`hasPublished`).
+- The **hold-interval drop-to-empty** (`recordFailure`) resets
+  `publishedHash`/`hasPublished`, so a later recovery (refetch of the prior
+  content) re-fires `onUpdate` and re-enforces the recovered set rather than
+  seeing a stale published hash and suppressing the re-apply.
+
 ## Refresh correctness & fail-safe behavior (#2050)
 
 A fetch is treated as **successful** only when the transport read completes
@@ -115,11 +155,14 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
 - **plaintext-http feeds are warned (#3934).** A feed URL using `http://`
   (no transport integrity — a MITM can substitute the body) logs a one-time
   `slog.Warn` at `Apply`. `https` is strongly preferred for any feed source.
-- **content-based change detection.** Prefixes are canonicalized (parsed to
-  masked CIDR / `/32` / `/128`), deduped, sorted, and SHA-256 hashed. The
-  `onUpdate` recompile callback fires only when the hash changes — a same-count
-  content swap (`192.0.2.0/24` -> `198.51.100.0/24`) fires; a reordered but
-  identical set does not.
+- **content-based change detection, keyed off the last *published* set (#5646).**
+  Prefixes are canonicalized (parsed to masked CIDR / `/32` / `/128`), deduped,
+  sorted, and SHA-256 hashed. The `onUpdate` recompile callback fires whenever
+  the fetched content differs from what was last **successfully applied** — a
+  same-count content swap (`192.0.2.0/24` -> `198.51.100.0/24`) fires; a
+  reordered but identical set does not. See "Publication-debt retry" below for
+  why the trigger keys off the *published* hash, not merely the last-fetched
+  hash.
 - **no success stamp on a partial/errored read.** `LastFetch`/`LastSuccess`
   are stamped, and the active snapshot replaced, only on a complete successful
   fetch. A failed fetch records `LastError` and leaves the snapshot untouched.
@@ -203,8 +246,11 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
   *scanner-level* error (overlong line / read error) is NOT skipped: it fails
   the whole fetch (retain last-good).
 - A successful fetch always replaces the snapshot and stamps success, but
-  the `onUpdate` recompile fires only when the canonical content hash
-  changes — not on every fetch and not merely on a count change.
+  the `onUpdate` recompile fires only when the canonical content hash differs
+  from the last **successfully-applied** set — not on every fetch, not merely on
+  a count change, and (per #5646) not suppressed by a prior **rejected** apply of
+  the same content (which is retried on the next refetch). See "Publication-debt
+  retry" above.
 - **Feed size vs. the dataplane control-socket cap (#2744 / #3934):** feed
   prefixes are carried inline as CIDR text in the userspace-dp `apply_snapshot`
   (`buildAddressBookTableWithFeeds`, `pkg/dataplane/userspace/policies.go`).

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -100,10 +100,20 @@ const httpClientTimeout = 30 * time.Second
 
 // Manager manages dynamic address feed servers and their periodic updates.
 type Manager struct {
-	mu       sync.RWMutex
-	feeds    map[string]*feedState // keyed by feed-name (or feed-server name for single-feed servers)
-	client   *http.Client
-	onUpdate func() // callback when feeds are updated
+	mu     sync.RWMutex
+	feeds  map[string]*feedState // keyed by feed-name (or feed-server name for single-feed servers)
+	client *http.Client
+	// onUpdate is the publish callback invoked when a feed refresh produces
+	// content that must be (re-)applied to the dataplane. It RETURNS the apply
+	// result: a nil return means the content was ACCEPTED (applied), a non-nil
+	// return means the apply was REJECTED (preflight reject, compile failure,
+	// control-socket error, ...). installSnapshot advances its per-feed
+	// publishedHash only on a nil return, so a rejected apply leaves publication
+	// debt that the next identical refetch retries — closing #5646 (the pre-fix
+	// void callback committed the content hash regardless of the apply result,
+	// so an identical refetch saw "unchanged" and the good content sat
+	// un-enforced forever).
+	onUpdate func() error // callback when feeds are updated; returns apply result
 
 	// now is the clock source, overridable in tests for HoldInterval timing.
 	now func() time.Time
@@ -122,6 +132,22 @@ type feedState struct {
 	prefixes    []string
 	hash        [32]byte // sha256 over the canonical join; zero when no snapshot
 	hasSnapshot bool     // true once a good fetch has installed a snapshot
+
+	// publishedHash is the content hash of the snapshot last CONFIRMED applied
+	// to the dataplane — it advances ONLY when the onUpdate publish callback
+	// returns nil (apply ACCEPTED). It is deliberately decoupled from hash (the
+	// hash of the currently-INSTALLED snapshot): installSnapshot always commits
+	// hash to the freshly-fetched content, but fires onUpdate whenever the
+	// fetched content differs from publishedHash — not merely from hash. A
+	// REJECTED apply therefore leaves publishedHash stale, so an identical
+	// refetch still re-fires onUpdate and RETRIES the publish, closing the #5646
+	// publication-debt window (the pre-fix code keyed the retry decision off
+	// hash, which committed before the void callback, so a rejected apply
+	// suppressed every later identical refetch and the good content was never
+	// enforced). hasPublished distinguishes "never successfully published" (zero
+	// publishedHash) from a genuine all-zero digest, mirroring hasSnapshot.
+	publishedHash [32]byte
+	hasPublished  bool
 
 	// Parse-quality of the INSTALLED snapshot (#2993). A feed body may mix
 	// valid + invalid lines: the valid prefixes are installed but the skipped
@@ -144,9 +170,13 @@ type feedState struct {
 }
 
 // New creates a new feed manager.
-// onUpdate is called whenever a feed refresh produces a semantically different
-// prefix set (content change, not merely a count change).
-func New(onUpdate func()) *Manager {
+// onUpdate is called whenever a feed refresh produces content that differs from
+// what was last SUCCESSFULLY applied (not merely a count change, and not merely
+// a difference from the last FETCH). It RETURNS the apply result: a nil return
+// records the content as published (a later identical refetch is suppressed —
+// no thrash), a non-nil return leaves the content unpublished so the next
+// identical refetch retries the apply on the normal refresh cadence (#5646).
+func New(onUpdate func() error) *Manager {
 	return &Manager{
 		feeds: make(map[string]*feedState),
 		client: &http.Client{
@@ -383,6 +413,19 @@ func carryForwardSnapshot(dst, src *feedState) {
 	dst.lastSuccess = src.lastSuccess
 	dst.invalidLines = src.invalidLines
 	dst.invalidSample = append([]string(nil), src.invalidSample...)
+	// Carry the published-hash tracking forward too (#5646). The prior
+	// producer's snapshot is being re-enforced by the SAME applyConfigLocked
+	// that runs this Apply (it reads SnapshotForBindings from the carried
+	// prefixes), so its apply state is inherited: if the predecessor had
+	// successfully published this content, the replacement inherits
+	// publishedHash == hash and does NOT re-fire onUpdate on its first
+	// identical refetch (preserves the #5282 no-thrash contract). If the
+	// predecessor had unpublished publication DEBT (content fetched but its
+	// apply kept being rejected), hasPublished is false here, so the
+	// replacement's first fetch re-fires and retries — the debt is not lost
+	// across a reconfigure.
+	dst.publishedHash = src.publishedHash
+	dst.hasPublished = src.hasPublished
 }
 
 // StopAll cancels all running feed refresh goroutines.
@@ -809,11 +852,30 @@ func hashPrefixes(canon []string) [32]byte {
 }
 
 // installSnapshot replaces the active snapshot with a fresh good fetch, stamps
-// success, clears stale/error state, and fires onUpdate only on a content
-// change (hash differs from the currently installed snapshot).
+// success, clears stale/error state, and (re-)publishes to the dataplane when
+// the fetched content differs from what was last SUCCESSFULLY applied.
+//
+// The publish decision is keyed off publishedHash — the hash last CONFIRMED
+// applied — NOT off the installed-content hash. This is the #5646 fix: the
+// pre-fix code committed the content hash and then fired a VOID onUpdate, so a
+// REJECTED apply (preflight reject #3261/#5645, compile failure, control-socket
+// error) left the hash committed and every later identical refetch saw
+// "unchanged" and skipped onUpdate — the good content sat un-enforced forever
+// (publication debt). onUpdate now returns the apply result: publishedHash
+// advances only on a nil (accepted) return, so a rejected apply leaves the
+// content unpublished and the next identical refetch RE-FIRES onUpdate to retry
+// the apply. The retry fires on the normal refresh cadence (one publish attempt
+// per fetch), never a tight loop.
 func (m *Manager) installSnapshot(fs *feedState, res fetchResult) {
 	m.mu.Lock()
+	// changed = the installed enforced content differs from the prior install.
+	// Drives the display/degraded logging (a content change), independent of
+	// whether that content has been PUBLISHED.
 	changed := !fs.hasSnapshot || fs.hash != res.hash
+	// needsPublish = the fetched content differs from what was last CONFIRMED
+	// applied. Drives the onUpdate publish/retry. A rejected apply leaves
+	// publishedHash stale, so this stays true on an identical refetch → retry.
+	needsPublish := !fs.hasPublished || fs.publishedHash != res.hash
 	oldCount := len(fs.prefixes)
 	now := m.now()
 	fs.prefixes = res.prefixes
@@ -829,7 +891,7 @@ func (m *Manager) installSnapshot(fs *feedState, res fetchResult) {
 
 	slog.Info("dynamic-address: feed updated",
 		"name", fs.name, "prefixes", len(res.prefixes), "previous", oldCount,
-		"changed", changed, "invalid_lines", res.invalidLines)
+		"changed", changed, "needs_publish", needsPublish, "invalid_lines", res.invalidLines)
 
 	// A degraded install (some published lines skipped) is loud, but only on a
 	// content change so a persistently-malformed-but-stable feed does not flood
@@ -841,9 +903,32 @@ func (m *Manager) installSnapshot(fs *feedState, res fetchResult) {
 			"invalid_lines", res.invalidLines, "invalid_sample", res.invalidSample)
 	}
 
-	if changed && m.onUpdate != nil {
-		m.onUpdate()
+	if !needsPublish {
+		// Already applied this exact content — no republish, no thrash.
+		return
 	}
+
+	// Publish to the dataplane. A nil callback (no consumer wired) is treated as
+	// a vacuous success so publishedHash tracks the installed content and a
+	// later identical refetch is still suppressed.
+	var applyErr error
+	if m.onUpdate != nil {
+		applyErr = m.onUpdate()
+	}
+	if applyErr != nil {
+		// Apply REJECTED: do NOT advance publishedHash. The content is installed
+		// (fs.prefixes/fs.hash) and enforced-in-intent, but the dataplane did
+		// not accept it. Leaving publishedHash stale means the next identical
+		// refetch re-fires this path and retries the apply (#5646). This is
+		// publication debt, surfaced loudly but bounded to one retry per fetch.
+		slog.Warn("dynamic-address: feed apply REJECTED — good content not yet enforced (publication debt), will retry on next refresh",
+			"name", fs.name, "prefixes", len(res.prefixes), "err", applyErr)
+		return
+	}
+	m.mu.Lock()
+	fs.publishedHash = res.hash
+	fs.hasPublished = true
+	m.mu.Unlock()
 }
 
 // recordFailure handles a failed fetch under the retain-last-good policy:
@@ -886,6 +971,13 @@ func (m *Manager) recordFailure(fs *feedState, ferr error) {
 			// the degraded markers too (#2993).
 			fs.invalidLines = 0
 			fs.invalidSample = nil
+			// #5646: reset the published-hash tracking. The enforced set is now
+			// empty; if this feed later RECOVERS and refetches its prior content,
+			// installSnapshot must re-fire onUpdate to re-enforce it. Leaving a
+			// stale publishedHash equal to the recovered content would suppress
+			// that re-apply and leave the recovered denylist un-enforced.
+			fs.publishedHash = [32]byte{}
+			fs.hasPublished = false
 			dropped = true
 		}
 	}
@@ -896,7 +988,16 @@ func (m *Manager) recordFailure(fs *feedState, ferr error) {
 		slog.Warn("dynamic-address: hold interval elapsed, dropping stale feed to empty",
 			"name", fs.name, "err", ferr, "hold", fs.holdInterval)
 		if m.onUpdate != nil {
-			m.onUpdate()
+			// The drop-to-empty is a fail-CLOSED transition (a denylist stops
+			// enforcing stale prefixes). If the apply of the now-empty set is
+			// rejected the dataplane keeps enforcing the last-good prefixes —
+			// strictly safer than an empty set — so we only log the rejection;
+			// publishedHash was already reset above so a later recovery
+			// re-publishes regardless.
+			if err := m.onUpdate(); err != nil {
+				slog.Warn("dynamic-address: drop-to-empty apply rejected — dataplane retains last-good set",
+					"name", fs.name, "err", err)
+			}
 		}
 	case enteredStale:
 		// One-time loud warning on entry to the stale state. Subsequent

--- a/pkg/feeds/feeds_dup_name_4913_test.go
+++ b/pkg/feeds/feeds_dup_name_4913_test.go
@@ -51,7 +51,7 @@ func TestApplyDeDupsDuplicateFeedNames(t *testing.T) {
 	ts := httptest.NewServer(cs.handler())
 	defer ts.Close()
 
-	m := New(func() {})
+	m := New(func() error { return nil })
 	// Two servers "aaa" and "bbb" each declare the SAME feed name "dup" with a
 	// distinct path so the winner's URL is identifiable. Both hit the same
 	// counting server. Winner must be the sorted-first server, "aaa".

--- a/pkg/feeds/feeds_firstfetch_failopen_5645_test.go
+++ b/pkg/feeds/feeds_firstfetch_failopen_5645_test.go
@@ -45,7 +45,7 @@ func denyBindingCfg(feedName, url string) *config.DynamicAddressConfig {
 // the deny must not fail open. Reverting the SnapshotForBindings omission
 // publishes "denylist" as a non-nil empty slice, turning both assertions RED.
 func TestFirstFetchFailedDenyFeedNotPublishedMatchNone(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 
 	// First (and only) fetch fails: the endpoint is DOWN (500). There is NO
 	// prior good snapshot — this is the first-fetch case, not the re-fetch window.
@@ -86,7 +86,7 @@ func TestFirstFetchFailedDenyFeedNotPublishedMatchNone(t *testing.T) {
 // feed (a PERMIT feed that fetches non-empty enforces those prefixes, and a
 // resolved DENY feed enforces its denylist).
 func TestFirstFetchSuccessPublishesFeed(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 
 	good := &bodyServer{}
 	good.set("203.0.113.0/24\n", http.StatusOK)
@@ -126,7 +126,7 @@ func TestPermitFeedNoMembersOmittedNotFailOpen(t *testing.T) {
 // later FAILED refresh keeps the last-good prefixes published (retainForever) —
 // the binding stays present, never dropping to the omitted/match-none state.
 func TestReFetchWindowStillPublishesLastGood(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 
 	srv := &bodyServer{}
 	srv.set("203.0.113.0/24\n", http.StatusOK)

--- a/pkg/feeds/feeds_publication_debt_5646_test.go
+++ b/pkg/feeds/feeds_publication_debt_5646_test.go
@@ -1,0 +1,153 @@
+package feeds
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRejectedApplyRetriesOnIdenticalRefetch is the #5646 fail-on-revert test.
+//
+// installSnapshot must (re-)fire the publish callback (onUpdate) whenever the
+// fetched content differs from what was last SUCCESSFULLY applied — not merely
+// from the last FETCH. The pre-#5646 code committed the content hash and then
+// fired a VOID callback, so a REJECTED apply (preflight reject, compile
+// failure, control-socket error) left the hash committed; a later identical
+// refetch then saw "unchanged" and skipped onUpdate → the good content was
+// never enforced (publication debt).
+//
+// RED-on-revert: on pre-fix code the second (identical) fetch does NOT re-fire
+// onUpdate because the content hash already matched, so calls stays at 1 and
+// this test FAILS at fetch#2. On fixed code the rejected first apply leaves
+// publishedHash stale, so the identical refetch re-fires and the retry succeeds.
+func TestRejectedApplyRetriesOnIdenticalRefetch(t *testing.T) {
+	var calls atomic.Int32
+	var rejectNext atomic.Bool
+	rejectNext.Store(true) // reject the FIRST apply, accept the rest
+	m := New(func() error {
+		calls.Add(1)
+		if rejectNext.Swap(false) {
+			return fmt.Errorf("synthetic apply rejection (preflight/compile/control-socket)")
+		}
+		return nil
+	})
+
+	srv := &bodyServer{}
+	srv.set("192.0.2.0/24\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("f", ts.URL, time.Hour)
+	ctx := context.Background()
+
+	// Fetch #1: content installed, onUpdate fires, apply REJECTED. The content
+	// is installed (enforced-in-intent) but must NOT be recorded as published.
+	m.fetchFeed(ctx, fs)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch#1: onUpdate calls = %d, want 1", got)
+	}
+	if fs.hasPublished {
+		t.Fatalf("fetch#1: a rejected apply must NOT mark content published (publishedHash must stay stale so the next refetch retries)")
+	}
+	if got := m.GetPrefixes("f"); len(got) != 1 || got[0] != "192.0.2.0/24" {
+		t.Fatalf("fetch#1: content not installed: got %v", got)
+	}
+
+	// Fetch #2: IDENTICAL content. Pre-fix: the content hash already matches, so
+	// onUpdate is skipped (calls stays 1) → publication debt, good content never
+	// re-applied. Fixed: publishedHash is still stale, so onUpdate RE-FIRES
+	// (retry); this time the apply succeeds and the content is recorded as
+	// published.
+	m.fetchFeed(ctx, fs)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("fetch#2 (identical content, retry after rejected apply): onUpdate calls = %d, want 2 — a rejected apply MUST be retried on an identical refetch, not suppressed as publication debt", got)
+	}
+	if !fs.hasPublished {
+		t.Fatalf("fetch#2: a successful retry must mark content published")
+	}
+
+	// Fetch #3: IDENTICAL content, already successfully published → must NOT
+	// re-fire onUpdate (no thrash / no busy-loop on a stable, applied feed).
+	m.fetchFeed(ctx, fs)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("fetch#3 (identical content, already published): onUpdate calls = %d, want still 2 — a successfully-applied feed must not re-fire (no thrash)", got)
+	}
+}
+
+// TestSuccessfulApplyThenIdenticalRefetchDoesNotThrash pins the no-thrash
+// guarantee independent of any rejection: a feed whose FIRST apply is accepted
+// must not re-fire onUpdate on an identical refetch. This is the counterpart to
+// the retry-on-rejection behaviour and guards against a fix that over-fires.
+func TestSuccessfulApplyThenIdenticalRefetchDoesNotThrash(t *testing.T) {
+	var calls atomic.Int32
+	m := New(func() error { calls.Add(1); return nil })
+
+	srv := &bodyServer{}
+	srv.set("203.0.113.0/24\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("f", ts.URL, time.Hour)
+	ctx := context.Background()
+
+	m.fetchFeed(ctx, fs) // install + apply accepted
+	m.fetchFeed(ctx, fs) // identical refetch — must be suppressed
+	m.fetchFeed(ctx, fs) // identical refetch — must be suppressed
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("identical successful refetches fired onUpdate %d times, want 1 (no thrash)", got)
+	}
+	if !fs.hasPublished {
+		t.Fatalf("accepted apply must mark content published")
+	}
+}
+
+// TestRejectedApplyThenNewContentPublishes proves the retry decision keys off
+// the LAST-PUBLISHED content, not the last fetch: after a rejected apply of set
+// A, fetching a DIFFERENT set B must publish B (needsPublish is true for any
+// content that was never successfully applied), and a subsequent successful
+// apply advances publishedHash so an identical B refetch is then suppressed.
+func TestRejectedApplyThenNewContentPublishes(t *testing.T) {
+	var calls atomic.Int32
+	var rejectNext atomic.Bool
+	rejectNext.Store(true) // reject only the first apply
+	m := New(func() error {
+		calls.Add(1)
+		if rejectNext.Swap(false) {
+			return fmt.Errorf("synthetic apply rejection")
+		}
+		return nil
+	})
+
+	srv := &bodyServer{}
+	srv.set("192.0.2.0/24\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("f", ts.URL, time.Hour)
+	ctx := context.Background()
+
+	m.fetchFeed(ctx, fs) // A installed, apply REJECTED (calls=1)
+	if calls.Load() != 1 || fs.hasPublished {
+		t.Fatalf("after rejected A: calls=%d hasPublished=%v, want 1/false", calls.Load(), fs.hasPublished)
+	}
+
+	// New content B — apply accepted this time.
+	srv.set("198.51.100.0/24\n", http.StatusOK)
+	m.fetchFeed(ctx, fs)
+	if calls.Load() != 2 || !fs.hasPublished {
+		t.Fatalf("after B: calls=%d hasPublished=%v, want 2/true", calls.Load(), fs.hasPublished)
+	}
+	if got := m.GetPrefixes("f"); len(got) != 1 || got[0] != "198.51.100.0/24" {
+		t.Fatalf("B not enforced: got %v", got)
+	}
+
+	// Identical B refetch — already published, must not re-fire.
+	m.fetchFeed(ctx, fs)
+	if calls.Load() != 2 {
+		t.Fatalf("identical B refetch re-fired onUpdate: calls=%d, want 2", calls.Load())
+	}
+}

--- a/pkg/feeds/feeds_samplecap_4922_test.go
+++ b/pkg/feeds/feeds_samplecap_4922_test.go
@@ -188,7 +188,7 @@ func TestInvalidSampleBoundedThroughAllFeeds(t *testing.T) {
 	ts := httptest.NewServer(srv.handler())
 	defer ts.Close()
 
-	m := New(func() {})
+	m := New(func() error { return nil })
 	fs := m.newFeed("huge", ts.URL, time.Hour)
 	m.fetchFeed(context.Background(), fs)
 

--- a/pkg/feeds/feeds_sizecap_3934_test.go
+++ b/pkg/feeds/feeds_sizecap_3934_test.go
@@ -149,7 +149,7 @@ func (s *oversizeServer) handler() http.HandlerFunc {
 // clobbering the last-good — the retention assertion goes RED.
 func TestFetchFeedOverSizeRetainsLastGood(t *testing.T) {
 	var calls int
-	m := New(func() { calls++ })
+	m := New(func() error { calls++; return nil })
 	srv := &oversizeServer{}
 	ts := httptest.NewServer(srv.handler())
 	defer ts.Close()
@@ -212,7 +212,7 @@ func (s *slowServer) handler() http.HandlerFunc {
 // retain the last-good snapshot, not block the refresh indefinitely. The
 // timeout is overridden to a short value so the test is fast.
 func TestFetchFeedSlowServerTimesOut(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 	m.client.Timeout = 150 * time.Millisecond
 
 	srv := &slowServer{delay: 2 * time.Second, body: "203.0.113.0/24\n"}

--- a/pkg/feeds/feeds_snapshot_handoff_5282_test.go
+++ b/pkg/feeds/feeds_snapshot_handoff_5282_test.go
@@ -39,7 +39,7 @@ func waitFor(t *testing.T, d time.Duration, cond func() bool, msg string) {
 // both the immediate assertion (no snapshot after Apply) and the post-failure
 // assertion (retainForever holds an EMPTY set) turn RED.
 func TestApplyReconfigureFailedFetchRetainsLastGood(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 
 	// 1) Install a deny feed's last-good snapshot from a healthy endpoint.
 	good := &bodyServer{}
@@ -101,7 +101,7 @@ func TestApplyReconfigureFailedFetchRetainsLastGood(t *testing.T) {
 // keeps its carried-forward snapshot. This is the removed-vs-persisted boundary:
 // carry-forward must not resurrect a deleted feed.
 func TestApplyDropsRemovedFeed(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 	good := &bodyServer{}
 	good.set("203.0.113.0/24\n", http.StatusOK)
 	ts := httptest.NewServer(good.handler())
@@ -140,7 +140,7 @@ func TestApplyDropsRemovedFeed(t *testing.T) {
 // DIFFERENT set, the new fetch atomically REPLACES the carried-forward snapshot
 // (no stale-union, no torn read) rather than leaving the old prefixes installed.
 func TestApplyReconfigureSuccessfulFetchReplacesSnapshot(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 
 	// Last-good from endpoint A.
 	oldSrv := &bodyServer{}

--- a/pkg/feeds/feeds_test.go
+++ b/pkg/feeds/feeds_test.go
@@ -145,7 +145,7 @@ func TestInvalidSampleIsBounded(t *testing.T) {
 // TestMixedFeedDegradedStatus confirms a mixed body installs valid prefixes and
 // surfaces a degraded status with the invalid-line count through AllFeeds.
 func TestMixedFeedDegradedStatus(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 	srv := &bodyServer{}
 	srv.set("192.0.2.0/24\nnot-an-ip\n203.0.113.0/24\n", http.StatusOK)
 	ts := httptest.NewServer(srv.handler())
@@ -175,7 +175,7 @@ func TestMixedFeedDegradedStatus(t *testing.T) {
 // TestCleanFeedNotDegraded is the no-behaviour-change guard: an all-valid feed
 // installs fully with zero invalid lines and is NOT marked degraded.
 func TestCleanFeedNotDegraded(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 	srv := &bodyServer{}
 	srv.set("192.0.2.0/24\n203.0.113.0/24\n", http.StatusOK)
 	ts := httptest.NewServer(srv.handler())
@@ -202,7 +202,7 @@ func TestCleanFeedNotDegraded(t *testing.T) {
 // TestDegradedClearsAfterCleanRefetch confirms a feed that recovers (provider
 // fixes the body) drops the degraded markers on the next clean install.
 func TestDegradedClearsAfterCleanRefetch(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 	srv := &bodyServer{}
 	srv.set("192.0.2.0/24\nbad-line\n", http.StatusOK)
 	ts := httptest.NewServer(srv.handler())
@@ -253,7 +253,7 @@ func TestParseFeedOverlongLineErrors(t *testing.T) {
 // with identical count must fire onUpdate. The old code compared len only.
 func TestSameCountContentChangeFires(t *testing.T) {
 	var calls atomic.Int32
-	m := New(func() { calls.Add(1) })
+	m := New(func() error { calls.Add(1); return nil })
 
 	srv := &bodyServer{}
 	srv.set("192.0.2.0/24\n", http.StatusOK)
@@ -281,7 +281,7 @@ func TestSameCountContentChangeFires(t *testing.T) {
 
 func TestIdenticalContentDoesNotFire(t *testing.T) {
 	var calls atomic.Int32
-	m := New(func() { calls.Add(1) })
+	m := New(func() error { calls.Add(1); return nil })
 
 	srv := &bodyServer{}
 	// Same prefixes in a different order each fetch -> canonical hash identical.
@@ -310,7 +310,7 @@ func TestIdenticalContentDoesNotFire(t *testing.T) {
 // not replace the snapshot and must not stamp lastFetch/lastSuccess.
 func TestErrorRetainsSnapshotNoStamp(t *testing.T) {
 	var calls atomic.Int32
-	m := New(func() { calls.Add(1) })
+	m := New(func() error { calls.Add(1); return nil })
 
 	srv := &bodyServer{}
 	srv.set("192.0.2.0/24\n", http.StatusOK)
@@ -351,7 +351,7 @@ func TestErrorRetainsSnapshotNoStamp(t *testing.T) {
 // HTTP-200 empty body must NOT wipe the enforced set; it is treated as suspect.
 func TestZeroPrefixRetainsLastGood(t *testing.T) {
 	var calls atomic.Int32
-	m := New(func() { calls.Add(1) })
+	m := New(func() error { calls.Add(1); return nil })
 
 	srv := &bodyServer{}
 	srv.set("203.0.113.0/24\n", http.StatusOK)
@@ -397,7 +397,7 @@ func TestResolveHoldInterval(t *testing.T) {
 // (see TestUnsetHoldIntervalRetainsForever) — it requires hold-interval > 0.
 func TestHoldIntervalRetainThenDrop(t *testing.T) {
 	var calls atomic.Int32
-	m := New(func() { calls.Add(1) })
+	m := New(func() error { calls.Add(1); return nil })
 
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	var nowMu sync.Mutex
@@ -480,7 +480,7 @@ func TestHoldIntervalRetainThenDrop(t *testing.T) {
 // after the window elapsed.
 func TestUnsetHoldIntervalRetainsForever(t *testing.T) {
 	var calls atomic.Int32
-	m := New(func() { calls.Add(1) })
+	m := New(func() error { calls.Add(1); return nil })
 
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	var nowMu sync.Mutex
@@ -545,7 +545,7 @@ func TestUnsetHoldIntervalRetainsForever(t *testing.T) {
 // TestStartupNoSnapshotFailClosed targets behavior 5 startup semantics: before
 // any good fetch, a failing feed has no snapshot and GetPrefixes is empty.
 func TestStartupNoSnapshotFailClosed(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 	srv := &bodyServer{}
 	srv.set("nope", http.StatusInternalServerError)
 	ts := httptest.NewServer(srv.handler())
@@ -577,7 +577,7 @@ func TestStartupNoSnapshotFailClosed(t *testing.T) {
 
 // TestAllFeedsStatusFields confirms the additive status fields surface.
 func TestAllFeedsStatusFields(t *testing.T) {
-	m := New(func() {})
+	m := New(func() error { return nil })
 	srv := &bodyServer{}
 	srv.set("192.0.2.0/24\n", http.StatusOK)
 	ts := httptest.NewServer(srv.handler())


### PR DESCRIPTION
## Problem (codex-review-181 F2, #5646)

`installSnapshot` committed the fetched content hash and then fired a **void** `onUpdate` callback that drives the daemon to APPLY the snapshot. If that apply was **rejected** — a whole-snapshot preflight reject (#3261/#5645), a compile failure, or a transient control-socket error — the hash was already committed, so every later refetch of the (still-good, still un-applied) **identical** content saw "unchanged hash" and **skipped** `onUpdate`.

The good content then sat un-enforced indefinitely — **publication debt**: the provider keeps serving the same body (hash never changes again) and the default refresh is hourly, so the intended deny feed/policy silently **failed open** until an unrelated commit or a genuine content change happened to re-drive the apply.

## Fix — design (a): split published-hash from fetched-hash

- `onUpdate` changed `func()` → `func() error`: nil = apply **accepted**, non-nil = **rejected**.
- `feedState` gains `publishedHash`/`hasPublished`, tracking the hash last **confirmed applied**.
- `installSnapshot` still commits `fs.hash` to the freshly-fetched content (display + #5282 carry stay truthful), but fires `onUpdate` whenever the fetched content differs from **`publishedHash`** — not from `fs.hash` — and advances `publishedHash` only on a nil return.
- A **rejected** apply leaves `publishedHash` stale → the next identical refetch **re-fires and retries** on the normal refresh cadence (one attempt per fetch, no tight loop).
- A **successfully-applied** feed has `publishedHash == fs.hash` → identical refetch suppressed (**no thrash**).
- `carryForwardSnapshot` inherits `publishedHash`/`hasPublished` (#5282 no-re-fire contract preserved; unpublished debt survives a reconfigure). The hold-interval drop-to-empty resets both fields so a recovery re-enforces.

### onUpdate contract change + call sites
Only production call site is `ensureFeedManager` (`daemon_feeds.go`), now returning the result of the new `applyConfigResult` (an error-returning sibling of `applyConfig`) instead of swallowing it. Nil active config → vacuous success. All `pkg/feeds` test callbacks updated to `func() error`.

## Validation
- `go build ./...`, `go vet`, and `go test ./pkg/feeds/... ./pkg/dataplane/userspace/... ./pkg/daemon/...` all green.
- **RED-on-revert proven**: reverting the gate to the pre-fix hash-based decision makes `TestRejectedApplyRetriesOnIdenticalRefetch` observe `calls = 1, want 2` at fetch#2. With the fix, fetch#2 retries and succeeds, fetch#3 (already published) does not re-fire.
- `#5282`/`#5645`/`#3934` feeds tests unaffected.
- `pkg/feeds/README.md` "Publication-debt retry" section documents the new contract.

Closes #5646

🤖 Generated with [Claude Code](https://claude.com/claude-code)