### PR TITLE
daemon: fence host-inbound fail-open at cold boot (#5644)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47299,3 +47299,7 @@ top.
   _Log.md (Edit)
   - **Action**: #5671 — add `&& as != nil` guard to memberIsNestedSet (mirror lookupApplicationSet #5179); a tolerant-loaded present-but-nil app-set slot no longer misclassifies a shadowing leaf application as a nested set (false "not found"). Added fail-on-revert test (RED proven with guard neutralized).
   - **File(s)**: pkg/config/predefined.go, pkg/config/predefined_membernestedset_nilguard_5671_test.go
+
+- **Timestamp**: 2026-07-12
+  - **Action**: #5644 (M37) — close the cold-boot host-inbound fail-open. On COLD BOOT both nft tables are absent, so a failed `applyHostInboundFilter` install has no prior table to retain (the atomic `-f -` fail-closed guarantee is day-2 only) and the boot apply only logs+discards the error → host services reachable with no host-inbound default-deny. Added a fail-closed DENY-ALL fence (`installHostInboundColdBootFence` / `buildHostInboundFencePayload`) installed when the real ruleset fails to load and `d.hostInboundEnforced` is still false (cold boot); the commit still fails (drives retry). Lifeline-excluded, no service accepts, no counters. Day-2 failures unchanged (prior table retained, no fence). Added fail-on-revert tests (RED proven with the fence neutralized). Doc: docs/host-inbound-service-matrix.md new "Cold-boot fail-closed install fence (#5644, M37)" section.
+  - **File(s)**: pkg/daemon/daemon.go (Edit), pkg/daemon/daemon_nft.go (Edit), pkg/daemon/host_inbound_coldboot_fence_5644_test.go (Write), docs/host-inbound-service-matrix.md (Edit), _Log.md (Edit)

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -318,6 +318,61 @@ Two observability surfaces consume it:
   visible in a config-only / degraded boot). Alert with e.g.
   `max_over_time(xpf_host_inbound_addressless_zones[1h]) > 0`.
 
