### PR TITLE
api: bound the ClearSessions full-table walk on both surfaces

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47880,3 +47880,32 @@ top.
   over-cap /111, empty, mixed) and both lenient-warn cases RED — "expected
   strict commit to reject pool shape", "lenient compile must record a
   source-nat pool address warning"; restored GREEN.
+
+- **Timestamp**: 2026-07-13
+  **Action**: #5779 — ClearSessions full-table walks were unbounded on both
+  surfaces (follow-up to #5708/#5778, the session-CLEAR mutation counterpart).
+  Both ClearSessions branches walk the whole v4+v6 conntrack table holding
+  per-bucket BPF-map locks: the clear-all path (ClearAllSessions is a chunked
+  full-table scan+delete via ClearAllSessionsChunked, NOT O(1)) and the
+  filtered path (clearFilteredSessionsV4/V6 — cursor IterateSessionsFrom in
+  production, rescan IterateSessions fallback). Same DoS class as #5708's read
+  scans. Fix: gate the gRPC ClearSessions handler ONCE at entry (after the
+  dp-loaded check) through the shared diagcmd.SessionWalkLimiter → over-cap
+  codes.ResourceExhausted; covers both branches + the peer fan-out with a
+  single slot. Gated the REST clearSessionsHandler's LOCAL-ONLY fallback
+  (s.dp.ClearAllSessions()) → HTTP 429; the HA-delegated REST path is already
+  gated by the gRPC handler it forwards to, so gating only the fallback avoids
+  a double-acquire. No keyed single-session (no-walk) branch exists inside
+  ClearSessions to exempt (DeleteSession is a separate dp op, not a gated RPC).
+  SessionCount/GetStatus/show-buffers NOT touched — that's the separate #5782
+  decision. Updated enumeration comments (diagcmd/limiter.go, server_sessions.go
+  alias, pkg/api/README.md).
+  **File(s)**: pkg/grpcapi/server_sessions.go, pkg/api/sessions.go,
+  pkg/diagcmd/limiter.go, pkg/api/README.md,
+  pkg/grpcapi/server_sessions_clear_bound_5779_test.go,
+  pkg/api/sessions_clear_bound_5779_test.go
+  GREEN: go test ./pkg/grpcapi/... ./pkg/api/... ./pkg/diagcmd/... all ok;
+  gofmt + go vet + go build clean. Fail-on-revert proven: removing both gates →
+  gRPC clear-all/shared-saturation tests RED ("err = <nil>, want
+  ResourceExhausted") + REST clear RED (status 200/cleared, want 429); restored
+  GREEN.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -788,6 +788,17 @@ under the daemon's errgroup. Nothing else imports this package.
     longer issue unbounded full-table scans; over-cap gRPC scans return
     `codes.ResourceExhausted`. A mix of REST + gRPC scrapers cannot collectively
     exceed `diagcmd.MaxConcurrentSessionWalks`.
+    **#5779 extends the SAME shared bound to the session-CLEAR (mutation)
+    path**, which was the remaining uncovered full-table walk: `ClearAllSessions`
+    is a chunked full-table scan+delete (not O(1)), and the gRPC `ClearSessions`
+    filtered path (`clearFilteredSessionsV4/V6`, cursor or rescan) walks the
+    whole table too. The gRPC `ClearSessions` handler now acquires one shared
+    slot covering both its clear-all and filtered branches (over-cap →
+    `codes.ResourceExhausted`); this REST clear endpoint's local-only fallback
+    (`s.dp.ClearAllSessions()`) acquires the same shared limiter (over-cap →
+    HTTP 429). The HA-delegated REST clear path is gated by the gRPC handler it
+    forwards to, so it is not double-charged. A keyed single-session delete (no
+    walk) is a different operation and is not gated.
   - **Bounded Total.** The offset mode's exact `total` previously forced a FULL
     v4+v6 table scan on EVERY 100-row page (O(table) per page, repeated per
     poll) just to count. The walk now caps the count at `sessionCountCap`

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -765,6 +765,20 @@ func (s *Server) clearSessionsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Admission bound (#5779): this local-only fallback drives a full-table
+	// chunked clear-all walk (ClearAllSessions), holding per-bucket BPF-map
+	// locks like the read scans. Gate it through the SAME shared limiter;
+	// over-cap gets HTTP 429. The HA-delegated path above is already gated by
+	// the gRPC ClearSessions handler, so gating ONLY this fallback avoids a
+	// double-acquire on one clear. Release on every exit path via defer.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		writeError(w, http.StatusTooManyRequests,
+			"session clear concurrency limit reached; retry shortly")
+		return
+	}
+	defer release()
+
 	v4, v6, err := s.dp.ClearAllSessions()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/pkg/api/sessions_clear_bound_5779_test.go
+++ b/pkg/api/sessions_clear_bound_5779_test.go
@@ -1,0 +1,58 @@
+// #5779: the REST session-clear endpoint's local-only fallback drives a
+// full-table chunked clear-all walk (ClearAllSessions), the same per-bucket
+// BPF-map lock contention DoS class as the #5433/#5708 read scans, on the
+// mutation path. The fix gates that fallback through the SAME shared
+// sessionWalkLimiter (HTTP 429 on over-cap).
+//
+// FAIL-ON-REVERT: removing the sessionWalkLimiter.Acquire()/429 branch from the
+// clear fallback makes the over-cap request reach ClearAllSessions and return
+// 200 (cleared), flipping the want-429/no-walk assertions red.
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+)
+
+func TestRESTClearSessionsConcurrencyBound(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1) // single slot
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	// clusterSessionFn nil -> clusterSession() nil -> the local-only
+	// ClearAllSessions fallback (the path this gate guards).
+	dp := &clearAllDP{Manager: dataplane.New()}
+	s := &Server{dp: dp}
+
+	// Over-cap: rejected 429, and the clear-all walk must NOT run.
+	rr := httptest.NewRecorder()
+	s.clearSessionsHandler(rr, httptest.NewRequest("POST", "/api/v1/security/sessions/clear", nil))
+	if rr.Code != http.StatusTooManyRequests {
+		release()
+		t.Fatalf("clear status = %d while the limiter is saturated, want 429; body: %s", rr.Code, rr.Body.String())
+	}
+	if dp.cleared {
+		release()
+		t.Fatal("clear-all walk ran despite the limiter being saturated (gate not consulted)")
+	}
+
+	// Free the slot; the next clear must be admitted (200) and run the walk.
+	release()
+	rr2 := httptest.NewRecorder()
+	s.clearSessionsHandler(rr2, httptest.NewRequest("POST", "/api/v1/security/sessions/clear", nil))
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("clear status = %d after slot release, want 200; body: %s", rr2.Code, rr2.Body.String())
+	}
+	if !dp.cleared {
+		t.Fatal("clear-all did not run after admission")
+	}
+}

