### PR TITLE
config: walk all interfaces roots in two AST pre-walks (#5744)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47880,3 +47880,31 @@ top.
   over-cap /111, empty, mixed) and both lenient-warn cases RED — "expected
   strict commit to reject pool shape", "lenient compile must record a
   source-nat pool address warning"; restored GREEN.
+
+- **Timestamp**: 2026-07-13
+  **Action**: Fix #5744 — two interface AST pre-walks were still
+  first-root-only after PR #5741 routed the interface-range expansion +
+  stable-ID collision gates through all top-level roots. A hierarchical config
+  splitting `interfaces { }` across two sibling roots could place a unit-alias
+  collision (validateInterfaceUnitAliasCollisionsAST, #5631) or an
+  unsupported/silently-dropped interface stanza
+  (validateUnsupportedInterfaceStanzasAST, #2008/#2354) in the SECOND root and
+  bypass both validators. Fix: both functions now flatten EVERY `interfaces`
+  root's children into one per-interface pass (mirrors #5741's all-roots
+  union). Correctness: compileInterfaces stores each interface node with
+  whole-interface last-writer-wins (`ifaces.Interfaces[ifName] = ifc`), so a
+  unit-alias collision is always intra-node — flattening across roots detects
+  each node independently, exactly matching what compileInterfaces consumes (no
+  cross-root per-interface aggregation, which would over-flag). Pure pkg/config
+  Go change.
+  **File(s)**: pkg/config/compiler_interface_unit_alias.go,
+  pkg/config/compiler_interfaces_unsupported.go,
+  pkg/config/interface_prewalk_all_roots_5744_test.go (new),
+  docs/config-schema.md
+  GREEN: `go test ./pkg/config/...` passes. gofmt clean on touched files, go
+  vet clean. Fail-on-revert proven: restoring both validators' first-root-only
+  selection turns the three second-root cases RED — "expected strict commit to
+  reject a unit-alias collision in the SECOND interfaces root", "expected
+  strict commit to reject an unsupported `mac` stanza in the SECOND interfaces
+  root", "lenient compile must warn about the second-root unsupported stanza";
+  the single-root no-regression case stayed GREEN; restored GREEN.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3291,7 +3291,18 @@ reserved for whole-dataplane selection where a rewrite shim
   carried the same first-root-only defect for split `security` /
   `interfaces` / `routing-instances` roots and were fixed the same way
   (`#5691`, `ConfigTree.FindChildren`-based union across all matching
-  roots).
+  roots). **#5744 (the two remaining interface AST pre-walks):** the
+  unit-alias collision gate (`validateInterfaceUnitAliasCollisionsAST`,
+  `#5631`) and the unsupported-stanza gate
+  (`validateUnsupportedInterfaceStanzasAST`, `#2008`/`#2354`) were the last
+  sibling pre-walks still `break`-ing on the first `interfaces` root, so a
+  unit-alias collision or an unsupported/silently-dropped stanza placed in a
+  SECOND `interfaces` root bypassed them. Both now flatten every
+  `interfaces` root's children into one per-interface pass (whole-interface
+  last-writer-wins across roots keeps the collision intra-node, so each
+  interface node is still detected independently, matching
+  `compileInterfaces`). Regression coverage:
+  `pkg/config/interface_prewalk_all_roots_5744_test.go`.
 - **#3444 (destination-NAT rule-set `to` scope reject):** a Junos
   destination-NAT rule-set has only a `from` clause (zone | interface |
   routing-instance) — DNAT translates the destination on inbound, so there

--- a/pkg/config/compiler_interface_unit_alias.go
+++ b/pkg/config/compiler_interface_unit_alias.go
@@ -73,14 +73,27 @@ import (
 // token is skipped — the compiler `continue`s on the identical Atoi error, so
 // it never reaches `ifc.Units` and cannot collide.
 func validateInterfaceUnitAliasCollisionsAST(nodes []*Node, lenient bool) ([]string, error) {
-	var ifaces *Node
+	// #5744: union across EVERY top-level `interfaces` root, not just the first.
+	// A hierarchical config can split its interfaces across two sibling
+	// `interfaces { }` stanzas, and compileSections compiles them all — so a
+	// unit-alias collision living in a SECOND root was skipped by the old
+	// first-root-only scan, the sibling gap PR #5741 closed for the
+	// interface-range / stable-ID gates (expandInterfaceRanges,
+	// validateZoneIDCollisionAST). Flattening every interfaces root's children
+	// into one per-interface pass is equivalent to nesting a loop over the roots:
+	// compileInterfaces stores each interface node with whole-interface
+	// last-writer-wins (`ifaces.Interfaces[ifName] = ifc`), so the collision is
+	// always intra-node and each interface node is detected independently,
+	// exactly as before.
+	var ifaceChildren []*Node
+	sawInterfaces := false
 	for _, n := range nodes {
 		if n.Name() == "interfaces" {
-			ifaces = n
-			break
+			sawInterfaces = true
+			ifaceChildren = append(ifaceChildren, n.Children...)
 		}
 	}
-	if ifaces == nil {
+	if !sawInterfaces {
 		return nil, nil
 	}
 
@@ -94,7 +107,7 @@ func validateInterfaceUnitAliasCollisionsAST(nodes []*Node, lenient bool) ([]str
 		return nil
 	}
 
-	for _, iface := range ifaces.Children {
+	for _, iface := range ifaceChildren {
 		ifName := iface.Name()
 		if ifName == "" {
 			continue

--- a/pkg/config/compiler_interfaces_unsupported.go
+++ b/pkg/config/compiler_interfaces_unsupported.go
@@ -84,14 +84,23 @@ import "fmt"
 // mac` identity key (both legitimate uses of these keywords elsewhere)
 // are never touched.
 func validateUnsupportedInterfaceStanzasAST(nodes []*Node, lenient bool) ([]string, error) {
-	var ifaces *Node
+	// #5744: union across EVERY top-level `interfaces` root, not just the first.
+	// A hierarchical config can split its interfaces across two sibling
+	// `interfaces { }` stanzas, and compileSections compiles them all — so an
+	// unsupported / silently-dropped interface stanza living in a SECOND root
+	// was skipped by the old first-root-only scan, the sibling gap PR #5741
+	// closed for the interface-range / stable-ID gates. Flattening every
+	// interfaces root's children into one per-interface pass is equivalent to
+	// nesting a loop over the roots; each stanza is flagged independently.
+	var ifaceChildren []*Node
+	sawInterfaces := false
 	for _, n := range nodes {
 		if n.Name() == "interfaces" {
-			ifaces = n
-			break
+			sawInterfaces = true
+			ifaceChildren = append(ifaceChildren, n.Children...)
 		}
 	}
-	if ifaces == nil {
+	if !sawInterfaces {
 		return nil, nil
 	}
 
@@ -107,7 +116,7 @@ func validateUnsupportedInterfaceStanzasAST(nodes []*Node, lenient bool) ([]stri
 
 	// Each direct child of `interfaces` is a physical/aggregate interface
 	// instance (wildcard name slot).
-	for _, iface := range ifaces.Children {
+	for _, iface := range ifaceChildren {
 		ifName := iface.Name()
 		if ifName == "" {
 			continue

--- a/pkg/config/interface_prewalk_all_roots_5744_test.go
+++ b/pkg/config/interface_prewalk_all_roots_5744_test.go
@@ -1,0 +1,216 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5744: two interface AST pre-walks — the unit-alias collision gate
+// (validateInterfaceUnitAliasCollisionsAST, #5631) and the unsupported-stanza
+// gate (validateUnsupportedInterfaceStanzasAST, #2008/#2354) — were still
+// FIRST-ROOT-ONLY after PR #5741 routed the interface-range expansion and the
+// stable-ID collision gates through all top-level roots. A hierarchical config
+// can split its `interfaces { }` across TWO sibling roots (compileSections
+// dispatches every one), so a collision or an unsupported stanza placed in the
+// SECOND root bypassed these validators entirely.
+//
+// A split config with two top-level roots of the same stanza is a
+// hierarchical-only shape: the flat-set path (ParseSetCommand + tree.SetPath)
+// always MERGES `set interfaces …` onto ONE root, so these tests are authored
+// through NewParser (the only shape that can express sibling roots) and each
+// asserts the two-root precondition, mirroring the #5741
+// compiler_multi_root_5675_5691_test.go pattern.
+//
+// FAIL-ON-REVERT: restoring either validator's first-root-only selection (a
+// `for … break` on the first `interfaces` root) turns the second-root case
+// GREEN and so RED here.
+
+// TestUnitAliasCollisionSecondRootRejected_5744 — a numeric unit-alias collision
+// (`unit 0` + `unit 00` collapsing to the same logical unit) living in the
+// SECOND `interfaces` root is rejected at strict commit.
+func TestUnitAliasCollisionSecondRootRejected_5744(t *testing.T) {
+	input := `
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}
+interfaces {
+    ge-0/0/1 {
+        unit 0 {
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+        unit 00 {
+            family inet {
+                address 10.0.2.1/24;
+            }
+        }
+    }
+}
+`
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	// Precondition: the split-root shape this guards actually exists.
+	if got := len(tree.FindChildren("interfaces")); got != 2 {
+		t.Fatalf("expected 2 top-level interfaces roots, got %d", got)
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected strict commit to reject a unit-alias collision in the SECOND interfaces root")
+	}
+	if !strings.Contains(err.Error(), "same logical unit") || !strings.Contains(err.Error(), "ge-0/0/1") {
+		t.Fatalf("error %q does not name the second-root unit-alias collision", err.Error())
+	}
+}
+
+// TestUnsupportedStanzaSecondRootRejected_5744 — an unsupported interface stanza
+// (a static `mac` override, H10) living in the SECOND `interfaces` root is
+// flagged (strict: rejected) instead of being silently dropped at compile.
+func TestUnsupportedStanzaSecondRootRejected_5744(t *testing.T) {
+	input := `
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}
+interfaces {
+    ge-0/0/1 {
+        mac 00:11:22:33:44:55;
+        unit 0 {
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+    }
+}
+`
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if got := len(tree.FindChildren("interfaces")); got != 2 {
+		t.Fatalf("expected 2 top-level interfaces roots, got %d", got)
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected strict commit to reject an unsupported `mac` stanza in the SECOND interfaces root")
+	}
+	if !strings.Contains(err.Error(), "mac` override is not supported") || !strings.Contains(err.Error(), "ge-0/0/1") {
+		t.Fatalf("error %q does not name the second-root unsupported stanza", err.Error())
+	}
+}
+
+// TestUnsupportedStanzaSecondRootLenientWarns_5744 — the tolerant load /
+// peer-sync path (#1960) downgrades the second-root unsupported stanza to a
+// warning and still loads (no-brick), proving the all-roots walk feeds the
+// lenient path too.
+func TestUnsupportedStanzaSecondRootLenientWarns_5744(t *testing.T) {
+	input := `
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/24;
+            }
+        }
+    }
+}
+interfaces {
+    ge-0/0/1 {
+        unit 0 {
+            inner-vlan-id 100;
+            family inet {
+                address 10.0.1.1/24;
+            }
+        }
+    }
+}
+`
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if got := len(tree.FindChildren("interfaces")); got != 2 {
+		t.Fatalf("expected 2 top-level interfaces roots, got %d", got)
+	}
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not brick on a second-root unsupported stanza: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "inner-vlan-id") && strings.Contains(w, "ge-0/0/1") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile must warn about the second-root unsupported stanza; warnings = %v", cfg.Warnings)
+	}
+}
+
+// TestInterfacePrewalkSingleRootUnchanged_5744 pins no regression: a
+// single-root config behaves identically — a collision / unsupported stanza in
+// the ONLY root is still rejected, and a clean single/split config still
+// compiles.
+func TestInterfacePrewalkSingleRootUnchanged_5744(t *testing.T) {
+	// Single-root collision still rejected.
+	collide := `
+interfaces {
+    ge-0/0/1 {
+        unit 0 {
+            family inet { address 10.0.1.1/24; }
+        }
+        unit 00 {
+            family inet { address 10.0.2.1/24; }
+        }
+    }
+}
+`
+	tree, errs := NewParser(collide).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	if _, err := CompileConfig(tree); err == nil || !strings.Contains(err.Error(), "same logical unit") {
+		t.Fatalf("single-root unit-alias collision must still be rejected, got err=%v", err)
+	}
+
+	// Clean split-root config compiles with no interface pre-walk error.
+	clean := `
+interfaces {
+    ge-0/0/0 {
+        unit 0 { family inet { address 10.0.0.1/24; } }
+    }
+}
+interfaces {
+    ge-0/0/1 {
+        unit 0 { family inet { address 10.0.1.1/24; } }
+    }
+}
+`
+	tree2, errs2 := NewParser(clean).Parse()
+	if len(errs2) > 0 {
+		t.Fatalf("parse: %v", errs2)
+	}
+	if got := len(tree2.FindChildren("interfaces")); got != 2 {
+		t.Fatalf("expected 2 top-level interfaces roots, got %d", got)
+	}
+	if _, err := CompileConfig(tree2); err != nil {
+		t.Fatalf("clean split-root interfaces config must compile: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #5744

## Defect

PR #5741 (#5675/#5691) added `ConfigTree.FindChildren` and routed the interface-range expansion + the stable-ID collision gates (zone/tunnel/routing-instance) through it so they observe **every** top-level root, not just the first. But two **sibling** AST pre-walks in `pkg/config` were out of that PR's scope and still used the first-root-only pattern (a `for … break` on the first `interfaces` root):

- `validateInterfaceUnitAliasCollisionsAST` (`compiler_interface_unit_alias.go`, #5631)
- `validateUnsupportedInterfaceStanzasAST` (`compiler_interfaces_unsupported.go`, #2008 H9/H10, #2354)

A hierarchical config can split its `interfaces { }` across two sibling top-level roots (the flat-set `SetPath` path always merges `set interfaces …` onto one root, so this shape is **hierarchical-only**), and `compileSections` dispatches every matching root. So a numeric unit-alias collision (`unit 0` + `unit 00`), or an unsupported/silently-dropped interface stanza, placed in the **SECOND** `interfaces` root **bypassed these validators entirely**:

- **Unit-alias bypass**: the collision is not rejected → the later spelling silently wins the unit filter (a fail-open on the interface firewall filter, the #5631 failure shape).
- **Unsupported-stanza bypass**: an unsupported stanza in a second root is not flagged and is silently dropped at compile — committed operator intent is not enforced and no warning is emitted.

## Fix (mirrors #5741 exactly, pure `pkg/config` Go)

Both validators now flatten **every** `interfaces` root's children into one per-interface pass instead of `break`-ing on the first root.

This is equivalent to nesting a loop over the roots, and is correct: `compileInterfaces` stores each interface node with **whole-interface last-writer-wins** (`ifaces.Interfaces[ifName] = ifc`), so a same-named interface split across roots is a whole-interface overwrite, **not** a unit-alias. The collision the gate detects is therefore always **intra-node**, and each interface node is still detected independently — exactly matching what `compileInterfaces` consumes. No cross-root per-interface aggregation (which would over-flag relative to the compiler). All existing per-root validation logic is preserved; only the root selection changed from first-only to all-roots.

## Tests — `pkg/config/interface_prewalk_all_roots_5744_test.go`

Authored through `NewParser` (the only shape that can express sibling roots), each asserting the two-root precondition, mirroring #5741's `compiler_multi_root_5675_5691_test.go`:

- `TestUnitAliasCollisionSecondRootRejected_5744` — a `unit 0` + `unit 00` collision in the SECOND root is rejected at strict commit.
- `TestUnsupportedStanzaSecondRootRejected_5744` — a static `mac` override in the SECOND root is rejected.
- `TestUnsupportedStanzaSecondRootLenientWarns_5744` — a second-root `inner-vlan-id` warns-and-loads on the tolerant path (#1960).
- `TestInterfacePrewalkSingleRootUnchanged_5744` — no regression: single-root collision still rejected, clean split-root config compiles.

### Fail-on-revert (RED proof)

Restoring both validators' first-root-only selection:

```
--- FAIL: TestUnitAliasCollisionSecondRootRejected_5744
    expected strict commit to reject a unit-alias collision in the SECOND interfaces root
--- FAIL: TestUnsupportedStanzaSecondRootRejected_5744
    expected strict commit to reject an unsupported `mac` stanza in the SECOND interfaces root
--- FAIL: TestUnsupportedStanzaSecondRootLenientWarns_5744
    lenient compile must warn about the second-root unsupported stanza; warnings = []
```

The single-root no-regression case stayed GREEN throughout. Restored → GREEN.

## Gates

- `go test ./pkg/config/...` passes; `go vet ./pkg/config/` clean; `gofmt -l` clean on touched files; `go build ./...` clean.
- `docs/config-schema.md` updated (extends the #5675/#5691 multi-root note with the #5744 pre-walks); `_Log.md` updated.

## Provenance

Sibling gap of PR #5741 (#5675/#5691) — the two interface AST pre-walks that were out of that PR's scope. Pure `pkg/config` Go change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUMttPTPdBuENAmt9WaFJt