### PR TITLE
daemon: fail commit on route-leak snapshot reconcile failure (#5696)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47512,3 +47512,28 @@ top.
   proven: neutralizing the collision branch (`if false && ...`) →
   TestPolicyRouteFilterPrefixListSameFamilyNoCollision RED (two colliding
   `match ipv6 address prefix-list` lines); restored GREEN.
+
+- **Timestamp**: 2026-07-12
+  **Action**: #5696 (M19, a #5642 residual) — fail the commit closed on a
+  route-leak snapshot republish / FIB-invalidation failure instead of logging
+  and forgetting it. `reconcileRouteLeakSnapshot` (the commit-tail routes-only
+  republish that clears a deleted-VRF inter-VRF leak after `applyRoutingRules`,
+  #5642) was VOID and swallowed BOTH failure legs at WARN — a transient
+  `PublishRouteOverlaySnapshot` OR `BumpFIBGeneration` failure only logged and
+  returned, so the commit reported SUCCESS while the userspace FIB kept the
+  exact stale leak #5642 removed. Unlike the ip-monitoring actuator (#3757
+  dirty-retry engine) this commit-tail path has no owner to rediscover a
+  swallowed failure. It now RETURNS an error; `applyConfigLocked` captures it
+  (`routeLeakErr`) and threads it into `applyTailReconciles`' tail
+  `errors.Join(..., ifaceErr, routeLeakErr)` (the #5679/#5310 fail-closed-but-
+  complete pattern). Benign no-ops (helperless, duplicate-skip) return nil and
+  keep the commit successful. Updated the two existing `applyTailReconciles`
+  test call sites for the new param.
+  **File(s)**: pkg/daemon/daemon_apply.go, pkg/daemon/README.md,
+  pkg/daemon/route_leak_snapshot_failclosed_5696_test.go,
+  pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go,
+  pkg/daemon/device_map_teardown_failclosed_5309_test.go
+  GREEN: `go test ./pkg/daemon/...` passes; gofmt + build clean. Fail-on-revert
+  proven: neutralizing both failure legs (`return nil`) →
+  TestRouteLeakReconcileFailsCommitOnPublishError and ...OnBumpError RED
+  (returns nil on injected failure); restored GREEN.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -522,6 +522,27 @@ never lock an operator out of a remote box it manages.
   `apply_failure_failclosed_5679_test.go` (ordinary-apply-fails-commit +
   wraps-injected + does-not-skip-peer-sync fail-on-revert, plus the abort-class
   still-early-returns + still-skips-peer-sync guard against over-reach).
+  **Route-leak snapshot reconcile fail-closed (#5696, a #5642 residual):**
+  `reconcileRouteLeakSnapshot` republishes the routes-only userspace snapshot after
+  `applyRoutingRules` reconciles the kernel ip-rule table on a rib-group / next-table
+  transition, so the userspace FIB does not keep a deleted-VRF inter-VRF leak that
+  the earlier full apply published from the PRE-reconcile rules (#5642). But it was
+  VOID and swallowed BOTH its failure legs at WARN — a transient
+  `PublishRouteOverlaySnapshot` failure OR a `BumpFIBGeneration` failure only logged
+  and returned, so the commit reported SUCCESS while the userspace FIB retained the
+  exact stale leak #5642 removed. Unlike the ip-monitoring actuator (`daemon_ipmon.go`,
+  #3757 dirty-retry), this commit-tail reconcile has NO retry engine to rediscover a
+  swallowed failure — it is logged-and-forgotten. It now RETURNS an `error`;
+  `applyConfigLocked` captures it (`routeLeakErr`) and threads it into the tail
+  `errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr,
+  ifaceErr, routeLeakErr)`, so a genuine republish/FIB-bump failure fails the commit
+  closed (the OLD pre-reconcile snapshot stays live; a re-commit re-runs the
+  reconcile). Benign no-ops — helperless dataplane, or a duplicate-skip because the
+  route set did not move — return `nil` and keep the commit successful (no FIB-bump
+  churn). Tests: `route_leak_snapshot_failclosed_5696_test.go`
+  (publish-fails-commit + bump-fails-commit fail-on-revert, duplicate-skip /
+  helperless / clean-success stay-success, and the `applyTailReconciles` commit-join
+  wiring proof).
   **Per-term disposition mirrors userspace (#3427):** `nftRulesFromTerm` maps a
   term's `then` action to the kernel verdict the SAME way the userspace lo0
   evaluator does (`pkg/dataplane/userspace/filters.go` `NextTerm =

--- a/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
+++ b/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
@@ -247,7 +247,7 @@ func TestApplyTailReconcilesSurfacesInterfaceReconcileError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: interface reconcile (xfrmi create) failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the interface-reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -782,8 +782,11 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// ApplyConfig already published is stale. Rebuild + republish the routes-only
 	// snapshot against the now-reconciled kernel rules so the userspace FIB does
 	// not retain a deleted-VRF inter-VRF leak. A no-op (content-hash duplicate
-	// skip) when the route set did not move.
-	d.reconcileRouteLeakSnapshot(cfg, commitOverlay)
+	// skip) when the route set did not move. #5696 (M19): a genuine republish /
+	// FIB-bump failure is a DEFERRED error threaded into the tail errors.Join —
+	// this reconcile has no dirty-retry owner, so a swallowed failure would keep
+	// the stale leak on a "successful" commit.
+	routeLeakErr := d.reconcileRouteLeakSnapshot(cfg, commitOverlay)
 
 	ipsecErr, dhcpServerErr := d.applyServicesReconcile(cfg)
 
@@ -800,9 +803,10 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// behavior-preserving mechanical move. The five head-produced deferred
 	// errors (networkdErr/applyErr/dhcpServerErr/ipsecErr/ifaceErr) are threaded
 	// in — applyErr is the #5679 ordinary (non-abort) dataplane-apply failure
-	// that must fail the commit without disarming/aborting; the helper creates
-	// lo0Err/hostInboundErr and returns the seven-way errors.Join.
-	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr)
+	// that must fail the commit without disarming/aborting; routeLeakErr is the
+	// #5696 route-leak republish/FIB-bump failure; the helper creates
+	// lo0Err/hostInboundErr and returns the joined errors.
+	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr)
 }
 
 // applyDataplaneAndHACore runs the ordering-entangled dataplane-apply and
@@ -1515,37 +1519,59 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 // rib-group publish nothing and churn nothing. A nil scheduler-state argument
 // keeps the manager's current policy-scheduler view (the one the full apply just
 // published) so the unchanged-content hash matches and the skip fires.
-func (d *Daemon) reconcileRouteLeakSnapshot(cfg *config.Config, overlay []config.RouteOverlayEntry) {
+//
+// #5696 (M19, a #5642 residual): a genuine route-publication or FIB-invalidation
+// failure returns a DEFERRED error the caller joins into the tail commit-error
+// (fail-closed but complete). This commit-tail reconcile has no dirty-retry
+// engine, so swallowing the failure would leave the userspace FIB with a stale
+// inter-VRF leak — the exact bug #5642 fixed — while reporting a successful
+// commit. Benign no-ops (helperless, duplicate-skip) return nil.
+func (d *Daemon) reconcileRouteLeakSnapshot(cfg *config.Config, overlay []config.RouteOverlayEntry) error {
 	if cfg == nil {
-		return
+		return nil
 	}
 	pub, ok := d.dp.(routeOverlayPublisher)
 	if !ok {
 		// Helperless (no userspace dataplane publisher): the kernel ip-rule
 		// reconcile above is the only route-leak consumer and it already ran.
-		return
+		return nil
 	}
 	published, err := pub.PublishRouteOverlaySnapshot(cfg, overlay, nil)
 	if err != nil {
+		// #5696 (M19): surface the publish failure as a deferred commit error
+		// instead of swallowing it. This commit-tail reconcile has no dirty-retry
+		// engine (unlike the ip-monitoring actuator), so a swallowed failure would
+		// silently reinstate the exact stale inter-VRF leak #5642 removed while the
+		// commit reports success. The caller joins this into the tail errors.Join
+		// so the commit fails CLOSED — the OLD pre-reconcile snapshot stays live
+		// and a re-commit re-runs the reconcile (#5679/#5310 fail-closed pattern).
 		slog.Warn("route-leak snapshot reconcile: routes-only republish failed; the "+
 			"userspace FIB may retain a stale inter-VRF leak until the next apply",
 			"err", err)
-		return
+		return fmt.Errorf("route-leak snapshot republish: %w", err)
 	}
 	if !published {
 		// Duplicate-skip (route set unchanged) or no published snapshot yet /
 		// helper not running: nothing moved, so do not bump the FIB generation
-		// (would needlessly churn established-flow route caches).
-		return
+		// (would needlessly churn established-flow route caches). Benign no-op —
+		// stays a successful commit.
+		return nil
 	}
 	// Ordering (mirrors the ip-monitoring actuator, #1827 AGY r2-1): bump the
 	// FIB generation ONLY after a real publish so established flows re-resolve
 	// onto the reconciled routes; bumping before/without a publish would leave
 	// flows pinned to the stale leak route.
 	if _, err := pub.BumpFIBGeneration(); err != nil {
+		// #5696 (M19): the leak-free routes ARE on the wire (publish succeeded),
+		// but the FIB generation was not bumped — established flows stay pinned to
+		// the stale leak route. With no retry owner for this commit-tail path a
+		// swallowed bump leaves that inconsistency unrediscovered; fail the commit
+		// closed so a re-commit re-runs the reconcile.
 		slog.Warn("route-leak snapshot reconcile: FIB generation bump unconfirmed after "+
 			"republish; established flows may re-resolve on a later sweep", "err", err)
+		return fmt.Errorf("route-leak snapshot FIB generation bump: %w", err)
 	}
+	return nil
 }
 
 // applyFabricIPVLAN creates the fabric-member IPVLAN overlays (fab0/fab1) for
@@ -1861,10 +1887,12 @@ func (d *Daemon) applyInterfaceReconcile(cfg *config.Config) error {
 // still runs). networkdErr/applyErr/dhcpServerErr/ipsecErr/ifaceErr originate in
 // the head and are threaded in as parameters (applyErr is the #5679 ordinary
 // non-abort dataplane-apply failure that must fail the commit while the OLD
-// policy stays live); lo0Err/hostInboundErr originate in step 9.5 below. The
-// returned errors.Join preserves the exact operand order the inline tail used
-// (#1778/#2987/#4433/#5310/#5679).
-func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr error) error {
+// policy stays live); routeLeakErr is the #5696 route-leak snapshot
+// republish/FIB-bump failure (also head-produced, threaded in like ifaceErr);
+// lo0Err/hostInboundErr originate in step 9.5 below. The returned errors.Join
+// preserves the exact operand order the inline tail used
+// (#1778/#2987/#4433/#5310/#5679/#5696).
+func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr error) error {
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	vrrpInstances := vrrp.CollectInstances(cfg)
 	if d.cluster != nil {
@@ -2124,16 +2152,18 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 		d.applyStep0Tunables(userspaceDP, claimHostTunables, governor, netdevBudget,
 			coalesceExplicit, coalesceEnable, coalesceRX, coalesceTX, rssAllowed)
 	}
-	// #1778 + #2987 + #4433 + #5310 + #5679: deferred reconcile failures — every
-	// reconcile step above has run; surface the networkd write failure, the
+	// #1778 + #2987 + #4433 + #5310 + #5679 + #5696: deferred reconcile failures —
+	// every reconcile step above has run; surface the networkd write failure, the
 	// ordinary (non-abort) dataplane-apply failure (#5679 — the new policy is
 	// NOT on the wire, the old one still is), the Kea restart/stop failure, the
-	// IPsec render/reload failure, and the interface-reconcile failure
-	// (xfrmi/bond/tunnel/legacy-reth create/up/delete — #5310) through the commit
-	// so a step that left stale or missing kernel/swanctl/dataplane state fails
-	// the commit (fail-closed) instead of reporting success. All are joined so
-	// none masks the other.
-	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr)
+	// IPsec render/reload failure, the interface-reconcile failure
+	// (xfrmi/bond/tunnel/legacy-reth create/up/delete — #5310), and the route-leak
+	// snapshot republish/FIB-bump failure (#5696 — a stale inter-VRF leak would
+	// otherwise survive on a "successful" commit) through the commit so a step
+	// that left stale or missing kernel/swanctl/dataplane state fails the commit
+	// (fail-closed) instead of reporting success. All are joined so none masks the
+	// other.
+	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr, routeLeakErr)
 }
 
 // compileErrorMustAbortApply reports whether a dataplane ApplyConfig error

--- a/pkg/daemon/device_map_teardown_failclosed_5309_test.go
+++ b/pkg/daemon/device_map_teardown_failclosed_5309_test.go
@@ -262,7 +262,7 @@ func TestApplyTailReconcilesSurfacesDeviceMapTeardownError_5309(t *testing.T) {
 
 	teardownErr := fmt.Errorf("device-map teardown: %w",
 		errors.New("rename-back ge-0-0-9 -> enp99s0: EBUSY"))
-	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface a device-map teardown failure carried " +
 			"in networkdErr (fail-closed); got nil")

--- a/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
+++ b/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
@@ -1,0 +1,157 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// #5696 (M19, a #5642 residual): reconcileRouteLeakSnapshot is a commit-tail
+// reconcile with NO dirty-retry engine (unlike the ip-monitoring actuator).
+// A route-publication or FIB-invalidation failure MUST fail the commit closed —
+// a deferred error threaded into applyTailReconciles' tail errors.Join — rather
+// than be logged-and-forgotten. Otherwise the userspace FIB keeps the exact
+// stale inter-VRF leak #5642 removed while the commit reports success, with no
+// owner to rediscover the inconsistency. Benign no-ops (duplicate-skip,
+// helperless, clean success) stay successful commits.
+//
+// These tests reuse the fakeOverlayDP publish surface from daemon_ipmon_test.go.
+
+// TestRouteLeakReconcileFailsCommitOnPublishError: a transient routes-only
+// republish failure surfaces as a non-nil deferred error that wraps the cause.
+//
+// FAIL-ON-REVERT: revert the publish leg back to a bare `return` (swallowing the
+// error) and reconcileRouteLeakSnapshot returns nil — this test goes RED. That
+// is the exact "logged and forgotten" fail-open the issue describes.
+func TestRouteLeakReconcileFailsCommitOnPublishError(t *testing.T) {
+	sentinel := errors.New("apply_snapshot socket timeout")
+	dp := &fakeOverlayDP{publishErr: sentinel}
+	d := &Daemon{dp: dp}
+
+	err := d.reconcileRouteLeakSnapshot(&config.Config{}, nil)
+	if err == nil {
+		t.Fatal("route-leak republish failure must fail the commit (deferred error); got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("returned error must wrap the publish failure; got %v", err)
+	}
+	// Publish failed → the helper does not have the new routes, so no bump.
+	for _, c := range dp.calls {
+		if c == "bump" {
+			t.Fatalf("calls = %v: bumped FIB generation after a failed publish", dp.calls)
+		}
+	}
+}
+
+// TestRouteLeakReconcileFailsCommitOnBumpError: the publish succeeds (route set
+// moved) but the FIB-generation invalidation fails, so established flows stay
+// pinned to the stale leak route — the commit must still fail closed.
+//
+// FAIL-ON-REVERT: revert the bump leg back to a bare warn (no error return) and
+// this test goes RED.
+func TestRouteLeakReconcileFailsCommitOnBumpError(t *testing.T) {
+	sentinel := errors.New("bump_fib_generation control socket timeout")
+	dp := &fakeOverlayDP{bumpErr: sentinel}
+	d := &Daemon{dp: dp}
+
+	err := d.reconcileRouteLeakSnapshot(&config.Config{}, nil)
+	if err == nil {
+		t.Fatal("route-leak FIB-bump failure must fail the commit (deferred error); got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("returned error must wrap the bump failure; got %v", err)
+	}
+	if len(dp.calls) != 2 || dp.calls[0] != "publish" || dp.calls[1] != "bump" {
+		t.Fatalf("calls = %v, want [publish bump]", dp.calls)
+	}
+}
+
+// TestRouteLeakReconcileDuplicateSkipStaysSuccess: an unchanged route set
+// (PublishRouteOverlaySnapshot duplicate-skip → published=false) is a benign
+// no-op — nil error, and no FIB-generation bump churn.
+func TestRouteLeakReconcileDuplicateSkipStaysSuccess(t *testing.T) {
+	dp := &fakeOverlayDP{publishSkipped: true}
+	d := &Daemon{dp: dp}
+
+	if err := d.reconcileRouteLeakSnapshot(&config.Config{}, nil); err != nil {
+		t.Fatalf("duplicate-skip must stay a successful commit; got %v", err)
+	}
+	for _, c := range dp.calls {
+		if c == "bump" {
+			t.Fatalf("calls = %v: bumped FIB generation on a duplicate-skip", dp.calls)
+		}
+	}
+}
+
+// TestRouteLeakReconcileSuccessStaysSuccess: a real publish followed by a
+// confirmed bump is a clean, successful commit.
+func TestRouteLeakReconcileSuccessStaysSuccess(t *testing.T) {
+	dp := &fakeOverlayDP{}
+	d := &Daemon{dp: dp}
+
+	if err := d.reconcileRouteLeakSnapshot(&config.Config{}, nil); err != nil {
+		t.Fatalf("clean republish+bump must be a successful commit; got %v", err)
+	}
+	if len(dp.calls) != 2 || dp.calls[0] != "publish" || dp.calls[1] != "bump" {
+		t.Fatalf("calls = %v, want [publish bump]", dp.calls)
+	}
+}
+
+// TestRouteLeakReconcileHelperlessStaysSuccess: with no routeOverlayPublisher
+// (helperless dataplane) the kernel ip-rule reconcile is the only route-leak
+// consumer and already ran — a benign no-op that keeps the commit successful.
+func TestRouteLeakReconcileHelperlessStaysSuccess(t *testing.T) {
+	d := &Daemon{} // d.dp is nil → not a routeOverlayPublisher
+	if err := d.reconcileRouteLeakSnapshot(&config.Config{}, nil); err != nil {
+		t.Fatalf("helperless reconcile must stay a successful commit; got %v", err)
+	}
+}
+
+// TestApplyTailReconcilesSurfacesRouteLeakError is the commit-level wiring proof
+// (#5696): it drives the REAL applyTailReconciles with an injected route-leak
+// error in the routeLeakErr slot and asserts the returned commit error includes
+// it via the tail errors.Join.
+//
+// FAIL-ON-REVERT: drop routeLeakErr from that join (or from the parameter list)
+// and this test goes RED — the apply completes and returns nil despite the
+// route-leak reconcile having failed. The nft seams are stubbed to succeed so
+// the injected routeLeakErr is the ONLY operand that can surface.
+func TestApplyTailReconcilesSurfacesRouteLeakError(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
+
+	d := &Daemon{
+		dp:       &runtimeOnlyApplyTestDP{},
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+
+	injected := errors.New("injected: route-leak snapshot republish failed")
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, injected)
+	if err == nil {
+		t.Fatal("applyTailReconciles must surface the route-leak reconcile failure " +
+			"(fail-closed); got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned commit error must include the route-leak failure via the "+
+			"tail errors.Join wiring, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (#5696 / codex-review-182 M19, a #5642 residual)

`reconcileRouteLeakSnapshot` (added by #5642) republishes the routes-only userspace snapshot after `applyRoutingRules` reconciles the kernel ip-rule table on a rib-group / next-table transition, so the userspace FIB does not retain a deleted-VRF **inter-VRF leak** that the earlier full apply published from the pre-reconcile rules.

But the reconcile was **VOID** and swallowed **both** of its failure legs at `WARN`:
- a transient `PublishRouteOverlaySnapshot` failure only logged and returned;
- a `BumpFIBGeneration` failure (publish succeeded, invalidation did not) only logged and returned.

So the commit reported **SUCCESS** while the userspace FIB kept the exact stale inter-VRF leak #5642 removed — with **no completion-debt owner** to rediscover it. Unlike the ip-monitoring actuator (`daemon_ipmon.go`, #3757 dirty-retry engine), this commit-tail reconcile has no retry sweep: the failure is logged-and-forgotten.

## Fix (fail-closed but complete — the #5679/#5310 pattern)

`reconcileRouteLeakSnapshot` now **returns an `error`**. `applyConfigLocked` captures it (`routeLeakErr`) and threads it into `applyTailReconciles`' tail `errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr, routeLeakErr)`, so a genuine republish/FIB-bump failure **fails the commit closed** while every other reconcile step still runs. The OLD pre-reconcile snapshot stays live and a re-commit re-runs the reconcile.

**Benign no-ops preserved:** a helperless dataplane, or a duplicate-skip because the route set did not move, return `nil` and keep the commit successful with no FIB-bump churn.

Swallowed-failure site: `pkg/daemon/daemon_apply.go` — `reconcileRouteLeakSnapshot` publish leg (was line ~1529) and FIB-bump leg (was line ~1545).

## Tests / fail-on-revert

`pkg/daemon/route_leak_snapshot_failclosed_5696_test.go`:
- `TestRouteLeakReconcileFailsCommitOnPublishError` / `...OnBumpError` — injected failure ⇒ non-nil deferred error (wraps the cause). **RED** when both legs are neutralized to `return nil`; **GREEN** restored.
- duplicate-skip / helperless / clean-success ⇒ stay `nil` (successful commit).
- `TestApplyTailReconcilesSurfacesRouteLeakError` — end-to-end commit-join wiring proof.

`go test ./pkg/daemon/...` GREEN; gofmt + go vet clean. Updated the two existing `applyTailReconciles` test call sites for the new parameter.

Closes #5696

🤖 Generated with [Claude Code](https://claude.com/claude-code)