### PR TITLE
ha/dhcpserver: carry DHCPv6 preferred lifetime across lease sync (#5073)

### DIFF
--- a/pkg/cluster/lease_sync_wire_test.go
+++ b/pkg/cluster/lease_sync_wire_test.go
@@ -159,17 +159,26 @@ func TestDHCPLeasePayload_LengthGated(t *testing.T) {
 		t.Errorf("newer-peer record lost known fields: %+v", got)
 	}
 
-	// Legacy peer: truncate the record so the trailing flags byte (and
-	// hostname) are missing. The decoder must not panic and must zero the
-	// absent fields rather than mis-read.
-	short := rec[:len(rec)-3]
+	// Legacy peer: truncate the record so the trailing PreferredRemaining field
+	// (#5073), the FQDN flags byte, AND the hostname are missing. The record tail
+	// is [hostname len(2) + bytes][flags(1)][PreferredRemaining(4)]; cut 7 bytes
+	// (the pref field, the flags byte, and into the hostname) so the hostname
+	// read fails and every trailing field is absent. The decoder must not panic
+	// and must leave the absent fields at their defaults rather than mis-read.
+	short := rec[:len(rec)-7]
 	got2 := decodeOneLease(short)
 	if got2.Address != l.Address {
 		t.Errorf("legacy-peer record lost leading field address: %+v", got2)
 	}
-	// FQDNFwd was the last byte; truncated → must be false (zero).
+	// FQDNFwd lived in the flags byte, now truncated away → must be false (zero).
 	if got2.FQDNFwd {
 		t.Errorf("legacy-peer truncated record must not set absent flag")
+	}
+	// #5073: a record truncated before the trailing PreferredRemaining defaults
+	// it to Remaining (preferred==valid), never 0 (which would deprecate).
+	if got2.PreferredRemaining != got2.Remaining {
+		t.Errorf("legacy-peer truncated record must default PreferredRemaining to Remaining=%d, got %d",
+			got2.Remaining, got2.PreferredRemaining)
 	}
 }
 
@@ -290,5 +299,152 @@ func TestDHCPLeasePayload_HugeCountDoesNotOverAllocate(t *testing.T) {
 	out := decodeDHCPLeasePayload(payload)
 	if len(out) != 0 {
 		t.Errorf("huge-count empty-body frame: got %d leases, want 0", len(out))
+	}
+}
+
+// TestDHCPLease_PreferredRemaining_RoundTrip is the #5073 primary fail-on-revert.
+// A DEPRECATED DHCPv6 binding has a preferred lifetime of 0 with a still-positive
+// valid lifetime (the client must stop originating from the address but the lease
+// is not yet expired). Before #5073 the wire carried no preferred lifetime, so a
+// deprecated binding synced as PreferredRemaining==Remaining and takeover REVIVED
+// the address. The append-only trailing PreferredRemaining field carries it.
+//
+// FAIL-ON-REVERT: neutralize the encode/decode of the trailing field (drop the
+// AppendUint32 in encodeOneLease, or the guarded read in decodeOneLease) and the
+// deprecated lease decodes PreferredRemaining=Remaining(1800) via the default —
+// a revival — so the want==0 assertion goes RED.
+func TestDHCPLease_PreferredRemaining_RoundTrip(t *testing.T) {
+	in := []dhcpserver.SyncLease{
+		{ // deprecated IA_NA: preferred=0, valid=1800
+			Family: 6, Address: "2001:db8::dep", SubnetID: 2,
+			DUID: "00:01:00:0a", IAID: 3, LeaseType: "IA_NA",
+			ValidLife: 1800, Remaining: 1800, PreferredRemaining: 0,
+			Hostname: "dep", FQDNFwd: true,
+		},
+		{ // partially deprecated IA_PD: preferred < valid remaining
+			Family: 6, Address: "2001:db8:dead::", SubnetID: 2,
+			DUID: "00:01:00:0b", IAID: 4, LeaseType: "IA_PD", PrefixLen: 56,
+			ValidLife: 7200, Remaining: 6000, PreferredRemaining: 1200,
+		},
+		{ // healthy: preferred == valid remaining
+			Family: 6, Address: "2001:db8::ok", SubnetID: 2,
+			DUID: "00:01:00:0c", IAID: 5, LeaseType: "IA_NA",
+			ValidLife: 3600, Remaining: 3000, PreferredRemaining: 3000,
+		},
+	}
+	out := decodeDHCPLeasePayload(encodeDHCPLeasePayload(in))
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("PreferredRemaining round-trip mismatch:\n in=%+v\nout=%+v", in, out)
+	}
+	if out[0].PreferredRemaining != 0 {
+		t.Errorf("deprecated binding revived: PreferredRemaining=%d, want 0 (a reverted "+
+			"trailing field defaults to Remaining=%d)", out[0].PreferredRemaining, out[0].Remaining)
+	}
+}
+
+// TestDHCPLease_BackwardCompat_AbsentPrefDefaultsRemaining is the LOAD-BEARING
+// #5073 compat guard. An OLDER peer that predates the trailing PreferredRemaining
+// field emits a record ending at the FQDN flags byte. The decoder MUST default
+// the absent field to Remaining (preferred==valid, the pre-#5073 behavior), NOT 0
+// — defaulting to 0 would wrongly deprecate every lease synced from that peer.
+//
+// The old-format record is manufactured by encoding a current record and
+// stripping the trailing 4-byte PreferredRemaining field, which is byte-exact
+// what an old peer would have put on the wire.
+//
+// FAIL-ON-REVERT: change decodeOneLease's default from `l.Remaining` to 0 and the
+// PreferredRemaining==Remaining assertion goes RED (old peers' leases deprecated).
+func TestDHCPLease_BackwardCompat_AbsentPrefDefaultsRemaining(t *testing.T) {
+	l := dhcpserver.SyncLease{
+		Family: 6, Address: "2001:db8::old", SubnetID: 2,
+		DUID: "00:01:00:0d", IAID: 6, LeaseType: "IA_NA",
+		ValidLife: 1800, Remaining: 1500, PreferredRemaining: 1500,
+		Hostname: "oldpeer", FQDNRev: true,
+	}
+	rec, err := encodeOneLease(l)
+	if err != nil {
+		t.Fatalf("encodeOneLease: %v", err)
+	}
+	// Strip the trailing 4-byte PreferredRemaining → an exact old-format record
+	// that ends at the FQDN flags byte.
+	oldRec := rec[:len(rec)-4]
+	got := decodeOneLease(oldRec)
+
+	if got.Remaining != 1500 {
+		t.Fatalf("old-format record lost Remaining: got %d, want 1500", got.Remaining)
+	}
+	if got.PreferredRemaining != got.Remaining {
+		t.Errorf("absent trailing field must default PreferredRemaining to Remaining=%d "+
+			"(preferred==valid), got %d — an old peer's leases must NOT be deprecated",
+			got.Remaining, got.PreferredRemaining)
+	}
+	// The FQDN flags byte (the old last field) must still decode.
+	if !got.FQDNRev || got.FQDNFwd {
+		t.Errorf("old-format record mis-decoded FQDN flags: fwd=%v rev=%v", got.FQDNFwd, got.FQDNRev)
+	}
+}
+
+// TestDHCPLease_FramingSkipsNewerLongerRecord confirms the per-record recLen
+// framing lets an older decoder step past a NEWER peer's longer record (the one
+// carrying the extra trailing PreferredRemaining) and still decode the record
+// that follows it. This is the #5073 mixed-version safety the append-only field
+// relies on: encodeDHCPLeasePayload writes each record with its own length
+// prefix, and decodeDHCPLeasePayload advances off += recLen regardless of how
+// many trailing fields decodeOneLease actually read.
+func TestDHCPLease_FramingSkipsNewerLongerRecord(t *testing.T) {
+	first := dhcpserver.SyncLease{
+		Family: 6, Address: "2001:db8::1", SubnetID: 2,
+		DUID: "00:01:00:01", IAID: 1, LeaseType: "IA_NA",
+		ValidLife: 1800, Remaining: 1500, PreferredRemaining: 0, // deprecated → longest-meaning trailing field
+		Hostname: "first",
+	}
+	second := dhcpserver.SyncLease{
+		Family: 4, Address: "10.0.0.2", SubnetID: 1,
+		HWAddress: "aa:bb", ValidLife: 600, Remaining: 500, PreferredRemaining: 500,
+		Hostname: "second",
+	}
+	out := decodeDHCPLeasePayload(encodeDHCPLeasePayload([]dhcpserver.SyncLease{first, second}))
+	if len(out) != 2 {
+		t.Fatalf("got %d leases, want 2 (recLen framing must step past the longer first record)", len(out))
+	}
+	if !reflect.DeepEqual(out[1], second) {
+		t.Errorf("record after a longer newer record mis-decoded:\n got=%+v\nwant=%+v", out[1], second)
+	}
+}
+
+// TestPeerDHCPLeasesAged_PreferredRemaining extends the #4871 aging guard to the
+// #5073 preferred lifetime: a held lease's PreferredRemaining counts down in the
+// same real time as Remaining, so standby residence must age BOTH. A deprecated
+// lease (PreferredRemaining=0) stays deprecated; a healthy lease's preferred ages
+// in lock-step and never exceeds the aged Remaining.
+//
+// FAIL-ON-REVERT: drop the PreferredRemaining aging in peerDHCPLeasesAged and the
+// healthy lease keeps PreferredRemaining=600 while Remaining ages to 500 —
+// violating PreferredRemaining<=Remaining — so the ==500 assertion goes RED.
+func TestPeerDHCPLeasesAged_PreferredRemaining(t *testing.T) {
+	s := &SessionSync{}
+	now := time.Unix(1_700_000_000, 0)
+	recvAt := now.Add(-100 * time.Second) // 100s residence
+	s.peerDHCPLeases6 = []dhcpserver.SyncLease{
+		{Family: 6, Address: "2001:db8::a", Remaining: 600, PreferredRemaining: 600}, // healthy
+		{Family: 6, Address: "2001:db8::b", Remaining: 600, PreferredRemaining: 0},   // deprecated
+	}
+	s.peerDHCPLeases6RecvAt = recvAt
+
+	got := s.peerDHCPLeasesAged(6, now)
+	if len(got) != 2 {
+		t.Fatalf("aged set: got %d leases, want 2: %+v", len(got), got)
+	}
+	byAddr := map[string]dhcpserver.SyncLease{}
+	for _, l := range got {
+		byAddr[l.Address] = l
+	}
+	if h := byAddr["2001:db8::a"]; h.Remaining != 500 || h.PreferredRemaining != 500 {
+		t.Errorf("healthy lease aging: Remaining=%d PreferredRemaining=%d, want 500/500",
+			h.Remaining, h.PreferredRemaining)
+	}
+	if d := byAddr["2001:db8::b"]; d.Remaining != 500 || d.PreferredRemaining != 0 {
+		t.Errorf("deprecated lease aging: Remaining=%d PreferredRemaining=%d, want 500/0 "+
+			"(must stay deprecated, never revived)", d.Remaining, d.PreferredRemaining)
 	}
 }

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -990,6 +990,18 @@ func (s *SessionSync) peerDHCPLeasesAged(family int, now time.Time) []dhcpserver
 		if l.Remaining <= 0 {
 			continue // aged out on the standby — drop, never resurrect at seed
 		}
+		// #5073: the PREFERRED remaining counts down in the same real time as the
+		// valid remaining, so it must age by the same residence. Floor at 0
+		// (already-deprecated stays deprecated) and cap at the aged Remaining so
+		// the invariant PreferredRemaining <= Remaining survives residence. A
+		// deprecated lease held on the standby is never revived at seed.
+		l.PreferredRemaining -= residence
+		if l.PreferredRemaining < 0 {
+			l.PreferredRemaining = 0
+		}
+		if l.PreferredRemaining > l.Remaining {
+			l.PreferredRemaining = l.Remaining
+		}
 		out = append(out, l)
 	}
 	return out

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -654,10 +654,14 @@ func decodeConfigPayload(payload []byte) (configText string, gen uint64) {
 // length-prefixed lease records. Each record is itself length-gated so the
 // schema can grow: a decoder reads only the fields the inner length covers,
 // tolerating a longer record from a newer peer (trailing fields ignored) and a
-// shorter record from an older peer (absent fields default to zero) — the same
-// length-gated-trailing-field discipline as #2170 sessions. The lease wire
-// carries REMAINING LIFETIME (not absolute expiry) so the receiver re-anchors
-// to its local clock at seed (the #2239 clock invariant).
+// shorter record from an older peer (absent fields default to zero, EXCEPT the
+// #5073 PreferredRemaining trailing field which defaults to Remaining so an
+// older peer's lease is not wrongly deprecated) — the same length-gated-
+// trailing-field discipline as #2170 sessions. The lease wire carries REMAINING
+// LIFETIME (not absolute expiry) so the receiver re-anchors to its local clock
+// at seed (the #2239 clock invariant). The trailing field order is, after the
+// FQDN flags byte: PreferredRemaining (uint32 LE, #5073). Adding a field here is
+// append-only and does NOT bump SessionSyncWireVersion.
 
 // putLeaseString appends a uint16-length-prefixed string. It FAILS CLOSED when
 // s exceeds the uint16 wire prefix (math.MaxUint16 = 65535 bytes): the prefix
@@ -737,6 +741,13 @@ func encodeOneLease(l dhcpserver.SyncLease) ([]byte, error) {
 		flags |= 0x02
 	}
 	b = append(b, flags)
+	// #5073 APPEND-ONLY trailing field: PreferredRemaining (seconds of preferred
+	// lifetime left). It MUST stay last so an older decoder (whose record ends at
+	// the FQDN flags byte) simply ignores it, and a newer decoder defaults it to
+	// Remaining when an older sender omits it (see decodeOneLease). This is a
+	// length-gated trailing field like the #3931 config-gen — it does NOT bump
+	// SessionSyncWireVersion.
+	b = binary.LittleEndian.AppendUint32(b, uint32(l.PreferredRemaining))
 	return b, nil
 }
 
@@ -771,6 +782,14 @@ func decodeOneLease(buf []byte) dhcpserver.SyncLease {
 	}
 	l.Remaining = int(binary.LittleEndian.Uint32(buf[off:]))
 	off += 4
+	// #5073: default PreferredRemaining to the valid Remaining (preferred==valid,
+	// the pre-#5073 behavior). This is LOAD-BEARING and set BEFORE any later
+	// early-return: an OLDER peer's record ends at the FQDN flags byte with NO
+	// trailing PreferredRemaining, and defaulting to Remaining (NOT 0) avoids
+	// wrongly deprecating every lease synced from that peer. The trailing-field
+	// read at the tail overrides this only when a newer sender actually supplied
+	// the field.
+	l.PreferredRemaining = l.Remaining
 	if off >= len(buf) {
 		return l
 	}
@@ -805,6 +824,15 @@ func decodeOneLease(buf []byte) dhcpserver.SyncLease {
 		flags := buf[off]
 		l.FQDNFwd = flags&0x01 != 0
 		l.FQDNRev = flags&0x02 != 0
+		off++ // advance past flags so the #5073 trailing field can follow
+	}
+	// #5073 append-only trailing field. PRESENT (a newer peer) → read it;
+	// ABSENT (an older peer whose record stopped at the FQDN flags byte) → leave
+	// the preferred==valid default set above. Guarded by remaining length so a
+	// truncated tail never over-reads.
+	if off+4 <= len(buf) {
+		l.PreferredRemaining = int(binary.LittleEndian.Uint32(buf[off:]))
+		off += 4
 	}
 	return l
 }

--- a/pkg/daemon/daemon_dhcp_lease_sync_test.go
+++ b/pkg/daemon/daemon_dhcp_lease_sync_test.go
@@ -195,11 +195,11 @@ func TestSeedDHCPLeasesFromPeer(t *testing.T) {
 	// Standby holds peer leases (would arrive over the sync channel).
 	d.sessionSync.SetPeerDHCPLeasesForTesting(4, []dhcpserver.SyncLease{
 		{Family: 4, Address: "10.0.61.50", HWAddress: "aa:bb:cc:dd:ee:01",
-			SubnetID: 1, Remaining: 1800, State: 0},
+			SubnetID: 1, Remaining: 1800, PreferredRemaining: 1800, State: 0},
 	})
 	d.sessionSync.SetPeerDHCPLeasesForTesting(6, []dhcpserver.SyncLease{
 		{Family: 6, Address: "2001:db8::100", DUID: "00:01:00:01", IAID: 9,
-			LeaseType: "IA_NA", SubnetID: 1, Remaining: 2400, State: 0},
+			LeaseType: "IA_NA", SubnetID: 1, Remaining: 2400, PreferredRemaining: 2400, State: 0},
 	})
 
 	d.seedDHCPLeasesFromPeer(context.Background())

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -102,6 +102,17 @@ type ddnsLease struct {
 	LeaseType   int  // Kea numeric lease_type: 0=IA_NA, 1=IA_TA, 2=IA_PD
 	LeaseTypeOK bool // false ⇒ lease_type column present but unparseable
 	PrefixLen   int  // v6 IA_PD delegated prefix length (0 when absent)
+
+	// #5073: the v6 memfile carries DISTINCT valid_lifetime and pref_lifetime
+	// columns. The lease-sync memfile fallback (readSyncLeasesViaMemfile) needs
+	// both to recover a clock-skew-safe preferred remaining independent of the
+	// valid remaining, so a DEPRECATED binding (pref_lifetime=0) is not revived
+	// on takeover. Both are OPTIONAL columns (not in requiredLeaseColumns): an
+	// old memfile or a v4 file leaves them 0 with PrefLifetimeOK=false, and the
+	// sync path then defaults preferred==valid. The DDNS reconciler ignores both.
+	ValidLifetime  int  // memfile valid_lifetime column (seconds), 0 if absent
+	PrefLifetime   int  // memfile pref_lifetime column (seconds), 0 if absent
+	PrefLifetimeOK bool // true ⇒ pref_lifetime column present AND parseable
 }
 
 // Kea memfile lease_type column values (v6 only).
@@ -421,6 +432,22 @@ func parseActiveLeasesFileInto(path string, family int, now time.Time, acc *ddns
 			if pl := get(fields, "prefix_len"); pl != "" {
 				if v, e := strconv.Atoi(strings.TrimSpace(pl)); e == nil {
 					l.PrefixLen = v
+				}
+			}
+			// #5073: recover valid_lifetime + pref_lifetime so the lease-sync
+			// memfile fallback can derive a preferred remaining that does NOT
+			// revive a deprecated (pref_lifetime=0) binding on takeover. Both
+			// columns are OPTIONAL; an absent/unparseable pref_lifetime leaves
+			// PrefLifetimeOK false so the sync path defaults preferred==valid.
+			if vl := get(fields, "valid_lifetime"); vl != "" {
+				if v, e := strconv.Atoi(strings.TrimSpace(vl)); e == nil {
+					l.ValidLifetime = v
+				}
+			}
+			if pf := get(fields, "pref_lifetime"); pf != "" {
+				if v, e := strconv.Atoi(strings.TrimSpace(pf)); e == nil {
+					l.PrefLifetime = v
+					l.PrefLifetimeOK = true
 				}
 			}
 		} else {

--- a/pkg/dhcpserver/lease_sync.go
+++ b/pkg/dhcpserver/lease_sync.go
@@ -89,7 +89,35 @@ type SyncLease struct {
 	FQDNRev   bool // client requested reverse DNS update
 	ValidLife int  // the lease's configured valid-lifetime (seconds)
 	Remaining int  // seconds of lifetime left at read time (clock-skew-safe)
-	State     int  // Kea lease state (0=default/active)
+
+	// PreferredRemaining is the SECONDS of PREFERRED lifetime left at the moment
+	// the SENDER read the lease. For DHCPv6 the preferred lifetime is a SEPARATE
+	// deadline from the valid lifetime: a DEPRECATED binding has preferred=0 with
+	// a still-positive valid lifetime (the client must stop using the address for
+	// new connections but the lease is not yet expired). It is re-anchored to the
+	// receiver's local clock at seed exactly like Remaining (the #2239 clock
+	// invariant) and the invariant 0 <= PreferredRemaining <= Remaining always
+	// holds (#5073). A value of 0 means DEPRECATED. For DHCPv4 (no preferred
+	// concept) and for leases synced from an OLDER peer that predates this field,
+	// PreferredRemaining defaults to Remaining (preferred==valid), preserving the
+	// pre-#5073 behavior.
+	PreferredRemaining int
+
+	State int // Kea lease state (0=default/active)
+}
+
+// clampPreferredRemaining enforces the #5073 invariant 0 <= pref <= remaining.
+// The preferred lifetime can never outlive the valid lifetime (RFC 8415 §6.3),
+// and a negative computed remainder (a deprecated lease whose preferred deadline
+// has already passed) floors to 0 (deprecated), never revives.
+func clampPreferredRemaining(pref, remaining int) int {
+	if pref < 0 {
+		return 0
+	}
+	if pref > remaining {
+		return remaining
+	}
+	return pref
 }
 
 // IdentityKey returns a stable per-lease identity used for dedup/diff on the
@@ -142,12 +170,17 @@ type keaLeaseJSON struct {
 	PrefixLen int    `json:"prefix-len,omitempty"` // v6 IA_PD
 	SubnetID  int    `json:"subnet-id,omitempty"`
 	ValidLft  int    `json:"valid-lft,omitempty"`
-	CLTT      int64  `json:"cltt,omitempty"`   // client-last-transaction-time epoch (get)
-	Expire    int64  `json:"expire,omitempty"` // absolute expiry epoch (add)
-	State     int    `json:"state"`
-	Hostname  string `json:"hostname,omitempty"`
-	FQDNFwd   bool   `json:"fqdn-fwd,omitempty"`
-	FQDNRev   bool   `json:"fqdn-rev,omitempty"`
+	// PreferredLft is a POINTER so an absent field (nil, an older Kea or a v4
+	// lease) is distinguishable from an explicit preferred-lft:0 (a DEPRECATED
+	// v6 binding). omitempty only drops a nil pointer, so a &0 still emits
+	// "preferred-lft":0 on the add path — the deprecation must reach Kea (#5073).
+	PreferredLft *int   `json:"preferred-lft,omitempty"`
+	CLTT         int64  `json:"cltt,omitempty"`   // client-last-transaction-time epoch (get)
+	Expire       int64  `json:"expire,omitempty"` // absolute expiry epoch (add)
+	State        int    `json:"state"`
+	Hostname     string `json:"hostname,omitempty"`
+	FQDNFwd      bool   `json:"fqdn-fwd,omitempty"`
+	FQDNRev      bool   `json:"fqdn-rev,omitempty"`
 }
 
 type keaLeaseGetAllArgs struct {
@@ -260,6 +293,18 @@ func keaLeaseToSync(kl keaLeaseJSON, family int, now time.Time) SyncLease {
 		rem = 0
 	}
 	l.Remaining = int(rem)
+	// #5073: preferred remaining is anchored to the SAME expire epoch as the
+	// valid remaining. Both lifetimes count from cltt, so
+	//   preferred_remaining = valid_remaining - (valid-lft - preferred-lft).
+	// A DEPRECATED lease (preferred-lft=0) yields a negative remainder that
+	// clamps to 0; a lease with preferred==valid yields exactly Remaining. When
+	// Kea reports no preferred-lft (nil — an older Kea or a v4 lease) default to
+	// preferred==valid (PreferredRemaining=Remaining), the pre-#5073 behavior.
+	if kl.PreferredLft != nil {
+		l.PreferredRemaining = clampPreferredRemaining(l.Remaining-(kl.ValidLft-*kl.PreferredLft), l.Remaining)
+	} else {
+		l.PreferredRemaining = l.Remaining
+	}
 	return l
 }
 
@@ -340,6 +385,17 @@ func readSyncLeasesViaMemfile(path string, family int, now time.Time) ([]SyncLea
 			continue
 		}
 		l.Remaining = int(rem)
+		// #5073: preferred remaining, re-anchored the SAME way as Remaining. The
+		// memfile expire epoch is cltt+valid_lifetime, so the preferred deadline
+		// is expire-valid_lifetime+pref_lifetime and
+		//   preferred_remaining = Remaining - (valid_lifetime - pref_lifetime),
+		// clamped [0, Remaining]. A DEPRECATED binding (pref_lifetime=0) floors
+		// to 0 and is not revived. When the pref_lifetime/valid_lifetime columns
+		// are absent (v4, or an old memfile) default preferred==valid.
+		l.PreferredRemaining = l.Remaining
+		if family == 6 && a.PrefLifetimeOK && a.ValidLifetime > 0 {
+			l.PreferredRemaining = clampPreferredRemaining(l.Remaining-(a.ValidLifetime-a.PrefLifetime), l.Remaining)
+		}
 		out = append(out, l)
 	}
 	return out, nil
@@ -551,6 +607,14 @@ func syncLeaseToKea(l SyncLease, now time.Time) keaLeaseJSON {
 	if l.Family == 6 {
 		kl.DUID = l.DUID
 		kl.IAID = l.IAID
+		// #5073: carry the PREFERRED remaining onto the socket add/update path so
+		// a DEPRECATED binding (PreferredRemaining=0) is seeded deprecated rather
+		// than revived. Clamp to [0, rem] (rem is the floored valid-lft) so the
+		// invariant preferred<=valid holds; the pointer emits "preferred-lft":0
+		// for a deprecated lease (omitempty only drops nil). A lease from an
+		// older peer defaults PreferredRemaining=Remaining, so preferred==valid.
+		prefRem := clampPreferredRemaining(l.PreferredRemaining, rem)
+		kl.PreferredLft = &prefRem
 		// Normalize the lease kind through the shared inverse so the socket-add
 		// path and the memfile pre-seed path agree on every type (#2268). An
 		// unknown string falls back to IA_NA, matching writeMemfile6.
@@ -768,6 +832,13 @@ func (m *Manager) writeMemfile6(path string, leases []SyncLease, now time.Time) 
 		}
 		rem := l.Remaining
 		expire := now.Unix() + int64(rem)
+		// #5073: the pref_lifetime column must carry the PREFERRED remaining, not
+		// the valid remaining. Writing `rem` here revived a DEPRECATED binding
+		// (preferred=0) as fully preferred on takeover. Clamp defensively to
+		// [0, rem] so the invariant preferred<=valid holds even if an upstream
+		// producer left PreferredRemaining unset (0 → deprecated, safe) or larger
+		// than rem (an older-peer default equals rem, so the clamp is a no-op).
+		prefRem := clampPreferredRemaining(l.PreferredRemaining, rem)
 		// Encode the v6 lease kind symmetrically with the read path
 		// (keaLeaseTypeToString) via the shared inverse so IA_NA / IA_TA / IA_PD
 		// all round-trip (#2268). An unknown string falls back to IA_NA (an
@@ -788,7 +859,7 @@ func (m *Manager) writeMemfile6(path string, leases []SyncLease, now time.Time) 
 		// state,user_context,hwtype,hwaddr_source,pool_id
 		fmt.Fprintf(&b, "%s,%s,%d,%d,%d,%d,%d,%d,%d,%s,%s,%s,%s,%d,,,,0\n",
 			csvField(l.Address), csvField(l.DUID),
-			rem, expire, l.SubnetID, rem,
+			rem, expire, l.SubnetID, prefRem,
 			leaseType, l.IAID, prefixLen,
 			boolCSV(l.FQDNFwd), boolCSV(l.FQDNRev), csvField(l.Hostname),
 			csvField(l.HWAddress), keaStateDefault)

--- a/pkg/dhcpserver/lease_sync_test.go
+++ b/pkg/dhcpserver/lease_sync_test.go
@@ -1192,3 +1192,194 @@ func TestKeaMemfileHeadersMatchKea30xSchema(t *testing.T) {
 		}
 	}
 }
+
+// TestKeaLeaseToSync_PreferredRemaining is the #5073 socket-reader guard. Kea's
+// lease6-get-all reports valid-lft AND preferred-lft; both count from cltt, so
+// the preferred remaining is anchored to the same expire as the valid remaining:
+//
+//	preferred_remaining = valid_remaining - (valid-lft - preferred-lft)
+//
+// A DEPRECATED binding (preferred-lft=0) must read PreferredRemaining=0, NOT the
+// valid remaining — reading valid revives it on takeover. When Kea omits
+// preferred-lft (nil), default preferred==valid.
+//
+// FAIL-ON-REVERT: drop the preferred-lft handling in keaLeaseToSync and the
+// deprecated case reads PreferredRemaining=Remaining (revival) → RED.
+func TestKeaLeaseToSync_PreferredRemaining(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	intp := func(n int) *int { return &n }
+	// cltt+valid-lft-now = (now-600+3600)-now = 3000 valid remaining.
+	base := keaLeaseJSON{
+		IPAddress: "2001:db8::1", DUID: "00:01:00:01", IAID: 7, Type: "IA_NA",
+		SubnetID: 1, ValidLft: 3600, CLTT: now.Unix() - 600, State: keaStateDefault,
+	}
+	cases := []struct {
+		name    string
+		prefLft *int
+		want    int
+	}{
+		{"deprecated", intp(0), 0},           // 3000 - (3600-0) = -600 -> clamp 0
+		{"partial", intp(1200), 600},         // 3000 - (3600-1200) = 600
+		{"healthy", intp(3600), 3000},        // 3000 - 0 = 3000 == Remaining
+		{"absent-defaults-valid", nil, 3000}, // no preferred-lft -> preferred==valid
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kl := base
+			kl.PreferredLft = tc.prefLft
+			l := keaLeaseToSync(kl, 6, now)
+			if l.Remaining != 3000 {
+				t.Fatalf("Remaining = %d, want 3000", l.Remaining)
+			}
+			if l.PreferredRemaining != tc.want {
+				t.Errorf("PreferredRemaining = %d, want %d", l.PreferredRemaining, tc.want)
+			}
+			if l.PreferredRemaining < 0 || l.PreferredRemaining > l.Remaining {
+				t.Errorf("invariant 0 <= PreferredRemaining(%d) <= Remaining(%d) violated",
+					l.PreferredRemaining, l.Remaining)
+			}
+		})
+	}
+}
+
+// TestGetSyncLeases6_MemfileFallback_PreferredRemaining is the #5073 memfile-
+// reader guard. The v6 memfile carries distinct valid_lifetime and pref_lifetime
+// columns; the fallback read must recover a preferred remaining that does NOT
+// revive a deprecated (pref_lifetime=0) binding. valid_lifetime=3600 with
+// expire=now+1800 means the lease aged 1800s (Remaining=1800), so:
+//   - pref_lifetime=0    -> PreferredRemaining=0    (deprecated, not revived)
+//   - pref_lifetime=2400 -> PreferredRemaining=600  (1800-(3600-2400))
+//   - pref_lifetime=3600 -> PreferredRemaining=1800 (== Remaining, healthy)
+//
+// FAIL-ON-REVERT: drop the pref_lifetime handling and every lease reads
+// PreferredRemaining=Remaining, so the deprecated row's want-0 assertion goes RED.
+func TestGetSyncLeases6_MemfileFallback_PreferredRemaining(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "kea-leases6.csv")
+	expire := strconv.FormatInt(now.Unix()+1800, 10) // Remaining = 1800 for all rows
+	csv := keaMemfileHeader6 + "\n" +
+		// address,duid,valid_lifetime,expire,subnet_id,pref_lifetime,lease_type,iaid,prefix_len,...
+		"2001:db8::dep,00:01:00:01,3600," + expire + ",1,0,0,1,128,0,0,dep,,0,,,,0\n" +
+		"2001:db8::par,00:01:00:02,3600," + expire + ",1,2400,0,2,128,0,0,par,,0,,,,0\n" +
+		"2001:db8::ok,00:01:00:03,3600," + expire + ",1,3600,0,3,128,0,0,ok,,0,,,,0\n"
+	if err := os.WriteFile(memfile, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", filepath.Join(dir, "missing.sock"), "", memfile)
+
+	leases, err := m.GetSyncLeases6(context.Background(), now)
+	if err != nil {
+		t.Fatalf("GetSyncLeases6 (fallback): %v", err)
+	}
+	byAddr := map[string]SyncLease{}
+	for _, l := range leases {
+		byAddr[l.Address] = l
+	}
+	want := map[string]int{"2001:db8::dep": 0, "2001:db8::par": 600, "2001:db8::ok": 1800}
+	for addr, wantPref := range want {
+		l, ok := byAddr[addr]
+		if !ok {
+			t.Fatalf("lease %s missing from fallback read: %+v", addr, leases)
+		}
+		if l.Remaining != 1800 {
+			t.Errorf("%s Remaining = %d, want 1800", addr, l.Remaining)
+		}
+		if l.PreferredRemaining != wantPref {
+			t.Errorf("%s PreferredRemaining = %d, want %d", addr, l.PreferredRemaining, wantPref)
+		}
+	}
+}
+
+// TestGetSyncLeases6_MemfileFallback_AbsentPrefColumnDefaultsValid confirms an
+// OLD v6 memfile that lacks the pref_lifetime column defaults preferred==valid
+// (PreferredRemaining=Remaining), never 0 — an absent column must not deprecate.
+func TestGetSyncLeases6_MemfileFallback_AbsentPrefColumnDefaultsValid(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "kea-leases6.csv")
+	expire := strconv.FormatInt(now.Unix()+1800, 10)
+	// A minimal header WITHOUT pref_lifetime / valid_lifetime (only the required
+	// columns + expire). PreferredRemaining must default to Remaining.
+	csv := "address,duid,expire,subnet_id,lease_type,iaid,prefix_len,fqdn_fwd,fqdn_rev,hostname,state\n" +
+		"2001:db8::old,00:01:00:09," + expire + ",1,0,9,128,0,0,old,0\n"
+	if err := os.WriteFile(memfile, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", filepath.Join(dir, "missing.sock"), "", memfile)
+
+	leases, err := m.GetSyncLeases6(context.Background(), now)
+	if err != nil {
+		t.Fatalf("GetSyncLeases6 (fallback): %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("want 1 lease, got %d: %+v", len(leases), leases)
+	}
+	if leases[0].Remaining != 1800 || leases[0].PreferredRemaining != 1800 {
+		t.Errorf("absent pref_lifetime column: Remaining=%d PreferredRemaining=%d, want 1800/1800",
+			leases[0].Remaining, leases[0].PreferredRemaining)
+	}
+}
+
+// TestPreSeedMemfile6_PreferredLifetime is the #5073 pre-seed-writer guard. The
+// v6 memfile pref_lifetime column (index 5) must carry PreferredRemaining, while
+// valid_lifetime (index 2) carries the valid remaining — the two lifetimes are
+// written INDEPENDENTLY. A deprecated binding (PreferredRemaining=0, Remaining=
+// 1800) must emit pref_lifetime=0 with valid_lifetime=1800; before #5073 the
+// writer substituted the valid remaining into pref_lifetime, reviving it.
+//
+// FAIL-ON-REVERT: restore `rem` (the valid remaining) in the pref_lifetime slot
+// and the deprecated row emits pref_lifetime=1800 → the want-"0" assertion RED.
+func TestPreSeedMemfile6_PreferredLifetime(t *testing.T) {
+	localNow := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile6 := filepath.Join(dir, "kea-leases6.csv")
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", "", "", memfile6)
+
+	if err := m.PreSeedMemfile6([]SyncLease{
+		{Family: 6, Address: "2001:db8::dep", DUID: "00:01:00:01", IAID: 1,
+			LeaseType: "IA_NA", SubnetID: 1, Remaining: 1800, PreferredRemaining: 0,
+			State: keaStateDefault}, // deprecated
+		{Family: 6, Address: "2001:db8::par", DUID: "00:01:00:02", IAID: 2,
+			LeaseType: "IA_NA", SubnetID: 1, Remaining: 1800, PreferredRemaining: 600,
+			State: keaStateDefault}, // partially deprecated
+		{Family: 6, Address: "2001:db8::ok", DUID: "00:01:00:03", IAID: 3,
+			LeaseType: "IA_NA", SubnetID: 1, Remaining: 1800, PreferredRemaining: 1800,
+			State: keaStateDefault}, // healthy
+	}, localNow); err != nil {
+		t.Fatalf("PreSeedMemfile6: %v", err)
+	}
+
+	raw, err := os.ReadFile(memfile6)
+	if err != nil {
+		t.Fatalf("read pre-seeded memfile: %v", err)
+	}
+	rows := map[string][]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n")[1:] {
+		f := strings.Split(line, ",")
+		rows[f[0]] = f // key by address column
+	}
+	// v6 column order: address(0),duid(1),valid_lifetime(2),expire(3),
+	// subnet_id(4),pref_lifetime(5),lease_type(6),...
+	want := map[string]struct{ valid, pref string }{
+		"2001:db8::dep": {"1800", "0"},
+		"2001:db8::par": {"1800", "600"},
+		"2001:db8::ok":  {"1800", "1800"},
+	}
+	for addr, w := range want {
+		f, ok := rows[addr]
+		if !ok {
+			t.Fatalf("row for %s missing:\n%s", addr, raw)
+		}
+		if f[2] != w.valid {
+			t.Errorf("%s valid_lifetime(col2) = %q, want %q", addr, f[2], w.valid)
+		}
+		if f[5] != w.pref {
+			t.Errorf("%s pref_lifetime(col5) = %q, want %q (independent of valid_lifetime)",
+				addr, f[5], w.pref)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (#5073)

DHCPv6 splits a binding into two independent deadlines: the **valid**
lifetime (when the lease expires) and the **preferred** lifetime (when
the client must stop originating new connections from the address). A
**deprecated** binding has `preferred=0` with a still-positive valid
lifetime.

The HA lease-sync path only carried the valid remaining
(`SyncLease.Remaining`). `writeMemfile6` substituted `rem` (valid
remaining) into the Kea `pref_lifetime` column, and the wire had no
preferred field at all. So a deprecated binding (pref=0, valid=1800)
synced as `Remaining=1800` and **takeover revived it** — the standby
seeded the address/prefix as fully preferred, drawing new flows onto an
address the network was phasing out.

Invariant enforced end-to-end: `0 <= PreferredRemaining <= Remaining`,
preserved **independently** across sync and pre-seed, re-anchored to the
receiver's local clock at seed (the #2239 clock invariant).

## Fix (Go-only, append-only wire extension — NOT a flag-day)

- **`SyncLease.PreferredRemaining`** (0 = deprecated) + `clampPreferredRemaining` `[0, Remaining]`.
- **Readers** populate it re-anchored like `Remaining`:
  - socket (`keaLeaseToSync`): `preferred-lft` added to `keaLeaseJSON` as `*int` (absent vs explicit 0); `pref_remaining = valid_remaining - (valid-lft - preferred-lft)`, clamped.
  - memfile (`readSyncLeasesViaMemfile`): recover the distinct `valid_lifetime` + `pref_lifetime` columns; same derivation. Absent columns → preferred==valid.
- **Writers** emit it independently:
  - pre-seed memfile (`writeMemfile6`): `pref_lifetime` column now carries `PreferredRemaining` (deprecated → `0`).
  - socket add/update (`syncLeaseToKea`): sends `preferred-lft`, emitting `preferred-lft:0` for a deprecated lease.
- **Wire** (`sync_protocol.go`): `PreferredRemaining` is an **append-only** `uint32` LE trailing field after the FQDN flags byte (same length-gated discipline as #3931). `decodeOneLease` advances past the flags byte, then reads it guarded by remaining length. **Backward-compat (load-bearing):** an absent trailing field (older peer) defaults to `Remaining` (preferred==valid), **NOT 0** — 0 would wrongly deprecate every lease from an old peer. **`SessionSyncWireVersion` UNCHANGED.**
- **Standby aging** (`peerDHCPLeasesAged`): `PreferredRemaining` ages by the same residence as `Remaining`, floored at 0, capped at aged `Remaining`.

## Tests (fail-on-revert, each confirmed RED on revert)

- `pkg/cluster`: deprecated lease round-trips `PreferredRemaining=0`; neutralizing encode/decode → revived (RED).
- `pkg/cluster` **backward-compat**: hand-crafted OLD-format record (no trailing field) decodes `PreferredRemaining=Remaining`, not 0; changing the decode default to 0 → RED. **Load-bearing.**
- `pkg/cluster` framing: newer longer record skipped via `recLen`, following record still decodes.
- `pkg/cluster` aging: `PreferredRemaining` ages with `Remaining`.
- `pkg/dhcpserver`: pre-seed writer emits `pref_lifetime=0`/`valid=1800` for a deprecated lease independently; socket + memfile readers populate `PreferredRemaining` (deprecated→0, partial, healthy, absent-column/absent-field default to valid).

## Validation

`go build ./...`; `go vet ./pkg/cluster/ ./pkg/dhcpserver/`; `go test -race ./pkg/cluster/ ./pkg/dhcpserver/ -count=1` — all GREEN. `pkg/daemon` lease-sync tests GREEN. `test-failover` not run (no dataplane/failover-machinery change).

## Docs

The DHCP lease-sync wire record layout is documented only in the in-code #2239 codec comment (`docs/sync-protocol.md` covers session/config sync, not the DHCP lease record fields); that comment is updated to describe the new trailing field and its non-zero default.

Closes #5073

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2F3h4kxf29m6X8BszpM5p