### PR TITLE
grpcapi: classify commit apply errors as retryable (#5742)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48877,3 +48877,32 @@ top.
   - **File(s)**: pkg/grpcapi/server_show_status.go, pkg/grpcapi/server_show_system.go,
     pkg/grpcapi/server_show.go, pkg/diagcmd/limiter.go,
     pkg/grpcapi/server_sessioncount_bound_5782_test.go
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5742 classify commit RPC apply errors. Commit / CommitConfirmed
+    blanket-mapped EVERY non-context commit-callback error to codes.InvalidArgument
+    ("you sent bad config"). But the daemon commit path (commitAndApply /
+    commitConfirmedAndApply -> applyAndSyncCommitted) returns a NON-FATAL
+    tail-reconcile / ordinary dataplane-apply error (networkd #1778, Kea #2987,
+    IPsec #4433, iface #5310, non-abort apply #5679, #5578 deletion-clear)
+    ALONGSIDE the committed config (compiled != nil) — the config is valid and
+    committed+active, only a transient control-socket step failed and self-heals
+    on retry (#5646). InvalidArgument misleads an operator/automation client into
+    EDITING valid config instead of retrying. Added commitApplyStatus(compiled,
+    err) — one private helper shared by both RPCs — classifying STRUCTURALLY on
+    the daemon's existing (compiled, err) contract (no sentinel / string match
+    needed): context.Canceled/DeadlineExceeded preserved and checked FIRST;
+    compiled != nil -> codes.Unavailable (transient, retryable); else keep
+    codes.InvalidArgument (compile/schema reject, compileErrorMustAbortApply
+    fail-closed gate, device-map preflight, bootstrap refusal, pre-promotion
+    persistence — all return nil config). Fail-safe: unclassifiable -> InvalidArgument.
+    Message text ("%v") byte-identical; only the code moves. Tail errors were
+    ALREADY distinctly encoded by the daemon (non-nil compiled on non-fatal via
+    applyAndSyncCommitted, daemon_apply.go ~332) so NO new sentinel was added.
+    Consumer check: no pkg/cli/cmd/cli code switches on the commit status code
+    (remote CLI wraps the message verbatim; local CLI calls store.Commit directly),
+    so NO consumer update needed. Fail-on-revert proven via -overlay (restore the
+    blanket default:InvalidArgument -> tail-reconcile->Unavailable rows RED for
+    both Commit and CommitConfirmed; schema/context rows stay green).
+  - **File(s)**: pkg/grpcapi/server_config.go,
+    pkg/grpcapi/server_config_commit_errclass_5742_test.go, pkg/grpcapi/README.md

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -107,6 +107,21 @@ contract.
 - `CommitFn` (passed in by the daemon) holds the apply semaphore across
   `Commit()` and the dataplane apply. This is the same primitive `pkg/cli`
   uses; concurrent operator commits serialize via that semaphore (#846).
+- **Commit error-code contract (#5742).** `Commit` / `CommitConfirmed`
+  classify the callback error structurally via `commitApplyStatus`, keying
+  off whether the daemon returned the committed config alongside it:
+  a **non-fatal tail-reconcile / ordinary dataplane-apply** error (networkd
+  write, Kea restart, IPsec reload, interface reconcile, non-abort apply —
+  the daemon commits+arms the config and returns it *with* the error) →
+  `codes.Unavailable` (transient, **retryable**; the config was accepted and
+  self-heals on the next commit/feed retry, #5646). A true **config-validation
+  / compile-reject** (compiler/schema reject, `compileErrorMustAbortApply`
+  fail-closed gate, device-map preflight, bootstrap refusal, pre-promotion
+  persistence — no config committed, `nil` returned) → `codes.InvalidArgument`
+  (fix the config). `context.Canceled` / `DeadlineExceeded` are preserved and
+  take precedence. The human-readable message is unchanged; only the code
+  distinguishes "retry" from "fix your config". Unclassifiable errors fail
+  safe to `InvalidArgument`.
 - **Zeroize goes through the apply gate AND stops xpfd (#5281).** The
   `SystemAction{zeroize}` handler does NOT call `performZeroizeWipe`
   directly. It routes through `ZeroizeFn` (wired by the daemon to

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -25,6 +25,49 @@ func configMutationStatus(err error) error {
 	return status.Errorf(codes.InvalidArgument, "%v", err)
 }
 
+// commitApplyStatus maps a non-nil commit-callback error (commitFn /
+// commitConfirmedFn) to the right gRPC status code (#5742). The daemon commit
+// path (commitAndApply / commitConfirmedAndApply → applyAndSyncCommitted)
+// already encodes the error CLASS in whether it returns the committed config
+// alongside the error, so no error-text matching or new cross-package sentinel
+// is needed — classify structurally on (compiled, err):
+//
+//   - context.Canceled / context.DeadlineExceeded (checked FIRST so a wrapped
+//     context error can never be mis-mapped even if a caller also returns a
+//     non-nil config): the commit was aborted by a daemon stop or a busy
+//     apply-lock. Preserved as Canceled / DeadlineExceeded, unchanged.
+//   - A NON-FATAL tail-reconcile / ordinary dataplane-apply error — networkd
+//     write (#1778), Kea restart (#2987), IPsec reload (#4433), interface
+//     reconcile (#5310), non-abort apply (#5679), #5578 deletion-clear:
+//     applyAndSyncCommitted returns the committed config ALONGSIDE the error
+//     (compiled != nil). The config is VALID and committed+active; only a
+//     transient control-socket / subsystem step failed and self-heals on retry
+//     (#5646). Map to codes.Unavailable (transient, retryable) so an operator /
+//     automation client retries rather than editing a config that was never
+//     rejected — the whole point of #5742.
+//   - Everything else (compiled == nil): a real config-validation / compile
+//     reject (the #5679 abort gate compileErrorMustAbortApply), a device-map
+//     commit preflight reject, a bootstrap-mode refusal, or a pre-promotion
+//     store persistence error — the config was NOT committed. Keep the
+//     historical codes.InvalidArgument. This is the FAIL-SAFE default: an error
+//     that cannot be positively identified as a tail-reconcile stays
+//     InvalidArgument, so a client is never told to retry genuinely-bad config.
+//
+// Only the machine-readable code moves; the human-readable "%v" error text is
+// byte-identical to the pre-#5742 mapping. Callers MUST pass a non-nil err.
+func commitApplyStatus(compiled *config.Config, err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return status.Errorf(codes.Canceled, "commit busy: %v", err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return status.Errorf(codes.DeadlineExceeded, "commit busy: %v", err)
+	case compiled != nil:
+		return status.Errorf(codes.Unavailable, "%v", err)
+	default:
+		return status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+}
+
 // --- Config lifecycle RPCs ---
 
 func (s *Server) EnterConfigure(ctx context.Context, req *pb.EnterConfigureRequest) (*pb.EnterConfigureResponse, error) {
@@ -231,14 +274,10 @@ func (s *Server) Commit(ctx context.Context, req *pb.CommitRequest) (*pb.CommitR
 	}
 	compiled, err := s.commitFn(ctx, req.Comment)
 	if err != nil {
-		switch {
-		case errors.Is(err, context.Canceled):
-			return nil, status.Errorf(codes.Canceled, "commit busy: %v", err)
-		case errors.Is(err, context.DeadlineExceeded):
-			return nil, status.Errorf(codes.DeadlineExceeded, "commit busy: %v", err)
-		default:
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
-		}
+		// #5742: classify structurally — a non-fatal tail-reconcile / ordinary
+		// apply error (the daemon returns the committed config alongside it) is
+		// transient/retryable (Unavailable), NOT a config reject (InvalidArgument).
+		return nil, commitApplyStatus(compiled, err)
 	}
 	return &pb.CommitResponse{Summary: summary, Warnings: configWarnings(compiled)}, nil
 }
@@ -261,14 +300,10 @@ func (s *Server) CommitConfirmed(ctx context.Context, req *pb.CommitConfirmedReq
 	}
 	compiled, err := s.commitConfirmedFn(ctx, int(req.Minutes))
 	if err != nil {
-		switch {
-		case errors.Is(err, context.Canceled):
-			return nil, status.Errorf(codes.Canceled, "commit busy: %v", err)
-		case errors.Is(err, context.DeadlineExceeded):
-			return nil, status.Errorf(codes.DeadlineExceeded, "commit busy: %v", err)
-		default:
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
-		}
+		// #5742: same structural classification as Commit — commitConfirmedAndApply
+		// shares applyAndSyncCommitted, so a non-fatal tail error carries the
+		// committed config (Unavailable/retryable) vs a nil-config config reject.
+		return nil, commitApplyStatus(compiled, err)
 	}
 	return &pb.CommitConfirmedResponse{Warnings: configWarnings(compiled)}, nil
 }

--- a/pkg/grpcapi/server_config_commit_errclass_5742_test.go
+++ b/pkg/grpcapi/server_config_commit_errclass_5742_test.go
@@ -1,0 +1,139 @@
+// #5742: the commit RPCs (Commit / CommitConfirmed) used to blanket EVERY
+// non-context commit-callback error to codes.InvalidArgument ("you sent bad
+// config"). But the daemon commit path returns a NON-FATAL tail-reconcile /
+// ordinary dataplane-apply error (networkd write #1778, Kea restart #2987,
+// IPsec reload #4433, iface reconcile #5310, non-abort apply #5679) ALONGSIDE
+// the committed config (compiled != nil, applyAndSyncCommitted) — the config is
+// valid and committed+active, only a transient control-socket step failed and
+// self-heals on retry (#5646). commitApplyStatus classifies structurally on
+// (compiled, err): a non-nil-config error → codes.Unavailable (retryable), a
+// nil-config error → codes.InvalidArgument (real config reject), with
+// context.Canceled / DeadlineExceeded preserved and checked FIRST.
+//
+// FAIL-ON-REVERT: restore the old blanket `default: status.Errorf(codes.
+// InvalidArgument, ...)` in Commit/CommitConfirmed and the
+// "tail-reconcile → Unavailable" rows below go RED (they observe
+// InvalidArgument instead), while the "schema-reject → InvalidArgument" and
+// context rows stay green.
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func newCommitClassServer(t *testing.T, compiled *config.Config, injected error) *Server {
+	t.Helper()
+	return &Server{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		commitFn: func(context.Context, string) (*config.Config, error) {
+			return compiled, injected
+		},
+		commitConfirmedFn: func(context.Context, int) (*config.Config, error) {
+			return compiled, injected
+		},
+	}
+}
+
+// TestCommitErrorClassification_5742 drives BOTH commit RPCs through injected
+// (compiled, err) callbacks and asserts the machine-readable status code is
+// classified by error class, while the human-readable message is preserved.
+func TestCommitErrorClassification_5742(t *testing.T) {
+	nonNil := &config.Config{} // daemon returns the committed config on a non-fatal tail error
+
+	tailErr := errors.New("networkd write failed: transient control-socket hiccup")
+	rejectErr := errors.New("schema validation rejected: unknown zone reference")
+
+	cases := []struct {
+		name     string
+		compiled *config.Config
+		err      error
+		wantCode codes.Code
+		wantMsg  string // substring the operator-facing message must still carry ("" = skip)
+	}{
+		{
+			// Non-fatal tail-reconcile/apply: config committed+active, transient
+			// subsystem failure → retryable. THIS is the #5742 fix.
+			name: "tail_reconcile_nonfatal", compiled: nonNil, err: tailErr,
+			wantCode: codes.Unavailable, wantMsg: "networkd write failed",
+		},
+		{
+			// Real config reject (compile/schema): no config was committed →
+			// keep the historical InvalidArgument. Fail-safe default.
+			name: "schema_reject", compiled: nil, err: rejectErr,
+			wantCode: codes.InvalidArgument, wantMsg: "schema validation rejected",
+		},
+		{
+			// A busy apply-lock / daemon-stop abort: preserved verbatim.
+			name: "context_canceled", compiled: nil, err: fmt.Errorf("commit aborted: %w", context.Canceled),
+			wantCode: codes.Canceled, wantMsg: "",
+		},
+		{
+			// Precedence guard: a wrapped context error wins even if a
+			// (malformed) callback also hands back a non-nil config — the
+			// classifier must check context errors BEFORE compiled != nil.
+			name: "context_canceled_beats_config", compiled: nonNil, err: fmt.Errorf("commit aborted: %w", context.Canceled),
+			wantCode: codes.Canceled, wantMsg: "",
+		},
+		{
+			name: "context_deadline", compiled: nil, err: fmt.Errorf("commit slow: %w", context.DeadlineExceeded),
+			wantCode: codes.DeadlineExceeded, wantMsg: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("Commit", func(t *testing.T) {
+				s := newCommitClassServer(t, tc.compiled, tc.err)
+				_, err := s.Commit(context.Background(), &pb.CommitRequest{})
+				assertCommitStatus(t, err, tc.wantCode, tc.wantMsg)
+			})
+			t.Run("CommitConfirmed", func(t *testing.T) {
+				s := newCommitClassServer(t, tc.compiled, tc.err)
+				_, err := s.CommitConfirmed(context.Background(), &pb.CommitConfirmedRequest{Minutes: 5})
+				assertCommitStatus(t, err, tc.wantCode, tc.wantMsg)
+			})
+		})
+	}
+}
+
+func assertCommitStatus(t *testing.T, err error, wantCode codes.Code, wantMsg string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("commit succeeded; want error with code %v", wantCode)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a *status.Status: %T (%v)", err, err)
+	}
+	if got := st.Code(); got != wantCode {
+		t.Fatalf("status code = %v, want %v (message %q)", got, wantCode, st.Message())
+	}
+	if wantMsg != "" && !strings.Contains(st.Message(), wantMsg) {
+		t.Fatalf("status message %q missing preserved substring %q", st.Message(), wantMsg)
+	}
+}
+
+// TestCommitSucceedsWithCommittedConfig_5742 pins that the admitted (no-error)
+// path is unchanged: a nil error yields a normal response even when the daemon
+// returns a non-nil compiled config (the same value shape as the non-fatal
+// error path), so the classification helper never trips on success.
+func TestCommitSucceedsWithCommittedConfig_5742(t *testing.T) {
+	s := newCommitClassServer(t, &config.Config{}, nil)
+	if _, err := s.Commit(context.Background(), &pb.CommitRequest{}); err != nil {
+		t.Fatalf("Commit with (nonNil config, nil err) = %v, want success", err)
+	}
+	if _, err := s.CommitConfirmed(context.Background(), &pb.CommitConfirmedRequest{Minutes: 5}); err != nil {
+		t.Fatalf("CommitConfirmed with (nonNil config, nil err) = %v, want success", err)
+	}
+}


### PR DESCRIPTION
## Summary

`Commit` / `CommitConfirmed` blanket-mapped **every** non-context commit-callback error to `codes.InvalidArgument` ("you sent bad config"). But the daemon commit path (`commitAndApply` / `commitConfirmedAndApply` → `applyAndSyncCommitted`) returns a **non-fatal tail-reconcile / ordinary dataplane-apply** error — networkd write (#1778), Kea restart (#2987), IPsec reload (#4433), interface reconcile (#5310), non-abort apply (#5679), the #5578 deletion-clear — **alongside the committed config**. In that case the config is valid and committed+active; only a transient control-socket / subsystem step failed and self-heals on retry (#5646). `InvalidArgument` misleads an operator/automation client into **editing valid config** instead of retrying.

## Fix

Add `commitApplyStatus(compiled, err)` — one private helper shared by both RPCs — that classifies **structurally** off the daemon's existing `(compiled, err)` contract (no error-text matching, no new sentinel):

- `context.Canceled` / `DeadlineExceeded` — preserved, checked **first** (a wrapped context error is never mis-mapped even if a caller also returns a non-nil config).
- Non-fatal tail-reconcile / apply error → carries the committed config (`compiled != nil`) → **`codes.Unavailable`** (transient, retryable).
- Everything else (`compiled == nil`: compiler/schema reject, `compileErrorMustAbortApply` fail-closed gate, device-map preflight, bootstrap refusal, pre-promotion persistence) → keep **`codes.InvalidArgument`**. Fail-safe default: an unclassifiable error stays `InvalidArgument`.

The human-readable `%v` message is **byte-identical**; only the status code moves. The daemon already distinctly encodes the two classes (whether it returns the committed config, `daemon_apply.go` `applyAndSyncCommitted`), so **no sentinel was added**.

## Consumer check

No `pkg/cli` / `cmd/cli` code switches on the commit status code — the remote CLI wraps the message verbatim (`fmt.Errorf("commit failed: %v", err)`), the local CLI calls `store.Commit()` directly. **No consumer update required.**

## Tests

`server_config_commit_errclass_5742_test.go` table-drives **both** RPCs through injected `(compiled, err)` callbacks:
- tail-reconcile error → `Unavailable`
- schema reject → `InvalidArgument`
- `context.Canceled` / `DeadlineExceeded` retain their codes (incl. a precedence row with a non-nil config)
- success path (non-nil config, nil err) unchanged

**Fail-on-revert** verified via `-overlay`: restoring the blanket `default: InvalidArgument` turns the tail-reconcile→`Unavailable` rows RED for both `Commit` and `CommitConfirmed`, while schema/context rows stay green.

Validation: `go build ./...`, `go vet ./pkg/grpcapi/`, `go test -race ./pkg/grpcapi/ ./pkg/cli/` all green. Existing `TestCommit*RejectsRetiredEBPF` (nil-config rejects) remain `InvalidArgument`. Doc: `pkg/grpcapi/README.md` gains the commit error-code contract.

Closes #5742

🤖 Generated with [Claude Code](https://claude.com/claude-code)