### PR TITLE
config: reject multi-range flexible-match-range terms (#5823)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1744,6 +1744,49 @@ and break the symmetry in the other direction. Pinned by
 `pkg/config/quotekey_roundtrip_3854_test.go` (`TestQuoteKeyLexerSymmetry3854`,
 `TestFormatParseRoundTrip3854`, `TestFormatParseIdempotent3854`).
 
+### `firewall ... from flexible-match-range` — at most ONE range per term (#5823)
+
+A firewall-filter term may name **at most one** `flexible-match-range range`.
+The userspace matcher (`flex_matches`, `userspace-dp/src/filter/engine/
+matching.rs`) evaluates a single byte-offset window per term; multi-range is a
+Junos-parity gap deliberately left unimplemented (defining the wire encoding +
+hot-path cost is a separate item).
+
+The pre-#5823 compiler (`compileFilterFrom`, `pkg/config/compiler_firewall.go`)
+iterated every named range but `break`ed after the first — silently keeping
+range #1 and dropping the rest. That is a **security fail-open**: an `accept`
+term stopped requiring the dropped ranges' condition (over-permit), and a
+`discard`/`reject` term stopped dropping the traffic they scoped (over-drop),
+with a clean commit.
+
+`compileFilterFrom` now aggregates EVERY named range across ALL repeated
+`flexible-match-range` blocks, both AST shapes (hierarchical + flat-set),
+duplicate names, and `from` group-expanded copies into
+`FirewallFilterTerm.FlexMatchRangeNames` (it still compiles only the first into
+`FlexMatch`, so a single-range term is byte-identical). This follows the
+#3203/#3205/#5832/#5833 strict/lenient discipline:
+
+- **Strict commit / commit-check** (`CompileConfig`): `validateFilterFlexMatchStrict`
+  (`compiler_validate_strict_filter.go`) hard-REJECTS `len(FlexMatchRangeNames) > 1`
+  BEFORE the dataplane apply, naming the family/filter/term and every range.
+- **Lenient load / peer-sync** (`CompileConfigLenient`, #1960 no-brick): the
+  strict error is downgraded to an operator-visible `cfg.Warnings` entry, and the
+  userspace snapshot builder (`buildFilterTermSnapshots`, `pkg/dataplane/
+  userspace/filters.go`) POISONS the term to match NOTHING — it emits a
+  `FlexMatchSnapshot` with the sentinel match-start `unrepresentable-multi-range`
+  (any non-`layer-3`/`layer-4` start lowers to `FlexMatchStart::Unsupported`,
+  whose `flex_matches()` returns `false`), plus a `slog.Warn`. This reuses the
+  existing per-term fail-closed channel — **no** multi-range support is added to
+  the wire/matcher. Silently enforcing only the first range (the pre-fix
+  behavior) would be fail-open.
+
+Pinned by `pkg/config/compiler_flexmatch_cardinality_5823_test.go` (strict
+reject for accept + discard terms; flat-set + group-expansion aggregation;
+lenient mark + warning; single-range unchanged) and
+`pkg/dataplane/userspace/filters_flex_multirange_5823_test.go` (wire poison +
+single-range byte-identical). Removing the aggregation, the strict gate, or the
+wire poison arm turns the matching test RED.
+
 ## Firewall-filter cross-family name collision fail-closed gate (#3884)
 
 Junos namespaces firewall filters **per family**, so `family inet filter blockX`

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -946,6 +946,22 @@ func compileFilterFrom(node *Node, term *FirewallFilterTerm, family string) {
 			term.IsFragment = true
 		case "flexible-match-range":
 			for _, rangeInst := range namedInstances(child.FindChildren("range")) {
+				// #5823: aggregate EVERY named range across every repeated
+				// flexible-match-range block (this switch arm fires once per
+				// block; namedInstances yields every range within a block).
+				// len(FlexMatchRangeNames) > 1 is the cardinality violation the
+				// strict gate rejects and the lenient path fails closed on. The
+				// pre-#5823 code `break`ed after the first range, silently
+				// dropping the rest (an accept term over-permitted, a
+				// discard/reject over-dropped). Compile the FIRST range into
+				// FlexMatch exactly as before (a single-range term is
+				// byte-identical); later ranges are only COUNTED — the wire is
+				// poisoned to match nothing when the count exceeds one, so
+				// compiling their fields would be dead work.
+				term.FlexMatchRangeNames = append(term.FlexMatchRangeNames, rangeInst.name)
+				if term.FlexMatch != nil {
+					continue
+				}
 				fm := &FlexMatchConfig{MatchStart: "layer-3"}
 				for _, rc := range rangeInst.node.Children {
 					switch rc.Name() {
@@ -1044,7 +1060,10 @@ func compileFilterFrom(node *Node, term *FirewallFilterTerm, family string) {
 					}
 				}
 				term.FlexMatch = fm
-				break // only first range supported per term
+				// #5823: do NOT break — the loop continues so every remaining
+				// range is COUNTED in FlexMatchRangeNames (the guard above skips
+				// re-compiling them). The strict gate then rejects a term with
+				// more than one range, and the lenient path fails it closed.
 			}
 		default:
 			// #3307: a `from` match leaf the dataplane does NOT enforce. The

--- a/pkg/config/compiler_flexmatch_cardinality_5823_test.go
+++ b/pkg/config/compiler_flexmatch_cardinality_5823_test.go
@@ -1,0 +1,236 @@
+package config
+
+// #5823: a firewall-filter term may name at most ONE flexible-match-range range
+// (the wire matcher supports one). The pre-fix compiler iterated every named
+// range, kept only the FIRST, and `break`ed — silently dropping every later
+// range. An `accept` term then OVER-PERMITTED (the dropped ranges' packets were
+// no longer required to match) and a `discard`/`reject` term OVER-DROPPED. This
+// is the same #1960 strict/lenient discipline as #3203/#3205/#5832/#5833:
+//   - STRICT commit (CompileConfig): hard-REJECT a term with cardinality > 1,
+//     naming the filter/term/ranges, BEFORE the dataplane apply.
+//   - LENIENT load / peer-sync (CompileConfigLenient): do NOT silently first-win
+//     — downgrade to a WARNING and mark the term (FlexMatchRangeNames) so the
+//     userspace snapshot builder poisons it to match NOTHING (fail-closed).
+//   - A single range compiles exactly as before.
+//
+// FAIL-ON-REVERT: removing the cardinality gate in validateFilterFlexMatchStrict
+// (or the FlexMatchRangeNames aggregation in compileFilterFrom) makes the
+// two-range config commit — the strict-reject and lenient-mark assertions go RED.
+
+import (
+	"strings"
+	"testing"
+)
+
+// twoRangeHierarchical is a hierarchical config whose single term names TWO
+// individually-VALID ranges in ONE flexible-match-range block. Every token is
+// well-formed, so a rejection can only be the cardinality gate, not a parse
+// error (UnknownFlexMatch stays empty).
+const twoRangeHierarchical = `firewall {
+    family inet {
+        filter fmr {
+            term t {
+                from {
+                    flexible-match-range {
+                        range r1 {
+                            match-start layer-3;
+                            byte-offset 9;
+                            bit-length 8;
+                            match-value 0x11;
+                            match-mask 0xFF;
+                        }
+                        range r2 {
+                            match-start layer-3;
+                            byte-offset 20;
+                            bit-length 8;
+                            match-value 0x22;
+                            match-mask 0xFF;
+                        }
+                    }
+                }
+                then accept;
+            }
+        }
+    }
+}
+`
+
+// Acceptance 1 + 3 (accept term) + 4: a hierarchical term with two valid ranges
+// is hard-rejected at commit (CompileConfig, which runs BEFORE the dataplane
+// apply), and the error names the family/filter/term and BOTH ranges.
+func TestFlexMatchMultiRangeHierarchicalRejected_5823(t *testing.T) {
+	tree, err := NewParser(twoRangeHierarchical).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := CompileConfig(tree)
+	if cerr == nil {
+		t.Fatal("a term naming two flexible-match-range ranges must be REJECTED at " +
+			"commit (#5823): the pre-fix compiler kept only the first, over-permitting")
+	}
+	for _, want := range []string{"inet", `filter "fmr"`, `term "t"`, "r1", "r2", "at most one range"} {
+		if !strings.Contains(cerr.Error(), want) {
+			t.Fatalf("reject error %q must contain %q (name the offending filter/term/ranges)", cerr, want)
+		}
+	}
+	// Prove it is a CARDINALITY rejection, not a parse-validation one: every
+	// token is valid, so UnknownFlexMatch must be empty on the lenient compile.
+	cfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile must not hard-fail: %v", lerr)
+	}
+	term := cfg.Firewall.FiltersInet["fmr"].Terms[0]
+	if len(term.UnknownFlexMatch) != 0 {
+		t.Fatalf("both ranges are individually valid; UnknownFlexMatch must be empty "+
+			"(the rejection is cardinality, not a parse error): %v", term.UnknownFlexMatch)
+	}
+	if len(term.FlexMatchRangeNames) != 2 {
+		t.Fatalf("FlexMatchRangeNames must aggregate BOTH ranges, got %v", term.FlexMatchRangeNames)
+	}
+}
+
+// Acceptance 2: the cardinality count AGGREGATES across repeated flat-set
+// flexible-match-range blocks, duplicate names, AND a `from` group expansion —
+// not just the ranges in a single block. Flat-set fixtures use
+// ParseSetCommand + SetPath (never NewParser).
+func TestFlexMatchMultiRangeFlatSetAndGroupCounted_5823(t *testing.T) {
+	// A group contributes a range rg; the term also names r1 directly. After
+	// ExpandGroups (run inside CompileConfig*), the term carries BOTH.
+	// One well-formed leaf per range keeps the flat-set path unambiguous (a
+	// single set command carries ONE leaf; #2419 dual-shape gotcha).
+	tree := buildFilterTree(t,
+		"set groups G firewall family inet filter f term t from flexible-match-range range rg byte-offset 0",
+		"set apply-groups G",
+		"set firewall family inet filter f term t from flexible-match-range range r1 byte-offset 9",
+		"set firewall family inet filter f term t then accept",
+	)
+	// Strict: rejected (cardinality > 1 after group expansion).
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("a flat-set term whose own range plus a group-expanded range total two " +
+			"must be rejected (#5823 cardinality aggregates across group expansion)")
+	}
+	// Lenient: both counted on the compiled term.
+	cfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile must not hard-fail: %v", lerr)
+	}
+	term := cfg.Firewall.FiltersInet["f"].Terms[0]
+	if len(term.FlexMatchRangeNames) != 2 {
+		t.Fatalf("cardinality must aggregate the direct range AND the group-expanded range, got %v",
+			term.FlexMatchRangeNames)
+	}
+	names := strings.Join(term.FlexMatchRangeNames, ",")
+	if !strings.Contains(names, "r1") || !strings.Contains(names, "rg") {
+		t.Fatalf("FlexMatchRangeNames must contain both r1 and rg, got %v", term.FlexMatchRangeNames)
+	}
+}
+
+// Acceptance 3 (discard term): the over-drop direction. Both ranges are valid,
+// so a discard term that would OVER-DROP is rejected on cardinality alone.
+func TestFlexMatchMultiRangeDiscardRejected_5823(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter d term t from flexible-match-range range a byte-offset 0",
+		"set firewall family inet filter d term t from flexible-match-range range b byte-offset 9",
+		"set firewall family inet filter d term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a discard term naming two ranges must be rejected (#5823): keeping only " +
+			"the first range OVER-DROPS the traffic the second range scoped")
+	}
+	if !strings.Contains(err.Error(), `filter "d"`) || !strings.Contains(err.Error(), `term "t"`) {
+		t.Fatalf("reject error %q must name the filter/term", err)
+	}
+}
+
+// Acceptance 5: the tolerant / peer-sync path fails CLOSED — the term is MARKED
+// (FlexMatchRangeNames > 1, which the userspace snapshot builder poisons to
+// match nothing) AND an operator-visible WARNING is emitted. It must NOT
+// hard-fail (a persisted/peer-synced config still boots, #1960).
+func TestFlexMatchMultiRangeLenientMarkedAndWarned_5823(t *testing.T) {
+	tree, err := NewParser(twoRangeHierarchical).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on a multi-range term (#1960 no-brick): %v", lerr)
+	}
+	term := cfg.Firewall.FiltersInet["fmr"].Terms[0]
+	if len(term.FlexMatchRangeNames) <= 1 {
+		t.Fatalf("the term must be MARKED with all ranges so the wire fails it closed, got %v",
+			term.FlexMatchRangeNames)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "flexible-match-range") && strings.Contains(w, "at most one range") {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatalf("a multi-range term on the tolerant path must emit an operator-visible "+
+			"cardinality WARNING, got warnings: %v", cfg.Warnings)
+	}
+}
+
+// Acceptance 6: a SINGLE range is unchanged — it compiles cleanly (strict), its
+// FlexMatch fields are exactly as authored, and FlexMatchRangeNames has one
+// entry (never triggers the gate).
+func TestFlexMatchSingleRangeUnchanged_5823(t *testing.T) {
+	// Hierarchical single range — every field nests cleanly, so this pins the
+	// compiled FlexMatch byte-for-byte against the pre-#5823 behavior.
+	const single = `firewall {
+    family inet {
+        filter ok {
+            term t {
+                from {
+                    flexible-match-range {
+                        range only {
+                            match-start layer-3;
+                            byte-offset 9;
+                            bit-length 8;
+                            match-value 0x11;
+                            match-mask 0xFF;
+                        }
+                    }
+                }
+                then accept;
+            }
+        }
+    }
+}
+`
+	tree, err := NewParser(single).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, cerr := CompileConfig(tree)
+	if cerr != nil {
+		t.Fatalf("a single-range term must compile cleanly (no regression): %v", cerr)
+	}
+	term := cfg.Firewall.FiltersInet["ok"].Terms[0]
+	if len(term.FlexMatchRangeNames) != 1 {
+		t.Fatalf("a single range must record exactly one name, got %v", term.FlexMatchRangeNames)
+	}
+	fm := term.FlexMatch
+	if fm == nil {
+		t.Fatal("single-range FlexMatch must be set")
+	}
+	if fm.MatchStart != "layer-3" || fm.ByteOffset != 9 || fm.BitLength != 8 || fm.Value != 0x11 || fm.Mask != 0xFF {
+		t.Fatalf("single-range FlexMatch fields changed: %+v", fm)
+	}
+
+	// Flat-set single range also compiles and counts exactly one.
+	ftree := buildFilterTree(t,
+		"set firewall family inet filter okflat term t from flexible-match-range range only byte-offset 9",
+		"set firewall family inet filter okflat term t then accept",
+	)
+	fcfg, ferr := CompileConfig(ftree)
+	if ferr != nil {
+		t.Fatalf("flat-set single-range term must compile cleanly: %v", ferr)
+	}
+	if got := fcfg.Firewall.FiltersInet["okflat"].Terms[0].FlexMatchRangeNames; len(got) != 1 {
+		t.Fatalf("flat-set single range must record exactly one name, got %v", got)
+	}
+}

