### PR TITLE
daemon: fail commit on ordinary dataplane apply failure (#5679)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47076,3 +47076,20 @@ top.
   semantics. Fail-on-revert proven (predefined-bundle match RED on the user-only
   gate; shadow test not gate-dependent). Diagnostic simulator only (non-enforcement).
 - **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/predefined_set_5666_test.go
+
+- **Timestamp**: 2026-07-12 06:35
+- **Action**: #5679 fix — ordinary full dataplane apply failure now FAILS the
+  commit instead of reporting success against stale policy. In
+  applyDataplaneAndHACore the non-abort ApplyConfig error path only recorded a
+  health failure then fell through (applyConfigLocked returned nil → commit OK
+  while the OLD policy stayed live: fail-open-to-stale). Added a fourth named
+  return `applyErr` capturing the ordinary failure, threaded through
+  applyConfigLocked into applyTailReconciles' tail errors.Join (fail-closed but
+  complete; still peer-syncs per #4034; abort-class still early-returns). Added
+  fail-on-revert tests (RED proven with `applyErr = err` neutralized). gofmt +
+  go vet clean; full pkg/daemon suite green.
+- **File(s)**: pkg/daemon/daemon_apply.go,
+  pkg/daemon/apply_failure_failclosed_5679_test.go,
+  pkg/daemon/device_map_teardown_failclosed_5309_test.go,
+  pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go,
+  pkg/daemon/README.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -485,8 +485,9 @@ never lock an operator out of a remote box it manages.
   route-based IPs bound to it, carried no traffic (cross-module false
   convergence). It now RETURNS an `errors.Join` of its sub-stage failures;
   `applyConfigLocked` captures it (`ifaceErr`) and threads it into the tail
-  `errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr,
-  ifaceErr)`, so a genuine reconcile failure fails the commit closed. The
+  `errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err,
+  ipsecErr, ifaceErr)` (`applyErr` = the #5679 ordinary dataplane-apply
+  failure, below), so a genuine reconcile failure fails the commit closed. The
   underlying managers keep their idempotency (`xfrmManager.Apply` adopts an
   already-exists link and treats an already-gone delete as success #4901/#5261;
   `bondManager` #4823/#5119), so a benign re-apply still returns `nil` — this is
@@ -497,6 +498,30 @@ never lock an operator out of a remote box it manages.
   the `applyTailReconciles` commit-join wiring proof) plus
   `pkg/routing/xfrm_apply_failclosed_5310_test.go` (the routing-side
   `xfrmManager.Apply` returns-error / tolerates-already-exists half).
+  **Ordinary dataplane-apply fail-closed (#5679, mirroring the above):** the
+  main config-apply's full dataplane push (`applyDataplaneAndHACore` →
+  `d.dp.ApplyConfig`) split its error into two classes but ACTED on only one.
+  A required-protocol-gate error (`compileErrorMustAbortApply`) DISARMS the
+  dataplane and returns early (terminal `err`, commit fails, peer sync skipped).
+  But an ORDINARY (non-abort) apply failure — a control-socket / helper hiccup
+  that leaves the OLD compiled policy live and forwarding — only called
+  `recordCompileFailure` (for `/health`) and then FELL THROUGH: `applyConfigLocked`
+  returned `nil` and the commit reported SUCCESS while `store.Commit` had already
+  promoted the NEW config, so a tightening commit (e.g. a new deny) looked applied
+  while the looser old policy was still on the wire — a fail-open-to-stale on the
+  main config path (the config-commit analog of the feeds publication-debt bug
+  #5646/#5667). The fix captures that ordinary failure as a DEFERRED commit error
+  (`applyErr`, a fourth named return of `applyDataplaneAndHACore`) threaded into
+  the tail `errors.Join`, so the commit reports FAILURE while the rest of the
+  reconciles still run (fail-closed but complete, exactly like `networkdErr` /
+  `ifaceErr`). It is NOT demoted to abort: the dataplane stays armed with the old
+  config, so `applyErrSkipsPeerSync` still returns `false` and the standby
+  converges (#4034); and because the applied identity never advanced, the feed
+  onUpdate retry (`applyConfigResult`, #5646) and any identical re-commit
+  re-apply and self-heal a transient error. Tests:
+  `apply_failure_failclosed_5679_test.go` (ordinary-apply-fails-commit +
+  wraps-injected + does-not-skip-peer-sync fail-on-revert, plus the abort-class
+  still-early-returns + still-skips-peer-sync guard against over-reach).
   **Per-term disposition mirrors userspace (#3427):** `nftRulesFromTerm` maps a
   term's `then` action to the kernel verdict the SAME way the userspace lo0
   evaluator does (`pkg/dataplane/userspace/filters.go` `NextTerm =

--- a/pkg/daemon/apply_failure_failclosed_5679_test.go
+++ b/pkg/daemon/apply_failure_failclosed_5679_test.go
@@ -1,0 +1,127 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// TestApplyConfigLockedFailsCommitOnOrdinaryDataplaneApplyError_5679 is the
+// #5679 commit-level wiring proof. An ORDINARY (non-abort-class) full dataplane
+// apply failure — d.dp.ApplyConfig returns a plain error that is NOT one of the
+// required-protocol-gate sentinels compileErrorMustAbortApply matches — does
+// NOT disarm the dataplane: the OLD compiled policy stays live and forwarding
+// while store.Commit has already promoted+persisted the NEW config. Before the
+// fix the failure was swallowed (recorded for /health, then fall-through) and
+// applyConfigLocked returned nil, so the commit reported SUCCESS while the new
+// policy was never on the wire — a fail-open-to-stale (a tightening commit,
+// e.g. a new deny, looked applied while the looser old policy still enforced).
+//
+// The fix captures the ordinary apply error as a DEFERRED commit error threaded
+// into applyTailReconciles' errors.Join (fail-closed but complete, like
+// networkdErr / ifaceErr), so applyConfigLocked now returns non-nil and the
+// commit reports failure.
+//
+// FAIL-ON-REVERT: delete the `applyErr = err` assignment in the ordinary-apply
+// branch of applyDataplaneAndHACore (daemon_apply.go) and this goes RED — the
+// error is swallowed and applyConfigLocked returns nil despite the new policy
+// not being on the dataplane.
+func TestApplyConfigLockedFailsCommitOnOrdinaryDataplaneApplyError_5679(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	// A plain, non-abort-class apply failure (a control-socket / helper error),
+	// distinct from the required-protocol-gate sentinels. Guard the premise so a
+	// future reclassification that makes this abort-class does not silently turn
+	// the test into an exercise of the (already-covered) early-abort path.
+	injected := errors.New("dataplane control-socket sync failed: connection reset")
+	if compileErrorMustAbortApply(injected) {
+		t.Fatal("precondition: injected error must be ORDINARY (non-abort-class); " +
+			"compileErrorMustAbortApply matched it — pick a different vector")
+	}
+
+	dp := &runtimeOnlyApplyTestDP{applyErr: injected}
+	d := &Daemon{
+		dp:       dp,
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+
+	err := d.applyConfigLocked(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("applyConfigLocked must FAIL the commit when an ordinary dataplane " +
+			"apply fails (the new policy is not on the wire); got nil — the error " +
+			"was swallowed and the commit would report success against stale policy")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("applyConfigLocked error must wrap the injected apply failure; got %v", err)
+	}
+	if dp.applyCalls != 1 {
+		t.Fatalf("dataplane ApplyConfig calls = %d, want 1 (apply must have been attempted)", dp.applyCalls)
+	}
+
+	// The ordinary apply failure is a DEFERRED (non-fatal) commit error, NOT a
+	// disarm/abort: the dataplane is still armed with the OLD config, so the
+	// standby must still receive the committed config (#4034). Pin that this
+	// error class does NOT suppress the peer sync — distinguishing it from the
+	// required-protocol-gate (disarmed) and context-abort classes.
+	if applyErrSkipsPeerSync(err) {
+		t.Fatal("an ordinary (non-abort) dataplane-apply failure must NOT skip the " +
+			"peer config-sync (#4034): the dataplane is still armed and the standby " +
+			"has to converge; only a disarmed-gate or context-abort error skips it")
+	}
+}
+
+// TestApplyConfigLockedAbortClassStillEarlyReturns_5679 pins the OTHER half of
+// the #5679 contract: an abort-class (required-protocol-gate) apply failure
+// still returns via the terminal `err` path — an EARLY return that skips the
+// routing / service / tail reconciles — rather than being demoted to the new
+// deferred applyErr slot. The abort class means the dataplane is DISARMED
+// (fail-closed), so aborting the rest of the apply is correct. This guards the
+// fix from over-reaching (folding the abort case into the deferred path would
+// keep running the tail against a disarmed dataplane).
+func TestApplyConfigLockedAbortClassStillEarlyReturns_5679(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	dp := &runtimeOnlyApplyTestDP{applyErr: dpuserspace.ErrPolicySchedulerProtocolIncompatible}
+	d := &Daemon{
+		dp:       dp,
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+
+	err := d.applyConfigLocked(context.Background(), cfg)
+	if !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+		t.Fatalf("abort-class apply failure must surface the gate sentinel; got %v", err)
+	}
+	// It MUST remain in the fatal (peer-sync-skipping, disarmed) class.
+	if !applyErrSkipsPeerSync(err) {
+		t.Fatal("abort-class (required-protocol-gate) apply failure must still skip " +
+			"the peer sync — the dataplane is disarmed; pushing it to the standby is worse")
+	}
+}

--- a/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
+++ b/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
@@ -247,7 +247,7 @@ func TestApplyTailReconcilesSurfacesInterfaceReconcileError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: interface reconcile (xfrmi create) failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, injected)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the interface-reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -125,7 +125,7 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 // rejected apply leaves publication debt that the next identical refetch
 // retries (rather than committing the content hash and suppressing retry
 // forever, the pre-#5646 bug). The returned error is still logged — by
-	// feeds.installSnapshot's reject branch (feeds side), not by this function.
+// feeds.installSnapshot's reject branch (feeds side), not by this function.
 func (d *Daemon) applyConfigResult(cfg *config.Config) error {
 	_ = d.applySem.Acquire(context.Background(), 1)
 	defer d.applySem.Release(1)
@@ -766,7 +766,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// networkd write error for the routing rules + tail reconcile below; an
 	// error (a #2926 context abort or an ApplyConfig compile abort) bails
 	// before the tail.
-	commitOverlay, networkdErr, err := d.applyDataplaneAndHACore(ctx, cfg)
+	commitOverlay, networkdErr, applyErr, err := d.applyDataplaneAndHACore(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -797,10 +797,12 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// RETH-MAC core that stays inline (it threads applyResult / rethMACPending
 	// / the deferred errors). The tail is independent per-subsystem dispatch
 	// reading only cfg (+ nil-guarded managers), so grouping it here is a
-	// behavior-preserving mechanical move. The four head-produced deferred
-	// errors (networkdErr/dhcpServerErr/ipsecErr/ifaceErr) are threaded in; the
-	// helper creates lo0Err/hostInboundErr and returns the six-way errors.Join.
-	return d.applyTailReconciles(cfg, networkdErr, dhcpServerErr, ipsecErr, ifaceErr)
+	// behavior-preserving mechanical move. The five head-produced deferred
+	// errors (networkdErr/applyErr/dhcpServerErr/ipsecErr/ifaceErr) are threaded
+	// in — applyErr is the #5679 ordinary (non-abort) dataplane-apply failure
+	// that must fail the commit without disarming/aborting; the helper creates
+	// lo0Err/hostInboundErr and returns the seven-way errors.Join.
+	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr)
 }
 
 // applyDataplaneAndHACore runs the ordering-entangled dataplane-apply and
@@ -809,17 +811,26 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 // state that the earlier decoupled phases do not touch stays local here —
 // rethMACPending and the deferred-worker-startup flag/defer are self-contained
 // — and the two values the tail still needs are returned: the ip-monitoring
-// commit overlay (fed to applyRoutingRules and the FRR render) and the captured
-// networkd write error (threaded into applyTailReconciles' five-way Join). The
-// three early error returns — the two #2926 context-abort boundaries
-// (ctx.Err() before ApplyConfig and before the FRR reload) and the
-// compileErrorMustAbortApply dataplane abort on an ApplyConfig failure — are
-// preserved; the caller bails without running the routing / service / tail
-// reconciles, exactly as the inline `return err` did. commitOverlay and networkdErr are named
-// returns so the pre-networkd boundaries can return them (nil) before the
-// networkd phase assigns networkdErr. Runs in the same slot, after the
-// fabric-IPVLAN reconcile and before the routing rules.
-func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config) (commitOverlay []config.RouteOverlayEntry, networkdErr error, err error) {
+// commit overlay (fed to applyRoutingRules and the FRR render), the captured
+// networkd write error, and the DEFERRED ordinary dataplane-apply error
+// (#5679) — both threaded into applyTailReconciles' Join. The three early
+// error returns — the two #2926 context-abort boundaries (ctx.Err() before
+// ApplyConfig and before the FRR reload) and the compileErrorMustAbortApply
+// dataplane abort on an ApplyConfig failure — are preserved; the caller bails
+// (via the terminal `err` return) without running the routing / service / tail
+// reconciles, exactly as the inline `return err` did.
+//
+// applyErr (#5679) is DISTINCT from that terminal `err`: an ORDINARY (non-abort
+// -class) ApplyConfig failure does NOT disarm the dataplane — the OLD compiled
+// config stays live and forwarding — so the tail reconciles MUST still run
+// (fail-closed but complete, exactly like networkdErr / ifaceErr). It is
+// returned as a deferred error the caller joins at the tail so the commit
+// reports FAILURE rather than silently succeeding against the stale policy,
+// instead of aborting the rest of the apply. commitOverlay, networkdErr, and
+// applyErr are named returns so the pre-networkd boundaries can return them
+// (nil) before the networkd / apply phases assign them. Runs in the same slot,
+// after the fabric-IPVLAN reconcile and before the routing rules.
+func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config) (commitOverlay []config.RouteOverlayEntry, networkdErr error, applyErr error, err error) {
 	// 1.9. Pre-check: will RETH MAC programming require a link cycle?
 	// If yes, tell the userspace DP to skip initial worker startup during
 	// ApplyConfig(). Workers will be started by NotifyLinkCycle() after MAC
@@ -909,7 +920,7 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 	// follows it begin, they run as one unit (no mid-sequence abort) — the
 	// next boundary is before the FRR reload.
 	if err := ctx.Err(); err != nil {
-		return commitOverlay, networkdErr, err
+		return commitOverlay, networkdErr, nil, err
 	}
 
 	// 2. Apply dataplane config through the runtime config sink.
@@ -919,8 +930,22 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 		if applyResult, err = d.dp.ApplyConfig(context.Background(), cfg); err != nil {
 			d.recordCompileFailure(err)
 			if compileErrorMustAbortApply(err) {
-				return commitOverlay, networkdErr, err
+				return commitOverlay, networkdErr, nil, err
 			}
+			// #5679: an ORDINARY (non-abort-class) full-apply failure does
+			// NOT disarm the dataplane — d.dp.ApplyConfig leaves the OLD
+			// compiled policy live and forwarding while store.Commit has
+			// already promoted+persisted the NEW config. Left unhandled the
+			// commit reported SUCCESS against stale enforcement (a tightening
+			// commit — e.g. a new deny — appeared applied while the looser old
+			// policy was still on the wire), a fail-open-to-stale on the main
+			// config-apply path. Capture the failure as a DEFERRED commit error
+			// (threaded into the tail Join, fail-closed but complete like
+			// networkdErr / ifaceErr) so the operator sees the commit fail; the
+			// applied config never advanced, so an identical re-commit / the
+			// feed onUpdate retry (#5646, via applyConfigResult) re-applies and
+			// self-heals a transient helper / control-socket error.
+			applyErr = err
 		} else {
 			d.recordCompileSuccess()
 		}
@@ -1204,10 +1229,10 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 	// store.Commit the store already holds the new config, so this is a clean
 	// "apply the rest on next start" boundary, not a divergence.)
 	if err := ctx.Err(); err != nil {
-		return commitOverlay, networkdErr, err
+		return commitOverlay, networkdErr, nil, err
 	}
 
-	return commitOverlay, networkdErr, nil
+	return commitOverlay, networkdErr, applyErr, nil
 }
 
 // applyServicesReconcile runs the per-service reconcile phases of a config
@@ -1833,11 +1858,13 @@ func (d *Daemon) applyInterfaceReconcile(cfg *config.Config) error {
 //
 // Error-join contract: the deferred reconcile errors accumulate across the
 // whole apply body but are joined only at this tail (fail-closed — every step
-// still runs). networkdErr/dhcpServerErr/ipsecErr/ifaceErr originate in the head
-// and are threaded in as parameters; lo0Err/hostInboundErr originate in step
-// 9.5 below. The returned errors.Join preserves the exact operand order the
-// inline tail used (#1778/#2987/#4433/#5310).
-func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, dhcpServerErr, ipsecErr, ifaceErr error) error {
+// still runs). networkdErr/applyErr/dhcpServerErr/ipsecErr/ifaceErr originate in
+// the head and are threaded in as parameters (applyErr is the #5679 ordinary
+// non-abort dataplane-apply failure that must fail the commit while the OLD
+// policy stays live); lo0Err/hostInboundErr originate in step 9.5 below. The
+// returned errors.Join preserves the exact operand order the inline tail used
+// (#1778/#2987/#4433/#5310/#5679).
+func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr error) error {
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	vrrpInstances := vrrp.CollectInstances(cfg)
 	if d.cluster != nil {
@@ -2097,14 +2124,16 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, dhcpServer
 		d.applyStep0Tunables(userspaceDP, claimHostTunables, governor, netdevBudget,
 			coalesceExplicit, coalesceEnable, coalesceRX, coalesceTX, rssAllowed)
 	}
-	// #1778 + #2987 + #4433 + #5310: deferred reconcile failures — every
-	// reconcile step above has run; surface the networkd write failure, the Kea
-	// restart/stop failure, the IPsec render/reload failure, and the
-	// interface-reconcile failure (xfrmi/bond/tunnel/legacy-reth create/up/delete
-	// — #5310) through the commit so a step that left stale or missing
-	// kernel/swanctl state fails the commit (fail-closed) instead of reporting
-	// success. All are joined so none masks the other.
-	return errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr)
+	// #1778 + #2987 + #4433 + #5310 + #5679: deferred reconcile failures — every
+	// reconcile step above has run; surface the networkd write failure, the
+	// ordinary (non-abort) dataplane-apply failure (#5679 — the new policy is
+	// NOT on the wire, the old one still is), the Kea restart/stop failure, the
+	// IPsec render/reload failure, and the interface-reconcile failure
+	// (xfrmi/bond/tunnel/legacy-reth create/up/delete — #5310) through the commit
+	// so a step that left stale or missing kernel/swanctl/dataplane state fails
+	// the commit (fail-closed) instead of reporting success. All are joined so
+	// none masks the other.
+	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr)
 }
 
 // compileErrorMustAbortApply reports whether a dataplane ApplyConfig error

--- a/pkg/daemon/device_map_teardown_failclosed_5309_test.go
+++ b/pkg/daemon/device_map_teardown_failclosed_5309_test.go
@@ -262,7 +262,7 @@ func TestApplyTailReconcilesSurfacesDeviceMapTeardownError_5309(t *testing.T) {
 
 	teardownErr := fmt.Errorf("device-map teardown: %w",
 		errors.New("rename-back ge-0-0-9 -> enp99s0: EBUSY"))
-	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface a device-map teardown failure carried " +
 			"in networkdErr (fail-closed); got nil")


### PR DESCRIPTION
## Summary

Fixes a fail-open-to-stale security bug (#5679, codex-review-182 M17): an
**ordinary** (non-abort-class) full dataplane apply failure was reported to the
operator as commit **SUCCESS** while the committed policy never reached the wire.

In `applyDataplaneAndHACore` the `d.dp.ApplyConfig` error path split the failure
into two classes but acted on only one:

- A **required-protocol-gate** error (`compileErrorMustAbortApply`) disarms the
  dataplane and returns early → the commit correctly fails.
- An **ordinary** failure (a control-socket / helper hiccup that leaves the OLD
  compiled policy live and forwarding) only called `recordCompileFailure` (for
  `/health`) and then **fell through**: `applyConfigLocked` returned `nil` and
  the commit reported success even though `store.Commit` had already promoted the
  NEW config. A tightening commit (e.g. a new deny) therefore looked applied
  while the looser old policy was still enforced.

This is the config-commit analog of the feeds publication-debt bug (#5646 / PR #5667).

## Fix

Capture the ordinary failure as a **deferred commit error** (`applyErr`, a fourth
named return of `applyDataplaneAndHACore`) threaded through `applyConfigLocked`
into `applyTailReconciles`' tail `errors.Join`, so the commit reports **failure**
while the remaining reconciles still run (fail-closed but complete, exactly like
`networkdErr` / `ifaceErr`).

It is deliberately **not** demoted to the abort class: the dataplane stays armed
with the old config, so `applyErrSkipsPeerSync` still returns `false` and the
standby converges (#4034); and because the applied identity never advanced, the
feed onUpdate retry (`applyConfigResult`, #5646) and any identical re-commit
re-apply and self-heal a transient error.

## Where the error was being swallowed

`pkg/daemon/daemon_apply.go` — the ordinary branch of `d.dp.ApplyConfig`'s error
handler inside `applyDataplaneAndHACore` (after the `compileErrorMustAbortApply`
early return): it recorded the compile failure and fell through, returning `nil`.

## Validation

- New `pkg/daemon/apply_failure_failclosed_5679_test.go`:
  - `TestApplyConfigLockedFailsCommitOnOrdinaryDataplaneApplyError_5679` — an
    ordinary `ApplyConfig` failure now fails `applyConfigLocked` (wraps the
    injected error; does NOT skip peer sync). **Proven RED** with `applyErr = err`
    neutralized, **GREEN** with it restored.
  - `TestApplyConfigLockedAbortClassStillEarlyReturns_5679` — over-reach guard:
    the abort-class error still early-returns and still skips the peer sync.
- Updated the two existing `applyTailReconciles` callers for the new arg.
- Documented the contract in `pkg/daemon/README.md`.
- `gofmt` + `go vet` clean; full `pkg/daemon` suite green.

Closes #5679

🤖 Generated with [Claude Code](https://claude.com/claude-code)