### PR TITLE
upgrade: make StartHealthDeadline authoritative in readiness gate (#5808)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48546,3 +48546,25 @@ top.
 - **File(s)**: pkg/grpcapi/config_session_lifecycle.go (new), pkg/grpcapi/config_session_lifecycle_5849_test.go (new), pkg/grpcapi/server.go, pkg/grpcapi/server_config.go, pkg/grpcapi/server_fabric_allowlist_4122_test.go, pkg/grpcapi/server_shutdown_monitor_4910_test.go, pkg/grpcapi/README.md, pkg/configstore/README.md
   **Action**: #5867 review-fold — add TestApplyTailReconcilesSurfacesMgmtRouteError_5867 (deferred-tail-join wiring regression test mirroring #5844) per independent-review MINOR; injects a sentinel as the final applyTailReconciles operand and asserts errors.Is(commitErr, sentinel) so dropping mgmtRouteErr from the tail errors.Join is fail-on-revert-caught. Production unchanged.
   **File(s)**: pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
+
+## 2026-07-15 — #5808 upgrade deadline-authoritative helper-readiness gate
+
+- **Timestamp**: 2026-07-15
+- **Action**: Make `StartHealthDeadline` authoritative across every blocking
+  op in the post-flip helper-readiness gate so a wedged `systemctl`/DBus or
+  an unresponsive control socket can never strand the cut past the rollback
+  deadline. Unified is-active into ONE ctx-bounded primitive shared by
+  pkg/upgrade and cmd/xpfd.
+- **File(s)**: pkg/upgrade/helper_health.go (ctx.WithTimeout gate, boundByDeadline
+  min-bound, context-aware poll timer, deadlineGateErr wrapping ctx cause,
+  last-genuine-failure preservation), pkg/upgrade/system_linux.go
+  (unitActiveProbeCtx via exec.CommandContext + exported UnitActive; fallback
+  poll ctx-bounded), cmd/xpfd/upgrade.go (UnitActive seam ctx-aware, delegates
+  to shared upgrade.UnitActive), pkg/upgrade/helper_health_5286_test.go +
+  cmd/xpfd/upgrade_helper_health_5286_test.go (seam signature ctx-aware),
+  pkg/upgrade/helper_health_deadline_5808_test.go (NEW — 5 fail-on-revert tests),
+  docs/in-place-upgrade.md (#5808 deadline-authoritative subsection).
+- **Validation**: go build ./... clean; go vet ./pkg/upgrade/ ./cmd/xpfd/ clean;
+  go test -race ./pkg/upgrade/ ./cmd/xpfd/ -count=3 GREEN; 3 fail-on-revert
+  overlays proven RED (exec.Command hang, no min-bound=10s, time.Sleep(poll)
+  5s overshoot).

--- a/cmd/xpfd/upgrade.go
+++ b/cmd/xpfd/upgrade.go
@@ -1,13 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -147,7 +146,7 @@ func buildUpgradeSystem(flags upgradeFlags) upgrade.System {
 		unit = upgrade.DefaultUnit
 	}
 	deps := upgrade.HelperHealthDeps{
-		UnitActive:    func() bool { return upgradeUnitActive(unit) },
+		UnitActive:    func(ctx context.Context) (bool, error) { return upgradeUnitActive(ctx, unit) },
 		Status:        upgradeHelperStatus,
 		HelperExe:     upgradeHelperExe,
 		ControlSocket: upgradeControlSock(flags.configDBDir),
@@ -193,10 +192,13 @@ func defaultUpgradeHelperExe(pid int) (string, error) {
 	return os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "exe"))
 }
 
-// defaultUpgradeUnitActive reports whether <unit>.service is active.
-func defaultUpgradeUnitActive(unit string) bool {
-	out, _ := exec.Command("systemctl", "is-active", unit+".service").Output()
-	return strings.TrimSpace(string(out)) == "active"
+// defaultUpgradeUnitActive reports whether <unit>.service is active. #5808: it
+// now delegates to the ONE shared, ctx-bounded primitive (upgrade.UnitActive →
+// exec.CommandContext) instead of duplicating an unbounded exec.Command, so
+// cmd/xpfd and pkg/upgrade have identical timeout behavior and a wedged
+// systemctl/DBus is killed at the readiness deadline.
+func defaultUpgradeUnitActive(ctx context.Context, unit string) (bool, error) {
+	return upgrade.UnitActive(ctx, unit)
 }
 
 // defaultUpgradeControlSocket resolves the helper control-socket path from the

--- a/cmd/xpfd/upgrade_helper_health_5286_test.go
+++ b/cmd/xpfd/upgrade_helper_health_5286_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -30,7 +31,7 @@ func TestBuildUpgradeSystem_WiresHelperProbe_5286(t *testing.T) {
 	})
 	defer restoreStatus()
 
-	restoreActive := swapUnitActive(func(string) bool { return true })
+	restoreActive := swapUnitActive(func(context.Context, string) (bool, error) { return true, nil })
 	defer restoreActive()
 
 	restoreExe := swapHelperExe(func(int) (string, error) {
@@ -45,8 +46,13 @@ func TestBuildUpgradeSystem_WiresHelperProbe_5286(t *testing.T) {
 	// revert of the Sys wiring to upgrade.NewSystem turns this RED.
 	cfg := newUpgradeConfig(upgradeFlags{unit: "xpfd", versionsDir: versions, configDBDir: t.TempDir()})
 
-	// deadline 0 => exactly one gate evaluation, then fail closed (no sleeps).
-	err := cfg.Sys.HelperHealthy(target, 0)
+	// A small positive deadline gives the gate budget for exactly one evaluation
+	// (the fake status returns instantly), then it fails closed at the deadline.
+	// #5808: the deadline is now AUTHORITATIVE — a zero deadline means "no
+	// budget", so the gate would (correctly) fail immediately WITHOUT consulting
+	// the helper; a tiny positive deadline is what lets the one evaluation (and
+	// thus the control-socket status query) run, which is what this test pins.
+	err := cfg.Sys.HelperHealthy(target, 50*time.Millisecond)
 	if err == nil {
 		t.Fatal("production System must FAIL CLOSED when the helper is up but not forwarding")
 	}
@@ -66,7 +72,7 @@ func TestBuildUpgradeSystem_ArmedForwardingTarget_Healthy(t *testing.T) {
 		return true, true, 777, nil // armed + forwarding
 	})
 	defer restoreStatus()
-	restoreActive := swapUnitActive(func(string) bool { return true })
+	restoreActive := swapUnitActive(func(context.Context, string) (bool, error) { return true, nil })
 	defer restoreActive()
 	restoreExe := swapHelperExe(func(int) (string, error) {
 		return filepath.Join(versions, target, "xpf-userspace-dp"), nil
@@ -95,7 +101,7 @@ func swapHelperExe(f upgrade.HelperExeFunc) func() {
 	return func() { upgradeHelperExe = old }
 }
 
-func swapUnitActive(f func(string) bool) func() {
+func swapUnitActive(f func(context.Context, string) (bool, error)) func() {
 	old := upgradeUnitActive
 	upgradeUnitActive = f
 	return func() { upgradeUnitActive = old }

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -180,6 +180,41 @@ forwarding path, so a healthy post-upgrade node MUST have an armed
 forwarding helper — there is no legitimate no-helper case to exempt. A
 not-healthy result flows into the existing rollback path below.
 
+#### `StartHealthDeadline` is AUTHORITATIVE across every blocking op (#5808)
+
+The gate must RETURN by `StartHealthDeadline` no matter which dependency
+wedges — otherwise a hung `systemctl`/DBus or an unresponsive control
+socket strands the post-flip cut PAST the point where an automatic
+rollback (standalone) or an operator-driven fence (HA) is still timely.
+Before #5808 the `systemctl is-active` precondition ran under an
+unbounded `exec.Command`, so a wedged systemd could block the whole gate
+indefinitely.
+
+The probe now bounds **every** blocking call by one `context.WithTimeout`
+of `StartHealthDeadline`:
+
+- **is-active probe** runs under `exec.CommandContext`; a wedged
+  `systemctl` is SIGKILLed at the deadline, not left blocking. This is the
+  single shared primitive `upgrade.UnitActive(ctx, unit)` — the wired
+  `HelperHealthProbe` precondition, the probe-less fallback poll, AND
+  `cmd/xpfd`'s wiring all route through it (one timeout behavior, not two
+  divergent `exec.Command` impls).
+- **control-socket status query** is capped to `min(StatusTimeout,
+  time-remaining-to-deadline)`, so a `StatusTimeout` larger than the
+  deadline can never run the query past it.
+- **poll wait** uses a context-aware timer (`select` on `ctx.Done()` vs
+  the poll timer), so it never overshoots the deadline by a full poll
+  interval.
+
+The gate distinguishes a definitive *not-ready* (retry until the deadline)
+from a deadline/cancellation: a deadline failure wraps the context cause,
+so callers can `errors.Is(err, context.DeadlineExceeded)`. The most-recent
+GENUINE readiness failure (e.g. "helper not forwarding") is retained as
+the diagnostic `last:` cause — a deadline *symptom* (a killed probe, or the
+status query having no remaining budget) does not mask it. Standalone
+auto-rollback and HA fence (`SkipStartHealthRollback`) both trigger
+PROMPTLY at the deadline instead of hanging.
+
 ### Rollback (binary + DB atomic)
 
 Standalone auto-rollback (on an unhealthy post-start helper) and operator

--- a/pkg/upgrade/helper_health.go
+++ b/pkg/upgrade/helper_health.go
@@ -1,6 +1,8 @@
 package upgrade
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -41,8 +43,14 @@ type HelperHealthDeps struct {
 	// daemon that is up while its helper is down / crash-looping / not
 	// forwarding reported "healthy" and the cut COMMITTED, clearing the
 	// rollback journal (standalone) or returning the node to HA election while
-	// it did not forward. Defaults to unitActiveProbe(DefaultUnit).
-	UnitActive func() bool
+	// it did not forward. Defaults to unitActiveProbeCtx(ctx, DefaultUnit).
+	//
+	// #5808: takes the readiness ctx so the underlying `systemctl is-active`
+	// runs under exec.CommandContext and is KILLED if it wedges (hung DBus),
+	// instead of blocking the whole gate past the rollback deadline. Returns
+	// distinguish definitive-inactive (false, nil), a genuine command failure
+	// (false, err), and deadline/cancel (false, ctx.Err() — errors.Is-able).
+	UnitActive func(ctx context.Context) (bool, error)
 	// Status performs the control-socket status query (armed+forwarding+pid).
 	Status HelperStatusFunc
 	// HelperExe resolves the armed helper PID's executable path (target-version
@@ -88,7 +96,7 @@ type HelperHealthDeps struct {
 func HelperHealthProbe(deps HelperHealthDeps) func(expectVersion string, deadline time.Duration) error {
 	unitActive := deps.UnitActive
 	if unitActive == nil {
-		unitActive = func() bool { return unitActiveProbe(DefaultUnit) }
+		unitActive = func(ctx context.Context) (bool, error) { return unitActiveProbeCtx(ctx, DefaultUnit) }
 	}
 	poll := deps.PollInterval
 	if poll <= 0 {
@@ -100,29 +108,87 @@ func HelperHealthProbe(deps HelperHealthDeps) func(expectVersion string, deadlin
 	}
 	return func(expectVersion string, deadline time.Duration) error {
 		wantDir := filepath.Clean(filepath.Join(deps.VersionsDir, expectVersion))
-		end := time.Now().Add(deadline)
+		// #5808: the deadline is AUTHORITATIVE across EVERY blocking op. One
+		// context bounds the systemctl is-active probe (exec.CommandContext,
+		// killed if it wedges), the control-socket status query (capped to the
+		// remaining time in checkHelperReady), and the poll wait — so a hung
+		// systemd/DBus can never strand the post-flip cutover past the rollback
+		// deadline. The gate returns promptly at `deadline` regardless.
+		ctx, cancel := context.WithTimeout(context.Background(), deadline)
+		defer cancel()
 		var last error
 		for {
-			last = checkHelperReady(deps, unitActive, statusTimeout, expectVersion, wantDir)
-			if last == nil {
+			res := checkHelperReady(ctx, deps, unitActive, statusTimeout, expectVersion, wantDir)
+			if res == nil {
 				return nil
 			}
-			if !time.Now().Before(end) {
-				return fmt.Errorf("post-cut dataplane readiness gate failed for target %s "+
-					"within %s (helper not confirmed armed+forwarding on the target "+
-					"version): %w", expectVersion, deadline, last)
+			// Keep the most-informative GENUINE readiness failure as `last`. A
+			// deadline/cancel symptom — a wedged probe killed by ctx, or the
+			// status query having no remaining budget (both wrap ctx.Err()) —
+			// must NOT mask the real cause (e.g. "helper not forwarding")
+			// observed on an earlier iteration in the final diagnostic (#5808).
+			if !errors.Is(res, context.DeadlineExceeded) && !errors.Is(res, context.Canceled) {
+				last = res
 			}
-			time.Sleep(poll)
+			// Deadline/cancel: surface it with the last sub-error and the ctx
+			// cause so callers can errors.Is it (context.DeadlineExceeded /
+			// Canceled) and distinguish it from a definitive not-ready.
+			if ctx.Err() != nil {
+				return deadlineGateErr(expectVersion, deadline, last, ctx.Err())
+			}
+			// Context-aware poll wait: ctx.Done() fires at the deadline even
+			// mid-sleep, so the wait NEVER overshoots the deadline by a full
+			// poll interval (#5808).
+			timer := time.NewTimer(poll)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return deadlineGateErr(expectVersion, deadline, last, ctx.Err())
+			case <-timer.C:
+			}
 		}
 	}
 }
 
-// checkHelperReady performs ONE evaluation of the three-part readiness gate.
-func checkHelperReady(deps HelperHealthDeps, unitActive func() bool, statusTimeout time.Duration, expectVersion, wantDir string) error {
+// deadlineGateErr wraps the readiness-gate deadline failure so it retains both
+// the last observed sub-error (for diagnosis) and the context cause (for
+// errors.Is against context.DeadlineExceeded / context.Canceled) (#5808).
+func deadlineGateErr(expectVersion string, deadline time.Duration, last, cause error) error {
+	return fmt.Errorf("post-cut dataplane readiness gate for target %s did not pass within %s "+
+		"(helper not confirmed armed+forwarding on the target version; last: %v): %w",
+		expectVersion, deadline, last, cause)
+}
+
+// boundByDeadline returns min(timeout, time-remaining-to-ctx-deadline) (#5808).
+// A per-op timeout must never let a single blocking call run past the overall
+// deadline; capping it keeps the deadline authoritative. Returns a non-positive
+// value (caller fails fast) when the deadline has already elapsed. If ctx has no
+// deadline, the configured timeout stands.
+func boundByDeadline(ctx context.Context, timeout time.Duration) time.Duration {
+	dl, ok := ctx.Deadline()
+	if !ok {
+		return timeout
+	}
+	if rem := time.Until(dl); rem < timeout {
+		return rem
+	}
+	return timeout
+}
+
+// checkHelperReady performs ONE evaluation of the three-part readiness gate,
+// bounded by ctx (#5808) so no single probe can run past the overall deadline.
+func checkHelperReady(ctx context.Context, deps HelperHealthDeps, unitActive func(context.Context) (bool, error), statusTimeout time.Duration, expectVersion, wantDir string) error {
 	// (a) Precondition: the unit process must be up. Necessary but NOT
 	// sufficient (#5286) — a Type=simple unit reports active immediately, before
-	// the dataplane arms.
-	if !unitActive() {
+	// the dataplane arms. Bounded by ctx (#5808): a wedged systemctl/DBus is
+	// killed at the deadline rather than blocking the gate past it. The error
+	// distinguishes a command/DBus failure or deadline (returned) from a
+	// definitive "not active" (retryable).
+	active, err := unitActive(ctx)
+	if err != nil {
+		return fmt.Errorf("unit-active probe: %w", err)
+	}
+	if !active {
 		return fmt.Errorf("unit not active (process not up)")
 	}
 	if deps.Status == nil {
@@ -131,6 +197,25 @@ func checkHelperReady(deps HelperHealthDeps, unitActive func() bool, statusTimeo
 	// (b) Positive dataplane readiness: the helper must be reachable AND report
 	// Enabled && ForwardingArmed — the authoritative "forwarding is live"
 	// signal. A down / stale / crash-looping helper fails here.
+	//
+	// #5808: cap the status timeout by the time REMAINING to the overall
+	// deadline (min(StatusTimeout, remaining)), so a StatusTimeout longer than
+	// the deadline cannot run the query past it. If nothing is left, fail now
+	// with the ctx cause.
+	statusTimeout = boundByDeadline(ctx, statusTimeout)
+	if statusTimeout <= 0 {
+		// No budget left for the status query — the deadline is effectively hit.
+		// Prefer the latched ctx cause, but fall back to DeadlineExceeded: the
+		// budget can reach zero a hair BEFORE context's timer fires ctx.Err()
+		// (time.Until(deadline) <= 0 while ctx.Err() is still nil), and this
+		// symptom must stay errors.Is-recognizable as a deadline (not a %!w(nil))
+		// so the retry loop does not let it mask the real prior cause (#5808).
+		cause := ctx.Err()
+		if cause == nil {
+			cause = context.DeadlineExceeded
+		}
+		return fmt.Errorf("no time left for control-socket status query: %w", cause)
+	}
 	enabled, armed, pid, err := deps.Status(deps.ControlSocket, statusTimeout)
 	if err != nil {
 		return fmt.Errorf("helper control-socket status query failed: %w", err)

--- a/pkg/upgrade/helper_health_5286_test.go
+++ b/pkg/upgrade/helper_health_5286_test.go
@@ -1,6 +1,7 @@
 package upgrade
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,7 +31,7 @@ func TestHelperHealthProbe_ArmedForwardingTargetVersion_Healthy(t *testing.T) {
 	versions := t.TempDir()
 	const target = "1.2.3"
 	probe := HelperHealthProbe(HelperHealthDeps{
-		UnitActive:   func() bool { return true },
+		UnitActive:   func(context.Context) (bool, error) { return true, nil },
 		Status:       fakeHelperStatus(true, true, 4242, nil),
 		HelperExe:    helperExeAt(versions, target),
 		VersionsDir:  versions,
@@ -49,8 +50,8 @@ func TestHelperHealthProbe_ActiveButNotForwarding_FailsClosed(t *testing.T) {
 	versions := t.TempDir()
 	const target = "1.2.3"
 	probe := HelperHealthProbe(HelperHealthDeps{
-		UnitActive:   func() bool { return true },              // process reported UP
-		Status:       fakeHelperStatus(true, false, 4242, nil), // enabled but NOT forwarding
+		UnitActive:   func(context.Context) (bool, error) { return true, nil }, // process reported UP
+		Status:       fakeHelperStatus(true, false, 4242, nil),                 // enabled but NOT forwarding
 		HelperExe:    helperExeAt(versions, target),
 		VersionsDir:  versions,
 		PollInterval: time.Millisecond,
@@ -72,7 +73,7 @@ func TestHelperHealthProbe_StaleVersionHelper_FailsClosed(t *testing.T) {
 	versions := t.TempDir()
 	const target = "2.0.0"
 	probe := HelperHealthProbe(HelperHealthDeps{
-		UnitActive:   func() bool { return true },
+		UnitActive:   func(context.Context) (bool, error) { return true, nil },
 		Status:       fakeHelperStatus(true, true, 4242, nil), // armed+forwarding...
 		HelperExe:    helperExeAt(versions, "1.0.0"),          // ...but the OLD binary
 		VersionsDir:  versions,
@@ -92,7 +93,7 @@ func TestHelperHealthProbe_StaleVersionHelper_FailsClosed(t *testing.T) {
 func TestHelperHealthProbe_UnitNotActive_FailsClosed(t *testing.T) {
 	versions := t.TempDir()
 	probe := HelperHealthProbe(HelperHealthDeps{
-		UnitActive:   func() bool { return false }, // process NOT up
+		UnitActive:   func(context.Context) (bool, error) { return false, nil }, // process NOT up
 		Status:       fakeHelperStatus(true, true, 1, nil),
 		HelperExe:    helperExeAt(versions, "1.2.3"),
 		VersionsDir:  versions,
@@ -108,7 +109,7 @@ func TestHelperHealthProbe_UnitNotActive_FailsClosed(t *testing.T) {
 func TestHelperHealthProbe_StatusQueryError_FailsClosed(t *testing.T) {
 	versions := t.TempDir()
 	probe := HelperHealthProbe(HelperHealthDeps{
-		UnitActive:   func() bool { return true },
+		UnitActive:   func(context.Context) (bool, error) { return true, nil },
 		Status:       fakeHelperStatus(false, false, 0, fmt.Errorf("dial unix: connection refused")),
 		HelperExe:    helperExeAt(versions, "1.2.3"),
 		VersionsDir:  versions,
@@ -130,9 +131,9 @@ func TestHelperHealthProbe_StatusQueryError_FailsClosed(t *testing.T) {
 // contrast is observable in a hostless test (the realSystem fallback otherwise
 // execs a real `systemctl is-active` that no test unit satisfies).
 func TestHelperHealthy_RevertToIsActiveOnly_RegressesToFalseHealthy(t *testing.T) {
-	old := unitActiveProbe
-	unitActiveProbe = func(string) bool { return true } // process reported UP
-	t.Cleanup(func() { unitActiveProbe = old })
+	old := unitActiveProbeCtx
+	unitActiveProbeCtx = func(context.Context, string) (bool, error) { return true, nil } // process reported UP
+	t.Cleanup(func() { unitActiveProbeCtx = old })
 
 	versions := t.TempDir()
 	const target = "9.9.9"
@@ -179,7 +180,7 @@ func TestRun_5286_NotForwardingHelper_DoesNotCommit(t *testing.T) {
 		writeFakeBin(t, filepath.Join(cfg.StagedDir, b), "binary-"+b+"-2.0.0")
 	}
 	fs.healthProbe = HelperHealthProbe(HelperHealthDeps{
-		UnitActive:   func() bool { return true },
+		UnitActive:   func(context.Context) (bool, error) { return true, nil },
 		Status:       fakeHelperStatus(true, false, 111, nil), // up but NOT forwarding
 		HelperExe:    helperExeAt(cfg.VersionsDir, "2.0.0"),
 		VersionsDir:  cfg.VersionsDir,

--- a/pkg/upgrade/helper_health_deadline_5808_test.go
+++ b/pkg/upgrade/helper_health_deadline_5808_test.go
@@ -1,0 +1,252 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #5808: the post-cut helper-readiness gate must keep the deadline AUTHORITATIVE
+// across EVERY blocking op — the `systemctl is-active` probe, the control-socket
+// status query, and the poll wait — so a wedged systemctl / hung DBus can never
+// strand the post-flip cutover past the rollback deadline.
+
+// writeFakeSystemctl installs a `systemctl` on PATH that sleeps far longer than
+// any test deadline, modelling a wedged is-active / hung DBus. exec.CommandContext
+// must KILL it at the deadline.
+func writeFakeSystemctl(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("fake systemctl relies on a POSIX shell")
+	}
+	dir := t.TempDir()
+	// `exec sleep` REPLACES the shell so the direct child of exec.CommandContext
+	// is the sleeper itself (a single process, like the real systemctl binary) —
+	// SIGKILL on ctx cancel then closes stdout and unblocks .Output(). A plain
+	// `sleep` would leave the sleeper as a grandchild holding the stdout pipe,
+	// which is a test-harness artifact, not the production shape.
+	script := "#!/bin/sh\nexec sleep 30\n"
+	path := filepath.Join(dir, "systemctl")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestUnitActive_WedgedSystemctlKilledByDeadline_5808 drives the REAL shared
+// primitive (UnitActive -> unitActiveProbeCtx -> exec.CommandContext) against a
+// never-returning `systemctl`, and asserts the ctx deadline KILLS it and the
+// call returns promptly with the ctx cause.
+//
+// FAIL-ON-REVERT: revert exec.CommandContext(ctx, ...) to exec.Command(...) and
+// the fake sleeps 30s — the call blocks well past the deadline and this test
+// hangs to its -timeout (RED).
+func TestUnitActive_WedgedSystemctlKilledByDeadline_5808(t *testing.T) {
+	writeFakeSystemctl(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	active, err := UnitActive(ctx, "xpfd")
+	elapsed := time.Since(start)
+
+	if active {
+		t.Fatal("a killed is-active probe must not report active")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("a deadline-killed probe must return the ctx cause (errors.Is DeadlineExceeded), got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("UnitActive took %v against a wedged systemctl; the deadline must KILL it (~100ms) — #5808", elapsed)
+	}
+}
+
+// baseDeadlineDeps returns deps whose unit-active + status + exe are all
+// injectable seams (no real systemd), with the version-dir tie satisfied.
+func baseDeadlineDeps(t *testing.T, statusTimeoutRecorder *time.Duration) HelperHealthDeps {
+	t.Helper()
+	versions := t.TempDir()
+	const target = "9.9.9"
+	// The status returns "up but NOT forwarding" so the gate keeps retrying until
+	// the deadline — exercising the poll/timeout bounds rather than passing.
+	return HelperHealthDeps{
+		UnitActive: func(context.Context) (bool, error) { return true, nil },
+		Status: func(_ string, timeout time.Duration) (bool, bool, int, error) {
+			if statusTimeoutRecorder != nil {
+				*statusTimeoutRecorder = timeout
+			}
+			return true, false, 1, nil // up, not forwarding -> retry
+		},
+		HelperExe:     func(int) (string, error) { return filepath.Join(versions, target), nil },
+		VersionsDir:   versions,
+		ControlSocket: "/unused.sock",
+	}
+}
+
+// TestHelperHealth_StatusTimeoutBoundedByRemaining_5808 pins that a StatusTimeout
+// LARGER than the overall deadline is capped to the remaining time, so the
+// control-socket query can never run past the deadline.
+//
+// FAIL-ON-REVERT: pass the raw StatusTimeout (not min(StatusTimeout, remaining))
+// and the recorded timeout is 10s, exceeding the deadline -> RED.
+func TestHelperHealth_StatusTimeoutBoundedByRemaining_5808(t *testing.T) {
+	var recorded time.Duration
+	deps := baseDeadlineDeps(t, &recorded)
+	deps.StatusTimeout = 10 * time.Second // far larger than the deadline
+	deps.PollInterval = 5 * time.Millisecond
+
+	const deadline = 120 * time.Millisecond
+	err := HelperHealthProbe(deps)("9.9.9", deadline)
+	if err == nil {
+		t.Fatal("gate must fail closed (helper not forwarding)")
+	}
+	if recorded <= 0 || recorded > deadline {
+		t.Fatalf("control-socket status timeout = %v; must be capped to <= remaining deadline (%v), "+
+			"never the raw 10s StatusTimeout (#5808)", recorded, deadline)
+	}
+}
+
+// TestHelperHealth_PollDoesNotOvershootDeadline_5808 pins that a poll interval
+// LARGER than the remaining time does not delay the gate's return past the
+// deadline (context-aware timer, not a blind time.Sleep(poll)).
+//
+// FAIL-ON-REVERT: restore time.Sleep(poll) and the gate returns after
+// deadline + poll (~5s) instead of ~deadline -> RED.
+func TestHelperHealth_PollDoesNotOvershootDeadline_5808(t *testing.T) {
+	deps := baseDeadlineDeps(t, nil)
+	deps.StatusTimeout = 20 * time.Millisecond
+	deps.PollInterval = 5 * time.Second // MUCH larger than the deadline
+
+	const deadline = 120 * time.Millisecond
+	start := time.Now()
+	err := HelperHealthProbe(deps)("9.9.9", deadline)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("gate must fail closed")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("deadline failure must errors.Is(context.DeadlineExceeded): %v", err)
+	}
+	if elapsed > deadline+2*time.Second {
+		t.Fatalf("gate returned after %v; the poll wait must not overshoot the deadline (%v) by a "+
+			"full interval (5s) — #5808", elapsed, deadline)
+	}
+}
+
+// TestHelperHealth_WedgedProbeReleasedAtDeadline_5808 models a blocking
+// unit-active probe (hung DBus) at the seam level: it blocks until the readiness
+// ctx is canceled, then returns. The gate must cancel that ctx at the deadline
+// (releasing the probe — no leaked goroutine/subprocess) and fail closed with
+// the ctx cause.
+//
+// FAIL-ON-REVERT: without the ctx threaded into checkHelperReady's unit-active
+// call, the probe blocks forever and the gate never returns -> hang to -timeout.
+func TestHelperHealth_WedgedProbeReleasedAtDeadline_5808(t *testing.T) {
+	released := make(chan struct{})
+	deps := baseDeadlineDeps(t, nil)
+	deps.PollInterval = 5 * time.Millisecond
+	deps.UnitActive = func(ctx context.Context) (bool, error) {
+		<-ctx.Done() // wedged until the gate cancels at the deadline
+		close(released)
+		return false, ctx.Err()
+	}
+
+	const deadline = 100 * time.Millisecond
+	start := time.Now()
+	err := HelperHealthProbe(deps)("9.9.9", deadline)
+	elapsed := time.Since(start)
+
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("wedged probe must fail closed at the deadline with the ctx cause, got %v", err)
+	}
+	if elapsed > deadline+2*time.Second {
+		t.Fatalf("gate took %v against a wedged probe; must return by ~deadline (%v) — #5808", elapsed, deadline)
+	}
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("wedged unit-active probe was NOT released after the deadline — leaked goroutine/subprocess (#5808)")
+	}
+}
+
+// TestCutover_WedgedHealthProbeBoundedRollbackAndFence_5808 drives BOTH cutover
+// branches end-to-end with the REAL bounded readiness probe wired to a WEDGED
+// unit-active seam: the post-flip health check for the new version blocks (hung
+// DBus) but is bounded by the deadline, so the standalone flow AUTO-ROLLS-BACK
+// and the HA flow (SkipStartHealthRollback) FENCES — both PROMPTLY, never
+// stranded past the deadline.
+//
+// FAIL-ON-REVERT: an unbounded probe would block the post-flip health wait
+// forever, stranding the cut past the rollback deadline — the elapsed-time bound
+// (and the whole run) would hang to -timeout.
+func TestCutover_WedgedHealthProbeBoundedRollbackAndFence_5808(t *testing.T) {
+	// wedgedHealthProbe wires the real HelperHealthProbe with a unit-active seam
+	// that blocks until the readiness ctx cancels, under a short 100ms deadline
+	// (ignoring the cfg's larger StartHealthDeadline to keep the test fast).
+	wedgedHealthProbe := func() func(string, time.Duration) error {
+		real := HelperHealthProbe(HelperHealthDeps{
+			UnitActive:    func(ctx context.Context) (bool, error) { <-ctx.Done(); return false, ctx.Err() },
+			Status:        func(string, time.Duration) (bool, bool, int, error) { return true, true, 1, nil },
+			HelperExe:     func(int) (string, error) { return "", nil },
+			VersionsDir:   t.TempDir(),
+			PollInterval:  5 * time.Millisecond,
+			StatusTimeout: time.Second,
+		})
+		return func(ver string, _ time.Duration) error { return real(ver, 100*time.Millisecond) }
+	}
+
+	runToUnhealthy2 := func(t *testing.T, opts Options) (err error, elapsed time.Duration, current string) {
+		t.Helper()
+		fs := newFakeSystem(t, "1.0.0")
+		r, cfg := testEnv(t, fs)
+		// First cut establishes a healthy 1.0.0 as the rollback target.
+		if e := r.Run(Options{AllowNoRollbackFirstCut: true}); e != nil {
+			t.Fatalf("first cut to 1.0.0: %v", e)
+		}
+		// Stage 2.0.0 and make its post-flip health WEDGE (bounded by the probe).
+		fs.stagedVersion = "2.0.0"
+		for _, b := range managedBins {
+			writeFakeBin(t, filepath.Join(cfg.StagedDir, b), "binary-"+b+"-2.0.0")
+		}
+		fs.healthProbe = wedgedHealthProbe()
+		start := time.Now()
+		err = r.Run(opts)
+		elapsed = time.Since(start)
+		cur, _ := os.Readlink(filepath.Join(cfg.VersionsDir, "current"))
+		return err, elapsed, filepath.Base(cur)
+	}
+
+	t.Run("standalone auto-rolls-back promptly", func(t *testing.T) {
+		err, elapsed, cur := runToUnhealthy2(t, Options{})
+		if err == nil || !strings.Contains(err.Error(), "rolled back to 1.0.0") {
+			t.Fatalf("standalone flow must auto-rollback on a wedged post-flip health probe, got %v", err)
+		}
+		if cur != "1.0.0" {
+			t.Fatalf("current=%q after standalone rollback, want 1.0.0", cur)
+		}
+		if elapsed > 5*time.Second {
+			t.Fatalf("standalone Run took %v; a wedged health probe must be deadline-bounded, not "+
+				"strand the cut past the rollback deadline (#5808)", elapsed)
+		}
+	})
+
+	t.Run("HA fences promptly (no auto-rollback)", func(t *testing.T) {
+		err, elapsed, cur := runToUnhealthy2(t, Options{SkipStartHealthRollback: true})
+		if err == nil || !strings.Contains(err.Error(), "rollback is operator-driven") {
+			t.Fatalf("HA flow must FENCE (surface failure, no auto-rollback) on a wedged health probe, got %v", err)
+		}
+		if cur != "2.0.0" {
+			t.Fatalf("current=%q; the HA fenced path leaves the target flipped for operator-driven "+
+				"rollback, want 2.0.0", cur)
+		}
+		if elapsed > 5*time.Second {
+			t.Fatalf("HA Run took %v; must be deadline-bounded (#5808)", elapsed)
+		}
+	})
+}

--- a/pkg/upgrade/system_linux.go
+++ b/pkg/upgrade/system_linux.go
@@ -2,6 +2,8 @@ package upgrade
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -138,16 +140,46 @@ func (s *realSystem) BinaryVersion(bin string) (string, error) {
 		"(want \"xpfd <version> ...\"): %q", bin, trimmed)
 }
 
-// unitActiveProbe reports whether <unit>.service is currently active per
-// `systemctl is-active`. It is a package var so BOTH the is-active-only
-// fallback below AND the wired HelperHealthProbe precondition share ONE seam a
-// test can force. Forcing it is the hinge of the #5286 RED-on-revert: with the
-// process reported ACTIVE but the helper NOT armed+forwarding, HelperHealthy is
-// (wrongly) healthy under the OLD is-active-only path but fails closed under
-// the new gate.
-var unitActiveProbe = func(unit string) bool {
-	out, _ := exec.Command("systemctl", "is-active", unit+".service").Output()
-	return strings.TrimSpace(string(out)) == "active"
+// unitActiveProbeCtx reports whether <unit>.service is active per `systemctl
+// is-active`, BOUNDED by ctx (#5808): a wedged systemctl / hung DBus is KILLED
+// when ctx is canceled (exec.CommandContext) instead of blocking the caller past
+// its deadline. It is the SINGLE production is-active primitive — the
+// is-active-only fallback below, the wired HelperHealthProbe precondition, AND
+// cmd/xpfd's probe (via the exported UnitActive) all route through it, so there
+// is exactly ONE timeout behavior (no more two divergent exec.Command impls).
+//
+// A package var so a test can force it. Forcing it is the hinge of the #5286
+// RED-on-revert (process ACTIVE but helper NOT armed+forwarding is healthy under
+// the OLD is-active-only path, fails closed under the new gate) AND the #5808
+// deadline tests (a fake that blocks until ctx cancels).
+//
+// Return semantics (#5808): (active, nil) is definitive; (false, ctx.Err()) when
+// the deadline/cancel killed the probe (errors.Is-able); (false, err) for a
+// genuine command failure (systemctl missing / DBus error). `systemctl
+// is-active` exits non-zero (3) for inactive/failed/activating and prints the
+// state to stdout — a recognized state under an *exec.ExitError is a DEFINITIVE
+// answer, NOT a command failure.
+var unitActiveProbeCtx = func(ctx context.Context, unit string) (bool, error) {
+	out, err := exec.CommandContext(ctx, "systemctl", "is-active", unit+".service").Output()
+	state := strings.TrimSpace(string(out))
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err() // deadline/cancel killed the probe
+		}
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && state != "" {
+			return state == "active", nil // definitive not-active, not a failure
+		}
+		return false, fmt.Errorf("systemctl is-active %s: %w (output: %q)", unit, err, state)
+	}
+	return state == "active", nil
+}
+
+// UnitActive is the exported, ctx-bounded is-active primitive so cmd/xpfd wires
+// ONE shared impl (through the unitActiveProbeCtx seam) rather than duplicating
+// exec.Command with its own, unbounded timeout behavior (#5808 unification).
+func UnitActive(ctx context.Context, unit string) (bool, error) {
+	return unitActiveProbeCtx(ctx, unit)
 }
 
 func (s *realSystem) HelperHealthy(expectVersion string, deadline time.Duration) error {
@@ -164,15 +196,28 @@ func (s *realSystem) HelperHealthy(expectVersion string, deadline time.Duration)
 	// NewSystemWithHelperHealth (cmd/xpfd) that ADDITIONALLY requires the
 	// dataplane to be armed+forwarding on the target version. This branch
 	// remains only for callers that inject no probe.
-	end := time.Now().Add(deadline)
+	// #5808: bound the whole fallback poll by one context — the is-active probe
+	// (killed if it wedges) and the poll wait — so this weak path also honors the
+	// deadline authoritatively and never strands on a hung systemctl/DBus.
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
 	for {
-		if unitActiveProbe(s.unit) {
+		active, err := unitActiveProbeCtx(ctx, s.unit)
+		if err == nil && active {
 			return nil
 		}
-		if time.Now().After(end) {
-			return fmt.Errorf("unit %s did not become active within %s", s.unit, deadline)
+		if ctx.Err() != nil {
+			return fmt.Errorf("unit %s did not become active within %s (last: %v): %w",
+				s.unit, deadline, err, ctx.Err())
 		}
-		time.Sleep(500 * time.Millisecond)
+		timer := time.NewTimer(500 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("unit %s did not become active within %s (last: %v): %w",
+				s.unit, deadline, err, ctx.Err())
+		case <-timer.C:
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #5808.

The post-flip helper-readiness gate (#5286) consults
`System.HelperHealthy(expectVersion, StartHealthDeadline)` before it
COMMITS (standalone: GC + clear the rollback journal) or returns the node
to HA election. But the `systemctl is-active` precondition ran under an
**unbounded** `exec.Command` — a wedged systemctl / hung DBus (or an
unresponsive control socket) could block the whole gate indefinitely,
stranding the cut PAST the point where an automatic rollback (standalone)
or an operator-driven fence (HA) is still timely. `StartHealthDeadline`
was advisory, not authoritative.

## Deadline-authoritative changes

One `context.WithTimeout(StartHealthDeadline)` now bounds **every**
blocking op in the gate:

- **is-active** runs under `exec.CommandContext` — a wedged systemctl is
  SIGKILLed at the deadline.
- **control-socket status query** capped to
  `min(StatusTimeout, remaining-to-deadline)` — a StatusTimeout larger
  than the deadline can't run past it.
- **poll wait** uses a context-aware timer (`select` on `ctx.Done()` vs
  the poll timer) — never overshoots by a full interval.
- deadline failures wrap the ctx cause →
  `errors.Is(err, context.DeadlineExceeded)`; a definitive not-ready
  (retryable) is distinguished from a command failure and from
  deadline/cancel. The most-recent GENUINE readiness failure (e.g.
  "helper not forwarding") is retained as the diagnostic `last:` cause —
  a deadline *symptom* no longer masks it.

## ONE unified production primitive

`systemctl is-active` is now the single ctx-bounded primitive
`upgrade.UnitActive(ctx, unit)` (backed by the `unitActiveProbeCtx`
seam). The wired `HelperHealthProbe` precondition, the probe-less
fallback poll, AND `cmd/xpfd`'s wiring all route through it — exactly one
timeout behavior, no two divergent `exec.Command` impls. `cmd/xpfd`'s
`defaultUpgradeUnitActive` delegates to it.

## Fail-on-revert tests (`pkg/upgrade/helper_health_deadline_5808_test.go`)

1. Wedged `systemctl` on PATH killed by the ctx deadline — revert
   `exec.CommandContext` → `exec.Command`: hangs to `-timeout` (RED).
2. `StatusTimeout` (10s) > remaining capped to ≤ deadline — revert the
   min-bound: recorded 10s > deadline (RED).
3. Poll interval (5s) > remaining does not overshoot — revert to
   `time.Sleep(poll)`: +5s overshoot (RED).
4. Wedged unit-active probe released at the deadline — no leaked
   goroutine/subprocess.
5. End-to-end cutover: standalone AUTO-ROLLS-BACK to the previous
   version; HA (`SkipStartHealthRollback`) FENCES ("rollback is
   operator-driven") — both bounded, never stranded past the deadline.

All three reverts (1–3) were independently proven RED via `-overlay`.

## Validation

- `go build ./...` clean
- `go vet ./pkg/upgrade/ ./cmd/xpfd/` clean
- `go test -race ./pkg/upgrade/ ./cmd/xpfd/ -count=3` GREEN
- `docs/in-place-upgrade.md` gains a `#5808` deadline-authoritative
  subsection documenting the readiness/deadline contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)