### PR TITLE
ddns: guard wire-RR clobber across both ownership surfaces (#5748)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-16 — #5748 (pkg/ddns, security): cross-surface DDNS wire-RR clobber guard
+- **Timestamp**: 2026-07-16 (fix/5748-ddns-cross-surface-clobber)
+- **Action**: Extend the #5709 wire-RR co-ownership clobber guard across BOTH
+  DDNS ownership surfaces. The #5709 guard (`wireRRSharedWithOther`) scanned only
+  the Surface B lease store (`Manager.state.records`, rdata in `Address`); a
+  Surface A router/interface record (`SurfaceAManager`, rdata in `AddrText`) that
+  co-owns the identical wire RR (same canonical FQDN + forward type + IP) was
+  invisible, so a lease teardown could still issue a wire DELETE that clobbered
+  the Surface-A-owned RR (and symmetrically a Surface A teardown could clobber a
+  lease-owned RR). Fixed BOTH directions. Mechanism: each surface publishes a
+  LOCK-FREE snapshot of its wire-RR claims (`WireRRClaims`, backed by
+  `atomic.Pointer[[]WireRRClaim]`, rebuilt under the manager's own `mu` at the end
+  of every non-degraded reconcile pass + after load); the daemon injects each
+  surface's accessor into the other (`SetSurfaceACoownerSource` /
+  `SetLeaseCoownerSource` in `pkg/daemon/daemon_run.go`). The lease guard scans
+  the injected Surface A snapshot after its own store; the Surface A
+  `withdrawOwnedLocked` adds a per-target lease-coowner skip. **Deadlock-free by
+  construction:** the accessor is a bare atomic load, so a teardown holding its
+  own `mu` never blocks on the peer's `mu` (no AB-BA cycle). Nil accessor ⇒
+  pre-#5748 single-surface behavior; nil-safe.
+- **File(s)**: pkg/ddns/state.go (new `WireRRClaim` type + `wireRRClaim` helper),
+  pkg/ddns/manager.go (`surfaceACoowners`/`wireRRClaims` fields, `SetSurfaceA…`,
+  `WireRRClaims`, `rebuildWireRRClaimsLocked`, extended `wireRRSharedWithOther`,
+  seed on load), pkg/ddns/surface_a.go (`leaseCoowners`/`wireRRClaims` fields +
+  `deleteCoowned` counter, `SetLeaseCoownerSource`, `WireRRClaims`,
+  `rebuildWireRRClaimsLocked`, `leaseWireRRCoowner`, per-target skip in
+  `withdrawOwnedLocked`, `SurfaceAStats.DeleteCoowned`), pkg/daemon/daemon_run.go
+  (cross-wire the two accessors), pkg/ddns/cross_surface_clobber_5748_test.go
+  (new, 5 fail-on-revert + regression tests), pkg/ddns/README.md (co-ownership
+  section extended to both surfaces).
+- **Validation**: `go build ./...`, `go vet ./pkg/ddns ./pkg/daemon` clean;
+  `go test ./pkg/ddns ./pkg/daemon -race` GREEN. Fail-on-revert proven firsthand
+  BOTH directions: neutralize the lease-side arm → RED (lease teardown DELETED
+  host-a.example.com=10.0.0.10); neutralize the Surface A per-target skip → RED
+  (surface A teardown DELETED wan.example.net=203.0.113.5). Restored → GREEN.
+
 ## 2026-07-16 — #5765 (Rust dataplane): u16 length-cast defense-in-depth (claude-spark-review-002)
 - **Timestamp**: 2026-07-16 (fix/5765-u16-lencast-hardening)
 - **Action**: Harden 4 `... as u16` casts on packet/segment/frame lengths in the

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1736,6 +1736,14 @@ func (d *Daemon) initManagers(configCompileFailed bool) error {
 		// publish). Constructed unconditionally for the same reason as the lease
 		// manager — a binding removal must have a running loop to withdraw.
 		d.surfaceA.mgr = ddns.NewSurfaceAManager()
+		// #5748: cross-wire the two DDNS ownership surfaces so each teardown guard
+		// can see a wire RR the OTHER surface co-owns and suppress a DELETE that
+		// would clobber it (the cross-surface arm of the #5709 co-ownership guard).
+		// Each accessor is a LOCK-FREE snapshot read (an atomic.Pointer load in the
+		// peer, never taking the peer's mutex), so a teardown holding its own
+		// manager's mu can consult the peer with no lock-order cycle / deadlock.
+		d.ddns.SetSurfaceACoownerSource(d.surfaceA.mgr.WireRRClaims)
+		d.surfaceA.mgr.SetLeaseCoownerSource(d.ddns.WireRRClaims)
 	}
 
 	// Create the RPM manager eagerly so the pointer is stable for the

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -520,6 +520,20 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   (standalone / pre-wire boot) restores the pre-#5748 single-surface behavior.
   Surface A suppressions are counted (`SurfaceAStats.DeleteCoowned`); both
   directions are fail-on-revert covered by `cross_surface_clobber_5748_test.go`.
