### PR TITLE
api: share the session-scan admission bound across gRPC

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47709,3 +47709,29 @@ top.
   GetSessionSummary over-cap and shared-singleton-saturation all return nil
   instead of ResourceExhausted); restored GREEN. Fully unit-verifiable, no
   cluster.
+
+- **Timestamp**: 2026-07-13
+  **Action**: #5708 / PR #5778 follow-up — hostile review (Bar 2) found a MISSED
+  gRPC scan path: GetZonePairSummary (pkg/grpcapi/server_sessions.go) is a
+  registered, client-reachable RPC whose computeZonePairSummary() does an
+  unconditional full v4+v6 IterateSessions/IterateSessionsV6 walk (same
+  BPF-map-lock cost as GetSessionSummary) but was NOT gated by the shared
+  sessionWalkLimiter — while its REST twin (GET
+  /security/sessions/summary/zone-pairs) IS gated, so zone-pairs was bounded on
+  REST but unbounded on gRPC (attacker just calls GetZonePairSummary). Folded
+  the same fail-fast Acquire→ResourceExhausted gate into GetZonePairSummary
+  (matching the two existing sites). Verified the peer path
+  (proxyPeerZonePairSummary) dials the peer with the x-peer-forwarded recursion
+  guard and does NOT re-enter the local handler → no double-acquire / cap-4
+  wedge. Added TestGRPCGetZonePairSummaryConcurrencyBound mirroring the summary
+  test. Updated the enumeration comments in diagcmd/limiter.go,
+  server_sessions.go (gRPC alias), and pkg/api/README.md to include
+  GetZonePairSummary. (ClearSessions REST/gRPC ungated gap is a separate
+  follow-up issue, out of this PR.)
+  **File(s)**: pkg/grpcapi/server_sessions.go,
+  pkg/grpcapi/server_sessions_bound_5708_test.go, pkg/diagcmd/limiter.go,
+  pkg/api/README.md
+  GREEN: go test ./pkg/grpcapi/... ./pkg/api/... ./pkg/diagcmd/... all ok;
+  gofmt + go vet + go build clean. Fail-on-revert proven: removing the
+  GetZonePairSummary gate → TestGRPCGetZonePairSummaryConcurrencyBound RED
+  ("err = <nil>, want codes.ResourceExhausted"); restored GREEN.

--- a/_Log.md
+++ b/_Log.md
@@ -47735,3 +47735,28 @@ top.
   gofmt + go vet + go build clean. Fail-on-revert proven: removing the
   GetZonePairSummary gate → TestGRPCGetZonePairSummaryConcurrencyBound RED
   ("err = <nil>, want codes.ResourceExhausted"); restored GREEN.
+
+- **Timestamp**: 2026-07-13
+  **Action**: #5708 / PR #5778 follow-up 2 — re-review's exhaustive sweep found
+  a 4th ungated client-reachable gRPC full-table READ-scan: showSessionsTop
+  (pkg/grpcapi/server_show_flow.go), dispatched from the registered ShowText
+  RPC via Topic "sessions-top:bytes"/"sessions-top:packets". It walks the whole
+  v4+v6 conntrack table (s.dp.IterateSessions/V6, same per-bucket BPF-map lock
+  cost as the gated trio); the #5319 bounded top-K caps only the OUTPUT (K heap
+  survivors), NOT the WALK — so the same unbounded-scan DoS applied. Folded the
+  same fail-fast Acquire→codes.ResourceExhausted gate at the top of
+  showSessionsTop (after the dp-not-loaded check, before the walk); ShowText
+  returns the handler error verbatim so an over-cap scan surfaces as a clean
+  ResourceExhausted. No REST twin exists (grep of pkg/api found no sessions-top
+  endpoint) — gRPC-only; noted in PR/README. Added
+  TestGRPCShowSessionsTopConcurrencyBound (drives the real ShowText dispatch).
+  Updated the enumeration comments (diagcmd/limiter.go, server_sessions.go
+  alias, pkg/api/README.md) to list the ShowText sessions-top scan as gated.
+  ClearSessions stays OUT (that's the #5779 mutation follow-up).
+  **File(s)**: pkg/grpcapi/server_show_flow.go, pkg/grpcapi/server_sessions.go,
+  pkg/diagcmd/limiter.go, pkg/api/README.md,
+  pkg/grpcapi/server_sessions_bound_5708_test.go
+  GREEN: go test ./pkg/grpcapi/... ./pkg/api/... all ok; gofmt + go vet + go
+  build clean. Fail-on-revert proven: removing the showSessionsTop gate →
+  TestGRPCShowSessionsTopConcurrencyBound RED ("err = <nil>, want
+  codes.ResourceExhausted"); restored GREEN.

--- a/_Log.md
+++ b/_Log.md
@@ -47680,3 +47680,32 @@ top.
   retry (pre-fix absent behavior) turns three tests RED — "retry debt was not
   recorded" (failed clear), "clearHelperHAStateLocked called 0 times, want 1"
   (poll-tick retry x2); restored GREEN.
+
+- **Timestamp**: 2026-07-13
+  **Action**: #5708 (codex-review-182 M35) — gRPC session list/summary scans
+  had no shared admission bound. The REST session-scan endpoints gate every
+  full v4+v6 conntrack-table walk through a fixed-capacity semaphore
+  (pkg/api sessionWalkLimiter, #5318/#5433), but the gRPC GetSessions /
+  GetSessionSummary RPCs (pkg/grpcapi/server_sessions.go) walked the same table
+  with NO admission bound — a gRPC caller could issue unbounded full-table
+  scans (each holding per-bucket BPF-map locks against the live session-sync
+  path), bypassing the REST gate = CPU/contention DoS through the uncovered
+  gRPC surface. Fix mirrors the existing shared diagcmd.DefaultLimiter
+  (diagnostics) precedent: hoisted the session-walk limiter to a process-wide
+  diagcmd.SessionWalkLimiter (+ MaxConcurrentSessionWalks=4), repointed
+  pkg/api's sessionWalkLimiter to it, and added a pkg/grpcapi alias gating
+  GetSessions (covers cursor+legacy+peer fan-out) and GetSessionSummary via
+  fail-fast Acquire → codes.ResourceExhausted on over-cap (the gRPC analog of
+  REST's HTTP 429). Now REST+gRPC scrapers draw from ONE aggregate budget and
+  a gRPC caller cannot exceed it. The list result set was already capped
+  (limit/pageSize clamp to 10000). Updated pkg/api/README.md admission-bound
+  section to note the #5708 hoist + gRPC coverage.
+  **File(s)**: pkg/diagcmd/limiter.go, pkg/api/sessions.go, pkg/api/README.md,
+  pkg/grpcapi/server_sessions.go,
+  pkg/grpcapi/server_sessions_bound_5708_test.go
+  GREEN: go test ./pkg/grpcapi/... ./pkg/api/... ./pkg/diagcmd/... all ok;
+  gofmt + go vet + go build clean. Fail-on-revert proven: removing the gRPC
+  Acquire gates → three admission-bound tests RED (GetSessions /
+  GetSessionSummary over-cap and shared-singleton-saturation all return nil
+  instead of ResourceExhausted); restored GREEN. Fully unit-verifiable, no
+  cluster.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -752,7 +752,8 @@ under the daemon's errgroup. Nothing else imports this package.
   - **Admission bound.** A session list is a full conntrack-table walk that
     contends with the live session-sync path for per-bucket BPF-map locks. The
     handler now acquires a slot from `sessionWalkLimiter`
-    (`diagcmd.NewLimiter(maxConcurrentSessionWalks)` = 4, the SAME fail-fast
+    (an alias of the process-wide `diagcmd.SessionWalkLimiter`, capacity
+    `diagcmd.MaxConcurrentSessionWalks` = 4, the SAME fail-fast
     counting-semaphore idiom the diagnostic ping/traceroute handlers use, #5057)
     BEFORE the walk and the peer fan-out, releasing on every exit path. Over-cap
     requests are rejected immediately with **HTTP 429** (`session list
@@ -773,6 +774,14 @@ under the daemon's errgroup. Nothing else imports this package.
     concurrency limit reached; retry shortly`). Pinned by
     `sessions_aggregation_bound_5433_test.go` (per-handler concurrency bound +
     shared-limiter cross-endpoint 429 + permit-release, RED-on-revert).
+    **#5708 hoists this limiter to `diagcmd.SessionWalkLimiter`** so the SAME
+    aggregate budget also covers the gRPC session-scan RPCs
+    (`GetSessions`/`GetSessionSummary`, `pkg/grpcapi/server_sessions.go`), which
+    drive the identical full v4+v6 walk and previously bypassed the REST bound
+    (codex-review-182 M35). A gRPC caller can no longer issue unbounded
+    full-table scans; over-cap gRPC scans return `codes.ResourceExhausted`. A
+    mix of REST + gRPC scrapers cannot collectively exceed
+    `diagcmd.MaxConcurrentSessionWalks`.
   - **Bounded Total.** The offset mode's exact `total` previously forced a FULL
     v4+v6 table scan on EVERY 100-row page (O(table) per page, repeated per
     poll) just to count. The walk now caps the count at `sessionCountCap`

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -775,10 +775,13 @@ under the daemon's errgroup. Nothing else imports this package.
     `sessions_aggregation_bound_5433_test.go` (per-handler concurrency bound +
     shared-limiter cross-endpoint 429 + permit-release, RED-on-revert).
     **#5708 hoists this limiter to `diagcmd.SessionWalkLimiter`** so the SAME
-    aggregate budget also covers the gRPC session-scan RPCs
+    aggregate budget also covers the gRPC session-scan paths
     (`GetSessions`, `GetSessionSummary`, and `GetZonePairSummary` in
-    `pkg/grpcapi/server_sessions.go`), which drive the identical full v4+v6 walk
-    and previously bypassed the REST bound (codex-review-182 M35). The gRPC
+    `pkg/grpcapi/server_sessions.go`, plus the `ShowText` `sessions-top:*`
+    scan in `server_show_flow.go` — gRPC-only, no REST twin), which drive the
+    identical full v4+v6 walk and previously bypassed the REST bound
+    (codex-review-182 M35). The `sessions-top` scan's #5319 bounded top-K caps
+    only the OUTPUT (K survivors), not the full-table WALK. The gRPC
     zone-pair RPC was a particularly clear gap — its REST twin
     (`GET /security/sessions/summary/zone-pairs`) was already gated, so
     zone-pairs was bounded on REST but unbounded on gRPC. A gRPC caller can no

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -776,12 +776,15 @@ under the daemon's errgroup. Nothing else imports this package.
     shared-limiter cross-endpoint 429 + permit-release, RED-on-revert).
     **#5708 hoists this limiter to `diagcmd.SessionWalkLimiter`** so the SAME
     aggregate budget also covers the gRPC session-scan RPCs
-    (`GetSessions`/`GetSessionSummary`, `pkg/grpcapi/server_sessions.go`), which
-    drive the identical full v4+v6 walk and previously bypassed the REST bound
-    (codex-review-182 M35). A gRPC caller can no longer issue unbounded
-    full-table scans; over-cap gRPC scans return `codes.ResourceExhausted`. A
-    mix of REST + gRPC scrapers cannot collectively exceed
-    `diagcmd.MaxConcurrentSessionWalks`.
+    (`GetSessions`, `GetSessionSummary`, and `GetZonePairSummary` in
+    `pkg/grpcapi/server_sessions.go`), which drive the identical full v4+v6 walk
+    and previously bypassed the REST bound (codex-review-182 M35). The gRPC
+    zone-pair RPC was a particularly clear gap — its REST twin
+    (`GET /security/sessions/summary/zone-pairs`) was already gated, so
+    zone-pairs was bounded on REST but unbounded on gRPC. A gRPC caller can no
+    longer issue unbounded full-table scans; over-cap gRPC scans return
+    `codes.ResourceExhausted`. A mix of REST + gRPC scrapers cannot collectively
+    exceed `diagcmd.MaxConcurrentSessionWalks`.
   - **Bounded Total.** The offset mode's exact `total` previously forced a FULL
     v4+v6 table scan on EVERY 100-row page (O(table) per page, repeated per
     poll) just to count. The walk now caps the count at `sessionCountCap`

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -21,31 +21,21 @@ import (
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
-// maxConcurrentSessionWalks bounds how many full session-table walks may
-// run at once across the session-scan REST endpoints (#5318, #5433): the
-// GET /security/sessions list, GET /security/sessions/summary, and GET
-// /security/sessions/summary/zone-pairs. Each of these walks the whole
-// v4+v6 conntrack table holding per-bucket BPF-map locks, so N concurrent
-// scrapers each drive their own full walk simultaneously — on a
-// multi-million-session firewall that multiplies contention with the live
-// dataplane session-sync path. The cap is deliberately small: legitimate
-// dashboards/automation poll a handful at a time, while a scrape flood must
-// never starve session installs. #5237 already aborts a walk when its own
-// client disconnects; this bounds how many connected clients can walk at
-// once, which the disconnect-abort does not.
-const maxConcurrentSessionWalks = 4
-
 // sessionWalkLimiter is the shared admission gate for the full-table
-// session-scan handlers (list, summary, zone-pairs). It reuses the diagcmd
-// fixed-capacity counting semaphore (the same fail-fast idiom the
-// diagnostic ping/traceroute handlers use, #5057): Acquire is non-blocking,
-// so an over-cap request is rejected immediately with HTTP 429 rather than
-// queued into an unbounded backlog. One shared limiter (not one per
-// endpoint) bounds the AGGREGATE walk concurrency, since all three handlers
-// contend for the same per-bucket BPF-map locks against session-sync
-// (#5433). It is a package var so a test can swap in a fresh small-capacity
-// limiter without mutating process-wide state.
-var sessionWalkLimiter = diagcmd.NewLimiter(maxConcurrentSessionWalks)
+// session-scan handlers (list, summary, zone-pairs). It aliases the
+// process-wide diagcmd.SessionWalkLimiter (capacity
+// diagcmd.MaxConcurrentSessionWalks), the SAME instance the gRPC
+// GetSessions/GetSessionSummary handlers use — so a mix of REST and gRPC
+// scrapers draws from one aggregate budget and a gRPC caller cannot bypass
+// this bound (#5708). It reuses the diagcmd fixed-capacity counting semaphore
+// (the same fail-fast idiom the diagnostic ping/traceroute handlers use,
+// #5057): Acquire is non-blocking, so an over-cap request is rejected
+// immediately with HTTP 429 rather than queued into an unbounded backlog. Each
+// walk holds per-bucket BPF-map locks across the whole v4+v6 conntrack table,
+// contending with the live dataplane session-sync path (#5318, #5433). It is a
+// package var so a test can swap in a fresh small-capacity limiter without
+// mutating the process-wide instance.
+var sessionWalkLimiter = diagcmd.SessionWalkLimiter
 
 // defaultSessionCountCap bounds how many matching sessions the offset list
 // walk counts before it stops and reports Total as an approximate lower

--- a/pkg/diagcmd/limiter.go
+++ b/pkg/diagcmd/limiter.go
@@ -76,3 +76,22 @@ func (l *Limiter) Cap() int { return cap(l.sem) }
 // both surfaces (a diagnostic admitted over REST and one admitted over
 // gRPC draw from the same MaxConcurrentDiagnostics budget).
 var DefaultLimiter = NewLimiter(MaxConcurrentDiagnostics)
+
+// MaxConcurrentSessionWalks bounds how many full session-table walks may run
+// at once across EVERY control surface that exposes them — the REST session
+// list/summary/zone-pair endpoints and the gRPC GetSessions/GetSessionSummary
+// RPCs share the single SessionWalkLimiter below (#5708). Each walk holds
+// per-bucket BPF-map locks across the whole v4+v6 conntrack table while
+// contending with the live dataplane session-sync path, so an unbounded scan
+// flood on ANY surface multiplies that contention. Before #5708 only the REST
+// endpoints were gated; a gRPC caller could issue unbounded full-table scans
+// through the uncovered gRPC surface (codex-review-182 M35). The value mirrors
+// the original REST cap (#5318/#5433).
+const MaxConcurrentSessionWalks = 4
+
+// SessionWalkLimiter is the process-wide session-scan limiter shared by the
+// REST and gRPC session list/summary handlers, so one aggregate cap covers
+// both surfaces: a session scan admitted over REST and one admitted over gRPC
+// draw from the same MaxConcurrentSessionWalks budget, and a mix of REST+gRPC
+// scrapers cannot collectively exceed it. Mirrors DefaultLimiter.
+var SessionWalkLimiter = NewLimiter(MaxConcurrentSessionWalks)

--- a/pkg/diagcmd/limiter.go
+++ b/pkg/diagcmd/limiter.go
@@ -79,8 +79,9 @@ var DefaultLimiter = NewLimiter(MaxConcurrentDiagnostics)
 
 // MaxConcurrentSessionWalks bounds how many full session-table walks may run
 // at once across EVERY control surface that exposes them — the REST session
-// list/summary/zone-pair endpoints and the gRPC GetSessions/GetSessionSummary
-// RPCs share the single SessionWalkLimiter below (#5708). Each walk holds
+// list/summary/zone-pair endpoints and the gRPC GetSessions/GetSessionSummary/
+// GetZonePairSummary RPCs share the single SessionWalkLimiter below (#5708).
+// Each walk holds
 // per-bucket BPF-map locks across the whole v4+v6 conntrack table while
 // contending with the live dataplane session-sync path, so an unbounded scan
 // flood on ANY surface multiplies that contention. Before #5708 only the REST

--- a/pkg/diagcmd/limiter.go
+++ b/pkg/diagcmd/limiter.go
@@ -80,7 +80,8 @@ var DefaultLimiter = NewLimiter(MaxConcurrentDiagnostics)
 // MaxConcurrentSessionWalks bounds how many full session-table walks may run
 // at once across EVERY control surface that exposes them — the REST session
 // list/summary/zone-pair endpoints and the gRPC GetSessions/GetSessionSummary/
-// GetZonePairSummary RPCs share the single SessionWalkLimiter below (#5708).
+// GetZonePairSummary RPCs plus the ShowText "sessions-top:*" scan share the
+// single SessionWalkLimiter below (#5708).
 // Each walk holds
 // per-bucket BPF-map locks across the whole v4+v6 conntrack table while
 // contending with the live dataplane session-sync path, so an unbounded scan

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -32,8 +32,9 @@ type sessionEgressKey struct {
 }
 
 // sessionWalkLimiter is the aggregate concurrency bound for the gRPC
-// session-scan RPCs (GetSessions list, GetSessionSummary, and
-// GetZonePairSummary). It aliases the
+// session-scan paths (GetSessions list, GetSessionSummary,
+// GetZonePairSummary, and the ShowText "sessions-top:*" scan in
+// server_show_flow.go). It aliases the
 // process-wide diagcmd.SessionWalkLimiter — the SAME instance the REST
 // session list/summary/zone-pair handlers use (pkg/api/sessions.go) — so a
 // session scan admitted over gRPC and one admitted over REST draw from one

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -22,6 +22,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/diagcmd"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
@@ -30,10 +31,40 @@ type sessionEgressKey struct {
 	vlanID  uint16
 }
 
+// sessionWalkLimiter is the aggregate concurrency bound for the gRPC
+// session-scan RPCs (GetSessions list + GetSessionSummary). It aliases the
+// process-wide diagcmd.SessionWalkLimiter — the SAME instance the REST
+// session list/summary/zone-pair handlers use (pkg/api/sessions.go) — so a
+// session scan admitted over gRPC and one admitted over REST draw from one
+// aggregate MaxConcurrentSessionWalks budget. Before #5708 the gRPC scans had
+// NO admission bound, so a gRPC caller could issue unbounded full v4+v6
+// conntrack-table walks (each holding per-bucket BPF-map locks against the
+// live session-sync path), bypassing the REST gate — a CPU/contention DoS
+// (codex-review-182 M35). Acquire is fail-fast; over-cap gRPC scans return
+// codes.ResourceExhausted (the gRPC analog of the REST HTTP 429, matching the
+// diagnostic ping/traceroute handlers, #5057). A package var so a test can
+// swap in a fresh small-capacity limiter.
+var sessionWalkLimiter = diagcmd.SessionWalkLimiter
+
 func (s *Server) GetSessions(ctx context.Context, req *pb.GetSessionsRequest) (*pb.GetSessionsResponse, error) {
 	if s.dp == nil || !s.dp.IsLoaded() {
 		return nil, status.Error(codes.Unavailable, "dataplane not loaded")
 	}
+
+	// Admission bound (#5708, codex-review-182 M35): GetSessions drives a full
+	// v4+v6 conntrack-table walk (both the cursor and legacy paths below, plus
+	// the peer fan-out) that contends with the live dataplane session-sync path
+	// for per-bucket BPF-map locks. Acquire a slot fail-fast BEFORE the walk so
+	// a concurrent gRPC scrape flood is rejected with ResourceExhausted rather
+	// than each driving its own simultaneous walk. The limiter is SHARED with
+	// the REST session scans, so a mix of REST+gRPC callers cannot collectively
+	// exceed the aggregate bound. Release on every exit path via defer.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		return nil, status.Error(codes.ResourceExhausted,
+			"session scan concurrency limit reached; retry shortly")
+	}
+	defer release()
 
 	// req.Offset is a signed int32; a negative value made the legacy
 	// path's `idx >= offset` test true for the first row (silently
@@ -719,6 +750,18 @@ func (s *Server) GetSessionSummary(ctx context.Context, req *pb.GetSessionSummar
 	if s.dp == nil || !s.dp.IsLoaded() {
 		return nil, status.Error(codes.Unavailable, "dataplane not loaded")
 	}
+
+	// Admission bound (#5708, codex-review-182 M35): the summary is an
+	// unconditional full v4+v6 conntrack-table walk (same per-bucket BPF-map
+	// lock contention as the list). Gate it through the SAME shared limiter as
+	// GetSessions and the REST scans so a gRPC scrape flood cannot drive
+	// unbounded concurrent walks. Release on every exit path via defer.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		return nil, status.Error(codes.ResourceExhausted,
+			"session scan concurrency limit reached; retry shortly")
+	}
+	defer release()
 
 	resp := &pb.GetSessionSummaryResponse{}
 

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -32,7 +32,8 @@ type sessionEgressKey struct {
 }
 
 // sessionWalkLimiter is the aggregate concurrency bound for the gRPC
-// session-scan RPCs (GetSessions list + GetSessionSummary). It aliases the
+// session-scan RPCs (GetSessions list, GetSessionSummary, and
+// GetZonePairSummary). It aliases the
 // process-wide diagcmd.SessionWalkLimiter — the SAME instance the REST
 // session list/summary/zone-pair handlers use (pkg/api/sessions.go) — so a
 // session scan admitted over gRPC and one admitted over REST draw from one
@@ -900,6 +901,21 @@ func (s *Server) GetZonePairSummary(ctx context.Context, req *pb.GetZonePairSumm
 	if s.dp == nil || !s.dp.IsLoaded() {
 		return nil, status.Error(codes.Unavailable, "dataplane not loaded")
 	}
+
+	// Admission bound (#5708, codex-review-182 M35): the zone-pair breakdown is
+	// an unconditional full v4+v6 conntrack-table walk (computeZonePairSummary,
+	// same per-bucket BPF-map lock contention as GetSessionSummary). Gate it
+	// through the SAME shared limiter as GetSessions/GetSessionSummary and the
+	// REST scans — the REST zone-pair handler is already gated, so without this
+	// zone-pairs is bounded on REST but unbounded on gRPC. Release on every exit
+	// path via defer; the peer fan-out below dials the peer (which gates its own
+	// walk), so this holds only the local slot.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		return nil, status.Error(codes.ResourceExhausted,
+			"session scan concurrency limit reached; retry shortly")
+	}
+	defer release()
 
 	resp := &pb.GetZonePairSummaryResponse{}
 	if s.cluster != nil {

--- a/pkg/grpcapi/server_sessions_bound_5708_test.go
+++ b/pkg/grpcapi/server_sessions_bound_5708_test.go
@@ -132,6 +132,34 @@ func TestGRPCGetZonePairSummaryConcurrencyBound(t *testing.T) {
 	}
 }
 
+// (a4) Same admission contract for the ShowText "sessions-top:*" scan, reached
+// via the registered ShowText RPC. Its #5319 bounded top-K caps only the K
+// survivors in the output heap, not the full-table WALK, so an unbounded
+// concurrent scrape must be gated by the shared limiter like the other scans.
+func TestGRPCShowSessionsTopConcurrencyBound(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	s := newBoundSessionServer(t)
+
+	_, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "sessions-top:bytes"})
+	if !isResourceExhausted(err) {
+		release()
+		t.Fatalf("ShowText sessions-top:bytes with a full session-walk limiter: err = %v, want codes.ResourceExhausted", err)
+	}
+
+	release()
+	if _, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "sessions-top:bytes"}); isResourceExhausted(err) {
+		t.Fatalf("ShowText sessions-top:bytes after slot release still ResourceExhausted: %v", err)
+	}
+}
+
 // (c) The gRPC session scans draw from the PROCESS-WIDE diagcmd.SessionWalkLimiter
 // — the SAME instance the REST scans use — so a mix of REST+gRPC scrapers cannot
 // collectively exceed the aggregate budget. Saturating the shared singleton

