### PR TITLE
daemon: fail closed on unreadable kernel-upgrade journal

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-16 — #5682 (security/HA): unreadable kernel-upgrade journal bypasses candidate election hold (codex-182 M24)
+- **Timestamp**: 2026-07-16 (fix/5682-upgrade-journal-failclosed)
+- **Action**: Fix #5682. `holdSecondaryIfKernelCandidateArmed`
+  (`pkg/daemon/kernel_selfrecover.go`) read the kernel-upgrade journal via
+  `KernelRunner.IsArmed()` and, on `err != nil || !armed`, RETURNED without
+  setting the election hold. `loadKernelJournal` already folds a clean `ENOENT`
+  to `KernelStateInit`+nil-err, so the `err != nil` branch is reached ONLY on a
+  genuine READ/PARSE failure (I/O error, corruption, malformed content) — an
+  UNREADABLE journal that CORRELATES with a bad upgrade. Treating it as "not
+  armed" failed OPEN: the node ran a normal candidate election, bypassing the
+  #1930 A/B kernel promote/rollback hold. Fix: split the branch — on `err != nil`
+  set `SetKernelUpgradeHold()` (fail-CLOSED, `slog.Warn` once) + mark
+  `Daemon.kernelUpgradeHoldFailClosed`; on `!armed` (clean read) proceed; on
+  armed hold as before. ENOENT still proceeds (never-armed node not bricked).
+  Not-stranded: `reconcileKernelUpgradeHold` self-heals a fail-closed hold — a
+  later successful NOT-armed read RELEASES it (transient blip), an armed read
+  CONVERTS it to a normal marker-gated hold, a still-unreadable read keeps
+  holding; the strict promotion-marker release is preserved for a genuinely-armed
+  hold (revert-window safety unchanged). Added `kernelRunnerFn`/`kernelSystemFn`
+  test seams to `Daemon`. Tests (fail-on-revert, firsthand RED-verified):
+  `kernel_upgrade_hold_failclosed_5682_test.go` — 4 mandated states
+  (unreadable-parse + unreadable-I/O→hold; ENOENT→no hold; armed→hold;
+  valid-not-armed→no hold) + self-heal release/convert + armed-marker-release
+  regression. Neutralizing the fix (unreadable→return) turned the two unreadable
+  cases + self-heal precondition RED. `go build ./...`, `go vet`, and full
+  `pkg/daemon` + `pkg/cluster` suites GREEN under `-race`. Docs:
+  `docs/in-place-upgrade.md` LANE-1 §"Election hold" item 1 updated with the
+  fail-closed + ENOENT-distinction + self-heal contract.
+- **File(s)**: pkg/daemon/kernel_selfrecover.go, pkg/daemon/daemon.go,
+  pkg/daemon/kernel_upgrade_hold_failclosed_5682_test.go (new),
+  docs/in-place-upgrade.md, _Log.md
+
 ## 2026-07-16 — #5695 (security/HA): VRRP/GARP gratuitous-arp-count accepts unbounded value (codex-182 M16)
 - **Timestamp**: 2026-07-16 (fix/5695-garp-count-cap)
 - **Action**: Fix #5695. `gratuitous-arp-count` had `ValidateIntegerMin(1)`

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -923,8 +923,31 @@ carrying traffic:
    set BEFORE `cluster.UpdateConfig` (which itself runs the first
    election) — not merely before `Start()` — so a candidate can never win
    even the initial single-node election. `SetKernelUpgradeHold` also
-   DEMOTES any already-primary group as defense in depth. The hold is
-   released only when the candidate is affirmatively VERIFIED+PROMOTED:
+   DEMOTES any already-primary group as defense in depth.
+
+   **Fail-closed on an UNREADABLE journal (#5682 / codex-review-182 M24).**
+   `holdSecondaryIfKernelCandidateArmed` reads the journal to decide
+   whether this is a candidate boot. A genuine read/parse FAILURE (I/O
+   error, corruption, malformed content) is a failure mode that itself
+   correlates with a bad upgrade, so it now sets the hold FAIL-CLOSED
+   rather than treating the unknown state as "not armed" and proceeding to
+   a normal election (which would bypass the hold and the promote/rollback
+   safety). A clean `ENOENT` is precisely distinguished (`loadKernelJournal`
+   folds a missing file to `KernelStateInit` with a nil error) and STILL
+   proceeds normally, so a node that simply never armed an upgrade is never
+   bricked into a spurious hold. A fail-closed hold is not stranded: it is
+   tracked distinctly (`Daemon.kernelUpgradeHoldFailClosed`) and
+   `reconcileKernelUpgradeHold` self-heals it — a later reconcile tick
+   re-reads the journal and RELEASES the hold once the read succeeds and
+   the node is definitively NOT armed (a transient I/O blip with no upgrade
+   pending), CONVERTS it to a normal armed hold if the read now shows a
+   genuine armed candidate (the strict marker gate then governs), or keeps
+   holding while the journal stays unreadable. The strict marker-only
+   release below is preserved for a genuinely-armed hold so the revert
+   window can never transiently promote an unverified candidate.
+
+   The hold is released only when the candidate is affirmatively
+   VERIFIED+PROMOTED:
    the promotion gate runs in a SEPARATE process
    (`xpf-kernel-promote.service`, `After=xpfd`) and writes a durable
    promotion marker for the running kernel, so the daemon reconciles the

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	"github.com/psaab/xpf/pkg/rpm"
 	"github.com/psaab/xpf/pkg/scheduler"
 	"github.com/psaab/xpf/pkg/snmp"
+	"github.com/psaab/xpf/pkg/upgrade"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
@@ -337,11 +338,31 @@ type Daemon struct {
 	schedulerRepublishFailing        atomic.Bool
 	schedulerRepublishFirstFailNanos atomic.Int64
 	cluster                          *cluster.Manager
-	sessionSync                      *cluster.SessionSync
-	syncBulkPrimed                   atomic.Bool
-	syncPeerBulkPrimed               atomic.Bool
-	syncPeerConnected                atomic.Bool
-	lastStandbyNeighborRefresh       atomic.Int64
+	// kernelUpgradeHoldFailClosed records that the kernel-upgrade election hold
+	// was set FAIL-CLOSED because the kernel-upgrade journal was UNREADABLE at
+	// boot (I/O error / corruption / parse failure — NOT a clean ENOENT), rather
+	// than because a candidate was affirmatively ARMED (#5682 / codex-review-182
+	// M24). It distinguishes the two holds for reconcileKernelUpgradeHold: a
+	// normal armed hold releases ONLY on the durable promotion marker (so the
+	// revert window can't transiently promote an unverified candidate), whereas a
+	// fail-closed hold ALSO self-heals — a later SUCCESSFUL journal read that
+	// shows the node is not armed releases it, so a transient I/O blip does not
+	// strand the node SECONDARY forever. Written once at boot (before the
+	// self-recovery goroutine starts) and read/written only from that goroutine's
+	// reconcile tick thereafter, so no lock is needed.
+	kernelUpgradeHoldFailClosed bool
+	// kernelRunnerFn / kernelSystemFn are test seams for the kernel-upgrade
+	// election-hold path (#5682). nil in production: the real KernelRunner (over
+	// the /var/lib/xpf journal) and the real KernelSystem are used. Tests inject a
+	// runner pointed at a temp journal + a stub system to drive the
+	// armed/not-armed/unreadable branches without a live UEFI host.
+	kernelRunnerFn             func() (*upgrade.KernelRunner, error)
+	kernelSystemFn             func() upgrade.KernelSystem
+	sessionSync                *cluster.SessionSync
+	syncBulkPrimed             atomic.Bool
+	syncPeerBulkPrimed         atomic.Bool
+	syncPeerConnected          atomic.Bool
+	lastStandbyNeighborRefresh atomic.Int64
 	// neighborGuards groups the #1780 Path A per-phase supervision state for
 	// runPeriodicNeighborResolution (in-flight overlap guards, last-success
 	// timestamps, loop-started gate, plus the warmNeighborCache warmup guard).

--- a/pkg/daemon/kernel_selfrecover.go
+++ b/pkg/daemon/kernel_selfrecover.go
@@ -18,6 +18,26 @@ func (a kernelSRCluster) LocalDrained() (bool, error)       { return a.m.LocalDr
 func (a kernelSRCluster) PeerHealthyPrimary() (bool, error) { return a.m.PeerHealthyPrimary(), nil }
 func (a kernelSRCluster) ResetFailover() error              { return a.m.ResetAllFailover() }
 
+// newKernelRunner builds the KernelRunner used to read the kernel-upgrade
+// journal (IsArmed). Production path constructs it over the real /var/lib/xpf
+// journal + system surface; tests inject kernelRunnerFn to point it at a temp
+// journal (#5682 election-hold fail-closed coverage).
+func (d *Daemon) newKernelRunner() (*upgrade.KernelRunner, error) {
+	if d.kernelRunnerFn != nil {
+		return d.kernelRunnerFn()
+	}
+	return upgrade.NewKernelRunner(upgrade.KernelConfig{Sys: upgrade.NewKernelSystem()})
+}
+
+// newKernelSystem builds the KernelSystem used by the hold-reconcile promotion
+// check (RunningKernel / ReadPromotionMarker). Test seam: kernelSystemFn.
+func (d *Daemon) newKernelSystem() upgrade.KernelSystem {
+	if d.kernelSystemFn != nil {
+		return d.kernelSystemFn()
+	}
+	return upgrade.NewKernelSystem()
+}
+
 // holdSecondaryIfKernelCandidateArmed keeps a CANDIDATE-TRIAL boot SECONDARY
 // until the promotion gate verifies the dataplane (r2 AGY Critical). The drain
 // the orchestrator set is in-memory ManualFailover, lost across the reboot, so a
@@ -39,15 +59,36 @@ func (d *Daemon) holdSecondaryIfKernelCandidateArmed() {
 	if d.cluster == nil {
 		return
 	}
-	r, err := upgrade.NewKernelRunner(upgrade.KernelConfig{Sys: upgrade.NewKernelSystem()})
+	r, err := d.newKernelRunner()
 	if err != nil {
 		return
 	}
 	armed, j, err := r.IsArmed()
-	if err != nil || !armed {
+	if err != nil {
+		// #5682 (codex-review-182 M24): the journal is UNREADABLE — an I/O error,
+		// corruption, or parse failure. IsArmed/loadKernelJournal already fold a
+		// clean ENOENT ("never armed") to not-armed with a nil error, so reaching
+		// this branch means the journal EXISTS but cannot be read/parsed. That is
+		// a failure mode which itself CORRELATES with a bad upgrade (a candidate
+		// kernel that corrupted /var/lib/xpf, a half-written journal from a crash
+		// mid-roll). Treating the unknown state as "not armed" and proceeding to a
+		// normal election would let this node elect/promote as if no upgrade were
+		// pending — bypassing the candidate-election hold and the promote/rollback
+		// safety of the #1930 A/B kernel channel. Fail CLOSED: hold SECONDARY
+		// exactly as a definitively-armed candidate would. reconcileKernelUpgradeHold
+		// self-heals this hold on a later successful read (see below), so a
+		// transient read error does not strand the node SECONDARY forever.
+		d.cluster.SetKernelUpgradeHold()
+		d.kernelUpgradeHoldFailClosed = true
+		slog.Warn("kernel-upgrade journal unreadable, holding election fail-closed "+
+			"(SECONDARY) until the state can be re-read", "err", err)
+		return
+	}
+	if !armed {
 		return
 	}
 	d.cluster.SetKernelUpgradeHold()
+	d.kernelUpgradeHoldFailClosed = false
 	slog.Info("kernel-candidate boot: holding SECONDARY (election hold) until promotion "+
 		"verifies the dataplane", "candidate", j.CandidateVersion)
 }
@@ -73,12 +114,64 @@ func (d *Daemon) holdSecondaryIfKernelCandidateArmed() {
 //     cleared, IsArmed false) -> the hold is gone by construction.
 //   - still verifying: marker not yet written -> keep holding.
 //
+// EXCEPTION (#5682): a FAIL-CLOSED hold — one set because the journal was
+// UNREADABLE at boot rather than affirmatively ARMED — ALSO self-heals here. It
+// has no promotion marker to wait on when the underlying cause was a transient
+// I/O blip with no upgrade pending, so it would otherwise strand the node
+// SECONDARY forever. On each tick it re-reads the journal: still unreadable ->
+// keep holding; now armed -> convert to a normal armed hold (the marker gate
+// governs); now cleanly not-armed -> release (the read error was transient). The
+// strict marker-only release is preserved for a genuinely-armed hold so the
+// revert window can't transiently promote an unverified candidate.
+//
 // No-op unless the hold is set.
 func (d *Daemon) reconcileKernelUpgradeHold() {
 	if d.cluster == nil || !d.cluster.KernelUpgradeHeld() {
+		// The hold is gone (or never set), possibly cleared by another path
+		// (rejoin / manual reset). Drop our local fail-closed bookkeeping so a
+		// future hold starts clean.
+		d.kernelUpgradeHoldFailClosed = false
 		return
 	}
-	sys := upgrade.NewKernelSystem()
+
+	// #5682 self-heal for a FAIL-CLOSED hold (unreadable journal at boot). Unlike
+	// a definitively-armed hold — which is released ONLY by the durable promotion
+	// marker below, so the revert window can't transiently promote an unverified
+	// candidate — a fail-closed hold was set from an AMBIGUOUS read, and the
+	// promotion marker will never appear when the underlying cause was a transient
+	// I/O blip with no upgrade in progress. Re-read the journal:
+	//   - still unreadable        -> keep holding (nothing changed).
+	//   - now readable & ARMED    -> a real candidate IS in progress: convert to a
+	//                                normal armed hold (clear the fail-closed flag)
+	//                                and fall through to the promotion-marker gate.
+	//   - now readable & NOT armed-> the boot-time error was transient and there is
+	//                                no upgrade pending: release the hold so the
+	//                                node is not stranded SECONDARY forever.
+	if d.kernelUpgradeHoldFailClosed {
+		r, err := d.newKernelRunner()
+		if err != nil {
+			return // cannot construct a reader; keep holding fail-closed
+		}
+		armed, _, ierr := r.IsArmed()
+		switch {
+		case ierr != nil:
+			return // journal still unreadable; keep holding fail-closed
+		case armed:
+			// A genuine candidate is armed after all — this is now an ordinary
+			// armed hold; the promotion-marker gate below governs its release.
+			d.kernelUpgradeHoldFailClosed = false
+		default:
+			// Definitively not armed on a clean read: the boot-time read failure
+			// was transient and no kernel upgrade is pending. Release the hold.
+			d.kernelUpgradeHoldFailClosed = false
+			d.cluster.ClearKernelUpgradeHold()
+			slog.Warn("kernel-upgrade journal now readable and NOT armed; releasing the " +
+				"fail-closed SECONDARY election hold (transient read error self-healed)")
+			return
+		}
+	}
+
+	sys := d.newKernelSystem()
 	running, err := sys.RunningKernel()
 	if err != nil {
 		return

--- a/pkg/daemon/kernel_upgrade_hold_failclosed_5682_test.go
+++ b/pkg/daemon/kernel_upgrade_hold_failclosed_5682_test.go
@@ -1,0 +1,263 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/upgrade"
+)
+
+// #5682 (codex-review-182 M24): an UNREADABLE kernel-upgrade journal (I/O error,
+// corruption, parse failure) must FAIL CLOSED — hold the candidate-election
+// SECONDARY, exactly as a definitively-armed candidate would — instead of being
+// treated as "not armed" and proceeding to a normal election. A clean ENOENT
+// ("never armed") must STILL proceed so a node that never armed an upgrade is
+// not bricked. These tests are the fail-on-revert gate: neutralizing the fix
+// (unreadable -> return without holding) turns the unreadable cases RED.
+
+// stubKernelSys satisfies upgrade.KernelSystem by embedding a nil interface: it
+// is legal to construct a KernelRunner with it (NewKernelRunner only rejects a
+// nil Sys), and IsArmed/loadKernelJournal never call any Sys method (they only
+// os.ReadFile the JournalPath), so no method is ever invoked in the hold path.
+type stubKernelSys struct{ upgrade.KernelSystem }
+
+// fakeKernelSys overrides only the two methods reconcileKernelUpgradeHold's
+// promotion-marker gate calls, so the self-heal/promotion tests can steer the
+// release decision without a live host.
+type fakeKernelSys struct {
+	upgrade.KernelSystem
+	running     string
+	runningErr  error
+	promoted    string
+	promotedErr error
+}
+
+func (f fakeKernelSys) RunningKernel() (string, error)       { return f.running, f.runningErr }
+func (f fakeKernelSys) ReadPromotionMarker() (string, error) { return f.promoted, f.promotedErr }
+
+// runnerAt returns a kernelRunnerFn seam whose KernelRunner reads the journal at
+// path (stub system; the journal read is pure filesystem).
+func runnerAt(path string) func() (*upgrade.KernelRunner, error) {
+	return func() (*upgrade.KernelRunner, error) {
+		return upgrade.NewKernelRunner(upgrade.KernelConfig{
+			JournalPath: path,
+			Sys:         stubKernelSys{},
+		})
+	}
+}
+
+// writeJournal marshals a valid journal to path.
+func writeJournal(t *testing.T, path string, j upgrade.KernelJournal) {
+	t.Helper()
+	data, err := json.Marshal(&j)
+	if err != nil {
+		t.Fatalf("marshal journal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write journal: %v", err)
+	}
+}
+
+// TestHoldSecondaryIfKernelCandidateArmed_FailClosed is the merge gate: it
+// covers all four journal states from the issue.
+func TestHoldSecondaryIfKernelCandidateArmed_FailClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, dir string) string // returns the journal path to point the runner at
+		wantHold   bool
+		wantFailCl bool // expected d.kernelUpgradeHoldFailClosed after the call
+	}{
+		{
+			// (3) UNREADABLE via parse failure (corrupt/malformed content on an
+			// existing file). MUST hold (fail-closed).
+			name: "unreadable_parse_failure_holds",
+			setup: func(t *testing.T, dir string) string {
+				p := filepath.Join(dir, "kernel-upgrade.state")
+				if err := os.WriteFile(p, []byte("{ this is not valid json"), 0o644); err != nil {
+					t.Fatalf("write malformed journal: %v", err)
+				}
+				return p
+			},
+			wantHold:   true,
+			wantFailCl: true,
+		},
+		{
+			// (3b) UNREADABLE via genuine I/O read error (path is a directory ->
+			// os.ReadFile returns EISDIR, which is NOT os.IsNotExist). MUST hold.
+			name: "unreadable_io_error_holds",
+			setup: func(t *testing.T, dir string) string {
+				p := filepath.Join(dir, "journal-is-a-dir")
+				if err := os.Mkdir(p, 0o755); err != nil {
+					t.Fatalf("mkdir journal path: %v", err)
+				}
+				return p
+			},
+			wantHold:   true,
+			wantFailCl: true,
+		},
+		{
+			// (2) MISSING journal (ENOENT) — a node that never armed an upgrade.
+			// MUST NOT hold (regression guard: do not brick a never-armed node).
+			name: "missing_enoent_no_hold",
+			setup: func(t *testing.T, dir string) string {
+				return filepath.Join(dir, "does-not-exist.state")
+			},
+			wantHold:   false,
+			wantFailCl: false,
+		},
+		{
+			// (1) Definitively ARMED — hold (unchanged behavior).
+			name: "armed_holds",
+			setup: func(t *testing.T, dir string) string {
+				p := filepath.Join(dir, "kernel-upgrade.state")
+				writeJournal(t, p, upgrade.KernelJournal{
+					State:            upgrade.KernelStateArmed,
+					CandidateVersion: "6.18.5-test",
+				})
+				return p
+			},
+			wantHold:   true,
+			wantFailCl: false,
+		},
+		{
+			// (4) Definitively NOT ARMED (valid content, pre-armed state) — no hold.
+			name: "not_armed_valid_no_hold",
+			setup: func(t *testing.T, dir string) string {
+				p := filepath.Join(dir, "kernel-upgrade.state")
+				writeJournal(t, p, upgrade.KernelJournal{
+					State:            upgrade.KernelStateInstalled,
+					CandidateVersion: "6.18.5-test",
+				})
+				return p
+			},
+			wantHold:   false,
+			wantFailCl: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := tt.setup(t, dir)
+			m := cluster.NewManager(0, 1)
+			d := &Daemon{cluster: m, kernelRunnerFn: runnerAt(path)}
+
+			d.holdSecondaryIfKernelCandidateArmed()
+
+			if got := m.KernelUpgradeHeld(); got != tt.wantHold {
+				t.Fatalf("KernelUpgradeHeld() = %v, want %v", got, tt.wantHold)
+			}
+			if got := d.kernelUpgradeHoldFailClosed; got != tt.wantFailCl {
+				t.Fatalf("kernelUpgradeHoldFailClosed = %v, want %v", got, tt.wantFailCl)
+			}
+		})
+	}
+}
+
+// TestReconcileKernelUpgradeHold_FailClosedSelfHeals proves a fail-closed hold
+// set on a transient read error is RELEASABLE (not stranded SECONDARY forever):
+// once the journal reads cleanly as NOT armed, the reconcile tick releases it.
+func TestReconcileKernelUpgradeHold_FailClosedSelfHeals(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kernel-upgrade.state")
+
+	// Boot with an unreadable (corrupt) journal -> fail-closed hold.
+	if err := os.WriteFile(path, []byte("{corrupt"), 0o644); err != nil {
+		t.Fatalf("write corrupt journal: %v", err)
+	}
+	m := cluster.NewManager(0, 1)
+	d := &Daemon{cluster: m, kernelRunnerFn: runnerAt(path)}
+	d.holdSecondaryIfKernelCandidateArmed()
+	if !m.KernelUpgradeHeld() || !d.kernelUpgradeHoldFailClosed {
+		t.Fatalf("precondition: expected fail-closed hold set (held=%v failClosed=%v)",
+			m.KernelUpgradeHeld(), d.kernelUpgradeHoldFailClosed)
+	}
+
+	// Reconcile while the journal is still unreadable: hold MUST persist.
+	d.reconcileKernelUpgradeHold()
+	if !m.KernelUpgradeHeld() {
+		t.Fatal("hold released while journal still unreadable; must keep holding fail-closed")
+	}
+
+	// The transient error clears: journal now reads cleanly as NOT armed.
+	writeJournal(t, path, upgrade.KernelJournal{State: upgrade.KernelStateInit})
+	d.reconcileKernelUpgradeHold()
+	if m.KernelUpgradeHeld() {
+		t.Fatal("fail-closed hold not released after journal became readable and not-armed (node stranded SECONDARY)")
+	}
+	if d.kernelUpgradeHoldFailClosed {
+		t.Fatal("kernelUpgradeHoldFailClosed still set after release")
+	}
+}
+
+// TestReconcileKernelUpgradeHold_FailClosedBecomesArmed proves that when a
+// fail-closed hold's journal later reads as genuinely ARMED, the hold is
+// converted to a normal armed hold (fail-closed flag cleared) and continues to
+// hold under the strict promotion-marker gate rather than self-healing away.
+func TestReconcileKernelUpgradeHold_FailClosedBecomesArmed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kernel-upgrade.state")
+	if err := os.WriteFile(path, []byte("{corrupt"), 0o644); err != nil {
+		t.Fatalf("write corrupt journal: %v", err)
+	}
+	m := cluster.NewManager(0, 1)
+	d := &Daemon{
+		cluster:        m,
+		kernelRunnerFn: runnerAt(path),
+		// promotion-marker gate: running kernel unreadable -> reconcile returns
+		// early (keeps holding). Proves an armed hold is NOT self-healed away.
+		kernelSystemFn: func() upgrade.KernelSystem {
+			return fakeKernelSys{runningErr: errors.New("uname unreadable")}
+		},
+	}
+	d.holdSecondaryIfKernelCandidateArmed()
+	if !d.kernelUpgradeHoldFailClosed {
+		t.Fatal("precondition: fail-closed flag must be set")
+	}
+
+	// Journal now reads as a genuine armed candidate.
+	writeJournal(t, path, upgrade.KernelJournal{
+		State:            upgrade.KernelStateArmed,
+		CandidateVersion: "6.18.5-test",
+	})
+	d.reconcileKernelUpgradeHold()
+	if !m.KernelUpgradeHeld() {
+		t.Fatal("armed candidate must keep holding (not self-heal away)")
+	}
+	if d.kernelUpgradeHoldFailClosed {
+		t.Fatal("fail-closed flag must clear once the journal reads armed (now a normal armed hold)")
+	}
+}
+
+// TestReconcileKernelUpgradeHold_ArmedReleasesOnPromotion is a regression guard
+// that the existing strict release path still works: a normal armed hold is
+// released once the promotion marker names the running kernel.
+func TestReconcileKernelUpgradeHold_ArmedReleasesOnPromotion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kernel-upgrade.state")
+	writeJournal(t, path, upgrade.KernelJournal{
+		State:            upgrade.KernelStateArmed,
+		CandidateVersion: "6.18.5-test",
+	})
+	m := cluster.NewManager(0, 1)
+	d := &Daemon{
+		cluster:        m,
+		kernelRunnerFn: runnerAt(path),
+		kernelSystemFn: func() upgrade.KernelSystem {
+			return fakeKernelSys{running: "6.18.5-test", promoted: "6.18.5-test"}
+		},
+	}
+	d.holdSecondaryIfKernelCandidateArmed()
+	if !m.KernelUpgradeHeld() || d.kernelUpgradeHoldFailClosed {
+		t.Fatalf("precondition: armed hold, not fail-closed (held=%v failClosed=%v)",
+			m.KernelUpgradeHeld(), d.kernelUpgradeHoldFailClosed)
+	}
+	d.reconcileKernelUpgradeHold()
+	if m.KernelUpgradeHeld() {
+		t.Fatal("armed hold must release once the promotion marker matches the running kernel")
+	}
+}


