### PR TITLE
upgrade: two-phase kernel arm with BootNext readback (#5847)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48622,3 +48622,29 @@ top.
   go test -race ./pkg/grpcapi/ GREEN; both raw-walk reverts proven RED via
   -overlay (nil-deref panic caught by recover→t.Fatalf), each revert breaking
   only its own test (independent guards).
+
+## 2026-07-15 — #5847 two-phase kernel arm (ARMING intent + BootNext readback)
+
+- **Timestamp**: 2026-07-15
+- **Action**: Fix the false-ARMED wedge — the kernel-roll arm persisted ARMED
+  BEFORE SetBootNext, so a crash in the gap left a journal claiming ARMED while
+  the firmware booted known-good and no trial happened, wedging HA self-recovery
+  (Arm refused-forever, self-recovery suppressed failback forever). Implemented
+  the two-phase arm: record ARMING (prepared intent + per-attempt nonce) before
+  any NVRAM mutation; SetBootNext; positively read GetBootNext() back ==
+  inactiveID; only then transition ARMING -> ARMED recording the confirmed
+  BootID. ARMING sits below ARMED in the state order, so Arm re-arms from ARMING,
+  self-recovery does not suppress on ARMING, and IsArmed is true only for the
+  verified ARMED.
+- **File(s)**: pkg/upgrade/kernel.go (KernelStateArming + reorder, journal
+  BootID/ArmNonce/ArmAttempts, GetBootNext interface method), pkg/upgrade/
+  kernel_linux.go (bootNextRE + GetBootNext efibootmgr readback), pkg/upgrade/
+  kernel_run.go (armCandidate two-phase rewrite + newArmNonce), pkg/upgrade/
+  kernel_test.go (fake GetBootNext + seams), pkg/upgrade/
+  kernel_arm_two_phase_5847_test.go (NEW — 4 fail-on-revert tests), docs/
+  in-place-upgrade.md (two-phase arm + BootNext-readback provenance + ARMING vs
+  verified-ARMED self-recovery semantics).
+- **Validation**: go build ./... clean; go vet ./pkg/upgrade/ clean; go test
+  -race ./pkg/upgrade/ GREEN; the ARMED-first revert (drop ARMING/readback)
+  proven RED via -overlay on Test 1 (re-arm + self-recovery) and Test 2
+  (readback mismatch), with Test 3 (no-regression) still green.

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -830,6 +830,31 @@ treats an unreadable observation as a definite safe state:
   failure (after still attempting the keepalive), and `DisarmWatchdog`
   propagates open/write/close failures (a genuinely-absent device is still
   a clean nil).
+- *Two-phase arm + BootNext readback (#5847).* The arm used to persist the
+  `ARMED` journal BEFORE `efibootmgr --bootnext`, on the theory that an
+  `ARMED`-without-`BootNext` journal is harmless. It is NOT: a crash in
+  that gap (or before the best-effort rollback ran) left a FALSE-ARMED
+  journal — the firmware still boots the known-good default and no trial
+  ever happens, yet `Arm` refused-forever (`>= ARMED`) and self-recovery
+  suppressed expired-lease failback INDEFINITELY (the drained node never
+  rejoined). Neither write order is atomic with the NVRAM mutation, so
+  `ARMED` is now made AUTHORITATIVE via a positive readback:
+  1. record `ARMING` (prepared intent, with a fresh per-attempt nonce)
+     BEFORE any NVRAM mutation;
+  2. `SetBootNext(inactiveID)`;
+  3. positively read `GetBootNext()` back and require it equals the armed
+     inactive-slot id — a firmware that silently dropped or partial-wrote
+     the variable must NOT yield a verified-ARMED journal;
+  4. only THEN durably transition `ARMING -> ARMED`, recording the
+     confirmed `BootID` for boot-provenance.
+
+  `ARMING` sits BELOW `ARMED` in the journal order, so a journal stuck
+  there (readback failed / never ran) lets `Arm` RE-ARM (the `>= ARMED`
+  refusal does not fire; `armCandidate` is idempotent) and does not
+  suppress self-recovery. Only the verified `ARMED` (readback confirmed)
+  counts as a genuine trial. The per-attempt `ArmNonce` (unique across
+  attempts even under a stuck clock) distinguishes a fresh arm from a
+  stale/crashed journal.
 
 In a cluster the roll is driven ONE NODE AT A TIME by the external
 orchestrator (`scripts/deploy/xpf-deploy.py kernel-roll`): drain
@@ -931,10 +956,15 @@ carrying traffic:
    can't silently age the deadline and let the next positive tick rejoin
    immediately.
 3. **Still-armed gate.** Self-recovery refuses to rejoin while the kernel
-   journal is still ARMED even if the lease has expired — a legitimately
-   long-hanging roll (one that outran its lease TTL) is still a trial in
-   flight; the promote/revert oneshot owns the resolution, and the
-   election hold keeps the node secondary meanwhile.
+   journal is at the VERIFIED `ARMED` state even if the lease has expired
+   — a legitimately long-hanging roll (one that outran its lease TTL) is
+   still a trial in flight; the promote/revert oneshot owns the
+   resolution, and the election hold keeps the node secondary meanwhile.
+   This gate is driven by `IsArmed`, which reports true ONLY for the
+   verified `ARMED` state — NOT the `ARMING` prepared-intent state (see
+   the two-phase arm below). A journal stuck at `ARMING` is NOT a genuine
+   trial, so self-recovery does NOT suppress on it and the drained node
+   can rejoin (#5847).
 
 ### Persistence precondition
 

--- a/pkg/upgrade/kernel.go
+++ b/pkg/upgrade/kernel.go
@@ -64,9 +64,23 @@ const (
 	// move (re-asserted). The candidate is on disk but NOT armed.
 	KernelStateInstalled KernelState = "INSTALLED"
 
+	// KernelStateArming: PREPARED-INTENT to arm, durably recorded BEFORE any
+	// NVRAM mutation (#5847). The INACTIVE slot's selector is (being) written,
+	// but `efibootmgr --bootnext` has NOT been positively confirmed via a
+	// readback. A journal stuck HERE — a crash between recording intent and the
+	// verified ARMED transition — is NOT a genuine in-flight trial: the firmware
+	// still boots the known-good default (no confirmed one-shot), so `Arm` may
+	// RE-ARM from ARMING and self-recovery must NOT suppress expired-lease
+	// failback on it (the drained node can rejoin). Only after a POSITIVE
+	// BootNext readback does the runner transition ARMING -> ARMED.
+	KernelStateArming KernelState = "ARMING"
+
 	// KernelStateArmed: the INACTIVE slot's selector points at the candidate
-	// (atomic ESP write) and `efibootmgr --bootnext <inactive-slot>` is set.
-	// The next boot is the one-shot candidate trial.
+	// (atomic ESP write) AND `efibootmgr --bootnext <inactive-slot>` is set AND
+	// was POSITIVELY READ BACK (#5847), so the next boot is genuinely the
+	// one-shot candidate trial. Only this VERIFIED state counts as an in-flight
+	// trial (IsArmed true; self-recovery suppresses failback). The armed boot id
+	// + a per-attempt nonce are recorded for provenance.
 	KernelStateArmed KernelState = "ARMED"
 
 	// KernelStatePromoted: on the candidate boot the promotion gate passed
@@ -90,10 +104,12 @@ func (s KernelState) order() int {
 		return 1
 	case KernelStateInstalled:
 		return 2
-	case KernelStateArmed:
+	case KernelStateArming:
 		return 3
-	case KernelStatePromoted, KernelStateReverted:
+	case KernelStateArmed:
 		return 4
+	case KernelStatePromoted, KernelStateReverted:
+		return 5
 	default:
 		return -1
 	}
@@ -128,6 +144,24 @@ type KernelJournal struct {
 	// by maxPromoteAttempts so a read-only-root journal that cannot clear cannot
 	// loop reboots forever (r1 AGY catastrophic).
 	PromoteAttempts int `json:"promote_attempts,omitempty"`
+
+	// BootID is the Boot#### id (the inactive slot) that was armed as the
+	// one-shot BootNext AND POSITIVELY READ BACK before the ARMED transition
+	// (#5847). Empty until the verified ARMED state. On the candidate boot the
+	// promotion gate can tie BootCurrent to this id to confirm the firmware
+	// booted the slot we actually armed (provenance for a genuine trial).
+	BootID string `json:"boot_id,omitempty"`
+
+	// ArmNonce is a per-attempt token generated when ENTERING ARMING (#5847) and
+	// carried onto the verified ARMED journal. It distinguishes a fresh arm from
+	// a stale journal left by a prior or crashed attempt, so provenance is not
+	// confused across attempts.
+	ArmNonce string `json:"arm_nonce,omitempty"`
+
+	// ArmAttempts counts arm attempts (armCandidate entries) for THIS run so a
+	// fresh ArmNonce is unique across attempts even under a stuck test clock
+	// (#5847).
+	ArmAttempts int `json:"arm_attempts,omitempty"`
 }
 
 // ErrKernelChannelUnavailable marks a pre-assert failure that means LANE 1
@@ -196,6 +230,12 @@ type KernelSystem interface {
 	ReadSlotSelector(slot string) (string, error)
 	// SetBootNext arms the one-shot boot of the given Boot#### id.
 	SetBootNext(bootID string) error
+	// GetBootNext returns the Boot#### id currently armed as the one-shot
+	// BootNext, or "" if none is set (#5847). The two-phase arm reads this back
+	// AFTER SetBootNext to POSITIVELY CONFIRM the firmware accepted the one-shot
+	// before recording the verified ARMED journal — a firmware that silently
+	// dropped or partial-wrote the variable must not yield a false-ARMED journal.
+	GetBootNext() (string, error)
 	// ArmWatchdog arms the persistent watchdog before the reboot (best
 	// effort; the firmware BootNext clear is the loop-safety, the watchdog
 	// only converts a hang into the reset that triggers the fallback).

--- a/pkg/upgrade/kernel_arm_two_phase_5847_test.go
+++ b/pkg/upgrade/kernel_arm_two_phase_5847_test.go
@@ -1,0 +1,215 @@
+// #5847: the kernel-roll ARM used to persist the ARMED journal BEFORE arming
+// the NVRAM BootNext one-shot. A crash in that gap (or before the best-effort
+// rollback ran) left a journal claiming ARMED while the firmware still boots the
+// known-good default and NO trial ever happens — a FALSE-ARMED journal. Arm then
+// refused-forever (>= ARMED) and KernelSelfRecovery treated it as a genuine
+// in-flight trial, SUPPRESSING expired-lease failback INDEFINITELY, so a drained
+// node never rejoined.
+//
+// The fix is a TWO-PHASE arm: record ARMING (prepared intent) before any NVRAM
+// mutation, SetBootNext, POSITIVELY read BootNext back == the inactive slot, and
+// only then durably transition ARMING -> ARMED (recording the confirmed boot id
+// + a per-attempt nonce). A journal stuck at ARMING is NOT a genuine trial: Arm
+// RE-ARMS from it and self-recovery does NOT suppress failback (IsArmed reports
+// true only for the verified ARMED).
+//
+// FAIL-ON-REVERT: revert armCandidate to save-ARMED-before-readback (drop the
+// ARMING phase) and the injected readback-failure / mismatch scenarios reach
+// (false-)ARMED instead of ARMING — Test 1 (re-arm + self-recovery) and Test 2
+// (readback mismatch) go RED.
+package upgrade
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// armToStuckArming drives Arm with a readback that fails, modelling a crash
+// between recording the ARMING intent and the verified ARMED transition (the
+// BootNext one-shot was never confirmed). It returns the runner + fake with the
+// on-disk journal stuck at ARMING.
+func armToStuckArming(t *testing.T) (*KernelRunner, *fakeKernelSystem) {
+	t.Helper()
+	f := newFakeKernelSystem()
+	// The firmware readback fails: we cannot confirm BootNext, so the arm must
+	// NOT advance past ARMING (a crash-before-verified-ARMED proxy).
+	f.getBootNextErr = errors.New("efivarfs readback raced / unavailable")
+	r := newKernelRunner(t, f)
+
+	if err := r.Arm("6.18.5-12-generic"); err == nil {
+		t.Fatal("arm must fail when the BootNext readback cannot confirm the one-shot")
+	}
+	j, err := r.loadKernelJournal()
+	if err != nil {
+		t.Fatalf("load journal: %v", err)
+	}
+	if j.State != KernelStateArming {
+		t.Fatalf("journal state = %s, want ARMING (intent persisted, ARMED NOT reached without a "+
+			"confirmed BootNext) — #5847", j.State)
+	}
+	if armed, _, _ := r.IsArmed(); armed {
+		t.Fatal("IsArmed must be FALSE at ARMING — an unconfirmed arm is not a verified trial (#5847)")
+	}
+	return r, f
+}
+
+// TestKernelArmStuckArming_ReArmsAndSelfRecovers_5847 is the headline #5847 fix:
+// a journal stuck at ARMING (crash before the verified ARMED) must (a) let Arm
+// RE-ARM (not refuse-forever) and (b) NOT suppress expired-lease self-recovery
+// (the drained node rejoins).
+func TestKernelArmStuckArming_ReArmsAndSelfRecovers_5847(t *testing.T) {
+	t.Run("Arm re-arms from ARMING", func(t *testing.T) {
+		r, f := armToStuckArming(t)
+		// Heal the firmware and re-arm the SAME candidate: ARMING < ARMED, so the
+		// ">= ARMED" refusal does not fire and the two-phase arm completes.
+		f.getBootNextErr = nil
+		f.rebooted = false
+		if err := r.Arm("6.18.5-12-generic"); err != nil {
+			t.Fatalf("re-arm from ARMING must succeed (not refuse-forever), got %v", err)
+		}
+		j, _ := r.loadKernelJournal()
+		if j.State != KernelStateArmed {
+			t.Fatalf("re-arm journal state = %s, want ARMED", j.State)
+		}
+		if !f.rebooted {
+			t.Fatal("a successful re-arm must reach the candidate reboot")
+		}
+	})
+
+	t.Run("self-recovery does NOT suppress on ARMING", func(t *testing.T) {
+		r, _ := armToStuckArming(t)
+		now := time.Unix(1_700_000_000, 0)
+		cl := &fakeSRCluster{drained: true, peerOK: true}
+		sr := NewKernelSelfRecovery(SelfRecoveryConfig{
+			NodeID:    0,
+			LeasePath: filepath.Join(t.TempDir(), "kernel-roll.lease"),
+			Grace:     10 * time.Second,
+			Now:       func() time.Time { return now },
+			// REAL wiring: the same IsArmed the daemon feeds self-recovery.
+			Armed: func() (bool, error) { a, _, e := r.IsArmed(); return a, e },
+		}, cl)
+		// An EXPIRED lease naming node 0 (orchestrator crashed mid-roll).
+		writeLease(t, sr.cfg.LeasePath, KernelRollLease{NodeID: 0, ExpiresAt: now.Add(-time.Minute)})
+
+		if did, err := sr.Tick(); err != nil || did {
+			t.Fatalf("first tick only starts the grace timer (did=%v err=%v)", did, err)
+		}
+		now = now.Add(11 * time.Second) // past grace
+		did, err := sr.Tick()
+		if err != nil {
+			t.Fatalf("tick: %v", err)
+		}
+		if !did || cl.resets != 1 {
+			t.Fatalf("a journal stuck at ARMING is NOT a genuine trial — self-recovery must rejoin the "+
+				"drained node, not suppress it forever (did=%v resets=%d) — the #5847 wedge", did, cl.resets)
+		}
+	})
+}
+
+// TestKernelArmBootNextReadbackMismatch_StaysArming_5847 pins that when
+// SetBootNext returns success but the READBACK reports a different id (firmware
+// silently dropped / partial-wrote the variable), the arm does NOT advance to
+// ARMED — it stays ARMING and surfaces the error, so no false-ARMED journal is
+// ever persisted.
+func TestKernelArmBootNextReadbackMismatch_StaysArming_5847(t *testing.T) {
+	f := newFakeKernelSystem()
+	f.getBootNextRet = "9999" // firmware reports a DIFFERENT id than we set (0004)
+	r := newKernelRunner(t, f)
+
+	err := r.Arm("6.18.5-12-generic")
+	if err == nil {
+		t.Fatal("a BootNext readback that disagrees with the armed id must FAIL the arm (no false-ARMED)")
+	}
+	j, _ := r.loadKernelJournal()
+	if j.State != KernelStateArmed {
+		// good: did NOT reach ARMED
+	} else {
+		t.Fatalf("readback mismatch reached ARMED — a firmware that dropped the one-shot must not " +
+			"yield a verified-ARMED journal (#5847)")
+	}
+	if j.State != KernelStateArming {
+		t.Fatalf("journal state = %s, want ARMING after a readback mismatch", j.State)
+	}
+	if armed, _, _ := r.IsArmed(); armed {
+		t.Fatal("IsArmed must be FALSE — the one-shot was never confirmed (#5847)")
+	}
+}
+
+// TestKernelArmVerifiedArmedStillSuppresses_5847 is the NO-REGRESSION guard: a
+// genuine verified ARMED (readback == the armed inactive slot) remains a real
+// trial-in-flight, so self-recovery STILL suppresses expired-lease failback and
+// IsArmed reports true — exactly as before #5847.
+func TestKernelArmVerifiedArmedStillSuppresses_5847(t *testing.T) {
+	f := newFakeKernelSystem() // GetBootNext mirrors bootNext -> readback matches
+	r := newKernelRunner(t, f)
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("arm (verified): %v", err)
+	}
+	j, _ := r.loadKernelJournal()
+	if j.State != KernelStateArmed {
+		t.Fatalf("journal state = %s, want ARMED (verified)", j.State)
+	}
+	if armed, _, _ := r.IsArmed(); !armed {
+		t.Fatal("a verified ARMED must be IsArmed true (genuine trial)")
+	}
+
+	now := time.Unix(1_700_000_000, 0)
+	cl := &fakeSRCluster{drained: true, peerOK: true}
+	sr := NewKernelSelfRecovery(SelfRecoveryConfig{
+		NodeID:    0,
+		LeasePath: filepath.Join(t.TempDir(), "kernel-roll.lease"),
+		Grace:     10 * time.Second,
+		Now:       func() time.Time { return now },
+		Armed:     func() (bool, error) { a, _, e := r.IsArmed(); return a, e },
+	}, cl)
+	writeLease(t, sr.cfg.LeasePath, KernelRollLease{NodeID: 0, ExpiresAt: now.Add(-time.Minute)})
+
+	_, _ = sr.Tick()
+	now = now.Add(11 * time.Second) // well past grace
+	if did, err := sr.Tick(); err != nil || did || cl.resets != 0 {
+		t.Fatalf("a genuine VERIFIED-ARMED trial must STILL suppress failback (no regression to the "+
+			"real trial-in-flight case): did=%v err=%v resets=%d", did, err, cl.resets)
+	}
+}
+
+// TestKernelArmProvenanceNonceAndBootID_5847 pins that the verified ARMED journal
+// records the confirmed boot id AND a per-attempt nonce, and that a fresh arm
+// gets a DISTINCT nonce from a stale (crashed) ARMING journal — so provenance
+// distinguishes a stale journal from a fresh arm.
+func TestKernelArmProvenanceNonceAndBootID_5847(t *testing.T) {
+	r, f := armToStuckArming(t)
+	stale, _ := r.loadKernelJournal()
+	if stale.ArmNonce == "" || stale.ArmAttempts != 1 {
+		t.Fatalf("the ARMING intent must record a nonce + attempt count (nonce=%q attempts=%d)",
+			stale.ArmNonce, stale.ArmAttempts)
+	}
+	if stale.BootID != "" {
+		t.Fatalf("BootID must be empty until a VERIFIED ARMED, got %q", stale.BootID)
+	}
+
+	// Re-arm to a verified ARMED (a fresh attempt).
+	f.getBootNextErr = nil
+	if err := r.Arm("6.18.5-12-generic"); err != nil {
+		t.Fatalf("re-arm: %v", err)
+	}
+	fresh, _ := r.loadKernelJournal()
+	if fresh.State != KernelStateArmed {
+		t.Fatalf("state = %s, want ARMED", fresh.State)
+	}
+	wantBoot := f.entries[SlotB] // inactive slot (A is active) -> the armed id
+	if fresh.BootID != wantBoot {
+		t.Fatalf("verified ARMED BootID = %q, want the confirmed inactive-slot id %q", fresh.BootID, wantBoot)
+	}
+	if fresh.ArmNonce == "" {
+		t.Fatal("verified ARMED must carry an arm nonce (provenance)")
+	}
+	if fresh.ArmAttempts != 2 {
+		t.Fatalf("arm attempts = %d, want 2 (stale attempt + fresh re-arm)", fresh.ArmAttempts)
+	}
+	if fresh.ArmNonce == stale.ArmNonce {
+		t.Fatalf("a fresh arm must get a DISTINCT nonce from the stale ARMING journal "+
+			"(both = %q) — provenance cannot distinguish stale vs fresh (#5847)", fresh.ArmNonce)
+	}
+}

--- a/pkg/upgrade/kernel_linux.go
+++ b/pkg/upgrade/kernel_linux.go
@@ -24,6 +24,7 @@ var (
 	// Some entries have no loader path (no tab) — `[^\t]+` then tolerates EOL.
 	bootEntryRE          = regexp.MustCompile(`^Boot([0-9A-F]{4})\*?\s+([^\t]+?)(?:\t.*)?$`)
 	bootCurrentRE        = regexp.MustCompile(`^BootCurrent:\s*([0-9A-F]{4})`)
+	bootNextRE           = regexp.MustCompile(`^BootNext:\s*([0-9A-F]{4})`)
 	slotSelectorKernelRE = regexp.MustCompile(`xpf_slot_kernel="vmlinuz-([^"]+)"`)
 )
 
@@ -369,6 +370,25 @@ func (s *realKernelSystem) ReadSlotSelector(slot string) (string, error) {
 
 func (s *realKernelSystem) SetBootNext(bootID string) error {
 	return runCmd("efibootmgr", "--bootnext", bootID)
+}
+
+// GetBootNext parses the one-shot BootNext id out of efibootmgr's output (the
+// "BootNext: XXXX" line), or returns "" if no one-shot is armed (#5847). The
+// two-phase arm reads this back to POSITIVELY CONFIRM the firmware accepted the
+// SetBootNext write before recording the verified ARMED journal. A missing
+// BootNext line is NOT an error — it is the legitimate "no one-shot set" state.
+func (s *realKernelSystem) GetBootNext() (string, error) {
+	out, err := captureCmd("efibootmgr")
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		m := bootNextRE.FindStringSubmatch(line)
+		if len(m) == 2 {
+			return m[1], nil
+		}
+	}
+	return "", nil
 }
 
 // watchdogTimeoutSecs is the timeout armed before the candidate reboot. It must

--- a/pkg/upgrade/kernel_run.go
+++ b/pkg/upgrade/kernel_run.go
@@ -324,27 +324,77 @@ func (r *KernelRunner) armCandidate(j *KernelJournal) error {
 		r.logf("kernel-upgrade arm: WARNING arm watchdog: %v (continuing; BootNext closes the loop)", err)
 	}
 
-	// Journal ARMED *before* arming BootNext (r1 Codex Critical-2): the
-	// reboot-boundary crash hole is "firmware booted the candidate but the
-	// journal still says INSTALLED, so Promote() no-ops". By persisting ARMED
-	// first, any crash after this point leaves a recoverable ARMED journal that
-	// Promote() acts on. The selector + ARMED journal are both harmless without
-	// BootNext (the firmware default is still the known-good slot), so ordering
-	// the durable ARMED write ahead of the one-shot is strictly safe.
-	if err := r.ktransition(j, KernelStateArmed); err != nil {
+	// Two-phase arm (#5847). The previous order persisted ARMED *before* the
+	// NVRAM one-shot on the theory that an ARMED-without-BootNext journal is
+	// harmless. It is NOT: a crash in that gap (or before the best-effort
+	// rollback ran) left a journal claiming ARMED while the firmware still boots
+	// the known-good default and no trial ever happens — a FALSE-ARMED journal.
+	// Arm then refuses-forever (>= ARMED), and self-recovery treats it as a
+	// genuine in-flight trial and suppresses expired-lease failback INDEFINITELY,
+	// so a drained node never rejoins. The two orders are not symmetric — neither
+	// single write is atomic with the NVRAM mutation — so make ARMED authoritative
+	// via a positive readback instead:
+	//
+	//   1. record ARMING (prepared intent) BEFORE the NVRAM mutation, with a
+	//      fresh per-attempt nonce;
+	//   2. SetBootNext(inactiveID);
+	//   3. POSITIVELY read BootNext back == inactiveID (a firmware that dropped
+	//      or partial-wrote the variable must not yield a false-ARMED journal);
+	//   4. only THEN durably transition ARMING -> ARMED, recording the confirmed
+	//      boot id.
+	//
+	// A journal stuck at ARMING is NOT a genuine trial (BootNext unconfirmed):
+	// Arm re-arms from it (ARMING < ARMED, so the >= ARMED refusal does not fire),
+	// and self-recovery does not suppress failback (IsArmed reports true only for
+	// the verified ARMED). armCandidate is idempotent, so a re-arm from ARMING
+	// re-runs cleanly.
+	j.ArmAttempts++
+	j.ArmNonce = r.newArmNonce(j)
+	j.BootID = ""
+	if err := r.ktransition(j, KernelStateArming); err != nil {
 		return err
 	}
 
 	if err := sys.SetBootNext(inactiveID); err != nil {
-		// Roll the journal back to INSTALLED so a retry re-arms cleanly; the
-		// selector is already correct and BootNext was not set, so the box
-		// still boots the known-good default.
-		j.State = KernelStateInstalled
-		_ = r.saveKernelJournal(j)
+		// BootNext was not set; the journal is only ARMING (no verified trial),
+		// so the box still boots the known-good default and a retry re-arms
+		// cleanly. Leave the journal at ARMING (do NOT drop back to INSTALLED):
+		// re-entry resumes the arm, and self-recovery already treats ARMING as
+		// no-trial.
 		return fmt.Errorf("kernel-upgrade arm: efibootmgr --bootnext %s: %w", inactiveID, err)
 	}
 
+	// Positively confirm the firmware accepted the one-shot BEFORE recording the
+	// verified-ARMED journal. If the readback disagrees (firmware silently
+	// dropped / partial-wrote the variable), do NOT advance to ARMED — stay
+	// ARMING and surface the error so no false-ARMED journal is persisted.
+	got, err = sys.GetBootNext()
+	if err != nil {
+		return fmt.Errorf("kernel-upgrade arm: read back BootNext (staying ARMING): %w", err)
+	}
+	if got != inactiveID {
+		return fmt.Errorf("kernel-upgrade arm: BootNext readback = %q, expected inactive slot %s "+
+			"(%s); firmware did not accept the one-shot — refusing to record ARMED (staying ARMING)",
+			got, j.InactiveSlot, inactiveID)
+	}
+
+	// Verified: the firmware WILL boot the candidate next. Record the confirmed
+	// boot id and transition to the genuine (trial-in-flight) ARMED state.
+	j.BootID = inactiveID
+	if err := r.ktransition(j, KernelStateArmed); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// newArmNonce builds a per-attempt arm token (#5847). It combines the system
+// clock with the run's monotonically-increasing attempt counter and the
+// candidate/slot identity so a fresh arm is always distinguishable from a stale
+// journal — the attempt counter guarantees uniqueness across attempts even under
+// a stuck test clock.
+func (r *KernelRunner) newArmNonce(j *KernelJournal) string {
+	return fmt.Sprintf("%d-%d-%s-%s", r.cfg.Sys.Now().UnixNano(), j.ArmAttempts, j.InactiveSlot, j.CandidateVersion)
 }
 
 // Promote runs the POST-REBOOT promotion gate from the candidate boot. It is

--- a/pkg/upgrade/kernel_test.go
+++ b/pkg/upgrade/kernel_test.go
@@ -33,6 +33,8 @@ type fakeKernelSystem struct {
 
 	bootCurrent       string
 	bootCurrentErr    error
+	getBootNextErr    error  // #5847: force a readback error (stay ARMING)
+	getBootNextRet    string // #5847: override readback (firmware "lied"); "" => mirror bootNext
 	runningErr        error
 	armWatchdogErr    error
 	disarmWatchdogErr error
@@ -122,6 +124,20 @@ func (f *fakeKernelSystem) SetBootNext(id string) error {
 	f.log("bootnext:" + id)
 	f.bootNext = id
 	return nil
+}
+
+// GetBootNext mirrors what SetBootNext stored (firmware accepted the one-shot)
+// unless a test injects getBootNextErr (readback error) or getBootNextRet
+// (firmware silently dropped/partial-wrote the variable → readback disagrees).
+func (f *fakeKernelSystem) GetBootNext() (string, error) {
+	f.log("get-bootnext")
+	if f.getBootNextErr != nil {
+		return "", f.getBootNextErr
+	}
+	if f.getBootNextRet != "" {
+		return f.getBootNextRet, nil
+	}
+	return f.bootNext, nil
 }
 func (f *fakeKernelSystem) ArmWatchdog() error {
 	if f.armWatchdogErr != nil {


### PR DESCRIPTION
## Summary

Closes #5847.

The LANE-1 kernel-roll arm persisted the `ARMED` journal **before** arming
the NVRAM `BootNext` one-shot. A crash in that gap (or before the
best-effort `INSTALLED` rollback ran) leaves a **FALSE-ARMED** journal:
the firmware still boots the known-good default and no candidate trial
ever happens, yet the journal claims `ARMED`.

That wedges HA recovery:
- `Arm` refuses any journal `>= ARMED` → the node cannot re-arm.
- `IsArmed` reports true from journal state alone, and
  `KernelSelfRecovery.Tick` treats true as a genuine in-flight trial →
  **suppresses expired-lease failback INDEFINITELY** → a drained node
  whose orchestrator crashed mid-roll never rejoins.

Neither write order is atomic with the NVRAM mutation, so no ordering
closes the hole. Make `ARMED` **authoritative via a positive readback**.

## Two-phase arm protocol

1. record **`ARMING`** (prepared intent) BEFORE any NVRAM mutation, with a
   fresh per-attempt nonce;
2. `SetBootNext(inactiveID)`;
3. positively read `GetBootNext()` back and require it `== inactiveID` (a
   firmware that silently dropped / partial-wrote the variable must not
   yield a false-ARMED journal);
4. only THEN durably transition `ARMING -> ARMED`, recording the confirmed
   `BootID`.

## ARMING-vs-ARMED recovery semantics

`ARMING` sits **below** `ARMED` in the journal order, so the semantics
fall out of the existing predicates (no logic change to Arm/IsArmed/Tick):

- **`Arm`** refuses only `atLeast(ARMED)` → a journal stuck at `ARMING` is
  **RE-ARMABLE** (armCandidate is idempotent), not refused-forever.
- **`IsArmed`** is `atLeast(ARMED)` → true **ONLY** for the verified
  `ARMED`, never `ARMING`.
- **`KernelSelfRecovery`** is driven by `IsArmed` → does **NOT** suppress
  failback on `ARMING` (node rejoins) but **STILL** suppresses on the
  verified `ARMED` (real trial in flight) — no regression.

## BootNext readback

Adds `GetBootNext()` to the `KernelSystem` interface + an `efibootmgr`
readback impl (`realKernelSystem`) — a missing `BootNext:` line is the
legitimate "no one-shot" state, not an error. Journal gains
`BootID`/`ArmNonce`/`ArmAttempts` provenance fields; the per-attempt nonce
is unique across attempts even under a stuck test clock, distinguishing a
fresh arm from a stale/crashed journal.

## Fail-on-revert tests (`kernel_arm_two_phase_5847_test.go`)

1. **crash before verified ARMED** (readback fails → journal `ARMING`) →
   `Arm` RE-ARMS **and** self-recovery clears the drain (the headline
   wedge);
2. `SetBootNext` succeeds but the **readback disagrees** → stays `ARMING`
   / errors, no false-ARMED;
3. a **genuine verified `ARMED`** still suppresses failback (no
   regression);
4. the **boot id + attempt nonce** are recorded on `ARMED`, and a fresh
   arm gets a **distinct** nonce from the stale `ARMING` journal.

Reverting `armCandidate` to save-ARMED-before-readback (dropping the
`ARMING` phase) makes tests **1 and 2 RED** via `-overlay`; test 3 stays
green.

## Validation

- `go build ./...` clean
- `go vet ./pkg/upgrade/` clean
- `go test -race ./pkg/upgrade/` GREEN
- `docs/in-place-upgrade.md` documents the two-phase arm, the BootNext
  readback, and the `ARMING`-vs-verified-`ARMED` self-recovery semantics.

This is the upgrade kernel-roll HA self-recovery (drain/rejoin state
machine), verified deterministically with injected seams — NOT the
VRRP/session-sync failover path, so no live `test-failover` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)