### PR TITLE
vrrp: clamp gratuitous-arp-count burst budget (#5695 M16)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-16 — #5695 (security/HA): VRRP/GARP gratuitous-arp-count accepts unbounded value (codex-182 M16)
+- **Timestamp**: 2026-07-16 (fix/5695-garp-count-cap)
+- **Action**: Fix #5695. `gratuitous-arp-count` had `ValidateIntegerMin(1)`
+  (min-only) at the schema and NO runtime upper bound, so a large count fanned an
+  unbounded per-VIP raw-socket GARP/NA burst on failover (1 immediate frame +
+  (count-1) 50ms follow-ups per VIP) — a self-inflicted CPU/socket exhaustion
+  vector. Grepped all consumers: two LIVE send sites — `pkg/vrrp/instance.go`
+  sendGARP (RETH/standalone VRRP) and `pkg/daemon/daemon_ha_vip.go`
+  directSendGARPs (direct-mode cluster). `pkg/cluster` `m.garpCounts` is written
+  but never read (dead). Fix, doctrine-aligned (no-schema-only-caps, PR #1845):
+  (1) PRIMARY runtime clamp — new `config.GratuitousARPBurstClamp = 32` (2× the
+  Junos 1..16 max; every legit config passes untouched, per-VIP tail hard-bounded
+  to ~(32-1)*50ms ≈ 1.55s) + `config.ClampGratuitousARPCount`; both send sites
+  clamp the effective count and slog.Warn ONCE (per-instance atomic.Bool in vrrp;
+  per-RG mutex-guarded map `warnGARPClampOnce` in daemon — never per-send). (2)
+  commit-side SIGNAL (option a) — new AST pre-walk `validateGratuitousARPCountAST`
+  in runPreWalkGates emits a WARNING (never hard-reject) when a count exceeds the
+  clamp, mirroring #1960 lenient/warn. Introduced `garpBurstFn`/`naBurstFn` test
+  seams in vrrp (mirror the existing `arpProbeFn` seam) to capture the effective
+  burst count. Tests (fail-on-revert, all firsthand RED-verified): config
+  `garp_clamp_5695_test.go` (helper + commit warning), vrrp
+  `instance_garp_clamp_5695_test.go` (sendGARP clamp), daemon
+  `direct_garp_clamp_5695_test.go` (directSendGARPs clamp). Build/vet clean; full
+  `pkg/config` + `pkg/vrrp` + `pkg/daemon` suites GREEN under `-race`.
+- **File(s)**: pkg/config/garp_clamp.go (new), pkg/config/compiler_chassis_garp_count.go (new),
+  pkg/config/compiler_prewalk.go, pkg/config/schema_chassis.go, pkg/vrrp/instance.go,
+  pkg/daemon/daemon_ha_vip.go, pkg/daemon/daemon.go, docs/config-schema.md,
+  pkg/config/garp_clamp_5695_test.go (new), pkg/vrrp/instance_garp_clamp_5695_test.go (new),
+  pkg/daemon/direct_garp_clamp_5695_test.go (new)
+
 ## 2026-07-16 — #5830 (routing): per-instance next-table diverges between userspace and kernel/FRR (split-brain leak)
 - **Timestamp**: 2026-07-16 (fix/5830-per-instance-nexttable)
 - **Action**: Fix #5830. STEP-0 on origin/master 04e1527ab confirmed the

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2754,6 +2754,17 @@ reserved for whole-dataplane selection where a rewrite shim
   `node 0 priority <v>;` bypasses the gate (identity-token rule) even
   though `compileChassis` reads its inline tokens — pinned by
   `TestSchemaValidate_ChassisCluster_PackedOneLinerBypassesGate`.
+  **#5695 (codex-182 M16)** completes the `gratuitous-arp-count`
+  "sanity-cap-belongs-in-the-runtime" note above: the runtime now clamps
+  the effective GARP/NA burst to `config.GratuitousARPBurstClamp` (32, 2×
+  the Junos max) at every send site (`pkg/vrrp` sendGARP, `pkg/daemon`
+  directSendGARPs), so an unbounded configured count can no longer fan a
+  per-VIP raw-socket exhaustion burst on failover. The schema stays
+  min-only (doctrine); the extra commit-side signal is a WARNING (never a
+  reject) from the `validateGratuitousARPCountAST` pre-walk gate when a
+  count exceeds the clamp — pinned by `garp_clamp_5695_test.go`
+  (config), `instance_garp_clamp_5695_test.go` (vrrp), and
+  `direct_garp_clamp_5695_test.go` (daemon).
 - **PR 3 (this work):** the remaining converged-plan sections in one PR —
   (a) **interfaces**: `ValueIPAddress`/`ValueCIDR` value types, the typed
   KEY-slot walker feature, and 16 typed slots (mtu ×3, vlan-id,

--- a/pkg/config/compiler_chassis_garp_count.go
+++ b/pkg/config/compiler_chassis_garp_count.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// compiler_chassis_garp_count.go carries the #5695 (codex-182 M16) commit-side
+// SIGNAL for an over-large chassis-cluster redundancy-group
+// gratuitous-arp-count.
+//
+// The PRIMARY M16 fix is the RUNTIME CLAMP (config.GratuitousARPBurstClamp,
+// consumed by pkg/vrrp sendGARP and pkg/daemon directSendGARPs) — an unbounded
+// configured count would fan the full per-VIP burst (1 immediate frame +
+// (count-1) 50ms follow-ups) on every failover, a self-inflicted CPU/socket
+// exhaustion vector.
+//
+// This gate is defense-in-depth, not a hard reject: the no-schema-only-caps
+// doctrine (schema_chassis.go, PR #1845) forbids rejecting AT COMMIT a count
+// the runtime executes (or, here, safely clamps) fine — Junos caps at 16 but
+// the runtime happily runs any count up to the clamp. So a count over the
+// runtime clamp is ACCEPTED and compiled verbatim; the operator just gets a
+// WARNING that the value will be clamped to GratuitousARPBurstClamp per VIP on
+// failover and therefore is not used as written. This mirrors the #1960
+// lenient/warn posture (signal without rejecting a runtime-valid config) and
+// the sibling chassis AST gates in runPreWalkGates.
+
+// validateGratuitousARPCountAST walks the chassis cluster subtree and emits an
+// operator warning (never an error) for any redundancy-group
+// gratuitous-arp-count that exceeds GratuitousARPBurstClamp. Runs on the
+// group-expanded tree so an apply-groups-inherited count is covered. A count
+// within [1, GratuitousARPBurstClamp] (which includes the whole Junos 1..16
+// range) is unaffected. A malformed / non-integer token is left to the schema
+// validator (ValidateIntegerMin) and skipped here.
+func validateGratuitousARPCountAST(nodes []*Node) []string {
+	var warnings []string
+	_ = forEachChild(nodes, "chassis", func(chassis *Node) error {
+		return forEachChild(chassis.Children, "cluster", func(cluster *Node) error {
+			for _, rgInst := range namedInstances(cluster.FindChildren("redundancy-group")) {
+				gc := rgInst.node.FindChild("gratuitous-arp-count")
+				if gc == nil {
+					continue
+				}
+				v := nodeVal(gc)
+				if v == "" {
+					continue
+				}
+				n, err := strconv.Atoi(v)
+				if err != nil {
+					continue
+				}
+				if n > GratuitousARPBurstClamp {
+					warnings = append(warnings, fmt.Sprintf(
+						"chassis cluster redundancy-group %s gratuitous-arp-count %d exceeds the "+
+							"runtime safety maximum %d and will be clamped to %d per VIP on failover "+
+							"(a burst beyond the Junos 1..16 range adds no neighbor-cache benefit); "+
+							"reduce it to <= %d to silence this warning (#5695)",
+						rgInst.name, n, GratuitousARPBurstClamp, GratuitousARPBurstClamp,
+						GratuitousARPBurstClamp))
+				}
+			}
+			return nil
+		})
+	})
+	return warnings
+}

--- a/pkg/config/compiler_prewalk.go
+++ b/pkg/config/compiler_prewalk.go
@@ -471,6 +471,14 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 		return nil, err
 	}
 
+	// #5695 (codex-182 M16): a redundancy-group gratuitous-arp-count over the
+	// runtime clamp (config.GratuitousARPBurstClamp) is accepted and compiled
+	// verbatim but WARNS — the value is clamped at runtime, never used as
+	// written. Never an error: the no-schema-only-caps doctrine forbids a
+	// commit hard-reject of a count the runtime safely clamps. The clamp itself
+	// (pkg/vrrp sendGARP, pkg/daemon directSendGARPs) is the primary fix.
+	garpCountWarnings := validateGratuitousARPCountAST(tree.Children)
+
 	var warnings []string
 	warnings = append(warnings, ctrlCharWarnings...)
 	warnings = append(warnings, trackWarnings...)
@@ -497,5 +505,6 @@ func runPreWalkGates(tree *ConfigTree, opts compileOpts) ([]string, error) {
 	warnings = append(warnings, dnatToScopeWarnings...)
 	warnings = append(warnings, natMixedScopeWarnings...)
 	warnings = append(warnings, chassisIdentityWarnings...)
+	warnings = append(warnings, garpCountWarnings...)
 	return warnings, nil
 }

--- a/pkg/config/garp_clamp.go
+++ b/pkg/config/garp_clamp.go
@@ -1,0 +1,41 @@
+package config
+
+// GratuitousARPBurstClamp is the runtime resource-safety maximum for the
+// per-VIP gratuitous ARP (IPv4) / unsolicited NA (IPv6) burst emitted on a
+// VRRP or chassis-cluster failover. Any configured gratuitous-arp-count is
+// clamped to this value before it drives raw-socket sends.
+//
+// Rationale for the value (#5695, codex-182 M16 — VRRP/GARP unbounded burst).
+// The burst helper (pkg/cluster/garp.go) sends one synchronous frame plus
+// (count-1) follow-ups at 50ms intervals, PER VIP, on every failover. A
+// neighbor cache is refreshed by the first valid frame; a burst beyond ~16
+// frames only adds redundancy for a lossy segment and yields no further cache
+// benefit. Junos itself caps gratuitous-arp-count at 16 (schema_chassis.go
+// valueDesc; the deployed value here is 8). 32 is 2x that documented Junos
+// maximum, so every legitimate configuration (1..16, plus generous
+// over-provisioning up to 32) passes through UNCHANGED — the clamp never
+// alters a count an operator could plausibly intend — while the per-VIP budget
+// is hard-bounded to 32 raw-socket sends and a ~(32-1)*50ms ≈ 1.55s burst
+// tail. Without the clamp a pathological count (e.g. 100000) fans
+// (100000-1)*50ms ≈ 83 minutes of raw-socket sends per VIP across EVERY VIP —
+// a self-inflicted CPU/socket-exhaustion vector on failover.
+//
+// The clamp lives in the RUNTIME (this constant is consumed by pkg/vrrp
+// sendGARP and pkg/daemon directSendGARPs) per the no-schema-only-caps doctrine
+// (schema_chassis.go, PR #1845): a sanity cap belongs in the runtime first, not
+// as a schema hard-reject of counts the runtime executes fine. The commit path
+// only WARNS (validateGratuitousARPCountAST) when a configured count exceeds
+// this bound, so a runtime-valid config is never rejected.
+const GratuitousARPBurstClamp = 32
+
+// ClampGratuitousARPCount bounds a configured gratuitous ARP / unsolicited NA
+// burst count to GratuitousARPBurstClamp. It returns the effective count and
+// whether clamping occurred. A count <= 0 is returned unchanged — only the
+// upper safety bound is enforced here; callers apply their own >0 default
+// (3) for the unset case.
+func ClampGratuitousARPCount(count int) (int, bool) {
+	if count > GratuitousARPBurstClamp {
+		return GratuitousARPBurstClamp, true
+	}
+	return count, false
+}

--- a/pkg/config/garp_clamp_5695_test.go
+++ b/pkg/config/garp_clamp_5695_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5695 (codex-182 M16): the configured gratuitous-arp-count accepted
+// an effectively UNBOUNDED value. A large count schedules a huge per-VIP
+// raw-socket send budget on failover (each VIP fans the full count; the burst
+// helper fans (count-1) frames over (count-1)*50ms) — a self-inflicted
+// CPU/socket-exhaustion vector.
+//
+// The PRIMARY fix is the runtime clamp (config.GratuitousARPBurstClamp, applied
+// in pkg/vrrp sendGARP and pkg/daemon directSendGARPs — tested there). This
+// file covers the config layer: the clamp helper and the doctrine-aligned
+// commit-time WARNING (option a — never a hard reject, since the runtime
+// clamps a too-large count fine; the no-schema-only-caps doctrine forbids
+// rejecting a runtime-valid count at commit).
+//
+// FAIL-ON-REVERT: raise GratuitousARPBurstClamp so nothing clamps, or drop the
+// validateGratuitousARPCountAST call from runPreWalkGates, and the warning
+// assertions below go RED.
+
+func TestClampGratuitousARPCount_5695(t *testing.T) {
+	cases := []struct {
+		in          int
+		wantOut     int
+		wantClamped bool
+	}{
+		{0, 0, false},   // unset — caller applies its own >0 default
+		{-5, -5, false}, // negative — upper bound only
+		{1, 1, false},   // Junos min
+		{3, 3, false},   // default
+		{8, 8, false},   // deployed value
+		{16, 16, false}, // Junos max — must pass untouched
+		{GratuitousARPBurstClamp, GratuitousARPBurstClamp, false}, // exactly at bound
+		{GratuitousARPBurstClamp + 1, GratuitousARPBurstClamp, true},
+		{100000, GratuitousARPBurstClamp, true}, // pathological — the M16 vector
+	}
+	for _, tc := range cases {
+		gotOut, gotClamped := ClampGratuitousARPCount(tc.in)
+		if gotOut != tc.wantOut || gotClamped != tc.wantClamped {
+			t.Errorf("ClampGratuitousARPCount(%d) = (%d, %v), want (%d, %v)",
+				tc.in, gotOut, gotClamped, tc.wantOut, tc.wantClamped)
+		}
+	}
+	if GratuitousARPBurstClamp < 16 {
+		t.Fatalf("clamp %d must be >= the Junos 1..16 range so no legitimate config is altered",
+			GratuitousARPBurstClamp)
+	}
+}
+
+// TestGratuitousARPCountCommitWarning_5695 proves an over-clamp count produces a
+// commit warning (accepted, not rejected) and that in-range counts do not.
+func TestGratuitousARPCountCommitWarning_5695(t *testing.T) {
+	hasClampWarning := func(warnings []string) bool {
+		for _, w := range warnings {
+			if strings.Contains(w, "gratuitous-arp-count") &&
+				strings.Contains(w, "runtime safety maximum") {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Over the clamp: WARN (but still compile — never reject).
+	over := flatTreeFromSets(t,
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set chassis cluster redundancy-group 1 node 1 priority 100",
+		"set chassis cluster redundancy-group 1 gratuitous-arp-count 100000")
+	cfg, err := CompileConfig(over)
+	if err != nil {
+		t.Fatalf("a too-large gratuitous-arp-count must be ACCEPTED (runtime clamps it), got commit error: %v", err)
+	}
+	if !hasClampWarning(cfg.Warnings) {
+		t.Fatalf("gratuitous-arp-count 100000 must emit the clamp warning; warnings=%v", cfg.Warnings)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "100000") && strings.Contains(w, "#5695") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("clamp warning must name the offending value and #5695; warnings=%v", cfg.Warnings)
+	}
+
+	// In-range counts (incl. the Junos max 16 and deployed 8): NO clamp warning.
+	for _, n := range []string{"1", "3", "8", "16", "32"} {
+		ok := flatTreeFromSets(t,
+			"set chassis cluster redundancy-group 1 node 0 priority 200",
+			"set chassis cluster redundancy-group 1 node 1 priority 100",
+			"set chassis cluster redundancy-group 1 gratuitous-arp-count "+n)
+		cfg, err := CompileConfig(ok)
+		if err != nil {
+			t.Fatalf("in-range gratuitous-arp-count %s must compile clean: %v", n, err)
+		}
+		if hasClampWarning(cfg.Warnings) {
+			t.Fatalf("in-range gratuitous-arp-count %s must NOT warn; warnings=%v", n, cfg.Warnings)
+		}
+	}
+}

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -197,15 +197,21 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 					children:      nil,
 				},
 			}},
-			// Runtime truth: any configured count > 0 is used verbatim
-			// as the GARP/NA burst length (pkg/vrrp/instance.go GARP
-			// loop, pkg/cluster/garp.go SendGratuitousARPBurst — both
-			// only special-case <= 0 to the default), read via
-			// daemon_ha_vip.go:475 and vrrp.go:94. Min-only per the
-			// no-schema-only-caps doctrine (Codex, PR #1845) — Junos
+			// Runtime truth: a configured count > 0 drives the GARP/NA
+			// burst length (pkg/vrrp/instance.go GARP loop, pkg/daemon
+			// directSendGARPs, pkg/cluster/garp.go SendGratuitousARPBurst
+			// — all only special-case <= 0 to the default). Min-only per
+			// the no-schema-only-caps doctrine (Codex, PR #1845) — Junos
 			// caps at 16, but enforcing that here would reject configs
 			// the runtime executes fine; a sanity cap belongs in the
-			// runtime first. Deployed: 8.
+			// runtime first. #5695 (codex-182 M16) added that runtime
+			// sanity cap: pkg/vrrp sendGARP and pkg/daemon directSendGARPs
+			// clamp the effective count to config.GratuitousARPBurstClamp
+			// (32, 2x the Junos max) so an unbounded count can no longer
+			// fan a per-VIP raw-socket exhaustion burst on failover. The
+			// commit path stays doctrine-aligned: a count over the clamp
+			// is ACCEPTED but WARNS (validateGratuitousARPCountAST), never
+			// hard-rejected. Deployed: 8.
 			"gratuitous-arp-count": {
 				desc:          "Gratuitous ARP/NA burst count on failover (default 3)",
 				args:          1,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -673,6 +673,11 @@ type Daemon struct {
 	// VIP presence/removal idempotently every pass.
 	directVIPMu    sync.Mutex
 	directVIPOwned map[int]bool
+	// garpClampWarned dedups the #5695 per-RG "gratuitous-arp-count clamped"
+	// warning so directSendGARPs (per-failover path) logs it at most once per
+	// RG, not per send. Guarded by garpClampWarnMu.
+	garpClampWarnMu sync.Mutex
+	garpClampWarned map[int]bool
 	// localFailoverCommitReady tracks whether this node has already
 	// applied the local side of a freshly committed transfer request for
 	// each RG. The cluster manager waits on this before telling the peer

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -528,6 +528,24 @@ func (d *Daemon) directBurstStillValid(rgID int, seq uint64) cluster.BurstStillV
 	}
 }
 
+// warnGARPClampOnce reports whether the #5695 "gratuitous-arp-count clamped"
+// warning for rgID has not yet been logged, recording it so subsequent
+// direct-mode bursts for the same RG stay silent. directSendGARPs runs on the
+// per-failover path, so the clamp warning must fire at most once per RG (the
+// logging rules forbid a per-send Warn).
+func (d *Daemon) warnGARPClampOnce(rgID int) bool {
+	d.garpClampWarnMu.Lock()
+	defer d.garpClampWarnMu.Unlock()
+	if d.garpClampWarned == nil {
+		d.garpClampWarned = make(map[int]bool)
+	}
+	if d.garpClampWarned[rgID] {
+		return false
+	}
+	d.garpClampWarned[rgID] = true
+	return true
+}
+
 // directSendGARPs sends gratuitous ARP/IPv6 NA bursts for all VIPs in the
 // given RG. Reads per-RG GratuitousARPCount (default 3).
 func (d *Daemon) directSendGARPs(rgID int) {
@@ -551,6 +569,20 @@ func (d *Daemon) directSendGARPs(rgID int) {
 				garpCount = rg.GratuitousARPCount
 			}
 		}
+	}
+	// #5695 (codex-182 M16): clamp the configured count to the runtime safety
+	// maximum before it drives per-VIP raw-socket bursts. Without the clamp an
+	// unbounded count would fan (count-1) 50ms follow-up frames per VIP on
+	// every direct-mode failover — a self-inflicted CPU/socket-exhaustion
+	// vector. Warn at most ONCE per RG (directSendGARPs runs on the
+	// per-failover path — never Warn per send).
+	if clamped, was := config.ClampGratuitousARPCount(garpCount); was {
+		if d.warnGARPClampOnce(rgID) {
+			slog.Warn("directSendGARPs: gratuitous-arp-count clamped to runtime safety maximum",
+				"rg", rgID, "configured", garpCount, "clamped", clamped,
+				"max", config.GratuitousARPBurstClamp)
+		}
+		garpCount = clamped
 	}
 
 	vipMap := vrrp.RethVIPsForRG(cfg, rgID)

--- a/pkg/daemon/direct_garp_clamp_5695_test.go
+++ b/pkg/daemon/direct_garp_clamp_5695_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"net"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #5695 (codex-182 M16): the direct-mode (private-rg-election / no-reth-vrrp)
+// failover path read the per-RG gratuitous-arp-count verbatim and fanned the
+// full burst (1 immediate frame + (count-1) 50ms follow-ups) per VIP — an
+// unbounded configured count was a self-inflicted CPU/socket-exhaustion vector.
+// directSendGARPs now clamps the effective count to
+// config.GratuitousARPBurstClamp.
+//
+// This test drives the full directSendGARPs path and captures the COUNT passed
+// to the burst senders via the directGARPBurstFn / directNABurstFn seams.
+//
+// FAIL-ON-REVERT: delete the `if clamped, was := config.ClampGratuitousARPCount`
+// block in directSendGARPs and the clamp assertion observes the raw 100000 →
+// RED.
+
+// directClampTestDaemon builds a cluster-mode Daemon that owns RG 1 with an
+// IPv4 + IPv6 VIP on reth0 and the given gratuitous-arp-count.
+func directClampTestDaemon(t *testing.T, garpCount int) *Daemon {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := configstore.New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	sets := "set chassis cluster cluster-id 1\n" +
+		"set chassis cluster redundancy-group 1 node 0 priority 200\n" +
+		"set chassis cluster redundancy-group 1 node 1 priority 100\n" +
+		"set interfaces reth0 redundant-ether-options redundancy-group 1\n" +
+		"set interfaces reth0 unit 0 family inet address 10.0.5.10/24\n" +
+		"set interfaces reth0 unit 0 family inet6 address fd00::10/64\n"
+	if garpCount > 0 {
+		sets += "set chassis cluster redundancy-group 1 gratuitous-arp-count " +
+			strconv.Itoa(garpCount) + "\n"
+	}
+	if _, err := s.LoadSet(sets); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return &Daemon{
+		store:             s,
+		rgStates:          make(map[int]*rgStateMachine),
+		directVIPOwned:    map[int]bool{1: true},
+		directAnnounceSeq: map[int]uint64{1: 1},
+	}
+}
+
+func TestDirectSendGARPs_ClampsBurstCount_5695(t *testing.T) {
+	cases := []struct {
+		name      string
+		garpCount int
+		want      int
+	}{
+		{"unset defaults to 3", 0, 3},
+		{"deployed value unclamped", 8, 8},
+		{"junos max unclamped", 16, 16},
+		{"pathological clamped", 100000, config.GratuitousARPBurstClamp},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var v4counts, v6counts []int
+			capture := func(_ string, _ net.IP, count int, _ cluster.BurstStillValid) error {
+				mu.Lock()
+				v4counts = append(v4counts, count)
+				mu.Unlock()
+				return nil
+			}
+			captureNA := func(_ string, _ net.IP, count int, _ cluster.BurstStillValid) error {
+				mu.Lock()
+				v6counts = append(v6counts, count)
+				mu.Unlock()
+				return nil
+			}
+			installBurstSeams(t, capture, captureNA)
+			prevProbe := directARPProbeFn
+			directARPProbeFn = func(string, net.IP, net.IP) error { return nil }
+			t.Cleanup(func() { directARPProbeFn = prevProbe })
+
+			d := directClampTestDaemon(t, tc.garpCount)
+			d.directSendGARPs(1)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(v4counts) == 0 {
+				t.Fatalf("no IPv4 GARP burst fired")
+			}
+			for _, c := range v4counts {
+				if c != tc.want {
+					t.Errorf("IPv4 GARP burst count = %d, want %d (configured=%d, clamp=%d)",
+						c, tc.want, tc.garpCount, config.GratuitousARPBurstClamp)
+				}
+			}
+			for _, c := range v6counts {
+				if c != tc.want {
+					t.Errorf("IPv6 NA burst count = %d, want %d (configured=%d, clamp=%d)",
+						c, tc.want, tc.garpCount, config.GratuitousARPBurstClamp)
+				}
+			}
+		})
+	}
+}

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/vishvananda/netlink"
 )
 
@@ -212,10 +213,11 @@ type vrrpInstance struct {
 	lastDropWarn atomic.Int64
 
 	// GARP suppression for strict-vip-ownership mode.
-	suppressGARP  atomic.Bool   // when true, becomeMaster() skips GARP/NA
-	garpEpoch     atomic.Uint64 // incremented on each becomeMaster()/ReconcileVIPs transition
-	lastGARPEpoch atomic.Uint64 // epoch of last completed sendGARP()
-	lastGARPTime  atomic.Int64  // Unix nanos of last GARP send (dampens routine GARP only; forced sends bypass — see garpSendAllowed)
+	suppressGARP    atomic.Bool   // when true, becomeMaster() skips GARP/NA
+	garpEpoch       atomic.Uint64 // incremented on each becomeMaster()/ReconcileVIPs transition
+	lastGARPEpoch   atomic.Uint64 // epoch of last completed sendGARP()
+	lastGARPTime    atomic.Int64  // Unix nanos of last GARP send (dampens routine GARP only; forced sends bypass — see garpSendAllowed)
+	garpClampWarned atomic.Bool   // #5695: guards a once-per-instance warn when a configured GARPCount is clamped (never per-send)
 
 	// onEventDrop is called when an event is dropped due to a full eventCh.
 	// Set by the manager to trigger immediate reconciliation.
@@ -2243,6 +2245,15 @@ func (vi *vrrpInstance) garpSendAllowed(force bool, nowNanos int64) bool {
 // sender (#2152) without performing real AF_PACKET I/O.
 var arpProbeFn = cluster.SendARPProbe
 
+// garpBurstFn / naBurstFn are the IPv4 gratuitous-ARP / IPv6 unsolicited-NA
+// burst senders used by sendGARP. They are package vars so tests can capture
+// the burst COUNT sendGARP passes, proving the #5695 runtime clamp bounds the
+// effective per-VIP burst budget without performing real AF_PACKET I/O.
+var (
+	garpBurstFn = cluster.SendGratuitousARPBurstGated
+	naBurstFn   = cluster.SendGratuitousIPv6BurstGated
+)
+
 // GatewayProbeTarget computes the supplementary gateway-probe target for an
 // IPv4 VIP subnet: the first usable host address (network address + 1), which
 // is the most common gateway address. The second return value reports whether
@@ -2311,6 +2322,19 @@ func (vi *vrrpInstance) sendGARP(force bool) {
 	count := vi.cfg.GARPCount
 	if count <= 0 {
 		count = 3 // default
+	} else if clamped, was := config.ClampGratuitousARPCount(count); was {
+		// #5695 (codex-182 M16): an unbounded configured count fans the full
+		// per-VIP burst (1 immediate frame + (count-1) 50ms follow-ups) on
+		// every failover — a self-inflicted CPU/socket-exhaustion vector.
+		// Clamp to the runtime safety maximum. Warn at most ONCE per instance
+		// (never per-send: sendGARP runs on the per-failover path — logging
+		// rules forbid a Warn inside it).
+		if vi.garpClampWarned.CompareAndSwap(false, true) {
+			slog.Warn("vrrp: gratuitous-arp-count clamped to runtime safety maximum",
+				"key", vi.key(), "configured", count, "clamped", clamped,
+				"max", config.GratuitousARPBurstClamp)
+		}
+		count = clamped
 	}
 	// Abdication gate for the detached burst follow-up loops (#2867). The
 	// cluster burst helpers send the first frame synchronously, then fan the
@@ -2331,7 +2355,7 @@ func (vi *vrrpInstance) sendGARP(force bool) {
 			continue
 		}
 		if ip.To4() != nil {
-			if err := cluster.SendGratuitousARPBurstGated(vi.cfg.Interface, ip, count, stillMaster); err != nil {
+			if err := garpBurstFn(vi.cfg.Interface, ip, count, stillMaster); err != nil {
 				slog.Warn("vrrp: GARP failed", "key", vi.key(), "vip", ip, "err", err)
 			}
 			// Probe the first usable host (network address + 1) of the
@@ -2354,7 +2378,7 @@ func (vi *vrrpInstance) sendGARP(force bool) {
 				}
 			}
 		} else {
-			if err := cluster.SendGratuitousIPv6BurstGated(vi.cfg.Interface, ip, count, stillMaster); err != nil {
+			if err := naBurstFn(vi.cfg.Interface, ip, count, stillMaster); err != nil {
 				slog.Warn("vrrp: NA failed", "key", vi.key(), "vip", ip, "err", err)
 			}
 		}

--- a/pkg/vrrp/instance_garp_clamp_5695_test.go
+++ b/pkg/vrrp/instance_garp_clamp_5695_test.go
@@ -1,0 +1,104 @@
+package vrrp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5695 (codex-182 M16): the configured GARP/NA burst count was used verbatim
+// as the per-VIP send budget on failover, with NO upper clamp — an unbounded
+// count fans the full burst (1 immediate frame + (count-1) 50ms follow-ups) per
+// VIP, a self-inflicted CPU/socket-exhaustion vector. sendGARP now clamps the
+// effective count to config.GratuitousARPBurstClamp.
+//
+// These tests capture the COUNT sendGARP passes to the burst senders via the
+// garpBurstFn / naBurstFn seams — no AF_PACKET I/O — and assert it is clamped.
+//
+// FAIL-ON-REVERT: delete the `else if clamped, was := ...` clamp branch in
+// sendGARP (leaving `count := vi.cfg.GARPCount; if count <= 0 { count = 3 }`)
+// and the clamp assertions below observe the raw 100000 and go RED.
+
+// captureBurstCounts swaps the burst/probe seams to record the count sendGARP
+// passes, restoring them when the returned cleanup runs. The recorded value is
+// the LAST count observed on each family.
+func captureBurstCounts(t *testing.T, v4count, v6count *int) func() {
+	t.Helper()
+	origGARP, origNA, origProbe := garpBurstFn, naBurstFn, arpProbeFn
+	garpBurstFn = func(iface string, ip net.IP, count int, stillValid cluster.BurstStillValid) error {
+		*v4count = count
+		return nil
+	}
+	naBurstFn = func(iface string, ip net.IP, count int, stillValid cluster.BurstStillValid) error {
+		*v6count = count
+		return nil
+	}
+	arpProbeFn = func(iface string, senderIP, targetIP net.IP) error { return nil }
+	return func() { garpBurstFn, naBurstFn, arpProbeFn = origGARP, origNA, origProbe }
+}
+
+func instanceWithGARPCount(t *testing.T, garpCount int, vips ...string) *vrrpInstance {
+	t.Helper()
+	vi := newInstance(Instance{
+		Interface:        "xpf-test-nonexistent0",
+		GroupID:          102,
+		Priority:         200,
+		GARPCount:        garpCount,
+		VirtualAddresses: vips,
+	}, &net.Interface{Name: "xpf-test-nonexistent0"}, make(chan VRRPEvent, 8), nil)
+	vi.setState(StateMaster)
+	return vi
+}
+
+func TestSendGARPClampsBurstCount_5695(t *testing.T) {
+	cases := []struct {
+		name      string
+		garpCount int
+		wantV4    int
+		wantV6    int
+	}{
+		{"unset defaults to 3", 0, 3, 3},
+		{"deployed value unclamped", 8, 8, 8},
+		{"junos max unclamped", 16, 16, 16},
+		{"one over clamp", config.GratuitousARPBurstClamp + 1, config.GratuitousARPBurstClamp, config.GratuitousARPBurstClamp},
+		{"pathological clamped", 100000, config.GratuitousARPBurstClamp, config.GratuitousARPBurstClamp},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v4, v6 int
+			cleanup := captureBurstCounts(t, &v4, &v6)
+			defer cleanup()
+
+			vi := instanceWithGARPCount(t, tc.garpCount, "10.0.0.100/24", "fd00::100/64")
+			vi.sendGARP(true) // force: bypass the time dampener
+
+			if v4 != tc.wantV4 {
+				t.Errorf("IPv4 GARP burst count = %d, want %d (GARPCount=%d, clamp=%d)",
+					v4, tc.wantV4, tc.garpCount, config.GratuitousARPBurstClamp)
+			}
+			if v6 != tc.wantV6 {
+				t.Errorf("IPv6 NA burst count = %d, want %d (GARPCount=%d, clamp=%d)",
+					v6, tc.wantV6, tc.garpCount, config.GratuitousARPBurstClamp)
+			}
+		})
+	}
+}
+
+// TestSendGARPClampNeverExceedsBudget is the security invariant in one line:
+// no matter how large the configured count, the effective per-VIP burst budget
+// never exceeds the runtime clamp.
+func TestSendGARPClampNeverExceedsBudget_5695(t *testing.T) {
+	var v4, v6 int
+	cleanup := captureBurstCounts(t, &v4, &v6)
+	defer cleanup()
+
+	vi := instanceWithGARPCount(t, 1<<30, "10.0.0.100/24", "fd00::100/64")
+	vi.sendGARP(true)
+
+	if v4 > config.GratuitousARPBurstClamp || v6 > config.GratuitousARPBurstClamp {
+		t.Fatalf("burst budget escaped the clamp: v4=%d v6=%d, clamp=%d (M16 exhaustion vector)",
+			v4, v6, config.GratuitousARPBurstClamp)
+	}
+}


### PR DESCRIPTION
Closes #5695

## Root cause (codex-182 M16, Medium/security)
The chassis-cluster / RETH `gratuitous-arp-count` leaf carried
`ValidateIntegerMin(1)` — a **minimum only, no maximum** — and had **no
runtime upper bound**. A large configured count scheduled an effectively
**unbounded per-VIP raw-socket send budget on failover**: each VIP fans out
the full count, and the burst helper fans `(count-1)` follow-up frames over
`(count-1)*50ms`. A pathological count (e.g. `100000`) is ~83 minutes of raw
GARP/NA sends **per VIP across every VIP** — a self-inflicted CPU/socket
exhaustion vector.

Grepped all consumers (`GARPCount` / `GratuitousARPCount`): the two **live**
send sites are `pkg/vrrp/instance.go` `sendGARP` (RETH/standalone VRRP) and
`pkg/daemon/daemon_ha_vip.go` `directSendGARPs` (direct-mode cluster). The
`pkg/cluster` `m.garpCounts` map is **written but never read** (dead), so it
needs no clamp.

## Fix — doctrine-aligned
Respects the **no-schema-only-caps doctrine** (`schema_chassis.go`, PR #1845:
*"Junos caps at 16, but enforcing that here would reject configs the runtime
executes fine; a sanity cap belongs in the runtime first"*).

**1. PRIMARY runtime clamp (closes M16).** New `config.GratuitousARPBurstClamp
= 32` + `config.ClampGratuitousARPCount`. Both send sites clamp the effective
burst count and `slog.Warn` **once** when they clamp (per-instance
`atomic.Bool` in vrrp; per-RG mutex-guarded map `warnGARPClampOnce` in
daemon — **never per-send**, per the logging rules for the per-failover path).

**Clamp value = 32, rationale:** `2×` the Junos `1..16` documented maximum.
Every legitimate config (the deployed `8`, the Junos max `16`, plus generous
over-provisioning to `32`) passes through **unchanged** — the clamp never
alters a count an operator could plausibly intend. It hard-bounds the per-VIP
budget to 32 raw-socket sends and a `~(32-1)*50ms ≈ 1.55s` burst tail. Beyond
~16 frames a GARP/NA burst adds no neighbor-cache benefit, so the headroom is
pure safety.

**2. Commit-side signal (defense-in-depth — option a).** New AST pre-walk gate
`validateGratuitousARPCountAST` in `runPreWalkGates` emits a **WARNING, never a
hard reject**, when a configured count exceeds the clamp — the operator learns
the value will be clamped at runtime. This keeps the doctrine (a runtime-valid
count is never rejected at commit; mirrors the #1960 lenient/warn posture). A
count in `1..32` is silent. **I chose option (a) over the absurd-bound
hard-reject (b)** because the runtime already clamps a too-large count *fine*,
so a warning gives the operator the signal without ever rejecting a config the
runtime executes — the cleaner operator experience and the stricter reading of
the no-schema-only-caps doctrine.

Introduced `garpBurstFn`/`naBurstFn` package-var seams in `pkg/vrrp` (mirroring
the existing `arpProbeFn` seam) so tests capture the effective burst count with
no AF_PACKET I/O.

## Fail-on-revert (the merge gate) — all three verified firsthand
Each mechanism was neutralized, its named test run RED, then restored GREEN.

- **config warning** — neutralized `validateGratuitousARPCountAST` call:
  ```
  --- FAIL: TestGratuitousARPCountCommitWarning_5695 (0.00s)
      garp_clamp_5695_test.go:77: gratuitous-arp-count 100000 must emit the clamp warning; warnings=[]
  ```
- **vrrp sendGARP clamp** — neutralized the clamp branch:
  ```
  --- FAIL: TestSendGARPClampsBurstCount_5695/pathological_clamped (0.00s)
      instance_garp_clamp_5695_test.go:78: IPv4 GARP burst count = 100000, want 32 (GARPCount=100000, clamp=32)
      instance_garp_clamp_5695_test.go:82: IPv6 NA burst count = 100000, want 32 (GARPCount=100000, clamp=32)
  --- FAIL: TestSendGARPClampNeverExceedsBudget_5695 (0.00s)
      instance_garp_clamp_5695_test.go:101: burst budget escaped the clamp: v4=1073741824 v6=1073741824, clamp=32 (M16 exhaustion vector)
  ```
- **daemon directSendGARPs clamp** — neutralized the clamp block:
  ```
  --- FAIL: TestDirectSendGARPs_ClampsBurstCount_5695/pathological_clamped (0.00s)
      direct_garp_clamp_5695_test.go:107: IPv4 GARP burst count = 100000, want 32 (configured=100000, clamp=32)
      direct_garp_clamp_5695_test.go:113: IPv6 NA burst count = 100000, want 32 (configured=100000, clamp=32)
  ```

Regression guard: legit counts (3, 8, 16, 32) are unaffected — no clamp, no warn — asserted in every test.

## Validation
- `go build ./...` clean; `go vet ./pkg/vrrp ./pkg/config ./pkg/daemon` clean.
- Full `pkg/config`, `pkg/vrrp`, `pkg/daemon` suites **GREEN under `-race`**.
- Go-only change; no Rust/dataplane touched.

## Docs
`schema_chassis.go` contract comment and `docs/config-schema.md` updated to
record that #5695 delivered the runtime sanity cap the doctrine deferred.