### PR TITLE
cli: reject malformed clear dhcp client-identifier selector

### DIFF
--- a/pkg/cli/cli_clear.go
+++ b/pkg/cli/cli_clear.go
@@ -480,13 +480,36 @@ func (c *CLI) handleClearDHCP(args []string) error {
 		return nil
 	}
 
+	// A bare `clear dhcp client-identifier` (no selector) is the intentional
+	// clear-ALL. But a malformed selector must NOT silently degrade to it:
+	// `... interface` (no name), `... interfce ge-0/0/0` (unknown selector),
+	// or a stray trailing token used to skip the scoped branch and fall
+	// through to ClearAllDUIDs(), wiping EVERY DHCPv6 DUID instead of the one
+	// the operator scoped. Validate the selector BEFORE any mutation and
+	// reject a malformed one, mirroring the remote CLI's #4883-E guard
+	// (cmd/cli/clear.go handleClearDHCP) so both parsers reject the same
+	// input the same way (#5896). Validation runs before the c.dhcp==nil
+	// check so bad input always errors, regardless of DHCP client state.
+	var ifName string
+	if len(args) >= 2 {
+		if args[1] != "interface" {
+			return fmt.Errorf("usage: clear dhcp client-identifier [interface <name>]")
+		}
+		if len(args) < 3 || args[2] == "" {
+			return fmt.Errorf("clear dhcp client-identifier: 'interface' requires a name")
+		}
+		if len(args) > 3 {
+			return fmt.Errorf("clear dhcp client-identifier: unexpected argument %q after interface name", args[3])
+		}
+		ifName = args[2]
+	}
+
 	if c.dhcp == nil {
 		fmt.Println("No DHCP clients running")
 		return nil
 	}
 
-	if len(args) >= 3 && args[1] == "interface" {
-		ifName := args[2]
+	if ifName != "" {
 		if err := c.dhcp.ClearDUID(ifName); err != nil {
 			return fmt.Errorf("clear DUID: %w", err)
 		}

--- a/pkg/cli/cli_clear_dhcp_duid_5896_test.go
+++ b/pkg/cli/cli_clear_dhcp_duid_5896_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dhcp"
+)
+
+// seedDUIDs writes placeholder DHCPv6 DUID state files for the named interfaces
+// into a manager's state directory. A subsequent clear is then observed purely
+// by which files survive: ClearDUID removes exactly one, ClearAllDUIDs removes
+// every file carrying the "dhcpv6-duid-" prefix.
+func seedDUIDs(t *testing.T, dir string, ifaces ...string) {
+	t.Helper()
+	for _, ifn := range ifaces {
+		p := filepath.Join(dir, "dhcpv6-duid-"+ifn)
+		if err := os.WriteFile(p, []byte("duid"), 0o644); err != nil {
+			t.Fatalf("seed DUID %s: %v", ifn, err)
+		}
+	}
+}
+
+func duidPresent(t *testing.T, dir, ifn string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(dir, "dhcpv6-duid-"+ifn))
+	return err == nil
+}
+
+// TestHandleClearDHCP_MalformedSelectorGuard_5896 locks the in-process CLI's
+// `clear dhcp client-identifier` handler to the SAME malformed-selector guard
+// the remote CLI already enforces (#4883-E, cmd/cli/clear.go handleClearDHCP).
+//
+// The bug (#5896): the in-process handler recognized only a fully-formed
+// `interface <name>` selector and let EVERY other shape fall through to the
+// unscoped ClearAllDUIDs(), so `clear dhcp client-identifier interface` (no
+// name), `... interfce ge-0-0-0` (misspelled selector), or a stray trailing
+// token wiped every DHCPv6 DUID on the box instead of the one the operator
+// scoped. A bare `clear dhcp client-identifier` (no selector) is the ONLY
+// intentional clear-all.
+//
+// Fail-on-revert: delete the guard and the three malformed cases fall back to
+// clear-all (files vanish, err is nil) — flipping wantErr AND the survival
+// assertions red. The stray-token case additionally regresses to a scoped
+// clear of ge-0-0-0 under the old `len(args) >= 3` branch, which the wantA
+// assertion catches.
+func TestHandleClearDHCP_MalformedSelectorGuard_5896(t *testing.T) {
+	const (
+		ifA = "ge-0-0-0"
+		ifB = "ge-0-0-1"
+	)
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+		wantA   bool // ge-0-0-0 DUID file survives the call
+		wantB   bool // ge-0-0-1 DUID file survives the call
+	}{
+		{
+			name:    "bare client-identifier is the intentional clear-all",
+			args:    []string{"client-identifier"},
+			wantErr: false,
+			wantA:   false,
+			wantB:   false,
+		},
+		{
+			name:    "well-formed scoped clears only that interface",
+			args:    []string{"client-identifier", "interface", ifA},
+			wantErr: false,
+			wantA:   false,
+			wantB:   true,
+		},
+		{
+			name:    "interface without a name is rejected, nothing cleared",
+			args:    []string{"client-identifier", "interface"},
+			wantErr: true,
+			wantA:   true,
+			wantB:   true,
+		},
+		{
+			name:    "unknown selector token is rejected, nothing cleared",
+			args:    []string{"client-identifier", "interfce", ifA},
+			wantErr: true,
+			wantA:   true,
+			wantB:   true,
+		},
+		{
+			name:    "stray trailing token is rejected, nothing cleared",
+			args:    []string{"client-identifier", "interface", ifA, "extra"},
+			wantErr: true,
+			wantA:   true,
+			wantB:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mgr, err := dhcp.New(dir, nil, nil)
+			if err != nil {
+				t.Fatalf("dhcp.New: %v", err)
+			}
+			seedDUIDs(t, dir, ifA, ifB)
+
+			c := &CLI{dhcp: mgr}
+			err = c.handleClearDHCP(tc.args)
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("args %v: want error (malformed selector must not silently clear), got nil", tc.args)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("args %v: unexpected error: %v", tc.args, err)
+			}
+			if got := duidPresent(t, dir, ifA); got != tc.wantA {
+				t.Errorf("args %v: DUID %s present=%v, want %v", tc.args, ifA, got, tc.wantA)
+			}
+			if got := duidPresent(t, dir, ifB); got != tc.wantB {
+				t.Errorf("args %v: DUID %s present=%v, want %v", tc.args, ifB, got, tc.wantB)
+			}
+		})
+	}
+}
+
+// TestHandleClearDHCP_MalformedSelectorRejectedBeforeNilCheck_5896 pins the
+// ordering choice: selector validation runs BEFORE the c.dhcp==nil
+// short-circuit, so malformed input always errors regardless of DHCP client
+// state, matching the remote CLI (which has no nil path). A bare clear-all
+// with no running client remains a benign no-op.
+func TestHandleClearDHCP_MalformedSelectorRejectedBeforeNilCheck_5896(t *testing.T) {
+	c := &CLI{dhcp: nil}
+	if err := c.handleClearDHCP([]string{"client-identifier", "interface"}); err == nil {
+		t.Fatal("malformed selector with nil dhcp: want error, got nil")
+	}
+	if err := c.handleClearDHCP([]string{"client-identifier"}); err != nil {
+		t.Fatalf("bare clear-all with nil dhcp: unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (#5896)

The in-process CLI handler for `clear dhcp client-identifier`
(`pkg/cli/cli_clear.go handleClearDHCP`) recognized only a fully-formed
`interface <name>` selector and let **every other shape** fall through to
the unscoped `ClearAllDUIDs()`. So a malformed selector silently wiped
**every** DHCPv6 DUID on the box instead of the one the operator scoped:

- `clear dhcp client-identifier interface` (no name) → `len(args) < 3` → fell through to clear-all
- `clear dhcp client-identifier interfce ge-0-0-0` (misspelled selector) → `args[1] != "interface"` → fell through to clear-all
- `clear dhcp client-identifier interface ge-0-0-0 extra` (stray token) → took the scoped branch but **silently ignored** the extra token

The remote CLI already rejects these shapes (the #4883-E guard in
`cmd/cli/clear.go handleClearDHCP`); the two parsers had diverged. This
is distinct from #5811 (global-only hardening): this command is
**legitimately scoped**, so `requireClearNoScope` does not apply — the
fix is to validate the selector, not forbid all scope.

## Fix

Validate the selector before any mutation, mirroring the remote guard
byte-for-byte in intent. When any selector token is typed (`len(args) >= 2`):
require `interface` as the keyword, require a non-empty name, and reject a
stray trailing token. Only a bare `clear dhcp client-identifier` (no
selector) still reaches `ClearAllDUIDs()` — the intentional clear-all. A
well-formed `clear dhcp client-identifier interface ge-0-0-0` still clears
exactly that identifier. Validation runs **before** the `c.dhcp == nil`
short-circuit so bad input always errors regardless of DHCP client state,
matching the remote CLI (which has no nil path).

## Test

`pkg/cli/cli_clear_dhcp_duid_5896_test.go` — a fail-on-revert table test
driving the handler with a real `dhcp.Manager` over a temp state dir
seeded with two DUID files, asserting per case both the returned error
and which DUID files survive:

- three malformed selectors → rejected, **nothing** cleared
- well-formed scoped → clears exactly one interface's DUID
- bare clear-all → removes both

Reverting the guard flips the three malformed cases red (files vanish,
err nil). A second test pins that validation precedes the nil check.

## Validation

- `GOCACHE=/dev/shm go build ./...` — clean
- `go vet ./pkg/cli/` — only the pre-existing `cli.go:511` unreachable-code warning (untouched file)
- `go test ./pkg/cli/` — green
- Fail-on-revert proven via a `-overlay` revert of the guard (worktree untouched): the three malformed cases fail with logs showing `All DHCPv6 DUIDs cleared` — the exact wipe the guard prevents.

No operator/design doc documents this command (only historical review
archives mention it); the handler comment documents the behavior and
cross-references #4883-E and #5896.

Closes #5896

🤖 Generated with [Claude Code](https://claude.com/claude-code)