### PR TITLE
zeroize: scope factory-reset deletion to xpf-owned artifacts

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48091,3 +48091,36 @@ top.
   -run '5302|ResendBurst|RefreshInterface' -count=1` (green); full
   `go test ./pkg/ra -count=1` re-run below; fail-on-revert of the
   burstCh refresh still flips the 5302 tests RED.
+
+- **Timestamp**: 2026-07-15
+  **Action**: #5768 (bug, security): bound factory-reset (zeroize) deletion
+  to xpf-OWNED artifacts. PR #5767 added the lexical FactoryResetForbiddenRoots
+  denylist, but a denylist is inherently incomplete on a wildcard-glob wipe: a
+  custom -config in an UNLISTED shared dir (/data/xpf.conf -> /data) or a SUBDIR
+  of a listed root (/opt/foo/x.conf -> /opt/foo; /opt denied, /opt/foo passes)
+  slipped past it, and the top-level sweep's broad `*.conf` suffix + `rollback*`
+  prefix globs then deleted UNOWNED siblings (a neighbor's foo.conf, xpf's own
+  rendered /etc/frr/frr.conf, a rollback-notes file). Replaced the two globs in
+  BOTH twin wipe primitives (grpcapi.zeroizeConfigDir, configstore.
+  FactoryResetConfigDir) with EXACT xpf-owned name matches: the live config
+  (name == configBase, any extension), rescue.conf (new shared
+  configstore.RescueConfigBase const, wired into Store.rescuePath), the audit
+  journal + rotated segments, the numbered text rollback slots
+  (<configBase>.<N>), and fsatomic crash temps. Dedicated xpf-owned subdir
+  RemoveAll's (.configdb, gRPC tls) and the isFsatomicTemp shape match are kept
+  (under-scoping a temp would strand an owned secret-bearing temp, #5475 — the
+  worse failure). ValidateFactoryResetRoot denylist retained as
+  defense-in-depth. The exact live-config match also fixes a latent bug: a
+  non-".conf" -config base (site.cfg) previously survived the suffix glob.
+  **File(s)**: pkg/grpcapi/server_diag_zeroize.go,
+  pkg/configstore/factory_reset.go, pkg/configstore/store_persist.go,
+  pkg/configstore/README.md,
+  pkg/grpcapi/zeroize_ownership_5768_test.go,
+  pkg/configstore/factory_reset_ownership_5768_test.go, _Log.md
+  **Validation**: `go build ./...`; `go test ./pkg/grpcapi/ ./pkg/configstore/
+  -count=1` (green); `go vet` clean. New fail-on-revert tests seed a validated
+  config root with owned artifacts + unowned siblings (other.conf, frr.conf,
+  rollback, rollback.bak, an unrelated subdir); after the wipe every owned
+  artifact is erased (no secret-retention regression) and every unowned sibling
+  survives. Restoring the `*.conf`/`rollback*` globs deletes the 4 siblings and
+  flips both tests RED (verified).

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -448,6 +448,22 @@ per-path:
   top-level temp — and its secrets — would survive. The gRPC
   `zeroizeConfigDir` mirror in `pkg/grpcapi` carries the same barriers
   (its own `zeroizeSyncDir` seam) and the same `.<base>.tmp-*` sweep.
+- **Ownership-scoped deletion (#5768).** The top-level sweep matches ONLY
+  the artifacts xpf itself created/tracks — the live config file (by EXACT
+  name, `configBase`, so a non-`.conf` `-config` base like `site.cfg` is
+  erased too), `rescue.conf` (`RescueConfigBase`), `.config.journal[.N]`,
+  the numbered text rollback slots `<configBase>.<N>`, and fsatomic crash
+  temps — NEVER a broad `*.conf` suffix or `rollback*` prefix glob. The old
+  globs deleted UNOWNED siblings when a custom `-config` resolved the config
+  root to a shared directory or a subdir that slipped past the
+  `FactoryResetForbiddenRoots` denylist (`/data/xpf.conf` → wipes `/data/*`;
+  `/etc/frr/x.conf` → deletes xpf's own rendered `frr.conf`). A denylist is
+  inherently incomplete on a wildcard wipe; ownership scoping bounds the
+  deletion to xpf's own files instead, with the denylist kept as
+  defense-in-depth. `FactoryResetConfigDir` (CLI) and the gRPC
+  `zeroizeConfigDir` mirror apply the identical scoped match; the dedicated
+  `<root>/.configdb` and (gRPC-only) `<root>/tls` subdir `RemoveAll`s stay —
+  those are exclusively xpf-owned subdirectories.
 - **`FactoryResetArchiveDir` — local config-archive erasure (#5186).**
   `zeroize` must remove EVERY on-box generation of config secrets. The
   config archive (`<archive-dir>/config-*.conf`, 0600 full-config-text

--- a/pkg/configstore/factory_reset.go
+++ b/pkg/configstore/factory_reset.go
@@ -28,6 +28,17 @@ import (
 // Production code must never mutate it.
 var DefaultArchiveDir = "/var/lib/xpf/archive"
 
+// RescueConfigBase is the fixed base name of the xpf rescue configuration file
+// the daemon writes alongside the live config (Store.rescuePath ->
+// "<configDir>/rescue.conf"). It is the full active-config TEXT with cleartext
+// secret leaves (IKE PSK, WireGuard keys, SNMP communities, #4056), so a factory
+// reset must erase it. It is a named constant — rather than a bare "rescue.conf"
+// literal scattered across the wipe primitives — so the config-state wipe's
+// ownership-scoped top-level match (#5768) deletes EXACTLY this xpf-owned name
+// instead of a broad `*.conf` glob that also caught unowned siblings. KEEP IN
+// SYNC with Store.rescuePath; the grpcapi wipe mirror references this const.
+const RescueConfigBase = "rescue.conf"
+
 // FactoryResetArchiveDir erases the LOCAL configuration archive as part of a
 // factory reset (#5186) — but ONLY when archiveDir is the xpf-owned default.
 //
@@ -94,10 +105,14 @@ func FactoryResetArchiveDir(archiveDir string) error {
 
 // FactoryResetForbiddenRoots are directories a factory-reset config-state wipe
 // must NEVER treat as an xpf-owned config root (#5684). FactoryResetConfigDir
-// scans configDir for *.conf / rollback* / journal / numbered-text-rollback /
-// fsatomic-temp artifacts and RemoveAll's <configDir>/.configdb — every removal
-// is bounded to configDir, but configDir itself is derived from
-// filepath.Dir(store.ConfigPath()). A daemon started with a custom `-config`
+// erases the xpf-owned config-state artifacts under configDir (the live config,
+// rescue.conf, the audit journal, the numbered text rollback slots, fsatomic
+// temps) and RemoveAll's <configDir>/.configdb. #5768 tightened the top-level
+// match from a broad `*.conf` / `rollback*` glob to those EXACT xpf-owned names
+// so an unowned sibling in the same directory is never deleted; this denylist
+// remains as defense-in-depth against ever entering the wipe on a shared root at
+// all. Every removal is bounded to configDir, but configDir itself is derived
+// from filepath.Dir(store.ConfigPath()). A daemon started with a custom `-config`
 // placed DIRECTLY in a shared directory (`-config /etc/xpf.conf` → configDir
 // "/etc"; `-config /srv/site.conf` → "/srv") or pointed at a directory-shaped
 // path (`-config /srv/firewall`, where filepath.Dir climbs to the PARENT
@@ -177,11 +192,14 @@ func ValidateFactoryResetRoot(configDir string) error {
 //     whole tree must go or the "erased" config is restored.
 //   - .config.journal[.N]   — the JSONL audit journal + rotated segments
 //     (prior-tenant commit history; legacy fat lines may carry full config).
+//   - <configBase>          — the LIVE config file, matched by EXACT name (#5768)
+//     so a non-".conf" -config base (e.g. site.cfg) is erased too, and a broad
+//     `*.conf` glob no longer catches unowned siblings.
+//   - rescue.conf           — the rescue config (RescueConfigBase / rescuePath):
+//     the full active-config TEXT with cleartext secret leaves (#4056).
 //   - <configBase>.<N>      — the canonical text rollback slots (full config
 //     text with cleartext secret leaves; loadRollbackHistory reads them at
 //     boot, so leaving them behind allows a rollback to the prior config).
-//   - *.conf                — the live config + rescue.conf (legacy set).
-//   - rollback*             — legacy rollback naming (pre-DB set).
 //   - .<base>.tmp-*         — fsatomic crash-leaked write temps (#5475): a
 //     daemon killed between fsatomic's CreateTemp and its rename leaves a
 //     ".<base>.tmp-<rand>" file (pkg/fsatomic createTemp) still holding the FULL
@@ -215,9 +233,11 @@ func ValidateFactoryResetRoot(configDir string) error {
 func FactoryResetConfigDir(configDir, configBase string) error {
 	// #5684: refuse to wipe a shared/parent/system directory. configDir is
 	// filepath.Dir(store.ConfigPath()); a custom -config placed in (or resolving
-	// to) a shared directory would turn this into a broad deletion of *.conf /
-	// .configdb / tls siblings xpf does not own. Fail CLOSED — surface the error
-	// and remove NOTHING — rather than erase the wrong tree.
+	// to) a shared directory must never let the reset RemoveAll <configDir>/.configdb
+	// (a dedicated xpf subdir) on a tree xpf does not own. #5768 additionally
+	// scopes the top-level file sweep below to EXACT xpf-owned names (no `*.conf` /
+	// `rollback*` glob), but this guard stays as defense-in-depth: fail CLOSED —
+	// surface the error and remove NOTHING — rather than enter the wipe at all.
 	if err := ValidateFactoryResetRoot(configDir); err != nil {
 		return err
 	}
@@ -247,18 +267,31 @@ func FactoryResetConfigDir(configDir, configBase string) error {
 	// residual key). RemoveAll erases the whole tree and is nil on absent.
 	fail(os.RemoveAll(dbDir))
 
-	// Top-level artifacts in a single ReadDir pass: the live/rescue .conf, the
-	// legacy rollback* files, the audit journal (+ rotated segments), and the
-	// numbered text rollback slots.
+	// Top-level artifacts in a single ReadDir pass. #5768: match ONLY names xpf
+	// itself created/tracks — the live config file, the rescue config, the audit
+	// journal (+ rotated segments), the numbered text rollback slots, and
+	// fsatomic crash temps. The pre-#5768 code matched a broad `*.conf` suffix and
+	// `rollback*` prefix, which — when a custom -config resolved configDir to a
+	// shared or subdir location that slipped past ValidateFactoryResetRoot —
+	// deleted UNOWNED siblings (a neighbor's foo.conf, xpf's own rendered
+	// /etc/frr/frr.conf, an unrelated rollback-notes file). Ownership scoping,
+	// not a bigger denylist, bounds the wipe to xpf's own artifacts. Note the
+	// exact live-config match also erases a non-".conf" -config base (e.g.
+	// site.cfg) the old suffix glob would have LEFT behind. configstore no longer
+	// writes any top-level `rollback*` file: the canonical text rollback slots are
+	// "<configBase>.<N>" (isTextRollbackSlot) and the DB slots live inside
+	// .configdb (RemoveAll'd above), so dropping the legacy `rollback*` prefix
+	// loses no owned artifact. isFsatomicTemp stays a shape match: under-scoping a
+	// temp risks stranding an owned secret-bearing temp (#5475), the worse failure.
 	entries, err := os.ReadDir(configDir)
 	fail(err)
 	for _, f := range entries {
 		name := f.Name()
-		if strings.HasSuffix(name, ".conf") ||
-			strings.HasPrefix(name, "rollback") ||
+		if name == configBase || // the live config file (exact name, any extension)
+			name == RescueConfigBase || // the rescue config (rescuePath)
 			name == ".config.journal" ||
 			strings.HasPrefix(name, ".config.journal.") ||
-			isTextRollbackSlot(name, configBase) ||
+			isTextRollbackSlot(name, configBase) || // <configBase>.<N> text slots
 			isFsatomicTemp(name) {
 			fail(os.Remove(filepath.Join(configDir, name)))
 		}

--- a/pkg/configstore/factory_reset_ownership_5768_test.go
+++ b/pkg/configstore/factory_reset_ownership_5768_test.go
@@ -1,0 +1,99 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFactoryResetConfigDirScopedToOwnedArtifacts5768 pins #5768 for the CLI /
+// shared config-state wipe primitive (FactoryResetConfigDir): it must delete
+// ONLY the artifacts xpf itself created/tracks and must NEVER delete unowned
+// siblings that merely share the config directory.
+//
+// The pre-#5768 code matched a broad `*.conf` suffix and `rollback*` prefix, so
+// a custom -config whose directory PASSED ValidateFactoryResetRoot (an unlisted
+// shared dir, or a subdir of a listed root) turned the factory reset into a
+// broad deletion of a neighbor's foo.conf or an unrelated rollback-notes file.
+//
+// The config root is a throwaway TempDir subdir (absolute, not an exact
+// FactoryResetForbiddenRoots entry, so it PASSES validation), seeded with both
+// xpf-owned artifacts and unowned siblings. After the wipe every owned artifact
+// is gone (no secret-retention regression) and every unowned sibling survives.
+// Note FactoryResetConfigDir does NOT remove <root>/tls (that is the gRPC
+// primitive's leg), so no tls artifact is seeded here.
+//
+// RED on revert: restore the `strings.HasSuffix(name, ".conf")` /
+// `strings.HasPrefix(name, "rollback")` globs and the unowned other.conf /
+// frr.conf / rollback / rollback.bak siblings are deleted — the "survives"
+// assertions fail.
+func TestFactoryResetConfigDirScopedToOwnedArtifacts5768(t *testing.T) {
+	dir := t.TempDir()
+	configBase := "xpf.conf"
+	secret := []byte("OWNED-SECRET-5768")
+	foreign := []byte("NOT-XPFS-5768")
+
+	if err := os.MkdirAll(filepath.Join(dir, ".configdb"), 0o700); err != nil {
+		t.Fatalf("mkdir .configdb: %v", err)
+	}
+	// xpf-owned config-state artifacts (must be erased — no secret retention).
+	owned := []string{
+		filepath.Join(dir, configBase),                 // the live config file
+		filepath.Join(dir, RescueConfigBase),           // rescue.conf
+		filepath.Join(dir, configBase+".1"),            // <base>.<N> text rollback slot
+		filepath.Join(dir, ".config.journal"),          // audit journal
+		filepath.Join(dir, ".config.journal.1"),        // rotated journal segment
+		filepath.Join(dir, ".xpf.conf.tmp-abc123"),     // fsatomic crash temp
+		filepath.Join(dir, ".configdb", "master.key"),  // AES-GCM key
+		filepath.Join(dir, ".configdb", "active.json"), // SSOT
+	}
+	for _, p := range owned {
+		if err := os.WriteFile(p, secret, 0o600); err != nil {
+			t.Fatalf("seed owned %s: %v", p, err)
+		}
+	}
+
+	// Unowned siblings sharing the directory (must SURVIVE) — exactly what the
+	// pre-#5768 broad globs would have deleted.
+	neighborDir := filepath.Join(dir, "neighbor")
+	if err := os.MkdirAll(neighborDir, 0o700); err != nil {
+		t.Fatalf("mkdir neighbor: %v", err)
+	}
+	unowned := []string{
+		filepath.Join(dir, "other.conf"),   // foreign .conf (was: *.conf suffix glob)
+		filepath.Join(dir, "frr.conf"),     // a neighbor's frr.conf (was: *.conf glob)
+		filepath.Join(dir, "rollback"),     // was: rollback* prefix glob
+		filepath.Join(dir, "rollback.bak"), // was: rollback* prefix glob
+		filepath.Join(dir, "notes.txt"),    // unrelated bystander
+		filepath.Join(neighborDir, "data"), // file inside an unrelated subdir
+	}
+	for _, p := range unowned {
+		if err := os.WriteFile(p, foreign, 0o600); err != nil {
+			t.Fatalf("seed unowned %s: %v", p, err)
+		}
+	}
+
+	if err := FactoryResetConfigDir(dir, configBase); err != nil {
+		t.Fatalf("FactoryResetConfigDir(%q): %v", dir, err)
+	}
+
+	// Every owned artifact must be gone — the wipe still erases xpf's secrets.
+	for _, p := range owned {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("owned artifact survived the wipe (secret-retention regression): %s (err=%v)", p, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".configdb")); !os.IsNotExist(err) {
+		t.Errorf("owned subdir .configdb survived the wipe (err=%v)", err)
+	}
+
+	// Every unowned sibling must SURVIVE — the #5768 ownership scoping.
+	for _, p := range unowned {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("#5768: factory reset deleted an UNOWNED sibling it must not touch: %s (%v)", p, err)
+		}
+	}
+	if _, err := os.Stat(neighborDir); err != nil {
+		t.Errorf("#5768: factory reset deleted an unrelated subdir: %s (%v)", neighborDir, err)
+	}
+}

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -551,9 +551,11 @@ func archiveRemoveErr(path string) error {
 	return nil
 }
 
-// rescuePath returns the path for the rescue configuration file.
+// rescuePath returns the path for the rescue configuration file. The base name
+// is RescueConfigBase (KEEP IN SYNC): the factory-reset wipe's ownership-scoped
+// top-level match (#5768) deletes exactly this name.
 func (s *Store) rescuePath() string {
-	return filepath.Join(filepath.Dir(s.filePath), "rescue.conf")
+	return filepath.Join(filepath.Dir(s.filePath), RescueConfigBase)
 }
 
 // SaveRescueConfig saves the active config as rescue configuration.

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -58,13 +58,16 @@ const (
 //   - .configdb/master.key      — the AES-GCM key that decrypts an encrypted DB
 //   - .configdb/                — the SSOT: active.json, candidate.json,
 //     rollback.N.json (Store.Load reloads active.json on next boot)
+//   - <configBase>              — the LIVE config file, matched by EXACT name
+//     (#5768) so a non-".conf" -config base (e.g. site.cfg) is erased too and a
+//     broad `*.conf` glob no longer catches unowned siblings
+//   - rescue.conf               — the rescue config (configstore.RescueConfigBase
+//     / rescuePath): full active-config TEXT with cleartext secret leaves (#4056)
 //   - <configBase>.<N>          — the CANONICAL text rollback slots
 //     (saveRollbackFiles / loadRollbackHistory), full config TEXT with
 //     cleartext secret leaves; loadRollbackHistory reloads them at boot, so
 //     leaving them behind would let the prior tenant's config be rolled back
 //     to — the exact leak #4576 closes
-//   - *.conf                    — the live config + rescue.conf (pre-#4576 set)
-//   - rollback*                 — legacy rollback naming (pre-#4576 set)
 //   - .<base>.tmp-*             — fsatomic crash-leaked write temps (#5475): a
 //     daemon killed between fsatomic's CreateTemp and its rename leaves a
 //     ".<base>.tmp-<rand>" file (pkg/fsatomic createTemp) still holding the FULL
@@ -148,16 +151,30 @@ func zeroizeConfigDir(configDir, configBase string) error {
 	// erase the whole tree explicitly.
 	fail(os.RemoveAll(filepath.Join(configDir, "tls")))
 
-	// Top-level artifacts in a single ReadDir pass.
+	// Top-level artifacts in a single ReadDir pass. #5768: match ONLY names xpf
+	// itself created/tracks — the live config file, the rescue config, the audit
+	// journal (+ rotated segments), the numbered text rollback slots, and fsatomic
+	// crash temps. The pre-#5768 code matched a broad `*.conf` suffix and
+	// `rollback*` prefix; when a custom -config resolved configDir to a shared or
+	// subdir location that slipped past ValidateFactoryResetRoot, those globs
+	// deleted UNOWNED siblings (a neighbor's foo.conf, xpf's own rendered
+	// /etc/frr/frr.conf, an unrelated rollback-notes file). Ownership scoping — not
+	// a bigger denylist — bounds the wipe to xpf's artifacts. The exact live-config
+	// match also erases a non-".conf" -config base the old suffix glob left behind.
+	// configstore writes no top-level `rollback*` file (canonical text slots are
+	// "<configBase>.<N>" via isTextRollbackFile; DB slots live inside .configdb,
+	// RemoveAll'd above), so dropping the legacy `rollback*` prefix loses no owned
+	// artifact. isFsatomicTemp stays a shape match: under-scoping a temp risks
+	// stranding an owned secret-bearing temp (#5475), the worse failure.
 	entries, err := os.ReadDir(configDir)
 	fail(err)
 	for _, f := range entries {
 		name := f.Name()
-		if strings.HasSuffix(name, ".conf") ||
-			strings.HasPrefix(name, "rollback") ||
+		if name == configBase || // the live config file (exact name, any extension)
+			name == configstore.RescueConfigBase || // the rescue config (rescuePath)
 			name == ".config.journal" ||
 			strings.HasPrefix(name, ".config.journal.") ||
-			isTextRollbackFile(name, configBase) ||
+			isTextRollbackFile(name, configBase) || // <configBase>.<N> text slots
 			isFsatomicTemp(name) {
 			fail(os.Remove(filepath.Join(configDir, name)))
 		}

--- a/pkg/grpcapi/zeroize_ownership_5768_test.go
+++ b/pkg/grpcapi/zeroize_ownership_5768_test.go
@@ -1,0 +1,110 @@
+package grpcapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// TestZeroizeConfigDirScopedToOwnedArtifacts5768 pins #5768: the gRPC
+// config-state wipe primitive (zeroizeConfigDir) must delete ONLY the artifacts
+// xpf itself created/tracks and must NEVER delete unowned siblings that merely
+// share the config directory.
+//
+// The pre-#5768 code matched a broad `*.conf` suffix and `rollback*` prefix, so
+// a custom -config whose directory PASSED ValidateFactoryResetRoot — an unlisted
+// shared dir (/data/xpf.conf -> /data) or a subdir of a listed root
+// (/opt/foo/x.conf -> /opt/foo; /opt is denied but /opt/foo passes) — turned the
+// factory reset into a broad deletion of a neighbor's foo.conf, xpf's own
+// rendered /etc/frr/frr.conf, or an unrelated rollback-notes file. A denylist is
+// inherently incomplete on a wildcard wipe; ownership scoping bounds the wipe to
+// xpf's own files instead.
+//
+// The config root here is a throwaway dir that PASSES ValidateFactoryResetRoot
+// (a TempDir subdir is absolute and not an exact FactoryResetForbiddenRoots
+// entry), seeded with both xpf-owned artifacts and unowned siblings. After the
+// wipe: every owned artifact is gone (no secret-retention regression) and every
+// unowned sibling survives.
+//
+// RED on revert: restore the `strings.HasSuffix(name, ".conf")` /
+// `strings.HasPrefix(name, "rollback")` globs and the unowned other.conf /
+// frr.conf / rollback / rollback.bak siblings are deleted — the "survives"
+// assertions fail.
+func TestZeroizeConfigDirScopedToOwnedArtifacts5768(t *testing.T) {
+	dir := t.TempDir()
+	configBase := "xpf.conf"
+	secret := []byte("OWNED-SECRET-5768")
+	foreign := []byte("NOT-XPFS-5768")
+
+	if err := os.MkdirAll(filepath.Join(dir, ".configdb"), 0o700); err != nil {
+		t.Fatalf("mkdir .configdb: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "tls"), 0o700); err != nil {
+		t.Fatalf("mkdir tls: %v", err)
+	}
+	// xpf-owned config-state artifacts (must be erased — no secret retention).
+	owned := []string{
+		filepath.Join(dir, configBase),                   // the live config file
+		filepath.Join(dir, configstore.RescueConfigBase), // rescue.conf
+		filepath.Join(dir, configBase+".1"),              // <base>.<N> text rollback slot
+		filepath.Join(dir, ".config.journal"),            // audit journal
+		filepath.Join(dir, ".config.journal.1"),          // rotated journal segment
+		filepath.Join(dir, ".xpf.conf.tmp-abc123"),       // fsatomic crash temp
+		filepath.Join(dir, ".configdb", "master.key"),    // AES-GCM key
+		filepath.Join(dir, ".configdb", "active.json"),   // SSOT
+		filepath.Join(dir, "tls", "key.pem"),             // self-signed REST key
+	}
+	for _, p := range owned {
+		if err := os.WriteFile(p, secret, 0o600); err != nil {
+			t.Fatalf("seed owned %s: %v", p, err)
+		}
+	}
+
+	// Unowned siblings sharing the directory (must SURVIVE). These are exactly
+	// what the pre-#5768 broad globs would have deleted.
+	neighborDir := filepath.Join(dir, "neighbor")
+	if err := os.MkdirAll(neighborDir, 0o700); err != nil {
+		t.Fatalf("mkdir neighbor: %v", err)
+	}
+	unowned := []string{
+		filepath.Join(dir, "other.conf"),   // foreign .conf (was: *.conf suffix glob)
+		filepath.Join(dir, "frr.conf"),     // a neighbor's frr.conf (was: *.conf glob)
+		filepath.Join(dir, "rollback"),     // was: rollback* prefix glob
+		filepath.Join(dir, "rollback.bak"), // was: rollback* prefix glob
+		filepath.Join(dir, "notes.txt"),    // unrelated bystander
+		filepath.Join(neighborDir, "data"), // file inside an unrelated subdir
+	}
+	for _, p := range unowned {
+		if err := os.WriteFile(p, foreign, 0o600); err != nil {
+			t.Fatalf("seed unowned %s: %v", p, err)
+		}
+	}
+
+	if err := zeroizeConfigDir(dir, configBase); err != nil {
+		t.Fatalf("zeroizeConfigDir(%q): %v", dir, err)
+	}
+
+	// Every owned artifact must be gone — the wipe still erases xpf's secrets.
+	for _, p := range owned {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("owned artifact survived the wipe (secret-retention regression): %s (err=%v)", p, err)
+		}
+	}
+	for _, d := range []string{filepath.Join(dir, ".configdb"), filepath.Join(dir, "tls")} {
+		if _, err := os.Stat(d); !os.IsNotExist(err) {
+			t.Errorf("owned subdir survived the wipe: %s (err=%v)", d, err)
+		}
+	}
+
+	// Every unowned sibling must SURVIVE — the #5768 ownership scoping.
+	for _, p := range unowned {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("#5768: zeroize deleted an UNOWNED sibling it must not touch: %s (%v)", p, err)
+		}
+	}
+	if _, err := os.Stat(neighborDir); err != nil {
+		t.Errorf("#5768: zeroize deleted an unrelated subdir: %s (%v)", neighborDir, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5768.

The #5684 fix guarded the factory-reset (`request system zeroize`) config-state wipe with a **lexical denylist** (`configstore.FactoryResetForbiddenRoots` via `ValidateFactoryResetRoot`). But a denylist is inherently incomplete on a wildcard-glob wipe: a custom `-config` in an **UNLISTED shared dir** (`/data/xpf.conf` → `/data`) or in a **SUBDIR of a listed root** (`/opt/foo/x.conf` → `/opt/foo`; `/opt` is denied but `/opt/foo` passes) slips past it. The top-level sweep's broad `*.conf` suffix + `rollback*` prefix globs then deleted **UNOWNED siblings** — a neighbor's `foo.conf`, xpf's own rendered `/etc/frr/frr.conf`, or an unrelated `rollback`-prefixed file.

## Fix: ownership-scoped deletion (not a bigger denylist)

Both twin wipe primitives — gRPC `zeroizeConfigDir` (`pkg/grpcapi`) and CLI/shared `FactoryResetConfigDir` (`pkg/configstore`) — now match **EXACT xpf-owned names** in the top-level sweep:

- the **live config file** by exact name (`configBase`), any extension;
- the **rescue config**, via a new shared `configstore.RescueConfigBase` const wired into `Store.rescuePath` (one source of truth);
- the audit journal `.config.journal` + rotated `.config.journal.N` segments;
- the numbered text rollback slots `<configBase>.<N>`;
- fsatomic crash-leaked write temps.

The broad `*.conf` suffix and `rollback*` prefix globs are **removed**. configstore writes no top-level `rollback*` file (canonical text slots are `<configBase>.<N>`; DB slots live inside `.configdb`, which is `RemoveAll`'d), so dropping the legacy prefix loses no owned artifact.

**Kept deliberately:**
- Dedicated xpf-owned subdir `RemoveAll`s (`.configdb`, gRPC-only `tls`) — exclusively xpf-owned.
- `isFsatomicTemp` shape match — under-scoping a temp risks stranding an owned secret-bearing temp on disk (#5475), the *worse* failure than deleting a foreign dotfile temp.
- `ValidateFactoryResetRoot` denylist — retained as **defense-in-depth**.

**Latent bug also fixed:** a non-`.conf` `-config` base (e.g. `site.cfg`) — the actual live config, xpf-owned — previously survived the `.conf` suffix glob and was left on disk after a reset. The exact-name match now erases it.

## Tests (fail-on-revert)

New `TestZeroizeConfigDirScopedToOwnedArtifacts5768` (grpcapi) and `TestFactoryResetConfigDirScopedToOwnedArtifacts5768` (configstore). Each seeds a config root that **PASSES** `ValidateFactoryResetRoot` (a `TempDir` subdir) with both xpf-owned artifacts and unowned siblings (`other.conf`, `frr.conf`, `rollback`, `rollback.bak`, `notes.txt`, an unrelated subdir). After the wipe:
- every **owned** artifact is erased (no secret-retention regression);
- every **unowned** sibling survives.

**Fail-on-revert verified:** restoring the `*.conf`/`rollback*` globs deletes the four siblings and flips both tests RED.

## Validation

- `go build ./...`
- `go test ./pkg/grpcapi/ ./pkg/configstore/ -count=1` — green
- `go vet ./pkg/grpcapi/ ./pkg/configstore/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)