### PR TITLE
config: fail closed on static-NAT `then static-nat inet` (#5859)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -50357,3 +50357,48 @@ top.
   (new — ip-debt-preserved fail-on-revert test, per-target + aggregate),
   pkg/cluster/README.md (edit — reconcileMonitorDebtsLocked reconciles
   interface-monitor debt ONLY; ip debt owned by reconcileRGIPDebts)
+
+- **Timestamp**: 2026-07-16
+- **Action**: #5859 — fail closed on static-NAT `then static-nat inet`
+  (NAT64). The compiler accepted the Junos static-NAT NAT64 target `then
+  static-nat inet` (records StaticNATRule.Then=="inet"), but the userspace
+  snapshot builder emitted the LITERAL string "inet" into the same-family
+  static_nat table's InternalIP address slot. Rust parse_nat_prefix("inet")
+  fails and the rule was SILENTLY SKIPPED — a strict-valid config claimed NAT64
+  translation but installed nothing (an inert, security-relevant NAT rule).
+  Bounded fail-closed fix (issue option 2; full lowering into the native NAT64
+  IR deferred to a /research follow-up): (1) new
+  validateStaticNATInetTargetStrict hard-rejects the target at strict commit /
+  commit-check, naming the rule-set + rule and directing to the native
+  `security nat nat64` rule-set; (2) the call site in runUniformGates downgrades
+  the reject to a SURFACED cfg.Warnings entry on the tolerant load / peer-sync
+  path (opts.lenientFirewallRefs, #1960 no-brick) — never a silent skip; (3)
+  buildStaticNATSnapshots DROPS the inet rule with a slog.Warn so the
+  unparseable "inet" sentinel never reaches the dataplane (symmetric with the
+  #5101 out-of-range-port fail-closed drop). The native `security nat nat64`
+  rule-set (buildNAT64Snapshots from cfg.Security.NAT.NAT64) is untouched and
+  remains the supported IPv6->IPv4 path. Fail-on-revert PROVEN firsthand: (a)
+  neutralize validateStaticNATInetTargetStrict → TestStaticNATInetTargetRejected-
+  Strict RED ("expected CompileConfig to REJECT `then static-nat inet`"); (b)
+  remove the buildStaticNATSnapshots drop guard → TestBuildStaticNATSnapshots-
+  DropsInet RED (observes StaticNATRuleSnapshot{InternalIP:"inet"} sentinel).
+  Behavior change: a previously-accepted-but-inert syntax now loudly rejects at
+  strict commit — the intended safer posture. Updated 4 existing tests that
+  encoded the old accepted behavior (TestStaticNATInet, TestStaticNATInet-
+  SetSyntax, TestStaticNATThenInetRoutingInstanceAdvisory → lenient compile +
+  surfaced-warning assertion, still validating the compiler recording;
+  TestStaticNATHostMaskInetActionNotRejected → proves the rejection is the
+  #5859 inet gate, not a host-mask "host route" error). Validation:
+  GOCACHE=/dev/shm/cache go build ./... clean; go vet ./pkg/config
+  ./pkg/dataplane/userspace clean; full pkg/config + pkg/dataplane/userspace
+  suites GREEN. Go-only (control plane fail-closed); static_nat.rs untouched.
+- **File(s)**: pkg/config/compiler_validate_strict_nat.go (new
+  validateStaticNATInetTargetStrict + updated host-mask inet-exemption comment),
+  pkg/config/compiler_uniformgates.go (wire the gate with strict/lenient split),
+  pkg/config/types_security.go (StaticNATRule.Then doc), pkg/dataplane/userspace/
+  nat_static.go (buildStaticNATSnapshots inet drop guard), pkg/config/
+  static_nat_inet_failclosed_5859_test.go (new), pkg/dataplane/userspace/
+  static_nat_inet_failclosed_5859_test.go (new), pkg/config/parser_security_test.go
+  + pkg/config/compiler_nat_target_parity_hb167_test.go + pkg/config/
+  compiler_nat_host_mask_test.go (updated to new fail-closed behavior),
+  docs/config-schema.md (#5859 note)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1678,6 +1678,26 @@ superset to false-reject, making them leaf-complete by construction:
 As with every flip, the reject fires only on the strict commit path;
 `compileTreeLenient` downgrades it to a warning on `Store.Load` / `SyncApply`.
 
+**`then static-nat inet` (Junos NAT64) is rejected at strict commit (#5859).**
+The Junos static-NAT NAT64 target `then static-nat inet` parses and the compiler
+records `StaticNATRule.Then == "inet"`, but there is NO dataplane lowering of the
+keyword: the userspace snapshot builder stores an IP address in the static_nat
+table's `InternalIP` slot, so emitting the literal string `"inet"` made the Rust
+`parse_nat_prefix` fail and the rule was SILENTLY SKIPPED — a strict-valid config
+claimed NAT64 translation but installed nothing (an inert, security-relevant NAT
+rule). Until the keyword is lowered into the native NAT64 IR (a larger design
+change — match scope, source pool, routing-instance, counters, fragments,
+reverse BIB, HA sync — tracked as a `/research`-scoped follow-up), the compiler
+FAILS CLOSED: `validateStaticNATInetTargetStrict` hard-rejects the target at
+strict commit / commit-check (naming the rule-set + rule and directing the
+operator to the native `security nat nat64` rule-set); the tolerant load /
+peer-sync path downgrades to a surfaced warning and `buildStaticNATSnapshots`
+DROPS the rule so the unparseable `"inet"` sentinel never reaches the dataplane.
+The supported IPv6→IPv4 path is the xpf-native `security nat nat64` rule-set
+above (`buildNAT64Snapshots` from `cfg.Security.NAT.NAT64`), which is unaffected.
+Tests: `static_nat_inet_failclosed_5859_test.go` (both `pkg/config` and
+`pkg/dataplane/userspace`).
+
 **The systematic per-subtree closure continues (#4313).** Each of the flips
 above (destination-NAT then, the three IPsec option containers, master-password,
 the Phase-1 IKE proposal, now the Phase-2 IPsec proposal and the two

--- a/pkg/config/compiler_nat_host_mask_test.go
+++ b/pkg/config/compiler_nat_host_mask_test.go
@@ -111,7 +111,13 @@ func TestStaticNATHostMaskNPTv6PrefixNotRejected(t *testing.T) {
 // The NAT64 `then static-nat inet` rule is a prefix translation, not host-1:1
 // static NAT: its match destination-address is the NAT64 well-known prefix
 // (64:ff9b::/96, a legitimate non-host prefix). The whole rule must be exempt
-// from the host-mask gate (Then == "inet").
+// from the host-mask gate (Then == "inet") — the host-mask check must never be
+// the thing that flags it.
+//
+// #5859: `then static-nat inet` is itself now REJECTED at strict commit (no
+// dataplane lowering; the literal "inet" installed a silently inert rule). This
+// test proves the rejection is the #5859 inet gate — NOT a host-mask "host
+// route" complaint about the /96 match — so the host-mask exemption still holds.
 func TestStaticNATHostMaskInetActionNotRejected(t *testing.T) {
 	tree := buildTree(t, []string{
 		"set security zones security-zone untrust",
@@ -120,8 +126,18 @@ func TestStaticNATHostMaskInetActionNotRejected(t *testing.T) {
 		"set security nat static rule-set rs1 rule r1 match destination-address 64:ff9b::/96",
 		"set security nat static rule-set rs1 rule r1 then static-nat inet",
 	})
-	if _, err := CompileConfig(tree); err != nil {
-		t.Fatalf("static-nat inet (NAT64) rule with prefix match must compile, got: %v", err)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("static-nat inet (NAT64) must be rejected at strict commit (#5859)")
+	}
+	// The rejection must come from the inet gate, not the host-mask gate: the
+	// /96 match is a legitimate NAT64 prefix and must never draw a "host route"
+	// error.
+	if strings.Contains(err.Error(), "host route") {
+		t.Fatalf("host-mask gate must EXEMPT the inet /96 match; got a host-route error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "nat64") {
+		t.Fatalf("rejection must be the #5859 inet gate (mention nat64), got: %v", err)
 	}
 }
 

--- a/pkg/config/compiler_nat_target_parity_hb167_test.go
+++ b/pkg/config/compiler_nat_target_parity_hb167_test.go
@@ -217,9 +217,18 @@ func TestStaticNATThenInetRoutingInstanceAdvisory(t *testing.T) {
 		"set security nat static rule-set S rule R1 match destination-address 203.0.113.5/32",
 		"set security nat static rule-set S rule R1 then static-nat inet routing-instance vr-green",
 	}
-	cfg, err := CompileConfig(buildTree(t, cmds))
+	tree := buildTree(t, cmds)
+	// #5859: `then static-nat inet` (NAT64) is now rejected at strict commit —
+	// no dataplane lowering exists and the literal "inet" installed a silently
+	// inert rule. The compiler still records the target + its trailing
+	// routing-instance advisory; validate that recording on the tolerant
+	// (lenient) path, which downgrades the reject to a surfaced warning.
+	if _, serr := CompileConfig(tree); serr == nil {
+		t.Fatal("strict CompileConfig must REJECT `then static-nat inet` (#5859)")
+	}
+	cfg, err := CompileConfigLenient(tree)
 	if err != nil {
-		t.Fatalf("then static-nat inet routing-instance must compile, got: %v", err)
+		t.Fatalf("lenient path must not brick on `then static-nat inet routing-instance`, got: %v", err)
 	}
 	rule := cfg.Security.NAT.Static[0].Rules[0]
 	if rule.Then != "inet" {
@@ -227,6 +236,9 @@ func TestStaticNATThenInetRoutingInstanceAdvisory(t *testing.T) {
 	}
 	if rule.ThenRoutingInstance != "vr-green" {
 		t.Fatalf("ThenRoutingInstance = %q, want vr-green", rule.ThenRoutingInstance)
+	}
+	if !hasWarningContaining(cfg.Warnings, "inet") {
+		t.Fatalf("lenient path must surface a downgrade warning for `static-nat inet`; warnings: %v", cfg.Warnings)
 	}
 }
 

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1631,6 +1631,26 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5859: reject a static-NAT rule whose target is the NAT64 keyword `then
+	// static-nat inet`. The compiler accepts the keyword but the userspace
+	// snapshot emits the literal string "inet" into the same-family static_nat
+	// address slot; the Rust parse of "inet" fails and the rule is SILENTLY
+	// SKIPPED — a strict-valid config claims NAT64 but installs nothing. No
+	// dataplane lowering of `static-nat inet` exists (the supported IPv6->IPv4
+	// path is the native `security nat nat64` rule-set). Strict on commit /
+	// commit-check (hard reject so the inert rule is operator-visible, naming
+	// the native alternative); lenient on load / peer-sync (warn — #1960; the
+	// snapshot builder then DROPS the rule so the sentinel never reaches Rust).
+	// Reuses lenientFirewallRefs, the same opt the target gates above use.
+	if err := validateStaticNATInetTargetStrict(cfg); err != nil {
+		if opts.lenientFirewallRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("static NAT inet (NAT64) target (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #5628 (codex-review-181 M16): a source / destination NAT rule's complete
 	// `then` block must carry EXACTLY ONE NAT-terminal translation action. A
 	// rule with ZERO actions installs no translation (an intended `off`

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1140,10 +1140,13 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 			// `then static-nat inet` is a NAT64 translation, not host-1:1
 			// static NAT: its `match destination-address` is the NAT64
 			// well-known prefix (e.g. 64:ff9b::/96, a legitimate non-host
-			// prefix) and the actual translation is driven by the separate
-			// NAT64 snapshot (buildNAT64Snapshots), not the static_nat table
-			// (the inet rule's static_nat snapshot entry is expected to be a
-			// no-op the Rust parse drops). Exempt the whole rule.
+			// prefix), so the host-mask check does not apply. The keyword is
+			// itself rejected at strict commit by validateStaticNATInetTarget-
+			// Strict (#5859) — no dataplane lowering exists, and emitting the
+			// literal "inet" left the rule silently inert — so this exemption
+			// only avoids a misleading second (host-mask) error on the same
+			// rule; the inet gate is the authoritative rejection. Exempt the
+			// whole rule.
 			if rule.Then == "inet" {
 				continue
 			}
@@ -1706,6 +1709,58 @@ func validateStaticNATThenTargetStrict(cfg *Config) error {
 					"translation and silently forward the packet untranslated "+
 					"(#4290)",
 				rs.Name, rule.Name)
+		}
+	}
+	return nil
+}
+
+// validateStaticNATInetTargetStrict rejects a static-NAT rule whose translation
+// target is the Junos NAT64 keyword `then static-nat inet` (#5859).
+//
+// The compiler ACCEPTS the keyword (compileNATStatic records rule.Then=="inet"),
+// but the userspace snapshot builder emits it as the LITERAL string "inet" in
+// the same-family static_nat table's InternalIP address slot. The Rust dataplane
+// (static_nat.rs) calls parse_nat_prefix on "inet", the parse fails, and the
+// rule is SILENTLY SKIPPED — a strict-valid config claims NAT64 translation but
+// is INERT (a security-relevant NAT rule that installs nothing). The dataplane
+// has no lowering of `static-nat inet` into the native NAT64 IR; the only
+// supported IPv6->IPv4 path is the native `security nat nat64` rule-set
+// (buildNAT64Snapshots reads cfg.Security.NAT.NAT64, NOT static-NAT rules).
+//
+// Until that lowering exists (a separate, larger design change: match scope,
+// source pool, routing-instance, counters, fragments, reverse BIB, HA sync),
+// fail CLOSED: hard-reject at strict commit so the operator sees a loud error
+// instead of a silently inert rule, and name the native rule-set as the
+// supported alternative. NPTv6 rules are skipped (Then holds the nptv6 prefix,
+// handled on a separate path). Rule-sets are walked in slice order for a
+// deterministic first error.
+//
+// Strict on commit / commit-check (hard reject); the call site downgrades to a
+// warning on the tolerant load / peer-sync path (#1960 no-brick), where the
+// snapshot builder (buildStaticNATSnapshots) independently DROPS the rule so the
+// unparseable "inet" sentinel never reaches the Rust static_nat table.
+func validateStaticNATInetTargetStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for _, rs := range cfg.Security.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil || rule.IsNPTv6 {
+				continue
+			}
+			if rule.Then == "inet" {
+				return fmt.Errorf(
+					"static NAT rule-set %q rule %q uses `then static-nat "+
+						"inet` (NAT64), which is not yet representable in the "+
+						"dataplane and would install as a silently inert rule "+
+						"(the literal \"inet\" cannot parse as a translation "+
+						"address); author the native `security nat nat64` "+
+						"rule-set instead (#5859)",
+					rs.Name, rule.Name)
+			}
 		}
 	}
 	return nil

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -4792,9 +4792,18 @@ security {
 	if len(errs) > 0 {
 		t.Fatalf("parse errors: %v", errs)
 	}
-	cfg, err := CompileConfig(tree)
+	// #5859: strict commit now REJECTS `then static-nat inet` (NAT64) — the
+	// dataplane has no lowering and the literal "inet" installed a silently
+	// inert rule. The compiler still PARSES and records the target
+	// (rule.Then=="inet"); use the tolerant load / peer-sync path
+	// (CompileConfigLenient) to validate that recording without tripping the
+	// strict reject, and confirm the reject surfaces as a warning.
+	if _, serr := CompileConfig(tree); serr == nil {
+		t.Fatal("strict CompileConfig must REJECT `then static-nat inet` (#5859)")
+	}
+	cfg, err := CompileConfigLenient(tree)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("lenient path must not brick on `then static-nat inet`: %v", err)
 	}
 	if len(cfg.Security.NAT.Static) != 1 {
 		t.Fatalf("expected 1 static rule-set, got %d", len(cfg.Security.NAT.Static))
@@ -4816,6 +4825,9 @@ security {
 	if rule.Then != "inet" {
 		t.Errorf("then = %q, want inet", rule.Then)
 	}
+	if !hasWarningContaining(cfg.Warnings, "inet") {
+		t.Fatalf("lenient path must surface a downgrade warning for `static-nat inet`; warnings: %v", cfg.Warnings)
+	}
 }
 
 func TestStaticNATInetSetSyntax(t *testing.T) {
@@ -4830,9 +4842,15 @@ func TestStaticNATInetSetSyntax(t *testing.T) {
 			t.Fatalf("SetPath(%q): %v", line, err)
 		}
 	}
-	cfg, err := CompileConfig(tree)
+	// #5859: strict commit rejects `then static-nat inet`; the compiler still
+	// records the target on the tolerant path. Validate the recording via the
+	// lenient compile and confirm the reject surfaces as a warning.
+	if _, serr := CompileConfig(tree); serr == nil {
+		t.Fatal("strict CompileConfig must REJECT `then static-nat inet` (#5859)")
+	}
+	cfg, err := CompileConfigLenient(tree)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("lenient path must not brick on `then static-nat inet`: %v", err)
 	}
 	if len(cfg.Security.NAT.Static) != 1 {
 		t.Fatalf("expected 1 static rule-set, got %d", len(cfg.Security.NAT.Static))
@@ -4843,6 +4861,9 @@ func TestStaticNATInetSetSyntax(t *testing.T) {
 	}
 	if rule.SourceAddress != "::/0" {
 		t.Errorf("source-address = %q, want ::/0", rule.SourceAddress)
+	}
+	if !hasWarningContaining(cfg.Warnings, "inet") {
+		t.Fatalf("lenient path must surface a downgrade warning for `static-nat inet`; warnings: %v", cfg.Warnings)
 	}
 }
 

--- a/pkg/config/static_nat_inet_failclosed_5859_test.go
+++ b/pkg/config/static_nat_inet_failclosed_5859_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5859: the Junos static-NAT NAT64 keyword `then static-nat inet` compiled
+// clean but the userspace snapshot emitted the literal string "inet" into the
+// same-family static_nat address slot; the Rust parse of "inet" failed and the
+// rule was SILENTLY SKIPPED — a strict-valid config claimed NAT64 translation
+// but installed nothing (a security-relevant NAT rule that is inert). No
+// dataplane lowering of `static-nat inet` exists; the supported IPv6->IPv4 path
+// is the native `security nat nat64` rule-set. The fix fails CLOSED: strict
+// commit hard-rejects the keyword (naming the native alternative), the tolerant
+// load / peer-sync path downgrades to a surfaced warning, and the snapshot
+// builder drops the rule so the sentinel never reaches the dataplane.
+
+func inetRuleSetLines() []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 64:ff9b::/96",
+		"set security nat static rule-set rs1 rule r1 then static-nat inet",
+	}
+}
+
+// TestStaticNATInetTargetRejectedStrict is the strict half: `then static-nat
+// inet` must be REJECTED at strict commit-check (CompileConfig), with an error
+// that names the rule-set and rule and points at the native nat64 rule-set.
+//
+// Fail-on-revert: removing the validateStaticNATInetTargetStrict gate (or its
+// call site in runUniformGates) makes CompileConfig succeed -> RED.
+func TestStaticNATInetTargetRejectedStrict(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range inetRuleSetLines() {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected CompileConfig to REJECT `then static-nat inet` (#5859)")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "rs1") || !strings.Contains(msg, "r1") {
+		t.Fatalf("error must name the rule-set and rule, got: %v", err)
+	}
+	if !strings.Contains(msg, "inet") || !strings.Contains(msg, "nat64") {
+		t.Fatalf("error must mention `inet` and direct to the native `nat64` rule-set, got: %v", err)
+	}
+}
+
+// TestStaticNATInetTargetLenientWarns is the tolerant-path half: the lenient
+// load / peer-sync compile (CompileConfigLenient) must NOT brick (#1960
+// no-brick) but MUST record a surfaced warning — the rule must not silently
+// become inert with no signal.
+//
+// Fail-on-revert: removing the lenientFirewallRefs downgrade at the call site
+// makes CompileConfigLenient return an error (or, if the gate is removed
+// entirely, no warning) -> RED.
+func TestStaticNATInetTargetLenientWarns(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range inetRuleSetLines() {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must NOT fail on `then static-nat inet` (no-brick): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "inet") && strings.Contains(w, "tolerant path") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path must SURFACE a downgrade warning for `static-nat inet`; warnings: %v", cfg.Warnings)
+	}
+}
+
+// TestNativeNAT64RuleSetUnaffected is the regression guard: the SUPPORTED
+// IPv6->IPv4 path — a native `security nat nat64` rule-set — must still compile
+// clean and produce NAT64 state. The #5859 reject targets ONLY the static-NAT
+// `then static-nat inet` keyword (cfg.Security.NAT.Static), never the native
+// rule-set (cfg.Security.NAT.NAT64).
+func TestNativeNAT64RuleSetUnaffected(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set security nat source pool p64 address 100.64.0.7/32",
+		"set security nat nat64 rule-set rs64 prefix 64:ff9b::/96",
+		"set security nat nat64 rule-set rs64 source-pool p64",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("native `security nat nat64` rule-set must still compile clean: %v", err)
+	}
+	if len(cfg.Security.NAT.NAT64) != 1 {
+		t.Fatalf("expected 1 native NAT64 rule-set, got %d", len(cfg.Security.NAT.NAT64))
+	}
+	if cfg.Security.NAT.NAT64[0].Prefix != "64:ff9b::/96" {
+		t.Fatalf("native NAT64 rule-set prefix = %q, want 64:ff9b::/96", cfg.Security.NAT.NAT64[0].Prefix)
+	}
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -931,7 +931,14 @@ type StaticNATRule struct {
 	// all-source mapping, a fail-open exposure, H01). The first element is
 	// mirrored into SourceAddress for back-compat. Empty = match any source.
 	SourceAddresses []string
-	Then            string // static-nat prefix (internal/private IP), or "inet" for NAT64
+	// Then is the static-nat prefix (internal/private IP). The Junos NAT64
+	// keyword `then static-nat inet` records the sentinel "inet" here, but it
+	// is REJECTED at strict commit (validateStaticNATInetTargetStrict, #5859):
+	// no dataplane lowering exists and emitting the literal "inet" into the
+	// static_nat address slot left the rule silently inert. Lenient load /
+	// peer-sync downgrades to a warning and the snapshot builder drops the rule
+	// (fail-closed). The supported IPv6->IPv4 path is `security nat nat64`.
+	Then string
 	// ThenPrefixName is the raw `then static-nat prefix-name <name>` reference
 	// (#4290). Junos static NAT `prefix-name` names a global address-book entry
 	// whose literal prefix is the 1:1 translation target — the named twin of

--- a/pkg/dataplane/userspace/nat_static.go
+++ b/pkg/dataplane/userspace/nat_static.go
@@ -62,18 +62,6 @@ func buildStaticNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32
 			// dataplane — fail CLOSED, symmetric with the #5101 out-of-range
 			// port drop below. The supported IPv6->IPv4 path is the native
 			// `security nat nat64` rule-set (buildNAT64Snapshots), untouched.
-			// #5859: `then static-nat inet` is the Junos NAT64 keyword. The
-			// compiler records rule.Then=="inet", but this same-family
-			// static_nat table stores an IP address in InternalIP — emitting
-			// the literal "inet" makes the Rust parse_nat_prefix fail and the
-			// rule is SILENTLY SKIPPED (a strict-valid config claims NAT64 but
-			// installs nothing). Strict commit now REJECTS this target
-			// (validateStaticNATInetTargetStrict); on the lenient load /
-			// peer-sync path it is a surfaced compile warning. Drop the rule
-			// here too so the unparseable "inet" sentinel never reaches the
-			// dataplane — fail CLOSED, symmetric with the #5101 out-of-range
-			// port drop below. The supported IPv6->IPv4 path is the native
-			// `security nat nat64` rule-set (buildNAT64Snapshots), untouched.
 			if rule.Then == "inet" {
 				slog.Warn("userspace snapshot: dropping static NAT `then static-nat inet` (NAT64) rule; not representable in the static_nat table (use `security nat nat64`) (fail-closed, #5859)",
 					"ruleset", rs.Name, "rule", rule.Name)

--- a/pkg/dataplane/userspace/nat_static.go
+++ b/pkg/dataplane/userspace/nat_static.go
@@ -50,6 +50,35 @@ func buildStaticNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32
 			if rule == nil || rule.IsNPTv6 {
 				continue
 			}
+			// #5859: `then static-nat inet` is the Junos NAT64 keyword. The
+			// compiler records rule.Then=="inet", but this same-family
+			// static_nat table stores an IP address in InternalIP — emitting
+			// the literal "inet" makes the Rust parse_nat_prefix fail and the
+			// rule is SILENTLY SKIPPED (a strict-valid config claims NAT64 but
+			// installs nothing). Strict commit now REJECTS this target
+			// (validateStaticNATInetTargetStrict); on the lenient load /
+			// peer-sync path it is a surfaced compile warning. Drop the rule
+			// here too so the unparseable "inet" sentinel never reaches the
+			// dataplane — fail CLOSED, symmetric with the #5101 out-of-range
+			// port drop below. The supported IPv6->IPv4 path is the native
+			// `security nat nat64` rule-set (buildNAT64Snapshots), untouched.
+			// #5859: `then static-nat inet` is the Junos NAT64 keyword. The
+			// compiler records rule.Then=="inet", but this same-family
+			// static_nat table stores an IP address in InternalIP — emitting
+			// the literal "inet" makes the Rust parse_nat_prefix fail and the
+			// rule is SILENTLY SKIPPED (a strict-valid config claims NAT64 but
+			// installs nothing). Strict commit now REJECTS this target
+			// (validateStaticNATInetTargetStrict); on the lenient load /
+			// peer-sync path it is a surfaced compile warning. Drop the rule
+			// here too so the unparseable "inet" sentinel never reaches the
+			// dataplane — fail CLOSED, symmetric with the #5101 out-of-range
+			// port drop below. The supported IPv6->IPv4 path is the native
+			// `security nat nat64` rule-set (buildNAT64Snapshots), untouched.
+			if rule.Then == "inet" {
+				slog.Warn("userspace snapshot: dropping static NAT `then static-nat inet` (NAT64) rule; not representable in the static_nat table (use `security nat nat64`) (fail-closed, #5859)",
+					"ruleset", rs.Name, "rule", rule.Name)
+				continue
+			}
 			// #5101: a PRESENT but out-of-range destination/mapped port must
 			// not reach clampPort. Clamping it to 0 collapses the rule to the
 			// whole-address (port-0) wildcard, which the Rust side installs as

--- a/pkg/dataplane/userspace/static_nat_inet_failclosed_5859_test.go
+++ b/pkg/dataplane/userspace/static_nat_inet_failclosed_5859_test.go
@@ -1,0 +1,84 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestBuildStaticNATSnapshotDropsInet is the #5859 wire half. The Junos NAT64
+// keyword `then static-nat inet` records rule.Then=="inet" in the compiler, but
+// this same-family static_nat table stores an IP address in InternalIP. Emitting
+// the literal string "inet" makes the Rust parse_nat_prefix fail and the rule is
+// SILENTLY SKIPPED — a strict-valid config claims NAT64 translation but installs
+// nothing. The builder must instead DROP the rule so the unparseable "inet"
+// sentinel never reaches the dataplane (fail-closed). Strict commit rejects the
+// keyword upstream; this drop backstops the tolerant load / peer-sync path.
+//
+// Fail-on-revert: removing the `rule.Then == "inet"` drop guard in
+// buildStaticNATSnapshots re-instates the StaticNATRuleSnapshot{InternalIP:
+// "inet"} sentinel emission — this test then goes RED (it observes a produced
+// snapshot carrying the "inet" sentinel).
+func TestBuildStaticNATSnapshotDropsInet(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{Name: "rs1", FromZone: "untrust", Rules: []*config.StaticNATRule{{
+			Name:  "r1",
+			Match: "64:ff9b::/96",
+			Then:  "inet",
+		}}},
+	}
+
+	snaps := buildStaticNATSnapshots(cfg, nil)
+	if len(snaps) != 0 {
+		t.Fatalf("expected the `static-nat inet` rule to be DROPPED (0 snapshots), got %d: %+v", len(snaps), snaps)
+	}
+	// Belt-and-suspenders: no snapshot may ever carry the "inet" sentinel in the
+	// IP-address field, regardless of count.
+	for _, s := range snaps {
+		if s.InternalIP == "inet" {
+			t.Fatalf("snapshot carries the unparseable \"inet\" sentinel in InternalIP: %+v", s)
+		}
+	}
+}
+
+// TestBuildStaticNATSnapshotKeepsNormalPrefix guards that the #5859 drop is
+// scoped to the `inet` sentinel ONLY — an ordinary `then static-nat prefix`
+// rule alongside an `inet` rule still produces its snapshot.
+func TestBuildStaticNATSnapshotKeepsNormalPrefix(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{Name: "rs1", FromZone: "untrust", Rules: []*config.StaticNATRule{
+			{Name: "inet-rule", Match: "64:ff9b::/96", Then: "inet"},
+			{Name: "prefix-rule", Match: "203.0.113.1/32", Then: "10.0.0.5/32"},
+		}},
+	}
+
+	snaps := buildStaticNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("expected exactly the prefix rule to survive (1 snapshot), got %d: %+v", len(snaps), snaps)
+	}
+	s := snaps[0]
+	if s.Name != "prefix-rule" || s.InternalIP != "10.0.0.5/32" {
+		t.Fatalf("surviving snapshot = %+v, want the prefix-rule with InternalIP 10.0.0.5/32", s)
+	}
+}
+
+// TestBuildNAT64SnapshotUnaffected is the regression guard for the SUPPORTED
+// IPv6->IPv4 path: a native `security nat nat64` rule-set (cfg.Security.NAT.
+// NAT64) still produces NAT64 state via buildNAT64Snapshots. The #5859 drop
+// touches only the static-NAT table, never the native NAT64 snapshot builder.
+func TestBuildNAT64SnapshotUnaffected(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.NAT64 = []*config.NAT64RuleSet{
+		{Name: "rs64", Prefix: "64:ff9b::/96"},
+	}
+
+	snaps := buildNAT64Snapshots(cfg)
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 native NAT64 snapshot, got %d", len(snaps))
+	}
+	if snaps[0].Prefix != "64:ff9b::/96" {
+		t.Fatalf("native NAT64 snapshot prefix = %q, want 64:ff9b::/96", snaps[0].Prefix)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #5859. The compiler accepted the Junos static-NAT NAT64 target `then static-nat inet` (recording `StaticNATRule.Then=="inet"`), but the userspace snapshot builder emitted the **literal string `"inet"`** into the same-family `static_nat` table's `InternalIP` address slot. The Rust dataplane's `parse_nat_prefix("inet")` fails and the rule was **silently skipped** — a strict-valid config claimed NAT64 translation but installed nothing (an inert, security-relevant NAT rule). No dataplane lowering of `static-nat inet` exists; the supported IPv6→IPv4 path is the native `security nat nat64` rule-set.

## Scope: bounded fail-closed, not full lowering

This PR implements the issue's **option 2** (bounded fail-closed). **Full lowering** of `static-nat inet` into the native NAT64 IR — match scope, source pool, routing-instance, counters, fragments, reverse BIB, and end-to-end HA-sync tests — is a larger design change and is **deferred to a `/research`-scoped follow-up**. This PR closes the silent-inert hole by failing closed:

1. **Strict reject** — `validateStaticNATInetTargetStrict` hard-rejects the target at strict commit / commit-check, naming the rule-set + rule and directing the operator to the native `security nat nat64` rule-set instead.
2. **Tolerant path fails closed with a surfaced error** — the `runUniformGates` call site downgrades the reject to a `cfg.Warnings` entry on the lenient load / peer-sync path (`opts.lenientFirewallRefs`, #1960 no-brick) — **never a silent skip**.
3. **No sentinel to the dataplane** — `buildStaticNATSnapshots` drops the `inet` rule with a `slog.Warn` so the unparseable `"inet"` sentinel never reaches the Rust `static_nat` table (symmetric with the #5101 out-of-range-port fail-closed drop).

The native NAT64 path (`buildNAT64Snapshots` from `cfg.Security.NAT.NAT64`) is **untouched** and remains the supported route (regression-guarded in both packages).

## Behavior change

A previously-accepted-but-inert syntax now **loudly rejects at strict commit** — the intended safer posture per the issue. Four existing tests that encoded the old accepted behavior are updated: three switch to the lenient compile + surfaced-warning assertion (still validating that the compiler records the target), and the host-mask test now proves the rejection is the #5859 inet gate, not a host-mask "host route" error. A config using the native `security nat nat64` rule-set is unaffected.

## Fail-on-revert (proven firsthand)

- Neutralize `validateStaticNATInetTargetStrict` → `TestStaticNATInetTargetRejectedStrict` goes **RED** (`expected CompileConfig to REJECT ...`).
- Remove the `buildStaticNATSnapshots` drop guard → `TestBuildStaticNATSnapshotDropsInet` goes **RED** (observes `StaticNATRuleSnapshot{InternalIP:"inet"}`).

## Validation

- `go build ./...` clean; `go vet ./pkg/config ./pkg/dataplane/userspace` clean.
- Full `pkg/config` + `pkg/dataplane/userspace` suites GREEN.
- Go-only control-plane fail-closed change; `static_nat.rs` is **not** modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBXaBf7Didmd66UvDBAqMZ