### PR TITLE
config: canonicalize interface-unit reference binders (#5878 phase 2)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -349,12 +349,68 @@ the reconciled `tunnelid_test.go` duplicate-spelling case, each RED on revert of
 the gate wiring (the parity test goes RED — node0 accepts — when the gate is put
 back node-local).
 
-**Phase 2 (deferred, #5878):** thread `CanonicalLogicalUnit` through the
-zone / CoS / routing-instance / NAT reference binders and the snapshot / status
-emitters so a `.01` reference resolves to the same runtime unit as the
-interface's canonical `.1` everywhere (the second, subtler half of #5878).
-Phase 1 (this section) closes the divergent-commit fail-open — the material
-security bug — and is sized separately from the reference-binder threading.
+**Phase 2 (#5878) — reference-binder canonicalization.** Phase 1 (above) closes
+the divergent-commit fail-open by rejecting a duplicate-spelling collision at
+commit. The second, subtler half of #5878 is that a cross-subsystem reference
+carrying a `.<unit>` suffix was BOUND by its raw string, not its canonical unit,
+so a `.01` reference and a `.1` reference resolved to DIFFERENT runtime units —
+even without a duplicate-spelling collision, a peer-only `${node}` rewrite that
+emits `.01` on the standby (vs `.1` on the active) could bind a zone / NAT /
+routing member to a different unit on standby. Phase 2 threads the canonical
+identity through the reference binders via one helper,
+`CanonicalInterfaceUnitRef(ref)` (`schema_validators.go`), which folds the
+`.<unit>` suffix through `CanonicalLogicalUnit` (`.01`→`.1`, `.+1`→`.1`,
+`.00`→`.0`) and returns a bare / trailing-dot / malformed-suffix ref unchanged (a
+malformed suffix is still rejected at commit by the #5933 reference gate). The
+per-unit interface snapshot keys every binder map by the canonical `"%s.%d"`
+unit name, so each binder now stores its map key on the canonical unit:
+
+  - **Security-zone membership** — `buildInterfaceZoneMap` (`zones.go`) and its
+    two mirrors, the #3072 conflict-detection SSOT `zoneIfaceLogicalKeys`
+    (`compiler_validate_strict_zones.go`) and the kernel host-deny scope map
+    `junosHostZoneByInterface` (`junos_host_deny.go`). Canonicalizing the
+    detector alongside the binder is load-bearing: without it, a `.01` member
+    would bind canonical unit 1 in `buildInterfaceZoneMap` (first-writer-wins)
+    while the detector still saw `.01` and `.1` as distinct keys, silently
+    reopening the multi-zone fail-open #3072 closed.
+  - **Routing-instance membership** — `buildInterfaceRoutingInstances` and
+    `buildInterfaceRouteTables` (`routes.go`).
+  - **Per-interface host-inbound override** — `buildInterfaceHostInboundMap`
+    (`zones_override.go`), plus the operator-facing lookups in
+    `ClassifyHostInboundForInterface` / `ResolveHostInboundIngressInterface`
+    (`host_inbound_classify.go`) so a `.01` ingress-interface ref resolves to
+    the canonical unit's zone.
+
+  **class-of-service** was already canonical: the nested `interfaces <if> unit
+  <n>` form keys `iface.Units[unitID]` by the canonical int (`CanonicalLogicalUnit`,
+  #5963), and the `.unit`-suffix-in-key form never resolves to a runtime unit in
+  the consumer (`interfaces.go` keys CoS by base name + int unit), so no CoS
+  divergence is possible. **NAT** rules bind by zone / routing-instance /
+  address, not by an interface-unit reference, so there is nothing to
+  canonicalize.
+
+  The daemon netlink VRF / tunnel-membership resolver is threaded too:
+  `riMemberLinuxName` (`pkg/daemon/daemon_run.go`) — shared by the step-0a VRF
+  bind loop and the `collectAppliedTunnels` RIListMember scan — now canonicalizes
+  the member ref BEFORE resolving it, so a `.01` routing-instance member binds the
+  SAME Linux device as `.1`. `TunnelNameMap` keys are built from the canonical int
+  unit number (`ifName + "." + strconv.Itoa(unitNum)`), so canonicalizing at the
+  top makes BOTH the tunnel-device path (tunMap hit) and the
+  `LinuxIfName`/unit-0-collapse path use the canonical name. This is NOT covered
+  by the Phase 1 alias gate: `validateInterfaceUnitAliasCollisionsAST` gates
+  `interfaces ... unit` DEFINITIONS, not routing-instance / zone membership
+  REFERENCES — a peer-only `groups node1 { routing-instances ri interface
+  ge-0/0/0.01 }` reference is a divergence the definition gate never sees, so the
+  reference must be canonicalized directly at the binder (it is). #5878 has no
+  remaining reference-binding residual.
+
+  Covered by `pkg/dataplane/userspace/unit_canonical_refbind_5878_test.go` (zone /
+  routing-instance / host-inbound `.01`→canonical-unit-1 binding, RED on revert of
+  each binder), `pkg/config/unit_canonical_refkey_5878_test.go`
+  (`CanonicalInterfaceUnitRef` matrix, `zoneIfaceLogicalKeys` canonical claim, and
+  a two-zone `.01`/`.1` duplicate-membership reject), and
+  `pkg/daemon/ri_member_canonical_5878_test.go` (netlink `.01`→canonical device
+  via both the tunnel-device and LinuxIfName paths, RED on revert).
 
 ### Non-numeric logical-unit identity fail-closed (#5829)
 

--- a/pkg/config/compiler_validate_strict_zones.go
+++ b/pkg/config/compiler_validate_strict_zones.go
@@ -203,7 +203,16 @@ func validateZoneCountStrict(cfg *Config) error {
 func zoneIfaceLogicalKeys(cfg *Config, iface string) []string {
 	base, unit, ok := strings.Cut(iface, ".")
 	if ok && unit != "" {
-		return []string{base + "." + unit}
+		// #5878 phase 2: fold the .<unit> suffix onto its canonical identity so
+		// ge-0/0/0.01 and ge-0/0/0.1 claim the SAME logical key — the membership
+		// conflict gate must treat two spellings of one unit as one unit, and
+		// stay aligned with buildInterfaceZoneMap, which now canonicalizes the
+		// key it binds. Without this, a .01 member would bind canonical unit 1 in
+		// buildInterfaceZoneMap (first-writer-wins) while this detector still saw
+		// .01 and .1 as distinct keys — reopening the silent multi-zone fail-open
+		// #3072 closed. A malformed suffix (rejected at commit by the #5933
+		// reference gate) keeps its raw spelling via CanonicalInterfaceUnitRef.
+		return []string{CanonicalInterfaceUnitRef(iface)}
 	}
 	// Bare interface: claim the physical interface and all its configured units.
 	if base == "" {

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -1120,10 +1120,15 @@ func junosHostZoneByInterface(cfg *Config) map[string]string {
 		if zone == nil {
 			continue
 		}
-		for _, iface := range zone.Interfaces {
-			if iface == "" {
+		for _, rawIface := range zone.Interfaces {
+			if rawIface == "" {
 				continue
 			}
+			// #5878 phase 2: bind on the canonical logical-unit identity so this
+			// mirror resolves ge-0/0/0.01 to the same runtime unit (ge-0/0/0.1)
+			// the dataplane snapshot does — the consumer looks this map up by the
+			// canonical "%s.%d" unit name.
+			iface := CanonicalInterfaceUnitRef(rawIface)
 			if _, exists := out[iface]; !exists {
 				out[iface] = zoneName
 			}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -175,6 +175,34 @@ func CanonicalLogicalUnit(raw string) (int, string, error) {
 	return int(v), strconv.FormatInt(v, 10), nil
 }
 
+// CanonicalInterfaceUnitRef canonicalizes the optional ".<unit>" suffix of a
+// cross-subsystem interface reference (#5878 phase 2) so two textual spellings
+// of one logical unit — ge-0/0/0.01, ge-0/0/0.1, ge-0/0/0.+1 — resolve to ONE
+// runtime identity when a reference binder keys a map by the reference. The
+// suffix is split on the FIRST "." — exactly how each subsystem's runtime splits
+// the reference (buildInterfaceZoneMap, buildInterfaceRoutingInstances,
+// buildInterfaceRouteTables, buildInterfaceHostInboundMap, junosHostZoneBy
+// Interface, zoneIfaceLogicalKeys) — so schema acceptance, validation, and
+// binding stay aligned. Interface names carry no "." except the unit suffix.
+//
+// A bare interface (no "."), a trailing-dot form ("base." — the runtime treats
+// it as bare), or a suffix that is not a valid logical unit is returned
+// UNCHANGED: a malformed suffix is rejected at commit by the strict #5933
+// reference gate (validateInterfaceUnitReferencesStrict) and stays inert on the
+// tolerant load / peer-sync path exactly as before — canonicalization never
+// changes the acceptance set, only which runtime unit a VALID reference binds.
+func CanonicalInterfaceUnitRef(ref string) string {
+	base, unitTok, hasUnit := strings.Cut(ref, ".")
+	if !hasUnit || unitTok == "" {
+		return ref
+	}
+	_, canon, err := CanonicalLogicalUnit(unitTok)
+	if err != nil {
+		return ref
+	}
+	return base + "." + canon
+}
+
 // ValidateLogicalUnit is the ONE canonical numeric-identity validator for a
 // logical `unit <n>` slot (#5829). A `unit <identity>` slot has no positional
 // key validation, so a non-numeric identity such as `unit tenant` passed

--- a/pkg/config/unit_canonical_refkey_5878_test.go
+++ b/pkg/config/unit_canonical_refkey_5878_test.go
@@ -1,0 +1,74 @@
+package config
+
+import "testing"
+
+// #5878 phase 2 — the canonical reference-key SSOT. CanonicalInterfaceUnitRef
+// folds every accepted textual spelling of a `.<unit>` suffix onto one identity,
+// and zoneIfaceLogicalKeys (the zone-membership conflict-detection SSOT that
+// mirrors buildInterfaceZoneMap's binding) claims that canonical key so `.01` and
+// `.1` are treated as the SAME logical unit.
+
+func TestCanonicalInterfaceUnitRef5878(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"ge-0/0/0.01", "ge-0/0/0.1"}, // leading zero
+		{"ge-0/0/0.1", "ge-0/0/0.1"},  // already canonical
+		{"ge-0/0/0.+1", "ge-0/0/0.1"}, // redundant sign
+		{"ge-0/0/0.00", "ge-0/0/0.0"}, // zero alias
+		{"ge-0/0/0.-0", "ge-0/0/0.0"}, // signed zero
+		{"ge-0/0/0", "ge-0/0/0"},      // bare interface — unchanged
+		{"ge-0/0/0.", "ge-0/0/0."},    // trailing dot (bare) — unchanged
+		{"ge-0/0/0.tenant", "ge-0/0/0.tenant"}, // malformed suffix — unchanged (rejected at commit by #5933)
+		{"ge-0/0/0.99999", "ge-0/0/0.99999"},   // out-of-range — unchanged
+	}
+	for _, c := range cases {
+		if got := CanonicalInterfaceUnitRef(c.in); got != c.want {
+			t.Errorf("CanonicalInterfaceUnitRef(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestZoneIfaceLogicalKeysCanonical5878 pins that a unit-qualified zone member's
+// claimed logical key is the CANONICAL unit — the property that keeps the #3072
+// membership conflict gate aligned with the now-canonical buildInterfaceZoneMap
+// binder. On revert (raw suffix), the key is `ge-0/0/0.01` and this goes RED.
+func TestZoneIfaceLogicalKeysCanonical5878(t *testing.T) {
+	cfg := &Config{}
+	keys := zoneIfaceLogicalKeys(cfg, "ge-0/0/0.01")
+	if len(keys) != 1 || keys[0] != "ge-0/0/0.1" {
+		t.Fatalf("zoneIfaceLogicalKeys(ge-0/0/0.01) = %v, want [ge-0/0/0.1]", keys)
+	}
+	// `.01` and `.1` must claim the SAME key (they are one unit).
+	if a, b := zoneIfaceLogicalKeys(cfg, "ge-0/0/0.01"), zoneIfaceLogicalKeys(cfg, "ge-0/0/0.1"); a[0] != b[0] {
+		t.Fatalf("zoneIfaceLogicalKeys: `.01` claims %q, `.1` claims %q — must be identical", a[0], b[0])
+	}
+}
+
+// TestZoneMembershipConflictCanonical5878 is the security consequence: two zones
+// claiming the SAME unit under two spellings (`.01` in one, `.1` in the other)
+// must be rejected as a duplicate zone assignment — otherwise buildInterfaceZone
+// Map binds one of them first-writer-wins and silently drops the other (the
+// #3072 fail-open, reopened by phase-2 canonicalization if the detector is not
+// aligned). On revert this config is silently accepted and the test goes RED.
+func TestZoneMembershipConflictCanonical5878(t *testing.T) {
+	cmds := []string{
+		"set interfaces ge-0/0/0 unit 1 family inet address 10.0.0.1/24",
+		"set security zones security-zone trust interfaces ge-0/0/0.1",
+		"set security zones security-zone untrust interfaces ge-0/0/0.01",
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("CompileConfig accepted ge-0/0/0.1 in trust and ge-0/0/0.01 in untrust " +
+			"(same canonical unit in two zones) — want a duplicate-zone-membership reject")
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -99,6 +99,20 @@ func buildRuntimeDataPlane(dpType string) (dataplane.RuntimeDataPlane, error) {
 // silently activate binds 0a has never performed and needs its own
 // ratification.
 func riMemberLinuxName(tunMap map[string]string, ifaceName string) string {
+	// #5878 phase 2: resolve the routing-instance member on its CANONICAL
+	// logical-unit identity BEFORE the tunMap lookup so a `.01` member resolves
+	// to the SAME device as `.1` (and as the interface's `unit 1`). TunnelNameMap
+	// keys are built from the canonical int unit number
+	// (ifName + "." + strconv.Itoa(unitNum)), so canonicalizing here makes BOTH
+	// the tunnel-device path (tunMap hit) AND the LinuxIfName/unit-0-collapse path
+	// use the canonical name — otherwise a peer-only
+	// `groups node1 { routing-instances ri interface ge-0/0/0.01 }` reference
+	// binds a DIFFERENT VRF/tunnel device on the standby (the #5878 HA-divergence
+	// class at the netlink layer). Note the P1 alias gate
+	// (validateInterfaceUnitAliasCollisionsAST) gates `interfaces ... unit`
+	// DEFINITIONS, NOT routing-instance/zone membership REFERENCES, so it does not
+	// prevent this reference divergence — the canonicalization does.
+	ifaceName = config.CanonicalInterfaceUnitRef(ifaceName)
 	if name, ok := tunMap[ifaceName]; ok && name != "" {
 		return name
 	}

--- a/pkg/daemon/ri_member_canonical_5878_test.go
+++ b/pkg/daemon/ri_member_canonical_5878_test.go
@@ -1,0 +1,59 @@
+package daemon
+
+import "testing"
+
+// #5878 phase 2 — the daemon netlink VRF/tunnel-membership resolver
+// (riMemberLinuxName) must resolve a routing-instance member on its CANONICAL
+// logical-unit identity, so a `.01` alias member binds the SAME Linux device as
+// the canonical `.1` (and as the interface's `unit 1`). Without this, a
+// peer-only `groups node1 { routing-instances ri interface ge-0/0/0.01 }`
+// reference — which the P1 alias gate never sees (it gates unit DEFINITIONS, not
+// membership REFERENCES) — resolves to "ge-0-0-0.01" on the standby vs
+// "ge-0-0-0.1" on the active: the #5878 HA-divergence class at the netlink layer.
+//
+// Fail-on-revert: drop the CanonicalInterfaceUnitRef call in riMemberLinuxName
+// and the `.01` cases resolve to the raw "...01" name != the canonical, so the
+// equality assertions go RED.
+func TestRIMemberLinuxNameCanonicalizesUnitAlias5878(t *testing.T) {
+	// TunnelNameMap keys are built from the canonical int unit number, so the map
+	// carries only the canonical spelling. The `.01` alias must still hit it.
+	tunMap := map[string]string{
+		"gr-0/0/0.1": "gr-0-0-0u1",
+	}
+
+	// Tunnel path (tunMap hit): `.01` and `.1` resolve to the SAME per-unit
+	// device via the canonical key.
+	if got := riMemberLinuxName(tunMap, "gr-0/0/0.01"); got != "gr-0-0-0u1" {
+		t.Errorf("riMemberLinuxName(.01, tunnel) = %q, want gr-0-0-0u1 (canonical .1 device)", got)
+	}
+	if a, b := riMemberLinuxName(tunMap, "gr-0/0/0.01"), riMemberLinuxName(tunMap, "gr-0/0/0.1"); a != b {
+		t.Errorf("tunnel path: .01 -> %q, .1 -> %q — must be identical", a, b)
+	}
+
+	// Non-tunnel path (LinuxIfName): `.01` resolves to the canonical
+	// "ge-0-0-0.1", NOT the raw "ge-0-0-0.01".
+	if got := riMemberLinuxName(nil, "ge-0/0/0.01"); got != "ge-0-0-0.1" {
+		t.Errorf("riMemberLinuxName(.01, non-tunnel) = %q, want ge-0-0-0.1", got)
+	}
+	if a, b := riMemberLinuxName(nil, "ge-0/0/0.01"), riMemberLinuxName(nil, "ge-0/0/0.1"); a != b {
+		t.Errorf("non-tunnel path: .01 -> %q, .1 -> %q — must be identical", a, b)
+	}
+
+	// A leading-zero unit 0 alias (`.00`) collapses to the base device, same as
+	// the canonical `.0` unit-0 collapse.
+	if got := riMemberLinuxName(nil, "ge-0/0/1.00"); got != "ge-0-0-1" {
+		t.Errorf("riMemberLinuxName(.00, non-tunnel) = %q, want ge-0-0-1 (unit-0 collapse)", got)
+	}
+
+	// Regression: canonical / bare / unit>0 spellings are unchanged.
+	noRegression := map[string]string{
+		"gr-0/0/0.0": "gr-0-0-0",   // unit-0 collapse
+		"gr-0/0/0":   "gr-0-0-0",   // bare
+		"ge-0/0/1.5": "ge-0-0-1.5", // non-tunnel unit>0 canonical
+	}
+	for in, want := range noRegression {
+		if got := riMemberLinuxName(nil, in); got != want {
+			t.Errorf("riMemberLinuxName(%q) = %q, want %q (no regression)", in, got, want)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/host_inbound_classify.go
+++ b/pkg/dataplane/userspace/host_inbound_classify.go
@@ -236,7 +236,10 @@ func ClassifyHostInboundForInterface(cfg *config.Config, fromZone, ifaceRef stri
 	// the enforcement view builder uses (unionHostInboundTokens over the zone-level
 	// stanza and the per-interface override, physical→unit inheritance included),
 	// then classify that single view.
-	svc, prot := unionHostInboundTokens(zone.HostInboundTraffic, buildInterfaceHostInboundMap(cfg)[ifaceRef])
+	// #5878 phase 2: look the override up on the ref's canonical logical-unit
+	// identity so a query for ge-0/0/0.01 finds an override authored as
+	// ge-0/0/0.1 (buildInterfaceHostInboundMap now keys by the canonical unit).
+	svc, prot := unionHostInboundTokens(zone.HostInboundTraffic, buildInterfaceHostInboundMap(cfg)[config.CanonicalInterfaceUnitRef(ifaceRef)])
 	v := ZoneHostInboundView{Zone: fromZone, Interfaces: []string{ifaceRef}, SystemServices: svc, Protocols: prot}
 	return classifyOneView(v, proto, hasProto, dstPort, icmpType, family)
 }
@@ -329,7 +332,10 @@ func ResolveHostInboundIngressInterface(cfg *config.Config, fromZone, ifaceRef s
 			return fmt.Errorf("ingress-interface %q is a physical interface; specify the logical unit, e.g. %s.%d", ifaceRef, ifaceRef, smallestUnitNumber(ic.Units))
 		}
 	}
-	zone := buildInterfaceZoneMap(cfg)[ifaceRef]
+	// #5878 phase 2: resolve the operator ref on its canonical logical-unit
+	// identity so `ingress-interface ge-0/0/0.01` validates against the zone the
+	// canonical unit ge-0/0/0.1 binds (buildInterfaceZoneMap now keys canonical).
+	zone := buildInterfaceZoneMap(cfg)[config.CanonicalInterfaceUnitRef(ifaceRef)]
 	if zone == "" {
 		return fmt.Errorf("unknown ingress-interface %q (not assigned to any security zone)", ifaceRef)
 	}

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -346,8 +346,12 @@ func buildInterfaceRouteTables(cfg *config.Config) (map[string]string, map[strin
 			if ifname == "" {
 				continue
 			}
-			v4[ifname] = ri.Name + ".inet.0"
-			v6[ifname] = ri.Name + ".inet6.0"
+			// #5878 phase 2: canonicalize the .<unit> suffix so ge-0/0/0.01 binds
+			// the same route table as ge-0/0/0.1 (the per-unit snapshot consumer
+			// keys these maps by the canonical "%s.%d" unit name).
+			key := config.CanonicalInterfaceUnitRef(ifname)
+			v4[key] = ri.Name + ".inet.0"
+			v6[key] = ri.Name + ".inet6.0"
 		}
 	}
 	return v4, v6
@@ -374,7 +378,10 @@ func buildInterfaceRoutingInstances(cfg *config.Config) map[string]string {
 			if ifname == "" {
 				continue
 			}
-			out[ifname] = ri.Name
+			// #5878 phase 2: canonicalize the .<unit> suffix so ge-0/0/0.01 binds
+			// the same routing-instance as ge-0/0/0.1 (the per-unit snapshot
+			// consumer keys this map by the canonical "%s.%d" unit name).
+			out[config.CanonicalInterfaceUnitRef(ifname)] = ri.Name
 		}
 	}
 	return out

--- a/pkg/dataplane/userspace/unit_canonical_refbind_5878_test.go
+++ b/pkg/dataplane/userspace/unit_canonical_refbind_5878_test.go
@@ -1,0 +1,140 @@
+package userspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5878 phase 2 — reference-binder canonicalization. The interface defines a
+// single logical unit (`unit 1`); zone / routing-instance / host-inbound
+// references spell the SAME unit as `.01` (leading-zero alias). The reference
+// binders must resolve `.01` to the interface's canonical runtime unit `.1`, so
+// the per-unit snapshot (which keys the binder maps by the canonical "%s.%d"
+// unit name) inherits the zone, routing-instance, and host-inbound override the
+// operator bound.
+//
+// These are fail-on-revert: restore the raw-suffix key in a binder and the
+// canonical unit-1 lookup misses — the unit binds to NO zone / NO routing
+// instance / NO override — and the matching subtest goes RED.
+
+// canonRefBindCfg5878 compiles (STRICT path — the commit path) a config whose
+// interface has `unit 1` and whose zone/routing-instance/host-inbound references
+// all use the `.01` leading-zero alias. Strict compile confirms `.01` is an
+// accepted (valid) logical-unit reference — the divergence #5878 phase 2 closes
+// is in BINDING, not acceptance.
+func canonRefBindCfg5878(t *testing.T) *config.Config {
+	t.Helper()
+	cmds := []string{
+		"set interfaces ge-0/0/0 unit 1 family inet address 10.0.0.1/24",
+		"set routing-instances ri1 instance-type virtual-router",
+		"set routing-instances ri1 interface ge-0/0/0.01",
+		"set security zones security-zone trust interfaces ge-0/0/0.01",
+		"set security zones security-zone trust interfaces ge-0/0/0.01 host-inbound-traffic system-services ssh",
+	}
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (strict): %v", err)
+	}
+	return cfg
+}
+
+// canonUnitName returns the canonical "%s.%d" runtime name of the sole
+// configured interface's unit — the exact key the per-unit snapshot consumer
+// uses to look up the reference-binder maps.
+func canonUnitName(t *testing.T, cfg *config.Config, unit int) string {
+	t.Helper()
+	if n := len(cfg.Interfaces.Interfaces); n != 1 {
+		t.Fatalf("expected exactly 1 configured interface, got %d", n)
+	}
+	for name := range cfg.Interfaces.Interfaces {
+		return fmt.Sprintf("%s.%d", name, unit)
+	}
+	return ""
+}
+
+func TestCanonicalZoneRefBind5878(t *testing.T) {
+	cfg := canonRefBindCfg5878(t)
+	unitName := canonUnitName(t, cfg, 1)
+
+	// Direct binder-map assertion: the canonical unit key carries the zone.
+	if got := buildInterfaceZoneMap(cfg)[unitName]; got != "trust" {
+		t.Fatalf("buildInterfaceZoneMap[%q] = %q, want \"trust\" "+
+			"(`.01` zone member must bind canonical unit 1)", unitName, got)
+	}
+
+	// End-to-end: the per-unit InterfaceSnapshot inherits the zone.
+	var found bool
+	for _, snap := range buildInterfaceSnapshots(cfg) {
+		if snap.Name == unitName {
+			found = true
+			if snap.Zone != "trust" {
+				t.Fatalf("unit snapshot %q Zone = %q, want \"trust\"", unitName, snap.Zone)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no InterfaceSnapshot named %q", unitName)
+	}
+}
+
+func TestCanonicalRoutingInstanceRefBind5878(t *testing.T) {
+	cfg := canonRefBindCfg5878(t)
+	unitName := canonUnitName(t, cfg, 1)
+
+	if got := buildInterfaceRoutingInstances(cfg)[unitName]; got != "ri1" {
+		t.Fatalf("buildInterfaceRoutingInstances[%q] = %q, want \"ri1\" "+
+			"(`.01` RI member must bind canonical unit 1)", unitName, got)
+	}
+	v4, v6 := buildInterfaceRouteTables(cfg)
+	if got := v4[unitName]; got != "ri1.inet.0" {
+		t.Fatalf("buildInterfaceRouteTables v4[%q] = %q, want \"ri1.inet.0\"", unitName, got)
+	}
+	if got := v6[unitName]; got != "ri1.inet6.0" {
+		t.Fatalf("buildInterfaceRouteTables v6[%q] = %q, want \"ri1.inet6.0\"", unitName, got)
+	}
+
+	// End-to-end: the per-unit snapshot inherits the routing instance.
+	for _, snap := range buildInterfaceSnapshots(cfg) {
+		if snap.Name == unitName && snap.RoutingInstance != "ri1" {
+			t.Fatalf("unit snapshot %q RoutingInstance = %q, want \"ri1\"", unitName, snap.RoutingInstance)
+		}
+	}
+}
+
+func TestCanonicalHostInboundRefBind5878(t *testing.T) {
+	cfg := canonRefBindCfg5878(t)
+	unitName := canonUnitName(t, cfg, 1)
+
+	ovr := buildInterfaceHostInboundMap(cfg)[unitName]
+	if ovr == nil {
+		t.Fatalf("buildInterfaceHostInboundMap[%q] = nil, want the `.01` unit override "+
+			"(must bind canonical unit 1)", unitName)
+	}
+	var hasSSH bool
+	for _, s := range ovr.SystemServices {
+		if s == "ssh" {
+			hasSSH = true
+		}
+	}
+	if !hasSSH {
+		t.Fatalf("host-inbound override for %q = %v, want it to admit ssh", unitName, ovr.SystemServices)
+	}
+
+	// The operator-facing ingress-interface validator resolves the `.01` spelling
+	// to the canonical unit's zone (no false "unknown ingress-interface").
+	if err := ResolveHostInboundIngressInterface(cfg, "trust", "ge-0/0/0.01"); err != nil {
+		t.Fatalf("ResolveHostInboundIngressInterface(.01) = %v, want nil", err)
+	}
+}

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -55,10 +55,17 @@ func buildInterfaceZoneMap(cfg *config.Config) map[string]string {
 		if zone == nil {
 			continue
 		}
-		for _, iface := range zone.Interfaces {
-			if iface == "" {
+		for _, rawIface := range zone.Interfaces {
+			if rawIface == "" {
 				continue
 			}
+			// #5878 phase 2: bind the zone reference on its CANONICAL logical-unit
+			// identity so ge-0/0/0.01 and ge-0/0/0.1 resolve to the same runtime
+			// unit as the interface's `unit 1` definition. The per-unit snapshot
+			// consumer (buildInterfaceSnapshots) keys this map by the canonical
+			// "%s.%d" unit name, so a raw ".01" key would miss and the unit would
+			// bind to NO zone. A bare ref or a malformed suffix is unchanged.
+			iface := config.CanonicalInterfaceUnitRef(rawIface)
 			if _, exists := out[iface]; !exists {
 				out[iface] = zoneName
 			}

--- a/pkg/dataplane/userspace/zones_override.go
+++ b/pkg/dataplane/userspace/zones_override.go
@@ -135,6 +135,11 @@ func buildInterfaceHostInboundMap(cfg *config.Config) map[string]*config.HostInb
 				continue
 			}
 			if strings.Contains(ref, ".") {
+				// #5878 phase 2: resolve the unit ref on its canonical identity so
+				// a reth0.050 override lands on the same key (reth0.50) the per-unit
+				// snapshot consumer looks up, and the #5489 owner guard compares the
+				// canonical unit against the (now canonical) zone map.
+				canonRef := config.CanonicalInterfaceUnitRef(ref)
 				// #5489: a unit-level override must come ONLY from the unit's
 				// authoritative zone owner. buildInterfaceZoneMap resolves the
 				// owner as the first sorted zone that claims the unit; on a
@@ -145,7 +150,7 @@ func buildInterfaceHostInboundMap(cfg *config.Config) map[string]*config.HostInb
 				// InterfaceSnapshot / ZoneHostInboundView. Quarantine the leak with
 				// the SAME predicate the physical-expansion branch uses (#3720
 				// M01): skip when a DIFFERENT zone owns this unit.
-				if z := zoneByIface[ref]; z != "" && z != zn {
+				if z := zoneByIface[canonRef]; z != "" && z != zn {
 					continue
 				}
 				// Logical unit ref: the most specific override. Merge (union) it
@@ -153,7 +158,7 @@ func buildInterfaceHostInboundMap(cfg *config.Config) map[string]*config.HostInb
 				// refs are walked sorted and a bare physical ref sorts before its
 				// units, a same-zone physical expansion below has already run, so
 				// this yields physical ∪ unit.
-				out[ref] = mergeHostInboundTraffic(out[ref], hib)
+				out[canonRef] = mergeHostInboundTraffic(out[canonRef], hib)
 				continue
 			}
 			// Bare physical ref: first-writer-wins across zones for the bare key


### PR DESCRIPTION
## Summary

Phase 2 of #5878. Phase 1 (#5971) added the both-node collision gate and the `CanonicalLogicalUnit` normalizer, rejecting a duplicate-spelling interface-unit alias at commit. The **residual** #5878 defect: the cross-subsystem REFERENCE binders still keyed on the RAW `.<unit>` suffix **string**, so `ge-0/0/0.01` and `ge-0/0/0.1` resolved to **different** runtime units. Even without a duplicate-spelling collision, a peer-only `${node}` rewrite emitting `.01` on the standby (vs `.1` on the active) could bind a zone / routing / host-inbound member to a **different** unit on standby — silently changing forwarding/security posture on failover.

This threads the canonical identity through the reference binders so `.01` and `.1` resolve to the SAME runtime unit as the interface's `unit 1` definition — in zone membership, routing-instance membership, host-inbound override, the dataplane snapshot, AND the daemon netlink VRF/tunnel-membership resolver.

## Change

One helper — `CanonicalInterfaceUnitRef(ref)` (`schema_validators.go`) — folds the `.<unit>` suffix through `CanonicalLogicalUnit` (`.01`→`.1`, `.+1`→`.1`, `.00`→`.0`) and returns a bare / trailing-dot / malformed-suffix ref unchanged (malformed suffix still hard-rejected at commit by the #5933 gate). The per-unit interface snapshot keys every binder map by the canonical `"%s.%d"` unit name, so each binder now keys on the canonical unit:

| Subsystem | Site(s) |
|-----------|---------|
| Security-zone membership | `buildInterfaceZoneMap` (`zones.go`) + mirrors: `zoneIfaceLogicalKeys` (#3072 detector) and `junosHostZoneByInterface` (kernel host-deny) |
| Routing-instance membership | `buildInterfaceRoutingInstances`, `buildInterfaceRouteTables` (`routes.go`) |
| Host-inbound override | `buildInterfaceHostInboundMap` (`zones_override.go`) + operator-ref lookups in `host_inbound_classify.go` |
| Daemon netlink VRF/tunnel bind | `riMemberLinuxName` (`daemon_run.go`) — canonicalize BEFORE the `tunMap` lookup |

Canonicalizing the #3072 conflict **detector** alongside the binder is load-bearing: otherwise a `.01` member would bind canonical unit 1 first-writer-wins while the detector still saw `.01`/`.1` as distinct keys — reopening the multi-zone fail-open #3072 closed. A two-zone `.01`/`.1` duplicate is now correctly rejected at commit.

### Netlink resolver (folded in — closes the last residual)

`riMemberLinuxName` (shared by the step-0a VRF bind loop and the `collectAppliedTunnels` RIListMember scan) previously resolved a member via `LinuxIfName` (which only replaces `/`→`-`, no suffix canonicalization) and stripped only `.0`, so a lone `.01` RI member resolved to `ge-0-0-0.01` ≠ canonical `ge-0-0-0.1` — the same #5878 HA-divergence class at the netlink layer.

**Placement:** canonicalize `ifaceName` at the **top of the function, before the `tunMap` lookup.** `TunnelNameMap` keys are built from the canonical int unit number (`ifName + "." + strconv.Itoa(unitNum)`, `types.go`), so canonicalizing at the top makes BOTH the tunnel-device path (tunMap hit) and the `LinuxIfName`/unit-0-collapse path resolve a `.01` member to the same device as `.1`.

> **Correction (from independent review):** an earlier draft claimed this was safe to defer because "P1 prevents both spellings coexisting for one interface." That is **false** — the P1 alias gate (`validateInterfaceUnitAliasCollisionsAST`) gates `interfaces ... unit` **DEFINITIONS**, not routing-instance / zone membership **REFERENCES**. A peer-only `groups node1 { routing-instances ri interface ge-0/0/0.01 }` reference is a divergence the definition gate never sees, so the reference is canonicalized directly at the binder. There is now **no remaining reference-binding residual.**

**Already canonical / not applicable:**
- **class-of-service** — nested `interfaces <if> unit <n>` form keys `iface.Units` by the canonical int (#5963); the `.unit`-suffix-in-key form never resolves to a runtime unit in the consumer, so no divergence is possible.
- **NAT** — binds by zone / routing-instance / address, not by an interface-unit reference.

## Tests (fail-on-revert — verified RED on reverting each binder)

- `pkg/dataplane/userspace/unit_canonical_refbind_5878_test.go` — config with `unit 1` + `.01` references binds the zone / routing-instance / host-inbound override to canonical unit 1; each binder revert drops the binding → matching subtest RED.
- `pkg/config/unit_canonical_refkey_5878_test.go` — `CanonicalInterfaceUnitRef` spelling matrix, `zoneIfaceLogicalKeys` canonical claim, and a two-zone `.01`/`.1` duplicate-membership reject.
- `pkg/daemon/ri_member_canonical_5878_test.go` — a `.01` RI member resolves to the same Linux device as `.1` via BOTH the tunnel-device (tunMap) and `LinuxIfName` paths; removing the canonicalize call goes RED (`.01`→`ge-0-0-0.01`). Existing `TestRIMemberLinuxNameResolvesPerUnitTunnels` unaffected (canonical spellings are a no-op).

## Validation

`go build ./...`, `go vet`, and `go test -race ./pkg/daemon/` (16s) `./pkg/config/` (132s) `./pkg/dataplane/userspace/` (29s) all green.

Closes #5878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgfNbsX5zjNkJhYdZhFUUv