### PR TITLE
routing: carry qualified-next-hop preference into the AF_XDP snapshot (#5678)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-16 — #5678 (routing M12): carry qualified-next-hop preference across the AF_XDP snapshot boundary
+- **Timestamp**: 2026-07-16 (fix/5678-qnh-snapshot-pref)
+- **Action**: Fix #5678 (codex-review-182 M12, High). STEP-0 confirmed live on
+  origin/master e00ddcceb (NOT stale-fixed): `buildRouteSnapshots`
+  (`pkg/dataplane/userspace/routes.go`) collapsed EVERY next-hop of a static
+  route onto ONE `RouteSnapshot` at the single route-level `Preference`,
+  dropping the PER-next-hop admin distance a `qualified-next-hop <gw>
+  { preference N; }` backup carries (`NextHopEntry.HasPreference`/`Preference`,
+  #3871 — the Junos floating-static idiom). So a primary + a less-preferred
+  backup were installed at EQUAL cost and the Rust FIB load-balanced (ECMP)
+  across both instead of using the backup only as a standby — a silent
+  routing-semantics change. BOUNDED (not a snapshot-schema decision): the
+  snapshot already has a PER-ROUTE `Preference` field AND the Rust FIB
+  tie-breaks same-prefix routes by ascending preference (#2390 `sort_routes` +
+  first-match `routes.iter().find(prefix.contains)`), and a floating static is
+  naturally two same-prefix routes at different distances (exactly how the FRR
+  renderer emits it, `pkg/frr/config_render.go` — one `ip route` line per
+  next-hop at `dist = nh.Preference` when HasPreference else route-level). Fix:
+  group a route's next-hops by their EFFECTIVE preference (qualified
+  `nh.Preference` when HasPreference, else `route.Preference`) and emit ONE
+  RouteSnapshot per distinct preference. The backup then arrives as a SEPARATE,
+  higher-preference route; the Rust #2390 tie-break selects the primary and
+  holds the backup as a standby entry (never reached by first-match while the
+  primary is present). NO Rust change — the existing per-route preference wire
+  field + sort already handle same-prefix multi-preference routes. Next-hops
+  that SHARE a preference (plain `next-hop [ a b ]`, or qualified NHs at the
+  same distance) still collapse to one equal-cost ECMP snapshot — real ECMP
+  unaffected. Discard/reject/next-table routes (no forwarding next-hops) emit
+  the base disposition unchanged. Fail-on-revert PROVEN: reverting the
+  per-next-hop preference carry folds primary+backup into one ECMP snapshot
+  (`NextHops:[10.0.0.1 10.0.0.2] Preference:5`) → the two floating-static tests
+  RED; the plain-ECMP no-regression test stays GREEN; restore → all GREEN.
+  Validation: go build ./... clean; go vet clean; `go test -race` green for
+  pkg/dataplane/userspace (28.1s), pkg/config (149.8s), pkg/routing (1.9s),
+  pkg/frr (1.2s). Go lowering + docs only.
+- **File(s)**: pkg/dataplane/userspace/routes.go (edit — `addRoutes` groups
+  next-hops by effective preference, one RouteSnapshot per group),
+  pkg/dataplane/userspace/routes_qnh_preference_5678_test.go (new — RED-on-revert
+  floating-static distinct-standby + same-preference-group ECMP + plain-list
+  ECMP no-regression), userspace-dp/src/afxdp/forwarding/README.md (edit —
+  #5678 bullet under the #2390 preference tie-break contract)
+
 ## 2026-07-16 — #5685 (dist/publish): validate the apt base URL BEFORE it is baked into the signed, root-run install.sh
 - **Timestamp**: 2026-07-16 (fix/5685-release-url-validate)
 - **Action**: Fix #5685 (security supply-chain, M40). `scripts/dist/publish.py

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -61,7 +61,7 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 				continue
 			}
 			tableName, familyName := normalizeRouteSnapshotFamily(table, family, route.Destination)
-			snap := RouteSnapshot{
+			base := RouteSnapshot{
 				Table:       tableName,
 				Family:      familyName,
 				Destination: route.Destination,
@@ -78,17 +78,69 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 				NextTable:  route.NextTable,
 				Preference: route.Preference,
 			}
+			// #5678: group next-hops by their EFFECTIVE preference. A
+			// qualified-next-hop carries its own admin distance (#3871
+			// HasPreference — the Junos floating-static idiom: a primary
+			// next-hop plus a less-preferred backup); a plain next-hop uses the
+			// route-level preference. Emit ONE snapshot per distinct preference
+			// so a backup lowers as a SEPARATE, higher-preference standby route,
+			// NOT co-installed with the primary as an equal-cost ECMP member.
+			// The Rust FIB tie-breaks same-prefix routes by ascending
+			// preference (#2390 sort_routes) and selects the lowest via
+			// first-match lookup, holding the higher-preference backup as a
+			// standby entry — so folding the backup into the primary's next-hop
+			// list load-balanced traffic across both instead of preferring the
+			// primary (the #5678 silent routing-semantics change). Next-hops
+			// that share a preference (a plain `next-hop [ a b ]` list, or
+			// qualified next-hops at the SAME distance) stay a single
+			// equal-cost ECMP snapshot — no regression for real ECMP. Mirrors
+			// the FRR renderer (pkg/frr/config_render.go), which emits one `ip
+			// route` line per next-hop at dist = nh.Preference when
+			// HasPreference else the route-level distance.
+			type prefGroup struct {
+				preference int
+				nextHops   []string
+			}
+			order := make([]int, 0, len(route.NextHops))
+			groups := make(map[int]*prefGroup)
 			for _, nh := range route.NextHops {
+				var target string
 				switch {
 				case nh.Address != "" && nh.Interface != "":
-					snap.NextHops = append(snap.NextHops, nh.Address+"@"+nh.Interface)
+					target = nh.Address + "@" + nh.Interface
 				case nh.Address != "":
-					snap.NextHops = append(snap.NextHops, nh.Address)
+					target = nh.Address
 				case nh.Interface != "":
-					snap.NextHops = append(snap.NextHops, "@"+nh.Interface)
+					target = "@" + nh.Interface
+				default:
+					continue
 				}
+				pref := route.Preference
+				if nh.HasPreference {
+					pref = nh.Preference
+				}
+				g, ok := groups[pref]
+				if !ok {
+					g = &prefGroup{preference: pref}
+					groups[pref] = g
+					order = append(order, pref)
+				}
+				g.nextHops = append(g.nextHops, target)
 			}
-			addSnapshot(snap)
+			if len(order) == 0 {
+				// No forwarding next-hops (discard / reject / next-table, or
+				// every next-hop had an empty target): emit the base
+				// disposition unchanged so the negative-route / leak entry is
+				// preserved.
+				addSnapshot(base)
+				continue
+			}
+			for _, pref := range order {
+				snap := base
+				snap.Preference = groups[pref].preference
+				snap.NextHops = groups[pref].nextHops
+				addSnapshot(snap)
+			}
 		}
 	}
 	interfaceTablesV4, interfaceTablesV6 := buildInterfaceRouteTables(cfg)

