### PR TITLE
daemon: gate DHCP recompile skip on host-inbound lifeline set

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-07-16 — #5791 (DHCP/host-inbound): gate lease-change recompile skip on host-inbound lifeline set, not the broad mgmt-VRF name class
+- **Timestamp**: 2026-07-16 (fix/5791-dhcp-hostinbound-reapply)
+- **Action**: Fix #5791 (security). `dhcpLeaseChangeRequiresRecompile`
+  (pkg/daemon/daemon_dhcp.go) decided whether a DHCP lease change may SKIP the
+  full dataplane/config reapply by testing each DHCP interface against the BROAD
+  management-VRF name class (`mgmtSet`, populated in daemon_apply.go from every
+  configured `fxp*`/`fab*`/`em*` interface). But the host-inbound LIFELINE class
+  is NARROWER (pkg/config/lifeline.go `HostInboundLifelineSet`): standalone
+  lifelines are only fxp0/em0/fab* (plus a configured chassis-cluster
+  control/fabric interface, #3277). So a zoned DHCP-only standalone `fxp1` — in
+  the broad mgmt class (`fxp*`) but NOT a lifeline — could start ADDRESSLESS
+  (no address-scoped host-inbound drop installed), acquire an address, and then
+  SKIP the reapply that rebuilds the host-inbound fence for the newly-reachable
+  address → the new address was reachable with NO host-inbound fence (security
+  gap). Fix: gate the skip on the config-derived host-inbound lifeline set — the
+  SAME `config.HostInboundLifelineSet` / `HostInboundLifelineInterface` the fence
+  application uses (pkg/dataplane/userspace/zones_host_inbound.go,
+  pkg/daemon/daemon_nft.go) — NOT the broad name class, so the skip decision and
+  the fence application agree by construction (no second, drifting classifier).
+  A non-lifeline DHCP interface now forces the full recompile that builds its
+  fence; a TRUE lifeline (fxp0 DHCPv4, em0, fab*, or a configured
+  control-interface) keeps the lightweight management-only fast path (no
+  churn/perf regression on routine mgmt lease renewals). Base-name mapping
+  (`fxp1.0`→`fxp1`) is handled by `HostInboundLifelineInterface`/`LifelineBaseName`
+  exactly as the fence does it. Kept the conservative
+  `len(mgmtSet)==0 → recompile` liveness guard (before-first-apply /
+  VRF-create-failed). Fail-on-revert PROVEN firsthand: new
+  `TestDHCPLeaseChangeRequiresRecompile_ZonedNonLifelineFxp1` asserts the REAL
+  recompile decision is TRUE for a zoned standalone fxp1; neutralizing the fix
+  (revert the per-interface proxy to `mgmtSet[config.DHCPLeaseIfName(...)]`) →
+  RED (`must require the full recompile so its address-scoped host-inbound fence
+  is (re)built`); restored → GREEN. Regression guards (all GREEN both ways):
+  `_LifelineFastPathPreserved` (fxp0/em0/fab0 still skip),
+  `_ClusterControlFxp1` (fxp1 as control-interface → lifeline → skip preserved),
+  `_ZonedDataInterfaceUnchanged` (ge-0/0/3 still recompiles). Validation:
+  `go build ./...` + `go vet ./pkg/daemon ./pkg/config` clean; `gofmt` clean;
+  `pkg/daemon` (24.6s) + `pkg/config` (148.6s) full suites `-race` GREEN.
+  Go-only, no cargo. Control-plane change → no loss-cluster smoke; gated on the
+  fail-on-revert unit tests.
+- **File(s)**: pkg/daemon/daemon_dhcp.go (edit — lifeline-set skip gate),
+  pkg/daemon/dhcp_recompile_test.go (edit — fail-on-revert + 3 regression
+  guards), pkg/daemon/README.md (edit — #5791 recompile-skip contract),
+  docs/host-inbound-service-matrix.md (edit — #5791 fixed note)
+
 ## 2026-07-16 — #5836 (dataplane loader): scope ifindex preflight to XPF-referenced links (codex-183)
 - **Timestamp**: 2026-07-16 (fix/5836-ifindex-preflight-scope)
 - **Action**: Fix #5836. `preflightCheckIfindexCaps` enumerated the WHOLE host

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -465,8 +465,15 @@ snapshot produces a zero-drop table shell:
   `applyConfig`, but classification does not prove host-inbound ran. A required
   protocol-gate error returns before `applyTailReconciles` and receives no
   cancellation closeout, leaving retry/re-render to a later applicable successful
-  reconcile that reaches the tail. The management-only classification branch is
-  the separate #5791 limitation.
+  reconcile that reaches the tail. **#5791 (fixed):** the callback's
+  management-only skip is now gated on the config-derived host-inbound LIFELINE
+  set (`config.HostInboundLifelineSet` / `HostInboundLifelineInterface` — the SAME
+  authority that lifeline-excludes these address sets), not the broad
+  management-VRF name class (fxp*/fab*/em*). So a zoned NON-lifeline DHCP interface
+  (a standalone `fxp1`) is classified for the full recompile that builds its
+  address-scoped fence; only a true lifeline (fxp0/em0/fab*/configured
+  control-interface) keeps the management-only fast path. The skip decision and
+  this fence now share one classifier and cannot drift.
 - If the fence **also** fails to load (nft itself broken), both errors are joined
   and an `ERROR`-level `COLD-BOOT FAIL-OPEN GUARD` log fires; `hostInboundEnforced`
   stays false. That is the irreducible catastrophic case — the daemon has done all

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -944,7 +944,15 @@ never lock an operator out of a remote box it manages.
   `applyConfig`; the chain receives a second fence/re-render opportunity only if
   that apply reaches `applyTailReconciles`. A required protocol-gate error can
   return before that tail, leaving the address for a later applicable successful
-  reconcile. The management-only callback branch is a distinct #5791 limitation.
+  reconcile. **#5791:** `dhcpLeaseChangeRequiresRecompile` now classifies the
+  management-only skip on the config-derived host-inbound LIFELINE set
+  (`config.HostInboundLifelineSet` / `HostInboundLifelineInterface`, the SAME
+  authority this fence uses), NOT the broad management-VRF name class
+  (fxp*/fab*/em*). Only a TRUE lifeline (fxp0, em0, fab*, or a configured
+  chassis-cluster control/fabric interface) takes the lightweight management-only
+  branch; a zoned NON-lifeline DHCP interface (e.g. a standalone `fxp1`) now forces
+  the full recompile that builds its address-scoped host-inbound fence, closing the
+  addressless→addressed gap where the broad class exempted it from that reapply.
   **Lifeline safety:** a zone with NO stanza emits no deny (admit-all);
   management/cluster-control interfaces (fxp0 / em0 / fab*) are excluded from
   the address sets so a host-inbound deny can never strand management or break

--- a/pkg/daemon/daemon_dhcp.go
+++ b/pkg/daemon/daemon_dhcp.go
@@ -222,10 +222,31 @@ func (d *Daemon) dhcpLeaseChangeRequiresRecompile(cfg *config.Config) bool {
 	// If management VRF bindings are unavailable, stay conservative. Read a
 	// single lock-free snapshot (#5113) so the whole classification runs
 	// against one consistent map, never a torn/nil-transient publication.
+	// (This is a "before-first-apply / VRF-create-failed" liveness guard, not
+	// the host-inbound classification below.)
 	mgmtSet := d.mgmtVRFIfaceSet()
 	if len(mgmtSet) == 0 {
 		return true
 	}
+	// #5791: gate the "skip the full reapply" decision on the config-derived
+	// host-inbound LIFELINE set — the SAME authority the host-inbound fence
+	// application uses (config.HostInboundLifelineSet, see
+	// pkg/dataplane/userspace/zones_host_inbound.go and pkg/daemon/daemon_nft.go)
+	// — NOT the broad management-VRF name class (fxp*/fab*/em*). The broad class
+	// wrongly exempted a zoned NON-lifeline fxp1: standalone lifelines are only
+	// fxp0/em0/fab* (plus a configured chassis-cluster control/fabric interface),
+	// so a DHCP-only zoned fxp1 would start ADDRESSLESS, install no address-scoped
+	// host-inbound drop, acquire an address, and then SKIP the reapply that would
+	// build the fence for the newly reachable address (a host-inbound gap, #3277).
+	// A lease change on a TRUE lifeline (fxp0 DHCPv4, em0, fab*, or a configured
+	// control-interface) still takes the lightweight management-only fast path;
+	// only a non-lifeline DHCP interface now forces the recompile that (re)builds
+	// its fence. Sharing HostInboundLifelineInterface with the fence keeps the
+	// skip decision and the fence application in lockstep by construction, so a
+	// future name can never drift the two apart. The base-name mapping
+	// (fxp1.0 -> fxp1) is handled inside HostInboundLifelineInterface via
+	// LifelineBaseName, exactly as the fence does it.
+	lifelines := config.HostInboundLifelineSet(cfg)
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
 		if ifc == nil {
 			continue
@@ -234,7 +255,7 @@ func (d *Daemon) dhcpLeaseChangeRequiresRecompile(cfg *config.Config) bool {
 			if unit == nil || (!unit.DHCP && !unit.DHCPv6) {
 				continue
 			}
-			if !mgmtSet[config.DHCPLeaseIfName(ifName, unit)] {
+			if !config.HostInboundLifelineInterface(ifName, lifelines) {
 				return true
 			}
 		}

--- a/pkg/daemon/dhcp_recompile_test.go
+++ b/pkg/daemon/dhcp_recompile_test.go
@@ -67,3 +67,125 @@ func TestDHCPLeaseChangeRequiresRecompile_RequiresMgmtMap(t *testing.T) {
 		t.Fatal("missing management VRF map should keep recompile path conservative")
 	}
 }
+
+// TestDHCPLeaseChangeRequiresRecompile_ZonedNonLifelineFxp1 is the #5791
+// fail-on-revert gate. A zoned, standalone (non-cluster) fxp1 DHCP client is in
+// the BROAD management-VRF name class (fxp*) but is NOT a host-inbound LIFELINE
+// (standalone lifelines are only fxp0/em0/fab*). Its learned address needs an
+// address-scoped host-inbound fence, so a lease change MUST force the full
+// recompile that (re)builds that fence — it must NOT take the lightweight
+// management-only skip path. Neutralizing the fix (gating the skip on the broad
+// mgmt-VRF class again, i.e. `mgmtSet[config.DHCPLeaseIfName(ifName, unit)]`)
+// makes this return false → RED.
+func TestDHCPLeaseChangeRequiresRecompile_ZonedNonLifelineFxp1(t *testing.T) {
+	d := &Daemon{}
+	// fxp1 is bound to the management VRF by the broad name class, so it IS in
+	// the published mgmt set — exactly the condition the old proxy exempted.
+	d.publishMgmtVRFIfaces(map[string]bool{"fxp0": true, "fxp1": true})
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"fxp1": {
+					Name: "fxp1",
+					Units: map[int]*config.InterfaceUnit{
+						0: {DHCP: true},
+					},
+				},
+			},
+		},
+	}
+
+	if !d.dhcpLeaseChangeRequiresRecompile(cfg) {
+		t.Fatal("zoned non-lifeline fxp1 DHCP lease change must require the full " +
+			"recompile so its address-scoped host-inbound fence is (re)built")
+	}
+}
+
+// TestDHCPLeaseChangeRequiresRecompile_LifelineFastPathPreserved guards the
+// lifeline fast-path (#5791 regression guard i): a lease change on a genuine
+// standalone lifeline (fxp0, em0, fab0) still takes the lightweight
+// management-only skip path — no recompile churn on routine management lease
+// renewals.
+func TestDHCPLeaseChangeRequiresRecompile_LifelineFastPathPreserved(t *testing.T) {
+	for _, ifName := range []string{"fxp0", "em0", "fab0"} {
+		t.Run(ifName, func(t *testing.T) {
+			d := &Daemon{}
+			d.publishMgmtVRFIfaces(map[string]bool{ifName: true})
+			cfg := &config.Config{
+				Interfaces: config.InterfacesConfig{
+					Interfaces: map[string]*config.InterfaceConfig{
+						ifName: {
+							Name: ifName,
+							Units: map[int]*config.InterfaceUnit{
+								0: {DHCP: true},
+							},
+						},
+					},
+				},
+			}
+
+			if d.dhcpLeaseChangeRequiresRecompile(cfg) {
+				t.Fatalf("lifeline %s DHCP lease refresh should keep the "+
+					"management-only fast path (no recompile churn)", ifName)
+			}
+		})
+	}
+}
+
+// TestDHCPLeaseChangeRequiresRecompile_ClusterControlFxp1 covers the
+// chassis-cluster case (#5791 regression guard ii): when fxp1 is configured as
+// the cluster control-interface it BECOMES a host-inbound lifeline
+// (HostInboundLifelineSet adds the configured control-interface, #3277), so its
+// lease change retains the management-only skip — no needless recompile on a
+// clustered control-interface lease.
+func TestDHCPLeaseChangeRequiresRecompile_ClusterControlFxp1(t *testing.T) {
+	d := &Daemon{}
+	d.publishMgmtVRFIfaces(map[string]bool{"fxp1": true})
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{
+			Cluster: &config.ClusterConfig{
+				ControlInterface: "fxp1",
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"fxp1": {
+					Name: "fxp1",
+					Units: map[int]*config.InterfaceUnit{
+						0: {DHCP: true},
+					},
+				},
+			},
+		},
+	}
+
+	if d.dhcpLeaseChangeRequiresRecompile(cfg) {
+		t.Fatal("fxp1 configured as cluster control-interface is a lifeline and " +
+			"should retain the management-only fast path")
+	}
+}
+
+// TestDHCPLeaseChangeRequiresRecompile_ZonedDataInterfaceUnchanged is #5791
+// regression guard iii: a normal zoned data-interface DHCP lease already forced
+// the recompile under the old proxy and must keep doing so under the lifeline
+// gate (it is neither in the mgmt class nor a lifeline).
+func TestDHCPLeaseChangeRequiresRecompile_ZonedDataInterfaceUnchanged(t *testing.T) {
+	d := &Daemon{}
+	d.publishMgmtVRFIfaces(map[string]bool{"fxp0": true})
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/3": {
+					Name: "ge-0/0/3",
+					Units: map[int]*config.InterfaceUnit{
+						0: {DHCP: true},
+					},
+				},
+			},
+		},
+	}
+
+	if !d.dhcpLeaseChangeRequiresRecompile(cfg) {
+		t.Fatal("zoned data-interface DHCP lease change must require the full recompile")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a host-inbound security gap (#5791). `dhcpLeaseChangeRequiresRecompile`
(`pkg/daemon/daemon_dhcp.go`) decided whether a DHCP lease change could **skip**
the full dataplane/config reapply by testing each DHCP interface against the
**broad management-VRF name class** — every configured `fxp*`/`fab*`/`em*`
interface (`mgmtSet`, populated in `pkg/daemon/daemon_apply.go`).

## Root cause

The broad management-VRF name class is the WRONG proxy for host-inbound lifeline
exemption. Host-inbound **lifeline** classification is narrower
(`pkg/config/lifeline.go` `HostInboundLifelineSet`): a standalone box's lifelines
are only `fxp0`/`em0`/`fab*`, plus a configured chassis-cluster control/fabric
interface (the #3277-correct set). `fxp1` is deliberately **non-lifeline** unless
a cluster role (`control-interface fxp1`) makes it one.

So a zoned DHCP-only standalone `fxp1` is in the broad mgmt class (`fxp*`) but is
**not** a lifeline. It could:

1. start **addressless** → install no address-scoped host-inbound drop,
2. acquire an address via DHCP, and
3. take the management-only skip branch of `onDHCPAddressChange`, which **bypasses
   the reapply** that would rebuild the host-inbound fence for the newly reachable
   address.

Result: the new `fxp1` address was reachable with **no host-inbound fence**.

## Fix

Gate the "skip full reapply" decision on the **config-derived host-inbound
lifeline set** — the SAME `config.HostInboundLifelineSet` /
`HostInboundLifelineInterface` the host-inbound fence application uses
(`pkg/dataplane/userspace/zones_host_inbound.go`, `pkg/daemon/daemon_nft.go`) —
instead of the broad mgmt-VRF name class. The skip decision and the fence
application now share **one classifier** and cannot drift silently.

- A **non-lifeline** DHCP interface (a zoned standalone `fxp1`) now forces the full
  recompile that builds its address-scoped host-inbound fence.
- A **true lifeline** (fxp0 DHCPv4, em0, fab*, or a configured control-interface)
  keeps the lightweight management-only fast path — **no churn/perf regression** on
  routine management lease renewals.
- **Clustered `fxp1`**: when `fxp1` is configured as the cluster
  `control-interface`, `HostInboundLifelineSet` adds it (#3277), so the gate yields
  "lifeline → skip" and does not force a needless recompile on a clustered
  control-interface lease.
- Base-name mapping (`fxp1.0` → `fxp1`) is handled by
  `HostInboundLifelineInterface` / `LifelineBaseName`, exactly as the fence does it.
- The conservative `len(mgmtSet)==0 → recompile` liveness guard
  (before-first-apply / VRF-create-failed) is preserved.

## Lifeline-vs-mgmt-class reconciliation

Before this change there were two contracts: the broad mgmt-VRF name class
(`fxp*`/`fab*`/`em*`) drove BOTH VRF binding and the DHCP recompile-skip proxy,
while the narrower `HostInboundLifelineSet` drove the actual fence exclusion. The
skip proxy is now joined to the fence's classifier, so a future interface name can
never make the skip decision and the fence disagree.

## Fail-on-revert (merge gate)

Proven firsthand. New `TestDHCPLeaseChangeRequiresRecompile_ZonedNonLifelineFxp1`
asserts the **real** recompile decision is TRUE for a zoned standalone `fxp1`
(mgmt set contains `fxp1`, i.e. exactly the condition the old proxy exempted).
Neutralizing the fix (reverting the per-interface proxy to
`mgmtSet[config.DHCPLeaseIfName(ifName, unit)]`):

```
=== RUN   TestDHCPLeaseChangeRequiresRecompile_ZonedNonLifelineFxp1
    dhcp_recompile_test.go:99: zoned non-lifeline fxp1 DHCP lease change must require the full recompile so its address-scoped host-inbound fence is (re)built
--- FAIL: TestDHCPLeaseChangeRequiresRecompile_ZonedNonLifelineFxp1 (0.00s)
FAIL	github.com/psaab/xpf/pkg/daemon	0.015s
```

Restored → GREEN. Regression guards (GREEN both ways — they hold under the fix and
under the neutralized proxy, confirming the fix only ADDS the fxp1 recompile):

- `_LifelineFastPathPreserved` — fxp0 / em0 / fab0 DHCP lease still skips.
- `_ClusterControlFxp1` — `fxp1` as `control-interface` → lifeline → skip preserved.
- `_ZonedDataInterfaceUnchanged` — `ge-0/0/3` DHCP still recompiles.

## Validation

- `go build ./...`, `go vet ./pkg/daemon ./pkg/config`, `gofmt` — clean.
- `pkg/daemon` (24.6s) + `pkg/config` (148.6s) full suites pass with `-race`.
- Go-only control-plane change → **no loss-cluster smoke**; gated on the
  fail-on-revert unit tests.

## Docs

- `pkg/daemon/README.md` — updated the DHCP recompile-skip contract (it previously
  called the management-only branch "a distinct #5791 limitation").
- `docs/host-inbound-service-matrix.md` — marked the #5791 classifier fixed.

Closes #5791
