### PR TITLE
config: validate cross-subsystem interface .unit references (#5933)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -339,15 +339,50 @@ The fix is fail-CLOSED at two layers, both keyed to one canonical validator
   deterministic warning instead of a silent drop.
 
 Valid numeric units (including the `0` and `16385` boundaries) compile
-bit-identically and reach the typed `ifc.Units` map. RESIDUAL: this pass types
-the `interfaces <if> unit <n>` slot; the cross-subsystem unit-reference grammar
-(class-of-service / security-zone / routing-instance interface references that
-carry a `.unit` suffix) still parses the suffix without this validator and is a
-follow-up (issue #5829 "every unit-reference slot"). Covered by
+bit-identically and reach the typed `ifc.Units` map. This pass types the
+`interfaces <if> unit <n>` slot; the cross-subsystem `.unit`-reference grammar is
+closed by #5933 (below). Covered by
 `pkg/config/interface_unit_nonnumeric_5829_test.go` (strict reject via both
 gates naming the interface + token, valid-unit-reaches-map, lenient
 warn-and-quarantine), RED on revert of either the `keyValidator` or the compiler
 gate.
+
+### Cross-subsystem interface `.unit`-reference validation (#5933)
+
+The residual #5829 deferred: three subsystems reference an interface by a
+`<if>.<unit>` string (NOT the `interfaces <if> unit <n>` instance key), and each
+parsed the `.unit` suffix WITHOUT `ValidateLogicalUnit`:
+
+- **class-of-service** — `class-of-service interfaces <if>.<unit>` (the shaper /
+  classifier binding; the reference is the `cos.Interfaces` map key);
+- **security-zone membership** — `security zones security-zone <z> interfaces
+  <if>.<unit>` (`zone.Interfaces`);
+- **routing-instance membership** — `routing-instances <ri> interface
+  <if>.<unit>` (`ri.Interfaces`; the route-leak / VRF member split is
+  `strings.Cut` + `strconv.Atoi` with a bare `continue` on error).
+
+None fail-open a firewall FILTER (filters bind only inside the now-gated
+`interfaces <if> unit <n>` loop — materiality confirmed lower than #5829's core
+in the #5932 review), but a malformed `.unit` there silently **mis-binds**: the
+CoS shaper never attaches, the zone-membership key never matches a configured
+unit, the route-leak member is dropped — a committed reference that carries no
+effect.
+
+The fix (`validateInterfaceUnitReferencesStrict`, `compiler_validate_strict_unitref.go`,
+dispatched from `runUniformGates` after the zone-interface-defined gate) routes
+every `.unit` suffix through the SAME canonical `ValidateLogicalUnit`, splitting
+on the FIRST `.` exactly as each subsystem's runtime does so schema acceptance
+matches runtime binding. A bare interface (no `.`) or a trailing-dot bare form
+(`base.`) carries no unit and is skipped. Strict on commit / commit-check
+(hard-reject); the `lenientInterfaceUnitRef` opt downgrades it to a `cfg.Warnings`
+entry on the tolerant load / peer-sync paths (#1960 no-brick — the runtime already
+ignores an unresolvable `.unit` suffix, so a leniently-loaded malformed reference
+is inert). This is a compiler-layer gate only: unlike #5829's dedicated numeric
+`unit` instance key, the interface-name token here is a free wildcard (legitimately
+bare OR unit-qualified), so a schema `keyValidator` would over-reject bare names.
+Covered by `pkg/config/interface_unit_ref_5933_test.go` (per-subsystem strict
+reject naming the subsystem + bad token, valid-unit accepted, bare-interface
+accepted, lenient warn), each subsystem independently RED on revert.
 
 ### security address-book same-name `address` + `address-set` collision (#5676)
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1897,6 +1897,19 @@ type compileOpts struct {
 	// paths anyway).
 	lenientNonNumericUnit bool
 
+	// lenientInterfaceUnitRef (#5933) downgrades the cross-subsystem interface
+	// `.unit`-suffix reference gate (a malformed logical unit in a
+	// class-of-service / security-zone / routing-instance interface reference)
+	// from a hard compile error to a cfg.Warnings entry. Strict commit /
+	// commit-check hard-reject so a malformed `.unit` reference cannot commit and
+	// then silently mis-bind (the CoS shaper never attaches, the zone-membership
+	// key never matches, the route-leak member is dropped). Set ONLY on the
+	// tolerant load / peer-sync paths so a config an older binary already
+	// persisted — which silently ignored the bad reference — still BOOTS, now
+	// with a deterministic warning. Same doctrine as lenientNonNumericUnit
+	// (#5829); this closes the residual #5829 deferred to #5933.
+	lenientInterfaceUnitRef bool
+
 	// nodeAware / stampNodeID (#4329) carry the runtime cluster node
 	// identity (from /etc/xpf/node-id, or `-node-id` on `xpfd
 	// check-config`) into compileExpanded so it can be stamped onto the
@@ -2049,6 +2062,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,
 		lenientNonNumericUnit:                  true,
+		lenientInterfaceUnitRef:                true,
 	})
 }
 
@@ -2405,6 +2419,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFirewallTCPFlags:                true,
 		lenientCoSNumericCodePoint:             true,
 		lenientNonNumericUnit:                  true,
+		lenientInterfaceUnitRef:                true,
 	})
 }
 

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -490,6 +490,26 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5933 cross-subsystem interface `.unit`-suffix reference gate. Strict on
+	// commit / commit-check (hard-reject a class-of-service / security-zone /
+	// routing-instance interface reference whose `.unit` suffix is non-numeric /
+	// negative / out of range — such a reference silently MIS-BINDS: the CoS
+	// shaper never attaches, the zone-membership key never matches a real unit,
+	// the route-leak member is dropped). Lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960 no-brick; the
+	// runtime already ignores an unresolvable `.unit` suffix, so a leniently-
+	// loaded malformed reference is inert). Routes every reference through the
+	// same canonical ValidateLogicalUnit #5829 introduced for the `interfaces
+	// <if> unit <n>` instance key, closing the residual #5829 deferred to #5933.
+	if err := validateInterfaceUnitReferencesStrict(cfg); err != nil {
+		if opts.lenientInterfaceUnitRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("interface unit reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #3200 host-inbound-traffic token gate. Strict on commit / commit-check
 	// (hard-reject an unknown/typo system-services or protocols token that
 	// would commit but enforce inconsistently — nft kernel mirror fails OPEN

--- a/pkg/config/compiler_validate_strict_unitref.go
+++ b/pkg/config/compiler_validate_strict_unitref.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validateInterfaceUnitReferencesStrict hard-rejects a cross-subsystem interface
+// reference whose `.<unit>` suffix is not a valid logical unit — the residual
+// #5829 deferred to #5933.
+//
+// #5829/#5932 typed the `interfaces <if> unit <n>` INSTANCE key (schema
+// keyValidator ValidateLogicalUnit + a compiler defense-in-depth) so a
+// non-numeric / negative / out-of-range logical unit is rejected at commit
+// instead of silently dropping the whole unit — a unit-level firewall filter had
+// been committing with no enforcement (fail-open). But the cross-subsystem
+// interface REFERENCES that carry a `.unit` SUFFIX still parsed the suffix
+// WITHOUT ValidateLogicalUnit:
+//
+//   - class-of-service interfaces <if>.<unit>                    (CoS shaper/classifier binding)
+//   - security zones security-zone <z> interfaces <if>.<unit>   (zone membership)
+//   - routing-instances <ri> interface <if>.<unit>              (VRF membership / route-leak)
+//
+// None of these fail-open a firewall FILTER (filters bind only inside the now-
+// gated `interfaces <if> unit <n>` loop of compiler_interfaces.go — confirmed in
+// the #5932 review), so materiality is lower than #5829's core. But a malformed
+// `.unit` suffix here silently MIS-BINDS: the CoS shaper never attaches to a real
+// unit, a zone-membership key never matches a configured unit
+// (buildInterfaceZoneMap), and the routing-instance route-leak member is dropped
+// (strings.Cut + strconv.Atoi -> continue in compiler_routing.go) — the operator
+// sees a committed reference that carries no effect. Route every `.unit` suffix
+// through the SAME canonical ValidateLogicalUnit so a malformed unit is rejected
+// at commit consistently across subsystems.
+//
+// The suffix is split the SAME way each subsystem's runtime splits the reference
+// (strings.Cut on the FIRST "."), so schema acceptance matches runtime binding
+// exactly. A BARE interface (no ".") or a trailing-dot form ("base." — which the
+// runtime treats as bare, see zoneIfaceLogicalKeys in
+// compiler_validate_strict_zones.go) carries no specific unit and is skipped.
+// References are visited in a deterministic (sorted) order so commit-check
+// surfaces a STABLE first-error message.
+//
+// Strict on the commit / commit-check path (CompileConfig — hard-reject);
+// downgraded to a cfg.Warnings entry on the tolerant load / peer-sync paths
+// (flag lenientInterfaceUnitRef) so an already-persisted or peer-synced config
+// that an older binary accepted still BOOTS (#1960 fail-closed-on-load doctrine;
+// the runtime already ignores an unresolvable `.unit` suffix, so a leniently-
+// loaded malformed reference is inert — the shaper/zone-member/route-leak simply
+// does not bind, exactly as before this gate, now with an operator-visible
+// warning). Mirrors the sibling strict gates in compiler_validate_strict_zones.go.
+func validateInterfaceUnitReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+
+	// checkRef validates one interface reference's OPTIONAL ".unit" suffix. ctx
+	// names the subsystem + scope so the operator error is actionable.
+	checkRef := func(ctx, ref string) error {
+		_, unitTok, hasUnit := strings.Cut(ref, ".")
+		if !hasUnit || unitTok == "" {
+			return nil // bare interface (or trailing-dot bare form) — no unit slot
+		}
+		if err := ValidateLogicalUnit(unitTok, cfg); err != nil {
+			return fmt.Errorf("%s interface reference %q has invalid logical unit %q: %w",
+				ctx, ref, unitTok, err)
+		}
+		return nil
+	}
+
+	// (1) class-of-service interfaces <if>.<unit> — the CoS shaper/classifier
+	// binding. The interface reference is the map KEY, which carries the `.unit`
+	// suffix inline (e.g. "ge-0/0/0.0").
+	if cfg.ClassOfService != nil {
+		names := make([]string, 0, len(cfg.ClassOfService.Interfaces))
+		for name := range cfg.ClassOfService.Interfaces {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if err := checkRef("class-of-service interfaces", name); err != nil {
+				return err
+			}
+		}
+	}
+
+	// (2) security zones security-zone <z> interfaces <if>.<unit> — zone
+	// membership. Zones are visited in sorted order; each zone's Interfaces slice
+	// is in stable config order.
+	zoneNames := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		zoneNames = append(zoneNames, name)
+	}
+	sort.Strings(zoneNames)
+	for _, zoneName := range zoneNames {
+		zone := cfg.Security.Zones[zoneName]
+		if zone == nil {
+			continue
+		}
+		for _, iface := range zone.Interfaces {
+			if iface == "" {
+				continue
+			}
+			ctx := fmt.Sprintf("security zones security-zone %q", zoneName)
+			if err := checkRef(ctx, iface); err != nil {
+				return err
+			}
+		}
+	}
+
+	// (3) routing-instances <ri> interface <if>.<unit> — VRF membership /
+	// route-leak. Routing instances are visited in stable config order.
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		for _, iface := range ri.Interfaces {
+			if iface == "" {
+				continue
+			}
+			ctx := fmt.Sprintf("routing-instances %q", ri.Name)
+			if err := checkRef(ctx, iface); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/config/interface_unit_ref_5933_test.go
+++ b/pkg/config/interface_unit_ref_5933_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5933: the cross-subsystem interface REFERENCES that carry a `.unit` suffix —
+// class-of-service, security-zone membership, routing-instance membership —
+// parsed the suffix WITHOUT ValidateLogicalUnit, the residual #5829 (which typed
+// the `interfaces <if> unit <n>` INSTANCE key) deferred here. A malformed `.unit`
+// there silently MIS-BINDS: the CoS shaper never attaches, the zone-membership
+// key never matches a real unit, the route-leak member is dropped
+// (strings.Cut + strconv.Atoi -> continue). The fix routes every `.unit` suffix
+// through the canonical ValidateLogicalUnit at the compiler strict gate
+// (validateInterfaceUnitReferencesStrict) — hard-reject on commit, warn on the
+// tolerant load / peer-sync path.
+//
+// Flat-set MUST be built with ParseSetCommand/SetPath (flatTreeFromSets), never
+// NewParser (CLAUDE.md "Testing flat set syntax").
+//
+// FAIL-ON-REVERT (per subsystem, load-bearing): neutralize that subsystem's loop
+// in validateInterfaceUnitReferencesStrict → its reject test compiles the
+// malformed reference clean → the reject assertion goes RED.
+
+// badUnitTokens is the shared set of malformed logical-unit suffixes each
+// subsystem must reject at commit, plus the raw token the error must name.
+var badUnitTokens = []struct {
+	name string
+	tok  string // the ".unit" suffix
+	want string // substring the error must contain (the bad raw token)
+}{
+	{"non-numeric", "x", `"x"`},
+	{"negative", "-1", `"-1"`},
+	{"integer-overflow", "99999999999999999999", `"99999999999999999999"`},
+	{"out-of-range", "16386", `"16386"`}, // > MaxLogicalUnit (16385)
+}
+
+// TestUnitRef5933_CoS rejects a malformed `.unit` on a class-of-service
+// interface reference and accepts a valid one.
+func TestUnitRef5933_CoS(t *testing.T) {
+	for _, tc := range badUnitTokens {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t,
+				"set class-of-service interfaces ge-0-0-0."+tc.tok+" shaping-rate 1m")
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a malformed CoS interface .unit %q (silent mis-bind); want reject", tc.tok)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error must name the bad unit token %s: %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "class-of-service") {
+				t.Fatalf("error must name the subsystem (class-of-service): %v", err)
+			}
+		})
+	}
+	// A valid unit suffix compiles (false-reject guard). ge-0-0-0.0 -> unit 0.
+	tree := flatTreeFromSets(t, "set class-of-service interfaces ge-0-0-0.0 shaping-rate 1m")
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a valid CoS interface .unit 0: %v", err)
+	}
+}
+
+// TestUnitRef5933_Zone rejects a malformed `.unit` on a security-zone interface
+// member and accepts a valid one. The base interface is defined so the earlier
+// zone-interface-DEFINED gate passes and this gate is what fires.
+func TestUnitRef5933_Zone(t *testing.T) {
+	base := "set interfaces ge-0-0-0 unit 0 family inet address 10.0.1.1/24"
+	for _, tc := range badUnitTokens {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, base,
+				"set security zones security-zone trust interfaces ge-0-0-0."+tc.tok)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a malformed zone interface .unit %q (silent mis-bind); want reject", tc.tok)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error must name the bad unit token %s: %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "security-zone") {
+				t.Fatalf("error must name the subsystem (security-zone): %v", err)
+			}
+		})
+	}
+	tree := flatTreeFromSets(t, base,
+		"set security zones security-zone trust interfaces ge-0-0-0.0")
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a valid zone interface .unit 0: %v", err)
+	}
+}
+
+// TestUnitRef5933_RoutingInstance rejects a malformed `.unit` on a
+// routing-instance interface member and accepts a valid one.
+func TestUnitRef5933_RoutingInstance(t *testing.T) {
+	base := []string{
+		"set interfaces ge-0-0-0 unit 0 family inet address 10.0.1.1/24",
+		"set routing-instances vr1 instance-type virtual-router",
+	}
+	for _, tc := range badUnitTokens {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			cmds := append(append([]string{}, base...),
+				"set routing-instances vr1 interface ge-0-0-0."+tc.tok)
+			tree := flatTreeFromSets(t, cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a malformed routing-instance interface .unit %q (silent route-leak drop); want reject", tc.tok)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error must name the bad unit token %s: %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "routing-instances") {
+				t.Fatalf("error must name the subsystem (routing-instances): %v", err)
+			}
+		})
+	}
+	cmds := append(append([]string{}, base...),
+		"set routing-instances vr1 interface ge-0-0-0.0")
+	tree := flatTreeFromSets(t, cmds...)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a valid routing-instance interface .unit 0: %v", err)
+	}
+}
+
+// TestUnitRef5933_BareInterfaceAccepted guards against over-rejection: a BARE
+// interface reference (no `.unit`) in any of the three subsystems must NOT be
+// touched by the gate.
+func TestUnitRef5933_BareInterfaceAccepted(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set interfaces ge-0-0-0 unit 0 family inet address 10.0.1.1/24",
+		"set class-of-service interfaces ge-0-0-0 shaping-rate 1m",
+		"set security zones security-zone trust interfaces ge-0-0-0",
+		"set routing-instances vr1 instance-type virtual-router",
+		"set routing-instances vr1 interface ge-0-0-0",
+	)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected bare (no .unit) interface references: %v", err)
+	}
+}
+
+// TestUnitRef5933_LenientWarns proves the tolerant load / peer-sync path
+// (CompileConfigLenient) does NOT hard-error on a malformed `.unit` reference: it
+// downgrades to a deterministic warning naming the bad token, so an already-
+// persisted or peer-synced config still BOOTS (#1960 no-brick). Exercised on all
+// three subsystems.
+func TestUnitRef5933_LenientWarns(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{"cos", []string{"set class-of-service interfaces ge-0-0-0.x shaping-rate 1m"}},
+		{"zone", []string{
+			"set interfaces ge-0-0-0 unit 0 family inet address 10.0.1.1/24",
+			"set security zones security-zone trust interfaces ge-0-0-0.x",
+		}},
+		{"routing-instance", []string{
+			"set interfaces ge-0-0-0 unit 0 family inet address 10.0.1.1/24",
+			"set routing-instances vr1 instance-type virtual-router",
+			"set routing-instances vr1 interface ge-0-0-0.x",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, tc.cmds...)
+			cfg, err := CompileConfigLenient(tree)
+			if err != nil {
+				t.Fatalf("CompileConfigLenient hard-rejected a malformed .unit reference (want warn): %v", err)
+			}
+			found := false
+			for _, w := range cfg.Warnings {
+				if strings.Contains(w, `"x"`) && strings.Contains(w, "interface unit reference") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("lenient compile produced no malformed-unit-reference warning; got %v", cfg.Warnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Residual from #5829 / #5932

#5829/#5932 typed the `interfaces <if> unit <n>` **instance key** (schema `keyValidator ValidateLogicalUnit` + a compiler defense-in-depth) so a non-numeric / negative / out-of-range logical unit is rejected at commit instead of silently dropping the whole unit (a unit-level firewall filter had been committing with **no enforcement** — fail-open).

This closes the residual #5829 deferred here: the cross-subsystem interface **references** that carry a `.unit` **suffix** still parsed the suffix WITHOUT `ValidateLogicalUnit`:

- `class-of-service interfaces <if>.<unit>` — CoS shaper / classifier binding (`cos.Interfaces` key)
- `security zones security-zone <z> interfaces <if>.<unit>` — zone membership (`zone.Interfaces`)
- `routing-instances <ri> interface <if>.<unit>` — VRF membership / route-leak (`ri.Interfaces`)

## Materiality

Lower than #5829's core (confirmed in the #5932 review): firewall **filters** bind only inside the now-gated `interfaces <if> unit <n>` loop, so a malformed unit in these reference slots **cannot** fail-open a filter. But it silently **mis-binds**: the CoS shaper never attaches to a real unit, a zone-membership key never matches a configured unit (`buildInterfaceZoneMap`), and the routing-instance route-leak member is dropped (`strings.Cut` + `strconv.Atoi` → `continue` in `compiler_routing.go`) — a committed reference that carries no effect.

## Fix

New compiler strict gate `validateInterfaceUnitReferencesStrict` (`compiler_validate_strict_unitref.go`), dispatched from `runUniformGates` after the zone-interface-defined gate, routes every `.unit` suffix in the three subsystems through the **same canonical `ValidateLogicalUnit`**. The suffix is split on the FIRST `.` exactly as each subsystem's runtime splits the reference, so schema acceptance matches runtime binding. A bare interface (no `.`) or a trailing-dot bare form (`base.`) carries no unit and is skipped. Deterministic (sorted) order → stable first-error.

Strict on commit / commit-check (hard-reject); the new `lenientInterfaceUnitRef` opt downgrades it to a `cfg.Warnings` entry on the tolerant load / peer-sync paths (`CompileConfigLenient` / `CompileConfigForNodeLenient`) so a config an older binary already persisted still **boots** (#1960 no-brick — the runtime already ignores an unresolvable `.unit` suffix, so a leniently-loaded malformed reference is inert).

Compiler-layer gate only: unlike #5829's dedicated numeric `unit` instance key, the interface-name token here is a **free wildcard** (legitimately bare OR unit-qualified), so a schema `keyValidator` would over-reject bare names.

## Tests (`interface_unit_ref_5933_test.go`, flat-set via `ParseSetCommand`/`SetPath`)

- Per-subsystem strict reject of non-numeric / negative / integer-overflow / out-of-range `.unit` suffixes, naming the subsystem + bad token.
- Valid `.0` accepted; bare-interface accepted (over-rejection guard).
- Lenient warn-not-brick across all three subsystems.
- **Fail-on-revert, per subsystem (load-bearing):** neutralizing one subsystem's loop REDs **only** that subsystem's reject test — confirmed for CoS, zones, and routing-instances.

## Validation

`go build ./...`; `go vet ./pkg/config/`; `go test -race ./pkg/config/ -count=1` — all GREEN (140s). No dataplane change (commit-time input validation only), so no failover / smoke needed.

## Docs

`docs/config-schema.md`'s #5829 note records the residual is now closed by #5933 with a dedicated subsection.

Closes #5933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2F3h4kxf29m6X8BszpM5p