### PR TITLE
config: resolve app before app-set in direct-host projection (#5677)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-12 — #5677: direct-host (junos-host) projection resolves application-set before a same-named user application
+- **Timestamp**: 2026-07-12 (fix/5677-directhost-app-first)
+- **Action**: codex-review-182 M11 (High). In the config compiler's DIRECT
+  host-bound (`to-zone junos-host`) DENY projection, `junosHostResolveApplications`
+  consulted the application-SET table (`ResolveApplicationSet`, which also sees
+  the #4102 predefined bundles) BEFORE the user APPLICATION table, so a user
+  application shadowed by a same-named set was mis-resolved to the set — the
+  kernel `xpf_hostinbound` DENY projected the set's member ports, not the
+  operator's application ports. Fixed to app-first: resolve `ResolveApplication`
+  first and only OR-expand as an application-set when the token is NOT an
+  application, mirroring `resolveUserspaceApplicationNames` and the #5629/#5664
+  policy-match / NAT / catalog fixes. Distinct from closed #5629 (policy-match
+  ordering) and open #5671 (memberIsNestedSet nil guard) — this is the
+  direct-host projection site specifically. Fail-on-revert test uses a user
+  `application junos-ms-rpc` (tcp/9999) shadowing the predefined `junos-ms-rpc`
+  bundle (tcp/135 + udp/135): app-first projects tcp/9999 (1 fragment);
+  reverting to set-first projects tcp/135 + udp/135 (2 fragments) → RED. Proven
+  RED-on-revert, GREEN with the fix; full `pkg/config` suite passes.
+- **File(s)**: pkg/config/junos_host_deny.go, pkg/config/junos_host_deny_app_shadow_5677_test.go
+
 ## 2026-07-11 — #5628 (security): NAT rule `then` must carry exactly one terminal translation action
 - **Timestamp**: 2026-07-11 (fix/5628-nat-terminal-action)
 - **Action**: codex-review-181 M16. A source/destination NAT rule's complete

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -703,8 +703,17 @@ func junosHostResolveApplications(cfg *Config, tokens []string) (l4 []JunosHostD
 			appAny = true
 			continue
 		}
-		// application-set: OR-expand to member applications.
-		if _, isSet := ResolveApplicationSet(tok, cfg.Applications.ApplicationSets); isSet {
+		// #5677: resolve a user/predefined APPLICATION first, so a user
+		// application shadowing a same-named application-set keeps ITS OWN
+		// ports on this direct host-bound projection. Only OR-expand as an
+		// application-set when the token is NOT an application — mirroring the
+		// app-first precedence of resolveUserspaceApplicationNames and the
+		// #5629/#5664 policy-match / NAT / catalog fixes. Consulting the
+		// application-SET table first (the pre-#5677 bug) mis-resolved a
+		// shadowed user application to the set's members, so the kernel
+		// direct-host DENY projected the wrong ports.
+		_, isApp := ResolveApplication(tok, cfg.Applications.Applications)
+		if _, isSet := ResolveApplicationSet(tok, cfg.Applications.ApplicationSets); !isApp && isSet {
 			members, err := ExpandApplicationSet(tok, &cfg.Applications)
 			if err != nil {
 				ok = false

--- a/pkg/config/junos_host_deny_app_shadow_5677_test.go
+++ b/pkg/config/junos_host_deny_app_shadow_5677_test.go
@@ -1,0 +1,82 @@
+package config
+
+import "testing"
+
+// TestJunosHostDirectProjectionAppShadowsSet is the #5677 fail-on-revert guard
+// for the DIRECT host-bound (to-zone junos-host) projection's application
+// resolver. A user `application <X>` that shadows a same-named application-set
+// MUST project ITS OWN ports into the kernel DENY, not the set's member ports.
+//
+// The pre-#5677 bug: junosHostResolveApplications consulted the application-SET
+// table (ResolveApplicationSet, which also sees the #4102 predefined bundles)
+// BEFORE the user application, so a shadowed application was mis-resolved to the
+// set and the kernel `xpf_hostinbound` DENY dropped the wrong ports.
+//
+// This case uses a user application named `junos-ms-rpc` — the predefined
+// application-set bundle (junos-ms-rpc-tcp tcp/135 + junos-ms-rpc-udp udp/135,
+// #4102). A user application shadowing a PREDEFINED set name is NOT an
+// application/application-set collision (only user-authored AST stanzas are
+// examined by the #3339 gate; the predefined table lives outside the AST), so
+// the config commits clean and both resolvers see the name.
+//
+// With the app-first fix the deny projects exactly tcp/9999 (the user
+// application). Reverting to set-first re-expands the bundle and the deny
+// projects tcp/135 + udp/135 instead — the ports the operator's application
+// never named — making this test RED.
+func TestJunosHostDirectProjectionAppShadowsSet(t *testing.T) {
+	cmds := append(append([]string{}, junosHostBaseZones...),
+		// User application shadowing the predefined `junos-ms-rpc` app-set.
+		"set applications application junos-ms-rpc protocol tcp",
+		"set applications application junos-ms-rpc destination-port 9999",
+		// Deny the shadowed application on the direct host-bound path.
+		"set security policies from-zone untrust to-zone junos-host policy block-rpc match source-address bad-host",
+		"set security policies from-zone untrust to-zone junos-host policy block-rpc match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy block-rpc match application junos-ms-rpc",
+		"set security policies from-zone untrust to-zone junos-host policy block-rpc then deny",
+	)
+	cfg, err := CompileConfig(buildJunosHostWarnTree(t, cmds))
+	if err != nil {
+		// A user application shadowing a PREDEFINED set name must commit clean
+		// (not a #3339 collision). If this fails the shadow scenario itself is
+		// unconstructible and the resolver-ordering assertion below is moot.
+		t.Fatalf("CompileConfig: user application shadowing predefined app-set should commit clean, got %v", err)
+	}
+
+	proj := BuildJunosHostDenyProjection(cfg)
+	var prog *JunosHostDenyProgram
+	for i := range proj.Programs {
+		if proj.Programs[i].Zone == "untrust" {
+			prog = &proj.Programs[i]
+			break
+		}
+	}
+	if prog == nil {
+		t.Fatalf("no untrust program in projection: %+v", proj.Programs)
+	}
+	if !prog.Representable {
+		t.Fatalf("untrust program must be representable (tcp/9999 deny), got %+v", *prog)
+	}
+
+	// Collect every projected L4 fragment across both families.
+	var frags []JunosHostDenyL4
+	for _, r := range prog.RulesV4 {
+		frags = append(frags, r.L4...)
+	}
+	for _, r := range prog.RulesV6 {
+		frags = append(frags, r.L4...)
+	}
+	if len(frags) != 1 {
+		t.Fatalf("want exactly 1 L4 fragment (the user application tcp/9999); got %d: %+v\n"+
+			"set-first resolution (the #5677 bug) expands the junos-ms-rpc bundle to tcp/135 + udp/135",
+			len(frags), frags)
+	}
+	f := frags[0]
+	if f.Proto != HostInboundProtoTCP {
+		t.Fatalf("fragment proto = %d, want TCP (%d) — the user application is tcp-only; a UDP fragment means the app-set bundle was expanded (set-first)",
+			f.Proto, HostInboundProtoTCP)
+	}
+	if len(f.Ports) != 1 || f.Ports[0] != (PortRange{Lo: 9999, Hi: 9999}) {
+		t.Fatalf("fragment ports = %+v, want [{9999 9999}] (the user application) — port 135 means the predefined junos-ms-rpc bundle was resolved instead (the #5677 set-first bug)",
+			f.Ports)
+	}
+}


### PR DESCRIPTION
## Summary

The config compiler's DIRECT host-bound (`to-zone junos-host`) DENY projection
resolved a policy `match application` token against the application-**SET** table
*before* the user **APPLICATION** table. `junosHostResolveApplications`
(`pkg/config/junos_host_deny.go`) called `ResolveApplicationSet` — which also
matches the #4102 predefined bundles — first, and only fell through to the
application resolver when the token was not a set.

A user application shadowed by a same-named set was therefore mis-resolved to the
**set**: the kernel `xpf_hostinbound` DENY projected the set's member ports
instead of the operator's application ports.

This is the **direct-host projection site specifically** — distinct from closed
**#5629** (policy-match app-vs-set ordering) and open **#5671**
(`memberIsNestedSet` nil guard). Provenance: codex-review-182 finding **M11**
(High).

## Fix

Resolve the user/predefined **application first**, and only OR-expand as an
application-set when the token is **not** an application:

```go
_, isApp := ResolveApplication(tok, cfg.Applications.Applications)
if _, isSet := ResolveApplicationSet(tok, cfg.Applications.ApplicationSets); !isApp && isSet {
    // ... expand set members ...
}
```

This mirrors the established app-first precedence of
`resolveUserspaceApplicationNames` and the **#5629 / #5664** policy-match, NAT,
and AppID-catalog fixes, so a user application shadowing a same-named
(predefined or user) set keeps its own ports on **every** path.

## Validation — fail-on-revert

New test `TestJunosHostDirectProjectionAppShadowsSet`
(`pkg/config/junos_host_deny_app_shadow_5677_test.go`) builds — via
`ParseSetCommand` + `CompileConfig` (never `NewParser`) — a user
`application junos-ms-rpc` (tcp/9999) that shadows the **predefined**
`junos-ms-rpc` bundle (`junos-ms-rpc-tcp` tcp/135 + `junos-ms-rpc-udp` udp/135).

A user application shadowing a **predefined** set name is *not* a #3339
application/application-set collision (only user-authored AST stanzas are
examined; the predefined table lives outside the AST), so the config commits
clean and both resolvers see the name.

- **With the fix (app-first):** the deny projects exactly **1** L4 fragment —
  `tcp/9999`. ✅ GREEN
- **Reverting to set-first (the bug):** the bundle re-expands to
  `tcp/135 + udp/135` (**2** fragments). ❌ RED

Confirmed locally: the test PASSES with the fix and FAILS when the ordering is
reverted (observed `got 2: [{Proto:6 Ports:[{135 135}]} {Proto:17 Ports:[{135 135}]}]`).
`go build ./...` and the full `pkg/config` suite pass.

Closes #5677

🤖 Generated with [Claude Code](https://claude.com/claude-code)