### PR TITLE
test: pin routing-instance member-bind stays best-effort (#5946)

### DIFF
--- a/pkg/daemon/vrf_setup_bind_commit_truth_5700_test.go
+++ b/pkg/daemon/vrf_setup_bind_commit_truth_5700_test.go
@@ -208,3 +208,53 @@ func TestApplyTailReconcilesSurfacesVRFError_5700(t *testing.T) {
 			"errors.Join wiring, got %v", err)
 	}
 }
+
+// TestApplyVRFReconcileMemberBindStaysBestEffort_5700 pins the transient-vs-fatal
+// boundary the #5700 fix deliberately draws (the gap the PR #5945 hostile review
+// surfaced). The PRE-networkd routing-instance MEMBER bind
+// (BindInterfaceToVRF(member, ri.Name)) runs BEFORE applyInterfaceReconcile
+// creates the tunnel/xfrmi member devices, so a member that is a later-created
+// tunnel is legitimately "not found" at that phase — an EXPECTED transient
+// absence. It MUST stay best-effort (WARN) and NOT surface into commit truth;
+// only the transient-free ReconcileVRFs device setup (vrfErr) and the
+// post-networkd rebindManagementVRFIfaces (networkdErr) are load-bearing.
+//
+// Isolation: ReconcileVRFs SUCCEEDS (vrf-blue LinkAdd has no addFail, so the
+// device-setup path cannot confound vrfErr) and no fxp*/fab*/em* interface is
+// present (so the management desired-VRF and its pre-networkd bind never run).
+// Only the RI member ge-0-0-5 is absent from the fake link table, so
+// BindInterfaceToVRF's LinkByName(member) returns LinkNotFoundError and ONLY the
+// member bind fails. applyVRFReconcile must still return vrfErr == nil.
+//
+// FAIL-ON-REVERT: add `vrfErr = errors.Join(vrfErr, err)` to the member-bind
+// loop in applyVRFReconcile (surface the transient) and this goes RED — the test
+// is load-bearing against a regression that promotes the expected member-bind
+// transient into a false commit failure. The existing
+// TestApplyVRFReconcileToleratesSuccess_5700 covers the pre-networkd MGMT bind's
+// best-effort-ness; this covers the routing-instance MEMBER bind.
+func TestApplyVRFReconcileMemberBindStaysBestEffort_5700(t *testing.T) {
+	ops := newReconcileFakeLinkOps()
+
+	d := &Daemon{routing: routing.NewManagerWithLinkOpsForTest(ops)}
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{
+			Name:         "blue",
+			InstanceType: "vrf",         // non-forwarding -> reconciled + member-bound
+			TableID:      100,           // vrf-blue LinkAdd succeeds (no addFail)
+			Interfaces:   []string{"ge-0/0/5"}, // ge-0-0-5: absent from ops.links -> bind fails
+		},
+	}
+
+	ctxErr, vrfErr := d.applyVRFReconcile(context.Background(), cfg)
+	if ctxErr != nil {
+		t.Fatalf("ctxErr = %v, want nil (not a #2926-C1 cancellation)", ctxErr)
+	}
+	if vrfErr != nil {
+		t.Fatalf("vrfErr = %v, want nil: a routing-instance MEMBER bind failure is "+
+			"best-effort (an expected transient before tunnel/xfrmi member creation) and "+
+			"must NOT surface into commit truth — only the ReconcileVRFs device setup does "+
+			"(#5700)", vrfErr)
+	}
+}


### PR DESCRIPTION
## Summary

Test-only follow-up surfaced during the independent hostile review of PR #5945 (#5700, VRF setup/bind → commit truth).

The #5700 fix surfaces ONLY the two **transient-free** VRF failures into commit truth: `ReconcileVRFs` device creation (`vrfErr`) and the post-networkd authoritative management re-bind (`rebindManagementVRFIfaces` → `networkdErr`). The PRE-networkd routing-instance **MEMBER** binds (`BindInterfaceToVRF(member, ri.Name)`) run **before** `applyInterfaceReconcile` creates the tunnel/xfrmi member devices, so a member that is a later-created tunnel is legitimately "not found" at that phase — an **expected transient** — and is deliberately left best-effort `slog.Warn`. Surfacing it would false-fail valid commits.

That best-effort-ness was **safe by construction** (the member-bind loop makes no `vrfErr` assignment) but **not test-pinned**: the existing `vrf_setup_bind_commit_truth_5700_test.go` fixtures use only `fxp0`/mgmt, no routing-instance member. A future regression that added surfacing to the member-bind loop would not be caught.

## Change

Add `TestApplyVRFReconcileMemberBindStaysBestEffort_5700`:
- A `"vrf"` routing-instance whose member interface `ge-0-0-5` is **absent** from the fake link table → `BindInterfaceToVRF`'s `LinkByName(member)` returns `LinkNotFoundError` → the member bind fails.
- `ReconcileVRFs` **succeeds** (`vrf-blue` LinkAdd has no `addFail`), and no `fxp*/fab*/em*` interface is present (so the management desired-VRF and its pre-networkd bind never run) — isolating the member-bind path.
- Asserts `applyVRFReconcile` still returns `vrfErr == nil`.

## Test-only + fail-on-revert

**No production files changed** (diff is the single test file). Fail-on-revert verified via a read-only `-overlay`: injecting `vrfErr = errors.Join(vrfErr, err)` into the member-bind loop turns the new test **RED** (`vrfErr = interface ge-0-0-5 not found`), while `TestApplyVRFReconcileToleratesSuccess_5700` stays **green** (its mgmt-only fixture never exercises the member loop) — proving the test is load-bearing and specific to the routing-instance member-bind path.

Validation: `go test -race ./pkg/daemon/` green (16.3s), including all existing #5700 tests.

Closes #5946

🤖 Generated with [Claude Code](https://claude.com/claude-code)