### PR TITLE
userspace: clear helper neighbors on empty replace

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -50497,3 +50497,20 @@ top.
   + pkg/config/compiler_nat_target_parity_hb167_test.go + pkg/config/
   compiler_nat_host_mask_test.go (updated to new fail-closed behavior),
   docs/config-schema.md (#5859 note)
+
+- **Timestamp**: 2026-07-16
+  **Action**: #5864 fix — authoritative empty NeighborReplace now clears the
+  helper manager-neighbor table (was omitted on the wire → stale L2 forwarding).
+  Go: dropped `omitempty` from `ControlRequest.Neighbors` so a present-empty
+  publishable set encodes as `"neighbors":[]` (distinct from absent). Rust:
+  `handlers::neighbors::update` no longer early-returns on `None`/empty when
+  `neighbor_replace=true` — it treats absent/`null`/`[]` under replace as a
+  CLEAR (routes an empty slice into `apply_manager_neighbors(true, &[])`); a
+  non-replace update with no neighbors stays a no-op. Transport confirmed local
+  Go-daemon → local userspace-dp control socket (no cross-node flag-day).
+  Bounded clear-on-empty fix; generation-envelope/ACK/retry deferred (follow-up).
+  **File(s)**: pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/neighbor_replace_empty_5864_test.go (new),
+  userspace-dp/src/server/handlers/neighbors.rs,
+  userspace-dp/src/server/tests.rs (3 new #5864 tests),
+  userspace-dp/src/afxdp/forwarding/README.md (#5864 note)

--- a/pkg/dataplane/userspace/neighbor_replace_empty_5864_test.go
+++ b/pkg/dataplane/userspace/neighbor_replace_empty_5864_test.go
@@ -1,0 +1,92 @@
+// Wire-encoding fail-on-revert guard for #5864: an authoritative
+// NeighborReplace that transitions the publishable set to EMPTY must
+// encode as a present-but-empty "neighbors":[] so the helper can
+// distinguish a CLEAR from an absent field (no-op). With omitempty the
+// empty slice was dropped from the wire, the helper decoded it as absent
+// and returned before applying the replacement, and stale dynamic
+// neighbors stayed installed → blackhole after kernel neighbor deletion.
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestEmptyNeighborReplaceEncodesPresentEmpty asserts that the exact
+// request the send path builds for an authoritative empty replace
+// (filterPublishableNeighbors → non-nil empty slice, NeighborReplace:true)
+// marshals to JSON that unambiguously signals a CLEAR.
+//
+// Fail-on-revert: restore `json:"neighbors,omitempty"` on
+// ControlRequest.Neighbors and the empty slice is dropped from the wire —
+// the `"neighbors":[]` assertion goes RED.
+func TestEmptyNeighborReplaceEncodesPresentEmpty(t *testing.T) {
+	// Mirror RegenerateNeighborSnapshot: the publishable set collapses to
+	// empty when no usable neighbors remain. filterPublishableNeighbors
+	// returns a non-nil, zero-length slice for this case.
+	publishable := filterPublishableNeighbors(nil)
+	if publishable == nil {
+		t.Fatalf("filterPublishableNeighbors(nil) must be non-nil so the empty replace has a present slice to encode")
+	}
+	if len(publishable) != 0 {
+		t.Fatalf("filterPublishableNeighbors(nil) = %d entries, want 0", len(publishable))
+	}
+
+	req := ControlRequest{
+		Type:            "update_neighbors",
+		Neighbors:       publishable,
+		NeighborReplace: true,
+	}
+	raw, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+
+	if !strings.Contains(got, `"neighbors":[]`) {
+		t.Fatalf("empty replace must encode a present-empty neighbors field %q; got %s", `"neighbors":[]`, got)
+	}
+	if !strings.Contains(got, `"neighbor_replace":true`) {
+		t.Fatalf("replace flag must be transmitted; got %s", got)
+	}
+
+	// A decoder must see the field as PRESENT (non-nil, zero-length),
+	// distinct from a request that never set neighbors at all.
+	var decoded ControlRequest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Neighbors == nil {
+		t.Fatalf("clear-replace must decode to a present (non-nil) neighbors slice, not absent")
+	}
+	if len(decoded.Neighbors) != 0 {
+		t.Fatalf("clear-replace neighbors len = %d, want 0", len(decoded.Neighbors))
+	}
+	if !decoded.NeighborReplace {
+		t.Fatalf("clear-replace must decode NeighborReplace=true")
+	}
+}
+
+// TestNonEmptyNeighborReplaceStillEncodesEntries is a sanity guard that
+// the omitempty removal did not disturb the normal non-empty publish.
+func TestNonEmptyNeighborReplaceStillEncodesEntries(t *testing.T) {
+	publishable := filterPublishableNeighbors([]NeighborSnapshot{
+		{Ifindex: 7, IP: "10.0.0.1", MAC: "02:00:00:00:00:01", State: "reachable", Family: "inet"},
+	})
+	if len(publishable) != 1 {
+		t.Fatalf("one publishable neighbor expected, got %d", len(publishable))
+	}
+	req := ControlRequest{Type: "update_neighbors", Neighbors: publishable, NeighborReplace: true}
+	raw, err := json.Marshal(&req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, `"ip":"10.0.0.1"`) {
+		t.Fatalf("non-empty replace must carry the neighbor entry; got %s", got)
+	}
+	if !strings.Contains(got, `"neighbor_replace":true`) {
+		t.Fatalf("replace flag must be transmitted; got %s", got)
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -27,21 +27,34 @@ const (
 )
 
 type ControlRequest struct {
-	Type               string                    `json:"type"`
-	SuppressStatus     bool                      `json:"suppress_status,omitempty"`
-	Snapshot           *ConfigSnapshot           `json:"snapshot,omitempty"`
-	Forwarding         *ForwardingControlRequest `json:"forwarding,omitempty"`
-	HAState            *HAStateUpdateRequest     `json:"ha_state,omitempty"`
-	Queue              *QueueControlRequest      `json:"queue,omitempty"`
-	Binding            *BindingControlRequest    `json:"binding,omitempty"`
-	Packet             *InjectPacketRequest      `json:"packet,omitempty"`
-	SessionSync        *SessionSyncRequest       `json:"session_sync,omitempty"`
-	SessionDeltas      *SessionDeltaDrainRequest `json:"session_deltas,omitempty"`
-	SessionExport      *SessionExportRequest     `json:"session_export,omitempty"`
-	Neighbors          []NeighborSnapshot        `json:"neighbors,omitempty"`
-	NeighborGeneration uint64                    `json:"neighbor_generation,omitempty"`
-	NeighborReplace    bool                      `json:"neighbor_replace,omitempty"`
-	Fabrics            []FabricSnapshot          `json:"fabrics,omitempty"`
+	Type           string                    `json:"type"`
+	SuppressStatus bool                      `json:"suppress_status,omitempty"`
+	Snapshot       *ConfigSnapshot           `json:"snapshot,omitempty"`
+	Forwarding     *ForwardingControlRequest `json:"forwarding,omitempty"`
+	HAState        *HAStateUpdateRequest     `json:"ha_state,omitempty"`
+	Queue          *QueueControlRequest      `json:"queue,omitempty"`
+	Binding        *BindingControlRequest    `json:"binding,omitempty"`
+	Packet         *InjectPacketRequest      `json:"packet,omitempty"`
+	SessionSync    *SessionSyncRequest       `json:"session_sync,omitempty"`
+	SessionDeltas  *SessionDeltaDrainRequest `json:"session_deltas,omitempty"`
+	SessionExport  *SessionExportRequest     `json:"session_export,omitempty"`
+	// Neighbors carries the manager-neighbor set for an update_neighbors
+	// request. It deliberately does NOT use omitempty (#5864): when the
+	// authoritative publishable set transitions to EMPTY, the send path
+	// still passes a present-but-empty slice with NeighborReplace=true to
+	// CLEAR the helper table. omitempty drops both nil and empty slices,
+	// which erased that clear on the wire (the helper decoded neighbors as
+	// absent and returned before applying the replacement, leaving stale
+	// dynamic neighbors installed → blackhole after kernel neighbor
+	// deletion). Without omitempty a present-empty replace encodes as
+	// "neighbors":[] — distinct from an absent field — so the helper
+	// applies the clear. A nil slice on non-neighbor requests encodes as
+	// "neighbors":null, which the Rust Option<Vec<..>> decodes back to
+	// None (harmless; those requests ignore the field).
+	Neighbors          []NeighborSnapshot `json:"neighbors"`
+	NeighborGeneration uint64             `json:"neighbor_generation,omitempty"`
+	NeighborReplace    bool               `json:"neighbor_replace,omitempty"`
+	Fabrics            []FabricSnapshot   `json:"fabrics,omitempty"`
 }
 
 type ControlResponse struct {

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -202,6 +202,22 @@ next-hops, preference 0). The wire specimen lives in
       snapshot-refresh manager-key set, the `update_neighbors` handler,
       and `parse_neighbor_entries` share the same gate so an installed
       neighbor is never pruned as a stale key.
+    - **Authoritative empty replace clears (#5864).** An
+      `update_neighbors` request with `neighbor_replace=true` is an
+      AUTHORITATIVE replacement of the manager-neighbor table, so a
+      request with ZERO entries CLEARS it — the last usable neighbor
+      disappearing (kernel neighbor deletion) must drop the helper's
+      stale entry, not leave it forwarding to a dead MAC. The handler
+      therefore treats an absent/`null`/`[]` neighbors field under
+      `replace` as "clear", NOT as "no-op": it does not early-return on
+      `None` when `replace` is set. Go stopped sending the field with
+      `omitempty` so a present-empty set encodes as `"neighbors":[]`
+      (distinct from absent) rather than being dropped; the helper
+      accepts both the absent and explicit-empty forms as a clear. A
+      NON-replace update with no neighbors stays a no-op (nothing to
+      add). NOTE: this is the bounded clear-on-empty fix; it does NOT add
+      a replace-generation envelope / ACK / retry-debt (deferred
+      robustness, tracked separately).
     - **Fabric-link skips (#3773 M13).** `build_fabric_link_or_skip` is the
       SHARED classifier for both fabric-resolution passes
       (`populate_fabrics` snapshot build, `resolve_fabric_links_from_snapshots`

--- a/userspace-dp/src/server/handlers/neighbors.rs
+++ b/userspace-dp/src/server/handlers/neighbors.rs
@@ -10,8 +10,17 @@ pub(super) fn update(
     neighbors: Option<&Vec<NeighborSnapshot>>,
     replace: bool,
 ) {
-    let Some(neighbors) = neighbors else {
-        return;
+    // #5864: an authoritative replace with zero entries must CLEAR the
+    // manager-neighbor table. When the Go publishable set transitions to
+    // empty, the field can arrive as absent/None (older wire) or as an
+    // explicit `[]` (post-#5864 wire, omitempty removed). Both mean the
+    // same thing under NeighborReplace: clear. Only bail early on a
+    // NON-replace update with no neighbors — that carries nothing to add
+    // and must not touch the existing table.
+    let neighbors: &[NeighborSnapshot] = match neighbors {
+        Some(neighbors) => neighbors.as_slice(),
+        None if replace => &[],
+        None => return,
     };
     let mut resolved = Vec::with_capacity(neighbors.len());
     for neigh in neighbors {

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -2442,3 +2442,113 @@ fn nat64_synced_entry_rebuilds_reverse_bib_4565() {
         "non-nat64 keeps the generic SNAT source"
     );
 }
+
+// --- #5864: authoritative empty NeighborReplace clears the table --------
+
+/// Seed exactly one publishable manager neighbor through the real
+/// `update_neighbors` handler path and return the driven state.
+fn seed_one_manager_neighbor() -> Arc<Mutex<ServerState>> {
+    let state = new_state(ProcessStatus::default());
+    let mut seed = req("update_neighbors");
+    seed.neighbor_replace = true;
+    seed.neighbors = Some(vec![crate::NeighborSnapshot {
+        interface: "ge-0-0-1".to_string(),
+        ifindex: 7,
+        family: "inet".to_string(),
+        ip: "10.0.0.1".to_string(),
+        mac: "02:00:00:00:00:01".to_string(),
+        state: "REACHABLE".to_string(),
+        ..crate::NeighborSnapshot::default()
+    }]);
+    let resp = run_request(state.clone(), seed);
+    assert!(resp.ok, "seed update_neighbors failed: {}", resp.error);
+    assert_eq!(
+        state
+            .lock()
+            .expect("state")
+            .afxdp
+            .dynamic_neighbor_status()
+            .0,
+        1,
+        "seed must install exactly one manager neighbor"
+    );
+    state
+}
+
+/// #5864 fail-on-revert: an authoritative NeighborReplace with the field
+/// ABSENT on the wire (Go drops the empty slice under omitempty →
+/// neighbors=None) must CLEAR the manager-neighbor table, not early-return
+/// and leave the stale entry installed. Reverting the None/empty handling
+/// in `handlers::neighbors::update` (restoring `let Some(..) else return`)
+/// makes the final assertion go RED — the stale neighbor survives.
+#[test]
+fn update_neighbors_absent_replace_clears_table_5864() {
+    let state = seed_one_manager_neighbor();
+
+    let mut clear = req("update_neighbors");
+    clear.neighbor_replace = true;
+    clear.neighbors = None;
+    let resp = run_request(state.clone(), clear);
+    assert!(resp.ok, "empty replace failed: {}", resp.error);
+
+    assert_eq!(
+        state
+            .lock()
+            .expect("state")
+            .afxdp
+            .dynamic_neighbor_status()
+            .0,
+        0,
+        "authoritative replace with neighbors=None must clear the table"
+    );
+}
+
+/// #5864 companion: an explicit present-but-empty slice (the post-fix Go
+/// wire, `\"neighbors\":[]`) under NeighborReplace must clear identically.
+#[test]
+fn update_neighbors_explicit_empty_replace_clears_table_5864() {
+    let state = seed_one_manager_neighbor();
+
+    let mut clear = req("update_neighbors");
+    clear.neighbor_replace = true;
+    clear.neighbors = Some(Vec::new());
+    let resp = run_request(state.clone(), clear);
+    assert!(resp.ok, "empty-slice replace failed: {}", resp.error);
+
+    assert_eq!(
+        state
+            .lock()
+            .expect("state")
+            .afxdp
+            .dynamic_neighbor_status()
+            .0,
+        0,
+        "authoritative replace with neighbors=[] must clear the table"
+    );
+}
+
+/// #5864 guard: a NON-replace update with no neighbors must remain a
+/// no-op — it carries nothing to add and must NOT touch the existing
+/// table. Guards against the clear-on-empty fix over-reaching into the
+/// (defensive) non-replace path.
+#[test]
+fn update_neighbors_none_without_replace_is_noop_5864() {
+    let state = seed_one_manager_neighbor();
+
+    let mut noop = req("update_neighbors");
+    noop.neighbor_replace = false;
+    noop.neighbors = None;
+    let resp = run_request(state.clone(), noop);
+    assert!(resp.ok, "noop update failed: {}", resp.error);
+
+    assert_eq!(
+        state
+            .lock()
+            .expect("state")
+            .afxdp
+            .dynamic_neighbor_status()
+            .0,
+        1,
+        "non-replace update with no neighbors must not clear the table"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a High-severity HA/forwarding-convergence bug: an authoritative
`NeighborReplace=true` with an **empty** publishable neighbor set failed
to clear the userspace-dp manager-neighbor table, so the helper kept
forwarding to a stale MAC after kernel neighbor deletion (blackhole /
misdelivery until a later non-empty snapshot or a restart).

## Root cause (both sides of the control socket)

- **Go** marshaled `ControlRequest.Neighbors` with `omitempty`, so a
  present-but-empty publishable slice was dropped from the wire —
  indistinguishable from "field absent".
- **Rust** `handlers::neighbors::update` early-returned when the decoded
  `neighbors` was `None`, before `apply_manager_neighbors`, so an
  authoritative replace with zero entries never reached the clear path.

## Transport-boundary finding

This `NeighborReplace` message is a **local Go-daemon → local
`userspace-dp` control-socket** message on the same node
(`requestDetailedLocked` dials `m.cfg.ControlSocket`, a unix socket).
The daemon and helper deploy in lockstep from the same build, so there
is **no cross-node mixed-version wire flag-day** — a straightforward
coordinated wire fix is safe (per the scoping check requested).

## Fix (minimal, both sides)

1. **Go** (`protocol.go`): drop `omitempty` from `ControlRequest.Neighbors`
   so a present-empty replace encodes as `"neighbors":[]` (distinct from
   absent). `NeighborReplace` (bool) is already transmitted when true. A
   nil slice on non-neighbor requests encodes as `"neighbors":null`,
   which the Rust `Option<Vec<..>>` decodes back to `None` (harmless).
2. **Rust** (`server/handlers/neighbors.rs`): no longer early-returns on
   `None`/empty when `NeighborReplace` is set — treats absent/`null`/`[]`
   under replace as a CLEAR (routes an empty slice into
   `apply_manager_neighbors(true, &[])`, which already clears the manager
   keys + forwarding entries and publishes the cleared state). A
   non-replace update with no neighbors stays a no-op.

## STEP 0 — not stale

Confirmed live on origin/master (`b7343fda5`): `Neighbors` still carried
`omitempty` and the Rust handler still `return`ed on `None` before
`apply_manager_neighbors`.

## Tests (fail-on-revert, both sides)

- **Go** `TestEmptyNeighborReplaceEncodesPresentEmpty`: the empty replace
  the send path builds marshals to `"neighbors":[]` + `"neighbor_replace":true`
  and round-trips to a present (non-nil, len 0) slice. Re-adding
  `omitempty` → wire becomes `{"type":"update_neighbors","neighbor_replace":true}`
  → **RED**.
- **Rust** `update_neighbors_absent_replace_clears_table_5864`: seed one
  manager neighbor, then send `neighbors=None, replace=true` (the exact
  omitempty-drop path) → table must be empty. Restoring the early-return
  → table len 1, expected 0 → **RED**. Companion tests cover explicit
  `[]` and the non-replace no-op guard.

## Validation

- Go: `go build ./...` clean, `go vet ./pkg/dataplane/userspace` clean,
  `go test ./pkg/dataplane/userspace` green.
- Rust: `cargo build --release` clean; new tests pass; broader
  `server::` (80) and `neighbor` (160) suites pass.

## Smoke deferral

Rust dataplane forwarding change — the loss-cluster iperf/functional
smoke is blocked by the shim-ABI wall, so it is **deferred**. Correctness
is gated on the Go + cargo fail-on-revert unit tests above.

## Deferred follow-up

This is the bounded clear-on-empty fix. The larger robustness envelope
from the issue closeout (replace-generation fencing, applied-generation
ACK, retry debt on failure, full wire-compat matrix) is deferred to
**#6034**.

Closes #5864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjaPvHW7ERQxfgxQCXfeia