### PR TITLE
HA config-sync: reconcile the config-push invariant to desired state (#5863)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-16 — #5863 (HA config-sync): level-triggered reconcile of the config-push invariant
+- **Timestamp**: 2026-07-16 (fix/5863-ha-configsync-reconcile)
+- **Action**: Fix #5863. Config replication to a reconnecting peer was
+  EDGE-TRIGGERED only by `OnPeerConnected`, which skipped the push when the node
+  was not RG0 primary at connect time OR had been up <30s — and nothing
+  re-evaluated the skipped work on a LATER promotion or 30s-stability crossing,
+  so a peer could stay INDEFINITELY divergent until an unrelated commit/reconnect.
+  Replaced the connect-only edge with reconcile-to-desired:
+  `reconcileConfigSyncToPeer` re-evaluates the invariant (RG0 authority AND
+  stable AND peer connected AND config-sync enabled AND current generation not
+  yet pushed on this connection) and pushes ONLY on divergence, at most once per
+  `(peer-connection-epoch × config-generation)`. Triggers: peer (re)connect
+  (`OnPeerConnected`), RG0 promotion (`applyRG0OwnershipTransition`), and a
+  low-frequency `configSyncReconcileLoop` that wakes at the stability threshold
+  and thereafter on a coarse 30s safety-net tick. `syncPeerConnEpoch` is bumped
+  on each connect so a fresh connection re-pushes; the commit-path push records
+  the same marker so a subsequent reconcile is a no-op. Control-socket-safe: an
+  already-satisfied evaluation is a cheap no-op (state gates + one hash, no
+  `QueueConfig`); stays RG0-primary-gated so a reconnecting SECONDARY never
+  overwrites authoritative config (#2239/#4385).
+- **File(s)**: pkg/daemon/daemon.go (marker/epoch/test-seam fields),
+  pkg/daemon/daemon_ha_sync.go (reconciler + loop + epoch bump + push marking +
+  OnPeerConnected rewire), pkg/daemon/daemon_ha.go (RG0-promotion hook),
+  pkg/daemon/configsync_reconcile_5863_test.go (fail-on-revert + regression
+  tests), docs/sync-protocol.md (reconcile-side trigger doc).
+- **Validation**: `go build ./...`, `go vet ./pkg/daemon`, `go test -race
+  ./pkg/daemon` all green; fail-on-revert proven (neutralize reconciler → RED,
+  restore → GREEN). Smoke (`test-failover`) blocked by the loss-cluster shim-ABI
+  wall; gated on the fail-on-revert unit tests.
+
 ## 2026-07-16 — #5830 (routing): per-instance next-table diverges between userspace and kernel/FRR (split-brain leak)
 - **Timestamp**: 2026-07-16 (fix/5830-per-instance-nexttable)
 - **Action**: Fix #5830. STEP-0 on origin/master 04e1527ab confirmed the

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -330,10 +330,37 @@ until an unrelated transport-disconnect reverse-sync — an RG failover could th
 silently restore config the operator believed changed. The autonomous
 event-options engine is the deliberate exception: it commits with
 `syncPeer=false` because each node fires remediation independently from its own
-RPM events and must not push node-local state to the peer. There is no periodic
-config reconcile ticker — convergence is driven by the commit push plus the
-reverse-sync-on-reconnect path, so the commit-side trigger MUST fire on every
-operator transport.
+RPM events and must not push node-local state to the peer. The commit-side
+trigger MUST still fire on every operator transport (a commit is the only edge
+that carries a *new* generation), but it is no longer the sole convergence path
+— the reconcile-side trigger below closes the connect/role/uptime ordering gap.
+
+**Reconnect/reconcile-side trigger — level-triggered (#5863).** The commit push
+alone is not sufficient. A peer can (re)connect while this node is not yet the
+RG0 authority or is still within the post-boot stability window; the historical
+code pushed only from the `OnPeerConnected` edge and evaluated the
+primary/stability gates *only at connect time*, so a **later** promotion or the
+crossing of the 30s stability threshold never re-pushed — the peer could stay
+INDEFINITELY divergent until an unrelated commit/reconnect. The push is now
+modeled as reconciliation to a desired state, not a one-shot edge.
+`reconcileConfigSyncToPeer` (`pkg/daemon/daemon_ha_sync.go`) re-evaluates the
+invariant — *this node is the RG0 config authority (`rg0ConfigSyncAuthority`)
+AND stable (uptime ≥ 30s) AND a peer is connected AND config sync is enabled AND
+the current config generation has not already been pushed on this peer's current
+connection* — and pushes ONLY when desired-vs-actual diverges, at most once per
+`(peer-connection-epoch × config-generation)`. It is invoked on every input
+change: peer (re)connect (`OnPeerConnected`), RG0 promotion
+(`applyRG0OwnershipTransition`), and a low-frequency reconcile loop
+(`configSyncReconcileLoop`) that wakes at the stability threshold and thereafter
+on a coarse 30s safety-net tick to recover any dropped promotion/connect edge.
+The `(epoch × generation)` marker makes every already-satisfied evaluation a
+cheap no-op (state gates + one config-text hash, no `QueueConfig`), so the
+shared userspace control socket never sees a push storm and session installs are
+never starved during bulk sync — the control-socket-contention rule. The
+reconcile stays RG0-primary-gated exactly like the commit push, so a
+reconnecting SECONDARY never overwrites the authoritative primary's config
+(#2239/#4385); a fresh connection bumps the epoch, so it always re-receives the
+config even when the generation is unchanged.
 
 **Ordering guard (#3931).** Config sync historically applied via a racing
 `go OnConfigReceived` goroutine per message with no sequence number, so a rapid

--- a/pkg/daemon/configsync_reconcile_5863_test.go
+++ b/pkg/daemon/configsync_reconcile_5863_test.go
@@ -1,0 +1,240 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// newConfigSyncStore builds a committed store whose active config enables
+// chassis-cluster configuration-synchronize, so ActiveConfig().Chassis.Cluster
+// .ConfigSync is true and the reconciler reaches its push decision. hostName
+// lets a caller mutate the active generation (a later commit changes the
+// config text → a new configGenerationHash).
+func newConfigSyncStore(t *testing.T, hostName string) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "config"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, cmd := range []string{
+		"chassis cluster cluster-id 1",
+		"chassis cluster node 0",
+		"chassis cluster configuration-synchronize",
+		"system host-name " + hostName,
+	} {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q): %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || cfg.Chassis.Cluster == nil || !cfg.Chassis.Cluster.ConfigSync {
+		t.Fatalf("config-sync not enabled in active config: %#v", cfg)
+	}
+	return store
+}
+
+// commitHostName mutates the active config (new host-name) so the reconciler's
+// config-generation token changes, modeling an operator commit while the peer
+// connection stays up.
+func commitHostName(t *testing.T, store *configstore.Store, hostName string) {
+	t.Helper()
+	// The store stays in configure mode after the initial Commit, so no
+	// EnterConfigure here (a second EnterConfigure would self-conflict on the
+	// held config lock).
+	if err := store.SetFromInput("system host-name " + hostName); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+}
+
+// newReconcileDaemon wires a Daemon for the reconciler tests: a real store with
+// config-sync enabled, a primary/secondary cluster manager, and a counting push
+// seam so pushes can be observed without a live TCP sync transport. The node is
+// marked connected with a live epoch.
+func newReconcileDaemon(t *testing.T, primary bool, uptime time.Duration) (*Daemon, *atomic.Int64) {
+	t.Helper()
+	var pushes atomic.Int64
+	d := &Daemon{
+		cluster:   newClusterManager(primary),
+		store:     newConfigSyncStore(t, "recon-host"),
+		startTime: time.Now().Add(-uptime),
+	}
+	d.configSyncPushForTest = func() { pushes.Add(1) }
+	d.syncPeerConnected.Store(true)
+	d.syncPeerConnEpoch.Add(1) // simulate a live peer connection
+	return d, &pushes
+}
+
+// TestConfigSyncReconcile_PushesAfterPromotion is the primary #5863 fail-on-
+// revert case: a peer connects while this node is SECONDARY (the connect edge
+// skips the push), then this node is promoted to RG0 primary with the
+// connection still up. The old edge-triggered code never re-pushed; the
+// reconciler must push exactly once on the promotion re-evaluation and stay a
+// no-op thereafter.
+func TestConfigSyncReconcile_PushesAfterPromotion(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, false /*secondary*/, 60*time.Second)
+
+	// Peer connected while secondary → the connect-edge reconcile must skip.
+	d.reconcileConfigSyncToPeer("peer-connect")
+	if got := pushes.Load(); got != 0 {
+		t.Fatalf("secondary must not push config; got %d pushes", got)
+	}
+
+	// Later promotion to RG0 primary with the SAME connection up → the
+	// reconciler must now push the authoritative config exactly once.
+	d.cluster = newClusterManager(true /*primary*/)
+	d.reconcileConfigSyncToPeer("rg0-promotion")
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("promotion must push exactly once; got %d pushes", got)
+	}
+
+	// Invariant still satisfied → further ticks are no-ops (no push storm).
+	for i := 0; i < 5; i++ {
+		d.reconcileConfigSyncToPeer("reconcile-loop")
+	}
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("held invariant must not re-push; got %d pushes", got)
+	}
+}
+
+// TestConfigSyncReconcile_PushesAfterStabilityCrossing covers the second
+// ordering: a peer connects while this node is primary but too young (<30s
+// uptime) → the connect edge skips; when uptime crosses the stability
+// threshold, the reconciler (fired by the reconcile loop) must push once.
+func TestConfigSyncReconcile_PushesAfterStabilityCrossing(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, true /*primary*/, 0 /*just started*/)
+
+	// Primary but uptime 0 → connect-edge reconcile skips on stability gate.
+	d.reconcileConfigSyncToPeer("peer-connect")
+	if got := pushes.Load(); got != 0 {
+		t.Fatalf("young node must not push config; got %d pushes", got)
+	}
+
+	// Cross the stability threshold with the connection still up.
+	d.startTime = time.Now().Add(-60 * time.Second)
+	d.reconcileConfigSyncToPeer("reconcile-loop")
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("stability crossing must push exactly once; got %d pushes", got)
+	}
+}
+
+// TestConfigSyncReconcile_HappyPathPushesOnce verifies the normal case: a
+// primary + stable node with a connected peer pushes exactly once at connect
+// time and does not storm on repeated ticks.
+func TestConfigSyncReconcile_HappyPathPushesOnce(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, true /*primary*/, 60*time.Second)
+
+	for i := 0; i < 10; i++ {
+		d.reconcileConfigSyncToPeer("peer-connect")
+	}
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("primary+stable must push exactly once across many ticks; got %d", got)
+	}
+}
+
+// TestConfigSyncReconcile_SecondaryNeverPushes guards #2239/#4385: a
+// reconnecting SECONDARY must never push its (potentially stale) config over
+// the authoritative primary's, regardless of uptime or how many ticks fire.
+func TestConfigSyncReconcile_SecondaryNeverPushes(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, false /*secondary*/, 120*time.Second)
+
+	for i := 0; i < 10; i++ {
+		d.reconcileConfigSyncToPeer("reconcile-loop")
+	}
+	if got := pushes.Load(); got != 0 {
+		t.Fatalf("secondary must never push config; got %d pushes", got)
+	}
+}
+
+// TestConfigSyncReconcile_DisconnectedSkips verifies no push is attempted while
+// no peer connection is up, even on a primary + stable node.
+func TestConfigSyncReconcile_DisconnectedSkips(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, true /*primary*/, 60*time.Second)
+	d.syncPeerConnected.Store(false)
+
+	d.reconcileConfigSyncToPeer("reconcile-loop")
+	if got := pushes.Load(); got != 0 {
+		t.Fatalf("disconnected node must not push config; got %d pushes", got)
+	}
+}
+
+// TestConfigSyncReconcile_ReconnectRepushes proves a new connection epoch
+// re-pushes: after a satisfied push, a peer reconnect (epoch bump) must make the
+// reconciler push again so the fresh connection receives the config.
+func TestConfigSyncReconcile_ReconnectRepushes(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, true /*primary*/, 60*time.Second)
+
+	d.reconcileConfigSyncToPeer("peer-connect")
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("initial push expected; got %d", got)
+	}
+
+	// Peer drops and reconnects: onSessionSyncPeerConnected bumps the epoch.
+	d.onSessionSyncPeerConnected()
+	d.reconcileConfigSyncToPeer("peer-connect")
+	if got := pushes.Load(); got != 2 {
+		t.Fatalf("reconnect (new epoch) must re-push; got %d pushes", got)
+	}
+}
+
+// TestConfigSyncReconcile_ConfigChangeRepushes proves a config-generation
+// change (a commit while the peer stays connected) re-pushes exactly once.
+func TestConfigSyncReconcile_ConfigChangeRepushes(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, true /*primary*/, 60*time.Second)
+
+	d.reconcileConfigSyncToPeer("peer-connect")
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("initial push expected; got %d", got)
+	}
+
+	// New commit → new active generation → the reconciler must push once more.
+	commitHostName(t, d.store, "recon-host-2")
+	d.reconcileConfigSyncToPeer("reconcile-loop")
+	if got := pushes.Load(); got != 2 {
+		t.Fatalf("config-generation change must re-push; got %d pushes", got)
+	}
+	// Generation now satisfied again → no further push.
+	d.reconcileConfigSyncToPeer("reconcile-loop")
+	if got := pushes.Load(); got != 2 {
+		t.Fatalf("stable generation must not re-push; got %d pushes", got)
+	}
+}
+
+// TestConfigSyncReconcileLoop_FiresOnStabilityCrossing exercises the real
+// reconcile loop end-to-end: a primary + connected node that starts too young
+// must push once the loop wakes at the stability threshold, and must not storm
+// afterwards.
+func TestConfigSyncReconcileLoop_FiresOnStabilityCrossing(t *testing.T) {
+	d, pushes := newReconcileDaemon(t, true /*primary*/, 0 /*just started*/)
+	d.configSyncStable = 30 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.configSyncReconcileLoop(ctx)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for pushes.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("reconcile loop did not push after crossing stability threshold")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("reconcile loop must push exactly once; got %d", got)
+	}
+	// Give the loop several more periodic evaluations; it must stay a no-op.
+	time.Sleep(150 * time.Millisecond)
+	if got := pushes.Load(); got != 1 {
+		t.Fatalf("reconcile loop stormed the control socket; got %d pushes", got)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -365,7 +365,30 @@ type Daemon struct {
 	syncReadyTimerMu   sync.Mutex
 	syncReadyTimer     *time.Timer
 	syncReadyTimeout   time.Duration
-	slogHandler        *logging.SyslogSlogHandler
+
+	// #5863: config-sync to a reconnecting peer is level-triggered, not a
+	// one-shot connect edge. syncPeerConnEpoch is bumped on every peer sync
+	// (re)connect so the reconciler can tell one live connection from the
+	// next. The config-sync marker (configSyncMu-guarded) records the
+	// (peer-connection-epoch × config-generation) that has already been
+	// pushed, so the reconciler pushes AT MOST ONCE per epoch/generation and
+	// is a no-op once the desired state is satisfied. This keeps the shared
+	// userspace control socket safe: a later RG0 promotion or the crossing of
+	// the stability threshold re-evaluates the invariant and pushes exactly
+	// once, instead of leaving the peer indefinitely divergent (the connect
+	// edge could have skipped the only push) OR re-pushing on every tick.
+	syncPeerConnEpoch     atomic.Uint64
+	configSyncMu          sync.Mutex
+	configSyncHasPushed   bool
+	configSyncPushedEpoch uint64
+	configSyncPushedGen   uint64
+	configSyncStable      time.Duration // stability threshold; 0 → default 30s (test override)
+	// configSyncPushForTest, when non-nil, replaces the reconciler's real
+	// SessionSync.QueueConfig push so a unit test can count pushes without a
+	// live TCP sync transport (mirrors syncPeerForTest for the commit path).
+	configSyncPushForTest func()
+
+	slogHandler *logging.SyslogSlogHandler
 	// #3932: the flow-traceoptions writer is published through an atomic
 	// pointer read lock-free by a SINGLE stable EventReader callback that
 	// traceCBOnce registers exactly once. Each commit that changes

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -352,6 +352,14 @@ func (d *Daemon) applyRG0OwnershipTransition(newState cluster.NodeState) {
 		slog.Info("cluster: became primary for RG0, enabling config writes")
 		d.store.SetClusterReadOnly(false)
 
+		// #5863: becoming the RG0 config authority is a desired-state change.
+		// A peer that connected while this node was secondary had its config
+		// push skipped by the connect edge; now that this node owns config,
+		// reconcile so the connected peer receives the authoritative config
+		// once (level-triggered, RG0-gated, deduped per epoch/generation) —
+		// instead of waiting for an unrelated commit/reconnect.
+		d.reconcileConfigSyncToPeer("rg0-promotion")
+
 		// On failover to primary: re-initiate synced IPsec SAs.
 		if cc := d.clusterConfig(); cc != nil && cc.IPsecSASync && d.ipsec != nil && d.sessionSync != nil {
 			go d.reinitiateIPsecSAs()

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"net"
 	"strings"
@@ -49,6 +50,11 @@ func (d *Daemon) armSyncReadyTimer() {
 
 func (d *Daemon) onSessionSyncPeerConnected() {
 	d.syncPeerConnected.Store(true)
+	// #5863: a fresh connection is a new epoch. The config-sync reconciler
+	// keys its "already pushed" marker on this epoch, so bumping it here forces
+	// a re-push to the reconnected peer even if the prior connection had
+	// already been satisfied.
+	d.syncPeerConnEpoch.Add(1)
 	d.hbSuppressStart.Store(0) // fresh connection → reset suppression cap
 
 	// Determine whether this is a true cold start or a routine reconnect.
@@ -359,6 +365,158 @@ func (d *Daemon) pushConfigToPeer() {
 		return
 	}
 	d.sessionSync.QueueConfig(configText)
+	// #5863: record the reconcile marker so the level-triggered reconciler
+	// treats this generation as already pushed on the current connection
+	// epoch and does not redundantly re-push it. Only mark when a peer
+	// connection is actually up — QueueConfig no-ops with no active conn, and
+	// a later (re)connect bumps the epoch so the reconciler pushes fresh.
+	if d.syncPeerConnected.Load() {
+		d.markConfigSyncPushed(configText)
+	}
+}
+
+// configGenerationHash reduces the active config text to a compact generation
+// token (#5863). The reconciler pushes at most once per (peer-connection-epoch
+// × generation); a new commit changes the text and therefore the generation,
+// so a config change while a peer stays connected re-pushes exactly once.
+func configGenerationHash(configText string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(configText))
+	return h.Sum64()
+}
+
+// configSyncStableAfter is the uptime a node must have before it is trusted to
+// push its on-disk config to a peer (#5863). A freshly booted node must not
+// overwrite the peer with stale config before it has settled; the default
+// mirrors the historical 30s connect-edge gate. Overridable for tests.
+func (d *Daemon) configSyncStableAfter() time.Duration {
+	if d.configSyncStable > 0 {
+		return d.configSyncStable
+	}
+	return 30 * time.Second
+}
+
+// markConfigSyncPushed records that configText's generation has been pushed to
+// the peer on the current connection epoch (#5863). Any push path (commit sync
+// or the reconciler) records through here so the marker always reflects the
+// latest generation pushed on the live connection, and a redundant reconcile is
+// a no-op.
+func (d *Daemon) markConfigSyncPushed(configText string) {
+	gen := configGenerationHash(configText)
+	epoch := d.syncPeerConnEpoch.Load()
+	d.configSyncMu.Lock()
+	d.configSyncHasPushed = true
+	d.configSyncPushedEpoch = epoch
+	d.configSyncPushedGen = gen
+	d.configSyncMu.Unlock()
+}
+
+// reconcileConfigSyncToPeer is the level-triggered config-sync reconciler
+// (#5863). It re-evaluates the desired invariant — "if I am the RG0 config
+// authority AND stable (uptime ≥ stability threshold) AND a peer is connected
+// AND config sync is enabled AND I have not already pushed my current config
+// generation on this peer's current connection, then push it (once)" — and
+// pushes ONLY when desired-vs-actual diverges.
+//
+// It replaces the old edge-triggered OnPeerConnected-only push, which evaluated
+// the primary/stability gates solely at connect time: a later RG0 promotion or
+// the crossing of the stability threshold never re-pushed, so a peer that
+// connected while this node was secondary (or freshly booted) could stay
+// INDEFINITELY divergent until an unrelated commit/reconnect. The reconciler is
+// invoked on every input change (peer (re)connect, RG0 promotion, stability
+// timer, and a low-frequency safety-net tick).
+//
+// Control-socket safety (CLAUDE.md): the config push is heavy and the userspace
+// control socket is shared. The (epoch × generation) marker guarantees AT MOST
+// ONE push per connection per config generation — once satisfied every further
+// call is a cheap no-op (state gates + one hash, no QueueConfig), so a
+// safety-net tick or a burst of triggers cannot storm the socket or starve
+// session installs during bulk sync. It stays RG0-primary-gated exactly like
+// the old connect edge, so a reconnecting SECONDARY never overwrites the
+// authoritative primary's config (#2239/#4385).
+func (d *Daemon) reconcileConfigSyncToPeer(reason string) {
+	if d.sessionSync == nil && d.configSyncPushForTest == nil {
+		return
+	}
+	// Desired-state gates, re-read fresh on every call (persistent state, not
+	// a captured edge).
+	if !d.syncPeerConnected.Load() {
+		slog.Debug("cluster: config-sync reconcile skip (no peer connection)", "reason", reason)
+		return
+	}
+	if !rg0ConfigSyncAuthority(d.cluster) {
+		slog.Debug("cluster: config-sync reconcile skip (not RG0 primary)", "reason", reason)
+		return
+	}
+	if time.Since(d.startTime) < d.configSyncStableAfter() {
+		slog.Debug("cluster: config-sync reconcile skip (uptime below stability threshold)", "reason", reason)
+		return
+	}
+	if d.store == nil {
+		return
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil || cfg.Chassis.Cluster == nil || !cfg.Chassis.Cluster.ConfigSync {
+		slog.Debug("cluster: config-sync reconcile skip (config sync disabled)", "reason", reason)
+		return
+	}
+	configText := d.store.ShowActive()
+	if configText == "" {
+		return
+	}
+	gen := configGenerationHash(configText)
+	epoch := d.syncPeerConnEpoch.Load()
+
+	// Check-and-claim the (epoch × generation) marker under one lock so two
+	// concurrent triggers (e.g. a promotion racing the safety-net tick) push
+	// at most once. Claim the marker BEFORE the push: a failed/dropped send
+	// disconnects, and the next (re)connect bumps the epoch so the reconciler
+	// re-pushes on the fresh connection.
+	d.configSyncMu.Lock()
+	if d.configSyncHasPushed && d.configSyncPushedEpoch == epoch && d.configSyncPushedGen == gen {
+		d.configSyncMu.Unlock()
+		slog.Debug("cluster: config-sync reconcile no-op (already pushed for epoch/generation)",
+			"reason", reason, "epoch", epoch, "generation", gen)
+		return
+	}
+	d.configSyncHasPushed = true
+	d.configSyncPushedEpoch = epoch
+	d.configSyncPushedGen = gen
+	d.configSyncMu.Unlock()
+
+	slog.Info("cluster: config-sync reconcile pushing config to peer",
+		"reason", reason, "epoch", epoch, "generation", gen, "size", len(configText))
+	if d.configSyncPushForTest != nil {
+		d.configSyncPushForTest()
+		return
+	}
+	d.sessionSync.QueueConfig(configText)
+}
+
+// configSyncReconcileLoop is the low-frequency level-triggered safety net for
+// config sync (#5863). It wakes at the stability threshold (so a node that was
+// too young to push at connect time reconciles the moment it crosses the
+// threshold) and thereafter on a coarse periodic tick that recovers any dropped
+// promotion/connect edge. Every wake is a no-op once the (epoch × generation)
+// marker is satisfied, so it never adds sustained control-socket traffic.
+func (d *Daemon) configSyncReconcileLoop(ctx context.Context) {
+	const periodic = 30 * time.Second
+	for {
+		// Wake at the stability threshold while still too young to push, else
+		// on the coarse periodic tick.
+		delay := periodic
+		if until := d.configSyncStableAfter() - time.Since(d.startTime); until > 0 {
+			delay = until
+		}
+		t := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return
+		case <-t.C:
+			d.reconcileConfigSyncToPeer("reconcile-loop")
+		}
+	}
 }
 
 // errConfigSyncRejectedPrimary is returned by handleConfigSync when this node
@@ -618,10 +776,14 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				return d.handleConfigSync(configText)
 			}
 
-			// Wire peer connected callback: push config to returning peer.
-			// Only push if this node is RG0 primary (config authority) and
-			// has been running >30s (stable node). A freshly started node
-			// must NOT push stale config from disk.
+			// Wire peer connected callback: reconcile config to the returning
+			// peer. #5863: the push is level-triggered, not a one-shot connect
+			// edge — reconcileConfigSyncToPeer re-evaluates the RG0-authority +
+			// stability + config-generation invariant and pushes at most once
+			// per connection/generation. A node that is secondary or too young
+			// at connect time correctly skips here, and a LATER promotion or
+			// stability crossing re-pushes via the promotion hook / reconcile
+			// loop, instead of leaving the peer indefinitely divergent.
 			d.sessionSync.OnPeerConnected = func() {
 				d.cluster.RecordEvent(cluster.EventFabric, -1, "Peer connected")
 				d.onSessionSyncPeerConnected()
@@ -644,16 +806,7 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				if cc := d.clusterConfig(); cc != nil && cc.IPsecSASync {
 					d.nudgeIPsecSASync()
 				}
-				if d.cluster == nil || !d.cluster.IsLocalPrimary(0) {
-					slog.Info("cluster: skipping config push (not RG0 primary)")
-					return
-				}
-				if time.Since(d.startTime) < 30*time.Second {
-					slog.Info("cluster: skipping config push (daemon just started)")
-					return
-				}
-				slog.Info("cluster: pushing config to reconnected peer")
-				d.pushConfigToPeer()
+				d.reconcileConfigSyncToPeer("peer-connect")
 			}
 
 			d.sessionSync.OnBulkSyncReceived = func() {
@@ -828,6 +981,15 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			if cc.IPsecSASync && d.ipsec != nil {
 				go d.syncIPsecSAPeriodic(commsCtx)
 			}
+
+			// #5863: start the level-triggered config-sync reconcile loop.
+			// It is the low-frequency safety net that (a) fires the moment the
+			// node crosses the stability threshold and (b) recovers any dropped
+			// promotion/connect edge. Started unconditionally (config-sync may
+			// be enabled by a later commit without a comms restart); it is a
+			// cheap no-op on any node that is not the RG0 config authority or
+			// whose current generation is already pushed.
+			go d.configSyncReconcileLoop(commsCtx)
 
 			// #2239: start the DHCP-server lease-sync push loop if enabled.
 			// The loop is gated on the RG-MASTER node-level gate internally;


### PR DESCRIPTION
## Root cause

Config replication to a reconnecting cluster peer was **edge-triggered only** by the `OnPeerConnected` callback (`pkg/daemon/daemon_ha_sync.go`). That callback skipped the push when the node was **not RG0 primary** at connect time OR had been up **<30s**, and *nothing re-evaluated the skipped work*:

1. Session-sync connects while this node is secondary (or at uptime 10s) → the callback skips the push.
2. The node later becomes RG0 primary (or uptime reaches 30s) while the connection stays up.
3. No new connect edge and no commit occurs → the peer retains stale active config **indefinitely**.

The RG0 promotion handler (`applyRG0OwnershipTransition`) re-initiated IPsec SAs and nudged DHCP lease-sync but did **not** push/reconcile config, and the 30s threshold had **no** timer callback.

## Fix — reconcile to desired, not a second edge

The bug is an edge-triggered gate over **persistent state** (config authority + peer connectivity + post-boot stability). Rather than bolt on a second edge (a push on promotion) with its own ordering gaps, the push is modeled as **reconciliation to a desired state**.

`reconcileConfigSyncToPeer` re-evaluates the invariant on every input change:

> *this node is the RG0 config authority (`rg0ConfigSyncAuthority`) AND stable (uptime ≥ 30s) AND a peer is connected AND config sync is enabled AND the current config generation has not already been pushed on this peer's current connection*

…and pushes **only when desired-vs-actual diverges**. It is invoked on:
- **(c) peer (re)connect** — `OnPeerConnected` (the existing callback, rewired).
- **(a) RG0 promotion** — hooked into the existing `applyRG0OwnershipTransition` StatePrimary path.
- **(b) crossing the 30s stability threshold** + safety net — a low-frequency `configSyncReconcileLoop` that wakes exactly at the stability threshold and thereafter on a coarse 30s tick to recover any dropped promotion/connect edge.

This mirrors the discipline of the sibling nudges (`nudgeDHCPLeaseSync` / `nudgeIPsecSASync` / `advertiseIPsecSAOnce`): RG-master-gated and idempotent.

## Control-socket safety (CLAUDE.md rule)

The config push is heavy and the userspace control socket is shared (status poll, HA sync, session installs, snapshot sync). The reconcile is **deduped by a `(peer-connection-epoch × config-generation)` marker** so it pushes **at most once per connection per generation**:
- `syncPeerConnEpoch` is bumped on each (re)connect, so a fresh connection re-receives the config even if the generation is unchanged; a stale connection's marker never matches the new epoch.
- The commit-path push (`pushConfigToPeer`) records the same marker, so a subsequent reconcile is a no-op (no duplicate push after a commit).
- Every already-satisfied evaluation is a cheap no-op (state gates + one FNV hash of the config text, **no `QueueConfig`**), so a safety-net tick or a burst of triggers cannot storm the socket or starve session installs during bulk sync.
- Per-tick reconcile traces use `slog.Debug`; only an actual push logs `slog.Info`.

## No regression of the #2239/#4385 no-overwrite guard

The reconcile stays **RG0-primary-gated** exactly like the old connect edge (`rg0ConfigSyncAuthority`), so a reconnecting **SECONDARY** still never overwrites the authoritative primary's config. The receiver-side rejection (`handleConfigSync` → `errConfigSyncRejectedPrimary`) is untouched.

## Fail-on-revert tests (merge gate)

New `pkg/daemon/configsync_reconcile_5863_test.go` reproduces the ordering bug and guards the regressions, driving promotion + uptime transitions against a real store (config-sync enabled) and counting pushes via a seam:

- `PushesAfterPromotion` — connect while **secondary** → 0 pushes; **promote** with connection up → exactly 1 push; further ticks → still 1.
- `PushesAfterStabilityCrossing` — connect while primary but **uptime 0** → 0 pushes; **cross 30s** → exactly 1 push.
- `HappyPathPushesOnce` — primary + stable + connected → exactly 1 push across 10 ticks (no storm).
- `SecondaryNeverPushes` — reconnecting secondary → 0 pushes across 10 ticks (no authoritative-overwrite).
- `DisconnectedSkips`, `ReconnectRepushes` (new epoch → re-push), `ConfigChangeRepushes` (new generation → re-push), and `ReconcileLoop_FiresOnStabilityCrossing` (loop end-to-end).

**Fail-on-revert proven firsthand.** Neutralizing the reconciler (early `return` at the top of `reconcileConfigSyncToPeer`) → RED:

```
--- FAIL: TestConfigSyncReconcile_PushesAfterPromotion (0.00s)
    configsync_reconcile_5863_test.go:98: promotion must push exactly once; got 0 pushes
--- FAIL: TestConfigSyncReconcile_PushesAfterStabilityCrossing (0.00s)
    configsync_reconcile_5863_test.go:127: stability crossing must push exactly once; got 0 pushes
--- FAIL: TestConfigSyncReconcile_HappyPathPushesOnce (0.00s)
    configsync_reconcile_5863_test.go:141: primary+stable must push exactly once across many ticks; got 0
--- FAIL: TestConfigSyncReconcileLoop_FiresOnStabilityCrossing (2.00s)
    configsync_reconcile_5863_test.go:228: reconcile loop did not push after crossing stability threshold
```

Restoring the reconciler → GREEN (`go test -race ./pkg/daemon` passes).

## Validation

`go build ./...`, `go vet ./pkg/daemon`, and `go test -race ./pkg/daemon` all green. `gofmt` clean. `docs/sync-protocol.md` gains a "Reconnect/reconcile-side trigger" section documenting the level-triggered mechanism (replacing the now-false "there is no periodic config reconcile ticker" note).

**HA config-sync — `test-failover` smoke is blocked by the loss-cluster shim-ABI wall; this change is gated on the fail-on-revert unit tests. Parent to record the smoke deferral.**

Closes #5863