### PR TITLE
config: reject non-numeric logical unit id at commit (#5829)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48772,3 +48772,28 @@ top.
     missed — verified it now flags monitor.go:348 on revert.
   - **File(s)**: pkg/monitoriface/monitor.go, pkg/monitoriface/monitor_nil_5886_test.go,
     pkg/config/interface_nil_canary_5886_test.go
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5829 fail-closed non-numeric logical-unit id. `interfaces <if>
+    unit <identity>` had no positional key validation, so `unit tenant` passed
+    schema + commit and compileInterfaces silently DISCARDED the whole unit on
+    strconv failure — a unit-level firewall FILTER committed with no enforcement
+    (fail-open). Added one canonical validator config.ValidateLogicalUnit
+    (0..MaxLogicalUnit=16385: rejects non-numeric, negative, overflow,
+    out-of-range) and gated it at two layers: (1) schema — the `unit` node's
+    instance key now carries keyValidator ValidateLogicalUnit so commit/commit
+    check reject the malformed id naming the interface + token (flat-set +
+    hierarchical); (2) compiler — compiler_interfaces.go returns a hard error
+    instead of the bare continue; the tolerant load / peer-sync path
+    (new lenientNonNumericUnit opt on CompileConfigLenient /
+    CompileConfigForNodeLenient) warns + quarantines the unit instead (no silent
+    drop, no misattribution). Valid numeric units (incl. 0 and 16385) compile
+    bit-identically and reach ifc.Units. tunnelid.go's best-effort endpoint-name
+    union compiles leniently to preserve its pre-fix drop behavior.
+    Fail-on-revert proven via -overlay (revert gate + keyValidator → reject +
+    quarantine tests RED). RESIDUAL noted: cross-subsystem unit-reference slots
+    (CoS/zones/routing `.unit` suffix) still untyped — follow-up.
+  - **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_interfaces.go,
+    pkg/config/compiler.go, pkg/config/compiler_interfaces.go,
+    pkg/config/compiler_dispatch.go, pkg/config/tunnelid.go,
+    pkg/config/interface_unit_nonnumeric_5829_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -300,14 +300,54 @@ The gate is surgical: a single canonical `unit 0` (the overwhelming common case)
 and distinct unit numbers (`unit 0` + `unit 1`) never trip it, and same-spelling
 flat-set lines merge into one AST node upstream (they are the same unit, not an
 alias) — so non-colliding compilation is bit-identical. A non-numeric unit token
-is skipped (the compiler `continue`s on the identical Atoi error, so it never
-reaches `ifc.Units`). Where a duplicate-spelling config ALSO produces a
+is now REJECTED at commit rather than silently skipped (see the #5829 gate
+below). Where a duplicate-spelling config ALSO produces a
 pre-expansion tunnel-endpoint-id collision (#1873), that earlier gate rejects
 first — either way the aliased config is refused, never silently committed.
 Covered by `pkg/config/interface_unit_alias_5631_test.go` (both config orders
 reject identically = order-independent, lenient-warn, non-colliding-commits) and
 the reconciled `tunnelid_test.go` duplicate-spelling case, each RED on revert of
 the gate wiring.
+
+### Non-numeric logical-unit identity fail-closed (#5829)
+
+`interfaces <if> unit <identity>` had NO positional key validation: the `unit`
+schema node deliberately left its instance key untyped (deferred with the
+`vrrp-group <id>` class), and `compileInterfaces` parsed it with `strconv.Atoi`
+and a bare `continue` on error. So a non-numeric identity such as `unit tenant`
+passed schema + commit, and the compiler then **silently discarded the whole
+unit** — its addresses, firewall filters, sampling, DHCP/DDNS and tunnel state
+vanished with no diagnostic. The security bite: a unit-level input/output
+firewall FILTER committed with **no enforcement** (fail-open), the same class as
+the undefined-filter-reference gate.
+
+The fix is fail-CLOSED at two layers, both keyed to one canonical validator
+`ValidateLogicalUnit` (`schema_validators.go`, range `0..MaxLogicalUnit` = 16385
+— non-numeric, negative, integer overflow, and out-of-range all fail):
+
+- **Schema (strict commit/check):** the `unit` node carries
+  `keyValidator: ValidateLogicalUnit`, so `commit`/`commit check`
+  (`SchemaValidate`) reject a malformed identity naming the interface and the
+  raw token, for both the flat-set and hierarchical AST shapes (the shared
+  `validateKeySlot` path, same mechanism as the typed `address <cidr>` key).
+- **Compiler (defense-in-depth, all paths):** `compiler_interfaces.go` returns a
+  hard error instead of the bare `continue`. On the tolerant load / peer-sync
+  paths the `lenientNonNumericUnit` opt (set by `CompileConfigLenient` /
+  `CompileConfigForNodeLenient`) downgrades that to a `cfg.Warnings` entry and
+  **quarantines** the unit — dropped, its children never reattached to another
+  unit — so a config an older binary silently truncated still boots, now with a
+  deterministic warning instead of a silent drop.
+
+Valid numeric units (including the `0` and `16385` boundaries) compile
+bit-identically and reach the typed `ifc.Units` map. RESIDUAL: this pass types
+the `interfaces <if> unit <n>` slot; the cross-subsystem unit-reference grammar
+(class-of-service / security-zone / routing-instance interface references that
+carry a `.unit` suffix) still parses the suffix without this validator and is a
+follow-up (issue #5829 "every unit-reference slot"). Covered by
+`pkg/config/interface_unit_nonnumeric_5829_test.go` (strict reject via both
+gates naming the interface + token, valid-unit-reaches-map, lenient
+warn-and-quarantine), RED on revert of either the `keyValidator` or the compiler
+gate.
 
 ### security address-book same-name `address` + `address-set` collision (#5676)
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1863,6 +1863,22 @@ type compileOpts struct {
 	// lenientFirewallTCPFlags.
 	lenientCoSNumericCodePoint bool
 
+	// lenientNonNumericUnit (#5829) downgrades the malformed logical-unit
+	// identity gate (a non-numeric / negative / overflow `interfaces <if>
+	// unit <id>`) from a hard compile error to a cfg.Warnings entry with the
+	// offending unit quarantined (skipped, its children NOT reattached to any
+	// other unit). Strict commit / commit-check hard-reject so a unit-level
+	// firewall filter cannot commit and then silently vanish (fail-open). Set
+	// ONLY on the tolerant load / peer-sync paths (CompileConfigLenient /
+	// CompileConfigForNodeLenient) so a config an older binary already
+	// persisted — which silently dropped the bad unit — still BOOTS, now with
+	// a deterministic warning instead of a silent drop. Same doctrine as
+	// lenientCoSNumericCodePoint. Like the other lenient gates this is an
+	// AST-level compile decision the read-only SchemaValidate walk cannot make
+	// (and since #1319 PR 2 SchemaValidate violations only warn on tolerant
+	// paths anyway).
+	lenientNonNumericUnit bool
+
 	// nodeAware / stampNodeID (#4329) carry the runtime cluster node
 	// identity (from /etc/xpf/node-id, or `-node-id` on `xpfd
 	// check-config`) into compileExpanded so it can be stamped onto the
@@ -2013,6 +2029,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientEventWithinTrigger:              true,
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,
+		lenientNonNumericUnit:                  true,
 	})
 }
 
@@ -2367,6 +2384,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientEventWithinTrigger:              true,
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,
+		lenientNonNumericUnit:                  true,
 	})
 }
 

--- a/pkg/config/compiler_dispatch.go
+++ b/pkg/config/compiler_dispatch.go
@@ -36,7 +36,7 @@ func compileSections(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 				return fmt.Errorf("security: %w", err)
 			}
 		case "interfaces":
-			if err := compileInterfaces(node, &cfg.Interfaces); err != nil {
+			if err := compileInterfaces(node, &cfg.Interfaces, opts, &cfg.Warnings); err != nil {
 				return fmt.Errorf("interfaces: %w", err)
 			}
 		case "applications":

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -22,7 +22,7 @@ var vrrpGroupPropertyKeywords = map[string]bool{
 	"track-priority-cost": true,
 }
 
-func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
+func compileInterfaces(node *Node, ifaces *InterfacesConfig, opts compileOpts, warnings *[]string) error {
 	for _, child := range node.Children {
 		if child.IsLeaf {
 			continue
@@ -220,8 +220,29 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 
 		for _, unitInst := range namedInstances(child.FindChildren("unit")) {
 			unitNum, err := strconv.Atoi(unitInst.name)
-			if err != nil {
-				continue
+			if err != nil || unitNum < 0 || unitNum > MaxLogicalUnit {
+				// #5829: a non-numeric / negative / overflow / out-of-range
+				// logical-unit id is NOT a droppable no-op — every child
+				// (addresses, firewall filters, sampling, DHCP/DDNS, tunnel)
+				// carries security intent that would silently vanish (a
+				// unit-level filter would commit with no enforcement:
+				// fail-open). Fail CLOSED, mirroring the schema keyValidator
+				// (ValidateLogicalUnit) range. Strict compile hard-errors
+				// naming the interface + raw token; the tolerant load /
+				// peer-sync path (lenientNonNumericUnit) instead warns and
+				// QUARANTINES the unit — skipped here, its children never
+				// reattached to another unit — so an already-persisted config
+				// an older binary silently dropped still boots, now with a
+				// deterministic diagnostic.
+				msg := fmt.Sprintf("interfaces %s: logical unit %q must be an integer in 0..%d",
+					ifName, unitInst.name, MaxLogicalUnit)
+				if opts.lenientNonNumericUnit {
+					if warnings != nil {
+						*warnings = append(*warnings, msg)
+					}
+					continue
+				}
+				return fmt.Errorf("%s", msg)
 			}
 			unit := &InterfaceUnit{Number: unitNum}
 

--- a/pkg/config/interface_unit_nonnumeric_5829_test.go
+++ b/pkg/config/interface_unit_nonnumeric_5829_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5829: `interfaces <if> unit <identity>` had NO positional key validation.
+// A non-numeric identity such as `unit tenant` passed schema + commit, and
+// compileInterfaces then SILENTLY DISCARDED the whole unit on strconv failure
+// (bare `continue`) — every child (addresses, firewall filters, sampling,
+// DHCP/DDNS, tunnel) vanished with no diagnostic. Security bite: a unit-level
+// input/output firewall FILTER committed with NO enforcement (fail-open).
+//
+// The fix is fail-CLOSED at two layers:
+//   - schema: the `unit` instance key is typed (keyValidator ValidateLogicalUnit)
+//     so `commit`/`commit check` (SchemaValidate) reject the malformed identity;
+//   - compiler: compiler_interfaces.go returns a hard error (strict) / warns +
+//     quarantines the unit (tolerant load / peer-sync) instead of the bare
+//     `continue` — defense-in-depth for any path that bypasses SchemaValidate.
+//
+// Flat-set MUST be built with ParseSetCommand/SetPath (flatTreeFromSets), never
+// NewParser (CLAUDE.md "Testing flat set syntax").
+//
+// FAIL-ON-REVERT: restore the bare `if err != nil { continue }` at
+// compiler_interfaces.go AND drop `keyValidator: ValidateLogicalUnit` from the
+// schema unit node → the malformed configs compile clean (filter dropped) and
+// SchemaValidate accepts them → the reject assertions below go RED.
+
+// TestUnit5829_MalformedRejectedAtCommit proves a non-numeric / negative /
+// overflow / out-of-range logical unit is hard-rejected at strict commit by
+// BOTH the schema gate and the compiler gate, naming the interface + bad token.
+func TestUnit5829_MalformedRejectedAtCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		want string // substring expected in the error (the bad raw token)
+	}{
+		{
+			// The exact security fail-open: a unit-level firewall filter under a
+			// non-numeric unit. Before the fix this committed with no enforcement.
+			name: "non-numeric unit carrying a firewall filter",
+			cmds: []string{"set interfaces ge-0-0-0 unit tenant family inet filter input FOO"},
+			want: `"tenant"`,
+		},
+		{
+			name: "non-numeric unit carrying an address",
+			cmds: []string{"set interfaces ge-0-0-0 unit foo family inet address 10.0.1.1/24"},
+			want: `"foo"`,
+		},
+		{
+			name: "negative unit",
+			cmds: []string{"set interfaces ge-0-0-0 unit -1 family inet address 10.0.1.1/24"},
+			want: `"-1"`,
+		},
+		{
+			name: "integer-overflow unit",
+			cmds: []string{"set interfaces ge-0-0-0 unit 99999999999999999999 family inet address 10.0.1.1/24"},
+			want: `"99999999999999999999"`,
+		},
+		{
+			name: "out-of-range unit (> MaxLogicalUnit)",
+			cmds: []string{"set interfaces ge-0-0-0 unit 16386 family inet address 10.0.1.1/24"},
+			want: `"16386"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, tc.cmds...)
+
+			// Primary gate: schema keyValidator at commit-check.
+			if err := SchemaValidate(tree, nil); err == nil {
+				t.Fatalf("SchemaValidate accepted malformed unit; want commit rejection")
+			} else if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("SchemaValidate error must name the bad unit token %s: %v", tc.want, err)
+			}
+
+			// Defense-in-depth: compiler hard error (also covers any bypass of
+			// SchemaValidate). Must NOT be a clean compile that drops the unit.
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted malformed unit (silent drop / fail-open); want reject")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("CompileConfig error must name the bad unit token %s: %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "ge-0-0-0") {
+				t.Fatalf("error must name the interface: %v", err)
+			}
+		})
+	}
+}
+
+// TestUnit5829_ValidUnitCompilesFilterReachesMap guards against a false-reject:
+// a valid numeric unit (including the max boundary) with the SAME filter must
+// compile identically and the filter must reach the typed map.
+func TestUnit5829_ValidUnitCompilesFilterReachesMap(t *testing.T) {
+	// FOO must be a defined filter (an undefined-filter reference is itself a
+	// separate fail-open gate); the point here is the unit + its filter binding
+	// survive compilation into the typed map.
+	def := "set firewall family inet filter FOO term t1 then accept"
+	cases := []struct {
+		cmds    []string
+		wantNum int
+	}{
+		{[]string{def, "set interfaces ge-0-0-0 unit 0 family inet filter input FOO"}, 0},
+		// Max-boundary unit remains accepted.
+		{[]string{def, "set interfaces ge-0-0-0 unit 16385 family inet filter input FOO"}, 16385},
+	}
+	for _, tc := range cases {
+		tree := flatTreeFromSets(t, tc.cmds...)
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("SchemaValidate rejected a valid unit %d: %v", tc.wantNum, err)
+		}
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig rejected a valid unit %d: %v", tc.wantNum, err)
+		}
+		ifc := cfg.Interfaces.Interfaces["ge-0-0-0"]
+		if ifc == nil {
+			t.Fatalf("interface ge-0-0-0 missing after compiling unit %d", tc.wantNum)
+		}
+		unit, ok := ifc.Units[tc.wantNum]
+		if !ok || unit == nil {
+			t.Fatalf("valid unit %d not in the typed map: units=%v", tc.wantNum, ifc.Units)
+		}
+		if unit.FilterInputV4 != "FOO" {
+			t.Fatalf("unit %d filter did not reach the typed map: got %q, want FOO", tc.wantNum, unit.FilterInputV4)
+		}
+	}
+}
+
+// TestUnit5829_LenientWarnsAndQuarantines proves the tolerant load / peer-sync
+// path (CompileConfigLenient) does NOT hard-error and does NOT silently drop:
+// it emits a deterministic warning naming the interface + bad token, and the
+// malformed unit's filter is quarantined (never reattached to another unit).
+func TestUnit5829_LenientWarnsAndQuarantines(t *testing.T) {
+	tree := flatTreeFromSets(t, "set interfaces ge-0-0-0 unit tenant family inet filter input FOO")
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a malformed unit (want warn): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "tenant") && strings.Contains(w, "ge-0-0-0") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile produced no malformed-unit warning; got %v", cfg.Warnings)
+	}
+	// Quarantine: the malformed unit's filter must NOT have leaked onto any
+	// unit (in particular it must not be silently misattributed to unit 0).
+	if ifc := cfg.Interfaces.Interfaces["ge-0-0-0"]; ifc != nil {
+		for num, u := range ifc.Units {
+			if u != nil && u.FilterInputV4 == "FOO" {
+				t.Fatalf("malformed unit's filter leaked onto unit %d (want quarantined): %+v", num, u)
+			}
+		}
+	}
+}

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -11,13 +11,17 @@ package config
 // changes, ranges derived from what the runtime actually consumes
 // (cited per leaf). The `address` nodes use the typed-KEY-slot
 // feature (keyValidator) because their value is a named-instance
-// identity token, not a leaf value. Deliberately NOT typed:
-// `unit <n>` / `vrrp-group <id>` instance ids (same deferral class
-// as the chassis PR-2 redundancy-group/node ids: garbage ids make
-// the compiler silently drop the instance, but these ids are
-// cross-referenced from other subsystems — e.g. class-of-service
-// `interfaces <if> unit <n>` — and deserve one dedicated pass that
-// types every referencing slot together). NOTE (#4573): the SCHEMA
+// identity token, not a leaf value. The `unit <n>` instance key is
+// ALSO typed now (keyValidator ValidateLogicalUnit, #5829): a
+// non-numeric / negative / overflow / out-of-range unit id made the
+// compiler SILENTLY DROP the whole unit — including its firewall
+// filters (a security fail-open) — so it is rejected at commit here
+// plus defense-in-depth in the compiler. Deliberately still NOT typed:
+// `vrrp-group <id>` instance ids (same deferral class as the chassis
+// PR-2 redundancy-group/node ids: garbage ids make the compiler
+// silently coerce/drop the instance, but these ids are cross-referenced
+// from other subsystems and their range is backstopped by a semantic
+// commit gate — see below). NOTE (#4573): the SCHEMA
 // deferral above is only safe for NON-numeric garbage; an
 // OUT-OF-RANGE NUMERIC `vrrp-group <id>` is bounded by a semantic
 // commit gate on the compiled *Config — `validateVRRPGroupIDStrict`
@@ -83,7 +87,13 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 		"member-interfaces": {desc: "Member interfaces", children: nil},
 	}},
 	"tunnel": {desc: "Tunnel parameters", children: tunnelSchemaChildren()},
-	"unit": {desc: "Logical unit number", args: 1, valueHint: ValueHintUnitNumber, placeholder: "<unit-number>", children: map[string]*schemaNode{
+	// #5829: the unit instance key is a NUMERIC identity token — type it so
+	// `commit`/`commit check` reject a non-numeric / negative / overflow /
+	// out-of-range `unit <n>` naming the bad value, instead of the compiler
+	// silently discarding the unit (and its firewall filters) later. keyValidator
+	// alone gates the identity arg (schema_walk validateKeySlot); valueHint stays
+	// for dynamic unit-number completion.
+	"unit": {desc: "Logical unit number", args: 1, valueHint: ValueHintUnitNumber, placeholder: "<unit-number>", keyValidator: ValidateLogicalUnit, children: map[string]*schemaNode{
 		"description":    {desc: "Text description", args: 1, scalar: true, placeholder: "<text>", children: nil},
 		"point-to-point": {desc: "Point-to-point interface", children: nil},
 		// 802.1Q VID is a 12-bit wire field: 0 is the compiler's

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -138,6 +138,25 @@ func ValidateInteger(min, max int64) LeafValidator {
 	}
 }
 
+// MaxLogicalUnit is the logical `unit <n>` ceiling: Junos accepts a logical
+// unit number of 0 through 16385 and the runtime keys
+// InterfaceConfig.Units by this int (#5829).
+const MaxLogicalUnit = 16385
+
+// ValidateLogicalUnit is the ONE canonical numeric-identity validator for a
+// logical `unit <n>` slot (#5829). A `unit <identity>` slot has no positional
+// key validation, so a non-numeric identity such as `unit tenant` passed
+// schema + commit and the compiler then SILENTLY DISCARDED the whole unit on
+// strconv failure — dropping the unit's addresses, firewall filters, sampling,
+// DHCP/DDNS and tunnel state with no diagnostic (a security fail-open: a
+// unit-level firewall filter commits with no enforcement). Reject the malformed
+// identity at commit instead: non-numeric, negative, integer overflow, and
+// out-of-range [0..MaxLogicalUnit] all fail here. Reuse this on every slot that
+// names an interface unit so the grammar stays consistent across subsystems.
+func ValidateLogicalUnit(raw string, cfg *Config) error {
+	return ValidateInteger(0, MaxLogicalUnit)(raw, cfg)
+}
+
 // validatePercent returns a closure that accepts a real number in
 // [min, max] inclusive. The input must parse as a float.
 func ValidatePercent(min, max float64) LeafValidator {

--- a/pkg/config/tunnelid.go
+++ b/pkg/config/tunnelid.go
@@ -186,7 +186,12 @@ func emitNodeExpandedTunnelNames(tree *ConfigTree, nodeID int, out map[string]st
 	}
 	ifaces := InterfacesConfig{Interfaces: make(map[string]*InterfaceConfig)}
 	for _, ifacesNode := range ifacesNodes {
-		if err := compileInterfaces(ifacesNode, &ifaces); err != nil {
+		// #5829: this is the best-effort tunnel-endpoint-name UNION used for
+		// ID allocation, not a commit gate — compile leniently so a malformed
+		// `unit <id>` is quarantined (dropped from the union, no hard error)
+		// exactly as the pre-#5829 bare-continue did. The strict commit path
+		// (compileSections) still hard-rejects the same config.
+		if err := compileInterfaces(ifacesNode, &ifaces, compileOpts{lenientNonNumericUnit: true}, nil); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
## Problem

`interfaces <if> unit <identity>` had **no positional key validation**. A non-numeric identity such as `unit tenant` passed schema + commit, and `compileInterfaces` then **silently discarded the whole unit** on the `strconv.Atoi` error (a bare `continue`). Every child — addresses, firewall filters, sampling, DHCP/DDNS, tunnel — vanished from the compiled `Config` with no diagnostic. Security bite: a unit-level input/output firewall **FILTER committed with no enforcement** (fail-open).

Trace: `schema_interfaces.go` left the unit key untyped; `compiler_interfaces.go:221-225` did `Atoi` + bare `continue`.

## Fix — fail CLOSED at two layers

One canonical validator `config.ValidateLogicalUnit` (`0..MaxLogicalUnit`=16385; rejects non-numeric, negative, integer overflow, out-of-range):

- **Schema (strict commit/check):** the `unit` node carries `keyValidator: ValidateLogicalUnit`, so `commit`/`commit check` (`SchemaValidate`) reject the malformed identity naming the interface + raw token, for **both** flat-set and hierarchical AST shapes (shared `validateKeySlot`, same mechanism as the typed `address <cidr>` key).
- **Compiler (defense-in-depth, all paths):** `compiler_interfaces.go` returns a hard error instead of the bare `continue`. The tolerant load / peer-sync paths (new `lenientNonNumericUnit` opt on `CompileConfigLenient` / `CompileConfigForNodeLenient`) downgrade to a `cfg.Warnings` entry and **quarantine** the unit — dropped, children never reattached to another unit — so a config an older binary silently truncated still boots, now with a deterministic warning instead of a silent drop.

Valid numeric units (incl. the `0` and `16385` boundaries) compile bit-identically and reach `ifc.Units`. `tunnelid.go`'s best-effort endpoint-name union compiles leniently to preserve its pre-fix drop behavior.

**Residual:** this pass types the `interfaces <if> unit <n>` slot. Cross-subsystem unit-reference grammar (CoS / security-zone / routing-instance `.unit` suffix) is a follow-up.

## Tests

`interface_unit_nonnumeric_5829_test.go` — strict reject via **both** gates naming the interface + token (non-numeric / negative / overflow / out-of-range); valid-unit-reaches-map (0 and 16385); lenient warn-and-quarantine. Proven **RED on revert** of either the `keyValidator` or the compiler gate (via `-overlay`).

## Validation

`go build ./...` clean; `go vet ./pkg/config/` clean; `go test -race ./pkg/config/ -run 'Interface|Unit|Schema'` green; full `go test ./pkg/config/` green; `./pkg/configstore/` green. Frozen `tunnelid_test.go` overflow-unit + leading-zero collision tests still pass.

Closes #5829

🤖 Generated with [Claude Code](https://claude.com/claude-code)