### PR TITLE
vrrp: fail-closed MASTER publish, gen-gated VIP reconcile

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-16 — #5082 VRRP: fail-closed MASTER publish + generation-gated VIP reconcile
+- **Timestamp**: 2026-07-16 (fix/5082-vrrp-vip-gen)
+- **Action**: Fixed two VRRP HA correctness defects (codex-review-177
+  `[A5-b1-F7]`, High/High). (1) FAIL-OPEN publish: `becomeMaster` set
+  StateMaster, called void `addVIPs()`, then advertised/emitted regardless of
+  whether the kernel VIP add succeeded — a transient netlink failure made the
+  peer + dependent services trust a blackhole owner. (2) RECONCILE RACE:
+  `ReconcileVIPs` was check-then-act (`if state==Master { addVIPs }`) with no
+  ownership generation, so a superior-advert demotion to BACKUP could interleave
+  and re-add VIPs + force GARP while BACKUP (dup address / split routing). Fix:
+  `addVIPs`→`addVIPsLocked` returns a structured `vipActuationResult`
+  (applied/failed/linkErr); `becomeMaster` returns bool and gates advert/emit on
+  `res.ok()` — on failure it rolls back partial adds, reverts to StateBackup, and
+  the run-loop re-arms the master-down timer (`rearmForRetry`) to retry (no
+  parallel state system). A monotonic `ownerGen` (bumped by `setState` on every
+  real transition) is captured before the netlink add and revalidated after; a
+  new `vipMu` serializes add/remove + revalidation across the run-loop and the
+  manager's `ReconcileVIPs`, which now re-adds/GARPs only if still the
+  current-generation MASTER after the add. Netlink is behind injectable seams
+  (`linkByNameFn`/`addrAddFn`/`addrDelFn`). Success path unchanged (uncontended
+  lock) → ~60ms failover preserved.
+- **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/manager.go,
+  pkg/vrrp/vip_gen_5082_test.go (new), pkg/vrrp/instance_preempt_gate_test.go,
+  pkg/vrrp/instance_preempt_holdtime_test.go, docs/critical-patterns.md
+- **Validation**: `go build ./...` + `go vet ./pkg/vrrp` clean; full
+  `go test -race ./pkg/vrrp` green. Two new fail-on-revert tests (fail-closed
+  publish + reconcile generation guard) PROVEN RED on revert firsthand. The
+  state-machine wiring tests use fake interfaces (fail-soft before); they now
+  install no-op success netlink seams (`installFakeVIPNetlink`) since
+  `becomeMaster` is fail-closed. Cluster `make test-failover` smoke DEFERRED
+  (shim-ABI wall); correctness gated on the unit tests + full -race suite.
+
 ## 2026-07-16 — #5816 review fold: fence the finally-rejoin after a lost lease (PR #6021)
 - **Timestamp**: 2026-07-16 (fix/5816-deploy-lease-renew-fence)
 - **Action**: Folded one MERGE-NEEDS-MINOR reviewer finding into PR #6021. Gap:

--- a/docs/critical-patterns.md
+++ b/docs/critical-patterns.md
@@ -144,6 +144,23 @@ See the deploy backing table in
   and a 500ms time dampener; `force=true` (used by `ReconcileVIPs` after a
   MAC change) bypasses ONLY the dampener so the post-MAC-change GARP is not
   swallowed by a routine burst from the prior 500ms (#2081).
+- **Fail-closed VIP ownership (#5082)**: `becomeMaster()` gates the MASTER
+  advert/event on SUCCESSFUL required-VIP actuation. `addVIPs` returns a
+  structured result (which VIPs actuated, which failed) instead of void; a
+  swallowed LinkByName/AddrAdd failure no longer lets the peer and dependent
+  services trust an owner that cannot receive VIP traffic. On any required-VIP
+  failure `becomeMaster` rolls back partial adds, reverts to `StateBackup`, and
+  returns `false` WITHOUT advertising/emitting — the run-loop then re-arms the
+  master-down timer (`rearmForRetry`) to retry the election. The clean success
+  path is unchanged (the `vipMu` lock is uncontended), so ~60ms failover timing
+  is preserved. A monotonic **ownership generation** (`ownerGen`, bumped by
+  `setState` on every real transition) is captured before the netlink add and
+  revalidated after: `ReconcileVIPs` re-adds VIPs and forces GARP only if the
+  instance is STILL the current-generation MASTER after the add, closing the
+  check-then-act TOCTOU where a superior advert demoting to BACKUP could
+  interleave and re-add VIPs + force GARP while BACKUP (duplicate address,
+  split routing). `vipMu` serializes the add/remove + revalidation across the
+  run-loop and the manager's `ReconcileVIPs`.
 - **Fabric forwarding**: the userspace dataplane redirects packets for
   peer-owned synced sessions over the fabric link
   (`resolve_fabric_redirect()` / `ingress_is_fabric()` in

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -219,6 +219,34 @@ type vrrpInstance struct {
 	lastGARPTime    atomic.Int64  // Unix nanos of last GARP send (dampens routine GARP only; forced sends bypass — see garpSendAllowed)
 	garpClampWarned atomic.Bool   // #5695: guards a once-per-instance warn when a configured GARPCount is clamped (never per-send)
 
+	// ownerGen is the identity of the current Master/Backup ownership tenure
+	// (#5082). setState bumps it whenever the state actually changes, so every
+	// state transition begins a fresh generation. Code that actuates the VIP
+	// set via netlink (becomeMaster, ReconcileVIPs) captures the generation
+	// before the netlink op and revalidates it afterward: if a demotion raced
+	// in and bumped ownerGen, the actuation is stale — roll back the added VIPs
+	// and do NOT advertise/emit/GARP for a tenure we have already left. Atomic
+	// so log/test readers stay lock-free; the load-bearing check-then-act runs
+	// under vipMu below.
+	ownerGen atomic.Uint64
+
+	// vipMu serializes VIP netlink actuation (addVIPs/removeVIPs) plus the
+	// ownership-generation revalidation across the two goroutines that touch
+	// VIPs: the run-loop (becomeMaster/becomeBackup) and the manager's
+	// ReconcileVIPs. Holding vipMu across "read gen + actuate + revalidate"
+	// makes the check-then-act atomic so a demotion cannot interleave a
+	// ReconcileVIPs re-add and strand a BACKUP announcing VIPs (#5082). The
+	// lock is uncontended on the normal failover path (ReconcileVIPs is a rare
+	// post-programRethMAC reconcile), so it adds no latency to ~60ms failover.
+	vipMu sync.Mutex
+
+	// netlink seams for VIP actuation. Production leaves them nil and the
+	// helpers call netlink live; unit tests inject them to drive addVIPs down
+	// a chosen success/failure path without a real kernel interface (#5082).
+	linkByNameFn func(name string) (netlink.Link, error)
+	addrAddFn    func(link netlink.Link, addr *netlink.Addr) error
+	addrDelFn    func(link netlink.Link, addr *netlink.Addr) error
+
 	// onEventDrop is called when an event is dropped due to a full eventCh.
 	// Set by the manager to trigger immediate reconciliation.
 	onEventDrop func()
@@ -665,8 +693,18 @@ func (vi *vrrpInstance) getState() VRRPState {
 
 func (vi *vrrpInstance) setState(s VRRPState) {
 	vi.mu.Lock()
+	changed := vi.state != s
 	vi.state = s
 	vi.mu.Unlock()
+	// A real state change starts a new ownership tenure. Bump the generation
+	// so any in-flight VIP actuation (becomeMaster/ReconcileVIPs) that captured
+	// the prior generation revalidates as stale and rolls back instead of
+	// advertising/GARPing for a tenure we have left (#5082). ownerGen is atomic
+	// and independent of vi.mu, so a concurrent ReconcileVIPs holding vipMu
+	// still observes this bump when it rechecks after its netlink add.
+	if changed {
+		vi.ownerGen.Add(1)
+	}
 }
 
 // advertInterval returns the advertisement interval as a Duration.
@@ -921,8 +959,11 @@ func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTime
 				slog.Info("vrrp: held master silent during preempt hold-time, immediate takeover",
 					"key", vi.key())
 				vi.disarmPreemptHold(preemptHoldTimer)
-				vi.becomeMaster()
-				advertTimer.Reset(vi.advertInterval())
+				if vi.becomeMaster() {
+					advertTimer.Reset(vi.advertInterval())
+				} else {
+					vi.rearmForRetry(masterDownTimer)
+				}
 			} else {
 				// The held master is still alive (adverts keep arriving and
 				// refreshing lastMasterSeen). Preserve the preempt-hold intent:
@@ -948,8 +989,11 @@ func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTime
 			vi.armPreemptHold(masterDownTimer, preemptHoldTimer, hold)
 			return false
 		}
-		vi.becomeMaster()
-		advertTimer.Reset(vi.advertInterval())
+		if vi.becomeMaster() {
+			advertTimer.Reset(vi.advertInterval())
+		} else {
+			vi.rearmForRetry(masterDownTimer)
+		}
 	case <-preemptHoldTimer.C:
 		// The preempt hold-time elapsed (#2850). The hold is no longer
 		// armed; clear the flag before deciding (#2900).
@@ -972,9 +1016,12 @@ func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTime
 		if vi.shouldPreemptObservedMaster() {
 			slog.Info("vrrp: preempt hold-time elapsed, taking over",
 				"key", vi.key())
-			vi.becomeMaster()
-			advertTimer.Reset(vi.advertInterval())
-			masterDownTimer.Stop()
+			if vi.becomeMaster() {
+				advertTimer.Reset(vi.advertInterval())
+				masterDownTimer.Stop()
+			} else {
+				vi.rearmForRetry(masterDownTimer)
+			}
 		} else {
 			// Preemption is no longer warranted — do NOT become MASTER.
 			// Return to a normal BACKUP tenure by re-arming masterDownTimer
@@ -1023,12 +1070,15 @@ func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer, preemptHoldTime
 		vi.forcePreemptOnce = false
 		vi.mu.Unlock()
 		if force || vi.shouldPreemptObservedMaster() {
-			vi.becomeMaster()
-			advertTimer.Reset(vi.advertInterval())
-			masterDownTimer.Stop()
-			// A coordinated/forced promotion supersedes any pending
-			// preempt hold-time countdown (#2850).
-			vi.disarmPreemptHold(preemptHoldTimer)
+			if vi.becomeMaster() {
+				advertTimer.Reset(vi.advertInterval())
+				masterDownTimer.Stop()
+				// A coordinated/forced promotion supersedes any pending
+				// preempt hold-time countdown (#2850).
+				vi.disarmPreemptHold(preemptHoldTimer)
+			} else {
+				vi.rearmForRetry(masterDownTimer)
+			}
 		}
 	}
 	return false
@@ -1874,16 +1924,55 @@ func (vi *vrrpInstance) vipFamilies() (hasIPv4, hasIPv6 bool) {
 	return hasIPv4, hasIPv6
 }
 
-// becomeMaster transitions to Master state: add VIPs, send advert, emit event,
+// becomeMaster transitions to Master state: add VIPs, and — only if the
+// required VIP set actually actuated in the kernel — send advert, emit event,
 // then send GARP/NA asynchronously. The critical path is addVIPs (kernel needs
 // VIP addresses for bpf_fib_lookup) + sendAdvert (tells peer to step down).
 // GARP only updates L2 switch/router MAC tables and runs in the background.
-func (vi *vrrpInstance) becomeMaster() {
+//
+// Fail-closed ownership (#5082): a transient netlink failure must NOT let the
+// peer and dependent services trust an owner that cannot receive VIP traffic.
+// addVIPs now returns a structured result; if any required VIP failed to
+// actuate (or a concurrent demotion superseded this tenure), becomeMaster rolls
+// back any partial adds, reverts to BACKUP, and returns false WITHOUT
+// advertising or emitting a MASTER event. The caller re-arms the master-down
+// timer so the election retries on the next horizon. On the clean success path
+// nothing is added versus before (the vipMu lock is uncontended), so the ~60ms
+// failover timing is preserved.
+//
+// Returns true iff ownership was claimed (VIP set actuated and advert/event
+// published).
+func (vi *vrrpInstance) becomeMaster() bool {
 	pri := vi.getPriority()
 	slog.Info("vrrp: transitioning to MASTER",
 		"key", vi.key(), "priority", pri)
 	vi.setState(StateMaster)
-	vi.addVIPs()
+	gen := vi.ownerGen.Load()
+
+	vi.vipMu.Lock()
+	res := vi.addVIPsLocked()
+	superseded := vi.ownerGen.Load() != gen
+	if !res.ok() || superseded {
+		// Fail-closed: the required VIP set did not actuate, or a newer
+		// transition superseded this one while we were in netlink. Roll back
+		// any partially-added VIPs, revert to a BACKUP tenure, and do NOT claim
+		// ownership. Reverting to StateBackup (an existing state) integrates
+		// with the run-loop's masterDownTimer retry — no parallel state system.
+		// (superseded is captured before the setState bump below so the log
+		// reflects the true reason, not the revert's own generation bump.)
+		vi.removeVIPsLocked(res.applied)
+		vi.setState(StateBackup)
+		vi.vipMu.Unlock()
+		slog.Error("vrrp: VIP actuation failed, not claiming ownership (fail-closed)",
+			"key", vi.key(), "failed", res.failed, "applied", res.applied,
+			"link_err", res.linkErr, "superseded", superseded)
+		// Publish the honest BACKUP state so dependent services never trust an
+		// ownership we could not back.
+		vi.emitEvent()
+		return false
+	}
+	vi.vipMu.Unlock()
+
 	vi.sendAdvert(pri)
 	vi.emitEvent()
 	vi.garpEpoch.Add(1)
@@ -1896,6 +1985,16 @@ func (vi *vrrpInstance) becomeMaster() {
 		slog.Info("vrrp: GARP suppressed (strict-vip-ownership)",
 			"key", vi.key())
 	}
+	return true
+}
+
+// rearmForRetry re-arms the master-down timer after a failed Master promotion
+// (VIP actuation failure in becomeMaster reverted us to BACKUP) so the election
+// retries on the next master-down horizon instead of leaving the instance idle.
+// Used by the run-loop's becomeMaster call sites (#5082).
+func (vi *vrrpInstance) rearmForRetry(masterDownTimer *time.Timer) {
+	stopAndDrainTimer(masterDownTimer)
+	masterDownTimer.Reset(vi.masterDownInterval())
 }
 
 // becomeBackup transitions to Backup state: remove VIPs, reset timers.
@@ -2123,18 +2222,75 @@ func (vi *vrrpInstance) sendPacketIPv6(pkt *VRRPPacket) error {
 }
 
 // addVIPs adds virtual IP addresses to the interface via netlink.
-func (vi *vrrpInstance) addVIPs() {
-	link, err := netlink.LinkByName(vi.cfg.Interface)
+// vipActuationResult reports the outcome of an attempt to add the instance's
+// virtual IP set on the interface (#5082). It lets becomeMaster/ReconcileVIPs
+// gate ownership publication on the ACTUAL kernel state instead of assuming the
+// add succeeded (the old void addVIPs swallowed every failure).
+type vipActuationResult struct {
+	// applied lists the VIPs confirmed present after the op — freshly added
+	// OR already present (EEXIST). These are the addresses to roll back if the
+	// tenure turns out to be stale/degraded.
+	applied []string
+	// failed lists VIPs that could not be actuated: an unresolvable interface
+	// (linkErr set — every VIP fails), a parse error, or a netlink AddrAdd
+	// error other than EEXIST.
+	failed []string
+	// linkErr is non-nil if the interface itself could not be resolved via
+	// netlink; in that case no VIP could be actuated at all.
+	linkErr error
+}
+
+// ok reports whether the FULL required VIP set actuated: the interface
+// resolved and no VIP failed. becomeMaster claims ownership only when ok().
+func (r vipActuationResult) ok() bool {
+	return r.linkErr == nil && len(r.failed) == 0
+}
+
+// nlLinkByName resolves an interface, via the test seam when set.
+func (vi *vrrpInstance) nlLinkByName(name string) (netlink.Link, error) {
+	if vi.linkByNameFn != nil {
+		return vi.linkByNameFn(name)
+	}
+	return netlink.LinkByName(name)
+}
+
+// nlAddrAdd adds an address, via the test seam when set.
+func (vi *vrrpInstance) nlAddrAdd(link netlink.Link, addr *netlink.Addr) error {
+	if vi.addrAddFn != nil {
+		return vi.addrAddFn(link, addr)
+	}
+	return netlink.AddrAdd(link, addr)
+}
+
+// nlAddrDel deletes an address, via the test seam when set.
+func (vi *vrrpInstance) nlAddrDel(link netlink.Link, addr *netlink.Addr) error {
+	if vi.addrDelFn != nil {
+		return vi.addrDelFn(link, addr)
+	}
+	return netlink.AddrDel(link, addr)
+}
+
+// addVIPsLocked adds the instance's configured virtual IP set to the interface
+// and returns which VIPs actuated and which failed. The caller MUST hold vipMu.
+// It replaces the old void addVIPs: a swallowed LinkByName/AddrAdd failure used
+// to let becomeMaster publish an owner that could not receive VIP traffic
+// (#5082). EEXIST counts as applied (the address is present regardless).
+func (vi *vrrpInstance) addVIPsLocked() vipActuationResult {
+	var res vipActuationResult
+	link, err := vi.nlLinkByName(vi.cfg.Interface)
 	if err != nil {
 		slog.Warn("vrrp: failed to find interface for VIP add",
 			"key", vi.key(), "err", err)
-		return
+		res.linkErr = err
+		res.failed = append(res.failed, vi.cfg.VirtualAddresses...)
+		return res
 	}
 	for _, vip := range vi.cfg.VirtualAddresses {
 		addr, err := netlink.ParseAddr(vip)
 		if err != nil {
 			slog.Warn("vrrp: failed to parse VIP",
 				"key", vi.key(), "vip", vip, "err", err)
+			res.failed = append(res.failed, vip)
 			continue
 		}
 		// Skip DAD for IPv6 VIPs — VRRP handles ownership; DAD would
@@ -2142,32 +2298,55 @@ func (vi *vrrpInstance) addVIPs() {
 		if addr.IP.To4() == nil {
 			addr.Flags |= unix.IFA_F_NODAD
 		}
-		if err := netlink.AddrAdd(link, addr); err != nil {
-			// EEXIST is fine — address already present.
-			if !strings.Contains(err.Error(), "exists") {
+		if err := vi.nlAddrAdd(link, addr); err != nil {
+			// EEXIST is fine — address already present, so it IS actuated.
+			if strings.Contains(err.Error(), "exists") {
+				res.applied = append(res.applied, vip)
+			} else {
 				slog.Warn("vrrp: failed to add VIP",
 					"key", vi.key(), "vip", vip, "err", err)
+				res.failed = append(res.failed, vip)
 			}
 		} else {
 			slog.Info("vrrp: added VIP", "key", vi.key(), "vip", vip)
+			res.applied = append(res.applied, vip)
 		}
 	}
+	return res
 }
 
-// removeVIPs removes virtual IP addresses from the interface via netlink.
+// removeVIPs removes ALL configured virtual IP addresses from the interface.
+// It acquires vipMu so it is safe to call from the run-loop (becomeBackup, run
+// startup/shutdown) without interleaving a concurrent ReconcileVIPs add (#5082).
 func (vi *vrrpInstance) removeVIPs() {
-	link, err := netlink.LinkByName(vi.cfg.Interface)
+	vi.vipMu.Lock()
+	vi.removeVIPsLocked(nil)
+	vi.vipMu.Unlock()
+}
+
+// removeVIPsLocked removes the given VIPs (nil ⇒ all configured VirtualAddresses)
+// from the interface via netlink. The caller MUST hold vipMu. Passing a subset
+// (res.applied) lets a failed/superseded actuation roll back exactly the
+// addresses it added.
+func (vi *vrrpInstance) removeVIPsLocked(vips []string) {
+	if vips == nil {
+		vips = vi.cfg.VirtualAddresses
+	}
+	if len(vips) == 0 {
+		return
+	}
+	link, err := vi.nlLinkByName(vi.cfg.Interface)
 	if err != nil {
 		slog.Debug("vrrp: failed to find interface for VIP remove",
 			"key", vi.key(), "err", err)
 		return
 	}
-	for _, vip := range vi.cfg.VirtualAddresses {
+	for _, vip := range vips {
 		addr, err := netlink.ParseAddr(vip)
 		if err != nil {
 			continue
 		}
-		if err := netlink.AddrDel(link, addr); err != nil {
+		if err := vi.nlAddrDel(link, addr); err != nil {
 			// Ignore "not found" — may have been removed already.
 			if !strings.Contains(err.Error(), "not found") &&
 				!strings.Contains(err.Error(), "no such") {

--- a/pkg/vrrp/instance_preempt_gate_test.go
+++ b/pkg/vrrp/instance_preempt_gate_test.go
@@ -33,6 +33,10 @@ func newGateTestInstance(t *testing.T, priority int, preempt bool) *vrrpInstance
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
 	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
 	vi.suppressGARP.Store(true)
+	// becomeMaster is fail-closed on VIP actuation (#5082); this test uses a
+	// fake interface, so install no-op success seams to keep the transition
+	// reachable — the state-machine logic under test is what matters here.
+	installFakeVIPNetlink(vi)
 	vi.setState(StateBackup)
 	return vi
 }

--- a/pkg/vrrp/instance_preempt_holdtime_test.go
+++ b/pkg/vrrp/instance_preempt_holdtime_test.go
@@ -31,6 +31,10 @@ func newHoldTestInstance(t *testing.T, priority, holdSec int) *vrrpInstance {
 	}, &net.Interface{Name: "eth0"}, make(chan VRRPEvent, 16), nil)
 	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
 	vi.suppressGARP.Store(true)
+	// becomeMaster is fail-closed on VIP actuation (#5082); this test uses a
+	// fake interface, so install no-op success seams to keep the transition
+	// reachable — the hold-time logic under test is what matters here.
+	installFakeVIPNetlink(vi)
 	vi.setState(StateBackup)
 	return vi
 }

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -722,21 +722,56 @@ func (m *Manager) ReconcileVIPs() {
 	defer m.mu.RUnlock()
 
 	for _, vi := range m.instances {
-		if vi.getState() == StateMaster {
-			vi.addVIPs()
-			// Bump garpEpoch so the epoch-dedup in sendGARP() doesn't
-			// block this send. ReconcileVIPs is called after programRethMAC
-			// (link DOWN/UP) which changes the MAC — GARP is critical here.
-			vi.garpEpoch.Add(1)
-			if !vi.suppressGARP.Load() {
-				// force=true: bypass the 500ms time dampener. The epoch bump
-				// above defeats the epoch-dedup, but the dampener would STILL
-				// suppress this burst if any routine GARP was emitted in the
-				// prior 500ms — leaving peers with a stale ARP entry for the
-				// just-changed RETH virtual MAC until it ages out (#2081).
-				vi.sendGARP(true)
-			}
-		}
+		vi.reconcileVIP()
+	}
+}
+
+// reconcileVIP re-adds this instance's VIPs if it is currently MASTER, then
+// forces a GARP burst — but only if the instance is STILL the current-generation
+// MASTER after the netlink add completes (#5082). ReconcileVIPs runs on the
+// manager goroutine while becomeMaster/becomeBackup run on the run-loop, so the
+// old `if getState()==StateMaster { addVIPs() }` was a check-then-act TOCTOU: a
+// superior advert transitioning us to BACKUP could interleave between the state
+// check and the netlink add, re-adding VIPs and forcing GARP while BACKUP
+// (duplicate address, ARP/ND, split routing).
+//
+// The fix holds vipMu across "state check + generation capture + netlink add +
+// revalidation". becomeBackup's removeVIPs also takes vipMu, so it cannot
+// interleave the add; and setState bumps ownerGen independently of vipMu, so the
+// post-add revalidation observes a racing demotion even though it happened while
+// we held vipMu. On a superseding transition we roll back exactly the VIPs we
+// re-added and suppress the forced GARP — a BACKUP never announces VIPs.
+func (vi *vrrpInstance) reconcileVIP() {
+	vi.vipMu.Lock()
+	if vi.getState() != StateMaster {
+		vi.vipMu.Unlock()
+		return
+	}
+	gen := vi.ownerGen.Load()
+	res := vi.addVIPsLocked()
+	// Revalidate under vipMu: a becomeBackup that raced in bumped ownerGen (and
+	// flipped state). If superseded, undo the re-added VIPs and do NOT GARP —
+	// announcing a VIP we no longer own is the split-routing hazard this closes.
+	if vi.getState() != StateMaster || vi.ownerGen.Load() != gen {
+		vi.removeVIPsLocked(res.applied)
+		vi.vipMu.Unlock()
+		slog.Warn("vrrp: ReconcileVIPs superseded by demotion; rolled back re-added VIPs, GARP suppressed",
+			"key", vi.key(), "rolled_back", res.applied)
+		return
+	}
+	// Bump garpEpoch so the epoch-dedup in sendGARP() doesn't block this send.
+	// ReconcileVIPs is called after programRethMAC (link DOWN/UP) which changes
+	// the MAC — GARP is critical here.
+	vi.garpEpoch.Add(1)
+	suppress := vi.suppressGARP.Load()
+	vi.vipMu.Unlock()
+	if !suppress {
+		// force=true: bypass the 500ms time dampener. The epoch bump above
+		// defeats the epoch-dedup, but the dampener would STILL suppress this
+		// burst if any routine GARP was emitted in the prior 500ms — leaving
+		// peers with a stale ARP entry for the just-changed RETH virtual MAC
+		// until it ages out (#2081).
+		vi.sendGARP(true)
 	}
 }
 

--- a/pkg/vrrp/vip_gen_5082_test.go
+++ b/pkg/vrrp/vip_gen_5082_test.go
@@ -1,0 +1,163 @@
+package vrrp
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #5082 — VRRP must not publish MASTER/advert/event before the required VIP set
+// has actually actuated in the kernel, and ReconcileVIPs must not re-add VIPs
+// (or force GARP) after a demotion raced it to BACKUP.
+//
+// Both tests inject the netlink seams (linkByNameFn/addrAddFn/addrDelFn) so the
+// add/remove path is driven without a real interface. GARP is suppressed so the
+// revert runs never perform real network I/O — garpEpoch (bumped immediately
+// before the GARP send, on the success branch only) is the discriminator for
+// "would have announced ownership".
+
+func fiveZeroEightTwoLink(name string) netlink.Link {
+	return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+}
+
+// installFakeVIPNetlink wires the VIP netlink seams to a no-op SUCCESS path so a
+// unit test that drives the state machine on a FAKE interface can still reach
+// MASTER. becomeMaster is now fail-closed on VIP actuation (#5082): on an
+// unresolvable interface (as used by the state-machine wiring tests) it would
+// otherwise refuse to claim ownership and revert to BACKUP. State-machine tests
+// (preempt gate / hold-time / owner-preempt) that don't exercise VIP actuation
+// install this so the transition logic under test is isolated from netlink.
+func installFakeVIPNetlink(vi *vrrpInstance) {
+	vi.linkByNameFn = func(name string) (netlink.Link, error) {
+		return fiveZeroEightTwoLink(name), nil
+	}
+	vi.addrAddFn = func(link netlink.Link, addr *netlink.Addr) error { return nil }
+	vi.addrDelFn = func(link netlink.Link, addr *netlink.Addr) error { return nil }
+}
+
+// Test A (fail-closed publish): a transient netlink AddrAdd failure for a
+// required VIP during becomeMaster must NOT publish ownership — no MASTER event,
+// no advert, becomeMaster returns false and the instance reverts to BACKUP.
+//
+// Reverting the gate (advertise/emit regardless of the actuation result) turns
+// this RED: becomeMaster returns true, emits a StateMaster event, and bumps
+// garpEpoch.
+func TestBecomeMaster_FailClosedOnVIPActuationFailure_5082(t *testing.T) {
+	eventCh := make(chan VRRPEvent, 8)
+	vi := newInstance(Instance{
+		Interface:         "xpf-5082-a0",
+		GroupID:           1,
+		Priority:          100,
+		Family:            "inet",
+		AdvertiseInterval: 1000,
+		VirtualAddresses:  []string{"10.0.61.1/24"},
+	}, &net.Interface{Name: "xpf-5082-a0"}, eventCh, nil)
+	vi.setState(StateBackup) // the state becomeMaster transitions FROM
+	vi.suppressGARP.Store(true)
+
+	// Interface resolves, but AddrAdd fails for the required VIP.
+	vi.linkByNameFn = func(name string) (netlink.Link, error) {
+		return fiveZeroEightTwoLink(name), nil
+	}
+	vi.addrAddFn = func(link netlink.Link, addr *netlink.Addr) error {
+		return errors.New("injected netlink AddrAdd failure")
+	}
+	vi.addrDelFn = func(link netlink.Link, addr *netlink.Addr) error {
+		return nil
+	}
+
+	owned := vi.becomeMaster()
+
+	if owned {
+		t.Fatal("becomeMaster returned true despite VIP actuation failure — " +
+			"published an ownership it cannot back (fail-open)")
+	}
+	if got := vi.getState(); got != StateBackup {
+		t.Fatalf("state = %v, want StateBackup after fail-closed becomeMaster", got)
+	}
+	if ep := vi.garpEpoch.Load(); ep != 0 {
+		t.Fatalf("garpEpoch = %d, want 0 — GARP announced a VIP that never actuated", ep)
+	}
+	// No StateMaster event may have been published to the manager.
+	for {
+		select {
+		case ev := <-eventCh:
+			if ev.State == StateMaster {
+				t.Fatal("emitted a StateMaster event despite VIP actuation " +
+					"failure — peer/services trust a blackhole owner (fail-open)")
+			}
+		default:
+			return
+		}
+	}
+}
+
+// Test B (reconcile race / generation guard): a demotion to BACKUP that races
+// ReconcileVIPs between its state check and the netlink add must not leave the
+// re-added VIPs in place or fire a forced GARP. The racing demotion is injected
+// inside the addrAddFn (mimicking a concurrent becomeBackup whose setState bumps
+// ownerGen while ReconcileVIPs holds vipMu). The generation revalidation after
+// the add must roll back exactly the re-added VIPs and suppress GARP.
+//
+// Reverting the revalidation turns this RED: the re-added VIP is retained
+// (deleted count < added count) and garpEpoch is bumped (forced GARP while
+// BACKUP).
+func TestReconcileVIPs_GenerationGuard_NoReaddWhileBackup_5082(t *testing.T) {
+	eventCh := make(chan VRRPEvent, 8)
+	vi := newInstance(Instance{
+		Interface:         "xpf-5082-b0",
+		GroupID:           1,
+		Priority:          100,
+		Family:            "inet",
+		AdvertiseInterval: 1000,
+		VirtualAddresses:  []string{"10.0.61.1/24"},
+	}, &net.Interface{Name: "xpf-5082-b0"}, eventCh, nil)
+	vi.setState(StateMaster) // reconcileVIP only acts while MASTER
+	vi.suppressGARP.Store(true)
+
+	vi.linkByNameFn = func(name string) (netlink.Link, error) {
+		return fiveZeroEightTwoLink(name), nil
+	}
+
+	var mu sync.Mutex
+	var added, deleted []string
+	vi.addrAddFn = func(link netlink.Link, addr *netlink.Addr) error {
+		mu.Lock()
+		added = append(added, addr.String())
+		mu.Unlock()
+		// A superior advert transitions us to BACKUP mid-actuation. This is the
+		// exact race the guard closes: setState bumps ownerGen (and flips state)
+		// independently of vipMu, so the post-add revalidation observes it.
+		vi.setState(StateBackup)
+		return nil
+	}
+	vi.addrDelFn = func(link netlink.Link, addr *netlink.Addr) error {
+		mu.Lock()
+		deleted = append(deleted, addr.String())
+		mu.Unlock()
+		return nil
+	}
+
+	vi.reconcileVIP()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(added) == 0 {
+		t.Fatal("addrAddFn never called — the test did not exercise the add path")
+	}
+	if len(deleted) != len(added) {
+		t.Fatalf("rolled back %d of %d re-added VIPs — a BACKUP retains VIPs "+
+			"re-added by a raced ReconcileVIPs (reconcile TOCTOU)",
+			len(deleted), len(added))
+	}
+	if ep := vi.garpEpoch.Load(); ep != 0 {
+		t.Fatalf("garpEpoch = %d, want 0 — forced GARP fired while BACKUP "+
+			"(reconcile race announces a VIP we no longer own)", ep)
+	}
+	if got := vi.getState(); got != StateBackup {
+		t.Fatalf("state = %v, want StateBackup", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two High/High VRRP HA correctness defects (codex-review-177 `[A5-b1-F7]`, issue #5082).

**Defect 1 — fail-open MASTER publication.** `becomeMaster` set `StateMaster`, called a **void** `addVIPs()`, then `sendAdvert`/`emitEvent` **regardless** of whether the kernel VIP add succeeded. `addVIPs` swallowed `LinkByName`/`AddrAdd` failures (log + continue) with no debt/rollback/retry, so a transient netlink failure made the peer and dependent services trust an owner that cannot receive VIP traffic (blackhole).

**Defect 2 — reconcile race.** `ReconcileVIPs` was check-then-act (`if state==Master { addVIPs() }`) with no ownership generation. A concurrent superior-advert transition to BACKUP could interleave between the state check and the netlink add, re-adding VIPs + forcing GARP while BACKUP (duplicate address, ARP/ND, split routing).

## Fix

- **Structured actuation result.** `addVIPs` → `addVIPsLocked` returns `vipActuationResult{applied, failed, linkErr}` (EEXIST counts as applied). `removeVIPs` keeps a lock-taking wrapper plus `removeVIPsLocked(subset)` for precise rollback. Netlink is behind injectable seams (`linkByNameFn`/`addrAddFn`/`addrDelFn`).
- **Ownership generation.** `ownerGen` (monotonic, bumped by `setState` on every real transition) is captured before the netlink op and revalidated after. A new `vipMu` serializes add/remove + revalidation across the run-loop (`becomeMaster`/`becomeBackup`) and the manager's `ReconcileVIPs`.
- **Gated publish.** `becomeMaster` now returns `bool`; it advertises/emits only when the full required VIP set actuated **and** the generation is still current. On failure or a superseding transition it rolls back partial adds, reverts to `StateBackup`, and returns `false` without publishing. The run-loop re-arms the master-down timer (`rearmForRetry`) to retry — reusing the existing `StateBackup` state + timers, **no parallel state system**.
- **Reconcile guard.** `reconcileVIP` holds `vipMu` across state-check + generation capture + add + revalidation; a racing demotion (observed via the `setState` `ownerGen` bump) rolls back the re-added VIPs and suppresses the forced GARP. A BACKUP can no longer announce VIPs.

**Failover timing preserved.** The clean success path adds nothing versus before — `vipMu` is uncontended on the failover critical path, GARP stays async — so the ~60ms failover is unchanged; only a netlink failure or raced demotion takes the new branch.

## Tests (fail-on-revert, proven RED firsthand)

`pkg/vrrp/vip_gen_5082_test.go`:
- **Test A (fail-closed publish):** an injected `AddrAdd` failure during `becomeMaster` → asserts it does **not** return true / emit `StateMaster` / bump `garpEpoch`. Revert the gate → RED (`becomeMaster returned true despite VIP actuation failure — published an ownership it cannot back (fail-open)`).
- **Test B (reconcile generation guard):** a demotion injected mid-actuation during `reconcileVIP` → asserts the re-added VIP is rolled back and no forced GARP fires. Revert the revalidation → RED (`rolled back 0 of 1 re-added VIPs — a BACKUP retains VIPs re-added by a raced ReconcileVIPs`).

State-machine wiring tests (preempt gate / hold-time) used fake interfaces and relied on the old fail-soft `addVIPs`; they now install no-op success netlink seams (`installFakeVIPNetlink`) since `becomeMaster` is fail-closed.

## Validation

- `go build ./...` + `go vet ./pkg/vrrp` clean
- Full `go test -race ./pkg/vrrp` green (the failover-timing-critical state-machine suite is the regression gate)
- Both new tests proven RED-on-revert firsthand

## Smoke deferral

HA/VRRP failover machinery: the loss-cluster `make test-failover` smoke is **blocked by the shim-ABI wall** (pinned cpumap vs repo ABI — verify-dataplane fail-closes every cluster-deploy). Not attempted. Correctness is gated on the two fail-on-revert unit tests + the full `pkg/vrrp` `-race` suite.

Closes #5082

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EywFDQGpDGciAo5c9cCQkd