### PR TITLE
filter: make FilterResult.forwarding_class Option (zero-alloc)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-16 — #5151 (filter): FilterResult.forwarding_class → Option<Arc<str>> (zero-alloc warmed-packet-path default)
+- **Timestamp**: 2026-07-16 (fix/5151-filterresult-option-fc)
+- **Action**: Fix #5151 (perf, zero-allocation warmed-packet-path invariant).
+  STEP-0 confirmed live on origin/master 8a769005f: `impl Default for
+  FilterResult` set `forwarding_class: Arc::<str>::from("")`, which allocates
+  an Arc header/data block on EVERY `FilterResult::default()`. That default is
+  the accumulator init for the full v4/v6/lo0 filter evaluators
+  (`evaluate_filter_ref_counted_v{4,6}`, etc.), so every full filter eval on the
+  packet path (session-miss / cache-sensitive) paid an empty-Arc allocation.
+  TxSelectionFilterResult and CachedTxSelectionFilterResult already use
+  `Option<Arc<str>> = None` — FilterResult was the inconsistent hold-out.
+  Fix (surgical, mirrors the TxSelection pattern): change
+  `FilterResult.forwarding_class` from `Arc<str>` to `Option<Arc<str>>` with a
+  `None` default (zero-alloc). The single write site — `merge_matched_modifiers`
+  in filter/engine/eval.rs, the ONLY place a matched term's forwarding-class is
+  folded into a FilterResult accumulator — now wraps in `Some(...)`, so the Arc
+  is cloned ONLY when a term ACTUALLY sets a forwarding-class (allocation on a
+  match, never on the default). `None` is semantically identical to the old
+  empty `""` ("no forwarding-class"). Consumer audit (grepped the whole crate):
+  NO production code reads `FilterResult.forwarding_class` — the CoS
+  forwarding-class classification path uses the dedicated TxSelection evaluators
+  (`evaluate_filter_ref_tx_selection_*`) whose result already carries
+  `Option`; the two FilterResult consumers in afxdp/poll_descriptor/filter.rs
+  (`evaluate_interface_filter_non_routing_counted`, `evaluate_lo0_filter_counted`)
+  read only `.action`/`.log_match`. The only readers are 3 tests, updated from
+  `result.forwarding_class.as_ref() == "x"` to `.as_deref() == Some("x")`.
+  FilterResult is a pure in-process eval result (`#[derive(Clone, Debug,
+  PartialEq, Eq)]`, NOT `#[repr(C)]`, NOT serialized / NOT HA-synced / NOT a map
+  struct) — no wire/serialized/map struct touched. Fail-on-revert PROVEN:
+  reverting the default to `Some(Arc::<str>::from(""))` (the faithful
+  re-introduction of the empty-Arc allocation under the new type) flips the new
+  `filter_result_forwarding_class_defaults_none_zero_alloc` test RED
+  (`assertion left == right failed  left: Some("")  right: None`); a bare `Arc`
+  clone at the write site fails to compile. Validation:
+  `CARGO_TARGET_DIR=/tmp/cargo-5151` release build clean (167 pre-existing
+  warnings, 0 errors); new test GREEN; full `cargo test --release` suite GREEN.
+- **File(s)**: userspace-dp/src/filter/mod.rs (FilterResult.forwarding_class:
+  Arc<str> → Option<Arc<str>>; Default → None), userspace-dp/src/filter/engine/eval.rs
+  (merge_matched_modifiers write wraps Some(...)), userspace-dp/src/filter/tests.rs
+  (3 result reads → .as_deref()==Some(..); new fail-on-revert test
+  filter_result_forwarding_class_defaults_none_zero_alloc)
+
 ## 2026-07-16 — #5155 (afxdp/session_glue): O(N) HashSet dedup for DemoteOwnerRGS cancelled_keys (was O(N^2) on packet worker)
 - **Timestamp**: 2026-07-16 (fix/5155-demote-dedup-hashset)
 - **Action**: Fix #5155 (perf, failover-time packet-worker stall).

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -174,7 +174,10 @@ fn merge_matched_modifiers(acc: &mut FilterResult, filter: &Filter, term: &Filte
         acc.routing_instance = term.routing_instance.clone();
     }
     if !term.forwarding_class.is_empty() {
-        acc.forwarding_class = term.forwarding_class.clone();
+        // #5151: clone the Arc only when a term ACTUALLY sets a forwarding-class
+        // (the allocation happens on a match, not on every default). `None` on
+        // the default preserves the old empty-`""` "no forwarding-class" meaning.
+        acc.forwarding_class = Some(term.forwarding_class.clone());
     }
     if term.log {
         acc.log = true;

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -838,7 +838,11 @@ pub(crate) struct FilterResult {
     pub(crate) dscp_rewrite: Option<u8>,
     pub(crate) policer_name: String,
     pub(crate) routing_instance: String,
-    pub(crate) forwarding_class: Arc<str>,
+    // #5151: `None` == no forwarding-class matched (semantically identical to
+    // the historical empty `""`). Mirrors TxSelection/CachedTxSelection which
+    // already use `Option<Arc<str>>` — the accumulator init no longer allocates
+    // an empty Arc header/data block on every full filter eval (packet path).
+    pub(crate) forwarding_class: Option<Arc<str>>,
     pub(crate) log: bool,
     pub(crate) log_match: Option<FilterLogMatch>,
 }
@@ -902,7 +906,10 @@ impl Default for FilterResult {
             dscp_rewrite: None,
             policer_name: String::new(),
             routing_instance: String::new(),
-            forwarding_class: Arc::<str>::from(""),
+            // #5151: zero-alloc default — no Arc header/data block allocated on
+            // the warmed packet path. A matching `then forwarding-class` term
+            // sets `Some(..)` in `merge_matched_modifiers`.
+            forwarding_class: None,
             log: false,
             log_match: None,
         }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2041,7 +2041,93 @@ fn interface_filter_assignment() {
         0,
         TermMatchExtra::default(),
     );
-    assert_eq!(result.forwarding_class.as_ref(), "bandwidth-10mb");
+    assert_eq!(result.forwarding_class.as_deref(), Some("bandwidth-10mb"));
+}
+
+/// #5151: FilterResult's forwarding-class accumulator is zero-allocation on the
+/// warmed packet path. The default (accumulator init for every full v4/v6/lo0
+/// eval) must be `None` — NOT an allocated empty `Arc::<str>::from("")`. A
+/// filter eval that matches NO `then forwarding-class` term must yield `None`
+/// (zero-alloc, semantically identical to the historical empty `""`), and a
+/// term that DOES set a forwarding-class must yield `Some("class")`.
+///
+/// Fail-on-revert: reverting the default to `Arc::<str>::from("")` makes the
+/// `None` assertions RED (the default becomes `Some("")`), and reverting the
+/// `merge_matched_modifiers` write to a bare `Arc` clone fails to compile.
+#[test]
+fn filter_result_forwarding_class_defaults_none_zero_alloc() {
+    // The accumulator init is `None` — no empty Arc header/data block allocated.
+    assert_eq!(FilterResult::default().forwarding_class, None);
+
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "ge-0/0/0.0".into(),
+        ifindex: 5,
+        filter_output_v4: "fc-egress".into(),
+        filter_output_v6: "plain-egress".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[
+            // Output filter WITH a `then forwarding-class` term.
+            FirewallFilterSnapshot {
+                name: "fc-egress".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "classify".into(),
+                    action: "accept".into(),
+                    forwarding_class: "iperf-a".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    ..Default::default()
+                }],
+            },
+            // Output filter with NO forwarding-class term at all.
+            FirewallFilterSnapshot {
+                name: "plain-egress".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "accept-all".into(),
+                    action: "accept".into(),
+                    ..Default::default()
+                }],
+            },
+        ],
+        &[],
+        &ifaces,
+        "",
+        "",
+    )
+    .expect("filter state compiles");
+
+    // A matching `then forwarding-class` term → Some("iperf-a").
+    let matched = evaluate_interface_output_filter(
+        &state,
+        5,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        1234,
+        5201,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(matched.forwarding_class.as_deref(), Some("iperf-a"));
+
+    // No forwarding-class term matched → None (zero-alloc, == old empty "").
+    let no_fc = evaluate_interface_output_filter(
+        &state,
+        5,
+        true,
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2)),
+        PROTO_TCP,
+        1234,
+        5201,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(no_fc.forwarding_class, None);
 }
 
 #[test]
@@ -2414,7 +2500,7 @@ fn interface_output_filter_counted_records_term_hits() {
         TermMatchExtra::default(),
         1514,
     );
-    assert_eq!(result.forwarding_class.as_ref(), "iperf-a");
+    assert_eq!(result.forwarding_class.as_deref(), Some("iperf-a"));
     let filter = state
         .filters
         .get("inet6:bandwidth-output")
@@ -2464,7 +2550,7 @@ fn interface_output_filter_without_count_does_not_record_term_hits() {
         TermMatchExtra::default(),
         1514,
     );
-    assert_eq!(result.forwarding_class.as_ref(), "iperf-a");
+    assert_eq!(result.forwarding_class.as_deref(), Some("iperf-a"));
     let filter = state
         .filters
         .get("inet6:bandwidth-output")


### PR DESCRIPTION
## Problem (#5151, perf — zero-allocation warmed-packet-path invariant)

`impl Default for FilterResult` set `forwarding_class: Arc::<str>::from("")`,
which allocates an Arc header/data block on **every** `FilterResult::default()`.
That default is the accumulator init for the full v4/v6/lo0 filter evaluators
(`evaluate_filter_ref_counted_v{4,6}`, etc.), so every full filter evaluation on
the packet path (session-miss / cache-sensitive) paid an empty-Arc allocation.

`TxSelectionFilterResult` and `CachedTxSelectionFilterResult` already meet the
zero-alloc invariant with `Option<Arc<str>> = None`. `FilterResult` was the
inconsistent hold-out.

## Fix (surgical — mirrors the TxSelection pattern)

- `FilterResult.forwarding_class`: `Arc<str>` → `Option<Arc<str>>`, default `None`
  (zero-alloc). `None` is semantically identical to the historical empty `""`
  ("no forwarding-class").
- The **only** write site — `merge_matched_modifiers` in `filter/engine/eval.rs`,
  where a matched term's forwarding-class is folded into a `FilterResult`
  accumulator — wraps the clone in `Some(...)`, so the Arc is cloned **only when
  a term actually sets a forwarding-class** (allocation on a match, never on the
  default).

## Consumer audit (whole-crate grep)

No production code reads `FilterResult.forwarding_class`:
- The CoS forwarding-class classification path uses the dedicated TxSelection
  evaluators (`evaluate_filter_ref_tx_selection_*`), whose result already carries
  an `Option` — those read sites (`cos_classify.rs`) are unchanged.
- The two `FilterResult` consumers in `poll_descriptor/filter.rs`
  (`evaluate_interface_filter_non_routing_counted`, `evaluate_lo0_filter_counted`)
  read only `.action` / `.log_match`.
- The only readers are **3 tests**, migrated from
  `result.forwarding_class.as_ref() == "x"` → `.as_deref() == Some("x")`.

`FilterResult` is a pure in-process eval result (`#[derive(Clone, Debug,
PartialEq, Eq)]`, **not** `#[repr(C)]`, not serialized, not HA-synced, not a map
struct) — **no wire/serialized/map struct touched.**

## Test — fail-on-revert

New `filter_result_forwarding_class_defaults_none_zero_alloc`:
- `FilterResult::default().forwarding_class == None` (zero-alloc).
- A filter eval with no `then forwarding-class` term → `None`.
- A filter with a `then forwarding-class` term → `Some("iperf-a")`.

**Fail-on-revert PROVEN:** reverting the default to `Some(Arc::<str>::from(""))`
(the faithful re-introduction of the empty-Arc allocation under the new type)
flips the test RED:
```
assertion `left == right` failed
  left: Some("")
 right: None
```
A bare `Arc` clone at the write site fails to compile.

## Validation

- Release build clean (167 pre-existing warnings, 0 errors).
- Full `cargo test --release` suite GREEN: **3941 passed, 0 failed, 2 ignored**.

Closes #5151

🤖 Generated with [Claude Code](https://claude.com/claude-code)