### PR TITLE
daemon: surface VRF setup/mgmt-bind failure into commit truth (#5700)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48973,3 +48973,32 @@ top.
     the cursor path.
   - **File(s)**: pkg/api/sessions.go, pkg/api/api_ctx_cancel_5232_5233_test.go,
     pkg/api/README.md
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5700 surface VRF setup/mgmt-bind failure into commit truth (M25).
+    applyVRFReconcile (pkg/daemon/daemon_apply.go) LOGGED-and-DROPPED its
+    ReconcileVRFs failure at WARN and returned only the #2926-C1 ctx-cancellation,
+    even though reconcileVRFs's partial-failure contract records the VRF in the
+    managed set (IsManagedVRF true) — so a commit reported the VRF configured while
+    its vrf-* device was absent on the kernel, no retry owner (false convergence).
+    The authoritative post-networkd management-VRF re-bind (:1346, which networkctl
+    reconfigure necessitates by stripping the master binding) swallowed its failure
+    at WARN too. Mirrored the #5310 ifaceErr / #5696 routeLeakErr / #5844
+    routingRuleErr deferred-error joins: applyVRFReconcile now returns (ctxErr,
+    vrfErr) — ctxErr the UNCHANGED C1 abort, vrfErr the deferred ReconcileVRFs
+    (setup) failure threaded into the tail errors.Join; extracted
+    rebindManagementVRFIfaces which aggregates+RETURNS the authoritative mgmt-bind
+    failures, joined into networkdErr. A failed commit is the retry owner (next
+    apply re-reconciles). Left best-effort (documented): the routing-instance
+    member binds (run before tunnel/xfrmi creation -> expected transient absence)
+    and the pre-networkd mgmt bind (stripped+re-established by the authoritative
+    rebind) — surfacing either would false-fail valid commits. #2926-C1 semantics
+    preserved (TestC1PostPromotionCancelRunsHostAuthorizationCloseout stays green).
+    Fail-on-revert proven via -overlay (restore the three swallows -> the setup /
+    mgmt-bind / tail-join surface tests RED; positive controls stay green).
+  - **File(s)**: pkg/daemon/daemon_apply.go,
+    pkg/daemon/vrf_setup_bind_commit_truth_5700_test.go, pkg/daemon/README.md,
+    pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go,
+    pkg/daemon/route_leak_snapshot_failclosed_5696_test.go,
+    pkg/daemon/device_map_teardown_failclosed_5309_test.go,
+    pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -673,6 +673,32 @@ never lock an operator out of a remote box it manages.
   applyRoutingRules fails-closed-and-complete via a `RuleList`-failing
   `NewManagerWithRuleOpsForTest` fake, clean-config stays-success, and the
   `applyTailReconciles` commit-join wiring proof).
