### PR TITLE
frr: AND route-filter with same-family from-prefix-list via access-list

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47491,3 +47491,24 @@ top.
   GREEN; gofmt clean on touched files. Fail-on-revert proven: neutralizing the
   new zeroizeConfigDir guard → TestZeroizeConfigDirRefusesSharedRoot RED
   (seeded siblings deleted, returns nil); restored GREEN.
+
+- **Timestamp**: 2026-07-12
+  **Action**: #5730 — fix on-family route-filter + same-family from-prefix-list
+  FRR match collision (route_map REPLACE silently dropped the route-filter
+  constraint). In renderPolicyTermSequences/emitTermBody, track whether this
+  sequence emitted a route-filter `match ip|ipv6 address prefix-list` line and
+  its family (rfMatchEmitted/rfMatchV6). When a from-prefix-list would emit a
+  SAME-family, same-type prefix-list match, render it instead as an FRR
+  ACCESS-LIST match (`match ip|ipv6 address <name>_rf`, exact-match) — a
+  distinct FRR rule type — so FRR ANDs the two constraints. Off-family (#5702)
+  coexistence is already a distinct type, left unchanged. New helper
+  renderFromPrefixListACL emits the access-list definition inline (same
+  established pattern as renderRouteFilterEntry). Updated the #5702 mixed-family
+  test whose belt assertion encoded the buggy on-family collision (V6ONLY as
+  prefix-list in both sequences → now access-list in the on-family v6 seq).
+  **File(s)**: pkg/frr/policy_render.go, pkg/frr/frr_test.go,
+  pkg/frr/policy_mixedfamily_prefixlist_5702_test.go
+  GREEN: `go test ./pkg/frr/...` passes; gofmt + go vet clean. Fail-on-revert
+  proven: neutralizing the collision branch (`if false && ...`) →
+  TestPolicyRouteFilterPrefixListSameFamilyNoCollision RED (two colliding
+  `match ipv6 address prefix-list` lines); restored GREEN.

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -6035,3 +6035,121 @@ func TestGenerateProtocols_ISISBFDInsideInterfaceBlock(t *testing.T) {
 		t.Errorf("`isis bfd` emitted AFTER the interface `exit` (#2942 regression) — lands in global scope; got:\n%s", got)
 	}
 }
