### PR TITLE
routing: recreate a tracked bond missing from the kernel

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47142,3 +47142,17 @@ top.
   attached (was asserting len==0, which only held on hosts lacking eth0).
 - **File(s)**: pkg/dhcp/duid_stability_5711_test.go (Edit),
   pkg/dhcp/dhcp_test.go (Edit)
+
+- **Timestamp**: 2026-07-12 07:15
+  **Action**: Fix #5703 (codex-review-182 M29) — a tracked desired bond
+  MISSING from the kernel was treated as "unchanged" by bondManager.Apply's
+  reconcile pass (LinkByName miss → bring-up block skipped → `continue`), so a
+  vanished bond was never recreated (false convergence, persistent outage). The
+  "unchanged" branch now verifies the kernel device is present; if it has
+  vanished it recreates the bond via createLocked (create+enslave, tracking the
+  realized member set) instead of reporting success. Added fail-on-revert test
+  TestBondApplyRecreatesTrackedBondMissingFromKernel (proved RED with the
+  recreate branch neutralized: addCalls=[]; GREEN restored). Updated the Apply
+  doc comment and the pkg/routing/README.md bond-reconcile "keep" bullet.
+  **File(s)**: pkg/routing/bond.go (Edit), pkg/routing/bond_test.go (Edit),
+  pkg/routing/README.md (Edit), _Log.md (Edit)

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -116,9 +116,16 @@ set (`name→bondSig` — mode, MTU, and the sorted resolved Linux member
 set) against the tracked set instead of clearing all and rebuilding:
 
 - **keep** a bond untouched when it is still desired with an identical
-  `bondSig` — no `LinkDel`/`LinkAdd`/`LinkSetMaster`, so an unrelated
-  policy-only commit no longer flaps the LAG (`LinkDel`→`LinkAdd`→
-  re-enslave→LACP re-converge, traffic loss on the bond);
+  `bondSig` **and its kernel device is still present** — no `LinkDel`/
+  `LinkAdd`/`LinkSetMaster`, so an unrelated policy-only commit no longer
+  flaps the LAG (`LinkDel`→`LinkAdd`→re-enslave→LACP re-converge, traffic
+  loss on the bond). The keep verifies the kernel device via `LinkByName`
+  before declaring convergence: a tracked, still-desired bond that has
+  **vanished** from the kernel (deleted out from under the daemon — an
+  operator `ip link del`, a driver reset, a transient kernel failure) is
+  **not** kept but **recreated** through the create path, rather than
+  reported as falsely converged and left down forever (#5703 /
+  codex-review-182 M29);
 - **create** a newly-desired bond (also adopts a kernel bond that
   outlived in-memory tracking, e.g. across a daemon restart). Both the
   create and adopt paths enumerate the bond's **actual** enslaved member

--- a/pkg/routing/bond.go
+++ b/pkg/routing/bond.go
@@ -76,10 +76,14 @@ func bondSigOf(ifc *config.InterfaceConfig) bondSig {
 // the fix for #5119, mirroring the #2546 XFRM reconcile:
 //
 //   - KEEP a bond untouched when it is still desired with an identical
-//     signature (mode, MTU, member set) — no LinkDel/LinkAdd/LinkSetMaster,
-//     so an unrelated policy-only commit no longer flaps the LAG (LinkDel→
-//     LinkAdd→re-enslave→LACP re-converge). This was the non-idempotent
-//     anti-pattern #2546 fixed for XFRM but not bonds.
+//     signature (mode, MTU, member set) AND its kernel device is still
+//     present — no LinkDel/LinkAdd/LinkSetMaster, so an unrelated policy-only
+//     commit no longer flaps the LAG (LinkDel→LinkAdd→re-enslave→LACP
+//     re-converge). This was the non-idempotent anti-pattern #2546 fixed for
+//     XFRM but not bonds. If a tracked, still-desired bond has VANISHED from
+//     the kernel (deleted out from under the daemon), the KEEP is NOT taken:
+//     the bond is RECREATED rather than reported as falsely converged
+//     (#5703 / codex-review-182 M29).
 //   - CREATE a bond that is newly desired (also adopts a kernel bond that
 //     outlived in-memory tracking, e.g. across a daemon restart). Both the
 //     create and adopt paths verify the bond's ACTUAL enslaved member set and
@@ -175,7 +179,9 @@ func (b *bondManager) Apply(interfaces []*config.InterfaceConfig) error {
 		if trackedSig, kept := b.bonds[name]; kept {
 			// Survived the delete pass.
 			if trackedSig == sig {
-				// Unchanged — bring it up idempotently (a no-op on an
+				// Unchanged in the desired config. Verify the kernel device
+				// is actually PRESENT before declaring convergence. If it is
+				// still there, bring it up idempotently (a no-op on an
 				// already-up bond, matching the XFRM keep path); zero
 				// LinkDel/LinkAdd/LinkSetMaster, so no flap.
 				if link, err := b.ops.LinkByName(name); err == nil {
@@ -183,6 +189,22 @@ func (b *bondManager) Apply(interfaces []*config.InterfaceConfig) error {
 						slog.Warn("failed to bring up existing bond", "name", name, "err", err)
 						errs = append(errs, fmt.Errorf("bond %s: bring up existing: %w", name, err))
 					}
+					continue
+				}
+				// The tracked bond has VANISHED from the kernel (deleted out
+				// from under the daemon — an operator `ip link del`, a driver
+				// reset, or a transient kernel failure) yet is still desired
+				// with an identical signature. Treating this as "unchanged"
+				// is false convergence: the reconciler reports success while
+				// the bond stays down forever (#5703 / codex-review-182 M29).
+				// RECREATE it via createLocked, which finds no kernel device
+				// (LinkByName miss) and takes the create+enslave path,
+				// tracking the ACTUAL realized member set (a still-absent
+				// member yields a partial sig for a later in-place completion,
+				// #5261). A create failure is aggregated, not swallowed.
+				slog.Warn("tracked bond missing from kernel; recreating", "name", name)
+				if err := b.createLocked(name, ifcByName[name], sig); err != nil {
+					errs = append(errs, err)
 				}
 				continue
 			}

--- a/pkg/routing/bond_test.go
+++ b/pkg/routing/bond_test.go
@@ -265,6 +265,69 @@ func TestBondApplyContinuesPastOneFailedBond(t *testing.T) {
 	}
 }
 
+// TestBondApplyRecreatesTrackedBondMissingFromKernel is the #5703 /
+// codex-review-182 M29 RED-on-revert guard. A bond that was created and is
+// still desired with an IDENTICAL signature, but whose kernel device has
+// VANISHED (deleted out from under the daemon — an operator `ip link del`, a
+// driver reset, a transient kernel failure), must be RECREATED on the next
+// reconcile. On master the "unchanged" branch verified nothing: LinkByName
+// missed, the bring-up block was skipped, and Apply `continue`d — false
+// convergence, so the bond stayed down forever while the reconciler reported
+// success.
+//
+// RED on revert: with the recreate branch removed, the second Apply issues
+// ZERO LinkAdd for bond0 (the `contains(ops.addCalls, "bond0")` assertion
+// fails) and the member is never re-enslaved.
+func TestBondApplyRecreatesTrackedBondMissingFromKernel(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	ops.seedMember("ge-0-0-1")
+	b := &bondManager{ops: ops}
+
+	cfg := []*config.InterfaceConfig{bondFabricConfig("bond0", "ge-0-0-1")}
+	full := bondSigOf(cfg[0])
+
+	// First Apply creates and tracks the bond.
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("first Apply() = %v, want nil", err)
+	}
+	if !contains(ops.addCalls, "bond0") {
+		t.Fatalf("first Apply did not create bond0: addCalls=%v", ops.addCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("after create b.bonds[bond0]=%+v, want full desired %+v", got, full)
+	}
+
+	// The kernel bond disappears out from under the daemon. Its member
+	// detaches (MasterIndex clears) but stays present in the kernel. The
+	// tracked signature is UNCHANGED — this is exactly the false-convergence
+	// case: still desired, identical sig, but no kernel device.
+	delete(ops.links, "bond0")
+	for _, l := range ops.links {
+		l.Attrs().MasterIndex = 0
+	}
+
+	// Re-apply the identical config. The bond MUST be recreated, not treated
+	// as unchanged.
+	ops.reset()
+	if err := b.Apply(cfg); err != nil {
+		t.Fatalf("second Apply() (bond vanished) = %v, want nil", err)
+	}
+	if !contains(ops.addCalls, "bond0") {
+		t.Fatalf("vanished bond0 was NOT recreated — false convergence (#5703/M29): "+
+			"addCalls=%v", ops.addCalls)
+	}
+	if !contains(ops.masterCalls, "ge-0-0-1") {
+		t.Fatalf("recreated bond0 did NOT re-enslave its member ge-0-0-1: masterCalls=%v",
+			ops.masterCalls)
+	}
+	if got := b.bonds["bond0"]; got != full {
+		t.Fatalf("after recreate b.bonds[bond0]=%+v, want full desired %+v", got, full)
+	}
+	if _, ok := ops.links["bond0"]; !ok {
+		t.Fatalf("bond0 kernel device absent after recreate: %+v", ops.links)
+	}
+}
+
 // contains reports whether s appears in xs.
 func contains(xs []string, s string) bool {
 	for _, x := range xs {


### PR DESCRIPTION
## Problem

`bondManager.Apply` (`pkg/routing/bond.go`) reconciles the desired fabric/ae
bond set differentially against its tracked `name→bondSig` map. In the
create/reconcile pass, a bond still desired with an **identical** signature
took the "unchanged" branch, which called `LinkByName` only to bring the device
up idempotently. When that `LinkByName` **missed** — the tracked bond had
vanished from the kernel (an operator `ip link del`, a driver reset, a transient
kernel failure) — the bring-up block was skipped and `Apply` `continue`d
**without recreating it**.

The result was **false convergence**: the reconciler reported success while the
desired bond stayed down forever — a persistent outage of that LAG. This is
codex-review-182 finding **M29** (Medium), verified against origin/master
`fc479ca65`.

## Fix

The "unchanged" branch now checks the kernel device's presence before declaring
convergence:

- `LinkByName` **hit** → bring the bond up in place (zero
  `LinkDel`/`LinkAdd`/`LinkSetMaster`, no flap — unchanged behavior).
- `LinkByName` **miss** → **recreate** the bond via `createLocked`, which finds
  no kernel device and takes the create+enslave path, tracking the **actual**
  realized member set (a still-absent member yields a partial sig for a later
  in-place completion, #5261). A create failure is aggregated into the returned
  error, not swallowed.

The idempotent-keep, partial-completion, member-add, member-removal, delete, and
adopt paths are unchanged.

**Scope:** missing-CREATE path only. The sibling #5704 (RETH deletion failures
reported as successful) is a different code path and is driven separately to
avoid conflicts.

## Validation

- New fail-on-revert test `TestBondApplyRecreatesTrackedBondMissingFromKernel`:
  create+track a bond, delete its kernel device (members detach but stay
  present), re-apply the identical config, assert the bond is recreated
  (`LinkAdd` for `bond0`) and its member re-enslaved. **Proven RED** with the
  recreate branch neutralized (`addCalls=[]`), **GREEN** with the fix.
- `go test ./pkg/routing/... ./pkg/networkd/...` — all pass.
- `gofmt` clean; updated the `Apply` doc comment and the
  `pkg/routing/README.md` bond-reconcile "keep" bullet.

Closes #5703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VkzmZN5B6KprGb5G2UTgT