### PR TITLE
ddns: deterministic cross-surface suppression tie-break (#6015)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-16 — #6015 ddns cross-surface deterministic suppression tie-break (close window (b))
+
+- **Timestamp**: 2026-07-16 (fix/6015-ddns-suppression-tiebreak)
+- **Action**: Closed the #5748/#6012 cross-surface mutual-suppression window (b):
+  when BOTH ownership surfaces (Surface B lease `Manager`, Surface A
+  `SurfaceAManager`) tore down the SAME co-owned wire RR in overlapping passes,
+  each read the OTHER's pre-rebuild end-of-pass snapshot (still listing the RR
+  owned) and each suppress-and-RELEASED → the RR was left on the wire UNOWNED.
+  Fix: a deterministic tie-break. Surface B (lease Manager) is the SOLE
+  SUPPRESSION AUTHORITY — it alone suppress-and-releases a cross-surface co-owned
+  RR (UNCHANGED from #6012). Surface A is the NON-AUTHORITY: on a co-owned-RR
+  teardown it does NOT delete (would clobber B's still-owned RR — the #6012
+  caution) and does NOT suppress-and-release (the window-(b) orphan); instead it
+  DEFERS — RE-ASSERTS (re-UPSERTs) the RR so a leaked RR self-heals, and KEEPS its
+  ownership claim, retrying the teardown each pass until the lease authority has
+  RELEASED (a later pass finds `leaseWireRRCoowner` false and deletes + releases
+  normally). Because B always releases first and A always defers-until-B-is-gone,
+  exactly one surface ever deletes a cross-surface co-owned RR: mutual suppression
+  can never orphan it and A never clobbers B. `rebuildWireRRClaimsLocked` keeps
+  advertising A's deferred claim so B still sees the co-ownership. Window (a) (a
+  just-published co-owner not yet in the peer snapshot) is accepted as-is
+  (operator-repairable via `request system dynamic-dns update`; the new A re-assert
+  self-heals it on the next deferred pass).
+- **File(s)**: pkg/ddns/surface_a.go (withdrawOwnedLocked defer+re-assert branch,
+  SurfaceAStats.DeleteCoowned doc), pkg/ddns/cross_surface_clobber_5748_test.go
+  (updated TestSurfaceATeardownSuppressedByLeaseCoowner_5748 →
+  TestSurfaceATeardownDefersToLeaseCoowner_5748_6015; added
+  TestCrossSurfaceMutualTeardownNotOrphaned_6015), pkg/ddns/README.md
+  (Cross-surface co-ownership → #6015 tie-break).
+- **Validation**: `go build ./...` clean; `go vet ./pkg/ddns` clean; `go test
+  -race ./pkg/ddns` green (whole suite incl. #6012 cross-surface tests). Both new
+  guards proven RED-on-revert firsthand: neutralizing the deferred keep-claim
+  (`if false && deferredCoowned > 0`) → window-(b) test orphans (Scopes=0) RED;
+  naive "A always deletes" (delete instead of defer) → no-clobber test issues a
+  wire DELETE of the lease-co-owned RR RED. STEP 0: window (b) confirmed live on
+  origin/master 60067bedb (both surfaces rebuild snapshots at end-of-pass, both
+  suppress-and-release, no tie-break).
+
 ## 2026-07-16 — #6036 fold: deterministic per-interface RA prefix order (#5861)
 
 - **Timestamp**: 2026-07-16 (fix/5861-ra-stable-active-reconcile)

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -518,22 +518,36 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   snapshot WITHOUT taking the peer's mutex, so a guard holding its own manager's
   `mu` never blocks on the peer's `mu` (no AB-BA cycle). A nil accessor
   (standalone / pre-wire boot) restores the pre-#5748 single-surface behavior.
-  Surface A suppressions are counted (`SurfaceAStats.DeleteCoowned`); both
+  Surface A deferrals are counted (`SurfaceAStats.DeleteCoowned`); both
   directions are fail-on-revert covered by `cross_surface_clobber_5748_test.go`.
-  **Eventual-consistency caveat (#5748 follow-up):** the cross-surface
-  snapshot is rebuilt at the END of each reconcile pass, so cross-surface
-  visibility is eventually- (not strongly-) consistent. Two tight-race
-  windows remain — both a STRICT improvement over the prior deterministic,
-  always-reachable cross-surface clobber, not a new outage class: (a) a
-  just-published co-owner not yet in the peer snapshot when the other
-  surface tears down → a residual clobber that shrinks the prior 100%
-  clobber to a sub-millisecond race (operator-repairable via `request
-  system dynamic-dns update`, the #5710 force-update); (b) both surfaces
-  tearing down the SAME co-owned RR in overlapping passes each read the
-  other's pre-rebuild snapshot and both suppress → the RR — still holding
-  the identical published rdata (a valid, not-orphaned record) — is left on
-  the wire until an owner's later IP change re-issues it. A deterministic
-  suppression tie-break to close window (b) is tracked as a #5748 follow-up.
+  **Deterministic suppression tie-break (#6015, closes window (b)):** the
+  cross-surface snapshot is rebuilt at the END of each reconcile pass, so
+  cross-surface visibility is eventually- (not strongly-) consistent. Without a
+  tie-break, if BOTH surfaces tore down the SAME co-owned RR in overlapping
+  passes, each read the OTHER's pre-rebuild snapshot (still listing the RR
+  owned) and each suppress-and-RELEASED → the RR was left on the wire UNOWNED
+  (orphaned window (b)). The tie-break designates **Surface B (the lease
+  `Manager`) as the SOLE SUPPRESSION AUTHORITY**: only Surface B may
+  suppress-and-release a cross-surface co-owned RR (unchanged from #6012 —
+  `deleteOwnedLocked` / `wireRRSharedWithOther`). **Surface A is the
+  NON-AUTHORITY**: on a teardown of a co-owned RR it does NOT delete (that would
+  clobber the lease-owned RR — the #6012 caution) and does NOT suppress-and-release
+  (that is the window-(b) orphan). Instead it **DEFERS**: it RE-ASSERTS (re-UPSERTs)
+  the RR so a leaked RR self-heals, and KEEPS its ownership claim, retrying the
+  teardown on later passes. The real wire delete is deferred until the lease
+  authority has RELEASED its co-ownership — a later pass finds `leaseWireRRCoowner`
+  false for every target and deletes + releases normally
+  (`SurfaceAManager.withdrawOwnedLocked`). Because Surface B always releases first
+  and Surface A always defers-until-B-is-gone, exactly ONE surface ever deletes a
+  cross-surface co-owned RR: mutual suppression can never orphan it (Surface A stays
+  the deterministic last-claimant), and Surface A never clobbers a record Surface B
+  still owns. `rebuildWireRRClaimsLocked` keeps advertising Surface A's deferred
+  claim so the lease side continues to see the co-ownership. The remaining
+  **window (a)** (a just-published co-owner not yet in the peer snapshot when the
+  other surface tears down → a residual sub-millisecond clobber) is accepted as-is:
+  it is operator-repairable via `request system dynamic-dns update` (the #5710
+  force-update), and the #6015 Surface A re-assert self-heals it on the next
+  deferred pass.
 - **Source / VRF binding (#2665, `backend_bind.go`)** — the per-family
   `source-address` / `destination-interface` / `routing-instance` leaves build a
   custom `net.Dialer` (one `Control` hook: `unix.Bind` for the source IP +

--- a/pkg/ddns/cross_surface_clobber_5748_test.go
+++ b/pkg/ddns/cross_surface_clobber_5748_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
 // #5748 cross-surface wire-RR clobber guard tests.
@@ -137,16 +139,20 @@ func TestLeaseTeardownNilSurfaceAAccessorDeletes_5748(t *testing.T) {
 	}
 }
 
-// TestSurfaceATeardownSuppressedByLeaseCoowner_5748 is the fail-on-revert test for
-// the SYMMETRIC direction (Surface A → lease): a Surface A router record publishes
-// wan.example.net A 203.0.113.5, and a DHCP lease co-owns the IDENTICAL wire RR.
-// When the Surface A binding is removed, its withdraw must NOT issue the wire
-// DELETE — that would clobber the lease-owned RR.
+// TestSurfaceATeardownDefersToLeaseCoowner_5748_6015 is the fail-on-revert test for
+// the SYMMETRIC direction (Surface A → lease) under the #6015 deterministic
+// tie-break: a Surface A router record publishes wan.example.net A 203.0.113.5, and
+// a DHCP lease co-owns the IDENTICAL wire RR. When the Surface A binding is removed,
+// its withdraw must NOT issue the wire DELETE — that would clobber the lease-owned
+// RR (the #6012 protection). Under #6015 Surface A is the NON-AUTHORITY, so rather
+// than suppress-and-RELEASE (like the lease side) it DEFERS: it RE-ASSERTS (re-UPSERTs)
+// the RR and KEEPS its ownership claim until the lease authority releases.
 //
-// Fail-on-revert: neutralize the per-target leaseWireRRCoowner skip in
-// withdrawOwnedLocked and the Surface A teardown issues a wire DELETE of
-// wan.example.net A 203.0.113.5 — the "no delete" assertion goes RED.
-func TestSurfaceATeardownSuppressedByLeaseCoowner_5748(t *testing.T) {
+// Fail-on-revert (the #6012 caution): make the leaseWireRRCoowner branch DELETE
+// instead of defer (the naive "A always deletes") and the Surface A teardown issues a
+// wire DELETE of wan.example.net A 203.0.113.5 — the "no delete" assertion goes RED,
+// i.e. A clobbers the lease-owned RR.
+func TestSurfaceATeardownDefersToLeaseCoowner_5748_6015(t *testing.T) {
 	fu := newFakeUpdater()
 	now := time.Unix(1_700_000_000, 0)
 	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
@@ -168,6 +174,7 @@ func TestSurfaceATeardownSuppressedByLeaseCoowner_5748(t *testing.T) {
 	if st := m.Stats(); st.Scopes != 1 || st.UpsertOK != 1 {
 		t.Fatalf("phase 1 stats: %+v", st)
 	}
+	fu.upserts = nil
 
 	// Phase 2: the binding is REMOVED → withdraw. The RR is still co-owned by the
 	// DHCP lease, so NO wire delete may be issued.
@@ -177,22 +184,143 @@ func TestSurfaceATeardownSuppressedByLeaseCoowner_5748(t *testing.T) {
 		t.Fatalf("phase 2 withdraw: %v", err)
 	}
 
-	// THE ASSERTION (RED pre-fix): no wire delete for the lease-co-owned RR.
+	// THE #6012 CAUTION ASSERTION (RED on the naive "A always deletes"): no wire
+	// delete for the lease-co-owned RR — Surface A never clobbers a lease-owned RR.
 	if names := fu.deleteNames(); len(names) != 0 {
 		t.Fatalf("surface A teardown issued a wire DELETE for a lease-co-owned RR "+
-			"(cross-surface clobber #5748): %v", names)
+			"(cross-surface clobber #5748/#6015 caution): %v", names)
 	}
 	st := m.Stats()
 	if st.DeleteCoowned != 1 {
-		t.Fatalf("expected exactly one cross-surface suppression, got %+v", st)
+		t.Fatalf("expected exactly one cross-surface deferral, got %+v", st)
 	}
 	// No real withdraw happened, so DeleteOK must not be inflated.
 	if st.DeleteOK != 0 {
 		t.Fatalf("no wire delete was issued; DeleteOK must stay 0, got %d", st.DeleteOK)
 	}
-	// The Surface A ownership claim is released; the RR is left live for the lease.
-	if st.Scopes != 0 {
-		t.Fatalf("surface A ownership must be released after suppression, got Scopes=%d", st.Scopes)
+	// #6015: the non-authority DEFERS — it KEEPS its ownership claim (does NOT
+	// release) so the RR can never be orphaned by a simultaneous lease teardown.
+	if st.Scopes != 1 {
+		t.Fatalf("surface A (non-authority) must KEEP its claim (deferred), got Scopes=%d", st.Scopes)
+	}
+	// #6015: the non-authority RE-ASSERTS (re-UPSERTs) the RR so a leaked RR
+	// self-heals.
+	if got := fu.upsertNames(); !equalStr(got, []string{"wan.example.net=203.0.113.5"}) {
+		t.Fatalf("surface A must re-assert the co-owned RR (self-heal); got upserts %v", got)
+	}
+}
+
+// TestCrossSurfaceMutualTeardownNotOrphaned_6015 is the primary fail-on-revert
+// proof for window (b): BOTH surfaces tear down the SAME co-owned wire RR in
+// overlapping passes, each reading the OTHER's pre-rebuild snapshot (still listing
+// the RR owned). Without a deterministic tie-break both suppress-and-release → the
+// RR is left on the wire UNOWNED (orphaned). With the #6015 tie-break exactly one
+// deterministic outcome holds: the lease Manager (Surface B, AUTHORITY) releases and
+// the SurfaceAManager (Surface A, NON-AUTHORITY) DEFERS — it keeps its claim and
+// re-asserts — so the RR remains owned by exactly one surface and is never orphaned.
+//
+// Fail-on-revert: make Surface A's leaseWireRRCoowner branch suppress-and-RELEASE
+// (drop the claim, the pre-#6015 behavior) and after both tear down NEITHER surface
+// owns the RR → orphaned → the "still owned by Surface A" assertion goes RED.
+func TestCrossSurfaceMutualTeardownNotOrphaned_6015(t *testing.T) {
+	// The single co-owned wire RR both surfaces publish.
+	const fqdn = "shared.example.net"
+	const rdata = "203.0.113.9"
+
+	// ---- Surface B: the lease Manager ----
+	up := newFakeUpdater()
+	b := testDDNS(t, up)
+	// Surface A's PRE-REBUILD snapshot still lists the co-owned RR (frozen to model
+	// the overlapping-pass race: B reads A's snapshot before A rebuilds it).
+	b.surfaceACoowners = func() []WireRRClaim {
+		return []WireRRClaim{wireRRClaim(fqdn, "A", rdata)}
+	}
+
+	// ---- Surface A: the SurfaceAManager ----
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	a := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	// Surface B's PRE-REBUILD snapshot still lists the co-owned RR (the symmetric
+	// frozen snapshot: A reads B's snapshot before B rebuilds it).
+	a.SetLeaseCoownerSource(func() []WireRRClaim {
+		return []WireRRClaim{wireRRClaim(fqdn, "A", rdata)}
+	})
+
+	// Phase 1 — both surfaces publish + own the SAME RR. The lease host is the
+	// leftmost label and the policy Domain is the zone, so host "shared" + Domain
+	// "example.net" resolves to shared.example.net — the SAME name Surface A owns.
+	polLease := policyFromConfig(&config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.net", TTLSeconds: 300,
+	})
+	if err := runReconcile(t, b, polLease, []Lease{leaseV4(rdata, "mac:bb", "shared")}); err != nil {
+		t.Fatalf("surface B publish: %v", err)
+	}
+	if n := len(b.state.records); n != 1 {
+		t.Fatalf("surface B must own the lease RR, got %d", n)
+	}
+	scA := surfaceAScope(fqdn, FamilyV4, 0)
+	obs := fixedObserver(rdata)
+	if err := a.Reconcile(context.Background(), []SurfaceAScope{scA}, obs, nil, nil); err != nil {
+		t.Fatalf("surface A publish: %v", err)
+	}
+	if st := a.Stats(); st.Scopes != 1 {
+		t.Fatalf("surface A must own the RR, got Scopes=%d", st.Scopes)
+	}
+
+	// Phase 2 — BOTH tear down the SAME RR in overlapping passes, each seeing the
+	// peer's frozen (pre-rebuild) snapshot.
+	up.deletes = nil
+	fu.deletes = nil
+	fu.upserts = nil
+	now = now.Add(time.Minute)
+	// Surface B tears down: its lease is gone. It is the AUTHORITY → suppress + RELEASE.
+	if err := runReconcile(t, b, polLease, nil); err != nil {
+		t.Fatalf("surface B teardown: %v", err)
+	}
+	// Surface A tears down: its binding is gone. It is the NON-AUTHORITY → DEFER
+	// (keep claim + re-assert), NEVER release-and-forget.
+	if err := a.Reconcile(context.Background(), []SurfaceAScope{}, obs, nil, nil); err != nil {
+		t.Fatalf("surface A teardown: %v", err)
+	}
+
+	// Surface B (authority) released its claim (unchanged #6012).
+	if n := len(b.state.records); n != 0 {
+		t.Fatalf("surface B (authority) must release its claim, got %d owned", n)
+	}
+	// THE WINDOW-(b) ASSERTION (RED pre-fix): after both tore down the RR must NOT
+	// be orphaned. Surface A (non-authority) still owns it (deferred) → not orphaned.
+	// Revert the tie-break (A releases too) → Scopes==0 → this fails RED.
+	if st := a.Stats(); st.Scopes != 1 {
+		t.Fatalf("window (b): co-owned RR left ORPHANED — the non-authority must KEEP "+
+			"its claim after a simultaneous teardown, got Scopes=%d", st.Scopes)
+	}
+	// Neither surface issued a wire DELETE (the RR is still valid on the wire).
+	if names := up.deleteNames(); len(names) != 0 {
+		t.Fatalf("surface B must not delete a co-owned RR, got %v", names)
+	}
+	if names := fu.deleteNames(); len(names) != 0 {
+		t.Fatalf("surface A must not delete a co-owned RR, got %v", names)
+	}
+	// Surface A re-asserted the RR (self-heal).
+	if got := fu.upsertNames(); !equalStr(got, []string{fqdn + "=" + rdata}) {
+		t.Fatalf("surface A must re-assert the co-owned RR during the deferred teardown; got %v", got)
+	}
+
+	// Phase 3 — the lease authority has now RELEASED. Its rebuilt snapshot no longer
+	// lists the RR, so Surface A's next teardown pass finds no co-owner and issues
+	// the deterministic real delete + releases its claim. This closes the loop: the
+	// RR is correctly REMOVED (not orphaned) once neither surface owns it.
+	a.SetLeaseCoownerSource(func() []WireRRClaim { return nil })
+	fu.deletes = nil
+	now = now.Add(time.Minute)
+	if err := a.Reconcile(context.Background(), []SurfaceAScope{}, obs, nil, nil); err != nil {
+		t.Fatalf("surface A final teardown: %v", err)
+	}
+	if got := fu.deleteNames(); !contains(got, fqdn+"="+rdata) {
+		t.Fatalf("once the lease authority released, surface A must issue the real delete; got %v", got)
+	}
+	if st := a.Stats(); st.Scopes != 0 {
+		t.Fatalf("surface A must release after the lease authority is gone, got Scopes=%d", st.Scopes)
 	}
 }
 

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -1509,29 +1509,57 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 	// candidate delete of this record (same family/FQDN/provider), so compute once.
 	sibling := m.siblingFamilyOwnedLocked(owned)
 	var firstErr error
-	var suppressed int
+	noteFirst := func(e error) {
+		if e != nil && firstErr == nil {
+			firstErr = e
+		}
+	}
+	var deferredCoowned int // #6015: targets a DHCP lease still co-owns (defer + re-assert)
+	var deleted int         // real wire deletes issued this pass
 	for _, a := range targets {
-		// #5748 (cross-surface arm of #5709): if a Surface B DHCP lease scope still
-		// co-owns THIS exact wire RR (canonical FQDN + forward type + this rdata),
-		// do NOT issue the wire delete — it would clobber the RR the lease surface
-		// still legitimately owns and refreshes. Release only this surface's claim
-		// (the ownership drop below) and leave the RR live; the lease surface, as the
-		// last claimant, issues the real delete when it in turn tears down. The
+		// #5748 + #6015 (cross-surface arm of #5709): if a Surface B DHCP lease
+		// scope still co-owns THIS exact wire RR (canonical FQDN + forward type +
+		// this rdata), Surface A must not issue the wire delete — that would clobber
+		// the RR the lease surface still legitimately owns and refreshes (the #6012
+		// caution). But it must also not suppress-and-RELEASE its own claim the way
+		// the lease side does: that is the #6015 window-(b) mutual-suppression path.
+		// If BOTH surfaces tear down the SAME co-owned RR in overlapping passes, each
+		// reads the OTHER's pre-rebuild (end-of-pass) snapshot — still listing the RR
+		// as owned — so if both released their claims the RR would be left on the
+		// wire UNOWNED (orphaned).
+		//
+		// The deterministic tie-break (#6015): Surface B (the lease Manager) is the
+		// SOLE SUPPRESSION AUTHORITY — it alone suppress-and-RELEASES a cross-surface
+		// co-owned RR (unchanged from #6012, deleteOwnedLocked / wireRRSharedWithOther).
+		// Surface A is the NON-AUTHORITY: it DEFERS — it RE-ASSERTS (re-UPSERTs) the
+		// RR so a leaked RR self-heals, and KEEPS its ownership claim, retrying the
+		// teardown on later passes. The real delete is deferred until the lease
+		// authority has RELEASED its co-ownership (a later pass finds
+		// leaseWireRRCoowner false for every target and deletes normally below).
+		// Because B always releases first and A always defers-until-B-is-gone, exactly
+		// ONE surface ever deletes a cross-surface co-owned RR — mutual suppression can
+		// never orphan it, and A never clobbers B's still-owned record. The
 		// leaseCoowners read is LOCK-FREE (no Manager.mu), so this is safe under m.mu.
 		if m.leaseWireRRCoowner(owned.FQDN, owned.ForwardType, a.String()) {
-			suppressed++
+			deferredCoowned++
 			m.deleteCoowned++
-			slog.Debug("ddns surface-a: skipping wire delete — RR still co-owned by a DHCP lease scope; "+
-				"releasing this surface's claim only",
+			// Re-assert the RR (self-heal): re-UPSERT the exact owned RR so a leaked
+			// co-owned record (e.g. the residual window-(a) sub-ms clobber) is
+			// restored. Re-adding an identical RR is idempotent at the provider.
+			if rec, err := buildHostRecord(owned.FQDN, a, owned.TTL); err == nil {
+				noteFirst(m.providerIO(func() error { return backend.UpsertLease(ctx, rec) }))
+			} else {
+				noteFirst(err)
+			}
+			slog.Debug("ddns surface-a: cross-surface co-owned RR — deferring wire delete and "+
+				"re-asserting; a DHCP lease scope still co-owns it (keeping claim until it releases)",
 				"fqdn", owned.FQDN, "type", owned.ForwardType, "addr", a.String(),
 				"provider", owned.scopeOf().PolicyID)
 			continue
 		}
 		rec, err := buildHostRecord(owned.FQDN, a, owned.TTL)
 		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
+			noteFirst(err)
 			continue
 		}
 		rec.SiblingFamilyOwned = sibling
@@ -1540,26 +1568,36 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 		// candidate is a benign no-op (the backend maps not-found to success), so an
 		// error here is a REAL provider failure.
 		if err := m.providerIO(func() error { return backend.DeleteLease(ctx, rec) }); err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
+			noteFirst(err)
+		} else {
+			deleted++
 		}
 	}
 	if firstErr != nil {
-		// A candidate delete failed with a real provider error. Keep ownership so the
-		// next reconcile retries EVERY candidate (an already-deleted one is a benign
-		// no-op) — a genuinely-live value is never orphaned. The
-		// errGenericDeleteUnsupported sentinel is preserved (%w) so withdrawScopeLocked
-		// marks the scope terminal instead of retrying a structurally-unsupported verb.
+		// A candidate delete (or a deferred re-assert) failed with a real provider
+		// error. Keep ownership so the next reconcile retries EVERY candidate (an
+		// already-deleted one is a benign no-op) — a genuinely-live value is never
+		// orphaned. The errGenericDeleteUnsupported sentinel is preserved (%w) so
+		// withdrawScopeLocked marks the scope terminal instead of retrying a
+		// structurally-unsupported verb.
 		m.deleteFail++
 		return fmt.Errorf("ddns surface-a: withdraw %s %s: %w", owned.ForwardType, owned.FQDN, firstErr)
 	}
-	// deleteOK counts a real wire withdraw. If EVERY candidate was cross-surface
-	// co-owned and suppressed, nothing was deleted — do not inflate deleteOK; the
-	// deleteCoowned counter already recorded the suppression. Ownership is still
-	// released below (mirrors the lease path's #5709 claim release).
-	if suppressed < len(targets) {
+	// deleteOK counts a real wire withdraw. If every candidate was cross-surface
+	// co-owned (deferred) nothing was deleted — do not inflate deleteOK; the
+	// deleteCoowned counter already recorded the suppression.
+	if deleted > 0 {
 		m.deleteOK++
+	}
+	// #6015 deterministic tie-break: if ANY target is still cross-surface co-owned
+	// by a DHCP lease, this record is a DEFERRED cross-surface teardown — KEEP the
+	// ownership claim (do NOT drop it below) so the RR is never orphaned and Surface
+	// A stays the deterministic last-claimant that deletes only once the lease
+	// authority has released. rebuildWireRRClaimsLocked keeps advertising the claim
+	// so the lease side still sees the co-ownership. A later pass, once the lease no
+	// longer co-owns, falls through to the real delete + ownership release.
+	if deferredCoowned > 0 {
+		return nil
 	}
 
 	// Racing-op guard (#2778): drop ownership only if the live entry is STILL the
@@ -2123,10 +2161,15 @@ type SurfaceAStats struct {
 	Skipped          uint64
 	BackedOff        uint64
 	SkippedNoBackend uint64
-	// DeleteCoowned is the count of wire deletes SUPPRESSED because the RR is still
+	// DeleteCoowned is the count of wire deletes DEFERRED because the RR is still
 	// co-owned by a Surface B DHCP lease scope (#5748, the cross-surface arm of the
-	// #5709 co-ownership guard). A non-zero value is normal when Surface A and a
-	// DHCP lease legitimately publish the same host/address.
+	// #5709 co-ownership guard). Under the #6015 deterministic tie-break Surface A is
+	// the NON-AUTHORITY: rather than suppress-and-release like the lease side, each
+	// such pass DEFERS the delete, RE-ASSERTS the RR, and KEEPS the ownership claim
+	// until the lease authority releases — so this counter tallies deferred passes,
+	// not one-shot suppressions, and grows once per reconcile while the co-ownership
+	// persists. A non-zero value is normal when Surface A and a DHCP lease
+	// legitimately publish the same host/address.
 	DeleteCoowned uint64
 	// Orphaned is the count of records this node published at a PREVIOUS provider
 	// endpoint that a provider identity change (rename / in-place mutation /

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -413,11 +413,16 @@ type SurfaceAManager struct {
 	// the credential (mirrors manager.go upsertLocked's skippedNoBackend, #2691
 	// P3 review MAJOR).
 	skippedNoBackend uint64
-	// deleteCoowned counts wire deletes SUPPRESSED because the RR is still co-owned
-	// by a Surface B DHCP lease scope (#5748, the cross-surface arm of #5709). Like
-	// the lease Manager's deleteCoowned, dropping this surface's claim on a
-	// still-co-owned RR can never leak a stale record, so the suppression needs no
-	// write-ahead. Guarded by mu.
+	// deleteCoowned counts wire deletes DEFERRED because the RR is still co-owned
+	// by a Surface B DHCP lease scope (#5748 cross-surface arm of #5709, tie-break
+	// #6015). UNLIKE the lease Manager (which is the sole suppression AUTHORITY and
+	// drops its claim), Surface A is the NON-AUTHORITY: on a co-owned teardown it
+	// does NOT drop its claim and does NOT issue the wire delete. It DEFERS — it
+	// re-UPSERTs the RR (self-heal) and KEEPS its ownership claim, retrying the
+	// teardown each pass until the lease authority releases (window-(b) fix: two
+	// surfaces releasing the same co-owned RR in overlapping passes would orphan
+	// it). So this counter tallies deferred passes, not one-shot suppressions.
+	// Guarded by mu.
 	deleteCoowned uint64
 
 	// leaseCoowners, when non-nil, returns the wire-RR claims currently owned by
@@ -1596,6 +1601,12 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 	// authority has released. rebuildWireRRClaimsLocked keeps advertising the claim
 	// so the lease side still sees the co-ownership. A later pass, once the lease no
 	// longer co-owns, falls through to the real delete + ownership release.
+	//
+	// Steady-state note (#6015): if a live DHCP lease legitimately co-owns this RR
+	// indefinitely while A's own binding is permanently removed, A defers FOREVER —
+	// it re-UPSERTs the identical RR and keeps its Scopes claim every reconcile pass
+	// until the lease releases. That is correct (never orphan, never clobber) and
+	// bounded to ~1 idempotent UPSERT per poll at DDNS cadence (not per-packet).
 	if deferredCoowned > 0 {
 		return nil
 	}


### PR DESCRIPTION
Closes #6015

## Problem — window (b), cross-surface mutual suppression

#5748 (PR #6012) added a cross-surface wire-RR clobber guard: each ownership surface (Surface B lease `Manager`, Surface A `SurfaceAManager`) publishes a lock-free `atomic.Pointer[[]WireRRClaim]` snapshot rebuilt at the END of each reconcile pass; each teardown consults the peer's snapshot before issuing a wire DELETE and suppresses the DELETE when the peer co-owns the RR.

Because the snapshot is rebuilt at end-of-pass, if BOTH surfaces tear down the SAME co-owned wire RR (identical canonical FQDN + forward type + rdata) in overlapping passes, each reads the OTHER's **pre-rebuild** snapshot (still listing the RR owned) and each **suppress-and-RELEASED** its claim → the RR was left on the wire **UNOWNED** (orphaned). A later IP change on a surviving owner could then leave a stale A alongside the new one on an exact-RR backend.

## The tie-break rule

Designate **Surface B (the lease `Manager`) as the SOLE SUPPRESSION AUTHORITY** for a cross-surface co-owned RR:

- **Surface B (authority)** — teardown of a co-owned RR: suppress + **RELEASE** its claim (leave the RR). **UNCHANGED from #6012** — `deleteOwnedLocked` / `wireRRSharedWithOther` are untouched.
- **Surface A (non-authority)** — teardown of a co-owned RR: it must **not delete** (that would clobber the lease-owned RR — the #6012 caution) and must **not suppress-and-release** (the window-(b) orphan). Instead it **DEFERS**: it **RE-ASSERTS** (re-UPSERTs) the RR so a leaked record self-heals, and **KEEPS** its ownership claim, retrying the teardown each pass. The real wire delete is deferred until the lease authority has RELEASED its co-ownership (a later pass finds `leaseWireRRCoowner` false for every target and deletes + releases normally).

Because Surface B always releases first and Surface A always defers-until-B-is-gone, **exactly one surface ever deletes a cross-surface co-owned RR**: mutual suppression can never orphan it (Surface A is the deterministic last-claimant) and Surface A never clobbers a record Surface B still owns. `rebuildWireRRClaimsLocked` keeps advertising Surface A's deferred claim so the lease side continues to see the co-ownership.

### How this avoids the #6012 caution (the "naive A always deletes" clobber)

The naive fix — "only B suppresses, A always deletes" — reintroduces the Surface-A→lease clobber #6012 closed: A would DELETE an RR Surface B legitimately still owns. This PR does **not** let A delete a co-owned RR. A never deletes while B co-owns; it defers + re-asserts. The delete happens only once B has released (no co-owner remains), at which point the RR is truly unowned and the delete is correct.

Window (a) (a just-published co-owner not yet in the peer snapshot) is accepted as-is: operator-repairable via `request system dynamic-dns update` (#5710), and now additionally self-healed by the Surface A re-assert on the next deferred pass.

## Scope

Confined to `SurfaceAManager.withdrawOwnedLocked`. The lease `Manager` (Surface B) is unmodified. `SurfaceAStats.DeleteCoowned` now tallies deferred passes rather than one-shot suppressions (documented in the field comment + README).

## Tests (fail-on-revert)

- `TestSurfaceATeardownSuppressedByLeaseCoowner_5748` → **`TestSurfaceATeardownDefersToLeaseCoowner_5748_6015`**: A defers + re-asserts + keeps its claim, never deletes a lease-owned RR. Fail-on-revert (the #6012 caution): naive "A always deletes" → A issues a wire DELETE of the lease-co-owned RR → RED.
- **`TestCrossSurfaceMutualTeardownNotOrphaned_6015`**: both surfaces tear down the same co-owned RR in overlapping passes (each frozen to see the peer's pre-rebuild snapshot) → the RR is never orphaned (Surface A keeps its claim + re-asserts; Surface B releases), then Surface A issues the real delete once the lease authority releases. Fail-on-revert: neutralize the deferred keep-claim → both release → RR orphaned (Scopes=0) → RED.

Both proven RED-on-revert firsthand.

## Validation

- `go build ./...` clean
- `go vet ./pkg/ddns ./pkg/daemon` clean
- `go test -race ./pkg/ddns` green (whole suite incl. the #6012 cross-surface tests)
- `pkg/dhcpserver` consumer tests green
- Docs: `pkg/ddns/README.md` "Cross-surface co-ownership" updated with the #6015 tie-break; dated `_Log.md` entry.

STEP 0: window (b) confirmed live on origin/master `60067bedb` (both surfaces rebuild snapshots at end-of-pass, both suppress-and-release, no tie-break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjRZtNg2nQvdm1c21wbf3u