### PR TITLE
config: aggregate AST pre-passes across all top-level roots (#5675, #5691)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47076,3 +47076,15 @@ top.
   semantics. Fail-on-revert proven (predefined-bundle match RED on the user-only
   gate; shadow test not gate-dependent). Diagnostic simulator only (non-enforcement).
 - **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/predefined_set_5666_test.go
+
+- **Timestamp**: 2026-07-12
+- **Action**: Fix #5675/#5691 — AST pre-passes must aggregate across ALL
+  top-level roots, not just the first. `expandInterfaceRanges` (#4027) broke on
+  the first `interfaces` root (phantom re-mint for split roots, #5675); the
+  stable-ID collision gates (zone #3075 / tunnel #1873 / routing-instance #3855)
+  read only the first `security`/`interfaces`/`routing-instances` root (#5691).
+  Added `ConfigTree.FindChildren`; unioned View 1 + Views 2/3 across all roots.
+  Fail-on-revert tests proven RED-on-neuter.
+- **File(s)**: pkg/config/ast.go, pkg/config/compiler_interface_range.go,
+  pkg/config/zoneid.go, pkg/config/tunnelid.go, pkg/config/routinginstanceid.go,
+  pkg/config/compiler_multi_root_5675_5691_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3159,8 +3159,25 @@ reserved for whole-dataplane selection where a rewrite shim
   rewrite, not a `setSchema` change: adding schema children for `member` /
   `member-range` would alter the flat-set grouping the expansion depends
   on, so the construct stays out of the grammar SSOT and is normalized
-  before any typed-leaf walk. Regression coverage:
-  `pkg/config/compiler_interface_range_4027_test.go`.
+  before any typed-leaf walk. **#5675 (multi-root aggregation):** the pass
+  scans EVERY top-level `interfaces` root, not just the first. A
+  hierarchical config can split its interfaces across two sibling
+  `interfaces { }` stanzas (flat-set always merges onto one root, so this
+  shape is hierarchical-only), and `compileSections` dispatches every root
+  — so a `break`-on-first-root scan skipped an interface-range living in a
+  second root, re-minting the phantom `interface-range` interface and
+  dropping that range's members. The pass now collects ranges and
+  member-own config across all `interfaces` roots and replays the expanded
+  members through `SetPath` (which `compileSections` merges with the rest).
+  Regression coverage:
+  `pkg/config/compiler_interface_range_4027_test.go` and
+  `pkg/config/compiler_multi_root_5675_5691_test.go`
+  (`TestInterfaceRangeSecondRootExpands_5675`). The sibling stable-ID
+  collision gates (zone `#3075`, tunnel `#1873`, routing-instance `#3855`)
+  carried the same first-root-only defect for split `security` /
+  `interfaces` / `routing-instances` roots and were fixed the same way
+  (`#5691`, `ConfigTree.FindChildren`-based union across all matching
+  roots).
 - **#3444 (destination-NAT rule-set `to` scope reject):** a Junos
   destination-NAT rule-set has only a `from` clause (zone | interface |
   routing-instance) — DNAT translates the destination on inbound, so there

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -136,6 +136,23 @@ func (t *ConfigTree) FindChild(name string) *Node {
 	return nil
 }
 
+// FindChildren returns every top-level child matching name. A Junos config may
+// legitimately carry the SAME top-level stanza more than once (two hierarchical
+// `interfaces { }` / `security { }` / `routing-instances { }` blocks parse into
+// sibling roots), and compileSections dispatches EVERY matching root — so any
+// AST pre-pass that must observe the whole config (the stable-ID collision
+// gates, the interface-range expansion) has to union across all matching roots,
+// not just the first FindChild hit (#5675 / #5691).
+func (t *ConfigTree) FindChildren(name string) []*Node {
+	var result []*Node
+	for _, child := range t.Children {
+		if len(child.Keys) > 0 && child.Keys[0] == name {
+			result = append(result, child)
+		}
+	}
+	return result
+}
+
 // Clone creates a deep copy of the config tree.
 func (t *ConfigTree) Clone() *ConfigTree {
 	if t == nil {

--- a/pkg/config/compiler_interface_range.go
+++ b/pkg/config/compiler_interface_range.go
@@ -53,52 +53,61 @@ type interfaceRangeDef struct {
 // and leaving the tree byte-identical — when there is no interface-range
 // stanza, so a config without the construct is unaffected.
 func expandInterfaceRanges(tree *ConfigTree) []string {
-	var ifaces *Node
-	for _, n := range tree.Children {
-		if n.Name() == "interfaces" {
-			ifaces = n
-			break
-		}
-	}
-	if ifaces == nil {
+	// #5675: union across EVERY top-level `interfaces` root, not just the first.
+	// A hierarchical config can split its interfaces across two sibling
+	// `interfaces { }` stanzas, and compileSections compiles them all — so if
+	// an interface-range lives in a second root the old first-root-only scan
+	// skipped it, re-minting the #4027 phantom "interface-range" iface and
+	// dropping the range's shared config for its members.
+	ifaceRoots := tree.FindChildren("interfaces")
+	if len(ifaceRoots) == 0 {
 		return nil
 	}
 
-	// Separate interface-range definitions from real interface children.
+	// Separate interface-range definitions from real interface children, across
+	// every interfaces root. keptByRoot holds each root's non-range children so
+	// the strip is deferred until we know a range was actually seen (a config
+	// with no interface-range stays byte-identical — the no-op contract).
 	var ranges []interfaceRangeDef
 	var warnings []string
 	sawRange := false
-	kept := make([]*Node, 0, len(ifaces.Children))
-	for _, child := range ifaces.Children {
-		if child.Name() != "interface-range" {
-			kept = append(kept, child)
-			continue
-		}
-		sawRange = true
-		if len(child.Keys) >= 2 {
-			// Hierarchical: Keys=["interface-range", <name>], children are
-			// the member/config nodes directly.
-			rd, w := parseHierInterfaceRange(child)
-			warnings = append(warnings, w...)
-			if rd != nil {
-				ranges = append(ranges, *rd)
+	keptByRoot := make([][]*Node, len(ifaceRoots))
+	for ri, ifaces := range ifaceRoots {
+		kept := make([]*Node, 0, len(ifaces.Children))
+		for _, child := range ifaces.Children {
+			if child.Name() != "interface-range" {
+				kept = append(kept, child)
+				continue
 			}
-		} else {
-			// Flat-set: Keys=["interface-range"], each child is a leaf whose
-			// Keys[0] is the range name and Keys[1:] the config statement.
-			rds, w := parseFlatInterfaceRanges(child)
-			warnings = append(warnings, w...)
-			ranges = append(ranges, rds...)
+			sawRange = true
+			if len(child.Keys) >= 2 {
+				// Hierarchical: Keys=["interface-range", <name>], children are
+				// the member/config nodes directly.
+				rd, w := parseHierInterfaceRange(child)
+				warnings = append(warnings, w...)
+				if rd != nil {
+					ranges = append(ranges, *rd)
+				}
+			} else {
+				// Flat-set: Keys=["interface-range"], each child is a leaf whose
+				// Keys[0] is the range name and Keys[1:] the config statement.
+				rds, w := parseFlatInterfaceRanges(child)
+				warnings = append(warnings, w...)
+				ranges = append(ranges, rds...)
+			}
 		}
+		keptByRoot[ri] = kept
 	}
 	if !sawRange {
 		// No interface-range stanza present — leave the tree untouched.
 		return nil
 	}
-	// Strip every interface-range node so the range name is never compiled as
-	// a phantom interface, even if the stanza was malformed and yielded no
-	// expandable range.
-	ifaces.Children = kept
+	// Strip every interface-range node (in every root) so the range name is
+	// never compiled as a phantom interface, even if the stanza was malformed
+	// and yielded no expandable range.
+	for ri, ifaces := range ifaceRoots {
+		ifaces.Children = keptByRoot[ri]
+	}
 
 	// Build the ordered, de-duplicated member set and, per member, the
 	// concatenation of every containing range's shared statements (range
@@ -125,22 +134,27 @@ func expandInterfaceRanges(tree *ConfigTree) []string {
 		}
 	}
 
-	// Snapshot and remove each member's existing explicit interface node so
-	// its own statements can be re-applied LAST — SetPath replaces a
-	// single-value leaf (e.g. mtu), so applying shared config first and the
-	// member's own config last gives the member precedence on a conflict
-	// while additive statements (addresses) accumulate.
+	// Snapshot and remove each member's existing explicit interface node (in
+	// every root) so its own statements can be re-applied LAST — SetPath
+	// replaces a single-value leaf (e.g. mtu), so applying shared config first
+	// and the member's own config last gives the member precedence on a
+	// conflict while additive statements (addresses) accumulate. A member whose
+	// own node lives in a different root than its range is still captured
+	// because we sweep every root; SetPath below replays into the first root,
+	// which compileSections merges with the rest.
 	memberOwn := map[string][][]string{}
-	remaining := ifaces.Children[:0]
-	for _, child := range ifaces.Children {
-		name := child.Name()
-		if inRange[name] && !child.IsLeaf {
-			memberOwn[name] = flattenNodesToPaths(child.Children, nil)
-			continue
+	for _, ifaces := range ifaceRoots {
+		remaining := ifaces.Children[:0]
+		for _, child := range ifaces.Children {
+			name := child.Name()
+			if inRange[name] && !child.IsLeaf {
+				memberOwn[name] = append(memberOwn[name], flattenNodesToPaths(child.Children, nil)...)
+				continue
+			}
+			remaining = append(remaining, child)
 		}
-		remaining = append(remaining, child)
+		ifaces.Children = remaining
 	}
-	ifaces.Children = remaining
 
 	for _, m := range memberOrder {
 		for _, p := range memberShared[m] {

--- a/pkg/config/compiler_multi_root_5675_5691_test.go
+++ b/pkg/config/compiler_multi_root_5675_5691_test.go
@@ -1,0 +1,266 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+// A split config with TWO top-level roots of the same stanza is a
+// hierarchical-only shape: the flat-set path (ParseSetCommand + tree.SetPath)
+// always MERGES `set interfaces …` onto ONE `interfaces` root, so it can never
+// produce sibling roots. compileSections, by contrast, dispatches EVERY
+// matching root. These tests pin the AST pre-passes to that reality — they must
+// union across all matching roots, not just the first FindChild hit. They are
+// authored through NewParser (the only shape that can express split roots) and
+// each asserts the two-root precondition before exercising the fix, so a future
+// parser change that starts merging duplicate roots surfaces as a loud
+// precondition failure rather than a silently-passing test.
+
+// TestInterfaceRangeSecondRootExpands_5675 is the #5675 (codex-182 M09)
+// RED-on-revert guard. An `interfaces interface-range` stanza living in a
+// SECOND top-level `interfaces { }` root must still expand into its member
+// interfaces. Before the fix expandInterfaceRanges broke on the first
+// `interfaces` root, so a range in a later root was never expanded: the range
+// name was compiled as a phantom interface (the #4027 regression) and its
+// members plus shared config were dropped. This test goes RED on that behavior.
+func TestInterfaceRangeSecondRootExpands_5675(t *testing.T) {
+	input := `
+interfaces {
+    ge-0/0/0 {
+        mtu 1500;
+    }
+}
+interfaces {
+    interface-range R {
+        member ge-0/0/1;
+        member ge-0/0/2;
+        mtu 9000;
+    }
+}
+`
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	// Precondition: the split-root shape this guards actually exists.
+	if got := len(tree.FindChildren("interfaces")); got != 2 {
+		t.Fatalf("expected 2 top-level interfaces roots, got %d", got)
+	}
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifaces := cfg.Interfaces.Interfaces
+
+	// No phantom interface minted from the second root's range name.
+	if _, ok := ifaces["interface-range"]; ok {
+		t.Errorf("phantom interface %q minted from the second interfaces root (#5675)", "interface-range")
+	}
+	if _, ok := ifaces["R"]; ok {
+		t.Errorf("phantom interface %q minted from the second interfaces root (#5675)", "R")
+	}
+
+	// Both members from the second-root range exist and carry its shared MTU.
+	for _, m := range []string{"ge-0/0/1", "ge-0/0/2"} {
+		ifc, ok := ifaces[m]
+		if !ok {
+			t.Errorf("member %s from the second-root interface-range not compiled (#5675)", m)
+			continue
+		}
+		if ifc.Disable {
+			t.Errorf("member %s must not be admin-down", m)
+		}
+		if ifc.MTU != 9000 {
+			t.Errorf("member %s MTU = %d, want 9000 (second-root range shared config)", m, ifc.MTU)
+		}
+	}
+
+	// The first root's normal interface is untouched.
+	if ge0 := ifaces["ge-0/0/0"]; ge0 == nil || ge0.MTU != 1500 {
+		t.Errorf("first-root ge-0/0/0 disturbed: %+v", ge0)
+	}
+}
+
+// TestZoneIDCollisionAcrossSplitSecurityRoots_5691 is one arm of the #5691
+// (codex-182 M08) RED-on-revert guard. Two security zones whose names fold to
+// the same StableZoneID, split across two top-level `security { }` roots, must
+// be rejected by the collision gate. Before the fix validateZoneIDCollisionAST
+// read only the first `security` root (tree.FindChild), so a collision spanning
+// the roots was invisible and admitted — while compileSections compiled BOTH
+// zones with the same numeric id (a silent zone merge). This test goes RED
+// (err == nil) on that behavior.
+func TestZoneIDCollisionAcrossSplitSecurityRoots_5691(t *testing.T) {
+	a, b := findZoneCollisionPair(t)
+	input := fmt.Sprintf(`
+security {
+    zones {
+        security-zone %s {
+            host-inbound-traffic {
+                system-services {
+                    ping;
+                }
+            }
+        }
+    }
+}
+security {
+    zones {
+        security-zone %s {
+            host-inbound-traffic {
+                system-services {
+                    ping;
+                }
+            }
+        }
+    }
+}
+`, a, b)
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if got := len(tree.FindChildren("security")); got != 2 {
+		t.Fatalf("expected 2 top-level security roots, got %d", got)
+	}
+
+	if _, err := validateZoneIDCollisionAST(tree, false); err == nil {
+		t.Fatalf("expected a zone-id collision error across split security roots "+
+			"(zones %q/%q both fold to %d), got nil (#5691)", a, b, StableZoneID(a))
+	}
+}
+
+// TestRoutingInstanceTableIDCollisionAcrossSplitRoots_5691 is the routing-
+// instance (VRF) arm of the #5691 guard. Two instances whose names fold to the
+// same kernel table id, split across two `routing-instances { }` roots, must be
+// rejected. Before the fix the gate read only the first root, so two VRFs could
+// silently share one kernel table (a cross-VRF route leak). RED on revert.
+func TestRoutingInstanceTableIDCollisionAcrossSplitRoots_5691(t *testing.T) {
+	a, b := findRoutingInstanceCollisionPair(t)
+	input := fmt.Sprintf(`
+routing-instances {
+    %s {
+        instance-type virtual-router;
+    }
+}
+routing-instances {
+    %s {
+        instance-type virtual-router;
+    }
+}
+`, a, b)
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if got := len(tree.FindChildren("routing-instances")); got != 2 {
+		t.Fatalf("expected 2 top-level routing-instances roots, got %d", got)
+	}
+
+	if _, err := validateRoutingInstanceTableIDCollisionAST(tree, false); err == nil {
+		t.Fatalf("expected a routing-instance table-id collision error across split roots "+
+			"(instances %q/%q both fold to table %d), got nil (#5691)",
+			a, b, StableRoutingInstanceTableID(a))
+	}
+}
+
+// TestTunnelEndpointIDCollisionAcrossSplitInterfaceRoots_5691 is the tunnel arm
+// of the #5691 guard. Two tunnel interfaces whose unit-qualified endpoint names
+// fold to the same StableTunnelEndpointID, split across two `interfaces { }`
+// roots, must be rejected. Before the fix View 1 (and Views 2/3) read only the
+// first `interfaces` root, so a cross-root tunnel id collision was admitted
+// while the snapshot builder would drop one endpoint at runtime. RED on revert.
+func TestTunnelEndpointIDCollisionAcrossSplitInterfaceRoots_5691(t *testing.T) {
+	ifA, ifB := findTunnelCollisionPair(t)
+	input := fmt.Sprintf(`
+interfaces {
+    %s {
+        unit 0 {
+            tunnel {
+                source 10.0.0.1;
+                destination 10.0.0.2;
+            }
+        }
+    }
+}
+interfaces {
+    %s {
+        unit 0 {
+            tunnel {
+                source 10.0.1.1;
+                destination 10.0.1.2;
+            }
+        }
+    }
+}
+`, ifA, ifB)
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if got := len(tree.FindChildren("interfaces")); got != 2 {
+		t.Fatalf("expected 2 top-level interfaces roots, got %d", got)
+	}
+
+	if _, err := validateTunnelEndpointIDCollisionAST(tree, false); err == nil {
+		t.Fatalf("expected a tunnel-endpoint id collision error across split interfaces roots "+
+			"(%s.0 / %s.0 both fold to %d), got nil (#5691)",
+			ifA, ifB, StableTunnelEndpointID(ifA+".0"))
+	}
+}
+
+// findZoneCollisionPair returns two distinct zone names that fold to the same
+// StableZoneID. The zone id space has ~65533 buckets, so a collision is found
+// within a few hundred candidates by the birthday bound (pigeonhole guarantees
+// one well before the cap).
+func findZoneCollisionPair(t *testing.T) (string, string) {
+	t.Helper()
+	seen := map[uint16]string{}
+	for i := 0; i < 300000; i++ {
+		name := fmt.Sprintf("zone%d", i)
+		id := StableZoneID(name)
+		if other, ok := seen[id]; ok {
+			return other, name
+		}
+		seen[id] = name
+	}
+	t.Fatal("no StableZoneID collision found within 300000 candidates")
+	return "", ""
+}
+
+// findRoutingInstanceCollisionPair returns two distinct instance names that
+// fold to the same StableRoutingInstanceTableID. The band has 900000 buckets;
+// the birthday bound finds a collision within a couple thousand candidates.
+func findRoutingInstanceCollisionPair(t *testing.T) (string, string) {
+	t.Helper()
+	seen := map[int]string{}
+	for i := 0; i < 300000; i++ {
+		name := fmt.Sprintf("vrf%d", i)
+		id := StableRoutingInstanceTableID(name)
+		if other, ok := seen[id]; ok {
+			return other, name
+		}
+		seen[id] = name
+	}
+	t.Fatal("no StableRoutingInstanceTableID collision found within 300000 candidates")
+	return "", ""
+}
+
+// findTunnelCollisionPair returns two distinct tunnel interface base names
+// whose unit-0 endpoint names ("<base>.0") fold to the same
+// StableTunnelEndpointID. ~65535 buckets, so a collision is found within a few
+// hundred candidates.
+func findTunnelCollisionPair(t *testing.T) (string, string) {
+	t.Helper()
+	seen := map[uint16]string{}
+	for i := 0; i < 300000; i++ {
+		base := fmt.Sprintf("gr-0/0/%d", i)
+		id := StableTunnelEndpointID(base + ".0")
+		if other, ok := seen[id]; ok {
+			return other, base
+		}
+		seen[id] = base
+	}
+	t.Fatal("no StableTunnelEndpointID collision found within 300000 candidates")
+	return "", ""
+}

--- a/pkg/config/routinginstanceid.go
+++ b/pkg/config/routinginstanceid.go
@@ -92,7 +92,12 @@ func emitNodeExpandedRoutingInstanceNames(tree *ConfigTree, nodeID int, out map[
 	if err := clone.ExpandGroupsWithVars(vars); err != nil {
 		return
 	}
-	collectRoutingInstanceNamesAST(clone.FindChild("routing-instances"), out)
+	// #5691: union across every top-level `routing-instances` root — a split
+	// config can declare instances in a second stanza that compileSections still
+	// compiles.
+	for _, ri := range clone.FindChildren("routing-instances") {
+		collectRoutingInstanceNamesAST(ri, out)
+	}
 }
 
 // validateRoutingInstanceTableIDCollisionAST checks the UNION of routing-instance
@@ -120,8 +125,13 @@ func emitNodeExpandedRoutingInstanceNames(tree *ConfigTree, nodeID int, out map[
 // so the two never actually share a kernel table.
 func validateRoutingInstanceTableIDCollisionAST(tree *ConfigTree, lenient bool) ([]string, error) {
 	names := make(map[string]struct{})
-	// View 1 — pre-expansion presence union (main + every groups block).
-	collectRoutingInstanceNamesAST(tree.FindChild("routing-instances"), names)
+	// View 1 — pre-expansion presence union (main + every groups block). Union
+	// across EVERY top-level `routing-instances` root (#5691): a split config can
+	// declare instances in a second stanza, and compileSections compiles them
+	// all, so a first-root-only scan would miss a collision spanning the roots.
+	for _, ri := range tree.FindChildren("routing-instances") {
+		collectRoutingInstanceNamesAST(ri, names)
+	}
 	for _, child := range tree.Children {
 		if child.Name() != "groups" {
 			continue
@@ -131,10 +141,14 @@ func validateRoutingInstanceTableIDCollisionAST(tree *ConfigTree, lenient bool) 
 			// Keys[1]; the children are then the group body. The other shape
 			// nests the group name as a child node.
 			if len(child.Keys) >= 2 {
-				collectRoutingInstanceNamesAST(child.FindChild("routing-instances"), names)
+				for _, ri := range child.FindChildren("routing-instances") {
+					collectRoutingInstanceNamesAST(ri, names)
+				}
 				break
 			}
-			collectRoutingInstanceNamesAST(group.FindChild("routing-instances"), names)
+			for _, ri := range group.FindChildren("routing-instances") {
+				collectRoutingInstanceNamesAST(ri, names)
+			}
 		}
 	}
 	// Views 2/3 — post-expansion instance names for node0 and node1. Both

--- a/pkg/config/tunnelid.go
+++ b/pkg/config/tunnelid.go
@@ -174,13 +174,21 @@ func emitNodeExpandedTunnelNames(tree *ConfigTree, nodeID int, out map[string]st
 	if err := clone.ExpandGroupsWithVars(vars); err != nil {
 		return
 	}
-	ifacesNode := clone.FindChild("interfaces")
-	if ifacesNode == nil {
+	// #5691: compile EVERY top-level `interfaces` root into one InterfacesConfig
+	// (compileInterfaces merges into the shared map, exactly as compileSections
+	// dispatches each root) so a tunnel split into a second stanza is emitted
+	// here too. A per-root compile error contributes the empty set (non-fatal),
+	// matching the pre-existing doctrine — View 1 above already covers the
+	// pre-expansion union.
+	ifacesNodes := clone.FindChildren("interfaces")
+	if len(ifacesNodes) == 0 {
 		return
 	}
 	ifaces := InterfacesConfig{Interfaces: make(map[string]*InterfaceConfig)}
-	if err := compileInterfaces(ifacesNode, &ifaces); err != nil {
-		return
+	for _, ifacesNode := range ifacesNodes {
+		if err := compileInterfaces(ifacesNode, &ifaces); err != nil {
+			return
+		}
 	}
 	cfg := &Config{Interfaces: ifaces}
 	for _, ep := range EmitTunnelEndpointNames(cfg) {
@@ -238,8 +246,14 @@ func emitNodeExpandedTunnelNames(tree *ConfigTree, nodeID int, out map[string]st
 // buildTunnelEndpointSnapshots).
 func validateTunnelEndpointIDCollisionAST(tree *ConfigTree, lenient bool) ([]string, error) {
 	names := make(map[string]struct{})
-	// View 1 — pre-expansion presence union (UNCHANGED, #1873).
-	collectTunnelEndpointNamesAST(tree.FindChild("interfaces"), names)
+	// View 1 — pre-expansion presence union (#1873). Union across EVERY
+	// top-level `interfaces` root (#5691): a split config can declare tunnel
+	// interfaces in a second `interfaces { }` stanza, and compileSections
+	// compiles them all, so a first-root-only scan would miss a collision
+	// spanning the roots.
+	for _, ifaces := range tree.FindChildren("interfaces") {
+		collectTunnelEndpointNamesAST(ifaces, names)
+	}
 	for _, child := range tree.Children {
 		if child.Name() != "groups" {
 			continue
@@ -248,10 +262,14 @@ func validateTunnelEndpointIDCollisionAST(tree *ConfigTree, lenient bool) ([]str
 			// Node{Keys:["groups","node0"]} merges the group name
 			// into Keys[1]; the children are then the group body.
 			if len(child.Keys) >= 2 {
-				collectTunnelEndpointNamesAST(child.FindChild("interfaces"), names)
+				for _, ifaces := range child.FindChildren("interfaces") {
+					collectTunnelEndpointNamesAST(ifaces, names)
+				}
 				break
 			}
-			collectTunnelEndpointNamesAST(group.FindChild("interfaces"), names)
+			for _, ifaces := range group.FindChildren("interfaces") {
+				collectTunnelEndpointNamesAST(ifaces, names)
+			}
 		}
 	}
 	// Views 2/3 — post-expansion emitted names for node0 and node1

--- a/pkg/config/zoneid.go
+++ b/pkg/config/zoneid.go
@@ -88,7 +88,12 @@ func emitNodeExpandedZoneNames(tree *ConfigTree, nodeID int, out map[string]stru
 	if err := clone.ExpandGroupsWithVars(vars); err != nil {
 		return
 	}
-	collectZoneNamesAST(clone.FindChild("security"), out)
+	// #5691: union across every top-level `security` root — a split config can
+	// declare zones in a second `security { }` stanza that compileSections still
+	// compiles.
+	for _, sec := range clone.FindChildren("security") {
+		collectZoneNamesAST(sec, out)
+	}
 }
 
 // validateZoneIDCollisionAST checks the UNION of security-zone names across
@@ -120,8 +125,13 @@ func emitNodeExpandedZoneNames(tree *ConfigTree, nodeID int, out map[string]stru
 // is inert on the later-folding zone rather than mis-attributed.
 func validateZoneIDCollisionAST(tree *ConfigTree, lenient bool) ([]string, error) {
 	names := make(map[string]struct{})
-	// View 1 — pre-expansion presence union (main + every groups block).
-	collectZoneNamesAST(tree.FindChild("security"), names)
+	// View 1 — pre-expansion presence union (main + every groups block). Union
+	// across EVERY top-level `security` root (#5691): a split config can declare
+	// zones in a second `security { }` stanza, and compileSections compiles them
+	// all, so a first-root-only scan would miss a collision spanning the roots.
+	for _, sec := range tree.FindChildren("security") {
+		collectZoneNamesAST(sec, names)
+	}
 	for _, child := range tree.Children {
 		if child.Name() != "groups" {
 			continue
@@ -131,10 +141,14 @@ func validateZoneIDCollisionAST(tree *ConfigTree, lenient bool) ([]string, error
 			// Keys[1]; the children are then the group body. The other shape
 			// nests the group name as a child node.
 			if len(child.Keys) >= 2 {
-				collectZoneNamesAST(child.FindChild("security"), names)
+				for _, sec := range child.FindChildren("security") {
+					collectZoneNamesAST(sec, names)
+				}
 				break
 			}
-			collectZoneNamesAST(group.FindChild("security"), names)
+			for _, sec := range group.FindChildren("security") {
+				collectZoneNamesAST(sec, names)
+			}
 		}
 	}
 	// Views 2/3 — post-expansion zone names for node0 and node1. Both computed


### PR DESCRIPTION
## Summary

Several config-compiler AST pre-passes located their target stanza with a
**first-match scan** (`FindChild` / a `for … break` on the first `interfaces`),
while `compileSections` dispatches **every** matching top-level root. A Junos
config can legitimately carry the same top-level stanza more than once — two
hierarchical `interfaces { }` / `security { }` / `routing-instances { }` blocks
parse into sibling roots. So a config that split its definitions across repeated
top-level roots had the later roots **bypass the pre-pass** while still
compiling normally.

(The flat-set path always merges `set …` onto one root via `SetPath`, so the
split-root shape is **hierarchical-only** — the tests are authored through
`NewParser` and assert the two-root precondition.)

### #5675 (codex-182 M09) — interface-range
`expandInterfaceRanges` (#4027) broke on the first `interfaces` root. An
`interface-range` stanza in a **second** root was never expanded — re-minting
the phantom `interface-range` interface the #4027 pass exists to prevent and
dropping the range's shared config for its members. `interface-range` is exempt
from the #5180 duplicate-block gate, so split roots reach this bug.

### #5691 (codex-182 M08) — stable-ID collision gates
The stable-ID collision gates for **zones** (#3075), **tunnel endpoints**
(#1873), and **routing-instances** (#3855) computed their name union from only
the first matching root (View 1 and the per-node Views 2/3). A stable-ID
collision spanning two roots was silently admitted while both colliding objects
compiled with the same numeric id — a silent zone merge / cross-VRF kernel-table
share / dropped tunnel endpoint.

## Fix
- Add `ConfigTree.FindChildren`; union every matching top-level root (and every
  same-stanza sibling inside a `groups` body) in each pre-pass.
- `expandInterfaceRanges` collects ranges + member-own config across all
  `interfaces` roots and replays members through `SetPath` (merged by
  `compileSections`); `emitNodeExpandedTunnelNames` compiles every `interfaces`
  root into one `InterfacesConfig`.
- For a **single-root** config `FindChildren` returns exactly one root → behavior
  is bit-identical in the common case. The change only **adds** coverage/rejects
  for split-root configs (monotone over the prior verdict).

## Validation
- `go test ./pkg/config/...` green.
- New fail-on-revert tests in `compiler_multi_root_5675_5691_test.go`:
  `TestInterfaceRangeSecondRootExpands_5675` (end-to-end) plus three `_5691`
  collision arms (zone / routing-instance / tunnel, computed colliding pairs).
  Each proven **RED** when the multi-root aggregation is neutralized back to
  first-root-only and **GREEN** when restored.
- Docs: updated the #4027 section in `docs/config-schema.md`.

Closes #5675
Closes #5691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mYhLdWkbQNKSVvvdYaJDq