### PR TITLE
frr: AND the off-family from-prefix-list in a split route-filter term (M27)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-12 — #5702 (bug): mixed-family route-filter split must AND the off-family from-prefix-list predicate
+- **Timestamp**: 2026-07-12 (fix/5702-routefilter-mixedfamily)
+- **Action**: codex-review-182 M27. A policy-statement term whose route-filters
+  mix families (v4 + v6) SPLITS into a per-family v4 sequence and a v6 sequence
+  (#2607). When that term ALSO carried a `from prefix-list` of a single family,
+  the renderer (renderPolicyTermSequences / emitTermBody in
+  pkg/frr/policy_render.go) DROPPED the off-family prefix-list `match` line —
+  guarded emission `if seqFam=="" || (seqFam=="v6"&&matchKW=="ipv6") ||
+  (seqFam=="v4"&&matchKW=="ip")`. That left the off-family sequence with only its
+  route-filter match, silently LOOSENING the term's AND to its route-filter half:
+  a v4 route matching the v4 route-filter matched the term even though the term
+  also required membership in a v6-only prefix-list no v4 route can satisfy — a
+  fail-OPEN policy-semantics change. Fix: always emit the `from prefix-list`
+  match line. In the off-family sequence it names a DIFFERENT FRR match type than
+  the sequence's own `match ip/ipv6 address <route-filter>`, so the two coexist
+  and the sequence AND-NOMATCHes every route of that family — i.e. the off-family
+  half is NON-MATCHING, honoring the AND as an unsatisfiable constraint instead
+  of dropping it. Non-split and on-family cases are byte-identical (the guard was
+  already true there); only the off-family split emission changes. Different-type
+  coexistence, NOT the #2071 same-type collision. Fail-on-revert proven:
+  restoring the guard drops `match ipv6 address prefix-list V6ONLY` from the v4
+  sequence → the two direction tests go RED.
+- **File(s)**: pkg/frr/policy_render.go,
+  pkg/frr/policy_mixedfamily_prefixlist_5702_test.go
+
 ## 2026-07-12 — #5693 (bug): validate next-table target routing-instance definedness at commit
 - **Timestamp**: 2026-07-12 (fix/5693-nexttable-target-defined)
 - **Action**: codex-review-182 M14. A static route whose `next-table <target>`

--- a/pkg/frr/policy_mixedfamily_prefixlist_5702_test.go
+++ b/pkg/frr/policy_mixedfamily_prefixlist_5702_test.go
@@ -1,0 +1,175 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// routeMapSequenceContaining returns the text of the single `route-map <name>
+// <action> <seq>` block (up to its `exit`) that contains needle, or "" if no
+// sequence contains it. Used to assert that an AND predicate co-resides in the
+// SAME sequence as a route-filter match (FRR ANDs match clauses within one
+// sequence).
+func routeMapSequenceContaining(render, name, needle string) string {
+	marker := "route-map " + name + " "
+	idx := 0
+	for {
+		start := strings.Index(render[idx:], marker)
+		if start < 0 {
+			return ""
+		}
+		start += idx
+		// The sequence body runs to its terminating "exit\n" line.
+		rest := render[start:]
+		end := strings.Index(rest, "\nexit\n")
+		var block string
+		if end < 0 {
+			block = rest
+		} else {
+			block = rest[:end+len("\nexit\n")]
+		}
+		if strings.Contains(block, needle) {
+			return block
+		}
+		idx = start + len(marker)
+	}
+}
+
+// TestMixedFamilyRouteFilterFromPrefixList_OffFamilyNonMatching_5702 proves the
+// #5702 fix. A policy term whose route-filters mix families (v4 + v6) SPLITS
+// into a per-family v4 sequence and a v6 sequence (#2607). When that term ALSO
+// carries a `from prefix-list` of a SINGLE family, the split must AND that
+// prefix-list predicate into BOTH sequences. In the OFF-family sequence the
+// predicate is unsatisfiable (a v4 route can never be in a v6-only list), so
+// that sequence must AND-NOMATCH — i.e. be NON-MATCHING for its family.
+//
+// Pre-#5702 the renderer DROPPED the off-family `from prefix-list` match line
+// and emitted the surviving sequence with only its route-filter match, silently
+// LOOSENING the term's AND to its route-filter half: a v4 route matching the v4
+// route-filter matched the term even though the term also required membership in
+// a v6-only prefix-list — a fail-open policy-semantics change.
+//
+// FAIL-ON-REVERT: restoring the family guard (drop the off-family match) removes
+// the `match ipv6 address prefix-list V6ONLY` line from the v4 sequence, so the
+// assertion that the v4 route-filter sequence also carries the v6 prefix-list
+// AND predicate fires RED.
+func TestMixedFamilyRouteFilterFromPrefixList_OffFamilyNonMatching_5702(t *testing.T) {
+	po := &config.PolicyOptionsConfig{
+		PrefixLists: map[string]*config.PrefixList{
+			// A v6-ONLY prefix-list — no v4 route can ever be a member.
+			"V6ONLY": {Name: "V6ONLY", Prefixes: []string{"2001:db8:aaaa::/48"}},
+		},
+		Communities: map[string]*config.CommunityDef{},
+		ASPaths:     map[string]*config.ASPathDef{},
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"MIX": {Name: "MIX", Terms: []*config.PolicyTerm{
+				{
+					Name: "t1",
+					RouteFilters: []*config.RouteFilter{
+						{Prefix: "10.0.0.0/8", MatchType: "orlonger"},    // v4 → splits
+						{Prefix: "2001:db8::/32", MatchType: "orlonger"}, // v6 → splits
+					},
+					// The AND predicate: membership in a v6-only prefix-list.
+					PrefixList: []string{"V6ONLY"},
+					Action:     "reject",
+				},
+			}, DefaultAction: "accept"},
+		},
+	}
+	got := New().generatePolicyOptions(po)
+
+	// The v4 sequence is the one carrying the v4 route-filter match.
+	v4seq := routeMapSequenceContaining(got, "MIX", "match ip address prefix-list MIX-t1_v4")
+	if v4seq == "" {
+		t.Fatalf("expected a v4 route-filter sequence in render:\n%s", got)
+	}
+	// #5702: that v4 sequence MUST also carry the v6-only prefix-list AND
+	// predicate, so it AND-NOMATCHes every v4 route (non-matching for v4)
+	// instead of matching the v4 route-filter alone.
+	if !strings.Contains(v4seq, "match ipv6 address prefix-list V6ONLY\n") {
+		t.Fatalf("v4 sequence must AND the off-family `from prefix-list` predicate "+
+			"(match ipv6 address prefix-list V6ONLY) so it is NON-MATCHING for v4 "+
+			"routes; the predicate was dropped (pre-#5702 fail-open):\n%s", v4seq)
+	}
+
+	// Belt: the off-family match appears in BOTH sequences now (v4 AND-NOMATCH
+	// + v6 on-family), where pre-fix it appeared only in the v6 sequence.
+	if n := strings.Count(got, "match ipv6 address prefix-list V6ONLY\n"); n != 2 {
+		t.Errorf("expected the V6ONLY match in both split sequences (v4 AND-NOMATCH + "+
+			"v6), got %d occurrences:\n%s", n, got)
+	}
+}
+
+// TestMixedFamilyRouteFilterFromPrefixList_V4List_OffFamilyNonMatching_5702 is
+// the mirror: a v4-ONLY `from prefix-list` combined with mixed-family
+// route-filters must AND-NOMATCH the V6 sequence (a v6 route can never be in a
+// v4-only list).
+func TestMixedFamilyRouteFilterFromPrefixList_V4List_OffFamilyNonMatching_5702(t *testing.T) {
+	po := &config.PolicyOptionsConfig{
+		PrefixLists: map[string]*config.PrefixList{
+			"V4ONLY": {Name: "V4ONLY", Prefixes: []string{"192.0.2.0/24"}},
+		},
+		Communities: map[string]*config.CommunityDef{},
+		ASPaths:     map[string]*config.ASPathDef{},
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"MIX": {Name: "MIX", Terms: []*config.PolicyTerm{
+				{
+					Name: "t1",
+					RouteFilters: []*config.RouteFilter{
+						{Prefix: "10.0.0.0/8", MatchType: "orlonger"},
+						{Prefix: "2001:db8::/32", MatchType: "orlonger"},
+					},
+					PrefixList: []string{"V4ONLY"},
+					Action:     "reject",
+				},
+			}, DefaultAction: "accept"},
+		},
+	}
+	got := New().generatePolicyOptions(po)
+
+	v6seq := routeMapSequenceContaining(got, "MIX", "match ipv6 address prefix-list MIX-t1_v6")
+	if v6seq == "" {
+		t.Fatalf("expected a v6 route-filter sequence in render:\n%s", got)
+	}
+	if !strings.Contains(v6seq, "match ip address prefix-list V4ONLY\n") {
+		t.Fatalf("v6 sequence must AND the off-family v4-only `from prefix-list` "+
+			"predicate (match ip address prefix-list V4ONLY) so it is NON-MATCHING "+
+			"for v6 routes (pre-#5702 fail-open dropped it):\n%s", v6seq)
+	}
+}
+
+// TestMixedFamilyRouteFilterNoPrefixList_Unchanged_5702 guards the common case:
+// a mixed-family route-filter term with NO `from prefix-list` is byte-identical
+// to the pre-#5702 render (the fix only touches the off-family prefix-list
+// emission). Both family sequences carry only their own route-filter match.
+func TestMixedFamilyRouteFilterNoPrefixList_Unchanged_5702(t *testing.T) {
+	po := &config.PolicyOptionsConfig{
+		PrefixLists: map[string]*config.PrefixList{},
+		Communities: map[string]*config.CommunityDef{},
+		ASPaths:     map[string]*config.ASPathDef{},
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"MIX": {Name: "MIX", Terms: []*config.PolicyTerm{
+				{
+					Name: "t1",
+					RouteFilters: []*config.RouteFilter{
+						{Prefix: "10.0.0.0/8", MatchType: "orlonger"},
+						{Prefix: "2001:db8::/32", MatchType: "orlonger"},
+					},
+					Action: "reject",
+				},
+			}, DefaultAction: "accept"},
+		},
+	}
+	got := New().generatePolicyOptions(po)
+	// No stray prefix-list AND predicate leaks into either sequence.
+	if strings.Contains(got, "prefix-list V6ONLY") || strings.Contains(got, "prefix-list V4ONLY") {
+		t.Fatalf("no from-prefix-list configured; render must not emit one:\n%s", got)
+	}
+	// Exactly the two per-family route-filter matches, nothing else.
+	if !strings.Contains(got, "match ip address prefix-list MIX-t1_v4\n") ||
+		!strings.Contains(got, "match ipv6 address prefix-list MIX-t1_v6\n") {
+		t.Fatalf("mixed-family split must keep both per-family route-filter matches:\n%s", got)
+	}
+}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -1934,11 +1934,27 @@ func (m *Manager) renderPolicyTermSequences(po *config.PolicyOptionsConfig, rout
 				// Unknown/empty lists default to IPv4.
 				//
 				// In a SPLIT mixed-route-filter term (seqFam != "") the
-				// prefix-list match is emitted ONLY in the sequence whose
-				// family matches the list, so the off-family sequence does
-				// not pick up a `match ip/ipv6` clause that would AND-NOMATCH
-				// its own family's routes (the #2071 co-resident collision,
-				// avoided by construction here).
+				// `from prefix-list` match is ANDed with this family's
+				// route-filter match. When the referenced list's family is
+				// the OPPOSITE of seqFam, the match line MUST STILL be
+				// emitted: it names a different FRR match type than this
+				// sequence's `match ip/ipv6 address <route-filter>`, so the
+				// two coexist and the sequence AND-NOMATCHes every route of
+				// seqFam's family — exactly the intended Junos semantics
+				// ("(route-filter) AND (off-family prefix-list)" is
+				// unsatisfiable for this family, so the term is non-matching
+				// for it). Dropping the off-family match instead (the pre-#5702
+				// behavior) silently LOOSENED the term to its route-filter half:
+				// a v4 route matching the v4 route-filter matched the term even
+				// though the term also required membership in a v6-only
+				// prefix-list no v4 route can satisfy — a fail-open
+				// policy-semantics change (#5702). Emitting it fail-CLOSES the
+				// off-family sequence, matching the non-split term's behavior
+				// (where both `match ip` and `match ipv6` already co-reside and
+				// AND-NOMATCH). This is a DIFFERENT-type coexistence, NOT the
+				// #2071 same-type collision — a v4 route-filter is `match ip`
+				// and a v6 prefix-list is `match ipv6`, so neither replaces the
+				// other.
 				//
 				// fromPrefixList is ONE entry of a possibly multi-valued
 				// `from prefix-list` set (#2642). Multiple entries match
@@ -1957,9 +1973,7 @@ func (m *Manager) renderPolicyTermSequences(po *config.PolicyOptionsConfig, rout
 						}
 					}
 				}
-				if seqFam == "" || (seqFam == "v6" && matchKW == "ipv6") || (seqFam == "v4" && matchKW == "ip") {
-					fmt.Fprintf(&b, " match %s address prefix-list %s\n", matchKW, fromPrefixList)
-				}
+				fmt.Fprintf(&b, " match %s address prefix-list %s\n", matchKW, fromPrefixList)
 			}
 
 			// Junos "from protocol [ bgp ospf static ]" matches ANY listed


### PR DESCRIPTION
## Problem

A policy-statement term whose route-filters mix families (≥1 v4 and ≥1 v6 prefix) is **split** into a per-family v4 route-map sequence and a v6 sequence — FRR ANDs `match ip address` and `match ipv6 address` within one index, and a route is exclusively one family (#2607).

When that term ALSO carried a `from prefix-list`, `emitTermBody` **dropped** the prefix-list `match` line in the sequence whose family didn't match the list (the guard `seqFam=="" || (seqFam=="v6" && matchKW=="ipv6") || (seqFam=="v4" && matchKW=="ip")`).

Dropping it silently **loosened** the term. Junos evaluates the term as `(route-filter) AND (from prefix-list)`. With a mixed route-filter and a v6-only prefix-list, only a v6 route can satisfy the AND — no v4 route can. But the v4 sequence, stripped of the v6 prefix-list predicate, matched **every** v4 route the v4 route-filter allowed → the term matched traffic the dropped predicate existed to exclude (codex-review-182 M27, **fail-open policy-semantics change**).

## Fix

`pkg/frr/policy_render.go` (`emitTermBody`, ~line 1976): **always emit** the `from prefix-list` match line. In the off-family sequence it names a **different** FRR match type than that sequence's own `match ip/ipv6 address <route-filter>`, so the two coexist and the sequence **AND-NOMATCHes** every route of its family — the off-family half becomes **non-matching**, honoring the AND as an unsatisfiable constraint rather than dropping it (the same fail-closed behavior the non-split term already has). This is different-type coexistence, **not** the #2071 same-type collision (a v4 route-filter is `match ip`, a v6 prefix-list is `match ipv6` — neither replaces the other).

Non-split and on-family cases are **byte-identical** (the guard was already true there); only the off-family split emission changes. Pure mixed-family route-filter terms with no `from prefix-list` are untouched.

## Fix site

- `pkg/frr/policy_render.go:1976` — unconditional `match %s address prefix-list %s` emission (removed the family-alignment guard); comment rewritten to document the corrected semantics.

## Tests (fail-on-revert)

`pkg/frr/policy_mixedfamily_prefixlist_5702_test.go`:
- `TestMixedFamilyRouteFilterFromPrefixList_OffFamilyNonMatching_5702` — mixed route-filter + v6-only `from prefix-list`; asserts the **v4** sequence carries `match ipv6 address prefix-list V6ONLY` (AND-NOMATCH → non-matching for v4).
- `TestMixedFamilyRouteFilterFromPrefixList_V4List_OffFamilyNonMatching_5702` — mirror with a v4-only list; the **v6** sequence must carry `match ip address prefix-list V4ONLY`.
- `TestMixedFamilyRouteFilterNoPrefixList_Unchanged_5702` — guards the no-churn common case.

**Fail-on-revert proven:** restoring the family guard drops `match ipv6 address prefix-list V6ONLY` from the v4 sequence (leaving only `match ip address prefix-list MIX-t1_v4`), so both direction tests go **RED**. With the fix, `go build ./...` and `go test ./pkg/frr/... ./pkg/config/...` are green.

## Docs

The render semantics are documented in the `emitTermBody` code comment (the canonical location for this renderer detail); no separate markdown doc covers the route-map family split, so none was changed. `_Log.md` updated.

Closes #5702

🤖 Generated with [Claude Code](https://claude.com/claude-code)