### PR TITLE
dataplane: ensure HA-clear retry loop on failed clear

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -50918,3 +50918,39 @@ top.
   pkg/configstore/store.go,
   pkg/configstore/peer_effective_snat_5876_test.go (new),
   docs/config-schema.md
+
+## 2026-07-16 — #5873 ensure HA-clear retry loop before failed-clear return
+
+- **Timestamp**: 2026-07-16
+- **Action**: Fix an HA-state cleanup ordering bug: a standalone
+  (non-cluster) HA-state clear that fails records a `pendingHAStateClear`
+  retry debt (#5487), but that debt's ONLY retry consumer is the periodic
+  status loop (`retryPendingHAStateClearLocked` on the 1/s tick). The two
+  apply-path clear sites in `Compile` (manager_compile.go) could return the
+  fail-closed error BEFORE the loop was started: the first-startup full-publish
+  path returns from the failed-clear branch just ABOVE `ensureStatusLoopLocked`,
+  and the deferred-XSK resume path returns without ever calling it. On first
+  startup (or any apply with no pre-existing loop) a failed clear therefore
+  orphaned the debt — nothing ever retried the idempotent empty
+  `update_ha_state`, so stale helper HA groups persisted and kept owner-RG-0
+  transit `ForwardCandidate`s `HAInactive` (drop) indefinitely, contradicting
+  the debt's eventual-cleanup contract. Fix (minimal call-ordering): added a
+  thin wrapper `clearHelperHAStateWithDebtEnsureRetryLocked` (manager_ha.go,
+  next to the existing debt lifecycle) that runs `clearHelperHAStateWithDebtLocked`
+  and, on failure, calls `ensureStatusLoopLocked` (idempotent — guarded on
+  `m.syncCancel`) before returning the raw error. Both clear sites now use the
+  wrapper, so a recorded debt ALWAYS has a running worker to retry it. Ordering
+  preserved: record debt (inside WithDebt) -> ensure loop -> return err. The
+  clear still fails closed. Invariant now documented in code comments
+  (manager_ha.go / manager_compile.go); no prose doc described the clear-debt
+  retry, so no docs change beyond the code comments.
+  Validation: `go build ./...` clean; `go vet ./pkg/dataplane/userspace` clean;
+  `TMPDIR=/tmp go test ./pkg/dataplane/userspace` GREEN (14.8s). Fail-on-revert
+  proven firsthand: removing the `ensureStatusLoopLocked` call from the wrapper
+  turns `TestClearHelperHAStateEnsureRetryStartsLoopOnFailedClear` RED
+  (`syncCancel == nil`; the debt is orphaned). Smoke (`make test-failover`)
+  deferred — shim-wall-blocked, pure control-plane ordering fix gated on the
+  fail-on-revert unit test.
+  **File(s)**: pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/manager_compile.go,
+  pkg/dataplane/userspace/manager_ha_clear_debt_5873_test.go (new)

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -273,9 +273,16 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		// helper side here too so the standalone state is consistent
 		// regardless of which apply path runs. (Idempotent empty update.)
 		if !m.clusterHA {
-			if err := m.clearHelperHAStateWithDebtLocked(); err != nil {
+			if err := m.clearHelperHAStateWithDebtEnsureRetryLocked(); err != nil {
 				// Debt recorded — the status poll retries the clear until it
 				// succeeds; still surface the error so the apply fails closed.
+				// #5873: this deferred-publish resume path returns without
+				// reaching the ensureStatusLoopLocked() call on the normal apply
+				// path, so the WithDebtEnsureRetry wrapper starts the loop (the
+				// debt's only retry consumer) before this failure propagates —
+				// otherwise the failed clear would orphan the debt with no worker
+				// to retry it. The pendingXSKStartup precondition guarantees
+				// m.proc != nil, so the loop can actually run.
 				return result, fmt.Errorf("clear userspace HA state (deferred startup): %w", err)
 			}
 		}
@@ -362,7 +369,7 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		if err := m.syncHAStateLocked(); err != nil {
 			return result, fmt.Errorf("publish userspace HA state: %w", err)
 		}
-	} else if err := m.clearHelperHAStateWithDebtLocked(); err != nil {
+	} else if err := m.clearHelperHAStateWithDebtEnsureRetryLocked(); err != nil {
 		// Non-cluster node: ensure neither the manager nor the helper retains
 		// HA groups. seedHAGroupInventoryLocked already cleared m.haGroups
 		// above; this also clears any groups a prior clustered apply pushed to
@@ -371,6 +378,13 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		// On failure a retry debt is recorded (#5487) so the status poll
 		// re-attempts the idempotent clear until the helper reports no groups;
 		// the error is still surfaced so this apply fails closed.
+		// #5873: the recorded debt's ONLY retry consumer is the periodic status
+		// loop, which the success path starts below via ensureStatusLoopLocked().
+		// On first startup (or any apply with no pre-existing loop) returning
+		// here BEFORE that call would orphan the debt — no worker would ever
+		// retry the clear, so the stale helper HA groups (and the owner-RG-0
+		// transit-drop gate) would persist indefinitely. The WithDebtEnsureRetry
+		// wrapper starts the loop (idempotent) before this failure propagates.
 		return result, fmt.Errorf("clear userspace HA state: %w", err)
 	}
 	if err := m.syncDesiredForwardingStateLocked(); err != nil {

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -112,6 +112,30 @@ func (m *Manager) clearHelperHAStateWithDebtLocked() error {
 	return nil
 }
 
+// clearHelperHAStateWithDebtEnsureRetryLocked runs the standalone clear via
+// clearHelperHAStateWithDebtLocked and, when it fails, guarantees the periodic
+// status loop is running before the error propagates (#5873). The recorded
+// pendingHAStateClear debt has exactly one retry consumer — the status-loop
+// tick (retryPendingHAStateClearLocked). Both apply-path clear sites can return
+// the failure BEFORE reaching the normal ensureStatusLoopLocked() call: the
+// first-startup full-publish path (returns from the failed-clear branch just
+// above ensureStatusLoopLocked) and the deferred-XSK resume path (returns
+// without ever calling it). Either way, without a running loop the debt is
+// orphaned — nothing ever retries the idempotent clear, so stale helper HA
+// groups keep the owner-RG-0 transit ForwardCandidates HAInactive (drop)
+// indefinitely, contradicting the debt's eventual-cleanup contract. Ensuring
+// the loop here (idempotent — guarded on m.syncCancel) gives the just-recorded
+// debt a worker on its very first tick. The clear still fails closed: the raw
+// error is returned so the caller surfaces the apply failure. Ordering: record
+// debt (inside WithDebt) -> ensure loop -> return err.
+func (m *Manager) clearHelperHAStateWithDebtEnsureRetryLocked() error {
+	if err := m.clearHelperHAStateWithDebtLocked(); err != nil {
+		m.ensureStatusLoopLocked()
+		return err
+	}
+	return nil
+}
+
 // retryPendingHAStateClearLocked settles a stranded standalone HA-state clear
 // debt from the status poll tick. It runs OUTSIDE the m.clusterHA HA-sync guard
 // (that guard is exactly why a standalone clear is never retried), but only

--- a/pkg/dataplane/userspace/manager_ha_clear_debt_5873_test.go
+++ b/pkg/dataplane/userspace/manager_ha_clear_debt_5873_test.go
@@ -1,0 +1,114 @@
+package userspace
+
+import (
+	"errors"
+	"testing"
+)
+
+// #5873: a standalone HA-state clear that FAILS records a pendingHAStateClear
+// retry debt (#5487), but that debt has exactly ONE retry consumer — the
+// periodic status-loop tick (retryPendingHAStateClearLocked). Both apply-path
+// clear sites (manager_compile.go) can return the failure BEFORE reaching the
+// normal ensureStatusLoopLocked() call:
+//
+//   - first-startup full publish: the failed-clear branch returns just ABOVE
+//     the ensureStatusLoopLocked() call, so on the very first apply (no loop
+//     yet) a failed clear leaves the debt with no worker to retry it;
+//   - deferred-XSK resume: that path returns without ever calling
+//     ensureStatusLoopLocked().
+//
+// Either way the debt is orphaned and the stale helper HA groups (owner-RG-0
+// transit-drop gate) persist indefinitely, contradicting the eventual-cleanup
+// contract. clearHelperHAStateWithDebtEnsureRetryLocked is the shared wrapper
+// both sites now use: on a failed clear it records the debt AND ensures the
+// status loop is running before the error propagates.
+//
+// FAIL-ON-REVERT: remove the m.ensureStatusLoopLocked() call from
+// clearHelperHAStateWithDebtEnsureRetryLocked (or revert the call sites to the
+// bare clearHelperHAStateWithDebtLocked, i.e. move the loop-ensure back after
+// the return) and (b) below fails — the loop is not started, so the recorded
+// debt can never be retried.
+
+// (a)+(b) A first-startup-style failed standalone clear with NO pre-existing
+// status loop must both record the debt AND start the loop that will retry it,
+// while still surfacing the error (fail closed).
+func TestClearHelperHAStateEnsureRetryStartsLoopOnFailedClear(t *testing.T) {
+	m := New()
+	// No status loop yet — models first startup / any apply with no loop.
+	if m.syncCancel != nil {
+		t.Fatal("test precondition: syncCancel should be nil before any apply")
+	}
+	m.clusterHA = false // standalone
+
+	clearErr := errors.New("update_ha_state boom")
+	m.clearHelperHAStateHook = func() error { return clearErr }
+
+	err := m.clearHelperHAStateWithDebtEnsureRetryLocked()
+
+	// The clear still fails closed: the raw error propagates so the apply
+	// call sites surface the failure.
+	if err == nil {
+		t.Fatal("clearHelperHAStateWithDebtEnsureRetryLocked returned nil on clear failure, want error")
+	}
+	if !errors.Is(err, clearErr) {
+		t.Fatalf("returned error = %v, want it to wrap the clear failure", err)
+	}
+	// (a) The retry debt is recorded.
+	if !m.pendingHAStateClear {
+		t.Fatal("pendingHAStateClear = false after failed standalone clear; the retry debt was not recorded")
+	}
+	// (b) The periodic status loop — the debt's ONLY retry consumer — is now
+	// running (syncCancel set by ensureStatusLoopLocked). Without this the debt
+	// is orphaned: nothing ever retries the idempotent clear and the stale
+	// helper HA groups persist. This is the assertion the revert breaks.
+	if m.syncCancel == nil {
+		t.Fatal("status loop not started after a failed standalone clear (syncCancel == nil); the recorded HA-clear debt is orphaned with no worker to retry it (#5873)")
+	}
+	// Stop the loop goroutine we started.
+	m.syncCancel()
+}
+
+// A failed clear must ensure the loop even when a status loop ALREADY exists —
+// ensureStatusLoopLocked must be idempotent (safe to call with a running loop)
+// so the wrapper can call it unconditionally on the failure path.
+func TestClearHelperHAStateEnsureRetryIdempotentWithExistingLoop(t *testing.T) {
+	m := New()
+	m.clusterHA = false
+
+	// Simulate a pre-existing loop.
+	m.ensureStatusLoopLocked()
+	firstCancel := m.syncCancel
+	if firstCancel == nil {
+		t.Fatal("ensureStatusLoopLocked did not set syncCancel")
+	}
+
+	m.clearHelperHAStateHook = func() error { return errors.New("still failing") }
+	if err := m.clearHelperHAStateWithDebtEnsureRetryLocked(); err == nil {
+		t.Fatal("want error on failed clear")
+	}
+	// The existing loop must NOT be replaced (same cancel func) — idempotent.
+	if m.syncCancel == nil {
+		t.Fatal("syncCancel cleared by a redundant ensure; ensureStatusLoopLocked is not idempotent")
+	}
+	m.syncCancel()
+}
+
+// The success path records no debt and does NOT start a loop from the wrapper:
+// the normal apply path starts the loop itself (ensureStatusLoopLocked at the
+// end of Compile). The wrapper only owns the failed-clear ordering.
+func TestClearHelperHAStateEnsureRetryNoLoopOnSuccess(t *testing.T) {
+	m := New()
+	m.clusterHA = false
+	m.clearHelperHAStateHook = func() error { return nil }
+
+	if err := m.clearHelperHAStateWithDebtEnsureRetryLocked(); err != nil {
+		t.Fatalf("clearHelperHAStateWithDebtEnsureRetryLocked returned %v on success, want nil", err)
+	}
+	if m.pendingHAStateClear {
+		t.Fatal("pendingHAStateClear = true after a successful clear, want false")
+	}
+	if m.syncCancel != nil {
+		m.syncCancel()
+		t.Fatal("status loop started on the success path; the wrapper must only ensure the loop on a failed clear")
+	}
+}


### PR DESCRIPTION
## Problem

Standalone (non-cluster) HA-state cleanup records a `pendingHAStateClear`
retry debt (#5487) on a failed helper RPC and returns the apply error.
That debt's **only** retry consumer is the periodic status loop
(`retryPendingHAStateClearLocked` on the 1/s tick), but the two apply-path
clear sites in `Compile` (`pkg/dataplane/userspace/manager_compile.go`) could
return the fail-closed error **before** the loop was ever started:

- the **first-startup full-publish** path returns from the failed-clear branch
  just *above* the `ensureStatusLoopLocked()` call; and
- the **deferred-XSK resume** path returns without ever calling it.

On first startup (or any apply with no pre-existing loop) a failed clear
therefore **orphaned** the debt — nothing retried the idempotent empty
`update_ha_state`, so stale helper HA groups survived a cluster→standalone
transition and kept owner-RG-0 transit `ForwardCandidate`s `HAInactive`
(drop) indefinitely, despite the code claiming eventual cleanup.

## Fix (minimal call-ordering)

Add a thin wrapper `clearHelperHAStateWithDebtEnsureRetryLocked`
(`manager_ha.go`, beside the existing debt lifecycle) that runs
`clearHelperHAStateWithDebtLocked` and, on failure, calls
`ensureStatusLoopLocked` (idempotent — guarded on `m.syncCancel`) **before**
returning the raw error. Both clear sites now use the wrapper, so a recorded
debt always has a running worker to retry it.

Ordering preserved: **record debt → ensure loop → return err**. The clear
still fails closed (the apply error is surfaced unchanged). This is a pure
call-ordering fix, not a redesign — the broader restructures listed in the
issue's "Required invariants" (generation fencing, restart re-derivation,
readiness gating) are intentionally out of scope.

## Validation

- `go build ./...` — clean
- `go vet ./pkg/dataplane/userspace` — clean
- `TMPDIR=/tmp go test ./pkg/dataplane/userspace` — GREEN (14.8s; short TMPDIR so
  the unix-socket-binding tests pass under the sun_path 108-char limit)
- **Fail-on-revert (firsthand):** new `manager_ha_clear_debt_5873_test.go`.
  Removing the `ensureStatusLoopLocked` call from the wrapper turns
  `TestClearHelperHAStateEnsureRetryStartsLoopOnFailedClear` RED:

  ```
  --- FAIL: TestClearHelperHAStateEnsureRetryStartsLoopOnFailedClear (0.00s)
      manager_ha_clear_debt_5873_test.go:65: status loop not started after a
      failed standalone clear (syncCancel == nil); the recorded HA-clear debt
      is orphaned with no worker to retry it (#5873)
  ```

## Smoke deferral

`make test-failover` is shim-wall-blocked (loss cluster ABI). This is a pure
control-plane ordering fix on the HA-cleanup path with no dataplane/wire
change; correctness is gated on the fail-on-revert unit test above.

## Docs

No prose doc describes the `pendingHAStateClear` clear-debt retry lifecycle
(it lives in code comments only); the loop-ensured-on-failed-clear invariant
is captured in the updated `manager_ha.go` / `manager_compile.go` comments.
Dated `_Log.md` entry added.

Closes #5873

🤖 Generated with [Claude Code](https://claude.com/claude-code)