### PR TITLE
dhcprelay: rate-limit the relay ingress path per interface (#5670)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47360,3 +47360,14 @@ top.
     docs/config-schema.md (Edit), _Log.md (Edit)
   - **Action**: #5644 (M37) — close the cold-boot host-inbound fail-open. On COLD BOOT both nft tables are absent, so a failed `applyHostInboundFilter` install has no prior table to retain (the atomic `-f -` fail-closed guarantee is day-2 only) and the boot apply only logs+discards the error → host services reachable with no host-inbound default-deny. Added a fail-closed DENY-ALL fence (`installHostInboundColdBootFence` / `buildHostInboundFencePayload`) installed when the real ruleset fails to load and `d.hostInboundEnforced` is still false (cold boot); the commit still fails (drives retry). Lifeline-excluded, no service accepts, no counters. Day-2 failures unchanged (prior table retained, no fence). Added fail-on-revert tests (RED proven with the fence neutralized). Doc: docs/host-inbound-service-matrix.md new "Cold-boot fail-closed install fence (#5644, M37)" section.
   - **File(s)**: pkg/daemon/daemon.go (Edit), pkg/daemon/daemon_nft.go (Edit), pkg/daemon/host_inbound_coldboot_fence_5644_test.go (Write), docs/host-inbound-service-matrix.md (Edit), _Log.md (Edit)
+
+## 2026-07-12 — #5670 DHCP relay per-interface ingress rate limit
+- **Timestamp**: 2026-07-12
+- **Action**: Add per-interface token-bucket rate limit on the DHCP relay
+  ingress path (DoS/amplification hardening). New `overrides
+  maximum-packet-rate <pps>` override (default 100 pps), `RequestsDroppedRateLimit`
+  counter, CLI display + docs. Fail-on-revert tests (deterministic clock seam).
+- **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/relay_ratelimit_5670_test.go,
+  pkg/config/types_system.go, pkg/config/compiler_services.go,
+  pkg/config/schema_routing.go, pkg/config/compiler_dhcp_relay_overrides_test.go,
+  pkg/cli/show_services_dhcp.go, pkg/dhcprelay/README.md, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3043,6 +3043,23 @@ reserved for whole-dataplane selection where a rewrite shim
     `pkg/config/compiler_dhcp_relay_overrides_test.go` (compile flat-set
     + merged-Keys value + block form + advisory) and
     `pkg/dhcprelay/relay_test.go` (`TestRunRelay_ConfiguredMaxHopCount`).
+- **#5670 (DHCP relay ingress rate limit):** added under group `overrides`:
+  - `maximum-packet-rate <pps>` (`ValidateInteger(1, 1000000)`) —
+    **enforced (DoS hardening)**. The relay admits at most this many
+    client-facing datagrams per second per interface, via a per-interface
+    token bucket checked BEFORE `dhcpv4.FromBytes` + the Option-82 fan-out,
+    so an untrusted client segment cannot CPU-exhaust the relay or amplify a
+    flood into the upstream servers (1 client packet → N server packets).
+    Unset = 100 pps default (`resolveMaxPacketRate`); the bucket starts full
+    with a 2-second burst; excess is dropped and counted in
+    `RelayStats.RequestsDroppedRateLimit`. Compiled into
+    `DHCPRelayGroup.MaximumPacketRate` and flows into
+    `relaySpec.maxPacketRate` (a change restarts the per-interface relay).
+    Both AST shapes handled. Coverage:
+    `pkg/config/compiler_dhcp_relay_overrides_test.go` (flat-set + merged +
+    block + completion + default) and `pkg/dhcprelay/relay_ratelimit_5670_test.go`
+    (`TestTokenBucket_BurstThenRefill` deterministic unit + the end-to-end
+    flood-drop `TestRunRelay_RateLimit_5670` / `TestRunRelay_RateLimit_DefaultBound`).
 - **#2008 H7 (security log profile):** declared the `security log
   profile <name>` stanza — `stream-name` (`ValueHintStreamName`
   completion), `default-profile` (presence flag), and

--- a/pkg/cli/show_services_dhcp.go
+++ b/pkg/cli/show_services_dhcp.go
@@ -125,6 +125,11 @@ func (c *CLI) showDHCPRelay() error {
 			if g.MaximumHopCount > 0 {
 				overrides = append(overrides, fmt.Sprintf("maximum-hop-count %d", g.MaximumHopCount))
 			}
+			// #5670: per-interface ingress rate limit (pps). Enforced; unset uses
+			// the default (100 pps) — show the effective bound either way.
+			if g.MaximumPacketRate > 0 {
+				overrides = append(overrides, fmt.Sprintf("maximum-packet-rate %d", g.MaximumPacketRate))
+			}
 			if g.ForwardOnly {
 				overrides = append(overrides, "forward-only (accepted-only)")
 			}
@@ -142,9 +147,9 @@ func (c *CLI) showDHCPRelay() error {
 		stats := c.dhcpRelay.Stats()
 		if len(stats) > 0 {
 			fmt.Println("\nRelay statistics:")
-			fmt.Printf("  %-16s %-20s %-20s %s\n", "Interface", "Requests relayed", "Replies forwarded", "Dropped (max-hops)")
+			fmt.Printf("  %-16s %-18s %-18s %-18s %s\n", "Interface", "Requests relayed", "Replies forwarded", "Dropped (max-hops)", "Dropped (rate-limit)")
 			for _, s := range stats {
-				fmt.Printf("  %-16s %-20d %-20d %d\n", s.Interface, s.RequestsRelayed, s.RepliesForwarded, s.RequestsDroppedMaxHops)
+				fmt.Printf("  %-16s %-18d %-18d %-18d %d\n", s.Interface, s.RequestsRelayed, s.RepliesForwarded, s.RequestsDroppedMaxHops, s.RequestsDroppedRateLimit)
 			}
 			// Reply-delivery breakdown (#2076). L2-fallback is the one to
 			// alert on: it means the raw-L2 path failed (CAP_NET_RAW,

--- a/pkg/config/compiler_dhcp_relay_overrides_test.go
+++ b/pkg/config/compiler_dhcp_relay_overrides_test.go
@@ -499,3 +499,117 @@ func TestDHCPRelayOverrides_5414_SchemaCompletion(t *testing.T) {
 		t.Errorf("overrides completion missing trust-option-82; got %v", comps)
 	}
 }
+
+// #5670: `overrides maximum-packet-rate <pps>` is the per-interface DHCP relay
+// ingress rate limit and must compile from the flat-set path to
+// DHCPRelayGroup.MaximumPacketRate. RED-on-revert: without the compiler case
+// the field reads back its zero value (silent drop) and the relay runs
+// unbounded on that segment.
+func TestDHCPRelayOverrides_5670_PacketRate_FlatSet(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set forwarding-options dhcp-relay server-group sg 10.1.1.1",
+		"set forwarding-options dhcp-relay group lan active-server-group sg",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/0.0",
+		"set forwarding-options dhcp-relay group lan overrides maximum-packet-rate 250",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	g := relayGroup(t, cfg, "lan")
+	if g.MaximumPacketRate != 250 {
+		t.Errorf("MaximumPacketRate = %d, want 250 (flat-set overrides)", g.MaximumPacketRate)
+	}
+	// The interface list must stay clean — the value token must not be swallowed.
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("Interfaces = %v, want [ge-0/0/0.0] (packet-rate value swallowed?)", g.Interfaces)
+	}
+}
+
+// Default: absent maximum-packet-rate leaves the field 0 (the compiler's
+// unset), which relay.go resolves to the 100 pps default.
+func TestDHCPRelayOverrides_5670_PacketRate_DefaultUnset(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set forwarding-options dhcp-relay server-group sg 10.1.1.1",
+		"set forwarding-options dhcp-relay group lan active-server-group sg",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/0.0",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if g := relayGroup(t, cfg, "lan"); g.MaximumPacketRate != 0 {
+		t.Errorf("MaximumPacketRate = %d, want 0 (absent override → resolver default)", g.MaximumPacketRate)
+	}
+}
+
+// Merged-Keys and block forms of maximum-packet-rate must also compile — the
+// same three parse shapes #4309/#5414 cover. The merged-Keys shape exercises
+// the inline override loop's value consumption (the loop must advance past the
+// value token, not treat "250" as an override keyword).
+func TestDHCPRelayOverrides_5670_PacketRate_MergedAndBlock(t *testing.T) {
+	merged := &Node{
+		Keys: []string{"dhcp-relay"},
+		Children: []*Node{
+			{Keys: []string{"server-group", "sg", "10.1.1.1"}, IsLeaf: true},
+			{
+				Keys: []string{
+					"group", "lan",
+					"overrides", "maximum-packet-rate", "250",
+					"interface", "ge-0/0/0.0",
+				},
+				IsLeaf: true,
+			},
+		},
+	}
+	fo := &ForwardingOptionsConfig{}
+	if err := compileDHCPRelay(merged, fo); err != nil {
+		t.Fatalf("compileDHCPRelay (merged): %v", err)
+	}
+	if g := fo.DHCPRelay.Groups["lan"]; g == nil || g.MaximumPacketRate != 250 {
+		t.Errorf("merged-Keys MaximumPacketRate not 250: %+v", g)
+	} else if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("merged-Keys Interfaces = %v, want [ge-0/0/0.0] (packet-rate value swallowed?)", g.Interfaces)
+	}
+
+	block := &Node{
+		Keys: []string{"dhcp-relay"},
+		Children: []*Node{
+			{Keys: []string{"server-group", "sg", "10.1.1.1"}, IsLeaf: true},
+			{
+				Keys: []string{"group", "lan"},
+				Children: []*Node{
+					{Keys: []string{"interface", "ge-0/0/0.0"}, IsLeaf: true},
+					{Keys: []string{"overrides"}, Children: []*Node{
+						{Keys: []string{"maximum-packet-rate", "250"}, IsLeaf: true},
+					}},
+				},
+			},
+		},
+	}
+	fo2 := &ForwardingOptionsConfig{}
+	if err := compileDHCPRelay(block, fo2); err != nil {
+		t.Fatalf("compileDHCPRelay (block): %v", err)
+	}
+	if g := fo2.DHCPRelay.Groups["lan"]; g == nil || g.MaximumPacketRate != 250 {
+		t.Errorf("block-form MaximumPacketRate not 250: %+v", g)
+	}
+}
+
+// Structural completion must offer maximum-packet-rate under overrides so an
+// operator can discover the knob via `?`.
+func TestDHCPRelayOverrides_5670_SchemaCompletion(t *testing.T) {
+	comps := CompleteSetPath([]string{
+		"forwarding-options", "dhcp-relay", "group", "lan", "overrides", "",
+	})
+	found := false
+	for _, c := range comps {
+		if c == "maximum-packet-rate" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("overrides completion missing maximum-packet-rate; got %v", comps)
+	}
+}

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1632,6 +1632,13 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 								g.MaximumHopCount = n
 							}
 						}
+					case "maximum-packet-rate":
+						if i+1 < len(keys) {
+							i++
+							if n, err := strconv.Atoi(keys[i]); err == nil {
+								g.MaximumPacketRate = n
+							}
+						}
 					}
 				}
 			}
@@ -1677,6 +1684,12 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 								g.MaximumHopCount = n
 							}
 						}
+					case "maximum-packet-rate":
+						if v := nodeVal(oc); v != "" {
+							if n, err := strconv.Atoi(v); err == nil {
+								g.MaximumPacketRate = n
+							}
+						}
 					}
 				}
 				for i := 1; i < len(prop.Keys); i++ {
@@ -1694,6 +1707,13 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 							i++
 							if n, err := strconv.Atoi(prop.Keys[i]); err == nil {
 								g.MaximumHopCount = n
+							}
+						}
+					case "maximum-packet-rate":
+						if i+1 < len(prop.Keys) {
+							i++
+							if n, err := strconv.Atoi(prop.Keys[i]); err == nil {
+								g.MaximumPacketRate = n
 							}
 						}
 					}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -711,6 +711,14 @@ var schemaForwardingOptions = &schemaNode{desc: "Packet forwarding options", chi
 				"maximum-hop-count": {desc: "Drop relayed requests whose hop count reaches this limit", args: 1, placeholder: "<count>",
 					valueType: ValueInteger, valueDesc: "relay hop limit (RFC 1542 §4.1.1; 1..16)",
 					valueExamples: []string{"4", "16"}, validator: ValidateInteger(1, 16), children: nil},
+				// #5670: per-interface ingress rate limit (packets/second). ENFORCED
+				// — a token bucket bounds the client-facing admit rate so an
+				// untrusted segment cannot CPU-exhaust the relay or amplify a flood
+				// into the upstream servers. Unset = default 100 pps; set high to
+				// effectively disable.
+				"maximum-packet-rate": {desc: "Rate-limit client-facing relay requests (packets/second per interface)", args: 1, placeholder: "<pps>",
+					valueType: ValueInteger, valueDesc: "relay ingress rate limit in pps (default 100)",
+					valueExamples: []string{"100", "500"}, validator: ValidateInteger(1, 1000000), children: nil},
 				"forward-only":       {desc: "Forward without retaining relay state (accepted-only; matches default — #4309)", children: nil},
 				"relay-agent-option": {desc: "Insert Option 82 relay agent information (accepted-only; always inserted — #4309)", children: nil},
 				// #5414: trust-option-82 marks the group's interfaces as

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -1087,6 +1087,17 @@ type DHCPRelayGroup struct {
 	// relay, so an inbound nonzero giaddr + Option 82 is preserved untouched
 	// (the RFC 1542 §4.1 intermediate-relay behavior, #5071).
 	TrustOption82 bool
+	// MaximumPacketRate is the per-interface DHCP relay ingress rate limit in
+	// packets per second (#5670, Junos `overrides maximum-packet-rate`).
+	// ENFORCED. The relay admits at most this many client-facing datagrams per
+	// second per interface (a token bucket with a short burst allowance),
+	// dropping the excess before the DHCP parse + Option-82 fan-out so an
+	// untrusted client segment cannot CPU-exhaust the relay or amplify a flood
+	// into the upstream servers (1 client packet → N server packets). 0 = unset
+	// = the default (defaultMaxPacketRate, 100 pps). Set a high value to
+	// effectively disable the bound. Compiled into `relaySpec.maxPacketRate`
+	// (a change restarts the per-interface relay).
+	MaximumPacketRate int
 }
 
 // SamplingConfig holds sampling instance definitions.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -184,7 +184,10 @@ RFC 768).
   (#4163)** counts replies dropped because their source IP was not a
   configured server — a non-zero value is a rogue-reply injection attempt (or
   a multi-homed server unicasting from an unlisted source IP); see "Reply
-  source validation" below. `show ... dhcp-relay` prints this breakdown.
+  source validation" below. **`RequestsDroppedRateLimit` (#5670)** counts
+  client-facing datagrams dropped by the per-interface ingress rate limiter — a
+  sustained nonzero value is a flood / amplification attempt (see "Ingress rate
+  limit" below). `show ... dhcp-relay` prints this breakdown.
 
 ## Reply source validation (#4163)
 
@@ -259,6 +262,43 @@ set forwarding-options dhcp-relay group <g> overrides relay-agent-option
 - **`relay-agent-option` — accepted-only.** The relay ALWAYS inserts
   Option 82 (`circuit-id`); this knob is accepted and matches the
   default, with the same accepted-only advisory.
+
+### Ingress rate limit (#5670)
+
+```
+set forwarding-options dhcp-relay group <g> overrides maximum-packet-rate <pps>
+```
+
+- **`maximum-packet-rate` — ENFORCED (DoS hardening).** The relay admits at
+  most this many client-facing datagrams per second **per interface**, via a
+  per-interface token bucket (`tokenBucket` in `relay.go`) checked in the main
+  read loop **before** `dhcpv4.FromBytes`. Without it an untrusted client
+  segment can flood `:67`: each admitted packet costs a variable-length TLV
+  parse, an Option 82 allocation, and a **fan-out send to EVERY configured
+  server** — a 1→N amplification that can also make the real servers rate-limit
+  legitimate clients. The bound is applied at the cheapest point (before the
+  parse) so a flood is dropped without doing the work.
+- **Default 100 pps** when unset (`resolveMaxPacketRate`). DHCP relay traffic is
+  inherently low-rate (a handful of packets per lease, renewals on the order of
+  hours), so 100 pps sustained is generous for legitimate use. The bucket starts
+  **full** with a **2-second burst** (`relayBurstFor` = `2×rate`), so a
+  simultaneous-boot spike up to `2×rate` packets is admitted instantly before
+  the sustained rate throttles a persistent flood. Set a high value
+  (schema range `1..1000000`) to effectively disable the bound on a segment that
+  legitimately needs it.
+- **Counted + throttled log.** Every dropped datagram bumps
+  `RelayStats.RequestsDroppedRateLimit`; the log is warn-once-per-session then
+  `Debug` (never per packet, per the project logging rules). A sustained
+  nonzero counter means the segment is exceeding its pps bound — a flood /
+  amplification attempt or a segment that should raise `maximum-packet-rate`.
+- Compiles to `DHCPRelayGroup.MaximumPacketRate` and flows into
+  `relaySpec.maxPacketRate` (a change resizes the bucket, so it restarts the
+  per-interface relay). All three parse shapes (flat-set, merged-Keys, block
+  form) are covered; the flat-set consumer treats `overrides` as a property
+  boundary so the value token is not swallowed into the interface list. The
+  token-bucket refill semantics are unit-tested deterministically with an
+  injected clock (`TestTokenBucket_BurstThenRefill`); the end-to-end flood-drop
+  is `TestRunRelay_RateLimit_5670` / `TestRunRelay_RateLimit_DefaultBound`.
 
 ### Trust override (#5414)
 

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -45,6 +45,84 @@ func resolveMaxHopCount(n int) uint8 {
 	return uint8(n)
 }
 
+// defaultMaxPacketRate is the per-interface DHCP relay ingress rate limit (in
+// packets per second) applied when a group does not configure `overrides
+// maximum-packet-rate` (#5670). DHCP relay traffic is inherently low-rate (a
+// client sends a handful of packets per lease then renews on the order of
+// hours), so a 100 pps sustained bound with a short burst allowance is
+// generous for legitimate use yet caps an untrusted client segment that would
+// otherwise flood the relay — each admitted packet costs a variable-length
+// dhcpv4.FromBytes TLV parse, an Option 82 allocation, and a fan-out send to
+// EVERY configured server (a 1→N amplification into the upstream DHCP servers).
+const defaultMaxPacketRate = 100
+
+// resolveMaxPacketRate maps a configured per-interface packet-rate limit to the
+// value the relay enforces: 0 (unset) or a nonsensical negative falls back to
+// defaultMaxPacketRate. The schema bounds the leaf to 1..1000000, so this only
+// backstops a config that predates the bound (e.g. a loaded active.json).
+func resolveMaxPacketRate(n int) int {
+	if n <= 0 {
+		return defaultMaxPacketRate
+	}
+	return n
+}
+
+// tokenBucket is a simple token-bucket rate limiter for the per-interface relay
+// ingress path (#5670). It is accessed only from the single per-interface main
+// read-loop goroutine, so it carries no internal lock. `now` is an injectable
+// clock (time.Now in production; a fake in tests) so the refill behavior is
+// deterministically testable without sleeping.
+type tokenBucket struct {
+	rate   float64          // tokens added per second (sustained pps)
+	burst  float64          // bucket capacity (max tokens)
+	tokens float64          // current tokens
+	last   time.Time        // last refill timestamp
+	now    func() time.Time // clock seam
+}
+
+// newTokenBucket builds a token bucket admitting `rate` packets/second with a
+// `burst` capacity. It starts FULL so a cold relay tolerates an initial
+// simultaneous-boot burst up to `burst` before throttling to the sustained
+// rate. A nil clock defaults to time.Now.
+func newTokenBucket(rate, burst int, now func() time.Time) *tokenBucket {
+	if now == nil {
+		now = time.Now
+	}
+	return &tokenBucket{
+		rate:   float64(rate),
+		burst:  float64(burst),
+		tokens: float64(burst),
+		last:   now(),
+		now:    now,
+	}
+}
+
+// allow refills the bucket for the elapsed wall-clock time (capped at burst)
+// and consumes one token. It returns true if a token was available (the packet
+// is admitted) or false if the bucket is empty (the packet must be dropped).
+func (b *tokenBucket) allow() bool {
+	now := b.now()
+	if elapsed := now.Sub(b.last).Seconds(); elapsed > 0 {
+		b.tokens += elapsed * b.rate
+		if b.tokens > b.burst {
+			b.tokens = b.burst
+		}
+		b.last = now
+	}
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+// relayBurstFor sizes the token-bucket burst capacity from the sustained rate:
+// two seconds' worth of packets, so a brief simultaneous-boot spike is admitted
+// instantly while the sustained rate still bounds a persistent flood.
+func relayBurstFor(rate int) int {
+	return rate * 2
+}
+
 // readBufSize is the size of the per-loop read buffer for both the
 // client-facing and server-facing UDP sockets.
 //
@@ -145,6 +223,15 @@ type RelayStats struct {
 	// preserved only when the group sets `overrides trust-option-82`.
 	RequestsUntrustedGiaddrReset uint64
 
+	// RequestsDroppedRateLimit counts client-facing datagrams dropped by the
+	// per-interface ingress rate limiter (#5670) BEFORE the DHCP parse. A
+	// sustained nonzero value means this segment is exceeding its configured
+	// (or default 100) pps bound — either a misbehaving/looping client
+	// population or an active flood/amplification attempt. It is the
+	// observability signal for the DoS-hardening token bucket; raise the
+	// group's `overrides maximum-packet-rate` if a legitimate segment trips it.
+	RequestsDroppedRateLimit uint64
+
 	// RepliesDroppedUnknownServer counts server replies dropped because their
 	// source IP is NOT one of the configured DHCP servers (#4163). The
 	// server-facing socket is bound (not connected), so it accepts datagrams
@@ -198,6 +285,11 @@ type relaySpec struct {
 	// giaddr is treated as client-forged (overwritten, not preserved). A
 	// change flips the anti-spoofing behavior, so it participates in equal().
 	trustOption82 bool
+	// maxPacketRate is the per-interface DHCP relay ingress rate limit in
+	// packets per second (#5670). 0 = unset = the default (defaultMaxPacketRate,
+	// 100). A change resizes the token bucket, so it requires a fresh session
+	// and participates in equal().
+	maxPacketRate int
 }
 
 // equal reports whether two specs would produce an identical relay session.
@@ -209,6 +301,9 @@ func (s relaySpec) equal(o relaySpec) bool {
 		return false
 	}
 	if s.trustOption82 != o.trustOption82 {
+		return false
+	}
+	if s.maxPacketRate != o.maxPacketRate {
 		return false
 	}
 	if len(s.servers) != len(o.servers) {
@@ -277,6 +372,18 @@ type interfaceRelay struct {
 	// segment attempted to spoof a downstream relay's identity / Option 82.
 	requestsUntrustedGiaddrReset atomic.Uint64
 
+	// maxPacketRate is the resolved per-interface DHCP relay ingress rate limit
+	// in packets per second (#5670) — the token bucket admits at most this many
+	// client-facing datagrams per second. Resolved from the group's `overrides
+	// maximum-packet-rate` (default 100). Set once at start; read-only
+	// thereafter.
+	maxPacketRate int
+
+	// requestsDroppedRateLimit counts client-facing datagrams dropped by the
+	// per-interface ingress rate limiter (#5670). Observability for a flood /
+	// amplification attempt or a segment exceeding its configured pps bound.
+	requestsDroppedRateLimit atomic.Uint64
+
 	// Reply-delivery counters (#2076).
 	repliesL2Unicast           atomic.Uint64
 	repliesUnicastCiaddr       atomic.Uint64
@@ -335,6 +442,11 @@ type Manager struct {
 	// Both are seams so lifecycle tests drive a deterministic ifindex change.
 	resolveIfindex ifindexResolver
 	ifindexCheck   time.Duration
+
+	// now is the clock seam for the #5670 per-interface ingress rate limiter's
+	// token bucket. Defaulted to time.Now in NewManager; tests inject a fake so
+	// the rate-limit refill behavior is deterministic without sleeping.
+	now func() time.Time
 	// newL2 opens the raw-L2 unicast sender for an interface (#2076). It is
 	// a seam so tests can inject a fake or force open failure. The default
 	// returns (nil, err) → fail-soft to the broadcast path; the production
@@ -403,6 +515,7 @@ func NewManager() *Manager {
 		resolveIfindex: defaultIfindexResolver,
 		ifindexCheck:   ifindexCheckInterval,
 		newL2:          defaultL2SenderFactory,
+		now:            time.Now,
 	}
 }
 
@@ -633,6 +746,7 @@ func computeDesired(cfg *config.DHCPRelayConfig) map[string]desiredRelay {
 					alwaysBroadcast: group.AlwaysBroadcast,
 					maxHopCount:     group.MaximumHopCount,
 					trustOption82:   group.TrustOption82,
+					maxPacketRate:   group.MaximumPacketRate,
 				},
 				servers: serverAddrs,
 			}
@@ -713,6 +827,7 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 			alwaysBroadcast: d.spec.alwaysBroadcast,
 			maxHopCount:     resolveMaxHopCount(d.spec.maxHopCount),
 			trustOption82:   d.spec.trustOption82,
+			maxPacketRate:   resolveMaxPacketRate(d.spec.maxPacketRate),
 		}
 		m.relays[name] = ir
 		toStart = append(toStart, struct {
@@ -759,6 +874,7 @@ func (m *Manager) Stats() []RelayStats {
 			RequestsDroppedBackup:        ir.requestsDroppedBackup.Load(),
 			RequestsDroppedMaxHops:       ir.requestsDroppedMaxHops.Load(),
 			RequestsUntrustedGiaddrReset: ir.requestsUntrustedGiaddrReset.Load(),
+			RequestsDroppedRateLimit:     ir.requestsDroppedRateLimit.Load(),
 			RepliesDroppedUnknownServer:  ir.repliesDroppedUnknownServer.Load(),
 			RepliesL2Unicast:             ir.repliesL2Unicast.Load(),
 			RepliesUnicastCiaddr:         ir.repliesUnicastCiaddr.Load(),
@@ -1010,7 +1126,7 @@ func (m *Manager) runRelaySession(ctx context.Context,
 	slog.Info("dhcp-relay: listening",
 		"interface", ifaceName, "giaddr", giaddr, "ifindex", boundIfindex,
 		"always_broadcast", ir.alwaysBroadcast, "raw_l2", l2 != nil,
-		"trust_option_82", ir.trustOption82)
+		"trust_option_82", ir.trustOption82, "max_packet_rate_pps", ir.maxPacketRate)
 
 	// Both the cancel watcher and the server-response goroutine are tracked by
 	// the WaitGroup so the runner's wg.Wait() is a true join of every spawned
@@ -1118,6 +1234,16 @@ func (m *Manager) runRelaySession(ctx context.Context,
 	func() {
 		defer cancel()
 		buf := make([]byte, readBufSize)
+		// #5670: per-interface ingress rate limiter. The token bucket admits at
+		// most ir.maxPacketRate client-facing datagrams per second (with a short
+		// burst allowance) so an untrusted client segment cannot flood the relay.
+		// It is owned solely by this single-goroutine read loop, so it needs no
+		// lock; the drop COUNTER on ir is atomic (Stats reads it). warnedRateLimit
+		// throttles the log to warn-once-per-session then Debug (never per packet,
+		// per the project logging rules).
+		rateBucket := newTokenBucket(ir.maxPacketRate,
+			relayBurstFor(ir.maxPacketRate), m.now)
+		warnedRateLimit := false
 		for {
 			n, srcAddr, err := conn.ReadFrom(buf)
 			if err != nil {
@@ -1130,6 +1256,26 @@ func (m *Manager) runRelaySession(ctx context.Context,
 				}
 				slog.Warn("dhcp-relay: read error",
 					"interface", ifaceName, "err", err)
+				continue
+			}
+
+			// #5670: bound the per-interface admit rate BEFORE the (variable-
+			// length TLV) dhcpv4.FromBytes parse and the Option-82 fan-out to
+			// EVERY configured server. Each admitted packet is a CPU cost and a
+			// 1→N amplification into the upstream DHCP servers, so an untrusted
+			// client segment flooding :67 must be throttled at the cheapest point.
+			// Excess is dropped and counted; the log is throttled (warn-once then
+			// Debug) so a sustained flood cannot spam the journal.
+			if !rateBucket.allow() {
+				ir.requestsDroppedRateLimit.Add(1)
+				if !warnedRateLimit {
+					slog.Warn("dhcp-relay: client request rate limit exceeded, dropping excess",
+						"interface", ifaceName, "rate_pps", ir.maxPacketRate, "src", srcAddr)
+					warnedRateLimit = true
+				} else {
+					slog.Debug("dhcp-relay: client request rate limit exceeded, dropping",
+						"interface", ifaceName, "src", srcAddr)
+				}
 				continue
 			}
 

--- a/pkg/dhcprelay/relay_ratelimit_5670_test.go
+++ b/pkg/dhcprelay/relay_ratelimit_5670_test.go
@@ -1,0 +1,219 @@
+package dhcprelay
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// relayConfigWithRate builds a single-interface relay config whose group sets
+// the #5670 per-interface ingress rate limit (packets/second).
+func relayConfigWithRate(rate int) *config.DHCPRelayConfig {
+	return &config.DHCPRelayConfig{
+		ServerGroups: map[string]*config.DHCPRelayServerGroup{
+			"sg": {Name: "sg", Servers: []string{"192.0.2.1"}},
+		},
+		Groups: map[string]*config.DHCPRelayGroup{
+			"g": {
+				Name:              "g",
+				Interfaces:        []string{"ge-0-0-0"},
+				ActiveServerGroup: "sg",
+				MaximumPacketRate: rate,
+			},
+		},
+	}
+}
+
+// TestTokenBucket_BurstThenRefill is the deterministic unit proof of the #5670
+// token-bucket semantics with an injected (frozen/advanceable) clock — no
+// sleeping. It pins three properties: (1) a frozen clock admits exactly the
+// burst capacity then denies; (2) advancing the clock one second refills
+// exactly `rate` tokens; (3) a long idle refill is CAPPED at the burst
+// capacity, not rate×elapsed (so an idle relay cannot bank unbounded credit and
+// defeat the limiter on the next flood).
+func TestTokenBucket_BurstThenRefill(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	clock := func() time.Time { return now }
+	b := newTokenBucket(10, 20, clock) // rate 10/s, burst 20
+
+	// (1) Full bucket, frozen clock: exactly `burst` (20) admitted, rest denied.
+	allowed := 0
+	for i := 0; i < 50; i++ {
+		if b.allow() {
+			allowed++
+		}
+	}
+	if allowed != 20 {
+		t.Fatalf("initial burst: allowed %d, want 20 (burst capacity)", allowed)
+	}
+	if b.allow() {
+		t.Fatal("empty bucket must deny with no time advance")
+	}
+
+	// (2) Advance 1s → +10 tokens (== rate), so 10 more admitted.
+	now = now.Add(time.Second)
+	allowed = 0
+	for i := 0; i < 50; i++ {
+		if b.allow() {
+			allowed++
+		}
+	}
+	if allowed != 10 {
+		t.Fatalf("after 1s refill: allowed %d, want 10 (sustained rate)", allowed)
+	}
+
+	// (3) Advance far → refill capped at burst (20), NOT rate×100.
+	now = now.Add(100 * time.Second)
+	allowed = 0
+	for i := 0; i < 200; i++ {
+		if b.allow() {
+			allowed++
+		}
+	}
+	if allowed != 20 {
+		t.Fatalf("long-idle refill: allowed %d, want 20 (capped at burst, not rate×elapsed)", allowed)
+	}
+}
+
+// TestRunRelay_RateLimit_5670 is the end-to-end fail-on-revert proof for the
+// #5670 per-interface DHCP relay ingress rate limit. A burst of N valid
+// BOOTREQUEST/DISCOVER datagrams is pushed through the live runRelay loop with
+// the clock FROZEN, so the whole burst arrives "instantly": the token bucket
+// refills nothing, admits exactly its burst capacity, and drops the excess
+// BEFORE the DHCP parse + Option-82 fan-out.
+//
+// GREEN (rate limiter present): exactly `burst` datagrams reach the server and
+// the excess (N-burst) is counted in RequestsDroppedRateLimit.
+//
+// RED-on-revert: neutralize the limiter (delete the `if !rateBucket.allow()`
+// drop, or wire an effectively-infinite rate) and ALL N datagrams are relayed
+// with RequestsDroppedRateLimit == 0 — both assertions below fail. Verified RED
+// during development by removing the drop block.
+func TestRunRelay_RateLimit_5670(t *testing.T) {
+	const rate = 5
+	burst := relayBurstFor(rate) // 10
+	const n = 25
+
+	// One valid client DISCOVER, replayed N times to model a flood from a single
+	// untrusted client-facing segment.
+	discover, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	discover.OpCode = dhcpv4.OpcodeBootRequest
+	discover.ClientHWAddr = net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x05}
+	discover.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeDiscover))
+	wire := discover.ToBytes()
+
+	pending := make([][]byte, n)
+	for i := range pending {
+		pending[i] = append([]byte(nil), wire...)
+	}
+
+	client := newFakeConn()
+	client.pending = pending
+	server := newFakeConn()
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+	// Freeze the clock: the whole burst is admitted/denied at one instant, so the
+	// bucket refills nothing mid-burst and the outcome is deterministic.
+	frozen := time.Unix(1_700_000_000, 0)
+	m.now = func() time.Time { return frozen }
+
+	m.Apply(context.Background(), relayConfigWithRate(rate))
+	defer m.Stop()
+
+	// Wait until the loop has read all N datagrams and blocked on the (N+1)th
+	// read — at that point every pending packet has been fully processed (the
+	// loop reads, acts, then loops back to ReadFrom).
+	deadline := time.Now().Add(2 * time.Second)
+	for client.readCalls.Load() < int64(n+1) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := client.readCalls.Load(); got < int64(n+1) {
+		t.Fatalf("relay did not consume all %d datagrams (readCalls=%d)", n, got)
+	}
+
+	// Exactly `burst` relayed to the one configured server.
+	if got := server.writeCount(); got != burst {
+		t.Errorf("relayed %d datagrams, want %d (token-bucket burst) — "+
+			"rate limiter not bounding the flood", got, burst)
+	}
+
+	var relayed, dropped uint64
+	for _, s := range m.Stats() {
+		relayed += s.RequestsRelayed
+		dropped += s.RequestsDroppedRateLimit
+	}
+	if relayed != uint64(burst) {
+		t.Errorf("RequestsRelayed = %d, want %d (burst admitted)", relayed, burst)
+	}
+	if dropped != uint64(n-burst) {
+		t.Errorf("RequestsDroppedRateLimit = %d, want %d (excess dropped) — "+
+			"the flood was not throttled", dropped, n-burst)
+	}
+}
+
+// TestRunRelay_RateLimit_DefaultBound proves an UNCONFIGURED relay still gets a
+// bound (the security-hardening default): with no `overrides
+// maximum-packet-rate`, the resolver applies defaultMaxPacketRate (100 pps) so
+// its burst is relayBurstFor(100)=200 — a frozen-clock flood of 250 admits
+// exactly 200 and drops 50. RED-on-revert: if the default is not applied
+// (bucket rate 0 / limiter opt-in only), an unconfigured relay would relay all
+// 250 with zero drops.
+func TestRunRelay_RateLimit_DefaultBound(t *testing.T) {
+	burst := relayBurstFor(defaultMaxPacketRate) // 200
+	const n = 250
+
+	discover, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	discover.OpCode = dhcpv4.OpcodeBootRequest
+	discover.ClientHWAddr = net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x06}
+	discover.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeDiscover))
+	wire := discover.ToBytes()
+
+	pending := make([][]byte, n)
+	for i := range pending {
+		pending[i] = append([]byte(nil), wire...)
+	}
+
+	client := newFakeConn()
+	client.pending = pending
+	server := newFakeConn()
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+	frozen := time.Unix(1_700_000_000, 0)
+	m.now = func() time.Time { return frozen }
+
+	// singleInterfaceConfig sets NO maximum-packet-rate → resolver default.
+	m.Apply(context.Background(), singleInterfaceConfig())
+	defer m.Stop()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for client.readCalls.Load() < int64(n+1) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := client.readCalls.Load(); got < int64(n+1) {
+		t.Fatalf("relay did not consume all %d datagrams (readCalls=%d)", n, got)
+	}
+
+	if got := server.writeCount(); got != burst {
+		t.Errorf("relayed %d datagrams, want %d (default %d pps → burst %d) — "+
+			"unconfigured relay is unbounded", got, burst, defaultMaxPacketRate, burst)
+	}
+	var dropped uint64
+	for _, s := range m.Stats() {
+		dropped += s.RequestsDroppedRateLimit
+	}
+	if dropped != uint64(n-burst) {
+		t.Errorf("RequestsDroppedRateLimit = %d, want %d (default bound not applied?)",
+			dropped, n-burst)
+	}
+}


### PR DESCRIPTION
## Summary

The DHCP relay client-facing read loop (`pkg/dhcprelay/relay.go`) forwarded
every received request to all N configured servers with an Option 82 insert and
**no rate limit**. An untrusted host on a relay-facing segment can flood `:67`
unauthenticated; each admitted packet costs a variable-length `dhcpv4.FromBytes`
TLV parse, an Option 82 allocation, and a **sequential send to every configured
server** — a CPU-exhaustion vector **and** a 1→N amplification into the upstream
DHCP servers (which then rate-limit legitimate clients as collateral). No
per-interface pps cap, no rate-limit drop counter (fable-review-174 H2).

## Fix

A per-interface **token bucket** checked in the main read loop **before** the
DHCP parse + the server fan-out, so a flood is dropped at the cheapest point.

- New `set forwarding-options dhcp-relay group <g> overrides maximum-packet-rate <pps>`
  override (schema range `1..1000000`), compiled through all three parse shapes
  (flat-set / merged-Keys / block form) into `DHCPRelayGroup.MaximumPacketRate`
  → `relaySpec.maxPacketRate` (a change restarts the per-interface relay).
- **Default 100 pps** when unset (`resolveMaxPacketRate`) — bounds an
  unconfigured relay too. Bucket starts full with a 2-second burst
  (`relayBurstFor = 2×rate`) so a simultaneous-boot spike is admitted before the
  sustained rate throttles a persistent flood; set a high value to effectively
  disable.
- Every drop bumps `RelayStats.RequestsDroppedRateLimit`; log is
  warn-once-per-session then `Debug` (never per packet). `show services
  dhcp-relay` prints the counter + effective override.

## Rate-limit semantics

- **Per-interface** (not per-source): one token bucket per relay interface.
- **Default:** 100 pps sustained, 200-packet burst (unset).
- **Configurable:** `overrides maximum-packet-rate <pps>`, enforced.

## Fail-on-revert tests

- `TestTokenBucket_BurstThenRefill` — deterministic unit proof (injected clock,
  no sleeping): burst admitted, 1s refill == rate, long-idle refill capped at
  burst.
- `TestRunRelay_RateLimit_5670` / `TestRunRelay_RateLimit_DefaultBound` —
  end-to-end through the live relay with a frozen clock: exactly the burst is
  relayed, the excess is dropped and counted. **Verified RED** with the limiter
  neutralized (all packets relayed, zero drops), **GREEN** restored.
- Config compile/completion coverage for the new override in all AST shapes.

## Validation

`go test ./pkg/dhcprelay/... ./pkg/config/... ./pkg/cli/...` green; `gofmt` +
`go vet` clean on touched files.

Closes #5670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9Cobd2faFG5BLmNhkR7CJ