### PR TITLE
test: cover config-sync transport wiring fail-on-revert

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-16 — #5961 test: fail-on-revert cover config-sync transport wiring
+- **Timestamp**: 2026-07-16 (fix/5961-configsync-wiring-test)
+- **Action**: Closed the #5054 (PR #5958) test-coverage gap. The existing
+  fail-on-revert suite (`configsync_transport_5054_test.go`) exercised the
+  DECISION FUNCTION (`rg0ConfigSyncAuthority` + `commitAndApplyOperator`) but
+  NOT the per-transport WIRING — the gRPC/REST/local-shell `CommitFn` /
+  `CommitConfirmedFn` closures inlined at their construction sites in
+  `daemon_run.go`. Verified the gap live on origin/master (48672f892):
+  reverting the REST/shell `CommitFn` wiring to
+  `commitAndApply(ctx, comment, false)` left the ENTIRE `pkg/daemon` suite
+  green, so a single-transport #5054 regression was silent. Small testability
+  refactor: extracted the three transports' inline commit closures into six
+  named per-transport seams on `*Daemon` (`grpc/rest/shellCommitFn` +
+  `…CommitConfirmedFn`), each routing through
+  `commitAndApplyOperator` / `commitConfirmedAndApplyOperator`; rewired the
+  three `daemon_run.go` sites to call them. Added two table tests
+  (`TestTransportCommitFnWiringSyncsPeerByRG0Ownership`,
+  `TestTransportCommitConfirmedFnWiringSyncsPeerByRG0Ownership`) driving each
+  seam under rg0-owner / non-owner / standalone and asserting peer-sync IFF RG0
+  owner. Reverting ANY ONE seam to a hardcoded `syncPeer` reds exactly that
+  transport's sub-case (owner→false = 0 pushes; non-owner→true = 1 push);
+  proved each of gRPC/REST/shell reds independently. Corrected the
+  `configsync_transport_5054_test.go` header comment, which overstated that the
+  decision-function tests covered "the REST/shell wiring" — they invoke
+  `commitAndApplyOperator` directly, so a single-transport revert left them
+  green (the closed gap).
+- **File(s)**: pkg/daemon/daemon_run.go (extract 6 per-transport commit-fn
+  seams + rewire 3 sites), pkg/daemon/configsync_transport_5054_test.go
+  (2 new table tests + corrected header comment), _Log.md
+
 ## 2026-07-16 — #6027 cluster: purge m.garpCounts[rgID] on RG removal
 - **Timestamp**: 2026-07-16 (fix/6027-garpcounts-purge)
 - **Action**: Fixed the third same-id-re-add map-lifecycle gap in the

--- a/pkg/daemon/configsync_transport_5054_test.go
+++ b/pkg/daemon/configsync_transport_5054_test.go
@@ -10,19 +10,32 @@
 // autonomous event-options engine keeps its explicit opt-out (syncPeer=false)
 // because each node fires remediation independently from its own RPM events.
 //
-// These tests pin (1) the pure decision function across the cluster-state table
-// and (2) the behavioral outcome: an operator commit syncs the peer iff this
-// node owns RG0, a standalone / non-owner node does not, and the event-engine
-// opt-out still suppresses the sync even on an RG0 owner.
+// These tests pin (1) the pure decision function across the cluster-state table,
+// (2) the behavioral outcome of the shared operator commit path — an operator
+// commit syncs the peer iff this node owns RG0, a standalone / non-owner node
+// does not, and the event-engine opt-out still suppresses the sync even on an
+// RG0 owner — and (3) the per-transport WIRING in daemon_run.go: the gRPC / REST
+// / local-shell commit closures (the grpc/rest/shell CommitFn/CommitConfirmedFn
+// seams) each route through commitAndApplyOperator / commitConfirmedAndApplyOperator,
+// so no single transport can silently diverge from the RG0-ownership policy.
 //
-// FAIL-ON-REVERT: reverting commitAndApplyOperator (or the REST/shell wiring) to
-// pass syncPeer=false turns TestOperatorCommitSyncsPeerWhenRG0Owner /
-// TestOperatorCommitConfirmedSyncsPeerWhenRG0Owner RED (0 pushes → standby stays
-// stale). Neutralizing rg0ConfigSyncAuthority to always-false turns both the
-// owner decision-table case and those behavioral tests RED.
+// FAIL-ON-REVERT: reverting commitAndApplyOperator itself (or neutralizing
+// rg0ConfigSyncAuthority to always-false) turns TestOperatorCommit* and the
+// owner decision-table case RED. INDEPENDENTLY, reverting ANY ONE transport seam
+// in daemon_run.go back to commitAndApply(ctx, comment, false) — the exact #5054
+// regression — turns that transport's owner sub-case in
+// TestTransportCommitFnWiringSyncsPeerByRG0Ownership /
+// TestTransportCommitConfirmedFnWiringSyncsPeerByRG0Ownership RED (0 pushes on
+// the RG0 owner); a hardcoded syncPeer=true reds its non-owner sub-case.
+//
+// The pre-#5961 decision-function / operator-path tests above did NOT cover the
+// transport wiring: they invoke commitAndApplyOperator directly, so reverting a
+// single transport's daemon_run.go closure left every one of them green. That is
+// the coverage gap the TestTransportCommit*Wiring tests close (#5961).
 package daemon
 
 import (
+	"context"
 	"testing"
 
 	"golang.org/x/sync/semaphore"
@@ -167,5 +180,78 @@ func TestOperatorCommitConfirmedSyncsPeerWhenRG0Owner(t *testing.T) {
 	}
 	if *calls != 1 {
 		t.Fatalf("operator commit-confirmed on the RG0 owner must sync the peer exactly once (#5054); got %d", *calls)
+	}
+}
+
+// syncByOwnershipCases is the shared per-transport wiring table: an operator
+// commit must sync the peer IFF this node owns RG0, on every transport. The
+// owner case reds a transport reverted to a hardcoded syncPeer=false (the #5054
+// regression); the non-owner / standalone cases red a hardcoded syncPeer=true.
+var syncByOwnershipCases = []struct {
+	name    string
+	cluster func(*testing.T) *cluster.Manager
+	want    int
+}{
+	{"rg0-owner", clusterOwningRG0, 1},
+	{"non-owner", clusterNotOwningRG0, 0},
+	{"standalone", func(*testing.T) *cluster.Manager { return nil }, 0},
+}
+
+// TestTransportCommitFnWiringSyncsPeerByRG0Ownership drives the EXACT commit
+// closures wired into the gRPC / REST / local-shell servers in daemon_run.go
+// (grpcCommitFn / restCommitFn / shellCommitFn) and asserts each resolves
+// peer-sync by RG0 ownership, never a per-transport constant. This is the
+// coverage the decision-function tests above lack: a single-transport wiring
+// regression turns exactly one sub-case RED here instead of staying silent.
+func TestTransportCommitFnWiringSyncsPeerByRG0Ownership(t *testing.T) {
+	transports := []struct {
+		name string
+		fn   func(*Daemon) func(context.Context, string) (*config.Config, error)
+	}{
+		{"grpc", (*Daemon).grpcCommitFn},
+		{"rest", (*Daemon).restCommitFn},
+		{"shell", (*Daemon).shellCommitFn},
+	}
+	for _, tr := range transports {
+		for _, tc := range syncByOwnershipCases {
+			t.Run(tr.name+"/"+tc.name, func(t *testing.T) {
+				d, calls := newSyncProbeDaemon(t, tc.cluster(t))
+				if _, err := tr.fn(d)(t.Context(), ""); err != nil {
+					t.Fatalf("%s CommitFn: %v", tr.name, err)
+				}
+				if *calls != tc.want {
+					t.Fatalf("%s CommitFn on %s: peer syncs = %d, want %d — the transport wiring must route through commitAndApplyOperator, not a hardcoded syncPeer (#5054/#5961)", tr.name, tc.name, *calls, tc.want)
+				}
+			})
+		}
+	}
+}
+
+// TestTransportCommitConfirmedFnWiringSyncsPeerByRG0Ownership is the
+// commit-confirmed analogue: the gRPC / REST / local-shell CommitConfirmedFn
+// closures (grpcCommitConfirmedFn / restCommitConfirmedFn / shellCommitConfirmedFn)
+// must route through commitConfirmedAndApplyOperator so `commit confirmed` obeys
+// the same transport-independent RG0-ownership peer-sync policy.
+func TestTransportCommitConfirmedFnWiringSyncsPeerByRG0Ownership(t *testing.T) {
+	transports := []struct {
+		name string
+		fn   func(*Daemon) func(context.Context, int) (*config.Config, error)
+	}{
+		{"grpc", (*Daemon).grpcCommitConfirmedFn},
+		{"rest", (*Daemon).restCommitConfirmedFn},
+		{"shell", (*Daemon).shellCommitConfirmedFn},
+	}
+	for _, tr := range transports {
+		for _, tc := range syncByOwnershipCases {
+			t.Run(tr.name+"/"+tc.name, func(t *testing.T) {
+				d, calls := newSyncProbeDaemon(t, tc.cluster(t))
+				if _, err := tr.fn(d)(t.Context(), 1); err != nil {
+					t.Fatalf("%s CommitConfirmedFn: %v", tr.name, err)
+				}
+				if *calls != tc.want {
+					t.Fatalf("%s CommitConfirmedFn on %s: peer syncs = %d, want %d — the transport wiring must route through commitConfirmedAndApplyOperator, not a hardcoded syncPeer (#5054/#5961)", tr.name, tc.name, *calls, tc.want)
+				}
+			})
+		}
 	}
 }

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -731,18 +731,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// applyConfigFn stays wired for non-commit paths (rollback,
 		// confirm) that still need the full reconcile.
 		shell.SetApplyConfigFn(d.applyConfig)
-		shell.SetCommitFns(
-			func(ctx context.Context, comment string) (*config.Config, error) {
-				// #5054: in-process CLI commits sync to the peer on
-				// the SAME RG0-ownership policy as gRPC/REST — peer
-				// convergence is transport-independent, decided in
-				// commitAndApplyOperator, not by which API committed.
-				return d.commitAndApplyOperator(ctx, comment)
-			},
-			func(ctx context.Context, minutes int) (*config.Config, error) {
-				return d.commitConfirmedAndApplyOperator(ctx, minutes)
-			},
-		)
+		// #5054: in-process CLI commits sync to the peer on the SAME
+		// RG0-ownership policy as gRPC/REST — peer convergence is
+		// transport-independent, decided in commitAndApplyOperator, not
+		// by which API committed. Wiring lives in the shellCommitFn /
+		// shellCommitConfirmedFn seams so it is fail-on-revert covered
+		// (#5961, configsync_transport_5054_test.go).
+		shell.SetCommitFns(d.shellCommitFn(), d.shellCommitConfirmedFn())
 		shell.SetRPMResultsFn(func() []*rpm.ProbeResult {
 			if d.rpm != nil {
 				return d.rpm.Results()
@@ -1173,6 +1168,62 @@ func (d *Daemon) runShutdownSequence(wg *sync.WaitGroup, stop func(), runErr err
 	return runErr
 }
 
+// #5054/#5961: transport commit-wiring seams.
+//
+// The gRPC, HTTP/REST, and local-shell commit handlers must ALL route an
+// operator commit through commitAndApplyOperator / commitConfirmedAndApplyOperator
+// so the peer-sync decision is derived from RG0 ownership
+// (rg0ConfigSyncAuthority) and is transport-independent — the #5054 invariant.
+// Before #5054 only gRPC synced the peer; a REST/shell commit left the standby
+// on stale config.
+//
+// These closures were inlined at each transport's construction site, so no test
+// could exercise the wiring: reverting one transport back to
+// commitAndApply(ctx, comment, false) left every test green (#5961). They are
+// extracted here as three named per-transport seams — one method pair per
+// transport — so each transport's wiring is independently reachable from a test
+// and independently fail-on-revert covered (configsync_transport_5054_test.go).
+// They are intentionally identical: the whole point of #5054 is that every
+// transport resolves peer-sync the same way; keeping a distinct named seam per
+// transport is what lets a single-transport regression turn a single test case
+// RED instead of staying silent.
+
+func (d *Daemon) grpcCommitFn() func(context.Context, string) (*config.Config, error) {
+	return func(ctx context.Context, comment string) (*config.Config, error) {
+		return d.commitAndApplyOperator(ctx, comment)
+	}
+}
+
+func (d *Daemon) grpcCommitConfirmedFn() func(context.Context, int) (*config.Config, error) {
+	return func(ctx context.Context, minutes int) (*config.Config, error) {
+		return d.commitConfirmedAndApplyOperator(ctx, minutes)
+	}
+}
+
+func (d *Daemon) restCommitFn() func(context.Context, string) (*config.Config, error) {
+	return func(ctx context.Context, comment string) (*config.Config, error) {
+		return d.commitAndApplyOperator(ctx, comment)
+	}
+}
+
+func (d *Daemon) restCommitConfirmedFn() func(context.Context, int) (*config.Config, error) {
+	return func(ctx context.Context, minutes int) (*config.Config, error) {
+		return d.commitConfirmedAndApplyOperator(ctx, minutes)
+	}
+}
+
+func (d *Daemon) shellCommitFn() func(context.Context, string) (*config.Config, error) {
+	return func(ctx context.Context, comment string) (*config.Config, error) {
+		return d.commitAndApplyOperator(ctx, comment)
+	}
+}
+
+func (d *Daemon) shellCommitConfirmedFn() func(context.Context, int) (*config.Config, error) {
+	return func(ctx context.Context, minutes int) (*config.Config, error) {
+		return d.commitConfirmedAndApplyOperator(ctx, minutes)
+	}
+}
+
 // startGRPCServer constructs and launches the gRPC API server goroutine.
 // Extracted verbatim from Run()'s PHASE 5 (#4662 Increment 2); the leaf
 // startup block carries no ordering dependency (same code, same call point).
@@ -1248,13 +1299,11 @@ func (d *Daemon) startGRPCServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		// that hasn't yet been propagated. #5054: the RG0-ownership
 		// peer-sync decision now lives in commitAndApplyOperator,
 		// shared with the REST and local-shell commit paths so every
-		// transport converges identically.
-		CommitFn: func(ctx context.Context, comment string) (*config.Config, error) {
-			return d.commitAndApplyOperator(ctx, comment)
-		},
-		CommitConfirmedFn: func(ctx context.Context, minutes int) (*config.Config, error) {
-			return d.commitConfirmedAndApplyOperator(ctx, minutes)
-		},
+		// transport converges identically. Wiring lives in the
+		// grpcCommitFn / grpcCommitConfirmedFn seams so it is
+		// fail-on-revert covered (#5961).
+		CommitFn:          d.grpcCommitFn(),
+		CommitConfirmedFn: d.grpcCommitConfirmedFn(),
 		// #5281: a gRPC zeroize runs the wipe under the SAME apply gate as
 		// commit/sync and enters a terminal reset generation so no concurrent
 		// or later config writer re-creates the erased state before the daemon
@@ -1339,13 +1388,11 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		// RG0-ownership policy as gRPC/local-shell. Peer convergence
 		// is transport-independent (decided in commitAndApplyOperator),
 		// so a REST commit no longer leaves the standby on stale config
-		// until an unrelated transport-disconnect reverse-sync.
-		CommitFn: func(ctx context.Context, comment string) (*config.Config, error) {
-			return d.commitAndApplyOperator(ctx, comment)
-		},
-		CommitConfirmedFn: func(ctx context.Context, minutes int) (*config.Config, error) {
-			return d.commitConfirmedAndApplyOperator(ctx, minutes)
-		},
+		// until an unrelated transport-disconnect reverse-sync. Wiring
+		// lives in the restCommitFn / restCommitConfirmedFn seams so it
+		// is fail-on-revert covered (#5961).
+		CommitFn:          d.restCommitFn(),
+		CommitConfirmedFn: d.restCommitConfirmedFn(),
 		// #758: surface compile state so /health returns 503
 		// when the dataplane has never compiled successfully.
 		CompileHealthFn: func() api.CompileHealthSnapshot {


### PR DESCRIPTION
## Summary

Closes #5961.

The #5054 fix (PR #5958) routes the gRPC/REST/local-shell operator commit handlers through `commitAndApplyOperator`, deriving the peer-sync decision from RG0 ownership (`rg0ConfigSyncAuthority`) so it is transport-independent. The existing fail-on-revert suite (`configsync_transport_5054_test.go`) covered the **decision function** and the shared `commitAndApplyOperator` path, but **not** the per-transport **wiring** — the three `CommitFn`/`CommitConfirmedFn` closures were inlined at their construction sites in `daemon_run.go`, unreachable from any test.

## Step 0 — gap confirmed live on origin/master (48672f892)

Reverting the REST/shell `CommitFn` wiring back to `commitAndApply(ctx, comment, false)` left the **entire `pkg/daemon` suite green** — so a future single-transport regression (the exact #5054 bug) would be silent. The `configsync_transport_5054_test.go:18` header comment also overstated coverage, claiming the decision-function tests red on reverting "the REST/shell wiring" when they only exercise the shared operator path (they invoke `commitAndApplyOperator` directly).

## Fix

**Small testability refactor (noted per the issue's design constraint).** The commit closures were constructed inline in `daemon_run.go` and not reachable from a test. Extracted them into six named per-transport seams on `*Daemon`:

- `grpcCommitFn` / `grpcCommitConfirmedFn`
- `restCommitFn` / `restCommitConfirmedFn`
- `shellCommitFn` / `shellCommitConfirmedFn`

Each routes through `commitAndApplyOperator` / `commitConfirmedAndApplyOperator`; the three `daemon_run.go` construction sites now call them. The seams are intentionally identical (the #5054 invariant is that every transport resolves peer-sync the same way), but keeping a **distinct named seam per transport** is what makes each transport's wiring independently reachable from a test and independently fail-on-revert covered — so a single-transport regression reds exactly one test sub-case instead of staying silent.

Added two table tests driving each seam under rg0-owner / non-owner / standalone, asserting the peer is synced **iff** this node owns RG0:

- `TestTransportCommitFnWiringSyncsPeerByRG0Ownership`
- `TestTransportCommitConfirmedFnWiringSyncsPeerByRG0Ownership`

Corrected the header comment to state accurately what each layer covers.

## Fail-on-revert (verified firsthand — each transport reds independently)

Reverting REST `commitAndApplyOperator` → `commitAndApply(ctx, comment, false)`:
```
configsync_transport_5054_test.go:223: rest CommitFn on rg0-owner: peer syncs = 0, want 1 — the transport wiring must route through commitAndApplyOperator, not a hardcoded syncPeer (#5054/#5961)
--- FAIL: TestTransportCommitFnWiringSyncsPeerByRG0Ownership (0.01s)
```

Reverting shell `commitConfirmedAndApplyOperator` → `commitConfirmedAndApply(ctx, minutes, false)`:
```
configsync_transport_5054_test.go:252: shell CommitConfirmedFn on rg0-owner: peer syncs = 0, want 1 — the transport wiring must route through commitConfirmedAndApplyOperator, not a hardcoded syncPeer (#5054/#5961)
--- FAIL: TestTransportCommitConfirmedFnWiringSyncsPeerByRG0Ownership (0.01s)
```

Reverting gRPC `commitAndApplyOperator` → `commitAndApply(ctx, comment, false)`:
```
configsync_transport_5054_test.go:223: grpc CommitFn on rg0-owner: peer syncs = 0, want 1 — the transport wiring must route through commitAndApplyOperator, not a hardcoded syncPeer (#5054/#5961)
--- FAIL: TestTransportCommitFnWiringSyncsPeerByRG0Ownership (0.01s)
```

A hardcoded `syncPeer=true` reds the other direction (non-owner + standalone):
```
configsync_transport_5054_test.go:223: rest CommitFn on non-owner: peer syncs = 1, want 0 ...
configsync_transport_5054_test.go:223: rest CommitFn on standalone: peer syncs = 1, want 0 ...
--- FAIL: TestTransportCommitFnWiringSyncsPeerByRG0Ownership (0.01s)
```

All seams restored; the pre-existing decision-function tests still pass.

## Validate

- `go build ./...` — clean
- `go vet ./pkg/daemon` — clean
- `go test ./pkg/daemon` — `ok  github.com/psaab/xpf/pkg/daemon  7.486s`
- `gofmt` clean on both touched Go files

## Docs

Test + comment change; added a dated `_Log.md` entry. No module doc needs updating — the runtime peer-sync contract (`docs/`) is unchanged; this closes a test-coverage gap only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQSJHw4PGUvHBPjmLn2Txe