### PR TITLE
config: nil-safe interface walk in show presenters (#5910)

### DIFF
--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -134,12 +134,17 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 						}
 					}
 					ifc, ok := cfg.Interfaces.Interfaces[base]
-					if !ok {
+					// #5910: `ok` proves KEY presence, not a non-nil value — the
+					// tolerant load / HA config-sync path admits a present-but-nil
+					// InterfaceConfig (#3494/#5068). Guard nil AND walk units via
+					// the shared nil-safe iterator (a raw `range ifc.Units` /
+					// `unit.Number` nil-derefs and panics the daemon).
+					if !ok || ifc == nil {
 						continue
 					}
-					for _, unit := range ifc.Units {
+					config.RangeUnits(ifc, func(_ int, unit *config.InterfaceUnit) {
 						if wantUnit >= 0 && unit.Number != wantUnit {
-							continue
+							return
 						}
 						for _, addr := range unit.Addresses {
 							fmt.Printf("      Address: %s\n", addr)
@@ -150,7 +155,7 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 						if unit.DHCPv6 {
 							fmt.Printf("      DHCPv6: enabled\n")
 						}
-					}
+					})
 				}
 			}
 

--- a/pkg/cli/cli_show_security_zones_nil_5910_test.go
+++ b/pkg/cli/cli_show_security_zones_nil_5910_test.go
@@ -1,0 +1,100 @@
+// #5910: the local `show security zones detail` renderer (showZonesDisplay)
+// carried the SAME present-but-nil InterfaceConfig/InterfaceUnit nil-deref class
+// as #5813 that the #5068 pass missed. Its per-interface detail loop did
+// `ifc, ok := cfg.Interfaces.Interfaces[base]; if !ok { continue }` then
+// `range ifc.Units` — `ok` proves KEY presence, not a non-nil value, so a
+// present-but-nil InterfaceConfig (tolerant load / HA config-sync path,
+// #3494/#5068) nil-derefs, and a present-but-nil InterfaceUnit nil-derefs on
+// `unit.Number`. It now guards `!ok || ifc == nil` and walks units via the
+// shared config.RangeUnits nil-safe iterator.
+//
+// FAIL-ON-REVERT: restoring the raw `if !ok { continue }` + `range ifc.Units`
+// makes the injected nil slot deref and panic; the recover turns that into a
+// test FAILURE rather than a silent pass.
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// zoneIfaceCLIStore commits a config binding lo.0 to zone trust so the
+// showZonesDisplay(detail) per-interface loop runs. The CLI renderer splits the
+// logical "lo.0" to its BASE "lo" and looks that up, so the nil slots are
+// injected under the "lo" key.
+func zoneIfaceCLIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(`set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24
+set security zones security-zone trust interfaces ge-0/0/0.0
+set security zones security-zone untrust`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatalf("fixture missing active config")
+	}
+	if z := cfg.Security.Zones["trust"]; z == nil || len(z.Interfaces) == 0 {
+		t.Fatalf("fixture zone trust missing interface binding: %+v", z)
+	}
+	return store
+}
+
+// TestCLIShowZonesDisplayNilIfaceSlots5910 drives the REAL showZonesDisplay
+// detail renderer (dp nil: counters skipped) against a zone binding lo.0, with
+// a nil InterfaceConfig / nil InterfaceUnit injected under the base "lo" key.
+// Without the guards a present-but-nil slot nil-derefs (`range ifc.Units` /
+// `unit.Number`).
+func TestCLIShowZonesDisplayNilIfaceSlots5910(t *testing.T) {
+	cases := []struct {
+		name        string
+		mutate      func(cfg *config.Config)
+		wantAddress bool
+	}{
+		{"nil-interface-config", func(cfg *config.Config) {
+			// The CLI renderer splits "ge-0/0/0.0" to the BASE "ge-0/0/0" and
+			// looks that up, so inject the present-but-nil slot under the base.
+			cfg.Interfaces.Interfaces["ge-0/0/0"] = nil
+		}, false},
+		{"nil-interface-unit", func(cfg *config.Config) {
+			cfg.Interfaces.Interfaces["ge-0/0/0"] = &config.InterfaceConfig{
+				Name: "ge-0/0/0",
+				Units: map[int]*config.InterfaceUnit{
+					0: {Number: 0, Addresses: []string{"127.0.0.1/8"}},
+					7: nil, // present-but-nil unit alongside a valid one
+				},
+			}
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := zoneIfaceCLIStore(t)
+			cfg := store.ActiveConfig()
+			tc.mutate(cfg)
+			c := &CLI{store: store} // dp nil: skip counters, run interface detail
+			out := captureStdout(t, func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("showZonesDisplay %s panicked (nil-guard regression #5910): %v", tc.name, r)
+					}
+				}()
+				if err := c.showZonesDisplay(cfg, true, ""); err != nil {
+					t.Fatalf("showZonesDisplay: %v", err)
+				}
+			})
+			if tc.wantAddress && !strings.Contains(out, "127.0.0.1/8") {
+				t.Fatalf("valid unit address dropped by nil-unit skip:\n%s", out)
+			}
+		})
+	}
+}

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -255,8 +255,13 @@ read-only presentation (`show security flow session`, gRPC `GetSessions`, REST
 no-op on a nil `cfg`/`ifc`), so every read-only presenter that walks the
 interface tree stays panic-safe with the guard in ONE place. The three session
 egress-interface map builders (CLI `buildSessionEgressIfacesWithLookup`, gRPC
-`buildSessionFilter`, REST `buildSessionView`) all route through them; new
-interface-tree presenters should too rather than reintroducing a raw range.
+`buildSessionFilter`, REST `buildSessionView`) route through them, and #5910
+extended the same walk to the show presenters that the first pass missed —
+`showVLANs` (gRPC `show vlans`) and the `show security zones` detail renderers
+(gRPC `showZonesDetail`, CLI `showZonesDisplay`), where a bare
+`ifc, ok := …Interfaces[name]` proved key presence but not a non-nil value. New
+interface-tree presenters should route through these helpers too rather than
+reintroducing a raw range.
 
 **Comments (`# ...`, `// ...`, `/* ... */`) and unterminated blocks
 (M-8):** the lexer (`skipWhitespaceAndComments`) skips `#`/`//` line

