### PR TITLE
cluster: purge garpCounts[rgID] on RG removal

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-16 — #6027 cluster: purge m.garpCounts[rgID] on RG removal
+- **Timestamp**: 2026-07-16 (fix/6027-garpcounts-purge)
+- **Action**: Fixed the third same-id-re-add map-lifecycle gap in the
+  chassis-cluster `UpdateConfig` removed-RG cleanup loop (after #5990). The
+  manager keys `garpCounts` by RG id and WRITES it only when the config sets a
+  positive `gratuitous-arp-count` (`group_state.go` ~line 105). The removal loop
+  cleared `monitorWeights` and the group but NOT `garpCounts`, so a same-id RG
+  remove/re-add whose re-added config omitted an explicit count inherited the
+  PRIOR incarnation's stale count instead of the default — the consumers
+  (`pkg/vrrp`, `pkg/daemon`) treat an ABSENT `garpCounts` entry as the default
+  burst (3), so a surviving stale entry defeats that fallback. Fix: add
+  `delete(m.garpCounts, id)` in the same removed-RG loop, co-located with the
+  existing `monitorWeights`/`groups` deletes, under `m.mu` (held by
+  `UpdateConfig`). LOW severity — narrow trigger, wrong GARP burst count, not a
+  fail-open. Scanned the Manager struct for other per-RG (`map[int]`) maps
+  WRITTEN in `UpdateConfig` but not purged in the removal loop: only `groups`
+  and `garpCounts` are written in that function; the `peer*`/`failover*`
+  `map[int]` maps are not written in `UpdateConfig`, so no additional same-class
+  gap in scope.
+- **File(s)**: pkg/cluster/group_state.go (edit — removal loop
+  `delete(m.garpCounts, id)` + comment),
+  pkg/cluster/garpcounts_purge_6027_test.go (new — fail-on-revert test),
+  pkg/cluster/README.md (edit — per-RG cleanup-on-removal maps now list
+  garpCounts)
+- **Validation**: `GOCACHE=/dev/shm/cache go build ./...` clean; `go vet
+  ./pkg/cluster` clean; `gofmt -l` clean on touched files (pre-existing gofmt
+  flags on sync.go/sync_protocol.go left untouched). New fail-on-revert test
+  PROVEN RED firsthand — with the delete removed, after removal
+  `garpCounts[1]==7` survives → `garpcounts_purge_6027_test.go:56: garpCounts[1]
+  not purged on RG removal (#6027): got 7, want absent` → restored → GREEN. Full
+  `go test -race ./pkg/cluster` GREEN (10.2s). Go-only, no cargo. HA
+  test-failover smoke blocked by the loss-cluster shim-ABI wall — gated on the
+  fail-on-revert unit test + full -race suite; parent to record the smoke
+  deferral.
+
 ## 2026-07-16 — #5990 cluster: purge Monitor per-RG ipState/ipDebts on RG removal
 - **Timestamp**: 2026-07-16 (fix/5990-monitor-ipstate-purge)
 - **Action**: Fixed a chassis-cluster HA monitor map-lifecycle fail-open. The

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -565,6 +565,19 @@ rather than inheriting a stale down/hold-down state. A KEPT RG whose
 ip-monitoring or targets merely changed is NOT purged here —
 `reconcileRGIPDebts` owns that reconcile per-poll.
 
+**Purge per-RG GARP count on RG removal (#6027).** `UpdateConfig` writes
+`m.garpCounts[rg.ID]` ONLY when the config sets a positive
+`gratuitous-arp-count`; the consumers (`pkg/vrrp`, `pkg/daemon`) treat an
+absent entry as the default burst (3). The removal loop now
+`delete(m.garpCounts, id)` alongside `monitorWeights` and `m.groups`, so a
+same-id RG remove/re-add where the re-add omits an explicit count does not
+inherit the prior incarnation's stale count — the entry stays absent and the
+default applies. This is the third same-id-re-add map-lifecycle gap closed in
+this loop, after the #5990 ip-monitor `ipState`/`ipDebts`/`ipThresholdState`
+purge. The per-RG cleanup-on-removal maps are: `holdTimer` (stopped, #5245),
+`monitorWeights` (interface + re-derivable ip debt), `garpCounts` (#6027), and
+the group itself.
+
 `LinkAttrsUp` is exported because the same carrier-aware read is needed
 outside the monitor loop:
 

--- a/pkg/cluster/garpcounts_purge_6027_test.go
+++ b/pkg/cluster/garpcounts_purge_6027_test.go
@@ -1,0 +1,75 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// garpRG builds an RG with an explicit gratuitous-arp-count. A count of 0 means
+// "no explicit count" — UpdateConfig only writes m.garpCounts when the count is
+// positive, so a 0 leaves the RG on the default GARP burst (3, applied by the
+// VRRP/daemon consumers when the map entry is absent).
+func garpRG(id, garpCount int) *config.RedundancyGroup {
+	return &config.RedundancyGroup{
+		ID:                 id,
+		NodePriorities:     map[int]int{0: 200},
+		GratuitousARPCount: garpCount,
+	}
+}
+
+// TestGARPCountsPurgedOnRGRemoval_6027 pins the map-lifecycle fix for #6027:
+// when an RG is REMOVED from config, the manager's per-RG m.garpCounts entry
+// must be purged in the same removed-RG cleanup loop that already clears
+// monitorWeights and the group. Otherwise a same-id RG remove/re-add where the
+// re-added config omits an explicit gratuitous-arp-count inherits the PRIOR
+// incarnation's count instead of the default.
+//
+// This is the third same-id-re-add gap in this loop: #5990 fixed the
+// ip-monitor ipState/ipDebts/ipThresholdState; this fixes garpCounts.
+//
+// Fail-on-revert: remove `delete(m.garpCounts, id)` from UpdateConfig's
+// removed-RG loop. After removal the stale garpCounts[1]==7 survives (the
+// "PURGED" assertion goes RED), and after a same-id re-add with no explicit
+// count the stale 7 is still present instead of an absent entry (the "default"
+// assertion goes RED).
+func TestGARPCountsPurgedOnRGRemoval_6027(t *testing.T) {
+	m := NewManager(0, 1)
+
+	// --- Add RG 1 with an explicit non-default GARP count. ---
+	m.UpdateConfig(makeConfig(garpRG(1, 7)))
+	drainEvents(m, 4)
+
+	if got, ok := m.garpCounts[1]; !ok || got != 7 {
+		t.Fatalf("after add: garpCounts[1] = (%d, present=%v), want (7, true)", got, ok)
+	}
+
+	// --- REMOVE RG 1 from config. The removed-RG cleanup loop must purge
+	// the per-RG GARP count alongside monitorWeights and the group. ---
+	m.UpdateConfig(makeConfig())
+	drainEvents(m, 4)
+
+	if m.GroupState(1) != nil {
+		t.Fatalf("RG 1 should be gone after removal, still present")
+	}
+	if got, ok := m.garpCounts[1]; ok {
+		t.Fatalf("garpCounts[1] not purged on RG removal (#6027): got %d, want absent", got)
+	}
+
+	// --- RE-ADD the SAME RG id with NO explicit gratuitous-arp-count. ---
+	// Because UpdateConfig only writes garpCounts for a positive count, the
+	// entry must stay ABSENT so the consumer falls back to the default burst.
+	// Without the purge, the stale garpCounts[1]==7 survives here and the
+	// re-added RG wrongly inherits the prior incarnation's count.
+	m.UpdateConfig(makeConfig(garpRG(1, 0)))
+	drainEvents(m, 4)
+
+	if m.GroupState(1) == nil {
+		t.Fatalf("RG 1 should be present after re-add")
+	}
+	if got, ok := m.garpCounts[1]; ok {
+		t.Fatalf("after same-id re-add with no explicit count: garpCounts[1] = %d "+
+			"(stale from prior incarnation), want absent so the default GARP "+
+			"count is used (#6027)", got)
+	}
+}

--- a/pkg/cluster/group_state.go
+++ b/pkg/cluster/group_state.go
@@ -59,6 +59,14 @@ func (m *Manager) UpdateConfig(cfg *config.ClusterConfig) {
 					delete(m.monitorWeights, k)
 				}
 			}
+			// Purge the per-RG GARP count so a same-id re-add that omits an
+			// explicit gratuitous-arp-count does not inherit this incarnation's
+			// stale count (#6027). garpCounts is only WRITTEN when the config
+			// sets a positive count, so a re-add with no explicit count relies
+			// on the map entry being absent to fall back to the default. The
+			// third same-id-re-add map-lifecycle gap in this loop after #5990
+			// (ip-monitor ipState/ipDebts/ipThresholdState).
+			delete(m.garpCounts, id)
 			delete(m.groups, id)
 		}
 	}


### PR DESCRIPTION
## Problem

`m.garpCounts` (pkg/cluster manager, keyed by RG id) is written in
`group_state.go` `UpdateConfig` only when the config sets a positive
`gratuitous-arp-count`. The removed-RG cleanup loop that clears the RG's
`monitorWeights` and group state on removal did NOT delete
`m.garpCounts[rgID]`. A same-id RG remove/re-add whose re-added config omits an
explicit `gratuitous-arp-count` therefore inherited the PRIOR incarnation's
stale count instead of the default — the consumers (`pkg/vrrp`, `pkg/daemon`)
treat an ABSENT `garpCounts` entry as the default burst (3), so a surviving
stale entry defeats that fallback.

This is the third same-id-re-add map-lifecycle gap closed in this loop, after
the #5990 ip-monitor `ipState`/`ipDebts`/`ipThresholdState` purge.

Severity **LOW**: narrow trigger (same-id re-add omitting the count), and the
effect is a wrong GARP burst count, not a fail-open.

## Fix

Add `delete(m.garpCounts, id)` in the same removed-RG cleanup loop, co-located
with the existing `monitorWeights`/`groups` deletes. It runs under `m.mu` (held
by `UpdateConfig`); `garpCounts` is a manager map, no lock issue.

## Additional same-class scan

Scanned the Manager struct for any other per-RG (`map[int]`) map WRITTEN in
`UpdateConfig` but not purged in the removal loop. Only `groups` and
`garpCounts` are written directly in `UpdateConfig`; the `peer*`/`failover*`
`map[int]` maps are not written there, so **no additional same-class gap** was
found in scope.

## Docs

- `pkg/cluster/README.md`: the per-RG cleanup-on-removal maps section now lists
  `garpCounts` (#6027) alongside `holdTimer`, `monitorWeights`, and the group.
- `_Log.md`: dated entry.

## Validation

- `go build ./...` clean; `go vet ./pkg/cluster` clean; `gofmt -l` clean on
  touched Go files (pre-existing gofmt flags on sync.go/sync_protocol.go left
  untouched).
- New fail-on-revert test `pkg/cluster/garpcounts_purge_6027_test.go`: add RG
  with count 7 → assert `garpCounts[1]==7` → remove RG → assert purged → re-add
  same id with no explicit count → assert entry absent (default applies). Proven
  RED firsthand — with the `delete` removed:
  `garpcounts_purge_6027_test.go:56: garpCounts[1] not purged on RG removal
  (#6027): got 7, want absent`. Restored → GREEN.
- Full `go test -race ./pkg/cluster` GREEN (10.2s).

## Smoke deferral

HA/cluster change. `make test-failover` is blocked by the loss-cluster shim-ABI
wall (pinned cpumap=16 vs repo 256 → verify-dataplane fail-closes every
cluster-deploy). Merge is gated on the fail-on-revert unit test plus the full
`pkg/cluster` `-race` suite; the on-cluster failover smoke is deferred until a
full reload crosses the ABI bump.

Closes #6027

🤖 Generated with [Claude Code](https://claude.com/claude-code)