--- a/pkg/grpcapi/server_sessions_bound_5708_test.go
+++ b/pkg/grpcapi/server_sessions_bound_5708_test.go
@@ -1,0 +1,152 @@
+// #5708 (codex-review-182 M35): the gRPC session list/summary scans had no
+// shared admission bound, so a gRPC caller could issue unbounded full v4+v6
+// conntrack-table walks (each holding per-bucket BPF-map locks against the live
+// session-sync path) — a CPU/contention DoS through the uncovered gRPC surface,
+// bypassing the REST sessionWalkLimiter. The fix hoists that limiter to
+// diagcmd.SessionWalkLimiter and gates GetSessions/GetSessionSummary through it.
+//
+// FAIL-ON-REVERT: removing the sessionWalkLimiter.Acquire() gate from the gRPC
+// handlers makes the over-cap ResourceExhausted assertions here go RED (an
+// over-cap call proceeds to the walk and returns a normal response instead).
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// boundSessionDP is a minimal grpcRuntime fake: IsLoaded true, empty session
+// tables (so a call that PASSES the admission gate returns cleanly). It embeds
+// *dataplane.Manager to satisfy the rest of the interface.
+type boundSessionDP struct {
+	*dataplane.Manager
+}
+
+func (boundSessionDP) IsLoaded() bool { return true }
+
+func (boundSessionDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return nil
+}
+
+func (boundSessionDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func newBoundSessionServer(t *testing.T) *Server {
+	t.Helper()
+	return &Server{
+		dp:    boundSessionDP{Manager: dataplane.New()},
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+	}
+}
+
+func isResourceExhausted(err error) bool {
+	return status.Code(err) == codes.ResourceExhausted
+}
+
+// (a) A gRPC GetSessions issued while the shared session-walk limiter is
+// saturated must be rejected with ResourceExhausted rather than driving its own
+// concurrent full-table walk; once a slot frees the next call proceeds.
+func TestGRPCGetSessionsConcurrencyBound(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1) // single slot
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	s := newBoundSessionServer(t)
+
+	_, err = s.GetSessions(context.Background(), &pb.GetSessionsRequest{})
+	if !isResourceExhausted(err) {
+		release()
+		t.Fatalf("GetSessions with a full session-walk limiter: err = %v, want codes.ResourceExhausted (admission gate not consulted)", err)
+	}
+
+	// Free the slot; the next scan must be admitted (no longer rejected).
+	release()
+	if _, err := s.GetSessions(context.Background(), &pb.GetSessionsRequest{}); isResourceExhausted(err) {
+		t.Fatalf("GetSessions after slot release still ResourceExhausted: %v", err)
+	}
+}
+
+// (a') Same admission contract for the summary scan.
+func TestGRPCGetSessionSummaryConcurrencyBound(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	s := newBoundSessionServer(t)
+
+	_, err = s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{})
+	if !isResourceExhausted(err) {
+		release()
+		t.Fatalf("GetSessionSummary with a full session-walk limiter: err = %v, want codes.ResourceExhausted", err)
+	}
+
+	release()
+	if _, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{}); isResourceExhausted(err) {
+		t.Fatalf("GetSessionSummary after slot release still ResourceExhausted: %v", err)
+	}
+}
+
+// (c) The gRPC session scans draw from the PROCESS-WIDE diagcmd.SessionWalkLimiter
+// — the SAME instance the REST scans use — so a mix of REST+gRPC scrapers cannot
+// collectively exceed the aggregate budget. Saturating the shared singleton
+// directly (no package-var swap) must make a gRPC GetSessions ResourceExhausted.
+func TestGRPCGetSessionsDrawsFromSharedSessionWalkLimiter(t *testing.T) {
+	if sessionWalkLimiter != diagcmd.SessionWalkLimiter {
+		t.Fatal("gRPC sessionWalkLimiter is not the shared diagcmd.SessionWalkLimiter instance; REST+gRPC budgets are not aggregated")
+	}
+
+	// Saturate the shared limiter directly.
+	var releases []func()
+	t.Cleanup(func() {
+		for _, r := range releases {
+			r()
+		}
+	})
+	for {
+		rel, err := diagcmd.SessionWalkLimiter.Acquire()
+		if err != nil {
+			break
+		}
+		releases = append(releases, rel)
+	}
+	if len(releases) == 0 {
+		t.Fatal("could not acquire any slot on the shared limiter")
+	}
+
+	s := newBoundSessionServer(t)
+	if _, err := s.GetSessions(context.Background(), &pb.GetSessionsRequest{}); !isResourceExhausted(err) {
+		t.Fatalf("GetSessions with the shared limiter saturated: err = %v, want codes.ResourceExhausted (handler not drawing from the shared instance)", err)
+	}
+}
+
+// (b) The returned session set is capped: a huge requested limit is clamped so
+// a single scan cannot return an unbounded result set.
+func TestGRPCGetSessionsResultCapEnforced(t *testing.T) {
+	s := newBoundSessionServer(t)
+	resp, err := s.GetSessions(context.Background(), &pb.GetSessionsRequest{Limit: 1_000_000})
+	if err != nil {
+		t.Fatalf("GetSessions: %v", err)
+	}
+	if resp.Limit != 10000 {
+		t.Fatalf("resp.Limit = %d for requested Limit=1_000_000, want it clamped to 10000 (result cap not enforced)", resp.Limit)
+	}
+}

