### PR TITLE
test: pin tunnel-endpoint-ID overflow test to the collision error (#5934)

### DIFF
--- a/pkg/config/tunnelid_test.go
+++ b/pkg/config/tunnelid_test.go
@@ -181,8 +181,26 @@ func TestTunnelEndpointIDOverflowOnlyUnitHashesBareRef(t *testing.T) {
 		"set interfaces wg34524 unit 0 tunnel mode wireguard",
 		"set interfaces wg34524 unit 0 tunnel wireguard peer aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa allowed-ips 10.0.0.0/24",
 	})
-	if _, err := CompileConfig(tree); err == nil {
+	_, err := CompileConfig(tree)
+	if err == nil {
 		t.Fatalf("CompileConfig accepted a builder-emitted collision hidden behind an overflow-only unit spelling (wg0 emits bare ref, collides with wg34524.0)")
+	}
+	// #5934: pin the error to the tunnel-endpoint-ID collision gate
+	// (validateTunnelEndpointIDCollisionAST, "interfaces: tunnel endpoint id
+	// collision between %q and %q ..."). A bare `err != nil` would pass
+	// VACUOUSLY if a future gate reorder made the collision gate stop firing and
+	// a DIFFERENT error surfaced first — e.g. the #5829 fail-closed unit gate
+	// rejecting the overflow `unit 99999...`, or a parse error — silently no
+	// longer exercising the collision path this test exists to guard. Assert the
+	// SPECIFIC collision error (and the two colliding interface names) so a
+	// wrong error class fails loudly instead.
+	if !strings.Contains(err.Error(), "tunnel endpoint id collision") {
+		t.Fatalf("want the tunnel-endpoint-ID collision error (validateTunnelEndpointIDCollisionAST) — the collision gate did not fire / was shadowed by a different gate (#5934); got: %v", err)
+	}
+	for _, name := range []string{`"wg0"`, `"wg34524.0"`} {
+		if !strings.Contains(err.Error(), name) {
+			t.Fatalf("collision error must name the colliding interface %s (the bare-ref hash of wg0 == wg34524.0); got: %v", name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Finding (from the #5932/#5829 review)

`TestTunnelEndpointIDOverflowOnlyUnitHashesBareRef` (`tunnelid_test.go`) asserted only `err != nil`, so it did not pin the failure to the tunnel-endpoint-ID collision gate (`validateTunnelEndpointIDCollisionAST`).

It is **non-vacuous today** — `CompileConfig` on the fixture returns `interfaces: tunnel endpoint id collision between "wg0" and "wg34524.0" (both fold to 17799) …`, and the collision gate (a pre-expansion pure-AST walk) runs **before** `compileSections`, so the #5829 fail-closed unit gate does not shadow it (verified firsthand). But an unpinned `err != nil` would pass **vacuously** if a future gate reorder made the collision gate stop firing and a different error surfaced first (e.g. the #5829 unit gate rejecting the overflow `unit 99999…`) — silently no longer exercising the collision path.

## Fix (test-only)

Tighten the assertion to require the specific collision error (the `"tunnel endpoint id collision"` gate signature **and** both colliding interface names `"wg0"`/`"wg34524.0"`), so a wrong error class fails loudly.

## Load-bearing demonstration (read-only `-overlay`, not committed)

Neutralizing `validateTunnelEndpointIDCollisionAST` to `return nil` lets the #5829 unit gate fire instead (`logical unit "99999…" must be an integer in 0..16385`). The **tightened** test REDs ("the collision gate did not fire / was shadowed by a different gate"), whereas the old `err != nil`-only assertion **passed** on that #5829 error — exactly the shadow scenario. So the pin genuinely guards the collision path.

**TEST-ONLY:** the diff touches only `pkg/config/tunnelid_test.go`; the collision gate itself is unchanged.

## Validation

`go test ./pkg/config/ -run TunnelEndpointID` green.

Closes #5934

🤖 Generated with [Claude Code](https://claude.com/claude-code)