### PR TITLE
config: warn on interface-address DNAT/static-NAT bypass (#5837 Track-1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -50918,3 +50918,34 @@ top.
   pkg/configstore/store.go,
   pkg/configstore/peer_effective_snat_5876_test.go (new),
   docs/config-schema.md
+
+- **Timestamp**: 2026-07-16
+  **Action**: #5837 (Track-1 mitigation) — commit-time WARNING for the
+  first-packet interface-address DNAT/static-NAT bypass. On a session miss the
+  userspace AF_XDP shim classifies a packet destined to a firewall-local
+  interface address as kernel-local (`is_local_destination`) BEFORE consulting
+  destination-NAT / static-NAT (`pre_routing_dnat`), so a Junos port-forward /
+  static 1:1 mapping onto the WAN interface's own address is INERT on the first
+  packet (delivered to the host instead of translated + zone-policed); reply /
+  established traffic is unaffected. Today this is SILENT. Added
+  `validateNATInterfaceAddressCollisionWarnings`
+  (new `pkg/config/compiler_validate_warn_nat_iface_addr.go`), wired into
+  `ValidateConfig` so it fires on BOTH the strict commit and tolerant
+  load/peer-sync paths (WARN-only — valid Junos, never rejects/changes
+  forwarding). It checks each DNAT rule's `match destination-address` (the
+  PUBLIC address the outside targets — NOT the pool/translated-to address, which
+  the ingress classifier never inspects) and each static-NAT rule's `match`
+  external address against the set of configured interface addresses (static unit
+  addresses + VRRP VIPs, both families, normalized via `hostLocalAddrFamily`),
+  naming the rule-set/rule + colliding interface. Track-2 (the dedicated-intent-
+  map dataplane fix) stays deferred per the converged plan §0a. Fail-on-revert
+  proven firsthand (RED: "expected exactly one #5837 DNAT advisory, got 0" when
+  the emit is neutralized). NOTE for reviewer: §0a's literal wording says "DNAT
+  pool address" but the #5837 bypass is triggered by the MATCHED/ingress public
+  address (what `is_local_destination` inspects), matching the plan BACKGROUND
+  ("the address the outside world targets") — so the check keys on the match
+  address; a control test proves pool==iface does NOT warn.
+  **File(s)**: pkg/config/compiler_validate_warn_nat_iface_addr.go (new),
+  pkg/config/compiler_interface_addr_nat_warning_5837_test.go (new),
+  pkg/config/compiler_validate_warn.go,
+  docs/userspace-dnat-plan.md

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-16 — #5837 rev6052 fold: exclude interface-mode-SNAT-routed addrs from the NAT-interface-address advisory
+
+- **Timestamp**: 2026-07-16 (fix/5837-track1-interface-addr-nat-warning)
+- **Action**: Reviewer-found, parent-verified over-warn fold. The #5837 Track-1
+  advisory (`validateNATInterfaceAddressCollisionWarnings`) false-warned on the
+  CANONICAL masquerade + WAN-port-forward config: interface-mode source-NAT
+  `trust`→`untrust` plus a DNAT from `untrust` matching the untrust interface's
+  own WAN-IP. That translation is NOT inert — when interface-mode SNAT targets a
+  zone, the dataplane moves that zone's interface addresses out of the
+  kernel-local set and into `interface_nat`
+  (`nat_translated_local_exclusions`, `userspace-dp/src/afxdp/rst.rs`), so
+  `is_local_destination` returns FALSE (short-circuits on `USERSPACE_INTERFACE_NAT`
+  membership BEFORE the local_v4/v6 check) and inbound DNAT DOES apply.
+  Fix: replicated the rst.rs predicate on the Go side
+  (`interfaceModeSNATExcludedAddresses`): collect the to-zone of every
+  `cfg.Security.NAT.Source` rule that is `interface_mode && !off && to_zone != ""`
+  (mirrors rst.rs exactly — snapshot mapping confirmed in
+  `pkg/dataplane/userspace/nat_source.go:185-194`), then exclude the configured
+  addresses of every interface (via `buildZoneInterfaceMapLocal`, same package)
+  whose zone is in that set. Used the SAFE SUPERSET (all configured unit
+  addresses of a to-zone interface, not just `pick_interface_v4/v6`): never
+  false-warns, only slightly under-warns on a non-picked secondary address, and
+  is insulated from the kernel/config address-ordering divergence a runtime pick
+  would see. VRRP VIPs are NOT excluded (pick reads configured addresses, never
+  VIPs) — a VIP DNAT/static match stays inert and still warns.
+- **File(s)**: pkg/config/compiler_validate_warn_nat_iface_addr.go,
+  pkg/config/compiler_interface_addr_nat_warning_5837_test.go,
+  docs/userspace-dnat-plan.md, _Log.md
+- **Validation**: `go build ./...` clean, `go vet ./pkg/config` clean,
+  `go test ./pkg/config` green (11.9s). New fail-on-revert test
+  `TestDNATInterfaceAddressExcludedByInterfaceSNAT_5837` (canonical config → NO
+  advisory) proven RED when the `if excluded[host]` guard is disabled (assertion
+  failure, build stays clean); keep-green
+  `TestDNATInterfaceAddressStillWarnsWhenSNATToOtherZone_5837` proves the
+  exclusion is to-zone scoped (SNAT to a different zone still warns); existing 6
+  tests stay green.
+
 ## 2026-07-16 — #5805: per-destination ICMP/UDP flood sketches → token bucket
 
 - **Timestamp**: 2026-07-16 (fix/5805-per-dest-flood-tokenbucket)

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -938,6 +938,31 @@ Scope: literal `match destination-address` values are checked; address-book-NAME
 matches are out of scope (resolving them needs the address-book fold, and the
 common case uses a literal address).
 
+**Interface-mode-SNAT exclusion (rev6052): only fires when the address is
+genuinely kernel-local.** An interface address is NOT always kernel-local. When
+an interface-mode source-NAT rule translates traffic TO a zone, the dataplane
+moves every address of that zone's interfaces OUT of the kernel-local set and
+INTO `interface_nat` (`nat_translated_local_exclusions`,
+`userspace-dp/src/afxdp/rst.rs`). `is_local_destination` then short-circuits to
+FALSE for such an address (it checks `USERSPACE_INTERFACE_NAT` membership BEFORE
+the `local_v4`/`local_v6` check), so the first SYN reaches the helper and inbound
+DNAT / static-NAT DOES apply — the translation is NOT inert. Warning on it would
+be a false-warn on the CANONICAL masquerade + WAN-port-forward config (interface
+SNAT `trust`→`untrust` + a DNAT from `untrust` matching the untrust interface's
+own WAN-IP). The advisory therefore excludes any matched address that
+interface-mode source-NAT routes into `interface_nat`: it iterates
+`cfg.Security.NAT.Source`, collects the to-zone of every rule that is
+`interface_mode && !off && to_zone != ""` (mirroring the rst.rs predicate
+exactly), and excludes the configured addresses of every interface in those
+zones. The Go mirror excludes the SAFE SUPERSET (all configured unit addresses of
+a to-zone interface, not just the single `pick_interface_v4/v6` result), so it
+can never false-warn; it may only slightly under-warn on a genuinely-inert
+SECONDARY (non-picked) address of a multi-address interface. VRRP VIPs are NOT
+excluded — `pick_interface_v4/v6` reads configured interface addresses, never
+VIPs, so a VIP stays kernel-local and a DNAT/static match on it is still inert
+(still warns). The advisory now fires only when the address is genuinely
+kernel-local, not when it is interface-NAT-routed.
+
 **Track-2 (deferred): the full dataplane fix.** A dedicated intent map probed
 before the local classification (Option B) is a large, verifier-gated, HA-aware
 project deferred by the converged #5837 research plan

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -900,3 +900,46 @@ drops the pool-less `off` entry (reverting to the pre-#3844 fail-open, never a
 crash); a newer helper honoring an older control plane that omits the field
 defaults it `false` (a normal translate entry). `protocol_wire_v1.json`
 regenerated (one `"off": false` line on the DNAT specimen).
+
+## Known limitation: first-packet interface-address DNAT / static-NAT bypass (#5837)
+
+**Symptom.** A destination-NAT or static-NAT rule whose PUBLIC (matched /
+external) destination address is one of the firewall's own configured interface
+addresses is INERT on the FIRST packet of a new flow. The client's initial
+packet is delivered to the local host stack instead of being translated and
+zone-policed. Reply packets and packets on an already-established session are
+unaffected (the translation applies once a session exists) — only the very first
+packet of each new flow is misrouted.
+
+**Root cause.** On a non-GRE session miss the userspace AF_XDP shim
+(`userspace-xdp/src/lib.rs` `try_xdp_userspace` / `is_local_destination`)
+classifies a packet destined to a firewall-local interface address as
+kernel-local and shunts it to the host BEFORE consulting destination-NAT /
+static-NAT (`is_local_destination` runs ahead of `pre_routing_dnat`).
+`is_local_destination` inspects the INGRESS destination — for a DNAT rule that is
+the `match destination-address` (the public IP the client targets), NOT the
+`then destination-nat pool` address (the internal translation TARGET, which the
+ingress classifier never sees). So a legitimate Junos port-forward / static 1:1
+mapping onto the WAN interface's own address never fires on the first packet.
+
+**Track-1 mitigation (shipped): a commit-time WARNING.** The Go config compiler
+now emits a WARN-only advisory (`validateNATInterfaceAddressCollisionWarnings`,
+`pkg/config/compiler_validate_warn_nat_iface_addr.go`, wired into
+`ValidateConfig`) for each destination-NAT / static-NAT rule whose matched /
+external public address equals a configured interface address (static unit
+addresses AND VRRP VIPs, both families). It names the rule-set/rule and the
+colliding interface address. The advisory fires on BOTH the strict commit path
+and the tolerant load / peer-sync path — the config is legal Junos and works for
+reply / established traffic, so it never rejects or changes forwarding (a hard
+reject would also brick a boot on a previously-committed config). This makes the
+previously SILENT bypass LOUD so the operator can either move the service to a
+non-interface public address or knowingly accept first-packet local delivery.
+Scope: literal `match destination-address` values are checked; address-book-NAME
+matches are out of scope (resolving them needs the address-book fold, and the
+common case uses a literal address).
+
+**Track-2 (deferred): the full dataplane fix.** A dedicated intent map probed
+before the local classification (Option B) is a large, verifier-gated, HA-aware
+project deferred by the converged #5837 research plan
+(`docs/research/5837-xdp-dnat-before-local/plan.md` §0/§0a/§0b). Until it lands
+the commit warning is the honest mitigation.

--- a/pkg/config/compiler_interface_addr_nat_warning_5837_test.go
+++ b/pkg/config/compiler_interface_addr_nat_warning_5837_test.go
@@ -177,3 +177,81 @@ func TestDNATPoolAddressIsInterfaceNoWarn(t *testing.T) {
 		t.Fatalf("pool-address collision is not the #5837 bypass; must not warn, got: %v", ws)
 	}
 }
+
+// #5837 rev6052 (fold): interface-mode source-NAT to a zone routes THAT zone's
+// interface addresses out of the kernel-local set and into interface_nat (the
+// dataplane's nat_translated_local_exclusions, userspace-dp/src/afxdp/rst.rs).
+// is_local_destination then returns FALSE for such an address — it short-circuits
+// on USERSPACE_INTERFACE_NAT membership BEFORE the local_v4/v6 check — so the
+// first SYN reaches the helper and inbound DNAT applies. The translation is NOT
+// inert, so the advisory must be SUPPRESSED. This is the canonical masquerade +
+// WAN-port-forward config (interface SNAT trust->untrust + DNAT from untrust
+// matching the untrust interface's own WAN-IP). Reverting the exclusion
+// (interfaceModeSNATExcludedAddresses / the `if excluded[host]` guard) makes this
+// warn again — RED.
+func TestDNATInterfaceAddressExcludedByInterfaceSNAT_5837(t *testing.T) {
+	lines := []string{
+		// trust (LAN) interface + zone
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.61.1/24",
+		"set security zones security-zone trust interfaces ge-0/0/1.0",
+		// untrust (WAN) interface + zone — its own address is the WAN-IP
+		"set interfaces ge-0/0/2 unit 0 family inet address 172.16.50.8/24",
+		"set security zones security-zone untrust interfaces ge-0/0/2.0",
+		// interface-mode source-NAT trust -> untrust (canonical masquerade)
+		"set security nat source rule-set S from zone trust",
+		"set security nat source rule-set S to zone untrust",
+		"set security nat source rule-set S rule R match source-address 10.0.61.0/24",
+		"set security nat source rule-set S rule R then source-nat interface",
+		// WAN port-forward: DNAT from untrust matching the untrust WAN-IP
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 172.16.50.8/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	}
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile, got: %v", err)
+	}
+	if ws := nat5837Warnings(cfg); len(ws) != 0 {
+		t.Fatalf("interface-mode SNAT routes the WAN-IP into interface_nat; the "+
+			"DNAT is NOT inert and must not warn (rev6052 false-warn), got: %v", ws)
+	}
+}
+
+// Keep-green control: interface-mode source-NAT exists but its to-zone is NOT
+// the zone that owns the matched WAN-IP, so that address stays kernel-local (it
+// is not routed into interface_nat) and the DNAT is still inert — it must STILL
+// warn. Proves the exclusion is to-zone scoped (mirrors the rst.rs predicate),
+// not a blanket "any interface-mode SNAT suppresses every advisory".
+func TestDNATInterfaceAddressStillWarnsWhenSNATToOtherZone_5837(t *testing.T) {
+	lines := []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.61.1/24",
+		"set security zones security-zone trust interfaces ge-0/0/1.0",
+		"set interfaces ge-0/0/2 unit 0 family inet address 172.16.50.8/24",
+		"set security zones security-zone untrust interfaces ge-0/0/2.0",
+		"set interfaces ge-0/0/3 unit 0 family inet address 10.0.30.10/24",
+		"set security zones security-zone dmz interfaces ge-0/0/3.0",
+		// interface-mode SNAT trust -> DMZ (NOT untrust)
+		"set security nat source rule-set S from zone trust",
+		"set security nat source rule-set S to zone dmz",
+		"set security nat source rule-set S rule R match source-address 10.0.61.0/24",
+		"set security nat source rule-set S rule R then source-nat interface",
+		// DNAT from untrust matching the untrust WAN-IP — untrust is NOT the SNAT to-zone
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 172.16.50.8/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	}
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile, got: %v", err)
+	}
+	ws := nat5837Warnings(cfg)
+	if len(ws) != 1 {
+		t.Fatalf("SNAT to a different zone must not exclude the untrust WAN-IP; "+
+			"expected exactly 1 advisory, got %d: %v", len(ws), ws)
+	}
+	if !strings.Contains(ws[0], "172.16.50.8") {
+		t.Fatalf("advisory should name the WAN-IP, got: %s", ws[0])
+	}
+}

--- a/pkg/config/compiler_interface_addr_nat_warning_5837_test.go
+++ b/pkg/config/compiler_interface_addr_nat_warning_5837_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5837 (Track-1 mitigation): a destination-NAT / static-NAT rule whose PUBLIC
+// (matched / external) destination address equals a configured interface address
+// is INERT on the first packet — the userspace AF_XDP shim classifies a
+// firewall-local destination as kernel-local and shunts it to the host BEFORE
+// consulting DNAT/static-NAT (is_local_destination runs before pre_routing_dnat).
+// The commit compiler now emits a WARN-only advisory naming the rule + the
+// colliding interface address on BOTH compile paths. See
+// compiler_validate_warn_nat_iface_addr.go and
+// docs/research/5837-xdp-dnat-before-local/plan.md §0a.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+// nat5837Warnings returns every cfg.Warnings entry that names the #5837
+// interface-address NAT-bypass advisory.
+func nat5837Warnings(cfg *Config) []string {
+	var out []string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#5837") {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// ifaceWithAddr configures ge-0/0/2.0 with the WAN interface address and puts it
+// in the untrust zone, so the NAT rule-sets' `from zone untrust` resolves.
+func ifaceWithAddr(addr string) []string {
+	return []string{
+		"set interfaces ge-0/0/2 unit 0 family inet address " + addr,
+		"set security zones security-zone untrust interfaces ge-0/0/2.0",
+	}
+}
+
+// A destination-NAT rule that matches the firewall's own WAN interface address
+// must produce exactly one #5837 advisory naming the rule-set/rule + interface.
+func TestDNATInterfaceAddressCollisionWarns(t *testing.T) {
+	lines := append(ifaceWithAddr("172.16.50.8/24"),
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 172.16.50.8/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	)
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile (WARN-only), got: %v", err)
+	}
+	ws := nat5837Warnings(cfg)
+	if len(ws) != 1 {
+		t.Fatalf("expected exactly one #5837 DNAT advisory, got %d: %v", len(ws), ws)
+	}
+	w := ws[0]
+	for _, want := range []string{
+		"security nat destination rule-set \"RD\" rule \"R1\"",
+		"172.16.50.8",
+		"ge-0/0/2.0",
+		"INERT on the first packet",
+	} {
+		if !strings.Contains(w, want) {
+			t.Fatalf("advisory missing %q, got: %s", want, w)
+		}
+	}
+}
+
+// The same collision must also warn on the tolerant load / peer-sync path
+// (the advisory is emitted from ValidateConfig, which runs on every compile).
+func TestDNATInterfaceAddressCollisionWarnsLenient(t *testing.T) {
+	lines := append(ifaceWithAddr("172.16.50.8/24"),
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 172.16.50.8",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	)
+	cfg, err := CompileConfigLenient(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("lenient compile must succeed, got: %v", err)
+	}
+	if got := len(nat5837Warnings(cfg)); got != 1 {
+		t.Fatalf("expected one #5837 advisory on the lenient path, got %d", got)
+	}
+}
+
+// A static-NAT rule whose external (public) match address is a firewall
+// interface address must produce a #5837 advisory.
+func TestStaticNATInterfaceAddressCollisionWarns(t *testing.T) {
+	lines := append(ifaceWithAddr("172.16.50.8/24"),
+		"set security nat static rule-set RS from zone untrust",
+		"set security nat static rule-set RS rule R1 match destination-address 172.16.50.8/32",
+		"set security nat static rule-set RS rule R1 then static-nat prefix 10.0.30.100/32",
+	)
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile (WARN-only), got: %v", err)
+	}
+	ws := nat5837Warnings(cfg)
+	if len(ws) != 1 {
+		t.Fatalf("expected exactly one #5837 static-NAT advisory, got %d: %v", len(ws), ws)
+	}
+	for _, want := range []string{
+		"security nat static rule-set \"RS\" rule \"R1\"",
+		"172.16.50.8",
+		"ge-0/0/2.0",
+	} {
+		if !strings.Contains(ws[0], want) {
+			t.Fatalf("advisory missing %q, got: %s", want, ws[0])
+		}
+	}
+}
+
+// A VRRP virtual address (VIP) is firewall-local too: a DNAT match on the VIP
+// must warn, naming the VIP-bearing interface.
+func TestDNATVRRPVIPCollisionWarns(t *testing.T) {
+	lines := []string{
+		"set interfaces reth0 unit 0 family inet address 172.16.50.2/24",
+		"set interfaces reth0 unit 0 family inet address 172.16.50.2/24 vrrp-group 1 virtual-address 172.16.50.1",
+		"set security zones security-zone untrust interfaces reth0.0",
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 172.16.50.1",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	}
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile, got: %v", err)
+	}
+	ws := nat5837Warnings(cfg)
+	if len(ws) != 1 {
+		t.Fatalf("expected one #5837 advisory for a VIP collision, got %d: %v", len(ws), ws)
+	}
+	if !strings.Contains(ws[0], "172.16.50.1") || !strings.Contains(ws[0], "VRRP VIP") {
+		t.Fatalf("VIP advisory should name the VIP + mark it a VRRP VIP, got: %s", ws[0])
+	}
+}
+
+// NO-false-warn control: a DNAT rule whose public match address is NOT any
+// interface address must produce no #5837 advisory. Also covers the pool
+// address deliberately being an interface address (10.0.30.100 is NOT here) —
+// the check keys on the matched/public address, not the translated-to pool.
+func TestDNATNonInterfaceAddressNoWarn(t *testing.T) {
+	lines := append(ifaceWithAddr("172.16.50.8/24"),
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 203.0.113.5/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	)
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile, got: %v", err)
+	}
+	if ws := nat5837Warnings(cfg); len(ws) != 0 {
+		t.Fatalf("a non-interface public address must not warn, got: %v", ws)
+	}
+}
+
+// Control: a DNAT whose POOL (translated-to) address is an interface address but
+// whose MATCH (public) address is not must NOT warn — the #5837 bypass is about
+// the ingress destination the shim classifies as local, not the pool target.
+func TestDNATPoolAddressIsInterfaceNoWarn(t *testing.T) {
+	lines := append(ifaceWithAddr("172.16.50.8/24"),
+		"set security nat destination pool P1 address 172.16.50.8", // pool == iface addr
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 203.0.113.5/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	)
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile, got: %v", err)
+	}
+	if ws := nat5837Warnings(cfg); len(ws) != 0 {
+		t.Fatalf("pool-address collision is not the #5837 bypass; must not warn, got: %v", ws)
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1611,6 +1611,18 @@ func ValidateConfig(cfg *Config) []string {
 	warnings = append(warnings, validateHostInboundMulticastWarnings(cfg)...)
 	warnings = append(warnings, validateHostInboundManagedRoutingMismatch(cfg)...)
 
+	// #5837 (Track-1 mitigation): a destination-NAT / static-NAT rule whose
+	// public (matched / external) destination address equals a configured
+	// interface address is INERT on the first packet — the userspace AF_XDP shim
+	// classifies a firewall-local destination as kernel-local and shunts it to the
+	// host BEFORE consulting DNAT/static-NAT (is_local_destination runs before
+	// pre_routing_dnat). Today that bypass is SILENT; this advisory makes it LOUD,
+	// naming the rule + the colliding interface address. WARN-only on both compile
+	// paths (valid Junos; works for reply/established traffic; the full dataplane
+	// fix is deferred to Track-2). See docs/nat-destination.md and the converged
+	// plan docs/research/5837-xdp-dnat-before-local/plan.md §0a.
+	warnings = append(warnings, validateNATInterfaceAddressCollisionWarnings(cfg)...)
+
 	return warnings
 }
 

--- a/pkg/config/compiler_validate_warn_nat_iface_addr.go
+++ b/pkg/config/compiler_validate_warn_nat_iface_addr.go
@@ -1,0 +1,210 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// compiler_validate_warn_nat_iface_addr.go is the Track-1 (#5837) commit-time
+// advisory: a destination-NAT or static-NAT rule whose PUBLIC / matched
+// destination address (the address the outside world targets) equals a
+// configured interface address on this firewall.
+//
+// Why it matters (the #5837 bypass): on a non-GRE session miss the userspace
+// AF_XDP shim (userspace-xdp/src/lib.rs try_xdp_userspace / is_local_destination)
+// classifies a packet whose destination is a firewall-local interface address as
+// kernel-local and shunts it to the host stack BEFORE consulting destination-NAT
+// or static-NAT. `is_local_destination` inspects the INGRESS destination — for a
+// DNAT rule that is the `match destination-address` (the public IP the client
+// targets), NOT the `then destination-nat pool` address (the internal
+// translation TARGET, which the ingress classifier never sees). So a legitimate
+// Junos port-forward / static 1:1 mapping that matches the WAN interface's own
+// address is INERT on the first packet: the client's SYN is delivered to a local
+// service instead of translated + zone-policed. Reply packets and packets on an
+// already-established session are unaffected (the translation is applied once a
+// session exists); only the FIRST packet of a new flow is misrouted.
+//
+// Track-1 makes that silent bypass LOUD. The full dataplane fix (a dedicated
+// intent map probed before local classification, Option B / Track-2) is a large,
+// verifier-gated, HA-aware project deferred by the converged #5837 research plan
+// (docs/research/5837-xdp-dnat-before-local/plan.md §0/§0a). Until it lands the
+// honest mitigation is a commit-time WARNING naming the offending rule and the
+// colliding interface address.
+//
+// WARN-only on BOTH the strict commit path and the tolerant load / peer-sync
+// path (it is emitted from ValidateConfig, which runs on every compile): the
+// config is legal Junos and works for reply / established traffic, so it must
+// never reject or change forwarding — a hard reject would also brick a boot on a
+// previously-committed config (#1960 no-brick doctrine), and the config may be
+// deliberately staged for the Track-2 future. This mirrors the sibling direct
+// host-bound advisories in compiler_validate_warn_host_inbound.go.
+//
+// Scope: literal `match destination-address` host / prefix values are checked
+// (address-book-NAME-referenced matches are out of scope — resolving them needs
+// the address-book fold and the overwhelmingly common #5837 case uses a literal
+// address). Both IPv4 and IPv6 are covered (the normalization strips the prefix
+// and canonicalizes the host, so `10.0.61.1/32` on the rule matches `10.0.61.1/24`
+// on the interface). Configured static interface addresses AND VRRP virtual
+// addresses (VIPs — also firewall-local) are enumerated.
+
+// interfaceLocalAddressIndex returns a map from a normalized host IP (the value
+// hostLocalAddrFamily produces) to a human label for the interface unit that
+// carries it. Both static unit addresses and VRRP virtual addresses (VIPs) are
+// included, since both are classified firewall-local by the shim. Iteration is
+// fully sorted so the label chosen for an address shared by several units is
+// deterministic (first unit in sorted interface+unit order wins).
+func interfaceLocalAddressIndex(cfg *Config) map[string]string {
+	if cfg == nil || len(cfg.Interfaces.Interfaces) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	record := func(host, label string) {
+		if host == "" {
+			return
+		}
+		if _, ok := out[host]; !ok {
+			out[host] = label
+		}
+	}
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, name)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil {
+			continue
+		}
+		unitNums := make([]int, 0, len(ifc.Units))
+		for un := range ifc.Units {
+			unitNums = append(unitNums, un)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := ifc.Units[un]
+			if unit == nil {
+				continue
+			}
+			label := fmt.Sprintf("%s.%d", ifName, un)
+			for _, a := range unit.Addresses {
+				if host, _ := hostLocalAddrFamily(a); host != "" {
+					record(host, label)
+				}
+			}
+			vgKeys := make([]string, 0, len(unit.VRRPGroups))
+			for k := range unit.VRRPGroups {
+				vgKeys = append(vgKeys, k)
+			}
+			sort.Strings(vgKeys)
+			for _, k := range vgKeys {
+				vg := unit.VRRPGroups[k]
+				if vg == nil {
+					continue
+				}
+				for _, vip := range vg.VirtualAddresses {
+					if host, _ := hostLocalAddrFamily(vip); host != "" {
+						record(host, label+" (VRRP VIP)")
+					}
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// validateNATInterfaceAddressCollisionWarnings emits the Track-1 (#5837)
+// commit-time advisory for each destination-NAT / static-NAT rule whose public
+// (matched / external) destination address equals a configured interface address.
+// See the file header for the mechanism. WARN-only, both compile paths.
+func validateNATInterfaceAddressCollisionWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	ifAddrs := interfaceLocalAddressIndex(cfg)
+	if len(ifAddrs) == 0 {
+		return nil
+	}
+	var warnings []string
+
+	// Destination NAT: the address the outside world targets is the rule's
+	// `match destination-address` (NOT the pool / translated-to address). Only a
+	// rule that actually translates (has a pool, is not a `destination-nat off`
+	// exemption) is inert on the first packet, so gate on that.
+	if dst := cfg.Security.NAT.Destination; dst != nil {
+		for _, rs := range dst.RuleSets {
+			if rs == nil {
+				continue
+			}
+			for _, rule := range rs.Rules {
+				if rule == nil {
+					continue
+				}
+				if rule.Then.Off || rule.Then.PoolName == "" {
+					continue // no translation → nothing to be inert
+				}
+				for _, addr := range natMatchValues(rule.Match.DestinationAddresses, rule.Match.DestinationAddress) {
+					host, _ := hostLocalAddrFamily(addr)
+					if host == "" {
+						continue
+					}
+					if iface, ok := ifAddrs[host]; ok {
+						warnings = append(warnings, fmt.Sprintf(
+							"security nat destination rule-set %q rule %q matches "+
+								"destination-address %s, which is a configured interface "+
+								"address (%s): the userspace AF_XDP shim classifies the first "+
+								"packet to a firewall-local address as kernel-local BEFORE "+
+								"consulting destination-NAT, so this translation is INERT on "+
+								"the first packet of a new flow (the packet is delivered to the "+
+								"host instead of translated + zone-policed). Reply / "+
+								"established-session traffic is unaffected. Known first-packet "+
+								"interface-address DNAT limitation (#5837); the dataplane fix is "+
+								"deferred (Track-2). Use a non-interface public address, or "+
+								"expect first-packet local delivery.",
+							rs.Name, rule.Name, host, iface))
+					}
+				}
+			}
+		}
+	}
+
+	// Static NAT: the public address is the rule `match destination-address`
+	// (StaticNATRule.Match, the external / public IP). Only a rule with a
+	// translation target is meaningful.
+	for _, rs := range cfg.Security.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			if rule.Then == "" && rule.ThenPrefixName == "" {
+				continue // no translation target → not a first-packet-inert rule
+			}
+			host, _ := hostLocalAddrFamily(rule.Match)
+			if host == "" {
+				continue
+			}
+			if iface, ok := ifAddrs[host]; ok {
+				warnings = append(warnings, fmt.Sprintf(
+					"security nat static rule-set %q rule %q matches destination-address "+
+						"%s, which is a configured interface address (%s): the userspace "+
+						"AF_XDP shim classifies the first packet to a firewall-local address "+
+						"as kernel-local BEFORE consulting static-NAT, so this 1:1 "+
+						"translation is INERT on the first packet of a new flow (the packet "+
+						"is delivered to the host instead of translated + zone-policed). "+
+						"Reply / established-session traffic is unaffected. Known first-packet "+
+						"interface-address static-NAT limitation (#5837); the dataplane fix is "+
+						"deferred (Track-2). Use a non-interface external address, or expect "+
+						"first-packet local delivery.",
+					rs.Name, rule.Name, host, iface))
+			}
+		}
+	}
+
+	return warnings
+}

--- a/pkg/config/compiler_validate_warn_nat_iface_addr.go
+++ b/pkg/config/compiler_validate_warn_nat_iface_addr.go
@@ -116,10 +116,119 @@ func interfaceLocalAddressIndex(cfg *Config) map[string]string {
 	return out
 }
 
+// interfaceModeSNATExcludedAddresses mirrors the userspace-dp dataplane's
+// nat_translated_local_exclusions (userspace-dp/src/afxdp/rst.rs:15-40): it
+// returns the set of normalized host IPs the dataplane moves OUT of the
+// kernel-local set and INTO interface_nat_v4/v6. Those addresses are therefore
+// NOT classified kernel-local by is_local_destination (which short-circuits to
+// FALSE for a USERSPACE_INTERFACE_NAT member BEFORE the local_v4/v6 check), so a
+// DNAT / static-NAT rule matching one of them is NOT inert on the first packet —
+// the SYN reaches the helper and inbound DNAT applies (static_nat.rs inbound DNAT
+// is not gated on local membership). Warning on such a rule is a false-warn; the
+// #5837 rev6052 fold excludes these addresses.
+//
+// Predicate mirror (rst.rs): collect the to-zone of every source-NAT rule that is
+// interface-mode, not `off`, and has a non-empty to-zone
+// (rule.interface_mode && !rule.off && !rule.to_zone.is_empty()); then, for every
+// interface whose security zone is in that to-zone set, the dataplane excludes
+// that interface's picked v4/v6 address (pick_interface_v4/v6). The Go predicate
+// mirrors the snapshot mapping exactly: SourceNATRuleSnapshot.InterfaceMode is
+// rule.Then.Interface, .Off is rule.Then.Off, and .ToZone is the rule-set ToZone
+// (pkg/dataplane/userspace/nat_source.go:185-194).
+//
+// This mirror uses the SAFE SUPERSET: it excludes EVERY configured address of
+// such an interface unit, not just the single pick_interface_v4/v6 result. The
+// superset can never false-warn (the whole point of this fold — the canonical
+// masquerade + WAN-port-forward config no longer trips the advisory); it can only
+// slightly UNDER-warn on a genuinely-inert SECONDARY (non-picked) address of a
+// multi-address interface, an accepted trade vs a false-warn on the canonical
+// config, and one that also insulates the commit-time check from the kernel /
+// config address-ordering divergence a runtime pick_interface would see. VRRP
+// VIPs are deliberately NOT excluded: pick_interface_v4/v6 iterates
+// iface.addresses (configured unit addresses), never VIPs, so the dataplane keeps
+// a VIP kernel-local and a DNAT/static match on a VIP stays genuinely inert (it
+// must still warn).
+func interfaceModeSNATExcludedAddresses(cfg *Config) map[string]bool {
+	if cfg == nil {
+		return nil
+	}
+	// Step 1: the interface-mode SNAT to-zone set (rst.rs predicate).
+	toZones := make(map[string]bool)
+	for _, rs := range cfg.Security.NAT.Source {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			if rule.Then.Interface && !rule.Then.Off && rs.ToZone != "" {
+				toZones[rs.ToZone] = true
+			}
+		}
+	}
+	if len(toZones) == 0 {
+		return nil
+	}
+	// Step 2: every interface unit whose security zone is in that to-zone set;
+	// exclude all of its configured addresses (safe superset of the dataplane's
+	// pick_interface_v4/v6). zoneByIface keys both `name.unit` and (when a bare
+	// interface is zone-listed) the physical `name`, so try the unit key first.
+	zoneByIface := buildZoneInterfaceMapLocal(cfg)
+	if len(zoneByIface) == 0 {
+		return nil
+	}
+	excluded := make(map[string]bool)
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, name)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil {
+			continue
+		}
+		unitNums := make([]int, 0, len(ifc.Units))
+		for un := range ifc.Units {
+			unitNums = append(unitNums, un)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := ifc.Units[un]
+			if unit == nil {
+				continue
+			}
+			unitName := fmt.Sprintf("%s.%d", ifName, un)
+			zone := zoneByIface[unitName]
+			if zone == "" {
+				zone = zoneByIface[ifName]
+			}
+			if zone == "" || !toZones[zone] {
+				continue
+			}
+			for _, a := range unit.Addresses {
+				if host, _ := hostLocalAddrFamily(a); host != "" {
+					excluded[host] = true
+				}
+			}
+		}
+	}
+	if len(excluded) == 0 {
+		return nil
+	}
+	return excluded
+}
+
 // validateNATInterfaceAddressCollisionWarnings emits the Track-1 (#5837)
 // commit-time advisory for each destination-NAT / static-NAT rule whose public
 // (matched / external) destination address equals a configured interface address.
 // See the file header for the mechanism. WARN-only, both compile paths.
+//
+// An address that interface-mode source-NAT routes into interface_nat (the
+// dataplane's nat_translated_local_exclusions) is EXCLUDED: it is not
+// kernel-local, so a DNAT/static match on it is not inert — warning there is the
+// #5837 rev6052 false-warn on the canonical masquerade + WAN-port-forward config.
 func validateNATInterfaceAddressCollisionWarnings(cfg *Config) []string {
 	if cfg == nil {
 		return nil
@@ -128,6 +237,7 @@ func validateNATInterfaceAddressCollisionWarnings(cfg *Config) []string {
 	if len(ifAddrs) == 0 {
 		return nil
 	}
+	excluded := interfaceModeSNATExcludedAddresses(cfg)
 	var warnings []string
 
 	// Destination NAT: the address the outside world targets is the rule's
@@ -150,6 +260,11 @@ func validateNATInterfaceAddressCollisionWarnings(cfg *Config) []string {
 					host, _ := hostLocalAddrFamily(addr)
 					if host == "" {
 						continue
+					}
+					if excluded[host] {
+						continue // interface-mode SNAT routes this addr into
+						// interface_nat (rst.rs) — NOT kernel-local, so the DNAT
+						// translation is not inert (#5837 rev6052).
 					}
 					if iface, ok := ifAddrs[host]; ok {
 						warnings = append(warnings, fmt.Sprintf(
@@ -188,6 +303,11 @@ func validateNATInterfaceAddressCollisionWarnings(cfg *Config) []string {
 			host, _ := hostLocalAddrFamily(rule.Match)
 			if host == "" {
 				continue
+			}
+			if excluded[host] {
+				continue // interface-mode SNAT routes this addr into interface_nat
+				// (rst.rs) — NOT kernel-local, so the static translation is not
+				// inert (#5837 rev6052).
 			}
 			if iface, ok := ifAddrs[host]; ok {
 				warnings = append(warnings, fmt.Sprintf(


### PR DESCRIPTION
## Track-1 mitigation of #5837 (make the silent bypass LOUD)

**The bug (#5837).** On a non-GRE session miss the userspace AF_XDP shim
(`userspace-xdp/src/lib.rs` `try_xdp_userspace` / `is_local_destination`)
classifies a packet destined to a firewall-local interface address as
kernel-local and shunts it to the host stack **BEFORE** consulting
destination-NAT / static-NAT (`pre_routing_dnat`). So a legitimate Junos
port-forward / static 1:1 mapping onto the firewall's own interface address
(a WAN-IP port forward) is **INERT on the first packet** of a new flow — the
client's SYN is delivered to a local service instead of being translated and
zone-policed. Reply packets and packets on an already-established session are
unaffected. **Today this is silent.**

**This change makes it loud.** A WARN-only commit-time advisory
(`validateNATInterfaceAddressCollisionWarnings`, new
`pkg/config/compiler_validate_warn_nat_iface_addr.go`, wired into
`ValidateConfig`) fires for each DNAT / static-NAT rule whose **public /
matched destination address** equals a configured interface address, naming
the rule-set/rule and the colliding interface. It fires on **both** the strict
commit path and the tolerant load / peer-sync path (the config is legal Junos
and works for reply / established traffic, so it never rejects or changes
forwarding — a hard reject would also brick a boot on a previously-committed
config, #1960 no-brick).

### What is checked
- **DNAT**: the rule's `match destination-address` (the public IP the outside
  targets) — **not** the `then destination-nat pool` address (the internal
  translation TARGET, which `is_local_destination` never inspects).
- **static NAT**: the rule's `match` external / public address.
- **Interface-address set**: every unit's static addresses **and** VRRP virtual
  addresses (VIPs), both families, normalized via the existing
  `hostLocalAddrFamily` helper (prefix stripped, host canonicalized), so
  `10.0.61.1/32` on the rule matches `10.0.61.1/24` on the interface.
- Literal match values only; address-book-NAME matches are out of scope (the
  overwhelmingly common #5837 case uses a literal address).

### Reviewer note — deviation from §0a's literal wording
Plan §0a's parenthetical says "DNAT **pool** address", but the #5837 bypass is
triggered by the **matched/ingress public address** (what `is_local_destination`
inspects) — which also matches the plan **BACKGROUND** ("the address the outside
world targets") and §5d's intent-map keying (keyed on `parsed.dst_addr`, the
ingress dst). Keying on the pool address would both **miss** the real #5837 case
and **false-positive** on a legal DNAT-to-self. The implementation therefore
keys on the match address; a dedicated control test
(`TestDNATPoolAddressIsInterfaceNoWarn`) proves `pool == iface` does **not**
warn. Flagging for your call.

### Track-2 (deferred)
The full dataplane fix (a dedicated intent map probed before local
classification, Option B) is a large, verifier-gated, HA-aware project deferred
per the converged research plan
(`docs/research/5837-xdp-dnat-before-local/plan.md` §0/§0a/§0b).

### Validation
- `go build ./...` clean; `go vet ./pkg/config` clean; `go test ./pkg/config` green.
- **Fail-on-revert proven firsthand**: neutralizing the emit turns the positive
  tests RED (`expected exactly one #5837 DNAT advisory, got 0`) while the
  no-false-warn controls stay green.
- New tests: DNAT collision (strict + lenient), static-NAT collision, VRRP-VIP
  collision, non-interface-address no-warn, pool==iface no-warn.

Docs: `docs/userspace-dnat-plan.md` gains a "Known limitation" section; dated
`_Log.md` entry added.

Mitigates #5837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6zvrThAF9MY4aBnZJxCEP