+## Cold-boot fail-closed install fence (#5644, M37)
+
+`applyHostInboundFilter` loads the chain with `nft -f -`, which is **atomic**:
+on a load failure the kernel keeps the PREVIOUS `inet xpf_hostinbound` table
+untouched. That is the fail-closed guarantee behind #3333 — a failed day-2
+install retains the prior host-inbound default-deny, so a committed deny that did
+not reach the kernel never silently relaxes enforcement. **But that guarantee is
+day-2 only: on a COLD BOOT both nft tables are absent, so a failed install has no
+prior generation to retain.** The boot apply reaches `applyHostInboundFilter`
+through `applyConfig`, which only **logs and discards** the returned error
+(a boot apply must not brick startup), so a cold-boot install failure would leave
+the host input path with **no** `xpf_hostinbound` chain — every host-bound service
+to a firewall-local address reachable with no host-inbound default-deny
+(fail-open) — while the daemon proceeds to publish host service / VIP / HA-ready.
+
+To close that window, a cold-boot install failure installs a **fail-closed
+DENY-ALL fence** before returning the error:
+
+- `d.hostInboundEnforced` (a `Daemon` atomic bool) records whether a
+  host-inbound table (real ruleset OR fence) has loaded at least once this boot.
+  It is the cold-boot discriminator: on a real-install failure it is **false**
+  only when no table has ever loaded (cold boot, both tables absent); day-2 it is
+  **true**, so the atomic-load retention already covers the failure and NO fence
+  is installed (the prior real table stands — the normal path is bit-unchanged).
+- `installHostInboundColdBootFence` / `buildHostInboundFencePayload`
+  (`daemon_nft.go`) build the fence: the same atomic-replace `xpf_hostinbound`
+  table reduced to the global mandatory admits (`ct established,related`, raw
+  ESP/AH, IPv6 ND, v4/v6 PMTUD+error, the configured WireGuard listen port) and a
+  catch-all `<fam> daddr <addrs> drop` for **every** firewall-local address the
+  real ruleset would scope (the per-zone views + the addressed-but-unzoned set).
+  It carries **no per-service accept and no named counters** — it is strictly the
+  real table with every service ACCEPT removed, so during the fence window even a
+  `system-services all` zone is denied (maximally fail-closed). The address sets
+  are already lifeline-excluded (fxp0 / em0 / fab* and their addresses are
+  subtracted by `BuildZoneHostInboundViews` / `BuildUnzonedHostInboundAddrs`), so
+  the fence can **never** strand management or break HA.
+- The commit still **fails** (`applyHostInboundFilter` returns the wrapped nft
+  error, joined into the commit result) — the fence only closes the exposure; the
+  failed apply is what drives the retry. The next clean commit / re-render (or the
+  DHCP/VIP re-apply that already re-runs this path) replaces the fence with the
+  real ruleset and self-heals.
+- If the fence **also** fails to load (nft itself broken), both errors are joined
+  and an `ERROR`-level `COLD-BOOT FAIL-OPEN GUARD` log fires; `hostInboundEnforced`
+  stays false. That is the irreducible catastrophic case — the daemon has done all
+  it can short of holding forwarding.
+
+Relationship to the addressless window above: at the very first cold-boot apply an
+interface may have no address yet, so both the real ruleset AND the fence scope
+nothing — but with no address there is also no reachable host service, so there is
+no exposure, and the re-render on address-appearance re-runs this path (installing
+the fence if the real apply fails again). This is scoped to the **direct-host nft
+input authority** only; the AF_XDP transit arm / attach readiness is owned
+separately by #5275. Fail-on-revert proofs:
+`pkg/daemon/host_inbound_coldboot_fence_5644_test.go`.
+
 ### Per-interface / per-family refinement (#3710)
 
 The zone-level signal above **collapses**: `AddresslessEnforcingZones` marks a

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -462,6 +462,21 @@ type Daemon struct {
 	// map[string]bool types and are reached as d.hostInboundFailOpen.<field>.
 	hostInboundFailOpen hostInboundFailOpenState
 
+	// hostInboundEnforced records whether a host-inbound enforcement table
+	// (the real ruleset OR the #5644 cold-boot fail-closed fence) has been
+	// successfully installed at least once since this daemon started. It is the
+	// "enforcement established" signal that closes the cold-boot fail-open window
+	// (#5644, M37): on COLD BOOT both nft tables are absent, so a failed
+	// host-inbound install has no prior table to retain (the atomic `-f -` load's
+	// fail-closed guarantee only holds day-2), leaving host-bound services
+	// reachable with no host-inbound default-deny. applyHostInboundFilter reads
+	// this to decide whether a failed install is a cold-boot (false → install a
+	// deny-all fence so host services stay fenced) versus a day-2 failure (true →
+	// the prior table is retained, already fail-closed). Written under applySem in
+	// applyHostInboundFilter; atomic so a publication-readiness reader on another
+	// goroutine sees a consistent value without taking applySem.
+	hostInboundEnforced atomic.Bool
+
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
 	//

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -3,6 +3,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -310,12 +311,136 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	nftConf := buildHostInboundFilterPayload(views, unzonedV4, unzonedV6, programs, wgListenPorts)
 	if out, err := nftApplyPayload(nftConf); err != nil {
 		slog.Warn("failed to apply host-inbound filter", "err", err, "output", string(out))
+		// #5644 (M37) cold-boot fail-closed fence. The atomic `-f -` load leaves
+		// the PREVIOUS table untouched on failure, so day-2 a failed install is
+		// already fail-closed (the prior host-inbound default-deny stays in the
+		// kernel). But on COLD BOOT both tables are absent — there is no prior
+		// generation to retain — so a failed install here would leave the host
+		// input path OPEN: host-bound services to firewall-local addresses become
+		// reachable with NO host-inbound default-deny (fail-open), and the boot
+		// apply only logs+discards this error (applyConfig), so the daemon proceeds
+		// to publish host service / VIP / HA-ready over an unenforced input path.
+		// d.hostInboundEnforced is still false only when no real/fence table has
+		// ever loaded this boot (i.e. cold boot), so gate the fence on it: install
+		// a maximally-restrictive deny-all fence (host services DENIED to every
+		// non-lifeline firewall-local address, only mandatory L3 / return traffic
+		// admitted) so enforcement is fail-closed until a clean commit re-renders
+		// the real ruleset. The commit still fails (we return the error), which is
+		// what drives the retry/re-render; the fence only closes the exposure in
+		// the meantime.
+		if !d.hostInboundEnforced.Load() {
+			if fenceErr := d.installHostInboundColdBootFence(views, unzonedV4, unzonedV6, wgListenPorts); fenceErr != nil {
+				return errors.Join(fmt.Errorf("apply host-inbound nftables filter: %w", err), fenceErr)
+			}
+		}
 		return fmt.Errorf("apply host-inbound nftables filter: %w", err)
 	}
+	// A real host-inbound table is now installed: enforcement is established, so a
+	// LATER failed install (day-2) is retained by the atomic load and needs no
+	// fence (#5644).
+	d.hostInboundEnforced.Store(true)
 	slog.Info("host-inbound filter applied", "zones", len(views),
 		"unzoned_deny_v4", len(unzonedV4), "unzoned_deny_v6", len(unzonedV6),
 		"junos_host_deny_programs", len(programs))
 	return nil
+}
+
+// installHostInboundColdBootFence installs the #5644 (M37) cold-boot
+// fail-closed host-inbound fence: a minimal xpf_hostinbound table that DENIES
+// every host-bound service to firewall-local addresses, admitting only the
+// mandatory L3 / return traffic (established/related, raw ESP+AH for
+// host-terminated IPsec, IPv6 ND, v4/v6 PMTUD+error, and the configured
+// WireGuard listen port(s)). It is installed ONLY when the real host-inbound
+// ruleset failed to load and no enforcement table exists yet this boot (cold
+// boot, both tables absent), so a failed install cannot leave the host input
+// path fail-open until the next clean commit.
+//
+// Safety: the fence drops only to the SAME address sets the real ruleset would
+// scope (views + the addressed-but-unzoned set), which are already
+// lifeline-excluded (fxp0/em0/fab* and their addresses are subtracted by
+// BuildZoneHostInboundViews / BuildUnzonedHostInboundAddrs), so the fence can
+// never strand management or break HA — it is strictly the real table with every
+// service ACCEPT removed. It carries no named counters (a fence is transient) so
+// it has fewer moving parts than the real payload and is more likely to load when
+// the real one hit a payload-specific nft error. On success the fence table
+// exists, so d.hostInboundEnforced is set true — a subsequent failed real apply
+// is then retained by the atomic `-f -` load (still fail-closed). On failure (nft
+// itself is broken) the error is returned and joined into the commit result; the
+// caller logs it and the daemon has done all it can short of holding forwarding.
+func (d *Daemon) installHostInboundColdBootFence(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) error {
+	fence := buildHostInboundFencePayload(views, unzonedV4, unzonedV6, wgListenPorts)
+	if out, err := nftApplyPayload(fence); err != nil {
+		slog.Error("COLD-BOOT FAIL-OPEN GUARD: host-inbound install failed AND the fail-closed "+
+			"fence could not be installed; host-bound services may be reachable without "+
+			"host-inbound enforcement until the next successful commit re-renders the ruleset",
+			"err", err, "output", string(out))
+		return fmt.Errorf("install host-inbound cold-boot fail-closed fence: %w", err)
+	}
+	d.hostInboundEnforced.Store(true)
+	slog.Warn("host-inbound install failed at cold boot (no prior table to retain); installed a "+
+		"fail-closed DENY-ALL fence so host-bound services are NOT exposed — the next clean "+
+		"commit replaces it with the real host-inbound ruleset",
+		"fenced_zones", len(views), "fenced_unzoned_v4", len(unzonedV4),
+		"fenced_unzoned_v6", len(unzonedV6))
+	return nil
+}
+
+// buildHostInboundFencePayload assembles the #5644 cold-boot fail-closed fence
+// payload (see installHostInboundColdBootFence). It is the atomic-replace
+// xpf_hostinbound table reduced to: the global mandatory accepts, then a
+// catch-all DROP for every firewall-local address the real ruleset would scope —
+// NO per-service accepts, NO named counters. Split out as a pure function so
+// tests can parse-check the full payload without invoking nft. A syntax error on
+// any line rejects the WHOLE payload (atomic load), so the fence fails
+// closed-as-absent rather than half-applied — exactly like the real builder.
+func buildHostInboundFencePayload(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) string {
+	var rules []string
+	rules = append(rules, "add table inet xpf_hostinbound")
+	rules = append(rules, "delete table inet xpf_hostinbound")
+	rules = append(rules, "table inet xpf_hostinbound {")
+	rules = append(rules, "  chain input {")
+	// Same hook/priority as the real host-inbound chain so the fence occupies the
+	// same evaluation slot (#3364).
+	rules = append(rules, fmt.Sprintf("    type filter hook input priority %d; policy accept;", nftHostInboundPriority))
+	// Mandatory admits — return traffic and core L3 control, NOT a service
+	// exposure (mirrors the real chain's global accepts, counters omitted):
+	rules = append(rules, "    ct state established,related accept")
+	// Raw ESP (50) / AH (51) so the kernel XFRM stack can decrypt host-terminated
+	// IPsec (mirrors the real chain and the userspace passthrough stage).
+	rules = append(rules, "    meta l4proto { 50, 51 } accept")
+	// IPv6 ND + v4/v6 PMTUD/error control messages — mandatory link operation.
+	rules = append(rules, "    icmpv6 type { 1, 2, 3, 4 } accept")
+	rules = append(rules, "    icmpv6 type { 133, 134, 135, 136, 137 } accept")
+	rules = append(rules, "    icmp type { destination-unreachable, time-exceeded, parameter-problem } accept")
+	// The XDP shim steers local-destination UDP on the WG listen port to the
+	// kernel WG socket; admit it so a responder-only tunnel is not black-holed by
+	// the fence (mirrors emitHostInboundWireGuardAccept). No-op when WG is unset.
+	if len(wgListenPorts) > 0 {
+		rules = append(rules, "    udp dport "+renderWireGuardPortSpec(wgListenPorts)+" accept")
+	}
+	// Catch-all DROP for every firewall-local address the real ruleset would scope
+	// — per host-inbound-configured zone (default-deny parity, #3405) and the
+	// addressed-but-unzoned set (#4420 HI-2). These sets are already
+	// lifeline-excluded, so the fence never denies management / cluster-control
+	// traffic. During the fence window even a `system-services all` zone is denied
+	// (maximally fail-closed); the next clean commit restores the real accepts.
+	for _, v := range views {
+		if len(v.V4Addrs) > 0 {
+			rules = append(rules, "    ip daddr "+nftAddrSet(v.V4Addrs)+" drop")
+		}
+		if len(v.V6Addrs) > 0 {
+			rules = append(rules, "    ip6 daddr "+nftAddrSet(v.V6Addrs)+" drop")
+		}
+	}
+	if len(unzonedV4) > 0 {
+		rules = append(rules, "    ip daddr "+nftAddrSet(unzonedV4)+" drop")
+	}
+	if len(unzonedV6) > 0 {
+		rules = append(rules, "    ip6 daddr "+nftAddrSet(unzonedV6)+" drop")
+	}
+	rules = append(rules, "  }")
+	rules = append(rules, "}")
+	return strings.Join(rules, "\n") + "\n"
 }
 
 // hostInboundFailOpenState groups the three previous-apply host-inbound

