### PR TITLE
fabric: invalidate stale peer on same-parent replacement (#5686)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-16 — #5686 (HA/fabric): stale fabric peer usable as redirect target during same-parent replacement (codex-182 M01)
+- **Timestamp**: 2026-07-16 (fix/5686-fabric-stale-peer)
+- **Action**: Fix #5686. The fabric-authority preserve/merge paths kept an
+  already-resolved `FabricLink` across a build/refresh that could not
+  re-resolve it, keyed ONLY on `parent_ifindex`. When a fabric peer under the
+  SAME parent was REPLACED (configured `peer_address` changed), the replacement
+  arrived UNRESOLVED (empty peer_mac → skipped, absent from the new resolved
+  set), so the OLD link was preserved and the stale old peer stayed a valid
+  `resolve_fabric_redirect` target throughout the replacement's resolution
+  window — fabric-forwarded traffic could be sent to a peer no longer current.
+  Fix (invalidate-before-accept, keyed on peer identity): a preserved link is
+  SUPERSEDED when the incoming snapshots configure its parent but name a
+  different, parseable peer address (`fabric_link_superseded_by_snapshots`,
+  `src/afxdp/forwarding/mod.rs`); superseded links are dropped from the
+  preserved/merged set BEFORE they can be kept, in BOTH `refresh_fabric_links`
+  (SyncFabricState) and `refresh_runtime_snapshot_inner` (config apply,
+  `coordinator/snapshot_refresh.rs`). During the unresolved window redirect for
+  that parent yields NO target → the packet takes its normal non-fabric
+  disposition (safe fallback, matching the existing fail-closed contract), not
+  a wrong-peer redirect; the replacement installs on resolve. Steady-state
+  same-peer refresh and parent-omitted (removal) are NOT supersessions, so the
+  working link survives. Pruned set stored into BOTH `ha.forwarding` and the
+  worker fast-path `ha.fabrics` Arc (the worker only overwrites from a non-empty
+  `ha.fabrics`, so a stale non-empty Arc would re-add the removed link).
+  Tests (fail-on-revert, firsthand RED-verified):
+  `refresh_fabric_links_replacement_peer_invalidates_stale_old_5686`,
+  `refresh_fabric_links_replacement_leaves_other_parent_untouched_5686`,
+  `fabric_link_superseded_by_snapshots_only_on_same_parent_different_peer_5686`
+  (`src/afxdp/coordinator/tests.rs`). Neutralizing the prune (retain stale old
+  peer) turned the two integration tests RED (old peer still redirect target /
+  parents `[80, 90]` vs `[90]`); restored → GREEN. `cargo build --release`
+  clean, `cargo clippy` clean on touched code, full cargo suite 3894 passed / 0
+  failed. Docs: `docs/fabric-cross-chassis-fwd.md` + `forwarding/README.md`
+  (replacement/resolution-window invariant). Fabric HA dataplane —
+  test-failover smoke blocked by the loss-cluster shim-ABI wall; gated on the
+  fail-on-revert unit tests.
+- **File(s)**: src/afxdp/forwarding/mod.rs, src/afxdp/coordinator/snapshot_refresh.rs,
+  src/afxdp/coordinator/tests.rs, docs/fabric-cross-chassis-fwd.md,
+  src/afxdp/forwarding/README.md, _Log.md
+
 ## 2026-07-16 — #5682 (security/HA): unreadable kernel-upgrade journal bypasses candidate election hold (codex-182 M24)
 - **Timestamp**: 2026-07-16 (fix/5682-upgrade-journal-failclosed)
 - **Action**: Fix #5682. `holdSecondaryIfKernelCandidateArmed`

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -395,6 +395,76 @@ re-resolves and re-syncs the fabric MACs within seconds. The persisted
 fabric set is therefore the **observability snapshot** (so `show` reflects
 the resolved truth), not the restore source.
 
+## Same-parent peer replacement must invalidate the stale peer (#5686 M01)
+
+The two fabric-authority paths PRESERVE an already-resolved `FabricLink`
+across a build/refresh that could not re-resolve it: `refresh_fabric_links`
+(the `SyncFabricState` / `update_fabrics` path) keeps the prior working set
+when *nothing* resolves this pass, and `refresh_runtime_snapshot_inner` (the
+config-apply path) merges old links back for any parent absent from the new
+build. That preserve exists because a fabric peer's neighbor MAC resolves
+asynchronously — the snapshot for a parent can be present but UNRESOLVED
+(empty `peer_mac`) for a window until ARP/NDP completes, and blindly wiping
+the resolved link during that window would blackhole cross-chassis
+forwarding.
+
+The bug (codex-review-182 M01): the preserve/merge keyed only on
+`parent_ifindex`. When a fabric peer under the SAME parent is **replaced**
+(the configured `peer_address` changes), the replacement arrives UNRESOLVED,
+so it is skipped and absent from the new resolved set — and the preserve
+logic kept the OLD link because its parent still existed. During the
+replacement's resolution window the STALE old peer therefore remained a valid
+`resolve_fabric_redirect` target, and a synced-session packet could be
+fabric-redirected to a peer that is no longer current.
+
+**The exact window:** from the moment the replacement `peer_address` is
+staged (a new snapshot for parent X names peer `P_new`, still unresolved)
+until `P_new`'s neighbor MAC resolves. Throughout that window the old link
+`X → P_old` was authoritative AND `P_new` was not yet installable.
+
+**Fix — invalidate-before-accept, keyed on peer identity.** A preserved link
+is SUPERSEDED when the incoming snapshots configure its parent but name a
+different, parseable peer address
+(`fabric_link_superseded_by_snapshots`, `afxdp/forwarding/mod.rs`). A
+superseded link is dropped from the preserved/merged set *before* it can be
+kept, in both paths. Consequences:
+
+- The moment the replacement is staged, `X → P_old` is gone. It is never
+  again returned by `resolve_fabric_redirect`.
+- While `P_new` is unresolved, `resolve_fabric_redirect` yields **no target**
+  for parent X, so the synced-session packet takes its normal non-fabric
+  disposition (its local/forward path) — the safe fallback, never a
+  wrong-peer redirect. This matches the pre-existing fail-closed contract:
+  redirecting to "nothing" degrades to normal forwarding, not a silent drop.
+- When `P_new` resolves, it installs normally and becomes the redirect
+  target.
+
+Only a same-parent **different-peer** snapshot supersedes. A snapshot that
+still names the same peer (the steady-state 30 s refresh) does not — the
+working link is preserved unchanged. A snapshot that OMITS the parent
+entirely (fabric removed, not replaced) does not — link teardown is a
+separate concern and the preserve-across-unresolved behavior is retained. An
+unparseable replacement address is ignored (the malformed new link cannot
+resolve anyway).
+
+**Reader visibility.** The pruned set is stored into BOTH the full
+`ha.forwarding` Arc (the worker's authoritative per-tick reload) AND the
+worker fast-path `ha.fabrics` Arc. The worker overwrites its
+`forwarding.fabrics` from `ha.fabrics` only when that Arc is non-empty, so
+leaving a stale non-empty `ha.fabrics` would re-add the superseded link the
+`ha.forwarding` store just removed — both must be updated in lock-step. A
+torn read (old link gone, replacement not yet visible) is harmless here
+because "no target → safe fallback"; the invariant that must never break is
+that the OLD link is not readable after the replacement is staged.
+
+Guarded by `refresh_fabric_links_replacement_peer_invalidates_stale_old_5686`
+(the fail-on-revert: neutralizing the prune makes the "old peer is no longer
+a redirect target" assertion go RED),
+`refresh_fabric_links_replacement_leaves_other_parent_untouched_5686`
+(a different-parent peer is unaffected during the replacement window), and
+`fabric_link_superseded_by_snapshots_only_on_same_parent_different_peer_5686`
+(the supersession predicate).
+
 ## Rate-based flood screens are not re-counted on fabric-redirected traffic (#4155)
 
 A packet that ingresses the **non-owner** node for a session the RG **owner**

--- a/userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs
+++ b/userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs
@@ -29,6 +29,27 @@ impl super::Coordinator {
         // one link resolved this pass, so an all-unresolved refresh keeps the
         // working set (from a prior SyncFabricState) instead of wiping it.
         let replace = !new_fabrics.is_empty();
+        // #5686: when this pass resolves nothing (replace=false) we PRESERVE the
+        // working fabric set — but first drop any preserved link SUPERSEDED by a
+        // same-parent peer REPLACEMENT in the incoming snapshots. Otherwise the
+        // stale old peer stays a valid `resolve_fabric_redirect` target while the
+        // replacement peer is still unresolved (M01), and fabric-forwarded
+        // traffic is sent to a peer that is no longer current. Once the stale
+        // link is dropped, redirect for that parent yields no target during the
+        // resolution window and the packet takes its normal non-fabric
+        // disposition (safe). When replace=true the freshly-resolved
+        // `new_fabrics` is built entirely from the current snapshots, so no
+        // stale peer can survive there — the prune is only needed on the
+        // preserve path.
+        let superseded_removed = if replace {
+            false
+        } else {
+            let before = self.forwarding.fabrics.len();
+            self.forwarding
+                .fabrics
+                .retain(|link| !fabric_link_superseded_by_snapshots(link, snapshots));
+            before != self.forwarding.fabrics.len()
+        };
         // #3773 (M13): the skip list is pruned against whichever fabric set is
         // FINAL — a link kept from the prior resolved set is not reported as
         // "skipped" for the operator even if THIS pass could not re-resolve it
@@ -58,11 +79,23 @@ impl super::Coordinator {
             // use the snapshot's forwarding state which may have empty fabrics
             // if the peer MAC wasn't resolved at snapshot time.
             self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
-        } else if skips_changed {
-            // Nothing resolved this pass, but the skip diagnostics changed —
-            // publish the updated (named) skip set without disturbing the
-            // preserved working fabric links.
+        } else if skips_changed || superseded_removed {
+            // Nothing resolved this pass. Publish either because the skip
+            // diagnostics changed or because #5686 pruned a stale (superseded)
+            // link out of the preserved working set.
             self.forwarding.fabric_skips = pruned;
+            if superseded_removed {
+                // #5686: the pruned fabric set must also reach the worker
+                // fast-path Arc (`shared_fabrics` / `self.ha.fabrics`). The
+                // worker overwrites its forwarding.fabrics from that Arc ONLY
+                // when it is non-empty, so a stale non-empty `ha.fabrics` would
+                // re-add the superseded link the `ha.forwarding` store just
+                // removed. Store both so the stale peer is gone from every
+                // reader.
+                self.ha
+                    .fabrics
+                    .store(Arc::new(self.forwarding.fabrics.clone()));
+            }
             self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
         }
     }
@@ -152,7 +185,25 @@ impl super::Coordinator {
         // via refresh_fabric_links (SyncFabricState) and the snapshot
         // may not include them if the peer MAC wasn't resolved at
         // snapshot build time. Always keep the better-resolved set.
-        let preserved_fabrics = self.forwarding.fabrics.clone();
+        //
+        // #5686: but DROP any preserved link SUPERSEDED by a same-parent peer
+        // REPLACEMENT in this snapshot. If the snapshot names a new peer for a
+        // parent whose old peer is still resolved, keeping the old link would
+        // leave the STALE peer a valid `resolve_fabric_redirect` target while
+        // the replacement peer is still unresolved (its neighbor MAC not yet
+        // learned, so `populate_fabrics` skipped it and it is absent from the
+        // new build). Once dropped, redirect for that parent yields no target
+        // during the resolution window and the packet takes its normal
+        // non-fabric disposition (safe). A snapshot that still names the SAME
+        // peer (steady state) or omits the parent (fabric removed) does not
+        // supersede, so the working link survives as before.
+        let preserved_fabrics: Vec<FabricLink> = self
+            .forwarding
+            .fabrics
+            .iter()
+            .copied()
+            .filter(|link| !fabric_link_superseded_by_snapshots(link, &snapshot.fabrics))
+            .collect();
         // #3773 (M13): capture the prior fabric-skip set so the post-merge
         // transition log fires only when the named skip set actually changes.
         let old_fabric_skips = self.forwarding.fabric_skips.clone();

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -2035,6 +2035,128 @@ fn queue_warm_pass_warms_fabric_peer_over_parent_ifindex() {
     assert_eq!(item.hop, IpAddr::V4(Ipv4Addr::new(10, 99, 0, 2)));
 }
 
+// #5686: a fabric peer REPLACED under the same parent must not leave the OLD
+// peer selectable as a `resolve_fabric_redirect` target while the replacement
+// is still unresolved. A "resolved" fabric snapshot carries a parseable
+// `peer_mac`; an empty `peer_mac` (no neighbor) is the UNRESOLVED window that
+// `resolve_fabric_links_from_snapshots` skips.
+fn fabric_snap_5686(parent: i32, peer: &str, peer_mac: &str) -> crate::FabricSnapshot {
+    crate::FabricSnapshot {
+        name: format!("fab-{parent}"),
+        parent_ifindex: parent,
+        overlay_ifindex: parent + 1000,
+        peer_address: peer.to_string(),
+        local_mac: "02:bf:72:00:00:01".to_string(),
+        peer_mac: peer_mac.to_string(),
+        up: true,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn refresh_fabric_links_replacement_peer_invalidates_stale_old_5686() {
+    let mut coord = Coordinator::new();
+    let parent = 80i32;
+    let p_old: IpAddr = "10.99.0.2".parse().unwrap();
+    let p_new: IpAddr = "10.99.0.9".parse().unwrap();
+
+    // 1. Install P_old (resolved) under parent X → it is the redirect target.
+    coord.refresh_fabric_links(&[fabric_snap_5686(parent, "10.99.0.2", "02:00:00:00:00:02")]);
+    let res = resolve_fabric_redirect(&coord.forwarding).expect("P_old redirect after install");
+    assert_eq!(res.next_hop, Some(p_old), "P_old is the redirect target after install");
+    assert_eq!(res.egress_ifindex, parent);
+
+    // 2. Replace with P_new under the SAME parent while P_new is UNRESOLVED
+    //    (empty peer_mac → the resolver skips it, so nothing resolves this pass
+    //    and the preserve path runs). #5686: the stale P_old must NO LONGER be
+    //    a redirect target, and the unresolved P_new must not be returned.
+    coord.refresh_fabric_links(&[fabric_snap_5686(parent, "10.99.0.9", "")]);
+    assert!(
+        resolve_fabric_redirect(&coord.forwarding).is_none(),
+        "after a same-parent replacement the OLD peer is no longer a fabric \
+         redirect target, and the unresolved replacement is not returned either",
+    );
+    // The worker-visible fast-path Arc must be pruned too — otherwise its
+    // supplemental non-empty patch re-adds the stale peer on the hot path.
+    assert!(
+        coord.ha.fabrics.load().iter().all(|f| f.peer_addr != p_old),
+        "shared worker Arc (ha.fabrics) must not retain the stale old peer",
+    );
+
+    // 3. Once P_new RESOLVES → redirect returns P_new.
+    coord.refresh_fabric_links(&[fabric_snap_5686(parent, "10.99.0.9", "02:00:00:00:00:09")]);
+    let res = resolve_fabric_redirect(&coord.forwarding).expect("P_new redirect after resolve");
+    assert_eq!(res.next_hop, Some(p_new), "resolved replacement P_new is the redirect target");
+    assert_eq!(res.egress_ifindex, parent);
+}
+
+#[test]
+fn refresh_fabric_links_replacement_leaves_other_parent_untouched_5686() {
+    let mut coord = Coordinator::new();
+    let x = 80i32;
+    let y = 90i32;
+    let py: IpAddr = "10.99.1.2".parse().unwrap();
+
+    // Install both X→Px_old and Y→Py, both resolved.
+    coord.refresh_fabric_links(&[
+        fabric_snap_5686(x, "10.99.0.2", "02:00:00:00:00:02"),
+        fabric_snap_5686(y, "10.99.1.2", "02:00:00:00:01:02"),
+    ]);
+    assert_eq!(coord.forwarding.fabrics.len(), 2, "both fabrics resolved");
+
+    // Replace X's peer (UNRESOLVED) while Y still names the SAME peer (also
+    // unresolved this pass → replace=false, the preserve path). #5686 must drop
+    // ONLY the superseded X link and keep the untouched Y link.
+    coord.refresh_fabric_links(&[
+        fabric_snap_5686(x, "10.99.0.9", ""),
+        fabric_snap_5686(y, "10.99.1.2", ""),
+    ]);
+    let parents: Vec<i32> = coord.forwarding.fabrics.iter().map(|f| f.parent_ifindex).collect();
+    assert_eq!(parents, vec![y], "only Y survives; the superseded X link is dropped");
+    let res = resolve_fabric_redirect(&coord.forwarding).expect("Y still redirects");
+    assert_eq!(
+        res.next_hop,
+        Some(py),
+        "different-parent peer Y is unaffected by X's replacement",
+    );
+    assert_eq!(res.egress_ifindex, y);
+}
+
+#[test]
+fn fabric_link_superseded_by_snapshots_only_on_same_parent_different_peer_5686() {
+    let link = FabricLink {
+        parent_ifindex: 80,
+        overlay_ifindex: 1080,
+        peer_addr: "10.99.0.2".parse().unwrap(),
+        peer_mac: [2, 0, 0, 0, 0, 2],
+        local_mac: [2, 0xbf, 0x72, 0, 0, 1],
+        up: true,
+    };
+    // Same parent, DIFFERENT peer → superseded.
+    assert!(fabric_link_superseded_by_snapshots(
+        &link,
+        &[fabric_snap_5686(80, "10.99.0.9", "")]
+    ));
+    // Same parent, SAME peer (steady-state refresh) → NOT superseded.
+    assert!(!fabric_link_superseded_by_snapshots(
+        &link,
+        &[fabric_snap_5686(80, "10.99.0.2", "")]
+    ));
+    // DIFFERENT parent, different peer → NOT superseded (other fabric).
+    assert!(!fabric_link_superseded_by_snapshots(
+        &link,
+        &[fabric_snap_5686(90, "10.99.0.9", "")]
+    ));
+    // Parent OMITTED entirely (removal, not replacement) → NOT superseded.
+    assert!(!fabric_link_superseded_by_snapshots(&link, &[]));
+    // Unparseable replacement address on the same parent → NOT superseded
+    // (the malformed new link cannot resolve, so it is not yet a replacement).
+    assert!(!fabric_link_superseded_by_snapshots(
+        &link,
+        &[fabric_snap_5686(80, "not-an-ip", "")]
+    ));
+}
+
 #[test]
 fn queue_warm_pass_noop_without_worker_queue() {
     // No warm_queue installed (worker not yet spawned) → no panic, no-op.

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -217,6 +217,24 @@ next-hops, preference 0). The wire specimen lives in
       Fabric is an HA optimization, so a malformed link is
       skipped-with-visibility, NOT fail-closed-whole-snapshot. See
       `docs/fabric-cross-chassis-fwd.md`.
+    - **Same-parent peer replacement (#5686 M01).** The snapshot/refresh
+      paths PRESERVE a resolved `FabricLink` across a pass that could not
+      re-resolve it (peer MAC not yet learned). That preserve MUST NOT keep a
+      link whose peer has been REPLACED: if the incoming snapshots configure
+      the SAME parent but a DIFFERENT peer address, the old link is SUPERSEDED
+      and dropped (`fabric_link_superseded_by_snapshots`) — otherwise the stale
+      old peer stays a valid `resolve_fabric_redirect` target while the
+      replacement peer is still unresolved, and fabric-forwarded traffic is
+      sent to a peer that is no longer current. Once dropped, redirect for that
+      parent yields NO target during the resolution window and the packet takes
+      its normal non-fabric disposition (safe) rather than a wrong-peer
+      redirect; when the replacement resolves it installs normally. A snapshot
+      that still names the same peer (steady-state refresh) or omits the parent
+      (fabric removed, not replaced) is not a supersession, so the working link
+      survives. The prune runs in both `refresh_fabric_links` (SyncFabricState)
+      and `refresh_runtime_snapshot_inner` (config apply); the pruned set is
+      stored into BOTH the full `ha.forwarding` Arc AND the worker fast-path
+      `ha.fabrics` Arc so no reader retains the stale peer.
 
 ## Session identity is NOT VRF-aware — single forwarding domain (#2387)
 

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -597,6 +597,40 @@ pub(super) fn resolve_fabric_links_from_snapshots(
     (out, skips)
 }
 
+/// #5686: an already-resolved `FabricLink` is SUPERSEDED when the incoming
+/// fabric snapshots still configure its parent interface but now name a
+/// DIFFERENT peer address — a same-parent peer REPLACEMENT. Such a stale link
+/// must never be preserved across a snapshot/refresh merge: until the
+/// replacement peer resolves (its neighbor MAC is learned), redirecting fabric
+/// traffic to the OLD peer would send it to a peer that is no longer current
+/// (the M01 stale-fabric-peer window). Dropping the old link makes
+/// `resolve_fabric_redirect` return `None` for that parent during the
+/// resolution window, so a synced-session packet takes its normal non-fabric
+/// disposition (safe) instead of a wrong-peer redirect.
+///
+/// Only a same-parent, different-and-parseable peer address supersedes:
+/// - A snapshot that still names the SAME peer (the steady-state periodic
+///   `SyncFabricState` refresh) is NOT a supersession — the working link is
+///   preserved unchanged.
+/// - A snapshot that OMITS the parent entirely (fabric removed, not replaced)
+///   is NOT a supersession — link teardown is a separate concern, and the
+///   existing preserve-across-unresolved-refresh behavior is kept.
+/// - An UNPARSEABLE replacement address is ignored: the malformed new link
+///   cannot resolve anyway, so it is not yet a valid replacement to gate on.
+pub(super) fn fabric_link_superseded_by_snapshots(
+    old: &FabricLink,
+    snapshots: &[crate::FabricSnapshot],
+) -> bool {
+    snapshots.iter().any(|snap| {
+        snap.parent_ifindex == old.parent_ifindex
+            && snap
+                .peer_address
+                .parse::<IpAddr>()
+                .map(|addr| addr != old.peer_addr)
+                .unwrap_or(false)
+    })
+}
+
 pub(super) fn resolve_fabric_redirect(
     forwarding: &ForwardingState,
 ) -> Option<ForwardingResolution> {


### PR DESCRIPTION
## Summary

Fixes #5686 (codex-review-182 M01, Medium) — a **stale fabric peer stayed usable as a redirect target during a same-parent peer replacement's resolution window**.

## Root cause & the exact window

Fabric-redirect authority (`resolve_fabric_redirect` / `resolve_fabric_redirect_from_list`, `userspace-dp/src/afxdp/forwarding/mod.rs`) reads `ForwardingState.fabrics` — a `Vec<FabricLink>` where only RESOLVED links appear (a link is installed only once its peer neighbor MAC is known). Peer MACs resolve asynchronously, so the two authority-refresh paths **preserve** an already-resolved link across a pass that can't re-resolve it:

- `refresh_fabric_links` (the `SyncFabricState` / `update_fabrics` path) keeps the prior working set when nothing resolves this pass;
- `refresh_runtime_snapshot_inner` (config apply) merges old links back for any parent absent from the new build.

Both preserve/merge sites keyed **only on `parent_ifindex`**. When a fabric peer under the SAME parent is **replaced** (configured `peer_address` changes), the replacement arrives UNRESOLVED (empty `peer_mac` → skipped, absent from the new resolved set), so the OLD link `X → P_old` was preserved because its parent still existed.

**The window:** from the moment the replacement `peer_address` (`P_new`, unresolved) is staged until `P_new`'s neighbor MAC resolves, the stale `X → P_old` remained authoritative AND `P_new` was not yet installable — so a synced-session packet could be fabric-redirected to a peer that is no longer current.

## Fix — (A) invalidate-before-accept, keyed on peer identity

A preserved link is **superseded** when the incoming snapshots configure its parent but name a *different, parseable* peer address — `fabric_link_superseded_by_snapshots()`. Superseded links are dropped from the preserved/merged set **before** they can be kept, in **both** paths.

- The moment the replacement is staged, `X → P_old` is gone and is never again returned by `resolve_fabric_redirect`.
- While `P_new` is unresolved, `resolve_fabric_redirect` yields **no target** for parent X → the packet takes its normal **non-fabric disposition** (its local/forward path). This is the safe fallback and matches the existing fail-closed contract (redirect-to-nothing degrades to normal forwarding, not a silent drop), never a wrong-peer redirect.
- When `P_new` resolves it installs normally and becomes the target.

Approach (A) was chosen over (B) gate-on-resolved because `forwarding.fabrics` already stores *only resolved* links — there is no "unresolved link in the list" to gate on — so dropping the superseded entry is the minimal, model-matching change.

**Non-supersessions (working link survives):** a snapshot that still names the same peer (steady-state 30 s refresh) or omits the parent entirely (fabric *removed*, not replaced); an unparseable replacement address is ignored (the malformed new link can't resolve anyway).

**Reader visibility:** the pruned set is stored into BOTH the full `ha.forwarding` Arc (the worker's authoritative per-tick reload) AND the worker fast-path `ha.fabrics` Arc. The worker overwrites its `forwarding.fabrics` from `ha.fabrics` only when that Arc is non-empty, so a stale non-empty `ha.fabrics` would re-add the link the `ha.forwarding` store just removed — both are updated in lock-step.

## Fail-on-revert tests (merge gate)

Added (`userspace-dp/src/afxdp/coordinator/tests.rs`):
- `refresh_fabric_links_replacement_peer_invalidates_stale_old_5686` — install P_old (resolved) → returns P_old; replace with unresolved P_new under same parent → returns **None** (not P_old, not P_new); resolve P_new → returns P_new.
- `refresh_fabric_links_replacement_leaves_other_parent_untouched_5686` — different-parent peer unaffected during the replacement window; resolved single peer still redirects.
- `fabric_link_superseded_by_snapshots_only_on_same_parent_different_peer_5686` — the supersession predicate (same-parent-different-peer only; same-peer / different-parent / omitted / unparseable are not supersessions).

**Fail-on-revert proven firsthand.** Neutralizing the prune (retain the stale old peer during the unresolved window) turns the two integration tests RED:

```
test refresh_fabric_links_replacement_leaves_other_parent_untouched_5686 ... FAILED
test refresh_fabric_links_replacement_peer_invalidates_stale_old_5686 ... FAILED

---- refresh_fabric_links_replacement_leaves_other_parent_untouched_5686 ----
assertion `left == right` failed: only Y survives; the superseded X link is dropped
  left: [80, 90]
 right: [90]

---- refresh_fabric_links_replacement_peer_invalidates_stale_old_5686 ----
after a same-parent replacement the OLD peer is no longer a fabric redirect
target, and the unresolved replacement is not returned either

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 3862 filtered out
```

Restored → GREEN (3 passed).

## Validation
- `cargo build --release` clean.
- `cargo clippy --release` clean on touched code (673 pre-existing repo-wide warnings, none on the new helper/edits).
- **Full cargo suite: 3894 passed / 0 failed.**
- Docs updated: `docs/fabric-cross-chassis-fwd.md` (new "#5686 M01" section) + `userspace-dp/src/afxdp/forwarding/README.md` (replacement/resolution-window invariant).

## Smoke deferral
Fabric HA dataplane — `test-failover` smoke is blocked by the loss-cluster shim-ABI wall; this change is gated on the fail-on-revert unit tests. Parent to record the smoke deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWk862iPHDXvLDFen1V3SR