### PR TITLE
filter: compare flex-match fields in rotation change detector

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-16 — #5293: filter change-detector omits six flex-match fields
+
+- **Timestamp**: 2026-07-16 (fix/5293-filter-flex-semantics-match)
+- **Action**: `filter_term_semantics_match` (`engine/cache_sensitive.rs`) is the
+  per-term change detector behind the forwarding-rotation session purge. It
+  compared every neighboring discriminator (addresses, ports, protocol, ICMP
+  type/code, tcp-flags, dscp, action, modifiers) but went DIRECTLY from the ICMP
+  fields to the action, OMITTING all six flexible-match-range fields
+  (`flex_enabled`, `flex_offset`, `flex_length`, `flex_value`, `flex_mask`,
+  `flex_match_start`; #3077/#3232). A filter/PBR rotation that changed ONLY a
+  flex field therefore compared EQUAL, the worker skipped its per-packet-L4
+  session purge, and an established session kept its stale (pre-rotation)
+  routing-instance / forwarding decision until timeout — a cross-VRF
+  policy-coherency failure (stranded reachability / egress / zone-path / NAT),
+  not merely stale telemetry.
+  Fix: rebuilt the comparator on an EXHAUSTIVE `let FilterTerm { .. } = new;`
+  destructure with NO `..` rest pattern. Every field is bound to a name (and
+  compared) or explicitly to `_` (`id`/`counter`, deliberately not match
+  semantics). A newly-added FilterTerm field now FAILS TO COMPILE here until it
+  is classified — so a 7th match field can never silently regress the change
+  detector the way the flex fields did. The six flex fields are now compared.
+  Validation: added `flex_field_change_is_not_cache_equal` (clones one compiled
+  base term, mutates exactly one of the six flex fields per case, asserts NOT
+  cache-equal; control: identical term → equal). RED-on-revert proven firsthand
+  — dropping the six flex comparisons makes the test panic
+  (`a change to \`flex_enabled\` must NOT be cache-equal`). `cargo test --release
+  filter` all green (265 + 5 in the touched suites); full `cargo test --release`
+  clean. Cluster smoke DEFERRED — shim-wall blocked this window; pure
+  comparator-logic fix gated on the cargo RED-on-revert unit test.
+- **File(s)**: userspace-dp/src/filter/engine/cache_sensitive.rs,
+  userspace-dp/src/filter/README.md, _Log.md
+
 ## 2026-07-16 — #5805: per-destination ICMP/UDP flood sketches → token bucket
 
 - **Timestamp**: 2026-07-16 (fix/5805-per-dest-flood-tokenbucket)

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -450,7 +450,7 @@ exactly one of these two classes:
 | `is_fragment` (#2362) | NO — cache-sensitive | Junos `is-fragment`: matches ANY fragment (IPv4 MF set OR offset != 0; IPv6 fragment header present). Computed by `is_any_fragment` |
 | (future) `ihl_match` / IP options | NO — cache-sensitive | IHL varies per packet |
 | `icmp_type` / `icmp_code` (#2362) | NO — cache-sensitive | exact match on the ICMP/ICMPv6 type/code byte; non-ICMP packets never match. Could later be promoted to cache-key by adding (type, code) to `SessionKey` |
-| `flex_match` (#3077, #3232) | NO — cache-sensitive | Junos `from flexible-match-range`: reads `length` bytes (1..4) at `offset` from the START of the base header selected by `flex_match_start` (#3232) — `Layer3` (match-start layer-3, the default) reads from `TermMatchExtra::flex_l3` (the L3/IP header); `Layer4` (match-start layer-4) reads from `TermMatchExtra::flex_l4` (the transport header at `meta.l4_offset`); `Unsupported` (any other match-start, e.g. `payload`, that the Go commit gate rejects but the tolerant peer-sync path could still deliver) always FAILS CLOSED. The chosen bytes are ANDed with `mask` and required to `== value`. Byte-offset read, fully per-packet. The base slice being `None` (no frame / deferred CoS path; or, for layer-4, a non-first fragment whose post-IP bytes are payload) or a packet too short for the window FAILS CLOSED (no match, no OOB). **#5150: both base slices end at the IP-DECLARED datagram end (`l3_offset + IPv4 total-length`, or `l3_offset + 40 + IPv6 payload-length`), CLAMPED to `frame.len()` — NOT the physical frame end.** So attacker-controlled bytes in Ethernet slack (padding beyond the declared IP length) are excluded (a byte-match can only see the logical IP datagram), and a lying oversized IP length can never over-read past the frame. Before #5150 the slices extended to `frame.len()`, letting a flex term match padding bytes (match-on-padding / filter-evasion). Compiled from `FlexMatchSnapshot`; before #3077 the constraint was parsed but dropped on the wire (matched too broadly, fail-open); before #3232 a layer-4/payload match-start was silently evaluated at the L3 base (wrong-offset match — security evasion) |
+| `flex_match` (#3077, #3232) | NO — cache-sensitive | Junos `from flexible-match-range`: reads `length` bytes (1..4) at `offset` from the START of the base header selected by `flex_match_start` (#3232) — `Layer3` (match-start layer-3, the default) reads from `TermMatchExtra::flex_l3` (the L3/IP header); `Layer4` (match-start layer-4) reads from `TermMatchExtra::flex_l4` (the transport header at `meta.l4_offset`); `Unsupported` (any other match-start, e.g. `payload`, that the Go commit gate rejects but the tolerant peer-sync path could still deliver) always FAILS CLOSED. The chosen bytes are ANDed with `mask` and required to `== value`. Byte-offset read, fully per-packet. The base slice being `None` (no frame / deferred CoS path; or, for layer-4, a non-first fragment whose post-IP bytes are payload) or a packet too short for the window FAILS CLOSED (no match, no OOB). **#5150: both base slices end at the IP-DECLARED datagram end (`l3_offset + IPv4 total-length`, or `l3_offset + 40 + IPv6 payload-length`), CLAMPED to `frame.len()` — NOT the physical frame end.** So attacker-controlled bytes in Ethernet slack (padding beyond the declared IP length) are excluded (a byte-match can only see the logical IP datagram), and a lying oversized IP length can never over-read past the frame. Before #5150 the slices extended to `frame.len()`, letting a flex term match padding bytes (match-on-padding / filter-evasion). Compiled from `FlexMatchSnapshot`; before #3077 the constraint was parsed but dropped on the wire (matched too broadly, fail-open); before #3232 a layer-4/payload match-start was silently evaluated at the L3 base (wrong-offset match — security evasion). **#5293: all six `flex_*` fields (`flex_enabled`, `flex_offset`, `flex_length`, `flex_value`, `flex_mask`, `flex_match_start`) are now compared in `filter_term_semantics_match` (`engine/cache_sensitive.rs`) — before #5293 they were omitted from the forwarding-rotation change detector, so a rotation touching only a flex field skipped the session purge and stranded established sessions on their stale routing-instance / forwarding decision (cross-VRF policy-coherency failure)** |
 
 The `tcp_flags_mask` / `tcp_flags_forbidden` / `is_fragment` / `icmp_type` /
 `icmp_code` inputs (and the #3077 `flex_match` L3 slice, `flex_l3`) are
@@ -793,11 +793,27 @@ implementation (#1430); use it as the template:
    `userspace-dp/src/afxdp/worker/loop_body/mod.rs:295-330`
    uses `input_dscp_filter_families_changed` to decide whether
    to purge sessions. Extend the semantics-match comparison in
-   `userspace-dp/src/filter/engine/cache_sensitive.rs:104-143`
-   to cover the new match field's aggregate flag and per-term
-   content. **Compare by content, never by compiler-positional
-   filter/term IDs** — `Filter.id` and `FilterTerm.id` are
-   stable only within a snapshot.
+   `userspace-dp/src/filter/engine/cache_sensitive.rs`
+   (`filter_term_semantics_match`) to cover the new match
+   field's aggregate flag and per-term content. **Compare by
+   content, never by compiler-positional filter/term IDs** —
+   `Filter.id` and `FilterTerm.id` are stable only within a
+   snapshot. **#5293: `filter_term_semantics_match` now derives
+   its equality from an EXHAUSTIVE `let FilterTerm { .. } = new;`
+   destructure with NO `..` rest pattern** — a newly-added
+   FilterTerm field fails to compile there until it is classified
+   as compared (bound to a name and checked) or intentionally
+   ignored (bound to `_`, e.g. `id`/`counter`). This closes the
+   class of bug where a match field is silently omitted from the
+   change detector: before #5293 the six `flex_*`
+   flexible-match-range fields (#3077/#3232) were absent, so a
+   PBR/filter rotation touching ONLY a flex value/mask/offset/
+   length/enable/match-start compared equal, the worker skipped
+   its per-packet-L4 session purge, and an established session
+   stranded on its stale (pre-rotation) routing-instance /
+   forwarding decision until timeout. Regression test:
+   `filter/engine/cache_sensitive.rs`
+   ::`flex_field_change_is_not_cache_equal`.
 7. **Tests** in `userspace-dp/src/afxdp/flow_cache_tests.rs`
    following the DSCP runbook pattern in
    `from_forward_decision_skips_cache_for_dscp_matched_input_filter`

--- a/userspace-dp/src/filter/engine/cache_sensitive.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive.rs
@@ -285,58 +285,136 @@ fn three_color_policer_semantics_match(
 }
 
 fn filter_term_semantics_match(old: &FilterTerm, new: &FilterTerm) -> bool {
-    old.name == new.name
-        && old.source_v4 == new.source_v4
-        && old.source_v6 == new.source_v6
-        && old.dest_v4 == new.dest_v4
-        && old.dest_v6 == new.dest_v6
+    // #5293: derive this change-detector from an EXHAUSTIVE destructure of the
+    // FilterTerm with NO `..` rest pattern. Every field is bound either to a
+    // name (and compared against `old` below) or explicitly to `_` (a field
+    // that is deliberately NOT part of match semantics). Adding a new field to
+    // FilterTerm therefore FAILS TO COMPILE here until the author classifies it
+    // — making it impossible to silently omit a match-relevant field from the
+    // per-worker session-purge change detector, the way the six `flex_*` fields
+    // were omitted originally.
+    //
+    // The bug this closes: the flexible-match-range fields (#3077, #3232) were
+    // absent from the comparison, so a filter/PBR rotation that changed ONLY a
+    // flex value/mask/offset/length/enable/match-start compared EQUAL here. The
+    // worker then skipped its per-packet-L4 session purge, and an established
+    // session kept its stale (pre-rotation) routing-instance / forwarding
+    // decision until timeout — a cross-VRF policy-coherency failure (stranded
+    // reachability / egress / zone-path / NAT), not merely stale telemetry.
+    //
+    // Fields intentionally EXCLUDED from match semantics (bound to `_`):
+    //   id      — synthetic per-term identity, never a match/action criterion.
+    //   counter — runtime hit-counter Arc (shared handle), not config state.
+    let FilterTerm {
+        id: _,
+        name,
+        source_v4,
+        source_v6,
+        dest_v4,
+        dest_v6,
         // #2400: the *_constrained flags change match semantics (fail-closed vs
         // match-any) WITHOUT changing the parsed vecs/matcher in the
         // unscoped<->all-malformed transition (both leave empty vecs /
-        // PortMatcher::Any), so they MUST be compared here or a flow-cache
-        // rebuild would keep stale match-any decisions.
-        && old.source_addr_constrained == new.source_addr_constrained
-        && old.dest_addr_constrained == new.dest_addr_constrained
+        // PortMatcher::Any), so they MUST be compared or a flow-cache rebuild
+        // would keep stale match-any decisions.
+        source_addr_constrained,
+        dest_addr_constrained,
         // #2506: the except inversion flips the address decision without
-        // changing the parsed prefix vecs, so it must be compared here too — a
+        // changing the parsed prefix vecs, so it must be compared too — a
         // snapshot toggling `except` on/off otherwise keeps stale decisions.
-        && old.source_except == new.source_except
-        && old.dest_except == new.dest_except
-        && old.protocol_bitmap == new.protocol_bitmap
-        && old.protocol_match_enabled == new.protocol_match_enabled
-        && old.source_ports == new.source_ports
-        && old.dest_ports == new.dest_ports
-        && old.source_port_constrained == new.source_port_constrained
-        && old.dest_port_constrained == new.dest_port_constrained
+        source_except,
+        dest_except,
+        protocol_bitmap,
+        protocol_match_enabled,
+        source_ports,
+        dest_ports,
+        source_port_constrained,
+        dest_port_constrained,
         // #2622: the port-except inversion flips the port decision without
-        // changing the parsed port matcher, so it must be compared here too —
-        // a snapshot toggling `*-port-except` on/off otherwise keeps stale
+        // changing the parsed port matcher, so it must be compared too — a
+        // snapshot toggling `*-port-except` on/off otherwise keeps stale
         // flow-cache decisions (sibling of source_except/dest_except above).
-        && old.source_port_except == new.source_port_except
-        && old.dest_port_except == new.dest_port_except
-        && old.dscp_bitmap == new.dscp_bitmap
-        && old.dscp_match_enabled == new.dscp_match_enabled
-        && old.tcp_flags_mask == new.tcp_flags_mask
-        && old.tcp_flags_forbidden == new.tcp_flags_forbidden
-        && old.is_fragment == new.is_fragment
-        && old.icmp_type_bitmap == new.icmp_type_bitmap
-        && old.icmp_type_match_enabled == new.icmp_type_match_enabled
-        && old.icmp_code_bitmap == new.icmp_code_bitmap
-        && old.icmp_code_match_enabled == new.icmp_code_match_enabled
-        && old.action == new.action
+        source_port_except,
+        dest_port_except,
+        dscp_bitmap,
+        dscp_match_enabled,
+        tcp_flags_mask,
+        tcp_flags_forbidden,
+        is_fragment,
+        icmp_type_bitmap,
+        icmp_type_match_enabled,
+        icmp_code_bitmap,
+        icmp_code_match_enabled,
+        // #5293: flexible-match-range (#3077, #3232). All six fields change
+        // WHICH packets the term matches (byte-offset window, value/mask,
+        // enable, and the L3/L4 base), yet none are part of the 5-tuple
+        // SessionKey — so a rotation touching any of them must invalidate
+        // cached per-session decisions here.
+        flex_enabled,
+        flex_offset,
+        flex_length,
+        flex_value,
+        flex_mask,
+        flex_match_start,
+        action,
         // #2544: continue_term flips a matched term between terminate-here and
         // apply-modifiers-and-fall-through WITHOUT changing the parsed match
         // vecs, so toggling `then next term` on/off must rebuild flow-cache
         // decisions — compare it here.
-        && old.continue_term == new.continue_term
-        && old.count == new.count
-        && old.has_count == new.has_count
-        && old.log == new.log
-        && old.policer_name == new.policer_name
-        && three_color_policer_semantics_match(&old.three_color_policer, &new.three_color_policer)
-        && old.routing_instance == new.routing_instance
-        && old.forwarding_class == new.forwarding_class
-        && old.dscp_rewrite == new.dscp_rewrite
+        continue_term,
+        count,
+        has_count,
+        log,
+        policer_name,
+        three_color_policer,
+        routing_instance,
+        forwarding_class,
+        dscp_rewrite,
+        counter: _,
+    } = new;
+
+    old.name == *name
+        && old.source_v4 == *source_v4
+        && old.source_v6 == *source_v6
+        && old.dest_v4 == *dest_v4
+        && old.dest_v6 == *dest_v6
+        && old.source_addr_constrained == *source_addr_constrained
+        && old.dest_addr_constrained == *dest_addr_constrained
+        && old.source_except == *source_except
+        && old.dest_except == *dest_except
+        && old.protocol_bitmap == *protocol_bitmap
+        && old.protocol_match_enabled == *protocol_match_enabled
+        && old.source_ports == *source_ports
+        && old.dest_ports == *dest_ports
+        && old.source_port_constrained == *source_port_constrained
+        && old.dest_port_constrained == *dest_port_constrained
+        && old.source_port_except == *source_port_except
+        && old.dest_port_except == *dest_port_except
+        && old.dscp_bitmap == *dscp_bitmap
+        && old.dscp_match_enabled == *dscp_match_enabled
+        && old.tcp_flags_mask == *tcp_flags_mask
+        && old.tcp_flags_forbidden == *tcp_flags_forbidden
+        && old.is_fragment == *is_fragment
+        && old.icmp_type_bitmap == *icmp_type_bitmap
+        && old.icmp_type_match_enabled == *icmp_type_match_enabled
+        && old.icmp_code_bitmap == *icmp_code_bitmap
+        && old.icmp_code_match_enabled == *icmp_code_match_enabled
+        && old.flex_enabled == *flex_enabled
+        && old.flex_offset == *flex_offset
+        && old.flex_length == *flex_length
+        && old.flex_value == *flex_value
+        && old.flex_mask == *flex_mask
+        && old.flex_match_start == *flex_match_start
+        && old.action == *action
+        && old.continue_term == *continue_term
+        && old.count == *count
+        && old.has_count == *has_count
+        && old.log == *log
+        && old.policer_name == *policer_name
+        && three_color_policer_semantics_match(&old.three_color_policer, three_color_policer)
+        && old.routing_instance == *routing_instance
+        && old.forwarding_class == *forwarding_class
+        && old.dscp_rewrite == *dscp_rewrite
 }
 
 fn dscp_sensitive_filter_semantics_match(old: &Filter, new: &Filter) -> bool {
@@ -582,5 +660,73 @@ mod cache_sensitive_2400_tests {
             !super::filter_term_semantics_match(&unscoped, &all_malformed),
             "unscoped vs all-malformed port must NOT be cache-equal"
         );
+    }
+
+    /// #5293: the six flexible-match-range fields (`flex_enabled`,
+    /// `flex_offset`, `flex_length`, `flex_value`, `flex_mask`,
+    /// `flex_match_start`) change WHICH packets a term matches but are NOT part
+    /// of the 5-tuple SessionKey. A filter/PBR rotation that touches ONLY a flex
+    /// field must be reported as NOT cache-equal so the per-worker session purge
+    /// runs — otherwise an established session strands on its stale (pre-
+    /// rotation) routing-instance / forwarding decision until timeout.
+    ///
+    /// Each case clones one compiled base term and mutates exactly ONE flex
+    /// field, so the ONLY distinguishing bit is that field. REVERT (dropping the
+    /// `flex_*` comparisons from `filter_term_semantics_match`) makes every
+    /// "changed flex field" assertion FAIL — the comparator would wrongly return
+    /// `true` (equal) and skip the purge.
+    #[test]
+    fn flex_field_change_is_not_cache_equal() {
+        let base = term_from(FirewallTermSnapshot {
+            name: "t".into(),
+            action: "discard".into(),
+            ..Default::default()
+        });
+
+        // Control: a term compared with an untouched clone stays cache-equal
+        // (no spurious invalidation for a no-op rotation).
+        let identical = base.clone();
+        assert!(
+            super::filter_term_semantics_match(&base, &identical),
+            "an identical term must be cache-equal (no spurious purge)"
+        );
+
+        // Each mutated clone differs from `base` in EXACTLY one flex field.
+        let mut flex_enabled = base.clone();
+        flex_enabled.flex_enabled = !base.flex_enabled;
+
+        let mut flex_offset = base.clone();
+        flex_offset.flex_offset = base.flex_offset.wrapping_add(1);
+
+        let mut flex_length = base.clone();
+        flex_length.flex_length = base.flex_length.wrapping_add(1);
+
+        let mut flex_value = base.clone();
+        flex_value.flex_value = base.flex_value ^ 0xA5A5_A5A5;
+
+        let mut flex_mask = base.clone();
+        flex_mask.flex_mask = base.flex_mask ^ 0xA5A5_A5A5;
+
+        let mut flex_match_start = base.clone();
+        // Pick a variant strictly different from the base's (default Layer3).
+        flex_match_start.flex_match_start = match base.flex_match_start {
+            FlexMatchStart::Layer3 => FlexMatchStart::Layer4,
+            _ => FlexMatchStart::Layer3,
+        };
+
+        for (label, mutated) in [
+            ("flex_enabled", &flex_enabled),
+            ("flex_offset", &flex_offset),
+            ("flex_length", &flex_length),
+            ("flex_value", &flex_value),
+            ("flex_mask", &flex_mask),
+            ("flex_match_start", &flex_match_start),
+        ] {
+            assert!(
+                !super::filter_term_semantics_match(&base, mutated),
+                "a change to `{label}` must NOT be cache-equal (the rotation \
+                 purge must run so sessions do not strand on stale decisions)"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`filter_term_semantics_match` (`userspace-dp/src/filter/engine/cache_sensitive.rs`) is the per-term change detector behind the forwarding/PBR **rotation session purge**. It compared every neighboring discriminator (addresses, ports, protocol, tcp-flags, dscp, ICMP type/code bitmaps + enables) but went **directly from the ICMP fields to the action, omitting all six flexible-match-range fields**: `flex_enabled`, `flex_offset`, `flex_length`, `flex_value`, `flex_mask`, `flex_match_start` (#3077, #3232).

### Defect

Because the comparator returned `true` (equal) when only a flex value/mask/offset/length/enable/match-start changed, the worker **skipped its per-packet-L4-family session purge** on a flex-only rotation. An established session then kept its stored **pre-rotation routing-instance / forwarding decision** until timeout even though the new config selects a different VRF/base — a **cross-VRF policy-coherency failure** (stranded reachability / egress / zone-path / NAT), not merely stale telemetry.

### Fix — completeness-forcing construction

Rebuilt the comparator on an **exhaustive `let FilterTerm { .. } = new;` destructure with NO `..` rest pattern**. Every field is bound either to a name (and compared against `old`) or explicitly to `_` (`id` and `counter`, deliberately not match semantics). **A newly-added `FilterTerm` field now fails to compile here until the author classifies it** — so a future 7th match field can never silently regress this change detector the way the flex fields did. The six flex fields are now compared.

### Validation

- Added `flex_field_change_is_not_cache_equal`: clones one compiled base term, mutates **exactly one** of the six flex fields per case, asserts the pair is **NOT** cache-equal (control: an identical clone stays equal).
- **RED-on-revert proven firsthand** — dropping the six flex comparison lines makes the test panic:
  ```
  thread '...flex_field_change_is_not_cache_equal' panicked at src/filter/engine/cache_sensitive.rs:719:13:
  a change to `flex_enabled` must NOT be cache-equal (the rotation purge must run so sessions do not strand on stale decisions)
  test result: FAILED. 0 passed; 1 failed; ...
  ```
- `cargo test --release filter` green; full `cargo test --release` suite passes (**3972 tests, 0 failures**).

### Docs

`filter/README.md` path-(b) runbook step 6 and the `flex_match` capability row now record that the flex fields are part of the equality and that the exhaustive destructure enforces completeness. `_Log.md` entry added.

### Smoke

Loss-cluster smoke **deferred (shim-wall blocked this window)**. This is a pure comparator-logic fix gated on the cargo RED-on-revert unit test.

Closes #5293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaMgcVFSnFWZBRe9jYLHw6