### PR TITLE
daemon: fail-close route-only publish on unpublished policy delta (#5680)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47109,3 +47109,26 @@ top.
   pkg/daemon/device_map_teardown_failclosed_5309_test.go,
   pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go,
   pkg/daemon/README.md
+
+- **Timestamp**: 2026-07-12 (#5680)
+- **Action**: #5680 fix — route-only publication no longer ACKs an
+  old-policy/new-route HYBRID as the applied config. PublishRouteOverlaySnapshot
+  (manager_overlay.go) rebuilds ONLY next.Routes and inherits every compiled
+  policy section from m.lastSnapshot, then stamped next.Config = cfg +
+  markAppliedSnapshotLocked → advanced the applied identity to cfg even when
+  cfg's policy half was never compiled into the snapshot (the #5679 residual: an
+  ordinary ApplyConfig failure leaves lastSnapshot at the OLD policy while
+  store.Commit promoted the NEW cfg; the tail route-leak republish + ipmon
+  actuator then pass the NEW cfg). Added a fail-closed guard
+  (routeOnlyPublishHybrid): refuse the publish when cfg is not the config
+  lastSnapshot was compiled from (pointer fast-path + reflect.DeepEqual
+  fallback so a distinct-but-equal config is never falsely refused). On refusal
+  the OLD consistent snapshot stays live and the desired-overlay cache stays at
+  baseline (#3760). Added fail-on-revert test (RED proven with the guard
+  neutralized: publish returns nil error + appliedSnapshot advances to cfgB +
+  hybrid shipped to helper) plus a false-refusal guard test. Composes with
+  #5679 (commit already fails via applyErr; this stops the manager's applied
+  identity from lying). gofmt clean; pkg/dataplane/userspace + pkg/daemon green.
+- **File(s)**: pkg/dataplane/userspace/manager_overlay.go,
+  pkg/dataplane/userspace/route_overlay_test.go,
+  docs/rib-group-route-leaking.md, _Log.md

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -103,6 +103,30 @@ routes-only publish surface (no `Compile`, no helper restart) and duplicate-skip
 an unchanged route set, so a steady-state commit and a never-had-a-rib-group
 config publish nothing.
 
