### PR TITLE
deploy: renew + fence the cross-orchestrator roll lease

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-16 — #5816 (scripts/deploy, security/correctness): cross-orchestrator lease renew + fence
+- **Timestamp**: 2026-07-16 (fix/5816-deploy-lease-renew-fence)
+- **Action**: Fix #5816 (codex-183 audit). STEP-0 confirmed live on origin/master
+  (3b3b15eff): `scripts/deploy/xpf-deploy.py` `_acquire_lease` writes
+  `expires_at = node_now + --lease-ttl` ONCE; neither `cmd_kernel_roll` nor
+  `cmd_image_roll` renewed the lease or re-checked ownership before their later
+  mutations (drain / arm+reboot / image-recreate / rejoin). #5470/#5545 fixed
+  only the `--lease-ttl<=0` degenerate case (positive_int floor). A positive TTL
+  shorter than boot/drain latency or the recreate hook expired BOTH node leases
+  mid-roll while the driver kept running → a successor could atomically reclaim
+  both and start its own roll on the same HA pair (split-brain deploy). Fix:
+  (1) `_renew_lease` re-writes `expires_at = now+ttl` iff the holder still
+  matches, atomically (temp+rename) under the acquire flock; a reclaimed lease
+  (holder differs / gone) → "lost" (never resurrected); a transport failure →
+  "unreachable" (never a false loss, #4905-A discipline). (2) `_keepalive_leases`
+  renews every reachable target each reboot-poll tick — during the wait only the
+  still-up PEER lease is renewed (rolled node is unreachable / has a fresh
+  lease-less disk), which is the load-bearing reservation. (3)
+  `_fence_before_mutate` renews-and-verifies ownership of every relevant lease
+  immediately before EACH mutation and die()s fail-closed on a lost/unconfirmable
+  lease. Owner-identity token (`nodename:pid<pid>`) is unchanged from
+  acquire/reclaim; acquire/reclaim atomicity untouched. TTL floor NOT raised
+  (renewal makes a short TTL safe; recreate hook is fenced to a fresh TTL right
+  before it). Fail-on-revert PROVEN firsthand (neutralize→RED→restore): remove
+  kernel fence-before-drain → drain executes on a lost pair; remove poll-loop
+  keepalive → lease expires mid-roll (TTL 15 < 30s promote) → pre-rejoin fence
+  aborts a roll that promoted; remove image fence-before-recreate → destructive
+  recreate runs on a lost pair. New `test_xpf_deploy_lease_renew_fence.py`
+  (17 tests: renew verdict mapping, fence gate, keepalive, + 3 end-to-end
+  gate/renewal tests). Verified: full deploy suite 143/143; `make selftest`
+  41/0/0; `make test-deploy-lib` 19/0; `make test-cluster-lock-lib` 12/12.
+  Doc: `docs/in-place-upgrade.md` lease-contract section extended with the
+  renew+fence mechanism and the sharpened self-recovery relation.
+- **File(s)**: scripts/deploy/xpf-deploy.py,
+  scripts/deploy/test_xpf_deploy_lease_renew_fence.py (new),
+  scripts/deploy/test_xpf_deploy_kernel_roll.py,
+  scripts/deploy/test_xpf_deploy_image_roll_identity.py,
+  docs/in-place-upgrade.md, _Log.md
+
 ## 2026-07-16 — #5815 (scripts/dist, security): publish gate ignored signed base_image_pinned
 - **Timestamp**: 2026-07-16 (fix/5815-publish-base-pinned-gate)
 - **Action**: Fix #5815 (codex-183 audit, release-provenance bypass). STEP-0

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-16 — #5816 review fold: fence the finally-rejoin after a lost lease (PR #6021)
+- **Timestamp**: 2026-07-16 (fix/5816-deploy-lease-renew-fence)
+- **Action**: Folded one MERGE-NEEDS-MINOR reviewer finding into PR #6021. Gap:
+  `cmd_kernel_roll`'s `finally` best-effort restore-forwarding rejoin fired on
+  `drained and not completed and not rebooted` with NO ownership check. Because
+  `die()` == `sys.exit()` == `SystemExit`, that `finally` STILL RUNS after a
+  fence-abort — so a reachable path (short TTL + slow blocking drain → our lease
+  expires mid-drain → successor reclaims → the fence-before-ARM detects "lost" →
+  `die()`) let the UNFENCED finally issue `xpfd upgrade kernel rejoin`, UN-draining
+  a pair the successor now owns — violating the PR's own invariant (a lost
+  orchestrator must NOT mutate the pair). Fix: added a `lost_lease` flag local to
+  `roll_one`; `_fence_before_mutate` gained an optional `on_lost` callback invoked
+  immediately before its `die()` on BOTH a confirmed loss AND an
+  unconfirmable-after-retries lease (treat unconfirmable ownership as unsafe-to-
+  mutate, same fail-closed stance as the fences). All three kernel fences pass
+  `on_lost=_note_lost_lease`; the keepalive-loss site sets the flag too. The
+  finally-rejoin is gated on `not lost_lease` — a clean abort where the lease is
+  still confidently held STILL rejoins (restore-forwarding preserved). image-roll's
+  finally (holder-guarded `_clear_lease` only, no rejoin) is already safe and was
+  left unchanged. New fail-on-revert test
+  (`KernelRollLostAfterDrainNoRejoinTests.test_fence_before_arm_loss_suppresses_finally_rejoin`)
+  drives drain-succeeds → lease-reclaimed → fence-before-arm LOST → `die()` and
+  asserts verbs == [('fw0','drain')], NOT [('fw0','drain'),('fw0','rejoin')] — the
+  fence-before-ARM-LOST → finally path the existing fence-before-DRAIN abort test
+  (drained never set) could not reach. RED-on-revert PROVEN firsthand: neutralizing
+  the `and not lost_lease` gate → the finally rejoins unconditionally → test RED
+  (`[('fw0','drain'),('fw0','rejoin')] != [('fw0','drain')]`, log "roll did not
+  complete and fw0 never rebooted; rejoining fw0 to restore forwarding..."); gate
+  restored → GREEN (18/18). Validation: `python3 -m unittest
+  test_xpf_deploy_lease_renew_fence` = 18 tests OK; `ast.parse` clean.
+- **File(s)**: scripts/deploy/xpf-deploy.py (edit — `_fence_before_mutate` on_lost
+  param; `roll_one` lost_lease flag + `_note_lost_lease`; 3 fence calls + keepalive
+  loss site set it; finally-rejoin gated on `not lost_lease`),
+  scripts/deploy/test_xpf_deploy_lease_renew_fence.py (edit — new
+  `_KernelLostAfterDrainBackend` + `KernelRollLostAfterDrainNoRejoinTests`),
+  docs/in-place-upgrade.md (edit — Fence `lost_lease` finally-suppression note +
+  corrected the "always rejoined" paragraph)
+
 ## 2026-07-16 — #5816 (scripts/deploy, security/correctness): cross-orchestrator lease renew + fence
 - **Timestamp**: 2026-07-16 (fix/5816-deploy-lease-renew-fence)
 - **Action**: Fix #5816 (codex-183 audit). STEP-0 confirmed live on origin/master

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -886,6 +886,44 @@ comfortably exceed the whole roll (`--boot-deadline` plus drain/rejoin
 margins). The same `--lease-ttl` contract applies to `image-roll`
 (#5470).
 
+The lease is RENEWED-WHILE-OWNED and FENCED-BEFORE-MUTATE (#5816). The
+one-shot lease of #5470/#5545 wrote `expires_at` ONCE and neither roll
+path renewed it nor re-checked ownership before its later mutations, so a
+positive TTL shorter than the real roll (boot/drain deadlines, an image
+recreate, ordinary reboot/rejoin latency) let BOTH node leases EXPIRE
+while a driver kept running — and a successor could then atomically
+reclaim both expired leases and start its own roll against the same pair
+(split-brain deploy). Two mechanisms close this, both keyed on the SAME
+owner-identity token (`nodename:pid<pid>`) the acquire/reclaim already
+use:
+
+- **Renewal** (`_renew_lease`): re-writes `expires_at = node_now + ttl`
+  iff the holder still matches, atomically (temp+rename) under the acquire
+  flock; a lease another orchestrator reclaimed (holder differs / file
+  gone) is reported LOST and left untouched — renewal never resurrects a
+  lost lease. It is fired every reboot-poll tick (keep-alive). The rolled
+  node is unreachable while it reboots (kernel-roll) or has a fresh
+  lease-less disk after recreate (image-roll), so during the wait ONLY the
+  still-up PEER's lease is renewed — that peer lease is the load-bearing
+  reservation (a successor can never acquire BOTH node leases while we
+  hold the peer's). A mid-reboot transport failure is NEVER misread as a
+  loss (the #4905-A discipline).
+- **Fence** (`_fence_before_mutate`): immediately before EACH pair-mutating
+  action (drain, arm+reboot, image-recreate, rejoin) it renews-and-verifies
+  ownership of every relevant lease and, unless it can prove we still own
+  them, `die()`s fail-closed. The load-bearing invariant: an orchestrator
+  that has lost (or cannot confirm) its lease MUST NOT mutate the pair.
+
+Because renewal keeps the TTL a rolling window that never elapses while the
+driver is live, the `--lease-ttl` FLOOR was NOT raised: a short TTL is now
+safe (it is renewed). Size it above a single un-interruptible mutation the
+keep-alive cannot cover mid-call — chiefly the `image-roll` recreate hook,
+which the fence renews to a fresh full TTL immediately before invoking; the
+default 1800s comfortably exceeds a VM launch + day-0. This also sharpens
+the crashed-roll self-recovery contract below: the lease now stays alive
+ONLY while the orchestrator is live, so an EXPIRED lease is an unambiguous
+crash signal — a slow-but-alive driver no longer looks crashed.
+
 The poll decides "the node rebooted" from an AFFIRMATIVE signal only — a
 CHANGED `boot_id` (`/proc/sys/kernel/random/boot_id`, recorded pre-arm) or the
 candidate kernel actually running — never from an empty status read (#4905-A).

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -913,6 +913,14 @@ use:
   ownership of every relevant lease and, unless it can prove we still own
   them, `die()`s fail-closed. The load-bearing invariant: an orchestrator
   that has lost (or cannot confirm) its lease MUST NOT mutate the pair.
+  Because `die()` is a `SystemExit`, `kernel-roll`'s `finally` still runs
+  after a fence-abort — and its own best-effort restore-forwarding rejoin
+  IS a pair mutation. So the fence records the loss (a `lost_lease` flag,
+  set on a confirmed loss OR an unconfirmable-after-retries lease — the same
+  fail-closed stance) and the `finally` SKIPS that rejoin whenever the flag
+  is set: an orchestrator that lost its lease must not un-drain a pair a
+  successor now owns. A clean abort where the lease is still confidently
+  held leaves the flag clear and the restore rejoin runs as before.
 
 Because renewal keeps the TTL a rolling window that never elapses while the
 driver is live, the `--lease-ttl` FLOOR was NOT raised: a short TTL is now
@@ -936,7 +944,9 @@ preflight WITHOUT rebooting) look like a finished revert; the `finally` then
 skipped its rejoin and left the node DRAINED + ForceSecondary with both leases
 released — a silent loss of redundancy. Rejoin is now decided from the
 confirmed drain state: a drained node that never affirmatively rebooted is
-always rejoined.
+rejoined — UNLESS the roll aborted because we lost the lease (see the Fence
+`lost_lease` note above), in which case the pair belongs to a successor and
+the finally must NOT un-drain it.
 
 If `rejoin` cannot confirm within its deadline, `RejoinAndConfirm`
 (`pkg/upgrade/kernel_drain.go`) now surfaces the last non-nil

--- a/scripts/deploy/test_xpf_deploy_image_roll_identity.py
+++ b/scripts/deploy/test_xpf_deploy_image_roll_identity.py
@@ -143,6 +143,13 @@ def _patches(fake):
     hook is a no-op, and time is faked so the poll loop terminates fast."""
     return [
         mock.patch.object(xpf_deploy, "_node_exec", fake),
+        # The #5816 renew/fence path goes through _node_exec_result (structured
+        # result) so a mid-reboot transport failure is not misread as a lost
+        # lease. These identity tests do not exercise lease loss, so answer every
+        # renew with a still-owned verdict (RENEWED) — the roll proceeds.
+        mock.patch.object(xpf_deploy, "_node_exec_result",
+                          lambda runner, backend, node, argv:
+                              xpf_deploy.NodeExecResult(0, "RENEWED\n", "", True)),
         mock.patch.object(xpf_deploy, "_recreate_node_from_image",
                           lambda *a, **k: None),
         mock.patch.object(xpf_deploy, "_verified_image_manifest_versions",

--- a/scripts/deploy/test_xpf_deploy_kernel_roll.py
+++ b/scripts/deploy/test_xpf_deploy_kernel_roll.py
@@ -126,6 +126,12 @@ class _ArmFailedFake:
                 return R(255, "", "ssh: connect timeout", False)  # transient blip
             return R(0, KNOWN_GOOD + "\n", "", True)   # back, still known-good
         if argv[:2] == ["sh", "-c"]:
+            # The lease renew/fence scripts (#5816) echo RENEWED on success; the
+            # acquire/clear scripts echo ACQUIRED (clear ignores output). Answer
+            # a renew with a still-owned verdict so the fence never spuriously
+            # aborts on the happy path.
+            if "RENEWED" in argv[-1]:
+                return R(0, "RENEWED\n", "", True)
             return R(0, "ACQUIRED\n", "", True)   # lease acquire / clear
         return R(0, "", "", True)
 

--- a/scripts/deploy/test_xpf_deploy_lease_renew_fence.py
+++ b/scripts/deploy/test_xpf_deploy_lease_renew_fence.py
@@ -244,6 +244,81 @@ class KernelRollFenceAbortTests(unittest.TestCase):
                          "a lost-lease driver mutated the pair (split-brain)")
 
 
+# ── end-to-end: a lease LOST after the drain must NOT trigger the finally rejoin ─
+class _KernelLostAfterDrainBackend:
+    """Scripted `_node_exec_result` for cmd_kernel_roll where the lease is still
+    owned at the pre-DRAIN fence (drain runs) but a successor reclaims it before
+    the pre-ARM fence (every renew from the 3rd on answers LOST). The pre-arm
+    fence then die()s — and because die() is a SystemExit, roll_one's `finally`
+    still runs with drained=True / completed=False / rebooted=False, the exact
+    state that fires the best-effort restore-forwarding rejoin. Records
+    (node, verb) so a test can prove the drain ran but NO post-loss rejoin did:
+    an orchestrator that lost the lease must not un-drain a pair a successor owns.
+
+    Renew ordering in roll_one(fw0, fw1): pre-drain fence renews fw0 then fw1
+    (calls 1,2 -> RENEWED), the drain runs, then the pre-arm fence renews fw0
+    (call 3 -> LOST) and die()s before it renews fw1."""
+
+    def __init__(self):
+        self.verbs = []
+        self.renews = 0
+
+    def __call__(self, runner, backend, node, argv):
+        if argv[:2] == ["sh", "-c"]:
+            s = argv[-1]
+            if "RENEWED" in s:              # a renew/fence tick
+                self.renews += 1
+                # First two renews (pre-drain fence, fw0+fw1) grant ownership so
+                # the drain runs; from the third on a successor has reclaimed the
+                # lease, so the pre-arm fence reads LOST and aborts.
+                verdict = "RENEWED" if self.renews <= 2 else "LOST"
+                return R(0, verdict + "\n", "", True)
+            return R(0, "ACQUIRED\n", "", True)   # acquire / clear
+        if argv[:3] == ["xpfd", "upgrade", "kernel"]:
+            verb = argv[3]
+            if verb == "status":
+                return R(0, f"promoted={KNOWN_GOOD} armed=none\n", "", True)
+            self.verbs.append((node, verb))   # drain (ok) / rejoin (must NOT run)
+            return R(0, "", "", True)
+        if argv[:1] == ["cat"] and "boot_id" in argv[-1]:
+            return R(0, "BOOT\n", "", True)
+        if argv == ["uname", "-r"]:
+            return R(0, KNOWN_GOOD + "\n", "", True)
+        return R(0, "", "", True)
+
+
+class KernelRollLostAfterDrainNoRejoinTests(unittest.TestCase):
+    def test_fence_before_arm_loss_suppresses_finally_rejoin(self):
+        """A lease reclaimed AFTER the drain (fence-before-arm reports LOST) must
+        NOT let the finally best-effort rejoin fire — that would un-drain a pair a
+        successor now owns, breaking the fence's own invariant (a lost
+        orchestrator must not mutate the pair, #5816).
+
+        This exercises the fence-before-ARM-LOST -> finally path, which the
+        existing fence-abort test (fence-before-DRAIN, drained never set) does
+        NOT reach: there the finally's `drained` guard is False, so the rejoin
+        could never fire regardless of the lease state.
+
+        RED on revert: drop the `and not lost_lease` guard from roll_one's
+        finally-rejoin condition (let it rejoin unconditionally on
+        drained/not-completed/not-rebooted). The finally then issues
+        `xpfd upgrade kernel rejoin` on fw0 after the loss, so `verbs` becomes
+        [('fw0','drain'),('fw0','rejoin')] instead of [('fw0','drain')]."""
+        fake = _KernelLostAfterDrainBackend()
+        with mock.patch.object(xpf_deploy, "_node_exec_result", fake), \
+                mock.patch("time.sleep", return_value=None):
+            with self.assertRaises(SystemExit) as cm:
+                xpf_deploy.cmd_kernel_roll(_kernel_args())
+        msg = str(cm.exception)
+        self.assertIn("LOST", msg)
+        self.assertIn("arm+reboot fw0", msg)
+        # The drain ran (pre-drain fence granted ownership); the post-loss rejoin
+        # must NOT have run (the lost_lease gate suppressed the finally rejoin).
+        self.assertEqual(fake.verbs, [("fw0", "drain")],
+                         "a lost-lease driver un-drained the pair in the finally "
+                         "(split-brain rejoin)")
+
+
 # ── end-to-end: renewal keeps a legit-slow roll's lease valid throughout ────
 class _ExpiringLeaseKernelBackend:
     """Scripted `_node_exec_result` for cmd_kernel_roll that models a real

--- a/scripts/deploy/test_xpf_deploy_lease_renew_fence.py
+++ b/scripts/deploy/test_xpf_deploy_lease_renew_fence.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Unit tests for the cross-orchestrator lease RENEW + FENCE (#5816).
+
+The LANE-1/LANE-2 HA roll drivers (`kernel-roll` / `image-roll`) reserve BOTH
+HA nodes with a lease whose deadline is `expires_at = now + --lease-ttl`. Before
+this fix the lease was ONE-SHOT: `_acquire_lease` wrote the deadline once and
+NEITHER roll path renewed it NOR re-verified ownership before its later mutation
+points. A positive TTL shorter than the real roll duration (boot/drain deadlines,
+an image-recreate hook, ordinary reboot/rejoin latency) let BOTH node leases
+EXPIRE while the driver kept running — with no renewal and no ownership check. A
+successor orchestrator could then atomically RECLAIM both expired leases and
+start its own roll while the predecessor was still mutating the same pair:
+split-brain deploy (corrupt the pair / brick both nodes).
+
+The fix adds two mechanisms, both keyed on the SAME owner identity the existing
+acquire/reclaim use (`nodename:pid<pid>` holder token):
+
+  1. RENEWAL (`_renew_lease`): re-write `expires_at = now + ttl` iff WE still own
+     the lease (holder matches), atomically (temp+rename) under the acquire
+     flock. A lease another orchestrator reclaimed (holder differs / file gone)
+     is reported "lost" and left untouched — renewal never resurrects a lost
+     lease. Fired every poll tick (keep-alive) so a legitimately-slow roll never
+     loses the lease.
+  2. FENCE (`_fence_before_mutate`): immediately before EACH pair-mutating action
+     (drain, arm+reboot, image-recreate, rejoin), renew-and-verify ownership of
+     every lease or die() fail-closed. The load-bearing invariant: an
+     orchestrator that has lost (or cannot confirm) its lease must NOT mutate the
+     pair.
+
+RED-on-revert (proven by hand, see the docstrings on the end-to-end tests):
+  * Remove the fence-before-mutate call → a driver whose lease was reclaimed
+    proceeds to drain/recreate a pair it no longer owns (the fence-abort tests
+    flip: the mutation IS executed).
+  * Remove the poll-loop keep-alive renewal → a roll that outruns its TTL loses
+    the lease mid-flight and the pre-rejoin fence aborts a roll that should have
+    succeeded (the renewal test flips: SystemExit instead of completion).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_SPEC = importlib.util.spec_from_file_location(
+    "xpf_deploy", Path(__file__).with_name("xpf-deploy.py"))
+xpf_deploy = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(xpf_deploy)
+
+R = xpf_deploy.NodeExecResult
+KNOWN_GOOD = "6.17.0-good"
+CANDIDATE = "6.99.0-cand"
+HOLDER = "orchA:pid1234"
+
+
+# ── pure helpers: _renew_lease verdict mapping ─────────────────────────────
+class RenewLeaseVerdictTests(unittest.TestCase):
+    """`_renew_lease` maps the structured node result to owned/lost/unreachable.
+
+    The tri-state is the crux: a mid-reboot TRANSPORT failure must be
+    "unreachable" (retry, NEVER a loss — the #4905-A discipline), a reachable
+    RENEWED is "owned", a reachable LOST (reclaimed by a peer) is "lost"."""
+
+    def _renew_with(self, result):
+        runner = xpf_deploy.Runner(False)
+        with mock.patch.object(xpf_deploy, "_node_exec_result",
+                               return_value=result):
+            return xpf_deploy._renew_lease(runner, "ssh", "fw0", 0, HOLDER, 1800)
+
+    def test_renewed_is_owned(self):
+        self.assertEqual(self._renew_with(R(0, "RENEWED\n", "", True)), "owned")
+
+    def test_lost_is_lost(self):
+        self.assertEqual(self._renew_with(R(0, "LOST\n", "", True)), "lost")
+
+    def test_transport_failure_is_unreachable_not_lost(self):
+        # An un-ok read (SSH/incus drop, mid-reboot) must NEVER be a loss.
+        self.assertEqual(
+            self._renew_with(R(255, "", "ssh: connect timeout", False)),
+            "unreachable")
+
+    def test_unexpected_output_is_unreachable_not_lost(self):
+        # A truncated / unknown token fails SAFE (unknown), never a false loss.
+        self.assertEqual(self._renew_with(R(0, "weird\n", "", True)),
+                         "unreachable")
+
+    def test_dry_run_is_owned(self):
+        runner = xpf_deploy.Runner(True)   # dry-run: no remote action
+        self.assertEqual(
+            xpf_deploy._renew_lease(runner, "ssh", "fw0", 0, HOLDER, 1800),
+            "owned")
+
+    def test_renew_script_is_atomic_and_holder_guarded(self):
+        # The renew must mirror acquire's discipline: under the flock, guard on
+        # the holder, write temp+rename, and echo RENEWED/LOST.
+        captured = {}
+
+        def _capture(runner, backend, node, argv):
+            captured["argv"] = argv
+            return R(0, "RENEWED\n", "", True)
+
+        runner = xpf_deploy.Runner(False)
+        with mock.patch.object(xpf_deploy, "_node_exec_result", _capture):
+            xpf_deploy._renew_lease(runner, "ssh", "fw0", 0, HOLDER, 1800)
+        script = captured["argv"][-1]
+        self.assertIn("flock", script)                 # serialized vs reclaim
+        self.assertIn('"holder"', script)              # holder-guarded rewrite
+        self.assertIn(HOLDER, script)                  # OUR identity, not any
+        self.assertIn(".tmp", script)                  # temp file
+        self.assertIn("mv -f", script)                 # atomic rename
+        self.assertIn("RENEWED", script)
+        self.assertIn("LOST", script)
+
+
+# ── pure helpers: _fence_before_mutate gate ────────────────────────────────
+class FenceTests(unittest.TestCase):
+    """The fence gate: owned → proceed; lost → abort; unreachable → abort."""
+
+    def _fence(self, verdicts):
+        # verdicts: dict node -> "owned"/"lost"/"unreachable"
+        runner = xpf_deploy.Runner(False)
+        with mock.patch.object(
+                xpf_deploy, "_renew_lease",
+                side_effect=lambda r, b, n, nid, h, t: verdicts[n]), \
+                mock.patch("time.sleep", return_value=None):
+            xpf_deploy._fence_before_mutate(
+                runner, "ssh", [("fw0", 0), ("fw1", 0)], HOLDER, 1800, "drain fw0")
+
+    def test_all_owned_proceeds(self):
+        # No exception -> the caller is cleared to mutate.
+        self._fence({"fw0": "owned", "fw1": "owned"})
+
+    def test_lost_aborts_fail_closed(self):
+        with self.assertRaises(SystemExit) as cm:
+            self._fence({"fw0": "lost", "fw1": "owned"})
+        self.assertIn("LOST", str(cm.exception))
+        self.assertIn("Refusing", str(cm.exception))
+
+    def test_peer_lost_aborts(self):
+        # Losing the PEER lease (the load-bearing reservation) also aborts.
+        with self.assertRaises(SystemExit) as cm:
+            self._fence({"fw0": "owned", "fw1": "lost"})
+        self.assertIn("fw1", str(cm.exception))
+
+    def test_persistently_unreachable_aborts_fail_closed(self):
+        # Cannot prove ownership after retries -> refuse to mutate (fail-closed).
+        with self.assertRaises(SystemExit) as cm:
+            self._fence({"fw0": "unreachable", "fw1": "owned"})
+        self.assertIn("could NOT confirm", str(cm.exception))
+
+    def test_dry_run_never_fences(self):
+        runner = xpf_deploy.Runner(True)
+        # _renew_lease must not even be consulted in dry-run.
+        with mock.patch.object(xpf_deploy, "_renew_lease",
+                               side_effect=AssertionError("must not renew")):
+            xpf_deploy._fence_before_mutate(
+                runner, "ssh", [("fw0", 0)], HOLDER, 1800, "drain fw0")
+
+
+class KeepaliveTests(unittest.TestCase):
+    """`_keepalive_leases`: renew the reachable, surface a provable loss, and
+    NEVER treat an unreachable (mid-reboot) node as a loss."""
+
+    def _keepalive(self, verdicts):
+        runner = xpf_deploy.Runner(False)
+        with mock.patch.object(
+                xpf_deploy, "_renew_lease",
+                side_effect=lambda r, b, n, nid, h, t: verdicts[n]):
+            return xpf_deploy._keepalive_leases(
+                runner, "ssh", [("fw0", 0), ("fw1", 0)], HOLDER, 1800)
+
+    def test_all_owned_returns_none(self):
+        self.assertIsNone(self._keepalive({"fw0": "owned", "fw1": "owned"}))
+
+    def test_unreachable_node_is_not_a_loss(self):
+        # fw0 mid-reboot (unreachable) while the peer lease stays owned -> the
+        # keep-alive tolerates it (returns None), never a spurious loss.
+        self.assertIsNone(
+            self._keepalive({"fw0": "unreachable", "fw1": "owned"}))
+
+    def test_provable_loss_is_surfaced(self):
+        self.assertEqual(
+            self._keepalive({"fw0": "owned", "fw1": "lost"}), "fw1")
+
+
+# ── end-to-end: kernel-roll fence aborts BEFORE mutating a lost pair ────────
+class _KernelLostLeaseBackend:
+    """Scripted `_node_exec_result` for cmd_kernel_roll where a successor has
+    already reclaimed the lease: every renew answers LOST. Records the xpfd
+    verbs (drain/arm/rejoin) so a test can prove NONE ran — the fence aborted
+    before the first mutation."""
+
+    def __init__(self):
+        self.verbs = []
+
+    def __call__(self, runner, backend, node, argv):
+        if argv[:2] == ["sh", "-c"]:
+            s = argv[-1]
+            if "RENEWED" in s:          # renew/fence -> reclaimed by successor
+                return R(0, "LOST\n", "", True)
+            return R(0, "ACQUIRED\n", "", True)   # acquire / clear
+        if argv[:3] == ["xpfd", "upgrade", "kernel"]:
+            verb = argv[3]
+            if verb == "status":
+                return R(0, f"promoted={KNOWN_GOOD} armed=none\n", "", True)
+            self.verbs.append(verb)     # drain / arm / rejoin (should NOT run)
+            return R(0, "", "", True)
+        if argv[:1] == ["cat"] and "boot_id" in argv[-1]:
+            return R(0, "BOOT\n", "", True)
+        if argv == ["uname", "-r"]:
+            return R(0, KNOWN_GOOD + "\n", "", True)
+        return R(0, "", "", True)
+
+
+def _kernel_args():
+    return types.SimpleNamespace(
+        dry_run=False, backend="ssh", nodes=["fw0", "fw1"],
+        version=CANDIDATE, node0_id=0, node1_id=1,
+        lease_ttl=1800, boot_deadline=600)
+
+
+class KernelRollFenceAbortTests(unittest.TestCase):
+    def test_fence_aborts_before_first_mutation_on_lost_lease(self):
+        """A predecessor whose lease was reclaimed must NOT drain/arm the pair.
+
+        RED on revert: delete the `_fence_before_mutate(... "drain fw0")` call in
+        cmd_kernel_roll's roll_one and this flips — the driver proceeds to
+        `xpfd upgrade kernel drain` on a pair it no longer owns, so `verbs`
+        contains "drain" and the SystemExit is gone."""
+        fake = _KernelLostLeaseBackend()
+        with mock.patch.object(xpf_deploy, "_node_exec_result", fake), \
+                mock.patch("time.sleep", return_value=None):
+            with self.assertRaises(SystemExit) as cm:
+                xpf_deploy.cmd_kernel_roll(_kernel_args())
+        msg = str(cm.exception)
+        self.assertIn("LOST", msg)
+        self.assertIn("drain fw0", msg)
+        # The load-bearing assertion: NO mutation ran — the fence stopped the
+        # roll before the drain.
+        self.assertEqual(fake.verbs, [],
+                         "a lost-lease driver mutated the pair (split-brain)")
+
+
+# ── end-to-end: renewal keeps a legit-slow roll's lease valid throughout ────
+class _ExpiringLeaseKernelBackend:
+    """Scripted `_node_exec_result` for cmd_kernel_roll that models a real
+    WALL-CLOCK lease. A virtual clock advances on each patched time.sleep; the
+    lease on each node has a deadline. A renew RESETS the deadline to now+ttl iff
+    we still own it; if a renew/check finds the lease EXPIRED (now >= deadline),
+    a successor 'B' reclaims it and every later renew answers LOST.
+
+    With the poll-loop keep-alive present, the deadline is pushed forward every
+    tick, so a roll that outruns its TTL never loses the lease and COMPLETES.
+    Neutralize the keep-alive and the lease expires mid-roll; the pre-rejoin
+    fence then aborts a roll that SHOULD have succeeded.
+
+    TTL(15) > sleep-step(10) so renewal always stays ahead; promote takes 3
+    ticks (30s virtual) > TTL(15) so WITHOUT renewal the lease expires."""
+
+    TTL_TICKS_TO_PROMOTE = 3
+
+    def __init__(self, ttl):
+        self.now = 0.0
+        self.ttl = ttl
+        self.ticks = 0
+        self.deadline = {}       # node -> virtual expiry
+        self.reclaimed = set()   # nodes a successor grabbed after expiry
+        self.armed_tick = {}     # node -> tick it was armed (reboot origin)
+        self.verbs = []          # (node, verb) for drain/arm/rejoin
+
+    # patched time hooks -------------------------------------------------
+    def time(self):
+        return self.now
+
+    def sleep(self, secs):
+        self.now += secs
+        self.ticks += 1
+
+    # lease model --------------------------------------------------------
+    def _verdict(self, node):
+        if node in self.reclaimed:
+            return "LOST"
+        if self.now >= self.deadline.get(node, 0.0):
+            self.reclaimed.add(node)      # successor grabs the expired lease
+            return "LOST"
+        self.deadline[node] = self.now + self.ttl   # still owned -> extend
+        return "RENEWED"
+
+    def _rebooted(self, node):
+        at = self.armed_tick.get(node)
+        return at is not None and (self.ticks - at) >= self.TTL_TICKS_TO_PROMOTE
+
+    def __call__(self, runner, backend, node, argv):
+        if argv[:2] == ["sh", "-c"]:
+            s = argv[-1]
+            if "RENEWED" in s:
+                return R(0, self._verdict(node) + "\n", "", True)
+            self.deadline[node] = self.now + self.ttl   # acquire seeds deadline
+            return R(0, "ACQUIRED\n", "", True)
+        if argv[:3] == ["xpfd", "upgrade", "kernel"]:
+            verb = argv[3]
+            if verb == "status":
+                # Before reboot the candidate is ARMED (armed=<ver>, waiting to
+                # boot); after reboot it is PROMOTED (running the candidate,
+                # nothing armed). armed=none pre-reboot would (correctly) read as
+                # an arm that failed its preflight — not what this fake models.
+                if self._rebooted(node):
+                    return R(0, f"promoted={CANDIDATE} armed=none\n", "", True)
+                return R(0, f"promoted={KNOWN_GOOD} armed={CANDIDATE}\n",
+                         "", True)
+            if verb == "arm":
+                self.armed_tick[node] = self.ticks
+            self.verbs.append((node, verb))
+            return R(0, "", "", True)
+        if argv[:1] == ["cat"] and "boot_id" in argv[-1]:
+            tag = "B" if self._rebooted(node) else "A"
+            return R(0, f"BOOT-{tag}-{node}\n", "", True)
+        if argv == ["uname", "-r"]:
+            return R(0, (CANDIDATE if self._rebooted(node) else KNOWN_GOOD)
+                     + "\n", "", True)
+        return R(0, "", "", True)
+
+
+class KernelRollRenewalTests(unittest.TestCase):
+    def test_slow_roll_keeps_lease_and_completes(self):
+        """A roll longer than the TTL stays VALID+OWNED (renewal fires) and
+        completes — no spurious fence-abort on the legitimately-slow path.
+
+        RED on revert: delete the poll-loop keep-alive block
+        (`lost = _keepalive_leases(...)`) in cmd_kernel_roll. The lease then
+        expires ~2 ticks into the reboot poll (TTL 15 < 30s to promote); the
+        pre-rejoin fence renew answers LOST and the roll dies with SystemExit
+        instead of returning 0 — a roll that SHOULD have succeeded is aborted."""
+        fake = _ExpiringLeaseKernelBackend(ttl=15)
+        args = _kernel_args()
+        args.lease_ttl = 15
+        args.boot_deadline = 300
+        with mock.patch.object(xpf_deploy, "_node_exec_result", fake), \
+                mock.patch("time.time", fake.time), \
+                mock.patch("time.sleep", fake.sleep):
+            rc = xpf_deploy.cmd_kernel_roll(args)
+        self.assertEqual(rc, 0, "the slow-but-owned roll must complete")
+        rejoins = [n for (n, v) in fake.verbs if v == "rejoin"]
+        self.assertEqual(rejoins, ["fw0", "fw1"],
+                         "both nodes must rejoin — renewal held the lease")
+        # And the lease was never actually lost on the happy path.
+        self.assertEqual(fake.reclaimed, set(),
+                         "renewal must keep the lease from expiring mid-roll")
+
+
+# ── end-to-end: image-roll fence aborts before the destructive recreate ────
+NEWVER = "2.0.0-newimage"
+NEW_MANIFEST = {
+    "xpf-version": NEWVER,
+    "ha-protocol-version": "3",
+    "ha-protocol-min-compat": "2",
+    "session-sync-protocol-version": "5",
+}
+
+
+class _ImageLostAfterDrainBackend:
+    """`_node_exec` (stdout) fake for cmd_image_roll: drain/rejoin/proto/cat.
+    Paired with a `_node_exec_result` renew fake that grants ownership at the
+    pre-drain fence but reports LOST at the pre-recreate fence — a successor
+    reclaimed the lease after the drain. Records drains so a test proves the
+    drain ran but the recreate did NOT."""
+
+    def __init__(self):
+        self.drained = []
+        self.rejoined = []
+
+    def __call__(self, runner, backend, node, argv, check=True):
+        if argv[:2] == ["sh", "-c"]:
+            return "ACQUIRED\n"          # acquire / clear / mixed-ha probe
+        if argv == ["xpfd", "protocol-versions"]:
+            # peer reports NEW_MANIFEST-compatible versions so the mixed-base
+            # gate passes and the roll reaches the drain.
+            return ("ha-protocol-version=3\n"
+                    "session-sync-protocol-version=5\n")
+        if argv[:4] == ["xpfd", "upgrade", "kernel", "drain"]:
+            self.drained.append(node)
+            return ""
+        if argv[:4] == ["xpfd", "upgrade", "kernel", "rejoin"]:
+            self.rejoined.append(node)
+            return ""
+        return ""
+
+
+def _image_args():
+    return types.SimpleNamespace(
+        dry_run=False, backend="ssh", nodes=["fw0", "fw1"],
+        node0_id=0, node1_id=1, recreate_hook="/bin/true",
+        manifest="xpf-2.0.0-newimage.manifest",
+        sha256sums=None, sig=None, pubkey=None,
+        lease_ttl=1800, drain_deadline=120, boot_deadline=40,
+        allow_session_drop=False)
+
+
+class ImageRollFenceAbortTests(unittest.TestCase):
+    def test_fence_aborts_before_recreate_on_lost_lease(self):
+        """A lease reclaimed AFTER the drain must NOT proceed to the destructive
+        recreate. The pre-drain fence grants ownership (drain runs); the
+        pre-recreate fence answers LOST and aborts — recreate never fires.
+
+        RED on revert: delete the `_fence_before_mutate(... "image-recreate")`
+        call in cmd_image_roll's roll_one and this flips — the driver recreates
+        (destroy+launch) a node whose pair a successor now owns; the recreate
+        hook is invoked and no SystemExit is raised."""
+        exec_fake = _ImageLostAfterDrainBackend()
+        recreate_calls = []
+
+        renew_calls = {"n": 0}
+
+        def _renew_result(runner, backend, node, argv):
+            # First fence (before drain) = 2 renews -> owned; second fence
+            # (before recreate) = renews 3+ -> lost (successor reclaimed).
+            renew_calls["n"] += 1
+            verdict = "RENEWED" if renew_calls["n"] <= 2 else "LOST"
+            return R(0, verdict + "\n", "", True)
+
+        stack = [
+            mock.patch.object(xpf_deploy, "_node_exec", exec_fake),
+            mock.patch.object(xpf_deploy, "_node_exec_result", _renew_result),
+            mock.patch.object(
+                xpf_deploy, "_recreate_node_from_image",
+                lambda *a, **k: recreate_calls.append(a[2])),
+            mock.patch.object(xpf_deploy, "_verified_image_manifest_versions",
+                              lambda *a, **k: dict(NEW_MANIFEST)),
+            mock.patch.object(xpf_deploy.os.path, "isfile", lambda p: True),
+            mock.patch("time.sleep", lambda *a, **k: None),
+        ]
+        for p in stack:
+            p.start()
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                xpf_deploy.cmd_image_roll(_image_args())
+        finally:
+            for p in reversed(stack):
+                p.stop()
+        msg = str(cm.exception)
+        self.assertIn("LOST", msg)
+        self.assertIn("image-recreate fw0", msg)
+        self.assertEqual(exec_fake.drained, ["fw0"],
+                         "the drain ran (pre-drain fence granted ownership)")
+        # The load-bearing assertion: the destructive recreate did NOT run.
+        self.assertEqual(recreate_calls, [],
+                         "a lost-lease driver recreated the node (split-brain)")
+        self.assertNotIn("fw0", exec_fake.rejoined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -1431,6 +1431,126 @@ def _clear_lease(runner, backend, node, holder):
                check=False)
 
 
+def _renew_lease(runner, backend, node, target_node_id, holder, ttl_secs):
+    """RENEW our reservation lease on `node` iff WE still own it (holder
+    matches), extending `expires_at = node_now + ttl`. Returns one of:
+
+      "owned"       — we still hold it; the deadline was re-written atomically.
+      "lost"        — the node is REACHABLE but the lease is gone / reclaimed by
+                      another holder (its `holder` no longer matches ours). We
+                      must NOT recreate it — another orchestrator owns the pair.
+      "unreachable" — a TRANSPORT/lock failure (SSH/incus drop, control-socket
+                      contention, mid-reboot). UNKNOWN, never a loss (#4905-A
+                      discipline): the caller retries rather than fencing.
+
+    The whole read-decide-rewrite runs under the SAME flock as acquire/clear so
+    a renew can never race a concurrent reclaim, and the new deadline is written
+    temp+rename so a reader (the Go self-recovery loop, which does NOT take the
+    flock) never sees a torn lease. Crucially the rewrite is holder-guarded:
+    a lease another orchestrator has already reclaimed (holder differs) is left
+    untouched and reported "lost" — renewal never resurrects a lost lease.
+
+    This is the RENEWAL half of the #5816 fix: a one-shot wall-clock lease with
+    no renewal expires while a legitimately-slow roll is still running, letting
+    a successor reclaim the pair (split-brain). Renewing while-owned keeps the
+    lease valid across the roll's real duration; the `_fence_before_mutate`
+    fence uses the "lost" verdict to refuse mutating a pair we no longer own.
+    Note: because renewal keeps the lease alive ONLY while this orchestrator is
+    live, the Go crashed-roll self-recovery (which fires on an EXPIRED lease)
+    still triggers correctly if the orchestrator dies — it just no longer fires
+    against a slow-but-alive driver."""
+    if runner.dry:
+        return "owned"
+    h = holder.replace('"', "")
+    # Inner critical section (under flock): confirm WE still hold the lease,
+    # then rewrite its deadline. A missing file or a holder mismatch prints
+    # LOST and does NOT write; a match rewrites expires_at and prints RENEWED.
+    crit = (
+        'f=/var/lib/xpf/kernel-roll.lease; '
+        '[ -f "$f" ] || { echo LOST; exit 0; }; '
+        'cur=$(sed -n \'s/.*"holder": *"\\([^"]*\\)".*/\\1/p\' "$f"); '
+        'if [ "$cur" != "%s" ]; then echo LOST; exit 0; fi; '
+        "exp=$(date -u -d \"+%d seconds\" +%%Y-%%m-%%dT%%H:%%M:%%SZ); "
+        "umask 022; "
+        "printf '{\"node_id\": %d, \"holder\": \"%s\", \"expires_at\": \"%%s\"}' "
+        "\"$exp\" > \"$f.tmp\" && mv -f \"$f.tmp\" \"$f\" && echo RENEWED"
+    ) % (h, ttl_secs, target_node_id, h)
+    script = (
+        "mkdir -p /var/lib/xpf; "
+        "flock -w 30 /var/lib/xpf/kernel-roll.lock "
+        "sh -c " + shlex.quote(crit)
+    )
+    # Use the STRUCTURED wrapper so a transport failure (un-ok) is distinguished
+    # from a reachable LOST — a mid-reboot node's unreachable read must NEVER be
+    # misread as a lost lease (the #4905-A trap). Only a reachable, affirmative
+    # LOST is a real loss.
+    res = _node_exec_result(runner, backend, node, ["sh", "-c", script])
+    if not res.ok:
+        return "unreachable"
+    if "RENEWED" in res.out:
+        return "owned"
+    if "LOST" in res.out:
+        return "lost"
+    # Unexpected output (truncated read, unknown token) — fail safe as unknown,
+    # not as a confirmed loss.
+    return "unreachable"
+
+
+def _keepalive_leases(runner, backend, targets, holder, ttl_secs):
+    """Renew our lease on each REACHABLE target during a long wait (the boot
+    poll), returning the name of any target where we have provably LOST the
+    lease (reclaimed by another orchestrator), else None.
+
+    `targets` is a list of (node_name, node_id). A target that is momentarily
+    UNREACHABLE (transport blip, or the rolled node mid-reboot) is left for the
+    next tick — never misread as a loss. This keeps the still-up PEER's lease
+    alive throughout, which is the load-bearing reservation: as long as the peer
+    lease is renewed, a successor can never acquire BOTH node leases and start a
+    concurrent roll."""
+    for name, nid in targets:
+        if _renew_lease(runner, backend, name, nid, holder, ttl_secs) == "lost":
+            return name
+    return None
+
+
+def _fence_before_mutate(runner, backend, targets, holder, ttl_secs, action):
+    """FENCE: renew-and-verify ownership of EVERY lease in `targets` immediately
+    before a pair-mutating action, or die() fail-closed. This is the load-bearing
+    invariant of #5816: an orchestrator that has lost (or cannot confirm) its
+    lease MUST NOT perform a pair-mutating action (drain / arm+reboot / image
+    recreate / rejoin) — otherwise a successor that reclaimed the expired lease
+    and a stalled predecessor both mutate the same HA pair (split-brain deploy).
+
+    Each target is renewed (extending the deadline to a fresh full TTL, so the
+    common legitimately-slow case never loses the lease at a phase boundary). A
+    confirmed LOSS aborts immediately; a transient UNREACHABLE is retried a few
+    times, then — still unable to prove ownership — also aborts fail-closed (we
+    would rather stop a roll we cannot prove we own than risk mutating a pair a
+    peer may now own). `targets` is a list of (node_name, node_id)."""
+    if runner.dry:
+        return
+    import time as _time
+    for name, nid in targets:
+        st = "unreachable"
+        for attempt in range(3):
+            st = _renew_lease(runner, backend, name, nid, holder, ttl_secs)
+            if st in ("owned", "lost"):
+                break
+            if attempt < 2:
+                _time.sleep(1)   # brief retry to ride out a transient blip
+        if st == "lost":
+            die(f"{name}: LOST the roll lease before {action} — another "
+                f"orchestrator has reclaimed the HA-pair reservation. Refusing "
+                f"to {action}: an orchestrator that no longer holds the lease "
+                f"must NOT mutate the pair (split-brain deploy). Investigate "
+                f"the half-rolled cluster before retrying.")
+        if st != "owned":
+            die(f"{name}: could NOT confirm the roll lease before {action} "
+                f"(node unreachable / lock contended after retries). Refusing "
+                f"to {action} fail-closed — an orchestrator that cannot prove it "
+                f"still holds the pair reservation must not mutate the pair.")
+
+
 def _kernel_status(runner, backend, node):
     """Return dict parsed from `xpfd upgrade kernel status` (promoted=, armed=)."""
     out = _node_exec(runner, backend, node,
@@ -1531,6 +1651,16 @@ def cmd_kernel_roll(args):
                                # rebooted (revert/promote — drain state is gone)
         rebooted = False       # the node actually rebooted into the candidate
         try:
+            # FENCE (#5816): renew-and-verify we still own BOTH node leases
+            # immediately before the first pair-mutating action. A one-shot
+            # wall-clock lease with no renewal can expire mid-roll (a positive
+            # TTL shorter than boot/drain latency); if a successor then reclaims
+            # it, draining here would put both drivers on the same pair. Renewing
+            # extends the deadline to a fresh TTL; a confirmed LOSS aborts before
+            # any mutation (state is untouched, so the finally releases the
+            # leases rather than TTL-holding them).
+            _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
+                                 holder, lease_ttl, f"drain {node}")
             # 2. DRAIN node -> peer via the non-interactive in-guest verb, which
             #    CONFIRMS the strong drain predicate (peer holds RGs, sync clean)
             #    before returning — so we never arm an undrained primary (r1
@@ -1558,6 +1688,13 @@ def cmd_kernel_roll(args):
             # fall back to the running==candidate signal (a promote still sets
             # rebooted, and an unconfirmed reboot conservatively rejoins).
             pre_boot_id = _boot_id(runner, backend, node)
+            # FENCE (#5816): arm REBOOTS the node — the highest-consequence
+            # mutation. Re-verify ownership of both leases (and refresh the
+            # deadline) on the still-reachable node before we commit to the
+            # reboot. After this the node is down and its lease can't be renewed
+            # until it is back; the peer lease keeps the reservation held.
+            _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
+                                 holder, lease_ttl, f"arm+reboot {node}")
             print(f"   arming candidate {version} on {node} (will reboot)...")
             _node_exec(runner, backend, node,
                        ["xpfd", "upgrade", "kernel", "arm", version], check=False)
@@ -1572,6 +1709,22 @@ def cmd_kernel_roll(args):
             running = ""   # last observed kernel ("" = never reachable)
             while _time.time() < deadline:
                 _time.sleep(10)
+                # RENEWAL (#5816): keep the reservation alive across the reboot
+                # wait so a legitimately-slow roll never loses it. The rolled
+                # node is unreachable while it reboots — its lease can't be
+                # renewed yet and that is NOT a loss — but the still-up peer's
+                # lease IS renewed every tick, which is the load-bearing
+                # reservation (a successor can never acquire BOTH leases while we
+                # hold the peer's). A provably LOST lease (reclaimed by a peer
+                # roll) is a split-brain signal: stop before rejoin.
+                lost = _keepalive_leases(runner, backend,
+                                         [(node, nid), (peer, nid)],
+                                         holder, lease_ttl)
+                if lost:
+                    die(f"{lost}: LOST the roll lease mid-reboot-poll — another "
+                        f"orchestrator reclaimed the pair reservation. Stopping "
+                        f"the roll of {node}; investigate the half-rolled "
+                        f"cluster (a successor may be mutating this pair).")
                 st = _kernel_status(runner, backend, node)
                 ok, running = _running_kernel_result(runner, backend, node)
                 if not ok:
@@ -1639,6 +1792,13 @@ def cmd_kernel_roll(args):
             #    (the "never both down" gate — r1 Codex Critical). `rejoin`
             #    clears manual failover on ALL RGs and confirms peer-alive +
             #    sync; a failure here STOPS the roll (the peer stays primary).
+            # FENCE (#5816): the node is back up and its lease survived the
+            # reboot (persistent /var/lib) — re-verify ownership of both leases
+            # (and refresh the deadline) before rejoin re-enables its forwarding.
+            # If a successor reclaimed while we were rebooting, abort rather than
+            # rejoin a pair the peer now owns.
+            _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
+                                 holder, lease_ttl, f"rejoin {node}")
             print(f"   rejoining {node} (confirming sync)...")
             _node_exec(runner, backend, node,
                        ["xpfd", "upgrade", "kernel", "rejoin"])  # check=True: abort on fail
@@ -2025,6 +2185,15 @@ def cmd_image_roll(args):
                           f"when old/new advertise the same HA version). If the "
                           f"drain aborts as HA-incompatible, the OLD image cannot "
                           f"relax it — re-image BOTH nodes together.")
+            # FENCE (#5816): renew-and-verify we still own BOTH node leases
+            # immediately before the first pair-mutating action. The one-shot
+            # lease can expire mid-roll (a positive TTL shorter than drain/boot
+            # latency or the recreate hook); if a successor reclaimed it,
+            # draining here would put both drivers on the same pair. This runs
+            # BEFORE state_changed flips, so a confirmed loss aborts while the
+            # cluster is still untouched (the finally then releases the leases).
+            _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
+                                 holder, lease_ttl, f"drain {node}")
             print(f"   draining {node} -> {peer} (confirmed)...")
             # First mutation: from here on a failure leaves a half-rolled
             # cluster, so leases must stay TTL-held (never-both-down).
@@ -2037,6 +2206,16 @@ def cmd_image_roll(args):
                       f"(launch + day-0), poll boot+verify, then rejoin")
                 completed = True  # dry-run: release the leases on the way out
                 return
+            # FENCE (#5816): recreate DESTROYS+relaunches the node from a fresh
+            # image — the single highest-consequence, un-interruptible mutation
+            # and the one #5545 flagged as potentially outlasting a short TTL.
+            # Renew-and-verify both leases (fresh full TTL) immediately before
+            # it. The recreate wipes /var/lib on the node, so the node's own
+            # lease is gone afterwards; from here the still-up PEER's lease is
+            # the sole reservation (renewed every poll tick below), which is
+            # what actually blocks a successor from acquiring both leases.
+            _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
+                                 holder, lease_ttl, f"image-recreate {node}")
             _recreate_node_from_image(runner, backend, node, args)
 
             # 3. poll until the node is back AS THE EXPECTED NODE ON THE NEW
@@ -2060,6 +2239,20 @@ def cmd_image_roll(args):
                            "(xpfd never answered protocol-versions)")
             while _time.time() < deadline:
                 _time.sleep(10)
+                # RENEWAL (#5816): keep the reservation alive across the boot
+                # wait. The recreated node has a FRESH disk with no lease file,
+                # so ONLY the peer's lease is renewed here — it is the sole
+                # remaining reservation and the one that blocks a successor from
+                # acquiring both leases. A provably LOST peer lease means a
+                # successor reclaimed the pair: stop before rejoin.
+                lost = _keepalive_leases(runner, backend, [(peer, nid)],
+                                         holder, lease_ttl)
+                if lost:
+                    die(f"{lost}: LOST the roll lease while waiting for {node} to "
+                        f"come back on the new image — another orchestrator "
+                        f"reclaimed the pair reservation. Stopping; investigate "
+                        f"the half-rolled cluster (a successor may be mutating "
+                        f"this pair).")
                 pv = _node_protocol_versions(runner, backend, node)
                 # Only read the node-id marker once xpfd is actually answering,
                 # to avoid an extra `cat` on every poll while the node is down.
@@ -2078,6 +2271,12 @@ def cmd_image_roll(args):
             print(f"   {node} back on the new image: {last_reason}")
 
             # 4. rejoin + confirm sync BEFORE touching the peer (never-both-down).
+            # FENCE (#5816): re-verify ownership before rejoin re-enables the
+            # node's forwarding. Only the PEER's lease is checked — the recreate
+            # gave the node a fresh disk with no lease file, so fencing the node
+            # would false-abort. The peer lease is the reservation that matters.
+            _fence_before_mutate(runner, backend, [(peer, nid)],
+                                 holder, lease_ttl, f"rejoin {node}")
             print(f"   rejoining {node} (confirming sync)...")
             _node_exec(runner, backend, node,
                        ["xpfd", "upgrade", "kernel", "rejoin",

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -1513,7 +1513,8 @@ def _keepalive_leases(runner, backend, targets, holder, ttl_secs):
     return None
 
 
-def _fence_before_mutate(runner, backend, targets, holder, ttl_secs, action):
+def _fence_before_mutate(runner, backend, targets, holder, ttl_secs, action,
+                         on_lost=None):
     """FENCE: renew-and-verify ownership of EVERY lease in `targets` immediately
     before a pair-mutating action, or die() fail-closed. This is the load-bearing
     invariant of #5816: an orchestrator that has lost (or cannot confirm) its
@@ -1526,7 +1527,16 @@ def _fence_before_mutate(runner, backend, targets, holder, ttl_secs, action):
     confirmed LOSS aborts immediately; a transient UNREACHABLE is retried a few
     times, then — still unable to prove ownership — also aborts fail-closed (we
     would rather stop a roll we cannot prove we own than risk mutating a pair a
-    peer may now own). `targets` is a list of (node_name, node_id)."""
+    peer may now own). `targets` is a list of (node_name, node_id).
+
+    `on_lost`, when supplied, is invoked immediately BEFORE the fail-closed
+    die() — on BOTH a confirmed loss AND an unconfirmable (persistently
+    unreachable) lease. die() raises SystemExit, so a caller's `finally` block
+    still runs while unwinding; a caller whose finally performs a best-effort
+    pair mutation (e.g. cmd_kernel_roll's restore-forwarding rejoin) uses this
+    hook to record that it no longer safely owns the pair and SUPPRESS that
+    mutation. An unconfirmable lease is treated as unsafe-to-mutate exactly like
+    a proven loss — the same fail-closed stance the fence itself takes."""
     if runner.dry:
         return
     import time as _time
@@ -1539,12 +1549,16 @@ def _fence_before_mutate(runner, backend, targets, holder, ttl_secs, action):
             if attempt < 2:
                 _time.sleep(1)   # brief retry to ride out a transient blip
         if st == "lost":
+            if on_lost is not None:
+                on_lost()
             die(f"{name}: LOST the roll lease before {action} — another "
                 f"orchestrator has reclaimed the HA-pair reservation. Refusing "
                 f"to {action}: an orchestrator that no longer holds the lease "
                 f"must NOT mutate the pair (split-brain deploy). Investigate "
                 f"the half-rolled cluster before retrying.")
         if st != "owned":
+            if on_lost is not None:
+                on_lost()
             die(f"{name}: could NOT confirm the roll lease before {action} "
                 f"(node unreachable / lock contended after retries). Refusing "
                 f"to {action} fail-closed — an orchestrator that cannot prove it "
@@ -1650,6 +1664,18 @@ def cmd_kernel_roll(args):
         completed = False      # the roll finished (rejoin confirmed) OR the node
                                # rebooted (revert/promote — drain state is gone)
         rebooted = False       # the node actually rebooted into the candidate
+        lost_lease = False     # a fence/keepalive proved (or could not disprove)
+                               # a successor reclaimed the pair reservation. The
+                               # best-effort restore-forwarding rejoin in the
+                               # finally MUST be suppressed once this is set: a
+                               # die() is a SystemExit, so the finally still runs
+                               # after a fence-abort, and an orchestrator that has
+                               # lost its lease must NOT mutate (un-drain) a pair a
+                               # successor now owns (#5816).
+
+        def _note_lost_lease():
+            nonlocal lost_lease
+            lost_lease = True
         try:
             # FENCE (#5816): renew-and-verify we still own BOTH node leases
             # immediately before the first pair-mutating action. A one-shot
@@ -1660,7 +1686,8 @@ def cmd_kernel_roll(args):
             # any mutation (state is untouched, so the finally releases the
             # leases rather than TTL-holding them).
             _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
-                                 holder, lease_ttl, f"drain {node}")
+                                 holder, lease_ttl, f"drain {node}",
+                                 on_lost=_note_lost_lease)
             # 2. DRAIN node -> peer via the non-interactive in-guest verb, which
             #    CONFIRMS the strong drain predicate (peer holds RGs, sync clean)
             #    before returning — so we never arm an undrained primary (r1
@@ -1694,7 +1721,8 @@ def cmd_kernel_roll(args):
             # reboot. After this the node is down and its lease can't be renewed
             # until it is back; the peer lease keeps the reservation held.
             _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
-                                 holder, lease_ttl, f"arm+reboot {node}")
+                                 holder, lease_ttl, f"arm+reboot {node}",
+                                 on_lost=_note_lost_lease)
             print(f"   arming candidate {version} on {node} (will reboot)...")
             _node_exec(runner, backend, node,
                        ["xpfd", "upgrade", "kernel", "arm", version], check=False)
@@ -1721,6 +1749,8 @@ def cmd_kernel_roll(args):
                                          [(node, nid), (peer, nid)],
                                          holder, lease_ttl)
                 if lost:
+                    lost_lease = True   # suppress the finally restore-rejoin: a
+                                        # reclaimed pair must not be un-drained
                     die(f"{lost}: LOST the roll lease mid-reboot-poll — another "
                         f"orchestrator reclaimed the pair reservation. Stopping "
                         f"the roll of {node}; investigate the half-rolled "
@@ -1798,7 +1828,8 @@ def cmd_kernel_roll(args):
             # If a successor reclaimed while we were rebooting, abort rather than
             # rejoin a pair the peer now owns.
             _fence_before_mutate(runner, backend, [(node, nid), (peer, nid)],
-                                 holder, lease_ttl, f"rejoin {node}")
+                                 holder, lease_ttl, f"rejoin {node}",
+                                 on_lost=_note_lost_lease)
             print(f"   rejoining {node} (confirming sync)...")
             _node_exec(runner, backend, node,
                        ["xpfd", "upgrade", "kernel", "rejoin"])  # check=True: abort on fail
@@ -1812,7 +1843,15 @@ def cmd_kernel_roll(args):
             #     with no lease and a later retry could drain the peer while this
             #     node is down, opening a no-primary window (r1 Codex High).
             #     (A node that rebooted has already lost the in-memory drain.)
-            if drained and not completed and not rebooted and not runner.dry:
+            #     BUT skip this rejoin when we LOST (or could not confirm) the
+            #     lease: die() is a SystemExit, so a fence-abort at arm/rejoin — or
+            #     a keepalive-detected loss — still reaches this finally, and
+            #     rejoining here would UN-DRAIN a pair a successor now owns,
+            #     violating the fence's own invariant (a lost orchestrator must not
+            #     mutate the pair, #5816). A clean abort where we still hold the
+            #     lease (`lost_lease` stays False) keeps rejoining as before.
+            if (drained and not completed and not rebooted
+                    and not lost_lease and not runner.dry):
                 print(f"   roll did not complete and {node} never rebooted; "
                       f"rejoining {node} to restore forwarding...")
                 try:


### PR DESCRIPTION
Closes #5816

## STEP-0 confirmation
Verified live on current origin/master (3b3b15eff): `scripts/deploy/xpf-deploy.py` `_acquire_lease` writes `expires_at = node_now + --lease-ttl` **once** (inside the acquire flock), and neither `cmd_kernel_roll` nor `cmd_image_roll` renews the lease or re-checks continued ownership before its later mutation points. #5470/#5545 fixed only the degenerate `--lease-ttl<=0` case (`positive_int` floor). Still a one-shot wall-clock lease — NOT stale-fixed.

## Root cause
The cross-orchestrator reservation held on BOTH HA nodes is a one-shot lease. A positive TTL shorter than `--boot-deadline` / `--drain-deadline` / an image-recreate hook / ordinary drain-reboot-rejoin latency lets both node leases **expire** while the driver keeps running — with no renewal and no ownership check. A successor orchestrator can then atomically reclaim both expired leases and start its own roll while the predecessor is still mutating the same pair → **split-brain deploy** (corrupt the pair / brick both nodes).

Failure trace: A acquires both leases (short positive TTL) → A stalls/legitimately runs longer than TTL → both leases expire (A keeps running, no renewal) → B reclaims both and starts its roll → both A and B mutate the same HA pair.

## Fix — renew-while-owned + fence-before-mutate
Both keyed on the **same owner-identity token** the acquire/reclaim path already uses (`nodename:pid<pid>`), and preserving the existing flock + temp-rename atomicity:

- **`_renew_lease`** — re-writes `expires_at = now + ttl` iff the holder still matches, atomically (temp+rename) under the acquire flock. A lease a successor reclaimed (holder differs / file gone) → `"lost"` and is left untouched (renewal never resurrects a lost lease). A transport failure → `"unreachable"` (retry), **never** a false loss (the #4905-A discipline via the structured `_node_exec_result`).
- **`_keepalive_leases`** — renews every reachable target each reboot-poll tick. While the rolled node is unreachable (kernel-roll reboot) or has a fresh lease-less disk (image-roll recreate), **only the still-up PEER's lease** is renewed — that peer lease is the load-bearing reservation (a successor can never acquire *both* node leases while we hold the peer's).
- **`_fence_before_mutate`** — renews-and-verifies ownership of every relevant lease immediately before **each** mutation (drain / arm+reboot / image-recreate / rejoin) and `die()`s fail-closed on a lost/unconfirmable lease. Invariant: *an orchestrator that has lost (or cannot confirm) its lease must NOT mutate the pair.*

Fence placement:
- kernel-roll: before drain, before arm+reboot, keepalive each poll tick, before rejoin (node lease survives the reboot on persistent `/var/lib`).
- image-roll: before drain, before the destructive recreate, keepalive (peer-only) each poll tick, before rejoin (peer-only — the recreate wiped the node's lease by design; fencing it would false-abort).

## TTL floor — not touched
The `--lease-ttl` floor is **NOT** raised. With renewal in place a short TTL is safe (a rolling window that never elapses while the driver is live). The one un-interruptible mutation the keep-alive cannot cover mid-call — the `image-roll` recreate hook — is fenced to a fresh full TTL immediately before invoking it; the default 1800s comfortably exceeds a VM launch + day-0. The existing acquire/reclaim atomicity and the `--lease-ttl<=0` rejection (#5470) are unchanged. This also sharpens the Go crashed-roll self-recovery contract: the lease now stays alive only while the orchestrator is live, so an expired lease is an unambiguous crash signal.

## Fail-on-revert (proven firsthand)
New `scripts/deploy/test_xpf_deploy_lease_renew_fence.py` (17 tests). Each mechanism neutralized → RED → restored → GREEN:

- **Fence (kernel drain)** — remove `_fence_before_mutate(... "drain fw0")`: the driver proceeds to `xpfd upgrade kernel drain` on a lost pair (console shows `draining fw0 -> fw1 (confirmed)...`) instead of aborting. RED:
  ```
  AssertionError: 'drain fw0' not found in '...LOST the roll lease before arm+reboot fw0...'
  ```
- **Renewal (kernel keep-alive)** — remove the poll-loop `_keepalive_leases`: with TTL 15 < 30s-to-promote the lease expires mid-roll; fw0 promotes but the pre-rejoin fence aborts a roll that should have succeeded. RED:
  ```
  SystemExit: ERROR: fw0: LOST the roll lease before rejoin fw0 — another orchestrator has reclaimed the HA-pair reservation. Refusing to rejoin fw0...
  ```
- **Fence (image recreate)** — remove `_fence_before_mutate(... "image-recreate fw0")`: the destructive recreate runs on a lost pair. RED:
  ```
  AssertionError: 'image-recreate fw0' not found in '...fw1: LOST the roll lease while waiting for fw0 to come back...'
  ```

Assertions gate on the real mutation decision (drain/arm/recreate executed vs abort), not an internal flag. Existing kernel-roll + image-roll-identity test fakes were taught to answer the new renew scripts (regression guards for the happy path).

## Verification (hermetic — Python deploy tooling, no loss-cluster smoke)
- Full deploy suite: **143/143** (`python3 -m unittest discover scripts/deploy`)
- `make selftest`: **41 passed, 0 skipped, 0 failed** (runs `scripts/deploy/test_*.py`, incl. the new file)
- `make test-deploy-lib`: **19 passed, 0 failed**
- `make test-cluster-lock-lib`: **12/12 cases pass**

## Docs
`docs/in-place-upgrade.md` lease-contract section extended with the renew+fence mechanism, the peer-lease-is-load-bearing rationale, the TTL-floor-not-raised justification, and the sharpened self-recovery relation. `_Log.md` dated entry added.

Coordination: scoped to the lease/roll functions; does not touch the fetch/verify region (#5817).

🤖 Generated with [Claude Code](https://claude.com/claude-code)