### PR TITLE
config: reject next-table naming an undefined routing-instance (M14)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-12 — #5693 (bug): validate next-table target routing-instance definedness at commit
+- **Timestamp**: 2026-07-12 (fix/5693-nexttable-target-defined)
+- **Action**: codex-review-182 M14. A static route whose `next-table <target>`
+  named an UNDEFINED routing-instance was accepted at commit and then silently
+  dropped at apply time: the applier (pkg/routing.nextTableManager.Apply)
+  resolves the target via a name→table-id map built only from defined
+  instances, missed the lookup, warned, and SKIPPED the rule — the intended
+  inter-VRF leak never happened and matching traffic followed the ingress
+  table's own routes. The raw next-table grammar was also lost before
+  validation (parseNextTableInstance strips the .inet[6].N suffix at compile).
+  Fix: (a) preserve the operator's raw token in a new
+  StaticRoute.NextTableRaw field (populated at both compile sites +
+  same-destination merge); (b) add validateNextTableTargetReferencesStrict
+  (compiler_validate_strict_routing.go) — for each GLOBAL inet.0/inet6.0 static
+  route with a next-table, require the parsed instance to be a defined
+  routing-instance, rejecting with an error that quotes the raw token. Wired in
+  runUniformGates after the rib-group gate; strict on commit/commit-check,
+  downgraded to a warning on tolerant load/peer-sync (opts.lenientNextTableRefs,
+  #1960). Mirrors validateRibGroupImportRibReferencesStrict and keeps the commit
+  gate + runtime applier in lockstep on resolvability (#2226). Fail-on-revert
+  proven: neutering the gate → all reject tests RED. Fixed two pre-existing
+  tests that used undefined targets (TestNextTableStaticRoutes /
+  TestIPv6NextTableStaticRoutes now define the instance) + regenerated
+  golden_4406 baseline (benign: only the new empty NextTableRaw field).
+- **File(s)**: pkg/config/types_routing.go, pkg/config/compiler_routing.go,
+  pkg/config/compiler_validate_strict_routing.go,
+  pkg/config/compiler_uniformgates.go, pkg/config/compiler.go,
+  pkg/config/compiler_routing_nexttable_target_5693_test.go,
+  pkg/config/parser_routing_test.go, pkg/config/testdata/golden_4406.json,
+  docs/rib-group-route-leaking.md
+
 ## 2026-07-12 — #5705 (bug/security): bound + clamp tunnel keepalive interval (time.Duration overflow → xpfd panic)
 - **Timestamp**: 2026-07-12 (fix/5705-keepalive-bound)
 - **Action**: codex-review-182 M31. An unbounded tunnel `keepalive <seconds>`

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -120,6 +120,28 @@ The window warn (`validateRoutingRuleWindowWarnings`) additionally flags a
 config that would leak more than `maxRibGroupLeakRules` (1000) connected
 prefixes.
 
+### Strict rejection — undefined `next-table` target (#5693)
+
+A static route whose `next-table <target>` names a routing-instance that is
+**not defined** in the config is now **hard-rejected at commit**
+(`validateNextTableTargetReferencesStrict`, `compiler_validate_strict_routing.go`).
+Previously the target was unvalidated: the applier
+(`pkg/routing.nextTableManager.Apply`) resolves it through a name→table-id map
+built only from defined instances, so an undefined target missed the lookup,
+logged `next-table references unknown routing instance`, and **silently skipped
+the rule** — the intended inter-VRF leak never happened and matching traffic
+followed the ingress table's own routes (often the WAN default). The gate
+resolves the target with the same `parseNextTableInstance` the applier uses
+(strip the trailing `.inet[6].N` suffix → instance name) so the commit gate and
+the runtime applier stay in lockstep on what resolves (the #2226 rib-group
+doctrine). The error quotes the operator's **raw** `next-table` token
+(`StaticRoute.NextTableRaw`, preserved before the suffix strip) so a
+`Comcst.inet.0` typo is named verbatim. Only the global `inet.0` + `inet6.0`
+static routes are validated — those are exactly the routes `daemon_apply` feeds
+to `ApplyNextTableRules`. Strict on commit / commit-check; downgraded to a
+warning on the tolerant load / peer-sync paths (`opts.lenientNextTableRefs`,
+#1960 no-brick) since the applier keeps a dangling next-table inert.
+
 ## Deferred (Phase 2 and beyond)
 
 - **VRF→VRF import targets** — need `iif`-scoped rules or true route-copy;

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -928,6 +928,19 @@ type compileOpts struct {
 	// guard skips the phantom rib and installs no rule, so a leniently-loaded
 	// config is already inert. Same doctrine as lenientRoutingExportRef.
 	lenientRibGroupRefs bool
+	// lenientNextTableRefs (#5693) downgrades the next-table target
+	// definedness gate (validateNextTableTargetReferencesStrict) from a hard
+	// compile error to a cfg.Warnings entry. A static route whose
+	// `next-table <target>` names an undefined routing-instance was previously
+	// unvalidated: the applier resolved the target through a name→table-id map
+	// built only from defined instances, missed, warned, and skipped the rule,
+	// so the inter-VRF leak silently never happened. The strict commit /
+	// commit-check path hard-rejects so the typo is operator-visible; the
+	// tolerant load / peer-sync paths warn so an already-persisted or peer-
+	// synced config carrying a dangling next-table still BOOTS (#1960) — the
+	// applier's tableIDs !ok guard keeps it inert. Same doctrine as
+	// lenientRibGroupRefs.
+	lenientNextTableRefs bool
 	// lenientDHCPStaticBindings (#2243 review) downgrades the DHCP-server
 	// static (fixed/reserved) host-binding gate (validateDHCPStaticBindingsStrict)
 	// from a hard compile error to a cfg.Warnings entry. The strict commit /
@@ -1854,6 +1867,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientNATMatchApplications:            true,
 		lenientPolicyMatchAddressSetMembers:    true,
 		lenientRibGroupRefs:                    true,
+		lenientNextTableRefs:                   true,
 		lenientDHCPStaticBindings:              true,
 		lenientWireguardPeers:                  true,
 		lenientPolicyZoneRefs:                  true,
@@ -2201,6 +2215,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientNATMatchApplications:            true,
 		lenientPolicyMatchAddressSetMembers:    true,
 		lenientRibGroupRefs:                    true,
+		lenientNextTableRefs:                   true,
 		lenientDHCPStaticBindings:              true,
 		lenientWireguardPeers:                  true,
 		lenientPolicyZoneRefs:                  true,

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -200,6 +200,7 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 				case "next-table":
 					if i+1 < len(routeInst.node.Keys) {
 						i++
+						route.NextTableRaw = routeInst.node.Keys[i]
 						route.NextTable = parseNextTableInstance(routeInst.node.Keys[i])
 					}
 				case "qualified-next-hop":
@@ -350,6 +351,7 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 				route.NextHops = append(route.NextHops, nh)
 			case "next-table":
 				if v := nodeVal(prop); v != "" {
+					route.NextTableRaw = v
 					route.NextTable = parseNextTableInstance(v)
 				}
 			}
@@ -370,6 +372,7 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 			}
 			if route.NextTable != "" {
 				existingRoute.NextTable = route.NextTable
+				existingRoute.NextTableRaw = route.NextTableRaw
 			}
 		} else {
 			destIdx[route.Destination] = len(existing)

--- a/pkg/config/compiler_routing_nexttable_target_5693_test.go
+++ b/pkg/config/compiler_routing_nexttable_target_5693_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNextTableUndefinedTargetRejected_5693 proves the #5693 fix: a static
+// route whose `next-table <target>` names an UNDEFINED routing-instance is
+// REJECTED at the strict commit path (CompileConfig) instead of being silently
+// accepted and then dropped at apply time (the applier's tableIDs lookup
+// misses, warns, and skips — the intended inter-VRF leak never happens).
+//
+// FAIL-ON-REVERT: removing the validateNextTableTargetReferencesStrict call
+// from runUniformGates (or reverting the gate to a no-op) makes CompileConfig
+// accept the undefined-target config, so the reject assertions below fire RED.
+func TestNextTableUndefinedTargetRejected_5693(t *testing.T) {
+	// inet.0 (global) undefined target.
+	t.Run("inet-flatset-undefined", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 0.0.0.0/0 next-table Comcst-GigabitPro.inet.0",
+		)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("expected CompileConfig to reject a next-table naming an undefined routing-instance")
+		}
+		// The error must name the RAW token the operator typed (#5693
+		// grammar preservation), not just the stripped instance.
+		if !strings.Contains(err.Error(), "Comcst-GigabitPro.inet.0") {
+			t.Fatalf("error %q must quote the raw next-table token", err.Error())
+		}
+	})
+
+	// inet6.0 rib undefined target — the gate covers both global route sets.
+	t.Run("inet6-flatset-undefined", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options rib inet6.0 static route ::/0 next-table ATT.inet6.0",
+		)
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("expected CompileConfig to reject an undefined inet6 next-table target")
+		}
+	})
+
+	// Hierarchical AST shape (load merge / saved config).
+	t.Run("hierarchical-undefined", func(t *testing.T) {
+		tree := hierTree(t, `routing-options {
+    static {
+        route 10.0.0.0/8 {
+            next-table nope.inet.0;
+        }
+    }
+}`)
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatal("expected CompileConfig to reject an undefined hierarchical next-table target")
+		}
+	})
+}
+
+// TestNextTableDefinedTargetAccepted_5693 proves the happy path is undisturbed:
+// a next-table pointing at a DEFINED routing-instance compiles, and both the
+// parsed instance (NextTable) and the preserved raw token (NextTableRaw) are
+// populated.
+func TestNextTableDefinedTargetAccepted_5693(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set routing-instances Comcast-GigabitPro instance-type virtual-router",
+		"set routing-options static route 0.0.0.0/0 next-table Comcast-GigabitPro.inet.0",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("defined next-table target must compile, got %v", err)
+	}
+	if len(cfg.RoutingOptions.StaticRoutes) != 1 {
+		t.Fatalf("StaticRoutes = %d, want 1", len(cfg.RoutingOptions.StaticRoutes))
+	}
+	sr := cfg.RoutingOptions.StaticRoutes[0]
+	if sr.NextTable != "Comcast-GigabitPro" {
+		t.Errorf("NextTable = %q, want Comcast-GigabitPro", sr.NextTable)
+	}
+	// #5693 grammar preservation: the raw token survives to validation.
+	if sr.NextTableRaw != "Comcast-GigabitPro.inet.0" {
+		t.Errorf("NextTableRaw = %q, want Comcast-GigabitPro.inet.0", sr.NextTableRaw)
+	}
+}
+
+// TestNextTableTargetGate_LenientDowngrade_5693 proves the strict/tolerant
+// split: the definedness gate hard-rejects on the strict commit path but is
+// downgraded to a warning on the tolerant load path (CompileConfigLenient), so
+// an already-persisted config carrying a dangling next-table still LOADS (#1960
+// no-brick) — the applier keeps it inert.
+func TestNextTableTargetGate_LenientDowngrade_5693(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set routing-options static route 0.0.0.0/0 next-table ghost.inet.0",
+	)
+	// Strict path rejects.
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("strict CompileConfig must reject the dangling next-table")
+	}
+	// Tolerant path loads with a warning instead of failing.
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant load must NOT hard-fail on a dangling next-table, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "next-table") && strings.Contains(w, "ghost") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("tolerant load must record a next-table downgrade warning, got %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1795,6 +1795,24 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5693: next-table target definedness gate. A static route whose
+	// `next-table <target>` names an UNDEFINED routing-instance was accepted
+	// at commit and then silently dropped at apply time (the applier's
+	// tableIDs lookup misses, warns, and skips) — the intended inter-VRF leak
+	// never happened and traffic followed the ingress table's own routes.
+	// Strict on commit / commit-check (hard reject so the typo is operator-
+	// visible); lenient on load / peer-sync (warn — #1960; the applier's !ok
+	// guard keeps a dangling next-table inert). Mirrors
+	// validateRibGroupImportRibReferencesStrict.
+	if err := validateNextTableTargetReferencesStrict(cfg); err != nil {
+		if opts.lenientNextTableRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("next-table target reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2492: RPM test source-address gate. A malformed `source-address`
 	// (non-empty but unparseable) silently degrades the tcp-ping/http-get
 	// probe dialer to a wildcard/kernel-chosen source bind, so the probe

--- a/pkg/config/compiler_validate_strict_routing.go
+++ b/pkg/config/compiler_validate_strict_routing.go
@@ -720,6 +720,78 @@ func ribInstanceFromName(ribName string) (string, bool) {
 	return "", false
 }
 
+// validateNextTableTargetReferencesStrict hard-rejects a static route whose
+// `next-table <target>` names a routing-instance that is NOT defined in the
+// config (a typo, a deleted instance, or an unparseable target). next-table
+// implements inter-VRF route leaking: the applier (pkg/routing.nextTableManager
+// Apply) resolves the target to a kernel table id via a map keyed by
+// routing-instance NAME. An unresolvable target had `tableIDs[...] == !ok`,
+// so the applier logged a `slog.Warn("next-table references unknown routing
+// instance")` and SKIPPED the rule — the leak silently never happened, with no
+// commit-time diagnostic. Traffic that the operator intended to leak into
+// another VRF instead followed the ingress table's own default (often the WAN
+// default route), a silent mis-forward.
+//
+// The gate resolves the target with the SAME parseNextTableInstance the
+// compiler and applier use (strip the trailing .inet[6].N suffix → instance
+// name), then requires that name to be a defined routing-instance. This keeps
+// the commit-time gate and the runtime applier in lockstep on what resolves
+// (the #2226 rib-group doctrine). The error names the RAW next-table token the
+// operator typed (route.NextTableRaw, preserved before the suffix strip, #5693)
+// so a "Comcst.inet.0" typo is quoted verbatim rather than as the stripped
+// "Comcst".
+//
+// Only the GLOBAL inet.0 + inet6.0 static routes are validated — those are
+// exactly the routes daemon_apply feeds to ApplyNextTableRules
+// (daemon_apply.go); next-table on a per-instance static route is never
+// programmed, so validating it would reject a target the applier never
+// resolves. Routes are walked inet.0 then inet6.0 in declaration order so the
+// first-reported error is deterministic.
+//
+// Strict on commit / commit-check (hard reject so the typo is operator-
+// visible); the call site downgrades this to a warning on the tolerant load /
+// peer-sync paths (opts.lenientNextTableRefs) so an already-persisted or peer-
+// synced config carrying a dangling next-table still BOOTS (#1960
+// fail-closed-on-load class) — the applier's tableIDs !ok guard keeps it inert.
+// Mirrors validateRibGroupImportRibReferencesStrict.
+func validateNextTableTargetReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	definedInstance := make(map[string]bool, len(cfg.RoutingInstances))
+	for _, ri := range cfg.RoutingInstances {
+		if ri != nil && ri.Name != "" {
+			definedInstance[ri.Name] = true
+		}
+	}
+	routeSets := [][]*StaticRoute{
+		cfg.RoutingOptions.StaticRoutes,
+		cfg.RoutingOptions.Inet6StaticRoutes,
+	}
+	for _, routes := range routeSets {
+		for _, sr := range routes {
+			if sr == nil || sr.NextTable == "" {
+				continue
+			}
+			if definedInstance[sr.NextTable] {
+				continue
+			}
+			raw := sr.NextTableRaw
+			if raw == "" {
+				raw = sr.NextTable
+			}
+			return fmt.Errorf(
+				"routing-options static route %q next-table %q references an "+
+					"undefined routing-instance %q; define `set routing-instances "+
+					"%s instance-type ...` in the same commit or the next-table "+
+					"leak is silently dropped at apply time and matching traffic "+
+					"follows the ingress table's own routes",
+				sr.Destination, raw, sr.NextTable, sr.NextTable)
+		}
+	}
+	return nil
+}
+
 // validateRouteFilterMatchTypesStrict gates the two route-filter match-types
 // that the FRR prefix-list backend cannot render losslessly (#2525):
 //

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -219,7 +219,13 @@ func TestECMPStaticRoutes(t *testing.T) {
 
 func TestNextTableStaticRoutes(t *testing.T) {
 	tree := &ConfigTree{}
-	setCommands := []string{"set routing-options static route 0.0.0.0/0 next-table Comcast-GigabitPro.inet.0", "set routing-options static route 10.1.10.0/24 next-hop 50.247.115.22"}
+	setCommands := []string{
+		// The next-table target routing-instance must be defined or the
+		// #5693 definedness gate rejects the commit.
+		"set routing-instances Comcast-GigabitPro instance-type virtual-router",
+		"set routing-options static route 0.0.0.0/0 next-table Comcast-GigabitPro.inet.0",
+		"set routing-options static route 10.1.10.0/24 next-hop 50.247.115.22",
+	}
 	for _, cmd := range setCommands {
 		fields := strings.Fields(cmd)
 		if err := tree.SetPath(fields[1:]); err != nil {
@@ -250,7 +256,14 @@ func TestNextTableStaticRoutes(t *testing.T) {
 	if len(r1.NextHops) != 1 || r1.NextHops[0].Address != "50.247.115.22" {
 		t.Errorf("route 1 next-hops: %v", r1.NextHops)
 	}
-	hierInput := `routing-options {
+	// The next-table target routing-instance must be defined or the #5693
+	// definedness gate rejects the commit.
+	hierInput := `routing-instances {
+    Comcast-GigabitPro {
+        instance-type virtual-router;
+    }
+}
+routing-options {
     static {
         route 0.0.0.0/0 {
             next-table Comcast-GigabitPro.inet.0;
@@ -2834,7 +2847,15 @@ func TestGlobalInterfaceRoutesRibGroupSetSyntax(t *testing.T) {
 }
 
 func TestIPv6NextTableStaticRoutes(t *testing.T) {
-	lines := []string{"set routing-options rib inet6.0 static route ::/0 next-table Comcast-GigabitPro.inet6.0", "set routing-options rib inet6.0 static route 2001:db8::/32 next-table ATT.inet6.0", "set routing-options static route 0.0.0.0/0 next-table Comcast-GigabitPro.inet.0"}
+	lines := []string{
+		// The next-table target routing-instances must be defined or the
+		// #5693 definedness gate rejects the commit.
+		"set routing-instances Comcast-GigabitPro instance-type virtual-router",
+		"set routing-instances ATT instance-type virtual-router",
+		"set routing-options rib inet6.0 static route ::/0 next-table Comcast-GigabitPro.inet6.0",
+		"set routing-options rib inet6.0 static route 2001:db8::/32 next-table ATT.inet6.0",
+		"set routing-options static route 0.0.0.0/0 next-table Comcast-GigabitPro.inet.0",
+	}
 	tree := &ConfigTree{}
 	for _, line := range lines {
 		cmd, err := ParseSetCommand(line)

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -839,7 +839,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -856,7 +857,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "2602:ffd3:0:2::/64",
@@ -873,7 +875,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -946,7 +949,8 @@
               "Discard": false,
               "Reject": false,
               "Preference": 5,
-              "NextTable": ""
+              "NextTable": "",
+              "NextTableRaw": ""
             }
           ],
           "Inet6StaticRoutes": null,
@@ -2088,7 +2092,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -2105,7 +2110,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "2602:ffd3:0:2::/64",
@@ -2122,7 +2128,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -2195,7 +2202,8 @@
               "Discard": false,
               "Reject": false,
               "Preference": 5,
-              "NextTable": ""
+              "NextTable": "",
+              "NextTableRaw": ""
             }
           ],
           "Inet6StaticRoutes": null,
@@ -3336,7 +3344,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -3353,7 +3362,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "2602:ffd3:0:2::/64",
@@ -3370,7 +3380,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -3443,7 +3454,8 @@
               "Discard": false,
               "Reject": false,
               "Preference": 5,
-              "NextTable": ""
+              "NextTable": "",
+              "NextTableRaw": ""
             }
           ],
           "Inet6StaticRoutes": null,
@@ -4584,7 +4596,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -4601,7 +4614,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "2602:ffd3:0:2::/64",
@@ -4618,7 +4632,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -4691,7 +4706,8 @@
               "Discard": false,
               "Reject": false,
               "Preference": 5,
-              "NextTable": ""
+              "NextTable": "",
+              "NextTableRaw": ""
             }
           ],
           "Inet6StaticRoutes": null,
@@ -5833,7 +5849,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -5850,7 +5867,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "2602:ffd3:0:2::/64",
@@ -5867,7 +5885,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -5940,7 +5959,8 @@
               "Discard": false,
               "Reject": false,
               "Preference": 5,
-              "NextTable": ""
+              "NextTable": "",
+              "NextTableRaw": ""
             }
           ],
           "Inet6StaticRoutes": null,
@@ -7081,7 +7101,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -7098,7 +7119,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "2602:ffd3:0:2::/64",
@@ -7115,7 +7137,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -7188,7 +7211,8 @@
               "Discard": false,
               "Reject": false,
               "Preference": 5,
-              "NextTable": ""
+              "NextTable": "",
+              "NextTableRaw": ""
             }
           ],
           "Inet6StaticRoutes": null,
@@ -8164,7 +8188,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -8181,7 +8206,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -9130,7 +9156,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -9147,7 +9174,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -10095,7 +10123,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -10112,7 +10141,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -11060,7 +11090,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -11077,7 +11108,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -12026,7 +12058,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -12043,7 +12076,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,
@@ -12991,7 +13025,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           },
           {
             "Destination": "::/0",
@@ -13008,7 +13043,8 @@
             "Discard": false,
             "Reject": false,
             "Preference": 5,
-            "NextTable": ""
+            "NextTable": "",
+            "NextTableRaw": ""
           }
         ],
         "Inet6StaticRoutes": null,

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -234,6 +234,13 @@ type StaticRoute struct {
 	Reject     bool
 	Preference int    // route preference (admin distance), default 5
 	NextTable  string // routing instance name for inter-VRF route leaking (e.g. "Comcast.inet.0" → "Comcast")
+	// NextTableRaw preserves the operator's original next-table token
+	// (e.g. "Comcast.inet.0") before parseNextTableInstance strips the
+	// family/index suffix. The commit-time definedness gate
+	// (validateNextTableTargetReferencesStrict) reports this raw token so
+	// the error names exactly what was typed, and the raw grammar is not
+	// lost before validation runs (#5693). Empty when no next-table.
+	NextTableRaw string
 }
 
 // ProtocolsConfig holds dynamic routing protocol configuration.


