### PR TITLE
config: validate CoS forwarding-class queue at commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-16 — #5973 (config/CoS): validate forwarding-class queue-number at commit
+- **Timestamp**: 2026-07-16 (fix/5973-cos-queue-validate)
+- **Action**: The `class-of-service forwarding-classes queue <N> <fc>` parse
+  site in compiler_class_of_service.go SILENTLY DROPPED a queue token strconv.Atoi
+  could not parse (`strconv.Atoi -> continue`): the forwarding-class → queue
+  mapping never bound and CompileConfig accepted the stanza with no operator
+  error — the same mis-bind / silent-drop class #5963/#5933 closed on adjacent
+  CoS slots, surfaced during the independent review of PR #5972 (#5963). The
+  `queue` schema leaf carries no keyValidator, so SchemaValidate accepts a
+  non-numeric token and the compiler was the only gate. Fix: convert the silent
+  `continue` into a strict reject at commit (naming the forwarding-class + raw
+  token, "expected queue 0..255") with a warn-and-drop downgrade on the tolerant
+  load / peer-sync path via opts.lenientCoSForwardingClassQueue — the SAME #4594
+  flag the downstream forwarding-class queue-RANGE gate uses (#1960 no-brick; the
+  malformed queue was inert then too, the FC never bound). Division of labour: a
+  PARSEABLE but out-of-range (999) or negative queue still flows to the existing
+  #4594 range gate (validateClassOfServiceForwardingClassQueueStrict); this site
+  closes the ONE case that gate can never see — a strconv error means no Queue
+  int is left to range-check. Queue domain confirmed 0..255 (dataplane u8 queue
+  id), NOT Junos-classic 0..7, so CanonicalLogicalUnit (units 0..16385) was NOT
+  reused.
+- **File(s)**: pkg/config/compiler_class_of_service.go (parse-site gate),
+  pkg/config/cos_fc_queue_5973_test.go (new — strict reject of
+  non-numeric/overflow naming the token, valid queue 0/7/255 binds, lenient
+  warn-and-drop leaving the FC inert; RED on revert of the gate),
+  docs/config-schema.md (#5973 note), _Log.md.
+- **Validation**: go build ./... ; go vet ./pkg/config/ ; go test -race
+  ./pkg/config/ -count=1 — all GREEN. Fail-on-revert confirmed: restoring the
+  silent `strconv.Atoi -> continue` turns TestCoSForwardingClassQueue5973_Reject
+  RED.
+
 ## 2026-07-15 — #5827 (config/security): cap retained parse diagnostics (heap DoS)
 - **Timestamp**: 2026-07-15 (fix/5827-parse-error-cap)
 - **Action**: The recursive-descent config parser (pkg/config/parser.go) recorded

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -462,6 +462,38 @@ binds the shaper unchanged. Covered by `pkg/config/cos_nested_unit_5963_test.go`
 valid `unit 0`/`unit 100` binds the shaper, lenient warn-and-drop), RED on revert
 of the parse-site gate.
 
+#### Residual closed: the `forwarding-classes queue <N>` token (#5973)
+
+Surfaced during the independent review of PR #5972 (#5963): the SAME silent-drop
+class existed on a DISTINCT CoS field in the same file — the
+`class-of-service forwarding-classes queue <N> <fc>` parse site. Its schema node
+(`schema_cos.go`, the `queue` leaf) carries no `keyValidator`, so `SchemaValidate`
+accepts a non-numeric queue token; the CoS compiler then SILENTLY DROPPED a token
+`strconv.Atoi` could not parse (`strconv.Atoi(queueNode.Keys[1]); if err != nil {
+continue }` in `compiler_class_of_service.go`). `set class-of-service
+forwarding-classes queue abc iperf-video` compiled clean and the
+forwarding-class → queue mapping never bound — the same mis-bind / silent-drop
+class #5963/#5933 closed, and inconsistent with the sibling fairness
+rss-expectation queue parse in the same file, which hard-rejects
+`err != nil || queue < 0 || queue > 255`.
+
+Division of labour with the existing #4594 range gate: a PARSEABLE but
+out-of-range queue (e.g. `999`) or a negative one already flows to the downstream
+`validateClassOfServiceForwardingClassQueueStrict` gate, which rejects it on the
+strict path and warns on the tolerant path (queue domain is **0..255**, the
+dataplane's `u8` queue id — NOT the Junos-classic 0..7). #5973 closes the ONE
+case that range gate can never see: a `strconv.Atoi` error means the FC never
+binds, so there is no `Queue` int left for the range gate to check. The fix
+rejects the strconv-error token AT the parse site (strict on commit /
+commit-check, naming the forwarding-class + bad token); the
+`lenientCoSForwardingClassQueue` opt — the SAME #4594 flag the downstream range
+gate uses — downgrades it to a `cfg.Warnings` entry on the tolerant load /
+peer-sync paths (#1960 no-brick — the malformed queue was inert before the gate
+too, the FC simply did not bind). A VALID queue still binds unchanged. Covered by
+`pkg/config/cos_fc_queue_5973_test.go` (strict reject of non-numeric/overflow
+naming the token, valid `queue 0`/`7`/`255` binds, lenient warn-and-drop leaving
+the FC inert), RED on revert of the parse-site gate.
+
 ### security address-book same-name `address` + `address-set` collision (#5676)
 
 `address` and `address-set` entries share ONE operator-visible namespace (a

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -152,11 +152,48 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig, opts compileOp
 			if len(queueNode.Keys) < 3 {
 				continue
 			}
-			queue, err := strconv.Atoi(queueNode.Keys[1])
-			if err != nil {
-				continue
-			}
 			name := queueNode.Keys[2]
+			rawQueue := queueNode.Keys[1]
+			queue, err := strconv.Atoi(rawQueue)
+			if err != nil {
+				// #5973: a non-numeric or integer-overflowing
+				// forwarding-class queue token was previously
+				// SILENTLY DROPPED here (strconv.Atoi -> continue):
+				// the forwarding-class -> queue mapping never bound
+				// and CompileConfig accepted the stanza with no
+				// effect — the same mis-bind / fail-open class
+				// #5963/#5933 closed on adjacent CoS slots, and
+				// inconsistent with the sibling fairness
+				// rss-expectation queue parse (which hard-rejects
+				// `err != nil || queue < 0 || queue > 255`). This is
+				// the ONE malformed case the downstream #4594
+				// forwarding-class queue-range gate
+				// (validateClassOfServiceForwardingClassQueueStrict)
+				// can never see: a strconv error means the FC never
+				// binds, so there is no Queue int left for the range
+				// gate to check. A PARSEABLE but out-of-range value
+				// (e.g. 999) or a negative one still flows through to
+				// that downstream gate, which already rejects it
+				// (strict) / warns (lenient). Reject at commit here;
+				// downgrade to a warning on the tolerant load /
+				// peer-sync path (opts.lenientCoSForwardingClassQueue,
+				// the SAME #4594 flag that downstream gate uses) so an
+				// already-persisted or peer-synced config an older
+				// binary accepted still boots — #1960 no-brick; the
+				// malformed queue was inert then too (the FC never
+				// bound).
+				detail := fmt.Errorf(
+					"class-of-service forwarding-classes forwarding-class %q queue %q: expected queue 0..255: %w",
+					name, rawQueue, err)
+				if opts.lenientCoSForwardingClassQueue {
+					if warnings != nil {
+						*warnings = append(*warnings, fmt.Sprintf(
+							"class-of-service forwarding-class queue (downgraded to warning on tolerant path): %v", detail))
+					}
+					continue
+				}
+				return detail
+			}
 			if existing, claimed := queueOwner[queue]; claimed && existing != name {
 				return fmt.Errorf(
 					"class-of-service forwarding-classes queue %d: "+

--- a/pkg/config/cos_fc_queue_5973_test.go
+++ b/pkg/config/cos_fc_queue_5973_test.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5973: the `class-of-service forwarding-classes queue <N> <fc>` parse site
+// (compiler_class_of_service.go) previously SILENTLY DROPPED a queue token that
+// strconv.Atoi could not parse (`strconv.Atoi -> continue`): the
+// forwarding-class -> queue mapping never bound and CompileConfig returned nil
+// with no operator error — the same mis-bind / fail-open class #5963/#5933
+// closed on adjacent CoS slots, and inconsistent with the sibling fairness
+// rss-expectation queue parse (which hard-rejects
+// `err != nil || queue < 0 || queue > 255`).
+//
+// The `queue` schema node (schema_cos.go) carries no keyValidator, so
+// SchemaValidate accepts a non-numeric token; the compiler is the only gate.
+// The fix rejects the strconv-error token at strict commit and warns on the
+// tolerant load / peer-sync path (opts.lenientCoSForwardingClassQueue — the
+// same #4594 flag the downstream forwarding-class queue-RANGE gate uses).
+//
+// Division of labour: a PARSEABLE but out-of-range value (e.g. 999) or a
+// negative one still flows to the downstream #4594 range gate
+// (validateClassOfServiceForwardingClassQueueStrict), which already rejects it
+// (see compiler_cos_fc_queue_4594_test.go). This site closes the ONE case that
+// gate can never see — a strconv error means the FC never binds, so there is no
+// Queue int left to range-check.
+//
+// Flat-set MUST be built with ParseSetCommand/SetPath (flatTreeFromSets), never
+// NewParser (CLAUDE.md "Testing flat set syntax").
+//
+// FAIL-ON-REVERT (load-bearing): restore the silent `strconv.Atoi(...); if err
+// != nil { continue }` at the parse site → the reject test compiles the
+// malformed queue clean (accept + silent drop) → its assertion goes RED. The
+// out-of-range 999 case is NOT part of this guard (it survives the revert via
+// the downstream #4594 gate); only the strconv-error tokens below prove the
+// revert.
+
+// cosBadQueueTokens is the set of queue tokens strconv.Atoi rejects — the exact
+// tokens that hit the previously-silent `continue`. The compiler error always
+// quotes the raw token via `queue %q`, so `want` is that quoted form.
+var cosBadQueueTokens = []struct {
+	name string
+	tok  string
+	want string
+}{
+	{"non-numeric", "abc", `"abc"`},
+	{"integer-overflow", "99999999999999999999", `"99999999999999999999"`},
+}
+
+// TestCoSForwardingClassQueue5973_Reject proves a forwarding-class queue token
+// that strconv.Atoi cannot parse is REJECTED at strict commit (CompileConfig)
+// instead of silently dropped.
+func TestCoSForwardingClassQueue5973_Reject(t *testing.T) {
+	for _, tc := range cosBadQueueTokens {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t,
+				"set class-of-service forwarding-classes queue "+tc.tok+" iperf-video")
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a malformed forwarding-class queue %q (silent FC drop); want reject", tc.tok)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error must name the bad queue token %s: %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "class-of-service forwarding-classes") {
+				t.Fatalf("error must name the subsystem (class-of-service forwarding-classes): %v", err)
+			}
+		})
+	}
+}
+
+// TestCoSForwardingClassQueue5973_ValidBinds guards against over-rejection: a
+// VALID queue (including the 0 and 255 boundaries) still compiles AND binds the
+// forwarding-class -> queue mapping (semantics unchanged for the good case).
+func TestCoSForwardingClassQueue5973_ValidBinds(t *testing.T) {
+	cases := []struct {
+		tok  string
+		want int
+	}{
+		{"0", 0},
+		{"7", 7},
+		{"255", 255},
+	}
+	for _, tc := range cases {
+		t.Run("queue-"+tc.tok, func(t *testing.T) {
+			tree := flatTreeFromSets(t,
+				"set class-of-service forwarding-classes queue "+tc.tok+" iperf-video")
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig rejected a valid forwarding-class queue %s: %v", tc.tok, err)
+			}
+			fc := cfg.ClassOfService.ForwardingClasses["iperf-video"]
+			if fc == nil {
+				t.Fatalf("forwarding-class iperf-video never bound for valid queue %s", tc.tok)
+			}
+			if fc.Queue != tc.want {
+				t.Fatalf("forwarding-class iperf-video queue = %d, want %d", fc.Queue, tc.want)
+			}
+		})
+	}
+}
+
+// TestCoSForwardingClassQueue5973_LenientWarns proves the tolerant load /
+// peer-sync path (CompileConfigLenient) does NOT hard-error on a strconv-error
+// queue token: it downgrades to a deterministic warning naming the bad token so
+// an already-persisted or peer-synced config still BOOTS (#1960 no-brick). The
+// malformed queue is inert (the FC does not bind), exactly as before the gate.
+func TestCoSForwardingClassQueue5973_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set class-of-service forwarding-classes queue abc iperf-video")
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-rejected a malformed forwarding-class queue (want warn): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, `"abc"`) && strings.Contains(w, "class-of-service forwarding-class") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile produced no malformed forwarding-class queue warning; got %v", cfg.Warnings)
+	}
+	// The malformed queue must remain inert — the FC never bound.
+	if fc := cfg.ClassOfService.ForwardingClasses["iperf-video"]; fc != nil {
+		t.Fatalf("malformed queue must not bind the forwarding-class on the lenient path; got %+v", fc)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the silent-drop of a malformed `class-of-service forwarding-classes
queue <N> <fc>` value in `pkg/config/compiler_class_of_service.go` — a
near-clone of #5963 (nested CoS unit) on a **different** CoS field (queue
number) in the **same** file. Surfaced during the independent review of PR
#5972 (#5963).

Before this change, the parse site did:

```go
queue, err := strconv.Atoi(queueNode.Keys[1])
if err != nil {
    continue   // silent drop — FC never binds, no operator error
}
```

A queue token `strconv.Atoi` could not parse (non-numeric, integer-overflow)
was **silently dropped**: the forwarding-class → queue mapping never bound and
`CompileConfig` returned nil. The `queue` schema leaf (`schema_cos.go`) has no
`keyValidator`, so `SchemaValidate` accepts a non-numeric token and the
compiler was the only gate.

## Fix

Convert the silent `continue` into a strict reject at commit / commit-check
(naming the forwarding-class + raw token, `expected queue 0..255`), with a
warn-and-drop downgrade on the tolerant load / peer-sync path via
`opts.lenientCoSForwardingClassQueue` — the **same #4594 flag** the downstream
forwarding-class queue-**range** gate uses (#1960 no-brick; the malformed queue
was inert then too, the FC never bound).

**Division of labour with the existing #4594 range gate.** A *parseable* but
out-of-range queue (e.g. `999`) or a negative one already flows to
`validateClassOfServiceForwardingClassQueueStrict`, which rejects it (strict) /
warns (lenient). #5973 closes the ONE case that gate can never see — a
`strconv` error means the FC never binds, so there is no `Queue` int left to
range-check. This gate therefore does **not** front-run the range gate for
parseable values, and the existing #4594 tests stay green.

**Queue range: `0..255`** — the dataplane's `u8` queue id, confirmed from
`compiler_validate_strict_cos.go` (`class.Queue < 0 || class.Queue > 255`),
explicitly **NOT** the Junos-classic 0..7. `CanonicalLogicalUnit` (logical
units `0..16385`) was deliberately **not** reused.

## Test

`pkg/config/cos_fc_queue_5973_test.go`:
- **Reject** — non-numeric `abc` and integer-overflow token rejected at
  `CompileConfig`, error names the quoted raw token + subsystem.
- **ValidBinds** — queue `0` / `7` / `255` compile and bind
  `ForwardingClasses["iperf-video"].Queue`.
- **LenientWarns** — `CompileConfigLenient` warns (no error), FC stays inert.

**Fail-on-revert:** restoring the silent `strconv.Atoi -> continue` turns
`TestCoSForwardingClassQueue5973_Reject` RED (both sub-cases); GREEN restored.

## Validation

`go build ./...` · `go vet ./pkg/config/` · `go test -race ./pkg/config/
-count=1` — all green (race suite 132s). Config-validation change → no
test-failover.

## Docs

`docs/config-schema.md` records the queue-number is now validated at the parse
site (#5973), sibling to the #5963 nested-unit note.

Closes #5973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EE8HrVStE9HufGLPawS6U8