### PR TITLE
appid: warn when a hash collision displaces a stable app_id

### DIFF
--- a/docs/services-application-identification.md
+++ b/docs/services-application-identification.md
@@ -67,10 +67,17 @@ upfront what they're getting and not getting.
    only the colliding user apps can renumber — never the whole
    catalog. **Honest residual (#5296):** stability is NOT absolute —
    adding a user app that hash-collides with an existing user app can
-   renumber that small colliding set. The zero-residual path
-   (versioning application identity in the session state) is a
-   cross-language conntrack-ABI + HA-wire change, deliberately out of
-   scope for this bounded fix.
+   renumber that small colliding set. Because this is the one case that
+   warrants operator attention, `AssignStableAppIDs` emits a
+   `slog.Warn` at catalog build (config compile, never per-packet)
+   whenever a user app is displaced off its natural `StableAppID` slot —
+   naming the `application`, the `natural_app_id` slot it wanted, and
+   the `assigned_app_id` it was displaced to (#5988). An operator who
+   sees this log knows a displacement (and thus a possible
+   renumber-across-edit for that app) has occurred; a collision-free
+   catalog stays silent. The zero-residual path (versioning application
+   identity in the session state) is a cross-language conntrack-ABI +
+   HA-wire change, deliberately out of scope for this bounded fix.
 2. **Snapshot ship**: `buildAppCatalogSnapshot`
    (`pkg/dataplane/userspace/flow.go`) emits the catalog as the
    `app_catalog` field of the config snapshot — an ordered list

--- a/pkg/config/appid_displace_warn_5988_test.go
+++ b/pkg/config/appid_displace_warn_5988_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+// #5988: a user application whose stable name-derived StableAppID hash-collides
+// with an already-placed id is DISPLACED to the lowest free id by
+// AssignStableAppIDs. That displaced id is NOT a pure function of the app name
+// alone, so the small colliding set can renumber across catalog edits — the one
+// case docs/services-application-identification.md says needs operator
+// attention. Before #5988 the displacement was SILENT; AssignStableAppIDs now
+// emits a slog.Warn naming the app, the natural slot it wanted, and the id it
+// was displaced to. This test locks that observability signal.
+
+// displaceCaptureRecord is one slog record captured by displaceCaptureHandler.
+type displaceCaptureRecord struct {
+	level slog.Level
+	msg   string
+	attrs map[string]slog.Value
+}
+
+// displaceCaptureHandler records every slog record so the test can assert the
+// displacement warning fired with the expected attributes.
+type displaceCaptureHandler struct{ recs *[]displaceCaptureRecord }
+
+func (h displaceCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h displaceCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := map[string]slog.Value{}
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value
+		return true
+	})
+	*h.recs = append(*h.recs, displaceCaptureRecord{level: r.Level, msg: r.Message, attrs: attrs})
+	return nil
+}
+func (h displaceCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h displaceCaptureHandler) WithGroup(string) slog.Handler      { return h }
+
+// captureDisplaceWarns installs a capturing slog handler as the default logger
+// for the test's lifetime and returns the slice records land in.
+func captureDisplaceWarns(t *testing.T) *[]displaceCaptureRecord {
+	t.Helper()
+	recs := &[]displaceCaptureRecord{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(displaceCaptureHandler{recs: recs}))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return recs
+}
+
+// TestAssignStableAppIDsDisplacementWarns_5988 constructs a real user-app vs
+// user-app fold collision (svc-217 and svc-396 both fold to the same
+// StableAppID), runs AssignStableAppIDs, and asserts a Warn fired for the app
+// that lost its natural slot — naming the app, its natural (wanted) id, and the
+// displaced id it actually got.
+//
+// RED on revert: delete the slog.Warn in AssignStableAppIDs' displaced-fill loop
+// and no record is captured, so the "expected a displacement Warn" assertion
+// fails.
+func TestAssignStableAppIDsDisplacementWarns_5988(t *testing.T) {
+	const a = "svc-217"
+	const b = "svc-396"
+
+	// Fixture guard: the two names must still collide under the fold, and
+	// neither may have become a predefined name (a predefined would be placed
+	// first and win the slot, changing which app is displaced).
+	if StableAppID(a) != StableAppID(b) {
+		t.Skipf("test fixture stale: %q (id %d) no longer collides with %q (id %d) under the fold",
+			a, StableAppID(a), b, StableAppID(b))
+	}
+	if _, ok := PredefinedApplications[a]; ok {
+		t.Skipf("test fixture stale: %q is now a predefined application", a)
+	}
+	if _, ok := PredefinedApplications[b]; ok {
+		t.Skipf("test fixture stale: %q is now a predefined application", b)
+	}
+	natural := StableAppID(a) // == StableAppID(b)
+
+	recs := captureDisplaceWarns(t)
+
+	out, err := AssignStableAppIDs([]string{a, b})
+	if err != nil {
+		t.Fatalf("AssignStableAppIDs(%v) error = %v", []string{a, b}, err)
+	}
+
+	// Exactly one of the pair keeps the natural slot; the other is displaced.
+	// sort.Strings orders "svc-217" before "svc-396", so svc-217 is placed
+	// first and keeps `natural`, and svc-396 is displaced.
+	if out[a] != natural {
+		t.Fatalf("expected %q to keep its natural id %d, got %d", a, natural, out[a])
+	}
+	if out[b] == natural {
+		t.Fatalf("expected %q to be displaced off id %d, but it kept it", b, natural)
+	}
+	if out[b] == 0 {
+		t.Fatalf("displaced %q got the reserved id 0", b)
+	}
+	displacedID := out[b]
+
+	// The observability contract: a Warn must name the displaced app, the
+	// natural slot it wanted, and the id it was displaced to.
+	var found bool
+	for _, r := range *recs {
+		if r.level != slog.LevelWarn {
+			continue
+		}
+		app, ok := r.attrs["application"]
+		if !ok || app.String() != b {
+			continue
+		}
+		found = true
+
+		nat, ok := r.attrs["natural_app_id"]
+		if !ok {
+			t.Errorf("displacement Warn for %q missing natural_app_id attribute", b)
+		} else if got := uint16(nat.Uint64()); got != natural {
+			t.Errorf("displacement Warn natural_app_id = %d, want the wanted slot %d", got, natural)
+		}
+
+		asn, ok := r.attrs["assigned_app_id"]
+		if !ok {
+			t.Errorf("displacement Warn for %q missing assigned_app_id attribute", b)
+		} else if got := uint16(asn.Uint64()); got != displacedID {
+			t.Errorf("displacement Warn assigned_app_id = %d, want the displaced id %d", got, displacedID)
+		}
+		break
+	}
+	if !found {
+		t.Fatalf("expected a displacement Warn naming the displaced app %q; captured %d records: %+v",
+			b, len(*recs), *recs)
+	}
+}
+
+// TestAssignStableAppIDsNoDisplacementNoWarn_5988 is the negative control: a
+// collision-free catalog must NOT emit any displacement Warn, so the signal is
+// meaningful (it fires only on the rare residual, never on the common case).
+func TestAssignStableAppIDsNoDisplacementNoWarn_5988(t *testing.T) {
+	// Two names that do NOT collide under the fold and are not predefined.
+	const a = "svc-217"
+	const c = "svc-218"
+	if StableAppID(a) == StableAppID(c) {
+		t.Skipf("test fixture stale: %q and %q now collide under the fold", a, c)
+	}
+
+	recs := captureDisplaceWarns(t)
+
+	if _, err := AssignStableAppIDs([]string{a, c}); err != nil {
+		t.Fatalf("AssignStableAppIDs(%v) error = %v", []string{a, c}, err)
+	}
+	for _, r := range *recs {
+		if r.level == slog.LevelWarn {
+			if _, ok := r.attrs["application"]; ok {
+				t.Errorf("no-collision catalog emitted a displacement Warn: %+v", r)
+			}
+		}
+	}
+}

--- a/pkg/config/appid_stable.go
+++ b/pkg/config/appid_stable.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"hash/fnv"
+	"log/slog"
 	"sort"
 )
 
@@ -131,6 +132,18 @@ func AssignStableAppIDs(names []string) (map[string]uint16, error) {
 		for i, n := range displaced {
 			out[n] = free[i]
 			taken[free[i]] = true
+			// A displaced app is the HONEST RESIDUAL (#5296): its stable,
+			// name-derived StableAppID hash-collided with an already-placed id
+			// (another user app, or — placed first — a predefined), so it was
+			// bumped to the lowest free id. That bumped id is NOT a pure
+			// function of the app name alone, so this small colliding set can
+			// renumber across catalog edits — the one case the doc says needs
+			// operator attention. This runs at catalog build (config compile),
+			// never per-packet/per-session, so a Warn is correct here (#5988).
+			slog.Warn("application id displaced by stable-id hash collision; its app_id may renumber across catalog edits (rare — see docs/services-application-identification.md)",
+				"application", n,
+				"natural_app_id", StableAppID(n),
+				"assigned_app_id", free[i])
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds observability for the honest residual documented in #5296 (PR #5984): when a user application's stable name-derived `StableAppID` hash-collides with an already-placed id, `AssignStableAppIDs` (`pkg/config/appid_stable.go`) DISPLACES the colliding user app to the lowest free id. That displaced id is no longer a pure function of the app name alone, so the small colliding set can renumber across catalog edits — the one case `docs/services-application-identification.md` says warrants operator attention. Until now the displacement was **silent**.

Closes #5988

## Change

- **`pkg/config/appid_stable.go`**: emit a `slog.Warn` in the displaced-slot fill loop naming the displaced `application`, the `natural_app_id` slot it wanted, and the `assigned_app_id` it was displaced to.
  - This runs at **catalog build** (config compile) — the only callers are `appid.BuildCatalog` (`pkg/appid/catalog.go`) and `dataplane.compileApplications` (`pkg/dataplane/compiler.go`), **never** a per-packet/per-session path — so a `Warn` here is correct, not a hot-path log.
  - A collision-free catalog stays silent, so the signal fires only on the rare residual.
- **`pkg/config/appid_displace_warn_5988_test.go`** (new): constructs a real user-app vs user-app fold collision (`svc-217` and `svc-396` both fold to the same `StableAppID`), runs `AssignStableAppIDs`, and asserts a `Warn` fired naming the displaced app with its natural and assigned ids. A negative-control test proves a collision-free catalog emits no displacement `Warn`.
- **`docs/services-application-identification.md`**: document the log signal so operators know the displacement event is now observable.

## Validation

- `go build ./...`, `go vet ./pkg/config` — clean.
- `go test ./pkg/config` — full suite green (the appid stability/collision/parity contracts are extensive).
- **Fail-on-revert (firsthand):** removing the `slog.Warn` turns `TestAssignStableAppIDsDisplacementWarns_5988` RED — `expected a displacement Warn naming the displaced app "svc-396"; captured 0 records: []`. Restoring it → GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018998YD7nY8LDZ5izG99zss