### PR TITLE
eventengine: dedup the action queue on every enqueue, not only when full (#5853)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -59,6 +59,45 @@
   pkg/cli/cli_clear_exact_arity_5811_test.go (Write), pkg/cli/README.md (Edit),
   _Log.md (Edit)
 
+## 2026-07-15 — #5853 (bug): event-options action queue dedups early (one-per-policy on every enqueue)
+- **Timestamp**: 2026-07-15 (fix/5853-eventqueue-dedup-early)
+- **Action**: The action queue documents "at most one pending action per policy"
+  (dedup-by-policy) but `enqueue` (pkg/eventengine/engine.go) did an unconditional
+  fast-path channel send and only ran the `supersede` dedup in the full/`default`
+  branch. So while the worker was blocked behind the config lock, a burst from ONE
+  policy filled all 64 slots with redundant duplicates (later discarded by
+  cooldown/staleness) and the NEXT remediation for an UNRELATED policy was dropped
+  queue-full — one flapping policy could starve every other policy. Fix: enqueue
+  now runs `supersede` on EVERY enqueue (removed the fast-path send + default), so
+  a same-policy duplicate REPLACES the queued entry (≤1 slot) instead of taking a
+  new one, leaving slots free for other policies. Reused the already-proven
+  supersede (drain → drop same-policy → refill survivors FIFO + new at tail,
+  #2869) under the producer-only enqueueMu — worker stays lock-free, no new shared
+  state. Counter correctness: the same-policy supersede-drop now increments a new
+  `Superseded` counter (benign dedup — the newer equivalent action still runs)
+  instead of `droppedQueueFull`; droppedQueueFull is reserved for genuine capacity
+  loss (queue full of OTHER policies, unfittable new arrival / lost survivor), so
+  the alert-worthy `xpf_event_actions_dropped_total{reason=queue_full}` metric is
+  no longer inflated by routine bursts. Exposed `xpf_event_actions_superseded_total`
+  in the Prometheus collector.
+- **Validation**: gofmt clean; go build ./...; go vet ./pkg/eventengine/
+  ./pkg/api/ clean; go test ./pkg/eventengine/ -race + ./pkg/api/ green.
+  Fail-on-revert: a same-policy burst of exactly actionQueueDepth events occupies
+  1 slot (pre-fix 64) and an unrelated policy still enqueues (pre-fix dropped);
+  reverting enqueue to dedup-only-when-full flips the new
+  TestQueue_SamePolicyBurstDoesNotStarveOthers_5853 + the updated
+  TestQueue_DedupByPolicy (Superseded>=1 / DroppedQueueFull==0 / QueueDepth<=1)
+  RED. The #3750 cooldown-suppresses-queued-duplicate test behavior is preserved
+  (event #1 is in-flight in the worker, so the early dedup finds nothing queued to
+  supersede and #2 still queues) — comment updated.
+- **File(s)**: pkg/eventengine/engine.go (Edit),
+  pkg/eventengine/engine_dedup_early_5853_test.go (Write),
+  pkg/eventengine/engine_integration_test.go (Edit),
+  pkg/eventengine/engine_stale_revalidate_3750_test.go (Edit),
+  pkg/eventengine/README.md (Edit), pkg/api/metrics.go (Edit),
+  pkg/api/metrics_descriptors.go (Edit), pkg/api/metrics_system.go (Edit),
+  _Log.md (Edit)
+
 ## 2026-07-15 — #5738 (bug/syslog) commit 2/2: CLI reloadSyslog source-iface + event-mode parity
 - **Timestamp**: 2026-07-15 (fix/5738-syslog-source-iface-parity)
 - **Action**: Aligned the CLI in-process commit path (reloadSyslog /

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -245,6 +245,7 @@ type xpfCollector struct {
 	eventActionsRejected          *prometheus.Desc
 	eventActionsRetried           *prometheus.Desc
 	eventActionsDropped           *prometheus.Desc
+	eventActionsSuperseded        *prometheus.Desc
 	eventAttributesInvalid        *prometheus.Desc
 	eventActionQueueDepth         *prometheus.Desc
 	eventStreamSubscriberDropped  *prometheus.Desc
@@ -697,6 +698,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.eventActionsRejected
 	ch <- c.eventActionsRetried
 	ch <- c.eventActionsDropped
+	ch <- c.eventActionsSuperseded
 	ch <- c.eventAttributesInvalid
 	ch <- c.eventActionQueueDepth
 	ch <- c.eventStreamSubscriberDropped

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -705,16 +705,29 @@ func newCollector(srv *Server) *xpfCollector {
 			"xpf_event_actions_dropped_total",
 			"Total event-options remediation actions dropped (NOT applied). "+
 				"reason=lock_held: the config lock stayed held past the "+
-				"retry deadline. reason=queue_full: a newer same-policy "+
-				"action superseded this one, or the bounded action queue "+
-				"was full (#2157). reason=stale: at commit time the policy had "+
-				"been removed or redefined, or its 30s cooldown was now active — "+
-				"the action was revalidated and dropped rather than committing a "+
-				"batch no active policy authorizes (#3750). A nonzero "+
-				"lock_held/queue_full value means automated remediation was "+
-				"lost — investigate the lock holder; stale is expected under "+
-				"operator config churn or duplicate events.",
+				"retry deadline. reason=queue_full: the bounded action queue "+
+				"was full of OTHER policies' actions and this one could not fit "+
+				"(#2157; a same-policy dedup is counted separately as "+
+				"xpf_event_actions_superseded_total, #5853). reason=stale: at "+
+				"commit time the policy had been removed or redefined, or its 30s "+
+				"cooldown was now active — the action was revalidated and dropped "+
+				"rather than committing a batch no active policy authorizes "+
+				"(#3750). A nonzero lock_held/queue_full value means automated "+
+				"remediation was lost — investigate the lock holder; stale is "+
+				"expected under operator config churn or duplicate events.",
 			[]string{"reason"}, nil,
+		),
+		eventActionsSuperseded: prometheus.NewDesc(
+			"xpf_event_actions_superseded_total",
+			"Total event-options remediation actions SUPERSEDED by a newer "+
+				"same-policy trigger while queued (#5853). The dedup keeps at "+
+				"most one pending action per policy, so a burst from one policy "+
+				"cannot fill the bounded queue and starve other policies. This is "+
+				"benign — nothing is lost, the newer equivalent action still "+
+				"runs — and is expected under duplicate events; it is NOT a "+
+				"capacity drop (see reason=queue_full on "+
+				"xpf_event_actions_dropped_total).",
+			nil, nil,
 		),
 		eventAttributesInvalid: prometheus.NewDesc(
 			"xpf_event_attributes_match_invalid_total",

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -271,6 +271,8 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 			prometheus.CounterValue, float64(st.DroppedQueueFull), "queue_full")
 		ch <- prometheus.MustNewConstMetric(c.eventActionsDropped,
 			prometheus.CounterValue, float64(st.DroppedStale), "stale")
+		ch <- prometheus.MustNewConstMetric(c.eventActionsSuperseded,
+			prometheus.CounterValue, float64(st.Superseded))
 		ch <- prometheus.MustNewConstMetric(c.eventAttributesInvalid,
 			prometheus.CounterValue, float64(st.AttributesInvalid))
 		ch <- prometheus.MustNewConstMetric(c.eventActionQueueDepth,

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -161,12 +161,14 @@ one gate:
   OLD command set must not commit under the new definition. Dropped.
 - **Cooldown active (H3):** a successful commit of the SAME policy is within the
   30 s cooldown window. The enqueue-time cooldown check in `evaluateEvent` races
-  the arm-on-commit timing (the cooldown is armed only after a commit, and
-  `enqueue` dedups a same-policy duplicate ONLY when the queue is full), so a
-  duplicate can slip into the queue while the worker is blocked. Re-enforcing the
-  cooldown here at commit time suppresses the within-window duplicate instead of
-  double-committing — restoring the documented "not more than once in any 30 s
-  window" invariant even under lock contention.
+  the arm-on-commit timing (the cooldown is armed only after a commit), so a
+  duplicate can slip into the queue while the worker is blocked: the first event
+  is already IN-FLIGHT in the worker (dequeued, retrying under the held lock), so
+  the enqueue-time dedup finds no same-policy entry still QUEUED to supersede and
+  the duplicate is enqueued. Re-enforcing the cooldown here at commit time
+  suppresses the within-window duplicate instead of double-committing — restoring
+  the documented "not more than once in any 30 s window" invariant even under lock
+  contention.
 
 Legitimate remediations are unaffected: distinct policies and a re-fire AFTER the
 cooldown elapses pass the gate and commit. Regression-locked (fail-on-revert) by
@@ -248,19 +250,29 @@ cannot occur.
   parks the worker in the retry select under a held lock, closes the engine, and
   asserts the stop func was invoked — reverting to `time.After` never consults
   the seam and the test goes RED).
-- **Bounded queue, dedup-by-policy:** the queue holds at most one pending
-  action per policy — a newer trigger supersedes an older queued one (no value
-  in applying a stale remediation twice). Overflow bumps
+- **Bounded queue, dedup-by-policy (early — #5853):** the queue holds at most one
+  pending action per policy — a newer trigger supersedes an older queued one (no
+  value in applying a stale remediation twice). The dedup runs on **every**
+  enqueue via `supersede()`, not only once the channel is full. The pre-#5853
+  `enqueue` did an unconditional fast-path send and deduped only in the full
+  branch, so while the worker was blocked behind the config lock a burst from ONE
+  policy filled all 64 slots with redundant duplicates (later discarded by
+  cooldown/staleness) and the NEXT remediation for an UNRELATED policy was dropped
+  queue-full — one flapping policy could starve every other policy's remediation.
+  Early dedup keeps a same-policy burst to a single slot, leaving the rest free.
+  A same-policy replacement is a **benign** dedup (the newer equivalent action
+  still runs — nothing is lost) and is counted as
+  `xpf_event_actions_superseded_total`, **not** as a drop. A genuine capacity loss
+  — the queue full of unrelated policies with no same-policy entry to evict, so
+  the genuinely-unfittable new arrival cannot fit — bumps
   `xpf_event_actions_dropped_total{reason="queue_full"}` **exactly once per
-  dropped action**. When the queue is full of unrelated policies and there is no
-  stale same-policy entry to evict, the genuinely-unfittable new arrival is
-  dropped (the older FIFO survivors are kept) and counted once by `enqueue` —
-  `supersede()` does NOT also count that overflow in its refill loop (it only
-  counts a SURVIVOR it could not re-place). Loss is always counted, never silent,
-  and never double-counted (#2869).
-- **FIFO ordering across policies (#2869):** the queue is FIFO. When the queue
-  is full and `supersede()` drains/refills it to drop a stale same-policy entry,
-  it re-enqueues the surviving OTHER-policy actions in their original order and
+  dropped action** (counted by `enqueue`; `supersede()` does NOT also count that
+  overflow in its refill loop — it only counts a SURVIVOR it could not re-place).
+  Loss is always counted, never silent, and never double-counted (#2869), and the
+  benign dedup no longer inflates the alert-worthy `queue_full` metric.
+- **FIFO ordering across policies (#2869):** the queue is FIFO. Each enqueue's
+  `supersede()` drains/refills the queue to drop any stale same-policy entry, then
+  re-enqueues the surviving OTHER-policy actions in their original order and
   places the new (superseding) action at the **TAIL** — never the head.
   Prepending the new action would let the newest event jump ahead of every older
   queued remediation (LIFO), starving older policies under sustained event

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -94,7 +94,10 @@ const policyCooldown = 30 * time.Second
 // actionQueueDepth bounds the worker's pending-action channel. Dedup-by-policy
 // (a newer trigger supersedes an older queued one) keeps at most one pending
 // action per policy, so this is also an upper bound on distinct policies with
-// a remediation in flight while the config lock is held.
+// a remediation in flight while the config lock is held. #5853: the dedup runs
+// on EVERY enqueue (not only when the channel is full), so a burst from ONE
+// policy occupies at most ONE slot — it can never fill the queue with redundant
+// duplicates and starve an unrelated policy's remediation into a queue-full drop.
 const actionQueueDepth = 64
 
 // Backoff schedule for a held config lock (#2157). The worker retries an
@@ -114,7 +117,8 @@ type Stats struct {
 	CommittedWithDebt uint64 // subset of Committed that promoted+armed but left a best-effort subsystem in debt (#5063)
 	Rejected          uint64 // actions rejected (bad plan / CommitCheck / commit not promoted)
 	Retried           uint64 // retry attempts after a held config lock
-	DroppedQueueFull  uint64 // actions superseded/evicted because the queue was full
+	DroppedQueueFull  uint64 // actions genuinely dropped: the queue was full of OTHER policies (a distinct policy could not fit, or a survivor was lost) — capacity loss, alert-worthy
+	Superseded        uint64 // same-policy queued actions REPLACED by a newer trigger (benign dedup; nothing lost — the newer equivalent action runs) (#5853)
 	DroppedLockHeld   uint64 // actions dropped after the lock-retry deadline elapsed
 	DroppedStale      uint64 // actions dropped at commit: policy removed/redefined or cooldown active (#3750)
 	AttributesInvalid uint64 // runtime fail-closed: malformed/unknown attributes-match line
@@ -128,6 +132,7 @@ type engineCounters struct {
 	rejected          atomic.Uint64
 	retried           atomic.Uint64
 	droppedQueueFull  atomic.Uint64
+	superseded        atomic.Uint64
 	droppedLockHeld   atomic.Uint64
 	droppedStale      atomic.Uint64
 	attributesInvalid atomic.Uint64
@@ -249,19 +254,18 @@ type Engine struct {
 
 	// enqueueMu serializes ALL producer-side queue mutation (#5062). HandleEvent
 	// releases e.mu (evaluateEvent returns) BEFORE it enqueues, so many RPM-probe
-	// goroutines run enqueue concurrently. When the bounded queue is full, enqueue
-	// falls into supersede, which DRAINS the accepted actions into a private slice
-	// (opening slots) and then best-effort re-enqueues the survivors. Without a
-	// producer lock a SECOND concurrent producer — via enqueue's fast-path send OR
-	// its own supersede — takes those drain-freed slots between the drain and the
-	// re-enqueue, so supersede's refill `default` branch DROPS a survivor (an
-	// already-accepted action for a DIFFERENT policy), losing it and its FIFO
-	// position (miscounted droppedQueueFull). Holding enqueueMu across the WHOLE
-	// enqueue (fast-path send AND the supersede drain+refill) makes the
-	// drain->re-enqueue atomic w.r.t. other producers: the only concurrent actor
-	// left is the consumer (actionWorker), which only REMOVES items, so a
-	// drain-freed slot can never be re-filled by anyone but supersede itself and a
-	// survivor is preserved exactly once, in FIFO order.
+	// goroutines run enqueue concurrently. Every enqueue runs supersede (#5853),
+	// which DRAINS the accepted actions into a private slice (opening slots),
+	// drops any same-policy entry, and then best-effort re-enqueues the survivors.
+	// Without a producer lock a SECOND concurrent producer — via its own supersede
+	// — takes those drain-freed slots between the drain and the re-enqueue, so
+	// supersede's refill `default` branch DROPS a survivor (an already-accepted
+	// action for a DIFFERENT policy), losing it and its FIFO position (miscounted
+	// droppedQueueFull). Holding enqueueMu across the WHOLE enqueue (the supersede
+	// drain+refill) makes the drain->re-enqueue atomic w.r.t. other producers: the
+	// only concurrent actor left is the consumer (actionWorker), which only
+	// REMOVES items, so a drain-freed slot can never be re-filled by anyone but
+	// supersede itself and a survivor is preserved exactly once, in FIFO order.
 	//
 	// Lock ordering (no cycle, no deadlock): enqueueMu is a producer-only LEAF
 	// lock. It is NEVER held while e.mu is held (enqueue runs after evaluateEvent
@@ -609,6 +613,7 @@ func (e *Engine) Stats() Stats {
 		Rejected:          e.counters.rejected.Load(),
 		Retried:           e.counters.retried.Load(),
 		DroppedQueueFull:  e.counters.droppedQueueFull.Load(),
+		Superseded:        e.counters.superseded.Load(),
 		DroppedLockHeld:   e.counters.droppedLockHeld.Load(),
 		DroppedStale:      e.counters.droppedStale.Load(),
 		AttributesInvalid: e.counters.attributesInvalid.Load(),
@@ -623,35 +628,54 @@ func (e *Engine) Stats() Stats {
 // actions, the new action is dropped (counted) rather than blocking the caller
 // goroutine (#2157 bounded queue).
 //
+// #5853: the dedup runs on EVERY enqueue via supersede, not only when the
+// channel is full. The pre-#5853 fast path did an UNCONDITIONAL send first and
+// only deduped in the full/`default` branch, so while the worker was blocked
+// behind the config lock a burst from ONE policy filled all 64 slots with
+// redundant duplicates (later discarded by cooldown/staleness) and the next
+// remediation for an UNRELATED policy was dropped queue-full. Draining and
+// replacing the same-policy entry up front keeps at most one pending action per
+// policy, so a same-policy burst occupies a single slot and leaves the rest free
+// for other policies. supersede is non-blocking (select-with-default drain +
+// refill), so this never blocks the caller even mid-shutdown (e.actions is never
+// closed); a genuine full-of-other-policies queue still drops the new action
+// (counted) via supersede returning false.
+//
 // The whole body runs under enqueueMu (#5062) so concurrent producers cannot
-// interleave: the fast-path send below and supersede's drain+refill must be
-// atomic w.r.t. one another, otherwise a second producer could take a slot
-// supersede freed while draining and force supersede to drop an already-accepted
-// survivor. See the enqueueMu field comment for the lock-ordering rationale.
+// interleave: supersede's drain+refill must be atomic w.r.t. other producers,
+// otherwise a second producer could take a slot supersede freed while draining
+// and force supersede to drop an already-accepted survivor. See the enqueueMu
+// field comment for the lock-ordering rationale.
 func (e *Engine) enqueue(a plannedAction) {
 	e.enqueueMu.Lock()
 	defer e.enqueueMu.Unlock()
+	// Fast exit during shutdown: don't churn the queue for an action the worker
+	// will never apply. supersede would otherwise still succeed (the channel is
+	// unbounded-in-shutdown only in that it is never closed), but there is no
+	// consumer left to drain it.
 	select {
-	case e.actions <- a:
-		e.counters.queueDepth.Add(1)
 	case <-e.stopCh:
-		// Shutting down; drop silently.
+		return
 	default:
-		// Queue full. Try to supersede a same-policy action by draining and
-		// re-enqueuing, dropping any older same-policy entry. Best-effort,
-		// non-blocking. Runs under enqueueMu so the drain-freed slots are never
-		// visible to another producer (#5062).
-		if e.supersede(a) {
-			return
-		}
-		e.counters.droppedQueueFull.Add(1)
-		slog.Warn("event-options: action queue full, dropping remediation",
-			"policy", a.policyName)
 	}
+	if e.supersede(a) {
+		return
+	}
+	// supersede could not place `a`: the queue is full of OTHER policies'
+	// actions and there was no same-policy entry to evict. This is the only
+	// genuine capacity drop (an unrelated policy really did fill the queue).
+	e.counters.droppedQueueFull.Add(1)
+	slog.Warn("event-options: action queue full, dropping remediation",
+		"policy", a.policyName)
 }
 
 // supersede non-blockingly rebuilds the queue, replacing any existing
-// same-policy action with a, and returns true if a was placed.
+// same-policy action with a, and returns true if a was placed. It is the SOLE
+// enqueue path (#5853): every enqueue drains the buffered queue, drops any
+// existing same-policy entry (benign dedup, counted as superseded), re-enqueues
+// the surviving OTHER-policy actions in FIFO order, and places a at the tail. It
+// returns false only when the queue is full of OTHER policies and a could not be
+// placed (a genuine capacity drop the caller counts as droppedQueueFull).
 //
 // CALLER MUST HOLD enqueueMu (#5062). That is what makes the drain->re-enqueue
 // atomic w.r.t. other producers: while this runs, no other enqueue/supersede can
@@ -669,8 +693,14 @@ func (e *Engine) supersede(a plannedAction) bool {
 		case old := <-e.actions:
 			e.counters.queueDepth.Add(-1)
 			if old.policyName == a.policyName {
-				// Drop the stale same-policy action; it is superseded.
-				e.counters.droppedQueueFull.Add(1)
+				// Drop the stale same-policy action; it is superseded by the
+				// newer trigger a. This is a benign dedup — the newer equivalent
+				// action still runs — NOT a capacity loss, so count it as
+				// superseded rather than droppedQueueFull (#5853). Inflating the
+				// alert-worthy queue_full metric on every same-policy burst
+				// (which the early dedup makes routine) would mask real capacity
+				// drops.
+				e.counters.superseded.Add(1)
 				continue
 			}
 			drained = append(drained, old)

--- a/pkg/eventengine/engine_dedup_early_5853_test.go
+++ b/pkg/eventengine/engine_dedup_early_5853_test.go
@@ -1,0 +1,117 @@
+package eventengine
+
+import "testing"
+
+// #5853: the action-queue dedup-by-policy invariant ("at most one pending action
+// per policy") must hold on EVERY enqueue, not only once the channel is full.
+// The pre-#5853 enqueue did an unconditional fast-path send and only deduped in
+// the full/`default` branch, so while the worker was blocked behind the config
+// lock a burst from ONE policy filled all 64 slots with redundant duplicates and
+// the next remediation for an UNRELATED policy was dropped queue-full.
+
+// drainPolicyNames non-destructively... no: it drains the buffered queue and
+// returns the policy names in FIFO order. Used by the dedup tests to inspect the
+// exact queue contents (the worker is not started by New(), so the queue is
+// inert and this is race-free).
+func drainPolicyNames(e *Engine) []string {
+	var out []string
+	for {
+		select {
+		case a := <-e.actions:
+			out = append(out, a.policyName)
+		default:
+			return out
+		}
+	}
+}
+
+// TestQueue_SamePolicyBurstDoesNotStarveOthers_5853 pins the fix: a same-policy
+// burst occupies exactly ONE slot (early dedup), so an unrelated policy's action
+// still enqueues instead of being dropped queue-full.
+//
+// New(nil, nil) does NOT start the actionWorker, so the queue is inert and the
+// producer-side dedup is exercised deterministically without a consumer draining
+// underneath (same seam as TestSupersede_PreservesFIFOPlacesNewAtTail).
+//
+// FAIL-ON-REVERT: revert enqueue to the fast-path-send-then-dedup-only-when-full
+// form and BOTH assertions go RED — the burst fills all actionQueueDepth slots
+// (depth != 1) and the unrelated action is dropped queue-full (absent from the
+// drained queue).
+func TestQueue_SamePolicyBurstDoesNotStarveOthers_5853(t *testing.T) {
+	e := New(nil, nil)
+	defer e.Close()
+
+	// Burst == actionQueueDepth same-policy events. The pre-fix fast path
+	// fast-sends each (there is room until the 64th), so it NEVER hits the
+	// full/`default` branch, no supersede runs, and all 64 slots hold redundant
+	// 'flapping' duplicates. With the fix each enqueue supersedes the queued
+	// entry, so exactly one slot is ever used.
+	for i := 0; i < actionQueueDepth; i++ {
+		e.enqueue(plannedAction{policyName: "flapping"})
+	}
+	if got := int(e.counters.queueDepth.Load()); got != 1 {
+		t.Fatalf("same-policy burst of %d occupied %d queue slots; want 1 — dedup "+
+			"must run on EVERY enqueue, not only when full (#5853; pre-fix fills all %d slots)",
+			actionQueueDepth, got, actionQueueDepth)
+	}
+	if st := e.Stats(); st.Superseded != uint64(actionQueueDepth-1) {
+		t.Fatalf("Superseded=%d; want %d (every redundant same-policy duplicate is a benign dedup)",
+			st.Superseded, actionQueueDepth-1)
+	}
+	if st := e.Stats(); st.DroppedQueueFull != 0 {
+		t.Fatalf("DroppedQueueFull=%d after a same-policy burst; a dedup is benign, "+
+			"NOT a capacity drop — it must not inflate the queue_full alert metric (#5853)", st.DroppedQueueFull)
+	}
+
+	// The whole point: an UNRELATED policy's remediation must STILL enqueue.
+	// Pre-fix the queue is full of 'flapping', and supersede can only evict a
+	// SAME-policy entry (none matches 'unrelated'), so this action is dropped
+	// queue-full — the starvation the issue describes.
+	e.enqueue(plannedAction{policyName: "unrelated"})
+
+	got := drainPolicyNames(e)
+	if len(got) != 2 || got[0] != "flapping" || got[1] != "unrelated" {
+		t.Fatalf("queue = %v; want [flapping unrelated] — the unrelated remediation must "+
+			"not be starved/dropped by the same-policy burst (#5853)", got)
+	}
+	if st := e.Stats(); st.DroppedQueueFull != 0 {
+		t.Fatalf("DroppedQueueFull=%d; the unrelated policy must have been queued, not dropped (#5853)",
+			st.DroppedQueueFull)
+	}
+}
+
+// TestQueue_InterleavedPoliciesEachKeepOneSlot_5853 proves the invariant holds
+// across MANY policies interleaved with duplicates: N distinct policies each
+// firing repeatedly must leave exactly N queued entries (one per policy), FIFO
+// by first appearance, never N×duplicates.
+func TestQueue_InterleavedPoliciesEachKeepOneSlot_5853(t *testing.T) {
+	e := New(nil, nil)
+	defer e.Close()
+
+	policies := []string{"a", "b", "c", "d"}
+	// Fire each policy 5 times, interleaved.
+	for round := 0; round < 5; round++ {
+		for _, p := range policies {
+			e.enqueue(plannedAction{policyName: p})
+		}
+	}
+	if got := int(e.counters.queueDepth.Load()); got != len(policies) {
+		t.Fatalf("queueDepth=%d; want %d (one pending action per policy, no duplicates)",
+			got, len(policies))
+	}
+	// FIFO by first appearance: a, b, c, d (later duplicates supersede in place at
+	// the tail, but with all four already queued each duplicate re-drops its own
+	// and re-appends at the tail — the relative order of the four distinct
+	// policies is preserved because a same-policy supersede only moves its OWN
+	// entry). The final round fired a,b,c,d in order, so the tail order is a,b,c,d.
+	got := drainPolicyNames(e)
+	want := []string{"a", "b", "c", "d"}
+	if len(got) != len(want) {
+		t.Fatalf("queue=%v; want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("queue order=%v; want %v", got, want)
+		}
+	}
+}

--- a/pkg/eventengine/engine_integration_test.go
+++ b/pkg/eventengine/engine_integration_test.go
@@ -635,7 +635,16 @@ func TestQueue_ConcurrentProbesSerialize(t *testing.T) {
 
 // #2157 queue dedup: a second trigger of the SAME policy while the first is
 // stuck behind a held lock supersedes the older queued action (dedup-by-policy)
-// rather than queuing two; the drop is counted as queue_full.
+// rather than queuing two. #5853: the dedup runs on EVERY enqueue (not only when
+// the queue is full), so a same-policy burst keeps at most ONE pending action
+// and NEVER fills the bounded queue with duplicates. The dedup is counted as
+// Superseded (a benign replacement — the newer equivalent action still runs),
+// NOT DroppedQueueFull (which is reserved for a genuine capacity loss when the
+// queue is full of OTHER policies).
+//
+// FAIL-ON-REVERT: revert enqueue to dedup-only-when-full and Superseded stays 0
+// while DroppedQueueFull climbs, so the Superseded>=1 / QueueDepth<=1 /
+// DroppedQueueFull==0 assertions go RED.
 func TestQueue_DedupByPolicy(t *testing.T) {
 	s := newStore(t)
 	pol := &config.EventPolicy{
@@ -656,15 +665,25 @@ func TestQueue_DedupByPolicy(t *testing.T) {
 	e.HandleEvent(eventFor("ping_test_failed"))
 	waitFor(t, "worker retrying first action", func() bool { return e.Stats().Retried >= 1 })
 
-	// Fill the queue with same-policy triggers; dedup must keep at most one
-	// pending and count the rest as superseded. The cooldown is armed only on
-	// commit (not yet, since the lock is held), so evaluate does not filter
-	// these.
+	// Burst same-policy triggers; the early dedup (#5853) must keep at most one
+	// pending and supersede the rest. The cooldown is armed only on commit (not
+	// yet, since the lock is held), so evaluate does not filter these.
 	for i := 0; i < actionQueueDepth+4; i++ {
 		e.HandleEvent(eventFor("ping_test_failed"))
 	}
 
-	waitFor(t, "queue_full drops", func() bool { return e.Stats().DroppedQueueFull >= 1 })
+	// The benign dedup is counted as Superseded, not DroppedQueueFull, and the
+	// bounded queue never fills with duplicates: at most one same-policy action
+	// stays pending (the first event is already in-flight in the worker).
+	waitFor(t, "superseded dedup", func() bool { return e.Stats().Superseded >= 1 })
+	if got := e.Stats().DroppedQueueFull; got != 0 {
+		t.Errorf("DroppedQueueFull=%d; a same-policy burst is a benign dedup, not a "+
+			"capacity drop — it must not increment the queue_full metric (#5853)", got)
+	}
+	if got := e.Stats().QueueDepth; got > 1 {
+		t.Errorf("QueueDepth=%d; the one-pending-per-policy invariant must hold on "+
+			"every enqueue, so a same-policy burst occupies at most one slot (#5853)", got)
+	}
 
 	// Release and confirm it still converges to a single commit.
 	s.ExitConfigureSession("operator")

--- a/pkg/eventengine/engine_stale_revalidate_3750_test.go
+++ b/pkg/eventengine/engine_stale_revalidate_3750_test.go
@@ -130,11 +130,14 @@ func TestStale_RedefinedPolicyDropsOldBatch_3750(t *testing.T) {
 }
 
 // #3750 H3: the 30s cooldown must gate a QUEUED duplicate. The cooldown is
-// checked at evaluate but armed only on commit, and enqueue dedups only when the
-// queue is FULL — so two events for one policy both queue while the worker is
-// blocked on a held lock. When the lock releases the worker commits the first,
-// arms the cooldown, then must DROP the second (cooldown active) instead of
-// double-committing within the window.
+// checked at evaluate but armed only on commit. The worker dequeues event #1
+// (now retrying under the held lock, so it is IN-FLIGHT and no longer in the
+// channel); event #2 then enqueues — the queue holds no same-policy entry to
+// supersede (#1 is in the worker, not queued), so #2 is queued (this is true
+// both before and after the #5853 early-dedup change: the dedup is against
+// QUEUED entries, and #1 is not one). When the lock releases the worker commits
+// the first, arms the cooldown, then must DROP the second (cooldown active)
+// instead of double-committing within the window.
 //
 // FAIL-ON-REVERT: without the gate the worker commits both queued actions, so
 // Committed==2 and DroppedStale==0, failing the assertions below.
@@ -160,8 +163,9 @@ func TestStale_CooldownSuppressesQueuedDuplicate_3750(t *testing.T) {
 	waitFor(t, "worker retrying action #1", func() bool { return e.Stats().Retried >= 1 })
 
 	// Event #2: evaluateEvent sees the cooldown UNARMED (arm-on-commit, and #1
-	// has not committed), so it enqueues a duplicate. The queue is not full, so
-	// enqueue does NOT dedup it — exactly the H3 setup.
+	// has not committed), so it enqueues a duplicate. #1 is IN-FLIGHT in the
+	// worker (not in the channel), so the early dedup (#5853) finds no same-policy
+	// queued entry to supersede and #2 is queued — exactly the H3 setup.
 	e.HandleEvent(eventFor("ping_test_failed"))
 	waitFor(t, "duplicate queued", func() bool { return e.Stats().QueueDepth >= 1 })
 


### PR DESCRIPTION
Closes #5853

## Problem
The event-options action queue documents "at most one pending action per policy" (dedup-by-policy), but the dedup only ran **after** the bounded channel was already full. `enqueue` did an unconditional fast-path send first and reached `supersede` (drain → drop stale same-policy → refill) only in the full/`default` branch. So while the worker was blocked behind the config lock, a burst from **one** flapping policy filled all 64 slots with redundant duplicates (later discarded by cooldown/staleness), and the **next** remediation for an **unrelated** policy was dropped queue-full — one noisy policy could starve every other policy's automated remediation.

## Fix
`enqueue` now runs `supersede` on **every** enqueue (the fast-path send + `default` branch are gone), enforcing one-pending-per-policy up front. A same-policy duplicate **replaces** the queued entry instead of consuming a fresh slot, so a same-policy burst occupies a single slot and leaves the rest free.

**Concurrency:** reuses the already-proven `supersede` (drain → drop same-policy → re-enqueue survivors FIFO → new action at tail, #2869) under the producer-only `enqueueMu`. The worker stays lock-free (only removes items), drain→refill is atomic w.r.t. other producers, no survivor is lost/reordered, no new shared state, no lost wakeup. `supersede` is non-blocking (`select`-with-default), so `enqueue` never blocks even mid-shutdown (`e.actions` is never closed).

**Counter correctness:** a same-policy replacement is a **benign** dedup (the newer equivalent action still runs — nothing lost), now counted as a new `xpf_event_actions_superseded_total` rather than `droppedQueueFull`. `reason="queue_full"` is reserved for a **genuine** capacity loss (queue full of *other* policies, unfittable new arrival / lost survivor). Without this split the early dedup would inflate the alert-worthy `queue_full` metric on every routine burst and mask real drops.

## Tests (fail-on-revert)
- `TestQueue_SamePolicyBurstDoesNotStarveOthers_5853` — a burst of exactly `actionQueueDepth` same-policy events occupies **1** slot (pre-fix 64), and an unrelated policy still enqueues (pre-fix dropped queue-full).
- `TestQueue_InterleavedPoliciesEachKeepOneSlot_5853` — N distinct policies fired repeatedly leave exactly N queued entries, FIFO.
- `TestQueue_DedupByPolicy` updated: asserts `Superseded>=1` / `DroppedQueueFull==0` / `QueueDepth<=1` (was `DroppedQueueFull>=1`).
- `#3750` cooldown-suppresses-queued-duplicate behavior preserved (event #1 is in-flight in the worker, not queued, so the early dedup finds nothing to supersede and #2 still queues) — comments corrected.

**Verified via Go `-overlay`:** reverting `enqueue` to fast-path-send-then-dedup-only-when-full flips both the new burst test (`64 slots occupied; want 1`) and `TestQueue_DedupByPolicy` (`QueueDepth=4`, invariant violated) **RED**.

## Validation
- `gofmt` clean; `go build ./...` clean
- `go vet ./pkg/eventengine/ ./pkg/api/` clean
- `go test ./pkg/eventengine/ -race` and `./pkg/api/` green
- Docs: engine.go invariant + enqueue/supersede/enqueueMu comments, `pkg/eventengine/README.md` queue section, and the Prometheus metric help updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)