### PR TITLE
dhcpserver: close the Kea LFC lease-source residuals — socket preference, crash-cleanup safety, degraded banner (#5938)

### DIFF
--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -412,11 +412,36 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   and the trusted-empty result is returned only when every existing file in the
   set validates AND the merged active set is empty. `readSyncLeasesViaMemfile`
   (the HA lease-sync fallback) inherits the union through `parseActiveLeases`.
-  RESIDUAL (deferred to a follow-up, tracked on #5796): this reads the on-disk
-  LFC set coherently for the common phases, but does not yet prefer the live
-  `lease_cmds` control socket over the journal in every consumer, nor
-  crash-interrupted-cleanup generation proofs (`.output`/`.completed` mid-move),
-  nor a degraded-source banner on the display surfaces (issue invariants 2/3/8).
+  The #5796 residual invariants 2/3/8 are now CLOSED (#5938):
+  - **Invariant 2 — live `lease_cmds` socket preference (display):** when the
+    `lease_cmds` hook is EXPECTED (lease-sync enabled), the display path
+    (`getDisplayLeases` → `GetLeasesWithSource{4,6}`, `lease_source.go`) queries
+    the authoritative live lease DB (`lease{4,6}-get-all` over the control
+    socket, reusing the HA-sync `keaControl` plumbing) and only falls back to the
+    memfile file set when the socket is unavailable. On a box WITHOUT the hook the
+    memfile is the normal source, so a memfile read there is NOT flagged degraded.
+    (The HA-sync `getSyncLeases` already preferred the socket; this extends the
+    same discipline to the display.)
+  - **Invariant 3 — crash-interrupted-cleanup safety:** the reader IGNORES
+    kea-lfc's `.output`/`.completed` intermediates. This is proven safe by an
+    exact argument (documented at `keaLFCLeaseFilePaths`, `lease_lfc.go`): every
+    lease reachable through `.output` is a subset of `.1 ∪ .2` (kea-lfc builds
+    `.output` by merging them) which the reader already ingests, and the atomic
+    `.output → .2` swap means no active lease is ever reachable ONLY through an
+    intermediate — so a torn cleanup never presents a stale-yet-authoritative set.
+    No generation protocol is needed for this read-only path. Pinned by
+    `TestKeaLFCIntermediatesIgnored_5938`.
+  - **Invariant 8 — degraded-source display banner:** a `LeaseSource`
+    (`lease_source.go`) is threaded from the read to the authoritative gRPC
+    `show dhcp server` handler; when the source is degraded — the expected live
+    socket was unavailable (memfile fallback in use) OR a present LFC sibling was
+    unreadable and skipped — a one-line banner is printed above the lease table so
+    a partial display is never mistaken for a healthy empty set. The memfile
+    file-set read on the display path is now degrade-TOLERANT
+    (`parseLeaseCSVDegradable`): an unreadable sibling is skipped (recorded) rather
+    than blanking the whole show. (The interactive-CLI local path keeps its #4908
+    read-error warning; the socket preference does not apply to its throwaway
+    manager, which has no hook context.)
 - **Hostname normalization** — `deriveFQDN` / `finalizeFQDN`
   (`ddns_hostname.go`) ALWAYS contains the published name in the configured
   zone: the client picks the host part, the firewall picks the domain. A

--- a/pkg/dhcpserver/lease_lfc.go
+++ b/pkg/dhcpserver/lease_lfc.go
@@ -29,7 +29,39 @@ package dhcpserver
 //	<f>.pid        kea-lfc's pid file.
 //
 // The .output/.completed/.pid files hold no lease union we must read and are
-// ignored. NOTE the suffix mapping: .1 is INPUT and .2 is PREVIOUS — so the
+// ignored.
+//
+// #5938 Invariant 3 — crash-interrupted-cleanup safety argument. A cleanup that
+// crashes mid-run can leave a stale `.output` and/or `.completed` behind, so the
+// reader must be provably correct to SKIP them. It is, and here is the exact
+// argument (no generation protocol is needed for this read-only display/DDNS
+// path):
+//
+//   - `.output` is kea-lfc's IN-PROGRESS compaction target: it is built by
+//     MERGING the INPUT (.1) and PREVIOUS (.2) files (Kea src: LFCController /
+//     memfile — kea-lfc reads `.1`+`.2` and writes the compacted union to
+//     `.output`). Every lease key that could appear in `.output` therefore ALSO
+//     appears in `.1` ∪ `.2`, which this reader already ingests. So `.output`
+//     contributes NO lease key we would otherwise miss — reading it could only
+//     re-assert rows we already have (idempotent under the last-row-wins dedup)
+//     or, worse, a TORN half-written merge (kea-lfc crashed mid-write) whose
+//     partial rows are strictly LESS complete than `.1`+`.2`. Skipping it is thus
+//     not merely safe but STRICTLY SAFER than reading it.
+//   - `.completed` is kea-lfc's zero-content FINISH MARKER (its presence tells
+//     the server the swap may proceed); it carries no lease rows at all.
+//   - The atomic swap kea-lfc performs on SUCCESS (`.output` → `.2`, unlink
+//     `.1`) means a lease is never in-flight-only: before the swap it lives in
+//     `.1`+`.2`; after the swap it lives in the new `.2`. At NO instant is an
+//     active lease reachable ONLY through `.output`/`.completed`. A crash at any
+//     point leaves the pre-swap `.1`+`.2` intact (or the post-swap `.2`), both of
+//     which this reader covers. Hence a torn cleanup can never briefly present a
+//     STALE-yet-authoritative set through the intermediates.
+//
+// TestKeaLFCIntermediatesIgnored pins this: `.output`/`.completed` present
+// alongside `.2`+`.1` do not change the resolved lease set, and a lease living
+// in `.output` is already covered by `.2`/`.1`.
+//
+// NOTE the suffix mapping: .1 is INPUT and .2 is PREVIOUS — so the
 // CHRONOLOGICAL read order (oldest → newest) is .2 → .1 → current, i.e. the
 // previous-compacted snapshot first, then the input file, then the current
 // append log.

--- a/pkg/dhcpserver/lease_source.go
+++ b/pkg/dhcpserver/lease_source.go
@@ -1,0 +1,197 @@
+package dhcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// lease_source.go completes the Kea LFC lease-source invariants #5796/#5936
+// deferred (#5938): the live `lease_cmds` socket is preferred over the memfile
+// snapshot for the DISPLAY path (Invariant 2), and a degraded lease source is
+// surfaced to `show dhcp server leases` via a banner (Invariant 8). The
+// crash-interrupted-cleanup safety argument (Invariant 3) is documented at
+// keaLFCLeaseFilePaths (lease_lfc.go) and pinned by a test.
+//
+// This is the DISPLAY sibling of the HA-sync getSyncLeases path (lease_sync.go),
+// which already prefers the socket and falls back to the memfile. GetLeases4/6
+// are deliberately left untouched (they keep the #4908 file-read-error surface
+// the interactive CLI relies on); the socket-first + degraded-source path is
+// exposed through GetLeasesWithSource4/6, consumed by the authoritative gRPC
+// `show dhcp server` handler.
+
+// Lease-source origin labels (human-readable, shown in logs / the degraded
+// banner detail).
+const (
+	leaseSourceLiveSocket      = "live lease_cmds control socket"
+	leaseSourceMemfile         = "memfile LFC file-set"
+	leaseSourceMemfileFallback = "memfile LFC file-set (socket fallback)"
+)
+
+// LeaseSource describes WHERE a displayed lease set came from and whether that
+// source is DEGRADED (the shown set may be incomplete). It is threaded from the
+// lease read to the show handler so the operator is never silently shown a
+// best-effort fallback as if it were authoritative (#5938 Invariant 8).
+type LeaseSource struct {
+	Origin   string // human label of the source actually used
+	Degraded bool   // true ⇒ the displayed lease set may be incomplete
+	Detail   string // one-line reason for the degradation (banner text)
+}
+
+// Banner returns the one-line operator banner for a degraded source, or "" when
+// the source is healthy (no banner). The show handlers print this above the
+// lease table so a degraded read is visually distinct from a healthy empty set.
+func (s LeaseSource) Banner() string {
+	if !s.Degraded {
+		return ""
+	}
+	return "WARNING: DHCP lease display is DEGRADED — " + s.Detail +
+		"; the lease set shown below may be incomplete"
+}
+
+// skippedDetail renders the "N sibling(s) unreadable" degradation reason.
+func skippedDetail(paths []string) string {
+	return fmt.Sprintf("%d Kea lease file(s) unreadable and skipped: %s",
+		len(paths), strings.Join(paths, ", "))
+}
+
+// GetLeasesWithSource4 returns the active DHCPv4 leases for display PLUS the
+// source they were read from (#5938). It prefers the live lease DB when the
+// lease_cmds hook is available and falls back to the memfile LFC file set,
+// annotating the source degraded on fallback or on an unreadable sibling.
+func (m *Manager) GetLeasesWithSource4() ([]Lease, LeaseSource) {
+	return m.getDisplayLeases(4, time.Now())
+}
+
+// GetLeasesWithSource6 is the DHCPv6 counterpart of GetLeasesWithSource4.
+func (m *Manager) GetLeasesWithSource6() ([]Lease, LeaseSource) {
+	return m.getDisplayLeases(6, time.Now())
+}
+
+// getDisplayLeases resolves the active display lease set for a family, preferring
+// the live lease_cmds socket when it is EXPECTED (Invariant 2) and degrading to
+// the memfile LFC file set otherwise, tracking the source (Invariant 8).
+func (m *Manager) getDisplayLeases(family int, now time.Time) ([]Lease, LeaseSource) {
+	// Invariant 2: the running Kea lease DB (queried via lease{4,6}-get-all over
+	// the control socket) is the AUTHORITATIVE source. Prefer it — but ONLY when
+	// the lease_cmds hook is expected to be present (lease-sync enabled injects
+	// the control socket + hook, see SetLeaseSyncEnabled). On a box WITHOUT the
+	// hook the memfile is the normal authoritative source, so a memfile read
+	// there is NOT a degradation and must not raise the banner.
+	if m.leaseSyncEnabled.Load() {
+		ctx, cancel := context.WithTimeout(context.Background(), keaControlTimeout)
+		defer cancel()
+		leases, err := m.readDisplayLeasesViaSocket(ctx, family, now)
+		if err == nil {
+			return leases, LeaseSource{Origin: leaseSourceLiveSocket}
+		}
+		// The EXPECTED socket failed (Kea not up yet, hook missing, timeout).
+		// Fall back to the memfile file set and flag the display degraded — the
+		// snapshot is complete for the LFC phases (#5796) but may lag the live DB.
+		slog.Debug("dhcpserver: live lease_cmds query failed; display falling back to memfile",
+			"family", family, "err", err)
+		fallback, skipped := parseLeaseCSVDegradable(m.leaseFile(family), now)
+		detail := "live lease_cmds control socket unavailable — showing memfile snapshot"
+		if len(skipped) > 0 {
+			detail += "; " + skippedDetail(skipped)
+		}
+		return fallback, LeaseSource{Origin: leaseSourceMemfileFallback, Degraded: true, Detail: detail}
+	}
+
+	// No hook expected: the memfile LFC file set is the normal source. Still
+	// surface a banner if a sibling file was present but unreadable (Invariant 8
+	// mangled-sibling half) so a partial display is never mistaken for complete.
+	leases, skipped := parseLeaseCSVDegradable(m.leaseFile(family), now)
+	if len(skipped) > 0 {
+		return leases, LeaseSource{Origin: leaseSourceMemfile, Degraded: true, Detail: skippedDetail(skipped)}
+	}
+	return leases, LeaseSource{Origin: leaseSourceMemfile}
+}
+
+// readDisplayLeasesViaSocket queries the live Kea lease DB for a family via
+// lease{4,6}-get-all on the control socket and maps each active lease to the
+// display Lease shape. It mirrors the memfile display filters (only Kea's
+// default/active state; drop leases whose expiry has lapsed) so the socket and
+// memfile displays agree. Reuses the HA-sync socket plumbing (keaControl +
+// keaLeaseGetAllArgs). Any transport / result error is returned so the caller
+// falls back to the memfile.
+func (m *Manager) readDisplayLeasesViaSocket(ctx context.Context, family int, now time.Time) ([]Lease, error) {
+	socket := m.controlSocket(family)
+	resp, err := keaControl(ctx, m.keaDial, socket, keaCommand{Command: fmt.Sprintf("lease%d-get-all", family)})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Result == keaResultEmpty {
+		return nil, nil // no leases (a successful empty set)
+	}
+	if resp.Result != keaResultSuccess {
+		return nil, fmt.Errorf("lease%d-get-all: result=%d text=%q", family, resp.Result, resp.Text)
+	}
+	var args keaLeaseGetAllArgs
+	if len(resp.Arguments) > 0 {
+		if err := json.Unmarshal(resp.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("lease%d-get-all decode: %w", family, err)
+		}
+	}
+	nowUnix := now.Unix()
+	out := make([]Lease, 0, len(args.Leases))
+	for _, kl := range args.Leases {
+		if kl.State != keaStateDefault {
+			continue // only active leases (mirrors parseLeaseCSV's state filter)
+		}
+		// Kea get-all returns cltt + valid-lft; the absolute expiry is their sum
+		// (matching the memfile's `expire` column). Drop a lapsed lease.
+		expire := kl.Expire
+		if expire == 0 {
+			expire = kl.CLTT + int64(kl.ValidLft)
+		}
+		if expire > 0 && nowUnix >= expire {
+			continue
+		}
+		out = append(out, Lease{
+			Address:    kl.IPAddress,
+			HWAddress:  kl.HWAddress,
+			Hostname:   kl.Hostname,
+			ValidLife:  strconv.Itoa(kl.ValidLft),
+			ExpireTime: strconv.FormatInt(expire, 10),
+			SubnetID:   strconv.Itoa(kl.SubnetID),
+		})
+	}
+	return out, nil
+}
+
+// parseLeaseCSVDegradable reads the full Kea LFC file set like parseLeaseCSV but
+// is DEGRADE-tolerant for the display (#5938 Invariant 8): instead of ABORTING
+// the whole read when one sibling file cannot be opened (a non-IsNotExist error
+// — a mangled / permission-broken .2 / .1 / current), it SKIPS that file,
+// records its path, and continues, so a single unreadable sibling shows the
+// remaining leases plus a banner rather than blanking `show dhcp server leases`.
+// A genuinely-absent file (IsNotExist) is handled inside parseLeaseCSVFileInto
+// (returns nil) and is NOT a degradation — it is the common no-LFC steady state.
+// Returns the merged active leases and the list of skipped (unreadable) paths.
+func parseLeaseCSVDegradable(path string, now time.Time) ([]Lease, []string) {
+	acc := &leaseCSVAccum{
+		latest: make(map[string]Lease),
+		seen:   make(map[string]struct{}),
+	}
+	var skipped []string
+	for _, f := range keaLFCLeaseFilePaths(path) {
+		if err := parseLeaseCSVFileInto(f, now, acc); err != nil {
+			slog.Debug("dhcpserver: skipping unreadable Kea lease file for display",
+				"path", f, "err", err)
+			skipped = append(skipped, f)
+			continue
+		}
+	}
+	leases := make([]Lease, 0, len(acc.order))
+	for _, addr := range acc.order {
+		if l := acc.latest[addr]; l.Address != "" {
+			leases = append(leases, l)
+		}
+	}
+	return leases, skipped
+}

--- a/pkg/dhcpserver/lease_source_5938_test.go
+++ b/pkg/dhcpserver/lease_source_5938_test.go
@@ -1,0 +1,247 @@
+package dhcpserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// lease_source_5938_test.go pins the three Kea LFC lease-source invariants #5938
+// closed (residual from #5796/#5936):
+//   - Invariant 2: the DISPLAY path PREFERS the live lease_cmds socket over the
+//     memfile snapshot when the hook is expected (getDisplayLeases).
+//   - Invariant 3: the crash-interrupted-cleanup intermediates (.output/.completed)
+//     are provably safe to ignore (TestKeaLFCIntermediatesIgnored_5938).
+//   - Invariant 8: a DEGRADED source (socket-unavailable fallback, or an
+//     unreadable sibling) raises a banner on the show path.
+
+// ---- Invariant 2: live lease_cmds socket preference -----------------------
+
+// TestDisplayLeases_PrefersLiveSocket_5938 asserts that when the lease_cmds hook
+// is expected (lease-sync enabled) the display reads the LIVE lease DB, not the
+// memfile — proven by seeding the socket and the memfile with DIFFERENT leases
+// and requiring the socket's lease.
+//
+// FAIL-ON-REVERT: remove the socket-preference branch in getDisplayLeases (always
+// parse the memfile) → the memfile lease is returned instead of the socket lease
+// → the "socket lease present / memfile lease absent" assertions go RED.
+func TestDisplayLeases_PrefersLiveSocket_5938(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	sock := tmpSocket(t, "k4.sock")
+	stub := &stubKea{handler: func(cmd keaCommand) keaResponse {
+		if cmd.Command != "lease4-get-all" {
+			t.Errorf("unexpected command %q (want lease4-get-all — the live query)", cmd.Command)
+		}
+		return leaseGetAllResponse([]keaLeaseJSON{
+			{IPAddress: "10.0.0.50", HWAddress: "aa:bb:cc:dd:ee:50", SubnetID: 1,
+				ValidLft: 3600, CLTT: now.Unix() - 600, State: keaStateDefault, Hostname: "live-host"},
+		})
+	}}
+	dial, stop := startStubKea(t, sock, stub)
+	defer stop()
+
+	// The memfile holds a DIFFERENT lease so a memfile read is distinguishable.
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, memfile, lfcV4Header+"\n"+
+		"10.0.0.99,aa:bb:cc:dd:ee:99,,3600,"+lfcFuture+",1,0,1,memfile-host,0\n")
+
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(dial, sock, "", memfile, "")
+	m.SetLeaseSyncEnabled(true) // the hook is expected
+
+	leases, src := m.getDisplayLeases(4, now)
+	if src.Degraded {
+		t.Errorf("live socket read must NOT be degraded: %+v", src)
+	}
+	if src.Origin != leaseSourceLiveSocket {
+		t.Errorf("source origin = %q, want %q", src.Origin, leaseSourceLiveSocket)
+	}
+	if len(leases) != 1 || leases[0].Address != "10.0.0.50" {
+		t.Fatalf("want the LIVE socket lease 10.0.0.50, got %+v (a memfile lease 10.0.0.99 means the socket preference was skipped)", leases)
+	}
+	// The live query was actually issued.
+	if got := stub.seen(); len(got) != 1 || got[0].Command != "lease4-get-all" {
+		t.Fatalf("live lease4-get-all not issued: %+v", got)
+	}
+}
+
+// TestDisplayLeases_SocketUnavailableFallsBackDegraded_5938 covers the Invariant 2
+// fallback AND the Invariant 8 banner: the hook is expected but the socket is
+// unreachable, so the display falls back to the memfile and flags DEGRADED.
+//
+// FAIL-ON-REVERT (Invariant 8): drop the Degraded flag on the fallback source →
+// the banner is empty → the assertions below go RED.
+func TestDisplayLeases_SocketUnavailableFallsBackDegraded_5938(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, memfile, lfcV4Header+"\n"+
+		"10.0.0.99,aa:bb:cc:dd:ee:99,,3600,"+lfcFuture+",1,0,1,memfile-host,0\n")
+
+	m := New()
+	// ctrlSocket4 points at a path with no server → dial fails → fallback.
+	m.SetLeaseSyncSeamsForTesting(nil, filepath.Join(dir, "missing.sock"), "", memfile, "")
+	m.SetLeaseSyncEnabled(true) // the hook is EXPECTED, so the failure is a degradation
+
+	leases, src := m.getDisplayLeases(4, now)
+	if !src.Degraded {
+		t.Fatalf("an EXPECTED-but-unreachable socket must degrade the source: %+v", src)
+	}
+	if src.Banner() == "" {
+		t.Fatalf("degraded source must produce a non-empty banner")
+	}
+	// The memfile fallback still returns its leases (display not blanked).
+	if len(leases) != 1 || leases[0].Address != "10.0.0.99" {
+		t.Fatalf("fallback must return the memfile lease 10.0.0.99, got %+v", leases)
+	}
+}
+
+// TestDisplayLeases_NoHookNotDegraded_5938 guards against a FALSE degraded banner:
+// on a box WITHOUT the lease_cmds hook (lease-sync disabled) the memfile is the
+// normal authoritative source, so the read must NOT be degraded.
+func TestDisplayLeases_NoHookNotDegraded_5938(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, memfile, lfcV4Header+"\n"+
+		"10.0.0.99,aa:bb:cc:dd:ee:99,,3600,"+lfcFuture+",1,0,1,memfile-host,0\n")
+
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", "", memfile, "")
+	// leaseSyncEnabled defaults false — the hook is NOT expected.
+
+	leases, src := m.getDisplayLeases(4, now)
+	if src.Degraded {
+		t.Fatalf("a memfile read on a box without the hook must NOT be degraded: %+v", src)
+	}
+	if src.Banner() != "" {
+		t.Fatalf("healthy source must produce no banner, got %q", src.Banner())
+	}
+	if len(leases) != 1 || leases[0].Address != "10.0.0.99" {
+		t.Fatalf("want the memfile lease 10.0.0.99, got %+v", leases)
+	}
+}
+
+// TestDisplayLeases_UnreadableSiblingDegraded_5938 is the Invariant 8
+// mangled-sibling half: an unreadable LFC sibling (present but EACCES) is SKIPPED
+// (not aborted) and the source is flagged degraded, so the remaining leases still
+// display with a banner rather than blanking the show.
+//
+// FAIL-ON-REVERT: revert parseLeaseCSVDegradable to abort on the first file error
+// (the parseLeaseCSV behavior) → the show is blanked / errored instead of a
+// partial+banner; or drop the Degraded flag → banner empty. Either goes RED.
+func TestDisplayLeases_UnreadableSiblingDegraded_5938(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-000 unreadable-file test is meaningless as root (permission bypass)")
+	}
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	cur := filepath.Join(dir, "leases4.csv")
+
+	// CURRENT is readable with one active lease.
+	writeCSV(t, cur, lfcV4Header+"\n"+
+		"10.0.0.10,aa:bb:cc:dd:ee:10,,3600,"+lfcFuture+",1,0,1,host-a,0\n")
+	// PREVIOUS (.2) is PRESENT but UNREADABLE (EACCES on open, not IsNotExist).
+	unreadable := cur + ".2"
+	writeCSV(t, unreadable, lfcV4Header+"\n")
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", "", cur, "")
+
+	leases, src := m.getDisplayLeases(4, now)
+	if !src.Degraded {
+		t.Fatalf("an unreadable sibling must degrade the source: %+v", src)
+	}
+	if src.Banner() == "" {
+		t.Fatalf("degraded source must produce a non-empty banner")
+	}
+	// The readable current file's lease still displays (not blanked by the skip).
+	if len(leases) != 1 || leases[0].Address != "10.0.0.10" {
+		t.Fatalf("want the readable current lease 10.0.0.10 (skip must not blank the display), got %+v", leases)
+	}
+}
+
+// ---- Invariant 3: crash-interrupted-cleanup intermediates ignored ---------
+
+// TestKeaLFCIntermediatesIgnored_5938 proves the reader IGNORES kea-lfc's
+// crash-interrupted intermediates (.output/.completed): their presence does NOT
+// change the resolved lease set, and every lease reachable through them is still
+// covered by the .2/.1 union the reader actually ingests (the Invariant 3 safety
+// argument, documented at keaLFCLeaseFilePaths).
+func TestKeaLFCIntermediatesIgnored_5938(t *testing.T) {
+	now := lfcNow
+	dir := t.TempDir()
+	cur := filepath.Join(dir, "leases4.csv")
+
+	// The canonical LFC set the reader DOES ingest (.2 → .1 → current).
+	writeCSV(t, cur+".2", lfcV4Header+"\n"+ // PREVIOUS: lease B
+		"10.0.0.11,aa:bb:cc:dd:ee:11,,3600,"+lfcFuture+",1,0,1,host-b,0\n")
+	writeCSV(t, cur+".1", lfcV4Header+"\n"+ // INPUT: lease A
+		"10.0.0.10,aa:bb:cc:dd:ee:10,,3600,"+lfcFuture+",1,0,1,host-a,0\n")
+	writeCSV(t, cur, lfcV4Header+"\n") // CURRENT: fresh header-only append log
+
+	// Baseline: resolve WITHOUT any intermediates present.
+	base, err := parseLeaseCSV(cur, now)
+	if err != nil {
+		t.Fatalf("parseLeaseCSV baseline: %v", err)
+	}
+	baseSet := addrSet(base)
+	if !baseSet["10.0.0.10"] || !baseSet["10.0.0.11"] {
+		t.Fatalf("baseline must resolve A(.1) + B(.2): %+v", base)
+	}
+
+	// Now drop kea-lfc's crash-interrupted intermediates alongside the set.
+	// `.output` is kea-lfc's in-progress merge of (.1,.2) — here we also add a
+	// BOGUS unique lease C that lives ONLY in .output, to PROVE the reader never
+	// opens it (in reality .output ⊆ .1∪.2, so C could not exist; the bogus row
+	// makes the skip observable).
+	writeCSV(t, cur+".output", lfcV4Header+"\n"+
+		"10.0.0.10,aa:bb:cc:dd:ee:10,,3600,"+lfcFuture+",1,0,1,host-a,0\n"+
+		"10.0.0.77,aa:bb:cc:dd:ee:77,,3600,"+lfcFuture+",1,0,1,ONLY-in-output,0\n")
+	writeCSV(t, cur+".completed", "") // zero-content finish marker
+
+	after, err := parseLeaseCSV(cur, now)
+	if err != nil {
+		t.Fatalf("parseLeaseCSV with intermediates: %v", err)
+	}
+	afterSet := addrSet(after)
+
+	// (1) The intermediates do NOT change the resolved set.
+	if len(after) != len(base) || !sameSet(baseSet, afterSet) {
+		t.Fatalf(".output/.completed changed the resolved set: base=%+v after=%+v", base, after)
+	}
+	// (2) The lease living ONLY in .output is NOT present — .output is ignored.
+	if afterSet["10.0.0.77"] {
+		t.Fatalf(".output was READ (lease 10.0.0.77 leaked into the display) — must be ignored")
+	}
+	// (3) A lease reachable through .output (A) is still covered by .1.
+	if !afterSet["10.0.0.10"] {
+		t.Fatalf("lease A must remain covered by .1 independent of .output: %+v", after)
+	}
+}
+
+func addrSet(ls []Lease) map[string]bool {
+	m := make(map[string]bool, len(ls))
+	for _, l := range ls {
+		m[l.Address] = true
+	}
+	return m
+}
+
+func sameSet(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -90,8 +90,17 @@ func (s *Server) showDHCPServer(buf *strings.Builder) {
 		buf.WriteString("DHCP server not running\n")
 		return
 	}
-	leases4, _ := s.dhcpServer.GetLeases4()
-	leases6, _ := s.dhcpServer.GetLeases6()
+	// #5938 Invariant 2/8: prefer the live lease_cmds DB over the memfile
+	// snapshot, and surface a banner when the source is degraded (socket
+	// unavailable → memfile fallback, or an unreadable sibling was skipped) so a
+	// partial display is never mistaken for a healthy empty set.
+	leases4, src4 := s.dhcpServer.GetLeasesWithSource4()
+	leases6, src6 := s.dhcpServer.GetLeasesWithSource6()
+	if banner := src4.Banner(); banner != "" {
+		buf.WriteString(banner + "\n")
+	} else if banner := src6.Banner(); banner != "" {
+		buf.WriteString(banner + "\n")
+	}
 	if len(leases4) == 0 && len(leases6) == 0 {
 		buf.WriteString("No active leases\n")
 	}
@@ -170,8 +179,14 @@ func (s *Server) showDHCPServerDetail(cfg *config.Config, buf *strings.Builder) 
 	}
 	// Leases with subnet IDs
 	if s.dhcpServer != nil && s.dhcpServer.IsRunning() {
-		leases4, _ := s.dhcpServer.GetLeases4()
-		leases6, _ := s.dhcpServer.GetLeases6()
+		// #5938 Invariant 2/8: live-socket-preferred read + degraded-source banner.
+		leases4, src4 := s.dhcpServer.GetLeasesWithSource4()
+		leases6, src6 := s.dhcpServer.GetLeasesWithSource6()
+		if banner := src4.Banner(); banner != "" {
+			buf.WriteString(banner + "\n")
+		} else if banner := src6.Banner(); banner != "" {
+			buf.WriteString(banner + "\n")
+		}
 		if len(leases4) == 0 && len(leases6) == 0 {
 			buf.WriteString("Active leases: none\n")
 		}


### PR DESCRIPTION
## Residual from #5796 / #5936

#5796/#5936 fixed the core lease-loss / DDNS mass-delete fail-open (all Kea memfile consumers read the full LFC file set `.2 → .1 → current`, last-row-wins, via the shared `keaLFCLeaseFilePaths`). Three invariants were explicitly deferred as fidelity/observability hardening (none an active lease-loss path). **This closes all three.**

## Invariant 2 — live `lease_cmds` socket preference (display)

The HA-sync `getSyncLeases` path already preferred the live lease DB; the DISPLAY path did not. New `getDisplayLeases` (`lease_source.go`), exposed as `GetLeasesWithSource{4,6}`, queries `lease{4,6}-get-all` over the control socket (reusing the HA-sync `keaControl` / `keaLeaseGetAllArgs` plumbing) **when the hook is EXPECTED** (`leaseSyncEnabled`), falling back to the memfile only when the socket is unavailable. Key nuance: on a box **without** the hook the memfile is the normal authoritative source, so a memfile read there is **not** flagged degraded — no false banner on non-lease-sync boxes. `GetLeases{4,6}` are left untouched (the interactive CLI keeps its #4908 file-read-error surface).

## Invariant 3 — crash-interrupted-cleanup safety

kea-lfc can leave `.output`/`.completed` intermediates on a crash. The reader already ignores them; this adds the **exact safety argument** (documented at `keaLFCLeaseFilePaths`) rather than a generation protocol (unnecessary for a read-only path): every lease reachable through `.output` is a subset of `.1 ∪ .2` (kea-lfc merges them to build `.output`) which the reader already ingests, and the atomic `.output → .2` swap means no active lease is ever reachable **only** through an intermediate — so a torn cleanup can never present a stale-yet-authoritative set. `.completed` is a zero-content finish marker.

## Invariant 8 — degraded-source display banner

A `LeaseSource` (`Origin`/`Degraded`/`Detail` + `Banner()`) is threaded from the read to the authoritative gRPC `show dhcp server` handler. When degraded — expected live socket unavailable (memfile fallback), or a present LFC sibling unreadable and skipped — a one-line banner prints above the lease table so a partial display is never mistaken for a healthy empty set. The display memfile read is now degrade-tolerant (`parseLeaseCSVDegradable`): an unreadable sibling is **skipped** (recorded), not aborted, so one mangled `.2` no longer blanks the whole show.

## Fail-on-revert tests (pkg/dhcpserver — each confirmed RED on revert)

| Inv | Test | Revert → RED |
|---|---|---|
| 2 | `TestDisplayLeases_PrefersLiveSocket` (+ `NoHookNotDegraded` guard) | disable socket-preference branch → memfile lease returned |
| 8 | `TestDisplayLeases_SocketUnavailableFallsBackDegraded` | drop `Degraded` on fallback → empty banner |
| 8 | `TestDisplayLeases_UnreadableSiblingDegraded` | drop skip-record → not degraded |
| 3 | `TestKeaLFCIntermediatesIgnored` | add `.output` to `keaLFCLeaseFilePaths` → `.output`-only lease leaks |

## Validation

`go build ./...`; `go vet ./pkg/dhcpserver/ ./pkg/grpcapi/`; `go test -race ./pkg/dhcpserver/ ./pkg/grpcapi/ -count=1` — **all GREEN**. Not a failover change (read-path fidelity + display), so no `test-failover`. Go-only (dhcpserver is Go), no cargo.

Docs: `pkg/dhcpserver/README.md` moves invariants 2/3/8 from deferred to implemented.

Closes #5938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2F3h4kxf29m6X8BszpM5p