### PR TITLE
dhcpserver: read the full Kea LFC file set for leases

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48797,3 +48797,32 @@ top.
     pkg/config/compiler.go, pkg/config/compiler_interfaces.go,
     pkg/config/compiler_dispatch.go, pkg/config/tunnelid.go,
     pkg/config/interface_unit_nonnumeric_5829_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5796 Kea LFC file-set lease read. All three dhcpserver memfile
+    consumers (DDNS `parseActiveLeases4/6`, display `parseLeaseCSV`, HA fallback
+    `readSyncLeasesViaMemfile`) opened ONLY the current `kea-leases{4,6}.csv`,
+    which after Lease File Cleanup starts is just the new append log — the active
+    set spans Kea's LFC file set. A header-only current file right after LFC
+    rotation was read as trusted-empty and the DDNS reconciler would MASS-DELETE
+    every owned A/AAAA/PTR (fail-open). Added ONE shared enumerator
+    `keaLFCLeaseFilePaths` (lease_lfc.go) returning the set in Kea CHRONOLOGICAL
+    order PREVIOUS(.2) -> INPUT(.1) -> CURRENT and refactored both parsers to a
+    per-file helper + accumulator so rows replay through the SAME append-only
+    last-row-wins dedup across files (newer supersedes older; release/expiry
+    tombstones survive). Suffix mapping verified against Kea source
+    memfile_lease_mgr.cc appendSuffix (.1=INPUT, .2=PREVIOUS) — the team-lead's
+    dispatch note had them swapped; the read ORDER (previous, then input, then
+    current) is unchanged. Fail-safe preserved+extended: any existing mangled
+    sibling makes the whole family untrusted; trusted-empty only when all files
+    validate and the merged set is empty; no-LFC steady state (.1/.2 absent) is
+    byte-identical to before. Fail-on-revert proven via -overlay: single-file
+    read -> union/display/fail-closed tests RED; reversed merge order ->
+    order test RED (resurrected released lease). go build ./... + vet +
+    -race dhcpserver/ddns green. RESIDUAL (issue invariants 2/3/8, follow-up):
+    no live lease_cmds socket preference in every consumer, no
+    crash-interrupted-cleanup generation proof, no degraded-source display
+    banner.
+  - **File(s)**: pkg/dhcpserver/lease_lfc.go (new),
+    pkg/dhcpserver/lease_lfc_5796_test.go (new), pkg/dhcpserver/ddns_leases.go,
+    pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/README.md

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -384,6 +384,39 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   destructive-delete class is now closed at BOTH the header level (required
   columns present, each once, no duplicates) and the row level (every data
   row long enough to supply every required column).
+- **Kea LFC file-set snapshot (#5796)** — Kea never rewrites the memfile in
+  place; it APPENDS every renewal/release/decline/reclaim and periodically runs
+  Lease File Cleanup (`kea-lfc`) to compact the log. During and after a cleanup
+  the live lease set is NOT the current file alone — it spans Kea's LFC file
+  set. For a current lease file `<f>` (authoritative from Kea src
+  `memfile_lease_mgr.cc appendSuffix` / `LFCFileType`): `<f>.1` is the INPUT file
+  (the current file the server moves aside at the START of a cleanup) and
+  `<f>.2` is the PREVIOUS file (the COMPACTED result of the last COMPLETED
+  cleanup, one row per active lease); `.output`/`.completed`/`.pid` are kea-lfc
+  scratch/markers with no lease union and are ignored. Reading only `<f>` LOST
+  every lease living in `.2`/`.1`: right after LFC rotates the current file it
+  is a fresh, often header-only append log while the active leases sit in the
+  compacted previous file — so a valid header-only current file wrongly read as
+  a trusted-empty set would authorize the DDNS reconciler to MASS-DELETE every
+  owned A/AAAA/PTR (fail-open). BOTH the destructive `parseActiveLeases4/6` and
+  the display `parseLeaseCSV` now read the whole set via the one shared
+  `keaLFCLeaseFilePaths` (`lease_lfc.go`) in Kea CHRONOLOGICAL order — PREVIOUS
+  (`.2`) → INPUT (`.1`) → CURRENT (`<f>`), oldest first — and replay the rows
+  through the SAME append-only, last-row-wins dedup, so a newer row in the input
+  or current file supersedes an older row in previous and a release/expiry row
+  still tombstones a lease a later re-allocation reclaims. A missing `.1`/`.2`
+  (the common no-LFC steady state) collapses the set to exactly the current file
+  (byte-identical to the pre-#5796 read). The fail-safe posture is preserved and
+  EXTENDED across the set: any EXISTING sibling that is headerless / mangled /
+  ragged makes the WHOLE family untrusted (error → destructive diff skipped),
+  and the trusted-empty result is returned only when every existing file in the
+  set validates AND the merged active set is empty. `readSyncLeasesViaMemfile`
+  (the HA lease-sync fallback) inherits the union through `parseActiveLeases`.
+  RESIDUAL (deferred to a follow-up, tracked on #5796): this reads the on-disk
+  LFC set coherently for the common phases, but does not yet prefer the live
+  `lease_cmds` control socket over the journal in every consumer, nor
+  crash-interrupted-cleanup generation proofs (`.output`/`.completed` mid-move),
+  nor a degraded-source banner on the display surfaces (issue invariants 2/3/8).
 - **Hostname normalization** — `deriveFQDN` / `finalizeFQDN`
   (`ddns_hostname.go`) ALWAYS contains the published name in the configured
   zone: the client picks the host part, the firewall picks the domain. A

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -123,13 +123,82 @@ func parseActiveLeases6(path string, now time.Time) ([]ddnsLease, error) {
 	return parseActiveLeases(path, 6, now)
 }
 
+// ddnsLeaseAccum accumulates the append-only, last-row-wins disposition per
+// address ACROSS the Kea LFC file set (#5796). A non-empty ddnsLease.Address is
+// an active lease to publish; a zero value is a tombstone (the last row seen for
+// that address, in chronological file+row order, was inactive/expired). order
+// preserves first-appearance for a stable output.
+type ddnsLeaseAccum struct {
+	latest  map[string]ddnsLease
+	order   []string
+	inOrder map[string]struct{}
+}
+
+func newDDNSLeaseAccum() *ddnsLeaseAccum {
+	return &ddnsLeaseAccum{
+		latest:  map[string]ddnsLease{},
+		inOrder: map[string]struct{}{},
+	}
+}
+
+func (a *ddnsLeaseAccum) note(addr string) {
+	if _, ok := a.inOrder[addr]; !ok {
+		a.inOrder[addr] = struct{}{}
+		a.order = append(a.order, addr)
+	}
+}
+
+// parseActiveLeases reads the Kea memfile lease set for `family` and returns
+// only the active leases. `path` is the CURRENT lease file; #5796: it reads the
+// FULL Kea LFC file set (previous `.2`, input `.1`, current) via
+// keaLFCLeaseFilePaths in chronological order and MERGES them with the same
+// append-only, last-row-wins dedup Kea itself uses, so a lease that currently
+// lives only in the compacted PREVIOUS or INPUT file (e.g. right after LFC
+// rotated a fresh header-only current file) is NOT lost and a header-only
+// current file cannot by itself trigger the destructive DDNS trusted-empty path.
+//
+// The #1387/Codex fail-safe is preserved and EXTENDED across the set: any
+// EXISTING file that is headerless / mangled-header / ragged makes the whole
+// family untrusted (error → Reconcile SKIPS the destructive diff). Trusted-empty
+// (nil, nil) is returned only when every existing file in the set validates AND
+// the merged active set is empty — a genuinely-missing `.1`/`.2`/current file
+// (os.IsNotExist) simply contributes nothing.
 func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, error) {
+	acc := newDDNSLeaseAccum()
+	for _, f := range keaLFCLeaseFilePaths(path) {
+		if err := parseActiveLeasesFileInto(f, family, now, acc); err != nil {
+			return nil, err
+		}
+	}
+	out := make([]ddnsLease, 0, len(acc.order))
+	for _, addr := range acc.order {
+		l, ok := acc.latest[addr]
+		if !ok || l.Address == "" {
+			continue // tombstoned by the FINAL inactive/expired row across the set
+		}
+		out = append(out, l)
+	}
+	if len(out) == 0 {
+		// Trusted-empty: every existing file in the set validated (no error
+		// above) and the merged active set is empty. Return nil (not a
+		// non-nil empty slice) to match the pre-#5796 os.IsNotExist /
+		// header-only trusted-empty contract the DDNS reconciler relies on.
+		return nil, nil
+	}
+	return out, nil
+}
+
+// parseActiveLeasesFileInto parses ONE Kea LFC-set file into acc, applying the
+// per-file fail-safe validation. A genuinely-missing file is skipped (nil
+// error). An EXISTING file that is anomalous (headerless / mangled header /
+// ragged row) returns an error so the whole family is treated as untrusted.
+func parseActiveLeasesFileInto(path string, family int, now time.Time, acc *ddnsLeaseAccum) error {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil
 		}
-		return nil, err
+		return err
 	}
 	defer f.Close()
 
@@ -138,7 +207,7 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	r.Comment = '#'
 	records, err := r.ReadAll()
 	if err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
+		return fmt.Errorf("parse %s: %w", path, err)
 	}
 
 	// Fail-safe (#1387 + Codex r4): the trusted-empty result (nil, nil) is
@@ -163,7 +232,7 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	//      healthy header + no active rows genuinely means "no active
 	//      leases", and clearing owned DNS records is then correct.
 	if len(records) == 0 {
-		return nil, fmt.Errorf("parse %s: Kea %s lease file has no header (anomalous: mid-write or corrupt)",
+		return fmt.Errorf("parse %s: Kea %s lease file has no header (anomalous: mid-write or corrupt)",
 			path, familyLabel(family))
 	}
 
@@ -187,7 +256,7 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	for i, h := range records[0] {
 		key := strings.ToLower(strings.TrimSpace(h))
 		if _, dup := cols[key]; dup {
-			return nil, fmt.Errorf("parse %s: duplicate column %q in Kea %s lease header (ambiguous)",
+			return fmt.Errorf("parse %s: duplicate column %q in Kea %s lease header (ambiguous)",
 				path, key, familyLabel(family))
 		}
 		cols[key] = i
@@ -214,7 +283,7 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		}
 	}
 	if len(missing) > 0 {
-		return nil, fmt.Errorf("parse %s: missing required column(s) %v in Kea %s lease header",
+		return fmt.Errorf("parse %s: missing required column(s) %v in Kea %s lease header",
 			path, missing, familyLabel(family))
 	}
 
@@ -240,32 +309,25 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	}
 
 	// Header is present AND valid. A file with only a header (zero data rows)
-	// is now a LEGITIMATE trusted zero-lease result — return early before the
-	// per-row loop so a genuinely-empty Kea correctly clears owned records.
+	// is a LEGITIMATE trusted zero-lease contribution — return before the
+	// per-row loop, adding nothing to acc, so a genuinely-empty file in the LFC
+	// set contributes no leases (and, alone, correctly clears owned records).
 	if len(records) < 2 {
-		return nil, nil
+		return nil
 	}
 
 	// Kea appends rows; the LAST row for an address is authoritative (lease
-	// renewal / state change). We keep the last seen row per address and
-	// emit in first-appearance order. The map value carries the row's final
-	// disposition: a non-empty Address is an active lease to publish, an
-	// empty (zero) value is a tombstone (the last row was inactive/expired)
-	// and is filtered from the output. CRITICAL (#1387 MAJOR-3): an active
-	// row must be able to RECLAIM an address that an earlier row tombstoned
-	// (declined/expired/reclaimed then re-allocated), so we recompute the
-	// disposition on every row and ensure the address is recorded in `order`
-	// whenever it first appears, tombstone or not. Output order is stable;
-	// the tombstone filter at emit time is what drops still-inactive ones.
-	latest := map[string]ddnsLease{}
-	order := []string{}
-	inOrder := map[string]struct{}{}
-	noteAddr := func(addr string) {
-		if _, ok := inOrder[addr]; !ok {
-			inOrder[addr] = struct{}{}
-			order = append(order, addr)
-		}
-	}
+	// renewal / state change). We keep the last seen row per address (across
+	// the whole LFC file set, via acc) and emit in first-appearance order. The
+	// map value carries the row's final disposition: a non-empty Address is an
+	// active lease to publish, an empty (zero) value is a tombstone (the last
+	// row was inactive/expired) and is filtered from the output. CRITICAL
+	// (#1387 MAJOR-3): an active row must be able to RECLAIM an address that an
+	// earlier row tombstoned (declined/expired/reclaimed then re-allocated), so
+	// we recompute the disposition on every row and ensure the address is
+	// recorded in acc.order whenever it first appears, tombstone or not. Output
+	// order is stable; the tombstone filter at emit time drops still-inactive
+	// ones.
 	for rowNum, fields := range records[1:] {
 		// Row-conformance (Codex r6): a row too short to supply every
 		// required column cannot be read reliably. Treat the whole family's
@@ -276,14 +338,14 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		// 0-based over the data rows (records[1:]); +2 gives the 1-based file
 		// line number including the header.
 		if len(fields) <= maxRequiredIdx {
-			return nil, fmt.Errorf("parse %s: Kea %s lease row %d has %d field(s), too short for required columns (need > %d; ragged/truncated source)",
+			return fmt.Errorf("parse %s: Kea %s lease row %d has %d field(s), too short for required columns (need > %d; ragged/truncated source)",
 				path, familyLabel(family), rowNum+2, len(fields), maxRequiredIdx)
 		}
 		addr := get(fields, "address")
 		if addr == "" {
 			continue
 		}
-		noteAddr(addr)
+		acc.note(addr)
 
 		// State filter: only "default" (active) rows are publishable;
 		// declined / expired-reclaimed rows must NOT have DNS records.
@@ -293,8 +355,8 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 			if st, e := strconv.Atoi(s); e == nil && st != keaStateDefault {
 				// A non-default state for an address supersedes any earlier
 				// row for it: write a tombstone (the address stays in
-				// `order` so a LATER active row can reclaim it).
-				latest[addr] = ddnsLease{}
+				// acc.order so a LATER active row can reclaim it).
+				acc.latest[addr] = ddnsLease{}
 				continue
 			}
 		}
@@ -309,7 +371,7 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		// stale regardless of state column lag. Tombstone it (a later
 		// active row with a future expire can still reclaim the address).
 		if expire > 0 && now.Unix() >= expire {
-			latest[addr] = ddnsLease{}
+			acc.latest[addr] = ddnsLease{}
 			continue
 		}
 
@@ -347,18 +409,10 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		} else {
 			l.Identity = identity4(get(fields, "client_id"), get(fields, "hwaddr"))
 		}
-		latest[addr] = l
+		acc.latest[addr] = l
 	}
 
-	out := make([]ddnsLease, 0, len(order))
-	for _, addr := range order {
-		l, ok := latest[addr]
-		if !ok || l.Address == "" {
-			continue // tombstoned by the FINAL inactive/expired row
-		}
-		out = append(out, l)
-	}
-	return out, nil
+	return nil
 }
 
 // leaseColumnValue looks up a field by header name, CASE-INSENSITIVELY. It

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -505,8 +505,11 @@ func (m *Manager) GetLeases6() ([]Lease, error) {
 	return parseLeaseCSV(m.leaseFile(6), time.Now())
 }
 
-// parseLeaseCSV parses Kea's append-only memfile CSV and returns the
-// CURRENT, ACTIVE leases for display (`show dhcp server leases`).
+// parseLeaseCSV parses Kea's append-only memfile CSV set and returns the
+// CURRENT, ACTIVE leases for display (`show dhcp server leases`). #5796: it
+// reads the FULL Kea LFC file set (previous `.2`, input `.1`, current) and
+// merges them, so the display never omits the compacted active leases that live
+// in the previous/input files right after an LFC rotation.
 //
 // Kea never rewrites the memfile in place between lease-file-cleanup
 // (LFC) compactions: every renewal, re-allocation, release, decline,
@@ -529,13 +532,55 @@ func (m *Manager) GetLeases6() ([]Lease, error) {
 // pre-#2085 behaviour for older Kea or exotic headers rather than
 // blanking the whole `show` on one odd row. now is injected so the
 // expiry comparison is deterministic in tests.
+// leaseCSVAccum accumulates the lenient last-row-wins display disposition per
+// address ACROSS the Kea LFC file set (#5796). A zero Lease (empty Address) is a
+// TOMBSTONE meaning the last row seen for that address (in chronological
+// file+row order) was inactive/expired. order keeps first-appearance order so
+// the display is stable and deterministic.
+type leaseCSVAccum struct {
+	latest map[string]Lease
+	order  []string
+	seen   map[string]struct{}
+}
+
 func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
+	acc := &leaseCSVAccum{
+		latest: make(map[string]Lease),
+		seen:   make(map[string]struct{}),
+	}
+	// #5796: read the whole Kea LFC file set (previous .2 → input .1 → current)
+	// in chronological order and merge, so `show dhcp server leases` does not
+	// omit the compacted active set that lives in the previous/input files right
+	// after an LFC rotation. A missing .1/.2 (the common no-LFC case) collapses
+	// the set to exactly the current file, byte-identical to the pre-#5796 read.
+	for _, f := range keaLFCLeaseFilePaths(path) {
+		if err := parseLeaseCSVFileInto(f, now, acc); err != nil {
+			return nil, err
+		}
+	}
+
+	leases := make([]Lease, 0, len(acc.order))
+	for _, addr := range acc.order {
+		if l := acc.latest[addr]; l.Address != "" {
+			leases = append(leases, l)
+		}
+	}
+	if len(leases) == 0 {
+		return nil, nil
+	}
+	return leases, nil
+}
+
+// parseLeaseCSVFileInto reads ONE Kea LFC-set file into acc using the lenient
+// display semantics. A genuinely-missing file is skipped (nil); a
+// non-IsNotExist open error is returned so the display surfaces it.
+func parseLeaseCSVFileInto(path string, now time.Time, acc *leaseCSVAccum) error {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil
 		}
