### PR TITLE
web-mgmt: bind listeners on the host-inbound-admitted 80/443 (#5715)

### DIFF
--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -89,8 +89,8 @@ follow-up; until it lands, surface 3 stays a hand-mirror held by the set-level
 | `ssh` | tcp 22 | tcp 22 | dual | |
 | `telnet` | tcp 23 | tcp 23 | dual | |
 | `ftp` | tcp 21 | tcp 21 | dual | Control port only; FTP data is an ALG/transit concern. |
-| `http` / `webapi-clear-text` | tcp 80 | tcp 80 | dual | |
-| `https` / `webapi-ssl` | tcp 443 | tcp 443 | dual | |
+| `http` / `webapi-clear-text` | tcp 80 | tcp 80 | dual | Web-management HTTP. The admit port is the canonical Junos J-Web port (`webmgmt.HTTPPort` = 80) and EQUALS the actual listener bind (#5715): `resolveAPIBinds` binds an explicitly-configured `web-management http` on TCP/80, not the pre-#5715 8080. Listener↔admit are one contract (`webmgmt` SSOT), guarded by `TestWebMgmtListenerMatchesHostInboundAdmit_5715` + the Go/Rust port-parity `TestHostInboundRustWebPortsMatchSSOT_5715`. |
+| `https` / `webapi-ssl` | tcp 443 | tcp 443 | dual | Web-management HTTPS. Admit port = `webmgmt.HTTPSPort` = 443 = the listener bind (#5715, was 8443). Same contract as `http` above. |
 | `ping` | icmp/icmpv6 echo-request | ICMP type 8 (v4) / 128 (v6) | dual | Echo-request only; ICMP errors are global-accepted (see below). |
 | `dns` | udp 53, tcp 53 | udp 53, tcp 53 | dual | |
 | `dhcp` / `bootp` | udp {67, 68} | udp 67, 68 | **ip (v4)** | DHCPv4; must not open on v6 (#3225). |

--- a/pkg/config/host_inbound_rust_parity_test.go
+++ b/pkg/config/host_inbound_rust_parity_test.go
@@ -4,8 +4,11 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/webmgmt"
 )
 
 // host_inbound_rust_parity_test.go closes the Go<->Rust drift gap for the
@@ -209,4 +212,53 @@ func TestHostInboundRustClassifierMatchesGoSSOT(t *testing.T) {
 	rustL2 := rustArrayTokens(l2Section)
 	assertSameSet(t, "L2 protocols (HOST_INBOUND_L2_PROTOCOLS vs HostInboundL2Protocols)",
 		goKeySet(HostInboundL2Protocols), rustL2)
+}
+
+// rustArmInsertPortRe captures the tcp-port the classify_system_service arm
+// starting at a given token inserts: from the token to the FIRST
+// `hi.tcp_ports.insert(<N>)` within the same `{ ... }` arm body (the `[^}]`
+// class stops the match at the arm's closing brace so it cannot leak into a
+// later arm). Tolerant of whitespace / newlines and the alias order inside the
+// pattern (`"http" | "webapi-clear-text"`).
+func rustArmInsertPort(t *testing.T, section, token string) uint16 {
+	t.Helper()
+	re := regexp.MustCompile(`"` + regexp.QuoteMeta(token) + `"[^}]*?hi\.tcp_ports\.insert\((\d+)\)`)
+	m := re.FindStringSubmatch(section)
+	if m == nil {
+		t.Fatalf("could not find `hi.tcp_ports.insert(N)` for the %q arm in classify_system_service — "+
+			"Rust web-management admit moved/renamed; update the #5715 port-parity test", token)
+	}
+	n, err := strconv.ParseUint(m[1], 10, 16)
+	if err != nil {
+		t.Fatalf("Rust %q arm inserts a non-uint16 port %q: %v", token, m[1], err)
+	}
+	return uint16(n)
+}
+
+// TestHostInboundRustWebPortsMatchSSOT_5715 is the cross-LANGUAGE PORT contract
+// the #5715 research flagged as missing: TestHostInboundRustClassifierMatchesGoSSOT
+// proves Go and Rust know the same http/https TOKENS, but NOT that they admit the
+// same PORTS. This asserts the Rust classifier inserts EXACTLY the webmgmt SSOT
+// ports (80/443) for the http and https arms — the same constants the Go catalog
+// (config.HostInboundServiceMatch) and the daemon listener bind derive from.
+//
+// FAIL-ON-REVERT: change the Rust `http` arm to `insert(8080)` (or the SSOT
+// constant) and this goes RED, naming the mismatch. It fails LOUDLY (never a
+// zero-match pass) if the Rust arm moves — rustArmInsertPort t.Fatals on no match.
+func TestHostInboundRustWebPortsMatchSSOT_5715(t *testing.T) {
+	raw, err := os.ReadFile(hostInboundRustSource)
+	if err != nil {
+		t.Fatalf("reading Rust host-inbound classifier %s: %v", hostInboundRustSource, err)
+	}
+	src := rustStripComments(string(raw))
+	svcSection := rustSection(t, src, "fn classify_system_service(", "fn classify_protocol(")
+
+	if got := rustArmInsertPort(t, svcSection, "http"); got != webmgmt.HTTPPort {
+		t.Errorf("Rust `http` admits TCP/%d, but the webmgmt SSOT (and Go catalog + listener) use %d — port drift",
+			got, webmgmt.HTTPPort)
+	}
+	if got := rustArmInsertPort(t, svcSection, "https"); got != webmgmt.HTTPSPort {
+		t.Errorf("Rust `https` admits TCP/%d, but the webmgmt SSOT (and Go catalog + listener) use %d — port drift",
+			got, webmgmt.HTTPSPort)
+	}
 }

--- a/pkg/config/host_inbound_tokens.go
+++ b/pkg/config/host_inbound_tokens.go
@@ -1,6 +1,10 @@
 package config
 
-import "sort"
+import (
+	"sort"
+
+	"github.com/psaab/xpf/pkg/webmgmt"
+)
 
 // host_inbound_tokens.go is the single source of truth (SSOT) for the set of
 // recognized `security zones <z> host-inbound-traffic { system-services ...;
@@ -345,9 +349,13 @@ func HostInboundServiceMatch(token, family string) []L4Match {
 	case "ftp":
 		return []L4Match{hiTCP(21)}
 	case "http", "webapi-clear-text":
-		return []L4Match{hiTCP(80)}
+		// #5715: the admit port is the canonical web-management HTTP listener
+		// port (webmgmt SSOT), the SAME constant pkg/daemon binds the listener
+		// to — so the host-inbound admit and the actual listener are ONE
+		// contract and cannot drift.
+		return []L4Match{hiTCP(webmgmt.HTTPPort)}
 	case "https", "webapi-ssl":
-		return []L4Match{hiTCP(443)}
+		return []L4Match{hiTCP(webmgmt.HTTPSPort)}
 	case "ping":
 		// #3201/#3240: echo-request only — v4 type 8, v6 type 128. Error/PMTUD +
 		// ND subtypes are admitted globally, not per-token.

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -41,6 +41,7 @@ import (
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
 	"github.com/psaab/xpf/pkg/vrrp"
+	"github.com/psaab/xpf/pkg/webmgmt"
 )
 
 // buildRuntimeDataPlane selects the userspace-native Boot() path for the
@@ -1535,25 +1536,35 @@ func (d *Daemon) resolveAPIBinds(apiCfg *api.Config, cfg *config.Config) {
 	if cfg != nil && cfg.System.Services != nil &&
 		cfg.System.Services.WebManagement != nil {
 		wm := cfg.System.Services.WebManagement
-		// Bind HTTP to configured interface
-		if wm.HTTPInterface != "" {
-			bindIP := resolveInterfaceAddr(cfg, wm.HTTPInterface, "127.0.0.1")
+		// #5715: an explicitly configured `web-management http` binds the
+		// canonical Junos J-Web port TCP/80 (webmgmt SSOT — the SAME port the
+		// host-inbound `http` service token admits, so the listener and the
+		// admission agree), on the configured interface address or loopback.
+		// With NO `web-management http` stanza (wm.HTTP false — e.g. an
+		// api-auth-only block) apiCfg.Addr is left untouched at the -api-addr
+		// default (127.0.0.1:8080), a loopback-only diagnostic path that is never
+		// host-inbound-admitted; that path must NOT be silently moved to port 80.
+		if wm.HTTP {
+			httpBindIP := "127.0.0.1"
+			if wm.HTTPInterface != "" {
+				httpBindIP = resolveInterfaceAddr(cfg, wm.HTTPInterface, "127.0.0.1")
+			}
 			// net.JoinHostPort (not string-concat) so an IPv6 interface
-			// address is bracketed ("[2001:db8::1]:8080") — a bare
-			// "2001:db8::1:8080" is unparseable by net.SplitHostPort (the
+			// address is bracketed ("[2001:db8::1]:80") — a bare
+			// "2001:db8::1:80" is unparseable by net.SplitHostPort (the
 			// clamp below) and net.Listen, blackholing an IPv6-only mgmt bind.
-			apiCfg.Addr = net.JoinHostPort(bindIP, "8080")
-			slog.Info("HTTP API bound to interface", "interface", wm.HTTPInterface, "addr", apiCfg.Addr)
+			apiCfg.Addr = net.JoinHostPort(httpBindIP, webmgmt.HTTPPortString())
+			slog.Info("HTTP web-management bound", "interface", wm.HTTPInterface, "addr", apiCfg.Addr)
 		}
-		// Enable HTTPS if configured
+		// Enable HTTPS if configured — bind the canonical TCP/443 (webmgmt SSOT).
 		if wm.HTTPS {
 			httpsBindIP := "127.0.0.1"
 			if wm.HTTPSInterface != "" {
 				httpsBindIP = resolveInterfaceAddr(cfg, wm.HTTPSInterface, "127.0.0.1")
-				slog.Info("HTTPS API bound to interface", "interface", wm.HTTPSInterface, "addr", net.JoinHostPort(httpsBindIP, "8443"))
 			}
 			apiCfg.TLS = true
-			apiCfg.HTTPSAddr = net.JoinHostPort(httpsBindIP, "8443")
+			apiCfg.HTTPSAddr = net.JoinHostPort(httpsBindIP, webmgmt.HTTPSPortString())
+			slog.Info("HTTPS web-management bound", "interface", wm.HTTPSInterface, "addr", apiCfg.HTTPSAddr)
 		}
 		// API authentication
 		if wm.APIAuth != nil && (len(wm.APIAuth.Users) > 0 || len(wm.APIAuth.APIKeys) > 0) {

--- a/pkg/daemon/webmgmt_bind_ifname_5714_test.go
+++ b/pkg/daemon/webmgmt_bind_ifname_5714_test.go
@@ -62,8 +62,8 @@ func TestWebMgmtBindResolvesJunosIfnameToLinux_5714(t *testing.T) {
 	apiCfg := api.Config{Addr: "127.0.0.1:8080"}
 	d.resolveAPIBinds(&apiCfg, webmgmtIfnameCfg("ge-0/0/0.0"))
 
-	if apiCfg.Addr != "10.0.0.5:8080" {
-		t.Fatalf("web-mgmt bind Addr = %q, want 10.0.0.5:8080 (Junos ge-0/0/0.0 -> Linux ge-0-0-0). "+
+	if apiCfg.Addr != "10.0.0.5:80" {
+		t.Fatalf("web-mgmt bind Addr = %q, want 10.0.0.5:80 (Junos ge-0/0/0.0 -> Linux ge-0-0-0, canonical web-mgmt port #5715). "+
 			"127.0.0.1 means the authored Junos name reached the kernel lookup verbatim (the #5714 bug)", apiCfg.Addr)
 	}
 }
@@ -105,8 +105,10 @@ func TestWebMgmtBindUnresolvableLogsLoudError_5714(t *testing.T) {
 		t.Fatalf("unresolvable web-mgmt interface must log a LOUD ERROR naming the interface, "+
 			"not a silent fallback; got records: %+v", recs)
 	}
-	// Fallback is retained (loopback), so the mgmt API still serves locally.
-	if apiCfg.Addr != "127.0.0.1:8080" {
-		t.Fatalf("unresolvable interface bind Addr = %q, want loopback fallback 127.0.0.1:8080", apiCfg.Addr)
+	// Fallback is retained (loopback), so the mgmt API still serves locally —
+	// on the canonical web-mgmt port (#5715), since `web-management http` is
+	// explicitly configured.
+	if apiCfg.Addr != "127.0.0.1:80" {
+		t.Fatalf("unresolvable interface bind Addr = %q, want loopback fallback 127.0.0.1:80", apiCfg.Addr)
 	}
 }

--- a/pkg/daemon/webmgmt_port_contract_5715_test.go
+++ b/pkg/daemon/webmgmt_port_contract_5715_test.go
@@ -1,0 +1,224 @@
+package daemon
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/webmgmt"
+)
+
+// webmgmt_port_contract_5715_test.go is the #5715 cross-package contract: the
+// web-management LISTENER bind ports (derived by resolveAPIBinds from a
+// web-management config) must EQUAL the host-inbound service-catalog admit ports
+// for the `http` / `https` tokens (config.HostInboundServiceMatch, the Go SSOT
+// the nft kernel mirror renders and the Rust classifier parity-tracks).
+//
+// Before #5715 the listener bound 8080/8443 while the catalog admitted 80/443,
+// so a zoned interface configured with least-privilege `system-services https`
+// admitted an unused TCP/443 socket and DROPPED the real TCP/8443 listener. Both
+// sides now derive from the pkg/webmgmt SSOT (HTTPPort=80 / HTTPSPort=443).
+
+// hostInboundTCPPort returns the single TCP admit port the host-inbound catalog
+// grants for token in family, failing if the token does not map to exactly one
+// single-port TCP match (the http/https contract shape).
+func hostInboundTCPPort(t *testing.T, token, family string) uint16 {
+	t.Helper()
+	ms := config.HostInboundServiceMatch(token, family)
+	if len(ms) != 1 {
+		t.Fatalf("HostInboundServiceMatch(%q,%q) returned %d matches, want exactly 1", token, family, len(ms))
+	}
+	m := ms[0]
+	if m.Proto != config.HostInboundProtoTCP {
+		t.Fatalf("HostInboundServiceMatch(%q,%q) proto = %d, want TCP", token, family, m.Proto)
+	}
+	if len(m.Ports) != 1 || m.Ports[0].Lo != m.Ports[0].Hi {
+		t.Fatalf("HostInboundServiceMatch(%q,%q) ports = %+v, want one single port", token, family, m.Ports)
+	}
+	return m.Ports[0].Lo
+}
+
+// listenerPort extracts the numeric port from a "host:port" listen address.
+func listenerPort(t *testing.T, addr string) uint16 {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	p, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		t.Fatalf("parse port %q: %v", portStr, err)
+	}
+	return uint16(p)
+}
+
+// webmgmtCfg builds a web-management config binding HTTP and/or HTTPS to a Junos
+// interface, WITH api-auth so an off-loopback resolved bind survives the
+// #4047/#5127 loopback fail-safe clamp (otherwise the assertion would see the
+// clamped loopback, not the resolved bind — but the PORT is preserved either
+// way, which is what this contract checks).
+func webmgmtCfg(http, https bool, iface string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*config.InterfaceUnit{0: {Number: 0}}},
+	}
+	wm := &config.WebManagementConfig{
+		APIAuth: &config.APIAuthConfig{
+			Users: []*config.APIAuthUser{{Username: "admin", Password: config.Secret("secret")}},
+		},
+	}
+	if http {
+		wm.HTTP = true
+		wm.HTTPInterface = iface
+	}
+	if https {
+		wm.HTTPS = true
+		wm.HTTPSInterface = iface
+	}
+	cfg.System.Services = &config.SystemServicesConfig{WebManagement: wm}
+	return cfg
+}
+
+// TestWebMgmtListenerMatchesHostInboundAdmit_5715 is the load-bearing #5715
+// contract test.
+//
+// FAIL-ON-REVERT: restore the old listener port (bind 8080/8443 instead of the
+// webmgmt SSOT 80/443) and the derived listener port no longer equals the
+// host-inbound admit port — every assertion below goes RED. Likewise, changing
+// only the catalog (config.HostInboundServiceMatch) breaks the equality.
+func TestWebMgmtListenerMatchesHostInboundAdmit_5715(t *testing.T) {
+	// The interface seam resolves ge-0-0-0 to a routable v4 address so the bind
+	// is off-loopback (mgmt-relevant); api-auth keeps it off-loopback past the
+	// clamp.
+	prev := interfaceAddrsByName
+	defer func() { interfaceAddrsByName = prev }()
+	interfaceAddrsByName = func(kernelName string) ([]net.Addr, error) {
+		if kernelName == "ge-0-0-0" {
+			return []net.Addr{&net.IPNet{IP: net.IPv4(10, 0, 0, 5), Mask: net.CIDRMask(24, 32)}}, nil
+		}
+		return nil, nil
+	}
+
+	d := &Daemon{}
+	apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+	d.resolveAPIBinds(&apiCfg, webmgmtCfg(true, true, "ge-0/0/0.0"))
+
+	httpBind := listenerPort(t, apiCfg.Addr)
+	httpsBind := listenerPort(t, apiCfg.HTTPSAddr)
+
+	// (1) listener == catalog admit, per family, for http and https.
+	for _, fam := range []string{"ip", "ip6"} {
+		if admit := hostInboundTCPPort(t, "http", fam); httpBind != admit {
+			t.Errorf("[%s] HTTP listener binds :%d but host-inbound admits :%d — contract broken", fam, httpBind, admit)
+		}
+		if admit := hostInboundTCPPort(t, "https", fam); httpsBind != admit {
+			t.Errorf("[%s] HTTPS listener binds :%d but host-inbound admits :%d — contract broken", fam, httpsBind, admit)
+		}
+	}
+	// (2) both sides equal the webmgmt SSOT constants.
+	if httpBind != webmgmt.HTTPPort {
+		t.Errorf("HTTP listener :%d != webmgmt.HTTPPort %d", httpBind, webmgmt.HTTPPort)
+	}
+	if httpsBind != webmgmt.HTTPSPort {
+		t.Errorf("HTTPS listener :%d != webmgmt.HTTPSPort %d", httpsBind, webmgmt.HTTPSPort)
+	}
+	// (3) the webapi-* aliases share the same admit ports (they are web-mgmt).
+	if p := hostInboundTCPPort(t, "webapi-clear-text", "ip"); p != webmgmt.HTTPPort {
+		t.Errorf("webapi-clear-text admits :%d, want %d", p, webmgmt.HTTPPort)
+	}
+	if p := hostInboundTCPPort(t, "webapi-ssl", "ip"); p != webmgmt.HTTPSPort {
+		t.Errorf("webapi-ssl admits :%d, want %d", p, webmgmt.HTTPSPort)
+	}
+	// (4) negative control: the OLD listener ports are NOT what the catalog
+	// admits (a lifeline guard — 8080/8443 must not be silently admitted).
+	if webmgmt.HTTPPort == 8080 || webmgmt.HTTPSPort == 8443 {
+		t.Fatalf("canonical ports regressed to the pre-#5715 8080/8443")
+	}
+}
+
+// TestWebMgmtBindPortSelection_5715 pins the resolveAPIBinds port-selection
+// cases the #5715 research spec enumerates: HTTP-only, HTTPS-only, both (v4/v6),
+// no-stanza (diagnostic default retained), and api-auth-only (not moved to 80).
+func TestWebMgmtBindPortSelection_5715(t *testing.T) {
+	prev := interfaceAddrsByName
+	defer func() { interfaceAddrsByName = prev }()
+	interfaceAddrsByName = func(kernelName string) ([]net.Addr, error) {
+		switch kernelName {
+		case "ge-0-0-0":
+			return []net.Addr{&net.IPNet{IP: net.IPv4(10, 0, 0, 5), Mask: net.CIDRMask(24, 32)}}, nil
+		case "ge-0-0-1":
+			return []net.Addr{&net.IPNet{IP: net.ParseIP("2001:db8::5"), Mask: net.CIDRMask(64, 128)}}, nil
+		}
+		return nil, nil
+	}
+
+	t.Run("http-only binds 80", func(t *testing.T) {
+		d := &Daemon{}
+		apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+		d.resolveAPIBinds(&apiCfg, webmgmtCfg(true, false, "ge-0/0/0.0"))
+		if apiCfg.Addr != "10.0.0.5:80" {
+			t.Errorf("http-only Addr = %q, want 10.0.0.5:80", apiCfg.Addr)
+		}
+		if apiCfg.TLS {
+			t.Errorf("http-only must not enable TLS")
+		}
+	})
+
+	t.Run("https-only binds 443, http keeps loopback default", func(t *testing.T) {
+		d := &Daemon{}
+		apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+		d.resolveAPIBinds(&apiCfg, webmgmtCfg(false, true, "ge-0/0/0.0"))
+		if apiCfg.HTTPSAddr != "10.0.0.5:443" {
+			t.Errorf("https-only HTTPSAddr = %q, want 10.0.0.5:443", apiCfg.HTTPSAddr)
+		}
+		// HTTP was NOT configured → apiCfg.Addr stays the diagnostic default
+		// (loopback 8080), never exposed off-loopback implicitly.
+		if apiCfg.Addr != "127.0.0.1:8080" {
+			t.Errorf("https-only HTTP Addr = %q, want the retained loopback default 127.0.0.1:8080", apiCfg.Addr)
+		}
+	})
+
+	t.Run("ipv6 interface binds bracketed 80/443", func(t *testing.T) {
+		d := &Daemon{}
+		apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+		d.resolveAPIBinds(&apiCfg, webmgmtCfg(true, true, "ge-0/0/1.0"))
+		if apiCfg.Addr != "[2001:db8::5]:80" {
+			t.Errorf("v6 HTTP Addr = %q, want [2001:db8::5]:80", apiCfg.Addr)
+		}
+		if apiCfg.HTTPSAddr != "[2001:db8::5]:443" {
+			t.Errorf("v6 HTTPS Addr = %q, want [2001:db8::5]:443", apiCfg.HTTPSAddr)
+		}
+	})
+
+	t.Run("no web-management stanza keeps -api-addr default", func(t *testing.T) {
+		d := &Daemon{}
+		apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+		d.resolveAPIBinds(&apiCfg, &config.Config{})
+		if apiCfg.Addr != "127.0.0.1:8080" {
+			t.Errorf("no-stanza Addr = %q, want the untouched diagnostic default 127.0.0.1:8080", apiCfg.Addr)
+		}
+		if apiCfg.TLS {
+			t.Errorf("no-stanza must not enable HTTPS")
+		}
+	})
+
+	t.Run("api-auth-only block does not move loopback listener to 80", func(t *testing.T) {
+		cfg := &config.Config{System: config.SystemConfig{Services: &config.SystemServicesConfig{
+			WebManagement: &config.WebManagementConfig{
+				APIAuth: &config.APIAuthConfig{
+					Users: []*config.APIAuthUser{{Username: "admin", Password: config.Secret("secret")}},
+				},
+			},
+		}}}
+		d := &Daemon{}
+		apiCfg := api.Config{Addr: "127.0.0.1:8080"}
+		d.resolveAPIBinds(&apiCfg, cfg)
+		if apiCfg.Addr != "127.0.0.1:8080" {
+			t.Errorf("api-auth-only Addr = %q, want the retained diagnostic default 127.0.0.1:8080 "+
+				"(an api-auth-only block must NOT silently move the loopback listener to port 80)", apiCfg.Addr)
+		}
+	})
+}

--- a/pkg/webmgmt/ports.go
+++ b/pkg/webmgmt/ports.go
@@ -1,0 +1,35 @@
+// Package webmgmt holds the single source of truth for the web-management
+// service contract shared across the control plane and the host-inbound
+// admission surfaces. It is a LEAF package (imports only the standard library)
+// so both pkg/config (the host-inbound service catalog) and pkg/daemon (the
+// listener bind) can depend on it without an api<->config import cycle and
+// without making pkg/daemon constants authoritative to pkg/config.
+package webmgmt
+
+import "strconv"
+
+// Canonical external TCP ports for an explicitly configured `system services
+// web-management http|https` service (#5715). Junos J-Web binds http=80 /
+// https=443 by default and xpfd already requires privileged networking (no
+// systemd User= directive), so binding these privileged ports adds no new
+// requirement. These are THE contract: the host-inbound service catalog
+// (config.HostInboundServiceMatch for the http / https / webapi-clear-text /
+// webapi-ssl tokens, mirrored by the Rust classify_system_service admit set)
+// admits EXACTLY these ports, so the listener bind and the host-inbound admit
+// are ONE cross-package contract. Before #5715 the listener bound 8080/8443
+// while the catalog admitted 80/443, so host-inbound admitted an unused socket
+// and dropped the real listener on a zoned interface.
+//
+// NOT the loopback diagnostic default: with NO `system services web-management`
+// stanza the daemon keeps the `-api-addr` flag default (127.0.0.1:8080), a
+// loopback-only REST/diagnostic path that is never subject to host-inbound
+// admission (loopback traffic does not traverse the zone host-inbound gate).
+const (
+	HTTPPort  uint16 = 80
+	HTTPSPort uint16 = 443
+)
+
+// HTTPPortString and HTTPSPortString are the net.JoinHostPort spellings of the
+// canonical ports (net.JoinHostPort takes a string port).
+func HTTPPortString() string  { return strconv.Itoa(int(HTTPPort)) }
+func HTTPSPortString() string { return strconv.Itoa(int(HTTPSPort)) }


### PR DESCRIPTION
## Problem (#5715, codex-review-182 M43)

The web-management HTTP/HTTPS listeners bound **TCP/8080 and TCP/8443**, but both host-inbound service catalogs — the Go nft SSOT (`config.HostInboundServiceMatch`) and the Rust AF_XDP classifier (`userspace-dp/.../host_inbound.rs`) — admit web-management on the canonical Junos J-Web ports **TCP/80 and TCP/443**. So a zoned interface configured with least-privilege `system-services https` **admitted an unused TCP/443 socket and DROPPED the actual TCP/8443 listener** — web-management unreachable where scoped, and an unused port admitted.

## Canonical port set chosen: **TCP/80 + TCP/443** (evidence-based)

- The Go catalog (`host_inbound_tokens.go:347-350`) and Rust catalog (`host_inbound.rs`) **already** admit 80/443 — they are the SSOT the nft kernel mirror renders and the Rust classifier parity-tracks. The **listener** (8080/8443) is the divergent side.
- Junos J-Web binds http=80 / https=443 by default; the issue's own research comment (pinned) chose 80/443 as "the least surprising vSRX-compatible contract."
- xpfd runs privileged (production unit has no `User=`), so binding privileged ports adds no new requirement.

→ The smallest correct change is to move the **listener** to 80/443 to match the existing catalog. No catalog port change needed.

## Files

| Surface | File | Change |
|---|---|---|
| **SSOT** | `pkg/webmgmt/ports.go` (new leaf pkg) | `HTTPPort=80` / `HTTPSPort=443` — one authority, no api↔config cycle |
| **Listener** | `pkg/daemon/daemon_run.go` (`resolveAPIBinds`) | bind `webmgmt.HTTPPort`/`HTTPSPort`; HTTP branch keyed on `wm.HTTP` so loopback `web-management http` also gets 80; no-stanza / api-auth-only keep the 8080 loopback diagnostic default |
| **Go catalog** | `pkg/config/host_inbound_tokens.go` | route `http`/`https`/`webapi-*` through `webmgmt.*` (was hardcoded 80/443) → listener + catalog share one constant |
| **Rust catalog** | *(unchanged)* | already admits 80/443 |

## Fail-on-revert contract tests (both confirmed RED)

- **`TestWebMgmtListenerMatchesHostInboundAdmit_5715`** (pkg/daemon, the load-bearing cross-package contract): the `resolveAPIBinds`-derived listener port **==** `config.HostInboundServiceMatch` admit port **==** `webmgmt.*Port`, for http+https across ip/ip6, plus `webapi-*` aliases and an 8080/8443 negative control. Reverting the listener to 8080 → **RED** (`listener binds :8080 but host-inbound admits :80`).
- **`TestHostInboundRustWebPortsMatchSSOT_5715`** (pkg/config, cross-**language** PORT parity — the gap the research flagged: the existing parity test compared token SETS only). Reverting the Rust `http` arm to `insert(8080)` → **RED**.
- `TestWebMgmtBindPortSelection_5715` pins http-only / https-only / both (v4+v6) / no-stanza / api-auth-only selection. `webmgmt_bind_ifname_5714_test.go` updated for the new port (its Junos→Linux ifname-resolution guard is otherwise unchanged).

## Validation

`go build ./...`; `go vet ./pkg/webmgmt/ ./pkg/config/ ./pkg/daemon/`; `go test -race ./pkg/webmgmt/ ./pkg/config/ ./pkg/daemon/ -count=1` — **all GREEN**. Full Rust suite `cargo test --release` — **GREEN** (no Rust source changed; run as dataplane-catalog insurance). Live host-inbound reachability smoke **deferred** (loss-cluster shim-wall); the cross-package contract test + full Go/Rust suites are the gate.

## Scope note

The static `show system services` "HTTP REST 127.0.0.1:8080 (always on)" CLI line describes the **diagnostic** `-api-addr` default (unchanged) and is left as a cosmetic simplification — making it reflect a configured web-management port is a separate CLI-rendering change with its own golden tests.

Closes #5715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2F3h4kxf29m6X8BszpM5p