### PR TITLE
daemon/HA: reuse one warmup socket per family, bound failover neighbor-warm FD cost (#5451)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47563,3 +47563,30 @@ top.
   Pre-existing env failures in the package (applyHelperStatus map-not-loaded,
   XDP-program RX-liveness tests) reproduce identically on pristine
   origin/master cd3ae8973 — not introduced by this change.
+
+- **Timestamp**: 2026-07-12 23:38
+  **Action**: Fix #5451 — warmNeighborCache opened one connected UDP socket per
+  unique session IP with no cap on failover. At CGNAT scale (tens of thousands
+  of unique dsts) that DialTimeout storm exhausted ephemeral ports / file
+  descriptors and stalled failover convergence. Root cause is per-IP socket
+  churn, not simultaneous-open count (the old loop was already sequential
+  dial→write→close), so bounded concurrency would not have helped — replaced
+  the per-IP dial with ONE reusable unconnected datagram socket per address
+  family (net.ListenUDP + WriteToUDPAddrPort per dst). An unconnected send
+  triggers the same kernel neighbor resolution (route lookup →
+  neigh_resolve_output → arp_solicit/ndisc_solicit) as the old connected
+  Write, so every unique IP is still warmed; FD/ephemeral-port high-water mark
+  is now bounded by the constant neighborWarmMaxSockets (=2, one per family),
+  not by session-table size. Sockets are opened lazily per family (none opened
+  for an empty table). Added a minimal injectable seam (neighborWarmDialer /
+  neighborWarmConn) so tests can count sockets + capture probed dsts without
+  touching the network. Warming stays best-effort (a per-probe error does not
+  abort the rest). Did both v4 and v6.
+  **File(s)**: pkg/daemon/daemon_ha.go, pkg/daemon/daemon.go,
+  pkg/daemon/warmneighbor_bound_5451_test.go
+  GREEN: `go test ./pkg/daemon/...` passes; gofmt + vet clean. Fail-on-revert
+  proven: restoring the open-per-IP loop (through the same seam) →
+  TestWarmNeighborCacheBoundsSocketsAtCGNATScale RED ("opened 1000 sockets for
+  1000 unique IPs; want <= 2"); coverage assertion (all 500+500 IPs warmed)
+  stays green both ways; restored GREEN. Live failover-convergence timing
+  verify is cluster/lab-bound (loss cluster shim-ABI-walled) → deferred.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -346,14 +346,20 @@ type Daemon struct {
 	// stays a flat Daemon field: it is the standby-side refresh rate limit read
 	// in daemon_health.go, a different mechanism from the periodic-resolution
 	// supervision grouped here.
-	neighborGuards    neighborPeriodicGuards
-	hbSuppressStart   atomic.Int64 // CLOCK_MONOTONIC nanos of first heartbeat suppression; 0 = inactive (#1792)
-	syncPrimeRetryGen atomic.Uint64
-	syncReadyTimerGen atomic.Uint64
-	syncReadyTimerMu  sync.Mutex
-	syncReadyTimer    *time.Timer
-	syncReadyTimeout  time.Duration
-	slogHandler       *logging.SyslogSlogHandler
+	neighborGuards neighborPeriodicGuards
+	// neighborWarmDialer is the socket factory warmNeighborCache uses to trigger
+	// kernel neighbor (ARP/ND) resolution on failover. Nil in production (the
+	// default udpNeighborWarmDialer is used); tests inject a fake to count
+	// sockets and capture probed destinations without touching the network
+	// (#5451).
+	neighborWarmDialer neighborWarmDialer
+	hbSuppressStart    atomic.Int64 // CLOCK_MONOTONIC nanos of first heartbeat suppression; 0 = inactive (#1792)
+	syncPrimeRetryGen  atomic.Uint64
+	syncReadyTimerGen  atomic.Uint64
+	syncReadyTimerMu   sync.Mutex
+	syncReadyTimer     *time.Timer
+	syncReadyTimeout   time.Duration
+	slogHandler        *logging.SyslogSlogHandler
 	// #3932: the flow-traceoptions writer is published through an atomic
 	// pointer read lock-free by a SINGLE stable EventReader callback that
 	// traceCBOnce registers exactly once. Each commit that changes

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1307,10 +1307,84 @@ func (d *Daemon) clearRethServices() {
 	}
 }
 
+// neighborWarmProbeTimeout bounds each warmup send. A UDP send to an
+// unconnected socket normally returns immediately (the ARP/ND solicit is
+// queued asynchronously), so this deadline effectively never fires; it is a
+// defensive per-probe bound matching the pre-#5451 per-dial DialTimeout.
+const neighborWarmProbeTimeout = 50 * time.Millisecond
+
+// neighborWarmMaxSockets caps how many datagram sockets warmNeighborCache
+// opens, regardless of session-table size: one reusable unconnected socket per
+// address family (IPv4 + IPv6). Before #5451 the warmup opened one CONNECTED
+// socket per unique session IP — at CGNAT scale (tens of thousands of unique
+// destinations) that burst of DialTimeout calls exhausted ephemeral ports / file
+// descriptors and stalled failover convergence, the worst possible time for a
+// local resource storm. Reusing one unconnected socket per family and sending an
+// unconnected datagram per destination triggers the same kernel neighbor
+// resolution (route lookup → neigh_resolve_output → arp_solicit/ndisc_solicit)
+// while bounding the FD/port high-water mark by this constant.
+const neighborWarmMaxSockets = 2
+
+// neighborWarmDialer opens datagram sockets used by warmNeighborCache to
+// trigger kernel neighbor (ARP/ND) resolution. It is a seam so tests can count
+// sockets opened and capture probed destinations without touching the network
+// (#5451).
+type neighborWarmDialer interface {
+	// open returns one datagram socket for the given network ("udp4"/"udp6").
+	open(network string) (neighborWarmConn, error)
+}
+
+// neighborWarmConn is a single unconnected datagram socket that can probe many
+// destinations. probe sends a byte to dst, which triggers neighbor resolution
+// for that destination's next-hop.
+type neighborWarmConn interface {
+	probe(dst netip.AddrPort) error
+	Close() error
+}
+
+// udpNeighborWarmDialer is the production neighborWarmDialer: it opens a real
+// unconnected UDP socket via net.ListenUDP.
+type udpNeighborWarmDialer struct{}
+
+func (udpNeighborWarmDialer) open(network string) (neighborWarmConn, error) {
+	conn, err := net.ListenUDP(network, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &udpNeighborWarmConn{conn: conn}, nil
+}
+
+type udpNeighborWarmConn struct{ conn *net.UDPConn }
+
+func (c *udpNeighborWarmConn) probe(dst netip.AddrPort) error {
+	// A send is what actually drives ARP/ND: connect() alone only does the
+	// route lookup. One byte to (dst, port 1) on the unconnected socket makes
+	// the kernel call neigh_resolve_output() for the next-hop.
+	_ = c.conn.SetWriteDeadline(time.Now().Add(neighborWarmProbeTimeout))
+	_, err := c.conn.WriteToUDPAddrPort([]byte{0}, dst)
+	return err
+}
+
+func (c *udpNeighborWarmConn) Close() error { return c.conn.Close() }
+
+func (d *Daemon) warmDialer() neighborWarmDialer {
+	if d.neighborWarmDialer != nil {
+		return d.neighborWarmDialer
+	}
+	return udpNeighborWarmDialer{}
+}
+
 // warmNeighborCache iterates synced sessions and sends ARP requests /
 // ICMPv6 Neighbor Solicitations for unique destination IPs. This
 // pre-populates the kernel neighbor cache so that bpf_fib_lookup
 // returns SUCCESS (not NO_NEIGH) for the first packet after failover.
+//
+// It reuses ONE unconnected datagram socket per address family (see
+// neighborWarmMaxSockets) rather than opening a connected socket per unique IP,
+// so the failover-time FD/ephemeral-port high-water mark is bounded by a
+// constant instead of by session-table size (#5451). Every unique IP is still
+// warmed; warming stays best-effort (a per-probe error does not abort the
+// rest).
 func (d *Daemon) warmNeighborCache() {
 	if d.dp == nil {
 		return
@@ -1349,36 +1423,41 @@ func (d *Daemon) warmNeighborCache() {
 		return true
 	})
 
-	// Resolve IPv4 neighbors by sending a UDP packet to trigger kernel ARP.
-	// UDP connect() alone does NOT trigger ARP — only the route lookup is
-	// performed. We must send at least one byte so the kernel actually
-	// calls neigh_resolve_output() → arp_solicit().
+	dialer := d.warmDialer()
+
+	// Resolve IPv4 neighbors by sending a UDP datagram per destination to
+	// trigger kernel ARP. One reusable unconnected socket serves every
+	// destination, so FD/port cost is O(1), not O(unique IPs).
 	count := 0
-	for ip4 := range seen {
-		addr := netip.AddrFrom4(ip4)
-		if !addr.IsGlobalUnicast() || addr.IsPrivate() && addr.IsLoopback() {
-			continue
-		}
-		conn, err := net.DialTimeout("udp4", netip.AddrPortFrom(addr, 1).String(), 50*time.Millisecond)
-		if err == nil {
-			conn.Write([]byte{0}) // triggers ARP resolution
+	if len(seen) > 0 {
+		if conn, err := dialer.open("udp4"); err == nil {
+			for ip4 := range seen {
+				addr := netip.AddrFrom4(ip4)
+				if !addr.IsGlobalUnicast() || addr.IsPrivate() && addr.IsLoopback() {
+					continue
+				}
+				if conn.probe(netip.AddrPortFrom(addr, 1)) == nil {
+					count++
+				}
+			}
 			conn.Close()
-			count++
 		}
 	}
 
-	// Resolve IPv6 neighbors.
+	// Resolve IPv6 neighbors (one reusable unconnected socket).
 	countV6 := 0
-	for ip6 := range seenV6 {
-		addr := netip.AddrFrom16(ip6)
-		if !addr.IsGlobalUnicast() {
-			continue
-		}
-		conn, err := net.DialTimeout("udp6", netip.AddrPortFrom(addr, 1).String(), 50*time.Millisecond)
-		if err == nil {
-			conn.Write([]byte{0}) // triggers NDP resolution
+	if len(seenV6) > 0 {
+		if conn, err := dialer.open("udp6"); err == nil {
+			for ip6 := range seenV6 {
+				addr := netip.AddrFrom16(ip6)
+				if !addr.IsGlobalUnicast() {
+					continue
+				}
+				if conn.probe(netip.AddrPortFrom(addr, 1)) == nil {
+					countV6++
+				}
+			}
 			conn.Close()
-			countV6++
 		}
 	}
 

--- a/pkg/daemon/warmneighbor_bound_5451_test.go
+++ b/pkg/daemon/warmneighbor_bound_5451_test.go
@@ -1,0 +1,175 @@
+package daemon
+
+import (
+	"fmt"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// warmNeighborTestStore is a minimal SessionStore that yields a fixed set of
+// IPv4/IPv6 destination IPs to warmNeighborCache. Only ForEachV4/ForEachV6 are
+// exercised; the rest of the interface is embedded (nil) and never called.
+type warmNeighborTestStore struct {
+	dataplane.SessionStore
+	v4 [][4]byte
+	v6 [][16]byte
+}
+
+func (s *warmNeighborTestStore) ForEachV4(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for _, ip := range s.v4 {
+		// SrcIP == DstIP so each session contributes exactly one unique IP.
+		if !fn(dataplane.SessionKey{SrcIP: ip, DstIP: ip}, dataplane.SessionValue{}) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *warmNeighborTestStore) ForEachV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for _, ip := range s.v6 {
+		if !fn(dataplane.SessionKeyV6{SrcIP: ip, DstIP: ip}, dataplane.SessionValueV6{}) {
+			return nil
+		}
+	}
+	return nil
+}
+
+// warmNeighborTestDP is a minimal RuntimeDataPlane whose Sessions() returns the
+// injected store. warmNeighborCache only touches d.dp.Sessions().
+type warmNeighborTestDP struct {
+	dataplane.RuntimeDataPlane
+	store dataplane.SessionStore
+}
+
+func (d *warmNeighborTestDP) Sessions() dataplane.SessionStore { return d.store }
+
+// countingWarmDialer records every socket opened and every destination probed
+// so the test can assert (a) the socket high-water mark is bounded by a
+// constant and (b) every unique IP was warmed.
+type countingWarmDialer struct {
+	mu       sync.Mutex
+	opens    int                // total sockets opened (the resource high-water)
+	probedV4 map[netip.Addr]int // dst -> probe count (udp4 socket)
+	probedV6 map[netip.Addr]int // dst -> probe count (udp6 socket)
+}
+
+func newCountingWarmDialer() *countingWarmDialer {
+	return &countingWarmDialer{
+		probedV4: map[netip.Addr]int{},
+		probedV6: map[netip.Addr]int{},
+	}
+}
+
+func (c *countingWarmDialer) open(network string) (neighborWarmConn, error) {
+	c.mu.Lock()
+	c.opens++
+	c.mu.Unlock()
+	return &countingWarmConn{dialer: c, network: network}, nil
+}
+
+type countingWarmConn struct {
+	dialer  *countingWarmDialer
+	network string
+}
+
+func (c *countingWarmConn) probe(dst netip.AddrPort) error {
+	c.dialer.mu.Lock()
+	defer c.dialer.mu.Unlock()
+	if c.network == "udp6" {
+		c.dialer.probedV6[dst.Addr()]++
+	} else {
+		c.dialer.probedV4[dst.Addr()]++
+	}
+	return nil
+}
+
+func (c *countingWarmConn) Close() error { return nil }
+
+// TestWarmNeighborCacheBoundsSocketsAtCGNATScale is the #5451 regression guard.
+// With a large session table (500 unique v4 + 500 unique v6 destinations) the
+// warmup must open a CONSTANT number of sockets (one reusable socket per
+// family), not one per unique IP, while still warming every destination.
+//
+// Fail-on-revert: restoring the pre-#5451 open-per-IP loop drives `opens` to
+// ~1000 (one socket per unique IP), tripping the neighborWarmMaxSockets bound.
+func TestWarmNeighborCacheBoundsSocketsAtCGNATScale(t *testing.T) {
+	const n = 500
+
+	v4 := make([][4]byte, 0, n)
+	wantV4 := map[netip.Addr]bool{}
+	for i := 0; i < n; i++ {
+		// 100.64.0.0/10 (CGNAT) — global-unicast, non-private, passes the filter.
+		ip := [4]byte{100, 64, byte(i / 256), byte(i % 256)}
+		v4 = append(v4, ip)
+		wantV4[netip.AddrFrom4(ip)] = true
+	}
+
+	v6 := make([][16]byte, 0, n)
+	wantV6 := map[netip.Addr]bool{}
+	for i := 0; i < n; i++ {
+		// 2001:db8::/32 documentation range — global unicast.
+		var ip [16]byte
+		ip[0], ip[1] = 0x20, 0x01
+		ip[2], ip[3] = 0x0d, 0xb8
+		ip[14] = byte(i / 256)
+		ip[15] = byte(i % 256)
+		v6 = append(v6, ip)
+		wantV6[netip.AddrFrom16(ip)] = true
+	}
+
+	dialer := newCountingWarmDialer()
+	d := &Daemon{
+		dp:                 &warmNeighborTestDP{store: &warmNeighborTestStore{v4: v4, v6: v6}},
+		neighborWarmDialer: dialer,
+	}
+
+	d.warmNeighborCache()
+
+	// (a) Bound: sockets opened must be a small constant, NOT ~one per IP.
+	if dialer.opens > neighborWarmMaxSockets {
+		t.Errorf("opened %d sockets for %d unique IPs; want <= %d (socket per family, not per IP)",
+			dialer.opens, 2*n, neighborWarmMaxSockets)
+	}
+
+	// (b) Coverage: every unique destination must be warmed exactly once — no
+	// correctness regression from the resource bound.
+	if err := assertWarmedExactly(dialer.probedV4, wantV4); err != nil {
+		t.Errorf("v4 coverage: %v", err)
+	}
+	if err := assertWarmedExactly(dialer.probedV6, wantV6); err != nil {
+		t.Errorf("v6 coverage: %v", err)
+	}
+}
+
+// TestWarmNeighborCacheNoSocketsWhenEmpty confirms the warmup opens no sockets
+// when there are no sessions (lazy per-family open).
+func TestWarmNeighborCacheNoSocketsWhenEmpty(t *testing.T) {
+	dialer := newCountingWarmDialer()
+	d := &Daemon{
+		dp:                 &warmNeighborTestDP{store: &warmNeighborTestStore{}},
+		neighborWarmDialer: dialer,
+	}
+	d.warmNeighborCache()
+	if dialer.opens != 0 {
+		t.Errorf("opened %d sockets for an empty session table; want 0", dialer.opens)
+	}
+}
+
+func assertWarmedExactly(got map[netip.Addr]int, want map[netip.Addr]bool) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("warmed %d distinct IPs, want %d", len(got), len(want))
+	}
+	for ip := range want {
+		c, ok := got[ip]
+		if !ok {
+			return fmt.Errorf("IP %v was never warmed", ip)
+		}
+		if c != 1 {
+			return fmt.Errorf("IP %v warmed %d times, want exactly 1", ip, c)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Defect
On failover, `warmNeighborCache` (`pkg/daemon/daemon_ha.go`) collected every unique src/dst IP from the session table (bounded only by table size) and opened **one connected UDP socket per unique IP** via `net.DialTimeout`, with no cap. At CGNAT scale (tens of thousands of unique destinations) this fired a burst of tens of thousands of `DialTimeout` calls on the new primary right when failover latency matters, exhausting ephemeral ports / file descriptors and stalling failover convergence.

The root cause is **per-IP socket churn**, not simultaneous-open count: the old loop was already sequential (`dial → write → close`), so bounding *concurrency* would not help (and would even raise peak FDs vs the sequential original). The fix must reduce the *total* number of sockets, not just the in-flight count.

## Fix
Reuse **one unconnected datagram socket per address family** (`net.ListenUDP` + `WriteToUDPAddrPort` per destination) instead of a socket per IP. An unconnected send triggers the same kernel neighbor resolution (route lookup → `neigh_resolve_output` → `arp_solicit`/`ndisc_solicit`) as the old connected `Write`, so:

- **every unique IP is still warmed** (no correctness regression);
- the FD/ephemeral-port high-water mark is bounded by the constant `neighborWarmMaxSockets` (=2, one per family) **regardless of session-table size**;
- sockets are opened **lazily per family** (zero sockets for an empty table);
- warming stays **best-effort** (a per-probe error does not abort the rest), matching prior behavior.

Both v4 and v6 paths are fixed. A minimal test seam (`neighborWarmDialer` / `neighborWarmConn`, overridable via a nil-by-default `Daemon` field, default `udpNeighborWarmDialer`) lets tests count sockets and capture probed destinations without touching the network.

**Pure Go control-plane change — no wire/ABI/forwarding/Rust surface touched.**

## Validation
Added `pkg/daemon/warmneighbor_bound_5451_test.go`: drives a 500-unique-v4 + 500-unique-v6 session table (CGNAT `100.64/10` + `2001:db8::/32`) through a counting fake dialer and asserts (a) `opens <= neighborWarmMaxSockets` and (b) every unique IP is warmed **exactly once**; plus an empty-table case asserting zero sockets opened.

`go test ./pkg/daemon/...` passes; `go vet ./pkg/daemon/` + `gofmt -l` clean.

### Fail-on-revert (RED) proof
Restoring the open-per-IP loop (through the same seam) turns the bound test RED while coverage stays green:
```
=== RUN   TestWarmNeighborCacheBoundsSocketsAtCGNATScale
    warmneighbor_bound_5451_test.go:133: opened 1000 sockets for 1000 unique IPs; want <= 2 (socket per family, not per IP)
--- FAIL: TestWarmNeighborCacheBoundsSocketsAtCGNATScale (0.20s)
=== RUN   TestWarmNeighborCacheNoSocketsWhenEmpty
--- PASS: TestWarmNeighborCacheNoSocketsWhenEmpty (0.00s)
```
The fix restores GREEN.

> **Live failover-timing verify deferred** — end-to-end failover-convergence measurement is cluster/lab-bound (the loss userspace cluster is shim-ABI-walled per project memory), so the runtime failover-latency improvement is not measured here. The unit test covers the resource-bound + coverage invariant that is the fix's contract.

Closes #5451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNEVrePodApsgbw6bvkcSw