### PR TITLE
cluster: purge monitor per-RG ip state on RG removal

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-16 — #5990 cluster: purge Monitor per-RG ipState/ipDebts on RG removal
+- **Timestamp**: 2026-07-16 (fix/5990-monitor-ipstate-purge)
+- **Action**: Fixed a chassis-cluster HA monitor map-lifecycle fail-open. The
+  Monitor keys `ipState` by `(rgID, address)` and `ipDebts`/`ipThresholdState`
+  by rgID. On RG removal, `group_state.go UpdateConfig` cleared only the
+  MANAGER's `monitorWeights` for the removed RG (and #5080 reconciled
+  interface-monitor debt) — it never purged the Monitor's per-RG maps. A same-id
+  RG remove/re-add while a monitored ip target was DOWN then left stale
+  `ipDebts[rg.ID]` behind: `reconcileRGIPDebts` saw `desired==installed` by its
+  own stale record and fired no `SetMonitorWeight`, so the debt the manager had
+  cleared was never re-installed → the re-added RG carried a MISSING ip-monitor
+  debt (weight stuck at 255) until the target's next dampened transition, and
+  could stay primary with a dead monitored uplink. Fix: `Monitor.UpdateGroups`
+  now purges `ipState` (per-target, by removed rgID), `ipDebts`, and
+  `ipThresholdState` for every RG no longer in config — alongside the existing
+  `ifaceState` purge, under `mon.mu`, calling no `m.mu`-taking function (no lock
+  inversion). Purging `ipState` also means a re-added RG whose target has since
+  recovered starts from fresh dampening. A KEPT RG whose ip-monitoring/targets
+  merely changed is left to `reconcileRGIPDebts` (per-poll), unchanged.
+- **File(s)**: pkg/cluster/monitor.go,
+  pkg/cluster/monitor_ipstate_purge_5990_test.go (new), pkg/cluster/README.md
+- **Validation**: `go build ./...` + `go vet ./pkg/cluster` clean;
+  `gofmt -l` clean on touched files; full `go test -race ./pkg/cluster` green
+  (10.3s). New fail-on-revert test (independent + aggregate/global-threshold
+  modes) PROVEN RED on revert firsthand — with the purge removed, `ipDebts[1]`
+  survives removal and a same-id re-add leaves RG weight stuck at 255 (verified
+  with a throwaway probe that drove the full remove→re-add→poll path). Cluster
+  `make test-failover` loss-cluster smoke DEFERRED (shim-ABI wall) — gated on the
+  fail-on-revert unit tests + full `-race` suite.
+
 ## 2026-07-16 — #5082 VRRP: fail-closed MASTER publish + generation-gated VIP reconcile
 - **Timestamp**: 2026-07-16 (fix/5082-vrrp-vip-gen)
 - **Action**: Fixed two VRRP HA correctness defects (codex-review-177

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -547,6 +547,24 @@ Monitor's `ipDebts` still recorded the debt installed, so the next
 with a dead monitored uplink jumped back to weight 255 and could win
 election → blackhole. Fail-open (#5080 fold).
 
+**Purge per-RG IP-monitor state on RG removal (#5990).** The manager clears
+a removed RG's `monitorWeights` in `UpdateConfig`'s removal loop, but the
+Monitor keeps its OWN per-RG maps: dampened `ipState` (keyed by
+`(rgID, address)`), the installed-debt record `ipDebts` (keyed by rgID), and
+the `ipThresholdState` mirror. `Monitor.UpdateGroups` now drops every entry
+whose RG is no longer in config, alongside the `ifaceState` purge. Without
+this, a same-id RG remove/re-add while a monitored target is DOWN left stale
+`ipDebts[rg.ID]` behind: on re-add `reconcileRGIPDebts` saw
+`desired==installed` by its OWN stale record and fired no `SetMonitorWeight`,
+so the debt the manager already cleared was never re-installed — the re-added
+RG carried a MISSING ip-monitor debt (weight stuck at 255) until the target
+next transitioned (a dampened edge), and could stay primary with a dead
+monitored uplink. Fail-open, narrow trigger. Purging `ipState` too means a
+re-added RG whose target has since recovered starts from fresh dampening
+rather than inheriting a stale down/hold-down state. A KEPT RG whose
+ip-monitoring or targets merely changed is NOT purged here —
+`reconcileRGIPDebts` owns that reconcile per-poll.
+
 `LinkAttrsUp` is exported because the same carrier-aware read is needed
 outside the monitor loop:
 

--- a/pkg/cluster/monitor.go
+++ b/pkg/cluster/monitor.go
@@ -299,17 +299,32 @@ func (mon *Monitor) Stop() {
 // state if the same monitor key is ever re-added — reporting an interface as
 // still-failed on the strength of a measurement from a prior config epoch.
 //
+// It applies the SAME per-RG cleanup to the IP-monitor state (#5990): the
+// dampened ipState (keyed by (rgID, address)) is dropped for any target whose
+// RG is no longer desired, and the per-RG ipDebts / ipThresholdState
+// bookkeeping is dropped for any RG no longer in config. Without this, a
+// same-id RG remove/re-add while a monitored target is down leaves stale
+// ipDebts[rg.ID] behind: the manager already cleared that RG's monitorWeights
+// on removal, but the next reconcileRGIPDebts sees desired==installed by its
+// OWN stale record and no-ops the install — the re-added RG silently carries a
+// MISSING ip-monitor debt and can stay primary with a dead monitored uplink
+// (fail-open). A clean per-RG slate forces the reconcile to re-derive the debt.
+//
 // The MANAGER-side debt for these removed/changed monitors (monitorWeights and
-// each RG's MonitorFails) is cleared separately in reconcileMonitorDebtsLocked
-// under m.mu (#5080). UpdateGroups deliberately does NOT call the locking
-// SetMonitorWeight here: it is invoked from Manager.UpdateConfig with m.mu
-// already held, so re-acquiring m.mu would self-deadlock.
+// each RG's MonitorFails) is cleared separately: interface monitors in
+// reconcileMonitorDebtsLocked, and a whole removed RG's keys in UpdateConfig's
+// removal loop — both under m.mu (#5080). UpdateGroups deliberately does NOT
+// call the locking SetMonitorWeight here: it is invoked from
+// Manager.UpdateConfig with m.mu already held, so re-acquiring m.mu would
+// self-deadlock. It touches only the Monitor's own maps (guarded by mon.mu).
 func (mon *Monitor) UpdateGroups(groups []*config.RedundancyGroup) {
 	mon.mu.Lock()
 	defer mon.mu.Unlock()
 
 	desired := make(map[monitorKey]bool)
+	desiredRGs := make(map[int]bool)
 	for _, rg := range groups {
+		desiredRGs[rg.ID] = true
 		for _, im := range rg.InterfaceMonitors {
 			desired[monitorKey{rgID: rg.ID, iface: im.Interface}] = true
 		}
@@ -317,6 +332,30 @@ func (mon *Monitor) UpdateGroups(groups []*config.RedundancyGroup) {
 	for key := range mon.ifaceState {
 		if !desired[key] {
 			delete(mon.ifaceState, key)
+		}
+	}
+
+	// Purge per-RG IP-monitor state for RGs removed from config (#5990).
+	// ipDebts / ipThresholdState are keyed directly by RG id; ipState embeds
+	// the RG id in its key. Dropping every entry whose RG is no longer desired
+	// gives a same-id re-add a clean slate so reconcileRGIPDebts re-derives the
+	// debt from a fresh probe instead of no-oping against stale bookkeeping.
+	// (A KEPT RG whose ip-monitoring/targets merely changed is NOT purged here —
+	// reconcileRGIPDebts owns that per-poll and clears the obsolete per-target
+	// debt itself.)
+	for key := range mon.ipState {
+		if !desiredRGs[key.rgID] {
+			delete(mon.ipState, key)
+		}
+	}
+	for rgID := range mon.ipDebts {
+		if !desiredRGs[rgID] {
+			delete(mon.ipDebts, rgID)
+		}
+	}
+	for rgID := range mon.ipThresholdState {
+		if !desiredRGs[rgID] {
+			delete(mon.ipThresholdState, rgID)
 		}
 	}
 

--- a/pkg/cluster/monitor_ipstate_purge_5990_test.go
+++ b/pkg/cluster/monitor_ipstate_purge_5990_test.go
@@ -1,0 +1,170 @@
+package cluster
+
+import (
+	"testing"
+)
+
+// TestMonitorIPStatePurgedOnRGRemoval_5990 pins the map-lifecycle fix for #5990:
+// when an RG is REMOVED from config, the Monitor's per-RG ipState and ipDebts
+// (and the ipThresholdState mirror) must be purged, so a same-id RG re-add while
+// a monitored target is STILL DOWN re-derives the ip-monitor election debt from
+// a fresh probe rather than no-oping against stale bookkeeping.
+//
+// The manager clears the removed RG's monitorWeights on removal, but the Monitor
+// keys ipState by (rgID, address) and ipDebts by rgID. Leaving them behind means
+// the next reconcileRGIPDebts after a same-id re-add sees desired==installed by
+// its OWN stale ipDebts record and fires no SetMonitorWeight — the re-added RG
+// carries a MISSING ip-monitor debt (weight stuck at 255) and can stay primary
+// with a dead monitored uplink. Fail-open.
+//
+// Fail-on-revert: delete the ipState/ipDebts/ipThresholdState purge loops in
+// Monitor.UpdateGroups. After re-add the stale ipDebts[1] makes the reconcile
+// no-op, so RG 1's weight stays 255 (the ip debt is never re-installed) and the
+// final assertions fail RED.
+func TestMonitorIPStatePurgedOnRGRemoval_5990(t *testing.T) {
+	t.Run("per_target_ip_debt", func(t *testing.T) {
+		m := NewManager(0, 1)
+		cfg := makeConfig(independentIPRG(1, 100, "10.0.0.1"))
+		m.UpdateConfig(cfg)
+		drainEvents(m, 4)
+
+		reach := map[string]bool{"10.0.0.1": true}
+		mon := NewMonitor(m, cfg.RedundancyGroups)
+		injectFakeNl(mon)
+		setNoDampening(mon)
+		mon.probeFn = reachProbeFn(reach)
+		m.monitor = mon
+
+		const ipKey = "ip:10.0.0.1"
+		ipStateKey := ipMonitorKey{rgID: 1, address: "10.0.0.1"}
+
+		// Healthy target → full weight, no debt.
+		mon.poll()
+		if w := m.GroupState(1).Weight; w != 255 {
+			t.Fatalf("all-reachable weight = %d, want 255", w)
+		}
+
+		// Target unreachable → per-target ip debt installed (255-100=155).
+		reach["10.0.0.1"] = false
+		mon.poll()
+		if w := m.GroupState(1).Weight; w != 155 {
+			t.Fatalf("weight with ip target down = %d, want 155 (255-100)", w)
+		}
+		if _, ok := m.monitorWeights[monitorKey{rgID: 1, iface: ipKey}]; !ok {
+			t.Fatalf("precondition: monitorWeights missing live ip debt %s", ipKey)
+		}
+		if _, ok := mon.ipDebts[1]; !ok {
+			t.Fatalf("precondition: mon.ipDebts[1] missing installed ip debt")
+		}
+		if st := mon.ipState[ipStateKey]; st == nil || !st.down {
+			t.Fatalf("precondition: mon.ipState[%v] should be dampened-down, got %+v", ipStateKey, st)
+		}
+
+		// --- REMOVE RG 1 from config while the target is still down. ---
+		// m.monitor is set, so UpdateConfig routes through Monitor.UpdateGroups,
+		// which must purge the per-RG ipState/ipDebts/ipThresholdState.
+		reach["10.0.0.1"] = false
+		m.UpdateConfig(makeConfig())
+		drainEvents(m, 4)
+
+		if m.GroupState(1) != nil {
+			t.Fatalf("RG 1 should be gone after removal, still present")
+		}
+		if _, ok := mon.ipDebts[1]; ok {
+			t.Fatalf("mon.ipDebts[1] not purged on RG removal (#5990)")
+		}
+		if _, ok := mon.ipThresholdState[1]; ok {
+			t.Fatalf("mon.ipThresholdState[1] not purged on RG removal (#5990)")
+		}
+		if st, ok := mon.ipState[ipStateKey]; ok {
+			t.Fatalf("mon.ipState[%v] not purged on RG removal (#5990), got %+v", ipStateKey, st)
+		}
+		// The manager-side debt is also gone (removal loop clears monitorWeights).
+		if _, ok := m.monitorWeights[monitorKey{rgID: 1, iface: ipKey}]; ok {
+			t.Fatalf("monitorWeights[rg1,%s] should be cleared on RG removal", ipKey)
+		}
+
+		// --- RE-ADD the SAME RG id while the target is STILL DOWN. ---
+		// A fresh RedundancyGroupState starts at weight 255 with no debt; the
+		// next poll must RE-DERIVE the ip debt from a clean per-RG slate.
+		m.UpdateConfig(makeConfig(independentIPRG(1, 100, "10.0.0.1")))
+		drainEvents(m, 4)
+		if w := m.GroupState(1).Weight; w != 255 {
+			t.Fatalf("re-added RG weight before poll = %d, want 255 (fresh state)", w)
+		}
+
+		mon.poll()
+
+		// With the purge, the fresh ipState dampens to down and the reconcile
+		// installs the debt again. Without the purge, stale ipDebts[1] makes the
+		// reconcile no-op and the weight stays 255 (fail-open) — RED.
+		if w := m.GroupState(1).Weight; w != 155 {
+			t.Fatalf("weight after same-id re-add + poll = %d, want 155 "+
+				"(ip debt must be RE-DERIVED from a clean per-RG monitor state; "+
+				"stale ipDebts must not no-op the install — #5990)", w)
+		}
+		if _, ok := m.monitorWeights[monitorKey{rgID: 1, iface: ipKey}]; !ok {
+			t.Fatalf("monitorWeights missing re-derived ip debt %s after same-id re-add", ipKey)
+		}
+		if st := m.GroupState(1); !monitorFailsHas(st.MonitorFails, ipKey) {
+			t.Fatalf("MonitorFails = %v, want to contain re-derived %s", st.MonitorFails, ipKey)
+		}
+	})
+
+	t.Run("aggregate_threshold_ip_debt", func(t *testing.T) {
+		m := NewManager(0, 1)
+		// global-threshold 100, global-weight 100, one target weight 100.
+		cfg := makeConfig(thresholdRG(1, 100, 100, 100, "10.0.0.9"))
+		m.UpdateConfig(cfg)
+		drainEvents(m, 4)
+
+		reach := map[string]bool{"10.0.0.9": true}
+		mon := NewMonitor(m, cfg.RedundancyGroups)
+		injectFakeNl(mon)
+		setNoDampening(mon)
+		mon.probeFn = reachProbeFn(reach)
+		m.monitor = mon
+
+		ipStateKey := ipMonitorKey{rgID: 1, address: "10.0.0.9"}
+
+		mon.poll()
+		if w := m.GroupState(1).Weight; w != 255 {
+			t.Fatalf("all-reachable weight = %d, want 255", w)
+		}
+
+		// Target down: cumulative 100 >= threshold 100 → aggregate debt (255-100=155).
+		reach["10.0.0.9"] = false
+		mon.poll()
+		if w := m.GroupState(1).Weight; w != 155 {
+			t.Fatalf("weight with aggregate ip debt = %d, want 155", w)
+		}
+		if !mon.ipThresholdState[1] {
+			t.Fatalf("precondition: mon.ipThresholdState[1] should be true (aggregate installed)")
+		}
+
+		// --- REMOVE RG 1 while the target is still down. ---
+		m.UpdateConfig(makeConfig())
+		drainEvents(m, 4)
+		if _, ok := mon.ipDebts[1]; ok {
+			t.Fatalf("mon.ipDebts[1] not purged on RG removal (aggregate, #5990)")
+		}
+		if _, ok := mon.ipThresholdState[1]; ok {
+			t.Fatalf("mon.ipThresholdState[1] not purged on RG removal (aggregate, #5990)")
+		}
+		if _, ok := mon.ipState[ipStateKey]; ok {
+			t.Fatalf("mon.ipState[%v] not purged on RG removal (aggregate, #5990)", ipStateKey)
+		}
+
+		// --- RE-ADD same id, target still down → aggregate debt re-derived. ---
+		m.UpdateConfig(makeConfig(thresholdRG(1, 100, 100, 100, "10.0.0.9")))
+		drainEvents(m, 4)
+		mon.poll()
+		if w := m.GroupState(1).Weight; w != 155 {
+			t.Fatalf("weight after same-id re-add + poll = %d, want 155 "+
+				"(aggregate ip debt must be RE-DERIVED — #5990)", w)
+		}
+		if _, ok := m.monitorWeights[monitorKey{rgID: 1, iface: ipAggregateMonitorName}]; !ok {
+			t.Fatalf("monitorWeights missing re-derived aggregate ip debt after same-id re-add")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

The chassis-cluster `Monitor` keys its dampened `ipState` by `(rgID, address)`
and its installed-debt record `ipDebts` (plus the `ipThresholdState` mirror) by
RG id. When an RG is REMOVED from config, `group_state.go UpdateConfig` clears
only the MANAGER's `monitorWeights` for the removed RG (and, post-#5080,
reconciles interface-monitor debt) — it never purged the Monitor's own per-RG
maps.

So a same-id RG remove/re-add while a monitored ip target was DOWN left stale
`ipDebts[rg.ID]` behind. On re-add, `reconcileRGIPDebts` saw `desired==installed`
by its OWN stale record and fired no `SetMonitorWeight`, so the debt the manager
had already cleared on removal was never re-installed. The re-added RG then
carried a MISSING ip-monitor election debt (weight stuck at 255) until the
target's next dampened transition — **a node could stay primary with a dead
monitored uplink. Fail-open**, narrow trigger (same-id remove/re-add during an
active target-down window).

## Fix

`Monitor.UpdateGroups` now purges `ipState` (every target whose RG is no longer
desired), `ipDebts`, and `ipThresholdState` for RGs removed from config,
alongside the existing `ifaceState` purge. It runs under `mon.mu` and calls no
`m.mu`-taking function, so it introduces **no lock-order inversion**
(`UpdateConfig` already holds `m.mu` when it calls `UpdateGroups`; the
established `m.mu → mon.mu` order is preserved). A same-id re-add now starts from
a clean per-RG slate and `reconcileRGIPDebts` re-derives the debt from a fresh
probe. Purging `ipState` also means a re-added RG whose target has since
recovered starts from fresh dampening. A KEPT RG whose ip-monitoring or targets
merely changed is deliberately **not** purged here — `reconcileRGIPDebts` owns
that reconcile per-poll and clears the obsolete per-target debt itself.

## Test (fail-on-revert)

`monitor_ipstate_purge_5990_test.go` (independent per-target mode + aggregate
global-threshold mode): install an ip-monitor debt with the target down, remove
the RG (assert the Monitor's per-RG `ipState`/`ipDebts`/`ipThresholdState` purged
and the manager's `monitorWeights` cleared), re-add the same id with the target
STILL down, and assert the debt is re-derived (weight 155, `monitorWeights` +
`MonitorFails` carry the ip key).

Proven RED on revert firsthand — with the purge removed:
```
--- FAIL: TestMonitorIPStatePurgedOnRGRemoval_5990/per_target_ip_debt
    monitor_ipstate_purge_5990_test.go:74: mon.ipDebts[1] not purged on RG removal (#5990)
--- FAIL: TestMonitorIPStatePurgedOnRGRemoval_5990/aggregate_threshold_ip_debt
    monitor_ipstate_purge_5990_test.go:149: mon.ipDebts[1] not purged on RG removal (aggregate, #5990)
```
A throwaway probe driving the full remove→re-add→poll path confirmed the core
fail-open with the purge reverted: `weight after same-id re-add = 255, want 155`.

## Validation

- `go build ./...` + `go vet ./pkg/cluster` clean; `gofmt -l` clean on touched Go files
- full `go test -race ./pkg/cluster` green (10.3s)

## Smoke deferral

Cluster `make test-failover` loss-cluster smoke is **DEFERRED** (shim-ABI wall).
This is a pure Go control-plane map-lifecycle fix with no dataplane surface;
gated on the fail-on-revert unit tests + full `go test -race ./pkg/cluster`.

## Docs

Extended `pkg/cluster/README.md`'s monitor-debt reconcile section with the per-RG
ip-monitor state purge on RG removal; added a dated `_Log.md` entry.

Closes #5990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wTch5eCLtSnkoqAA9Xu9R