### PR TITLE
configstore: generation-bound commit transaction (#5848)

### DIFF
--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -266,6 +266,55 @@ inline archive-site passwords).
 
 `pkg/config` only.
 
+## Generation-bound commit transaction (#5848)
+
+Candidate compilation/pre-flight and candidate promotion are two separately
+locked store operations. `CompileCandidate`/`CommitCheck` take only
+`s.mu.RLock`; `CommitWithDescription`/`CommitConfirmed` separately take
+`s.mu.Lock` and recompile the *then-current* `s.candidate`. The daemon's
+commit path uses that gap to run an EXTERNAL pre-flight the store cannot do
+itself — the #1956 device-map management-lockout gate, which resolves the
+proposed config against LIVE hardware while the operator is still connected.
+Candidate mutations (`Set`/`Delete`/`LoadOverride`/`LoadMerge`/`LoadSet`/
+`Deactivate`/`Activate`/`Copy`/`Rename`/`Insert`/`Annotate`/`Rollback`) do
+NOT take the daemon apply semaphore, and REST/internal callers pass
+`sessionID == ""` which bypasses config-lock holder enforcement. So a
+concurrent edit could land between the daemon's pre-flight of candidate C1 and
+`Commit`'s promotion, and the daemon would persist+apply an unexamined C2 — a
+management-lockout-gate bypass (examined generation != promoted generation).
+
+The fix is a monotonic **candidate generation token** (`candidateGen`, bumped
+via `bumpCandidateGenLocked` under `s.mu.Lock` at EVERY candidate change:
+mutation, load, rollback, enter/exit/reclaim config mode, the peer-sync reset,
+and the post-commit reset — a table-driven test asserts each mutating op bumps
+it) plus a generation-bound commit path:
+
+- `CompileCandidateGen() (*config.Config, uint64, error)` — compiles the
+  candidate AND reads the generation under ONE `RLock`, so the compiled
+  snapshot and the token are a consistent pair. The daemon runs its hardware
+  pre-flight on that immutable snapshot OUTSIDE the store lock (`s.mu` is never
+  held across netlink/hardware probing).
+- `CommitWithDescriptionGen(desc, expectedGen)` / `CommitConfirmedGen(minutes,
+  expectedGen)` — promote ONLY if `candidateGen == expectedGen`, else return
+  `ErrCandidateGenerationConflict` without mutating any state. The plain
+  `CommitWithDescription`/`CommitConfirmed` remain for the direct callers (CLI,
+  event-engine) that perform no external pre-flight.
+
+The daemon (`commitWithGenBinding`, `pkg/daemon/daemon_apply.go`) snapshots →
+pre-flights → commits bound to the snapshot generation, retrying the whole
+sequence a bounded number of times on conflict and surfacing the conflict to
+the REST/gRPC caller if the candidate keeps changing. The token is
+**authoritative over content**: a candidate edited and reverted to
+byte-identical bytes still yields a new token, so the conservative outcome is a
+conflict/retry — never a silent substitution. The rollback target for
+commit-confirmed (the active config) is stable across the transaction because
+every path that mutates `active` runs under the daemon apply semaphore the
+commit path holds from pre-flight through promotion.
+
+Scope: REST configuration-session identity / ETag semantics remain a separate
+follow-up; generation binding is the invariant required even for
+same-session/internal concurrent callers.
+
 ## Persist-failure semantics (#1799)
 
 A `db.WriteActive` failure used to be non-fatal everywhere (one-shot

--- a/pkg/configstore/gen_commit_5848_test.go
+++ b/pkg/configstore/gen_commit_5848_test.go
@@ -252,6 +252,20 @@ func TestCandidateGenerationBumps(t *testing.T) {
 				t.Fatal(err)
 			}
 		}},
+		{"insert", func(t *testing.T, s *Store) {
+			// Two ordered sibling nodes under the root so InsertBefore has a
+			// valid element + same-parent reference to reorder.
+			if err := s.SetFromInput("a"); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.SetFromInput("b"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.Insert([]string{"a"}, []string{"b"}, true); err != nil {
+				t.Fatal(err)
+			}
+		}},
 		{"load-override", nil, func(t *testing.T, s *Store) {
 			if err := s.LoadOverride("system { host-name over; }"); err != nil {
 				t.Fatal(err)
@@ -314,5 +328,34 @@ func TestCandidateGenerationBumpsOnEnterExit(t *testing.T) {
 	g2 := s.CandidateGeneration()
 	if g2 <= g1 {
 		t.Fatalf("ExitConfigure did not advance candidateGen (%d -> %d)", g1, g2)
+	}
+}
+
+// Rollback to a NUMBERED history slot (n > 0) also advances the generation — a
+// distinct store_command/store_commit bump site from the rollback-0 case in the
+// table above (which reclones the active). Driven standalone because it needs a
+// committed history entry to roll back to.
+func TestCandidateGenerationBumpsOnRollbackN(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	// One commit creates a rollback slot (the pre-commit active config).
+	if err := s.SetFromInput("system host-name v1"); err != nil {
+		t.Fatalf("set v1: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	// Stage a further change so the candidate differs from the rollback target.
+	if err := s.SetFromInput("system host-name v2"); err != nil {
+		t.Fatalf("set v2: %v", err)
+	}
+	before := s.CandidateGeneration()
+	if err := s.Rollback(1); err != nil {
+		t.Fatalf("Rollback(1): %v", err)
+	}
+	if after := s.CandidateGeneration(); after <= before {
+		t.Fatalf("Rollback(1) did not advance candidateGen (before=%d after=%d)", before, after)
 	}
 }

--- a/pkg/configstore/gen_commit_5848_test.go
+++ b/pkg/configstore/gen_commit_5848_test.go
@@ -1,0 +1,318 @@
+// #5848: candidate preflight and promotion were two separately-locked store
+// ops, so a concurrent REST/CLI candidate edit could land between them and the
+// daemon would promote a candidate it never examined (device-map management-
+// lockout bypass). The generation-bound commit transaction closes this: every
+// candidate change bumps candidateGen; CompileCandidateGen snapshots the
+// (compiled, generation) pair atomically; CommitWithDescriptionGen /
+// CommitConfirmedGen promote ONLY if the generation is unchanged, else return
+// ErrCandidateGenerationConflict without mutating state.
+//
+// FAIL-ON-REVERT: dropping the `s.candidateGen != expectedGen` check in
+// CommitWithDescriptionGen / CommitConfirmedGen makes the stale-generation
+// commit silently promote the unexamined C2 — the conflict tests then get a nil
+// error and an active config carrying "c2", flipping both assertions RED.
+package configstore
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func genStoreInConfig(t *testing.T, host string) *Store {
+	t.Helper()
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("system host-name " + host); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+	return s
+}
+
+// A commit bound to a stale generation (the candidate changed after the
+// snapshot) must CONFLICT and promote NOTHING — the examined generation is not
+// the promoted generation.
+func TestCommitWithDescriptionGenConflictDoesNotPromote(t *testing.T) {
+	s := genStoreInConfig(t, "c1")
+
+	// Snapshot the generation the daemon would pre-flight (C1).
+	compiled, gen, err := s.CompileCandidateGen()
+	if err != nil {
+		t.Fatalf("CompileCandidateGen: %v", err)
+	}
+	if compiled == nil {
+		t.Fatalf("CompileCandidateGen returned nil compiled for a valid candidate")
+	}
+
+	// Concurrent edit lands between pre-flight and promote: candidate -> C2,
+	// generation advances past the snapshot.
+	if err := s.SetFromInput("system host-name c2"); err != nil {
+		t.Fatalf("concurrent mutate: %v", err)
+	}
+
+	_, err = s.CommitWithDescriptionGen("desc", gen)
+	if !errors.Is(err, ErrCandidateGenerationConflict) {
+		t.Fatalf("stale-generation commit: err=%v, want ErrCandidateGenerationConflict", err)
+	}
+	// C2 was NEVER examined; it must not have been promoted.
+	if active := s.ShowActiveSet(); strings.Contains(active, "host-name c2") {
+		t.Fatalf("conflicting commit promoted the unexamined candidate C2; active=%q", active)
+	}
+}
+
+// The generation is authoritative over CONTENT: a candidate edited and then
+// reverted to byte-identical content still carries a NEW generation, so a commit
+// bound to the original generation conflicts (the conservative, safe choice —
+// the examined generation is gone even though the bytes match).
+func TestCommitGenConflictOnChangeAndRevertToIdentical(t *testing.T) {
+	s := genStoreInConfig(t, "c1")
+	before := s.ShowCandidateSet()
+
+	_, gen, err := s.CompileCandidateGen()
+	if err != nil {
+		t.Fatalf("CompileCandidateGen: %v", err)
+	}
+
+	// Change away and back to byte-identical content.
+	if err := s.SetFromInput("system host-name c2"); err != nil {
+		t.Fatalf("edit away: %v", err)
+	}
+	if err := s.DeleteFromInput("system host-name c2"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := s.SetFromInput("system host-name c1"); err != nil {
+		t.Fatalf("edit back: %v", err)
+	}
+	if now := s.ShowCandidateSet(); now != before {
+		t.Fatalf("test setup: candidate not restored to identical content\nbefore=%q\nnow=%q", before, now)
+	}
+
+	if _, err := s.CommitWithDescriptionGen("desc", gen); !errors.Is(err, ErrCandidateGenerationConflict) {
+		t.Fatalf("change-and-revert commit: err=%v, want ErrCandidateGenerationConflict (generation is authoritative)", err)
+	}
+}
+
+// A commit bound to the CURRENT generation (no intervening edit) promotes
+// exactly the prepared candidate — the pre-#5848 success path is preserved.
+func TestCommitWithDescriptionGenSucceedsWhenUnchanged(t *testing.T) {
+	s := genStoreInConfig(t, "c1")
+
+	compiled, gen, err := s.CompileCandidateGen()
+	if err != nil {
+		t.Fatalf("CompileCandidateGen: %v", err)
+	}
+
+	promoted, err := s.CommitWithDescriptionGen("desc", gen)
+	if err != nil {
+		t.Fatalf("in-generation commit failed: %v", err)
+	}
+	if promoted == nil {
+		t.Fatalf("commit returned nil compiled")
+	}
+	if promoted != compiled {
+		// Both compile the same unchanged candidate; they need not be the same
+		// pointer, but the promoted active must carry C1.
+		t.Logf("note: compiled snapshot and promoted config are distinct objects (expected)")
+	}
+	if active := s.ShowActiveSet(); !strings.Contains(active, "host-name c1") {
+		t.Fatalf("in-generation commit did not promote C1; active=%q", active)
+	}
+}
+
+// Two commits cannot both promote against ONE prepared generation: the first
+// consumes it (bumping the generation on the post-commit candidate reset), so a
+// replayed commit bound to the same generation conflicts.
+func TestCommitGenCannotDoublePromote(t *testing.T) {
+	s := genStoreInConfig(t, "c1")
+
+	_, gen, err := s.CompileCandidateGen()
+	if err != nil {
+		t.Fatalf("CompileCandidateGen: %v", err)
+	}
+	if _, err := s.CommitWithDescriptionGen("first", gen); err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+	if _, err := s.CommitWithDescriptionGen("second", gen); !errors.Is(err, ErrCandidateGenerationConflict) {
+		t.Fatalf("replayed commit on a consumed generation: err=%v, want ErrCandidateGenerationConflict", err)
+	}
+}
+
+// Commit-confirmed honors the same generation binding.
+func TestCommitConfirmedGenConflictDoesNotPromote(t *testing.T) {
+	s := genStoreInConfig(t, "c1")
+
+	_, gen, err := s.CompileCandidateGen()
+	if err != nil {
+		t.Fatalf("CompileCandidateGen: %v", err)
+	}
+	if err := s.SetFromInput("system host-name c2"); err != nil {
+		t.Fatalf("concurrent mutate: %v", err)
+	}
+
+	if _, err := s.CommitConfirmedGen(5, gen); !errors.Is(err, ErrCandidateGenerationConflict) {
+		t.Fatalf("stale-generation commit-confirmed: err=%v, want ErrCandidateGenerationConflict", err)
+	}
+	if active := s.ShowActiveSet(); strings.Contains(active, "host-name c2") {
+		t.Fatalf("conflicting commit-confirmed promoted the unexamined candidate C2; active=%q", active)
+	}
+	// Cancel any (should-be-absent) confirm timer to avoid a background rollback.
+	_ = s.ConfirmCommit()
+}
+
+func TestCommitConfirmedGenSucceedsWhenUnchanged(t *testing.T) {
+	s := genStoreInConfig(t, "c1")
+
+	_, gen, err := s.CompileCandidateGen()
+	if err != nil {
+		t.Fatalf("CompileCandidateGen: %v", err)
+	}
+	if _, err := s.CommitConfirmedGen(5, gen); err != nil {
+		t.Fatalf("in-generation commit-confirmed failed: %v", err)
+	}
+	if active := s.ShowActiveSet(); !strings.Contains(active, "host-name c1") {
+		t.Fatalf("in-generation commit-confirmed did not promote C1; active=%q", active)
+	}
+	if err := s.ConfirmCommit(); err != nil {
+		t.Fatalf("ConfirmCommit: %v", err)
+	}
+}
+
+// Every candidate-mutating store op must advance the generation, or a mutation
+// slips past the guard. Table-driven so a newly-added mutator that forgets the
+// bump is caught here.
+func TestCandidateGenerationBumps(t *testing.T) {
+	ops := []struct {
+		name string
+		// prep runs mutations that set up the op (not asserted); do returns the
+		// op whose generation bump is asserted.
+		prep func(t *testing.T, s *Store)
+		do   func(t *testing.T, s *Store)
+	}{
+		{"set", nil, func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("system host-name h1"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"delete", func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("system host-name h1"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.DeleteFromInput("system host-name h1"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"deactivate", func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.DeactivateFromInput("interfaces ge-0-0-0"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"activate", func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24"); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.DeactivateFromInput("interfaces ge-0-0-0"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.ActivateFromInput("interfaces ge-0-0-0"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"copy", func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.Copy([]string{"interfaces", "ge-0-0-0"}, []string{"interfaces", "ge-0-0-1"}); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"rename", func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("interfaces ge-0-0-0 unit 0 family inet address 10.0.0.1/24"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.Rename([]string{"interfaces", "ge-0-0-0"}, []string{"interfaces", "ge-0-0-9"}); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"annotate", func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("system host-name h1"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.Annotate([]string{"system"}, "a comment"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"load-override", nil, func(t *testing.T, s *Store) {
+			if err := s.LoadOverride("system { host-name over; }"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"load-merge", nil, func(t *testing.T, s *Store) {
+			if err := s.LoadMerge("set system host-name merged"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"load-set", nil, func(t *testing.T, s *Store) {
+			if _, err := s.LoadSet("set system host-name loaded"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"rollback-0", func(t *testing.T, s *Store) {
+			if err := s.SetFromInput("system host-name dirty"); err != nil {
+				t.Fatal(err)
+			}
+		}, func(t *testing.T, s *Store) {
+			if err := s.Rollback(0); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			s := newTestStore(t)
+			if err := s.EnterConfigure(); err != nil {
+				t.Fatalf("EnterConfigure: %v", err)
+			}
+			if op.prep != nil {
+				op.prep(t, s)
+			}
+			before := s.CandidateGeneration()
+			op.do(t, s)
+			if after := s.CandidateGeneration(); after <= before {
+				t.Fatalf("op %q did not advance candidateGen (before=%d after=%d) — mutation slips past the #5848 guard",
+					op.name, before, after)
+			}
+		})
+	}
+}
+
+// Entering and exiting configuration mode advance the generation too (the
+// candidate identity changes), so a commit prepared against an old generation
+// cannot survive a config-mode transition.
+func TestCandidateGenerationBumpsOnEnterExit(t *testing.T) {
+	s := newTestStore(t)
+	g0 := s.CandidateGeneration()
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	g1 := s.CandidateGeneration()
+	if g1 <= g0 {
+		t.Fatalf("EnterConfigure did not advance candidateGen (%d -> %d)", g0, g1)
+	}
+	s.ExitConfigure()
+	g2 := s.CandidateGeneration()
+	if g2 <= g1 {
+		t.Fatalf("ExitConfigure did not advance candidateGen (%d -> %d)", g1, g2)
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -67,6 +67,24 @@ type Store struct {
 	configDir bool // true if in configuration mode
 	filePath  string
 
+	// candidateGen is a MONOTONIC token that changes whenever the candidate
+	// tree changes identity or content — every set/delete/load/rename/copy/
+	// insert/annotate/(de)activate mutation, every rollback, every
+	// enter/exit/reclaim of configuration mode, the peer-sync candidate reset,
+	// and the post-commit candidate reset. It backs the #5848 generation-bound
+	// commit transaction: the daemon snapshots+compiles the candidate and reads
+	// this token atomically (CompileCandidateGen), runs its external
+	// device-map hardware pre-flight on that immutable snapshot OUTSIDE the store
+	// lock, then commits ONLY if the token is unchanged (CommitWithDescriptionGen
+	// / CommitConfirmedGen). A concurrent candidate edit between snapshot and
+	// promote bumps the token, so the commit returns
+	// ErrCandidateGenerationConflict instead of silently promoting an unexamined
+	// generation. It is authoritative over content: a candidate edited and then
+	// reverted to byte-identical content still yields a new token (the examined
+	// generation is gone), so the conservative outcome is a conflict/retry.
+	// ALWAYS bumped via bumpCandidateGenLocked under s.mu.Lock.
+	candidateGen uint64
+
 	// Persistent storage
 	db      *DB
 	journal *journal.Journal
@@ -600,6 +618,7 @@ func (s *Store) SyncApply(content string, chassisPreserve func(*config.ConfigTre
 	// If in config mode, update candidate too.
 	if s.configDir {
 		s.candidate = s.active.Clone()
+		s.bumpCandidateGenLocked() // #5848: candidate reset by authoritative load/sync
 	}
 
 	// #3861: an authoritative config synced from the cluster primary

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -32,7 +32,8 @@ func (s *Store) SetAs(sessionID string, path []string) error {
 	if err := s.candidate.SetPath(path); err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -71,7 +72,8 @@ func (s *Store) DeleteAs(sessionID string, path []string) error {
 	if err := s.candidate.DeletePath(path); err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -121,7 +123,8 @@ func (s *Store) DeactivateFromInputAs(sessionID, input string) error {
 	if err := applyEditLine(s.candidate, "deactivate "+input); err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -151,7 +154,8 @@ func (s *Store) ActivateFromInputAs(sessionID, input string) error {
 	if err := applyEditLine(s.candidate, "activate "+input); err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -175,7 +179,8 @@ func (s *Store) CopyAs(sessionID string, srcPath, dstPath []string) error {
 	if err := s.candidate.CopyPath(srcPath, dstPath); err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -199,7 +204,8 @@ func (s *Store) RenameAs(sessionID string, srcPath, dstPath []string) error {
 	if err := s.candidate.RenamePath(srcPath, dstPath); err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -232,7 +238,8 @@ func (s *Store) InsertAs(sessionID string, elementPath, refPath []string, before
 	if err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -288,7 +295,8 @@ func (s *Store) AnnotateAs(sessionID string, path []string, comment string) erro
 	if err := s.candidate.AnnotatePath(path, comment); err != nil {
 		return err
 	}
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -321,7 +329,8 @@ func (s *Store) LoadOverrideAs(sessionID, content string) error {
 	}
 
 	s.candidate = tree
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -415,7 +424,8 @@ func (s *Store) LoadMergeAs(sessionID, content string) error {
 	}
 
 	s.candidate = working
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return nil
 }
@@ -538,7 +548,8 @@ func (s *Store) LoadSetAs(sessionID, content string) (int, error) {
 		count++
 	}
 	s.candidate = working
-	s.touchConfigLockLocked() // #4476: refresh the config-lock idle lease
+	s.touchConfigLockLocked()  // #4476: refresh the config-lock idle lease
+	s.bumpCandidateGenLocked() // #5848: candidate changed — advance the generation
 	s.dirty = true
 	return count, nil
 }

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -95,7 +95,33 @@ func (s *Store) Commit() (*config.Config, error) {
 func (s *Store) CommitWithDescription(description string) (*config.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.commitWithDescriptionLocked(description)
+}
 
+// CommitWithDescriptionGen is CommitWithDescription bound to an expected
+// candidate generation (#5848). It promotes the candidate ONLY if the current
+// candidate generation still equals expectedGen — the token the caller captured
+// (via CompileCandidateGen) before running its external device-map pre-flight.
+// A concurrent set/delete/load/rollback/enter-exit between snapshot and promote
+// bumps the generation, so this returns ErrCandidateGenerationConflict WITHOUT
+// mutating any store state, and the caller re-runs the whole
+// snapshot→pre-flight→commit against the new generation. This closes the
+// examined-generation-vs-promoted-generation race: the compiled config the
+// daemon pre-flighted against live hardware is exactly the one promoted, or the
+// commit conflicts — never a silent substitution.
+func (s *Store) CommitWithDescriptionGen(description string, expectedGen uint64) (*config.Config, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.candidateGen != expectedGen {
+		return nil, fmt.Errorf("%w (examined generation %d, current %d)",
+			ErrCandidateGenerationConflict, expectedGen, s.candidateGen)
+	}
+	return s.commitWithDescriptionLocked(description)
+}
+
+// commitWithDescriptionLocked is the shared body of CommitWithDescription and
+// the generation-bound CommitWithDescriptionGen. Caller holds s.mu.Lock.
+func (s *Store) commitWithDescriptionLocked(description string) (*config.Config, error) {
 	// #3893: reject a user-session commit on a read-only secondary. The
 	// internal HA-sync ingress (SyncApply) and the commit-confirmed timeout
 	// revert (PromoteRollback) promote the active config directly and never
@@ -184,6 +210,7 @@ func (s *Store) CommitWithDescription(description string) (*config.Config, error
 	// Promote candidate to active
 	s.active = s.candidate
 	s.candidate = s.active.Clone()
+	s.bumpCandidateGenLocked() // #5848: fresh candidate — advance the generation
 	s.compiled = compiled
 	s.dirty = false
 	s.touchConfigLockLocked() // #4476: a commit is activity — refresh the lease
@@ -291,7 +318,33 @@ const MaxCommitConfirmedMinutes = 65535
 func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.commitConfirmedLocked(minutes)
+}
 
+// CommitConfirmedGen is CommitConfirmed bound to an expected candidate
+// generation (#5848), the commit-confirmed analogue of CommitWithDescriptionGen.
+// It promotes+arms the auto-rollback timer ONLY if the candidate generation
+// still equals expectedGen, else returns ErrCandidateGenerationConflict without
+// mutating state. The rollback TARGET (the current active config the daemon
+// pre-flighted) is stable across the transaction: the daemon holds its apply
+// semaphore from pre-flight through this call, and every path that mutates the
+// active config (commit, commit-confirmed, peer SyncApply, confirm-timeout
+// rollback) runs under that same semaphore — so binding the (racy, semaphore-
+// free) candidate generation is sufficient to keep both the promoted candidate
+// and the stashed rollback target bound to what was examined.
+func (s *Store) CommitConfirmedGen(minutes int, expectedGen uint64) (*config.Config, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.candidateGen != expectedGen {
+		return nil, fmt.Errorf("%w (examined generation %d, current %d)",
+			ErrCandidateGenerationConflict, expectedGen, s.candidateGen)
+	}
+	return s.commitConfirmedLocked(minutes)
+}
+
+// commitConfirmedLocked is the shared body of CommitConfirmed and the
+// generation-bound CommitConfirmedGen. Caller holds s.mu.Lock.
+func (s *Store) commitConfirmedLocked(minutes int) (*config.Config, error) {
 	// #3893: reject a user-session commit-confirmed on a read-only secondary
 	// (same gate as CommitWithDescription).
 	if err := s.ensureWritableLocked(); err != nil {
@@ -384,6 +437,7 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 	// Promote candidate to active
 	s.active = s.candidate
 	s.candidate = s.active.Clone()
+	s.bumpCandidateGenLocked() // #5848: fresh candidate — advance the generation
 	s.compiled = compiled
 	s.dirty = false
 	s.touchConfigLockLocked() // #4476: a commit is activity — refresh the lease
@@ -764,6 +818,7 @@ func (s *Store) PromoteRollback(gen uint64) (prevCfg *config.Config, ok bool) {
 	s.compiled = s.confirmPrevCfg
 	if s.candidate != nil {
 		s.candidate = s.active.Clone()
+		s.bumpCandidateGenLocked() // #5848: candidate reset on auto-rollback
 	}
 	s.dirty = false
 
@@ -884,6 +939,7 @@ func (s *Store) RollbackAs(sessionID string, n int) error {
 
 	if n == 0 {
 		s.candidate = s.active.Clone()
+		s.bumpCandidateGenLocked() // #5848: candidate replaced by rollback 0
 		s.dirty = false
 		return nil
 	}
@@ -893,6 +949,7 @@ func (s *Store) RollbackAs(sessionID string, n int) error {
 		return err
 	}
 	s.candidate = entry.Config.Clone()
+	s.bumpCandidateGenLocked() // #5848: candidate replaced by rollback n
 	s.dirty = true
 	return nil
 }

--- a/pkg/configstore/store_gen.go
+++ b/pkg/configstore/store_gen.go
@@ -1,0 +1,67 @@
+package configstore
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// ErrCandidateGenerationConflict is returned by the generation-bound commit
+// entry points (CommitWithDescriptionGen / CommitConfirmedGen) when the
+// candidate configuration changed between the caller's snapshot+pre-flight and
+// the promotion attempt (#5848). It is a sentinel so callers can errors.Is it
+// and RETRY the whole snapshot→pre-flight→commit against the new generation
+// instead of promoting a candidate the external pre-flight never examined.
+var ErrCandidateGenerationConflict = errors.New(
+	"candidate configuration changed during commit preparation (generation conflict); re-validate and retry")
+
+// bumpCandidateGenLocked advances the candidate generation token. It MUST be
+// called under s.mu.Lock at EVERY site that changes the candidate tree's
+// identity or content (mutation, load, rollback, enter/exit/reclaim config
+// mode, peer-sync reset, post-commit reset). Missing a site would let a
+// candidate change slip past the generation guard, so a table-driven test
+// (TestCandidateGenerationBumps*) asserts each mutating store op advances it.
+func (s *Store) bumpCandidateGenLocked() {
+	s.candidateGen++
+}
+
+// CandidateGeneration returns the current candidate generation token. Used by
+// the daemon's commit transaction (paired with CompileCandidateGen) and by
+// tests asserting that mutating ops advance the token.
+func (s *Store) CandidateGeneration() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.candidateGen
+}
+
+// CompileCandidateGen atomically compiles the current candidate AND reads the
+// candidate generation token under a SINGLE read lock, so the returned compiled
+// config and generation are a consistent pair describing the same candidate
+// state (#5848). The daemon runs its external #1956 device-map hardware
+// pre-flight on the returned compiled snapshot OUTSIDE the store lock, then
+// commits with the returned generation via CommitWithDescriptionGen /
+// CommitConfirmedGen so a concurrent candidate mutation between snapshot and
+// promote is a CONFLICT, not a silent substitution.
+//
+// The generation is returned even when the candidate is absent or fails
+// commit-check: the daemon still gen-binds the subsequent commit so that a
+// candidate which a concurrent edit turns FROM non-compiling INTO a valid
+// (e.g. management-stranding) config cannot be promoted without a fresh
+// pre-flight. When compilation fails the returned *config.Config is nil and the
+// caller skips the hardware pre-flight (there is nothing to examine); the
+// generation-bound commit then recompiles under the lock and surfaces the SAME
+// compile/mode error when the candidate is unchanged.
+func (s *Store) CompileCandidateGen() (*config.Config, uint64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	gen := s.candidateGen
+	if s.candidate == nil {
+		return nil, gen, fmt.Errorf("not in configuration mode")
+	}
+	compiled, err := s.compileTree(s.candidate)
+	if err != nil {
+		return nil, gen, err
+	}
+	return compiled, gen, nil
+}

--- a/pkg/configstore/store_gen.go
+++ b/pkg/configstore/store_gen.go
@@ -18,10 +18,24 @@ var ErrCandidateGenerationConflict = errors.New(
 
 // bumpCandidateGenLocked advances the candidate generation token. It MUST be
 // called under s.mu.Lock at EVERY site that changes the candidate tree's
-// identity or content (mutation, load, rollback, enter/exit/reclaim config
-// mode, peer-sync reset, post-commit reset). Missing a site would let a
-// candidate change slip past the generation guard, so a table-driven test
-// (TestCandidateGenerationBumps*) asserts each mutating store op advances it.
+// identity or content: the public candidate MUTATORS (set/delete/deactivate/
+// activate/copy/rename/insert/annotate/load-override/load-merge/load-set,
+// rollback), the config-mode transitions (enter/exit/reclaim/force-exit), the
+// peer-sync + confirm-recovery + authoritative-load resets, and the post-commit
+// candidate reset. Missing a site would let a candidate change slip past the
+// generation guard.
+//
+// Test coverage is layered, not a single exhaustive table:
+//   - TestCandidateGenerationBumps drives every PUBLIC candidate mutator and
+//     asserts each advances the token;
+//   - TestCandidateGenerationBumpsOnEnterExit covers the config-mode
+//     transitions, and the commit/commit-confirmed/rollback tests exercise the
+//     post-commit and rollback reset bumps;
+//   - the remaining internal reset sites (peer-sync, confirm-recovery,
+//     reclaim/force-exit) are guarded by the structural invariant that every
+//     `s.candidate = …` reassignment is immediately followed by a bump —
+//     verified by code audit — plus the generation-conflict tests that would
+//     fail if a reset silently kept a stale token.
 func (s *Store) bumpCandidateGenLocked() {
 	s.candidateGen++
 }

--- a/pkg/configstore/store_lock.go
+++ b/pkg/configstore/store_lock.go
@@ -119,6 +119,7 @@ func (s *Store) reclaimStaleLockLocked() bool {
 		"idle_for", time.Since(s.configLockAt).Round(time.Second),
 		"lease_ttl", configLockLeaseTTL)
 	s.candidate = nil
+	s.bumpCandidateGenLocked() // #5848: candidate discarded — advance the generation
 	s.configDir = false
 	s.dirty = false
 	s.exclusiveHolder = ""
@@ -164,6 +165,7 @@ func (s *Store) EnterConfigureSession(sessionID string) error {
 		}
 	}
 	s.candidate = s.active.Clone()
+	s.bumpCandidateGenLocked() // #5848: entered config mode — advance the generation
 	s.configDir = true
 	s.dirty = false
 	s.exclusiveHolder = ""
@@ -188,6 +190,7 @@ func (s *Store) EnterConfigureExclusive(holder string) error {
 		}
 	}
 	s.candidate = s.active.Clone()
+	s.bumpCandidateGenLocked() // #5848: entered config mode — advance the generation
 	s.configDir = true
 	s.dirty = false
 	s.configHolder = ""
@@ -234,6 +237,7 @@ func (s *Store) ExitConfigureSession(sessionID string) bool {
 		return false
 	}
 	s.candidate = nil
+	s.bumpCandidateGenLocked() // #5848: candidate discarded — advance the generation
 	s.configDir = false
 	s.dirty = false
 	s.exclusiveHolder = ""
@@ -253,6 +257,7 @@ func (s *Store) ForceExitConfigure() {
 	slog.Warn("force-releasing stale config lock", "holder", s.configHolder,
 		"held_for", time.Since(s.configLockAt).Round(time.Second))
 	s.candidate = nil
+	s.bumpCandidateGenLocked() // #5848: candidate discarded — advance the generation
 	s.configDir = false
 	s.dirty = false
 	s.exclusiveHolder = ""
@@ -283,6 +288,7 @@ func (s *Store) ExitConfigure() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.candidate = nil
+	s.bumpCandidateGenLocked() // #5848: candidate discarded — advance the generation
 	s.configDir = false
 	s.dirty = false
 	s.exclusiveHolder = ""

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -207,6 +207,7 @@ func (s *Store) recoverPendingConfirmLocked() {
 		}
 		if s.candidate != nil {
 			s.candidate = s.active.Clone()
+			s.bumpCandidateGenLocked() // #5848: candidate reset by confirm-recovery rollback
 		}
 		if perr == nil {
 			// #5835: durable-or-retry removal — a failed DeleteConfirm retains

--- a/pkg/daemon/commit_gen_binding_5848_test.go
+++ b/pkg/daemon/commit_gen_binding_5848_test.go
@@ -1,0 +1,119 @@
+// #5848: the daemon's commit path pre-flighted the candidate (device-map
+// management-lockout gate) and promoted it in two separately-locked store ops,
+// so a concurrent REST/CLI candidate edit could slip a different candidate into
+// the promotion. commitWithGenBinding binds the examined candidate generation to
+// the promoted one: a concurrent edit is a bounded-retry conflict that re-runs
+// the pre-flight on the new generation, never a silent substitution.
+//
+// FAIL-ON-REVERT: the load-bearing guard is the store's generation check
+// (pkg/configstore, TestCommit*Gen*). These daemon tests exercise the retry loop
+// that consumes it end-to-end.
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// A candidate edit landing DURING the pre-flight window bumps the generation, so
+// the first commit conflicts; the helper retries, re-runs the pre-flight on the
+// new generation, and promotes exactly the RE-examined candidate. Examined ==
+// promoted.
+func TestCommitWithGenBindingRepreflightsOnConcurrentEdit(t *testing.T) {
+	s := newCommitReadyStore(t, "system host-name base", "system host-name staged1")
+	d := &Daemon{store: s}
+
+	var examined []string
+	attempt := 0
+	oldActive, compiled, err := d.commitWithGenBinding(
+		func(cand *config.Config) error {
+			examined = append(examined, cand.System.HostName)
+			if attempt == 0 {
+				// Simulate a concurrent REST edit arriving during the FIRST
+				// pre-flight (candidate mutation does not take applySem). This
+				// advances the generation, so the first commit must conflict.
+				if err := s.SetFromInput("system host-name staged2"); err != nil {
+					t.Fatalf("concurrent edit: %v", err)
+				}
+			}
+			attempt++
+			return nil
+		},
+		func(gen uint64) (*config.Config, error) { return s.CommitWithDescriptionGen("", gen) },
+	)
+	if err != nil {
+		t.Fatalf("commitWithGenBinding: %v", err)
+	}
+	if len(examined) != 2 {
+		t.Fatalf("expected 2 pre-flights (conflict + retry), got %d: %v", len(examined), examined)
+	}
+	if examined[0] != "staged1" || examined[1] != "staged2" {
+		t.Fatalf("pre-flight examined the wrong candidates: %v (want [staged1 staged2])", examined)
+	}
+	// The promoted config must be the one the WINNING attempt pre-flighted.
+	if compiled == nil || compiled.System.HostName != "staged2" {
+		t.Fatalf("promoted compiled is not the re-examined candidate: %+v", compiled)
+	}
+	if active := s.ShowActiveSet(); !strings.Contains(active, "host-name staged2") {
+		t.Fatalf("active is not the re-examined candidate; active=%q", active)
+	}
+	if oldActive == nil || oldActive.System.HostName != "base" {
+		t.Fatalf("oldActive not captured as the pre-commit active (base); got %+v", oldActive)
+	}
+}
+
+// A candidate that keeps changing under every attempt surfaces the conflict
+// after the bounded retries instead of spinning forever — the REST/gRPC caller
+// then retries the whole commit.
+func TestCommitWithGenBindingSurfacesPersistentConflict(t *testing.T) {
+	s := newCommitReadyStore(t, "system host-name base", "system host-name s1")
+	d := &Daemon{store: s}
+
+	preflights := 0
+	_, _, err := d.commitWithGenBinding(
+		func(cand *config.Config) error {
+			preflights++
+			// Always edit the candidate → the examined generation is always
+			// stale by commit time.
+			return s.SetFromInput(fmt.Sprintf("system host-name h%d", preflights))
+		},
+		func(gen uint64) (*config.Config, error) { return s.CommitWithDescriptionGen("", gen) },
+	)
+	if !errors.Is(err, configstore.ErrCandidateGenerationConflict) {
+		t.Fatalf("persistent conflict: err=%v, want ErrCandidateGenerationConflict", err)
+	}
+	if preflights != maxCommitPreflightRetries+1 {
+		t.Fatalf("expected %d pre-flight attempts, got %d", maxCommitPreflightRetries+1, preflights)
+	}
+	// Nothing was promoted: active stays at the committed baseline.
+	if active := s.ShowActiveSet(); !strings.Contains(active, "host-name base") {
+		t.Fatalf("active mutated by a conflicting commit; active=%q", active)
+	}
+}
+
+// The no-race common path: pre-flight runs once, the generation is unchanged,
+// the candidate is promoted exactly as before #5848.
+func TestCommitWithGenBindingNoRaceCommitsOnce(t *testing.T) {
+	s := newCommitReadyStore(t, "system host-name base", "system host-name staged")
+	d := &Daemon{store: s}
+
+	preflights := 0
+	_, compiled, err := d.commitWithGenBinding(
+		func(cand *config.Config) error { preflights++; return nil },
+		func(gen uint64) (*config.Config, error) { return s.CommitWithDescriptionGen("", gen) },
+	)
+	if err != nil {
+		t.Fatalf("commitWithGenBinding: %v", err)
+	}
+	if preflights != 1 {
+		t.Fatalf("no-race commit ran %d pre-flights, want 1", preflights)
+	}
+	if compiled == nil || compiled.System.HostName != "staged" {
+		t.Fatalf("promoted the wrong candidate: %+v", compiled)
+	}
+}

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/eventengine"
@@ -76,7 +77,14 @@ func (d *Daemon) bootstrapFromFile() error {
 	// the day-0 import committed unchecked and the box could come up
 	// console-only from the very first boot. Refusing to commit here leaves
 	// the daemon in the lifeline-safe bootstrap state instead.
-	if cand, err := d.store.CompileCandidate(); err == nil {
+	// #5848: snapshot the candidate generation with the compile so the promotion
+	// below is bound to the EXACT candidate this pre-flight examined. Bootstrap
+	// runs single-threaded before the gRPC/HTTP servers start, so no concurrent
+	// candidate edit can occur and the generation always matches — this is
+	// belt-and-suspenders that keeps the examined-equals-promoted invariant
+	// uniform with the operator commit paths (commitWithGenBinding).
+	cand, gen, cerr := d.store.CompileCandidateGen()
+	if cerr == nil {
 		if perr := d.deviceMapCommitPreflight(cand, nil); perr != nil {
 			d.store.ExitConfigure()
 			slog.Error("bootstrap config REJECTED: its device-map would strand management on next "+
@@ -85,7 +93,7 @@ func (d *Daemon) bootstrapFromFile() error {
 			return fmt.Errorf("bootstrap device-map preflight: %w", perr)
 		}
 	}
-	if _, err := d.store.Commit(); err != nil {
+	if _, err := d.store.CommitWithDescriptionGen("", gen); err != nil {
 		d.store.ExitConfigure()
 		return fmt.Errorf("commit: %w", err)
 	}
@@ -229,6 +237,70 @@ func (d *Daemon) factoryReset(ctx context.Context, wipe func() error) error {
 	return nil
 }
 
+// maxCommitPreflightRetries bounds how many times commitWithGenBinding
+// re-snapshots + re-pre-flights + re-attempts a promotion when a concurrent
+// candidate edit invalidates the examined generation (#5848). A handful of
+// retries absorbs an operator/automation edit racing a commit; if the candidate
+// keeps changing under us we surface the conflict rather than spin forever, so
+// the REST/gRPC caller can retry the whole commit.
+const maxCommitPreflightRetries = 3
+
+// commitWithGenBinding runs the #5848 generation-bound commit transaction so
+// the candidate examined by the external #1956 device-map hardware pre-flight is
+// EXACTLY the candidate the store promotes — never a different one substituted
+// by a concurrent REST/CLI candidate edit (set/delete/load/rollback), which do
+// NOT take the apply semaphore.
+//
+// Each attempt: snapshot+compile the candidate and read its generation token
+// atomically (CompileCandidateGen); run the caller's preflight on that immutable
+// compiled snapshot OUTSIDE the store lock (s.mu is NOT held across netlink /
+// hardware probing); then commit bound to the snapshot generation. If a
+// candidate edit landed in between, the generation-checked commit returns
+// ErrCandidateGenerationConflict and we retry against the fresh generation
+// (bounded). commitFn performs the generation-checked promotion
+// (CommitWithDescriptionGen / CommitConfirmedGen).
+//
+// A snapshot that fails to compile (not in configuration mode / commit-check
+// error) skips the pre-flight — there is nothing to examine — but STILL
+// gen-binds the commit: a concurrent edit that turns a non-compiling candidate
+// into a valid, management-stranding one cannot be promoted unexamined; the
+// bound commit conflicts and the retry re-pre-flights it. When the candidate is
+// unchanged, the bound commit recompiles under the lock and surfaces the SAME
+// compile/mode error the pre-#5848 path did.
+//
+// Caller holds d.applySem. Returns the pre-commit active config (for the #4234
+// deletion-clear diff) and the compiled promoted config.
+func (d *Daemon) commitWithGenBinding(
+	preflight func(cand *config.Config) error,
+	commitFn func(expectedGen uint64) (*config.Config, error),
+) (oldActive, compiled *config.Config, err error) {
+	for attempt := 0; ; attempt++ {
+		cand, gen, cerr := d.store.CompileCandidateGen()
+		if cerr == nil {
+			// Run the hardware pre-flight on the exact compiled snapshot,
+			// OUTSIDE the store lock (CompileCandidateGen already released it).
+			if perr := preflight(cand); perr != nil {
+				return nil, nil, perr
+			}
+		}
+		// Capture the pre-commit active config right before the promotion so
+		// applyAndSyncCommitted can diff deleted policies (#4234). Active only
+		// changes under d.applySem (held here), so it is stable across the
+		// transaction.
+		oldActive = d.store.ActiveConfig()
+		compiled, err = commitFn(gen)
+		if err == nil {
+			return oldActive, compiled, nil
+		}
+		if errors.Is(err, configstore.ErrCandidateGenerationConflict) && attempt < maxCommitPreflightRetries {
+			slog.Warn("commit: candidate configuration changed during pre-flight; re-validating on the new generation",
+				"attempt", attempt+1)
+			continue
+		}
+		return nil, nil, err
+	}
+}
+
 // commitAndApply atomically promotes the candidate config and
 // applies it. Holds applySem across configstore.Commit and
 // applyConfigLocked so two concurrent committers can't interleave
@@ -285,29 +357,19 @@ func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer bo
 		return nil, errDaemonResetting
 	}
 
-	// #1956 R-8 device-map pre-flight: reject a candidate whose device-map
-	// would strand management on next boot, while the operator is still
-	// connected and BEFORE the store promotes it. Runs under applySem (after
-	// Acquire) but before Commit, so a reject never leaves a promoted store.
-	// Plain commit has no auto-rollback target, so pass nil.
-	if cand, err := d.store.CompileCandidate(); err == nil {
-		if err := d.deviceMapCommitPreflight(cand, nil); err != nil {
-			return nil, err
-		}
-	}
-
-	// Capture the pre-commit active config BEFORE Commit promotes the candidate,
-	// so applyAndSyncCommitted can diff it against the new config and clear the
-	// sessions of any deleted policy (#4234).
-	oldActive := d.store.ActiveConfig()
-
-	var compiled *config.Config
-	var err error
-	if comment != "" {
-		compiled, err = d.store.CommitWithDescription(comment)
-	} else {
-		compiled, err = d.store.Commit()
-	}
+	// #5848 generation-bound commit transaction. The #1956 R-8 device-map
+	// pre-flight (reject a candidate whose device-map would strand management on
+	// next boot, while the operator is still connected) and the store promotion
+	// used to be two separately-locked ops, so a concurrent REST/CLI candidate
+	// edit could land between them and the daemon would promote a candidate it
+	// never pre-flighted. commitWithGenBinding binds the examined generation to
+	// the promoted generation: the pre-flighted candidate is the one promoted, or
+	// the commit conflicts and re-validates. Plain commit has no auto-rollback
+	// target, so the pre-flight passes nil.
+	oldActive, compiled, err := d.commitWithGenBinding(
+		func(cand *config.Config) error { return d.deviceMapCommitPreflight(cand, nil) },
+		func(gen uint64) (*config.Config, error) { return d.store.CommitWithDescriptionGen(comment, gen) },
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -506,23 +568,23 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 		return nil, errDaemonResetting
 	}
 
-	// #1956 R-8/V-3 device-map pre-flight: validate BOTH the candidate AND
-	// the rollback target (the currently-active config, restored on a
-	// confirmed-commit timeout) against present hardware. If EITHER would
-	// strand management on next boot, reject while the operator is still
-	// connected — so when a timeout fires the target is KNOWN-safe and is
-	// applied UNCONDITIONALLY (OQ-15.2, no rollback-time abort). Runs under
-	// applySem before Commit, so a reject never leaves a promoted store.
-	if cand, err := d.store.CompileCandidate(); err == nil {
-		if err := d.deviceMapCommitPreflight(cand, d.store.ActiveConfig()); err != nil {
-			return nil, err
-		}
-	}
-
-	// Pre-commit active config for the #4234 deletion-clear (see commitAndApply).
-	oldActive := d.store.ActiveConfig()
-
-	compiled, err := d.store.CommitConfirmed(minutes)
+	// #5848 generation-bound commit transaction (commit-confirmed variant).
+	// #1956 R-8/V-3 device-map pre-flight: validate BOTH the candidate AND the
+	// rollback target (the currently-active config, restored on a confirmed-commit
+	// timeout) against present hardware. If EITHER would strand management on next
+	// boot, reject while the operator is still connected — so when a timeout fires
+	// the target is KNOWN-safe and is applied UNCONDITIONALLY (OQ-15.2, no
+	// rollback-time abort). The pre-flight and the promotion are now bound to one
+	// candidate generation, so a concurrent candidate edit cannot slip a different
+	// candidate into the promotion after the pre-flight cleared the examined one.
+	// The rollback target (active) is stable across the transaction: it changes
+	// only under d.applySem, held here from pre-flight through the commit.
+	oldActive, compiled, err := d.commitWithGenBinding(
+		func(cand *config.Config) error {
+			return d.deviceMapCommitPreflight(cand, d.store.ActiveConfig())
+		},
+		func(gen uint64) (*config.Config, error) { return d.store.CommitConfirmedGen(minutes, gen) },
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem (#5848 — bug, security, High)

Candidate pre-flight and candidate promotion are two **separately-locked** store ops. `commitAndApply` / `commitConfirmedAndApply` run the #1956 device-map management-lockout pre-flight (resolve the proposed config against **live hardware** while the operator is connected) via `CompileCandidate` (`s.mu.RLock`), then later promote via `Store.Commit` (`s.mu.Lock`, recompiling the *then-current* candidate).

Candidate mutations (`Set`/`Delete`/`Load*`/`Rollback`/…) do **not** take the apply semaphore, and REST/internal callers pass `sessionID==""` which bypasses config-lock holder enforcement. So a concurrent `set`/`delete`/`load` can switch the candidate from the pre-flighted **C1** to an unexamined **C2** between the two locked ops — and C2 (e.g. a device-map that strands management on next boot) gets persisted+applied without the hardware pre-flight that authorized promotion. Examined generation ≠ promoted generation.

## Fix — monotonic candidate generation, bound across the commit

**configstore:**
- `Store.candidateGen`, bumped via `bumpCandidateGenLocked` under `s.mu.Lock` at **every** candidate change: all `store_command.go` mutators, rollback (0 and N), enter/exit/reclaim config mode, the confirm-timeout & peer-sync candidate resets, and the post-commit reset. A **table-driven test asserts each mutating op bumps it** (catches a future mutator that forgets).
- `CompileCandidateGen()` — compiles the candidate **and** reads the token under one `RLock` (consistent snapshot pair); the daemon pre-flights that immutable snapshot **outside** the store lock.
- `CommitWithDescriptionGen(desc, expectedGen)` / `CommitConfirmedGen(minutes, expectedGen)` — promote **only** if `candidateGen == expectedGen`, else return `ErrCandidateGenerationConflict` **without mutating state**. Plain `CommitWithDescription`/`CommitConfirmed` keep exact behavior for the direct callers (CLI, event-engine) that run no external pre-flight; both share an extracted `*Locked` body.
- Token is **authoritative over content**: edit-and-revert-to-byte-identical still yields a new token → conflict/retry, never a silent substitution.

**daemon:**
- `commitWithGenBinding` = snapshot → pre-flight (outside `s.mu`) → generation-checked commit, with a **bounded retry** that re-validates on the new generation when a concurrent edit conflicts, and surfaces the conflict to the REST/gRPC caller if the candidate keeps changing. `commitAndApply` + `commitConfirmedAndApply` route through it; `bootstrapFromFile` is gen-bound too for uniformity (single-threaded at boot, never actually conflicts). **`s.mu` is never held across the netlink/hardware pre-flight.**
- Commit-confirmed rollback target (the `active` config) is stable across the transaction: every `active` mutation runs under the apply semaphore the commit path holds from pre-flight through promotion, so binding the racy **candidate** generation is sufficient.

## Sites instrumented with a generation bump
`store_command.go` (11 mutators: set/delete/deactivate/activate/copy/rename/insert/annotate/load-override/load-merge/load-set); `store_commit.go` (post-commit reset, post-commit-confirmed reset, confirm-timeout rollback reset, Rollback 0, Rollback N); `store_lock.go` (enter ×2, exit/reclaim/force-exit ×4); `store_persist.go` (confirm-recovery rollback reset); `store.go` (authoritative load/sync reset).

## REST
No REST code change: REST set/delete/load call the store mutators that now bump the generation, so a REST edit racing a commit conflicts. **Follow-up (out of scope):** explicit REST configuration-session identity / ETag semantics — generation binding is the invariant required even for same-session/internal concurrent callers.

## Fail-on-revert tests
- **pkg/configstore** (`gen_commit_5848_test.go`) — stale-generation `Commit`/`CommitConfirmed` return `ErrCandidateGenerationConflict` and promote nothing (C2 never reaches `active`); in-generation commit still promotes; a consumed generation can't double-promote; change-and-revert-to-identical still conflicts; every mutating op bumps the token. **Neutralizing the `candidateGen != expectedGen` check turns the four conflict tests RED** (verified: nil error, C2 promoted).
- **pkg/daemon** (`commit_gen_binding_5848_test.go`) — `commitWithGenBinding` re-pre-flights on a concurrent edit (examined == promoted), surfaces a persistent conflict after the bounded retries, commits once on the no-race path.

## Validation
`go build ./...`; `go vet ./pkg/configstore/ ./pkg/daemon/`; `go test -race ./pkg/configstore/ ./pkg/daemon/ -count=1` — all green.

## Docs
`pkg/configstore/README.md` gains a "Generation-bound commit transaction (#5848)" section (token, snapshot/commit API, conflict-retry contract, follow-up scope).

Closes #5848

🤖 Generated with [Claude Code](https://claude.com/claude-code)