### PR TITLE
config: reject peer-only interface-unit alias collisions (#5878 Phase 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -49114,3 +49114,20 @@ top.
     0x8100/untagged/reject cases stay green).
   - **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/cbpf_8021ad_5088_test.go,
     pkg/vrrp/README.md
+
+- **Timestamp**: 2026-07-16 (fix/5878-canonical-unit-collision)
+  - **Action**: #5878 Phase 1 — CanonicalLogicalUnit normalizer + both-node
+    union interface-unit alias collision gate. Added CanonicalLogicalUnit to
+    schema_validators.go (ValidateLogicalUnit now delegates); rewrote
+    validateInterfaceUnitAliasCollisionsAST into a pre-expansion both-node
+    union (View 1 group union + Views 2/3 node0/node1 expansions) modeled on
+    validateTunnelEndpointIDCollisionAST; relocated its call from
+    runPreWalkGates into the pre-expansion gate block of
+    compileConfigForNodeWithOpts + compileConfigWithOpts so a peer-only
+    groups-node1/${node} alias that collides only in the STANDBY view is
+    rejected at a node0 commit. Lenient path stays warn-only (#1960). Phase 2
+    (reference-binder threading) deferred.
+  - **File(s)**: pkg/config/schema_validators.go,
+    pkg/config/compiler_interface_unit_alias.go, pkg/config/compiler.go,
+    pkg/config/compiler_prewalk.go,
+    pkg/config/interface_unit_parity_5878_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -262,7 +262,7 @@ valid-compiles-to-expected-if_id + tolerant-warn + schema-layer reject +
 #2933-non-regression, each RED on revert to the silent `continue` / untyped
 leaf).
 
-### Numeric interface-unit alias collision fail-closed (#5631)
+### Numeric interface-unit alias collision fail-closed (#5631, both-node union #5878)
 
 `compileInterfaces` (`compiler_interfaces.go`) keys logical units by their
 numeric value: it iterates `namedInstances(child.FindChildren("unit"))` and
@@ -285,29 +285,76 @@ DIFFERENT security state. Rather than pick an arbitrary winner (exactly the
 order-dependent ambiguity that makes this unsafe), the fix REJECTS the aliased
 config at commit so the operator authors a single canonical `unit <n>`:
 
-- **Compiled-config strict gate** — `validateInterfaceUnitAliasCollisionsAST`
-  (`compiler_interface_unit_alias.go`), wired into `runPreWalkGates`
-  (`compiler_prewalk.go`) after `expandInterfaceRanges`. It groups the distinct
-  raw unit spellings under each interface by their canonical `strconv.Atoi`
-  value (mirroring the compiler's own split) and, when two DISTINCT spellings
-  resolve to the same number, hard-rejects on the strict commit / commit-check
-  path naming the interface, the spellings, and the canonical unit — and
-  downgrades to a `cfg.Warnings` entry on the tolerant load / peer-sync path
+- **Compiled-config strict gate (both-node union)** —
+  `validateInterfaceUnitAliasCollisionsAST` (`compiler_interface_unit_alias.go`).
+  It groups the distinct raw unit spellings under each interface by their
+  canonical unit and, when two DISTINCT spellings resolve to the same unit,
+  hard-rejects on the strict commit / commit-check path naming the interface,
+  the spellings, and the canonical unit — and downgrades to a `cfg.Warnings`
+  entry on the tolerant load / peer-sync path
   (`lenientInterfaceUnitAliasCollisions`, #1960 fail-closed-on-load class), so an
   already-persisted or peer-synced config an older binary accepted still boots.
+
+**One canonical normalizer (#5878).** Canonicalization is centralized in
+`CanonicalLogicalUnit(raw) (int, string, error)` (`schema_validators.go`), the
+ONE function that folds every alias spelling of a numeric unit to its shared
+identity (`01`==`1`, `+1`==`1`, `-0`/`00`==`0`), rejecting a malformed /
+out-of-range token via the same range check `ValidateLogicalUnit` has always
+used (`ValidateLogicalUnit` now delegates to it, so validation and
+canonicalization can never diverge). The alias gate keys collisions by this
+canonical unit.
+
+**Both-node-effective union — the #5878 gap.** The #5631 gate originally ran
+INSIDE `compileExpanded` (`runPreWalkGates`) AFTER
+`tree.ExpandGroupsWithVars({node: nodeN})`, so it saw only the SUBMITTING node's
+post-`${node}` effective view, and commit compiles `s.nodeID` alone
+(`Store.compileTree` → `CompileConfigForNode`). A peer-only
+`groups node1 { … unit 01 }` applied through `apply-groups "${node}"` folds its
+aliasing spelling onto a base `unit 1` ONLY in the standby's effective view —
+invisible at a node0 commit. The active node commits green; the standby's
+compiled config then diverges (a different firewall filter / address set) and a
+failover silently changes forwarding / security posture despite a
+"synchronized" commit. The gate is now the BOTH-NODE UNION, modeled exactly on
+`validateTunnelEndpointIDCollisionAST` (`tunnelid.go`) and run in the
+**pre-expansion** gate block of `compileConfigForNodeWithOpts` /
+`compileConfigWithOpts` (beside the tunnel/zone/table-id gates):
+  - **View 1** — the pre-expansion presence union across every `interfaces`
+    root AND every `groups` block, grouped per interface by canonical unit.
+  - **Views 2/3** — the concrete per-interface unit spellings after expanding
+    the candidate for node0 and node1 (`ExpandGroupsWithVars` +
+    `expandInterfaceRanges`), so a wildcard / interface-range apply-group whose
+    alias only lands on a concrete interface post-expansion is caught. Per-node
+    expansion errors are non-fatal (contribute the empty set); View 1 still
+    covers any collision inside an un-expandable group.
+  Because all three views are pure functions of the same candidate config
+  (Views 2/3 computed on both nodes), the accept/reject verdict is IDENTICAL on
+  node0 and node1 (no originator-accepts / peer-rejects split) and MONOTONE over
+  the old single-view gate — the same HA-symmetry argument `tunnelid.go` makes.
+  A node0 commit now rejects a node1-only alias collision.
 
 The gate is surgical: a single canonical `unit 0` (the overwhelming common case)
 and distinct unit numbers (`unit 0` + `unit 1`) never trip it, and same-spelling
 flat-set lines merge into one AST node upstream (they are the same unit, not an
 alias) — so non-colliding compilation is bit-identical. A non-numeric unit token
-is now REJECTED at commit rather than silently skipped (see the #5829 gate
+is REJECTED at commit rather than silently skipped (see the #5829 gate
 below). Where a duplicate-spelling config ALSO produces a
 pre-expansion tunnel-endpoint-id collision (#1873), that earlier gate rejects
 first — either way the aliased config is refused, never silently committed.
 Covered by `pkg/config/interface_unit_alias_5631_test.go` (both config orders
-reject identically = order-independent, lenient-warn, non-colliding-commits) and
+reject identically = order-independent, lenient-warn, non-colliding-commits),
+`pkg/config/interface_unit_parity_5878_test.go` (peer-only-node1 collision
+rejected at a node0 commit, both-node verdict parity, alias-form + injection-
+vector matrices, VLAN-split regression guards, `CanonicalLogicalUnit` units) and
 the reconciled `tunnelid_test.go` duplicate-spelling case, each RED on revert of
-the gate wiring.
+the gate wiring (the parity test goes RED — node0 accepts — when the gate is put
+back node-local).
+
+**Phase 2 (deferred, #5878):** thread `CanonicalLogicalUnit` through the
+zone / CoS / routing-instance / NAT reference binders and the snapshot / status
+emitters so a `.01` reference resolves to the same runtime unit as the
+interface's canonical `.1` everywhere (the second, subtler half of #5878).
+Phase 1 (this section) closes the divergent-commit fail-open — the material
+security bug — and is sized separately from the reference-binder threading.
 
 ### Non-numeric logical-unit identity fail-closed (#5829)
 
@@ -323,7 +370,9 @@ the undefined-filter-reference gate.
 
 The fix is fail-CLOSED at two layers, both keyed to one canonical validator
 `ValidateLogicalUnit` (`schema_validators.go`, range `0..MaxLogicalUnit` = 16385
-— non-numeric, negative, integer overflow, and out-of-range all fail):
+— non-numeric, negative, integer overflow, and out-of-range all fail; since
+#5878 it delegates the validation half to `CanonicalLogicalUnit` so the same
+function both validates AND emits the canonical identity):
 
 - **Schema (strict commit/check):** the `unit` node carries
   `keyValidator: ValidateLogicalUnit`, so `commit`/`commit check`

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2251,6 +2251,19 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 		return nil, dupBlockErr
 	}
 
+	// #5878: numeric interface-unit alias gate (#5631) as a BOTH-NODE-effective
+	// union. Runs PRE-expansion, beside the tunnel/zone/table-id gates, so a
+	// peer-only `groups node1`/`${node}` alias that collides only in the
+	// STANDBY node's effective view is rejected at commit even on a generic
+	// (non-node) compile — the union is a pure function of the candidate and
+	// verdict-identical across both nodes. Strict rejects; lenient warns
+	// (#1960). See validateInterfaceUnitAliasCollisionsAST.
+	unitAliasWarnings, unitAliasErr := validateInterfaceUnitAliasCollisionsAST(
+		tree, opts.lenientInterfaceUnitAliasCollisions)
+	if unitAliasErr != nil {
+		return nil, unitAliasErr
+	}
+
 	usedNodeFallback := false
 
 	// Expand groups before compilation — resolve all apply-groups references.
@@ -2277,6 +2290,7 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 	cfg.Warnings = append(cfg.Warnings, zoneIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
+	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
 	return cfg, nil
 }
 
@@ -2467,6 +2481,19 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 		return nil, dupBlockErr
 	}
 
+	// #5878: numeric interface-unit alias gate (#5631) as a BOTH-NODE-effective
+	// union — see compileConfigWithOpts. Pre-expansion on purpose: the union
+	// across View 1 (groups) + Views 2/3 (node0/node1 expansions) is identical
+	// on both nodes, so a `groups node1`/`${node}` alias that collides only in
+	// the peer's effective view is rejected here even when THIS commit compiles
+	// s.nodeID alone (the #5878 divergent-commit defect). Strict rejects on the
+	// operator commit / commit-check path; lenient warns on load / peer-sync.
+	unitAliasWarnings, unitAliasErr := validateInterfaceUnitAliasCollisionsAST(
+		tree, opts.lenientInterfaceUnitAliasCollisions)
+	if unitAliasErr != nil {
+		return nil, unitAliasErr
+	}
+
 	vars := map[string]string{"node": fmt.Sprintf("node%d", nodeID)}
 	if err := tree.ExpandGroupsWithVars(vars); err != nil {
 		return nil, fmt.Errorf("apply-groups: %w", err)
@@ -2489,6 +2516,7 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 	cfg.Warnings = append(cfg.Warnings, zoneIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
+	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
 	return cfg, nil
 }
 

--- a/pkg/config/compiler_interface_unit_alias.go
+++ b/pkg/config/compiler_interface_unit_alias.go
@@ -3,14 +3,14 @@ package config
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 )
 
 // compiler_interface_unit_alias.go carries the #5631 (codex-review-181 M23)
 // reject-at-commit gate for numeric interface-unit ALIASES — two distinct
 // unit-number spellings under one interface that canonicalize to the SAME
-// logical unit.
+// logical unit — PROMOTED in #5878 to a BOTH-NODE-EFFECTIVE union gate that
+// runs PRE-expansion so a peer-only alias is caught at either node's commit.
 //
 // The compiler keys logical units by the numeric value: compileInterfaces
 // (compiler_interfaces.go) iterates `namedInstances(child.FindChildren("unit"))`
@@ -48,54 +48,164 @@ import (
 // the sibling silent-inconsistency gates (validateApplicationNameCollisionsAST,
 // validateFirewallFilterFamilyCollisionsAST, #1960 / #3261).
 //
-// Strict path (commit / commit-check, lenient=false): the first interface with
-// a numeric unit-alias collision is a hard compile error naming the interface,
-// the colliding spellings, and the canonical unit number.
+// # Both-node union (#5878)
+//
+// The #5631 gate originally ran INSIDE compileExpanded (runPreWalkGates) AFTER
+// `tree.ExpandGroupsWithVars({node: nodeN})`, so it saw exactly the SUBMITTING
+// node's post-`${node}` effective view. A `groups node1 { … unit 01 }` block
+// applied through `apply-groups "${node}"` folds its aliasing spelling onto a
+// base `unit 1` ONLY in the standby node's effective view — invisible at a
+// node0 commit (Store.compileTree compiles s.nodeID only). The active node
+// commits green; the standby's compiled config then diverges (a different
+// firewall filter / address set) and a failover silently changes forwarding
+// or security posture despite a "synchronized" commit (#5878).
+//
+// This gate is now the BOTH-NODE UNION, modeled EXACTLY on
+// validateTunnelEndpointIDCollisionAST (tunnelid.go), and runs in the
+// PRE-expansion gate block of compileConfigForNodeWithOpts /
+// compileConfigWithOpts (beside the tunnel/zone/table-id gates):
+//
+//	View 1 — the PRE-expansion presence union across every top-level
+//	  "interfaces" root AND every "groups" block, grouping raw unit spellings
+//	  under each interface by canonical unit. Catches a collision hidden inside
+//	  an un-expandable / node-inverted group and keeps the verdict identical on
+//	  both nodes (a `groups node0`-scoped alias must reject on node1 too, or
+//	  config-sync would split — originator accepts, peer rejects).
+//	View 2 — the concrete per-interface unit spellings after expanding the
+//	  candidate for node0 (ExpandGroupsWithVars + expandInterfaceRanges).
+//	View 3 — the same for node1.
+//
+// Views 2/3 close the wildcard / interface-range gap: an apply-group that
+// carries the aliasing spelling onto interfaces named by a wildcard or range
+// registers only the literal wildcard name in View 1 (which never matches the
+// base interface), so only post-expansion do both concrete spellings land on
+// the same interface. Per-node expansion errors are NON-FATAL and contribute
+// the EMPTY set (mirrors emitNodeExpandedTunnelNames): a config with only
+// `groups node0` legitimately fails node1 expansion, and View 1 still covers
+// any collision inside the un-expandable group. Because all three views are
+// pure functions of the SAME candidate config (Views 2/3 both computed on both
+// nodes), the union — and therefore the accept/reject verdict — is IDENTICAL on
+// node0 and node1, and it is MONOTONE over the old single-view gate (it only
+// ADDS rejects). Same HA-symmetry / monotonicity safety argument tunnelid.go
+// makes.
+//
+// Strict path (commit / commit-check, lenient=false): the lowest colliding
+// canonical unit on the lowest-named interface is a hard compile error naming
+// the interface, the colliding spellings, and the canonical unit number.
 //
 // Lenient path (load / peer-sync, lenient=true): every collision is returned as
-// a warning and compilation continues with the (arbitrary but deterministic-
-// for-a-fixed-config) last-writer result, so an already-persisted or peer-
-// synced config an older binary silently accepted still BOOTS. The operator
-// gets the warning as the signal to collapse the aliases.
+// a warning and compilation continues, so an already-persisted or peer-synced
+// config an older binary silently accepted still BOOTS (#1960 no-brick
+// doctrine). The operator gets the warning as the signal to collapse the
+// aliases.
 //
 // This is an AST pre-walk (not a SchemaValidate typed leaf) for the same
 // reason as validateUnsupportedInterfaceStanzasAST: the colliding instances
 // are merged away by last-writer-wins by the time the typed `ifc.Units` map
-// exists — only the raw AST still carries every spelling. It runs on the
-// group-expanded, inactive-pruned tree (runPreWalkGates), so an
-// apply-groups-inherited or interface-range-expanded unit alias is caught and
-// an `inactive:` unit is ignored for free.
+// exists — only the raw AST still carries every spelling. Inactive subtrees are
+// pruned before the pre-expansion gate block runs (cloneForExpansion), so an
+// `inactive:` unit is ignored for free.
 //
 // Detection is scoped to DISTINCT spellings that canonicalize to the same
 // number: a single canonical `unit 0` (the overwhelming common case) never
 // trips it, and flat-set `set` lines with the SAME spelling merge into one AST
-// node upstream (they are the same unit, not an alias). A non-numeric unit
-// token is skipped — the compiler `continue`s on the identical Atoi error, so
-// it never reaches `ifc.Units` and cannot collide.
-func validateInterfaceUnitAliasCollisionsAST(nodes []*Node, lenient bool) ([]string, error) {
-	// #5744: union across EVERY top-level `interfaces` root, not just the first.
-	// A hierarchical config can split its interfaces across two sibling
-	// `interfaces { }` stanzas, and compileSections compiles them all — so a
-	// unit-alias collision living in a SECOND root was skipped by the old
-	// first-root-only scan, the sibling gap PR #5741 closed for the
-	// interface-range / stable-ID gates (expandInterfaceRanges,
-	// validateZoneIDCollisionAST). Flattening every interfaces root's children
-	// into one per-interface pass is equivalent to nesting a loop over the roots:
-	// compileInterfaces stores each interface node with whole-interface
-	// last-writer-wins (`ifaces.Interfaces[ifName] = ifc`), so the collision is
-	// always intra-node and each interface node is detected independently,
-	// exactly as before.
-	var ifaceChildren []*Node
-	sawInterfaces := false
-	for _, n := range nodes {
-		if n.Name() == "interfaces" {
-			sawInterfaces = true
-			ifaceChildren = append(ifaceChildren, n.Children...)
+// node upstream (they are the same unit, not an alias). A non-numeric or
+// out-of-range unit token is skipped — the compiler `continue`s on the
+// identical CanonicalLogicalUnit error, so it never reaches `ifc.Units` and
+// cannot collide.
+
+// collectInterfaceUnitSpellingsAST folds the distinct raw unit spellings under
+// each interface of one "interfaces" hierarchy node into perIface, keyed by
+// interface name then by CANONICAL logical unit (#5878). Two spellings that
+// CanonicalLogicalUnit maps to the same int land in the same inner set — that
+// is the collision the gate rejects. A malformed / out-of-range unit token is
+// dropped (the compiler drops it too), mirroring the pre-#5878 strconv.Atoi
+// skip so detection matches what compileInterfaces actually consumes.
+func collectInterfaceUnitSpellingsAST(ifacesNode *Node, perIface map[string]map[int]map[string]bool) {
+	if ifacesNode == nil {
+		return
+	}
+	for _, iface := range ifacesNode.Children {
+		ifName := iface.Name()
+		if ifName == "" {
+			continue
+		}
+		for _, inst := range namedInstances(iface.FindChildren("unit")) {
+			num, _, err := CanonicalLogicalUnit(inst.name)
+			if err != nil {
+				continue
+			}
+			if perIface[ifName] == nil {
+				perIface[ifName] = make(map[int]map[string]bool)
+			}
+			if perIface[ifName][num] == nil {
+				perIface[ifName][num] = make(map[string]bool)
+			}
+			perIface[ifName][num][inst.name] = true
 		}
 	}
-	if !sawInterfaces {
-		return nil, nil
+}
+
+// collectNodeExpandedInterfaceUnitSpellings folds the per-interface unit
+// spellings the compiler would see after expanding the candidate tree for
+// chassis-cluster node nodeID into perIface (#5878 Views 2/3). It clones the
+// candidate, resolves apply-groups "${node}" for the node, expands interface
+// ranges (so a range/wildcard member's alias is seen exactly as the real
+// runPreWalkGates path sees it), and collects every top-level "interfaces"
+// root's units. Mirrors emitNodeExpandedTunnelNames: per-node expansion errors
+// are NON-FATAL and contribute the empty set (View 1 still covers a collision
+// inside an un-expandable group), so the verdict stays a pure function of the
+// candidate config and is identical on both nodes.
+func collectNodeExpandedInterfaceUnitSpellings(tree *ConfigTree, nodeID int, perIface map[string]map[int]map[string]bool) {
+	clone := tree.Clone()
+	vars := map[string]string{"node": fmt.Sprintf("node%d", nodeID)}
+	if err := clone.ExpandGroupsWithVars(vars); err != nil {
+		return
 	}
+	// expandInterfaceRanges mutates the clone in place; its warnings are
+	// emitted on the real path (runPreWalkGates) and discarded here.
+	_ = expandInterfaceRanges(clone)
+	for _, ifaces := range clone.FindChildren("interfaces") {
+		collectInterfaceUnitSpellingsAST(ifaces, perIface)
+	}
+}
+
+func validateInterfaceUnitAliasCollisionsAST(tree *ConfigTree, lenient bool) ([]string, error) {
+	// perIface[ifName][canonicalUnit] = set of raw spellings.
+	perIface := make(map[string]map[int]map[string]bool)
+
+	// View 1 — pre-expansion presence union across every top-level `interfaces`
+	// root (#5744: a split config can declare an interface's units across two
+	// sibling `interfaces { }` stanzas, and compileSections compiles them all)
+	// AND every `groups` block. Modeled on validateTunnelEndpointIDCollisionAST.
+	for _, ifaces := range tree.FindChildren("interfaces") {
+		collectInterfaceUnitSpellingsAST(ifaces, perIface)
+	}
+	for _, child := range tree.Children {
+		if child.Name() != "groups" {
+			continue
+		}
+		for _, group := range child.Children {
+			// Node{Keys:["groups","node0"]} merges the group name into
+			// Keys[1]; the children are then the group body directly.
+			if len(child.Keys) >= 2 {
+				for _, ifaces := range child.FindChildren("interfaces") {
+					collectInterfaceUnitSpellingsAST(ifaces, perIface)
+				}
+				break
+			}
+			for _, ifaces := range group.FindChildren("interfaces") {
+				collectInterfaceUnitSpellingsAST(ifaces, perIface)
+			}
+		}
+	}
+
+	// Views 2/3 — post-expansion per-interface unit spellings for node0 and
+	// node1. Both computed on both nodes from the shared candidate, so the
+	// union stays HA-symmetric; per-node expansion errors contribute the empty
+	// set (non-fatal).
+	collectNodeExpandedInterfaceUnitSpellings(tree, 0, perIface)
+	collectNodeExpandedInterfaceUnitSpellings(tree, 1, perIface)
 
 	var warnings []string
 	emit := func(format string, args ...any) error {
@@ -107,41 +217,27 @@ func validateInterfaceUnitAliasCollisionsAST(nodes []*Node, lenient bool) ([]str
 		return nil
 	}
 
-	for _, iface := range ifaceChildren {
-		ifName := iface.Name()
-		if ifName == "" {
-			continue
-		}
+	// Deterministic, node-symmetric first error: lowest-named interface, then
+	// lowest colliding canonical unit.
+	ifNames := make([]string, 0, len(perIface))
+	for ifName := range perIface {
+		ifNames = append(ifNames, ifName)
+	}
+	sort.Strings(ifNames)
 
-		// Group the distinct raw unit spellings by their canonical numeric
-		// value, mirroring the compiler's namedInstances + strconv.Atoi split
-		// exactly so detection matches what compileInterfaces consumes.
-		distinct := make(map[int]map[string]bool)
-		for _, inst := range namedInstances(iface.FindChildren("unit")) {
-			num, err := strconv.Atoi(inst.name)
-			if err != nil {
-				continue
-			}
-			if distinct[num] == nil {
-				distinct[num] = make(map[string]bool)
-			}
-			distinct[num][inst.name] = true
-		}
-
-		// Report the lowest colliding unit number first so the strict
-		// first-error is order-independent (both config orders reject with the
-		// same message).
-		nums := make([]int, 0, len(distinct))
-		for num := range distinct {
-			if len(distinct[num]) >= 2 {
+	for _, ifName := range ifNames {
+		byUnit := perIface[ifName]
+		nums := make([]int, 0, len(byUnit))
+		for num := range byUnit {
+			if len(byUnit[num]) >= 2 {
 				nums = append(nums, num)
 			}
 		}
 		sort.Ints(nums)
 
 		for _, num := range nums {
-			spellings := make([]string, 0, len(distinct[num]))
-			for s := range distinct[num] {
+			spellings := make([]string, 0, len(byUnit[num]))
+			for s := range byUnit[num] {
 				spellings = append(spellings, s)
 			}
 			sort.Strings(spellings)
@@ -155,7 +251,10 @@ func validateInterfaceUnitAliasCollisionsAST(nodes []*Node, lenient bool) ([]str
 					"address ownership then depends on config order (the later "+
 					"spelling wins the unit filter while tunnel-address side "+
 					"effects accumulate from every spelling, a fail-open on the "+
-					"security filter) — use a single canonical `unit %d` (#5631)",
+					"security filter); the aliasing spelling may live in a "+
+					"peer-only `groups node{0,1}`/`${node}` block that only "+
+					"collides in the STANDBY node's effective view — use a single "+
+					"canonical `unit %d` (#5631; both-node union #5878)",
 				ifName, strings.Join(quoted, ", "), num, num); err != nil {
 				return nil, err
 			}

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -442,24 +442,15 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 		return nil, err
 	}
 
-	// #5631 (codex-review-181 M23) numeric interface-unit alias gate. Two
-	// distinct unit spellings under one interface that canonicalize to the
-	// same logical unit (`unit 00` and `unit 0`) collide on
-	// `ifc.Units[unitNum]` with last-writer-wins for the unit filter but
-	// append-only accumulation for the interface tunnel addresses — so the
-	// winning firewall filter and the surviving tunnel addresses depend on
-	// config order (a fail-open on the security filter). Runs on the group-
-	// expanded, inactive-pruned tree (apply-groups / interface-range aliases
-	// covered; `inactive:` units ignored) and AFTER expandInterfaceRanges so a
-	// range member's unit alias is seen. Strict (commit / commit-check):
-	// hard-reject naming the interface, spellings, and canonical unit. Lenient
-	// (load / peer-sync): warn so an already-persisted or peer-synced config an
-	// older binary accepted still boots (#1960).
-	unitAliasWarnings, err := validateInterfaceUnitAliasCollisionsAST(
-		tree.Children, opts.lenientInterfaceUnitAliasCollisions)
-	if err != nil {
-		return nil, err
-	}
+	// #5631 (codex-review-181 M23) numeric interface-unit alias gate MOVED to
+	// the PRE-expansion gate block of compileConfigForNodeWithOpts /
+	// compileConfigWithOpts in #5878 and PROMOTED to a both-node-effective
+	// union so a peer-only `groups node1`/`${node}` alias that collides only in
+	// the STANDBY node's effective view is rejected at either node's commit
+	// (see validateInterfaceUnitAliasCollisionsAST in
+	// compiler_interface_unit_alias.go). It no longer runs here — a
+	// post-`${node}`-expansion, node-LOCAL pre-walk could not see the peer's
+	// view.
 
 	// #5694 (codex-182 M15) chassis-cluster identity gate. compileChassis parses
 	// a `redundancy-group <name>` instance id and a per-RG `node <id>` with
@@ -505,7 +496,6 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	warnings = append(warnings, policyMissingMatchWarnings...)
 	warnings = append(warnings, dnatToScopeWarnings...)
 	warnings = append(warnings, natMixedScopeWarnings...)
-	warnings = append(warnings, unitAliasWarnings...)
 	warnings = append(warnings, chassisIdentityWarnings...)
 	return warnings, nil
 }

--- a/pkg/config/interface_unit_parity_5878_test.go
+++ b/pkg/config/interface_unit_parity_5878_test.go
@@ -1,0 +1,380 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5878: the #5631 numeric interface-unit alias gate originally ran INSIDE
+// compileExpanded (runPreWalkGates) AFTER tree.ExpandGroupsWithVars, so it saw
+// only the SUBMITTING node's post-`${node}` effective view. A peer-only
+// `groups node1 { … unit 01 }` block applied through apply-groups "${node}"
+// folds its aliasing spelling onto a base `unit 1` ONLY in the standby node's
+// effective view — invisible at a node0 commit (Store.compileTree compiles
+// s.nodeID only). The active node commits green; the standby's compiled config
+// then diverges and a failover silently changes forwarding / security posture.
+//
+// The fix promotes the gate to a BOTH-NODE-effective UNION (View 1 pre-expansion
+// group union + Views 2/3 node0/node1 expansions) run in the PRE-expansion gate
+// block, so a peer-only alias is rejected at EITHER node's commit and the
+// accept/reject verdict is identical on both nodes.
+//
+// These tests use ParseSetCommand + tree.SetPath (buildTreeFromSet, shared with
+// ipsec_proposal_ref_test.go) per CLAUDE.md — NewParser must not be used for
+// multi-line set input. Faithful HA configs define BOTH `groups node0` and
+// `groups node1` (as `apply-groups "${node}"` requires the per-node group to
+// exist on each node), with the alias living in exactly one peer group so that
+// node's own view is clean while the OTHER node's diverges.
+
+// canonParityBase gives the two firewall filters the aliasing units reference.
+func canonParityBase() []string {
+	return []string{
+		"set firewall family inet filter good term t1 then accept",
+		"set firewall family inet filter evil term t1 then accept",
+	}
+}
+
+// peerOnlyAliasConfig builds a shared HA candidate where the base carries the
+// canonical `unit <base>`, `groups node0` re-states the canonical unit (clean),
+// and `groups node1` injects the aliasing spelling `unit <alias>`. With
+// apply-groups "${node}", node0's effective view is a single canonical unit
+// (clean) while node1 folds two spellings of the same logical unit. A
+// node-LOCAL gate therefore ACCEPTS on node0 and REJECTS on node1 (the #5878
+// divergent commit); the both-node union rejects on BOTH.
+func peerOnlyAliasConfig(base, alias string) []string {
+	return append(canonParityBase(),
+		"set interfaces ge-0/0/0 unit "+base+" family inet filter input good",
+		"set groups node0 interfaces ge-0/0/0 unit "+base+" family inet address 10.0.0.1/24",
+		"set groups node1 interfaces ge-0/0/0 unit "+alias+" family inet filter input evil",
+		`set apply-groups "${node}"`,
+	)
+}
+
+// -----------------------------------------------------------------------------
+// 6.1 Core RED (pre-fix) case — peer-only alias.
+// -----------------------------------------------------------------------------
+
+// A base `unit 1` plus a peer-only `groups node1 { … unit 01 }` collide ONLY in
+// node1's effective view. Both a node0 commit AND a node1 commit must REJECT
+// with the SAME error (verdict parity), and a generic CompileConfig too.
+//
+// FAIL-ON-REVERT: reverting the pre-expansion relocation (putting the gate back
+// node-local inside runPreWalkGates) makes CompileConfigForNode(tree, 0) ACCEPT
+// the divergent config — node0's own effective view is the clean canonical
+// `unit 1` — so the node0 assertion below goes RED.
+func TestUnitAliasPeerOnlyGroupRejectedBothNodes_5878(t *testing.T) {
+	tree := buildTreeFromSet(t, peerOnlyAliasConfig("1", "01"))
+
+	_, err0 := CompileConfigForNode(tree, 0)
+	_, err1 := CompileConfigForNode(tree, 1)
+	_, errG := CompileConfig(tree)
+
+	if err0 == nil {
+		t.Fatal("node0 commit ACCEPTED a peer-only unit-alias collision (unit 01 in groups node1) — the #5878 divergent-commit fail-open")
+	}
+	if err1 == nil {
+		t.Fatal("node1 commit accepted a unit-alias collision visible in its own effective view")
+	}
+	if errG == nil {
+		t.Fatal("generic CompileConfig accepted a peer-only unit-alias collision")
+	}
+
+	// Verdict parity: identical rejection on both nodes (the union is a pure
+	// function of the candidate config).
+	if err0.Error() != err1.Error() {
+		t.Fatalf("node0/node1 verdicts diverge:\n node0: %v\n node1: %v", err0, err1)
+	}
+
+	for _, want := range []string{"ge-0/0/0", "#5631", "#5878", "`unit 01`", "`unit 1`", "same logical unit 1"} {
+		if !strings.Contains(err0.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err0)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 6.2 Alias-form matrix — each aliasing spelling injected via a peer-only
+// groups node1 block, asserted rejected identically on node0 and node1.
+// -----------------------------------------------------------------------------
+
+func TestUnitAliasFormMatrixPeerOnly_5878(t *testing.T) {
+	cases := []struct {
+		name  string
+		base  string // canonical spelling on the base interface + groups node0
+		alias string // aliasing spelling injected via groups node1
+		canon int
+	}{
+		{"leading-zero", "1", "01", 1},
+		{"double-leading-zero", "1", "001", 1},
+		{"signed", "1", "+1", 1},
+		{"zero-double", "0", "00", 0},
+		{"zero-signed-neg", "0", "-0", 0},
+		{"zero-signed-pos", "0", "+0", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTreeFromSet(t, peerOnlyAliasConfig(tc.base, tc.alias))
+
+			_, err0 := CompileConfigForNode(tree, 0)
+			_, err1 := CompileConfigForNode(tree, 1)
+			if err0 == nil {
+				t.Fatalf("node0 accepted peer-only alias %q vs %q (canon %d)", tc.alias, tc.base, tc.canon)
+			}
+			if err1 == nil {
+				t.Fatalf("node1 accepted alias %q vs %q (canon %d)", tc.alias, tc.base, tc.canon)
+			}
+			if err0.Error() != err1.Error() {
+				t.Fatalf("verdict not symmetric for %q:\n node0: %v\n node1: %v", tc.name, err0, err1)
+			}
+			if !strings.Contains(err0.Error(), "#5878") {
+				t.Fatalf("error missing #5878 provenance: %v", err0)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 6.3 Injection-vector matrix.
+// -----------------------------------------------------------------------------
+
+// Node inversion: aliasing spelling in `groups node0` while `groups node1` is
+// clean. node0's effective view folds `01` onto `1`; node1 never applies
+// node0's group — but the both-node UNION rejects on both nodes so config-sync
+// cannot split (originator accepts / peer rejects).
+func TestUnitAliasNodeInversionGroupNode0_5878(t *testing.T) {
+	tree := buildTreeFromSet(t, append(canonParityBase(),
+		"set interfaces ge-0/0/0 unit 1 family inet filter input good",
+		"set groups node0 interfaces ge-0/0/0 unit 01 family inet filter input evil",
+		"set groups node1 interfaces ge-0/0/0 unit 1 family inet address 10.0.0.1/24",
+		`set apply-groups "${node}"`,
+	))
+	_, err0 := CompileConfigForNode(tree, 0)
+	_, err1 := CompileConfigForNode(tree, 1)
+	if err0 == nil {
+		t.Fatal("node0 accepted a groups node0 unit-alias collision it directly applies")
+	}
+	if err1 == nil {
+		t.Fatal("node1 accepted a groups node0 unit-alias collision (both-node union must reject on the peer too)")
+	}
+	if err0.Error() != err1.Error() {
+		t.Fatalf("node-inversion verdict not symmetric:\n node0: %v\n node1: %v", err0, err1)
+	}
+}
+
+// Plain (non-node) apply-groups inheritance: a shared group carries the
+// aliasing spelling. Both node views apply it, so both reject. No `${node}`, so
+// no per-node group is required.
+func TestUnitAliasGroupInheritance_5878(t *testing.T) {
+	tree := buildTreeFromSet(t, append(canonParityBase(),
+		"set interfaces ge-0/0/0 unit 1 family inet filter input good",
+		"set groups aliasg interfaces ge-0/0/0 unit 01 family inet filter input evil",
+		"set interfaces ge-0/0/0 apply-groups aliasg",
+	))
+	_, err0 := CompileConfigForNode(tree, 0)
+	_, err1 := CompileConfigForNode(tree, 1)
+	if err0 == nil || err1 == nil {
+		t.Fatalf("apply-groups-inherited unit alias not rejected: node0=%v node1=%v", err0, err1)
+	}
+	if err0.Error() != err1.Error() {
+		t.Fatalf("group-inheritance verdict not symmetric:\n node0: %v\n node1: %v", err0, err1)
+	}
+}
+
+// Interface-range / wildcard expansion: a peer-only group applies the aliasing
+// spelling onto an interface named by an interface-range member. The alias only
+// lands on the concrete interface AFTER expandInterfaceRanges runs on the
+// node-expanded view (Views 2/3), which the union gate performs. groups node0
+// exists (harmless, unrelated interface) so node0's `${node}` expansion resolves.
+func TestUnitAliasInterfaceRangeExpansion_5878(t *testing.T) {
+	tree := buildTreeFromSet(t, append(canonParityBase(),
+		"set interfaces interface-range r1 member ge-0/0/5",
+		"set interfaces interface-range r1 unit 1 family inet filter input good",
+		"set groups node0 interfaces ge-0/0/9 description clean",
+		"set groups node1 interfaces ge-0/0/5 unit 01 family inet filter input evil",
+		`set apply-groups "${node}"`,
+	))
+	_, err0 := CompileConfigForNode(tree, 0)
+	_, err1 := CompileConfigForNode(tree, 1)
+	if err0 == nil {
+		t.Fatal("node0 accepted an interface-range member unit-alias collision hidden in groups node1")
+	}
+	if err1 == nil {
+		t.Fatal("node1 accepted an interface-range member unit-alias collision")
+	}
+	if err0.Error() != err1.Error() {
+		t.Fatalf("interface-range verdict not symmetric:\n node0: %v\n node1: %v", err0, err1)
+	}
+	if !strings.Contains(err0.Error(), "ge-0/0/5") {
+		t.Fatalf("error does not name the expanded range member ge-0/0/5: %v", err0)
+	}
+}
+
+// Rollback / load (lenient) path: the same peer-only collision must NOT
+// hard-fail on the tolerant load / peer-sync path — an already-persisted or
+// peer-synced config an older binary accepted still has to boot — but it
+// surfaces the collision as a warning (#1960 no-brick doctrine).
+func TestUnitAliasPeerOnlyLenientWarns_5878(t *testing.T) {
+	tree := buildTreeFromSet(t, peerOnlyAliasConfig("1", "01"))
+	// Node-aware lenient (HA peer-sync ingress) for node1 — the view that folds
+	// the alias. Must warn, not error.
+	cfg, err := CompileConfigForNodeLenient(tree, 1)
+	if err != nil {
+		t.Fatalf("CompileConfigForNodeLenient(node1) must downgrade the peer-only alias to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#5878") && strings.Contains(w, "ge-0/0/0") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #5878 unit-alias warning on the lenient node1 path, got: %v", cfg.Warnings)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 6.4 Compile-parity harness — verdict identity across node0 and node1 for the
+// whole alias-form matrix, driven through one helper.
+// -----------------------------------------------------------------------------
+
+func TestUnitAliasCompileParityHarness_5878(t *testing.T) {
+	cases := []struct {
+		name       string
+		cmds       []string
+		wantReject bool
+	}{
+		{
+			name:       "peer-only-node1-alias",
+			cmds:       peerOnlyAliasConfig("1", "01"),
+			wantReject: true,
+		},
+		{
+			name: "peer-only-node0-alias",
+			cmds: append(canonParityBase(),
+				"set interfaces ge-0/0/0 unit 1 family inet filter input good",
+				"set groups node0 interfaces ge-0/0/0 unit 001 family inet filter input evil",
+				"set groups node1 interfaces ge-0/0/0 unit 1 family inet address 10.0.0.1/24",
+				`set apply-groups "${node}"`,
+			),
+			wantReject: true,
+		},
+		{
+			name: "clean-distinct-units",
+			cmds: append(canonParityBase(),
+				"set interfaces ge-0/0/0 unit 0 family inet filter input good",
+				"set interfaces ge-0/0/0 unit 1 family inet filter input evil",
+			),
+			wantReject: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTreeFromSet(t, tc.cmds)
+			_, err0 := CompileConfigForNode(tree, 0)
+			_, err1 := CompileConfigForNode(tree, 1)
+			// (a) verdict identical across nodes.
+			if (err0 == nil) != (err1 == nil) {
+				t.Fatalf("verdict diverges across nodes: node0=%v node1=%v", err0, err1)
+			}
+			if tc.wantReject {
+				if err0 == nil {
+					t.Fatalf("expected rejection, both nodes accepted")
+				}
+				if err0.Error() != err1.Error() {
+					t.Fatalf("reject text differs across nodes:\n node0: %v\n node1: %v", err0, err1)
+				}
+			} else if err0 != nil {
+				t.Fatalf("expected acceptance, got node0=%v node1=%v", err0, err1)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 6.6 Regression guards — the gate must NOT false-positive on the common case
+// or a legitimate VLAN split.
+// -----------------------------------------------------------------------------
+
+// A single canonical `unit 0` (the overwhelming common case) is not an alias.
+func TestUnitAliasSingleCanonicalUnitClean_5878(t *testing.T) {
+	tree := buildTreeFromSet(t, append(canonParityBase(),
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/0 unit 0 family inet filter input good",
+	))
+	for _, nodeID := range []int{0, 1} {
+		if _, err := CompileConfigForNode(tree, nodeID); err != nil {
+			t.Fatalf("node%d rejected a single canonical unit 0: %v", nodeID, err)
+		}
+	}
+}
+
+// A legitimate VLAN split — distinct units 0 and 1 on one interface assigned to
+// different zones — must not trip the gate on either node, including when a
+// peer-only group adds a DISTINCT further unit (unit 2, not an alias).
+func TestUnitAliasVLANSplitDistinctUnitsClean_5878(t *testing.T) {
+	tree := buildTreeFromSet(t, append(canonParityBase(),
+		"set interfaces ge-0/0/0 unit 0 vlan-id 10 family inet address 10.0.0.1/24",
+		"set interfaces ge-0/0/0 unit 1 vlan-id 20 family inet address 10.0.1.1/24",
+		"set groups node0 interfaces ge-0/0/0 unit 2 vlan-id 30 family inet address 10.0.2.1/24",
+		"set groups node1 interfaces ge-0/0/0 unit 3 vlan-id 40 family inet address 10.0.3.1/24",
+		`set apply-groups "${node}"`,
+	))
+	for _, nodeID := range []int{0, 1} {
+		cfg, err := CompileConfigForNode(tree, nodeID)
+		if err != nil {
+			t.Fatalf("node%d rejected a legitimate VLAN split (distinct units): %v", nodeID, err)
+		}
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "#5878") || strings.Contains(w, "same logical unit") {
+				t.Fatalf("node%d emitted a spurious unit-alias warning on distinct units: %q", nodeID, w)
+			}
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// CanonicalLogicalUnit unit tests — the shared normalizer (#5878).
+// -----------------------------------------------------------------------------
+
+func TestCanonicalLogicalUnit_5878(t *testing.T) {
+	ok := []struct {
+		raw   string
+		num   int
+		canon string
+	}{
+		{"0", 0, "0"},
+		{"00", 0, "0"},
+		{"-0", 0, "0"},
+		{"+0", 0, "0"},
+		{"1", 1, "1"},
+		{"01", 1, "1"},
+		{"001", 1, "1"},
+		{"+1", 1, "1"},
+		{"16385", 16385, "16385"},
+	}
+	for _, tc := range ok {
+		num, canon, err := CanonicalLogicalUnit(tc.raw)
+		if err != nil {
+			t.Fatalf("CanonicalLogicalUnit(%q) unexpected error: %v", tc.raw, err)
+		}
+		if num != tc.num || canon != tc.canon {
+			t.Fatalf("CanonicalLogicalUnit(%q) = (%d, %q); want (%d, %q)", tc.raw, num, canon, tc.num, tc.canon)
+		}
+		// All aliases of a value fold to one canonical string.
+		if _, altCanon, _ := CanonicalLogicalUnit(tc.canon); altCanon != canon {
+			t.Fatalf("canonical form not idempotent for %q: %q vs %q", tc.raw, canon, altCanon)
+		}
+	}
+
+	// Malformed / out-of-range are rejected (parity with ValidateLogicalUnit).
+	for _, bad := range []string{"", "tenant", "-1", "16386", "1.0", " 1", "0x1", "99999999999999999999"} {
+		if _, _, err := CanonicalLogicalUnit(bad); err == nil {
+			t.Fatalf("CanonicalLogicalUnit(%q) accepted a malformed/out-of-range unit", bad)
+		}
+		// ValidateLogicalUnit delegates to CanonicalLogicalUnit — same verdict.
+		if err := ValidateLogicalUnit(bad, nil); err == nil {
+			t.Fatalf("ValidateLogicalUnit(%q) accepted a malformed/out-of-range unit", bad)
+		}
+	}
+}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -143,6 +143,38 @@ func ValidateInteger(min, max int64) LeafValidator {
 // InterfaceConfig.Units by this int (#5829).
 const MaxLogicalUnit = 16385
 
+// CanonicalLogicalUnit is the ONE canonical normalizer for a logical
+// `unit <n>` identity (#5878). It maps every textual spelling of a numeric
+// logical unit to its shared canonical identity: it parses the raw token as a
+// base-10 integer (so `01`==`1`, `+1`==`1`, `-0`==`0`, `00`==`0` all collapse)
+// and returns the canonical int plus its canonical decimal string
+// (strconv.FormatInt). A truly-malformed identity — non-numeric, negative
+// non-zero, integer overflow, or out-of-range [0..MaxLogicalUnit] — is rejected
+// via the same ValidateInteger check ValidateLogicalUnit has always used, so
+// the acceptance set and error text are unchanged.
+//
+// The canonicalization the compiler performs ad hoc via `strconv.Atoi` at ~10
+// call sites (compileInterfaces keys `ifc.Units[unitNum]` by the parsed int)
+// is centralized here so a collision gate, and eventually the zone/NAT/routing
+// reference binders (phase 2, #5878), can share one identity: two spellings
+// that fold to the same canonical unit are the SAME unit.
+func CanonicalLogicalUnit(raw string) (int, string, error) {
+	// Delegate the acceptance/range check to ValidateInteger so the error
+	// text is byte-identical to ValidateLogicalUnit's historical output
+	// (the #5829 tests and operator diagnostics depend on it). ValidateInteger
+	// ignores the *Config argument, so nil is safe here.
+	if err := ValidateInteger(0, MaxLogicalUnit)(raw, nil); err != nil {
+		return 0, "", err
+	}
+	// ParseInt with the same base/bitsize accepts exactly what ValidateInteger
+	// just accepted, so this never fails on the post-validate path.
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, "", err
+	}
+	return int(v), strconv.FormatInt(v, 10), nil
+}
+
 // ValidateLogicalUnit is the ONE canonical numeric-identity validator for a
 // logical `unit <n>` slot (#5829). A `unit <identity>` slot has no positional
 // key validation, so a non-numeric identity such as `unit tenant` passed
@@ -153,8 +185,12 @@ const MaxLogicalUnit = 16385
 // identity at commit instead: non-numeric, negative, integer overflow, and
 // out-of-range [0..MaxLogicalUnit] all fail here. Reuse this on every slot that
 // names an interface unit so the grammar stays consistent across subsystems.
+//
+// It now delegates the validation half to CanonicalLogicalUnit (#5878) — the
+// shared normalizer — so validation and canonicalization can never diverge.
 func ValidateLogicalUnit(raw string, cfg *Config) error {
-	return ValidateInteger(0, MaxLogicalUnit)(raw, cfg)
+	_, _, err := CanonicalLogicalUnit(raw)
+	return err
 }
 
 // validatePercent returns a closure that accepts a real number in


### PR DESCRIPTION
## Summary

`#5878` Phase 1 — a **canonical logical-unit normalizer** plus a **both-node-effective union** collision gate for numeric interface-unit aliases.

**Root cause.** The `#5631` unit-alias gate (`validateInterfaceUnitAliasCollisionsAST`) ran inside `compileExpanded` (`runPreWalkGates`) **after** `tree.ExpandGroupsWithVars({node: nodeN})`, so it saw only the *submitting* node's post-`${node}` effective view. Commit compiles `s.nodeID` alone (`Store.compileTree` → `CompileConfigForNode`). A peer-only `groups node1 { … unit 01 }` applied through `apply-groups "${node}"` folds its aliasing spelling onto a base `unit 1` **only in the standby's effective view** — invisible at a node0 commit. The active node commits green; the standby's compiled config then diverges (a different firewall filter / address set) and a failover silently changes forwarding or security posture despite a "synchronized" commit. Same both-node-symmetry class already closed for tunnel IDs (`#1873`/`#1914`), zone IDs (`#3075`), routing-instance table IDs (`#3855`).

## What changed (Phase 1)

- **`CanonicalLogicalUnit(raw) (int, string, error)`** in `schema_validators.go` — the ONE normalizer folding every alias spelling (`01`==`1`, `+1`==`1`, `-0`/`00`==`0`) to its canonical identity, rejecting malformed/out-of-range via the same `ValidateInteger` range check. `ValidateLogicalUnit` delegates to it (acceptance set + error text byte-identical).
- **`validateInterfaceUnitAliasCollisionsAST` rewritten** as a both-node union modeled exactly on `validateTunnelEndpointIDCollisionAST`: **View 1** pre-expansion union across every `interfaces` root + every `groups` block; **Views 2/3** per-interface unit spellings after expanding for node0 / node1 (`ExpandGroupsWithVars` + `expandInterfaceRanges`). Per-node expansion errors are non-fatal. Verdict identical on both nodes, monotone over the old single-view gate.
- **Relocated** the call from `runPreWalkGates` into the **pre-expansion** gate block of `compileConfigForNodeWithOpts` **and** `compileConfigWithOpts` — a node0 commit now rejects a node1-only alias collision. Strict rejects on commit/commit-check; tolerant load / peer-sync stays **warn-only** (`#1960` no-brick doctrine).

## Precedent followed

The pre-expansion both-node union follows `validateTunnelEndpointIDCollisionAST` (`tunnelid.go`) exactly — Views 1/2/3, both-node expansion via `ExpandGroupsWithVars`, non-fatal per-node errors → empty set.

## Closes vs Addresses

**`Addresses #5878`** (issue kept open). Phase 1 closes the material divergent-commit fail-open. **Phase 2 (deferred)** threads `CanonicalLogicalUnit` through the zone/CoS/routing/NAT reference binders + snapshot/status emitters so a `.01` reference resolves to the same runtime unit as the interface's canonical `.1` everywhere (§2.3 of the plan — the subtler half). Sized separately (touches `pkg/dataplane/userspace` map builders + status emitters).

## Fail-on-revert

`interface_unit_parity_5878_test.go`: reverting the pre-expansion relocation (gate back node-local) makes the peer-only-node1 test go **RED** — node0 **accepts** the divergent config (`node0=<nil>`) while node1 rejects. Verified live before commit. Also: both-node verdict parity, alias-form matrix (`.01/.001/+1/00/-0/+0`), injection-vector matrix (peer-only group / node inversion / group inheritance / interface-range expansion / lenient load), VLAN-split + single-canonical-unit regression guards, `CanonicalLogicalUnit` units.

## Validation

- `go build ./...`, `go vet ./pkg/config/` — green
- `go test -race ./pkg/config/` (130s) — green
- `go test ./pkg/configstore/` (commit-path consumer) — green
- Existing `#5631`/`#5744`/`#5829`/`#5933` + `tunnelid` duplicate-spelling tests pass unchanged

Config-validation change (HA-config correctness, not failover machinery) — no `test-failover` required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Q81Whqgs6dYjSkiwJfGFb