--- a/pkg/grpcapi/server_sessions_bound_5708_test.go
+++ b/pkg/grpcapi/server_sessions_bound_5708_test.go
@@ -105,6 +105,33 @@ func TestGRPCGetSessionSummaryConcurrencyBound(t *testing.T) {
 	}
 }
 
+// (a3) Same admission contract for the zone-pair breakdown scan. The REST twin
+// (GET /security/sessions/summary/zone-pairs) is already gated, so without this
+// zone-pairs would be bounded on REST but an unbounded full-table walk on gRPC.
+func TestGRPCGetZonePairSummaryConcurrencyBound(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	s := newBoundSessionServer(t)
+
+	_, err = s.GetZonePairSummary(context.Background(), &pb.GetZonePairSummaryRequest{})
+	if !isResourceExhausted(err) {
+		release()
+		t.Fatalf("GetZonePairSummary with a full session-walk limiter: err = %v, want codes.ResourceExhausted", err)
+	}
+
+	release()
+	if _, err := s.GetZonePairSummary(context.Background(), &pb.GetZonePairSummaryRequest{}); isResourceExhausted(err) {
+		t.Fatalf("GetZonePairSummary after slot release still ResourceExhausted: %v", err)
+	}
+}
+
 // (c) The gRPC session scans draw from the PROCESS-WIDE diagcmd.SessionWalkLimiter
 // — the SAME instance the REST scans use — so a mix of REST+gRPC scrapers cannot
 // collectively exceed the aggregate budget. Saturating the shared singleton

