### PR TITLE
config: reject same-name address/address-set collision (#5676)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47680,3 +47680,33 @@ top.
   retry (pre-fix absent behavior) turns three tests RED — "retry debt was not
   recorded" (failed clear), "clearHelperHAStateLocked called 0 times, want 1"
   (poll-tick retry x2); restored GREEN.
+
+- **Timestamp**: 2026-07-13
+  **Action**: Fix #5676 (codex-review-182 M10, High) — address-book `address`
+  and `address-set` names share one untagged namespace, so a plain address
+  silently SHADOWS a same-named address-set at name→prefix resolution
+  (address-first everywhere: dataplane expandBookNameRecursive /
+  nameRepresentability / capabilities, host-inbound junos_host_deny), changing
+  which traffic a permit/deny rule covers with no diagnostic. Fix: new strict
+  gate `validateAddressBookNameCollisionStrict` (+ `resolveAddressBookNameKind`
+  SSOT encoding the deterministic address-first winner + `AddressBookRefKind`)
+  in `compiler_validate_strict_addrbook.go`, wired in `runEarlyStrictAndFolds`
+  right after `validateAddressBookEntryNamesStrict` and BEFORE the zone-local
+  fold (pristine-book ordering — so global vs different-zone names aren't
+  misreported and a real zone-local collision names the clean zone). Strict on
+  commit/commit-check = HARD REJECT (matches vSRX, which forbids the collision);
+  tolerant load/peer-sync = WARN + keep the address-first winner
+  (`lenientAddressBookNameCollision`, #1960 no-brick so a leniently-loaded
+  config forwards exactly as before). Pure pkg/config — no dataplane/Rust/wire
+  change.
+  **File(s)**: pkg/config/compiler_validate_strict_addrbook.go (new),
+  pkg/config/addr_set_namespace_5676_test.go (new),
+  pkg/config/compiler_earlystrict.go, pkg/config/compiler.go,
+  docs/config-schema.md
+  GREEN: `go test ./pkg/config/...` passes (incl. TestEveryStrictCommitGateIsWired
+  canary + golden). gofmt clean on touched files, go vet clean. Fail-on-revert
+  proven: unwiring the `validateAddressBookNameCollisionStrict` dispatch turns
+  the strict-reject (global + both orderings + zone-local) and lenient-warn
+  tests RED — "expected strict commit to reject a same-name address +
+  address-set collision", "lenient compile must record a collision warning";
+  restored GREEN.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -309,6 +309,42 @@ reject identically = order-independent, lenient-warn, non-colliding-commits) and
 the reconciled `tunnelid_test.go` duplicate-spelling case, each RED on revert of
 the gate wiring.
 
+### security address-book same-name `address` + `address-set` collision (#5676)
+
+`address` and `address-set` entries share ONE operator-visible namespace (a
+policy `match source-address <name>` / `destination-address <name>` names a
+single token) but are stored in two SEPARATE maps
+(`AddressBook.Addresses` / `AddressBook.AddressSets`). So an operator can author
+`address blocklist 10.0.1.0/24` AND `address-set blocklist { address other; }`
+in the same book with no commit error — and every place a name is resolved to
+prefixes checks `Addresses` before `AddressSets` (**address-first**: the
+dataplane `expandBookNameRecursive` / `nameRepresentability` /
+`capabilities`, and the host-inbound `junos_host_deny` compiler). The plain
+address therefore SILENTLY SHADOWS the same-named address-set: a deny built on
+the SET covers only the single address, so the set's other members leak (an
+under-block) — a security-relevant change to which traffic a rule covers, with
+no diagnostic (codex-review-182 M10, High).
+
+`validateAddressBookNameCollisionStrict` (`compiler_validate_strict_addrbook.go`,
+wired in `runEarlyStrictAndFolds` right after `validateAddressBookEntryNamesStrict`
+and BEFORE the zone-local fold — the same PRISTINE-book ordering constraint, so a
+global `address foo` and a *different* zone's zone-local `address-set foo`
+(genuinely distinct namespaces after the fold) are never misreported, and a real
+zone-local collision names the clean zone). It hard-rejects the collision on the
+strict commit / commit-check path — matching vSRX, which itself forbids a
+same-name `address` + `address-set` in one book (there is no vendor-defined
+precedence to honor). The tolerant load / peer-sync path
+(`opts.lenientAddressBookNameCollision`, #1960 no-brick) downgrades to a
+`cfg.Warnings` entry so an already-persisted or peer-synced config carrying a
+pre-existing collision still BOOTS — and keeps the **deterministic address-first
+winner** the runtime already used (`resolveAddressBookNameKind`, the single
+source of truth), so a leniently-loaded config forwards exactly as before rather
+than silently changing its dispositions on reload. Covered by
+`pkg/config/addr_set_namespace_5676_test.go` (global + zone-local reject,
+both config orderings, lenient-warn, deterministic-winner, namespace-aware
+absent-collision, non-colliding-commits), the strict-reject + lenient-warn cases
+RED on revert of the gate wiring.
+
 ## Multi-value leaves and bracketed lists (the dual-AST contract)
 
 A `multi: true` leaf with `children: nil` (e.g. `from protocol`,

--- a/pkg/config/addr_set_namespace_5676_test.go
+++ b/pkg/config/addr_set_namespace_5676_test.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5676 (codex-review-182 M10, High): an address book (global or
+// zone-local) that defines the SAME name as BOTH a plain `address` AND an
+// `address-set`. The two kinds share one operator-visible namespace but are
+// stored in separate maps (AddressBook.Addresses / AddressBook.AddressSets), so
+// the collision committed silently and every name→prefix resolver
+// (pkg/dataplane/userspace expandBookNameRecursive, host-inbound junos_host_deny)
+// resolved address-first — the plain address SHADOWED the same-named
+// address-set, dropping the set's other members and changing which traffic a
+// permit/deny rule covers with no diagnostic.
+//
+// The fix hard-rejects the collision on the strict commit / commit-check path
+// (validateAddressBookNameCollisionStrict, wired in runEarlyStrictAndFolds) and
+// downgrades to a warning on the tolerant load / peer-sync path
+// (CompileConfigLenient, opts.lenientAddressBookNameCollision), keeping the
+// deterministic address-first winner the runtime already used.
+//
+// FAIL-ON-REVERT: dropping the `if err := validateAddressBookNameCollisionStrict(
+// cfg); ... ` dispatch in compiler_earlystrict.go turns every strict-reject case
+// GREEN (CompileConfig accepts the collision) and drops the lenient warning — so
+// TestAddrSetCollision{Global,ZoneLocal}RejectedAtCommit and
+// TestAddrSetCollisionLenientDowngrades go RED.
+
+// TestAddrSetCollisionGlobalRejectedAtCommit — a global address book that names
+// the same token as both an `address` and an `address-set` is rejected at strict
+// commit, and the diagnostic names both the colliding entry and the book.
+func TestAddrSetCollisionGlobalRejectedAtCommit(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security address-book global address blocklist 10.0.1.0/24",
+		"set security address-book global address other 10.9.9.9/32",
+		"set security address-book global address-set blocklist address other",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected strict commit to reject a same-name address + address-set collision in the global book")
+	}
+	msg := err.Error()
+	for _, want := range []string{"blocklist", "address", "address-set", "global"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("collision error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestAddrSetCollisionGlobalRejectedBothOrderings — the reject is independent of
+// the order the two entries appear in the config (the collision is a property of
+// the two maps, not of set-command line order). Junos-parity: vSRX rejects the
+// second same-name definition regardless of which kind was declared first.
+func TestAddrSetCollisionGlobalRejectedBothOrderings(t *testing.T) {
+	orderings := map[string][]string{
+		"address-first": {
+			"set security address-book global address dup 10.0.1.0/24",
+			"set security address-book global address m 10.2.2.2/32",
+			"set security address-book global address-set dup address m",
+		},
+		"set-first": {
+			"set security address-book global address m 10.2.2.2/32",
+			"set security address-book global address-set dup address m",
+			"set security address-book global address dup 10.0.1.0/24",
+		},
+	}
+	for name, cmds := range orderings {
+		t.Run(name, func(t *testing.T) {
+			if _, err := CompileConfig(buildTree(t, cmds)); err == nil {
+				t.Fatalf("expected strict commit to reject the collision (%s ordering)", name)
+			}
+		})
+	}
+}
+
+// TestAddrSetCollisionZoneLocalRejectedAtCommit — the gate covers zone-local
+// address books too (#3061), and names the offending zone (validated on the
+// pristine book BEFORE the zone-local fold).
+func TestAddrSetCollisionZoneLocalRejectedAtCommit(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone trust interfaces eth0",
+		"set security zones security-zone trust address-book address grp 10.0.5.0/24",
+		"set security zones security-zone trust address-book address inner 10.0.6.7/32",
+		"set security zones security-zone trust address-book address-set grp address inner",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected strict commit to reject a same-name collision in a zone-local address book")
+	}
+	msg := err.Error()
+	for _, want := range []string{"grp", "trust", "address-set"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("zone-local collision error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestAddrSetCollisionLenientDowngrades — the tolerant load / peer-sync path
+// (#1960 no-brick) must NOT fail-closed on a pre-existing collision: it records
+// a warning and boots, keeping the deterministic address-first winner so the
+// config forwards exactly as before.
+func TestAddrSetCollisionLenientDowngrades(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security address-book global address blocklist 10.0.1.0/24",
+		"set security address-book global address other 10.9.9.9/32",
+		"set security address-book global address-set blocklist address other",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not brick on a pre-existing collision: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "collision") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile must record a collision warning; warnings = %v", cfg.Warnings)
+	}
+	// Both entries survive in their distinct maps — the namespace is tagged at
+	// storage, and the runtime resolver picks the documented winner.
+	ab := cfg.Security.AddressBook
+	if _, ok := ab.Addresses["blocklist"]; !ok {
+		t.Fatalf("expected the plain address `blocklist` to survive the lenient load")
+	}
+	if _, ok := ab.AddressSets["blocklist"]; !ok {
+		t.Fatalf("expected the address-set `blocklist` to survive the lenient load")
+	}
+}
+
+// TestAddrSetCollisionDeterministicWinner is the security-relevant resolution
+// assertion: given a collision, resolution is DETERMINISTIC — the plain
+// `address` WINS (address-first), matching the runtime name→prefix resolver
+// bit-for-bit. So a policy `match source-address blocklist` / `deny` covers
+// exactly the plain address's prefix, never an unpredictable mix, and an
+// operator/reviewer can reason about which traffic the rule covers. The winner
+// is a property of the two KINDS, not of config-set order (both orderings
+// resolve identically).
+func TestAddrSetCollisionDeterministicWinner(t *testing.T) {
+	build := func(t *testing.T, cmds []string) *AddressBook {
+		t.Helper()
+		cfg, err := CompileConfigLenient(buildTree(t, cmds))
+		if err != nil {
+			t.Fatalf("lenient compile: %v", err)
+		}
+		return cfg.Security.AddressBook
+	}
+
+	addressFirst := build(t, []string{
+		"set security address-book global address blocklist 10.0.1.0/24",
+		"set security address-book global address other 10.9.9.9/32",
+		"set security address-book global address-set blocklist address other",
+		"set security policies from-zone trust to-zone untrust policy deny-grp match source-address blocklist",
+		"set security policies from-zone trust to-zone untrust policy deny-grp match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy deny-grp match application any",
+		"set security policies from-zone trust to-zone untrust policy deny-grp then deny",
+	})
+	setFirst := build(t, []string{
+		"set security address-book global address other 10.9.9.9/32",
+		"set security address-book global address-set blocklist address other",
+		"set security address-book global address blocklist 10.0.1.0/24",
+	})
+
+	for name, ab := range map[string]*AddressBook{"address-first": addressFirst, "set-first": setFirst} {
+		kind, collision := resolveAddressBookNameKind(ab, "blocklist")
+		if !collision {
+			t.Fatalf("[%s] expected resolveAddressBookNameKind to report a collision", name)
+		}
+		if kind != AddrRefAddress {
+			t.Fatalf("[%s] expected the plain address to win the collision (address-first), got kind=%d", name, kind)
+		}
+	}
+}
+
+// TestAddrSetNameKindNamespaceAware — ABSENT a collision, the two kinds are
+// distinguishable and each resolves to its own kind; an undefined name is None.
+func TestAddrSetNameKindNamespaceAware(t *testing.T) {
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set security address-book global address lone-addr 10.0.1.0/24",
+		"set security address-book global address member 10.0.2.0/24",
+		"set security address-book global address-set lone-set address member",
+	}))
+	if err != nil {
+		t.Fatalf("non-colliding book must compile clean: %v", err)
+	}
+	ab := cfg.Security.AddressBook
+	cases := []struct {
+		name     string
+		wantKind AddressBookRefKind
+		wantColl bool
+	}{
+		{"lone-addr", AddrRefAddress, false},
+		{"lone-set", AddrRefAddressSet, false},
+		{"member", AddrRefAddress, false},
+		{"undefined", AddrRefNone, false},
+	}
+	for _, tc := range cases {
+		kind, coll := resolveAddressBookNameKind(ab, tc.name)
+		if kind != tc.wantKind || coll != tc.wantColl {
+			t.Fatalf("resolveAddressBookNameKind(%q) = (%d, %v), want (%d, %v)",
+				tc.name, kind, coll, tc.wantKind, tc.wantColl)
+		}
+	}
+}
+
+// TestAddrSetNoCollisionCompilesUnchanged — configs that do NOT collide must
+// keep compiling clean on the strict path: only an address, only a set, an
+// address-set whose MEMBER shares a distinct address's name, and a global
+// `address foo` alongside a DIFFERENT zone's zone-local `address-set foo`
+// (distinct namespaces after the zone-local fold — NOT a collision).
+func TestAddrSetNoCollisionCompilesUnchanged(t *testing.T) {
+	cases := map[string][]string{
+		"only-address": {
+			"set security address-book global address foo 10.0.1.0/24",
+		},
+		"only-set": {
+			"set security address-book global address bar 10.0.2.0/24",
+			"set security address-book global address-set foo address bar",
+		},
+		"set-member-shares-address-name": {
+			// The classic valid shape: `servers` is a set whose member is the
+			// address `web-server`. Different names — never a collision.
+			"set security address-book global address web-server 10.0.1.0/24",
+			"set security address-book global address-set servers address web-server",
+		},
+		"global-address-vs-different-zone-set": {
+			"set interfaces eth0 unit 0 family inet address 10.0.0.1/24",
+			"set security zones security-zone trust interfaces eth0",
+			"set security address-book global address shared 10.0.1.0/24",
+			"set security zones security-zone trust address-book address m 10.0.9.0/24",
+			"set security zones security-zone trust address-book address-set shared address m",
+		},
+	}
+	for name, cmds := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := CompileConfig(buildTree(t, cmds)); err != nil {
+				t.Fatalf("non-colliding config %q must compile clean on the strict path: %v", name, err)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1088,6 +1088,24 @@ type compileOpts struct {
 	// no-brick); the fold's no-clobber guard keeps such a config from silently
 	// overwriting an operator entry. Same doctrine as lenientZoneCount.
 	lenientAddressBookNames bool
+	// lenientAddressBookNameCollision (#5676) downgrades the same-name
+	// `address` + `address-set` collision gate
+	// (validateAddressBookNameCollisionStrict) from a hard compile error to a
+	// cfg.Warnings entry. An address book (global or zone-local) that defines
+	// the SAME name as BOTH a plain `address` and an `address-set` was
+	// previously unvalidated — the two kinds share one operator-visible
+	// namespace but are stored in separate maps, so every name→prefix resolver
+	// (dataplane expandBookNameRecursive, host-inbound junos_host_deny) silently
+	// resolved address-first and the plain address SHADOWED the same-named
+	// address-set, dropping the set's other members and changing which traffic a
+	// permit/deny rule covers. The strict commit / commit-check path
+	// hard-rejects so the ambiguity is operator-visible (Junos forbids the
+	// collision outright); the tolerant load / peer-sync paths warn so an
+	// already-persisted or peer-synced config carrying a pre-existing collision
+	// still BOOTS (#1960) — the runtime keeps the deterministic address-first
+	// winner it already used, so a leniently-loaded config forwards exactly as
+	// before, now flagged. Same doctrine as lenientAddressBookNames.
+	lenientAddressBookNameCollision bool
 	// lenientZoneInterfaceMembership (#3072) downgrades the zone-interface
 	// membership gate (validateZoneInterfaceMembershipStrict) from a hard
 	// compile error to a cfg.Warnings entry. The strict commit / commit-check
@@ -1920,6 +1938,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientZoneIDCollision:                 true,
 		lenientRoutingInstanceTableIDCollision: true,
 		lenientAddressBookNames:                true,
+		lenientAddressBookNameCollision:        true,
 		lenientZoneInterfaceMembership:         true,
 		lenientZoneInterfaceDefined:            true,
 		lenientHostInboundTokens:               true,
@@ -2271,6 +2290,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientZoneIDCollision:                 true,
 		lenientRoutingInstanceTableIDCollision: true,
 		lenientAddressBookNames:                true,
+		lenientAddressBookNameCollision:        true,
 		lenientZoneInterfaceMembership:         true,
 		lenientZoneInterfaceDefined:            true,
 		lenientHostInboundTokens:               true,

--- a/pkg/config/compiler_earlystrict.go
+++ b/pkg/config/compiler_earlystrict.go
@@ -24,6 +24,11 @@ import (
 //     #4340) — MUST run before the zone-local fold injects the `/`-bearing
 //     synthetic names. Strict on commit; downgraded to a warning on the
 //     tolerant lenientAddressBookNames path (#1960 no-brick).
+//     2b. validateAddressBookNameCollisionStrict on the PRISTINE books (#5676) —
+//     rejects a same-name `address` + `address-set` in one book (global or
+//     zone-local). Same pristine-book ordering constraint as (2): runs before
+//     the fold so a global vs a different-zone name are not misreported as a
+//     collision. Strict on commit; downgraded on lenientAddressBookNameCollision.
 //  3. resolveZoneLocalAddressBooks (MUT cfg.Security) — folds zone-local books
 //     into the global book under zone-qualified internal names. Output consumed
 //     non-locally by the P6b policy match-address validators.
@@ -81,6 +86,28 @@ func runEarlyStrictAndFolds(cfg *Config, opts compileOpts) error {
 		if opts.lenientAddressBookNames {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("address-book/zone name (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+	// #5676 — reject a same-name `address` + `address-set` collision within one
+	// address book (global or zone-local). The two kinds share one operator-
+	// visible namespace but land in separate maps, so a plain address silently
+	// shadowed a same-named address-set at name→prefix resolution (address-first
+	// everywhere), changing which traffic a permit/deny rule covers with no
+	// diagnostic. MUST run here, on the PRISTINE books BEFORE the zone-local fold
+	// mints synthetic zone-local/<zone>/<name> names — so a global `address foo`
+	// and a different zone's zone-local `address-set foo` (distinct namespaces
+	// post-fold) are not misreported as a collision, and a real zone-local
+	// collision is named against the clean zone. Strict on commit / commit-check
+	// (hard reject; Junos forbids the collision outright); tolerant load /
+	// peer-sync downgrade to a warning (#1960 no-brick — the runtime keeps the
+	// deterministic address-first winner it already used). Mirrors
+	// validateAddressBookEntryNamesStrict.
+	if err := validateAddressBookNameCollisionStrict(cfg); err != nil {
+		if opts.lenientAddressBookNameCollision {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("address-book name collision (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return err
 		}

--- a/pkg/config/compiler_validate_strict_addrbook.go
+++ b/pkg/config/compiler_validate_strict_addrbook.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// AddressBookRefKind classifies how a bare address-book name resolves within a
+// SINGLE address book. `address` and `address-set` entries are stored in
+// DISTINCT maps (AddressBook.Addresses / AddressBook.AddressSets), so absent a
+// same-name collision every name resolves unambiguously to exactly one kind —
+// the two kinds ARE namespace-distinguishable at the storage layer.
+type AddressBookRefKind int
+
+const (
+	// AddrRefNone: the name is defined as neither an address nor an address-set.
+	AddrRefNone AddressBookRefKind = iota
+	// AddrRefAddress: the name resolves to a plain `address` entry.
+	AddrRefAddress
+	// AddrRefAddressSet: the name resolves to an `address-set` entry.
+	AddrRefAddressSet
+)
+
+// resolveAddressBookNameKind classifies name within ab and reports whether the
+// name COLLIDES — i.e. is defined as BOTH a plain `address` AND an
+// `address-set` in the same book (the #5676 shadow).
+//
+// `address` and `address-set` share one operator-visible namespace (an operator
+// types a single token in `match source-address <name>`), yet land in two
+// separate maps, so a same-name collision is possible. Before #5676 that
+// collision resolved silently and INCONSISTENTLY-looking but actually
+// address-first everywhere a name is turned into prefixes: the dataplane
+// resolver (pkg/dataplane/userspace expandBookNameRecursive / nameRepresentability
+// / capabilities) and the host-inbound deny compiler (junos_host_deny) all check
+// `ab.Addresses[name]` before `ab.AddressSets[name]`. So a plain `address`
+// silently SHADOWED a same-named `address-set`, dropping the set's other members
+// and CHANGING which traffic a permit/deny rule covers with no diagnostic.
+//
+// This helper is the single source of truth for that deterministic winner: on a
+// collision the plain `address` WINS (address-first), matching the runtime
+// resolver bit-for-bit. The strict admission gate
+// (validateAddressBookNameCollisionStrict) hard-rejects the collision so it can
+// never be freshly authored; the tolerant load / peer-sync path KEEPS this
+// address-first winner (so a reload does not silently change the forwarding an
+// already-running config has been doing — the #1960 no-behavior-change-on-boot
+// doctrine) and only warns.
+func resolveAddressBookNameKind(ab *AddressBook, name string) (kind AddressBookRefKind, collision bool) {
+	if ab == nil {
+		return AddrRefNone, false
+	}
+	_, isAddr := ab.Addresses[name]
+	_, isSet := ab.AddressSets[name]
+	switch {
+	case isAddr && isSet:
+		return AddrRefAddress, true // address-first deterministic winner
+	case isAddr:
+		return AddrRefAddress, false
+	case isSet:
+		return AddrRefAddressSet, false
+	default:
+		return AddrRefNone, false
+	}
+}
+
+// validateAddressBookNameCollisionStrict (#5676) hard-rejects an address book —
+// the global book or ANY zone-local book — that defines the SAME name as BOTH a
+// plain `address` and an `address-set`.
+//
+// The two kinds share one operator-visible namespace but are stored in two
+// separate maps (AddressBook.Addresses / AddressBook.AddressSets), so an
+// operator can author `address blocklist 10.0.0.0/24` AND
+// `address-set blocklist { address other; ... }` in the same book with no
+// commit error. A security-policy `match source-address blocklist` /
+// `destination-address blocklist` is then AMBIGUOUS: every place a name is
+// resolved to prefixes checks Addresses before AddressSets (address-first — see
+// resolveAddressBookNameKind), so the plain address silently WINS and the
+// same-named address-set's other members are dropped. A deny built on the SET
+// then covers only the single address (an under-block — traffic the operator
+// meant to deny is permitted); symmetrically a permit built on the address is
+// unaffected but the operator's mental model (a group) is wrong. This is a
+// silent, security-relevant change to which traffic a rule covers — an
+// admission / root-identity defect (codex-review-182 M10, High).
+//
+// Junos itself forbids a same-name `address` + `address-set` in one address
+// book (the CLI rejects the second definition at commit), so there is no
+// vendor-defined precedence to honor — the hard reject MATCHES vSRX. The error
+// names both colliding entries and the book (global / the zone) so the operator
+// renames one and the reference becomes unambiguous.
+//
+// MUST run on the PRISTINE books — i.e. BEFORE resolveZoneLocalAddressBooks
+// folds zone-local entries into the global book under synthetic
+// zone-local/<zone>/<name> names — so a global `address foo` and a DIFFERENT
+// zone's zone-local `address-set foo` (two genuinely distinct namespaces after
+// the fold) are never misreported as a collision, and so a real zone-local
+// collision is reported against the clean zone name rather than the synthetic
+// key. The caller (runEarlyStrictAndFolds) enforces that ordering.
+//
+// Strict on commit / commit-check (hard reject so the ambiguity is
+// operator-visible); the call site downgrades this to a warning on the tolerant
+// load / peer-sync path (opts.lenientAddressBookNameCollision, #1960 no-brick)
+// so an already-persisted or peer-synced config carrying a pre-existing
+// collision still BOOTS — the runtime then resolves the deterministic
+// address-first winner exactly as it already did. Mirrors
+// validateAddressBookEntryNamesStrict.
+func validateAddressBookNameCollisionStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := addressBookNameCollision("security address-book global", cfg.Security.AddressBook); err != nil {
+		return err
+	}
+	// Walk zones in sorted order so the first-reported error is deterministic
+	// regardless of Go map iteration order.
+	zoneNames := make([]string, 0, len(cfg.Security.Zones))
+	for z := range cfg.Security.Zones {
+		zoneNames = append(zoneNames, z)
+	}
+	sort.Strings(zoneNames)
+	for _, z := range zoneNames {
+		zone := cfg.Security.Zones[z]
+		if zone == nil {
+			continue
+		}
+		scope := fmt.Sprintf("security zone %q address-book", z)
+		if err := addressBookNameCollision(scope, zone.AddressBook); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addressBookNameCollision returns the first same-name `address` +
+// `address-set` collision in ab (walked in sorted name order for a
+// deterministic first error), naming the offending entry and the book scope.
+func addressBookNameCollision(scope string, ab *AddressBook) error {
+	if ab == nil {
+		return nil
+	}
+	names := make([]string, 0, len(ab.Addresses))
+	for n := range ab.Addresses {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if _, collision := resolveAddressBookNameKind(ab, n); collision {
+			return fmt.Errorf(
+				"%s defines %q as BOTH an `address` and an `address-set`; "+
+					"the two share one namespace, so a policy `match "+
+					"source-address %s` / `destination-address %s` resolves "+
+					"ambiguously and the plain address silently shadows the "+
+					"same-named address-set (dropping its other members and "+
+					"changing which traffic a permit/deny rule covers). Rename one "+
+					"of the two entries so every policy reference is unambiguous",
+				scope, n, n, n)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #5676

## Defect (codex-review-182 M10, High)

Address-book `address` and `address-set` entries share ONE operator-visible namespace — a policy `match source-address <name>` / `destination-address <name>` names a single token — but are stored in two **separate maps** (`AddressBook.Addresses` / `AddressBook.AddressSets`). So an operator can author

```
set security address-book global address blocklist 10.0.1.0/24
set security address-book global address-set blocklist { address other; }
```

in the **same** book with no commit error. Every place a name is resolved to prefixes checks `Addresses` **before** `AddressSets` (**address-first**): the dataplane `expandBookNameRecursive` / `nameRepresentability` / `capabilities`, and the host-inbound `junos_host_deny` compiler. The plain address therefore **silently shadows** the same-named address-set — a deny built on the SET covers only the single address, so the set's other members leak (an under-block). This is a silent, security-relevant change to which traffic a permit/deny rule covers — an admission / root-identity defect.

## Fix (pure `pkg/config` — no dataplane/Rust/wire change)

- New strict gate `validateAddressBookNameCollisionStrict` + `resolveAddressBookNameKind` (the single source of truth encoding the deterministic winner) + `AddressBookRefKind`, in `compiler_validate_strict_addrbook.go`.
- Wired in `runEarlyStrictAndFolds` immediately after `validateAddressBookEntryNamesStrict` and **before** the zone-local fold. The pristine-book ordering is load-bearing: a global `address foo` and a *different* zone's zone-local `address-set foo` are genuinely distinct namespaces after the fold (never a collision), and a real zone-local collision is named against the **clean zone** rather than the synthetic `zone-local/<zone>/<name>` key.
- **Strict** (CompileConfig, commit / commit-check) = **HARD REJECT**, diagnostic names both entries + the book/zone.
- **Lenient** (CompileConfigLenient — Store.Load / SyncApply / peer-sync) = **WARN + keep resolving** (`opts.lenientAddressBookNameCollision`, #1960 no-brick), mirroring `validateNextTableTargetReferencesStrict` / the #5756/#5758 split.

### Deterministic winner & Junos-precedence finding

**Junos/vSRX forbids a same-name `address` + `address-set` in one address book** (the CLI rejects the second definition at commit), so there is **no vendor-defined precedence** to honor — the hard reject matches vSRX exactly.

Because Junos forbids it, the lenient path (which exists only for grandfathered / peer-synced configs an older binary already accepted) picks and documents a deterministic winner: **the plain `address` wins (address-first)**. Rationale: this matches, bit-for-bit, what every runtime name→prefix resolver already does, so a leniently-loaded config forwards **exactly as before** rather than silently changing its dispositions on reload. Flipping the winner would be a worse surprise than the status quo; the strict reject is the actual protection that prevents the ambiguity from ever being authored.

## Tests — `pkg/config/addr_set_namespace_5676_test.go`

- (a) global collision → strict `CompileConfig` **rejects** with a diagnostic naming both entries + the book (and a zone-local collision naming the zone; both config orderings).
- (b) same config via `CompileConfigLenient` **loads** with a collision **warning**; both entries survive their distinct maps.
- (c) security-relevant: given a collision, resolution is **deterministic** (plain address wins) via the SSOT resolver — identical for both config orderings; absent a collision each kind resolves to its own kind (namespace-aware).
- (d) no-collision configs (only address / only set / set-member-shares-address-name / global-vs-different-zone-set) compile unchanged on the strict path.

### Fail-on-revert (RED proof)

Temporarily unwiring the `validateAddressBookNameCollisionStrict` dispatch in `runEarlyStrictAndFolds`:

```
--- FAIL: TestAddrSetCollisionGlobalRejectedAtCommit
    expected strict commit to reject a same-name address + address-set collision in the global book
--- FAIL: TestAddrSetCollisionGlobalRejectedBothOrderings/address-first
--- FAIL: TestAddrSetCollisionGlobalRejectedBothOrderings/set-first
--- FAIL: TestAddrSetCollisionZoneLocalRejectedAtCommit
    (collision not caught — falls through to the unrelated interface-defined error)
--- FAIL: TestAddrSetCollisionLenientDowngrades
    lenient compile must record a collision warning; warnings = []
```

Restored → GREEN.

## Gates

- `go test ./pkg/config/...` passes (incl. the `TestEveryStrictCommitGateIsWired` canary and the #4406 golden gate).
- `go vet ./pkg/config/` clean; `gofmt -l` clean on touched files; `go build ./...` clean.
- `docs/config-schema.md` updated (new "same-name address + address-set collision (#5676)" subsection under Strict commit-time validators); `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUMttPTPdBuENAmt9WaFJt