### PR TITLE
policymatch: expand predefined app-set bundles in the policy simulator (#5666)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -46720,3 +46720,15 @@ top.
   match-none = deny fail-open); the resolved-feed test stays green. Restoring ->
   GREEN. Permit-none and the #5282 re-fetch window are unaffected
   (TestFirstFetchSuccessPublishesFeed, TestReFetchWindowStillPublishesLastGood).
+
+- **Timestamp**: 2026-07-11
+- **Action**: #5666 — route the operator-side policy simulator's app-set
+  expansion through config.ResolveApplicationSet (predefined-aware, #4102/#5629)
+  so `test policy` / `show security match-policies` / MatchPolicies match a
+  PREDEFINED bundle (junos-ms-rpc etc.) the way the #5629-fixed dataplane does.
+  Both matchApp + appTermL4Constrained gated on the USER-only ApplicationSets
+  map; a predefined bundle resolved to no members → wrong dry-run verdict.
+  Resolve app-first so a user app shadowing a predefined-set name keeps app
+  semantics. Fail-on-revert proven (predefined-bundle match RED on the user-only
+  gate; shadow test not gate-dependent). Diagnostic simulator only (non-enforcement).
+- **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/predefined_set_5666_test.go

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -1714,7 +1714,16 @@ func matchApp(cfg *config.Config, apps []string, proto string, srcPort, dstPort 
 		}
 		// Application-set: expand recursively (multi-level) and test each
 		// member application.
-		if _, isSet := cfg.Applications.ApplicationSets[a]; isSet {
+		// #5666: recognize a PREDEFINED application-set bundle (junos-ms-rpc,
+		// junos-sun-rpc, junos-cifs, junos-routing-inbound), not just
+		// user-defined sets — mirror the #5629 dataplane fix so this operator
+		// simulator matches the fixed dataplane. Resolve an application FIRST so
+		// a user application shadowing a predefined-set name keeps application
+		// semantics (matches resolveUserspaceApplicationNames + #5629's
+		// app-first precedence). config.ResolveApplicationSet consults user sets
+		// then the #4102 predefined table.
+		_, isApp := config.ResolveApplication(a, cfg.Applications.Applications)
+		if _, isSet := config.ResolveApplicationSet(a, cfg.Applications.ApplicationSets); !isApp && isSet {
 			members, err := config.ExpandApplicationSet(a, &cfg.Applications)
 			if err != nil {
 				// #3727: an unexpandable application-set is a whole-snapshot
@@ -1881,7 +1890,16 @@ func hasL4ConstrainedTerm(cfg *config.Config, apps []string, proto string) bool 
 			// match-any covers this protocol with an ungated term.
 			return false
 		}
-		if _, isSet := cfg.Applications.ApplicationSets[a]; isSet {
+		// #5666: recognize a PREDEFINED application-set bundle (junos-ms-rpc,
+		// junos-sun-rpc, junos-cifs, junos-routing-inbound), not just
+		// user-defined sets — mirror the #5629 dataplane fix so this operator
+		// simulator matches the fixed dataplane. Resolve an application FIRST so
+		// a user application shadowing a predefined-set name keeps application
+		// semantics (matches resolveUserspaceApplicationNames + #5629's
+		// app-first precedence). config.ResolveApplicationSet consults user sets
+		// then the #4102 predefined table.
+		_, isApp := config.ResolveApplication(a, cfg.Applications.Applications)
+		if _, isSet := config.ResolveApplicationSet(a, cfg.Applications.ApplicationSets); !isApp && isSet {
 			members, err := config.ExpandApplicationSet(a, &cfg.Applications)
 			if err != nil {
 				continue

--- a/pkg/policymatch/predefined_set_5666_test.go
+++ b/pkg/policymatch/predefined_set_5666_test.go
@@ -1,0 +1,83 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5666 — the operator-side policy simulator (matchApp / appTermL4Constrained,
+// backing `test policy` / `show security match-policies` + the REST/gRPC
+// MatchPolicies RPCs) gated application-set expansion on the USER-only
+// cfg.Applications.ApplicationSets map. A strict PREDEFINED bundle
+// (junos-ms-rpc/junos-sun-rpc/junos-cifs/junos-routing-inbound) referenced by a
+// policy therefore resolved to NO members and never matched — while the
+// #5629-fixed dataplane DOES match it. So the operator's dry-run reported the
+// WRONG verdict (no match) for traffic the enforced dataplane permits/denies — a
+// confusing simulator↔dataplane divergence. The fix routes both sites through
+// config.ResolveApplicationSet (user sets first, then the #4102 predefined table),
+// resolving an application FIRST so a user app shadowing a predefined-set name
+// keeps application semantics (matching #5629 + resolveUserspaceApplicationNames).
+//
+// Fail-on-revert: restoring the user-only `ApplicationSets[a]` gate makes the
+// predefined-bundle policy no longer match (falls through to default-deny).
+func TestPredefinedApplicationSetPolicyMatches_5666(t *testing.T) {
+	// No user application-sets — junos-ms-rpc is a PREDEFINED bundle only.
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-msrpc",
+				config.PolicyMatch{Applications: []string{"junos-ms-rpc"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	// junos-ms-rpc expands to junos-ms-rpc-tcp (tcp/135) + junos-ms-rpc-udp (udp/135).
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 135})
+	if res.ContentRejected {
+		t.Fatalf("ContentRejected=true for a well-formed predefined bundle; reasons=%v", res.ContentRejectionReasons)
+	}
+	if !res.Matched || res.Action != config.PolicyPermit || res.PolicyName != "permit-msrpc" {
+		t.Fatalf("predefined bundle junos-ms-rpc tcp/135 did not match the permit: Matched=%v Action=%v Name=%q DefaultUsed=%v — the simulator must match the #5629-fixed dataplane",
+			res.Matched, res.Action, res.PolicyName, res.DefaultUsed)
+	}
+
+	// udp/135 also matches (junos-ms-rpc-udp).
+	resUDP := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "udp", DstPort: 135})
+	if !resUDP.Matched || resUDP.Action != config.PolicyPermit {
+		t.Fatalf("junos-ms-rpc udp/135 did not match: Matched=%v Action=%v", resUDP.Matched, resUDP.Action)
+	}
+
+	// A non-member (tcp/80) must NOT match — the bundle is narrow, not match-any.
+	resNo := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	if resNo.Matched {
+		t.Fatalf("tcp/80 wrongly matched junos-ms-rpc (should be default-deny): Action=%v", resNo.Action)
+	}
+}
+
+// TestUserAppShadowsPredefinedSetName_5666 pins the app-first precedence: a USER
+// application whose name collides with a predefined-set bundle keeps APPLICATION
+// semantics (resolves as the user app, NOT the predefined bundle).
+func TestUserAppShadowsPredefinedSetName_5666(t *testing.T) {
+	// User app "junos-ms-rpc" = tcp/9999 (shadows the predefined bundle name).
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-shadow",
+				config.PolicyMatch{Applications: []string{"junos-ms-rpc"}})),
+		},
+	}, config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			"junos-ms-rpc": {Name: "junos-ms-rpc", Protocol: "tcp", DestinationPort: "9999"},
+		},
+	})
+
+	// The user app matches tcp/9999, NOT tcp/135 (the predefined bundle's port).
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 9999})
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("user app junos-ms-rpc tcp/9999 did not match (app-first precedence broken): Matched=%v Action=%v", res.Matched, res.Action)
+	}
+	res135 := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 135})
+	if res135.Matched {
+		t.Fatalf("tcp/135 matched — a user app shadowing junos-ms-rpc must NOT expand as the predefined bundle: Action=%v", res135.Action)
+	}
+}


