### PR TITLE
config: reject malformed chassis RG/node identities at commit (#5694)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-07-12 — #5694 (bug): reject malformed chassis RG/node identities at commit (alias-to-0)
+- **Timestamp**: 2026-07-12 (fix/5694-chassis-identity-validate)
+- **Action**: codex-review-182 M15. compileChassis parses a
+  `redundancy-group <name>` instance id and a per-RG `node <id>` with
+  strconv.Atoi and, on parse FAILURE, leaves the field at its zero default
+  (`rgID := 0; if n, err := Atoi(name); err == nil { rgID = n }`). A
+  non-numeric identity therefore silently became redundancy-group / node 0,
+  aliasing a valid id 0 and mis-assigning cluster ownership / priority. The
+  sibling validateChassisClusterStrict only sees the COMPILED int (already 0,
+  passes its 0..255 range check), so a new AST PRE-WALK gate
+  (validateChassisClusterIdentitiesAST in compiler_chassis_identity.go, wired
+  into runPreWalkGates) validates the RAW token: a malformed RG/RG-node id is
+  hard-rejected at strict commit / warned on tolerant load+peer-sync
+  (lenientChassisClusterIdentities, #1960). Scope is the two INSTANCE-NAME
+  slots the schema leaves unvalidated; the top-level `cluster node <id>` is
+  already a typed value leaf (ValidateInteger(0,1)). PURE config-layer — no
+  pkg/cluster runtime touch, so no test-failover needed. Fail-on-revert proven
+  (non-numeric + negative RG-node ids RED at commit, lenient warn RED, when the
+  validator is neutered); packed one-liner shape covered. Full pkg/config suite
+  green.
+- **File(s)**: pkg/config/compiler_chassis_identity.go,
+  pkg/config/compiler_chassis_identity_5694_test.go, pkg/config/compiler.go,
+  pkg/config/compiler_prewalk.go, docs/config-schema.md
+
 ## 2026-07-12 — #5732 (bug): bound composed BGP policy-CHAIN route-map sequences (follow-up to #5701)
 - **Timestamp**: 2026-07-12 (fix/5732-composed-chain-seq-bound)
 - **Action**: Follow-up to #5701/#5731 (my own scope note). The #5701 gate bounds

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2339,7 +2339,15 @@ reserved for whole-dataplane selection where a rewrite shim
   (`pkg/cluster/heartbeat.go`): >255 groups wrap the count byte to 0 and
   desync the wire, an id >255 truncates and collides. That gate runs on
   the compiled `*Config`, NOT through the schema walker, so it does not
-  change the identity-token typing decision above),
+  change the identity-token typing decision above; #5694 further adds
+  `validateChassisClusterIdentitiesAST` — an AST PRE-WALK gate in
+  `runPreWalkGates` (`compiler_chassis_identity.go`) that rejects a
+  MALFORMED `redundancy-group <id>` / RG-scoped `node <id>` token (non-
+  numeric, empty, or negative) at strict commit and warns on tolerant
+  load, because `compileChassis` otherwise Atoi-coerces such a token to 0
+  and silently aliases redundancy-group / node 0. Being an AST walk it
+  covers every shape, INCLUDING the packed one-liner the schema walker
+  bypasses — pinned by `compiler_chassis_identity_5694_test.go`),
   `interface-monitor <if> weight <n>` (tokens pack inline into a
   `children==nil` leaf; typing the weight needs a children map, which
   would flip SetPath grouping), `control-ports` (not compiled), and the

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -371,6 +371,20 @@ type compileOpts struct {
 	// clobbered. Same doctrine as lenientIPsecTrafficSelectors.
 	lenientReservedProposalSetNames bool
 
+	// lenientChassisClusterIdentities (#5694, codex-182 M15) downgrades the
+	// malformed chassis-cluster identity gate
+	// (validateChassisClusterIdentitiesAST) from a hard compile error to a
+	// cfg.Warnings entry on the tolerant load / peer-sync paths. A
+	// `redundancy-group <name>` or per-RG `node <id>` whose raw token is not a
+	// non-negative integer collapses to id 0 in compileChassis (Atoi-then-
+	// default), aliasing redundancy-group / node 0 and silently mis-assigning
+	// cluster ownership. Commit / commit-check stay strict so a new operator
+	// edit is rejected; an already-persisted or peer-synced config an older
+	// binary accepted must still BOOT (warn) per the #1960 fail-closed-on-load
+	// doctrine — compileChassis keeps the stable zero coercion, now flagged.
+	// Same doctrine as lenientReservedProposalSetNames.
+	lenientChassisClusterIdentities bool
+
 	// lenientIPsecProposalProtocol (#4298, V-2) downgrades the IPsec
 	// proposal `protocol ah` reject (validateIPsecProposalProtocolStrict)
 	// from a hard error to a warning on the tolerant load / peer-sync paths.
@@ -1842,6 +1856,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientIPsecEndpoints:                  true,
 		lenientIPsecTrafficSelectors:           true,
 		lenientReservedProposalSetNames:        true,
+		lenientChassisClusterIdentities:        true,
 		lenientIPsecProposalProtocol:           true,
 		lenientIPsecManualKey:                  true,
 		lenientLogProfileStreamRef:             true,
@@ -2191,6 +2206,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientIPsecEndpoints:                  true,
 		lenientIPsecTrafficSelectors:           true,
 		lenientReservedProposalSetNames:        true,
+		lenientChassisClusterIdentities:        true,
 		lenientIPsecProposalProtocol:           true,
 		lenientIPsecManualKey:                  true,
 		lenientLogProfileStreamRef:             true,

--- a/pkg/config/compiler_chassis_identity.go
+++ b/pkg/config/compiler_chassis_identity.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// compiler_chassis_identity.go carries the #5694 (codex-182 M15) reject-at-
+// commit gate for MALFORMED chassis-cluster REDUNDANCY-GROUP and per-RG NODE
+// identities.
+//
+// compileChassis (compiler_system.go) parses each identity with strconv.Atoi
+// and, on parse FAILURE, LEAVES the field at its zero default rather than
+// erroring:
+//
+//   - `redundancy-group <name>`: `rgID := 0; if n, err := Atoi(name); err ==
+//     nil { rgID = n }` — a non-numeric name (a typo like `redundancy-group
+//     reth0`) skips the assignment and the group is built with ID 0, ALIASING a
+//     valid redundancy-group 0.
+//   - the RG-scoped `node <id> priority <v>`: same Atoi-then-default pattern,
+//     so a malformed node token assigns the priority to node 0, overriding
+//     node 0's real priority.
+//
+// A malformed identity therefore silently mis-assigns cluster OWNERSHIP /
+// priority instead of being rejected. This is DISTINCT from the sibling
+// validateChassisClusterStrict (compiler_validate_strict_chassis.go), which
+// gates the COMPILED int (RG count, RG id range 0..255, node-priority range) —
+// by the time that runs the malformed token has already collapsed to 0, which
+// passes its range check (0 is valid). Only the RAW AST still distinguishes a
+// malformed token from a real 0, so this gate is an AST pre-walk (mirrors
+// validateApplicationNameCollisionsAST and the other reject-at-commit AST
+// gates in runPreWalkGates).
+//
+// SCOPE: only the two INSTANCE-NAME identity slots the schema explicitly leaves
+// unvalidated (schema_chassis.go: "Instance-name slots (redundancy-group <id>,
+// the RG-scoped node <id>) are NOT value slots ... typing them needs a new
+// walker feature (deferred)"). The TOP-LEVEL `chassis cluster node <id>` is a
+// typed value leaf (ValidateInteger(0, 1)) already rejected by SchemaValidate,
+// so it is intentionally not re-checked here.
+//
+// Strict path (commit / commit-check, lenient=false): the first malformed
+// identity is a hard compile error naming the offending token. Lenient path
+// (load / peer-sync, lenient=true): every malformed identity is a warning and
+// compilation continues with the existing zero-coercion, so an already-
+// persisted or peer-synced config an older binary silently accepted still
+// BOOTS (#1960 fail-closed-on-load doctrine). compileChassis is unchanged — the
+// lenient path deliberately keeps producing the (arbitrary but stable) zero
+// coercion it always did.
+
+// validateChassisClusterIdentitiesAST walks the chassis cluster subtree and
+// rejects (strict) or warns (lenient) a redundancy-group or per-RG node
+// identity whose raw token is not a well-formed non-negative integer. See the
+// file-level comment for the doctrine.
+func validateChassisClusterIdentitiesAST(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+	emit := func(what, token string) error {
+		msg := fmt.Sprintf(
+			"chassis cluster %s %q is not a valid non-negative integer id; a "+
+				"malformed identity silently defaults to 0 and aliases "+
+				"redundancy-group / node 0, mis-assigning cluster ownership — use "+
+				"a numeric id (#5694)", what, token)
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+	// validID mirrors compileChassis's Atoi-then-default: a token that Atoi
+	// accepts as a non-negative integer is what compileChassis reads; anything
+	// else (non-numeric, empty, or negative) collapses to the zero default and
+	// aliases id 0.
+	validID := func(tok string) bool {
+		n, err := strconv.Atoi(tok)
+		return err == nil && n >= 0
+	}
+	walkErr := forEachChild(nodes, "chassis", func(chassis *Node) error {
+		return forEachChild(chassis.Children, "cluster", func(cluster *Node) error {
+			for _, rgInst := range namedInstances(cluster.FindChildren("redundancy-group")) {
+				if !validID(rgInst.name) {
+					if err := emit("redundancy-group", rgInst.name); err != nil {
+						return err
+					}
+				}
+				// The RG-scoped `node <id>` identity (nested `node { ... }` or
+				// the packed one-liner `node 0 priority <v>`; compileChassis
+				// reads both via nodeVal(child) on a `node` CHILD).
+				for _, child := range rgInst.node.Children {
+					if child.Name() != "node" {
+						continue
+					}
+					if v := nodeVal(child); v != "" && !validID(v) {
+						if err := emit("redundancy-group node", v); err != nil {
+							return err
+						}
+					}
+				}
+			}
+			return nil
+		})
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return warnings, nil
+}

--- a/pkg/config/compiler_chassis_identity_5694_test.go
+++ b/pkg/config/compiler_chassis_identity_5694_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5694 (codex-182 M15): a malformed chassis-cluster
+// redundancy-group / per-RG node IDENTITY parsed to a DEFAULT of 0 in
+// compileChassis (`rgID := 0; if n, err := Atoi(name); err == nil { rgID = n }`,
+// same for the RG-scoped `node <id>`), so a non-numeric identity silently
+// aliased a valid id 0 and mis-assigned cluster ownership / priority instead of
+// being rejected. The sibling validateChassisClusterStrict only sees the
+// COMPILED int (already collapsed to 0, which passes its 0..255 range check), so
+// the new gate validateChassisClusterIdentitiesAST runs on the RAW AST and
+// REJECTS a malformed identity at strict commit / WARNS on tolerant load.
+//
+// The TOP-LEVEL `chassis cluster node <id>` is a typed value leaf
+// (ValidateInteger(0,1)) already rejected by SchemaValidate, so it is out of
+// scope for this gate (covered by TestChassisIdentity5694_TopLevelNodeSchema).
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath (flatTreeFromSets),
+// never NewParser (CLAUDE.md "Testing flat set syntax").
+//
+// FAIL-ON-REVERT: drop the validateChassisClusterIdentitiesAST call from
+// runPreWalkGates (or make validID always return true) and the malformed
+// configs compile clean — the reject assertions below go RED.
+
+// TestChassisIdentity5694_MalformedRejectedAtCommit proves a malformed RG id or
+// per-RG node id is hard-rejected at strict commit, naming the bad token.
+func TestChassisIdentity5694_MalformedRejectedAtCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		want string // substring expected in the commit error (the bad token)
+	}{
+		{
+			name: "non-numeric redundancy-group id",
+			cmds: []string{"set chassis cluster redundancy-group reth0 node 0 priority 100"},
+			want: `"reth0"`,
+		},
+		{
+			name: "alpha redundancy-group id",
+			cmds: []string{"set chassis cluster redundancy-group primary node 0 priority 100"},
+			want: `"primary"`,
+		},
+		{
+			name: "non-numeric per-RG node id",
+			cmds: []string{"set chassis cluster redundancy-group 1 node one priority 100"},
+			want: `"one"`,
+		},
+		{
+			// A negative per-RG node id is caught ONLY by this gate (there is no
+			// node-id range check elsewhere; the strict RG-id gate would catch a
+			// negative RG id, so a node id is the clean pure-new-coverage case).
+			name: "negative per-RG node id",
+			cmds: []string{"set chassis cluster redundancy-group 1 node -1 priority 100"},
+			want: `"-1"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, tc.cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a malformed chassis identity (coerced to 0); want reject")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error should name the bad identity token %s: %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "chassis cluster") {
+				t.Fatalf("error should scope to chassis cluster: %v", err)
+			}
+		})
+	}
+}
+
+// TestChassisIdentity5694_ValidCommits guards against a false-reject: a valid
+// redundancy-group 0 (the id the bug aliased) AND a positive id, with valid
+// node ids, must all commit clean.
+func TestChassisIdentity5694_ValidCommits(t *testing.T) {
+	cases := [][]string{
+		// RG 0 is a legitimate id — must NOT be rejected just because 0 is also
+		// the malformed-token default.
+		{"set chassis cluster redundancy-group 0 node 0 priority 100",
+			"set chassis cluster redundancy-group 0 node 1 priority 1"},
+		// Positive RG id + both node ids.
+		{"set chassis cluster redundancy-group 1 node 0 priority 200",
+			"set chassis cluster redundancy-group 1 node 1 priority 100"},
+		// An RG with no per-RG node stanza at all.
+		{"set chassis cluster redundancy-group 2"},
+	}
+	for _, cmds := range cases {
+		tree := flatTreeFromSets(t, cmds...)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig rejected a valid chassis identity: %v (cmds=%v)", err, cmds)
+		}
+	}
+}
+
+// TestChassisIdentity5694_MalformedLenientWarns proves the tolerant load /
+// peer-sync path WARNS (does not error) on a malformed identity, so an
+// already-persisted or peer-synced config an older binary silently accepted
+// still boots (#1960).
+func TestChassisIdentity5694_MalformedLenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, "set chassis cluster redundancy-group reth0 node 0 priority 100")
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a malformed identity (want warn): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "reth0") && strings.Contains(w, "chassis cluster") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile produced no malformed-identity warning; got %v", cfg.Warnings)
+	}
+}
+
+// TestChassisIdentity5694_PackedOneLinerCovered proves the AST gate catches the
+// hierarchical packed one-liner `node <id> priority <v>;` shape that the schema
+// walker bypasses (the known residual noted in docs/config-schema.md) — a
+// malformed node id there still Atoi-coerces to 0 in compileChassis.
+func TestChassisIdentity5694_PackedOneLinerCovered(t *testing.T) {
+	tree := hierTree(t, `chassis {
+    cluster {
+        redundancy-group 1 {
+            node foo priority 100;
+        }
+    }
+}`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("packed one-liner malformed node id must be rejected by the AST gate")
+	}
+	if !strings.Contains(err.Error(), "foo") {
+		t.Fatalf("error should name the bad node token: %v", err)
+	}
+}
+
+// TestChassisIdentity5694_TopLevelNodeSchema documents that the top-level
+// `chassis cluster node <id>` is already rejected by the schema value-leaf gate
+// (ValidateInteger(0,1)), so the AST identity gate deliberately does not
+// re-check it.
+func TestChassisIdentity5694_TopLevelNodeSchema(t *testing.T) {
+	tree := flatTreeFromSets(t, "set chassis cluster node foo")
+	if err := SchemaValidate(tree, nil); err == nil {
+		t.Fatal("top-level chassis cluster node foo must be rejected by SchemaValidate")
+	}
+}

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -461,6 +461,25 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 		return nil, err
 	}
 
+	// #5694 (codex-182 M15) chassis-cluster identity gate. compileChassis parses
+	// a `redundancy-group <name>` instance id and a per-RG `node <id>` with
+	// strconv.Atoi and, on parse failure, LEAVES the field at its zero default —
+	// a non-numeric identity silently becomes redundancy-group / node 0,
+	// aliasing a valid id 0 and mis-assigning cluster ownership / priority. The
+	// schema leaves these instance-name slots unvalidated (schema_chassis.go);
+	// the top-level `cluster node <id>` value leaf is already schema-typed.
+	// Strict (commit / commit-check): the first malformed identity hard-rejects
+	// naming the token. Lenient (load / peer-sync): warn so an already-persisted
+	// or peer-synced config an older binary silently accepted still BOOTS
+	// (#1960). Runs on the raw AST because the malformed token has collapsed to
+	// 0 by the time the typed ClusterConfig exists — only the AST distinguishes
+	// a malformed token from a real 0.
+	chassisIdentityWarnings, err := validateChassisClusterIdentitiesAST(
+		tree.Children, opts.lenientChassisClusterIdentities)
+	if err != nil {
+		return nil, err
+	}
+
 	var warnings []string
 	warnings = append(warnings, ctrlCharWarnings...)
 	warnings = append(warnings, trackWarnings...)
@@ -487,5 +506,6 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	warnings = append(warnings, dnatToScopeWarnings...)
 	warnings = append(warnings, natMixedScopeWarnings...)
 	warnings = append(warnings, unitAliasWarnings...)
+	warnings = append(warnings, chassisIdentityWarnings...)
 	return warnings, nil
 }


### PR DESCRIPTION
Closes #5694.

## Root

`compileChassis` (`pkg/config/compiler_system.go`) parses a `redundancy-group <name>` instance id and a per-RG `node <id>` with `strconv.Atoi` and, on parse **failure**, leaves the field at its **zero default**:

```go
rgID := 0
if n, err := strconv.Atoi(rgInst.name); err == nil { rgID = n }
```

A non-numeric or negative identity (a typo like `redundancy-group reth0` or `node one`) skips the assignment and is silently built as **redundancy-group / node 0**, aliasing a valid id 0 and mis-assigning cluster ownership / priority instead of being rejected. codex-review-182 finding **M15**.

The sibling `validateChassisClusterStrict` only inspects the **compiled int**, which has already collapsed to 0 and passes its `0..255` range check — it cannot distinguish a malformed token from a real 0. Only the **raw AST** still carries the original token.

## Fix

Add `validateChassisClusterIdentitiesAST` — an **AST pre-walk** gate in `runPreWalkGates` (new file `pkg/config/compiler_chassis_identity.go`), mirroring `validateApplicationNameCollisionsAST` and the other reject-at-commit AST gates — that validates the raw `redundancy-group` and RG-scoped `node` identity tokens are well-formed non-negative integers.

- **Strict** (commit / commit-check): first malformed identity hard-rejects, naming the token.
- **Lenient** (load / peer-sync, `lenientChassisClusterIdentities`): warn so an already-persisted or peer-synced config an older binary accepted still boots (#1960).

**Scope** is the two INSTANCE-NAME identity slots the schema explicitly leaves unvalidated (`schema_chassis.go`). The top-level `chassis cluster node <id>` is a typed value leaf (`ValidateInteger(0,1)`) already rejected by `SchemaValidate`, so it is intentionally not re-checked. Being an AST walk, the gate also covers the hierarchical packed one-liner `node <id> priority <v>;` shape the schema walker bypasses.

## Pure config-layer

This is a **commit-time config-parse validation** change — `pkg/config` only. It does **NOT** touch the `pkg/cluster` runtime state machine / VRRP / session-sync / failover path, so it needs no `test-failover`.

## Validation — fail-on-revert (`compiler_chassis_identity_5694_test.go`)

Built via `ParseSetCommand` + `SetPath` (never `NewParser`).

- `redundancy-group reth0` / `redundancy-group primary` / per-RG `node one` / per-RG `node -1` → **rejected** at strict commit, naming the token.
- Valid `redundancy-group 0` (the aliased id), positive ids, and both node ids → **commit clean** (no false-reject).
- The tolerant path **warns** instead of erroring.
- The hierarchical packed one-liner `node foo priority 100;` → **rejected** (covered).

Proven **RED-on-revert**: neutering the identity check makes every malformed config compile clean; the four malformed cases + the lenient-warn case go RED. Full `pkg/config` suite (incl. existing chassis/cluster tests) and `go build ./...` pass.

Provenance: codex-review-182 M15. Distinct from `validateChassisClusterStrict` (#4434, semantic RG count/id-range on the compiled int).

🤖 Generated with [Claude Code](https://claude.com/claude-code)