### PR TITLE
filter: meter lo0 policers on host-bound traffic (#5857)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,57 @@
+## 2026-07-16 — #5857: lo0 firewall policers now meter host-bound traffic
+
+- **Timestamp**: 2026-07-16 (fix/5857-lo0-policer-meter)
+- **Action**: Wired the existing three-color policer metering into the lo0 /
+  local-delivery filter path. Root cause: a firewall filter on `lo0` can carry
+  a `then policer`, and the compiler links the three-color runtime onto the
+  term, but the local-delivery path (`apply_lo0_filter_action`) consumed only
+  `result.action` + `result.log_match` — it never called
+  `apply_term_three_color_policer`, never metered the named policer, and never
+  applied a policer drop. So a strict-valid control-plane rate limit
+  (SSH/BGP/routing/ICMP to the RE) was INERT (a security / control-plane-
+  protection gap: an untrusted peer could exceed the operator's envelope).
+  Fix REUSES the proven runtime (used by interface TX-selection + cached-flow
+  paths), it does not reimplement it:
+    - `filter/engine/eval.rs`: threaded `now_ns: Option<u64>` through the shared
+      `evaluate_filter_ref_counted` → `_v4`/`_v6` → `merge_matched_modifiers`.
+      `Some(now_ns)` (the lo0 path) meters each matched term's three-color
+      policer via `apply_term_three_color_policer` and folds the drop into
+      `FilterResult.policer_drop` (OR-accumulated across a `then next term`
+      chain, so a later permit cannot erase an earlier drop) with the policer's
+      DSCP-rewrite precedence over the term's. `None` (interface input/output
+      action-eval + PBR prechecks — which meter their policer in the separate
+      tx-selection walk) skips metering here → byte-for-byte identical to the
+      pre-fix behavior (no double-meter). `evaluate_lo0_filter_counted` gained
+      the `now_ns` param; the `evaluate_lo0_filter` test wrapper passes `None`.
+    - `filter/mod.rs`: added `FilterResult.policer_drop` (default false; set only
+      by the metered lo0 walk).
+    - `afxdp/poll_descriptor/filter.rs`: `apply_lo0_filter_action` +
+      `host_inbound_gated_lo0_action` take `now_ns: u64`; `apply_lo0_filter_action`
+      passes `Some(now_ns)` and downgrades an `Accept` verdict to a silent
+      `Discard` when `policer_drop` (Junos policer drops are silent — no RST /
+      ICMP reject). All 3 LocalDelivery call sites in `poll_descriptor/mod.rs`
+      (flowless, session-HIT, session-MISS) pass `now_ns`.
+  - **Test (fail-on-revert)**: `lo0_policer_meters_and_drops_host_bound_traffic`
+    in `poll_descriptor/filter.rs` drives `host_inbound_gated_lo0_action` with a
+    conforming then an exceeding host-bound UDP packet on an admit-all zone;
+    asserts the exceeding packet returns `Discard` AND the policer `drop_packets`
+    counter advances. Reverting the wire-in → second packet ACCEPTED → RED
+    (verified firsthand: `assertion left == right failed: host-bound traffic
+    above the lo0 policer rate must be dropped`).
+  - **Validation**: full Rust suite `cargo test --release` → 3867 passed, 0
+    failed; lo0 (13) + policer (16) suites green; `cargo build --release` clean;
+    my hunk rustfmt-clean. Smoke deferred (loss-cluster shim-ABI wall);
+    correctness gated on the cargo fail-on-revert test.
+  - **Scope note**: host-bound DSCP/color rewrite for a policed lo0 packet is
+    NOT applied to the delivered frame (the lo0 local-delivery path has no
+    frame-DSCP-rewrite mechanism — even a term's plain `then dscp` is unapplied
+    on lo0); only the drop is enforced. Documented in `filter/README.md`.
+- **File(s)**: userspace-dp/src/filter/engine/eval.rs,
+  userspace-dp/src/filter/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/filter.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/filter/README.md, _Log.md
+
 ## 2026-07-16 — #6036 fold: deterministic per-interface RA prefix order (#5861)
 
 - **Timestamp**: 2026-07-16 (fix/5861-ra-stable-active-reconcile)

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -512,6 +512,9 @@ pub(super) fn apply_lo0_filter_action(
     flow: Option<&SessionFlow>,
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
+    // #5857: poll-iteration monotonic timestamp — threaded so the lo0 filter
+    // METERS each matched term's three-color policer (control-plane rate limit).
+    now_ns: u64,
 ) -> (crate::filter::FilterAction, Option<PendingFilterLog>) {
     let Some(flow) = flow else {
         return (crate::filter::FilterAction::Accept, None);
@@ -528,7 +531,27 @@ pub(super) fn apply_lo0_filter_action(
         meta.dscp,
         extra,
         meta.pkt_len as u64,
+        // #5857: Some(now_ns) meters the policer on every matched lo0 term
+        // (drop + color decision), exactly like the interface TX-selection leg.
+        Some(now_ns),
     );
+    // #5857: a policer that marked this host-bound packet as exceeding/violating
+    // (`policer_drop`) forces a DROP even when the matched term's verdict was
+    // Accept. This is the control-plane rate-limit enforcement that was inert
+    // before #5857: the compiler linked the policer runtime and the evaluator
+    // reported a match, but the lo0/local-delivery path never metered nor
+    // dropped. A policer drop is a SILENT discard (Junos policer semantics — no
+    // TCP RST / ICMP unreachable is synthesized), so it maps to `Discard`, not
+    // `Reject`. An already-terminal `Discard`/`Reject` verdict is left intact
+    // (the packet drops either way; the term's own action governs reply
+    // semantics). Because `policer_drop` is OR-accumulated across the whole
+    // `next term` chain, a later permit cannot erase an earlier policer drop.
+    let action =
+        if result.policer_drop && matches!(result.action, crate::filter::FilterAction::Accept) {
+            crate::filter::FilterAction::Discard
+        } else {
+            result.action
+        };
     // #3615: DEFER the filter-log emit — return the matched record so the caller
     // can emit it AFTER the reject-reply enqueue outcome is known (flow-backed)
     // or with reject_reply_enqueued=false (flowless). This preserves the exact
@@ -548,7 +571,7 @@ pub(super) fn apply_lo0_filter_action(
         // #2520: AppID via the hot-path app_catalog.lookup.
         app_id: resolve_flow_app_id(&forwarding.app_catalog, flow),
     });
-    (result.action, pending)
+    (action, pending)
 }
 
 /// #3485: host-inbound zone admission MUST gate the lo0 (host-bound) firewall
@@ -597,6 +620,8 @@ pub(super) fn host_inbound_gated_lo0_action(
     flow: &SessionFlow,
     meta: UserspaceDpMeta,
     lo0_ingress_zone_override: Option<u16>,
+    // #5857: poll-iteration monotonic timestamp for the lo0 policer meter.
+    now_ns: u64,
 ) -> Option<(crate::filter::FilterAction, Option<PendingFilterLog>)> {
     // Host-inbound gate FIRST — a denied packet is a fail-closed silent drop
     // with NO lo0 side-effects (#3485). #3362: keyed by ingress interface so a
@@ -630,6 +655,7 @@ pub(super) fn host_inbound_gated_lo0_action(
         Some(flow),
         meta,
         lo0_ingress_zone_override,
+        now_ns,
     ))
 }
 
@@ -750,6 +776,7 @@ mod lo0_gate_tests {
             &flow,
             meta,
             Some(DENY_ZONE),
+            0, // #5857: now_ns — irrelevant (host-inbound denies before lo0 eval)
         );
         assert!(
             action.is_none(),
@@ -780,6 +807,7 @@ mod lo0_gate_tests {
             &flow,
             meta,
             Some(ADMIT_ZONE),
+            0, // #5857: now_ns — no policer term in these tests, so unused
         );
         assert_eq!(
             action.map(|(a, _)| a),
@@ -843,6 +871,7 @@ mod lo0_gate_tests {
             &flow,
             meta,
             Some(ADMIT_ZONE),
+            0, // #5857: now_ns — no policer term in these tests, so unused
         );
         assert!(
             action.is_none(),
@@ -853,6 +882,144 @@ mod lo0_gate_tests {
             lo0_term_packets(&fw),
             0,
             "lo0 filter must NOT run when the logical override denies (#3609)",
+        );
+    }
+
+    /// #5857: a lo0 (host-bound) firewall filter term carrying a named policer
+    /// must METER host-bound traffic and DROP packets that exceed the configured
+    /// rate. Before #5857 the control-plane rate limit was INERT — the compiler
+    /// linked the three-color runtime and `evaluate_lo0_filter_counted` reported
+    /// a match + copied `policer_name`, but the local-delivery path
+    /// (`apply_lo0_filter_action`) consumed only `action` + `log_match`: it never
+    /// metered the policer nor dropped an exceeding packet. An untrusted peer
+    /// could therefore exceed the operator's control-plane protection envelope.
+    ///
+    /// This drives `host_inbound_gated_lo0_action` — the single helper both
+    /// LocalDelivery call sites (session-HIT and session-MISS) route through —
+    /// with a conforming then an exceeding host-bound UDP packet on an admit-all
+    /// zone, and asserts the exceeding packet DROPS and the policer drop counter
+    /// advances (proving the meter actually ran, not just that a verdict flipped).
+    ///
+    /// Fail-on-revert: neutralizing the metering wire-in (the
+    /// `apply_term_three_color_policer` call in `eval::merge_matched_modifiers`,
+    /// or the `policer_drop`→`Discard` downgrade in `apply_lo0_filter_action`)
+    /// leaves the second packet ACCEPTED and `drop_packets` at 0 — RED on both.
+    #[test]
+    fn lo0_policer_meters_and_drops_host_bound_traffic() {
+        // lo0 filter: UDP host-bound traffic is accepted but rate-limited by a
+        // single-rate policer (1000-byte bucket) — a control-plane protect-RE
+        // filter policing a host-bound service.
+        let mut fw = ForwardingState::default();
+        fw.filter_state = crate::filter::parse_filter_state(
+            &[crate::FirewallFilterSnapshot {
+                name: "protect-re".into(),
+                family: "inet".into(),
+                terms: vec![crate::FirewallTermSnapshot {
+                    name: "police-udp".into(),
+                    protocols: vec!["udp".into()],
+                    policer: "rl-1kb".into(),
+                    action: "accept".into(),
+                    count: "lo0-udp".into(),
+                    ..Default::default()
+                }],
+            }],
+            &[crate::PolicerSnapshot {
+                name: "rl-1kb".into(),
+                bandwidth_bps: 8_000, // 1000 bytes/sec committed rate
+                burst_bytes: 1_000,   // 1000-byte token bucket
+                discard_excess: true,
+            }],
+            &[],
+            "protect-re",
+            "",
+        )
+        .expect("filter state compiles");
+
+        let src = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+        let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        // meta.pkt_len drives the policer byte count (apply_lo0_filter_action
+        // passes it as `packet_bytes`).
+        let make = |pkt_len: u16| {
+            let meta = UserspaceDpMeta {
+                protocol: crate::ip_proto::PROTO_UDP,
+                addr_family: libc::AF_INET as u8,
+                l3_offset: 14,
+                l4_offset: 34,
+                pkt_len,
+                ..UserspaceDpMeta::default()
+            };
+            let flow = SessionFlow {
+                src_ip: src,
+                dst_ip: dst,
+                forward_key: SessionKey {
+                    addr_family: libc::AF_INET as u8,
+                    protocol: crate::ip_proto::PROTO_UDP,
+                    src_ip: src,
+                    dst_ip: dst,
+                    src_port: 40000,
+                    dst_port: 5000,
+                },
+            };
+            (flow, meta)
+        };
+        let extra_udp = TermMatchExtra {
+            l4_present: true,
+            ..Default::default()
+        };
+        // now_ns fixed so the token bucket does NOT refill between the packets.
+        const NOW_NS: u64 = 1_000;
+
+        // First 900-byte packet drains most of the 1000-byte bucket — conforming
+        // → delivered (Accept).
+        let (flow1, meta1) = make(900);
+        let first = host_inbound_gated_lo0_action(
+            &fw,
+            meta1.ingress_ifindex as i32,
+            ADMIT_ZONE,
+            5000,
+            false,
+            0,
+            extra_udp,
+            &flow1,
+            meta1,
+            Some(ADMIT_ZONE),
+            NOW_NS,
+        );
+        assert_eq!(
+            first.map(|(a, _)| a),
+            Some(FilterAction::Accept),
+            "a conforming host-bound packet must be delivered",
+        );
+
+        // Second 900-byte packet exceeds the ~100 remaining tokens — the policer
+        // drops it. Before #5857 this was ACCEPTED (rate limit inert).
+        let (flow2, meta2) = make(900);
+        let second = host_inbound_gated_lo0_action(
+            &fw,
+            meta2.ingress_ifindex as i32,
+            ADMIT_ZONE,
+            5000,
+            false,
+            0,
+            extra_udp,
+            &flow2,
+            meta2,
+            Some(ADMIT_ZONE),
+            NOW_NS,
+        );
+        assert_eq!(
+            second.map(|(a, _)| a),
+            Some(FilterAction::Discard),
+            "host-bound traffic above the lo0 policer rate must be dropped (#5857)",
+        );
+
+        // The policer's drop counter advanced — proving the meter ran on the
+        // host-bound path.
+        let status = fw.filter_state.three_color_policer_statuses();
+        assert_eq!(status.len(), 1, "one lowered single-rate policer");
+        assert!(
+            status[0].drop_packets >= 1,
+            "the lo0 policer must record the host-bound drop",
         );
     }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -437,6 +437,7 @@ fn flowless_local_delivery_verdict(
         flow,
         meta,
         ingress_zone_override,
+        now_ns,
     ) {
         None => {
             // #3610: emit the tuple-rich host-inbound deny event before the
@@ -1201,6 +1202,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 flow,
                                 meta,
                                 Some(resolved.metadata.ingress_zone),
+                                now_ns,
                             ) {
                                 None => {
                                     // Host-inbound denied: silent drop, tear down
@@ -2246,6 +2248,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 flow,
                                 meta,
                                 ingress_zone_override,
+                                now_ns,
                             ) {
                                 None => {
                                     // Host-inbound denied: silent drop, never

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -848,6 +848,39 @@ a lo0 decision in the first place. This is noted here so future
 readers do not repeat the v1 plan investigation that mistook lo0
 for a missing cache-sensitive gate.
 
+### lo0 host-bound filters meter their policer (#5857)
+
+A firewall filter attached to `lo0` can carry a `then policer`, and the
+compiler links the three-color runtime onto the term exactly as it does
+for interface filters. Before #5857 the lo0 / local-delivery path
+evaluated the filter with `evaluate_lo0_filter_counted` but consumed only
+`action` + `log_match` — it never metered the named policer nor applied a
+policer drop, so a strict-valid control-plane rate limit (SSH / BGP /
+routing / ICMP to the routing engine) was **inert** (a
+control-plane-protection gap: an untrusted peer could exceed the
+operator's envelope).
+
+lo0 has NO separate tx-selection leg (unlike interface input/output
+filters, which meter their policer in the tx-selection walk), so the lo0
+action-eval is the ONLY place its policer can be metered — there is no
+double-meter risk. `evaluate_lo0_filter_counted` now threads a
+poll-iteration `now_ns` (`Some(..)` on the live path) so the shared
+term walk meters each matched term's three-color policer via
+`apply_term_three_color_policer` — the SAME runtime the interface
+tx-selection leg uses — folding the drop into `FilterResult.policer_drop`
+(OR-accumulated across a `then next term` chain, so a later permit cannot
+erase an earlier policer drop). `apply_lo0_filter_action` then downgrades
+an `Accept` verdict to a silent `Discard` when `policer_drop` is set
+(policer drops are silent per Junos semantics — no TCP RST / ICMP
+unreachable is synthesized). The three non-lo0 callers of the shared walk
+(interface input/output action-eval + PBR prechecks) pass `now_ns = None`
+so they do NOT meter here (byte-for-byte identical to pre-#5857). Test:
+`lo0_policer_meters_and_drops_host_bound_traffic` in
+`poll_descriptor/filter.rs`. Host-bound **DSCP/color rewrite** for a
+policed lo0 packet is not applied to the delivered frame (the lo0
+local-delivery path has no frame-DSCP-rewrite mechanism — even a term's
+plain `then dscp` is not applied on lo0); only the drop is enforced.
+
 ### `then reject` synthesizes an active reply (#2521)
 
 `FilterAction::Reject` (`then reject`) no longer realizes as a silent

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -13,6 +13,9 @@
 
 use super::super::*;
 use super::matching::{term_matches, term_matches_v4, term_matches_v6};
+// #5857: the lo0 host-bound filter meters its three-color policer on the same
+// runtime the interface TX-selection leg uses (`merge_matched_tx_modifiers`).
+use super::policer::apply_term_three_color_policer;
 
 /// Evaluate a named filter against a packet flow. First matching term wins.
 /// If no term matches, the implicit action is Accept.
@@ -57,9 +60,22 @@ pub(crate) fn evaluate_filter_counted(
         dscp,
         extra,
         packet_bytes,
+        // #5857: interface input/output filters meter their three-color policer
+        // in the tx-selection walk, not in this action-eval — pass None so this
+        // walk does NOT meter (metering here would double-meter).
+        None,
     )
 }
 
+/// #5857: `now_ns` selects whether matched terms meter their three-color
+/// policer. `Some(now_ns)` — the lo0 host-bound path — meters every matched
+/// term (drop + color/DSCP decision) exactly like the interface TX-selection
+/// leg. `None` — the interface input/output filter action-eval and the PBR
+/// prechecks — does NOT meter here: those filters meter their policer in the
+/// separate tx-selection walk (`evaluate_filter_ref_tx_selection_*`), so
+/// metering in this action-eval too would DOUBLE-meter. With `None` the walk is
+/// byte-for-byte identical to the pre-#5857 behavior (no drop, term dscp-rewrite
+/// precedence unchanged).
 #[inline]
 pub(super) fn evaluate_filter_ref_counted(
     filter: &Filter,
@@ -71,6 +87,7 @@ pub(super) fn evaluate_filter_ref_counted(
     dscp: u8,
     extra: TermMatchExtra<'_>,
     packet_bytes: u64,
+    now_ns: Option<u64>,
 ) -> FilterResult {
     match (src_ip, dst_ip) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_counted_v4(
@@ -83,6 +100,7 @@ pub(super) fn evaluate_filter_ref_counted(
             dscp,
             extra,
             packet_bytes,
+            now_ns,
         ),
         (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_counted_v6(
             filter,
@@ -94,6 +112,7 @@ pub(super) fn evaluate_filter_ref_counted(
             dscp,
             extra,
             packet_bytes,
+            now_ns,
         ),
         _ => FilterResult::default(),
     }
@@ -110,6 +129,7 @@ fn evaluate_filter_ref_counted_v4(
     dscp: u8,
     extra: TermMatchExtra<'_>,
     packet_bytes: u64,
+    now_ns: Option<u64>,
 ) -> FilterResult {
     // #2544: accumulate modifiers across fall-through terms. A matched
     // fall-through term (continue_term) applies its modifiers and continues; a
@@ -125,7 +145,7 @@ fn evaluate_filter_ref_counted_v4(
         if term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
-        merge_matched_modifiers(&mut acc, filter, term);
+        merge_matched_modifiers(&mut acc, filter, term, now_ns, packet_bytes);
         if !term.continue_term {
             acc.action = term.action;
             normalize_log_match_action(&mut acc);
@@ -162,11 +182,36 @@ fn normalize_log_match_action(acc: &mut FilterResult) {
 /// NOT set here — the caller sets it only for a terminating term, and
 /// `normalize_log_match_action` (#2616) rewrites the stored log_match action to
 /// the final verdict before the result is returned.
+///
+/// #5857: `now_ns` gates the three-color policer METER — a side effect that
+/// (like the tx-selection leg's `merge_matched_tx_modifiers`) must run on EVERY
+/// matched term, fall-through or terminating, exactly once. `Some(now_ns)` (the
+/// lo0 host-bound path) meters `term.three_color_policer` and folds its drop
+/// (OR-accumulated so a later permit cannot erase an earlier drop) and its
+/// color/DSCP rewrite (policer rewrite wins over the term's configured rewrite,
+/// matching the tx-selection precedence). `None` (interface input/output
+/// action-eval + PBR prechecks, which meter their policer in the tx-selection
+/// walk) skips the meter and is byte-for-byte identical to pre-#5857.
 #[inline]
-fn merge_matched_modifiers(acc: &mut FilterResult, filter: &Filter, term: &FilterTerm) {
-    if term.dscp_rewrite.is_some() {
-        acc.dscp_rewrite = term.dscp_rewrite;
+fn merge_matched_modifiers(
+    acc: &mut FilterResult,
+    filter: &Filter,
+    term: &FilterTerm,
+    now_ns: Option<u64>,
+    packet_bytes: u64,
+) {
+    // #5857: meter the three-color policer once per matched term when the caller
+    // requested metering (lo0). `now_ns == None` returns the default no-op action
+    // (drop=false, dscp_rewrite=None), preserving the non-metered paths exactly.
+    let policer_action = apply_term_three_color_policer(term, now_ns, packet_bytes);
+    // #5857: policer color/DSCP rewrite takes precedence over the term's
+    // configured rewrite; otherwise the term's rewrite carries forward (a `None`
+    // policer action + no term rewrite leaves any earlier term's rewrite intact,
+    // matching the pre-#5857 `if term.dscp_rewrite.is_some()` assignment).
+    if let Some(rewrite) = policer_action.dscp_rewrite.or(term.dscp_rewrite) {
+        acc.dscp_rewrite = Some(rewrite);
     }
+    acc.policer_drop |= policer_action.drop;
     if !term.policer_name.is_empty() {
         acc.policer_name = term.policer_name.clone();
     }
@@ -198,6 +243,7 @@ fn evaluate_filter_ref_counted_v6(
     dscp: u8,
     extra: TermMatchExtra<'_>,
     packet_bytes: u64,
+    now_ns: Option<u64>,
 ) -> FilterResult {
     // #2544: see evaluate_filter_ref_counted_v4 — accumulate fall-through
     // modifiers; return on the first terminating matched term.
@@ -211,7 +257,7 @@ fn evaluate_filter_ref_counted_v6(
         if term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
-        merge_matched_modifiers(&mut acc, filter, term);
+        merge_matched_modifiers(&mut acc, filter, term, now_ns, packet_bytes);
         if !term.continue_term {
             acc.action = term.action;
             normalize_log_match_action(&mut acc);
@@ -336,7 +382,9 @@ fn evaluate_filter_ref_non_routing_counted_v4(
         if always_count && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
-        merge_matched_modifiers(&mut acc, filter, term);
+        // #5857: the non-routing input-filter evaluator does NOT meter its
+        // policer here (it is metered in the tx-selection walk); pass None.
+        merge_matched_modifiers(&mut acc, filter, term, None, packet_bytes);
         // This loop variant never carries a routing-instance through the
         // result (it defers to the routing-instance evaluator); keep that.
         acc.routing_instance = String::new();
@@ -429,7 +477,9 @@ fn evaluate_filter_ref_non_routing_counted_v6(
         if always_count && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
-        merge_matched_modifiers(&mut acc, filter, term);
+        // #5857: the non-routing input-filter evaluator does NOT meter its
+        // policer here (it is metered in the tx-selection walk); pass None.
+        merge_matched_modifiers(&mut acc, filter, term, None, packet_bytes);
         acc.routing_instance = String::new();
         if !term.continue_term {
             acc.action = term.action;
@@ -620,11 +670,20 @@ pub(crate) fn evaluate_lo0_filter(
     dscp: u8,
     extra: TermMatchExtra<'_>,
 ) -> FilterResult {
+    // #5857: the test convenience wrapper does NOT meter (now_ns = None); it is
+    // used only by tests that assert the verdict/counters, not policer metering.
     evaluate_lo0_filter_counted(
-        state, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra, 0,
+        state, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra, 0, None,
     )
 }
 
+/// #5857: `now_ns` threads the poll-iteration monotonic timestamp so the lo0
+/// host-bound filter METERS each matched term's three-color policer (the same
+/// runtime the interface TX-selection leg meters). `Some(now_ns)` — the live
+/// local-delivery path — enforces the configured control-plane rate limit;
+/// `None` — the `evaluate_lo0_filter` test convenience wrapper — evaluates the
+/// verdict/counters without metering. lo0 has no separate tx-selection leg, so
+/// this is the ONLY place its policer is metered (no double-meter risk).
 pub(crate) fn evaluate_lo0_filter_counted(
     state: &FilterState,
     is_v6: bool,
@@ -636,6 +695,7 @@ pub(crate) fn evaluate_lo0_filter_counted(
     dscp: u8,
     extra: TermMatchExtra<'_>,
     packet_bytes: u64,
+    now_ns: Option<u64>,
 ) -> FilterResult {
     let filter = if is_v6 {
         state.lo0_filter_v6_fast.as_deref()
@@ -655,6 +715,7 @@ pub(crate) fn evaluate_lo0_filter_counted(
         dscp,
         extra,
         packet_bytes,
+        now_ns,
     )
 }
 
@@ -728,6 +789,10 @@ pub(crate) fn evaluate_interface_filter_counted(
         dscp,
         extra,
         packet_bytes,
+        // #5857: interface input/output filters meter their three-color policer
+        // in the tx-selection walk, not in this action-eval — pass None so this
+        // walk does NOT meter (metering here would double-meter).
+        None,
     )
 }
 
@@ -1003,6 +1068,10 @@ pub(crate) fn evaluate_interface_output_filter_counted(
         dscp,
         extra,
         packet_bytes,
+        // #5857: interface input/output filters meter their three-color policer
+        // in the tx-selection walk, not in this action-eval — pass None so this
+        // walk does NOT meter (metering here would double-meter).
+        None,
     )
 }
 

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -837,6 +837,15 @@ pub(crate) struct FilterResult {
     pub(crate) action: FilterAction,
     pub(crate) dscp_rewrite: Option<u8>,
     pub(crate) policer_name: String,
+    // #5857: OR of every matched term's three-color-policer drop decision. Only
+    // the METERED walk (`evaluate_lo0_filter_counted` with `now_ns = Some`, the
+    // lo0 host-bound path) sets this; the shared action-eval walk leaves it false
+    // (its policer is metered in the tx-selection leg, not here). A late permit
+    // cannot erase an earlier policer drop because this is OR-accumulated across
+    // the whole `next term` chain. The lo0 caller downgrades an `Accept` verdict
+    // to a silent `Discard` when this is set — enforcing the configured
+    // control-plane rate limit that was previously inert on host-bound traffic.
+    pub(crate) policer_drop: bool,
     pub(crate) routing_instance: String,
     // #5151: `None` == no forwarding-class matched (semantically identical to
     // the historical empty `""`). Mirrors TxSelection/CachedTxSelection which
@@ -905,6 +914,8 @@ impl Default for FilterResult {
             action: FilterAction::Accept,
             dscp_rewrite: None,
             policer_name: String::new(),
+            // #5857: no policer drop by default; set only by the metered lo0 walk.
+            policer_drop: false,
             routing_instance: String::new(),
             // #5151: zero-alloc default — no Arc header/data block allocated on
             // the warmed packet path. A matching `then forwarding-class` term


### PR DESCRIPTION
## Summary

Closes #5857.

Firewall filters attached to `lo0` can carry a `then policer`, and the Rust
filter compiler links the three-color runtime onto the term exactly as it does
for interface filters. But the lo0 / local-delivery path evaluated the filter
with `evaluate_lo0_filter_counted` and consumed only `result.action` +
`result.log_match`: it never called `apply_term_three_color_policer`, never
metered the named policer, and never applied a policer drop. A strict-valid
control-plane rate limit (SSH, BGP, routing protocols, ICMP to the routing
engine) was therefore **inert** — counters/logs could make the term look active
while every matching host-bound packet was delivered unmetered. An untrusted
peer could exceed the operator's control-plane-protection envelope. This is a
security-appliance correctness gap, not just missing telemetry.

## Fix — reuse the existing metering, do not reimplement it

The three-color meter (`apply_term_three_color_policer`) is proven on the
interface TX-selection and cached-flow paths; it was simply **absent** from the
lo0 path. This PR wires it in:

- **`filter/engine/eval.rs`** — thread `now_ns: Option<u64>` through the shared
  `evaluate_filter_ref_counted` → `_v4`/`_v6` → `merge_matched_modifiers`.
  `Some(now_ns)` (the lo0 host-bound path) meters each matched term's
  three-color policer and folds the drop into `FilterResult.policer_drop`
  (OR-accumulated across a `then next term` chain, so a later permit cannot
  erase an earlier policer drop), with the policer's DSCP-rewrite taking
  precedence over the term's — exactly as the tx-selection leg does. `None`
  (interface input/output action-eval + PBR prechecks, which meter their policer
  in the separate tx-selection walk) skips metering here and is byte-for-byte
  identical to pre-change behavior → **no double-meter**. lo0 has no
  tx-selection leg, so this is the ONLY place its policer is metered.
- **`filter/mod.rs`** — add `FilterResult.policer_drop` (default false; set only
  by the metered lo0 walk).
- **`afxdp/poll_descriptor/filter.rs`** — `apply_lo0_filter_action` +
  `host_inbound_gated_lo0_action` take `now_ns: u64`; `apply_lo0_filter_action`
  passes `Some(now_ns)` and downgrades an `Accept` verdict to a silent `Discard`
  when `policer_drop` is set (Junos policer drops are silent — no TCP RST / ICMP
  unreachable). All 3 LocalDelivery call sites in `poll_descriptor/mod.rs`
  (flowless, session-HIT, session-MISS) thread `now_ns`.

**Scope note:** host-bound DSCP/color rewrite for a policed lo0 packet is NOT
applied to the delivered frame (the lo0 local-delivery path has no
frame-DSCP-rewrite mechanism — even a term's plain `then dscp` is unapplied on
lo0). Only the drop — the control-plane-protection enforcement — is wired.
Documented in `filter/README.md`.

## Test — fail-on-revert (cargo)

`lo0_policer_meters_and_drops_host_bound_traffic` (in `poll_descriptor/filter.rs`)
drives `host_inbound_gated_lo0_action` — the single helper both LocalDelivery
sites route through — with a conforming then an exceeding host-bound UDP packet
on an admit-all zone. It asserts the exceeding packet returns `Discard` **and**
the policer `drop_packets` counter advances.

Reverting the metering wire-in → second packet accepted, drop counter 0 → **RED**
(verified firsthand):

```
test afxdp::poll_descriptor::filter::lo0_gate_tests::lo0_policer_meters_and_drops_host_bound_traffic ... FAILED
assertion `left == right` failed: host-bound traffic above the lo0 policer rate must be dropped (#5857)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3868 filtered out
```

## Validation

- `cargo build --release` clean.
- Full `cargo test --release`: **3867 passed, 0 failed**.
- lo0 suite (13) + policer suite (16) green; new test green.
- `cargo fmt` clean on the changed hunk.

## Smoke deferral

Loss-cluster smoke is blocked by the shim-ABI wall, and this is a pure Rust
dataplane local-delivery change. Correctness is gated on the cargo
fail-on-revert test above; no cluster smoke was attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)