### PR TITLE
appid: match session application filter case-sensitively (#5820)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -49114,3 +49114,31 @@ top.
     0x8100/untagged/reject cases stay green).
   - **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/cbpf_8021ad_5088_test.go,
     pkg/vrrp/README.md
+
+- **Timestamp**: 2026-07-16
+  - **Action**: #5820 AppID session-match case sensitivity (Option A). Made
+    SessionMatches (pkg/appid/runtime.go) compare the operator `show`/`clear ...
+    application <name>` filter against the resolved application name with
+    case-EXACT equality (`==`) instead of strings.EqualFold. Application names are
+    case-sensitive identifiers everywhere else in the stack (parser, store,
+    resolver, catalog, AppID stamping), so the fold was the sole inconsistency: a
+    single-case filter collapsed two distinct apps on the display path and — since
+    the same predicate drives the destructive ClearSessions walk — broadened a
+    filtered clear to delete sessions the operator did not name. Coupled refinement
+    of #5821: relaxed validateReservedApplicationNamesStrict (compiler_validate_
+    strict_application.go) from EqualFold to exact `==` on both the application and
+    application-set walks — the sentinel is only ever rendered upper-case UNKNOWN
+    and matching is now case-exact, so only an app literally named UNKNOWN can
+    alias it; `unknown`/`Unknown` are now ACCEPTED. Flipped the #5821
+    TestReservedApplicationNameCaseVariantsRejected → CaseVariantsAccepted; updated
+    TestSessionMatchesUnknown to case-exact; added TestSessionMatchesCaseSensitive-
+    5820 (Payroll/payroll + JUNOS-HTTP/junos-http). Fail-on-revert proven for all
+    three (restoring EqualFold turns them RED). No dataplane/catalog/wire change; no
+    config previously accepted is now rejected (one #5821 class is re-accepted).
+    Validation: go build ./..., go vet, go test -race ./pkg/appid ./pkg/config all
+    green.
+  - **File(s)**: pkg/appid/runtime.go, pkg/appid/runtime_test.go,
+    pkg/appid/session_match_case_5820_test.go,
+    pkg/config/compiler_validate_strict_application.go,
+    pkg/config/compiler_reserved_appname_5821_test.go,
+    docs/services-application-identification.md

--- a/docs/services-application-identification.md
+++ b/docs/services-application-identification.md
@@ -113,24 +113,43 @@ upfront what they're getting and not getting.
      alone (#3428); the session source port is threaded into
      `ResolveSessionName` for this purpose.
 
-**`UNKNOWN` name reserved out of the user namespace (#5821)**:
-because `ResolveSessionName` returns the literal `UNKNOWN` for the
-unclassified/unstamped/catalog-skew state and `SessionMatches`
+**Filter matching is case-sensitive (#5820)**: `SessionMatches`
 (`pkg/appid/runtime.go`) compares an operator `show ... application
-<name>` / `clear ... application <name>` filter against that same
-flattened name, a user-defined application (or application-set) named
-`UNKNOWN` would be indistinguishable from the sentinel — the filter
-could not tell "no known application" from the configured app, and a
-destructive filtered session clear could delete both groups. A
-commit-time gate (`validateReservedApplicationNamesStrict`,
+<name>` / `clear ... application <name>` filter against the session's
+resolved application name with **case-EXACT equality** (`==`, not
+`strings.EqualFold`). Application names are case-sensitive identifiers
+everywhere else in the stack — the parser, typed store, resolver,
+catalog, and AppID stamping all preserve and key on exact case, so
+`Payroll` and `payroll` are two DISTINCT applications with distinct
+AppIDs and distinct session labels, and a user `JUNOS-HTTP` never
+folds onto the predefined `junos-http`. The pre-#5820 fold was the sole
+inconsistency: it let a single-case filter collapse two distinct
+applications on the display path and — because the same predicate drives
+the destructive `ClearSessions` walk — broaden a filtered clear to delete
+sessions the operator did not name. Junos application filters are
+case-exact, so exact matching is the parity contract. Regression:
+`pkg/appid` `TestSessionMatchesCaseSensitive5820` (fail-on-revert).
+
+**`UNKNOWN` name reserved out of the user namespace (#5821, relaxed to
+exact-case in #5820)**: because `ResolveSessionName` returns the literal
+upper-case `UNKNOWN` for the unclassified/unstamped/catalog-skew state and
+`SessionMatches` compares an operator filter against that same flattened
+name, a user-defined application (or application-set) named `UNKNOWN`
+would be indistinguishable from the sentinel — the filter could not tell
+"no known application" from the configured app, and a destructive filtered
+session clear could delete both groups. A commit-time gate
+(`validateReservedApplicationNamesStrict`,
 `pkg/config/compiler_validate_strict_application.go`) therefore
 **reserves `UNKNOWN` out of the `applications application` /
-`applications application-set` namespace, case-insensitively**
-(`SessionMatches` folds case, so `unknown`/`Unknown` alias the sentinel
-too). The reserved literal `config.ReservedApplicationName` is kept
-equal to `appid.Unknown` by the `pkg/appid`
-`TestReservedApplicationNameMatchesUnknownSentinel` canary. This is a
-**new fail-closed restriction** (release-note behavior change): a
+`applications application-set` namespace, case-sensitively**. The
+sentinel is only ever rendered upper-case `UNKNOWN`, and now that filter
+matching is case-exact (#5820), only an application literally named
+`UNKNOWN` can alias it — `unknown` / `Unknown` are distinct names that are
+now ACCEPTED (this is the #5820 relaxation of the original #5821
+case-insensitive reservation). The reserved literal
+`config.ReservedApplicationName` is kept equal to `appid.Unknown` by the
+`pkg/appid` `TestReservedApplicationNameMatchesUnknownSentinel` canary.
+This is a **fail-closed restriction** (release-note behavior change): a
 previously-valid config that already named an application `UNKNOWN` now
 hard-rejects on the operator's next commit. The tolerant load / peer-sync
 path downgrades the reject to a warning so an already-persisted or

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -207,11 +207,24 @@ func ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto ui
 	return resolveTupleFallback(proto, srcPort, dstPort, cfg)
 }
 
+// SessionMatches reports whether a session's resolved application name equals
+// the operator's `show`/`clear ... application <name>` filter.
+//
+// The comparison is CASE-SENSITIVE exact equality (#5820). Application names
+// are case-sensitive identifiers everywhere else in the stack — the parser,
+// typed store, resolver, catalog, and AppID stamping all preserve and key on
+// exact case, so `Payroll` and `payroll` are two distinct applications with
+// distinct AppIDs and distinct session labels. A case-folded filter compare
+// here (the pre-#5820 strings.EqualFold) was the sole inconsistency: it let a
+// single-case filter collapse two distinct applications on the display path and
+// — because the same predicate drives the destructive ClearSessions walk —
+// broaden a filtered clear to delete sessions the operator did not name. Junos
+// application filters are case-exact, so exact `==` here is the parity contract.
 func SessionMatches(filter string, appNames map[uint16]string, cfg *config.Config, proto uint8, srcPort, dstPort uint16, appID uint16) bool {
 	if filter == "" {
 		return true
 	}
-	return strings.EqualFold(ResolveSessionName(appNames, cfg, proto, srcPort, dstPort, appID), filter)
+	return ResolveSessionName(appNames, cfg, proto, srcPort, dstPort, appID) == filter
 }
 
 func sortedNames(names map[string]struct{}) []string {

--- a/pkg/appid/runtime_test.go
+++ b/pkg/appid/runtime_test.go
@@ -424,11 +424,19 @@ func TestResolveTupleFallbackNoMislabelOnMalformedPort(t *testing.T) {
 	}
 }
 
+// TestSessionMatchesUnknown pins the case-EXACT match of the UNKNOWN sentinel
+// (#5820). An unclassified session (app_id 0 with AppID enabled) resolves to the
+// upper-case sentinel "UNKNOWN", so only the exact "UNKNOWN" filter selects it —
+// a lowercase "unknown" filter no longer folds onto it.
 func TestSessionMatchesUnknown(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Services.ApplicationIdentification = true
-	if !SessionMatches("unknown", nil, cfg, 6, 40000, 80, 0) {
-		t.Fatal("SessionMatches() should match UNKNOWN when AppID is enabled")
+	if !SessionMatches("UNKNOWN", nil, cfg, 6, 40000, 80, 0) {
+		t.Fatal("SessionMatches(\"UNKNOWN\") should match the unclassified sentinel when AppID is enabled")
+	}
+	// #5820: case-exact — the lowercase spelling must NOT fold onto the sentinel.
+	if SessionMatches("unknown", nil, cfg, 6, 40000, 80, 0) {
+		t.Fatal("SessionMatches(\"unknown\") must NOT match the upper-case UNKNOWN sentinel (case-sensitive, #5820)")
 	}
 }
 

--- a/pkg/appid/session_match_case_5820_test.go
+++ b/pkg/appid/session_match_case_5820_test.go
@@ -1,0 +1,86 @@
+package appid
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5820: the operational `show`/`clear ... application <name>` filter must
+// identify exactly ONE application. Application names are case-sensitive
+// identifiers end to end — the parser, typed store, resolver, catalog, and
+// AppID stamping all preserve and key on exact case — so two applications
+// differing only in case ("Foo" vs "foo") are DISTINCT, receive distinct
+// AppIDs, and stamp distinct session labels. SessionMatches was the sole
+// case-folding component (strings.EqualFold): it let a single-case filter
+// collapse two distinct applications on the display path and — because the same
+// predicate drives the destructive ClearSessions walk — broaden a filtered
+// clear to delete sessions the operator did not name. This regression pins the
+// case-EXACT predicate.
+//
+// FAIL-ON-REVERT: restoring the pre-#5820 predicate
+//   strings.EqualFold(ResolveSessionName(...), filter)
+// makes the case-mismatch assertions below over-match (filter "foo" wrongly
+// matches the "Foo" session, filter "junos-http" wrongly matches the
+// "JUNOS-HTTP" session), turning this test RED — the required fail-on-revert
+// acceptance test for the over-delete/over-collapse bug.
+func TestSessionMatchesCaseSensitive5820(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = true
+
+	// Distinct-case apps get distinct AppIDs; the map mirrors what BuildCatalog
+	// stamps for a config that legitimately defines both "Foo" and "foo".
+	appNames := map[uint16]string{
+		1: "Foo",
+		2: "foo",
+		3: "http",
+		4: "JUNOS-HTTP", // user app whose name folds onto a predefined name
+		5: "junos-http", // predefined-style name
+	}
+
+	// Helper: a TCP/80 session carrying the given app_id.
+	match := func(filter string, appID uint16) bool {
+		return SessionMatches(filter, appNames, cfg, 6, 40000, 80, appID)
+	}
+
+	// A session resolved to "Foo" must NOT match the lower-case filter "foo",
+	// and MUST match the exact "Foo". (RED on revert: EqualFold folds "foo"
+	// onto "Foo".)
+	if match("foo", 1) {
+		t.Error("SessionMatches: filter \"foo\" must NOT match a session resolved to \"Foo\" (case-sensitive, #5820)")
+	}
+	if !match("Foo", 1) {
+		t.Error("SessionMatches: filter \"Foo\" must match a session resolved to \"Foo\"")
+	}
+
+	// The distinct lower-case session matches only its own exact name.
+	if !match("foo", 2) {
+		t.Error("SessionMatches: filter \"foo\" must match a session resolved to \"foo\"")
+	}
+	if match("Foo", 2) {
+		t.Error("SessionMatches: filter \"Foo\" must NOT match a session resolved to \"foo\" (case-sensitive, #5820)")
+	}
+
+	// "http" matches only the exact spelling.
+	if !match("http", 3) {
+		t.Error("SessionMatches: filter \"http\" must match a session resolved to \"http\"")
+	}
+	if match("HTTP", 3) {
+		t.Error("SessionMatches: filter \"HTTP\" must NOT match a session resolved to \"http\" (case-sensitive, #5820)")
+	}
+
+	// User-vs-predefined case collision: a user "JUNOS-HTTP" and a "junos-http"
+	// must not collapse. The filter "junos-http" selects only the exact
+	// "junos-http" session, never the user "JUNOS-HTTP" one. (RED on revert.)
+	if match("junos-http", 4) {
+		t.Error("SessionMatches: filter \"junos-http\" must NOT match a session resolved to \"JUNOS-HTTP\" (no case collapse, #5820)")
+	}
+	if !match("junos-http", 5) {
+		t.Error("SessionMatches: filter \"junos-http\" must match a session resolved to \"junos-http\"")
+	}
+
+	// An empty filter still matches everything (unchanged select-all behavior).
+	if !match("", 1) {
+		t.Error("SessionMatches: an empty filter must match any session")
+	}
+}

--- a/pkg/config/compiler_reserved_appname_5821_test.go
+++ b/pkg/config/compiler_reserved_appname_5821_test.go
@@ -14,11 +14,16 @@ import (
 // sessions from the configured app, and a filtered clear could delete both.
 //
 // These tests pin the strict reject at commit (CompileConfig) for the
-// application, application-set, and multi-term (implicit-set) spellings and for
-// every casing variant (SessionMatches folds case, so the reservation is
-// case-insensitive), plus the lenient downgrade-to-warning on the tolerant load
-// / peer-sync path (CompileConfigLenient) so an already-persisted config still
-// boots (#1960).
+// application, application-set, and multi-term (implicit-set) spellings of the
+// EXACT sentinel `UNKNOWN`, plus the lenient downgrade-to-warning on the
+// tolerant load / peer-sync path (CompileConfigLenient) so an already-persisted
+// config still boots (#1960).
+//
+// #5820 relaxed the reservation from case-insensitive to case-sensitive: the
+// sentinel is only ever rendered upper-case `UNKNOWN` and SessionMatches now
+// compares filters case-exactly, so casing variants ("unknown"/"Unknown") are
+// distinct application names that no longer alias the sentinel and are ACCEPTED
+// (see TestReservedApplicationNameCaseVariantsAccepted).
 //
 // buildTreeFromSet (ipsec_proposal_ref_test.go) builds the candidate tree the
 // way the configstore does (ParseSetCommand + SetPath), NOT NewParser — the
@@ -42,20 +47,24 @@ func TestReservedApplicationNameRejected(t *testing.T) {
 	}
 }
 
-// Casing variants must collide too: SessionMatches folds case, so "unknown" and
-// "Unknown" alias the sentinel just as "UNKNOWN" does.
-func TestReservedApplicationNameCaseVariantsRejected(t *testing.T) {
+// #5820: casing variants are now DISTINCT application names, not aliases of the
+// sentinel. The sentinel is only ever rendered upper-case `UNKNOWN` by
+// ResolveSessionName and SessionMatches compares filters case-exactly, so
+// "unknown"/"Unknown"/"uNkNoWn" can no longer collide with `UNKNOWN` on the
+// display/filter surface — the reservation is case-sensitive and ACCEPTS them.
+//
+// FAIL-ON-REVERT: restoring the pre-#5820 case-fold predicate in
+// validateReservedApplicationNamesStrict (strings.EqualFold(name,
+// ReservedApplicationName)) makes CompileConfig REJECT these variants again, so
+// this test goes RED (expects acceptance, gets a reserved-name error).
+func TestReservedApplicationNameCaseVariantsAccepted(t *testing.T) {
 	for _, variant := range []string{"unknown", "Unknown", "uNkNoWn"} {
 		tree := buildTreeFromSet(t, []string{
 			"set applications application " + variant + " protocol tcp",
 			"set applications application " + variant + " destination-port 80",
 		})
-		_, err := CompileConfig(tree)
-		if err == nil {
-			t.Fatalf("CompileConfig: expected rejection of application named %q (case variant of the sentinel), got nil", variant)
-		}
-		if !strings.Contains(err.Error(), "reserved") {
-			t.Fatalf("variant %q: unexpected error text: %v", variant, err)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig: expected case variant %q of the sentinel to be ACCEPTED (case-sensitive reservation, #5820), got: %v", variant, err)
 		}
 	}
 }

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -743,17 +743,20 @@ const ReservedApplicationName = "UNKNOWN"
 // validateReservedApplicationNamesStrict hard-rejects, at commit /
 // commit-check, a user-defined `applications application <name>` or
 // `applications application-set <name>` whose name equals the AppID unknown
-// sentinel (ReservedApplicationName == "UNKNOWN") CASE-INSENSITIVELY (#5821).
+// sentinel (ReservedApplicationName == "UNKNOWN") CASE-SENSITIVELY (#5821,
+// relaxed to exact-case in #5820).
 //
 // Without this reservation the sentinel and a real catalog application share
 // one flat string on the AppID display/filter surface (ResolveSessionName /
 // SessionMatches, pkg/appid/runtime.go): `show ... application UNKNOWN` cannot
 // tell truly-unknown sessions from sessions classified as the user application,
 // and the destructive `clear ... application UNKNOWN` selector can delete both
-// groups. SessionMatches already folds case (strings.EqualFold), so "unknown"
-// and "Unknown" collide with the sentinel too; the reservation is therefore
-// case-insensitive to keep the whole case-folded name-slot owned by the
-// sentinel.
+// groups. The sentinel is only ever rendered upper-case `UNKNOWN` by
+// ResolveSessionName, and SessionMatches now compares filters case-exactly
+// (#5820), so only an application literally named `UNKNOWN` can alias it —
+// "unknown"/"Unknown" are distinct names that no longer collide. The
+// reservation is therefore case-sensitive, matching the case-exact namespace
+// contract of the store/catalog.
 //
 // Applications and application-sets share one flat Junos namespace, and a
 // multi-term application additionally mints an implicit application-set under
@@ -785,7 +788,7 @@ func validateReservedApplicationNamesStrict(cfg *Config) error {
 	}
 	sort.Strings(appNames)
 	for _, name := range appNames {
-		if strings.EqualFold(name, ReservedApplicationName) {
+		if name == ReservedApplicationName {
 			return reservedApplicationNameError("application", name)
 		}
 	}
@@ -795,7 +798,7 @@ func validateReservedApplicationNamesStrict(cfg *Config) error {
 	}
 	sort.Strings(setNames)
 	for _, name := range setNames {
-		if strings.EqualFold(name, ReservedApplicationName) {
+		if name == ReservedApplicationName {
 			return reservedApplicationNameError("application-set", name)
 		}
 	}
@@ -809,7 +812,7 @@ func reservedApplicationNameError(kind, name string) error {
 	return fmt.Errorf(
 		"applications %s %q: %q is reserved as the AppID \"no known application\" "+
 			"sentinel and may not name a user application or application-set "+
-			"(reserved case-insensitively) — the `show`/`clear ... application "+
+			"(reserved exact-case) — the `show`/`clear ... application "+
 			"<name>` filter and the session renderer cannot distinguish a real "+
 			"application named %q from the unclassified/unstamped state, so a "+
 			"filtered session clear could delete both; rename it (#5821)",


### PR DESCRIPTION
## Summary

Fixes #5820 (AppID: case-insensitive session matching collapses valid application names and broadens destructive clears) via **Option A** of the research plan (`docs/research/5820-appid-case-match/plan.md`): make the operator application filter match **case-sensitively** and relax the coupled #5821 reservation to exact-case.

`SessionMatches` (`pkg/appid/runtime.go`) compared the operator `show`/`clear ... application <name>` filter against the session's resolved application name with `strings.EqualFold`. Application names are **case-sensitive identifiers everywhere else** in the stack — the parser, typed store, resolver, catalog, and AppID stamping all preserve and key on exact case, so `Payroll` and `payroll` compile to two distinct applications with distinct AppIDs and distinct session labels, and a user `JUNOS-HTTP` never resolves onto the predefined `junos-http`. The fold was the sole inconsistency: a single-case filter collapsed two distinct apps on the display path and — because the same predicate drives the destructive `ClearSessions` walk — **broadened a filtered clear to delete sessions the operator did not name** (the security core of the issue).

## Changes

- **`pkg/appid/runtime.go`** — `SessionMatches` now compares with case-exact `==` instead of `strings.EqualFold`. Junos application filters are case-exact, so this is the parity contract. `strings` stays imported (still used by `portInSpec`).
- **`pkg/config/compiler_validate_strict_application.go`** — coupled refinement of #5821: `validateReservedApplicationNamesStrict` reserved the whole case-fold class of `UNKNOWN` *only because* `SessionMatches` folded. With matching now case-exact, only an app literally named `UNKNOWN` can alias the upper-case-only sentinel, so both the application and application-set walks change to `==`; the doc comment and error message drop "case-insensitively". This **relaxes** the reservation — `unknown`/`Unknown` are accepted again.
- **Docs** — `docs/services-application-identification.md`: filter contract now states filters are case-sensitive; the #5821 reservation note flips from case-insensitive to exact-case.

## Behavior change (release note)

Application filter matching **and** the `UNKNOWN` reservation are now **case-sensitive**, matching Junos. A config class that #5821 newly rejected (`application unknown`/`Unknown`) is accepted again; **no config previously accepted is now rejected**. No dataplane/catalog/wire change.

## Coupled #5821 test flip

`TestReservedApplicationNameCaseVariantsRejected` → **`TestReservedApplicationNameCaseVariantsAccepted`**: `unknown`/`Unknown`/`uNkNoWn` now accepted; the exact `UNKNOWN` (application, application-set, multi-term implicit set) stays rejected; the lenient downgrade and the cross-package `TestReservedApplicationNameMatchesUnknownSentinel` canary are unchanged.

## Fail-on-revert

- `pkg/appid/TestSessionMatchesCaseSensitive5820` (new) — restoring `strings.EqualFold` makes filter `foo` over-match the `Foo` session and `junos-http` over-match `JUNOS-HTTP` → RED (verified).
- `pkg/appid/TestSessionMatchesUnknown` — restoring the fold makes lowercase `unknown` fold onto the sentinel → RED (verified).
- `pkg/config/TestReservedApplicationNameCaseVariantsAccepted` — restoring the fold re-rejects the variants → RED (verified).

## Validation

`go build ./...`, `go vet ./pkg/appid ./pkg/config`, `go test -race ./pkg/appid ./pkg/config -count=1` all green. No other app-name `EqualFold` consumer exists (remaining `EqualFold` sites in `pkg/cli`/`pkg/api` are protocol filters). Control-plane appid/config semantics only — not failover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116fN43oibuQf9fb5JcKfeF