--- a/pkg/dataplane/userspace/routes_qnh_preference_5678_test.go
+++ b/pkg/dataplane/userspace/routes_qnh_preference_5678_test.go
@@ -1,0 +1,188 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #5678: a static route's qualified-next-hop PREFERENCE (the Junos
+// floating-static idiom — a primary next-hop plus a less-preferred backup)
+// was dropped when the route was lowered into the AF_XDP snapshot. The
+// lowering collapsed every next-hop onto ONE RouteSnapshot at the single
+// route-level preference, so the backup was installed at EQUAL cost to the
+// primary and the Rust FIB load-balanced (ECMP) across BOTH instead of using
+// the backup only as a standby.
+//
+// The fix groups next-hops by their EFFECTIVE preference (per-next-hop when
+// HasPreference, else route-level) and emits one RouteSnapshot per distinct
+// preference. The Rust FIB tie-breaks same-prefix routes by preference (#2390)
+// and first-match-selects the lowest, holding the higher-preference backup as
+// a standby entry.
+//
+// FAIL-ON-REVERT: revert the preference-carry (collapse both next-hops onto one
+// route-level-preference snapshot) and the primary + backup become a single
+// equal-cost ECMP snapshot — this test then fails (two distinct-preference
+// snapshots are no longer produced).
+func TestQualifiedNextHopPreferenceLowersAsDistinctStandby_5678(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(int) ([]netlink.Rule, error) { return nil, nil }
+
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{
+			Destination: "10.5.0.0/16",
+			Preference:  5, // route-level distance for the primary next-hop
+			NextHops: []config.NextHopEntry{
+				// Primary: plain next-hop → route-level preference (5).
+				{Address: "10.0.0.1"},
+				// Backup: qualified-next-hop preference 250 (a floating
+				// standby, per #3871).
+				{Address: "10.0.0.2", Preference: 250, HasPreference: true},
+			},
+		},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+
+	// Collect the snapshots for this prefix.
+	var primary, backup *RouteSnapshot
+	other := 0
+	for i := range routes {
+		r := &routes[i]
+		if r.Destination != "10.5.0.0/16" {
+			other++
+			continue
+		}
+		switch {
+		case len(r.NextHops) == 1 && r.NextHops[0] == "10.0.0.1":
+			primary = r
+		case len(r.NextHops) == 1 && r.NextHops[0] == "10.0.0.2":
+			backup = r
+		}
+	}
+	if other != 0 {
+		t.Fatalf("unexpected extra snapshots for other prefixes: %d (routes=%+v)", other, routes)
+	}
+
+	// The floating static must lower as TWO snapshots, one per next-hop, at
+	// DISTINCT preferences — NOT a single ECMP snapshot carrying both.
+	if primary == nil || backup == nil {
+		t.Fatalf("want a separate primary(10.0.0.1) and backup(10.0.0.2) snapshot; "+
+			"the backup was folded into an equal-cost ECMP member with the primary. routes=%+v", routes)
+	}
+	if primary.Preference != 5 {
+		t.Fatalf("primary preference = %d, want 5 (route-level)", primary.Preference)
+	}
+	if backup.Preference != 250 {
+		t.Fatalf("backup preference = %d, want 250 (qualified-next-hop distance)", backup.Preference)
+	}
+	// The backup must be STRICTLY less-preferred (higher admin distance) than
+	// the primary — a standby, not a co-equal ECMP member.
+	if backup.Preference <= primary.Preference {
+		t.Fatalf("backup preference %d must be strictly higher (less preferred) than primary %d",
+			backup.Preference, primary.Preference)
+	}
+	// Neither snapshot may carry the OTHER tier's next-hop: proves the two are
+	// not an equal-cost ECMP pair.
+	for _, r := range []*RouteSnapshot{primary, backup} {
+		if len(r.NextHops) != 1 {
+			t.Fatalf("snapshot %+v has %d next-hops, want exactly 1 (no ECMP across tiers)", r, len(r.NextHops))
+		}
+	}
+}
+
+// #5678 no-regression: a route with genuinely equal next-hops (a plain
+// `next-hop [ a b ]` list, no qualified preference) must still lower to a
+// SINGLE equal-cost ECMP snapshot carrying both next-hops.
+func TestPlainNextHopListStaysECMP_5678(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(int) ([]netlink.Rule, error) { return nil, nil }
+
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{
+			Destination: "10.6.0.0/16",
+			Preference:  5,
+			NextHops: []config.NextHopEntry{
+				{Address: "10.0.0.1"},
+				{Address: "10.0.0.2"},
+			},
+		},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+
+	var matches []RouteSnapshot
+	for _, r := range routes {
+		if r.Destination == "10.6.0.0/16" {
+			matches = append(matches, r)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("plain next-hop list lowered to %d snapshots, want 1 ECMP snapshot: %+v", len(matches), matches)
+	}
+	got := matches[0]
+	if len(got.NextHops) != 2 {
+		t.Fatalf("ECMP snapshot has %d next-hops, want 2: %+v", len(got.NextHops), got)
+	}
+	if got.NextHops[0] != "10.0.0.1" || got.NextHops[1] != "10.0.0.2" {
+		t.Fatalf("ECMP next-hops = %v, want [10.0.0.1 10.0.0.2]", got.NextHops)
+	}
+	if got.Preference != 5 {
+		t.Fatalf("ECMP preference = %d, want 5", got.Preference)
+	}
+}
+
+// #5678: two qualified next-hops at the SAME distance are still ECMP with each
+// other (they share a preference group), but a third at a distinct distance is
+// a separate standby. Guards the grouping (by preference, not per-next-hop).
+func TestQualifiedNextHopsSamePreferenceGroupECMP_5678(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(int) ([]netlink.Rule, error) { return nil, nil }
+
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{
+			Destination: "10.7.0.0/16",
+			Preference:  5,
+			NextHops: []config.NextHopEntry{
+				{Address: "10.0.0.1", Preference: 10, HasPreference: true},
+				{Address: "10.0.0.2", Preference: 10, HasPreference: true},
+				{Address: "10.0.0.3", Preference: 250, HasPreference: true},
+			},
+		},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+
+	byPref := map[int][]string{}
+	for _, r := range routes {
+		if r.Destination != "10.7.0.0/16" {
+			continue
+		}
+		byPref[r.Preference] = r.NextHops
+	}
+	if len(byPref) != 2 {
+		t.Fatalf("want 2 preference groups, got %d: %+v", len(byPref), byPref)
+	}
+	if nh := byPref[10]; len(nh) != 2 || nh[0] != "10.0.0.1" || nh[1] != "10.0.0.2" {
+		t.Fatalf("preference-10 group = %v, want ECMP [10.0.0.1 10.0.0.2]", nh)
+	}
+	if nh := byPref[250]; len(nh) != 1 || nh[0] != "10.0.0.3" {
+		t.Fatalf("preference-250 group = %v, want standby [10.0.0.3]", nh)
+	}
+}

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -139,6 +139,27 @@ Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
   preference). Two same-prefix routes in a table select by operator
   preference, not insertion order; same-prefix/same-preference routes
   keep insertion order (stable sort).
+- **Qualified-next-hop backups lower as distinct-preference standby
+  routes (#5678).** A Junos floating static (a primary `next-hop` plus a
+  `qualified-next-hop <gw> { preference N; }` backup, #3871) carries a
+  PER-next-hop admin distance. The Go snapshot builder
+  (`pkg/dataplane/userspace/routes.go`) groups a route's next-hops by
+  their EFFECTIVE preference (the qualified `nh.Preference` when
+  `HasPreference`, else the route-level `Preference`) and emits ONE
+  `RouteSnapshot` per distinct preference. So the backup arrives as a
+  SEPARATE, higher-preference route for the same prefix — the #2390
+  tie-break above then selects the primary and holds the backup as a
+  standby entry (first-match lookup never reaches it while the primary
+  route is present). Before #5678 the builder collapsed every next-hop
+  onto ONE route-level-preference snapshot, so the backup was installed
+  as an equal-cost ECMP member and traffic load-balanced across both
+  tiers — a silent routing-semantics change. Next-hops that SHARE a
+  preference (a plain `next-hop [ a b ]` list, or qualified next-hops at
+  the same distance) still collapse to one equal-cost ECMP snapshot, so
+  real ECMP is unaffected. This mirrors the FRR renderer
+  (`pkg/frr/config_render.go`), which emits one `ip route` line per
+  next-hop at `dist = nh.Preference` when `HasPreference` else the
+  route-level distance.
 
 All three wire fields (`routing_instance`, `next_hops`, `preference`)
 are additive: an old Rust helper ignores them (pre-fix behavior) and an


### PR DESCRIPTION
## Problem (#5678, routing-semantics M12, codex-review-182)

A static route's **qualified-next-hop preference** — the Junos floating-static idiom, a primary next-hop plus a less-preferred backup (`qualified-next-hop <gw> { preference N; }`, #3871) — was **lost when the route was lowered into the AF_XDP snapshot**.

`buildRouteSnapshots` (`pkg/dataplane/userspace/routes.go`) collapsed **every** next-hop of a route onto **one** `RouteSnapshot` at the single route-level `Preference`, dropping the per-next-hop admin distance carried on the qualified backup (`NextHopEntry.HasPreference`/`Preference`). The backup was therefore installed at **equal cost** to the primary, and the Rust FIB **load-balanced (ECMP) across both** instead of using the backup only as a standby. Traffic that should egress only the primary was silently split to the backup — a silent routing-semantics change.

The FRR/kernel path already renders this correctly (#3871, `pkg/frr/config_render.go` emits one `ip route` line per next-hop at `dist = nh.Preference` when `HasPreference` else the route-level distance); only the AF_XDP snapshot boundary dropped it.

## Fix — bounded, no schema change

Group a route's next-hops by their **effective preference** (the qualified `nh.Preference` when `HasPreference`, else the route-level `Preference`) and emit **one `RouteSnapshot` per distinct preference**.

The backup then arrives as a **separate, higher-preference route** for the same prefix. The Rust FIB's existing same-prefix tie-break (#2390 `sort_routes`: descending prefix length, then ascending preference, with first-match `routes.iter().find(prefix.contains)`) **selects the primary and holds the backup as a standby entry** that is never reached while the primary route is present.

This reuses the **existing per-route `Preference` wire field** — the snapshot schema already supports same-prefix multi-preference routes and the Rust FIB already honors them, so **no snapshot-schema or Rust change is required**. (This is why it is a bounded patch, not the larger link-state design proposal in the issue thread — that proposal concerns automatically *activating* the backup on primary next-hop failure, a separate, larger question.)

- Next-hops that **share** a preference (a plain `next-hop [ a b ]` list, or qualified next-hops at the same distance) still collapse to **one equal-cost ECMP snapshot** — real ECMP is unaffected.
- Discard, reject, and next-table routes carry no forwarding next-hop and emit the base disposition unchanged.

## Test — fail-on-revert

`pkg/dataplane/userspace/routes_qnh_preference_5678_test.go`:

- **Floating static** (primary + qualified backup at preference 250) → lowers to **two distinct-preference snapshots**, each with a single next-hop; the backup is strictly less preferred. Reverting the preference-carry folds both into one ECMP snapshot (`NextHops:[10.0.0.1 10.0.0.2] Preference:5`) → **RED**.
- **Same-preference qualified next-hops** stay ECMP with each other, distinct-distance tier is a separate standby → **RED** on revert.
- **Plain `next-hop [ a b ]` list** → still one equal-cost ECMP snapshot → **GREEN** across the revert (no regression).

Validation: `go build ./...` clean; `go vet` clean; `go test -race` green for `pkg/dataplane/userspace`, `pkg/config`, `pkg/routing`, `pkg/frr`.

Closes #5678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
