### PR TITLE
cli: reject scope suffixes on global-only clear commands (#5811)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-15 — #5811 (bug/audit/security): global-only clear commands enforce exact arity
+- **Timestamp**: 2026-07-15 (fix/5811-clear-exact-arity)
+- **Action**: Global-only `clear` handlers (whose backend action can ONLY clear
+  everything, no scoped variant) recognized a fixed keyword prefix and silently
+  DISCARDED every trailing token, then issued the unscoped mutation. So a
+  scoped-LOOKING command — `clear arp 192.0.2.10`, `clear ipv6 neighbors
+  interface ge-0-0-0`, `clear interfaces statistics ge-0-0-0`, `clear security
+  nat statistics rule web`, `clear security nat source persistent-nat-table pool
+  p1`, `clear security counters zone untrust`, `clear firewall all filter edge`,
+  `clear system config-lock session 42` — reported success while wiping the
+  ENTIRE cache/counter/table. Added a `requireClearNoScope(cmd, clears, extra)`
+  helper (byte-identical copy in `cmd/cli/clear.go` and `pkg/cli/cli_clear.go`)
+  that REJECTS any trailing operand with an "unexpected argument(s) ...; this
+  command clears X and takes no scope" error BEFORE any mutation. Wired it into
+  every global-only clear on BOTH parsers, restoring arity parity (the in-process
+  `policies hit-count` now matches the remote's #5570 guard). Legit scoped clears
+  (`clear security flow session <filter>`, `clear dhcp client-identifier
+  interface <name>`) are untouched. Follow-up candidate (out of #5811 scope): the
+  in-process `clear dhcp client-identifier` does not mirror the remote's #4883-E
+  malformed-selector guard.
+- **Validation**: gofmt clean; go build ./... + go test ./cmd/cli/ ./pkg/cli/
+  -count=1 green; go vet clean apart from a pre-existing cli.go unreachable-code
+  note in an untouched file. Fail-on-revert proven via overlay: neutralizing
+  requireClearNoScope (discard suffix) flips the reject tests RED on BOTH parsers
+  (no error returned; the dp/RPC mutation runs).
+- **File(s)**: cmd/cli/clear.go (Edit), pkg/cli/cli_clear.go (Edit),
+  cmd/cli/clear_exact_arity_5811_test.go (Write),
+  pkg/cli/cli_clear_exact_arity_5811_test.go (Write), pkg/cli/README.md (Edit),
+  _Log.md (Edit)
+
 ## 2026-07-15 — #5738 (bug/syslog) commit 2/2: CLI reloadSyslog source-iface + event-mode parity
 - **Timestamp**: 2026-07-15 (fix/5738-syslog-source-iface-parity)
 - **Action**: Aligned the CLI in-process commit path (reloadSyslog /

--- a/cmd/cli/clear.go
+++ b/cmd/cli/clear.go
@@ -7,6 +7,25 @@ import (
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
 
+// requireClearNoScope rejects any trailing operand on a GLOBAL-ONLY clear
+// command — one whose backend action can ONLY clear everything and has no
+// scoped variant. Such handlers historically recognized a fixed keyword prefix
+// and silently DISCARDED the remaining tokens, then issued the unscoped
+// mutation, so an operator who typed a scope (e.g. `clear arp 192.0.2.10`) got
+// a success message while the ENTIRE cache/table/counter set was wiped (#5811).
+// Require exact arity instead: return an error naming the stray tokens and
+// stating the command takes no scope, BEFORE any mutation runs. cmd is the full
+// command path shown in the message; clears names what it unconditionally
+// clears. The wording is kept byte-identical to pkg/cli's copy so both CLIs
+// reject the same input the same way.
+func requireClearNoScope(cmd, clears string, extra []string) error {
+	if len(extra) == 0 {
+		return nil
+	}
+	return fmt.Errorf("unexpected argument(s) %v after %q; this command clears %s "+
+		"and takes no scope (per-scope clear is not supported)", extra, cmd, clears)
+}
+
 func (c *ctl) handleClear(args []string) error {
 	showHelp := func() {
 		printRemoteTreeHelp("clear:", "clear")
@@ -18,7 +37,7 @@ func (c *ctl) handleClear(args []string) error {
 
 	switch args[0] {
 	case "arp":
-		return c.handleClearArp()
+		return c.handleClearArp(args[1:])
 	case "ipv6":
 		return c.handleClearIPv6(args[1:])
 	case "security":
@@ -42,6 +61,9 @@ func (c *ctl) handleClearSystem(args []string) error {
 		printRemoteTreeHelp("clear system:", "clear", "system")
 		return nil
 	}
+	if err := requireClearNoScope("clear system config-lock", "the configuration lock", args[1:]); err != nil {
+		return err
+	}
 	resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 		Action: "clear-config-lock",
 	})
@@ -54,6 +76,9 @@ func (c *ctl) handleClearSystem(args []string) error {
 
 func (c *ctl) handleClearInterfaces(args []string) error {
 	if len(args) >= 1 && args[0] == "statistics" {
+		if err := requireClearNoScope("clear interfaces statistics", "all interface statistics", args[1:]); err != nil {
+			return err
+		}
 		resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 			Action: "clear-interfaces-statistics",
 		})
@@ -67,7 +92,10 @@ func (c *ctl) handleClearInterfaces(args []string) error {
 	return nil
 }
 
-func (c *ctl) handleClearArp() error {
+func (c *ctl) handleClearArp(args []string) error {
+	if err := requireClearNoScope("clear arp", "the ARP cache", args); err != nil {
+		return err
+	}
 	resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 		Action: "clear-arp",
 	})
@@ -82,6 +110,9 @@ func (c *ctl) handleClearIPv6(args []string) error {
 	if len(args) < 1 || args[0] != "neighbors" {
 		printRemoteTreeHelp("clear ipv6:", "clear", "ipv6")
 		return nil
+	}
+	if err := requireClearNoScope("clear ipv6 neighbors", "the IPv6 neighbor cache", args[1:]); err != nil {
+		return err
 	}
 	resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 		Action: "clear-ipv6-neighbors",
@@ -102,6 +133,10 @@ func (c *ctl) handleClearSecurity(args []string) error {
 	switch args[0] {
 	case "nat":
 		if len(args) >= 3 && args[1] == "source" && args[2] == "persistent-nat-table" {
+			if err := requireClearNoScope("clear security nat source persistent-nat-table",
+				"the entire persistent NAT table", args[3:]); err != nil {
+				return err
+			}
 			resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 				Action: "clear-persistent-nat",
 			})
@@ -112,6 +147,10 @@ func (c *ctl) handleClearSecurity(args []string) error {
 			return nil
 		}
 		if len(args) >= 2 && args[1] == "statistics" {
+			if err := requireClearNoScope("clear security nat statistics",
+				"all NAT translation statistics", args[2:]); err != nil {
+				return err
+			}
 			resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 				Action: "clear-nat-counters",
 			})
@@ -202,10 +241,9 @@ func (c *ctl) handleClearSecurity(args []string) error {
 		if len(args) < 2 || args[1] != "hit-count" {
 			return fmt.Errorf("usage: clear security policies hit-count")
 		}
-		if len(args) > 2 {
-			return fmt.Errorf("unknown/unsupported selector %q for "+
-				"clear security policies hit-count; per-scope clear is not "+
-				"supported (this command clears ALL policy hit counters)", args[2])
+		if err := requireClearNoScope("clear security policies hit-count",
+			"all policy hit counters", args[2:]); err != nil {
+			return err
 		}
 		resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 			Action: "clear-policy-counters",
@@ -217,6 +255,9 @@ func (c *ctl) handleClearSecurity(args []string) error {
 		return nil
 
 	case "counters":
+		if err := requireClearNoScope("clear security counters", "all counters", args[1:]); err != nil {
+			return err
+		}
 		_, err := c.client.ClearCounters(c.ctx(), &pb.ClearCountersRequest{})
 		if err != nil {
 			return fmt.Errorf("%v", err)
@@ -234,6 +275,9 @@ func (c *ctl) handleClearFirewall(args []string) error {
 	if len(args) < 1 || args[0] != "all" {
 		printRemoteTreeHelp("clear firewall:", "clear", "firewall")
 		return nil
+	}
+	if err := requireClearNoScope("clear firewall all", "all firewall filter counters", args[1:]); err != nil {
+		return err
 	}
 	resp, err := c.client.SystemAction(c.ctx(), &pb.SystemActionRequest{
 		Action: "clear-firewall-counters",

--- a/cmd/cli/clear_exact_arity_5811_test.go
+++ b/cmd/cli/clear_exact_arity_5811_test.go
@@ -1,0 +1,133 @@
+// #5811: global-only `clear` commands (whose backend action can ONLY clear
+// everything) previously recognized a fixed keyword prefix and silently
+// DISCARDED any trailing tokens, then issued the unscoped mutation. So a
+// scoped-LOOKING command — `clear arp 192.0.2.10`, `clear security nat
+// statistics rule web`, `clear security counters zone untrust`, `clear firewall
+// all filter edge` — reported success while wiping the ENTIRE cache/counter
+// set. These tests pin the exact-arity rejection on the REMOTE CLI: a trailing
+// operand must ERROR before any RPC, and the bare form must still clear.
+//
+// Fail-on-revert: drop a `requireClearNoScope(...)` guard (return to discarding
+// the suffix) and the matching reject test flips RED — the RPC fires (calls==1)
+// and err is nil.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// clearArityRecorder records the destructive RPCs a clear handler would issue,
+// so a test can assert a scoped-looking request issued NONE.
+type clearArityRecorder struct {
+	pb.BpfrxServiceClient
+
+	sysCalls      int
+	lastSysAction string
+	clearCtrCalls int
+}
+
+func (f *clearArityRecorder) SystemAction(
+	_ context.Context, in *pb.SystemActionRequest, _ ...grpc.CallOption,
+) (*pb.SystemActionResponse, error) {
+	f.sysCalls++
+	f.lastSysAction = in.GetAction()
+	return &pb.SystemActionResponse{Message: "ok"}, nil
+}
+
+func (f *clearArityRecorder) ClearCounters(
+	_ context.Context, _ *pb.ClearCountersRequest, _ ...grpc.CallOption,
+) (*pb.ClearCountersResponse, error) {
+	f.clearCtrCalls++
+	return &pb.ClearCountersResponse{}, nil
+}
+
+// A trailing scope operand must ERROR before any RPC for every global-only
+// clear command reachable through handleClear / handleClearSecurity /
+// handleClearFirewall.
+func TestClearGlobalOnlyTrailingScopeRejectedNoRPC_5811(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(c *ctl) error
+	}{
+		// Routed through the top-level dispatch so the args[1:] threading into
+		// handleClearArp is covered too.
+		{"arp addr via dispatch", func(c *ctl) error { return c.handleClear([]string{"arp", "192.0.2.10"}) }},
+		{"arp addr", func(c *ctl) error { return c.handleClearArp([]string{"192.0.2.10"}) }},
+		{"ipv6 neighbors iface", func(c *ctl) error { return c.handleClearIPv6([]string{"neighbors", "interface", "ge-0-0-0"}) }},
+		{"interfaces statistics iface", func(c *ctl) error { return c.handleClearInterfaces([]string{"statistics", "ge-0-0-0"}) }},
+		{"system config-lock session", func(c *ctl) error { return c.handleClearSystem([]string{"config-lock", "session", "42"}) }},
+		{"nat statistics rule", func(c *ctl) error { return c.handleClearSecurity([]string{"nat", "statistics", "rule", "web"}) }},
+		{"nat persistent-nat-table pool", func(c *ctl) error {
+			return c.handleClearSecurity([]string{"nat", "source", "persistent-nat-table", "pool", "p1"})
+		}},
+		{"security counters zone", func(c *ctl) error { return c.handleClearSecurity([]string{"counters", "zone", "untrust"}) }},
+		{"policies hit-count selector", func(c *ctl) error {
+			return c.handleClearSecurity([]string{"policies", "hit-count", "from-zone", "trust"})
+		}},
+		{"firewall all filter", func(c *ctl) error { return c.handleClearFirewall([]string{"all", "filter", "edge"}) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &clearArityRecorder{}
+			c := &ctl{client: fake}
+			err := tt.call(c)
+			if err == nil {
+				t.Fatalf("%s: expected an error for a scoped-looking global clear, got nil", tt.name)
+			}
+			if !strings.Contains(err.Error(), "takes no scope") {
+				t.Fatalf("%s: error %q does not explain the no-scope rejection", tt.name, err)
+			}
+			if fake.sysCalls != 0 || fake.clearCtrCalls != 0 {
+				t.Fatalf("%s: destructive RPC issued (SystemAction=%d action=%q, ClearCounters=%d); a "+
+					"scoped-looking clear must wipe NOTHING", tt.name, fake.sysCalls, fake.lastSysAction, fake.clearCtrCalls)
+			}
+		})
+	}
+}
+
+// The bare (exact-arity) form of each global-only clear still issues its RPC.
+func TestClearGlobalOnlyBareStillClears_5811(t *testing.T) {
+	tests := []struct {
+		name       string
+		call       func(c *ctl) error
+		wantSys    string // expected SystemAction, or "" if ClearCounters is used
+		wantCtrRPC bool
+	}{
+		{"arp", func(c *ctl) error { return c.handleClearArp(nil) }, "clear-arp", false},
+		{"ipv6 neighbors", func(c *ctl) error { return c.handleClearIPv6([]string{"neighbors"}) }, "clear-ipv6-neighbors", false},
+		{"interfaces statistics", func(c *ctl) error { return c.handleClearInterfaces([]string{"statistics"}) }, "clear-interfaces-statistics", false},
+		{"system config-lock", func(c *ctl) error { return c.handleClearSystem([]string{"config-lock"}) }, "clear-config-lock", false},
+		{"nat statistics", func(c *ctl) error { return c.handleClearSecurity([]string{"nat", "statistics"}) }, "clear-nat-counters", false},
+		{"nat persistent-nat-table", func(c *ctl) error {
+			return c.handleClearSecurity([]string{"nat", "source", "persistent-nat-table"})
+		}, "clear-persistent-nat", false},
+		{"policies hit-count", func(c *ctl) error { return c.handleClearSecurity([]string{"policies", "hit-count"}) }, "clear-policy-counters", false},
+		{"firewall all", func(c *ctl) error { return c.handleClearFirewall([]string{"all"}) }, "clear-firewall-counters", false},
+		{"security counters", func(c *ctl) error { return c.handleClearSecurity([]string{"counters"}) }, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &clearArityRecorder{}
+			c := &ctl{client: fake}
+			if err := tt.call(c); err != nil {
+				t.Fatalf("%s: bare form returned unexpected error: %v", tt.name, err)
+			}
+			if tt.wantCtrRPC {
+				if fake.clearCtrCalls != 1 {
+					t.Fatalf("%s: ClearCounters calls = %d, want 1", tt.name, fake.clearCtrCalls)
+				}
+				return
+			}
+			if fake.sysCalls != 1 || fake.lastSysAction != tt.wantSys {
+				t.Fatalf("%s: SystemAction calls=%d action=%q, want 1 / %q",
+					tt.name, fake.sysCalls, fake.lastSysAction, tt.wantSys)
+			}
+		})
+	}
+}

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -149,6 +149,20 @@ presenter's rendered output is byte-identical:
   because an empty `ClearSessionsRequest` means clear-all to the peer.
   Key ports are network byte order (`ntohs` before comparing) and
   dataplane IPv4 NAT fields decode with NativeEndian (`uint32ToIP`).
+- GLOBAL-ONLY clears (`cli_clear.go`) — commands whose backend action can
+  ONLY clear everything and have no scoped variant (`clear arp`, `clear ipv6
+  neighbors`, `clear interfaces statistics`, `clear system config-lock`,
+  `clear security nat statistics`, `clear security nat source
+  persistent-nat-table`, `clear security counters`, `clear security policies
+  hit-count`, `clear firewall all`) enforce EXACT ARITY via
+  `requireClearNoScope`: a trailing scope-looking operand (e.g. `clear arp
+  192.0.2.10`) is REJECTED before any mutation instead of being silently
+  discarded and clearing everything (#5811, extends the #5570 policy-hit-count
+  fix to the whole global-only set). The remote CLI (`cmd/cli/clear.go`) carries
+  a byte-identical `requireClearNoScope` so both parsers reject the same input
+  the same way. Scoped clears (`clear security flow session <filter>`, `clear
+  dhcp client-identifier interface <name>`) are unaffected — they legitimately
+  take a scope.
 - `show security match-policies` (`showMatchPolicies`) and `test policy`
   (`testPolicy`) are THIN adapters over the single shared policy simulator
   `pkg/policymatch` (#3042) — the same matcher the REST and gRPC surfaces

--- a/pkg/cli/cli_clear.go
+++ b/pkg/cli/cli_clear.go
@@ -15,6 +15,25 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// requireClearNoScope rejects any trailing operand on a GLOBAL-ONLY clear
+// command — one whose backend action can ONLY clear everything and has no
+// scoped variant. Such handlers historically recognized a fixed keyword prefix
+// and silently DISCARDED the remaining tokens, then issued the unscoped
+// mutation, so an operator who typed a scope (e.g. `clear arp 192.0.2.10`) got
+// a success message while the ENTIRE cache/table/counter set was wiped (#5811).
+// Require exact arity instead: return an error naming the stray tokens and
+// stating the command takes no scope, BEFORE any mutation runs. cmd is the full
+// command path shown in the message; clears names what it unconditionally
+// clears. The wording is kept byte-identical to cmd/cli's copy so both CLIs
+// reject the same input the same way.
+func requireClearNoScope(cmd, clears string, extra []string) error {
+	if len(extra) == 0 {
+		return nil
+	}
+	return fmt.Errorf("unexpected argument(s) %v after %q; this command clears %s "+
+		"and takes no scope (per-scope clear is not supported)", extra, cmd, clears)
+}
+
 func (c *CLI) handleClear(args []string) error {
 	clearTree := operationalTree["clear"].Children
 	showHelp := func() {
@@ -28,7 +47,7 @@ func (c *CLI) handleClear(args []string) error {
 
 	switch args[0] {
 	case "arp":
-		return c.handleClearArp()
+		return c.handleClearArp(args[1:])
 	case "ipv6":
 		return c.handleClearIPv6(args[1:])
 	case "security":
@@ -52,6 +71,9 @@ func (c *CLI) handleClearSystem(args []string) error {
 		cmdtree.PrintTreeHelp("clear system:", operationalTree, "clear", "system")
 		return nil
 	}
+	if err := requireClearNoScope("clear system config-lock", "the configuration lock", args[1:]); err != nil {
+		return err
+	}
 	holder, locked := c.store.ConfigHolder()
 	if !locked {
 		fmt.Println("No configuration lock held")
@@ -64,6 +86,9 @@ func (c *CLI) handleClearSystem(args []string) error {
 
 func (c *CLI) handleClearInterfaces(args []string) error {
 	if len(args) >= 1 && args[0] == "statistics" {
+		if err := requireClearNoScope("clear interfaces statistics", "all interface statistics", args[1:]); err != nil {
+			return err
+		}
 		fmt.Println("Interface statistics counters noted")
 		fmt.Println("(kernel counters are cumulative and cannot be reset)")
 		return nil
@@ -72,7 +97,10 @@ func (c *CLI) handleClearInterfaces(args []string) error {
 	return nil
 }
 
-func (c *CLI) handleClearArp() error {
+func (c *CLI) handleClearArp(args []string) error {
+	if err := requireClearNoScope("clear arp", "the ARP cache", args); err != nil {
+		return err
+	}
 	out, err := exec.Command("ip", "-4", "neigh", "flush", "all").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("flush ARP: %s", strings.TrimSpace(string(out)))
@@ -85,6 +113,9 @@ func (c *CLI) handleClearIPv6(args []string) error {
 	if len(args) < 1 || args[0] != "neighbors" {
 		cmdtree.PrintTreeHelp("clear ipv6:", operationalTree, "clear", "ipv6")
 		return nil
+	}
+	if err := requireClearNoScope("clear ipv6 neighbors", "the IPv6 neighbor cache", args[1:]); err != nil {
+		return err
 	}
 	out, err := exec.Command("ip", "-6", "neigh", "flush", "all").CombinedOutput()
 	if err != nil {
@@ -104,9 +135,17 @@ func (c *CLI) handleClearSecurity(args []string) error {
 	switch args[0] {
 	case "nat":
 		if len(args) >= 3 && args[1] == "source" && args[2] == "persistent-nat-table" {
+			if err := requireClearNoScope("clear security nat source persistent-nat-table",
+				"the entire persistent NAT table", args[3:]); err != nil {
+				return err
+			}
 			return c.clearPersistentNAT()
 		}
 		if len(args) >= 2 && args[1] == "statistics" {
+			if err := requireClearNoScope("clear security nat statistics",
+				"all NAT translation statistics", args[2:]); err != nil {
+				return err
+			}
 			if c.dp == nil || !c.dp.IsLoaded() {
 				fmt.Println("dataplane not loaded")
 				return nil
@@ -146,20 +185,27 @@ func (c *CLI) handleClearSecurity(args []string) error {
 		return nil
 
 	case "policies":
-		if len(args) >= 2 && args[1] == "hit-count" {
-			if c.dp == nil || !c.dp.IsLoaded() {
-				fmt.Println("dataplane not loaded")
-				return nil
-			}
-			if err := c.dp.ClearPolicyCounters(); err != nil {
-				return fmt.Errorf("clear policy counters: %w", err)
-			}
-			fmt.Println("policy hit counters cleared")
+		if len(args) < 2 || args[1] != "hit-count" {
+			return fmt.Errorf("usage: clear security policies hit-count")
+		}
+		if err := requireClearNoScope("clear security policies hit-count",
+			"all policy hit counters", args[2:]); err != nil {
+			return err
+		}
+		if c.dp == nil || !c.dp.IsLoaded() {
+			fmt.Println("dataplane not loaded")
 			return nil
 		}
-		return fmt.Errorf("usage: clear security policies hit-count")
+		if err := c.dp.ClearPolicyCounters(); err != nil {
+			return fmt.Errorf("clear policy counters: %w", err)
+		}
+		fmt.Println("policy hit counters cleared")
+		return nil
 
 	case "counters":
+		if err := requireClearNoScope("clear security counters", "all counters", args[1:]); err != nil {
+			return err
+		}
 		if c.dp == nil || !c.dp.IsLoaded() {
 			fmt.Println("dataplane not loaded")
 			return nil
@@ -413,6 +459,9 @@ func (c *CLI) handleClearFirewall(args []string) error {
 	if len(args) < 1 || args[0] != "all" {
 		cmdtree.PrintTreeHelp("clear firewall:", operationalTree, "clear", "firewall")
 		return nil
+	}
+	if err := requireClearNoScope("clear firewall all", "all firewall filter counters", args[1:]); err != nil {
+		return err
 	}
 	if c.dp == nil || !c.dp.IsLoaded() {
 		fmt.Println("Dataplane not loaded")

--- a/pkg/cli/cli_clear_exact_arity_5811_test.go
+++ b/pkg/cli/cli_clear_exact_arity_5811_test.go
@@ -1,0 +1,112 @@
+// #5811: global-only `clear` commands (whose backend can ONLY clear
+// everything) previously recognized a fixed keyword prefix and silently
+// DISCARDED any trailing tokens, then performed the unscoped mutation — a
+// scoped-LOOKING command reported success while wiping the ENTIRE
+// cache/counter/table. These tests pin the exact-arity rejection on the
+// IN-PROCESS CLI, mirroring cmd/cli, so the two parsers reject the same input
+// identically.
+//
+// Fail-on-revert: drop a `requireClearNoScope(...)` guard (return to discarding
+// the suffix) and the matching reject test flips RED — no error is returned and
+// (for the dp-backed handlers) the clear method runs.
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// arityClearDP is a cliRuntime that reports IsLoaded()==true and records the
+// destructive dataplane clears a handler would issue, so a test can assert a
+// scoped-looking clear ran NONE of them. It embeds *dataplane.Manager to
+// satisfy the full cliRuntime surface; only IsLoaded + the clear methods are
+// overridden.
+type arityClearDP struct {
+	*dataplane.Manager
+
+	natCounters    int
+	allCounters    int
+	filterCounters int
+	policyCounters int
+}
+
+func (d *arityClearDP) IsLoaded() bool              { return true }
+func (d *arityClearDP) ClearNATRuleCounters() error { d.natCounters++; return nil }
+func (d *arityClearDP) ClearAllCounters() error     { d.allCounters++; return nil }
+func (d *arityClearDP) ClearFilterCounters() error  { d.filterCounters++; return nil }
+func (d *arityClearDP) ClearPolicyCounters() error  { d.policyCounters++; return nil }
+
+func newArityDP() *arityClearDP { return &arityClearDP{Manager: dataplane.New()} }
+
+// A trailing scope operand must ERROR before any dataplane mutation for every
+// global-only clear command.
+func TestClearGlobalOnlyTrailingScopeRejected_5811(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(c *CLI) error
+	}{
+		{"arp addr via dispatch", func(c *CLI) error { return c.handleClear([]string{"arp", "192.0.2.10"}) }},
+		{"arp addr", func(c *CLI) error { return c.handleClearArp([]string{"192.0.2.10"}) }},
+		{"ipv6 neighbors iface", func(c *CLI) error { return c.handleClearIPv6([]string{"neighbors", "interface", "ge-0-0-0"}) }},
+		{"interfaces statistics iface", func(c *CLI) error { return c.handleClearInterfaces([]string{"statistics", "ge-0-0-0"}) }},
+		{"system config-lock session", func(c *CLI) error { return c.handleClearSystem([]string{"config-lock", "session", "42"}) }},
+		{"nat statistics rule", func(c *CLI) error { return c.handleClearSecurity([]string{"nat", "statistics", "rule", "web"}) }},
+		{"nat persistent-nat-table pool", func(c *CLI) error {
+			return c.handleClearSecurity([]string{"nat", "source", "persistent-nat-table", "pool", "p1"})
+		}},
+		{"security counters zone", func(c *CLI) error { return c.handleClearSecurity([]string{"counters", "zone", "untrust"}) }},
+		{"policies hit-count selector", func(c *CLI) error {
+			return c.handleClearSecurity([]string{"policies", "hit-count", "from-zone", "trust"})
+		}},
+		{"firewall all filter", func(c *CLI) error { return c.handleClearFirewall([]string{"all", "filter", "edge"}) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp := newArityDP()
+			// Store intentionally nil: every arity guard returns BEFORE any
+			// store/dataplane/exec access, so a scoped-looking clear never
+			// reaches a mutation.
+			c := &CLI{dp: dp}
+			err := tt.call(c)
+			if err == nil {
+				t.Fatalf("%s: expected an error for a scoped-looking global clear, got nil", tt.name)
+			}
+			if !strings.Contains(err.Error(), "takes no scope") {
+				t.Fatalf("%s: error %q does not explain the no-scope rejection", tt.name, err)
+			}
+			if n := dp.natCounters + dp.allCounters + dp.filterCounters + dp.policyCounters; n != 0 {
+				t.Fatalf("%s: a dataplane clear ran (%d total); a scoped-looking clear must wipe NOTHING", tt.name, n)
+			}
+		})
+	}
+}
+
+// The bare (exact-arity) form of each dp-backed global-only clear still runs.
+func TestClearGlobalOnlyBareStillClears_5811(t *testing.T) {
+	tests := []struct {
+		name  string
+		call  func(c *CLI) error
+		count func(d *arityClearDP) int
+	}{
+		{"nat statistics", func(c *CLI) error { return c.handleClearSecurity([]string{"nat", "statistics"}) }, func(d *arityClearDP) int { return d.natCounters }},
+		{"security counters", func(c *CLI) error { return c.handleClearSecurity([]string{"counters"}) }, func(d *arityClearDP) int { return d.allCounters }},
+		{"policies hit-count", func(c *CLI) error { return c.handleClearSecurity([]string{"policies", "hit-count"}) }, func(d *arityClearDP) int { return d.policyCounters }},
+		{"firewall all", func(c *CLI) error { return c.handleClearFirewall([]string{"all"}) }, func(d *arityClearDP) int { return d.filterCounters }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp := newArityDP()
+			c := &CLI{dp: dp}
+			var err error
+			_ = captureStdout(t, func() { err = tt.call(c) })
+			if err != nil {
+				t.Fatalf("%s: bare form returned unexpected error: %v", tt.name, err)
+			}
+			if got := tt.count(dp); got != 1 {
+				t.Fatalf("%s: bare form ran the clear %d times, want 1", tt.name, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #5811

## Problem
Global-only `clear` handlers — those whose backend action can ONLY clear everything and have no scoped variant — recognized a fixed keyword prefix and silently **discarded** every trailing token, then issued the unscoped mutation. A scoped-**looking** command reported success while wiping the ENTIRE cache/counter/table:

- `clear arp 192.0.2.10`
- `clear ipv6 neighbors interface ge-0-0-0`
- `clear interfaces statistics ge-0-0-0`
- `clear security nat statistics rule web`
- `clear security nat source persistent-nat-table pool p1`
- `clear security counters zone untrust`
- `clear firewall all filter edge`
- `clear system config-lock session 42`

That is a destructive-command footgun (audit/security): the command cannot honor a scope, so it must ERROR rather than silently clear everything and destroy state the operator meant to keep. This generalizes the #5570 fix (which hardened only `clear security policies hit-count`) to the whole global-only set.

## Fix
Add `requireClearNoScope(cmd, clears, extra)` — a small helper returning an `unexpected argument(s) ...; this command clears X and takes no scope` error for any trailing operand, **before** any RPC / dataplane / exec mutation runs. Wired into every global-only clear on **both** parsers:
- Remote CLI: `cmd/cli/clear.go`
- In-process CLI: `pkg/cli/cli_clear.go`

The two helper copies are **byte-identical**, so both parsers reject the same input the same way — restoring arity parity that had diverged (the in-process `policies hit-count` never got the #5570 guard; it does now).

**Not touched** (legitimately scoped): `clear security flow session <filter>` and `clear dhcp client-identifier interface <name>`. Follow-up candidate (out of scope): the in-process `clear dhcp client-identifier` still lacks the remote's #4883-E malformed-selector guard.

## Tests (fail-on-revert)
For arp, nat statistics, security counters, firewall all (plus ipv6 neighbors, interfaces statistics, system config-lock, persistent-nat-table, policies hit-count) on **both** parsers: a scope-looking suffix is rejected with an error **and** issues no RPC / runs no dataplane clear (fake gRPC client + fake `cliRuntime` record call counts), while the bare form still clears.

Fail-on-revert verified via Go `-overlay`: neutralizing `requireClearNoScope` (discard the suffix) flips the reject tests **RED** on both parsers — no error returned, the mutation runs.

## Validation
- `gofmt` clean
- `go build ./...` clean
- `go test ./cmd/cli/ ./pkg/cli/ -count=1` green
- `go vet` clean apart from a pre-existing `cli.go:511` unreachable-code note in an untouched file
- `pkg/cli/README.md` documents the global-only exact-arity contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)