### PR TITLE
config: quarantine SNMP community on malformed clients token (#5833)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-15 — #5833 (bug/audit/security): quarantine SNMP community on malformed clients token (lenient fail-closed)
+- **Timestamp**: 2026-07-15 (fix/5833-snmp-lenient-quarantine)
+- **Action**: #4834 fixed STRICT-commit rejection of malformed SNMP `clients`
+  tokens but its LENIENT load/peer-sync branch preserved the pre-fix runtime
+  behaviour, which is FAIL-OPEN for the `restrict` typo: `clients 0.0.0.0/0
+  restric` (missing 't') detaches the modifier, so `0.0.0.0/0` survives as an
+  unrestricted allow and compileClientNets silently drops only the bad token —
+  on restart/upgrade/peer-sync the community answers from every IPv4 source.
+  Fix: on the lenient path, when a community's `clients` list carries ANY
+  malformed token, QUARANTINE that community to deny-all instead of keeping the
+  surviving broad allow. validateSNMPClients now also returns a `malformed`
+  flag; compileSNMP records it per-community (sticky across #5472 same-name
+  merge blocks so a later well-formed block cannot reopen it) and overrides the
+  community's clientNets enforcement cache with snmpQuarantineClientNets()
+  (explicit `0.0.0.0/0 restrict` + `::/0 restrict` → AllowsSource denies every
+  source). Only the derived clientNets cache is overridden, NOT comm.Clients
+  (the config surface marshaled to the API / hashed by the SNMP reconcile), so
+  the operator's config text is preserved for display/change-detection; only
+  runtime enforcement is forced closed. The rest of the config (other
+  communities, other stanzas) still loads with a warning. Strict commit path
+  unchanged (still hard-rejects). Well-formed communities are not
+  quarantined (no false positives).
+- **Validation**: gofmt clean; go build ./... + go vet ./pkg/config + go test
+  ./pkg/config green. Fail-on-revert: neutralizing the clientNets override makes
+  the quarantined community allow 8.8.8.8/10.1.2.3/192.168.1.1 → RED; restored →
+  GREEN. New tests assert deny-all + rest-of-config-loads + no-false-quarantine;
+  strict-reject tests unchanged.
+- **File(s)**: pkg/config/snmp_clients.go (Edit),
+  pkg/config/compiler_system.go (Edit),
+  pkg/config/snmp_clients_4834_test.go (Edit),
+  docs/feature-coverage.md (Edit), _Log.md (Edit)
+
 ## 2026-07-15 — #5738 (bug/syslog) commit 2/2: CLI reloadSyslog source-iface + event-mode parity
 - **Timestamp**: 2026-07-15 (fix/5738-syslog-source-iface-parity)
 - **Action**: Aligned the CLI in-process commit path (reloadSyslog /

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -250,6 +250,14 @@ the userspace dataplane admission boundary is in
   into one entry before the immutable client-prefix cache is built, so a later
   duplicate with NO `clients` cannot overwrite an earlier block and silently
   erase its allowlist (an empty allowlist reads as allow-all → fail-open).
+  A malformed `clients` token is REJECTED at commit (#4834) and, on the tolerant
+  load / peer-sync path, QUARANTINES the affected community to deny-all (#5833):
+  a mistyped `restrict` (e.g. `0.0.0.0/0 restric`) detaches from its prefix and
+  used to leave a surviving unrestricted `0.0.0.0/0` allow, so on
+  restart/upgrade/peer-sync the community answered from every source. The lenient
+  path now compiles that community fail-CLOSED (`snmpQuarantineClientNets` →
+  deny-all) instead of fail-open, while the rest of the config loads with a
+  warning; the strict commit path still rejects it outright.
   Trap-group `categories` ENFORCED (#5522): `snmp trap-group <g> categories
   [ <cat> ]` scopes which notification categories a group receives — a link
   up/down trap (category `link`) is dispatched to a group only if the group

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1223,6 +1223,14 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 		V3Users:     make(map[string]*SNMPv3User),
 	}
 
+	// #5833: communities whose `clients` allowlist carried a malformed token on
+	// the tolerant load / peer-sync path are quarantined to deny-all. Sticky
+	// across same-name merge blocks (#5472): once a community is quarantined a
+	// LATER well-formed block must NOT un-quarantine it (its policy is no longer
+	// trustworthy). Empty on the strict path (a malformed token hard-rejects
+	// before it can be recorded here).
+	quarantinedComms := map[string]bool{}
+
 	for _, child := range node.Children {
 		switch child.Name() {
 		case "location":
@@ -1273,12 +1281,18 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 				// earlier block's entries were already validated (and, strict,
 				// would have aborted), so re-validating the accumulated list
 				// would double-report the same warning.
-				clientWarnings, err := validateSNMPClients(blockClients, lenient)
+				clientWarnings, blockMalformed, err := validateSNMPClients(blockClients, lenient)
 				if err != nil {
 					return err
 				}
 				if cfg != nil {
 					cfg.Warnings = append(cfg.Warnings, clientWarnings...)
+				}
+				// #5833: a malformed token on the lenient path quarantines the
+				// community (strict already aborted above). Record it BEFORE the
+				// clientNets build below so the deny-all override wins.
+				if blockMalformed {
+					quarantinedComms[commName] = true
 				}
 				// #5472: same-name `community` blocks MERGE into one entry
 				// instead of a plain map overwrite. Junos treats two
@@ -1316,6 +1330,15 @@ func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error
 				// the config is published to the SNMP agent, so the cache is
 				// set with no concurrent readers.
 				comm.clientNets = compileClientNets(comm.Clients)
+				// #5833: fail CLOSED for a quarantined community. compileClientNets
+				// above would drop the malformed token and leave the surviving
+				// broad allow live (fail-open); override the enforcement cache with
+				// an explicit deny-all so no source can query this community until
+				// the operator fixes the typo. Sticky across merge blocks, so a
+				// later well-formed block for the same community cannot reopen it.
+				if quarantinedComms[commName] {
+					comm.clientNets = snmpQuarantineClientNets()
+				}
 			}
 		case "trap-group":
 			tgName := nodeVal(child)

--- a/pkg/config/snmp_clients.go
+++ b/pkg/config/snmp_clients.go
@@ -177,18 +177,26 @@ func parseSNMPClients(node *Node) []SNMPClient {
 // prefix typo now also gets a clear error instead of a silently-shrunk
 // allowlist. Strict (commit / commit-check): hard-reject, naming the bad
 // token. Lenient (load / peer-sync): warn so an already-persisted config
-// an older binary accepted still boots (#1960 fail-closed-on-load class);
-// compileClientNets keeps dropping the entry on that path, matching the
-// pre-#4834 behavior exactly.
+// an older binary accepted still boots (#1960 fail-closed-on-load class).
+//
+// #5833: on the LENIENT path the caller must NOT keep the surviving broad
+// allow live. Dropping the malformed token and compiling the rest of the
+// allowlist normally is FAIL-OPEN: `0.0.0.0/0 restric` degrades to a plain
+// `0.0.0.0/0` allow, so on restart/upgrade/peer-sync the community becomes
+// answerable from every source — a warning does not make that safe. The
+// second return value reports whether ANY entry was malformed so the caller
+// (compileSNMP) can QUARANTINE the affected community to deny-all
+// (snmpQuarantineClientNets) instead. The warning is preserved either way.
 //
 // The message never includes the community NAME (a secret, per the
 // snmpInertKnobWarnings convention) — only the offending token, which is
 // an IP/CIDR literal or a keyword typo, not a credential.
-func validateSNMPClients(clients []SNMPClient, lenient bool) (warnings []string, err error) {
+func validateSNMPClients(clients []SNMPClient, lenient bool) (warnings []string, malformed bool, err error) {
 	for _, cl := range clients {
 		if _, _, perr := parseClientPrefix(cl.Prefix); perr == nil {
 			continue
 		}
+		malformed = true
 		msg := fmt.Sprintf(
 			"snmp community clients entry %q is not a valid IP/CIDR prefix "+
 				"(if this was meant to be the \"restrict\" keyword, check for a "+
@@ -197,10 +205,36 @@ func validateSNMPClients(clients []SNMPClient, lenient bool) (warnings []string,
 				"unrestricted allow)",
 			cl.Prefix)
 		if lenient {
-			warnings = append(warnings, msg+" (ignored: entry dropped from the allowlist)")
+			warnings = append(warnings, msg+" (the affected community is quarantined to deny-all until the typo is fixed)")
 			continue
 		}
-		return nil, fmt.Errorf("%s", msg)
+		return nil, true, fmt.Errorf("%s", msg)
 	}
-	return warnings, nil
+	return warnings, malformed, nil
+}
+
+// snmpQuarantineClientNets returns a fail-CLOSED SNMP client match set: an
+// explicit `restrict` on all IPv4 (0.0.0.0/0) and all IPv6 (::/0) sources, so
+// SNMPCommunity.AllowsSource denies every query regardless of source family.
+//
+// It is installed on a community whose `clients` allowlist carried a MALFORMED
+// token on the tolerant load / peer-sync path (#5833). The strict commit path
+// rejects such a config outright; the lenient path must still boot (#1960), but
+// silently dropping the bad token and keeping the surviving broad allow is
+// fail-OPEN (the `restrict` typo turns `0.0.0.0/0 restrict` into an
+// unrestricted allow answerable from every source). Quarantining to deny-all
+// makes the lenient path fail CLOSED for the affected community while the rest
+// of the config loads, until the operator fixes the typo.
+//
+// This overrides only clientNets (the derived enforcement cache), not
+// comm.Clients (the config surface marshaled to the API / hashed by the SNMP
+// reconcile): the operator's config text is preserved for display and
+// change-detection; only runtime enforcement is forced closed.
+func snmpQuarantineClientNets() []compiledSNMPClient {
+	_, v4, _ := net.ParseCIDR("0.0.0.0/0")
+	_, v6, _ := net.ParseCIDR("::/0")
+	return []compiledSNMPClient{
+		{net: v4, ones: 0, restrict: true},
+		{net: v6, ones: 0, restrict: true},
+	}
 }

--- a/pkg/config/snmp_clients_4834_test.go
+++ b/pkg/config/snmp_clients_4834_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"strings"
 	"testing"
 )
@@ -46,19 +47,29 @@ func TestSNMPClients_MalformedPrefixRejected(t *testing.T) {
 	}
 }
 
-// TestSNMPClients_RestrictTypoLenientWarns pins the no-brick contract
-// (#1960 doctrine): the malformed token the STRICT path rejects is
-// tolerated on the lenient load/peer-sync path, downgraded to a warning
-// so an already-persisted config an older binary accepted still boots.
-// compileClientNets keeps silently dropping the unparseable entry on this
-// path, matching pre-#4834 runtime behavior exactly (the warning is the
-// only new signal).
-func TestSNMPClients_RestrictTypoLenientWarns(t *testing.T) {
+// TestSNMPClients_RestrictTypoLenientQuarantines pins the #5833 fail-CLOSED
+// contract on the tolerant load / peer-sync path. The malformed token the
+// STRICT path rejects must NOT brick the node (#1960), but it must also NOT
+// leave the surviving broad allow live: `0.0.0.0/0 restric` + `10.0.0.0/8`
+// used to drop the bad token and keep `0.0.0.0/0` as a plain allow, so on
+// restart/upgrade/peer-sync the community answered from EVERY source (fail
+// open). The community is now QUARANTINED to deny-all instead, while the rest
+// of the config (a second, well-formed community) still loads, and the warning
+// is preserved.
+//
+// FAIL-ON-REVERT: reverting the quarantine (dropping the malformed token and
+// keeping the surviving 0.0.0.0/0 allow) makes AllowsSource("8.8.8.8") return
+// true, so the deny assertions below fire RED.
+func TestSNMPClients_RestrictTypoLenientQuarantines(t *testing.T) {
 	tree := &ConfigTree{}
 	lines := []string{
 		"set snmp community mon authorization read-only",
 		"set snmp community mon clients 0.0.0.0/0 restric",
 		"set snmp community mon clients 10.0.0.0/8",
+		// A second, WELL-FORMED community: the quarantine is scoped to the
+		// affected community, and the REST of the config must still load.
+		"set snmp community pub authorization read-only",
+		"set snmp community pub clients 192.168.0.0/16",
 	}
 	for _, line := range lines {
 		path, err := ParseSetCommand(line)
@@ -75,6 +86,76 @@ func TestSNMPClients_RestrictTypoLenientWarns(t *testing.T) {
 	}
 	if !hasWarningSubstr(cfg.Warnings, "restric") {
 		t.Fatalf("expected a downgraded clients-token warning naming 'restric', warnings=%v", cfg.Warnings)
+	}
+
+	mon := cfg.System.SNMP.Communities["mon"]
+	if mon == nil {
+		t.Fatal("community 'mon' missing from compiled config")
+	}
+	// Quarantined = DENY-ALL. Every source is denied — the surviving broad
+	// 0.0.0.0/0 allow (and the 10.0.0.0/8 allow) must NOT be honored, and IPv6
+	// is denied too.
+	for _, src := range []string{"8.8.8.8", "10.1.2.3", "192.168.1.1", "2001:db8::1"} {
+		if mon.AllowsSource(net.ParseIP(src)) {
+			t.Errorf("quarantined community must DENY %s, but it was allowed "+
+				"(fail-open: the broad allow survived the malformed \"restrict\" token, #5833)", src)
+		}
+	}
+
+	// The rest of the config loaded: the well-formed community keeps its
+	// intended allowlist policy (no false quarantine of a sibling community).
+	pub := cfg.System.SNMP.Communities["pub"]
+	if pub == nil {
+		t.Fatal("well-formed community 'pub' missing — the rest of the config failed to load")
+	}
+	if !pub.AllowsSource(net.ParseIP("192.168.1.1")) {
+		t.Error("well-formed community 'pub' must ALLOW its listed source 192.168.1.1")
+	}
+	if pub.AllowsSource(net.ParseIP("8.8.8.8")) {
+		t.Error("well-formed community 'pub' must DENY an unlisted source 8.8.8.8")
+	}
+}
+
+// TestSNMPClients_WellFormedLenientNoQuarantine confirms the #5833 quarantine
+// does not over-fire: a well-formed clients allowlist on the LENIENT path keeps
+// its intended longest-prefix restrict/allow semantics (a correctly-spelled
+// `restrict` is the modifier, never a malformed prefix entry), with no warning
+// and no deny-all quarantine.
+func TestSNMPClients_WellFormedLenientNoQuarantine(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set snmp community mon authorization read-only",
+		"set snmp community mon clients 10.0.0.0/8 restrict", // deny the /8...
+		"set snmp community mon clients 10.1.0.0/16",         // ...except this more-specific /16
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient failed on a well-formed allowlist: %v", err)
+	}
+	if hasWarningSubstr(cfg.Warnings, "restric") {
+		t.Fatalf("well-formed clients must not produce a token warning, warnings=%v", cfg.Warnings)
+	}
+	mon := cfg.System.SNMP.Communities["mon"]
+	if mon == nil {
+		t.Fatal("community 'mon' missing from compiled config")
+	}
+	// Longest-prefix restrict semantics intact (no false quarantine):
+	//   10.2.3.4 -> matched only by 10.0.0.0/8 restrict -> DENY
+	//   10.1.2.3 -> matched by more-specific 10.1.0.0/16 allow           -> ALLOW
+	if mon.AllowsSource(net.ParseIP("10.2.3.4")) {
+		t.Error("10.0.0.0/8 restrict must DENY 10.2.3.4")
+	}
+	if !mon.AllowsSource(net.ParseIP("10.1.2.3")) {
+		t.Error("more-specific 10.1.0.0/16 allow must PERMIT 10.1.2.3 (false quarantine?)")
 	}
 }
 


### PR DESCRIPTION
Closes #5833

## Problem (bug / audit / security — fail-open)

#4834 added STRICT-commit rejection of a malformed SNMP `clients` token, but its LENIENT load / peer-sync branch deliberately preserved pre-fix runtime behaviour — which is **fail-OPEN** for the `restrict` typo. Given:

```
clients 0.0.0.0/0 restric   # typo: missing 't'
clients 10.0.0.0/8
```

`restric` is not the exact `restrict` keyword, so `parseSNMPClients` treats it as its own (unparseable) prefix entry and it **detaches** from the preceding `0.0.0.0/0`. `compileClientNets` then silently drops the bad token and leaves `0.0.0.0/0` as a plain **allow** — so on restart / upgrade / peer-sync the community becomes answerable from **every IPv4 source**. A warning doesn't make that safe.

Trace: `pkg/config/snmp_clients.go` (tokenizer detaches the modifier; lenient `validateSNMPClients` warned + continued), `pkg/config/snmp_clients_4834_test.go` (lenient test only checked the warning, not the runtime policy).

## Fix — lenient fail-CLOSED quarantine

On the tolerant load / peer-sync path, when a community's `clients` list carries ANY malformed token, **quarantine that community to deny-all** instead of keeping the surviving broad allow:

- `validateSNMPClients` now also returns a `malformed` flag (strict path still hard-rejects; the flag drives the lenient quarantine).
- `compileSNMP` records malformed communities in a per-community set that is **sticky across #5472 same-name merge blocks** (a later well-formed block cannot reopen a quarantined community), and overrides the community's `clientNets` enforcement cache with `snmpQuarantineClientNets()` — an explicit `0.0.0.0/0 restrict` + `::/0 restrict` match set so `AllowsSource` denies every source, both families.
- **Only the derived `clientNets` enforcement cache is overridden, NOT `comm.Clients`** (the config surface marshaled to the API and hashed by the SNMP reconcile fingerprint). The operator's config text is preserved for display / change-detection; only runtime enforcement is forced closed until the typo is fixed.

Strict commit / commit-check is unchanged (still hard-rejects, naming the bad token). Well-formed communities are never quarantined, and the rest of the config still loads with a warning (#1960 no-brick) — just fail-closed for the affected object rather than fail-open.

## Tests (fail-on-revert)

`pkg/config/snmp_clients_4834_test.go`:

- **`TestSNMPClients_RestrictTypoLenientQuarantines`** (replaces the old warn-only lenient test) — lenient compile of the `0.0.0.0/0 restric` + `10.0.0.0/8` config: the affected community DENIES `8.8.8.8` / `10.1.2.3` / `192.168.1.1` / `2001:db8::1` (deny-all, not the surviving broad allow), a sibling well-formed community still loads with its intended policy, and the `restric` warning is recorded. **FAIL-ON-REVERT verified**: neutralizing the `clientNets` deny-all override makes the community ALLOW `8.8.8.8`/`10.1.2.3`/`192.168.1.1` → RED; restored → GREEN.
- **`TestSNMPClients_WellFormedLenientNoQuarantine`** — a well-formed `10.0.0.0/8 restrict` + `10.1.0.0/16` allowlist keeps its longest-prefix restrict/allow semantics on the lenient path (no false quarantine, no warning).
- **`TestSNMPClients_RestrictTypoRejected` / `TestSNMPClients_MalformedPrefixRejected`** — strict mode still ERRORS on the malformed token (unchanged).

## Validation

`gofmt` clean on touched files; `go build ./...` + `go vet ./pkg/config/` clean; `go test ./pkg/config/ -count=1` green. Doc: `docs/feature-coverage.md` SNMP section updated with the #5833 quarantine note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)