### PR TITLE
cli,dhcpserver: bound control-plane clear/show/DDNS memory (#4886)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -48973,3 +48973,27 @@ top.
     the cursor path.
   - **File(s)**: pkg/api/sessions.go, pkg/api/api_ctx_cancel_5232_5233_test.go,
     pkg/api/README.md
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #4886 control-plane unbounded-memory cohort — fixed the 3 LIVE
+    parts (STEP-0 found A-gRPC already bounded by #5454 and B-rebuffer already
+    streamed by #4731/#4709; did NOT touch those). A-CLI: cli_clear.go
+    clearFilteredSessions snapshotted every matching fwd/rev/DNAT key before
+    deleting → bounded it via a collect-≤cliClearFilteredBatch → delete → resume
+    loop mirroring the #5454 gRPC path (cursor primary IterateSessionsFrom to keep
+    it O(N) and avoid the O(N²) CPU-stall #4719, bounded rescan fallback);
+    peak O(batch). B: dispatchWithPager now TTY-gates via stdoutIsTerminal()
+    (TCGETS) — a non-TTY stdout (the `show | match` filter pipe) auto-disables the
+    pager, fixing the nested-pager --More---into-hidden-pipe hang. C:
+    ddns_leases.go parseActiveLeasesFileInto streams csv.Read() row-by-row into acc
+    instead of csv.ReadAll(), dropping the O(history) retained-rows transient.
+    Per-part fail-on-revert proven via -overlay: A snapshot-all → chunk 20 > batch 4
+    RED; B no-guard → --More-- leak RED; C ReadAll → 22.97MB > 19MB bound RED
+    (streaming 14.9MB). Also added cursor overrides to the 2 existing clear test
+    fakes (they embed *dataplane.Manager and only overrode IterateSessions).
+  - **File(s)**: pkg/cli/cli_clear.go, pkg/cli/cli_dispatch.go,
+    pkg/dhcpserver/ddns_leases.go, pkg/cli/cli_clear_bounded_4886_test.go,
+    pkg/cli/cli_dispatch_pager_tty_4886_test.go,
+    pkg/dhcpserver/ddns_leases_streaming_4886_test.go,
+    pkg/cli/cli_clear_reversekey_test.go, pkg/cli/cli_clear_errors_test.go,
+    pkg/cli/README.md

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -151,6 +151,25 @@ presenter's rendered output is byte-identical:
   because an empty `ClearSessionsRequest` means clear-all to the peer.
   Key ports are network byte order (`ntohs` before comparing) and
   dataplane IPv4 NAT fields decode with NativeEndian (`uint32ToIP`).
+  The FILTERED clear (`clearFilteredSessions`) is BOUNDED (#4886): it
+  collects at most `cliClearFilteredBatch` forward keys (plus each
+  session's reverse/DNAT companion), deletes that chunk, and resumes —
+  cursor primary (`IterateSessionsFrom`, one O(N) forward pass, deferred
+  anchor delete) with a fresh-rescan fallback for a cursor-less dataplane
+  — so peak memory is O(batch), not O(matches). The pre-#4886 path
+  snapshotted every matching key first (hundreds of MB before deleting on
+  a multi-million-entry table). This mirrors the already-bounded gRPC
+  `ClearSessions` (#5454); using the cursor (not a bare rescan) keeps a
+  broad clear O(N), avoiding the O(N²) CPU-stall that would starve the HA
+  watchdog (#4719).
+- `show` PAGER auto-disable (`dispatchWithPager`, #4886): the pager only
+  engages when `os.Stdout` is a real terminal (`stdoutIsTerminal`, probed
+  via TCGETS — `/dev/null` is a CharDevice so `os.ModeCharDevice` is
+  wrong). A `show … | match X` redirects `os.Stdout` to the filter pipe;
+  the inner bare `show` used to route back to the pager, which then wrote
+  `--More--` into the hidden outer pipe while blocking on stdin — the
+  command hung with no visible prompt. Auto-disabling on a non-TTY stdout
+  (pipe / file / scripted) fixes the nesting and streams straight through.
 - GLOBAL-ONLY clears (`cli_clear.go`) — commands whose backend action can
   ONLY clear everything and have no scoped variant (`clear arp`, `clear ipv6
   neighbors`, `clear interfaces statistics`, `clear system config-lock`,

--- a/pkg/cli/cli_clear.go
+++ b/pkg/cli/cli_clear.go
@@ -234,100 +234,276 @@ func (c *CLI) clearFilteredSessions(f sessionFilter) error {
 	// without this an interface-filtered clear matches nothing.
 	f.populateIfaceMaps(c)
 
-	v4Deleted := 0
-	v6Deleted := 0
 	var agg sessionClearErrors
-
-	var v4Keys []dataplane.SessionKey
-	var v4RevKeys []dataplane.SessionKey
-	var snatDNATKeys []dataplane.DNATKey
-	// Enumeration failure must be surfaced: a partial scan silently
-	// skips sessions the operator asked to clear (#2468).
-	agg.add("v4 iterate", c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
-		if val.IsReverse != 0 {
-			return true
-		}
-		if !f.matchesV4(key, val) {
-			return true
-		}
-		v4Keys = append(v4Keys, key)
-		// The reverse companion is installed keyed on val.ReverseKey
-		// (the TRANSLATED tuple for NAT'd sessions — session_store.go
-		// PutClusterSyncedV4 / manager_ha.go), NOT a naive src/dst swap
-		// of the forward key. For a non-NAT session the two coincide;
-		// for a NAT'd session a naive swap would leave the real reverse
-		// entry behind (#2733). A zero ReverseKey (Protocol==0) means no
-		// reverse companion was installed (the needsReverse gate), so
-		// skip it.
-		if val.ReverseKey.Protocol != 0 {
-			v4RevKeys = append(v4RevKeys, val.ReverseKey)
-		}
-		if val.Flags&dataplane.SessFlagSNAT != 0 &&
-			val.Flags&dataplane.SessFlagStaticNAT == 0 {
-			// Companion dnat_table key must match the write-side encoding
-			// (#2406: host-order port) or the delete silently misses.
-			snatDNATKeys = append(snatDNATKeys, dataplane.DNATKeyForSessionV4(key, val))
-		}
-		return true
-	}))
-
-	for _, key := range v4Keys {
-		if err := c.dp.DeleteSession(key); err != nil {
-			agg.add("v4 forward delete", err)
-		} else {
-			v4Deleted++
-		}
-	}
-	for _, key := range v4RevKeys {
-		agg.addExceptNotFound("v4 reverse delete", c.dp.DeleteSession(key))
-	}
-	for _, dk := range snatDNATKeys {
-		agg.addExceptNotFound("v4 DNAT companion delete", c.dp.DeleteDNATEntry(dk))
-	}
-
-	var v6Keys []dataplane.SessionKeyV6
-	var v6RevKeys []dataplane.SessionKeyV6
-	var snatDNATKeysV6 []dataplane.DNATKeyV6
-	agg.add("v6 iterate", c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-		if val.IsReverse != 0 {
-			return true
-		}
-		if !f.matchesV6(key, val) {
-			return true
-		}
-		v6Keys = append(v6Keys, key)
-		// Reverse companion at the TRANSLATED tuple val.ReverseKey, not a
-		// naive swap (see V4 above, #2733). Zero ReverseKey => no companion.
-		if val.ReverseKey.Protocol != 0 {
-			v6RevKeys = append(v6RevKeys, val.ReverseKey)
-		}
-		if val.Flags&dataplane.SessFlagSNAT != 0 &&
-			val.Flags&dataplane.SessFlagStaticNAT == 0 {
-			// Companion dnat_table_v6 key must match the write-side encoding
-			// (#2406: host-order port) or the delete silently misses.
-			snatDNATKeysV6 = append(snatDNATKeysV6, dataplane.DNATKeyForSessionV6(key, val))
-		}
-		return true
-	}))
-
-	for _, key := range v6Keys {
-		if err := c.dp.DeleteSessionV6(key); err != nil {
-			agg.add("v6 forward delete", err)
-		} else {
-			v6Deleted++
-		}
-	}
-	for _, key := range v6RevKeys {
-		agg.addExceptNotFound("v6 reverse delete", c.dp.DeleteSessionV6(key))
-	}
-	for _, dk := range snatDNATKeysV6 {
-		agg.addExceptNotFound("v6 DNAT companion delete", c.dp.DeleteDNATEntryV6(dk))
-	}
+	// #4886 A: bound the working set. The pre-#4886 CLI snapshotted EVERY
+	// matching forward key + its reverse and DNAT companions (v4 then v6) into
+	// growing slices before deleting, so a broad filtered clear on a
+	// multi-million-entry table allocated O(matches) up front and could OOM the
+	// in-process daemon before making progress. clearFilteredV4Bounded /
+	// clearFilteredV6Bounded collect at most cliClearFilteredBatch keys, delete
+	// that chunk, and resume (cursor primary; bounded rescan fallback) — peak
+	// O(batch). The filter and the f.validate() above are unchanged, so the exact
+	// set is cleared and a typo'd predicate still never widens to clear-all (#3439).
+	v4Deleted := clearFilteredV4Bounded(c, &f, &agg)
+	v6Deleted := clearFilteredV6Bounded(c, &f, &agg)
 
 	fmt.Printf("%d IPv4 and %d IPv6 matching sessions cleared\n", v4Deleted, v6Deleted)
 	agg.add("peer clear", c.clearPeerSessions(&f))
 	agg.report()
 	return nil
+}
+
+// cliClearFilteredBatch bounds the forward-key working set per chunk for the
+// filtered CLI session clear (#4886). A test seam shrinks it to exercise the
+// multi-chunk path on a small table.
+var cliClearFilteredBatch = 1024
+
+// cliClearBatchObserver, when non-nil, is invoked once per collected chunk with
+// the forward-key count — a test-only seam proving the working set is bounded.
+// A revert to the pre-#4886 snapshot-all path reports a single len==matches
+// chunk, so the bounded-batch assertion REDs (#4886).
+var cliClearBatchObserver func(chunkLen int)
+
+// cliSessionCursor is the cursor-iteration capability (the CLI mirror of
+// grpcapi.sessionCursorIterator, #5454). The production dataplane satisfies it,
+// so the CLI runs the O(N)-CPU bounded cursor path; only a cursor-less test fake
+// falls back to the bounded fresh-rescan. Using the cursor (not a bare rescan)
+// keeps a broad clear on a huge table a single O(N) forward pass rather than
+// O(N^2), which would trade the memory DoS for a CPU-stall able to starve the HA
+// watchdog (#4719) — the same reason the #5454 gRPC path prefers the cursor.
+type cliSessionCursor interface {
+	IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6From(cursor *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+}
+
+// cliClearBatchV4 accumulates one bounded chunk of matching v4 forward keys plus
+// each session's reverse companion (keyed on the TRANSLATED tuple val.ReverseKey,
+// #2733) and DNAT companion (#2406), mirroring grpcapi.clearBatchV4 (#5454/#4886).
+type cliClearBatchV4 struct {
+	fwd  []dataplane.SessionKey
+	rev  []dataplane.SessionKey
+	dnat []dataplane.DNATKey
+}
+
+func (b *cliClearBatchV4) reset() { b.fwd = b.fwd[:0]; b.rev = b.rev[:0]; b.dnat = b.dnat[:0] }
+
+// collect appends a matched forward session's keys and returns true once the
+// forward chunk is full. Callers must skip reverse entries (val.IsReverse != 0)
+// and non-matching keys BEFORE collect, preserving the pre-#4886 CLI semantics.
+func (b *cliClearBatchV4) collect(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	b.fwd = append(b.fwd, key)
+	if val.ReverseKey.Protocol != 0 {
+		b.rev = append(b.rev, val.ReverseKey)
+	}
+	if val.Flags&dataplane.SessFlagSNAT != 0 && val.Flags&dataplane.SessFlagStaticNAT == 0 {
+		b.dnat = append(b.dnat, dataplane.DNATKeyForSessionV4(key, val))
+	}
+	return len(b.fwd) >= cliClearFilteredBatch
+}
+
+func (b *cliClearBatchV4) deleteAll(c *CLI, agg *sessionClearErrors) int {
+	deleted := 0
+	for _, key := range b.fwd {
+		// addExceptNotFound (not add): the cursor path leaves the chunk anchor
+		// live and may re-collect it next round, so a benign already-gone
+		// forward key must not read as a failure — matching grpcapi #5454.
+		if err := c.dp.DeleteSession(key); err != nil {
+			agg.addExceptNotFound("v4 forward delete", err)
+		} else {
+			deleted++
+		}
+	}
+	for _, key := range b.rev {
+		agg.addExceptNotFound("v4 reverse delete", c.dp.DeleteSession(key))
+	}
+	for _, dk := range b.dnat {
+		agg.addExceptNotFound("v4 DNAT companion delete", c.dp.DeleteDNATEntry(dk))
+	}
+	return deleted
+}
+
+// clearFilteredV4Bounded deletes every matching v4 session (plus companions)
+// while holding at most O(cliClearFilteredBatch) keys. Cursor primary
+// (IterateSessionsFrom from a live anchor, one O(N) pass, deferred anchor
+// delete); bounded fresh-rescan fallback for a cursor-less dataplane (#4886).
+func clearFilteredV4Bounded(c *CLI, f *sessionFilter, agg *sessionClearErrors) int {
+	iterDP, ok := c.dp.(cliSessionCursor)
+	if !ok {
+		return clearFilteredV4Rescan(c, f, agg)
+	}
+	deleted := 0
+	var a, b cliClearBatchV4
+	cur, prev := &a, &b
+	prevValid := false
+	var cursor *dataplane.SessionKey
+	for {
+		cur.reset()
+		iterErr := iterDP.IterateSessionsFrom(cursor, func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse != 0 {
+				return true
+			}
+			if !f.matchesV4(key, val) {
+				return true
+			}
+			return !cur.collect(key, val)
+		})
+		agg.add("v4 iterate", iterErr)
+		if cliClearBatchObserver != nil {
+			cliClearBatchObserver(len(cur.fwd))
+		}
+		if prevValid {
+			deleted += prev.deleteAll(c, agg)
+			prevValid = false
+		}
+		full := len(cur.fwd) >= cliClearFilteredBatch && iterErr == nil
+		if !full {
+			deleted += cur.deleteAll(c, agg)
+			return deleted
+		}
+		anchor := cur.fwd[len(cur.fwd)-1]
+		cursor = &anchor
+		cur, prev = prev, cur
+		prevValid = true
+	}
+}
+
+// clearFilteredV4Rescan is the bounded fallback for a cursor-less dataplane
+// (test/edge): collect up to cliClearFilteredBatch keys via a fresh iterate,
+// delete them, rescan — every collected key is deleted so a fresh scan returns
+// the next chunk, converging while holding only O(chunk) keys (#4886).
+func clearFilteredV4Rescan(c *CLI, f *sessionFilter, agg *sessionClearErrors) int {
+	deleted := 0
+	var b cliClearBatchV4
+	for {
+		b.reset()
+		iterErr := c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse != 0 {
+				return true
+			}
+			if !f.matchesV4(key, val) {
+				return true
+			}
+			return !b.collect(key, val)
+		})
+		agg.add("v4 iterate", iterErr)
+		if cliClearBatchObserver != nil {
+			cliClearBatchObserver(len(b.fwd))
+		}
+		if len(b.fwd) == 0 {
+			return deleted
+		}
+		deleted += b.deleteAll(c, agg)
+		if len(b.fwd) < cliClearFilteredBatch || iterErr != nil {
+			return deleted
+		}
+	}
+}
+
+// cliClearBatchV6 is the IPv6 analogue of cliClearBatchV4.
+type cliClearBatchV6 struct {
+	fwd  []dataplane.SessionKeyV6
+	rev  []dataplane.SessionKeyV6
+	dnat []dataplane.DNATKeyV6
+}
+
+func (b *cliClearBatchV6) reset() { b.fwd = b.fwd[:0]; b.rev = b.rev[:0]; b.dnat = b.dnat[:0] }
+
+func (b *cliClearBatchV6) collect(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	b.fwd = append(b.fwd, key)
+	if val.ReverseKey.Protocol != 0 {
+		b.rev = append(b.rev, val.ReverseKey)
+	}
+	if val.Flags&dataplane.SessFlagSNAT != 0 && val.Flags&dataplane.SessFlagStaticNAT == 0 {
+		b.dnat = append(b.dnat, dataplane.DNATKeyForSessionV6(key, val))
+	}
+	return len(b.fwd) >= cliClearFilteredBatch
+}
+
+func (b *cliClearBatchV6) deleteAll(c *CLI, agg *sessionClearErrors) int {
+	deleted := 0
+	for _, key := range b.fwd {
+		if err := c.dp.DeleteSessionV6(key); err != nil {
+			agg.addExceptNotFound("v6 forward delete", err)
+		} else {
+			deleted++
+		}
+	}
+	for _, key := range b.rev {
+		agg.addExceptNotFound("v6 reverse delete", c.dp.DeleteSessionV6(key))
+	}
+	for _, dk := range b.dnat {
+		agg.addExceptNotFound("v6 DNAT companion delete", c.dp.DeleteDNATEntryV6(dk))
+	}
+	return deleted
+}
+
+func clearFilteredV6Bounded(c *CLI, f *sessionFilter, agg *sessionClearErrors) int {
+	iterDP, ok := c.dp.(cliSessionCursor)
+	if !ok {
+		return clearFilteredV6Rescan(c, f, agg)
+	}
+	deleted := 0
+	var a, b cliClearBatchV6
+	cur, prev := &a, &b
+	prevValid := false
+	var cursor *dataplane.SessionKeyV6
+	for {
+		cur.reset()
+		iterErr := iterDP.IterateSessionsV6From(cursor, func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if val.IsReverse != 0 {
+				return true
+			}
+			if !f.matchesV6(key, val) {
+				return true
+			}
+			return !cur.collect(key, val)
+		})
+		agg.add("v6 iterate", iterErr)
+		if cliClearBatchObserver != nil {
+			cliClearBatchObserver(len(cur.fwd))
+		}
+		if prevValid {
+			deleted += prev.deleteAll(c, agg)
+			prevValid = false
+		}
+		full := len(cur.fwd) >= cliClearFilteredBatch && iterErr == nil
+		if !full {
+			deleted += cur.deleteAll(c, agg)
+			return deleted
+		}
+		anchor := cur.fwd[len(cur.fwd)-1]
+		cursor = &anchor
+		cur, prev = prev, cur
+		prevValid = true
+	}
+}
+
+func clearFilteredV6Rescan(c *CLI, f *sessionFilter, agg *sessionClearErrors) int {
+	deleted := 0
+	var b cliClearBatchV6
+	for {
+		b.reset()
+		iterErr := c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if val.IsReverse != 0 {
+				return true
+			}
+			if !f.matchesV6(key, val) {
+				return true
+			}
+			return !b.collect(key, val)
+		})
+		agg.add("v6 iterate", iterErr)
+		if cliClearBatchObserver != nil {
+			cliClearBatchObserver(len(b.fwd))
+		}
+		if len(b.fwd) == 0 {
+			return deleted
+		}
+		deleted += b.deleteAll(c, agg)
+		if len(b.fwd) < cliClearFilteredBatch || iterErr != nil {
+			return deleted
+		}
+	}
 }
 
 // sessionClearErrors accumulates per-operation failures during a CLI

--- a/pkg/cli/cli_clear_bounded_4886_test.go
+++ b/pkg/cli/cli_clear_bounded_4886_test.go
@@ -1,0 +1,151 @@
+package cli
+
+// #4886 A (CLI half): the on-box filtered session clear used to snapshot EVERY
+// matching forward key + its reverse/DNAT companions (v4 then v6) into growing
+// slices before deleting, so a broad filtered clear on a multi-million-entry
+// table allocated O(matches) up front and could OOM the in-process daemon before
+// making progress. It now collects at most cliClearFilteredBatch keys, deletes
+// that chunk, and resumes (cursor primary; bounded rescan fallback), peak
+// O(batch). The gRPC half was already bounded by #5454.
+//
+// FAIL-ON-REVERT: restoring the snapshot-all path (collect every matching key
+// before deleting) stops calling cliClearBatchObserver and collects a single
+// len==matches slice, so the bounded-chunk assertions below (observer fired,
+// every chunk <= batch, multi-chunk) go RED.
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// orderedClearDP is an in-insertion-order, cursor-honoring, removing v4 session
+// store, so the bounded cursor clear can be driven over multiple chunks with a
+// small cliClearFilteredBatch. IterateSessionsFrom yields keys STRICTLY AFTER
+// the cursor (exclusive), matching *dataplane.Manager.IterateSessionsFrom, and
+// skips already-deleted keys. Embeds *dataplane.Manager for the rest of
+// cliRuntime.
+type orderedClearDP struct {
+	*dataplane.Manager
+	keys    []dataplane.SessionKey
+	vals    map[dataplane.SessionKey]dataplane.SessionValue
+	deleted map[dataplane.SessionKey]bool
+	nDelete int
+}
+
+func (d *orderedClearDP) IsLoaded() bool { return true }
+
+func (d *orderedClearDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for _, k := range d.keys {
+		if d.deleted[k] {
+			continue
+		}
+		if !fn(k, d.vals[k]) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *orderedClearDP) IterateSessionsFrom(cursor *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	start := 0
+	if cursor != nil {
+		for i, k := range d.keys {
+			if k == *cursor {
+				start = i + 1 // exclusive: yield keys AFTER the cursor
+				break
+			}
+		}
+	}
+	for _, k := range d.keys[start:] {
+		if d.deleted[k] {
+			continue
+		}
+		if !fn(k, d.vals[k]) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *orderedClearDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *orderedClearDP) IterateSessionsV6From(*dataplane.SessionKeyV6, func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *orderedClearDP) DeleteSession(key dataplane.SessionKey) error {
+	if d.deleted[key] {
+		return ebpf.ErrKeyNotExist // already gone: benign (addExceptNotFound)
+	}
+	d.deleted[key] = true
+	d.nDelete++
+	return nil
+}
+
+func (d *orderedClearDP) DeleteSessionV6(dataplane.SessionKeyV6) error { return nil }
+func (d *orderedClearDP) DeleteDNATEntry(dataplane.DNATKey) error      { return nil }
+func (d *orderedClearDP) DeleteDNATEntryV6(dataplane.DNATKeyV6) error  { return nil }
+
+func TestClearFilteredSessionsBoundedWorkingSet_4886(t *testing.T) {
+	const (
+		batch = 4
+		n     = 20 // > batch → multi-chunk
+	)
+	origBatch := cliClearFilteredBatch
+	origObs := cliClearBatchObserver
+	t.Cleanup(func() {
+		cliClearFilteredBatch = origBatch
+		cliClearBatchObserver = origObs
+	})
+	cliClearFilteredBatch = batch
+
+	var chunks int32
+	var maxChunk int32
+	cliClearBatchObserver = func(chunkLen int) {
+		atomic.AddInt32(&chunks, 1)
+		for {
+			m := atomic.LoadInt32(&maxChunk)
+			if int32(chunkLen) <= m || atomic.CompareAndSwapInt32(&maxChunk, m, int32(chunkLen)) {
+				break
+			}
+		}
+	}
+
+	dp := &orderedClearDP{
+		Manager: dataplane.New(),
+		vals:    map[dataplane.SessionKey]dataplane.SessionValue{},
+		deleted: map[dataplane.SessionKey]bool{},
+	}
+	for i := 0; i < n; i++ {
+		// Non-NAT TCP sessions (no reverse/DNAT companion): only the forward
+		// key is collected, so the chunk size == forward-key count.
+		k := dataplane.SessionKey{Protocol: 6, SrcPort: uint16(1000 + i)}
+		dp.keys = append(dp.keys, k)
+		dp.vals[k] = dataplane.SessionValue{}
+	}
+
+	c := newRecordingCLI(t, dp)
+	if err := c.handleClearSecurity([]string{"flow", "session", "protocol", "tcp"}); err != nil {
+		t.Fatalf("handleClearSecurity: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&chunks); got == 0 {
+		t.Fatal("clear did not proceed in chunks (bounded-batch observer never fired) — snapshot-all path?")
+	}
+	if got := atomic.LoadInt32(&maxChunk); got > batch {
+		t.Fatalf("peak collected chunk = %d, want <= batch %d (working set not bounded)", got, batch)
+	}
+	if got := atomic.LoadInt32(&chunks); got < n/batch {
+		t.Fatalf("only %d chunk(s) for %d sessions at batch %d — want >= %d (not actually chunked)", got, n, batch, n/batch)
+	}
+	// Correctness: every matching session was cleared (exact set, no leak).
+	if dp.nDelete != n {
+		t.Fatalf("cleared %d sessions, want %d (bounded clear must clear the same set as snapshot-all)", dp.nDelete, n)
+	}
+}

--- a/pkg/cli/cli_clear_errors_test.go
+++ b/pkg/cli/cli_clear_errors_test.go
@@ -53,6 +53,17 @@ func (d *clearFaultCLIDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, data
 	return d.iterV6Err
 }
 
+// #4886: cursor overrides for the bounded CLI clear — the table is under
+// cliClearFilteredBatch, so it clears in one chunk; delegate to the full scans
+// (preserving iterErr/iterV6Err so the enumeration-failure tests still fire).
+func (d *clearFaultCLIDP) IterateSessionsFrom(_ *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return d.IterateSessions(fn)
+}
+
+func (d *clearFaultCLIDP) IterateSessionsV6From(_ *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return d.IterateSessionsV6(fn)
+}
+
 func (d *clearFaultCLIDP) DeleteSession(key dataplane.SessionKey) error {
 	if _, isForward := d.v4Sessions[key]; isForward {
 		return d.fwdDelErr

--- a/pkg/cli/cli_clear_reversekey_test.go
+++ b/pkg/cli/cli_clear_reversekey_test.go
@@ -55,6 +55,17 @@ func (d *recordingClearCLIDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, 
 	return nil
 }
 
+// #4886: the bounded CLI clear prefers the cursor path (cliSessionCursor). This
+// fixture's table is well under cliClearFilteredBatch, so it clears in one chunk;
+// the cursor is irrelevant, so delegate to the full-scan iterators.
+func (d *recordingClearCLIDP) IterateSessionsFrom(_ *dataplane.SessionKey, fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return d.IterateSessions(fn)
+}
+
+func (d *recordingClearCLIDP) IterateSessionsV6From(_ *dataplane.SessionKeyV6, fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return d.IterateSessionsV6(fn)
+}
+
 func (d *recordingClearCLIDP) DeleteSession(key dataplane.SessionKey) error {
 	d.deletedV4 = append(d.deletedV4, key)
 	if d.missingV4[key] {

--- a/pkg/cli/cli_dispatch.go
+++ b/pkg/cli/cli_dispatch.go
@@ -195,7 +195,28 @@ func filterStream(src io.Reader, out io.Writer, pipeType, pipeArg string) {
 // to the terminal a screenful at a time rather than being buffered whole in
 // memory first (#4709). At most one screen of lines (plus one lookahead line
 // and the OS pipe buffer) is ever held at once, regardless of total output.
+// stdoutIsTerminal reports whether the process-global os.Stdout is a real
+// terminal (#4886 B). It probes with TCGETS, NOT os.ModeCharDevice — /dev/null
+// is a CharDevice too (CLAUDE.md TTY-detection rule). A pipe (the `| match`
+// filter's os.Stdout redirect), a file redirect, or a non-interactive run all
+// read as non-terminal, so the pager auto-disables and cannot nest / hang.
+func stdoutIsTerminal() bool {
+	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETS)
+	return err == nil
+}
+
 func (c *CLI) dispatchWithPager(line string) error {
+	// #4886 B: only page when stdout is a real terminal. A non-TTY stdout means
+	// output is redirected — most importantly into the `| match/except/…` filter
+	// pipe: dispatchWithPipe redirects os.Stdout to the pipe, then calls dispatch,
+	// which routes a bare `show` back HERE. Engaging the pager then wrote
+	// `--More--` into the hidden outer pipe while blocking on os.Stdin, so
+	// `show … | match X` HUNG with no visible prompt; it also mis-paged
+	// scripted / file-redirected shows. Standard pager auto-disable (like less):
+	// when stdout is not a TTY, stream straight through with no pager.
+	if !stdoutIsTerminal() {
+		return c.dispatchOperational(line)
+	}
 	origStdout := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/pkg/cli/cli_dispatch_pager_tty_4886_test.go
+++ b/pkg/cli/cli_dispatch_pager_tty_4886_test.go
@@ -1,0 +1,101 @@
+package cli
+
+// #4886 B: dispatch() routes any `show ` to dispatchWithPager, which had NO TTY
+// guard. So `show … | match X` → dispatchWithPipe redirects os.Stdout to the
+// filter pipe → the inner bare `show` routes back to dispatchWithPager → the
+// pager engaged even though os.Stdout was the pipe, writing `--More--` into the
+// hidden outer pipe while blocking on os.Stdin → the command HUNG with no
+// visible prompt. dispatchWithPager now auto-disables when stdout is not a TTY
+// (stdoutIsTerminal), so a piped / scripted / redirected show streams straight
+// through with no pager.
+//
+// FAIL-ON-REVERT: remove the `if !stdoutIsTerminal()` guard and the piped-show
+// nesting test HANGS (the inner pager writes --More-- into the pipe and blocks
+// on stdin with no key feeder) → the timeout fires RED; the direct pipe-stdout
+// test also sees a `--More--` leak.
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStdoutIsTerminal_PipeIsNotATTY_4886 pins the guard's input: a pipe (the
+// `| match` filter's os.Stdout redirect) reads as non-terminal, so the pager
+// auto-disables. This is the exact condition that broke the nested pager.
+func TestStdoutIsTerminal_PipeIsNotATTY_4886(t *testing.T) {
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() { os.Stdout = orig; w.Close(); r.Close() }()
+
+	os.Stdout = w
+	if stdoutIsTerminal() {
+		t.Fatal("stdoutIsTerminal() = true for an os.Pipe stdout; want false (pager must auto-disable when piped)")
+	}
+	// Sanity: the real test stdout may or may not be a TTY, but a pipe must not.
+}
+
+// TestPagerAutoDisablesOnNonTTYStdout_4886 is the behavioral guard: with os.Stdout
+// redirected to a pipe (exactly the state dispatchWithPipe leaves for the inner
+// `show` of a `show … | match …`), dispatchWithPager must NOT engage the pager —
+// it must stream straight through with NO `--More--` prompt. `show` (no subcommand)
+// prints ~33 lines of help, MORE than the default pageSize (23), so on the
+// pre-#4886 (no-guard) path the pager DID emit a `--More--` into this non-TTY
+// stdout (the prompt that, in the real nested case, went into the hidden filter
+// pipe while the pager blocked on stdin → the hang). Asserting no `--More--` leak
+// RED-fails on the guard revert regardless of whether stdin blocks.
+func TestPagerAutoDisablesOnNonTTYStdout_4886(t *testing.T) {
+	c := newRecordingCLI(t, nil)
+
+	// Force stdin to immediate EOF so a reverted (no-guard) pager cannot actually
+	// block the test — it still EMITS the --More-- before reading, which is the
+	// signal we assert on.
+	origIn := os.Stdin
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	inW.Close() // read side is at EOF immediately
+	os.Stdin = inR
+
+	origOut := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	os.Stdout = w
+
+	var out []byte
+	readDone := make(chan struct{})
+	go func() { out, _ = io.ReadAll(r); close(readDone) }()
+
+	done := make(chan error, 1)
+	go func() { done <- c.dispatchWithPager("show") }()
+
+	var derr error
+	select {
+	case derr = <-done:
+	case <-time.After(5 * time.Second):
+		os.Stdout, os.Stdin = origOut, origIn
+		w.Close()
+		<-readDone
+		t.Fatalf("dispatchWithPager did not return within 5s (pager blocked): %q", string(out))
+	}
+
+	os.Stdout, os.Stdin = origOut, origIn
+	w.Close()
+	<-readDone
+	inR.Close()
+
+	if derr != nil {
+		t.Fatalf("dispatchWithPager: %v", derr)
+	}
+	if strings.Contains(string(out), "--More--") {
+		t.Fatalf("pager engaged on a non-TTY stdout (--More-- leaked) — the nested `show | match` hang path; the TTY guard is missing:\n%q", string(out))
+	}
+}

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -3,6 +3,7 @@ package dhcpserver
 import (
 	"encoding/csv"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -205,7 +206,21 @@ func parseActiveLeasesFileInto(path string, family int, now time.Time, acc *ddns
 	r := csv.NewReader(f)
 	r.FieldsPerRecord = -1 // memfile rows vary across Kea versions
 	r.Comment = '#'
-	records, err := r.ReadAll()
+	// #4886 C: stream row-by-row (r.Read) instead of csv.ReadAll(). A Kea LFC
+	// memfile accumulates many historical rows between compactions; ReadAll
+	// materialized ALL of them ([][]string) before reducing to acc (which keeps
+	// only the latest row per address) — an O(history) transient that can OOM the
+	// control plane under lease churn. Read the header first (for schema
+	// validation), then fold each data row into acc as it is read: peak memory
+	// O(unique addresses), not O(history). acc keeps latest-per-address, so this
+	// is semantically identical to the pre-#4886 ReadAll path.
+	header, err := r.Read()
+	if err == io.EOF {
+		// No header at all — anomalous (Kea always writes a header). Fail SAFE
+		// (untrusted → Reconcile SKIPS the destructive diff), not trusted-empty.
+		return fmt.Errorf("parse %s: Kea %s lease file has no header (anomalous: mid-write or corrupt)",
+			path, familyLabel(family))
+	}
 	if err != nil {
 		return fmt.Errorf("parse %s: %w", path, err)
 	}
@@ -231,11 +246,6 @@ func parseActiveLeasesFileInto(path string, family int, now time.Time, acc *ddns
 	//      -rows treated as a legitimate trusted zero-lease (nil, nil): a
 	//      healthy header + no active rows genuinely means "no active
 	//      leases", and clearing owned DNS records is then correct.
-	if len(records) == 0 {
-		return fmt.Errorf("parse %s: Kea %s lease file has no header (anomalous: mid-write or corrupt)",
-			path, familyLabel(family))
-	}
-
 	// Build the header->index map with CASE-INSENSITIVE keys. Kea's real
 	// memfile headers are lower-case, but normalizing defends against a
 	// mangled header ("Address"/"ADDRESS") silently resolving to no column.
@@ -253,7 +263,7 @@ func parseActiveLeasesFileInto(path string, family int, now time.Time, acc *ddns
 	// can never drive a destructive diff. Names compared case-insensitively
 	// (two "Address"/"address" columns collide).
 	cols := make(map[string]int)
-	for i, h := range records[0] {
+	for i, h := range header {
 		key := strings.ToLower(strings.TrimSpace(h))
 		if _, dup := cols[key]; dup {
 			return fmt.Errorf("parse %s: duplicate column %q in Kea %s lease header (ambiguous)",
@@ -308,14 +318,12 @@ func parseActiveLeasesFileInto(path string, family int, now time.Time, acc *ddns
 		}
 	}
 
-	// Header is present AND valid. A file with only a header (zero data rows)
-	// is a LEGITIMATE trusted zero-lease contribution — return before the
-	// per-row loop, adding nothing to acc, so a genuinely-empty file in the LFC
-	// set contributes no leases (and, alone, correctly clears owned records).
-	if len(records) < 2 {
-		return nil
-	}
-
+	// Header is present AND valid. A file with only a header (zero data rows) is
+	// a LEGITIMATE trusted zero-lease contribution: the streaming loop below reads
+	// zero data rows and returns nil, adding nothing to acc, so a genuinely-empty
+	// file in the LFC set contributes no leases (and, alone, correctly clears
+	// owned records).
+	//
 	// Kea appends rows; the LAST row for an address is authoritative (lease
 	// renewal / state change). We keep the last seen row per address (across
 	// the whole LFC file set, via acc) and emit in first-appearance order. The
@@ -328,7 +336,16 @@ func parseActiveLeasesFileInto(path string, family int, now time.Time, acc *ddns
 	// recorded in acc.order whenever it first appears, tombstone or not. Output
 	// order is stable; the tombstone filter at emit time drops still-inactive
 	// ones.
-	for rowNum, fields := range records[1:] {
+	rowNum := -1
+	for {
+		fields, rerr := r.Read()
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return fmt.Errorf("parse %s: %w", path, rerr)
+		}
+		rowNum++
 		// Row-conformance (Codex r6): a row too short to supply every
 		// required column cannot be read reliably. Treat the whole family's
 		// source as unreliable (torn/truncated memfile) rather than silently

--- a/pkg/dhcpserver/ddns_leases_streaming_4886_test.go
+++ b/pkg/dhcpserver/ddns_leases_streaming_4886_test.go
@@ -1,0 +1,104 @@
+package dhcpserver
+
+// #4886 C: parseActiveLeasesFileInto used csv.ReadAll(), materializing EVERY row
+// of a Kea LFC memfile ([][]string holding all rows LIVE at once) before reducing
+// to the accumulator (which keeps only the latest row per address). A Kea memfile
+// accumulates many historical rows between LFC compactions, so under lease churn
+// this was an O(history) transient that could OOM the control plane. It now
+// streams row-by-row (csv.Read) and folds each row into acc as it is read: peak
+// live memory O(unique addresses), not O(history).
+//
+// FAIL-ON-REVERT: restoring csv.ReadAll() holds all N rows live at once, so the
+// TotalAlloc for a many-rows/few-addresses file jumps (the retained [][]string) —
+// TestParseActiveLeasesStreamingBounded_4886 asserts the per-parse allocation is
+// bounded well under the ReadAll retained-row cost. The correctness test proves
+// the streaming loop is functionally identical to ReadAll.
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// bigHistoryFile writes a Kea v4 memfile with nRows historical rows spread over
+// nAddrs addresses (round-robin), each row active (state 0, future expire). The
+// LAST row per address wins; with all rows active the result is nAddrs active
+// leases regardless of history depth.
+func bigHistoryFile(t *testing.T, nRows, nAddrs int) string {
+	t.Helper()
+	var b strings.Builder
+	b.Grow(nRows * 64)
+	b.WriteString(lfcV4Header + "\n")
+	for i := 0; i < nRows; i++ {
+		a := i % nAddrs
+		// address, hwaddr, client_id, valid_lifetime, expire, subnet_id,
+		// fqdn_fwd, fqdn_rev, hostname, state
+		fmt.Fprintf(&b, "10.0.%d.%d,aa:bb:cc:dd:%02x:%02x,,3600,%s,1,0,1,host-%d,0\n",
+			a/256, a%256, (a>>8)&0xff, a&0xff, lfcFuture, a)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, path, b.String())
+	return path
+}
+
+// TestParseActiveLeasesLargeHistoryCorrect_4886: a large-history file (many rows,
+// few addresses) parses to exactly the latest-per-address active set — proving
+// the streaming loop is functionally identical to the pre-#4886 ReadAll path and
+// handles a deep history without dropping/duplicating leases.
+func TestParseActiveLeasesLargeHistoryCorrect_4886(t *testing.T) {
+	const nRows, nAddrs = 20000, 8
+	path := bigHistoryFile(t, nRows, nAddrs)
+
+	leases, err := parseActiveLeases4(path, lfcNow)
+	if err != nil {
+		t.Fatalf("parseActiveLeases4: %v", err)
+	}
+	if len(leases) != nAddrs {
+		t.Fatalf("large-history parse returned %d leases, want %d (latest-per-address across %d rows)",
+			len(leases), nAddrs, nRows)
+	}
+	seen := map[string]bool{}
+	for _, l := range leases {
+		if seen[l.Address] {
+			t.Fatalf("duplicate address %s in result", l.Address)
+		}
+		seen[l.Address] = true
+	}
+}
+
+// TestParseActiveLeasesStreamingBounded_4886: per-parse allocation for a
+// many-rows/few-addresses file is bounded well below the retained-row cost of
+// csv.ReadAll(). ReadAll holds all nRows []string rows LIVE (referenced by the
+// records slice) → TotalAlloc includes the full retained backing; streaming lets
+// each row be freed after it is folded into acc, so TotalAlloc scales with the
+// row STREAM, not the retained set. The bound is generous (well between the two)
+// so it is robust yet REDs on the ReadAll revert.
+func TestParseActiveLeasesStreamingBounded_4886(t *testing.T) {
+	const nRows, nAddrs = 60000, 8
+	path := bigHistoryFile(t, nRows, nAddrs)
+
+	var m1, m2 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+	if _, err := parseActiveLeases4(path, lfcNow); err != nil {
+		t.Fatalf("parseActiveLeases4: %v", err)
+	}
+	runtime.ReadMemStats(&m2)
+	allocated := m2.TotalAlloc - m1.TotalAlloc
+
+	// Streaming allocates on the order of the row STREAM (each row's []string +
+	// cell strings, transient/GC-able). ReadAll additionally RETAINS every row in
+	// the records [][]string, so csv.ReadAll copies and holds them all → a
+	// materially higher per-parse allocation. Empirically (60k rows / 8 addrs,
+	// stable to <1%): streaming ~14.9 MiB, ReadAll ~23.0 MiB. Bound = 19 MiB sits
+	// cleanly between (streaming +4 MiB headroom; RED on the ReadAll revert).
+	const bound = 19 << 20
+	if allocated > bound {
+		t.Fatalf("parse allocated %d bytes for %d rows / %d addresses — want <= %d (ReadAll-retains-all-rows regression?)",
+			allocated, nRows, nAddrs, bound)
+	}
+	t.Logf("streaming parse allocated %d bytes for %d rows / %d addresses (bound %d)", allocated, nRows, nAddrs, bound)
+}


### PR DESCRIPTION
Three unbounded-work/unbounded-memory defects in control-plane show/clear/DDNS paths. **STEP-0 on current master found two of the three already fixed by later PRs** — this fixes the three LIVE parts and leaves the fixed ones untouched.

## Already fixed (not touched)
- **A-gRPC**: `server_sessions.go` `ClearSessions` bounded by **#5454**.
- **B re-buffer**: `cli_dispatch.go` already streams (`filterStream`/`pageStream`, **#4731/#4709**), `| last` capped (**#5037**); no `io.ReadAll`.

## Live fixes
**A (`cli_clear.go clearFilteredSessions`)** — the CLI half still snapshotted every matching fwd/rev/DNAT key before deleting. Now collects ≤ `cliClearFilteredBatch` keys, deletes, resumes — **cursor primary** (`IterateSessionsFrom`, one O(N) pass, deferred anchor delete) with a rescan fallback; peak O(batch). Mirrors the bounded gRPC #5454; the cursor keeps it O(N) (a bare rescan is O(N²), starving the HA watchdog #4719). `validate()`-before-clear + filter unchanged → exact set cleared, #3439 typo-guard preserved. Two existing clear fakes gained `IterateSessionsFrom` overrides.

**B (`cli_dispatch.go dispatchWithPager`)** — the LIVE B defect is the **nested pager**, not the re-buffer: `show … | match X` redirected `os.Stdout` to the filter pipe, the inner `show` routed back to the pager, which wrote `--More--` into the hidden pipe while blocking on stdin → hang. Now the pager **auto-disables when stdout is not a terminal** (`stdoutIsTerminal`, TCGETS — not `os.ModeCharDevice`).

**C (`dhcpserver/ddns_leases.go`)** — the DDNS parser `csv.ReadAll`'d every row of the Kea LFC memfile before reducing to the accumulator. Now **streams `csv.Read()` row-by-row**, folding each into the accumulator → peak O(unique addresses). Header validated first; fail-safe posture + all validation unchanged → byte-identical result.

## Per-part fail-on-revert (each proven RED via `go test -overlay`)
- **A**: snapshot-all → peak chunk 20 > batch 4 RED.
- **B**: remove the TTY guard → a non-TTY `show` emits `--More--` RED.
- **C**: restore `csv.ReadAll` → 22.97 MiB > 19 MiB bound RED (streaming a stable 14.9 MiB for 60k rows / 8 addresses).

## Validation
`go build ./...` clean; `go vet ./pkg/cli/ ./pkg/dhcpserver/` clean; `go test -race ./pkg/cli/ ./pkg/dhcpserver/` green.

Closes #4886

🤖 Generated with [Claude Code](https://claude.com/claude-code)