--- a/pkg/grpcapi/server_show_flow.go
+++ b/pkg/grpcapi/server_show_flow.go
@@ -258,6 +258,23 @@ func (s *Server) showSessionsTop(cfg *config.Config, topic string, buf *strings.
 		buf.WriteString("Dataplane not loaded\n")
 		return nil
 	}
+
+	// Admission bound (#5708, codex-review-182 M35): the top-K selection is a
+	// full v4+v6 conntrack-table walk (same per-bucket BPF-map lock contention
+	// as GetSessionSummary). The #5319 bounded top-K caps only the OUTPUT (K
+	// survivors), not the WALK, so an unbounded concurrent `show ... top`
+	// scrape flood still multiplies lock contention. Gate it through the SAME
+	// shared limiter as the GetSessions/GetSessionSummary/GetZonePairSummary
+	// RPCs and the REST session scans; an over-cap scan surfaces as
+	// codes.ResourceExhausted (ShowText returns this handler error verbatim).
+	// Release on every exit path via defer.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		return status.Error(codes.ResourceExhausted,
+			"session scan concurrency limit reached; retry shortly")
+	}
+	defer release()
+
 	sortByBytes := topic == "sessions-top:bytes"
 	sortLabel := "bytes"
 	if !sortByBytes {


### PR DESCRIPTION
## Summary

Fixes #5708 (codex-review-182 finding **M35**). The REST session-scan endpoints
gate every full v4+v6 conntrack-table walk through a fixed-capacity counting
semaphore (`sessionWalkLimiter`, #5318/#5433) — each walk holds per-bucket
BPF-map locks while contending with the live dataplane session-sync path. The
gRPC session scans — `GetSessions` (cursor + legacy paths, plus the peer
fan-out) and `GetSessionSummary` — walked the same table with **no admission
bound**. A gRPC caller could issue unbounded concurrent full-table scans through
the uncovered gRPC surface, bypassing the REST gate: a **CPU/contention DoS**.

## Fix

Share **one aggregate bound** across both surfaces, mirroring the existing
`diagcmd.DefaultLimiter` precedent already used by the REST + gRPC diagnostic
ping/traceroute handlers:

- Hoist the session-walk limiter to a process-wide `diagcmd.SessionWalkLimiter`
  (capacity `diagcmd.MaxConcurrentSessionWalks` = 4, unchanged from the REST
  value).
- Repoint `pkg/api`'s `sessionWalkLimiter` to that shared instance (REST
  behavior and the HTTP 429 contract are unchanged).
- Add a `pkg/grpcapi` alias and acquire a slot **fail-fast** at the entry of
  `GetSessions` (covers cursor, legacy, and the peer fan-out) and
  `GetSessionSummary`; an over-cap scan returns `codes.ResourceExhausted` — the
  gRPC analog of the REST HTTP 429.

A mix of REST + gRPC scrapers now draws from one aggregate
`MaxConcurrentSessionWalks` budget and cannot collectively exceed it. The gRPC
list result set was already capped (`limit`/`page_size` clamp to 10000); this
adds the missing **concurrency** admission bound. `pkg/api/README.md` updated to
document the hoist and gRPC coverage.

## Validation

`pkg/grpcapi/server_sessions_bound_5708_test.go` runs **fully unprivileged**. It
asserts `GetSessions`/`GetSessionSummary` return `ResourceExhausted` while the
limiter is saturated — both via a swapped small-capacity limiter **and** by
saturating the shared `diagcmd.SessionWalkLimiter` directly (proving the
handlers draw from the shared instance) — that a freed slot admits the next
scan, and that the result set stays capped.

**RED-on-revert** (removing the gRPC `Acquire` gates):

```
--- FAIL: TestGRPCGetSessionsConcurrencyBound
    server_sessions_bound_5708_test.go:73: GetSessions with a full session-walk limiter: err = <nil>, want codes.ResourceExhausted (admission gate not consulted)
--- FAIL: TestGRPCGetSessionSummaryConcurrencyBound
    server_sessions_bound_5708_test.go:99: GetSessionSummary with a full session-walk limiter: err = <nil>, want codes.ResourceExhausted
--- FAIL: TestGRPCGetSessionsDrawsFromSharedSessionWalkLimiter
    server_sessions_bound_5708_test.go:137: GetSessions with the shared limiter saturated: err = <nil>, want codes.ResourceExhausted (handler not drawing from the shared instance)
```

Restored GREEN. `go test ./pkg/grpcapi/... ./pkg/api/... ./pkg/diagcmd/...` all
pass; `gofmt` / `go vet` / `go build ./...` clean.

Provenance: codex-review-182 M35 (Medium), verified against origin/master.

Closes #5708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj6WhNAWdp6vTuvREojiF8