### PR TITLE
dataplane: reconcile base-vs-unit-0 host-inbound view for one address (#5699)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-12 — #5699 (bug): reconcile base-vs-unit-0 host-inbound view for one live address
+- **Timestamp**: 2026-07-12 (fix/5699-baseunit0-hostinbound)
+- **Action**: codex-review-182 M22. A non-VLAN unit 0 collapses onto the base
+  netdev (ge-0/0/0.0 → Linux ge-0-0-0), so the base-interface snapshot and the
+  unit-0 snapshot enumerate the SAME live kernel address via buildLinkSnapshot.
+  BuildZoneHostInboundViews groups addresses by (zone, effective-token sig); the
+  base ref keys the address under overrideByIface[base] (physical-level override
+  only) while unit 0 keys it under overrideByIface[base.0] (base ∪ unit-0 merged,
+  #3720). A per-interface host-inbound override on the unit-0 ref made the two
+  sigs diverge, emitting the SINGLE live address into TWO views with conflicting
+  admit sets — the kernel host-inbound chain matches destination address only, so
+  the verdict is order-dependent (deterministic false-deny of the service the
+  unit-0 override opened). Fix (pkg/dataplane/userspace/zones_host_inbound.go):
+  skip the base (physical, no-dot) snapshot's host-inbound address contribution
+  when unit 0 is configured — unit 0 is the authoritative carrier (its merged
+  override matches enforcement + InterfaceHostInboundEffective), so the address
+  resolves to ONE view with the additive zone∪physical∪unit-0 set. PRECEDENCE:
+  unit-0 (merged) wins — the Junos-additive answer. Kept base as sole carrier
+  only when no unit 0 exists (never fail-open). Made buildLinkSnapshot a package
+  var (interfaces.go) so the view builder is unit-testable with an injected base
+  address (the conflict only manifests when the base netdev carries the live
+  addr). Scope: pkg/dataplane/userspace (go dataplane manager / view builder) —
+  NOT config-layer, NOT the daemon nft emission, NOT cluster/VRRP/failover.
+  Fail-on-revert proven (address in 2 conflicting views RED without the skip).
+  Full pkg/dataplane/userspace + pkg/config suites green.
+- **File(s)**: pkg/dataplane/userspace/zones_host_inbound.go,
+  pkg/dataplane/userspace/interfaces.go,
+  pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go,
+  docs/host-inbound-service-matrix.md
+
 ## 2026-07-12 — #5692 (bug): reject duplicate IPsec traffic-selector local-ip/remote-ip leaves
 - **Timestamp**: 2026-07-12 (fix/5692-ipsec-selector-accumulate)
 - **Action**: codex-review-182 M13. Repeated valid `traffic-selector <ts>

--- a/_Log.md
+++ b/_Log.md
@@ -23,6 +23,19 @@
   NOT config-layer, NOT the daemon nft emission, NOT cluster/VRRP/failover.
   Fail-on-revert proven (address in 2 conflicting views RED without the skip).
   Full pkg/dataplane/userspace + pkg/config suites green.
+- **Timestamp**: 2026-07-12 (fix/5699 review fold — VLAN unit-0 fail-open)
+- **Action**: PR #5736 review MINOR: the first-cut skip guard fired whenever
+  unit 0 merely EXISTS, but the base↔unit-0 address collapse happens ONLY for a
+  same-netdev unit 0. A VLAN unit 0 (VlanID>0 → Linux <base>.<vlan>) or a
+  tunnel-mapped unit 0 is a DISTINCT netdev, so base and unit-0 enumerate
+  DISJOINT addresses — skipping the base there dropped the base netdev's own
+  live address from all host-inbound views → kernel input falls through to
+  policy accept (FAIL-OPEN). Refined the guard to skip ONLY when
+  snapshotLinuxName(base, unit0) == snapshotLinuxName(base, nil) (the base
+  snapshot's own LinuxName), i.e. base and unit-0 are literally the same kernel
+  device — provably correct for VLAN/tunnel/reth/plain by construction. Added
+  TestHostInboundVlanUnit0KeepsBaseAddress_5699 (base addr stays deny-scoped;
+  RED against the over-firing guard) + TestHostInboundNoUnit0KeepsBase_5699.
 - **File(s)**: pkg/dataplane/userspace/zones_host_inbound.go,
   pkg/dataplane/userspace/interfaces.go,
   pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go,

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -418,6 +418,27 @@ operator diagnostic agrees with what the dataplane admits. Before #3720 it read
 only the exact ref and reported "no override / default-deny" for a unit that in
 fact inherited a physical override.
 
+**Base-vs-unit-0 single-address reconciliation (#5699).** A non-VLAN unit 0
+collapses onto the base netdev (`ge-0/0/0.0` → Linux `ge-0-0-0`), so the base
+interface snapshot and the unit-0 snapshot (`buildInterfaceSnapshots`) enumerate
+the IDENTICAL live kernel address through `buildLinkSnapshot`. `BuildZoneHostInboundViews`
+groups addresses by `(zone, effective-token signature)`, and the base ref keys
+its copy under `overrideByIface[ifN]` (physical-level override only) while unit 0
+keys the same address under `overrideByIface[ifN.0]` (the base ∪ unit-0 merged
+override above). A per-interface override on the **unit-0** ref therefore made
+the two signatures diverge, emitting the SINGLE live address into TWO
+host-inbound views with conflicting admit sets. Because the kernel
+`xpf_hostinbound` chain matches destination address only (no ingress-interface
+predicate), whichever view's rule block sorts first decides — a deterministic
+false-deny (the base view's narrower set drops a service the unit-0 override
+opened). The fix skips the base (physical) snapshot's host-inbound address
+contribution when unit 0 is configured: unit 0's snapshot is the authoritative
+carrier (its merged override matches enforcement and `InterfaceHostInboundEffective`),
+so the address resolves to ONE view carrying the additive `zone ∪ physical ∪
+unit-0` admit set. The base snapshot is kept as the sole carrier only when the
+interface has no unit 0 (rare bootstrap / DHCP-on-raw-netdev), so an address is
+never dropped from the deny scope (never fail-open).
+
 **Gate alignment.** The commit-time duplicate-address gate
 (`buildHostInboundOverrideMapLocal` +
 `validateDuplicateHostLocalAddressStrict`, `pkg/config/dup_host_local_address.go`)

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -435,9 +435,16 @@ opened). The fix skips the base (physical) snapshot's host-inbound address
 contribution when unit 0 is configured: unit 0's snapshot is the authoritative
 carrier (its merged override matches enforcement and `InterfaceHostInboundEffective`),
 so the address resolves to ONE view carrying the additive `zone ∪ physical ∪
-unit-0` admit set. The base snapshot is kept as the sole carrier only when the
-interface has no unit 0 (rare bootstrap / DHCP-on-raw-netdev), so an address is
-never dropped from the deny scope (never fail-open).
+unit-0` admit set. The skip is gated on the ACTUAL same-netdev collapse
+(`snapshotLinuxName(base, unit0) == snapshotLinuxName(base, nil)`), NOT merely
+"unit 0 exists": a VLAN unit 0 (`VlanID > 0` → Linux `<base>.<vlan>`) or a
+tunnel-mapped unit 0 resolves to a DISTINCT netdev, so the base and unit-0
+snapshots enumerate DISJOINT addresses — skipping the base there would drop the
+base netdev's own live address from every view and the kernel input chain would
+fall through to `policy accept` (FAIL-OPEN). The base snapshot is kept as the
+sole carrier both for a VLAN/tunnel unit 0 (distinct netdev) and for an
+interface with no unit 0 at all (rare bootstrap / DHCP-on-raw-netdev), so an
+address is never dropped from the deny scope.
 
 **Gate alignment.** The commit-time duplicate-address gate
 (`buildHostInboundOverrideMapLocal` +

--- a/pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go
+++ b/pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go
@@ -1,0 +1,101 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestHostInboundBaseUnit0NoConflict_5699 is the #5699 (codex-182 M22)
+// fail-on-revert guard. A non-VLAN unit 0 collapses onto the base netdev
+// (ge-0/0/0.0 → Linux ge-0-0-0), so the base-interface snapshot and the unit-0
+// snapshot enumerate the IDENTICAL live kernel address. The base ref keys that
+// address under overrideByIface[base] (base-level override only) while unit 0
+// keys it under overrideByIface[base.0] (base ∪ unit-0 override). A
+// per-interface host-inbound override on the unit-0 ref therefore made the two
+// signatures diverge, emitting the SINGLE live address into TWO host-inbound
+// views with conflicting admit sets — the kernel host-inbound chain matches
+// destination address only, so the verdict is order-dependent (deterministic
+// false-deny).
+//
+// The fix skips the base's redundant contribution when unit 0 exists, so the
+// address resolves to ONE view carrying the unit-0-authoritative (base ∪
+// unit-0) admit set.
+//
+// The base snapshot's addresses come only from the LIVE kernel
+// (buildLinkSnapshot), which returns nothing in a test env — so the conflict is
+// invisible unless the base netdev actually carries the address. This test
+// injects that via the buildLinkSnapshot seam to reproduce the deployed-box
+// behavior.
+//
+// FAIL-ON-REVERT: remove the base-snapshot skip in BuildZoneHostInboundViews and
+// the live address appears in TWO views again — the count assertion goes RED.
+func TestHostInboundBaseUnit0NoConflict_5699(t *testing.T) {
+	// Simulate the deployed box: the base netdev ge-0-0-0 (== unit-0 netdev for
+	// a non-VLAN unit 0) carries the configured address live.
+	prev := buildLinkSnapshot
+	defer func() { buildLinkSnapshot = prev }()
+	buildLinkSnapshot = func(linuxName string) (int, int, string, []InterfaceAddressSnapshot) {
+		if linuxName == "ge-0-0-0" {
+			return 2, 1500, "02:00:00:00:00:01", []InterfaceAddressSnapshot{
+				{Family: "inet", Address: "10.0.1.10/24"},
+			}
+		}
+		return 0, 0, "", nil
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.1.10/24"}},
+		}},
+	}
+	// Zone trust admits `ping` at the zone level; the unit-0 ref adds `ssh` via a
+	// per-interface host-inbound override — so base sig (ping) != unit-0 sig
+	// (ping+ssh).
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {
+			Name:               "trust",
+			Interfaces:         []string{"ge-0/0/0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ping"}},
+			InterfaceHostInbound: map[string]*config.HostInboundTraffic{
+				"ge-0/0/0.0": {SystemServices: []string{"ssh"}},
+			},
+		},
+	}
+
+	views := BuildZoneHostInboundViews(cfg)
+
+	var carrying []ZoneHostInboundView
+	for _, v := range views {
+		for _, a := range v.V4Addrs {
+			if a == "10.0.1.10" {
+				carrying = append(carrying, v)
+			}
+		}
+	}
+	if len(carrying) != 1 {
+		t.Fatalf("live address 10.0.1.10 appears in %d host-inbound views, want exactly 1 "+
+			"(the #5699 base-vs-unit-0 conflict); views carrying it: %+v", len(carrying), carrying)
+	}
+	// Precedence: the single view must carry the unit-0-authoritative merged
+	// admit set (zone ping ∪ unit-0 ssh), NOT the base-only (ping) set.
+	got := carrying[0]
+	if !containsAll(got.SystemServices, []string{"ping", "ssh"}) {
+		t.Fatalf("winning view services = %v, want the unit-0 merged set [ping ssh] "+
+			"(unit-0 override must win, not the base-only ping)", got.SystemServices)
+	}
+}
+
+func containsAll(have, want []string) bool {
+	set := make(map[string]bool, len(have))
+	for _, h := range have {
+		set[h] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go
+++ b/pkg/dataplane/userspace/host_inbound_baseunit0_5699_test.go
@@ -87,6 +87,105 @@ func TestHostInboundBaseUnit0NoConflict_5699(t *testing.T) {
 	}
 }
 
+// TestHostInboundVlanUnit0KeepsBaseAddress_5699 guards against an over-firing
+// skip: for a VLAN unit 0 (VlanID>0) the unit resolves to a DISTINCT netdev
+// (ge-0-0-0.100), so the base netdev (ge-0-0-0) and unit-0 enumerate DISJOINT
+// addresses. The base's own live address (e.g. a stray/DHCP addr on the raw
+// netdev) must therefore STILL be deny-scoped — skipping the base here would
+// drop it from every host-inbound view, and the kernel input chain would fall
+// through to `policy accept` (FAIL-OPEN).
+//
+// FAIL-ON-REVERT: a guard that skips the base whenever unit 0 merely EXISTS
+// (`ifc.Units[0] != nil`) drops the base address and this test goes RED.
+func TestHostInboundVlanUnit0KeepsBaseAddress_5699(t *testing.T) {
+	prev := buildLinkSnapshot
+	defer func() { buildLinkSnapshot = prev }()
+	buildLinkSnapshot = func(linuxName string) (int, int, string, []InterfaceAddressSnapshot) {
+		switch linuxName {
+		case "ge-0-0-0": // base raw netdev carries a live (stray/DHCP) address
+			return 2, 1500, "02:00:00:00:00:01", []InterfaceAddressSnapshot{
+				{Family: "inet", Address: "10.0.9.9/24"},
+			}
+		case "ge-0-0-0.100": // the VLAN unit netdev (distinct)
+			return 3, 1500, "02:00:00:00:00:01", nil
+		}
+		return 0, 0, "", nil
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+			// unit 0 is a VLAN unit -> Linux ge-0-0-0.100, a DIFFERENT netdev
+			// from the base ge-0-0-0.
+			0: {Number: 0, VlanID: 100, Addresses: []string{"172.16.100.8/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {
+			Name:               "trust",
+			Interfaces:         []string{"ge-0/0/0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ping"}},
+		},
+	}
+
+	views := BuildZoneHostInboundViews(cfg)
+	var baseScoped bool
+	for _, v := range views {
+		for _, a := range v.V4Addrs {
+			if a == "10.0.9.9" {
+				baseScoped = true
+			}
+		}
+	}
+	if !baseScoped {
+		t.Fatalf("VLAN unit-0 case: the base netdev's live address 10.0.9.9 was DROPPED from all "+
+			"host-inbound views (fail-open) — base and unit-0 are DISJOINT netdevs, the base must "+
+			"stay deny-scoped; views=%+v", views)
+	}
+}
+
+// TestHostInboundNoUnit0KeepsBase_5699 confirms the unchanged behavior: a
+// physical interface with NO unit 0 keeps the base as the sole carrier of its
+// live address (never dropped).
+func TestHostInboundNoUnit0KeepsBase_5699(t *testing.T) {
+	prev := buildLinkSnapshot
+	defer func() { buildLinkSnapshot = prev }()
+	buildLinkSnapshot = func(linuxName string) (int, int, string, []InterfaceAddressSnapshot) {
+		if linuxName == "ge-0-0-0" {
+			return 2, 1500, "02:00:00:00:00:01", []InterfaceAddressSnapshot{
+				{Family: "inet", Address: "10.0.9.9/24"},
+			}
+		}
+		return 0, 0, "", nil
+	}
+
+	cfg := &config.Config{}
+	// No units at all on the physical interface.
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0"},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {
+			Name:               "trust",
+			Interfaces:         []string{"ge-0/0/0"}, // base ref (no unit 0 exists)
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ping"}},
+		},
+	}
+
+	views := BuildZoneHostInboundViews(cfg)
+	var baseScoped bool
+	for _, v := range views {
+		for _, a := range v.V4Addrs {
+			if a == "10.0.9.9" {
+				baseScoped = true
+			}
+		}
+	}
+	if !baseScoped {
+		t.Fatalf("no-unit-0 case: the base netdev's live address 10.0.9.9 must stay deny-scoped; views=%+v", views)
+	}
+}
+
 func containsAll(have, want []string) bool {
 	set := make(map[string]bool, len(have))
 	for _, h := range have {

--- a/pkg/dataplane/userspace/interfaces.go
+++ b/pkg/dataplane/userspace/interfaces.go
@@ -427,7 +427,12 @@ func snapshotLinuxName(cfg *config.Config, ifName string, iface *config.Interfac
 	return config.LinuxIfName(ifName)
 }
 
-func buildLinkSnapshot(linuxName string) (ifindex int, mtu int, hardwareAddr string, addresses []InterfaceAddressSnapshot) {
+// buildLinkSnapshot resolves a kernel interface's live ifindex/MTU/MAC/addresses.
+// It is a package var so the host-inbound view builder (which resolves the base
+// netdev's LIVE addresses through it) is unit-testable without a real kernel
+// interface — the #5699 base-vs-unit-0 double-emission only manifests when the
+// base netdev actually carries the (unit-0-collapsed) live address.
+var buildLinkSnapshot = func(linuxName string) (ifindex int, mtu int, hardwareAddr string, addresses []InterfaceAddressSnapshot) {
 	if linuxName == "" {
 		return 0, 0, "", nil
 	}

--- a/pkg/dataplane/userspace/zones_host_inbound.go
+++ b/pkg/dataplane/userspace/zones_host_inbound.go
@@ -190,6 +190,30 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 		if snap.Zone == "" || hostInboundLifelineInterface(snap.Name, lifelines) {
 			continue
 		}
+		// #5699: a PHYSICAL (no-unit) snapshot whose interface has a unit 0
+		// carries the SAME live netdev addresses as that unit-0 snapshot — a
+		// non-VLAN unit 0 collapses onto the base netdev (snapshotLinuxName), so
+		// buildLinkSnapshot(base) and buildLinkSnapshot(unit0-linux) enumerate
+		// the identical kernel addresses. But the base ref keys them under
+		// overrideByIface[base] (base-level override only), while unit 0 keys
+		// them under overrideByIface[base.0] (base ∪ unit-0 override, the
+		// dataplane-additive #3720 resolution). When a per-interface override on
+		// the unit-0 ref makes those two signatures differ, the SINGLE live
+		// address is emitted into TWO views with conflicting admit sets — the
+		// kernel host-inbound chain matches destination address only, so the
+		// verdict is order-dependent (a deterministic false-deny). Unit 0's view
+		// is the authoritative carrier (its merged override matches enforcement),
+		// so skip the base's redundant contribution. Only when unit 0 exists: a
+		// physical interface with no unit 0 (rare bootstrap/DHCP-on-raw-netdev)
+		// keeps the base as the sole carrier so its address is still deny-scoped
+		// (never fail-open).
+		if !strings.Contains(snap.Name, ".") {
+			if ifc := cfg.Interfaces.Interfaces[snap.Name]; ifc != nil {
+				if _, hasUnit0 := ifc.Units[0]; hasUnit0 {
+					continue
+				}
+			}
+		}
 		zone := cfg.Security.Zones[snap.Zone]
 		if !configured(zone) {
 			continue

--- a/pkg/dataplane/userspace/zones_host_inbound.go
+++ b/pkg/dataplane/userspace/zones_host_inbound.go
@@ -190,26 +190,33 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 		if snap.Zone == "" || hostInboundLifelineInterface(snap.Name, lifelines) {
 			continue
 		}
-		// #5699: a PHYSICAL (no-unit) snapshot whose interface has a unit 0
-		// carries the SAME live netdev addresses as that unit-0 snapshot — a
-		// non-VLAN unit 0 collapses onto the base netdev (snapshotLinuxName), so
-		// buildLinkSnapshot(base) and buildLinkSnapshot(unit0-linux) enumerate
-		// the identical kernel addresses. But the base ref keys them under
-		// overrideByIface[base] (base-level override only), while unit 0 keys
-		// them under overrideByIface[base.0] (base ∪ unit-0 override, the
+		// #5699: a PHYSICAL (no-unit) snapshot whose unit 0 COLLAPSES onto the
+		// SAME kernel netdev carries the identical live addresses as that unit-0
+		// snapshot — buildLinkSnapshot(base-linux) and buildLinkSnapshot(unit0-
+		// linux) enumerate the same kernel addresses. But the base ref keys them
+		// under overrideByIface[base] (base-level override only), while unit 0
+		// keys them under overrideByIface[base.0] (base ∪ unit-0 override, the
 		// dataplane-additive #3720 resolution). When a per-interface override on
 		// the unit-0 ref makes those two signatures differ, the SINGLE live
 		// address is emitted into TWO views with conflicting admit sets — the
 		// kernel host-inbound chain matches destination address only, so the
 		// verdict is order-dependent (a deterministic false-deny). Unit 0's view
 		// is the authoritative carrier (its merged override matches enforcement),
-		// so skip the base's redundant contribution. Only when unit 0 exists: a
-		// physical interface with no unit 0 (rare bootstrap/DHCP-on-raw-netdev)
-		// keeps the base as the sole carrier so its address is still deny-scoped
-		// (never fail-open).
+		// so skip the base's redundant contribution.
+		//
+		// Gate strictly on the ACTUAL same-netdev collapse, NOT merely
+		// "unit 0 exists": a VLAN unit 0 (VlanID>0) or a tunnel-mapped unit 0
+		// resolves to a DISTINCT netdev (snapshotLinuxName -> "<base>.<vlan>" /
+		// the tunnel name), so base and unit-0 enumerate DISJOINT addresses.
+		// Skipping the base there would DROP the base netdev's own live address
+		// from every host-inbound view — no longer deny-scoped, the kernel input
+		// chain falls through to `policy accept` (FAIL-OPEN). Compare the unit-0
+		// resolved linux name to the base snapshot's linux name so the skip fires
+		// only when they are literally the same kernel device.
 		if !strings.Contains(snap.Name, ".") {
 			if ifc := cfg.Interfaces.Interfaces[snap.Name]; ifc != nil {
-				if _, hasUnit0 := ifc.Units[0]; hasUnit0 {
+				if u0 := ifc.Units[0]; u0 != nil &&
+					snapshotLinuxName(cfg, snap.Name, ifc, u0) == snap.LinuxName {
 					continue
 				}
 			}


### PR DESCRIPTION
Closes #5699.

## Root

A non-VLAN unit 0 collapses onto the base netdev (`ge-0/0/0.0` → Linux `ge-0-0-0`), so the base-interface snapshot and the unit-0 snapshot (`buildInterfaceSnapshots`) enumerate the **identical** live kernel address through `buildLinkSnapshot`. `BuildZoneHostInboundViews` groups addresses by `(zone, effective-token signature)`, and:

- the **base** ref keys the address under `overrideByIface[ifN]` — physical-level override only;
- **unit 0** keys the same address under `overrideByIface[ifN.0]` — the `base ∪ unit-0` merged override (#3720).

A per-interface host-inbound override on the **unit-0** ref therefore made the two signatures diverge, emitting the **single live address into two host-inbound views with conflicting admit sets**. The kernel `xpf_hostinbound` chain matches destination address only (no ingress predicate), so whichever rule block sorts first decides — a **deterministic false-deny** (the base view's narrower set drops a service the unit-0 override opened). codex-review-182 finding **M22**.

## Fix + precedence

Skip the base (physical, no-dot) snapshot's host-inbound address contribution **when unit 0 is configured**. Unit 0's snapshot is the authoritative carrier — its merged override matches enforcement and the `InterfaceHostInboundEffective` diagnostic — so the address resolves to **one** view carrying the additive `zone ∪ physical ∪ unit-0` admit set.

**Precedence chosen: unit-0 (merged) wins** — the Junos-additive answer. Host-inbound is additive across zone/physical/unit levels, so the unit-0 effective set already *includes* the physical override; the base view's physical-only set is a strict, incomplete subset. The base snapshot is kept as the sole carrier only when the interface has **no** unit 0 (rare bootstrap / DHCP-on-raw-netdev), so an address is never dropped from the deny scope (never fail-open).

## Scope (answering the dispatch question)

`pkg/dataplane/userspace` — the **Go dataplane manager / host-inbound view builder**. It does **NOT** change `pkg/config`, the daemon nft emission, or any cluster/VRRP/session-sync/failover path. The #3718 commit-time ambiguity gate (`validateDuplicateHostLocalAddressStrict`) is unaffected — it already records one merged signature per unit and never iterated a base snapshot, so it does not false-positive on this single-interface case. Not a localized reconciliation gone broad; a clean skip in the view builder.

`buildLinkSnapshot` is made a package var so the view builder is unit-testable with an injected base-netdev address — the conflict only manifests when the base netdev actually carries the (unit-0-collapsed) live address, which the live kernel does on a deployed box but a test env does not.

## Validation — fail-on-revert (`host_inbound_baseunit0_5699_test.go`)

`TestHostInboundBaseUnit0NoConflict_5699` injects the base-netdev live address via the `buildLinkSnapshot` seam (a zone with a zone-level `ping` and a unit-0 override adding `ssh`) and asserts the address resolves to exactly **one** view carrying the merged `[ping ssh]` set.

Reverting the skip puts the address into **two** conflicting views — observed `[{ge-0/0/0,[ping]}, {ge-0/0/0.0,[ping ssh]}]` — and the test goes **RED**. Full `pkg/dataplane/userspace` and `pkg/config` suites plus `go build ./...` pass.

Note: the bug's ultimate confirmation is on a deployed box (where the base netdev carries the live address); the unit test reproduces that exact scenario via the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)