--- a/pkg/config/compiler_validate_strict_filter.go
+++ b/pkg/config/compiler_validate_strict_filter.go
@@ -931,7 +931,25 @@ func validateFilterFlexMatchStrict(cfg *Config) error {
 				continue
 			}
 			for _, term := range filter.Terms {
-				if term == nil || len(term.UnknownFlexMatch) == 0 {
+				if term == nil {
+					continue
+				}
+				// #5823: a term may name at most ONE flexible-match-range range
+				// (the wire matcher supports one). More than one is a cardinality
+				// violation the pre-fix compiler silently collapsed to the first
+				// range — an accept term then over-permitted, a discard/reject
+				// over-dropped. Reject deterministically, naming every range so
+				// the operator knows exactly what to split into separate terms.
+				if len(term.FlexMatchRangeNames) > 1 {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: flexible-match-range "+
+							"specifies %d ranges (%s) but at most one range per term "+
+							"is supported; split the extra ranges into separate terms",
+						family, name, term.Name,
+						len(term.FlexMatchRangeNames),
+						strings.Join(term.FlexMatchRangeNames, ", "))
+				}
+				if len(term.UnknownFlexMatch) == 0 {
 					continue
 				}
 				return fmt.Errorf(

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -1005,6 +1005,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               },
               {
@@ -1042,6 +1043,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               }
             ],
@@ -2258,6 +2260,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               },
               {
@@ -2295,6 +2298,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               }
             ],
@@ -3510,6 +3514,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               },
               {
@@ -3547,6 +3552,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               }
             ],
@@ -4762,6 +4768,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               },
               {
@@ -4799,6 +4806,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               }
             ],
@@ -6015,6 +6023,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               },
               {
@@ -6052,6 +6061,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               }
             ],
@@ -7267,6 +7277,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               },
               {
@@ -7304,6 +7315,7 @@
                 "Policer": "",
                 "FlexMatch": null,
                 "UnknownFlexMatch": null,
+                "FlexMatchRangeNames": null,
                 "UnknownFrom": null
               }
             ],

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -1327,6 +1327,20 @@ type FirewallFilterTerm struct {
 	// the commit; the tolerant load / peer-sync path downgrades to a warning
 	// (#1960 no-brick). Populated by compileFilterFrom.
 	UnknownFlexMatch []string
+	// FlexMatchRangeNames records EVERY named `flexible-match-range` range seen
+	// for this term, aggregated across ALL repeated flexible-match-range blocks
+	// and BOTH AST shapes (hierarchical + flat-set), including duplicate names
+	// and `from` group-expanded copies (#5823). The wire matcher supports at
+	// most ONE range per term; the pre-#5823 compiler silently kept only the
+	// FIRST and dropped the rest — an accept term then over-permitted and a
+	// discard/reject term over-dropped the traffic the missing ranges covered.
+	// len > 1 is a CARDINALITY violation: validateFilterFlexMatchStrict
+	// hard-rejects it at commit (naming every range), and the tolerant load /
+	// peer-sync path fails CLOSED — the userspace snapshot builder poisons the
+	// term to match NOTHING (an unrepresentable flex-match) rather than silently
+	// enforcing only the first range. A single range (len == 1) compiles exactly
+	// as before via FlexMatch. Populated by compileFilterFrom.
+	FlexMatchRangeNames []string
 	// UnknownFrom records `from` match leaves the dataplane does NOT enforce
 	// (#3307). The schema gate is opt-in (schema_walk.go), so an unknown `from`
 	// leaf (e.g. ttl / source-mac-address / ip-options / fragment-offset /

--- a/pkg/dataplane/userspace/filters.go
+++ b/pkg/dataplane/userspace/filters.go
@@ -11,6 +11,14 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
+// flexMatchStartUnrepresentable is the sentinel match-start emitted for a term
+// whose flexible-match-range is UNREPRESENTABLE on the wire (#5823: more than
+// one range named for a single term). It is deliberately NOT "layer-3" /
+// "layer-4", so the Rust filter compiler lowers it to
+// FlexMatchStart::Unsupported and flex_matches() returns false — the term
+// matches NOTHING (fail-closed) rather than enforcing only the first range.
+const flexMatchStartUnrepresentable = "unrepresentable-multi-range"
+
 // BuildFirewallFilterSnapshots returns the effective (compiled) firewall-filter
 // snapshots the userspace dataplane actually receives for cfg — the same value
 // buildSnapshot threads into ConfigSnapshot.Filters. It is exported so the
@@ -274,7 +282,37 @@ func buildFilterTermSnapshots(filterName string, filter *config.FirewallFilter, 
 		// byte offset is L3-relative (match-start layer-3, the only start point
 		// the compiler emits). A zero effective length is dropped (no
 		// constraint) rather than emitted as a degenerate always-fail match.
-		if fm := term.FlexMatch; fm != nil {
+		if len(term.FlexMatchRangeNames) > 1 {
+			// #5823: the term names more than one flexible-match-range range;
+			// the wire matcher supports exactly one. The strict commit gate
+			// (validateFilterFlexMatchStrict) already rejects this, so a term
+			// reaches here ONLY on the tolerant load / peer-sync path (#1960).
+			// Silently enforcing just the first range is fail-OPEN — the packets
+			// the other ranges covered escape the intended match (an accept term
+			// over-permits, a discard/reject over-drops). Fail CLOSED: emit an
+			// UNREPRESENTABLE flex-match so the term matches NOTHING. A
+			// non-{layer-3,layer-4} match-start lowers to
+			// FlexMatchStart::Unsupported in the Rust matcher, whose
+			// flex_matches() returns false for the term (never the wrong-base
+			// match) — the existing per-term fail-closed channel, so no
+			// multi-range support is added to the wire/matcher. Length stays
+			// 1..=4 so flex_enabled is true (a length outside that range would
+			// instead reject the WHOLE snapshot); Value/Mask are unread once the
+			// start is Unsupported.
+			slog.Warn("firewall filter term names multiple flexible-match-range ranges; "+
+				"the dataplane supports one — poisoning the term to match nothing "+
+				"(fail-closed) until the config is split into separate terms",
+				"filter_term", term.Name,
+				"ranges", strings.Join(term.FlexMatchRangeNames, ","),
+				"issue", "#5823")
+			snap.FlexMatch = &FlexMatchSnapshot{
+				Offset:     0,
+				Length:     1,
+				Value:      0,
+				Mask:       0,
+				MatchStart: flexMatchStartUnrepresentable,
+			}
+		} else if fm := term.FlexMatch; fm != nil {
 			// #3203: round UP to whole bytes so a non-multiple-of-8 bit length
 			// (e.g. 12 bits -> 2 bytes) reads enough bytes to cover the field.
 			// Integer truncation (BitLength/8) gave 1 byte for 12 bits, dropping

--- a/pkg/dataplane/userspace/filters_flex_multirange_5823_test.go
+++ b/pkg/dataplane/userspace/filters_flex_multirange_5823_test.go
@@ -1,0 +1,90 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5823: a firewall-filter term that names MORE THAN ONE flexible-match-range
+// range is unrepresentable on the wire (the matcher supports one). The strict
+// commit gate rejects it, but a tolerant-load / peer-sync config can still carry
+// it. The snapshot builder must NOT silently emit only the first range
+// (fail-OPEN); it poisons the term to match NOTHING by emitting an
+// UNREPRESENTABLE flex-match (a non-layer-3/4 match-start → FlexMatchStart::
+// Unsupported → flex_matches() returns false in the Rust matcher).
+//
+// FAIL-ON-REVERT: dropping the len(FlexMatchRangeNames) > 1 poison arm in
+// buildFilterTermSnapshots makes the builder emit the first range's real
+// FlexMatch, so MatchStart is layer-3 (or "") — the term matches the first
+// range instead of nothing, and this assert FAILS.
+func TestFilterSnapshotMultiRangePoisonedToMatchNothing_5823(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"edge": {Name: "edge", Terms: []*config.FirewallFilterTerm{{
+			Name:   "multi",
+			Action: "accept",
+			// The first range is compiled into FlexMatch (as today), but two
+			// ranges were named — the cardinality marker drives the poison.
+			FlexMatch: &config.FlexMatchConfig{
+				MatchStart: "layer-3",
+				ByteOffset: 6,
+				BitLength:  16,
+				Value:      0x0800,
+				Mask:       0xFFFF,
+			},
+			FlexMatchRangeNames: []string{"r1", "r2"},
+		}}},
+	}
+	fm := buildFirewallFilterSnapshots(cfg)[0].Terms[0].FlexMatch
+	if fm == nil {
+		t.Fatal("a multi-range term must still emit a FlexMatch (the fail-closed poison), not drop it")
+	}
+	if fm.MatchStart != flexMatchStartUnrepresentable {
+		t.Fatalf("multi-range term must be poisoned to an UNREPRESENTABLE match-start "+
+			"(match nothing), got MatchStart=%q — the builder is enforcing only the first "+
+			"range (fail-open)", fm.MatchStart)
+	}
+	// Length must stay in the representable 1..=4 range so flex_enabled is true
+	// (the matcher then evaluates the term and, seeing an unsupported start,
+	// fails it closed). A length outside 1..=4 would instead reject the WHOLE
+	// snapshot — not the intended per-term match-nothing.
+	if fm.Length < 1 || fm.Length > 4 {
+		t.Fatalf("poison FlexMatch length %d must be 1..=4 so flex stays ENABLED and the "+
+			"term is evaluated to false, not snapshot-rejected", fm.Length)
+	}
+	// The first range's real value must NOT leak onto the wire.
+	if fm.Value == 0x0800 && fm.Mask == 0xFFFF && fm.Offset == 6 {
+		t.Fatal("the first range's real match leaked onto the wire — the term is not poisoned")
+	}
+}
+
+// A SINGLE range is unaffected — the builder emits the real flex-match
+// byte-identically (no poison, MatchStart is the normal layer-3 => "" mapping).
+func TestFilterSnapshotSingleRangeNotPoisoned_5823(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"edge": {Name: "edge", Terms: []*config.FirewallFilterTerm{{
+			Name:   "one",
+			Action: "discard",
+			FlexMatch: &config.FlexMatchConfig{
+				MatchStart: "layer-3",
+				ByteOffset: 6,
+				BitLength:  16,
+				Value:      0x0800,
+				Mask:       0xFFFF,
+			},
+			FlexMatchRangeNames: []string{"only"},
+		}}},
+	}
+	fm := buildFirewallFilterSnapshots(cfg)[0].Terms[0].FlexMatch
+	if fm == nil {
+		t.Fatal("single-range FlexMatch must be emitted")
+	}
+	if fm.MatchStart == flexMatchStartUnrepresentable {
+		t.Fatal("a single-range term must NOT be poisoned")
+	}
+	if fm.Offset != 6 || fm.Length != 2 || fm.Value != 0x0800 || fm.Mask != 0xFFFF {
+		t.Fatalf("single-range wire fields changed: %+v", fm)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5823. A firewall-filter term may name **at most one** `flexible-match-range range` — the userspace matcher (`flex_matches`) evaluates a single byte-offset window per term. The compiler iterated every named range but kept only the **first** and `break`ed, silently dropping the rest. That is a **security fail-open**: an `accept` term stopped requiring the dropped ranges' condition (over-permit) and a `discard`/`reject` term stopped dropping the traffic they scoped (over-drop), with a clean commit.

## Fix — #1960 strict/lenient discipline (like #3203/#3205/#5832/#5833)

- **`compileFilterFrom`** (`compiler_firewall.go`): removes the `break` and aggregates **every** named range across all repeated `flexible-match-range` blocks, both AST shapes (hierarchical + flat-set), duplicate names, and `from` group-expanded copies into `FirewallFilterTerm.FlexMatchRangeNames`. Only the first range is still compiled into `FlexMatch`, so a **single-range term is byte-identical**.
- **Strict commit / commit-check** (`CompileConfig`): `validateFilterFlexMatchStrict` hard-**rejects** `len(FlexMatchRangeNames) > 1` **before** the dataplane apply, naming the family/filter/term and every range.
- **Lenient load / peer-sync** (`CompileConfigLenient`, #1960 no-brick): the strict error downgrades to an operator-visible `cfg.Warnings` entry, and the userspace snapshot builder (`filters.go`) **poisons** the term to match **nothing** — it emits a `FlexMatchSnapshot` with the sentinel match-start `unrepresentable-multi-range`, which the Rust matcher lowers to `FlexMatchStart::Unsupported` (`flex_matches()` returns `false`) — plus a `slog.Warn`. This **reuses the existing per-term fail-closed channel**; no multi-range support is added to the wire/matcher (defining that is a separate Junos-parity item).

Silently enforcing only the first range (the pre-fix behavior) would be fail-open in both directions.

## Tests (fail-on-revert)

- `pkg/config/compiler_flexmatch_cardinality_5823_test.go` — strict reject for **accept + discard** terms; flat-set + `apply-groups` expansion aggregation; lenient mark + warning; single-range unchanged (fields byte-identical).
- `pkg/dataplane/userspace/filters_flex_multirange_5823_test.go` — wire poison (match-nothing) + single-range byte-identical.

Fail-on-revert verified via `go test -overlay` (worktree unmutated): dropping the aggregation → all config tests RED; dropping the strict gate → strict-reject + lenient-warning RED (single-range PASS); dropping the wire poison arm → the match-nothing test RED (first range leaks = fail-open). The Rust `FlexMatchStart::Unsupported` fail-closed behavior is already covered by `userspace-dp/src/filter/tests.rs`.

## Validation

- `go build ./...` clean
- `go vet ./pkg/config/ ./pkg/dataplane/userspace/` clean
- `go test -race ./pkg/config/ ./pkg/dataplane/userspace/` green
- `golden_4406.json` regenerated — the **only** diff is the additive `FlexMatchRangeNames` field (12 lines), confirming no other behavior changed
- `docs/config-schema.md` documents the cardinality rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)