+
+// TestPolicyRouteFilterPrefixListSameFamilyNoCollision locks the #5730 fix: a
+// policy term carrying BOTH an on-family route-filter AND a same-family
+// `from prefix-list` must render the two as DISTINCT FRR match rule types so
+// FRR ANDs them, not as two `match ipv6 address prefix-list` clauses (which
+// collide — FRR's route_map_add_match REPLACES a same-type rule and keeps only
+// the LAST, silently dropping the route-filter constraint and loosening
+// "(route-filter) AND (prefix-list)" to prefix-list-only).
+//
+// The fix renders the from-prefix-list as an ACCESS-LIST match
+// (`match ipv6 address <name>_rf`, a distinct FRR rule type from
+// `match ipv6 address prefix-list`). A v6 route in the prefix-list but OUTSIDE
+// the route-filter range therefore still fails the route-filter's prefix-list
+// clause and does NOT match the term.
+//
+// Fail-on-revert: neutralize the collision branch so the from-prefix-list
+// renders as a second `match ipv6 address prefix-list V6ONLY` — the
+// access-list match / definition assertions fail AND the "must NOT collide"
+// assertion fires.
+func TestPolicyRouteFilterPrefixListSameFamilyNoCollision(t *testing.T) {
+	m := New()
+	po := &config.PolicyOptionsConfig{
+		PrefixLists: map[string]*config.PrefixList{
+			"V6ONLY": {Name: "V6ONLY", Prefixes: []string{"2001:db8:ffff::/48"}},
+		},
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"MIX": {
+				Name: "MIX",
+				Terms: []*config.PolicyTerm{
+					{
+						Name:   "t1",
+						Action: "accept",
+						RouteFilters: []*config.RouteFilter{
+							{Prefix: "2001:db8::/32", MatchType: "orlonger"},
+						},
+						PrefixList: []string{"V6ONLY"},
+					},
+				},
+				DefaultAction: "reject",
+			},
+		},
+	}
+
+	got := m.generatePolicyOptions(po)
+
+	// The route-filter's prefix-list match line must still be present.
+	if !strings.Contains(got, "match ipv6 address prefix-list MIX-t1") {
+		t.Errorf("route-filter match line dropped; want %q in:\n%s",
+			"match ipv6 address prefix-list MIX-t1", got)
+	}
+	// The from-prefix-list must render as an ACCESS-LIST match (distinct FRR
+	// rule type) so FRR ANDs it with the route-filter's prefix-list match.
+	if !strings.Contains(got, "match ipv6 address V6ONLY_rf") {
+		t.Errorf("from-prefix-list not rendered as an access-list match; want %q in:\n%s",
+			"match ipv6 address V6ONLY_rf", got)
+	}
+	// Its access-list definition must be emitted (exact-match preserves the
+	// Junos `from prefix-list` exact semantics).
+	wantACL := "ipv6 access-list V6ONLY_rf seq 5 permit 2001:db8:ffff::/48 exact-match"
+	if !strings.Contains(got, wantACL) {
+		t.Errorf("missing access-list definition; want %q in:\n%s", wantACL, got)
+	}
+	// The COLLISION form must NOT appear: a second `match ipv6 address
+	// prefix-list` for the from-prefix-list would let FRR replace the
+	// route-filter clause (the #5730 bug).
+	if strings.Contains(got, "match ipv6 address prefix-list V6ONLY") {
+		t.Errorf("from-prefix-list collided as a second same-type prefix-list match (#5730 regression); got:\n%s", got)
+	}
+	// Exactly ONE `match ipv6 address prefix-list` line — the route-filter's.
+	if n := strings.Count(got, "match ipv6 address prefix-list "); n != 1 {
+		t.Errorf("expected exactly 1 `match ipv6 address prefix-list` line (the route-filter's), got %d:\n%s", n, got)
+	}
+}
+
+// TestPolicyRouteFilterPrefixListOffFamilyUnchanged guards that the #5730 fix
+// does NOT touch the #5702 off-family coexistence: a v4 route-filter co-resident
+// with a v6 `from prefix-list` are ALREADY distinct FRR rule types
+// (`match ip address prefix-list` vs `match ipv6 address prefix-list`), so the
+// from-prefix-list stays a prefix-list match (fail-closed AND — no v4 route can
+// satisfy a v6-only list), never an access-list.
+func TestPolicyRouteFilterPrefixListOffFamilyUnchanged(t *testing.T) {
+	m := New()
+	po := &config.PolicyOptionsConfig{
+		PrefixLists: map[string]*config.PrefixList{
+			"V6ONLY": {Name: "V6ONLY", Prefixes: []string{"2001:db8:ffff::/48"}},
+		},
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"OFF": {
+				Name: "OFF",
+				Terms: []*config.PolicyTerm{
+					{
+						Name:   "t1",
+						Action: "accept",
+						RouteFilters: []*config.RouteFilter{
+							{Prefix: "10.0.0.0/8", MatchType: "orlonger"},
+						},
+						PrefixList: []string{"V6ONLY"},
+					},
+				},
+				DefaultAction: "reject",
+			},
+		},
+	}
+
+	got := m.generatePolicyOptions(po)
+
+	if !strings.Contains(got, "match ip address prefix-list OFF-t1") {
+		t.Errorf("v4 route-filter match line missing; got:\n%s", got)
+	}
+	// Off-family from-prefix-list must remain a prefix-list match (#5702),
+	// NOT be converted to an access-list.
+	if !strings.Contains(got, "match ipv6 address prefix-list V6ONLY") {
+		t.Errorf("off-family from-prefix-list must stay a prefix-list match (#5702); got:\n%s", got)
+	}
+	if strings.Contains(got, "V6ONLY_rf") {
+		t.Errorf("off-family from-prefix-list must NOT be converted to an access-list; got:\n%s", got)
+	}
+}

