### PR TITLE
feeds: fail closed for nested-set feed binding with static alias

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-16 — #5753 (pkg/dataplane/userspace, security): nested-set feed-binding partial-deny fail-open
+- **Timestamp**: 2026-07-16 (fix/5753-feeds-nested-alias-failopen)
+- **Action**: Close the residual nested-set arm of the #5645/#5751 partial-deny
+  fail-open class for dynamic-address feed bindings. PR #5751 fail-closed the
+  TOP-LEVEL and composite cases: a DECLARED dynamic-address binding ABSENT from
+  the resolved feed overlay (feed unready) is treated as unresolved →
+  unrepresentable → the whole snapshot is rejected (previous-good retained /
+  fresh-boot default-deny), even when a STATIC address-book alias of the same
+  name exists. But #5751 threaded that guard ONLY into the top-level
+  `addrRepresentable`; the recursive `nameRepresentability` walk did NOT receive
+  `cfg.Security.DynamicAddress.AddressBindings`, so when it recursed into an
+  address-set member it resolved the STATIC alias instead of recognizing a
+  declared-but-unresolved dynamic binding. Result: a `deny <address-set>` where
+  the set nests a binding name that also has a static alias, with an unready
+  feed, compiled the set to a book row carrying only the partial static subset
+  while the unready feed's prefixes went unmatched — a deny fail-OPEN.
+  Fix: thread `AddressBindings` through `nameRepresentable` /
+  `nameRepresentability` and apply the SAME declared-but-unresolved guard in the
+  nested recursion, ordered AFTER the feedOverlay branch (a READY feed is in the
+  overlay and resolves normally — no regression) and BEFORE the static
+  `ab.Addresses` lookup (so an unready binding wins over a static alias of the
+  same name). A nested static member with no declared binding of that name is
+  untouched (no over-block). Mirrors #5751's fail-closed mechanism exactly
+  (`__unsupported_address__` sentinel → Rust preflight whole-snapshot reject);
+  did not invent a new disposition.
+- **File(s)**: pkg/dataplane/userspace/policies_representable.go (thread
+  `bindings` param into `nameRepresentable`/`nameRepresentability` + the
+  declared-binding guard + doc comments), pkg/dataplane/userspace/policies_lower.go
+  (pass `cfg.Security.DynamicAddress.AddressBindings` at the single call site),
+  pkg/dataplane/userspace/feed_nested_alias_failclosed_5753_test.go (new
+  fail-on-revert + regression guards), pkg/feeds/README.md (document the
+  nested-set arm in the all-constituent-readiness contract).
+- **Validation**: `go build ./...` clean; `gofmt` + `go vet ./pkg/dataplane/userspace
+  ./pkg/config` clean; `go test ./pkg/dataplane/userspace -race` GREEN (full
+  package, 29.5s). Fail-on-revert proven firsthand: neutralizing the nested guard
+  (`if false && bindings[name] != nil`) turns `TestNestedFeedBindingWithStaticAliasFailsClosed`
+  RED — the deny source routes as a book reference (`SourceBookIDs=[2750498671]`,
+  a partial-static deny fail-open) instead of the sentinel; restoring → GREEN.
+  Regression guards stay green: nested static-only set (no binding) resolves
+  normally; nested binding with a READY feed unions feed + static + sibling
+  prefixes; the #5751 top-level/composite siblings still pass.
+
 ## 2026-07-16 — #5748 (pkg/ddns, security): cross-surface DDNS wire-RR clobber guard
 - **Timestamp**: 2026-07-16 (fix/5748-ddns-cross-surface-clobber)
 - **Action**: Extend the #5709 wire-RR co-ownership clobber guard across BOTH

--- a/pkg/dataplane/userspace/feed_nested_alias_failclosed_5753_test.go
+++ b/pkg/dataplane/userspace/feed_nested_alias_failclosed_5753_test.go
@@ -1,0 +1,226 @@
+// feed_nested_alias_failclosed_5753_test.go: #5753 residual (codex-182 M38).
+// PR #5751 (#5645) closed the TOP-LEVEL and composite partial-deny fail-opens
+// for dynamic-address feed bindings: a DECLARED binding ABSENT from the resolved
+// overlay (feed unready) fails closed even when a STATIC address-book alias of
+// the same name exists. But #5751 threaded that guard ONLY into the top-level
+// addrRepresentable branch, NOT into the nested nameRepresentability recursion.
+//
+// The residual: a dynamic-address binding name nested INSIDE an address-set that
+// ALSO has a static alias of that name, with an UNREADY feed, in a `deny`
+// policy, stayed fail-OPEN. The nameRepresentability walk did not receive
+// cfg.Security.DynamicAddress.AddressBindings, so when it recursed into the set
+// member it resolved the STATIC alias (representable) instead of recognizing a
+// declared-but-unresolved dynamic binding — the set compiled to a book row
+// carrying only the partial static subset while the unready feed's prefixes went
+// unmatched. For a `deny`, under-matching = fail-OPEN.
+//
+// The fix threads AddressBindings into nameRepresentable/nameRepresentability so
+// the nested walk applies the SAME declared-but-unresolved guard the top level
+// has: an unready declared binding taints the enclosing set -> the source side
+// routes to the #3261 __unsupported_address__ sentinel -> the Rust preflight
+// rejects the whole snapshot (previous-good retained / fresh-boot default-deny).
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// denyNestedStaticAliasCfg builds a config where the address-set "blocklist-set"
+// nests two members: a concrete sibling "corp-net" and "denylist", where
+// "denylist" is BOTH a static address-book entry (10.0.0.0/8) AND — when
+// withBinding is true — a declared feed-backed dynamic-address binding. A `deny`
+// policy references the SET (not the member directly), which is what routes the
+// declared binding through the NESTED nameRepresentability recursion rather than
+// the top-level addrRepresentable guard #5751 already covers.
+func denyNestedStaticAliasCfg(withBinding bool) *config.Config {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			AddressBook: &config.AddressBook{
+				Addresses: map[string]*config.Address{
+					// Static alias of the SAME name as the dynamic binding.
+					"denylist": {Name: "denylist", Value: "10.0.0.0/8"},
+					// A concrete sibling so the set is neither empty nor pure-feed
+					// (isolates the residual from the #3261 empty-set reject).
+					"corp-net": {Name: "corp-net", Value: "192.168.0.0/16"},
+				},
+				AddressSets: map[string]*config.AddressSet{
+					"blocklist-set": {
+						Name:      "blocklist-set",
+						Addresses: []string{"corp-net", "denylist"},
+					},
+				},
+			},
+			Policies: []*config.ZonePairPolicies{
+				{
+					FromZone: "untrust",
+					ToZone:   "trust",
+					Policies: []*config.Policy{
+						{
+							Name: "block-threats",
+							Match: config.PolicyMatch{
+								SourceAddresses:      []string{"blocklist-set"},
+								DestinationAddresses: []string{"any"},
+							},
+							Action: config.PolicyDeny,
+						},
+					},
+				},
+			},
+		},
+	}
+	if withBinding {
+		cfg.Security.DynamicAddress = config.DynamicAddressConfig{
+			AddressBindings: map[string]*config.AddressBinding{
+				"denylist": {Name: "denylist", FeedNames: []string{"threat"}},
+			},
+		}
+	}
+	return cfg
+}
+
+// TestNestedFeedBindingWithStaticAliasFailsClosed is the #5753 fail-on-revert.
+// With the feed UNRESOLVED (overlay omits "denylist", exactly what
+// SnapshotForBindings emits before the first successful fetch) and "denylist"
+// declared as a dynamic-address binding nested inside "blocklist-set", a
+// `deny blocklist-set` MUST fail CLOSED: the source side routes to the #3261
+// address sentinel and carries NO book reference to the partial static-subset
+// row. Neutralizing the fix (stop threading AddressBindings into the nested
+// nameRepresentability walk) lets the static alias resolve the member normally,
+// so the set is representable, SourceBookIDs is non-empty, and no sentinel is
+// emitted — a partial-static deny fail-open — turning the assertions RED.
+func TestNestedFeedBindingWithStaticAliasFailsClosed(t *testing.T) {
+	cfg := denyNestedStaticAliasCfg(true)
+
+	// UNRESOLVED: the feed has not completed its first fetch, so the daemon's
+	// SnapshotForBindings OMITS "denylist" (empty overlay here).
+	overlay := map[string][]string{}
+
+	// Precondition: the static alias DID create a name/ID for BOTH the member
+	// and the enclosing set — this is what makes the residual reachable (overlay
+	// omission alone cannot suppress the set's book reference).
+	_, nameToID, err := buildAddressBookTableWithFeeds(cfg, overlay)
+	if err != nil {
+		t.Fatalf("buildAddressBookTableWithFeeds error: %v", err)
+	}
+	if _, ok := nameToID["blocklist-set"]; !ok {
+		t.Fatalf("precondition: the nesting address-set must create a name/ID; nameToID=%v", nameToID)
+	}
+	if _, ok := nameToID["denylist"]; !ok {
+		t.Fatalf("precondition: the static address-book alias must create a name/ID "+
+			"for denylist; nameToID=%v", nameToID)
+	}
+
+	snaps, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	if err != nil {
+		t.Fatalf("buildPolicySnapshots error: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 policy rule, got %d", len(snaps))
+	}
+	rule := snaps[0]
+
+	// THE FAIL-OPEN SURFACE: the deny source must NOT resolve to a book reference
+	// (the set's partial static-subset row). That would enforce a partial deny
+	// while the unready feed's prefixes are unmatched.
+	if len(rule.SourceBookIDs) != 0 {
+		t.Fatalf("fail-open: a nested unresolved feed binding with a static alias routed as "+
+			"a book reference (partial static deny); SourceBookIDs=%v", rule.SourceBookIDs)
+	}
+	// It must route to the #3261 address sentinel so the Rust preflight rejects
+	// the whole snapshot (previous-good retained / fresh-boot default-deny).
+	if !addressListHasSentinel(rule.SourceLiterals) {
+		t.Fatalf("a nested unresolved feed binding with a static alias must fail CLOSED via "+
+			"the __unsupported_address__ sentinel; SourceLiterals=%v", rule.SourceLiterals)
+	}
+}
+
+// TestNestedStaticAliasNoBindingResolvesNormally is regression guard (i): a
+// nested static alias with NO declared dynamic binding of that name must still
+// resolve normally (no over-block). The fix must be scoped to DECLARED bindings
+// only — a plain static member of a set is unaffected.
+func TestNestedStaticAliasNoBindingResolvesNormally(t *testing.T) {
+	cfg := denyNestedStaticAliasCfg(false) // no AddressBindings entry
+	overlay := map[string][]string{}
+
+	_, nameToID, err := buildAddressBookTableWithFeeds(cfg, overlay)
+	if err != nil {
+		t.Fatalf("buildAddressBookTableWithFeeds error: %v", err)
+	}
+	wantID, ok := nameToID["blocklist-set"]
+	if !ok || wantID == 0 {
+		t.Fatalf("precondition: the address-set must have a book ID; nameToID=%v", nameToID)
+	}
+
+	snaps, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	if err != nil {
+		t.Fatalf("buildPolicySnapshots error: %v", err)
+	}
+	rule := snaps[0]
+
+	if !containsID(rule.SourceBookIDs, wantID) {
+		t.Fatalf("a nested static-only set (no dynamic binding) must route as a book reference; "+
+			"SourceBookIDs=%v want %d", rule.SourceBookIDs, wantID)
+	}
+	if addressListHasSentinel(rule.SourceLiterals) {
+		t.Fatalf("a nested static-only set must NOT fail closed (no over-block); SourceLiterals=%v",
+			rule.SourceLiterals)
+	}
+	// The compiled row carries the concrete static prefixes — real disposition,
+	// not just an internal flag.
+	books, _, _ := buildAddressBookTableWithFeeds(cfg, overlay)
+	row := findBookByName(books, "blocklist-set")
+	if row == nil {
+		t.Fatalf("static-only blocklist-set produced no book row")
+	}
+	if !contains(row.PrefixesV4, "192.168.0.0/16") || !contains(row.PrefixesV4, "10.0.0.0/8") {
+		t.Fatalf("static-only set row must carry both static members; PrefixesV4=%v", row.PrefixesV4)
+	}
+}
+
+// TestNestedFeedBindingWithStaticAliasReadyEnforcesUnion is regression guard
+// (ii): once the nested binding's feed IS ready (overlay carries its prefixes),
+// the same name resolves normally and the deny enforces the UNION of the feed
+// prefixes, the static alias, and the concrete sibling. Proves the fail-closed
+// guard is scoped to the unresolved window and does not suppress a resolved
+// nested feed binding (no regression on feed prefix compilation).
+func TestNestedFeedBindingWithStaticAliasReadyEnforcesUnion(t *testing.T) {
+	cfg := denyNestedStaticAliasCfg(true)
+	overlay := map[string][]string{
+		"denylist": {"198.51.100.0/24"},
+	}
+
+	_, nameToID, _ := buildAddressBookTableWithFeeds(cfg, overlay)
+	wantID := nameToID["blocklist-set"]
+	if wantID == 0 {
+		t.Fatalf("precondition: resolved nesting set must have an ID; nameToID=%v", nameToID)
+	}
+
+	snaps, _ := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	rule := snaps[0]
+	if !containsID(rule.SourceBookIDs, wantID) {
+		t.Fatalf("a resolved nested feed binding must route as a book reference; "+
+			"SourceBookIDs=%v want %d", rule.SourceBookIDs, wantID)
+	}
+	if addressListHasSentinel(rule.SourceLiterals) {
+		t.Fatalf("a resolved nested feed binding must NOT fail closed; SourceLiterals=%v",
+			rule.SourceLiterals)
+	}
+
+	// The set row unions the feed prefix, the static alias, and the concrete
+	// sibling — the resolved deny enforces the full set (feed prefixes compiled
+	// normally).
+	books, _, _ := buildAddressBookTableWithFeeds(cfg, overlay)
+	row := findBookByName(books, "blocklist-set")
+	if row == nil {
+		t.Fatalf("resolved blocklist-set produced no book row")
+	}
+	if !contains(row.PrefixesV4, "198.51.100.0/24") {
+		t.Fatalf("resolved nested feed binding must compile its feed prefix; PrefixesV4=%v", row.PrefixesV4)
+	}
+	if !contains(row.PrefixesV4, "192.168.0.0/16") || !contains(row.PrefixesV4, "10.0.0.0/8") {
+		t.Fatalf("resolved set row must union feed + static + sibling prefixes; PrefixesV4=%v",
+			row.PrefixesV4)
+	}
+}

--- a/pkg/dataplane/userspace/policies_lower.go
+++ b/pkg/dataplane/userspace/policies_lower.go
@@ -91,7 +91,11 @@ func buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg *config.Config, activeSt
 			return false
 		}
 		if _, known := nameToID[tok]; known {
-			return nameRepresentable(cfg.Security.AddressBook, feedOverlay, tok, make(map[string]bool))
+			// #5753: thread the declared dynamic-address bindings into the walk so
+			// a binding buried inside a nested address-set with an UNREADY feed
+			// fails closed even when a static alias of the same name exists — the
+			// nested-set analogue of the top-level guard above.
+			return nameRepresentable(cfg.Security.AddressBook, feedOverlay, cfg.Security.DynamicAddress.AddressBindings, tok, make(map[string]bool))
 		}
 		return false
 	}

--- a/pkg/dataplane/userspace/policies_representable.go
+++ b/pkg/dataplane/userspace/policies_representable.go
@@ -59,7 +59,7 @@ func allAddressTokensRepresentable(addrRepresentable func(tok string) bool, addr
 // representable+enforced when its feed is live, and #3261-rejected (sentinel,
 // fail-closed) only when the feed is currently empty (an empty row -> MatchNone
 // -> the deny would otherwise drop silently).
-func nameRepresentable(ab *config.AddressBook, feedOverlay map[string][]string, name string, visited map[string]bool) bool {
+func nameRepresentable(ab *config.AddressBook, feedOverlay map[string][]string, bindings map[string]*config.AddressBinding, name string, visited map[string]bool) bool {
 	// The closure must be BOTH structurally resolvable AND contribute >=1
 	// concrete prefix. The >=1-concrete requirement is enforced HERE, exactly
 	// once at the top, mirroring strict's single `count==0` reject after
@@ -68,7 +68,14 @@ func nameRepresentable(ab *config.AddressBook, feedOverlay map[string][]string, 
 	// -> rejected; a mutual-cycle-with-concrete set is (true,true) -> accepted.
 	// (A direct feed name never reaches here — addrRepresentable short-circuits
 	// it via feedOverlay, preserving the #2049 direct-feed exemption.)
-	r, c := nameRepresentability(ab, feedOverlay, name, visited)
+	//
+	// #5753: `bindings` (cfg.Security.DynamicAddress.AddressBindings) is threaded
+	// into the recursion so that a DECLARED dynamic-address binding buried inside
+	// a nested address-set whose feed is UNREADY (absent from feedOverlay) is
+	// recognized as unresolved and fails CLOSED even when a static alias of the
+	// same name exists — the nested-set arm of the #5645/#5751 partial-deny
+	// fail-open. See nameRepresentability.
+	r, c := nameRepresentability(ab, feedOverlay, bindings, name, visited)
 	return r && c
 }
 
@@ -116,7 +123,20 @@ func nameRepresentable(ab *config.AddressBook, feedOverlay map[string][]string, 
 // (addrRepresentable short-circuits feed names BEFORE nameRepresentable, so a
 // policy referencing a feed name directly never reaches the top `r && c` gate),
 // preserving the #2049 direct-feed exemption.
-func nameRepresentability(ab *config.AddressBook, feedOverlay map[string][]string, name string, visited map[string]bool) (representable, concrete bool) {
+//
+// #5753: `bindings` is the declared dynamic-address binding set
+// (cfg.Security.DynamicAddress.AddressBindings). It is consulted AFTER the
+// feedOverlay branch and BEFORE the static ab.Addresses lookup — mirroring the
+// top-level addrRepresentable ordering — so a member name that is a DECLARED
+// binding whose feed is currently UNREADY (hence absent from feedOverlay) is
+// treated as unresolvable (false, false) even when a static address-book alias
+// of the same name exists. This closes the nested-set arm of the #5645/#5751
+// partial-deny fail-open: without it, the walk would resolve the static alias
+// and enforce only the partial static subset while the unready feed's prefixes
+// go unmatched (a `deny` fail-OPEN). A READY feed is still in feedOverlay and
+// resolves normally in the branch above (no regression); a static alias with NO
+// declared binding of that name is untouched (no over-block).
+func nameRepresentability(ab *config.AddressBook, feedOverlay map[string][]string, bindings map[string]*config.AddressBinding, name string, visited map[string]bool) (representable, concrete bool) {
 	if name == "" {
 		return false, false
 	}
@@ -140,6 +160,22 @@ func nameRepresentability(ab *config.AddressBook, feedOverlay map[string][]strin
 		// nameRepresentable), preserving the #2049 direct-feed exemption.
 		return true, len(feeds) > 0
 	}
+	// #5753: a DECLARED dynamic-address binding that is ABSENT from feedOverlay is
+	// UNRESOLVED (at least one feed constituent has no installed snapshot yet —
+	// SnapshotForBindings publishes a binding only when ALL feeds are ready). A
+	// READY binding is in feedOverlay and already resolved by the branch above, so
+	// reaching here means the feed is unready. It must fail CLOSED even when a
+	// STATIC address-book entry of the SAME name exists (the ab.Addresses branch
+	// below): otherwise a nested `deny <set-containing-name>` would enforce only
+	// the partial static subset while the unready feed's prefixes go unmatched (a
+	// deny fail-OPEN). Returning (false,false) here poisons the enclosing set so
+	// buildOneRuleSnapshot emits the __unsupported_address__ sentinel and the Rust
+	// preflight rejects the whole snapshot (previous-good retained / fresh-boot
+	// default-deny) — the nested-set analogue of the top-level addrRepresentable
+	// guard (#5751). Indexing a nil bindings map is safe (zero value nil).
+	if bindings[name] != nil {
+		return false, false
+	}
 	if ab == nil {
 		return false, false
 	}
@@ -161,7 +197,7 @@ func nameRepresentability(ab *config.AddressBook, feedOverlay map[string][]strin
 	anyConcrete := false
 	for _, member := range set.Addresses {
 		hasMember = true
-		r, c := nameRepresentability(ab, feedOverlay, member, visited)
+		r, c := nameRepresentability(ab, feedOverlay, bindings, member, visited)
 		if !r {
 			// A structurally-invalid member poisons the parent — matches strict's
 			// abort on resolve()==false (also fires when the member is an EMPTY
@@ -172,7 +208,7 @@ func nameRepresentability(ab *config.AddressBook, feedOverlay map[string][]strin
 	}
 	for _, nested := range set.AddressSets {
 		hasMember = true
-		r, c := nameRepresentability(ab, feedOverlay, nested, visited)
+		r, c := nameRepresentability(ab, feedOverlay, bindings, nested, visited)
 		if !r {
 			return false, false
 		}

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -105,9 +105,18 @@ enforced only the static subset. The fix now requires **all** constituents ready
 (case 1), and the userspace `addrRepresentable` treats a **declared**
 dynamic-address binding that is **absent** from the overlay as unresolved →
 unrepresentable → fail-closed **even when a static alias of the same name
-exists** (case 2). Only the referencing security **policy** path is gated this
-way; NAT rules that reference an unready feed still fall back to the static
-subset (out of scope for the deny fail-open this issue names).
+exists** (case 2). A third residual arm of the same class was closed in **#5753**:
+a declared binding nested **inside an address-set** that also carries a static
+alias of that name stayed fail-open because the recursive representability walk
+(`nameRepresentability`) did not receive the binding set and resolved the static
+alias instead. That walk is now threaded `cfg.Security.DynamicAddress.AddressBindings`
+so the **nested** member gets the SAME declared-but-unresolved guard the top level
+has — an unready binding taints the enclosing set → the `deny` fails closed
+instead of narrowing to the partial static subset. A **ready** feed (present in
+the overlay) and a static member with **no** declared binding of that name are
+unaffected. Only the referencing security **policy** path is gated this way; NAT
+rules that reference an unready feed still fall back to the static subset (out of
+scope for the deny fail-open this issue names).
 
 ## Publication-debt retry — a rejected apply is retried, not swallowed (#5646)
 


### PR DESCRIPTION
## STEP 0 — confirmed NOT already fixed

On current `origin/master`, `nameRepresentability`
(`pkg/dataplane/userspace/policies_representable.go`) does NOT receive
`cfg.Security.DynamicAddress.AddressBindings`. The only guard that consults the
declared bindings is the TOP-LEVEL `addrRepresentable` branch in
`policies_lower.go` (added by PR #5751). PR #5751's own body/commit explicitly
deferred this arm: *"The nested-set static-alias variant … would need `cfg`
threaded into `nameRepresentability`; left for a follow-up."* So the residual
fail-open is still present.

## Issue #5753 (codex-182 M38 residual, security — partial-deny fail-open)

PR #5751 (#5645) closed the composite-binding and top-level static-alias
partial-deny fail-opens for dynamic-address feed bindings. ONE residual arm of
the SAME class remained: a dynamic-address binding name nested INSIDE an
address-set that ALSO has a static address-book alias of that name, with an
UNREADY feed, in a `deny` policy, stayed fail-OPEN.

### Root cause

The recursive representability walk `nameRepresentability` was not passed the
declared dynamic bindings. When it recursed into an address-set member it could
not tell that a member name was a DECLARED-but-unresolved dynamic binding — it
resolved the STATIC alias instead, so the set compiled to a book row carrying
only the partial static subset while the unready feed's prefixes went unmatched.
For a `deny` policy, under-matching = fail-OPEN.

## Fix — mirrors #5751 exactly

- Thread `cfg.Security.DynamicAddress.AddressBindings` through
  `nameRepresentable` → `nameRepresentability`.
- In the recursion, consult it **AFTER** the `feedOverlay` branch (a READY feed
  is present in the overlay and resolves there — no regression) and **BEFORE**
  the static `ab.Addresses` lookup (so an unready declared binding wins over a
  static alias of the same name) — the SAME ordering the top-level
  `addrRepresentable` uses. A declared binding absent from the overlay returns
  `(false, false)`, poisoning the enclosing set → `buildOneRuleSnapshot` emits
  the `__unsupported_address__` sentinel → the Rust preflight rejects the whole
  snapshot (previous-good retained / fresh-boot default-deny).
- `policies_lower.go` passes the bindings at the single call site.

No new disposition invented — it reuses the exact #5751/#3261 fail-closed
marker. A nested static member with NO declared binding of that name is
untouched (no over-block); a READY feed compiles its prefixes normally.

## Fail-on-revert tests

`pkg/dataplane/userspace/feed_nested_alias_failclosed_5753_test.go`:

- **`TestNestedFeedBindingWithStaticAliasFailsClosed`** — the binding nested in
  an address-set that also has a static alias, feed unready, `deny` policy →
  source routes to the sentinel, no book reference.
- **`TestNestedStaticAliasNoBindingResolvesNormally`** — nested static alias
  with no dynamic binding still resolves as a book reference (row unions both
  static members); no over-block.
- **`TestNestedFeedBindingWithStaticAliasReadyEnforcesUnion`** — the same nested
  binding with a READY feed resolves normally; the set row unions feed + static
  + sibling prefixes.
- The #5751 top-level/composite siblings stay green.

### RED-on-revert (proven firsthand)

Neutralizing the nested guard (`if false && bindings[name] != nil`):

```
=== RUN   TestNestedFeedBindingWithStaticAliasFailsClosed
    feed_nested_alias_failclosed_5753_test.go:128: fail-open: a nested unresolved feed binding with a static alias routed as a book reference (partial static deny); SourceBookIDs=[2750498671]
--- FAIL: TestNestedFeedBindingWithStaticAliasFailsClosed (0.00s)
FAIL
FAIL	github.com/psaab/xpf/pkg/dataplane/userspace	0.004s
```

Restoring the guard → GREEN.

## Validation

`go build ./...` clean; `gofmt` + `go vet ./pkg/dataplane/userspace ./pkg/config`
clean; `go test ./pkg/dataplane/userspace -race` GREEN (full package). This is a
Go control-plane compile-path change (snapshot representability); **no loss-cluster
smoke** — it is gated on the unit tests above. Docs: `pkg/feeds/README.md`
all-constituent-readiness section extended with the nested-set arm.

Closes #5753
