### PR TITLE
config: validate every static-route next-hop gateway at commit (#5726)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-12 — #5726 (bug): commit-time next-hop gateway validation — qualified-next-hop + ECMP list
+- **Timestamp**: 2026-07-12 (fix/5726-nexthop-validation)
+- **Action**: fable-review-175 F-01/F-02. Two fail-open commit-time next-hop
+  gateway validation gaps: (F-01) the `qualified-next-hop <gateway>` schema node
+  carried no keyValidator (unlike `next-hop`), so a typo'd floating-backup
+  gateway committed clean and FRR rendered it verbatim → the backup silently
+  never installed; (F-02) an ECMP `next-hop [ gw1 gw2 ]` collapses onto ONE leaf
+  (Keys=["next-hop", gw1, gw2], #2419) but the shared schema_walk container
+  keyValidator loop validated only the first token (argEnd = 1+args), so 2nd+
+  gateways bypassed ValidateStaticNextHop while the compiler installed them.
+  Fixes: (F-01) added `keyValueType: ValueIPAddress, keyValidator:
+  ValidateStaticNextHop` to the qualified-next-hop node (schema_routing.go),
+  mirroring next-hop; (F-02) in schema_walk.go the container keyValidator loop
+  now special-cases `valueList && keyValidator != nil` (uniquely `next-hop` —
+  the ONLY valueList node in the schema) to validate the WHOLE Keys[1:] gateway
+  run, skipping an `interface <name>` modifier that appears after ≥1 gateway
+  (mirrors the compiler's #3881 keyword-bounded scan; an ifname is not a valid
+  gateway literal). BLAST RADIUS: gated on `valueList` (not `multi`) so the
+  positional `route-filter` multi leaf (keyValidatorPos) is untouched — an
+  initial `multi` gate regressed route-filter's `upto /24` value tail; narrowed
+  to valueList, full pkg/config suite green. Fail-on-revert proven for both
+  halves (drop qualified keyValidator → F-01 RED; restore argEnd span → F-02
+  RED; interface-modifier accept stays green).
+- **File(s)**: pkg/config/schema_routing.go, pkg/config/schema_walk.go,
+  pkg/config/schema_nexthop_validation_5726_test.go, docs/config-schema.md
+
 ## 2026-07-12 — #5714 (bug/security): web-mgmt bind resolves Junos ifname to Linux kernel name before InterfaceByName
 - **Timestamp**: 2026-07-12 (fix/5714-webmgmt-ifname)
 - **Action**: codex-review-182 M42. The web-management HTTP/HTTPS bind passed

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -465,6 +465,23 @@ floating-backup leaf carrying its own per-next-hop preference (#3871): a plain
 `next-hop` list is equal-cost ECMP, a `qualified-next-hop` is a distance-N
 backup.
 
+**Commit-time gateway validation of a value list (#5726).** The container
+keyValidator loop in `schema_walk.go` normally validates only the declared
+identity-arg span (`1 + args` tokens). For a `valueList` leaf that would leave
+every gateway past the first UNVALIDATED — a typo'd ECMP member
+(`next-hop [ 192.168.1.1 1.2.3.999 ]`) then committed clean and FRR silently
+dropped it (fail-open). The loop therefore special-cases `valueList &&
+keyValidator != nil` (only `next-hop`) to run `ValidateStaticNextHop` over the
+WHOLE `Keys[1:]` run, mirroring the compiler's keyword-bounded gateway scan
+(#3881): an `interface <name>` token appearing AFTER at least one gateway is the
+egress modifier and is skipped (an ifname is not a valid gateway literal), while
+a LEADING `interface` token is itself a gateway value. A POSITIONAL multi leaf
+(`route-filter`, `keyValidatorPos` + a per-position grammar and a value tail) is
+NOT a `valueList` and keeps the declared-arg span. `qualified-next-hop` now also
+carries the `ValidateStaticNextHop` keyValidator on its gateway identity arg
+(#5726) — before, a malformed floating-backup gateway committed clean and the
+backup never installed.
+
 **Fully-inline route-keys form drops the `interface` modifier (#3881).** The
 above covers the flat-set and hierarchical-brace shapes, where `next-hop` is
 its own leaf/child node. A THIRD shape exists: the hierarchical route written

--- a/pkg/config/schema_nexthop_validation_5726_test.go
+++ b/pkg/config/schema_nexthop_validation_5726_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5726: two commit-time next-hop gateway validation gaps.
+//
+//   - F-01: the `qualified-next-hop <gateway>` node carried NO keyValidator
+//     (unlike the sibling `next-hop`), so a typo'd floating-backup gateway
+//     committed clean and FRR rendered it verbatim -> the backup silently
+//     never installed.
+//   - F-02: an ECMP `next-hop [ gw1 gw2 ]` collapses onto ONE leaf
+//     (Keys=["next-hop", gw1, gw2], #2419), but the shared schema_walk
+//     container keyValidator loop validated only the first token
+//     (argEnd = 1+args), so every 2nd+ gateway bypassed validation while the
+//     compiler installed it as an equal-cost next-hop.
+//
+// Both are fail-open: the malformed gateway commits, FRR emits it verbatim,
+// and the route/backup/ECMP member silently never installs. ValidateStaticNextHop
+// already rejects the bad token (`1.2.3.999`) — the fix simply invokes it on
+// these two paths.
+//
+// FAIL-ON-REVERT:
+//   - Drop the keyValidator from the qualified-next-hop node -> F-01 reject
+//     cases stop erroring (RED).
+//   - Restore the schema_walk container loop to the argEnd=1+args span (drop
+//     the `multi` branch) -> F-02 second-gateway reject stops erroring (RED),
+//     while the interface-modifier accept case is unaffected either way.
+
+// schemaValidate5726 builds a flat-set tree (ParseSetCommand + SetPath — never
+// NewParser, per CLAUDE.md; the bracket list needs the flat-set collapse) and
+// runs the commit-check schema gate.
+func schemaValidate5726(t *testing.T, sets ...string) error {
+	t.Helper()
+	return SchemaValidate(flatTreeFromSets(t, sets...), nil)
+}
+
+// --- F-01: qualified-next-hop gateway is validated at commit ---------------
+
+func TestSchema5726_QualifiedNextHop_RejectsBadGateway(t *testing.T) {
+	err := schemaValidate5726(t,
+		"set routing-options static route 10.0.0.0/8 next-hop 192.168.1.1",
+		"set routing-options static route 10.0.0.0/8 qualified-next-hop 1.2.3.999 preference 100",
+	)
+	if err == nil {
+		t.Fatal("expected SchemaValidate to reject qualified-next-hop 1.2.3.999, got nil (the #5726 F-01 silent-accept)")
+	}
+	if !strings.Contains(err.Error(), "1.2.3.999") {
+		t.Fatalf("error should name the bad qualified-next-hop gateway: %v", err)
+	}
+}
+
+func TestSchema5726_QualifiedNextHop_AcceptsValid(t *testing.T) {
+	// A valid IPv4/IPv6 gateway and a bare interface-name backup must all pass;
+	// the inline preference/interface modifiers must not be mis-validated as a
+	// gateway.
+	cases := [][]string{
+		{"set routing-options static route 10.0.0.0/8 qualified-next-hop 192.168.1.2 preference 100"},
+		{"set routing-options static route ::/0 qualified-next-hop 2001:db8::1 preference 50"},
+		{"set routing-options static route 10.0.0.0/8 qualified-next-hop 192.168.1.2 interface ge-0/0/0.0"},
+	}
+	for _, sets := range cases {
+		if err := schemaValidate5726(t, sets...); err != nil {
+			t.Fatalf("valid qualified-next-hop must pass commit-check, got %v (sets=%v)", err, sets)
+		}
+	}
+}
+
+// --- F-02: every gateway in an ECMP next-hop list is validated -------------
+
+func TestSchema5726_ECMPNextHopList_RejectsBadSecondGateway(t *testing.T) {
+	// First gateway valid, SECOND a typo. Pre-#5726 only the first was checked,
+	// so this committed clean and FRR then dropped the bad ECMP member.
+	err := schemaValidate5726(t,
+		"set routing-options static route 0.0.0.0/0 next-hop [ 192.168.1.1 1.2.3.999 ]",
+	)
+	if err == nil {
+		t.Fatal("expected SchemaValidate to reject the 2nd ECMP gateway 1.2.3.999, got nil (the #5726 F-02 silent-accept)")
+	}
+	if !strings.Contains(err.Error(), "1.2.3.999") {
+		t.Fatalf("error should name the bad ECMP gateway: %v", err)
+	}
+}
+
+func TestSchema5726_ECMPNextHopList_RejectsBadThirdGateway(t *testing.T) {
+	// Guard the tail beyond position 2 as well.
+	err := schemaValidate5726(t,
+		"set routing-options static route 0.0.0.0/0 next-hop [ 192.168.1.1 192.168.1.2 999.999.999.999 ]",
+	)
+	if err == nil {
+		t.Fatal("expected SchemaValidate to reject the 3rd ECMP gateway, got nil")
+	}
+}
+
+func TestSchema5726_ECMPNextHopList_AcceptsAllValid(t *testing.T) {
+	if err := schemaValidate5726(t,
+		"set routing-options static route 0.0.0.0/0 next-hop [ 192.168.1.1 192.168.1.2 192.168.1.3 ]",
+	); err != nil {
+		t.Fatalf("a fully-valid ECMP next-hop list must pass commit-check, got %v", err)
+	}
+}
+
+// TestSchema5726_NextHop_InterfaceModifierNotValidatedAsGateway is the critical
+// guard that the widened validation still EXCLUDES the `interface <name>`
+// egress modifier: an ifname like ge-0/0/0 is NOT a valid gateway literal
+// (ValidateStaticNextHop rejects the slash form), so validating it as a gateway
+// would falsely reject a legitimate `next-hop <gw> interface <if>` config.
+func TestSchema5726_NextHop_InterfaceModifierNotValidatedAsGateway(t *testing.T) {
+	cases := []string{
+		// Single gateway + inline interface modifier.
+		"set routing-options static route 0.0.0.0/0 next-hop 10.0.0.1 interface ge-0/0/0.0",
+		// Bracket form carrying the interface modifier after the gateway.
+		"set routing-options static route 0.0.0.0/0 next-hop [ 10.0.0.1 interface ge-0/0/0.0 ]",
+		// IPv6 link-local gateway REQUIRES an egress interface — must pass.
+		"set routing-options static route ::/0 next-hop fe80::1 interface reth0.50",
+	}
+	for _, s := range cases {
+		if err := schemaValidate5726(t, s); err != nil {
+			t.Fatalf("next-hop with an interface modifier must pass (ifname is not a gateway): %v (set=%q)", err, s)
+		}
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -95,27 +95,37 @@ func staticRouteNode() *schemaNode {
 				children: map[string]*schemaNode{
 					"interface": {desc: "Egress interface for this next-hop", args: 1, placeholder: "<interface-name>", children: nil},
 				}},
-			"qualified-next-hop": {desc: "Qualified next-hop", args: 1, placeholder: "<gateway>", children: map[string]*schemaNode{
-				"interface": {desc: "Egress interface", args: 1, placeholder: "<interface-name>", children: nil},
-				// The qualified-next-hop preference is carried PER next-hop
-				// (NextHopEntry.Preference, #3871) so the qualified gateway
-				// renders as a FLOATING backup at its own admin distance — it is
-				// NO LONGER folded into the single route-level preference (that
-				// fold was the #3871 bug: it made every next-hop equal-cost).
-				// The typing is still the same i32 wire field gated for the
-				// route-level `preference` leaf (#3827): a negative / i32-
-				// overflow value is rejected at commit (naming the leaf) instead
-				// of only tripping the Rust snapshot backstop
-				// (RoutePreferenceOutOfRange) with retained-prior-state.
-				"preference": {desc: "Preference", args: 1, placeholder: "<value>",
-					valueType: ValueInteger, valueDesc: "Route preference / administrative distance (0..2147483647; lower = more preferred, default 5)",
-					valueExamples: []string{"5", "100"}, validator: ValidateInteger(0, maxWireI32), children: nil},
-				// metric is carried per next-hop (NextHopEntry.Metric, #3871) but
-				// NOT rendered — FRR's static-route CLI has no metric field, so a
-				// metric-only qualified-next-hop (no preference) does NOT float;
-				// preference is what creates the floating backup.
-				"metric": {desc: "Metric", args: 1, placeholder: "<value>", children: nil},
-			}},
+			// #5726: the qualified-next-hop gateway is validated at commit via
+			// the CONTAINER keyValidator (ValidateStaticNextHop), mirroring the
+			// sibling `next-hop` node. Before this the node carried no
+			// keyValidator, so a typo'd floating-backup gateway (1.2.3.999)
+			// committed clean and FRR then rendered it verbatim → the backup
+			// silently never installed (discovered only during the primary-path
+			// failure it exists to survive).
+			"qualified-next-hop": {desc: "Qualified next-hop", args: 1, placeholder: "<gateway>",
+				keyValueType: ValueIPAddress, keyValueDesc: "next-hop IP address, ip@interface, or interface name",
+				keyValueExamples: []string{"192.168.1.1", "2001:db8::1"}, keyValidator: ValidateStaticNextHop,
+				children: map[string]*schemaNode{
+					"interface": {desc: "Egress interface", args: 1, placeholder: "<interface-name>", children: nil},
+					// The qualified-next-hop preference is carried PER next-hop
+					// (NextHopEntry.Preference, #3871) so the qualified gateway
+					// renders as a FLOATING backup at its own admin distance — it is
+					// NO LONGER folded into the single route-level preference (that
+					// fold was the #3871 bug: it made every next-hop equal-cost).
+					// The typing is still the same i32 wire field gated for the
+					// route-level `preference` leaf (#3827): a negative / i32-
+					// overflow value is rejected at commit (naming the leaf) instead
+					// of only tripping the Rust snapshot backstop
+					// (RoutePreferenceOutOfRange) with retained-prior-state.
+					"preference": {desc: "Preference", args: 1, placeholder: "<value>",
+						valueType: ValueInteger, valueDesc: "Route preference / administrative distance (0..2147483647; lower = more preferred, default 5)",
+						valueExamples: []string{"5", "100"}, validator: ValidateInteger(0, maxWireI32), children: nil},
+					// metric is carried per next-hop (NextHopEntry.Metric, #3871) but
+					// NOT rendered — FRR's static-route CLI has no metric field, so a
+					// metric-only qualified-next-hop (no preference) does NOT float;
+					// preference is what creates the floating backup.
+					"metric": {desc: "Metric", args: 1, placeholder: "<value>", children: nil},
+				}},
 			"discard":    {desc: "Discard (blackhole) route", children: nil},
 			"reject":     {desc: "Reject route (send ICMP unreachable)", children: nil},
 			"next-table": {desc: "Resolve in another routing table", args: 1, placeholder: "<table>", children: nil},

--- a/pkg/config/schema_walk.go
+++ b/pkg/config/schema_walk.go
@@ -400,14 +400,51 @@ func walkSchemaNode(node *Node, parent *schemaNode, path []string, vc *walkConte
 	// each token's 0-based arg index so a multi-arg slot can enforce a
 	// distinct grammar per position (prefix slot vs match-type slot).
 	if childSchema.keyValidatorPos != nil || childSchema.keyValidator != nil {
-		argEnd := declaredKeyTokens
-		if argEnd > len(node.Keys) {
-			argEnd = len(node.Keys)
-		}
 		keyPath := append(append([]string(nil), path...), keyword)
-		for argIdx, tok := range node.Keys[1:argEnd] {
-			if err := validateKeySlot(childSchema, argIdx, tok, vc); err != nil {
-				return typedLeafInvalidErrorf(keyPath, tok, err)
+		if childSchema.valueList && childSchema.keyValidator != nil {
+			// #5726: a VALUE-LIST container leaf (only the static-route
+			// `next-hop`: multi + valueList + keyValidator + an `interface`
+			// modifier child) packs its whole homogeneous value LIST onto
+			// Keys beyond the identity: `next-hop [ gw1 gw2 ]` collapses to
+			// Keys=["next-hop", gw1, gw2] (#2419). Validate EVERY packed
+			// gateway, not just the first — the pre-#5726 argEnd=1+args span
+			// left gw2.. UNVALIDATED, so a typo'd ECMP member committed clean
+			// and FRR then silently dropped it (fail-open). Gated on valueList
+			// (NOT multi) so a POSITIONAL multi leaf like `route-filter`
+			// (keyValidatorPos, per-position grammar + a value tail) keeps the
+			// old declared-arg span — the else branch below. Mirror the
+			// compiler's keyword-bounded gateway scan (compiler_routing.go
+			// isRouteInlineKeyword / #3881): a token that names a declared
+			// modifier CHILD (`interface`) AFTER at least one gateway is the
+			// egress modifier — it and its argument are NOT validated as
+			// gateways (an ifname like ge-0/0/0 is not a valid gateway
+			// literal). A LEADING such token is itself a gateway value.
+			valuesSeen := 0
+			for j := 1; j < len(node.Keys); j++ {
+				tok := node.Keys[j]
+				if valuesSeen > 0 && childSchema.children != nil {
+					if _, isModifier := childSchema.children[tok]; isModifier {
+						j++ // skip the modifier keyword AND its value token
+						continue
+					}
+				}
+				if err := validateKeySlot(childSchema, valuesSeen, tok, vc); err != nil {
+					return typedLeafInvalidErrorf(keyPath, tok, err)
+				}
+				valuesSeen++
+			}
+		} else {
+			// Non-multi container: only the declared identity-arg span is a
+			// value slot; tokens past it are keywords/ignored per the
+			// compiler-faithful contract.
+			argEnd := declaredKeyTokens
+			if argEnd > len(node.Keys) {
+				argEnd = len(node.Keys)
+			}
+			for argIdx, tok := range node.Keys[1:argEnd] {
+				if err := validateKeySlot(childSchema, argIdx, tok, vc); err != nil {
+					return typedLeafInvalidErrorf(keyPath, tok, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Closes #5726.

Two fail-open **commit-time** next-hop gateway validation gaps let a typo'd gateway commit clean; FRR then rendered it verbatim and the route / floating backup / ECMP member silently never installed.

## F-01 — `qualified-next-hop <gateway>` had no validator

`pkg/config/schema_routing.go` — the `qualified-next-hop` node carried no `keyValidator`, unlike its sibling `next-hop` (`ValidateStaticNextHop`). Fixed by adding `keyValueType: ValueIPAddress` + `keyValidator: ValidateStaticNextHop`, mirroring `next-hop`.

## F-02 — ECMP `next-hop [ gw1 gw2 ]` validated only the first gateway

`pkg/config/schema_walk.go` — a canonical Junos ECMP list collapses onto ONE leaf (`Keys=["next-hop", gw1, gw2]`, #2419), but the shared container keyValidator loop validated only the declared identity-arg span (`argEnd = 1 + args`), so every gateway past the first bypassed `ValidateStaticNextHop` while the compiler installed each as equal-cost. The loop now validates the whole `Keys[1:]` gateway run for a value-list leaf.

## Shared-loop blast radius (important for review)

The widened validation is gated on **`valueList && keyValidator != nil`**. `next-hop` is the **only** `valueList` node in the entire schema, so **no other leaf changes behavior**.

I initially gated on the broader `multi` flag — that **regressed** the positional `route-filter` leaf (`keyValidatorPos`, packs a per-position grammar plus a value tail like `upto /24`), which must keep the declared-arg span. The full `pkg/config` suite caught it; I narrowed the gate to `valueList` and the suite is green. This is why the gate is `valueList`, not `multi`.

The value-list scan mirrors the compiler's keyword-bounded gateway scan (`compiler_routing.go`, `isRouteInlineKeyword` / #3881): an `interface <name>` token appearing **after** ≥1 gateway is the egress modifier and is **skipped** (an ifname like `ge-0/0/0` is not a valid gateway literal, so validating it would falsely reject a legitimate `next-hop <gw> interface <if>` config); a **leading** `interface` token is itself a gateway value.

## Validation — fail-on-revert (`schema_nexthop_validation_5726_test.go`)

Built via `ParseSetCommand` + `SetPath` (never `NewParser`).

- `qualified-next-hop 1.2.3.999` → **rejected** (drop the qualified keyValidator → **RED**).
- `next-hop [ 192.168.1.1 1.2.3.999 ]` (2nd typo) and a 3-gateway list with a typo → **rejected** (restore the `argEnd=1+args` span → **RED**).
- A fully-valid ECMP list and `next-hop <gw> interface ge-0/0/0.0` (single + bracket + IPv6 link-local) → **pass** (unaffected by either revert).

Proven RED-on-revert for each half independently. Full `pkg/config` suite (incl. route-filter positional tests), `pkg/cli`, `pkg/cmdtree`, and `go build ./...` all pass.

Provenance: fable-review-175 F-01/F-02. Distinct from #2448 (runtime Rust-FIB drop), #5678 (qualified-next-hop preference drop at snapshot), #5161 (interface-only ECMP starve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)