### PR TITLE
api: abort the cursor session walk on client disconnect (#5233)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48948,3 +48948,28 @@ top.
     both Commit and CommitConfirmed; schema/context rows stay green).
   - **File(s)**: pkg/grpcapi/server_config.go,
     pkg/grpcapi/server_config_commit_errclass_5742_test.go, pkg/grpcapi/README.md
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5233 close the CURSOR-path residual of the session-walk
+    context-cancel fix. The non-cursor session handlers (sessionsOffset /
+    sessionSummaryHandler / sessionZonePairHandler) were already guarded by the
+    merged newRequestCancelSampler; the issue's own closeout comment (codex-183)
+    named the residual: sessionsCursor (pkg/api/sessions.go) — the page_size>0
+    cursor path over IterateSessionsFrom/IterateSessionsV6From — checked only
+    len(all) >= pageSize, never r.Context(). A selective/no-match cursor query
+    never fills the page, so the callback walked the rest of a multi-million-entry
+    conntrack table holding per-bucket BPF-map locks for a page nobody will read,
+    and it transitioned into the v6 full walk unconditionally after v4. Wired the
+    SAME sampler into both cursor callbacks (return false on cancel) and added a
+    direct r.Context().Err() check before the v6 phase and before the terminal
+    envelope, so a disconnect neither launches the second walk nor emits a
+    misleading next_page_token/partial page (nor the include_peer fan-out inside
+    writeSessionList). Full-page writes stay unguarded (valid complete results);
+    non-cancelled page-token/error semantics unchanged. New cursor-capable
+    counting fake (cursorCountDP) + fail-on-revert tests extend
+    api_ctx_cancel_5232_5233_test.go. Fail-on-revert proven via -overlay (strip
+    the cursor checks -> cancelled walks run all 20480 entries + write an
+    envelope, tests RED). pkg/api/README.md cancel-contract section updated for
+    the cursor path.
+  - **File(s)**: pkg/api/sessions.go, pkg/api/api_ctx_cancel_5232_5233_test.go,
+    pkg/api/README.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -440,8 +440,18 @@ under the daemon's errgroup. Nothing else imports this package.
   session-sync path (#5233) instead of holding it for a discarded scan. The
   sampler probes `ctx.Err()` once per batch (not per session) so the check
   adds no per-entry cost, and it never fires on the normal path — output and
-  ordering are unchanged. Pinned by `api_ctx_cancel_5232_5233_test.go`. This
-  is the REST analog of the gRPC `streamDiagCmd` cancellation cleanup (#5060).
+  ordering are unchanged. The `/sessions` CURSOR path (`page_size>0`,
+  `sessionsCursor` over `IterateSessionsFrom`/`IterateSessionsV6From`) uses the
+  SAME sampler in both cursor callbacks — a selective/no-match query never
+  fills the page, so without it the callback would walk the rest of the table —
+  PLUS a direct `r.Context().Err()` check at each phase boundary: it does not
+  start the second (v6) full walk after a cancelled v4 phase, and does not emit
+  a misleading terminal `next_page_token`/partial-page envelope (nor the
+  `include_peer` fan-out inside `writeSessionList`) to a dead connection. A full
+  page is still emitted normally — it is a complete, valid result. Pinned by
+  `api_ctx_cancel_5232_5233_test.go` (`TestSessionsCursorAbortsWalkOnCanceledContext_5233`
+  for the cursor path). This is the REST analog of the gRPC `streamDiagCmd`
+  cancellation cleanup (#5060).
 - Session-count metrics come from the LIVE dataplane session table, not
   the BPF GC sweep stats (#3929). `collectSessionGauges`
   (`metrics_sessions.go`) derives `xpf_sessions_active` (forward entries)

--- a/pkg/api/api_ctx_cancel_5232_5233_test.go
+++ b/pkg/api/api_ctx_cancel_5232_5233_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -213,4 +215,137 @@ func TestSessionHandlersAbortWalkOnCanceledContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+// cursorCountDP is the CURSOR-path analogue of cancelCountDP: it serves nV4
+// forward v4 sessions and nV6 forward v6 sessions through the
+// sessionCursorIterator (IterateSessionsFrom / IterateSessionsV6From) that
+// s.sessionsCursor drives, counting how many of each family the walk visited
+// before it stopped. The embedded *dataplane.Manager satisfies the rest of the
+// apiRuntimeDataPlane surface (and its GetSessionV4/V6 "map not found" makes
+// enrichSessionV4/V6 a no-op merge). cancelCountDP deliberately implements only
+// the NON-cursor iterators, so sessionsCursor was never exercised and the
+// cursor-path context-cancel gap remained open until #5233's closeout.
+type cursorCountDP struct {
+	*dataplane.Manager
+	nV4, nV6             int
+	visitedV4, visitedV6 int
+}
+
+func (d *cursorCountDP) IsLoaded() bool { return true }
+
+func (d *cursorCountDP) IterateSessionsFrom(_ *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for i := 0; i < d.nV4; i++ {
+		d.visitedV4++
+		var k dataplane.SessionKey
+		var v dataplane.SessionValue // IsReverse==0 => matchV4 admits it
+		if !fn(k, v) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (d *cursorCountDP) IterateSessionsV6From(_ *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for i := 0; i < d.nV6; i++ {
+		d.visitedV6++
+		var k dataplane.SessionKeyV6
+		var v dataplane.SessionValueV6
+		if !fn(k, v) {
+			return nil
+		}
+	}
+	return nil
+}
+
+// TestSessionsCursorAbortsWalkOnCanceledContext_5233 pins the cursor-path half
+// of #5233 (the residual left open when the non-cursor handlers were guarded).
+// A page_size>0 request routes to sessionsCursor via the sessionCursorIterator
+// assertion; a destination_port filter that no zero-value synthetic session can
+// match means the page NEVER fills, so ONLY the request-context checks can bound
+// the walk — isolating the fix from the len(all)>=pageSize page cap.
+//
+// FAIL-ON-REVERT: drop the cancelled()/r.Context().Err() checks from
+// sessionsCursor and the cancelled walks run every entry (v4 == n, v6 == n) and
+// write a terminal envelope — flipping every assertion below red.
+func TestSessionsCursorAbortsWalkOnCanceledContext_5233(t *testing.T) {
+	const n = 20 * sessionWalkCancelInterval
+	// No zero-key session matches destination_port=443, so len(all) stays 0 and
+	// the page (page_size=500) never fills.
+	const noMatch = "page_size=500&destination_port=443"
+
+	t.Run("cancelled no-match stops v4 within one window and skips v6", func(t *testing.T) {
+		dp := &cursorCountDP{Manager: dataplane.New(), nV4: n, nV6: n}
+		s := &Server{dp: dp}
+		rr := httptest.NewRecorder()
+		s.sessionsHandler(rr, cancelledRequest(httptest.NewRequest(http.MethodGet, "/api/v1/sessions?"+noMatch, nil)))
+
+		if dp.visitedV4 != sessionWalkCancelInterval {
+			t.Errorf("v4 visited %d, want %d (one sampling window before the abort)", dp.visitedV4, sessionWalkCancelInterval)
+		}
+		if dp.visitedV6 != 0 {
+			t.Errorf("v6 visited %d, want 0 (the v6 phase must not start after a cancelled v4 walk)", dp.visitedV6)
+		}
+		// No envelope: the handler returned before writeSessionList, so the
+		// (misleading) terminal page — AND the include_peer fan-out that
+		// writeSessionList performs first — never ran on the dead connection.
+		if rr.Body.Len() != 0 {
+			t.Errorf("cancelled cursor walk wrote a %d-byte envelope, want none: %s", rr.Body.Len(), rr.Body.String())
+		}
+	})
+
+	t.Run("cancelled v6start-token does not start the v6 walk", func(t *testing.T) {
+		dp := &cursorCountDP{Manager: dataplane.New(), nV6: n}
+		s := &Server{dp: dp}
+		rr := httptest.NewRecorder()
+		v6start := base64.RawURLEncoding.EncodeToString([]byte("v6start"))
+		s.sessionsHandler(rr, cancelledRequest(httptest.NewRequest(http.MethodGet,
+			"/api/v1/sessions?"+noMatch+"&page_token="+v6start, nil)))
+
+		if dp.visitedV6 != 0 {
+			t.Errorf("v6 visited %d on a cancelled v6start request, want 0 (the pre-v6 ctx check must fire before the walk)", dp.visitedV6)
+		}
+		if rr.Body.Len() != 0 {
+			t.Errorf("cancelled v6start walk wrote a %d-byte envelope, want none: %s", rr.Body.Len(), rr.Body.String())
+		}
+	})
+
+	t.Run("non-cancelled no-match walks BOTH families fully and writes the last page", func(t *testing.T) {
+		dp := &cursorCountDP{Manager: dataplane.New(), nV4: n, nV6: n}
+		s := &Server{dp: dp}
+		rr := httptest.NewRecorder()
+		s.sessionsHandler(rr, httptest.NewRequest(http.MethodGet, "/api/v1/sessions?"+noMatch, nil))
+
+		if dp.visitedV4 != n {
+			t.Errorf("v4 visited %d, want all %d (the cancel check must be inert on the normal path)", dp.visitedV4, n)
+		}
+		if dp.visitedV6 != n {
+			t.Errorf("v6 visited %d, want all %d", dp.visitedV6, n)
+		}
+		if rr.Code != http.StatusOK || rr.Body.Len() == 0 {
+			t.Errorf("non-cancelled cursor walk: code=%d body=%d, want 200 with a terminal envelope", rr.Code, rr.Body.Len())
+		}
+	})
+
+	// Page-token semantics preserved on the normal path: a match-all request
+	// fills exactly one page and emits a v4 next_page_token (omitempty, so its
+	// presence proves a resume token was issued).
+	t.Run("non-cancelled match-all fills a page and issues a next-page token", func(t *testing.T) {
+		dp := &cursorCountDP{Manager: dataplane.New(), nV4: n, nV6: n}
+		s := &Server{dp: dp}
+		rr := httptest.NewRecorder()
+		s.sessionsHandler(rr, httptest.NewRequest(http.MethodGet, "/api/v1/sessions?page_size=100", nil))
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("match-all cursor request: code=%d, want 200; body: %s", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), `"next_page_token"`) {
+			t.Errorf("full page must emit a next_page_token (page-token semantics preserved); body: %s", rr.Body.String())
+		}
+		// The v4 walk stops one probe past the full page (pageSize appended, the
+		// next callback observes len(all)>=pageSize) and v6 is never reached.
+		if dp.visitedV4 != 101 || dp.visitedV6 != 0 {
+			t.Errorf("match-all page: v4 visited %d (want 101), v6 visited %d (want 0)", dp.visitedV4, dp.visitedV6)
+		}
+	})
 }

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -316,9 +316,24 @@ func (s *Server) sessionsCursor(w http.ResponseWriter, r *http.Request, iterDP s
 	var lastV4 dataplane.SessionKey
 	var lastV6 dataplane.SessionKeyV6
 
+	// Abort the walk when the REST client disconnects (#5233). A SELECTIVE or
+	// no-match cursor query never fills the page, so without this the callback
+	// runs the remainder of a multi-million-entry conntrack table holding
+	// per-bucket BPF-map locks for a page nobody will read — contending with the
+	// live dataplane session-sync path. The non-cursor sessionsOffset /
+	// summary / zone-pair walks already sample this (same helper); the cursor
+	// path was the residual (#5233 closeout). Sampled per batch off the
+	// per-session hot path; r.Context().Err() is re-checked directly at each
+	// phase boundary (cheap, once per phase) so a disconnect neither launches
+	// the second full walk nor writes a misleading terminal envelope.
+	cancelled := newRequestCancelSampler(r.Context(), sessionWalkCancelInterval)
+
 	// Phase 1: v4 from cursor.
 	if startV4 {
 		if err := iterDP.IterateSessionsFrom(cursorV4, func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if cancelled() {
+				return false
+			}
 			if len(all) >= pageSize {
 				return false
 			}
@@ -332,6 +347,9 @@ func (s *Server) sessionsCursor(w http.ResponseWriter, r *http.Request, iterDP s
 			writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
 			return
 		}
+		// A full page is a complete, valid result — emit it even though the
+		// callback may have observed cancellation on its final probe (the client
+		// being gone only means the write is discarded).
 		if len(all) >= pageSize {
 			s.writeSessionList(w, r, SessionListResponse{
 				PageSize:      pageSize,
@@ -343,9 +361,18 @@ func (s *Server) sessionsCursor(w http.ResponseWriter, r *http.Request, iterDP s
 		startV6 = true
 	}
 
-	// Phase 2: v6.
+	// Phase 2: v6. The direct r.Context().Err() check gates BOTH the v4->v6
+	// transition and the v6-start-token path: never launch a second full-table
+	// walk for a client that has already disconnected, and never emit a
+	// (misleading) partial/terminal envelope to a dead connection (#5233).
 	if startV6 {
+		if r.Context().Err() != nil {
+			return
+		}
 		if err := iterDP.IterateSessionsV6From(cursorV6, func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if cancelled() {
+				return false
+			}
 			if len(all) >= pageSize {
 				return false
 			}
@@ -369,7 +396,12 @@ func (s *Server) sessionsCursor(w http.ResponseWriter, r *http.Request, iterDP s
 		}
 	}
 
-	// Both families exhausted — last page, empty next_page_token.
+	// Both families exhausted — last page, empty next_page_token. Suppress the
+	// terminal envelope if the client disconnected during the final walk: a
+	// "last page, no next token" reply would misrepresent iteration state.
+	if r.Context().Err() != nil {
+		return
+	}
 	s.writeSessionList(w, r, SessionListResponse{
 		PageSize: pageSize,
 		Sessions: all,


### PR DESCRIPTION
## Summary

Closes #5233 — the **cursor-path residual** of the session-walk
context-cancellation fix.

The non-cursor REST session handlers (`sessionsOffset`,
`sessionSummaryHandler`, `sessionZonePairHandler`) already sample the request
context and break their conntrack-table walk on client disconnect
(`newRequestCancelSampler`, #5232/#5233). The **cursor path**
(`sessionsCursor`, `page_size>0`, over `IterateSessionsFrom` /
`IterateSessionsV6From`) was the residual named in the issue's own closeout
comment: its v4/v6 callbacks checked only `len(all) >= pageSize` and **never**
`r.Context()`.

On a **selective / no-match** cursor query the page never fills, so each
callback walked the remainder of a multi-million-entry conntrack table holding
the per-bucket BPF-map locks for a page nobody will read — contending with the
live dataplane session-sync path — and it transitioned into the v6 full walk
unconditionally after v4.

## Fix

Mirror the merged sampler pattern into the cursor path:

- Construct `newRequestCancelSampler(r.Context(), sessionWalkCancelInterval)`
  and check it at the top of **both** cursor callbacks (`return false` breaks
  the iteration).
- Add a direct `r.Context().Err()` check **before the v6 phase** (covers both
  the v4→v6 transition and a `v6start` page token) and **before the terminal
  envelope**, so a disconnect neither launches the second full walk nor emits
  a misleading `next_page_token` / partial-page envelope. Because the
  `include_peer` fan-out runs first inside `writeSessionList`, that peer scan
  is skipped too.
- A **full page stays unguarded** — it is a complete, valid result.

The sampler probes `ctx.Err()` once per batch off the per-session hot path and
never fires on the normal path, so **page-token, error, and ordering semantics
are unchanged** for a live client (existing `TestRESTSessionCursorPagination` /
`OffsetParity` / `BadToken` stay green).

## Tests (fail-on-revert)

`api_ctx_cancel_5232_5233_test.go` gains a cursor-capable counting fake
(`cursorCountDP` — the existing `cancelCountDP` implements only the non-cursor
iterators, so `sessionsCursor` was never exercised). A no-match query isolates
the fix from the page cap. Asserts: cancelled v4 walk stops within one sampling
window; v6 phase never starts; no envelope written (⇒ no peer scan); a
`v6start` token + cancelled context does not walk v6; and the non-cancelled
path walks both families fully and still issues a page token.

**Fail-on-revert** (verified via `-overlay`): stripping the cursor checks makes
the cancelled walks visit all 20480 entries and write an envelope — the new
assertions go red while the three non-cursor guards stay intact.

## Validation

`go build ./...`, `go vet ./pkg/api`, `go test -race ./pkg/api` all green;
gofmt clean. `pkg/api/README.md` client-disconnect section updated for the
cursor path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
