### PR TITLE
upgrade: fail stale-STOPPED recovery closed on known-good restart failure (#5846)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -91,6 +91,34 @@
   pkg/cli/cli_clear_exact_arity_5811_test.go (Write), pkg/cli/README.md (Edit),
   _Log.md (Edit)
 
+## 2026-07-15 — #5846 (bug/security/HIGH): stale-STOPPED upgrade recovery fails closed on restart failure
+- **Timestamp**: 2026-07-15 (fix/5846-stopped-recovery-restart-failclosed)
+- **Action**: In the resume-vs-fresh recovery (pkg/upgrade/cutover.go, Runner.Run),
+  when a stale journal's target A differs from the newly-staged B and its State is
+  STOPPED, recovery restarts the still-current KNOWN-GOOD daemon (the stopped cut
+  never flipped `current`). The pre-fix code only LOGGED a StartUnit failure, then
+  removeAllPartials + reset the journal and PROCEEDED into a fresh cut to B — so
+  the new cut used PreviousVersion (read from `current`) = the version that JUST
+  FAILED TO RESTART as its rollback target while the control plane was DOWN, and
+  the stale-recovery evidence was destroyed. Fix: if StartUnit fails during
+  stale-STOPPED recovery, return the error immediately (fail-closed) — do NOT
+  removeAllPartials, do NOT reset the journal. Preserve the stale journal +
+  partials so an operator or the next-boot re-run retries; a fresh cut proceeds
+  ONLY when the known-good restart succeeds. Scoped strictly to the STOPPED
+  sub-arm; the pure STAGED/PREFLIGHT/COPIED/VERIFIED sub-states (daemon never
+  stopped, live untouched) are unchanged. Mirrors the #5845 rolling.go/
+  kernel_drain.go fail-closed-on-lifecycle-error posture (errors-wrapped %w).
+- **Validation**: gofmt clean; go build ./...; go vet ./pkg/upgrade/ clean;
+  go test ./pkg/upgrade/ green. Fail-on-revert: a stale-STOPPED superseded
+  recovery with an injected StartUnit failure ABORTS (returns the error, current
+  stays 1.0.0, no verify/dropin for B, on-disk journal preserved as STOPPED/2.0.0,
+  partial dir preserved); the StartUnit-SUCCESS variant proceeds to the fresh 3.0.0
+  cut unchanged. Reverting to the swallow-and-log form flips the abort test RED
+  (confirmed via overlay).
+- **File(s)**: pkg/upgrade/cutover.go (Edit),
+  pkg/upgrade/stopped_recovery_restart_5846_test.go (Write),
+  docs/in-place-upgrade.md (Edit), _Log.md (Edit)
+
 ## 2026-07-15 — #5738 (bug/syslog) commit 2/2: CLI reloadSyslog source-iface + event-mode parity
 - **Timestamp**: 2026-07-15 (fix/5738-syslog-source-iface-parity)
 - **Action**: Aligned the CLI in-process commit path (reloadSyslog /

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -64,6 +64,23 @@ journal. The ONLY live-state mutations are STOP and FLIP-then-START;
 PREFLIGHT / COPY / VERIFY are pure and abortable (a failure there leaves
 the running daemon and config untouched).
 
+**Superseded stale cut (a NEWER version was staged before the old cut
+finished).** When the journaled target differs from the newly-staged
+version, the live system is recovered to a consistent state BEFORE a fresh
+cut starts, so the new cut's rollback target (`PreviousVersion`, read from
+`current`) is always a verified-live version. For a stale **STOPPED**
+journal the old cut already stopped the daemon but never flipped `current`,
+so recovery restarts the still-current KNOWN-GOOD daemon. That restart is
+**fail-closed** (#5846): if `StartUnit` FAILS, recovery ABORTS and returns
+the error — it does NOT sweep partials, reset the journal, or begin a fresh
+cut, because doing so would start a new cut whose rollback target is the
+version that JUST FAILED TO RESTART while the control plane is DOWN
+(possible unrecoverable state). The stale journal + partials are PRESERVED
+so an operator or the next-boot re-run retries recovery; a fresh cut
+proceeds only once the known-good daemon is confirmed restarted. This
+mirrors the fail-closed-on-lifecycle-error posture of the rolling/kernel
+drain paths (#5845).
+
 - **PREFLIGHT** — check `/var` free ≥ staged size + config-DB snapshot
   size + margin; GC eligible versions if short; take the pre-upgrade
   config-DB snapshot (`.partial`+rename, never torn) for rollback.

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -363,7 +363,25 @@ func (r *Runner) Run(opts Options) (err error) {
 				"recovering and starting fresh", stagedVer, j.TargetVersion)
 			if j.State == StateStopped {
 				if startErr := r.cfg.Sys.StartUnit(r.cfg.Unit); startErr != nil {
-					r.logf("upgrade: WARN failed to restart unit after stale-stop recovery: %v", startErr)
+					// #5846: the still-current KNOWN-GOOD daemon (the stopped cut
+					// never flipped `current`) FAILED to restart. Do NOT swallow
+					// this and fall through to a fresh cut: proceeding would
+					// removeAllPartials + reset the journal (destroying the
+					// stale-recovery evidence) and start a NEW cut whose rollback
+					// target (PreviousVersion, read from `current` below) is the very
+					// version that just failed to restart — all while the control
+					// plane is DOWN. Abort fail-closed: PRESERVE the stale journal
+					// and partials so an operator (or the next-boot re-run) retries
+					// recovery, and surface the error. This mirrors the
+					// fail-closed-on-lifecycle-error posture of the sibling drain
+					// paths (#5845 rolling.go / kernel_drain.go). Recovery only
+					// proceeds to the fresh cut once the known-good daemon is
+					// confirmed restarted (StartUnit == nil).
+					return fmt.Errorf("stale-stop recovery: the known-good daemon failed "+
+						"to restart after a superseded stopped cut (journaled target %s); "+
+						"refusing to start a new cut with an unverified rollback target while "+
+						"the control plane is down — preserving the stale journal and partials "+
+						"for recovery: %w", j.TargetVersion, startErr)
 				}
 			}
 			r.removeAllPartials()

--- a/pkg/upgrade/stopped_recovery_restart_5846_test.go
+++ b/pkg/upgrade/stopped_recovery_restart_5846_test.go
@@ -1,0 +1,142 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/upgrade/stagedgen"
+)
+
+// #5846: when a superseded STOPPED cut is recovered (its journaled target A
+// differs from a newly-staged B), Run restarts the still-current KNOWN-GOOD
+// daemon (the stopped cut never flipped `current`) before starting fresh. The
+// pre-#5846 code only LOGGED a StartUnit failure, then removeAllPartials + reset
+// the journal and proceeded into a fresh cut to B — so the new cut used a
+// rollback target (PreviousVersion, read from `current`) that JUST FAILED TO
+// RESTART, while the control plane was DOWN, and the stale-recovery evidence was
+// destroyed. The fix aborts fail-closed: it returns the error and PRESERVES the
+// stale journal + partials.
+
+// seedStaleStoppedSupersede sets up the resume-vs-fresh recovery scenario: a
+// stale STOPPED journal pinned to 2.0.0 (target A, current still 1.0.0), then a
+// newer 3.0.0 (target B) staged + published so the version compare supersedes
+// the stale cut and drives recovery. It also drops a partial version dir so a
+// test can prove removeAllPartials did / did not run. Returns the runner, cfg,
+// and the seeded partial dir path.
+func seedStaleStoppedSupersede(t *testing.T, fs *fakeSystem) (*Runner, Config, string) {
+	t.Helper()
+	r, cfg := testEnv(t, fs) // publishes gen of fs.stagedVersion (2.0.0)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	sg := r.stagedGenConfig()
+	gOld, _ := sg.ResolveCurrent()
+
+	// A STOPPED journal pinned to the OLD 2.0.0 generation: the cut stopped the
+	// daemon but never flipped `current` (still 1.0.0).
+	verDir := filepath.Join(cfg.VersionsDir, "2.0.0")
+	for _, b := range managedBins {
+		writeFakeBin(t, filepath.Join(verDir, b), "binary-"+b+"-2.0.0")
+	}
+	if err := os.WriteFile(filepath.Join(verDir, stagedgen.SrcGenFile), []byte(gOld+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jStale := &Journal{TargetVersion: "2.0.0", PreviousVersion: "1.0.0",
+		State: StateStopped, SourceGeneration: gOld}
+	if err := r.saveJournal(jStale); err != nil {
+		t.Fatal(err)
+	}
+
+	// Partial-dir evidence that removeAllPartials would sweep.
+	partial := filepath.Join(cfg.VersionsDir, partialPrefix+"stale-cut"+partialSuffix)
+	if err := os.MkdirAll(partial, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A newer apt install stages + publishes a NEW-version generation (3.0.0).
+	fs.stagedVersion = "3.0.0"
+	for _, b := range managedBins {
+		writeFakeBin(t, filepath.Join(cfg.StagedDir, b), "binary-"+b+"-3.0.0")
+	}
+	if _, err := sg.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	return r, cfg, partial
+}
+
+// TestCut_StaleStoppedRecoveryRestartFailsAborts_5846 pins the fail-closed
+// contract: if the known-good daemon restart FAILS during stale-STOPPED
+// recovery, Run aborts (returns the error) and does NOT proceed into a fresh cut
+// to B, and the stale journal + partials are preserved.
+//
+// FAIL-ON-REVERT: revert to swallowing the StartUnit error (log + fall through)
+// and this goes RED — Run proceeds to a successful 3.0.0 cut (current becomes
+// 3.0.0), returns nil, and the journal/partial are gone.
+func TestCut_StaleStoppedRecoveryRestartFailsAborts_5846(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg, partial := seedStaleStoppedSupersede(t, fs)
+
+	// The known-good restart during recovery FAILS.
+	fs.startFailOnce = true
+
+	err := r.Run(Options{})
+	if err == nil {
+		t.Fatal("recovery must abort when the known-good daemon restart fails; got nil " +
+			"(the #5846 fail-open: a fresh cut with an unverified rollback target while down)")
+	}
+	if !strings.Contains(err.Error(), "control plane is down") ||
+		!strings.Contains(err.Error(), "unverified rollback target") {
+		t.Fatalf("abort error must explain the unverified-rollback-while-down refusal, got %v", err)
+	}
+
+	// The fresh cut to 3.0.0 must NOT have run: `current` unchanged, and no cut
+	// steps (verify / dropin / stop) for 3.0.0 fired after the failed restart.
+	cur, _ := os.Readlink(filepath.Join(cfg.VersionsDir, currentLink))
+	if filepath.Base(cur) != "1.0.0" {
+		t.Fatalf("current = %q; the fresh cut must not have flipped — want 1.0.0 (known-good)", cur)
+	}
+	for _, step := range []string{"verify", "dropin"} {
+		for _, c := range fs.calls {
+			if c == step {
+				t.Fatalf("fresh cut step %q fired after the failed restart; recovery must abort BEFORE the new cut (calls=%v)", step, fs.calls)
+			}
+		}
+	}
+
+	// The stale journal must be PRESERVED (not reset), so the next boot / operator
+	// re-runs recovery.
+	j, jerr := r.loadJournal()
+	if jerr != nil {
+		t.Fatalf("stale journal must be preserved for recovery; loadJournal: %v", jerr)
+	}
+	if j.State != StateStopped || j.TargetVersion != "2.0.0" {
+		t.Fatalf("stale journal = {State:%v Target:%s}; must be preserved as {Stopped 2.0.0}", j.State, j.TargetVersion)
+	}
+
+	// Partials must be PRESERVED (removeAllPartials must not have run).
+	if _, serr := os.Stat(partial); serr != nil {
+		t.Fatalf("partial dir was swept despite the aborted recovery: %v", serr)
+	}
+}
+
+// TestCut_StaleStoppedRecoveryRestartSucceedsProceeds_5846 pins the unchanged
+// happy path: when the known-good restart SUCCEEDS, recovery proceeds to the
+// fresh cut to B exactly as before (current flips to 3.0.0, no error).
+func TestCut_StaleStoppedRecoveryRestartSucceedsProceeds_5846(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg, partial := seedStaleStoppedSupersede(t, fs)
+
+	// startFailOnce unset: the known-good restart SUCCEEDS, so recovery proceeds.
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("recovery with a successful known-good restart must proceed to the fresh cut, got %v", err)
+	}
+	cur, _ := os.Readlink(filepath.Join(cfg.VersionsDir, currentLink))
+	if filepath.Base(cur) != "3.0.0" {
+		t.Fatalf("current = %q after a successful-restart recovery, want 3.0.0 (fresh cut proceeded)", cur)
+	}
+	// The fresh cut swept the stale partial.
+	if _, serr := os.Stat(partial); serr == nil {
+		t.Errorf("partial dir survived a successful recovery+cut; removeAllPartials should have swept it")
+	}
+}


### PR DESCRIPTION
Closes #5846

## Problem (bug, security, HIGH)
The resume-vs-fresh recovery (`Runner.Run`, `pkg/upgrade/cutover.go`) handles a stale journal whose target A differs from a newly-staged B (a newer apt install superseded an in-flight cut). For a stale **STOPPED** journal the old cut stopped the daemon but never flipped `current`, so recovery restarts the still-current **known-good** daemon before starting a fresh cut to B.

But the `StartUnit` (known-good restart) error was only **logged**. Recovery then `removeAllPartials`'d, reset the journal to `StateInit`, and proceeded through the fresh cut for B — which sets its rollback target (`PreviousVersion`) from `current`, i.e. the version that **just failed to restart**, all while the control plane is **down**. So a new cut could run with an unverified rollback target on a node with no running daemon, and the stale-recovery evidence (journal + partials) was destroyed, hiding the fault.

## Fix (fail-closed)
If `StartUnit` fails during stale-STOPPED recovery, **return the error immediately**. Do **not** `removeAllPartials`, do **not** reset the journal — the control plane must be verified running before a new cut whose rollback target would otherwise be the just-failed version. The stale journal + partials are **preserved** so an operator (or the next-boot re-run) retries recovery; a fresh cut proceeds **only** once the known-good restart succeeds.

Scoped strictly to the STOPPED sub-arm — the pure `STAGED/PREFLIGHT/COPIED/VERIFIED` sub-states (daemon never stopped, live untouched) still sweep partials and start fresh as before. Mirrors the fail-closed-on-lifecycle-error posture of the sibling drain paths (#5845 `rolling.go` / `kernel_drain.go`), returning an `errors`-wrapped (`%w`) diagnostic.

## Tests (fail-on-revert)
`stopped_recovery_restart_5846_test.go`:
- **Abort** — a superseded stale-STOPPED recovery with an injected `StartUnit` failure: `Run` returns the error, `current` stays `1.0.0` (no flip), no fresh-cut steps (`verify`/`dropin`) for B fired, the on-disk journal is preserved as `{STOPPED, 2.0.0}`, and a seeded partial dir survives.
- **Proceed** — the `StartUnit`-success variant proceeds to the fresh `3.0.0` cut unchanged (happy path).

**Verified via Go `-overlay`:** reverting to the swallow-and-log form flips the abort test **RED** (`Run` returns `nil` and cuts to `3.0.0`).

## Validation
- `gofmt` clean; `go build ./...` clean
- `go vet ./pkg/upgrade/` clean
- `go test ./pkg/upgrade/` green
- `docs/in-place-upgrade.md` documents the fail-closed stale-STOPPED recovery contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)