### PR TITLE
ddns: don't let one scope delete another scope's co-owned wire RR

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47121,3 +47121,27 @@ top.
   pkg/daemon/device_map_teardown_failclosed_5309_test.go,
   pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go,
   pkg/daemon/README.md
+
+- **Timestamp**: 2026-07-12
+- **Action**: #5709 fix (codex-review-182 M36) — prevent a DDNS wire-RR
+  cross-scope clobber. Two DDNS scopes (e.g. two redundancy groups, or a
+  per-interface + global binding) can resolve the same host to the same
+  address and CO-OWN one wire resource record; each keeps a distinct
+  ownership row (ScopeKey prefix) but on the wire there is ONE RR. Because
+  `deleteOwnedLocked` reconstructed the wire RR from {FQDN, ForwardType,
+  Address} alone, one scope's teardown (lease expiry / config removal)
+  issued a wire DELETE that removed the RR the OTHER scope still owned —
+  clobbering a live record. Added `wireRRSharedWithOther(owned)`: when
+  another store row (a different scope) carries the same canonical FQDN +
+  forward type + rdata, `deleteOwnedLocked` SUPPRESSES the wire delete,
+  releases only the departing scope's claim, and leaves the live RR for the
+  surviving scope (reference-count decrement over the claim table; equal
+  {FQDN, Address} implies an equal reverse PTR so both directions are
+  covered). Runs before the wire op and is backend-independent. Counted via
+  `Stats.DeleteCoowned` + `xpf_dhcp_ddns_skipped_total{reason="coowned"}`.
+  Added fail-on-revert test `TestCoOwnedWireRRSurvivesOtherScopeTeardown`
+  (RED proven by neutralizing the guard: RG1 teardown deleted the co-owned
+  RR; GREEN restored). gofmt clean; pkg/ddns + pkg/api suites green.
+- **File(s)**: pkg/ddns/manager.go, pkg/ddns/scope_test.go,
+  pkg/api/metrics_system.go, pkg/api/metrics_descriptors.go,
+  pkg/ddns/README.md

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -437,7 +437,9 @@ func newCollector(srv *Server) *xpfCollector {
 
 		// #1387 inc-2: DHCP dynamic-DNS counters. Label cardinality is
 		// CLOSED (plan §4.4 m4): result in {ok,fail}; reason in
-		// {no-name,no-backend,conflict,ptr-notauth} — never a raw rcode.
+		// {no-name,no-backend,conflict,ptr-notauth,ptr-deferred,coowned} —
+		// never a raw rcode. "coowned" (#5709) counts wire deletes suppressed
+		// because the RR is still co-owned by another DDNS scope.
 		dhcpDDNSUpsertsTotal: prometheus.NewDesc(
 			"xpf_dhcp_ddns_upserts_total",
 			"Total DHCP dynamic-DNS forward/reverse record upserts by result.",

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -65,6 +65,8 @@ func (c *xpfCollector) collectDDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.SkippedPTRNotAuth), "ptr-notauth")
 	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSSkippedTotal, prometheus.CounterValue,
 		float64(st.PTRDeferred), "ptr-deferred")
+	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSSkippedTotal, prometheus.CounterValue,
+		float64(st.DeleteCoowned), "coowned")
 	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSOwnedRecords, prometheus.GaugeValue,
 		float64(st.OwnedRecords))
 	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSPTRPending, prometheus.GaugeValue,

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -15,7 +15,7 @@ moved with its assertions intact.
 
 | File | Contents |
 |------|----------|
