### PR TITLE
config: validate nested class-of-service unit at commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -49158,3 +49158,8 @@ top.
     pkg/config/compiler_validate_strict_application.go,
     pkg/config/compiler_reserved_appname_5821_test.go,
     docs/services-application-identification.md
+
+## 2026-07-16 — #5963 CoS nested-unit validation
+- **Timestamp**: 2026-07-16
+- **Action**: Fix #5963 — reject a malformed NESTED `class-of-service interfaces <if> unit <n>` at commit instead of silently dropping it. Replaced the silent `strconv.Atoi(unitNode.Keys[1]); if err != nil { continue }` at the CoS parse site with `CanonicalLogicalUnit` (#5878 normalizer — returns the int used to key `iface.Units` + the shared #5829 acceptance check). Strict hard-reject on commit/commit-check; lenient warn-and-drop on the tolerant load/peer-sync path via the existing `lenientInterfaceUnitRef` flag (matches #5933's suffix-gate doctrine, #1960 no-brick). Valid unit still binds the shaper unchanged.
+- **File(s)**: pkg/config/compiler_class_of_service.go (edit), pkg/config/cos_nested_unit_5963_test.go (new, RED-on-revert), docs/config-schema.md (edit — #5933 section residual-closed note)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -433,6 +433,35 @@ Covered by `pkg/config/interface_unit_ref_5933_test.go` (per-subsystem strict
 reject naming the subsystem + bad token, valid-unit accepted, bare-interface
 accepted, lenient warn), each subsystem independently RED on revert.
 
