### PR TITLE
feeds: fail closed for composite/static-alias feed readiness

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-12 — #5645 (security/bug): composite/static-alias feed readiness must fail closed
+- **Timestamp**: 2026-07-12 (fix/5645-feed-empty-publish)
+- **Action**: codex-review-182 M38 residual (issue reopened after #5665). #5665
+  closed the all-unready first-fetch fail-open by OMITTING a binding whose feeds
+  ALL lacked a snapshot. Two residual partial-deny fail-opens remained: (1) a
+  COMPOSITE binding unioning a ready + an unready feed published only the ready
+  subset (unready feed's deny prefixes silently unmatched); (2) when the binding
+  name ALSO exists as a STATIC address-book entry, overlay omission was not
+  enough — buildAddressBookTableWithFeeds still built the static name/ID, so a
+  `deny <name>` enforced only the static subset. Fix Part 1
+  (pkg/feeds/feeds.go SnapshotForBindings): require ALL feed constituents ready;
+  if ANY is unready (unknown feed, no first fetch, or hold-expired drop) omit the
+  whole binding instead of publishing the partial/empty union. Fix Part 2
+  (pkg/dataplane/userspace/policies_lower.go addrRepresentable): a DECLARED
+  dynamic-address binding ABSENT from the resolved overlay is unresolved →
+  unrepresentable (returns false BEFORE the static nameToID branch), so the
+  __unsupported_address__ sentinel fires and the Rust preflight rejects the whole
+  snapshot (previous-good retained / fresh-boot default-deny) even when a static
+  alias exists. Scope: security POLICY path only (the deny fail-open the issue
+  names); NAT still falls back to the static subset (documented out-of-scope).
+  RED-on-revert proven for both mechanisms; resolved/all-ready companions stay
+  green. Docs: pkg/feeds/README.md first-fetch section updated with the
+  all-constituent readiness + static-alias taint contract.
+- **File(s)**: pkg/feeds/feeds.go, pkg/feeds/feeds_firstfetch_failopen_5645_test.go,
+  pkg/dataplane/userspace/policies_lower.go,
+  pkg/dataplane/userspace/feed_static_alias_failclosed_5645_test.go,
+  pkg/feeds/README.md, _Log.md
+
 ## 2026-07-12 — #5712 (bug): in-process CLI commit must preserve the configured syslog transport
 - **Timestamp**: 2026-07-12 (fix/5712-syslog-transport-preserve)
 - **Action**: codex-review-182 M39. The CLI-side reloadSyslog (pkg/cli/apply.go)

--- a/pkg/dataplane/userspace/feed_static_alias_failclosed_5645_test.go
+++ b/pkg/dataplane/userspace/feed_static_alias_failclosed_5645_test.go
@@ -1,0 +1,142 @@
+// feed_static_alias_failclosed_5645_test.go: #5645 residual (codex-182). The
+// #5665 first-fetch fix OMITS an unresolved feed binding from the overlay so a
+// direct feed-bound deny fails closed. But when the SAME name ALSO exists as a
+// STATIC address-book entry, buildAddressBookTableWithFeeds still builds that
+// static name/ID from the static book, so a `deny <name>` would enforce only the
+// partial static subset while the unready feed's prefixes stay silently
+// unmatched — a residual deny fail-OPEN. The fix: addrRepresentable treats a
+// DECLARED dynamic-address binding that is ABSENT from the overlay as UNRESOLVED
+// (fail closed) regardless of a static alias.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// denyStaticAliasCfg builds a config where "denylist" is BOTH a declared
+// feed-backed dynamic-address binding AND a static address-book entry, and a
+// policy DENIES it. This is the static+unready acceptance case codex-182
+// requires added to #5645.
+func denyStaticAliasCfg() *config.Config {
+	return &config.Config{
+		Security: config.SecurityConfig{
+			AddressBook: &config.AddressBook{
+				Addresses: map[string]*config.Address{
+					"denylist": {Name: "denylist", Value: "10.0.0.0/8"},
+				},
+			},
+			DynamicAddress: config.DynamicAddressConfig{
+				AddressBindings: map[string]*config.AddressBinding{
+					"denylist": {Name: "denylist", FeedNames: []string{"threat"}},
+				},
+			},
+			Policies: []*config.ZonePairPolicies{
+				{
+					FromZone: "untrust",
+					ToZone:   "trust",
+					Policies: []*config.Policy{
+						{
+							Name: "block-threats",
+							Match: config.PolicyMatch{
+								SourceAddresses:      []string{"denylist"},
+								DestinationAddresses: []string{"any"},
+							},
+							Action: config.PolicyDeny,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestUnresolvedFeedBindingWithStaticAliasFailsClosed is the static-alias
+// fail-on-revert. With the feed UNRESOLVED (overlay omits "denylist", exactly
+// what SnapshotForBindings emits before the first successful fetch), a
+// `deny denylist` must fail CLOSED: the source side routes to the #3261 address
+// sentinel and carries NO book reference to the static-only 10.0.0.0/8 row.
+// Reverting the addrRepresentable declared-binding guard lets the static alias
+// resurrect the name as a representable book reference (SourceBookIDs non-empty,
+// no sentinel) — a partial-static deny fail-open — turning the assertions RED.
+func TestUnresolvedFeedBindingWithStaticAliasFailsClosed(t *testing.T) {
+	cfg := denyStaticAliasCfg()
+
+	// UNRESOLVED: the feed has not completed its first fetch, so the daemon's
+	// SnapshotForBindings OMITS "denylist" (empty overlay here).
+	overlay := map[string][]string{}
+
+	// Precondition: the static alias DID create a name/ID — this is what makes
+	// the residual reachable (overlay omission alone cannot suppress it).
+	_, nameToID, err := buildAddressBookTableWithFeeds(cfg, overlay)
+	if err != nil {
+		t.Fatalf("buildAddressBookTableWithFeeds error: %v", err)
+	}
+	if _, ok := nameToID["denylist"]; !ok {
+		t.Fatalf("precondition: the static address-book alias must create a name/ID "+
+			"for denylist; nameToID=%v", nameToID)
+	}
+
+	snaps, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	if err != nil {
+		t.Fatalf("buildPolicySnapshots error: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 policy rule, got %d", len(snaps))
+	}
+	rule := snaps[0]
+
+	// THE FAIL-OPEN SURFACE: the deny source must NOT resolve to a book reference
+	// (the static-only 10.0.0.0/8 row). That would enforce a partial deny while
+	// the unready feed's prefixes are unmatched.
+	if len(rule.SourceBookIDs) != 0 {
+		t.Fatalf("fail-open: an unresolved feed binding with a static alias routed as "+
+			"a book reference (partial static deny); SourceBookIDs=%v", rule.SourceBookIDs)
+	}
+	// It must route to the #3261 address sentinel so the Rust preflight rejects
+	// the whole snapshot (previous-good retained / fresh-boot default-deny).
+	if !addressListHasSentinel(rule.SourceLiterals) {
+		t.Fatalf("an unresolved feed binding with a static alias must fail CLOSED via "+
+			"the __unsupported_address__ sentinel; SourceLiterals=%v", rule.SourceLiterals)
+	}
+}
+
+// TestResolvedFeedBindingWithStaticAliasEnforcesUnion is the non-tautological
+// companion: once the feed IS ready (overlay carries its prefixes), the same
+// name resolves normally and the deny enforces the UNION of the feed prefixes
+// and the static alias. Proves the fail-closed guard is scoped to the
+// unresolved window and does not suppress a resolved composite name.
+func TestResolvedFeedBindingWithStaticAliasEnforcesUnion(t *testing.T) {
+	cfg := denyStaticAliasCfg()
+	overlay := map[string][]string{
+		"denylist": {"198.51.100.0/24"},
+	}
+
+	_, nameToID, _ := buildAddressBookTableWithFeeds(cfg, overlay)
+	wantID := nameToID["denylist"]
+	if wantID == 0 {
+		t.Fatalf("precondition: resolved feed name must have an ID")
+	}
+	snaps, _ := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	rule := snaps[0]
+	if !containsID(rule.SourceBookIDs, wantID) {
+		t.Fatalf("a resolved feed binding must route as a book reference; "+
+			"SourceBookIDs=%v want %d", rule.SourceBookIDs, wantID)
+	}
+	if addressListHasSentinel(rule.SourceLiterals) {
+		t.Fatalf("a resolved feed binding must NOT fail closed; SourceLiterals=%v",
+			rule.SourceLiterals)
+	}
+
+	// The book row carries BOTH the feed prefix and the static alias (the union).
+	books, _, _ := buildAddressBookTableWithFeeds(cfg, overlay)
+	row := findBookByName(books, "denylist")
+	if row == nil {
+		t.Fatalf("resolved denylist produced no book row")
+	}
+	if !contains(row.PrefixesV4, "198.51.100.0/24") || !contains(row.PrefixesV4, "10.0.0.0/8") {
+		t.Fatalf("resolved row must union feed + static prefixes; PrefixesV4=%v",
+			row.PrefixesV4)
+	}
+}

--- a/pkg/dataplane/userspace/policies_lower.go
+++ b/pkg/dataplane/userspace/policies_lower.go
@@ -74,6 +74,22 @@ func buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg *config.Config, activeSt
 		if _, feedBound := feedOverlay[tok]; feedBound {
 			return true
 		}
+		// #5645 residual (codex-182): a DECLARED dynamic-address binding that is
+		// ABSENT from the resolved overlay is UNRESOLVED — at least one of its feed
+		// constituents has no installed snapshot yet (SnapshotForBindings publishes
+		// a binding only when ALL feeds are ready). It must fail CLOSED even when a
+		// STATIC address-book entry of the SAME name exists: otherwise a
+		// `deny <name>` would enforce only the partial static subset and the unready
+		// feed's prefixes would be silently unmatched (a deny fail-OPEN). Returning
+		// false here (before the static nameToID branch) taints the side so
+		// buildOneRuleSnapshot emits the __unsupported_address__ sentinel and the
+		// Rust preflight rejects the whole snapshot (previous-good retained /
+		// fresh-boot default-deny) — the static-alias analogue of the all-unready
+		// omission the daemon's feed overlay already fails closed. Indexing a nil
+		// AddressBindings map is safe (zero value nil).
+		if b := cfg.Security.DynamicAddress.AddressBindings[tok]; b != nil {
+			return false
+		}
 		if _, known := nameToID[tok]; known {
 			return nameRepresentable(cfg.Security.AddressBook, feedOverlay, tok, make(map[string]bool))
 		}

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -80,18 +80,34 @@ for the whole window until the first fetch succeeded (a firewall **fail-open**).
 A blocked/failed first fetch (`retainForever` has nothing to retain) held that
 window open indefinitely.
 
-`SnapshotForBindings` now **omits** a binding whose feeds all lack an installed
-snapshot (before the first successful fetch, an unknown/typo'd feed name, or
-after a hold-interval drop) rather than publishing an empty slice. A ready feed
-always installs ≥ 1 prefix (a zero-prefix fetch is rejected — see below), so
-"resolves to zero prefixes" is exactly "no backing feed has a snapshot". Leaving
-the name **unresolved** makes the policy lowering treat it as unrepresentable
-(`addrRepresentable` → `__unsupported_address__` → whole-snapshot preflight
-reject), so the referencing policy fails **closed** (previous-good retained /
-fresh-boot default-deny) — the same action-agnostic contract `#3261` gives an
-empty static book. A **persisted** feed carries its last-good snapshot forward
-(`#5282`), so it still resolves to prefixes here and is still published; the
-omission fires only for a feed with no prior good fetch.
+`SnapshotForBindings` now **omits** a binding unless **every** one of its feeds
+has an installed snapshot. If **any** constituent is unready — before its first
+successful fetch, an unknown/typo'd feed name, or after a hold-interval drop —
+the whole binding is omitted rather than published with the ready subset or an
+empty slice. A ready feed always installs ≥ 1 prefix (a zero-prefix fetch is
+rejected — see below), so "no installed snapshot" is exactly `len(prefixes)==0`.
+Leaving the name **unresolved** makes the policy lowering treat it as
+unrepresentable (`addrRepresentable` → `__unsupported_address__` → whole-snapshot
+preflight reject), so the referencing policy fails **closed** (previous-good
+retained / fresh-boot default-deny) — the same action-agnostic contract `#3261`
+gives an empty static book. A **persisted** feed carries its last-good snapshot
+forward (`#5282`), so it still resolves to prefixes here and is still published;
+the omission fires only for a binding with an unready feed.
+
+**All-constituent readiness + static-alias taint (codex-182 residual).** The
+first cut omitted a binding only when **all** its feeds were unready. Two residual
+partial-deny fail-opens remained: (1) a **composite** binding unioning a ready
+and an unready feed published only the ready subset — the unready feed's prefixes
+were silently unmatched; and (2) when the binding name **also** exists as a
+**static** address-book entry, omitting it from the overlay was not enough —
+`buildAddressBookTableWithFeeds` still built the static name/ID, so a `deny`
+enforced only the static subset. The fix now requires **all** constituents ready
+(case 1), and the userspace `addrRepresentable` treats a **declared**
+dynamic-address binding that is **absent** from the overlay as unresolved →
+unrepresentable → fail-closed **even when a static alias of the same name
+exists** (case 2). Only the referencing security **policy** path is gated this
+way; NAT rules that reference an unready feed still fall back to the static
+subset (out of scope for the deny fail-open this issue names).
 
 ## Publication-debt retry — a rejected apply is retried, not swallowed (#5646)
 

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -473,23 +473,26 @@ func (m *Manager) GetPrefixes(name string) []string {
 // Resolution semantics:
 //   - A binding's FeedNames are unioned (a binding may aggregate several
 //     feeds). Prefixes are deduped across feeds and returned sorted.
-//   - A feed with no installed snapshot (before the first successful fetch, or
-//     after an explicit hold-interval drop) contributes nothing. If NONE of a
-//     binding's feeds has an installed snapshot the binding is UNRESOLVED and
-//     its name is OMITTED from the returned map entirely (#5645) — it is NOT
-//     published as a present-but-empty slice. Publishing an empty slice made
-//     the daemon compile a direct feed-bound name to a match-none address book
-//     row: correct for a PERMIT (permit-none), but a DENY policy referencing
-//     that name then never fired and the traffic it must block was PERMITTED
-//     for the whole pre-first-fetch window (fail-OPEN). Omitting the name
-//     leaves it unresolved, so the policy lowering treats it as
-//     unrepresentable (addrRepresentable -> __unsupported_address__ -> whole-
-//     snapshot preflight reject) and the referencing policy fails CLOSED —
-//     the same action-agnostic contract #3261 gives an empty static book, and
-//     the first-fetch analogue of the #5282 re-fetch window.
-//   - An unknown feed-name (binding references a feed that was never started)
-//     contributes nothing — it is treated the same as an unready feed, so a
-//     binding backed only by unknown names is also omitted (unresolved).
+//   - A binding is ENFORCEABLE only when EVERY one of its feed constituents has
+//     an installed snapshot. If ANY feed is unready — before its first
+//     successful fetch, an unknown/typo'd feed name, or after an explicit
+//     hold-interval drop — the binding is UNRESOLVED and its name is OMITTED
+//     from the returned map entirely (#5645, tightened to all-constituent
+//     readiness by codex-182). Publishing the READY subset of a composite
+//     binding, or a present-but-empty slice for an all-unready one, made the
+//     daemon compile a direct feed-bound name to a PARTIAL / match-none address
+//     book row: correct for a PERMIT (permit-none / permit-subset), but a DENY
+//     policy referencing that name then under-matched (or never fired) and the
+//     traffic it must block was PERMITTED for the whole window until every feed
+//     succeeded (fail-OPEN). Omitting the whole binding leaves the name
+//     unresolved, so the policy lowering treats it as unrepresentable
+//     (addrRepresentable -> __unsupported_address__ -> whole-snapshot preflight
+//     reject) and the referencing policy fails CLOSED — the same action-agnostic
+//     contract #3261 gives an empty static book, and the first-fetch analogue of
+//     the #5282 re-fetch window. The daemon ALSO treats a declared-but-omitted
+//     binding as unrepresentable even when a STATIC address-book alias of the
+//     same name exists (pkg/dataplane/userspace addrRepresentable), so the
+//     static subset cannot resurrect a partial deny.
 //
 // Reading the live last-good snapshot here means a persistent fetch failure
 // keeps enforcing the retained prefixes (the #2050 fail-safe). A persisted
@@ -505,17 +508,32 @@ func (m *Manager) SnapshotForBindings(daCfg *config.DynamicAddressConfig) map[st
 	defer m.mu.RUnlock()
 	out := make(map[string][]string, len(daCfg.AddressBindings))
 	for name, binding := range daCfg.AddressBindings {
-		if binding == nil {
+		if binding == nil || len(binding.FeedNames) == 0 {
 			continue
 		}
-		// Dedup across the binding's feeds; deep-copy from the live state.
+		// #5645 (tightened to all-constituent readiness by codex-182): a binding
+		// is UNRESOLVED unless EVERY one of its feeds has an installed snapshot. A
+		// ready feed always installs >= 1 prefix (a zero-prefix fetch is rejected
+		// as suspect — see readFeed), so "no installed snapshot" is exactly
+		// len(fs.prefixes) == 0 (before the first successful fetch, an unknown/
+		// typo'd feed name, or after an explicit hold-interval drop) — never a
+		// legitimately-empty successful fetch. If ANY constituent is unready, OMIT
+		// the whole binding: publishing the ready subset (or an all-unready empty
+		// slice) would enforce only a PARTIAL / match-none set, and for a DENY that
+		// under-match is fail-OPEN. Omitting keeps the name UNRESOLVED so the
+		// referencing policy fails CLOSED (see the doc comment). A persisted feed
+		// carried forward across a reconfigure (#5282) still has its last-good
+		// prefixes here, so this never re-opens the re-fetch window.
 		seen := make(map[string]struct{})
 		merged := make([]string, 0)
+		allReady := true
 		for _, feedName := range binding.FeedNames {
 			fs, ok := m.feeds[feedName]
-			if !ok {
-				continue
+			if !ok || len(fs.prefixes) == 0 {
+				allReady = false
+				break
 			}
+			// Dedup across the binding's feeds; deep-copy from the live state.
 			for _, p := range fs.prefixes {
 				if _, dup := seen[p]; dup {
 					continue
@@ -524,21 +542,10 @@ func (m *Manager) SnapshotForBindings(daCfg *config.DynamicAddressConfig) map[st
 				merged = append(merged, p)
 			}
 		}
-		sort.Strings(merged)
-		// #5645: a binding whose feeds ALL lack an installed snapshot resolves to
-		// no enforceable prefixes. A ready feed always installs >= 1 prefix (a
-		// zero-prefix fetch is rejected as suspect — see readFeed), so
-		// len(merged) == 0 is EXACTLY "no backing feed has an installed snapshot"
-		// (before the first successful fetch, an unknown/typo'd feed name, or after
-		// an explicit hold-interval drop) — never a legitimately-empty successful
-		// fetch. Do NOT publish it as a present-but-empty (match-none) entry: for a
-		// DENY policy match-none is fail-OPEN. Omit the name so it stays UNRESOLVED
-		// and the referencing policy fails CLOSED (see the doc comment). A
-		// persisted feed carried forward across a reconfigure (#5282) still has its
-		// last-good prefixes here, so this never re-opens the re-fetch window.
-		if len(merged) == 0 {
+		if !allReady {
 			continue
 		}
+		sort.Strings(merged)
 		out[name] = merged
 	}
 	return out

--- a/pkg/feeds/feeds_firstfetch_failopen_5645_test.go
+++ b/pkg/feeds/feeds_firstfetch_failopen_5645_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -118,6 +119,85 @@ func TestPermitFeedNoMembersOmittedNotFailOpen(t *testing.T) {
 	if _, published := overlay["allowlist"]; published {
 		t.Fatalf("a permit feed with no members must stay unresolved (omitted), never "+
 			"resolve to a match-any/empty entry; overlay=%v", overlay)
+	}
+}
+
+// TestCompositeBindingPartialReadinessOmitted is the codex-182 residual
+// fail-on-revert for the COMPOSITE case. A binding that unions a READY feed with
+// an UNREADY constituent must be OMITTED entirely — publishing the ready subset
+// enforces only a PARTIAL deny set and silently drops the unready feed's
+// prefixes (fail-OPEN). Covers the report's ready+unready, ready+unknown, and
+// ready+hold-expired acceptance cases. Reverting SnapshotForBindings to require
+// only that SOME feed is ready (the old len(merged) != 0 gate) publishes
+// "denylist" with just feed-ready's prefixes, turning each assertion RED.
+func TestCompositeBindingPartialReadinessOmitted(t *testing.T) {
+	cases := []struct {
+		name string
+		prep func(m *Manager)
+	}{
+		{
+			name: "ready+unready-no-first-fetch",
+			prep: func(m *Manager) {
+				m.installPrefixes("feed-ready", []string{"198.51.100.0/24"})
+				// Registered but never fetched: no installed snapshot.
+				m.newFeed("feed-unready", "http://example.test/unready", retainForever)
+			},
+		},
+		{
+			name: "ready+unknown",
+			prep: func(m *Manager) {
+				m.installPrefixes("feed-ready", []string{"198.51.100.0/24"})
+				// "feed-unready" is never registered at all (typo'd / not started).
+			},
+		},
+		{
+			name: "ready+hold-expired-drop",
+			prep: func(m *Manager) {
+				m.installPrefixes("feed-ready", []string{"198.51.100.0/24"})
+				// A feed that HAD a snapshot but was dropped to empty by a
+				// hold-interval expiry (#2050): registered, prefixes cleared.
+				m.installPrefixes("feed-unready", []string{"203.0.113.0/24"})
+				m.mu.Lock()
+				m.feeds["feed-unready"].prefixes = nil
+				m.feeds["feed-unready"].hasSnapshot = false
+				m.mu.Unlock()
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(nil)
+			tc.prep(m)
+			overlay := m.SnapshotForBindings(bindingCfg(map[string][]string{
+				"denylist": {"feed-ready", "feed-unready"},
+			}))
+			if got, published := overlay["denylist"]; published {
+				t.Fatalf("fail-open: a composite DENY binding with an unready "+
+					"constituent was published as a PARTIAL set %v; it must be omitted "+
+					"(unresolved -> fail closed) until ALL feeds are ready", got)
+			}
+		})
+	}
+}
+
+// TestCompositeBindingAllReadyPublished is the non-tautological companion: once
+// EVERY constituent is ready, the composite binding IS published with the full
+// deduped union. Proves the omission is scoped to partial readiness and does not
+// suppress a fully-resolved composite feed.
+func TestCompositeBindingAllReadyPublished(t *testing.T) {
+	m := New(nil)
+	m.installPrefixes("feed-a", []string{"198.51.100.0/24"})
+	m.installPrefixes("feed-b", []string{"203.0.113.0/24"})
+	overlay := m.SnapshotForBindings(bindingCfg(map[string][]string{
+		"denylist": {"feed-a", "feed-b"},
+	}))
+	got, published := overlay["denylist"]
+	if !published {
+		t.Fatalf("a fully-ready composite binding must be published; overlay=%v", overlay)
+	}
+	want := []string{"198.51.100.0/24", "203.0.113.0/24"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("composite union = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #5645 — reopened per codex-review-182 (M38 residual) after the #5665
first-fetch fix. #5665 closed the **all-unready** fail-open by omitting a binding
whose feeds all lacked a snapshot. Two residual **partial-deny** fail-opens
remained:

1. **Composite binding** — a binding unioning a READY feed + an UNREADY feed was
   published with only the ready subset. A `deny` enforced a PARTIAL set; the
   unready feed's prefixes were silently unmatched (fail-open on the missing
   portion) until every feed succeeded.
2. **Static alias** — when the binding name ALSO exists as a STATIC address-book
   entry, omitting it from the overlay was insufficient:
   `buildAddressBookTableWithFeeds` still built the static name/ID, so a
   `deny <name>` enforced only the static subset while the unready feed was
   unmatched (fail-open).

## Fix

Per the report's approved boundary — *"require all constituents ready and
preserve unresolved taint through static merge"*:

- **`pkg/feeds/feeds.go` `SnapshotForBindings`** — publish a binding only when
  **every** feed constituent has an installed snapshot. If **any** is unready
  (no first fetch, unknown/typo'd feed, or hold-interval drop), omit the whole
  binding instead of the ready subset / empty slice.
- **`pkg/dataplane/userspace/policies_lower.go` `addrRepresentable`** — a
  DECLARED dynamic-address binding ABSENT from the resolved overlay is
  unresolved → returns false **before** the static `nameToID` branch, so the
  side is tainted with `__unsupported_address__` and the Rust preflight rejects
  the whole snapshot (previous-good retained / fresh-boot default-deny) **even
  when a static alias exists**.

**Scope:** the security POLICY path the issue names. NAT rules referencing an
unready feed still fall back to the static subset (out of scope). The nested-set
static-alias variant is not in the four required acceptance cases and is left for
a follow-up (would need `cfg` threaded into `nameRepresentability`).

## Fail-on-revert tests

- `pkg/feeds` `TestCompositeBindingPartialReadinessOmitted` — subtests
  `ready+unready-no-first-fetch`, `ready+unknown`, `ready+hold-expired-drop`
  (the report's composite acceptance cases). Companion
  `TestCompositeBindingAllReadyPublished` stays green.
- `pkg/dataplane/userspace` `TestUnresolvedFeedBindingWithStaticAliasFailsClosed`
  (the report's `static+unready` case). Companion
  `TestResolvedFeedBindingWithStaticAliasEnforcesUnion` stays green.

**RED-on-revert proven for both mechanisms**; neutralizing either guard turns the
respective tests RED (partial-set publish / partial static book reference).

## Validation

`go build ./...` clean; `gofmt` + `go vet` clean; `go test ./pkg/feeds/...
./pkg/dataplane/userspace/... ./pkg/config/... ./pkg/daemon/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)