### PR TITLE
vrrp: bound advert address count before serialize

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-16 — #5090 (pkg/vrrp, validation hardening): bound VRRPv3 advert address count before serialize
+- **Timestamp**: 2026-07-16 (fix/5090-vrrp-advert-count-cap)
+- **Action**: Fix #5090. STEP-0 confirmed live on origin/master: `Marshal` in
+  `pkg/vrrp/packet.go` took `count := len(p.IPAddresses)` (unbounded int),
+  serialized the full 8+N-byte payload, then narrowed the header Count field
+  with `buf[3] = uint8(count)` and NO address-count bound. With 256 addresses
+  Count wraps to 0 (256 mod 256) while the payload is fully serialized, so
+  receivers reject/misparse the advert. Trigger is impractical (IPv6 MTU caps a
+  single-family list well below 255) → Low validation hardening. Fix: add
+  `MinAdvertAddrCount=1`/`MaxAdvertAddrCount=255` constants (RFC 5798 §5.2.4 —
+  Count is an 8-bit field) and a guard at the top of `Marshal`, BEFORE buffer
+  allocation, that returns an error when `count < 1 || count > 255` — mirroring
+  the vrrp.go MinVRID/MaxVRID guard (#4573). REJECT, not silent truncate (a cap
+  would drop VIPs from the advert). Callers (`sendPacketIPv4`/`sendPacketIPv6`)
+  already propagate a Marshal error; `sendAdvert` only builds a packet when
+  `len(addrs) > 0`, so the lower bound never fires on the legit path. No wire-
+  format change; the normal 1..255 path is byte-identical.
+- **File(s)**: pkg/vrrp/packet.go,
+  pkg/vrrp/packet_addrcount_5090_test.go (new), _Log.md
+- **Validation**: new tests (`TestMarshal_RejectsOver255Addresses`,
+  `TestMarshal_AddressCountBoundaries`, `TestMarshal_NormalAdvertUnchanged`) —
+  fail-on-revert proven firsthand: neutralize the guard → 256-address Marshal
+  succeeds with serialized Count byte == 0 (RED), boundary count=0/256 no longer
+  error (RED); restore → GREEN. Full `pkg/vrrp` suite green under `-race`;
+  `go build ./...` + `go vet ./pkg/vrrp` clean. No doc change: README documents
+  state-machine/timing/checksum behavior, not a wire-format Count/Marshal
+  address-count contract — the code-level doc comment on the new constants is
+  the contract home.
+
 ## 2026-07-16 — #5817 (scripts/deploy, security): fetch verify/use TOCTOU + non-exclusive temp
 - **Timestamp**: 2026-07-16 (fix/5817-deploy-verify-toctou)
 - **Action**: Fix #5817 (codex-183 audit, supply-chain TOCTOU). STEP-0 confirmed

--- a/pkg/vrrp/packet.go
+++ b/pkg/vrrp/packet.go
@@ -16,6 +16,21 @@ const (
 	vrrpHeaderLen = 8
 )
 