--- a/pkg/frr/policy_mixedfamily_prefixlist_5702_test.go
+++ b/pkg/frr/policy_mixedfamily_prefixlist_5702_test.go
@@ -94,11 +94,32 @@ func TestMixedFamilyRouteFilterFromPrefixList_OffFamilyNonMatching_5702(t *testi
 			"routes; the predicate was dropped (pre-#5702 fail-open):\n%s", v4seq)
 	}
 
-	// Belt: the off-family match appears in BOTH sequences now (v4 AND-NOMATCH
-	// + v6 on-family), where pre-fix it appeared only in the v6 sequence.
-	if n := strings.Count(got, "match ipv6 address prefix-list V6ONLY\n"); n != 2 {
-		t.Errorf("expected the V6ONLY match in both split sequences (v4 AND-NOMATCH + "+
-			"v6), got %d occurrences:\n%s", n, got)
+	// #5730: the V6ONLY predicate ANDs into BOTH split sequences, but the
+	// ON-family (v6) sequence must render it as a DISTINCT FRR rule type
+	// (access-list), NOT a second `match ipv6 address prefix-list` — that would
+	// COLLIDE with the v6 route-filter's own prefix-list match (FRR's
+	// route_map_add_match REPLACES a same-type rule, keeping only the last, so
+	// the v6 route-filter constraint would be silently dropped). Therefore the
+	// prefix-list form of V6ONLY appears ONLY in the off-family v4 sequence
+	// (exactly once); the v6 sequence carries the access-list form.
+	if n := strings.Count(got, "match ipv6 address prefix-list V6ONLY\n"); n != 1 {
+		t.Errorf("expected the V6ONLY prefix-list match ONLY in the off-family v4 "+
+			"sequence (the on-family v6 sequence renders it as an access-list per "+
+			"#5730), got %d occurrences:\n%s", n, got)
+	}
+	// The v6 route-filter sequence ANDs V6ONLY as an access-list (#5730),
+	// coexisting with `match ipv6 address prefix-list MIX-t1_v6` as a distinct
+	// FRR rule type instead of colliding with it.
+	v6seq := routeMapSequenceContaining(got, "MIX", "match ipv6 address prefix-list MIX-t1_v6")
+	if v6seq == "" {
+		t.Fatalf("expected a v6 route-filter sequence in render:\n%s", got)
+	}
+	if !strings.Contains(v6seq, "match ipv6 address V6ONLY_rf\n") {
+		t.Fatalf("v6 sequence must AND the on-family V6ONLY predicate as an "+
+			"access-list (#5730), not a colliding same-type prefix-list match:\n%s", v6seq)
+	}
+	if !strings.Contains(got, "ipv6 access-list V6ONLY_rf seq 5 permit 2001:db8:aaaa::/48 exact-match\n") {
+		t.Fatalf("missing the #5730 access-list definition for the on-family V6ONLY predicate:\n%s", got)
 	}
 }
 

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -1501,6 +1501,47 @@ func renderRouteFilterEntry(b *strings.Builder, plName string, idx int, rf *conf
 	return true
 }
 
+// renderFromPrefixListACL writes an FRR access-list DEFINITION mirroring the
+// matchKW-family entries of Junos from-prefix-list pl into access-list aclName,
+// so the caller can reference it with a `match ip|ipv6 address <aclName>`
+// clause. It exists to break the #5730 collision: when one route-map sequence
+// carries BOTH a route-filter and a SAME-FAMILY `from prefix-list`, both would
+// otherwise render as `match ip|ipv6 address prefix-list`, and FRR's
+// route_map_add_match REPLACES a same-type rule (keeps the LAST) — silently
+// dropping the route-filter constraint and loosening "(route-filter) AND
+// (prefix-list)" to prefix-list-only (a fail-open policy-semantics change). An
+// access-list match is a DISTINCT FRR rule type (`route_match_ip_address`
+// vs `route_match_ip_address_prefix_list`), so FRR ANDs the two constraints
+// instead of replacing. Entries use `exact-match` to mirror Junos `from
+// prefix-list` (and the prefix-list renderer's bare-permit) exact semantics.
+// Only the matchKW-family entries are emitted, mirroring the single-family
+// match the prefix-list branch derives (a mixed v4+v6 list selects the IPv6
+// matcher — the same #2071 homogeneous-family limitation). An empty family set
+// (or nil list) emits NO definition: the undefined access-list then NOMATCHes
+// every route (fail-closed), matching an undefined prefix-list. The prefix is
+// sanitized as a #4482-style belt against a leniently-loaded stored value.
+// Mirrors renderRouteFilterEntry's inline-definition style: the unindented
+// `access-list` line is emitted into the route-map body builder and processed
+// by FRR at the config node, exactly like the route-filter prefix-lists.
+func renderFromPrefixListACL(b *strings.Builder, aclName, matchKW string, pl *config.PrefixList) {
+	if pl == nil {
+		return
+	}
+	v6 := matchKW == "ipv6"
+	seqn := 5
+	for _, prefix := range pl.Prefixes {
+		if strings.Contains(prefix, ":") != v6 {
+			continue
+		}
+		if v6 {
+			fmt.Fprintf(b, "ipv6 access-list %s seq %d permit %s exact-match\n", aclName, seqn, sanitizeFRRValue(prefix))
+		} else {
+			fmt.Fprintf(b, "access-list %s seq %d permit %s exact-match\n", aclName, seqn, sanitizeFRRValue(prefix))
+		}
+		seqn += 5
+	}
+}
+
 // indexedRouteFilter carries a route-filter together with its ORIGINAL
 // index in the term's route-filter slice so the FRR prefix-list entry
 // seq slot ((idx+1)*5) stays stable when the slice is partitioned by
@@ -1884,6 +1925,15 @@ func (m *Manager) renderPolicyTermSequences(po *config.PolicyOptionsConfig, rout
 		emitTermBody := func(seqFam string, seqNum int, rfs []indexedRouteFilter, plName, fromPrefixList, fromCommunity, fromASPath string) {
 			fmt.Fprintf(&b, "route-map %s %s %d\n", routeMapName, action, seqNum)
 
+			// rfMatchEmitted / rfMatchV6 record whether THIS sequence emitted a
+			// route-filter "match ip|ipv6 address prefix-list" line and its
+			// family, so the from-prefix-list branch below can detect a
+			// same-family, same-type collision (#5730) and render the
+			// from-prefix-list as a DISTINCT-type access-list match instead of a
+			// second (colliding) prefix-list match.
+			rfMatchEmitted := false
+			rfMatchV6 := false
+
 			// Inline prefix-list for this sequence's route-filters.
 			if len(term.RouteFilters) > 0 {
 				// matchV6 selects the address family of the
@@ -1935,6 +1985,8 @@ func (m *Manager) renderPolicyTermSequences(po *config.PolicyOptionsConfig, rout
 				} else {
 					fmt.Fprintf(&b, " match ip address prefix-list %s\n", plName)
 				}
+				rfMatchEmitted = true
+				rfMatchV6 = matchV6
 			}
 
 			if fromPrefixList != "" {
@@ -1980,16 +2032,34 @@ func (m *Manager) renderPolicyTermSequences(po *config.PolicyOptionsConfig, rout
 				// last. OR is therefore expressed by one route-map SEQUENCE
 				// per entry (the dispatch loop below), each carrying the full
 				// term body — exactly the #2607 split structure.
+				fromPL := po.PrefixLists[fromPrefixList]
 				matchKW := "ip"
-				if pl := po.PrefixLists[fromPrefixList]; pl != nil {
-					for _, p := range pl.Prefixes {
+				if fromPL != nil {
+					for _, p := range fromPL.Prefixes {
 						if strings.Contains(p, ":") {
 							matchKW = "ipv6"
 							break
 						}
 					}
 				}
-				fmt.Fprintf(&b, " match %s address prefix-list %s\n", matchKW, fromPrefixList)
+				// #5730: when THIS sequence ALSO emitted a same-family
+				// route-filter "match ip|ipv6 address prefix-list" line, a
+				// second same-type "match ... prefix-list" for the
+				// from-prefix-list COLLIDES — FRR's route_map_add_match REPLACES
+				// a same-type rule (keeps the LAST), silently dropping the
+				// route-filter constraint and loosening "(route-filter) AND
+				// (prefix-list)" to prefix-list-only. Render the from-prefix-list
+				// as an ACCESS-LIST match — a DISTINCT FRR rule type — so FRR
+				// ANDs the two constraints. A DIFFERENT-family route-filter (the
+				// #5702 off-family fail-closed coexistence) is already a distinct
+				// FRR type, so it keeps the prefix-list match unchanged.
+				if rfMatchEmitted && rfMatchV6 == (matchKW == "ipv6") {
+					aclName := fromPrefixList + "_rf"
+					renderFromPrefixListACL(&b, aclName, matchKW, fromPL)
+					fmt.Fprintf(&b, " match %s address %s\n", matchKW, aclName)
+				} else {
+					fmt.Fprintf(&b, " match %s address prefix-list %s\n", matchKW, fromPrefixList)
+				}
 			}
 
 			// Junos "from protocol [ bgp ospf static ]" matches ANY listed


### PR DESCRIPTION
## Problem (#5730)

A policy term carrying BOTH a `from route-filter` and a **same-family** `from prefix-list` rendered two `match ip|ipv6 address prefix-list` clauses in one route-map sequence:

```
route-map MIX permit 10
 match ipv6 address prefix-list MIX-t1     <- the route-filter
 match ipv6 address prefix-list V6ONLY     <- the from-prefix-list
```

FRR's `route_map_add_match` **REPLACES** a same-type match rule (keeps the LAST), so the route-filter clause was silently dropped — the term matched iff the route was in `V6ONLY`, **regardless of the route-filter range**. This loosened the intended `(route-filter) AND (prefix-list)` intersection to prefix-list-only (a fail-open policy-semantics change). It fires on non-split single-family terms **and** on the on-family half of a #2607 mixed-family split, and is distinct from #5702 (the OFF-family fail-open).

## Fix

In `renderPolicyTermSequences`/`emitTermBody`, track whether this sequence emitted a route-filter `match ip|ipv6 address prefix-list` line and its family (`rfMatchEmitted`/`rfMatchV6`). When a from-prefix-list would emit a **same-family, same-type** prefix-list match, render it instead as an FRR **access-list** match:

```
route-map MIX permit 10
 match ipv6 address prefix-list MIX-t1     <- route-filter (kept)
ipv6 access-list V6ONLY_rf seq 5 permit 2001:db8:ffff::/48 exact-match
 match ipv6 address V6ONLY_rf              <- from-prefix-list, DISTINCT rule type
```

`route_match_ip_address` (access-list) and `route_match_ip_address_prefix_list` are **distinct** FRR rule types, so FRR **ANDs** them instead of replacing. Access-list entries use `exact-match` to preserve Junos `from prefix-list` exact semantics. An empty/undefined list emits no definition and NOMATCHes every route (fail-closed), same as an undefined prefix-list. A **different-family** route-filter (the #5702 off-family coexistence) is already a distinct FRR type, so it keeps the prefix-list match unchanged.

The new `renderFromPrefixListACL` helper emits the access-list definition inline, using the same config-node-processed pattern `renderRouteFilterEntry` already uses for route-filter prefix-lists.

## Validation

- `TestPolicyRouteFilterPrefixListSameFamilyNoCollision` — both constraints render as distinct match types; the collision form is absent. **Fail-on-revert proven**: neutralizing the collision branch reintroduces two colliding `match ipv6 address prefix-list` lines → RED.
- `TestPolicyRouteFilterPrefixListOffFamilyUnchanged` — off-family (#5702) coexistence stays a prefix-list match, never converted.
- Updated the #5702 mixed-family test whose belt assertion had encoded the buggy on-family collision (V6ONLY as a prefix-list in *both* sequences → now access-list in the on-family v6 sequence; the #5702 off-family guarantee is preserved).
- `go test ./pkg/frr/...` GREEN; `gofmt` + `go vet` clean.

Closes #5730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8m12eKKrqe9i1fKh7fFE2