### PR TITLE
daemon: clamp archival transfer-interval before NewTicker (#5784)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47935,3 +47935,27 @@ top.
   strict commit to reject an unsupported `mac` stanza in the SECOND interfaces
   root", "lenient compile must warn about the second-root unsupported stanza";
   the single-root no-regression case stayed GREEN; restored GREEN.
+
+- **Timestamp**: 2026-07-13
+  **Action**: Fix #5784 — `system archival transfer-interval` (config-minutes)
+  was multiplied by time.Minute with no product-side overflow clamp before
+  time.NewTicker (daemon_archive_timer.go runArchiveTimer). Same class as the
+  just-merged #5723/#5705 (config-interval × time.Unit overflows int64-ns → a
+  non-positive Duration → NewTicker panic → xpfd crash), minutes-scoped. Safe
+  at commit (schema ValidateInteger 1..2880); the residual is the lenient
+  Store.Load / peer-sync ingress, whose `interval <= 0` guard inspects the
+  minutes integer NOT the × time.Minute product. Fix: added
+  config.MaxDurationMinutes (= MaxInt64 / time.Minute, mirroring
+  MaxDurationSeconds) and clampArchiveIntervalMinutes (mirroring
+  clampRPMIntervalSeconds), applied before time.NewTicker. Defense-in-depth;
+  schema bound unchanged. Go-only, minimal.
+  **File(s)**: pkg/config/schema_validators.go,
+  pkg/daemon/daemon_archive_timer.go,
+  pkg/daemon/archive_interval_clamp_5784_test.go (new),
+  pkg/daemon/README.md
+  GREEN: `go test ./pkg/daemon/...` + `./pkg/config/...` pass; gofmt clean on
+  touched files; go vet clean; `go build ./...` clean. Fail-on-revert proven:
+  neutering clampArchiveIntervalMinutes to the raw `time.Duration(min) *
+  time.Minute` product turns the pathological cases RED — the products overflow
+  non-positive (e.g. MaxInt64 → -1m0s, 200000000 → -1790762h...) and
+  time.NewTicker panics "non-positive interval for NewTicker"; restored GREEN.

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -185,7 +185,7 @@ const MaxDurationSeconds = int64(math.MaxInt64) / int64(time.Second)
 
 // MaxDurationMinutes is the minutes analogue of MaxDurationSeconds: the
 // largest minute count that survives `time.Duration(n) * time.Minute`
-// without int64 overflow (math.MaxInt64 / 6e10 = 153722867280). Above this,
+// without int64 overflow (math.MaxInt64 / 6e10 = 153722867). Above this,
 // a configured minute knob converts to a non-positive Duration — e.g. the
 // `system archival transfer-interval` timer's time.NewTicker panics on a
 // non-positive interval (#5784, the minutes straggler of the #5705/#5723

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -183,6 +183,17 @@ const MaxDurationMillis = int64(math.MaxInt64) / int64(time.Millisecond)
 // invert the damping behaviour).
 const MaxDurationSeconds = int64(math.MaxInt64) / int64(time.Second)
 
+// MaxDurationMinutes is the minutes analogue of MaxDurationSeconds: the
+// largest minute count that survives `time.Duration(n) * time.Minute`
+// without int64 overflow (math.MaxInt64 / 6e10 = 153722867280). Above this,
+// a configured minute knob converts to a non-positive Duration — e.g. the
+// `system archival transfer-interval` timer's time.NewTicker panics on a
+// non-positive interval (#5784, the minutes straggler of the #5705/#5723
+// config-interval × time.Unit overflow class). Used to clamp minute-
+// denominated runtime intervals whose commit-time schema bound the lenient
+// Store.Load / peer-sync ingress can bypass.
+const MaxDurationMinutes = int64(math.MaxInt64) / int64(time.Minute)
+
 // maxWireU16 / maxWireU32 are the inclusive ceilings for typed leaves
 // whose value lands in a Rust u16 / u32 wire field. #1979 Layer B uses
 // these so the commit-time range gate agrees EXACTLY with the build-time

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -91,6 +91,19 @@ tracker issue #4407 carries the remaining increments.
   `ipsecSANudgeCh` and increment 2's `lastStandbyNeighborRefresh`) — it is the
   one-shot transfer-on-commit upload seam used by `archiveConfig` in
   `daemon_flow.go`, a different mechanism from the periodic timer grouped here.
+  - **Interval overflow bound (#5784).** `transfer-interval` is an
+    operator-settable value in MINUTES, bounded to `[1, 2880]` at commit
+    (`schema_system.go`), so a normal commit cannot overflow
+    `time.Duration(min)*time.Minute` into a non-positive Duration and panic
+    `time.NewTicker` in `runArchiveTimer` (an xpfd crash). The `interval <= 0`
+    guard in `reconcileArchiveTimer` inspects the minutes integer, not the
+    `× time.Minute` product, so a pathological value from the lenient
+    `Store.Load` / peer-sync ingress (which bypasses the strict schema bound)
+    would still reach `NewTicker`. `clampArchiveIntervalMinutes`
+    (`daemon_archive_timer.go`) re-applies a `[1, config.MaxDurationMinutes]`
+    clamp at runtime as defense-in-depth — the minutes-scoped sibling of the
+    #5723 `clampRPMIntervalSeconds` / #5705 keepalive clamps, closing the
+    config-interval × time.Unit overflow class for the minutes straggler.
 - **Increment 4 — host-inbound fail-open / ambiguity previous-apply sets
   (#3698 / #3710 / #3718):** the three flat `map[string]bool` fields
   (`hostInboundAddresslessZones`, `hostInboundAddresslessIfaces`,

--- a/pkg/daemon/archive_interval_clamp_5784_test.go
+++ b/pkg/daemon/archive_interval_clamp_5784_test.go
@@ -1,0 +1,84 @@
+package daemon
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestClampArchiveIntervalMinutes_5784 pins the product-overflow clamp on the
+// `system archival transfer-interval` NewTicker path. transfer-interval is a
+// config-MINUTES value multiplied by time.Minute before time.NewTicker; a
+// value above config.MaxDurationMinutes overflows int64 nanoseconds to a
+// non-positive time.Duration, which time.NewTicker PANICS on (crashing xpfd).
+// The schema bounds the leaf to 1..2880 at commit, but the lenient
+// Store.Load / peer-sync ingress can carry a pathological value, so the clamp
+// is defense-in-depth mirroring clampRPMIntervalSeconds (#5723).
+//
+// FAIL-ON-REVERT: reverting clampArchiveIntervalMinutes to the raw
+// `time.Duration(min) * time.Minute` product makes the pathological cases
+// return a NON-POSITIVE Duration, so the `> 0` assertions go RED.
+func TestClampArchiveIntervalMinutes_5784(t *testing.T) {
+	ceiling := time.Duration(config.MaxDurationMinutes) * time.Minute
+
+	// Valid schema-range intervals pass through unchanged.
+	valid := map[int]time.Duration{
+		1:    1 * time.Minute,
+		60:   60 * time.Minute,
+		2880: 2880 * time.Minute, // the schema max
+	}
+	for in, want := range valid {
+		if got := clampArchiveIntervalMinutes(in); got != want {
+			t.Errorf("clampArchiveIntervalMinutes(%d) = %v, want %v (valid interval must pass through unchanged)", in, got, want)
+		}
+	}
+
+	// Non-positive / sub-minimum inputs default to a sane positive minimum.
+	for _, in := range []int{0, -1, -5} {
+		if got := clampArchiveIntervalMinutes(in); got != time.Minute {
+			t.Errorf("clampArchiveIntervalMinutes(%d) = %v, want %v (sub-minimum default)", in, got, time.Minute)
+		}
+	}
+
+	// Pathological lenient-ingress values: the raw `× time.Minute` product
+	// overflows int64-ns to a non-positive Duration. The clamp must instead
+	// return a POSITIVE Duration bounded by the ceiling.
+	pathological := []int{
+		int(config.MaxDurationMinutes) + 1, // just over the overflow threshold
+		200_000_000,                        // ~1.5e8+, the issue's crafted magnitude
+		math.MaxInt64,                      // the extreme
+	}
+	for _, in := range pathological {
+		// Demonstrate the pre-fix hazard explicitly: the raw product is
+		// non-positive for these inputs (this is exactly what reached NewTicker).
+		if raw := time.Duration(in) * time.Minute; raw > 0 {
+			t.Fatalf("test precondition: expected raw product for %d to overflow non-positive, got %v", in, raw)
+		}
+		got := clampArchiveIntervalMinutes(in)
+		if got <= 0 {
+			t.Errorf("clampArchiveIntervalMinutes(%d) = %v; MUST be positive (NewTicker panics on a non-positive interval)", in, got)
+		}
+		if got > ceiling {
+			t.Errorf("clampArchiveIntervalMinutes(%d) = %v; must be bounded by the ceiling %v", in, got, ceiling)
+		}
+	}
+
+	// The ceiling itself maps to a positive Duration (not the overflow edge).
+	if got := clampArchiveIntervalMinutes(int(config.MaxDurationMinutes)); got != ceiling || got <= 0 {
+		t.Errorf("clampArchiveIntervalMinutes(MaxDurationMinutes) = %v, want %v (>0)", got, ceiling)
+	}
+
+	// End-to-end: a clamped pathological interval constructs a real
+	// time.Ticker without panicking (the crash this fix prevents).
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("time.NewTicker panicked on the clamped pathological interval: %v", r)
+			}
+		}()
+		tk := time.NewTicker(clampArchiveIntervalMinutes(math.MaxInt64))
+		tk.Stop()
+	}()
+}

--- a/pkg/daemon/daemon_archive_timer.go
+++ b/pkg/daemon/daemon_archive_timer.go
@@ -42,6 +42,30 @@ func realArchiveTicker(d time.Duration) (<-chan time.Time, func()) {
 	return t.C, t.Stop
 }
 
+// clampArchiveIntervalMinutes converts a config-derived `system archival
+// transfer-interval` (minutes) into a POSITIVE, overflow-safe time.Duration
+// for time.NewTicker. transfer-interval is bounded to 1..2880 at commit by the
+// schema (ValidateInteger), so a normal commit never reaches the panic — but a
+// crafted on-disk Store.Load / peer-sync config bypasses that strict bound
+// (the #5723 lenient ingress). The raw-int `interval <= 0` guard in
+// reconcileArchiveTimer inspects the MINUTES integer, not the
+// `× time.Minute` product, so a value above config.MaxDurationMinutes
+// (~1.5e8 min) overflows int64 nanoseconds to a non-positive Duration and
+// time.NewTicker PANICS, crashing xpfd. Clamping the minutes to
+// [1, MaxDurationMinutes] before the multiply keeps the product positive and
+// bounded — defense-in-depth mirroring clampRPMIntervalSeconds (#5723) /
+// clampKeepaliveIntervalSec (#5705), minutes-scoped (#5784). This is the
+// straggler of the #5705/#5723 config-interval × time.Unit overflow class.
+func clampArchiveIntervalMinutes(min int) time.Duration {
+	if min < 1 {
+		return time.Minute
+	}
+	if int64(min) > config.MaxDurationMinutes {
+		return time.Duration(config.MaxDurationMinutes) * time.Minute
+	}
+	return time.Duration(min) * time.Minute
+}
+
 // archiveTimerKey collapses (interval, sites) into a stable string so
 // reconcileArchiveTimer can hash-gate: an unrelated commit that leaves the
 // periodic-archival config untouched must NOT bounce a healthy timer. An empty
