### PR TITLE
dhcp: discard explicitly-invalidated DHCPv6 IA_NA address on renew (#5927)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48877,3 +48877,24 @@ top.
   - **File(s)**: pkg/grpcapi/server_show_status.go, pkg/grpcapi/server_show_system.go,
     pkg/grpcapi/server_show.go, pkg/diagcmd/limiter.go,
     pkg/grpcapi/server_sessioncount_bound_5782_test.go
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5927 DHCPv6 explicit valid-lifetime-0 IA_NA invalidation (RFC 8415
+    §18.2.10.1). Diagnosis: the ticket's floor at dhcp.go (`LeaseTime==0 → 3600`)
+    is a RED HERRING — selectIANAAddress (#4383) already skips 0-lifetime IAADDRs,
+    so parseV6Reply errors before the floor (floor only hit in the degenerate no-IA
+    config). Real gap: the RENEW/REBIND loop treated the explicit-0 error as a
+    TRANSIENT failure (keep-and-wait-T2), keeping a server-invalidated address in
+    service. Fix: thread present-0-vs-absent through selectIANAAddress (added
+    sawZeroLifetime return) → parseV6Reply returns a DISTINCT errV6AddrInvalidated
+    sentinel ONLY when a present-but-0 IAADDR left no usable address (fail-safe
+    toward keep on absent/transient) → the renew AND rebind loops errors.Is-check
+    the sentinel and DECONFIGURE the held address + re-acquire (IA_NA analog of the
+    IA_PD withdrawal reconcile). Floor left as-is with a clarifying comment.
+    Guardrail: an ABSENT IA_NA (generic error) still KEEPS the address + retries
+    (no over-correction). Fail-on-revert proven via -overlay (remove the deconfigure
+    branches → (b) invalidation kept-and-rebinds, test RED; (d) absent stays green).
+    OUT OF SCOPE noted: address-change-on-renew (different addr, lifetime>0) is a
+    separate concern, not #5927.
+  - **File(s)**: pkg/dhcp/dhcp.go, pkg/dhcp/dhcpv6_zero_lifetime_invalidate_5927_test.go,
+    pkg/dhcp/dhcpv6_iana_test.go (signature), pkg/dhcp/README.md

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -104,6 +104,20 @@ the debounced `onAddressChange` callback when content changed.
   abandoning the cycle and re-acquiring, paced by `reacquireBackstop` so a
   server that keeps granting a 0-second lease cannot become a tight
   DISCOVER/SOLICIT loop. v4 and v6 share this one definition.
+- **DHCPv6 explicit valid-lifetime-0 invalidation (RFC 8415 §18.2.10.1,
+  #5927)**: a Reply that carries an IA_NA whose IAADDR(s) are **all
+  valid-lifetime 0** is the server's directive to STOP using the held
+  address. `selectIANAAddress` skips 0-lifetime IAADDRs (#4383) and
+  `parseV6Reply` reports this distinctly via the `errV6AddrInvalidated`
+  sentinel (present-but-0), separate from the generic "no usable IA_NA /
+  live IA_PD" error (an **absent / transient** reply). On the sentinel
+  during RENEW/REBIND the run loop **deconfigures** the held address and
+  re-acquires — the IA_NA analog of the IA_PD withdrawal reconcile — while
+  a merely absent/transient reply **keeps** the address and retries
+  (T1→T2→solicit, the #4874/#1844 anti-outage path). NOTE: the
+  `LeaseTime == 0 → 3600s` default in `parseV6Reply` is NOT this path — it
+  only applies to a degenerate no-IA config; the explicit-0 invalidation
+  is handled before it.
 - **Successful T1 renew / T2 rebind is committed**, and the run loop
   returns to the T1 wait with timers recomputed from the renewed
   lease. Pre-#1777 the renewal result was dead-assigned and the loop

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -1045,6 +1045,21 @@ func (m *Manager) runDHCPv4(ctx context.Context, ifaceName string) {
 // discriminator is errors.Is(err, errDHCPNAK); see runDHCPv4 (#3956).
 var errDHCPNAK = errors.New("DHCPv4 server sent NAK")
 
+// errV6AddrInvalidated signals that a DHCPv6 Reply EXPLICITLY invalidated the
+// held IA_NA address: the reply carried IA_NA IAADDR option(s) that were ALL
+// valid-lifetime 0 (RFC 8415 §18.2.10.1 — the address is no longer valid and
+// MUST be discarded), with no live IA_NA address and no live delegated prefix
+// to fall back to. It is DISTINCT from the generic "no usable IA_NA / live
+// IA_PD" error, which means the reply carried NO usable IAADDR at all (an
+// ABSENT / transient reply — server omission or packet loss). The
+// discriminator is errors.Is(err, errV6AddrInvalidated): on an EXPLICIT
+// invalidation the renew/rebind loop DECONFIGURES the held address and
+// re-acquires (§18.2.10.1); on the ABSENT/transient error it KEEPS the address
+// and retries (T1→T2→solicit), the correct #4874/#1844 anti-outage behavior.
+// Fail SAFE toward keep-and-retry: the sentinel is returned ONLY when a
+// present-but-0 IAADDR is positively observed (#5927).
+var errV6AddrInvalidated = errors.New("DHCPv6 reply explicitly invalidated the held IA_NA address (valid-lifetime 0)")
+
 // abandonLeaseAfterNAK deconfigures the interface and drops the lease
 // record after a DHCPNAK revoked the lease (RFC 2131 §4.4.5). The client
 // must stop using the address immediately and return to INIT — it must
@@ -1438,6 +1453,25 @@ func (m *Manager) runDHCPv6(ctx context.Context, ifaceName string) {
 					"lease_time", committed.LeaseTime)
 				continue
 			}
+			if errors.Is(rerr, errV6AddrInvalidated) {
+				// #5927: the server EXPLICITLY invalidated the held IA_NA
+				// address (valid-lifetime 0). RFC 8415 §18.2.10.1: stop using
+				// it NOW — deconfigure + re-acquire, do NOT keep it and wait for
+				// T2 (which would keep a server-withdrawn address in service).
+				// This is the IA_NA analog of the IA_PD withdrawal reconcile
+				// above. A merely absent/transient renew reply keeps the
+				// generic error and the keep-and-wait-T2 path below (#4874).
+				slog.Info("DHCPv6: server invalidated held address (valid-lifetime 0), deconfiguring and re-acquiring",
+					"interface", ifaceName, "address", committed.Address)
+				if committed.Address.IsValid() {
+					m.removeAddress(ifaceName, committed)
+				}
+				m.mu.Lock()
+				delete(m.leases, key)
+				delete(m.delegatedPDs, ifaceName)
+				m.mu.Unlock()
+				break // re-acquire from a fresh solicit
+			}
 			slog.Warn("DHCPv6: T1 renewal failed, waiting for T2",
 				"interface", ifaceName, "err", rerr)
 
@@ -1472,6 +1506,22 @@ func (m *Manager) runDHCPv6(ctx context.Context, ifaceName string) {
 					"delegated_prefixes", len(renewed.prefixes),
 					"lease_time", committed.LeaseTime)
 				continue
+			}
+			if errors.Is(rerr, errV6AddrInvalidated) {
+				// #5927: explicit invalidation on REBIND too — deconfigure the
+				// held address before falling back to a fresh solicit (the
+				// generic rebind-failure break below keeps it in service until
+				// re-acquire, which is correct only for a transient failure).
+				slog.Info("DHCPv6: server invalidated held address on rebind (valid-lifetime 0), deconfiguring and re-acquiring",
+					"interface", ifaceName, "address", committed.Address)
+				if committed.Address.IsValid() {
+					m.removeAddress(ifaceName, committed)
+				}
+				m.mu.Lock()
+				delete(m.leases, key)
+				delete(m.delegatedPDs, ifaceName)
+				m.mu.Unlock()
+				break
 			}
 			slog.Warn("DHCPv6: T2 rebind failed, lease will expire, re-acquiring",
 				"interface", ifaceName, "err", rerr)
@@ -1612,12 +1662,21 @@ func (m *Manager) doDHCPv6(ctx context.Context, ifaceName string, mode dhcpExcha
 // caller pairs lease.LeaseTime with the right lifetime rather than a
 // stale one from a different IAADDR. Returns an invalid Addr and zero
 // duration when the reply carries no usable IA_NA address.
-func selectIANAAddress(adv *dhcpv6.Message) (netip.Addr, time.Duration) {
+//
+// The third return, sawZeroLifetime, reports whether the reply carried an
+// IA_NA IAADDR option with valid-lifetime 0 (an explicit stop-using directive,
+// RFC 8415 §18.2.10.1). Combined with an invalid returned Addr (no positive
+// address selectable), it lets the caller distinguish an EXPLICIT invalidation
+// (present-but-0 → discard the held address) from an ABSENT IA_NA (no IAADDR
+// at all → keep + retry). A reply with both a 0-lifetime and a positive IAADDR
+// still selects the positive one (valid Addr) — not an invalidation. (#5927)
+func selectIANAAddress(adv *dhcpv6.Message) (addr netip.Addr, validLT time.Duration, sawZeroLifetime bool) {
 	var (
 		best      netip.Addr
 		bestValid time.Duration
 		bestPref  time.Duration
 		found     bool
+		sawZero   bool
 	)
 	for _, opt := range adv.Options.Options {
 		ianaOpt, ok := opt.(*dhcpv6.OptIANA)
@@ -1629,8 +1688,11 @@ func selectIANAAddress(adv *dhcpv6.Message) (netip.Addr, time.Duration) {
 			if !ok {
 				continue
 			}
-			// Expired/declined address — never install it (F-264).
+			// Expired/declined address — never install it (F-264). Record
+			// that a present-but-0 IAADDR was seen so the caller can tell an
+			// EXPLICIT invalidation from an absent IA_NA (#5927).
 			if iaaddr.ValidLifetime == 0 {
+				sawZero = true
 				continue
 			}
 			a, ok := netip.AddrFromSlice(iaaddr.IPv6Addr)
@@ -1647,7 +1709,7 @@ func selectIANAAddress(adv *dhcpv6.Message) (netip.Addr, time.Duration) {
 			}
 		}
 	}
-	return best, bestValid
+	return best, bestValid, sawZero
 }
 
 // parseV6Reply extracts the lease (IA_NA address, lifetime, DNS, gateway)
@@ -1681,9 +1743,16 @@ func (m *Manager) parseV6Reply(ctx context.Context, ifaceName string, adv *dhcpv
 	// paired with a stale value from a different address (#4383).
 	var addr netip.Addr
 	var validLT time.Duration
+	// iaNAExplicitlyInvalidated: the reply carried IA_NA IAADDR(s) that were
+	// ALL valid-lifetime 0 (no positive address selectable) — the server's
+	// RFC 8415 §18.2.10.1 "stop using this address" directive (#5927). Kept
+	// distinct from an absent IA_NA so the caller can discard vs keep+retry.
+	var iaNAExplicitlyInvalidated bool
 
 	if wantNA {
-		addr, validLT = selectIANAAddress(adv)
+		var sawZeroLifetime bool
+		addr, validLT, sawZeroLifetime = selectIANAAddress(adv)
+		iaNAExplicitlyInvalidated = !addr.IsValid() && sawZeroLifetime
 	}
 
 	// Extract IA_PD delegated prefixes, split into live and (RFC 8415
@@ -1711,6 +1780,15 @@ func (m *Manager) parseV6Reply(ctx context.Context, ifaceName string, adv *dhcpv
 	// Codex F6). The trailing wantNA||wantPD guard keeps a degenerate
 	// no-IA config on its prior no-reject path.
 	if !addr.IsValid() && len(result.prefixes) == 0 && (wantNA || wantPD) {
+		// #5927: distinguish an EXPLICIT invalidation (the reply carried an
+		// IA_NA whose IAADDR(s) were all valid-lifetime 0 — RFC 8415
+		// §18.2.10.1, stop using the address) from an ABSENT / transient reply
+		// (no usable IAADDR at all). Only the former returns the
+		// errV6AddrInvalidated sentinel, on which the renew/rebind loop
+		// deconfigures the held address; the generic error keeps it + retries.
+		if iaNAExplicitlyInvalidated {
+			return nil, fmt.Errorf("DHCPv6 reply on %s: %w", ifaceName, errV6AddrInvalidated)
+		}
 		return nil, fmt.Errorf("no usable IA_NA address or live IA_PD prefix in DHCPv6 reply on %s", ifaceName)
 	}
 
@@ -1732,6 +1810,15 @@ func (m *Manager) parseV6Reply(ctx context.Context, ifaceName string, adv *dhcpv
 		lease.LeaseTime = result.prefixes[0].ValidLifetime
 	}
 
+	// A sane default for the DEGENERATE no-IA config (wantNA=false &&
+	// wantPD=false), the only shape that reaches here with LeaseTime 0: a
+	// selected IA_NA address and a live IA_PD prefix both carry a positive
+	// lifetime (selectIANAAddress skips valid-lifetime-0 IAADDRs, #4383;
+	// extractDelegatedPrefixes routes valid-lifetime-0 prefixes to
+	// withdrawnPDs). This is NOT the explicit-0 invalidation path — that is
+	// handled upstream at the "no usable IA_NA / live IA_PD" guard, which
+	// returns errV6AddrInvalidated so the renew/rebind loop deconfigures the
+	// held address (RFC 8415 §18.2.10.1, #5927), never reaching this floor.
 	if lease.LeaseTime == 0 {
 		lease.LeaseTime = 3600 * time.Second
 	}

--- a/pkg/dhcp/dhcpv6_iana_test.go
+++ b/pkg/dhcp/dhcpv6_iana_test.go
@@ -153,7 +153,7 @@ func TestSelectIANAAddressTieBreak(t *testing.T) {
 			ValidLifetime:     800 * time.Second,
 		},
 	)
-	addr, validLT := selectIANAAddress(adv)
+	addr, validLT, _ := selectIANAAddress(adv)
 	if addr != netip.MustParseAddr("2001:db8::c") {
 		t.Errorf("tie-break address = %v, want 2001:db8::c (first-seen)", addr)
 	}
@@ -186,7 +186,7 @@ func TestSelectIANAAddressMultipleIANA(t *testing.T) {
 	adv.AddOption(iana1)
 	adv.AddOption(iana2)
 
-	addr, validLT := selectIANAAddress(adv)
+	addr, validLT, _ := selectIANAAddress(adv)
 	if addr != netip.MustParseAddr("2001:db8::2") {
 		t.Errorf("address = %v, want 2001:db8::2 (longest preferred across IA_NA options)", addr)
 	}

--- a/pkg/dhcp/dhcpv6_zero_lifetime_invalidate_5927_test.go
+++ b/pkg/dhcp/dhcpv6_zero_lifetime_invalidate_5927_test.go
@@ -1,0 +1,201 @@
+package dhcp
+
+// #5927: a DHCPv6 Reply with an EXPLICIT valid-lifetime 0 for the held IA_NA
+// address (RFC 8415 §18.2.10.1 — "stop using this address") must DISCARD the
+// address: deconfigure + re-acquire, not keep it in service. The floor at
+// dhcp.go (`if lease.LeaseTime == 0 { 3600 }`) was a RED HERRING for this —
+// selectIANAAddress (#4383) already skips valid-lifetime-0 IAADDRs, so the
+// address is never selected and parseV6Reply errors before the floor. The real
+// residual was the RENEW/REBIND loop treating that error as a TRANSIENT failure
+// (keep-and-wait-T2) instead of an explicit invalidation.
+//
+// The fix threads a present-0-vs-absent signal through selectIANAAddress /
+// parseV6Reply (the errV6AddrInvalidated sentinel) so the loop can DECONFIGURE
+// on an explicit invalidation (b) while KEEPING the address on a merely absent /
+// transient reply (d) — the correct #4874/#1844 anti-outage behavior.
+//
+// FAIL-ON-REVERT: remove the `errors.Is(rerr, errV6AddrInvalidated)` deconfigure
+// branch from the renew loop → an explicit invalidation is treated as a generic
+// failure → the loop keeps the address and issues a REBIND (kept-and-wait-T2) →
+// TestRunDHCPv6ExplicitInvalidationDeconfigures_5927's "no REBIND / lease
+// deleted" assertions go RED. The (d) absent test guards against over-correcting
+// the transient path into a deconfigure.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+// (parse layer) present-0 → sentinel; absent → generic; positive/infinite → install.
+func TestParseV6ReplyZeroLifetimeDistinction_5927(t *testing.T) {
+	m := &Manager{}
+
+	// (b) The only IA_NA IAADDR has valid-lifetime 0 → explicit invalidation.
+	advZero := iaNAReply(t, &dhcpv6.OptIAAddress{
+		IPv6Addr:          mustIP(t, "2001:db8::1"),
+		PreferredLifetime: 100 * time.Second,
+		ValidLifetime:     0,
+	})
+	if _, err := m.parseV6Reply(context.Background(), "wan0", advZero, nil); !errors.Is(err, errV6AddrInvalidated) {
+		t.Fatalf("explicit valid-lifetime-0 IA_NA: err=%v, want errV6AddrInvalidated (present-0 invalidation)", err)
+	}
+
+	// (d) No IA_NA option at all → absent/transient → generic error, NOT the
+	// sentinel (the loop must keep + retry, never deconfigure on this).
+	advAbsent, err := dhcpv6.NewMessage()
+	if err != nil {
+		t.Fatalf("NewMessage: %v", err)
+	}
+	advAbsent.MessageType = dhcpv6.MessageTypeReply
+	_, err = m.parseV6Reply(context.Background(), "wan0", advAbsent, nil)
+	if err == nil {
+		t.Fatal("absent IA_NA: want an error")
+	}
+	if errors.Is(err, errV6AddrInvalidated) {
+		t.Fatal("absent IA_NA wrongly returned the invalidation sentinel — would deconfigure on a transient reply (over-correction)")
+	}
+
+	// (ii) Positive lifetime → installs normally, no sentinel.
+	advPos := iaNAReply(t, &dhcpv6.OptIAAddress{
+		IPv6Addr:          mustIP(t, "2001:db8::2"),
+		PreferredLifetime: 50 * time.Second,
+		ValidLifetime:     100 * time.Second,
+	})
+	res, err := m.parseV6Reply(context.Background(), "wan0", advPos, nil)
+	if err != nil {
+		t.Fatalf("positive lifetime: %v", err)
+	}
+	if !res.lease.Address.IsValid() || res.lease.LeaseTime != 100*time.Second {
+		t.Fatalf("positive lifetime: addr=%v leaseTime=%v, want installed with 100s", res.lease.Address, res.lease.LeaseTime)
+	}
+
+	// (iii) 0xFFFFFFFF (infinite) is a non-zero lifetime → installed normally,
+	// never mistaken for an invalidation.
+	advInf := iaNAReply(t, &dhcpv6.OptIAAddress{
+		IPv6Addr:          mustIP(t, "2001:db8::3"),
+		PreferredLifetime: 0xFFFFFFFF * time.Second,
+		ValidLifetime:     0xFFFFFFFF * time.Second,
+	})
+	res, err = m.parseV6Reply(context.Background(), "wan0", advInf, nil)
+	if err != nil {
+		t.Fatalf("infinite lifetime: %v", err)
+	}
+	if !res.lease.Address.IsValid() {
+		t.Fatal("infinite lifetime: address not installed")
+	}
+}
+
+func newV6InvalidationManager(modes *[]dhcpExchangeMode, exchange func(n int, mode dhcpExchangeMode) (*dhcpv6Result, error)) *Manager {
+	m := &Manager{
+		leases:               map[clientKey]*Lease{},
+		delegatedPDs:         map[string][]DelegatedPrefix{},
+		v6opts:               map[string]*DHCPv6Options{"wan0": {IATypes: []string{"ia-na"}}},
+		afterForTest:         immediateAfter,
+		waitLinkLocalForTest: func(context.Context, string, time.Duration) error { return nil },
+	}
+	m.doV6ExchangeForTest = func(_ context.Context, _ string, mode dhcpExchangeMode, _ *Lease, _ []DelegatedPrefix) (*dhcpv6Result, error) {
+		*modes = append(*modes, mode)
+		return exchange(len(*modes), mode)
+	}
+	return m
+}
+
+// (b) run loop: an explicit invalidation on RENEW deconfigures the held address
+// and re-acquires via a fresh SOLICIT — it does NOT keep it and wait for T2.
+func TestRunDHCPv6ExplicitInvalidationDeconfigures_5927(t *testing.T) {
+	leaseX := &Lease{
+		Interface: "wan0", Family: AFInet6,
+		Address:   netip.MustParsePrefix("2001:db8::1/128"),
+		LeaseTime: 100 * time.Second,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var modes []dhcpExchangeMode
+	m := newV6InvalidationManager(&modes, func(n int, _ dhcpExchangeMode) (*dhcpv6Result, error) {
+		switch n {
+		case 1: // acquire → install X
+			return &dhcpv6Result{lease: leaseX}, nil
+		case 2: // T1 renew → server explicitly invalidates X (valid-lifetime 0)
+			return nil, fmt.Errorf("renew: %w", errV6AddrInvalidated)
+		default: // re-acquire SOLICIT reached → cancel so the loop exits
+			cancel()
+			return nil, context.Canceled
+		}
+	})
+
+	done := make(chan struct{})
+	go func() { m.runDHCPv6(ctx, "wan0"); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runDHCPv6 did not terminate")
+	}
+
+	key := clientKey{iface: "wan0", family: AFInet6}
+	m.mu.Lock()
+	_, stillHeld := m.leases[key]
+	m.mu.Unlock()
+	if stillHeld {
+		t.Fatal("held address was NOT deconfigured on explicit invalidation (lease still present) — kept an address the server invalidated")
+	}
+	if len(modes) < 3 {
+		t.Fatalf("expected >=3 exchanges (acquire, renew, re-solicit), got %d: %v", len(modes), modes)
+	}
+	for i, md := range modes {
+		if md == exchangeRebind {
+			t.Fatalf("loop issued a REBIND (exchange %d) after explicit invalidation — that is kept-and-wait-T2; want deconfigure + fresh SOLICIT, modes=%v", i, modes)
+		}
+	}
+}
+
+// (d) run loop guardrail: an ABSENT / transient RENEW reply (generic error, NOT
+// the invalidation sentinel) must KEEP the held address and fall through to the
+// T2 REBIND — the fix must not over-correct the transient path into a deconfigure.
+func TestRunDHCPv6AbsentIANAKeepsAddress_5927(t *testing.T) {
+	leaseX := &Lease{
+		Interface: "wan0", Family: AFInet6,
+		Address:   netip.MustParsePrefix("2001:db8::1/128"),
+		LeaseTime: 100 * time.Second,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var modes []dhcpExchangeMode
+	m := newV6InvalidationManager(&modes, func(n int, _ dhcpExchangeMode) (*dhcpv6Result, error) {
+		switch n {
+		case 1: // acquire → install X
+			return &dhcpv6Result{lease: leaseX}, nil
+		case 2: // T1 renew → generic transient failure (NO usable IA_NA), NOT the sentinel
+			return nil, fmt.Errorf("no usable IA_NA address or live IA_PD prefix in DHCPv6 reply on wan0")
+		default: // T2 REBIND reached (address was KEPT) → cancel so the loop exits
+			cancel()
+			return nil, context.Canceled
+		}
+	})
+
+	done := make(chan struct{})
+	go func() { m.runDHCPv6(ctx, "wan0"); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runDHCPv6 did not terminate")
+	}
+
+	key := clientKey{iface: "wan0", family: AFInet6}
+	m.mu.Lock()
+	held := m.leases[key]
+	m.mu.Unlock()
+	if held == nil {
+		t.Fatal("held address was deconfigured on a transient absent-IA_NA renew — over-correction; the transient path must keep + retry")
+	}
+	if len(modes) < 3 || modes[2] != exchangeRebind {
+		t.Fatalf("expected acquire→renew→REBIND (keep-and-wait-T2), got modes=%v", modes)
+	}
+}


### PR DESCRIPTION
## Defect

A DHCPv6 Reply carrying an IA_NA whose IAADDR(s) are **all valid-lifetime 0** is the server's RFC 8415 §18.2.10.1 directive to **stop using the held address**. xpf kept using it.

**The ticket's floor (`LeaseTime==0 → 3600s` in `parseV6Reply`) is a RED HERRING** for this: `selectIANAAddress` (#4383) already skips valid-lifetime-0 IAADDRs, so an explicit-0 address is never selected → `parseV6Reply` errors at the "no usable IA_NA / live IA_PD" guard **before** the floor (the floor is only reachable in the degenerate no-IA config). The real residual is the **RENEW/REBIND loop**: it treated that error as a **transient** failure (keep the address, wait T2, rebind, re-solicit), so the held address stayed configured across the whole window even though the server withdrew it — unlike the IA_PD path, which reconciles a withdrawal.

## The crux — distinguish two cases that produced the same error

- **(b) explicit invalidation**: IA_NA IAADDR(s) present, all valid-lifetime 0 → discard (deconfigure + re-acquire).
- **(d) absent / transient**: no usable IAADDR at all → keep + retry (the correct #4874/#1844 anti-outage behavior).

## Fix (fails SAFE toward keep-and-retry)

- `selectIANAAddress` returns a third value `sawZeroLifetime` (a present-but-0 IAADDR was observed);
- `parseV6Reply` returns a **distinct `errV6AddrInvalidated` sentinel** only when a present-but-0 IAADDR left no usable address (never for a merely absent IA_NA);
- the renew **and** rebind loops `errors.Is`-check the sentinel and **deconfigure** the held address + re-acquire (the IA_NA analog of the IA_PD withdrawal reconcile), instead of keep-and-wait-T2.

The floor is left unchanged (correct degenerate-no-IA default) with a clarifying comment. The `0xFFFFFFFF` infinite sentinel (non-zero) and the IA_PD withdrawal reconcile are unaffected.

**Out of scope** (noted for a future issue): address-change-on-renew (a different address with lifetime > 0) is a separate concern from explicit-0 invalidation.

## Tests

`dhcpv6_zero_lifetime_invalidate_5927_test.go`:
- parse layer: present-0 → sentinel; absent → generic error (**not** the sentinel); positive + `0xFFFFFFFF` → installed;
- run loop **(b)**: held IA_NA X + RENEW valid-lifetime 0 → X **deconfigured** + fresh SOLICIT, **no rebind**;
- run loop **(d)**: absent-IA_NA RENEW → X **kept** + T2 REBIND (over-correction guard).

Proven **RED on revert** of the deconfigure branches via `go test -overlay`: (b) goes RED (address kept, rebinds); (d) stays green. Full `go test -race ./pkg/dhcp/` green (the #4874 IA_PD withdrawal test and existing `selectIANAAddress` tests unaffected).

## Validation

`go build ./...` clean; `go vet ./pkg/dhcp/` clean; `go test -race ./pkg/dhcp/` green.

Closes #5927

🤖 Generated with [Claude Code](https://claude.com/claude-code)