### PR TITLE
screen: token-bucket the per-destination ICMP/UDP flood sketches (#5805)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-16 — #5805: per-destination ICMP/UDP flood sketches → token bucket
+
+- **Timestamp**: 2026-07-16 (fix/5805-per-dest-flood-tokenbucket)
+- **Action**: The #3607 token-bucket migration fixed the per-ZONE aggregate
+  ICMP/UDP flood gates but deliberately left the PRIMARY per-DESTINATION
+  sketches on `RateCounter`, which has the count-all / whole-second defect: a
+  destination sending exactly the configured threshold in one second is dropped
+  to ~0 in every subsequent second until a fully idle second (rejected packets
+  keep incrementing the window). So the primary Junos-compatible per-destination
+  ICMP/UDP flood limits did NOT implement the configured rate — a legitimate
+  at-threshold destination was starved.
+  Fix (pattern-extension of #3607 — reuse the proven `TokenBucket`, no new
+  mechanism): made the count-min `SynRateSketch` GENERIC over its per-cell
+  limiter via a new `SketchCell` trait (`RateCounter::increment` /
+  `TokenBucket::admit_is_over`). The SYN per-source/per-destination sketches keep
+  `RateCounter` cells (count-all is deliberate there — "admitted" activates SYN
+  cookies / the alarm); the ICMP/UDP per-destination flood sketches now use
+  `SynRateSketch<TokenBucket>` (`for_flood_dst`, keyed on `loop_now_ns`). A
+  sustained at-threshold destination is admitted STEADILY (token bucket refills
+  continuously), an over-threshold destination is still limited DOWN to the rate,
+  a sub-ms straddle sees at most `threshold` tokens (#2937 preserved), and live
+  threshold changes grant no unintended burst (capacity clamp, inherited from
+  `TokenBucket`). Both cells are 16 B, so the sketch memory bound (ROWS*cols*16)
+  is unchanged and the no-eviction / seeded-mapping / AND-min semantics are
+  preserved.
+- **File(s)**: `userspace-dp/src/screen/syn_rate.rs` (SketchCell trait, generic
+  sketch, `for_flood_dst`), `userspace-dp/src/screen/mod.rs` (flood sketch field
+  types → `SynRateSketch<TokenBucket>`, `for_flood_dst` alloc, `now_ns` in the
+  flood-drop helpers), `userspace-dp/src/screen/syn_rate_tests.rs` (+4
+  token-bucket sketch tests), `userspace-dp/src/screen/tests.rs` (+4 RED-on-revert
+  integration tests: ICMP/UDP/flowless sustained-at-threshold across 20s, IPv6
+  over-threshold-still-limited; rewrote the old RateCounter boundary test to the
+  token-bucket burst-bound-and-refill semantics),
+  `docs/syn-cookie-flood-protection.md`.
+
 ## 2026-07-16 — #5856: per-zone Time-Exceeded / Packet-Too-Big ICMP buckets
 
 - **Timestamp**: 2026-07-16 (fix/5856-per-zone-icmp-buckets)

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -182,9 +182,13 @@ code-vs-comment contradiction). A per-IP trip hard-drops with the existing
 `syn-flood` reason id (no Go gRPC/CLI change); per-source vs per-destination is
 distinguished by separate per-worker counters.
 
-Substrate (`userspace-dp/src/screen/syn_rate.rs`): a per-zone **count-min sketch
-of `RateCounter`s** — `ROWS=4` independent seeded-hash rows × `DST_COLS=1024` /
-`SRC_COLS=2048` columns — with **no eviction**. A key always counts in its
+Substrate (`userspace-dp/src/screen/syn_rate.rs`): a per-zone **count-min sketch**
+generic over its per-cell limiter (`SynRateSketch<C>`) — `ROWS=4` independent
+seeded-hash rows × `DST_COLS=1024` / `SRC_COLS=2048` columns — with **no
+eviction**. The SYN per-source/per-destination sketches use count-all
+`RateCounter` cells (this section); the #5805 ICMP/UDP per-destination flood
+sketches use monotonic-ns `TokenBucket` cells (see the #4112 section above). A
+key always counts in its
 `ROWS` cells and trips ⟺ ALL cells are over threshold (the CMS `min` read,
 implemented as the AND of the per-row results, never OR/MAX). No eviction means
 no Hot-Set-Lockout / Cold-Start-Eviction-Race starvation (a victim is always
@@ -357,16 +361,19 @@ to ~0 until a fully idle second (the #3607 over-throttle) — while a
 sub-millisecond boundary straddle still sees at most `budget` tokens, so an
 attacker cannot double the plausible-ACK validation budget across a wall-second
 boundary (#2937 preserved). The same token bucket is the drop authority for the
-ICMP/UDP flood per-zone aggregates and for the SYN-flood aggregate DROP path
-when `syn-cookie` is OFF (with no cookie to bypass, a sustained-at-threshold
-legitimate SYN stream must be admitted, so the bucket — not the count-all
-counter — is the sole drop gate on every initial SYN). The SYN-flood aggregate
-that ACTIVATES cookies when `syn-cookie` is ON, the alarm-threshold arrival-rate
-measurement, and the #3315 per-source/per-destination sketch deliberately stay
-on the count-all sliding-window `RateCounter`: there "admitted" means "skip a
-security response" (the cookie challenge, the alarm, the per-IP cap), so the
-sustained-at-threshold over-throttle is protective or benign rather than a bug
-(see `screen/rate.rs` and `docs/research/3607-screen-rate/plan.md`).
+ICMP/UDP flood per-zone aggregates, for the #5805 ICMP/UDP per-DESTINATION flood
+sketch cells (`SynRateSketch<TokenBucket>`, `for_flood_dst` — a sustained
+at-threshold destination must stay admitted, the same shaper argument as the
+aggregate), and for the SYN-flood aggregate DROP path when `syn-cookie` is OFF
+(with no cookie to bypass, a sustained-at-threshold legitimate SYN stream must be
+admitted, so the bucket — not the count-all counter — is the sole drop gate on
+every initial SYN). The SYN-flood aggregate that ACTIVATES cookies when
+`syn-cookie` is ON, the alarm-threshold arrival-rate measurement, and the #3315
+per-source/per-destination SYN sketch deliberately stay on the count-all
+sliding-window `RateCounter`: there "admitted" means "skip a security response"
+(the cookie challenge, the alarm, the per-IP cap), so the sustained-at-threshold
+over-throttle is protective or benign rather than a bug (see `screen/rate.rs` and
+`docs/research/3607-screen-rate/plan.md`).
 Invalid ACKs outside a local active flood window remain ordinary session-miss
 traffic instead of being counted as cookie failures.
 

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -187,12 +187,18 @@ pub(crate) struct ScreenState {
     /// threshold` is per destination). Present (Some) only for zones whose
     /// `icmp_flood_threshold > 0`; reuses the #3315 count-min `SynRateSketch`
     /// substrate. PRIMARY cap — checked before the per-zone aggregate ceiling.
-    icmp_dst_sketch: FxHashMap<String, SynRateSketch>,
+    /// #5805: the sketch cells are monotonic-ns `TokenBucket`s, not
+    /// `RateCounter`s, so a destination parked at exactly `icmp_flood_threshold`
+    /// pps stays admitted STEADILY (the count-all `RateCounter` collapsed it to
+    /// ~0 after the first second) while an over-threshold destination is still
+    /// limited down to the configured rate.
+    icmp_dst_sketch: FxHashMap<String, SynRateSketch<TokenBucket>>,
     /// #4112: per-zone per-DESTINATION (IP + PORT) UDP flood sketch (Junos `udp
     /// flood threshold` is per destination IP AND port). Present only for zones
     /// whose `udp_flood_threshold > 0`; reuses the #3315 sketch via
     /// `increment_ip_port`. PRIMARY cap — checked before the per-zone aggregate.
-    udp_dst_sketch: FxHashMap<String, SynRateSketch>,
+    /// #5805: `TokenBucket` cells (see `icmp_dst_sketch`).
+    udp_dst_sketch: FxHashMap<String, SynRateSketch<TokenBucket>>,
     syn_cookie_active_until_secs: FxHashMap<String, u64>,
     /// #3607: the standby SYN-cookie ACK validation budget is a validate-budget
     /// shaper ("admitted" = "spend a SipHash on a plausible returning ACK"; a
@@ -434,12 +440,12 @@ impl ScreenState {
             if profiles[zone].icmp_flood_threshold > 0 {
                 self.icmp_dst_sketch
                     .entry(zone.clone())
-                    .or_insert_with(SynRateSketch::for_dst);
+                    .or_insert_with(SynRateSketch::for_flood_dst);
             }
             if profiles[zone].udp_flood_threshold > 0 {
                 self.udp_dst_sketch
                     .entry(zone.clone())
-                    .or_insert_with(SynRateSketch::for_dst);
+                    .or_insert_with(SynRateSketch::for_flood_dst);
             }
             self.syn_cookie_active_until_secs
                 .entry(zone.clone())
@@ -651,13 +657,15 @@ impl ScreenState {
         dst_ip: &IpAddr,
         threshold: u32,
         now_ns: u64,
-        now_secs: u64,
     ) -> bool {
-        // (1) per-DESTINATION cap — PRIMARY (Junos parity). Still the #3315
-        // count-min `RateCounter` sketch (deferred from the #3607 migration —
-        // see the plan §5b); keyed on `now_secs`.
+        // (1) per-DESTINATION cap — PRIMARY (Junos parity). #5805: the count-min
+        // sketch now carries monotonic-ns `TokenBucket` cells (keyed on `now_ns`,
+        // the batch-cached `loop_now_ns`), so a destination parked at exactly
+        // `threshold` pps is admitted STEADILY instead of collapsing to ~0 after
+        // the first second (the count-all `RateCounter` defect). An
+        // over-threshold destination is still limited down to `threshold`.
         if let Some(sketch) = self.icmp_dst_sketch.get_mut(zone)
-            && sketch.increment(dst_ip, now_secs, threshold)
+            && sketch.increment(dst_ip, now_ns, threshold)
         {
             return true;
         }
@@ -686,10 +694,10 @@ impl ScreenState {
         dst_port: u16,
         threshold: u32,
         now_ns: u64,
-        now_secs: u64,
     ) -> bool {
-        // (1) per-DESTINATION cap — PRIMARY (Junos parity). Still the #3315
-        // `RateCounter` sketch (deferred, `now_secs`).
+        // (1) per-DESTINATION cap — PRIMARY (Junos parity). #5805: `TokenBucket`
+        // sketch cells keyed on `now_ns` (see `icmp_flood_drop`), so a
+        // (dst_ip, dst_port) parked at exactly `threshold` pps stays admitted.
         //
         // #4567: a non-first IP fragment carries no L4 header, so the flowless
         // caller passes `dst_port == 0`. Counting it via `increment_ip_port(ip,
@@ -707,9 +715,9 @@ impl ScreenState {
         // lacks, so the per-IP fold is the bounded, honest abstraction.
         if let Some(sketch) = self.udp_dst_sketch.get_mut(zone) {
             let over = if dst_port == 0 {
-                sketch.increment(dst_ip, now_secs, threshold)
+                sketch.increment(dst_ip, now_ns, threshold)
             } else {
-                sketch.increment_ip_port(dst_ip, dst_port, now_secs, threshold)
+                sketch.increment_ip_port(dst_ip, dst_port, now_ns, threshold)
             };
             if over {
                 return true;
@@ -878,7 +886,7 @@ impl ScreenState {
         // (SECONDARY). Junos measures this rate per destination IP (#4112 F18).
         if icmp_flood_threshold > 0
             && (pkt.protocol == PROTO_ICMP || pkt.protocol == PROTO_ICMPV6)
-            && self.icmp_flood_drop(zone, &pkt.dst_ip, icmp_flood_threshold, now_ns, now_secs)
+            && self.icmp_flood_drop(zone, &pkt.dst_ip, icmp_flood_threshold, now_ns)
         {
             return ScreenVerdict::Drop("icmp-flood");
         }
@@ -888,14 +896,7 @@ impl ScreenState {
         // (#4112 F18).
         if udp_flood_threshold > 0
             && pkt.protocol == PROTO_UDP
-            && self.udp_flood_drop(
-                zone,
-                &pkt.dst_ip,
-                pkt.dst_port,
-                udp_flood_threshold,
-                now_ns,
-                now_secs,
-            )
+            && self.udp_flood_drop(zone, &pkt.dst_ip, pkt.dst_port, udp_flood_threshold, now_ns)
         {
             return ScreenVerdict::Drop("udp-flood");
         }
@@ -1228,7 +1229,7 @@ impl ScreenState {
         // fragment-based flood from evading the per-destination cap.
         if icmp_flood_threshold > 0
             && (pkt.protocol == PROTO_ICMP || pkt.protocol == PROTO_ICMPV6)
-            && self.icmp_flood_drop(zone, &pkt.dst_ip, icmp_flood_threshold, now_ns, now_secs)
+            && self.icmp_flood_drop(zone, &pkt.dst_ip, icmp_flood_threshold, now_ns)
         {
             return ScreenVerdict::Drop("icmp-flood");
         }
@@ -1240,14 +1241,7 @@ impl ScreenState {
         // stray `(ip, 0)` cell (#4112 F18, #4567).
         if udp_flood_threshold > 0
             && pkt.protocol == PROTO_UDP
-            && self.udp_flood_drop(
-                zone,
-                &pkt.dst_ip,
-                pkt.dst_port,
-                udp_flood_threshold,
-                now_ns,
-                now_secs,
-            )
+            && self.udp_flood_drop(zone, &pkt.dst_ip, pkt.dst_port, udp_flood_threshold, now_ns)
         {
             return ScreenVerdict::Drop("udp-flood");
         }

--- a/userspace-dp/src/screen/syn_rate.rs
+++ b/userspace-dp/src/screen/syn_rate.rs
@@ -13,15 +13,34 @@
 //! additionally per destination PORT), not per zone aggregate. `increment` keys
 //! on the destination IP (ICMP, and a port-less UDP fragment — #4567);
 //! `increment_ip_port` mixes the destination port in (UDP with a real L4 port).
-//! The per-zone aggregate `RateCounter` is retained as a coarser SECONDARY
+//! The per-zone aggregate `TokenBucket` is retained as a coarser SECONDARY
 //! ceiling above these per-destination caps.
 //!
-//! ## Substrate — count-min sketch of `RateCounter`s, NO eviction
+//! ## The cell type is generic over [`SketchCell`] (#5805)
+//!
+//! The sketch is parameterized over its per-cell limiter so the SAME count-min
+//! structure serves two consumers with different admission semantics:
+//!
+//! - The #3315 SYN per-source / per-destination sketches use `RateCounter`
+//!   cells (the DEFAULT `SynRateSketch<RateCounter>` — `for_dst` / `for_src`).
+//!   There "admitted" means "skip a recoverable security response", so the
+//!   count-all sustained-at-threshold over-throttle is deliberate.
+//! - The #4112 / #5805 ICMP/UDP per-destination flood sketches use `TokenBucket`
+//!   cells (`SynRateSketch<TokenBucket>` — `for_flood_dst`). A flood cap is a
+//!   pure rate gate: a destination parked at exactly `threshold` events/second
+//!   must stay admitted STEADILY. `RateCounter` collapsed it to ~0 after the
+//!   first second (count-all whole-second window, #5805); the token bucket
+//!   refills continuously so the configured rate is honoured, while a
+//!   sub-millisecond boundary straddle still sees at most `threshold` tokens
+//!   (#2937 preserved) and an over-threshold destination is still limited DOWN
+//!   to the rate.
+//!
+//! ## Substrate — count-min sketch of `SketchCell`s, NO eviction
 //!
 //! The limiter is a **count-min sketch (CMS)**: `ROWS` independent rows of
-//! `cols` `RateCounter`s. A key (an IP) maps, via `ROWS` INDEPENDENT seeded
-//! hashes, to one cell per row. `increment` advances and counts the key in all
-//! `ROWS` cells and reports whether it is over the threshold.
+//! `cols` cells. A key (an IP) maps, via `ROWS` INDEPENDENT seeded hashes, to
+//! one cell per row. `increment` advances and counts the key in all `ROWS`
+//! cells and reports whether it is over the threshold.
 //!
 //! Trip ⟺ EVERY one of the `ROWS` cells reports over-threshold. Because the
 //! smallest over-threshold cell implies all cells exceed it, this is exactly
@@ -74,14 +93,63 @@
 //! eviction scan — steady-state AND under a spoofed flood. Allocated once at
 //! config for zones that configure a threshold; freed when disabled.
 //!
-//! `RateCounter` ≈ 16 B. Per configured zone, per worker: per-dest
-//! `ROWS*DST_COLS*16 = 64 KiB` + per-source `ROWS*SRC_COLS*16 = 128 KiB` =
-//! 192 KiB/zone, × num_workers. Bounded by the Go commit-time memory advisory.
+//! Both `RateCounter` and `TokenBucket` cells are ≈ 16 B, so the per-cell size
+//! (and thus the sketch's memory bound) is identical whichever cell the sketch
+//! carries. Per configured zone, per worker: per-dest `ROWS*DST_COLS*16 = 64
+//! KiB` + per-source `ROWS*SRC_COLS*16 = 128 KiB` = 192 KiB/zone, ×
+//! num_workers. Fixed at construction, never resized — bounded by the Go
+//! commit-time memory advisory.
 
-use super::rate::RateCounter;
+use super::rate::{RateCounter, TokenBucket};
 use rustc_hash::FxHasher;
 use std::hash::Hasher;
 use std::net::IpAddr;
+
+/// One count-min sketch cell: charge an event and report whether the key is
+/// OVER its per-cell limit. This abstracts the two per-cell limiters the sketch
+/// can carry so the count-min structure (rows, seeded hashing, all-row update,
+/// AND/MIN reduction) is written ONCE and shared:
+///
+/// - [`RateCounter`] — the count-all two-bucket sliding window. Used by the
+///   #3315 SYN per-source / per-destination sketches, where "admitted" means
+///   "skip a recoverable security response" (activate SYN cookies / raise the
+///   alarm) and the sustained-at-threshold over-throttle is DELIBERATE.
+/// - [`TokenBucket`] — the monotonic-nanosecond shaper (#3607). Used by the
+///   #4112 / #5805 ICMP/UDP per-destination FLOOD sketches, a pure rate gate
+///   that MUST admit a destination parked at exactly `threshold` events/second
+///   without collapsing after the first second (the #5805 fix).
+///
+/// Both cells are 16 bytes, so the sketch's `ROWS*cols*16` memory bound is
+/// identical for either. `now` is a monotonic time value whose UNIT is defined
+/// by the impl — wall/monotonic SECONDS for `RateCounter`, monotonic
+/// NANOSECONDS for `TokenBucket` — and the caller passes the matching clock
+/// (`now_secs` for the SYN sketches, the batch-cached `loop_now_ns` for the
+/// flood sketches).
+pub(super) trait SketchCell: Clone + Default {
+    /// Charge one event against this cell; return `true` when the key is OVER
+    /// LIMIT (drop) and `false` when admitted — the `true == drop` polarity the
+    /// count-min AND-reduction expects. The event is charged in every row cell
+    /// (the count-min side effect) whatever the verdict.
+    fn charge(&mut self, now: u64, threshold: u32) -> bool;
+}
+
+impl SketchCell for RateCounter {
+    #[inline]
+    fn charge(&mut self, now_secs: u64, threshold: u32) -> bool {
+        self.increment(now_secs, threshold)
+    }
+}
+
+impl SketchCell for TokenBucket {
+    #[inline]
+    fn charge(&mut self, now_ns: u64, threshold: u32) -> bool {
+        // The token bucket consumes a token only on ADMIT: a rejected packet
+        // OBSERVES capacity but does not charge it (the #5805 fix — a sustained
+        // at-threshold destination is never starved by its own rejected
+        // packets, unlike `RateCounter`'s count-all window).
+        self.admit_is_over(now_ns, threshold)
+    }
+}
 
 /// Number of independent hash rows (`d`). 4 keeps the over-count false-positive
 /// rate (`~load^4`) below noise while bounding the per-packet cache-line touches.
@@ -120,11 +188,17 @@ const ROW_SEEDS: [u64; ROWS] = [
     0x27D4_EB2F_1656_67C5,
 ];
 
-/// Count-min sketch of `RateCounter`s with no eviction. See module docs.
-pub(super) struct SynRateSketch {
-    /// `ROWS` rows of `cols` counters. `Box<[Box<[RateCounter]>]>` is allocated
-    /// once at construction and never resized — the hot path only indexes.
-    rows: Box<[Box<[RateCounter]>]>,
+/// Count-min sketch of [`SketchCell`]s with no eviction. See module docs.
+///
+/// Generic over the per-cell limiter `C`. The DEFAULT `RateCounter` keeps the
+/// SYN per-source / per-destination sketches (#3315) bit-identical; the
+/// ICMP/UDP per-destination flood sketches use `SynRateSketch<TokenBucket>`
+/// (#5805) so a sustained-at-threshold destination is admitted at the
+/// configured rate rather than collapsing after the first second.
+pub(super) struct SynRateSketch<C = RateCounter> {
+    /// `ROWS` rows of `cols` cells. `Box<[Box<[C]>]>` is allocated once at
+    /// construction and never resized — the hot path only indexes.
+    rows: Box<[Box<[C]>]>,
     /// Index mask (`cols - 1`); `cols` is a power of two.
     mask: usize,
     /// Per-boot secret folded into the cell hash alongside `ROW_SEEDS[row]`
@@ -136,23 +210,22 @@ pub(super) struct SynRateSketch {
     seed: u64,
 }
 
-impl SynRateSketch {
-    fn with_cols(cols: usize) -> Self {
-        Self::with_cols_seeded(cols, crate::hot_hash_seed::hot_path_hash_seed())
-    }
-
-    /// Seed-parameterized core of `with_cols`. Split out so adversarial tests can
-    /// pin the seed and assert (a) intra-seed stability of the key→cell mapping
-    /// and (b) cross-seed reshuffling — mirroring `FlowCache::set_index_seeded`.
-    /// Production always calls through `with_cols`, which supplies the per-boot
-    /// process seed.
-    fn with_cols_seeded(cols: usize, seed: u64) -> Self {
+impl<C: SketchCell> SynRateSketch<C> {
+    /// Seed-parameterized generic core. Builds `ROWS` rows of `cols`
+    /// default-initialised cells. Split out so adversarial tests can pin the
+    /// seed and assert (a) intra-seed stability of the key→cell mapping and (b)
+    /// cross-seed reshuffling — mirroring `FlowCache::set_index_seeded`.
+    /// Production allocates through the typed `with_cols` / `for_flood_dst`
+    /// constructors, which supply the per-boot process seed. Both cell types
+    /// cold-start correctly from `default()` (an empty `RateCounter` window / a
+    /// cold `TokenBucket` that begins FULL on first use).
+    fn build_seeded(cols: usize, seed: u64) -> Self {
         debug_assert!(
             cols.is_power_of_two(),
             "SynRateSketch cols must be a power of two"
         );
         let rows = (0..ROWS)
-            .map(|_| vec![RateCounter::default(); cols].into_boxed_slice())
+            .map(|_| vec![C::default(); cols].into_boxed_slice())
             .collect::<Vec<_>>()
             .into_boxed_slice();
         Self {
@@ -160,16 +233,6 @@ impl SynRateSketch {
             mask: cols - 1,
             seed,
         }
-    }
-
-    /// Allocate the per-DESTINATION sketch (`DST_COLS` columns).
-    pub(super) fn for_dst() -> Self {
-        Self::with_cols(DST_COLS)
-    }
-
-    /// Allocate the per-SOURCE sketch (`SRC_COLS` columns).
-    pub(super) fn for_src() -> Self {
-        Self::with_cols(SRC_COLS)
     }
 
     /// Cell index for `ip` in row `row` (independent seeded hash, masked to the
@@ -186,20 +249,22 @@ impl SynRateSketch {
         (h.finish() as usize) & self.mask
     }
 
-    /// Count one SYN for `ip` and report whether `ip` is over `threshold` in the
-    /// trailing 1-second window.
+    /// Count one event for `ip` and report whether `ip` is over `threshold`.
     ///
-    /// Every row cell is incremented (the count-min side effect MUST happen in
-    /// all rows even when an earlier row is already under threshold), then the
+    /// `now` is the cell's clock unit — `now_secs` for a `RateCounter` sketch,
+    /// the batch-cached `loop_now_ns` for a `TokenBucket` sketch.
+    ///
+    /// Every row cell is charged (the count-min side effect MUST happen in all
+    /// rows even when an earlier row is already under threshold), then the
     /// per-row over-threshold results are AND-ed: the key trips ⟺ ALL rows
     /// report over-threshold (= `min` over rows > threshold). `&=` here is the
     /// non-short-circuiting bitwise-and assignment, so it never skips a row's
-    /// `increment`.
-    pub(super) fn increment(&mut self, ip: &IpAddr, now_secs: u64, threshold: u32) -> bool {
+    /// `charge`.
+    pub(super) fn increment(&mut self, ip: &IpAddr, now: u64, threshold: u32) -> bool {
         let mut over_all = true;
         for row in 0..ROWS {
             let idx = self.cell_index(row, ip);
-            let over = self.rows[row][idx].increment(now_secs, threshold);
+            let over = self.rows[row][idx].charge(now, threshold);
             over_all &= over;
         }
         over_all
@@ -223,21 +288,21 @@ impl SynRateSketch {
     }
 
     /// Count one packet for `(ip, port)` and report whether it is over
-    /// `threshold` in the trailing 1-second window. Mirrors `increment` but keys
-    /// on the L4 destination port too — the UDP per-destination-port flood cap
-    /// (#4112 F18). Every row cell is still incremented (non-short-circuiting
-    /// AND), so the count-min side effect happens in all rows.
+    /// `threshold`. Mirrors `increment` but keys on the L4 destination port too
+    /// — the UDP per-destination-port flood cap (#4112 F18). Every row cell is
+    /// still charged (non-short-circuiting AND), so the count-min side effect
+    /// happens in all rows. `now` is the cell's clock unit (see `increment`).
     pub(super) fn increment_ip_port(
         &mut self,
         ip: &IpAddr,
         port: u16,
-        now_secs: u64,
+        now: u64,
         threshold: u32,
     ) -> bool {
         let mut over_all = true;
         for row in 0..ROWS {
             let idx = self.cell_index_ip_port(row, ip, port);
-            let over = self.rows[row][idx].increment(now_secs, threshold);
+            let over = self.rows[row][idx].charge(now, threshold);
             over_all &= over;
         }
         over_all
@@ -262,12 +327,54 @@ impl SynRateSketch {
 
     /// Directly drive a specific `(row, col)` cell over `threshold`, simulating
     /// colliding hot keys without searching for collider IPs. Test seam only.
+    /// Charges the cell `threshold + 1` times at the SAME `now`, which drives a
+    /// `RateCounter` window strictly above `threshold` AND drains a `TokenBucket`
+    /// cell to empty (cold-start capacity is `threshold`), so the cell reports
+    /// over-limit for either cell type.
     #[cfg(test)]
-    pub(super) fn saturate_cell(&mut self, row: usize, col: usize, now_secs: u64, threshold: u32) {
-        // Drive the trailing-window sum strictly above threshold.
+    pub(super) fn saturate_cell(&mut self, row: usize, col: usize, now: u64, threshold: u32) {
         for _ in 0..=threshold {
-            self.rows[row][col].increment(now_secs, threshold);
+            self.rows[row][col].charge(now, threshold);
         }
+    }
+}
+
+impl SynRateSketch<RateCounter> {
+    fn with_cols(cols: usize) -> Self {
+        Self::with_cols_seeded(cols, crate::hot_hash_seed::hot_path_hash_seed())
+    }
+
+    /// Seed-pinned `RateCounter` constructor. Production calls through
+    /// `with_cols`; adversarial tests pin the seed to assert key→cell mapping
+    /// stability and cross-seed reshuffling.
+    fn with_cols_seeded(cols: usize, seed: u64) -> Self {
+        Self::build_seeded(cols, seed)
+    }
+
+    /// Allocate the per-DESTINATION SYN sketch (`DST_COLS` columns) with
+    /// count-all `RateCounter` cells (#3315). Deliberately NOT `TokenBucket`:
+    /// "admitted" here means "skip a recoverable security response".
+    pub(super) fn for_dst() -> Self {
+        Self::with_cols(DST_COLS)
+    }
+
+    /// Allocate the per-SOURCE SYN sketch (`SRC_COLS` columns), `RateCounter`
+    /// cells (#3315).
+    pub(super) fn for_src() -> Self {
+        Self::with_cols(SRC_COLS)
+    }
+}
+
+impl SynRateSketch<TokenBucket> {
+    /// Allocate the per-DESTINATION ICMP/UDP FLOOD sketch (`DST_COLS` columns)
+    /// with monotonic-ns `TokenBucket` cells (#5805). A distinct constructor
+    /// name (not `for_dst`) keeps the SYN-path `SynRateSketch::for_dst()`
+    /// unambiguously the `RateCounter` variant. The token bucket admits a
+    /// destination parked at exactly `threshold` events/second steadily (the
+    /// #5805 fix) while still bounding a burst to capacity (#2937) and limiting
+    /// an over-threshold destination down to the configured rate.
+    pub(super) fn for_flood_dst() -> Self {
+        Self::build_seeded(DST_COLS, crate::hot_hash_seed::hot_path_hash_seed())
     }
 }
 

--- a/userspace-dp/src/screen/syn_rate_tests.rs
+++ b/userspace-dp/src/screen/syn_rate_tests.rs
@@ -226,3 +226,112 @@ fn single_source_flood_trips_under_pinned_seed() {
         );
     }
 }
+
+// ================================================================
+// #5805: the ICMP/UDP per-destination FLOOD sketch (`for_flood_dst`) carries
+// `TokenBucket` cells. `increment` here takes `now_ns` (monotonic nanoseconds),
+// NOT `now_secs`. These pin the token-bucket sketch invariants directly.
+// ================================================================
+
+/// One whole nanosecond-second for readable `now_ns` arithmetic.
+const NS: u64 = 1_000_000_000;
+
+/// #5805: the flood sketch is still fixed at `ROWS * DST_COLS` cells and does
+/// NOT grow under a flood of distinct destinations — the token-bucket cell is
+/// the same 16 bytes as `RateCounter`, so the operator memory advisory bound is
+/// unchanged.
+#[test]
+fn flood_sketch_capacity_fixed_and_no_growth() {
+    let mut s = SynRateSketch::for_flood_dst();
+    let before = s.capacity();
+    assert_eq!(
+        before,
+        ROWS * DST_COLS,
+        "flood sketch capacity is ROWS * DST_COLS"
+    );
+    let now_ns = 5 * NS;
+    for k in 0..50_000u32 {
+        let dst = v4((k >> 24) as u8, (k >> 16) as u8, (k >> 8) as u8, k as u8);
+        s.increment(&dst, now_ns, 20);
+    }
+    assert_eq!(
+        s.capacity(),
+        before,
+        "token-bucket flood sketch must not grow under a flood"
+    );
+}
+
+/// #5805: enforcement preserved — an instantaneous burst ABOVE the per-cell
+/// capacity drains all `ROWS` cells, so the count-min AND reports over-limit.
+/// The token-bucket migration does not weaken the flood cap.
+#[test]
+fn flood_sketch_over_threshold_trips_at_instant() {
+    let mut s = SynRateSketch::for_flood_dst();
+    const T: u32 = 5;
+    let victim = v4(10, 0, 0, 1);
+    let now_ns = 3 * NS;
+    // Cold-start capacity is T; the first T admit, the (T+1)th (same instant)
+    // finds every row drained → trips.
+    for _ in 0..T {
+        assert!(
+            !s.increment(&victim, now_ns, T),
+            "first {T} admitted (cold-start capacity)"
+        );
+    }
+    assert!(
+        s.increment(&victim, now_ns, T),
+        "an over-capacity burst trips (all rows drained)"
+    );
+}
+
+/// #5805 unit-level RED-ON-REVERT: a destination parked at EXACTLY `threshold`
+/// events/second, paced across 20 one-second boundaries, stays admitted on the
+/// token-bucket flood sketch. The count-all `RateCounter` (the reverted cell)
+/// would collapse it to ~one window after the first second.
+#[test]
+fn flood_sketch_sustained_at_threshold_admits_across_seconds() {
+    const T: u32 = 200;
+    let mut s = SynRateSketch::for_flood_dst();
+    let dst = v4(10, 0, 2, 1);
+    let interval_ns = NS / T as u64;
+    let mut now_ns = 4 * NS;
+    let total = T * 20;
+    let mut admitted = 0u32;
+    for _ in 0..total {
+        if !s.increment(&dst, now_ns, T) {
+            admitted += 1;
+        }
+        now_ns += interval_ns;
+    }
+    assert!(
+        admitted as f64 >= 0.99 * total as f64,
+        "sustained at-threshold destination must stay admitted (#5805): {admitted}/{total}"
+    );
+}
+
+/// #5805: distinct destination PORTS count independently on the token-bucket
+/// sketch (`increment_ip_port`), matching Junos `udp flood threshold`. Two ports
+/// to the same IP, each sustained at threshold, both stay admitted.
+#[test]
+fn flood_sketch_distinct_ports_independent_sustained() {
+    const T: u32 = 100;
+    let mut s = SynRateSketch::for_flood_dst();
+    let dst = v4(10, 0, 2, 9);
+    let interval_ns = NS / T as u64;
+    let mut now_ns = 4 * NS;
+    let total = T * 10;
+    let (mut ok80, mut ok443) = (0u32, 0u32);
+    for _ in 0..total {
+        if !s.increment_ip_port(&dst, 80, now_ns, T) {
+            ok80 += 1;
+        }
+        if !s.increment_ip_port(&dst, 443, now_ns, T) {
+            ok443 += 1;
+        }
+        now_ns += interval_ns;
+    }
+    assert!(
+        ok80 as f64 >= 0.99 * total as f64 && ok443 as f64 >= 0.99 * total as f64,
+        "each (ip,port) sustained at threshold stays admitted independently: {ok80}/{ok443} of {total}"
+    );
+}

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -2132,39 +2132,65 @@ fn icmp_flood_triggers() {
 }
 
 #[test]
-fn icmp_flood_sliding_window_blocks_boundary_burst_then_recovers() {
-    // #2937: the rate counter is a two-bucket sliding window, NOT a fixed
-    // wall-second window. After the budget is exhausted in second 100, the
-    // immediately following second (101) must NOT hand out a fresh full
-    // budget — the previous second's tally still counts for the whole of
-    // second 101. A full empty second must elapse before the budget frees.
+fn icmp_flood_per_dest_token_bucket_bounds_burst_and_refills() {
+    // #5805: the per-destination ICMP flood cap is now a monotonic-ns TOKEN
+    // BUCKET (was a count-all `RateCounter`). Two properties:
+    //   (a) #2937 preserved — an instantaneous burst is bounded to `threshold`
+    //       (the capacity), and a sub-millisecond straddle hands out no fresh
+    //       budget; and
+    //   (b) #5805 fixed — a FULL second later the bucket has refilled to
+    //       capacity and admits the budget again, WITHOUT requiring a fully idle
+    //       second. The reverted `RateCounter` kept the destination dropped in
+    //       the second immediately following an at-threshold second (its
+    //       previous-second tally weighed the whole current second) — this final
+    //       assertion is RED on the reverted count-all cell.
+    const THRESHOLD: u32 = 2;
     let mut profile = ScreenProfile::default();
-    profile.icmp_flood_threshold = 2;
+    profile.icmp_flood_threshold = THRESHOLD;
     let mut state = make_state("trust", profile);
     let pkt = icmp_pkt(
         IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
         IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
         84,
     );
-    assert_eq!(state.check_packet("trust", &pkt, 100), ScreenVerdict::Pass);
-    assert_eq!(state.check_packet("trust", &pkt, 100), ScreenVerdict::Pass);
-    // Exceeds in window 100.
+    // Instantaneous burst at second 100: exactly `threshold` admitted, the rest
+    // dropped (cold-start capacity bound).
+    let now_ns = 100 * NS;
+    let mut admitted = 0u32;
+    for _ in 0..(THRESHOLD * 3) {
+        if state.check_packet_with_zone_id_opts("trust", 3, &pkt, now_ns, 100, false)
+            == ScreenVerdict::Pass
+        {
+            admitted += 1;
+        }
+    }
     assert_eq!(
-        state.check_packet("trust", &pkt, 100),
-        ScreenVerdict::Drop("icmp-flood")
+        admitted, THRESHOLD,
+        "instantaneous burst bounded to capacity (#2937)"
     );
-    // Boundary into second 101: the previous second contributed 3 events,
-    // so the trailing 1-second sum is already over the threshold and the
-    // first packet of the new second is still dropped (fixed-window reset
-    // would have admitted it — that was the boundary-burst bug).
+    // A sub-millisecond straddle 100us later must NOT refill a fresh budget.
+    let straddle_ns = now_ns + 100_000;
     assert_eq!(
-        state.check_packet("trust", &pkt, 101),
-        ScreenVerdict::Drop("icmp-flood")
+        state.check_packet_with_zone_id_opts("trust", 3, &pkt, straddle_ns, 100, false),
+        ScreenVerdict::Drop("icmp-flood"),
+        "a sub-ms straddle must not hand out a second budget (#2937)"
     );
-    // After a full empty second (102 has no traffic from 101), second 103
-    // sees prev_count == 0 and admits the budget again.
-    assert_eq!(state.check_packet("trust", &pkt, 103), ScreenVerdict::Pass);
-    assert_eq!(state.check_packet("trust", &pkt, 103), ScreenVerdict::Pass);
+    // A FULL second later the bucket has refilled to capacity → the budget is
+    // admitted again, WITHOUT needing a fully idle second (the #5805 fix; the
+    // count-all RateCounter would still be dropping here).
+    let next_secs_ns = now_ns + NS;
+    let mut admitted2 = 0u32;
+    for _ in 0..THRESHOLD {
+        if state.check_packet_with_zone_id_opts("trust", 3, &pkt, next_secs_ns, 101, false)
+            == ScreenVerdict::Pass
+        {
+            admitted2 += 1;
+        }
+    }
+    assert_eq!(
+        admitted2, THRESHOLD,
+        "a full second later the per-destination budget refills (#5805 recovery)"
+    );
 }
 
 // ================================================================
@@ -2326,6 +2352,164 @@ fn icmp_flood_flowless_per_destination_independent() {
         state.check_flowless_screens("trust", &flowless_icmp_pkt(src, dst_a), true, 100),
         ScreenVerdict::Drop("icmp-flood"),
         "flowless single-destination flood still capped"
+    );
+}
+
+/// #5805 RED-ON-REVERT (headline): a single destination receiving ICMP at
+/// EXACTLY the per-destination `icmp flood threshold` rate, SUSTAINED for 20
+/// seconds (the clock advanced past every 1-second boundary), stays admitted.
+/// The per-destination token bucket refills continuously at the configured
+/// rate, so the destination is served steadily. Reverting the sketch cell to
+/// the count-all `RateCounter` collapses admission to ~one window after the
+/// first second (its whole-second boundary reset counts even the rejected
+/// packets) → this assertion goes RED. Events are paced at the real monotonic
+/// rate via `now_ns`, mirroring `syn_flood_cookie_off_sustained_at_threshold`.
+#[test]
+fn icmp_flood_per_dest_sustained_at_threshold_admitted() {
+    const THRESHOLD: u32 = 100;
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = THRESHOLD;
+    let mut state = make_state("trust", profile);
+    let pkt = icmp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        84,
+    );
+    let interval_ns = NS / THRESHOLD as u64; // exactly threshold events/second
+    let mut now_ns = 9 * NS;
+    let total = THRESHOLD * 20; // 20 seconds sustained at threshold
+    let mut admitted = 0u32;
+    for _ in 0..total {
+        let now_secs = now_ns / NS;
+        if state.check_packet_with_zone_id_opts("trust", 3, &pkt, now_ns, now_secs, false)
+            == ScreenVerdict::Pass
+        {
+            admitted += 1;
+        }
+        now_ns += interval_ns;
+    }
+    assert!(
+        admitted as f64 >= 0.99 * total as f64,
+        "per-destination ICMP at threshold must stay admitted across 20s (#5805): {admitted}/{total}"
+    );
+}
+
+/// #5805 RED-ON-REVERT: the UDP per-destination-PORT flood cap has the same
+/// token-bucket behaviour — a `(dst_ip, dst_port)` parked at exactly `udp flood
+/// threshold` pps for 20 seconds stays admitted. RED on the reverted
+/// `RateCounter` cell.
+#[test]
+fn udp_flood_per_dest_port_sustained_at_threshold_admitted() {
+    const THRESHOLD: u32 = 100;
+    let mut profile = ScreenProfile::default();
+    profile.udp_flood_threshold = THRESHOLD;
+    let mut state = make_state("trust", profile);
+    let mut pkt = udp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+    );
+    pkt.dst_port = 443;
+    let interval_ns = NS / THRESHOLD as u64;
+    let mut now_ns = 9 * NS;
+    let total = THRESHOLD * 20;
+    let mut admitted = 0u32;
+    for _ in 0..total {
+        let now_secs = now_ns / NS;
+        if state.check_packet_with_zone_id_opts("trust", 3, &pkt, now_ns, now_secs, false)
+            == ScreenVerdict::Pass
+        {
+            admitted += 1;
+        }
+        now_ns += interval_ns;
+    }
+    assert!(
+        admitted as f64 >= 0.99 * total as f64,
+        "per-(dst,port) UDP at threshold must stay admitted across 20s (#5805): {admitted}/{total}"
+    );
+}
+
+/// #5805 enforcement preserved (IPv6): an OVER-threshold destination (sending at
+/// 2× the per-destination cap) is still LIMITED down to the configured rate —
+/// the fix must not weaken enforcement. The token bucket admits ≈ `threshold`
+/// per second plus the one-time cold-start capacity, so over 20 seconds a 2×
+/// flood sees ≈ `threshold × 21` admitted: well below the `threshold × 40`
+/// offered (a real flood is still dropped, enforcement holds) AND well above the
+/// ~`threshold` a reverted count-all `RateCounter` would admit (no collapse —
+/// the lower bound is RED on revert). Uses an IPv6 destination.
+#[test]
+fn icmp_flood_per_dest_over_threshold_still_limited() {
+    const THRESHOLD: u32 = 100;
+    const SECS: u32 = 20;
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = THRESHOLD;
+    let mut state = make_state("trust", profile);
+    let pkt = icmp_pkt(
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x50)),
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x99)),
+        84,
+    );
+    // Offer 2× the cap, evenly spaced.
+    let interval_ns = NS / (2 * THRESHOLD) as u64;
+    let mut now_ns = 9 * NS;
+    let total = 2 * THRESHOLD * SECS;
+    let mut admitted = 0u32;
+    for _ in 0..total {
+        let now_secs = now_ns / NS;
+        if state.check_packet_with_zone_id_opts("trust", 3, &pkt, now_ns, now_secs, false)
+            == ScreenVerdict::Pass
+        {
+            admitted += 1;
+        }
+        now_ns += interval_ns;
+    }
+    // Enforcement: a real 2× flood is limited, not passed wholesale.
+    assert!(
+        admitted < total,
+        "an over-threshold destination must still be rate-limited: {admitted}/{total}"
+    );
+    assert!(
+        admitted <= THRESHOLD * (SECS + 2),
+        "admitted must be bounded to ~the configured rate (+cold-start burst): {admitted}"
+    );
+    // No collapse: the configured rate IS delivered every second (RED on the
+    // reverted count-all cell, which admits ~one window total).
+    assert!(
+        admitted >= THRESHOLD * SECS,
+        "the configured rate must be delivered steadily, not collapsed (#5805): {admitted}"
+    );
+}
+
+/// #5805 RED-ON-REVERT (flowless fragment path): a UDP non-first fragment carries
+/// no L4 port, so `udp_flood_drop` folds it into the per-destination-IP token
+/// bucket (#4567). A sustained at-threshold fragment stream to one destination
+/// IP stays admitted across seconds. RED on the reverted `RateCounter` cell.
+#[test]
+fn udp_flood_flowless_fragment_sustained_at_threshold_admitted() {
+    const THRESHOLD: u32 = 100;
+    let mut profile = ScreenProfile::default();
+    profile.udp_flood_threshold = THRESHOLD;
+    let mut state = make_state("trust", profile);
+    let pkt = flowless_nonfirst_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_UDP,
+    );
+    let interval_ns = NS / THRESHOLD as u64;
+    let mut now_ns = 9 * NS;
+    let total = THRESHOLD * 20;
+    let mut admitted = 0u32;
+    for _ in 0..total {
+        let now_secs = now_ns / NS;
+        if state.check_flowless_screens_opts("trust", &pkt, true, now_ns, now_secs, false)
+            == ScreenVerdict::Pass
+        {
+            admitted += 1;
+        }
+        now_ns += interval_ns;
+    }
+    assert!(
+        admitted as f64 >= 0.99 * total as f64,
+        "flowless UDP fragment at threshold must stay admitted across 20s (#5805): {admitted}/{total}"
     );
 }
 
@@ -5150,7 +5334,11 @@ fn udp_flood_flowless_fragment_folds_into_per_ip_bucket_4567() {
     let cells = state.udp_dst_sketch.get("trust").unwrap().cell_indices(&d);
     let sketch = state.udp_dst_sketch.get_mut("trust").unwrap();
     for (row, &col) in cells.iter().enumerate() {
-        sketch.saturate_cell(row, col, 100, T);
+        // #5805: the flood sketch cells are token buckets keyed on `now_ns`; the
+        // check below runs at `now_secs=100` (→ `now_ns = 100 * NANOS_PER_SEC`),
+        // so saturate at the SAME instant or the bucket would "refill" across the
+        // apparent elapsed second and un-saturate.
+        sketch.saturate_cell(row, col, 100 * NS, T);
     }
     let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
     let pkt = flowless_nonfirst_fragment(src, d, PROTO_UDP);
@@ -5180,7 +5368,11 @@ fn udp_flood_first_fragment_still_counts_per_ip_port_4567() {
     let cells = state.udp_dst_sketch.get("trust").unwrap().cell_indices(&d);
     let sketch = state.udp_dst_sketch.get_mut("trust").unwrap();
     for (row, &col) in cells.iter().enumerate() {
-        sketch.saturate_cell(row, col, 100, T);
+        // #5805: the flood sketch cells are token buckets keyed on `now_ns`; the
+        // check below runs at `now_secs=100` (→ `now_ns = 100 * NANOS_PER_SEC`),
+        // so saturate at the SAME instant or the bucket would "refill" across the
+        // apparent elapsed second and un-saturate.
+        sketch.saturate_cell(row, col, 100 * NS, T);
     }
     let pkt = udp_pkt(src, d); // dst_port = 5001 (real L4 port, flow path)
     for i in 0..T {


### PR DESCRIPTION
## Problem

The #3607 token-bucket migration fixed the per-**zone** aggregate ICMP/UDP flood gates but deliberately left the **primary** per-**destination** sketches on `RateCounter`. `RateCounter` has the confirmed count-all / whole-second defect: after a destination sends exactly the configured threshold in one second, the first packet of the next second sees `prev_count == threshold`, increments `count`, and is already over-limit; rejected packets keep incrementing, so a sustained at-threshold destination is dropped nearly completely until a full idle second.

So the primary Junos-compatible per-destination ICMP/UDP flood limits did **not** implement the configured `N packets/second` contract — a legitimate service parked at its configured screen threshold was starved to ~one window/second (measured `100/2000` admitted over 20 s below).

## Fix (pattern-extension of #3607 — reuse the proven `TokenBucket`, no new mechanism)

Made the count-min `SynRateSketch` generic over its per-cell limiter via a new `SketchCell` trait (`RateCounter::increment` / `TokenBucket::admit_is_over`):

- **SYN per-source/per-destination sketches (#3315)** keep count-all `RateCounter` cells — there "admitted" activates a *recoverable* security response (SYN cookies / the alarm), so the over-throttle is deliberate.
- **ICMP/UDP per-destination flood sketches (#4112)** now use `SynRateSketch<TokenBucket>` (`for_flood_dst`, keyed on the batch-cached `loop_now_ns`).

Correctness properties (mirroring the #3607 aggregate argument):
- A sustained **at-threshold** destination is admitted **steadily** (continuous refill, no whole-second boundary collapse).
- An **over-threshold** destination is still limited **down to** the configured rate (enforcement preserved — a real flood is still dropped).
- A sub-millisecond boundary straddle still sees at most `threshold` tokens (**#2937** anti-micro-burst preserved).
- A live threshold change grants no unintended burst (capacity clamp, inherited from `TokenBucket`).

Both cells are 16 bytes, so the count-min **memory bound** (`ROWS*cols*16`), no-eviction structure, seeded key mapping, and AND/MIN trip semantics are unchanged. Applies to ICMP (per dst IP) and UDP (per dst IP+port, with the #4567 per-IP fold for port-less non-first fragments). The now-unused `now_secs` parameter was dropped from `icmp_flood_drop`/`udp_flood_drop`.

## Tests (cargo fail-on-revert)

Added RED-on-revert coverage plus sketch-level invariants:

| Test | Covers |
|------|--------|
| `icmp_flood_per_dest_sustained_at_threshold_admitted` | ICMP v4, 20 s sustained at threshold stays admitted |
| `udp_flood_per_dest_port_sustained_at_threshold_admitted` | UDP v4 (dst IP+port), 20 s sustained |
| `udp_flood_flowless_fragment_sustained_at_threshold_admitted` | flowless non-first fragment (per-IP fold), 20 s sustained |
| `icmp_flood_per_dest_over_threshold_still_limited` | IPv6, 2× threshold stays limited to the rate without collapsing |
| `icmp_flood_per_dest_token_bucket_bounds_burst_and_refills` | #2937 burst bound + 1 s refill recovery (rewritten from the old RateCounter boundary test) |
| `flood_sketch_*` (4) | sketch-level: memory bound / no growth, burst bound, sustained admit, per-port independence |

**Firsthand RED-on-revert** — reverting the flood cell to `RateCounter` (seconds-keyed) collapses the sustained streams after the first second:

```
test screen::tests::icmp_flood_per_dest_sustained_at_threshold_admitted ... FAILED
test screen::tests::udp_flood_per_dest_port_sustained_at_threshold_admitted ... FAILED
test screen::tests::udp_flood_flowless_fragment_sustained_at_threshold_admitted ... FAILED
test screen::tests::icmp_flood_per_dest_over_threshold_still_limited ... FAILED
test screen::tests::icmp_flood_per_dest_token_bucket_bounds_burst_and_refills ... FAILED

per-destination ICMP at threshold must stay admitted across 20s (#5805): 100/2000
per-(dst,port) UDP at threshold must stay admitted across 20s (#5805): 100/2000
flowless UDP fragment at threshold must stay admitted across 20s (#5805): 100/2000
the configured rate must be delivered steadily, not collapsed (#5805): 100
assertion failed: a full second later the per-destination budget refills (#5805 recovery)

test result: FAILED. 171 passed; 6 failed
```

On the fix: **full `cargo test --release` suite green — 3971 passed, 0 failed** (2 pre-existing ignored). `cargo fmt` clean on touched hunks (crate baseline is not fully fmt-clean; unrelated lines untouched).

## Docs
`docs/syn-cookie-flood-protection.md` updated to state the per-destination flood sketches now use `TokenBucket` cells (parity with the aggregate gate) while the SYN sketches stay on `RateCounter`. `_Log.md` entry added.

## Smoke deferral
Rust dataplane screen change; loss-cluster smoke is blocked by the shim-ABI wall. Correctness is gated on the cargo fail-on-revert tests above.

Closes #5805

🤖 Generated with [Claude Code](https://claude.com/claude-code)