+#### Residual closed: the NESTED `class-of-service interfaces <if> unit <n>` form (#5963)
+
+#5933 above closed the three `.unit` SUFFIX references, but the DISTINCT nested
+grammar slot — `class-of-service interfaces <if> unit <n> ...`, where the unit is
+a CHILD node rather than a `.unit` suffix — remained unvalidated. Its schema node
+(`schema_cos.go`) carries no `keyValidator` (the `unit` key is a free
+`<unit-number>` placeholder), so `SchemaValidate` accepted a non-numeric `unit`,
+and the CoS compiler then SILENTLY DROPPED it: `strconv.Atoi(unitNode.Keys[1]); if
+err != nil { continue }` in `compiler_class_of_service.go`. `set class-of-service
+interfaces ge-0-0-0 unit abc shaping-rate 1m` compiled clean (`CompileConfig`
+returned nil) and the shaper never bound — the SAME mis-bind / silent-drop class
+#5829/#5933 closed, and arguably the more common Junos CoS syntax. #5933 could not
+catch it: by the time `validateInterfaceUnitReferencesStrict` runs the malformed
+unit is already dropped at parse, so there is nothing left at the reference gate.
+
+The fix routes `unitNode.Keys[1]` through the canonical `CanonicalLogicalUnit`
+normalizer (#5878) AT the CoS parse site — it returns the parsed int (used to key
+`iface.Units`) plus the shared #5829 acceptance check in one call, so a
+non-numeric / negative / integer-overflow / out-of-range `[0..MaxLogicalUnit]`
+unit is REJECTED at commit instead of dropped. Strict on commit / commit-check
+(hard-reject naming the interface + bad token); the `lenientInterfaceUnitRef` opt
+(the same flag the #5933 suffix gate uses) downgrades it to a `cfg.Warnings` entry
+on the tolerant load / peer-sync paths (#1960 no-brick — the malformed unit was
+inert before the gate too, the shaper simply did not bind). A VALID unit still
+binds the shaper unchanged. Covered by `pkg/config/cos_nested_unit_5963_test.go`
+(strict reject of non-numeric/negative/overflow/out-of-range naming the token,
+valid `unit 0`/`unit 100` binds the shaper, lenient warn-and-drop), RED on revert
+of the parse-site gate.
+
 ### security address-book same-name `address` + `address-set` collision (#5676)
 
 `address` and `address-set` entries share ONE operator-visible namespace (a

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -536,9 +536,33 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig, opts compileOp
 			if len(unitNode.Keys) < 2 {
 				continue
 			}
-			unitID, err := strconv.Atoi(unitNode.Keys[1])
+			// #5963: the NESTED `class-of-service interfaces <if> unit <n>`
+			// form (unit as a child node, distinct from the `.unit` suffix
+			// references #5933 gated) previously SILENTLY DROPPED a malformed
+			// unit here (strconv.Atoi -> continue): the shaper/classifier
+			// never bound and CompileConfig accepted the stanza with no
+			// effect — the same mis-bind / fail-open class #5829/#5933
+			// closed. Route the identity through the canonical
+			// CanonicalLogicalUnit normalizer (#5878) so a non-numeric /
+			// negative / out-of-range unit is REJECTED at commit instead of
+			// dropped. Strict on commit / commit-check (hard-reject); on the
+			// tolerant load / peer-sync path (lenientInterfaceUnitRef, the
+			// same flag the #5933 gate uses) downgrade to a cfg.Warnings
+			// entry so an already-persisted or peer-synced config an older
+			// binary accepted still boots — #1960 no-brick; the malformed
+			// unit was inert then too (the shaper simply did not bind).
+			unitID, _, err := CanonicalLogicalUnit(unitNode.Keys[1])
 			if err != nil {
-				continue
+				if opts.lenientInterfaceUnitRef {
+					if warnings != nil {
+						*warnings = append(*warnings, fmt.Sprintf(
+							"class-of-service interfaces %s unit %q (downgraded to warning on tolerant path): %v",
+							iface.Name, unitNode.Keys[1], err))
+					}
+					continue
+				}
+				return fmt.Errorf("class-of-service interfaces %s unit %q: %w",
+					iface.Name, unitNode.Keys[1], err)
 			}
 			unit := &CoSInterfaceUnit{Unit: unitID}
 			parseCoSInterfaceUnitBody(unitNode, unit)

--- a/pkg/config/cos_nested_unit_5963_test.go
+++ b/pkg/config/cos_nested_unit_5963_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5963: the NESTED `class-of-service interfaces <if> unit <n>` form (unit as a
+// CHILD node) is a DISTINCT grammar slot from the `.unit` SUFFIX references
+// #5933 gated. Its schema node (schema_cos.go) carries no keyValidator, so
+// SchemaValidate accepts a non-numeric `unit`; the compiler then SILENTLY
+// DROPPED it (strconv.Atoi -> continue in compiler_class_of_service.go) — the
+// shaper never bound and CompileConfig returned nil, the same mis-bind /
+// fail-open class #5829/#5933 closed. The fix routes the identity through the
+// canonical CanonicalLogicalUnit normalizer at the CoS parse site: hard-reject
+// on commit, warn on the tolerant load / peer-sync path.
+//
+// Flat-set MUST be built with ParseSetCommand/SetPath (flatTreeFromSets), never
+// NewParser (CLAUDE.md "Testing flat set syntax").
+//
+// FAIL-ON-REVERT (load-bearing): restore the silent `strconv.Atoi(...); if err
+// != nil { continue }` at the parse site → the reject test compiles the
+// malformed nested unit clean (accept + silent drop) → its assertion goes RED.
+
+// cosBadNestedUnits is the set of malformed nested-unit tokens the CoS parse
+// site must reject at commit. The compiler error always quotes the raw token
+// via `unit %q`, so `want` is that quoted form regardless of the inner
+// ValidateInteger text.
+var cosBadNestedUnits = []struct {
+	name string
+	tok  string
+	want string
+}{
+	{"non-numeric", "abc", `"abc"`},
+	{"negative", "-1", `"-1"`},
+	{"integer-overflow", "99999999999999999999", `"99999999999999999999"`},
+	{"out-of-range", "16386", `"16386"`}, // > MaxLogicalUnit (16385)
+}
+
+// TestCoSNestedUnit5963_Reject proves a malformed nested
+// `class-of-service interfaces <if> unit <bad>` is REJECTED at strict commit
+// (CompileConfig) instead of silently dropped.
+func TestCoSNestedUnit5963_Reject(t *testing.T) {
+	for _, tc := range cosBadNestedUnits {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t,
+				"set class-of-service interfaces ge-0-0-0 unit "+tc.tok+" shaping-rate 1m")
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a malformed nested CoS unit %q (silent shaper drop); want reject", tc.tok)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error must name the bad unit token %s: %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "class-of-service interfaces") {
+				t.Fatalf("error must name the subsystem (class-of-service interfaces): %v", err)
+			}
+		})
+	}
+}
+
+// TestCoSNestedUnit5963_ValidBinds guards against over-rejection: a VALID nested
+// unit still compiles AND binds the shaper (semantics unchanged for the good
+// case). unit 0 and unit 100 are both exercised.
+func TestCoSNestedUnit5963_ValidBinds(t *testing.T) {
+	cases := []struct {
+		unit int
+		tok  string
+	}{
+		{0, "0"},
+		{100, "100"},
+	}
+	for _, tc := range cases {
+		t.Run("unit-"+tc.tok, func(t *testing.T) {
+			tree := flatTreeFromSets(t,
+				"set class-of-service interfaces ge-0-0-0 unit "+tc.tok+" shaping-rate 1m")
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig rejected a valid nested CoS unit %s: %v", tc.tok, err)
+			}
+			iface := cfg.ClassOfService.Interfaces["ge-0-0-0"]
+			if iface == nil {
+				t.Fatalf("CoS interface ge-0-0-0 not compiled for valid unit %s", tc.tok)
+			}
+			u := iface.Units[tc.unit]
+			if u == nil {
+				t.Fatalf("shaper never bound: iface.Units[%d] is nil for valid unit %s", tc.unit, tc.tok)
+			}
+			if u.ShapingRateBytes == 0 {
+				t.Fatalf("shaping-rate not bound for valid unit %s (got 0 bytes)", tc.tok)
+			}
+		})
+	}
+}
+
+// TestCoSNestedUnit5963_LenientWarns proves the tolerant load / peer-sync path
+// (CompileConfigLenient) does NOT hard-error on a malformed nested unit: it
+// downgrades to a deterministic warning naming the bad token so an already-
+// persisted or peer-synced config still BOOTS (#1960 no-brick). The malformed
+// unit is inert (the shaper does not bind), exactly as before the gate.
+func TestCoSNestedUnit5963_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set class-of-service interfaces ge-0-0-0 unit abc shaping-rate 1m")
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-rejected a malformed nested CoS unit (want warn): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, `"abc"`) && strings.Contains(w, "class-of-service interfaces") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile produced no malformed nested-unit warning; got %v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #5933 (PR #5960). #5933 closed the three `<if>.<unit>` **suffix**
reference slots (CoS interface refs, security-zone members, routing-instance
refs) via `config.ValidateLogicalUnit`. A **distinct** grammar slot remained:
the **nested** `class-of-service interfaces <if> unit <n> ...` form, where the
unit is a **child node**, not a `.unit` suffix.

At `pkg/config/compiler_class_of_service.go`, a malformed nested unit was
**silently dropped** at parse:

```go
unitID, err := strconv.Atoi(unitNode.Keys[1])
if err != nil {
    continue   // silent drop — shaper never binds
}
```

`set class-of-service interfaces ge-0-0-0 unit abc shaping-rate 1m` compiled
clean (`CompileConfig` returned nil) and the shaper never bound — the same
mis-bind / fail-open class #5829/#5933 fixed, and arguably the more common
Junos CoS syntax. #5933 couldn't reach it: by the time
`validateInterfaceUnitReferencesStrict` runs, the bad unit is already dropped
at parse, so there's nothing left at the reference gate.

## Fix

Route `unitNode.Keys[1]` through the canonical **`CanonicalLogicalUnit`**
normalizer (#5878) at the CoS parse site — it returns the parsed int (used to
key `iface.Units`) **plus** the shared #5829 acceptance check in one call, so a
non-numeric / negative / integer-overflow / out-of-range `[0..MaxLogicalUnit]`
unit is **rejected at commit** instead of dropped. Clean fit because the parse
site needs the int anyway; `CanonicalLogicalUnit` replaces `strconv.Atoi`
one-for-one and adds validation.

- **Strict** on commit / commit-check — hard-reject naming the interface + bad token.
- **Lenient** on the tolerant load / peer-sync paths via the existing
  `lenientInterfaceUnitRef` flag (the same flag the #5933 suffix gate uses) —
  downgrade to a `cfg.Warnings` entry so an already-persisted or peer-synced
  config an older binary accepted still boots (#1960 no-brick; the malformed
  unit was inert before the gate too — the shaper simply did not bind).
- A **valid** unit still binds the shaper unchanged.

## Validation

- `go build ./...`, `go vet ./pkg/config/`, `go test -race ./pkg/config/` (130s) — all green.
- New `pkg/config/cos_nested_unit_5963_test.go`: strict reject of
  non-numeric/negative/overflow/out-of-range (naming the token + subsystem),
  valid `unit 0`/`unit 100` binds the shaper, lenient warn-and-drop.
- **Fail-on-revert proven**: restoring the silent `continue` turns the reject
  and lenient-warn tests RED (accept + silent drop, no warning).

Docs: `docs/config-schema.md` #5933 section extended with a residual-closed
subsection for the nested form.

Closes #5963

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUssQcuDCc9mJ6YD3p3kMg