### PR TITLE
config: merge repeated policy-statement blocks (#5824)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48651,3 +48651,27 @@ top.
   -race ./pkg/upgrade/ GREEN; the ARMED-first revert (drop ARMING/readback)
   proven RED via -overlay on Test 1 (re-arm + self-recovery) and Test 2
   (readback mismatch), with Test 3 (no-regression) still green.
+
+## 2026-07-15 — #5824 fold: cross-root policy-statement same-name term dedup
+
+- **Timestamp**: 2026-07-15
+- **Action**: Fold the independent-review MINOR on PR #5922. psTermIndex is a
+  LOCAL var in compilePolicyOptions, which runs once PER top-level policy-options
+  AST root (NewParser appends top-level nodes unmerged). Two separate top-level
+  `policy-options {}` roots each defining `policy-statement R { term x }` reused
+  the persisted ps but got a fresh empty termsByName, so term x was DUPLICATED
+  (malformed double route-map) instead of composing. FIX: seed the fresh
+  termsByName from the persisted ps.Terms when it is first created, so a same-name
+  term composes across roots exactly as within a root. Corrected the block
+  comment's inaccurate cross-root persistence claim.
+- **File(s)**: pkg/config/compiler_routing.go (ps.Terms seed + comment fix),
+  pkg/config/compiler_policy_block_merge_5824_test.go (new
+  TestPolicyStatementSameTermAcrossRootsMerges_5824).
+- **Validation**: go build ./... clean; go vet ./pkg/config/ ./pkg/frr/ clean;
+  go test -race ./pkg/config/ ./pkg/frr/ GREEN (all 5 5824 tests). Fail-on-revert:
+  dropping the ps.Terms seed via -overlay makes ONLY the cross-root test RED
+  (len(R.Terms)==2 duplicate); the 4 within-root tests stay green.
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5824 fold — cross-root policy-statement term compose. Seed the per-call psTermIndex from the persisted ps.Terms so a same-name term across SEPARATE top-level policy-options roots composes onto one PolicyTerm instead of duplicating (a malformed double route-map). Corrects the block-merge comment's cross-root claim. Parent RED-on-revert confirmed (neutralize seed → SameTermAcrossRootsMerges_5824 RED, got [x x]).
+  - **File(s)**: pkg/config/compiler_routing.go, pkg/config/compiler_policy_block_merge_5824_test.go

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1719,6 +1719,36 @@ is exactly the repetition). The ordered list lands in `PolicyTerm.ASPathPrepend
 `TestGeneratePolicyOptions_ASPathPrepend` in
 `pkg/frr/policy_as_path_prepend_2892_test.go` (render).
 
+### Repeated policy-statement blocks MERGE, not last-win (#5824)
+
+A single `policy-options policy-statement <name>` may be authored across MULTIPLE
+separate hierarchical blocks (two `policy-statement P { ... }` braces), repeated
+`policy-options` roots, or group-expanded fragments — each is a distinct AST
+instance. `compilePolicyOptions` (`compiler_routing.go`) used to build a FRESH
+`PolicyStatement` per instance and do an unconditional
+`po.PolicyStatements[name] = ps`, so a second same-name block silently REPLACED
+the first — its terms, route-filters, actions, and default action vanished. Flat
+`set policy-options policy-statement P term ...` lines COMPOSE under one node via
+`SetPath`, so the hierarchical and flat spellings of the same policy diverged.
+Routing policy is ORDERED security/route-control state: a lost reject term
+over-exports/over-imports and a lost accept term withdraws reachability, while
+FRR receives a valid-but-incomplete route-map and commit + daemon apply both
+look successful.
+
+The policy-statement loop now mirrors the sibling `prefix-list` (#2641) and
+`community` (#2587) merge loops above: it REUSES the existing map entry AND a
+per-policy term index that persists ACROSS instances, so later blocks MERGE into
+the earlier one — new terms append in first-authored ORDER, and a repeated
+fragment of the SAME term composes onto the existing `PolicyTerm` (from-match /
+route-filters / then-action all accumulate via `parsePolicyTermChildren`). The
+policy-level default `then` composes as flat-set does (last-non-empty wins), so
+the two spellings compile to an identical `PolicyStatement`. Fail-on-revert
+covered by `pkg/config/compiler_policy_block_merge_5824_test.go` (two-block
+merge, hierarchical==flat parity, same-term-across-blocks compose, single-block
+unchanged) and the end-to-end render guard
+`pkg/frr/policy_block_merge_5824_test.go` (the early reject term's `deny`
+sequence + route-filter survive into the FRR route-map).
+
 ### Quoted-value escape round-trip contract (#3854)
 
 When a key or value contains a character that is not a bare Junos identifier

--- a/pkg/config/compiler_policy_block_merge_5824_test.go
+++ b/pkg/config/compiler_policy_block_merge_5824_test.go
@@ -228,3 +228,88 @@ func TestPolicyStatementSingleBlockUnchanged_5824(t *testing.T) {
 		t.Fatalf("single-block default action = %q, want reject", ps.DefaultAction)
 	}
 }
+
+// twoRootHierarchical: TWO SEPARATE top-level `policy-options {}` roots (not two
+// blocks in one root), each defining term x of policy-statement R — root 1 the
+// from-match, root 2 the then-action. NewParser appends top-level nodes without
+// merging, so compilePolicyOptions runs once PER root with a FRESH psTermIndex.
+const twoRootHierarchical = `policy-options {
+    policy-statement R {
+        term x {
+            from {
+                protocol static;
+            }
+        }
+    }
+}
+policy-options {
+    policy-statement R {
+        term x {
+            then reject;
+        }
+    }
+}
+`
+
+// Cross-root (#5824 fold): a same-name term across SEPARATE top-level
+// policy-options roots must COMPOSE to ONE term, not duplicate. psTermIndex is
+// local to each compilePolicyOptions call, so the second root gets a fresh empty
+// index; without seeding it from the persisted ps.Terms, term x is appended a
+// SECOND time (root-1's fragment on term#0, root-2's on term#1) — FRR then
+// renders a malformed double `route-map R` sequence. It must be ONE composed
+// term, and hierarchical must equal flat-set for this shape.
+//
+// FAIL-ON-REVERT: drop the `for _, t := range ps.Terms { termsByName[t.Name]=t }`
+// seed and len(R.Terms)==2 (duplicate) — this test goes RED.
+func TestPolicyStatementSameTermAcrossRootsMerges_5824(t *testing.T) {
+	tree, err := NewParser(twoRootHierarchical).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, cerr := CompileConfig(tree)
+	if cerr != nil {
+		t.Fatalf("compile: %v", cerr)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["R"]
+	if ps == nil {
+		t.Fatal("policy-statement R missing from compiled config")
+	}
+	if len(ps.Terms) != 1 {
+		t.Fatalf("a same-name term across SEPARATE top-level policy-options roots must compose "+
+			"to ONE term, got %v (a duplicate renders a malformed double route-map) — #5824 cross-root",
+			termNames(ps))
+	}
+	x := ps.Terms[0]
+	if x.Name != "x" {
+		t.Fatalf("merged term name = %q, want x", x.Name)
+	}
+	if len(x.FromProtocols) != 1 || x.FromProtocols[0] != "static" {
+		t.Fatalf("root-1 from-match must survive the cross-root compose, got %v", x.FromProtocols)
+	}
+	if x.Action != "reject" {
+		t.Fatalf("root-2 then-action must compose onto the SAME term, got %q", x.Action)
+	}
+
+	// Hierarchical (two roots) must equal flat-set (which already composes under
+	// one node via SetPath) for this shape.
+	fTree := buildFilterTree(t,
+		"set policy-options policy-statement R term x from protocol static",
+		"set policy-options policy-statement R term x then reject",
+	)
+	fCfg, ferr := CompileConfig(fTree)
+	if ferr != nil {
+		t.Fatalf("compile flat: %v", ferr)
+	}
+	fps := fCfg.PolicyOptions.PolicyStatements["R"]
+	if fps == nil || len(fps.Terms) != 1 {
+		t.Fatalf("flat-set baseline must be ONE term, got %v", termNames(fps))
+	}
+	if hn, fn := termNames(ps), termNames(fps); len(hn) != len(fn) || hn[0] != fn[0] {
+		t.Fatalf("cross-root hierarchical vs flat term set diverged: %v vs %v", hn, fn)
+	}
+	if ps.Terms[0].Action != fps.Terms[0].Action ||
+		len(ps.Terms[0].FromProtocols) != len(fps.Terms[0].FromProtocols) {
+		t.Fatalf("cross-root hierarchical term diverged from flat: action %q vs %q, from %v vs %v",
+			ps.Terms[0].Action, fps.Terms[0].Action, ps.Terms[0].FromProtocols, fps.Terms[0].FromProtocols)
+	}
+}

--- a/pkg/config/compiler_policy_block_merge_5824_test.go
+++ b/pkg/config/compiler_policy_block_merge_5824_test.go
@@ -1,0 +1,230 @@
+package config
+
+// #5824: repeated hierarchical `policy-options policy-statement <name> { ... }`
+// blocks are distinct AST instances. compilePolicyOptions used to build a FRESH
+// PolicyStatement per instance and do an unconditional
+// `po.PolicyStatements[name] = ps`, so a second same-name block silently
+// REPLACED the first — its terms / route-filters / actions / default action
+// vanished. Flat `set policy-options policy-statement <name> ...` lines compose
+// under one node via SetPath, so hierarchical and flat diverged. Routing policy
+// is ORDERED security/route-control state: a lost reject term over-exports /
+// over-imports; a lost accept term withdraws reachability, while commit and FRR
+// apply both look successful.
+//
+// The fix MERGES same-name blocks (reuse the map entry + a per-policy term index
+// across instances), accumulating terms in first-authored ORDER and composing
+// repeated fragments of the same term — matching flat-set semantics.
+//
+// FAIL-ON-REVERT: restoring the fresh-per-instance `po.PolicyStatements[name] =
+// ps` overwrite makes the first block's terms disappear — every assertion below
+// that the early term survives goes RED.
+
+import (
+	"testing"
+)
+
+// twoBlockHierarchical: block 1 defines term t1 (from static, route-filter,
+// then reject); block 2 (SAME policy name) defines term t2 (from bgp, then
+// accept) plus a policy-level default `then reject`.
+const twoBlockHierarchical = `policy-options {
+    policy-statement P {
+        term t1 {
+            from {
+                protocol static;
+                route-filter 10.0.0.0/8 orlonger;
+            }
+            then reject;
+        }
+    }
+    policy-statement P {
+        term t2 {
+            from {
+                protocol bgp;
+            }
+            then accept;
+        }
+        then reject;
+    }
+}
+`
+
+func policyP(t *testing.T, cfg *Config) *PolicyStatement {
+	t.Helper()
+	ps := cfg.PolicyOptions.PolicyStatements["P"]
+	if ps == nil {
+		t.Fatalf("policy-statement P missing from compiled config")
+	}
+	return ps
+}
+
+func termNames(ps *PolicyStatement) []string {
+	names := make([]string, 0, len(ps.Terms))
+	for _, tm := range ps.Terms {
+		names = append(names, tm.Name)
+	}
+	return names
+}
+
+// Acceptance 1 + 3: two hierarchical same-name blocks with DIFFERENT terms — the
+// early block's reject term (t1, with its route-filter) AND the later block's
+// accept term (t2) are BOTH present, in authored order.
+func TestPolicyStatementHierarchicalBlocksMerge_5824(t *testing.T) {
+	tree, err := NewParser(twoBlockHierarchical).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, cerr := CompileConfig(tree)
+	if cerr != nil {
+		t.Fatalf("compile: %v", cerr)
+	}
+	ps := policyP(t, cfg)
+	got := termNames(ps)
+	if len(got) != 2 || got[0] != "t1" || got[1] != "t2" {
+		t.Fatalf("merged policy must carry BOTH terms in authored order [t1 t2], got %v "+
+			"(the early block's term was overwritten)", got)
+	}
+	// The early reject term must survive intact, with its route-filter.
+	t1 := ps.Terms[0]
+	if t1.Action != "reject" {
+		t.Fatalf("early term t1 must keep Action=reject (a lost reject over-exports), got %q", t1.Action)
+	}
+	if len(t1.FromProtocols) != 1 || t1.FromProtocols[0] != "static" {
+		t.Fatalf("early term t1 must keep from protocol static, got %v", t1.FromProtocols)
+	}
+	if len(t1.RouteFilters) != 1 || t1.RouteFilters[0].Prefix != "10.0.0.0/8" {
+		t.Fatalf("early term t1 must keep its route-filter, got %v", t1.RouteFilters)
+	}
+	// The later accept term is also present.
+	if ps.Terms[1].Action != "accept" {
+		t.Fatalf("later term t2 must be accept, got %q", ps.Terms[1].Action)
+	}
+	// The policy-level default from the later block composes in.
+	if ps.DefaultAction != "reject" {
+		t.Fatalf("policy default action from the later block must compose, got %q", ps.DefaultAction)
+	}
+}
+
+// Acceptance 2: hierarchical and flat-set representations of the SAME policy
+// compile to an identical PolicyStatement (term set, order, actions,
+// route-filters, default action). Flat fixtures use ParseSetCommand + SetPath.
+func TestPolicyStatementHierarchicalEqualsFlatSet_5824(t *testing.T) {
+	hTree, err := NewParser(twoBlockHierarchical).Parse()
+	if err != nil {
+		t.Fatalf("parse hierarchical: %v", err)
+	}
+	hCfg, cerr := CompileConfig(hTree)
+	if cerr != nil {
+		t.Fatalf("compile hierarchical: %v", cerr)
+	}
+
+	fTree := buildFilterTree(t,
+		"set policy-options policy-statement P term t1 from protocol static",
+		"set policy-options policy-statement P term t1 from route-filter 10.0.0.0/8 orlonger",
+		"set policy-options policy-statement P term t1 then reject",
+		"set policy-options policy-statement P term t2 from protocol bgp",
+		"set policy-options policy-statement P term t2 then accept",
+		"set policy-options policy-statement P then reject",
+	)
+	fCfg, cerr2 := CompileConfig(fTree)
+	if cerr2 != nil {
+		t.Fatalf("compile flat: %v", cerr2)
+	}
+
+	h := policyP(t, hCfg)
+	f := policyP(t, fCfg)
+	if hn, fn := termNames(h), termNames(f); len(hn) != len(fn) || hn[0] != fn[0] || hn[1] != fn[1] {
+		t.Fatalf("hierarchical vs flat term order diverged: %v vs %v", hn, fn)
+	}
+	if h.DefaultAction != f.DefaultAction {
+		t.Fatalf("hierarchical vs flat default action diverged: %q vs %q", h.DefaultAction, f.DefaultAction)
+	}
+	for i := range h.Terms {
+		ht, ft := h.Terms[i], f.Terms[i]
+		if ht.Action != ft.Action {
+			t.Fatalf("term %s action diverged: %q vs %q", ht.Name, ht.Action, ft.Action)
+		}
+		if len(ht.RouteFilters) != len(ft.RouteFilters) {
+			t.Fatalf("term %s route-filter count diverged: %d vs %d", ht.Name, len(ht.RouteFilters), len(ft.RouteFilters))
+		}
+		if len(ht.FromProtocols) != len(ft.FromProtocols) {
+			t.Fatalf("term %s from-protocol count diverged: %v vs %v", ht.Name, ht.FromProtocols, ft.FromProtocols)
+		}
+	}
+}
+
+// A repeated fragment of the SAME term across blocks composes onto one term
+// (from-match in block 1, then-action in block 2) rather than creating a
+// duplicate or dropping one fragment.
+func TestPolicyStatementSameTermAcrossBlocksMerges_5824(t *testing.T) {
+	const src = `policy-options {
+    policy-statement Q {
+        term shared {
+            from {
+                protocol static;
+            }
+        }
+    }
+    policy-statement Q {
+        term shared {
+            then reject;
+        }
+    }
+}
+`
+	tree, err := NewParser(src).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, cerr := CompileConfig(tree)
+	if cerr != nil {
+		t.Fatalf("compile: %v", cerr)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["Q"]
+	if ps == nil || len(ps.Terms) != 1 {
+		t.Fatalf("same-name term across blocks must compose to ONE term, got %v", termNames(ps))
+	}
+	shared := ps.Terms[0]
+	if shared.Name != "shared" {
+		t.Fatalf("merged term name = %q, want shared", shared.Name)
+	}
+	if len(shared.FromProtocols) != 1 || shared.FromProtocols[0] != "static" {
+		t.Fatalf("block-1 from-match must survive, got %v", shared.FromProtocols)
+	}
+	if shared.Action != "reject" {
+		t.Fatalf("block-2 then-action must compose onto the same term, got %q", shared.Action)
+	}
+}
+
+// Acceptance 4: a single block is unchanged — one term, correct action.
+func TestPolicyStatementSingleBlockUnchanged_5824(t *testing.T) {
+	const src = `policy-options {
+    policy-statement Solo {
+        term only {
+            from {
+                protocol direct;
+            }
+            then accept;
+        }
+        then reject;
+    }
+}
+`
+	tree, err := NewParser(src).Parse()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, cerr := CompileConfig(tree)
+	if cerr != nil {
+		t.Fatalf("compile: %v", cerr)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["Solo"]
+	if ps == nil || len(ps.Terms) != 1 || ps.Terms[0].Name != "only" {
+		t.Fatalf("single-block policy must have exactly one term 'only', got %v", termNames(ps))
+	}
+	if ps.Terms[0].Action != "accept" {
+		t.Fatalf("single-block term action = %q, want accept", ps.Terms[0].Action)
+	}
+	if ps.DefaultAction != "reject" {
+		t.Fatalf("single-block default action = %q, want reject", ps.DefaultAction)
+	}
+}

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -646,12 +646,17 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 	// each is a distinct AST instance. Flat `set policy-options policy-statement
 	// NAME ...` lines already COMPOSE under one node via SetPath, so hierarchical
 	// must merge the same way or the two shapes diverge. Reuse the existing map
-	// entry AND a per-policy term index that persists ACROSS instances so later
-	// blocks MERGE into the earlier one: new terms append in first-authored ORDER
+	// entry (po.PolicyStatements, which persists across every instance AND across
+	// repeated policy-options roots) AND a per-policy term index so later blocks
+	// MERGE into the earlier one: new terms append in first-authored ORDER
 	// (routing policy is ordered security/route-control state — an earlier reject
 	// term must not be lost or reordered), and a repeated fragment of the SAME
 	// term composes onto the existing PolicyTerm (route-filters / from / then all
-	// accumulate). Mirrors the prefix-list / community merge loops above (#5824).
+	// accumulate). Within ONE policy-options root the term index (psTermIndex,
+	// below) carries the composition across instances; ACROSS separate top-level
+	// policy-options roots (each a distinct compilePolicyOptions call with a fresh
+	// psTermIndex) the composition is re-seeded from the persisted ps.Terms
+	// (#5824). Mirrors the prefix-list / community merge loops above (#5824).
 	//
 	// The pre-#5824 code created a FRESH PolicyStatement per instance and did an
 	// unconditional `po.PolicyStatements[ps.Name] = ps`, so a second same-name
@@ -670,6 +675,18 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 		if termsByName == nil {
 			termsByName = make(map[string]*PolicyTerm)
 			psTermIndex[inst.name] = termsByName
+			// #5824 cross-root: psTermIndex is LOCAL to this compilePolicyOptions
+			// call, but compilePolicyOptions runs once PER top-level policy-options
+			// AST root (NewParser appends top-level nodes without merging). So a
+			// second top-level `policy-options {}` root reuses the persisted `ps`
+			// (from po.PolicyStatements) but gets a FRESH, empty termsByName — a
+			// same-name term in that root would append as a DUPLICATE (a malformed
+			// double route-map sequence in FRR) instead of composing. Seed the fresh
+			// index from ps.Terms so a same-name term composes onto the existing
+			// PolicyTerm across roots, exactly as it already does within a root.
+			for _, t := range ps.Terms {
+				termsByName[t.Name] = t
+			}
 		}
 
 		for _, prop := range inst.node.Children {

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -640,10 +640,37 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 		}
 	}
 
-	// Parse policy-statements
+	// Parse policy-statements. A named policy-statement may be defined across
+	// MULTIPLE separate hierarchical blocks (two `policy-statement NAME { ... }`
+	// braces), repeated `policy-options` roots, or group-expanded fragments —
+	// each is a distinct AST instance. Flat `set policy-options policy-statement
+	// NAME ...` lines already COMPOSE under one node via SetPath, so hierarchical
+	// must merge the same way or the two shapes diverge. Reuse the existing map
+	// entry AND a per-policy term index that persists ACROSS instances so later
+	// blocks MERGE into the earlier one: new terms append in first-authored ORDER
+	// (routing policy is ordered security/route-control state — an earlier reject
+	// term must not be lost or reordered), and a repeated fragment of the SAME
+	// term composes onto the existing PolicyTerm (route-filters / from / then all
+	// accumulate). Mirrors the prefix-list / community merge loops above (#5824).
+	//
+	// The pre-#5824 code created a FRESH PolicyStatement per instance and did an
+	// unconditional `po.PolicyStatements[ps.Name] = ps`, so a second same-name
+	// block silently REPLACED the first — its terms / route-filters / actions /
+	// default action vanished. FRR then received a valid but INCOMPLETE route-map
+	// (a lost reject term over-exports/over-imports; a lost accept term withdraws
+	// reachability) while commit and daemon apply both looked successful.
+	psTermIndex := make(map[string]map[string]*PolicyTerm)
 	for _, inst := range namedInstances(node.FindChildren("policy-statement")) {
-		ps := &PolicyStatement{Name: inst.name}
-		termsByName := make(map[string]*PolicyTerm)
+		ps := po.PolicyStatements[inst.name]
+		if ps == nil {
+			ps = &PolicyStatement{Name: inst.name}
+			po.PolicyStatements[inst.name] = ps
+		}
+		termsByName := psTermIndex[inst.name]
+		if termsByName == nil {
+			termsByName = make(map[string]*PolicyTerm)
+			psTermIndex[inst.name] = termsByName
+		}
 
 		for _, prop := range inst.node.Children {
 			switch prop.Name() {
@@ -687,8 +714,9 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 				}
 			}
 		}
-
-		po.PolicyStatements[ps.Name] = ps
+		// #5824: NO unconditional overwrite here — ps is the SHARED map entry, so
+		// this instance's contributions are already merged into any earlier
+		// same-name block's terms/actions in authored order.
 	}
 
 	return nil

--- a/pkg/frr/policy_block_merge_5824_test.go
+++ b/pkg/frr/policy_block_merge_5824_test.go
@@ -1,0 +1,63 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5824: end-to-end guard. A policy-statement defined across TWO hierarchical
+// blocks must render BOTH terms into the FRR route-map. Before the compiler
+// merge fix, the second same-name block REPLACED the first, so the early reject
+// term (and its route-filter) never reached FRR — a valid but incomplete
+// route-map that over-exports the routes the operator meant to block.
+//
+// FAIL-ON-REVERT: restoring the fresh-per-instance PolicyStatement overwrite in
+// compilePolicyOptions drops term t1, so its `deny` sequence and the
+// 10.0.0.0/8 route-filter prefix disappear from the rendered route-map.
+func TestPolicyBlockMergeRendersEarlyRejectTerm_5824(t *testing.T) {
+	const src = `policy-options {
+    policy-statement P {
+        term t1 {
+            from {
+                protocol static;
+                route-filter 10.0.0.0/8 orlonger;
+            }
+            then reject;
+        }
+    }
+    policy-statement P {
+        term t2 {
+            from {
+                protocol bgp;
+            }
+            then accept;
+        }
+    }
+}
+`
+	tree, perr := config.NewParser(src).Parse()
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	cfg, cerr := config.CompileConfig(tree)
+	if cerr != nil {
+		t.Fatalf("compile: %v", cerr)
+	}
+	m := New()
+	got := m.generatePolicyOptions(&cfg.PolicyOptions)
+
+	// The early block's reject term renders a `deny` sequence.
+	if !strings.Contains(got, "route-map P deny") {
+		t.Fatalf("early reject term dropped from the route-map (over-export):\n%s", got)
+	}
+	// ...matched by its route-filter prefix (rendered into a prefix-list entry).
+	if !strings.Contains(got, "10.0.0.0/8") {
+		t.Fatalf("early term's route-filter prefix 10.0.0.0/8 missing from the route-map:\n%s", got)
+	}
+	// The later block's accept term is also present.
+	if !strings.Contains(got, "route-map P permit") {
+		t.Fatalf("later accept term missing from the route-map:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5824. A single `policy-options policy-statement <name>` may be authored across **multiple** separate hierarchical blocks (two `policy-statement P { ... }` braces), repeated `policy-options` roots, or group-expanded fragments — each a distinct AST instance. `compilePolicyOptions` built a **fresh** `PolicyStatement` per instance and did an unconditional `po.PolicyStatements[name] = ps`, so a second same-name block silently **replaced** the first — its terms, route-filters, actions, and default action vanished.

Flat `set policy-options policy-statement P term ...` lines compose under one node via `SetPath`, so the hierarchical and flat spellings of the same policy **diverged**. Routing policy is ordered security/route-control state: a lost reject term over-exports/over-imports and a lost accept term withdraws reachability, while FRR receives a valid-but-incomplete route-map and commit + daemon apply both look successful.

## Fix — merge, mirroring the sibling `prefix-list`/`community` loops

The policy-statement loop now reuses the existing map entry **and** a per-policy term index that persists **across instances** (like the `prefix-list` #2641 and `community` #2587 merge loops directly above it):

- new terms **append in first-authored ORDER** (an earlier reject term must not be lost or reordered);
- a repeated fragment of the **same** term composes onto the existing `PolicyTerm` (from-match / route-filters / then-action all accumulate via `parsePolicyTermChildren`);
- the policy-level default `then` composes as flat-set does (last-non-empty wins), so **hierarchical and flat compile to an identical `PolicyStatement`** — the load-bearing parity invariant (rejecting scalar conflicts would have *broken* that parity, since flat-set last-wins).

## Tests (fail-on-revert)

- `pkg/config/compiler_policy_block_merge_5824_test.go` — two-block merge (early reject term + route-filter survive in authored order); **hierarchical == flat** parity incl. default action; same-term-across-blocks compose to one term; single-block unchanged.
- `pkg/frr/policy_block_merge_5824_test.go` — end-to-end: the early reject term's `deny` sequence and `10.0.0.0/8` route-filter survive into the rendered FRR route-map.

Fail-on-revert verified via `go test -overlay` (worktree unmutated) restoring the fresh-per-instance overwrite: the hierarchical config then keeps only the **last** block (`[t2]` vs flat `[t1 t2]`) and the merge + render tests go RED, while single-block stays green.

## Validation

- `go build ./...` clean
- `go vet ./pkg/config/ ./pkg/frr/` clean
- `go test -race ./pkg/config/ ./pkg/frr/` green
- `docs/config-schema.md` documents the block-merge rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)