### PR TITLE
routing: bound + clamp tunnel keepalive interval (time.Duration overflow → xpfd panic)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-12 — #5705 (bug/security): bound + clamp tunnel keepalive interval (time.Duration overflow → xpfd panic)
+- **Timestamp**: 2026-07-12 (fix/5705-keepalive-bound)
+- **Action**: codex-review-182 M31. An unbounded tunnel `keepalive <seconds>`
+  overflowed `time.Duration(sec) * time.Second` (int64 ns) at the runtime
+  probe/ticker multiply; the product wrapped non-positive and `time.NewTicker`
+  panics on a non-positive interval → commit-reachable, self-inflicted xpfd
+  crash. Fixed in BOTH sites: (a) ADMISSION — typed the `keepalive` leaf in
+  `tunnelSchemaChildren()` with `valueType: ValueInteger` +
+  `ValidateInteger(0, 32767)` (0 = disabled; 32767 = de-facto GRE keepalive
+  ceiling, far under int64-ns overflow) so an out-of-range value is rejected at
+  commit-check for both interface-level and unit-level tunnel stanzas; (b)
+  RUNTIME CLAMP — `clampKeepaliveIntervalSec` (`[1, maxKeepaliveIntervalSec]`)
+  applied before the Duration multiply in `keepaliveLoop` (ticker) and
+  `keepaliveProbeDeadline`, defense-in-depth for an un-gated value. Fail-on-
+  revert proven: widening the schema bound → `32768` no longer rejected (config
+  test RED); neutering the clamp → ticker duration wraps to
+  `-8446744073709551616` (routing test RED).
+- **File(s)**: pkg/config/schema_interfaces.go,
+  pkg/config/tunnel_keepalive_bound_5705_test.go, pkg/routing/tunnel.go,
+  pkg/routing/tunnel_keepalive_bound_5705_test.go, pkg/routing/README.md
+
 ## 2026-07-11 — #5628 (security): NAT rule `then` must carry exactly one terminal translation action
 - **Timestamp**: 2026-07-11 (fix/5628-nat-terminal-action)
 - **Action**: codex-review-181 M16. A source/destination NAT rule's complete

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -365,8 +365,15 @@ func vrrpGroupSchemaNode(v6 bool) *schemaNode {
 //   - key: compiled via uint32(Atoi) (compiler_interfaces.go:168/:262),
 //     so negatives and values past 2^32-1 silently wrap; the GRE key
 //     wire field (IKey/OKey, tunnel.go:238-239) is exactly 32 bits.
-//   - keepalive / keepalive-retry: deliberately untyped (pass-through
-//     integers consumed by the keepalive prober only when > 0).
+//   - keepalive: typed 0..32767 seconds (0 = disabled). An unbounded
+//     value overflowed time.Duration(sec)*time.Second (int64 ns) at the
+//     runtime probe/ticker multiply and could wrap non-positive →
+//     time.NewTicker panic → xpfd crash (#5705). 32767 s matches the
+//     de-facto GRE keepalive ceiling and is far under the int64-ns
+//     overflow; the runtime also clamps (pkg/routing/tunnel.go
+//     clampKeepaliveIntervalSec) as defense-in-depth.
+//   - keepalive-retry: deliberately untyped (pass-through count consumed
+//     by the keepalive prober only when > 0; never a Duration multiply).
 func tunnelSchemaChildren() map[string]*schemaNode {
 	return map[string]*schemaNode{
 		"source": {
@@ -410,7 +417,16 @@ func tunnelSchemaChildren() map[string]*schemaNode {
 			validator:     ValidateInteger(0, 255),
 			children:      nil,
 		},
-		"keepalive":       {desc: "Keepalive interval", args: 1, placeholder: "<seconds>", children: nil},
+		"keepalive": {
+			desc:          "Keepalive interval",
+			args:          1,
+			placeholder:   "<seconds>",
+			valueType:     ValueInteger,
+			valueDesc:     "Keepalive interval in seconds (0..32767; 0 = disabled). Bounded to keep time.Duration(sec)*time.Second from overflowing int64 ns (#5705)",
+			valueExamples: []string{"0", "10", "30"},
+			validator:     ValidateInteger(0, 32767),
+			children:      nil,
+		},
 		"keepalive-retry": {desc: "Keepalive retry count", args: 1, placeholder: "<number>", children: nil},
 		"routing-instance": {desc: "Routing instance", children: map[string]*schemaNode{
 			"destination": {desc: "Destination routing instance", args: 1, placeholder: "<name>", children: nil},

--- a/pkg/config/tunnel_keepalive_bound_5705_test.go
+++ b/pkg/config/tunnel_keepalive_bound_5705_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTunnelKeepaliveInterval_SchemaGate_5705 proves the #5705 admission
+// fix: the tunnel `keepalive` VALUE is a typed integer bounded to
+// 0..32767 seconds, so a value that would overflow
+// time.Duration(sec)*time.Second (int64 ns) at the runtime probe/ticker
+// multiply is REJECTED at the commit-check gate (SchemaValidate) instead
+// of reaching the dataplane and panicking xpfd via time.NewTicker.
+//
+// FAIL-ON-REVERT: dropping `valueType: ValueInteger, validator:
+// ValidateInteger(0, 32767)` from the keepalive leaf makes the untyped
+// leaf accept any token again, so the reject assertions below fire RED.
+func TestTunnelKeepaliveInterval_SchemaGate_5705(t *testing.T) {
+	// The tunnel stanza appears at both interface level and unit level;
+	// both share tunnelSchemaChildren(), so validate each position.
+	prefixes := []string{
+		"set interfaces gr-0/0/0 tunnel keepalive",
+		"set interfaces gr-0/0/0 unit 0 tunnel keepalive",
+	}
+	// Values that MUST be rejected at commit: the huge int64-overflowing
+	// values are the actual #5705 crash trigger; negatives and non-ints
+	// are rejected as a side effect of typing the leaf.
+	bad := []string{
+		"banana",
+		"-1",
+		"-5",
+		"32768",                   // one past the ceiling
+		"10000000000",             // 1e10 s * 1e9 ns overflows int64 → wraps negative → NewTicker panic
+		"9223372036854775807",     // int64 max
+		"99999999999999999999999", // not representable
+	}
+	// Values that MUST be accepted (0 = disabled, plus the ceiling).
+	good := []string{"0", "1", "10", "30", "300", "32767"}
+
+	for _, pfx := range prefixes {
+		for _, v := range bad {
+			tree := flatTreeFromSets(t, pfx+" "+v)
+			if err := SchemaValidate(tree, nil); err == nil {
+				t.Fatalf("%s %q: expected SchemaValidate to reject, got nil", pfx, v)
+			}
+		}
+		for _, v := range good {
+			tree := flatTreeFromSets(t, pfx+" "+v)
+			if err := SchemaValidate(tree, nil); err != nil {
+				t.Fatalf("%s %q: expected SchemaValidate to accept, got %v", pfx, v, err)
+			}
+		}
+	}
+}
+
+// TestTunnelKeepaliveInterval_ErrorNamesValue_5705 confirms the reject
+// error names the offending token so the operator sees which value the
+// commit-check refused.
+func TestTunnelKeepaliveInterval_ErrorNamesValue_5705(t *testing.T) {
+	tree := flatTreeFromSets(t, "set interfaces gr-0/0/0 unit 0 tunnel keepalive 10000000000")
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("expected an int64-overflowing keepalive to be rejected at commit-check")
+	}
+	if !strings.Contains(err.Error(), "10000000000") {
+		t.Fatalf("error %q must name the offending value", err.Error())
+	}
+}
+
+// TestTunnelKeepaliveInterval_HierarchicalGate_5705 exercises the
+// hierarchical AST shape (as `load merge` / a saved config produces) in
+// addition to flat-set.
+func TestTunnelKeepaliveInterval_HierarchicalGate_5705(t *testing.T) {
+	reject := hierTree(t, `interfaces {
+    gr-0/0/0 {
+        unit 0 {
+            tunnel {
+                keepalive 10000000000;
+            }
+        }
+    }
+}`)
+	if err := SchemaValidate(reject, nil); err == nil {
+		t.Fatal("hierarchical overflowing keepalive must be rejected at commit-check")
+	}
+
+	accept := hierTree(t, `interfaces {
+    gr-0/0/0 {
+        unit 0 {
+            tunnel {
+                keepalive 30;
+            }
+        }
+    }
+}`)
+	if err := SchemaValidate(accept, nil); err != nil {
+		t.Fatalf("hierarchical valid keepalive must pass commit-check, got %v", err)
+	}
+}

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -569,6 +569,16 @@ peer behind a valid route read up forever and the fail-safe
   to admit the daemon gid (or `CAP_NET_RAW`); when it does not, the probe
   is **ProbeUnsupported** and the link is HELD (never torn down — see
   hold-on-unknown).
+- **Interval bound (#5705)**: the configured `keepalive <seconds>` is
+  bounded to `0..32767` at commit-check (`pkg/config`
+  `tunnelSchemaChildren`, `ValidateInteger(0, 32767)`; `0` = disabled)
+  AND clamped at runtime by `clampKeepaliveIntervalSec` before every
+  `time.Duration(sec) * time.Second` multiply (the `keepaliveLoop`
+  ticker and `keepaliveProbeDeadline`). `time.Duration` is int64 ns, so
+  an unbounded value overflowed the multiply, wrapped non-positive, and
+  panicked `time.NewTicker` — a commit-reachable, self-inflicted xpfd
+  crash. The runtime clamp is defense-in-depth for a value that reaches
+  the dataplane un-gated (stale DB, a path bypassing `SchemaValidate`).
 - **Reply match**: `Seq` + a per-probe random **Data-nonce** — NOT the
   ICMP ID. Datagram ("ping") sockets rewrite the outbound id to the
   socket source port, so id is advisory only.

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -1638,12 +1638,42 @@ func (t *tunnelManager) startKeepalive(tunnelName, source, remoteAddr string, in
 		"source", source, "remote", remoteAddr, "interval", interval, "retries", maxRetries)
 }
 
+// maxKeepaliveIntervalSec bounds the tunnel keepalive interval before it
+// is multiplied into a time.Duration. time.Duration is int64 nanoseconds,
+// so time.Duration(sec)*time.Second overflows once sec exceeds ~9.2e9;
+// an overflowed product wraps non-positive, and time.NewTicker panics on
+// a non-positive interval, crashing xpfd (#5705). The commit-check schema
+// rejects an out-of-range keepalive at admission (pkg/config
+// tunnelSchemaChildren, ValidateInteger(0, 32767)); this ceiling mirrors
+// that bound as a runtime clamp so an un-gated value (stale DB, a path
+// that bypasses SchemaValidate) still cannot overflow or panic. 32767 s
+// matches the de-facto GRE keepalive ceiling and 32767*1e9 ns is far
+// under the int64 limit.
+const maxKeepaliveIntervalSec = 32767
+
+// clampKeepaliveIntervalSec constrains a keepalive interval to a
+// positive, non-overflowing range [1, maxKeepaliveIntervalSec]. The
+// keepalive loop only starts for intervals > 0, so the min-1 floor is
+// purely defensive against a degenerate non-positive value reaching
+// time.NewTicker (which would panic).
+func clampKeepaliveIntervalSec(sec int) int {
+	if sec < 1 {
+		return 1
+	}
+	if sec > maxKeepaliveIntervalSec {
+		return maxKeepaliveIntervalSec
+	}
+	return sec
+}
+
 // keepaliveProbeDeadline returns the per-probe round-trip budget: a
 // fraction of the interval, capped at 800ms (R5). Keeps the probe well
-// inside the tick so a slow/lost reply cannot overrun the next tick.
+// inside the tick so a slow/lost reply cannot overrun the next tick. The
+// interval is clamped first so a huge value cannot overflow the
+// Duration multiply into a bogus (potentially in-range positive) budget.
 func keepaliveProbeDeadline(intervalSec int) time.Duration {
 	const maxDeadline = 800 * time.Millisecond
-	half := time.Duration(intervalSec) * time.Second / 2
+	half := time.Duration(clampKeepaliveIntervalSec(intervalSec)) * time.Second / 2
 	if half <= 0 || half > maxDeadline {
 		return maxDeadline
 	}
@@ -1669,7 +1699,9 @@ func keepaliveProbeDeadline(intervalSec int) time.Duration {
 //     the transition retries.
 func (t *tunnelManager) keepaliveLoop(ctx context.Context, done chan struct{}, tunnelName string, state *KeepaliveState, prober tunnelProber, gen *atomic.Uint64, startGen uint64) {
 	defer close(done)
-	ticker := time.NewTicker(time.Duration(state.Interval) * time.Second)
+	// Clamp before the Duration multiply: an un-gated / overflowing
+	// interval would wrap non-positive and panic time.NewTicker (#5705).
+	ticker := time.NewTicker(time.Duration(clampKeepaliveIntervalSec(state.Interval)) * time.Second)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/routing/tunnel_keepalive_bound_5705_test.go
+++ b/pkg/routing/tunnel_keepalive_bound_5705_test.go
@@ -1,0 +1,90 @@
+package routing
+
+import (
+	"testing"
+	"time"
+)
+
+// TestClampKeepaliveIntervalSec_5705 proves the runtime clamp keeps the
+// keepalive interval inside a positive, non-overflowing range so the
+// Duration multiply used by keepaliveLoop / keepaliveProbeDeadline can
+// never wrap non-positive.
+//
+// FAIL-ON-REVERT: removing the upper clamp lets a huge interval overflow
+// time.Duration(sec)*time.Second into a negative value, so the
+// "positive ticker duration" assertion below fires RED (and the live
+// path panics time.NewTicker).
+func TestClampKeepaliveIntervalSec_5705(t *testing.T) {
+	cases := []struct {
+		in, want int
+	}{
+		{-5, 1},  // negative → floor 1 (defensive; loop never starts at <=0)
+		{0, 1},   // zero → floor 1
+		{1, 1},   // in range, unchanged
+		{30, 30}, // in range, unchanged
+		{maxKeepaliveIntervalSec, maxKeepaliveIntervalSec},
+		{maxKeepaliveIntervalSec + 1, maxKeepaliveIntervalSec},
+		{10000000000, maxKeepaliveIntervalSec}, // 1e10 s would overflow the ns multiply
+		{1 << 62, maxKeepaliveIntervalSec},     // extreme value
+	}
+	for _, c := range cases {
+		if got := clampKeepaliveIntervalSec(c.in); got != c.want {
+			t.Fatalf("clampKeepaliveIntervalSec(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// TestKeepaliveTickerDurationPositive_5705 reproduces the exact multiply
+// keepaliveLoop performs to arm its ticker and asserts the result is a
+// strictly positive Duration for a value that WOULD overflow int64 ns
+// without the clamp. Without the clamp, time.Duration(1e10)*time.Second
+// wraps negative and time.NewTicker(d) panics ("non-positive interval").
+func TestKeepaliveTickerDurationPositive_5705(t *testing.T) {
+	// Runtime (not const) so the intentional overflow is a wrap, not a
+	// compile-time "constant overflows int64" error.
+	overflowingIntervalSec := 10000000000 // 1e10
+
+	// Demonstrate the bare (pre-fix) multiply actually wraps non-positive.
+	raw := time.Duration(overflowingIntervalSec) * time.Second
+	if raw > 0 {
+		t.Fatalf("test premise invalid: raw multiply %d did not overflow non-positive", raw)
+	}
+
+	// The clamped multiply keepaliveLoop now uses must be strictly
+	// positive so time.NewTicker does not panic.
+	d := time.Duration(clampKeepaliveIntervalSec(overflowingIntervalSec)) * time.Second
+	if d <= 0 {
+		t.Fatalf("clamped ticker duration = %d, want > 0", d)
+	}
+
+	// time.NewTicker panics on a non-positive interval; prove the clamped
+	// duration does not.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("time.NewTicker panicked on clamped duration: %v", r)
+			}
+		}()
+		tk := time.NewTicker(d)
+		tk.Stop()
+	}()
+}
+
+// TestKeepaliveProbeDeadlineClamped_5705 confirms keepaliveProbeDeadline
+// returns a sane bounded budget (never a bogus sub-deadline produced by
+// an overflowed interval) for both normal and overflowing intervals.
+func TestKeepaliveProbeDeadlineClamped_5705(t *testing.T) {
+	const maxDeadline = 800 * time.Millisecond
+
+	// Overflowing interval: budget must stay within the [1, maxDeadline]
+	// envelope, not a wrapped nonsense value.
+	got := keepaliveProbeDeadline(10000000000)
+	if got <= 0 || got > maxDeadline {
+		t.Fatalf("keepaliveProbeDeadline(overflow) = %v, want in (0, %v]", got, maxDeadline)
+	}
+
+	// A small interval still yields interval/2 (500ms for 1s).
+	if got := keepaliveProbeDeadline(1); got != 500*time.Millisecond {
+		t.Fatalf("keepaliveProbeDeadline(1) = %v, want 500ms", got)
+	}
+}


### PR DESCRIPTION
## Problem

An unbounded tunnel `keepalive <seconds>` overflowed `time.Duration(sec) * time.Second` at the runtime probe/ticker multiply. `time.Duration` is int64 nanoseconds, so a value past ~9.2e9 seconds wraps the product **non-positive**, and `time.NewTicker` **panics** on a non-positive interval — a commit-reachable, self-inflicted xpfd crash (codex-review-182 M31). There was neither a strict admission bound nor a runtime clamp.

## Fix (both sites, per the issue)

**(a) Admission bound** — `pkg/config/schema_interfaces.go` `tunnelSchemaChildren()`: typed the `keepalive` leaf `valueType: ValueInteger` + `ValidateInteger(0, 32767)` (0 = disabled). Covers both the interface-level and unit-level tunnel stanzas (shared schema), so an out-of-range value is **rejected at commit-check** instead of reaching the dataplane. 32767 s is the de-facto GRE keepalive ceiling and `32767*1e9` ns is far under the int64 limit.

**(b) Runtime clamp** — `pkg/routing/tunnel.go` `clampKeepaliveIntervalSec` (`[1, maxKeepaliveIntervalSec]`) applied before every `time.Duration(sec) * time.Second` multiply: the `keepaliveLoop` ticker and `keepaliveProbeDeadline`. Defense-in-depth for a value that reaches the runtime un-gated (stale DB, a path bypassing `SchemaValidate`) — it can no longer overflow or panic.

## Fix sites (on this branch)

- `pkg/config/schema_interfaces.go:413` — `keepalive` typed leaf, `ValidateInteger(0, 32767)`
- `pkg/routing/tunnel.go:1666` — `clampKeepaliveIntervalSec` helper + `maxKeepaliveIntervalSec` const; applied in `keepaliveProbeDeadline` and `keepaliveLoop`'s `time.NewTicker`

## Tests (fail-on-revert)

- `TestTunnelKeepaliveInterval_SchemaGate_5705` / `_ErrorNamesValue_5705` / `_HierarchicalGate_5705` (`pkg/config/tunnel_keepalive_bound_5705_test.go`) — out-of-range/overflowing keepalive REJECTED at admission (flat-set via `ParseSetCommand`+`SetPath`, plus hierarchical).
- `TestClampKeepaliveIntervalSec_5705` / `TestKeepaliveTickerDurationPositive_5705` / `TestKeepaliveProbeDeadlineClamped_5705` (`pkg/routing/tunnel_keepalive_bound_5705_test.go`) — huge value clamped, not overflowed; clamped ticker duration is strictly positive and `time.NewTicker` does not panic.

**Fail-on-revert proven:**
- Widen the schema bound → `keepalive 32768` no longer rejected → config test **RED**.
- Neuter the clamp → ticker duration wraps to `-8446744073709551616` (negative) → routing test **RED**.

With the fix, `go build ./...` and `go test ./pkg/config/... ./pkg/routing/...` are green.

## Docs

`pkg/routing/README.md` keepalive section + `_Log.md` dated entry.

Closes #5705

🤖 Generated with [Claude Code](https://claude.com/claude-code)