### PR TITLE
daemon: resolve web-mgmt bind ifname to Linux name (#5714)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-12 — #5714 (bug/security): web-mgmt bind resolves Junos ifname to Linux kernel name before InterfaceByName
+- **Timestamp**: 2026-07-12 (fix/5714-webmgmt-ifname)
+- **Action**: codex-review-182 M42. The web-management HTTP/HTTPS bind passed
+  the AUTHORED Junos interface name (e.g. `ge-0/0/0.0`) verbatim to
+  `net.InterfaceByName`, which expects the LINUX kernel ifname (`ge-0-0-0`).
+  The lookup always missed on a renamed interface, so `resolveInterfaceAddr`
+  SILENTLY fell back to loopback (127.0.0.1) with only a `slog.Warn` — web-
+  management was not reachable on the configured interface while the operator
+  believed it was bound there. Fixed in `pkg/daemon/daemon_cluster_bind.go`:
+  `resolveInterfaceAddr` now takes the active `*config.Config` and maps the
+  authored ref to its Linux ifname via `config.ResolveKernelIfName` (the same
+  Junos->Linux mapping networkd/linksetup use) BEFORE the kernel lookup, and
+  on any resolution/lookup failure logs LOUDLY at `slog.Error` (naming the
+  interface + resolved kernel name) instead of a silent Warn. The loopback
+  fallback is retained (a mgmt interface merely not up yet at daemon start must
+  not abort the daemon) but is now loud. The kernel-address lookup is behind a
+  package-var seam (`interfaceAddrsByName`) so the bind resolution is unit-
+  testable. Callers in `resolveAPIBinds` (daemon_run.go) updated to pass cfg.
+  Fail-on-revert proven: authored `ge-0/0/0.0` resolves to the Linux
+  interface's address (10.0.0.5), NOT loopback — dropping the ResolveKernelIfName
+  mapping flips the address test RED; reverting the Error log to Warn flips the
+  loud-failure test RED.
+- **File(s)**: pkg/daemon/daemon_cluster_bind.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/webmgmt_bind_ifname_5714_test.go
+
 ## 2026-07-12 — #5705 (bug/security): bound + clamp tunnel keepalive interval (time.Duration overflow → xpfd panic)
 - **Timestamp**: 2026-07-12 (fix/5705-keepalive-bound)
 - **Action**: codex-review-182 M31. An unbounded tunnel `keepalive <seconds>`

--- a/pkg/daemon/daemon_cluster_bind.go
+++ b/pkg/daemon/daemon_cluster_bind.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/psaab/xpf/pkg/config"
 	"golang.org/x/sys/unix"
 )
 
@@ -14,17 +15,46 @@ func isInteractive() bool {
 	return err == nil
 }
 
