### PR TITLE
dataplane: retry chunk tail on batch-delete missing key (#5448)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47537,3 +47537,23 @@ top.
   proven: neutralizing both failure legs (`return nil`) →
   TestRouteLeakReconcileFailsCommitOnPublishError and ...OnBumpError RED
   (returns nil on injected failure); restored GREEN.
+
+- **Timestamp**: 2026-07-12 23:25
+  **Action**: Fix #5448 — batchDeleteV4/V6 dropped the unattempted chunk tail on
+  a missing key. cilium/ebpf BatchDelete stops at the first absent key and
+  returns (count_before_stop, ErrKeyNotExist); the old loop swallowed the error
+  via ignoreSessionNotFound and advanced `keys = keys[n:]`, so
+  chunk[chunkDeleted+1:n] was never retried → stale peer-synced sessions leaked
+  after HA bulk reconcile (ReconcileClusterBulk). Mirrored clearSessionsV4's
+  established per-key fallback: on the not-found error, delete the chunk
+  remainder one key at a time before advancing; genuine (non-not-found) errors
+  still propagate. Fixed both V4 and V6 identically; clamped chunkDeleted to
+  [0,len(chunk)] like the sibling.
+  **File(s)**: pkg/dataplane/session_store.go,
+  pkg/dataplane/session_store_batchdelete_5448_test.go
+  GREEN: `go test ./pkg/dataplane/...` — new tests pass; gofmt + vet clean.
+  Fail-on-revert proven: reverting to the buggy loop → both
+  TestBatchDeleteV{4,6}RetriesTailAfterMissingKey RED (tail keys survive,
+  deleted count 2 not 4); restored GREEN. (Pre-existing, unrelated:
+  TestUserspaceManagerDoesNotImportReflectOrUnsafe fails on pristine
+  origin/master — manager_overlay.go imports reflect; not touched here.)

--- a/pkg/dataplane/session_store.go
+++ b/pkg/dataplane/session_store.go
@@ -462,6 +462,14 @@ func (s dataPlaneSessionStore) DeleteBatchKnownV6(entries []SessionEntryV6, _ De
 	return deleted, nil
 }
 
+// batchDeleteV4 removes keys from the v4 session map in
+// sessionDeleteBatchSize chunks. cilium/ebpf BatchDelete stops at the first
+// missing key and returns (count_before_stop, ErrKeyNotExist); the stopped
+// key sits at index chunkDeleted, so keys[chunkDeleted+1:n] were never
+// attempted. Mirror clearSessionsV4 (pkg/dataplane/maps_session.go): on the
+// not-found error, retry the chunk remainder one key at a time before
+// advancing, so the unattempted tail is not silently dropped (#5448) — a
+// dropped tail leaks stale peer-synced sessions after HA bulk reconcile.
 func (s dataPlaneSessionStore) batchDeleteV4(keys []SessionKey) (int, error) {
 	deleted := 0
 	for len(keys) > 0 {
@@ -469,16 +477,33 @@ func (s dataPlaneSessionStore) batchDeleteV4(keys []SessionKey) (int, error) {
 		if len(keys) < n {
 			n = len(keys)
 		}
-		chunkDeleted, err := s.dp.BatchDeleteSessions(keys[:n])
+		chunk := keys[:n]
+		chunkDeleted, err := s.dp.BatchDeleteSessions(chunk)
+		if chunkDeleted < 0 {
+			chunkDeleted = 0
+		} else if chunkDeleted > len(chunk) {
+			chunkDeleted = len(chunk)
+		}
 		deleted += chunkDeleted
-		if err := ignoreSessionNotFound(err); err != nil {
-			return deleted, err
+		if err != nil {
+			if !sessionNotFound(err) {
+				return deleted, err
+			}
+			// Batch stopped at the first missing key (index chunkDeleted):
+			// that key is already gone, but chunk[chunkDeleted+1:] were never
+			// attempted. Finish the remainder per-key so nothing is dropped.
+			for _, k := range chunk[chunkDeleted:] {
+				if delErr := s.dp.DeleteSession(k); delErr == nil {
+					deleted++
+				}
+			}
 		}
 		keys = keys[n:]
 	}
 	return deleted, nil
 }
 
+// batchDeleteV6 is the IPv6 variant of batchDeleteV4 (#5448).
 func (s dataPlaneSessionStore) batchDeleteV6(keys []SessionKeyV6) (int, error) {
 	deleted := 0
 	for len(keys) > 0 {
@@ -486,10 +511,23 @@ func (s dataPlaneSessionStore) batchDeleteV6(keys []SessionKeyV6) (int, error) {
 		if len(keys) < n {
 			n = len(keys)
 		}
-		chunkDeleted, err := s.dp.BatchDeleteSessionsV6(keys[:n])
+		chunk := keys[:n]
+		chunkDeleted, err := s.dp.BatchDeleteSessionsV6(chunk)
+		if chunkDeleted < 0 {
+			chunkDeleted = 0
+		} else if chunkDeleted > len(chunk) {
+			chunkDeleted = len(chunk)
+		}
 		deleted += chunkDeleted
-		if err := ignoreSessionNotFound(err); err != nil {
-			return deleted, err
+		if err != nil {
+			if !sessionNotFound(err) {
+				return deleted, err
+			}
+			for _, k := range chunk[chunkDeleted:] {
+				if delErr := s.dp.DeleteSessionV6(k); delErr == nil {
+					deleted++
+				}
+			}
 		}
 		keys = keys[n:]
 	}

--- a/pkg/dataplane/session_store_batchdelete_5448_test.go
+++ b/pkg/dataplane/session_store_batchdelete_5448_test.go
@@ -1,0 +1,192 @@
+package dataplane
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// batchDeleteTailDP is a DataPlane fake whose batch delete emulates cilium/ebpf
+// BatchDelete: it stops at the first key marked "already gone" (missing) and
+// returns (count_before_stop, ErrKeyNotExist), leaving every subsequent key in
+// the chunk unattempted. It records every key a delete was attempted on (batch
+// or per-key) so the test can assert the unattempted tail is retried rather
+// than dropped (#5448).
+type batchDeleteTailDP struct {
+	DataPlane
+
+	missingV4 SessionKey
+	presentV4 map[SessionKey]bool // false once deleted
+	attempted []SessionKey
+
+	missingV6   SessionKeyV6
+	presentV6   map[SessionKeyV6]bool
+	attemptedV6 []SessionKeyV6
+}
+
+func (m *batchDeleteTailDP) BatchDeleteSessions(keys []SessionKey) (int, error) {
+	deleted := 0
+	for _, k := range keys {
+		m.attempted = append(m.attempted, k)
+		if k == m.missingV4 {
+			// Kernel batch delete stops at the first missing key; the tail is
+			// left untouched.
+			return deleted, ebpf.ErrKeyNotExist
+		}
+		m.presentV4[k] = false
+		deleted++
+	}
+	return deleted, nil
+}
+
+func (m *batchDeleteTailDP) DeleteSession(k SessionKey) error {
+	m.attempted = append(m.attempted, k)
+	if k == m.missingV4 {
+		return ebpf.ErrKeyNotExist
+	}
+	m.presentV4[k] = false
+	return nil
+}
+
+func (m *batchDeleteTailDP) BatchDeleteSessionsV6(keys []SessionKeyV6) (int, error) {
+	deleted := 0
+	for _, k := range keys {
+		m.attemptedV6 = append(m.attemptedV6, k)
+		if k == m.missingV6 {
+			return deleted, ebpf.ErrKeyNotExist
+		}
+		m.presentV6[k] = false
+		deleted++
+	}
+	return deleted, nil
+}
+
+func (m *batchDeleteTailDP) DeleteSessionV6(k SessionKeyV6) error {
+	m.attemptedV6 = append(m.attemptedV6, k)
+	if k == m.missingV6 {
+		return ebpf.ErrKeyNotExist
+	}
+	m.presentV6[k] = false
+	return nil
+}
+
+// TestBatchDeleteV4RetriesTailAfterMissingKey asserts that when the kernel
+// batch-delete stops on a missing key in the MIDDLE of a chunk, batchDeleteV4
+// still deletes the keys after it (chunk[chunkDeleted+1:]) instead of dropping
+// them. Before #5448 the loop advanced by the full chunk width on
+// ErrKeyNotExist, so the unattempted tail leaked (stale HA-synced sessions
+// after bulk reconcile).
+func TestBatchDeleteV4RetriesTailAfterMissingKey(t *testing.T) {
+	keys := make([]SessionKey, 5)
+	for i := range keys {
+		keys[i] = SessionKey{
+			Protocol: 6,
+			SrcIP:    [4]byte{10, 0, 0, byte(i)},
+			DstIP:    [4]byte{10, 0, 1, byte(i)},
+			SrcPort:  uint16(1000 + i),
+			DstPort:  80,
+		}
+	}
+	const missingIdx = 2 // interleaved missing key with a non-empty tail after it
+	missing := keys[missingIdx]
+
+	dp := &batchDeleteTailDP{
+		missingV4: missing,
+		presentV4: map[SessionKey]bool{},
+	}
+	for i, k := range keys {
+		// Every key is present except the one a concurrent GC already removed.
+		dp.presentV4[k] = i != missingIdx
+	}
+	store := dataPlaneSessionStore{dp: dp}
+
+	deleted, err := store.batchDeleteV4(keys)
+	if err != nil {
+		t.Fatalf("batchDeleteV4 returned error: %v", err)
+	}
+
+	// Every non-missing key must be gone (tail retried, not dropped).
+	for i, k := range keys {
+		if i == missingIdx {
+			continue
+		}
+		if dp.presentV4[k] {
+			t.Errorf("key index %d (%v) survived — unattempted tail was dropped", i, k)
+		}
+	}
+	// 4 real keys deleted; the missing key is not counted.
+	if deleted != len(keys)-1 {
+		t.Errorf("deleted count = %d, want %d", deleted, len(keys)-1)
+	}
+}
+
+// TestBatchDeleteV6RetriesTailAfterMissingKey is the IPv6 sibling.
+func TestBatchDeleteV6RetriesTailAfterMissingKey(t *testing.T) {
+	keys := make([]SessionKeyV6, 5)
+	for i := range keys {
+		var src, dst [16]byte
+		src[0], src[15] = 0x20, byte(i)
+		dst[0], dst[15] = 0x30, byte(i)
+		keys[i] = SessionKeyV6{
+			Protocol: 6,
+			SrcIP:    src,
+			DstIP:    dst,
+			SrcPort:  uint16(1000 + i),
+			DstPort:  80,
+		}
+	}
+	const missingIdx = 2
+	missing := keys[missingIdx]
+
+	dp := &batchDeleteTailDP{
+		missingV6: missing,
+		presentV6: map[SessionKeyV6]bool{},
+	}
+	for i, k := range keys {
+		dp.presentV6[k] = i != missingIdx
+	}
+	store := dataPlaneSessionStore{dp: dp}
+
+	deleted, err := store.batchDeleteV6(keys)
+	if err != nil {
+		t.Fatalf("batchDeleteV6 returned error: %v", err)
+	}
+
+	for i, k := range keys {
+		if i == missingIdx {
+			continue
+		}
+		if dp.presentV6[k] {
+			t.Errorf("v6 key index %d survived — unattempted tail was dropped", i)
+		}
+	}
+	if deleted != len(keys)-1 {
+		t.Errorf("v6 deleted count = %d, want %d", deleted, len(keys)-1)
+	}
+}
+
+// TestBatchDeleteV4PropagatesRealError confirms a non-not-found batch error is
+// still surfaced (the #5448 fix must not swallow genuine failures).
+func TestBatchDeleteV4PropagatesRealError(t *testing.T) {
+	realErr := errors.New("map delete failed")
+	dp := &batchDeleteErrDP{err: realErr}
+	store := dataPlaneSessionStore{dp: dp}
+	_, err := store.batchDeleteV4([]SessionKey{{Protocol: 6, SrcPort: 1}})
+	if !errors.Is(err, realErr) {
+		t.Fatalf("batchDeleteV4 error = %v, want %v", err, realErr)
+	}
+}
+
+type batchDeleteErrDP struct {
+	DataPlane
+	err error
+}
+
+func (m *batchDeleteErrDP) BatchDeleteSessions(keys []SessionKey) (int, error) {
+	return 0, m.err
+}
+
+func (m *batchDeleteErrDP) BatchDeleteSessionsV6(keys []SessionKeyV6) (int, error) {
+	return 0, m.err
+}


### PR DESCRIPTION
## Defect
`batchDeleteV4`/`batchDeleteV6` in `pkg/dataplane/session_store.go` (the cluster-bulk session store that feeds `ReconcileClusterBulk` for HA stale-session cleanup) dropped the not-yet-attempted tail of a chunk when the kernel batch-delete stopped on a missing key.

cilium/ebpf `BatchDelete` stops at the first absent key and returns `(count_before_stop, ErrKeyNotExist)`. The old loop swallowed that error via `ignoreSessionNotFound` and advanced `keys = keys[n:]`, so `chunk[chunkDeleted+1:n]` — the keys after the missing one, never attempted — were skipped forever.

## Impact
`DeleteBatchKnownV4/V6` feeds `ReconcileClusterBulk` (HA bulk stale-session cleanup). A single missing key mid-chunk aborted deletion of the rest of that chunk, so stale peer-synced sessions survived bulk resync — inflating the session table and delaying GC after churn.

## Fix
Mirror the established `clearSessionsV4` pattern in `pkg/dataplane/maps_session.go`: on the not-found error, delete the chunk remainder one key at a time before advancing. The stopped key at index `chunkDeleted` is already gone; `chunk[chunkDeleted+1:]` are retried so nothing is dropped. Genuine (non-not-found) batch errors still propagate. `chunkDeleted` is clamped to `[0,len(chunk)]` like the sibling. Fixed **both** V4 and V6 identically.

Pure Go control-plane change — no forwarding/wire-ABI/Rust surface touched.

## Validation
Added `pkg/dataplane/session_store_batchdelete_5448_test.go`: a fake `dp` whose batch delete stops on an interleaved missing key in the **middle** of the chunk (non-empty unattempted tail). Asserts every non-missing key is eventually deleted and the returned count is correct, for both V4 and V6, plus a case proving a real batch error still propagates.

`go test ./pkg/dataplane/...` passes for the new tests; `gofmt` + `go vet` clean.

### Fail-on-revert (RED) proof
Restoring the buggy loop (advance by full `n` on `ErrKeyNotExist`) turns both tail-retry tests RED:
```
--- FAIL: TestBatchDeleteV4RetriesTailAfterMissingKey (0.00s)
    session_store_batchdelete_5448_test.go:115: key index 3 ({[10 0 0 3] [10 0 1 3] 1003 80 6 [0 0 0]}) survived — unattempted tail was dropped
    session_store_batchdelete_5448_test.go:115: key index 4 ({[10 0 0 4] [10 0 1 4] 1004 80 6 [0 0 0]}) survived — unattempted tail was dropped
    session_store_batchdelete_5448_test.go:120: deleted count = 2, want 4
--- FAIL: TestBatchDeleteV6RetriesTailAfterMissingKey (0.00s)
    session_store_batchdelete_5448_test.go:161: v6 key index 3 survived — unattempted tail was dropped
    session_store_batchdelete_5448_test.go:161: v6 key index 4 survived — unattempted tail was dropped
    session_store_batchdelete_5448_test.go:165: v6 deleted count = 2, want 4
```
The fix restores GREEN.

> Note: `TestUserspaceManagerDoesNotImportReflectOrUnsafe` fails on pristine `origin/master` (`manager_overlay.go` imports `reflect`) — pre-existing and unrelated to this change, which does not touch that file.

Closes #5448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNEVrePodApsgbw6bvkcSw