### PR TITLE
cluster: fail closed on oversized DHCP lease-sync field

### DIFF
--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -423,7 +423,16 @@ mechanism (PATH C of `docs/research/2239-dhcp-ha-lease-sync/plan.md`):
   legacy set so a peer that predates the feature hits the `default` receive
   case and ignores them — no `CurrentHAProtocolVersion` bump (the change is
   additive AND config-knob-gated, so bumping would falsely block session sync
-  across a mixed-base pair).
+  across a mixed-base pair). Each per-lease string field (address, hwaddr,
+  clientid, DUID, leasetype, hostname) is `uint16`-length-prefixed, so the
+  writer FAILS CLOSED on a field longer than 65535 bytes: `putLeaseString` /
+  `encodeOneLease` return an error rather than let `uint16(len)` silently narrow
+  and misframe the peer's decode, and `encodeDHCPLeasePayload` DROPS that one
+  lease (with a warning; the count stays consistent) so the surviving leases
+  still round-trip — a >64 KiB field is defensive-only, real DHCP identifiers
+  are far below it (#4892). The wire format is unchanged; the decoder
+  (`getLeaseString`) is untouched — the writer just never emits an oversized
+  field.
 - **Clock invariant** — each lease carries REMAINING LIFETIME, never an
   absolute wall-clock expiry (the channel only syncs a MONOTONIC offset). The
   promoting node re-anchors to its LOCAL clock at seed (`expire = now + remaining`),

--- a/pkg/cluster/lease_sync_wire_test.go
+++ b/pkg/cluster/lease_sync_wire_test.go
@@ -2,12 +2,98 @@ package cluster
 
 import (
 	"encoding/binary"
+	"math"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/psaab/xpf/pkg/dhcpserver"
 )
+
+// TestDHCPLeaseEncode_OversizedFieldFailsClosed is the #4892 regression. The
+// lease-sync wire prefixes each string with a uint16 length; a field longer than
+// math.MaxUint16 (65535) bytes would silently narrow the prefix (uint16(len)
+// wraps) and the peer would misframe the record — reading the wrapped low-16
+// length and then the string's trailing bytes as later fields, corrupting the
+// lease identity/type/prefix-length/hostname on the standby.
+//
+// The fix bounds the writer: encodeOneLease REJECTS an oversized lease (returns
+// an error) rather than emitting a misframed record, and encodeDHCPLeasePayload
+// DROPS it from the push (count stays consistent) so the surviving leases still
+// round-trip byte-identical.
+//
+// FAIL-ON-REVERT: restoring `uint16(len(s))` narrowing in putLeaseString removes
+// the error, so (1) encodeOneLease returns nil error on the oversized lease and
+// this test's err==nil check fails, and (2) the oversized record is emitted
+// misframed, so the payload decodes 3 leases (the middle one corrupted) instead
+// of the 2 clean survivors — both assertions go RED.
+func TestDHCPLeaseEncode_OversizedFieldFailsClosed(t *testing.T) {
+	oversize := math.MaxUint16 + 1 // 65536: first length that overflows the uint16 prefix.
+
+	// Each variable-length field must independently fail closed — the error is
+	// threaded at every putLeaseString site in encodeOneLease.
+	cases := []struct {
+		field string
+		set   func(*dhcpserver.SyncLease)
+	}{
+		{"Address", func(l *dhcpserver.SyncLease) { l.Address = strings.Repeat("a", oversize) }},
+		{"HWAddress", func(l *dhcpserver.SyncLease) { l.HWAddress = strings.Repeat("b", oversize) }},
+		{"ClientID", func(l *dhcpserver.SyncLease) { l.ClientID = strings.Repeat("c", oversize) }},
+		{"DUID", func(l *dhcpserver.SyncLease) { l.DUID = strings.Repeat("d", oversize) }},
+		{"LeaseType", func(l *dhcpserver.SyncLease) { l.LeaseType = strings.Repeat("e", oversize) }},
+		{"Hostname", func(l *dhcpserver.SyncLease) { l.Hostname = strings.Repeat("f", oversize) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			l := dhcpserver.SyncLease{Family: 4, Address: "10.0.0.1", SubnetID: 1}
+			tc.set(&l)
+			if _, err := encodeOneLease(l); err == nil {
+				t.Fatalf("encodeOneLease with an oversized %s did not fail closed; "+
+					"the uint16 prefix silently narrowed and the record is misframed", tc.field)
+			}
+		})
+	}
+
+	// Boundary: exactly math.MaxUint16 bytes still fits the prefix and must encode.
+	atLimit := dhcpserver.SyncLease{Family: 4, Address: "10.0.0.2", SubnetID: 1,
+		Hostname: strings.Repeat("h", math.MaxUint16)}
+	if _, err := encodeOneLease(atLimit); err != nil {
+		t.Fatalf("encodeOneLease rejected a field of exactly %d bytes (must fit the uint16 prefix): %v",
+			math.MaxUint16, err)
+	}
+
+	// Payload-level: an oversized lease is DROPPED, the clean leases survive
+	// byte-identical, and the count reflects only what was emitted.
+	normal1 := dhcpserver.SyncLease{
+		Family: 4, Address: "10.0.61.7", SubnetID: 1,
+		HWAddress: "aa:bb:cc:dd:ee:07", ClientID: "01:aa:bb:cc:dd:ee:07",
+		ValidLife: 3600, Remaining: 3000, Hostname: "host-1", FQDNFwd: true,
+	}
+	oversized := dhcpserver.SyncLease{
+		Family: 6, Address: "2001:db8::dead", SubnetID: 2,
+		DUID: "00:01:00:03", IAID: 9, LeaseType: "IA_NA",
+		ValidLife: 7200, Remaining: 6000, Hostname: strings.Repeat("x", oversize),
+	}
+	normal2 := dhcpserver.SyncLease{
+		Family: 6, Address: "2001:db8::beef", SubnetID: 2,
+		DUID: "00:01:00:04", IAID: 11, LeaseType: "IA_PD", PrefixLen: 56,
+		ValidLife: 7200, Remaining: 6000, Hostname: "host-2", FQDNRev: true,
+	}
+	payload := encodeDHCPLeasePayload([]dhcpserver.SyncLease{normal1, oversized, normal2})
+	out := decodeDHCPLeasePayload(payload)
+	if len(out) != 2 {
+		t.Fatalf("payload decoded %d leases, want 2 (the oversized lease must be dropped, "+
+			"not emitted misframed): %+v", len(out), out)
+	}
+	if !reflect.DeepEqual(out[0], normal1) {
+		t.Errorf("first surviving lease not byte-identical:\n got=%+v\nwant=%+v", out[0], normal1)
+	}
+	if !reflect.DeepEqual(out[1], normal2) {
+		t.Errorf("second surviving lease not byte-identical (a misframed oversized record "+
+			"would surface here):\n got=%+v\nwant=%+v", out[1], normal2)
+	}
+}
 
 // Test: the #2239 DHCP-lease wire codec round-trips a mixed v4/v6 set,
 // including a PD lease and the FQDN flags.
@@ -61,7 +147,10 @@ func TestDHCPLeasePayload_LengthGated(t *testing.T) {
 		HWAddress: "aa", ValidLife: 100, Remaining: 50, State: 0,
 		Hostname: "h", FQDNFwd: true,
 	}
-	rec := encodeOneLease(l)
+	rec, err := encodeOneLease(l)
+	if err != nil {
+		t.Fatalf("encodeOneLease: %v", err)
+	}
 
 	// Newer peer: append 8 bytes of an unknown future field.
 	newer := append(append([]byte{}, rec...), 1, 2, 3, 4, 5, 6, 7, 8)

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -3,6 +3,9 @@ package cluster
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"math"
 	"net"
 	"strings"
 	"time"
@@ -656,10 +659,22 @@ func decodeConfigPayload(payload []byte) (configText string, gen uint64) {
 // carries REMAINING LIFETIME (not absolute expiry) so the receiver re-anchors
 // to its local clock at seed (the #2239 clock invariant).
 
-// putLeaseString appends a uint16-length-prefixed string.
-func putLeaseString(b []byte, s string) []byte {
+// putLeaseString appends a uint16-length-prefixed string. It FAILS CLOSED when
+// s exceeds the uint16 wire prefix (math.MaxUint16 = 65535 bytes): the prefix
+// would otherwise silently narrow (uint16(len(s)) wraps to the low 16 bits) and
+// the peer's getLeaseString would read a truncated string, then misread the
+// record's trailing bytes as later fields — a cross-node lease-sync misframe
+// that corrupts the lease's identity/type/prefix-length/hostname on the standby
+// (#4892). The wire format is unchanged (getLeaseString still trusts the uint16
+// prefix); the writer simply never emits an oversized field — the encoder
+// rejects the whole lease instead. Real DHCP identifiers/DUIDs/hostnames are far
+// below 64 KiB, so this is defensive validation, not an expected path.
+func putLeaseString(b []byte, s string) ([]byte, error) {
+	if len(s) > math.MaxUint16 {
+		return nil, fmt.Errorf("lease-sync string field length %d exceeds uint16 wire limit %d", len(s), math.MaxUint16)
+	}
 	b = binary.LittleEndian.AppendUint16(b, uint16(len(s)))
-	return append(b, s...)
+	return append(b, s...), nil
 }
 
 // getLeaseString reads a uint16-length-prefixed string at off, returning the
@@ -679,11 +694,17 @@ func getLeaseString(buf []byte, off int) (string, int, bool) {
 
 // encodeOneLease serializes one SyncLease into a self-describing record body
 // (without the outer record-length prefix). Field order is fixed and append-
-// only; decoders read what the record length covers.
-func encodeOneLease(l dhcpserver.SyncLease) []byte {
+// only; decoders read what the record length covers. It returns an error when
+// any variable-length field exceeds the uint16 wire prefix (#4892): the lease is
+// rejected from the sync push rather than emitted misframed. err names the field
+// so the caller's warning is actionable.
+func encodeOneLease(l dhcpserver.SyncLease) ([]byte, error) {
 	b := make([]byte, 0, 96)
 	b = append(b, byte(l.Family))
-	b = putLeaseString(b, l.Address)
+	var err error
+	if b, err = putLeaseString(b, l.Address); err != nil {
+		return nil, fmt.Errorf("encode lease Address: %w", err)
+	}
 	b = binary.LittleEndian.AppendUint32(b, uint32(l.SubnetID))
 	b = binary.LittleEndian.AppendUint32(b, uint32(l.ValidLife))
 	b = binary.LittleEndian.AppendUint32(b, uint32(l.Remaining))
@@ -691,13 +712,23 @@ func encodeOneLease(l dhcpserver.SyncLease) []byte {
 	// identity + naming (variable). v4: hwaddr, clientid. v6: duid, iaid,
 	// leasetype, prefixlen. Both families carry all slots; the unused ones
 	// are empty/zero so the record layout is family-uniform and append-only.
-	b = putLeaseString(b, l.HWAddress)
-	b = putLeaseString(b, l.ClientID)
-	b = putLeaseString(b, l.DUID)
+	if b, err = putLeaseString(b, l.HWAddress); err != nil {
+		return nil, fmt.Errorf("encode lease HWAddress: %w", err)
+	}
+	if b, err = putLeaseString(b, l.ClientID); err != nil {
+		return nil, fmt.Errorf("encode lease ClientID: %w", err)
+	}
+	if b, err = putLeaseString(b, l.DUID); err != nil {
+		return nil, fmt.Errorf("encode lease DUID: %w", err)
+	}
 	b = binary.LittleEndian.AppendUint32(b, l.IAID)
-	b = putLeaseString(b, l.LeaseType)
+	if b, err = putLeaseString(b, l.LeaseType); err != nil {
+		return nil, fmt.Errorf("encode lease LeaseType: %w", err)
+	}
 	b = binary.LittleEndian.AppendUint32(b, uint32(l.PrefixLen))
-	b = putLeaseString(b, l.Hostname)
+	if b, err = putLeaseString(b, l.Hostname); err != nil {
+		return nil, fmt.Errorf("encode lease Hostname: %w", err)
+	}
 	var flags byte
 	if l.FQDNFwd {
 		flags |= 0x01
@@ -706,7 +737,7 @@ func encodeOneLease(l dhcpserver.SyncLease) []byte {
 		flags |= 0x02
 	}
 	b = append(b, flags)
-	return b
+	return b, nil
 }
 
 // decodeOneLease parses a record body produced by encodeOneLease. It is
@@ -783,10 +814,25 @@ func decodeOneLease(buf []byte) dhcpserver.SyncLease {
 // zero count (a legitimate "I serve no leases" message, distinct from a legacy
 // peer that never sends this type at all).
 func encodeDHCPLeasePayload(leases []dhcpserver.SyncLease) []byte {
-	b := make([]byte, 0, 8+len(leases)*64)
-	b = binary.LittleEndian.AppendUint32(b, uint32(len(leases)))
+	// Encode records first so an oversized field (which encodeOneLease rejects,
+	// #4892) DROPS just that lease — fail-closed — while the count prefix stays
+	// consistent with the records actually emitted. Dropping one unencodable
+	// lease is strictly safer than either misframing the peer's decode or
+	// blocking the entire push; the standby simply lacks that one lease (the
+	// client re-DHCPs on takeover) instead of seeding a corrupted identity.
+	recs := make([][]byte, 0, len(leases))
 	for _, l := range leases {
-		rec := encodeOneLease(l)
+		rec, err := encodeOneLease(l)
+		if err != nil {
+			slog.Warn("cluster sync: dropping unencodable DHCP lease from sync push",
+				"family", l.Family, "address", l.Address, "err", err)
+			continue
+		}
+		recs = append(recs, rec)
+	}
+	b := make([]byte, 0, 8+len(recs)*64)
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(recs)))
+	for _, rec := range recs {
 		b = binary.LittleEndian.AppendUint32(b, uint32(len(rec)))
 		b = append(b, rec...)
 	}


### PR DESCRIPTION
## Problem
The HA DHCP lease-sync wire codec (`pkg/cluster/sync_protocol.go`) length-prefixes each string field with `uint16(len(s))` but appends the full string. A field longer than 65535 bytes silently narrows the prefix; the peer's `getLeaseString` reads the wrapped low-16 length and then misreads the record's trailing bytes as later fields, corrupting the lease's identity/type/prefix-length/hostname on the standby — a cross-node lease-sync misframe. Fields affected: `Address`, `HWAddress`, `ClientID`, `DUID`, `LeaseType`, `Hostname`.

## Fix (writer-side, fail-closed, NO wire change)
- `putLeaseString` and `encodeOneLease` now return an error when a field exceeds `math.MaxUint16` (65535). `err` names the field.
- `encodeDHCPLeasePayload` DROPS an unencodable lease with a warning and keeps the count prefix consistent with the records actually emitted — so the surviving leases still round-trip byte-identical. Dropping one lease is strictly safer than misframing the peer's decode or blocking the whole push (the client re-DHCPs on takeover).
- **Reader unchanged**: `getLeaseString` / `decodeOneLease` / `decodeDHCPLeasePayload` are untouched and the wire format is identical — the writer just never emits an oversized field. `encodeDHCPLeasePayload`'s signature is unchanged, so the sole caller (`sync.go` `QueueDHCPLeases`) is untouched.
- A >64 KiB DHCP identifier is unreachable from well-formed input; this is defensive validation that turns a silent wire misframe into a rejected lease.

## Test / fail-on-revert
`TestDHCPLeaseEncode_OversizedFieldFailsClosed`: asserts an oversized field is rejected at every `putLeaseString` site, that a 65535-byte field still encodes (boundary), and that an oversized lease is dropped from the payload while the clean leases round-trip. Restoring the `uint16(len(s))` narrowing makes all 6 field sub-cases report no error and the payload decode 3 leases (the middle one corrupted, hostname lost) instead of the 2 clean survivors — RED.

## Validation
- `go build ./...`, `go vet ./pkg/cluster/` clean
- `go test -race ./pkg/cluster/ ./pkg/dhcpserver/` green
- `pkg/cluster/README.md` #2239 lease-sync wire section updated to document the writer-side fail-closed bound.

Closes #4892

🤖 Generated with [Claude Code](https://claude.com/claude-code)