### PR TITLE
userspace: fail closed when ctrl disable before teardown fails

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47563,3 +47563,41 @@ top.
   Pre-existing env failures in the package (applyHelperStatus map-not-loaded,
   XDP-program RX-liveness tests) reproduce identically on pristine
   origin/master cd3ae8973 — not introduced by this change.
+
+- **Timestamp**: 2026-07-12
+  **Action**: #5486 (codex-review-179 A6/C179-083) — disableUserspaceCtrlLocked
+  was void and swallowed ctrl-map Lookup/Update errors before worker/UMEM
+  teardown. On `ctrlMap.Lookup` error it returned silently and it discarded
+  the `ctrlMap.Update` result (`_ =`), so a failed disable left a stale
+  `enabled=1` ctrl row with READY bindings — the XDP shim kept redirecting
+  transit to soon-dead XSK fds until heartbeat expiry (transit outage +
+  UMEM-quiescence ordering violation), while callers
+  (stopLocked/PrepareLinkCycle/DisableAndStopHelper/NotifyLinkCycle) tore down
+  workers regardless. Fix: `disableUserspaceCtrlLocked` now returns error;
+  extracted pure `disableUserspaceCtrl(ctrlMapUpdater)` that on Lookup failure
+  writes a zeroed (Enabled=0) fail-closed row anyway, CHECKS the Update result,
+  and reads back to confirm Enabled==0 (silent no-op is caught). New
+  `disableCtrlBeforeTeardownLocked` wrapper propagates at all 4 call sites: on
+  failure it logs Error and force-clears ALL bindings via a new
+  `clearAllBindingRowsLocked` (reuses the bootstrap zero-all pattern; the
+  bootstrap block now calls the shared helper) so the shim has no READY slot to
+  redirect before teardown. Happy path preserved byte-for-byte (same slog.Info,
+  same fields, nil error, no binding clear). Interface seam (ctrlMapUpdater +
+  disableCtrlMapHook) lets the fault tests run UNPRIVILEGED (no memlock).
+  Operator-facing behavior (ctrl.enabled=0 degraded path) unchanged, so no doc
+  update needed — internal fail-closed robustness only. Final runtime AF_XDP
+  lifecycle verify is lab-bound (deferred).
+  **File(s)**: pkg/dataplane/userspace/process_linkcycle.go,
+  pkg/dataplane/userspace/process.go, pkg/dataplane/userspace/maps_sync.go,
+  pkg/dataplane/userspace/manager.go,
+  pkg/dataplane/userspace/ctrl_disable_5486_test.go
+  GREEN: full `go test ./pkg/dataplane/userspace/` passes (unprivileged +
+  root); gofmt + `go build ./...` + `go vet` clean. Fail-on-revert proven:
+  neutralizing disableUserspaceCtrl to the old swallow behavior (silent
+  return on Lookup err, discarded Update, no readback) turns all three fault
+  tests RED — Lookup fault ("returned nil on lookup fault, want error"),
+  Update fault on teardown path ("returned nil on update fault, want error"),
+  readback mismatch ("returned nil on readback mismatch, want error");
+  restored GREEN. Pre-existing failure
+  TestUserspaceManagerDoesNotImportReflectOrUnsafe (manager_overlay.go imports
+  reflect) reproduces on pristine origin/master — not this change.

--- a/pkg/dataplane/userspace/ctrl_disable_5486_test.go
+++ b/pkg/dataplane/userspace/ctrl_disable_5486_test.go
@@ -1,0 +1,172 @@
+package userspace
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// fakeCtrlMap is a programmable stand-in for the userspace_ctrl *ebpf.Map. It
+// satisfies ctrlMapUpdater so the #5486 disable/fail-closed logic can be
+// fault-injected without a privileged BPF map (the real-map link-cycle tests
+// skip when memlock is unavailable).
+type fakeCtrlMap struct {
+	stored     userspaceCtrlValue
+	haveStored bool
+
+	// lookupErrs[i] (if non-nil) is returned by the i-th Lookup call.
+	lookupErrs  []error
+	lookupCalls int
+
+	updateErr     error // returned by every Update when non-nil
+	swallowUpdate bool  // Update returns nil but does NOT persist (silent no-op)
+	updates       int
+}
+
+func (f *fakeCtrlMap) Lookup(key, valueOut interface{}) error {
+	idx := f.lookupCalls
+	f.lookupCalls++
+	if idx < len(f.lookupErrs) && f.lookupErrs[idx] != nil {
+		return f.lookupErrs[idx]
+	}
+	vp, ok := valueOut.(*userspaceCtrlValue)
+	if !ok {
+		return fmt.Errorf("fakeCtrlMap.Lookup: unexpected valueOut type %T", valueOut)
+	}
+	if !f.haveStored {
+		return ebpf.ErrKeyNotExist
+	}
+	*vp = f.stored
+	return nil
+}
+
+func (f *fakeCtrlMap) Update(key, value interface{}, flags ebpf.MapUpdateFlags) error {
+	f.updates++
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	if f.swallowUpdate {
+		return nil
+	}
+	v, ok := value.(userspaceCtrlValue)
+	if !ok {
+		return fmt.Errorf("fakeCtrlMap.Update: unexpected value type %T", value)
+	}
+	f.stored = v
+	f.haveStored = true
+	return nil
+}
+
+// (a) Lookup fault: the disable MUST still attempt a fail-closed (Enabled=0)
+// write rather than silently bailing, and MUST return the error so a teardown
+// caller learns the prior value was unreadable.
+func TestDisableUserspaceCtrlLookupFaultWritesFailClosedAndReturnsError(t *testing.T) {
+	fake := &fakeCtrlMap{lookupErrs: []error{errors.New("lookup boom")}}
+
+	err := disableUserspaceCtrl(fake)
+	if err == nil {
+		t.Fatal("disableUserspaceCtrl returned nil on lookup fault, want error")
+	}
+	if fake.updates == 0 {
+		t.Fatal("no ctrl Update attempted after lookup fault; fail-closed gate was not written")
+	}
+	if !fake.haveStored || fake.stored.Enabled != 0 {
+		t.Fatalf("fail-closed ctrl row not written with Enabled=0: haveStored=%v stored=%+v", fake.haveStored, fake.stored)
+	}
+}
+
+// (b) Update fault on the teardown path: the disable error MUST propagate and
+// ALL bindings MUST be cleared (m.lastBindingIndices niled) so the XDP shim has
+// no READY slot to redirect to before worker/UMEM teardown.
+func TestDisableCtrlBeforeTeardownUpdateFaultClearsBindings(t *testing.T) {
+	m := New()
+	m.disableCtrlMapHook = &fakeCtrlMap{
+		stored:     userspaceCtrlValue{Enabled: 1},
+		haveStored: true,
+		updateErr:  errors.New("update boom"),
+	}
+	m.lastBindingIndices = []uint32{1, 2, 3}
+
+	err := m.disableCtrlBeforeTeardownLocked()
+	if err == nil {
+		t.Fatal("disableCtrlBeforeTeardownLocked returned nil on update fault, want error")
+	}
+	if m.lastBindingIndices != nil {
+		t.Fatalf("lastBindingIndices = %v after fail-closed teardown, want nil (bindings must be cleared)", m.lastBindingIndices)
+	}
+}
+
+// (c) Readback shows Enabled!=0: a silent write no-op (Update reports success
+// but the row did not change) MUST be caught by the readback and returned as
+// an error — otherwise a stale Enabled=1 strands transit redirecting to
+// soon-dead XSK fds.
+func TestDisableUserspaceCtrlReadbackMismatchReturnsError(t *testing.T) {
+	fake := &fakeCtrlMap{
+		stored:        userspaceCtrlValue{Enabled: 1},
+		haveStored:    true,
+		swallowUpdate: true, // Update "succeeds" but does not persist Enabled=0
+	}
+
+	err := disableUserspaceCtrl(fake)
+	if err == nil {
+		t.Fatal("disableUserspaceCtrl returned nil on readback mismatch, want error")
+	}
+	if !strings.Contains(err.Error(), "readback") {
+		t.Fatalf("error = %v, want a readback-mismatch error", err)
+	}
+}
+
+// Happy path: a successful disable sets Enabled=0, preserves the other ctrl
+// fields byte-for-byte, and returns nil.
+func TestDisableUserspaceCtrlHappyPathPreservesFieldsAndReturnsNil(t *testing.T) {
+	fake := &fakeCtrlMap{
+		stored:     userspaceCtrlValue{Enabled: 1, Flags: userspaceCtrlFlagStrict, Workers: 3, QueueCount: 3},
+		haveStored: true,
+	}
+
+	if err := disableUserspaceCtrl(fake); err != nil {
+		t.Fatalf("disableUserspaceCtrl happy path returned %v, want nil", err)
+	}
+	if fake.stored.Enabled != 0 {
+		t.Fatalf("ctrl.Enabled = %d after disable, want 0", fake.stored.Enabled)
+	}
+	if fake.stored.Flags != userspaceCtrlFlagStrict || fake.stored.Workers != 3 || fake.stored.QueueCount != 3 {
+		t.Fatalf("disable clobbered ctrl fields: %+v, want Flags/Workers/QueueCount preserved", fake.stored)
+	}
+}
+
+// Happy-path teardown: a verified disable must NOT clear bindings (byte-for-byte
+// with the pre-fix behavior — only a failed disable triggers the fail-closed
+// binding clear).
+func TestDisableCtrlBeforeTeardownSuccessKeepsBindings(t *testing.T) {
+	m := New()
+	m.disableCtrlMapHook = &fakeCtrlMap{stored: userspaceCtrlValue{Enabled: 1}, haveStored: true}
+	m.lastBindingIndices = []uint32{7, 8}
+
+	if err := m.disableCtrlBeforeTeardownLocked(); err != nil {
+		t.Fatalf("disableCtrlBeforeTeardownLocked returned %v on success, want nil", err)
+	}
+	if len(m.lastBindingIndices) != 2 {
+		t.Fatalf("lastBindingIndices = %v after successful disable, want preserved [7 8]", m.lastBindingIndices)
+	}
+}
+
+// A missing ctrl map is itself a fail-closed-worthy anomaly during teardown:
+// the disable returns an error and the teardown wrapper clears bindings.
+func TestDisableCtrlBeforeTeardownMissingMapClearsBindings(t *testing.T) {
+	m := New()
+	// No disableCtrlMapHook and no loaded shim map -> ctrlMapForDisableLocked
+	// returns nil.
+	m.lastBindingIndices = []uint32{9}
+
+	err := m.disableCtrlBeforeTeardownLocked()
+	if err == nil {
+		t.Fatal("disableCtrlBeforeTeardownLocked returned nil with no ctrl map, want error")
+	}
+	if m.lastBindingIndices != nil {
+		t.Fatalf("lastBindingIndices = %v after missing-map teardown, want nil", m.lastBindingIndices)
+	}
+}

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -209,6 +209,12 @@ type Manager struct {
 
 	lookupUserspaceCtrlForFailClosedHook userspaceCtrlLookupHook
 
+	// disableCtrlMapHook, when non-nil, replaces the bpfShim userspace_ctrl
+	// map in disableUserspaceCtrlLocked so tests can inject Lookup/Update/
+	// readback faults without a privileged BPF map (#5486). Production leaves
+	// it nil.
+	disableCtrlMapHook ctrlMapUpdater
+
 	// addrListForLocalSyncHook, when non-nil, replaces netlink.AddrList in
 	// buildDesiredLocalAddressSets so tests can inject a transient
 	// enumeration failure (#3924). Production leaves it nil.

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -176,13 +176,7 @@ func (m *Manager) programBootstrapMapsLocked(snapshot *ConfigSnapshot, cfg confi
 	}
 
 	// Bindings map is now an Array — zero previously-set indices.
-	{
-		var zeroBinding userspaceBindingValue
-		for _, idx := range m.lastBindingIndices {
-			_ = bindingsMap.Update(idx, zeroBinding, ebpf.UpdateAny)
-		}
-		m.lastBindingIndices = nil
-	}
+	m.clearAllBindingRowsLocked()
 	// Heartbeat map is now an Array — zero used slots instead of deleting.
 	// Slots with value 0 appear as stale (bpf_ktime_get_ns() >> 0) so the
 	// XDP shim correctly refuses to redirect until userspace begins updating.
@@ -813,6 +807,27 @@ func (m *Manager) clearStaleBindingRowsLocked(bindingsMap *ebpf.Map, newBindingI
 		}
 	}
 	return newBindingIndices
+}
+
+// clearAllBindingRowsLocked zeroes every userspace_bindings row recorded in
+// m.lastBindingIndices and forgets the inventory. It is the fail-closed
+// teardown primitive (#5486): when ctrl-disable cannot be verified before
+// worker/UMEM teardown, this leaves the XDP shim with no READY slot to
+// redirect to, so no packet can reach a soon-dead XSK fd. It mirrors the
+// bootstrap zero-all used by the initial map program. Best-effort: a per-row
+// Update failure on the teardown path is not fatal (the helper is stopping),
+// but the inventory is always niled so a fresh apply re-establishes rows.
+func (m *Manager) clearAllBindingRowsLocked() {
+	bindingsMap := m.bpfShim.Map(mapNameUserspaceBindings)
+	if bindingsMap == nil {
+		m.lastBindingIndices = nil
+		return
+	}
+	var zeroBinding userspaceBindingValue
+	for _, idx := range m.lastBindingIndices {
+		_ = bindingsMap.Update(idx, zeroBinding, ebpf.UpdateAny)
+	}
+	m.lastBindingIndices = nil
 }
 
 // userspaceCounterSnapshot holds cumulative counter totals from the helper,

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -209,8 +209,10 @@ func (m *Manager) stopLocked() {
 	// Disable userspace forwarding BEFORE stopping the helper. Without this,
 	// the XDP shim continues redirecting to XSK after the helper exits,
 	// sending packets to dead socket fds. Setting ctrl.enabled=0 makes the
-	// shim pass only proven local/control traffic and drop transit.
-	m.disableUserspaceCtrlLocked()
+	// shim pass only proven local/control traffic and drop transit. If the
+	// disable cannot be verified, the wrapper clears all bindings fail-closed
+	// before the helper shutdown below (#5486).
+	_ = m.disableCtrlBeforeTeardownLocked()
 	_ = m.requestLocked(ControlRequest{Type: "shutdown"}, nil)
 	done := make(chan struct{})
 	go func(cmd *exec.Cmd) {

--- a/pkg/dataplane/userspace/process_linkcycle.go
+++ b/pkg/dataplane/userspace/process_linkcycle.go
@@ -1,29 +1,102 @@
 package userspace
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/cilium/ebpf"
 )
 
+// ctrlMapUpdater is the subset of *ebpf.Map used to flip the ctrl.enabled
+// gate. *ebpf.Map satisfies it directly; tests substitute a fake to inject
+// Lookup/Update/readback faults without a privileged BPF map (#5486).
+type ctrlMapUpdater interface {
+	Lookup(key, valueOut interface{}) error
+	Update(key, value interface{}, flags ebpf.MapUpdateFlags) error
+}
+
+// ctrlMapForDisableLocked returns the ctrl-map accessor used to disable ctrl.
+// Production returns the real bpfShim userspace_ctrl map; a test hook can
+// override it. Returns nil (a true nil interface, never a typed nil) when the
+// shim map is not loaded.
+func (m *Manager) ctrlMapForDisableLocked() ctrlMapUpdater {
+	if m.disableCtrlMapHook != nil {
+		return m.disableCtrlMapHook
+	}
+	if cm := m.bpfShim.Map(mapNameUserspaceCtrl); cm != nil {
+		return cm
+	}
+	return nil
+}
+
 // disableUserspaceCtrlLocked sets ctrl.enabled=0 in the BPF map so the XDP
 // shim stops redirecting packets to XSK. This MUST be called before the
-// helper exits to prevent packets being sent to dead socket fds.
-func (m *Manager) disableUserspaceCtrlLocked() {
-	ctrlMap := m.bpfShim.Map(mapNameUserspaceCtrl)
+// helper exits (or workers/UMEM are torn down) to prevent packets being sent
+// to dead socket fds.
+//
+// It returns an error instead of silently swallowing failures (#5486): a
+// stale enabled=1 row with READY bindings keeps the shim redirecting to
+// soon-dead XSK fds until heartbeat expiry, so a caller preparing teardown
+// MUST learn the gate was not established and fail closed (clear bindings).
+func (m *Manager) disableUserspaceCtrlLocked() error {
+	ctrlMap := m.ctrlMapForDisableLocked()
 	if ctrlMap == nil {
-		return
+		return fmt.Errorf("userspace: cannot disable ctrl: %s map not loaded", mapNameUserspaceCtrl)
 	}
+	return disableUserspaceCtrl(ctrlMap)
+}
+
+// disableUserspaceCtrl writes ctrl.enabled=0 and verifies the gate took.
+//
+// On a Lookup failure it does NOT bail out leaving enabled=1: it writes a
+// zeroed (Enabled=0) fail-closed row anyway, then returns the read error. The
+// Update result is checked (not discarded) and the row is read back to confirm
+// Enabled==0 — a silent no-op here would strand transit redirecting to
+// soon-dead XSK fds after worker/UMEM teardown.
+func disableUserspaceCtrl(ctrlMap ctrlMapUpdater) error {
 	zero := uint32(0)
-	// Read current ctrl, set enabled=0, write back.
 	var ctrl userspaceCtrlValue
-	if err := ctrlMap.Lookup(zero, &ctrl); err != nil {
-		return
+	lookupErr := ctrlMap.Lookup(zero, &ctrl)
+	if lookupErr != nil {
+		// Prior ctrl unreadable — still establish the fail-closed gate with
+		// a zeroed ctrl row rather than leaving a stale enabled=1.
+		ctrl = userspaceCtrlValue{}
 	}
 	ctrl.Enabled = 0
-	_ = ctrlMap.Update(zero, ctrl, ebpf.UpdateAny)
+	if err := ctrlMap.Update(zero, ctrl, ebpf.UpdateAny); err != nil {
+		return fmt.Errorf("userspace: disable ctrl update failed: %w", err)
+	}
+	// Read back to confirm the disable actually took. A silent write no-op
+	// would leave enabled=1 and keep transit redirecting after teardown.
+	var verify userspaceCtrlValue
+	if err := ctrlMap.Lookup(zero, &verify); err != nil {
+		return fmt.Errorf("userspace: disable ctrl readback failed: %w", err)
+	}
+	if verify.Enabled != 0 {
+		return fmt.Errorf("userspace: disable ctrl readback shows enabled=%d, want 0", verify.Enabled)
+	}
+	if lookupErr != nil {
+		slog.Warn("userspace: disabled ctrl via fail-closed fallback (prior ctrl unreadable)", "err", lookupErr)
+		return fmt.Errorf("userspace: disable ctrl lookup failed (fail-closed fallback written): %w", lookupErr)
+	}
 	slog.Info("userspace: disabled ctrl (helper stopping)")
+	return nil
+}
+
+// disableCtrlBeforeTeardownLocked disables ctrl ahead of stopping workers or
+// cycling the link. Teardown cannot abort — the helper is stopping — so if the
+// disable cannot be verified, the fail-closed gate is not trustworthy: this
+// forcibly clears ALL binding rows (nothing READY for the shim to redirect)
+// before the caller proceeds to worker/UMEM teardown, logs the failure, and
+// returns the error for callers that surface it (#5486).
+func (m *Manager) disableCtrlBeforeTeardownLocked() error {
+	if err := m.disableUserspaceCtrlLocked(); err != nil {
+		slog.Error("userspace: ctrl disable before teardown failed; clearing all bindings fail-closed", "err", err)
+		m.clearAllBindingRowsLocked()
+		return err
+	}
+	return nil
 }
 
 // reEnableUserspaceCtrlLocked sets ctrl.enabled=1 in the BPF map.
@@ -55,7 +128,9 @@ func (m *Manager) DisableAndStopHelper() {
 	if m.proc == nil || m.proc.Process == nil {
 		return
 	}
-	m.disableUserspaceCtrlLocked()
+	// Teardown path: the wrapper logs and clears bindings fail-closed if the
+	// disable cannot be verified; there is no error channel to surface it on.
+	_ = m.disableCtrlBeforeTeardownLocked()
 }
 
 // PrepareLinkCycle must be called BEFORE any link DOWN/UP cycle (e.g. RETH
@@ -73,7 +148,10 @@ func (m *Manager) PrepareLinkCycle() {
 	if m.proc == nil || m.proc.Process == nil {
 		return
 	}
-	m.disableUserspaceCtrlLocked()
+	// Disable ctrl BEFORE stopping workers. If the disable cannot be
+	// verified the wrapper clears all bindings fail-closed so the shim has
+	// no READY slot to redirect to while the workers are being joined.
+	_ = m.disableCtrlBeforeTeardownLocked()
 	// Tell the Rust helper to stop all workers. This joins worker
 	// threads so they stop touching UMEM before the NIC unmaps pages
 	// during link DOWN.
@@ -116,8 +194,10 @@ func (m *Manager) NotifyLinkCycle() {
 		return
 	}
 	// Ensure ctrl is disabled (PrepareLinkCycle should have done this,
-	// but guard against callers that skip it).
-	m.disableUserspaceCtrlLocked()
+	// but guard against callers that skip it). The subsequent rebind
+	// re-establishes ctrl; a fail-closed binding clear here is safe because
+	// applyHelperStatusLocked below repopulates the binding rows.
+	_ = m.disableCtrlBeforeTeardownLocked()
 	// Reset the ctrl enable gate so the fill-ring bootstrap delay
 	// restarts from scratch after rebind.  Without this, ctrl stays
 	// enabled while the new bindings aren't ready — packets redirected


### PR DESCRIPTION
## Summary

Fixes #5486 (codex-review-179 A6/C179-083). `disableUserspaceCtrlLocked`
(`pkg/dataplane/userspace/process_linkcycle.go`) was **void and swallowed both
ctrl-map errors**: on `ctrlMap.Lookup` failure it returned silently, and it
discarded the `ctrlMap.Update` result (`_ = ...`). Its own doc says it MUST run
before the helper exits so the XDP shim stops redirecting to XSK, yet
`stopLocked` / `PrepareLinkCycle` / `DisableAndStopHelper` / `NotifyLinkCycle`
proceed to stop workers regardless. With a stale `enabled=1` row and READY
bindings the shim keeps redirecting until heartbeat expiry; after worker/UMEM
teardown those redirects target **dead XSK fds** — a heartbeat-timeout transit
outage and a UMEM-quiescence ordering violation.

**Invariant:** no packet may be redirected after its worker/UMEM lifetime ends;
the ctrl-disabled fail-closed gate MUST be established before teardown.

## Fix

- `disableUserspaceCtrlLocked` now **returns error**, behind a small
  `ctrlMapUpdater` seam (`*ebpf.Map` satisfies it) so the logic is
  fault-injectable without a privileged BPF map.
- On `Lookup` failure it no longer bails leaving `enabled=1` — it writes a
  zeroed (`Enabled=0`) **fail-closed row anyway**, then returns the read error.
- The `Update` result is **checked** (not discarded) and the row is **read
  back** to confirm `Enabled==0`, so a silent write no-op is caught.
- `disableCtrlBeforeTeardownLocked` wraps the disable at all 4 call sites.
  Teardown can't abort (helper is stopping), so on failure it logs at Error,
  **force-clears ALL binding rows** via `clearAllBindingRowsLocked` (nothing
  READY for the shim to redirect), and returns the error.
- `clearAllBindingRowsLocked` reuses the existing bootstrap zero-all pattern;
  the bootstrap map programmer now calls the shared helper.
- **Happy path byte-for-byte:** a verified disable logs the same `slog.Info`,
  preserves the other ctrl fields, returns nil, and does NOT clear bindings.

Operator-facing behavior (the `ctrl.enabled=0` degraded path) is unchanged —
this is an internal fail-closed robustness fix — so no doc update is needed.

## Validation

Fault-injection fail-on-revert tests (`ctrl_disable_5486_test.go`) against a
fake ctrl map, **run unprivileged** (no memlock gate):

- (a) Lookup fault → fail-closed `Enabled=0` write still attempted + error returned
- (b) Update fault on the teardown path → error returned + all bindings cleared
- (c) readback shows `enabled!=0` → error returned

**RED-on-revert** (neutralizing `disableUserspaceCtrl` back to the swallow
behavior: silent return on Lookup err, discarded Update, no readback):

```
--- FAIL: TestDisableUserspaceCtrlLookupFaultWritesFailClosedAndReturnsError
    ctrl_disable_5486_test.go:71: disableUserspaceCtrl returned nil on lookup fault, want error
--- FAIL: TestDisableCtrlBeforeTeardownUpdateFaultClearsBindings
    ctrl_disable_5486_test.go:95: disableCtrlBeforeTeardownLocked returned nil on update fault, want error
--- FAIL: TestDisableUserspaceCtrlReadbackMismatchReturnsError
    ctrl_disable_5486_test.go:115: disableUserspaceCtrl returned nil on readback mismatch, want error
```

Restored GREEN. Full `go test ./pkg/dataplane/userspace/` passes (unprivileged
and as root, including the real-map link-cycle happy-path tests); `gofmt` /
`go vet` / `go build ./...` clean. The pre-existing
`TestUserspaceManagerDoesNotImportReflectOrUnsafe` failure (`manager_overlay.go`
imports `reflect`) reproduces on pristine `origin/master` and is unrelated.

**Final runtime AF_XDP-lifecycle verify is lab-bound / deferred.**

Closes #5486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj6WhNAWdp6vTuvREojiF8