### PR TITLE
config: no direct-host drop for any + source-address-excluded

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-16 — #5828 (config/host-inbound): `source-address any` + excluded must project no direct-host drop
+- **Timestamp**: 2026-07-16 (fix/5828-hostinbound-any-excluded)
+- **Action**: Fix #5828 — the direct-host `junos-host` deny projection
+  miscompiled a policy term combining `match source-address any` +
+  `match source-address-excluded` + `then deny`. In Junos exclusion semantics
+  `any` + excluded = "every source EXCEPT every source" = the empty set → the
+  term matches nothing and must project NO drop rule. The pre-fix
+  `junosHostBuildRule` (pkg/config/junos_host_deny.go) resolved `any` to an
+  empty concrete family slice and, in the `t.srcExcluded` arm, classified
+  `len(src)==0` uniformly as `SrcAny=true` → an UNCONDITIONAL all-source DROP
+  (the nft renderer emits `iifname "<zone>" counter name "<cn>" drop` with no
+  saddr predicate) — an over-deny that can lock out ALL direct host-bound
+  traffic on the ingress zone (availability/security failure). Fix: in the
+  excluded arm, when the family-scoped `srcAny` is set, return `ok=false` (no
+  rule). Keyed on the per-family flag so `any` suppresses BOTH families while
+  `any-ipv4`/`any-ipv6` suppress only their own. The genuinely-constrained
+  excluded case (`source-address 10.0.0.0/8` + excluded → drop all except 10/8,
+  and match ALL of the opposite family with no prefix) and the deny-all case
+  (`source-address any` + deny, no exclusion → unconditional drop) are
+  UNCHANGED. Fail-on-revert proven: restoring `len(src)==0 => SrcAny` makes
+  TestJunosHostAnyExcludedProjectsNoRule (pkg/config) and
+  TestJunosHostAnyExcludedEmitsNoDropLine (pkg/daemon, projection-to-nft) go
+  RED; the 3 regression guards stay GREEN on both.
+- **File(s)**: pkg/config/junos_host_deny.go (edit — srcAny guard in
+  junosHostBuildRule excluded arm),
+  pkg/config/junos_host_deny_any_excluded_5828_test.go (new — set-command
+  ParseSetCommand+SetPath projection fail-on-revert + 3 regression guards),
+  pkg/daemon/host_inbound_junos_host_4146_test.go (edit — added
+  TestJunosHostAnyExcludedEmitsNoDropLine projection-to-nft guard),
+  docs/host-inbound-service-matrix.md (edit — source-exclusion semantics note).
+
 ## 2026-07-16 — #5973 (config/CoS): validate forwarding-class queue-number at commit
 - **Timestamp**: 2026-07-16 (fix/5973-cos-queue-validate)
 - **Action**: The `class-of-service forwarding-classes queue <N> <fc>` parse

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -765,6 +765,25 @@ proto + optional dst/src port + optional ICMP type/code (application-sets
 OR-expanded to multiple rules); `match destination-address any`; **no**
 `scheduler-name`; ingress zone **not** `tcp-rst`.
 
+**Source-exclusion semantics (`source-address-excluded`).** The excluded arm
+projects *every source NOT in the resolved set*, per Junos `matchAddr`:
+- A **constrained** set (e.g. `source-address 10.0.0.0/8` + excluded) drops
+  every source EXCEPT the set on the family that carries a prefix (IPv4:
+  `saddr != 10.0.0.0/8`), and — because the set has no prefix of the *other*
+  family — drops **ALL** of that other family (IPv6 here): "everything except
+  10/8" is all IPv6. This match-all-of-opposite-family behavior is intentional.
+- The **wildcard** case `source-address any` (or the family-scoped `any-ipv4` /
+  `any-ipv6`) + excluded is the degenerate "every source EXCEPT every source" =
+  the **empty set**: it matches NOTHING and projects **no drop rule** for the
+  affected family (`junosHostBuildRule` returns `ok=false` when the family's
+  `srcAny` is set). `any` suppresses both families; `any-ipv4` / `any-ipv6`
+  suppress only their own. Emitting an unconditional all-source drop here (the
+  #5828 bug — the old `len(src)==0 => SrcAny` classification) would invert the
+  authored domain and could lock out **all** direct host-bound traffic on the
+  ingress zone. A plain `source-address any` + `then deny` with **no** exclusion
+  is unaffected — that is a legitimate drop-all deny and still emits the
+  unconditional drop.
+
 **Un-representable remainder (keeps the commit warning below):** feed-tainted
 source, multi-term / ALG application, an application scoped to an IPsec/ident
 exempt tuple, an **explicit** `match destination-address` (needs the live

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -494,9 +494,23 @@ func junosHostBuildRule(family string, t junosHostTerm, permit []string, permitA
 	}
 	rule := JunosHostDenyRule{Family: family, L4: l4}
 	if t.srcExcluded {
-		// `source-address-excluded`: match every source NOT in the set. A family
-		// with no prefix in the excluded set therefore matches ALL of that family
-		// (mirrors matchAddr's "constrained, no F-prefix, except -> match ALL").
+		if srcAny {
+			// `any` (a family wildcard) + `source-address-excluded` is "every
+			// source EXCEPT every source" = the empty set: the term matches
+			// NOTHING for this family and MUST project no rule (#5828). This is
+			// keyed on the family-scoped srcAny, so `any` suppresses BOTH families
+			// while `any-ipv4`/`any-ipv6` suppress only their own. Falling through
+			// to the len(src)==0 => SrcAny arm below would invert this degenerate
+			// case into an unconditional all-source DROP — an over-deny that can
+			// lock out every direct host-bound flow on the ingress zone.
+			return JunosHostDenyRule{}, false
+		}
+		// A genuinely constrained excluded set: match every source NOT in the
+		// set. A family with no prefix in the excluded set therefore matches ALL
+		// of that family (mirrors matchAddr's "constrained, no F-prefix, except
+		// -> match ALL"). This is the intended match-all-of-opposite-family
+		// semantic — e.g. `source-address 10.0.0.0/8 + excluded` drops every IPv6
+		// source (no v6 prefix in the set) and every non-10/8 IPv4 source.
 		rule.SrcExcluded = len(src) > 0
 		rule.SrcAny = len(src) == 0
 		rule.Src = append([]string(nil), src...)

--- a/pkg/config/junos_host_deny_any_excluded_5828_test.go
+++ b/pkg/config/junos_host_deny_any_excluded_5828_test.go
@@ -1,0 +1,151 @@
+package config
+
+import "testing"
+
+// jh5828Projection compiles a flat-set config (ParseSetCommand + SetPath, never
+// NewParser — the parser merges newline-separated set lines) and returns the
+// single ingress-zone junos-host deny program. Every case authors an `untrust`
+// zone with one non-lifeline netdev (ge-0/0/1.0) so the program is enforceable.
+func jh5828Projection(t *testing.T, policyCmds ...string) JunosHostDenyProgram {
+	t.Helper()
+	base := []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.10/24",
+		"set security zones security-zone untrust interfaces ge-0/0/1.0",
+		"set security zones security-zone untrust host-inbound-traffic system-services ssh",
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range append(base, policyCmds...) {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	proj := BuildJunosHostDenyProjection(cfg)
+	if len(proj.Programs) != 1 {
+		t.Fatalf("want exactly 1 junos-host program, got %d: %+v", len(proj.Programs), proj.Programs)
+	}
+	return proj.Programs[0]
+}
+
+// isUnconditionalDrop reports whether a projected deny rule matches EVERY source
+// on its ingress iifname — the exact shape junosHostSrcPredicate renders with an
+// empty source predicate (`SrcAny`, or an excluded set with no family prefix).
+// The #5828 bug turned an `any` + source-address-excluded term into one of these.
+func isUnconditionalDrop(r JunosHostDenyRule) bool {
+	return r.SrcAny || (r.SrcExcluded && len(r.Src) == 0)
+}
+
+// TestJunosHostAnyExcludedProjectsNoRule is the #5828 fail-on-revert guard.
+//
+// `match source-address any` + `match source-address-excluded` + `then deny`
+// is, in Junos exclusion semantics, "every source EXCEPT every source" = the
+// empty set: the term matches NOTHING and must project NO drop rule for either
+// family. The pre-fix projection classified `any`'s empty concrete slice as
+// `SrcAny` in the excluded arm and emitted an UNCONDITIONAL all-source DROP —
+// an over-deny that can lock out all direct host-bound traffic on the ingress
+// zone (an availability/security failure).
+//
+// RED on revert: restoring the `len(src)==0 => SrcAny` behavior in
+// junosHostBuildRule makes both families emit an unconditional drop, so
+// len(RulesV4)/len(RulesV6) become 1 and isUnconditionalDrop is true — every
+// assertion below fails.
+func TestJunosHostAnyExcludedProjectsNoRule(t *testing.T) {
+	p := jh5828Projection(t,
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address-excluded",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	// The program stays representable — the term is inert, not un-representable.
+	if !p.Representable {
+		t.Fatalf("program must stay representable (the term is inert, not un-representable): %+v", p)
+	}
+	if len(p.RulesV4) != 0 {
+		t.Errorf("IPv4: any + source-address-excluded must emit NO deny rule, got %+v", p.RulesV4)
+	}
+	if len(p.RulesV6) != 0 {
+		t.Errorf("IPv6: any + source-address-excluded must emit NO deny rule, got %+v", p.RulesV6)
+	}
+	// Belt and suspenders: assert no unconditional all-source drop slipped in
+	// under any classification (the exact #5828 over-deny shape).
+	for _, r := range append(append([]JunosHostDenyRule{}, p.RulesV4...), p.RulesV6...) {
+		if isUnconditionalDrop(r) {
+			t.Errorf("emitted an unconditional all-source drop for any+excluded (the #5828 over-deny): %+v", r)
+		}
+	}
+}
+
+// TestJunosHostAnyDenyStillDropsAll is the deny-all regression guard: a plain
+// `source-address any` + `then deny` with NO exclusion is a legitimate
+// drop-every-source deny and MUST still emit the unconditional drop for both
+// families. Only the degenerate any+excluded case changed.
+func TestJunosHostAnyDenyStillDropsAll(t *testing.T) {
+	p := jh5828Projection(t,
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	if len(p.RulesV4) != 1 || !p.RulesV4[0].SrcAny {
+		t.Errorf("IPv4: `any` deny (no excluded) must emit one all-source drop (SrcAny), got %+v", p.RulesV4)
+	}
+	if len(p.RulesV6) != 1 || !p.RulesV6[0].SrcAny {
+		t.Errorf("IPv6: `any` deny (no excluded) must emit one all-source drop (SrcAny), got %+v", p.RulesV6)
+	}
+}
+
+// TestJunosHostConcreteExcludedUnchanged is the non-`any` exclusion regression
+// guard: `source-address 10.0.0.0/8` + excluded + deny drops every source
+// EXCEPT 10/8 on IPv4 (SrcExcluded, Src=[10.0.0.0/8]) and — because the excluded
+// set has no IPv6 prefix — drops ALL IPv6 (the documented match-all-of-opposite-
+// family semantic). The #5828 fix keys strictly on the `any` wildcard, so this
+// genuinely-constrained exclusion is UNCHANGED.
+func TestJunosHostConcreteExcludedUnchanged(t *testing.T) {
+	p := jh5828Projection(t,
+		"set security address-book global address bad-net 10.0.0.0/8",
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address bad-net",
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address-excluded",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	if len(p.RulesV4) != 1 {
+		t.Fatalf("IPv4: want one except-10/8 drop, got %+v", p.RulesV4)
+	}
+	r4 := p.RulesV4[0]
+	if !r4.SrcExcluded || len(r4.Src) != 1 || r4.Src[0] != "10.0.0.0/8" || r4.SrcAny {
+		t.Errorf("IPv4 rule = %+v, want SrcExcluded with Src=[10.0.0.0/8] (drop all except 10/8)", r4)
+	}
+	// IPv6: no v6 prefix in the excluded set -> match ALL v6 (unchanged
+	// match-all-of-opposite-family semantic).
+	if len(p.RulesV6) != 1 || !p.RulesV6[0].SrcAny {
+		t.Errorf("IPv6: excluded set with no v6 prefix must match ALL v6 (SrcAny), got %+v", p.RulesV6)
+	}
+}
+
+// TestJunosHostConcreteDenyUnchanged guards a normal per-source deny (no
+// exclusion): `source-address 10.0.0.5/32` + deny drops exactly that source on
+// IPv4 and nothing on IPv6 (no v6 prefix, positive set -> match nothing).
+func TestJunosHostConcreteDenyUnchanged(t *testing.T) {
+	p := jh5828Projection(t,
+		"set security address-book global address bad-host 10.0.0.5/32",
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address bad-host",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	if len(p.RulesV4) != 1 || p.RulesV4[0].SrcAny || len(p.RulesV4[0].Src) != 1 || p.RulesV4[0].Src[0] != "10.0.0.5/32" {
+		t.Errorf("IPv4: want a single-source drop for 10.0.0.5/32, got %+v", p.RulesV4)
+	}
+	if len(p.RulesV6) != 0 {
+		t.Errorf("IPv6: a v4-only positive source must emit no v6 rule, got %+v", p.RulesV6)
+	}
+}

--- a/pkg/daemon/host_inbound_junos_host_4146_test.go
+++ b/pkg/daemon/host_inbound_junos_host_4146_test.go
@@ -239,6 +239,47 @@ func TestJunosHostDenyAppScopedToExemptTupleUnrepresentable(t *testing.T) {
 	}
 }
 
+// TestJunosHostAnyExcludedEmitsNoDropLine is the #5828 projection-to-nft
+// fail-on-revert guard: `match source-address any` + `source-address-excluded`
+// + `then deny` is an EMPTY source match ("every source except every source"),
+// so it must render NO junos-host drop line for either family. The pre-fix
+// projection mis-classified `any`'s empty concrete set as `SrcAny` and emitted
+// an UNCONDITIONAL, source-predicate-less drop
+// (`iifname "ge-0-0-1" counter name "<cn>" drop`) — an over-deny that locks out
+// all direct host-bound traffic on the ingress zone.
+//
+// RED on revert: restoring the `len(src)==0 => SrcAny` behavior emits the
+// unconditional drop for both families, so the `counter name "<cn>" drop`
+// substring reappears and these assertions fail.
+func TestJunosHostAnyExcludedEmitsNoDropLine(t *testing.T) {
+	cfg := junosHostDenyTestConfig()
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host",
+			Policies: zonePairDeny("untrust", "block-all", "srcx:any", "app:any")},
+	}
+	payload, programs := junosHostPayload(t, cfg)
+	// The term is inert: it projects zero rules, so BuildJunosHostPrograms
+	// filters the (representable) program out entirely — no kernel program, no
+	// drop line. On revert the any+excluded term emits an unconditional
+	// all-source drop for both families, so a program with rules reappears.
+	if len(programs) != 0 {
+		t.Fatalf("any+excluded must yield no junos-host program (inert term), got %d: %+v", len(programs), programs)
+	}
+	for _, fam := range []string{"ip", "ip6"} {
+		cn := xnft.HostInboundJunosHostDenyCounterName("untrust", fam)
+		if strings.Contains(payload, `counter name "`+cn+`" drop`) {
+			t.Errorf("junos-host %s drop line emitted for any+excluded (the #5828 over-deny); counter %q:\n%s", fam, cn, payload)
+		}
+	}
+	// No junos-host drop line at all in the section window (xpfjh_ tags every
+	// junos-host named counter).
+	for _, l := range junosHostSection(payload) {
+		if strings.Contains(l, "drop") && strings.Contains(l, "xpfjh_") {
+			t.Errorf("unexpected junos-host drop line for an inert any+excluded term: %q", l)
+		}
+	}
+}
+
 // TestJunosHostDenyNftParses feeds a representable junos-host DENY payload
 // through `nft -c -f -` so the rendered iifname / saddr / counter lines are
 // validated against the real nft parser (v1.1.6). nft absent => skip; a


### PR DESCRIPTION
## Problem

The direct-host `junos-host` deny projection miscompiled a policy term
combining `match source-address any` + `match source-address-excluded` +
`then deny`. In Junos exclusion semantics this is an empty source match —
"all sources except all sources" matches nothing — so the term is inert and
must project no drop rule.

`junosHostBuildRule` (`pkg/config/junos_host_deny.go`) resolves `any` to an
empty concrete per-family source slice plus a family-scoped `srcAny` flag.
The `t.srcExcluded` arm classified `len(src)==0` uniformly as `SrcAny=true`,
so the wildcard case fell through to an **unconditional all-source DROP** —
the nft renderer emits `iifname "<zone>" counter name "<cn>" drop` with no
saddr predicate. That inverts the authored source domain and can deny **all**
direct host-bound traffic on the ingress zone (an availability/security
failure).

## Fix

In the excluded arm, when the family-scoped `srcAny` is set, return
`ok=false` so no rule is projected for that family. Keying on the per-family
flag keeps `any` suppressing **both** families while `any-ipv4`/`any-ipv6`
suppress only their own.

Unchanged behavior (regression-guarded):
- `source-address 10.0.0.0/8` + excluded + deny → drop every source EXCEPT
  10/8 on IPv4, and match **ALL** IPv6 (no v6 prefix in the set — the
  documented match-all-of-opposite-family semantic).
- `source-address any` + `then deny` with **no** exclusion → legitimate
  drop-all deny, still emits the unconditional drop.

## Tests (fail-on-revert)

- `TestJunosHostAnyExcludedProjectsNoRule` (pkg/config, `ParseSetCommand` +
  `SetPath` end-to-end projection): any+excluded emits no rule for either
  family.
- `TestJunosHostAnyExcludedEmitsNoDropLine` (pkg/daemon, projection-to-nft):
  no junos-host drop line is rendered.

Both go **RED** when the `len(src)==0 => SrcAny` behavior is restored. Three
regression guards (deny-all, concrete-excluded, concrete-deny) stay green on
both old and new code.

Doc: source-exclusion semantics note added to
`docs/host-inbound-service-matrix.md`.

## Validation

`go build ./...`; `go vet ./pkg/config/ ./pkg/daemon/`; `go test -race
./pkg/config/` (136s, ok); pkg/daemon junos-host + host-inbound tests ok.
Config-compile projection only (control plane) — no dataplane/failover path
touched.

Closes #5828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2ctrFG8P9mqu4mCCFvnEW