+// MinAdvertAddrCount / MaxAdvertAddrCount bound the number of virtual IP
+// addresses a single VRRPv3 advertisement may carry. RFC 5798 §5.2.4 defines
+// the "Count IPvX Addr" field as 8 bits, so at most 255 addresses fit and a
+// valid advert carries at least one. Marshal writes this count straight onto
+// the single wire byte (`buf[3] = uint8(count)`), so an unbounded address
+// slice would truncate: 256 addresses wrap to Count 0, producing a
+// fully-serialized 8+N-byte payload whose header claims zero addresses — every
+// receiver then rejects (or misparses) the advert. Marshal range-checks the
+// slice length against these bounds BEFORE serializing and refuses to build
+// such a packet, mirroring the VRID guard (vrrp.go MinVRID/MaxVRID, #4573).
+const (
+	MinAdvertAddrCount = 1
+	MaxAdvertAddrCount = 255
+)
+
 // VRRPPacket represents a VRRPv3 advertisement packet (RFC 5798).
 type VRRPPacket struct {
 	VRID         uint8
@@ -39,6 +54,14 @@ func (p *VRRPPacket) Marshal(isIPv6 bool, srcIP, dstIP net.IP) ([]byte, error) {
 	}
 
 	count := len(p.IPAddresses)
+	// Reject before serializing: the count is written to a single u8 wire byte
+	// (buf[3]), so >255 addresses would narrow lossily (256→Count 0) and a
+	// 0-address advert is meaningless per RFC 5798 §5.2.4. Surface the
+	// misconfiguration instead of emitting an advert with a wrong Count.
+	if count < MinAdvertAddrCount || count > MaxAdvertAddrCount {
+		return nil, fmt.Errorf("VRRP advert address count %d out of range %d..%d",
+			count, MinAdvertAddrCount, MaxAdvertAddrCount)
+	}
 	pktLen := vrrpHeaderLen + count*addrSize
 	buf := make([]byte, pktLen)
 

--- a/pkg/vrrp/packet_addrcount_5090_test.go
+++ b/pkg/vrrp/packet_addrcount_5090_test.go
@@ -1,0 +1,151 @@
+package vrrp
+
+import (
+	"net"
+	"testing"
+)
+
+// #5090: Marshal sizes and fills the advert payload from an unbounded int
+// address count but narrows the header Count field with uint8(count). Without a
+// bound, 256 addresses serialize a full 8+N-byte payload while Count wraps to 0
+// (256 mod 256) — receivers reject or misparse the advert. The guard rejects
+// len(IPAddresses) outside 1..255 BEFORE serialization so a wrong Count is never
+// emitted. These tests assert the real Marshal result (error vs the serialized
+// Count byte), not an internal flag.
+
+// makeV4Addrs builds n distinct IPv4 addresses for advert construction.
+func makeV4Addrs(n int) []net.IP {
+	addrs := make([]net.IP, 0, n)
+	for i := 0; i < n; i++ {
+		addrs = append(addrs, net.IPv4(10, 0, byte(i>>8), byte(i)))
+	}
+	return addrs
+}
+
+// TestMarshal_RejectsOver255Addresses is the fail-on-revert gate: 256 addresses
+// must return an error and NOT produce a buffer with Count=0. Neutralizing the
+// guard (buf[3]=uint8(count) with no bound) makes Marshal succeed and Count wrap
+// to 0 — this test then goes RED because err == nil.
+func TestMarshal_RejectsOver255Addresses(t *testing.T) {
+	src := net.IPv4(10, 0, 0, 2)
+	dst := net.IPv4(224, 0, 0, 18)
+
+	pkt := &VRRPPacket{
+		VRID:         42,
+		Priority:     200,
+		MaxAdvertInt: 100,
+		IPAddresses:  makeV4Addrs(256),
+	}
+
+	buf, err := pkt.Marshal(false, src, dst)
+	if err == nil {
+		// Under the neutralized (buggy) code Marshal succeeds and the Count byte
+		// wraps to 0 despite 256 serialized addresses. Assert that concrete wrong
+		// result so the fail-on-revert direction is unambiguous.
+		gotCount := buf[3]
+		t.Fatalf("expected error for 256 addresses; got nil err with Count byte = %d "+
+			"(256 wrapped to 0 → receivers reject the advert)", gotCount)
+	}
+}
+
+// TestMarshal_AddressCountBoundaries pins that the guard does not off-by-one
+// reject a legal maximum (255) and does reject 256, and that a valid count is
+// serialized into the Count byte unchanged.
+func TestMarshal_AddressCountBoundaries(t *testing.T) {
+	src := net.IPv4(10, 0, 0, 2)
+	dst := net.IPv4(224, 0, 0, 18)
+
+	cases := []struct {
+		count     int
+		wantError bool
+	}{
+		{0, true},    // empty advert is meaningless (Count must be >= 1)
+		{1, false},   // minimum legal
+		{254, false}, // just below max
+		{255, false}, // maximum representable in the u8 Count field
+		{256, true},  // wraps to 0 — must be rejected
+	}
+
+	for _, tc := range cases {
+		pkt := &VRRPPacket{
+			VRID:         7,
+			Priority:     100,
+			MaxAdvertInt: 100,
+			IPAddresses:  makeV4Addrs(tc.count),
+		}
+		buf, err := pkt.Marshal(false, src, dst)
+		if tc.wantError {
+			if err == nil {
+				t.Errorf("count=%d: expected error, got nil (Count byte=%d)", tc.count, buf[3])
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("count=%d: unexpected error: %v", tc.count, err)
+			continue
+		}
+		// The serialized Count byte must equal the address count exactly.
+		if int(buf[3]) != tc.count {
+			t.Errorf("count=%d: Count byte = %d, want %d", tc.count, buf[3], tc.count)
+		}
+		// Payload length must match header + count*addrSize (IPv4 = 4 bytes each).
+		if wantLen := vrrpHeaderLen + tc.count*4; len(buf) != wantLen {
+			t.Errorf("count=%d: buffer len = %d, want %d", tc.count, len(buf), wantLen)
+		}
+	}
+}
+
+// TestMarshal_NormalAdvertUnchanged is the regression guard: a small (1-3
+// address) advert must serialize byte-identically to the pre-guard behavior —
+// Count == len(addresses) and the payload is untouched. The guard only rejects
+// out-of-range counts; it must not alter the normal 1..255 path.
+func TestMarshal_NormalAdvertUnchanged(t *testing.T) {
+	src := net.IPv4(10, 0, 0, 2)
+	dst := net.IPv4(224, 0, 0, 18)
+
+	pkt := &VRRPPacket{
+		VRID:         42,
+		Priority:     200,
+		MaxAdvertInt: 100,
+		IPAddresses: []net.IP{
+			net.IPv4(10, 0, 1, 1),
+			net.IPv4(10, 0, 1, 2),
+			net.IPv4(10, 0, 1, 3),
+		},
+	}
+
+	buf, err := pkt.Marshal(false, src, dst)
+	if err != nil {
+		t.Fatalf("normal 3-address advert must marshal: %v", err)
+	}
+
+	// Header fields must be exactly as before the guard.
+	if got := buf[0]; got != (vrrpVersion<<4)|vrrpTypeAdvert {
+		t.Errorf("byte0 version|type = 0x%02x, want 0x%02x", got, (vrrpVersion<<4)|vrrpTypeAdvert)
+	}
+	if buf[1] != 42 {
+		t.Errorf("VRID = %d, want 42", buf[1])
+	}
+	if buf[2] != 200 {
+		t.Errorf("Priority = %d, want 200", buf[2])
+	}
+	if buf[3] != 3 {
+		t.Errorf("Count = %d, want 3 (== len(IPAddresses))", buf[3])
+	}
+	if wantLen := vrrpHeaderLen + 3*4; len(buf) != wantLen {
+		t.Fatalf("buffer len = %d, want %d", len(buf), wantLen)
+	}
+
+	// The three addresses must be laid out contiguously after the 8-byte header.
+	for i, want := range []net.IP{
+		net.IPv4(10, 0, 1, 1),
+		net.IPv4(10, 0, 1, 2),
+		net.IPv4(10, 0, 1, 3),
+	} {
+		off := vrrpHeaderLen + i*4
+		got := net.IP(buf[off : off+4])
+		if !got.Equal(want.To4()) {
+			t.Errorf("address %d = %v, want %v", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #5090

## STEP-0 confirmation (not already fixed)
On current `origin/master`, `Marshal` in `pkg/vrrp/packet.go` still had
`count := len(p.IPAddresses)` (unbounded int) followed by
`buf[3] = uint8(count)` with **no** address-count bound — the exact bug
described in #5090. Verified live before starting.

## Root cause
`Marshal` sizes and fills the VRRPv3 advert payload from an unbounded
`int` address count, then narrows the header **Count** field with
`uint8(count)`. With 256 addresses the full `8 + N*addrSize`-byte payload
serializes correctly, but the Count byte wraps to `256 mod 256 == 0`.
A receiver then sees a fully-formed advert claiming **zero** addresses and
rejects or misparses it. The trigger is impractical (an IPv6 MTU caps a
single-family VIP list well below 255), so this is Low validation
hardening — but a large-but-representable config must never silently
serialize with a wrong (wrapped) Count.

## Fix — reject, do NOT truncate
Added `MinAdvertAddrCount = 1` / `MaxAdvertAddrCount = 255` constants
(RFC 5798 §5.2.4 defines "Count IPvX Addr" as an 8-bit field) and a guard
at the top of `Marshal`, **before** buffer allocation, that returns an
error when `count < 1 || count > 255`. This mirrors the existing VRID
range guard (`vrrp.go` `MinVRID`/`MaxVRID`, #4573) — same
`return nil, fmt.Errorf(...)` convention `Marshal` already uses for
invalid addresses.

The guard **rejects** rather than capping the list to 255: silently
truncating would drop VIPs from the advert (a hidden correctness change),
so a misconfiguration surfaces as a clear error naming the count and the
1..255 range instead. The `>255` upper bound is the load-bearing fix; the
`==0` lower bound is included because RFC 5798 requires Count ≥ 1 and the
code's own `sendAdvert` only ever builds a packet when `len(addrs) > 0`,
so it never fires on the legitimate path.

Callers `sendPacketIPv4`/`sendPacketIPv6` already propagate a `Marshal`
error (and `sendAdvert` logs it at Debug) — no panic, clean failure. The
guard fires before serialization, so a 256-address packet never produces
a Count=0 buffer.

## 255 boundary handling
`254` and `255` addresses **succeed** with `Count == len` (255 is the max
representable in the u8 Count field — the fix does not off-by-one reject a
legal 255). `256` errors. `0` errors. A normal 1–3 address advert
serializes **byte-identically** to before — no wire-format change.

## Fail-on-revert (the merge gate)
New tests in `pkg/vrrp/packet_addrcount_5090_test.go` assert the **real**
Marshal result (error vs the serialized Count byte), not an internal flag.
Neutralizing the guard (revert to `buf[3]=uint8(count)` with no bound) and
running the named tests:

```
=== RUN   TestMarshal_RejectsOver255Addresses
    packet_addrcount_5090_test.go:46: expected error for 256 addresses; got nil err with Count byte = 0 (256 wrapped to 0 → receivers reject the advert)
--- FAIL: TestMarshal_RejectsOver255Addresses (0.00s)
=== RUN   TestMarshal_AddressCountBoundaries
    packet_addrcount_5090_test.go:79: count=0: expected error, got nil (Count byte=0)
    packet_addrcount_5090_test.go:79: count=256: expected error, got nil (Count byte=0)
--- FAIL: TestMarshal_AddressCountBoundaries (0.00s)
=== RUN   TestMarshal_NormalAdvertUnchanged
--- PASS: TestMarshal_NormalAdvertUnchanged (0.00s)
FAIL
```

Restoring the guard → all GREEN. `TestMarshal_NormalAdvertUnchanged`
passes under both (it is the regression guard for the normal path, not the
bug). Full `pkg/vrrp` suite passes under `-race`; `go build ./...` and
`go vet ./pkg/vrrp` clean.

## Docs
No doc change: `pkg/vrrp/README.md` documents state-machine/timing/checksum
behavior, not a wire-format Count/Marshal address-count contract — the
code-level doc comment on the new constants is the contract home.

## Testing scope
Pure-logic Go change (no dataplane/HA runtime path exercised) → no
loss-cluster smoke; gated on the unit tests above.