### PR TITLE
ha: converge peer config-sync across all commit transports (#5054)

### DIFF
--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -313,6 +313,26 @@ sender (`QueueConfig`) stamps a strictly-monotonic `gen` drawn from a
 process-wide counter seeded from `CLOCK_MONOTONIC` nanos (same cross-boot
 reasoning as the session install `genCounter`).
 
+**Commit-side trigger — transport-independent (#5054).** An operator commit
+pushes the newly-committed config to the peer regardless of which management
+transport delivered it: the gRPC, REST, and local interactive-shell commit
+handlers all route through `commitAndApplyOperator` /
+`commitConfirmedAndApplyOperator` (`pkg/daemon/daemon_apply.go`), which derive
+the push decision from **RG0 ownership** (`rg0ConfigSyncAuthority` — cluster
+configured AND this node is the RG0 config-authority primary), not from the
+transport. The same RG0-ownership rule gates the actual push in
+`syncConfigToPeer`, so a standalone / non-owner node never pushes. Before #5054
+only the gRPC handler synced; REST and the local shell passed `syncPeer=false`,
+so a REST/shell commit on a healthy cluster left the standby on the prior config
+until an unrelated transport-disconnect reverse-sync — an RG failover could then
+silently restore config the operator believed changed. The autonomous
+event-options engine is the deliberate exception: it commits with
+`syncPeer=false` because each node fires remediation independently from its own
+RPM events and must not push node-local state to the peer. There is no periodic
+config reconcile ticker — convergence is driven by the commit push plus the
+reverse-sync-on-reconnect path, so the commit-side trigger MUST fire on every
+operator transport.
+
 **Ordering guard (#3931).** Config sync historically applied via a racing
 `go OnConfigReceived` goroutine per message with no sequence number, so a rapid
 commit pair (C1 then C2) could apply out of order and leave the standby on the

--- a/pkg/daemon/configsync_transport_5054_test.go
+++ b/pkg/daemon/configsync_transport_5054_test.go
@@ -1,0 +1,171 @@
+// #5054: REST and local-shell commits skipped peer config-sync while gRPC did
+// not, so after a REST/shell commit a healthy HA cluster stayed diverged until
+// an unrelated transport-disconnect reverse-sync — an RG failover could then
+// silently restore config the operator believed changed.
+//
+// The fix makes the peer-sync decision transport-independent: all operator
+// commit paths (gRPC / REST / local shell) route through commitAndApplyOperator
+// / commitConfirmedAndApplyOperator, which derive the decision from RG0
+// ownership (rg0ConfigSyncAuthority) rather than a per-transport constant. The
+// autonomous event-options engine keeps its explicit opt-out (syncPeer=false)
+// because each node fires remediation independently from its own RPM events.
+//
+// These tests pin (1) the pure decision function across the cluster-state table
+// and (2) the behavioral outcome: an operator commit syncs the peer iff this
+// node owns RG0, a standalone / non-owner node does not, and the event-engine
+// opt-out still suppresses the sync even on an RG0 owner.
+//
+// FAIL-ON-REVERT: reverting commitAndApplyOperator (or the REST/shell wiring) to
+// pass syncPeer=false turns TestOperatorCommitSyncsPeerWhenRG0Owner /
+// TestOperatorCommitConfirmedSyncsPeerWhenRG0Owner RED (0 pushes → standby stays
+// stale). Neutralizing rg0ConfigSyncAuthority to always-false turns both the
+// owner decision-table case and those behavioral tests RED.
+package daemon
+
+import (
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// clusterOwningRG0 builds a cluster.Manager whose local node (0) owns RG0. A
+// freshly constructed manager has no live peer, so UpdateConfig's single-node
+// election promotes the sole node to RG0 primary.
+func clusterOwningRG0(t *testing.T) *cluster.Manager {
+	t.Helper()
+	m := cluster.NewManager(0, 1)
+	m.UpdateConfig(&config.ClusterConfig{
+		RethCount: 1,
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 0, NodePriorities: map[int]int{0: 200, 1: 100}},
+		},
+	})
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("test setup: expected local node to own RG0")
+	}
+	return m
+}
+
+// clusterNotOwningRG0 builds a configured cluster.Manager where the local node
+// is NOT the RG0 config authority (RG0 is absent → IsLocalPrimary(0) is false),
+// modeling a node whose peer owns the config-ownership group.
+func clusterNotOwningRG0(t *testing.T) *cluster.Manager {
+	t.Helper()
+	m := cluster.NewManager(0, 1)
+	m.UpdateConfig(&config.ClusterConfig{
+		RethCount: 1,
+		RedundancyGroups: []*config.RedundancyGroup{
+			{ID: 1, NodePriorities: map[int]int{0: 200, 1: 100}},
+		},
+	})
+	if m.IsLocalPrimary(0) {
+		t.Fatal("test setup: local node must not own RG0")
+	}
+	return m
+}
+
+// TestRG0ConfigSyncAuthorityDecision is the load-bearing pure-decision table:
+// the peer-sync policy depends ONLY on cluster/RG0 state, never on transport, so
+// gRPC/REST/shell all resolve identically for a given cluster state.
+func TestRG0ConfigSyncAuthorityDecision(t *testing.T) {
+	cases := []struct {
+		name string
+		cl   *cluster.Manager
+		want bool
+	}{
+		{"standalone-nil-cluster", nil, false},
+		{"cluster-rg0-owner", clusterOwningRG0(t), true},
+		{"cluster-non-owner", clusterNotOwningRG0(t), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rg0ConfigSyncAuthority(tc.cl); got != tc.want {
+				t.Fatalf("rg0ConfigSyncAuthority(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// newSyncProbeDaemon builds a bare daemon with a committed baseline and a staged
+// change (so a commit has a real diff), a stubbed apply body, and a
+// syncPeerForTest recorder. The returned pointer counts peer-push attempts.
+func newSyncProbeDaemon(t *testing.T, cl *cluster.Manager) (*Daemon, *int) {
+	t.Helper()
+	s := newCommitReadyStore(t, "system host-name OLD", "system host-name NEW")
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s, cluster: cl}
+	d.applyBodyForTest = func(_ *config.Config) {}
+	calls := 0
+	d.syncPeerForTest = func() { calls++ }
+	return d, &calls
+}
+
+// TestOperatorCommitSyncsPeerWhenRG0Owner: an operator commit on the RG0 owner
+// pushes the committed config to the peer exactly once — regardless of which
+// transport delivered it, since all route through commitAndApplyOperator.
+func TestOperatorCommitSyncsPeerWhenRG0Owner(t *testing.T) {
+	d, calls := newSyncProbeDaemon(t, clusterOwningRG0(t))
+
+	if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+		t.Fatalf("commitAndApplyOperator: %v", err)
+	}
+	if *calls != 1 {
+		t.Fatalf("operator commit on the RG0 owner must sync the peer exactly once (#5054); got %d", *calls)
+	}
+}
+
+// TestOperatorCommitDoesNotSyncWhenStandalone: on a non-cluster node the
+// operator commit path must not attempt a peer push.
+func TestOperatorCommitDoesNotSyncWhenStandalone(t *testing.T) {
+	d, calls := newSyncProbeDaemon(t, nil)
+
+	if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+		t.Fatalf("commitAndApplyOperator: %v", err)
+	}
+	if *calls != 0 {
+		t.Fatalf("operator commit on a standalone node must NOT sync a peer; got %d pushes", *calls)
+	}
+}
+
+// TestOperatorCommitDoesNotSyncWhenNonOwner: a clustered node that does not own
+// RG0 must not push (the RG0 owner is the config authority).
+func TestOperatorCommitDoesNotSyncWhenNonOwner(t *testing.T) {
+	d, calls := newSyncProbeDaemon(t, clusterNotOwningRG0(t))
+
+	if _, err := d.commitAndApplyOperator(t.Context(), ""); err != nil {
+		t.Fatalf("commitAndApplyOperator: %v", err)
+	}
+	if *calls != 0 {
+		t.Fatalf("operator commit on a non-RG0-owner must NOT sync a peer; got %d pushes", *calls)
+	}
+}
+
+// TestEventEngineCommitDoesNotSyncEvenWhenRG0Owner pins the autonomous
+// event-options opt-out: the engine commits with syncPeer=false directly, so
+// even on an RG0 owner it must NOT push its node-local remediation to the peer.
+func TestEventEngineCommitDoesNotSyncEvenWhenRG0Owner(t *testing.T) {
+	d, calls := newSyncProbeDaemon(t, clusterOwningRG0(t))
+
+	// The shape initEventEngine wires: commitAndApply with syncPeer=false.
+	if _, err := d.commitAndApply(t.Context(), "", false); err != nil {
+		t.Fatalf("commitAndApply(false): %v", err)
+	}
+	if *calls != 0 {
+		t.Fatalf("the event-engine opt-out (syncPeer=false) must NOT sync the peer even on an RG0 owner; got %d pushes", *calls)
+	}
+}
+
+// TestOperatorCommitConfirmedSyncsPeerWhenRG0Owner: the commit-confirmed
+// operator path syncs the peer on the RG0 owner, same policy as plain commit.
+func TestOperatorCommitConfirmedSyncsPeerWhenRG0Owner(t *testing.T) {
+	d, calls := newSyncProbeDaemon(t, clusterOwningRG0(t))
+
+	if _, err := d.commitConfirmedAndApplyOperator(t.Context(), 1); err != nil {
+		t.Fatalf("commitConfirmedAndApplyOperator: %v", err)
+	}
+	if *calls != 1 {
+		t.Fatalf("operator commit-confirmed on the RG0 owner must sync the peer exactly once (#5054); got %d", *calls)
+	}
+}

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -529,6 +529,39 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 	return d.applyAndSyncCommitted(oldActive, compiled, syncPeer)
 }
 
+// commitAndApplyOperator is the peer-sync-aware entry point for an
+// OPERATOR-initiated plain commit. The gRPC, REST, and local interactive-shell
+// commit handlers ALL route through it (#5054), so the peer-sync decision is
+// made in one place and no longer depends on which management transport
+// delivered the commit. It derives the decision from RG0 ownership
+// (rg0ConfigSyncAuthority) — the same rule the push site (syncConfigToPeer)
+// applies — so a commit that changes the shared firewall intent converges on
+// the cluster peer regardless of the transport.
+//
+// Before #5054 only the gRPC handler passed syncPeer=true; REST and the local
+// shell passed false, so a REST/shell commit on a healthy cluster left the
+// standby on the PRIOR config until an unrelated transport-disconnect
+// reverse-sync — an RG failover could then silently restore config the operator
+// believed changed. Because the RG0-ownership gate makes the push a no-op on a
+// standalone / non-owner node (identical to syncConfigToPeer's gate), the only
+// behavior change is that REST and shell commits now converge the peer exactly
+// as gRPC always did.
+//
+// The autonomous event-options engine deliberately does NOT use this wrapper: it
+// commits with syncPeer=false (commitAndApply directly, see initEventEngine)
+// because each node fires its remediation independently from that node's local
+// RPM events and must not push node-local state to the peer.
+func (d *Daemon) commitAndApplyOperator(ctx context.Context, comment string) (*config.Config, error) {
+	return d.commitAndApply(ctx, comment, rg0ConfigSyncAuthority(d.cluster))
+}
+
+// commitConfirmedAndApplyOperator is the commit-confirmed analogue of
+// commitAndApplyOperator: the same transport-independent RG0-ownership peer-sync
+// policy for an operator-initiated `commit confirmed` (#5054).
+func (d *Daemon) commitConfirmedAndApplyOperator(ctx context.Context, minutes int) (*config.Config, error) {
+	return d.commitConfirmedAndApply(ctx, minutes, rg0ConfigSyncAuthority(d.cluster))
+}
+
 // executeConfirmedRollback is the daemon-owned commit-confirmed timeout
 // rollback transaction (#1922 Item 1a). The configstore confirm timer
 // fires this (via SetRollbackExecutor) on its own goroutine, NOT under

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -307,14 +307,34 @@ func (d *Daemon) bulkSyncViaEventStreamOrFallback(ss *cluster.SessionSync) error
 	return ss.BulkSync()
 }
 
-// syncConfigToPeer sends the active config to the cluster peer if this node
-// is primary and config sync is enabled.
+// rg0ConfigSyncAuthority is the SINGLE, transport-independent rule for whether
+// this node should push its committed config to the cluster peer (#5054): the
+// node must be the RG0 (config-ownership group) PRIMARY of a configured cluster.
+// It depends only on cluster/RG0 state — never on which management transport
+// (gRPC, REST, or the local interactive shell) delivered the commit — so every
+// operator commit path resolves the peer-sync decision identically and the two
+// nodes cannot diverge by transport.
+//
+// A nil manager (a standalone, non-cluster node) is never an authority, so a
+// standalone node never attempts a peer push. Kept as a small pure function so
+// the decision is unit-testable in isolation and is reused by BOTH the operator
+// commit entry points (commitAndApplyOperator / commitConfirmedAndApplyOperator)
+// and the actual push site (syncConfigToPeer below), so the attempt-time and
+// push-time gates cannot drift.
+func rg0ConfigSyncAuthority(cl *cluster.Manager) bool {
+	return cl != nil && cl.IsLocalPrimary(0)
+}
+
+// syncConfigToPeer sends the active config to the cluster peer if this node is
+// the RG0 config-sync authority and config sync is enabled.
 func (d *Daemon) syncConfigToPeer() {
-	if d.cluster == nil || d.sessionSync == nil {
+	if d.sessionSync == nil {
 		return
 	}
-	// Only sync if this node is primary for RG0 (config ownership group).
-	if !d.cluster.IsLocalPrimary(0) {
+	// Only sync if this node is the RG0 (config ownership group) primary — the
+	// same rule the operator commit entry points use to decide whether to
+	// attempt a push (#5054).
+	if !rg0ConfigSyncAuthority(d.cluster) {
 		return
 	}
 	d.pushConfigToPeer()

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -718,13 +718,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 		shell.SetApplyConfigFn(d.applyConfig)
 		shell.SetCommitFns(
 			func(ctx context.Context, comment string) (*config.Config, error) {
-				// In-process CLI commits don't sync to peer (the
-				// CLI is local; preserves prior per-transport
-				// behavior, same as HTTP).
-				return d.commitAndApply(ctx, comment, false)
+				// #5054: in-process CLI commits sync to the peer on
+				// the SAME RG0-ownership policy as gRPC/REST — peer
+				// convergence is transport-independent, decided in
+				// commitAndApplyOperator, not by which API committed.
+				return d.commitAndApplyOperator(ctx, comment)
 			},
 			func(ctx context.Context, minutes int) (*config.Config, error) {
-				return d.commitConfirmedAndApply(ctx, minutes, false)
+				return d.commitConfirmedAndApplyOperator(ctx, minutes)
 			},
 		)
 		shell.SetRPMResultsFn(func() []*rpm.ProbeResult {
@@ -1206,14 +1207,17 @@ func (d *Daemon) startGRPCServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		// #2464: per-collector NetFlow v9 / IPFIX write-health for
 		// `show services flow-monitoring statistics`.
 		FlowCollectorHealthFn: d.FlowCollectorHealth,
-		// gRPC commits sync to cluster peer atomically inside
+		// gRPC commits sync to the cluster peer atomically inside
 		// the apply lock so the peer can never observe an apply
-		// that hasn't yet been propagated.
+		// that hasn't yet been propagated. #5054: the RG0-ownership
+		// peer-sync decision now lives in commitAndApplyOperator,
+		// shared with the REST and local-shell commit paths so every
+		// transport converges identically.
 		CommitFn: func(ctx context.Context, comment string) (*config.Config, error) {
-			return d.commitAndApply(ctx, comment, true)
+			return d.commitAndApplyOperator(ctx, comment)
 		},
 		CommitConfirmedFn: func(ctx context.Context, minutes int) (*config.Config, error) {
-			return d.commitConfirmedAndApply(ctx, minutes, true)
+			return d.commitConfirmedAndApplyOperator(ctx, minutes)
 		},
 		// #5281: a gRPC zeroize runs the wipe under the SAME apply gate as
 		// commit/sync and enters a terminal reset generation so no concurrent
@@ -1295,13 +1299,16 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		IPsec:    d.ipsec,
 		DHCP:     d.dhcp,
 		VRRPMgr:  d.vrrpMgr,
-		// HTTP commits don't sync to peer (preserves prior
-		// behavior; see #846 for follow-up).
+		// #5054: HTTP/REST commits sync to the peer on the SAME
+		// RG0-ownership policy as gRPC/local-shell. Peer convergence
+		// is transport-independent (decided in commitAndApplyOperator),
+		// so a REST commit no longer leaves the standby on stale config
+		// until an unrelated transport-disconnect reverse-sync.
 		CommitFn: func(ctx context.Context, comment string) (*config.Config, error) {
-			return d.commitAndApply(ctx, comment, false)
+			return d.commitAndApplyOperator(ctx, comment)
 		},
 		CommitConfirmedFn: func(ctx context.Context, minutes int) (*config.Config, error) {
-			return d.commitConfirmedAndApply(ctx, minutes, false)
+			return d.commitConfirmedAndApplyOperator(ctx, minutes)
 		},
 		// #758: surface compile state so /health returns 503
 		// when the dataplane has never compiled successfully.


### PR DESCRIPTION
## Summary

In an HA chassis cluster the committed config generation must converge on both nodes regardless of which management transport committed it. It did not: the **gRPC** commit handler passed `syncPeer=true`, but the **REST** and **local interactive-shell** handlers passed `false`. Because `pushCommittedConfigToPeer` is invoked only from the commit paths (there is **no periodic reconcile ticker**), a REST or shell commit on a healthy cluster left the standby on the prior config until an unrelated transport-disconnect reverse-sync. An RG failover could then promote a peer still on the old config and silently restore a policy/setting the operator believed changed.

## Fix shape chosen: **unify to the gRPC policy** (guards already sufficient)

`syncConfigToPeer` **already self-gates** — it no-ops unless the node is cluster-enabled, owns **RG0** (the config-ownership group), and has config-sync enabled. So gRPC's blanket `true` was safe *because the push self-gates*. This is the "internal guards already sufficient" case, so the fix unifies the transports onto that same policy rather than adding a new gate — **and removes the per-transport hardcoded boolean** so the transport no longer decides:

- Extract the RG0-ownership rule into the pure, transport-independent **`rg0ConfigSyncAuthority(cl)`** (cluster configured **AND** this node is the RG0 primary) and route `syncConfigToPeer` through it, so the attempt-time and push-time gates cannot drift.
- Add **`commitAndApplyOperator` / `commitConfirmedAndApplyOperator`**, which derive `syncPeer` from `rg0ConfigSyncAuthority(d.cluster)`. The gRPC, REST, and local-shell commit + commit-confirmed handlers all route through them. A standalone / non-owner node is a no-op (identical to the push-time gate), so the only behavior change is that **REST and shell commits now converge the peer exactly as gRPC always did**.

### Why not remove the boolean entirely / add a reconcile ticker

The **autonomous event-options engine** deliberately commits with `syncPeer=false` (`initEventEngine`) because each node fires remediation independently from its own local RPM events and must **not** push node-local state to the peer. That opt-out is preserved (it calls `commitAndApply` directly, not the operator wrapper). A periodic reconcile ticker is explicitly **out of scope** (separate enhancement).

Deriving the operator decision at commit time is safe against an ownership race because `syncConfigToPeer` re-checks RG0 ownership at push time; the wrapper decision only controls whether a push is *attempted*. The wire protocol of `pushCommittedConfigToPeer` is unchanged — this is about *which* commit paths invoke it.

## Peer-sync outcome surfacing

`syncConfigToPeer`/`pushConfigToPeer` already log and no-op on a non-authority node. A **structured per-commit sync-debt field in the REST/gRPC response is noted as a follow-up** — it would touch the CLI/gRPC/REST response plumbing and would balloon this diff, so it is intentionally deferred.

## Tests (`pkg/daemon`)

- **Pure decision table** for `rg0ConfigSyncAuthority`: standalone(nil)→false, RG0-owner→true, non-owner→false (transport-independent — all operator transports resolve identically for a given cluster state).
- **Behavioral** via the existing `syncPeerForTest` seam: an operator commit and commit-confirmed sync the peer **exactly once on the RG0 owner**, a **standalone** and a **non-owner** node do **not**, and the **event-engine opt-out** still suppresses the sync even on an owner.

**Fail-on-revert:** restoring the operator wrappers to `syncPeer=false` turns `TestOperatorCommitSyncsPeerWhenRG0Owner` and `TestOperatorCommitConfirmedSyncsPeerWhenRG0Owner` **RED** (0 pushes → standby stays stale). Neutralizing `rg0ConfigSyncAuthority` to always-false turns the owner decision-table case and those behavioral tests RED. *(Both proven locally.)*

## Validation

- `go build ./...`
- `go vet ./pkg/daemon/`
- `go test -race ./pkg/daemon/ -count=1` — all green (17s)

Control-plane HA config-sync path only (Go, no dataplane/cargo change). `test-failover` is a **no-regression** check handled at review. `docs/sync-protocol.md` updated to state the commit-side trigger is transport-independent (RG0-ownership-driven).

Closes #5054

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AghGi5P31fYXD4cfgCHPxc