### PR TITLE
routing: reject per-instance next-table, drop userspace-only leak

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,48 @@
+## 2026-07-16 — #5830 (routing): per-instance next-table diverges between userspace and kernel/FRR (split-brain leak)
+- **Timestamp**: 2026-07-16 (fix/5830-per-instance-nexttable)
+- **Action**: Fix #5830. STEP-0 on origin/master 04e1527ab confirmed the
+  divergence across all three surfaces: `validateNextTableTargetReferencesStrict`
+  (`pkg/config/compiler_validate_strict_routing.go`) validated only GLOBAL
+  inet.0/inet6.0 next-table targets; `daemon_apply.go` feeds only global statics
+  to `ApplyNextTableRules` and `pkg/frr/config_render.go` renders nothing for a
+  NextTable route (kernel/FRR OMIT per-instance next-table); yet
+  `pkg/dataplane/userspace/routes.go` PUBLISHED every routing-instance's
+  next-table as a live `NextTable` snapshot in `<inst>.inet[6].0`. Result: a
+  committed per-instance next-table leaks in the userspace dataplane with no
+  kernel/FRR equivalent, and an UNDEFINED per-instance target bypassed the #5693
+  commit gate. **Direction chosen: (A) reject-consistently** — per-instance
+  next-table is NOT a supported/programmed feature (the kernel ip rule is a
+  global destination-only `to <dst> lookup <table>` with no source-table
+  scoping; true per-instance support needs iif/fwmark source-scoped rules, the
+  same substrate deferred to rib-group VRF→VRF Phase 2), so full-parity (B) is a
+  feature-add, out of scope. Fix: (1) extend
+  `validateNextTableTargetReferencesStrict` to hard-reject ANY per-instance
+  next-table at commit (defined or undefined; undefined additionally named),
+  strict on commit/commit-check, downgraded to a warning on tolerant load /
+  peer-sync via the existing `lenientNextTableRefs` flag (#1960 no-brick); (2)
+  `buildRouteSnapshots` no longer publishes a per-instance next-table
+  (`perInstance` guard in `addRoutes`) — global next-table still published (it
+  IS programmed via ip rule). Now all three surfaces agree per-instance
+  next-table is absent, the #5693 bypass is closed, and no userspace/kernel
+  forwarding divergence remains.
+- **File(s)**: pkg/config/compiler_validate_strict_routing.go,
+  pkg/dataplane/userspace/routes.go,
+  pkg/config/compiler_routing_nexttable_perinstance_5830_test.go (new),
+  pkg/dataplane/userspace/routes_perinstance_nexttable_5830_test.go (new),
+  pkg/dataplane/userspace/manager_routes_test.go (payload updated to a next-hop —
+  the old vehicle was a now-dropped per-instance next-table),
+  docs/rib-group-route-leaking.md, _Log.md
+- **Validation**: `go build ./...` clean; `go test -race ./pkg/config`
+  (153s, PASS), `./pkg/routing` (PASS), `./pkg/dataplane/userspace` (28.5s,
+  PASS); `go vet` clean. FAIL-ON-REVERT proven both directions: gating the
+  userspace `perInstance` skip → `TestBuildRouteSnapshotsDropsPerInstanceNextTable_5830`
+  RED (per-instance NextTable snapshot reappears); neutering the validator's
+  per-instance loop → all 4 `TestPerInstanceNextTableRejected_5830` subtests RED.
+  Pre-existing (unrelated) failure noted: `pkg/dataplane`
+  `TestUserspaceManagerDoesNotImportReflectOrUnsafe` flags `manager_overlay.go`
+  importing `reflect` — that file is byte-identical to origin/master and
+  untouched by this change.
+
 ## 2026-07-16 — #5566 (daemon): stale kernel host-inbound authorization after a coarse tightening (security fail-open)
 - **Timestamp**: 2026-07-16 (fix/5566-hostinbound-conntrack-flush)
 - **Action**: Fix #5566 (security fail-open, direct-kernel host-inbound path).

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -188,6 +188,52 @@ to `ApplyNextTableRules`. Strict on commit / commit-check; downgraded to a
 warning on the tolerant load / peer-sync paths (`opts.lenientNextTableRefs`,
 #1960 no-brick) since the applier keeps a dangling next-table inert.
 
+### Strict rejection — per-instance `next-table` is unsupported (#5830)
+
+`next-table` is only implemented for the **global** `routing-options` static
+routes. A `next-table` authored **under a routing-instance** was accepted at
+commit but the three forwarding surfaces diverged:
+
+- the strict definedness gate above only inspected the global `inet.0` /
+  `inet6.0` routes, so an undefined per-instance target bypassed the #5693
+  protection entirely;
+- `daemon_apply` feeds only `cfg.RoutingOptions.Static/Inet6StaticRoutes` to
+  `ApplyNextTableRules` (`pkg/routing.nextTableManager.Apply`), and the FRR
+  renderer emits nothing for a `NextTable` route
+  (`pkg/frr/config_render.go`), so the **kernel/FRR** plane omitted the
+  per-instance route entirely;
+- the **userspace** FIB builder published it as a live `NextTable` route in the
+  instance's `<inst>.inet[6].0` table (`pkg/dataplane/userspace/routes.go`).
+
+The same committed config therefore **leaked traffic in the userspace
+dataplane** while the kernel/FRR view had no equivalent route — a
+control-plane/data-plane split-brain, not merely a missing diagnostic.
+
+Because per-instance `next-table` is **not programmed on any kernel/FRR
+surface**, the fix makes the three surfaces agree that it is *not a live
+forwarding route*:
+
+- `validateNextTableTargetReferencesStrict` now **hard-rejects at commit** ANY
+  `next-table` under a routing-instance — defined *or* undefined target (an
+  undefined target's error additionally names it). Strict on commit /
+  commit-check; downgraded to a warning on the tolerant load / peer-sync paths
+  (`opts.lenientNextTableRefs`, #1960 no-brick) so an already-persisted or
+  peer-synced legacy config still boots.
+- `buildRouteSnapshots` no longer publishes a per-instance `next-table` into the
+  userspace FIB (`perInstance` guard in `addRoutes`). GLOBAL `next-table` IS
+  programmed via `ip rule` and stays published so the Rust FIB can
+  cross-reference the target table. A leniently-loaded legacy per-instance
+  `next-table` is thus inert on **both** planes.
+
+Supporting per-instance `next-table` for real is a **feature**, not a bug fix:
+the kernel `ip rule` the applier programs is a global destination-only
+`to <dst> lookup <table>` with no source-table scoping, so honoring a
+per-instance leak would need **source-table-scoped** (`iif`/fwmark) rules —
+the same substrate the rib-group **VRF→VRF import** target is deferred to
+Phase 2 for (see *Deferred* below). Appending per-instance routes to the
+existing global `ApplyNextTableRules` call would lose source-table identity and
+could steer traffic from unrelated VRFs, so it is deliberately **not** done.
+
 ### Strict rejection — contradictory static-route dispositions (#5633)
 
 A single static-route destination may carry only **one** disposition: a

--- a/pkg/config/compiler_routing_nexttable_perinstance_5830_test.go
+++ b/pkg/config/compiler_routing_nexttable_perinstance_5830_test.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPerInstanceNextTableRejected_5830 proves the #5830 fix: a `next-table`
+// authored UNDER a routing-instance is hard-rejected at the strict commit path
+// (CompileConfig). Before the fix it was accepted at commit, omitted from the
+// kernel/FRR forwarding plane, yet PUBLISHED as a live NextTable route in the
+// instance's userspace FIB table — a control-plane/data-plane split-brain that
+// leaked traffic in the userspace dataplane only, and (for an undefined
+// target) sidestepped the #5693 definedness gate.
+//
+// Per-instance next-table is not a supported forwarding disposition (it is not
+// programmed on any kernel/FRR surface), so BOTH a defined and an undefined
+// target are rejected.
+//
+// FAIL-ON-REVERT: removing the per-instance loop from
+// validateNextTableTargetReferencesStrict makes CompileConfig accept these
+// configs, so every reject assertion below fires RED.
+func TestPerInstanceNextTableRejected_5830(t *testing.T) {
+	t.Run("inet-defined-target", func(t *testing.T) {
+		// The target instance IS defined, but per-instance next-table is still
+		// unsupported (never programmed on kernel/FRR) so it must be rejected.
+		tree := flatTreeFromSets(t,
+			"set routing-instances leaker instance-type virtual-router",
+			"set routing-instances target instance-type virtual-router",
+			"set routing-instances leaker routing-options static route 10.0.0.0/8 next-table target.inet.0",
+		)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("expected CompileConfig to reject a per-instance next-table (defined target)")
+		}
+		if !strings.Contains(err.Error(), "routing-instances leaker") ||
+			!strings.Contains(err.Error(), "not supported") {
+			t.Fatalf("error %q must name the offending instance and flag the unsupported disposition", err.Error())
+		}
+	})
+
+	t.Run("inet-undefined-target", func(t *testing.T) {
+		// The target instance is NOT defined — this is the #5693-bypass case:
+		// the global gate never saw a per-instance route, so an undefined
+		// per-instance target used to commit green.
+		tree := flatTreeFromSets(t,
+			"set routing-instances leaker instance-type virtual-router",
+			"set routing-instances leaker routing-options static route 10.0.0.0/8 next-table Nope.inet.0",
+		)
+		err := mustRejectCompile(t, tree)
+		if !strings.Contains(err.Error(), "Nope.inet.0") {
+			t.Fatalf("error %q must quote the raw next-table token", err.Error())
+		}
+		if !strings.Contains(err.Error(), "undefined") {
+			t.Fatalf("error %q must note the undefined target", err.Error())
+		}
+	})
+
+	t.Run("inet6-undefined-target", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-instances leaker instance-type virtual-router",
+			"set routing-instances leaker routing-options rib leaker.inet6.0 static route ::/0 next-table Nope.inet6.0",
+		)
+		mustRejectCompile(t, tree)
+	})
+
+	t.Run("hierarchical-defined-target", func(t *testing.T) {
+		tree := hierTree(t, `routing-instances {
+    target {
+        instance-type virtual-router;
+    }
+    leaker {
+        instance-type virtual-router;
+        routing-options {
+            static {
+                route 10.0.0.0/8 {
+                    next-table target.inet.0;
+                }
+            }
+        }
+    }
+}`)
+		mustRejectCompile(t, tree)
+	})
+}
+
+// TestPerInstanceNextTableLenientDowngrade_5830 proves the tolerant load /
+// peer-sync path (CompileConfigLenient) does NOT brick on an already-persisted
+// or peer-synced legacy config carrying a per-instance next-table: it compiles
+// with a persistent WARNING instead (#1960 no-brick). The userspace snapshot
+// drops the route and the kernel/FRR plane never programmed it, so the config
+// boots inert.
+func TestPerInstanceNextTableLenientDowngrade_5830(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set routing-instances leaker instance-type virtual-router",
+		"set routing-instances target instance-type virtual-router",
+		"set routing-instances leaker routing-options static route 10.0.0.0/8 next-table target.inet.0",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant load must NOT brick on a per-instance next-table, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "next-table") && strings.Contains(w, "downgraded to warning") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("tolerant load must emit a persistent next-table warning, got warnings %v", cfg.Warnings)
+	}
+}
+
+// TestGlobalNextTableUnaffected_5830 guards against regression: the GLOBAL
+// routing-options next-table path (defined target accepted, undefined target
+// rejected by the #5693 definedness gate) is unchanged by the #5830
+// per-instance rejection.
+func TestGlobalNextTableUnaffected_5830(t *testing.T) {
+	t.Run("global-defined-accepted", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-instances Comcast instance-type virtual-router",
+			"set routing-options static route 0.0.0.0/0 next-table Comcast.inet.0",
+		)
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("a global next-table with a defined target must still compile, got %v", err)
+		}
+		if len(cfg.RoutingOptions.StaticRoutes) != 1 ||
+			cfg.RoutingOptions.StaticRoutes[0].NextTable != "Comcast" {
+			t.Fatalf("global next-table route not compiled as expected: %+v", cfg.RoutingOptions.StaticRoutes)
+		}
+	})
+
+	t.Run("global-undefined-rejected", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 0.0.0.0/0 next-table Ghost.inet.0",
+		)
+		err := mustRejectCompile(t, tree)
+		// The global gate reports "undefined routing-instance", not the
+		// per-instance "not supported" wording.
+		if !strings.Contains(err.Error(), "undefined") {
+			t.Fatalf("global undefined next-table error %q must flag the undefined target", err.Error())
+		}
+	})
+}
+
+func mustRejectCompile(t *testing.T, tree *ConfigTree) error {
+	t.Helper()
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected CompileConfig to reject the config")
+	}
+	return err
+}

--- a/pkg/config/compiler_validate_strict_routing.go
+++ b/pkg/config/compiler_validate_strict_routing.go
@@ -741,12 +741,22 @@ func ribInstanceFromName(ribName string) (string, bool) {
 // so a "Comcst.inet.0" typo is quoted verbatim rather than as the stripped
 // "Comcst".
 //
-// Only the GLOBAL inet.0 + inet6.0 static routes are validated — those are
-// exactly the routes daemon_apply feeds to ApplyNextTableRules
-// (daemon_apply.go); next-table on a per-instance static route is never
-// programmed, so validating it would reject a target the applier never
-// resolves. Routes are walked inet.0 then inet6.0 in declaration order so the
-// first-reported error is deterministic.
+// The GLOBAL inet.0 + inet6.0 static routes are validated for target
+// DEFINEDNESS — those are exactly the routes daemon_apply feeds to
+// ApplyNextTableRules (daemon_apply.go). A next-table authored UNDER a
+// routing-instance is a different case (#5830): it is not programmed on the
+// kernel/FRR plane AT ALL (daemon_apply passes only the global statics; the
+// FRR renderer emits nothing for a NextTable route) yet the userspace FIB used
+// to publish it as a live route — a split-brain that leaked traffic in the
+// userspace dataplane with no kernel/FRR equivalent and, for an undefined
+// target, bypassed the definedness gate above. So the second loop rejects ANY
+// per-instance next-table as an unsupported forwarding disposition (defined or
+// undefined target); the userspace snapshot no longer publishes it
+// (pkg/dataplane/userspace/routes.go). Supporting per-instance next-table for
+// real needs source-table-scoped (iif/fwmark) ip rules — a feature deferred
+// alongside the rib-group VRF->VRF Phase-2 work, not a bug fix. Routes are
+// walked inet.0 then inet6.0 in declaration order so the first-reported error
+// is deterministic.
 //
 // Strict on commit / commit-check (hard reject so the typo is operator-
 // visible); the call site downgrades this to a warning on the tolerant load /
@@ -787,6 +797,49 @@ func validateNextTableTargetReferencesStrict(cfg *Config) error {
 					"leak is silently dropped at apply time and matching traffic "+
 					"follows the ingress table's own routes",
 				sr.Destination, raw, sr.NextTable, sr.NextTable)
+		}
+	}
+
+	// #5830: reject ANY next-table authored under a routing-instance. Unlike
+	// the global routes above, a per-instance next-table is not programmed on
+	// the kernel/FRR forwarding plane (see this function's doc comment), so a
+	// defined OR undefined target is unsupported — accepting it published a
+	// userspace-only NextTable leak with no kernel/FRR equivalent (a split-
+	// brain) and let an undefined per-instance target sidestep the definedness
+	// gate above. Walk each instance's inet.0 then inet6.0 route set in
+	// declaration order so the first-reported error is deterministic. Strict on
+	// commit / commit-check; downgraded to a warning on the tolerant load /
+	// peer-sync paths (opts.lenientNextTableRefs — same wiring as the global
+	// gate) so an already-persisted or peer-synced legacy config carrying a
+	// per-instance next-table still BOOTS (the userspace snapshot drops it and
+	// the kernel/FRR plane never programmed it, so it stays inert).
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil || ri.Name == "" {
+			continue
+		}
+		for _, routes := range [][]*StaticRoute{ri.StaticRoutes, ri.Inet6StaticRoutes} {
+			for _, sr := range routes {
+				if sr == nil || sr.NextTable == "" {
+					continue
+				}
+				raw := sr.NextTableRaw
+				if raw == "" {
+					raw = sr.NextTable
+				}
+				undefinedNote := ""
+				if !definedInstance[sr.NextTable] {
+					undefinedNote = fmt.Sprintf(
+						" (its target routing-instance %q is also undefined)", sr.NextTable)
+				}
+				return fmt.Errorf(
+					"routing-instances %s static route %q next-table %q is not "+
+						"supported: a next-table under a routing-instance is not "+
+						"programmed on the kernel/FRR forwarding plane and would "+
+						"leak only in the userspace dataplane (a split-brain); move "+
+						"the leak to the global `routing-options static route %s "+
+						"next-table %s` or remove it%s",
+					ri.Name, sr.Destination, raw, sr.Destination, raw, undefinedNote)
+			}
 		}
 	}
 	return nil

--- a/pkg/dataplane/userspace/manager_routes_test.go
+++ b/pkg/dataplane/userspace/manager_routes_test.go
@@ -16,7 +16,13 @@ func TestBuildRouteSnapshotsNormalizesFamilyFromDestination(t *testing.T) {
 		{
 			Name: "blue",
 			StaticRoutes: []*config.StaticRoute{
-				{Destination: "2001:db8:1::/64", NextTable: "core"},
+				// #5830: a per-instance next-table is now DROPPED from the
+				// userspace snapshot (it is not programmed on kernel/FRR — a
+				// split-brain). This test only exercises family-normalization
+				// from the destination, so use a forwarding next-hop route (which
+				// survives) as the vehicle. A v6 destination in the inet-labeled
+				// StaticRoutes list must still normalize to inet6 / blue.inet6.0.
+				{Destination: "2001:db8:1::/64", NextHops: []config.NextHopEntry{{Address: "2001:db8:1::1"}}},
 			},
 		},
 	}

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -55,9 +55,27 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 		seen[key] = struct{}{}
 		out = append(out, snap)
 	}
-	addRoutes := func(table, family string, routes []*config.StaticRoute) {
+	addRoutes := func(table, family string, routes []*config.StaticRoute, perInstance bool) {
 		for _, route := range routes {
 			if route == nil {
+				continue
+			}
+			// #5830: a `next-table` authored UNDER a routing-instance is NOT
+			// programmed on the kernel/FRR forwarding plane — daemon_apply feeds
+			// only the GLOBAL routing-options statics to ApplyNextTableRules, the
+			// FRR renderer emits nothing for a NextTable route, and the kernel
+			// ip-rule leak carries no source-table scoping. Publishing it here as
+			// a live per-instance NextTable route made the userspace FIB leak
+			// traffic the kernel/FRR view never routes — a control-plane/data-
+			// plane split-brain. Skip it so both planes agree the per-instance
+			// next-table is ABSENT. The commit-time gate
+			// (validateNextTableTargetReferencesStrict, #5830) hard-rejects such a
+			// config; this companion drop keeps a tolerantly-loaded / peer-synced
+			// legacy config (its reject downgraded to a warning, #1960 no-brick)
+			// from leaking in the userspace dataplane. GLOBAL next-table
+			// (perInstance == false) IS programmed via ip rule and stays
+			// published so the Rust FIB can cross-reference the target table.
+			if perInstance && route.NextTable != "" {
 				continue
 			}
 			tableName, familyName := normalizeRouteSnapshotFamily(table, family, route.Destination)
@@ -154,8 +172,8 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 			addSnapshot(snap)
 		}
 	}
-	addRoutes("inet.0", "inet", cfg.RoutingOptions.StaticRoutes)
-	addRoutes("inet6.0", "inet6", cfg.RoutingOptions.Inet6StaticRoutes)
+	addRoutes("inet.0", "inet", cfg.RoutingOptions.StaticRoutes, false)
+	addRoutes("inet6.0", "inet6", cfg.RoutingOptions.Inet6StaticRoutes, false)
 
 	if len(cfg.RoutingInstances) > 0 {
 		insts := make([]*config.RoutingInstanceConfig, 0, len(cfg.RoutingInstances))
@@ -166,8 +184,8 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 		}
 		sort.Slice(insts, func(i, j int) bool { return insts[i].Name < insts[j].Name })
 		for _, ri := range insts {
-			addRoutes(ri.Name+".inet.0", "inet", ri.StaticRoutes)
-			addRoutes(ri.Name+".inet6.0", "inet6", ri.Inet6StaticRoutes)
+			addRoutes(ri.Name+".inet.0", "inet", ri.StaticRoutes, true)
+			addRoutes(ri.Name+".inet6.0", "inet6", ri.Inet6StaticRoutes, true)
 		}
 	}
 	for _, iface := range interfaces {

--- a/pkg/dataplane/userspace/routes_perinstance_nexttable_5830_test.go
+++ b/pkg/dataplane/userspace/routes_perinstance_nexttable_5830_test.go
@@ -1,0 +1,102 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// TestBuildRouteSnapshotsDropsPerInstanceNextTable_5830 proves the userspace
+// half of the #5830 fix: a `next-table` authored UNDER a routing-instance is
+// NOT published as a live NextTable route in the instance's FIB table.
+//
+// Before the fix, buildRouteSnapshots copied every per-instance static route's
+// NextTable into the helper snapshot, so the userspace dataplane leaked traffic
+// the kernel/FRR forwarding plane never routes (daemon_apply feeds only global
+// statics to ApplyNextTableRules, and the FRR renderer emits nothing for a
+// NextTable route) — a control-plane/data-plane split-brain. Dropping the
+// per-instance next-table makes both planes agree the route is ABSENT.
+//
+// FAIL-ON-REVERT: restoring the userspace-only publication (removing the
+// `perInstance && route.NextTable != ""` skip in addRoutes) re-adds the
+// NextTable snapshot into <inst>.inet.0 / <inst>.inet6.0, so the assertions
+// below fire RED.
+func TestBuildRouteSnapshotsDropsPerInstanceNextTable_5830(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	// Per-instance next-table is never programmed as a kernel ip-rule, so the
+	// live rule table lists nothing for it.
+	ruleListFn = func(family int) ([]netlink.Rule, error) { return nil, nil }
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{
+			Name:    "leaker",
+			TableID: 101,
+			StaticRoutes: []*config.StaticRoute{
+				// The divergent case: a per-instance next-table leak.
+				{Destination: "10.0.0.0/8", NextTable: "target", NextTableRaw: "target.inet.0"},
+				// A legitimate per-instance forwarding route MUST still publish —
+				// the fix drops only next-table, not the whole instance route set.
+				{Destination: "192.0.2.0/24", NextHops: []config.NextHopEntry{{Address: "10.9.9.1"}}},
+			},
+			Inet6StaticRoutes: []*config.StaticRoute{
+				{Destination: "2001:db8::/32", NextTable: "target", NextTableRaw: "target.inet6.0"},
+			},
+		},
+		{Name: "target", TableID: 102},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+
+	sawForwarding := false
+	for _, r := range routes {
+		if r.NextTable != "" {
+			t.Fatalf("no per-instance next-table must be published, got %+v", r)
+		}
+		if r.Table == "leaker.inet.0" && r.Destination == "192.0.2.0/24" {
+			sawForwarding = true
+		}
+	}
+	if !sawForwarding {
+		t.Fatal("a per-instance FORWARDING route must still be published; the fix must drop only next-table, not the whole instance route set")
+	}
+}
+
+// TestBuildRouteSnapshotsKeepsGlobalNextTable_5830 guards against regression: a
+// GLOBAL routing-options next-table IS programmed on the kernel (via ip rule)
+// and MUST stay published in the userspace snapshot so the Rust FIB can
+// cross-reference the target table. The #5830 fix drops ONLY per-instance
+// next-table.
+func TestBuildRouteSnapshotsKeepsGlobalNextTable_5830(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(family int) ([]netlink.Rule, error) { return nil, nil }
+
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "0.0.0.0/0", NextTable: "Comcast", NextTableRaw: "Comcast.inet.0"},
+	}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "Comcast", TableID: 201},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+
+	found := false
+	for _, r := range routes {
+		if r.Table == "inet.0" && r.Destination == "0.0.0.0/0" && r.NextTable == "Comcast" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("a GLOBAL next-table route must remain published in the userspace snapshot")
+	}
+}


