### PR TITLE
api: report partial counts on non-atomic clear-all

### DIFF
--- a/cmd/cli/clear.go
+++ b/cmd/cli/clear.go
@@ -226,6 +226,16 @@ func (c *ctl) handleClearSecurity(args []string) error {
 			return fmt.Errorf("%v", err)
 		}
 		fmt.Printf("%d IPv4 and %d IPv6 session entries cleared\n", resp.Ipv4Cleared, resp.Ipv6Cleared)
+		// #5882: clear is non-atomic (chunked v4-then-v6 + peer clear), so the
+		// backend reports partial-failure detail via Failures/FailureSummary
+		// with an OK RPC status rather than a hard error. Surface it here or the
+		// operator reads "N cleared" and a nil error as full success while some
+		// entries were never removed (a visible-error -> silent-success gap on
+		// both the clear-all and filtered paths). Mirrors the local CLI
+		// (pkg/cli/cli_clear.go).
+		if resp.Failures > 0 {
+			fmt.Printf("warning: %d failure(s) during clear: %s\n", resp.Failures, resp.FailureSummary)
+		}
 		return nil
 
 	case "policies":

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -811,9 +811,23 @@ func (s *Server) clearSessionsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
+	// Chunked clear-all is NON-atomic (#5882): ClearAllSessions clears the
+	// IPv4 table then the IPv6 table, so a failure can leave IPv4 already
+	// deleted while returning PARTIAL v4/v6 counts alongside the error.
+	// Surface those counts (with a Failures>0 / FailureSummary marker)
+	// instead of discarding them behind a bare HTTP 500 — mirroring the
+	// gRPC ClearSessions clear-all branch and the HA-delegated path above,
+	// so an operator learns what was actually revoked and whether a retry
+	// need only target the unfinished family.
 	v4, v6, err := s.dp.ClearAllSessions()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeOK(w, ClearSessionsResult{
+			IPv4Cleared:    v4,
+			IPv6Cleared:    v6,
+			NodeID:         s.nodeID(),
+			Failures:       1,
+			FailureSummary: "clear-all: " + err.Error(),
+		})
 		return
 	}
 	writeOK(w, ClearSessionsResult{IPv4Cleared: v4, IPv6Cleared: v6, NodeID: s.nodeID()})

--- a/pkg/api/sessions_clear_partial_5882_test.go
+++ b/pkg/api/sessions_clear_partial_5882_test.go
@@ -1,0 +1,69 @@
+// #5882: the REST session-clear endpoint's local-only fallback drives a
+// chunked clear-all (ClearAllSessions) that is NON-atomic — it clears the IPv4
+// table then the IPv6 table, so a failure can leave IPv4 already deleted while
+// returning PARTIAL v4/v6 counts alongside the error. The fallback must surface
+// those partial counts (HTTP 200 body with Failures>0 / FailureSummary) rather
+// than discarding them behind a bare HTTP 500, mirroring the gRPC clear-all
+// branch and the HA-delegated path.
+//
+// FAIL-ON-REVERT: restoring `writeError(w, 500, err.Error())` makes the request
+// return 500 with no body counts, flipping the want-200 / partial-count / non-
+// empty-failure-summary assertions RED.
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// clearAllPartialDP returns partial counts + an error, modeling a chunked
+// clear-all that cleared IPv4 then failed clearing IPv6.
+type clearAllPartialDP struct {
+	*dataplane.Manager
+}
+
+func (d *clearAllPartialDP) IsLoaded() bool { return true }
+func (d *clearAllPartialDP) ClearAllSessions() (int, int, error) {
+	return 4, 0, fmt.Errorf("ipv6 chunk delete EIO")
+}
+
+func TestRESTClearSessionsPartialCountsSurvive(t *testing.T) {
+	// clusterSessionFn unset -> clusterSession() nil -> the local-only
+	// ClearAllSessions fallback (the path #5882 fixes).
+	dp := &clearAllPartialDP{Manager: dataplane.New()}
+	s := &Server{dp: dp}
+
+	rr := httptest.NewRecorder()
+	s.clearSessionsHandler(rr, httptest.NewRequest("POST", "/api/v1/security/sessions/clear", nil))
+
+	// #5882: a partial clear-all is a reported partial success (200), not a
+	// bare 500 that discards what was actually revoked.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("clear status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	// writeOK wraps the payload in {"success":true,"data":{...}}.
+	var env struct {
+		Data ClearSessionsResult `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode body %q: %v", rr.Body.String(), err)
+	}
+	got := env.Data
+	if got.IPv4Cleared != 4 {
+		t.Fatalf("IPv4Cleared=%d, want 4 (V4 cleared before V6 failed)", got.IPv4Cleared)
+	}
+	if got.IPv6Cleared != 0 {
+		t.Fatalf("IPv6Cleared=%d, want 0", got.IPv6Cleared)
+	}
+	if got.Failures == 0 {
+		t.Fatalf("clear-all failure not reported: Failures=0, summary=%q", got.FailureSummary)
+	}
+	if got.FailureSummary == "" {
+		t.Fatalf("empty FailureSummary on a partial clear-all failure")
+	}
+}

--- a/pkg/grpcapi/clear_sessions_all_partial_5882_test.go
+++ b/pkg/grpcapi/clear_sessions_all_partial_5882_test.go
@@ -1,0 +1,93 @@
+// #5882: the chunked clear-ALL path (ClearAllSessions -> clearSessionsChunkedV4
+// then …V6) is NON-atomic — a V6-phase failure can leave IPv4 already fully
+// deleted, and ClearAllSessions returns the PARTIAL v4/v6 counts alongside the
+// error. The gRPC ClearSessions clear-all branch must surface those partial
+// counts via the response Ipv4Cleared/Ipv6Cleared + Failures/FailureSummary
+// (the same partial-success contract the FILTERED path already honors, #2468)
+// instead of discarding them behind a bare RPC error.
+//
+// FAIL-ON-REVERT: restoring the old `return nil, status.Errorf(...)` makes the
+// partial-failure test get a nil response + bare error (counts lost), flipping
+// its "want a response, not a bare error" and count/Failures assertions RED.
+package grpcapi
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// clearAllPartialDP is a minimal grpcRuntime fake for the clear-ALL branch: it
+// embeds *dataplane.Manager to satisfy the rest of the interface and overrides
+// only IsLoaded + ClearAllSessions so a test can inject the partial counts +
+// error a mid-operation chunked clear returns.
+type clearAllPartialDP struct {
+	*dataplane.Manager
+	v4  int
+	v6  int
+	err error
+}
+
+func (d *clearAllPartialDP) IsLoaded() bool { return true }
+
+func (d *clearAllPartialDP) ClearAllSessions() (int, int, error) {
+	return d.v4, d.v6, d.err
+}
+
+// allReq is a parameterless request -> the clear-ALL branch of ClearSessions.
+func allReq() *pb.ClearSessionsRequest { return &pb.ClearSessionsRequest{} }
+
+// A clear-all that deleted IPv4 then failed clearing IPv6 must return a
+// RESPONSE carrying the partial counts + a Failures>0 marker, not a bare error.
+func TestClearSessionsRPCClearAllPartialCountsSurvive(t *testing.T) {
+	dp := &clearAllPartialDP{
+		Manager: dataplane.New(),
+		v4:      7, // IPv4 table fully cleared before the IPv6 phase failed
+		v6:      0,
+		err:     fmt.Errorf("ipv6 chunk delete EIO"),
+	}
+	s := newClearServer(t, dp)
+	resp, err := s.ClearSessions(context.Background(), allReq())
+	// #5882: partial clear-all is reported via the response, never a bare error.
+	if err != nil {
+		t.Fatalf("ClearSessions returned a bare error, want a response: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("nil response on partial clear-all")
+	}
+	if resp.Ipv4Cleared != 7 {
+		t.Fatalf("Ipv4Cleared=%d, want 7 (V4 fully deleted before V6 failed)", resp.Ipv4Cleared)
+	}
+	if resp.Ipv6Cleared != 0 {
+		t.Fatalf("Ipv6Cleared=%d, want 0", resp.Ipv6Cleared)
+	}
+	if resp.Failures == 0 {
+		t.Fatalf("clear-all failure not reported: Failures=0, summary=%q", resp.FailureSummary)
+	}
+	if resp.FailureSummary == "" {
+		t.Fatalf("empty FailureSummary on a partial clear-all failure")
+	}
+}
+
+// The err==nil clear-all path is unchanged: Failures==0 and the exact counts.
+func TestClearSessionsRPCClearAllSuccessNoFailures(t *testing.T) {
+	dp := &clearAllPartialDP{
+		Manager: dataplane.New(),
+		v4:      5,
+		v6:      3,
+	}
+	s := newClearServer(t, dp)
+	resp, err := s.ClearSessions(context.Background(), allReq())
+	if err != nil {
+		t.Fatalf("ClearSessions unexpected RPC error: %v", err)
+	}
+	if resp.Failures != 0 {
+		t.Fatalf("success clear-all reported Failures=%d summary=%q, want 0", resp.Failures, resp.FailureSummary)
+	}
+	if resp.Ipv4Cleared != 5 || resp.Ipv6Cleared != 3 {
+		t.Fatalf("counts v4=%d v6=%d, want 5/3", resp.Ipv4Cleared, resp.Ipv6Cleared)
+	}
+}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -1097,13 +1097,19 @@ func (s *Server) ClearSessions(ctx context.Context, req *pb.ClearSessionsRequest
 		req.Application == "" && req.Interface == "" &&
 		!req.NatOnly && req.SourceNatPool == "" {
 		v4, v6, err := s.dp.ClearAllSessions()
-		if err != nil {
-			// Bulk clear-all is atomic in the dataplane: a failure means
-			// nothing was reliably cleared, so this stays a hard RPC error
-			// rather than a partial-success count.
-			return nil, status.Errorf(codes.Internal, "%v", err)
-		}
 		var agg clearErrors
+		// Chunked clear-all is NON-atomic (#5882): ClearAllSessions walks and
+		// deletes the IPv4 table, THEN the IPv6 table (clearSessionsChunkedV4
+		// then …V6 in maps_session.go), so a V6-phase failure can leave IPv4
+		// already fully deleted. ClearAllSessions returns the PARTIAL v4/v6
+		// counts alongside the error, so surface them via the response
+		// Failures / FailureSummary instead of discarding them behind a bare
+		// RPC error — EXACTLY as the filtered clear path below does. An
+		// operator/monitor then learns what was actually revoked (e.g. IPv4
+		// cleared, IPv6 failed → retry only IPv6) instead of "0 cleared + hard
+		// error". agg.add ignores a nil err, so the success path is unchanged
+		// (Failures==0, accurate counts).
+		agg.add("clear-all", err)
 		if !forwarded {
 			agg.add("peer clear", s.clearPeerSessions(req))
 		}


### PR DESCRIPTION
## Problem (#5882)

The chunked clear-all path is **not atomic**: `ClearAllSessions` ->
`ClearAllSessionsChunked` (`pkg/dataplane/maps_session.go`) clears the
IPv4 table, then the IPv6 table, so a V6-phase failure can leave IPv4
already fully deleted. It already returns the partial `v4`/`v6` counts
alongside the error. Both API handlers threw those counts away on error:

- **gRPC** `ClearSessions` clear-all branch returned a bare
  `status.Errorf(codes.Internal, ...)` and carried a **false** comment
  claiming the op is atomic and "nothing was reliably cleared". Operators
  and monitoring saw *0 cleared + hard error* even when the whole IPv4
  table was in fact revoked — they couldn't tell what to retry.
- **REST** local-only fallback (`pkg/api/sessions.go`) returned a bare
  HTTP 500 with `err.Error()`, dropping the counts.

## Fix (reporting only — no proto change)

`ClearSessionsResponse` / `ClearSessionsResult` already carry
`failures` + `failure_summary` (#2468), and the **filtered** clear path
already reports partial sub-operation failures via a `clearErrors` agg +
`agg.apply(resp)`. This mirrors that exact pattern in the clear-all path.

**Sites touched:**
1. **gRPC clear-all branch** (`pkg/grpcapi/server_sessions.go`): record the
   clear-all error into the same `clearErrors` agg
   (`agg.add("clear-all", err)`), still run the peer clear when not
   forwarded, build the response with the partial `Ipv4Cleared`/`Ipv6Cleared`
   counts, `agg.apply(resp)`, return `resp, nil`. `agg.add` ignores a nil
   error, so the `err==nil` success path is **unchanged** (Failures==0,
   exact counts). The false "atomic" comment is replaced with an accurate
   non-atomic note citing #5882.
2. **REST** (`pkg/api/sessions.go`): the **HA-delegated path already proxies**
   the gRPC `ClearSessionsResponse` (counts + failures + failure_summary), so
   the fixed gRPC response now flows through it unchanged. The **local-only
   fallback** now emits HTTP 200 `ClearSessionsResult` with the partial
   counts + `Failures=1` + a `clear-all: <err>` summary instead of a bare 500.
3. **ClearAllSessions wrapper** (`pkg/dataplane/maps_session.go`): already
   threads the partial counts through on error — **no change needed**.

Dataplane deletion semantics (chunked, cooperative — #4719/#5304) are
**unchanged**. This is purely about reporting the partial result.

## Fail-on-revert tests
- `pkg/grpcapi/clear_sessions_all_partial_5882_test.go`: a fake whose
  `ClearAllSessions` returns partial counts (v4=7, v6=0) + a non-nil error
  asserts the RPC returns a **response** (not a bare error) with
  `Ipv4Cleared=7`, `Ipv6Cleared=0`, `Failures>0`, non-empty
  `FailureSummary`. **Restoring the old `return nil, status.Errorf(...)`
  turns it RED** (nil response + bare error, counts lost). A success-path
  test (err==nil) still returns `Failures==0` with the exact counts.
- `pkg/api/sessions_clear_partial_5882_test.go`: the REST local-only
  fallback with a partial+err fake asserts HTTP 200 + partial counts +
  `Failures>0` + non-empty `FailureSummary`. **Restoring the old bare-500
  turns it RED.**

Both RED-on-revert transitions were verified live.

## Validation
`go build ./...`; `go vet ./pkg/grpcapi/ ./pkg/api/`;
`go test -race ./pkg/grpcapi/ ./pkg/api/ -count=1` — all green.

## Docs
No markdown doc documents the clear-sessions endpoint field semantics; the
contract lives in the `ClearSessionsResult` / `clearErrors` Go doc comments,
which stay accurate. No separate doc change.

Closes #5882

🤖 Generated with [Claude Code](https://claude.com/claude-code)