### PR DESCRIPTION
## Problem

A static route whose `next-table <target>` named a routing-instance that is **not defined** in the config was **accepted at commit** and then **silently dropped at apply time**. The applier (`pkg/routing.nextTableManager.Apply`) resolves the target through a name→table-id map built only from defined instances, so an undefined target missed the lookup, logged `next-table references unknown routing instance`, and skipped the rule — the intended inter-VRF leak never happened and matching traffic followed the ingress table's own routes (often the WAN default), a silent mis-forward with no commit-time diagnostic (codex-review-182 M14).

The raw next-table grammar was also **lost before validation**: `parseNextTableInstance` strips the `.inet[6].N` suffix at compile time, so only the bare instance name survived.

Distinct from #5632 (next-table `.inet` `LastIndex`) and #5633 — this is the target-definedness + raw-grammar-preservation follow-on.

## Fix (both halves, per the issue)

**(a) Preserve the raw token** — `pkg/config/types_routing.go`: new `StaticRoute.NextTableRaw`, populated at both compile sites (inline route-keys + hierarchical) and carried through the same-destination merge in `compiler_routing.go`.

**(b) Validate definedness** — `pkg/config/compiler_validate_strict_routing.go`: `validateNextTableTargetReferencesStrict` rejects a global `inet.0`/`inet6.0` static route whose parsed next-table instance is not a defined routing-instance, quoting the raw token in the error. It resolves the target with the same `parseNextTableInstance` the applier uses, so the commit gate and runtime applier stay in lockstep on what resolves (the #2226 rib-group doctrine). Only the global route sets are validated — exactly what `daemon_apply` feeds to `ApplyNextTableRules`. Wired into `runUniformGates` after the rib-group gate; strict on commit/commit-check, downgraded to a warning on tolerant load/peer-sync (`opts.lenientNextTableRefs`, #1960 no-brick). Mirrors `validateRibGroupImportRibReferencesStrict`.

## Fix sites (on this branch)

- `pkg/config/types_routing.go:238` — `NextTableRaw` field
- `pkg/config/compiler_routing.go:202` / `:353` — populate raw at both compile sites (+ `:373` merge)
- `pkg/config/compiler_validate_strict_routing.go:723` — `validateNextTableTargetReferencesStrict`
- `pkg/config/compiler_uniformgates.go:1798` — gate wired into `runUniformGates`
- `pkg/config/compiler.go:943` — `lenientNextTableRefs` opt (+ set true on the two tolerant paths)

## Tests (fail-on-revert)

`pkg/config/compiler_routing_nexttable_target_5693_test.go`:
- `TestNextTableUndefinedTargetRejected_5693` (inet flat-set / inet6 rib / hierarchical) — undefined target REJECTED at commit; error quotes the raw token.
- `TestNextTableDefinedTargetAccepted_5693` — defined target compiles; `NextTable` + `NextTableRaw` both populated (grammar preserved).
- `TestNextTableTargetGate_LenientDowngrade_5693` — strict rejects; `CompileConfigLenient` loads with a warning.

**Fail-on-revert proven:** neutering `validateNextTableTargetReferencesStrict` (return nil) makes every reject assertion fire **RED**; restoring makes them pass. `go build ./...` and `go test ./pkg/config/... ./pkg/routing/...` are green (also re-ran pkg/frr, pkg/api, pkg/dataplane/userspace, pkg/grpcapi, pkg/daemon — green).

## Collateral

Two pre-existing tests used undefined targets and now define the instance (`TestNextTableStaticRoutes` / `TestIPv6NextTableStaticRoutes`). The `golden_4406` baseline was regenerated **for the new empty `NextTableRaw` field only** — verified the diff is purely the added field, no behavior/error change.

## Docs

`docs/rib-group-route-leaking.md` (new "Strict rejection — undefined next-table target" subsection) + `_Log.md`.

Closes #5693

🤖 Generated with [Claude Code](https://claude.com/claude-code)