### PR TITLE
test: extend #5886 nil-interface canary to the multi-line map-index shape (#5931)

### DIFF
--- a/pkg/config/interface_nil_canary_5886_test.go
+++ b/pkg/config/interface_nil_canary_5886_test.go
@@ -1,18 +1,29 @@
 package config
 
 // #5886 canary: a repository-wide guard against RAW read-only interface/unit
-// range-derefs re-appearing in the remote/CLI presenter packages. The nil-safe
-// walk owner is this package (RangeInterfaces / RangeUnits / LookupInterface /
+// derefs re-appearing in the remote/CLI presenter packages. The nil-safe walk
+// owner is this package (RangeInterfaces / RangeUnits / LookupInterface /
 // LookupUnit). A tolerant load / HA sync can leave a present-but-nil
-// InterfaceConfig / InterfaceUnit map value; a `for k, v := range
-// X.Interfaces.Interfaces { … v.Field … }` (or `range X.Units`) that does not
-// immediately nil-skip the value panics a read-only presenter (the #5886 DoS).
+// InterfaceConfig / InterfaceUnit map value, so a raw walk that does not
+// nil-skip the value panics a read-only presenter (the #5886 DoS).
 //
-// This canary fails if any NON-test .go file in pkg/grpcapi / pkg/api / pkg/cli
-// contains a 2-variable range over the interface or unit map whose value
-// variable is NOT nil-skipped on the very next line. It does not require the
-// shared iterator specifically (an inline `if v == nil { continue }` is fine) —
-// it only forbids the raw, unguarded shape. New presenters must keep the guard.
+// The canary flags three dangerous shapes in any NON-test .go file under
+// pkg/grpcapi / pkg/api / pkg/cli / pkg/monitoriface:
+//
+//  1. 2-var RANGE with a named value that is NOT nil-skipped on the next line
+//     (`for k, v := range X.Interfaces.Interfaces { … v.Field … }`).
+//  2. SAME-LINE map-index-then-deref (`if v, ok := X…[k]; ok && v.Field`).
+//  3. MULTI-LINE map-index whose `ok` gates a block and whose value is NOT
+//     nil-skipped on the next line (`if v, ok := X…[k]; ok {` then a bare
+//     `v.Field` on a later line). This is #5931: `ok` proves KEY presence, not
+//     a non-nil value, so the deref inside the block still nil-derefs. The
+//     fixed fabric-lookup sites (server_cluster.go, …) route through
+//     config.LookupInterface, which returns ok ONLY for a non-nil slot; a
+//     future revert to the raw multi-line map index is caught here.
+//
+// A `_`-blank presence check (`if _, isLocal := X…[k]; isLocal {`) can never
+// deref the value and is NOT flagged; a next-line `if v == nil { … }` guard is
+// an accepted inline nil-skip (mirrors the range rule).
 import (
 	"os"
 	"path/filepath"
@@ -22,18 +33,62 @@ import (
 	"testing"
 )
 
+// reRange: a 2-var range over the interface or `.Units` map binding a NAMED
+// value var (a `_` value is deref-free and safe).
+var reRange = regexp.MustCompile(`^\s*for \w+, ([A-Za-z]\w*) := range \w+\.(?:Interfaces\.Interfaces|Units) \{\s*$`)
+
+// reMapIndexDeref: SAME-LINE map-index-then-deref, `if v, ok := X.Interfaces.
+// Interfaces[k]; ok && v.Field` (or `.Units[k]`) — the deref is in the same
+// condition. Route through config.LookupInterface / LookupUnit (ok ⇒ non-nil).
+var reMapIndexDeref = regexp.MustCompile(`:= \w+\.(?:Interfaces\.Interfaces|Units)\[[^\]]*\]; \w+ && \w+\.`)
+
+// reMapIndexMultiline: MULTI-LINE map-index whose `ok` opens a block,
+// `if v, ok := X.Interfaces.Interfaces[k]; ok {` with a NAMED value var (group
+// 1; a `_`-blank value never derefs, so [A-Za-z] excludes it). The deref is on
+// a LATER line, so reMapIndexDeref/reRange both miss it (#5931). Flagged unless
+// the value is nil-skipped on the very next line.
+var reMapIndexMultiline = regexp.MustCompile(`^\s*if ([A-Za-z]\w*), \w+ := \w+\.(?:Interfaces\.Interfaces|Units)\[[^\]]*\]; \w+ \{\s*$`)
+
+// nilSkippedNext reports whether line `next` inline-guards value var `v` with a
+// nil check (`if v == nil` / `if v != nil`) — the accepted inline nil-skip.
+func nilSkippedNext(v, next string) bool {
+	return strings.Contains(next, "if "+v+" == nil") || strings.Contains(next, "if "+v+" != nil")
+}
+
+// rawInterfaceDerefViolations returns the 0-based indices of lines in `lines`
+// that match a dangerous raw interface/unit deref shape (#5886/#5931). Shared by
+// the tree scan and the self-test so both exercise the identical detection.
+func rawInterfaceDerefViolations(lines []string) []int {
+	var out []int
+	for i, l := range lines {
+		if reMapIndexDeref.MatchString(l) {
+			out = append(out, i)
+			continue
+		}
+		if m := reMapIndexMultiline.FindStringSubmatch(l); m != nil {
+			next := ""
+			if i+1 < len(lines) {
+				next = lines[i+1]
+			}
+			if !nilSkippedNext(m[1], next) {
+				out = append(out, i)
+			}
+			continue
+		}
+		if m := reRange.FindStringSubmatch(l); m != nil {
+			next := ""
+			if i+1 < len(lines) {
+				next = lines[i+1]
+			}
+			if !nilSkippedNext(m[1], next) {
+				out = append(out, i)
+			}
+		}
+	}
+	return out
+}
+
 func TestNoRawInterfaceUnitRangeDerefInPresenters_5886(t *testing.T) {
-	// range over the interface map or a `.Units` map, binding a NAMED value var
-	// (a `_` value is deref-free and safe).
-	reRange := regexp.MustCompile(`^\s*for \w+, ([A-Za-z]\w*) := range \w+\.(?:Interfaces\.Interfaces|Units) \{\s*$`)
-
-	// map-INDEX-then-deref in one condition: `if v, ok := X.Interfaces.Interfaces[k];
-	// ok && v.Field` (or `.Units[k]`). This is the shape #5886/monitor.go:343 hid in
-	// — the range regex above does not catch it. Route the lookup through
-	// config.LookupInterface / LookupUnit (which return ok only for a non-nil slot)
-	// so `ok` implies a safe dereference.
-	reMapIndexDeref := regexp.MustCompile(`:= \w+\.(?:Interfaces\.Interfaces|Units)\[[^\]]*\]; \w+ && \w+\.`)
-
 	dirs := []string{"../grpcapi", "../api", "../cli", "../monitoriface"}
 	var violations []string
 	for _, dir := range dirs {
@@ -51,28 +106,72 @@ func TestNoRawInterfaceUnitRangeDerefInPresenters_5886(t *testing.T) {
 				t.Fatalf("read %s: %v", path, err)
 			}
 			lines := strings.Split(string(data), "\n")
-			for i, l := range lines {
-				if reMapIndexDeref.MatchString(l) {
-					violations = append(violations, path+":"+strconv.Itoa(i+1)+": "+strings.TrimSpace(l))
-				}
-				m := reRange.FindStringSubmatch(l)
-				if m == nil {
-					continue
-				}
-				v := m[1]
-				next := ""
-				if i+1 < len(lines) {
-					next = lines[i+1]
-				}
-				if !strings.Contains(next, "if "+v+" == nil") && !strings.Contains(next, "if "+v+" != nil") {
-					violations = append(violations, path+":"+strconv.Itoa(i+1)+": "+strings.TrimSpace(l))
-				}
+			for _, idx := range rawInterfaceDerefViolations(lines) {
+				violations = append(violations, path+":"+strconv.Itoa(idx+1)+": "+strings.TrimSpace(lines[idx]))
 			}
 		}
 	}
 	if len(violations) > 0 {
-		t.Fatalf("raw unguarded interface/unit range-deref in a read-only presenter (nil-deref DoS, #5886) — "+
-			"add `if <v> == nil { continue }` or use config.RangeInterfaces/RangeUnits:\n  %s",
+		t.Fatalf("raw unguarded interface/unit deref in a read-only presenter (nil-deref DoS, #5886/#5931) — "+
+			"add `if <v> == nil { continue }` or use config.RangeInterfaces/RangeUnits/LookupInterface/LookupUnit:\n  %s",
 			strings.Join(violations, "\n  "))
+	}
+}
+
+// TestNilInterfaceCanarySelfCheck_5931 pins the detection itself with in-test
+// fixtures (no production source needed) and proves the #5931 multi-line
+// extension is load-bearing: the multi-line shape is caught by the new regex and
+// MISSED by the pre-#5931 pair (reRange + reMapIndexDeref).
+func TestNilInterfaceCanarySelfCheck_5931(t *testing.T) {
+	// The #5931 dangerous shape: ok gates a block, the deref is on a LATER line.
+	multiline := []string{
+		"\tif ifc, ok := cfg.Interfaces.Interfaces[name]; ok {",
+		"\t\tout = ifc.Description",
+		"\t}",
+	}
+	if got := rawInterfaceDerefViolations(multiline); len(got) != 1 || got[0] != 0 {
+		t.Fatalf("multi-line map-index-deref NOT flagged (canary blind spot #5931): violations=%v", got)
+	}
+	// RED-ON-REVERT: the pre-#5931 regex pair MISSES the multi-line shape, so
+	// reverting reMapIndexMultiline out would re-open the blind spot.
+	if reMapIndexDeref.MatchString(multiline[0]) {
+		t.Fatal("precondition: same-line reMapIndexDeref must NOT match the multi-line shape (it would already be covered)")
+	}
+	if reRange.MatchString(multiline[0]) {
+		t.Fatal("precondition: reRange must NOT match the multi-line shape")
+	}
+	if !reMapIndexMultiline.MatchString(multiline[0]) {
+		t.Fatal("reMapIndexMultiline must match the multi-line shape (the load-bearing extension)")
+	}
+
+	positives := [][]string{
+		multiline,
+		// same-line deref (shape 2, existing).
+		{"\tif ifc, ok := cfg.Interfaces.Interfaces[name]; ok && ifc.Description != \"\" {", "\t}"},
+		// unit-map multi-line.
+		{"\tif u, ok := ifc.Units[num]; ok {", "\t\tx = u.VlanID", "\t}"},
+		// range without a next-line nil-skip (shape 1, existing).
+		{"\tfor name, ifc := range cfg.Interfaces.Interfaces {", "\t\tuse(ifc.Name)", "\t}"},
+	}
+	for i, p := range positives {
+		if len(rawInterfaceDerefViolations(p)) == 0 {
+			t.Errorf("positive[%d] not flagged (should be a violation): %q", i, p)
+		}
+	}
+
+	negatives := [][]string{
+		// _-blank presence-only: the value can never be dereferenced.
+		{"\tif _, isLocal := cfg.Interfaces.Interfaces[name]; isLocal {", "\t\tcontinue"},
+		// nil-safe accessor (the steered-to form, #5930).
+		{"\tif ifc, ok := config.LookupInterface(cfg, name); ok {", "\t\tx = ifc.Description"},
+		// raw map-index but nil-skipped on the very next line (accepted inline guard).
+		{"\tif ifc, ok := cfg.Interfaces.Interfaces[name]; ok {", "\t\tif ifc == nil {", "\t\t\tcontinue", "\t\t}"},
+		// range WITH a next-line nil-skip.
+		{"\tfor name, ifc := range cfg.Interfaces.Interfaces {", "\t\tif ifc == nil {", "\t\t\tcontinue", "\t\t}"},
+	}
+	for i, ne := range negatives {
+		if got := rawInterfaceDerefViolations(ne); len(got) != 0 {
+			t.Errorf("negative[%d] false-positived at lines %v (should be safe): %q", i, got, ne)
+		}
 	}
 }


### PR DESCRIPTION
## Gap (from the PR #5930 review)

The #5886 source-scan canary (`TestNoRawInterfaceUnitRangeDerefInPresenters_5886`) flagged the 2-var `for k, v := range m` range form and the **same-line** map-index form `if v, ok := m[k]; ok && v.Field`, but MISSED the **multi-line** form:

```go
if v, ok := X.Interfaces.Interfaces[k]; ok {
    something = v.Field   // deref on a LATER line
}
```

That is exactly the shape the fixed fabric-lookup sites use (`server_cluster.go:34/38`, …), now routed through `config.LookupInterface`. Correct today, but a future revert to a raw multi-line map index would be caught by **neither** existing regex — a green-under-broken blind spot.

## Fix (test-only)

- Add `reMapIndexMultiline` for `if v, ok := X…[k]; ok {` with a **named** value var (`[A-Za-z]` excludes the `_`-blank presence-only sites), honoring a next-line `if v == nil` inline nil-skip exactly like the range rule.
- Factor the per-file scan into a shared `rawInterfaceDerefViolations` helper used by both the tree scan and the self-test.

## Self-test + fail-on-revert

`TestNilInterfaceCanarySelfCheck_5931` (in-test fixtures, no production source): the multi-line shape is **flagged**; the `_`-blank presence check, the `config.LookupInterface` form, a nil-skipped raw map index, and a nil-skipped range are **not** flagged. It proves the extension is load-bearing — the multi-line shape is missed by the pre-#5931 pair and matched only by `reMapIndexMultiline`, so removing the new branch REDs the assertion (**verified via `go test -overlay`**).

Scanned the current tree with the new regex: **zero** occurrences (all sites use `config.LookupInterface`) — no false positive, no real bug to file.

**TEST-ONLY:** the diff touches only `pkg/config/interface_nil_canary_5886_test.go`.

## Validation

`go vet ./pkg/config/` clean; `go test ./pkg/config/` green.

Closes #5931

🤖 Generated with [Claude Code](https://claude.com/claude-code)