### PR TITLE
daemon: reconcile cluster RA on config apply for stable-active RGs (#5861)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -19,17 +19,32 @@
   slice is aliased to the active config. Added `SeedDelegatedPrefixesForRATesting`
   test seam to `pkg/dhcp/test_seams.go` so the daemon test can model several PD
   sources feeding one RA interface.
+  Same fold, second per-poll-tick-spam site: `buildRAConfigs` logged
+  `slog.Info("DHCPv6 PD: advertising prefix via RA", …)` once per PD prefix. It
+  is a pure builder the periodic reconcile now re-runs every ~2s, so with PD
+  prefixes present that Info repeated every tick — per-poll-tick spam CLAUDE.md
+  forbids. Demoted to `slog.Debug` (gate-on-change would need stateful
+  bookkeeping in the pure builder — not clean; the one-time operational signal is
+  already carried by the reconcile's hash-gated apply Info). Scanned the whole
+  periodic path: the reconcile's own L76/L79 Info are hash-gated (fire only on an
+  actual apply, not every tick) and both Warn lines are error paths — left as-is;
+  daemon_ra.go:63 was the only unconditional per-tick Info.
   Validation: `go build ./...` clean; `go vet ./pkg/daemon ./pkg/dhcp` clean;
   `go test -race ./pkg/daemon` + `./pkg/dhcp` GREEN. New fail-on-revert test
   `TestClusterRAMultiPDPrefixOrderStableNoFlap` drives the periodic reconcile 64×
-  on a stable-active owner and asserts ra.Apply fires exactly ONCE (no digest
-  flap) AND the applied prefixes are in sorted order; neutralizing the sort
-  (build stays green) reds it verbatim: "cluster RA reconcile flapped: ra.Apply
-  called 13 times across 64 stable reconciles, want exactly 1". The two existing
-  #5861 tests (TestClusterRAStableActiveReappliesOnCommit /
+  on a stable-active owner and asserts (a) ra.Apply fires exactly ONCE (no digest
+  flap), (b) the applied prefixes are in sorted order, and (c) the PD-advertise
+  line does NOT reach an Info-level slog handler. Neutralizing the sort reds (a)
+  verbatim: "cluster RA reconcile flapped: ra.Apply called 13 times across 64
+  stable reconciles, want exactly 1"; reverting the Debug back to Info reds (c):
+  "buildRAConfigs logged the PD-advertise line at Info 256 times across 64
+  periodic reconciles". Both reverts keep the build GREEN (assertion failures,
+  not build breaks). The two existing #5861 tests
+  (TestClusterRAStableActiveReappliesOnCommit /
   TestClusterRADemotionRaceDoesNotTransmit) stay GREEN.
 - **File(s)**: pkg/daemon/daemon_ra_reconcile.go (within-interface prefix sort +
-  sortRAPrefixes), pkg/daemon/ra_stable_active_5861_test.go (new flap-guard
+  sortRAPrefixes), pkg/daemon/daemon_ra.go (demote per-tick PD-advertise Info →
+  Debug), pkg/daemon/ra_stable_active_5861_test.go (new flap-guard + no-Info-spam
   test), pkg/dhcp/test_seams.go (SeedDelegatedPrefixesForRATesting seam),
   pkg/daemon/README.md (per-RG RA reconcile idempotence: within-interface sort)
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-16 — #6036 fold: deterministic per-interface RA prefix order (#5861)
+
+- **Timestamp**: 2026-07-16 (fix/5861-ra-stable-active-reconcile)
+- **Action**: Folded the MERGE-READY reviewer MINOR on PR #6036. Root cause:
+  `desiredClusterRA` sorted the desired RA set BY interface but NOT the
+  `Prefixes` WITHIN each interface. `buildRAConfigs` appends DHCPv6-PD-delegated
+  prefixes in `DelegatedPrefixesForRA`'s map-iteration order (`m.delegatedPDs` is
+  a map). When 2+ delegated PDs target the SAME RA interface, their prefixes land
+  on one config's slice in nondeterministic order; because `raDesiredHash`
+  marshals order-sensitively and `ra.configEqual` compares prefixes
+  index-by-index, the new every-2s periodic cluster reconcile would FLAP the
+  digest → a spurious `ra.Apply` (sub-second RA gap) + a per-poll-tick apply log
+  (which the project's logging discipline forbids). Fix: `desiredClusterRA` now
+  sorts each interface's `Prefixes` by a stable total key (`sortRAPrefixes`:
+  Prefix string, then ValidLifetime/PreferredLife/OnLink/Autonomous tie-breaks;
+  nils last) after the by-interface sort. Safe to sort in place — `buildRAConfigs`
+  returns freshly-owned configs (static entries deep-cloned by
+  `cloneRAInterfaceConfig`, PD-only entries newly allocated), so no `Prefixes`
+  slice is aliased to the active config. Added `SeedDelegatedPrefixesForRATesting`
+  test seam to `pkg/dhcp/test_seams.go` so the daemon test can model several PD
+  sources feeding one RA interface.
+  Validation: `go build ./...` clean; `go vet ./pkg/daemon ./pkg/dhcp` clean;
+  `go test -race ./pkg/daemon` + `./pkg/dhcp` GREEN. New fail-on-revert test
+  `TestClusterRAMultiPDPrefixOrderStableNoFlap` drives the periodic reconcile 64×
+  on a stable-active owner and asserts ra.Apply fires exactly ONCE (no digest
+  flap) AND the applied prefixes are in sorted order; neutralizing the sort
+  (build stays green) reds it verbatim: "cluster RA reconcile flapped: ra.Apply
+  called 13 times across 64 stable reconciles, want exactly 1". The two existing
+  #5861 tests (TestClusterRAStableActiveReappliesOnCommit /
+  TestClusterRADemotionRaceDoesNotTransmit) stay GREEN.
+- **File(s)**: pkg/daemon/daemon_ra_reconcile.go (within-interface prefix sort +
+  sortRAPrefixes), pkg/daemon/ra_stable_active_5861_test.go (new flap-guard
+  test), pkg/dhcp/test_seams.go (SeedDelegatedPrefixesForRATesting seam),
+  pkg/daemon/README.md (per-RG RA reconcile idempotence: within-interface sort)
+
 ## 2026-07-16 — #5961 test: fail-on-revert cover config-sync transport wiring
 - **Timestamp**: 2026-07-16 (fix/5961-configsync-wiring-test)
 - **Action**: Closed the #5054 (PR #5958) test-coverage gap. The existing

