### PR TITLE
config: reserve UNKNOWN out of the application namespace (#5821)

### DIFF
--- a/docs/services-application-identification.md
+++ b/docs/services-application-identification.md
@@ -113,6 +113,34 @@ upfront what they're getting and not getting.
      alone (#3428); the session source port is threaded into
      `ResolveSessionName` for this purpose.
 
+**`UNKNOWN` name reserved out of the user namespace (#5821)**:
+because `ResolveSessionName` returns the literal `UNKNOWN` for the
+unclassified/unstamped/catalog-skew state and `SessionMatches`
+(`pkg/appid/runtime.go`) compares an operator `show ... application
+<name>` / `clear ... application <name>` filter against that same
+flattened name, a user-defined application (or application-set) named
+`UNKNOWN` would be indistinguishable from the sentinel — the filter
+could not tell "no known application" from the configured app, and a
+destructive filtered session clear could delete both groups. A
+commit-time gate (`validateReservedApplicationNamesStrict`,
+`pkg/config/compiler_validate_strict_application.go`) therefore
+**reserves `UNKNOWN` out of the `applications application` /
+`applications application-set` namespace, case-insensitively**
+(`SessionMatches` folds case, so `unknown`/`Unknown` alias the sentinel
+too). The reserved literal `config.ReservedApplicationName` is kept
+equal to `appid.Unknown` by the `pkg/appid`
+`TestReservedApplicationNameMatchesUnknownSentinel` canary. This is a
+**new fail-closed restriction** (release-note behavior change): a
+previously-valid config that already named an application `UNKNOWN` now
+hard-rejects on the operator's next commit. The tolerant load / peer-sync
+path downgrades the reject to a warning so an already-persisted or
+peer-synced config still boots (#1960 no-brick). A residual display-side
+gap remains for an already-stamped session whose real catalog app is
+literally `UNKNOWN` on a leniently-loaded legacy config — the sentinel and
+that app still flatten to the same string on the show/clear surface until
+the operator renames the app; carrying an explicit typed unknown-kind
+through the filter path is tracked as a follow-up.
+
 **`app_id` space cap (#3438 H4)**: `app_id` is a `u16` on the
 Rust wire with `0` reserved as the unknown sentinel, so real
 applications occupy ids `1..65535`. Both id-assignment walks

--- a/pkg/appid/reserved_name_5821_test.go
+++ b/pkg/appid/reserved_name_5821_test.go
@@ -1,0 +1,29 @@
+package appid
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestReservedApplicationNameMatchesUnknownSentinel is a cross-package drift
+// canary for the #5821 reservation. pkg/config reserves an application /
+// application-set name equal to config.ReservedApplicationName out of the user
+// namespace at commit, precisely so that a real catalog application can never
+// alias the AppID "no known application" sentinel that ResolveSessionName
+// returns and SessionMatches filters on (appid.Unknown, this package).
+//
+// pkg/config cannot import pkg/appid (appid imports config — an import cycle),
+// so the reserved literal is duplicated in config.ReservedApplicationName rather
+// than referencing appid.Unknown. This canary asserts the two stay equal: if a
+// future edit changes appid.Unknown without updating the reservation (or vice
+// versa), the reservation would stop protecting the sentinel it guards and this
+// test goes RED.
+func TestReservedApplicationNameMatchesUnknownSentinel(t *testing.T) {
+	if config.ReservedApplicationName != Unknown {
+		t.Fatalf("config.ReservedApplicationName = %q but appid.Unknown = %q — the "+
+			"#5821 reservation has drifted away from the sentinel it protects; keep "+
+			"them equal (or wire a shared source)",
+			config.ReservedApplicationName, Unknown)
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -564,6 +564,24 @@ type compileOpts struct {
 	// doctrine as lenientApplicationSpecs / lenientApplicationSetMembers.
 	lenientApplicationNameCollisions bool
 
+	// lenientReservedApplicationNames (#5821) downgrades the reserved-name gate
+	// (validateReservedApplicationNamesStrict) from a hard compile error to a
+	// cfg.Warnings entry. The strict commit / commit-check path hard-rejects a
+	// user-defined `applications application <name>` or `application-set <name>`
+	// whose name equals the AppID unknown sentinel "UNKNOWN"
+	// (ReservedApplicationName) case-insensitively — a real catalog application
+	// so named is indistinguishable from the "no known application" sentinel on
+	// the AppID display/filter surface (ResolveSessionName / SessionMatches,
+	// pkg/appid/runtime.go), so a `show`/`clear ... application UNKNOWN` selector
+	// cannot separate the two and a filtered clear could delete both classes.
+	// This is a NEW fail-closed restriction that can reject a config an older
+	// binary accepted, so the tolerant load / peer-sync paths downgrade it to a
+	// warning: an already-persisted or peer-synced config carrying the reserved
+	// name still BOOTS (#1960 no-brick) rather than bricking a running node on
+	// upgrade, while the operator's next commit fails loudly. Same doctrine as
+	// lenientApplicationNameCollisions / lenientApplicationSpecs.
+	lenientReservedApplicationNames bool
+
 	// lenientFirewallFilterFamilyCollisions (#3884, fable-review-161 F-030)
 	// downgrades the firewall-filter cross-family name-collision gate
 	// (validateFirewallFilterFamilyCollisionsAST) from a hard compile error to a
@@ -1946,6 +1964,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRouteFilterMatchTypes:           true,
 		lenientApplicationSpecs:                true,
 		lenientApplicationNameCollisions:       true,
+		lenientReservedApplicationNames:        true,
 		lenientFirewallFilterFamilyCollisions:  true,
 		lenientFirewallFilterFamilyAnyMatches:  true,
 		lenientFilterProtocols:                 true,
@@ -2301,6 +2320,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRouteFilterMatchTypes:           true,
 		lenientApplicationSpecs:                true,
 		lenientApplicationNameCollisions:       true,
+		lenientReservedApplicationNames:        true,
 		lenientFirewallFilterFamilyCollisions:  true,
 		lenientFirewallFilterFamilyAnyMatches:  true,
 		lenientFilterProtocols:                 true,

--- a/pkg/config/compiler_reserved_appname_5821_test.go
+++ b/pkg/config/compiler_reserved_appname_5821_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5821: the AppID display/filter surface (ResolveSessionName / SessionMatches,
+// pkg/appid/runtime.go) uses the literal "UNKNOWN" as the "no known
+// application" sentinel and carries a user-defined application/application-set
+// name verbatim into the SAME flattened string. A catalog application literally
+// named UNKNOWN is therefore indistinguishable from the sentinel — a
+// `show`/`clear ... application UNKNOWN` selector cannot separate unclassified
+// sessions from the configured app, and a filtered clear could delete both.
+//
+// These tests pin the strict reject at commit (CompileConfig) for the
+// application, application-set, and multi-term (implicit-set) spellings and for
+// every casing variant (SessionMatches folds case, so the reservation is
+// case-insensitive), plus the lenient downgrade-to-warning on the tolerant load
+// / peer-sync path (CompileConfigLenient) so an already-persisted config still
+// boots (#1960).
+//
+// buildTreeFromSet (ipsec_proposal_ref_test.go) builds the candidate tree the
+// way the configstore does (ParseSetCommand + SetPath), NOT NewParser — the
+// parser merges newline-separated set lines into one node (per CLAUDE.md).
+
+// FAIL-ON-REVERT: neutralizing validateReservedApplicationNamesStrict (making it
+// `return nil`) makes CompileConfig ACCEPT `application UNKNOWN`, so this test
+// goes RED (expects a rejection, gets nil).
+func TestReservedApplicationNameRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application UNKNOWN protocol tcp",
+		"set applications application UNKNOWN destination-port 80",
+	})
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of application named UNKNOWN, got nil")
+	}
+	if !strings.Contains(err.Error(), "reserved") || !strings.Contains(err.Error(), "#5821") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Casing variants must collide too: SessionMatches folds case, so "unknown" and
+// "Unknown" alias the sentinel just as "UNKNOWN" does.
+func TestReservedApplicationNameCaseVariantsRejected(t *testing.T) {
+	for _, variant := range []string{"unknown", "Unknown", "uNkNoWn"} {
+		tree := buildTreeFromSet(t, []string{
+			"set applications application " + variant + " protocol tcp",
+			"set applications application " + variant + " destination-port 80",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("CompileConfig: expected rejection of application named %q (case variant of the sentinel), got nil", variant)
+		}
+		if !strings.Contains(err.Error(), "reserved") {
+			t.Fatalf("variant %q: unexpected error text: %v", variant, err)
+		}
+	}
+}
+
+// An application-set named UNKNOWN is rejected the same way (applications and
+// application-sets share one flat Junos namespace). A valid predefined member
+// keeps the set-member gate happy so the reservation gate is what fires.
+func TestReservedApplicationSetNameRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application-set UNKNOWN application junos-http",
+	})
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of application-set named UNKNOWN, got nil")
+	}
+	if !strings.Contains(err.Error(), "reserved") ||
+		!strings.Contains(err.Error(), "application-set") ||
+		!strings.Contains(err.Error(), "#5821") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// A MULTI-TERM `application UNKNOWN` mints an implicit application-set under its
+// own name (cfg.Applications.ApplicationSets["UNKNOWN"]); the reservation gate
+// walks that map too, so the authored parent name is still caught even though
+// the compiler stores only the generated per-term application (UNKNOWN-t1).
+func TestReservedMultiTermApplicationNameRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application UNKNOWN term t1 protocol tcp destination-port 80",
+		"set applications application UNKNOWN term t2 protocol udp destination-port 53",
+	})
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of multi-term application named UNKNOWN, got nil")
+	}
+	if !strings.Contains(err.Error(), "reserved") || !strings.Contains(err.Error(), "#5821") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// A normal application name is accepted; the reservation is scoped strictly to
+// the sentinel and must not reject ordinary catalog names.
+func TestNonReservedApplicationNameAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application my-app protocol tcp",
+		"set applications application my-app destination-port 80",
+		"set applications application-set my-set application my-app",
+	})
+
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig: expected a normal application name to be accepted, got: %v", err)
+	}
+}
+
+// A generated per-term application name (`<parent>-<term>`) never equals the
+// reserved sentinel, so a normally-named multi-term application compiles clean.
+func TestReservedGateDoesNotRejectGeneratedTermNames(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application unknown-svc term t1 protocol tcp destination-port 80",
+	})
+
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig: expected multi-term application unknown-svc (not the sentinel) to be accepted, got: %v", err)
+	}
+}
+
+// Tolerant load / peer-sync (#1960): an already-persisted config carrying the
+// now-reserved name must still BOOT — the reject is downgraded to a warning so a
+// running node does not brick on upgrade.
+func TestReservedApplicationNameLenientDowngrade(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application UNKNOWN protocol tcp",
+		"set applications application UNKNOWN destination-port 80",
+	})
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: expected the reserved name to downgrade to a warning and boot, got error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("CompileConfigLenient: expected a non-nil config on the tolerant path")
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "reserved application name") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CompileConfigLenient: expected a 'reserved application name' warning, got: %v", cfg.Warnings)
+	}
+}
+
+// The reserved literal must remain exactly "UNKNOWN" — the same value the AppID
+// sentinel uses (appid.Unknown). If this constant changes, the reservation
+// stops protecting the sentinel it is meant to reserve. (The cross-package
+// canary in pkg/appid asserts equality with appid.Unknown directly.)
+func TestReservedApplicationNameConstant(t *testing.T) {
+	if ReservedApplicationName != "UNKNOWN" {
+		t.Fatalf("ReservedApplicationName = %q, want \"UNKNOWN\"", ReservedApplicationName)
+	}
+}

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -797,6 +797,29 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5821 reserved application-name gate. The AppID display/filter surface
+	// (ResolveSessionName / SessionMatches, pkg/appid/runtime.go) uses the
+	// literal "UNKNOWN" as the "no known application" sentinel and carries a
+	// user-defined application/application-set name verbatim into the SAME
+	// flattened string, so a catalog application literally named UNKNOWN
+	// (case-insensitively, since SessionMatches folds case) is indistinguishable
+	// from the sentinel — `show ... application UNKNOWN` cannot tell unclassified
+	// sessions from the configured app, and the destructive `clear ...
+	// application UNKNOWN` selector could delete both. Reserve the sentinel out
+	// of the user application/application-set namespace at commit. This is a NEW
+	// fail-closed restriction that can reject a config an older binary accepted;
+	// lenient on load / peer-sync (warn so an already-persisted or peer-synced
+	// config carrying the reserved name still BOOTS — #1960 no-brick), strict on
+	// commit so the operator's next edit fails loudly.
+	if err := validateReservedApplicationNamesStrict(cfg); err != nil {
+		if opts.lenientReservedApplicationNames {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("reserved application name (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #2175 firewall-filter `from protocol <token>` fail-open gate. Strict on
 	// commit / commit-check (hard-reject a term whose protocol token is not
 	// resolvable by the centralized appid.ProtocolNumber SSOT — neither a

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -721,3 +721,97 @@ func icmpConstraintDesc(app *Application) string {
 func ApplicationsToValidateStrict(cfg *Config) map[string]struct{} {
 	return applicationsToValidateStrict(cfg)
 }
+
+// ReservedApplicationName is the AppID display/filter sentinel that means "no
+// known application" (appid.Unknown == "UNKNOWN", pkg/appid/runtime.go).
+// ResolveSessionName returns this literal for an unstamped / catalog-skew
+// session when `services application-identification` is enabled, and
+// SessionMatches compares an operator `show ... application <name>` /
+// `clear ... application <name>` filter against the flattened result string. A
+// user-defined application (or application-set) name is carried verbatim into
+// that same flattened string, so a catalog application literally named
+// "UNKNOWN" is indistinguishable from the sentinel: a `show`/`clear` filter
+// cannot separate "no known application" from the configured application, and a
+// destructive filtered session clear can delete BOTH classes (#5821).
+//
+// pkg/config cannot import pkg/appid (appid imports config — an import cycle),
+// so the literal is duplicated here rather than referenced. The pkg/appid
+// canary TestReservedApplicationNameMatchesUnknownSentinel asserts the two stay
+// equal so the reservation cannot drift away from the sentinel it protects.
+const ReservedApplicationName = "UNKNOWN"
+
+// validateReservedApplicationNamesStrict hard-rejects, at commit /
+// commit-check, a user-defined `applications application <name>` or
+// `applications application-set <name>` whose name equals the AppID unknown
+// sentinel (ReservedApplicationName == "UNKNOWN") CASE-INSENSITIVELY (#5821).
+//
+// Without this reservation the sentinel and a real catalog application share
+// one flat string on the AppID display/filter surface (ResolveSessionName /
+// SessionMatches, pkg/appid/runtime.go): `show ... application UNKNOWN` cannot
+// tell truly-unknown sessions from sessions classified as the user application,
+// and the destructive `clear ... application UNKNOWN` selector can delete both
+// groups. SessionMatches already folds case (strings.EqualFold), so "unknown"
+// and "Unknown" collide with the sentinel too; the reservation is therefore
+// case-insensitive to keep the whole case-folded name-slot owned by the
+// sentinel.
+//
+// Applications and application-sets share one flat Junos namespace, and a
+// multi-term application additionally mints an implicit application-set under
+// its own name (cfg.Applications.ApplicationSets[<parent>]). Both maps are
+// walked so every authored spelling is caught: a simple `application UNKNOWN`
+// lands in Applications; an `application-set UNKNOWN` (or the implicit set of a
+// multi-term `application UNKNOWN`) lands in ApplicationSets. Generated per-term
+// names (`<parent>-<term>`) never equal the reserved name, so they are
+// unaffected. Iteration is sorted so the first-reported error is deterministic.
+//
+// This is a NEW fail-closed restriction (#5821): a previously-valid config that
+// already named an application/application-set UNKNOWN now hard-rejects on the
+// operator's next commit — the intended fix, called out as a release-note
+// behavior change (mirroring the #5539 RETH-generic guard). Strict on the
+// commit / commit-check path; the call site (compiler_uniformgates.go,
+// lenientReservedApplicationNames) downgrades a returned error to a warning on
+// the tolerant load / peer-sync path so an already-persisted or peer-synced
+// config carrying the reserved name still BOOTS (#1960 no-brick) rather than
+// bricking a running node on upgrade. Mirrors the strict commit-reservation
+// pattern of validateVRRPGroupIDStrict (#4573) and the sibling application
+// gates.
+func validateReservedApplicationNamesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	appNames := make([]string, 0, len(cfg.Applications.Applications))
+	for name := range cfg.Applications.Applications {
+		appNames = append(appNames, name)
+	}
+	sort.Strings(appNames)
+	for _, name := range appNames {
+		if strings.EqualFold(name, ReservedApplicationName) {
+			return reservedApplicationNameError("application", name)
+		}
+	}
+	setNames := make([]string, 0, len(cfg.Applications.ApplicationSets))
+	for name := range cfg.Applications.ApplicationSets {
+		setNames = append(setNames, name)
+	}
+	sort.Strings(setNames)
+	for _, name := range setNames {
+		if strings.EqualFold(name, ReservedApplicationName) {
+			return reservedApplicationNameError("application-set", name)
+		}
+	}
+	return nil
+}
+
+// reservedApplicationNameError builds the operator-visible commit error for a
+// user application / application-set that collides with the AppID unknown
+// sentinel. kind is "application" or "application-set".
+func reservedApplicationNameError(kind, name string) error {
+	return fmt.Errorf(
+		"applications %s %q: %q is reserved as the AppID \"no known application\" "+
+			"sentinel and may not name a user application or application-set "+
+			"(reserved case-insensitively) — the `show`/`clear ... application "+
+			"<name>` filter and the session renderer cannot distinguish a real "+
+			"application named %q from the unclassified/unstamped state, so a "+
+			"filtered session clear could delete both; rename it (#5821)",
+		kind, name, ReservedApplicationName, ReservedApplicationName)
+}


### PR DESCRIPTION
## Summary

The AppID display/filter surface encodes the "no known application" state as the ordinary string `UNKNOWN` (`appid.Unknown`, `pkg/appid/runtime.go`): `ResolveSessionName` returns it for an unstamped / catalog-skew session when `services application-identification` is enabled, and `SessionMatches` compares an operator `show ... application <name>` / `clear ... application <name>` filter against that same flattened string. Nothing reserved that name out of the user application / application-set namespace, so a user-defined application (or application-set) literally named `UNKNOWN` aliased the sentinel:

- `show ... application UNKNOWN` could not tell truly-unknown sessions from sessions classified as the configured app;
- the destructive `clear ... application UNKNOWN` selector could delete **both** groups;
- `SessionMatches` folds case (`strings.EqualFold`), so `unknown` / `Unknown` collided with the sentinel too.

## Fix (control-plane config validation — the clean core)

Adds a commit-time gate `validateReservedApplicationNamesStrict` (`pkg/config/compiler_validate_strict_application.go`) that **hard-rejects** an `applications application <name>` or `applications application-set <name>` equal to `UNKNOWN` **case-insensitively**, mirroring the strict commit-reservation pattern of `validateVRRPGroupIDStrict` (#4573) / `ValidateLogicalUnit` (#5932) and the sibling application gates. It walks both `cfg.Applications.Applications` and `.ApplicationSets`, so every authored spelling is caught — including the implicit application-set a multi-term `application UNKNOWN` mints under its own name. Generated per-term names (`<parent>-<term>`) never equal the sentinel and are unaffected. Wired into `runUniformGates`, so the strict-gate wiring canary (`TestEveryStrictCommitGateIsWired`, #4422) recognizes it.

The reserved literal lives in `pkg/config` as `ReservedApplicationName` because `pkg/config` cannot import `pkg/appid` (import cycle). A `pkg/appid` canary (`TestReservedApplicationNameMatchesUnknownSentinel`) asserts it stays equal to `appid.Unknown` so the reservation cannot drift away from the sentinel it protects.

## ⚠️ Behavior change (release-note-worthy)

This is a **NEW fail-closed restriction**. A previously-valid config that already named an application / application-set `UNKNOWN` (any casing) now **hard-rejects on the operator's next commit** — the intended fix, in the same spirit as the #5539 RETH-generic guard. The **tolerant load / peer-sync path downgrades the reject to a warning** (`lenientReservedApplicationNames`) so an already-persisted or peer-synced config still **BOOTS** rather than bricking a running node on upgrade (#1960 no-brick).

## Residual / follow-up (out of scope here)

This reserves the sentinel at commit (the clean control-plane core). A **display-side residual remains**: for an already-stamped session whose real catalog app is literally `UNKNOWN` on a *leniently-loaded legacy* config, the sentinel and that app still flatten to the same string on the show/clear surface until the operator renames the app. Carrying an explicit typed unknown-kind (`{Kind: Known|Unstamped|CatalogSkew|TupleFallback, ...}`) through the CLI/gRPC/REST filter path — the issue's broader "typed result" direction — is a session-tag / renderer change and is left as a **follow-up**; it is deliberately not expanded into here (shim-wall-fragile).

## Validation

- `go build ./...`
- `go vet ./pkg/config/ ./pkg/appid/`
- `go test -race ./pkg/config/ ./pkg/appid/ -count=1` — all green (pkg/config ~132s)
- **Fail-on-revert:** neutralizing `validateReservedApplicationNamesStrict` to `return nil` turns the four reject tests **and** the lenient-warning test RED.
- Docs updated: `docs/services-application-identification.md`.

Control-plane config validation only (Go, no dataplane/cargo change) → no `test-failover` / dataplane smoke required.

Closes #5821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AghGi5P31fYXD4cfgCHPxc