### PR TITLE
api: gate metrics auth by listener bind

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -47986,3 +47986,21 @@ top.
   time.Minute` product turns the pathological cases RED — the products overflow
   non-positive (e.g. MaxInt64 → -1m0s, 200000000 → -1790762h...) and
   time.NewTicker panics "non-positive interval for NewTicker"; restored GREEN.
+
+- **Timestamp**: 2026-07-14 14:15 PDT
+  **Action**: Fix #4162 — make Prometheus metrics authentication listener-owned.
+  `NewServer` now builds the mux, Prometheus collector/limiter, and CSRF guard
+  once, then independently derives each HTTP/HTTPS owner handler from that
+  listener's configured bind. With API auth, only a literal loopback listener
+  leaves `/metrics` open; routable, wildcard, hostname, malformed, and
+  otherwise unprovable binds fail closed. Nil auth returns the unchanged shared
+  base. This preserves the global scrape limiter and session-gauge cache while
+  keeping `/health` exempt. The actual owner-handler matrix covers both mixed
+  listener orientations, Basic/Bearer/API-key credentials, IPv4/IPv6 loopback,
+  wildcard/hostname/malformed failure, auth-wrapped health/non-metrics routes,
+  nil-auth 404 pass-through, and persistence-degraded HTTPS installation.
+  **File(s)**: pkg/api/server.go, pkg/api/auth.go,
+  pkg/api/metrics_auth_gate_4162_test.go, docs/architecture.md, _Log.md
+  **Validation**: `gofmt -w pkg/api/server.go pkg/api/auth.go
+  pkg/api/metrics_auth_gate_4162_test.go`; focused #4162/cache/TLS/lifecycle
+  `go test ./pkg/api -run 'Test(IsLoopbackBindAddr|MetricsAuthGateNonLoopback|NewServerMetricsAuthIsOwnedByEachListener|SessionGaugeCacheWalksOncePerTTL|SessionGaugeCacheRefreshesAfterTTL|SessionGaugeCacheCoalescesConcurrentScrapes|SessionGaugeCacheValuesCorrect|HTTPSInstalledOnPersistFailure|RunClosesSurvivingListenerOnBindFailure|RunGracefulShutdownClosesBothListeners)$' -count=1`; `go test ./pkg/api -count=1`; `go test -race ./pkg/api -count=1`; `go vet ./pkg/api`; `go build ./pkg/api`; `go build ./cmd/xpfd`; all passed. `git diff --check` passed. Residual gaps: none; no true certificate-generation-failure seam exists in the approved scope.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,15 +251,16 @@ editing cmdtree.
     `constantTimeAPIKeyMatch` skips an empty configured key) — the
     constant-time compare still runs unconditionally, so the #4157
     known/unknown-user timing profile is preserved.
-  - **`/metrics` posture (#4162).** The Prometheus endpoint is
-    unauthenticated on the loopback default bind — the standard Prometheus
-    posture. When `system services web-management http interface <if>`
-    rebinds the HTTP API to a routable management address AND auth is
-    configured, `/metrics` requires the same credentials as every other
-    endpoint (`isLoopbackBindAddr` → `authMiddleware` gate); a
-    routable-interface Prometheus scraper must then present the configured
-    API key / basic-auth. `/health` stays exempt (no sensitive data, no
-    table walk).
+  - **`/metrics` posture (#4162).** Authentication policy is owned by each
+    enabled HTTP or HTTPS listener, using that listener's configured/effective
+    `cfg.Addr` or `cfg.HTTPSAddr`; it is never inferred from the request host,
+    forwarded headers, URL, or the sibling listener. With API auth configured,
+    `/metrics` is unauthenticated only on a literal IPv4/IPv6 loopback bind
+    (the standard Prometheus posture). Every routable, wildcard, hostname,
+    malformed, or otherwise unprovable bind fails closed and requires the same
+    Basic, Bearer, or API-key credentials as every other protected endpoint.
+    `/health` remains exempt. With `cfg.Auth == nil`, no auth wrapper is
+    installed on either listener, so both use the shared base mux unchanged.
   - **Cross-site mutation guard (CSRF, #5055).** HTTP Basic auth is an
     *ambient* browser credential (`WWW-Authenticate: Basic`) — once a browser
     is challenged it reattaches the cached credentials to every request to the

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -17,15 +17,15 @@ type AuthConfig struct {
 // authMiddleware wraps an http.Handler with Basic Auth / Bearer / X-API-Key
 // checks. /health always bypasses authentication (it exposes no sensitive data
 // and is a liveness probe). /metrics bypasses authentication only when
-// metricsRequireAuth is false — the loopback-bind default, the standard
-// Prometheus posture. When the HTTP API is rebound to a routable management
-// interface (metricsRequireAuth true), /metrics requires credentials like every
-// other endpoint so the aggregate session/counter surface is not exposed
-// unauthenticated on a routable interface (#4162).
+// metricsRequireAuth is false for a literal loopback bind, the standard
+// Prometheus posture. NewServer derives it independently from the configured
+// address of each enabled HTTP or HTTPS listener. A routable, wildcard,
+// hostname, malformed, or otherwise unprovable bind requires credentials for
+// /metrics like every other endpoint (#4162).
 func authMiddleware(cfg AuthConfig, metricsRequireAuth bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// /health is always exempt; /metrics is exempt unless the bind is
-		// non-loopback and auth-gating was requested.
+		// /health is always exempt; /metrics is exempt only when this listener
+		// has a literal loopback bind.
 		if r.URL.Path == "/health" || (r.URL.Path == "/metrics" && !metricsRequireAuth) {
 			next.ServeHTTP(w, r)
 			return

--- a/pkg/api/metrics_auth_gate_4162_test.go
+++ b/pkg/api/metrics_auth_gate_4162_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -76,4 +78,123 @@ func TestMetricsAuthGateNonLoopback(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewServerMetricsAuthIsOwnedByEachListener exercises the actual HTTP and
+// HTTPS owner handlers constructed by NewServer. It intentionally covers both
+// mixed-listener orientations so restoring one wrapper derived from cfg.Addr
+// makes this test fail closed-to-open (or open-to-closed) immediately.
+func TestNewServerMetricsAuthIsOwnedByEachListener(t *testing.T) {
+	resetTLSSeams(t)
+	// NewServer must install HTTPS after a persistence failure because the
+	// generated in-memory certificate remains usable. Avoid test writes to the
+	// production TLS location while preserving that production contract.
+	tlsMkdirAllDurable = func(string, os.FileMode) error {
+		return errors.New("injected TLS persistence failure")
+	}
+
+	auth := &AuthConfig{
+		Users:   map[string]string{"admin": "secret123"},
+		APIKeys: map[string]bool{"tok-abc-123": true},
+	}
+	basic := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:secret123"))
+
+	newServer := func(t *testing.T, cfg Config) *Server {
+		t.Helper()
+		s := NewServer(cfg)
+		if s.httpServer == nil || s.httpServer.Handler == nil {
+			t.Fatal("NewServer did not install the HTTP owner handler")
+		}
+		if cfg.TLS && cfg.HTTPSAddr != "" && (s.httpsServer == nil || s.httpsServer.Handler == nil) {
+			t.Fatal("NewServer did not install the requested HTTPS owner handler")
+		}
+		return s
+	}
+	request := func(t *testing.T, handler http.Handler, path string, header map[string]string, want int) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		for key, value := range header {
+			req.Header.Set(key, value)
+		}
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+		if recorder.Code != want {
+			t.Fatalf("%s with headers %v: status = %d, want %d", path, header, recorder.Code, want)
+		}
+	}
+
+	t.Run("HTTP loopback HTTPS wildcard", func(t *testing.T) {
+		s := newServer(t, Config{
+			Addr:      "127.0.0.1:8080",
+			HTTPSAddr: "0.0.0.0:8443",
+			TLS:       true,
+			Auth:      auth,
+		})
+		request(t, s.httpServer.Handler, "/metrics", nil, http.StatusOK)
+		request(t, s.httpsServer.Handler, "/metrics", nil, http.StatusUnauthorized)
+		request(t, s.httpsServer.Handler, "/metrics", map[string]string{"Authorization": basic}, http.StatusOK)
+		request(t, s.httpsServer.Handler, "/metrics", map[string]string{"Authorization": "Bearer tok-abc-123"}, http.StatusOK)
+		request(t, s.httpsServer.Handler, "/metrics", map[string]string{"X-API-Key": "tok-abc-123"}, http.StatusOK)
+		request(t, s.httpsServer.Handler, "/health", nil, http.StatusOK)
+		request(t, s.httpsServer.Handler, "/api/v1/status", nil, http.StatusUnauthorized)
+	})
+
+	t.Run("HTTP wildcard HTTPS loopback", func(t *testing.T) {
+		s := newServer(t, Config{
+			Addr:      "0.0.0.0:8080",
+			HTTPSAddr: "127.0.0.1:8443",
+			TLS:       true,
+			Auth:      auth,
+		})
+		request(t, s.httpServer.Handler, "/metrics", nil, http.StatusUnauthorized)
+		request(t, s.httpsServer.Handler, "/metrics", nil, http.StatusOK)
+		request(t, s.httpServer.Handler, "/health", nil, http.StatusOK)
+		request(t, s.httpServer.Handler, "/api/v1/status", nil, http.StatusUnauthorized)
+	})
+
+	t.Run("literal IPv4 and IPv6 loopback", func(t *testing.T) {
+		v4 := newServer(t, Config{Addr: "127.0.0.2:8080", Auth: auth})
+		request(t, v4.httpServer.Handler, "/metrics", nil, http.StatusOK)
+
+		v6 := newServer(t, Config{
+			Addr:      "192.0.2.10:8080",
+			HTTPSAddr: "[::1]:8443",
+			TLS:       true,
+			Auth:      auth,
+		})
+		request(t, v6.httpsServer.Handler, "/metrics", nil, http.StatusOK)
+	})
+
+	t.Run("unprovable binds fail closed", func(t *testing.T) {
+		for _, addr := range []string{
+			":8080",
+			"0.0.0.0:8080",
+			"[::]:8080",
+			"localhost:8080",
+			"metrics.example.test:8080",
+			"not-a-listen-address",
+		} {
+			s := newServer(t, Config{Addr: addr, Auth: auth})
+			request(t, s.httpServer.Handler, "/metrics", nil, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("auth-wrapped listener leaves health open", func(t *testing.T) {
+		s := newServer(t, Config{Addr: "192.0.2.10:8080", Auth: auth})
+		request(t, s.httpServer.Handler, "/metrics", nil, http.StatusUnauthorized)
+		request(t, s.httpServer.Handler, "/health", nil, http.StatusOK)
+		request(t, s.httpServer.Handler, "/api/v1/status", nil, http.StatusUnauthorized)
+	})
+
+	t.Run("nil auth leaves both listeners on the base mux", func(t *testing.T) {
+		s := newServer(t, Config{
+			Addr:      "192.0.2.10:8080",
+			HTTPSAddr: "198.51.100.10:8443",
+			TLS:       true,
+		})
+		request(t, s.httpServer.Handler, "/metrics", nil, http.StatusOK)
+		request(t, s.httpsServer.Handler, "/metrics", nil, http.StatusOK)
+		request(t, s.httpServer.Handler, "/not-a-route", nil, http.StatusNotFound)
+		request(t, s.httpsServer.Handler, "/not-a-route", nil, http.StatusNotFound)
+	})
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -502,32 +502,29 @@ func NewServer(cfg Config) *Server {
 	// System actions
 	mux.HandleFunc("POST /api/v1/system/action", s.systemActionHandler)
 
-	var handler http.Handler = mux
 	// #5055: guard the mutation surface against cross-site credentialed requests
 	// (CSRF via browser-ambient Basic auth). This wraps the mux BEFORE auth so it
 	// applies to every mutation route whether or not auth is configured; a
 	// request that clears auth then hits this guard, so an attacker holding
 	// ambient Basic credentials is still blocked from driving a state change from
 	// a cross-site page. Safe methods and header-key/Bearer clients are unaffected.
-	handler = mutationCrossSiteGuard(handler)
-	if cfg.Auth != nil {
-		// #4162 (auth posture): /metrics is unauthenticated by default, which
-		// is the standard Prometheus posture and safe on the loopback default
-		// bind (127.0.0.1). But when web-management rebinds the HTTP API to a
-		// routable management interface (daemon_run.go resolveInterfaceAddr),
-		// an unauthenticated /metrics becomes remotely reachable. When auth is
-		// configured AND the bind is non-loopback, require credentials for
-		// /metrics too. A routable-interface Prometheus scraper must then
-		// present the configured API key / basic-auth, same as every other
-		// endpoint (documented in docs/architecture.md). /health stays exempt
-		// (it exposes no table walk and no sensitive data).
-		metricsRequireAuth := !isLoopbackBindAddr(cfg.Addr)
-		handler = authMiddleware(*cfg.Auth, metricsRequireAuth, handler)
+	sharedBase := mutationCrossSiteGuard(mux)
+	// #4162: auth policy belongs to the listener that accepted the request.
+	// Keep one mux/collector/CSRF base so HTTP and HTTPS share the scrape
+	// limiter and session-gauge cache, then derive an auth wrapper from each
+	// listener's configured bind independently. Never infer this from r.Host
+	// or the sibling listener: only a literal loopback bind leaves /metrics
+	// open when auth is configured. /health remains exempt in authMiddleware.
+	listenerHandler := func(addr string) http.Handler {
+		if cfg.Auth == nil {
+			return sharedBase
+		}
+		return authMiddleware(*cfg.Auth, !isLoopbackBindAddr(addr), sharedBase)
 	}
 
 	s.httpServer = &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           handler,
+		Handler:           listenerHandler(cfg.Addr),
 		ReadHeaderTimeout: apiReadHeaderTimeout,
 		ReadTimeout:       apiReadTimeout,
 		IdleTimeout:       apiIdleTimeout,
@@ -544,7 +541,7 @@ func NewServer(cfg Config) *Server {
 		} else {
 			s.httpsServer = &http.Server{
 				Addr:              cfg.HTTPSAddr,
-				Handler:           handler,
+				Handler:           listenerHandler(cfg.HTTPSAddr),
 				ReadHeaderTimeout: apiReadHeaderTimeout,
 				ReadTimeout:       apiReadTimeout,
 				IdleTimeout:       apiIdleTimeout,


### PR DESCRIPTION
Closes #4162

## Design

Implements approved Architecture R2: https://github.com/psaab/xpf/issues/4162#issuecomment-4973970284

Independent review approval: https://github.com/psaab/xpf/issues/4162#issuecomment-4973990590

Builds one shared mux/collector/CSRF base and derives HTTP and HTTPS authentication wrappers independently from each listener bind.

## Validation

- `gofmt -w pkg/api/server.go pkg/api/auth.go pkg/api/metrics_auth_gate_4162_test.go`
- focused #4162/cache/TLS/lifecycle tests
- `go test ./pkg/api -count=1`
- `go test -race ./pkg/api -count=1`
- `go vet ./pkg/api`
- `go build ./pkg/api`
- `go build ./cmd/xpfd`
- `git diff --check`

All passed. Validation record: `_Log.md`.