### PR DESCRIPTION
## Summary
The operator-side security-policy simulator (`matchApp` + `appTermL4Constrained`, backing `test policy` / `show security match-policies` + the REST/gRPC MatchPolicies RPCs) gated application-set expansion on the USER-only `cfg.Applications.ApplicationSets` map. A strict **predefined** bundle (junos-ms-rpc/junos-sun-rpc/junos-cifs/junos-routing-inbound) referenced by a policy resolved to no members and never matched — while the **#5629-fixed dataplane DOES match it**. So an operator's dry-run reported the wrong verdict (no match) for traffic the enforced dataplane permits/denies — the 4th site of the #5629 bug, surfaced by the #5664 review.

## Fix
Route both sites through `config.ResolveApplicationSet` (user sets first, then the #4102 predefined table), resolving an application **first** so a user app shadowing a predefined-set name keeps application semantics — matching #5629 + `resolveUserspaceApplicationNames`.

## Scope
Diagnostic **simulator only** (non-enforcement — the package is explicitly "OPPOSITE of what the dataplane actually does"; the other caller, policies_scheduler.go, only feeds a scheduler-inactivity predicate *into* the sim). No dataplane change.

## Validation
- `go build ./...` + `go vet` clean; gofmt clean; full `pkg/policymatch` suite green.
- **Fail-on-revert proven**: restoring the user-only gate fails `TestPredefinedApplicationSetPolicyMatches_5666` (junos-ms-rpc tcp/135 no longer matches → default-deny); `TestUserAppShadowsPredefinedSetName_5666` stays green (a user app shadowing the bundle name keeps app semantics).

Closes #5666