### PR TITLE
daemon: run HA sync invalidators on best-effort tail error

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,56 @@
+## 2026-07-16 — #5564 (daemon): HA config-sync tail failure permanently bypassed policy session invalidation (fail-open)
+- **Timestamp**: 2026-07-16 (fix/5564-syncapply-invalidators)
+- **Action**: Fix #5564 (security fail-open, HA receive side). STEP-0 confirmed
+  live on origin/master 8a769005f: `syncAndApply`
+  (pkg/daemon/daemon_apply.go) promotes the peer config to active
+  (`configstore.SyncApply`) and arms the dataplane snapshot
+  (`applyConfigLocked`), but returned early on ANY apply error
+  (`if err := d.applyConfigLocked(...); err != nil { return nil, err }`) BEFORE
+  `clearSessionsForPolicyChanges` (the three invalidators: #4234 deletion-clear,
+  modified-policy re-eval, #4342 default-policy change). A NON-FATAL best-effort
+  tail failure (host-inbound/lo0 nft, networkd, ...) therefore left surviving
+  established sessions forwarding under their OLD authorization on an armed
+  standby. Because `configstore.SyncApply` already promoted the incoming text to
+  active, the primary's equal-active-text re-push hit `handleConfigSync`'s
+  fast path (`activeText == incomingText`) and returned nil without re-entering
+  `syncAndApply`, making the omission PERMANENT (visible at failover). The commit
+  path `applyAndSyncCommitted` already handled this correctly (classify via
+  `applyErrSkipsPeerSync`, run invalidators for non-fatal tail errors); the
+  receive path had diverged. Fix: mirror the commit path. Capture the apply
+  error instead of early-returning; return early ONLY for the two FATAL classes
+  `applyErrSkipsPeerSync` matches (required-protocol-gate → dataplane DISARMED,
+  #2138; daemon-stop context abort, #2926 — config not live-forwarding, no
+  session state to invalidate). For every other (non-fatal tail) error the config
+  reached active+armed, so the invalidators run and the tail error is surfaced
+  (joined with any #5578 partial-invalidation error), not swallowed. Structured
+  the invalidation as a DEFERRED, guarded (`armedActive`) block on a named-return
+  function so a future early-return added between the apply and the invalidators
+  cannot re-introduce the skip; it never runs on the fatal path (armedActive stays
+  false, config discarded to nil). `deviceMapPassiveAdmissionAlarm` moved into the
+  same guarded block (also runs whenever the config went active). Control-flow
+  fix only — no wire/protocol/failover-machinery change.
+- **Fail-on-revert**: new pkg/daemon/configsync_invalidate_5564_test.go builds a
+  real store (baseline p-first id-0 + p-web id-1 committed active) and a fake DP
+  holding v4+v6 ESTABLISHED sessions under p-web; the peer text (candidate
+  ShowCandidate) DELETES p-web. `TestSyncAndApplyRunsInvalidatorsOnNonFatalApplyError`
+  injects a non-fatal tail error via applyErrForTest → asserts BOTH v4+v6 sessions
+  are cleared (invalidators ran), the table was scanned, and the tail error is
+  surfaced. PROVEN RED on revert (early `return nil, err`): both sessions SURVIVE
+  ("fail-open: stale authorization keeps forwarding"), iterateCalls==0, config
+  dropped to nil. `TestSyncAndApplySkipsInvalidatorsOnFatalApplyError` (fatal
+  ErrPolicySchedulerProtocolIncompatible) asserts sessions survive + no scan + nil
+  config + error surfaced (no spurious invalidation, no regression).
+  `TestSyncAndApplyRunsInvalidatorsOnCleanApply` guards against over-suppression.
+  `TestSyncAndApplySurfacesPartialInvalidationError` (#5578 on the receive path,
+  delErr) asserts the partial-clear error is joined through the defer into the
+  return. Validation: GOCACHE/GOTMPDIR go build ./... + go vet ./pkg/daemon clean;
+  go test -race ./pkg/daemon ./pkg/cluster both GREEN. Not touching
+  wire/failover machinery, so test-failover shim-wall-blocked = no regression.
+- **File(s)**: pkg/daemon/daemon_apply.go (syncAndApply: named returns +
+  deferred/guarded invalidation + applyErrSkipsPeerSync fatal-vs-tail classify),
+  pkg/daemon/configsync_invalidate_5564_test.go (new, 4 tests), docs/sync-protocol.md
+  ("Receive-side session invalidation (#5564)" subsection)
+
 ## 2026-07-16 — #5155 (afxdp/session_glue): O(N) HashSet dedup for DemoteOwnerRGS cancelled_keys (was O(N^2) on packet worker)
 - **Timestamp**: 2026-07-16 (fix/5155-demote-dedup-hashset)
 - **Action**: Fix #5155 (perf, failover-time packet-worker stall).

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -391,6 +391,32 @@ apply the accepted config, and returns an `error` so the ordered apply loop
 advances the high-water mark only on a successful apply (see Apply-then-advance
 above).
 
+**Receive-side session invalidation (#5564).** `syncAndApply`
+(`pkg/daemon/daemon_apply.go`) is the receive-side analogue of the commit path's
+`applyAndSyncCommitted`. `configstore.SyncApply` promotes the peer config to
+active BEFORE the reconcile, and `applyConfigLocked` then arms the dataplane
+snapshot — so once the apply reaches its tail the standby is forwarding under the
+new policy set. The three session invalidators (`clearSessionsForPolicyChanges`:
+the #4234 deletion-clear, the modified-policy re-eval, and the #4342
+default-policy change) MUST therefore run to re-authorize surviving established
+sessions against the now-active config. They run from a deferred, guarded block
+so they ALWAYS fire once the config reached active+armed — including on a
+NON-FATAL best-effort tail failure (host-inbound/lo0 nft, networkd, ...) that
+`applyConfigLocked` joins and returns. Skipping them on such an error (the
+pre-#5564 early `return nil, err`) was a security fail-open: a session a
+peer-tightened/deleted policy should now DENY kept forwarding under its stale
+authorization, and because the store already held the incoming text the primary's
+equal-active-text re-push took the fast path (`activeText == incomingText`, at the
+top of `handleConfigSync`) and never re-entered `syncAndApply` to correct it,
+making the omission permanent (visible at failover). The classifier
+`applyErrSkipsPeerSync` (shared with the commit path) still distinguishes the two
+FATAL classes — a required-protocol-gate error (dataplane DISARMED, #2138) and a
+daemon-stop context abort (#2926) — where the config is not live-forwarding and
+the invalidators are correctly skipped; on those `syncAndApply` returns a nil
+config plus the error. Any other tail error is surfaced (joined with any partial
+#5578 invalidation error) AFTER the invalidators run, so the high-water mark still
+does not advance and the primary's re-push re-converges the mark on the fast path.
+
 ## IPsec SA Payload (Variable)
 
 Newline-separated (`\n`) list of strongSwan connection names (e.g., `vpn-gw1\nvpn-gw2`). On failover, the new primary calls `swanctl --initiate` for each name.

--- a/pkg/daemon/configsync_invalidate_5564_test.go
+++ b/pkg/daemon/configsync_invalidate_5564_test.go
@@ -1,0 +1,252 @@
+// #5564: on the HA receive side, syncAndApply promotes the peer config to
+// active and arms the dataplane snapshot BEFORE it runs the three session
+// invalidators (clearSessionsForPolicyChanges: the #4234 deletion-clear, the
+// modified-policy re-eval, and the #4342 default-policy change). Before the fix
+// it returned early on ANY applyConfigLocked error — so a NON-FATAL best-effort
+// tail failure (host-inbound/lo0 nft, networkd, ...) left surviving established
+// sessions forwarding under their OLD authorization on an armed standby
+// (security fail-open). Because the store already holds the incoming text, the
+// next equal-active-text re-push takes handleConfigSync's fast path and never
+// re-enters syncAndApply, making the omission PERMANENT (visible at failover).
+//
+// These tests pin the fix: a non-fatal tail apply error on the RECEIVE path
+// STILL invalidates the sessions of a peer-deleted policy (and surfaces the tail
+// error), while a genuinely-FATAL apply (dataplane disarmed / daemon-stop abort
+// — the config is not live-forwarding) does NOT invalidate (no spurious clear)
+// yet still surfaces the error. RED-on-revert: restoring the early
+// `return nil, err` before the invalidators leaves the non-fatal test's sessions
+// installed under stale authorization (and drops the promoted config).
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// newSyncReadyStore commits a baseline with two trust->untrust permit policies
+// (p-first at the overloaded id 0, p-web at id 1) so a peer-pushed config that
+// DELETES p-web has a real, non-overloaded clear set {webID}. It returns the
+// store (active = baseline WITH p-web), the hierarchical peer text WITHOUT p-web
+// (what SyncApply promotes), and p-web's runtime id.
+func newSyncReadyStore(t *testing.T) (*configstore.Store, string, uint32) {
+	t.Helper()
+	s, err := configstore.New(filepath.Join(t.TempDir(), "config"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	lines := []string{
+		"security zones security-zone trust",
+		"security zones security-zone untrust",
+	}
+	for _, p := range []string{"p-first", "p-web"} {
+		lines = append(lines,
+			"security policies from-zone trust to-zone untrust policy "+p+" match source-address any",
+			"security policies from-zone trust to-zone untrust policy "+p+" match destination-address any",
+			"security policies from-zone trust to-zone untrust policy "+p+" match application any",
+			"security policies from-zone trust to-zone untrust policy "+p+" then permit",
+		)
+	}
+	for _, line := range lines {
+		if err := s.SetFromInput(line); err != nil {
+			t.Fatalf("set %q: %v", line, err)
+		}
+	}
+	compiled, err := s.Commit()
+	if err != nil {
+		t.Fatalf("commit baseline: %v", err)
+	}
+	webID := dpuserspace.PolicyIDsByStableKey(compiled)["trust->untrust/p-web"]
+	if webID == 0 {
+		t.Fatalf("precondition: p-web must have a non-overloaded runtime id; got %d", webID)
+	}
+	// Build the peer text WITHOUT p-web from the candidate; active still holds it
+	// (a delete only touches the candidate until the next commit).
+	if err := s.DeleteFromInput("security policies from-zone trust to-zone untrust policy p-web"); err != nil {
+		t.Fatalf("delete p-web from candidate: %v", err)
+	}
+	return s, s.ShowCandidate(), webID
+}
+
+// syncSessionDP builds a fake dataplane holding one v4 and one v6 ESTABLISHED
+// session admitted under the deleted policy (webID) — the surviving synced
+// sessions the receive-side invalidators must drop when p-web is peer-deleted.
+func syncSessionDP(webID uint32) (dp *policyInvalTestDP, v4 dataplane.SessionKey, v6 dataplane.SessionKeyV6) {
+	v4 = dataplane.SessionKey{
+		SrcIP: [4]byte{10, 0, 0, 1}, DstIP: [4]byte{10, 0, 0, 2},
+		SrcPort: 40001, DstPort: 80, Protocol: 6,
+	}
+	v6 = dataplane.SessionKeyV6{
+		SrcIP: [16]byte{0x20, 0x01, 15: 0x01}, DstIP: [16]byte{0x20, 0x01, 15: 0x02},
+		SrcPort: 40003, DstPort: 80, Protocol: 6,
+	}
+	dp = &policyInvalTestDP{
+		v4: map[dataplane.SessionKey]dataplane.SessionValue{
+			v4: {State: dataplane.SessStateEstablished, PolicyID: webID},
+		},
+		v6: map[dataplane.SessionKeyV6]dataplane.SessionValueV6{
+			v6: {State: dataplane.SessStateEstablished, PolicyID: webID},
+		},
+	}
+	return dp, v4, v6
+}
+
+// TestSyncAndApplyRunsInvalidatorsOnNonFatalApplyError is the #5564
+// RED-on-revert pin: a peer config sync whose applyConfigLocked returns a
+// NON-FATAL best-effort tail error STILL invalidates the sessions of the
+// peer-deleted policy AND surfaces the tail error. Restoring the pre-fix early
+// `return nil, err` leaves the sessions installed under stale authorization
+// (fail-open) and drops the promoted config → RED.
+func TestSyncAndApplyRunsInvalidatorsOnNonFatalApplyError(t *testing.T) {
+	s, peerText, webID := newSyncReadyStore(t)
+	dp, v4, v6 := syncSessionDP(webID)
+
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s, dp: dp}
+	d.applyBodyForTest = func(*config.Config) {}
+	// Exactly the shape applyConfigLocked's tail joins (networkd/nft/Kea): the
+	// config is active + the dataplane armed, only a best-effort subsystem failed.
+	nonFatal := errors.New("apply host-inbound filter: simulated best-effort failure")
+	d.applyErrForTest = nonFatal
+
+	compiled, err := d.syncAndApply(context.Background(), peerText, nil)
+
+	// The non-fatal tail error must be SURFACED (not swallowed) up the sync path.
+	if !errors.Is(err, nonFatal) {
+		t.Fatalf("syncAndApply must surface the non-fatal tail apply error; got %v", err)
+	}
+	// RED-on-revert (the core security signal): the sessions of the peer-DELETED
+	// policy MUST be invalidated even though the apply's tail returned a non-fatal
+	// error. The pre-fix early `return nil, err` skips the invalidators, leaving
+	// them installed under stale authorization (fail-open).
+	if _, ok := dp.v4[v4]; ok {
+		t.Errorf("v4 session under peer-DELETED policy (id %d) survived the receive-side "+
+			"invalidation on a non-fatal tail error (fail-open: stale authorization keeps forwarding)", webID)
+	}
+	if _, ok := dp.v6[v6]; ok {
+		t.Errorf("v6 session under peer-DELETED policy (id %d) survived the receive-side "+
+			"invalidation on a non-fatal tail error (fail-open)", webID)
+	}
+	// The invalidator's session scan must have actually run.
+	if dp.iterateCalls == 0 {
+		t.Errorf("the session table was never scanned on a non-fatal tail error; the three "+
+			"invalidators must run once the config reached active+armed")
+	}
+	// The peer config is still active locally (promoted before the tail hiccup),
+	// so the promoted config is returned alongside the error (mark-and-continue).
+	if compiled == nil {
+		t.Errorf("syncAndApply must return the promoted peer config on a non-fatal tail error; got nil")
+	}
+	// The peer config is promoted to active locally regardless of the tail hiccup.
+	if _, ok := dpuserspace.PolicyIDsByStableKey(s.ActiveConfig())["trust->untrust/p-web"]; ok {
+		t.Errorf("p-web is still in the active config after the sync; SyncApply must have promoted the peer delete")
+	}
+}
+
+// TestSyncAndApplySkipsInvalidatorsOnFatalApplyError proves a genuinely-FATAL
+// apply (a required-protocol-gate error that DISARMS the dataplane — the config
+// is not live-forwarding) does NOT run the invalidators: there is no armed
+// session state to invalidate, so a spurious clear must be avoided. The fatal
+// error is still surfaced and the config discarded (nil), matching the primary
+// applyAndSyncCommitted fatal branch.
+func TestSyncAndApplySkipsInvalidatorsOnFatalApplyError(t *testing.T) {
+	s, peerText, webID := newSyncReadyStore(t)
+	dp, v4, v6 := syncSessionDP(webID)
+
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s, dp: dp}
+	d.applyBodyForTest = func(*config.Config) {}
+	d.applyErrForTest = dpuserspace.ErrPolicySchedulerProtocolIncompatible
+
+	compiled, err := d.syncAndApply(context.Background(), peerText, nil)
+
+	if !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+		t.Fatalf("a fatal apply error must be surfaced; got %v", err)
+	}
+	if compiled != nil {
+		t.Fatalf("a fatal apply error must return a nil config; got %+v", compiled)
+	}
+	// No spurious invalidation: the dataplane is disarmed (fail-closed), so the
+	// sessions must NOT be swept and the session table must not even be scanned.
+	if _, ok := dp.v4[v4]; !ok {
+		t.Errorf("v4 session was invalidated on a FATAL (dataplane-disarmed) apply; the "+
+			"invalidators must NOT run when the config never went live-forwarding")
+	}
+	if _, ok := dp.v6[v6]; !ok {
+		t.Errorf("v6 session was invalidated on a FATAL (dataplane-disarmed) apply")
+	}
+	if dp.iterateCalls != 0 {
+		t.Errorf("the session table was scanned (%d iterate calls) on a fatal apply; the "+
+			"invalidators must be skipped entirely", dp.iterateCalls)
+	}
+}
+
+// TestSyncAndApplyRunsInvalidatorsOnCleanApply guards against over-suppression:
+// a clean apply (no tail error) on the receive path still invalidates the
+// peer-deleted policy's sessions and returns a nil error.
+func TestSyncAndApplyRunsInvalidatorsOnCleanApply(t *testing.T) {
+	s, peerText, webID := newSyncReadyStore(t)
+	dp, v4, v6 := syncSessionDP(webID)
+
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s, dp: dp}
+	d.applyBodyForTest = func(*config.Config) {}
+	// applyErrForTest nil = clean apply.
+
+	compiled, err := d.syncAndApply(context.Background(), peerText, nil)
+	if err != nil {
+		t.Fatalf("a clean peer sync must succeed; got %v", err)
+	}
+	if compiled == nil {
+		t.Fatalf("a clean peer sync must return the promoted config; got nil")
+	}
+	if _, ok := dp.v4[v4]; ok {
+		t.Errorf("v4 session under peer-DELETED policy (id %d) survived a clean sync invalidation", webID)
+	}
+	if _, ok := dp.v6[v6]; ok {
+		t.Errorf("v6 session under peer-DELETED policy (id %d) survived a clean sync invalidation", webID)
+	}
+}
+
+// TestSyncAndApplySurfacesPartialInvalidationError is the #5578 pin on the
+// RECEIVE path: a clean apply whose post-apply session invalidation FAILS (the
+// batch delete errors, leaving the matched sessions installed under stale
+// authorization) must surface that error up the sync path, joined into the
+// return through the deferred invalidation.
+func TestSyncAndApplySurfacesPartialInvalidationError(t *testing.T) {
+	s, peerText, webID := newSyncReadyStore(t)
+	dp, v4, v6 := syncSessionDP(webID)
+	errBoom := errors.New("batch delete failed")
+	dp.delErr = errBoom
+
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s, dp: dp}
+	d.applyBodyForTest = func(*config.Config) {}
+
+	compiled, err := d.syncAndApply(context.Background(), peerText, nil)
+	if err == nil {
+		t.Fatal("syncAndApply swallowed a failed policy session invalidation; the stale-" +
+			"authorization gap must be surfaced up the sync-recv path (#5578)")
+	}
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("sync error %v does not carry the invalidation failure", err)
+	}
+	// Mark-and-continue: the config is still promoted to active and returned.
+	if compiled == nil {
+		t.Fatalf("a partial-invalidation error must not drop the promoted config; got nil")
+	}
+	// The stale-authorization gap: the delete failed, so the sessions remain.
+	if _, ok := dp.v4[v4]; !ok {
+		t.Error("precondition: v4 session should still be present after a failed delete (models stale authorization)")
+	}
+	if _, ok := dp.v6[v6]; !ok {
+		t.Error("precondition: v6 session should still be present after a failed delete (models stale authorization)")
+	}
+}

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -472,7 +472,7 @@ func (d *Daemon) pushCommittedConfigToPeer() {
 // promotion) + applyConfigLocked, so a peer-sync can't interleave
 // between a local committer's Commit and applyConfig (which would
 // briefly leave store=peer-config but kernel=local-config).
-func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPreserve func(*config.ConfigTree)) (*config.Config, error) {
+func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPreserve func(*config.ConfigTree)) (compiled *config.Config, retErr error) {
 	if err := d.applySem.Acquire(ctx, 1); err != nil {
 		return nil, err
 	}
@@ -494,21 +494,48 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 	// primary's delete-sync).
 	oldActive := d.store.ActiveConfig()
 
-	compiled, err := d.store.SyncApply(configText, chassisPreserve)
-	if err != nil {
-		return nil, err
+	var syncErr error
+	compiled, syncErr = d.store.SyncApply(configText, chassisPreserve)
+	if syncErr != nil {
+		return nil, syncErr
 	}
-	var clearErr error
-	if compiled != nil {
-		if err := d.applyConfigLocked(d.applyCancelCtx(), compiled); err != nil {
-			return nil, err
+	if compiled == nil {
+		// No config to reconcile (e.g. a no-op sync): nothing was promoted, so
+		// there is no active-config session state to invalidate.
+		return compiled, nil
+	}
+
+	// #5564: SyncApply (above) has ALREADY promoted the peer config to active,
+	// and once applyConfigLocked arms the dataplane snapshot this node is
+	// forwarding under it. The three session invalidators
+	// (clearSessionsForPolicyChanges: the #4234 deletion-clear, the
+	// modified-policy re-eval, and the #4342 default-policy change) MUST
+	// therefore run to bring surviving established sessions' authorization in
+	// line with the now-active config. Skipping them is a security fail-open: a
+	// session a peer-tightened/deleted policy should now DENY keeps forwarding
+	// under its stale authorization — and because the store already holds the
+	// incoming text, the next equal-active-text re-push takes handleConfigSync's
+	// fast path and never re-enters here to correct it, making the omission
+	// PERMANENT (and visible at failover).
+	//
+	// The invalidation runs from ONE deferred, guarded place (armedActive) so it
+	// ALWAYS fires once the config reached active+armed — EVEN on a NON-FATAL
+	// best-effort tail failure (host-inbound/lo0 nft, networkd, ...) that
+	// applyConfigLocked joins and returns — and so a future early-return added
+	// between the apply and here cannot re-introduce the skip. It does NOT run on
+	// a genuinely-fatal apply (see below), where the config is not live-forwarding
+	// and there is no session state to invalidate.
+	var armedActive bool
+	defer func() {
+		if !armedActive {
+			return
 		}
 		// #5578: surface a PARTIAL session invalidation to handleConfigSync
 		// (which logs it and returns it up the sync-recv path) so a peer-pushed
 		// policy deletion/tightening that could not fully drop this node's synced
 		// sessions is not silently swallowed. A non-fatal partial clear does not
 		// abort the (already-promoted) sync — it is joined into the return only.
-		clearErr = d.clearSessionsForPolicyChanges(oldActive, compiled)
+		clearErr := d.clearSessionsForPolicyChanges(oldActive, compiled)
 		// #1956 V-1 passive-node device-map admission gate (OQ-15.1 option
 		// (a): passive gate + loud health alarm). The active node's strict
 		// commit can only validate ITS OWN hardware (R-8), so a synced
@@ -521,8 +548,25 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 		// reboot. (Option (b), distributed pre-commit validation, is the
 		// documented end-state follow-up.)
 		d.deviceMapPassiveAdmissionAlarm(compiled)
+		retErr = errors.Join(retErr, clearErr)
+	}()
+
+	// #5564: capture the apply error instead of returning early on ANY error.
+	// applyErrSkipsPeerSync (shared with applyAndSyncCommitted) classifies the
+	// two FATAL classes — a required-protocol-gate error (dataplane DISARMED,
+	// #2138) or a daemon-stop context abort (#2926) — that mean the config is
+	// NOT live-forwarding. On those, discard the config and return the error
+	// WITHOUT invalidating (armedActive stays false; no spurious clear), exactly
+	// as the pre-#5564 early-return and applyAndSyncCommitted's fatal branch did.
+	// Every OTHER (non-fatal, best-effort tail) error leaves the config active +
+	// the snapshot armed, so the invalidators still run and the tail error is
+	// surfaced (joined with any partial-invalidation error), not swallowed.
+	applyErr := d.applyConfigLocked(d.applyCancelCtx(), compiled)
+	if applyErrSkipsPeerSync(applyErr) {
+		return nil, applyErr
 	}
-	return compiled, clearErr
+	armedActive = true
+	return compiled, applyErr
 }
 
 // deviceMapPassiveAdmissionAlarm raises a loud, never-silent HA-health alarm


### PR DESCRIPTION
## Summary

On the HA receive side, `syncAndApply` (`pkg/daemon/daemon_apply.go`) promotes
the peer config to active (`configstore.SyncApply`) and arms the dataplane
snapshot (`applyConfigLocked`) **before** it runs the three session invalidators
(`clearSessionsForPolicyChanges`: the #4234 deletion-clear, the modified-policy
re-eval, and the #4342 default-policy change). It returned early on **any**
`applyConfigLocked` error, so a **non-fatal** best-effort tail failure
(host-inbound/lo0 nft, networkd, …) skipped the invalidators. Surviving
established sessions then kept forwarding under their **old** authorization on an
armed standby — a security **fail-open**: a session a peer-tightened/deleted
policy should now deny keeps flowing under the stale decision, eligible to
forward immediately at failover.

Because `SyncApply` already promoted the incoming text to active, the primary's
equal-active-text re-push hits `handleConfigSync`'s fast path
(`activeText == incomingText`) and returns success without re-entering
`syncAndApply`, making the omission **permanent**. The commit path
`applyAndSyncCommitted` already handled this correctly (classify via
`applyErrSkipsPeerSync`, still run the invalidators for a non-fatal tail error);
the receive path had diverged.

## Fix

Mirror the commit path:

- Capture the apply error instead of early-returning on any error.
- Return early **only** for the two fatal classes `applyErrSkipsPeerSync`
  matches — a required-protocol-gate error (dataplane **disarmed**, #2138) and a
  daemon-stop context abort (#2926) — where the config is not live-forwarding and
  there is no session state to invalidate. On those, discard the config (nil) and
  return the error with **no** spurious invalidation (preserves existing fatal
  behavior).
- For every other (non-fatal tail) error the config reached active + the snapshot
  is armed, so run the invalidators and **surface** the tail error joined with any
  #5578 partial-invalidation error rather than swallowing it.
- The invalidation runs from a **deferred, guarded** (`armedActive`) block on a
  named-return function so a future early-return added between the apply and the
  invalidators cannot re-introduce the skip. `deviceMapPassiveAdmissionAlarm`
  moves into the same block.

Control-flow fix only — no wire/protocol/failover-machinery change.

## Test — fail-on-revert

`pkg/daemon/configsync_invalidate_5564_test.go` builds a real store (baseline
`p-first` id-0 + `p-web` id-1 committed active) and a fake dataplane holding v4+v6
established sessions under `p-web`; the peer text deletes `p-web`.

- `TestSyncAndApplyRunsInvalidatorsOnNonFatalApplyError` — injects a non-fatal
  tail error → asserts both v4+v6 sessions cleared, table scanned, tail error
  surfaced. **Proven RED on revert** (early `return nil, err`): both sessions
  survive under stale authorization (fail-open), `iterateCalls == 0`, config
  dropped to nil.
- `TestSyncAndApplySkipsInvalidatorsOnFatalApplyError` — fatal
  `ErrPolicySchedulerProtocolIncompatible` → sessions survive, no scan, nil
  config, error surfaced (no spurious invalidation / no regression).
- `TestSyncAndApplyRunsInvalidatorsOnCleanApply` — guards against
  over-suppression.
- `TestSyncAndApplySurfacesPartialInvalidationError` — #5578 on the receive path;
  the partial-clear error is joined through the defer into the return.

Validation: `go build ./...` + `go vet ./pkg/daemon` clean; `go test -race
./pkg/daemon ./pkg/cluster` both green. No failover machinery touched, so the
`test-failover` shim-wall block is a no-regression.

Docs: added a "Receive-side session invalidation (#5564)" subsection to
`docs/sync-protocol.md`.

Closes #5564

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi