### PR TITLE
config: guard memberIsNestedSet against nil app-set slot

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47247,3 +47247,7 @@ top.
   **File(s)**: pkg/ddns/manager.go (Edit), pkg/ddns/manager_test.go (Edit),
   pkg/daemon/daemon_ddns_surface_a.go (Edit), pkg/ddns/README.md (Edit),
   _Log.md (Edit)
+
+- **Timestamp**: 2026-07-12
+  - **Action**: #5671 — add `&& as != nil` guard to memberIsNestedSet (mirror lookupApplicationSet #5179); a tolerant-loaded present-but-nil app-set slot no longer misclassifies a shadowing leaf application as a nested set (false "not found"). Added fail-on-revert test (RED proven with guard neutralized).
+  - **File(s)**: pkg/config/predefined.go, pkg/config/predefined_membernestedset_nilguard_5671_test.go

--- a/pkg/config/predefined.go
+++ b/pkg/config/predefined.go
@@ -293,7 +293,15 @@ func expandAppSet(name string, apps *ApplicationsConfig, depth int) ([]string, e
 // every existing config while enabling nested references to predefined bundles.
 func memberIsNestedSet(memberName string, apps *ApplicationsConfig) bool {
 	if apps.ApplicationSets != nil {
-		if _, ok := apps.ApplicationSets[memberName]; ok {
+		// #5671: mirror lookupApplicationSet's `&& as != nil` guard. The
+		// tolerant-load / peer-sync path (#1960) can admit a present-but-nil
+		// slot (ApplicationSets[memberName] == nil). Treating that slot as a
+		// nested set routed the member to expandAppSet → lookupApplicationSet,
+		// which skips the nil and errors "application-set not found" — instead
+		// of falling through to resolve the member as a leaf application (which
+		// may well exist and shadow the nulled name). Skip the nil slot so the
+		// leaf-application / predefined-set classification below runs.
+		if as, ok := apps.ApplicationSets[memberName]; ok && as != nil {
 			return true
 		}
 	}

--- a/pkg/config/predefined_membernestedset_nilguard_5671_test.go
+++ b/pkg/config/predefined_membernestedset_nilguard_5671_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"testing"
+)
+
+// TestMemberIsNestedSetNilGuard5671 is the #5671 RED-on-revert proof.
+//
+// memberIsNestedSet lacked the `&& as != nil` guard that its sibling
+// lookupApplicationSet carries (#5179). The tolerant-load / peer-sync path
+// (#1960) can admit a present-but-nil application-set slot
+// (ApplicationSets[name] == nil). Without the guard, memberIsNestedSet
+// reported such a slot as a nested set ("is a set: true"), so expandAppSet
+// routed the member to lookupApplicationSet, which correctly skips the nil and
+// returns not-found — turning a resolvable leaf-application reference into a
+// hard "application-set not found" expansion error.
+//
+// The scenario is not reachable through the parser (the set grammar cannot
+// produce a nil map value), so — like the #5179 sibling test — the config is
+// constructed directly to model the tolerant-load state. Neutralizing the
+// guard (dropping `&& as != nil`) turns both assertions RED: the direct
+// classification flips to true, and the end-to-end expansion errors instead of
+// resolving the shadowing leaf.
+func TestMemberIsNestedSetNilGuard5671(t *testing.T) {
+	// A real leaf application named "shadow" AND a present-but-nil app-set slot
+	// of the same name. The nil slot must NOT win the nested-set classification;
+	// the member must resolve as the leaf application.
+	newApps := func() *ApplicationsConfig {
+		return &ApplicationsConfig{
+			Applications: map[string]*Application{
+				"shadow": {Name: "shadow", Protocol: "tcp", DestinationPort: "443"},
+			},
+			ApplicationSets: map[string]*ApplicationSet{
+				"parent": {Name: "parent", Applications: []string{"shadow"}},
+				"shadow": nil, // tolerant-loaded null slot
+			},
+		}
+	}
+
+	t.Run("classification: nil slot is not a nested set", func(t *testing.T) {
+		apps := newApps()
+		if memberIsNestedSet("shadow", apps) {
+			t.Fatalf("memberIsNestedSet(nil-valued app-set slot shadowing a leaf) = true, " +
+				"want false so the member resolves as the leaf application")
+		}
+	})
+
+	t.Run("expansion: member resolves as leaf, not not-found", func(t *testing.T) {
+		apps := newApps()
+		got, err := ExpandApplicationSet("parent", apps)
+		if err != nil {
+			t.Fatalf("ExpandApplicationSet(parent) unexpected error: %v "+
+				"(nil app-set slot must fall through to the shadowing leaf)", err)
+		}
+		if len(got) != 1 || got[0] != "shadow" {
+			t.Fatalf("ExpandApplicationSet(parent) = %v, want [shadow]", got)
+		}
+	})
+
+	// Sanity: a non-nil user-defined nested set still classifies as a nested set
+	// (the guard must not over-reject genuine sets).
+	t.Run("non-nil nested set still classifies as set", func(t *testing.T) {
+		apps := &ApplicationsConfig{
+			Applications: map[string]*Application{},
+			ApplicationSets: map[string]*ApplicationSet{
+				"real": {Name: "real", Applications: []string{}},
+			},
+		}
+		if !memberIsNestedSet("real", apps) {
+			t.Fatalf("memberIsNestedSet(non-nil user set) = false, want true")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`memberIsNestedSet` (`pkg/config/predefined.go`) lacked the `&& as != nil`
guard that its sibling `lookupApplicationSet` carries (added in #5179),
producing a concrete classification asymmetry on the tolerant-load /
peer-sync path.

The tolerant-load / peer-sync path (#1960) can admit a present-but-nil
application-set map value (`ApplicationSets[name] == nil`).
`lookupApplicationSet` already skips such a slot, but `memberIsNestedSet`
reported it as a nested set. `expandAppSet` then routed the member into
`lookupApplicationSet`, which correctly skips the nil and returns
not-found — so the expansion failed with `application-set "<name>" not
found` instead of falling through to resolve the member as a leaf
application. When a real leaf application shadows the nulled name, that
turns a resolvable reference into a hard "not found" — a rare but
reachable false negative.

## Fix

One line, mirroring `lookupApplicationSet` exactly: only treat a slot as
a nested set when the value is non-nil, so a nil slot falls through to the
leaf-application / predefined-set classification.

## Validation

- Added `TestMemberIsNestedSetNilGuard5671`, a fail-on-revert test built
  directly on `ApplicationsConfig` (the parser cannot produce a nil map
  value, matching the #5179 sibling test's approach). Asserts the direct
  classification (nil slot → not a nested set), the end-to-end expansion
  (member resolves as the shadowing leaf, no error), and a sanity case
  that a genuine non-nil user set still classifies as a set.
- Proven RED with the guard neutralized (classification flips to `true`;
  expansion errors `application-set "shadow" not found`), GREEN with the
  guard in place.
- `go test ./pkg/config/...` passes; `gofmt` clean.

Closes #5671

🤖 Generated with [Claude Code](https://claude.com/claude-code)