### PR TITLE
daemon/rss: restore default table on workers→1 transition (#5124)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47407,3 +47407,20 @@ top.
   ./pkg/dataplane/userspace/... ./pkg/appid/...` GREEN; `go build ./...` OK.
   Fail-on-revert proven: dropping the TCP member → policymatch tcp/5060 SIP
   falls to default-deny (Matched=false, DefaultUsed=true), RED; restored GREEN.
+
+## 2026-07-12 — #5124 RSS workers→1 stale indirection table
+- **Timestamp**: 2026-07-12
+- **Action**: Fix daemon/rss: workers→1 transition now probes + restores the
+  NIC default RSS indirection table instead of early-returning, so a stale
+  concentrated `[1,..,1,0,..,0]` table left by a prior workers<queues apply is
+  undone (RX no longer hashed onto the old queue subset). Removed the
+  `workers == 1 { return }` short-circuit in `applyRSSIndirection` (falls
+  through to the allowlist loop) and generalized the restore guard in
+  `applyRSSIndirectionOne` from `workers > 1 && workers >= queues && queues > 1`
+  to `workers >= 1 && queues > 1`. computeWeightVector(1,q) still returns nil
+  (no weight vector applied); the single-worker default-RSS policy is unchanged.
+- **File(s)**: pkg/daemon/rss_indirection.go, pkg/daemon/rss_indirection_test.go
+- **Validation**: `go test ./pkg/daemon/...` GREEN. Fail-on-revert proven:
+  reverting the guard to `workers > 1 ...` → 4 new tests RED (top-level +
+  per-iface workers→1 stale restore, default-table probe-only, 4→1→4
+  transition); restored GREEN. gofmt + go vet clean.

--- a/pkg/daemon/rss_indirection.go
+++ b/pkg/daemon/rss_indirection.go
@@ -130,9 +130,14 @@ func (realRSSExecutor) listInterfaces() []string {
 //     also repeated inside applyRSSIndirectionOne as defense in depth.
 //   - enabled == false is a hard kill switch: restore the default
 //     indirection table on every allowlisted mlx5 interface.
-//   - workers == 1 is skipped (single worker benefits from default RSS
-//     spreading across all HW queues / IRQ lines; weight-pinning to a
-//     single queue would serialize the worker on one IRQ — reviewer #L1).
+//   - workers == 1: no weight vector is applied (single worker benefits
+//     from default RSS spreading across all HW queues / IRQ lines;
+//     weight-pinning to a single queue would serialize the worker on one
+//     IRQ — reviewer #L1). BUT the allowlist is still walked so the live
+//     table is probed and reset to default if it carries a stale
+//     concentrated layout left over from a prior workers < queue_count
+//     apply — a day-2 workers→1 reduction must not leave RX hashed onto
+//     the old subset of queues (#5124).
 //   - workers >= queue_count: weight reshaping is skipped (default
 //     table already delivers to every queue), BUT the live table is
 //     probed and reset to default if it carries a stale concentrated
@@ -162,8 +167,16 @@ func applyRSSIndirection(enabled bool, workers int, allowed []string, execer rss
 		return
 	}
 	if workers == 1 {
-		slog.Info("linksetup: rss indirection skipped (single worker — keep default RSS)")
-		return
+		// Single worker keeps default RSS: no weight vector is applied
+		// (pinning to queue 0 would serialize the worker on one IRQ).
+		// We do NOT return here — the allowlist loop below still runs so
+		// a stale concentrated table left by a prior workers<queues apply
+		// is probed and restored to the NIC default on a workers→1
+		// reduction (#5124). computeWeightVector(1, queues) returns nil,
+		// so applyRSSIndirectionOne issues at most one `ethtool -x` probe
+		// plus, only when the live table is concentrated, one
+		// `ethtool -X default` restore. A fresh default table is a no-op.
+		slog.Debug("linksetup: rss single worker — keep default RSS, probe for stale concentrated table")
 	}
 	if len(allowed) == 0 {
 		// No userspace-dp bindings derived from config — nothing to
@@ -245,20 +258,26 @@ func applyRSSIndirectionOne(iface string, workers int, execer rssExecutor) {
 	if weights == nil {
 		slog.Info("linksetup: rss weight reshaping skipped", "iface", iface,
 			"workers", workers, "queues", queues, "reason", reason)
-		// #805: When workers >= queues > 1 we previously left the
-		// indirection table alone. That's correct on a fresh install
-		// (kernel default is round-robin = what we want) but wrong on
-		// the workers<queues → workers>=queues transition, where a
-		// concentrated `[1,...,1,0,...,0]` table written by an earlier
+		// #805/#5124: When no weight vector is applied — either
+		// workers >= queues (#805) OR workers == 1 (#5124) — we
+		// previously left the indirection table alone. That's correct on
+		// a fresh install (kernel default is round-robin = what we want)
+		// but wrong on any transition DOWN from a concentrated table: a
+		// `[1,...,1,0,...,0]` table written by an earlier
 		// applyRSSIndirectionOne for the prior worker count stays live
-		// and starves queues that now host worker-bound AF_XDP sockets.
-		// Inspect the live table; if it isn't the round-robin default,
-		// restore it.
+		// and starves queues that no worker consumes (workers→1: RX stays
+		// hashed onto the old subset even though single-worker policy is
+		// default RSS across all queues; workers>=queues: queues that now
+		// host worker-bound AF_XDP sockets get no traffic). Inspect the
+		// live table; if it isn't the round-robin default, restore it.
 		//
-		// Guard requires queues > 1: with a single-queue NIC there is
-		// no possible concentration to undo (the default and any
-		// "configured" layout both have entry[i] == 0 for every i).
-		if workers > 1 && workers >= queues && queues > 1 {
+		// Guard: queues > 1 (a single-queue NIC has no possible
+		// concentration to undo — default and any "configured" layout
+		// both have entry[i] == 0 for every i), and workers >= 1 (a real
+		// worker configuration where default RSS is the desired state;
+		// workers <= 0 is a non-userspace deploy filtered by the caller,
+		// and restoring its table would be out of scope).
+		if workers >= 1 && queues > 1 {
 			maybeRestoreDefault(iface, queues, execer)
 		}
 		return

--- a/pkg/daemon/rss_indirection_test.go
+++ b/pkg/daemon/rss_indirection_test.go
@@ -305,16 +305,70 @@ func TestApplyRSSIndirectionOne_EthtoolMissing_SkipsGracefully(t *testing.T) {
 	}
 }
 
-// Workers == 1 skips at the top level (no sysfs scan, no ethtool).
-func TestApplyRSSIndirection_SingleWorker_Skips(t *testing.T) {
+// #5124 fail-on-revert: workers→1 must NOT early-return at the top level.
+// A prior workers<queues apply left a concentrated table; the single-worker
+// reconcile must walk the allowlist, probe the live table, and restore the
+// NIC default so RX is no longer hashed onto the old subset of queues. With
+// the pre-#5124 `workers == 1 { return }` early return (or a guard that
+// requires workers > 1), no ethtool call fires and this test goes RED.
+func TestApplyRSSIndirection_SingleWorker_StaleTable_RestoresDefault(t *testing.T) {
+	f := &fakeRSSExecutor{
+		ifaces:   []string{"eth0"},
+		drivers:  map[string]string{"eth0": "mlx5_core"},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirection(true, 1, f.ifaces, f)
+
+	if len(f.calls) != 2 {
+		t.Fatalf("workers→1 with stale table: want 2 calls (probe + restore), got %d: %v",
+			len(f.calls), f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[0], []string{"-x", "eth0"}) {
+		t.Errorf("call 0: want `ethtool -x eth0` probe, got %v", f.calls[0])
+	}
+	if !reflect.DeepEqual(f.calls[1], []string{"-X", "eth0", "default"}) {
+		t.Errorf("call 1: want `ethtool -X eth0 default` restore, got %v", f.calls[1])
+	}
+}
+
+// #5124: workers→1 on a NIC whose live table is ALREADY the round-robin
+// default must issue only the probe and NO restore write (idempotent — a
+// fresh single-worker boot must not churn the NIC mid-traffic).
+func TestApplyRSSIndirection_SingleWorker_DefaultTable_ProbeOnly(t *testing.T) {
+	f := &fakeRSSExecutor{
+		ifaces:   []string{"eth0"},
+		drivers:  map[string]string{"eth0": "mlx5_core"},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(defaultTable6q)},
+	}
+	applyRSSIndirection(true, 1, f.ifaces, f)
+
+	if len(f.calls) != 1 {
+		t.Fatalf("workers=1 with default table: want 1 call (probe only), got %d: %v",
+			len(f.calls), f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[0], []string{"-x", "eth0"}) {
+		t.Errorf("call 0: want `ethtool -x eth0` probe, got %v", f.calls[0])
+	}
+	for _, c := range f.calls {
+		if len(c) >= 1 && c[0] == "-X" {
+			t.Errorf("default table → must not invoke -X, got %v", c)
+		}
+	}
+}
+
+// #5124: single-queue NIC has no possible concentration to undo — the
+// queues>1 guard must short-circuit BEFORE any ethtool probe.
+func TestApplyRSSIndirection_SingleWorker_SingleQueue_NoOp(t *testing.T) {
 	f := &fakeRSSExecutor{
 		ifaces:  []string{"eth0"},
 		drivers: map[string]string{"eth0": "mlx5_core"},
-		queues:  map[string]int{"eth0": 4},
+		queues:  map[string]int{"eth0": 1},
 	}
 	applyRSSIndirection(true, 1, f.ifaces, f)
 	if len(f.calls) != 0 {
-		t.Fatalf("workers=1 must issue no ethtool calls, got %v", f.calls)
+		t.Fatalf("workers=1 on single-queue NIC must issue no ethtool calls, got %v", f.calls)
 	}
 }
 
@@ -615,11 +669,13 @@ func TestApplyRSSIndirectionOne_WorkersGreaterEqualQueues_DefaultTable_NoOp(t *t
 	}
 }
 
-// #805 test 4: workers == 1 with stale table — must NOT touch.
-// Single-worker deploys keep default RSS regardless of stale state;
-// "stale" is only meaningful when transitioning from workers<queues
-// where some prior apply wrote concentrated weights.
-func TestApplyRSSIndirectionOne_WorkersIsOne_StaleTable_NotTouched(t *testing.T) {
+// #5124 (was #805 test 4): workers == 1 with a stale concentrated table —
+// must probe and restore the NIC default. Single-worker policy is default
+// RSS across every queue; a concentrated table left by a prior
+// workers<queues apply keeps RX hashed onto the old subset, so the reconcile
+// must undo it. With the fix neutralized (guard requiring workers > 1) this
+// goes RED — no ethtool call fires.
+func TestApplyRSSIndirectionOne_WorkersIsOne_StaleTable_RestoresDefault(t *testing.T) {
 	f := &fakeRSSExecutor{
 		drivers:  map[string]string{"eth0": mlx5Driver},
 		queues:   map[string]int{"eth0": 6},
@@ -627,8 +683,47 @@ func TestApplyRSSIndirectionOne_WorkersIsOne_StaleTable_NotTouched(t *testing.T)
 	}
 	applyRSSIndirectionOne("eth0", 1, f)
 
+	if len(f.calls) != 2 {
+		t.Fatalf("workers=1 stale table: want 2 calls (probe + restore), got %d: %v",
+			len(f.calls), f.calls)
+	}
+	if !reflect.DeepEqual(f.calls[0], []string{"-x", "eth0"}) {
+		t.Errorf("call 0: want probe, got %v", f.calls[0])
+	}
+	if !reflect.DeepEqual(f.calls[1], []string{"-X", "eth0", "default"}) {
+		t.Errorf("call 1: want -X default, got %v", f.calls[1])
+	}
+}
+
+// #5124: workers == 1 with a live table that is ALREADY default — probe
+// only, no restore write (mirrors the workers>=queues default no-op path).
+func TestApplyRSSIndirectionOne_WorkersIsOne_DefaultTable_NoOp(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(defaultTable6q)},
+	}
+	applyRSSIndirectionOne("eth0", 1, f)
+
+	for _, c := range f.calls {
+		if len(c) >= 1 && c[0] == "-X" {
+			t.Errorf("workers=1 default table → must not invoke -X, got %v", c)
+		}
+	}
+}
+
+// #5124: workers == 1 on a single-queue NIC — the queues>1 guard
+// short-circuits before any probe (no concentration is possible).
+func TestApplyRSSIndirectionOne_WorkersIsOne_SingleQueue_NoOp(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 1},
+		ethtoolX: map[string][]byte{"eth0": []byte(staleTable6q4w)},
+	}
+	applyRSSIndirectionOne("eth0", 1, f)
+
 	if len(f.calls) != 0 {
-		t.Errorf("workers=1 must issue zero ethtool calls, got %v", f.calls)
+		t.Errorf("workers=1 single-queue NIC → zero ethtool calls, got %v", f.calls)
 	}
 }
 
@@ -767,6 +862,67 @@ func TestApplyRSSIndirectionOne_BootSequence_4then6_RestoresDefault(t *testing.T
 	if !sawRestore {
 		t.Fatalf("step 2 (workers=6): expected -X default restore, got %v",
 			f.calls[step1Calls:])
+	}
+}
+
+// #5124: full 4→1→4 worker-count transition on a 6-queue mlx5 NIC.
+//   - Step 1 (4→concentrated): workers=4 writes [1,1,1,1,0,0].
+//   - Step 2 (workers→1): the reduction must probe the now-stale
+//     concentrated table and restore the round-robin default so RX is no
+//     longer hashed onto queues 0..3 only.
+//   - Step 3 (1→4): workers back to 4 re-writes the concentrated table.
+//
+// The kernel-side table is simulated between steps. With the pre-#5124
+// behavior, Step 2 issues no restore and the stale table survives into
+// Step 3 — Step 2's assertion goes RED.
+func TestApplyRSSIndirectionOne_Transition_4then1then4(t *testing.T) {
+	f := &fakeRSSExecutor{
+		drivers:  map[string]string{"eth0": mlx5Driver},
+		queues:   map[string]int{"eth0": 6},
+		ethtoolX: map[string][]byte{"eth0": []byte(defaultTable6q)},
+	}
+
+	// Step 1: workers=4 on a default table → write concentrated weights.
+	applyRSSIndirectionOne("eth0", 4, f)
+	sawWeight := false
+	for _, c := range f.calls {
+		if len(c) >= 3 && c[0] == "-X" && c[2] == "weight" {
+			sawWeight = true
+		}
+	}
+	if !sawWeight {
+		t.Fatalf("step 1 (workers=4): expected -X weight write, got %v", f.calls)
+	}
+	// Kernel now holds the concentrated layout.
+	f.ethtoolX["eth0"] = []byte(staleTable6q4w)
+	step1End := len(f.calls)
+
+	// Step 2: workers→1. Must probe + restore the NIC default.
+	applyRSSIndirectionOne("eth0", 1, f)
+	sawRestore := false
+	for _, c := range f.calls[step1End:] {
+		if len(c) >= 3 && c[0] == "-X" && c[2] == "default" {
+			sawRestore = true
+		}
+	}
+	if !sawRestore {
+		t.Fatalf("step 2 (workers→1): expected -X default restore of the stale table, got %v",
+			f.calls[step1End:])
+	}
+	// Kernel now holds the round-robin default again.
+	f.ethtoolX["eth0"] = []byte(defaultTable6q)
+	step2End := len(f.calls)
+
+	// Step 3: workers back to 4 → re-write concentrated weights.
+	applyRSSIndirectionOne("eth0", 4, f)
+	sawReWeight := false
+	for _, c := range f.calls[step2End:] {
+		if len(c) >= 3 && c[0] == "-X" && c[2] == "weight" {
+			sawReWeight = true
+		}
+	}
+	if !sawReWeight {
+		t.Fatalf("step 3 (1→4): expected -X weight re-write, got %v", f.calls[step2End:])
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #5124 (codex-review-177 `[A7-b2-F13]`). A day-2 reduction of `system dataplane workers` down to **1** left the mlx5 RSS indirection table in the concentrated `[1,..,1,0,..,0]` shape a prior `workers < queues` apply wrote. RX stayed hashed onto the old subset of queues even though the single-worker policy is default RSS across every queue — avoidable RX-ring/IRQ pressure and throughput/latency variance until an operator toggled the knob or restored the NIC default by hand. Not a blackhole (the Rust planner assigns all queues to worker 0), purely RX distribution.

## Root cause

`applyRSSIndirection` short-circuited on `workers == 1` **before** walking the allowlist, and `applyRSSIndirectionOne` gated its stale-table restore on `workers > 1`. The workers>=queue_count path already probes+restores a stale table (#805); the workers→1 path did not.

## Fix

- Drop the `workers == 1 { return }` early return so the allowlist loop runs.
- Widen the restore guard in `applyRSSIndirectionOne` from `workers > 1 && workers >= queues && queues > 1` to `workers >= 1 && queues > 1`.

`computeWeightVector(1, queues)` still returns nil — **no weight vector is applied**, so the single-worker default-RSS policy (no pinning to queue 0) is unchanged. The only new behavior: a stale concentrated table is detected and reset to the kernel round-robin default. A fresh single-worker boot with an already-default table issues one `ethtool -x` probe and no write (idempotent); a single-queue NIC short-circuits before any probe.

## Scope

Pure Go control-plane (`pkg/daemon/rss_indirection.go`). No Rust userspace-dp change, no ABI change, no cluster forwarding/failover path touched — unit-testable via the injected `rssExecutor` fake, no live cluster required.

## Tests / fail-on-revert

- Repurposed the two tests that pinned the old skip behavior to assert probe+restore.
- Added: default-table probe-only, single-queue no-op, and a full **4→1→4** transition test.
- **Fail-on-revert proven**: reverting the guard to `workers > 1 ...` turns the workers→1 restore tests RED (zero ethtool calls); the fix restores them GREEN. `go test ./pkg/daemon/...` GREEN, gofmt + go vet clean.

## Docs

The canonical module contract is the `applyRSSIndirection` doc comment (updated invariants + guard comment). `docs/pr/805-rss-refresh` is a frozen PR-investigation doc, not a living contract, so it is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8ctXhXNASS43vsMZxDEcm