### PR TITLE
config: resolve CopyPath destination parent by full identity

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48473,3 +48473,34 @@ top.
 - **Timestamp**: 2026-07-15
 - **Action**: #5850 (security) — gRPC MonitorPacketDrop called EventBuffer.Subscribe(256) directly, bypassing the defaultMaxSubscribers=64 admission cap (only TrySubscribe enforces it). The primary gRPC listener is loopback-clamped but UNAUTHENTICATED, so any local process could open an unbounded number of packet-drop streams — each adding a buffered channel AND expanding the synchronous O(N) per-event fan-out — exhausting memory + event-production CPU (a DoS distinct from #4484 L-2, which capped only REST SSE and wrongly treated gRPC as inherently bounded). Fixed server_diag_monitor.go MonitorPacketDrop to use TrySubscribe(256); on nil (cap reached) return status.Error(codes.ResourceExhausted, "too many concurrent event subscribers") BEFORE the defer sub.Close() and before streaming — mirroring the REST SSE 503 (pkg/api/sse.go). No cap/fan-out change — admission gate only; the existing defer sub.Close() (Subscription.Close → unsubscribe) frees the slot on teardown. Tests (new monitor_packet_drop_subscriber_cap_5850_test.go): fill the buffer to cap via TrySubscribe, then MonitorPacketDrop is rejected with ResourceExhausted (TestMonitorPacketDropRejectsOverCap_5850); a stream that tears down frees its slot (TestMonitorPacketDropTeardownFreesSlot_5850, goroutine + ctx cancel). Under-cap streaming is already covered by the existing MonitorPacketDrop match tests (they run against the new TrySubscribe path). Fail-on-revert verified: reverting to Subscribe admits the over-cap stream (returns after the bounded ctx timeout, not ResourceExhausted) → RED; restore → GREEN. gofmt/go vet/go build clean; go test -race ./pkg/grpcapi/ ./pkg/logging/ green. Doc: pkg/logging/README.md subscriber-cap paragraph corrected (request-created gRPC MonitorPacketDrop now uses TrySubscribe, not just REST SSE).
 - **File(s)**: pkg/grpcapi/server_diag_monitor.go, pkg/grpcapi/monitor_packet_drop_subscriber_cap_5850_test.go, pkg/logging/README.md
+
+- **Timestamp**: 2026-07-15
+  **Action**: #5822 (bug): config AST CopyPath could not resolve an existing
+  non-first same-keyword destination parent (and silently duplicated on
+  collision). CopyPath (pkg/config/ast_edit.go) resolved the destination parent
+  via insertNode (pkg/config/ast.go), whose per-level loop broke on the FIRST
+  child whose first keyword matched (matchNodeKeys returns 1 on a keyword-only
+  partial match) — so `copy ... to policy Z` with siblings [A B Z] descended
+  into policy A, could not find the rest of the dest-parent path, and failed
+  "destination parent ... not found" (or, on a resolvable existing target,
+  silently appended a duplicate). Fixed by routing CopyPath's dest-parent
+  resolution through childrenAtPath (longest-consumed-match) — the SAME resolver
+  RenamePath uses — unifying the two edit paths onto one navigator (the
+  divergence WAS the bug, per the issue). Added a collision guard (reject a copy
+  onto an existing same-identity target with keysEqual, like RenamePath) and
+  made it atomic (resolve parent + collision-check fully, THEN clone+append — a
+  failed copy leaves the tree byte-for-byte unchanged). A missing destination
+  parent (and a missing source) now wraps config.ErrPathNotFound so callers can
+  errors.Is it. Removed the now-dead insertNode helper (its only caller was
+  CopyPath).
+  **File(s)**: pkg/config/ast_edit.go, pkg/config/ast.go,
+  pkg/config/copypath_sibling_5822_test.go,
+  pkg/configstore/copy_sibling_5822_test.go, docs/config-schema.md, _Log.md
+  **Validation**: `go build ./...`; `go vet ./pkg/config/ ./pkg/configstore/`
+  clean; `go test -race ./pkg/config/ ./pkg/configstore/` green. Fail-on-revert:
+  restoring origin/master's ast.go+ast_edit.go (insertNode) flips the new tests
+  RED — non-first (app2/app3) + nested + integration copies error "destination
+  parent ... not found"; collision copy silently succeeds+duplicates;
+  missing-parent error is not ErrPathNotFound-wrapped. first-sibling (app1) is a
+  passing control. (Used a fresh GOCACHE=/dev/shm/cache5822 — shared cache is
+  contaminated.)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -634,6 +634,29 @@ append-on-reinsert) was removed. Covered by `TestRenameNonFirstSibling` in
 `A->A2` still works, colliding `B->C` rejected with the tree unchanged, and a
 post-rename `CompileConfig` seeing `[A B2 C]`).
 
+**Copy-side contract: same resolver, same collision rule (#5822).** `copy <src>
+to <dst>` (`CopyPath`, `ast_edit.go`) is the copy-side sibling of the rename fix.
+The pre-#5822 implementation resolved the DESTINATION PARENT through `insertNode`,
+whose per-level loop broke on the FIRST child whose FIRST key matched (the same
+`matchNodeKeys`-returns-`1` keyword-only match) — so a copy whose destination
+parent was a non-first same-keyword sibling (`copy ... to policy Z` with siblings
+`[A B Z]`) descended into `policy A`, could not find the rest of the
+destination-parent path, and failed `destination parent ... not found` (the issue
+title), or — on a resolvable-but-existing target — silently appended a DUPLICATE.
+`CopyPath` now resolves BOTH the source (`findNodeWithParent`) and the destination
+parent (`childrenAtPath`) by full identity — the SAME longest-key-match navigator
+`RenamePath` uses — so the two edit paths no longer carry divergent navigation
+semantics (that divergence WAS the bug). It rejects a copy whose new identity
+already exists under the destination parent (never a silent merge/duplicate), and
+resolves + validates fully BEFORE cloning/appending so a failed copy (missing
+destination parent OR collision) leaves the tree byte-for-byte unchanged; a
+missing destination parent wraps `config.ErrPathNotFound`. The now-dead
+first-keyword-match `insertNode` helper was removed. Covered by
+`copypath_sibling_5822_test.go` (`pkg/config`) — first/middle/last + nested
+multi-key sibling parents, collision-rejected-unchanged, missing-parent sentinel
+— and `copy_sibling_5822_test.go` (`pkg/configstore`, the operational
+`Store.Copy` path).
+
 **`annotate <path> "comment"` resolves through `navigatePath` (#4587).**
 `annotate` attaches a `/* comment */` to the statement at a path, and — like
 `delete`/`deactivate`/`rename` above — the path routinely crosses NAMED /

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -386,29 +386,6 @@ func (t *ConfigTree) findNode(path []string) (*Node, error) {
 	return navigateToNode(t.Children, path)
 }
 
-// insertNode inserts a node as a child at the given parent path.
-func (t *ConfigTree) insertNode(parentPath []string, node *Node) error {
-	children := &t.Children
-	pos := 0
-	for pos < len(parentPath) {
-		found := false
-		for _, child := range *children {
-			consumed := matchNodeKeys(child, parentPath, pos)
-			if consumed > 0 {
-				children = &child.Children
-				pos += consumed
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("destination parent path element %q not found", parentPath[pos])
-		}
-	}
-	*children = append(*children, node)
-	return nil
-}
-
 // findNodeWithParent navigates the tree and returns the target node
 // plus the parent's children slice (for insertion/removal at the correct level).
 func (t *ConfigTree) findNodeWithParent(path []string) (*Node, *[]*Node, error) {

--- a/pkg/config/ast_edit.go
+++ b/pkg/config/ast_edit.go
@@ -17,25 +17,63 @@ import (
 // remaining string matchers continue to work during the transition.
 var ErrPathNotFound = errors.New("path not found")
 
-// CopyPath copies a subtree from src to dst path.
-// The destination's last N keys (where N = len(sourceNode.Keys)) replace the source keys.
+// CopyPath copies a subtree from src to dst, replacing the source node's keys
+// with the destination's last N keys (N = len(sourceNode.Keys)).
+//
+// Both the source node and the destination PARENT are resolved by FULL identity
+// via the longest-consumed-match navigator (findNodeWithParent / childrenAtPath) —
+// the SAME resolver RenamePath uses — NOT the first-keyword-match insertNode the
+// pre-#5822 implementation used. insertNode stopped at the FIRST child whose
+// first keyword matched (matchNodeKeys returns a 1-key partial match when the
+// keyword matches but later keys differ), so a copy whose destination parent was
+// a NON-FIRST same-keyword sibling — e.g. `copy ... to policy Z` with siblings
+// [policy A, policy B, policy Z] — descended into `policy A` and inserted the
+// clone under the WRONG subtree (insertion-order dependent). This is the copy-side
+// sibling of the #3982 rename-side fix; keeping two navigators with different
+// ambiguity semantics WAS the bug, so insertNode is removed and both edit paths
+// now share one resolver.
+//
+// Collision + atomicity: a copy whose new identity already exists under the
+// destination parent is REJECTED (not silently merged or duplicated), mirroring
+// RenamePath's collision guard. The destination parent is resolved and the
+// collision checked BEFORE any mutation, and the source is cloned only after both
+// pass, so a failed copy (missing destination parent OR collision) leaves the
+// tree byte-for-byte unchanged. A missing destination parent wraps ErrPathNotFound
+// so callers can classify it with errors.Is.
 func (t *ConfigTree) CopyPath(src, dst []string) error {
 	if len(src) == 0 || len(dst) == 0 {
 		return fmt.Errorf("empty path")
 	}
 	srcNode, _, err := t.findNodeWithParent(src)
 	if err != nil {
-		return fmt.Errorf("source not found: %s", strings.Join(src, " "))
+		return fmt.Errorf("%w: source %s", ErrPathNotFound, strings.Join(src, " "))
 	}
-	cloned := cloneNodes([]*Node{srcNode})[0]
 	nk := len(srcNode.Keys)
 	if len(dst) < nk {
 		return fmt.Errorf("destination path too short")
 	}
-	cloned.Keys = append([]string(nil), dst[len(dst)-nk:]...)
-	// Find the parent for the destination
+	newKeys := append([]string(nil), dst[len(dst)-nk:]...)
 	dstParentPath := dst[:len(dst)-nk]
-	return t.insertNode(dstParentPath, cloned)
+
+	// Resolve the destination parent via the longest-consumed-match navigator so a
+	// non-first same-keyword sibling parent is reached by full identity (#5822).
+	dstParent, err := t.childrenAtPath(dstParentPath)
+	if err != nil {
+		return fmt.Errorf("%w: destination parent %s", ErrPathNotFound, strings.Join(dstParentPath, " "))
+	}
+	// Collision guard: reject a copy onto an existing same-identity target rather
+	// than silently duplicating it. Checked BEFORE any mutation.
+	for _, n := range *dstParent {
+		if keysEqual(n.Keys, newKeys) {
+			return fmt.Errorf("copy target already exists: %s", strings.Join(dst, " "))
+		}
+	}
+	// All checks passed — now (and only now) mutate: clone the source subtree,
+	// stamp the destination keys, and append under the resolved parent.
+	cloned := cloneNodes([]*Node{srcNode})[0]
+	cloned.Keys = newKeys
+	*dstParent = append(*dstParent, cloned)
+	return nil
 }
 
 // RenamePath moves a subtree from src to dst path.

--- a/pkg/config/copypath_sibling_5822_test.go
+++ b/pkg/config/copypath_sibling_5822_test.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+// #5822: CopyPath must resolve an EXISTING non-first same-keyword destination
+// parent by full identity (longest-consumed-match, like RenamePath), not the
+// pre-#5822 first-keyword-match insertNode which stopped at the first
+// same-keyword sibling. These tests build fixtures with ParseSetCommand +
+// SetPath (never NewParser — newlines merge, per the parser gotcha).
+//
+// FAIL-ON-REVERT: route CopyPath back through insertNode and every non-first /
+// nested target goes RED — insertNode descends into the FIRST same-keyword
+// sibling and cannot find the rest of the destination-parent path, so CopyPath
+// errors (or, on a collision, silently appends a duplicate).
+
+// ks is a terse key-group literal for descend.
+func ks(keys ...string) []string { return keys }
+
+// descend walks children matching each key group by FULL identity (keysEqual),
+// returning the reached node or nil. Unlike findNode/navigateToNode
+// (first-keyword-match), it disambiguates same-keyword siblings so a test can
+// inspect a specific sibling's subtree.
+func descend(children []*Node, groups ...[]string) *Node {
+	var node *Node
+	cur := children
+	for _, g := range groups {
+		node = nil
+		for _, c := range cur {
+			if keysEqual(c.Keys, g) {
+				node = c
+				break
+			}
+		}
+		if node == nil {
+			return nil
+		}
+		cur = node.Children
+	}
+	return node
+}
+
+// build5822AppsTree returns a tree with three same-keyword `application`
+// siblings (app1, app2, app3), each carrying `term t1 protocol tcp`.
+func build5822AppsTree(t *testing.T) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set applications application app1 term t1 protocol tcp",
+		"set applications application app2 term t1 protocol tcp",
+		"set applications application app3 term t1 protocol tcp",
+	} {
+		parts, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(parts); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestCopyPath_ResolvesExactSameKeywordSiblingParent_5822 pins acceptance #1/#3:
+// copying a subtree INTO the first / middle / last of three same-keyword
+// `application` siblings resolves the EXACT destination parent every time
+// (insertion-order independent) and never leaks into a wrong sibling.
+func TestCopyPath_ResolvesExactSameKeywordSiblingParent_5822(t *testing.T) {
+	for _, target := range []string{"app1", "app2", "app3"} {
+		t.Run(target, func(t *testing.T) {
+			tree := build5822AppsTree(t)
+			src := []string{"applications", "application", "app1", "term", "t1"}
+			dst := []string{"applications", "application", target, "term", "copied"}
+			if err := tree.CopyPath(src, dst); err != nil {
+				t.Fatalf("CopyPath into non-first same-keyword parent %q failed: %v "+
+					"(insertNode cannot resolve it — #5822)", target, err)
+			}
+			// The copied term must land under the TARGET application.
+			if descend(tree.Children, ks("applications"), ks("application", target), ks("term", "copied")) == nil {
+				t.Fatalf("copied term not found under %q after copy", target)
+			}
+			// It must NOT have leaked into any OTHER application — the #5822 bug
+			// resolves the FIRST same-keyword sibling as the parent.
+			for _, other := range []string{"app1", "app2", "app3"} {
+				if other == target {
+					continue
+				}
+				if descend(tree.Children, ks("applications"), ks("application", other), ks("term", "copied")) != nil {
+					t.Fatalf("copied term leaked into wrong sibling %q — copy resolved the wrong "+
+						"same-keyword parent (#5822)", other)
+				}
+			}
+		})
+	}
+}
+
+// TestCopyPath_NestedMultiKeySameKeywordParent_5822 pins acceptance #2: the
+// destination-parent path passes through TWO non-first same-keyword levels
+// (application app3 AND term t3), each of which must be resolved by full
+// identity.
+func TestCopyPath_NestedMultiKeySameKeywordParent_5822(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set applications application src term st source-port 100",
+		"set applications application app1 term t1 protocol tcp",
+		"set applications application app3 term t1 protocol tcp",
+		"set applications application app3 term t3 protocol udp",
+	} {
+		parts, _ := ParseSetCommand(cmd)
+		if err := tree.SetPath(parts); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	// Copy the `source-port 100` leaf into app3's SECOND term (t3).
+	src := []string{"applications", "application", "src", "term", "st", "source-port", "100"}
+	dst := []string{"applications", "application", "app3", "term", "t3", "source-port", "100"}
+	if err := tree.CopyPath(src, dst); err != nil {
+		t.Fatalf("CopyPath into nested non-first same-keyword parent failed: %v (#5822)", err)
+	}
+	if descend(tree.Children, ks("applications"), ks("application", "app3"), ks("term", "t3"), ks("source-port", "100")) == nil {
+		t.Fatal("copied leaf not found under app3/term t3")
+	}
+	// Must not have leaked into app1, app3/term t1, or the source.
+	if descend(tree.Children, ks("applications"), ks("application", "app1"), ks("term", "t1"), ks("source-port", "100")) != nil {
+		t.Fatal("copied leaf leaked into app1/term t1 (#5822)")
+	}
+	if descend(tree.Children, ks("applications"), ks("application", "app3"), ks("term", "t1"), ks("source-port", "100")) != nil {
+		t.Fatal("copied leaf leaked into app3/term t1 (wrong nested sibling, #5822)")
+	}
+}
+
+// TestCopyPath_CollisionRejectedAndTreeUnchanged_5822 pins the collision +
+// atomicity rule: a copy onto an EXISTING same-identity target is rejected, not
+// silently merged/duplicated, and the tree is left byte-for-byte unchanged.
+//
+// FAIL-ON-REVERT: insertNode appends the clone unconditionally, so the buggy
+// path returns nil (no error) and adds a duplicate sibling — both assertions RED.
+func TestCopyPath_CollisionRejectedAndTreeUnchanged_5822(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set security zones security-zone trust host-inbound-traffic system-services ping",
+		"set security zones security-zone existing host-inbound-traffic system-services ssh",
+	} {
+		parts, _ := ParseSetCommand(cmd)
+		if err := tree.SetPath(parts); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	before := tree.Format()
+
+	err := tree.CopyPath(
+		[]string{"security", "zones", "security-zone", "trust"},
+		[]string{"security", "zones", "security-zone", "existing"}, // already exists
+	)
+	if err == nil {
+		t.Fatal("copy onto an existing same-identity target must be rejected, not silently duplicated (#5822)")
+	}
+	if got := tree.Format(); got != before {
+		t.Fatalf("a rejected copy must leave the tree byte-for-byte unchanged (atomicity, #5822):\n"+
+			"--- before ---\n%s\n--- after ---\n%s", before, got)
+	}
+}
+
+// TestCopyPath_MissingDestParentWrapsErrPathNotFound_5822 pins the typed-error +
+// atomicity rule: a copy whose destination parent does not exist wraps the
+// ErrPathNotFound sentinel and leaves the tree unchanged.
+//
+// FAIL-ON-REVERT: insertNode returns a bare fmt.Errorf that does NOT wrap
+// ErrPathNotFound, so the errors.Is assertion goes RED.
+func TestCopyPath_MissingDestParentWrapsErrPathNotFound_5822(t *testing.T) {
+	tree := build5822AppsTree(t)
+	before := tree.Format()
+
+	err := tree.CopyPath(
+		[]string{"applications", "application", "app1", "term", "t1"},
+		[]string{"applications", "application", "nope", "term", "copied"}, // parent app "nope" absent
+	)
+	if err == nil {
+		t.Fatal("copy into a missing destination parent must error")
+	}
+	if !errors.Is(err, ErrPathNotFound) {
+		t.Fatalf("missing-dest-parent error must wrap ErrPathNotFound, got %v", err)
+	}
+	if got := tree.Format(); got != before {
+		t.Fatalf("a failed copy must leave the tree unchanged:\n--- before ---\n%s\n--- after ---\n%s", before, got)
+	}
+}

--- a/pkg/configstore/copy_sibling_5822_test.go
+++ b/pkg/configstore/copy_sibling_5822_test.go
@@ -1,0 +1,67 @@
+package configstore
+
+import (
+	"slices"
+	"testing"
+)
+
+// #5822 integration: the operational `copy` path (Store.Copy -> ConfigTree.CopyPath)
+// must resolve a NON-FIRST same-keyword destination parent (`security-zone zZ`,
+// the third of three siblings) and land the copied subtree under it — not fail
+// because the pre-#5822 insertNode stopped at the first same-keyword sibling.
+//
+// FAIL-ON-REVERT: routed back through insertNode, Store.Copy returns a
+// "destination parent path element ... not found" error (insertNode descends the
+// first sibling zA and cannot find zZ), so the `Copy` call errors and this test
+// goes RED.
+func TestStoreCopy_ResolvesNonFirstSiblingZone_5822(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	// Three same-keyword `security-zone` siblings; the copy target zZ is LAST.
+	for _, cmd := range []string{
+		"security zones security-zone zA host-inbound-traffic system-services ssh",
+		"security zones security-zone zB host-inbound-traffic system-services ping",
+		"security zones security-zone zZ host-inbound-traffic system-services dns",
+	} {
+		if err := s.SetFromInput(cmd); err != nil {
+			t.Fatalf("set %q: %v", cmd, err)
+		}
+	}
+
+	// Copy zA's `system-services ssh` into zZ. The destination PARENT
+	// (security-zone zZ host-inbound-traffic) passes through the NON-FIRST
+	// same-keyword sibling zZ.
+	if err := s.Copy(
+		[]string{"security", "zones", "security-zone", "zA", "host-inbound-traffic", "system-services", "ssh"},
+		[]string{"security", "zones", "security-zone", "zZ", "host-inbound-traffic", "system-services", "ssh"},
+	); err != nil {
+		t.Fatalf("Store.Copy into non-first sibling zone failed: %v (insertNode cannot resolve zZ — #5822)", err)
+	}
+	if !s.IsDirty() {
+		t.Error("store should be dirty after copy")
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit after copy: %v", err)
+	}
+
+	cfg := s.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("compiled config is nil after commit")
+	}
+	zZ := cfg.Security.Zones["zZ"]
+	if zZ == nil || zZ.HostInboundTraffic == nil {
+		t.Fatalf("zZ or its host-inbound-traffic missing after copy: %+v", cfg.Security.Zones["zZ"])
+	}
+	if !slices.Contains(zZ.HostInboundTraffic.SystemServices, "ssh") {
+		t.Fatalf("copied `ssh` did not land under zZ; zZ host-inbound services = %v (copy resolved the wrong "+
+			"same-keyword parent — #5822)", zZ.HostInboundTraffic.SystemServices)
+	}
+	// It must NOT have leaked into the OTHER siblings (the #5822 bug lands it
+	// under the first sibling).
+	if zB := cfg.Security.Zones["zB"]; zB != nil && zB.HostInboundTraffic != nil &&
+		slices.Contains(zB.HostInboundTraffic.SystemServices, "ssh") {
+		t.Fatalf("copied `ssh` leaked into wrong sibling zB: %v (#5822)", zB.HostInboundTraffic.SystemServices)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5822.

`CopyPath` resolved the destination **parent** through `insertNode`, whose per-level loop broke on the FIRST child whose FIRST keyword matched (`matchNodeKeys` returns a 1-key partial match when the keyword matches but later keys differ). So a copy whose destination parent was a **non-first same-keyword sibling** — `copy ... to policy Z` with siblings `[A B Z]` — descended into `policy A`, couldn't find the rest of the destination-parent path, and failed `destination parent ... not found`; on a resolvable-but-existing target it silently appended a **duplicate**.

`RenamePath` already resolves both source (`findNodeWithParent`) and destination parent (`childrenAtPath`) by **full identity** (longest-consumed key match, the #3982 rename-side fix). Keeping `CopyPath` on `insertNode`'s first-keyword-match while `RenamePath` used longest-match meant the two edit paths carried **different ambiguity semantics** — and that divergence was the bug.

## Fix (resolver unification + collision + atomicity)

- **Resolver unification:** `CopyPath` now resolves the destination parent via `childrenAtPath` (longest-consumed-match), the same navigator `RenamePath` uses. Both config-edit paths share one resolver.
- **Removed the now-dead `insertNode`** (its only caller was `CopyPath`).
- **Collision rule:** a copy whose new identity already exists under the destination parent is **rejected** (mirroring `RenamePath`), not silently merged/duplicated.
- **Atomicity:** the destination parent is resolved and the collision checked **before** any mutation; the source is cloned and appended only after both pass — so a failed copy (missing parent OR collision) leaves the tree **byte-for-byte unchanged**.
- **Typed error:** a missing destination parent (and a missing source) wraps `config.ErrPathNotFound` so callers can classify with `errors.Is` (the sentinel eventengine already relies on for `DeletePath`).

## Tests (fail-on-revert)

`pkg/config/copypath_sibling_5822_test.go`:
- first / middle / last of three same-keyword `application` siblings — copy resolves the exact parent, no leak into wrong siblings;
- nested two-level non-first same-keyword parents (`application app3` → `term t3`);
- collision → rejected + tree byte-for-byte unchanged;
- missing destination parent → wraps `ErrPathNotFound` + tree unchanged.

`pkg/configstore/copy_sibling_5822_test.go` (acceptance #6): the **operational** `Store.Copy` path into a non-first `security-zone` sibling, asserted via the compiled `ActiveConfig()`.

**Fail-on-revert verified:** restoring `origin/master`'s `ast.go`+`ast_edit.go` (the `insertNode` path) flips the new tests RED — non-first/nested/integration copies error `destination parent ... not found`, the collision copy silently succeeds and duplicates, and the missing-parent error is no longer `ErrPathNotFound`-wrapped; the first-sibling case is a passing control.

## Validation

- `go build ./...`
- `go vet ./pkg/config/ ./pkg/configstore/` — clean
- `go test -race ./pkg/config/ ./pkg/configstore/` — green

Doc: `docs/config-schema.md` gets the copy-side contract note alongside the existing #3982 rename note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)