### PR TITLE
upgrade: confirm per-RG rejoin before advancing to the peer (#5138)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47424,3 +47424,24 @@ top.
   reverting the guard to `workers > 1 ...` → 4 new tests RED (top-level +
   per-iface workers→1 stale restore, default-table probe-only, 4→1→4
   transition); restored GREEN. gofmt + go vet clean.
+
+- **Timestamp**: 2026-07-12
+- **Action**: #5138 — RejoinAndConfirm now gates on per-RG local eligibility
+  (Part 2). Part 1 ({0,1,2} fail-closed) was already fixed by #5044/PR #5175.
+  Added `RollingCluster.LocalRejoinComplete()`; grpcCluster impl reads the
+  STATUS topic (configured-RG enumeration, fail-closed) + INFORMATION topic
+  (per-RG `Weight: W/255`) and reports rejoined only when EVERY configured RG
+  has a non-zero weight (ForceSecondary zeroes weight; a still-zero RG is still
+  drained). RejoinAndConfirm's poll loop adds `rejoined` to the success
+  predicate and surfaces the last local-rejoin error at the deadline. Fake
+  updated with inverted `rejoinIncomplete` field so existing healthy-cluster
+  tests stay green.
+- **File(s)**: pkg/upgrade/rolling.go, pkg/upgrade/cluster_cli.go,
+  pkg/upgrade/kernel_drain.go, pkg/upgrade/rolling_test.go,
+  pkg/upgrade/cluster_cli_test.go, pkg/upgrade/kernel_drain_test.go,
+  docs/in-place-upgrade.md
+- **Validation**: `go test ./pkg/upgrade/` GREEN; full `go build ./...` +
+  `go vet ./pkg/upgrade/` clean; gofmt clean on touched files. Fail-on-revert
+  proven: neutralizing the RejoinAndConfirm gate AND the parser →
+  TestRejoinAndConfirmRefusesHeldRG, TestRejoinAndConfirmSurfacesLocalRejoinError,
+  TestLocalRejoinCompleteFromStatus all RED; restored GREEN.

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -419,9 +419,21 @@ state machines are untouched.
    re-polled until the deadline (NOT a hard abort on the first dial
    error). Only the deadline aborts, surfacing the last observed error;
    the node is then left secondary for the operator to inspect.
-7. `ResetFailover()` to rejoin election; forward-verify is the natural
-   post-promotion check (`make test-failover`) — a passive node
-   structurally cannot forward, so it is never "verified while passive".
+7. `ResetFailover()` to rejoin election, then a **per-RG rejoin confirm**
+   before the driver advances to the peer. `ResetFailover` enumerates the
+   configured RGs FAIL-CLOSED (no `{0,1,2}` guess — #5044) and resets each,
+   but a reset that returned nil is not proof the RG actually left the drain.
+   So `RejoinAndConfirm` additionally gates on `LocalRejoinComplete()`: every
+   configured RG (enumerated from `show chassis cluster status`) must show a
+   non-zero `Weight` in `show chassis cluster information` — `ForceSecondary`
+   zeroes every RG's weight, so a configured RG still at weight 0 (or absent
+   from the local view) reads as STILL DRAINED and the rejoin does not confirm
+   (#5138). Without this, `PeerAlive` + `SyncEstablished` (both GLOBAL) would
+   green-light the rejoin while some RG — e.g. RG≥3 the old guess dropped —
+   stayed demoted, and the driver would drain the peer that still owned it,
+   opening a no-primary window for that group. forward-verify is the natural
+   post-promotion check (`make test-failover`) — a passive node structurally
+   cannot forward, so it is never "verified while passive".
 
 ### `--unit` and the cluster control endpoint (#1983)
 

--- a/pkg/upgrade/cluster_cli.go
+++ b/pkg/upgrade/cluster_cli.go
@@ -576,6 +576,98 @@ func parseRGIDs(s string) []int {
 	return out
 }
 
+// LocalRejoinComplete reports whether the local node has left the
+// ForceSecondary drain for EVERY configured redundancy group (#5138). The
+// configured RG set is enumerated fail-closed from the STATUS topic (the same
+// source ResetFailover resets over); per-RG eligibility is read from the
+// INFORMATION topic, whose FormatInformation render carries a "Weight: W/255"
+// line per RG. ForceSecondary sets weight 0 for every RG; ResetFailover
+// restores it via re-election. So a configured RG that still shows weight 0 —
+// or is absent from the local status entirely — is NOT yet rejoined. Both
+// topics are dialed here and the decision is delegated to a pure function so
+// the fail-closed contract is unit-tested without a gRPC dial.
+func (g *grpcCluster) LocalRejoinComplete() (bool, error) {
+	st, stErr := g.statusText()
+	info, infoErr := g.information()
+	return localRejoinCompleteFromStatus(st, stErr, info, infoErr)
+}
+
+// localRejoinCompleteFromStatus decides per-RG rejoin from the rendered STATUS
+// text (s / statusErr — configured-RG enumeration) and INFORMATION text (info /
+// infoErr — per-RG weight). It FAILS CLOSED: a status-enumeration error, an
+// information-fetch error, a configured RG missing from the information render,
+// or a configured RG whose local weight is still 0 (the ForceSecondary drain)
+// all report not-rejoined. Kept pure so RejoinAndConfirm's per-RG gate is
+// exercised over rendered fixtures rather than a live cluster.
+func localRejoinCompleteFromStatus(s string, statusErr error, info string, infoErr error) (bool, error) {
+	rgs, err := configuredRGsFromStatus(s, statusErr)
+	if err != nil {
+		return false, err
+	}
+	if infoErr != nil {
+		return false, fmt.Errorf("read cluster information for per-RG rejoin: %w", infoErr)
+	}
+	weights := parseLocalRGWeights(info)
+	for _, rg := range rgs {
+		w, ok := weights[rg]
+		if !ok {
+			// Configured (per status) but not rendered in the local
+			// information view — cannot confirm eligibility: fail closed.
+			return false, nil
+		}
+		if w <= 0 {
+			// Still held in the ForceSecondary drain (weight 0).
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// parseLocalRGWeights extracts the LOCAL node's per-RG weight from the
+// `show chassis cluster information` (FormatInformation) text. It returns a map
+// rgID -> weight. FormatInformation renders, per group:
+//
+//	Redundancy group N:
+//	  ...
+//	  Weight: W/255 (threshold: 0)
+//
+// The header here is "Redundancy group N:" (a trailing ':' after the ID) —
+// DISTINCT from the STATUS topic's "Redundancy group: N , Failover count: M"
+// (a ':' immediately after "group"), so a status header can never be mistaken
+// for an information header. A malformed/unparseable header resets the current
+// group so a stray Weight line cannot bleed into the previous RG.
+func parseLocalRGWeights(info string) map[int]int {
+	out := map[int]int{}
+	cur := -1
+	for _, line := range strings.Split(info, "\n") {
+		l := strings.TrimSpace(line)
+		ll := strings.ToLower(l)
+		// Information-topic RG header: "redundancy group N:" — require the
+		// space after "group" (the status header has "group:" with no space)
+		// and a trailing ':'.
+		if strings.HasPrefix(ll, "redundancy group ") && strings.HasSuffix(ll, ":") {
+			cur = -1
+			mid := strings.TrimSpace(l[len("redundancy group") : len(l)-1])
+			if n, ok := atoiSafe(mid); ok {
+				cur = n
+			}
+			continue
+		}
+		if cur >= 0 && strings.HasPrefix(ll, "weight:") {
+			// "Weight: W/255 (threshold: 0)" -> W (the digits before '/').
+			rest := strings.TrimSpace(l[len("weight:"):])
+			numTok := rest
+			if i := strings.IndexByte(rest, '/'); i >= 0 {
+				numTok = strings.TrimSpace(rest[:i])
+			}
+			if n, ok := atoiSafe(numTok); ok {
+				out[cur] = n
+			}
+		}
+	}
+	return out
+}
+
 func (g *grpcCluster) LocalPrimary() (bool, error) {
 	s, err := g.information()
 	if err != nil {

--- a/pkg/upgrade/cluster_cli_test.go
+++ b/pkg/upgrade/cluster_cli_test.go
@@ -373,6 +373,109 @@ func TestConfiguredRGsFromStatus_FailsClosed(t *testing.T) {
 	}
 }
 
+// TestParseLocalRGWeights_AgainstRealFormatInformation feeds REAL
+// cluster.Manager.FormatInformation() output through parseLocalRGWeights so a
+// rename of the per-RG "Redundancy group N:" header or the "Weight: W/255" line
+// breaks HERE (a unit test), not in production where it would silently make the
+// #5138 per-RG rejoin gate read every RG as "not rendered" → fail-closed forever
+// (a rejoin that can never confirm). It also proves the parser keys ID -> weight
+// for more than one group, including RG>=3.
+func TestParseLocalRGWeights_AgainstRealFormatInformation(t *testing.T) {
+	m := cluster.NewManager(0, 1)
+	m.UpdateConfig(&config.ClusterConfig{
+		ClusterID: 1,
+		NodeID:    0,
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 0, Preempt: true, NodePriorities: map[int]int{0: 200, 1: 100}},
+			{ID: 3, Preempt: true, NodePriorities: map[int]int{0: 200, 1: 100}},
+		},
+	})
+
+	info := m.FormatInformation()
+	if !strings.Contains(info, "Weight:") {
+		t.Fatalf("FormatInformation() lacks the 'Weight:' line parseLocalRGWeights keys on:\n%s", info)
+	}
+
+	weights := parseLocalRGWeights(info)
+	if len(weights) != 2 {
+		t.Fatalf("parseLocalRGWeights = %v, want 2 groups (0 and 3) from:\n%s", weights, info)
+	}
+	for _, rg := range []int{0, 3} {
+		w, ok := weights[rg]
+		if !ok {
+			t.Fatalf("parseLocalRGWeights missing RG %d: %v\n%s", rg, weights, info)
+		}
+		// A freshly configured (undrained) RG must render a NON-ZERO weight, or
+		// the rejoin gate would never confirm a healthy node.
+		if w <= 0 {
+			t.Errorf("parseLocalRGWeights[%d] = %d, want > 0 for an undrained RG", rg, w)
+		}
+	}
+}
+
+// TestLocalRejoinCompleteFromStatus proves the #5138 fix: rejoin is confirmed
+// ONLY when EVERY configured RG (enumerated fail-closed from the status topic)
+// has left the ForceSecondary drain (non-zero weight in the information topic).
+// A configured RG still at weight 0 — or absent from the local information view
+// — must read as NOT rejoined so RejoinAndConfirm cannot advance the orchestrator
+// to drain the peer while that RG has no primary on either node. RED if the
+// per-RG gate is dropped and rejoin confirms on peer-alive/sync alone.
+func TestLocalRejoinCompleteFromStatus(t *testing.T) {
+	// Status enumerates configured RGs 0, 1, 3 (RG>=3 must be honored).
+	status := strings.Join([]string{
+		"Node name: node0",
+		"Redundancy group: 0 , Failover count: 0",
+		"Redundancy group: 1 , Failover count: 0",
+		"Redundancy group: 3 , Failover count: 0",
+	}, "\n")
+
+	// FormatInformation grammar: "Redundancy group N:" header + "Weight: W/255".
+	infoAllEligible := strings.Join([]string{
+		"Redundancy group 0:",
+		"  Local state: Secondary",
+		"  Weight: 255/255 (threshold: 0)",
+		"Redundancy group 1:",
+		"  Local state: Secondary",
+		"  Weight: 128/255 (threshold: 0)",
+		"Redundancy group 3:",
+		"  Local state: Secondary",
+		"  Weight: 255/255 (threshold: 0)",
+	}, "\n")
+	// RG3 still held in the ForceSecondary drain (weight 0) — the exact #5138
+	// scenario the pre-#5044 {0,1,2} guess would have stranded.
+	infoRG3Held := strings.ReplaceAll(infoAllEligible,
+		"Redundancy group 3:\n  Local state: Secondary\n  Weight: 255/255 (threshold: 0)",
+		"Redundancy group 3:\n  Local state: Secondary\n  Weight: 0/255 (threshold: 0)")
+	// RG3 not rendered in the local information view at all.
+	infoRG3Missing := strings.Join([]string{
+		"Redundancy group 0:",
+		"  Weight: 255/255 (threshold: 0)",
+		"Redundancy group 1:",
+		"  Weight: 255/255 (threshold: 0)",
+	}, "\n")
+
+	if ok, err := localRejoinCompleteFromStatus(status, nil, infoAllEligible, nil); err != nil || !ok {
+		t.Fatalf("all RGs weight>0: got ok=%v err=%v, want ok=true err=nil", ok, err)
+	}
+	if ok, err := localRejoinCompleteFromStatus(status, nil, infoRG3Held, nil); err != nil || ok {
+		t.Fatalf("RG3 held at weight 0: got ok=%v err=%v, want ok=false err=nil "+
+			"(rejoin must NOT confirm while a configured RG is still drained)", ok, err)
+	}
+	if ok, err := localRejoinCompleteFromStatus(status, nil, infoRG3Missing, nil); err != nil || ok {
+		t.Fatalf("RG3 missing from information: got ok=%v err=%v, want ok=false err=nil "+
+			"(cannot confirm eligibility for an unrendered RG — fail closed)", ok, err)
+	}
+	// A status-enumeration failure fails closed with an error (propagated so the
+	// deadline miss surfaces WHY), never a guessed RG set.
+	if ok, err := localRejoinCompleteFromStatus("", errors.New("gRPC unavailable"), infoAllEligible, nil); err == nil || ok {
+		t.Fatalf("status error: got ok=%v err=%v, want ok=false err!=nil", ok, err)
+	}
+	// An information-fetch failure likewise fails closed.
+	if ok, err := localRejoinCompleteFromStatus(status, nil, "", errors.New("gRPC unavailable")); err == nil || ok {
+		t.Fatalf("information error: got ok=%v err=%v, want ok=false err!=nil", ok, err)
+	}
+}
+
 func TestParseHAProtocolCompatible(t *testing.T) {
 	match := "HA protocol version: 1\nPeer HA protocol version: 1\n"
 	mismatch := "HA protocol version: 1\nPeer HA protocol version: 2\n"

--- a/pkg/upgrade/kernel_drain.go
+++ b/pkg/upgrade/kernel_drain.go
@@ -117,8 +117,16 @@ func RejoinAndConfirm(cl RollingCluster, deadline time.Duration) error {
 	if err := cl.ResetFailover(); err != nil {
 		return fmt.Errorf("reset failover: %w", err)
 	}
-	// Confirm the peer is still a healthy member and sync is re-established —
+	// Confirm the peer is still a healthy member, sync is re-established, AND
+	// this node has actually resumed eligibility for EVERY configured RG —
 	// i.e. the cluster is whole again — before declaring the rejoin done.
+	// PeerAlive + SyncEstablished are GLOBAL predicates: they hold even if some
+	// configured RG (e.g. RG>=3 the pre-#5044 {0,1,2} guess dropped) is still
+	// held in the ForceSecondary drain. Without the per-RG gate the orchestrator
+	// would confirm rejoin and advance to drain the PEER while that RG has no
+	// primary on either node — a per-RG blackhole (#5138). LocalRejoinComplete
+	// fails closed on an enumeration error or a still-demoted RG, so the roll
+	// stops here instead.
 	dl := time.Now().Add(deadline)
 	// Retain the last non-nil transport/gRPC error from each predicate so a
 	// deadline miss reports WHY the rejoin never confirmed, not just the
@@ -127,11 +135,12 @@ func RejoinAndConfirm(cl RollingCluster, deadline time.Duration) error {
 	// through syslog to learn it was e.g. a refused gRPC dial while xpfd was
 	// still restarting. Mirrors DrainAndConfirm's timeout, which already wraps
 	// the last DrainComplete error.
-	var lastAErr, lastSErr error
+	var lastAErr, lastSErr, lastRErr error
 	for {
 		alive, aerr := cl.PeerAlive()
 		synced, serr := cl.SyncEstablished()
-		if aerr == nil && serr == nil && alive && synced {
+		rejoined, rerr := cl.LocalRejoinComplete()
+		if aerr == nil && serr == nil && rerr == nil && alive && synced && rejoined {
 			return nil
 		}
 		if aerr != nil {
@@ -140,15 +149,21 @@ func RejoinAndConfirm(cl RollingCluster, deadline time.Duration) error {
 		if serr != nil {
 			lastSErr = serr
 		}
+		if rerr != nil {
+			lastRErr = rerr
+		}
 		if time.Now().After(dl) {
 			base := fmt.Errorf("rejoin not confirmed within %s "+
-				"(peer-alive=%v sync-established=%v)", deadline, alive, synced)
+				"(peer-alive=%v sync-established=%v local-rejoined=%v)", deadline, alive, synced, rejoined)
 			var details []string
 			if lastAErr != nil {
 				details = append(details, fmt.Sprintf("last peer-alive error: %v", lastAErr))
 			}
 			if lastSErr != nil {
 				details = append(details, fmt.Sprintf("last sync-established error: %v", lastSErr))
+			}
+			if lastRErr != nil {
+				details = append(details, fmt.Sprintf("last local-rejoin error: %v", lastRErr))
 			}
 			if len(details) > 0 {
 				return fmt.Errorf("%w; %s", base, strings.Join(details, "; "))

--- a/pkg/upgrade/kernel_drain_test.go
+++ b/pkg/upgrade/kernel_drain_test.go
@@ -149,3 +149,47 @@ func TestRejoinAndConfirmSuccessUnchanged(t *testing.T) {
 		t.Fatalf("successful rejoin must return nil unchanged; got: %v", err)
 	}
 }
+
+// #5138: peer-alive + sync are GLOBAL predicates — they hold even when a
+// configured RG (e.g. RG>=3) is still held in the ForceSecondary drain after
+// ResetFailover. RejoinAndConfirm must NOT confirm rejoin on those two alone; it
+// must also see LocalRejoinComplete (per-RG eligibility for EVERY configured RG).
+// With a healthy peer + sync but an incomplete per-RG rejoin, the deadline must
+// be MISSED and the error must name the failed local-rejoin check — otherwise the
+// orchestrator would advance to drain the peer while that RG has no primary on
+// either node (a per-RG blackhole). RED-on-revert: dropping the LocalRejoinComplete
+// gate makes RejoinAndConfirm return nil here (peer-alive + sync suffice), failing
+// the assertions below.
+func TestRejoinAndConfirmRefusesHeldRG(t *testing.T) {
+	f := &fakeCluster{peerAlive: true, synced: true, rejoinIncomplete: true}
+	err := RejoinAndConfirm(f, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("rejoin must NOT confirm while a configured RG is still held in the " +
+			"ForceSecondary drain (peer-alive + sync are not sufficient) — never-both-down")
+	}
+	if !strings.Contains(err.Error(), "local-rejoined=false") {
+		t.Fatalf("timeout error must report the per-RG rejoin state; got: %v", err)
+	}
+	if !f.resetCalled {
+		t.Fatal("ResetFailover should still have been attempted")
+	}
+}
+
+// #5138: a persistent per-RG enumeration/transport failure must surface at the
+// deadline (naming the local-rejoin check with its cause), same discipline as the
+// peer-alive/sync surfacing (#4717). RED-on-revert: the discarded-error code drops
+// the local-rejoin cause.
+func TestRejoinAndConfirmSurfacesLocalRejoinError(t *testing.T) {
+	wantCause := errors.New("enumerate configured redundancy groups: gRPC unavailable")
+	f := &fakeCluster{peerAlive: true, synced: true, rejoinErr: wantCause}
+	err := RejoinAndConfirm(f, 30*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error when LocalRejoinComplete keeps failing")
+	}
+	if !strings.Contains(err.Error(), "local-rejoin error") {
+		t.Fatalf("timeout error must name the failed LocalRejoinComplete check; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), wantCause.Error()) {
+		t.Fatalf("timeout error must surface the underlying LocalRejoinComplete cause; got: %v", err)
+	}
+}

--- a/pkg/upgrade/rolling.go
+++ b/pkg/upgrade/rolling.go
@@ -34,6 +34,18 @@ type RollingCluster interface {
 	// LocalPrimary reports whether the local node currently owns the RGs
 	// (used by the controlled-promotion forward-verify).
 	LocalPrimary() (bool, error)
+	// LocalRejoinComplete reports whether the local node has actually
+	// resumed election eligibility for EVERY configured redundancy group
+	// after ResetFailover — i.e. no configured RG is still held in the
+	// ForceSecondary drain (weight 0). ResetFailover only REQUESTS the reset
+	// per RG; a request that returned nil is not proof the RG left the drain,
+	// and a client that could not enumerate an RG never issued its reset at
+	// all. RejoinAndConfirm gates the "never both down" advance on this
+	// per-RG check so a rejoin can never confirm while some configured RG
+	// (e.g. RG>=3 the pre-#5044 {0,1,2} guess dropped) stays demoted with no
+	// primary on either node (#5138). FAILS CLOSED: an enumeration error or a
+	// configured RG missing from the local status reads as not-yet-rejoined.
+	LocalRejoinComplete() (bool, error)
 }
 
 // RollingConfig tunes the rolling driver timing.

--- a/pkg/upgrade/rolling_test.go
+++ b/pkg/upgrade/rolling_test.go
@@ -22,6 +22,13 @@ type fakeCluster struct {
 	syncPolls    int
 	forced       bool
 	resetCalled  bool
+	// #5138 per-RG rejoin gate. Default (zero value) reports rejoin COMPLETE
+	// so the many existing healthy-cluster tests keep passing without edits;
+	// a test sets rejoinIncomplete=true to model a configured RG still held in
+	// the ForceSecondary drain after ResetFailover, or rejoinErr for a
+	// persistent enumeration/transport failure surfaced at the deadline.
+	rejoinIncomplete bool
+	rejoinErr        error
 	// #4717 test seams: when set, the predicate returns this error on EVERY
 	// poll (persistent transport failure), so a deadline miss must surface it.
 	peerAliveErr error
@@ -52,6 +59,12 @@ func (f *fakeCluster) DrainComplete() (bool, error) {
 }
 func (f *fakeCluster) ResetFailover() error        { f.resetCalled = true; return nil }
 func (f *fakeCluster) LocalPrimary() (bool, error) { return f.localPri, nil }
+func (f *fakeCluster) LocalRejoinComplete() (bool, error) {
+	if f.rejoinErr != nil {
+		return false, f.rejoinErr
+	}
+	return !f.rejoinIncomplete, nil
+}
 
 func fastRC() RollingConfig {
 	return RollingConfig{


### PR DESCRIPTION
## Problem (#5138, Part 2)

`RejoinAndConfirm` (`pkg/upgrade/kernel_drain.go`) confirmed a node back in
the cluster on `PeerAlive()` + `SyncEstablished()` alone. Both are **global**
predicates — they hold even when a single configured redundancy group is still
held in the `ForceSecondary` (ISSU) drain.

Part 1 of #5138 — the `configuredRGs()` `{0,1,2}` fallback — was **already
fixed** by #5044 (PR #5175): `ResetFailover` now enumerates the configured RGs
fail-closed and resets each. But a reset that returned `nil` is not proof the
RG actually left the drain, and a client that couldn't enumerate an RG never
issued its reset at all. So a configured RG — e.g. `RG>=3`, which the pre-#5044
`{0,1,2}` guess silently dropped — could stay demoted while the confirm step
green-lit the rejoin, and the orchestrator would advance to drain the peer that
still owned that group → **no primary on either node, a per-RG blackhole**.

## Fix

Add a per-RG eligibility gate to the rejoin confirm.

- `RollingCluster` gains `LocalRejoinComplete() (bool, error)`.
- The gRPC impl enumerates the configured RGs from the **STATUS** topic (the
  same fail-closed source `ResetFailover` resets over) and reads each RG's local
  `Weight` from the **INFORMATION** topic (`FormatInformation` renders
  `Weight: W/255` per RG). `ForceSecondary` zeroes every RG's weight and
  `ResetFailover` restores it via re-election, so a configured RG still at
  weight 0 — or absent from the local view — reads as **still drained**.
- The decision is a pure `localRejoinCompleteFromStatus()` that **fails closed**
  on an enumeration error, an information-fetch error, a missing RG, or a
  weight-0 RG.
- `RejoinAndConfirm` adds this predicate to its poll-loop success condition and
  surfaces the last local-rejoin error at the deadline (mirrors the #4717
  peer-alive/sync surfacing), so a stuck RG stops the roll here.

The fake `RollingCluster` gains an inverted `rejoinIncomplete` field so the
existing healthy-cluster tests stay green with no edits.

## Tests

- `TestLocalRejoinCompleteFromStatus` — fail-closed matrix (all-eligible → ok;
  RG3 weight 0 → not rejoined; RG3 missing → not rejoined; status error /
  information error → error).
- `TestParseLocalRGWeights_AgainstRealFormatInformation` — feeds REAL
  `cluster.Manager.FormatInformation()` through the weight parser so a
  header/field rename breaks a unit test, not production.
- `TestRejoinAndConfirmRefusesHeldRG` — peer-alive + sync are NOT sufficient
  while an RG is held (**RED-on-revert** when the gate is dropped).
- `TestRejoinAndConfirmSurfacesLocalRejoinError` — deadline error names the
  local-rejoin check and carries its cause.

**Fail-on-revert proven**: neutralizing both the `RejoinAndConfirm` gate and the
parser turns the three new tests RED; restoring turns them GREEN.

## Validation

`go test ./pkg/upgrade/` GREEN; `go build ./...` + `go vet ./pkg/upgrade/`
clean; gofmt clean on touched files. **Control-plane only**, unit-testable with
rendered-text fixtures — no live cluster or dataplane change.

Closes #5138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QNnTw3ytMtc91pxEu6oFK