### PR TITLE
grpcapi: nil-safe interface walk in show interfaces extensive/detail (#5913)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48582,3 +48582,20 @@ top.
 - **Timestamp**: 2026-07-15
   **Action**: #5813 (CLI/gRPC/REST session display nil-slot panic) — the tolerant load / HA config-sync path admits present-but-nil InterfaceConfig / InterfaceUnit map values (#3494/#5068). THREE identical session egress-interface map builders walked cfg.Interfaces.Interfaces + ifc.Units with NO nil guard and nil-dereferenced/panicked the in-process daemon on a routine session display: CLI buildSessionEgressIfacesWithLookup (session_display.go), gRPC buildSessionFilter (server_sessions.go), REST buildSessionView (api/sessions.go). CENTRALIZED the tolerant walk into two shared nil-safe iterators in pkg/config — RangeInterfaces (skips nil InterfaceConfig) + RangeUnits (skips nil InterfaceUnit) in new interfaces_iter.go — and migrated all three builders onto them (first-wins ifindex/vlanID ordering preserved). Panic-recovery in CLI.Run NOT added: the nil-guard stands on its own and a shared helper is the durable fix; a blanket recover would mask future presenter bugs. AUDIT of the remote surfaces: the gRPC + REST session/filter builders had the IDENTICAL raw walk (not merely the CLI) — both fixed here; the broader interface-show presenters (terse/detail/extensive/summary/completers) were already guarded by #5068 and are out of scope, but the shared iterators are now available for future migration; interfaceAliasSet (server_diag_monitor.go) was already nil-safe. Tests (fail-on-revert): pkg/config interfaces_iter_5813_test.go (RangeInterfaces/RangeUnits skip nils, nil-receiver no-ops); pkg/cli session_display_nil_5813_test.go (deterministic-lookup seam with nil ifc + nil unit + valid siblings asserting first-wins mapping and nil-slots-omitted; REAL showFlowSession handler driven with fake loaded dp and nil slots on the loopback so the production net.InterfaceByName path reaches the deref; a -race concurrent-publish test — atomic.Pointer swap of fresh tolerant configs vs 8 concurrent read-only presenters); pkg/grpcapi + pkg/api nil-slot builder tests on a loopback-zone store. Fail-on-revert verified firsthand: removing the RangeUnits unit-guard → all four packages RED; removing either nil-interface guard (RangeInterfaces or RangeUnits ifc-guard — intentionally double-layered) → the dedicated pkg/config test RED. go build ./... clean; go vet clean on config/grpcapi/api (pkg/cli shows only the pre-existing cli.go:511 unreachable-code warning, unrelated — byte-identical on origin/master); go test -race green on all four packages. Doc: pkg/config/README.md Gotchas — new "Present-but-nil interface/unit slots" entry pointing at the shared iterators.
   **File(s)**: pkg/config/interfaces_iter.go, pkg/config/interfaces_iter_5813_test.go, pkg/cli/session_display.go, pkg/cli/session_display_nil_5813_test.go, pkg/grpcapi/server_sessions.go, pkg/grpcapi/server_sessions_nil_5813_test.go, pkg/api/sessions.go, pkg/api/sessions_nil_5813_test.go, pkg/config/README.md, _Log.md
+
+## 2026-07-15 — #5913 show interfaces extensive/detail nil-guard
+
+- **Timestamp**: 2026-07-15
+- **Action**: Route the config-map-build loops in showInterfacesExtensive
+  (ifCfgMap) and showInterfacesDetail (ifDescMap) through config.RangeInterfaces
+  so a present-but-nil InterfaceConfig slot (tolerant load / HA config-sync) no
+  longer nil-derefs ifc.Name/ifc.Description and panics the daemon. Same
+  #5813/#5910 class, same file #5910 patched.
+- **File(s)**: pkg/grpcapi/server_show_interfaces_text.go (2 loops → RangeInterfaces),
+  pkg/grpcapi/server_show_interfaces_nil_5913_test.go (NEW — 2 fail-on-revert
+  tests driving the real presenters), pkg/config/README.md (nil-safe-iterator
+  guarded-site enumeration extended to the interfaces presenters).
+- **Validation**: go build ./... clean; go vet ./pkg/grpcapi/ clean;
+  go test -race ./pkg/grpcapi/ GREEN; both raw-walk reverts proven RED via
+  -overlay (nil-deref panic caught by recover→t.Fatalf), each revert breaking
+  only its own test (independent guards).

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -259,7 +259,11 @@ egress-interface map builders (CLI `buildSessionEgressIfacesWithLookup`, gRPC
 extended the same walk to the show presenters that the first pass missed —
 `showVLANs` (gRPC `show vlans`) and the `show security zones` detail renderers
 (gRPC `showZonesDetail`, CLI `showZonesDisplay`), where a bare
-`ifc, ok := …Interfaces[name]` proved key presence but not a non-nil value. New
+`ifc, ok := …Interfaces[name]` proved key presence but not a non-nil value.
+#5913 extended it once more to the `show interfaces extensive`/`detail` text
+presenters (gRPC `showInterfacesExtensive`/`showInterfacesDetail`), whose
+config-map builders (`ifCfgMap`/`ifDescMap`) still carried the same raw
+`range cfg.Interfaces.Interfaces` reading `ifc.Name`/`ifc.Description`. New
 interface-tree presenters should route through these helpers too rather than
 reintroducing a raw range.
 

--- a/pkg/grpcapi/server_show_interfaces_nil_5913_test.go
+++ b/pkg/grpcapi/server_show_interfaces_nil_5913_test.go
@@ -1,0 +1,129 @@
+// #5913: the `show interfaces extensive` and `show interfaces detail` text
+// presenters build their config lookup maps with a raw
+// `range cfg.Interfaces.Interfaces` (reading `ifc.Name` / `ifc.Description`),
+// the SAME present-but-nil InterfaceConfig nil-deref class as #5813/#5910 in the
+// SAME file #5910 patched (showVLANs / showZonesDetail). The tolerant load / HA
+// config-sync path admits present-but-nil map values (#3494/#5068), so a routine
+// `show interfaces extensive|detail` against a peer-synced config panicked the
+// in-process daemon.
+//
+// Both config-map-build loops now walk via config.RangeInterfaces (the shared
+// nil-safe iterator), which SKIPS present-but-nil slots. These two presenters
+// call netlink.LinkList() (real kernel) — the same real-presenter path the
+// #4328 reth tests already drive and assert err==nil against, so the map-build
+// loop (which runs whenever LinkList succeeds) is reachable directly.
+//
+// The presenters render LIVE kernel traffic counters, so two sequential renders
+// are not byte-identical; the assertions therefore pin behavior that does NOT
+// depend on volatile counters: no panic on the nil slot, the nil key never
+// leaks, and a valid config Description for a real kernel link still surfaces
+// through the guarded walk.
+//
+// FAIL-ON-REVERT: restoring either raw `range cfg.Interfaces.Interfaces` makes
+// the injected present-but-nil slot deref `ifc.Name`/`ifc.Description` and panic;
+// require5913NoPanic turns that into a test FAILURE rather than a crashed run.
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// require5913NoPanic fails the test (rather than crashing the run) if fn panics,
+// naming the #5913 nil-guard regression.
+func require5913NoPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked (nil-guard regression #5913): %v", name, r)
+		}
+	}()
+	fn()
+}
+
+// firstNonLoopbackLink returns the name of a real non-"lo" kernel link, or ""
+// if the host exposes only loopback. The presenters SKIP "lo" and only emit a
+// config Description when the config interface name matches a kernel link, so a
+// real link name lets the test assert that valid config DATA still flows through
+// the guarded walk (not merely that it doesn't panic).
+func firstNonLoopbackLink(t *testing.T) string {
+	t.Helper()
+	links, err := netlink.LinkList()
+	if err != nil {
+		t.Fatalf("netlink.LinkList() error = %v (the presenters depend on it)", err)
+	}
+	for _, l := range links {
+		if n := l.Attrs().Name; n != "" && n != "lo" {
+			return n
+		}
+	}
+	return ""
+}
+
+// nilSlotConfig builds a config with valid interface slots plus a present-but-nil
+// InterfaceConfig slot (the tolerant load / HA config-sync shape). When a real
+// kernel link exists, one valid slot is named after it and given a distinctive
+// Description so the presenter (which only surfaces config for interfaces that
+// appear in the netlink walk) actually renders it.
+func nilSlotConfig(realIf, desc string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/9":        {Name: "ge-0/0/9", Description: "unmatched-valid-5913"},
+		"zz-5913-nil-ifc": nil, // present-but-nil (tolerant path) — the nil-deref trigger
+	}
+	if realIf != "" {
+		cfg.Interfaces.Interfaces[realIf] = &config.InterfaceConfig{Name: realIf, Description: desc}
+	}
+	return cfg
+}
+
+// TestShowInterfacesExtensiveNilSlots5913 drives the REAL showInterfacesExtensive
+// presenter against a config carrying a present-but-nil InterfaceConfig alongside
+// valid slots. The guarded walk must (a) not panic, (b) not leak the nil slot's
+// key, and (c) still surface a valid config slot's Description when it matches a
+// real kernel link.
+func TestShowInterfacesExtensiveNilSlots5913(t *testing.T) {
+	realIf := firstNonLoopbackLink(t)
+	const desc = "xpf-5913-extensive-desc"
+	cfg := nilSlotConfig(realIf, desc)
+
+	var buf strings.Builder
+	require5913NoPanic(t, "showInterfacesExtensive", func() {
+		if err := (&Server{}).showInterfacesExtensive(cfg, &buf); err != nil {
+			t.Fatalf("showInterfacesExtensive error = %v", err)
+		}
+	})
+	out := buf.String()
+	if strings.Contains(out, "zz-5913-nil-ifc") {
+		t.Fatalf("present-but-nil InterfaceConfig key leaked into extensive output:\n%s", out)
+	}
+	if realIf != "" && !strings.Contains(out, desc) {
+		t.Fatalf("valid config Description for kernel link %q dropped by the guarded walk:\n%s", realIf, out)
+	}
+}
+
+// TestShowInterfacesDetailNilSlots5913 drives the REAL showInterfacesDetail
+// presenter with the same guarantees. The detail loop reads
+// `ifc.Description`/`ifc.Name`, so a raw walk nil-derefs on the nil slot.
+func TestShowInterfacesDetailNilSlots5913(t *testing.T) {
+	realIf := firstNonLoopbackLink(t)
+	const desc = "xpf-5913-detail-desc"
+	cfg := nilSlotConfig(realIf, desc)
+
+	var buf strings.Builder
+	require5913NoPanic(t, "showInterfacesDetail", func() {
+		if err := (&Server{}).showInterfacesDetail(cfg, "", &buf); err != nil {
+			t.Fatalf("showInterfacesDetail error = %v", err)
+		}
+	})
+	out := buf.String()
+	if strings.Contains(out, "zz-5913-nil-ifc") {
+		t.Fatalf("present-but-nil InterfaceConfig key leaked into detail output:\n%s", out)
+	}
+	if realIf != "" && !strings.Contains(out, desc) {
+		t.Fatalf("valid config Description for kernel link %q dropped by the guarded walk:\n%s", realIf, out)
+	}
+}

--- a/pkg/grpcapi/server_show_interfaces_text.go
+++ b/pkg/grpcapi/server_show_interfaces_text.go
@@ -49,9 +49,13 @@ func (s *Server) showInterfacesExtensive(cfg *config.Config, buf *strings.Builde
 	var rethMaps config.RethShowMaps
 	if cfg != nil {
 		rethMaps = cfg.RethShowMaps()
-		for _, ifc := range cfg.Interfaces.Interfaces {
+		// #5913: skip present-but-nil InterfaceConfig slots (tolerant load / HA
+		// config-sync path admits them) via the shared nil-safe iterator — a raw
+		// `range cfg.Interfaces.Interfaces` nil-derefs `ifc.Name` and panics the
+		// in-process daemon on a routine `show interfaces extensive`.
+		config.RangeInterfaces(cfg, func(_ string, ifc *config.InterfaceConfig) {
 			ifCfgMap[ifc.Name] = ifc
-		}
+		})
 		for _, z := range cfg.Security.Zones {
 			if z == nil { // #3493: tolerant/HA-sync path may carry a nil zone value
 				continue
@@ -183,11 +187,15 @@ func (s *Server) showInterfacesDetail(cfg *config.Config, filter string, buf *st
 				ifZoneMap[ifName] = z.Name
 			}
 		}
-		for _, ifc := range cfg.Interfaces.Interfaces {
+		// #5913: skip present-but-nil InterfaceConfig slots via the shared
+		// nil-safe iterator (tolerant load / HA config-sync path) — a raw
+		// `range cfg.Interfaces.Interfaces` nil-derefs `ifc.Description` and
+		// panics on a routine `show interfaces detail`.
+		config.RangeInterfaces(cfg, func(_ string, ifc *config.InterfaceConfig) {
 			if ifc.Description != "" {
 				ifDescMap[ifc.Name] = ifc.Description
 			}
-		}
+		})
 	}
 	found := false
 	for _, link := range linksList {


### PR DESCRIPTION
## Summary

Closes #5913.

The `show interfaces extensive` and `show interfaces detail` text
presenters build their per-interface config lookup maps
(`ifCfgMap`/`ifDescMap`) with a raw `for _, ifc := range
cfg.Interfaces.Interfaces`, reading `ifc.Name` / `ifc.Description`
directly — the **same present-but-nil `InterfaceConfig` nil-deref class
as #5813/#5910, in the same file #5910 patched** (showVLANs /
showZonesDetail). #5910's pass missed these two sites; #5911's review
found them.

The tolerant load / HA config-sync path admits a present-key/nil-value
`InterfaceConfig` slot (#3494/#5068). A raw walk nil-derefs on such a
slot and panics the in-process daemon during a routine `show interfaces
extensive|detail` against a peer-synced config.

## The 2-site migration

Both config-map-build loops now route through `config.RangeInterfaces`
(the shared nil-safe iterator added for #5813, merged #5908), which
skips present-but-nil slots:

- `server_show_interfaces_text.go:52` — `showInterfacesExtensive`
  (`ifCfgMap[ifc.Name] = ifc`)
- `server_show_interfaces_text.go:186` — `showInterfacesDetail`
  (`ifDescMap[ifc.Name] = ifc.Description`)

Output for valid configs is unchanged (nil-skip only affects nil slots).
These are the **only two** remaining raw interface-map walks in this
file — the daemon apply-path walks operate on validated config and are
out of scope.

## Test-harness approach

These two presenters call `netlink.LinkList()` (real kernel), unlike
`showVLANs`. The config-map-build loop that carries the nil-deref runs
whenever `LinkList()` succeeds — which the **#4328 reth tests already
prove reliable** in this env (they call `showInterfacesExtensive` /
`showInterfacesDetail` directly and assert `err == nil`). So the tests
drive the **real presenters** directly.

The presenters render **live kernel traffic counters**, so two sequential
renders are not byte-identical — the assertions therefore pin
counter-independent behavior:

1. **no panic** on the injected present-but-nil slot (fail-on-revert,
   via `recover → t.Fatalf`);
2. the nil slot's key **never leaks** into the output;
3. a valid config **Description for a real kernel link still surfaces**
   through the guarded walk (valid config data flows through).

## Fail-on-revert

Both raw-walk reverts proven **RED** via `-overlay` (nil-deref panic
caught by `recover → t.Fatalf`), and **each revert breaks only its own
test** — confirming the two guards are independent.

## Validation

- `go build ./...` clean
- `go vet ./pkg/grpcapi/` clean (the pre-existing `cli.go:511` warning is
  unrelated and untouched)
- `go test -race ./pkg/grpcapi/` GREEN
- `pkg/config/README.md`'s nil-safe-iterator guarded-site enumeration is
  extended to these two presenters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)