### PR TITLE
grpcapi,configstore,cli: bound zeroize to an xpf-owned config root

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47472,3 +47472,22 @@ top.
   Fail-on-revert proven: neutralizing ValidateFactoryResetRoot →
   TestValidateFactoryResetRoot (15 rows), TestFactoryResetConfigDirRefusesSharedParent,
   and TestZeroizeRefusesSharedConfigRoot all RED; restored GREEN.
+
+## 2026-07-12 — #5684 follow-up: grpcapi zeroizeConfigDir defense-in-depth (PR #5767 review fold)
+
+- **Timestamp**: 2026-07-12
+- **Action**: Folded one hostile-review finding on PR #5767. The gRPC config-
+  state wipe PRIMITIVE `grpcapi.zeroizeConfigDir` (server_diag_zeroize.go) — the
+  MORE destructive one (RemoveAll's `<root>/tls` + `<root>/.configdb`) — did not
+  itself call `ValidateFactoryResetRoot`, so the #5684 defense-in-depth was
+  one-sided (only the CLI's `configstore.FactoryResetConfigDir` re-validated).
+  No live bypass (only runZeroize→zeroizeConfigRoot reaches it, which validates),
+  but the guarantee + docs were asymmetric. Added the guard as the FIRST
+  statement of `zeroizeConfigDir` (fail-closed before any glob/RemoveAll) and
+  corrected docs/system-login.md to say BOTH primitives re-validate.
+- **File(s)**: pkg/grpcapi/server_diag_zeroize.go,
+  pkg/grpcapi/zeroize_scope_5684_test.go, docs/system-login.md
+- **Validation**: `go test ./pkg/grpcapi/... ./pkg/configstore/... ./pkg/cli/...`
+  GREEN; gofmt clean on touched files. Fail-on-revert proven: neutralizing the
+  new zeroizeConfigDir guard → TestZeroizeConfigDirRefusesSharedRoot RED
+  (seeded siblings deleted, returns nil); restored GREEN.

--- a/_Log.md
+++ b/_Log.md
@@ -47445,3 +47445,30 @@ top.
   proven: neutralizing the RejoinAndConfirm gate AND the parser →
   TestRejoinAndConfirmRefusesHeldRG, TestRejoinAndConfirmSurfacesLocalRejoinError,
   TestLocalRejoinCompleteFromStatus all RED; restored GREEN.
+
+## 2026-07-12 — #5684 zeroize config-root scope guard (codex-182 M33)
+
+- **Timestamp**: 2026-07-12
+- **Action**: Bound `request system zeroize` to an xpf-owned config root so a
+  custom/adversarial `-config` cannot turn a factory reset into a broad deletion
+  of a shared/parent directory. `configDir` is `filepath.Dir(store.ConfigPath())`;
+  a `-config` placed directly in a shared dir (`/etc/xpf.conf`→`/etc`,
+  `/srv/site.conf`→`/srv`) or a directory-shaped `-config` (`/srv/firewall`,
+  where `filepath.Dir` climbs to the PARENT `/srv`) had the wipe glob `*.conf` /
+  `rollback*` and `RemoveAll` `<root>/.configdb`+`<root>/tls` inside a directory
+  xpf does not own. Added `configstore.ValidateFactoryResetRoot` +
+  `FactoryResetForbiddenRoots`; guard runs at both resolution points
+  (`(*Server).zeroizeConfigRoot`, `(*CLI).zeroizeConfigRoot`) — fail CLOSED
+  before any wipe leg — and inside the shared `FactoryResetConfigDir` primitive
+  as defense-in-depth. Default `/etc/xpf` and dedicated subdirs pass.
+- **File(s)**: pkg/configstore/factory_reset.go,
+  pkg/configstore/factory_reset_scope_5684_test.go,
+  pkg/grpcapi/server_diag_system_action.go,
+  pkg/grpcapi/zeroize_scope_5684_test.go, pkg/cli/cli_request_system.go,
+  docs/system-login.md
+- **Validation**: `go test ./pkg/configstore/... ./pkg/grpcapi/... ./pkg/cli/...`
+  GREEN; gofmt + `go vet` clean on touched files (pre-existing
+  cli/completion_panic_test.go gofmt + cli.go:511 vet noise untouched).
+  Fail-on-revert proven: neutralizing ValidateFactoryResetRoot →
+  TestValidateFactoryResetRoot (15 rows), TestFactoryResetConfigDirRefusesSharedParent,
+  and TestZeroizeRefusesSharedConfigRoot all RED; restored GREEN.

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -175,6 +175,28 @@ absence by `generateSelfSignedCertAt` on the next boot). A wipe that cannot
 fully erase this state returns an error rather than reporting a clean factory
 reset.
 
+**Config-root scope guard (#5684).** The wipe target is the daemon's configured
+config root — `filepath.Dir(store.ConfigPath())`, the directory of the `-config`
+path (#5280/#5554), so a non-default `-config /srv/xpf/site.conf` erases
+`/srv/xpf`, not a hardcoded `/etc/xpf`. But `filepath.Dir` on a
+custom/adversarial `-config` can resolve to a directory xpf does not own: a
+config file placed directly in a shared directory (`-config /etc/xpf.conf` →
+`/etc`; `-config /srv/site.conf` → `/srv`) or a directory-shaped `-config`
+(`-config /srv/firewall`, where `filepath.Dir` climbs to the **parent** `/srv`).
+Because the config-state sweep globs `*.conf` / `rollback*` and `RemoveAll`s
+`<root>/.configdb` and `<root>/tls`, an unowned root would turn a factory reset
+into a **broad deletion of sibling files** in that shared/parent directory.
+`configstore.ValidateFactoryResetRoot` closes this: it refuses a config root
+that is non-absolute (a relative/empty `-config` resolves to the daemon's
+working directory) or equal to the filesystem root or a well-known shared/system
+directory (`FactoryResetForbiddenRoots`: `/`, `/etc`, `/srv`, `/home`, `/var`,
+`/usr`, …). The check is lexical on `filepath.Clean` (so a trailing slash and
+`..` traversal normalize first). The default `/etc/xpf` and any dedicated
+subdirectory pass. The guard runs at both resolution points
+(`(*Server).zeroizeConfigRoot`, `(*CLI).zeroizeConfigRoot`) — so a bad root
+fails **closed before any wipe leg runs**, erasing nothing — and again inside the
+shared `FactoryResetConfigDir` primitive as defense-in-depth.
+
 **Rendered service-config erasure (#4585).** The wipe erases that
 SSOT/rollback/journal state directly, but the prior tenant's secrets are ALSO
 rendered into service configs xpfd writes **outside** `/etc/xpf`. `zeroize` now

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -194,8 +194,12 @@ directory (`FactoryResetForbiddenRoots`: `/`, `/etc`, `/srv`, `/home`, `/var`,
 `..` traversal normalize first). The default `/etc/xpf` and any dedicated
 subdirectory pass. The guard runs at both resolution points
 (`(*Server).zeroizeConfigRoot`, `(*CLI).zeroizeConfigRoot`) — so a bad root
-fails **closed before any wipe leg runs**, erasing nothing — and again inside the
-shared `FactoryResetConfigDir` primitive as defense-in-depth.
+fails **closed before any wipe leg runs**, erasing nothing — and, as
+defense-in-depth, again inside **each** config-state wipe primitive before it
+touches disk: the CLI's `configstore.FactoryResetConfigDir` and the gRPC
+`grpcapi.zeroizeConfigDir` (the latter is the more destructive one — it
+`RemoveAll`s `<root>/tls` and `<root>/.configdb`), so neither primitive trusts
+its caller to have handed it an xpf-owned root.
 
 **Rendered service-config erasure (#4585).** The wipe erases that
 SSOT/rollback/journal state directly, but the prior tenant's secrets are ALSO

--- a/pkg/cli/cli_request_system.go
+++ b/pkg/cli/cli_request_system.go
@@ -135,7 +135,17 @@ func (c *CLI) zeroizeConfigRoot() (configDir, configBase string, err error) {
 	if p == "" {
 		return "", "", fmt.Errorf("zeroize: config store has no config path; cannot determine configured config root to erase")
 	}
-	return filepath.Dir(p), filepath.Base(p), nil
+	dir := filepath.Dir(p)
+	// #5684: refuse if the resolved root is a shared/parent/system directory. A
+	// custom -config placed directly in a shared directory (or a directory-shaped
+	// -config, where filepath.Dir climbs to the PARENT) would otherwise turn the
+	// factory reset into a broad deletion of *.conf / .configdb / tls siblings xpf
+	// does not own. Fail CLOSED (the shared FactoryResetConfigDir primitive guards
+	// again, but stopping here gives the earliest, clearest operator error).
+	if err := configstore.ValidateFactoryResetRoot(dir); err != nil {
+		return "", "", err
+	}
+	return dir, filepath.Base(p), nil
 }
 
 // zeroizeConfigState erases the on-disk configuration STATE for a factory reset:

--- a/pkg/configstore/factory_reset.go
+++ b/pkg/configstore/factory_reset.go
@@ -2,6 +2,7 @@ package configstore
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -91,6 +92,66 @@ func FactoryResetArchiveDir(archiveDir string) error {
 	return firstErr
 }
 
+// FactoryResetForbiddenRoots are directories a factory-reset config-state wipe
+// must NEVER treat as an xpf-owned config root (#5684). FactoryResetConfigDir
+// scans configDir for *.conf / rollback* / journal / numbered-text-rollback /
+// fsatomic-temp artifacts and RemoveAll's <configDir>/.configdb — every removal
+// is bounded to configDir, but configDir itself is derived from
+// filepath.Dir(store.ConfigPath()). A daemon started with a custom `-config`
+// placed DIRECTLY in a shared directory (`-config /etc/xpf.conf` → configDir
+// "/etc"; `-config /srv/site.conf` → "/srv") or pointed at a directory-shaped
+// path (`-config /srv/firewall`, where filepath.Dir climbs to the PARENT
+// "/srv") turns a factory reset into a broad deletion of files xpf does not own
+// — the destructive-scope defect #5684 closes. ValidateFactoryResetRoot rejects
+// these so the reset fails CLOSED (erases NOTHING, reports incomplete) instead
+// of wiping the wrong tree. The default appliance root /etc/xpf and any
+// dedicated subdirectory (/srv/xpf, /opt/xpf/data) are deliberately NOT on the
+// list and pass. It is a var so a test can register a throwaway tree as a shared
+// root (mirroring the DefaultArchiveDir seam); production code must never mutate
+// it.
+var FactoryResetForbiddenRoots = []string{
+	"/",
+	"/bin", "/boot", "/dev", "/etc", "/home", "/lib", "/lib32", "/lib64",
+	"/libx32", "/media", "/mnt", "/opt", "/proc", "/root", "/run", "/sbin",
+	"/srv", "/sys", "/tmp", "/usr", "/usr/local", "/var", "/var/lib",
+	"/var/tmp",
+}
+
+// ValidateFactoryResetRoot reports whether configDir is a plausible xpf-owned
+// config root that a factory reset may erase, returning a descriptive error if
+// it is not (#5684). configDir is filepath.Dir(store.ConfigPath()), so a
+// custom/adversarial `-config` can resolve it to a directory xpf does not own;
+// this is the guard that keeps `zeroize` from broad-deleting an enclosing
+// directory. It rejects:
+//
+//   - a NON-ABSOLUTE path — an empty or relative `-config` resolves
+//     filepath.Dir to "." (the daemon's working directory), never a config root;
+//   - the filesystem root and the well-known shared/system directories in
+//     FactoryResetForbiddenRoots — a `-config` placed directly in a shared
+//     directory (or a directory-shaped `-config`, where filepath.Dir climbs to
+//     the PARENT) would otherwise wipe *.conf / .configdb / tls siblings xpf
+//     does not own.
+//
+// The comparison is lexical on filepath.Clean(configDir), so a trailing slash
+// and `..` traversal (`/etc/xpf/..` → /etc) are normalized before the check.
+// Callers surface the error so the reset erases NOTHING and reports incomplete
+// rather than deleting the wrong tree. The default appliance root /etc/xpf and
+// any dedicated subdirectory pass. This is a purely lexical guard (it does not
+// resolve symlinks); a defense against config-path misconfiguration, not against
+// an operator who symlinks the config root at a shared directory.
+func ValidateFactoryResetRoot(configDir string) error {
+	clean := filepath.Clean(configDir)
+	if !filepath.IsAbs(clean) {
+		return fmt.Errorf("zeroize: refusing to factory-reset non-absolute config root %q: a relative or empty -config path resolves to the daemon working directory, not an xpf config directory", configDir)
+	}
+	for _, forbidden := range FactoryResetForbiddenRoots {
+		if clean == forbidden {
+			return fmt.Errorf("zeroize: refusing to factory-reset shared/system directory %q as a config root: the -config path must live in a directory xpf owns (e.g. /etc/xpf), not directly in a shared directory whose siblings are not xpf's to erase", clean)
+		}
+	}
+	return nil
+}
+
 // FactoryResetConfigDir securely erases the on-disk configuration STATE under
 // configDir as part of a factory reset (#4858). It is the single shared
 // primitive behind `request system zeroize` so the on-box CLI and any RPC
@@ -152,6 +213,15 @@ func FactoryResetArchiveDir(archiveDir string) error {
 // generation of config secrets — is erased by the sibling FactoryResetArchiveDir
 // (#5186), which both the CLI and the gRPC wipe also call.
 func FactoryResetConfigDir(configDir, configBase string) error {
+	// #5684: refuse to wipe a shared/parent/system directory. configDir is
+	// filepath.Dir(store.ConfigPath()); a custom -config placed in (or resolving
+	// to) a shared directory would turn this into a broad deletion of *.conf /
+	// .configdb / tls siblings xpf does not own. Fail CLOSED — surface the error
+	// and remove NOTHING — rather than erase the wrong tree.
+	if err := ValidateFactoryResetRoot(configDir); err != nil {
+		return err
+	}
+
 	var firstErr error
 	fail := func(err error) {
 		if err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {

--- a/pkg/configstore/factory_reset_scope_5684_test.go
+++ b/pkg/configstore/factory_reset_scope_5684_test.go
@@ -1,0 +1,129 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestValidateFactoryResetRoot pins the #5684 shared/parent-directory guard: a
+// factory-reset config-state wipe must REFUSE a config root that resolves to a
+// shared/system directory or is non-absolute, and ACCEPT the default appliance
+// root plus any dedicated subdirectory. configDir is filepath.Dir(ConfigPath()),
+// so a custom -config placed directly in a shared directory (or a directory-
+// shaped -config, where filepath.Dir climbs to the parent) would otherwise turn
+// the reset into a broad deletion of unowned siblings.
+//
+// RED on revert: neutering ValidateFactoryResetRoot (return nil) makes every
+// wantErr row fail — /etc, /, /srv, /home, an empty and a relative path would
+// all be accepted as erasable config roots.
+func TestValidateFactoryResetRoot(t *testing.T) {
+	cases := []struct {
+		dir     string
+		wantErr bool
+	}{
+		// Shared/system roots and the filesystem root: REFUSED.
+		{"/", true},
+		{"/etc", true},
+		{"/srv", true},
+		{"/home", true},
+		{"/root", true},
+		{"/var", true},
+		{"/var/lib", true},
+		{"/usr", true},
+		{"/usr/local", true},
+		{"/tmp", true},
+		{"/etc/", true},       // trailing slash cleans to /etc
+		{"/etc/xpf/..", true}, // .. traversal cleans to /etc
+		// Non-absolute (empty/relative) -config: filepath.Dir → "." / relative.
+		{"", true},
+		{".", true},
+		{"relative/dir", true},
+		{"xpf.conf", true},
+		// The default appliance root and dedicated subdirectories: ACCEPTED.
+		{"/etc/xpf", false},
+		{"/etc/xpf/", false},
+		{"/srv/xpf", false},
+		{"/opt/xpf/data", false},
+		{"/var/lib/xpf", false},
+	}
+	for _, tc := range cases {
+		err := ValidateFactoryResetRoot(tc.dir)
+		if tc.wantErr && err == nil {
+			t.Errorf("ValidateFactoryResetRoot(%q) = nil, want an error (shared/parent/non-absolute root must be refused)", tc.dir)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("ValidateFactoryResetRoot(%q) = %v, want nil (a dedicated xpf config root must be accepted)", tc.dir, err)
+		}
+	}
+}
+
+// forbidFactoryResetRoot registers dir as a #5684 forbidden root for the test's
+// lifetime so a THROWAWAY directory can stand in for a shared/system root like
+// /etc or /srv, keeping the test hermetic (mirrors the DefaultArchiveDir seam).
+// Production code never mutates FactoryResetForbiddenRoots.
+func forbidFactoryResetRoot(t *testing.T, dir string) {
+	t.Helper()
+	old := FactoryResetForbiddenRoots
+	FactoryResetForbiddenRoots = append(append([]string(nil), old...), filepath.Clean(dir))
+	t.Cleanup(func() { FactoryResetForbiddenRoots = old })
+}
+
+// TestFactoryResetConfigDirRefusesSharedParent is the #5684 fail-on-revert: when
+// the resolved config root is a shared/parent directory, FactoryResetConfigDir
+// must erase NOTHING and return an error — a custom/adversarial -config path can
+// never turn a factory reset into a broad deletion of the enclosing directory.
+//
+// The scenario reproduces the defect: an operator points -config at a file in a
+// shared directory (or at a directory-shaped path, where filepath.Dir climbs to
+// the parent), so configDir resolves to a directory xpf does not own that holds
+// unrelated files — a sibling *.conf, a foreign .configdb, a foreign tls/,
+// a rollback-shaped file, a foreign journal. A pre-fix wipe globbed *.conf and
+// RemoveAll'd .configdb + tls INSIDE that shared directory.
+//
+// RED on revert: remove the ValidateFactoryResetRoot guard at the top of
+// FactoryResetConfigDir and every seeded artifact below is deleted — the
+// "survives" assertions fail, and the "returns an error" check fails.
+func TestFactoryResetConfigDirRefusesSharedParent(t *testing.T) {
+	shared := filepath.Join(t.TempDir(), "shared")
+	if err := os.MkdirAll(filepath.Join(shared, ".configdb"), 0o700); err != nil {
+		t.Fatalf("mkdir shared/.configdb: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(shared, "tls"), 0o700); err != nil {
+		t.Fatalf("mkdir shared/tls: %v", err)
+	}
+	// Files a pre-fix broad wipe would have destroyed inside the shared dir.
+	seeded := map[string]string{
+		filepath.Join(shared, "neighbor.conf"):             "not xpf's config",
+		filepath.Join(shared, ".configdb", "foreign.json"): "someone else's DB",
+		filepath.Join(shared, "tls", "key.pem"):            "someone else's key",
+		filepath.Join(shared, "xpf.conf.1"):                "rollback-shaped bystander",
+		filepath.Join(shared, ".config.journal"):           "foreign journal",
+	}
+	for p, body := range seeded {
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+	}
+
+	// Treat the throwaway dir as a shared/system root (stands in for /etc, /srv).
+	forbidFactoryResetRoot(t, shared)
+
+	err := FactoryResetConfigDir(shared, "xpf.conf")
+	if err == nil {
+		t.Fatalf("FactoryResetConfigDir(%q) = nil; want an error refusing to wipe a shared/parent directory", shared)
+	}
+
+	// Every seeded artifact must SURVIVE — the reset touched nothing.
+	for p := range seeded {
+		if _, statErr := os.Stat(p); statErr != nil {
+			t.Errorf("factory reset removed %s from a shared directory it must not touch: %v", p, statErr)
+		}
+	}
+	// The subdirectories themselves must survive too.
+	for _, d := range []string{filepath.Join(shared, ".configdb"), filepath.Join(shared, "tls")} {
+		if _, statErr := os.Stat(d); statErr != nil {
+			t.Errorf("factory reset removed shared subdir %s: %v", d, statErr)
+		}
+	}
+}

--- a/pkg/grpcapi/server_diag_system_action.go
+++ b/pkg/grpcapi/server_diag_system_action.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/configstore"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
@@ -106,7 +107,17 @@ func (s *Server) zeroizeConfigRoot() (configDir, configBase string, err error) {
 	if p == "" {
 		return "", "", fmt.Errorf("zeroize: config store has no config path; cannot determine configured config root to erase")
 	}
-	return filepath.Dir(p), filepath.Base(p), nil
+	dir := filepath.Dir(p)
+	// #5684: refuse if the resolved root is a shared/parent/system directory. A
+	// custom -config placed directly in a shared directory (or a directory-shaped
+	// -config, where filepath.Dir climbs to the PARENT) would otherwise turn the
+	// factory reset into a broad deletion of *.conf / .configdb / tls siblings xpf
+	// does not own. Fail CLOSED here, BEFORE runZeroize enters the terminal reset
+	// generation or performZeroizeWipe touches any leg.
+	if err := configstore.ValidateFactoryResetRoot(dir); err != nil {
+		return "", "", err
+	}
+	return dir, filepath.Base(p), nil
 }
 
 // runZeroize erases on-disk state for a factory reset. It routes through the

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -105,6 +105,17 @@ const (
 // silently-incomplete zeroize is never reported as a successful factory reset.
 // os.ErrNotExist is not an error here (an already-absent artifact is the goal).
 func zeroizeConfigDir(configDir, configBase string) error {
+	// #5684 defense-in-depth: refuse a shared/parent/system config root before
+	// any glob or RemoveAll. In production runZeroize already validates via
+	// (*Server).zeroizeConfigRoot before performZeroizeWipe reaches here, but
+	// this is the MORE destructive wipe primitive (it RemoveAll's <root>/tls and
+	// <root>/.configdb), so it re-validates itself — the same defense-in-depth the
+	// CLI's configstore.FactoryResetConfigDir applies. Fail CLOSED, removing
+	// NOTHING, rather than trust the caller not to hand it an unowned root.
+	if err := configstore.ValidateFactoryResetRoot(configDir); err != nil {
+		return err
+	}
+
 	var firstErr error
 	fail := func(err error) {
 		if err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {

--- a/pkg/grpcapi/zeroize_scope_5684_test.go
+++ b/pkg/grpcapi/zeroize_scope_5684_test.go
@@ -1,0 +1,63 @@
+package grpcapi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestZeroizeRefusesSharedConfigRoot pins the gRPC half of #5684: a `zeroize`
+// SystemAction whose configured config root resolves to a shared/parent/system
+// directory must FAIL CLOSED — surface an error and NEVER invoke the wipe — so a
+// custom/adversarial -config can't turn a factory reset into a broad deletion of
+// the enclosing directory. configDir is filepath.Dir(store.ConfigPath()); the
+// guard lives in (*Server).zeroizeConfigRoot, before runZeroize enters the
+// terminal reset generation or performZeroizeWipe touches any leg.
+//
+// The wipe primitive is stubbed to a capture (never touches real system paths),
+// and a throwaway directory is registered as a shared root via the
+// configstore.FactoryResetForbiddenRoots seam, so the test is hermetic and safe
+// on revert.
+//
+// RED on revert: drop the ValidateFactoryResetRoot guard in zeroizeConfigRoot
+// and the handler proceeds to call the (stubbed) wipe — `wiped` flips true and
+// the fail-closed error disappears, tripping both assertions.
+func TestZeroizeRefusesSharedConfigRoot(t *testing.T) {
+	origWipe := performZeroizeWipe
+	origStop := scheduleStopDaemon
+	t.Cleanup(func() {
+		performZeroizeWipe = origWipe
+		scheduleStopDaemon = origStop
+	})
+
+	var wiped bool
+	performZeroizeWipe = func(_, _ string) error { wiped = true; return nil }
+	scheduleStopDaemon = func() {}
+
+	// A config file placed directly in a shared directory: filepath.Dir resolves
+	// the config root to that shared directory (the #5684 footgun).
+	shared := filepath.Join(t.TempDir(), "shared")
+	if err := os.MkdirAll(shared, 0o700); err != nil {
+		t.Fatalf("mkdir shared: %v", err)
+	}
+	configPath := filepath.Join(shared, "xpf.conf")
+	store := newConfigStore(t, configPath)
+	s := &Server{store: store}
+
+	// Register the throwaway dir as a shared/system root for this test.
+	old := configstore.FactoryResetForbiddenRoots
+	configstore.FactoryResetForbiddenRoots = append(append([]string(nil), old...), filepath.Clean(shared))
+	t.Cleanup(func() { configstore.FactoryResetForbiddenRoots = old })
+
+	resp, err := s.SystemAction(context.Background(), &pb.SystemActionRequest{Action: "zeroize"})
+	if err == nil {
+		t.Fatalf("SystemAction(zeroize) with a shared config root must fail closed; got resp=%+v", resp)
+	}
+	if wiped {
+		t.Error("zeroize must NOT invoke the wipe when the config root is a shared/parent directory (fail-closed)")
+	}
+}

--- a/pkg/grpcapi/zeroize_scope_5684_test.go
+++ b/pkg/grpcapi/zeroize_scope_5684_test.go
@@ -61,3 +61,61 @@ func TestZeroizeRefusesSharedConfigRoot(t *testing.T) {
 		t.Error("zeroize must NOT invoke the wipe when the config root is a shared/parent directory (fail-closed)")
 	}
 }
+
+// TestZeroizeConfigDirRefusesSharedRoot pins the #5684 defense-in-depth guard on
+// the gRPC config-state wipe PRIMITIVE (zeroizeConfigDir) — the more destructive
+// one, since it RemoveAll's <root>/.configdb and <root>/tls. In production
+// runZeroize validates the root before performZeroizeWipe reaches this
+// primitive, but the primitive re-validates itself so it never trusts a caller
+// to have handed it an xpf-owned root (mirroring the CLI's FactoryResetConfigDir
+// guard). Fully hermetic: zeroizeConfigDir only ever touches configDir, so a
+// throwaway shared dir + the FactoryResetForbiddenRoots seam keeps even the RED
+// path from reaching a real system directory.
+//
+// RED on revert: remove the ValidateFactoryResetRoot guard at the top of
+// zeroizeConfigDir and every seeded artifact is deleted (*.conf glob,
+// isTextRollbackFile, RemoveAll .configdb + tls) — the "survives" assertions
+// fail and the "returns an error" check fails (the removals succeed → nil).
+func TestZeroizeConfigDirRefusesSharedRoot(t *testing.T) {
+	shared := filepath.Join(t.TempDir(), "shared")
+	if err := os.MkdirAll(filepath.Join(shared, ".configdb"), 0o700); err != nil {
+		t.Fatalf("mkdir shared/.configdb: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(shared, "tls"), 0o700); err != nil {
+		t.Fatalf("mkdir shared/tls: %v", err)
+	}
+	// Files a pre-fix broad wipe would have destroyed inside the shared dir.
+	seeded := map[string]string{
+		filepath.Join(shared, "neighbor.conf"):             "not xpf's config",
+		filepath.Join(shared, ".configdb", "foreign.json"): "someone else's DB",
+		filepath.Join(shared, "tls", "key.pem"):            "someone else's key",
+		filepath.Join(shared, "xpf.conf.1"):                "rollback-shaped bystander",
+		filepath.Join(shared, ".config.journal"):           "foreign journal",
+	}
+	for p, body := range seeded {
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+	}
+
+	// Register the throwaway dir as a shared/system root for this test.
+	old := configstore.FactoryResetForbiddenRoots
+	configstore.FactoryResetForbiddenRoots = append(append([]string(nil), old...), filepath.Clean(shared))
+	t.Cleanup(func() { configstore.FactoryResetForbiddenRoots = old })
+
+	if err := zeroizeConfigDir(shared, "xpf.conf"); err == nil {
+		t.Fatalf("zeroizeConfigDir(%q) = nil; want an error refusing to wipe a shared/parent directory", shared)
+	}
+
+	// Every seeded artifact must SURVIVE — the primitive touched nothing.
+	for p := range seeded {
+		if _, statErr := os.Stat(p); statErr != nil {
+			t.Errorf("zeroizeConfigDir removed %s from a shared directory it must not touch: %v", p, statErr)
+		}
+	}
+	for _, d := range []string{filepath.Join(shared, ".configdb"), filepath.Join(shared, "tls")} {
+		if _, statErr := os.Stat(d); statErr != nil {
+			t.Errorf("zeroizeConfigDir removed shared subdir %s: %v", d, statErr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **#5684** (codex-review-182 finding M33, High): a custom config path could turn `request system zeroize` (factory reset) into a **broad deletion of a shared or parent directory**.

The wipe target is the configured config root, resolved as `filepath.Dir(store.ConfigPath())` (#5280/#5554). A daemon started with a `-config` placed directly in a shared directory (`-config /etc/xpf.conf` → configDir `/etc`; `-config /srv/site.conf` → `/srv`) or pointed at a directory-shaped path (`-config /srv/firewall`, where `filepath.Dir` climbs to the **parent** `/srv`) resolved the root to a directory xpf does not own. Because the config-state sweep globs `*.conf` / `rollback*` and `RemoveAll`s `<root>/.configdb` and `<root>/tls`, an unowned root turned a factory reset into a broad deletion of sibling files in that shared/parent directory.

## Fix

- New `configstore.ValidateFactoryResetRoot` + `FactoryResetForbiddenRoots` — a lexical guard (on `filepath.Clean`) that **refuses** a config root that is non-absolute (relative/empty `-config` → daemon working directory) or equal to the filesystem root or a well-known shared/system directory (`/`, `/etc`, `/srv`, `/home`, `/var`, `/usr`, …). The default `/etc/xpf` and any dedicated subdirectory pass.
- Guard runs at **both resolution points** — `(*Server).zeroizeConfigRoot` (gRPC) and `(*CLI).zeroizeConfigRoot` (on-box CLI) — so a bad root **fails closed before any wipe leg runs**, erasing nothing and reporting the reset incomplete.
- Guard also runs inside the shared `FactoryResetConfigDir` primitive as **defense-in-depth**. Mirrors the existing `FactoryResetArchiveDir` ownership guard.

## Validation

- `go test ./pkg/configstore/... ./pkg/grpcapi/... ./pkg/cli/...` → GREEN; gofmt + `go vet` clean on touched files.
- **Fail-on-revert proven**: neutralizing `ValidateFactoryResetRoot` makes `TestValidateFactoryResetRoot` (15 rows), `TestFactoryResetConfigDirRefusesSharedParent`, and `TestZeroizeRefusesSharedConfigRoot` all RED; restored GREEN.
- Doc: `docs/system-login.md` "Config-root scope guard (#5684)".

Closes #5684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRqZAZ1vHkGoaQyXjHktqA