### PR TITLE
nat: fail closed when interface SNAT has no egress address

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-16 — #5688 (Rust NAT): interface-mode SNAT with no same-family egress address leaked the source untranslated (fail-open)
+- **Timestamp**: 2026-07-16 (fix/5688-interface-snat-no-egress-drop)
+- **Action**: Fix #5688 (security/correctness fail-open, Rust userspace-dp
+  source NAT). STEP-0 confirmed live on origin/master 04e1527ab: in
+  `match_source_nat_result_for_tuple` (`userspace-dp/src/nat/source.rs`) the
+  `interface_mode` branch resolved `rewrite_src` from the egress interface's
+  same-family address (`egress_v4`/`egress_v6`) and returned
+  `SourceNatLookup::Matched` UNCONDITIONALLY — even when that address was
+  `None`. A `Matched` decision with a `None` source rewrite forwards the packet
+  UNTRANSLATED, so a v4 packet whose egress interface has no v4 address (or a v6
+  packet with no v6 egress address) leaked its private/internal source onto the
+  egress. Fix: fail CLOSED — when the same-family egress address is absent,
+  return `SourceNatLookup::Unavailable(SourceNatFailureReason::InterfaceNoEgressAddress)`
+  (new runtime-only reason, exception string
+  `source_nat_interface_no_egress_address`). That funnels through the SAME drop /
+  `nat_alloc_fail` disposition (`record_source_nat_failure`,
+  `poll_descriptor/nat_exception.rs`) a pool-mode allocation failure takes, so
+  the flow is dropped + counted instead of leaking. Disposition-only: no NAT
+  tuple / map-key / wire layout change. Families resolved independently (v4
+  packet → v4 egress addr, v6 packet → v6 egress addr); the working case (egress
+  HAS a same-family address) still translates.
+- **File(s)**: `userspace-dp/src/nat/source.rs` (new `InterfaceNoEgressAddress`
+  reason + exception string + fail-closed interface-mode branch),
+  `userspace-dp/src/nat/tests_source.rs` (3 fail-on-revert tests),
+  `userspace-dp/README.md` (source-NAT semantics bullet).
+- **Validation**: `cargo test --release` FULL suite 3945 passed / 0 failed.
+  Fail-on-revert proven: reverting to `Matched`-with-`None`-rewrite turns
+  `interface_source_nat_no_v4_egress_addr_fails_closed` and
+  `interface_source_nat_no_v6_egress_addr_fails_closed` RED while the
+  no-regression / dual-stack test
+  `interface_source_nat_translates_when_same_family_egress_addr_present` stays
+  GREEN. Smoke deferred (loss-cluster shim-wall) — unit-covered fail-closed.
+
 ## 2026-07-16 — #5566 (daemon): stale kernel host-inbound authorization after a coarse tightening (security fail-open)
 - **Timestamp**: 2026-07-16 (fix/5566-hostinbound-conntrack-flush)
 - **Action**: Fix #5566 (security fail-open, direct-kernel host-inbound path).

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -178,6 +178,27 @@ logging rules, not these specific hot-path constants.
   published or deleted by this path. Fail-on-revert: the wiring test
   `close_delta_deletes_dnat_table_entry_for_snat_flow` plus the key-SSOT
   tests in `src/afxdp/tests.rs`.
+- **Interface-mode SNAT fails closed with no egress address (#5688)**:
+  interface source-NAT translates the source to the egress interface's
+  OWN address of the PACKET's family (`match_source_nat_result_for_tuple`
+  in `src/nat/source.rs`). When the egress interface has NO same-family
+  address (a v4 packet on an egress with only v6 addresses, or vice
+  versa) there is nothing to translate to. The pre-#5688 code returned
+  `Matched` with a `None` rewrite, so the packet was forwarded with its
+  private/internal source UNTRANSLATED onto the egress — an address leak.
+  The fix fails CLOSED: it returns
+  `SourceNatLookup::Unavailable(SourceNatFailureReason::InterfaceNoEgressAddress)`,
+  which funnels through the SAME drop / `nat_alloc_fail`
+  (`record_source_nat_failure`) disposition a pool-mode allocation
+  failure takes, so the flow is dropped and counted instead of leaking.
+  The families are resolved independently (a v4 packet checks the v4
+  egress address, a v6 packet the v6 one), and the working case — egress
+  HAS a same-family address — still translates. No NAT tuple / map-key /
+  wire layout change; disposition-only. Fail-on-revert:
+  `interface_source_nat_no_v4_egress_addr_fails_closed`,
+  `interface_source_nat_no_v6_egress_addr_fails_closed`, and
+  `interface_source_nat_translates_when_same_family_egress_addr_present`
+  in `src/nat/tests_source.rs`.
 - **Source-NAT pool subnet expansion (#3049)**: a source-NAT pool
   address entry may be a bare IP, a host CIDR (`/32`, `/128`), or a
   subnet CIDR (e.g. `203.0.113.0/28`). Junos uses the FULL prefix range

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -101,6 +101,14 @@ pub(crate) enum SourceNatFailureReason {
     /// subscriber; an out-of-range source has no reserved block, so the
     /// allocation fails closed rather than silently round-robining it.
     DeterministicSubscriberOutOfRange,
+    /// #5688: an interface-mode source-NAT rule matched, but the egress interface
+    /// has NO address of the packet's family (a v4 packet on an egress interface
+    /// with only v6 addresses, or vice versa). Interface SNAT translates the
+    /// source to the egress interface's OWN same-family address; with none to
+    /// use there is nothing to translate to, so the flow fails CLOSED (drop +
+    /// count) rather than forwarding the private/internal source UNTRANSLATED
+    /// onto the egress — the leak this closes.
+    InterfaceNoEgressAddress,
 }
 
 impl SourceNatFailureReason {
@@ -116,6 +124,7 @@ impl SourceNatFailureReason {
             Self::DeterministicSubscriberOutOfRange => {
                 "source_nat_deterministic_subscriber_out_of_range"
             }
+            Self::InterfaceNoEgressAddress => "source_nat_interface_no_egress_address",
         }
     }
 }
@@ -1153,12 +1162,28 @@ pub(crate) fn match_source_nat_result_for_tuple(
         }
         *matched_counter = rule.hit_counter.clone();
         if rule.interface_mode {
+            // #5688: interface SNAT translates the source to the egress
+            // interface's OWN same-family address. Resolve it by the PACKET's
+            // family — a v4 packet needs a v4 egress address, a v6 packet a v6
+            // one. If the egress interface has NO address of that family there is
+            // nothing to translate to. Returning `Matched` with a `None` rewrite
+            // here forwarded the packet UNTRANSLATED — the private/internal source
+            // leaked onto the egress. Fail CLOSED instead: report `Unavailable`
+            // so the flow funnels through the same drop / `nat_alloc_fail`
+            // disposition a pool-mode allocation failure takes, and the leak
+            // cannot happen.
             let rewrite_src = match src_ip {
                 IpAddr::V4(_) => egress_v4.map(IpAddr::V4),
                 IpAddr::V6(_) => egress_v6.map(IpAddr::V6),
             };
+            let Some(rewrite_src) = rewrite_src else {
+                return SourceNatLookup::Unavailable(SourceNatFailure::for_rule(
+                    rule,
+                    SourceNatFailureReason::InterfaceNoEgressAddress,
+                ));
+            };
             return SourceNatLookup::Matched(NatDecision {
-                rewrite_src,
+                rewrite_src: Some(rewrite_src),
                 rewrite_dst: None,
                 ..NatDecision::default()
             });

--- a/userspace-dp/src/nat/tests_source.rs
+++ b/userspace-dp/src/nat/tests_source.rs
@@ -80,6 +80,151 @@ fn interface_source_nat_matches_v6_rule() {
     );
 }
 
+// === #5688: interface SNAT with no same-family egress address must fail CLOSED ===
+
+/// #5688 fail-on-revert: interface-mode SNAT translates the source to the egress
+/// interface's OWN address of the PACKET's family. When a v4 packet's egress
+/// interface has NO v4 address (only a v6 address here), there is nothing to
+/// translate to. Before the fix this returned `Matched` with a `None` rewrite,
+/// so the packet was forwarded with its private/internal source UNTRANSLATED —
+/// the leak. The fix fails CLOSED: `Unavailable(InterfaceNoEgressAddress)`, which
+/// funnels through the same drop / `nat_alloc_fail` disposition a pool-mode
+/// allocation failure takes. Reverting to `Matched`-with-`None` makes this panic
+/// (the returned lookup is no longer `Unavailable`). Passing a v6 egress address
+/// that must NOT be used also proves the RIGHT family is resolved.
+#[test]
+fn interface_source_nat_no_v4_egress_addr_fails_closed() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let lookup = match_source_nat_result(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "10.0.61.102".parse().expect("src"),
+        "172.16.80.200".parse().expect("dst"),
+        None, // egress interface has NO v4 address
+        // a v6 address is present but must NOT be used to translate a v4 packet
+        Some("2001:559:8585:80::8".parse().expect("egress v6")),
+    );
+    match lookup {
+        SourceNatLookup::Unavailable(f) => {
+            assert_eq!(f.reason, SourceNatFailureReason::InterfaceNoEgressAddress);
+        }
+        other => panic!(
+            "expected Unavailable (fail-closed drop), got {other:?} — a \
+             Matched-with-None-rewrite forwards the private source UNTRANSLATED (#5688 leak)"
+        ),
+    }
+}
+
+/// #5688 symmetric v6: a v6 packet whose egress interface has NO v6 address
+/// (only a v4 address present, which must NOT be used) fails closed the same
+/// way. Independent of the v4 branch — the dual-stack family check is per-packet.
+#[test]
+fn interface_source_nat_no_v6_egress_addr_fails_closed() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat6".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["::/0".to_string()],
+        interface_mode: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let lookup = match_source_nat_result(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "2001:559:8585:ef00::100".parse().expect("src"),
+        "2001:559:8585:80::200".parse().expect("dst"),
+        // a v4 address is present but must NOT be used to translate a v6 packet
+        Some("172.16.80.8".parse().expect("egress v4")),
+        None, // egress interface has NO v6 address
+    );
+    match lookup {
+        SourceNatLookup::Unavailable(f) => {
+            assert_eq!(f.reason, SourceNatFailureReason::InterfaceNoEgressAddress);
+        }
+        other => panic!(
+            "expected Unavailable (fail-closed drop), got {other:?} — a \
+             Matched-with-None-rewrite forwards the private source UNTRANSLATED (#5688 leak)"
+        ),
+    }
+}
+
+/// #5688 no-regression / dual-stack independence: the SAME lookup that fails
+/// closed for a family with no egress address still TRANSLATES when the egress
+/// interface HAS the packet's family address. A v6 packet is translated to the
+/// egress v6 address even though there is ALSO a v4 address present (which is
+/// irrelevant to a v6 packet), and vice versa — proving the working case is
+/// preserved and the families are resolved independently.
+#[test]
+fn interface_source_nat_translates_when_same_family_egress_addr_present() {
+    let rules = parse_source_nat_rules(&[
+        SourceNATRuleSnapshot {
+            name: "snat4".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["0.0.0.0/0".to_string()],
+            interface_mode: true,
+            ..SourceNATRuleSnapshot::default()
+        },
+        SourceNATRuleSnapshot {
+            name: "snat6".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["::/0".to_string()],
+            interface_mode: true,
+            ..SourceNATRuleSnapshot::default()
+        },
+    ]);
+    // v4 packet -> egress v4 address (v6 also present but unused).
+    let v4 = match_source_nat_result(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "10.0.61.102".parse().expect("src"),
+        "172.16.80.200".parse().expect("dst"),
+        Some("172.16.80.8".parse().expect("egress v4")),
+        Some("2001:559:8585:80::8".parse().expect("egress v6")),
+    );
+    assert_eq!(
+        v4,
+        SourceNatLookup::Matched(NatDecision {
+            rewrite_src: Some("172.16.80.8".parse().expect("snat v4")),
+            rewrite_dst: None,
+            ..NatDecision::default()
+        })
+    );
+    // v6 packet -> egress v6 address (v4 also present but unused).
+    let v6 = match_source_nat_result(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "2001:559:8585:ef00::100".parse().expect("src"),
+        "2001:559:8585:80::200".parse().expect("dst"),
+        Some("172.16.80.8".parse().expect("egress v4")),
+        Some("2001:559:8585:80::8".parse().expect("egress v6")),
+    );
+    assert_eq!(
+        v6,
+        SourceNatLookup::Matched(NatDecision {
+            rewrite_src: Some("2001:559:8585:80::8".parse().expect("snat v6")),
+            rewrite_dst: None,
+            ..NatDecision::default()
+        })
+    );
+}
+
 #[test]
 fn off_rule_short_circuits_translation() {
     let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {


### PR DESCRIPTION
## Problem (#5688, Rust NAT security/correctness M05)

Interface-mode source NAT translates the source to the **egress interface's own address of the packet's family**. In `match_source_nat_result_for_tuple` (`userspace-dp/src/nat/source.rs`) the `interface_mode` branch resolved `rewrite_src` from `egress_v4`/`egress_v6` and returned `SourceNatLookup::Matched` **unconditionally** — including when that address was `None`:

```rust
let rewrite_src = match src_ip {
    IpAddr::V4(_) => egress_v4.map(IpAddr::V4),
    IpAddr::V6(_) => egress_v6.map(IpAddr::V6),
};
return SourceNatLookup::Matched(NatDecision { rewrite_src, .. }); // rewrite_src may be None!
```

A `Matched` decision carrying a `None` source rewrite forwards the packet **UNTRANSLATED**. So a v4 packet whose egress interface has no v4 address (or a v6 packet with no v6 egress address) leaked its **private/internal source onto the egress** — the exact leak interface SNAT exists to prevent. Confirmed live on origin/master `04e1527ab` (provenance M05, `fc479ca65`).

## Fix (fail closed)

When the same-family egress address is absent, return `SourceNatLookup::Unavailable(SourceNatFailureReason::InterfaceNoEgressAddress)` (new runtime-only reason, exception string `source_nat_interface_no_egress_address`) instead of `Matched`-with-`None`. That funnels through the **same drop / `nat_alloc_fail` disposition** (`record_source_nat_failure` in `poll_descriptor/nat_exception.rs`) a pool-mode allocation failure takes — so the flow is dropped **and counted**, with consistent telemetry.

- **Disposition-only** change (`Matched` → `Unavailable` on the no-same-family-egress-address branch). **No NAT tuple / map-key / wire layout change.**
- Families resolved **independently**: a v4 packet checks the v4 egress address, a v6 packet the v6 one.
- **Working case preserved**: egress HAS a same-family address → still translates (no regression).

## Validation

- `cargo test --release` **full suite: 3945 passed / 0 failed**.
- **Fail-on-revert proven**: reverting to `Matched`-with-`None`-rewrite turns `interface_source_nat_no_v4_egress_addr_fails_closed` and `interface_source_nat_no_v6_egress_addr_fails_closed` **RED**, while the no-regression / dual-stack test `interface_source_nat_translates_when_same_family_egress_addr_present` stays **GREEN**.
- Smoke deferred (loss-cluster shim-wall) — unit-covered fail-closed.

Docs: `userspace-dp/README.md` source-NAT semantics bullet + `_Log.md`.

Closes #5688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi