### PR TITLE
grpcapi: gate ungated SessionCount full-table walk (#5782)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48814,3 +48814,23 @@ top.
     clear → error case silently transitions, tests RED).
   - **File(s)**: cmd/cli/shared.go, cmd/cli/config_exit_retry_5812_test.go,
     cmd/cli/README.md
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5782 gate ungated SessionCount full-table walk. s.dp.SessionCount()
+    does a full v4+v6 session-map iteration holding the per-bucket BPF-map locks
+    for O(table) — the same lock-contention DoS class #5708 bounded for the
+    read-scans — reachable UNGATED via GetStatus (server_show_status.go) and
+    `show system buffers[-detail]` (showBuffers/showBuffersDetail, ShowText). Gated
+    all 3 client-reachable surfaces through the SHARED diagcmd.SessionWalkLimiter
+    (the same instance #5708/#5779 use), returning codes.ResourceExhausted on
+    contention exactly like sessions-top (ShowText propagates the handler error;
+    showBuffers/showBuffersDetail changed to return error). Left server_sessions.go:300
+    (setSessionsTotal) alone — it is only called from the already-limiter-held
+    GetSessions handler (gating again would draw a redundant second slot). Noted
+    api/health.go:119 as a same-class REST site OUTSIDE the grpcapi scope (follow-up).
+    Fail-on-revert proven via -overlay (remove the 3 gates → over-cap calls walk +
+    return normal responses, bound tests RED). Doc: limiter.go MaxConcurrentSessionWalks
+    surface list now includes GetStatus + show-buffers.
+  - **File(s)**: pkg/grpcapi/server_show_status.go, pkg/grpcapi/server_show_system.go,
+    pkg/grpcapi/server_show.go, pkg/diagcmd/limiter.go,
+    pkg/grpcapi/server_sessioncount_bound_5782_test.go

--- a/pkg/diagcmd/limiter.go
+++ b/pkg/diagcmd/limiter.go
@@ -81,9 +81,13 @@ var DefaultLimiter = NewLimiter(MaxConcurrentDiagnostics)
 // at once across EVERY control surface that exposes them — the REST session
 // list/summary/zone-pair endpoints and the REST session-clear fallback, plus
 // the gRPC GetSessions/GetSessionSummary/GetZonePairSummary RPCs, the ShowText
-// "sessions-top:*" scan, and the gRPC ClearSessions clear (both the clear-all
-// and filtered full-table walks, #5779) — share the single SessionWalkLimiter
-// below (#5708).
+// "sessions-top:*" scan, the gRPC ClearSessions clear (both the clear-all
+// and filtered full-table walks, #5779), and the count-only SessionCount()
+// walk reachable via the gRPC GetStatus RPC and the ShowText
+// "buffers"/"buffers-detail" (`show system buffers[-detail]`) surfaces (#5782)
+// — share the single SessionWalkLimiter below (#5708). SessionCount is
+// count-only (no per-entry alloc/enrich) but its KERNEL iteration + per-bucket
+// lock cost is the same O(table) contention, so it draws from the same budget.
 // Each walk holds
 // per-bucket BPF-map locks across the whole v4+v6 conntrack table while
 // contending with the live dataplane session-sync path, so an unbounded scan

--- a/pkg/grpcapi/server_sessioncount_bound_5782_test.go
+++ b/pkg/grpcapi/server_sessioncount_bound_5782_test.go
@@ -1,0 +1,160 @@
+// #5782: SessionCount() is a full v4+v6 session-map iteration holding the
+// per-bucket BPF-map locks for O(table) — the SAME lock-contention DoS class
+// #5708 bounded for the IterateSessions* read-scans, but reachable UNGATED via
+// two client surfaces: the GetStatus RPC and `show system buffers[-detail]`
+// (ShowText). Both now draw from the shared diagcmd.SessionWalkLimiter and fail
+// fast with ResourceExhausted on contention, exactly like the read-scans and
+// sessions-top.
+//
+// FAIL-ON-REVERT: remove the sessionWalkLimiter.Acquire() gate from GetStatus /
+// showBuffers / showBuffersDetail and an over-cap call proceeds straight to the
+// SessionCount walk and returns a normal response — the ResourceExhausted +
+// "SessionCount not walked" assertions below go RED.
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// countBoundDP is a grpcRuntime fake: IsLoaded true, a controllable SessionCount
+// that records whether it was invoked (so a gated over-cap call proves it did
+// NOT walk), and empty map stats (so showBuffers takes the non-userspace-provider
+// branch and reaches the SessionCount call). Embeds *dataplane.Manager for the
+// rest of the interface, mirroring boundSessionDP (#5708).
+type countBoundDP struct {
+	*dataplane.Manager
+	v4, v6     int
+	countCalls int32
+}
+
+func (*countBoundDP) IsLoaded() bool { return true }
+
+func (d *countBoundDP) SessionCount() (int, int) {
+	atomic.AddInt32(&d.countCalls, 1)
+	return d.v4, d.v6
+}
+
+func (*countBoundDP) GetMapStats() []dataplane.MapStats { return nil }
+
+func newCountBoundServer(t *testing.T, dp *countBoundDP) *Server {
+	t.Helper()
+	return &Server{
+		dp:    dp,
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+	}
+}
+
+// GetStatus's SessionCount walk is gated: a saturated limiter → ResourceExhausted
+// with NO walk; after a slot frees → the correct count.
+func TestGRPCGetStatusSessionCountBound_5782(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	dp := &countBoundDP{Manager: dataplane.New(), v4: 3, v6: 5}
+	s := newCountBoundServer(t, dp)
+
+	_, err = s.GetStatus(context.Background(), &pb.GetStatusRequest{})
+	if !isResourceExhausted(err) {
+		release()
+		t.Fatalf("GetStatus with a saturated session-walk limiter: err = %v, want codes.ResourceExhausted (admission gate not consulted)", err)
+	}
+	if n := atomic.LoadInt32(&dp.countCalls); n != 0 {
+		release()
+		t.Fatalf("SessionCount walked %d times despite a saturated limiter — the gate must fail fast BEFORE the walk", n)
+	}
+
+	release()
+	resp, err := s.GetStatus(context.Background(), &pb.GetStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetStatus after slot release: %v", err)
+	}
+	if resp.SessionCount != 8 {
+		t.Fatalf("GetStatus SessionCount = %d, want 8 (v4=3 + v6=5) — the admitted path must return the real count", resp.SessionCount)
+	}
+}
+
+// `show system buffers` and `... detail` (ShowText topics) are gated identically:
+// a saturated limiter → ResourceExhausted (ShowText returns the handler error
+// verbatim) with NO walk; released → the session-count line renders.
+func TestGRPCShowBuffersSessionCountBound_5782(t *testing.T) {
+	for _, topic := range []string{"buffers", "buffers-detail"} {
+		t.Run(topic, func(t *testing.T) {
+			orig := sessionWalkLimiter
+			t.Cleanup(func() { sessionWalkLimiter = orig })
+			sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+			release, err := sessionWalkLimiter.Acquire()
+			if err != nil {
+				t.Fatalf("failed to pre-acquire the only slot: %v", err)
+			}
+
+			dp := &countBoundDP{Manager: dataplane.New(), v4: 3, v6: 5}
+			s := newCountBoundServer(t, dp)
+
+			_, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic})
+			if !isResourceExhausted(err) {
+				release()
+				t.Fatalf("ShowText %q with a saturated limiter: err = %v, want codes.ResourceExhausted", topic, err)
+			}
+			if n := atomic.LoadInt32(&dp.countCalls); n != 0 {
+				release()
+				t.Fatalf("%s: SessionCount walked %d times despite a saturated limiter", topic, n)
+			}
+
+			release()
+			resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic})
+			if err != nil {
+				t.Fatalf("ShowText %q after slot release: %v", topic, err)
+			}
+			if !strings.Contains(resp.Output, "Active sessions: 3 IPv4, 5 IPv6, 8 total") {
+				t.Fatalf("%s: admitted render missing the session-count line; got:\n%s", topic, resp.Output)
+			}
+		})
+	}
+}
+
+// The gated SessionCount surfaces draw from the PROCESS-WIDE
+// diagcmd.SessionWalkLimiter — the SAME instance the REST + gRPC read-scans use
+// — so a mix of scrapers cannot collectively exceed the aggregate budget.
+// Saturating the shared singleton directly must make GetStatus ResourceExhausted.
+func TestGRPCSessionCountDrawsFromSharedLimiter_5782(t *testing.T) {
+	if sessionWalkLimiter != diagcmd.SessionWalkLimiter {
+		t.Fatal("grpcapi sessionWalkLimiter is not the shared diagcmd.SessionWalkLimiter instance; the SessionCount budget is not aggregated with the read-scans")
+	}
+	var releases []func()
+	t.Cleanup(func() {
+		for _, r := range releases {
+			r()
+		}
+	})
+	for {
+		rel, err := diagcmd.SessionWalkLimiter.Acquire()
+		if err != nil {
+			break
+		}
+		releases = append(releases, rel)
+	}
+	if len(releases) == 0 {
+		t.Fatal("could not acquire any slot on the shared limiter")
+	}
+
+	dp := &countBoundDP{Manager: dataplane.New(), v4: 1, v6: 1}
+	s := newCountBoundServer(t, dp)
+	if _, err := s.GetStatus(context.Background(), &pb.GetStatusRequest{}); !isResourceExhausted(err) {
+		t.Fatalf("GetStatus with the shared limiter saturated: err = %v, want codes.ResourceExhausted (handler not drawing from the shared instance)", err)
+	}
+}

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -460,10 +460,14 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		s.showRootAuthentication(cfg, &buf)
 
 	case "buffers":
-		s.showBuffers(cfg, &buf)
+		if err := s.showBuffers(cfg, &buf); err != nil {
+			return nil, err
+		}
 
 	case "buffers-detail":
-		s.showBuffersDetail(cfg, &buf)
+		if err := s.showBuffersDetail(cfg, &buf); err != nil {
+			return nil, err
+		}
 
 	case "wireguard":
 		// #1865: WG tunnel telemetry (summary).

--- a/pkg/grpcapi/server_show_status.go
+++ b/pkg/grpcapi/server_show_status.go
@@ -32,6 +32,18 @@ func (s *Server) GetStatus(_ context.Context, _ *pb.GetStatusRequest) (*pb.GetSt
 	// this reported 0 sessions on every real deployment. SessionCount counts
 	// forward entries only, so it is the live session total.
 	if s.dp != nil && s.dp.IsLoaded() {
+		// #5782: SessionCount() is a full v4+v6 session-map iteration holding the
+		// per-bucket BPF-map locks for O(table) — the SAME lock-contention DoS
+		// class #5708 bounded for the session read-scans, reachable UNGATED here.
+		// Gate it through the shared diagcmd.SessionWalkLimiter (the same instance
+		// the GetSessions/sessions-top scans use); on contention fail fast with
+		// ResourceExhausted rather than driving another concurrent full-table walk.
+		release, err := sessionWalkLimiter.Acquire()
+		if err != nil {
+			return nil, status.Error(codes.ResourceExhausted,
+				"session scan concurrency limit reached; retry shortly")
+		}
+		defer release() // idempotent; released on panic too (limiter contract)
 		v4, v6 := s.dp.SessionCount()
 		resp.SessionCount = int32(v4 + v6)
 	}

--- a/pkg/grpcapi/server_show_system.go
+++ b/pkg/grpcapi/server_show_system.go
@@ -411,8 +411,21 @@ func (s *Server) showTask(cfg *config.Config, buf *strings.Builder) {
 	fmt.Fprintf(buf, "  Uptime: %s\n", uptime)
 }
 
-func (s *Server) showBuffers(cfg *config.Config, buf *strings.Builder) {
+func (s *Server) showBuffers(cfg *config.Config, buf *strings.Builder) error {
 	if s.dp != nil {
+		// #5782: this render ends with a full v4+v6 SessionCount() table walk
+		// (same per-bucket BPF-map lock contention as the session read-scans).
+		// Gate the whole render through the shared diagcmd.SessionWalkLimiter and
+		// fail fast with ResourceExhausted on contention — the same mechanism
+		// sessions-top and the GetSessions RPCs use (ShowText returns this
+		// verbatim) — so a `show system buffers` scrape flood cannot drive
+		// unbounded concurrent table walks.
+		release, err := sessionWalkLimiter.Acquire()
+		if err != nil {
+			return status.Error(codes.ResourceExhausted,
+				"session scan concurrency limit reached; retry shortly")
+		}
+		defer release()
 		if provider, ok := s.dp.(userspaceStatusProvider); ok {
 			status, err := provider.Status()
 			if err != nil {
@@ -464,10 +477,18 @@ func (s *Server) showBuffers(cfg *config.Config, buf *strings.Builder) {
 	} else {
 		buf.WriteString("Dataplane not loaded\n")
 	}
+	return nil
 }
 
-func (s *Server) showBuffersDetail(cfg *config.Config, buf *strings.Builder) {
+func (s *Server) showBuffersDetail(cfg *config.Config, buf *strings.Builder) error {
 	if s.dp != nil {
+		// #5782: same full-table SessionCount() walk gate as showBuffers.
+		release, err := sessionWalkLimiter.Acquire()
+		if err != nil {
+			return status.Error(codes.ResourceExhausted,
+				"session scan concurrency limit reached; retry shortly")
+		}
+		defer release()
 		if provider, ok := s.dp.(userspaceStatusProvider); ok {
 			status, err := provider.Status()
 			if err != nil {
@@ -532,6 +553,7 @@ func (s *Server) showBuffersDetail(cfg *config.Config, buf *strings.Builder) {
 	} else {
 		buf.WriteString("Dataplane not loaded\n")
 	}
+	return nil
 }
 
 func (s *Server) showBackupRouter(cfg *config.Config, buf *strings.Builder) {


### PR DESCRIPTION
## Defect

`s.dp.SessionCount()` does a FULL v4+v6 session-map iteration holding the per-bucket BPF-map locks for O(table) — the **same** kernel-iteration / lock-contention DoS class #5708 bounded for the session read-scans. But it was reachable **ungated** (outside #5708's `IterateSessions*`-scoped limiter) via two client-reachable surfaces:

- the **GetStatus** RPC (`server_show_status.go`);
- **`show system buffers[-detail]`** (`showBuffers`/`showBuffersDetail`, dispatched from `ShowText`).

A gRPC caller spamming either could drive unbounded concurrent full-table iterations.

## Fix

Gate all three client-reachable `SessionCount` surfaces through the **same** process-wide `diagcmd.SessionWalkLimiter` the read-scans use, failing fast with `codes.ResourceExhausted` on contention — the identical mechanism `sessions-top` and `GetSessions` use (not a new one):

- **GetStatus** — acquire around the `SessionCount` call → RPC returns `ResourceExhausted` on contention.
- **showBuffers / showBuffersDetail** — now return an error; acquire at the top of the dataplane-loaded render; `ShowText` returns it verbatim. When admitted the render is byte-identical (the `SessionCount` call sites are unchanged).

Both draw from the shared limiter, so REST + gRPC + read-scan + count scrapers cannot collectively exceed `MaxConcurrentSessionWalks`.

**Left alone** (not client-reachable-ungated): `server_sessions.go:300` (`setSessionsTotal`) is only called from within the already-limiter-held `GetSessions` handler; `api/health.go:119` is the same walk on the REST `/health` surface, **outside** this grpcapi-scoped change and noted as a one-line follow-up (the shared limiter already spans REST); the `runtime.go`/`api.go`/`runtime_probes.go` hits are interface declarations, not calls.

## Tests

`server_sessioncount_bound_5782_test.go` (mirroring the #5708 bound suite): a `countBoundDP` fake records whether `SessionCount` is actually invoked. Under a saturated limiter, GetStatus and ShowText `buffers`/`buffers-detail` return `ResourceExhausted` **and never walk** (`countCalls==0`); after a slot frees, the admitted path returns the real count. A shared-singleton saturation test proves the budget is aggregated with the read-scans. Proven **RED on revert** of the three gates via `go test -overlay`.

## Doc

`pkg/diagcmd/limiter.go` `MaxConcurrentSessionWalks` now lists the GetStatus + show-buffers `SessionCount` surfaces among the bounded set.

## Validation

`go build ./...` clean; `go vet ./pkg/grpcapi/` clean; `go test -race ./pkg/grpcapi/` green.

Closes #5782

🤖 Generated with [Claude Code](https://claude.com/claude-code)