+  **Eventual-consistency caveat (#5748 follow-up):** the cross-surface
+  snapshot is rebuilt at the END of each reconcile pass, so cross-surface
+  visibility is eventually- (not strongly-) consistent. Two tight-race
+  windows remain — both a STRICT improvement over the prior deterministic,
+  always-reachable cross-surface clobber, not a new outage class: (a) a
+  just-published co-owner not yet in the peer snapshot when the other
+  surface tears down → a residual clobber that shrinks the prior 100%
+  clobber to a sub-millisecond race (operator-repairable via `request
+  system dynamic-dns update`, the #5710 force-update); (b) both surfaces
+  tearing down the SAME co-owned RR in overlapping passes each read the
+  other's pre-rebuild snapshot and both suppress → the RR — still holding
+  the identical published rdata (a valid, not-orphaned record) — is left on
+  the wire until an owner's later IP change re-issues it. A deterministic
+  suppression tie-break to close window (b) is tracked as a #5748 follow-up.
 - **Source / VRF binding (#2665, `backend_bind.go`)** — the per-family
   `source-address` / `destination-interface` / `routing-instance` leaves build a
   custom `net.Dialer` (one `Control` hook: `unix.Bind` for the source IP +

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -497,6 +497,29 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   claim table). Suppressions are counted (`Stats.DeleteCoowned`, the
   `xpf_dhcp_ddns_skipped_total{reason="coowned"}` metric) and covered by
   `TestCoOwnedWireRRSurvivesOtherScopeTeardown`.
+- **Cross-surface co-ownership — the guard spans BOTH ownership surfaces
+  (#5748)** — the #5709 guard originally scanned ONLY the lease store
+  (Surface B, `Manager.state.records`, rdata in `Address`). Router / interface
+  DDNS records live in the SEPARATE Surface A store (`SurfaceAManager`, rdata in
+  `AddrText`), so a Surface A record and a Surface B lease that resolve the same
+  host to the same address co-own ONE wire RR that neither surface's guard could
+  see — a teardown on either surface could still clobber the identical RR the
+  OTHER owns. Each surface now publishes a LOCK-FREE snapshot of its wire-RR
+  claims (`Manager.WireRRClaims` / `SurfaceAManager.WireRRClaims`, backed by an
+  `atomic.Pointer[[]WireRRClaim]` rebuilt under the manager's own mutex at the
+  end of every non-degraded reconcile pass and after load). The daemon injects
+  each surface's accessor into the other (`SetSurfaceACoownerSource` /
+  `SetLeaseCoownerSource`, wired in `pkg/daemon/daemon_run.go`).
+  `wireRRSharedWithOther` (lease side) and the per-target skip in
+  `SurfaceAManager.withdrawOwnedLocked` (Surface A side) consult the peer's
+  snapshot in addition to their own store, so a co-owned RR is preserved
+  regardless of which surface owns the survivor. **Lock order / deadlock-free by
+  construction:** the accessor is a bare atomic load — a teardown reads the peer
+  snapshot WITHOUT taking the peer's mutex, so a guard holding its own manager's
+  `mu` never blocks on the peer's `mu` (no AB-BA cycle). A nil accessor
+  (standalone / pre-wire boot) restores the pre-#5748 single-surface behavior.
+  Surface A suppressions are counted (`SurfaceAStats.DeleteCoowned`); both
+  directions are fail-on-revert covered by `cross_surface_clobber_5748_test.go`.
 - **Source / VRF binding (#2665, `backend_bind.go`)** — the per-family
   `source-address` / `destination-interface` / `routing-instance` leaves build a
   custom `net.Dialer` (one `Control` hook: `unix.Bind` for the source IP +

--- a/pkg/ddns/cross_surface_clobber_5748_test.go
+++ b/pkg/ddns/cross_surface_clobber_5748_test.go
@@ -1,0 +1,229 @@
+package ddns
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// #5748 cross-surface wire-RR clobber guard tests.
+//
+// #5709 added the wireRRSharedWithOther co-ownership guard so a DHCP-lease
+// (Surface B) teardown does not delete a wire RR another lease scope still
+// co-owns. That guard scanned ONLY the lease store (m.state.records). Router /
+// interface DDNS records live in a SEPARATE ownership surface (Surface A,
+// SurfaceAManager, rdata in AddrText not Address). A Surface A record and a
+// Surface B lease can resolve the SAME host to the SAME address and thus co-own
+// ONE wire RR — but the #5709 guard could not see the other surface, so a
+// teardown on either surface could still CLOBBER the identical RR the other
+// surface owns and refreshes. #5748 extends the guard across BOTH surfaces via a
+// LOCK-FREE claim-snapshot accessor the daemon injects in each direction.
+//
+// These are the fail-on-revert proofs. They assert on the WIRE DELETE
+// disposition (the fakeUpdater's recorded deletes), not merely an internal flag.
+// The Surface-B-to-Surface-B #5709 guard itself stays covered by
+// TestCoOwnedWireRRSurvivesOtherScopeTeardown (scope_test.go), which runs with a
+// nil cross-surface accessor and therefore also guards that the pre-#5748
+// Surface-B path is unchanged (regression (ii)).
+
+// TestLeaseTeardownSuppressedBySurfaceACoowner_5748 is the primary fail-on-revert
+// test for the lease→Surface-A direction: a DHCP lease publishes
+// host-a.example.com A 10.0.0.10, and a Surface A router record co-owns the
+// IDENTICAL wire RR. When the lease expires, its teardown must NOT issue the wire
+// DELETE — that would clobber the Surface-A-owned RR.
+//
+// Fail-on-revert: neutralize the cross-surface arm of wireRRSharedWithOther (drop
+// the m.surfaceACoowners scan) and the lease teardown reconstructs
+// host-a.example.com A 10.0.0.10 from its expiring owned record and issues a wire
+// DELETE — the "no delete" assertion below then goes RED.
+func TestLeaseTeardownSuppressedBySurfaceACoowner_5748(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+
+	// A Surface A router record co-owns the SAME wire RR. On the Surface A side its
+	// rdata lives in AddrText; the injected accessor presents the already-normalized
+	// WireRRClaim the lease guard consults (exactly what SurfaceAManager.WireRRClaims
+	// returns in production).
+	m.surfaceACoowners = func() []WireRRClaim {
+		return []WireRRClaim{wireRRClaim("host-a.example.com", "A", "10.0.0.10")}
+	}
+
+	// Phase 1: publish + own the lease record.
+	if err := runReconcile(t, m, pol, []Lease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatalf("phase 1 reconcile: %v", err)
+	}
+	if n := len(m.state.records); n != 1 {
+		t.Fatalf("phase 1: lease record must be owned, got %d", n)
+	}
+	up.upserts = nil
+	up.deletes = nil
+
+	// Phase 2: the lease disappears (expiry) → teardown. The wire RR is still
+	// co-owned by the Surface A record, so NO wire delete may be issued.
+	if err := runReconcile(t, m, pol, nil); err != nil {
+		t.Fatalf("phase 2 reconcile: %v", err)
+	}
+
+	// THE ASSERTION (RED pre-fix): no wire delete for the Surface-A-co-owned RR.
+	if names := up.deleteNames(); len(names) != 0 {
+		t.Fatalf("lease teardown issued a wire DELETE for a Surface-A-co-owned RR "+
+			"(cross-surface clobber #5748): %v", names)
+	}
+	// The suppression is observable and reuses the #5709 counter.
+	if got := m.deleteCoowned.Load(); got != 1 {
+		t.Fatalf("expected exactly one cross-surface co-owned suppression, got %d", got)
+	}
+	// The lease's own ownership claim is released; the RR is left live for Surface A.
+	if n := len(m.state.records); n != 0 {
+		t.Fatalf("lease ownership claim must be released after suppression, got %d", n)
+	}
+}
+
+// TestLeaseTeardownNoCoownerStillDeletes_5748 is regression guard (i): a lease
+// teardown with NO co-owner on EITHER surface still issues the wire DELETE (no
+// over-suppression → no stale RR left on the wire). The accessor is wired but
+// returns a NON-matching claim, so the cross-surface arm must not fire.
+func TestLeaseTeardownNoCoownerStillDeletes_5748(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	// A Surface A record exists, but for a DIFFERENT name/address — not a co-owner.
+	m.surfaceACoowners = func() []WireRRClaim {
+		return []WireRRClaim{wireRRClaim("other.example.com", "A", "10.9.9.9")}
+	}
+
+	if err := runReconcile(t, m, pol, []Lease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatalf("phase 1 reconcile: %v", err)
+	}
+	up.deletes = nil
+	if err := runReconcile(t, m, pol, nil); err != nil {
+		t.Fatalf("phase 2 reconcile: %v", err)
+	}
+
+	if got := up.deleteNames(); !equalStr(got, []string{"host-a.example.com=10.0.0.10"}) {
+		t.Fatalf("a lease teardown with NO co-owner must issue the wire delete; got %v", got)
+	}
+	if got := m.deleteCoowned.Load(); got != 0 {
+		t.Fatalf("no suppression expected without a co-owner, got %d", got)
+	}
+	if n := len(m.state.records); n != 0 {
+		t.Fatalf("ownership must be cleared after a real withdraw, got %d", n)
+	}
+}
+
+// TestLeaseTeardownNilSurfaceAAccessorDeletes_5748 is regression guard (iii): a
+// nil Surface A accessor (not wired — standalone / test / pre-wire boot) behaves
+// EXACTLY as pre-#5748: the lease teardown issues the wire DELETE and never
+// panics.
+func TestLeaseTeardownNilSurfaceAAccessorDeletes_5748(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up) // m.surfaceACoowners is nil (never wired)
+	pol := enabledPolicy()
+
+	if err := runReconcile(t, m, pol, []Lease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatalf("phase 1 reconcile: %v", err)
+	}
+	up.deletes = nil
+	if err := runReconcile(t, m, pol, nil); err != nil {
+		t.Fatalf("phase 2 reconcile: %v", err)
+	}
+
+	if got := up.deleteNames(); !equalStr(got, []string{"host-a.example.com=10.0.0.10"}) {
+		t.Fatalf("nil Surface A accessor must behave as pre-#5748 (delete issued); got %v", got)
+	}
+	if got := m.deleteCoowned.Load(); got != 0 {
+		t.Fatalf("nil accessor must never suppress, got %d", got)
+	}
+}
+
+// TestSurfaceATeardownSuppressedByLeaseCoowner_5748 is the fail-on-revert test for
+// the SYMMETRIC direction (Surface A → lease): a Surface A router record publishes
+// wan.example.net A 203.0.113.5, and a DHCP lease co-owns the IDENTICAL wire RR.
+// When the Surface A binding is removed, its withdraw must NOT issue the wire
+// DELETE — that would clobber the lease-owned RR.
+//
+// Fail-on-revert: neutralize the per-target leaseWireRRCoowner skip in
+// withdrawOwnedLocked and the Surface A teardown issues a wire DELETE of
+// wan.example.net A 203.0.113.5 — the "no delete" assertion goes RED.
+func TestSurfaceATeardownSuppressedByLeaseCoowner_5748(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+
+	// A DHCP lease scope co-owns the SAME wire RR (rdata in Address on the lease
+	// side); the injected accessor presents the normalized WireRRClaim (exactly what
+	// Manager.WireRRClaims returns in production).
+	m.SetLeaseCoownerSource(func() []WireRRClaim {
+		return []WireRRClaim{wireRRClaim("wan.example.net", "A", "203.0.113.5")}
+	})
+
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	obs := fixedObserver("203.0.113.5")
+
+	// Phase 1: publish the Surface A record.
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil); err != nil {
+		t.Fatalf("phase 1 publish: %v", err)
+	}
+	if st := m.Stats(); st.Scopes != 1 || st.UpsertOK != 1 {
+		t.Fatalf("phase 1 stats: %+v", st)
+	}
+
+	// Phase 2: the binding is REMOVED → withdraw. The RR is still co-owned by the
+	// DHCP lease, so NO wire delete may be issued.
+	now = now.Add(time.Minute)
+	fu.deletes = nil
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{}, obs, nil, nil); err != nil {
+		t.Fatalf("phase 2 withdraw: %v", err)
+	}
+
+	// THE ASSERTION (RED pre-fix): no wire delete for the lease-co-owned RR.
+	if names := fu.deleteNames(); len(names) != 0 {
+		t.Fatalf("surface A teardown issued a wire DELETE for a lease-co-owned RR "+
+			"(cross-surface clobber #5748): %v", names)
+	}
+	st := m.Stats()
+	if st.DeleteCoowned != 1 {
+		t.Fatalf("expected exactly one cross-surface suppression, got %+v", st)
+	}
+	// No real withdraw happened, so DeleteOK must not be inflated.
+	if st.DeleteOK != 0 {
+		t.Fatalf("no wire delete was issued; DeleteOK must stay 0, got %d", st.DeleteOK)
+	}
+	// The Surface A ownership claim is released; the RR is left live for the lease.
+	if st.Scopes != 0 {
+		t.Fatalf("surface A ownership must be released after suppression, got Scopes=%d", st.Scopes)
+	}
+}
+
+// TestSurfaceATeardownNoLeaseCoownerStillDeletes_5748 is the symmetric regression
+// guard: a Surface A teardown with NO lease co-owner still issues the wire DELETE
+// (and a nil lease accessor never panics — the accessor here returns a
+// non-matching claim, and the nil-accessor path is covered by every pre-existing
+// surface_a withdraw test which never wires a lease source).
+func TestSurfaceATeardownNoLeaseCoownerStillDeletes_5748(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	m.SetLeaseCoownerSource(func() []WireRRClaim {
+		return []WireRRClaim{wireRRClaim("other.example.net", "A", "198.51.100.7")}
+	})
+
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	obs := fixedObserver("203.0.113.5")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil); err != nil {
+		t.Fatalf("phase 1 publish: %v", err)
+	}
+	now = now.Add(time.Minute)
+	fu.deletes = nil
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{}, obs, nil, nil); err != nil {
+		t.Fatalf("phase 2 withdraw: %v", err)
+	}
+
+	if got := fu.deleteNames(); !contains(got, "wan.example.net=203.0.113.5") {
+		t.Fatalf("a surface A teardown with NO lease co-owner must issue the wire delete; got %v", got)
+	}
+	if st := m.Stats(); st.DeleteCoowned != 0 {
+		t.Fatalf("no suppression expected without a lease co-owner, got %+v", st)
+	}
+}

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -424,6 +424,28 @@ type Manager struct {
 
 	// last resolved policy (for Stats()).
 	lastPolicy atomic.Pointer[ddnsPolicy]
+
+	// surfaceACoowners, when non-nil, returns the wire-RR claims currently owned
+	// by the SEPARATE Surface A ownership surface (router/interface DDNS records,
+	// whose rdata lives in AddrText not Address, in the SurfaceAManager store).
+	// The daemon injects it (SetSurfaceACoownerSource) so this lease teardown can
+	// suppress a wire DELETE that would clobber a Surface-A-owned identical RR —
+	// the cross-surface arm of the #5709 co-ownership class (#5748). It is a
+	// LOCK-FREE snapshot accessor (an atomic.Pointer load inside SurfaceAManager);
+	// it MUST NOT take SurfaceAManager.mu, so wireRRSharedWithOther can call it
+	// while THIS manager holds m.mu without any lock-order cycle. Lock order:
+	// m.mu (held) → lock-free peer read (no peer mutex). Nil in tests / standalone
+	// / a not-yet-wired boot ⇒ exactly the pre-#5748 Surface-B-only scan.
+	surfaceACoowners func() []WireRRClaim
+
+	// wireRRClaims is the LOCK-FREE snapshot of the wire RRs THIS (Surface B lease)
+	// surface currently owns, published for the Surface A teardown guard to consult
+	// symmetrically (#5748). Rebuilt under m.mu at the end of every non-degraded
+	// reconcile pass and after load (rebuildWireRRClaimsLocked), and read via
+	// WireRRClaims() with a bare atomic load — never taking m.mu — so the peer can
+	// query it while holding SurfaceAManager.mu without a deadlock. Nil until the
+	// first rebuild; WireRRClaims() then returns an empty slice.
+	wireRRClaims atomic.Pointer[[]WireRRClaim]
 }
 
 // loadStateOrDegrade loads the ownership store and classifies a load failure
@@ -508,7 +530,7 @@ func NewManager(parser LeaseParser, updater DNSUpdater, nodeID string) *Manager 
 			"(record reconcile logged-and-skipped until a backend exists)")
 		updater = nopUpdater{}
 	}
-	return &Manager{
+	m := &Manager{
 		state:          st,
 		degraded:       degraded,
 		degradedReason: reason,
@@ -519,6 +541,11 @@ func NewManager(parser LeaseParser, updater DNSUpdater, nodeID string) *Manager 
 		leasePath6:     "/var/lib/kea/kea-leases6.csv",
 		now:            time.Now,
 	}
+	// #5748: seed the cross-surface wire-RR claim snapshot from the loaded store so
+	// the Surface A guard sees this surface's ownership from the very first pass
+	// (before this manager's first reconcile). Construction is single-threaded.
+	m.rebuildWireRRClaimsLocked()
+	return m
 }
 
 // NewProductionManager constructs the always-on production manager
@@ -558,7 +585,7 @@ func newManagerForTesting(parser LeaseParser, updater DNSUpdater, statePath, lea
 	if updater == nil {
 		updater = nopUpdater{}
 	}
-	return &Manager{
+	m := &Manager{
 		state:          st,
 		degraded:       degraded,
 		degradedReason: reason,
@@ -569,6 +596,8 @@ func newManagerForTesting(parser LeaseParser, updater DNSUpdater, statePath, lea
 		leasePath6:     leasePath6,
 		now:            now,
 	}
+	m.rebuildWireRRClaimsLocked() // #5748: seed the cross-surface claim snapshot
+	return m
 }
 
 // NewManagerForTesting builds a Manager with injectable lease parser, state +
@@ -805,6 +834,11 @@ func (m *Manager) ReconcileScoped(ctx context.Context, cfg *config.DHCPServerCon
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// #5748: republish this surface's wire-RR claim snapshot for the Surface A
+	// teardown guard AFTER the pass has mutated the store. Registered second so it
+	// runs BEFORE the unlock (LIFO), i.e. still under m.mu. A degraded pass returns
+	// early below with an unchanged (empty) store, so the rebuild is a harmless nop.
+	defer m.rebuildWireRRClaimsLocked()
 
 	// #5070: refresh the interface-name resolver for THIS pass so a
 	// destination-interface binding resolves to the local node's real kernel
@@ -1033,6 +1067,16 @@ func (m *Manager) dhcidSharedWithOther(owned ownedRecord) bool {
 // surviving scope, as the LAST claimant, issues the real wire delete when it in
 // turn tears down. Address must be non-empty (a lease record's rdata is always
 // its Address) so two rdata-less rows never falsely co-match. Caller holds m.mu.
+//
+// #5748: the scan is now surface-agnostic. Beyond the Surface B lease store
+// (m.state.records) it also consults the SEPARATE Surface A ownership surface
+// (router/interface DDNS records, rdata in AddrText not Address) through the
+// injected surfaceACoowners accessor. A Surface A record and a Surface B lease
+// can legitimately resolve the same host to the same address and thus co-own one
+// wire RR; without the cross-surface arm a lease teardown would still issue a
+// DELETE that clobbers a Surface-A-owned identical RR. The accessor is a
+// LOCK-FREE snapshot read (see the field doc), so this runs while m.mu is held
+// with no lock-order cycle. Nil accessor ⇒ pre-#5748 Surface-B-only behavior.
 func (m *Manager) wireRRSharedWithOther(owned ownedRecord) bool {
 	if owned.Address == "" {
 		return false
@@ -1049,7 +1093,58 @@ func (m *Manager) wireRRSharedWithOther(owned ownedRecord) bool {
 			return true
 		}
 	}
+	// Cross-surface (#5748): a Surface A router/interface record may co-own the
+	// SAME wire RR (canonical FQDN + forward type + rdata). Its rdata lives in
+	// AddrText, already normalized into the Rdata field of each WireRRClaim; build
+	// the same canonical claim for this lease record and compare by value.
+	if m.surfaceACoowners != nil {
+		ownedClaim := wireRRClaim(owned.FQDN, owned.ForwardType, owned.Address)
+		for _, c := range m.surfaceACoowners() {
+			if c == ownedClaim {
+				return true
+			}
+		}
+	}
 	return false
+}
+
+// SetSurfaceACoownerSource injects the accessor the daemon wires so a lease
+// teardown can consult the Surface A ownership surface for a cross-surface wire-RR
+// co-owner (#5748). fn MUST be lock-free with respect to SurfaceAManager.mu (it is
+// SurfaceAManager.WireRRClaims, a bare atomic load) so calling it under m.mu can
+// never deadlock. Idempotent; nil clears it (restores Surface-B-only behavior).
+func (m *Manager) SetSurfaceACoownerSource(fn func() []WireRRClaim) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.surfaceACoowners = fn
+}
+
+// WireRRClaims returns a LOCK-FREE snapshot of the wire RRs this (Surface B lease)
+// surface currently owns, for the Surface A teardown guard to consult (#5748). It
+// does a bare atomic load and NEVER takes m.mu, so a peer holding
+// SurfaceAManager.mu can call it with no lock-order cycle. Returns an empty slice
+// before the first rebuild.
+func (m *Manager) WireRRClaims() []WireRRClaim {
+	if p := m.wireRRClaims.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// rebuildWireRRClaimsLocked recomputes this surface's published wire-RR claim
+// snapshot from the durable store and publishes it atomically for the peer's
+// lock-free read (#5748). Caller holds m.mu. A lease record's rdata IS its
+// Address; rdata-less rows are skipped (they can never co-own a wire RR). The
+// snapshot is an immutable slice — replaced wholesale, never mutated in place.
+func (m *Manager) rebuildWireRRClaimsLocked() {
+	claims := make([]WireRRClaim, 0, len(m.state.records))
+	for _, r := range m.state.records {
+		if r.Address == "" {
+			continue
+		}
+		claims = append(claims, wireRRClaim(r.FQDN, r.ForwardType, r.Address))
+	}
+	m.wireRRClaims.Store(&claims)
 }
 
 // parseLeases reads a family's active leases via the injected LeaseParser

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -323,6 +323,50 @@ func ownedRecordKey(scope ScopeKey, identity, address string) string {
 	return scope.scopePrefix() + identity + "|" + address
 }
 
+// WireRRClaim identifies ONE forward DNS resource record that a DDNS ownership
+// surface currently claims: the CANONICAL FQDN, the forward record type
+// ("A"/"AAAA"), and the textual rdata (the published IP). Two owned records that
+// produce an EQUAL WireRRClaim CO-OWN one wire RR — whether they are two DDNS
+// scopes within ONE surface (the #5709 lease-vs-lease case) or one record from
+// EACH of the two ownership surfaces (the Surface B DHCP lease store in Manager
+// and the Surface A router/interface store in SurfaceAManager — the #5748
+// cross-surface case). Because the reverse PTR derives deterministically from
+// (FQDN, rdata), an equal forward claim implies an equal PTR RR, so matching the
+// forward tuple captures both directions (#5709).
+//
+// It is the cross-surface interchange type: each manager publishes a LOCK-FREE
+// snapshot of its own claims (Manager.WireRRClaims / SurfaceAManager.WireRRClaims,
+// backed by an atomic.Pointer) that the OTHER surface's teardown guard consults
+// WITHOUT taking the publisher's mutex. That lock-free read is what makes the
+// two guards deadlock-free despite each holding its own manager's lock (#5748).
+type WireRRClaim struct {
+	FQDN        string // canonical form (dnsCanonicalFQDN)
+	ForwardType string // "A" | "AAAA"
+	Rdata       string // textual published address (the rdata)
+}
+
+// wireRRClaim builds a canonicalized WireRRClaim from a name, forward type, and
+// textual rdata. The FQDN is DNS-canonicalized and the rdata is normalized
+// through netip so the two ownership surfaces — whose rdata reaches this helper
+// via DIFFERENT code paths (a Kea memfile string on the lease side, a
+// netip-formatted AddrText on the Surface A side) — compare EQUAL for the same
+// address even if their textual forms differ (e.g. an IPv6 address written
+// expanded vs compressed). An unparseable rdata is kept verbatim (best effort —
+// a stored address is normally well-formed). Empty rdata yields the zero-Rdata
+// claim; callers skip records with no rdata (a rdata-less claim must never
+// co-match another rdata-less one).
+func wireRRClaim(fqdn, forwardType, rdata string) WireRRClaim {
+	norm := rdata
+	if a, err := netip.ParseAddr(rdata); err == nil {
+		norm = a.Unmap().String()
+	}
+	return WireRRClaim{
+		FQDN:        dnsCanonicalFQDN(fqdn),
+		ForwardType: forwardType,
+		Rdata:       norm,
+	}
+}
+
 // ddnsState is the in-memory + on-disk ownership store. records is keyed
 // by ownedRecordKey. It is NOT goroutine-safe on its own; the DDNS
 // manager serializes all access under its own mutex.

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -412,6 +413,30 @@ type SurfaceAManager struct {
 	// the credential (mirrors manager.go upsertLocked's skippedNoBackend, #2691
 	// P3 review MAJOR).
 	skippedNoBackend uint64
+	// deleteCoowned counts wire deletes SUPPRESSED because the RR is still co-owned
+	// by a Surface B DHCP lease scope (#5748, the cross-surface arm of #5709). Like
+	// the lease Manager's deleteCoowned, dropping this surface's claim on a
+	// still-co-owned RR can never leak a stale record, so the suppression needs no
+	// write-ahead. Guarded by mu.
+	deleteCoowned uint64
+
+	// leaseCoowners, when non-nil, returns the wire-RR claims currently owned by
+	// the SEPARATE Surface B DHCP lease surface (Manager.state.records, rdata in
+	// Address). The daemon injects it (SetLeaseCoownerSource) so a Surface A
+	// teardown suppresses a wire DELETE that would clobber a lease-owned identical
+	// RR — the symmetric direction of the #5748 cross-surface guard. It is a
+	// LOCK-FREE snapshot accessor (Manager.WireRRClaims, a bare atomic load); it
+	// MUST NOT take Manager.mu, so withdrawOwnedLocked can call it while THIS
+	// manager holds m.mu without a lock-order cycle. Lock order: m.mu (held) →
+	// lock-free peer read (no peer mutex). Nil ⇒ no cross-surface suppression.
+	leaseCoowners func() []WireRRClaim
+
+	// wireRRClaims is the LOCK-FREE snapshot of the wire RRs THIS (Surface A)
+	// surface currently owns, published for the lease Manager's teardown guard to
+	// consult (#5748). Rebuilt under m.mu at the end of every non-degraded reconcile
+	// pass and after load, read via WireRRClaims() with a bare atomic load — never
+	// taking m.mu. Nil until the first rebuild.
+	wireRRClaims atomic.Pointer[[]WireRRClaim]
 }
 
 // NewSurfaceAManager constructs the production Surface A manager (plan §5.5). It
@@ -443,6 +468,10 @@ func NewSurfaceAManager() *SurfaceAManager {
 	// transport/connection pool rather than allocating a fresh one each pass.
 	m.newBackend = m.resolveBackend
 	m.seedFromStore()
+	// #5748: seed the cross-surface wire-RR claim snapshot from the loaded store so
+	// the lease guard sees this surface's ownership from the first pass. Single-
+	// threaded during construction.
+	m.rebuildWireRRClaimsLocked()
 	return m
 }
 
@@ -469,6 +498,7 @@ func newSurfaceAManagerForTesting(statePath string, backend DNSUpdater, now func
 		now:            now,
 	}
 	m.seedFromStore()
+	m.rebuildWireRRClaimsLocked() // #5748: seed the cross-surface claim snapshot
 	return m
 }
 
@@ -737,6 +767,11 @@ func (m *SurfaceAManager) observeIO(fn func()) {
 func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope, observe AddressObserver, gate ScopeGate, catalog map[string]*config.DDNSProvider, resolveIf ...func(string) string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// #5748: republish this surface's wire-RR claim snapshot for the lease Manager's
+	// teardown guard AFTER the pass mutates the store. Registered second so it runs
+	// BEFORE the unlock (LIFO), still under m.mu. A degraded pass returns early with
+	// an unchanged store, so the rebuild is a harmless nop.
+	defer m.rebuildWireRRClaimsLocked()
 
 	// #5070: refresh the per-pass interface-name resolver (read by resolveBackend
 	// + CheckIPClient under this same lock).
@@ -1474,7 +1509,24 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 	// candidate delete of this record (same family/FQDN/provider), so compute once.
 	sibling := m.siblingFamilyOwnedLocked(owned)
 	var firstErr error
+	var suppressed int
 	for _, a := range targets {
+		// #5748 (cross-surface arm of #5709): if a Surface B DHCP lease scope still
+		// co-owns THIS exact wire RR (canonical FQDN + forward type + this rdata),
+		// do NOT issue the wire delete — it would clobber the RR the lease surface
+		// still legitimately owns and refreshes. Release only this surface's claim
+		// (the ownership drop below) and leave the RR live; the lease surface, as the
+		// last claimant, issues the real delete when it in turn tears down. The
+		// leaseCoowners read is LOCK-FREE (no Manager.mu), so this is safe under m.mu.
+		if m.leaseWireRRCoowner(owned.FQDN, owned.ForwardType, a.String()) {
+			suppressed++
+			m.deleteCoowned++
+			slog.Debug("ddns surface-a: skipping wire delete — RR still co-owned by a DHCP lease scope; "+
+				"releasing this surface's claim only",
+				"fqdn", owned.FQDN, "type", owned.ForwardType, "addr", a.String(),
+				"provider", owned.scopeOf().PolicyID)
+			continue
+		}
 		rec, err := buildHostRecord(owned.FQDN, a, owned.TTL)
 		if err != nil {
 			if firstErr == nil {
@@ -1502,7 +1554,13 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 		m.deleteFail++
 		return fmt.Errorf("ddns surface-a: withdraw %s %s: %w", owned.ForwardType, owned.FQDN, firstErr)
 	}
-	m.deleteOK++
+	// deleteOK counts a real wire withdraw. If EVERY candidate was cross-surface
+	// co-owned and suppressed, nothing was deleted — do not inflate deleteOK; the
+	// deleteCoowned counter already recorded the suppression. Ownership is still
+	// released below (mirrors the lease path's #5709 claim release).
+	if suppressed < len(targets) {
+		m.deleteOK++
+	}
 
 	// Racing-op guard (#2778): drop ownership only if the live entry is STILL the
 	// exact record we deleted. A concurrent publish could have re-asserted this
@@ -1558,6 +1616,67 @@ func (m *SurfaceAManager) withdrawTargets(owned ownedRecord) []netip.Addr {
 		out = append(out, a)
 	}
 	return out
+}
+
+// SetLeaseCoownerSource injects the accessor the daemon wires so a Surface A
+// teardown can consult the Surface B DHCP lease surface for a cross-surface
+// wire-RR co-owner (#5748, symmetric direction). fn MUST be lock-free with respect
+// to Manager.mu (it is Manager.WireRRClaims, a bare atomic load) so calling it
+// under m.mu can never deadlock. Idempotent; nil clears it.
+func (m *SurfaceAManager) SetLeaseCoownerSource(fn func() []WireRRClaim) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.leaseCoowners = fn
+}
+
+// WireRRClaims returns a LOCK-FREE snapshot of the wire RRs this (Surface A)
+// surface currently owns, for the lease Manager's teardown guard to consult
+// (#5748). It does a bare atomic load and NEVER takes m.mu, so a peer holding
+// Manager.mu can call it with no lock-order cycle. Empty before the first rebuild.
+func (m *SurfaceAManager) WireRRClaims() []WireRRClaim {
+	if p := m.wireRRClaims.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// rebuildWireRRClaimsLocked recomputes this surface's published wire-RR claim
+// snapshot from the durable store and publishes it atomically for the lease
+// Manager's lock-free read (#5748). Caller holds m.mu. A Surface A record's rdata
+// is its AddrText (with the legacy lease-shape Address fallback — the same
+// precedence classifyOwnedBackend/withdrawTargets use); rdata-less rows are
+// skipped. The snapshot is an immutable slice, replaced wholesale.
+func (m *SurfaceAManager) rebuildWireRRClaimsLocked() {
+	claims := make([]WireRRClaim, 0, len(m.state.records))
+	for _, r := range m.state.records {
+		rdata := r.AddrText
+		if rdata == "" {
+			rdata = r.Address // legacy lease-shape entry (pre-AddrText)
+		}
+		if rdata == "" {
+			continue
+		}
+		claims = append(claims, wireRRClaim(r.FQDN, r.ForwardType, rdata))
+	}
+	m.wireRRClaims.Store(&claims)
+}
+
+// leaseWireRRCoowner reports whether a Surface B DHCP lease scope still co-owns
+// the wire RR (canonical FQDN + forward type + rdata) this Surface A teardown is
+// about to delete (#5748). It reads the injected lease-claim snapshot LOCK-FREE
+// (no Manager.mu), so it is safe to call while holding m.mu. Nil accessor ⇒ no
+// cross-surface co-owner (pre-#5748 behavior). Caller holds m.mu.
+func (m *SurfaceAManager) leaseWireRRCoowner(fqdn, forwardType, rdata string) bool {
+	if m.leaseCoowners == nil {
+		return false
+	}
+	want := wireRRClaim(fqdn, forwardType, rdata)
+	for _, c := range m.leaseCoowners() {
+		if c == want {
+			return true
+		}
+	}
+	return false
 }
 
 // siblingFamilyOwnedLocked reports whether ANOTHER owned record shares this
@@ -2004,6 +2123,11 @@ type SurfaceAStats struct {
 	Skipped          uint64
 	BackedOff        uint64
 	SkippedNoBackend uint64
+	// DeleteCoowned is the count of wire deletes SUPPRESSED because the RR is still
+	// co-owned by a Surface B DHCP lease scope (#5748, the cross-surface arm of the
+	// #5709 co-ownership guard). A non-zero value is normal when Surface A and a
+	// DHCP lease legitimately publish the same host/address.
+	DeleteCoowned uint64
 	// Orphaned is the count of records this node published at a PREVIOUS provider
 	// endpoint that a provider identity change (rename / in-place mutation /
 	// removed binding after an edit) left stale and un-withdrawable through the
@@ -2048,6 +2172,7 @@ func (m *SurfaceAManager) Stats() SurfaceAStats {
 		Skipped:          m.skipped,
 		BackedOff:        m.backedOff,
 		SkippedNoBackend: m.skippedNoBackend,
+		DeleteCoowned:    m.deleteCoowned,
 		Orphaned:         len(m.orphans),
 		Degraded:         m.degraded,
 		DegradedReason:   m.degradedReason,


### PR DESCRIPTION
## Root cause

The #5709 co-ownership guard (`wireRRSharedWithOther`) suppresses a DDNS wire
DELETE when another scope still co-owns the same wire RR (canonical FQDN +
forward type + rdata), so a lease teardown does not clobber a live record a peer
scope refreshes. That guard scanned **only** the Surface B lease store
(`Manager.state.records`, rdata in `Address`).

Router/interface DDNS records live in a **separate** ownership surface — Surface
A (`SurfaceAManager`, `interface-ddns-state.json`), rdata in `AddrText`, not
`Address`. A Surface A record and a Surface B lease can resolve the same host to
the same address and thus co-own **one** wire RR. The #5709 guard could not see
the other surface's rows (different map; and Surface A's `Address` is empty so
the `owned.Address == ""` early-return also excluded them), so a teardown on
either surface could still issue a wire DELETE that clobbered the identical RR
the other surface owns — the exact cross-scope clobber #5709 fixed, just across
the two ownership surfaces.

## Fix (both directions)

- **Cross-manager visibility mechanism:** each surface publishes a **lock-free**
  snapshot of its wire-RR claims (`Manager.WireRRClaims` /
  `SurfaceAManager.WireRRClaims`, backed by an `atomic.Pointer[[]WireRRClaim]`
  rebuilt under the manager's own mutex at the end of every non-degraded
  reconcile pass and seeded after load). The daemon injects each surface's
  accessor into the other (`SetSurfaceACoownerSource` / `SetLeaseCoownerSource`
  in `pkg/daemon/daemon_run.go`), mirroring how the two managers are already
  daemon-held peers.
- The lease guard (`wireRRSharedWithOther`) scans the injected Surface A snapshot
  after its own store; `SurfaceAManager.withdrawOwnedLocked` adds a per-target
  lease-coowner skip. A suppressed teardown releases only this surface's
  ownership claim and leaves the RR live for the peer.
- **Symmetric direction fixed:** yes — both lease→Surface-A and Surface-A→lease.

## Lock order / deadlock handling

The accessor is a **bare atomic load** — a teardown holding its own manager's
`mu` reads the peer snapshot **without** taking the peer's `mu`, so there is no
AB-BA cycle even though each surface's reconcile loop runs on its own goroutine.
This is deadlock-free by construction (documented on the accessor fields + the
guard functions). A **nil accessor** (standalone / pre-wire boot) restores the
pre-#5748 single-surface behavior; the guard is nil-safe. `WireRRClaim`
normalizes rdata through `netip` so the two surfaces (Kea memfile string vs
netip-formatted `AddrText`) compare equal for the same address.

## Fail-on-revert (the merge gate)

New tests in `pkg/ddns/cross_surface_clobber_5748_test.go` assert on the **wire
DELETE disposition** (the fakeUpdater's recorded deletes), not an internal flag.
Proven firsthand:

- Neutralize the lease-side cross-surface arm → **RED**:
  `lease teardown issued a wire DELETE for a Surface-A-co-owned RR (cross-surface clobber #5748): [host-a.example.com=10.0.0.10]`
- Neutralize the Surface A per-target skip → **RED**:
  `surface A teardown issued a wire DELETE for a lease-co-owned RR (cross-surface clobber #5748): [wan.example.net=203.0.113.5]`
- Restored → **GREEN**.

Regression guards: (i) a teardown with **no** co-owner still issues the DELETE
(no over-suppression → no stale RR); (ii) the #5709 Surface-B-to-Surface-B guard
is unchanged (`TestCoOwnedWireRRSurvivesOtherScopeTeardown`, nil cross-surface
accessor); (iii) a nil Surface A accessor behaves as pre-fix (no panic, delete
issued).

## Validation

`go build ./...`, `go vet ./pkg/ddns ./pkg/daemon` clean;
`go test ./pkg/ddns ./pkg/daemon -race` GREEN. Go control-plane change only (no
dataplane forwarding path) → **no loss-cluster smoke**; gated on unit tests.

Docs: `pkg/ddns/README.md` co-ownership section extended to both surfaces;
`_Log.md` dated entry added.

Closes #5748

🤖 Generated with [Claude Code](https://claude.com/claude-code)