--- a/pkg/diagcmd/limiter.go
+++ b/pkg/diagcmd/limiter.go
@@ -79,9 +79,11 @@ var DefaultLimiter = NewLimiter(MaxConcurrentDiagnostics)
 
 // MaxConcurrentSessionWalks bounds how many full session-table walks may run
 // at once across EVERY control surface that exposes them — the REST session
-// list/summary/zone-pair endpoints and the gRPC GetSessions/GetSessionSummary/
-// GetZonePairSummary RPCs plus the ShowText "sessions-top:*" scan share the
-// single SessionWalkLimiter below (#5708).
+// list/summary/zone-pair endpoints and the REST session-clear fallback, plus
+// the gRPC GetSessions/GetSessionSummary/GetZonePairSummary RPCs, the ShowText
+// "sessions-top:*" scan, and the gRPC ClearSessions clear (both the clear-all
+// and filtered full-table walks, #5779) — share the single SessionWalkLimiter
+// below (#5708).
 // Each walk holds
 // per-bucket BPF-map locks across the whole v4+v6 conntrack table while
 // contending with the live dataplane session-sync path, so an unbounded scan

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -32,9 +32,10 @@ type sessionEgressKey struct {
 }
 
 // sessionWalkLimiter is the aggregate concurrency bound for the gRPC
-// session-scan paths (GetSessions list, GetSessionSummary,
-// GetZonePairSummary, and the ShowText "sessions-top:*" scan in
-// server_show_flow.go). It aliases the
+// session-table walk paths (GetSessions list, GetSessionSummary,
+// GetZonePairSummary, the ShowText "sessions-top:*" scan in
+// server_show_flow.go, and the ClearSessions clear — both its clear-all and
+// filtered full-table walks, #5779). It aliases the
 // process-wide diagcmd.SessionWalkLimiter — the SAME instance the REST
 // session list/summary/zone-pair handlers use (pkg/api/sessions.go) — so a
 // session scan admitted over gRPC and one admitted over REST draw from one
@@ -1057,6 +1058,25 @@ func (s *Server) ClearSessions(ctx context.Context, req *pb.ClearSessionsRequest
 	if s.dp == nil || !s.dp.IsLoaded() {
 		return nil, status.Error(codes.Unavailable, "dataplane not loaded")
 	}
+
+	// Admission bound (#5779): ClearSessions drives a full v4+v6 conntrack-table
+	// walk on BOTH branches — the clear-all path (ClearAllSessions is a chunked
+	// full-table scan+delete, not O(1)) and the filtered path
+	// (clearFilteredSessionsV4/V6, cursor or rescan) — each holding per-bucket
+	// BPF-map locks that contend with the live session-sync path. This is the
+	// same DoS class as the #5708 read scans, on the mutation path. Gate the
+	// whole handler through the SAME shared limiter as the read scans; acquire
+	// ONCE here so both branches (and the peer fan-out below) draw a single
+	// slot, and a REST clear that delegates to this RPC is not double-charged.
+	// Over-cap clears get codes.ResourceExhausted. There is no keyed
+	// single-session (no-walk) branch in ClearSessions to exempt. Release on
+	// every exit path via defer.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		return nil, status.Error(codes.ResourceExhausted,
+			"session scan concurrency limit reached; retry shortly")
+	}
+	defer release()
 
 	// Check if this is a forwarded request from a peer (prevent recursion).
 	forwarded := false