### PR DESCRIPTION
Closes #5682 (codex-review-182 M24, High, security)

## Root cause
On a kernel-candidate boot, `holdSecondaryIfKernelCandidateArmed`
(`pkg/daemon/kernel_selfrecover.go`) reads the kernel-upgrade journal via
`KernelRunner.IsArmed()`. The old guard was:

```go
armed, j, err := r.IsArmed()
if err != nil || !armed {
    return   // <- no hold set; node runs a NORMAL election
}
d.cluster.SetKernelUpgradeHold()
```

`IsArmed` → `loadKernelJournal` already folds a clean **ENOENT** to
`KernelStateInit` + nil error, so `err != nil` is reached **only** on a
genuine read/parse failure of an existing-but-unreadable journal (I/O
error, corruption, malformed content). Collapsing that into the same
`return` as `!armed` meant an **unreadable** journal was treated as "not
armed" and the node proceeded to a normal candidate election — it could
elect/promote as if no upgrade were pending. Because an unreadable journal
is a failure mode that itself **correlates** with a bad upgrade (a
candidate kernel that corrupted `/var/lib/xpf`, a half-written journal
from a crash mid-roll), this failed **OPEN** and defeated the
promote/rollback safety of the #1930 A/B kernel channel.

## Fix
Split the branch in `holdSecondaryIfKernelCandidateArmed`:

- **`err != nil` (UNREADABLE / ambiguous)** → `SetKernelUpgradeHold()`
  **fail-CLOSED** + `slog.Warn` once, and record the fail-closed reason.
- **`!armed` (clean read, no upgrade)** → proceed normally (no hold).
- **armed** → hold as before (`slog.Info`).

### ENOENT vs. unreadable
The distinction is made precisely, one layer down, in `loadKernelJournal`:
`os.IsNotExist(err)` returns a zero `KernelStateInit` journal with a **nil**
error (so a missing file is a legitimate "not armed" and still proceeds —
a node that simply never armed an upgrade is **never** bricked into a
spurious hold), while every other read error and every `json.Unmarshal`
failure propagates as a non-nil error. So reaching the new fail-closed
branch means the journal **exists but cannot be read/parsed** — exactly
the case that must fail closed.

### Not stranded (bounded recovery)
A fail-closed hold set on a **transient** I/O blip (no upgrade actually in
progress) has no promotion marker to wait on, so the existing
marker-only release in `reconcileKernelUpgradeHold` would never fire and
the node would sit SECONDARY forever. To prevent that, the fail-closed
hold is tracked distinctly (`Daemon.kernelUpgradeHoldFailClosed`) and
`reconcileKernelUpgradeHold` **self-heals** it on its 5s tick by re-reading
the journal:

- still unreadable → keep holding fail-closed;
- now readable & **not armed** → **release** (the boot-time error was
  transient, no upgrade pending);
- now readable & **armed** → **convert** to a normal armed hold (clear the
  fail-closed flag; the strict promotion-marker gate then governs release).

The strict marker-only release is **preserved** for a genuinely-armed hold,
so the documented revert window (`revert()` clears the journal then
reboots) can never transiently promote an unverified candidate — only the
fail-closed hold gets the "release on a later clean not-armed read"
self-heal. A hold cleared by another path (rejoin / manual reset) also
clears the local fail-closed bookkeeping.

Added `kernelRunnerFn`/`kernelSystemFn` test seams to `Daemon` so the hold
path is unit-testable without a live UEFI host.

## Fail-on-revert tests (merge gate)
`pkg/daemon/kernel_upgrade_hold_failclosed_5682_test.go`:

- **UNREADABLE (parse failure)** → hold SET + fail-closed flag.
- **UNREADABLE (I/O error: path is a directory → EISDIR, not ENOENT)** →
  hold SET.
- **MISSING (ENOENT)** → NO hold (regression guard — never-armed node not
  bricked).
- **definitively ARMED** → hold (unchanged).
- **valid NOT-armed** → no hold.
- self-heal: fail-closed hold → still-unreadable keeps holding →
  now-not-armed **releases**; fail-closed → now-armed **converts**;
  armed-hold **releases on promotion marker** (regression guard).

Fail-on-revert proven firsthand. Neutralizing the fix (`if err != nil {
return }`, the old fail-open behavior):

```
--- FAIL: TestHoldSecondaryIfKernelCandidateArmed_FailClosed (0.00s)
    --- FAIL: .../unreadable_parse_failure_holds (0.00s)
        kernel_upgrade_hold_failclosed_5682_test.go:152: KernelUpgradeHeld() = false, want true
    --- FAIL: .../unreadable_io_error_holds (0.00s)
        kernel_upgrade_hold_failclosed_5682_test.go:152: KernelUpgradeHeld() = false, want true
--- FAIL: TestReconcileKernelUpgradeHold_FailClosedSelfHeals (0.00s)
    kernel_upgrade_hold_failclosed_5682_test.go:176: precondition: expected fail-closed hold set (held=false failClosed=false)
FAIL	github.com/psaab/xpf/pkg/daemon	0.030s
```

The ENOENT / armed / valid-not-armed cases stay green under the
neutralized code (they don't depend on the fail-closed branch), which
confirms the tests bind the specific unreadable→fail-closed behavior.
Restoring the fix → all GREEN.

## Validation
- `go build ./...`, `go vet ./pkg/daemon ./pkg/cluster` — clean.
- Full `pkg/daemon` + `pkg/cluster` suites GREEN under `-race`.
- `gofmt` clean.

**HA/upgrade — `test-failover` + upgrade-channel smoke are blocked by the
loss-cluster shim-ABI wall; this change is gated on the fail-on-revert
unit tests. Parent to record the smoke deferral.**

## Docs
`docs/in-place-upgrade.md` LANE-1 "Election hold" item 1 updated with the
fail-closed-on-unreadable contract, the ENOENT-vs-unreadable distinction,
and the self-heal / not-stranded rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)