### PR TITLE
config: emit per-unit GRE tunnel fields, not iface-level

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47360,3 +47360,23 @@ top.
     docs/config-schema.md (Edit), _Log.md (Edit)
   - **Action**: #5644 (M37) — close the cold-boot host-inbound fail-open. On COLD BOOT both nft tables are absent, so a failed `applyHostInboundFilter` install has no prior table to retain (the atomic `-f -` fail-closed guarantee is day-2 only) and the boot apply only logs+discards the error → host services reachable with no host-inbound default-deny. Added a fail-closed DENY-ALL fence (`installHostInboundColdBootFence` / `buildHostInboundFencePayload`) installed when the real ruleset fails to load and `d.hostInboundEnforced` is still false (cold boot); the commit still fails (drives retry). Lifeline-excluded, no service accepts, no counters. Day-2 failures unchanged (prior table retained, no fence). Added fail-on-revert tests (RED proven with the fence neutralized). Doc: docs/host-inbound-service-matrix.md new "Cold-boot fail-closed install fence (#5644, M37)" section.
   - **File(s)**: pkg/daemon/daemon.go (Edit), pkg/daemon/daemon_nft.go (Edit), pkg/daemon/host_inbound_coldboot_fence_5644_test.go (Write), docs/host-inbound-service-matrix.md (Edit), _Log.md (Edit)
+
+- **Timestamp**: 2026-07-12
+  - **Action**: #5635 (M27) — EmitTunnelEndpointNames loses per-unit GRE
+    key/endpoint/TTL/routing-instance. When an interface carried BOTH an
+    interface-level `tunnel` stanza (iface.Tunnel != nil) AND per-unit
+    tunnel stanzas, the non-WireGuard emit loop at
+    pkg/config/tunnelemit.go:101-103 emitted `iface.Tunnel` for EVERY unit,
+    so the per-unit overrides the compiler stored in `unit.Tunnel`
+    (cloneForUnit + unit-level parse) — key, source/destination endpoint,
+    TTL, routing-instance — were dropped from the emitted set the dataplane
+    snapshot builder (buildTunnelEndpointSnapshots) and the commit-time
+    collision gate consume. Fixed to emit each unit's own TunnelConfig when
+    it has a tunnel stanza, falling back to the interface-level tunnel for
+    units without one (unchanged behavior). WireGuard single-lowest-unit
+    pick (#1910) deliberately untouched — GRE-scoped. Added fail-on-revert
+    tests: RED proven with the per-unit branch neutralized (all five fields
+    revert to interface-level values), GREEN restored. Updated the
+    EmitTunnelEndpointNames contract doc comment.
+  - **File(s)**: pkg/config/tunnelemit.go (Edit),
+    pkg/config/tunnelemit_perunit_5635_test.go (Write), _Log.md (Edit)

--- a/pkg/config/tunnelemit.go
+++ b/pkg/config/tunnelemit.go
@@ -35,6 +35,12 @@ type TunnelEndpointName struct {
 //   - it applies the same interface-level-WireGuard single-lowest-unit
 //     pick (#1910): one persistent TUN per interface-level WG tunnel, keyed
 //     by the lowest configured unit ref;
+//   - for a non-WireGuard interface that carries BOTH an interface-level
+//     tunnel and per-unit tunnel stanzas, it emits each unit's OWN
+//     TunnelConfig — key, source/destination endpoint, TTL, and
+//     routing-instance — instead of the interface-level object, so per-unit
+//     GRE/IPIP overrides survive the emit (#5635); a unit with no tunnel
+//     stanza inherits the interface-level tunnel unchanged;
 //   - it formats every ref as the canonical "%s.%d" the builder formats
 //     from the int-keyed Units map (leading-zero / overflow / last-wins
 //     unit canonicalization is already resolved by compileInterfaces when
@@ -99,7 +105,23 @@ func EmitTunnelEndpointNames(cfg *Config) []TunnelEndpointName {
 				continue
 			}
 			for _, unitNum := range unitNums {
-				add(fmt.Sprintf("%s.%d", name, unitNum), iface.Tunnel)
+				// #5635: a unit that carries its OWN tunnel stanza holds
+				// the per-unit GRE/IPIP overrides — key, source/destination
+				// endpoint, TTL, and routing-instance — that the compiler
+				// cloned from the interface-level tunnel and then applied on
+				// top of (compiler_interfaces.go: cloneForUnit + the
+				// unit-level tunnel parse). Emit that per-unit TunnelConfig,
+				// NOT the interface-level object, so the dataplane snapshot
+				// builder (buildTunnelEndpointSnapshots) and the commit-time
+				// collision gate see the unit's real endpoint instead of the
+				// interface-level defaults. A unit with no tunnel stanza
+				// (unit.Tunnel == nil) still inherits the interface-level
+				// tunnel unchanged.
+				tunnel := iface.Tunnel
+				if unit := iface.Units[unitNum]; unit != nil && unit.Tunnel != nil {
+					tunnel = unit.Tunnel
+				}
+				add(fmt.Sprintf("%s.%d", name, unitNum), tunnel)
 			}
 			continue
 		}

--- a/pkg/config/tunnelemit_perunit_5635_test.go
+++ b/pkg/config/tunnelemit_perunit_5635_test.go
@@ -1,0 +1,127 @@
+package config
+
+import "testing"
+
+// buildTree (ParseSetCommand + SetPath, NOT NewParser) is defined in
+// compiler_equal_flow_worker_cap_test.go and reused here.
+
+// findEmittedTunnel returns the emitted per-unit TunnelConfig for the given
+// unit-qualified ref, or nil if the emitter did not produce that ref.
+func findEmittedTunnel(eps []TunnelEndpointName, name string) *TunnelConfig {
+	for _, ep := range eps {
+		if ep.Name == name {
+			return ep.Tunnel
+		}
+	}
+	return nil
+}
+
+// TestEmitTunnelEndpointNamesPreservesPerUnitGREOverrides is the #5635
+// RED-on-revert gate. A GRE interface carries BOTH an interface-level tunnel
+// stanza and a per-unit tunnel stanza on unit 7 that overrides EVERY field —
+// key, source and destination endpoint, TTL, and routing-instance — with
+// values distinct from the interface-level defaults. The compiler stores those
+// overrides in unit.Tunnel (cloneForUnit + the unit-level tunnel parse).
+//
+// Before the fix, EmitTunnelEndpointNames took the iface.Tunnel != nil branch
+// and emitted the INTERFACE-LEVEL tunnel object for every unit, so the
+// dataplane snapshot builder (buildTunnelEndpointSnapshots) and the commit-time
+// collision gate saw the interface-level defaults for gr-0/0/0.7 and the
+// per-unit key/endpoint/TTL/routing-instance were silently dropped from the
+// emitted (round-tripped) config. The fix emits the unit's OWN TunnelConfig.
+func TestEmitTunnelEndpointNamesPreservesPerUnitGREOverrides(t *testing.T) {
+	cmds := []string{
+		// Interface-level tunnel: complete endpoint + distinct key/ttl/RI.
+		"set interfaces gr-0/0/0 tunnel source 10.0.0.1",
+		"set interfaces gr-0/0/0 tunnel destination 10.0.0.2",
+		"set interfaces gr-0/0/0 tunnel key 1000",
+		"set interfaces gr-0/0/0 tunnel ttl 10",
+		"set interfaces gr-0/0/0 tunnel routing-instance destination IFACE-VR",
+		// Per-unit tunnel on unit 7 overriding EVERY field with distinct
+		// values. cloneForUnit seeds it from the interface-level tunnel; the
+		// unit-level parse then overrides each field.
+		"set interfaces gr-0/0/0 unit 7 tunnel source 10.7.7.1",
+		"set interfaces gr-0/0/0 unit 7 tunnel destination 10.7.7.2",
+		"set interfaces gr-0/0/0 unit 7 tunnel key 7777",
+		"set interfaces gr-0/0/0 unit 7 tunnel ttl 77",
+		"set interfaces gr-0/0/0 unit 7 tunnel routing-instance destination UNIT-VR",
+		"set interfaces gr-0/0/0 unit 7 family inet address 10.7.0.1/30",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+
+	// Sanity: the compiler must have stored the per-unit overrides on
+	// unit.Tunnel (this is the committed intent the emit must reflect).
+	ifc := cfg.Interfaces.Interfaces["gr-0/0/0"]
+	if ifc == nil || ifc.Tunnel == nil {
+		t.Fatal("gr-0/0/0 interface-level tunnel not found")
+	}
+	u7 := ifc.Units[7]
+	if u7 == nil || u7.Tunnel == nil {
+		t.Fatal("gr-0/0/0 unit 7 per-unit tunnel not found")
+	}
+	if u7.Tunnel.Key != 7777 || u7.Tunnel.Source != "10.7.7.1" ||
+		u7.Tunnel.Destination != "10.7.7.2" || u7.Tunnel.TTL != 77 ||
+		u7.Tunnel.RoutingInstance != "UNIT-VR" {
+		t.Fatalf("compiler did not store per-unit overrides: %+v", u7.Tunnel)
+	}
+
+	// The emit must carry the unit's own tunnel, not the interface-level one.
+	emitted := EmitTunnelEndpointNames(cfg)
+	tun := findEmittedTunnel(emitted, "gr-0/0/0.7")
+	if tun == nil {
+		t.Fatalf("gr-0/0/0.7 not emitted; got %d endpoints: %+v", len(emitted), emitted)
+	}
+
+	if tun.Key != 7777 {
+		t.Errorf("emitted Key = %d, want 7777 (per-unit override dropped — #5635)", tun.Key)
+	}
+	if tun.Source != "10.7.7.1" {
+		t.Errorf("emitted Source = %q, want 10.7.7.1 (per-unit override dropped — #5635)", tun.Source)
+	}
+	if tun.Destination != "10.7.7.2" {
+		t.Errorf("emitted Destination = %q, want 10.7.7.2 (per-unit override dropped — #5635)", tun.Destination)
+	}
+	if tun.TTL != 77 {
+		t.Errorf("emitted TTL = %d, want 77 (per-unit override dropped — #5635)", tun.TTL)
+	}
+	if tun.RoutingInstance != "UNIT-VR" {
+		t.Errorf("emitted RoutingInstance = %q, want UNIT-VR (per-unit override dropped — #5635)", tun.RoutingInstance)
+	}
+
+	// Explicitly assert the emit did NOT fall back to the interface-level
+	// defaults — this is precisely what the pre-fix code emitted.
+	if tun.Key == ifc.Tunnel.Key && tun.Destination == ifc.Tunnel.Destination {
+		t.Errorf("emitted the interface-level tunnel for gr-0/0/0.7 (key=%d dst=%q) — per-unit overrides lost",
+			tun.Key, tun.Destination)
+	}
+}
+
+// TestEmitTunnelEndpointNamesUnitWithoutStanzaInheritsInterfaceTunnel guards the
+// fallback path the #5635 fix must not regress: an interface-level tunnel with a
+// unit that has NO tunnel stanza still emits the interface-level tunnel for that
+// unit (the interface-level endpoint applies to every unit).
+func TestEmitTunnelEndpointNamesUnitWithoutStanzaInheritsInterfaceTunnel(t *testing.T) {
+	cmds := []string{
+		"set interfaces gr-0/0/0 tunnel source 198.51.100.1",
+		"set interfaces gr-0/0/0 tunnel destination 198.51.100.2",
+		"set interfaces gr-0/0/0 tunnel key 42",
+		// unit 3 has no per-unit tunnel stanza — only an address.
+		"set interfaces gr-0/0/0 unit 3 family inet address 10.3.0.1/30",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	emitted := EmitTunnelEndpointNames(cfg)
+	tun := findEmittedTunnel(emitted, "gr-0/0/0.3")
+	if tun == nil {
+		t.Fatalf("gr-0/0/0.3 not emitted; got %+v", emitted)
+	}
+	if tun.Source != "198.51.100.1" || tun.Destination != "198.51.100.2" || tun.Key != 42 {
+		t.Errorf("no-stanza unit did not inherit interface-level tunnel: src=%q dst=%q key=%d",
+			tun.Source, tun.Destination, tun.Key)
+	}
+}


### PR DESCRIPTION
## Problem (#5635, codex-review-181 M27, High)

`EmitTunnelEndpointNames` (`pkg/config/tunnelemit.go`) is the single
source of truth for the configured tunnel-endpoint set the AF_XDP
dataplane snapshot builder (`buildTunnelEndpointSnapshots`) and the
commit-time collision gate (`validateTunnelEndpointIDCollisionAST`)
consume.

When an interface carried **both** an interface-level `tunnel` stanza
(`iface.Tunnel != nil`) **and** per-unit tunnel stanzas, the
non-WireGuard emit loop (`tunnelemit.go:101-103`) emitted the
**interface-level** tunnel object for **every** unit. The per-unit
GRE/IPIP overrides the compiler stores on `unit.Tunnel`
(`compiler_interfaces.go`: `cloneForUnit` seeds each unit from the
interface-level tunnel, then the unit-level parse overrides on top) —
**key, source/destination endpoint, TTL, and routing-instance** — were
silently dropped from the emitted set. The dataplane and the collision
gate then saw the interface-level defaults for that unit rather than its
real endpoint, so a re-parse / round-trip of the emitted config lost the
unit's key/endpoint/TTL/routing-instance.

## Fix

Emit each unit's **own** `TunnelConfig` when the unit has a tunnel
stanza, falling back to the interface-level tunnel for units without one
(the interface-level endpoint applies to every unit — unchanged
behavior). The emitted **name** set is identical, so the #1914 SSOT
parity pin (`TestEmitTunnelEndpointNamesMatchesBuilder`) stays green;
only the tunnel object each per-unit ref carries is corrected.

The interface-level-WireGuard single-lowest-unit pick (#1910) is
deliberately untouched — WG per-unit peer-merge semantics are a separate
design question (M27 adjunct); this change is scoped to the GRE/IPIP
dropped-fields bug.

## Validation

- Added fail-on-revert tests
  (`TestEmitTunnelEndpointNamesPreservesPerUnitGREOverrides`,
  `TestEmitTunnelEndpointNamesUnitWithoutStanzaInheritsInterfaceTunnel`).
  A GRE interface with an interface-level tunnel plus a unit-7 stanza
  overriding all five fields with distinct values asserts the emit
  carries the unit's values, not the interface-level ones.
- **RED proven** with the per-unit branch neutralized (every field
  reverts to the interface-level value: `Key=1000`, `Source=10.0.0.1`,
  `Destination=10.0.0.2`, `TTL=10`, `RoutingInstance=IFACE-VR`),
  **GREEN restored**.
- `go test ./pkg/config/...` and the userspace tunnel parity test pass.

Closes #5635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b9ZhYXn6YP2tn2dBkFYK8