### PR TITLE
nat: reject zone-scoped IPv6 SNAT pool addresses at strict commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -50918,3 +50918,42 @@ top.
   pkg/configstore/store.go,
   pkg/configstore/peer_effective_snat_5876_test.go (new),
   docs/config-schema.md
+
+- **Timestamp**: 2026-07-16
+  **Action**: #5875 — reject zone-qualified IPv6 SNAT pool addresses at strict
+  commit (control-plane/dataplane representability). Strict source-NAT
+  validation ACCEPTED a scoped IPv6 literal (`fe80::1%eth0`) in a source-NAT
+  pool `address`: the Junos lexer admits `%` (`lexer.go` `isIdentChar`) and Go's
+  `netip.ParseAddr` honors a zone, so the scoped form passed the #5627
+  pool-address grammar gate and the snapshot builder shipped the raw string.
+  The Rust allocator parses each member as `std::net::IpAddr`
+  (`expand_pool_address`, `userspace-dp/src/nat/source.rs`), which has no scope
+  model, so the scoped form fails to parse, the whole pool is marked
+  `InvalidPool`, and the rule silently stops translating after apply — a
+  commit-vs-apply divergence. Fix (mirrors #5859/#5818/#5819 fail-closed shape):
+  added `validateSourceNATPoolAddressScopeStrict` (`compiler_validate_strict_nat.go`)
+  + shared detector `config.PoolAddressHasZoneScope` (a `%` substring test).
+  The gate hard-rejects a `%zone`-scoped pool address at strict commit (naming
+  the pool + address, advising removal of the suffix), iterates ONLY referenced
+  pools (same scoping as #5627), and runs BEFORE the grammar gate so a
+  scoped-CIDR gets the precise scope message rather than a generic invalid-CIDR
+  one. Dispatched in `runUniformGates` with the `lenientDestNATAddresses`
+  downgrade (warn on load / peer-sync, #1960 no-brick) and in the #5876
+  peer-effective SNAT view (`validateSourceNATStrictView`) so a
+  peer-`${node}`-only scoped address is rejected at the origin commit too. The
+  snapshot builder (`nat_source.go`) independently fails closed — marks the pool
+  unusable with reason `zone_scoped_pool_address` (Rust maps the unknown reason
+  to `InvalidPool` via the existing fallback, same as #5819's
+  `persistent_nat_no_translation`) — so a persisted/peer-synced scoped pool
+  installs nothing rather than shipping the unparseable string. No Rust change.
+  Fail-on-revert proven firsthand (RED verbatim): strict reject neutralized →
+  scoped address compiles clean; lenient warn absent; snapshot ships the raw
+  string with `PoolUnusable=false`. `go build ./...`, `go vet`, and the full
+  `pkg/config` + `pkg/dataplane/userspace` suites green.
+  **File(s)**: pkg/config/compiler_validate_strict_nat.go,
+  pkg/config/compiler_uniformgates.go,
+  pkg/config/compiler_peer_effective_snat.go,
+  pkg/config/compiler_zone_scoped_snat_pool_5875_test.go (new),
+  pkg/dataplane/userspace/nat_source.go,
+  pkg/dataplane/userspace/nat_source_zone_scope_5875_test.go (new),
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3405,6 +3405,40 @@ reserved for whole-dataplane selection where a rewrite shim
     Fail-on-revert: `TestSourceNATPoolBadGrammarRejected` /
     `TestSourceNATPoolBadGrammarLenientWarns`
     (`pkg/config/strict_nat_pool_grammar_5627_test.go`).
+  - `security nat source pool <name> address <member>` zone/scope qualifier
+    (#5875) — a NEW representability constraint alongside #5627. A source-NAT
+    pool address may carry an IPv6 **zone/scope qualifier** (`fe80::1%eth0`):
+    the Junos lexer admits `%` (`lexer.go` `isIdentChar`) and Go's
+    `netip.ParseAddr` honors a zone, so the scoped literal passed the #5627
+    grammar gate (a bare IP with a zone parses fine) and the snapshot builder
+    copied the raw string onto the wire. But the Rust allocator parses each pool
+    member as `std::net::IpAddr` (`expand_pool_address`,
+    `userspace-dp/src/nat/source.rs`), which has **no scope model**, so the
+    scoped form fails to parse, the whole pool is marked `InvalidPool`, and the
+    rule silently stops translating after apply — the same commit-vs-apply
+    outage as #5627 but from a different cause. `validateSourceNATPoolAddressScopeStrict`
+    (`compiler_validate_strict_nat.go`) **rejects a `%zone`-scoped pool address
+    at strict commit**, naming the pool and the offending address, and telling
+    the operator to remove the `%zone` suffix. The reject is safe: a global SNAT
+    pool address never needs an interface scope, and the issue forbids silently
+    stripping `%zone` (it would change the modeled address). The gate iterates
+    ONLY referenced pools (same scoping as #5627) and runs BEFORE the #5627
+    grammar gate so a `%zone`-scoped member — including a scoped-CIDR the grammar
+    gate would otherwise reject with a generic invalid-CIDR message — gets the
+    precise scope diagnostic. It reuses the `lenientDestNATAddresses` downgrade
+    (warn on load / peer-sync, #1960 no-brick); the snapshot builder
+    independently marks such a pool unusable
+    (reason `zone_scoped_pool_address`), installing nothing rather than shipping
+    the unparseable string. Registered in the SNAT strict set, so the #5876
+    peer-effective SNAT gate rejects a peer-`${node}`-only scoped address too.
+    The shared detector is `config.PoolAddressHasZoneScope` (a `%` substring
+    test), used by both the Go validator and the snapshot builder. Fail-on-revert:
+    `TestSourceNATPoolZoneScopedAddressRejected` /
+    `TestSourceNATPoolZoneScopedAddressLenientWarns` /
+    `TestPeerOnlyZoneScopedSNATPoolRejected_5875`
+    (`pkg/config/compiler_zone_scoped_snat_pool_5875_test.go`) and
+    `TestSourceNATSnapshotZoneScopedPoolUnusable_5875`
+    (`pkg/dataplane/userspace/nat_source_zone_scope_5875_test.go`).
   - `security nat static rule-set rule then static-nat prefix-name <addr>`
     (#4290) — the NAMED form of `then static-nat prefix <ip>`. `prefix-name`
     references a global `security address-book` entry whose literal prefix

--- a/pkg/config/compiler_peer_effective_snat.go
+++ b/pkg/config/compiler_peer_effective_snat.go
@@ -8,7 +8,7 @@ import "fmt"
 // installable before promotion (#5876).
 //
 // The strict SNAT gates (validateSourceNATPoolStrict,
-// validateSourceNATPoolAddressGrammarStrict,
+// validateSourceNATPoolAddressGrammarStrict, validateSourceNATPoolAddressScopeStrict,
 // validateSourceNATPersistentNoTranslationStrict, validateNATPoolReferencesStrict,
 // validateNATSourceAddressNameReferencesStrict) already run inside
 // compileExpanded — but ONLY against the single node the commit compiles for.
@@ -107,6 +107,9 @@ func validateSourceNATStrictView(cfg *Config) error {
 		return err
 	}
 	if err := validateNATPoolReferencesStrict(cfg); err != nil {
+		return err
+	}
+	if err := validateSourceNATPoolAddressScopeStrict(cfg); err != nil {
 		return err
 	}
 	if err := validateSourceNATPoolAddressGrammarStrict(cfg); err != nil {

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -683,6 +683,35 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 		}
 	}
 
+	// #5875 source-NAT pool ZONE-SCOPED ADDRESS gate. A source-NAT pool address
+	// may carry an IPv6 zone/scope qualifier (`fe80::1%eth0`): the Junos lexer
+	// admits `%` and Go's netip.ParseAddr honors a zone, so the scoped literal
+	// slipped through and the snapshot builder copied the raw string onto the
+	// wire. But the Rust allocator parses each pool member as std::net::IpAddr
+	// (no scope model), so the scoped form fails to parse, the pool is marked
+	// InvalidPool, and the rule silently stops translating after apply — a
+	// commit-vs-apply divergence. Reject the scoped form: a global SNAT pool
+	// address never needs an interface scope, and stripping `%zone` silently
+	// would change the modeled address. Strict on commit / commit-check
+	// (hard-reject so the un-representable pool is operator-visible); lenient on
+	// load / peer-sync (downgrade to a warning so a config persisted before this
+	// gate existed still boots — #1960 no-brick; the snapshot builder
+	// independently marks the pool unusable with reason "zone_scoped_pool_address").
+	// Shares the lenientDestNATAddresses flag (same NAT silent-drop /
+	// wrong-translate doctrine). Runs BEFORE the grammar gate so a `%zone`-scoped
+	// member (including a scoped-CIDR the grammar gate would otherwise reject with
+	// a generic invalid-CIDR message) gets the precise, actionable scope
+	// diagnostic. Registered in the SNAT strict set, so #5876's peer-effective
+	// SNAT gate covers it too.
+	if err := validateSourceNATPoolAddressScopeStrict(cfg); err != nil {
+		if opts.lenientDestNATAddresses {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("source-nat pool zone-scoped address (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
+
 	// #5627 source-NAT pool ADDRESS-grammar gate. The strict path validated a
 	// source pool's `port range` but left its ADDRESS members unchecked, so a
 	// pool referenced by a pool-mode `then source-nat pool <name>` rule that

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -901,6 +901,110 @@ func validateSourceNATPoolAddressGrammarStrict(cfg *Config) error {
 	return nil
 }
 
+// PoolAddressHasZoneScope reports whether a source-NAT pool address literal
+// carries an IPv6 zone/scope qualifier (`%<zone>`), e.g. `fe80::1%eth0`
+// (#5875). The Junos lexer permits the `%`-qualified text (lexer.go isIdentChar
+// admits `%`) and Go's netip.ParseAddr accepts a zone, so a scoped literal
+// passes the source-pool address grammar gate. But the live Rust allocator
+// parses each pool member as std::net::IpAddr (`expand_pool_address`,
+// userspace-dp/src/nat/source.rs), which has NO zone model, so the scoped form
+// fails to parse and the whole pool is marked InvalidPool and dropped at apply.
+//
+// No legitimate source-NAT pool address ever carries a `%zone` suffix — a
+// global SNAT pool address needs no interface scope, and `%` is not part of any
+// IPv4/IPv6/CIDR literal — so a `%` anywhere in the member is unambiguously the
+// zone qualifier. Detection is a plain substring test so it also catches a
+// scoped-CIDR (`fe80::1%eth0/64`) form that netip.ParsePrefix would reject with
+// a less specific message. Shared by the strict validator
+// (validateSourceNATPoolAddressScopeStrict) and the userspace snapshot builder
+// (pkg/dataplane/userspace/nat_source.go) so both fail closed identically.
+func PoolAddressHasZoneScope(addr string) bool {
+	return strings.Contains(addr, "%")
+}
+
+// validateSourceNATPoolAddressScopeStrict (#5875) hard-rejects a source-NAT
+// pool, referenced by a pool-mode `then source-nat pool <name>` rule, whose
+// address membership carries an IPv6 zone/scope qualifier (`%<zone>`) that the
+// live Rust dataplane cannot represent — a NEW representability constraint
+// alongside validateSourceNATPoolAddressGrammarStrict (#5627).
+//
+// A scoped literal such as `fe80::1%eth0` passes the grammar gate because Go's
+// netip.ParseAddr accepts a zone identifier, and the snapshot builder copies
+// the raw string onto the wire. But Rust parses pool members as
+// std::net::IpAddr (no scope model), so `expand_pool_address` returns false,
+// the allocator marks the whole pool InvalidPool, and the rule silently stops
+// translating after apply — a commit-vs-apply divergence. Rejecting the scoped
+// form is safe: a global SNAT pool address never needs an interface scope, and
+// stripping the `%zone` silently would change the modeled address, so the fix
+// rejects rather than rewrites (per the issue's "do not strip %zone silently").
+//
+// Mirrors validateSourceNATPoolAddressGrammarStrict's scoping exactly: only
+// pools a pool-mode rule references are checked (an unreferenced pool never
+// reaches the Rust grammar), in sorted rule-set / declaration order for a
+// deterministic first-reported offender. Dispatched BEFORE the grammar gate so
+// a `%zone`-scoped member (including a scoped-CIDR the grammar gate would
+// otherwise reject with a generic invalid-CIDR message) gets this precise,
+// actionable scope diagnostic. Strict on commit / commit-check
+// (hard-reject so the un-representable pool is operator-visible); the call site
+// (runUniformGates) downgrades it to a warning on the tolerant load / peer-sync
+// path (#1960 no-brick) — the snapshot builder independently marks the pool
+// unusable (reason "zone_scoped_pool_address"), installing nothing rather than
+// shipping the unparseable string. Because it is registered in the SNAT strict
+// set, the #5876 peer-effective SNAT gate runs it against the peer view too.
+func validateSourceNATPoolAddressScopeStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	pools := cfg.Security.NAT.SourcePools
+	rulesets := append([]*NATRuleSet(nil), cfg.Security.NAT.Source...)
+	sort.SliceStable(rulesets, func(i, j int) bool {
+		if rulesets[i] == nil || rulesets[j] == nil {
+			return rulesets[i] != nil
+		}
+		return rulesets[i].Name < rulesets[j].Name
+	})
+	seen := make(map[string]bool)
+	for _, rs := range rulesets {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil || rule.Then.PoolName == "" {
+				continue
+			}
+			name := rule.Then.PoolName
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			pool, ok := pools[name]
+			if !ok || pool == nil {
+				// Undefined reference — validateNATPoolReferencesStrict (#5626).
+				continue
+			}
+			var addrs []string
+			if pool.Address != "" {
+				addrs = append(addrs, pool.Address)
+			}
+			addrs = append(addrs, pool.Addresses...)
+			for _, a := range addrs {
+				if PoolAddressHasZoneScope(a) {
+					return fmt.Errorf(
+						"source-nat pool %q (referenced by rule-set %q rule %q): "+
+							"address %q carries an IPv6 zone/scope qualifier (%%zone), "+
+							"which the dataplane cannot represent — Rust parses pool "+
+							"members as an unscoped IP address, so the rule commits but "+
+							"the dataplane marks the pool unusable (InvalidPool) and "+
+							"drops it at runtime, silently stopping translation; remove "+
+							"the %%zone suffix (a global SNAT pool address needs no scope)",
+						name, rs.Name, rule.Name, a)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // validateNATSourceAddressNameReferencesStrict hard-rejects a source or
 // destination NAT rule whose `match source-address-name <name>` OR `match
 // destination-address-name <name>` (#3229) names an address-book entry that

--- a/pkg/config/compiler_zone_scoped_snat_pool_5875_test.go
+++ b/pkg/config/compiler_zone_scoped_snat_pool_5875_test.go
@@ -1,0 +1,246 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5875: strict source-NAT validation ACCEPTED a scoped IPv6 literal
+// (`fe80::1%eth0`) in a source-NAT pool address. The Junos lexer permits the
+// `%`-qualified text and Go's netip.ParseAddr honors a zone identifier, so the
+// address passed the #5627 pool-address grammar gate and the snapshot builder
+// copied the raw string onto the wire. But the live Rust allocator
+// (expand_pool_address, userspace-dp/src/nat/source.rs) parses each pool member
+// as std::net::IpAddr, which has NO zone model — so the scoped form fails to
+// parse, the whole pool is marked InvalidPool, and the rule silently stops
+// translating after apply: a control-plane/dataplane disagreement.
+//
+// The fix (validateSourceNATPoolAddressScopeStrict, wired in runUniformGates and
+// the #5876 peer-effective SNAT view) hard-rejects a `%zone`-scoped pool address
+// at strict commit; the tolerant load / peer-sync path downgrades to a warning
+// and the snapshot builder independently marks the pool unusable
+// ("zone_scoped_pool_address"), installing nothing rather than shipping the
+// unparseable string.
+//
+// FAIL-ON-REVERT: dropping the `validateSourceNATPoolAddressScopeStrict(cfg)`
+// dispatch in compiler_uniformgates.go (or making the validator `return nil`)
+// turns every reject case GREEN and so RED here.
+
+// snat5875Tree builds a config with one source-NAT rule-set whose single rule
+// references pool `p1` in pool-mode, prefixed by the caller's pool `set` lines.
+// Mirrors snat5627Tree (ParseSetCommand + SetPath, never NewParser — the
+// flat-set testing gotcha).
+func snat5875Tree(t *testing.T, poolCmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	cmds := append([]string{}, poolCmds...)
+	cmds = append(cmds,
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool p1",
+	)
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestSourceNATPoolZoneScopedAddressRejected: every `%zone`-scoped pool address
+// shape the Rust IpAddr parse cannot represent must be REJECTED at strict
+// commit, naming the offending pool AND the address. The reject assertions FAIL
+// against the unpatched validator (the fail-on-revert proof).
+func TestSourceNATPoolZoneScopedAddressRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		pool []string
+		addr string // the offending literal the diagnostic must name
+	}{
+		{
+			name: "link-local-named-scope",
+			pool: []string{"set security nat source pool p1 address fe80::1%eth0"},
+			addr: "fe80::1%eth0",
+		},
+		{
+			name: "link-local-numeric-scope",
+			pool: []string{"set security nat source pool p1 address fe80::1%2"},
+			addr: "fe80::1%2",
+		},
+		{
+			name: "global-scope",
+			pool: []string{"set security nat source pool p1 address 2001:db8::1%eth0"},
+			addr: "2001:db8::1%eth0",
+		},
+		{
+			name: "scoped-cidr",
+			pool: []string{"set security nat source pool p1 address fe80::1%eth0/64"},
+			addr: "fe80::1%eth0/64",
+		},
+		{
+			name: "mixed-valid-scoped",
+			pool: []string{
+				"set security nat source pool p1 address 203.0.113.5/32",
+				"set security nat source pool p1 address fe80::1%eth0",
+			},
+			addr: "fe80::1%eth0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileConfig(snat5875Tree(t, tc.pool...))
+			if err == nil {
+				t.Fatalf("expected strict commit to reject zone-scoped pool address %q", tc.addr)
+			}
+			msg := err.Error()
+			// Must name the offending pool + address and describe the cause.
+			if !strings.Contains(msg, "p1") {
+				t.Fatalf("error %q does not name the offending pool", msg)
+			}
+			if !strings.Contains(msg, tc.addr) {
+				t.Fatalf("error %q does not name the offending address %q", msg, tc.addr)
+			}
+			if !strings.Contains(msg, "zone/scope") {
+				t.Fatalf("error %q does not explain the zone/scope cause", msg)
+			}
+		})
+	}
+}
+
+// TestSourceNATPoolZoneScopedAddressLenientWarns: the tolerant load / peer-sync
+// path (#1960 no-brick) must NOT fail-closed on a scoped pool address — it
+// records a warning and boots (the snapshot builder independently marks the
+// pool unusable). RED-on-revert: with the gate removed, no warning is recorded.
+func TestSourceNATPoolZoneScopedAddressLenientWarns(t *testing.T) {
+	cfg, err := CompileConfigLenient(snat5875Tree(t,
+		"set security nat source pool p1 address fe80::1%eth0"))
+	if err != nil {
+		t.Fatalf("lenient compile must not brick on a scoped pool address: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "source-nat pool zone-scoped address") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile must record a source-nat pool zone-scoped address warning; warnings = %v", cfg.Warnings)
+	}
+	// The pool address is preserved (not stripped) so the snapshot builder can
+	// independently mark it unusable — the issue forbids silently stripping the
+	// %zone. Assert the raw literal survived compilation.
+	p := cfg.Security.NAT.SourcePools["p1"]
+	if p == nil {
+		t.Fatalf("pool p1 dropped on lenient compile")
+	}
+	if !strings.Contains(strings.Join(p.Addresses, ","), "fe80::1%eth0") {
+		t.Fatalf("lenient compile must preserve the raw scoped literal (no silent strip); got %v", p.Addresses)
+	}
+}
+
+// TestSourceNATPoolUnscopedAddressCompiles: an UNSCOPED pool address — bare v4,
+// a global v6, an unscoped link-local, and a host CIDR — must still compile
+// clean on the strict path. Regression guard against a false-reject (the fix
+// targets ONLY the `%zone` suffix, not any legitimate v6 literal).
+func TestSourceNATPoolUnscopedAddressCompiles(t *testing.T) {
+	cases := []struct {
+		name string
+		pool []string
+	}{
+		{"bare-v4", []string{"set security nat source pool p1 address 203.0.113.10"}},
+		{"global-v6", []string{"set security nat source pool p1 address 2001:db8::1/128"}},
+		{"link-local-no-scope", []string{"set security nat source pool p1 address fe80::1"}},
+		{"host-cidr", []string{"set security nat source pool p1 address 203.0.113.10/32"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := CompileConfig(snat5875Tree(t, tc.pool...)); err != nil {
+				t.Fatalf("unscoped pool address %q must compile clean on the strict path: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestSourceNATPoolUnreferencedScopedNotRejected pins the scoping decision (same
+// as the #5627 grammar gate): the live dataplane only expands pools a pool-mode
+// rule references, so a defined-but-UNREFERENCED scoped pool never reaches the
+// Rust grammar and must NOT be rejected here — the gate stays grammar-equivalent
+// with live rather than Go-stricter.
+func TestSourceNATPoolUnreferencedScopedNotRejected(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set security nat source pool orphan address fe80::1%eth0",
+		"set security nat source pool orphan port range 5000 to 6000",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("an unreferenced pool with a scoped address must not be rejected (grammar-equivalence with live, which never expands it): %v", err)
+	}
+}
+
+// TestPeerOnlyZoneScopedSNATPoolRejected_5875 proves the scope validator
+// composes with the #5876 peer-effective SNAT gate: a `%zone`-scoped pool
+// address that appears ONLY on the peer node's `${node}` effective view (node0's
+// own view is clean) must be rejected at the origin (node0) commit via
+// ValidatePeerEffectiveSourceNATStrict — otherwise the standby lenient-loads the
+// config-synced snapshot and its dataplane fails the pool closed while node0
+// committed green. FAIL-ON-REVERT: dropping the scope validator from
+// validateSourceNATStrictView leaves node0 accepting the peer-only scoped
+// address.
+func TestPeerOnlyZoneScopedSNATPoolRejected_5875(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security nat source rule-set RS from zone trust",
+		"set security nat source rule-set RS to zone untrust",
+		"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+		"set security nat source rule-set RS rule R1 then source-nat pool P",
+		"set groups node0 security nat source pool P address 203.0.113.5/32",
+		"set groups node1 security nat source pool P address fe80::1%eth0",
+		`set apply-groups "${node}"`,
+	})
+	// node0's own effective view is clean (unscoped address) — the green commit.
+	if _, err := CompileConfigForNode(tree, 0); err != nil {
+		t.Fatalf("node0 local compile must be clean: %v", err)
+	}
+	// The peer-effective gate run at a node0 commit must reject the node1-only
+	// scoped address.
+	err := ValidatePeerEffectiveSourceNATStrict(tree, 0)
+	if err == nil {
+		t.Fatal("node0 commit ACCEPTED a peer-only zone-scoped source-NAT pool address (node1 view) — peer-effective fail-open")
+	}
+	for _, want := range []string{"node1", "P", "fe80::1%eth0", "zone/scope"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("peer-effective scope reject missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestPoolAddressHasZoneScope is a focused unit test of the shared detector so
+// the Go strict validator and the userspace snapshot builder agree on what a
+// zone-scoped literal is.
+func TestPoolAddressHasZoneScope(t *testing.T) {
+	scoped := []string{"fe80::1%eth0", "fe80::1%2", "2001:db8::1%eth0", "fe80::1%eth0/64"}
+	for _, a := range scoped {
+		if !PoolAddressHasZoneScope(a) {
+			t.Errorf("PoolAddressHasZoneScope(%q) = false, want true", a)
+		}
+	}
+	unscoped := []string{"fe80::1", "2001:db8::1", "203.0.113.10", "203.0.113.0/24", "2001:db8::/112"}
+	for _, a := range unscoped {
+		if PoolAddressHasZoneScope(a) {
+			t.Errorf("PoolAddressHasZoneScope(%q) = true, want false", a)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/nat_source.go
+++ b/pkg/dataplane/userspace/nat_source.go
@@ -90,6 +90,25 @@ func buildSourceNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[stri
 						poolUnusable = true
 						poolUnusableReason = "empty_pool"
 					}
+					// #5875: an IPv6 pool address carrying a `%<zone>` scope
+					// qualifier (`fe80::1%eth0`) is not dataplane-representable —
+					// the Rust allocator parses each member as std::net::IpAddr,
+					// which has no zone model, so expand_pool_address returns false
+					// and the whole pool is marked InvalidPool and dropped. The
+					// strict commit gate (validateSourceNATPoolAddressScopeStrict)
+					// hard-rejects this; on the tolerant load / peer-sync path that
+					// gate only warns, so fail CLOSED here — mark the pool unusable
+					// rather than ship the unparseable string to Rust. A global SNAT
+					// pool address never needs an interface scope.
+					for _, a := range poolAddresses {
+						if config.PoolAddressHasZoneScope(a) {
+							slog.Warn("userspace snapshot: marking source NAT rule with zone-scoped pool address unusable",
+								"rule", rule.Name, "pool", rule.Then.PoolName, "address", a)
+							poolUnusable = true
+							poolUnusableReason = "zone_scoped_pool_address"
+							break
+						}
+					}
 					// #3906: `port no-translation` preserves the source port.
 					// The dataplane takes the address-only path and ignores the
 					// port range in this mode, so a defaulted/valid range is

--- a/pkg/dataplane/userspace/nat_source_zone_scope_5875_test.go
+++ b/pkg/dataplane/userspace/nat_source_zone_scope_5875_test.go
@@ -1,0 +1,72 @@
+// #5875: a source-NAT pool address carrying an IPv6 zone/scope qualifier
+// (`fe80::1%eth0`) is not representable by the Rust allocator (which parses each
+// member as std::net::IpAddr, no zone model). Strict commit now rejects it, but
+// a config persisted before the gate existed — or a peer-synced config on the
+// LENIENT load path — still reaches the snapshot builder. The builder must fail
+// CLOSED: mark the pool unusable ("zone_scoped_pool_address") so it installs
+// nothing rather than shipping the unparseable string to Rust (where it would
+// silently poison the whole pool at apply).
+//
+// RED-on-revert (nat_source.go zone-scope check removed): PoolUnusable comes
+// back false and the raw scoped string ships in PoolAddresses.
+package userspace
+
+import "testing"
+
+// This test reuses compileSNATPoolLenient (nat_source_pool_port_5457_test.go),
+// which compiles via the tolerant path so a scoped pool address (which strict
+// commit now rejects) survives into the compiled config, exactly as it would on
+// a peer-sync / persisted-config load — the case the snapshot builder's
+// fail-closed guard exists for.
+
+// TestSourceNATSnapshotZoneScopedPoolUnusable_5875: a scoped pool address makes
+// the snapshot builder mark the pool unusable with the zone_scoped reason and
+// NOT translate. RED-on-revert: PoolUnusable stays false.
+func TestSourceNATSnapshotZoneScopedPoolUnusable_5875(t *testing.T) {
+	cfg := compileSNATPoolLenient(t,
+		"set security nat source pool p1 address fe80::1%eth0")
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	s := snaps[0]
+	if !s.PoolUnusable {
+		t.Fatalf("PoolUnusable = false, want true (scoped pool address must fail closed; on revert the raw string %v ships)", s.PoolAddresses)
+	}
+	if s.PoolUnusableReason != "zone_scoped_pool_address" {
+		t.Fatalf("PoolUnusableReason = %q, want %q", s.PoolUnusableReason, "zone_scoped_pool_address")
+	}
+}
+
+// TestSourceNATSnapshotZoneScopedMixedPoolUnusable_5875: one scoped member among
+// otherwise-valid members still poisons the pool at the dataplane, so the
+// builder must fail the whole pool closed (matching the Rust "one bad member =
+// InvalidPool" behavior).
+func TestSourceNATSnapshotZoneScopedMixedPoolUnusable_5875(t *testing.T) {
+	cfg := compileSNATPoolLenient(t,
+		"set security nat source pool p1 address 203.0.113.5/32",
+		"set security nat source pool p1 address fe80::1%eth0")
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	if !snaps[0].PoolUnusable || snaps[0].PoolUnusableReason != "zone_scoped_pool_address" {
+		t.Fatalf("mixed pool with a scoped member must be unusable (zone_scoped_pool_address); got unusable=%v reason=%q",
+			snaps[0].PoolUnusable, snaps[0].PoolUnusableReason)
+	}
+}
+
+// TestSourceNATSnapshotUnscopedPoolUsable_5875: an UNSCOPED pool address (bare
+// link-local, no `%`) is representable, so the builder must NOT mark the pool
+// unusable. Regression guard against over-broad fail-closed.
+func TestSourceNATSnapshotUnscopedPoolUsable_5875(t *testing.T) {
+	cfg := compileSNATPoolLenient(t,
+		"set security nat source pool p1 address 2001:db8::5/128")
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	if snaps[0].PoolUnusable {
+		t.Fatalf("PoolUnusable = true, want false for an unscoped pool address: reason=%q", snaps[0].PoolUnusableReason)
+	}
+}


### PR DESCRIPTION
## Problem (#5875)

Strict source-NAT validation ACCEPTED a scoped IPv6 literal (`fe80::1%eth0`)
in a source-NAT pool `address`. The Junos lexer admits `%` (`lexer.go`
`isIdentChar`) and Go's `netip.ParseAddr` honors a zone, so the scoped form
passed the #5627 pool-address grammar gate and the userspace snapshot builder
copied the raw string onto the wire. But the Rust allocator parses each pool
member as `std::net::IpAddr` (`expand_pool_address`,
`userspace-dp/src/nat/source.rs`), which has **no scope model**, so the scoped
form fails to parse, the whole pool is marked `InvalidPool`, and the rule
silently stops translating after apply — a control-plane/dataplane
disagreement.

**Step-0 (not stale):** confirmed on `origin/master` (`f1d475beb`) that a
source-NAT pool address `fe80::1%eth0` compiles clean at strict commit and is
stored verbatim in `pool.Addresses` (ships to the snapshot).

## Fix (bounded fail-closed reject — mirrors #5859/#5818/#5819)

- **`validateSourceNATPoolAddressScopeStrict`** (`compiler_validate_strict_nat.go`)
  + shared detector **`config.PoolAddressHasZoneScope`** (a `%` substring test).
  Hard-rejects a `%zone`-scoped pool address at strict commit, naming the pool +
  offending address and advising removal of the suffix. Iterates ONLY referenced
  pools (same scoping as #5627 — the exact set the dataplane snapshot expands)
  and runs BEFORE the grammar gate so a scoped member (including a scoped-CIDR
  the grammar gate would otherwise reject with a generic invalid-CIDR message)
  gets the precise scope diagnostic.
- Dispatched in **`runUniformGates`** with the `lenientDestNATAddresses`
  downgrade (warn on load / peer-sync, #1960 no-brick) and in the **#5876
  peer-effective SNAT view** (`validateSourceNATStrictView`) so a
  peer-`${node}`-only scoped address is rejected at the origin commit too.
- The userspace snapshot builder (**`nat_source.go`**) independently fails
  closed: marks such a pool unusable with reason `zone_scoped_pool_address`
  (Rust maps the unknown reason to `InvalidPool` via the existing fallback, as
  #5819's `persistent_nat_no_translation` does), so a persisted/peer-synced
  scoped pool installs nothing rather than shipping the unparseable string.

The reject is safe: a global SNAT pool address never needs an interface scope,
and the issue forbids silently stripping `%zone` (it would change the modeled
address). **No Rust change.**

## Tests (fail-on-revert, proven RED firsthand)

- `TestSourceNATPoolZoneScopedAddressRejected` — strict reject of link-local
  named/numeric scope, global scope, scoped-CIDR, and a mixed valid+scoped pool
  (each names the pool + address + "zone/scope").
- `TestSourceNATPoolZoneScopedAddressLenientWarns` — tolerant path warns + boots
  and preserves the raw literal (no silent strip).
- `TestSourceNATPoolUnscopedAddressCompiles` / `TestSourceNATPoolUnreferencedScopedNotRejected`
  — no false-reject; grammar-equivalence scoping.
- `TestPeerOnlyZoneScopedSNATPoolRejected_5875` — peer-`${node}`-only scoped
  address rejected at the origin (node0) commit.
- `TestSourceNATSnapshotZoneScopedPoolUnusable_5875` (+ mixed + unscoped guard)
  — snapshot builder marks the pool unusable on the lenient path.

Verified `go build ./...`, `go vet ./pkg/config ./pkg/dataplane/userspace`, and
the full `pkg/config` + `pkg/dataplane/userspace` suites pass.

Closes #5875

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1i8yTEfv8fkTT5PftZqf3