-// resolveInterfaceAddr returns the first IPv4 address on the named interface.
-// If the interface is not found or has no IPv4 addresses, it returns fallback.
-func resolveInterfaceAddr(ifname, fallback string) string {
-	iface, err := net.InterfaceByName(ifname)
+// interfaceAddrsByName resolves a LINUX-kernel interface name to its addresses.
+// It is a package var so the web-management bind resolution
+// (resolveInterfaceAddr) is unit-testable without a real kernel interface.
+var interfaceAddrsByName = func(kernelName string) ([]net.Addr, error) {
+	iface, err := net.InterfaceByName(kernelName)
 	if err != nil {
-		slog.Warn("web-management interface not found, using fallback", "interface", ifname, "fallback", fallback)
+		return nil, err
+	}
+	return iface.Addrs()
+}
+
+// resolveInterfaceAddr returns the first IPv4 (then IPv6) address on the
+// interface identified by the AUTHORED Junos ref (e.g. "ge-0/0/0.0"). If the
+// interface cannot be resolved or has no usable address it returns fallback.
+//
+// #5714: the ref is first mapped to its Linux kernel ifname via
+// config.ResolveKernelIfName (the same Junos->Linux mapping networkd/linksetup
+// use) BEFORE the kernel lookup — net.InterfaceByName expects the kernel name
+// (e.g. "ge-0-0-0"), not the Junos name (e.g. "ge-0/0/0"), so passing the
+// authored name verbatim never matched and the bind SILENTLY fell back to
+// loopback, leaving web-management unreachable on the configured interface while
+// the operator believed it was bound there. On any resolution/lookup failure
+// this now logs LOUDLY at ERROR (the bind did NOT land on the configured
+// interface) and returns fallback, so the mgmt API still serves on loopback
+// rather than not at all — a hard error here would strand a mgmt interface that
+// is merely not up yet at daemon start.
+func resolveInterfaceAddr(cfg *config.Config, ifname, fallback string) string {
+	kernelName := ifname
+	if cfg != nil {
+		kernelName = cfg.ResolveKernelIfName(ifname)
+	}
+	addrs, err := interfaceAddrsByName(kernelName)
+	if err != nil {
+		slog.Error("web-management interface not found; NOT bound to configured interface, using loopback fallback",
+			"interface", ifname, "kernel", kernelName, "fallback", fallback, "err", err)
 		return fallback
 	}
-	addrs, err := iface.Addrs()
-	if err != nil || len(addrs) == 0 {
-		slog.Warn("web-management interface has no addresses, using fallback", "interface", ifname, "fallback", fallback)
+	if len(addrs) == 0 {
+		slog.Error("web-management interface has no addresses; NOT bound to configured interface, using loopback fallback",
+			"interface", ifname, "kernel", kernelName, "fallback", fallback)
 		return fallback
 	}
 	for _, a := range addrs {
@@ -46,7 +76,8 @@ func resolveInterfaceAddr(ifname, fallback string) string {
 			return ipNet.IP.String()
 		}
 	}
-	slog.Warn("web-management interface has no usable addresses, using fallback", "interface", ifname, "fallback", fallback)
+	slog.Error("web-management interface has no usable addresses; NOT bound to configured interface, using loopback fallback",
+		"interface", ifname, "kernel", kernelName, "fallback", fallback)
 	return fallback
 }
 

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1377,7 +1377,7 @@ func (d *Daemon) resolveAPIBinds(apiCfg *api.Config, cfg *config.Config) {
 		wm := cfg.System.Services.WebManagement
 		// Bind HTTP to configured interface
 		if wm.HTTPInterface != "" {
-			bindIP := resolveInterfaceAddr(wm.HTTPInterface, "127.0.0.1")
+			bindIP := resolveInterfaceAddr(cfg, wm.HTTPInterface, "127.0.0.1")
 			// net.JoinHostPort (not string-concat) so an IPv6 interface
 			// address is bracketed ("[2001:db8::1]:8080") — a bare
 			// "2001:db8::1:8080" is unparseable by net.SplitHostPort (the
@@ -1389,7 +1389,7 @@ func (d *Daemon) resolveAPIBinds(apiCfg *api.Config, cfg *config.Config) {
 		if wm.HTTPS {
 			httpsBindIP := "127.0.0.1"
 			if wm.HTTPSInterface != "" {
-				httpsBindIP = resolveInterfaceAddr(wm.HTTPSInterface, "127.0.0.1")
+				httpsBindIP = resolveInterfaceAddr(cfg, wm.HTTPSInterface, "127.0.0.1")
 				slog.Info("HTTPS API bound to interface", "interface", wm.HTTPSInterface, "addr", net.JoinHostPort(httpsBindIP, "8443"))
 			}
 			apiCfg.TLS = true

--- a/pkg/daemon/webmgmt_bind_ifname_5714_test.go
+++ b/pkg/daemon/webmgmt_bind_ifname_5714_test.go
@@ -1,0 +1,112 @@
+package daemon
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// webmgmtIfnameCfg builds a config whose web-management HTTP listener binds to
+// the authored Junos interface httpIface, WITH api-auth so an off-loopback
+// resolved bind survives the #4047/#5127 loopback fail-safe clamp (an
+// unauthenticated off-loopback bind is otherwise pulled back to loopback,
+// masking the resolution result). The dataplane interface ge-0/0/0 is modeled
+// so config.ResolveKernelIfName maps the Junos ref to its Linux ifname.
+func webmgmtIfnameCfg(httpIface string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0},
+		}},
+	}
+	cfg.System.Services = &config.SystemServicesConfig{
+		WebManagement: &config.WebManagementConfig{
+			HTTP:          true,
+			HTTPInterface: httpIface,
+			APIAuth: &config.APIAuthConfig{
+				Users: []*config.APIAuthUser{{Username: "admin", Password: config.Secret("secret")}},
+			},
+		},
+	}
+	return cfg
+}
+
+// TestWebMgmtBindResolvesJunosIfnameToLinux_5714 is the #5714 fail-on-revert
+// guard: a web-management bind to an AUTHORED Junos interface name (ge-0/0/0.0)
+// must resolve to the mapped LINUX kernel ifname (ge-0-0-0) and listen on THAT
+// interface's address — not fall back to loopback because the Junos name was
+// handed verbatim to net.InterfaceByName (which only knows kernel names).
+//
+// FAIL-ON-REVERT: dropping the config.ResolveKernelIfName mapping in
+// resolveInterfaceAddr passes "ge-0/0/0.0" straight to the kernel lookup, which
+// (via the mocked seam, and in reality) does not match "ge-0-0-0", so the bind
+// silently falls back to 127.0.0.1 and the address assertion below fires RED.
+func TestWebMgmtBindResolvesJunosIfnameToLinux_5714(t *testing.T) {
+	// Kernel-address seam: ONLY the resolved Linux name "ge-0-0-0" has an
+	// address; the authored Junos name (or any other) errors — exactly the
+	// asymmetry net.InterfaceByName exhibits on a renamed interface.
+	prev := interfaceAddrsByName
+	defer func() { interfaceAddrsByName = prev }()
+	interfaceAddrsByName = func(kernelName string) ([]net.Addr, error) {
+		if kernelName == "ge-0-0-0" {
+			return []net.Addr{&net.IPNet{IP: net.IPv4(10, 0, 0, 5), Mask: net.CIDRMask(24, 32)}}, nil
+		}
+		return nil, fmt.Errorf("no such kernel interface: %s", kernelName)
+	}
+
+	d := &Daemon{}
+	apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+	d.resolveAPIBinds(&apiCfg, webmgmtIfnameCfg("ge-0/0/0.0"))
+
+	if apiCfg.Addr != "10.0.0.5:8080" {
+		t.Fatalf("web-mgmt bind Addr = %q, want 10.0.0.5:8080 (Junos ge-0/0/0.0 -> Linux ge-0-0-0). "+
+			"127.0.0.1 means the authored Junos name reached the kernel lookup verbatim (the #5714 bug)", apiCfg.Addr)
+	}
+}
+
+// TestWebMgmtBindUnresolvableLogsLoudError_5714 pins the "fail loudly" half of
+// #5714: when the configured web-management interface cannot be resolved to a
+// usable address, the bind must emit a LOUD ERROR naming the interface (so the
+// operator learns web-management is NOT reachable where configured) rather than
+// silently falling back to loopback. The loopback fallback itself is retained so
+// the mgmt API is not stranded (a mgmt interface merely not up yet at daemon
+// start must not abort the daemon).
+//
+// FAIL-ON-REVERT: the pre-#5714 code logged this at slog.Warn (silent-ish); the
+// ERROR-level assertion below fires RED if the level is reverted to Warn.
+func TestWebMgmtBindUnresolvableLogsLoudError_5714(t *testing.T) {
+	prev := interfaceAddrsByName
+	defer func() { interfaceAddrsByName = prev }()
+	interfaceAddrsByName = func(kernelName string) ([]net.Addr, error) {
+		return nil, fmt.Errorf("no such kernel interface: %s", kernelName)
+	}
+
+	var recs []captureRecord
+	prevLog := slog.Default()
+	slog.SetDefault(slog.New(capturingHandler{recs: &recs}))
+	defer slog.SetDefault(prevLog)
+
+	d := &Daemon{}
+	apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+	d.resolveAPIBinds(&apiCfg, webmgmtIfnameCfg("ge-0/0/9.0"))
+
+	var loud bool
+	for _, r := range recs {
+		if r.level == slog.LevelError && r.attrs["interface"] == "ge-0/0/9.0" {
+			loud = true
+			break
+		}
+	}
+	if !loud {
+		t.Fatalf("unresolvable web-mgmt interface must log a LOUD ERROR naming the interface, "+
+			"not a silent fallback; got records: %+v", recs)
+	}
+	// Fallback is retained (loopback), so the mgmt API still serves locally.
+	if apiCfg.Addr != "127.0.0.1:8080" {
+		t.Fatalf("unresolvable interface bind Addr = %q, want loopback fallback 127.0.0.1:8080", apiCfg.Addr)
+	}
+}


### PR DESCRIPTION
## Summary

The web-management HTTP/HTTPS bind passed the **authored Junos** interface name
(e.g. `ge-0/0/0.0`) verbatim to `net.InterfaceByName`, which expects the **Linux
kernel** ifname (e.g. `ge-0-0-0`). Since every dataplane interface is renamed at
daemon start, the lookup always missed, so `resolveInterfaceAddr` **silently fell
back to loopback** (`127.0.0.1`) with only a `slog.Warn`. Web-management was then
not reachable on the configured interface while the operator believed it was
bound there — an availability + operator-confusion defect on a security-relevant
surface. Provenance: codex-review-182 finding **M42** (Medium).

## Fix

`pkg/daemon/daemon_cluster_bind.go` — `resolveInterfaceAddr` now:
1. Takes the active `*config.Config` and maps the authored ref to its Linux
   ifname via `config.ResolveKernelIfName` (the **same** Junos→Linux mapping
   networkd/linksetup use) **before** the kernel lookup.
2. On any resolution/lookup failure, logs **loudly at `slog.Error`** (naming the
   authored interface + resolved kernel name) instead of a silent `Warn`.

The loopback fallback is **retained** (not turned into a hard error): a mgmt
interface that is merely not up yet at daemon start must not abort the daemon,
and loopback preserves local mgmt access rather than stranding the API entirely.
The two callers in `resolveAPIBinds` (`daemon_run.go`) pass `cfg`. The
kernel-address lookup is factored behind a package-var seam
(`interfaceAddrsByName`) so the bind resolution is unit-testable.

## Validation — fail-on-revert (`pkg/daemon/webmgmt_bind_ifname_5714_test.go`)

- **`TestWebMgmtBindResolvesJunosIfnameToLinux_5714`** — binds web-management to
  the authored `ge-0/0/0.0` (with api-auth so the off-loopback bind survives the
  #4047/#5127 loopback clamp) and asserts the listen address is the mapped Linux
  interface's address (`10.0.0.5:8080`), **not** loopback. Dropping the
  `ResolveKernelIfName` mapping → the Junos name reaches the kernel lookup
  verbatim → falls back to `127.0.0.1:8080` → **RED** (verified).
- **`TestWebMgmtBindUnresolvableLogsLoudError_5714`** — an unresolvable interface
  emits an `slog.Error` naming the interface (and still falls back to loopback).
  Reverting the level to `Warn` → **RED** (verified).

Both confirmed RED on revert and GREEN with the fix. Full `pkg/daemon` suite and
`go build ./...` pass; the existing #5127 loopback-clamp tests are unaffected. No
operator/module doc documents the web-mgmt bind resolution (the
`pkg/api/README.md` `InterfaceByName` mention is a different, counter-read path),
so the behavior is documented inline in the `#5714` code comment.

Closes #5714

🤖 Generated with [Claude Code](https://claude.com/claude-code)