### PR TITLE
cli: reject scoped-looking local request clears

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47247,3 +47247,26 @@ top.
   **File(s)**: pkg/ddns/manager.go (Edit), pkg/ddns/manager_test.go (Edit),
   pkg/daemon/daemon_ddns_surface_a.go (Edit), pkg/ddns/README.md (Edit),
   _Log.md (Edit)
+
+- **Timestamp**: 2026-07-12
+  **Action**: #5647 residual (codex-review-182) — the LOCAL interactive CLI
+  siblings of the remote-CLI clears fixed in #5652 still silently dropped a
+  scoped-looking suffix and performed the selector-free global mutation:
+  `request protocols ospf clear` (vtysh `clear ip ospf process`), `request
+  protocols bgp clear` (vtysh `clear bgp * soft`), and `request security ipsec
+  sa clear` (strongSwan `TerminateAllSAs`). A trailing selector such as
+  `... clear neighbor 10.0.0.1` / `... sa clear 42` was ignored while every
+  OSPF adjacency / BGP session / IPsec SA was reset. Mirrored the #5652 fix:
+  reject the scoped-looking suffix BEFORE the mutation (shared
+  `rejectScopedClear` helper) rather than widen scope silently. The guard runs
+  ahead of the FRR/strongSwan manager-availability gate (moved the nil-manager
+  check into each `clear` case), so a scoped suffix is refused before any
+  global reset. Added fail-on-revert `TestLocalRequestScopedClearRejected_5647`
+  (proved RED by neutralizing the `len(args) > N` guards: scoped suffix falls
+  to the nil-manager gate, no rejection error; GREEN restored) plus
+  `TestLocalRequestUnscopedClearProceeds_5647` (bare clear still reaches the
+  manager gate — guard is selector-specific). `go test ./pkg/cli/...
+  ./pkg/grpcapi/... ./cmd/cli/...` green.
+  **File(s)**: pkg/cli/cli_request.go (Edit), pkg/cli/cli_request_security.go
+  (Edit), pkg/cli/request_scope_5647_test.go (Write), docs/phases.md (Edit),
+  _Log.md (Edit)

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -380,9 +380,12 @@ Gap audit: `docs/archived/userspace-forwarding-and-failover-gap-audit.md` (PR #3
 - **BGP neighbor:** `show bgp neighbor <ip>` via FRR vtysh
 - **IPsec SA clear:** `request security ipsec sa clear` terminates all IKE SAs
   (global-only; like `request protocols ospf clear` / `... bgp clear` these
-  reset the whole process and take NO selector. The CLI rejects a
-  scoped-looking suffix — e.g. `... sa clear <id>`, `... ospf clear neighbor
-  <ip>` — instead of silently widening it to a global reset, #5647)
+  reset the whole process and take NO selector. BOTH the remote CLI
+  (`cmd/cli`, #5652) and the local interactive CLI (`pkg/cli`, #5647 residual
+  from codex-review-182) reject a scoped-looking suffix — e.g. `... sa clear
+  <id>`, `... ospf clear neighbor <ip>` — instead of silently widening it to a
+  global reset. The reject runs BEFORE the FRR/strongSwan manager-availability
+  gate, so an unrecognized selector is refused, not dropped, #5647)
 - **NAT counter clear:** `clear security nat statistics` zeros BPF nat_rule_counters
 - **Route summary enhanced:** Per-protocol breakdown (Direct/Local/Static/OSPF/BGP/IS-IS) with inet.0/inet6.0 sections
 - **ICMP type/code in CoS:** Filter terms now show icmp-type/icmp-code instead of "match any"

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -21,7 +21,24 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 )
+
+// rejectScopedClear returns the error for a global-only `request ... clear`
+// that was handed a scoped-looking suffix. #5647: the FRR/strongSwan wiring
+// behind these clears has no per-neighbor / per-area / per-SA plumbing, so a
+// trailing selector token (`... clear neighbor 10.0.0.1`, `... sa clear 42`)
+// used to be silently DROPPED while the selector-free global reset still ran —
+// the operator believed the action was scoped but every OSPF adjacency / BGP
+// session / IPsec SA was reset. Mirror the remote CLI (cmd/cli, #5652): reject
+// the suffix before the mutation rather than silently widen scope, because
+// Junos never widens scope silently. cmd is the full command path, effect
+// describes the global action, and extra is the rejected trailing token(s).
+func rejectScopedClear(cmd, effect string, extra []string) error {
+	return fmt.Errorf("%s does not accept a selector (%q); it %s. Re-run "+
+		"without a selector to confirm the global clear",
+		cmd, strings.Join(extra, " "), effect)
+}
 
 func (c *CLI) handleRequest(args []string) error {
 	if len(args) == 0 {
@@ -71,15 +88,22 @@ func (c *CLI) handleRequestProtocols(args []string) error {
 		writeCompletionHelp(os.Stdout, treeHelpCandidates(operationalTree["request"].Children["protocols"].Children))
 		return nil
 	}
-	if c.frr == nil {
-		return fmt.Errorf("FRR manager not available")
-	}
 	switch args[0] {
 	case "ospf":
 		if len(args) < 2 || args[1] != "clear" {
 			fmt.Println("request protocols ospf:")
 			writeCompletionHelp(os.Stdout, treeHelpCandidates(operationalTree["request"].Children["protocols"].Children["ospf"].Children))
 			return nil
+		}
+		// #5647: reject a scoped-looking suffix BEFORE the mutation — the
+		// suffix validation is input-shape checking and precedes the runtime
+		// manager-availability gate.
+		if len(args) > 2 {
+			return rejectScopedClear("request protocols ospf clear",
+				"resets the entire OSPF process", args[2:])
+		}
+		if c.frr == nil {
+			return fmt.Errorf("FRR manager not available")
 		}
 		output, err := c.frr.ExecVtysh("clear ip ospf process")
 		if err != nil {
@@ -95,6 +119,14 @@ func (c *CLI) handleRequestProtocols(args []string) error {
 			fmt.Println("request protocols bgp:")
 			writeCompletionHelp(os.Stdout, treeHelpCandidates(operationalTree["request"].Children["protocols"].Children["bgp"].Children))
 			return nil
+		}
+		// #5647: reject a scoped-looking suffix BEFORE the mutation.
+		if len(args) > 2 {
+			return rejectScopedClear("request protocols bgp clear",
+				"soft-clears every BGP session", args[2:])
+		}
+		if c.frr == nil {
+			return fmt.Errorf("FRR manager not available")
 		}
 		output, err := c.frr.ExecVtysh("clear bgp * soft")
 		if err != nil {

--- a/pkg/cli/cli_request_security.go
+++ b/pkg/cli/cli_request_security.go
@@ -20,6 +20,14 @@ func (c *CLI) handleRequestSecurity(args []string) error {
 			writeCompletionHelp(os.Stdout, treeHelpCandidates(operationalTree["request"].Children["security"].Children["ipsec"].Children["sa"].Children))
 			return nil
 		}
+		// #5647: `ipsec sa clear` terminates EVERY IPsec SA
+		// (TerminateAllSAs). Reject a scoped-looking suffix such as
+		// `... sa clear 42` / `... sa clear tunnel gw-a` BEFORE the mutation
+		// instead of silently dropping the selector and tearing down all SAs.
+		if len(args) > 3 {
+			return rejectScopedClear("request security ipsec sa clear",
+				"terminates every IPsec SA", args[3:])
+		}
 		if c.ipsec == nil {
 			return fmt.Errorf("IPsec manager not available")
 		}

--- a/pkg/cli/request_scope_5647_test.go
+++ b/pkg/cli/request_scope_5647_test.go
@@ -1,0 +1,128 @@
+// #5647 (residual, codex-review-182): the LOCAL interactive CLI siblings of
+// the remote-CLI clears fixed in #5652 still silently dropped a scoped-looking
+// suffix and performed the selector-free global mutation:
+//
+//	request protocols ospf clear      -> vtysh `clear ip ospf process`
+//	request protocols bgp clear       -> vtysh `clear bgp * soft`
+//	request security ipsec sa clear   -> strongSwan TerminateAllSAs()
+//
+// None of these has per-neighbor / per-area / per-SA plumbing, so a trailing
+// selector (`... clear neighbor 10.0.0.1`, `... sa clear 42`) was ignored while
+// every OSPF adjacency / BGP session / IPsec SA was reset. This mirrors the
+// remote-CLI fix (cmd/cli, #5652): reject the scoped-looking suffix BEFORE the
+// mutation instead of widening scope silently.
+//
+// Fail-on-revert design: the handlers run the selector guard BEFORE the
+// manager-availability gate. With a zero-value CLI (nil frr/ipsec):
+//
+//   - A scoped-looking suffix returns the "does not accept a selector"
+//     rejection (guard short-circuits before the mutation path).
+//   - A bare, unscoped clear falls THROUGH the guard to the nil-manager gate
+//     ("... manager not available"), proving the only thing between the parsed
+//     command and the global mutation is the manager itself — i.e. a dropped
+//     selector would have executed the global reset.
+//
+// Neutralize the fix (delete the `len(args) > N` guards) and the scoped case
+// falls to the same nil-manager gate: it no longer returns "does not accept a
+// selector", so TestLocalRequestScopedClearRejected_5647 goes RED.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// A scoped-looking suffix on a global-only local clear must ERROR with the
+// selector-rejection reason and must NOT fall through toward the global reset.
+func TestLocalRequestScopedClearRejected_5647(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(c *CLI) error
+	}{
+		{
+			name: "ospf clear neighbor",
+			call: func(c *CLI) error {
+				return c.handleRequestProtocols([]string{"ospf", "clear", "neighbor", "10.0.0.1"})
+			},
+		},
+		{
+			name: "bgp clear neighbor",
+			call: func(c *CLI) error {
+				return c.handleRequestProtocols([]string{"bgp", "clear", "neighbor", "10.0.0.1"})
+			},
+		},
+		{
+			name: "ipsec sa clear id",
+			call: func(c *CLI) error {
+				return c.handleRequestSecurity([]string{"ipsec", "sa", "clear", "42"})
+			},
+		},
+		{
+			name: "ipsec sa clear tunnel name",
+			call: func(c *CLI) error {
+				return c.handleRequestSecurity([]string{"ipsec", "sa", "clear", "tunnel", "gw-a"})
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Zero-value CLI: frr and ipsec are nil. The selector guard runs
+			// BEFORE the nil-manager gate, so a correct fix returns the
+			// selector-rejection error; a reverted fix returns the
+			// "... manager not available" error instead.
+			c := &CLI{}
+			err := tc.call(c)
+			if err == nil {
+				t.Fatalf("%s: returned nil; expected a rejection error for a "+
+					"scoped-looking suffix on a global-only clear", tc.name)
+			}
+			if !strings.Contains(err.Error(), "does not accept a selector") {
+				t.Fatalf("%s: error %q missing the selector-rejection reason — "+
+					"a scoped-looking suffix must be refused before the global "+
+					"reset, not silently dropped", tc.name, err)
+			}
+		})
+	}
+}
+
+// The bare, unscoped clears still proceed past the guard to the manager gate
+// (proving the guard is selector-specific, and that an unguarded scoped suffix
+// WOULD have reached the global mutation). With nil managers the gate reports
+// "... manager not available"; crucially it is NOT the selector rejection.
+func TestLocalRequestUnscopedClearProceeds_5647(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(c *CLI) error
+	}{
+		{
+			name: "ospf clear",
+			call: func(c *CLI) error { return c.handleRequestProtocols([]string{"ospf", "clear"}) },
+		},
+		{
+			name: "bgp clear",
+			call: func(c *CLI) error { return c.handleRequestProtocols([]string{"bgp", "clear"}) },
+		},
+		{
+			name: "ipsec sa clear",
+			call: func(c *CLI) error { return c.handleRequestSecurity([]string{"ipsec", "sa", "clear"}) },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &CLI{}
+			err := tc.call(c)
+			if err == nil {
+				t.Fatalf("%s: expected the nil-manager gate error, got nil", tc.name)
+			}
+			if strings.Contains(err.Error(), "does not accept a selector") {
+				t.Fatalf("%s: a bare, unscoped clear must NOT be rejected as "+
+					"scoped: %v", tc.name, err)
+			}
+			if !strings.Contains(err.Error(), "manager not available") {
+				t.Fatalf("%s: unscoped clear should reach the manager gate, got %v",
+					tc.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`#5647` residual (codex-review-182, verified vs `fc479ca65`). The merged
`#5652` fix taught the **remote CLI** (`cmd/cli`) to reject a scoped-looking
suffix on the global-only protocol/IPsec clears, but its **local
interactive-CLI siblings** in `pkg/cli` still silently dropped the suffix and
performed the selector-free global mutation:

| local command | daemon action (global, no selector) |
|---|---|
| `request protocols ospf clear` | vtysh `clear ip ospf process` |
| `request protocols bgp clear` | vtysh `clear bgp * soft` |
| `request security ipsec sa clear` | strongSwan `TerminateAllSAs()` |

A trailing selector such as `... clear neighbor 10.0.0.1` or `... sa clear 42`
was **ignored** while every OSPF adjacency / BGP session / IPsec SA was reset —
the operator believed the action was scoped; it was global. A command that
looks targeted quietly widens to an appliance-wide reset.

## Fix

Mirror the `#5652` direction: **reject** the scoped-looking suffix *before* the
mutation rather than widen scope silently (Junos never widens scope silently).
A shared `rejectScopedClear` helper emits the same `does not accept a selector`
error the remote CLI produces, so both CLI surfaces behave identically. The
guard runs **ahead** of the FRR/strongSwan manager-availability gate (the
nil-manager check moved into each clear case), so an unrecognized selector is
refused, not dropped — and the bare, unscoped clear still proceeds as before.

## Validation

- `TestLocalRequestScopedClearRejected_5647` — a scoped suffix must return the
  selector rejection. **Proved RED** by neutralizing the `len(args) > N`
  guards (the scoped case then falls through to the nil-manager gate with no
  rejection error); GREEN restored.
- `TestLocalRequestUnscopedClearProceeds_5647` — the bare clear still reaches
  the manager gate, so the guard is selector-specific, not a blanket block.
- `go test ./pkg/cli/... ./pkg/grpcapi/... ./cmd/cli/...` green; `gofmt` clean.

Closes #5647

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM5YiM1X1eE4ssBVneF8sa