### PR TITLE
cli: guard the filtered-clear rescan fallback against no progress (#5948)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -49024,3 +49024,26 @@ top.
     pkg/daemon/route_leak_snapshot_failclosed_5696_test.go,
     pkg/daemon/device_map_teardown_failclosed_5309_test.go,
     pkg/daemon/routing_rule_reconcile_failclosed_5844_test.go
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5948 harden clearFilteredV*Rescan with a no-progress guard
+    (#4886 follow-up, flagged as the optional note in the #5947 review). The
+    fresh-RESCAN fallback (pkg/cli/cli_clear.go, cursor-LESS dp only — test/edge,
+    unreachable in production since both dp types implement the cursor iterators)
+    re-collects matching keys from the top each round and relies on deletes
+    succeeding to shrink the set. A cursor-less dp whose DeleteSession
+    PERSISTENTLY errored (genuine, non-not-found) for >= batch matching keys would
+    re-collect the identical set forever (infinite loop). Fixed: cliClearBatchV*
+    .deleteAll now returns (deleted, removed) where removed = deleted + not-found
+    (forward keys no longer in the map); the rescan breaks with `if removed == 0`
+    on a non-empty chunk (all forward deletes genuinely failed) rather than
+    looping. removed (not deleted) is the progress metric so a concurrently-
+    drained (not-found = gone) chunk is still progress, not a false stall. The
+    cursor path is UNCHANGED (already unconditionally terminating; its call sites
+    ignore removed). Fail-on-revert: a cursor-less fake with persistently-failing
+    deletes + a round-cap backstop — remove the guard and the terminate test loops
+    past the cap (dp.exceeded → RED) rather than wedging the suite; positive
+    controls (succeeding deletes clear the full set; not-found is progress) stay
+    green.
+  - **File(s)**: pkg/cli/cli_clear.go,
+    pkg/cli/cli_clear_rescan_no_progress_5948_test.go, pkg/cli/README.md

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -161,7 +161,17 @@ presenter's rendered output is byte-identical:
   a multi-million-entry table). This mirrors the already-bounded gRPC
   `ClearSessions` (#5454); using the cursor (not a bare rescan) keeps a
   broad clear O(N), avoiding the O(N²) CPU-stall that would starve the HA
-  watchdog (#4719).
+  watchdog (#4719). The cursor path terminates unconditionally (the cursor
+  advances every round regardless of delete success). The fresh-rescan
+  fallback re-collects from the top each round, so it depends on deletes
+  actually removing keys to converge; a #5948 no-progress guard breaks the
+  loop if a non-empty chunk removed NOTHING (every forward delete genuinely
+  failed → the same set would be re-collected forever). A not-found key
+  counts as removed (it will not reappear), so a concurrently-drained chunk
+  is still progress, not a stall. This is defense-in-depth: production always
+  takes the cursor path (both `dataplane.Manager` and the userspace
+  `LegacyDataPlaneAdapter` implement the cursor iterators), so the rescan is
+  test/edge only.
 - `show` PAGER auto-disable (`dispatchWithPager`, #4886): the pager only
   engages when `os.Stdout` is a real terminal (`stdoutIsTerminal`, probed
   via TCGETS — `/dev/null` is a CharDevice so `os.ModeCharDevice` is

--- a/pkg/cli/cli_clear.go
+++ b/pkg/cli/cli_clear.go
@@ -301,16 +301,27 @@ func (b *cliClearBatchV4) collect(key dataplane.SessionKey, val dataplane.Sessio
 	return len(b.fwd) >= cliClearFilteredBatch
 }
 
-func (b *cliClearBatchV4) deleteAll(c *CLI, agg *sessionClearErrors) int {
-	deleted := 0
+// deleteAll deletes this chunk's forward keys plus reverse/DNAT companions.
+// It returns deleted (forward keys this call actually removed, for the operator
+// "N cleared" tally) and removed (forward keys no longer in the map after this
+// call = deleted PLUS already-gone/not-found). removed drives the #5948
+// rescan no-progress guard: a fresh rescan only shrinks the match set for the
+// forward keys that are gone, so removed==0 on a non-empty chunk means the next
+// identical rescan would re-collect the same set. A not-found forward key IS
+// progress (it will not reappear), so it counts toward removed but not deleted.
+func (b *cliClearBatchV4) deleteAll(c *CLI, agg *sessionClearErrors) (deleted, removed int) {
 	for _, key := range b.fwd {
 		// addExceptNotFound (not add): the cursor path leaves the chunk anchor
 		// live and may re-collect it next round, so a benign already-gone
 		// forward key must not read as a failure — matching grpcapi #5454.
 		if err := c.dp.DeleteSession(key); err != nil {
 			agg.addExceptNotFound("v4 forward delete", err)
+			if dataplane.IsKeyNotFound(err) {
+				removed++ // already gone: not a delete, but still progress
+			}
 		} else {
 			deleted++
+			removed++
 		}
 	}
 	for _, key := range b.rev {
@@ -319,7 +330,7 @@ func (b *cliClearBatchV4) deleteAll(c *CLI, agg *sessionClearErrors) int {
 	for _, dk := range b.dnat {
 		agg.addExceptNotFound("v4 DNAT companion delete", c.dp.DeleteDNATEntry(dk))
 	}
-	return deleted
+	return deleted, removed
 }
 
 // clearFilteredV4Bounded deletes every matching v4 session (plus companions)
@@ -352,12 +363,17 @@ func clearFilteredV4Bounded(c *CLI, f *sessionFilter, agg *sessionClearErrors) i
 			cliClearBatchObserver(len(cur.fwd))
 		}
 		if prevValid {
-			deleted += prev.deleteAll(c, agg)
+			// Cursor path terminates unconditionally (the cursor advances every
+			// round regardless of delete success), so the removed count is unused
+			// here — only the fresh-rescan fallback needs the no-progress guard.
+			d, _ := prev.deleteAll(c, agg)
+			deleted += d
 			prevValid = false
 		}
 		full := len(cur.fwd) >= cliClearFilteredBatch && iterErr == nil
 		if !full {
-			deleted += cur.deleteAll(c, agg)
+			d, _ := cur.deleteAll(c, agg)
+			deleted += d
 			return deleted
 		}
 		anchor := cur.fwd[len(cur.fwd)-1]
@@ -369,8 +385,13 @@ func clearFilteredV4Bounded(c *CLI, f *sessionFilter, agg *sessionClearErrors) i
 
 // clearFilteredV4Rescan is the bounded fallback for a cursor-less dataplane
 // (test/edge): collect up to cliClearFilteredBatch keys via a fresh iterate,
-// delete them, rescan — every collected key is deleted so a fresh scan returns
-// the next chunk, converging while holding only O(chunk) keys (#4886).
+// delete them, rescan — a deleted (or already-gone) key does not reappear, so a
+// fresh scan returns the next chunk, converging while holding only O(chunk) keys
+// (#4886). Progress depends on deletes actually removing keys, so a #5948
+// no-progress guard breaks the loop if a non-empty chunk removed nothing (every
+// forward delete genuinely failed → the same set would be re-collected forever).
+// The production cursor path (clearFilteredV4Bounded) does not need this — its
+// cursor advances every round regardless of delete success.
 func clearFilteredV4Rescan(c *CLI, f *sessionFilter, agg *sessionClearErrors) int {
 	deleted := 0
 	var b cliClearBatchV4
@@ -392,7 +413,19 @@ func clearFilteredV4Rescan(c *CLI, f *sessionFilter, agg *sessionClearErrors) in
 		if len(b.fwd) == 0 {
 			return deleted
 		}
-		deleted += b.deleteAll(c, agg)
+		d, removed := b.deleteAll(c, agg)
+		deleted += d
+		// #5948 no-progress guard. Unlike the cursor path, this fallback re-scans
+		// from the top each round and relies on the just-processed keys being GONE
+		// so the next scan returns a smaller set. If removed==0 — every forward key
+		// in this non-empty chunk failed to delete with a GENUINE (non-not-found)
+		// error, so all remain in the map — the next identical rescan would
+		// re-collect the same set forever. Stop with the aggregated delete errors
+		// already recorded rather than loop. A not-found key counts as removed (it
+		// will not reappear), so a concurrently-drained chunk still makes progress.
+		if removed == 0 {
+			return deleted
+		}
 		if len(b.fwd) < cliClearFilteredBatch || iterErr != nil {
 			return deleted
 		}
@@ -419,13 +452,18 @@ func (b *cliClearBatchV6) collect(key dataplane.SessionKeyV6, val dataplane.Sess
 	return len(b.fwd) >= cliClearFilteredBatch
 }
 
-func (b *cliClearBatchV6) deleteAll(c *CLI, agg *sessionClearErrors) int {
-	deleted := 0
+// deleteAll is the IPv6 analogue of cliClearBatchV4.deleteAll, returning the
+// same (deleted, removed) pair for the #5948 rescan no-progress guard.
+func (b *cliClearBatchV6) deleteAll(c *CLI, agg *sessionClearErrors) (deleted, removed int) {
 	for _, key := range b.fwd {
 		if err := c.dp.DeleteSessionV6(key); err != nil {
 			agg.addExceptNotFound("v6 forward delete", err)
+			if dataplane.IsKeyNotFound(err) {
+				removed++ // already gone: not a delete, but still progress
+			}
 		} else {
 			deleted++
+			removed++
 		}
 	}
 	for _, key := range b.rev {
@@ -434,7 +472,7 @@ func (b *cliClearBatchV6) deleteAll(c *CLI, agg *sessionClearErrors) int {
 	for _, dk := range b.dnat {
 		agg.addExceptNotFound("v6 DNAT companion delete", c.dp.DeleteDNATEntryV6(dk))
 	}
-	return deleted
+	return deleted, removed
 }
 
 func clearFilteredV6Bounded(c *CLI, f *sessionFilter, agg *sessionClearErrors) int {
@@ -463,12 +501,16 @@ func clearFilteredV6Bounded(c *CLI, f *sessionFilter, agg *sessionClearErrors) i
 			cliClearBatchObserver(len(cur.fwd))
 		}
 		if prevValid {
-			deleted += prev.deleteAll(c, agg)
+			// Cursor path terminates unconditionally; the removed count is unused
+			// here (only the fresh-rescan fallback needs the no-progress guard).
+			d, _ := prev.deleteAll(c, agg)
+			deleted += d
 			prevValid = false
 		}
 		full := len(cur.fwd) >= cliClearFilteredBatch && iterErr == nil
 		if !full {
-			deleted += cur.deleteAll(c, agg)
+			d, _ := cur.deleteAll(c, agg)
+			deleted += d
 			return deleted
 		}
 		anchor := cur.fwd[len(cur.fwd)-1]
@@ -499,7 +541,14 @@ func clearFilteredV6Rescan(c *CLI, f *sessionFilter, agg *sessionClearErrors) in
 		if len(b.fwd) == 0 {
 			return deleted
 		}
-		deleted += b.deleteAll(c, agg)
+		d, removed := b.deleteAll(c, agg)
+		deleted += d
+		// #5948 no-progress guard (see clearFilteredV4Rescan): a non-empty chunk
+		// that removed nothing (all forward deletes genuinely failed → keys remain)
+		// would be re-collected identically forever; stop with the errors recorded.
+		if removed == 0 {
+			return deleted
+		}
 		if len(b.fwd) < cliClearFilteredBatch || iterErr != nil {
 			return deleted
 		}

--- a/pkg/cli/cli_clear_rescan_no_progress_5948_test.go
+++ b/pkg/cli/cli_clear_rescan_no_progress_5948_test.go
@@ -1,0 +1,269 @@
+package cli
+
+// #5948: the fresh-RESCAN fallback of the bounded filtered clear
+// (clearFilteredV*Rescan, used ONLY by a cursor-LESS dataplane) re-collects
+// matching keys from the top each round and relies on the just-processed keys
+// being GONE so the next scan returns a smaller set. If a cursor-less dp's
+// DeleteSession PERSISTENTLY errored (genuine, non-not-found) for >= batch
+// matching keys, the identical set would be re-collected forever — an infinite
+// loop. (The production cursor path cannot reach this: its cursor advances every
+// round regardless of delete success, and both production dp types implement the
+// cursor iterators, so the rescan is test/edge only.)
+//
+// The fix adds a no-progress guard: a non-empty chunk that REMOVED nothing
+// (deleteAll's removed==0 — every forward delete genuinely failed, so all keys
+// remain) breaks the loop with the aggregated errors already recorded. A
+// not-found key counts as removed (it will not reappear), so a concurrently-
+// drained chunk still makes progress and is not mistaken for a stall.
+//
+// FAIL-ON-REVERT: remove the `if removed == 0 { return deleted }` guard and
+// TestClearRescanNoProgressTerminates_5948 loops past the fake's round cap
+// (dp.exceeded → RED) instead of terminating after one round. The round cap
+// makes a regression fail deterministically rather than wedge the suite.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// cursorlessClearDP implements cliRuntime WITHOUT the cursor iterators
+// (IterateSessionsFrom/V6From), so the bounded filtered clear takes the
+// fresh-RESCAN fallback (clearFilteredV*Rescan), not the production cursor path.
+// It does NOT embed *dataplane.Manager precisely so those cursor methods are
+// absent (embedding would promote them and satisfy cliSessionCursor). A round
+// cap turns a regression's infinite loop into a deterministic failure: once
+// rounds exceeds maxRounds, IterateSessions yields nothing so the loop
+// terminates and the test asserts on dp.exceeded rather than hanging.
+type cursorlessClearDP struct {
+	keys      []dataplane.SessionKey // matching v4 forward keys
+	deleted   map[dataplane.SessionKey]bool
+	delErr    error // non-nil: DeleteSession genuinely fails and does NOT remove the key
+	notFound  bool  // DeleteSession reports not-found BUT the key is gone (concurrent drain)
+	rounds    int
+	maxRounds int
+	exceeded  bool
+	delCalls  int
+}
+
+func (d *cursorlessClearDP) IsLoaded() bool { return true }
+
+func (d *cursorlessClearDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	d.rounds++
+	if d.rounds > d.maxRounds {
+		// Regression backstop: a missing no-progress guard would call this
+		// forever. Yield nothing so the loop terminates via len==0; the test
+		// asserts !exceeded.
+		d.exceeded = true
+		return nil
+	}
+	for _, k := range d.keys {
+		if d.deleted[k] {
+			continue
+		}
+		if !fn(k, dataplane.SessionValue{}) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *cursorlessClearDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *cursorlessClearDP) DeleteSession(key dataplane.SessionKey) error {
+	d.delCalls++
+	switch {
+	case d.notFound:
+		d.deleted[key] = true // it IS gone (another actor removed it) — progress...
+		return ebpf.ErrKeyNotExist
+	case d.delErr != nil:
+		return d.delErr // genuine failure: key remains in the map
+	default:
+		d.deleted[key] = true
+		return nil
+	}
+}
+
+func (d *cursorlessClearDP) DeleteSessionV6(dataplane.SessionKeyV6) error { return nil }
+func (d *cursorlessClearDP) DeleteDNATEntry(dataplane.DNATKey) error      { return nil }
+func (d *cursorlessClearDP) DeleteDNATEntryV6(dataplane.DNATKeyV6) error  { return nil }
+
+// --- remaining cliRuntime surface: unused by the filtered-clear path, stubbed. ---
+func (d *cursorlessClearDP) Compile(*config.Config) (*dataplane.CompileResult, error) {
+	return nil, nil
+}
+func (d *cursorlessClearDP) ReadGlobalCounter(uint32) (uint64, error) { return 0, nil }
+func (d *cursorlessClearDP) ReadInterfaceCounters(int) (dataplane.InterfaceCounterValue, error) {
+	return dataplane.InterfaceCounterValue{}, nil
+}
+func (d *cursorlessClearDP) ReadZoneCounters(uint16, int) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, nil
+}
+func (d *cursorlessClearDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, nil
+}
+func (d *cursorlessClearDP) ReadFilterConfig(uint32) (dataplane.FilterConfig, error) {
+	return dataplane.FilterConfig{}, nil
+}
+func (d *cursorlessClearDP) ReadFilterCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, nil
+}
+func (d *cursorlessClearDP) ReadFloodCounters(uint16) (dataplane.FloodState, error) {
+	return dataplane.FloodState{}, nil
+}
+func (d *cursorlessClearDP) ReadNATPortCounter(uint32) (uint64, error) { return 0, nil }
+func (d *cursorlessClearDP) ReadNATRuleCounter(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, nil
+}
+func (d *cursorlessClearDP) SessionCount() (int, int)            { return len(d.keys), 0 }
+func (d *cursorlessClearDP) ClearAllCounters() error             { return nil }
+func (d *cursorlessClearDP) ClearAllSessions() (int, int, error) { return 0, 0, nil }
+func (d *cursorlessClearDP) ClearFilterCounters() error          { return nil }
+func (d *cursorlessClearDP) ClearNATRuleCounters() error         { return nil }
+func (d *cursorlessClearDP) ClearPolicyCounters() error          { return nil }
+func (d *cursorlessClearDP) GetMapStats() []dataplane.MapStats   { return nil }
+func (d *cursorlessClearDP) GetPersistentNAT() *dataplane.PersistentNATTable {
+	return nil
+}
+
+// compile-time: the fake really is a cliRuntime.
+var _ cliRuntime = (*cursorlessClearDP)(nil)
+
+func makeTCPKeys(n int) []dataplane.SessionKey {
+	keys := make([]dataplane.SessionKey, n)
+	for i := range keys {
+		keys[i] = dataplane.SessionKey{Protocol: 6, SrcPort: uint16(1000 + i)}
+	}
+	return keys
+}
+
+func withBatch(t *testing.T, n int) {
+	t.Helper()
+	orig := cliClearFilteredBatch
+	t.Cleanup(func() { cliClearFilteredBatch = orig })
+	cliClearFilteredBatch = n
+}
+
+// assertRescanPath fails if dp would take the cursor path instead of the rescan
+// fallback — the test is meaningless unless the rescan runs.
+func assertRescanPath(t *testing.T, dp cliRuntime) {
+	t.Helper()
+	if _, ok := dp.(cliSessionCursor); ok {
+		t.Fatal("fake satisfies cliSessionCursor; the clear would take the cursor path, not the rescan under test")
+	}
+}
+
+// TestClearRescanNoProgressTerminates_5948 is the core assertion: a cursor-less
+// dp whose DeleteSession PERSISTENTLY fails must make the filtered clear
+// TERMINATE (no infinite re-collect), surfacing the delete failures.
+func TestClearRescanNoProgressTerminates_5948(t *testing.T) {
+	withBatch(t, 4)
+	dp := &cursorlessClearDP{
+		keys:      makeTCPKeys(8), // > batch → the pre-fix loop would re-collect forever
+		deleted:   map[dataplane.SessionKey]bool{},
+		delErr:    errors.New("injected persistent EIO"),
+		maxRounds: 100, // regression backstop; the guard stops after round 1
+	}
+	assertRescanPath(t, dp)
+
+	c := newClearCLI(t, dp)
+	var out string
+	done := make(chan struct{})
+	go func() {
+		out = captureStdout(t, func() {
+			if err := c.handleClearSecurity([]string{"flow", "session", "protocol", "tcp"}); err != nil {
+				t.Errorf("handleClearSecurity: %v", err)
+			}
+		})
+		close(done)
+	}()
+	<-done // the round cap guarantees this returns even on a regression
+
+	if dp.exceeded {
+		t.Fatalf("rescan looped past the round cap (%d rounds) without progress — the no-progress guard is missing; in production (a cursor-less dp) this is an infinite loop", dp.maxRounds)
+	}
+	// The guard stops after the first non-empty, zero-removed round.
+	if dp.rounds != 1 {
+		t.Errorf("expected exactly 1 rescan round before the no-progress break, got %d", dp.rounds)
+	}
+	// The persistent delete failures are surfaced, not swallowed.
+	if !strings.Contains(out, "WARNING") || !strings.Contains(out, "forward delete") {
+		t.Errorf("persistent delete failure not surfaced:\n%s", out)
+	}
+}
+
+// TestClearRescanSucceedingClearsAll_5948 is the positive control: a cursor-less
+// dp whose deletes SUCCEED still clears the entire matched set over multiple
+// bounded rounds (normal progress unchanged by the guard).
+func TestClearRescanSucceedingClearsAll_5948(t *testing.T) {
+	withBatch(t, 4)
+	const n = 10
+	dp := &cursorlessClearDP{
+		keys:      makeTCPKeys(n),
+		deleted:   map[dataplane.SessionKey]bool{},
+		maxRounds: 100,
+	}
+	assertRescanPath(t, dp)
+
+	c := newClearCLI(t, dp)
+	out := captureStdout(t, func() {
+		if err := c.handleClearSecurity([]string{"flow", "session", "protocol", "tcp"}); err != nil {
+			t.Errorf("handleClearSecurity: %v", err)
+		}
+	})
+
+	if dp.exceeded {
+		t.Fatalf("succeeding-delete rescan looped past the round cap — should converge in ~n/batch rounds")
+	}
+	if got := len(dp.deleted); got != n {
+		t.Fatalf("cleared %d of %d matching sessions, want all %d (bounded rescan must clear the full set)", got, n, n)
+	}
+	if strings.Contains(out, "WARNING") {
+		t.Errorf("a clean rescan emitted a spurious WARNING:\n%s", out)
+	}
+}
+
+// TestClearRescanNotFoundIsProgress_5948 proves the guard uses REMOVED (deleted
+// OR not-found), not just successful deletes: a chunk whose keys were
+// concurrently drained (DeleteSession reports not-found but the keys are gone)
+// MUST be treated as progress, so the loop continues and clears the rest instead
+// of breaking early. A `deleted==0` guard would wrongly stop after round 1 and
+// leave the remaining matching keys uncleared.
+func TestClearRescanNotFoundIsProgress_5948(t *testing.T) {
+	withBatch(t, 4)
+	const n = 10
+	dp := &cursorlessClearDP{
+		keys:      makeTCPKeys(n),
+		deleted:   map[dataplane.SessionKey]bool{},
+		notFound:  true, // every delete is a benign not-found, but the key IS gone
+		maxRounds: 100,
+	}
+	assertRescanPath(t, dp)
+
+	c := newClearCLI(t, dp)
+	out := captureStdout(t, func() {
+		if err := c.handleClearSecurity([]string{"flow", "session", "protocol", "tcp"}); err != nil {
+			t.Errorf("handleClearSecurity: %v", err)
+		}
+	})
+
+	if dp.exceeded {
+		t.Fatal("not-found rescan looped past the round cap")
+	}
+	// Every matching key must have been visited/drained across the whole set —
+	// the guard must NOT break early on a not-found (== gone) chunk.
+	if got := len(dp.deleted); got != n {
+		t.Fatalf("only %d of %d matching keys drained; the no-progress guard broke early on a not-found chunk (treated not-found as no-progress)", got, n)
+	}
+	// not-found is benign: no failure WARNING.
+	if strings.Contains(out, "WARNING") {
+		t.Errorf("not-found (benign) rescan emitted a spurious WARNING:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5948 — the rescan-fallback no-progress hardening flagged as the
optional note in the independent review of PR #5947 (#4886).

The bounded filtered session clear (`clearFilteredSessions`) has two paths:

- **Cursor path** (`clearFilteredV*Bounded`, production) — terminates
  unconditionally: `IterateSessionsFrom` resumes EXCLUSIVE, so the cursor
  advances every round regardless of delete outcome.
- **Fresh-rescan fallback** (`clearFilteredV*Rescan`) — used **only** by a
  cursor-less dataplane. Both production dp types (`dataplane.Manager` and the
  userspace `LegacyDataPlaneAdapter`) implement the cursor iterators, so the
  rescan is **test/edge only**.

The rescan re-collects matching keys from the top each round and relies on the
just-processed keys being gone so the next scan returns a smaller set. If a
cursor-less dp's `DeleteSession` persistently returned a **genuine
(non-not-found)** error for ≥ batch matching keys, the identical set would be
re-collected **forever** — an infinite loop.

## Fix

`deleteAll` now returns `(deleted, removed)`:
- `deleted` — successful forward deletes, for the operator "N cleared" line
  (unchanged semantics);
- `removed` — forward keys **no longer in the map** after the call = `deleted`
  **plus** already-gone / not-found.

The rescan breaks with `if removed == 0` on a non-empty chunk (every forward
delete genuinely failed → all keys remain), surfacing the aggregated errors
instead of looping. Using `removed` rather than `deleted` is deliberate: a
**not-found** key counts as progress (it will not reappear), so a
concurrently-drained chunk is not mistaken for a stall and the remaining
matching keys are still cleared.

The **cursor path is unchanged** (it does not need the guard; its two
`deleteAll` call sites ignore `removed`).

## Tests (fail-on-revert)

`cli_clear_rescan_no_progress_5948_test.go` uses a **cursor-less** fake
(implements `cliRuntime` WITHOUT the cursor iterators — not embedding
`*dataplane.Manager`, which would promote them — so the rescan actually runs;
asserted via `assertRescanPath`):

- **persistent-failure → terminates** with the failures surfaced (a round-cap
  in the fake turns a regression's infinite loop into a **deterministic**
  failure, `dp.exceeded`, rather than wedging the suite);
- **succeeding deletes** still clear the full matched set (normal progress
  unchanged);
- **not-found (concurrently drained)** makes progress and clears all — proving
  the guard does not false-trigger on not-found.

**Fail-on-revert** (verified via `-overlay`): removing `if removed == 0 { return
deleted }` makes the terminate test loop past the round cap (`dp.exceeded` →
RED); the positive controls stay green.

## Validation

`go build ./...`, `go vet ./pkg/cli`, `go test -race ./pkg/cli` all green;
gofmt clean. `pkg/cli/README.md` bounded-clear section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