-| `manager.go` | `Manager` (the DDNS reconcile engine — moved from `dhcpserver/ddns.go`): `policyFromConfig`, `Reconcile`, `reconcileOnceLocked`, `upsertLocked`/`deleteOwnedLocked`, `withdrawAllLocked`, `ownerWatermark`, `dhcidSharedWithOther` (#2700 shared-DHCID guard), `Stats` (incl. `PTRPendingNow`, #2708), `OwnedRecordView(s)`, the `errDDNSNoBackendToWithdraw` keep-ownership sentinel (#2699), the write-ahead durability + never-delete-non-owned boundary. Also the `Lease` record + `LeaseParser` seam. |
+| `manager.go` | `Manager` (the DDNS reconcile engine — moved from `dhcpserver/ddns.go`): `policyFromConfig`, `Reconcile`, `reconcileOnceLocked`, `upsertLocked`/`deleteOwnedLocked`, `withdrawAllLocked`, `ownerWatermark`, `dhcidSharedWithOther` (#2700 shared-DHCID guard), `wireRRSharedWithOther` (#5709 co-owned wire-RR claim guard), `Stats` (incl. `PTRPendingNow`, #2708), `OwnedRecordView(s)`, the `errDDNSNoBackendToWithdraw` keep-ownership sentinel (#2699), the write-ahead durability + never-delete-non-owned boundary. Also the `Lease` record + `LeaseParser` seam. |
 | `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. Also the fail-closed load classifiers `errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion` + `quarantineBadState` (#2650) + the durable `<path>.degraded` marker helpers `readDegradedMarker` / `writeDegradedMarker` (#4873) that keep the fail-closed posture across restart. The load is SIZE-BOUNDED via `readBoundedStateFile` (`os.Stat` pre-check + `io.LimitReader` sentinel) against the derived `maxDDNSStateBytes` cap; an over-bound file is classified `errDDNSStateTooLarge` (wraps `errDDNSStateCorrupt`) so it fails closed like a corrupt file (#5571, CWE-770). |
 | `backend.go` | `DNSUpdater` interface, `LeaseDNSRecord`, `nopUpdater`, the record + reverse-PTR-name helpers — moved from `dhcpserver/ddns_dns.go`. |
 | `backend_rfc2136.go` | The LIVE RFC 2136 backend (`rfc2136Updater`): exact-RR adds/deletes, TSIG, RFC 4701 DHCID + RFC 4703 replace-owned two-attempt, the `errDDNSConflictRefused` / `errDDNSPTRPending` sentinels — moved from `dhcpserver/ddns_rfc2136.go`. `sendRemoveForward(..., keepDHCID)` keeps a shared DHCID on a partial dual-stack teardown (#2700); `dnsCanonicalFQDN` mirrors the DHCID FQDN canonicalization. |
@@ -446,6 +446,23 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   overlapping cross-RG pools attribute deterministically across passes (the gate
   cannot flap). The daemon also nudges DDNS on a partial demotion
   (`clearRethServicesForRG`) so the gate change takes effect within one pass.
+- **Wire-RR co-ownership claim accounting (#5709, codex-review-182 M36)** —
+  ScopeKey makes two scopes' store rows DISTINCT, but on the wire two scopes can
+  resolve the SAME host to the SAME address and thus publish ONE shared resource
+  record (`h.example.com A 10.0.5.5`). Because `deleteOwnedLocked` reconstructs
+  the wire RR from `{FQDN, ForwardType, Address}` alone, one scope's teardown
+  (lease expiry / config removal) would issue a wire DELETE that removed the RR
+  the OTHER scope still legitimately owns and refreshes — a silent cross-scope
+  clobber. `deleteOwnedLocked` now first calls `wireRRSharedWithOther(owned)`: if
+  ANOTHER store row (a different scope) carries the same canonical FQDN + forward
+  type + rdata, the wire delete is SUPPRESSED, only the departing scope's
+  ownership claim is released, and the live RR is left for the surviving scope.
+  The equal `{FQDN, Address}` also implies an equal reverse PTR, so suppressing
+  the whole `DeleteLease` covers both directions. Only the LAST claimant's
+  teardown issues the real wire delete (a reference-count decrement over the
+  claim table). Suppressions are counted (`Stats.DeleteCoowned`, the
+  `xpf_dhcp_ddns_skipped_total{reason="coowned"}` metric) and covered by
+  `TestCoOwnedWireRRSurvivesOtherScopeTeardown`.
 - **Source / VRF binding (#2665, `backend_bind.go`)** — the per-family
   `source-address` / `destination-interface` / `routing-instance` leaves build a
   custom `net.Dialer` (one `Control` hook: `unix.Bind` for the source IP +

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -214,12 +214,21 @@ func policyFromConfig(c *config.DHCPDynamicDNSConfig) ddnsPolicy {
 // Stats is the observable counter snapshot surfaced by `show` (and,
 // since increment 2, the Prometheus collector). All counters are monotonic.
 type Stats struct {
-	Enabled       bool
-	Backend       string
-	UpsertOK      uint64
-	UpsertFail    uint64
-	DeleteOK      uint64
-	DeleteFail    uint64
+	Enabled    bool
+	Backend    string
+	UpsertOK   uint64
+	UpsertFail uint64
+	DeleteOK   uint64
+	DeleteFail uint64
+	// DeleteCoowned counts wire deletes SUPPRESSED because the exact wire RR
+	// (same forward name + type + rdata) is still CO-OWNED by another DDNS scope
+	// — e.g. a second redundancy group, or a per-interface and a global binding
+	// resolving the same host to the same address (#5709). The departing scope's
+	// ownership claim is released but the live RR is left in place for the
+	// surviving scope; only the LAST claimant's teardown issues the real wire
+	// delete. A monotonic counter: a non-zero, rising value is normal in
+	// multi-scope deployments and means the cross-scope clobber was prevented.
+	DeleteCoowned uint64
 	SkippedNoName uint64
 	// SkippedNonAddress counts leases skipped because they are not an
 	// address-bearing lease type eligible for host DNS — an IA_PD
@@ -343,6 +352,7 @@ type Manager struct {
 	upsertFail        atomic.Uint64
 	deleteOK          atomic.Uint64
 	deleteFail        atomic.Uint64
+	deleteCoowned     atomic.Uint64 // wire delete skipped: RR still co-owned by another scope (#5709)
 	skippedNoName     atomic.Uint64
 	skippedNonAddress atomic.Uint64 // leases skipped: IA_PD / non-address lease type (#5072)
 	skippedNoBackend  atomic.Uint64 // upsert/delete skipped: no live backend wired
@@ -826,6 +836,45 @@ func (m *Manager) dhcidSharedWithOther(owned ownedRecord) bool {
 	return false
 }
 
+// wireRRSharedWithOther reports whether ANOTHER owned record — a DIFFERENT store
+// key, i.e. a different DDNS scope — publishes the SAME wire resource record as
+// `owned`: the same forward name + type + rdata (canonical FQDN, ForwardType,
+// and textual Address). Two DDNS scopes — e.g. two redundancy groups, or a
+// per-interface binding and a global one — can legitimately resolve the same
+// host to the same address and thus CO-OWN one wire RR; each keeps its own
+// ownership row because the ScopeKey prefix makes the store keys distinct (#2691
+// P1b). The reverse PTR is co-owned too: PTRName derives deterministically from
+// Address and the PTR target is the FQDN, so an equal (FQDN, Address) implies an
+// equal PTR RR — matching the forward tuple captures both directions (#5709).
+//
+// deleteOwnedLocked reconstructs the wire RR from (FQDN, ForwardType, Address)
+// alone, so without this claim accounting one scope's teardown (lease expiry /
+// config removal) would issue a wire DELETE that removes the RR the OTHER scope
+// still legitimately owns and refreshes — silently clobbering a live record
+// (codex-review-182 M36). When a co-owner exists the reconciler releases ONLY
+// the departing scope's ownership claim and leaves the wire RR in place; the
+// surviving scope, as the LAST claimant, issues the real wire delete when it in
+// turn tears down. Address must be non-empty (a lease record's rdata is always
+// its Address) so two rdata-less rows never falsely co-match. Caller holds m.mu.
+func (m *Manager) wireRRSharedWithOther(owned ownedRecord) bool {
+	if owned.Address == "" {
+		return false
+	}
+	ownedKey := ownedRecordKey(owned.scopeOf(), owned.Identity, owned.Address)
+	ownedFQDN := dnsCanonicalFQDN(owned.FQDN)
+	for k, r := range m.state.records {
+		if k == ownedKey {
+			continue
+		}
+		if r.Address == owned.Address &&
+			r.ForwardType == owned.ForwardType &&
+			dnsCanonicalFQDN(r.FQDN) == ownedFQDN {
+			return true
+		}
+	}
+	return false
+}
+
 // parseLeases reads a family's active leases via the injected LeaseParser
 // (#2691 P1a). A nil parser (the spine constructed without a Kea-memfile
 // parser) yields an empty, trusted lease set — identical to a healthy memfile
@@ -1300,6 +1349,26 @@ func (m *Manager) deleteOwnedLocked(ctx context.Context, updater DNSUpdater, own
 		}
 		return nil
 	}
+	// #5709 (codex-review-182 M36): if another owned record — a DIFFERENT DDNS
+	// scope — still CO-OWNS this exact wire RR (same forward name + type +
+	// rdata, hence the same reverse PTR), do NOT issue the wire delete: it would
+	// remove the RR the peer scope still legitimately owns and keeps fresh,
+	// silently clobbering a live record. Release only THIS scope's ownership
+	// claim and leave the wire RR in place; the surviving scope issues the real
+	// delete when it in turn becomes the last claimant. This is the wire-RR
+	// claim accounting the per-scope ownership store was missing. It runs BEFORE
+	// the wire op and independent of the backend (a nop updater must not orphan
+	// a co-owned RR either) — dropping a claim on a still-co-owned RR can never
+	// leak a stale record, so it needs no write-ahead.
+	if m.wireRRSharedWithOther(owned) {
+		slog.Debug("ddns: skipping wire delete — RR still co-owned by another scope; "+
+			"releasing this scope's claim only",
+			"fqdn", owned.FQDN, "type", owned.ForwardType, "address", owned.Address,
+			"scope", owned.scopeOf().scopePrefix())
+		m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
+		m.deleteCoowned.Add(1)
+		return nil
+	}
 	// Force the stored forward type / PTR name (re-derived above should
 	// match, but the store is authoritative for what was written).
 	rec.ForwardType = owned.ForwardType
@@ -1425,6 +1494,7 @@ func (m *Manager) Stats() Stats {
 		UpsertFail:        m.upsertFail.Load(),
 		DeleteOK:          m.deleteOK.Load(),
 		DeleteFail:        m.deleteFail.Load(),
+		DeleteCoowned:     m.deleteCoowned.Load(),
 		SkippedNoName:     m.skippedNoName.Load(),
 		SkippedNonAddress: m.skippedNonAddress.Load(),
 		SkippedNoBackend:  m.skippedNoBackend.Load(),

--- a/pkg/ddns/scope_test.go
+++ b/pkg/ddns/scope_test.go
@@ -400,3 +400,84 @@ func TestPerRGGatePartialDemotionSteadyState(t *testing.T) {
 		t.Fatalf("RG1 owned record must remain, got %d", ownedByRG(m, 1))
 	}
 }
+
+// TestCoOwnedWireRRSurvivesOtherScopeTeardown is the #5709 (codex-review-182
+// M36) fail-on-revert test: two DDNS scopes (two redundancy groups) resolve the
+// SAME host to the SAME address and thus CO-OWN one wire resource record
+// (shared.example.com A 10.0.5.5). Each scope keeps its OWN ownership row (the
+// ScopeKey prefix makes the store keys distinct), but on the wire there is ONE
+// RR. When scope RG1's lease expires, its teardown must NOT delete the wire RR
+// that scope RG2 still legitimately owns and refreshes.
+//
+// Fail-on-revert: with the pre-fix deleteOwnedLocked (no wireRRSharedWithOther
+// claim accounting) Pass 1 reconstructs shared.example.com A 10.0.5.5 from RG1's
+// expiring owned record and issues a wire DELETE — clobbering RG2's live record.
+// The "no delete for shared.example.com" assertion below catches that
+// regression; neutralize the guard in deleteOwnedLocked and this goes RED.
+//
+// Production analogue: the same fixed hostname/address is served by two DHCP
+// pools attributed to different RGs, or a scope attribution flips across a
+// reconfiguration, so the store transiently holds two scope rows for one wire
+// RR. It is a reconcile-layer test: it asserts on the durable ownership store +
+// the wire delete calls, not on an updater in isolation.
+func TestCoOwnedWireRRSurvivesOtherScopeTeardown(t *testing.T) {
+	up := newFakeUpdater()
+	// Two clients — DIFFERENT identities + scopes — but the SAME published host
+	// and the SAME address → one shared wire RR co-owned by RG1 and RG2.
+	rg1Lease := Lease{Family: 4, Address: "10.0.5.5", Identity: "mac:11", HostName: "shared", SubnetID: "1"}
+	rg2Lease := Lease{Family: 4, Address: "10.0.5.5", Identity: "mac:22", HostName: "shared", SubnetID: "2"}
+	m, src := scopeManagerSrc(t, up, []Lease{rg1Lease, rg2Lease}, nil)
+
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com", TTLSeconds: 300},
+	}
+	resolver := func(l Lease) (ScopeKey, bool) {
+		switch l.Identity {
+		case "mac:11":
+			return ScopeKey{Family: FamilyV4, RGOwner: 1}, true
+		case "mac:22":
+			return ScopeKey{Family: FamilyV4, RGOwner: 2}, true
+		}
+		return ScopeKey{}, false
+	}
+	gateBoth := func(ScopeKey) bool { return true }
+
+	// Phase 1: both scopes publish → the wire RR is co-owned by two store rows.
+	if err := m.ReconcileScoped(context.Background(), cfg,
+		ReconcileOptions{Gate: gateBoth, Resolver: resolver}); err != nil {
+		t.Fatalf("phase 1 reconcile: %v", err)
+	}
+	if ownedByRG(m, 1) != 1 || ownedByRG(m, 2) != 1 {
+		t.Fatalf("phase 1: both scopes must own the co-owned RR: rg1=%d rg2=%d",
+			ownedByRG(m, 1), ownedByRG(m, 2))
+	}
+
+	// Phase 2: RG1's lease EXPIRES (gone from the memfile); RG2's remains and is
+	// still master-owned by this node. RG1's teardown must not touch the wire RR.
+	src.v4 = []Lease{rg2Lease}
+	up.upserts = nil
+	up.deletes = nil
+	if err := m.ReconcileScoped(context.Background(), cfg,
+		ReconcileOptions{Gate: gateBoth, Resolver: resolver}); err != nil {
+		t.Fatalf("phase 2 reconcile: %v", err)
+	}
+
+	// THE ASSERTION (RED pre-fix): no wire delete for the co-owned RR.
+	for _, d := range up.deletes {
+		if d.FQDN == "shared.example.com" {
+			t.Fatalf("RG1 teardown DELETED the co-owned wire RR that RG2 still owns "+
+				"(cross-scope clobber, #5709): %s=%s", d.FQDN, d.Addr)
+		}
+	}
+	// RG1's expired ownership claim is released; RG2's is preserved (RR stays live).
+	if ownedByRG(m, 1) != 0 {
+		t.Fatalf("RG1's expired ownership claim must be released, got %d", ownedByRG(m, 1))
+	}
+	if ownedByRG(m, 2) != 1 {
+		t.Fatalf("RG2's co-owned record must survive RG1's teardown, got %d", ownedByRG(m, 2))
+	}
+	// The suppression is observable (exactly one co-owned wire-delete skip).
+	if got := m.deleteCoowned.Load(); got != 1 {
+		t.Fatalf("expected exactly one co-owned wire-delete suppression, got %d", got)
+	}
+}


### PR DESCRIPTION
## Problem

Two DDNS update scopes can co-own a single wire resource record (RR), and one
scope's teardown could **DELETE the other scope's still-live value** —
codex-review-182 finding **M36**, verified against origin/master `fc479ca65`.

`ScopeKey` (#2691 P1b) makes two scopes' ownership rows distinct in the store,
but on the wire two scopes can resolve the **same host to the same address** and
thus publish **one shared RR** (e.g. two redundancy groups serving the same
fixed hostname/address, a per-interface binding plus a global one, or a scope
attribution that flips across a reconfiguration so the store transiently holds
two scope rows for one wire RR). `deleteOwnedLocked` reconstructs the wire RR
from `{FQDN, ForwardType, Address}` alone, so one scope's teardown (lease expiry
/ config removal) issued a wire `DELETE` that removed the RR the **other** scope
still legitimately owned and refreshed — a silent cross-scope clobber of a live
record. The existing `dhcidSharedWithOther` guard only keeps a shared DHCID on
the wire for dual-stack A/AAAA siblings; it does not stop deleting the A/AAAA RR
itself when two scopes co-own it.

## Fix

Wire-RR claim accounting. `deleteOwnedLocked` now first calls
`wireRRSharedWithOther(owned)`: when **another** store row (a different scope)
carries the same canonical FQDN + forward type + rdata, the wire delete is
**suppressed**, only the departing scope's ownership claim is released, and the
live RR is left in place for the surviving scope. Only the **last** claimant's
teardown issues the real wire delete — a reference-count decrement over the
claim table. An equal `{FQDN, Address}` implies an equal reverse PTR, so
suppressing the whole `DeleteLease` covers both directions. The check runs
**before** the wire op and is backend-independent (a nop updater must not orphan
a co-owned RR either); dropping a claim on a still-co-owned RR can never leak a
stale record, so it needs no write-ahead.

Suppressions are observable: a new `Stats.DeleteCoowned` counter and a
`coowned` reason on `xpf_dhcp_ddns_skipped_total`.

## Validation

- **Fail-on-revert test** `TestCoOwnedWireRRSurvivesOtherScopeTeardown`
  (reconcile-layer): two scopes co-own `shared.example.com A 10.0.5.5`; RG1's
  lease expires and RG2's record must survive with **no wire delete** for the
  shared name. Proven **RED** by neutralizing the guard (RG1 teardown deleted the
  co-owned RR → `shared.example.com=10.0.5.5`) and **GREEN** with it restored.
- `gofmt` + `go vet` clean; `pkg/ddns` and `pkg/api` suites green.
- Docs updated: `pkg/ddns/README.md` (P1b section + manager function list) and
  the closed metric-label set.

Closes #5709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJCjJX5vNP2C74PUSivsh7