@@ -116,7 +140,7 @@ func (d *Daemon) runArchiveTimer(interval int, sites []string, stop <-chan struc
 	if newTicker == nil {
 		newTicker = realArchiveTicker
 	}
-	tickC, tickStop := newTicker(time.Duration(interval) * time.Minute)
+	tickC, tickStop := newTicker(clampArchiveIntervalMinutes(interval))
 	defer tickStop()
 
 	// Secondary shutdown guard: the daemon-stop context (nil at early boot, in


### PR DESCRIPTION
Closes #5784

## Defect

`system archival … transfer-interval` (`daemon_archive_timer.go` `runArchiveTimer` → `realArchiveTicker` → `time.NewTicker`) is a config-derived interval in **minutes** multiplied by `time.Minute` with **no product-side overflow clamp**. This is the same bug class as the just-merged #5723/#5705 — a config interval × a `time.Unit` overflows `int64` nanoseconds into a **non-positive** `time.Duration`, which `time.NewTicker` **panics** on (crashing xpfd) — but minutes-scoped rather than seconds.

At **commit** it is safe: the schema bounds `transfer-interval` to `ValidateInteger(1, 2880)`, far below the overflow threshold (~1.5e8 minutes). The residual is the **lenient ingress only**: a crafted on-disk `Store.Load` / peer-sync config carrying `transfer-interval` above ~1.5e8 minutes bypasses the strict `SchemaValidate` (the same lenient-load path #5723's runtime clamp defends), and the raw-int `interval <= 0` guard in `reconcileArchiveTimer` inspects the **minutes integer**, not the `× time.Minute` product — so the wrapped-negative Duration reaches `NewTicker` and panics.

## Fix (mirrors #5723, minutes-scoped, Go-only)

- Add `config.MaxDurationMinutes = math.MaxInt64 / int64(time.Minute)` — the minutes analogue of the existing `MaxDurationMillis` / `MaxDurationSeconds` (`schema_validators.go`).
- Add `clampArchiveIntervalMinutes` (`daemon_archive_timer.go`), mirroring `clampRPMIntervalSeconds`: a sub-minimum value → one minute, a value above `MaxDurationMinutes` → `MaxDurationMinutes × time.Minute`, otherwise pass through. Applied to the interval **before** `time.NewTicker`.

The commit-time schema bound (1..2880) is **unchanged**; the clamp is defense-in-depth for the strict-validate-bypassing lenient-Load ingress, closing the config-interval × `time.Unit` overflow class for the minutes straggler. `pkg/daemon/README.md` updated with a parallel note to #5723's `pkg/rpm/README.md`.

## Tests — `pkg/daemon/archive_interval_clamp_5784_test.go`

Feeds pathological minutes (`MaxDurationMinutes+1`, `200_000_000`, `math.MaxInt64`) and asserts the clamped Duration is **positive** and **bounded by the ceiling** (with a precondition proving the raw `× time.Minute` product overflows non-positive), that valid intervals (1, 60, 2880) pass through unchanged, that sub-minimum inputs default to one minute, and that `time.NewTicker` on the clamped pathological value does **not** panic.

### Fail-on-revert (RED proof)

Neutering `clampArchiveIntervalMinutes` to the raw `time.Duration(min) * time.Minute` product:

```
--- FAIL: TestClampArchiveIntervalMinutes_5784
    clampArchiveIntervalMinutes(0) = 0s, want 1m0s (sub-minimum default)
    clampArchiveIntervalMinutes(-1) = -1m0s, want 1m0s (sub-minimum default)
    clampArchiveIntervalMinutes(153722868) = -2562047h46m33.709551616s; MUST be positive (NewTicker panics on a non-positive interval)
    clampArchiveIntervalMinutes(200000000) = -1790762h14m33.709551616s; MUST be positive (NewTicker panics on a non-positive interval)
    clampArchiveIntervalMinutes(9223372036854775807) = -1m0s; MUST be positive (NewTicker panics on a non-positive interval)
    time.NewTicker panicked on the clamped pathological interval: non-positive interval for NewTicker
```

Restored → GREEN.

## Gates

- `go test ./pkg/daemon/...` and `./pkg/config/...` pass; `go vet ./pkg/daemon/ ./pkg/config/` clean; `gofmt -l` clean on touched files; `go build ./...` clean.

## Materiality / Provenance

Low — requires a hand-crafted Load/peer-sync config with `transfer-interval` on the order of 10^8 minutes (~285 years); a normal operator cannot trigger it (commit rejects >2880). Surfaced during the hostile review of PR #5781 (#5723) — the reviewer's repo-wide `NewTicker` sweep found `system archival transfer-interval` as the one remaining config-interval `NewTicker` whose product-overflow was unclamped, minutes-scoped and thus outside #5723's declared config-seconds scope. Verified against origin/master `bbff2d375`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUMttPTPdBuENAmt9WaFJt