### PR TITLE
config: make predefined junos-sip match UDP+TCP/5060

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47380,3 +47380,20 @@ top.
     EmitTunnelEndpointNames contract doc comment.
   - **File(s)**: pkg/config/tunnelemit.go (Edit),
     pkg/config/tunnelemit_perunit_5635_test.go (Write), _Log.md (Edit)
+
+## 2026-07-12 — #5634 junos-sip TCP/5060 parity
+
+- **Timestamp**: 2026-07-12
+- **Action**: Model predefined `junos-sip` as a UDP+TCP/5060 application-set
+  (was UDP-only application, dropping TCP/5060 SIP from any referencing policy).
+  Added `junos-sip-udp` (udp/5060) + `junos-sip-tcp` (tcp/5060) to
+  `PredefinedApplications`; removed the UDP-only `junos-sip` application; added
+  `junos-sip` = {junos-sip-udp, junos-sip-tcp} to `PredefinedApplicationSets`
+  (mirrors #4102 junos-ms-rpc). Must be a set only — app-first resolution would
+  otherwise shadow the set and re-drop TCP.
+- **File(s)**: pkg/config/predefined.go, pkg/config/predefined_sip_5634_test.go,
+  pkg/policymatch/predefined_sip_5634_test.go, docs/config-schema.md
+- **Validation**: `go test ./pkg/config/... ./pkg/policymatch/...
+  ./pkg/dataplane/userspace/... ./pkg/appid/...` GREEN; `go build ./...` OK.
+  Fail-on-revert proven: dropping the TCP member → policymatch tcp/5060 SIP
+  falls to default-deny (Matched=false, DefaultUsed=true), RED; restored GREEN.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -5604,9 +5604,15 @@ strict-vs-lenient gates:
   `junos-ms-rpc` = {`junos-ms-rpc-tcp`, `junos-ms-rpc-udp`}, `junos-sun-rpc` =
   {`junos-sun-rpc-tcp`, `junos-sun-rpc-udp`}, `junos-cifs` =
   {`junos-netbios-session`, `junos-smb-session`}, `junos-routing-inbound` =
-  {`junos-bgp`, `junos-rip`, `junos-ldp-tcp`, `junos-ldp-udp`}. Every member is
-  in the `PredefinedApplications` table, so each set expands to >= 1 member and
-  clears the empty-set fail-open gate (#3146). Before #4102 only the
+  {`junos-bgp`, `junos-rip`, `junos-ldp-tcp`, `junos-ldp-udp`}, and (#5634)
+  `junos-sip` = {`junos-sip-udp`, `junos-sip-tcp`} (both destination-port 5060 —
+  SIP signals over UDP by default and TCP since 12.3X48-D25 / 17.3R1). Every
+  member is in the `PredefinedApplications` table, so each set expands to >= 1
+  member and clears the empty-set fail-open gate (#3146). `junos-sip` was the
+  one predefined name MOVED from the application table to the set table:
+  `resolveUserspaceApplicationNames` resolves an application first, so a
+  UDP-only `junos-sip` application would shadow the set and re-drop TCP/5060 —
+  it must be a set only (`predefined_sip_5634_test.go`). Before #4102 only the
   protocol-split members shipped and the bundle names were nowhere, so a stock
   vSRX policy `match application junos-ms-rpc` hard-failed at commit
   (`validatePolicyMatchApplicationsStrict`) and, on the tolerant path, at runtime

--- a/pkg/config/predefined.go
+++ b/pkg/config/predefined.go
@@ -93,7 +93,14 @@ var PredefinedApplications = map[string]*Application{
 	"junos-cvspserver": {Name: "junos-cvspserver", Protocol: "tcp", DestinationPort: "2401"},
 
 	// --- VoIP / signaling ---
-	"junos-sip":     {Name: "junos-sip", Protocol: "udp", DestinationPort: "5060"},
+	// SIP signals over BOTH transports on port 5060 (UDP by default, TCP added
+	// in Junos 12.3X48-D25 / 17.3R1). Real Junos `junos-sip` matches UDP/5060 AND
+	// TCP/5060, so it is modeled as the PredefinedApplicationSet "junos-sip" below
+	// over these two single-protocol members — mirroring the junos-ms-rpc /
+	// junos-sun-rpc TCP+UDP split. The prior UDP-only predefined application
+	// silently dropped TCP/5060 SIP from any policy referencing junos-sip (#5634).
+	"junos-sip-udp": {Name: "junos-sip-udp", Protocol: "udp", DestinationPort: "5060"},
+	"junos-sip-tcp": {Name: "junos-sip-tcp", Protocol: "tcp", DestinationPort: "5060"},
 	"junos-mgcp-ua": {Name: "junos-mgcp-ua", Protocol: "udp", DestinationPort: "2427"},
 	"junos-mgcp-ca": {Name: "junos-mgcp-ca", Protocol: "udp", DestinationPort: "2727"},
 	"junos-h323":    {Name: "junos-h323", Protocol: "tcp", DestinationPort: "1720"},
@@ -182,6 +189,17 @@ var PredefinedApplicationSets = map[string]*ApplicationSet{
 	"junos-routing-inbound": {
 		Name:         "junos-routing-inbound",
 		Applications: []string{"junos-bgp", "junos-rip", "junos-ldp-tcp", "junos-ldp-udp"},
+	},
+	// SIP signaling over both transports: UDP/5060 (default) + TCP/5060 (SIP over
+	// TCP, Junos 12.3X48-D25 / 17.3R1). Junos `junos-sip` matches both; modeling
+	// it as a bundle (rather than the old UDP-only application) closes the
+	// TCP/5060 under-match (#5634). Member order is UDP-first to mirror the Junos
+	// default transport. resolveUserspaceApplicationNames resolves an application
+	// FIRST, so junos-sip MUST NOT remain in PredefinedApplications (an app hit
+	// would shadow this set and re-drop TCP/5060).
+	"junos-sip": {
+		Name:         "junos-sip",
+		Applications: []string{"junos-sip-udp", "junos-sip-tcp"},
 	},
 }
 

--- a/pkg/config/predefined_sip_5634_test.go
+++ b/pkg/config/predefined_sip_5634_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #5634 — the predefined `junos-sip` application shipped UDP-only
+// ({Protocol:"udp", DestinationPort:"5060"}), so a policy referencing
+// `match application junos-sip` matched only UDP/5060 and silently dropped
+// TCP/5060 SIP. Real Junos junos-sip matches BOTH UDP/5060 AND TCP/5060 (SIP
+// signals over both transports; TCP added in 12.3X48-D25 / 17.3R1). The fix
+// models junos-sip as a PredefinedApplicationSet over two single-protocol
+// members (junos-sip-udp = udp/5060, junos-sip-tcp = tcp/5060), mirroring the
+// #4102 junos-ms-rpc / junos-sun-rpc TCP+UDP split.
+//
+// Fail-on-revert: restoring the UDP-only `"junos-sip"` application entry (and
+// deleting the set) makes resolveUserspaceApplicationNames resolve junos-sip as
+// an application FIRST — the TCP member never resolves and this test goes RED
+// (ExpandApplicationSet no longer returns the tcp/5060 member).
+
+// TestPredefinedSipSetResolves_5634 pins junos-sip as a UDP+TCP/5060 bundle and
+// proves both members resolve as predefined applications with NO user config.
+func TestPredefinedSipSetResolves_5634(t *testing.T) {
+	empty := &ApplicationsConfig{}
+
+	// junos-sip resolves as an application-SET, not a bare application. It MUST
+	// NOT be a plain predefined application — an application hit would shadow the
+	// set (app-first precedence) and re-drop TCP/5060.
+	if _, ok := ResolveApplication("junos-sip", nil); ok {
+		t.Fatalf("junos-sip still resolves as a predefined APPLICATION; it must be a set only (app-first precedence would re-drop TCP/5060)")
+	}
+	if _, ok := ResolveApplicationSet("junos-sip", nil); !ok {
+		t.Fatalf("ResolveApplicationSet(junos-sip, nil) = false, want true (predefined set)")
+	}
+
+	got, err := ExpandApplicationSet("junos-sip", empty)
+	if err != nil {
+		t.Fatalf("ExpandApplicationSet(junos-sip): %v", err)
+	}
+	want := []string{"junos-sip-udp", "junos-sip-tcp"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExpandApplicationSet(junos-sip) = %v, want %v (UDP-first config order)", got, want)
+	}
+
+	// Both members must resolve as predefined applications with the exact
+	// protocol/port. The tcp/5060 member is the #5634 parity fix; the udp/5060
+	// member preserves the historical match.
+	for _, tc := range []struct {
+		name, proto, dport string
+	}{
+		{"junos-sip-udp", "udp", "5060"},
+		{"junos-sip-tcp", "tcp", "5060"},
+	} {
+		app, ok := ResolveApplication(tc.name, nil)
+		if !ok {
+			t.Fatalf("member %q does not resolve as a predefined application", tc.name)
+		}
+		if app.Protocol != tc.proto || app.DestinationPort != tc.dport {
+			t.Fatalf("member %q = proto %q dport %q, want proto %q dport %q",
+				tc.name, app.Protocol, app.DestinationPort, tc.proto, tc.dport)
+		}
+	}
+}
+
+// TestPredefinedSipPolicyCommits_5634 proves a stock policy that references
+// `match application junos-sip` commits cleanly under the STRICT path — the
+// bundle must be recognized by the commit gate exactly like any predefined app.
+func TestPredefinedSipPolicyCommits_5634(t *testing.T) {
+	cmds := append(append([]string{}, zoneBoilerplate...),
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application junos-sip",
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	)
+	tree := buildAppMatchTree(t, cmds...)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig: predefined junos-sip should commit clean, got %v", err)
+	}
+}

--- a/pkg/policymatch/predefined_sip_5634_test.go
+++ b/pkg/policymatch/predefined_sip_5634_test.go
@@ -1,0 +1,50 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5634 — the predefined `junos-sip` application was UDP-only, so a policy
+// `match application junos-sip` matched UDP/5060 SIP but silently DROPPED
+// TCP/5060 SIP (the flow fell through to default-deny). Real Junos junos-sip
+// matches BOTH transports on 5060. The fix models junos-sip as a UDP+TCP/5060
+// predefined application-set, so the operator simulator (this path) and the
+// #5629-fixed dataplane both match TCP/5060 SIP.
+//
+// Fail-on-revert: restoring the UDP-only junos-sip application makes the
+// tcp/5060 query below fall through to default-deny → this test goes RED.
+func TestPredefinedSipPolicyMatchesTCP_5634(t *testing.T) {
+	// No user applications/sets — junos-sip is a PREDEFINED bundle only.
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("permit-sip",
+				config.PolicyMatch{Applications: []string{"junos-sip"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	// TCP/5060 SIP — the #5634 parity fix. Must match the permit, not default-deny.
+	resTCP := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 5060})
+	if resTCP.ContentRejected {
+		t.Fatalf("ContentRejected=true for junos-sip tcp/5060; reasons=%v", resTCP.ContentRejectionReasons)
+	}
+	if !resTCP.Matched || resTCP.Action != config.PolicyPermit || resTCP.PolicyName != "permit-sip" {
+		t.Fatalf("junos-sip tcp/5060 did not match the permit (TCP/5060 SIP dropped — the #5634 bug): Matched=%v Action=%v Name=%q DefaultUsed=%v",
+			resTCP.Matched, resTCP.Action, resTCP.PolicyName, resTCP.DefaultUsed)
+	}
+
+	// UDP/5060 SIP — the historical match must be preserved.
+	resUDP := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "udp", DstPort: 5060})
+	if !resUDP.Matched || resUDP.Action != config.PolicyPermit {
+		t.Fatalf("junos-sip udp/5060 did not match: Matched=%v Action=%v", resUDP.Matched, resUDP.Action)
+	}
+
+	// A non-member (tcp/5061, the SIP-TLS port Junos has NO predefined app for)
+	// must NOT match — the bundle is narrow, not match-any.
+	resNo := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 5061})
+	if resNo.Matched {
+		t.Fatalf("tcp/5061 wrongly matched junos-sip (should be default-deny): Action=%v", resNo.Action)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a vSRX-parity + correctness gap (codex-review-181, #5634): the
predefined `junos-sip` application shipped **UDP-only**
(`{Protocol:"udp", DestinationPort:"5060"}`), so a policy
`match application junos-sip` matched UDP/5060 SIP but **silently dropped
TCP/5060 SIP** — the flow fell through to default-deny (or default-permit
for a deny policy: a fail-open under-match).

Real Junos `junos-sip` matches **both** transports on port 5060 — SIP
signals over UDP by default and over TCP since 12.3X48-D25 / 17.3R1.

## Change

Model `junos-sip` as a UDP+TCP/5060 predefined application-**set** over two
single-protocol members, mirroring the #4102 `junos-ms-rpc` / `junos-sun-rpc`
TCP+UDP split:

- add `junos-sip-udp` (udp/5060) and `junos-sip-tcp` (tcp/5060) to
  `PredefinedApplications`;
- **remove** the UDP-only `junos-sip` application;
- add `junos-sip` = {`junos-sip-udp`, `junos-sip-tcp`} to
  `PredefinedApplicationSets` (UDP-first — the Junos default transport).

`junos-sip` MUST move out of the application table:
`resolveUserspaceApplicationNames` (and the commit gate / operator simulator)
resolve an application **first**, so a lingering UDP-only `junos-sip`
application would shadow the set and re-drop TCP/5060. Both resolution
surfaces consult `ResolveApplication` then `ResolveApplicationSet`, so the
set resolves everywhere — commit gate, userspace snapshot builder, appid
catalog (member expansion), and the policy simulator.

The host-inbound `system-services sip` path already opened UDP+TCP 5060
(separate mechanism); `docs/host-inbound-service-matrix.md` already stated
`junos-sip = UDP+TCP 5060` — only the predefined policy-application table
was stale. `docs/config-schema.md` predefined-bundle list updated.

## Tests (fail-on-revert)

- `pkg/config/predefined_sip_5634_test.go` — `junos-sip` resolves as a set
  (not an app), expands to `[junos-sip-udp, junos-sip-tcp]` with the exact
  proto/port, and a stock `match application junos-sip` policy commits clean.
- `pkg/policymatch/predefined_sip_5634_test.go` — end-to-end 5-tuple: a
  **TCP/5060** SIP query matches the permit (the #5634 fix), UDP/5060 still
  matches, and TCP/5061 (no predefined SIP-TLS) stays default-deny.

Proven RED with the fix neutralized (drop the TCP member → policymatch
tcp/5060 SIP falls to default-deny, `Matched=false DefaultUsed=true`),
GREEN restored.

Validation: `go test ./pkg/config/... ./pkg/policymatch/...
./pkg/dataplane/userspace/... ./pkg/appid/...` GREEN; `go build ./...` OK.

Closes #5634

🤖 Generated with [Claude Code](https://claude.com/claude-code)