### PR TITLE
userspace: retain failed stale-binding clears in retry inventory

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47537,3 +47537,29 @@ top.
   proven: neutralizing both failure legs (`return nil`) →
   TestRouteLeakReconcileFailsCommitOnPublishError and ...OnBumpError RED
   (returns nil on injected failure); restored GREEN.
+
+- **Timestamp**: 2026-07-12
+  **Action**: #5697 (codex-review-182 M20) — failed stale-binding clears no
+  longer lose the retry inventory. In `applyHelperStatusLocked` the stale
+  userspace_bindings clear discarded the `bindingsMap.Update` result
+  (`_ = ...`) and unconditionally overwrote `m.lastBindingIndices` with only
+  the live bindings, so a clear that FAILED dropped the stale row from the
+  retry inventory — the clear loop only rescans indices in
+  `m.lastBindingIndices`, so the stranded row was never rediscovered and the
+  XDP shim kept steering transit to a slot no longer backed by a live worker.
+  Extracted the clear into `clearStaleBindingRowsLocked`, which RETAINS an idx
+  whose zeroing Update fails (logs slog.Warn, re-adds it to the returned
+  inventory) so a later status pass re-attempts the clear; a successful clear
+  drops the row. Pure refactor of one loop — no operator-facing behavior
+  change beyond the repair-loop now converging, so no operator/state/design
+  doc update needed.
+  **File(s)**: pkg/dataplane/userspace/maps_sync.go,
+  pkg/dataplane/userspace/maps_sync_stale_binding_retry_5697_test.go
+  GREEN: new unit tests pass (run as root for BPF map privileges); gofmt +
+  `go build ./...` clean. Fail-on-revert proven: neutralizing the fix
+  (`_ = bindingsMap.Update(...)`, drop on failure) →
+  TestClearStaleBindingRowsRetainsFailedClearInRetryInventory RED
+  ("retry inventory [] missing failed-clear idx 99"); restored GREEN.
+  Pre-existing env failures in the package (applyHelperStatus map-not-loaded,
+  XDP-program RX-liveness tests) reproduce identically on pristine
+  origin/master cd3ae8973 — not introduced by this change.

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -757,16 +757,7 @@ ctrlReady:
 			}
 		}
 	}
-	{
-		var zeroBinding userspaceBindingValue
-		for _, idx := range m.lastBindingIndices {
-			if _, keep := newBindingIndexSet[idx]; keep {
-				continue
-			}
-			_ = bindingsMap.Update(idx, zeroBinding, ebpf.UpdateAny)
-		}
-		m.lastBindingIndices = newBindingIndices
-	}
+	m.lastBindingIndices = m.clearStaleBindingRowsLocked(bindingsMap, newBindingIndices, newBindingIndexSet)
 	if err := m.syncIngressIfaceMapLocked(m.lastSnapshot); err != nil {
 		return m.failClosedUserspaceCtrlLocked(ctrlMap, ctrl, err)
 	}
@@ -790,6 +781,38 @@ ctrlReady:
 
 	m.recordHelperStatusLocked(status)
 	return nil
+}
+
+// clearStaleBindingRowsLocked zeroes userspace_bindings rows that were live on
+// the previous status pass (recorded in m.lastBindingIndices) but are absent
+// from the current pass (newBindingIndexSet). It returns the retry inventory
+// to store back into m.lastBindingIndices.
+//
+// A row whose zeroing Update FAILS is RETAINED in the returned inventory so a
+// later status pass re-attempts the clear (#5697, codex-review-182 M20). The
+// clear loop only rescans indices recorded in m.lastBindingIndices, so if a
+// failed clear dropped the row from the inventory it would never be
+// rediscovered — the stale row would persist in the BPF map indefinitely and
+// the XDP shim would keep steering transit to a slot no longer backed by a
+// live worker. A successful clear removes the row from the inventory (it is
+// not in newBindingIndexSet, so it is not carried forward).
+func (m *Manager) clearStaleBindingRowsLocked(bindingsMap *ebpf.Map, newBindingIndices []uint32, newBindingIndexSet map[uint32]struct{}) []uint32 {
+	var zeroBinding userspaceBindingValue
+	for _, idx := range m.lastBindingIndices {
+		if _, keep := newBindingIndexSet[idx]; keep {
+			continue
+		}
+		if err := bindingsMap.Update(idx, zeroBinding, ebpf.UpdateAny); err != nil {
+			slog.Warn("userspace: failed to clear stale binding entry; retaining in retry inventory",
+				"idx", idx, "err", err)
+			if _, seen := newBindingIndexSet[idx]; !seen {
+				newBindingIndexSet[idx] = struct{}{}
+				newBindingIndices = append(newBindingIndices, idx)
+			}
+			continue
+		}
+	}
+	return newBindingIndices
 }
 
 // userspaceCounterSnapshot holds cumulative counter totals from the helper,

--- a/pkg/dataplane/userspace/maps_sync_stale_binding_retry_5697_test.go
+++ b/pkg/dataplane/userspace/maps_sync_stale_binding_retry_5697_test.go
@@ -1,0 +1,133 @@
+package userspace
+
+import (
+	"slices"
+	"testing"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+// TestClearStaleBindingRowsRetainsFailedClearInRetryInventory exercises the
+// #5697 (codex-review-182 M20) fix: a stale userspace_bindings row whose
+// zeroing Update FAILS must be RETAINED in the retry inventory
+// (m.lastBindingIndices) so a later status pass re-attempts the clear, while a
+// row whose clear SUCCEEDS is dropped from the inventory.
+//
+// Before the fix the clear result was discarded (`_ = bindingsMap.Update(...)`)
+// and m.lastBindingIndices was unconditionally overwritten with only the live
+// bindings, so a failed clear stranded a stale binding in the BPF map that the
+// clear loop could never rediscover — the XDP shim kept steering transit to a
+// slot no longer backed by a live worker.
+func TestClearStaleBindingRowsRetainsFailedClearInRetryInventory(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	m := New()
+
+	// A small Array bindings map makes the clear Update fail deterministically
+	// for an out-of-bounds index (Array rejects key >= MaxEntries), matching
+	// the production userspace_bindings Array without needing a mock.
+	bindingsMap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Array,
+		KeySize:    4,
+		ValueSize:  uint32(unsafe.Sizeof(userspaceBindingValue{})),
+		MaxEntries: 8,
+	})
+	if err != nil {
+		skipIfBPFMapUnavailable(t, "new userspace_bindings array map", err)
+	}
+	t.Cleanup(func() { bindingsMap.Close() })
+
+	const goodIdx = uint32(3) // in bounds — clear succeeds
+	const badIdx = uint32(99) // out of bounds — clear fails
+
+	// Seed a live-looking value at goodIdx so we can prove it gets zeroed.
+	if err := bindingsMap.Update(goodIdx, userspaceBindingValue{Slot: 5, Flags: userspaceBindingReady}, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed goodIdx: %v", err)
+	}
+
+	// Both rows were live on the previous pass; neither is live now (empty
+	// newBindingIndexSet), so both are candidates for clearing.
+	m.lastBindingIndices = []uint32{goodIdx, badIdx}
+
+	retry := m.clearStaleBindingRowsLocked(bindingsMap, nil, map[uint32]struct{}{})
+
+	// The failed clear (badIdx) MUST be retained so the watchdog re-attempts
+	// it on a later pass. Dropping it is the M20 defect.
+	if !slices.Contains(retry, badIdx) {
+		t.Fatalf("retry inventory %v missing failed-clear idx %d; watchdog can never re-attempt the clear (M20 regression)", retry, badIdx)
+	}
+	// The successful clear (goodIdx) MUST be dropped from the inventory.
+	if slices.Contains(retry, goodIdx) {
+		t.Fatalf("retry inventory %v retains successfully-cleared idx %d; a cleared row must not be re-scanned", retry, goodIdx)
+	}
+
+	// The successful clear must actually have zeroed the BPF map row.
+	var val userspaceBindingValue
+	if err := bindingsMap.Lookup(goodIdx, &val); err != nil {
+		t.Fatalf("lookup goodIdx after clear: %v", err)
+	}
+	if val.Slot != 0 || val.Flags != 0 {
+		t.Fatalf("goodIdx row not zeroed after successful clear: %+v", val)
+	}
+}
+
+// TestClearStaleBindingRowsKeepsLiveBindings verifies the clear loop leaves
+// still-live bindings (present in newBindingIndexSet) untouched and carries
+// them forward in the returned inventory.
+func TestClearStaleBindingRowsKeepsLiveBindings(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	m := New()
+	bindingsMap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Array,
+		KeySize:    4,
+		ValueSize:  uint32(unsafe.Sizeof(userspaceBindingValue{})),
+		MaxEntries: 8,
+	})
+	if err != nil {
+		skipIfBPFMapUnavailable(t, "new userspace_bindings array map", err)
+	}
+	t.Cleanup(func() { bindingsMap.Close() })
+
+	const liveIdx = uint32(2)
+	const staleIdx = uint32(4)
+	if err := bindingsMap.Update(liveIdx, userspaceBindingValue{Slot: 1, Flags: userspaceBindingReady}, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed liveIdx: %v", err)
+	}
+	if err := bindingsMap.Update(staleIdx, userspaceBindingValue{Slot: 2, Flags: userspaceBindingReady}, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed staleIdx: %v", err)
+	}
+
+	m.lastBindingIndices = []uint32{liveIdx, staleIdx}
+	newIndices := []uint32{liveIdx}
+	newSet := map[uint32]struct{}{liveIdx: {}}
+
+	retry := m.clearStaleBindingRowsLocked(bindingsMap, newIndices, newSet)
+
+	if !slices.Contains(retry, liveIdx) {
+		t.Fatalf("retry inventory %v dropped still-live idx %d", retry, liveIdx)
+	}
+	if slices.Contains(retry, staleIdx) {
+		t.Fatalf("retry inventory %v retains cleared stale idx %d", retry, staleIdx)
+	}
+
+	// liveIdx must be untouched; staleIdx must be zeroed.
+	var live userspaceBindingValue
+	if err := bindingsMap.Lookup(liveIdx, &live); err != nil {
+		t.Fatalf("lookup liveIdx: %v", err)
+	}
+	if live.Slot != 1 || live.Flags != userspaceBindingReady {
+		t.Fatalf("live binding was modified: %+v", live)
+	}
+	var stale userspaceBindingValue
+	if err := bindingsMap.Lookup(staleIdx, &stale); err != nil {
+		t.Fatalf("lookup staleIdx: %v", err)
+	}
+	if stale.Slot != 0 || stale.Flags != 0 {
+		t.Fatalf("stale binding not zeroed: %+v", stale)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #5697 (codex-review-182 finding M20). When the userspace dataplane
manager reconciles the `userspace_bindings` BPF map against the helper's
reported bindings, `applyHelperStatusLocked` zeroes rows that were live on the
previous status pass but absent from the current one. The clear **discarded**
the `bindingsMap.Update` result (`_ = ...`) and then unconditionally overwrote
`m.lastBindingIndices` with only the live binding indices.

That drops the retry inventory on failure. The clear loop only rescans indices
recorded in `m.lastBindingIndices`, so a row whose zeroing `Update` failed was
forgotten: it stayed populated in the BPF map but was no longer tracked, so no
later status pass ever re-attempted the clear. The XDP shim kept steering
transit to a binding slot no longer backed by a live worker, and the stale row
persisted indefinitely.

## Fix

Extract the clear into `clearStaleBindingRowsLocked`. A row whose `Update`
fails is now **retained** in the returned inventory (logged at warn and
re-added to `newBindingIndices`) so the next status pass re-attempts the clear;
a successful clear leaves the row out of the inventory and it is dropped. The
repair loop now converges instead of leaking stale binding rows.

## Fail-on-revert test

`pkg/dataplane/userspace/maps_sync_stale_binding_retry_5697_test.go` drives the
extracted method against a small Array bindings map:

- an in-bounds index clears successfully and is dropped from the inventory;
- an out-of-bounds index (`Update` fails with E2BIG) is retained for retry.

Neutralizing the fix back to the discard-and-overwrite behavior turns the
retain assertion **RED** (`retry inventory [] missing failed-clear idx 99`);
GREEN restored. A companion test guards that still-live rows are carried
forward untouched.

Pre-existing environment-only failures in the package (`applyHelperStatus*`
map-not-loaded, XDP-program RX-liveness tests) reproduce identically on
pristine `origin/master` and are not introduced by this change. `go build
./...`, `gofmt`, and the new unit tests (run with BPF map privileges) are
clean.

Closes #5697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj6WhNAWdp6vTuvREojiF8