### PR DESCRIPTION
## Problem (#5830)

A static `next-table` route authored **inside a routing-instance** was accepted at commit, but the three forwarding surfaces diverged:

- **Validator** — `validateNextTableTargetReferencesStrict` (the #5693 definedness gate) inspected only the **global** `inet.0`/`inet6.0` routes, so an undefined per-instance target bypassed the commit-time protection.
- **Kernel/FRR** — `daemon_apply` feeds only `cfg.RoutingOptions.Static/Inet6StaticRoutes` to `ApplyNextTableRules`, and `pkg/frr/config_render.go` renders nothing for a `NextTable` route → the per-instance route was **omitted entirely**.
- **Userspace FIB** — `buildRouteSnapshots` **published** it as a live `NextTable` route in the instance's `<inst>.inet[6].0` table.

Net effect: the same committed config **leaked traffic in the userspace dataplane** while the kernel/FRR view had no equivalent route (a control-plane/data-plane split-brain), and undefined per-instance targets sidestepped #5693.

## Direction chosen: (A) reject-consistently

Per-instance next-table is **not a supported/programmed feature**. The kernel `ip rule` the applier installs is a global destination-only `to <dst> lookup <table>` with **no source-table scoping**; honoring a per-instance leak would need source-table-scoped (`iif`/fwmark) rules — the same substrate the rib-group VRF→VRF import target is deferred to **Phase 2** for. Appending per-instance routes to the global `ApplyNextTableRules` call would lose source-table identity and could steer traffic from unrelated VRFs (the issue warns against exactly this). Full parity (B) is therefore a **feature-add, out of scope**; the userspace publish is the bug.

The fix makes all three surfaces agree that per-instance next-table is **not a live forwarding route**:

1. `validateNextTableTargetReferencesStrict` now **hard-rejects at commit** ANY next-table under a routing-instance (defined or undefined target; an undefined target is additionally named). Strict on commit / commit-check; downgraded to a warning on tolerant load / peer-sync via the existing `lenientNextTableRefs` flag (#1960 no-brick) so an already-persisted or peer-synced legacy config still boots.
2. `buildRouteSnapshots` no longer publishes a per-instance next-table (a `perInstance` guard in `addRoutes`). **Global** next-table IS programmed via `ip rule` and stays published so the Rust FIB can cross-reference the target table. A leniently-loaded legacy per-instance next-table is thus inert on **both** planes.

## Tests — FAIL-ON-REVERT (both directions proven RED)

- `TestPerInstanceNextTableRejected_5830` — per-instance next-table (defined + undefined target, inet + inet6, flat-set + hierarchical shapes) rejected at commit. Neutering the validator's per-instance loop → all 4 subtests RED.
- `TestBuildRouteSnapshotsDropsPerInstanceNextTable_5830` — userspace snapshot carries no per-instance NextTable route, while a per-instance **forwarding** route still publishes (fix drops only next-table, not the whole instance route set). Restoring the userspace-only publication → RED.
- Regression guards: `TestPerInstanceNextTableLenientDowngrade_5830` (tolerant load warns, does not brick), `TestGlobalNextTableUnaffected_5830` + `TestBuildRouteSnapshotsKeepsGlobalNextTable_5830` (global next-table validation + publication unchanged).
- `manager_routes_test` — the family-normalization test used a now-dropped per-instance next-table purely as its vehicle; switched to a next-hop route so it keeps exercising normalization.

## Validation

`go build ./...` clean; `go test -race ./pkg/config` (153s), `./pkg/routing`, `./pkg/dataplane/userspace` (28.5s) all PASS; `go vet` clean.

Pre-existing unrelated failure noted: `pkg/dataplane` `TestUserspaceManagerDoesNotImportReflectOrUnsafe` flags `manager_overlay.go` importing `reflect` — that file is byte-identical to origin/master and untouched here.

Closes #5830

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi