### PR TITLE
config: merge repeated scheduler blocks instead of last-win (#5825)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48678,3 +48678,23 @@ top.
 - **Timestamp**: 2026-07-15
   - **Action**: #5824 fold — cross-root policy-statement term compose. Seed the per-call psTermIndex from the persisted ps.Terms so a same-name term across SEPARATE top-level policy-options roots composes onto one PolicyTerm instead of duplicating (a malformed double route-map). Corrects the block-merge comment's cross-root claim. Parent RED-on-revert confirmed (neutralize seed → SameTermAcrossRootsMerges_5824 RED, got [x x]).
   - **File(s)**: pkg/config/compiler_routing.go, pkg/config/compiler_policy_block_merge_5824_test.go
+
+## 2026-07-15 — #5825 scheduler block-merge (mirrors #5824)
+
+- **Timestamp**: 2026-07-15
+- **Action**: compileSchedulers allocated a FRESH SchedulerConfig per named AST
+  instance then unconditionally cfg.Schedulers[name]=sched, so a repeated
+  hierarchical `schedulers scheduler S {}` block (or a second top-level
+  `schedulers {}` root) REPLACED the earlier — every day/window authored earlier
+  vanished (a time-gated policy then active/inactive on the WRONG days). FIX:
+  reuse the existing map entry so distinct weekday windows UNION across
+  blocks/roots (Days map on the reused struct; no separate index needed). Scalars
+  (daily/date/all-day) follow flat-set/Junos-merge last-wins. Removed the
+  unconditional overwrite.
+- **File(s)**: pkg/config/compiler_system.go (reuse-and-merge),
+  pkg/config/compiler_scheduler_block_merge_5825_test.go (NEW 5 tests),
+  docs/config-schema.md (#5825 block-merge subsection).
+- **Validation**: go build ./... clean; go vet ./pkg/config/ clean; go test -race
+  ./pkg/config/ -run Scheduler GREEN; full pkg/config suite GREEN. Fail-on-revert:
+  restoring fresh-alloc+overwrite via -overlay -> the 4 merge tests RED (only the
+  last block's day survives), single-block stays green.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1749,6 +1749,31 @@ unchanged) and the end-to-end render guard
 `pkg/frr/policy_block_merge_5824_test.go` (the early reject term's `deny`
 sequence + route-filter survive into the FRR route-map).
 
+### Repeated scheduler blocks MERGE, not last-win (#5825)
+
+The SAME block-merge rule applies to `schedulers scheduler <name>`. A scheduler
+may be authored across multiple hierarchical blocks (two `scheduler S { ... }`
+braces) or repeated top-level `schedulers { ... }` roots, each a distinct AST
+instance. `compileSchedulers` (`compiler_system.go`) used to allocate a FRESH
+`SchedulerConfig` per instance and do an unconditional `cfg.Schedulers[name] =
+sched`, so a later same-name block REPLACED the first — every day/window authored
+earlier vanished. Flat `set schedulers scheduler S <day> ...` lines compose under
+one path, so the hierarchical and flat spellings diverged, and a security policy
+time-gated by the scheduler became active/inactive on the WRONG days with a clean
+commit.
+
+The loop now REUSES the existing map entry, so distinct weekday windows UNION
+across blocks/roots (the `Days` map lives on the reused struct — no separate index
+is needed, unlike the policy-statement term index, because per-day dedup is the
+map key). The daily/date scalars (`start-time`/`stop-time`/`start-date`/
+`stop-date`, the `daily` window, `all-day`) follow flat-set / Junos load-merge
+LAST-WINS: a repeated leaf replaces, exactly as a second `set` of the same leaf
+does, so no order-dependent divergence from flat is introduced (a "conflict" is
+not representable in flat-set — the last `set` simply wins). Fail-on-revert
+covered by `pkg/config/compiler_scheduler_block_merge_5825_test.go` (two-block day
+merge, hierarchical==flat parity, across-roots merge, daily+weekday compose,
+single-block unchanged).
+
 ### Quoted-value escape round-trip contract (#3854)
 
 When a key or value contains a character that is not a bare Junos identifier

--- a/pkg/config/compiler_scheduler_block_merge_5825_test.go
+++ b/pkg/config/compiler_scheduler_block_merge_5825_test.go
@@ -1,0 +1,200 @@
+package config_test
+
+// #5825: repeated hierarchical `schedulers scheduler <name> { ... }` blocks are
+// distinct AST instances. compileSchedulers used to allocate a FRESH
+// SchedulerConfig per instance and unconditionally `cfg.Schedulers[name] = sched`,
+// so a later same-name block REPLACED the earlier — every day/window authored in
+// the earlier block(s) vanished. Flat `set` composes into ONE path, so
+// hierarchical and flat diverged. A policy time-gated by the scheduler then
+// became active/inactive on the WRONG days with a clean commit (security).
+//
+// The fix REUSES the existing map entry so distinct weekday windows UNION across
+// blocks (and across separate top-level `schedulers {}` roots), matching flat-set
+// semantics. Daily/date scalars follow flat-set / Junos load-merge last-wins.
+//
+// FAIL-ON-REVERT: restoring the fresh-alloc + unconditional overwrite makes the
+// second block replace the first — the merge test below sees ONLY the last
+// block's day and goes RED.
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func schedDays(sc *config.SchedulerConfig) []string {
+	if sc == nil {
+		return nil
+	}
+	days := make([]string, 0, len(sc.Days))
+	for d := range sc.Days {
+		days = append(days, d)
+	}
+	sort.Strings(days)
+	return days
+}
+
+func getScheduler(t *testing.T, cfg *config.Config, name string) *config.SchedulerConfig {
+	t.Helper()
+	sc := cfg.Schedulers[name]
+	if sc == nil {
+		t.Fatalf("scheduler %q missing from compiled config", name)
+	}
+	return sc
+}
+
+// twoBlockSchedHier: block 1 defines the monday + tuesday windows, block 2 (SAME
+// scheduler name) defines wednesday. Pre-fix, only wednesday survives.
+const twoBlockSchedHier = `schedulers {
+    scheduler S {
+        monday {
+            start-time 08:00:00;
+            stop-time 12:00:00;
+        }
+        tuesday {
+            start-time 09:00:00;
+            stop-time 17:00:00;
+        }
+    }
+    scheduler S {
+        wednesday {
+            start-time 10:00:00;
+            stop-time 18:00:00;
+        }
+    }
+}
+`
+
+// Acceptance: weekdays split across two hierarchical blocks all survive on ONE
+// scheduler, with each day's window intact.
+func TestSchedulerHierarchicalBlocksMergeDays_5825(t *testing.T) {
+	cfg := compileHier(t, twoBlockSchedHier)
+	sc := getScheduler(t, cfg, "S")
+
+	if got := schedDays(sc); len(got) != 3 || got[0] != "monday" || got[1] != "tuesday" || got[2] != "wednesday" {
+		t.Fatalf("day windows split across two blocks must MERGE onto one scheduler, got %v "+
+			"(the earlier block's days were dropped by last-writer replacement) — #5825", got)
+	}
+	if w := sc.Days["monday"]; w == nil || w.StartTime != "08:00:00" || w.StopTime != "12:00:00" {
+		t.Fatalf("block-1 monday window must survive, got %+v", sc.Days["monday"])
+	}
+	if w := sc.Days["tuesday"]; w == nil || w.StartTime != "09:00:00" || w.StopTime != "17:00:00" {
+		t.Fatalf("block-1 tuesday window must survive, got %+v", sc.Days["tuesday"])
+	}
+	if w := sc.Days["wednesday"]; w == nil || w.StartTime != "10:00:00" || w.StopTime != "18:00:00" {
+		t.Fatalf("block-2 wednesday window must survive, got %+v", sc.Days["wednesday"])
+	}
+}
+
+// Acceptance: the two-block hierarchical form compiles to the SAME typed schedule
+// as the equivalent flat `set` commands (which already compose under one path).
+func TestSchedulerHierarchicalEqualsFlatSet_5825(t *testing.T) {
+	hCfg := compileHier(t, twoBlockSchedHier)
+	fCfg := compileFlat(t,
+		"set schedulers scheduler S monday start-time 08:00:00",
+		"set schedulers scheduler S monday stop-time 12:00:00",
+		"set schedulers scheduler S tuesday start-time 09:00:00",
+		"set schedulers scheduler S tuesday stop-time 17:00:00",
+		"set schedulers scheduler S wednesday start-time 10:00:00",
+		"set schedulers scheduler S wednesday stop-time 18:00:00",
+	)
+	h := getScheduler(t, hCfg, "S")
+	f := getScheduler(t, fCfg, "S")
+
+	hd, fd := schedDays(h), schedDays(f)
+	if len(hd) != len(fd) {
+		t.Fatalf("hierarchical vs flat day set diverged: %v vs %v", hd, fd)
+	}
+	for i := range hd {
+		if hd[i] != fd[i] {
+			t.Fatalf("hierarchical vs flat day set diverged: %v vs %v", hd, fd)
+		}
+		hw, fw := h.Days[hd[i]], f.Days[fd[i]]
+		if hw.StartTime != fw.StartTime || hw.StopTime != fw.StopTime ||
+			hw.AllDay != fw.AllDay || hw.Exclude != fw.Exclude {
+			t.Fatalf("day %s window diverged hierarchical vs flat: %+v vs %+v", hd[i], hw, fw)
+		}
+	}
+}
+
+// Cross-root: two SEPARATE top-level `schedulers {}` roots (each a distinct
+// compileSchedulers call) defining the same scheduler S must still merge — the
+// reused persisted map entry composes across roots. (Acceptance: "repeated
+// top-level roots".)
+func TestSchedulerAcrossRootsMergeDays_5825(t *testing.T) {
+	const src = `schedulers {
+    scheduler S {
+        monday {
+            start-time 08:00:00;
+            stop-time 12:00:00;
+        }
+    }
+}
+schedulers {
+    scheduler S {
+        wednesday {
+            start-time 10:00:00;
+            stop-time 18:00:00;
+        }
+    }
+}
+`
+	cfg := compileHier(t, src)
+	sc := getScheduler(t, cfg, "S")
+	if got := schedDays(sc); len(got) != 2 || got[0] != "monday" || got[1] != "wednesday" {
+		t.Fatalf("day windows across SEPARATE top-level schedulers roots must MERGE, got %v — #5825", got)
+	}
+	if sc.Days["monday"].StartTime != "08:00:00" || sc.Days["wednesday"].StartTime != "10:00:00" {
+		t.Fatalf("cross-root windows lost their times: %+v", sc.Days)
+	}
+}
+
+// A daily window plus a per-weekday override across two blocks both survive
+// (daily scalar + weekday list compose onto the reused scheduler).
+func TestSchedulerDailyPlusWeekdayMerge_5825(t *testing.T) {
+	const src = `schedulers {
+    scheduler S {
+        daily {
+            start-time 09:00:00;
+            stop-time 17:00:00;
+        }
+    }
+    scheduler S {
+        saturday {
+            all-day;
+        }
+    }
+}
+`
+	cfg := compileHier(t, src)
+	sc := getScheduler(t, cfg, "S")
+	if !sc.Daily || sc.StartTime != "09:00:00" || sc.StopTime != "17:00:00" {
+		t.Fatalf("block-1 daily window must survive the merge, got Daily=%v %s-%s",
+			sc.Daily, sc.StartTime, sc.StopTime)
+	}
+	if w := sc.Days["saturday"]; w == nil || !w.AllDay {
+		t.Fatalf("block-2 saturday all-day override must survive, got %+v", sc.Days["saturday"])
+	}
+}
+
+// Acceptance: a single block is unchanged — one scheduler, its days intact.
+func TestSchedulerSingleBlockUnchanged_5825(t *testing.T) {
+	const src = `schedulers {
+    scheduler Solo {
+        monday {
+            start-time 08:00:00;
+            stop-time 12:00:00;
+        }
+    }
+}
+`
+	cfg := compileHier(t, src)
+	sc := getScheduler(t, cfg, "Solo")
+	if got := schedDays(sc); len(got) != 1 || got[0] != "monday" {
+		t.Fatalf("single-block scheduler days changed: %v", got)
+	}
+	if w := sc.Days["monday"]; w == nil || w.StartTime != "08:00:00" || w.StopTime != "12:00:00" {
+		t.Fatalf("single-block monday window changed: %+v", sc.Days["monday"])
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1662,7 +1662,25 @@ func compileSchedulers(node *Node, cfg *Config) error {
 	}
 
 	for _, inst := range namedInstances(node.FindChildren("scheduler")) {
-		sched := &SchedulerConfig{Name: inst.name}
+		// #5825: REUSE the existing map entry instead of allocating a fresh
+		// SchedulerConfig per named AST instance. compileSchedulers runs once PER
+		// top-level `schedulers` root (compiler_dispatch.go) and once per named
+		// instance within a root; the pre-fix code built a fresh sched each time
+		// then unconditionally `cfg.Schedulers[name] = sched`, so a later same-name
+		// block/root REPLACED the first — every day/window authored earlier
+		// vanished. A policy time-gated by the scheduler then became active/inactive
+		// on the WRONG days with a clean commit. Flat `set` composes into ONE path,
+		// so hierarchical diverged from flat. Reusing the persisted entry composes
+		// every fragment: the weekday Days map (below) UNIONS distinct days across
+		// blocks/roots (no window lost), and the daily/date scalars follow
+		// flat-set / Junos load-merge last-wins (a repeated leaf replaces — no
+		// "conflict" arises in flat-set, so hierarchical must match). Mirrors the
+		// #5824 policy-statement block-merge.
+		sched := cfg.Schedulers[inst.name]
+		if sched == nil {
+			sched = &SchedulerConfig{Name: inst.name}
+			cfg.Schedulers[inst.name] = sched
+		}
 
 		for _, prop := range inst.node.Children {
 			name := prop.Name()
@@ -1707,8 +1725,9 @@ func compileSchedulers(node *Node, cfg *Config) error {
 				}
 			}
 		}
-
-		cfg.Schedulers[inst.name] = sched
+		// #5825: NO unconditional overwrite here — sched IS the shared map entry,
+		// so this instance's fragments are already composed into any earlier
+		// same-name block/root's days and scalars.
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes #5825. Same bug class as #5824 (policy-statement block-merge), in
the scheduler compiler.

`compileSchedulers` allocated a **fresh** `SchedulerConfig` per named AST
instance and did an unconditional `cfg.Schedulers[name] = sched`. A
scheduler authored across multiple hierarchical `schedulers scheduler S {
... }` blocks — or across two top-level `schedulers { ... }` roots — is a
distinct AST instance per fragment, so a later same-name block **replaced**
the earlier: every day/window authored earlier vanished. Flat `set
schedulers scheduler S <day> ...` composes under one path, so hierarchical
and flat diverged. A security policy time-gated by the scheduler then
became active/inactive on the **wrong days** with a clean commit.

## Fix (mirrors #5824)

Reuse the existing map entry instead of allocating fresh + overwriting:

```go
sched := cfg.Schedulers[inst.name]
if sched == nil {
    sched = &SchedulerConfig{Name: inst.name}
    cfg.Schedulers[inst.name] = sched
}
```

Every fragment composes onto one `SchedulerConfig`: distinct weekday
windows **union** across blocks and roots (the `Days` map lives on the
reused struct — no separate index needed, unlike policy-statement, because
the per-day map key **is** the dedup). The unconditional overwrite at the
end of the loop is removed.

## Conflicting-scalar decision

The daily/date scalars (`start-time`/`stop-time`/`start-date`/`stop-date`,
the `daily` window, `all-day`) follow **flat-set / Junos load-merge
last-wins** — a repeated leaf replaces, exactly as a second `set` of the
same leaf does. I deliberately did **not** make a conflicting scalar a hard
commit error: a "conflict" is not representable in flat-set (the last `set`
simply wins), and Junos `load merge` is itself last-wins for a scalar leaf,
so erroring would **reintroduce** the hierarchical-vs-flat divergence this
fix (and #5824) exists to remove. The security-relevant defect is the
**list** replacement (whole scheduler dropped), which the weekday union
resolves — no window is ever lost.

## Tests (`compiler_scheduler_block_merge_5825_test.go`)

- weekdays split across two hierarchical blocks all survive;
- hierarchical == flat-set parity (day set + each window);
- across separate top-level `schedulers {}` roots merge;
- daily + weekday compose across blocks;
- single-block unchanged.

**Fail-on-revert** (proven via `-overlay`): restoring the fresh-alloc +
unconditional overwrite makes the merge / parity / cross-root / daily tests
**RED** (only the last block's day survives) while single-block stays
green.

## Validation

- `go build ./...` clean
- `go vet ./pkg/config/` clean
- `go test -race ./pkg/config/ -run Scheduler` GREEN
- full `pkg/config` suite GREEN
- `docs/config-schema.md` gains a #5825 scheduler entry alongside the #5824
  policy-statement block-merge rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)