### PR TITLE
frame: saturate 16-bit length casts in the AF_XDP dataplane (#5765)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,56 @@
+## 2026-07-16 — #5765 (Rust dataplane): u16 length-cast defense-in-depth (claude-spark-review-002)
+- **Timestamp**: 2026-07-16 (fix/5765-u16-lencast-hardening)
+- **Action**: Harden 4 `... as u16` casts on packet/segment/frame lengths in the
+  AF_XDP userspace-dp that would silently WRAP for a >64K length. All four are
+  unreachable-for-wrap on origin/master today (an AF_XDP frame is bounded by the
+  UMEM frame size; an IPv4 `total_length` is itself a 16-bit field), so this is
+  pre-emptive defense-in-depth per the claude-spark-review-002 cohort. Added one
+  shared saturating-narrowing helper `saturate_len16(usize) -> u16`
+  (`u16::try_from(len).unwrap_or(u16::MAX)`) in `afxdp/frame/checksum.rs`,
+  mirroring the validated-narrowing newtype idiom in
+  `afxdp/forwarding_build/validated.rs` (VlanId/TunnelTtl/QueueId). The valid
+  (<64K) path is byte-identical to the old cast — a legitimate packet checksums
+  / injects unchanged; only the (unreachable) >64K case changes from a silent
+  wrap to a deterministic saturate. Per-site disposition:
+    * Site 1 — `checksum16_ipv4` (`checksum.rs`, IPv4 pseudo-header length):
+      HARDENED. Reachable-in-principle (returns a plain u16 checksum);
+      fail-on-revert tested directly at the function boundary with a 65540-byte
+      payload.
+    * Site 2 — TCP/UDP checksum-verify pseudo-headers (`frame/mod.rs` x3, incl.
+      the CSUM_BAD debug block): HARDENED (routed through the shared helper).
+      Structurally capped by the u16 `ip_total_len` wire field, so the wrap is
+      unreachable at the `verify_checksums` boundary; coverage via the shared
+      helper test.
+    * Site 3 — `coordinator/inject.rs` (`frame_len.min(u16::MAX)`): LEFT AS-IS.
+      Already saturating + gated upstream by `check_inject_packet_length`
+      (#2443, REJECTs oversize). Touching it would be churn / risk regressing a
+      correct fail-closed path.
+    * Site 4 — SYN-cookie reply builders (`frame/tcp.rs`, IPv4 total_length /
+      IPv6 payload_length): HARDENED for idiom-consistency, but truly
+      unreachable-for-wrap even at the boundary — `write_syn_cookie_tcp_header`
+      hard-rejects any `tcp_len` ∉ {20,24} (returns None) BEFORE a reply can be
+      emitted, so total_len ≤ 44. Guarded that structural gate with tests
+      (oversized tcp_len → None) instead of a vacuous saturate test.
+  Fail-on-revert PROVEN firsthand: neutralizing `saturate_len16` to bare
+  `len as u16` turned `saturate_len16_passes_through_in_range_and_saturates_above`
+  (left 0 vs right 65535) and `checksum16_ipv4_saturates_length_above_u16`
+  (checksum 5054 vs 5058) RED; the in-range regression + SYN-cookie gate tests
+  stayed GREEN; restored → all 6 GREEN. Validation: `cargo build --release`
+  clean (only pre-existing warnings); full `cargo test --release` pass.
+  No module doc needs an update — the validated-newtype architecture doc
+  (`docs/userspace-dataplane-architecture.md`) describes the control-plane→
+  dataplane SNAPSHOT trust boundary, a different concern from the hot-path
+  per-packet length narrowing, which is fully documented in the
+  `saturate_len16` doc-comment. Low-materiality defense-in-depth, all sites
+  unreachable-for-wrap → safe to merge without loss-cluster smoke; gated on the
+  unit tests.
+- **File(s)**: `userspace-dp/src/afxdp/frame/checksum.rs` (new `saturate_len16`
+  helper + site 1 + fail-on-revert test module `len16_hardening_tests`),
+  `userspace-dp/src/afxdp/frame/mod.rs` (re-export + 3 site-2 call swaps),
+  `userspace-dp/src/afxdp/frame/tcp.rs` (2 site-4 call swaps),
+  `userspace-dp/src/afxdp/frame/tcp_tests.rs` (SYN-cookie structural-gate +
+  in-range tests).
+
 ## 2026-07-16 — #5688 (Rust NAT): interface-mode SNAT with no same-family egress address leaked the source untranslated (fail-open)
 - **Timestamp**: 2026-07-16 (fix/5688-interface-snat-no-egress-drop)
 - **Action**: Fix #5688 (security/correctness fail-open, Rust userspace-dp

--- a/userspace-dp/src/afxdp/frame/checksum.rs
+++ b/userspace-dp/src/afxdp/frame/checksum.rs
@@ -349,12 +349,34 @@ pub(in crate::afxdp) fn checksum16_ipv6(
     checksum16_finish(sum)
 }
 
+/// Narrow a byte length into a 16-bit on-the-wire length field — an
+/// IPv4/TCP/UDP pseudo-header length, an IPv4 `total_length`, or an IPv6
+/// `payload_length`. Saturates at `u16::MAX` instead of the historical bare
+/// `as u16`, which silently WRAPPED (65536 → 0), forging a plausible but
+/// wrong length.
+///
+/// Defense-in-depth (#5765). Every frame the AF_XDP dataplane touches comes
+/// from a single UMEM frame (a few KiB), and an IPv4 `total_length` is itself
+/// a 16-bit field, so `len` is always ≤ `u16::MAX` today and the result is
+/// byte-identical to the old cast — a legitimate packet checksums the same.
+/// Only a future frame-size increase / GRO super-frame / IPv6-jumbogram
+/// reassembly that presented a >64 KiB length would differ, and there
+/// saturating keeps the value deterministic and non-wrapping (the checksum is
+/// still "wrong" for such a frame — the field is 16-bit on the wire — but can
+/// never masquerade as a small valid length). Mirrors the validated-narrowing
+/// newtype idiom in `afxdp/forwarding_build/validated.rs`
+/// (`VlanId`/`TunnelTtl`/`QueueId`).
+#[inline]
+pub(in crate::afxdp) fn saturate_len16(len: usize) -> u16 {
+    u16::try_from(len).unwrap_or(u16::MAX)
+}
+
 pub(in crate::afxdp) fn checksum16_ipv4(src: Ipv4Addr, dst: Ipv4Addr, protocol: u8, payload: &[u8]) -> u16 {
     let mut sum = 0u32;
     sum = checksum16_add_bytes(sum, &src.octets());
     sum = checksum16_add_bytes(sum, &dst.octets());
     sum = checksum16_add_bytes(sum, &[0, protocol]);
-    sum = checksum16_add_bytes(sum, &(payload.len() as u16).to_be_bytes());
+    sum = checksum16_add_bytes(sum, &saturate_len16(payload.len()).to_be_bytes());
     sum = checksum16_add_bytes(sum, payload);
     checksum16_finish(sum)
 }
@@ -979,6 +1001,100 @@ mod l4_offset_helper_tests {
             u16::from_be_bytes([p[36], p[37]]),
             0,
             "IPv4 TCP computed-zero must NOT canonicalize"
+        );
+    }
+}
+
+// #5765: defense-in-depth for the 16-bit on-the-wire length narrowing.
+// These sites are unreachable-for-wrap in production (an AF_XDP frame is
+// bounded by the UMEM frame size and an IPv4 total_length is itself a
+// 16-bit field), so the tests construct a synthetic >64 KiB length
+// DIRECTLY at the function boundary — bypassing that upstream bound — to
+// prove the hardened path SATURATES rather than silently WRAPS.
+#[cfg(test)]
+mod len16_hardening_tests {
+    use super::*;
+
+    #[test]
+    fn saturate_len16_passes_through_in_range_and_saturates_above() {
+        // The valid path is byte-identical to the old `as u16` cast.
+        assert_eq!(saturate_len16(0), 0);
+        assert_eq!(saturate_len16(1000), 1000);
+        assert_eq!(saturate_len16(u16::MAX as usize), u16::MAX);
+        // The >64K path SATURATES to u16::MAX — NOT the wrapped value the
+        // bare `as u16` would produce. Neutralizing the helper body to
+        // `len as u16` makes each of these observe the wrap and go RED:
+        //   65536 -> 0, 65540 -> 4, 131072 -> 0.
+        assert_eq!(saturate_len16(65536), u16::MAX, "65536 must saturate, not wrap to 0");
+        assert_eq!(saturate_len16(65540), u16::MAX, "65540 must saturate, not wrap to 4");
+        assert_eq!(saturate_len16(131072), u16::MAX, "131072 must saturate, not wrap to 0");
+    }
+
+    // Reference pseudo-header checksum for `checksum16_ipv4`, computed with
+    // an explicit 16-bit length field so the test controls wrap vs saturate
+    // independently of the function under test.
+    fn ipv4_pseudo_checksum_with_len(
+        src: Ipv4Addr,
+        dst: Ipv4Addr,
+        protocol: u8,
+        len_field: u16,
+        payload: &[u8],
+    ) -> u16 {
+        let mut pseudo = Vec::with_capacity(12 + payload.len());
+        pseudo.extend_from_slice(&src.octets());
+        pseudo.extend_from_slice(&dst.octets());
+        pseudo.extend_from_slice(&[0, protocol]);
+        pseudo.extend_from_slice(&len_field.to_be_bytes());
+        pseudo.extend_from_slice(payload);
+        checksum16(&pseudo)
+    }
+
+    #[test]
+    fn checksum16_ipv4_in_range_is_byte_identical() {
+        // Regression guard: a legitimate (<64K) L4 segment must checksum
+        // exactly as before — the pseudo-header carries the true length.
+        let src = Ipv4Addr::new(192, 0, 2, 1);
+        let dst = Ipv4Addr::new(198, 51, 100, 2);
+        let payload: Vec<u8> = (0..1400u32).map(|i| (i.wrapping_mul(31) & 0xff) as u8).collect();
+        let got = checksum16_ipv4(src, dst, PROTO_TCP, &payload);
+        let want =
+            ipv4_pseudo_checksum_with_len(src, dst, PROTO_TCP, payload.len() as u16, &payload);
+        assert_eq!(got, want, "in-range checksum must be byte-identical to the true-length reference");
+    }
+
+    #[test]
+    fn checksum16_ipv4_saturates_length_above_u16() {
+        // A 65540-byte payload: the true length overflows the 16-bit
+        // pseudo-header field. The hardened code narrows via saturate_len16
+        // -> 0xffff; the pre-fix `payload.len() as u16` wrapped 65540 -> 4.
+        // All-zero payload keeps the payload's own checksum contribution 0,
+        // so the two computations differ ONLY in the length word — making
+        // the wrap-vs-saturate divergence sharp and unambiguous. (65540 not
+        // 65536: a 65536 wrap yields the length word 0x0000, which is the
+        // one's-complement negative-zero of the saturated 0xffff and would
+        // fold to the SAME checksum — hiding the very difference under test.)
+        let src = Ipv4Addr::new(192, 0, 2, 1);
+        let dst = Ipv4Addr::new(198, 51, 100, 2);
+        let payload = vec![0u8; 65540];
+        let got = checksum16_ipv4(src, dst, PROTO_TCP, &payload);
+
+        // saturate_len16(65540) == 0xffff; the pre-fix `65540 as u16` == 4.
+        let saturated =
+            ipv4_pseudo_checksum_with_len(src, dst, PROTO_TCP, u16::MAX, &payload);
+        let wrapped =
+            ipv4_pseudo_checksum_with_len(src, dst, PROTO_TCP, payload.len() as u16, &payload);
+
+        assert_ne!(
+            saturated, wrapped,
+            "test setup invariant: saturated(0xffff) and wrapped(4) length words must diverge"
+        );
+        assert_eq!(
+            got, saturated,
+            "checksum16_ipv4 must use a SATURATED 16-bit pseudo-header length for a >64K payload"
+        );
+        assert_ne!(
+            got, wrapped,
+            "checksum16_ipv4 must NOT silently wrap the length (65540 -> 4)"
         );
     }
 }

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -52,7 +52,7 @@ pub(in crate::afxdp) use checksum::{
     adjust_l4_checksum_ipv4_src, adjust_l4_checksum_ipv4_words, adjust_l4_checksum_ipv6_words,
     checksum16, checksum16_add_bytes, checksum16_adjust, checksum16_finish, checksum16_ipv4,
     checksum16_ipv6, ipv6_words_from_octets, ipv6_words_from_slice,
-    recompute_l4_checksum_ipv4, recompute_l4_checksum_ipv6,
+    recompute_l4_checksum_ipv4, recompute_l4_checksum_ipv6, saturate_len16,
 };
 
 // Phase 2: header inspection / parsing helpers extracted to `inspect`.
