### PR TITLE
deploy: consume the verified inode, not a re-openable path (#5817)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-16 — #5817 (scripts/deploy, security): fetch verify/use TOCTOU + non-exclusive temp
+- **Timestamp**: 2026-07-16 (fix/5817-deploy-verify-toctou)
+- **Action**: Fix #5817 (codex-183 audit, supply-chain TOCTOU). STEP-0 confirmed
+  live on origin/master (3b3b15eff): `sign.verify_image_artifact` hashes a path
+  and returns only `True` (no inode retained); `cmd_fetch` verifies each artifact
+  at its PUBLIC `--out` pathname, then hands that SAME pathname to a different
+  consumer — `_install_libvirt_golden` copy-to-golden or `incus image import` —
+  so a process able to write `--out` could swap unauthenticated bytes in between
+  the checksum check and the consumer's open (verify-by-name / use-by-name race).
+  Secondary: `fetch_one` downloaded to a predictable shared `<dst>.tmp` with no
+  exclusive create, so a concurrent fetch to the same `--out` could collide.
+  Mechanism (A): the two in-process consumers now read from a private 0700
+  mkdtemp OUTSIDE `--out` (`_verified_private_artifacts`) — each consumed
+  artifact is COPIED there and re-verified against the signed manifest, then that
+  private path is handed to the consumer (portable for BOTH libvirt and incus:
+  each takes a pathname; nothing that can write `--out` can reach the staging
+  dir). Downloads use `mkstemp` (O_CREAT|O_EXCL, unpredictable) + atomic
+  `os.replace` (`_download_to`). Verification itself is unchanged (not weakened).
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_verify_toctou.py (new), docs/install-images.md,
+  _Log.md
+- **Validation**: new `test_xpf_deploy_verify_toctou` (5 tests) — fail-on-revert
+  proven firsthand: neutralize the staging (hand back public path) → swap-reaches
+  -consumer asserts flip RED; neutralize to `dst + ".tmp"` → predictable-temp
+  clobber assert flips RED; both restore GREEN. `make selftest` green.
+
 ## 2026-07-16 — #5815 (scripts/dist, security): publish gate ignored signed base_image_pinned
 - **Timestamp**: 2026-07-16 (fix/5815-publish-base-pinned-gate)
 - **Action**: Fix #5815 (codex-183 audit, release-provenance bypass). STEP-0

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -32,6 +32,19 @@ Two deliverables, same root disk:
 > (never part of an artifact filename) — so a crafted version cannot redirect
 > the download/write out of the output directory (#5992). This mirrors the
 > systemd-ExecStart version grammar hardened in #5713.
+>
+> `fetch` also closes the verify/use gap (#5817): the `--out` directory may be
+> writable by another local process, so authenticating an artifact at its public
+> pathname and then handing that SAME pathname to libvirt (copy-to-golden) or
+> `incus image import` would let a dir-writer swap unauthenticated bytes in
+> between the check and the consumer's open. Instead the two in-process consumers
+> read from a private 0700 staging dir OUTSIDE `--out` — each consumed artifact
+> is copied there and re-verified against the signed manifest, so the bytes the
+> consumer reads are exactly the bytes that were verified (the same private-copy
+> pattern `sign.verify_and_read` uses). Downloads land in an exclusively-created,
+> unpredictable temp (`mkstemp`, O_CREAT|O_EXCL) and publish atomically, so a
+> concurrent fetch to the same `--out` cannot collide with or clobber an
+> in-flight download via a predictable shared `<dst>.tmp`.
 
 ## Bake
 

--- a/scripts/deploy/test_xpf_deploy_verify_toctou.py
+++ b/scripts/deploy/test_xpf_deploy_verify_toctou.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Fail-on-revert tests for the fetch verify/use TOCTOU close (#5817).
+
+`xpf-deploy.py fetch` authenticated each downloaded artifact by PATHNAME, then
+handed that SAME public pathname to a DIFFERENT consumer — libvirt copy-to-golden
+(`_install_libvirt_golden`) or `incus image import`. The verified inode was not
+retained, so a process able to write the `--out` directory could RENAME/REPLACE
+the file with unauthenticated content AFTER the checksum check and BEFORE the
+consumer's open: the consumer then received bytes that were never authenticated
+(verify-by-name / use-by-name race). Secondarily, downloads landed in a
+predictable shared `<dst>.tmp` with no exclusive create, so a concurrent fetch to
+the same `--out` (or a pre-planted temp) could collide with / clobber the
+in-flight download and widen the race.
+
+The fix:
+  - `_verified_private_artifacts` copies each to-be-consumed artifact into a
+    private 0700 mkdtemp OUTSIDE `--out`, verifies the COPY there, and hands the
+    consumer THAT path — nothing that can write `--out` can reach the staging
+    dir, so the consumed bytes are exactly the verified bytes.
+  - `_download_to` downloads via an EXCLUSIVE, unpredictable `mkstemp` temp and
+    publishes atomically, so concurrent fetches / a pre-planted predictable temp
+    cannot collide or clobber.
+
+RED on revert:
+  - `_verified_private_artifacts` -> hand back the public path: the staged path
+    is inside `--out` AND a post-verify swap of the public bytes changes what the
+    consumer reads -> the swap-doesn't-reach-consumer asserts flip.
+  - `_download_to` -> `dst + ".tmp"`: a pre-planted predictable temp is clobbered
+    -> the untouched-temp asserts flip.
+
+These vectors exercise the CHECKSUM binding (pure Python) with the minisign
+signature step neutralized, mirroring test_xpf_deploy_gate's signed-manifest
+tests; the full minisign chain is covered there. pytest is not installed — run
+with `python3 -m unittest`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py"))
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+
+class VerifyUseTOCTOUTests(unittest.TestCase):
+    """The staging seam: the consumer must receive the VERIFIED inode, not a
+    re-openable public pathname whose bytes can be swapped after the check."""
+
+    def setUp(self):
+        here = Path(__file__).resolve().parent
+        sys.path.insert(0, str(here.parent / "dist"))
+        import sign
+        self.sign = sign
+        self.tmp = tempfile.mkdtemp(prefix="xpf-5817-")
+        self.out = os.path.join(self.tmp, "out")
+        os.makedirs(self.out)
+        # A real (non-placeholder) pubkey so _resolve_pubkey(None) accepts it —
+        # production supplies the real key the same way (XPF_IMAGE_PUBKEY). The
+        # checksum binding, not the signature, is what these vectors exercise, so
+        # neutralize the minisign check and drive the pure-Python hash compare.
+        self.pub = os.path.join(self.tmp, "test.pub")
+        with open(self.pub, "w") as f:
+            f.write("untrusted-test-key\n")
+        self._orig_env = os.environ.get("XPF_IMAGE_PUBKEY")
+        os.environ["XPF_IMAGE_PUBKEY"] = self.pub
+        self._orig_verify_sig = sign.verify_signature
+        sign.verify_signature = lambda m, s, p: None
+
+        self.names = {
+            "qcow2": "xpf-1.2.3.qcow2",
+            "metadata": "xpf-1.2.3.incus-metadata.tar.gz",
+            "manifest": "xpf-1.2.3.SHA256SUMS",
+            "sig": "xpf-1.2.3.SHA256SUMS.minisig",
+        }
+        self.qcow2_bytes = b"AUTHENTIC-QCOW2-BYTES"
+        self.meta_bytes = b"AUTHENTIC-METADATA-BYTES"
+        self._write(self.names["qcow2"], self.qcow2_bytes)
+        self._write(self.names["metadata"], self.meta_bytes)
+        self.manifest = os.path.join(self.out, self.names["manifest"])
+        sign.write_manifest(self.manifest, [
+            os.path.join(self.out, self.names["qcow2"]),
+            os.path.join(self.out, self.names["metadata"]),
+        ])
+        self.sig = os.path.join(self.out, self.names["sig"])
+        with open(self.sig, "w") as f:
+            f.write("stub-signature (verify_signature patched)\n")
+
+    def tearDown(self):
+        self.sign.verify_signature = self._orig_verify_sig
+        if self._orig_env is None:
+            os.environ.pop("XPF_IMAGE_PUBKEY", None)
+        else:
+            os.environ["XPF_IMAGE_PUBKEY"] = self._orig_env
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, name, data):
+        with open(os.path.join(self.out, name), "wb") as f:
+            f.write(data)
+
+    def _under_out(self, path):
+        return os.path.abspath(path).startswith(os.path.abspath(self.out) + os.sep)
+
+    def test_staged_path_private_and_swap_does_not_reach_consumer(self):
+        """The verify/use TOCTOU close: the consumer path is OUTSIDE --out, and a
+        post-verify swap of the public bytes does NOT change what it reads."""
+        with xpf_deploy._verified_private_artifacts(
+                self.sign, self.out, self.names, ["qcow2", "metadata"],
+                self.manifest, self.sig) as staged:
+            qpath, mpath = staged["qcow2"], staged["metadata"]
+            # (1) the consumer receives a path that is NOT the re-openable public
+            #     one — a --out writer cannot reach a private 0700 mkdtemp.
+            self.assertFalse(self._under_out(qpath),
+                             f"staged qcow2 {qpath} is inside public --out")
+            self.assertFalse(self._under_out(mpath),
+                             f"staged metadata {mpath} is inside public --out")
+            # (2) attacker swaps the PUBLIC files' bytes AFTER verification.
+            self._write(self.names["qcow2"], b"MALICIOUS-UNAUTHENTICATED-BYTES")
+            self._write(self.names["metadata"], b"MALICIOUS-METADATA")
+            # (3) the consumer still reads the VERIFIED bytes (swap didn't land).
+            with open(qpath, "rb") as f:
+                self.assertEqual(f.read(), self.qcow2_bytes)
+            with open(mpath, "rb") as f:
+                self.assertEqual(f.read(), self.meta_bytes)
+            # (4) the staged copy still verifies clean against the signed manifest.
+            self.assertTrue(
+                self.sign.verify_image_artifact(qpath, self.manifest, self.sig))
+
+    def test_authentic_artifacts_stage_and_verify(self):
+        """Regression: an untampered fetch stages + verifies both artifacts
+        end-to-end, hands back readable verified copies, and cleans up on exit."""
+        with xpf_deploy._verified_private_artifacts(
+                self.sign, self.out, self.names, ["metadata", "qcow2"],
+                self.manifest, self.sig) as staged:
+            with open(staged["qcow2"], "rb") as f:
+                self.assertEqual(f.read(), self.qcow2_bytes)
+            with open(staged["metadata"], "rb") as f:
+                self.assertEqual(f.read(), self.meta_bytes)
+            qpath = staged["qcow2"]
+            self.assertTrue(os.path.exists(qpath))
+        # staging dir is rmtree'd once the consumer returns.
+        self.assertFalse(os.path.exists(qpath))
+
+    def test_tampered_public_artifact_fails_closed(self):
+        """An artifact tampered BEFORE staging (copied bytes mismatch the signed
+        manifest) fails closed — staging does not weaken the checksum verify."""
+        self._write(self.names["qcow2"], b"TAMPERED-BEFORE-STAGE")
+        with self.assertRaises(SystemExit):
+            with xpf_deploy._verified_private_artifacts(
+                    self.sign, self.out, self.names, ["qcow2"],
+                    self.manifest, self.sig):
+                self.fail("must not yield a staged path for a tampered artifact")
+
+
+class DownloadExclusiveTempTests(unittest.TestCase):
+    """The secondary race: downloads must use an exclusive, unpredictable temp,
+    never a predictable shared `<dst>.tmp` a concurrent fetch could clobber."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix="xpf-5817-dl-")
+        self.dst = os.path.join(self.workdir, "xpf-1.2.3.qcow2")
+        self._orig_run = xpf_deploy.subprocess.run
+
+    def tearDown(self):
+        xpf_deploy.subprocess.run = self._orig_run
+        shutil.rmtree(self.workdir, ignore_errors=True)
+
+    @staticmethod
+    def _fake_curl_ok(argv, *a, **k):
+        # Emulate `curl -fsSL -o <tmp> <url>`: write known bytes to the -o target.
+        target = argv[argv.index("-o") + 1]
+        with open(target, "wb") as f:
+            f.write(b"DOWNLOADED-BYTES")
+
+        class _R:
+            returncode = 0
+        return _R()
+
+    @staticmethod
+    def _fake_curl_fail(argv, *a, **k):
+        class _R:
+            returncode = 22
+        return _R()
+
+    def test_exclusive_temp_does_not_clobber_predictable_name(self):
+        """A pre-planted predictable `<dst>.tmp` (a concurrent fetch's temp) is
+        left untouched; the download still succeeds via its own unpredictable
+        mkstemp temp and publishes atomically to dst."""
+        predictable = self.dst + ".tmp"
+        with open(predictable, "wb") as f:
+            f.write(b"PRE-EXISTING-JUNK")
+        xpf_deploy.subprocess.run = self._fake_curl_ok
+        xpf_deploy._download_to("http://x/xpf-1.2.3.qcow2", self.dst, self.workdir)
+        # download landed at dst via the unpredictable temp
+        with open(self.dst, "rb") as f:
+            self.assertEqual(f.read(), b"DOWNLOADED-BYTES")
+        # the predictable shared temp is UNTOUCHED (revert to `dst + ".tmp"`
+        # would overwrite+consume it -> these asserts flip RED)
+        self.assertTrue(os.path.exists(predictable),
+                        "predictable temp was consumed — download reused it")
+        with open(predictable, "rb") as f:
+            self.assertEqual(f.read(), b"PRE-EXISTING-JUNK")
+        # only the pre-existing predictable temp remains; the mkstemp temp was
+        # consumed by the atomic rename.
+        remaining = sorted(n for n in os.listdir(self.workdir)
+                           if n.endswith(".tmp"))
+        self.assertEqual(remaining, ["xpf-1.2.3.qcow2.tmp"])
+
+    def test_failed_download_cleans_temp_and_dies(self):
+        """A failed download fails closed and leaves no stray temp behind."""
+        xpf_deploy.subprocess.run = self._fake_curl_fail
+        with self.assertRaises(SystemExit):
+            xpf_deploy._download_to("http://x/xpf-1.2.3.qcow2", self.dst,
+                                    self.workdir)
+        self.assertFalse(os.path.exists(self.dst))
+        self.assertEqual(sorted(os.listdir(self.workdir)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -49,6 +49,7 @@ Examples:
 """
 
 import argparse
+import contextlib
 import json
 import os
 import re
@@ -1117,6 +1118,70 @@ def _ver_key(v):
     return (rel_key, pre_rank)
 
 
+def _download_to(url, dst, workdir):
+    """Download `url` to `dst` via an EXCLUSIVELY-created, unpredictable temp in
+    `workdir`, then publish atomically with os.replace (#5817).
+
+    mkstemp opens with O_CREAT|O_EXCL and a random name, so a concurrent fetch
+    to the same --out, or a pre-planted predictable `<dst>.tmp`, cannot collide
+    with or clobber the in-flight download (the old shared `<dst>.tmp` had no
+    exclusive create — two fetches raced onto the same path). The temp is
+    unlinked on download failure and consumed by the atomic rename on success."""
+    fd, tmp = tempfile.mkstemp(
+        prefix="." + os.path.basename(dst) + ".", suffix=".tmp", dir=workdir)
+    os.close(fd)
+    r = subprocess.run(["curl", "-fsSL", "-o", tmp, url])
+    if r.returncode != 0:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        die(f"download failed: {url}")
+    os.replace(tmp, dst)
+
+
+@contextlib.contextmanager
+def _verified_private_artifacts(sign_mod, out, names, keys, manifest, sig):
+    """Yield a {key: path} map of artifacts COPIED into a private 0700 staging
+    dir and re-verified there — closing the verify-by-name / use-by-name TOCTOU
+    (#5817).
+
+    The public --out dir may be writable by another local process. Verifying a
+    file at its public pathname and THEN handing that same pathname to libvirt
+    (`_install_libvirt_golden` copy-to-golden) or `incus image import` lets a
+    dir-writer swap unauthenticated bytes into the file BETWEEN the checksum
+    check and the consumer's open — the verified inode is not retained. Instead
+    we copy each artifact into a mkdtemp (0700, owned by us, OUTSIDE --out — the
+    same private-copy pattern sign.verify_and_read / verify_listed_artifact_bytes
+    use for the directly-signed TOCTOU class) and verify the COPY in place, then
+    give the consumer THAT path. Nothing that can write --out can reach the
+    staging dir, so the bytes the consumer reads are exactly the bytes that were
+    verified. Portable for BOTH consumers: each accepts a pathname and this hands
+    them a private one whose bytes cannot be swapped after the check.
+
+    The manifest + its .minisig stay in --out: they are self-authenticating
+    (verify_and_read re-checks the signature over the manifest bytes on every
+    call, and an attacker without the secret key cannot forge a manifest listing
+    a tampered artifact's hash), so only the checksummed artifacts need staging."""
+    stage = tempfile.mkdtemp(prefix="xpf-verify-")
+    try:
+        os.chmod(stage, 0o700)
+        staged = {}
+        for k in keys:
+            name = names[k]
+            src = os.path.join(out, name)
+            dst = os.path.join(stage, name)
+            shutil.copyfile(src, dst)
+            try:
+                sign_mod.verify_image_artifact(dst, manifest, sig)
+            except sign_mod.SignError as e:
+                die(f"VERIFICATION FAILED for {name}: {e}")
+            staged[k] = dst
+        yield staged
+    finally:
+        shutil.rmtree(stage, ignore_errors=True)
+
+
 def cmd_fetch(args):
     """Download an appliance image from XPF_IMAGE_BASE_URL, VERIFY the exact
     downloaded bytes against the signed per-version manifest (#1924 §5.2),
@@ -1184,10 +1249,9 @@ def cmd_fetch(args):
             print(f"  (dry-run) curl -fsSL {url} -> {dst}")
             return dst
         print(f"==> fetching {url}")
-        r = subprocess.run(["curl", "-fsSL", "-o", dst + ".tmp", url])
-        if r.returncode != 0:
-            die(f"download failed: {url}")
-        os.replace(dst + ".tmp", dst)
+        # #5817: exclusive-create unpredictable temp + atomic publish (no shared
+        # predictable `<dst>.tmp` a concurrent fetch could collide/overwrite).
+        _download_to(url, dst, out)
         return dst
 
     # Need at least the manifest + sig + the artifact(s) the operator wants.
@@ -1232,13 +1296,20 @@ def cmd_fetch(args):
     # libvirt golden basename = deploy's `image:` default, so the incus alias
     # and the libvirt golden name AGREE (fable-165 H-30).
     img_name = args.alias or "xpf-appliance"
-    qcow2_src = os.path.join(out, names["qcow2"])
+    # Public path for the non-consuming (--no-import) message only. The two
+    # in-process consumers below read from a private staging dir, NOT this
+    # re-openable public path (#5817).
+    qcow2_pub = os.path.join(out, names["qcow2"])
 
     # H-30: bridge the fetch -> libvirt gap. `deploy --hypervisor libvirt`
     # reads the golden at libvirt_golden_path(image); --install-libvirt puts
     # the verified qcow2 there (shared path helper — the two can't drift).
     if args.install_libvirt:
-        _install_libvirt_golden(qcow2_src, img_name)
+        # #5817: install the qcow2 to the golden from the private staging copy,
+        # so a post-verify swap in --out cannot poison the golden.
+        with _verified_private_artifacts(
+                sign, out, names, ["qcow2"], manifest, sig) as staged:
+            _install_libvirt_golden(staged["qcow2"], img_name)
         print(f"==> done. Deploy with: xpf-deploy.py --hypervisor libvirt "
               f"deploy <appliance.yaml>  (image: {img_name})")
         return 0
@@ -1247,7 +1318,7 @@ def cmd_fetch(args):
         golden = libvirt_golden_path(img_name)
         print(f"==> verified into {out} (not imported). For libvirt/KVM, install "
               f"it to the golden path deploy reads:\n"
-              f"      sudo install -m 0644 -D {qcow2_src} {golden}\n"
+              f"      sudo install -m 0644 -D {qcow2_pub} {golden}\n"
               f"   (or re-run fetch with --install-libvirt), then: "
               f"xpf-deploy.py --hypervisor libvirt deploy <appliance.yaml> "
               f"(image: {img_name}). For incus, re-run without "
@@ -1258,9 +1329,13 @@ def cmd_fetch(args):
     subprocess.run(["incus", "image", "delete", alias],
                    capture_output=True, text=True)
     print(f"==> importing verified image as incus alias '{alias}'")
-    r = subprocess.run(["incus", "image", "import",
-                        os.path.join(out, names["metadata"]),
-                        os.path.join(out, names["qcow2"]), "--alias", alias])
+    # #5817: import from the private staging dir so a post-verify swap of the
+    # public metadata/qcow2 in --out cannot feed unauthenticated bytes to
+    # `incus image import`. The dir is rmtree'd once the import returns.
+    with _verified_private_artifacts(
+            sign, out, names, ["metadata", "qcow2"], manifest, sig) as staged:
+        r = subprocess.run(["incus", "image", "import",
+                            staged["metadata"], staged["qcow2"], "--alias", alias])
     if r.returncode != 0:
         die("incus image import failed")
     print(f"==> done. Deploy with: xpf-deploy.py deploy <appliance.yaml> "


### PR DESCRIPTION
Closes #5817

## STEP-0 confirmation
Verified live on current origin/master (`3b3b15eff`):
- `sign.verify_image_artifact()` (scripts/dist/sign.py:244-265) hashes a path and returns only `True` — the verified inode is NOT retained.
- `cmd_fetch` verifies qcow2/metadata at their PUBLIC `--out` pathnames, then re-opens those same public paths in the consumers: `_install_libvirt_golden(qcow2_src, ...)` (copy-to-golden) and `incus image import <metadata> <qcow2>`.
- `fetch_one` downloaded to a predictable shared `<dst>.tmp` with no exclusive create.

Both the verify-by-name/use-by-name TOCTOU and the non-exclusive `<dst>.tmp` were STILL present. Not stale-fixed.

## Root cause
The public `--out` directory may be writable by another local process. Authenticating an artifact at its public pathname and then handing that SAME pathname to a different consumer lets a dir-writer rename/replace the file with unauthenticated content AFTER the checksum check and BEFORE the consumer's open. libvirt (`_install_libvirt_golden` → `shutil.copyfile`/`sudo install`) and `incus image import` both re-open by public pathname, so the downstream consumer receives bytes that were never authenticated. The predictable non-exclusive `<dst>.tmp` widens the window: concurrent fetches to one `--out` can collide/overwrite.

## Consumer interface
Both consumers accept a **pathname**, not a fd — libvirt's copy-to-golden and `incus image import` take file paths and do not universally accept `/proc/self/fd/N`. So the portable close is **(A) verify into a private, non-attacker-writable location**, not (B) fd-passing.

## Fix — mechanism (A)
- `_verified_private_artifacts(...)`: for each to-be-consumed artifact, copy it into a **private 0700 `mkdtemp` OUTSIDE `--out`**, re-verify the COPY against the signed manifest, and hand the consumer THAT path. Nothing that can write `--out` can reach the staging dir, so the bytes the consumer reads are exactly the bytes that were verified. Reuses the same private-copy pattern `sign.verify_and_read` / `verify_listed_artifact_bytes` already use for the directly-signed TOCTOU class. Wired into BOTH consumers (libvirt install: `["qcow2"]`; incus import: `["metadata","qcow2"]`), so it is portable for both. The manifest + `.minisig` stay in `--out` — they are self-authenticating (the minisig is re-checked over the manifest bytes on every call; an attacker without the secret key cannot forge a manifest listing a tampered artifact's hash), so only the checksummed artifacts need staging.
- `_download_to(...)`: download to an exclusively-created, unpredictable `mkstemp` temp (O_CREAT|O_EXCL) and publish atomically with `os.replace`. Unlinked on failure.

The signature/checksum verification itself is unchanged — this only closes the window between verify and use, and hardens temp creation. The non-consuming `--no-import`/`--qcow2-only` path still leaves the verified file in `--out` for the operator (no in-process consumer to protect); its message references the public path.

## Fail-on-revert (the merge gate) — proven firsthand
New `scripts/deploy/test_xpf_deploy_verify_toctou.py` (5 tests, auto-discovered by run-selftests.sh):

**TOCTOU close** — neutralized `_verified_private_artifacts` to hand back the public `src` path:
```
FAIL: test_staged_path_private_and_swap_does_not_reach_consumer
AssertionError: True is not false : staged qcow2 /tmp/xpf-5817-.../out/xpf-1.2.3.qcow2 is inside public --out
FAIL: test_authentic_artifacts_stage_and_verify
AssertionError: True is not false
Ran 3 tests ... FAILED (failures=2)
```
Restored → GREEN.

**O_EXCL temp** — neutralized `_download_to` to `dst + ".tmp"`:
```
FAIL: test_exclusive_temp_does_not_clobber_predictable_name
AssertionError: False is not true : predictable temp was consumed — download reused it
Ran 2 tests ... FAILED (failures=1)
```
Restored → GREEN.

Regression: an authentic fetch stages+verifies both artifacts end-to-end and cleans up; a pre-staging tamper fails closed (SystemExit).

## Verification
`make selftest` (scripts/run-selftests.sh — grow-root, bake sign-order, dist roundtrip, validate.py, xpf-deploy suite incl. the new test):
```
== selftest summary ==
  passed=41  skipped=0  failed=0
  OK — all self-tests passed (or SKIP-gated on missing tools)
```
Python deploy-tooling change — verified by `make selftest`; no loss-cluster smoke needed.

## Docs
`docs/install-images.md` records the verify/use + exclusive-temp supply-chain contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155Y5F849qaw7LWF4JrB4EW