### PR TITLE
cli: complete predefined application sets (#5763)

### DIFF
--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -396,6 +396,24 @@ func completePipeFilter(text string) (candidates []completionCandidate, handled 
 	return candidates, true
 }
 
+func appendPredefinedApplicationSetCompletions(out []config.SchemaCompletion) []config.SchemaCompletion {
+	emitted := make(map[string]struct{}, len(out)+len(config.PredefinedApplicationSets))
+	for _, candidate := range out {
+		emitted[candidate.Name] = struct{}{}
+	}
+	for name := range config.PredefinedApplicationSets {
+		if _, exists := emitted[name]; exists {
+			continue
+		}
+		out = append(out, config.SchemaCompletion{
+			Name: name,
+			Desc: "predefined application-set",
+		})
+		emitted[name] = struct{}{}
+	}
+	return out
+}
+
 // #1044c Phase 1: valueProvider relocated from cli.go (no behavior change).
 func (c *CLI) valueProvider(hint config.ValueHint, path []string) []config.SchemaCompletion {
 	cfg := c.store.ActiveConfig()
@@ -438,13 +456,13 @@ func (c *CLI) valueProvider(hint config.ValueHint, path []string) []config.Schem
 		for name := range config.PredefinedApplications {
 			out = append(out, config.SchemaCompletion{Name: name, Desc: "predefined"})
 		}
-		return out
+		return appendPredefinedApplicationSetCompletions(out)
 	case config.ValueHintAppSetName:
 		var out []config.SchemaCompletion
 		for _, as := range cfg.Applications.ApplicationSets {
 			out = append(out, config.SchemaCompletion{Name: as.Name, Desc: "application-set"})
 		}
-		return out
+		return appendPredefinedApplicationSetCompletions(out)
 	case config.ValueHintPoolName:
 		var out []config.SchemaCompletion
 		for name := range cfg.Security.NAT.SourcePools {
@@ -512,7 +530,7 @@ func (c *CLI) valueProvider(hint config.ValueHint, path []string) []config.Schem
 		for name := range config.PredefinedApplications {
 			out = append(out, config.SchemaCompletion{Name: name, Desc: "predefined"})
 		}
-		return out
+		return appendPredefinedApplicationSetCompletions(out)
 	case config.ValueHintPolicyName:
 		// Extract zone pair from path: ["security","policies","from-zone","X","to-zone","Y","policy"]
 		// or global: ["security","policies","global","policy"]

--- a/pkg/cli/completion_predefined_app_sets_5763_test.go
+++ b/pkg/cli/completion_predefined_app_sets_5763_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+var predefinedApplicationSetNames5763 = []string{
+	"junos-ms-rpc",
+	"junos-sun-rpc",
+	"junos-cifs",
+	"junos-routing-inbound",
+	"junos-sip",
+}
+
+type completionPath5763 struct {
+	name        string
+	words       []string
+	hint        config.ValueHint
+	placeholder string
+}
+
+func matchingCompletionDescriptions5763(candidates []completionCandidate, name string) []string {
+	var descriptions []string
+	for _, candidate := range candidates {
+		if candidate.name == name {
+			descriptions = append(descriptions, candidate.desc)
+		}
+	}
+	return descriptions
+}
+
+func requireCompletionCount5763(t *testing.T, candidates []completionCandidate, name string, want int) []string {
+	t.Helper()
+	descriptions := matchingCompletionDescriptions5763(candidates, name)
+	if len(descriptions) != want {
+		t.Errorf(
+			"completion %q occurrence count = %d, want %d; matching descriptions = %q; all candidates = %#v",
+			name,
+			len(descriptions),
+			want,
+			descriptions,
+			candidates,
+		)
+	}
+	return descriptions
+}
+
+func requireCompletion5763(t *testing.T, candidates []completionCandidate, name, wantDesc string) {
+	t.Helper()
+	descriptions := requireCompletionCount5763(t, candidates, name, 1)
+	if len(descriptions) == 1 && descriptions[0] != wantDesc {
+		t.Errorf("completion %q description = %q, want %q", name, descriptions[0], wantDesc)
+	}
+}
+
+func TestCompleteConfig_PredefinedApplicationSets_5763(t *testing.T) {
+	paths := []completionPath5763{
+		{
+			name:        "zone-pair-policy",
+			words:       []string{"set", "security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "match", "application"},
+			hint:        config.ValueHintPolicyApp,
+			placeholder: "<application>",
+		},
+		{
+			name:        "global-policy",
+			words:       []string{"set", "security", "policies", "global", "policy", "p", "match", "application"},
+			hint:        config.ValueHintPolicyApp,
+			placeholder: "<application>",
+		},
+		{
+			name:        "application-name",
+			words:       []string{"set", "applications", "application"},
+			hint:        config.ValueHintAppName,
+			placeholder: "<name>",
+		},
+		{
+			name:        "application-set-name",
+			words:       []string{"set", "applications", "application-set"},
+			hint:        config.ValueHintAppSetName,
+			placeholder: "<name>",
+		},
+	}
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if active := store.ActiveConfig(); active != nil {
+		t.Fatalf("ActiveConfig() after construction = %#v, want nil", active)
+	}
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if active := store.ActiveConfig(); active != nil {
+		t.Fatalf("ActiveConfig() after EnterConfigure() = %#v, want nil", active)
+	}
+	c := &CLI{store: store}
+
+	for _, path := range paths {
+		path := path
+		t.Run("pre-commit/"+path.name, func(t *testing.T) {
+			candidates := c.completeConfigWithDesc(path.words, "")
+			if len(candidates) != 1 {
+				t.Errorf("pre-commit candidates = %#v, want only %q", candidates, path.placeholder)
+			}
+			requireCompletionCount5763(t, candidates, path.placeholder, 1)
+			for _, name := range predefinedApplicationSetNames5763 {
+				requireCompletionCount5763(t, candidates, name, 0)
+			}
+		})
+	}
+
+	committed, err := store.Commit()
+	if err != nil {
+		t.Fatalf("first Commit() error = %v", err)
+	}
+	if committed == nil {
+		t.Fatal("first Commit() returned nil config")
+	}
+	if active := store.ActiveConfig(); active == nil {
+		t.Fatal("ActiveConfig() remained nil after first Commit()")
+	}
+
+	for _, path := range paths {
+		path := path
+		t.Run("default-catalog/"+path.name, func(t *testing.T) {
+			candidates := c.completeConfigWithDesc(path.words, "")
+			for _, name := range predefinedApplicationSetNames5763 {
+				requireCompletion5763(t, candidates, name, "predefined application-set")
+			}
+			switch path.hint {
+			case config.ValueHintPolicyApp:
+				requireCompletion5763(t, candidates, "any", "Any application")
+				requireCompletion5763(t, candidates, "junos-http", "predefined")
+			case config.ValueHintAppName:
+				requireCompletion5763(t, candidates, "junos-http", "predefined")
+			case config.ValueHintAppSetName:
+				requireCompletionCount5763(t, candidates, "any", 0)
+				requireCompletionCount5763(t, candidates, "junos-http", 0)
+			default:
+				t.Fatalf("unexpected value hint %v", path.hint)
+			}
+		})
+	}
+
+	for _, command := range []string{
+		"applications application junos-ms-rpc protocol tcp",
+		"applications application junos-ms-rpc destination-port 9999",
+		"applications application junos-ms-rpc description \"configured application shadow\"",
+		"applications application-set junos-sip application junos-http",
+	} {
+		if err := store.SetFromInput(command); err != nil {
+			t.Fatalf("SetFromInput(%q) error = %v", command, err)
+		}
+	}
+
+	shadowConfig, err := store.Commit()
+	if err != nil {
+		t.Fatalf("shadow Commit() error = %v", err)
+	}
+	if shadowConfig == nil {
+		t.Fatal("shadow Commit() returned nil config")
+	}
+	if active := store.ActiveConfig(); active == nil {
+		t.Fatal("ActiveConfig() remained nil after shadow Commit()")
+	}
+	shadowApp := shadowConfig.Applications.Applications["junos-ms-rpc"]
+	if shadowApp == nil {
+		t.Fatal("compiled Applications[\"junos-ms-rpc\"] is nil")
+	}
+	if shadowApp.Description != "configured application shadow" {
+		t.Fatalf("compiled junos-ms-rpc description = %q, want %q", shadowApp.Description, "configured application shadow")
+	}
+	if shadowSet := shadowConfig.Applications.ApplicationSets["junos-sip"]; shadowSet == nil {
+		t.Fatal("compiled ApplicationSets[\"junos-sip\"] is nil")
+	}
+
+	for _, path := range paths {
+		path := path
+		t.Run("configured-shadows/"+path.name, func(t *testing.T) {
+			candidates := c.completeConfigWithDesc(path.words, "")
+			if path.hint == config.ValueHintAppSetName {
+				requireCompletion5763(t, candidates, "junos-ms-rpc", "predefined application-set")
+			} else {
+				requireCompletion5763(t, candidates, "junos-ms-rpc", "configured application shadow")
+			}
+			requireCompletion5763(t, candidates, "junos-sip", "application-set")
+			for _, name := range predefinedApplicationSetNames5763 {
+				if name == "junos-ms-rpc" || name == "junos-sip" {
+					continue
+				}
+				requireCompletion5763(t, candidates, name, "predefined application-set")
+			}
+		})
+	}
+}

--- a/pkg/grpcapi/completion_predefined_app_sets_5763_test.go
+++ b/pkg/grpcapi/completion_predefined_app_sets_5763_test.go
@@ -1,0 +1,196 @@
+package grpcapi
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+var predefinedApplicationSetNames5763 = []string{
+	"junos-ms-rpc",
+	"junos-sun-rpc",
+	"junos-cifs",
+	"junos-routing-inbound",
+	"junos-sip",
+}
+
+type completionPath5763 struct {
+	name        string
+	words       []string
+	hint        config.ValueHint
+	placeholder string
+}
+
+func matchingCompletionDescriptions5763(pairs []completionPair, name string) []string {
+	var descriptions []string
+	for _, pair := range pairs {
+		if pair.name == name {
+			descriptions = append(descriptions, pair.desc)
+		}
+	}
+	return descriptions
+}
+
+func requireCompletionCount5763(t *testing.T, pairs []completionPair, name string, want int) []string {
+	t.Helper()
+	descriptions := matchingCompletionDescriptions5763(pairs, name)
+	if len(descriptions) != want {
+		t.Errorf(
+			"completion %q occurrence count = %d, want %d; matching descriptions = %q; all pairs = %#v",
+			name,
+			len(descriptions),
+			want,
+			descriptions,
+			pairs,
+		)
+	}
+	return descriptions
+}
+
+func requireCompletion5763(t *testing.T, pairs []completionPair, name, wantDesc string) {
+	t.Helper()
+	descriptions := requireCompletionCount5763(t, pairs, name, 1)
+	if len(descriptions) == 1 && descriptions[0] != wantDesc {
+		t.Errorf("completion %q description = %q, want %q", name, descriptions[0], wantDesc)
+	}
+}
+
+func TestCompleteConfigPairs_PredefinedApplicationSets_5763(t *testing.T) {
+	paths := []completionPath5763{
+		{
+			name:        "zone-pair-policy",
+			words:       []string{"set", "security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p", "match", "application"},
+			hint:        config.ValueHintPolicyApp,
+			placeholder: "<application>",
+		},
+		{
+			name:        "global-policy",
+			words:       []string{"set", "security", "policies", "global", "policy", "p", "match", "application"},
+			hint:        config.ValueHintPolicyApp,
+			placeholder: "<application>",
+		},
+		{
+			name:        "application-name",
+			words:       []string{"set", "applications", "application"},
+			hint:        config.ValueHintAppName,
+			placeholder: "<name>",
+		},
+		{
+			name:        "application-set-name",
+			words:       []string{"set", "applications", "application-set"},
+			hint:        config.ValueHintAppSetName,
+			placeholder: "<name>",
+		},
+	}
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if active := store.ActiveConfig(); active != nil {
+		t.Fatalf("ActiveConfig() after construction = %#v, want nil", active)
+	}
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if active := store.ActiveConfig(); active != nil {
+		t.Fatalf("ActiveConfig() after EnterConfigure() = %#v, want nil", active)
+	}
+	s := &Server{store: store}
+
+	for _, path := range paths {
+		path := path
+		t.Run("pre-commit/"+path.name, func(t *testing.T) {
+			pairs := s.completeConfigPairs(path.words, "")
+			if len(pairs) != 1 {
+				t.Errorf("pre-commit pairs = %#v, want only %q", pairs, path.placeholder)
+			}
+			requireCompletionCount5763(t, pairs, path.placeholder, 1)
+			for _, name := range predefinedApplicationSetNames5763 {
+				requireCompletionCount5763(t, pairs, name, 0)
+			}
+		})
+	}
+
+	committed, err := store.Commit()
+	if err != nil {
+		t.Fatalf("first Commit() error = %v", err)
+	}
+	if committed == nil {
+		t.Fatal("first Commit() returned nil config")
+	}
+	if active := store.ActiveConfig(); active == nil {
+		t.Fatal("ActiveConfig() remained nil after first Commit()")
+	}
+
+	for _, path := range paths {
+		path := path
+		t.Run("default-catalog/"+path.name, func(t *testing.T) {
+			pairs := s.completeConfigPairs(path.words, "")
+			for _, name := range predefinedApplicationSetNames5763 {
+				requireCompletion5763(t, pairs, name, "predefined application-set")
+			}
+			switch path.hint {
+			case config.ValueHintPolicyApp:
+				requireCompletion5763(t, pairs, "any", "Any application")
+				requireCompletion5763(t, pairs, "junos-http", "predefined")
+			case config.ValueHintAppName:
+				requireCompletion5763(t, pairs, "junos-http", "predefined")
+			case config.ValueHintAppSetName:
+				requireCompletionCount5763(t, pairs, "any", 0)
+				requireCompletionCount5763(t, pairs, "junos-http", 0)
+			default:
+				t.Fatalf("unexpected value hint %v", path.hint)
+			}
+		})
+	}
+
+	for _, command := range []string{
+		"applications application junos-ms-rpc protocol tcp",
+		"applications application junos-ms-rpc destination-port 9999",
+		"applications application junos-ms-rpc description \"configured application shadow\"",
+		"applications application-set junos-sip application junos-http",
+	} {
+		if err := store.SetFromInput(command); err != nil {
+			t.Fatalf("SetFromInput(%q) error = %v", command, err)
+		}
+	}
+
+	shadowConfig, err := store.Commit()
+	if err != nil {
+		t.Fatalf("shadow Commit() error = %v", err)
+	}
+	if shadowConfig == nil {
+		t.Fatal("shadow Commit() returned nil config")
+	}
+	if active := store.ActiveConfig(); active == nil {
+		t.Fatal("ActiveConfig() remained nil after shadow Commit()")
+	}
+	shadowApp := shadowConfig.Applications.Applications["junos-ms-rpc"]
+	if shadowApp == nil {
+		t.Fatal("compiled Applications[\"junos-ms-rpc\"] is nil")
+	}
+	if shadowApp.Description != "configured application shadow" {
+		t.Fatalf("compiled junos-ms-rpc description = %q, want %q", shadowApp.Description, "configured application shadow")
+	}
+	if shadowSet := shadowConfig.Applications.ApplicationSets["junos-sip"]; shadowSet == nil {
+		t.Fatal("compiled ApplicationSets[\"junos-sip\"] is nil")
+	}
+
+	for _, path := range paths {
+		path := path
+		t.Run("configured-shadows/"+path.name, func(t *testing.T) {
+			pairs := s.completeConfigPairs(path.words, "")
+			if path.hint == config.ValueHintAppSetName {
+				requireCompletion5763(t, pairs, "junos-ms-rpc", "predefined application-set")
+			} else {
+				requireCompletion5763(t, pairs, "junos-ms-rpc", "configured application shadow")
+			}
+			requireCompletion5763(t, pairs, "junos-sip", "application-set")
+			for _, name := range predefinedApplicationSetNames5763 {
+				if name == "junos-ms-rpc" || name == "junos-sip" {
+					continue
+				}
+				requireCompletion5763(t, pairs, name, "predefined application-set")
+			}
+		})
+	}
+}

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -664,6 +664,24 @@ func (s *Server) completeConfigPairs(words []string, partial string) []completio
 	}
 }
 
+func appendPredefinedApplicationSetCompletions(out []config.SchemaCompletion) []config.SchemaCompletion {
+	emitted := make(map[string]struct{}, len(out)+len(config.PredefinedApplicationSets))
+	for _, candidate := range out {
+		emitted[candidate.Name] = struct{}{}
+	}
+	for name := range config.PredefinedApplicationSets {
+		if _, exists := emitted[name]; exists {
+			continue
+		}
+		out = append(out, config.SchemaCompletion{
+			Name: name,
+			Desc: "predefined application-set",
+		})
+		emitted[name] = struct{}{}
+	}
+	return out
+}
+
 func (s *Server) valueProvider(hint config.ValueHint, path []string) []config.SchemaCompletion {
 	if s == nil || s.store == nil {
 		return nil
@@ -708,13 +726,13 @@ func (s *Server) valueProvider(hint config.ValueHint, path []string) []config.Sc
 		for name := range config.PredefinedApplications {
 			out = append(out, config.SchemaCompletion{Name: name, Desc: "predefined"})
 		}
-		return out
+		return appendPredefinedApplicationSetCompletions(out)
 	case config.ValueHintAppSetName:
 		var out []config.SchemaCompletion
 		for _, as := range cfg.Applications.ApplicationSets {
 			out = append(out, config.SchemaCompletion{Name: as.Name, Desc: "application-set"})
 		}
-		return out
+		return appendPredefinedApplicationSetCompletions(out)
 	case config.ValueHintPoolName:
 		var out []config.SchemaCompletion
 		for name := range cfg.Security.NAT.SourcePools {
@@ -776,7 +794,7 @@ func (s *Server) valueProvider(hint config.ValueHint, path []string) []config.Sc
 		for name := range config.PredefinedApplications {
 			out = append(out, config.SchemaCompletion{Name: name, Desc: "predefined"})
 		}
-		return out
+		return appendPredefinedApplicationSetCompletions(out)
 	case config.ValueHintPolicyName:
 		var policies []*config.Policy
 		for i, tok := range path {


### PR DESCRIPTION
## Summary

- include predefined application sets in local CLI config completion
- include the same catalog in gRPC/remote CLI completion
- preserve hint-specific precedence when configured applications or sets shadow a predefined name
- cover pre-commit, first-commit, second-commit, collision, cardinality, description, and local/gRPC parity behavior

This changes completion only. Runtime application-set resolution and policy
matching already support these predefined sets and remain unchanged.

## Validation

- `go test ./pkg/config ./pkg/cli ./pkg/grpcapi -run '5763|PredefinedApplicationSets|PredefinedApplicationSet' -count=1`
- focused local and gRPC completion tests under `-race`
- focused completion tests at `-count=50`
- `go test ./pkg/config ./pkg/cli ./pkg/grpcapi -count=1`
- `go vet ./pkg/config ./pkg/grpcapi`
- `go build ./...`

The independent implementation review approved commit
`f185478dce678d6921e27d645348b16ac379941b`; canonical reviewed diff SHA-256
is `96ee4a5742144ce77ba5a3f25aecaab87f04f92fe4f5579894253432e7bfe398`.

Closes #5763
