### PR TITLE
daemon: fail commit closed on routing-rule reconcile failure (#5844)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-15 — #5844 (bug/security/HIGH): routing-rule reconcile errors fail the commit closed
+- **Timestamp**: 2026-07-15 (fix/5844-routing-rule-reconcile-failclosed)
+- **Action**: `pkg/routing` correctly RETURNS next-table / rib-group / PBR
+  ip-rule reconcile failures, but the daemon call site (`applyRoutingRules`,
+  pkg/daemon/daemon_apply.go) was VOID and LOGGED-and-DROPPED them. So a commit
+  was ACKNOWLEDGED after a partial clear/add left stale-or-missing cross-VRF
+  policy in the kernel — and the immediately-following userspace route snapshot
+  (`reconcileRouteLeakSnapshot`) canonized that partial live kernel state into
+  the FIB. Made `applyRoutingRules` RETURN `errors.Join` of the three kernel
+  reconcile failures (ApplyNextTableRules / ApplyRibGroupRules / ApplyPBRRules),
+  collected while STILL running every rule type after one fails (fail-closed but
+  COMPLETE), keeping the per-error logging. `applyConfigLocked` captures it
+  (`routingRuleErr`) and threads it into the SAME tail `errors.Join` sink the
+  snapshot error uses (new final `applyTailReconciles` param); the snapshot
+  republish still runs first (ordering preserved). Mirrors the #5310 ifaceErr /
+  #5696 routeLeakErr deferred-error pattern. `BuildPBRRules` *build degradation*
+  is deliberately NOT joined — it is a fail-SAFE representability under-steer
+  (unrepresentable-as-ip-rule term dropped to the main table, still enforced by
+  the userspace filter path), not a partial kernel mutation, so fail-closing it
+  would reject configs that commit fine today.
+- **Validation**: gofmt clean; go build ./...; go test ./pkg/daemon/
+  ./pkg/routing/ -count=1 green; go vet ./pkg/daemon/ clean. Fail-on-revert
+  proven via overlay: dropping routingRuleErr from the tail join flips
+  TestApplyTailReconcilesSurfacesRoutingRuleError_5844 RED (commit returns nil
+  despite the injected failure); reverting applyRoutingRules to void breaks
+  compilation of the direct test.
+- **File(s)**: pkg/daemon/daemon_apply.go (Edit),
+  pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go (Write),
+  pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go (Edit, arity),
+  pkg/daemon/route_leak_snapshot_failclosed_5696_test.go (Edit, arity),
+  pkg/daemon/device_map_teardown_failclosed_5309_test.go (Edit, arity),
+  pkg/daemon/README.md (Edit), _Log.md (Edit)
+
 ## 2026-07-15 — #5738 (bug/syslog) commit 2/2: CLI reloadSyslog source-iface + event-mode parity
 - **Timestamp**: 2026-07-15 (fix/5738-syslog-source-iface-parity)
 - **Action**: Aligned the CLI in-process commit path (reloadSyslog /

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -605,6 +605,30 @@ never lock an operator out of a remote box it manages.
   (publish-fails-commit + bump-fails-commit fail-on-revert, duplicate-skip /
   helperless / clean-success stay-success, and the `applyTailReconciles` commit-join
   wiring proof).
+  **Routing-rule reconcile fail-closed (#5844, mirroring #5310/#5696):**
+  `applyRoutingRules` reconciles the kernel policy-routing (`ip rule`) table —
+  next-table (`ApplyNextTableRules`), rib-group (`ApplyRibGroupRules`), and
+  PBR/filter-based-forwarding (`ApplyPBRRules`). Each of those managers already
+  RETURNS a fail-closed error (a partial clear/add leaves stale-or-missing
+  cross-VRF policy in the kernel — `#3731`/`#5118`/`#2273`), but
+  `applyRoutingRules` was VOID and LOGGED-and-DROPPED all three, so a commit was
+  acknowledged after a partial reconcile — and the immediately-following
+  `reconcileRouteLeakSnapshot` then canonized that partial live kernel state into
+  the userspace FIB. It now collects the three errors via `errors.Join` (still
+  running every rule type after one fails — fail-closed but COMPLETE) and RETURNS
+  them; `applyConfigLocked` captures it (`routingRuleErr`) and threads it into the
+  tail `errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err,
+  ipsecErr, ifaceErr, routeLeakErr, routingRuleErr)`, so a partial ip-rule
+  reconcile fails the commit closed. The snapshot republish still runs (ordering
+  preserved: the deferred error does not abort it). `BuildPBRRules` *build
+  degradation* is DELIBERATELY not joined — a filter term that cannot be expressed
+  as an `ip rule` is a fail-SAFE under-steer (dropped to the main table, still
+  enforced by the userspace filter path), a representability warning rather than a
+  partial kernel mutation, so fail-closing it would reject configs that commit
+  fine today. Tests: `routing_rule_reconcile_failclosed_5844_test.go` (direct
+  applyRoutingRules fails-closed-and-complete via a `RuleList`-failing
+  `NewManagerWithRuleOpsForTest` fake, clean-config stays-success, and the
+  `applyTailReconciles` commit-join wiring proof).
   **Per-term disposition mirrors userspace (#3427):** `nftRulesFromTerm` maps a
   term's `then` action to the kernel verdict the SAME way the userspace lo0
   evaluator does (`pkg/dataplane/userspace/filters.go` `NextTerm =

--- a/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
+++ b/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
@@ -247,7 +247,7 @@ func TestApplyTailReconcilesSurfacesInterfaceReconcileError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: interface reconcile (xfrmi create) failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the interface-reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -798,7 +798,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		return d.closeoutHostAuthOnCancel(err, cfg)
 	}
 
-	d.applyRoutingRules(cfg, commitOverlay)
+	// #5844: applyRoutingRules RETURNS the joined next-table / rib-group / PBR
+	// ip-rule reconcile failures (a partial clear/add left stale-or-missing
+	// cross-VRF policy in the kernel). Capture it as a DEFERRED error — the
+	// snapshot republish below still runs (so it is not left stale), and the
+	// failure is threaded into the tail commit-error join so the commit fails
+	// closed instead of being acknowledged after a partial reconcile.
+	routingRuleErr := d.applyRoutingRules(cfg, commitOverlay)
 
 	// #5642: the full dataplane apply (applyDataplaneAndHACore → d.dp.ApplyConfig)
 	// ran BEFORE applyRoutingRules and built its userspace route snapshot from the
@@ -831,9 +837,11 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// errors (networkdErr/applyErr/dhcpServerErr/ipsecErr/ifaceErr) are threaded
 	// in — applyErr is the #5679 ordinary (non-abort) dataplane-apply failure
 	// that must fail the commit without disarming/aborting; routeLeakErr is the
-	// #5696 route-leak republish/FIB-bump failure; the helper creates
-	// lo0Err/hostInboundErr and returns the joined errors.
-	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr)
+	// #5696 route-leak republish/FIB-bump failure; routingRuleErr is the #5844
+	// next-table/rib-group/PBR ip-rule reconcile failure (a partial kernel
+	// policy-routing clear/add); the helper creates lo0Err/hostInboundErr and
+	// returns the joined errors.
+	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr)
 }
 
 // applyHostAuthorizationCloseout runs ONLY the security-critical host-
@@ -1503,7 +1511,20 @@ func (d *Daemon) applyServicesReconcile(cfg *config.Config) (error, error) {
 // early return. commitOverlay is the ip-monitoring route overlay folded into
 // the FRR assembly. Runs in the same slot, after the dataplane apply / RETH-MAC
 // sequence and before proactive neighbor resolution.
-func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.RouteOverlayEntry) {
+func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.RouteOverlayEntry) error {
+	// #5844: the kernel policy-routing (ip rule) reconciles below —
+	// next-table, rib-group, and PBR/filter-based-forwarding — each already
+	// RETURN a fail-closed error: a partial clear/add leaves stale-or-missing
+	// cross-VRF policy in the kernel, and the immediately-following userspace
+	// route snapshot (reconcileRouteLeakSnapshot) canonizes that partial live
+	// kernel state. The pre-#5844 call site LOGGED and DROPPED those returns, so
+	// a commit was acknowledged after a partial reconcile. Collect them here and
+	// return the joined error to applyConfigLocked, which threads it into the
+	// tail commit-error join. Fail-closed BUT complete: a single rule-type
+	// failure does NOT skip the others — every rule type runs, then the joined
+	// error surfaces (mirroring the #5310 ifaceErr / #5696 routeLeakErr pattern).
+	var routingErrs []error
+
 	// 3. Apply all routes + dynamic protocols via FRR.
 	// assembleFRRConfig is the SOLE frr.FullConfig constructor, shared
 	// with the ip-monitoring routes-only actuator (#1827) — the full
@@ -1544,6 +1565,7 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 		allRoutes = append(allRoutes, cfg.RoutingOptions.Inet6StaticRoutes...)
 		if err := d.routing.ApplyNextTableRules(allRoutes, cfg.RoutingInstances); err != nil {
 			slog.Warn("failed to apply next-table rules", "err", err)
+			routingErrs = append(routingErrs, fmt.Errorf("apply next-table rules: %w", err))
 		}
 	}
 
@@ -1571,6 +1593,7 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 		connectedPrefixes := config.RibGroupConnectedPrefixes(cfg)
 		if err := d.routing.ApplyRibGroupRules(cfg.RoutingOptions.RibGroups, cfg.RoutingInstances, connectedPrefixes); err != nil {
 			slog.Warn("failed to apply rib-group rules", "err", err)
+			routingErrs = append(routingErrs, fmt.Errorf("apply rib-group rules: %w", err))
 		}
 	}
 
@@ -1585,14 +1608,34 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 	if d.routing != nil {
 		pbrRules, buildErr := routing.BuildPBRRules(cfg)
 		if buildErr != nil {
+			// #5844: buildErr is DELIBERATELY not joined into the commit-error.
+			// It is a fail-SAFE representability degradation, not a partial
+			// kernel mutation: a filter term that cannot be expressed as an ip
+			// rule (port-except / tcp-flags / icmp / is-fragment / flex /
+			// overflow) is DROPPED to under-steer to the main table, and the
+			// userspace filter path still enforces it. ApplyPBRRules(pbrRules)
+			// below fully reconciles whatever WAS built (deleting any stale
+			// rule), so no stale-or-missing cross-VRF policy survives — the
+			// #5844 bug class. Fail-closing on buildErr would instead REJECT
+			// configs with such terms that commit fine today, so it stays a
+			// warn-and-continue.
 			slog.Warn("PBR rule build degraded; some routing-instance filter terms "+
 				"are not mirrored to the kernel FBF path and fall back to the main "+
 				"table (userspace filter path still enforces them)", "err", buildErr)
 		}
+		// ApplyPBRRules IS a kernel reconcile: a failed clear/add leaves a
+		// half-installed FBF policy in the kernel ip-rule table, so its error is
+		// joined into the commit-error (fail-closed).
 		if err := d.routing.ApplyPBRRules(pbrRules); err != nil {
 			slog.Warn("failed to apply PBR rules", "err", err)
+			routingErrs = append(routingErrs, fmt.Errorf("apply PBR rules: %w", err))
 		}
 	}
+
+	// Fail-closed but COMPLETE: every rule type above ran regardless of an
+	// earlier failure; surface the joined error so a partial ip-rule reconcile
+	// fails the commit instead of being silently acknowledged (#5844).
+	return errors.Join(routingErrs...)
 }
 
 // reconcileRouteLeakSnapshot republishes the userspace route snapshot after
@@ -1991,7 +2034,7 @@ func (d *Daemon) applyInterfaceReconcile(cfg *config.Config) error {
 // lo0Err/hostInboundErr originate in step 9.5 below. The returned errors.Join
 // preserves the exact operand order the inline tail used
 // (#1778/#2987/#4433/#5310/#5679/#5696).
-func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr error) error {
+func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr error) error {
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	vrrpInstances := vrrp.CollectInstances(cfg)
 	if d.cluster != nil {
@@ -2262,7 +2305,7 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	// that left stale or missing kernel/swanctl/dataplane state fails the commit
 	// (fail-closed) instead of reporting success. All are joined so none masks the
 	// other.
-	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr, routeLeakErr)
+	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr)
 }
 
 // compileErrorMustAbortApply reports whether a dataplane ApplyConfig error

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1610,14 +1610,31 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 		if buildErr != nil {
 			// #5844: buildErr is DELIBERATELY not joined into the commit-error.
 			// It is a fail-SAFE representability degradation, not a partial
-			// kernel mutation: a filter term that cannot be expressed as an ip
-			// rule (port-except / tcp-flags / icmp / is-fragment / flex /
-			// overflow) is DROPPED to under-steer to the main table, and the
-			// userspace filter path still enforces it. ApplyPBRRules(pbrRules)
+			// kernel mutation. The kernel ip rule (BuildPBRRules) is only a
+			// MIRROR of the userspace FBF steer for SLOW-PATH (XDP_PASS) packets
+			// (rules.go: "the kernel also honors PBR for XDP_PASS'd packets, e.g.
+			// SNAT'd traffic destined for a VRF/GRE tunnel"). The AUTHORITATIVE
+			// fast-path enforcement of a `then routing-instance` term — with the
+			// FULL L4 match the kernel ip rule cannot express (port-except /
+			// tcp-flags / icmp / is-fragment / flex) — is the userspace filter
+			// engine: buildFilterTermSnapshots carries term.RoutingInstance +
+			// the full match into the FirewallTermSnapshot
+			// (pkg/dataplane/userspace/filters.go), and the Rust evaluator sets
+			// acc.routing_instance = term.routing_instance on a full-term match
+			// (userspace-dp/src/filter/engine/eval.rs
+			// evaluate_interface_filter_routing_instance_*). So a term that
+			// cannot be mirrored to an ip rule is DROPPED from the kernel mirror
+			// only; on the fast path it is still steered, and a slow-path packet
+			// UNDER-steers to the main table (the fail-safe direction — never an
+			// address-only OVER-steer / cross-VRF leak, rules.go BuildPBRRules).
+			// The degradation is already observable (this WARN + the #4422
+			// PBRBuildStats degraded gauge), not silent. ApplyPBRRules(pbrRules)
 			// below fully reconciles whatever WAS built (deleting any stale
-			// rule), so no stale-or-missing cross-VRF policy survives — the
-			// #5844 bug class. Fail-closing on buildErr would instead REJECT
-			// configs with such terms that commit fine today, so it stays a
+			// rule), so no stale-or-missing cross-VRF policy survives in the
+			// mirror — the #5844 bug class is the netlink RuleAdd/RuleDel failure
+			// below, not this representability drop. Fail-closing on buildErr
+			// would instead REJECT configs with such terms that commit fine
+			// today AND are enforced on the fast path, so it stays a
 			// warn-and-continue.
 			slog.Warn("PBR rule build degraded; some routing-instance filter terms "+
 				"are not mirrored to the kernel FBF path and fall back to the main "+

--- a/pkg/daemon/device_map_teardown_failclosed_5309_test.go
+++ b/pkg/daemon/device_map_teardown_failclosed_5309_test.go
@@ -262,7 +262,7 @@ func TestApplyTailReconcilesSurfacesDeviceMapTeardownError_5309(t *testing.T) {
 
 	teardownErr := fmt.Errorf("device-map teardown: %w",
 		errors.New("rename-back ge-0-0-9 -> enp99s0: EBUSY"))
-	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface a device-map teardown failure carried " +
 			"in networkdErr (fail-closed); got nil")

--- a/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
+++ b/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
@@ -145,7 +145,7 @@ func TestApplyTailReconcilesSurfacesRouteLeakError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: route-leak snapshot republish failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, injected)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, injected, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the route-leak reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
+++ b/pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
@@ -1,0 +1,142 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/routing"
+	"github.com/psaab/xpf/pkg/vrrp"
+	"github.com/vishvananda/netlink"
+)
+
+// #5844: pkg/routing correctly RETURNS next-table / rib-group / PBR ip-rule
+// reconcile failures, but applyRoutingRules used to LOG-and-DROP them. So a
+// commit was acknowledged after a partial clear/add left stale-or-missing
+// cross-VRF policy in the kernel — and the immediately-following userspace route
+// snapshot (reconcileRouteLeakSnapshot) then canonized that partial live kernel
+// state. The fix makes applyRoutingRules RETURN the joined error and threads it
+// (routingRuleErr) into the tail commit-error join, fail-closed BUT complete
+// (every rule type still runs, then the joined error surfaces).
+
+// fakeRuleOps5844 is a minimal ruleOps double (RuleAdd/RuleDel/RuleList — all
+// exported, so it structurally satisfies pkg/routing's unexported ruleOps and
+// can back a routing.Manager via NewManagerWithRuleOpsForTest). A non-nil
+// listErr makes every per-family RuleList dump fail, which each rule manager's
+// clear() surfaces as a returned error — the partial-reconcile signal #5844
+// must not drop. listCalls counts how many times RuleList ran so a test can
+// prove all three rule types (next-table, rib-group, PBR) executed even after
+// one failed (fail-closed but COMPLETE).
+type fakeRuleOps5844 struct {
+	listErr   error
+	listCalls int
+	addCalls  int
+	delCalls  int
+}
+
+func (f *fakeRuleOps5844) RuleAdd(*netlink.Rule) error { f.addCalls++; return nil }
+func (f *fakeRuleOps5844) RuleDel(*netlink.Rule) error { f.delCalls++; return nil }
+func (f *fakeRuleOps5844) RuleList(int) ([]netlink.Rule, error) {
+	f.listCalls++
+	return nil, f.listErr
+}
+
+// TestApplyRoutingRulesFailsClosedAndComplete_5844 drives the REAL
+// applyRoutingRules against a routing.Manager whose ip-rule ops fail, and
+// asserts it (a) RETURNS the failure (fail-closed) and (b) STILL ran every rule
+// type (complete — a single rule-type failure does not skip the others). frr is
+// nil so the FRR block is a no-op and the ip-rule reconciles are isolated.
+//
+// FAIL-ON-REVERT: revert applyRoutingRules to its void, log-and-drop form and
+// this test stops compiling (no error to assign) — the silent partial-reconcile
+// acknowledgement #5844 describes.
+func TestApplyRoutingRulesFailsClosedAndComplete_5844(t *testing.T) {
+	injected := errors.New("injected: RuleList EPERM")
+	fake := &fakeRuleOps5844{listErr: injected}
+	d := &Daemon{routing: routing.NewManagerWithRuleOpsForTest(fake)}
+
+	// A minimal config: no next-table routes / rib-groups / PBR filters. Each
+	// rule manager's clear() still lists the kernel per family up front, so the
+	// injected RuleList failure surfaces from all three even with empty desired
+	// state — exactly the partial-reconcile window #5844 fails closed on.
+	cfg := &config.Config{}
+
+	err := d.applyRoutingRules(cfg, nil)
+	if err == nil {
+		t.Fatal("applyRoutingRules must return the ip-rule reconcile failure " +
+			"(fail-closed); got nil — the dropped-from-commit-truth bug #5844 describes")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned error must wrap the injected ip-rule failure, got %v", err)
+	}
+	// Complete: next-table + rib-group + PBR each ran clear() → RuleList per
+	// family (AF_INET + AF_INET6). Six total proves all three rule types
+	// executed even though the first already failed (not aborted-early).
+	if fake.listCalls < 6 {
+		t.Fatalf("expected all three rule types to run their clear() (>=6 RuleList "+
+			"calls across next-table/rib-group/PBR × 2 families); got %d — a failure "+
+			"aborted the reconcile early instead of completing it", fake.listCalls)
+	}
+}
+
+// TestApplyRoutingRulesCleanSucceeds_5844 proves a clean ip-rule reconcile does
+// NOT fail the commit: RuleList returns an empty kernel table, RuleAdd/RuleDel
+// succeed, and an empty config desires nothing, so applyRoutingRules returns
+// nil. Guards against a false failure from the new error threading.
+func TestApplyRoutingRulesCleanSucceeds_5844(t *testing.T) {
+	fake := &fakeRuleOps5844{} // listErr nil -> lists succeed (empty)
+	d := &Daemon{routing: routing.NewManagerWithRuleOpsForTest(fake)}
+	if err := d.applyRoutingRules(&config.Config{}, nil); err != nil {
+		t.Fatalf("a clean ip-rule reconcile must not fail the commit, got %v", err)
+	}
+}
+
+// TestApplyTailReconcilesSurfacesRoutingRuleError_5844 is the commit-level
+// wiring proof: it drives the REAL applyTailReconciles with an injected
+// routing-rule error (routingRuleErr, the new final operand) and asserts the
+// returned commit error includes it — pinning the tail errors.Join wiring the
+// direct applyRoutingRules test does not cover.
+//
+// FAIL-ON-REVERT: drop routingRuleErr from that join and this goes RED (the
+// apply completes and returns nil despite the ip-rule reconcile having failed —
+// the exact silent acknowledgement #5844 describes). The nft seams are stubbed
+// to succeed so the injected routingRuleErr is the ONLY operand that can surface.
+func TestApplyTailReconcilesSurfacesRoutingRuleError_5844(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
+
+	d := &Daemon{
+		dp:       &runtimeOnlyApplyTestDP{},
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+
+	injected := errors.New("injected: next-table ip-rule reconcile failed")
+	// routingRuleErr is the final applyTailReconciles operand; every other
+	// deferred error is nil so it is the only thing that can surface.
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, injected)
+	if err == nil {
+		t.Fatal("applyTailReconciles must surface the routing-rule reconcile failure " +
+			"(fail-closed); got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned commit error must include the routing-rule failure via the "+
+			"tail errors.Join wiring, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #5844

## Problem (bug, security, HIGH)
`pkg/routing` correctly **returns** the next-table / rib-group / PBR `ip rule` reconcile failures (each already fail-closed at its source — a partial clear/add leaves stale-or-missing cross-VRF policy in the kernel, #3731/#5118/#2273). But the daemon call site `applyRoutingRules` was **void** and **logged-and-dropped** all three. So a commit was **acknowledged** after a partial reconcile, and the immediately-following userspace route snapshot (`reconcileRouteLeakSnapshot`, which derives the NextTable leak from the *live* kernel ip-rule table) **canonized that partial live kernel state** into the FIB — a silent inter-VRF route-leak / policy widen-narrow that kernel-forwarded / local / route-based-IPsec plaintext could follow, reported as a successful commit.

## Fix (fail-closed-deferred, mirroring #5310 `ifaceErr` / #5696 `routeLeakErr`)
1. `applyRoutingRules` now **returns** `errors.Join` of the three kernel reconcile failures (`ApplyNextTableRules`, `ApplyRibGroupRules`, `ApplyPBRRules`), keeping the per-error logging. Fail-closed **but complete**: one rule-type failure does **not** skip the others — every rule type runs, then the joined error surfaces.
2. `applyConfigLocked` captures it (`routingRuleErr`) and threads it into the **same** tail `errors.Join` sink the snapshot error uses (a new final `applyTailReconciles` param). Ordering preserved: the snapshot republish still runs first (not left stale), and the commit then surfaces the routing-rule failure.

### Deliberate scope: `BuildPBRRules` build degradation is NOT joined
A filter term that can't be expressed as an `ip rule` (port-except / tcp-flags / icmp / is-fragment / flex / overflow) is a **fail-safe under-steer** — dropped to the main table, still enforced by the userspace filter path. `ApplyPBRRules` fully reconciles whatever *was* built (deleting stale rules), so no partial kernel mutation survives. It's a representability warning, not the #5844 bug class; fail-closing it would reject configs that commit fine today. Documented in code + `pkg/daemon/README.md`.

## Tests (fail-on-revert)
`routing_rule_reconcile_failclosed_5844_test.go`:
- **Direct** — a `RuleList`-failing `ruleOps` fake (via `routing.NewManagerWithRuleOpsForTest`) drives the real `applyRoutingRules`; asserts it (a) **returns** the failure and (b) still ran all three rule types' `clear()` (**6** `RuleList` calls = next-table/rib-group/PBR × 2 families → complete, not aborted-early).
- **Clean** — a clean reconcile returns `nil` (no false failure).
- **Wiring** — `applyTailReconciles` with an injected `routingRuleErr` surfaces it (mirrors `TestApplyTailReconcilesSurfacesInterfaceReconcileError`).

**Fail-on-revert verified via Go `-overlay`:** dropping `routingRuleErr` from the tail `errors.Join` flips the wiring test **RED** (commit returns `nil` despite the injected failure). Reverting `applyRoutingRules` to void breaks the direct test's compile.

## Validation
- `gofmt` clean; `go build ./...` clean
- `go test ./pkg/daemon/ ./pkg/routing/ -count=1` green
- `go vet ./pkg/daemon/` clean
- Three sibling deferred-error tests (#5310/#5696/#5309) updated for the new `applyTailReconciles` arity (trailing `nil`)
- `pkg/daemon/README.md` documents the new fail-closed leg

🤖 Generated with [Claude Code](https://claude.com/claude-code)