### PR TITLE
config: reject duplicate IPsec traffic-selector local-ip/remote-ip (M13)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-12 — #5692 (bug): reject duplicate IPsec traffic-selector local-ip/remote-ip leaves
+- **Timestamp**: 2026-07-12 (fix/5692-ipsec-selector-accumulate)
+- **Action**: codex-review-182 M13. Repeated valid `traffic-selector <ts>
+  local-ip`/`remote-ip` leaves under ONE selector pass the #4098 admission gate
+  (each is a well-formed CIDR) but the typed compiler (compiler_ipsec.go
+  traffic-selector loop) reads them last-wins, silently dropping every prefix
+  but the last. Confirmed the AST behavior: the hierarchical / load-merge /
+  HA-config-sync parse path KEEPS the repeated sibling leaves (admission
+  validates all, compile truncates), while the flat-set commit path collapses
+  them last-wins in SetPath (Junos "set replaces" for a single-value leaf — no
+  duplicate ever reaches the compiler). DECISION: REJECT, not accumulate —
+  Junos models each traffic-selector as exactly one local-ip + one remote-ip
+  (schema_security.go documents the LEAF-COMPLETE single-value grammar), and
+  multiple prefixes are the Junos way expressed as separate NAMED
+  traffic-selectors (already accumulated into the map + rendered as separate
+  swanctl children by effectiveTrafficSelectors). Accumulating would invent a
+  non-Junos multi-value local-ip AND diverge flat-set (SetPath-collapsed to
+  last) from hierarchical (accumulated), breaking the dual-AST-identical
+  contract. Extended validateIPsecTrafficSelectorsStrict to count local-ip /
+  remote-ip VALUES per selector (via the same trafficSelectorValues the #4098
+  gate uses) and reject when > 1 — strict commit / commit-check, lenient-warn on
+  load/peer-sync (#1960; the compiler's last-wins keeps a leniently-loaded dup
+  inert, now flagged). Fail-on-revert proven: neutering the value-count reject
+  makes the hierarchical dup tests go RED; flat-set last-wins + multi-named
+  selectors still compile.
+- **File(s)**: pkg/config/compiler_ipsec_trafficselector.go,
+  pkg/config/compiler_ipsec_ts_dup_5692_test.go, pkg/ipsec/README.md
+
 ## 2026-07-12 — #5694 (bug): reject malformed chassis RG/node identities at commit (alias-to-0)
 - **Timestamp**: 2026-07-12 (fix/5694-chassis-identity-validate)
 - **Action**: codex-review-182 M15. compileChassis parses a

--- a/pkg/config/compiler_ipsec_trafficselector.go
+++ b/pkg/config/compiler_ipsec_trafficselector.go
@@ -6,8 +6,12 @@ import (
 	"strings"
 )
 
-// compiler_ipsec_trafficselector.go carries the #4098 reject-at-commit gate
-// for IPsec `traffic-selector local-ip / remote-ip` values.
+// compiler_ipsec_trafficselector.go carries two reject-at-commit gates for
+// IPsec `traffic-selector local-ip / remote-ip` values, both in
+// validateIPsecTrafficSelectorsStrict: the #4098 swanctl-injection value gate
+// (below) and the #5692 duplicate-selector gate (repeated local-ip / remote-ip
+// leaves under one traffic-selector pass admission but the compiler keeps only
+// the last — see the inline note at the value-count loop).
 //
 // The defect: `security ipsec vpn <name> traffic-selector <ts> local-ip` and
 // `remote-ip` are free-form 1-arg strings (schema_security.go). The IPsec
@@ -78,12 +82,30 @@ func validateIPsecTrafficSelectorsStrict(nodes []*Node, lenient bool) ([]string,
 		return forEachChild(security.Children, "ipsec", func(ipsec *Node) error {
 			for _, vpnInst := range namedInstances(ipsec.FindChildren("vpn")) {
 				for _, tsInst := range namedInstances(vpnInst.node.FindChildren("traffic-selector")) {
+					// #5692: count local-ip / remote-ip VALUES across all such
+					// leaves in the selector. Junos models each as a SINGLE-value
+					// leaf (schema_security.go: the traffic-selector grammar is
+					// exactly one `local-ip <prefix>` and one `remote-ip <prefix>`),
+					// but the hierarchical / load-merge / HA-config-sync parse path
+					// keeps REPEATED sibling leaves (the flat-set path collapses them
+					// last-wins in SetPath). The typed compiler
+					// (compiler_ipsec.go traffic-selector loop) reads them last-wins
+					// too, so every prefix but the last is SILENTLY dropped — even
+					// though each passed this admission gate. Reject so the operator
+					// sees the truncation instead of a selector that enforces only
+					// its last prefix. Multiple prefixes are expressed the Junos way,
+					// as SEPARATE named traffic-selectors (each renders its own
+					// swanctl child — effectiveTrafficSelectors), which are already
+					// accumulated correctly.
+					valueCounts := map[string]int{}
 					for _, leaf := range tsInst.node.Children {
 						leafName := leaf.Name()
 						if leafName != "local-ip" && leafName != "remote-ip" {
 							continue
 						}
-						for _, val := range trafficSelectorValues(leaf) {
+						vals := trafficSelectorValues(leaf)
+						valueCounts[leafName] += len(vals)
+						for _, val := range vals {
 							if reason := trafficSelectorValueReject(val); reason != "" {
 								if err := emit(
 									"security ipsec vpn %q traffic-selector %q %s %q %s "+
@@ -97,6 +119,23 @@ func validateIPsecTrafficSelectorsStrict(nodes []*Node, lenient bool) ([]string,
 								); err != nil {
 									return err
 								}
+							}
+						}
+					}
+					// Deterministic leaf order for the first-error (strict) path.
+					for _, leafName := range []string{"local-ip", "remote-ip"} {
+						if valueCounts[leafName] > 1 {
+							if err := emit(
+								"security ipsec vpn %q traffic-selector %q specifies %d %s "+
+									"prefixes, but Junos allows exactly ONE %s per "+
+									"traffic-selector; the compiler keeps only the LAST and "+
+									"silently drops the earlier prefix(es) even though each "+
+									"passed admission — express multiple prefixes as separate "+
+									"named traffic-selectors (each renders its own SA child), "+
+									"#5692",
+								vpnInst.name, tsInst.name, valueCounts[leafName], leafName, leafName,
+							); err != nil {
+								return err
 							}
 						}
 					}

--- a/pkg/config/compiler_ipsec_ts_dup_5692_test.go
+++ b/pkg/config/compiler_ipsec_ts_dup_5692_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5692: repeated valid IPsec traffic-selector `local-ip` / `remote-ip` leaves
+// under ONE traffic-selector pass strict admission (each is a well-formed CIDR),
+// but the typed compiler (compiler_ipsec.go traffic-selector loop) reads them
+// LAST-WINS, silently dropping every prefix but the last — a multi-selector
+// policy that enforces only its last prefix. The hierarchical / load-merge /
+// HA-config-sync parse path keeps the repeated sibling leaves (the flat-set
+// commit path collapses them last-wins in SetPath, matching Junos "set
+// replaces" for a single-value leaf, so it never produces the duplicate).
+//
+// Junos models each traffic-selector as exactly ONE local-ip + ONE remote-ip;
+// multiple prefixes are expressed as separate NAMED traffic-selectors (each
+// renders its own swanctl SA child). validateIPsecTrafficSelectorsStrict now
+// REJECTS a duplicate at strict commit / commit-check (lenient-warn on load /
+// peer-sync, #1960) so the truncation is operator-visible.
+
+// TestTrafficSelectorDuplicateLocalIPRejectedStrict_5692 is the primary
+// fail-on-revert guard: a hierarchical traffic-selector with TWO local-ip
+// leaves is rejected at strict commit.
+//
+// FAIL-ON-REVERT: removing the #5692 value-count reject loop from
+// validateIPsecTrafficSelectorsStrict makes CompileConfig accept the duplicate
+// (silently keeping only the last local-ip), so this reject assertion fires RED.
+func TestTrafficSelectorDuplicateLocalIPRejectedStrict_5692(t *testing.T) {
+	tree := hierTree(t, `security {
+    ipsec {
+        vpn v1 {
+            traffic-selector ts1 {
+                local-ip 10.0.0.0/24;
+                local-ip 10.0.1.0/24;
+                remote-ip 192.0.2.0/24;
+            }
+        }
+    }
+}`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a traffic-selector with two local-ip leaves; want a strict reject (#5692)")
+	}
+	if !strings.Contains(err.Error(), "local-ip prefixes") || !strings.Contains(err.Error(), "ts1") {
+		t.Fatalf("reject error %q must name the selector and the duplicate local-ip", err.Error())
+	}
+}
+
+// TestTrafficSelectorDuplicateRemoteIPRejectedStrict_5692 is the remote-ip
+// symmetric.
+func TestTrafficSelectorDuplicateRemoteIPRejectedStrict_5692(t *testing.T) {
+	tree := hierTree(t, `security {
+    ipsec {
+        vpn v1 {
+            traffic-selector ts1 {
+                local-ip 10.0.0.0/24;
+                remote-ip 192.0.2.0/24;
+                remote-ip 198.51.100.0/24;
+            }
+        }
+    }
+}`)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a traffic-selector with two remote-ip leaves; want a strict reject (#5692)")
+	}
+	if !strings.Contains(err.Error(), "remote-ip prefixes") {
+		t.Fatalf("reject error %q must reference the duplicate remote-ip", err.Error())
+	}
+}
+
+// TestTrafficSelectorDuplicateLenientWarns_5692 proves the tolerant load /
+// peer-sync path DOWNGRADES the duplicate to a warning (no hard fail, #1960
+// no-brick) — an already-persisted config carrying a duplicate still BOOTS, and
+// the compiler's last-wins keeps it inert (enforces the last, as before, now
+// flagged).
+func TestTrafficSelectorDuplicateLenientWarns_5692(t *testing.T) {
+	tree := hierTree(t, `security {
+    ipsec {
+        vpn v1 {
+            traffic-selector ts1 {
+                local-ip 10.0.0.0/24;
+                local-ip 10.0.1.0/24;
+            }
+        }
+    }
+}`)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant load must NOT hard-fail on a duplicate selector, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "local-ip prefixes") && strings.Contains(w, "ts1") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("tolerant load must record a duplicate-selector warning, got %v", cfg.Warnings)
+	}
+	// The compiler keeps the LAST prefix (unchanged runtime behavior).
+	if got := cfg.Security.IPsec.VPNs["v1"].TrafficSelectors["ts1"].LocalIP; got != "10.0.1.0/24" {
+		t.Fatalf("compiler must keep the last local-ip, got %q", got)
+	}
+}
+
+// TestTrafficSelectorMultipleNamedSelectorsCompile_5692 proves the Junos-correct
+// way to express multiple selectors — separate NAMED traffic-selectors, each
+// with one local-ip/remote-ip — compiles clean via flat set, and BOTH are
+// accumulated (not truncated).
+func TestTrafficSelectorMultipleNamedSelectorsCompile_5692(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set security ipsec vpn v1 traffic-selector ts1 local-ip 10.0.0.0/24",
+		"set security ipsec vpn v1 traffic-selector ts1 remote-ip 192.0.2.0/24",
+		"set security ipsec vpn v1 traffic-selector ts2 local-ip 10.0.1.0/24",
+		"set security ipsec vpn v1 traffic-selector ts2 remote-ip 198.51.100.0/24",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("two named traffic-selectors must compile, got %v", err)
+	}
+	sel := cfg.Security.IPsec.VPNs["v1"].TrafficSelectors
+	if len(sel) != 2 {
+		t.Fatalf("expected 2 named traffic-selectors, got %d", len(sel))
+	}
+	if sel["ts1"].LocalIP != "10.0.0.0/24" || sel["ts2"].LocalIP != "10.0.1.0/24" {
+		t.Fatalf("both named selectors must be accumulated, got ts1=%q ts2=%q", sel["ts1"].LocalIP, sel["ts2"].LocalIP)
+	}
+}
+
+// TestTrafficSelectorFlatSetLastWinsCompiles_5692 proves the fix does NOT
+// false-reject the normal commit path: repeated flat-set `local-ip` lines
+// collapse last-wins in SetPath (Junos "set replaces" for a single-value leaf),
+// so the AST carries only ONE local-ip and the duplicate gate does not fire.
+func TestTrafficSelectorFlatSetLastWinsCompiles_5692(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set security ipsec vpn v1 traffic-selector ts1 local-ip 10.0.0.0/24",
+		"set security ipsec vpn v1 traffic-selector ts1 local-ip 10.0.1.0/24",
+		"set security ipsec vpn v1 traffic-selector ts1 remote-ip 192.0.2.0/24",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("flat-set last-wins must still compile (SetPath collapsed the duplicate), got %v", err)
+	}
+	if got := cfg.Security.IPsec.VPNs["v1"].TrafficSelectors["ts1"].LocalIP; got != "10.0.1.0/24" {
+		t.Fatalf("flat-set last-wins local-ip = %q, want 10.0.1.0/24", got)
+	}
+}

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -145,6 +145,20 @@ all files stay in `package ipsec`, so the public API is unchanged.
 - Traffic selectors are auto-derived from the policy source / destination
   prefixes when not given explicitly. Mixing explicit and derived
   selectors is supported but the explicit set wins.
+- **One `local-ip` / `remote-ip` per traffic-selector (#5692).** Each named
+  `traffic-selector` carries exactly ONE `local-ip` and ONE `remote-ip`
+  prefix — express multiple prefixes as separate NAMED traffic-selectors
+  (`effectiveTrafficSelectors` renders each as its own swanctl SA child).
+  Repeated `local-ip` / `remote-ip` leaves under one selector survive the
+  hierarchical / load-merge / HA-config-sync parse path (the flat-set commit
+  path collapses them last-wins in `SetPath`, matching Junos "set replaces"),
+  and the typed compiler (`compiler_ipsec.go`) reads them last-wins too —
+  silently dropping every prefix but the last even though each passes the
+  #4098 value gate. `validateIPsecTrafficSelectorsStrict`
+  (`pkg/config/compiler_ipsec_trafficselector.go`) now REJECTS a duplicate at
+  strict commit / commit-check (lenient-warn on load / peer-sync, #1960) so
+  the truncation is operator-visible instead of a selector that enforces only
+  its last prefix.
 - **DPD (dead-peer detection).** A `dead-peer-detection` stanza on an IKE
   gateway is compiled by `parseDeadPeerDetectionNode` (`pkg/config`
   `compiler_ipsec.go`) into `gw.DPDEnable` + mode/interval/threshold, and


### PR DESCRIPTION
## Problem

A named `traffic-selector <ts>` models exactly ONE `local-ip` and ONE `remote-ip` prefix — multiple prefixes are the Junos way expressed as separate **named** traffic-selectors, each rendering its own swanctl SA child (`effectiveTrafficSelectors`). But repeated `local-ip` / `remote-ip` leaves under a **single** traffic-selector **pass the #4098 admission gate** (each is a well-formed CIDR) and are then read **last-wins** by the typed compiler (`compiler_ipsec.go` traffic-selector loop), silently dropping every prefix but the last — a multi-selector policy that enforces only its last prefix (codex-review-182 M13).

**Confirmed the AST behavior differs by parser shape:**
- **Hierarchical / load-merge / HA-config-sync** path KEEPS the repeated sibling leaves → admission validates all, compilation truncates to the last.
- **Flat-set commit** path collapses them last-wins in `SetPath` (Junos "set replaces" for a single-value leaf) → no duplicate ever reaches the compiler there.

## Decision: REJECT (not accumulate)

Junos models each traffic-selector as a single `local-ip` + single `remote-ip` (`schema_security.go` documents the LEAF-COMPLETE single-value grammar), so a duplicate is **genuinely invalid**. Accumulating into a strongSwan comma-list would:
1. Invent a **non-Junos** multi-value `local-ip` semantics, and
2. **Diverge** the flat-set shape (SetPath-collapsed to the last value — nothing to accumulate) from the hierarchical shape (would accumulate) — breaking the dual-AST-identical compile contract.

The Junos-correct multiple-selector mechanism (separate **named** traffic-selectors) already works — each is accumulated into the map and rendered as its own swanctl child.

## Fix

`validateIPsecTrafficSelectorsStrict` (`pkg/config/compiler_ipsec_trafficselector.go`) now counts the `local-ip` / `remote-ip` VALUES per selector (via the same `trafficSelectorValues` the #4098 gate uses, so a repeated leaf **or** a single-leaf multi-value are both covered) and rejects when a family has more than one — **strict** on commit / commit-check, downgraded to a **warning** on the tolerant load / peer-sync path (#1960; the compiler's last-wins keeps a leniently-loaded duplicate inert, now flagged). The error tells the operator to use separate named traffic-selectors.

## Fix site

- `pkg/config/compiler_ipsec_trafficselector.go` — value-count reject loop added to `validateIPsecTrafficSelectorsStrict` (inside the per-selector walk that already backs the #4098 injection gate).

## Tests (fail-on-revert, both AST shapes)

`pkg/config/compiler_ipsec_ts_dup_5692_test.go`:
- `TestTrafficSelectorDuplicateLocalIPRejectedStrict_5692` / `_DuplicateRemoteIPRejectedStrict_5692` — hierarchical config with two `local-ip` / `remote-ip` leaves → **rejected** at strict commit (error names the selector + duplicate).
- `TestTrafficSelectorDuplicateLenientWarns_5692` — tolerant load **warns**, doesn't fail; compiler keeps the last prefix.
- `TestTrafficSelectorMultipleNamedSelectorsCompile_5692` — the Junos-correct way (two named selectors) compiles, both accumulated.
- `TestTrafficSelectorFlatSetLastWinsCompiles_5692` — flat-set repeated `local-ip` collapses in SetPath → no false reject (normal commit path unaffected).

**Fail-on-revert proven:** neutering the value-count reject makes the hierarchical duplicate + lenient-warn tests go **RED**, while the flat-set last-wins and multi-named-selector paths still compile. `go build ./...` and `go test ./pkg/config/... ./pkg/ipsec/...` are green.

## Docs

`pkg/ipsec/README.md` (traffic-selector section) + `_Log.md`.

Closes #5692

🤖 Generated with [Claude Code](https://claude.com/claude-code)