### PR TITLE
dhcp: use one stable DUID across DHCPv6 acquisition and renewal

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47076,3 +47076,12 @@ top.
   semantics. Fail-on-revert proven (predefined-bundle match RED on the user-only
   gate; shadow test not gate-dependent). Diagnostic simulator only (non-enforcement).
 - **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/predefined_set_5666_test.go
+
+## 2026-07-12 — #5711 DHCPv6 stable DUID across acquisition/renewal
+- **Timestamp**: 2026-07-12
+- **Action**: Fix DUID mismatch — bare acquisition used library-default DUID-LLT
+  (GetTime per-message) while renewal used persistent getDUID DUID-LL; make
+  buildDHCPv6Modifiers always attach the persistent getDUID client ID (symmetric
+  with buildDHCPv6RenewModifiers). Added fail-on-revert tests.
+- **File(s)**: pkg/dhcp/dhcp.go (Edit), pkg/dhcp/duid_stability_5711_test.go
+  (Write), pkg/dhcp/README.md (Edit)

--- a/_Log.md
+++ b/_Log.md
@@ -47129,3 +47129,16 @@ top.
   pkg/daemon/device_map_teardown_failclosed_5309_test.go,
   pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go,
   pkg/daemon/README.md
+
+## 2026-07-12 — #5711/#5743 test-quality fold (hostile-review)
+- **Timestamp**: 2026-07-12
+- **Action**: Fold two TEST-QUALITY findings from PR #5743 review (production
+  fix unchanged). (1) DUID-LLT companion test now seeds a persistent DUID-LLT
+  with Time set one hour in the past so it genuinely flips RED on revert
+  (acquisition default-LLT Time≈now vs renewal persisted-LLT Time=now-3600 →
+  bytes differ by 3600s); verified RED with the fix neutralized. (2) De-fragilized
+  the nil-opts sub-test in TestBuildDHCPv6Modifiers: seed a known DUID so getDUID
+  resolves deterministically from cache and assert exactly one Client-ID DUID is
+  attached (was asserting len==0, which only held on hosts lacking eth0).
+- **File(s)**: pkg/dhcp/duid_stability_5711_test.go (Edit),
+  pkg/dhcp/dhcp_test.go (Edit)

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -102,6 +102,18 @@ the debounced `onAddressChange` callback when content changed.
   `Lease.v6ServerDUID` fields so a later RENEW can target the original
   server. DHCPv6 stateless mode has no binding, so every refresh stays
   an Information-Request regardless of mode.
+- **Stable client DUID across acquisition and renewal (#5711)**: RFC
+  8415 §11 requires the *client* DUID to be constant for the client's
+  lifetime — the server binds the lease to it, so a RENEW/REBIND under a
+  different DUID is a new client and the lease is not renewed. Both the
+  acquisition modifiers (`buildDHCPv6Modifiers`) and the renew modifiers
+  (`buildDHCPv6RenewModifiers`) now unconditionally attach the persistent
+  `getDUID` client ID. Previously `buildDHCPv6Modifiers` returned no
+  modifiers when the interface had no configured DHCPv6 options, so the
+  bare-acquisition SOLICIT fell back to `dhcpv6.NewSolicit`'s default
+  DUID-LLT (a `GetTime()` timestamp stamped at send) while the renew path
+  presented the persistent DUID-LL — a DUID mismatch that churned the
+  lease on every renewal.
 - **Timeout falls through, NAK abandons (#3956)**: a renew *timeout*
   (no reply) at T1 falls through to the T2 rebind; a second timeout (or
   a failure to apply the renewed address) falls back to full

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -1674,15 +1674,25 @@ func (m *Manager) buildDHCPv6RenewModifiers(ifaceName string, opts *DHCPv6Option
 
 // buildDHCPv6Modifiers constructs DHCPv6 message modifiers from interface options.
 func (m *Manager) buildDHCPv6Modifiers(ifaceName string, opts *DHCPv6Options) []dhcpv6.Modifier {
-	if opts == nil {
-		return nil
-	}
-
 	var mods []dhcpv6.Modifier
 
-	// Use persistent DUID if configured
+	// The client DUID MUST stay stable across every DHCPv6 message for the
+	// lifetime of the client (RFC 8415 §11): the server binds the lease to
+	// the DUID, so the initial SOLICIT/REQUEST and its later RENEW/REBIND
+	// must present byte-identical client IDs. Always attach the persistent
+	// DUID — even when no DHCPv6 options are configured (opts == nil, the
+	// bare-acquisition path). Otherwise dhcpv6.NewSolicit (via RapidSolicit)
+	// falls back to a default DUID-LLT stamped with GetTime() at send, while
+	// the renew path (buildDHCPv6RenewModifiers) always uses the persistent
+	// getDUID (DUID-LL): the two paths present different DUIDs, the server
+	// treats the renewal as a new client, and the original lease is not
+	// renewed (#5711).
 	if duid, err := m.getDUID(ifaceName); err == nil {
 		mods = append(mods, dhcpv6.WithClientID(duid))
+	}
+
+	if opts == nil {
+		return mods
 	}
 
 	// Add IA_PD if requested

--- a/pkg/dhcp/dhcp_test.go
+++ b/pkg/dhcp/dhcp_test.go
@@ -1,12 +1,14 @@
 package dhcp
 
 import (
+	"bytes"
 	"net"
 	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/iana"
 )
 
 func TestExtractDelegatedPrefixes(t *testing.T) {
@@ -129,9 +131,36 @@ func TestBuildDHCPv6Modifiers(t *testing.T) {
 	}
 
 	t.Run("nil opts", func(t *testing.T) {
+		// Post-#5711 contract: even with no configured DHCPv6 options, the
+		// modifiers MUST carry the persistent Client-ID DUID so acquisition
+		// and renewal present the same identity. Seed a known DUID so getDUID
+		// resolves deterministically from the in-memory cache — independent of
+		// whether an "eth0" happens to exist on the test host (the old
+		// len(mods)==0 assertion only passed because getDUID errored on a host
+		// with no eth0; on a host with one it would have failed).
+		want := &dhcpv6.DUIDLL{
+			HWType:        iana.HWTypeEthernet,
+			LinkLayerAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01},
+		}
+		m.duids["eth0"] = want
+		defer delete(m.duids, "eth0")
+
 		mods := m.buildDHCPv6Modifiers("eth0", nil)
-		if len(mods) != 0 {
-			t.Errorf("got %d modifiers, want 0", len(mods))
+
+		msg, err := dhcpv6.NewMessage()
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.MessageType = dhcpv6.MessageTypeSolicit
+		for _, mod := range mods {
+			mod(msg)
+		}
+		got := msg.Options.ClientID()
+		if got == nil {
+			t.Fatal("nil opts must still attach the persistent Client-ID DUID (#5711)")
+		}
+		if !bytes.Equal(got.ToBytes(), want.ToBytes()) {
+			t.Errorf("Client-ID DUID = %x, want %x", got.ToBytes(), want.ToBytes())
 		}
 	})
 

--- a/pkg/dhcp/duid_stability_5711_test.go
+++ b/pkg/dhcp/duid_stability_5711_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/iana"
 )
 
 // firstHWIface returns a local interface whose hardware address is at least 4
@@ -92,18 +94,36 @@ func TestDHCPv6DUIDStableAcrossAcquisitionAndRenew(t *testing.T) {
 // TestDHCPv6DUIDLLTStableAcrossAcquisitionAndRenew is the DUID-LLT companion to
 // the above. A DUID-LLT embeds a generation timestamp; the stable identity must
 // come from the once-generated, persisted DUID-LLT — the same Time on every
-// message — NOT a per-message GetTime(). If acquisition recomputed the LLT Time
-// while renewal used the persisted one, their bytes would differ even though
-// both are DUID-LLT.
+// message — NOT a per-message GetTime().
 //
-// RED on revert: acquisition (opts == nil -> nil mods) let NewSolicit stamp a
-// fresh DUID-LLT with GetTime() at send, so the Time field (and thus the bytes)
-// would not match the persisted DUID-LLT the renew path presents.
+// This models the real production timeline: the DUID-LLT is generated and
+// persisted at boot (T0), and a RENEW fires hours later (T1). We seed the
+// persistent DUID-LLT with a Time set an hour in the PAST so it is clearly
+// distinct from a fresh GetTime() stamped at send. getDUID returns this cached
+// identity to both paths.
+//
+// RED on revert: with the fix neutralized (opts == nil -> nil mods),
+// acquisition falls through to dhcpv6.NewSolicit's default DUID-LLT whose Time
+// is GetTime() ≈ now, while the renew path presents the persisted DUID-LLT with
+// Time ≈ now-3600. Same DUID *type*, but the Time field (and thus the bytes)
+// differ by ~3600 — so the assertion flips RED. A naive "generate the LLT via
+// getDUID and compare" would NOT flip, because the default-at-send Time and a
+// just-generated persisted Time collapse to the same whole second.
 func TestDHCPv6DUIDLLTStableAcrossAcquisitionAndRenew(t *testing.T) {
 	ifc := firstHWIface(t)
 
+	// Persisted-at-boot DUID-LLT, Time one hour ago (relative to the dhcpv6
+	// 2000-01-01 epoch getDUID/GetTime both use). Seed the in-memory cache so
+	// getDUID returns exactly this identity for both paths.
+	epoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	pastTime := uint32(time.Since(epoch).Seconds()) - 3600 // an hour before "now"
+	persisted := &dhcpv6.DUIDLLT{
+		HWType:        iana.HWTypeEthernet,
+		Time:          pastTime,
+		LinkLayerAddr: ifc.HardwareAddr,
+	}
 	m := &Manager{
-		duids:     map[string]dhcpv6.DUID{},
+		duids:     map[string]dhcpv6.DUID{ifc.Name: persisted},
 		duidTypes: map[string]string{ifc.Name: "duid-llt"},
 		stateDir:  t.TempDir(),
 	}
@@ -111,12 +131,12 @@ func TestDHCPv6DUIDLLTStableAcrossAcquisitionAndRenew(t *testing.T) {
 	acq := acquisitionDUID(t, m, ifc)
 	renew := renewalDUID(t, m, ifc)
 	if !bytes.Equal(acq, renew) {
-		t.Fatalf("DUID-LLT diverges between acquisition and renewal (timestamp recomputed per-message?):\n  acquisition=%x\n  renewal    =%x", acq, renew)
+		t.Fatalf("DUID-LLT diverges between acquisition and renewal (per-message GetTime() vs persisted Time?):\n  acquisition=%x\n  renewal    =%x", acq, renew)
 	}
 
-	// Sanity: the stable identity must actually be a DUID-LLT (type 1), not a
-	// silently substituted default.
-	if got := m.duids[ifc.Name]; got == nil || got.DUIDType() != dhcpv6.DUID_LLT {
-		t.Fatalf("expected a persisted DUID-LLT, got %v", got)
+	// Both paths must present the persisted DUID-LLT byte-for-byte (including
+	// the past Time), not a silently substituted default-at-send LLT.
+	if want := persisted.ToBytes(); !bytes.Equal(acq, want) {
+		t.Fatalf("acquisition DUID-LLT is not the persisted identity:\n  got  =%x\n  want =%x", acq, want)
 	}
 }

--- a/pkg/dhcp/duid_stability_5711_test.go
+++ b/pkg/dhcp/duid_stability_5711_test.go
@@ -1,0 +1,122 @@
+package dhcp
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+// firstHWIface returns a local interface whose hardware address is at least 4
+// bytes long — dhcpv6.NewSolicit derives the IA_NA IAID from the last 4 MAC
+// bytes and errors on a shorter address, so loopback (empty MAC) will not do.
+// Skips the test when no such interface exists.
+func firstHWIface(t *testing.T) net.Interface {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Skipf("enumerate interfaces: %v", err)
+	}
+	for _, ifc := range ifaces {
+		if len(ifc.HardwareAddr) >= 4 {
+			return ifc
+		}
+	}
+	t.Skip("no interface with a >=4-byte hardware address available")
+	return net.Interface{}
+}
+
+// clientIDBytes rebuilds the SOLICIT the acquisition path actually sends
+// (dhcpv6.NewSolicit + WithRapidCommit, mirroring nclient6.RapidSolicit) and
+// the RENEW the renewal path sends (buildV6RenewMessage), then returns the
+// Client-ID DUID bytes each presents on the wire.
+func acquisitionDUID(t *testing.T, m *Manager, ifc net.Interface) []byte {
+	t.Helper()
+	mods := m.buildDHCPv6Modifiers(ifc.Name, nil)
+	sol, err := dhcpv6.NewSolicit(ifc.HardwareAddr, append(mods, dhcpv6.WithRapidCommit)...)
+	if err != nil {
+		t.Fatalf("build acquisition SOLICIT: %v", err)
+	}
+	duid := sol.Options.ClientID()
+	if duid == nil {
+		t.Fatal("acquisition SOLICIT carries no Client-ID")
+	}
+	return duid.ToBytes()
+}
+
+func renewalDUID(t *testing.T, m *Manager, ifc net.Interface) []byte {
+	t.Helper()
+	renewMods := m.buildDHCPv6RenewModifiers(ifc.Name, nil)
+	msg, err := buildV6RenewMessage(ifc.HardwareAddr, nil, nil, false, renewMods)
+	if err != nil {
+		t.Fatalf("build RENEW: %v", err)
+	}
+	duid := msg.Options.ClientID()
+	if duid == nil {
+		t.Fatal("RENEW carries no Client-ID")
+	}
+	return duid.ToBytes()
+}
+
+// TestDHCPv6DUIDStableAcrossAcquisitionAndRenew pins #5711: the DUID a bare
+// DHCPv6 client presents at initial acquisition (SOLICIT) MUST be byte-identical
+// to the DUID it presents at RENEW/REBIND. RFC 8415 §11 requires a stable
+// client DUID for the client's lifetime; the server binds the lease to it, so a
+// renewal sent under a different DUID is a new client and the original lease is
+// not renewed.
+//
+// RED on revert: before the fix, buildDHCPv6Modifiers returned nil when
+// opts == nil, so RapidSolicit/NewSolicit fell back to its default DUID-LLT
+// (Time = GetTime() at send) while the renew path always used the persistent
+// getDUID (default DUID-LL). Acquisition presented a DUID-LLT and renewal a
+// DUID-LL — different type and different bytes — and this assertion fails.
+func TestDHCPv6DUIDStableAcrossAcquisitionAndRenew(t *testing.T) {
+	ifc := firstHWIface(t)
+
+	// Default DUID type (empty -> DUID-LL). Both paths must read the same
+	// persistent identity.
+	m := &Manager{
+		duids:     map[string]dhcpv6.DUID{},
+		duidTypes: map[string]string{},
+		stateDir:  t.TempDir(),
+	}
+
+	acq := acquisitionDUID(t, m, ifc)
+	renew := renewalDUID(t, m, ifc)
+	if !bytes.Equal(acq, renew) {
+		t.Fatalf("DUID diverges between acquisition and renewal:\n  acquisition=%x\n  renewal    =%x", acq, renew)
+	}
+}
+
+// TestDHCPv6DUIDLLTStableAcrossAcquisitionAndRenew is the DUID-LLT companion to
+// the above. A DUID-LLT embeds a generation timestamp; the stable identity must
+// come from the once-generated, persisted DUID-LLT — the same Time on every
+// message — NOT a per-message GetTime(). If acquisition recomputed the LLT Time
+// while renewal used the persisted one, their bytes would differ even though
+// both are DUID-LLT.
+//
+// RED on revert: acquisition (opts == nil -> nil mods) let NewSolicit stamp a
+// fresh DUID-LLT with GetTime() at send, so the Time field (and thus the bytes)
+// would not match the persisted DUID-LLT the renew path presents.
+func TestDHCPv6DUIDLLTStableAcrossAcquisitionAndRenew(t *testing.T) {
+	ifc := firstHWIface(t)
+
+	m := &Manager{
+		duids:     map[string]dhcpv6.DUID{},
+		duidTypes: map[string]string{ifc.Name: "duid-llt"},
+		stateDir:  t.TempDir(),
+	}
+
+	acq := acquisitionDUID(t, m, ifc)
+	renew := renewalDUID(t, m, ifc)
+	if !bytes.Equal(acq, renew) {
+		t.Fatalf("DUID-LLT diverges between acquisition and renewal (timestamp recomputed per-message?):\n  acquisition=%x\n  renewal    =%x", acq, renew)
+	}
+
+	// Sanity: the stable identity must actually be a DUID-LLT (type 1), not a
+	// silently substituted default.
+	if got := m.duids[ifc.Name]; got == nil || got.DUIDType() != dhcpv6.DUID_LLT {
+		t.Fatalf("expected a persisted DUID-LLT, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

The bare DHCPv6 acquisition path and the renewal path presented **different client DUIDs**, so a DHCPv6 server treated a renewal as a brand-new client and did not renew the original lease (address churn / renewal failure). RFC 8415 §11 requires the client DUID to be stable for the lifetime of the client across all message types — the server binds the lease to the DUID.

## Where they diverged

- **Acquisition** — `buildDHCPv6Modifiers` (`pkg/dhcp/dhcp.go`) returned `nil` when the interface had no configured DHCPv6 options (`opts == nil`). With no `WithClientID` modifier, `dhcpv6.NewSolicit` (via `nclient6.RapidSolicit`) fell back to its **default DUID-LLT**, whose `Time` field is `GetTime()` stamped at send.
- **Renewal** — `buildDHCPv6RenewModifiers` (`pkg/dhcp/dhcp.go`) always attached the persistent `getDUID` client ID (default **DUID-LL**).

So acquisition sent `0001...` (DUID-LLT) and renewal sent `0003...` (DUID-LL) — different type and different bytes.

## Fix

`buildDHCPv6Modifiers` now unconditionally attaches the persistent `getDUID` client ID **before** the `opts == nil` early return, symmetric with `buildDHCPv6RenewModifiers`. Both paths read the same single source of truth (`getDUID`: in-memory cache → persisted file → generate+persist), so acquisition and renewal present byte-identical DUIDs. This also pins the DUID-LLT timestamp — the once-generated, persisted `Time` is reused on every message rather than recomputed per SOLICIT.

## Validation

- Added fail-on-revert tests in `pkg/dhcp/duid_stability_5711_test.go` that build the real acquisition SOLICIT (`dhcpv6.NewSolicit` + rapid commit) and the RENEW (`buildV6RenewMessage`) and assert the Client-ID DUID bytes are identical — for both the default DUID-LL and the DUID-LLT type.
- Proven **RED** with the fix neutralized (restoring the `opts == nil` early return): `acquisition=0001...31e6582b...` (DUID-LLT) vs `renewal=00030001...` (DUID-LL). **GREEN** with the fix.
- `go vet ./pkg/dhcp/...` and `go test ./pkg/dhcp/...` pass.

Closes #5711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeJ3FuuVMeAz3dnJgSd3tC