+  **VRF setup / management-bind fail-closed (#5700, mirroring #5310/#5696/#5844):**
+  `applyVRFReconcile` LOGGED-and-DROPPED its `ReconcileVRFs` failure (WARN) and
+  returned only the #2926-C1 ctx-cancellation, even though `reconcileVRFs`'s
+  partial-failure contract still records the VRF in the managed set
+  (`IsManagedVRF` true) — so a commit reported the VRF configured while its
+  `vrf-*` device was absent on the kernel, with no retry owner (false
+  convergence). It now returns `(ctxErr, vrfErr)`: `ctxErr` is the unchanged C1
+  abort; `vrfErr` is the deferred VRF-device-setup failure, captured by
+  `applyConfigLocked` and threaded into the tail `errors.Join(..., mgmtRouteErr,
+  vrfErr)`. The AUTHORITATIVE post-networkd management-VRF re-bind (which
+  `networkctl reconfigure` necessitates by stripping the master binding) is
+  extracted into `rebindManagementVRFIfaces`, which aggregates and RETURNS its
+  bind failures; `applyDataplaneAndHACore` joins them into `networkdErr` (like the
+  #1956 device-map-teardown joins), so a genuine management-VRF bind failure also
+  fails the commit closed. A failed commit is the retry owner (the next apply
+  re-reconciles). Deliberately LEFT best-effort (WARN, not surfaced): the
+  routing-instance member binds (they run BEFORE `applyInterfaceReconcile` creates
+  tunnel/xfrmi members, so a not-yet-created member is an EXPECTED transient
+  absence, not a permanent failure) and the pre-networkd management bind (stripped
+  and re-established by the authoritative rebind above) — surfacing either would
+  reject configs that commit fine today. Tests:
+  `vrf_setup_bind_commit_truth_5700_test.go` (direct `applyVRFReconcile`
+  surfaces-setup / tolerates-success / ctx-cancel-is-not-a-VRF-error via a
+  `vrf-mgmt`-`LinkAdd`-failing `NewManagerWithLinkOpsForTest` fake; direct
+  `rebindManagementVRFIfaces` surfaces-bind / tolerates-success / empty-noop; and
+  the `applyTailReconciles` commit-join wiring proof).
   **Per-term disposition mirrors userspace (#3427):** `nftRulesFromTerm` maps a
   term's `then` action to the kernel verdict the SAME way the userspace lo0
   evaluator does (`pkg/dataplane/userspace/filters.go` `NextTerm =

--- a/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
+++ b/pkg/daemon/apply_interface_reconcile_failclosed_5310_test.go
@@ -247,7 +247,7 @@ func TestApplyTailReconcilesSurfacesInterfaceReconcileError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: interface reconcile (xfrmi create) failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, injected, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the interface-reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -762,16 +762,21 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		slog.Warn("config validation", "warning", w)
 	}
 
-	if err := d.applyVRFReconcile(ctx, cfg); err != nil {
+	ctxErr, vrfErr := d.applyVRFReconcile(ctx, cfg)
+	if ctxErr != nil {
 		// #5643 Gap B: the #2926 C1 boundary lives inside applyVRFReconcile and
 		// returns ctx.Err() before the netlink phase. Store.Commit already
 		// promoted UPSTREAM, so a daemon-stop cancel landing here is post-
 		// promotion too — funnel it through the same host-authorization closeout
 		// as C2/C3 so the committed nft/login/root-auth tightening is enforced
-		// even when the apply is abandoned at the earliest boundary. A genuine
-		// (non-cancellation) VRF reconcile failure returns unchanged.
-		return d.closeoutHostAuthOnCancel(err, cfg)
+		// even when the apply is abandoned at the earliest boundary.
+		return d.closeoutHostAuthOnCancel(ctxErr, cfg)
 	}
+	// #5700: vrfErr is the DEFERRED VRF-device-setup failure (a genuine, non-
+	// cancellation ReconcileVRFs error). The rest of the apply still runs; it is
+	// threaded into the tail commit-error join below so the commit fails closed
+	// (with a retry owner) instead of reporting a VRF configured while its device
+	// is absent — exactly like ifaceErr/routeLeakErr/routingRuleErr.
 
 	// #5867: program the DHCP-learned management-VRF routes and capture the
 	// RouteReplace / cleanup failure as a DEFERRED error. A route whose
@@ -868,7 +873,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// next-table/rib-group/PBR ip-rule reconcile failure (a partial kernel
 	// policy-routing clear/add); the helper creates lo0Err/hostInboundErr and
 	// returns the joined errors.
-	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr)
+	return d.applyTailReconciles(cfg, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr)
 }
 
 // applyHostAuthorizationCloseout runs ONLY the security-critical host-
@@ -1340,13 +1345,18 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 	// 2.7. Re-bind management VRF interfaces after networkd.Apply().
 	// networkctl reconfigure strips VRF master bindings because networkd
 	// considers the daemon-created vrf-mgmt device "unmanaged" and ignores
-	// the VRF= directive. Re-bind here to restore VRF membership.
+	// the VRF= directive. Re-bind here to restore VRF membership. This is the
+	// AUTHORITATIVE management-VRF bind (post-networkd): #5700 surfaces its
+	// failure into commit truth (joined into networkdErr — mirroring the #1956
+	// device-map-teardown joins above) instead of swallowing at WARN, so a
+	// genuine bind failure fails the commit closed rather than reporting the
+	// management VRF configured while the interface carries no VRF membership.
+	// The management interfaces (fxp*/fab*/em*) exist by this phase, so the bind
+	// is transient-free (unlike the pre-networkd best-effort bind and the
+	// routing-instance tunnel-member binds in applyVRFReconcile).
 	if mgmtSet := d.mgmtVRFIfaceSet(); d.routing != nil && len(mgmtSet) > 0 {
-		for ifName := range mgmtSet {
-			if err := d.routing.BindInterfaceToVRF(ifName, "mgmt"); err != nil {
-				slog.Warn("failed to re-bind interface to management VRF",
-					"interface", ifName, "err", err)
-			}
+		if err := d.rebindManagementVRFIfaces(); err != nil {
+			networkdErr = errors.Join(networkdErr, err)
 		}
 		// Restart heartbeat after VRF rebind — networkd reconfigure moves
 		// the control interface (em0) out of vrf-mgmt temporarily, which
@@ -1873,18 +1883,29 @@ func (d *Daemon) applyFabricIPVLAN(cfg *config.Config) {
 // update/orphan-delete vrf-* devices), binding routing-instance member
 // interfaces to their VRFs, binding management interfaces (fxp*/fab*/em*) to
 // vrf-mgmt when it is managed, and applying the management-VRF routes.
-// Extracted verbatim from applyConfigLocked (#4407). Returns a non-nil error
-// only for the #2926-C1 ctx-cancellation check (the block's sole early return),
-// which applyConfigLocked propagates unchanged. Runs in the same slot, before
-// the interface-creation reconcile.
-func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) error {
+// Extracted verbatim from applyConfigLocked (#4407).
+//
+// Returns TWO errors (#5700). ctxErr is the #2926-C1 ctx-cancellation check (the
+// block's sole early return), which applyConfigLocked propagates unchanged
+// through the host-authorization closeout — the C1 abort semantics are
+// UNCHANGED. vrfErr is the DEFERRED VRF-device-setup failure: a ReconcileVRFs
+// error means the vrf-* device could not be created/reconciled, yet
+// reconcileVRFs's partial-failure contract still records the VRF in the
+// managed/tracked set (IsManagedVRF returns true below), so the commit used to
+// report the VRF configured while it was absent on the kernel — a false
+// convergence with no retry owner. vrfErr is threaded into the tail commit-error
+// join exactly like the #5310 ifaceErr / #5696 routeLeakErr / #5844
+// routingRuleErr deferred errors, so a failed commit fails closed and is the
+// retry owner (the next apply re-reconciles). Runs in the same slot, before the
+// interface-creation reconcile.
+func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) (ctxErr error, vrfErr error) {
 	// #2926 boundary C1: before the netlink reconcile phase. Nothing in the
 	// kernel / dataplane / FRR has been touched yet (the SNMP swap above is an
 	// idempotent in-memory pointer flip), so a cancellation here skips the
 	// entire pipeline cleanly. This is the cheapest, safest place to honor a
 	// daemon stop.
 	if err := ctx.Err(); err != nil {
-		return err
+		return err, nil
 	}
 
 	// 0. Reconcile VRF devices (routing-instance VRFs + management VRF).
@@ -1929,7 +1950,14 @@ func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) erro
 			})
 		}
 		if err := d.routing.ReconcileVRFs(desired); err != nil {
+			// #5700: the VRF DEVICE setup failed (vrf-* could not be created/
+			// reconciled). reconcileVRFs still records the VRF as managed on a
+			// partial failure, so surface this into commit truth rather than
+			// swallowing it at WARN — otherwise the commit reports the VRF
+			// configured while it is not on the kernel (false convergence). This is
+			// transient-free: VRF device creation depends on no other interface.
 			slog.Warn("failed to reconcile VRFs", "err", err)
+			vrfErr = errors.Join(vrfErr, fmt.Errorf("reconcile VRFs: %w", err))
 		}
 	}
 
@@ -1949,6 +1977,14 @@ func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) erro
 			}
 			for _, ifaceName := range ri.Interfaces {
 				linuxName := riMemberLinuxName(tunMap, ifaceName)
+				// #5700: deliberately best-effort (WARN, not surfaced). This runs
+				// BEFORE applyInterfaceReconcile creates tunnel/xfrmi devices, so a
+				// routing-instance member that is a later-created tunnel is legitimately
+				// "not found" here — an EXPECTED transient absence that must NOT be
+				// promoted into a permanent commit failure. Only the VRF DEVICE setup
+				// (ReconcileVRFs, surfaced above as vrfErr) and the authoritative
+				// post-networkd management re-bind (rebindManagementVRFIfaces) are
+				// load-bearing and transient-free.
 				if err := d.routing.BindInterfaceToVRF(linuxName, ri.Name); err != nil {
 					slog.Warn("failed to bind interface to VRF",
 						"interface", ifaceName, "linux", linuxName,
@@ -1972,6 +2008,12 @@ func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) erro
 	if d.routing != nil && len(mgmtIfaces) > 0 && d.routing.IsManagedVRF(mgmtVRFName) {
 		mgmtSet = mgmtIfaces
 		for ifName := range mgmtIfaces {
+			// #5700: this PRE-networkd bind is best-effort (WARN, not surfaced).
+			// applyNetworkdConfig's `networkctl reconfigure` strips the VRF master
+			// binding right after this phase, so the AUTHORITATIVE management-VRF
+			// bind is the post-networkd rebindManagementVRFIfaces (whose failure IS
+			// surfaced into commit truth). Surfacing this pre-strip bind would report
+			// a failure for a binding networkd is about to remove and re-establish.
 			if err := d.routing.BindInterfaceToVRF(ifName, mgmtVRFName); err != nil {
 				slog.Warn("failed to bind interface to management VRF",
 					"interface", ifName, "err", err)
@@ -1989,7 +2031,35 @@ func (d *Daemon) applyVRFReconcile(ctx context.Context, cfg *config.Config) erro
 	// dataplane apply). Ordering is unchanged: it still runs after this reconcile
 	// (which publishes the mgmt-interface set it reads) and before the interface/
 	// dataplane reconciles.
-	return nil
+	return nil, vrfErr
+}
+
+// rebindManagementVRFIfaces re-binds the published management-VRF interface set
+// to vrf-mgmt after applyNetworkdConfig's `networkctl reconfigure` strips the
+// VRF master binding (it treats the daemon-created vrf-mgmt device as
+// unmanaged). This is the AUTHORITATIVE, load-bearing management-VRF bind:
+// #5700 aggregates and RETURNS the per-interface bind failures so the caller can
+// join them into commit truth (via networkdErr) instead of swallowing at WARN —
+// a genuine bind failure otherwise reports the management VRF configured while
+// the interface carries no VRF membership (false convergence, no retry owner).
+// The management interfaces exist by this phase, so a failure is genuine, not a
+// transient absence. Returns nil when there is nothing to bind or every bind
+// succeeds. Extracted so the fail-closed bind can be unit-tested directly,
+// mirroring applyInterfaceReconcile (#5310).
+func (d *Daemon) rebindManagementVRFIfaces() error {
+	mgmtSet := d.mgmtVRFIfaceSet()
+	if d.routing == nil || len(mgmtSet) == 0 {
+		return nil
+	}
+	var errs []error
+	for ifName := range mgmtSet {
+		if err := d.routing.BindInterfaceToVRF(ifName, "mgmt"); err != nil {
+			slog.Warn("failed to re-bind interface to management VRF",
+				"interface", ifName, "err", err)
+			errs = append(errs, fmt.Errorf("re-bind %s to management VRF: %w", ifName, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // applyInterfaceReconcile creates/reconciles the interface-level network
@@ -2082,10 +2152,11 @@ func (d *Daemon) applyInterfaceReconcile(cfg *config.Config) error {
 // non-abort dataplane-apply failure that must fail the commit while the OLD
 // policy stays live); routeLeakErr is the #5696 route-leak snapshot
 // republish/FIB-bump failure (also head-produced, threaded in like ifaceErr);
-// lo0Err/hostInboundErr originate in step 9.5 below. The returned errors.Join
-// preserves the exact operand order the inline tail used
-// (#1778/#2987/#4433/#5310/#5679/#5696).
-func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr error) error {
+// vrfErr is the #5700 VRF-device-setup (ReconcileVRFs) failure, threaded in the
+// same way; lo0Err/hostInboundErr originate in step 9.5 below. The returned
+// errors.Join preserves the exact operand order the inline tail used
+// (#1778/#2987/#4433/#5310/#5679/#5696/#5700).
+func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr error) error {
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	vrrpInstances := vrrp.CollectInstances(cfg)
 	if d.cluster != nil {
@@ -2356,7 +2427,7 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	// that left stale or missing kernel/swanctl/dataplane state fails the commit
 	// (fail-closed) instead of reporting success. All are joined so none masks the
 	// other.
-	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr)
+	return errors.Join(networkdErr, applyErr, dhcpServerErr, hostInboundErr, lo0Err, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr)
 }
 
 // compileErrorMustAbortApply reports whether a dataplane ApplyConfig error

--- a/pkg/daemon/device_map_teardown_failclosed_5309_test.go
+++ b/pkg/daemon/device_map_teardown_failclosed_5309_test.go
@@ -262,7 +262,7 @@ func TestApplyTailReconcilesSurfacesDeviceMapTeardownError_5309(t *testing.T) {
 
 	teardownErr := fmt.Errorf("device-map teardown: %w",
 		errors.New("rename-back ge-0-0-9 -> enp99s0: EBUSY"))
-	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil, nil, nil, nil)
+	err := d.applyTailReconciles(cfg, teardownErr, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface a device-map teardown failure carried " +
 			"in networkdErr (fail-closed); got nil")

--- a/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
+++ b/pkg/daemon/route_leak_snapshot_failclosed_5696_test.go
@@ -145,7 +145,7 @@ func TestApplyTailReconcilesSurfacesRouteLeakError(t *testing.T) {
 	}
 
 	injected := errors.New("injected: route-leak snapshot republish failed")
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, injected, nil, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, injected, nil, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the route-leak reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
+++ b/pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
@@ -130,7 +130,7 @@ func TestApplyTailReconcilesSurfacesRoutingRuleError_5844(t *testing.T) {
 	injected := errors.New("injected: next-table ip-rule reconcile failed")
 	// routingRuleErr is the final applyTailReconciles operand; every other
 	// deferred error is nil so it is the only thing that can surface.
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, injected, nil)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, injected, nil, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the routing-rule reconcile failure " +
 			"(fail-closed); got nil")
@@ -184,7 +184,7 @@ func TestApplyTailReconcilesSurfacesMgmtRouteError_5867(t *testing.T) {
 	injected := errors.New("injected: mgmt-VRF RouteReplace rejected")
 	// mgmtRouteErr is the FINAL applyTailReconciles operand; every other deferred
 	// error is nil so it is the only thing that can surface.
-	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, injected)
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, injected, nil)
 	if err == nil {
 		t.Fatal("applyTailReconciles must surface the mgmt-VRF route reconcile failure " +
 			"(fail-closed); got nil")

--- a/pkg/daemon/vrf_setup_bind_commit_truth_5700_test.go
+++ b/pkg/daemon/vrf_setup_bind_commit_truth_5700_test.go
@@ -1,0 +1,210 @@
+package daemon
+
+// #5700 (daemon/routing M25): a VRF setup or (management) bind failure was
+// recorded "managed" and then DISCARDED from commit truth — applyVRFReconcile
+// returned nil for every genuine ReconcileVRFs failure (WARN-only) even though
+// reconcileVRFs's partial-failure contract still records the VRF in the managed
+// set (IsManagedVRF true), and the authoritative post-networkd management-VRF
+// re-bind swallowed its failure at WARN too. The commit reported the VRF
+// configured while it was NOT on the kernel, with no retry owner to reconcile it
+// (false convergence).
+//
+// The fix surfaces the TWO load-bearing, transient-free swallow sites into
+// commit truth, mirroring the #5310 ifaceErr / #5696 routeLeakErr / #5844
+// routingRuleErr deferred-error joins:
+//   - applyVRFReconcile now returns a deferred vrfErr for a ReconcileVRFs
+//     (VRF-device setup) failure — threaded into the tail errors.Join — while
+//     the #2926-C1 ctx-cancellation still aborts unchanged;
+//   - rebindManagementVRFIfaces aggregates the authoritative post-networkd
+//     management-VRF bind failures and returns them (joined into networkdErr).
+// The routing-instance member binds (which run before tunnel/xfrmi creation) and
+// the pre-networkd management bind (stripped by networkctl reconfigure) remain
+// best-effort WARN — surfacing them would promote an EXPECTED transient absence
+// into a false commit failure.
+//
+// FAIL-ON-REVERT: restore applyVRFReconcile's `return nil` (drop vrfErr) and
+// TestApplyVRFReconcileSurfacesSetupFailure_5700 goes RED (ctxErr/vrfErr both
+// nil despite the injected setup failure). Restore rebindManagementVRFIfaces'
+// WARN-only swallow and TestRebindManagementVRFSurfacesBindFailure_5700 goes RED.
+// Drop vrfErr from the tail errors.Join and
+// TestApplyTailReconcilesSurfacesVRFError_5700 goes RED.
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/routing"
+	"github.com/psaab/xpf/pkg/vrrp"
+	"github.com/vishvananda/netlink"
+)
+
+// mgmtIfaceConfig is a minimal config whose single management interface (fxp0)
+// makes applyVRFReconcile add vrf-mgmt to the desired VRF set (mgmtIfaces
+// detection keys on the fxp*/fab*/em* prefix).
+func mgmtIfaceConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"fxp0": {Name: "fxp0"},
+	}
+	return cfg
+}
+
+// TestApplyVRFReconcileSurfacesSetupFailure_5700 drives the REAL
+// applyVRFReconcile against a routing.Manager whose vrf-mgmt LinkAdd fails and
+// asserts it returns the failure as the DEFERRED vrfErr (not the ctx-abort
+// ctxErr), so the caller threads it into commit truth.
+func TestApplyVRFReconcileSurfacesSetupFailure_5700(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+	injected := errors.New("injected: vrf-mgmt LinkAdd EPERM")
+	ops.addFail["vrf-mgmt"] = injected
+
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+	ctxErr, vrfErr := d.applyVRFReconcile(context.Background(), mgmtIfaceConfig())
+
+	if ctxErr != nil {
+		t.Fatalf("ctxErr must be nil for a non-cancellation setup failure, got %v", ctxErr)
+	}
+	if vrfErr == nil {
+		t.Fatal("applyVRFReconcile must return the VRF-device setup failure as vrfErr " +
+			"(fail-closed); got nil — the swallowed false-convergence #5700 describes")
+	}
+	if !errors.Is(vrfErr, injected) {
+		t.Fatalf("vrfErr must wrap the injected ReconcileVRFs failure, got %v", vrfErr)
+	}
+}
+
+// TestApplyVRFReconcileToleratesSuccess_5700 is the positive control: a VRF
+// setup that succeeds does not fabricate a commit failure. The pre-networkd
+// management bind may WARN (fxp0 is not a live link in the fake) but must NOT
+// surface — only the setup (ReconcileVRFs) is load-bearing here.
+func TestApplyVRFReconcileToleratesSuccess_5700(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+	ctxErr, vrfErr := d.applyVRFReconcile(context.Background(), mgmtIfaceConfig())
+
+	if ctxErr != nil {
+		t.Fatalf("ctxErr = %v, want nil on the success path", ctxErr)
+	}
+	if vrfErr != nil {
+		t.Fatalf("vrfErr = %v, want nil: a successful VRF-device setup must not fail "+
+			"the commit (and a best-effort pre-networkd bind must not surface)", vrfErr)
+	}
+}
+
+// TestApplyVRFReconcileCtxCancelIsNotVRFError_5700 proves the #2926-C1 boundary
+// is preserved: a pre-cancelled context returns via ctxErr (the abort path),
+// NOT vrfErr — so the cancellation still funnels through the host-authorization
+// closeout and is never misreported as a VRF setup failure.
+func TestApplyVRFReconcileCtxCancelIsNotVRFError_5700(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+	ops.addFail["vrf-mgmt"] = errors.New("would fail if reached")
+
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctxErr, vrfErr := d.applyVRFReconcile(ctx, mgmtIfaceConfig())
+
+	if !errors.Is(ctxErr, context.Canceled) {
+		t.Fatalf("ctxErr = %v, want context.Canceled (the #2926-C1 abort)", ctxErr)
+	}
+	if vrfErr != nil {
+		t.Fatalf("vrfErr = %v, want nil: a C1 cancellation must not run the reconcile "+
+			"or manufacture a VRF setup error", vrfErr)
+	}
+}
+
+// TestRebindManagementVRFSurfacesBindFailure_5700 drives the REAL
+// rebindManagementVRFIfaces against a routing.Manager where the management
+// interface exists but vrf-mgmt does not, so BindInterfaceToVRF fails, and
+// asserts the aggregated error is RETURNED (so the caller joins it into
+// networkdErr / commit truth) instead of being swallowed at WARN.
+func TestRebindManagementVRFSurfacesBindFailure_5700(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+	// fxp0 exists; vrf-mgmt does NOT — a genuine bind failure (VRF device absent).
+	ops.links["fxp0"] = &netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "fxp0", Index: 2}}
+
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+	d.publishMgmtVRFIfaces(map[string]bool{"fxp0": true})
+
+	err := d.rebindManagementVRFIfaces()
+	if err == nil {
+		t.Fatal("rebindManagementVRFIfaces must return the management-VRF bind failure " +
+			"(fail-closed); got nil — the swallowed false-convergence #5700 describes")
+	}
+}
+
+// TestRebindManagementVRFToleratesSuccess_5700 is the positive control: when
+// both the interface and vrf-mgmt exist, the bind succeeds and no error surfaces.
+func TestRebindManagementVRFToleratesSuccess_5700(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+	ops.links["fxp0"] = &netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "fxp0", Index: 2}}
+	ops.links["vrf-mgmt"] = &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: "vrf-mgmt", Index: 9}, Table: 999}
+
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+	d.publishMgmtVRFIfaces(map[string]bool{"fxp0": true})
+
+	if err := d.rebindManagementVRFIfaces(); err != nil {
+		t.Fatalf("a successful management-VRF re-bind must not fail the commit, got %v", err)
+	}
+}
+
+// TestRebindManagementVRFNoSetIsNoop_5700 proves the empty/no-mgmt-VRF case is a
+// clean no-op (nil), so a non-VRF config never fails the commit here.
+func TestRebindManagementVRFNoSetIsNoop_5700(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+	// No publishMgmtVRFIfaces -> mgmtVRFIfaceSet() is empty.
+	if err := d.rebindManagementVRFIfaces(); err != nil {
+		t.Fatalf("no management-VRF interface set must be a no-op, got %v", err)
+	}
+}
+
+// TestApplyTailReconcilesSurfacesVRFError_5700 is the commit-level wiring proof:
+// it drives the REAL applyTailReconciles with an injected VRF error (vrfErr) and
+// asserts the returned commit error includes it — pinning the tail errors.Join
+// wiring the direct applyVRFReconcile test does not cover. The nft seams are
+// stubbed to succeed so the injected vrfErr is the only operand that can surface.
+//
+// FAIL-ON-REVERT: drop vrfErr from that join and this goes RED (the apply
+// completes and returns nil despite the VRF reconcile having failed).
+func TestApplyTailReconcilesSurfacesVRFError_5700(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
+
+	d := &Daemon{
+		dp:       &runtimeOnlyApplyTestDP{},
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+
+	injected := errors.New("injected: VRF reconcile (vrf-mgmt create) failed")
+	// vrfErr is the LAST operand of applyTailReconciles.
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, injected)
+	if err == nil {
+		t.Fatal("applyTailReconciles must surface the VRF reconcile failure " +
+			"(fail-closed); got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned commit error must include the VRF failure via the tail "+
+			"errors.Join wiring, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5700 — a VRF setup/bind failure was recorded "managed" and then
**discarded from commit truth** (M25, codex-review-182). `applyVRFReconcile`
logged its `ReconcileVRFs` failure at WARN and returned only the #2926-C1
ctx-cancellation, yet `reconcileVRFs`'s partial-failure contract still records
the VRF in the managed/tracked set (`IsManagedVRF` returns true) — so a commit
reported the VRF configured while its `vrf-*` device was **absent on the
kernel**, with **no retry owner** (false convergence). The authoritative
post-networkd management-VRF re-bind swallowed its failure at WARN too.

## Fix

Surface the two **load-bearing, transient-free** swallow sites into commit
truth, mirroring the #5310 `ifaceErr` / #5696 `routeLeakErr` / #5844
`routingRuleErr` deferred-error joins:

- `applyVRFReconcile` now returns `(ctxErr, vrfErr)`. `ctxErr` is the
  **UNCHANGED** #2926-C1 abort (still funneled through
  `closeoutHostAuthOnCancel`); `vrfErr` is the deferred `ReconcileVRFs`
  (VRF-device setup) failure, threaded into the tail `errors.Join`.
- The post-networkd management-VRF re-bind is extracted into
  `rebindManagementVRFIfaces`, which aggregates and **returns** its bind
  failures; `applyDataplaneAndHACore` joins them into `networkdErr` (like the
  #1956 device-map-teardown joins). The management interfaces exist by this
  phase, so a failure is genuine, not a transient absence.

A failed commit is the **retry owner** (the next apply re-reconciles).

### Deliberately left best-effort (documented)

The **routing-instance member binds** run *before* `applyInterfaceReconcile`
creates tunnel/xfrmi members, so a not-yet-created member is an **expected
transient absence** — surfacing it would promote a transient into a permanent
commit failure and reject configs that commit fine today. The **pre-networkd
management bind** is stripped and re-established by the authoritative rebind
above. Surfacing either would false-fail valid commits.

## Tests (fail-on-revert)

`vrf_setup_bind_commit_truth_5700_test.go` (mirroring the #5310/#5696/#5844
failclosed tests): direct `applyVRFReconcile` surfaces-setup / tolerates-success
/ **ctx-cancel-is-not-a-VRF-error** (proves the C1 boundary is preserved) via a
`vrf-mgmt`-`LinkAdd`-failing `NewManagerWithLinkOpsForTest` fake; direct
`rebindManagementVRFIfaces` surfaces-bind / tolerates-success / empty-noop; and
the `applyTailReconciles` commit-join wiring proof.

**Fail-on-revert** (verified via `-overlay`): restoring the WARN-only
`ReconcileVRFs` swallow, the WARN-only rebind swallow, or dropping `vrfErr` from
the tail join each turns the corresponding surface assertion red while the
positive controls stay green.

## Validation

`go build ./...`, `go vet ./pkg/daemon ./pkg/routing`, `go test -race
./pkg/daemon` (17.4s) all green; gofmt clean. The #2926-C1 boundary is
preserved (`TestC1PostPromotionCancelRunsHostAuthorizationCloseout` stays
green). `pkg/daemon/README.md` fail-closed section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
