### PR TITLE
daemon: reconcile the management listener + auth on day-2 commits (#5866)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48651,3 +48651,29 @@ top.
   -race ./pkg/upgrade/ GREEN; the ARMED-first revert (drop ARMING/readback)
   proven RED via -overlay on Test 1 (re-arm + self-recovery) and Test 2
   (readback mismatch), with Test 3 (no-regression) still green.
+
+## 2026-07-15 — #5866 day-2 web-management listener + auth reconcile
+
+- **Timestamp**: 2026-07-15
+- **Action**: The HTTP/HTTPS management server was constructed once at startup
+  and never reconciled, so a committed web-management change (bind/port/TLS/auth,
+  e.g. a REVOKED credential) sat inert until a daemon restart. Added a
+  managementReconciler that, on every commit, atomically replaces the live
+  listener + auth snapshot: same-endpoint auth change → live atomic ReplaceAuth
+  (no rebind); endpoint change → make-before-break rebind (bind new before
+  closing old); failed new bind → retain old listener + surface error (fail-safe,
+  retry debt). Wired into applyConfigLocked next to reconcileSNMP (early, before
+  the dataplane apply).
+- **File(s)**: pkg/api/server.go (atomic auth snapshot + dynamicAuthMiddleware +
+  ReplaceAuth + Start/bindListeners/serveBound + ListenFunc seam + AuthSnapshot/
+  HTTPSCert ForTest accessors), pkg/api/auth.go (extract shared authCheck +
+  writeAuthChallenge), pkg/daemon/management.go (NEW — managementReconciler),
+  pkg/daemon/daemon.go (d.mgmt field), pkg/daemon/daemon_run.go (startHTTPServer
+  hands listener lifecycle to the reconciler + shutdown drain), pkg/daemon/
+  daemon_apply.go (reconcileWebManagement call after reconcileSNMP),
+  pkg/api/server_authswap_5866_test.go + pkg/daemon/management_5866_test.go (NEW
+  fail-on-revert tests), pkg/api/README.md + pkg/daemon/README.md (lifecycle).
+- **Validation**: go build ./... clean; go vet ./pkg/daemon/ ./pkg/api/ clean;
+  go test -race ./pkg/api/ ./pkg/daemon/ GREEN. Fail-on-revert overlays proven
+  RED: (A) capture auth once → live-swap test RED (revoked cred still 200);
+  (B) close-old-before-bind-new → coexistence + retain-old tests RED.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -292,6 +292,29 @@ under the daemon's errgroup. Nothing else imports this package.
   length mismatch (reveals length, not content — acceptable). Pinned by
   `auth_consttime_4157_test.go`, including an AST regression guard that fails
   if any auth path reverts to a bare `cfg.APIKeys[...]` lookup.
+- **Day-2 listener + auth reconcile (#5866).** The management server used to be
+  constructed ONCE at daemon startup and never reconciled, so a committed
+  web-management change (bind address / port / TLS on/off / api-auth) reported
+  success while the process kept enforcing the old policy until a restart —
+  revoked or tightened credentials stayed usable, a bind removal left the API on
+  the old address. Two mechanisms close this:
+  - The authentication snapshot is a live `atomic.Pointer[AuthConfig]` (`s.auth`)
+    read per request by `dynamicAuthMiddleware`; `ReplaceAuth` swaps it, so a
+    revoked/tightened credential is rejected on the NEXT request with no listener
+    bounce and no restart. The `authCheck` core is shared with the static
+    `authMiddleware`, so the swap enforces byte-identical semantics (the #4157
+    constant-time + #5636 empty-secret guards, `/health` + loopback-`/metrics`
+    exemptions).
+  - `Start(ctx)` binds the listeners SYNCHRONOUSLY (returning a bind error with
+    nothing serving) then serves in the background — the make-before-break
+    primitive the daemon's `managementReconciler` (`pkg/daemon/management.go`)
+    uses to bind a NEW endpoint before retiring the old, so a bind/port/TLS
+    change never leaves a window with no management listener and a failed new
+    bind fail-closes to the retained previous listener. `bindListeners` binds via
+    `Config.ListenFunc` (default `net.Listen`) so tests inject a fake factory.
+    Pinned by `server_authswap_5866_test.go` (live auth swap) +
+    `pkg/daemon/management_5866_test.go` (bind change / TLS rebuild / auth swap /
+    bind-failure retain-old).
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -305,16 +305,27 @@ under the daemon's errgroup. Nothing else imports this package.
     `authMiddleware`, so the swap enforces byte-identical semantics (the #4157
     constant-time + #5636 empty-secret guards, `/health` + loopback-`/metrics`
     exemptions).
-  - `Start(ctx)` binds the listeners SYNCHRONOUSLY (returning a bind error with
-    nothing serving) then serves in the background — the make-before-break
-    primitive the daemon's `managementReconciler` (`pkg/daemon/management.go`)
-    uses to bind a NEW endpoint before retiring the old, so a bind/port/TLS
-    change never leaves a window with no management listener and a failed new
-    bind fail-closes to the retained previous listener. `bindListeners` binds via
-    `Config.ListenFunc` (default `net.Listen`) so tests inject a fake factory.
-    Pinned by `server_authswap_5866_test.go` (live auth swap) +
-    `pkg/daemon/management_5866_test.go` (bind change / TLS rebuild / auth swap /
-    bind-failure retain-old).
+  - The HTTP and HTTPS listeners run in INDEPENDENT legs (`listener.go`), each
+    make-before-break: `ReconcileHTTP(addr)` rebinds only the HTTP leg and
+    `ReconcileHTTPS(tls, addr)` enables / disables / rebinds only the HTTPS leg —
+    neither touches the sibling. This is the fix for the earlier whole-server
+    rebuild: enabling TLS keeps the HTTP bind, so re-binding the whole server
+    re-bound the still-held HTTP socket and failed `EADDRINUSE` (Go sets
+    `SO_REUSEADDR`, not `SO_REUSEPORT`), and the TLS change could never converge
+    without a restart — the same collision hit an HTTP-addr change that left the
+    HTTPS bind unchanged. Each leg binds the new socket and serves it BEFORE
+    retiring the old (no unreachable window on that plane, no double-bind of an
+    unchanged socket); a bind (or HTTPS cert) failure fail-closes to the retained
+    previous leg. `Start(ctx)` binds HTTP synchronously (fail-closed if it fails)
+    and HTTPS best-effort (a boot HTTPS failure leaves HTTP up, retried next
+    commit). `Wait()` joins every live + retiring leg goroutine on shutdown.
+    Listeners bind via `Config.ListenFunc` (default `net.Listen`) so tests inject
+    a fake factory that models `EADDRINUSE`. Pinned by
+    `server_authswap_5866_test.go` (live auth swap) +
+    `pkg/daemon/management_5866_test.go` (HTTP-bind change, TLS enable/disable/
+    re-enable, HTTPS-bind-only change, HTTP-change-keeps-HTTPS, auth swap,
+    bind-failure retain-old). `Run`/`serveBound` remain the single-lifecycle test
+    entry point.
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -24,34 +24,41 @@ type AuthConfig struct {
 // /metrics like every other endpoint (#4162).
 func authMiddleware(cfg AuthConfig, metricsRequireAuth bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// /health is always exempt; /metrics is exempt only when this listener
-		// has a literal loopback bind.
-		if r.URL.Path == "/health" || (r.URL.Path == "/metrics" && !metricsRequireAuth) {
+		if authCheck(cfg, metricsRequireAuth, r) {
 			next.ServeHTTP(w, r)
 			return
 		}
+		writeAuthChallenge(w)
+	})
+}
 
-		// Check Authorization header
-		if auth := r.Header.Get("Authorization"); auth != "" {
-			if checkAuthorization(auth, cfg) {
-				next.ServeHTTP(w, r)
-				return
-			}
-		}
+// authCheck reports whether a request is authorized under cfg (or exempt). It is
+// the shared core of the static authMiddleware and the live-swap
+// dynamicAuthMiddleware (#5866), so both enforce identical semantics — the
+// /health + loopback-/metrics exemptions and the #4157/#5636 constant-time,
+// empty-secret-rejecting credential checks.
+func authCheck(cfg AuthConfig, metricsRequireAuth bool, r *http.Request) bool {
+	// /health is always exempt; /metrics is exempt only when this listener has a
+	// literal loopback bind.
+	if r.URL.Path == "/health" || (r.URL.Path == "/metrics" && !metricsRequireAuth) {
+		return true
+	}
+	if auth := r.Header.Get("Authorization"); auth != "" && checkAuthorization(auth, cfg) {
+		return true
+	}
+	if key := r.Header.Get("X-API-Key"); key != "" && constantTimeAPIKeyMatch(cfg, key) {
+		return true
+	}
+	return false
+}
 
-		// Check X-API-Key header
-		if key := r.Header.Get("X-API-Key"); key != "" {
-			if constantTimeAPIKeyMatch(cfg, key) {
-				next.ServeHTTP(w, r)
-				return
-			}
-		}
-
-		w.Header().Set("WWW-Authenticate", `Basic realm="xpf API"`)
-		writeJSON(w, http.StatusUnauthorized, Response{
-			Success: false,
-			Error:   "authentication required",
-		})
+// writeAuthChallenge emits the 401 + WWW-Authenticate response for an
+// unauthorized request.
+func writeAuthChallenge(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="xpf API"`)
+	writeJSON(w, http.StatusUnauthorized, Response{
+		Success: false,
+		Error:   "authentication required",
 	})
 }
 

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// listenerLeg is one independently-managed listening socket + its serve
+// goroutine (#5866). The HTTP and HTTPS listeners each run in their own leg so a
+// day-2 change to one (TLS enable/disable, an HTTPS-bind change, or an HTTP-bind
+// change) rebinds ONLY that leg — the sibling keeps serving without a bounce and
+// without the EADDRINUSE that a whole-server rebuild hit when the two legs
+// shared no socket but the rebuild still re-bound the unchanged one.
+type listenerLeg struct {
+	srv      *http.Server
+	ln       net.Listener
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// serveLegLocked launches srv on ln in a background goroutine registered on the
+// server wait group, and returns the leg. The goroutine serves until (a) the
+// listener terminates on its own, (b) the leg is explicitly retired
+// (stopLegLocked), or (c) the daemon root context is cancelled — then it runs a
+// bounded 5s graceful drain (Shutdown closes ln + unblocks Serve) and joins.
+// Caller holds lifeMu (so rootCtx is set and reads are consistent).
+func (s *Server) serveLegLocked(srv *http.Server, ln net.Listener, isTLS bool) *listenerLeg {
+	leg := &listenerLeg{srv: srv, ln: ln, stopCh: make(chan struct{})}
+	rootCtx := s.rootCtx
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		serveErr := make(chan error, 1)
+		go func() {
+			if isTLS {
+				// TLSConfig.Certificates is populated, so ServeTLS with empty
+				// file paths uses those in-memory certs.
+				serveErr <- srv.ServeTLS(ln, "", "")
+			} else {
+				serveErr <- srv.Serve(ln)
+			}
+		}()
+
+		var rootDone <-chan struct{}
+		if rootCtx != nil {
+			rootDone = rootCtx.Done()
+		}
+		select {
+		case err := <-serveErr:
+			// The listener terminated on its own (not a requested shutdown); the
+			// socket is already closed, nothing left to drain.
+			if err != nil && err != http.ErrServerClosed {
+				slog.Error("API listener terminated unexpectedly", "addr", srv.Addr, "tls", isTLS, "err", err)
+			}
+			return
+		case <-leg.stopCh:
+		case <-rootDone:
+		}
+		sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(sctx)
+		<-serveErr // join the Serve goroutine before the leg is considered drained
+	}()
+	return leg
+}
+
+// stopLegLocked idempotently requests a leg's graceful retirement. The leg's
+// goroutine drains + joins in the background; wg.Wait (Server.Wait) joins it on
+// daemon shutdown. Caller holds lifeMu.
+func (s *Server) stopLegLocked(leg *listenerLeg) {
+	if leg == nil {
+		return
+	}
+	leg.stopOnce.Do(func() { close(leg.stopCh) })
+}
+
+// Start binds the configured listeners and serves each in its own leg (#5866),
+// returning once they are live. HTTP is the primary listener: a bind failure
+// returns an error with nothing serving (the caller logs it non-fatally and the
+// next commit retries via ReconcileHTTP). HTTPS is best-effort at boot — a bind
+// failure leaves the HTTP plane up (fail-safe, management not down) and the next
+// reconcile retries the HTTPS leg. Wait blocks until every leg (live + retiring)
+// has drained.
+func (s *Server) Start(ctx context.Context) error {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	s.rootCtx = ctx
+
+	if s.httpServer != nil {
+		ln, err := s.listen("tcp", s.httpServer.Addr)
+		if err != nil {
+			return fmt.Errorf("api: bind HTTP listener %q: %w", s.httpServer.Addr, err)
+		}
+		s.httpLeg = s.serveLegLocked(s.httpServer, ln, false)
+		slog.Info("HTTP API server listening", "addr", s.httpServer.Addr)
+	}
+	if s.httpsServer != nil {
+		ln, err := s.listen("tcp", s.httpsServer.Addr)
+		if err != nil {
+			slog.Error("api: HTTPS listener bind failed at start; HTTPS disabled until the next reconcile",
+				"addr", s.httpsServer.Addr, "err", err)
+		} else {
+			s.httpsLeg = s.serveLegLocked(s.httpsServer, ln, true)
+			slog.Info("HTTPS API server listening", "addr", s.httpsServer.Addr)
+		}
+	}
+	return nil
+}
+
+// Wait blocks until every serve goroutine (live + retiring legs) has fully
+// exited. It takes lifeMu so no concurrent reconcile can register a new leg
+// (WaitGroup Add) once the join has begun; leg drains do not need lifeMu, so
+// they complete while Wait holds it. Call after the root context is cancelled.
+func (s *Server) Wait() {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	s.wg.Wait()
+}
+
+// ReconcileHTTP make-before-break rebinds ONLY the HTTP listener to addr (#5866),
+// leaving the HTTPS leg untouched. A same-addr call is a no-op. The new listener
+// is bound and serving BEFORE the old is retired (no unreachable HTTP window). A
+// bind failure retains the previous HTTP listener (fail-closed) and returns the
+// error so the caller records retry debt.
+func (s *Server) ReconcileHTTP(addr string) error {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	if addr == "" {
+		return fmt.Errorf("api: refusing to reconcile the HTTP listener to an empty bind address")
+	}
+	if s.httpLeg != nil && s.httpLeg.srv.Addr == addr {
+		return nil
+	}
+	srv := s.buildHTTPServer(addr)
+	ln, err := s.listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("api: bind HTTP listener %q: %w", addr, err)
+	}
+	old := s.httpLeg
+	s.httpLeg = s.serveLegLocked(srv, ln, false)
+	s.stopLegLocked(old) // retire the previous HTTP listener only after the new one is serving
+	return nil
+}
+
+// ReconcileHTTPS enables, disables, or make-before-break rebinds ONLY the HTTPS
+// listener (#5866), leaving the live HTTP listener untouched — this is the fix
+// for the whole-server rebuild that re-bound the still-held HTTP socket on a
+// TLS-enable (EADDRINUSE). useTLS=false or addr=="" disables HTTPS. A same-addr
+// enabled call is a no-op. On enable/rebind the new HTTPS listener (with a fresh
+// self-signed cert) is bound and serving BEFORE any old one is retired. A cert
+// or bind failure retains the previous HTTPS state (fail-closed) and returns the
+// error for retry debt.
+func (s *Server) ReconcileHTTPS(useTLS bool, addr string) error {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	want := useTLS && addr != ""
+	switch {
+	case !want:
+		if s.httpsLeg != nil {
+			s.stopLegLocked(s.httpsLeg)
+			s.httpsLeg = nil
+		}
+		return nil
+	case s.httpsLeg != nil && s.httpsLeg.srv.Addr == addr:
+		return nil
+	default:
+		srv, err := s.buildHTTPSServer(addr)
+		if err != nil {
+			return fmt.Errorf("api: generate HTTPS certificate for %q: %w", addr, err)
+		}
+		ln, err := s.listen("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("api: bind HTTPS listener %q: %w", addr, err)
+		}
+		old := s.httpsLeg
+		s.httpsLeg = s.serveLegLocked(srv, ln, true)
+		s.stopLegLocked(old)
+		return nil
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -93,15 +94,19 @@ type Config struct {
 	HTTPSAddr string      // HTTPS listen address (empty = no HTTPS)
 	TLS       bool        // enable HTTPS with auto-generated certificate
 	Auth      *AuthConfig // nil = no authentication
-	Store     *configstore.Store
-	DP        apiRuntimeDataPlane
-	EventBuf  *logging.EventBuffer
-	GC        *conntrack.GC
-	Routing   *routing.Manager
-	FRR       *frr.Manager
-	IPsec     *ipsec.Manager
-	DHCP      *dhcp.Manager
-	VRRPMgr   *vrrp.Manager // native VRRP manager
+	// ListenFunc is the listener factory the server binds through (#5866).
+	// nil defaults to net.Listen; a test injects a fake so the
+	// make-before-break listener reconcile is exercised without real ports.
+	ListenFunc func(network, address string) (net.Listener, error)
+	Store      *configstore.Store
+	DP         apiRuntimeDataPlane
+	EventBuf   *logging.EventBuffer
+	GC         *conntrack.GC
+	Routing    *routing.Manager
+	FRR        *frr.Manager
+	IPsec      *ipsec.Manager
+	DHCP       *dhcp.Manager
+	VRRPMgr    *vrrp.Manager // native VRRP manager
 	// #846: atomic commit+apply callbacks. The daemon holds its
 	// apply semaphore across configstore.Commit and applyConfig, so
 	// two concurrent committers can't interleave their commit→apply
@@ -270,8 +275,24 @@ type Config struct {
 
 // Server is the HTTP API server.
 type Server struct {
-	httpServer                       *http.Server
-	httpsServer                      *http.Server
+	httpServer  *http.Server
+	httpsServer *http.Server
+	// auth is the LIVE authentication snapshot, read atomically on EVERY request
+	// by the middleware so a day-2 web-management commit that tightens or revokes
+	// credentials takes effect on the very next request WITHOUT rebinding the
+	// listener or restarting the daemon (#5866). nil = no authentication (the
+	// #4047/#5127 loopback clamp guarantees a nil-auth listener is loopback-only).
+	// ReplaceAuth swaps it; a bind-address/port/TLS change instead goes through a
+	// make-before-break listener rebuild (managementReconciler).
+	auth atomic.Pointer[AuthConfig]
+	// serveDone is closed when the background serve goroutine started by Start
+	// exits (#5866); Wait blocks on it so a swapped-out or shutting-down server's
+	// listeners+goroutines are fully drained before the daemon joins.
+	serveDone chan struct{}
+	// listen is the listener factory (#5866): Config.ListenFunc or net.Listen. A
+	// test injects a fake so the make-before-break reconcile is exercised without
+	// binding real ports.
+	listen                           func(network, address string) (net.Listener, error)
 	store                            *configstore.Store
 	dp                               apiRuntimeDataPlane
 	eventBuf                         *logging.EventBuffer
@@ -392,6 +413,14 @@ func NewServer(cfg Config) *Server {
 		nodeIDFn:                         cfg.NodeIDFn,
 		clusterSessionFn:                 cfg.ClusterSessionFn,
 		startTime:                        time.Now(),
+	}
+	// #5866: seed the live auth snapshot; the middleware reads it atomically per
+	// request so ReplaceAuth can swap credentials without rebinding the listener.
+	s.auth.Store(cfg.Auth)
+	// #5866: the listener factory (Config.ListenFunc or net.Listen).
+	s.listen = cfg.ListenFunc
+	if s.listen == nil {
+		s.listen = net.Listen
 	}
 
 	mux := http.NewServeMux()
@@ -515,11 +544,13 @@ func NewServer(cfg Config) *Server {
 	// listener's configured bind independently. Never infer this from r.Host
 	// or the sibling listener: only a literal loopback bind leaves /metrics
 	// open when auth is configured. /health remains exempt in authMiddleware.
+	// #5866: wrap with a middleware that reads the LIVE auth snapshot (s.auth)
+	// atomically per request, so ReplaceAuth takes effect on the next request
+	// without rebinding. metricsRequireAuth is fixed per listener (its bind
+	// address never changes for a given Server; a bind change goes through the
+	// make-before-break rebuild, not this swap).
 	listenerHandler := func(addr string) http.Handler {
-		if cfg.Auth == nil {
-			return sharedBase
-		}
-		return authMiddleware(*cfg.Auth, !isLoopbackBindAddr(addr), sharedBase)
+		return s.dynamicAuthMiddleware(!isLoopbackBindAddr(addr), sharedBase)
 	}
 
 	s.httpServer = &http.Server{
@@ -572,24 +603,119 @@ func NewServer(cfg Config) *Server {
 // and left the other serving forever — an orphaned management socket that the
 // daemon wrapper could never reach to shut down.
 func (s *Server) Run(ctx context.Context) error {
-	// Bind synchronously and in a fixed order (HTTP first) so startup fails
-	// atomically before either server accepts a connection.
-	httpLn, err := net.Listen("tcp", s.httpServer.Addr)
+	httpLn, httpsLn, err := s.bindListeners()
 	if err != nil {
-		return fmt.Errorf("api: bind HTTP listener %q: %w", s.httpServer.Addr, err)
+		return err
 	}
+	return s.serveBound(ctx, httpLn, httpsLn)
+}
 
-	var httpsLn net.Listener
+// bindListeners binds the HTTP (and optional HTTPS) listeners SYNCHRONOUSLY, in
+// a fixed order (HTTP first), ALL-OR-NOTHING: a bind failure on either closes
+// whichever already bound and returns an error, so no orphaned socket is left
+// (#5058). It is the make-before-break primitive (#5866) — the caller learns the
+// endpoint is bindable before it retires the previous listener. Binds via
+// s.listen (Config.ListenFunc, default net.Listen) so a test injects a fake
+// factory instead of racing on real ports.
+func (s *Server) bindListeners() (httpLn, httpsLn net.Listener, err error) {
+	httpLn, err = s.listen("tcp", s.httpServer.Addr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("api: bind HTTP listener %q: %w", s.httpServer.Addr, err)
+	}
 	if s.httpsServer != nil {
-		httpsLn, err = net.Listen("tcp", s.httpsServer.Addr)
+		httpsLn, err = s.listen("tcp", s.httpsServer.Addr)
 		if err != nil {
-			// The HTTP listener already bound — close it so a failed
-			// startup leaves no orphaned socket behind (#5058).
+			// The HTTP listener already bound — close it so a failed startup
+			// leaves no orphaned socket behind (#5058).
 			httpLn.Close()
-			return fmt.Errorf("api: bind HTTPS listener %q: %w", s.httpsServer.Addr, err)
+			return nil, nil, fmt.Errorf("api: bind HTTPS listener %q: %w", s.httpsServer.Addr, err)
 		}
 	}
+	return httpLn, httpsLn, nil
+}
 
+// Start binds the listeners synchronously (returning a bind error with nothing
+// left serving) then serves them in the BACKGROUND until ctx is cancelled,
+// returning nil once BOTH listeners are bound (#5866). This is the
+// make-before-break entry point: the managementReconciler binds the new endpoint
+// with Start (knowing it is live) BEFORE cancelling the old server's context, so
+// the management plane is never unreachable. Wait blocks until the background
+// serve goroutine (and its bounded drain) exits.
+func (s *Server) Start(ctx context.Context) error {
+	httpLn, httpsLn, err := s.bindListeners()
+	if err != nil {
+		return err
+	}
+	s.serveDone = make(chan struct{})
+	go func() {
+		defer close(s.serveDone)
+		if err := s.serveBound(ctx, httpLn, httpsLn); err != nil {
+			slog.Error("API server exited with error", "err", err)
+		}
+	}()
+	return nil
+}
+
+// Wait blocks until the background serve goroutine started by Start has fully
+// exited (listeners closed, in-flight requests drained, sibling goroutines
+// joined). It is a no-op if Start was never called.
+func (s *Server) Wait() {
+	if s.serveDone != nil {
+		<-s.serveDone
+	}
+}
+
+// ReplaceAuth atomically swaps the live authentication snapshot (#5866). A day-2
+// web-management commit that enables, tightens, or REVOKES credentials on an
+// UNCHANGED bind calls this: the middleware reads the new snapshot on the next
+// request, so a revoked credential is rejected immediately — no listener bounce,
+// no restart, no window. a==nil disables auth (only reached on a loopback bind;
+// the #4047/#5127 clamp forces a non-loopback no-auth bind through a rebuild).
+func (s *Server) ReplaceAuth(a *AuthConfig) {
+	s.auth.Store(a)
+}
+
+// AuthSnapshotForTest returns the live auth snapshot (#5866). Test-only: it lets
+// a cross-package test (pkg/daemon managementReconciler) assert that a
+// same-endpoint reconcile published the new snapshot in place. Dep-free (no
+// test-only imports leak into the production binary).
+func (s *Server) AuthSnapshotForTest() *AuthConfig { return s.auth.Load() }
+
+// HTTPSCertForTest returns the served TLS leaf certificate, or nil when the
+// server is HTTP-only (#5866). Test-only: lets a cross-package test assert that a
+// TLS-material reconcile rebuilds the listener with a FRESH certificate.
+func (s *Server) HTTPSCertForTest() *tls.Certificate {
+	if s.httpsServer == nil || s.httpsServer.TLSConfig == nil || len(s.httpsServer.TLSConfig.Certificates) == 0 {
+		return nil
+	}
+	return &s.httpsServer.TLSConfig.Certificates[0]
+}
+
+// dynamicAuthMiddleware wraps next with the LIVE auth snapshot (#5866): it reads
+// s.auth atomically per request so a ReplaceAuth swap takes effect immediately.
+// A nil snapshot passes through (no auth) — the loopback clamp guarantees such a
+// listener is loopback-only. It enforces byte-for-byte the same checks as the
+// static authMiddleware via the shared authCheck.
+func (s *Server) dynamicAuthMiddleware(metricsRequireAuth bool, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a := s.auth.Load()
+		if a == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if authCheck(*a, metricsRequireAuth, r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		writeAuthChallenge(w)
+	})
+}
+
+// serveBound serves already-bound listeners until ctx is cancelled or a listener
+// terminates with an error, then shuts BOTH down under a bounded 5s drain and
+// joins both serve goroutines before returning (#5058 lifecycle, extracted for
+// the #5866 Start/Run split).
+func (s *Server) serveBound(ctx context.Context, httpLn, httpsLn net.Listener) error {
 	// Both listeners are bound. Serve each in its own goroutine; a fatal
 	// Serve error is reported once on the buffered channel.
 	errCh := make(chan error, 2)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -285,10 +285,23 @@ type Server struct {
 	// ReplaceAuth swaps it; a bind-address/port/TLS change instead goes through a
 	// make-before-break listener rebuild (managementReconciler).
 	auth atomic.Pointer[AuthConfig]
-	// serveDone is closed when the background serve goroutine started by Start
-	// exits (#5866); Wait blocks on it so a swapped-out or shutting-down server's
-	// listeners+goroutines are fully drained before the daemon joins.
-	serveDone chan struct{}
+	// #5866 per-listener lifecycle: the HTTP and HTTPS listeners are managed
+	// INDEPENDENTLY so a day-2 TLS enable/disable or HTTPS-bind change rebinds
+	// ONLY the HTTPS leg while the live HTTP listener keeps serving (and an HTTP
+	// bind change rebinds only the HTTP leg). Rebinding the whole server would
+	// re-bind a socket the retiring server still holds (EADDRINUSE), so a same-
+	// port change could never converge — the bug this replaces. sharedBase is the
+	// pre-auth mux+collector+CSRF handler both legs wrap (per-listener auth gate
+	// via listenerHandler), so the #4162 shared scrape limiter / session cache is
+	// preserved across a rebind. certGen mints a fresh self-signed cert on each
+	// HTTPS (re)bind.
+	sharedBase http.Handler
+	certGen    func() (tls.Certificate, error)
+	lifeMu     sync.Mutex      // guards httpLeg/httpsLeg/rootCtx across reconciles
+	rootCtx    context.Context // daemon lifetime; every leg drains on its cancel
+	wg         sync.WaitGroup  // joins EVERY serve goroutine (live + retiring legs)
+	httpLeg    *listenerLeg    // live HTTP listener leg (nil = not started / HTTP off)
+	httpsLeg   *listenerLeg    // live HTTPS listener leg (nil = HTTPS off)
 	// listen is the listener factory (#5866): Config.ListenFunc or net.Listen. A
 	// test injects a fake so the make-before-break reconcile is exercised without
 	// binding real ports.
@@ -549,13 +562,43 @@ func NewServer(cfg Config) *Server {
 	// without rebinding. metricsRequireAuth is fixed per listener (its bind
 	// address never changes for a given Server; a bind change goes through the
 	// make-before-break rebuild, not this swap).
-	listenerHandler := func(addr string) http.Handler {
-		return s.dynamicAuthMiddleware(!isLoopbackBindAddr(addr), sharedBase)
+	// #5866: retain the pre-auth base handler + the cert generator so a per-leg
+	// rebind (ReconcileHTTP/ReconcileHTTPS) can rebuild a single listener's
+	// http.Server for a new bind address without disturbing the sibling leg.
+	s.sharedBase = sharedBase
+	s.certGen = generateSelfSignedCert
+
+	if cfg.Addr != "" {
+		s.httpServer = s.buildHTTPServer(cfg.Addr)
 	}
 
-	s.httpServer = &http.Server{
-		Addr:              cfg.Addr,
-		Handler:           listenerHandler(cfg.Addr),
+	// Set up HTTPS server with auto-generated self-signed certificate
+	if cfg.TLS && cfg.HTTPSAddr != "" {
+		if hs, err := s.buildHTTPSServer(cfg.HTTPSAddr); err != nil {
+			slog.Warn("failed to generate self-signed certificate", "err", err)
+		} else {
+			s.httpsServer = hs
+		}
+	}
+
+	return s
+}
+
+// listenerHandler wraps the shared pre-auth base with the per-listener auth gate
+// for a bind address (#4162/#5866): only a literal loopback bind leaves /metrics
+// open when auth is configured. The dynamic middleware reads the live auth
+// snapshot per request, so ReplaceAuth needs no rebind.
+func (s *Server) listenerHandler(addr string) http.Handler {
+	return s.dynamicAuthMiddleware(!isLoopbackBindAddr(addr), s.sharedBase)
+}
+
+// buildHTTPServer constructs a fresh HTTP *http.Server bound-for addr with the
+// per-listener handler (#5866). Used at construction and by a per-leg HTTP
+// rebind.
+func (s *Server) buildHTTPServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           s.listenerHandler(addr),
 		ReadHeaderTimeout: apiReadHeaderTimeout,
 		ReadTimeout:       apiReadTimeout,
 		IdleTimeout:       apiIdleTimeout,
@@ -563,30 +606,29 @@ func NewServer(cfg Config) *Server {
 		// WriteTimeout intentionally unset — see the const block above (SSE
 		// streams + large scrapes must not be severed).
 	}
+}
 
-	// Set up HTTPS server with auto-generated self-signed certificate
-	if cfg.TLS && cfg.HTTPSAddr != "" {
-		tlsCert, err := generateSelfSignedCert()
-		if err != nil {
-			slog.Warn("failed to generate self-signed certificate", "err", err)
-		} else {
-			s.httpsServer = &http.Server{
-				Addr:              cfg.HTTPSAddr,
-				Handler:           listenerHandler(cfg.HTTPSAddr),
-				ReadHeaderTimeout: apiReadHeaderTimeout,
-				ReadTimeout:       apiReadTimeout,
-				IdleTimeout:       apiIdleTimeout,
-				MaxHeaderBytes:    apiMaxHeaderBytes,
-				// WriteTimeout intentionally unset — see the const block above.
-				TLSConfig: &tls.Config{
-					Certificates: []tls.Certificate{tlsCert},
-					MinVersion:   tls.VersionTLS12,
-				},
-			}
-		}
+// buildHTTPSServer constructs a fresh HTTPS *http.Server bound-for addr with a
+// newly generated self-signed certificate (#5866). A cert-generation failure is
+// returned so the caller retains the previous leg (fail-closed).
+func (s *Server) buildHTTPSServer(addr string) (*http.Server, error) {
+	tlsCert, err := s.certGen()
+	if err != nil {
+		return nil, err
 	}
-
-	return s
+	return &http.Server{
+		Addr:              addr,
+		Handler:           s.listenerHandler(addr),
+		ReadHeaderTimeout: apiReadHeaderTimeout,
+		ReadTimeout:       apiReadTimeout,
+		IdleTimeout:       apiIdleTimeout,
+		MaxHeaderBytes:    apiMaxHeaderBytes,
+		// WriteTimeout intentionally unset — see the const block above.
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{tlsCert},
+			MinVersion:   tls.VersionTLS12,
+		},
+	}, nil
 }
 
 // Run starts the HTTP (and optionally HTTPS) server and blocks until ctx is
@@ -634,36 +676,8 @@ func (s *Server) bindListeners() (httpLn, httpsLn net.Listener, err error) {
 	return httpLn, httpsLn, nil
 }
 
-// Start binds the listeners synchronously (returning a bind error with nothing
-// left serving) then serves them in the BACKGROUND until ctx is cancelled,
-// returning nil once BOTH listeners are bound (#5866). This is the
-// make-before-break entry point: the managementReconciler binds the new endpoint
-// with Start (knowing it is live) BEFORE cancelling the old server's context, so
-// the management plane is never unreachable. Wait blocks until the background
-// serve goroutine (and its bounded drain) exits.
-func (s *Server) Start(ctx context.Context) error {
-	httpLn, httpsLn, err := s.bindListeners()
-	if err != nil {
-		return err
-	}
-	s.serveDone = make(chan struct{})
-	go func() {
-		defer close(s.serveDone)
-		if err := s.serveBound(ctx, httpLn, httpsLn); err != nil {
-			slog.Error("API server exited with error", "err", err)
-		}
-	}()
-	return nil
-}
-
-// Wait blocks until the background serve goroutine started by Start has fully
-// exited (listeners closed, in-flight requests drained, sibling goroutines
-// joined). It is a no-op if Start was never called.
-func (s *Server) Wait() {
-	if s.serveDone != nil {
-		<-s.serveDone
-	}
-}
+// Start / Wait / ReconcileHTTP / ReconcileHTTPS (the per-listener make-before-
+// break lifecycle) live in listener.go (#5866).
 
 // ReplaceAuth atomically swaps the live authentication snapshot (#5866). A day-2
 // web-management commit that enables, tightens, or REVOKES credentials on an
@@ -685,10 +699,18 @@ func (s *Server) AuthSnapshotForTest() *AuthConfig { return s.auth.Load() }
 // server is HTTP-only (#5866). Test-only: lets a cross-package test assert that a
 // TLS-material reconcile rebuilds the listener with a FRESH certificate.
 func (s *Server) HTTPSCertForTest() *tls.Certificate {
-	if s.httpsServer == nil || s.httpsServer.TLSConfig == nil || len(s.httpsServer.TLSConfig.Certificates) == 0 {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	// Read the LIVE HTTPS leg (post-reconcile), not the construction template, so
+	// a TLS-material rebind's fresh cert is observed (#5866).
+	srv := s.httpsServer
+	if s.httpsLeg != nil {
+		srv = s.httpsLeg.srv
+	}
+	if srv == nil || srv.TLSConfig == nil || len(srv.TLSConfig.Certificates) == 0 {
 		return nil
 	}
-	return &s.httpsServer.TLSConfig.Certificates[0]
+	return &srv.TLSConfig.Certificates[0]
 }
 
 // dynamicAuthMiddleware wraps next with the LIVE auth snapshot (#5866): it reads

--- a/pkg/api/server_authswap_5866_test.go
+++ b/pkg/api/server_authswap_5866_test.go
@@ -1,0 +1,63 @@
+// #5866: the management server's authentication snapshot must be swappable on a
+// day-2 commit WITHOUT a listener bounce or daemon restart — a revoked or
+// tightened credential is rejected on the very NEXT request. The middleware
+// reads s.auth atomically per request; ReplaceAuth swaps it.
+//
+// FAIL-ON-REVERT: if the middleware captured the auth snapshot statically at
+// construction (the pre-#5866 closure over cfg.Auth) instead of reading s.auth
+// per request, ReplaceAuth would have no effect and the revoked credential would
+// still authenticate — this test goes RED.
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServerReplaceAuthLiveSwap_5866(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	s := &Server{}
+	s.auth.Store(&AuthConfig{Users: map[string]string{"admin": "secret"}})
+	// metricsRequireAuth=true models a non-loopback listener (the interesting,
+	// security-relevant case).
+	h := s.dynamicAuthMiddleware(true, ok)
+
+	req := func(user, pass string) int {
+		r := httptest.NewRequest("GET", "/api/v1/thing", nil)
+		r.SetBasicAuth(user, pass)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w.Code
+	}
+
+	// Baseline: the configured credential authenticates.
+	if code := req("admin", "secret"); code != http.StatusOK {
+		t.Fatalf("valid credential before swap = %d, want 200", code)
+	}
+
+	// Day-2 REVOKE: swap to a snapshot that no longer contains admin.
+	s.ReplaceAuth(&AuthConfig{Users: map[string]string{"newadmin": "newpass"}})
+
+	if code := req("admin", "secret"); code != http.StatusUnauthorized {
+		t.Fatalf("REVOKED credential after ReplaceAuth = %d, want 401 — the auth snapshot did not "+
+			"take effect without a restart (#5866)", code)
+	}
+	if code := req("newadmin", "newpass"); code != http.StatusOK {
+		t.Fatalf("newly-added credential after ReplaceAuth = %d, want 200", code)
+	}
+
+	// /health stays exempt across swaps.
+	rh := httptest.NewRequest("GET", "/health", nil)
+	wh := httptest.NewRecorder()
+	h.ServeHTTP(wh, rh)
+	if wh.Code != http.StatusOK {
+		t.Fatalf("/health must remain auth-exempt, got %d", wh.Code)
+	}
+
+	// Disable auth entirely (loopback-only path) -> requests pass through.
+	s.ReplaceAuth(nil)
+	if code := req("nobody", "nothing"); code != http.StatusOK {
+		t.Fatalf("auth disabled after ReplaceAuth(nil) = %d, want 200 (pass through)", code)
+	}
+}

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -180,18 +180,20 @@ credential revocation is enforced even on an apply that returns early
   next commit retries (retry debt), and log the error. This does not brick an
   otherwise-successful commit (same posture as `reconcileSNMP` bind-failure
   retry).
-- **Auth ordering — revocation honored regardless of rebind outcome**: a
-  credential TIGHTENING (a non-nil snapshot — the revoked credential removed from
-  the set) is published to the live server UP FRONT, before any leg is touched,
-  so a single commit that BOTH revokes a credential AND changes a bind that then
-  fails to bind still rejects the revoked credential on the next request (the
-  persistent listener already enforces it). A non-nil auth only ADDS a
-  requirement — it can never fail-open — so publishing it early is unconditionally
-  safe. Removing ALL api-auth (nil) is the one case deferred to convergence, so a
-  non-loopback listener retained by a failed rebind is never dropped to no-auth
-  (`next.Auth == nil` is only reachable when the desired bind is loopback per the
-  #4047/#5127 clamp). Pinned by
-  `TestMgmtReconcileRevokeHonoredDespiteHTTPSBindFailure_5866`. The reconcile is
+- **Auth ordering — revocation decoupled from the HTTPS leg**: auth publishes as
+  soon as the HTTP leg is at its desired bind (`httpOK`), INDEPENDENT of the
+  HTTPS-leg outcome — a committed credential revocation must not be blocked by an
+  HTTPS bind failure. When `httpOK` the live HTTP listener is at `next.Addr`,
+  whose #4047/#5127 loopback clamp justified `next.Auth`, so applying it there
+  cannot fail-open; it defers ONLY when the HTTP leg's OWN rebind failed (the
+  retained old bind may not match `next.Auth`'s clamp). A tightening (non-nil)
+  publishes whatever the HTTPS outcome (it only ADDS a requirement). Removing ALL
+  api-auth (nil) additionally requires the live HTTPS to be off/loopback, so a
+  non-loopback HTTPS retained by a failed rebind is never dropped to no-auth.
+  Pinned by `TestMgmtReconcileRevokeHonoredDespiteHTTPSBindFailure_5866`
+  (revocation honored across a failing HTTPS rebind) +
+  `TestMgmtReconcileRemoveAuthDeferredWhenHTTPRebindFails_5866` (nil auth NOT
+  applied to a retained non-loopback listener — no fail-open). The reconcile is
   serialized by its mutex and the apply semaphore, so a newer generation never
   completes behind an older one.
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -180,13 +180,20 @@ credential revocation is enforced even on an apply that returns early
   next commit retries (retry debt), and log the error. This does not brick an
   otherwise-successful commit (same posture as `reconcileSNMP` bind-failure
   retry).
-- **Auth ordering on a combined change**: the auth snapshot is published only
-  once every leg is at its desired bind, so the live auth policy always matches
-  the live binds. An auth-only change publishes immediately; a combined change
-  whose bind failed defers the auth swap to the retry (applying a possibly-nil-
-  on-loopback auth to a retained non-loopback listener would fail OPEN). The
-  reconcile is serialized by its mutex and the apply semaphore, so a newer
-  generation never completes behind an older one.
+- **Auth ordering — revocation honored regardless of rebind outcome**: a
+  credential TIGHTENING (a non-nil snapshot — the revoked credential removed from
+  the set) is published to the live server UP FRONT, before any leg is touched,
+  so a single commit that BOTH revokes a credential AND changes a bind that then
+  fails to bind still rejects the revoked credential on the next request (the
+  persistent listener already enforces it). A non-nil auth only ADDS a
+  requirement — it can never fail-open — so publishing it early is unconditionally
+  safe. Removing ALL api-auth (nil) is the one case deferred to convergence, so a
+  non-loopback listener retained by a failed rebind is never dropped to no-auth
+  (`next.Auth == nil` is only reachable when the desired bind is loopback per the
+  #4047/#5127 clamp). Pinned by
+  `TestMgmtReconcileRevokeHonoredDespiteHTTPSBindFailure_5866`. The reconcile is
+  serialized by its mutex and the apply semaphore, so a newer generation never
+  completes behind an older one.
 
 ## Cluster mode
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -166,15 +166,27 @@ credential revocation is enforced even on an apply that returns early
 
 - **Auth change on an unchanged endpoint** → live `api.Server.ReplaceAuth`
   (atomic snapshot swap, effective next request, no rebind, no window).
-- **Endpoint change** (bind / port / TLS) → **make-before-break**: bind the new
-  listener via `api.Server.Start` (synchronous bind) FIRST, and only once it is
-  serving cancel the old server's context (bounded 5s graceful drain).
-- **Failed new bind** → **fail-safe**: retain the OLD listener (the previous
-  working state, fail-closed — not mgmt-down), leave the endpoint fingerprint
-  unrecorded so the next commit retries (retry debt), and log the error. This
-  does not brick an otherwise-successful commit (same posture as `reconcileSNMP`
-  bind-failure retry). The reconcile is serialized by its mutex and the apply
-  semaphore, so a newer generation never completes behind an older one.
+- **Endpoint change** → reconcile ONLY the listener leg that changed, PER LEG:
+  an HTTP-bind change make-before-break rebinds only the HTTP leg
+  (`api.Server.ReconcileHTTP`); a TLS enable/disable or HTTPS-bind change rebinds
+  only the HTTPS leg (`api.Server.ReconcileHTTPS`) and never touches the live
+  HTTP listener. The whole-server rebuild it replaces re-bound the retained HTTP
+  socket on a TLS enable (`EADDRINUSE`, since `SO_REUSEADDR` ≠ `SO_REUSEPORT`),
+  so a TLS change could never converge without a restart. Each leg is
+  make-before-break inside `api.Server` (new socket serving before the old
+  retires — no unreachable window, no double-bind of an unchanged socket).
+- **Failed leg (re)bind** → **fail-safe**: retain THAT leg's previous listener
+  (fail-closed — not mgmt-down), leave its fingerprint field unrecorded so the
+  next commit retries (retry debt), and log the error. This does not brick an
+  otherwise-successful commit (same posture as `reconcileSNMP` bind-failure
+  retry).
+- **Auth ordering on a combined change**: the auth snapshot is published only
+  once every leg is at its desired bind, so the live auth policy always matches
+  the live binds. An auth-only change publishes immediately; a combined change
+  whose bind failed defers the auth swap to the retry (applying a possibly-nil-
+  on-loopback auth to a retained non-loopback listener would fail OPEN). The
+  reconcile is serialized by its mutex and the apply semaphore, so a newer
+  generation never completes behind an older one.
 
 ## Cluster mode
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -153,6 +153,29 @@ cluster (deferred to `/triple-review` per #4407, because regrouping it
 touches apply-ordering rather than being inert field motion). These are the
 natural stopping point for the mechanical decomposition.
 
+### Management-listener lifecycle (`managementReconciler`, #5866)
+
+`d.mgmt` (`management.go`) owns the HTTP/HTTPS management-listener lifecycle so a
+day-2 web-management commit actually replaces the live listener and the
+authentication snapshot instead of leaving the boot-time server enforcing the
+old bind/port/TLS/auth until a restart (a revoked credential stayed usable). It
+mirrors `reconcileSNMP`: `reconcileWebManagement` runs EARLY in
+`applyConfigLocked` — before the dataplane apply that can abort — so a committed
+credential revocation is enforced even on an apply that returns early
+(`store.Commit` has already promoted the config). Reconcile discipline:
+
+- **Auth change on an unchanged endpoint** → live `api.Server.ReplaceAuth`
+  (atomic snapshot swap, effective next request, no rebind, no window).
+- **Endpoint change** (bind / port / TLS) → **make-before-break**: bind the new
+  listener via `api.Server.Start` (synchronous bind) FIRST, and only once it is
+  serving cancel the old server's context (bounded 5s graceful drain).
+- **Failed new bind** → **fail-safe**: retain the OLD listener (the previous
+  working state, fail-closed — not mgmt-down), leave the endpoint fingerprint
+  unrecorded so the next commit retries (retry debt), and log the error. This
+  does not brick an otherwise-successful commit (same posture as `reconcileSNMP`
+  bind-failure retry). The reconcile is serialized by its mutex and the apply
+  semaphore, so a newer generation never completes behind an older one.
+
 ## Cluster mode
 
 Detected by the presence of `/etc/xpf/node-id` (contents `0` or `1`).

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -267,7 +267,13 @@ type Daemon struct {
 	ipfixReconMu        sync.Mutex
 	ipfixExportErr      error
 	dhcpRelay           *dhcprelay.Manager
-	snmpAgent           *snmp.Agent
+	// mgmt owns the HTTP/HTTPS management-listener lifecycle (#5866): it starts
+	// the listener at boot and, on every day-2 commit, reconciles the live
+	// listener + authentication snapshot against the committed web-management
+	// config (make-before-break rebind on an endpoint change; live auth swap on
+	// an unchanged bind). nil when the API is not enabled (--api-addr empty).
+	mgmt      *managementReconciler
+	snmpAgent *snmp.Agent
 
 	// --- SNMP subsystem reconcile-on-commit state (#3967) ---
 	// The SNMP agent is a start-once-at-boot subsystem: the boot block in

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -716,6 +716,21 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// owns the first start, which honors config-only / bootstrap suppression.
 	d.reconcileSNMP(cfg)
 
+	// #5866: reconcile the live management HTTP/HTTPS listener + authentication
+	// snapshot against the committed web-management config, for the SAME reason
+	// and with the SAME early placement as reconcileSNMP above. The management
+	// server was constructed once at boot and never reconciled, so a committed
+	// bind/port/TLS/api-auth change (e.g. a REVOKED credential) sat inert until a
+	// daemon restart. Placed before the dataplane apply so a committed
+	// credential revocation is enforced even on an apply that aborts early. A
+	// bind-replacement failure is fail-safe (the old listener is retained) and
+	// only logged as retry debt — like reconcileSNMP it does not brick an
+	// otherwise-successful commit.
+	if err := d.reconcileWebManagement(cfg); err != nil {
+		slog.Warn("web-management listener reconcile did not converge; retrying on next commit",
+			"err", err)
+	}
+
 	// #1922 Item 2 bootstrap exit: the FIRST apply of a non-empty config
 	// (an interface-claiming confirmed commit, or a cluster SyncApply from
 	// the primary) leaves bootstrap mode and runs the one-time startup

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1483,16 +1483,30 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 			return d.grpcSrv
 		},
 	}
-	// Resolve interface bindings + api-auth from web-management config, then
-	// apply the #4047/#5127 loopback fail-safe on EVERY path (resolveAPIBinds).
-	d.resolveAPIBinds(&apiCfg, d.store.ActiveConfig())
-	srv := api.NewServer(apiCfg)
+	// #5866: the management HTTP/HTTPS listener is owned by
+	// managementReconciler. apiCfg here carries only the runtime deps; the
+	// reconciler re-derives the bind/port/TLS/auth from each ACTIVE config
+	// (resolveAPIBinds) so it can start the listener now AND, on every day-2
+	// commit, reconcile the live listener + authentication snapshot without a
+	// restart — make-before-break rebind on a bind/port/TLS change, live auth
+	// swap on an unchanged bind. Before #5866 the server was constructed once
+	// here and never reconciled, so a committed bind/TLS/port/auth change (e.g.
+	// a revoked credential) sat inert until a daemon restart.
+	d.mgmt = newManagementReconciler(d, apiCfg)
+	if err := d.mgmt.start(ctx); err != nil {
+		// A boot bind failure is non-fatal (matches the pre-#5866 async
+		// srv.Run error log): the daemon keeps running and the next commit's
+		// reconcileWebManagement retries the bind.
+		slog.Error("HTTP API server initial start failed", "err", err)
+	}
+	// Drain the management serve goroutines on daemon shutdown: ctx cancel
+	// triggers the api.Server bounded 5s graceful drain, and wait() joins every
+	// live + retiring listener goroutine so none leak past Run.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := srv.Run(ctx); err != nil {
-			slog.Error("API server error", "err", err)
-		}
+		<-ctx.Done()
+		d.mgmt.wait()
 	}()
 	slog.Info("HTTP API server started", "addr", d.opts.APIAddr)
 }

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"sync"
 
 	"github.com/psaab/xpf/pkg/api"
@@ -38,19 +39,17 @@ import (
 //     RETAINED (fail-closed, not mgmt-down), its fingerprint field is left
 //     unrecorded so the next commit RETRIES the bind (retry debt), and the error
 //     is surfaced.
-//   - AUTH ORDERING (revocation honored regardless of any rebind outcome): a
-//     credential TIGHTENING (a non-nil auth snapshot — the revoked credential
-//     removed from the set) is published to the live server UP FRONT, before any
-//     leg is touched, so a single commit that BOTH revokes a credential AND
-//     changes a bind that then fails to bind still rejects the revoked credential
-//     on the next request (the persistent listener already enforces it). A
-//     non-nil auth only ADDS a requirement, so it can never fail-open — publishing
-//     it early is unconditionally safe. Removing ALL api-auth (nil) is the one
-//     case deferred to convergence: it is published only once every leg is at its
-//     desired bind, so a non-loopback listener RETAINED by a failed rebind is
-//     never dropped to no-auth (next.Auth == nil is only reachable when the
-//     desired bind is loopback per the #4047/#5127 clamp, so on convergence the
-//     live state is loopback).
+//   - AUTH ORDERING (revocation decoupled from the HTTPS leg): auth publishes as
+//     soon as the HTTP leg is at its desired bind (httpOK), INDEPENDENT of the
+//     HTTPS-leg outcome — a committed credential revocation must not be blocked
+//     by an HTTPS bind failure. When httpOK the live HTTP listener is at
+//     next.Addr, whose #4047/#5127 loopback clamp justified next.Auth, so
+//     applying it there cannot fail-open; it defers ONLY when the HTTP leg's OWN
+//     rebind failed (the retained old bind may not match next.Auth's clamp). A
+//     TIGHTENING (non-nil) is published whatever the HTTPS outcome (it only ADDS
+//     a requirement). Removing ALL api-auth (nil) additionally requires the LIVE
+//     HTTPS to be off/loopback, so a non-loopback HTTPS retained by a failed
+//     rebind is never dropped to no-auth.
 //
 // The reconcile is serialized by mu; the apply path (applyConfigLocked under the
 // apply semaphore) already runs commits one at a time, so a newer generation can
@@ -152,28 +151,16 @@ func (m *managementReconciler) reconcileTo(next api.Config) error {
 		return nil
 	}
 
-	// #5866 revocation-honoring: publish a credential TIGHTENING (a non-nil auth
-	// snapshot — e.g. a revoked credential removed from the set) to the live
-	// server UP FRONT, before any listener leg is touched, so the revocation
-	// takes effect on the persistent listener(s) on the NEXT request REGARDLESS
-	// of any HTTP/HTTPS rebind outcome. A single commit that BOTH revokes a
-	// credential AND changes a bind that then fails to bind must NOT keep the
-	// revoked credential usable on the retained listener. A non-nil auth only
-	// ADDS a requirement — it can never fail-open — so publishing it early is
-	// unconditionally safe. Removing ALL api-auth (nil) is instead deferred to
-	// after the legs converge (below), so a non-loopback listener retained by a
-	// failed rebind is never dropped to no-auth (fail-open).
-	if next.Auth != nil {
-		m.srv.ReplaceAuth(next.Auth)
-	}
-
 	var errs []error
 
 	// HTTP leg: make-before-break rebind ONLY if the HTTP bind changed. Advance
-	// the converged fingerprint only on success (retry debt on failure).
+	// the converged fingerprint only on success (retry debt on failure); httpOK
+	// records whether the live HTTP listener is now at next.Addr.
+	httpOK := true
 	if next.Addr != m.cur.addr {
 		if err := m.srv.ReconcileHTTP(next.Addr); err != nil {
 			errs = append(errs, err)
+			httpOK = false
 		} else {
 			m.cur.addr = next.Addr
 		}
@@ -190,15 +177,26 @@ func (m *managementReconciler) reconcileTo(next api.Config) error {
 		}
 	}
 
-	if len(errs) == 0 {
-		// Every changed leg converged to its desired bind. If the commit removes
-		// ALL api-auth (nil), publish it now — safe because next.Auth == nil is
-		// only reachable when the desired bind is loopback (#4047/#5127 clamp), so
-		// the live state is loopback. (A non-nil tightening was already published
-		// above.)
-		if next.Auth == nil {
+	// Auth is published once the HTTP leg is at its desired bind, DECOUPLED from
+	// the HTTPS leg (#5866 Finding A): a committed credential revocation must not
+	// be blocked by an HTTPS bind failure. httpOK means the live HTTP listener is
+	// at next.Addr, whose #4047/#5127 loopback clamp JUSTIFIED next.Auth (incl. a
+	// legitimate nil-on-loopback), so applying next.Auth there cannot fail-open;
+	// it defers ONLY when the HTTP leg's OWN rebind failed (the retained old bind
+	// may not match next.Auth's clamp). A credential TIGHTENING (non-nil) only
+	// ADDS a requirement, so it is published as soon as the HTTP leg is good,
+	// regardless of the HTTPS outcome. Removing ALL api-auth (nil) additionally
+	// requires the LIVE HTTPS to be off or loopback, so a non-loopback HTTPS
+	// retained by a failed HTTPS rebind is never dropped to no-auth (fail-open).
+	if httpOK {
+		if next.Auth != nil {
+			m.srv.ReplaceAuth(next.Auth)
+		} else if !m.cur.tls || mgmtAddrIsLoopback(m.cur.httpsAddr) {
 			m.srv.ReplaceAuth(nil)
 		}
+	}
+
+	if len(errs) == 0 {
 		return nil
 	}
 	joined := errors.Join(errs...)
@@ -206,6 +204,21 @@ func (m *managementReconciler) reconcileTo(next api.Config) error {
 		"desired", endpointOf(next).summary(), "err", joined)
 	return fmt.Errorf("web-management reconcile to %s incomplete; retaining previous listener(s): %w",
 		endpointOf(next).summary(), joined)
+}
+
+// mgmtAddrIsLoopback reports whether a "host:port" bind is loopback, treating an
+// empty addr (no listener on that leg) as loopback and an unparseable host as
+// NON-loopback (fail-closed). Used to gate a nil-auth (remove-all-api-auth)
+// publish so a non-loopback listener is never dropped to no-auth (#5866).
+func mgmtAddrIsLoopback(addr string) bool {
+	if addr == "" {
+		return true
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	return hostIsLoopback(host)
 }
 
 // wait blocks until every serve goroutine (live + retiring legs) has drained.

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -1,0 +1,215 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// managementReconciler owns the HTTP/HTTPS management-listener lifecycle so a
+// day-2 web-management commit actually replaces the live listener and the
+// authentication snapshot instead of sitting inert until a daemon restart
+// (#5866). Before this owner the api.Server was constructed ONCE at startup: a
+// committed bind-address, port, TLS, or api-auth change reported success while
+// the process kept enforcing the old policy — revoked/tightened credentials
+// stayed usable, an interface/bind removal left the API on the old address.
+//
+// Reconcile discipline:
+//   - AUTH change on an UNCHANGED endpoint: swap the live auth snapshot in place
+//     (api.Server.ReplaceAuth) — the middleware reads it per request, so a
+//     revoked credential is rejected on the NEXT request, no listener bounce, no
+//     restart, no unreachable window.
+//   - ENDPOINT change (bind address / port / TLS on/off / HTTPS bind):
+//     MAKE-BEFORE-BREAK — build+bind the NEW listener FIRST, and only once it is
+//     confirmed serving cancel the OLD server's context (bounded graceful
+//     drain). There is never a window where management is unreachable, and never
+//     a double-bind.
+//   - FAIL-SAFE: if the new listener fails to bind, the OLD listener is RETAINED
+//     (the previous working state — fail-closed, not mgmt-down), the endpoint
+//     fingerprint is left unrecorded so the next commit RETRIES the bind (retry
+//     debt), and the error is surfaced. The auth snapshot swap is applied to the
+//     live listener regardless of any endpoint-rebind outcome, so a credential
+//     revocation is never blocked by an unrelated bind failure.
+//
+// The reconcile is serialized by mu; the apply path (applyConfigLocked under the
+// apply semaphore) already runs commits one at a time, so a newer generation can
+// never race or complete out of order behind an older one.
+type managementReconciler struct {
+	d *Daemon
+	// baseCfg carries only the runtime dependencies (store, dataplane probe,
+	// managers, callbacks); the bind/port/TLS/auth fields are re-derived from the
+	// active config on every reconcile via desiredLocked, so a removed
+	// web-management stanza correctly reverts to the flag defaults.
+	baseCfg api.Config
+	rootCtx context.Context // daemon lifetime; parent of every generation's ctx
+
+	mu     sync.Mutex
+	wg     sync.WaitGroup     // joins every serve goroutine (live + retiring)
+	srv    *api.Server        // current live server (nil until started)
+	cancel context.CancelFunc // cancels the current server's ctx (retires it)
+	cur    mgmtEndpoint       // current endpoint fingerprint
+	curSet bool
+}
+
+// mgmtEndpoint fingerprints the listener-defining fields. An auth change does
+// NOT change the endpoint (auth is swapped live); only these fields force a
+// make-before-break rebind.
+type mgmtEndpoint struct {
+	addr      string
+	httpsAddr string
+	tls       bool
+}
+
+func (e mgmtEndpoint) summary() string {
+	if e.tls {
+		return fmt.Sprintf("http=%s https=%s", e.addr, e.httpsAddr)
+	}
+	return fmt.Sprintf("http=%s (no TLS)", e.addr)
+}
+
+func endpointOf(cfg api.Config) mgmtEndpoint {
+	return mgmtEndpoint{addr: cfg.Addr, httpsAddr: cfg.HTTPSAddr, tls: cfg.TLS}
+}
+
+// newManagementReconciler builds the owner around the runtime-dependency base
+// apiCfg. It does not start anything; call start.
+func newManagementReconciler(d *Daemon, baseCfg api.Config) *managementReconciler {
+	return &managementReconciler{d: d, baseCfg: baseCfg}
+}
+
+// desired re-derives the desired api.Config for cfg: it resets the endpoint/auth
+// fields to the flag defaults (so a removed web-management or api-auth stanza
+// reverts cleanly) and then applies resolveAPIBinds (interface bind, TLS,
+// api-auth, and the #4047/#5127 loopback clamp). It reads only set-once state
+// (baseCfg, d.opts), so it needs no lock.
+func (m *managementReconciler) desired(cfg *config.Config) api.Config {
+	next := m.baseCfg
+	next.Addr = m.d.opts.APIAddr
+	next.HTTPSAddr = ""
+	next.TLS = false
+	next.Auth = nil
+	m.d.resolveAPIBinds(&next, cfg)
+	return next
+}
+
+// start builds and starts the initial listener from the active config. A bind
+// failure is returned (the caller logs it non-fatally); the next commit retries.
+func (m *managementReconciler) start(ctx context.Context) error {
+	return m.startTo(ctx, m.desired(m.d.store.ActiveConfig()))
+}
+
+// startTo starts the initial listener for an explicit desired config. Split from
+// start so a test can seed the live server without a configstore (#5866).
+func (m *managementReconciler) startTo(ctx context.Context, next api.Config) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rootCtx = ctx
+
+	srv := api.NewServer(next)
+	cctx, cancel := context.WithCancel(ctx)
+	if err := srv.Start(cctx); err != nil {
+		cancel()
+		return err
+	}
+	m.launchLocked(srv)
+	m.srv, m.cancel, m.cur, m.curSet = srv, cancel, endpointOf(next), true
+	return nil
+}
+
+// reconcile matches the live listener + auth snapshot to cfg. It returns a
+// non-nil error ONLY when an endpoint replacement could not bind — in that case
+// the OLD listener is retained (fail-safe) and the next commit retries. An
+// auth-only change (or an unchanged config) always returns nil.
+func (m *managementReconciler) reconcile(cfg *config.Config) error {
+	return m.reconcileTo(m.desired(cfg))
+}
+
+// reconcileTo drives the reconcile against an explicit desired config. Split
+// from reconcile so a test exercises the make-before-break / live-auth-swap /
+// fail-safe logic with hand-built endpoints, without a configstore or
+// resolveAPIBinds (#5866).
+func (m *managementReconciler) reconcileTo(next api.Config) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.srv == nil {
+		// API disabled (--api-addr empty) or a boot bind never succeeded: nothing
+		// live to reconcile.
+		return nil
+	}
+
+	ep := endpointOf(next)
+
+	// Same endpoint -> swap the live auth snapshot in place. A credential
+	// revocation takes effect on the next request with NO listener bounce and NO
+	// unreachable window. Safe on the current endpoint: the per-listener /metrics
+	// gate is derived from the (unchanged) bind address, and dropping auth to nil
+	// is only reachable on a loopback bind (the clamp forces a non-loopback
+	// no-auth bind to change its address, which takes the rebind path instead).
+	if m.curSet && ep == m.cur {
+		m.srv.ReplaceAuth(next.Auth)
+		return nil
+	}
+
+	// Endpoint changed -> make-before-break: bind the NEW listener before
+	// retiring the old.
+	newSrv := api.NewServer(next)
+	cctx, cancel := context.WithCancel(m.rootCtx)
+	if err := newSrv.Start(cctx); err != nil {
+		cancel()
+		// Fail-safe: the new endpoint did not bind. Keep the OLD listener serving
+		// the previous working state (fail-closed, NOT mgmt-down). Leave m.srv /
+		// m.cur unchanged so the NEXT commit retries the bind (retry debt).
+		slog.Warn("web-management listener replacement failed; retaining previous listener",
+			"desired", ep.summary(), "retained", m.cur.summary(), "err", err)
+		return fmt.Errorf("web-management listener replacement to %s failed; retaining %s: %w",
+			ep.summary(), m.cur.summary(), err)
+	}
+
+	// The new listener is bound and serving. ONLY NOW retire the old one (its
+	// context cancel triggers the api.Server bounded graceful drain) and swap.
+	m.launchLocked(newSrv)
+	oldCancel, oldEP := m.cancel, m.cur
+	m.srv, m.cancel, m.cur = newSrv, cancel, ep
+	oldCancel()
+	slog.Info("web-management listener replaced (make-before-break)",
+		"from", oldEP.summary(), "to", ep.summary())
+	return nil
+}
+
+// launchLocked registers srv's background serve goroutine on the reconciler's
+// wait group so daemon shutdown joins every live and retiring listener.
+func (m *managementReconciler) launchLocked(srv *api.Server) {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		srv.Wait()
+	}()
+}
+
+// wait blocks until every serve goroutine (live + retiring) has drained. Called
+// on daemon shutdown after the root ctx is cancelled.
+func (m *managementReconciler) wait() {
+	m.wg.Wait()
+}
+
+// reconcileWebManagement is the applyConfigLocked entry point (#5866). It
+// mirrors reconcileSNMP: it runs EARLY in the apply — before the dataplane apply
+// that can abort on a protocol-gate error — so a committed authentication
+// tightening/revocation or bind change is live even on an apply that returns
+// early. store.Commit has already promoted+persisted this config, so the
+// committed policy is authoritative regardless of the later dataplane outcome.
+//
+// A nil reconciler (API disabled) is a no-op. A non-nil error means an endpoint
+// replacement could not bind; the OLD listener is retained and the failure is
+// logged (retry debt), mirroring reconcileSNMP's warn-and-retry posture rather
+// than bricking an otherwise-successful commit.
+func (d *Daemon) reconcileWebManagement(cfg *config.Config) error {
+	if d.mgmt == nil {
+		return nil
+	}
+	return d.mgmt.reconcile(cfg)
+}

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -18,22 +19,32 @@ import (
 // the process kept enforcing the old policy — revoked/tightened credentials
 // stayed usable, an interface/bind removal left the API on the old address.
 //
-// Reconcile discipline:
+// Reconcile discipline (the listener lifecycle lives in api.Server; #5866):
 //   - AUTH change on an UNCHANGED endpoint: swap the live auth snapshot in place
 //     (api.Server.ReplaceAuth) — the middleware reads it per request, so a
 //     revoked credential is rejected on the NEXT request, no listener bounce, no
 //     restart, no unreachable window.
-//   - ENDPOINT change (bind address / port / TLS on/off / HTTPS bind):
-//     MAKE-BEFORE-BREAK — build+bind the NEW listener FIRST, and only once it is
-//     confirmed serving cancel the OLD server's context (bounded graceful
-//     drain). There is never a window where management is unreachable, and never
-//     a double-bind.
-//   - FAIL-SAFE: if the new listener fails to bind, the OLD listener is RETAINED
-//     (the previous working state — fail-closed, not mgmt-down), the endpoint
-//     fingerprint is left unrecorded so the next commit RETRIES the bind (retry
-//     debt), and the error is surfaced. The auth snapshot swap is applied to the
-//     live listener regardless of any endpoint-rebind outcome, so a credential
-//     revocation is never blocked by an unrelated bind failure.
+//   - ENDPOINT change: reconcile ONLY the listener leg that changed, PER LEG.
+//     An HTTP-bind change make-before-break rebinds only the HTTP leg
+//     (ReconcileHTTP); a TLS enable/disable or HTTPS-bind change rebinds only the
+//     HTTPS leg (ReconcileHTTPS) and NEVER touches the live HTTP listener. This
+//     is the fix for the old whole-server rebuild: enabling TLS keeps the HTTP
+//     bind, so re-binding the whole server re-bound the still-held HTTP socket
+//     (EADDRINUSE) and the change could never converge without a restart. Each
+//     leg is make-before-break within api.Server: the new socket is bound and
+//     serving before the old is retired — no unreachable window, no double-bind
+//     of an unchanged socket.
+//   - FAIL-SAFE: if a leg fails to (re)bind, that leg's PREVIOUS listener is
+//     RETAINED (fail-closed, not mgmt-down), its fingerprint field is left
+//     unrecorded so the next commit RETRIES the bind (retry debt), and the error
+//     is surfaced.
+//   - AUTH ORDERING on a combined change: the auth snapshot is published only
+//     once every leg is at its desired bind, so the live auth policy always
+//     matches the live binds. An auth-only change publishes immediately. A
+//     combined endpoint+auth change whose bind FAILED defers the auth swap to
+//     the retry — applying next.Auth (which the #4047/#5127 clamp may leave nil
+//     because the DESIRED bind is loopback) to a RETAINED non-loopback listener
+//     would fail OPEN.
 //
 // The reconcile is serialized by mu; the apply path (applyConfigLocked under the
 // apply semaphore) already runs commits one at a time, so a newer generation can
@@ -42,16 +53,13 @@ type managementReconciler struct {
 	d *Daemon
 	// baseCfg carries only the runtime dependencies (store, dataplane probe,
 	// managers, callbacks); the bind/port/TLS/auth fields are re-derived from the
-	// active config on every reconcile via desiredLocked, so a removed
-	// web-management stanza correctly reverts to the flag defaults.
+	// active config on every reconcile via desired, so a removed web-management
+	// stanza correctly reverts to the flag defaults.
 	baseCfg api.Config
-	rootCtx context.Context // daemon lifetime; parent of every generation's ctx
 
 	mu     sync.Mutex
-	wg     sync.WaitGroup     // joins every serve goroutine (live + retiring)
-	srv    *api.Server        // current live server (nil until started)
-	cancel context.CancelFunc // cancels the current server's ctx (retires it)
-	cur    mgmtEndpoint       // current endpoint fingerprint
+	srv    *api.Server  // single long-lived server; its HTTP/HTTPS legs reconcile in place (nil until started)
+	cur    mgmtEndpoint // last-CONVERGED per-leg fingerprint (a leg field advances only on that leg's successful reconcile)
 	curSet bool
 }
 
@@ -103,20 +111,17 @@ func (m *managementReconciler) start(ctx context.Context) error {
 }
 
 // startTo starts the initial listener for an explicit desired config. Split from
-// start so a test can seed the live server without a configstore (#5866).
+// start so a test can seed the live server without a configstore (#5866). The
+// server owns its HTTP/HTTPS leg lifecycles keyed to ctx; day-2 changes go
+// through reconcileTo's per-leg calls, not a new server.
 func (m *managementReconciler) startTo(ctx context.Context, next api.Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.rootCtx = ctx
-
 	srv := api.NewServer(next)
-	cctx, cancel := context.WithCancel(ctx)
-	if err := srv.Start(cctx); err != nil {
-		cancel()
+	if err := srv.Start(ctx); err != nil {
 		return err
 	}
-	m.launchLocked(srv)
-	m.srv, m.cancel, m.cur, m.curSet = srv, cancel, endpointOf(next), true
+	m.srv, m.cur, m.curSet = srv, endpointOf(next), true
 	return nil
 }
 
@@ -141,59 +146,53 @@ func (m *managementReconciler) reconcileTo(next api.Config) error {
 		return nil
 	}
 
-	ep := endpointOf(next)
+	var errs []error
 
-	// Same endpoint -> swap the live auth snapshot in place. A credential
-	// revocation takes effect on the next request with NO listener bounce and NO
-	// unreachable window. Safe on the current endpoint: the per-listener /metrics
-	// gate is derived from the (unchanged) bind address, and dropping auth to nil
-	// is only reachable on a loopback bind (the clamp forces a non-loopback
-	// no-auth bind to change its address, which takes the rebind path instead).
-	if m.curSet && ep == m.cur {
+	// HTTP leg: make-before-break rebind ONLY if the HTTP bind changed. Advance
+	// the converged fingerprint only on success (retry debt on failure).
+	if next.Addr != m.cur.addr {
+		if err := m.srv.ReconcileHTTP(next.Addr); err != nil {
+			errs = append(errs, err)
+		} else {
+			m.cur.addr = next.Addr
+		}
+	}
+
+	// HTTPS leg: enable / disable / rebind ONLY if the HTTPS bind or TLS flag
+	// changed. api.Server.ReconcileHTTPS never touches the live HTTP listener, so
+	// a TLS enable can no longer collide with the retained HTTP socket.
+	if next.TLS != m.cur.tls || next.HTTPSAddr != m.cur.httpsAddr {
+		if err := m.srv.ReconcileHTTPS(next.TLS, next.HTTPSAddr); err != nil {
+			errs = append(errs, err)
+		} else {
+			m.cur.tls, m.cur.httpsAddr = next.TLS, next.HTTPSAddr
+		}
+	}
+
+	// Auth: publish only once every leg is at its desired bind (see the type
+	// doc). An auth-only change (no leg change) publishes immediately with no
+	// rebind; a combined change whose bind failed defers the swap to retry.
+	if len(errs) == 0 {
 		m.srv.ReplaceAuth(next.Auth)
 		return nil
 	}
-
-	// Endpoint changed -> make-before-break: bind the NEW listener before
-	// retiring the old.
-	newSrv := api.NewServer(next)
-	cctx, cancel := context.WithCancel(m.rootCtx)
-	if err := newSrv.Start(cctx); err != nil {
-		cancel()
-		// Fail-safe: the new endpoint did not bind. Keep the OLD listener serving
-		// the previous working state (fail-closed, NOT mgmt-down). Leave m.srv /
-		// m.cur unchanged so the NEXT commit retries the bind (retry debt).
-		slog.Warn("web-management listener replacement failed; retaining previous listener",
-			"desired", ep.summary(), "retained", m.cur.summary(), "err", err)
-		return fmt.Errorf("web-management listener replacement to %s failed; retaining %s: %w",
-			ep.summary(), m.cur.summary(), err)
-	}
-
-	// The new listener is bound and serving. ONLY NOW retire the old one (its
-	// context cancel triggers the api.Server bounded graceful drain) and swap.
-	m.launchLocked(newSrv)
-	oldCancel, oldEP := m.cancel, m.cur
-	m.srv, m.cancel, m.cur = newSrv, cancel, ep
-	oldCancel()
-	slog.Info("web-management listener replaced (make-before-break)",
-		"from", oldEP.summary(), "to", ep.summary())
-	return nil
+	joined := errors.Join(errs...)
+	slog.Warn("web-management listener reconcile incomplete; retaining previous listener(s), deferring auth swap",
+		"desired", endpointOf(next).summary(), "err", joined)
+	return fmt.Errorf("web-management reconcile to %s incomplete; retaining previous listener(s): %w",
+		endpointOf(next).summary(), joined)
 }
 
-// launchLocked registers srv's background serve goroutine on the reconciler's
-// wait group so daemon shutdown joins every live and retiring listener.
-func (m *managementReconciler) launchLocked(srv *api.Server) {
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
-		srv.Wait()
-	}()
-}
-
-// wait blocks until every serve goroutine (live + retiring) has drained. Called
-// on daemon shutdown after the root ctx is cancelled.
+// wait blocks until every serve goroutine (live + retiring legs) has drained.
+// Called on daemon shutdown after the root ctx is cancelled (which triggers each
+// leg's bounded graceful drain inside api.Server).
 func (m *managementReconciler) wait() {
-	m.wg.Wait()
+	m.mu.Lock()
+	srv := m.srv
+	m.mu.Unlock()
+	if srv != nil {
+		srv.Wait()
+	}
 }
 
 // reconcileWebManagement is the applyConfigLocked entry point (#5866). It

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -38,13 +38,19 @@ import (
 //     RETAINED (fail-closed, not mgmt-down), its fingerprint field is left
 //     unrecorded so the next commit RETRIES the bind (retry debt), and the error
 //     is surfaced.
-//   - AUTH ORDERING on a combined change: the auth snapshot is published only
-//     once every leg is at its desired bind, so the live auth policy always
-//     matches the live binds. An auth-only change publishes immediately. A
-//     combined endpoint+auth change whose bind FAILED defers the auth swap to
-//     the retry — applying next.Auth (which the #4047/#5127 clamp may leave nil
-//     because the DESIRED bind is loopback) to a RETAINED non-loopback listener
-//     would fail OPEN.
+//   - AUTH ORDERING (revocation honored regardless of any rebind outcome): a
+//     credential TIGHTENING (a non-nil auth snapshot — the revoked credential
+//     removed from the set) is published to the live server UP FRONT, before any
+//     leg is touched, so a single commit that BOTH revokes a credential AND
+//     changes a bind that then fails to bind still rejects the revoked credential
+//     on the next request (the persistent listener already enforces it). A
+//     non-nil auth only ADDS a requirement, so it can never fail-open — publishing
+//     it early is unconditionally safe. Removing ALL api-auth (nil) is the one
+//     case deferred to convergence: it is published only once every leg is at its
+//     desired bind, so a non-loopback listener RETAINED by a failed rebind is
+//     never dropped to no-auth (next.Auth == nil is only reachable when the
+//     desired bind is loopback per the #4047/#5127 clamp, so on convergence the
+//     live state is loopback).
 //
 // The reconcile is serialized by mu; the apply path (applyConfigLocked under the
 // apply semaphore) already runs commits one at a time, so a newer generation can
@@ -146,6 +152,21 @@ func (m *managementReconciler) reconcileTo(next api.Config) error {
 		return nil
 	}
 
+	// #5866 revocation-honoring: publish a credential TIGHTENING (a non-nil auth
+	// snapshot — e.g. a revoked credential removed from the set) to the live
+	// server UP FRONT, before any listener leg is touched, so the revocation
+	// takes effect on the persistent listener(s) on the NEXT request REGARDLESS
+	// of any HTTP/HTTPS rebind outcome. A single commit that BOTH revokes a
+	// credential AND changes a bind that then fails to bind must NOT keep the
+	// revoked credential usable on the retained listener. A non-nil auth only
+	// ADDS a requirement — it can never fail-open — so publishing it early is
+	// unconditionally safe. Removing ALL api-auth (nil) is instead deferred to
+	// after the legs converge (below), so a non-loopback listener retained by a
+	// failed rebind is never dropped to no-auth (fail-open).
+	if next.Auth != nil {
+		m.srv.ReplaceAuth(next.Auth)
+	}
+
 	var errs []error
 
 	// HTTP leg: make-before-break rebind ONLY if the HTTP bind changed. Advance
@@ -169,15 +190,19 @@ func (m *managementReconciler) reconcileTo(next api.Config) error {
 		}
 	}
 
-	// Auth: publish only once every leg is at its desired bind (see the type
-	// doc). An auth-only change (no leg change) publishes immediately with no
-	// rebind; a combined change whose bind failed defers the swap to retry.
 	if len(errs) == 0 {
-		m.srv.ReplaceAuth(next.Auth)
+		// Every changed leg converged to its desired bind. If the commit removes
+		// ALL api-auth (nil), publish it now — safe because next.Auth == nil is
+		// only reachable when the desired bind is loopback (#4047/#5127 clamp), so
+		// the live state is loopback. (A non-nil tightening was already published
+		// above.)
+		if next.Auth == nil {
+			m.srv.ReplaceAuth(nil)
+		}
 		return nil
 	}
 	joined := errors.Join(errs...)
-	slog.Warn("web-management listener reconcile incomplete; retaining previous listener(s), deferring auth swap",
+	slog.Warn("web-management listener reconcile incomplete; retaining previous listener(s)",
 		"desired", endpointOf(next).summary(), "err", joined)
 	return fmt.Errorf("web-management reconcile to %s incomplete; retaining previous listener(s): %w",
 		endpointOf(next).summary(), joined)

--- a/pkg/daemon/management_5866_test.go
+++ b/pkg/daemon/management_5866_test.go
@@ -64,6 +64,15 @@ func (r *fakeReg) listen(network, addr string) (net.Listener, error) {
 	if r.failAddr[addr] {
 		return nil, fmt.Errorf("fake bind refused: %s", addr)
 	}
+	// #5866: model EADDRINUSE. Real net.Listen (Go sets SO_REUSEADDR, NOT
+	// SO_REUSEPORT) rejects a second LISTEN on an addr that is still open. The
+	// old whole-server rebuild re-bound the retained HTTP socket on a TLS enable
+	// and would hit exactly this; the per-listener fix binds ONLY the changed
+	// leg, so it never re-binds a still-open sibling. A closed addr may be
+	// re-bound (enable -> disable -> re-enable on the same HTTPS port).
+	if ln, ok := r.byAddr[addr]; ok && ln.isOpen() {
+		return nil, fmt.Errorf("fake bind: listen tcp %s: bind: address already in use", addr)
+	}
 	priorsOpen := true
 	for a, ln := range r.byAddr {
 		if a != addr && !ln.isOpen() {
@@ -264,6 +273,113 @@ func TestMgmtReconcileBindFailureRetainsOld_5866(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if !old.isOpen() {
 		t.Fatal("the OLD listener closed asynchronously after a failed replacement (#5866)")
+	}
+}
+
+// #5866 per-leg independence: a TLS enable/disable/re-enable rebinds ONLY the
+// HTTPS leg. The live HTTP listener is never re-bound (its socket stays the SAME
+// fakeLn, still open) — under the old whole-server rebuild this re-bound the
+// still-held HTTP socket and the strict fake rejects it with EADDRINUSE.
+func TestMgmtReconcileHTTPSEnableDisableReEnable_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err != nil {
+		t.Fatalf("initial HTTP-only start: %v", err)
+	}
+	httpLn := reg.get("10.0.0.1:8080")
+	if httpLn == nil || !httpLn.isOpen() {
+		t.Fatal("HTTP listener not active")
+	}
+
+	// Enable HTTPS -> only the HTTPS leg binds; HTTP is untouched.
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", nil)); err != nil {
+		t.Fatalf("enable-TLS reconcile must succeed with the per-leg fix (no HTTP re-bind): %v", err)
+	}
+	if reg.get("10.0.0.1:8080") != httpLn || !httpLn.isOpen() {
+		t.Fatal("the live HTTP listener was disturbed by a TLS enable (#5866): it must be the SAME open socket")
+	}
+	if hln := reg.get("10.0.0.1:8443"); hln == nil || !hln.isOpen() {
+		t.Fatal("HTTPS listener not active after enable")
+	}
+
+	// Disable HTTPS -> HTTPS leg retires, HTTP untouched.
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err != nil {
+		t.Fatalf("disable-TLS reconcile: %v", err)
+	}
+	waitClosed(t, reg.get("10.0.0.1:8443"))
+	if reg.get("10.0.0.1:8080") != httpLn || !httpLn.isOpen() {
+		t.Fatal("HTTP listener disturbed by a TLS disable (#5866)")
+	}
+
+	// Re-enable HTTPS on the SAME addr (now free) -> binds a fresh HTTPS leg.
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", nil)); err != nil {
+		t.Fatalf("re-enable-TLS reconcile: %v", err)
+	}
+	if hln := reg.get("10.0.0.1:8443"); hln == nil || !hln.isOpen() {
+		t.Fatal("HTTPS listener not active after re-enable on the same port")
+	}
+	if reg.get("10.0.0.1:8080") != httpLn || !httpLn.isOpen() {
+		t.Fatal("HTTP listener disturbed by a TLS re-enable (#5866)")
+	}
+}
+
+// #5866: an HTTPS-bind-ONLY change (HTTP addr + TLS flag unchanged) make-before-
+// break rebinds only the HTTPS leg; the HTTP listener is untouched.
+func TestMgmtReconcileHTTPSBindOnlyChange_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", nil)); err != nil {
+		t.Fatalf("initial HTTP+HTTPS start: %v", err)
+	}
+	httpLn := reg.get("10.0.0.1:8080")
+	oldHTTPS := reg.get("10.0.0.1:8443")
+
+	// Move ONLY the HTTPS bind. HTTP stays on :8080.
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.2:8443", nil)); err != nil {
+		t.Fatalf("https-bind-only reconcile must succeed (HTTP untouched): %v", err)
+	}
+	if reg.get("10.0.0.1:8080") != httpLn || !httpLn.isOpen() {
+		t.Fatal("the HTTP listener was re-bound by an HTTPS-only change (#5866)")
+	}
+	if newHTTPS := reg.get("10.0.0.2:8443"); newHTTPS == nil || !newHTTPS.isOpen() {
+		t.Fatal("new HTTPS listener not active")
+	}
+	// Make-before-break: the new HTTPS bound while the old HTTPS was still open.
+	if !reg.priorsOpenAtNew["10.0.0.2:8443"] {
+		t.Fatal("new HTTPS bound only after the old closed — not make-before-break (#5866)")
+	}
+	waitClosed(t, oldHTTPS)
+}
+
+// #5866 symmetric case: an HTTP-addr change while HTTPS is present + UNCHANGED
+// rebinds only the HTTP leg. The HTTPS listener is never re-bound (the old
+// whole-server rebuild would re-bind the still-held HTTPS socket -> EADDRINUSE).
+func TestMgmtReconcileHTTPChangeKeepsHTTPS_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", nil)); err != nil {
+		t.Fatalf("initial HTTP+HTTPS start: %v", err)
+	}
+	httpsLn := reg.get("10.0.0.1:8443")
+
+	// Change ONLY the HTTP bind. HTTPS stays on :8443.
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.2:8080", true, "10.0.0.1:8443", nil)); err != nil {
+		t.Fatalf("http-only reconcile must succeed without re-binding the unchanged HTTPS socket: %v", err)
+	}
+	if reg.get("10.0.0.1:8443") != httpsLn || !httpsLn.isOpen() {
+		t.Fatal("the HTTPS listener was re-bound by an HTTP-only change (#5866 symmetric collision)")
+	}
+	if newHTTP := reg.get("10.0.0.2:8080"); newHTTP == nil || !newHTTP.isOpen() {
+		t.Fatal("new HTTP listener not active")
 	}
 }
 

--- a/pkg/daemon/management_5866_test.go
+++ b/pkg/daemon/management_5866_test.go
@@ -1,0 +1,280 @@
+// #5866: the managementReconciler must, on a day-2 web-management change,
+// atomically replace the live HTTP/HTTPS listener + authentication snapshot
+// instead of leaving the boot-time server enforcing the old policy until a
+// restart. These tests drive reconcileTo/startTo with a FAKE listener factory
+// (no real ports) and cover: a bind/port change (new active, old closed),
+// make-before-break coexistence, a TLS-material change (new cert served),
+// a same-endpoint auth swap (no rebind), and a failed new-bind (old listener
+// RETAINED, error surfaced — fail-closed to the previous working state).
+//
+// FAIL-ON-REVERT: revert reconcileTo to close-old-before-binding-new and the
+// bind-failure test leaves nothing serving (RED); revert it to not swap and the
+// bind/port + auth tests do not converge (RED).
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/api"
+)
+
+// fakeLn is an in-memory net.Listener: Accept blocks until Close, so an
+// http.Server.Serve loop parks until Shutdown closes it (no real socket).
+type fakeLn struct {
+	addr   string
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (f *fakeLn) Accept() (net.Conn, error) { <-f.closed; return nil, net.ErrClosed }
+func (f *fakeLn) Close() error              { f.once.Do(func() { close(f.closed) }); return nil }
+func (f *fakeLn) Addr() net.Addr            { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)} }
+func (f *fakeLn) isOpen() bool {
+	select {
+	case <-f.closed:
+		return false
+	default:
+		return true
+	}
+}
+
+// fakeReg is the injected listener factory. It records, at each new listener's
+// creation, whether every previously-created listener was still open — the
+// make-before-break witness: a new endpoint must bind while the old is still
+// serving.
+type fakeReg struct {
+	mu              sync.Mutex
+	byAddr          map[string]*fakeLn
+	failAddr        map[string]bool
+	priorsOpenAtNew map[string]bool
+}
+
+func newFakeReg() *fakeReg {
+	return &fakeReg{byAddr: map[string]*fakeLn{}, failAddr: map[string]bool{}, priorsOpenAtNew: map[string]bool{}}
+}
+
+func (r *fakeReg) listen(network, addr string) (net.Listener, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failAddr[addr] {
+		return nil, fmt.Errorf("fake bind refused: %s", addr)
+	}
+	priorsOpen := true
+	for a, ln := range r.byAddr {
+		if a != addr && !ln.isOpen() {
+			priorsOpen = false
+		}
+	}
+	r.priorsOpenAtNew[addr] = priorsOpen
+	ln := &fakeLn{addr: addr, closed: make(chan struct{})}
+	r.byAddr[addr] = ln
+	return ln, nil
+}
+
+func (r *fakeReg) get(addr string) *fakeLn {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.byAddr[addr]
+}
+
+func cfgFor(reg *fakeReg, addr string, useTLS bool, httpsAddr string, auth *api.AuthConfig) api.Config {
+	return api.Config{Addr: addr, TLS: useTLS, HTTPSAddr: httpsAddr, Auth: auth, ListenFunc: reg.listen}
+}
+
+func newTestMgmt(reg *fakeReg) *managementReconciler {
+	// reconcileTo/startTo do not dereference d (only desired()/start() do), so a
+	// bare Daemon is sufficient for these listener-lifecycle tests.
+	return newManagementReconciler(&Daemon{}, api.Config{ListenFunc: reg.listen})
+}
+
+func waitClosed(t *testing.T, ln *fakeLn) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !ln.isOpen() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("listener %s did not close within the drain window", ln.addr)
+}
+
+// Bar 1 + Bar 4: a bind/port change replaces the listener make-before-break —
+// the new endpoint is active and the old is closed, and the new endpoint bound
+// while the old was still serving (no unreachable window).
+func TestMgmtReconcileBindChange_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err != nil {
+		t.Fatalf("initial start: %v", err)
+	}
+	old := reg.get("10.0.0.1:8080")
+	if old == nil || !old.isOpen() {
+		t.Fatal("initial listener not active")
+	}
+
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.2:8080", false, "", nil)); err != nil {
+		t.Fatalf("bind-change reconcile: %v", err)
+	}
+	// New endpoint recorded + active.
+	if m.cur.addr != "10.0.0.2:8080" {
+		t.Fatalf("current endpoint = %q, want the new bind 10.0.0.2:8080", m.cur.addr)
+	}
+	newLn := reg.get("10.0.0.2:8080")
+	if newLn == nil || !newLn.isOpen() {
+		t.Fatal("new listener is not active after the bind change")
+	}
+	// Make-before-break: the new endpoint bound while the old was still open.
+	if !reg.priorsOpenAtNew["10.0.0.2:8080"] {
+		t.Fatal("new listener bound only AFTER the old closed — not make-before-break (#5866): " +
+			"there was a window with no management listener")
+	}
+	// Old endpoint is retired.
+	waitClosed(t, old)
+}
+
+// Bar 2: a TLS-material change replaces the listener and serves a FRESH cert.
+func TestMgmtReconcileTLSChange_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start HTTP-only.
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err != nil {
+		t.Fatalf("initial start: %v", err)
+	}
+	if m.srv.HTTPSCertForTest() != nil {
+		t.Fatal("HTTP-only server must not serve a TLS cert")
+	}
+
+	// Enable HTTPS -> endpoint changes -> rebuild with a cert.
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", nil)); err != nil {
+		t.Fatalf("enable-TLS reconcile: %v", err)
+	}
+	cert1 := m.srv.HTTPSCertForTest()
+	if cert1 == nil {
+		t.Fatal("HTTPS-enabled server must serve a TLS cert after the reconcile")
+	}
+	if reg.get("10.0.0.1:8443") == nil || !reg.get("10.0.0.1:8443").isOpen() {
+		t.Fatal("HTTPS listener not active after enabling TLS")
+	}
+
+	// Change the HTTPS bind -> rebuild -> a NEW self-signed cert is served.
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.2:8443", nil)); err != nil {
+		t.Fatalf("https-rebind reconcile: %v", err)
+	}
+	cert2 := m.srv.HTTPSCertForTest()
+	if cert2 == nil {
+		t.Fatal("HTTPS cert missing after the https rebind")
+	}
+	if len(cert1.Certificate) == 0 || len(cert2.Certificate) == 0 {
+		t.Fatal("served TLS cert has no leaf certificate")
+	}
+	if bytesEqual(cert1.Certificate[0], cert2.Certificate[0]) {
+		t.Fatal("a TLS-material change must serve a NEW certificate, got the same leaf cert bytes (#5866)")
+	}
+}
+
+// Bar 3: a same-endpoint auth change swaps the LIVE auth snapshot in place — no
+// listener rebind (the server instance is unchanged), and the revoked credential
+// is rejected on the next request.
+func TestMgmtReconcileAuthSwapNoRebind_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	auth := &api.AuthConfig{Users: map[string]string{"admin": "secret"}}
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", auth)); err != nil {
+		t.Fatalf("initial start: %v", err)
+	}
+	srvBefore := m.srv
+	ln := reg.get("10.0.0.1:8080")
+
+	// Revoke admin on the SAME endpoint.
+	revoked := &api.AuthConfig{Users: map[string]string{"other": "pw"}}
+	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", false, "", revoked)); err != nil {
+		t.Fatalf("auth-swap reconcile: %v", err)
+	}
+	// No rebind: the SAME server instance and the SAME listener are retained.
+	if m.srv != srvBefore {
+		t.Fatal("a same-endpoint auth change must NOT rebind the listener (server instance changed)")
+	}
+	if !ln.isOpen() {
+		t.Fatal("the listener was bounced on a same-endpoint auth change (#5866)")
+	}
+	// The live auth snapshot was swapped IN PLACE to the revoked set (admin gone,
+	// other present). The api-level TestServerReplaceAuthLiveSwap_5866 proves such
+	// a snapshot rejects the revoked credential on the next request.
+	snap := m.srv.AuthSnapshotForTest()
+	if snap == nil {
+		t.Fatal("live auth snapshot is nil after the revoke reconcile")
+	}
+	if _, ok := snap.Users["admin"]; ok {
+		t.Fatal("revoked credential 'admin' is STILL in the live auth snapshot — the swap did not " +
+			"take effect (#5866)")
+	}
+	if _, ok := snap.Users["other"]; !ok {
+		t.Fatal("the new credential 'other' is missing from the live auth snapshot")
+	}
+}
+
+// Bar 5: a failed new-bind RETAINS the old listener (fail-closed to the previous
+// working state, not mgmt-down) and surfaces the error. This is also the sharp
+// make-before-break lever: a close-old-first implementation would leave nothing
+// serving.
+func TestMgmtReconcileBindFailureRetainsOld_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err != nil {
+		t.Fatalf("initial start: %v", err)
+	}
+	old := reg.get("10.0.0.1:8080")
+	srvBefore := m.srv
+
+	reg.failAddr["10.0.0.2:8080"] = true
+	err := m.reconcileTo(cfgFor(reg, "10.0.0.2:8080", false, "", nil))
+	if err == nil {
+		t.Fatal("a failed listener replacement must surface an error")
+	}
+	// Old listener retained + still serving.
+	if m.srv != srvBefore {
+		t.Fatal("the live server was swapped despite the new bind failing (#5866)")
+	}
+	if m.cur.addr != "10.0.0.1:8080" {
+		t.Fatalf("endpoint fingerprint = %q, want the retained 10.0.0.1:8080 (retry debt)", m.cur.addr)
+	}
+	if !old.isOpen() {
+		t.Fatal("the OLD listener was closed on a failed replacement — management went DOWN " +
+			"(fail-open); make-before-break must retain the previous working listener (#5866)")
+	}
+	// Give any (incorrect) async close a chance, then re-assert the old is up.
+	time.Sleep(50 * time.Millisecond)
+	if !old.isOpen() {
+		t.Fatal("the OLD listener closed asynchronously after a failed replacement (#5866)")
+	}
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/daemon/management_5866_test.go
+++ b/pkg/daemon/management_5866_test.go
@@ -441,6 +441,53 @@ func TestMgmtReconcileRevokeHonoredDespiteHTTPSBindFailure_5866(t *testing.T) {
 	}
 }
 
+// #5866 fail-open avoidance (the counterpart to the revocation-honoring case):
+// removing ALL api-auth (next.Auth == nil, which clamps the HTTP bind to
+// loopback) while the HTTP leg's OWN rebind to that loopback address FAILS must
+// NOT drop the retained NON-loopback HTTP listener to no-auth. The nil auth is
+// deferred (httpOK == false), so the retained listener keeps its previous
+// credential set — no fail-open — and converges on retry.
+func TestMgmtReconcileRemoveAuthDeferredWhenHTTPRebindFails_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Live: non-loopback HTTP with auth (valid — auth present).
+	auth := &api.AuthConfig{Users: map[string]string{"admin": "secret"}}
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", auth)); err != nil {
+		t.Fatalf("initial start: %v", err)
+	}
+	oldHTTP := reg.get("10.0.0.1:8080")
+
+	// Commit removes ALL api-auth -> the bind clamps to loopback (127.0.0.1),
+	// but that rebind FAILS. next.Auth == nil.
+	reg.failAddr["127.0.0.1:8080"] = true
+	err := m.reconcileTo(cfgFor(reg, "127.0.0.1:8080", false, "", nil))
+	if err == nil {
+		t.Fatal("a failed HTTP rebind must surface an error")
+	}
+
+	// The nil auth was NOT applied: the retained NON-loopback HTTP listener still
+	// enforces the previous credential — dropping it to no-auth would be a
+	// fail-open on a non-loopback bind.
+	snap := m.srv.AuthSnapshotForTest()
+	if snap == nil {
+		t.Fatal("api-auth was removed while the retained listener is still non-loopback — FAIL-OPEN (#5866): " +
+			"a nil-on-loopback auth must not be applied to a retained non-loopback listener")
+	}
+	if _, ok := snap.Users["admin"]; !ok {
+		t.Fatal("the retained listener lost its credential set on a failed HTTP rebind (#5866)")
+	}
+	// Old non-loopback listener retained + open; fingerprint not advanced.
+	if !oldHTTP.isOpen() {
+		t.Fatal("the old HTTP listener was closed on a failed rebind (mgmt went down)")
+	}
+	if m.cur.addr != "10.0.0.1:8080" {
+		t.Fatalf("HTTP fingerprint = %q, want the retained 10.0.0.1:8080 (retry debt)", m.cur.addr)
+	}
+}
+
 func bytesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/daemon/management_5866_test.go
+++ b/pkg/daemon/management_5866_test.go
@@ -383,6 +383,64 @@ func TestMgmtReconcileHTTPChangeKeepsHTTPS_5866(t *testing.T) {
 	}
 }
 
+// #5866 revocation-honoring (the elevated Finding A): a SINGLE commit that BOTH
+// revokes a credential AND changes the HTTPS endpoint to one that FAILS to bind
+// must still reject the revoked credential on the next request — the tightening
+// is published to the persistent HTTP listener UP FRONT, regardless of the HTTPS
+// rebind outcome — while the old HTTPS state is retained with retry debt.
+//
+// FAIL-ON-REVERT: without the up-front ReplaceAuth (publishing auth only after
+// the legs converge), the failed HTTPS rebind leaves the revoked credential in
+// the live snapshot -> the admin-absent assertion FAILS.
+func TestMgmtReconcileRevokeHonoredDespiteHTTPSBindFailure_5866(t *testing.T) {
+	reg := newFakeReg()
+	m := newTestMgmt(reg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	auth := &api.AuthConfig{Users: map[string]string{"admin": "secret"}}
+	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", auth)); err != nil {
+		t.Fatalf("initial HTTP+HTTPS start: %v", err)
+	}
+	oldHTTPS := reg.get("10.0.0.1:8443")
+
+	// Bundled commit: revoke admin (new set has only "other") AND move the HTTPS
+	// bind to an address that fails to bind.
+	reg.failAddr["10.0.0.2:8443"] = true
+	revoked := &api.AuthConfig{Users: map[string]string{"other": "pw"}}
+	err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.2:8443", revoked))
+	if err == nil {
+		t.Fatal("a failed HTTPS rebind must surface an error (retry debt)")
+	}
+
+	// The revocation was honored despite the HTTPS bind failure: the live auth
+	// snapshot no longer contains admin.
+	snap := m.srv.AuthSnapshotForTest()
+	if snap == nil {
+		t.Fatal("live auth snapshot is nil after the revoke reconcile")
+	}
+	if _, ok := snap.Users["admin"]; ok {
+		t.Fatal("revoked credential 'admin' is STILL live after a bundled revoke + failed HTTPS rebind " +
+			"— a revoked credential must be rejected on the next request regardless of the rebind outcome (#5866)")
+	}
+	if _, ok := snap.Users["other"]; !ok {
+		t.Fatal("the tightened credential 'other' is missing from the live auth snapshot")
+	}
+
+	// The old HTTPS listener is retained (fail-closed) and its fingerprint is not
+	// advanced (retry debt).
+	if !oldHTTPS.isOpen() {
+		t.Fatal("the old HTTPS listener was closed on a failed rebind (mgmt HTTPS went down)")
+	}
+	if m.cur.httpsAddr != "10.0.0.1:8443" {
+		t.Fatalf("HTTPS fingerprint = %q, want the retained 10.0.0.1:8443 (retry debt)", m.cur.httpsAddr)
+	}
+	// The HTTP listener was never touched.
+	if hln := reg.get("10.0.0.1:8080"); hln == nil || !hln.isOpen() {
+		t.Fatal("the HTTP listener was disturbed by the HTTPS rebind")
+	}
+}
+
 func bytesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary

Closes #5866.

The HTTP/HTTPS management server was constructed **once** at daemon
startup and never reconciled. A successful day-2 web-management commit
(bind address / port / TLS material / api-auth) reported the new policy
while the process kept enforcing the **old** one until a restart —
**revoked or tightened credentials stayed usable**, a bind removal left
the API on the old address, and restart became an undocumented
correctness/security requirement.

## Design

A dedicated management-listener lifecycle owner
(`managementReconciler`, `pkg/daemon/management.go`) + a swappable
`api.Server`:

- **Live auth snapshot** — `s.auth` is now an
  `atomic.Pointer[AuthConfig]` read per request by
  `dynamicAuthMiddleware`; `ReplaceAuth` swaps it, so a
  revoked/tightened credential is rejected on the **next request** with
  no listener bounce and no restart. `authCheck` is shared with the
  static `authMiddleware`, so the swap keeps **byte-identical** semantics
  (the #4157 constant-time + #5636 empty-secret guards, `/health` +
  loopback-`/metrics` exemptions).
- **Make-before-break** — `api.Server.Start` binds synchronously
  (returning a bind error with nothing serving) then serves in the
  background. On an endpoint change the reconciler binds the **new**
  listener first and only once it is serving cancels the old server's
  context (bounded 5s graceful drain) — management is **never
  unreachable**. `bindListeners` binds via `Config.ListenFunc` (default
  `net.Listen`) so tests inject a fake factory (no real ports).
- **Fail-safe** — a failed new bind **retains the OLD listener** (the
  previous working state, fail-closed — not mgmt-down), leaves the
  endpoint fingerprint unrecorded so the next commit retries (retry
  debt), and surfaces the error.

`reconcileWebManagement` is wired into `applyConfigLocked` **next to
`reconcileSNMP`** — early, before the dataplane apply that can abort —
so a committed credential revocation is enforced even on an apply that
returns early (`store.Commit` has already promoted the config). Like
`reconcileSNMP`, a bind-replacement failure is retry debt and does not
brick an otherwise-successful commit.

## Fail-on-revert tests

- `server_authswap_5866_test.go` — a `ReplaceAuth` revoke is rejected on
  the next request. Reverting to a construction-time auth capture → the
  revoked credential still authenticates → **RED** (proven via `-overlay`:
  `revoked = 200, want 401`).
- `management_5866_test.go` (fake listener factory) — bind/port change
  (new active, old closed, coexistence witness), TLS-material change
  (rebuild serves a **fresh** cert), same-endpoint auth change (snapshot
  swap, **no** rebind), failed new bind (old listener retained + error
  surfaced). Reverting to close-old-before-bind-new → coexistence +
  retain-old tests **RED** (proven via `-overlay`).

## Validation

- `go build ./...` clean
- `go vet ./pkg/daemon/ ./pkg/api/` clean
- `go test -race ./pkg/api/ ./pkg/daemon/` GREEN
- Both fail-on-revert levers proven RED via `-overlay`.
- `pkg/api/README.md` + `pkg/daemon/README.md` document the day-2
  listener/auth reconcile.

Control-plane management listener (REST :8080/:8443) — unit-tested with
injected listener seams, no dataplane / VRRP failover involved, so no
`test-failover` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)