### PR TITLE
rpm: hold path state neutral on lifecycle cancellation

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48272,3 +48272,35 @@ top.
   ctx.Err() check flips the abort tests RED (verified: phases ran p1,p2,p3,p4).
 - **Action**: #5854 — hard-reject next-table/rib-group ip-rule window over-subscription at strict commit (was warn-only → silent apply-time truncation → routes claimed but not programmed). Added validateRoutingRuleWindowsStrict (new compiler_validate_strict_routing_rulewindows.go) wired into runUniformGates after the #5693 next-table gate, gated by new opts.lenientRoutingRuleWindows (true in both lenient blocks): strict CompileConfig hard-rejects >100 next-table routes / >1000 rib-group leak prefixes; CompileConfigLenient (Store.Load / SyncApply / peer-sync) still warns-and-loads so grandfathered/peer-synced generations don't fail-closed (#1960). Removed the now-redundant warn-only validateRoutingRuleWindowWarnings + its ValidateConfig call (runUniformGates runs before ValidateConfig, so strict aborts clean; the lenient downgrade is the single warning — no double-warn). Window consts (maxNextTableRules=100, maxRibGroupLeakRules=1000) duplicated in pkg/config with keep-in-sync comment (pkg/config cannot import pkg/routing — cycle). Fail-on-revert tests (gate-unit + compile-path strict-reject + lenient-warn); neutralizing the gate turns all reject AND lenient-warn assertions RED. gofmt/go vet/go build clean; go test ./pkg/config/ ./pkg/routing/ green. Doc: docs/rib-group-route-leaking.md new "Strict rejection — ip-rule window over-subscription (#5854)" section.
 - **File(s)**: pkg/config/compiler_validate_strict_routing_rulewindows.go (new), pkg/config/compiler_uniformgates.go, pkg/config/compiler.go, pkg/config/compiler_validate_warn.go, pkg/config/compiler_validate_warn_routing.go, pkg/config/compiler_routing_rules_test.go, docs/rib-group-route-leaking.md
+
+- **Timestamp**: 2026-07-15
+  **Action**: #5852 (bug): RPM lifecycle cancellation (StopAll / config
+  replacement / daemon shutdown) was mis-counted as path loss. When StopAll
+  cancels the shared probe context while runProbe is in flight, runSingleTest
+  treated the resulting context.Canceled (or the socket-timeout that follows a
+  cancel racing a blocking ReadFrom) as an ORDINARY probe failure: incremented
+  TotalSent/SuccFail, advanced the successive-loss threshold, emitted
+  ping_probe_failed, and could cross the loss threshold -> ping_test_failed +
+  fireTransition, so services ip-monitoring could change route preference DURING
+  teardown/reconfigure. Fixed by holding path state NEUTRAL on a lifecycle
+  cancel, mirroring the existing ErrProbeSetup hold: after runProbe, if
+  `ctx.Err() != nil || errors.Is(err, context.Canceled)` the probe RETURNs
+  before any counter/threshold/event/Transition. Discriminator is the SHARED
+  ctx.Err() (the probeCtx is context.WithCancel in Apply, cancelled ONLY by
+  m.cancel()), NOT the returned error type — a genuine probe TIMEOUT is a
+  per-probe socket deadline (icmp SetReadDeadline / TCP dial timeout) that
+  leaves ctx.Err()==nil and MUST still count as real path loss. RETURN (not
+  continue) so no post-loop fireTransition publishes a stale edge once teardown
+  begins. Deferred the optional icmp ReadFrom context-deadline responsiveness
+  tweak (StopAll can still wait up to the 3s socket deadline) as a follow-up —
+  the neutral classification is the load-bearing correctness fix and StopAll's
+  wg.Wait is bounded (<=3s, within TimeoutStopSec=20).
+  **File(s)**: pkg/rpm/rpm.go, pkg/rpm/README.md,
+  pkg/rpm/cancel_neutral_5852_test.go, _Log.md
+  **Validation**: `go build ./...`; `go test ./pkg/rpm/ -count=1` (green);
+  `go vet ./pkg/rpm/` clean. Fail-on-revert: removing the neutral check flips
+  TestRunSingleTestLifecycleCancelIsNeutral5852 RED (cancelled probe advanced
+  TotalSent:1/SuccFail:1/LastStatus:fail) while the genuine-failure +
+  probe-owned-DeadlineExceeded tests stay GREEN (no over-neutralization).
+  (NOTE: the shared GOCACHE=/dev/shm/cache was contaminated by a prior
+  worktree — a fresh cache builds clean; used /dev/shm/cache5852.)

--- a/pkg/rpm/README.md
+++ b/pkg/rpm/README.md
@@ -97,6 +97,24 @@ out-of-range value to a warning.
   lookup/dial failure from it. Before #5061 the resolver Control
   returned the raw error, so an EPERM/ENODEV resolver bind was counted
   as probe loss for icmp-ping/tcp-ping/http-get.
+- **Lifecycle cancellation holds state too** (#5852): a `StopAll` /
+  config replacement / daemon shutdown cancels the SHARED probe context
+  (`Apply` builds it as `context.WithCancel`; `m.cancel()` cancels it).
+  A probe interrupted mid-flight by that cancel is NEUTRAL to path
+  health — `runSingleTest` returns before touching counters, the
+  successive-loss threshold, events, or `fireTransition`, so
+  ip-monitoring never remediates routes DURING teardown/reconfigure. The
+  discriminator is the SHARED `ctx.Err()`, NOT the returned error's type:
+  a genuine probe TIMEOUT is a per-probe SOCKET deadline (icmp
+  `SetReadDeadline` / TCP dial timeout) that leaves `ctx.Err() == nil`
+  and MUST still count as real path loss (an actually-unreachable target
+  must still fail over). Only `m.cancel()` cancels the shared context, so
+  `ctx.Err() != nil` is exactly a lifecycle stop; a probe's own timeout
+  never cancels it. Regression-locked by
+  `TestRunSingleTestLifecycleCancelIsNeutral5852` (neutral) +
+  `TestRunSingleTestGenuineFailureStillCounts5852` /
+  `TestRunSingleTestProbeDeadlineWithLiveCtxCounts5852` (no
+  over-neutralization). Sibling of the setup-error hold above.
 - The raw-socket seam is injectable (`icmpListenFunc` in `icmp.go`) so
   prober logic is unit-testable without privileges.
 - **The http-get probe's transport is one-shot** (#4912): `probeHTTP`

--- a/pkg/rpm/cancel_neutral_5852_test.go
+++ b/pkg/rpm/cancel_neutral_5852_test.go
@@ -1,0 +1,150 @@
+// cancel_neutral_5852_test.go — #5852: a LIFECYCLE cancellation of the shared
+// probe context (StopAll / config replacement / daemon shutdown) that interrupts
+// an in-flight probe must be NEUTRAL to path health — no counters, no
+// successive-loss advance, no ping_probe_failed / ping_test_failed event, no
+// fireTransition — so services ip-monitoring never remediates routes during
+// teardown/reconfigure. A GENUINE probe timeout/failure (the shared context NOT
+// cancelled) must still count as path loss, so real remediation is unaffected.
+package rpm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func cancelNeutralTest() *config.RPMTest {
+	return &config.RPMTest{Name: "t", Target: "192.0.2.10"}
+}
+
+func seedPassingResult(m *Manager) {
+	m.results["WAN/t"] = &ProbeResult{
+		ProbeName: "WAN", TestName: "t", ProbeType: "icmp-ping",
+		Target: "192.0.2.10", LastStatus: "pass",
+	}
+}
+
+// TestRunSingleTestLifecycleCancelIsNeutral5852 cancels the shared probe context
+// from inside the in-flight probe (modelling StopAll's m.cancel() landing
+// mid-ReadFrom) and asserts the cancelled probe leaves path health untouched:
+// no counters, no events, no transition.
+//
+// Fail-on-revert: remove the `ctx.Err() != nil` neutral check and the cancelled
+// probe is counted as a failure — TotalSent/SuccFail advance, ping_probe_failed
+// fires, and (threshold 1, probeCount 1) the loss threshold trips → status flips
+// pass→fail → ping_test_failed + fireTransition (route remediation at teardown).
+func TestRunSingleTestLifecycleCancelIsNeutral5852(t *testing.T) {
+	m := New()
+
+	var transitions, events atomic.Int32
+	m.SetTransitionCallback(func(Transition) { transitions.Add(1) })
+	m.SetEventCallback(func(Event) { events.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// The probe is interrupted by a lifecycle stop: cancel the shared context
+	// and return its error, exactly as icmp.go does when ctx.Err() != nil.
+	m.probeFn = func(pctx context.Context, _ *config.RPMTest, _ string) (time.Duration, error) {
+		cancel()
+		return 0, pctx.Err()
+	}
+
+	seedPassingResult(m)
+	// probeCount 1, threshold 1: a mis-counted cancel would immediately trip a
+	// pass→fail transition, so the neutral behavior is unambiguous.
+	m.runSingleTest(ctx, "WAN", cancelNeutralTest(), "WAN/t", 1, 0, 1)
+
+	r := m.results["WAN/t"]
+	if r.TotalSent != 0 || r.TotalRecv != 0 || r.SuccFail != 0 {
+		t.Fatalf("lifecycle cancel advanced counters: %+v", r)
+	}
+	if r.LastStatus != "pass" || !r.LastProbeAt.IsZero() {
+		t.Fatalf("lifecycle cancel mutated path state: LastStatus=%q LastProbeAt=%v", r.LastStatus, r.LastProbeAt)
+	}
+	if transitions.Load() != 0 {
+		t.Fatalf("lifecycle cancel fired %d transitions (route remediation during teardown), want 0", transitions.Load())
+	}
+	if events.Load() != 0 {
+		t.Fatalf("lifecycle cancel fired %d events (ping_probe_failed/ping_test_failed), want 0", events.Load())
+	}
+}
+
+// TestRunSingleTestGenuineFailureStillCounts5852 proves the fix does NOT
+// over-neutralize: a real probe timeout — a per-probe socket-deadline error
+// while the shared context stays LIVE (the target is actually unreachable) —
+// still counts as path loss and fires the fail transition.
+func TestRunSingleTestGenuineFailureStillCounts5852(t *testing.T) {
+	m := New()
+
+	var transitions int32
+	statusCh := make(chan string, 4)
+	m.SetTransitionCallback(func(tr Transition) { atomic.AddInt32(&transitions, 1); statusCh <- tr.Status })
+	var events int32
+	m.SetEventCallback(func(Event) { atomic.AddInt32(&events, 1) })
+
+	// A genuine probe timeout: a net-timeout-shaped error (icmp.go's
+	// "icmp echo ... timed out: <i/o timeout>"). The shared context is NEVER
+	// cancelled, so this is real path loss, not a lifecycle stop.
+	m.probeFn = func(_ context.Context, _ *config.RPMTest, _ string) (time.Duration, error) {
+		return 0, fmt.Errorf("icmp echo to 192.0.2.10 timed out: i/o timeout")
+	}
+
+	seedPassingResult(m)
+	m.runSingleTest(context.Background(), "WAN", cancelNeutralTest(), "WAN/t", 1, 0, 1)
+
+	r := m.results["WAN/t"]
+	if r.TotalSent != 1 || r.SuccFail != 1 || r.LastStatus != "fail" {
+		t.Fatalf("genuine failure was not counted as path loss: %+v", r)
+	}
+	if atomic.LoadInt32(&transitions) != 1 {
+		t.Fatalf("genuine failure fired %d transitions, want 1", atomic.LoadInt32(&transitions))
+	}
+	if atomic.LoadInt32(&events) != 2 {
+		t.Fatalf("genuine failure fired %d events, want 2 (ping_probe_failed + ping_test_failed)", atomic.LoadInt32(&events))
+	}
+	select {
+	case st := <-statusCh:
+		if st != "fail" {
+			t.Fatalf("genuine failure transition status = %q, want fail", st)
+		}
+	default:
+		t.Fatal("expected a fail transition from a genuine probe failure")
+	}
+}
+
+// TestRunSingleTestProbeDeadlineWithLiveCtxCounts5852 pins the timeout-vs-cancel
+// distinction precisely: a probe that surfaces context.DeadlineExceeded from its
+// OWN timeout while the SHARED context is NOT cancelled MUST still count as a
+// failure. The neutral classification keys off the shared ctx.Err(), NOT the
+// returned error type, so a probe-owned DeadlineExceeded is never mistaken for a
+// lifecycle stop (over-neutralization guard).
+func TestRunSingleTestProbeDeadlineWithLiveCtxCounts5852(t *testing.T) {
+	m := New()
+	var events int32
+	m.SetEventCallback(func(Event) { atomic.AddInt32(&events, 1) })
+
+	m.probeFn = func(_ context.Context, _ *config.RPMTest, _ string) (time.Duration, error) {
+		// Probe-owned deadline (NOT the shared context's) — real path loss.
+		return 0, fmt.Errorf("probe timed out: %w", context.DeadlineExceeded)
+	}
+
+	seedPassingResult(m)
+	// Shared context stays live (never cancelled).
+	m.runSingleTest(context.Background(), "WAN", cancelNeutralTest(), "WAN/t", 1, 0, 1)
+
+	if r := m.results["WAN/t"]; r.TotalSent != 1 || r.SuccFail != 1 || r.LastStatus != "fail" {
+		t.Fatalf("a probe-owned DeadlineExceeded (live shared ctx) must count as path loss: %+v", r)
+	}
+	if got := atomic.LoadInt32(&events); got != 2 {
+		t.Fatalf("probe-owned deadline fired %d events, want 2 (probe_failed + test_failed)", got)
+	}
+	// Sanity: the shared context really was never cancelled.
+	if errors.Is(context.Background().Err(), context.Canceled) {
+		t.Fatal("test bug: background ctx should not be cancelled")
+	}
+}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -520,6 +520,27 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 
 		rtt, err := m.runProbe(ctx, test, key)
 
+		// #5852: a LIFECYCLE cancellation of the shared probe context —
+		// StopAll / config replacement / daemon shutdown calling m.cancel()
+		// (Apply builds probeCtx as context.WithCancel) — is NEUTRAL to path
+		// health. The probe was torn down; it never reached a health verdict,
+		// so it must not be mis-counted as path loss and trigger ip-monitoring
+		// route remediation DURING teardown/reconfigure. Detect it by the
+		// SHARED context's own state (ctx.Err()), NOT the returned error type: a
+		// genuine probe TIMEOUT is a per-probe SOCKET deadline (icmp
+		// SetReadDeadline / TCP dial timeout) that leaves ctx.Err()==nil and
+		// MUST still count as real path loss — the target is actually
+		// unreachable. Only m.cancel() cancels probeCtx, so ctx.Err()!=nil is
+		// exactly a lifecycle stop; a probe timeout never cancels it.
+		// errors.Is(err, context.Canceled) is the equivalent belt (icmp.go
+		// returns ctx.Err() on cancellation). RETURN — not just skip this probe
+		// — so the post-loop transition can never publish a stale pass/fail edge
+		// once teardown has begun. Mirrors the ErrProbeSetup hold below: no
+		// counters, no successive-loss advance, no events, no Transition.
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+			return
+		}
+
 		// ErrProbeSetup = environment/capability failure (raw socket
 		// open denied, marshal, probe pin not installed #1895): the
 		// probe never reached the wire — or must not be sent at all


### PR DESCRIPTION
## Summary

Closes #5852.

A control-plane lifecycle action — `StopAll`, config replacement, daemon shutdown — cancels the shared probe context (`m.cancel()`) and must be **NEUTRAL to path health**: a probe torn down mid-flight never reached a health verdict. It wasn't. When `StopAll` cancelled the context while `runProbe` was in flight, `runSingleTest` treated the resulting `context.Canceled` — or the socket timeout that follows a cancel racing a blocking `ReadFrom` — as an **ordinary probe failure**: it incremented `TotalSent`/`SuccFail`, advanced the successive-loss threshold, emitted `ping_probe_failed`, and could cross the loss threshold → `ping_test_failed` + `fireTransition`. That let `services ip-monitoring` change static-route preference **during teardown/reconfigure** — remediating a path that isn't actually down, just being torn down.

## Fix

Hold path state neutral on a lifecycle cancel, exactly like the existing `ErrProbeSetup` hold: after `runProbe`, when the shared context is cancelled, `return` before touching any counter, the successive-loss threshold, any event, or `fireTransition`.

```go
if ctx.Err() != nil || errors.Is(err, context.Canceled) {
    return
}
```

**The discriminator is the SHARED context's own state (`ctx.Err()`), NOT the returned error's type.** The probe context is `context.WithCancel(ctx)` (`Apply`) cancelled ONLY by `m.cancel()`, so `ctx.Err() != nil` is exactly a lifecycle stop. A genuine probe **TIMEOUT** is a per-probe **socket deadline** (icmp `SetReadDeadline` / TCP dial timeout) that leaves `ctx.Err() == nil` and **MUST still count** as real path loss (an actually-unreachable target must still fail over). A probe's own timeout never cancels the shared context, so keying off the shared `ctx` is what keeps a real timeout counted while neutralizing only the lifecycle cancel. `RETURN` (not skip one probe) so no post-loop transition publishes a stale pass/fail edge once teardown has begun.

**Timeout-vs-cancel care (per the issue):** I deliberately do NOT neutralize based on `errors.Is(err, context.DeadlineExceeded)` — a probe's own timeout could surface that way. Only a cancelled shared context (`ctx.Err()`) is neutral.

**Deferred (optional, noted):** the icmp `ReadFrom` context-deadline responsiveness tweak (so `StopAll` doesn't block up to the 3s socket deadline for an in-flight read) is a follow-up — the neutral classification is the load-bearing correctness fix and `StopAll`'s `wg.Wait` is already bounded (≤3s, within the unit's `TimeoutStopSec=20`).

## Tests (fail-on-revert)

`pkg/rpm/cancel_neutral_5852_test.go` (uses the existing `m.probeFn` seam + `SetTransitionCallback`/`SetEventCallback`):
- **`TestRunSingleTestLifecycleCancelIsNeutral5852`** — probe cancels the shared ctx mid-flight; asserts `TotalSent`/`SuccFail`/`LastStatus` unchanged, no event, no transition.
- **`TestRunSingleTestGenuineFailureStillCounts5852`** — a net-timeout error with a LIVE shared ctx still counts (`TotalSent=1`, fail transition + 2 events).
- **`TestRunSingleTestProbeDeadlineWithLiveCtxCounts5852`** — a probe-owned `context.DeadlineExceeded` with a LIVE shared ctx still counts (over-neutralization guard; proves the check keys off `ctx.Err()`, not the error type).

**Fail-on-revert verified:** removing the neutral check flips the lifecycle test **RED** (the cancelled probe advances `TotalSent:1`/`SuccFail:1`/`LastStatus:fail`) while both genuine-failure tests stay green.

## Validation

- `go build ./...`
- `go test ./pkg/rpm/ -count=1` — green
- `go vet ./pkg/rpm/` — clean

Doc: `pkg/rpm/README.md` gets a "Lifecycle cancellation holds state too (#5852)" gotcha, sibling to the setup-error hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)