### PR TITLE
nat: validate peer node's source-NAT view before promotion

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -50856,3 +50856,30 @@ top.
   **File(s)**: pkg/dataplane/userspace/manager_overlay.go,
   pkg/dataplane/userspace/route_overlay_test.go (new test),
   docs/rib-group-route-leaking.md
+
+- **Timestamp**: 2026-07-16
+  **Action**: #5876 — strict SOURCE-NAT validation now covers the PEER node's
+  effective compiled view before promotion. The strict commit gate compiled
+  `s.nodeID` alone (`compileTreeStrict` → `CompileConfigForNode`), so a `${node}`
+  apply-group / per-node rewrite selecting a source-NAT pool or reference valid
+  on the origin but invalid on the peer (per-node pool `address` / `port range`,
+  or a shared top-level rule referencing a pool only a peer `groups nodeN` block
+  defines) passed green — then the standby lenient-loaded the synced snapshot
+  (`SyncApply` → `CompileConfigForNodeLenient`) and failed SNAT closed. Added
+  `ValidatePeerEffectiveSourceNATStrict(tree, localNodeID)` (new
+  `pkg/config/compiler_peer_effective_snat.go`): compiles the peer via
+  `CompileConfigForNodeLenient(peerID)` — the exact standby transform — and
+  re-runs the existing strict SOURCE-NAT validators
+  (`validateSourceNATPoolStrict`, `validateSourceNATPoolAddressGrammarStrict`,
+  `validateSourceNATPersistentNoTranslationStrict`,
+  `validateNATPoolReferencesStrict`,
+  `validateNATSourceAddressNameReferencesStrict`) against it, rejecting at the
+  origin commit naming the peer node + offending pool. Wired into
+  `configstore.compileTreeStrict` after the local compile + cross-checks.
+  Standalone (`nodeID < 0`) is a no-op. Fail-on-revert proven firsthand (RED in
+  both packages when the gate is neutralized).
+  **File(s)**: pkg/config/compiler_peer_effective_snat.go (new),
+  pkg/config/compiler_peer_effective_snat_5876_test.go (new),
+  pkg/configstore/store.go,
+  pkg/configstore/peer_effective_snat_5876_test.go (new),
+  docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -349,6 +349,42 @@ the reconciled `tunnelid_test.go` duplicate-spelling case, each RED on revert of
 the gate wiring (the parity test goes RED — node0 accepts — when the gate is put
 back node-local).
 
+**Peer-effective SOURCE-NAT — the #5876 gap.** The same divergent-commit class
+bit the strict SOURCE-NAT gates. Those validators
+(`validateSourceNATPoolStrict`, `validateSourceNATPoolAddressGrammarStrict`,
+`validateSourceNATPersistentNoTranslationStrict`,
+`validateNATPoolReferencesStrict`, `validateNATSourceAddressNameReferencesStrict`
+in `compiler_validate_strict_nat.go`) run inside `runUniformGates`, so a commit
+that compiles `s.nodeID` alone (`Store.compileTree` → `CompileConfigForNode`)
+strict-validated only the SUBMITTING node's source-NAT view. A `${node}`
+apply-group substitution / per-node rewrite that selects a source-NAT pool or
+reference valid on the origin but INVALID on the peer — a per-node pool
+`address` / `port range`, or a shared top-level rule whose
+`then source-nat pool <name>` names a pool only a peer `groups nodeN` block
+defines — passed green, and the standby then lenient-loaded the config-synced
+snapshot (`Store.SyncApply` → `CompileConfigForNodeLenient`, which downgrades the
+strict SNAT gate to a warning and fails the translation CLOSED). SNAT silently
+degraded on the node that just took over. Unlike the #5631/#5878 unit-alias gate
+— a pure-AST union that can be computed pre-expansion — source-NAT
+representability needs the fully COMPILED per-node view (pools resolved), so the
+fix RE-COMPILES rather than unions: `ValidatePeerEffectiveSourceNATStrict(tree,
+localNodeID)` (`compiler_peer_effective_snat.go`), wired into
+`configstore.compileTreeStrict` after the local compile + cross-checks, compiles
+the PEER node with `CompileConfigForNodeLenient(peerID)` — the exact transform
+the standby applies — and re-runs the strict SOURCE-NAT validators against that
+peer-effective `*Config`. A peer-only source-NAT error is now rejected at the
+origin commit, naming the peer node and the offending pool, so BOTH
+node-effective source-NAT outputs are proven representable before promotion.
+Non-source-NAT gate errors on the peer view are out of scope (downgraded to
+warnings by the lenient compile); a peer view that will not compile at all is
+left to the peer's own load path (no false-reject of the origin commit).
+Standalone (`nodeID < 0`) has no peer and is a no-op — zero behavior change off a
+cluster. Covered by `pkg/config/compiler_peer_effective_snat_5876_test.go`
+(peer-only reversed-range / per-node address / dangling-pool-reference vectors,
+both-views-valid + standalone over-reject guards, node0/node1 symmetry) and
+`pkg/configstore/peer_effective_snat_5876_test.go` (store-gate wiring), each RED
+on revert of the peer gate (node0 accepts the peer-only SNAT error).
+
 **Phase 2 (#5878) — reference-binder canonicalization.** Phase 1 (above) closes
 the divergent-commit fail-open by rejecting a duplicate-spelling collision at
 commit. The second, subtler half of #5878 is that a cross-subsystem reference

--- a/pkg/config/compiler_peer_effective_snat.go
+++ b/pkg/config/compiler_peer_effective_snat.go
@@ -78,18 +78,27 @@ func peerNodeID(nodeID int) (int, bool) {
 	}
 }
 
