### PR TITLE
rpm: bound config-seconds interval against Duration overflow (#5723)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47765,3 +47765,31 @@ top.
   tests RED — "expected strict commit to reject a same-name address +
   address-set collision", "lenient compile must record a collision warning";
   restored GREEN.
+
+- **Timestamp**: 2026-07-13 00:40
+  **Action**: Fix #5723 — config-seconds*time.Second overflow sweep (sibling of
+  #5705/#5722 keepalive crash). Audited the 5 flagged NewTicker/NewTimer/After
+  sites. Only RPM `test-interval`/`probe-interval` were operator-settable AND
+  unbounded at admission (ValidateIntegerMin(1), no upper) → a huge value
+  overflows time.Duration(sec)*time.Second to a non-positive Duration →
+  time.NewTicker panic in runProbeLoop (commit-reachable xpfd crash). Applied
+  the #5705 two-layer fix: (1) admission bound — probe-interval/test-interval
+  validators → ValidateInteger(1, MaxDurationSeconds) (the same
+  overflow-safe ceiling feeds update/hold-interval already use); (2) runtime
+  clamp — clampRPMIntervalSeconds([1, MaxDurationSeconds]) before the multiply
+  in runProbeLoop, defense-in-depth for the lenient HA-sync/Load ingress.
+  Other 4 sites need NO change: LLDP transmit-interval already bounded
+  ValidateInteger(5, 32768); feeds update-interval/hold-interval already
+  ValidateInteger(1, MaxDurationSeconds); daemon_ipsec_rebind + daemon_rpm
+  pin-retry use a test-seam Duration + compile-time-constant fallback with an
+  `interval <= 0` guard (not config-derived).
+  **File(s)**: pkg/config/schema_system.go, pkg/rpm/rpm.go, pkg/rpm/README.md,
+  pkg/config/rpm_interval_bound_5723_test.go,
+  pkg/rpm/rpm_interval_overflow_5723_test.go
+  GREEN: `go test ./pkg/rpm/... ./pkg/lldp/... ./pkg/daemon/... ./pkg/feeds/...
+  ./pkg/config/...` all pass; gofmt + vet clean. Fail-on-revert (both layers):
+  reverting clampRPMIntervalSeconds to a bare multiply →
+  TestClampRPMIntervalSecondsBoundsOverflow_5723 RED
+  ("clampRPMIntervalSeconds(9223372036854775807) = -1s, want positive");
+  reverting the validators to ValidateIntegerMin(1) →
+  TestRPMIntervalSchemaGate_5723 RED (6 huge values accepted). Restored GREEN.

--- a/pkg/config/rpm_interval_bound_5723_test.go
+++ b/pkg/config/rpm_interval_bound_5723_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+)
+
+// TestRPMIntervalSchemaGate_5723 proves the #5723 admission fix: the RPM
+// `test-interval` and `probe-interval` VALUES are typed integers bounded to
+// 1..MaxDurationSeconds, so a value that would overflow
+// time.Duration(sec)*time.Second (int64 ns) at the runtime probe loop's
+// time.NewTicker / time.After is REJECTED at the commit-check gate
+// (SchemaValidate) instead of reaching pkg/rpm and panicking xpfd. Sibling of
+// the #5705 tunnel-keepalive crash.
+//
+// FAIL-ON-REVERT: restoring `validator: ValidateIntegerMin(1)` (no upper bound)
+// on either leaf makes the huge-value reject assertions below fire RED.
+func TestRPMIntervalSchemaGate_5723(t *testing.T) {
+	prefixes := []string{
+		"set services rpm probe p1 test t1 test-interval",
+		"set services rpm probe p1 test t1 probe-interval",
+	}
+	// Values that MUST be rejected at commit: the huge int64-overflowing values
+	// are the actual #5723 crash trigger; negatives / non-ints are rejected as a
+	// side effect of typing the leaf.
+	bad := []string{
+		"banana",
+		"0",  // below the 1s minimum
+		"-1", // negative
+		// MaxDurationSeconds is math.MaxInt64/1e9 ≈ 9223372036; one past it
+		// overflows the *time.Second multiply.
+		"9223372037",           // MaxDurationSeconds + 1
+		"9999999999",           // ~1e10 s * 1e9 ns overflows int64 → non-positive Duration → NewTicker panic
+		"9223372036854775807",  // int64 max
+		"99999999999999999999", // not representable as int64
+	}
+	// Values that MUST be accepted (1 = min, plus a large-but-safe value and the
+	// exact ceiling).
+	good := []string{"1", "5", "30", "3600", "9223372036"} // last == MaxDurationSeconds
+
+	for _, pfx := range prefixes {
+		for _, v := range bad {
+			tree := flatTreeFromSets(t, pfx+" "+v)
+			if err := SchemaValidate(tree, nil); err == nil {
+				t.Errorf("%s %q: expected SchemaValidate to reject, got nil", pfx, v)
+			}
+		}
+		for _, v := range good {
+			tree := flatTreeFromSets(t, pfx+" "+v)
+			if err := SchemaValidate(tree, nil); err != nil {
+				t.Errorf("%s %q: expected SchemaValidate to accept, got %v", pfx, v, err)
+			}
+		}
+	}
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -571,10 +571,17 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 					args:          1,
 					desc:          "Seconds between probes within a test",
 					valueType:     ValueInteger,
-					valueDesc:     "Seconds between probes (>= 1)",
+					valueDesc:     "Seconds between probes (1..MaxDurationSeconds)",
 					valueExamples: []string{"5"},
-					validator:     ValidateIntegerMin(1),
-					children:      nil,
+					// #5723: bound the upper end (not just >= 1) so a
+					// pathological value cannot overflow
+					// time.Duration(sec)*time.Second into a non-positive Duration
+					// at the runtime probe loop (time.NewTicker / time.After panic
+					// / busy-spin) — sibling of the #5705 keepalive crash. Same
+					// MaxDurationSeconds ceiling the feeds update/hold-interval and
+					// other second-valued leaves use.
+					validator: ValidateInteger(1, MaxDurationSeconds),
+					children:  nil,
 				},
 				"probe-count": {
 					args:          1,
@@ -589,10 +596,15 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 					args:          1,
 					desc:          "Seconds between test cycles",
 					valueType:     ValueInteger,
-					valueDesc:     "Seconds between test cycles (>= 1)",
+					valueDesc:     "Seconds between test cycles (1..MaxDurationSeconds)",
 					valueExamples: []string{"30"},
-					validator:     ValidateIntegerMin(1),
-					children:      nil,
+					// #5723: bound the upper end so a pathological value cannot
+					// overflow time.Duration(sec)*time.Second into a non-positive
+					// Duration and panic time.NewTicker in the runtime probe loop
+					// (rpm.go runProbeLoop) — a commit-reachable xpfd crash,
+					// sibling of the #5705 keepalive overflow.
+					validator: ValidateInteger(1, MaxDurationSeconds),
+					children:  nil,
 				},
 				"thresholds": {desc: "Failure thresholds for the test", children: map[string]*schemaNode{
 					"successive-loss": {

--- a/pkg/rpm/README.md
+++ b/pkg/rpm/README.md
@@ -5,6 +5,17 @@ GET). Tracks RTT and jitter, emits events for the event-options engine,
 fires per-test pass/fail transitions for the ip-monitoring engine, and
 pins probes to devices/next-hops via `SO_BINDTODEVICE` / `SO_MARK`.
 
+**Interval overflow bound (#5723).** `test-interval` / `probe-interval`
+are operator-settable in seconds and are bounded to `[1,
+config.MaxDurationSeconds]` at commit (`schema_system.go`), so a
+pathological value cannot overflow `time.Duration(sec)*time.Second` into
+a non-positive Duration and panic `time.NewTicker` in `runProbeLoop`
+(a commit-reachable xpfd crash, sibling of the #5705 keepalive
+overflow). `clampRPMIntervalSeconds` (`rpm.go`) re-applies the same
+`[1, MaxDurationSeconds]` clamp at runtime as defense-in-depth for the
+lenient HA-sync / on-disk Load ingress, which only downgrades an
+out-of-range value to a warning.
+
 ## Entry points
 
 - `Manager` — `rpm.go`.

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -437,9 +437,29 @@ func (m *Manager) Results() []*ProbeResult {
 	return out
 }
 
+// clampRPMIntervalSeconds converts a config-derived RPM interval (seconds) to a
+// positive, non-overflowing time.Duration. A test-interval / probe-interval is
+// bounded to config.MaxDurationSeconds at commit by the schema (#5723), but the
+// lenient HA-sync / on-disk Load ingress only DOWNGRADES an out-of-range value
+// to a warning, so a peer-synced or persisted pathological value can still reach
+// the runtime probe loop. Clamping to [1, MaxDurationSeconds] before the
+// *time.Second multiply keeps time.Duration(sec)*time.Second within int64
+// nanoseconds, so a non-positive Duration can never reach time.NewTicker and
+// panic xpfd — the sibling of the #5705 keepalive overflow. EffectiveTest/
+// ProbeInterval already floor at their defaults, so sec < 1 is defensive.
+func clampRPMIntervalSeconds(sec int) time.Duration {
+	if sec < 1 {
+		return time.Second
+	}
+	if int64(sec) > config.MaxDurationSeconds {
+		return time.Duration(config.MaxDurationSeconds) * time.Second
+	}
+	return time.Duration(sec) * time.Second
+}
+
 func (m *Manager) runProbeLoop(ctx context.Context, probe *config.RPMProbe, test *config.RPMTest, key string) {
-	interval := time.Duration(test.EffectiveTestInterval()) * time.Second
-	probeInterval := time.Duration(test.EffectiveProbeInterval()) * time.Second
+	interval := clampRPMIntervalSeconds(test.EffectiveTestInterval())
+	probeInterval := clampRPMIntervalSeconds(test.EffectiveProbeInterval())
 	probeCount := test.EffectiveProbeCount()
 	threshold := test.EffectiveSuccessiveLossThreshold()
 

--- a/pkg/rpm/rpm_interval_overflow_5723_test.go
+++ b/pkg/rpm/rpm_interval_overflow_5723_test.go
@@ -1,0 +1,81 @@
+package rpm
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestClampRPMIntervalSecondsBoundsOverflow_5723 is the #5723 runtime-clamp
+// fail-on-revert guard (defense-in-depth for the lenient HA-sync / on-disk Load
+// ingress that downgrades an out-of-range interval to a warning, bypassing the
+// schema admission bound). A config-derived RPM interval whose
+// time.Duration(sec)*time.Second product overflows int64 nanoseconds must clamp
+// to a POSITIVE, time.NewTicker-safe Duration instead of wrapping to a
+// non-positive value that panics runProbeLoop.
+//
+// FAIL-ON-REVERT: revert clampRPMIntervalSeconds to a bare
+// `time.Duration(sec)*time.Second` and the overflow cases below return a
+// non-positive Duration — the >0 assertion fires RED and the NewTicker probe
+// panics.
+func TestClampRPMIntervalSecondsBoundsOverflow_5723(t *testing.T) {
+	overflowing := []int{
+		math.MaxInt64,                      // sec * 1e9 overflows hugely
+		math.MaxInt64 / 2,                  // still overflows the *time.Second multiply
+		1 << 40,                            // ~1.1e12 s * 1e9 ns overflows int64
+		9999999999,                         // ~1e10 s → overflow
+		int(config.MaxDurationSeconds) + 1, // one past the safe ceiling
+	}
+	for _, sec := range overflowing {
+		// Sanity: the UNCLAMPED multiply really does overflow to non-positive —
+		// this is the bug the clamp prevents.
+		if raw := time.Duration(sec) * time.Second; raw > 0 {
+			t.Fatalf("test premise broken: time.Duration(%d)*time.Second = %v is still positive", sec, raw)
+		}
+		got := clampRPMIntervalSeconds(sec)
+		if got <= 0 {
+			t.Fatalf("clampRPMIntervalSeconds(%d) = %v, want a positive Duration (overflow not bounded — #5723)", sec, got)
+		}
+		if got != time.Duration(config.MaxDurationSeconds)*time.Second {
+			t.Errorf("clampRPMIntervalSeconds(%d) = %v, want clamp to MaxDurationSeconds (%v)",
+				sec, got, time.Duration(config.MaxDurationSeconds)*time.Second)
+		}
+		// The whole point: constructing the probe ticker must not panic.
+		mustNotPanicNewTicker(t, got)
+	}
+
+	// Normal / boundary values pass through unchanged and stay ticker-safe.
+	for _, tc := range []struct {
+		sec  int
+		want time.Duration
+	}{
+		{0, time.Second},  // floored (defensive; EffectiveInterval never returns <1)
+		{-5, time.Second}, // floored
+		{1, time.Second},  // min
+		{30, 30 * time.Second},
+		{3600, 3600 * time.Second},
+		{int(config.MaxDurationSeconds), time.Duration(config.MaxDurationSeconds) * time.Second}, // exact ceiling, no overflow
+	} {
+		got := clampRPMIntervalSeconds(tc.sec)
+		if got != tc.want {
+			t.Errorf("clampRPMIntervalSeconds(%d) = %v, want %v", tc.sec, got, tc.want)
+		}
+		if got <= 0 {
+			t.Errorf("clampRPMIntervalSeconds(%d) = %v, want positive", tc.sec, got)
+		}
+		mustNotPanicNewTicker(t, got)
+	}
+}
+
+func mustNotPanicNewTicker(t *testing.T, d time.Duration) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("time.NewTicker(%v) panicked (non-positive Duration): %v", d, r)
+		}
+	}()
+	tk := time.NewTicker(d)
+	tk.Stop()
+}


### PR DESCRIPTION
## Defect
An operator-settable interval multiplied by `time.Second` with no upper bound overflows int64 nanoseconds into a **non-positive** `time.Duration`, which panics `time.NewTicker` — a **commit-reachable xpfd crash (DoS)**. This is the pattern the #5705/#5722 tunnel-keepalive fix closed; #5723 is the repo-wide sibling sweep of the `NewTicker`/`NewTimer`/`After` sites it flagged.

## Per-site audit

| Site | Operator-settable seconds? | Bounded at admission? | Verdict |
|------|:--:|:--:|--------|
| `pkg/rpm/rpm.go` `runProbeLoop` — `test-interval` → `time.NewTicker`, `probe-interval` → `time.After` | **yes** | **no** (`ValidateIntegerMin(1)`, no ceiling) | **FIXED** — `test-interval 9999999999` overflows `*time.Second` → non-positive → `NewTicker` panic |
| `pkg/lldp/lldp.go` `txLoop` — `transmit-interval` | yes | **yes** (`ValidateInteger(5, 32768)`; 32768 s can't overflow) | no change |
| `pkg/feeds/feeds.go` `refreshLoop` — `update-interval` (+ `resolveHoldInterval` `hold-interval`) | yes | **yes** (`ValidateInteger(1, MaxDurationSeconds)` — the exact overflow-safe ceiling) | no change |
| `pkg/daemon/daemon_ipsec_rebind.go` `ipsecRebindRetryLoop` | **no** | n/a | no change — test-seam `Duration` + compile-time constant fallback, `interval <= 0` guard |
| `pkg/daemon/daemon_rpm.go` `probePinRetryLoop` | **no** | n/a | no change — same test-seam + constant pattern |

Only the RPM site is a genuine #5705-class commit-reachable panic.

## Fix (mirrors the #5705 two-layer shape, RPM only)
1. **Admission bound** — `probe-interval` / `test-interval` validators change from `ValidateIntegerMin(1)` to `ValidateInteger(1, MaxDurationSeconds)`, so an overflowing value is **rejected at commit** (`SchemaValidate`). `MaxDurationSeconds` (= `math.MaxInt64 / time.Second`) is the same overflow-safe ceiling the feeds interval leaves already use.
2. **Runtime clamp** — `clampRPMIntervalSeconds` re-applies the `[1, MaxDurationSeconds]` clamp before the `*time.Second` multiply in `runProbeLoop`, as **defense-in-depth** for the lenient HA-sync / on-disk `Load` ingress, which only *downgrades* an out-of-range value to a warning instead of rejecting it.

No wire/ABI/forwarding/Rust surface is touched. Updated `pkg/rpm/README.md`.

## Validation
- `pkg/config/rpm_interval_bound_5723_test.go` — `SchemaValidate` rejects overflowing / negative / non-integer `test-interval` & `probe-interval`, accepts `1..MaxDurationSeconds`.
- `pkg/rpm/rpm_interval_overflow_5723_test.go` — `clampRPMIntervalSeconds` returns a positive, `NewTicker`-safe Duration for values whose raw multiply overflows to non-positive; passes normal/boundary values through unchanged.

`go test ./pkg/rpm/... ./pkg/lldp/... ./pkg/daemon/... ./pkg/feeds/... ./pkg/config/...` all pass; `go vet` + `gofmt -l` clean.

### Fail-on-revert (RED) proof — both layers
Runtime clamp reverted to a bare `time.Duration(sec)*time.Second`:
```
--- FAIL: TestClampRPMIntervalSecondsBoundsOverflow_5723 (0.00s)
    rpm_interval_overflow_5723_test.go:39: clampRPMIntervalSeconds(9223372036854775807) = -1s, want a positive Duration (overflow not bounded — #5723)
```
Admission validators reverted to `ValidateIntegerMin(1)`:
```
--- FAIL: TestRPMIntervalSchemaGate_5723 (0.00s)
    rpm_interval_bound_5723_test.go:44: set services rpm probe p1 test t1 test-interval "9223372037": expected SchemaValidate to reject, got nil
    ... (probe-interval + int64-max + 9999999999 likewise accepted)
```
Both restore GREEN with the fix in place.

Provenance: #5722 (#5705) hostile-review sibling sweep.

Closes #5723

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNEVrePodApsgbw6bvkcSw