### PR TITLE
dataplane: scope ifindex preflight to XPF-referenced links

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-16 — #5836 (dataplane loader): scope ifindex preflight to XPF-referenced links (codex-183)
+- **Timestamp**: 2026-07-16 (fix/5836-ifindex-preflight-scope)
+- **Action**: Fix #5836. `preflightCheckIfindexCaps` enumerated the WHOLE host
+  netns via `netlink.LinkList` and rejected the compile if ANY link had an
+  ifindex outside `[0, MaxInterfaces)` — so an unrelated bridge/veth/container
+  link or an abandoned operator netdev that churned past 65536 failed EVERY
+  subsequent userspace-dataplane compile, even though XPF's managed ports stayed
+  low. Chose **Option A (SCOPE)**: the preflight now takes a `referenced` set
+  and rejects only links XPF actually attaches AF_XDP to — the compiled port set
+  `result.pendingXDP` (physical zone interfaces, RETH members, VLAN parents,
+  tunnels, fabric parents, all resolved to `physIface.Index` in
+  compiler_iface.go). Moved both call sites (`CompileUserspaceShim` in loader.go;
+  retired-eBPF `Manager.Compile` in compiler.go) to run the check AFTER
+  `CompileConfig` so `pendingXDP` is populated — safe because every
+  ifindex-touching method of `userspaceShimCompileDataplane` (AddTxPort/SetZone/
+  SetVlanIfaceInfo/SetMirrorConfig) is a no-op, so CompileConfig writes no
+  ifindex-keyed kernel map before the check. Real fail-closed guardrails
+  UNCHANGED and preserved: `AddTxPort` tx_ports cap (loader.go) and the
+  `userspace_bindings` ARRAY cap `idx=ifindex*16+queue >= BindingArrayMaxEntries`
+  (userspace/maps_sync.go:696) still reject a genuinely-too-high XPF-mapped
+  ifindex. `userspace_ingress_ifaces` is a HASH (key=ifindex, no cap needed).
+  Rejected Option B (remove global preflight) because the userspace_bindings
+  guard fires at status-sync time (not compile) and the watchdog re-sync path
+  only logs-and-skips — keeping a scoped compile-time early-warning is safer.
+  Added `ifindexSet` helper. Tests (fail-on-revert, both firsthand RED-verified):
+  new `TestPreflightCheckIfindexCaps_UnrelatedHighIfindexIgnored` (the #5836 fix
+  — RED when scope guard reverted to whole-namespace),
+  `_ReferencedHighIfindexRejected` (real guard — RED when cap comparison
+  removed), `_EmptyReferencedPasses`; existing preflight tests updated to the
+  scoped signature. Build/vet clean; `pkg/dataplane` (minus pre-existing
+  unrelated `TestUserspaceManagerDoesNotImportReflectOrUnsafe`) + full
+  `pkg/dataplane/userspace` GREEN under `-race`.
+- **File(s)**: pkg/dataplane/loader.go, pkg/dataplane/compiler.go, pkg/dataplane/constants_test.go, _Log.md
+
 ## 2026-07-16 — #5765 (Rust dataplane): u16 length-cast defense-in-depth (claude-spark-review-002)
 - **Timestamp**: 2026-07-16 (fix/5765-u16-lencast-hardening)
 - **Action**: Harden 4 `... as u16` casts on packet/segment/frame lengths in the

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -312,19 +312,20 @@ func CompileConfig(dp DataPlane, cfg *config.Config, isRecompile bool) (*Compile
 
 // Compile translates a typed Config into eBPF map entries and attaches programs.
 func (m *Manager) Compile(cfg *config.Config) (*CompileResult, error) {
-	// Bonus early-warning gate: if any kernel ifindex already exceeds
-	// MaxInterfaces, fail now with a named-interface error rather than
-	// deep inside zone apply (AddTxPort returning E2BIG as "key too big
-	// for map"). See issue #814 — the call-site cap checks in
-	// loader.go's AddTxPort and userspace/maps_sync.go are the real
-	// guardrails since interfaces can appear via netlink at any time;
-	// this preflight just makes the first-compile failure legible.
-	if err := m.preflightCheckIfindexCaps(); err != nil {
+	result, err := CompileConfig(m, cfg, m.lastCompile != nil)
+	if err != nil {
 		return nil, err
 	}
 
-	result, err := CompileConfig(m, cfg, m.lastCompile != nil)
-	if err != nil {
+	// Scoped early-warning gate (#5836): if an interface XPF actually
+	// references (result.pendingXDP) exceeds MaxInterfaces, fail with a
+	// named-interface error. Scoping to the compiled port set means an
+	// unrelated high-ifindex host link no longer aborts every compile. See
+	// issue #814 — the call-site cap checks in loader.go's AddTxPort and
+	// userspace/maps_sync.go remain the real fail-closed guardrails since
+	// interfaces can appear via netlink at any time; this preflight just
+	// makes the first-compile failure legible.
+	if err := m.preflightCheckIfindexCaps(ifindexSet(result.pendingXDP)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/dataplane/constants_test.go
+++ b/pkg/dataplane/constants_test.go
@@ -57,7 +57,9 @@ func TestPreflightCheckIfindexCaps_WithinCap(t *testing.T) {
 		makeFakeLink("fab0", int(MaxInterfaces-1)),
 	}, nil)
 	m := &Manager{}
-	if err := m.preflightCheckIfindexCaps(); err != nil {
+	// All three links are XPF-referenced and within cap.
+	referenced := ifindexSet([]int{1, 2, int(MaxInterfaces - 1)})
+	if err := m.preflightCheckIfindexCaps(referenced); err != nil {
 		t.Fatalf("preflightCheckIfindexCaps returned %v, want nil", err)
 	}
 }
@@ -69,7 +71,8 @@ func TestPreflightCheckIfindexCaps_OverCap(t *testing.T) {
 		makeFakeLink("fab0", over),
 	}, nil)
 	m := &Manager{}
-	err := m.preflightCheckIfindexCaps()
+	// fab0 IS referenced (XPF attaches to it) and is over cap: must fail.
+	err := m.preflightCheckIfindexCaps(ifindexSet([]int{1, over}))
 	if err == nil {
 		t.Fatal("preflightCheckIfindexCaps returned nil, want error")
 	}
@@ -88,7 +91,7 @@ func TestPreflightCheckIfindexCaps_AtCapFails(t *testing.T) {
 		makeFakeLink("fab0", int(MaxInterfaces)),
 	}, nil)
 	m := &Manager{}
-	if err := m.preflightCheckIfindexCaps(); err == nil {
+	if err := m.preflightCheckIfindexCaps(ifindexSet([]int{int(MaxInterfaces)})); err == nil {
 		t.Fatal("preflightCheckIfindexCaps at cap returned nil, want error")
 	}
 }
@@ -97,9 +100,87 @@ func TestPreflightCheckIfindexCaps_NetlinkErrorIsNonFatal(t *testing.T) {
 	withFakeLinkLister(t, nil, errors.New("netlink temporary failure"))
 	m := &Manager{}
 	// The preflight must NOT abort compile on a transient netlink error
-	// — the call-site cap checks remain the real guardrail.
-	if err := m.preflightCheckIfindexCaps(); err != nil {
+	// — the call-site cap checks remain the real guardrail. Pass a
+	// non-empty referenced set so the linkLister call is actually reached.
+	if err := m.preflightCheckIfindexCaps(ifindexSet([]int{1})); err != nil {
 		t.Fatalf("preflightCheckIfindexCaps on netlink error returned %v, want nil", err)
+	}
+}
+
+// TestPreflightCheckIfindexCaps_UnrelatedHighIfindexIgnored is the #5836
+// fix: an unrelated host link (a bridge, veth, container link, or abandoned
+// operator netdev) with an ifindex >= MaxInterfaces that XPF does NOT
+// reference must NOT fail the compile. Only XPF-referenced links can key a
+// dense per-interface map, so only they are cap-checked.
+//
+// Fail-on-revert: neutralize the scope (make the loop reject every high
+// ifindex regardless of `referenced`, i.e. restore the whole-namespace
+// check) and this test goes RED because the unrelated br-lan link is
+// wrongly rejected.
+func TestPreflightCheckIfindexCaps_UnrelatedHighIfindexIgnored(t *testing.T) {
+	unrelated := int(MaxInterfaces) + 4242
+	withFakeLinkLister(t, []netlink.Link{
+		makeFakeLink("lo", 1),
+		makeFakeLink("ge-0-0-0", 6),
+		makeFakeLink("ge-0-0-1", 7),
+		// Unrelated management bridge that churned past the cap. Not in the
+		// XPF port set.
+		makeFakeLink("br-lan", unrelated),
+	}, nil)
+	m := &Manager{}
+	// XPF references only its two dataplane ports, both within cap.
+	referenced := ifindexSet([]int{6, 7})
+	if err := m.preflightCheckIfindexCaps(referenced); err != nil {
+		t.Fatalf("unrelated high-ifindex link wrongly failed the compile: %v", err)
+	}
+}
+
+// TestPreflightCheckIfindexCaps_ReferencedHighIfindexRejected proves the
+// real fail-closed guard is preserved: an XPF-referenced / map-bound link
+// with ifindex >= MaxInterfaces still fails, with a legible error naming
+// the interface and the remediation pointer.
+//
+// Fail-on-revert: neutralize the real guard (drop the `>= MaxInterfaces`
+// comparison / always return nil) and this test goes RED.
+func TestPreflightCheckIfindexCaps_ReferencedHighIfindexRejected(t *testing.T) {
+	over := int(MaxInterfaces) + 7
+	withFakeLinkLister(t, []netlink.Link{
+		makeFakeLink("lo", 1),
+		// An unrelated link that is ALSO over cap but not referenced —
+		// it must not be what triggers the error.
+		makeFakeLink("br-lan", int(MaxInterfaces)+9000),
+		// XPF's own dataplane port pushed past the cap.
+		makeFakeLink("ge-0-0-2", over),
+	}, nil)
+	m := &Manager{}
+	err := m.preflightCheckIfindexCaps(ifindexSet([]int{1, over}))
+	if err == nil {
+		t.Fatal("referenced over-cap link returned nil, want fail-closed error")
+	}
+	if !strings.Contains(err.Error(), "ge-0-0-2") {
+		t.Fatalf("error must name the referenced offending interface, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "br-lan") {
+		t.Fatalf("error wrongly blamed the unrelated link: %v", err)
+	}
+	if !strings.Contains(err.Error(), "MAX_INTERFACES") {
+		t.Fatalf("error missing remediation pointer: %v", err)
+	}
+}
+
+// TestPreflightCheckIfindexCaps_EmptyReferencedPasses confirms that when
+// XPF references no interfaces (empty/nil set), the preflight is a no-op
+// even if the host namespace holds a high-ifindex link.
+func TestPreflightCheckIfindexCaps_EmptyReferencedPasses(t *testing.T) {
+	withFakeLinkLister(t, []netlink.Link{
+		makeFakeLink("br-lan", int(MaxInterfaces)+1),
+	}, nil)
+	m := &Manager{}
+	if err := m.preflightCheckIfindexCaps(nil); err != nil {
+		t.Fatalf("empty referenced set returned %v, want nil", err)
+	}
+	if err := m.preflightCheckIfindexCaps(ifindexSet(nil)); err != nil {
+		t.Fatalf("ifindexSet(nil) returned %v, want nil", err)
 	}
 }
 

--- a/pkg/dataplane/loader.go
+++ b/pkg/dataplane/loader.go
@@ -171,9 +171,6 @@ func (m *Manager) LoadUserspaceShim() error {
 // attaches only the retained userspace XDP shim. This keeps normal AF_XDP
 // startup independent from xdp_main and TC program objects.
 func (m *Manager) CompileUserspaceShim(cfg *config.Config) (*CompileResult, error) {
-	if err := m.preflightCheckIfindexCaps(); err != nil {
-		return nil, err
-	}
 	if err := cleanupUserspaceShimLegacyTCLinks(); err != nil {
 		return nil, err
 	}
@@ -185,6 +182,16 @@ func (m *Manager) CompileUserspaceShim(cfg *config.Config) (*CompileResult, erro
 	compilerDP := userspaceShimCompileDataplane{Manager: m}
 	result, err := CompileConfig(compilerDP, cfg, m.lastCompile != nil)
 	if err != nil {
+		return nil, err
+	}
+	// Scoped ifindex-cap early-warning (#5836): reject only when an
+	// interface XPF actually attaches AF_XDP to (result.pendingXDP) has an
+	// ifindex >= MaxInterfaces — an unrelated high-ifindex host link must
+	// not fail the compile. The compiler's shim dataplane methods are
+	// no-ops, so CompileConfig writes no ifindex-keyed map before this runs;
+	// the userspace_bindings ARRAY cap in maps_sync.go stays the real
+	// fail-closed guardrail.
+	if err := m.preflightCheckIfindexCaps(ifindexSet(result.pendingXDP)); err != nil {
 		return nil, err
 	}
 	if err := m.attachUserspaceShimXDP(result); err != nil {
@@ -999,17 +1006,47 @@ func (m *Manager) AddTxPort(ifindex int) error {
 // can inject a fake without spinning up a netns.
 var linkLister = netlink.LinkList
 
-// preflightCheckIfindexCaps enumerates kernel links and returns a
-// descriptive error if any ifindex already exceeds MaxInterfaces. Called
-// from Manager.Compile() so every compile cycle fires it — catching
-// cases where a new namespace pushed ifindex past the cap between
-// config snapshots, before AddTxPort hits E2BIG deep in zone apply.
+// ifindexSet builds a lookup set from a slice of interface indexes. It
+// returns nil for an empty input so preflightCheckIfindexCaps can cheaply
+// short-circuit a config that references no interfaces.
+func ifindexSet(ifindexes []int) map[int]bool {
+	if len(ifindexes) == 0 {
+		return nil
+	}
+	s := make(map[int]bool, len(ifindexes))
+	for _, idx := range ifindexes {
+		s[idx] = true
+	}
+	return s
+}
+
+// preflightCheckIfindexCaps scans kernel links and returns a descriptive
+// error if an interface XPF actually references (attaches AF_XDP to /
+// inserts into a dense per-interface dataplane map) has an ifindex outside
+// [0, MaxInterfaces). Callers pass `referenced` — the compiled port set
+// (result.pendingXDP) — so the check is SCOPED to XPF's own interfaces.
 //
-// This is a bonus early-warning gate; the call-site cap checks in
-// AddTxPort and userspace/maps_sync.go are the real guardrails. Both
-// layers exist because interfaces can appear via netlink events at any
-// time (HA reconcile, link hotplug), not only at compile.
-func (m *Manager) preflightCheckIfindexCaps() error {
+// #5836: an UNRELATED host link (a bridge, veth, container link, or an
+// abandoned operator netdev) with a high ifindex must NOT fail the compile.
+// Only a link whose ifindex would key a dense dataplane map can overflow it,
+// so only those links are candidates for rejection. Long-lived namespaces
+// reach ifindex >= 65536 through interface churn even when XPF's managed
+// ports stay low; the previous whole-namespace enumeration rejected every
+// subsequent compile in that state.
+//
+// This remains a best-effort early-warning gate; the call-site cap checks in
+// AddTxPort (tx_ports DEVMAP) and userspace/maps_sync.go (userspace_bindings
+// ARRAY, idx = ifindex*BindingQueuesPerIface + queue) are the real
+// fail-closed guardrails. Both layers exist because interfaces can appear via
+// netlink events at any time (HA reconcile, link hotplug), not only at
+// compile. Called after CompileConfig so `referenced` reflects the exact set
+// of interfaces the compile resolved.
+func (m *Manager) preflightCheckIfindexCaps(referenced map[int]bool) error {
+	if len(referenced) == 0 {
+		// No XPF-referenced interfaces resolved (e.g. empty config): nothing
+		// can overflow a per-interface map, so there is nothing to pre-check.
+		return nil
+	}
 	links, err := linkLister()
 	if err != nil {
 		// Non-fatal: a transient netlink error on preflight should not
@@ -1021,6 +1058,12 @@ func (m *Manager) preflightCheckIfindexCaps() error {
 	for _, l := range links {
 		attrs := l.Attrs()
 		if attrs == nil {
+			continue
+		}
+		if !referenced[attrs.Index] {
+			// Not an interface XPF attaches/maps — an unrelated bridge, veth,
+			// container link, or operator netdev with a high ifindex must not
+			// fail the compile (#5836).
 			continue
 		}
 		if attrs.Index < 0 || uint32(attrs.Index) >= MaxInterfaces {


### PR DESCRIPTION
## Summary

`Manager.preflightCheckIfindexCaps` (`pkg/dataplane/loader.go`) enumerated
the **entire host network namespace** via `netlink.LinkList` and rejected the
compile if **any** link had an ifindex outside `[0, MaxInterfaces)` (65536).
The check was not scoped to the interfaces XPF actually references, so a
completely unrelated bridge, veth, management link, container link, or an
abandoned operator netdev with ifindex ≥ 65536 made **every** subsequent
`CompileUserspaceShim` fail. Long-lived namespaces reach that value through
interface churn even when XPF's managed ports stay low — the firewall could
wedge with no bad config of its own. The function's own comment already noted
that the real call-site checks (`AddTxPort`, `userspace/maps_sync.go`) are what
actually matter.

Closes #5836

## Root cause

`preflightCheckIfindexCaps` ran `for _, l := range linkLister()` and rejected on
`uint32(attrs.Index) >= MaxInterfaces` for **any** link — never filtered to the
links XPF attaches AF_XDP to or inserts into a dense per-interface dataplane map.

Which links actually need `ifindex < MaxInterfaces`?
- **`userspace_bindings`** is an `ebpf.Array` indexed by
  `idx = ifindex*BindingQueuesPerIface + queue`, so a bound interface's ifindex
  must stay under the cap or the flat index overflows. This is the real
  truncation surface.
- **`userspace_ingress_ifaces`** is a `HASH` keyed by ifindex — a high ifindex
  is a valid key, no cap needed.
- **`tx_ports`** (DEVMAP, `AddTxPort`) is **not populated** on the userspace
  path — `userspaceShimCompileDataplane.AddTxPort` is a no-op — it only applies
  to the retired-eBPF `Manager.Compile` path.

So only the interfaces in the compiled port set can overflow a map; unrelated
host links cannot.

## Fix — Option A (SCOPE), not Option B (remove)

`preflightCheckIfindexCaps(referenced map[int]bool)` now rejects **only** links
whose ifindex is in `referenced`. Callers pass `result.pendingXDP` — the
compiler's resolved port set (physical zone interfaces, RETH members, VLAN
parents, tunnels, and fabric parents, all resolved to `physIface.Index` in
`compiler_iface.go`). An unrelated high-ifindex host link is skipped.

Both call sites now run the check **after** `CompileConfig` (so `pendingXDP` is
populated):
- `CompileUserspaceShim` (loader.go) — the live path.
- `Manager.Compile` (compiler.go) — the retired-eBPF path, fixed for
  consistency (same false-rejection existed there).

This is safe on the userspace path because every ifindex-touching method of
`userspaceShimCompileDataplane` (`AddTxPort`, `SetZone`, `SetVlanIfaceInfo`,
`SetMirrorConfig`) is a no-op — `CompileConfig` writes no ifindex-keyed kernel
map before the scoped check runs, so nothing can truncate in between.

**Why A, not B:** Option B (remove the global preflight, rely purely on the
per-port checks) was rejected because the `userspace_bindings` guard fires at
helper-status-sync time rather than at compile, and the bindings watchdog
re-sync path only logs-and-skips. Keeping a scoped **compile-time** early-warning
with a legible error is the safer choice and matches the "early legible error"
intent.

## Real fail-closed guard preserved

Unchanged and still fail-closed for a genuinely-too-high **XPF-managed** ifindex:
- `userspace_bindings` ARRAY cap in `pkg/dataplane/userspace/maps_sync.go`:
  `idx >= dataplane.BindingArrayMaxEntries` → `failClosedUserspaceCtrlLocked`
  with a legible error naming ifindex + queue.
- `AddTxPort` tx_ports cap in `loader.go` (retired-eBPF path).

The scoped preflight *also* still rejects a referenced-and-over-cap ifindex at
compile time. This PR removes only the **false** rejection of unrelated links —
it does **not** open a hole for a real XPF ifindex that would truncate a map.

## Fail-on-revert tests (merge gate) — RED verified firsthand

Unit tests drive `preflightCheckIfindexCaps(referenced)` directly via the
existing injected `linkLister` seam.

**1. The #5836 fix** — `TestPreflightCheckIfindexCaps_UnrelatedHighIfindexIgnored`:
an unrelated `br-lan` link at ifindex 69778 (not in `referenced`) must not fail
the compile. Neutralizing the fix (restore the whole-namespace check by dropping
the scope guard):
```
=== RUN   TestPreflightCheckIfindexCaps_UnrelatedHighIfindexIgnored
    constants_test.go:134: unrelated high-ifindex link wrongly failed the compile: preflightCheckIfindexCaps: interface "br-lan" ifindex 69778 exceeds MAX_INTERFACES cap 65536 (raise MAX_INTERFACES in bpf/headers/xpf_common.h)
--- FAIL: TestPreflightCheckIfindexCaps_UnrelatedHighIfindexIgnored (0.00s)
```

**2. The preserved real guard** —
`TestPreflightCheckIfindexCaps_ReferencedHighIfindexRejected`: an XPF-referenced
`ge-0-0-2` link over cap must still fail (and the unrelated over-cap link must
not be blamed). Neutralizing the real guard (drop the `>= MaxInterfaces`
comparison):
```
=== RUN   TestPreflightCheckIfindexCaps_OverCap
    constants_test.go:77: preflightCheckIfindexCaps returned nil, want error
--- FAIL: TestPreflightCheckIfindexCaps_OverCap (0.00s)
=== RUN   TestPreflightCheckIfindexCaps_AtCapFails
    constants_test.go:95: preflightCheckIfindexCaps at cap returned nil, want error
--- FAIL: TestPreflightCheckIfindexCaps_AtCapFails (0.00s)
=== RUN   TestPreflightCheckIfindexCaps_ReferencedHighIfindexRejected
    constants_test.go:158: referenced over-cap link returned nil, want fail-closed error
--- FAIL: TestPreflightCheckIfindexCaps_ReferencedHighIfindexRejected (0.00s)
```
Both restored → GREEN.

**3. Regression** — `TestPreflightCheckIfindexCaps_WithinCap` /
`_EmptyReferencedPasses`: all-low-ifindex / empty-referenced host passes.

## Validation

- `go build ./...`, `go vet ./pkg/dataplane/...` — clean.
- `pkg/dataplane` and `pkg/dataplane/userspace` pass under `-race`. The only
  `pkg/dataplane` failure is the **pre-existing, unrelated**
  `TestUserspaceManagerDoesNotImportReflectOrUnsafe` (`manager_overlay.go`
  imports `reflect`; file is byte-identical to `origin/master` and untouched
  by this PR).
- This is a Go loader change (not dataplane forwarding), gated on unit tests —
  **no loss-cluster smoke needed**.

## Docs

The ifindex-preflight contract is documented only in the historical PR record
`docs/pr/814-max-interfaces/` (a point-in-time doc, not rewritten). The live
`pkg/dataplane/README.md` does not mention the preflight/ifindex cap, so no
module doc needs an update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e6JXS2Q64exkgDo6bKdKE
