### PR TITLE
api: gate ungated REST SessionCount full-table walk (#5939)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48841,3 +48841,21 @@ top.
     clear → error case silently transitions, tests RED).
   - **File(s)**: cmd/cli/shared.go, cmd/cli/config_exit_retry_5812_test.go,
     cmd/cli/README.md
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5939 gate REST SessionCount full-table walk (sibling of #5782/#5937).
+    statusHandler (GET /api/v1/status, pkg/api/health.go) called SessionCount() — a
+    full v4+v6 session-map walk under per-bucket BPF-map locks, O(table) — with no
+    limiter gate. Routed it through the SHARED diagcmd.SessionWalkLimiter (the same
+    instance sessions.go uses for the /security/sessions* scans); on contention
+    fail fast with HTTP 429 via writeError, mirroring sessionsHandler. Choice = 429
+    (not bounded-count-omit): the walk is in the AUTHENTICATED /api/v1/status query,
+    NOT the unauthenticated liveness /health (healthHandler, which does NOT walk),
+    so a 429 here cannot flap the liveness probe — the flap concern is moot and 429
+    matches the whole REST session-scan surface. Admitted path count unchanged.
+    Fail-on-revert proven via -overlay (remove the gate → walks + returns 200 w/
+    count regardless of the saturated limiter, bound test RED). Doc: limiter.go
+    surface list adds /api/v1/status. NOTE: touches the same limiter.go comment
+    sentence as the unmerged #5937 (adds the gRPC count surfaces) — reconcile at merge.
+  - **File(s)**: pkg/api/health.go, pkg/api/status_sessioncount_bound_5939_test.go,
+    pkg/diagcmd/limiter.go

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -116,6 +116,23 @@ func (s *Server) statusHandler(w http.ResponseWriter, _ *http.Request) {
 	// gc.Stats().TotalEntries is permanently 0 — this reported 0 sessions on
 	// every real deployment.
 	if s.dp != nil && s.dp.IsLoaded() {
+		// #5939: SessionCount() is a full v4+v6 session-map iteration holding the
+		// per-bucket BPF-map locks for O(table) — the SAME lock-contention DoS
+		// class #5708/#5782 bounded, reachable UNGATED here on the REST surface.
+		// Gate it through the shared diagcmd.SessionWalkLimiter (the same instance
+		// the /security/sessions* scans use, sessions.go) and fail fast with HTTP
+		// 429 on contention rather than driving another concurrent full-table walk,
+		// mirroring sessions.go. This is the AUTHENTICATED /api/v1/status query
+		// (authCheck exempts only /health + loopback-/metrics); the unauthenticated
+		// liveness /health handler does NOT walk the session table, so a 429 here
+		// cannot flap the liveness probe.
+		release, err := sessionWalkLimiter.Acquire()
+		if err != nil {
+			writeError(w, http.StatusTooManyRequests,
+				"session count concurrency limit reached; retry shortly")
+			return
+		}
+		defer release() // idempotent; released on panic too (limiter contract)
 		v4, v6 := s.dp.SessionCount()
 		resp.SessionCount = v4 + v6
 	}

--- a/pkg/api/status_sessioncount_bound_5939_test.go
+++ b/pkg/api/status_sessioncount_bound_5939_test.go
@@ -1,0 +1,88 @@
+// #5939: statusHandler (GET /api/v1/status) calls SessionCount() — a full v4+v6
+// session-map iteration holding the per-bucket BPF-map locks for O(table), the
+// SAME lock-contention DoS class #5708/#5782 bounded — with no limiter gate. It
+// now draws from the shared diagcmd.SessionWalkLimiter (the instance the
+// /security/sessions* scans already use, sessions.go) and fails fast with HTTP
+// 429 on contention, mirroring sessionsHandler.
+//
+// FAIL-ON-REVERT: remove the sessionWalkLimiter.Acquire()/429 branch from
+// statusHandler and an over-cap request proceeds straight to the SessionCount
+// walk and returns 200 with the count — the 429 + "SessionCount not walked"
+// assertions below go RED.
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+)
+
+// statusCountDP is an apiRuntimeDataPlane fake: IsLoaded true and a controllable
+// SessionCount that records whether it was invoked (so a gated over-cap request
+// proves it did NOT walk). Embeds *dataplane.Manager for the rest of the
+// interface, mirroring blockingSessionDP / cancelCountDP.
+type statusCountDP struct {
+	*dataplane.Manager
+	v4, v6     int
+	countCalls int32
+}
+
+func (*statusCountDP) IsLoaded() bool { return true }
+
+func (d *statusCountDP) SessionCount() (int, int) {
+	atomic.AddInt32(&d.countCalls, 1)
+	return d.v4, d.v6
+}
+
+func TestRESTStatusSessionCountBound_5939(t *testing.T) {
+	// The handler must draw from the PROCESS-WIDE shared limiter so the REST
+	// status count is aggregated with the session scans (a mix of scrapers
+	// cannot collectively exceed the budget).
+	if sessionWalkLimiter != diagcmd.SessionWalkLimiter {
+		t.Fatal("pkg/api sessionWalkLimiter is not the shared diagcmd.SessionWalkLimiter instance")
+	}
+
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("failed to pre-acquire the only slot: %v", err)
+	}
+
+	dp := &statusCountDP{Manager: dataplane.New(), v4: 3, v6: 5}
+	s := &Server{dp: dp, store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))}
+
+	// (a) Saturated limiter → HTTP 429 and NO walk.
+	rr := httptest.NewRecorder()
+	s.statusHandler(rr, httptest.NewRequest("GET", "/api/v1/status", nil))
+	if rr.Code != http.StatusTooManyRequests {
+		release()
+		t.Fatalf("statusHandler with a saturated session-walk limiter: code=%d, want 429 (admission gate not consulted); body: %s", rr.Code, rr.Body.String())
+	}
+	if n := atomic.LoadInt32(&dp.countCalls); n != 0 {
+		release()
+		t.Fatalf("SessionCount walked %d times despite a saturated limiter — the gate must fail fast BEFORE the walk", n)
+	}
+
+	// (b) After the slot frees → 200 with the real count.
+	release()
+	rr = httptest.NewRecorder()
+	s.statusHandler(rr, httptest.NewRequest("GET", "/api/v1/status", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("statusHandler after slot release: code=%d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if !bytes.Contains(rr.Body.Bytes(), []byte(`"session_count":8`)) {
+		t.Fatalf("admitted status body missing the real session count (v4=3+v6=5); got: %s", rr.Body.String())
+	}
+	if n := atomic.LoadInt32(&dp.countCalls); n != 1 {
+		t.Fatalf("SessionCount invoked %d times on the admitted path, want exactly 1", n)
+	}
+}

--- a/pkg/diagcmd/limiter.go
+++ b/pkg/diagcmd/limiter.go
@@ -81,9 +81,12 @@ var DefaultLimiter = NewLimiter(MaxConcurrentDiagnostics)
 // at once across EVERY control surface that exposes them — the REST session
 // list/summary/zone-pair endpoints and the REST session-clear fallback, plus
 // the gRPC GetSessions/GetSessionSummary/GetZonePairSummary RPCs, the ShowText
-// "sessions-top:*" scan, and the gRPC ClearSessions clear (both the clear-all
-// and filtered full-table walks, #5779) — share the single SessionWalkLimiter
-// below (#5708).
+// "sessions-top:*" scan, the gRPC ClearSessions clear (both the clear-all and
+// filtered full-table walks, #5779), and the count-only SessionCount() walk on
+// the REST /api/v1/status handler (#5939) — share the single SessionWalkLimiter
+// below (#5708). (SessionCount is count-only — no per-entry alloc/enrich — but
+// its KERNEL iteration + per-bucket lock cost is the same O(table) contention,
+// so it draws from the same budget.)
 // Each walk holds
 // per-bucket BPF-map locks across the whole v4+v6 conntrack table while
 // contending with the live dataplane session-sync path, so an unbounded scan


### PR DESCRIPTION
## Defect

`statusHandler` (GET `/api/v1/status`, `pkg/api/health.go`) calls `SessionCount()` — a full v4+v6 session-map iteration holding the per-bucket BPF-map locks for O(table), the **same** lock-contention DoS class #5708/#5782 bounded — with **no** `SessionWalkLimiter` gate. It is the REST-surface sibling of the gRPC `SessionCount` sites #5782 (PR #5937) gated, flagged there and filed as #5939.

## Fix

Route the `SessionCount()` call through the **same** process-wide `diagcmd.SessionWalkLimiter` the REST `/security/sessions*` scans use (`sessions.go`), failing fast with **HTTP 429** on contention — the same mechanism `sessionsHandler` uses, not a new one. Idempotent release via `defer`. The admitted-path count is unchanged.

## Contended-path choice — 429 (not a bounded "count unavailable")

The walk is in the **authenticated** `/api/v1/status` query (`authCheck` exempts only `/health` and loopback-`/metrics`), **not** the unauthenticated liveness `/health`. `healthHandler` (the real `/health`) does **not** walk the session table. So a 429 on `/api/v1/status` under session-scan contention **cannot flap the liveness probe**, and 429 mirrors the entire REST session-scan surface (list/summary/zone-pairs/clear all 429). The health-flap concern assumed this was the public `/health`; it is the authenticated status query, so it does not apply.

## Tests

`status_sessioncount_bound_5939_test.go` (mirroring the #5318 REST bound test + the #5782 gRPC bound test): a `statusCountDP` fake records whether `SessionCount` is actually invoked. Under a saturated limiter `GET /api/v1/status` returns 429 **and never walks** (`countCalls==0`); after a slot frees, the admitted path returns 200 with the real count (`session_count:8`) and walks exactly once. Also asserts the handler draws from the shared `diagcmd.SessionWalkLimiter` singleton. Proven **RED on revert** via `go test -overlay`.

## Doc

`pkg/diagcmd/limiter.go` `MaxConcurrentSessionWalks` now lists the REST `/api/v1/status` `SessionCount` surface. (Edits the same comment sentence as the unmerged #5937 — reconcile at merge.)

## Validation

`go build ./...` clean; `go vet ./pkg/api/` clean; `go test -race ./pkg/api/` green.

Closes #5939

🤖 Generated with [Claude Code](https://claude.com/claude-code)