### PR TITLE
grpcapi: coalesce MonitorInterface status fan-out (#5707)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47076,3 +47076,19 @@ top.
   semantics. Fail-on-revert proven (predefined-bundle match RED on the user-only
   gate; shadow test not gate-dependent). Diagnostic simulator only (non-enforcement).
 - **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/predefined_set_5666_test.go
+- **Timestamp**: 2026-07-12
+- **Action**: #5707 — coalesce the userspace-dataplane Status() control-socket
+  query for the MonitorInterface streaming path. Each open stream polls 1/s and
+  summary mode reads every configured interface each tick, so binding readSnap
+  to the raw s.userspaceDataplaneStatus issued O(interfaces*streams) Status()
+  calls per tick, contending on the shared helper control socket and starving
+  session installs. Added a Server-wide single-flight, short-TTL status cache
+  (monitorStatusCache, 900ms) that fans one query out to all callers within a
+  poll window, collapsing the fan-out to O(1)/tick regardless of interface or
+  subscriber count. Fail-on-revert proven: 6 concurrent streams → 1 Status()
+  call GREEN, 6 calls RED when reverted to the per-stream fetch. Race-clean.
+- **File(s)**: pkg/grpcapi/monitor_status_cache.go,
+  pkg/grpcapi/monitor_status_cache_test.go, pkg/grpcapi/server.go,
+  pkg/grpcapi/server_diag_monitor.go,
+  pkg/grpcapi/server_diag_monitor_fanout_5707_test.go,
+  pkg/monitoriface/README.md

--- a/pkg/grpcapi/monitor_status_cache.go
+++ b/pkg/grpcapi/monitor_status_cache.go
@@ -1,0 +1,77 @@
+package grpcapi
+
+import (
+	"sync"
+	"time"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/monitoriface"
+)
+
+// monitorStatusTTL bounds how long the MonitorInterface streaming path reuses a
+// single userspace-dataplane Status() snapshot (#5707). A stream polls once per
+// second, so a sub-second window collapses both the per-interface fan-out
+// (summary mode reads every configured interface each tick) and the per-stream
+// fan-out (S concurrent subscribers each running their own ticker) to one
+// control-socket query per tick, while never serving data older than one poll.
+const monitorStatusTTL = 900 * time.Millisecond
+
+// monitorStatusCache coalesces userspace-dataplane Status() queries so that
+// concurrent MonitorInterface streams — and the per-interface loop inside a
+// single summary-mode tick — share one control-socket read instead of issuing
+// O(interfaces*streams) of them. It is a single-flight cache: the first caller
+// after the freshness window elapses performs the fetch while holding the lock,
+// and every caller that arrives within the window (or blocks behind the
+// in-flight fetch) receives the same result. Status() returns the whole-process
+// snapshot for every interface at once, so one shared read fully serves a tick.
+type monitorStatusCache struct {
+	mu    sync.Mutex
+	fetch monitoriface.StatusReader
+	ttl   time.Duration
+	now   func() time.Time
+
+	status  dpuserspace.ProcessStatus
+	err     error
+	fetched time.Time
+	valid   bool
+}
+
+// newMonitorStatusCache builds a cache over fetch with the given freshness
+// window. now is injectable so tests can drive the window deterministically;
+// nil defaults to time.Now.
+func newMonitorStatusCache(fetch monitoriface.StatusReader, ttl time.Duration, now func() time.Time) *monitorStatusCache {
+	if now == nil {
+		now = time.Now
+	}
+	return &monitorStatusCache{fetch: fetch, ttl: ttl, now: now}
+}
+
+// get returns a Status() snapshot no older than the cache TTL, issuing at most
+// one backing fetch per window regardless of how many callers race for it.
+func (c *monitorStatusCache) get() (dpuserspace.ProcessStatus, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t := c.now()
+	if c.valid && t.Sub(c.fetched) < c.ttl {
+		return c.status, c.err
+	}
+	if c.fetch == nil {
+		return dpuserspace.ProcessStatus{}, nil
+	}
+	c.status, c.err = c.fetch()
+	c.fetched = t
+	c.valid = true
+	return c.status, c.err
+}
+
+// monitorStatusReader returns the shared, coalescing Status() reader used by the
+// MonitorInterface streaming path. All streams on this Server share one cache so
+// concurrent subscribers do not multiply the control-socket load (#5707).
+func (s *Server) monitorStatusReader() monitoriface.StatusReader {
+	s.monitorStatusOnce.Do(func() {
+		if s.monitorStatusCache == nil {
+			s.monitorStatusCache = newMonitorStatusCache(s.userspaceDataplaneStatus, monitorStatusTTL, nil)
+		}
+	})
+	return s.monitorStatusCache.get
+}

--- a/pkg/grpcapi/monitor_status_cache_test.go
+++ b/pkg/grpcapi/monitor_status_cache_test.go
@@ -1,0 +1,94 @@
+package grpcapi
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// TestMonitorStatusCacheCoalescesWithinWindow proves the cache issues exactly
+// one backing Status() fetch for all callers inside a freshness window and
+// refetches once the window elapses — the coalescing behavior that keeps the
+// MonitorInterface fan-out O(1) per tick (#5707).
+func TestMonitorStatusCacheCoalescesWithinWindow(t *testing.T) {
+	var calls atomic.Int64
+	base := time.Unix(1_000_000, 0)
+	clock := base
+	fetch := func() (dpuserspace.ProcessStatus, error) {
+		calls.Add(1)
+		return dpuserspace.ProcessStatus{Enabled: true}, nil
+	}
+	c := newMonitorStatusCache(fetch, 900*time.Millisecond, func() time.Time { return clock })
+
+	// First call fetches; the next several within the window are served cached.
+	for i := 0; i < 5; i++ {
+		if _, err := c.get(); err != nil {
+			t.Fatalf("get() error = %v", err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("Status() fetch count within window = %d, want 1", got)
+	}
+
+	// Advance past the TTL: exactly one more fetch, then cached again.
+	clock = base.Add(time.Second)
+	for i := 0; i < 5; i++ {
+		if _, err := c.get(); err != nil {
+			t.Fatalf("get() error = %v", err)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("Status() fetch count after TTL advance = %d, want 2", got)
+	}
+}
+
+// TestMonitorStatusCacheSingleFlightUnderRace exercises many concurrent callers
+// against a fixed clock: the mutex must serialize them into a single fetch, and
+// -race must stay clean. This guards the shared-state safety the fan-out fix
+// introduces across streams.
+func TestMonitorStatusCacheSingleFlightUnderRace(t *testing.T) {
+	var calls atomic.Int64
+	fixed := time.Unix(2_000_000, 0)
+	fetch := func() (dpuserspace.ProcessStatus, error) {
+		calls.Add(1)
+		return dpuserspace.ProcessStatus{}, nil
+	}
+	c := newMonitorStatusCache(fetch, time.Second, func() time.Time { return fixed })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.get(); err != nil {
+				t.Errorf("get() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("concurrent fetch count = %d, want 1 (single-flight within window)", got)
+	}
+}
+
+// TestMonitorStatusCachePropagatesError confirms the cached result carries the
+// backing error through the window instead of silently masking a failed query.
+func TestMonitorStatusCachePropagatesError(t *testing.T) {
+	sentinel := errors.New("control socket busy")
+	fixed := time.Unix(3_000_000, 0)
+	c := newMonitorStatusCache(func() (dpuserspace.ProcessStatus, error) {
+		return dpuserspace.ProcessStatus{}, sentinel
+	}, time.Second, func() time.Time { return fixed })
+
+	if _, err := c.get(); !errors.Is(err, sentinel) {
+		t.Fatalf("get() error = %v, want %v", err, sentinel)
+	}
+	// Second call within the window returns the cached error too.
+	if _, err := c.get(); !errors.Is(err, sentinel) {
+		t.Fatalf("cached get() error = %v, want %v", err, sentinel)
+	}
+}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -194,6 +194,17 @@ type Server struct {
 	// runs two supervisors (fab0 + fab1) against one Server.
 	fabricListenerMu sync.Mutex
 	fabricListenerUp map[string]bool
+	// monitorStatus coalesces the userspace-dataplane Status() control-socket
+	// query for the MonitorInterface streaming path (#5707). Every open stream
+	// polls once per second and summary mode reads every configured interface
+	// each tick, so without coalescing N interfaces across S concurrent streams
+	// issue O(N*S) Status() calls per tick, contending on the shared helper
+	// control socket and starving session installs. The cache serves one fetched
+	// snapshot to every caller within monitorStatusTTL, collapsing the fan-out to
+	// O(1) queries per tick regardless of interface or subscriber count. Lazily
+	// built by monitorStatusReader; a test may pre-seed it with an injected clock.
+	monitorStatusOnce  sync.Once
+	monitorStatusCache *monitorStatusCache
 }
 
 func (s *Server) userspaceDataplaneStatus() (dpuserspace.ProcessStatus, error) {

--- a/pkg/grpcapi/server_diag_monitor.go
+++ b/pkg/grpcapi/server_diag_monitor.go
@@ -505,8 +505,15 @@ func (s *Server) MonitorInterface(req *pb.MonitorInterfaceRequest, stream grpc.S
 	var baselineSingle *monitoriface.Snapshot
 	prevAll := make(map[string]*monitoriface.Snapshot)
 
+	// statusReader is the shared, coalescing Status() reader (#5707). Summary
+	// mode reads every configured interface each tick and every concurrent stream
+	// runs its own ticker, so binding the per-interface, per-stream snapshot read
+	// to the raw s.userspaceDataplaneStatus would issue O(interfaces*streams)
+	// control-socket queries per tick. The Server-wide cache fans one query out
+	// to all callers within a poll window, keeping the load O(1) per tick.
+	statusReader := s.monitorStatusReader()
 	readSnap := func(name string) *monitoriface.Snapshot {
-		snap, err := monitoriface.ReadSnapshot(s.monitorInterfaceDataplane(), s.userspaceDataplaneStatus, name)
+		snap, err := monitoriface.ReadSnapshot(s.monitorInterfaceDataplane(), statusReader, name)
 		if err != nil {
 			return nil
 		}

--- a/pkg/grpcapi/server_diag_monitor_fanout_5707_test.go
+++ b/pkg/grpcapi/server_diag_monitor_fanout_5707_test.go
@@ -1,0 +1,116 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/metadata"
+)
+
+// fanoutStatusDP is a grpcRuntime that counts Status() control-socket queries so
+// the #5707 fan-out test can assert how many backend status reads a burst of
+// MonitorInterface streams issues.
+type fanoutStatusDP struct {
+	dataplane.DataPlane
+	statusCalls atomic.Int64
+}
+
+func (d *fanoutStatusDP) IsLoaded() bool { return true }
+
+func (d *fanoutStatusDP) ReadInterfaceCounters(int) (dataplane.InterfaceCounterValue, error) {
+	return dataplane.InterfaceCounterValue{}, nil
+}
+
+func (d *fanoutStatusDP) Status() (dpuserspace.ProcessStatus, error) {
+	d.statusCalls.Add(1)
+	return dpuserspace.ProcessStatus{Enabled: true}, nil
+}
+
+// oneTickMonitorStream is a MonitorInterface server stream that records one
+// frame and then cancels its own context, so the handler's per-tick loop emits
+// exactly one frame (one tick) before returning. That makes each stream issue a
+// single per-tick status read, which is the unit the fan-out test counts.
+type oneTickMonitorStream struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	frames int
+}
+
+func newOneTickMonitorStream() *oneTickMonitorStream {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &oneTickMonitorStream{ctx: ctx, cancel: cancel}
+}
+
+func (m *oneTickMonitorStream) Send(*pb.MonitorInterfaceResponse) error {
+	m.frames++
+	m.cancel() // end the stream after this single tick
+	return nil
+}
+func (m *oneTickMonitorStream) Context() context.Context     { return m.ctx }
+func (m *oneTickMonitorStream) SetHeader(metadata.MD) error  { return nil }
+func (m *oneTickMonitorStream) SendHeader(metadata.MD) error { return nil }
+func (m *oneTickMonitorStream) SetTrailer(metadata.MD)       {}
+func (m *oneTickMonitorStream) SendMsg(any) error            { return nil }
+func (m *oneTickMonitorStream) RecvMsg(any) error            { return nil }
+
+// TestMonitorInterfaceSharesStatusAcrossStreams_5707 is the fail-on-revert guard
+// for the O(interfaces*streams) status fan-out fix. K concurrent
+// MonitorInterface streams each run one tick against a single "lo" interface.
+// With the shared per-Server status cache, all K ticks coalesce into ONE backend
+// Status() control-socket query. Reverting the fix — binding readSnap back to
+// the raw s.userspaceDataplaneStatus per stream — makes each stream fetch
+// independently, so the count becomes K and this test fails.
+func TestMonitorInterfaceSharesStatusAcrossStreams_5707(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := store.LoadOverride("system { host-name fw; }"); err != nil {
+		t.Fatalf("LoadOverride: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	dp := &fanoutStatusDP{}
+	s := &Server{store: store, dp: dp}
+
+	// Pre-seed the shared status cache with a FIXED clock so the whole burst
+	// falls inside one freshness window deterministically — the coalescing then
+	// hinges on the sharing, not on wall-clock timing.
+	fixed := time.Unix(1_700_000_000, 0)
+	s.monitorStatusCache = newMonitorStatusCache(
+		s.userspaceDataplaneStatus, monitorStatusTTL, func() time.Time { return fixed })
+
+	const streams = 6
+	var wg sync.WaitGroup
+	sinks := make([]*oneTickMonitorStream, streams)
+	for i := range sinks {
+		sinks[i] = newOneTickMonitorStream()
+		wg.Add(1)
+		go func(st *oneTickMonitorStream) {
+			defer wg.Done()
+			// context.Canceled is the expected return once the single tick ends.
+			_ = s.MonitorInterface(&pb.MonitorInterfaceRequest{InterfaceName: "lo"}, st)
+		}(sinks[i])
+	}
+	wg.Wait()
+
+	for i, st := range sinks {
+		if st.frames != 1 {
+			t.Fatalf("stream %d emitted %d frames, want exactly 1 tick", i, st.frames)
+		}
+	}
+
+	if got := dp.statusCalls.Load(); got != 1 {
+		t.Fatalf("Status() backend calls across %d streams = %d, want 1 "+
+			"(streams must not multiply status reads — #5707 fan-out regressed)", streams, got)
+	}
+}

--- a/pkg/monitoriface/README.md
+++ b/pkg/monitoriface/README.md
@@ -32,5 +32,14 @@ packets, bytes, delta, rate.
   no scheduling itself.
 - Userspace snapshots require a `StatusReader` callback to the dataplane
   process. With the eBPF backend, the userspace half is empty.
+- The `StatusReader` returns the whole-process status, so `ReadSnapshot`
+  invokes it once per interface. A caller that reads many interfaces per
+  tick — or fans one poll out to many concurrent subscribers — MUST
+  coalesce the `StatusReader` (share one snapshot per tick) or it issues
+  O(interfaces*subscribers) control-socket queries and contends with
+  session installs. `pkg/grpcapi`'s `MonitorInterface` streaming path
+  does this with a shared, short-TTL status cache (#5707); pass that
+  cached reader in as the `StatusReader` rather than a raw per-call
+  `Status()`.
 - VLAN sub-interfaces resolve to their physical parent via
   `ResolvePhysicalParent` so per-NIC summary rows aren't double-counted.


### PR DESCRIPTION
## Problem

`MonitorInterface` (gRPC server-streaming) bound its per-tick snapshot read to
the raw `s.userspaceDataplaneStatus`. Each open stream polls once per second and
summary mode reads **every** configured interface each tick, so **N interfaces ×
S concurrent streams** issued `O(N*S)` userspace-dataplane `Status()`
control-socket queries per tick. That contention scales with subscribers and
starves other manager work (session installs, bulk sync) on the shared helper
control socket.

Provenance: codex-review-182 finding M34 (Medium), verified against
origin/master `fc479ca65`.

## Fix

Add a Server-wide, single-flight status cache (`monitorStatusCache`, `900ms`
freshness window — just under the 1s poll) and route the `MonitorInterface`
`readSnap` closure through it. `Status()` returns the whole-process snapshot for
every interface at once, so **one shared read fully serves a tick**: the first
caller in a window fetches under the lock, and every caller within the window
(the per-interface summary loop *and* every concurrent stream) receives the same
result. The fan-out collapses to `O(1)` queries per tick regardless of interface
or subscriber count, while the sub-second window keeps data no older than one
poll.

Kernel counter and netlink reads stay per-interface and fresh; only the
control-socket `Status()` query is coalesced. The cache is mutex-guarded
single-flight (race-safe) with an injectable clock for deterministic tests.

## Hoisted call site

`pkg/grpcapi/server_diag_monitor.go` — the per-stream fetch inside `readSnap`
(previously `monitoriface.ReadSnapshot(..., s.userspaceDataplaneStatus, name)`)
now takes the shared `statusReader := s.monitorStatusReader()`.

## Fail-on-revert test

`TestMonitorInterfaceSharesStatusAcrossStreams_5707` — 6 concurrent
`MonitorInterface` streams, one tick each on `lo`, asserts **exactly one**
backend `Status()` call.
- **RED** (proven): reverting `readSnap` to the per-stream
  `s.userspaceDataplaneStatus` → 6 calls.
- **GREEN**: shared cache → 1 call.

Plus `monitor_status_cache_test.go`: within-window coalescing, TTL refetch,
32-goroutine single-flight under `-race`, error propagation.

## Validation

`go test -race ./pkg/api/... ./pkg/grpcapi/...` — green.

Closes #5707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gp5a3Gig37yfc6BWJ7eKi