### PR TITLE
vrrp: accept 802.1ad (0x88a8) in the AF_PACKET cBPF prefilter (#5088)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -49094,3 +49094,23 @@ top.
     green.
   - **File(s)**: pkg/cli/cli_clear.go,
     pkg/cli/cli_clear_rescan_no_progress_5948_test.go, pkg/cli/README.md
+
+- **Timestamp**: 2026-07-15
+  - **Action**: #5088 VRRP AF_PACKET cBPF: accept 802.1ad (0x88a8) alongside
+    802.1Q (0x8100). The raw sock_filter prefilter (pkg/vrrp/manager.go) matched
+    ONLY 0x8100 as the outer VLAN ethertype and rejected 0x88a8, while the Go
+    receiver parser (instance.go:1426) accepts BOTH — so on an S-tagged / provider-
+    bridged segment the kernel dropped every VRRP advert before Go, both nodes went
+    mutually deaf, and could own the same VRID/VIPs (split-brain). Inserted a
+    `jeq 0x88a8 -> check_vlan` instruction after the 0x8100 check (a single S-tag
+    has the identical layout: real ethertype @16) and RECOMPUTED all downstream
+    relative jump offsets for the +1 shift (instr 1 Jt 7->8, instr 2 Jt 14->15,
+    instr 3 Jt 1->2; the check_vlan/ipv4/ipv6 arms' offsets are unchanged since
+    both their source and target shifted together). Extracted the array into
+    vrrpCBPFFilter() so a bpf.VM test runs the EXACT program. Double-tag QinQ left
+    out of scope (the parser doesn't decode it either; contract = untagged +
+    single-tag {0x8100,0x88a8}). Fail-on-revert proven via -overlay + bpf.VM
+    (neutralize the 0x88a8 accept -> 802.1ad v4/v6 VRRP REJECTED, tests RED;
+    0x8100/untagged/reject cases stay green).
+  - **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/cbpf_8021ad_5088_test.go,
+    pkg/vrrp/README.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -561,10 +561,26 @@ fallback (unlike the link-watcher). The `subscribeAddrs` seam defaults to
 ### AF_PACKET cBPF filter + IPv6 extension headers (#2155)
 
 The AF_PACKET receiver attaches a cBPF prefilter
-(`openAfPacketReceiver`, `manager.go`) so the kernel drops non-VRRP
-frames before they reach the per-instance RX goroutine. It handles
-untagged and 802.1Q-tagged IPv4/IPv6:
+(`vrrpCBPFFilter`, attached in `openAfPacketReceiver`, `manager.go`) so
+the kernel drops non-VRRP frames before they reach the per-instance RX
+goroutine. It handles untagged and **single-tag** IPv4/IPv6, admitting
+BOTH `0x8100` (802.1Q) and `0x88a8` (802.1ad / S-tag) as the outer VLAN
+ethertype (#5088):
 
+- **Kernel prefilter and userspace parser MUST admit the same
+  encapsulation set (#5088).** A single S-tag has the identical layout as
+  a C-tag (real ethertype at offset 16), and `parseAfPacket`
+  (`instance.go`) accepts both `0x8100` and `0x88a8`. Before #5088 the
+  cBPF matched only `0x8100`, so on an S-tagged / provider-bridged segment
+  the kernel dropped every advert before Go — both nodes went mutually
+  deaf and could own the same VRID/VIPs (split-brain) despite the parser's
+  advertised 802.1ad support. Adding the `0x88a8` instruction shifts the
+  raw cBPF's relative jump offsets, which were recomputed; the exact
+  program is exercised in a `bpf.VM` (`cbpf_8021ad_5088_test.go`) against
+  untagged / 802.1Q / 802.1ad / non-VRRP frames. **Double-tag QinQ**
+  (`0x88a8` then `0x8100`, real ethertype at offset 20) is deliberately
+  NOT admitted — the Go parser does not decode it either, so the shared
+  contract stays "untagged + single-tag {0x8100, 0x88a8}".
 - IPv4 matches base protocol `== 112`; `parseAfPacketIPv4` then
   re-walks IHL + re-checks TTL 255 in Go (so IPv4 options are tolerated).
 - IPv6 matches the base **Next-Header** against the set

--- a/pkg/vrrp/cbpf_8021ad_5088_test.go
+++ b/pkg/vrrp/cbpf_8021ad_5088_test.go
@@ -1,0 +1,134 @@
+package vrrp
+
+// #5088: the AF_PACKET SOCK_RAW cBPF prefilter (vrrpCBPFFilter) used to accept
+// only 0x8100 (802.1Q) as the outer VLAN ethertype and kernel-drop 0x88a8
+// (802.1ad), even though the Go receiver parser (instance.go) accepts BOTH. On
+// an S-tagged / provider-bridged segment the kernel dropped every VRRP advert
+// before Go saw it, so both nodes went mutually deaf and could own the same
+// VRID/VIPs (split-brain). The fix admits single-tag 0x88a8 (identical layout:
+// real ethertype @16) alongside 0x8100, recomputing every downstream relative
+// jump for the inserted instruction.
+//
+// This test ASSEMBLES the exact production filter (vrrpCBPFFilter) and RUNS it in
+// a bpf.VM against synthetic frames — it is a behavioral test of the running
+// program, not a construction/offset-shape check.
+//
+// FAIL-ON-REVERT: restore the 0x8100-only outer check (drop the 0x88a8
+// instruction / recompute back) and every "802.1ad ... PASS" case below REJECTS
+// (vm.Run returns 0) — RED.
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"golang.org/x/net/bpf"
+	"golang.org/x/sys/unix"
+)
+
+// runVRRPFilter assembles the production cBPF array and runs it against frame,
+// returning true if the filter ACCEPTS (non-zero return = bytes to keep).
+func runVRRPFilter(t *testing.T, frame []byte) bool {
+	t.Helper()
+	raw := vrrpCBPFFilter()
+	insns := make([]bpf.Instruction, len(raw))
+	for i, f := range raw {
+		insns[i] = bpf.RawInstruction{Op: f.Code, Jt: f.Jt, Jf: f.Jf, K: f.K}.Disassemble()
+	}
+	vm, err := bpf.NewVM(insns)
+	if err != nil {
+		t.Fatalf("assemble vrrpCBPFFilter: %v", err)
+	}
+	n, err := vm.Run(frame)
+	if err != nil {
+		t.Fatalf("run filter: %v", err)
+	}
+	return n > 0
+}
+
+// vrrpFrame builds a 60-byte L2 frame. outerEth is the ethertype at offset 12.
+// When innerEth != 0 the frame is single-tagged (TCI at 14, real ethertype at
+// 16). protoByte is written at protoOff (the IPv4 proto / IPv6 next-header slot
+// for the chosen encapsulation).
+func vrrpFrame(outerEth, innerEth uint16, protoOff int, protoByte byte) []byte {
+	f := make([]byte, 60) // >= any offset used; dst/src MACs left zero
+	binary.BigEndian.PutUint16(f[12:14], outerEth)
+	if innerEth != 0 {
+		binary.BigEndian.PutUint16(f[16:18], innerEth)
+	}
+	if protoOff > 0 {
+		f[protoOff] = protoByte
+	}
+	return f
+}
+
+const (
+	ethIPv4    = 0x0800
+	ethIPv6    = 0x86DD
+	ethARP     = 0x0806
+	eth8021Q   = 0x8100
+	eth8021ad  = 0x88a8
+	protoVRRP  = 112
+	protoTCP   = 6
+	nhHopByHop = 0 // an IPv6 ext-header that a chained VRRP advert may lead with
+)
+
+func TestVRRPCBPFFilter_Accepts8021adAnd8021Q_5088(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame []byte
+		want  bool
+	}{
+		// --- PASS: every encapsulation the Go parser accepts ---
+		{"ipv4 untagged VRRP", vrrpFrame(ethIPv4, 0, 23, protoVRRP), true},
+		{"ipv6 untagged VRRP", vrrpFrame(ethIPv6, 0, 20, protoVRRP), true},
+		{"ipv6 untagged VRRP hop-by-hop", vrrpFrame(ethIPv6, 0, 20, nhHopByHop), true},
+		{"ipv4 802.1Q VRRP", vrrpFrame(eth8021Q, ethIPv4, 27, protoVRRP), true},
+		{"ipv6 802.1Q VRRP", vrrpFrame(eth8021Q, ethIPv6, 24, protoVRRP), true},
+		// The #5088 fix: 802.1ad (S-tag) must now pass, matching the parser.
+		{"ipv4 802.1ad VRRP", vrrpFrame(eth8021ad, ethIPv4, 27, protoVRRP), true},
+		{"ipv6 802.1ad VRRP", vrrpFrame(eth8021ad, ethIPv6, 24, protoVRRP), true},
+
+		// --- REJECT: everything the parser would drop must stay kernel-dropped ---
+		{"ipv4 untagged TCP", vrrpFrame(ethIPv4, 0, 23, protoTCP), false},
+		{"ipv6 untagged TCP", vrrpFrame(ethIPv6, 0, 20, protoTCP), false},
+		{"arp", vrrpFrame(ethARP, 0, 0, 0), false},
+		{"ipv4 802.1ad TCP (right encap, wrong proto)", vrrpFrame(eth8021ad, ethIPv4, 27, protoTCP), false},
+		{"802.1ad inner ARP (non-IP)", vrrpFrame(eth8021ad, ethARP, 0, 0), false},
+		{"802.1Q inner ARP (non-IP)", vrrpFrame(eth8021Q, ethARP, 0, 0), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runVRRPFilter(t, tc.frame)
+			if got != tc.want {
+				verb := "REJECTED"
+				if got {
+					verb = "ACCEPTED"
+				}
+				t.Fatalf("filter %s %q; want accept=%v", verb, tc.name, tc.want)
+			}
+		})
+	}
+}
+
+// TestVRRPCBPFFilter_8021adIsTheRevertGuard_5088 isolates the exact #5088
+// assertion so a revert produces an unambiguous failure: a single-tag 802.1ad
+// VRRP advert (v4 and v6) MUST be accepted. Reverting to the 0x8100-only outer
+// check makes both REJECT.
+func TestVRRPCBPFFilter_8021adIsTheRevertGuard_5088(t *testing.T) {
+	if !runVRRPFilter(t, vrrpFrame(eth8021ad, ethIPv4, 27, protoVRRP)) {
+		t.Error("802.1ad IPv4 VRRP advert rejected by the cBPF prefilter — the kernel drops it before Go, VRRP is deaf on S-tagged segments (#5088)")
+	}
+	if !runVRRPFilter(t, vrrpFrame(eth8021ad, ethIPv6, 24, protoVRRP)) {
+		t.Error("802.1ad IPv6 VRRP advert rejected by the cBPF prefilter (#5088)")
+	}
+}
+
+// Guard against an accidental filter length/shape regression: the array must be
+// the 32-instruction program (0..31) the offset comments assume.
+func TestVRRPCBPFFilter_Length_5088(t *testing.T) {
+	if got := len(vrrpCBPFFilter()); got != 32 {
+		t.Fatalf("vrrpCBPFFilter has %d instructions, want 32 (0x88a8 insertion + recomputed offsets)", got)
+	}
+	// unix.SockFilter and bpf.RawInstruction must stay field-compatible.
+	var _ = unix.SockFilter{Code: 0, Jt: 0, Jf: 0, K: 0}
+}

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -1001,6 +1001,85 @@ func buildAfPacketMembership(ifIndex int) unix.PacketMreq {
 	}
 }
 
+// vrrpCBPFFilter returns the AF_PACKET SOCK_RAW cBPF prefilter that admits VRRP
+// adverts and kernel-drops everything else, cutting RX-goroutine wakeups on a
+// data-bearing RETH VLAN. SOCK_RAW includes the Ethernet header.
+// Protocol/next-header offsets:
+//
+//	IPv4 untagged:  ethertype 0x0800 @12, proto @23 (14+9)
+//	IPv6 untagged:  ethertype 0x86DD @12, next-hdr @20 (14+6)
+//	IPv4 single-tag: outer 0x8100/0x88a8 @12, real 0x0800 @16, proto @27 (18+9)
+//	IPv6 single-tag: outer 0x8100/0x88a8 @12, real 0x86DD @16, next-hdr @24 (18+6)
+//
+// #5088: the outer-VLAN check admits BOTH 802.1Q (0x8100) AND 802.1ad (0x88a8)
+// — a single S-tag has the identical layout (real ethertype @16), and the Go
+// receiver (parseAfPacket, instance.go) already accepts both. Before this the
+// prefilter matched only 0x8100, so on an S-tagged / provider-bridged segment
+// the kernel dropped every advert before Go saw it and BOTH nodes went mutually
+// deaf → split-brain despite the parser's advertised 802.1ad support. The kernel
+// prefilter and the userspace parser MUST admit the same encapsulation set.
+// DOUBLE-tag QinQ (0x88a8 then 0x8100, real ethertype @20) is deliberately NOT
+// admitted here because the Go parser does not decode it either (a single-tag
+// walk); the shared contract stays "untagged + single-tag {0x8100, 0x88a8}".
+//
+// IPv4 matches base proto == 112 (the IPv4 arm re-validates IHL + TTL in Go, so
+// it tolerates IPv4 options). IPv6 must additionally admit VRRP adverts carrying
+// IPv6 extension headers (#2155): the base Next-Header is then the FIRST
+// ext-header's type, not 112. A fixed-offset cBPF cannot walk an ext-header
+// chain, so the IPv6 arm matches the base Next-Header against the small set
+//
+//	{112 VRRP, 0 Hop-by-Hop, 43 Routing, 60 Dest-Opts}
+//
+// (approach A2). Fragment (44) and AH (51) are deliberately NOT admitted (VRRP
+// adverts are never fragmented or AH-wrapped). The authoritative ext-header walk
+// + proto-112 + hop-limit-255 + VRID validation happens in Go; the cBPF is only
+// an in-kernel volume reducer.
+//
+// Jump offsets (Jt/Jf) are relative to the NEXT instruction; they were recomputed
+// for the inserted 0x88a8 instruction (#5088). A bpf.VM test
+// (cbpf_8021ad_5088_test.go) runs this exact array against synthetic frames.
+func vrrpCBPFFilter() []unix.SockFilter {
+	return []unix.SockFilter{
+		{Code: 0x28, K: 12},                    //  0: ldh [12] — ethertype
+		{Code: 0x15, Jt: 8, Jf: 0, K: 0x0800},  //  1: jeq 0x0800 → 10 (check_ipv4)
+		{Code: 0x15, Jt: 15, Jf: 0, K: 0x86DD}, //  2: jeq 0x86DD → 18 (check_ipv6)
+		{Code: 0x15, Jt: 2, Jf: 0, K: 0x8100},  //  3: jeq 0x8100 → 6 (check_vlan)
+		{Code: 0x15, Jt: 1, Jf: 0, K: 0x88a8},  //  4: jeq 0x88a8 → 6 (check_vlan); else reject
+		{Code: 0x06, K: 0},                     //  5: ret reject
+		// check_vlan: single-tag (0x8100 or 0x88a8) → real ethertype @16
+		{Code: 0x28, K: 16},                    //  6: ldh [16] — real ethertype
+		{Code: 0x15, Jt: 6, Jf: 0, K: 0x0800},  //  7: jeq 0x0800 → 14 (check_ipv4_vlan)
+		{Code: 0x15, Jt: 16, Jf: 0, K: 0x86DD}, //  8: jeq 0x86DD → 25 (check_ipv6_vlan)
+		{Code: 0x06, K: 0},                     //  9: ret reject
+		// check_ipv4: proto at 14+9=23
+		{Code: 0x30, K: 23},                // 10: ldb [23]
+		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 11: jeq 112 → accept; else reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 12: ret accept
+		{Code: 0x06, K: 0},                 // 13: ret reject
+		// check_ipv4_vlan: proto at 18+9=27
+		{Code: 0x30, K: 27},                // 14: ldb [27]
+		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 15: jeq 112 → accept; else reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 16: ret accept
+		{Code: 0x06, K: 0},                 // 17: ret reject
+		// check_ipv6: base next-header at 14+6=20. Accept {112,0,43,60}.
+		{Code: 0x30, K: 20},                // 18: ldb [20]
+		{Code: 0x15, Jt: 4, Jf: 0, K: 112}, // 19: jeq 112 → 24 accept
+		{Code: 0x15, Jt: 3, Jf: 0, K: 0},   // 20: jeq 0   → 24 accept (Hop-by-Hop)
+		{Code: 0x15, Jt: 2, Jf: 0, K: 43},  // 21: jeq 43  → 24 accept (Routing)
+		{Code: 0x15, Jt: 1, Jf: 0, K: 60},  // 22: jeq 60  → 24 accept (Dest-Opts)
+		{Code: 0x06, K: 0},                 // 23: ret reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 24: ret accept
+		// check_ipv6_vlan: base next-header at 18+6=24. Same accept set.
+		{Code: 0x30, K: 24},                // 25: ldb [24]
+		{Code: 0x15, Jt: 4, Jf: 0, K: 112}, // 26: jeq 112 → 31 accept
+		{Code: 0x15, Jt: 3, Jf: 0, K: 0},   // 27: jeq 0   → 31 accept (Hop-by-Hop)
+		{Code: 0x15, Jt: 2, Jf: 0, K: 43},  // 28: jeq 43  → 31 accept (Routing)
+		{Code: 0x15, Jt: 1, Jf: 0, K: 60},  // 29: jeq 60  → 31 accept (Dest-Opts)
+		{Code: 0x06, K: 0},                 // 30: ret reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 31: ret accept
+	}
+}
+
 // openAfPacketReceiver opens an AF_PACKET SOCK_RAW socket bound to the
 // given interface for receiving VRRP packets. This is used on VLAN sub-
 // interfaces where raw IP sockets don't reliably receive multicast.
@@ -1068,72 +1147,10 @@ func openAfPacketReceiver(ifIndex int) (int, error) {
 		slog.Debug("vrrp: failed to set allmulti", "err", err)
 	}
 
-	// BPF filter: accept VRRP for IPv4, IPv6, and 802.1Q-tagged variants.
-	// SOCK_RAW includes the Ethernet header. Protocol/next-header offsets:
-	//   IPv4 untagged:  ethertype 0x0800 @12, proto @23 (14+9)
-	//   IPv6 untagged:  ethertype 0x86DD @12, next-hdr @20 (14+6)
-	//   IPv4 802.1Q:    ethertype 0x8100 @12, real 0x0800 @16, proto @27 (18+9)
-	//   IPv6 802.1Q:    ethertype 0x8100 @12, real 0x86DD @16, next-hdr @24 (18+6)
-	//
-	// IPv4 matches base proto == 112 (the IPv4 arm already re-validates IHL +
-	// TTL in Go, so it tolerates IPv4 options). IPv6 must additionally admit
-	// VRRP adverts that carry one or more IPv6 extension headers (#2155): the
-	// base Next-Header of such a frame is the FIRST ext-header's type, not 112.
-	// A fixed-offset cBPF cannot walk an ext-header chain, so the IPv6 arm
-	// instead matches the base Next-Header against the small set
-	//   {112 VRRP, 0 Hop-by-Hop, 43 Routing, 60 Dest-Opts}
-	// (approach A2). Any conformant VRRP advert — bare or chained — starts with
-	// one of these, while ordinary IPv6 TCP/UDP/ICMPv6/ND stays kernel-dropped
-	// on a data-bearing RETH VLAN (e.g. reth0.80). Fragment (44) and AH (51)
-	// are deliberately NOT admitted: VRRP adverts are never legitimately
-	// fragmented (the receiver does no reassembly) and never AH-wrapped (VRRP
-	// has its own authentication, not IPsec-AH), so those frames stay
-	// kernel-dropped here rather than waking the RX goroutine only for the Go
-	// walker to drop them. The authoritative ext-header walk + proto-112 +
-	// hop-limit-255 + VRID validation happens in Go (parseAfPacketIPv6); the
-	// cBPF is only an in-kernel volume reducer.
-	//
-	// Jump offsets (Jt/Jf) are relative to the NEXT instruction.
-	filter := []unix.SockFilter{
-		{Code: 0x28, K: 12},                    //  0: ldh [12] — ethertype
-		{Code: 0x15, Jt: 7, Jf: 0, K: 0x0800},  //  1: jeq 0x0800 → 9 (check_ipv4)
-		{Code: 0x15, Jt: 14, Jf: 0, K: 0x86DD}, //  2: jeq 0x86DD → 17 (check_ipv6)
-		{Code: 0x15, Jt: 1, Jf: 0, K: 0x8100},  //  3: jeq 0x8100 → 5 (check_vlan); else reject
-		{Code: 0x06, K: 0},                     //  4: ret reject
-		// check_vlan:
-		{Code: 0x28, K: 16},                    //  5: ldh [16] — real ethertype
-		{Code: 0x15, Jt: 6, Jf: 0, K: 0x0800},  //  6: jeq 0x0800 → 13 (check_ipv4_vlan)
-		{Code: 0x15, Jt: 16, Jf: 0, K: 0x86DD}, //  7: jeq 0x86DD → 24 (check_ipv6_vlan)
-		{Code: 0x06, K: 0},                     //  8: ret reject
-		// check_ipv4: proto at 14+9=23
-		{Code: 0x30, K: 23},                //  9: ldb [23]
-		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 10: jeq 112 → accept; else reject
-		{Code: 0x06, K: 0xFFFFFFFF},        // 11: ret accept
-		{Code: 0x06, K: 0},                 // 12: ret reject
-		// check_ipv4_vlan: proto at 18+9=27
-		{Code: 0x30, K: 27},                // 13: ldb [27]
-		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 14: jeq 112 → accept; else reject
-		{Code: 0x06, K: 0xFFFFFFFF},        // 15: ret accept
-		{Code: 0x06, K: 0},                 // 16: ret reject
-		// check_ipv6: base next-header at 14+6=20. Accept the VRRP/ext-header
-		// set {112,0,43,60}; anything else (incl. Fragment 44, AH 51) is
-		// non-VRRP → reject in-kernel.
-		{Code: 0x30, K: 20},                // 17: ldb [20]
-		{Code: 0x15, Jt: 4, Jf: 0, K: 112}, // 18: jeq 112  → 23 accept
-		{Code: 0x15, Jt: 3, Jf: 0, K: 0},   // 19: jeq 0    → 23 accept (Hop-by-Hop)
-		{Code: 0x15, Jt: 2, Jf: 0, K: 43},  // 20: jeq 43   → 23 accept (Routing)
-		{Code: 0x15, Jt: 1, Jf: 0, K: 60},  // 21: jeq 60   → 23 accept (Dest-Opts)
-		{Code: 0x06, K: 0},                 // 22: ret reject
-		{Code: 0x06, K: 0xFFFFFFFF},        // 23: ret accept
-		// check_ipv6_vlan: base next-header at 18+6=24. Same accept set.
-		{Code: 0x30, K: 24},                // 24: ldb [24]
-		{Code: 0x15, Jt: 4, Jf: 0, K: 112}, // 25: jeq 112  → 30 accept
-		{Code: 0x15, Jt: 3, Jf: 0, K: 0},   // 26: jeq 0    → 30 accept (Hop-by-Hop)
-		{Code: 0x15, Jt: 2, Jf: 0, K: 43},  // 27: jeq 43   → 30 accept (Routing)
-		{Code: 0x15, Jt: 1, Jf: 0, K: 60},  // 28: jeq 60   → 30 accept (Dest-Opts)
-		{Code: 0x06, K: 0},                 // 29: ret reject
-		{Code: 0x06, K: 0xFFFFFFFF},        // 30: ret accept
-	}
+	// cBPF prefilter: accept VRRP for untagged + single-tag {802.1Q, 802.1ad}
+	// variants (#5088). Built by vrrpCBPFFilter so the exact instruction array
+	// the kernel runs can be exercised against synthetic frames in a bpf.VM.
+	filter := vrrpCBPFFilter()
 	if err := unix.SetsockoptSockFprog(fd, unix.SOL_SOCKET, unix.SO_ATTACH_FILTER, &unix.SockFprog{
 		Len:    uint16(len(filter)),
 		Filter: &filter[0],


### PR DESCRIPTION
## Summary

Closes #5088 — VRRP was unreachable on 802.1ad / S-tagged segments.

The AF_PACKET SOCK_RAW cBPF prefilter (`manager.go`) matched **only** `0x8100`
(802.1Q) as the outer VLAN ethertype and kernel-dropped `0x88a8` (802.1ad /
S-tag), even though the Go receiver parser (`instance.go`) accepts **both**. On
an S-tagged / provider-bridged segment the kernel therefore dropped every VRRP
advert before Go saw it → both nodes went mutually deaf and could simultaneously
own the same VRID/VIPs (**split-brain**), despite the parser's advertised
802.1ad support. The kernel prefilter and the userspace parser must admit the
same encapsulation set.

## Fix

Admit single-tag `0x88a8` alongside `0x8100`. A single S-tag has the identical
layout as a C-tag (real ethertype at offset 16), so an `0x88a8` frame routes
through the same `check_vlan` arm.

The raw `sock_filter` array uses **numeric relative jump offsets**, so inserting
the new `jeq 0x88a8 -> check_vlan` instruction after the `0x8100` check shifts
every downstream instruction by one. The crossing jumps were recomputed:

- instruction 1 `Jt 7 -> 8`, instruction 2 `Jt 14 -> 15`, instruction 3
  `Jt 1 -> 2`, new instruction 4 `Jt 1`;
- the `check_vlan` / IPv4 / IPv6 arm offsets are **unchanged** — both their
  source and target shifted together.

**Double-tag QinQ** (`0x88a8` then `0x8100`, real ethertype at offset 20) is
deliberately out of scope: the Go parser does not decode it either (a single-tag
walk), so the shared contract stays "untagged + single-tag {0x8100, 0x88a8}".

## Tests (bpf.VM, fail-on-revert)

The filter is extracted into `vrrpCBPFFilter()` so the exact instruction array
the kernel runs is testable. `cbpf_8021ad_5088_test.go` **assembles it into a
`bpf.VM` and runs it** against synthetic frames (not a construction check):

- **PASS**: untagged IPv4/IPv6 VRRP, IPv6 hop-by-hop, 802.1Q v4/v6 VRRP, **and
  802.1ad v4/v6 VRRP** (the fix).
- **REJECT**: untagged/tagged TCP (wrong proto), ARP, 802.1ad with non-IP inner.

**Fail-on-revert** (verified via `-overlay` + `bpf.VM`): neutralizing the
`0x88a8` acceptance makes both 802.1ad VRRP cases REJECT → RED; the 0x8100 /
untagged / reject cases stay green.

## Validation

`go build ./...`, `go vet ./pkg/vrrp`, `go test -race ./pkg/vrrp` all green;
gofmt clean. `pkg/vrrp/README.md` cBPF-filter section updated (accepted VLAN
ethertypes + the QinQ scope note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