--- a/pkg/grpcapi/server_show_interfaces_text.go
+++ b/pkg/grpcapi/server_show_interfaces_text.go
@@ -409,8 +409,13 @@ func (s *Server) showVLANs(cfg *config.Config, buf *strings.Builder) {
 			trunk  bool
 		}
 		var entries []vlanEntry
-		for _, ifc := range cfg.Interfaces.Interfaces {
-			for unitNum, unit := range ifc.Units {
+		// #5910: the tolerant load / HA config-sync path admits present-but-nil
+		// InterfaceConfig / InterfaceUnit map values (#3494/#5068). Walk via the
+		// shared nil-safe iterators so a nil slot is skipped, not dereferenced —
+		// a raw `range ifc.Units` / `unit.VlanID` nil-derefs and panics the
+		// in-process daemon during a routine `show vlans`.
+		config.RangeInterfaces(cfg, func(_ string, ifc *config.InterfaceConfig) {
+			config.RangeUnits(ifc, func(unitNum int, unit *config.InterfaceUnit) {
 				if unit.VlanID > 0 || ifc.VlanTagging {
 					entries = append(entries, vlanEntry{
 						iface:  ifc.Name,
@@ -420,8 +425,8 @@ func (s *Server) showVLANs(cfg *config.Config, buf *strings.Builder) {
 						trunk:  ifc.VlanTagging,
 					})
 				}
-			}
-		}
+			})
+		})
 		if len(entries) == 0 {
 			buf.WriteString("No VLANs configured\n")
 		} else {

--- a/pkg/grpcapi/server_show_presenter_nil_5910_test.go
+++ b/pkg/grpcapi/server_show_presenter_nil_5910_test.go
@@ -1,0 +1,143 @@
+// #5910: three read-only presenters OUTSIDE session scope carried the SAME
+// present-but-nil InterfaceConfig/InterfaceUnit nil-deref class as #5813 that
+// the #5068 pass missed:
+//   - showVLANs (this file): a raw `range cfg.Interfaces.Interfaces` +
+//     `range ifc.Units` walk with no nil guards.
+//   - showZonesDetail (this file): `ifc, ok := cfg.Interfaces.Interfaces[name]`
+//     then `range ifc.Units` — `ok` proves KEY presence, not a non-nil value,
+//     so a present-but-nil InterfaceConfig still nil-derefs.
+// Both now walk via config.RangeInterfaces / config.RangeUnits (the shared
+// nil-safe iterators added for #5813). The tolerant load / HA config-sync path
+// admits present-but-nil map values (#3494/#5068), so a routine `show vlans` /
+// `show security zones detail` against a peer-synced config panicked the
+// in-process daemon.
+//
+// FAIL-ON-REVERT: restoring a raw `range ifc.Units` (or dropping the RangeUnits
+// unit-guard) makes the injected nil slot deref and panic; the recover turns
+// that into a test FAILURE rather than a silent pass.
+package grpcapi
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// require5910NoPanic fails the test (rather than crashing the run) if fn panics,
+// naming the #5910 nil-guard regression.
+func require5910NoPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked (nil-guard regression #5910): %v", name, r)
+		}
+	}()
+	fn()
+}
+
+// TestShowVLANsNilSlots5910 drives the REAL showVLANs presenter (receiver
+// unused) against a tolerant config carrying a present-but-nil InterfaceConfig
+// AND a present-but-nil InterfaceUnit alongside valid units. Dropping the
+// RangeUnits unit-guard makes the nil unit's `unit.VlanID` deref panic. The
+// valid siblings still render; the nil slots contribute nothing.
+func TestShowVLANsNilSlots5910(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", VlanTagging: true, Units: map[int]*config.InterfaceUnit{
+			0:  {Number: 0},              // access unit (renders because VlanTagging)
+			50: {Number: 50, VlanID: 50}, // tagged subinterface
+			7:  nil,                      // present-but-nil unit (tolerant path)
+		}},
+		"zz-nil-ifc": nil, // present-but-nil InterfaceConfig (tolerant path)
+	}
+
+	var buf strings.Builder
+	require5910NoPanic(t, "showVLANs", func() {
+		(&Server{}).showVLANs(cfg, &buf)
+	})
+	out := buf.String()
+	if !strings.Contains(out, "ge-0/0/0") {
+		t.Fatalf("valid interface dropped from VLAN table:\n%s", out)
+	}
+	if !strings.Contains(out, "50") {
+		t.Fatalf("valid tagged unit 50 missing from VLAN table:\n%s", out)
+	}
+	if strings.Contains(out, "zz-nil-ifc") {
+		t.Fatalf("present-but-nil InterfaceConfig leaked into VLAN table:\n%s", out)
+	}
+}
+
+// zoneIfaceGRPCStore commits a config binding lo.0 to zone trust so the
+// showZonesDetail interface-detail loop runs and looks up the bound name. The
+// gRPC renderer looks up cfg.Interfaces.Interfaces[ifName] DIRECTLY (by the
+// logical name), so the nil slots are injected under the "lo.0" key.
+func zoneIfaceGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(`set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24
+set security zones security-zone trust interfaces ge-0/0/0.0
+set security zones security-zone untrust`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatalf("fixture missing active config")
+	}
+	z := cfg.Security.Zones["trust"]
+	if z == nil || len(z.Interfaces) == 0 {
+		t.Fatalf("fixture zone trust missing interface binding: %+v", z)
+	}
+	return store
+}
+
+// TestShowZonesDetailNilIfaceSlots5910 drives the REAL showZonesDetail renderer
+// (dp nil: counters skipped) against a zone that binds lo.0, with a nil
+// InterfaceConfig / nil InterfaceUnit injected under the looked-up key. Without
+// the guards a present-but-nil slot nil-derefs (`range ifc.Units` /
+// `unit.Addresses`).
+func TestShowZonesDetailNilIfaceSlots5910(t *testing.T) {
+	cases := []struct {
+		name        string
+		mutate      func(cfg *config.Config)
+		wantAddress bool
+	}{
+		{"nil-interface-config", func(cfg *config.Config) {
+			// The gRPC renderer looks up the LOGICAL name directly, so inject
+			// the present-but-nil slot under exactly that key.
+			cfg.Interfaces.Interfaces["ge-0/0/0.0"] = nil
+		}, false},
+		{"nil-interface-unit", func(cfg *config.Config) {
+			cfg.Interfaces.Interfaces["ge-0/0/0.0"] = &config.InterfaceConfig{
+				Name: "ge-0/0/0",
+				Units: map[int]*config.InterfaceUnit{
+					0: {Number: 0, Addresses: []string{"127.0.0.1/8"}},
+					7: nil, // present-but-nil unit alongside a valid one
+				},
+			}
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := zoneIfaceGRPCStore(t)
+			cfg := store.ActiveConfig()
+			tc.mutate(cfg)
+			s := &Server{store: store} // dp nil: skip counters, run interface detail
+			var buf strings.Builder
+			require5910NoPanic(t, "showZonesDetail "+tc.name, func() {
+				s.showZonesDetail(cfg, &buf)
+			})
+			if tc.wantAddress && !strings.Contains(buf.String(), "127.0.0.1/8") {
+				t.Fatalf("valid unit address dropped by nil-unit skip:\n%s", buf.String())
+			}
+		})
+	}
+}

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -130,8 +130,13 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 			buf.WriteString("  Interface details:\n")
 			for _, ifName := range zone.Interfaces {
 				fmt.Fprintf(buf, "    %s:\n", ifName)
+				// #5910: `ok` proves KEY presence, not a non-nil value — the
+				// tolerant load / HA config-sync path admits a present-but-nil
+				// InterfaceConfig (#3494/#5068). Walk units via the shared
+				// nil-safe iterator so a nil interface/unit slot is skipped, not
+				// dereferenced (a raw `range ifc.Units` panics the daemon).
 				if ifc, ok := cfg.Interfaces.Interfaces[ifName]; ok {
-					for _, unit := range ifc.Units {
+					config.RangeUnits(ifc, func(_ int, unit *config.InterfaceUnit) {
 						for _, addr := range unit.Addresses {
 							fmt.Fprintf(buf, "      Address: %s\n", addr)
 						}
@@ -141,7 +146,7 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 						if unit.DHCPv6 {
 							buf.WriteString("      DHCPv6: enabled\n")
 						}
-					}
+					})
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Closes #5910. Three read-only presenters **outside session scope** carried the same present-but-nil `InterfaceConfig`/`InterfaceUnit` nil-deref class as #5813 that the #5068 pass missed. The tolerant load / HA config-sync path (#3494/#5068) admits a present-key/nil-value `InterfaceConfig` (`cfg.Interfaces.Interfaces["ge-0/0/0"] = nil`) or `InterfaceUnit` (`ifc.Units[7] = nil`); a raw walk nil-derefs on such a slot and panics the in-process daemon during a routine `show`.

## The 3 sites migrated

- **`pkg/grpcapi/server_show_interfaces_text.go` `showVLANs`** — raw `for _, ifc := range cfg.Interfaces.Interfaces { for _, unit := range ifc.Units { unit.VlanID ... } }`, no nil guards. Its CLI twin (`cli_show_interfaces_stats.go`) was already #5068-guarded; this gRPC twin was not.
- **`pkg/grpcapi/server_show_zones_text.go` `showZonesDetail`** and **`pkg/cli/cli_show_security_zones.go` `showZonesDisplay`** — `ifc, ok := cfg.Interfaces.Interfaces[name]` then `range ifc.Units`. `ok` proves KEY presence, not a non-nil value, so a present-but-nil `InterfaceConfig` still nil-derefs, and a present-but-nil `InterfaceUnit` derefs on `unit.Number` / `unit.Addresses`.

All three now route through the shared nil-safe iterators `config.RangeInterfaces` / `config.RangeUnits` (`interfaces_iter.go`, added for #5813), which skip nil slots and no-op on a nil `cfg`/`ifc`. The CLI zone lookup additionally guards `!ok || ifc == nil` before the walk.

**No behavior change for valid configs:** the nil-skip only affects nil slots; valid siblings render identically (the helpers wrap the same `range`, so map iteration order is unchanged).

## Tests (fail-on-revert)

`server_show_presenter_nil_5910_test.go` + `cli_show_security_zones_nil_5910_test.go` inject a present-but-nil `InterfaceConfig` and a nil `InterfaceUnit` alongside a valid unit, then run the **real** presenters (`showVLANs`, `showZonesDetail`, `showZonesDisplay`), asserting no panic and that valid siblings still render. Fail-on-revert verified via `go test -overlay` restoring each site's origin/master raw walk: **every site goes RED** with the nil-deref panic surfaced as a test FAILURE (recover → `t.Fatalf`), not a silent pass.

## Validation

- `go build ./...` clean
- `go vet ./pkg/grpcapi/ ./pkg/cli/` clean except the pre-existing unrelated `cli.go:511` "unreachable code" warning (byte-identical on origin/master, untouched here)
- `go test -race ./pkg/grpcapi/ ./pkg/cli/` green
- `pkg/config/README.md` updated to record the extended presenter set

🤖 Generated with [Claude Code](https://claude.com/claude-code)