### PR TITLE
config/routing: reject contradictory duplicate-route dispositions

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-12 — #5633 (bug/config/routing): reject contradictory duplicate-route dispositions at commit
+- **Timestamp**: 2026-07-12 (fix/5633-dup-route-contradiction)
+- **Action**: codex-review-181 M25 / A3-b02-F03. The static-route merge in
+  `compileStaticRoutes` folds repeated same-destination `set` lines into one
+  StaticRoute (appended next-hops, sticky discard/reject/next-table), so
+  declaring a prefix once as `discard` (or `next-table X`) and once with a
+  `next-hop` compiled into ONE route holding both a blackhole/leak AND a
+  forwarding next-hop — accepted by the strict gate, then silently resolved by
+  the Rust forwarder (discard > next-table > next-hop) so the later next-hop is
+  ignored (a blackhole / cross-VRF leak the operator did not author). Added a
+  commit-time gate `validateStaticRouteDispositionConflictStrict` that rejects a
+  compiled route carrying ≥2 of {next-hop, next-table, discard, reject};
+  legitimate ECMP / qualified-next-hop (multiple next-hops = one disposition)
+  still compiles. Walks global inet.0/inet6.0 + every routing-instance's route
+  sets. Wired into runUniformGates after the #5693 next-table gate; downgraded
+  to a warning on the tolerant load/peer-sync path via new opts flag
+  `lenientRouteDispositionConflict` (#1960 no-brick). Fail-on-revert test
+  (RED proven with the gate neutralized; GREEN restored) covers both AST shapes,
+  both orderings, inet6, per-instance, the legit-multipath accepts, and the
+  lenient downgrade.
+- **File(s)**: pkg/config/compiler_validate_strict_routing.go (Edit),
+  pkg/config/compiler.go (Edit), pkg/config/compiler_uniformgates.go (Edit),
+  pkg/config/compiler_static_route_disposition_conflict_5633_test.go (Write),
+  _Log.md (Edit)
+
 ## 2026-07-12 — #5645 (security/bug): composite/static-alias feed readiness must fail closed
 - **Timestamp**: 2026-07-12 (fix/5645-feed-empty-publish)
 - **Action**: codex-review-182 M38 residual (issue reopened after #5665). #5665

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -166,6 +166,37 @@ to `ApplyNextTableRules`. Strict on commit / commit-check; downgraded to a
 warning on the tolerant load / peer-sync paths (`opts.lenientNextTableRefs`,
 #1960 no-brick) since the applier keeps a dangling next-table inert.
 
+### Strict rejection — contradictory static-route dispositions (#5633)
+
+A single static-route destination may carry only **one** disposition: a
+forwarding `next-hop` (possibly several, for ECMP), a `next-table` VRF leak,
+`discard` (silent blackhole), or `reject` (ICMP-unreachable drop). Repeated
+same-prefix `set` lines merge into one `StaticRoute` in `compileStaticRoutes`
+(`compiler_routing.go`) — next-hops are **appended** and the terminal /
+`next-table` fields are **sticky** (`discard`/`reject` latch true, `next-table`
+is last-writer-wins). So a config that declared one prefix once as `discard`
+(or `next-table X`) and once with a `next-hop` compiled into ONE route holding
+**both** a blackhole/leak and a forwarding next-hop, and the strict gate
+accepted it. The live snapshot copies every field
+(`pkg/dataplane/userspace/routes.go`) and the Rust forwarder resolves
+**discard > next-table > next-hop**
+(`userspace-dp/src/afxdp/forwarding/mod.rs`), so the stale terminal / leak won
+and a later next-hop meant to **restore ordinary forwarding was silently
+ignored** — a blackhole or a cross-VRF leak the operator never authored.
+
+`validateStaticRouteDispositionConflictStrict`
+(`compiler_validate_strict_routing.go`) now **hard-rejects at commit** any
+compiled route carrying ≥2 of {`next-hop`, `next-table`, `discard`, `reject`}.
+Legitimate ECMP / qualified-next-hop (multiple next-hops = the single
+`next-hop` disposition) still compiles. The gate walks the global `inet.0` +
+`inet6.0` route sets and every routing-instance's route sets (per-instance
+routes flow through the same merge), reporting the first conflict
+deterministically with the offending scope and destination. Strict on commit /
+commit-check; downgraded to a warning on the tolerant load / peer-sync paths
+(`opts.lenientRouteDispositionConflict`, #1960 no-brick) so an already-persisted
+or peer-synced config still boots — the dataplane then resolves the
+deterministic disposition precedence.
+
 ## Deferred (Phase 2 and beyond)
 
 - **VRF→VRF import targets** — need `iif`-scoped rules or true route-copy;

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -968,6 +968,20 @@ type compileOpts struct {
 	// leniently-loaded config renders nothing for it rather than poisoning the
 	// reload. Same doctrine as lenientNextTableRefs.
 	lenientPolicyRouteMapSeq bool
+	// lenientRouteDispositionConflict (#5633) downgrades the static-route
+	// disposition-conflict gate (validateStaticRouteDispositionConflictStrict)
+	// from a hard compile error to a cfg.Warnings entry. Repeated same-prefix
+	// static-route `set` lines merge into a single StaticRoute
+	// (compileStaticRoutes) with appended next-hops and sticky terminal /
+	// next-table fields, so declaring one prefix as `discard` (or `next-table X`)
+	// AND with a `next-hop` compiled into one route holding both a blackhole /
+	// leak and a forwarding next-hop. The strict commit / commit-check path
+	// hard-rejects so the contradiction is operator-visible; the tolerant load /
+	// peer-sync paths warn so an already-persisted or peer-synced config still
+	// BOOTS (#1960) — the dataplane resolves the deterministic disposition
+	// precedence (discard > next-table > next-hop). Same doctrine as
+	// lenientNextTableRefs.
+	lenientRouteDispositionConflict bool
 	// lenientDHCPStaticBindings (#2243 review) downgrades the DHCP-server
 	// static (fixed/reserved) host-binding gate (validateDHCPStaticBindingsStrict)
 	// from a hard compile error to a cfg.Warnings entry. The strict commit /
@@ -1897,6 +1911,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRibGroupRefs:                    true,
 		lenientNextTableRefs:                   true,
 		lenientPolicyRouteMapSeq:               true,
+		lenientRouteDispositionConflict:        true,
 		lenientDHCPStaticBindings:              true,
 		lenientWireguardPeers:                  true,
 		lenientPolicyZoneRefs:                  true,
@@ -2247,6 +2262,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRibGroupRefs:                    true,
 		lenientNextTableRefs:                   true,
 		lenientPolicyRouteMapSeq:               true,
+		lenientRouteDispositionConflict:        true,
 		lenientDHCPStaticBindings:              true,
 		lenientWireguardPeers:                  true,
 		lenientPolicyZoneRefs:                  true,

--- a/pkg/config/compiler_static_route_disposition_conflict_5633_test.go
+++ b/pkg/config/compiler_static_route_disposition_conflict_5633_test.go
@@ -1,0 +1,198 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5633: the compiler merges repeated same-destination static-route blocks
+// (flat "set" syntax emits one block per line) into a single StaticRoute
+// (compileStaticRoutes): next-hops are APPENDED and the terminal / next-table
+// fields are STICKY (discard/reject latch true, next-table is last-writer-wins).
+// A config that declares the SAME prefix once as `discard` (or `next-table X`)
+// and once with a `next-hop` therefore compiled into ONE route holding BOTH a
+// blackhole/leak AND a forwarding next-hop — a contradiction the strict gate
+// accepted. The live snapshot copies every field and the Rust forwarder
+// resolves discard > next-table > next-hop, so the stale terminal/leak wins and
+// the later next-hop meant to restore ordinary forwarding is silently ignored.
+//
+// validateStaticRouteDispositionConflictStrict rejects that mix at commit.
+//
+// FAIL-ON-REVERT: neutralize the gate (make
+// validateStaticRouteDispositionConflictStrict return nil, or drop its call in
+// runUniformGates) and CompileConfig silently merges the contradiction — every
+// assertCommitRejects below fires RED.
+
+func TestStaticRouteDispositionConflictRejected_5633(t *testing.T) {
+	// discard THEN next-hop for the same prefix (flat-set).
+	t.Run("discard-then-nexthop", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 10.0.0.0/8 discard",
+			"set routing-options static route 10.0.0.0/8 next-hop 10.0.0.1",
+		)
+		assertCommitRejects(t, tree, "contradictory dispositions")
+	})
+
+	// next-hop THEN discard — the sticky-latch is order-independent, so the
+	// reverse authoring order must reject identically.
+	t.Run("nexthop-then-discard", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 10.0.0.0/8 next-hop 10.0.0.1",
+			"set routing-options static route 10.0.0.0/8 discard",
+		)
+		assertCommitRejects(t, tree, "contradictory dispositions")
+	})
+
+	// next-table VRF leak PLUS a reachable next-hop. The routing-instance is
+	// DEFINED so the #5693 next-table-definedness gate passes and this gate is
+	// the one that fires (non-tautological: the error is the disposition
+	// conflict, not an undefined target).
+	t.Run("nexttable-plus-nexthop", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-instances secret instance-type virtual-router",
+			"set routing-options static route 172.16.0.0/12 next-table secret.inet.0",
+			"set routing-options static route 172.16.0.0/12 next-hop 10.0.0.1",
+		)
+		assertCommitRejects(t, tree, "contradictory dispositions")
+	})
+
+	// Two terminal dispositions on one prefix (discard is a silent blackhole,
+	// reject is an ICMP-unreachable drop — they are mutually exclusive).
+	t.Run("discard-plus-reject", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 192.168.0.0/16 discard",
+			"set routing-options static route 192.168.0.0/16 reject",
+		)
+		assertCommitRejects(t, tree, "contradictory dispositions")
+	})
+
+	// Hierarchical AST shape (load merge / saved config): duplicate route blocks
+	// with contradictory dispositions must reject too. The parser folds the two
+	// same-prefix blocks the same way the compiler merges flat-set duplicates.
+	t.Run("hierarchical-discard-nexthop", func(t *testing.T) {
+		tree := hierTree(t, `routing-options {
+    static {
+        route 10.1.0.0/16 {
+            discard;
+        }
+        route 10.1.0.0/16 {
+            next-hop 10.0.0.9;
+        }
+    }
+}`)
+		assertCommitRejects(t, tree, "contradictory dispositions")
+	})
+
+	// inet6.0 rib: the gate covers the v6 route set as well.
+	t.Run("inet6-discard-nexthop", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options rib inet6.0 static route 2001:db8::/32 discard",
+			"set routing-options rib inet6.0 static route 2001:db8::/32 next-hop 2001:db8::1",
+		)
+		assertCommitRejects(t, tree, "contradictory dispositions")
+	})
+
+	// Per-routing-instance static routes flow through the SAME merge path, so a
+	// contradiction inside a VRF must reject too. The error names the instance.
+	t.Run("per-instance-conflict", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-instances blue instance-type virtual-router",
+			"set routing-instances blue routing-options static route 10.9.0.0/16 discard",
+			"set routing-instances blue routing-options static route 10.9.0.0/16 next-hop 10.9.0.1",
+		)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("expected CompileConfig to reject a per-instance disposition conflict")
+		}
+		if !strings.Contains(err.Error(), "contradictory dispositions") {
+			t.Fatalf("error %q must report a disposition conflict", err.Error())
+		}
+		if !strings.Contains(err.Error(), "routing-instances blue") {
+			t.Fatalf("error %q must name the offending routing-instance", err.Error())
+		}
+	})
+}
+
+// TestStaticRouteLegitMultipathAccepted_5633 proves the gate does NOT regress
+// legitimate route shapes: ECMP (multiple next-hops for one prefix), a floating
+// qualified-next-hop backup, and each single-disposition route all still
+// compile cleanly. Only a mix of ≥2 DISTINCT dispositions is a conflict.
+func TestStaticRouteLegitMultipathAccepted_5633(t *testing.T) {
+	// ECMP: two next-hop `set` lines for the same prefix merge into one route
+	// with two equal-cost next-hops. That is a single "next-hop" disposition,
+	// not a conflict.
+	t.Run("ecmp-multi-nexthop", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 10.0.0.0/8 next-hop 10.0.0.1",
+			"set routing-options static route 10.0.0.0/8 next-hop 10.0.0.2",
+		)
+		cfg := assertCommitAccepts(t, tree)
+		r := findStaticRoute3871(t, cfg.RoutingOptions.StaticRoutes, "10.0.0.0/8")
+		if len(r.NextHops) != 2 {
+			t.Fatalf("ECMP route NextHops = %d, want 2: %+v", len(r.NextHops), r.NextHops)
+		}
+		if r.Discard || r.Reject || r.NextTable != "" {
+			t.Fatalf("ECMP route must carry no terminal/leak disposition: %+v", r)
+		}
+	})
+
+	// A primary next-hop plus a qualified-next-hop backup is still the single
+	// "next-hop" disposition (both forward), so it must not trip the gate.
+	t.Run("qualified-nexthop-backup", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 10.5.0.0/16 next-hop 10.0.0.1",
+			"set routing-options static route 10.5.0.0/16 qualified-next-hop 10.0.0.2 preference 250",
+		)
+		cfg := assertCommitAccepts(t, tree)
+		r := findStaticRoute3871(t, cfg.RoutingOptions.StaticRoutes, "10.5.0.0/16")
+		if len(r.NextHops) != 2 {
+			t.Fatalf("floating route NextHops = %d, want 2: %+v", len(r.NextHops), r.NextHops)
+		}
+	})
+
+	// Each single disposition on its own remains valid.
+	t.Run("single-dispositions", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-instances secret instance-type virtual-router",
+			"set routing-options static route 10.1.0.0/16 discard",
+			"set routing-options static route 10.2.0.0/16 reject",
+			"set routing-options static route 10.3.0.0/16 next-hop 10.0.0.1",
+			"set routing-options static route 10.4.0.0/16 next-table secret.inet.0",
+		)
+		assertCommitAccepts(t, tree)
+	})
+}
+
+// TestStaticRouteDispositionConflict_LenientDowngrade_5633 proves the
+// strict/tolerant split: the gate hard-rejects on the strict commit path but is
+// downgraded to a warning on the tolerant load path (CompileConfigLenient), so
+// an already-persisted or peer-synced config carrying the contradiction still
+// LOADS (#1960 no-brick) — the dataplane resolves the deterministic disposition
+// precedence.
+func TestStaticRouteDispositionConflict_LenientDowngrade_5633(t *testing.T) {
+	sets := []string{
+		"set routing-options static route 10.0.0.0/8 discard",
+		"set routing-options static route 10.0.0.0/8 next-hop 10.0.0.1",
+	}
+
+	// Strict path rejects.
+	if _, err := CompileConfig(flatTreeFromSets(t, sets...)); err == nil {
+		t.Fatal("strict CompileConfig must reject the disposition conflict")
+	}
+
+	// Tolerant path loads with a warning instead of failing.
+	cfg, err := CompileConfigLenient(flatTreeFromSets(t, sets...))
+	if err != nil {
+		t.Fatalf("tolerant load must NOT hard-fail on a disposition conflict, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "static route disposition conflict") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a disposition-conflict warning on the lenient path, warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1813,6 +1813,28 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5633: static-route disposition-conflict gate. Repeated same-prefix
+	// static-route `set` lines merge into a single StaticRoute
+	// (compileStaticRoutes) that appends next-hops and latches sticky terminal /
+	// next-table fields, so declaring one destination once as `discard` (or
+	// `next-table X`) and once with a `next-hop` compiled into ONE route holding
+	// a blackhole/leak AND a forwarding next-hop — a contradiction the strict
+	// gate accepted. The live snapshot copies every field and the Rust forwarder
+	// resolves discard > next-table > next-hop, so the stale terminal/leak wins
+	// and a later next-hop meant to restore forwarding is silently ignored.
+	// Strict on commit / commit-check (hard reject so the contradiction is
+	// operator-visible); lenient on load / peer-sync (warn — #1960; the dataplane
+	// resolves the deterministic precedence so the config still boots). Mirrors
+	// validateNextTableTargetReferencesStrict.
+	if err := validateStaticRouteDispositionConflictStrict(cfg); err != nil {
+		if opts.lenientRouteDispositionConflict {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("static route disposition conflict (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #5701: route-map sequence-number overflow gate. A policy-statement whose
 	// per-term Cartesian expansion (families x from-prefix-list x from-community
 	// x from-as-path) produces more sequences than the FRR route-map

--- a/pkg/config/compiler_validate_strict_routing.go
+++ b/pkg/config/compiler_validate_strict_routing.go
@@ -792,6 +792,111 @@ func validateNextTableTargetReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// staticRouteDispositionConflict names the mutually-exclusive dispositions a
+// single compiled StaticRoute carries. A well-formed static route has exactly
+// ONE of: forwarding next-hop(s), a next-table VRF leak, discard, or reject.
+// Multiple next-hops for one destination are legitimate ECMP / qualified-
+// next-hop (all the single "next-hop" disposition) and are NOT a conflict. The
+// helper returns "" when at most one disposition is present, otherwise a
+// human-readable `a + b`-style list of the ≥2 distinct dispositions found.
+func staticRouteDispositionConflict(sr *StaticRoute) string {
+	if sr == nil {
+		return ""
+	}
+	var found []string
+	if len(sr.NextHops) > 0 {
+		found = append(found, "next-hop")
+	}
+	if sr.NextTable != "" {
+		found = append(found, "next-table")
+	}
+	if sr.Discard {
+		found = append(found, "discard")
+	}
+	if sr.Reject {
+		found = append(found, "reject")
+	}
+	if len(found) < 2 {
+		return ""
+	}
+	return strings.Join(found, " + ")
+}
+
+// validateStaticRouteDispositionConflictStrict hard-rejects a static route that
+// carries MORE THAN ONE mutually-exclusive disposition for a single destination
+// prefix — e.g. `discard` together with a reachable `next-hop`, a `next-table`
+// VRF leak together with a `next-hop`, or `discard` together with `reject`.
+//
+// The compiler merges repeated same-destination static-route blocks (flat "set"
+// syntax emits one block per line) into a single StaticRoute
+// (compileStaticRoutes): next-hops are APPENDED and the terminal / next-table
+// fields are STICKY (discard/reject latch true, next-table/preference are
+// last-writer-wins). A config that declares the SAME prefix once as `discard`
+// (or `next-table X`) and once with a `next-hop` therefore compiled into ONE
+// route holding BOTH a blackhole/leak AND a forwarding next-hop — a
+// contradiction that passed the strict gate. The live snapshot copies every
+// field (pkg/dataplane/userspace/routes.go) and the Rust forwarder resolves
+// discard before next-table before next-hops
+// (userspace-dp/src/afxdp/forwarding/mod.rs), so the stale terminal / leak wins
+// and a later next-hop meant to RESTORE ordinary forwarding is silently ignored
+// — a blackhole or a cross-VRF leak the operator did not author (#5633).
+//
+// Junos permits exactly one action per static route. Rejecting the mix at commit
+// keeps the compiled route unambiguous and the operator informed rather than
+// letting the dataplane pick a precedence the config never expressed. Multiple
+// next-hops for one destination stay legitimate ECMP and do NOT trip this gate.
+//
+// Strict on commit / commit-check (hard reject so the contradiction is
+// operator-visible); the call site downgrades this to a warning on the tolerant
+// load / peer-sync path (opts.lenientRouteDispositionConflict, #1960) so an
+// already-persisted or peer-synced config still BOOTS — the dataplane then
+// resolves the deterministic disposition precedence. Global inet.0/inet6.0 are
+// walked first, then each routing-instance's routes in RoutingInstances order,
+// so the first-reported error is deterministic. Mirrors
+// validateNextTableTargetReferencesStrict.
+func validateStaticRouteDispositionConflictStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(scope string, routes []*StaticRoute) error {
+		for _, sr := range routes {
+			conflict := staticRouteDispositionConflict(sr)
+			if conflict == "" {
+				continue
+			}
+			return fmt.Errorf(
+				"%s %q defines contradictory dispositions (%s) for one "+
+					"destination prefix; a static route may carry only ONE of "+
+					"next-hop, next-table, discard, or reject (repeated "+
+					"same-prefix `set` lines merge into a single route). Split "+
+					"the destinations or keep one disposition — otherwise the "+
+					"dataplane silently resolves the terminal/leak action and "+
+					"ignores the forwarding next-hop",
+				scope, sr.Destination, conflict)
+		}
+		return nil
+	}
+	if err := check("routing-options static route", cfg.RoutingOptions.StaticRoutes); err != nil {
+		return err
+	}
+	if err := check("routing-options static route", cfg.RoutingOptions.Inet6StaticRoutes); err != nil {
+		return err
+	}
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		scope := fmt.Sprintf("routing-instances %s static route", ri.Name)
+		if err := check(scope, ri.StaticRoutes); err != nil {
+			return err
+		}
+		if err := check(scope, ri.Inet6StaticRoutes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateRouteFilterMatchTypesStrict gates the two route-filter match-types
 // that the FRR prefix-list backend cannot render losslessly (#2525):
 //


### PR DESCRIPTION
## Summary

The config compiler's duplicate-route **merge** accepted **contradictory**
route definitions for the same destination prefix and silently folded them
together instead of rejecting the contradiction at commit
(codex-review-181 **M25 / A3-b02-F03**, issue #5633).

`compileStaticRoutes` (`pkg/config/compiler_routing.go`) merges repeated
same-destination `set` lines into one `StaticRoute`: next-hops are **appended**
and the terminal / `next-table` fields are **sticky** (`discard`/`reject` latch
true, `next-table` last-writer-wins). So declaring one prefix once as `discard`
(or `next-table X`) and once with a `next-hop` compiled into ONE route holding
**both** a blackhole/leak **and** a forwarding next-hop. The live snapshot
copies every field (`pkg/dataplane/userspace/routes.go`) and the Rust forwarder
resolves **discard > next-table > next-hop**
(`userspace-dp/src/afxdp/forwarding/mod.rs`), so the stale terminal/leak wins
and a later next-hop meant to **restore ordinary forwarding is silently
ignored** — a blackhole or a cross-VRF leak the operator never authored.

## Fix

`validateStaticRouteDispositionConflictStrict`
(`pkg/config/compiler_validate_strict_routing.go`) hard-rejects at commit any
compiled route carrying **≥2** of the mutually-exclusive dispositions
`{next-hop, next-table, discard, reject}`.

- **Reject:** `discard` + `next-hop`, `next-table` + `next-hop`,
  `discard` + `reject` (any mix of ≥2 distinct dispositions), in either
  authoring order.
- **Allow (preserved):** ECMP / qualified-next-hop — multiple next-hops for one
  prefix are the single `next-hop` disposition, not a conflict; and every
  single-disposition route.

Walks global `inet.0`/`inet6.0` **and** every routing-instance's route sets
(per-instance routes flow through the same merge). Wired into `runUniformGates`
after the #5693 next-table gate. Strict on commit / commit-check; downgraded to
a warning on the tolerant load / peer-sync paths via the new opts flag
`lenientRouteDispositionConflict` (#1960 no-brick) so an already-persisted or
peer-synced config still boots.

## Validation

- Fail-on-revert `TestStaticRouteDispositionConflictRejected_5633` (+ the
  legit-multipath accept and lenient-downgrade companions). **Proved RED** with
  the gate neutralized (the contradiction merged silently, every reject subtest
  failed); **GREEN** restored with the gate live.
- Covers both AST shapes (flat-set + hierarchical), both orderings, the inet6
  rib, the per-instance route set, ECMP / qualified-next-hop accepts, and the
  tolerant-path warning.
- `go test ./pkg/config/...` passes; `gofmt` clean; `xpfd` builds.
- Documented in `docs/rib-group-route-leaking.md`.

Closes #5633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfFHzq9ffWL8Lvd4Sist2J