--- a/pkg/daemon/host_inbound_coldboot_fence_5644_test.go
+++ b/pkg/daemon/host_inbound_coldboot_fence_5644_test.go
@@ -1,0 +1,241 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #5644 (M37): cold boot with BOTH nft tables absent must not publish host
+// service / VIP / HA-ready over an UNENFORCED host input path. On COLD BOOT
+// there is no prior host-inbound table to retain, so a failed install (the boot
+// apply only logs+discards the error) would leave host-bound services reachable
+// with no host-inbound default-deny (fail-open). The fix installs a fail-closed
+// DENY-ALL fence when the real ruleset fails to load and no enforcement table
+// exists yet, so enforcement is established (fail-closed) before any host
+// service is exposed. These are the fail-on-revert proofs: neutralize the fence
+// (drop the installHostInboundColdBootFence call, or its emitted drops) and the
+// cold-boot assertions go RED.
+
+// realHostInboundPayload reports whether an nft `-f -` payload is the REAL
+// host-inbound ruleset (carries a per-service ACCEPT) rather than the fence
+// (drops only). hostInboundTestConfig's wan zone permits ssh, so the real
+// payload contains `tcp dport 22 accept`; the fence never accepts a service.
+func realHostInboundPayload(payload string) bool {
+	return strings.Contains(payload, "tcp dport 22 accept")
+}
+
+// TestColdBootHostInboundInstallFailureInstallsFence is the primary #5644
+// fail-on-revert proof: at cold boot, when the real host-inbound `nft -f -`
+// install fails and no enforcement table has ever loaded this boot, a fail-closed
+// DENY-ALL fence MUST be installed so host-bound services stay fenced. It also
+// asserts the commit still fails (the error is surfaced) so the retry/re-render
+// path is driven. Reverting the fence makes the fence-installed assertion and the
+// hostInboundEnforced assertion RED.
+func TestColdBootHostInboundInstallFailureInstallsFence(t *testing.T) {
+	cfg := hostInboundTestConfig()
+
+	injected := errors.New("nft: rule load failed")
+	var payloads []string
+	var fencePayload string
+	orig := nftApplyPayload
+	nftApplyPayload = func(payload string) ([]byte, error) {
+		payloads = append(payloads, payload)
+		if realHostInboundPayload(payload) {
+			// Real ruleset install fails (injected cold-boot install failure).
+			return []byte("Error: could not process rule\n"), injected
+		}
+		// The fence payload loads.
+		fencePayload = payload
+		return nil, nil
+	}
+	defer func() { nftApplyPayload = orig }()
+
+	d := &Daemon{}
+	// Cold boot: no enforcement table has ever loaded.
+	if d.hostInboundEnforced.Load() {
+		t.Fatal("precondition: hostInboundEnforced must start false (cold boot)")
+	}
+
+	err := d.applyHostInboundFilter(cfg)
+
+	// The commit must still fail closed (the real ruleset did not load).
+	if err == nil {
+		t.Fatal("cold-boot install failure must be surfaced as an error, got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the nft failure, got %v", err)
+	}
+
+	// A fence must have been installed (the second nft call).
+	if fencePayload == "" {
+		t.Fatalf("cold-boot install failure must install a fail-closed fence; nft payloads seen:\n%v", payloads)
+	}
+	if len(payloads) != 2 {
+		t.Errorf("expected exactly 2 nft applies (real + fence), got %d:\n%v", len(payloads), payloads)
+	}
+
+	// Enforcement is now established (via the fence) — a later day-2 failure is
+	// retained by the atomic load and needs no fence.
+	if !d.hostInboundEnforced.Load() {
+		t.Error("hostInboundEnforced must be true after the fence installs (enforcement established)")
+	}
+
+	// The fence must be a real xpf_hostinbound table that DENIES host services to
+	// the enforced zone's addresses (both families), NOT leave them open.
+	fenceMust := []string{
+		"table inet xpf_hostinbound",
+		"type filter hook input priority 10; policy accept;",
+		"ct state established,related accept",
+		// deny-all to the wan v4 + v6 firewall-local addresses (host services fenced).
+		"ip daddr 172.16.50.8 drop",
+		"ip6 daddr 2001:db8:50::8 drop",
+	}
+	for _, want := range fenceMust {
+		if !strings.Contains(fencePayload, want) {
+			t.Errorf("fence payload missing %q\n---\n%s", want, fencePayload)
+		}
+	}
+
+	// The fence must NOT accept any host service — that would re-open the exposure.
+	for _, banned := range []string{"tcp dport 22 accept", "icmp type echo-request accept"} {
+		if strings.Contains(fencePayload, banned) {
+			t.Errorf("fence must not accept host service %q (fail-open):\n%s", banned, fencePayload)
+		}
+	}
+}
+
+// TestColdBootFenceIsLifelineSafe proves the cold-boot fence never denies a
+// management / cluster-control lifeline address: fxp0 (mgmt) and em0 (control)
+// are lifelines, so their addresses are excluded from the deny sets and must not
+// appear in the fence. A fence that dropped a lifeline address could strand
+// management or break HA. Reverting the lifeline exclusion (or fencing on
+// lifeline addrs) makes this RED.
+func TestColdBootFenceIsLifelineSafe(t *testing.T) {
+	cfg := hostInboundTestConfig()
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+	fence := buildHostInboundFencePayload(views, unzonedV4, unzonedV6, nil)
+
+	// em0's cluster-control address must never be fenced (lifeline).
+	if strings.Contains(fence, "10.99.0.1") {
+		t.Errorf("fence must not deny the em0 cluster-control lifeline address:\n%s", fence)
+	}
+	// The enforced wan address must be fenced.
+	if !strings.Contains(fence, "ip daddr 172.16.50.8 drop") {
+		t.Errorf("fence must deny the enforced wan address:\n%s", fence)
+	}
+}
+
+// TestColdBootFenceAdmitsMandatoryL3 proves the fence still admits return
+// traffic and mandatory L3 control (established, raw ESP/AH, IPv6 ND, v4/v6
+// PMTUD+error), so the deny-all fence does not black-hole core operation.
+func TestColdBootFenceAdmitsMandatoryL3(t *testing.T) {
+	cfg := hostInboundTestConfig()
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+	fence := buildHostInboundFencePayload(views, unzonedV4, unzonedV6, nil)
+
+	for _, want := range []string{
+		"ct state established,related accept",
+		"meta l4proto { 50, 51 } accept",
+		"icmpv6 type { 133, 134, 135, 136, 137 } accept",
+		"icmp type { destination-unreachable, time-exceeded, parameter-problem } accept",
+	} {
+		if !strings.Contains(fence, want) {
+			t.Errorf("fence missing mandatory L3 admit %q\n---\n%s", want, fence)
+		}
+	}
+}
+
+// TestColdBootFenceAdmitsWireGuardPort proves the fence admits the configured
+// WireGuard listen port so a responder-only tunnel is not black-holed while the
+// fence is active (mirrors the real chain's WG admit).
+func TestColdBootFenceAdmitsWireGuardPort(t *testing.T) {
+	cfg := hostInboundTestConfig()
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	fence := buildHostInboundFencePayload(views, nil, nil, []uint16{51820})
+	if !strings.Contains(fence, "udp dport 51820 accept") {
+		t.Errorf("fence must admit the configured WG listen port:\n%s", fence)
+	}
+}
+
+// TestDay2HostInboundInstallFailureNoFence proves the NORMAL (tables-present)
+// path is unchanged: once a real host-inbound table has installed
+// (hostInboundEnforced == true), a LATER failed install must NOT install a fence
+// — the atomic `-f -` load already retains the prior table (fail-closed). Only
+// the real payload is attempted; no fence is emitted. This is the no-regression
+// guard: if the cold-boot fence were installed unconditionally it would clobber
+// the retained day-2 table with a deny-all, so this goes RED.
+func TestDay2HostInboundInstallFailureNoFence(t *testing.T) {
+	cfg := hostInboundTestConfig()
+
+	// First apply: real install succeeds → enforcement established.
+	orig := nftApplyPayload
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	d := &Daemon{}
+	if err := d.applyHostInboundFilter(cfg); err != nil {
+		t.Fatalf("first (successful) apply: %v", err)
+	}
+	if !d.hostInboundEnforced.Load() {
+		t.Fatal("hostInboundEnforced must be true after a successful real install")
+	}
+
+	// Second apply: real install fails. The prior table is retained by the atomic
+	// load, so NO fence must be installed.
+	injected := errors.New("nft: transient failure")
+	var payloads []string
+	nftApplyPayload = func(payload string) ([]byte, error) {
+		payloads = append(payloads, payload)
+		if realHostInboundPayload(payload) {
+			return []byte("Error\n"), injected
+		}
+		t.Errorf("day-2 failure must NOT install a fence; got fence payload:\n%s", payload)
+		return nil, nil
+	}
+	defer func() { nftApplyPayload = orig }()
+
+	err := d.applyHostInboundFilter(cfg)
+	if err == nil {
+		t.Fatal("day-2 install failure must still be surfaced as an error")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the nft failure, got %v", err)
+	}
+	if len(payloads) != 1 {
+		t.Errorf("day-2 failure must attempt only the real payload (no fence), got %d applies:\n%v", len(payloads), payloads)
+	}
+}
+
+// TestColdBootFenceCatastrophicFailureSurfaced proves that when the real install
+// AND the fence both fail (nft itself broken), both errors are surfaced so the
+// commit fails closed and the operator sees the fail-open guard fire.
+func TestColdBootFenceCatastrophicFailureSurfaced(t *testing.T) {
+	cfg := hostInboundTestConfig()
+
+	realErr := errors.New("nft: rule load failed")
+	fenceErr := errors.New("nft: binary missing")
+	orig := nftApplyPayload
+	nftApplyPayload = func(payload string) ([]byte, error) {
+		if realHostInboundPayload(payload) {
+			return nil, realErr
+		}
+		return nil, fenceErr
+	}
+	defer func() { nftApplyPayload = orig }()
+
+	d := &Daemon{}
+	err := d.applyHostInboundFilter(cfg)
+	if err == nil {
+		t.Fatal("catastrophic cold-boot failure must be surfaced as an error")
+	}
+	if !errors.Is(err, realErr) || !errors.Is(err, fenceErr) {
+		t.Errorf("error must join both the real and fence failures, got %v", err)
+	}
+	// The fence never loaded, so enforcement is NOT established.
+	if d.hostInboundEnforced.Load() {
+		t.Error("hostInboundEnforced must stay false when the fence also fails")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5644 (codex-review-181 **M37**).

On **cold boot** both nft tables are absent, so a failed
`applyHostInboundFilter` install has no prior table to retain — the atomic
`nft -f -` fail-closed guarantee (#3333) is **day-2 only**. The boot apply
reaches `applyHostInboundFilter` through `applyConfig`, which only **logs and
discards** the returned error (`daemon_apply.go:115-116` — a boot apply must not
brick startup), so a cold-boot install failure would leave the host input path
with **no** `xpf_hostinbound` chain: every host-bound service to a firewall-local
address reachable with no host-inbound default-deny (**fail-open**), while the
daemon proceeds to publish host service / VIP / HA-ready.

## Fix

- New `Daemon.hostInboundEnforced` atomic bool = "a host-inbound table (real or
  fence) has loaded at least once this boot". On a real-install failure it is
  `false` **only** at cold boot (no table ever loaded); day-2 it is `true`, so the
  atomic-load retention already covers the failure and **no fence** is installed —
  the normal path is bit-unchanged.
- `installHostInboundColdBootFence` / `buildHostInboundFencePayload`
  (`daemon_nft.go`) install a **fail-closed DENY-ALL fence**: the global mandatory
  admits (established, raw ESP/AH, IPv6 ND, v4/v6 PMTUD+error, WG listen port) plus
  a catch-all `drop` for every firewall-local address the real ruleset would scope
  (per-zone views + addressed-but-unzoned) — **no per-service accept, no
  counters**. Address sets are already lifeline-excluded (fxp0/em0/fab*), so the
  fence can never strand management or break HA.
- The commit still **fails** (the nft error is returned, joined into the commit
  result) — the fence only closes the exposure; the failed apply drives the
  retry/re-render, which self-heals. If the fence also fails, both errors are
  joined and an `ERROR`-level `COLD-BOOT FAIL-OPEN GUARD` fires.

Scope: direct-host nft input authority only; the AF_XDP transit arm is #5275.

## Validation

`pkg/daemon/host_inbound_coldboot_fence_5644_test.go` — fail-on-revert proofs:
cold-boot real-install failure installs the fence (deny-all, no service accepts,
`hostInboundEnforced` true); fence is lifeline-safe and admits mandatory L3 + WG;
day-2 failure installs **no** fence (only the real payload attempted);
catastrophic both-fail surfaces both errors. **RED proven** by neutralizing the
fence call (fail-open restored), **GREEN** with the fix.

`GOCACHE=/dev/shm/cache go test ./pkg/daemon/...` → `ok`. gofmt clean. Doc: new
"Cold-boot fail-closed install fence (#5644, M37)" section in
`docs/host-inbound-service-matrix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZPnFeaxqFw81wiaszFjL4