+**Hybrid-ACK guard (#5680, composes with #5679).** The routes-only publish
+surface (`Manager.PublishRouteOverlaySnapshot`, `manager_overlay.go`) rebuilds
+**only** the snapshot's `Routes` section and inherits every compiled policy
+section (zones/policies/NAT/screens/address-books) verbatim from
+`m.lastSnapshot` — the sections the last full `Compile`-based apply built from
+`m.lastSnapshot.Config`. If the passed `cfg` carries a **policy** delta that was
+never compiled into that snapshot, stamping `next.Config = cfg` (and the
+`markAppliedSnapshotLocked` that follows) would advance the applied identity to
+an **old-policy/new-route hybrid** — the operator would be told the new config
+is live while the dataplane still enforces the old policy. This is the #5679
+residual: an ordinary `d.dp.ApplyConfig` failure captures `applyErr` and
+continues (fail-closed but complete) **without** advancing `m.lastSnapshot`,
+while `store.Commit` has already promoted the new `cfg`; the tail route-leak
+republish (and the ip-monitoring actuator) then pass that new `cfg`. The publish
+therefore **refuses** (`routeOnlyPublishHybrid`) whenever `cfg` is not the
+config `m.lastSnapshot` was compiled from — pointer-identical in every
+legitimate route-only publish (`store.ActiveConfig()` == the object handed to
+`ApplyConfig`), with a `reflect.DeepEqual` fallback so a distinct-but-equal
+config is never falsely refused. On refusal the old, fully-consistent snapshot
+stays live, the desired-overlay cache stays at its baseline (the #3760
+mutate-after-success contract), and the caller reconverges once a full apply
+republishes the policy (`reconcileRouteLeakSnapshot` warns; the ip-monitoring
+actuator stays dirty and retries).
+
 ## Fail-loud diagnostics (commit-time warnings)
 
 `config.ValidateConfig` (`validateRibGroupLeakWarnings`) warns — rather than

--- a/pkg/dataplane/userspace/manager_overlay.go
+++ b/pkg/dataplane/userspace/manager_overlay.go
@@ -3,6 +3,7 @@ package userspace
 import (
 	"fmt"
 	"log/slog"
+	"reflect"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -135,6 +136,43 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 		return false, nil
 	}
 
+	// #5680: fail-closed hybrid-ACK guard. A route-only publish rebuilds ONLY
+	// next.Routes (below) and inherits EVERY compiled policy section
+	// (Zones/Policies/NAT/Screens/AddressBooks/...) verbatim from m.lastSnapshot
+	// via `next := *m.lastSnapshot`. Those sections were built by the last full,
+	// Compile-based apply_snapshot from m.lastSnapshot.Config — this path never
+	// re-compiles. If the caller passes a cfg whose POLICY half was never
+	// compiled into that snapshot, stamping next.Config = cfg and calling
+	// markAppliedSnapshotLocked would advance the applied identity
+	// (appliedSnapshot.Config) to a cfg the helper's live policy does NOT match:
+	// an OLD-policy/NEW-route HYBRID ACK'd as the newly applied config.
+	//
+	// This is the #5679 residual: an ordinary d.dp.ApplyConfig failure captures
+	// applyErr and continues (fail-closed but complete) WITHOUT advancing
+	// m.lastSnapshot, while store.Commit has already promoted the NEW cfg. The
+	// tail route-leak republish (reconcileRouteLeakSnapshot) and the
+	// ip-monitoring actuator then call this with the NEW cfg. Refuse the publish
+	// (fail-closed) so the applied identity never advances past the policy the
+	// dataplane actually enforces; the OLD, fully-consistent snapshot stays live
+	// and the caller reconverges once a full apply republishes the policy
+	// (reconcileRouteLeakSnapshot warns; the ipmon actuator stays dirty and
+	// retries). The deferred m.routeOverlay commit above is gated on err == nil,
+	// so a refused publish also leaves the desired-overlay cache at its
+	// last-applied baseline (the #3760 mutate-after-success contract).
+	//
+	// In EVERY legitimate route-only publish cfg IS the applied config: the
+	// ip-monitoring actuator passes store.ActiveConfig() and the route-leak
+	// reconcile passes the just-applied cfg, both pointer-identical to
+	// m.lastSnapshot.Config (ApplyConfig stores the exact object ActiveConfig
+	// returns). The pointer check short-circuits that common fast path; the
+	// content fallback only rejects a genuinely divergent config, never a
+	// distinct-but-equal one.
+	if routeOnlyPublishHybrid(cfg, m.lastSnapshot.Config) {
+		return false, fmt.Errorf("refusing route-only publish: cfg carries an unpublished " +
+			"policy delta the dataplane snapshot does not reflect; publishing would ACK an " +
+			"old-policy/new-route hybrid as the applied config (#5680)")
+	}
+
 	if err := m.ensureRequiredSnapshotProtocolLocked(cfg); err != nil {
 		if disarmErr := m.disarmSnapshotProtocolFailureLocked(err); disarmErr != nil {
 			slog.Warn("userspace: failed to disarm helper after refusing overlay publish",
@@ -194,4 +232,27 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 	slog.Info("userspace: route overlay snapshot published",
 		"generation", next.Generation, "overlay_routes", len(desiredOverlay))
 	return true, nil
+}
+
+// routeOnlyPublishHybrid reports whether a route-only publish for cfg would ship
+// an OLD-policy/NEW-route hybrid (#5680). applied is the config whose compiled
+// policy sections the current lastSnapshot carries (m.lastSnapshot.Config, set
+// together at each full Compile-based apply). The publish is a hybrid iff cfg is
+// NOT that config: it re-derives routes from cfg but keeps applied's compiled
+// policy, so ACK'ing cfg as applied would misreport the enforced policy.
+//
+// Nil applied (no established policy identity — e.g. the config-less bootstrap
+// snapshot) is not a hybrid: there is no policy identity to violate. Pointer
+// identity is the common legitimate case and the cheap fast path; the
+// reflect.DeepEqual fallback ensures a distinct-but-content-equal config is
+// accepted (never a false refusal) while a genuinely divergent config is
+// refused.
+func routeOnlyPublishHybrid(cfg, applied *config.Config) bool {
+	if applied == nil {
+		return false
+	}
+	if cfg == applied {
+		return false
+	}
+	return !reflect.DeepEqual(cfg, applied)
 }

--- a/pkg/dataplane/userspace/route_overlay_test.go
+++ b/pkg/dataplane/userspace/route_overlay_test.go
@@ -296,6 +296,137 @@ func TestPublishRouteOverlaySnapshotWithoutHelper(t *testing.T) {
 	}
 }
 
+// TestPublishRouteOverlaySnapshotRefusesPolicyHybrid is the #5680 fail-on-revert
+// regression. A route-only publish rebuilds ONLY the Routes section and inherits
+// every compiled policy section from m.lastSnapshot; it must NOT ACK a cfg whose
+// policy half was never compiled into that snapshot. Otherwise a route-only
+// publish advances the applied identity to an OLD-policy/NEW-route hybrid: the
+// operator is told the new config is live while the dataplane still enforces the
+// old policy.
+//
+// This models the #5679 residual: an ordinary d.dp.ApplyConfig failure captures
+// applyErr and continues WITHOUT advancing m.lastSnapshot, while store.Commit has
+// already promoted the NEW cfg. The tail route-leak republish and the
+// ip-monitoring actuator then call PublishRouteOverlaySnapshot with that NEW cfg.
+//
+// RED-on-revert: delete the routeOnlyPublishHybrid guard in
+// PublishRouteOverlaySnapshot and this test fails three ways — the publish
+// returns published=true with a nil error, m.appliedSnapshot.Config advances to
+// the unpublished cfgB, and the hybrid apply_snapshot is shipped to the helper.
+func TestPublishRouteOverlaySnapshotRefusesPolicyHybrid(t *testing.T) {
+	dir := t.TempDir()
+	controlSock, reqCh := overlayControlServer(t, dir)
+
+	// cfgA is the config the dataplane actually compiled and enforces: a LOOSER
+	// default-policy PERMIT. It is the currently applied policy identity.
+	cfgA := overlayTestConfig()
+	cfgA.Security.DefaultPolicy = config.PolicyPermit
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 7
+	m.lastSnapshot, _ = buildSnapshot(cfgA, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
+		m.lastSnapshotHash = h
+	}
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+	// The helper is enforcing cfgA at generation 7 — establish that applied
+	// identity so we can assert it does not advance.
+	m.appliedSnapshot = appliedSnapshot{Config: cfgA, Generation: 7}
+
+	// cfgB is the NEWLY-committed config whose policy half was NOT compiled into
+	// the dataplane. It TIGHTENS the default policy to DENY (the exact
+	// fail-open-to-stale hazard: a new deny that never reached the wire) and also
+	// moves a route, so a naive route-only publish would ship cfgB's routes on
+	// top of cfgA's PERMIT policy and ACK it as cfgB.
+	cfgB := overlayTestConfig()
+	cfgB.Security.DefaultPolicy = config.PolicyDeny
+	cfgB.RoutingOptions.StaticRoutes = append(cfgB.RoutingOptions.StaticRoutes,
+		&config.StaticRoute{Destination: "10.30.0.0/16", NextHops: []config.NextHopEntry{{Address: "172.16.50.9"}}})
+
+	overlay := []config.RouteOverlayEntry{
+		{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
+	}
+
+	published, err := m.PublishRouteOverlaySnapshot(cfgB, overlay, nil)
+	if err == nil {
+		t.Fatal("expected route-only publish to be refused for an unpublished policy delta, got nil error")
+	}
+	if published {
+		t.Fatal("hybrid publish reported published=true")
+	}
+
+	// Core hybrid-ACK assertion: the applied identity must stay at cfgA (the
+	// policy the dataplane actually enforces), NOT advance to the unpublished
+	// cfgB.
+	if m.appliedSnapshot.Config != cfgA {
+		t.Fatalf("applied identity advanced to the unpublished config: appliedSnapshot.Config=%p, want cfgA=%p (hybrid ACK)",
+			m.appliedSnapshot.Config, cfgA)
+	}
+	if m.lastSnapshot == nil || m.lastSnapshot.Config != cfgA {
+		t.Fatalf("lastSnapshot advanced past the enforced policy (hybrid): want Config=cfgA=%p", cfgA)
+	}
+
+	// The hybrid snapshot must never be shipped to the helper.
+	select {
+	case req := <-reqCh:
+		t.Fatalf("hybrid snapshot was shipped to the helper: %+v", req.Type)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// A refused publish must not advance the desired-overlay cache (#3760
+	// mutate-after-success contract): it stays at its nil baseline.
+	if got := m.routeOverlaySnapshot(); len(got) != 0 {
+		t.Fatalf("refused publish advanced the desired-overlay cache: %+v", got)
+	}
+}
+
+// TestPublishRouteOverlaySnapshotAcceptsEqualConfigDistinctPointer guards the
+// #5680 fix against a false refusal: a caller that passes a DISTINCT but
+// content-equal *config.Config (not pointer-identical to m.lastSnapshot.Config)
+// is a legitimate route-only publish and must still succeed. Only a genuine
+// policy divergence is refused.
+func TestPublishRouteOverlaySnapshotAcceptsEqualConfigDistinctPointer(t *testing.T) {
+	dir := t.TempDir()
+	controlSock, reqCh := overlayControlServer(t, dir)
+
+	applied := overlayTestConfig()
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 7
+	m.lastSnapshot, _ = buildSnapshot(applied, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
+		m.lastSnapshotHash = h
+	}
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// A separate object with identical content — the fix must accept this.
+	equal := overlayTestConfig()
+	if equal == applied {
+		t.Fatal("test setup: expected distinct config pointers")
+	}
+	overlay := []config.RouteOverlayEntry{
+		{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
+	}
+	published, err := m.PublishRouteOverlaySnapshot(equal, overlay, nil)
+	if err != nil {
+		t.Fatalf("content-equal distinct-pointer config was falsely refused: %v", err)
+	}
+	if !published {
+		t.Fatal("content-equal distinct-pointer publish reported published=false")
+	}
+	select {
+	case req := <-reqCh:
+		if req.Type != "apply_snapshot" {
+			t.Fatalf("request = %q, want apply_snapshot", req.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("legitimate publish did not ship an apply_snapshot")
+	}
+}
+
 // overlayControlServerToggle behaves like overlayControlServer but its
 // apply_snapshot handling can be flipped to fail (OK:false) via the
 // returned setter, so a publish failure can be exercised. All requests


### PR DESCRIPTION
## Summary

A **route-only publication** (`Manager.PublishRouteOverlaySnapshot`, `pkg/dataplane/userspace/manager_overlay.go`) rebuilds **only** the snapshot's `Routes` section and inherits every compiled policy section (zones/policies/NAT/screens/address-books) verbatim from `m.lastSnapshot`. It then stamped `next.Config = cfg` and called `markAppliedSnapshotLocked()`, advancing the applied identity (`appliedSnapshot.Config`) to `cfg` **even when `cfg`'s policy half was never compiled into the snapshot** — an OLD-policy/NEW-route **hybrid** ACK'd as the new config. Downstream, "what config is live" then reports the new config as fully applied while the dataplane still enforces the old policy.

**The hybrid-ACK site:** `manager_overlay.go` — `next.Config = cfg` (line ~151) → `m.lastSnapshot = &next` (~181) → `markAppliedSnapshotLocked()` (~187) → `appliedSnapshot.Config = m.lastSnapshot.Config` (`applied_nat_view.go:95`).

## Composition with #5679 (PR #5739)

This is the **#5679 residual**. #5679 made an ordinary `d.dp.ApplyConfig` failure fail the commit via a deferred `applyErr`, but that path does **not** advance `m.lastSnapshot` while `store.Commit` has already promoted the new `cfg`. The tail route-leak republish (`reconcileRouteLeakSnapshot`) and the ip-monitoring actuator then call `PublishRouteOverlaySnapshot` with that new `cfg`, so the manager's applied identity advanced to it — the commit reported failure (thanks to #5679) yet the dataplane manager still **lied** about which policy was live. This PR closes that residual so the manager's applied identity never advances past the policy it actually enforces.

## Fix

Add a fail-closed guard (`routeOnlyPublishHybrid`): refuse the route-only publish whenever `cfg` is not the config `m.lastSnapshot` was compiled from.

- In every **legitimate** route-only publish `cfg` **is** that config — the ip-monitoring actuator passes `store.ActiveConfig()` and the route-leak reconcile passes the just-applied `cfg`, both **pointer-identical** to `m.lastSnapshot.Config` (`ApplyConfig` stores the exact object `ActiveConfig()` returns). A pointer check short-circuits that fast path.
- A `reflect.DeepEqual` fallback only rejects a **genuinely divergent** config, never a distinct-but-equal one, so the legitimate fast path never regresses.
- On refusal the OLD, fully-consistent snapshot stays live, the desired-overlay cache stays at baseline (the #3760 mutate-after-success contract — the deferred `m.routeOverlay` commit is gated on `err == nil`), and the caller reconverges once a full apply republishes the policy.

## Validation

- **`TestPublishRouteOverlaySnapshotRefusesPolicyHybrid`** (fail-on-revert): a route-only publish with `cfgB` tightening the default policy to DENY over an applied `cfgA` PERMIT is refused; `appliedSnapshot.Config` stays at `cfgA`; no `apply_snapshot` is shipped; the overlay cache stays at baseline. **Proven RED** with the guard neutralized (publish returns nil error, `appliedSnapshot` advances to `cfgB`, the hybrid is shipped) and **GREEN** restored.
- **`TestPublishRouteOverlaySnapshotAcceptsEqualConfigDistinctPointer`**: a content-equal distinct-pointer config is never falsely refused.
- `gofmt` + `go vet` clean; `pkg/dataplane/userspace` and `pkg/daemon` suites green.
- Doc updated: `docs/rib-group-route-leaking.md` (hybrid-ACK guard section).

Closes #5680

🤖 Generated with [Claude Code](https://claude.com/claude-code)