### PR TITLE
daemon: flush stale kernel host-inbound conntrack on tightening (#5566)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-16 — #5566 (daemon): stale kernel host-inbound authorization after a coarse tightening (security fail-open)
+- **Timestamp**: 2026-07-16 (fix/5566-hostinbound-conntrack-flush)
+- **Action**: Fix #5566 (security fail-open, direct-kernel host-inbound path).
+  STEP-0 confirmed live on origin/master d9cb7d1ff: the `inet xpf_hostinbound`
+  chain leads with `ct state established,related accept`
+  (`buildHostInboundFilterPayload`, `pkg/daemon/daemon_nft.go`) BEFORE the
+  per-zone coarse catch-all drops, and replacing the table does NOT flush Linux
+  netfilter conntrack. Removing a host service (SSH/HTTPS/SNMP/...) therefore left
+  an EXISTING direct-kernel connection authorized under the OLD config — the
+  established-accept short-circuits the new drop, no host-inbound deny
+  counter/log. The Rust userspace local-delivery path already tears down
+  now-denied sessions per hit (poll_descriptor/mod.rs); the kernel path had no
+  equivalent. Fix: a conntrack RECONCILE at the tail of `applyHostInboundFilter`
+  (new `pkg/daemon/host_inbound_conntrack_flush.go`). After a successful real
+  table load, delete every established/related kernel conntrack entry whose
+  original-direction destination is a covered firewall-local host-inbound address
+  (the #5789 `desiredDrop` set — lifelines excluded) and whose (proto, dport) the
+  CURRENT coarse rules no longer admit, so the next packet is re-evaluated and
+  dropped by the per-zone catch-all. Reconcile (not an old-vs-new delta): the
+  admit decision is derived from the SAME structured SSOT the nft chain renders
+  from (`config.HostInboundServiceMatch`/`HostInboundProtocolMatch`), so it cannot
+  drift; a still-permitted service's flows are kept (no reset regression); no
+  prior-config snapshot persisted; no-op on loosening/unchanged commits. Global
+  exemptions (ESP/AH 50/51, ICMP ND/PMTUD/echo, the #5582 WireGuard listen port)
+  are never flushed. Best effort — a flush failure is logged (WARN), not surfaced
+  as a commit failure, since NEW-connection enforcement is already applied and a
+  failure only leaves pre-existing flows on old authorization (pre-fix behavior).
+  Netfilter conntrack here tracks only host-terminated/kernel-forwarded flows
+  (transit runs through userspace-dp's own session table), so the swept table is
+  small. Seam: `conntrackDeleteFilters` package var wraps
+  `netlink.ConntrackDeleteFilters` (netlink is already a direct dep; no
+  conntrack-tools binary dependency). Tests: fail-on-revert proofs in
+  `host_inbound_conntrack_flush_5566_test.go` — neutering the matcher and removing
+  the wiring each go RED (verified). Full `go test -race ./pkg/daemon` green.
+- **File(s)**: pkg/daemon/host_inbound_conntrack_flush.go (new),
+  pkg/daemon/host_inbound_conntrack_flush_5566_test.go (new),
+  pkg/daemon/daemon_nft.go, docs/host-inbound-service-matrix.md, _Log.md
+
 ## 2026-07-16 — #5564 (daemon): HA config-sync tail failure permanently bypassed policy session invalidation (fail-open)
 - **Timestamp**: 2026-07-16 (fix/5564-syncapply-invalidators)
 - **Action**: Fix #5564 (security fail-open, HA receive side). STEP-0 confirmed

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -207,10 +207,62 @@ operation or session return traffic. nft: `buildHostInboundFilterPayload`; Rust:
 
 | Class | nft | Rust | Rationale |
 |---|---|---|---|
-| Established/related | `ct state established,related accept` | conntrack fast path | Return / ongoing host traffic. |
+| Established/related | `ct state established,related accept` | conntrack fast path | Return / ongoing host traffic. **On a tightening the kernel entry is reconciled — see "Stale kernel authorization on a tightening (#5566)" below.** |
 | Raw IPsec ESP/AH | `meta l4proto { 50, 51 } accept` | `stage_ipsec_passthrough_check` (before `host_inbound_admits`) | Kernel XFRM decrypts host-terminated IPsec; makes `ike`/`ipsec` a working superset. |
 | ICMPv4 errors/PMTUD | `icmp type { destination-unreachable, time-exceeded, parameter-problem }` | proto 1 types 3, 11, 12 | PMTUD / unreachable / traceroute-to-self signalling. Echo-request is NOT here (gated on `ping`). |
 | ICMPv6 errors + ND | `icmpv6 type { 1, 2, 3, 4, 133, 134, 135, 136, 137 }` | proto 58 types 1-4, 133-137 | v6 error/PMTUD (1-4) + Neighbor Discovery (133-137). Echo-request (128) is NOT here (gated on `ping`). |
+
+## Stale kernel authorization on a tightening (#5566)
+
+The `ct state established,related accept` above is the FIRST rule in the chain
+(and, in the `to-zone junos-host` program branch, the residual established accept
+follows the fine DROP but still precedes the per-zone coarse drops). Replacing the
+`xpf_hostinbound` table does **not** flush Linux netfilter conntrack. So an
+EXISTING direct-kernel host connection admitted under a looser prior config — an
+SSH / HTTPS / SNMP session to a firewall-local address — kept riding that leading
+established-accept after the operator REMOVED the service: the new per-zone
+catch-all DROP never saw the flow's original-direction packets. That was a
+host-inbound false-allow confined to the direct-kernel delivery path; the Rust
+userspace local-delivery path already re-checks the effective host-inbound set on
+every session hit and tears a now-denied session down
+(`userspace-dp/src/afxdp/poll_descriptor/mod.rs`), but the kernel path had no
+equivalent teardown.
+
+**Fix — conntrack reconcile after every successful apply**
+(`pkg/daemon/host_inbound_conntrack_flush.go`, wired at the tail of
+`applyHostInboundFilter`). After the real `xpf_hostinbound` table loads, the
+daemon deletes every established/related **kernel** conntrack entry whose
+original-direction destination is a **covered** firewall-local host-inbound
+address (an address that carries a default-deny — the same `desiredDrop` set as
+#5789) and whose `(proto, dport)` the CURRENT coarse rules no longer admit. The
+next original-direction packet is then re-evaluated and dropped by the per-zone
+catch-all instead of short-circuiting on the established-accept. Properties:
+
+- **Reconcile, not a delta.** The flush condition is "not admitted by the CURRENT
+  config", derived from the SAME structured SSOT the nft chain renders from
+  (`config.HostInboundServiceMatch` / `HostInboundProtocolMatch`), so the admit
+  decision cannot drift from the chain's per-zone accepts. No prior-config
+  snapshot is persisted; the sweep is a no-op on loosening / unchanged commits
+  because still-permitted flows are kept. A service that stays configured is never
+  flushed (no connection-reset regression).
+- **Lifeline-safe.** Only addresses in the covered default-deny set are eligible;
+  management / cluster-control lifelines (fxp0 / em0 / fab*) are excluded from the
+  host-inbound views, so their conntrack is never flushed. Addressed-but-unzoned
+  addresses (#4420 HI-2) are covered with an empty admit set (fully denied except
+  the global exemptions below).
+- **Global exemptions preserved.** ESP/AH (proto 50/51), ICMP ND/PMTUD/error, and
+  the configured WireGuard listen port (#5582) are never flushed, mirroring the
+  chain's global accepts. ICMP echo conntrack is short-lived and left to age out.
+- **Best effort.** The nft table is already applied, so enforcement for NEW
+  connections holds regardless; a conntrack-subsystem flush failure is logged, not
+  surfaced as a commit failure (failing the commit would roll back correct
+  enforcement over a transient error). It only leaves PRE-EXISTING flows on their
+  old authorization — the pre-fix behavior.
+
+Kernel netfilter conntrack on this appliance tracks only host-terminated /
+kernel-forwarded flows (transit forwarding runs through userspace-dp's own session
+table), so the swept table is small. Fail-on-revert proofs:
+`pkg/daemon/host_inbound_conntrack_flush_5566_test.go`.
 
 ## Fail-closed invariant for a nil / configured=false known zone (#3705)
 

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -426,6 +426,17 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 		slog.Warn("failed to delete obsolete host-inbound gap fence after successful real install",
 			"err", err, "output", string(out))
 	}
+	// #5566: reconcile Linux netfilter conntrack against the just-applied
+	// host-inbound set. The chain's leading `ct state established,related accept`
+	// precedes the per-zone coarse drops and table replacement does not flush
+	// conntrack, so an EXISTING direct-kernel connection admitted under a looser
+	// prior config would keep that authorization after a service is removed. Flush
+	// the now-denied host-directed entries so the next original-direction packet is
+	// re-evaluated against the current rules — mirroring the Rust userspace
+	// local-delivery per-hit re-eval/teardown. Best effort (see the function doc):
+	// enforcement for NEW connections is already in place, so a flush failure never
+	// fails the commit.
+	d.flushDeniedHostInboundConntrack(views, unzonedV4, unzonedV6, wgListenPorts)
 	slog.Info("host-inbound filter applied", "zones", len(views),
 		"unzoned_deny_v4", len(unzonedV4), "unzoned_deny_v6", len(unzonedV6),
 		"junos_host_deny_programs", len(programs))

--- a/pkg/daemon/host_inbound_conntrack_flush.go
+++ b/pkg/daemon/host_inbound_conntrack_flush.go
@@ -1,0 +1,296 @@
+package daemon
+
+import (
+	"log/slog"
+	"net/netip"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #5566: stale kernel host-inbound authorization on a coarse tightening.
+//
+// The xpf_hostinbound kernel chain leads with `ct state established,related
+// accept` (buildHostInboundFilterPayload), which precedes every per-zone coarse
+// host-inbound catch-all DROP. Replacing the xpf_hostinbound table does NOT flush
+// Linux netfilter conntrack, so a direct-kernel host connection admitted under a
+// LOOSER prior config (e.g. an SSH/HTTPS/SNMP session) keeps riding that leading
+// established-accept after the operator REMOVES the service — the new per-zone
+// drop never sees the flow's original-direction packets. That is a host-inbound
+// false-allow limited to the direct-kernel delivery path: the Rust userspace
+// local-delivery path already re-checks the effective host-inbound set on every
+// session hit and tears a now-denied session down
+// (userspace-dp/src/afxdp/poll_descriptor/mod.rs), but the kernel path had no
+// equivalent teardown.
+//
+// The fix reconciles kernel conntrack against the JUST-APPLIED host-inbound set
+// after every successful real apply: any established/related kernel conntrack
+// entry whose ORIGINAL-direction destination is a firewall-local host-inbound
+// address under a default-deny AND whose (proto, dport) is NOT admitted by the
+// CURRENT coarse host-inbound set is deleted, so the next original-direction
+// packet is re-evaluated against the new rules (and dropped by the per-zone
+// catch-all) instead of short-circuiting on the established-accept. This mirrors
+// the Rust per-hit re-eval/teardown. Because the flush condition is "not admitted
+// by the CURRENT config", a still-permitted service's connections are never
+// flushed — a reconcile, not an edge-triggered delta, so it is regression-safe on
+// loosening and no-op commits and needs no persisted prior-config snapshot.
+//
+// Only firewall-local addresses that carry a catch-all DROP are eligible (the
+// covered set). Management / cluster-control lifeline addresses (fxp0 / em0 /
+// fab*) are excluded from the host-inbound views by BuildZoneHostInboundViews, so
+// they are never in the covered set and their conntrack is never flushed — the
+// flush can never strand management or break HA. Kernel netfilter conntrack on
+// this appliance tracks only host-terminated / kernel-forwarded flows (transit
+// forwarding runs through userspace-dp's own session table, not netfilter
+// conntrack), so the table swept here is small.
+
+// conntrackDeleteFilters is the netfilter-conntrack delete seam. It deletes every
+// entry in the main conntrack table (both families are queried by the caller)
+// that matches any supplied filter. A package var so the #5566 reconcile is
+// unit-testable without a live kernel conntrack subsystem (mirrors the
+// nftApplyPayload seam).
+var conntrackDeleteFilters = func(family netlink.InetFamily, filters ...netlink.CustomConntrackFilter) (uint, error) {
+	return netlink.ConntrackDeleteFilters(netlink.ConntrackTable, family, filters...)
+}
+
+// hostInboundAdmit records the CURRENT coarse host-inbound admit set for one
+// firewall-local destination address, unioned across every zone view whose
+// address set contains it (an address reachable from >1 zone is admitted if ANY
+// of those zones admits — matching the nft chain, which emits a per-zone accept
+// keyed on destination address only). An address present in the covered set with
+// an otherwise-empty admit (e.g. an addressed-but-unzoned interface, #4420) is
+// fully denied except for the global exemptions handled in MatchConntrackFlow.
+type hostInboundAdmit struct {
+	allowsAll bool               // `system-services all` / any-service → keep everything
+	tcp       []config.PortRange // admitted TCP destination ports
+	udp       []config.PortRange // admitted UDP destination ports
+	protos    map[uint8]bool     // admitted bare IP protocols (e.g. gre=47)
+}
+
+// add folds one structured host-inbound admit tuple (the #3627 B1a SSOT
+// config.L4Match) into the address's admit set. ICMP/ICMPv6 admits are NOT
+// recorded here: ND/PMTUD/error subtypes are globally accepted and echo-request
+// conntrack is short-lived, so ICMP is never flushed (MatchConntrackFlow returns
+// early for it). The ident-reset marker (Reject) does not admit TCP/113 — it
+// RESETS it — so it is skipped (a stale tcp/113 entry is therefore flushable).
+func (a *hostInboundAdmit) add(m config.L4Match) {
+	if m.Reject {
+		return
+	}
+	switch m.Proto {
+	case config.HostInboundProtoTCP:
+		a.tcp = append(a.tcp, m.Ports...)
+	case config.HostInboundProtoUDP:
+		a.udp = append(a.udp, m.Ports...)
+	case config.HostInboundProtoICMP, config.HostInboundProtoICMPv6:
+		// globally accepted / short-lived — not tracked for flushing.
+	default:
+		if a.protos == nil {
+			a.protos = map[uint8]bool{}
+		}
+		a.protos[m.Proto] = true
+	}
+}
+
+// hostInboundConntrackFlushFilter is the netlink CustomConntrackFilter that
+// selects now-denied host-inbound kernel conntrack entries for deletion (#5566).
+// It matches a flow iff the flow's ORIGINAL-direction destination is a covered
+// firewall-local host-inbound address AND the flow's (proto, dport) is not
+// admitted by the current coarse host-inbound set for that address and is not a
+// global exemption (ESP/AH, ICMP ND/PMTUD, the WireGuard listen port).
+type hostInboundConntrackFlushFilter struct {
+	admit   map[netip.Addr]*hostInboundAdmit
+	wgPorts []uint16
+}
+
+// MatchConntrackFlow reports whether the flow is a now-denied host-inbound entry
+// to flush. It is deliberately conservative — it returns false (keep) for any
+// flow it cannot prove is denied — so it can never delete a permitted or
+// non-host-inbound flow.
+func (f *hostInboundConntrackFlushFilter) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+	if flow == nil {
+		return false
+	}
+	// Original-direction destination = the firewall-local address the remote
+	// client connected to. Transit / host-originated flows have a non-local
+	// original destination and so are never in the covered admit map.
+	dst, ok := netip.AddrFromSlice(flow.Forward.DstIP)
+	if !ok {
+		return false
+	}
+	a := f.admit[dst.Unmap()]
+	if a == nil {
+		// Not a covered host-inbound deny address (includes every lifeline /
+		// fully-permitted / non-local destination) — never flush.
+		return false
+	}
+	if a.allowsAll {
+		// Zone opened to all services (`system-services all`) — keep everything.
+		// buildHostInboundConntrackFlushFilter already drops allows-all addresses
+		// from the covered map, so this is a defensive guard that keeps the matcher
+		// correct if that exclusion is ever changed.
+		return false
+	}
+	proto := flow.Forward.Protocol
+	switch proto {
+	case 50, 51:
+		// Raw ESP / AH: globally exempt (host-terminated IPsec is decrypted by the
+		// kernel XFRM stack before any host-inbound deny) — mirror the chain accept.
+		return false
+	case config.HostInboundProtoICMP, config.HostInboundProtoICMPv6:
+		// ND / PMTUD / ICMP-error are globally accepted and echo conntrack is
+		// short-lived — never flush ICMP.
+		return false
+	case config.HostInboundProtoTCP:
+		if portInRanges(flow.Forward.DstPort, a.tcp) {
+			return false
+		}
+	case config.HostInboundProtoUDP:
+		if f.isWireGuardPort(flow.Forward.DstPort) {
+			return false
+		}
+		if portInRanges(flow.Forward.DstPort, a.udp) {
+			return false
+		}
+	default:
+		if a.protos[proto] {
+			return false
+		}
+	}
+	// Covered address, current config does not admit this (proto, dport), and it is
+	// not a global exemption → the entry rides the leading established-accept under
+	// stale authorization. Flush it so the next packet is re-evaluated.
+	return true
+}
+
+// isWireGuardPort reports whether the destination UDP port is a configured
+// WireGuard listen port, which the host-inbound chain admits globally (#5582) so
+// the shim-steered outer transport reaches the kernel WG socket.
+func (f *hostInboundConntrackFlushFilter) isWireGuardPort(port uint16) bool {
+	for _, p := range f.wgPorts {
+		if p == port {
+			return true
+		}
+	}
+	return false
+}
+
+// portInRanges reports whether port falls in any inclusive PortRange.
+func portInRanges(port uint16, ranges []config.PortRange) bool {
+	for _, r := range ranges {
+		if port >= r.Lo && port <= r.Hi {
+			return true
+		}
+	}
+	return false
+}
+
+// buildHostInboundConntrackFlushFilter assembles the #5566 flush filter from the
+// SAME structured host-inbound SSOT the nft chain renders from
+// (config.HostInboundServiceMatch / HostInboundProtocolMatch), so the flush's
+// admit decision cannot drift from the kernel chain's per-zone accepts. Returns
+// nil when there is no covered firewall-local address (nothing to reconcile).
+func buildHostInboundConntrackFlushFilter(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) *hostInboundConntrackFlushFilter {
+	admit := map[netip.Addr]*hostInboundAdmit{}
+	ensure := func(addr string) *hostInboundAdmit {
+		ip, err := netip.ParseAddr(addr)
+		if err != nil {
+			return nil
+		}
+		key := ip.Unmap()
+		e := admit[key]
+		if e == nil {
+			e = &hostInboundAdmit{}
+			admit[key] = e
+		}
+		return e
+	}
+	addFamily := func(v dpuserspace.ZoneHostInboundView, family string, addrs []string) {
+		allowsAll := hostInboundAllowsAll(v)
+		for _, addr := range addrs {
+			e := ensure(addr)
+			if e == nil {
+				continue
+			}
+			if allowsAll {
+				e.allowsAll = true
+				continue
+			}
+			for _, svc := range v.SystemServices {
+				for _, m := range config.HostInboundServiceMatch(svc, family) {
+					e.add(m)
+				}
+			}
+			for _, proto := range v.Protocols {
+				for _, m := range config.HostInboundProtocolMatch(proto, family) {
+					e.add(m)
+				}
+			}
+		}
+	}
+	for _, v := range views {
+		addFamily(v, "ip", v.V4Addrs)
+		addFamily(v, "ip6", v.V6Addrs)
+	}
+	// #4420 HI-2: addressed-but-unzoned firewall-local addresses carry a catch-all
+	// DROP with no service accepts — fully denied except the global exemptions, so
+	// record them with an empty admit set.
+	for _, addr := range unzonedV4 {
+		ensure(addr)
+	}
+	for _, addr := range unzonedV6 {
+		ensure(addr)
+	}
+	// An address reachable from an `all` / any-service zone gets a bare
+	// `daddr <addr> accept` in the nft chain (no catch-all DROP), so every flow to
+	// it is admitted — it is not "covered" by a default-deny and must never be
+	// flushed even if a DIFFERENT zone view also names it (union: allows-all wins,
+	// mirroring the chain's accept rule). Drop those entries so the covered set
+	// equals the addresses that actually carry a default-deny.
+	for addr, a := range admit {
+		if a.allowsAll {
+			delete(admit, addr)
+		}
+	}
+	if len(admit) == 0 {
+		return nil
+	}
+	return &hostInboundConntrackFlushFilter{admit: admit, wgPorts: wgListenPorts}
+}
+
+// flushDeniedHostInboundConntrack reconciles Linux netfilter conntrack against
+// the just-applied host-inbound set (#5566): it deletes every established/related
+// kernel conntrack entry whose original-direction destination is a covered
+// firewall-local host-inbound address that the CURRENT coarse rules no longer
+// admit, so a service removed from a zone can no longer leave an existing
+// direct-kernel connection authorized under the old config via the chain's
+// leading `ct state established,related accept`.
+//
+// Best effort: the nft host-inbound table is already applied, so enforcement for
+// NEW connections holds regardless. A conntrack flush failure only leaves
+// PRE-EXISTING flows on their old authorization (the pre-fix behavior), so it is
+// logged rather than surfaced as a commit failure — failing the commit would roll
+// back correct enforcement over a transient conntrack-subsystem error.
+func (d *Daemon) flushDeniedHostInboundConntrack(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) {
+	filter := buildHostInboundConntrackFlushFilter(views, unzonedV4, unzonedV6, wgListenPorts)
+	if filter == nil {
+		return
+	}
+	var flushed uint
+	for _, family := range []netlink.InetFamily{unix.AF_INET, unix.AF_INET6} {
+		n, err := conntrackDeleteFilters(family, filter)
+		if err != nil {
+			slog.Warn("host-inbound conntrack reconcile failed: existing direct-kernel connections to a now-denied host service may retain OLD authorization until they close or time out",
+				"family", family, "err", err)
+			continue
+		}
+		flushed += n
+	}
+	if flushed > 0 {
+		slog.Info("host-inbound conntrack reconcile: flushed now-denied kernel conntrack entries so stale direct-kernel host connections are re-evaluated against the current host-inbound set",
+			"flushed", flushed)
+	}
+}

--- a/pkg/daemon/host_inbound_conntrack_flush_5566_test.go
+++ b/pkg/daemon/host_inbound_conntrack_flush_5566_test.go
@@ -1,0 +1,191 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #5566: the xpf_hostinbound kernel chain leads with `ct state
+// established,related accept`, which precedes the per-zone coarse host-inbound
+// drops, and replacing the table does NOT flush Linux conntrack. Removing a host
+// service therefore left an EXISTING direct-kernel connection authorized under the
+// OLD config (the established-accept short-circuits the new drop) — a host-inbound
+// false-allow the Rust userspace path already tears down per hit. The fix flushes
+// the now-denied host-directed conntrack entries after a successful host-inbound
+// apply so the next packet is re-evaluated against the current rules.
+//
+// These are the fail-on-revert proofs. Reverting the matcher logic
+// (MatchConntrackFlow) turns the match assertions RED; reverting the wiring
+// (removing d.flushDeniedHostInboundConntrack from applyHostInboundFilter) turns
+// the reconcile-invocation assertion RED.
+
+// hostInboundFlushTestConfig clones hostInboundTestConfig and parameterizes the
+// wan zone's system-services, opening the lan zone (reth1.0, 10.0.61.1) to `all`
+// so an allows-all address is available. em0/fxp0 stay management/cluster-control
+// lifelines (excluded from the host-inbound views, so never in the covered set).
+func hostInboundFlushTestConfig(wanServices ...string) *config.Config {
+	cfg := hostInboundTestConfig()
+	cfg.Security.Zones["wan"].HostInboundTraffic.SystemServices = wanServices
+	cfg.Security.Zones["lan"].HostInboundTraffic = &config.HostInboundTraffic{SystemServices: []string{"all"}}
+	return cfg
+}
+
+// ctFlow builds a synthetic conntrack flow with the given original-direction
+// (proto, destination IP, destination port) — the tuple the kernel host-inbound
+// chain evaluates for an inbound host connection.
+func ctFlow(proto uint8, dstIP string, dport uint16) *netlink.ConntrackFlow {
+	return &netlink.ConntrackFlow{
+		Forward: netlink.IPTuple{
+			SrcIP:    net.ParseIP("203.0.113.7"),
+			DstIP:    net.ParseIP(dstIP),
+			Protocol: proto,
+			SrcPort:  40000,
+			DstPort:  dport,
+		},
+	}
+}
+
+// TestHostInboundConntrackFlushFilterMatch_5566 exercises the flush filter's
+// per-flow decision directly. The wan zone is tightened to `snmp` only (ssh
+// removed): an established ssh (tcp/22) flow to the wan address is now denied and
+// MUST be selected for flush, while the still-permitted snmp (udp/161) flow, an
+// allows-all zone's flow, a lifeline address, ESP, ICMP, and a WireGuard flow MUST
+// all be preserved.
+func TestHostInboundConntrackFlushFilterMatch_5566(t *testing.T) {
+	cfg := hostInboundFlushTestConfig("snmp") // ssh removed → now denied
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+
+	f := buildHostInboundConntrackFlushFilter(views, unzonedV4, unzonedV6, nil)
+	if f == nil {
+		t.Fatal("expected a non-nil flush filter for an enforcing config")
+	}
+
+	cases := []struct {
+		name string
+		flow *netlink.ConntrackFlow
+		want bool
+	}{
+		// The headline bug: a removed service's established flow is now denied.
+		{"ssh-now-denied-v4", ctFlow(config.HostInboundProtoTCP, "172.16.50.8", 22), true},
+		{"ssh-now-denied-v6", ctFlow(config.HostInboundProtoTCP, "2001:db8:50::8", 22), true},
+		// A never-permitted service on a covered address is likewise flushable.
+		{"telnet-denied-v4", ctFlow(config.HostInboundProtoTCP, "172.16.50.8", 23), true},
+		// The still-permitted service's established flow MUST survive (no regression).
+		{"snmp-permitted-v4", ctFlow(config.HostInboundProtoUDP, "172.16.50.8", 161), false},
+		// An allows-all zone address keeps everything.
+		{"allows-all-zone", ctFlow(config.HostInboundProtoTCP, "10.0.61.1", 22), false},
+		// A management/cluster-control lifeline address is not covered → never flushed.
+		{"lifeline-em0", ctFlow(config.HostInboundProtoTCP, "10.99.0.1", 22), false},
+		// Global exemptions the chain always accepts are never flushed.
+		{"esp-exempt", ctFlow(50, "172.16.50.8", 0), false},
+		{"ah-exempt", ctFlow(51, "172.16.50.8", 0), false},
+		{"icmp-exempt", ctFlow(config.HostInboundProtoICMP, "172.16.50.8", 0), false},
+		{"icmpv6-exempt", ctFlow(config.HostInboundProtoICMPv6, "2001:db8:50::8", 0), false},
+		// A non-local (transit / host-originated) destination is never covered.
+		{"transit-dst", ctFlow(config.HostInboundProtoTCP, "8.8.8.8", 22), false},
+	}
+	for _, tc := range cases {
+		if got := f.MatchConntrackFlow(tc.flow); got != tc.want {
+			t.Errorf("%s: MatchConntrackFlow = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+
+	// The WireGuard listen port is globally admitted (#5582): a UDP flow to it on a
+	// covered address must NOT be flushed even though no zone service names it.
+	fWG := buildHostInboundConntrackFlushFilter(views, unzonedV4, unzonedV6, []uint16{51820})
+	if fWG.MatchConntrackFlow(ctFlow(config.HostInboundProtoUDP, "172.16.50.8", 51820)) {
+		t.Error("WireGuard listen-port flow to a covered address must not be flushed")
+	}
+}
+
+// TestHostInboundConntrackFlushReconcileOnTightening_5566 is the end-to-end
+// fail-on-revert proof for the wiring: a successful host-inbound apply that
+// TIGHTENS the config (removes ssh, keeps snmp) must drive the conntrack reconcile
+// with a filter that flushes the now-denied ssh flow and preserves the permitted
+// snmp flow. Removing d.flushDeniedHostInboundConntrack from applyHostInboundFilter
+// leaves conntrackDeleteFilters uncalled → the invocation assertion RED (the stale
+// ssh entry would survive on the leading established-accept).
+func TestHostInboundConntrackFlushReconcileOnTightening_5566(t *testing.T) {
+	origApply := nftApplyPayload
+	origDelete := nftDeleteTable
+	origCT := conntrackDeleteFilters
+	defer func() {
+		nftApplyPayload = origApply
+		nftDeleteTable = origDelete
+		conntrackDeleteFilters = origCT
+	}()
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+
+	var ctCalls int
+	var lastFilter netlink.CustomConntrackFilter
+	conntrackDeleteFilters = func(_ netlink.InetFamily, filters ...netlink.CustomConntrackFilter) (uint, error) {
+		ctCalls++
+		if len(filters) > 0 {
+			lastFilter = filters[0]
+		}
+		return 0, nil
+	}
+
+	d := &Daemon{}
+
+	// Step 1: loose config permits ssh + snmp; a direct-kernel ssh session exists.
+	if err := d.applyHostInboundFilter(hostInboundFlushTestConfig("ssh", "snmp")); err != nil {
+		t.Fatalf("step 1 (loose apply): %v", err)
+	}
+
+	// Step 2: TIGHTEN — remove ssh (keep snmp). The reconcile must run against the
+	// new set.
+	callsBefore := ctCalls
+	if err := d.applyHostInboundFilter(hostInboundFlushTestConfig("snmp")); err != nil {
+		t.Fatalf("step 2 (tighten apply): %v", err)
+	}
+	if ctCalls-callsBefore == 0 {
+		t.Fatal("#5566 FAIL-OPEN: a host-inbound tightening applied but the kernel conntrack " +
+			"reconcile never ran — an existing direct-kernel ssh connection would keep OLD " +
+			"authorization via the chain's leading `ct state established,related accept`")
+	}
+	if lastFilter == nil {
+		t.Fatal("reconcile ran but no conntrack filter was captured")
+	}
+	// The captured filter flushes the now-denied ssh flow...
+	if !lastFilter.MatchConntrackFlow(ctFlow(config.HostInboundProtoTCP, "172.16.50.8", 22)) {
+		t.Error("the tightening reconcile filter must flush the now-denied ssh (tcp/22) flow")
+	}
+	// ...and preserves the still-permitted snmp flow (no regression).
+	if lastFilter.MatchConntrackFlow(ctFlow(config.HostInboundProtoUDP, "172.16.50.8", 161)) {
+		t.Error("the reconcile filter must NOT flush the still-permitted snmp (udp/161) flow")
+	}
+}
+
+// TestHostInboundConntrackFlushNoOpWhenNothingCovered_5566 asserts the reconcile
+// is a no-op (no netlink delete) when there is no covered firewall-local
+// host-inbound address — an all-open config produces no default-deny, so there is
+// nothing to reconcile and the filter builder returns nil.
+func TestHostInboundConntrackFlushNoOpWhenNothingCovered_5566(t *testing.T) {
+	// Only an allows-all zone: no catch-all drop, so no covered address.
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth1": {Name: "reth1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.61.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"open": {
+			Name:               "open",
+			Interfaces:         []string{"reth1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"all"}},
+		},
+	}
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+	if f := buildHostInboundConntrackFlushFilter(views, unzonedV4, unzonedV6, nil); f != nil {
+		t.Errorf("expected nil filter when no address is covered by a default-deny, got %+v", f)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #5566 — a host-inbound **security fail-open** on the direct-kernel delivery path.

The `inet xpf_hostinbound` chain leads with `ct state established,related accept`, which precedes every per-zone coarse host-inbound catch-all DROP, and replacing the `xpf_hostinbound` table does **not** flush Linux netfilter conntrack. So removing a host service (SSH/HTTPS/SNMP/…) left an **existing direct-kernel connection authorized under the OLD config**: the leading established-accept short-circuits the new drop, producing no host-inbound deny counter/log. The Rust userspace local-delivery path already re-checks the effective host-inbound set on every session hit and tears a now-denied session down (`poll_descriptor/mod.rs`); the kernel path had no equivalent teardown.

## STEP-0 (verified vs origin/master `d9cb7d1ff`)
- `buildHostInboundFilterPayload` emits `ct state established,related accept` before the per-zone coarse drops (both the no-program `else` branch and, as the residual established accept, the `to-zone junos-host` program branch).
- Table replacement (`add`/`delete`/redefine) does not flush conntrack → stale authorization survives a tightening. Bounded, not a design fork.

## Fix
A conntrack **reconcile** at the tail of `applyHostInboundFilter` (new `pkg/daemon/host_inbound_conntrack_flush.go`). After a successful real table load, delete every established/related kernel conntrack entry whose original-direction destination is a **covered** firewall-local host-inbound address (the #5789 `desiredDrop` set — lifelines `fxp0`/`em0`/`fab*` are excluded from the views, so never eligible) and whose `(proto, dport)` the **current** coarse rules no longer admit. The next original-direction packet is then re-evaluated and dropped by the per-zone catch-all instead of riding the established-accept — mirroring the Rust per-hit teardown.

Key properties:
- **Reconcile, not a delta.** Flush condition = "not admitted by the CURRENT config", derived from the SAME structured SSOT the nft chain renders from (`config.HostInboundServiceMatch` / `HostInboundProtocolMatch`), so the admit decision cannot drift. Still-permitted services are never flushed (no reset regression); no-op on loosening/unchanged commits; no prior-config snapshot persisted.
- **Lifeline-safe.** Only covered default-deny addresses are eligible; management/cluster-control lifelines are never flushed. Addressed-but-unzoned addresses (#4420) are covered with an empty admit set.
- **Global exemptions preserved** — ESP/AH (50/51), ICMP ND/PMTUD/echo, and the #5582 WireGuard listen port are never flushed.
- **Best effort.** NEW-connection enforcement is already applied, so a conntrack-subsystem flush failure is logged (WARN), not surfaced as a commit failure.
- **Seam.** `conntrackDeleteFilters` package var wraps `netlink.ConntrackDeleteFilters` (netlink is already a direct dep; no `conntrack-tools` binary dependency). Kernel netfilter conntrack here tracks only host-terminated/kernel-forwarded flows (transit runs through userspace-dp's own session table), so the swept table is small.

## Tests — fail-on-revert
`pkg/daemon/host_inbound_conntrack_flush_5566_test.go`:
- **Matcher** — now-denied ssh (tcp/22) flushed; still-permitted snmp (udp/161), an allows-all zone, a lifeline address, ESP/AH, ICMP, WireGuard, and transit destinations all preserved (v4 + v6).
- **End-to-end wiring** — a tightening apply (remove ssh, keep snmp) drives the reconcile with a filter that flushes the ssh flow and preserves the snmp flow.
- Verified RED on revert: neutering the matcher **and** removing the flush call each fail the suite. `go test -race ./pkg/daemon` green; `go build ./...` + `gofmt` clean.

## Docs
`docs/host-inbound-service-matrix.md` (new "Stale kernel authorization on a tightening (#5566)" section + established/related row note) and `_Log.md`.

Closes #5566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi