### PR TITLE
config: cap retained parse diagnostics to bound heap on bad input (#5827)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-15 — #5827 (config/security): cap retained parse diagnostics (heap DoS)
+- **Timestamp**: 2026-07-15 (fix/5827-parse-error-cap)
+- **Action**: The recursive-descent config parser (pkg/config/parser.go) recorded
+  one ParseError per bad token via an UNCAPPED addError — so an all-invalid
+  payload up to the 16 MiB MaxConfigSize pinned ~16 million ParseError structs
+  (each holding a formatted message string) LIVE simultaneously: an unbounded-heap
+  OOM DoS reachable unauthenticated from the localhost gRPC/REST config-load API
+  AND the HA peer config-sync ingress. Fix: added `const maxParseErrors = 64` and
+  capped the RETAINED diagnostic set in addError + a new addErrorf (lazy-format so
+  the fmt.Sprintf call sites don't even allocate past the cap). Past the cap, both
+  count the drop in a saturating `Parser.suppressed` and return without appending;
+  Parse folds the count into ONE deterministic trailing "additional parse errors
+  suppressed (N)" diagnostic → len(errs) bounded to maxParseErrors+1, retained heap
+  O(cap), regardless of input size. The first ≤64 diagnostics keep parse order +
+  line/column. The lexer still drains the whole input O(input) for deterministic
+  termination (only RETENTION is capped) — mirrors the existing depth-cap
+  suppression (skipToBlockClose). ParseSetVerb/ParseSetCommand (flat-set) are
+  already bounded (return on the first bad token) — the shared cap needs no change
+  there. No cancellation/deadline added: input is pre-capped at 16 MiB and the
+  parse is O(input) linear.
+- **Validation**: gofmt clean; go build ./...; go vet ./pkg/config/ clean;
+  go test -race ./pkg/config/ (131s — the 16 MiB / 8 MiB DoS regression tests
+  under race instrumentation) + ./pkg/configstore/ GREEN. Fail-on-revert (overlay,
+  uncap addError/addErrorf): the retained-heap-budget test RED (524 MiB retained
+  for an 8 MiB payload vs 64 MiB budget), the mixed-order test RED (len 192 vs
+  ≤65), the depth×token test RED (434 vs ≤65). Existing config tests unaffected
+  (they assert len==0/>0, cap-safe).
+- **File(s)**: pkg/config/parser.go (Edit),
+  pkg/config/parser_error_cap_5827_test.go (Write),
+  pkg/configstore/parse_error_cap_5827_test.go (Write),
+  pkg/config/README.md (Edit), _Log.md (Edit)
+
 ## 2026-07-15 — #5832 (bug/audit/security): commit-time gate for Linux interface-name collisions
 - **Timestamp**: 2026-07-15 (fix/5832-ifname-collision-gate)
 - **Action**: config.LinuxIfName only does ReplaceAll("/","-") — NOT injective.

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -36,6 +36,26 @@ Regression coverage: `pkg/config/parser_recursion_dos_hb164_test.go`,
 `pkg/configstore/config_size_ceiling_hb164_test.go`,
 `pkg/api/config_load_bodycap_hb164_test.go`,
 `pkg/grpcapi/server_recvsize_hb164_test.go`.
+
+**Retained-diagnostic cap is a fourth guard (#5827).** The parser records one
+`ParseError` per bad token; an all-invalid payload (up to `MaxConfigSize`)
+otherwise pins ~16 million `ParseError` structs — each holding a formatted
+message string — LIVE at once, an unbounded-heap OOM DoS reachable from the
+same unauthenticated config-load / HA-sync ingress. `addError`/`addErrorf` now
+cap the RETAINED diagnostic set at `maxParseErrors` (64): past the cap they
+count the drop in `Parser.suppressed` (and skip formatting) instead of
+appending, and `Parse` folds the count into ONE deterministic trailing
+`additional parse errors suppressed (N)` diagnostic — so `len(errs)` is bounded
+to `maxParseErrors+1` and the retained heap to O(cap) regardless of input size.
+The first ≤64 diagnostics keep their parse order + line/column. The lexer still
+drains the whole input O(input) for deterministic termination (only the
+parser's RETENTION is capped), mirroring the `skipToBlockClose` depth-cap
+suppression. `ParseSetVerb`/`ParseSetCommand` (flat-set) are already bounded —
+they return on the FIRST bad token. Do NOT remove the cap. Regression coverage:
+`pkg/config/parser_error_cap_5827_test.go` (16 MiB bound + retained-heap budget
++ ordering + depth×token interaction + `FuzzParseErrorBound_5827`),
+`pkg/configstore/parse_error_cap_5827_test.go` (load-path concise-error /
+no-partial-apply).
 - `ParseSetCommand(input string) ([]string, error)` — `parser.go`.
   Parses one flat-set line into the path components. The caller then
   applies that path with `tree.SetPath()` to build the AST.

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -22,11 +22,33 @@ func (e ParseError) Error() string {
 // rather than recursing.
 const maxParseDepth = 256
 
+// maxParseErrors bounds the number of ParseError diagnostics a single parse
+// RETAINS (#5827). The parser records one ParseError per bad token
+// (parseStatements' TokenError branch, plus the statement-recovery / stray-brace
+// / depth-cap paths); a hostile or corrupt payload — e.g. a run of invalid
+// bytes up to the 16 MiB MaxConfigSize ceiling — otherwise produces MILLIONS of
+// ParseError structs, each pinning a formatted message string, all held LIVE
+// simultaneously until the parse returns. That is an unbounded-heap DoS on every
+// entry point that parses a config blob: config load/commit, HA config-sync, and
+// the CheckText validation path. Past the cap, addError/addErrorf stop retaining
+// (and stop formatting) diagnostics and bump `suppressed`; Parse appends a single
+// deterministic trailing "additional parse errors suppressed (N)" summary, so the
+// retained diagnostic set — and thus the retained heap — is bounded to O(cap)
+// regardless of input size. 64 is large enough to surface a useful set of real
+// errors in a genuinely-broken config while keeping the bound tight. The lexer
+// still drains the whole input in O(input) for deterministic termination; only
+// the parser's RETENTION is capped. This mirrors the depth-cap suppression
+// (skipToBlockClose) that already records one error for a pathological payload.
+const maxParseErrors = 64
+
 // Parser implements a recursive descent parser for Junos configuration syntax.
 type Parser struct {
 	lexer  *Lexer
 	errors []ParseError
 	depth  int // current block-nesting depth (bounded by maxParseDepth)
+	// suppressed counts ParseError diagnostics dropped once errors reached
+	// maxParseErrors (#5827). Parse folds it into a single trailing summary.
+	suppressed int
 }
 
 // NewParser creates a new Parser for the given configuration text.
@@ -60,10 +82,19 @@ func (p *Parser) Parse() (*ConfigTree, []ParseError) {
 		if tok.Type == TokenEOF {
 			break
 		}
-		p.addError(tok.Line, tok.Column,
-			fmt.Sprintf("unexpected %s at top level (unmatched '}'?)", tok))
+		p.addErrorf(tok.Line, tok.Column, "unexpected %s at top level (unmatched '}'?)", tok)
 		p.lexer.Next() // consume the stray token to guarantee forward progress
 		children = append(children, p.parseStatements()...)
+	}
+	// #5827: fold the suppressed-diagnostic count into a single deterministic
+	// trailing summary. Appended DIRECTLY (bypassing the cap) so it always
+	// surfaces exactly once even when the error set is at maxParseErrors, giving
+	// a bounded len(errors) <= maxParseErrors+1. The first maxParseErrors errors
+	// keep their parse order + line/column; this summary always sorts last.
+	if p.suppressed > 0 {
+		p.errors = append(p.errors, ParseError{
+			Message: fmt.Sprintf("additional parse errors suppressed (%d)", p.suppressed),
+		})
 	}
 	tree := &ConfigTree{Children: children}
 	return tree, p.errors
@@ -171,8 +202,8 @@ func (p *Parser) parseStatements() []*Node {
 	defer func() { p.depth-- }()
 	if p.depth > maxParseDepth {
 		tok := p.lexer.Peek()
-		p.addError(tok.Line, tok.Column,
-			fmt.Sprintf("configuration nesting exceeds maximum depth of %d", maxParseDepth))
+		p.addErrorf(tok.Line, tok.Column,
+			"configuration nesting exceeds maximum depth of %d", maxParseDepth)
 		// Drain the remainder of this over-deep block iteratively (no
 		// recursion) so a pathological payload records exactly one error and
 		// leaves the caller's matching '}' in place, rather than spamming one
@@ -252,8 +283,7 @@ func (p *Parser) parseStatement() *Node {
 		// Recovery: skip unexpected token
 		tok := p.lexer.Next()
 		if tok.Type != TokenEOF {
-			p.addError(tok.Line, tok.Column,
-				fmt.Sprintf("unexpected %s", tok))
+			p.addErrorf(tok.Line, tok.Column, "unexpected %s", tok)
 		}
 		return nil
 	}
@@ -321,8 +351,7 @@ func (p *Parser) parseStatement() *Node {
 		if closeTok.Type == TokenRBrace {
 			p.lexer.Next() // consume }
 		} else {
-			p.addError(closeTok.Line, closeTok.Column,
-				fmt.Sprintf("expected '}', got %s", closeTok))
+			p.addErrorf(closeTok.Line, closeTok.Column, "expected '}', got %s", closeTok)
 		}
 		return &Node{
 			Keys:     keys,
@@ -395,9 +424,36 @@ func (p *Parser) parseKeys() ([]string, []TokenType) {
 }
 
 func (p *Parser) addError(line, col int, msg string) {
+	// #5827: cap the retained diagnostic set. Past maxParseErrors, count the
+	// drop and return WITHOUT appending — so a pathological all-error payload
+	// never pins O(input) ParseError structs. Parse emits a single trailing
+	// summary of the suppressed count.
+	if len(p.errors) >= maxParseErrors {
+		p.suppressed++
+		return
+	}
 	p.errors = append(p.errors, ParseError{
 		Line:    line,
 		Column:  col,
 		Message: msg,
+	})
+}
+
+// addErrorf is addError with a lazily-formatted message: the fmt.Sprintf is
+// evaluated ONLY when the diagnostic is actually retained (#5827). Past the cap
+// it just bumps `suppressed`, so a hot error path (e.g. the stray-brace or
+// statement-recovery loops) does not allocate a per-token message string it
+// would immediately discard. The TokenError branch passes the lexer's
+// already-materialized tok.Value through addError; every call site that would
+// otherwise fmt.Sprintf a message uses addErrorf.
+func (p *Parser) addErrorf(line, col int, format string, args ...any) {
+	if len(p.errors) >= maxParseErrors {
+		p.suppressed++
+		return
+	}
+	p.errors = append(p.errors, ParseError{
+		Line:    line,
+		Column:  col,
+		Message: fmt.Sprintf(format, args...),
 	})
 }

--- a/pkg/config/parser_error_cap_5827_test.go
+++ b/pkg/config/parser_error_cap_5827_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// #5827: the recursive-descent parser recorded one ParseError per bad token with
+// an uncapped addError, so a hostile/corrupt payload (up to the 16 MiB
+// MaxConfigSize) pinned millions of ParseError structs LIVE simultaneously — an
+// unbounded-heap DoS on every config-parse entry point (load/commit, HA
+// config-sync, CheckText). The fix caps the RETAINED diagnostic set at
+// maxParseErrors and folds the rest into one trailing summary. The lexer still
+// drains the whole input in O(input) for deterministic termination.
+
+// invalidByte is a character the lexer always tokenizes as TokenError (not an
+// identifier char, brace, bracket, semicolon, quote, or whitespace). Verified by
+// the guard test below so the dense-payload tests can rely on it.
+const invalidByte = "@"
+
+// TestParseErrorCap_InvalidByteReallyErrors_5827 guards the assumption the
+// dense-payload tests rest on: a single invalidByte parses to exactly one error.
+func TestParseErrorCap_InvalidByteReallyErrors_5827(t *testing.T) {
+	_, errs := NewParser(invalidByte).Parse()
+	if len(errs) != 1 {
+		t.Fatalf("a single %q must yield exactly one parse error, got %d: %v", invalidByte, len(errs), errs)
+	}
+}
+
+// TestParseErrorCap_16MiBInvalidBounded_5827 is the primary deterministic
+// fail-on-revert lever: a 16 MiB all-invalid payload must parse+terminate with
+// NO panic/OOM and retain at most maxParseErrors+1 diagnostics (the cap errors
+// plus the trailing summary). It also pins that the summary reports the huge
+// suppressed count.
+//
+// FAIL-ON-REVERT: with the uncapped addError, len(errs) is ~16 million (one per
+// bad byte) — hugely greater than maxParseErrors+1 — and the summary is absent.
+func TestParseErrorCap_16MiBInvalidBounded_5827(t *testing.T) {
+	payload := strings.Repeat(invalidByte, 16<<20) // 16 MiB, MaxConfigSize
+	tree, errs := NewParser(payload).Parse()
+
+	if tree == nil {
+		t.Fatal("Parse must return a (possibly empty) tree, not nil, even on an all-invalid payload")
+	}
+	if len(errs) > maxParseErrors+1 {
+		t.Fatalf("retained diagnostics = %d, want <= maxParseErrors+1 (%d) — the uncapped "+
+			"addError pins one ParseError per bad byte (~16M) = OOM DoS (#5827)", len(errs), maxParseErrors+1)
+	}
+	// The trailing summary must be present and name a large suppressed count.
+	last := errs[len(errs)-1].Message
+	if !strings.HasPrefix(last, "additional parse errors suppressed (") {
+		t.Fatalf("last diagnostic must be the suppression summary, got %q", last)
+	}
+	// The first maxParseErrors diagnostics are the real per-byte errors.
+	if len(errs) != maxParseErrors+1 {
+		t.Fatalf("a 16 MiB all-invalid payload must fill the cap exactly: len=%d, want %d",
+			len(errs), maxParseErrors+1)
+	}
+}
+
+// TestParseErrorCap_RetainedHeapBudget_5827 asserts the retained heap after
+// parsing a dense-error payload is O(cap), not O(error count). It measures the
+// live-heap growth (runtime.MemStats HeapAlloc) with the returned diagnostics
+// kept alive; capped, this is dominated by the input payload + a handful of
+// structs; uncapped it would be hundreds of MiB of ParseError structs.
+//
+// The len<=cap+1 assertion above is the deterministic primary lever; this is the
+// stronger budget guard. The ceiling is generous (well above the payload, far
+// below the uncapped struct heap) to stay robust against GC/measurement noise.
+func TestParseErrorCap_RetainedHeapBudget_5827(t *testing.T) {
+	const payloadBytes = 8 << 20 // 8 MiB dense-error payload
+	payload := strings.Repeat(invalidByte, payloadBytes)
+
+	var m1, m2 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+	_, errs := NewParser(payload).Parse()
+	runtime.GC() // reclaim transient lexer strings + the empty tree; errs stays referenced below
+	runtime.ReadMemStats(&m2)
+
+	grew := int64(m2.HeapAlloc) - int64(m1.HeapAlloc)
+	// Uncapped: ~8M ParseError structs (each struct + its message string) ≈
+	// hundreds of MiB. Capped: the 8 MiB payload (still referenced) + ~cap
+	// structs. A 64 MiB ceiling passes the capped case and fails the uncapped.
+	const budget = 64 << 20
+	if grew > budget {
+		t.Fatalf("retained heap grew %d bytes after parsing an %d-byte dense-error payload; "+
+			"want <= %d — retention must be O(cap), not O(error count) (#5827)", grew, payloadBytes, budget)
+	}
+	if len(errs) > maxParseErrors+1 {
+		t.Fatalf("retained diagnostics = %d, want <= %d", len(errs), maxParseErrors+1)
+	}
+	runtime.KeepAlive(errs)
+	runtime.KeepAlive(payload)
+}
+
+// TestParseErrorCap_MixedValidInvalidOrderAndSummary_5827 pins that the FIRST
+// diagnostics preserve parse order + line/column, the trailing summary is
+// present when suppression happened, and valid statements before the error flood
+// still parse into the tree (the cap does not drop real config).
+func TestParseErrorCap_MixedValidInvalidOrderAndSummary_5827(t *testing.T) {
+	var b strings.Builder
+	// A valid statement first, then a flood of invalid bytes (each on its own
+	// line so line numbers advance and are checkable).
+	b.WriteString("system {\n")
+	b.WriteString("host-name fw;\n")
+	b.WriteString("}\n")
+	firstErrLine := 4 // the flood starts on line 4
+	for i := 0; i < maxParseErrors*3; i++ {
+		b.WriteString(invalidByte + "\n")
+	}
+	tree, errs := NewParser(b.String()).Parse()
+
+	// The valid `system { host-name fw; }` block parsed.
+	if len(tree.Children) == 0 || tree.Children[0].Keys[0] != "system" {
+		t.Fatalf("valid statement before the error flood was dropped; tree=%+v", tree.Children)
+	}
+	if len(errs) > maxParseErrors+1 {
+		t.Fatalf("len(errs)=%d, want <= %d", len(errs), maxParseErrors+1)
+	}
+	// First error keeps its line/column (ordering preserved).
+	if errs[0].Line != firstErrLine {
+		t.Fatalf("first diagnostic line = %d, want %d (order/position must be preserved)", errs[0].Line, firstErrLine)
+	}
+	// Errors are in non-decreasing line order for the retained prefix.
+	for i := 1; i < len(errs)-1; i++ { // exclude the trailing summary (line 0)
+		if errs[i].Line < errs[i-1].Line {
+			t.Fatalf("retained diagnostics out of order at %d: line %d < %d", i, errs[i].Line, errs[i-1].Line)
+		}
+	}
+	last := errs[len(errs)-1].Message
+	if !strings.HasPrefix(last, "additional parse errors suppressed (") {
+		t.Fatalf("trailing summary missing; last=%q", last)
+	}
+}
+
+// TestParseErrorCap_DepthAndTokenCapInteract_5827 exercises BOTH suppression
+// paths together: a payload with a flood of token errors AND over-deep nesting.
+// Both must suppress, the parse must terminate without panic, and the retained
+// set stays bounded (no double-count or blow-up).
+func TestParseErrorCap_DepthAndTokenCapInteract_5827(t *testing.T) {
+	var b strings.Builder
+	// A flood of token errors to reach the token cap...
+	for i := 0; i < maxParseErrors*2; i++ {
+		b.WriteString(invalidByte + " ")
+	}
+	// ...followed by an over-deep brace nest (well past maxParseDepth, far below
+	// any stack-overflow threshold) to also drive the depth-cap path.
+	b.WriteString("a " + strings.Repeat("{ ", maxParseDepth+50))
+	tree, errs := NewParser(b.String()).Parse()
+
+	if tree == nil {
+		t.Fatal("Parse returned nil tree on the combined token+depth payload")
+	}
+	if len(errs) > maxParseErrors+1 {
+		t.Fatalf("combined token+depth suppression retained %d diagnostics, want <= %d (#5827)",
+			len(errs), maxParseErrors+1)
+	}
+}
+
+// FuzzParseErrorBound_5827 pins the diagnostic bound for ARBITRARY input: for any
+// bytes, Parse must not panic and must retain at most maxParseErrors+1
+// diagnostics. The seeded corpus runs under `go test`; `go test -fuzz` explores
+// further. Deterministic termination relies on the lexer draining O(input).
+func FuzzParseErrorBound_5827(f *testing.F) {
+	f.Add("")
+	f.Add("system { host-name fw; }")
+	f.Add(strings.Repeat(invalidByte, 1000))
+	f.Add("a { b { c ] @ ; } }")
+	f.Add(strings.Repeat("@ ", 500) + strings.Repeat("{ ", maxParseDepth+10)) // token + depth caps
+	f.Fuzz(func(t *testing.T, in string) {
+		if len(in) > 16<<20 {
+			t.Skip() // every parse entry point size-gates at MaxConfigSize
+		}
+		_, errs := NewParser(in).Parse()
+		if len(errs) > maxParseErrors+1 {
+			t.Fatalf("len(errs)=%d exceeds maxParseErrors+1 (%d) for a %d-byte input", len(errs), maxParseErrors+1, len(in))
+		}
+	})
+}

--- a/pkg/configstore/parse_error_cap_5827_test.go
+++ b/pkg/configstore/parse_error_cap_5827_test.go
@@ -1,0 +1,47 @@
+package configstore
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5827 integration: the strict config-parse entry points (CheckText — day-0 /
+// check-config; the Load/SyncApply paths share the same NewParser().Parse()) must
+// stay safe on a dense-error payload. The parser fix caps the RETAINED diagnostic
+// set, so a hostile blob no longer pins O(input) ParseError structs before the
+// caller ever reads errs[0]. This pins the load-path contract: a bounded, concise
+// error and NO partial config applied. (The deterministic count/heap
+// fail-on-revert lever lives in pkg/config's parser_error_cap_5827_test.go.)
+
+// TestCheckText_DenseErrorPayloadConciseNoPartialApply_5827 drives the real
+// CheckText entry point with an 8 MiB all-invalid payload (under MaxConfigSize)
+// and asserts it returns a CONCISE error and a nil compiled config (no partial
+// apply), without OOM/panic.
+func TestCheckText_DenseErrorPayloadConciseNoPartialApply_5827(t *testing.T) {
+	payload := strings.Repeat("@", 8<<20) // 8 MiB dense-error, under the 16 MiB cap
+
+	compiled, err := CheckText(payload, -1)
+	if err == nil {
+		t.Fatal("CheckText must reject an all-invalid payload")
+	}
+	if compiled != nil {
+		t.Fatal("CheckText must NOT return a partial compiled config on a parse failure")
+	}
+	// Concise: the error surfaces the first diagnostic, never a dump of millions.
+	if !strings.Contains(err.Error(), "parse error") {
+		t.Fatalf("expected a concise parse error, got %q", err.Error())
+	}
+	if len(err.Error()) > 500 {
+		t.Fatalf("parse error must be concise (<=500 chars), got %d chars: %.120q...", len(err.Error()), err.Error())
+	}
+}
+
+// TestCheckText_OversizePayloadRejectedBeforeParse_5827 confirms the size gate
+// still fires first: a payload over MaxConfigSize is rejected up front (never
+// reaching the parser), a defence-in-depth layer complementing the parser cap.
+func TestCheckText_OversizePayloadRejectedBeforeParse_5827(t *testing.T) {
+	payload := strings.Repeat("@", (16<<20)+1) // one byte over MaxConfigSize
+	if _, err := CheckText(payload, -1); err == nil {
+		t.Fatal("CheckText must reject an over-MaxConfigSize payload before parsing")
+	}
+}


### PR DESCRIPTION
Closes #5827

## Problem (config, security)
The recursive-descent config parser records one `ParseError` per bad token, and `addError` appended each **uncapped**. A hostile/corrupt payload — a run of invalid bytes up to the 16 MiB `MaxConfigSize` — produced **millions of `ParseError` structs**, each pinning a formatted message string, held **live simultaneously** until the parse returned: an unbounded-heap OOM DoS reachable **unauthenticated** from the localhost gRPC/REST config-load API **and** the HA peer config-sync ingress (`Store.SyncApply`).

## Fix
- **Cap value: `maxParseErrors = 64`** — large enough to surface a useful set of real errors in a genuinely-broken config; small enough that the retained set (and heap) stays negligible.
- `addError` returns without appending past the cap, counting the drop in a saturating `Parser.suppressed`. A new `addErrorf` **defers its `fmt.Sprintf`** so the per-token message string isn't even formatted past the cap (the alloc the issue flags, not just the struct).
- `Parse` folds the suppressed count into **one deterministic trailing** `additional parse errors suppressed (N)` diagnostic → `len(errs) <= maxParseErrors+1`, retained heap **O(cap)** regardless of input size. The first ≤64 diagnostics keep parse order + line/column.
- The **lexer still drains the whole input O(input)** for deterministic termination — only the parser's *retention* is capped, mirroring the existing depth-cap suppression (`skipToBlockClose`).

### Shared bound — all parser entry points
The cap lives in `addError`/`addErrorf`, the single chokepoint for every retained diagnostic on the `NewParser().Parse()` path: **config load/commit** (`store_command.go`, `store_persist.go`, `store_commit.go`), **HA config-sync** (`store.go` `SyncApply`), and **CheckText** (`check.go`). `ParseSetVerb`/`ParseSetCommand` (flat-set) are already bounded — they return on the **first** bad token — so they need no change.

**Cancellation/deadline:** none added — input is pre-capped at 16 MiB by `checkConfigSize` and the parse is O(input) linear, terminating deterministically.

## Tests (fail-on-revert)
`pkg/config/parser_error_cap_5827_test.go`:
- **16 MiB all-invalid** → parses/terminates, no panic, `len(errs) <= cap+1`, summary present (the deterministic fail-on-revert lever).
- **Retained-heap budget** → live-heap growth after an 8 MiB dense-error parse stays O(cap); uncapped it is **~524 MiB** (verified).
- **Mixed valid/invalid** → first-error ordering + line/column preserved, summary present, valid statements before the flood still parse.
- **Depth-cap × token-cap interaction** → both suppress, no double-count/panic.
- **`FuzzParseErrorBound_5827`** → the bound holds for arbitrary bytes (seeded corpus).

`pkg/configstore/parse_error_cap_5827_test.go` — drives the real `CheckText` load path: a dense-error payload yields a **concise error + no partial config**, and the `MaxConfigSize` gate still fires first.

**Verified via Go `-overlay`:** un-capping `addError`/`addErrorf` flips the count tests RED (`len` 192/434 vs ≤65) and the heap test RED (524 MiB retained vs 64 MiB budget).

## Validation
- `gofmt` clean; `go build ./...` clean; `go vet ./pkg/config/` clean
- `go test -race ./pkg/config/ ./pkg/configstore/` GREEN
- `pkg/config/README.md` documents the cap alongside the sibling depth/size guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)