--- a/_Log.md
+++ b/_Log.md
@@ -50501,3 +50501,43 @@ top.
   + pkg/config/compiler_nat_target_parity_hb167_test.go + pkg/config/
   compiler_nat_host_mask_test.go (updated to new fail-closed behavior),
   docs/config-schema.md (#5859 note)
+
+## 2026-07-16 — #5861 cluster RA stable-active reconcile-on-apply
+
+- **Timestamp**: 2026-07-16
+- **Action**: Fix High-severity RA convergence bug: config changes on a
+  stable-active cluster RG were never applied until an ownership transition.
+  In cluster mode the commit path deliberately SKIPPED `ra.Apply` (RA managed
+  by ownership events) and `reconcileRGState` re-applied RA only on an
+  `rg_active` transition (`if tr.Changed`). A day-2 RA edit on an RG that
+  stayed MASTER therefore kept advertising the OLD prefixes/lifetimes/options
+  until failover/restart. Added `reconcileClusterRAServices` — the single
+  authoritative cluster RA applier. It builds the desired set as the union of
+  `buildRAConfigs` filtered to the RGs this node is the CURRENT active owner
+  for (`snapshotRethMasterState`), hash-gates the apply (`lastRAReconcileHash`,
+  updated only on success), and serializes the ownership snapshot + `ra.Apply`
+  under a new `raReconcileMu`. Wired into the commit path
+  (`applyServicesReconcile` cluster branch), the periodic safety reconcile
+  (`reconcileRGState`, dropped-event net), and — unifying the RA path — the
+  VRRP MASTER/BACKUP transitions (`applyRethServicesForRG` /
+  `clearRethServicesForRG` now route RA through the reconciler). Demotion-race
+  guard: the demote path updates rg-state before driving the RA reconcile, so
+  under `raReconcileMu` the snapshot always reflects the true current owner at
+  apply time; an inactive owner never transmits, a removal emits the
+  lifetime-0 goodbye only from the current owner. Added a `raApplyFn` test
+  hook (mirrors `startupGoodbyeWithdrawFn`) to spy `ra.Apply`.
+  Validation: `go build ./...` clean; `go vet ./pkg/daemon ./pkg/ra` clean;
+  `go test -race ./pkg/daemon ./pkg/ra` GREEN (pkg/ra had one pre-existing
+  intermittent `-race` flake in `TestRestartTimeoutNoReplacementWhenNoGoodbye`
+  / `reclaimTombstoneWhenStopped` — untouched code, byte-identical to
+  origin/master, passes on isolation/rerun). Two new fail-on-revert tests,
+  both verbatim RED on revert.
+- **File(s)**: pkg/daemon/daemon.go (raReconcileMu / lastRAReconcileHash /
+  raApplyFn fields), pkg/daemon/daemon_ra_reconcile.go (new —
+  reconcileClusterRAServices + desiredClusterRA + raDesiredHash),
+  pkg/daemon/daemon_apply.go (commit-path cluster RA reconcile),
+  pkg/daemon/daemon_ha.go (applyRethServicesForRG / clearRethServicesForRG
+  route RA through the reconciler; reconcileRGState periodic safety pass),
+  pkg/daemon/ra_stable_active_5861_test.go (new — stable-active + demotion-race
+  fail-on-revert tests), pkg/daemon/README.md (Cluster mode: per-RG RA
+  reconcile section)

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -203,6 +203,41 @@ Detected by the presence of `/etc/xpf/node-id` (contents `0` or `1`).
 Absent → standalone. Cluster mode triggers the bondless-RETH naming
 convention (`fxp0`, `em0`, `ge-{0,7}-0-X`).
 
+### Per-RG Router-Advertisement reconcile (#5861)
+
+In cluster mode RA senders run ONLY on the RG that is the current active
+owner: the desired RA set is the union of `buildRAConfigs` filtered to the
+RGs this node is MASTER for. Every RA-affecting cluster event —
+a day-2 config commit, a VRRP MASTER/BACKUP transition, and a periodic
+dropped-event safety pass (`reconcileRGState`) — funnels through the single
+authoritative applier `reconcileClusterRAServices` (`daemon_ra_reconcile.go`).
+
+Before #5861 the cluster commit path SKIPPED `ra.Apply` (RA was managed
+only by ownership events) and `reconcileRGState` re-applied RA only on an
+`rg_active` transition (`if tr.Changed`). So a day-2 RA edit (add/remove
+prefix, change DNS/MTU/lifetimes/options) on an RG that stayed MASTER never
+reached `ra.Apply` and the primary kept advertising the OLD set until
+failover/restart. `reconcileClusterRAServices` now re-applies RA on the
+active owner whenever the effective desired set changes even when ownership
+is stable, and `ra.Apply` diffs safely (no RA gap for unchanged senders).
+
+**Owner gating + demotion-race guard.** The desired set is built from
+`snapshotRethMasterState()` — an RG's interfaces are included ONLY while
+this node is its active owner. The ownership snapshot and the `ra.Apply`
+run under `raReconcileMu`, and the VRRP demote path updates rg-state
+(`SetVRRP`/`Reconcile`) BEFORE it drives the RA reconcile. So a config apply
+that races a demotion either snapshots the RG as already-inactive (its
+senders are withdrawn / never armed) or snapshots it active — in which case
+the node genuinely was the owner at apply time and the demote's own reconcile
+pass, serialized behind this one on `raReconcileMu`, withdraws immediately
+after. An inactive owner never transmits; a removal emits the lifetime-0
+goodbye only from the current owner (`ra.Apply`'s graceful-withdraw path).
+
+**Idempotence.** A stable digest of the desired set (`lastRAReconcileHash`,
+updated only on a successful apply) gates the actual `ra.Apply`, so the
+periodic safety pass costs nothing when nothing moved and a transient apply
+error is retried on the next pass rather than latched as converged.
+
 ### Direct-mode VIP failover (private-rg-election / no-reth-vrrp)
 
 When `no-reth-vrrp` or `private-rg-election` is configured, the daemon owns

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -246,6 +246,9 @@ the digest marshals order-sensitively and `ra.configEqual` compares prefixes
 index-by-index, the every-2s reconcile would FLAP the hash and spuriously
 re-apply RA (a sub-second RA gap + a per-poll-tick apply log). The in-place sort
 is safe because `buildRAConfigs` returns freshly-owned configs (#6036).
+Relatedly, `buildRAConfigs` is a pure builder the periodic reconcile now re-runs
+every tick, so its per-PD-prefix "advertising prefix via RA" line logs at
+`slog.Debug`, not `Info` — an `Info` there would be per-poll-tick spam (#6036).
 
 ### Direct-mode VIP failover (private-rg-election / no-reth-vrrp)
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -236,7 +236,16 @@ goodbye only from the current owner (`ra.Apply`'s graceful-withdraw path).
 **Idempotence.** A stable digest of the desired set (`lastRAReconcileHash`,
 updated only on a successful apply) gates the actual `ra.Apply`, so the
 periodic safety pass costs nothing when nothing moved and a transient apply
-error is retried on the next pass rather than latched as converged.
+error is retried on the next pass rather than latched as converged. For the
+digest to be stable, `desiredClusterRA` sorts the desired set both BY interface
+(the ownership snapshot iterates maps) AND, within each interface, its
+`Prefixes` slice (`sortRAPrefixes`). Without the within-interface sort, 2+
+DHCPv6-PD-delegated prefixes targeting one RA interface would append in
+`DelegatedPrefixesForRA`'s map-iteration order — nondeterministic — and, because
+the digest marshals order-sensitively and `ra.configEqual` compares prefixes
+index-by-index, the every-2s reconcile would FLAP the hash and spuriously
+re-apply RA (a sub-second RA gap + a per-poll-tick apply log). The in-place sort
+is safe because `buildRAConfigs` returns freshly-owned configs (#6036).
 
 ### Direct-mode VIP failover (private-rg-election / no-reth-vrrp)
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -705,6 +705,32 @@ type Daemon struct {
 	// (#5093). Nil means use d.ra.WithdrawOnce.
 	startupGoodbyeWithdrawFn func([]*config.RAInterfaceConfig) []ra.GoodbyeResult
 
+	// Cluster RA convergence (#5861). In cluster mode RA senders run ONLY on
+	// the RG that is the current active owner; the desired RA set is the union
+	// of buildRAConfigs filtered to the currently-active RGs. reconcileClusterRA
+	// funnels EVERY cluster RA transition — a day-2 config commit, a VRRP
+	// MASTER/BACKUP transition, and a periodic dropped-event safety pass —
+	// through one owner-gated + serialized applier so a config edit on a
+	// stable-active RG (no ownership transition) actually re-applies RA instead
+	// of stranding stale prefixes/lifetimes/options until the next failover.
+	//
+	// raReconcileMu serializes the ownership snapshot and the ra.Apply so a
+	// config apply cannot race a demotion and re-arm/transmit RA on a node that
+	// just became inactive (the demotion-race guard): the VRRP demote path
+	// updates rg-state BEFORE taking this lock to withdraw, so under the lock
+	// the snapshot always reflects the true current owner at apply time.
+	//
+	// lastRAReconcileHash is the digest of the last successfully applied desired
+	// set (empty = no senders). A matching hash short-circuits the periodic pass
+	// so it costs nothing when nothing changed; a mismatch (config edit, PD
+	// prefix change, or ownership move) drives ra.Apply, which diffs safely.
+	//
+	// raApplyFn is the ra.Apply entry point; overridable in tests to spy on the
+	// applied desired set. Nil means use d.ra.Apply.
+	raReconcileMu       sync.Mutex
+	lastRAReconcileHash string
+	raApplyFn           func([]*config.RAInterfaceConfig) error
+
 	// startupActiveAnnounce tracks whether the one-shot active-side
 	// neighbor refresh has been sent for each RG on this daemon run.
 	// This covers restart/redeploy of an already-active direct-mode RG,

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1584,6 +1584,17 @@ func (d *Daemon) applyServicesReconcile(cfg *config.Config) (error, error) {
 	// the reconcile loop sends goodbye RAs for inactive RGs.
 	//
 	// Stable link-local cleanup: handled by reconcile after election.
+	//
+	// #5861: a day-2 RA edit on an RG that stays MASTER never fires a VRRP
+	// event, so pre-#5861 the primary kept advertising the OLD prefixes/
+	// lifetimes/options until failover/restart. Reconcile the cluster RA
+	// senders against the union of buildRAConfigs for the RGs this node is
+	// CURRENTLY the active owner for — owner-gated + serialized so a commit
+	// racing a demotion can't re-arm RA on a now-inactive node. Hash-gated:
+	// a no-op when the effective RA set for the owned RGs did not change.
+	if isCluster {
+		d.reconcileClusterRAServices("commit")
+	}
 
 	// 6. Apply IPsec config
 	// Always call Apply so stale swanctl config is removed when VPNs are

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -869,6 +869,14 @@ func (d *Daemon) reconcileRGState() {
 	if anyRGChanged {
 		d.reconcileIPMonGating()
 	}
+
+	// #5861: dropped-event safety net. A VRRP event that started/stopped RA
+	// could be lost (event queue overflow, restart mid-transition), or a day-2
+	// RA edit on a stable-active RG could have landed while this node was
+	// already MASTER. Reconcile the cluster RA senders to the current active
+	// owners every pass — hash-gated, so it is a no-op when the effective RA
+	// set did not move, and re-applies (via ra.Apply's safe diff) when it did.
+	d.reconcileClusterRAServices("reconcile")
 }
 
 // startupGoodbyeNeeded reports whether the cold-boot one-shot goodbye still
@@ -1093,44 +1101,12 @@ func (d *Daemon) applyRethServicesForRG(rgID int) {
 	if cfg == nil {
 		return
 	}
-	rgIfaces := rethInterfacesForRG(cfg, rgID)
-	rgIfaceSet := make(map[string]bool, len(rgIfaces))
-	for _, n := range rgIfaces {
-		rgIfaceSet[n] = true
-	}
-
-	if d.ra != nil {
-		allRA := d.buildRAConfigs(cfg)
-		var rgRA []*config.RAInterfaceConfig
-		for _, ra := range allRA {
-			if rgIfaceSet[ra.Interface] {
-				rgRA = append(rgRA, ra)
-			}
-		}
-		// Collect RA configs from ALL master RGs (not just this one).
-		for otherRG, isMaster := range d.snapshotRethMasterState() {
-			if !isMaster || otherRG == rgID {
-				continue
-			}
-			otherIfaces := rethInterfacesForRG(cfg, otherRG)
-			otherSet := make(map[string]bool, len(otherIfaces))
-			for _, n := range otherIfaces {
-				otherSet[n] = true
-			}
-			for _, ra := range allRA {
-				if otherSet[ra.Interface] {
-					rgRA = append(rgRA, ra)
-				}
-			}
-		}
-		if len(rgRA) > 0 {
-			if err := d.ra.Apply(rgRA); err != nil {
-				slog.Warn("vrrp: failed to apply RA on MASTER", "rg", rgID, "err", err)
-			} else {
-				slog.Info("vrrp: RA senders started (MASTER)", "rg", rgID)
-			}
-		}
-	}
+	// RA senders (#5861): converge to the union of RA configs for every RG
+	// this node is currently the active owner for. reconcileClusterRAServices
+	// snapshots ownership + applies under raReconcileMu so this MASTER apply
+	// cannot race a concurrent commit/demotion; the state machine already
+	// marked rgID active before this call, so the snapshot includes it.
+	d.reconcileClusterRAServices(fmt.Sprintf("vrrp-master-rg%d", rgID))
 	if d.dhcpServer != nil && (cfg.System.DHCPServer.DHCPLocalServer != nil || cfg.System.DHCPServer.DHCPv6LocalServer != nil) {
 		dhcpCfg := d.filterDHCPConfigForMasterRGs(cfg)
 		if dhcpCfg != nil {
@@ -1198,19 +1174,14 @@ func (d *Daemon) clearRethServicesForRG(rgID int) {
 		}
 	}
 
-	if d.ra != nil {
-		if anyOtherMaster {
-			// Withdraw only this RG's interfaces; reapply others.
-			rgIfaces := rethInterfacesForRG(cfg, rgID)
-			d.ra.WithdrawInterfaces(rgIfaces)
-		} else {
-			if err := d.ra.Withdraw(); err != nil {
-				slog.Warn("vrrp: failed to withdraw RA on BACKUP", "rg", rgID, "err", err)
-			} else {
-				slog.Info("vrrp: RA withdrawn (BACKUP, goodbye RA sent)", "rg", rgID)
-			}
-		}
-	}
+	// RA senders (#5861): converge to the union of RA configs for the RGs this
+	// node still owns. The state machine already marked rgID inactive before
+	// this call, so reconcileClusterRAServices drops rgID's interfaces from the
+	// desired set — ra.Apply emits the lifetime-0 goodbye for them and leaves
+	// any still-owned RG's senders running (subsuming the prior
+	// WithdrawInterfaces / Withdraw split). Owner-gated + serialized so a
+	// concurrent commit cannot re-arm the demoted RG's senders.
+	d.reconcileClusterRAServices(fmt.Sprintf("vrrp-backup-rg%d", rgID))
 	if d.dhcpServer != nil {
 		// ApplyAsync on both branches (#1835 F2): keeps this VRRP
 		// event loop off the 15s-bounded systemctl path AND funnels

--- a/pkg/daemon/daemon_ra.go
+++ b/pkg/daemon/daemon_ra.go
@@ -60,7 +60,13 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 				result = append(result, ra)
 			}
 
-			slog.Info("DHCPv6 PD: advertising prefix via RA",
+			// Debug, not Info: buildRAConfigs is a pure builder now re-run on
+			// every ~2s periodic cluster RA reconcile (reconcileClusterRAServices),
+			// so this line would repeat per PD prefix every tick — per-poll-tick
+			// Info spam the logging discipline forbids. The one-time operational
+			// signal ("a PD prefix is being advertised") belongs on the actual
+			// apply, which the reconcile's hash-gated Info already carries.
+			slog.Debug("DHCPv6 PD: advertising prefix via RA",
 				"prefix", subPrefix, "interface", mapping.RAIface,
 				"delegated_from", mapping.Interface)
 		}

--- a/pkg/daemon/daemon_ra_reconcile.go
+++ b/pkg/daemon/daemon_ra_reconcile.go
@@ -109,7 +109,49 @@ func (d *Daemon) desiredClusterRA(cfg *config.Config) []*config.RAInterfaceConfi
 	sort.Slice(desired, func(i, j int) bool {
 		return desired[i].Interface < desired[j].Interface
 	})
+	// Sort the prefixes WITHIN each interface too. buildRAConfigs appends
+	// DHCPv6-PD-delegated prefixes in DelegatedPrefixesForRA's map-iteration
+	// order (m.delegatedPDs is a map), so when 2+ delegated PDs target the same
+	// RA interface their prefixes land on one config's slice in nondeterministic
+	// order. raDesiredHash marshals order-sensitively and ra.configEqual compares
+	// prefixes index-by-index, so an unsorted order would flap the digest and make
+	// the every-2s periodic reconcile spuriously re-apply RA (a sub-second RA gap
+	// + a per-poll-tick apply log). Sorting here gives a stable, total order.
+	// This is safe to do in place: buildRAConfigs returns freshly-owned configs
+	// (static entries are deep-cloned by cloneRAInterfaceConfig, PD-only entries
+	// are newly allocated), so no Prefixes slice is aliased to the active config.
+	for _, ra := range desired {
+		sortRAPrefixes(ra.Prefixes)
+	}
 	return desired
+}
+
+// sortRAPrefixes orders an RA interface's advertised prefixes by a stable, total
+// key so the desired-set digest and ra.configEqual observe a deterministic order
+// regardless of the source (map-iteration) order. nil entries sort last so a
+// slice carrying a nil placeholder still has a total order. Callers must own the
+// slice (see desiredClusterRA's in-place-sort safety note).
+func sortRAPrefixes(prefixes []*config.RAPrefix) {
+	sort.SliceStable(prefixes, func(i, j int) bool {
+		a, b := prefixes[i], prefixes[j]
+		if a == nil || b == nil {
+			// Non-nil before nil; two nils compare equal (stable keeps order).
+			return a != nil && b == nil
+		}
+		if a.Prefix != b.Prefix {
+			return a.Prefix < b.Prefix
+		}
+		if a.ValidLifetime != b.ValidLifetime {
+			return a.ValidLifetime < b.ValidLifetime
+		}
+		if a.PreferredLife != b.PreferredLife {
+			return a.PreferredLife < b.PreferredLife
+		}
+		if a.OnLink != b.OnLink {
+			return !a.OnLink // false sorts before true
+		}
+		return !a.Autonomous && b.Autonomous
+	})
 }
 
 // raDesiredHash returns a stable digest of the desired RA set. An empty set

--- a/pkg/daemon/daemon_ra_reconcile.go
+++ b/pkg/daemon/daemon_ra_reconcile.go
@@ -1,0 +1,131 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"sort"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// reconcileClusterRAServices converges the cluster RA senders to the union of
+// buildRAConfigs filtered to the RGs this node is the CURRENT active owner for
+// (#5861). It is the single authoritative cluster RA applier: every RA-affecting
+// cluster event — a day-2 config commit, a VRRP MASTER/BACKUP transition, and
+// the periodic dropped-event safety pass in reconcileRGState — funnels through
+// it. Standalone (non-cluster) mode is a no-op here; that path applies RA
+// directly in applyServicesReconcile.
+//
+// The pre-#5861 bug: a config commit in cluster mode SKIPPED ra.Apply (RA was
+// managed only by ownership events) and the reconcile loop re-applied RA only
+// on an rg_active transition (`if tr.Changed`). So a day-2 RA edit (add/remove
+// prefix, change DNS/MTU/lifetime) on an RG that stayed MASTER never reached
+// ra.Apply and the primary kept advertising the OLD set until failover/restart.
+//
+// Owner gating + demotion-race guard: the desired set is built from
+// snapshotRethMasterState() — an RG's interfaces are included ONLY while this
+// node is its active owner. The ownership snapshot and the ra.Apply run under
+// raReconcileMu, and the VRRP demote path updates rg-state (SetVRRP/Reconcile)
+// BEFORE it calls this function, so a config apply that races a demotion either
+// snapshots the RG as already-inactive (its senders are withdrawn / never
+// armed) or snapshots it active — in which case the node genuinely was the
+// owner at apply time and the demote's own reconcile pass, serialized behind
+// this one on raReconcileMu, withdraws immediately after. An inactive owner
+// never transmits; a removal emits the lifetime-0 goodbye only from the current
+// owner (ra.Apply's graceful-withdraw path).
+//
+// Idempotence: a stable digest of the desired set (lastRAReconcileHash) gates
+// the actual ra.Apply, so the periodic safety pass is free when nothing moved.
+// The digest is updated only on a successful apply, so a transient apply error
+// is retried on the next pass rather than being latched as converged.
+func (d *Daemon) reconcileClusterRAServices(reason string) {
+	d.raReconcileMu.Lock()
+	defer d.raReconcileMu.Unlock()
+
+	if d.store == nil {
+		return
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil || cfg.Chassis.Cluster == nil {
+		// Standalone mode owns RA directly in applyServicesReconcile.
+		return
+	}
+
+	apply := d.raApplyFn
+	if apply == nil {
+		if d.ra == nil {
+			return
+		}
+		apply = d.ra.Apply
+	}
+
+	desired := d.desiredClusterRA(cfg)
+	newHash := raDesiredHash(desired)
+	if newHash == d.lastRAReconcileHash {
+		return
+	}
+
+	if err := apply(desired); err != nil {
+		slog.Warn("ra: cluster RA reconcile failed; will retry",
+			"reason", reason, "err", err)
+		return
+	}
+	if len(desired) > 0 {
+		slog.Info("ra: cluster RA reconciled to current active owners",
+			"reason", reason, "interfaces", len(desired))
+	} else if d.lastRAReconcileHash != "" {
+		slog.Info("ra: cluster RA withdrawn (no active owner)", "reason", reason)
+	}
+	d.lastRAReconcileHash = newHash
+}
+
+// desiredClusterRA returns the union of buildRAConfigs entries whose interface
+// belongs to an RG this node is currently the active owner for. The union is
+// sorted by interface name so the digest is stable across map-iteration order
+// (snapshotRethMasterState and rethInterfacesForRG both iterate maps). Callers
+// must hold raReconcileMu.
+func (d *Daemon) desiredClusterRA(cfg *config.Config) []*config.RAInterfaceConfig {
+	ownedIfaces := make(map[string]bool)
+	for rgID, active := range d.snapshotRethMasterState() {
+		if !active {
+			continue
+		}
+		for _, n := range rethInterfacesForRG(cfg, rgID) {
+			ownedIfaces[n] = true
+		}
+	}
+	if len(ownedIfaces) == 0 {
+		return nil
+	}
+
+	var desired []*config.RAInterfaceConfig
+	for _, ra := range d.buildRAConfigs(cfg) {
+		if ownedIfaces[ra.Interface] {
+			desired = append(desired, ra)
+		}
+	}
+	sort.Slice(desired, func(i, j int) bool {
+		return desired[i].Interface < desired[j].Interface
+	})
+	return desired
+}
+
+// raDesiredHash returns a stable digest of the desired RA set. An empty set
+// hashes to "" so a pure-backup node (no active owner) matches the zero-value
+// lastRAReconcileHash and never issues a spurious withdraw. A non-empty set
+// hashes to a 64-char hex digest, which can never collide with "".
+func raDesiredHash(desired []*config.RAInterfaceConfig) string {
+	if len(desired) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(desired)
+	if err != nil {
+		// Marshal of exported-field structs cannot fail in practice; fall back
+		// to a value that forces an apply rather than a false cache hit.
+		return "unhashable"
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/daemon/ra_stable_active_5861_test.go
+++ b/pkg/daemon/ra_stable_active_5861_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"context"
+	"log/slog"
 	"net/netip"
 	"path/filepath"
 	"reflect"
@@ -13,6 +15,40 @@ import (
 	"github.com/psaab/xpf/pkg/dhcp"
 	"golang.org/x/sync/semaphore"
 )
+
+// recordingSlogHandler records the messages of every slog record it is asked to
+// handle at or above its level, so a test can assert whether a particular log
+// line fired (and how often). Used to prove a per-poll-tick line was demoted
+// below Info (#6036).
+type recordingSlogHandler struct {
+	mu    sync.Mutex
+	level slog.Level
+	msgs  []string
+}
+
+func (h *recordingSlogHandler) Enabled(_ context.Context, l slog.Level) bool { return l >= h.level }
+
+func (h *recordingSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, r.Message)
+	return nil
+}
+
+func (h *recordingSlogHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordingSlogHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *recordingSlogHandler) count(msg string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, m := range h.msgs {
+		if m == msg {
+			n++
+		}
+	}
+	return n
+}
 
 // raApplySpy records every desired set handed to ra.Apply so a test can assert
 // exactly what the daemon would transmit. It stands in for the concrete
@@ -269,6 +305,15 @@ func TestClusterRAMultiPDPrefixOrderStableNoFlap(t *testing.T) {
 	// Stable-active owner of RG1 — no transition for the rest of the test.
 	d.getOrCreateRGState(1).SetVRRP("reth0", true)
 
+	// Capture Info+ logs so we can prove buildRAConfigs' per-PD-prefix line does
+	// NOT fire on the periodic path (it is a pure builder re-run every ~2s, so an
+	// Info there is per-poll-tick spam — #6036). The handler drops anything below
+	// Info, so a correctly-demoted slog.Debug is invisible here.
+	rec := &recordingSlogHandler{level: slog.LevelInfo}
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(rec))
+	defer slog.SetDefault(prevLogger)
+
 	// Drive the periodic reconcile many times. Each pass re-derives the desired
 	// set (re-ranging m.delegatedPDs), so the digest must be invariant to the
 	// map order for the hash gate to hold ra.Apply at a single call.
@@ -296,5 +341,16 @@ func TestClusterRAMultiPDPrefixOrderStableNoFlap(t *testing.T) {
 		if !contains(got, p) {
 			t.Fatalf("applied RA set dropped prefix %s; got %v", p, got)
 		}
+	}
+
+	// buildRAConfigs runs on EVERY periodic pass (desiredClusterRA re-derives the
+	// set each tick), so its per-PD-prefix advertise line must be below Info or it
+	// is per-poll-tick spam. With the demote to slog.Debug it never reaches the
+	// Info-level handler. Reverting daemon_ra.go's slog.Debug back to slog.Info
+	// makes it fire once per PD prefix per pass (4*64) → this reds.
+	if n := rec.count("DHCPv6 PD: advertising prefix via RA"); n != 0 {
+		t.Fatalf("buildRAConfigs logged the PD-advertise line at Info %d times across "+
+			"%d periodic reconciles — per-poll-tick Info spam; it must be slog.Debug (#6036)",
+			n, passes)
 	}
 }

--- a/pkg/daemon/ra_stable_active_5861_test.go
+++ b/pkg/daemon/ra_stable_active_5861_test.go
@@ -1,12 +1,16 @@
 package daemon
 
 import (
+	"net/netip"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"sync"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dhcp"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -208,6 +212,89 @@ func TestClusterRADemotionRaceDoesNotTransmit(t *testing.T) {
 		if ra.Interface == "ge-0-0-0.50" {
 			t.Fatalf("demoted node's desired set still includes %s — the owner "+
 				"gate did not drop the demoted RG", ra.Interface)
+		}
+	}
+}
+
+// TestClusterRAMultiPDPrefixOrderStableNoFlap is the #6036 fold guard. When 2+
+// DHCPv6-PD-delegated prefixes target the SAME RA interface, buildRAConfigs
+// appends them in DelegatedPrefixesForRA's map-iteration order (m.delegatedPDs
+// is a map — nondeterministic across ranges). raDesiredHash marshals
+// order-sensitively and ra.configEqual compares prefixes index-by-index, so an
+// unsorted within-interface order makes the every-2s periodic cluster reconcile
+// FLAP the desired-set digest → a spurious ra.Apply (sub-second RA gap + a
+// per-poll-tick apply log the project's logging discipline forbids).
+//
+// desiredClusterRA now sorts each interface's Prefixes by a stable total key, so
+// the digest is invariant to the source order. This test seeds two PD sources
+// feeding one RA interface (reth0.50), runs reconcileClusterRAServices many times
+// on a stable-active owner, and asserts BOTH:
+//
+//   - ra.Apply is called exactly ONCE across all passes (the hash never flaps),
+//     and
+//   - the applied prefixes are in deterministic sorted order.
+//
+// Reverting the sort (the `for _, ra := range desired { sortRAPrefixes(...) }`
+// loop in desiredClusterRA) reds both assertions: the applied prefixes come out
+// in map order (not sorted → second assertion RED) and that order varies between
+// passes (digest flaps → ra.Apply re-fires → first assertion RED).
+func TestClusterRAMultiPDPrefixOrderStableNoFlap(t *testing.T) {
+	// Static RA prefix sorts into the MIDDLE of the PD prefixes, so no
+	// map-iteration interleaving of the two PD sources yields a globally sorted
+	// sequence — the sorted-order assertion is deterministically RED on revert.
+	const staticPrefix = "2001:db8:50::/64"
+	s := raClusterStore(t, staticPrefix)
+
+	// Two PD sources, each contributing two /64s to the SAME RA interface
+	// (reth0.50). Each source's own slice is reverse-sorted; combined with the
+	// nondeterministic cross-source map order, the pre-fix append order is never
+	// sorted.
+	mgr := dhcp.NewManagerForTesting(nil)
+	mgr.SeedDelegatedPrefixesForRATesting("ge-0/0/3", "reth0.50", []dhcp.DelegatedPrefix{
+		{Interface: "ge-0/0/3", Prefix: netip.MustParsePrefix("2001:db8:40::/64")},
+		{Interface: "ge-0/0/3", Prefix: netip.MustParsePrefix("2001:db8:10::/64")},
+	})
+	mgr.SeedDelegatedPrefixesForRATesting("ge-0/0/4", "reth0.50", []dhcp.DelegatedPrefix{
+		{Interface: "ge-0/0/4", Prefix: netip.MustParsePrefix("2001:db8:90::/64")},
+		{Interface: "ge-0/0/4", Prefix: netip.MustParsePrefix("2001:db8:60::/64")},
+	})
+
+	spy := &raApplySpy{}
+	d := &Daemon{
+		store:     s,
+		dhcp:      mgr,
+		rgStates:  make(map[int]*rgStateMachine),
+		raApplyFn: spy.apply,
+	}
+	// Stable-active owner of RG1 — no transition for the rest of the test.
+	d.getOrCreateRGState(1).SetVRRP("reth0", true)
+
+	// Drive the periodic reconcile many times. Each pass re-derives the desired
+	// set (re-ranging m.delegatedPDs), so the digest must be invariant to the
+	// map order for the hash gate to hold ra.Apply at a single call.
+	const passes = 64
+	for i := 0; i < passes; i++ {
+		d.reconcileClusterRAServices("periodic")
+	}
+
+	if got := spy.count(); got != 1 {
+		t.Fatalf("cluster RA reconcile flapped: ra.Apply called %d times across %d "+
+			"stable reconciles, want exactly 1 (unsorted per-interface prefix order "+
+			"made the desired-set digest nondeterministic — #6036)", got, passes)
+	}
+
+	got := spy.lastPrefixes()
+	want := append([]string(nil), got...)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("applied RA prefixes are not in deterministic sorted order:\n got  %v\n want %v\n"+
+			"(desiredClusterRA must sort each interface's Prefixes — #6036)", got, want)
+	}
+	// Sanity: every seeded prefix plus the static one made it through.
+	for _, p := range []string{staticPrefix, "2001:db8:40::/64", "2001:db8:10::/64",
+		"2001:db8:90::/64", "2001:db8:60::/64"} {
+		if !contains(got, p) {
+			t.Fatalf("applied RA set dropped prefix %s; got %v", p, got)
 		}
 	}
 }

--- a/pkg/daemon/ra_stable_active_5861_test.go
+++ b/pkg/daemon/ra_stable_active_5861_test.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"golang.org/x/sync/semaphore"
+)
+
+// raApplySpy records every desired set handed to ra.Apply so a test can assert
+// exactly what the daemon would transmit. It stands in for the concrete
+// *ra.Manager via the d.raApplyFn hook (mirrors startupGoodbyeWithdrawFn, #5093).
+type raApplySpy struct {
+	mu    sync.Mutex
+	calls [][]*config.RAInterfaceConfig
+}
+
+func (s *raApplySpy) apply(desired []*config.RAInterfaceConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Copy the slice header so a later in-place reuse by the caller cannot
+	// mutate a recorded call.
+	cp := append([]*config.RAInterfaceConfig(nil), desired...)
+	s.calls = append(s.calls, cp)
+	return nil
+}
+
+func (s *raApplySpy) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+func (s *raApplySpy) last() []*config.RAInterfaceConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.calls) == 0 {
+		return nil
+	}
+	return s.calls[len(s.calls)-1]
+}
+
+// appliedPrefixes flattens the prefixes of the last applied desired set.
+func (s *raApplySpy) lastPrefixes() []string {
+	var out []string
+	for _, ra := range s.last() {
+		for _, p := range ra.Prefixes {
+			out = append(out, p.Prefix)
+		}
+	}
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// raClusterStore builds a real config store committing a single-reth cluster
+// config: reth0 in RG1 (members ge-0/0/0 node0 + ge-7/0/0 node1), unit 50 tagged
+// VLAN 50, and a router-advertisement on reth0.50 advertising `prefix`. The
+// resolved RA interface is "ge-0-0-0.50" (verified against rethInterfacesForRG).
+func raClusterStore(t *testing.T, prefix string) *configstore.Store {
+	t.Helper()
+	s, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.LoadSet(
+		"set chassis cluster cluster-id 1\n" +
+			"set chassis cluster node 0\n" +
+			"set chassis cluster redundancy-group 1 node 0 priority 200\n" +
+			"set chassis cluster redundancy-group 1 node 1 priority 100\n" +
+			"set interfaces reth0 redundant-ether-options redundancy-group 1\n" +
+			"set interfaces reth0 unit 50 vlan-id 50\n" +
+			"set interfaces ge-0/0/0 gigether-options redundant-parent reth0\n" +
+			"set interfaces ge-7/0/0 gigether-options redundant-parent reth0\n" +
+			"set protocols router-advertisement interface reth0.50 prefix " + prefix + "\n",
+	); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	s.ExitConfigure()
+	return s
+}
+
+// TestClusterRAStableActiveReappliesOnCommit is the #5861 stable-active
+// regression. A day-2 RA edit (a new prefix added) on an RG that stays MASTER —
+// with NO ownership transition — must re-apply RA on this active owner. Before
+// #5861 the cluster commit path SKIPPED ra.Apply (RA was managed only by VRRP
+// ownership events) and the reconcile loop re-applied RA only on an rg_active
+// transition (`if tr.Changed`), so the primary kept advertising the OLD prefix
+// set until failover/restart.
+//
+// The test drives the real commit entrypoint (applyServicesReconcile) so it
+// binds the actual wiring: reverting the fix (deleting the
+// `if isCluster { d.reconcileClusterRAServices("commit") }` call) makes the spy
+// never see the new prefix on the stable-active RG → RED.
+func TestClusterRAStableActiveReappliesOnCommit(t *testing.T) {
+	const p1 = "2001:db8:1::/64"
+	const p2 = "2001:db8:aaaa::/64" // added day-2, no ownership change
+
+	s := raClusterStore(t, p1)
+	spy := &raApplySpy{}
+	d := &Daemon{
+		store:     s,
+		applySem:  semaphore.NewWeighted(1),
+		rgStates:  make(map[int]*rgStateMachine),
+		raApplyFn: spy.apply,
+	}
+	// This node is the CURRENT active owner of RG1 (MASTER). No transition
+	// happens for the rest of the test — ownership is stable.
+	d.getOrCreateRGState(1).SetVRRP("reth0", true)
+
+	// Initial commit while MASTER: RA senders come up advertising p1.
+	if _, _ = d.applyServicesReconcile(s.ActiveConfig()); spy.count() == 0 {
+		t.Fatal("initial cluster commit did not apply RA on the active owner")
+	}
+	if got := spy.lastPrefixes(); !contains(got, p1) {
+		t.Fatalf("initial apply missing %s; got prefixes %v", p1, got)
+	}
+	initialCalls := spy.count()
+
+	// Day-2 RA edit: add prefix p2. Ownership does NOT change.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.LoadSet(
+		"set protocols router-advertisement interface reth0.50 prefix " + p2 + "\n"); err != nil {
+		t.Fatalf("LoadSet day-2 edit: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit day-2 edit: %v", err)
+	}
+	s.ExitConfigure()
+
+	// The commit reconcile MUST re-apply RA with the new desired set even though
+	// no VRRP/cluster transition occurred (#5861 core fix).
+	d.applyServicesReconcile(s.ActiveConfig())
+	if spy.count() == initialCalls {
+		t.Fatal("day-2 RA edit on a stable-active RG did not reach ra.Apply " +
+			"(the #5861 bug — RA never re-applies without an ownership transition)")
+	}
+	got := spy.lastPrefixes()
+	if !contains(got, p2) {
+		t.Fatalf("stable-active re-apply missing the newly-added prefix %s; got %v", p2, got)
+	}
+	if !contains(got, p1) {
+		t.Fatalf("stable-active re-apply dropped the retained prefix %s; got %v", p1, got)
+	}
+}
+
+// TestClusterRADemotionRaceDoesNotTransmit is the #5861 demotion-race guard. A
+// config apply that RACES a demotion — the node was MASTER for RG1 when the
+// commit began but rg-state flipped to BACKUP before the RA apply — must NOT
+// re-arm/transmit RA on the now-inactive node. The guard is the at-apply-time
+// owner check in desiredClusterRA: the desired set is filtered by the ownership
+// snapshot taken under raReconcileMu, and the demote path updates rg-state
+// BEFORE it drives the RA reconcile, so under the lock the snapshot always
+// reflects the true current owner.
+//
+// Reverting the guard (dropping the `if !active { continue }` owner filter in
+// desiredClusterRA) makes the demoted node keep RG1's interface in the desired
+// set → the stale senders keep transmitting → RED.
+func TestClusterRADemotionRaceDoesNotTransmit(t *testing.T) {
+	const p1 = "2001:db8:1::/64"
+	s := raClusterStore(t, p1)
+	spy := &raApplySpy{}
+	d := &Daemon{
+		store:     s,
+		rgStates:  make(map[int]*rgStateMachine),
+		raApplyFn: spy.apply,
+	}
+
+	// Node is MASTER for RG1: prime the active RA senders (advertising p1).
+	d.getOrCreateRGState(1).SetVRRP("reth0", true)
+	d.reconcileClusterRAServices("commit")
+	if !contains(spy.lastPrefixes(), p1) {
+		t.Fatalf("precondition: active owner must advertise %s; got %v", p1, spy.lastPrefixes())
+	}
+
+	// DEMOTION: rg-state flips to BACKUP (this is exactly what the VRRP demote
+	// path does BEFORE it drives the RA withdraw). The commit that was in flight
+	// now reaches its RA apply — but the node is no longer the owner.
+	d.getOrCreateRGState(1).SetVRRP("reth0", false)
+	d.reconcileClusterRAServices("commit-racing-demotion")
+
+	// The now-inactive node must NOT be transmitting RG1's RA. The last apply is
+	// a withdraw (empty desired set), and no recorded apply after the demotion
+	// carries the demoted interface.
+	if got := spy.lastPrefixes(); len(got) != 0 {
+		t.Fatalf("demoted node still transmitting RA prefixes %v — demotion-race "+
+			"guard failed (re-armed RA on an inactive owner)", got)
+	}
+	for _, ra := range spy.last() {
+		if ra.Interface == "ge-0-0-0.50" {
+			t.Fatalf("demoted node's desired set still includes %s — the owner "+
+				"gate did not drop the demoted RG", ra.Interface)
+		}
+	}
+}

--- a/pkg/dhcp/test_seams.go
+++ b/pkg/dhcp/test_seams.go
@@ -49,6 +49,25 @@ func NewManagerForTestingWithHooks(runClient func(ctx context.Context, ifaceName
 	}
 }
 
+// SeedDelegatedPrefixesForRATesting installs delegated prefixes under
+// sourceIface (preserving the given slice order within that source) and points
+// that source's DHCPv6 RA target at raIface, so DelegatedPrefixesForRA surfaces
+// them. Calling it with distinct sourceIface values but the same raIface models
+// several PD sources feeding one RA interface — the cross-source iteration order
+// is then map-nondeterministic, exactly the #6036 hash-flap input. Test-only;
+// not for production callers.
+func (m *Manager) SeedDelegatedPrefixesForRATesting(sourceIface, raIface string, pds []DelegatedPrefix) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.delegatedPDs[sourceIface] = append(m.delegatedPDs[sourceIface], pds...)
+	opts := m.v6opts[sourceIface]
+	if opts == nil {
+		opts = &DHCPv6Options{}
+		m.v6opts[sourceIface] = opts
+	}
+	opts.RAIface = raIface
+}
+
 // RunningClientHandlesForTesting returns an opaque handle per running
 // client keyed "iface/4" or "iface/6". Handles compare equal across
 // calls iff the same client goroutine is still registered — tests use


### PR DESCRIPTION
## Summary

Fixes #5861 (High): in cluster mode a commit rebuilt the router-advertisement
configs but deliberately **skipped `ra.Apply`** (RA was managed only by
ownership events), and the periodic RG reconcile re-applied RA **only on an
`rg_active` transition** (`if tr.Changed`). So an RG that stayed MASTER across a
day-2 RA edit kept advertising the **old** prefixes/lifetimes/DNS/MTU/options
indefinitely — the primary advertised removed prefixes / stale lifetimes, or
failed to advertise added prefixes, until failover or restart.

## The fix

New `reconcileClusterRAServices` (`pkg/daemon/daemon_ra_reconcile.go`) — the
single authoritative cluster RA applier:

- **Owner-gated desired set** — the union of `buildRAConfigs` filtered to the
  RGs this node is the **current active owner** for (`snapshotRethMasterState`).
- **Hash-gated apply** — a stable digest of the desired set
  (`lastRAReconcileHash`, updated only on a successful apply) short-circuits the
  actual `ra.Apply`, so the periodic pass costs nothing when nothing moved and a
  transient apply error is retried rather than latched.
- **Serialized** under a new `raReconcileMu`; `ra.Apply` already diffs safely
  (no RA gap for unchanged senders).

Wired into every RA-affecting cluster event so desired state always converges:
the **commit path** (`applyServicesReconcile` cluster branch — the core fix),
the **periodic safety reconcile** (`reconcileRGState` — a dropped VRRP event can
no longer strand stale RA), and the **VRRP MASTER/BACKUP transitions**
(`applyRethServicesForRG` / `clearRethServicesForRG` now route RA through the
reconciler, subsuming the prior union-collect / Withdraw split).

## Demotion-race guard (how it works)

The desired set is owner-gated by the ownership snapshot taken **under
`raReconcileMu`**, and the VRRP demote path updates rg-state
(`SetVRRP`/`Reconcile`) **before** it drives the RA reconcile. So a config apply
that races a demotion either snapshots the RG as already-inactive (its senders
are withdrawn / never armed) or snapshots it active — in which case the node
genuinely was the owner at apply time and the demote's own reconcile pass,
serialized behind this one on `raReconcileMu`, withdraws immediately after. An
inactive owner **never transmits**; a removal emits the lifetime-0 goodbye
**only from the current owner** (`ra.Apply`'s graceful-withdraw path). This
reuses the existing rg-state `IsActive()` as the ownership source — **no
ownership-generation redesign** across `daemon_ha.go` (the bounded fix, not the
escape-hatch redesign).

## Tests (fail-on-revert, both verbatim RED on revert)

- `TestClusterRAStableActiveReappliesOnCommit` — drives the real commit
  entrypoint (`applyServicesReconcile`); a day-2 prefix add on a stable-MASTER
  RG re-applies RA with the new desired set. Revert the commit-path call → RA
  never applied → RED.
- `TestClusterRADemotionRaceDoesNotTransmit` — node was MASTER, rg-state flips
  to BACKUP, the racing commit's reconcile must **not** transmit on the
  now-inactive node. Revert the owner gate → demoted node keeps transmitting →
  RED.

A `raApplyFn` test hook (mirrors `startupGoodbyeWithdrawFn`, #5093) spies
`ra.Apply`.

## Validation

- `go build ./...` clean; `go vet ./pkg/daemon ./pkg/ra` clean.
- `go test -race ./pkg/daemon ./pkg/ra` green. `pkg/daemon` (the changed
  package) is `-race`-clean every run; the two new tests pass `-race -count=5`.
- `pkg/ra` carries a **pre-existing intermittent `-race` flake** in the #5094
  `reclaimTombstoneWhenStopped` test family (`TestRestartTimeoutNoReplacement
  WhenNoGoodbye` / `TestReclaimerHealsRestartAfterJoinTimeout_5094`) —
  reproduced on **pristine origin/master** with none of this change present, and
  `pkg/ra` is byte-identical to master here. Unrelated to #5861.

## Smoke deferral

HA/RA failover machinery smoke (`make test-failover`) is deferred behind the
loss-cluster shim-ABI wall. The fix is gated on the fail-on-revert unit tests
plus the full `-race` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QebJ4a11RDfksYerf4Gz8f