### PR TITLE
config: gate source-NAT pool address grammar at commit (#5627)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47710,3 +47710,39 @@ top.
   tests RED — "expected strict commit to reject a same-name address +
   address-set collision", "lenient compile must record a collision warning";
   restored GREEN.
+
+- **Timestamp**: 2026-07-13
+  **Action**: Fix #5627 (codex-review-181 M15 / A3-b00-F02) — the Go
+  strict-commit path validated a source-NAT pool's `port range` but left its
+  ADDRESS members unchecked, so a pool referenced by a pool-mode
+  `then source-nat pool <name>` rule that carried a malformed member
+  (`not-an-ip`, `203.0.113.1/garbage`), an over-capacity prefix (host count >
+  65536 — a `/15`, `10.0.0.0/8`, or a v6 prefix shorter than `/112`), or no
+  addresses at all committed green — then the live Rust allocator
+  (`expand_pool_address`, userspace-dp/src/nat/source.rs) marked the pool
+  InvalidPool/EmptyPool and DROPPED the rule at runtime (a persistent NAT
+  outage visible only after apply). Fix: new strict gate
+  `validateSourceNATPoolAddressGrammarStrict` (+ `MaxSourceNATPoolPrefixHosts`
+  const mirroring MAX_POOL_PREFIX_HOSTS, + `sourceNATPoolAddressReason` helper)
+  in `compiler_validate_strict_nat.go`, wired in `runUniformGates` right after
+  the #5626 reference gate. It iterates ONLY pools a pool-mode rule references
+  (the exact set the dataplane snapshot expands → grammar-EQUIVALENT with live,
+  not Go-stricter), counts hosts off the prefix LENGTH without enumerating, and
+  rejects the same shapes Rust rejects (bare IP via netip.ParseAddr / CIDR via
+  netip.ParsePrefix with host count <= cap; empty referenced pool). `/16`
+  (65536 hosts, at cap) accepted, matching Rust's `count > MAX` comparison.
+  Strict = HARD REJECT; lenient (CompileConfigLenient) = warn-and-load via the
+  shared `lenientDestNATAddresses` flag (#1960 no-brick; snapshot marks pool
+  unusable independently). GO-ONLY — no Rust/cargo touched; the Rust grammar is
+  the authoritative reference the Go gate now mirrors.
+  **File(s)**: pkg/config/compiler_validate_strict_nat.go,
+  pkg/config/compiler_uniformgates.go,
+  pkg/config/strict_nat_pool_grammar_5627_test.go (new),
+  docs/config-schema.md
+  GREEN: `go test ./pkg/config/...` passes (incl. TestEveryStrictCommitGateIsWired
+  canary). gofmt clean on touched files, go vet clean. Fail-on-revert proven:
+  unwiring the `validateSourceNATPoolAddressGrammarStrict` dispatch turns all 7
+  reject shapes (malformed-token, malformed-mask, over-cap /8, over-cap /15, v6
+  over-cap /111, empty, mixed) and both lenient-warn cases RED — "expected
+  strict commit to reject pool shape", "lenient compile must record a
+  source-nat pool address warning"; restored GREEN.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2943,6 +2943,39 @@ reserved for whole-dataplane selection where a rewrite shim
     `TestNATPoolReferenceUndefinedRejected_5626` /
     `TestNATPoolReferenceGate_LenientDowngrade_5626`
     (`pkg/config/compiler_nat_pool_ref_5626_test.go`).
+  - `security nat source pool <name> address <member>` grammar / cap (#5627) —
+    the companion to #5626: once a source pool is DEFINED and REFERENCED by a
+    pool-mode `then source-nat pool <name>` rule, its ADDRESS members must be
+    honorable by the live Rust allocator. The strict path previously validated
+    only the pool `port range` (#3906/#5457), so a referenced pool carrying a
+    malformed member (`not-an-ip`, `203.0.113.1/garbage`), an over-capacity
+    prefix (host count `1 << (addrbits - prefixlen)` **greater than**
+    `MaxSourceNATPoolPrefixHosts = 65536` — a `/15`, `10.0.0.0/8`, or a v6
+    prefix shorter than `/112`), or **no addresses at all** committed green.
+    The snapshot builder (`nat_source.go`) copies the raw strings onto the wire
+    and the Rust allocator (`expand_pool_address` / `parse_source_nat_rules`,
+    `userspace-dp/src/nat/source.rs`) then returns `false` for the bad member
+    and marks the pool `InvalidPool` / `EmptyPool`, DROPPING the rule at runtime
+    — a persistent NAT outage visible only after apply, where a single bad
+    member poisons an otherwise usable pool.
+    `validateSourceNATPoolAddressGrammarStrict`
+    (`compiler_validate_strict_nat.go`) closes the divergence by rejecting the
+    exact shapes the dataplane rejects: each member must be a bare IP
+    (`netip.ParseAddr`) or a CIDR (`netip.ParsePrefix`, non-canonical allowed,
+    like the Rust `IpNet`) whose host count does not exceed the cap, and a
+    referenced pool must be non-empty. A `/16` (exactly 65536 hosts, at the cap)
+    is accepted, matching the Rust `count > MAX_POOL_PREFIX_HOSTS` comparison.
+    The gate iterates ONLY pools a pool-mode rule references — the exact set the
+    dataplane snapshot expands, so an unreferenced pool (never seen by the Rust
+    grammar) is out of scope and the gate stays grammar-EQUIVALENT with live
+    rather than Go-stricter — in sorted rule-set / declaration order for a
+    deterministic first offender, and counts hosts off the prefix LENGTH without
+    enumerating (O(pool addresses), the audit's no-expansion invariant). It
+    reuses the `lenientDestNATAddresses` downgrade (warn on load / peer-sync,
+    #1960 no-brick; the snapshot builder marks the pool unusable independently).
+    Fail-on-revert: `TestSourceNATPoolBadGrammarRejected` /
+    `TestSourceNATPoolBadGrammarLenientWarns`
+    (`pkg/config/strict_nat_pool_grammar_5627_test.go`).
   - `security nat static rule-set rule then static-nat prefix-name <addr>`
     (#4290) — the NAMED form of `then static-nat prefix <ip>`. `prefix-name`
     references a global `security address-book` entry whose literal prefix

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -663,6 +663,32 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5627 source-NAT pool ADDRESS-grammar gate. The strict path validated a
+	// source pool's `port range` but left its ADDRESS members unchecked, so a
+	// pool referenced by a pool-mode `then source-nat pool <name>` rule that
+	// carried a malformed member (`not-an-ip`, `203.0.113.1/garbage`), an
+	// over-capacity prefix (host count > MaxSourceNATPoolPrefixHosts — a `/15`,
+	// `10.0.0.0/8`, or a v6 prefix shorter than `/112`), or no addresses at all
+	// committed green — then the live Rust allocator (`expand_pool_address`,
+	// userspace-dp/src/nat/source.rs) marked the pool InvalidPool/EmptyPool and
+	// DROPPED the rule at runtime, a persistent NAT outage visible only after
+	// apply. Reject the same shapes the dataplane rejects so Go and live stay
+	// grammar-equivalent. Strict on commit / commit-check (hard-reject);
+	// lenient on load / peer-sync (downgrade to a warning so a config persisted
+	// before this gate existed still boots — #1960 no-brick; the snapshot
+	// builder independently marks the pool unusable). Shares the
+	// lenientDestNATAddresses flag (same NAT silent-drop / wrong-translate
+	// doctrine as validateNATPoolReferencesStrict). Runs AFTER the pool-reference
+	// gate so an UNDEFINED pool wins the first-error slot.
+	if err := validateSourceNATPoolAddressGrammarStrict(cfg); err != nil {
+		if opts.lenientDestNATAddresses {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("source-nat pool address (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2243 DHCP-server static (fixed/reserved) host bindings. Strict on
 	// commit / commit-check (hard-reject a fixed-address that is malformed,
 	// family-mismatched, outside the enclosing pool subnet, or duplicates

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"sort"
 	"strconv"
 	"strings"
@@ -677,6 +678,165 @@ func validateNATPoolReferencesStrict(cfg *Config) error {
 	if cfg.Security.NAT.Destination != nil {
 		if err := check("destination", cfg.Security.NAT.Destination.RuleSets, cfg.Security.NAT.Destination.Pools); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// MaxSourceNATPoolPrefixHosts mirrors the userspace-dp
+// MAX_POOL_PREFIX_HOSTS constant (`userspace-dp/src/nat/source.rs`, #3049):
+// the upper bound on how many host addresses ONE source-NAT pool prefix is
+// expanded into by the Rust SNAT allocator. A pool member CIDR whose host
+// count exceeds this cap (an over-broad `/15`, `/8`, or any v6 prefix shorter
+// than `/112`) makes `expand_pool_address` return false, and the allocator
+// marks the WHOLE pool `InvalidPool`. The Go strict validator uses the same
+// bound so a pool the dataplane cannot honor is rejected at commit, not after
+// apply. A `/16` (exactly 65536 hosts) is at the cap and accepted, matching
+// the Rust `count > MAX_POOL_PREFIX_HOSTS` comparison exactly.
+const MaxSourceNATPoolPrefixHosts = 65536
+
+// sourceNATPoolAddressReason validates one source-NAT pool address member
+// against the live Rust pool grammar (`expand_pool_address`,
+// `userspace-dp/src/nat/source.rs`) and returns a human-readable reason when
+// the member is NOT honorable (ok=false), or ("", true) when it is.
+//
+// The live grammar accepts exactly two shapes:
+//
+//   - a bare IP (no `/`), parsed as a single host; and
+//   - a CIDR (`a.b.c.d/n`), enumerated over its FULL prefix range, valid only
+//     when the host count `1 << (addrbits - n)` does not exceed
+//     MaxSourceNATPoolPrefixHosts.
+//
+// Anything else — an unparseable token (`not-an-ip`), a malformed mask
+// (`203.0.113.1/garbage`), or an over-capacity prefix (`/15`, `10.0.0.0/8`, a
+// v6 prefix shorter than `/112`) — makes the Rust allocator return false for
+// the member and mark the pool `InvalidPool`, so the Go grammar must reject it
+// too. netip.ParsePrefix (like the Rust `IpNet` parse) accepts a non-canonical
+// prefix with host bits set; the runtime masks to the network base, so the Go
+// side counts hosts off the prefix LENGTH exactly as Rust does.
+func sourceNATPoolAddressReason(addr string) (string, bool) {
+	if strings.Contains(addr, "/") {
+		p, err := netip.ParsePrefix(addr)
+		if err != nil {
+			return "is not a valid CIDR (the dataplane cannot expand it and marks the pool unusable)", false
+		}
+		addrBits := 32
+		if p.Addr().Is6() {
+			addrBits = 128
+		}
+		hostBits := addrBits - p.Bits()
+		// Mirror the Rust arithmetic: reject when the enumerated host count
+		// exceeds the cap. The hostBits >= 64 guard both matches the Rust v6
+		// early-out and prevents a 1<<hostBits shift overflow (Go defines an
+		// over-wide shift as 0, which would otherwise UNDER-count and wrongly
+		// accept an astronomically large prefix).
+		if hostBits >= 64 || uint64(1)<<uint(hostBits) > MaxSourceNATPoolPrefixHosts {
+			return fmt.Sprintf(
+				"expands to more than %d host addresses, over the pool cap (the "+
+					"dataplane rejects the prefix and marks the pool unusable)",
+				MaxSourceNATPoolPrefixHosts), false
+		}
+		return "", true
+	}
+	if _, err := netip.ParseAddr(addr); err != nil {
+		return "is not a valid IP address (the dataplane cannot parse it and marks the pool unusable)", false
+	}
+	return "", true
+}
+
+// validateSourceNATPoolAddressGrammarStrict (#5627) hard-rejects a source-NAT
+// pool, REFERENCED by a pool-mode `then source-nat pool <name>` rule, whose
+// address membership the live Rust dataplane cannot honor as configured —
+// closing a commit-vs-apply grammar divergence (codex-review-181 M15 /
+// A3-b00-F02).
+//
+// The prior strict path (validateSourceNATPoolStrict) validated only a pool's
+// `port range`; it left the pool's ADDRESS members completely unchecked. The
+// snapshot builder (pkg/dataplane/userspace/nat_source.go) copies the raw
+// address strings onto the wire, and the Rust allocator
+// (`expand_pool_address` / `parse_source_nat_rules`,
+// `userspace-dp/src/nat/source.rs`) then rejects a malformed member, an
+// over-capacity prefix (host count > MaxSourceNATPoolPrefixHosts), or an empty
+// pool — marking the rule `InvalidPool` / `EmptyPool` and DROPPING it. So a
+// pool referencing `not-an-ip`, `203.0.113.1/garbage`, `10.0.0.0/8`, an
+// over-cap `/15`, or no addresses at all committed green then silently stopped
+// translating after apply: a single bad member poisons an otherwise usable
+// pool, producing a persistent NAT outage visible only at runtime.
+//
+// The gate iterates only pools that a pool-mode source-NAT rule actually
+// references (the exact set the dataplane snapshot expands — an unreferenced
+// pool never reaches the Rust grammar), in sorted rule-set / declaration order
+// for a deterministic first-reported offender. An UNDEFINED reference is
+// validateNATPoolReferencesStrict's (#5626) domain and is skipped here. Host
+// counting is O(pool address entries) with no enumeration — the invariant the
+// audit requires (do not expand up to 65,536 hosts in Go).
+//
+// Strict on commit / commit-check (hard-reject so the un-honorable pool is
+// operator-visible); the call site downgrades this to a warning on the
+// tolerant load / peer-sync path (opts.lenientDestNATAddresses — the shared
+// NAT silent-drop / wrong-translate doctrine, as validateNATPoolReferencesStrict
+// and validateSourceNATPoolStrict use) so an already-persisted or peer-synced
+// config carrying such a pool still BOOTS (#1960 no-brick) — the snapshot
+// builder independently marks the pool unusable, installing nothing rather
+// than translating wrongly. Mirrors validateSourceNATPoolStrict.
+func validateSourceNATPoolAddressGrammarStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	pools := cfg.Security.NAT.SourcePools
+	rulesets := append([]*NATRuleSet(nil), cfg.Security.NAT.Source...)
+	sort.SliceStable(rulesets, func(i, j int) bool {
+		if rulesets[i] == nil || rulesets[j] == nil {
+			return rulesets[i] != nil
+		}
+		return rulesets[i].Name < rulesets[j].Name
+	})
+	seen := make(map[string]bool)
+	for _, rs := range rulesets {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil || rule.Then.PoolName == "" {
+				continue
+			}
+			name := rule.Then.PoolName
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			pool, ok := pools[name]
+			if !ok || pool == nil {
+				// Undefined reference — validateNATPoolReferencesStrict (#5626).
+				continue
+			}
+			// Mirror the snapshot builder's live address set: the DNAT-compat
+			// single Address (unused by source pools today, but included for
+			// parity) plus the source pool Addresses.
+			var addrs []string
+			if pool.Address != "" {
+				addrs = append(addrs, pool.Address)
+			}
+			addrs = append(addrs, pool.Addresses...)
+			if len(addrs) == 0 {
+				return fmt.Errorf(
+					"source-nat pool %q (referenced by rule-set %q rule %q) has no "+
+						"pool addresses; the rule commits but the dataplane marks the "+
+						"pool unusable (EmptyPool) and drops it at runtime, silently "+
+						"stopping translation",
+					name, rs.Name, rule.Name)
+			}
+			for _, a := range addrs {
+				if reason, ok := sourceNATPoolAddressReason(a); !ok {
+					return fmt.Errorf(
+						"source-nat pool %q (referenced by rule-set %q rule %q): "+
+							"address %q %s; a single malformed or over-capacity member "+
+							"poisons the whole pool — the rule commits but the dataplane "+
+							"marks the pool unusable (InvalidPool) and drops it at runtime, "+
+							"silently stopping translation",
+						name, rs.Name, rule.Name, a, reason)
+				}
+			}
 		}
 	}
 	return nil

--- a/pkg/config/strict_nat_pool_grammar_5627_test.go
+++ b/pkg/config/strict_nat_pool_grammar_5627_test.go
@@ -1,0 +1,202 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5627 (codex-review-181 M15 / A3-b00-F02): the Go strict-commit
+// path validated a source-NAT pool's `port range` but left its ADDRESS members
+// unchecked, so a pool referenced by a pool-mode `then source-nat pool <name>`
+// rule that carried a malformed member, an over-capacity prefix (host count >
+// MaxSourceNATPoolPrefixHosts), or no addresses at all committed green — then
+// the live Rust allocator (expand_pool_address, userspace-dp/src/nat/source.rs)
+// marked the pool InvalidPool/EmptyPool and DROPPED the rule at runtime, a
+// persistent NAT outage visible only after apply. The fix
+// (validateSourceNATPoolAddressGrammarStrict) makes the Go strict grammar
+// equivalent to the live grammar: strict commit rejects the same shapes the
+// dataplane rejects; the tolerant load / peer-sync path warns-and-loads (#1960
+// no-brick), the snapshot builder independently marking the pool unusable.
+//
+// FAIL-ON-REVERT: dropping the `if err :=
+// validateSourceNATPoolAddressGrammarStrict(cfg); ...` dispatch in
+// compiler_uniformgates.go (or making the validator `return nil`) turns every
+// reject case GREEN and so RED here.
+
+// snat5627Tree builds a config with one source-NAT rule-set whose single rule
+// references pool `p1` in pool-mode, prefixed by the caller's pool `set` lines.
+// Mirrors the #3906 snatPoolTree pattern (ParseSetCommand + SetPath, never
+// NewParser — the flat-set testing gotcha).
+func snat5627Tree(t *testing.T, poolCmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	cmds := append([]string{}, poolCmds...)
+	cmds = append(cmds,
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool p1",
+	)
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestSourceNATPoolBadGrammarRejected covers every diverging pool shape named in
+// the codex-review-181 report: malformed token, malformed mask, over-cap /8,
+// over-cap /15, empty pool, v6 over-cap /111, and mixed valid+invalid. Each must
+// be REJECTED at strict commit — the reject assertions FAIL against the
+// unpatched validator (the fail-on-revert proof).
+func TestSourceNATPoolBadGrammarRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		pool []string
+		want string // substring the diagnostic must contain
+	}{
+		{
+			name: "malformed-token",
+			pool: []string{"set security nat source pool p1 address not-an-ip"},
+			want: "not a valid IP address",
+		},
+		{
+			name: "malformed-mask",
+			pool: []string{"set security nat source pool p1 address 203.0.113.1/garbage"},
+			want: "not a valid CIDR",
+		},
+		{
+			name: "over-cap-slash8",
+			pool: []string{"set security nat source pool p1 address 10.0.0.0/8"},
+			want: "over the pool cap",
+		},
+		{
+			name: "over-cap-slash15",
+			pool: []string{"set security nat source pool p1 address 10.0.0.0/15"},
+			want: "over the pool cap",
+		},
+		{
+			name: "v6-over-cap-slash111",
+			pool: []string{"set security nat source pool p1 address 2001:db8::/111"},
+			want: "over the pool cap",
+		},
+		{
+			name: "empty-pool",
+			pool: []string{"set security nat source pool p1 port range 5000 to 6000"},
+			want: "no pool addresses",
+		},
+		{
+			name: "mixed-valid-invalid",
+			pool: []string{
+				"set security nat source pool p1 address 203.0.113.5/32",
+				"set security nat source pool p1 address 203.0.113.1/garbage",
+			},
+			want: "not a valid CIDR",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileConfig(snat5627Tree(t, tc.pool...))
+			if err == nil {
+				t.Fatalf("expected strict commit to reject pool shape %q", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.want)
+			}
+			// Every reject must name the offending pool so the diagnostic is
+			// actionable.
+			if !strings.Contains(err.Error(), "p1") {
+				t.Fatalf("error %q does not name the offending pool", err.Error())
+			}
+		})
+	}
+}
+
+// TestSourceNATPoolValidGrammarCompiles asserts VALID pools still compile clean
+// on the strict path — no false-positive. Covers bare IP, /32, a small subnet,
+// the /16 boundary (exactly MaxSourceNATPoolPrefixHosts hosts — at the cap, NOT
+// over), a bracket list, a range, and a v6 /112 boundary.
+func TestSourceNATPoolValidGrammarCompiles(t *testing.T) {
+	cases := []struct {
+		name string
+		pool []string
+	}{
+		{"bare-ip", []string{"set security nat source pool p1 address 203.0.113.10"}},
+		{"host-cidr", []string{"set security nat source pool p1 address 203.0.113.10/32"}},
+		{"small-subnet", []string{"set security nat source pool p1 address 203.0.113.0/24"}},
+		{"slash16-boundary", []string{"set security nat source pool p1 address 100.64.0.0/16"}},
+		{"bracket-list", []string{"set security nat source pool p1 address [ 203.0.113.1/32 203.0.113.2/32 ]"}},
+		{"range", []string{"set security nat source pool p1 address 203.0.113.1/32 to 203.0.113.3/32"}},
+		{"v6-host", []string{"set security nat source pool p1 address 2001:db8::1/128"}},
+		{"v6-slash112-boundary", []string{"set security nat source pool p1 address 2001:db8::/112"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := CompileConfig(snat5627Tree(t, tc.pool...)); err != nil {
+				t.Fatalf("valid pool shape %q must compile clean on the strict path: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestSourceNATPoolBadGrammarLenientWarns asserts the tolerant load / peer-sync
+// path (#1960 no-brick) does NOT fail-closed on a malformed/over-cap/empty pool:
+// it records a warning and boots (the snapshot builder independently marks the
+// pool unusable). Covers a malformed member and an empty pool.
+func TestSourceNATPoolBadGrammarLenientWarns(t *testing.T) {
+	cases := []struct {
+		name string
+		pool []string
+	}{
+		{"malformed", []string{"set security nat source pool p1 address not-an-ip"}},
+		{"empty", []string{"set security nat source pool p1 port range 5000 to 6000"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfigLenient(snat5627Tree(t, tc.pool...))
+			if err != nil {
+				t.Fatalf("lenient compile must not brick on a bad pool: %v", err)
+			}
+			found := false
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, "source-nat pool address") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("lenient compile must record a source-nat pool address warning; warnings = %v", cfg.Warnings)
+			}
+		})
+	}
+}
+
+// TestSourceNATPoolUnreferencedBadPoolNotRejected pins the scoping decision:
+// the gate closes the Go-vs-LIVE grammar divergence, and the live dataplane only
+// expands pools that a pool-mode rule references. A defined-but-UNREFERENCED
+// malformed pool never reaches the Rust grammar, so it is not rejected here —
+// the gate stays grammar-EQUIVALENT with live rather than Go-stricter. (The port
+// leaf keeps the pool syntactically well-formed for the compiler.)
+func TestSourceNATPoolUnreferencedBadPoolNotRejected(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set security nat source pool orphan address not-an-ip",
+		"set security nat source pool orphan port range 5000 to 6000",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("an unreferenced pool with a bad address must not be rejected (grammar-equivalence with live, which never expands it): %v", err)
+	}
+}


### PR DESCRIPTION
Closes #5627

## Defect (codex-review-181 M15 / A3-b00-F02, Medium)

The Go strict-commit path validated a source-NAT pool's `port range` (#3906/#5457) but left its **address members completely unchecked**, while the live Rust allocator (`expand_pool_address` / `parse_source_nat_rules`, `userspace-dp/src/nat/source.rs`) enforces a real grammar:

- every member must be a **bare IP** or a **CIDR** whose host count `1 << (addrbits − prefixlen)` does not exceed `MAX_POOL_PREFIX_HOSTS = 65536`, and
- a referenced pool must be **non-empty**.

So a pool referenced by a pool-mode `then source-nat pool <name>` rule that carried a malformed member (`not-an-ip`, `203.0.113.1/garbage`), an over-capacity prefix (`/15`, `10.0.0.0/8`, a v6 prefix shorter than `/112`), or **no addresses at all** committed **green** — then the snapshot builder (`pkg/dataplane/userspace/nat_source.go`) copied the raw strings onto the wire, the Rust allocator returned `false` for the bad member and marked the pool `InvalidPool` / `EmptyPool`, and **DROPPED the rule** at runtime. The result is a persistent NAT outage visible only after apply, where a single bad member poisons an otherwise usable pool — a Go-vs-live grammar divergence.

## Fix — pure `pkg/config` strict validator (Go-only, no Rust/cargo touched)

`validateSourceNATPoolAddressGrammarStrict` (`compiler_validate_strict_nat.go`) + `MaxSourceNATPoolPrefixHosts` (mirrors the Rust cap) + `sourceNATPoolAddressReason` helper, wired into `runUniformGates` immediately after the #5626 pool-reference gate (so an **undefined** pool still wins the first-error slot).

- Rejects the exact shapes the dataplane rejects: each member must parse as a bare IP (`netip.ParseAddr`) or CIDR (`netip.ParsePrefix`, non-canonical allowed like the Rust `IpNet`) whose host count stays within the cap; a referenced pool must be non-empty.
- `/16` (exactly 65536 hosts, **at** the cap) is accepted, matching the Rust `count > MAX_POOL_PREFIX_HOSTS` comparison exactly.
- **Scoped to *referenced* pools** — the exact set the dataplane snapshot expands — so it stays **grammar-equivalent with live** rather than Go-stricter; an unreferenced pool never reaches the Rust grammar and is out of scope.
- Host counting is computed off the prefix **length** with no enumeration (`O(pool addresses)`, the audit's "do not expand 65,536 hosts in Go" invariant).
- **Strict** (commit / commit-check) = HARD REJECT naming the pool, rule-set, and rule. **Lenient** (`CompileConfigLenient` — Store.Load / SyncApply / peer-sync) = warn-and-load via the shared `lenientDestNATAddresses` flag (#1960 no-brick; the snapshot builder marks the pool unusable independently, so a leniently-loaded config installs nothing rather than mis-translating).

**Go-only confirmation:** the Rust dataplane is the *authoritative* grammar the Go gate now mirrors; no `.rs` / cargo source is touched. `git status` shows only `pkg/config/*.go` + `docs/config-schema.md` + `_Log.md`.

## Tests — `pkg/config/strict_nat_pool_grammar_5627_test.go`

- `TestSourceNATPoolBadGrammarRejected` — 7 diverging shapes from the report each REJECTED with a diagnostic: malformed token, malformed mask, over-cap `/8`, over-cap `/15`, v6 over-cap `/111`, empty pool, mixed valid+invalid.
- `TestSourceNATPoolValidGrammarCompiles` — valid pools compile clean (no false-positive): bare IP, `/32`, small subnet, **`/16` boundary**, bracket list, range, v6 `/128`, **v6 `/112` boundary**.
- `TestSourceNATPoolBadGrammarLenientWarns` — a malformed and an empty pool load-with-warning on the lenient path.
- `TestSourceNATPoolUnreferencedBadPoolNotRejected` — pins the grammar-equivalence scoping.

### Fail-on-revert (RED proof)

Unwiring the `validateSourceNATPoolAddressGrammarStrict` dispatch in `runUniformGates`:

```
--- FAIL: TestSourceNATPoolBadGrammarRejected/malformed-token
    expected strict commit to reject pool shape "malformed-token"
--- FAIL: TestSourceNATPoolBadGrammarRejected/malformed-mask
--- FAIL: TestSourceNATPoolBadGrammarRejected/over-cap-slash8
--- FAIL: TestSourceNATPoolBadGrammarRejected/over-cap-slash15
--- FAIL: TestSourceNATPoolBadGrammarRejected/v6-over-cap-slash111
--- FAIL: TestSourceNATPoolBadGrammarRejected/empty-pool
--- FAIL: TestSourceNATPoolBadGrammarRejected/mixed-valid-invalid
--- FAIL: TestSourceNATPoolBadGrammarLenientWarns/malformed
    lenient compile must record a source-nat pool address warning; warnings = [...]
--- FAIL: TestSourceNATPoolBadGrammarLenientWarns/empty
```

Restored → GREEN.

## Gates

- `go test ./pkg/config/...` passes (incl. the `TestEveryStrictCommitGateIsWired` canary).
- `go vet ./pkg/config/` clean; `gofmt -l` clean on touched files; `go build ./...` clean.
- `docs/config-schema.md` updated (new #5627 bullet in the NAT strict-gate list); `_Log.md` updated.

## Provenance

codex-review-181 (Paladin full-coverage security-zone audit), candidate M15 / finding A3-b00-F02, verified against origin/master. Full evidence in `/tmp/codex-review-181.md` (Appendix A per-candidate + Appendix D lane report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUMttPTPdBuENAmt9WaFJt