### PR TITLE
control plane: fix reentrant session-scan double-acquire via in-process admission lease (#5880 core)

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -832,6 +832,29 @@ under the daemon's errgroup. Nothing else imports this package.
     longer issue unbounded full-table scans; over-cap gRPC scans return
     `codes.ResourceExhausted`. A mix of REST + gRPC scrapers cannot collectively
     exceed `diagcmd.MaxConcurrentSessionWalks`.
+    **#5880 makes the shared limiter request-graph-aware to fix a reentrant
+    double-acquire.** A REST list/summary/zone-pair handler acquires a slot and
+    then delegates IN-PROCESS to the gRPC session service for `include_peer`
+    fan-out; that service acquired the SAME limiter AGAIN, double-charging one
+    logical operation and self-rejecting at capacity (`include_peer` failed under
+    load). The fix is an unforgeable **in-process admission lease** carried on
+    `context.Context` (`diagcmd.Limiter.AcquireCtx`, keyed by the private
+    `leaseKey{*Limiter}` — never derivable from any external header): the FIRST
+    handler to admit at the external trust boundary stamps the lease on the
+    context it delegates on (REST re-stamps the request via `r.WithContext`), and
+    the nested gRPC entry point REUSES that slot instead of re-acquiring. The
+    lease is **per-request-graph, not global**: two DISTINCT external requests
+    each acquire independently (the per-node bound is preserved), and the lease
+    never crosses a process/network boundary, so a peer node's own gRPC entry
+    acquires its own local slot (remote admission unchanged). Release stays
+    idempotent + cancellation-safe (a real slot via `sync.Once`; the lease-reuse
+    path is a no-op). Pinned by `TestAcquireCtx_5880` (mechanism),
+    `TestGetSessions_InProcessLeaseReuse_5880` (gRPC reuse at cap 1), and
+    `TestRESTIncludePeerReusesLease_5880` (REST include_peer succeeds at cap 1),
+    each RED on revert. The BROADER redesign #5880 also asks for — structural
+    per-surface admission via a registration/source-level test, weighted cost for
+    local+peer/cursor/clear, and a separate remote budget — is deferred to a
+    follow-up.
     **#5779 extends the SAME shared bound to the session-CLEAR (mutation)
     path**, which was the remaining uncovered full-table walk: `ClearAllSessions`
     is a chunked full-table scan+delete (not O(1)), and the gRPC `ClearSessions`

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -109,13 +109,21 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 	// rather than each driving its own simultaneous walk. Release on every
 	// exit path via defer. This covers both the offset and cursor paths. The
 	// limiter is shared with the summary/zone-pair scans (#5433).
-	release, err := sessionWalkLimiter.Acquire()
+	//
+	// #5880: acquire once at THIS external trust boundary and re-stamp the
+	// request context with the returned in-process admission lease. The
+	// include_peer fan-out (writeSessionList) delegates to the in-process gRPC
+	// session service on r.Context(), so re-stamping r propagates the lease and
+	// that nested call REUSES this slot instead of re-acquiring the same limiter
+	// and self-rejecting at capacity.
+	release, walkCtx, err := sessionWalkLimiter.AcquireCtx(r.Context())
 	if err != nil {
 		writeError(w, http.StatusTooManyRequests,
 			"session list concurrency limit reached; retry shortly")
 		return
 	}
 	defer release()
+	r = r.WithContext(walkCtx)
 
 	view := s.buildSessionView()
 	q, errMsg := buildSessionQuery(r, view)
@@ -647,13 +655,18 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, r *http.Request) {
 	// over-cap request is rejected with HTTP 429 instead of driving its own
 	// simultaneous walk. Release on every exit path via the deferred idempotent
 	// release; nothing is released on the ErrBusy path (release is nil there).
-	release, err := sessionWalkLimiter.Acquire()
+	//
+	// #5880: acquire once at this boundary and re-stamp r with the in-process
+	// admission lease so the include_peer delegation to the in-process gRPC
+	// GetSessionSummary reuses this slot rather than re-acquiring.
+	release, walkCtx, err := sessionWalkLimiter.AcquireCtx(r.Context())
 	if err != nil {
 		writeError(w, http.StatusTooManyRequests,
 			"session scan concurrency limit reached; retry shortly")
 		return
 	}
 	defer release()
+	r = r.WithContext(walkCtx)
 
 	var summary SessionSummary
 
@@ -866,13 +879,18 @@ func (s *Server) sessionZonePairHandler(w http.ResponseWriter, r *http.Request) 
 	// walk. Gate after the not-loaded early return, which serves an empty
 	// breakdown without walking. Release on every exit path via the deferred
 	// idempotent release; nothing is released on the ErrBusy path.
-	release, err := sessionWalkLimiter.Acquire()
+	//
+	// #5880: acquire once at this boundary and re-stamp r with the in-process
+	// admission lease so the include_peer delegation to the in-process gRPC
+	// GetZonePairSummary reuses this slot rather than re-acquiring.
+	release, walkCtx, err := sessionWalkLimiter.AcquireCtx(r.Context())
 	if err != nil {
 		writeError(w, http.StatusTooManyRequests,
 			"session scan concurrency limit reached; retry shortly")
 		return
 	}
 	defer release()
+	r = r.WithContext(walkCtx)
 
 	// Build zone ID -> name reverse map
 	zoneNames := make(map[uint16]string)

--- a/pkg/api/sessions_lease_5880_test.go
+++ b/pkg/api/sessions_lease_5880_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// leaseProbeCluster is a ClusterSessionService that models the in-process gRPC
+// session service: its GetSessions re-enters the SAME session-walk limiter via
+// AcquireCtx (exactly as the real grpcapi.Server.GetSessions now does). With the
+// REST boundary's admission lease propagated on ctx it reuses the slot; without
+// it, at capacity 1, it self-rejects — the #5880 double-acquire.
+type leaseProbeCluster struct {
+	admitted   bool
+	selfReject bool
+}
+
+func (c *leaseProbeCluster) GetSessions(ctx context.Context, _ *pb.GetSessionsRequest) (*pb.GetSessionsResponse, error) {
+	release, _, err := sessionWalkLimiter.AcquireCtx(ctx)
+	if err != nil {
+		c.selfReject = true
+		return nil, err
+	}
+	defer release()
+	c.admitted = true
+	// A non-nil Peer makes writeSessionList attach the peer set, so the REST
+	// response observably proves the delegation succeeded end-to-end.
+	return &pb.GetSessionsResponse{Peer: &pb.GetSessionsResponse{NodeId: 1}}, nil
+}
+
+func (c *leaseProbeCluster) ClearSessions(context.Context, *pb.ClearSessionsRequest) (*pb.ClearSessionsResponse, error) {
+	return &pb.ClearSessionsResponse{}, nil
+}
+func (c *leaseProbeCluster) GetSessionSummary(context.Context, *pb.GetSessionSummaryRequest) (*pb.GetSessionSummaryResponse, error) {
+	return &pb.GetSessionSummaryResponse{}, nil
+}
+func (c *leaseProbeCluster) GetZonePairSummary(context.Context, *pb.GetZonePairSummaryRequest) (*pb.GetZonePairSummaryResponse, error) {
+	return &pb.GetZonePairSummaryResponse{}, nil
+}
+
+// TestRESTIncludePeerReusesLease_5880 proves a REST include_peer list at
+// capacity 1 SUCCEEDS: the REST handler acquires the one slot, stamps the
+// in-process admission lease on the request context, and the include_peer
+// delegation to the in-process session service REUSES that slot rather than
+// self-rejecting. The peer set is attached in the response.
+//
+// FAIL-ON-REVERT: drop the `r = r.WithContext(walkCtx)` re-stamp in
+// sessionsHandler → the delegation runs on an unstamped context → the probe's
+// AcquireCtx finds no lease, tries to acquire at capacity 1 (the REST slot is
+// held), gets ErrBusy → selfReject=true, the peer is not attached → RED.
+func TestRESTIncludePeerReusesLease_5880(t *testing.T) {
+	orig := sessionWalkLimiter
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+	defer func() { sessionWalkLimiter = orig }()
+
+	probe := &leaseProbeCluster{}
+	dp := &cancelCountDP{Manager: dataplane.New(), nV4: 0} // loaded, empty local table
+	s := &Server{
+		dp:               dp,
+		clusterSessionFn: func() ClusterSessionService { return probe },
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions?include_peer=true", nil)
+	s.sessionsHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST include_peer at cap 1 returned HTTP %d, want 200 (self-reject regression): %s",
+			rr.Code, rr.Body.String())
+	}
+	if probe.selfReject {
+		t.Fatalf("in-process delegate self-rejected at cap 1 — the REST admission lease was NOT " +
+			"propagated to the include_peer fan-out (#5880 double-acquire)")
+	}
+	if !probe.admitted {
+		t.Fatalf("in-process delegate was never invoked/admitted")
+	}
+
+	// The handler wraps the list in {"success":true,"data":{...}}.
+	var env struct {
+		Success bool                `json:"success"`
+		Data    SessionListResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode REST body: %v", err)
+	}
+	if env.Data.Peer == nil {
+		t.Fatalf("peer sessions not attached — the include_peer fan-out was rejected under the limiter")
+	}
+}
+
+// TestRESTConcurrentDistinctRequestsBounded_5880 confirms the lease is
+// per-request-graph, not a global disable: two DISTINCT external REST list
+// requests at capacity 1 cannot both hold the slot — one is rejected with HTTP
+// 429 while the other holds it. (A leaked global lease would let the second in.)
+func TestRESTConcurrentDistinctRequestsBounded_5880(t *testing.T) {
+	orig := sessionWalkLimiter
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+	defer func() { sessionWalkLimiter = orig }()
+
+	// Hold the single slot to simulate one in-flight distinct request.
+	release, _, err := sessionWalkLimiter.AcquireCtx(context.Background())
+	if err != nil {
+		t.Fatalf("prime acquire: %v", err)
+	}
+	defer release()
+
+	s := &Server{dp: &cancelCountDP{Manager: dataplane.New(), nV4: 0}}
+	rr := httptest.NewRecorder()
+	// A SECOND distinct external request (fresh context, no lease) must be
+	// rejected — the limiter is at capacity.
+	s.sessionsHandler(rr, httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil))
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("second distinct request at cap 1 returned HTTP %d, want 429 "+
+			"(the lease must not globally open the limiter)", rr.Code)
+	}
+}

--- a/pkg/diagcmd/limiter.go
+++ b/pkg/diagcmd/limiter.go
@@ -1,6 +1,7 @@
 package diagcmd
 
 import (
+	"context"
 	"errors"
 	"sync"
 )
@@ -62,6 +63,53 @@ func (l *Limiter) Acquire() (release func(), err error) {
 	default:
 		return nil, ErrBusy
 	}
+}
+
+// leaseKey is the private, per-Limiter context key for an in-process admission
+// lease (#5880). Keyed by the *Limiter identity so a lease taken on one limiter
+// is never mistaken for another's, and UNFORGEABLE from outside the process: the
+// type is unexported and context values cannot be constructed from any external
+// input (HTTP header / gRPC metadata / request body), so only AcquireCtx below
+// can stamp it.
+type leaseKey struct{ l *Limiter }
+
+// AcquireCtx is the request-graph-aware form of Acquire (#5880). It admits ONE
+// logical scan per in-process request graph instead of once per handler, closing
+// the reentrant double-acquire where an outer handler (e.g. a REST list) holds a
+// slot and then delegates in-process to another handler (the gRPC session
+// service) that acquired the SAME limiter again — self-rejecting its own fan-out
+// at capacity.
+//
+//   - If ctx already carries THIS limiter's in-process admission lease (an
+//     ancestor handler in this process already acquired a slot and propagated
+//     the returned context), AcquireCtx returns a NO-OP release and ctx unchanged
+//     WITHOUT taking a second slot — the nested work reuses the ancestor's
+//     admission.
+//   - Otherwise it takes a slot exactly like Acquire (fail-fast, ErrBusy over
+//     cap) and returns a real release PLUS a child context stamped with the
+//     lease. The caller MUST propagate that context to any in-process delegation
+//     so the delegate reuses this slot instead of re-acquiring.
+//
+// The lease is per-REQUEST-GRAPH, NOT global: two DISTINCT external requests each
+// begin with an unstamped context and each acquire independently, so the global
+// per-node bound is preserved — only NESTED in-process delegation within ONE
+// request skips. The lease does NOT cross a process/network boundary (context
+// values are process-local and never serialized onto the wire), so a peer node's
+// own gRPC entry point sees no lease and acquires its own local slot — remote
+// admission is unchanged.
+//
+// The returned release is idempotent and cancellation-safe on BOTH paths: a real
+// slot rides Acquire's sync.Once, and the lease-reuse path is a bare no-op, so a
+// deferred release can never over-release another caller's slot.
+func (l *Limiter) AcquireCtx(ctx context.Context) (release func(), out context.Context, err error) {
+	if ctx.Value(leaseKey{l}) != nil {
+		return func() {}, ctx, nil
+	}
+	rel, err := l.Acquire()
+	if err != nil {
+		return nil, ctx, err
+	}
+	return rel, context.WithValue(ctx, leaseKey{l}, struct{}{}), nil
 }
 
 // InFlight reports the number of slots currently held. Intended for

--- a/pkg/diagcmd/limiter_lease_5880_test.go
+++ b/pkg/diagcmd/limiter_lease_5880_test.go
@@ -1,0 +1,98 @@
+package diagcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestAcquireCtx_5880 pins the in-process admission-lease semantics (#5880):
+// nested in-process delegation (a context carrying THIS limiter's lease) reuses
+// the ancestor's slot without re-acquiring, while a DISTINCT external request
+// (no lease) is still bounded — the lease is per-request-graph, never a global
+// disable. Release is idempotent + cancellation-safe on both paths.
+//
+// FAIL-ON-REVERT: drop the lease check in AcquireCtx (always Acquire) → at
+// capacity 1 the lease-reuse acquire below gets ErrBusy → the "lease reuse
+// acquire" fatal fires RED.
+func TestAcquireCtx_5880(t *testing.T) {
+	l := NewLimiter(1)
+
+	// Boundary acquire (no lease yet) — takes the single slot, stamps the lease.
+	rel1, leased, err := l.AcquireCtx(context.Background())
+	if err != nil {
+		t.Fatalf("first AcquireCtx: %v", err)
+	}
+	if l.InFlight() != 1 {
+		t.Fatalf("after boundary acquire InFlight=%d, want 1", l.InFlight())
+	}
+
+	// A DISTINCT external request (fresh, unstamped context) at capacity 1 is
+	// still bounded — the lease must NOT globally disable the limiter.
+	if _, _, err := l.AcquireCtx(context.Background()); !errors.Is(err, ErrBusy) {
+		t.Fatalf("distinct external request at cap 1: err=%v, want ErrBusy "+
+			"(the lease must not globally open the limiter)", err)
+	}
+
+	// Nested in-process delegation carrying the lease reuses the slot — no
+	// second charge, ctx unchanged.
+	rel2, leased2, err := l.AcquireCtx(leased)
+	if err != nil {
+		t.Fatalf("lease reuse AcquireCtx self-rejected at cap 1: %v", err)
+	}
+	if l.InFlight() != 1 {
+		t.Fatalf("lease reuse took an extra slot: InFlight=%d, want 1", l.InFlight())
+	}
+	if leased2 != leased {
+		t.Errorf("lease reuse must return the context unchanged")
+	}
+
+	// The lease-reuse release is a no-op — it must not free the ancestor's slot.
+	rel2()
+	if l.InFlight() != 1 {
+		t.Fatalf("lease-reuse release freed a slot: InFlight=%d, want 1", l.InFlight())
+	}
+
+	// The real release frees the one slot and is idempotent (double release safe:
+	// it must not over-release and free another caller's slot).
+	rel1()
+	rel1()
+	if l.InFlight() != 0 {
+		t.Fatalf("after release (incl. double) InFlight=%d, want 0", l.InFlight())
+	}
+
+	// A fresh acquire succeeds again now the slot is free.
+	rel3, _, err := l.AcquireCtx(context.Background())
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	rel3()
+}
+
+// TestAcquireCtx_PerLimiterKey_5880 confirms a lease is scoped to its OWN
+// limiter: a lease taken on limiter A does not let a nested acquire on a
+// different limiter B skip B's admission.
+func TestAcquireCtx_PerLimiterKey_5880(t *testing.T) {
+	a := NewLimiter(1)
+	b := NewLimiter(1)
+
+	relA, leasedA, err := a.AcquireCtx(context.Background())
+	if err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	defer relA()
+
+	// Fill B to capacity so a re-acquire would fail if the A-lease wrongly
+	// applied to B.
+	relB, _, err := b.AcquireCtx(context.Background())
+	if err != nil {
+		t.Fatalf("acquire B: %v", err)
+	}
+	defer relB()
+
+	// The A-lease context must NOT satisfy B — B is at capacity, so a nested
+	// acquire on B carrying only the A-lease must be bounded.
+	if _, _, err := b.AcquireCtx(leasedA); !errors.Is(err, ErrBusy) {
+		t.Fatalf("A-lease wrongly reused B's admission: err=%v, want ErrBusy", err)
+	}
+}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -62,7 +62,14 @@ func (s *Server) GetSessions(ctx context.Context, req *pb.GetSessionsRequest) (*
 	// than each driving its own simultaneous walk. The limiter is SHARED with
 	// the REST session scans, so a mix of REST+gRPC callers cannot collectively
 	// exceed the aggregate bound. Release on every exit path via defer.
-	release, err := sessionWalkLimiter.Acquire()
+	//
+	// #5880: use the request-graph-aware AcquireCtx so a REST list/summary
+	// handler that already holds a slot and delegates to this RPC IN-PROCESS
+	// (carrying the admission lease on ctx) REUSES that slot instead of
+	// re-acquiring the same limiter and self-rejecting its own include_peer
+	// fan-out at capacity. A direct external gRPC call carries no lease and
+	// acquires exactly one slot as before.
+	release, _, err := sessionWalkLimiter.AcquireCtx(ctx)
 	if err != nil {
 		return nil, status.Error(codes.ResourceExhausted,
 			"session scan concurrency limit reached; retry shortly")
@@ -763,7 +770,11 @@ func (s *Server) GetSessionSummary(ctx context.Context, req *pb.GetSessionSummar
 	// lock contention as the list). Gate it through the SAME shared limiter as
 	// GetSessions and the REST scans so a gRPC scrape flood cannot drive
 	// unbounded concurrent walks. Release on every exit path via defer.
-	release, err := sessionWalkLimiter.Acquire()
+	//
+	// #5880: AcquireCtx reuses an in-process admission lease so a REST
+	// summary handler delegating here for include_peer does not double-charge
+	// the limiter; a direct external gRPC caller acquires once as before.
+	release, _, err := sessionWalkLimiter.AcquireCtx(ctx)
 	if err != nil {
 		return nil, status.Error(codes.ResourceExhausted,
 			"session scan concurrency limit reached; retry shortly")
@@ -916,7 +927,11 @@ func (s *Server) GetZonePairSummary(ctx context.Context, req *pb.GetZonePairSumm
 	// zone-pairs is bounded on REST but unbounded on gRPC. Release on every exit
 	// path via defer; the peer fan-out below dials the peer (which gates its own
 	// walk), so this holds only the local slot.
-	release, err := sessionWalkLimiter.Acquire()
+	//
+	// #5880: AcquireCtx reuses an in-process admission lease so a REST zone-pair
+	// handler delegating here for include_peer does not double-charge the
+	// limiter; a direct external gRPC caller acquires once as before.
+	release, _, err := sessionWalkLimiter.AcquireCtx(ctx)
 	if err != nil {
 		return nil, status.Error(codes.ResourceExhausted,
 			"session scan concurrency limit reached; retry shortly")

--- a/pkg/grpcapi/sessions_lease_5880_test.go
+++ b/pkg/grpcapi/sessions_lease_5880_test.go
@@ -1,0 +1,75 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// emptyWalkGRPCDP is a minimal loaded dataplane whose session walk is empty, so
+// GetSessions reaches (and returns from) the limiter-gated walk without needing
+// a real conntrack table. It embeds *dataplane.Manager to satisfy the rest of
+// grpcRuntime (unused methods return the Manager's not-loaded/not-found errors).
+type emptyWalkGRPCDP struct{ *dataplane.Manager }
+
+func (emptyWalkGRPCDP) IsLoaded() bool { return true }
+func (emptyWalkGRPCDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return nil
+}
+func (emptyWalkGRPCDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+// TestGetSessions_InProcessLeaseReuse_5880 proves the gRPC session service reuses
+// an in-process admission lease instead of re-acquiring the shared limiter: at
+// capacity 1, a nested in-process call (carrying the lease a REST boundary
+// stamped) SUCCEEDS, while a direct external gRPC call (no lease) is still
+// bounded with ResourceExhausted.
+//
+// FAIL-ON-REVERT: restore the unconditional gRPC re-acquire (sessionWalkLimiter
+// .Acquire() instead of .AcquireCtx(ctx)) → at capacity 1 the leased in-process
+// call self-rejects with ResourceExhausted → the first assertion goes RED.
+func TestGetSessions_InProcessLeaseReuse_5880(t *testing.T) {
+	orig := sessionWalkLimiter
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+	defer func() { sessionWalkLimiter = orig }()
+
+	store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	s := &Server{dp: emptyWalkGRPCDP{dataplane.New()}, store: store}
+
+	// Model the REST external trust boundary: acquire the single slot and obtain
+	// the lease-stamped context it would delegate on.
+	release, leasedCtx, err := sessionWalkLimiter.AcquireCtx(context.Background())
+	if err != nil {
+		t.Fatalf("boundary acquire: %v", err)
+	}
+	defer release()
+	if got := sessionWalkLimiter.InFlight(); got != 1 {
+		t.Fatalf("after boundary acquire InFlight=%d, want 1", got)
+	}
+
+	// The nested in-process gRPC call carrying the lease MUST reuse the slot, not
+	// self-reject at capacity 1.
+	if _, err := s.GetSessions(leasedCtx, &pb.GetSessionsRequest{}); err != nil {
+		t.Fatalf("in-process GetSessions self-rejected at cap 1 (lease not honored — "+
+			"the #5880 double-acquire): %v", err)
+	}
+
+	// A DIRECT external gRPC call (no lease) at capacity 1 is still bounded.
+	_, err = s.GetSessions(context.Background(), &pb.GetSessionsRequest{})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("external gRPC GetSessions at cap 1: err=%v, want ResourceExhausted "+
+			"(the lease must not globally disable the limiter)", err)
+	}
+}


### PR DESCRIPTION
## Problem (#5880)

The session-walk semaphore (`diagcmd.SessionWalkLimiter`) is a process-wide bound shared by every full conntrack-table scan, but ownership was attached per-handler rather than propagated through a request graph. A REST list/summary/zone-pair handler acquires a slot and then delegates **in-process** to the gRPC session service for `include_peer` fan-out — and that service acquired the **same** limiter again. The nested delegation **double-charged** one logical operation, so at/near capacity an `include_peer` request **self-rejected** (`ResourceExhausted` / HTTP failure), with behavior depending on which surface initiated the scan.

Evidence: `pkg/api/sessions.go` (REST acquires) → `svc.GetSessions(...)` in-process → `pkg/grpcapi/server_sessions.go` (gRPC re-acquires the same `diagcmd.SessionWalkLimiter`).

## Fix — in-process admission lease (the clean core)

- **`diagcmd.Limiter.AcquireCtx(ctx)`**: request-graph-aware `Acquire`. If `ctx` already carries **this** limiter's lease (an ancestor already admitted in-process), it returns a **no-op release** and reuses that slot. Otherwise it acquires fail-fast and returns a child context stamped with the lease. Keyed by the private `leaseKey{*Limiter}` — **unforgeable** from any external header (context values are never derived from the wire) and **per-limiter-instance**.
- **REST** list/summary/zone-pair acquire once at the external boundary and re-stamp the request (`r.WithContext`) with the lease, so the `include_peer` delegation reuses the slot.
- **gRPC** `GetSessions`/`GetSessionSummary`/`GetZonePairSummary` use `AcquireCtx`: a nested in-process call carrying the lease reuses the slot; a **direct external** gRPC call carries no lease and acquires exactly one slot as before.

**Invariants preserved:** the lease is **per-request-graph, not global** — two distinct external requests each acquire independently (per-node bound holds); the lease never crosses a process/network boundary, so a **peer node's own gRPC entry acquires its own local slot** (remote admission unchanged). Release is idempotent + cancellation-safe on both paths. The REST clear path is **not** a double-acquire (delegates before its fallback acquire) and is unchanged; non-delegation gRPC scan sites (SessionCount/sessions-top/buffers) keep their single `Acquire`.

## Fail-on-revert tests (each RED on revert — one per production half)

| Layer | Test | Revert → RED |
|---|---|---|
| diagcmd | `TestAcquireCtx_5880` (+ per-limiter-key) | remove `AcquireCtx` lease check → reuse-at-cap-1 self-rejects |
| grpcapi | `TestGetSessions_InProcessLeaseReuse_5880` | gRPC `AcquireCtx` → plain `Acquire` → leased call `ResourceExhausted` at cap 1 |
| api | `TestRESTIncludePeerReusesLease_5880` | drop `r.WithContext(walkCtx)` → delegate self-rejects, peer not attached |

`TestRESTConcurrentDistinctRequestsBounded_5880` also confirms two distinct requests at cap 1 stay bounded (HTTP 429) — the lease is not a global disable.

## Closes vs Addresses

**`Closes #5880`** — the double-charge/self-reject is the material bug and it is fully fixed for all three in-process delegation paths (list/summary/zone-pair). The broader admission **redesign** the issue also enumerates — structural per-surface admission via a registration/source-level test, weighted cost for local+peer/cursor/clear, a separate remote budget (plus the adjacent redundant local double-**walk**) — is deferred to **#5968** with the scan-surface inventory.

## Validation

`go build ./...`; `go vet ./pkg/api/ ./pkg/grpcapi/ ./pkg/diagcmd/`; `go test -race ./pkg/api/ ./pkg/grpcapi/ ./pkg/diagcmd/ -count=1` — **all GREEN** (-race matters: concurrency). Control-plane admission (not failover), so no `test-failover`. Docs: `pkg/api/README.md` documents the in-process lease.

Closes #5880
Refs #5968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2F3h4kxf29m6X8BszpM5p