--- a/pkg/grpcapi/server_sessions_clear_bound_5779_test.go
+++ b/pkg/grpcapi/server_sessions_clear_bound_5779_test.go
@@ -1,0 +1,97 @@
+// #5779: ClearSessions drives full v4+v6 conntrack-table walks on BOTH the
+// clear-all path (ClearAllSessions is a chunked full-table scan+delete) and the
+// filtered path (clearFilteredSessionsV4/V6), the same per-bucket BPF-map lock
+// contention DoS class as the #5708 read scans, on the mutation path. The fix
+// gates the gRPC ClearSessions handler through the SAME shared sessionWalkLimiter.
+//
+// FAIL-ON-REVERT: removing the sessionWalkLimiter.Acquire() gate from
+// ClearSessions makes the over-cap ResourceExhausted assertions here go RED (an
+// over-cap clear proceeds instead of being rejected).
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// clearBoundDP is a minimal grpcRuntime fake for the ClearSessions gate test:
+// IsLoaded true and an atomic ClearAllSessions stub (so an ADMITTED clear-all
+// returns cleanly). The embedded *dataplane.Manager satisfies the rest of the
+// interface; the walk methods are never reached because the over-cap calls fail
+// at Acquire before any dp interaction and the admitted call uses clear-all.
+type clearBoundDP struct {
+	*dataplane.Manager
+}
+
+func (clearBoundDP) IsLoaded() bool                      { return true }
+func (clearBoundDP) ClearAllSessions() (int, int, error) { return 0, 0, nil }
+
+// TestGRPCClearSessionsConcurrencyBound asserts both the clear-all and filtered
+// ClearSessions variants are rejected with ResourceExhausted while the shared
+// session-walk limiter is saturated, and admitted once a slot frees.
+func TestGRPCClearSessionsConcurrencyBound(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	s := &Server{dp: clearBoundDP{Manager: dataplane.New()}}
+
+	// clear-all variant (no filters -> ClearAllSessions chunked full-table walk).
+	if _, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{}); !isResourceExhausted(err) {
+		release()
+		t.Fatalf("ClearSessions (clear-all) with a full session-walk limiter: err = %v, want codes.ResourceExhausted", err)
+	}
+
+	// filtered variant (Protocol filter -> clearFilteredSessions* full-table walk).
+	if _, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{Protocol: "tcp"}); !isResourceExhausted(err) {
+		release()
+		t.Fatalf("ClearSessions (filtered) with a full session-walk limiter: err = %v, want codes.ResourceExhausted", err)
+	}
+
+	// Free the slot; the next clear must be admitted.
+	release()
+	if _, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{}); isResourceExhausted(err) {
+		t.Fatalf("ClearSessions after slot release still ResourceExhausted: %v", err)
+	}
+}
+
+// TestGRPCClearSessionsDrawsFromSharedSessionWalkLimiter proves the ClearSessions
+// gate uses the process-wide diagcmd.SessionWalkLimiter (the SAME instance the
+// read scans and REST use) — saturating the shared singleton directly rejects a
+// clear.
+func TestGRPCClearSessionsDrawsFromSharedSessionWalkLimiter(t *testing.T) {
+	if sessionWalkLimiter != diagcmd.SessionWalkLimiter {
+		t.Fatal("gRPC sessionWalkLimiter is not the shared diagcmd.SessionWalkLimiter instance")
+	}
+
+	var releases []func()
+	t.Cleanup(func() {
+		for _, r := range releases {
+			r()
+		}
+	})
+	for {
+		rel, err := diagcmd.SessionWalkLimiter.Acquire()
+		if err != nil {
+			break
+		}
+		releases = append(releases, rel)
+	}
+	if len(releases) == 0 {
+		t.Fatal("could not acquire any slot on the shared limiter")
+	}
+
+	s := &Server{dp: clearBoundDP{Manager: dataplane.New()}}
+	if _, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{}); !isResourceExhausted(err) {
+		t.Fatalf("ClearSessions with the shared limiter saturated: err = %v, want codes.ResourceExhausted", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #5779 — the ClearSessions follow-up to #5708/#5778. `ClearSessions` drives
full v4+v6 conntrack-table walks on **both** the gRPC and REST surfaces with no
shared admission bound — the same per-bucket-BPF-map-lock contention DoS class
as #5708 (M35), but on the session-CLEAR (mutation) path. #5708 hoisted the
session-walk limiter to a process-wide shared singleton and gated the
LIST/SUMMARY read scans, leaving ClearSessions as the remaining uncovered
high-cost table walk.

**Both ClearSessions branches walk the whole table:**
- clear-all: `ClearAllSessions` is a chunked full-table scan+delete
  (`ClearAllSessionsChunked`), **not** an O(1) atomic op.
- filtered: `clearFilteredSessionsV4/V6` iterate the whole table (cursor
  `IterateSessionsFrom` in production, rescan `IterateSessions` fallback).

## Fix

Gate both surfaces through the SAME shared `diagcmd.SessionWalkLimiter`:
- The **gRPC `ClearSessions`** handler acquires one slot at entry (after the
  dataplane-loaded check), covering both the clear-all and filtered branches
  **and** the peer fan-out with a single acquire; over-cap → `codes.ResourceExhausted`.
  There is no keyed single-session (no-walk) branch in ClearSessions to exempt.
- The **REST clear endpoint's local-only fallback** (`s.dp.ClearAllSessions()`)
  acquires the same shared limiter; over-cap → HTTP 429. The HA-delegated REST
  path forwards to the gRPC handler (already gated), so gating **only** the
  fallback avoids double-charging one clear.

`SessionCount` / `GetStatus` / `show-buffers` count-only iteration is a
**separate decision tracked in #5782** and is intentionally untouched here.

## Validation

Fail-on-revert bound tests on both surfaces, run unprivileged. The gRPC test
asserts the clear-all and filtered variants return `ResourceExhausted` while the
limiter is saturated (and via saturating the shared singleton directly), then
admit after release. The REST test asserts the clear fallback returns 429 and
does **not** run `ClearAllSessions` while saturated, then admits (200, cleared)
after release.

**RED-on-revert** (both gates removed):

```
--- FAIL: TestGRPCClearSessionsConcurrencyBound
    server_sessions_clear_bound_5779_test.go:51: ClearSessions (clear-all) with a full session-walk limiter: err = <nil>, want codes.ResourceExhausted
--- FAIL: TestGRPCClearSessionsDrawsFromSharedSessionWalkLimiter
    server_sessions_clear_bound_5779_test.go:95: ClearSessions with the shared limiter saturated: err = <nil>, want codes.ResourceExhausted
--- FAIL: TestRESTClearSessionsConcurrencyBound
    sessions_clear_bound_5779_test.go:41: clear status = 200 while the limiter is saturated, want 429; body: {"success":true,"data":{"ipv4_cleared":1,...}}
```

Restored GREEN. `go test ./pkg/grpcapi/... ./pkg/api/... ./pkg/diagcmd/...` all
pass; `gofmt` / `go vet` / `go build ./...` clean. Doc enumerations updated
(diagcmd/limiter.go, the gRPC limiter alias, pkg/api/README.md).

Provenance: surfaced during the hostile review of PR #5778 (#5708); filed as a
follow-up per one-issue-per-finding discipline.

Closes #5779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj6WhNAWdp6vTuvREojiF8