-// validateSourceNATStrictView runs the strict SOURCE-NAT representability
-// validators (the source-NAT subset of the NAT gates runUniformGates dispatches
-// on the local compiled view) against an ALREADY-COMPILED *Config. It REUSES the
-// existing validators verbatim — no new SNAT rules — so the peer-effective gate
-// (#5876) and the local commit path cannot drift on what a representable source
-// pool / reference is.
+// validateSourceNATStrictView runs the strict NAT representability validators
+// that touch source-NAT rules (the source-NAT-relevant validators the NAT gates
+// in runUniformGates dispatch on the local compiled view) against an
+// ALREADY-COMPILED *Config. It REUSES the existing validators verbatim — no new
+// SNAT rules — so the peer-effective gate (#5876) and the local commit path
+// cannot drift on what a representable source pool / rule is.
 //
-// validateNATPoolReferencesStrict and validateNATSourceAddressNameReferencesStrict
-// also cover destination NAT; they are included whole (splitting them would
-// duplicate logic) so the peer gate is a beneficial superset that matches their
-// local-view behavior exactly — a peer-only DNAT pool / address-name error is
-// caught too, never a false-reject.
+// The peer view is validated by exactly the strict validators that iterate the
+// source-NAT config, because the standby's own SyncApply is LENIENT — the origin's
+// peer gate is the SOLE strict check the peer view ever gets, so any strict
+// validator that could catch a peer-only ${node}/groups divergence in a source
+// rule must run here (else that divergence strands the standby, the #5876 shape).
+// This includes the pool/reference/grammar/persistent validators AND the
+// rule-match/action validators (match-destination-port, terminal-action
+// cardinality, and match-applications — the last fails OPEN to a wildcard
+// translation, so omitting it would leave a peer-only fail-open, #6048 review).
+// validateNATPoolReferencesStrict / validateNATSourceAddressNameReferencesStrict /
+// the three match-action validators also cover destination NAT; they are included
+// whole (splitting them would duplicate logic) so the peer gate is a beneficial
+// superset that matches their local-view behavior exactly — a peer-only DNAT
+// pool / address-name / match error is caught too, never a false-reject.
 func validateSourceNATStrictView(cfg *Config) error {
 	if cfg == nil {
 		return nil
@@ -107,6 +116,15 @@ func validateSourceNATStrictView(cfg *Config) error {
 		return err
 	}
 	if err := validateNATSourceAddressNameReferencesStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateNATMatchDestinationPortStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateNATTerminalActionCardinalityStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateNATMatchApplicationsStrict(cfg); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/config/compiler_peer_effective_snat.go
+++ b/pkg/config/compiler_peer_effective_snat.go
@@ -1,0 +1,113 @@
+package config
+
+import "fmt"
+
+// ValidatePeerEffectiveSourceNATStrict re-runs the strict SOURCE-NAT
+// representability validators against the PEER node's effective compiled view so
+// a chassis-cluster commit proves BOTH node-effective source-NAT outputs are
+// installable before promotion (#5876).
+//
+// The strict SNAT gates (validateSourceNATPoolStrict,
+// validateSourceNATPoolAddressGrammarStrict,
+// validateSourceNATPersistentNoTranslationStrict, validateNATPoolReferencesStrict,
+// validateNATSourceAddressNameReferencesStrict) already run inside
+// compileExpanded — but ONLY against the single node the commit compiles for.
+// The strict commit gate (configstore.compileTreeStrict) compiles
+// CompileConfigForNode(localNodeID) alone, so a source-NAT pool / reference error
+// that is valid on the ORIGIN's effective view but invalid on the PEER's — a
+// per-node pool address, a divergent `port range`, a top-level rule referencing a
+// pool that only a peer `groups nodeN` block defines — is chassis-aware compiled
+// only for the local node and never strict-validated. The originating commit
+// passes green; the standby then ingests the synced snapshot via the TOLERANT
+// path (Store.SyncApply -> CompileConfigForNodeLenient), which downgrades the
+// strict SNAT gate to a warning and installs nothing (fail-closed) — SNAT
+// silently degrades on the node that just took over. This gate pulls the peer's
+// strict SNAT check forward to the origin's commit.
+//
+// The peer-effective view is produced with CompileConfigForNodeLenient(peerID) —
+// the EXACT transform the standby applies on Store.SyncApply — so the pools and
+// rules we validate are precisely what the peer will instantiate (same ${node}
+// apply-group substitution and per-node rewrites). The lenient compile downgrades
+// every gate to a warning, so it always yields the peer-effective *Config even
+// when a NON-source-NAT gate would strict-reject; those non-SNAT concerns are
+// OUT OF SCOPE for #5876 (a peer view that will not compile at all is a broader
+// structural problem left to the peer's own load path — we do not false-reject
+// the origin commit for it). Only the strict SOURCE-NAT validators are re-run.
+//
+// Standalone (localNodeID < 0) has no peer and is a no-op — zero behavior change
+// off a cluster. The verdict is deterministic: CompileConfigForNodeLenient(peerID)
+// is a pure function of the candidate tree, and the reused validators already walk
+// pools / rule-sets in sorted order for a stable first-reported offender.
+func ValidatePeerEffectiveSourceNATStrict(tree *ConfigTree, localNodeID int) error {
+	if tree == nil || localNodeID < 0 {
+		return nil
+	}
+	peerID, ok := peerNodeID(localNodeID)
+	if !ok {
+		return nil
+	}
+	// Compile the peer view the SAME way the standby ingests a config-synced
+	// snapshot (Store.SyncApply -> compileTreeLenient -> CompileConfigForNodeLenient):
+	// the lenient path downgrades every strict gate to a warning, so it produces
+	// the peer-effective *Config even where a non-SNAT gate would hard-reject.
+	peerCfg, err := CompileConfigForNodeLenient(tree, peerID)
+	if err != nil || peerCfg == nil {
+		// A peer view that will not compile AT ALL is a structural concern
+		// broader than source-NAT representability (#5876 scope). Leave it to the
+		// peer's own strict/load path rather than false-rejecting the origin
+		// commit here.
+		return nil
+	}
+	if err := validateSourceNATStrictView(peerCfg); err != nil {
+		return fmt.Errorf("chassis cluster peer node%d effective source-NAT is not "+
+			"representable (a shared commit would strand the standby): %w", peerID, err)
+	}
+	return nil
+}
+
+// peerNodeID returns the OTHER node id in a 2-node chassis cluster (0<->1). ok is
+// false for any id that has no defined 2-node peer (nodes are always 0 or 1).
+func peerNodeID(nodeID int) (int, bool) {
+	switch nodeID {
+	case 0:
+		return 1, true
+	case 1:
+		return 0, true
+	default:
+		return 0, false
+	}
+}
+
+// validateSourceNATStrictView runs the strict SOURCE-NAT representability
+// validators (the source-NAT subset of the NAT gates runUniformGates dispatches
+// on the local compiled view) against an ALREADY-COMPILED *Config. It REUSES the
+// existing validators verbatim — no new SNAT rules — so the peer-effective gate
+// (#5876) and the local commit path cannot drift on what a representable source
+// pool / reference is.
+//
+// validateNATPoolReferencesStrict and validateNATSourceAddressNameReferencesStrict
+// also cover destination NAT; they are included whole (splitting them would
+// duplicate logic) so the peer gate is a beneficial superset that matches their
+// local-view behavior exactly — a peer-only DNAT pool / address-name error is
+// caught too, never a false-reject.
+func validateSourceNATStrictView(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := validateSourceNATPoolStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateNATPoolReferencesStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateSourceNATPoolAddressGrammarStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateSourceNATPersistentNoTranslationStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateNATSourceAddressNameReferencesStrict(cfg); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/config/compiler_peer_effective_snat_5876_test.go
+++ b/pkg/config/compiler_peer_effective_snat_5876_test.go
@@ -120,6 +120,29 @@ func TestPeerOnlySNATDivergenceVectors_5876(t *testing.T) {
 			},
 			want: []string{"node1", "OnlyNode0"},
 		},
+		{
+			// #6048 review residual: a peer-only `match application` divergence.
+			// The application is defined only in groups node0, so the shared
+			// source-NAT rule references an UNDEFINED application on the node1
+			// (peer) view. validateNATMatchApplicationsStrict fails OPEN in the
+			// dataplane (undefined app -> wildcard translation), so if the peer
+			// gate did not run it, node0 would green-commit and strand node1 with
+			// a fail-open source-NAT rule.
+			name: "peer-only-undefined-match-application",
+			cmds: []string{
+				"set security nat source rule-set RS from zone trust",
+				"set security nat source rule-set RS to zone untrust",
+				"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+				"set security nat source rule-set RS rule R1 match application AppOnNode0",
+				"set security nat source rule-set RS rule R1 then source-nat interface",
+				"set groups node0 applications application AppOnNode0 protocol tcp destination-port 80",
+				// node1 group exists (so apply-groups resolves) but does NOT define
+				// the application, leaving the node1 view's rule referencing it.
+				"set groups node1 system host-name fw1",
+				`set apply-groups "${node}"`,
+			},
+			want: []string{"node1", "AppOnNode0"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/config/compiler_peer_effective_snat_5876_test.go
+++ b/pkg/config/compiler_peer_effective_snat_5876_test.go
@@ -1,0 +1,222 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5876: strict SOURCE-NAT validation ran ONLY against the SUBMITTING node's
+// effective compiled view. The strict commit gate compiles
+// CompileConfigForNode(s.nodeID) alone, so a source-NAT pool / reference error
+// that is valid on the origin's `${node}` effective view but INVALID on the
+// peer's — a per-node pool `port range`, a per-node pool address, a top-level
+// rule referencing a pool only a peer `groups nodeN` block defines — passed the
+// originating commit green and then failed only when the standby lenient-loaded
+// the config-synced snapshot (Store.SyncApply → CompileConfigForNodeLenient),
+// where the strict SNAT gate is downgraded to a warning and the dataplane fails
+// the translation closed. A green commit stranded the standby's SNAT.
+//
+// The fix (ValidatePeerEffectiveSourceNATStrict, wired into
+// configstore.compileTreeStrict) re-runs the strict SOURCE-NAT validators
+// against the PEER node's effective compile — the same
+// CompileConfigForNodeLenient transform the standby applies — so a peer-only
+// source-NAT error is rejected at the origin commit, proving BOTH node-effective
+// views are representable before promotion.
+//
+// These tests use ParseSetCommand + tree.SetPath (buildTreeFromSet) per
+// CLAUDE.md — NewParser must not be used for multi-line set input. A faithful HA
+// candidate defines BOTH `groups node0` and `groups node1` (apply-groups
+// "${node}" requires the per-node group to exist on each node) so each node's
+// own effective view resolves while the OTHER node's SNAT diverges.
+
+// peerDivergentSNATPortRange builds a shared HA candidate whose source-NAT pool
+// P carries a VALID `port range` on node0 and a REVERSED (invalid) range on
+// node1 via apply-groups "${node}". node0's effective view is clean; node1's
+// folds a reversed range that validateSourceNATPoolStrict rejects.
+func peerDivergentSNATPortRange() []string {
+	return []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool P",
+		"set groups node0 security nat source pool P address 203.0.113.5/32",
+		"set groups node0 security nat source pool P port range 1024 to 2048",
+		"set groups node1 security nat source pool P address 203.0.113.5/32",
+		"set groups node1 security nat source pool P port range 5000 to 100",
+		`set apply-groups "${node}"`,
+	}
+}
+
+// TestPeerOnlySNATPortRangeRejectedAtOriginCommit_5876 is the core RED-on-revert
+// case. node0's local compile is CLEAN (green commit today), yet the peer node1
+// effective view carries a reversed source-pool port range that would strand the
+// standby. ValidatePeerEffectiveSourceNATStrict(tree, 0) must REJECT, naming the
+// peer node and the offending pool.
+//
+// FAIL-ON-REVERT: revert ValidatePeerEffectiveSourceNATStrict to `return nil`
+// (or drop its call from compileTreeStrict) and node0 compiles clean — this
+// assertion goes RED because the peer-only error is never surfaced.
+func TestPeerOnlySNATPortRangeRejectedAtOriginCommit_5876(t *testing.T) {
+	tree := buildTreeFromSet(t, peerDivergentSNATPortRange())
+
+	// The originating node (node0) compiles CLEAN — this is the green commit the
+	// pre-fix contract wrongly promoted.
+	if _, err := CompileConfigForNode(tree, 0); err != nil {
+		t.Fatalf("node0 local compile must be clean (its own view has a valid port range): %v", err)
+	}
+
+	// The peer-effective gate run at a node0 commit must reject the node1-only
+	// reversed range.
+	err := ValidatePeerEffectiveSourceNATStrict(tree, 0)
+	if err == nil {
+		t.Fatal("node0 commit ACCEPTED a peer-only source-NAT reversed port range (node1 view) — the #5876 divergent-commit fail-open")
+	}
+	for _, want := range []string{"node1", "P", "port range", "source-nat pool"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("peer-effective SNAT reject missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestPeerOnlySNATDivergenceVectors_5876 exercises the divergence classes the
+// issue enumerates: a per-node pool ADDRESS error and a top-level rule that
+// references a pool only the peer's `groups` block defines (a dangling reference
+// in the peer view). In every case node0's own view is clean and the peer
+// (node1) view is unrepresentable, so ValidatePeerEffectiveSourceNATStrict(tree,
+// 0) rejects while the node0 local compile succeeds.
+func TestPeerOnlySNATDivergenceVectors_5876(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		want []string // substrings the reject must name
+	}{
+		{
+			name: "per-node-pool-address-grammar",
+			cmds: []string{
+				"set security nat source rule-set RS from zone trust",
+				"set security nat source rule-set RS to zone untrust",
+				"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+				"set security nat source rule-set RS rule R1 then source-nat pool Q",
+				"set groups node0 security nat source pool Q address 203.0.113.5/32",
+				"set groups node1 security nat source pool Q address not-an-ip",
+				`set apply-groups "${node}"`,
+			},
+			want: []string{"node1", "Q"},
+		},
+		{
+			name: "top-level-rule-references-node0-only-pool",
+			cmds: []string{
+				// Rule is SHARED (top-level); the pool it references lives ONLY in
+				// groups node0, so the peer (node1) view has a dangling reference.
+				"set security nat source rule-set RS from zone trust",
+				"set security nat source rule-set RS to zone untrust",
+				"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+				"set security nat source rule-set RS rule R1 then source-nat pool OnlyNode0",
+				"set groups node0 security nat source pool OnlyNode0 address 203.0.113.9/32",
+				// groups node1 must exist so apply-groups "${node}" resolves on
+				// node1 (harmless, unrelated leaf) — but it does NOT define the pool.
+				"set groups node1 system host-name fw1",
+				`set apply-groups "${node}"`,
+			},
+			want: []string{"node1", "OnlyNode0"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTreeFromSet(t, tc.cmds)
+			if _, err := CompileConfigForNode(tree, 0); err != nil {
+				t.Fatalf("node0 local compile must be clean: %v", err)
+			}
+			err := ValidatePeerEffectiveSourceNATStrict(tree, 0)
+			if err == nil {
+				t.Fatalf("node0 commit ACCEPTED a peer-only source-NAT error (%s)", tc.name)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("%s: peer-effective reject missing %q: %v", tc.name, want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestPeerEffectiveSNATSymmetry_5876 proves the both-views-representable
+// contract from the OTHER direction: the reversed range lives in node1's group,
+// so a node1 commit catches it in its OWN local compile, and the peer gate run
+// at a node1 commit (checking node0's clean view) does NOT false-reject.
+func TestPeerEffectiveSNATSymmetry_5876(t *testing.T) {
+	tree := buildTreeFromSet(t, peerDivergentSNATPortRange())
+
+	// node1's own local compile already rejects (its view has the reversed range).
+	if _, err := CompileConfigForNode(tree, 1); err == nil {
+		t.Fatal("node1 local compile should reject its own reversed source-pool port range")
+	}
+	// The peer gate run at a node1 commit checks node0's view (clean) — no
+	// false-reject.
+	if err := ValidatePeerEffectiveSourceNATStrict(tree, 1); err != nil {
+		t.Fatalf("node1 commit peer gate false-rejected node0's clean source-NAT view: %v", err)
+	}
+}
+
+// TestPeerEffectiveSNATBothViewsValidClean_5876 is the primary over-reject
+// guard: a clustered candidate whose source-NAT pool is valid on BOTH nodes must
+// pass the peer gate at either node's commit. The pool port range is valid in
+// both per-node groups.
+func TestPeerEffectiveSNATBothViewsValidClean_5876(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool P",
+		"set groups node0 security nat source pool P address 203.0.113.5/32",
+		"set groups node0 security nat source pool P port range 1024 to 2048",
+		"set groups node1 security nat source pool P address 198.51.100.5/32",
+		"set groups node1 security nat source pool P port range 3000 to 4000",
+		`set apply-groups "${node}"`,
+	})
+	for _, nodeID := range []int{0, 1} {
+		if _, err := CompileConfigForNode(tree, nodeID); err != nil {
+			t.Fatalf("node%d local compile of a both-valid config failed: %v", nodeID, err)
+		}
+		if err := ValidatePeerEffectiveSourceNATStrict(tree, nodeID); err != nil {
+			t.Fatalf("node%d peer gate false-rejected a config valid on both nodes: %v", nodeID, err)
+		}
+	}
+}
+
+// TestPeerEffectiveSNATStandaloneNoOp_5876 pins the standalone guarantee: with
+// no cluster (localNodeID < 0) there is no peer, so the gate is a pure no-op even
+// when the config carries a source-NAT error — standalone behavior is unchanged.
+func TestPeerEffectiveSNATStandaloneNoOp_5876(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security nat source pool P address 203.0.113.5/32",
+		"set security nat source pool P port range 5000 to 100", // reversed, but standalone → no peer
+	})
+	if err := ValidatePeerEffectiveSourceNATStrict(tree, -1); err != nil {
+		t.Fatalf("standalone (nodeID -1) must be a no-op, got: %v", err)
+	}
+	// An out-of-cluster node id with no defined 2-node peer is also a no-op.
+	if err := ValidatePeerEffectiveSourceNATStrict(tree, 5); err != nil {
+		t.Fatalf("nodeID 5 has no 2-node peer, must be a no-op, got: %v", err)
+	}
+}
+
+// TestPeerNodeID_5876 unit-tests the 2-node peer selector.
+func TestPeerNodeID_5876(t *testing.T) {
+	cases := []struct {
+		in       int
+		wantPeer int
+		wantOK   bool
+	}{
+		{0, 1, true},
+		{1, 0, true},
+		{-1, 0, false},
+		{2, 0, false},
+	}
+	for _, tc := range cases {
+		peer, ok := peerNodeID(tc.in)
+		if ok != tc.wantOK || (ok && peer != tc.wantPeer) {
+			t.Fatalf("peerNodeID(%d) = (%d, %v), want (%d, %v)", tc.in, peer, ok, tc.wantPeer, tc.wantOK)
+		}
+	}
+}

--- a/pkg/configstore/peer_effective_snat_5876_test.go
+++ b/pkg/configstore/peer_effective_snat_5876_test.go
@@ -1,0 +1,94 @@
+package configstore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #5876: the strict commit gate (compileTreeStrict) must reject a chassis-cluster
+// candidate whose SOURCE-NAT is representable on the SUBMITTING node but not on
+// the PEER — a green commit would strand the standby's SNAT. This test locks the
+// STORE wiring: compileTreeStrict compiles the local node clean, then the
+// peer-effective SNAT gate rejects.
+//
+// FAIL-ON-REVERT: drop the config.ValidatePeerEffectiveSourceNATStrict call from
+// compileTreeStrict (leaving the local compile) and compileTreeStrict(tree, 0)
+// returns nil — this test goes RED.
+
+func peerDivergentSNATTree(t *testing.T) *config.ConfigTree {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	cmds := []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool P",
+		"set groups node0 security nat source pool P address 203.0.113.5/32",
+		"set groups node0 security nat source pool P port range 1024 to 2048",
+		"set groups node1 security nat source pool P address 203.0.113.5/32",
+		"set groups node1 security nat source pool P port range 5000 to 100",
+		`set apply-groups "${node}"`,
+	}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestCompileTreeStrict_RejectsPeerOnlySNAT_5876 drives the store-level strict
+// commit gate for a node0 commit: the peer (node1) view has a reversed
+// source-pool port range, so the gate must reject naming the peer node.
+func TestCompileTreeStrict_RejectsPeerOnlySNAT_5876(t *testing.T) {
+	tree := peerDivergentSNATTree(t)
+
+	// node0 (the submitting node) strict-compiles cleanly on its own view.
+	if _, err := config.CompileConfigForNode(tree, 0); err != nil {
+		t.Fatalf("node0 local compile must be clean: %v", err)
+	}
+
+	// The strict commit gate for node0 must reject the peer-only SNAT error.
+	_, err := compileTreeStrict(tree, 0)
+	if err == nil {
+		t.Fatal("compileTreeStrict(node0) ACCEPTED a peer-only source-NAT reversed port range — #5876 fail-open")
+	}
+	for _, want := range []string{"node1", "source-nat pool"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("compileTreeStrict reject missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestCompileTreeStrict_StandalonePeerNoOp_5876 pins that standalone commits
+// (nodeID -1) skip the peer gate — a lone reversed range is still rejected by the
+// local strict gate, but no peer machinery runs and no false-reject occurs for a
+// clean standalone config.
+func TestCompileTreeStrict_StandaloneCleanSNAT_5876(t *testing.T) {
+	tree := &config.ConfigTree{}
+	for _, cmd := range []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool P",
+		"set security nat source pool P address 203.0.113.5/32",
+		"set security nat source pool P port range 1024 to 2048",
+	} {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	if _, err := compileTreeStrict(tree, -1); err != nil {
+		t.Fatalf("standalone clean SNAT config must compile: %v", err)
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -353,6 +353,20 @@ func compileTreeStrict(tree *config.ConfigTree, nodeID int) (*config.Config, err
 	if err := crossCheckRAIntervals(compiled); err != nil {
 		return nil, err
 	}
+	// #5876: a chassis-cluster commit must prove BOTH node-effective source-NAT
+	// views are representable before promotion, not only the submitting node's.
+	// This gate compiles for the local node alone (CompileConfigForNode above),
+	// so a ${node} apply-group substitution / per-node rewrite that selects a
+	// source-NAT pool or reference valid on the origin but invalid on the peer
+	// passes green — then the standby lenient-loads the synced snapshot and
+	// silently fails its SNAT closed. Re-run the strict SOURCE-NAT validators
+	// against the peer's effective compile (the same CompileConfigForNodeLenient
+	// transform the standby applies) so a peer-only pool/reference error is
+	// rejected here, at the one strict gate that ever sees this config.
+	// Standalone (nodeID < 0) has no peer and is a no-op.
+	if err := config.ValidatePeerEffectiveSourceNATStrict(tree, nodeID); err != nil {
+		return nil, err
+	}
 	return compiled, nil
 }
 


### PR DESCRIPTION
## Problem

Strict SOURCE-NAT validation ran only against the **submitting node's**
effective compiled view. The strict commit gate compiles for the local node
alone (`configstore.compileTreeStrict` → `CompileConfigForNode(nodeID)`), so the
strict source-NAT validators in `compiler_validate_strict_nat.go` saw only that
one node's pools and rules.

Chassis-aware compilation + `${node}` apply-group substitution can select a
**different** effective source-NAT view for the peer:

- a per-node pool `address`,
- a per-node pool `port range`, or
- a shared top-level rule whose `then source-nat pool <name>` names a pool that
  only a peer `groups nodeN` block defines.

A source-NAT error valid on the origin but invalid on the peer therefore passed
the originating commit **green** and surfaced only when the standby ingested the
config-synced snapshot via the tolerant path (`Store.SyncApply` →
`CompileConfigForNodeLenient`), which downgrades the strict SNAT gate to a
warning and fails the translation **closed**. A green commit stranded the
standby's SNAT; a failover then silently changed NAT behavior.

## Fix

Add `ValidatePeerEffectiveSourceNATStrict(tree, localNodeID)`
(`pkg/config/compiler_peer_effective_snat.go`), wired into
`compileTreeStrict` after the local compile + cross-checks. When clustered
(`nodeID >= 0`) it compiles the **peer** node (`1 - nodeID`) with
`CompileConfigForNodeLenient` — the **exact** transform the standby applies on
`SyncApply` — and re-runs the existing strict SOURCE-NAT validators against that
peer-effective `*Config`:

- `validateSourceNATPoolStrict`
- `validateSourceNATPoolAddressGrammarStrict`
- `validateSourceNATPersistentNoTranslationStrict`
- `validateNATPoolReferencesStrict`
- `validateNATSourceAddressNameReferencesStrict`

A peer-only source-NAT pool/reference error is now rejected at the origin
commit, naming the peer node + offending pool, so **both** node-effective
outputs are proven representable before promotion.

**Peer-effective view** = `CompileConfigForNodeLenient(peerID)` (verified this is
the exact transform the standby applies: `Store.SyncApply` →
`compileTreeLenient` → `CompileConfigForNodeLenient(s.nodeID)`).

**Scope:** validators are reused verbatim (no new SNAT rules). Non-source-NAT
gate errors on the peer view are out of scope (downgraded to warnings by the
lenient compile); a peer view that will not compile at all is left to the peer's
own load path (no false-reject of the origin commit). **Standalone**
(`nodeID < 0`) has no peer and is a no-op — zero behavior change off a cluster.
The peer compile is a pure function of the candidate tree and the reused
validators walk pools/rule-sets in sorted order → deterministic verdict.

## STEP 0 (not stale)

Confirmed on `origin/master` (`b71cd71ff`) that the strict SNAT validators run
inside `runUniformGates` and are dispatched only for the single node
`compileTreeStrict` compiles (local `nodeID` only). No peer-effective SNAT
validation existed. Not stale-fixed.

## Testing

- `go build ./...`, `go vet ./pkg/config ./pkg/configstore`,
  `go test ./pkg/config ./pkg/configstore` — all clean.
- `pkg/config/compiler_peer_effective_snat_5876_test.go` — peer-only
  reversed-range, per-node pool-address, and dangling peer-pool-reference
  vectors; both-views-valid + standalone over-reject guards; node0/node1
  symmetry; `peerNodeID` unit.
- `pkg/configstore/peer_effective_snat_5876_test.go` — store-gate wiring.
- **Fail-on-revert proven firsthand:** neutralizing the peer gate makes node0
  accept the peer-only SNAT error → RED in **both** packages.

## Smoke deferral

`make test-failover` is shim-wall-blocked and not required — this is pure
control-plane commit-gate validation with no dataplane/cluster runtime change.
The fail-on-revert unit tests are the regression gate.

## Docs

`docs/config-schema.md` — new "Peer-effective SOURCE-NAT — the #5876 gap"
subsection alongside the #5878 both-node-effective doctrine, explaining why this
gate re-compiles (source-NAT needs the compiled per-node view) rather than
unioning the AST. `_Log.md` dated entry added.

Closes #5876

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NT7g25WfaQLq4JYE53LJi3