-		return nil, err
+		return err
 	}
 	defer f.Close()
 
@@ -559,7 +604,8 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 
 	// cols maps header name -> column index; it stays nil until the
 	// first successful record (the header) is read. field() reads a named
-	// column out of a data row.
+	// column out of a data row. cols is FILE-LOCAL: each LFC-set file
+	// carries its own header.
 	var cols map[string]int
 	field := func(fields []string, name string) string {
 		if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
@@ -567,16 +613,6 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 		}
 		return ""
 	}
-
-	// latest holds the final disposition per address; a zero Lease
-	// (empty Address) is a TOMBSTONE meaning the last row for that
-	// address was inactive/expired. order keeps first-appearance order
-	// so the display is stable and deterministic. Re-recording the
-	// disposition on every row lets a later active append RECLAIM an
-	// address an earlier row tombstoned (release-then-reallocate).
-	latest := make(map[string]Lease)
-	order := make([]string, 0)
-	seen := make(map[string]struct{})
 	nowUnix := now.Unix()
 
 	for {
@@ -597,7 +633,9 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 		}
 		if cols == nil {
 			// First successful record is the header; build the column
-			// index map and move on (mirrors the old records[0]).
+			// index map and move on (mirrors the old records[0]). A file
+			// with no header at all contributes nothing (the lenient
+			// display never errors on it).
 			cols = make(map[string]int, len(fields))
 			for i, h := range fields {
 				cols[h] = i
@@ -609,9 +647,9 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 		if addr == "" {
 			continue
 		}
-		if _, ok := seen[addr]; !ok {
-			seen[addr] = struct{}{}
-			order = append(order, addr)
+		if _, ok := acc.seen[addr]; !ok {
+			acc.seen[addr] = struct{}{}
+			acc.order = append(acc.order, addr)
 		}
 
 		// State filter (lenient): only Kea's default state (0 = active)
@@ -622,7 +660,7 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 		// active append can still reclaim it.
 		if s := field(fields, "state"); s != "" {
 			if st, e := strconv.Atoi(s); e == nil && st != 0 {
-				latest[addr] = Lease{}
+				acc.latest[addr] = Lease{}
 				continue
 			}
 		}
@@ -633,12 +671,12 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 		expireStr := field(fields, "expire")
 		if expireStr != "" {
 			if exp, e := strconv.ParseInt(expireStr, 10, 64); e == nil && exp > 0 && nowUnix >= exp {
-				latest[addr] = Lease{}
+				acc.latest[addr] = Lease{}
 				continue
 			}
 		}
 
-		latest[addr] = Lease{
+		acc.latest[addr] = Lease{
 			Address:    addr,
 			HWAddress:  field(fields, "hwaddr"),
 			Hostname:   field(fields, "hostname"),
@@ -648,24 +686,7 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 		}
 	}
 
-	if cols == nil {
-		// No header row was ever read (empty file, comment-only file, or
-		// a file whose only line was malformed). Mirrors the old
-		// len(records) < 2 ⇒ nil,nil guard. A header-only file falls
-		// through with an empty order and returns nil,nil below.
-		return nil, nil
-	}
-
-	leases := make([]Lease, 0, len(order))
-	for _, addr := range order {
-		if l := latest[addr]; l.Address != "" {
-			leases = append(leases, l)
-		}
-	}
-	if len(leases) == 0 {
-		return nil, nil
-	}
-	return leases, nil
+	return nil
 }
 
 // subnetInterface returns the per-subnet interface binding for a

--- a/pkg/dhcpserver/lease_lfc.go
+++ b/pkg/dhcpserver/lease_lfc.go
@@ -1,0 +1,48 @@
+package dhcpserver
+
+// Kea Lease File Cleanup (LFC) file-set naming + read order (#5796).
+//
+// Kea's memfile backend never rewrites the lease file in place between LFC
+// compactions — every renewal / release / decline / expiry-reclaim is APPENDED
+// — and it periodically runs kea-lfc to compact the log. During AND after a
+// cleanup the live lease set is NOT the current file alone; it spans Kea's LFC
+// file set. Reading only the current file loses every lease that currently
+// lives in the previous or input file: right after LFC rotates the current
+// file, that file is a fresh (often header-only) append log while the active
+// leases sit in the compacted previous file. A header-only current file must
+// therefore never by itself authorize the destructive DDNS trusted-empty diff.
+//
+// File naming is authoritative from Kea source
+// (src/lib/dhcpsrv/memfile_lease_mgr.cc, appendSuffix / LFCFileType) for a
+// current lease file <f>:
+//
+//	<f>            CURRENT  — the live append log the server writes now.
+//	<f>.1          INPUT    — the current file the server MOVES ASIDE at the
+//	                          START of a cleanup; kea-lfc reads it. Present only
+//	                          while a cleanup is in progress (or left behind by a
+//	                          crashed cleanup).
+//	<f>.2          PREVIOUS — the COMPACTED result of the last COMPLETED cleanup
+//	                          (one row per active lease). Present once any LFC
+//	                          has run.
+//	<f>.output     kea-lfc's temporary compaction output.
+//	<f>.completed  kea-lfc's finish marker.
+//	<f>.pid        kea-lfc's pid file.
+//
+// The .output/.completed/.pid files hold no lease union we must read and are
+// ignored. NOTE the suffix mapping: .1 is INPUT and .2 is PREVIOUS — so the
+// CHRONOLOGICAL read order (oldest → newest) is .2 → .1 → current, i.e. the
+// previous-compacted snapshot first, then the input file, then the current
+// append log.
+//
+// keaLFCLeaseFilePaths returns the candidate paths in that chronological order.
+// A reader that OPENS each in turn (treating a missing file as simply absent —
+// skip, not an error) and replays the rows through the SAME append-only,
+// last-row-wins dedup the single-file parsers already use gets Kea's own final
+// disposition per lease key: a newer row in INPUT or CURRENT supersedes an older
+// row in PREVIOUS, and a release/expiry row still tombstones a lease that a
+// later re-allocation can reclaim. On a steady-state box with no LFC in progress
+// (.1/.2 absent) the set collapses to exactly the current file, so behavior is
+// byte-identical to the pre-#5796 single-file read.
+func keaLFCLeaseFilePaths(current string) []string {
+	return []string{current + ".2", current + ".1", current}
+}

--- a/pkg/dhcpserver/lease_lfc_5796_test.go
+++ b/pkg/dhcpserver/lease_lfc_5796_test.go
@@ -1,0 +1,180 @@
+package dhcpserver
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #5796: xpf treated the current Kea memfile (kea-leases{4,6}.csv) as the
+// COMPLETE lease DB, but after Lease File Cleanup (LFC) begins that file is only
+// the new append log — the active set spans Kea's LFC file set: PREVIOUS
+// (<f>.2, the compacted result of the last cleanup) and INPUT (<f>.1, the
+// current file moved aside at the start of a cleanup). Reading only the current
+// file LOSES leases that live in .2/.1, and a header-only current file then
+// falsely authorized the DESTRUCTIVE DDNS trusted-empty delete (fail-open).
+//
+// Suffix mapping is authoritative from Kea src
+// (memfile_lease_mgr.cc appendSuffix): .1 = INPUT, .2 = PREVIOUS. Chronological
+// read order (oldest → newest, last-row-wins) is therefore .2 → .1 → current.
+//
+// FAIL-ON-REVERT: restore the single-current-file read in parseActiveLeases /
+// parseLeaseCSV (drop the keaLFCLeaseFilePaths loop, open only `path`) → the
+// leases that live in .2/.1 vanish → TestLFC5796_* below go RED (union tests
+// return 0 leases; the order test resurrects a released lease; the display test
+// shows nothing).
+
+const (
+	lfcV4Header = "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state"
+	lfcFuture   = "1900000000" // > now
+	lfcPast     = "1600000000" // < now
+)
+
+var lfcNow = time.Unix(1_700_000_000, 0)
+
+// TestLFC5796_UnionAcrossFileSet: active leases living ONLY in the previous
+// (.2) and input (.1) files are returned even when the current file is a fresh
+// header-only append log. This is the core lease-loss bug AND the destructive
+// header-only-authorizes-mass-delete bug (invariant 5): a header-only current
+// with leases in .2/.1 must NOT be trusted-empty.
+func TestLFC5796_UnionAcrossFileSet(t *testing.T) {
+	dir := t.TempDir()
+	cur := filepath.Join(dir, "leases4.csv")
+
+	// PREVIOUS (.2): the compacted set from the last LFC — lease A + B active.
+	writeCSV(t, cur+".2", lfcV4Header+"\n"+
+		"10.0.0.10,aa:bb:cc:dd:ee:10,,3600,"+lfcFuture+",1,0,1,host-a,0\n"+
+		"10.0.0.11,aa:bb:cc:dd:ee:11,,3600,"+lfcFuture+",1,0,1,host-b,0\n")
+	// INPUT (.1): the pre-cleanup current file moved aside — lease C active.
+	writeCSV(t, cur+".1", lfcV4Header+"\n"+
+		"10.0.0.12,aa:bb:cc:dd:ee:12,,3600,"+lfcFuture+",1,0,1,host-c,0\n")
+	// CURRENT: freshly rotated header-only append log (no data rows yet).
+	writeCSV(t, cur, lfcV4Header+"\n")
+
+	leases, err := parseActiveLeases4(cur, lfcNow)
+	if err != nil {
+		t.Fatalf("parseActiveLeases4: %v", err)
+	}
+	// Destructive safety: header-only current + leases in .2/.1 is NOT
+	// trusted-empty. Pre-fix this returned nil (→ DDNS mass-delete).
+	if len(leases) != 3 {
+		t.Fatalf("want 3 active leases across the LFC set (A/.2 B/.2 C/.1); got %d: %+v", len(leases), leases)
+	}
+	got := map[string]bool{}
+	for _, l := range leases {
+		got[l.Address] = true
+	}
+	for _, want := range []string{"10.0.0.10", "10.0.0.11", "10.0.0.12"} {
+		if !got[want] {
+			t.Fatalf("lease %s from the previous/input file was LOST (single-file read regression): %+v", want, leases)
+		}
+	}
+}
+
+// TestLFC5796_ChronologicalOrderLastRowWins: a lease active in PREVIOUS (.2)
+// but RELEASED/expired in the current file must be dropped (current supersedes
+// previous), and a renewal in the current file must win its newer attributes.
+// If the merge order were reversed (current before previous), the stale .2 row
+// would resurrect a released lease — a correctness inversion.
+func TestLFC5796_ChronologicalOrderLastRowWins(t *testing.T) {
+	dir := t.TempDir()
+	cur := filepath.Join(dir, "leases4.csv")
+
+	// PREVIOUS (.2): A active with an OLD hostname; D active.
+	writeCSV(t, cur+".2", lfcV4Header+"\n"+
+		"10.0.0.10,aa:bb:cc:dd:ee:10,,3600,"+lfcFuture+",1,0,1,prev-name,0\n"+
+		"10.0.0.40,aa:bb:cc:dd:ee:40,,3600,"+lfcFuture+",1,0,1,host-d,0\n")
+	// CURRENT: A RENEWED with a NEW hostname (supersede); D EXPIRED (past
+	// expire → tombstone; a released/expired lease must not be resurrected).
+	writeCSV(t, cur, lfcV4Header+"\n"+
+		"10.0.0.10,aa:bb:cc:dd:ee:10,,3600,"+lfcFuture+",1,0,1,curr-name,0\n"+
+		"10.0.0.40,aa:bb:cc:dd:ee:40,,3600,"+lfcPast+",1,0,1,host-d,0\n")
+
+	leases, err := parseActiveLeases4(cur, lfcNow)
+	if err != nil {
+		t.Fatalf("parseActiveLeases4: %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("want exactly 1 active lease (A renewed; D released); got %d: %+v", len(leases), leases)
+	}
+	if leases[0].Address != "10.0.0.10" {
+		t.Fatalf("released lease D=10.0.0.40 was resurrected (wrong merge order): %+v", leases)
+	}
+	if leases[0].HostName != "curr-name" {
+		t.Fatalf("current-file renewal did not supersede the previous row: hostname=%q want curr-name", leases[0].HostName)
+	}
+}
+
+// TestLFC5796_NoLFCUnchanged: with no .1/.2 present (the common steady state),
+// the set collapses to exactly the current file — behavior byte-identical to
+// the pre-#5796 single-file read.
+func TestLFC5796_NoLFCUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	cur := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, cur, lfcV4Header+"\n"+
+		"10.0.0.99,aa:bb:cc:dd:ee:99,,3600,"+lfcFuture+",1,0,1,host-z,0\n")
+
+	leases, err := parseActiveLeases4(cur, lfcNow)
+	if err != nil {
+		t.Fatalf("parseActiveLeases4: %v", err)
+	}
+	if len(leases) != 1 || leases[0].Address != "10.0.0.99" {
+		t.Fatalf("no-LFC single-file read changed: %+v", leases)
+	}
+}
+
+// TestLFC5796_ExistingMangledSiblingFailsClosed: a PRESENT-but-anomalous
+// previous/input file (headerless — mid-write/corrupt) makes the WHOLE family
+// untrusted (error), so the DDNS reconciler skips the destructive diff across
+// the set rather than trusting a partial union (invariant 4, fail-closed).
+func TestLFC5796_ExistingMangledSiblingFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	cur := filepath.Join(dir, "leases4.csv")
+	// Current is a healthy header-only file (would be trusted-empty alone)...
+	writeCSV(t, cur, lfcV4Header+"\n")
+	// ...but the PREVIOUS file exists and is headerless (0 records) — anomalous.
+	writeCSV(t, cur+".2", "")
+
+	if _, err := parseActiveLeases4(cur, lfcNow); err == nil {
+		t.Fatal("an existing headerless .2 (previous) must make the family untrusted (error), not partial-trusted")
+	}
+}
+
+// TestLFC5796_DisplayUnionAcrossFileSet: the lenient display parser
+// (parseLeaseCSV) must ALSO union the LFC set so `show dhcp server leases` does
+// not omit the compacted active set right after an LFC rotation.
+func TestLFC5796_DisplayUnionAcrossFileSet(t *testing.T) {
+	dir := t.TempDir()
+	cur := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, cur+".2", lfcV4Header+"\n"+
+		"10.0.0.10,aa:bb:cc:dd:ee:10,,3600,"+lfcFuture+",1,0,1,host-a,0\n")
+	writeCSV(t, cur, lfcV4Header+"\n") // header-only current
+
+	leases, err := parseLeaseCSV(cur, lfcNow)
+	if err != nil {
+		t.Fatalf("parseLeaseCSV: %v", err)
+	}
+	if len(leases) != 1 || leases[0].Address != "10.0.0.10" {
+		t.Fatalf("display omitted the compacted previous-file lease (single-file read regression): %+v", leases)
+	}
+}
+
+// TestLFC5796_FileSetOrder pins the chronological order the merge relies on:
+// previous (.2) → input (.1) → current. A reorder here silently inverts
+// last-row-wins.
+func TestLFC5796_FileSetOrder(t *testing.T) {
+	got := keaLFCLeaseFilePaths("/var/lib/kea/kea-leases4.csv")
+	want := []string{
+		"/var/lib/kea/kea-leases4.csv.2", // PREVIOUS (oldest / compacted)
+		"/var/lib/kea/kea-leases4.csv.1", // INPUT
+		"/var/lib/kea/kea-leases4.csv",   // CURRENT (newest)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("keaLFCLeaseFilePaths returned %d paths, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("keaLFCLeaseFilePaths[%d] = %q, want %q (chronological .2 -> .1 -> current)", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

All three Kea memfile consumers — the destructive DDNS reconciler (`parseActiveLeases4/6`), the operational display (`parseLeaseCSV`), and the HA lease-sync fallback (`readSyncLeasesViaMemfile` → `parseActiveLeases`) — opened **only** the current lease file `kea-leases{4,6}.csv`. After Kea's Lease File Cleanup (LFC) begins, that file is only the new append log; the active lease set spans Kea's LFC file set. Reading one file **loses active leases** and, worse, a valid **header-only current file** right after an LFC rotation was read as a trusted-empty set → the DDNS reconciler would **mass-delete every xpf-owned A/AAAA/PTR** (fail-open).

## Fix

One shared enumerator `keaLFCLeaseFilePaths` (`lease_lfc.go`) returns the LFC set in Kea **chronological** order — **previous (`.2`) → input (`.1`) → current** — and both parsers replay it through the **same append-only, last-row-wins dedup** they already used. A newer row in input/current supersedes an older previous row; a release/expiry row still tombstones a lease a later re-allocation reclaims.

Suffix mapping is authoritative from Kea source (`memfile_lease_mgr.cc appendSuffix`): **`.1` = INPUT** (current file moved aside at the start of a cleanup), **`.2` = PREVIOUS** (compacted result of the last completed cleanup).

Fail-safe preserved and **extended** across the set: any existing headerless/mangled/ragged sibling makes the whole family untrusted (error → destructive diff skipped); trusted-empty only when every existing file validates AND the merged set is empty. Missing `.1`/`.2` (common no-LFC steady state) collapses to exactly the current file — byte-identical to before.

## Validation

- **Fail-on-revert (`-overlay`):** single-file read → union/display/fail-closed tests RED (leases in `.2`/`.1` vanish); reversed merge order → chronological-order test RED (a released lease is resurrected).
- `go build ./...`, `go vet ./pkg/dhcpserver/`, `go test -race ./pkg/dhcpserver/ ./pkg/ddns/` all green.
- New tests: `pkg/dhcpserver/lease_lfc_5796_test.go` (union, chronological order, no-LFC unchanged, existing-mangled-sibling fail-closed, display union, file-set order).

## Residual (deferred, noted in `pkg/dhcpserver/README.md`)

Issue invariants 2/3/8 are follow-up: no live `lease_cmds` control-socket preference in every consumer, no crash-interrupted-cleanup generation proof, no degraded-source display banner. This PR closes the on-disk lease-loss / fail-open core for the common LFC phases.

Closes #5796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vt2uxDDV1sAe48dWaruzt