@@ -1628,7 +1628,7 @@ pub(super) fn verify_built_frame_checksums(frame: &[u8]) -> (bool, bool) {
         pseudo.extend_from_slice(&dst.octets());
         pseudo.push(0);
         pseudo.push(PROTO_TCP);
-        pseudo.extend_from_slice(&(segment.len() as u16).to_be_bytes());
+        pseudo.extend_from_slice(&saturate_len16(segment.len()).to_be_bytes());
         pseudo.extend_from_slice(segment);
         // Zero the checksum field in pseudo buffer (offset 12 + 16 = 28..30).
         let csum_off = 12 + 16;
@@ -1654,7 +1654,7 @@ pub(super) fn verify_built_frame_checksums(frame: &[u8]) -> (bool, bool) {
             pseudo.extend_from_slice(&dst.octets());
             pseudo.push(0);
             pseudo.push(PROTO_UDP);
-            pseudo.extend_from_slice(&(segment.len() as u16).to_be_bytes());
+            pseudo.extend_from_slice(&saturate_len16(segment.len()).to_be_bytes());
             pseudo.extend_from_slice(segment);
             let csum_off = 12 + 6;
             if pseudo.len() > csum_off + 1 {
@@ -1709,7 +1709,7 @@ pub(super) fn verify_built_frame_checksums(frame: &[u8]) -> (bool, bool) {
                     pseudo.extend_from_slice(&dst.octets());
                     pseudo.push(0);
                     pseudo.push(PROTO_TCP);
-                    pseudo.extend_from_slice(&(segment.len() as u16).to_be_bytes());
+                    pseudo.extend_from_slice(&saturate_len16(segment.len()).to_be_bytes());
                     pseudo.extend_from_slice(segment);
                     pseudo[12 + 16] = 0;
                     pseudo[12 + 17] = 0;

--- a/userspace-dp/src/afxdp/frame/tcp.rs
+++ b/userspace-dp/src/afxdp/frame/tcp.rs
@@ -575,7 +575,7 @@ fn build_syn_cookie_tcp_reply_v4(
     write_reply_eth_header(frame, &mut out, parsed.l3)?;
     let ip_out = out.get_mut(parsed.l3..parsed.l3 + total_len)?;
     ip_out[0] = 0x45;
-    ip_out[2..4].copy_from_slice(&(total_len as u16).to_be_bytes());
+    ip_out[2..4].copy_from_slice(&saturate_len16(total_len).to_be_bytes());
     ip_out[8] = SYN_COOKIE_REPLY_TTL;
     ip_out[9] = PROTO_TCP;
     ip_out[12..16].copy_from_slice(&dst.octets());
@@ -612,7 +612,7 @@ fn build_syn_cookie_tcp_reply_v6(
     write_reply_eth_header(frame, &mut out, parsed.l3)?;
     let ip_out = out.get_mut(parsed.l3..frame_len)?;
     ip_out[0] = 0x60;
-    ip_out[4..6].copy_from_slice(&(tcp_len as u16).to_be_bytes());
+    ip_out[4..6].copy_from_slice(&saturate_len16(tcp_len).to_be_bytes());
     ip_out[6] = PROTO_TCP;
     ip_out[7] = SYN_COOKIE_REPLY_HOP_LIMIT;
     ip_out[8..24].copy_from_slice(dst);

--- a/userspace-dp/src/afxdp/frame/tcp_tests.rs
+++ b/userspace-dp/src/afxdp/frame/tcp_tests.rs
@@ -1103,3 +1103,77 @@ fn frame_tcp_v6_non_tcp_after_ext_header() {
     assert!(extract_tcp_flags_and_window(&frame).is_none());
     assert_eq!(extract_tcp_window(&frame, libc::AF_INET6 as u8), None);
 }
+
+// ---------- #5765: SYN-cookie length-field narrowing (defense-in-depth) ----------
+//
+// `build_syn_cookie_tcp_reply_v{4,6}` narrow a length (v4: the IPv4
+// `total_length = 20 + tcp_len`; v6: the IPv6 `payload_length = tcp_len`) into
+// the 16-bit wire field. The bare `as u16` at those sites is hardened to
+// `saturate_len16` for idiom-consistency with the checksum sites, BUT the
+// truncation is TRULY UNREACHABLE — even at this function boundary: the builder
+// calls `write_syn_cookie_tcp_header`, which hard-REJECTS (returns None) any
+// `tcp_len` that is not exactly `TCP_MIN_HEADER_LEN` (20) or
+// `TCP_MIN_HEADER_LEN + TCP_MSS_OPTION_LEN` (24). So `total_len` is at most 44
+// and the length narrowing can never observe a >64K value: an oversized reply
+// is discarded (None), never emitted with a wrapped length. The two tests below
+// GUARD that structural gate (a huge `tcp_len` yields None, not a bad reply);
+// the fail-on-revert coverage for the `saturate_len16` primitive these sites now
+// share lives in `checksum::len16_hardening_tests`.
+
+#[test]
+fn syn_cookie_reply_v4_rejects_oversized_tcp_len() {
+    let frame = reject_v4_tcp_frame(TCP_FLAG_SYN, 0x1111_2222, 0);
+    let parsed = parse_tcp_reply_source(&frame).expect("valid v4 SYN frame parses");
+    // A >64K tcp_len (total_len = 20 + tcp_len overflows u16) is structurally
+    // rejected by write_syn_cookie_tcp_header BEFORE any reply escapes — this
+    // is exactly what makes the total_len narrowing unreachable-for-wrap.
+    let out = build_syn_cookie_tcp_reply_v4(
+        &frame,
+        parsed,
+        65_516usize,
+        0xdead_beef,
+        0x1111_2223,
+        TCP_FLAG_SYN | TCP_FLAG_ACK,
+        0,
+    );
+    assert!(out.is_none(), "oversized tcp_len must be rejected, never emitted with a wrapped total_length");
+}
+
+#[test]
+fn syn_cookie_reply_v6_rejects_oversized_tcp_len() {
+    let frame = reject_v6_tcp_frame(TCP_FLAG_SYN, 0x3333_4444, 0);
+    let parsed = parse_tcp_reply_source(&frame).expect("valid v6 SYN frame parses");
+    // A >64K tcp_len (= the IPv6 payload_length, overflows u16) is likewise
+    // rejected before any reply escapes.
+    let out = build_syn_cookie_tcp_reply_v6(
+        &frame,
+        parsed,
+        65_536usize,
+        0xdead_beef,
+        0x3333_4445,
+        TCP_FLAG_SYN | TCP_FLAG_ACK,
+        0,
+    );
+    assert!(out.is_none(), "oversized tcp_len must be rejected, never emitted with a wrapped payload_length");
+}
+
+#[test]
+fn syn_cookie_reply_v4_in_range_length_is_exact() {
+    // Regression guard: a normal-sized reply must carry the exact
+    // total_length, byte-identical to the pre-hardening cast.
+    let frame = reject_v4_tcp_frame(TCP_FLAG_SYN, 0x1111_2222, 0);
+    let parsed = parse_tcp_reply_source(&frame).expect("valid v4 SYN frame parses");
+    let tcp_len = 24usize; // header + MSS option, the real production size
+    let out = build_syn_cookie_tcp_reply_v4(
+        &frame,
+        parsed,
+        tcp_len,
+        0xdead_beef,
+        0x1111_2223,
+        TCP_FLAG_SYN | TCP_FLAG_ACK,
+        1460,
+    )
+    .expect("v4 SYN-cookie reply builds");
+    let total_len_field = u16::from_be_bytes([out[parsed.l3 + 2], out[parsed.l3 + 3]]);
+    assert_eq!(total_len_field, (20 + tcp_len) as u16, "in-range total_length must be exact");
+}


### PR DESCRIPTION
## Summary

Four `... as u16` casts on packet/segment/frame lengths in the Rust
`userspace-dp` would silently **wrap** for a length > 65535 (65536 → 0),
forging a plausible-but-wrong pseudo-header / total-length / payload-length
field. Per the `claude-spark-review-002` cohort (#5765), all four are
**unreachable-for-wrap on current master** — an AF_XDP frame is bounded by the
UMEM frame size, and an IPv4 `total_length` is itself a 16-bit field — so this
is pre-emptive **defense-in-depth**, not a live bug fix.

The fix adds one shared saturating-narrowing helper, `saturate_len16(usize) ->
u16` (`u16::try_from(len).unwrap_or(u16::MAX)`), mirroring the
validated-narrowing newtype idiom already used at the forwarding-build trust
boundary (`VlanId`/`TunnelTtl`/`QueueId` in
`afxdp/forwarding_build/validated.rs`). The valid (<64K) path is
**byte-identical** to the old cast — a legitimate packet checksums and injects
unchanged. Only the (unreachable) >64K case changes, from a silent wrap to a
deterministic saturate that can never masquerade as a small valid length.

## Per-site disposition

| # | Site | Disposition |
|---|------|-------------|
| 1 | `frame/checksum.rs` `checksum16_ipv4` (IPv4 pseudo-header length) | **HARDENED** — reachable-in-principle (returns plain `u16`); fail-on-revert tested directly at the function boundary with a synthetic 65540-byte payload. |
| 2 | `frame/mod.rs` ×3 TCP/UDP checksum-verify pseudo-headers (incl. `CSUM_BAD` debug block) | **HARDENED** via the shared helper. Structurally capped by the u16 `ip_total_len` wire field → unreachable at the `verify_checksums` boundary; coverage rides on the shared-helper test. |
| 3 | `coordinator/inject.rs` (`frame_len.min(u16::MAX)`) | **LEFT AS-IS** — already saturating + gated upstream by `check_inject_packet_length` (#2443, rejects oversize). Touching it would be churn and risk regressing a correct fail-closed path. |
| 4 | `frame/tcp.rs` SYN-cookie reply builders (IPv4 total_length / IPv6 payload_length) | **HARDENED for idiom-consistency, but truly unreachable-for-wrap even at the boundary**: `write_syn_cookie_tcp_header` hard-rejects any `tcp_len ∉ {20,24}` (returns `None`) *before* a reply is emitted, so `total_len ≤ 44`. Guarded that structural gate with tests (oversized `tcp_len` → `None`) rather than a vacuous saturate test. |

## Fail-on-revert (the merge gate)

Neutralizing `saturate_len16` to the bare `len as u16` and re-running the new
tests:

```
running 6 tests
test ...::checksum16_ipv4_in_range_is_byte_identical ... ok
test ...::syn_cookie_reply_v4_in_range_length_is_exact ... ok
test ...::syn_cookie_reply_v4_rejects_oversized_tcp_len ... ok
test ...::syn_cookie_reply_v6_rejects_oversized_tcp_len ... ok
test ...::saturate_len16_passes_through_in_range_and_saturates_above ... FAILED
test ...::checksum16_ipv4_saturates_length_above_u16 ... FAILED

---- saturate_len16_passes_through_in_range_and_saturates_above ----
assertion `left == right` failed: 65536 must saturate, not wrap to 0
  left: 0
 right: 65535

---- checksum16_ipv4_saturates_length_above_u16 ----
assertion `left == right` failed: checksum16_ipv4 must use a SATURATED 16-bit pseudo-header length for a >64K payload
  left: 5054
 right: 5058

test result: FAILED. 4 passed; 2 failed; ...
```

Restoring the helper → all 6 GREEN. The in-range regression + SYN-cookie
structural-gate tests correctly stay GREEN under the neutralized code (they do
not exercise the >64K wrap).

## Validation

- `cargo build --release` clean (only pre-existing warnings).
- Full `cargo test --release` = **3951 passed / 0 failed** (main bin 3860 incl.
  6 new tests; +60+8+22+1 integration binaries).
- Clippy: the crate's pre-existing `-D warnings` state (167 unrelated
  unused-import warnings) is untouched; no clippy warning references the new
  code.

## Docs

No module doc change needed: the validated-newtype architecture doc
(`docs/userspace-dataplane-architecture.md`) describes the control-plane →
dataplane **snapshot** trust boundary, a different concern from the hot-path
per-packet length narrowing, which is fully documented in the `saturate_len16`
doc-comment.

## Merge / smoke note

Low-materiality defense-in-depth, all sites currently unreachable-for-wrap →
**safe to merge without loss-cluster smoke**; gated on the unit tests.

Closes #5765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
