### PR TITLE
userspace: retry stranded standalone HA-state clear via debt flag

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47620,3 +47620,37 @@ top.
   restored GREEN. Pre-existing failure
   TestUserspaceManagerDoesNotImportReflectOrUnsafe (manager_overlay.go imports
   reflect) reproduces on pristine origin/master — not this change.
+
+- **Timestamp**: 2026-07-12
+  **Action**: #5487 (codex-review-179 A6/C179-084) — standalone HA-state clear
+  had no retry/debt. Both non-cluster clear sites in manager_compile.go (~276
+  deferred-startup, ~363 post-apply) did
+  `if err := m.clearHelperHAStateLocked(); err != nil { return ..., err }`. The
+  snapshot is already acknowledged; if that idempotent empty `update_ha_state`
+  RPC hit a transient control-socket error the apply returned an error but the
+  helper kept stale HA groups while the manager is clusterHA=false. The status
+  poll's HA sync is gated behind `m.clusterHA` (process_status.go) and a
+  freshly-started helper hasn't reached ensureStatusLoopLocked, so the clear
+  was NEVER retried → owner_rg_id<=0 forwarding candidates stay HAInactive =
+  standalone transit forwarding outage until an unrelated full apply. Fix
+  (mirrors the existing #5134 pendingWorkerArm debt): added
+  `pendingHAStateClear` debt flag + `clearHelperHAStateWithDebtLocked`
+  (records debt on failure, still returns the error so the apply fails closed;
+  clears debt on success) used at BOTH standalone sites, and
+  `retryPendingHAStateClearLocked` invoked from the poll tick OUTSIDE the
+  clusterHA guard but only while standalone (retrying an empty update while
+  clustered would wipe live RG HA state). Fault-injection seam
+  (clearHelperHAStateHook) makes tests run unprivileged. Operator-facing
+  behavior (standalone ⇒ empty helper ha_state) unchanged — internal
+  convergence robustness — so no doc update needed. Final live
+  standalone-forwarding verify is cluster/lab-bound (deferred).
+  **File(s)**: pkg/dataplane/userspace/manager.go,
+  pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/manager_compile.go,
+  pkg/dataplane/userspace/process_status.go,
+  pkg/dataplane/userspace/hastate_clear_debt_5487_test.go
+  GREEN: full `go test ./pkg/dataplane/userspace/` passes; gofmt + go vet +
+  `go build ./...` clean. Fail-on-revert proven: neutralizing the debt-set and
+  retry (pre-fix absent behavior) turns three tests RED — "retry debt was not
+  recorded" (failed clear), "clearHelperHAStateLocked called 0 times, want 1"
+  (poll-tick retry x2); restored GREEN.

--- a/pkg/dataplane/userspace/hastate_clear_debt_5487_test.go
+++ b/pkg/dataplane/userspace/hastate_clear_debt_5487_test.go
@@ -1,0 +1,113 @@
+package userspace
+
+import (
+	"errors"
+	"testing"
+)
+
+// #5487: a standalone HA-state clear that fails must record a retry debt so the
+// status poll re-attempts the idempotent empty update_ha_state until it
+// succeeds — otherwise a cluster->standalone reconfig with a transient
+// control-socket error leaves stale helper HA groups and owner-RG-0 transit
+// forwarding stays HAInactive (drop). The clearHelperHAStateHook seam injects
+// the clear result so these run unprivileged (no control socket / BPF maps).
+
+// (a) A failed standalone clear sets the debt AND surfaces the error (the apply
+// call sites return this error, failing closed).
+func TestClearHelperHAStateWithDebtRecordsDebtOnFailure(t *testing.T) {
+	m := New()
+	clearErr := errors.New("update_ha_state boom")
+	m.clearHelperHAStateHook = func() error { return clearErr }
+
+	err := m.clearHelperHAStateWithDebtLocked()
+	if err == nil {
+		t.Fatal("clearHelperHAStateWithDebtLocked returned nil on clear failure, want error")
+	}
+	if !errors.Is(err, clearErr) {
+		t.Fatalf("returned error = %v, want it to wrap the clear failure", err)
+	}
+	if !m.pendingHAStateClear {
+		t.Fatal("pendingHAStateClear = false after failed standalone clear; the retry debt was not recorded (the clear can never be retried)")
+	}
+}
+
+// (b) A subsequent poll tick with the debt set retries the clear and clears the
+// debt on success.
+func TestRetryPendingHAStateClearReconcilesOnPollTick(t *testing.T) {
+	m := New()
+	m.pendingHAStateClear = true
+	m.clusterHA = false
+
+	calls := 0
+	m.clearHelperHAStateHook = func() error {
+		calls++
+		return nil // clear now succeeds
+	}
+
+	m.retryPendingHAStateClearLocked()
+
+	if calls != 1 {
+		t.Fatalf("clearHelperHAStateLocked called %d times on poll-tick retry, want 1", calls)
+	}
+	if m.pendingHAStateClear {
+		t.Fatal("pendingHAStateClear = true after a successful retry; the debt must clear so the poll stops re-attempting")
+	}
+}
+
+// (b') A retry that fails again keeps the debt set for the next tick.
+func TestRetryPendingHAStateClearKeepsDebtOnRepeatFailure(t *testing.T) {
+	m := New()
+	m.pendingHAStateClear = true
+	m.clusterHA = false
+
+	calls := 0
+	m.clearHelperHAStateHook = func() error {
+		calls++
+		return errors.New("still failing")
+	}
+
+	m.retryPendingHAStateClearLocked()
+
+	if calls != 1 {
+		t.Fatalf("clearHelperHAStateLocked called %d times, want 1", calls)
+	}
+	if !m.pendingHAStateClear {
+		t.Fatal("pendingHAStateClear = false after a failed retry; the debt must persist so the next tick re-attempts")
+	}
+}
+
+// (c) The success path records no debt.
+func TestClearHelperHAStateWithDebtNoDebtOnSuccess(t *testing.T) {
+	m := New()
+	m.clearHelperHAStateHook = func() error { return nil }
+
+	if err := m.clearHelperHAStateWithDebtLocked(); err != nil {
+		t.Fatalf("clearHelperHAStateWithDebtLocked returned %v on success, want nil", err)
+	}
+	if m.pendingHAStateClear {
+		t.Fatal("pendingHAStateClear = true after a successful clear, want false")
+	}
+}
+
+// The retry must NOT fire while clustered: retrying an empty update_ha_state on
+// a cluster node would wipe the live redundancy-group HA state.
+func TestRetryPendingHAStateClearSkippedWhenClustered(t *testing.T) {
+	m := New()
+	m.pendingHAStateClear = true
+	m.clusterHA = true
+
+	calls := 0
+	m.clearHelperHAStateHook = func() error {
+		calls++
+		return nil
+	}
+
+	m.retryPendingHAStateClearLocked()
+
+	if calls != 0 {
+		t.Fatalf("clearHelperHAStateLocked called %d times while clustered, want 0 (would wipe live HA state)", calls)
+	}
+	if !m.pendingHAStateClear {
+		t.Fatal("pendingHAStateClear cleared while clustered without running the clear; debt state corrupted")
+	}
+}

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -207,6 +207,22 @@ type Manager struct {
 	// helper / control-socket error.
 	pendingWorkerArm bool
 
+	// pendingHAStateClear records "clear debt" from a standalone (non-cluster)
+	// HA-state clear whose idempotent empty update_ha_state RPC failed (#5487).
+	// A cluster->standalone reconfig clears the helper's HA groups; if that RPC
+	// hits a transient control-socket error the apply returns an error but the
+	// helper keeps the stale groups while the manager is clusterHA=false. The
+	// status poll's HA sync is gated behind m.clusterHA, so the clear is never
+	// retried and owner_rg_id<=0 forwarding candidates stay HAInactive (transit
+	// drop). The poll tick retries clearHelperHAStateLocked while this is set,
+	// OUTSIDE the clusterHA guard, until the helper reports no groups.
+	pendingHAStateClear bool
+
+	// clearHelperHAStateHook, when non-nil, replaces the update_ha_state RPC in
+	// clearHelperHAStateLocked so tests can inject a transient clear failure
+	// without a control socket (#5487). Production leaves it nil.
+	clearHelperHAStateHook func() error
+
 	lookupUserspaceCtrlForFailClosedHook userspaceCtrlLookupHook
 
 	// disableCtrlMapHook, when non-nil, replaces the bpfShim userspace_ctrl

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -273,7 +273,9 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		// helper side here too so the standalone state is consistent
 		// regardless of which apply path runs. (Idempotent empty update.)
 		if !m.clusterHA {
-			if err := m.clearHelperHAStateLocked(); err != nil {
+			if err := m.clearHelperHAStateWithDebtLocked(); err != nil {
+				// Debt recorded — the status poll retries the clear until it
+				// succeeds; still surface the error so the apply fails closed.
 				return result, fmt.Errorf("clear userspace HA state (deferred startup): %w", err)
 			}
 		}
@@ -360,12 +362,15 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		if err := m.syncHAStateLocked(); err != nil {
 			return result, fmt.Errorf("publish userspace HA state: %w", err)
 		}
-	} else if err := m.clearHelperHAStateLocked(); err != nil {
+	} else if err := m.clearHelperHAStateWithDebtLocked(); err != nil {
 		// Non-cluster node: ensure neither the manager nor the helper retains
 		// HA groups. seedHAGroupInventoryLocked already cleared m.haGroups
 		// above; this also clears any groups a prior clustered apply pushed to
 		// the helper (cluster->standalone live reconfig), which would otherwise
 		// keep the HAInactive transit-drop gate armed (Codex review #1928 Q3).
+		// On failure a retry debt is recorded (#5487) so the status poll
+		// re-attempts the idempotent clear until the helper reports no groups;
+		// the error is still surfaced so this apply fails closed.
 		return result, fmt.Errorf("clear userspace HA state: %w", err)
 	}
 	if err := m.syncDesiredForwardingStateLocked(); err != nil {

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -76,6 +76,9 @@ func (m *Manager) syncHAStateLocked() error {
 // from the supplied groups, so an empty slice clears it (afxdp/ha.rs). This runs
 // only on snapshot apply for non-cluster nodes (rare), not on the hot path.
 func (m *Manager) clearHelperHAStateLocked() error {
+	if m.clearHelperHAStateHook != nil {
+		return m.clearHelperHAStateHook()
+	}
 	if m.proc == nil || m.proc.Process == nil {
 		return nil
 	}
@@ -90,6 +93,37 @@ func (m *Manager) clearHelperHAStateLocked() error {
 		return err
 	}
 	return m.applyHelperStatusLocked(&status)
+}
+
+// clearHelperHAStateWithDebtLocked runs the idempotent standalone HA-state
+// clear and records a retry debt if it fails (#5487). The apply path still
+// surfaces the error (fail-closed), but the debt lets the status poll retry
+// the clear until it succeeds — a transient control-socket error on a
+// cluster->standalone reconfig must not permanently strand stale helper HA
+// groups (which keep owner_rg_id<=0 transit ForwardCandidates HAInactive). On
+// success the debt is cleared. Both standalone clear sites in the apply path
+// use this instead of the bare clear.
+func (m *Manager) clearHelperHAStateWithDebtLocked() error {
+	if err := m.clearHelperHAStateLocked(); err != nil {
+		m.pendingHAStateClear = true
+		return err
+	}
+	m.pendingHAStateClear = false
+	return nil
+}
+
+// retryPendingHAStateClearLocked settles a stranded standalone HA-state clear
+// debt from the status poll tick. It runs OUTSIDE the m.clusterHA HA-sync guard
+// (that guard is exactly why a standalone clear is never retried), but only
+// while the node is actually standalone: retrying an empty update_ha_state on a
+// clustered node would wipe the live redundancy-group HA state.
+func (m *Manager) retryPendingHAStateClearLocked() {
+	if !m.pendingHAStateClear || m.clusterHA {
+		return
+	}
+	if err := m.clearHelperHAStateWithDebtLocked(); err != nil {
+		slog.Warn("userspace: standalone HA-state clear retry failed; will retry next tick", "err", err)
+	}
 }
 
 // SyncFabricState pushes current fabric snapshots (with fresh peer MACs)

--- a/pkg/dataplane/userspace/process_status.go
+++ b/pkg/dataplane/userspace/process_status.go
@@ -176,6 +176,14 @@ func (m *Manager) statusLoop(ctx context.Context) {
 						slog.Warn("userspace: deferred-worker arm retry failed; will retry", "err", err)
 					}
 				}
+				// #5487: settle a stranded standalone HA-state clear. The
+				// clusterHA-gated HA sync below never retries the empty
+				// update_ha_state on a standalone node, so a transient failure
+				// during a cluster->standalone reconfig would leave stale helper
+				// HA groups that keep owner-RG-0 transit HAInactive (drop). Retry
+				// the idempotent clear here (ungated by clusterHA, but only while
+				// standalone) until it succeeds.
+				m.retryPendingHAStateClearLocked()
 				helperActiveSig := activeHAGroupSignatureSlice(status.HAGroups)
 				if m.clusterHA {
 					_ = m.refreshHAStateFromMapsLocked()


### PR DESCRIPTION
## Summary

Fixes #5487 (codex-review-179 A6/C179-084). The two non-cluster HA-state clear
sites in the apply path (`manager_compile.go`: deferred-startup ~276 and
post-apply ~363) did `if err := m.clearHelperHAStateLocked(); err != nil {
return ..., err }`. The snapshot is **already acknowledged** by the time this
runs. If the idempotent empty `update_ha_state` RPC hits a transient
control-socket error, the apply returns an error but the helper keeps the HA
groups a prior clustered apply pushed, while the manager is `clusterHA=false`.

The periodic status poll gates its HA sync behind `m.clusterHA`, and a freshly
started helper hasn't reached `ensureStatusLoopLocked`, so the failed empty
update is **never retried**. A non-empty helper HA map makes `owner_rg_id<=0`
transit ForwardCandidates resolve **HAInactive** and drops them — a standalone
transit forwarding outage that persists until an unrelated full apply.

**Invariant:** `standalone ⇒ helper ha_state is empty` is a packet-time
invariant; its idempotent clear must converge.

## Fix (mirrors the existing #5134 `pendingWorkerArm` debt)

- Add a `pendingHAStateClear` debt flag and `clearHelperHAStateWithDebtLocked`,
  which records the debt on failure (**and still returns the error** so the
  apply fails closed) and clears it on success. Both standalone clear sites now
  use it.
- `retryPendingHAStateClearLocked` re-attempts the idempotent clear from the
  status poll tick, **outside** the `m.clusterHA` HA-sync guard (that guard is
  exactly why the standalone clear is stranded) but **only while standalone** —
  retrying an empty update on a clustered node would wipe the live
  redundancy-group HA state.

Operator-facing behavior (`standalone ⇒ empty helper ha_state`) is unchanged —
this is internal convergence robustness — so no doc update is needed.

## Validation

Fault-injection fail-on-revert tests (`hastate_clear_debt_5487_test.go`) use a
`clearHelperHAStateHook` seam so they **run unprivileged** (no control socket /
BPF maps). They cover: a failed clear records the debt + surfaces the error; a
poll-tick retry reconciles and clears the debt on success; a repeat failure
keeps the debt; the success path records no debt; and the retry is skipped
while clustered.

**RED-on-revert** (neutralizing the debt-set and retry back to the pre-fix
absent behavior):

```
--- FAIL: TestClearHelperHAStateWithDebtRecordsDebtOnFailure
    hastate_clear_debt_5487_test.go:30: pendingHAStateClear = false after failed standalone clear; the retry debt was not recorded (the clear can never be retried)
--- FAIL: TestRetryPendingHAStateClearReconcilesOnPollTick
    hastate_clear_debt_5487_test.go:50: clearHelperHAStateLocked called 0 times on poll-tick retry, want 1
--- FAIL: TestRetryPendingHAStateClearKeepsDebtOnRepeatFailure
    hastate_clear_debt_5487_test.go:72: clearHelperHAStateLocked called 0 times, want 1
```

Restored GREEN. Full `go test ./pkg/dataplane/userspace/` passes; `gofmt` /
`go vet` / `go build ./...` clean.

**Final live standalone-forwarding verify is cluster/lab-bound and deferred.**

Closes #5487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj6WhNAWdp6vTuvREojiF8