### PR TITLE
tx: enforce output filter on flowless egress packets

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -35,6 +35,51 @@
   exclusion is to-zone scoped (SNAT to a different zone still warns); existing 6
   tests stay green.
 
+## 2026-07-16 — #5467: flowless packets skip the egress output filter (fail-open)
+
+- **Timestamp**: 2026-07-16 (fix/5467-flowless-output-filter)
+- **Action**: `resolve_cos_tx_selection_internal`
+  (`afxdp/tx/cos_classify.rs`) resolves the CoS TX queue AND evaluates the
+  interface `filter output` on the egress path. Its flowless early-return
+  (`let Some(flow_key) = flow_key else { ... }`) resolved the BA/DSCP queue but
+  returned `drop:false, reject:false, filter_log:None` WITHOUT ever evaluating
+  the output filter. So a flowless packet — a non-first IP fragment or a
+  non-query ICMP error/control packet, both with no usable L4 ports (#2344 /
+  #3290) — egressed even when the interface output filter had a matching
+  `then discard`/`reject`/`log` term: egress deny/reject/log was silently
+  bypassed (fail-OPEN). The flow-keyed path below the early-return DID evaluate
+  the output filter; only the flowless arm skipped it.
+  Fix: the flowless arm now reconstructs the packet's own L3 tuple from the
+  shim-stamped meta (new `ForwardPacketMeta::l3_addrs`, mirroring
+  `frame::l3_session_flow_from_meta`; L4 ports forced to 0 since the header is
+  absent) and evaluates the output filter through the SAME entry point the
+  flow-keyed path uses (`interface_output_filter_needs_tx_eval` +
+  `evaluate_filter_ref_tx_selection_{,runtime_}counted`), collapsing
+  `drop`/`reject`/`filter_log` identically. Ports are 0, so a port-BEARING
+  output term never matches a fragment (no spurious drop — the #2357/#3290
+  guarantee holds); only an L3-only term takes effect, and with no matching
+  term the packet still egresses. Queue / DSCP-rewrite selection is preserved —
+  the gate ADDS enforcement only. `ForwardPacketMeta` gained
+  `flow_src_addr`/`flow_dst_addr` (copied through from `UserspaceDpMeta` in the
+  `From` impls); all existing struct literals use `..default()` so the zeroed
+  addrs report as absent. `forward_request` drops the packet on `cos.drop`
+  (existing gate), keeps the reject reply gated on a real L4 flow (a flowless
+  deny stays SILENT, #3615), and now attributes a flowless `then log` event via
+  an L3-only flow (`frame::l3_session_flow_from_meta`).
+- **File(s)**: `userspace-dp/src/afxdp/types/mod.rs`,
+  `userspace-dp/src/afxdp/tx/cos_classify.rs`,
+  `userspace-dp/src/afxdp/tx/cos_classify_tests.rs`,
+  `userspace-dp/src/afxdp/forward_request.rs`,
+  `userspace-dp/src/afxdp/README.md`
+- **Validation**: `cargo build` clean; `cargo test --release` full suite
+  3976 passed / 0 failed. Four new cargo unit tests in `cos_classify_tests.rs`
+  (flowless `then discard` / `reject` / `log` enforcement + a port-term
+  no-spurious-drop control); RED-on-revert proven firsthand — restoring the
+  bare early-return fails the discard/reject/log assertions (drop:false /
+  filter_log:None, fail-open) while the port-term control stays green. Cluster
+  smoke DEFERRED (shim-wall this window); filter-eval logic fix gated on the
+  cargo RED-on-revert unit test.
+
 ## 2026-07-16 — #5293: filter change-detector omits six flex-match fields
 
 - **Timestamp**: 2026-07-16 (fix/5293-filter-flex-semantics-match)

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -389,6 +389,30 @@ sync.
     default policy (fail-closed drop) until the deferred
     fragment-association-cache stage of the #3291 plan carries the first
     fragment's verdict; tracked as the deferred fragment-association-cache stage of #3291.
+  - **#5467 — egress `filter output` on the flowless TX path:** the #3291 gate
+    above enforces the INGRESS input filter / PBR / zone policy on a flowless
+    packet, but the EGRESS interface `filter output` was evaluated only on the
+    flow-keyed TX-selection path (`resolve_cos_tx_selection_*`,
+    `afxdp/tx/cos_classify.rs`). A non-first fragment / non-query ICMP packet
+    reached that resolver with `flow_key = None` and hit an early return that
+    skipped output-filter evaluation entirely — so an egress
+    `then discard`/`reject`/`log` term matching such a packet was silently
+    bypassed (fail-OPEN). The flowless `None` arm now reconstructs the packet's
+    own L3 tuple from the shim-stamped meta (`ForwardPacketMeta::l3_addrs`,
+    ports forced to 0) and evaluates the output filter through the SAME entry
+    point the flow-keyed path uses (`interface_output_filter_needs_tx_eval` +
+    `evaluate_filter_ref_tx_selection_{,runtime_}counted`), collapsing
+    `drop`/`reject`/`filter_log` identically. Ports are 0, so a port-BEARING
+    output term never matches a fragment (no spurious drop — the #2357/#3290
+    guarantee is preserved); only an L3-only term
+    (`source-address`/`destination-address`/`protocol`/bare `then`) takes
+    effect, and with no matching term the packet still egresses (pass-through
+    unchanged). Queue / DSCP-rewrite selection is untouched — this gate ADDS
+    enforcement only. A flowless `then reject` is a SILENT drop (the fragment
+    has no L4 header to synthesize a reply from, #3615) — `forward_request`
+    keeps the reject reply gated on a real L4 flow — but the packet is still
+    dropped, and when a `then log` term matched, the filter-log event is
+    attributed via the L3-only flow (`frame::l3_session_flow_from_meta`).
   - **#5690 — generic embedded-ICMP NAT reversal on the flowless arm:** an
     inbound non-query ICMP error (Time-Exceeded, Dest-Unreachable, PTB,
     Parameter-Problem, Redirect) referencing a NAT'd flow is itself FLOWLESS

--- a/userspace-dp/src/afxdp/forward_request.rs
+++ b/userspace-dp/src/afxdp/forward_request.rs
@@ -248,7 +248,20 @@ pub(super) fn build_live_forward_request_from_frame(
     } else {
         false
     };
-    if let (Some(filter_log), Some(flow)) = (cos.filter_log, tx_selection_flow) {
+    // #5467: a flowless packet (non-first fragment / non-query ICMP) has NO
+    // `tx_selection_flow`, yet an interface output `then log` term may have
+    // matched its L3 tuple inside `resolve_cos_tx_selection_at` (the flowless
+    // enforcement gate). Rebuild the L3-only flow (ports 0) SOLELY to attribute
+    // that filter-log event so egress logging is not silently bypassed. The
+    // reject reply above stays gated on `tx_selection_flow`, so a flowless deny
+    // remains a silent drop (#3615 — no L4 header to synthesize a reply from).
+    let flowless_log_flow = if tx_selection_flow.is_none() && cos.filter_log.is_some() {
+        crate::afxdp::frame::l3_session_flow_from_meta(meta)
+    } else {
+        None
+    };
+    let log_flow = tx_selection_flow.or(flowless_log_flow.as_ref());
+    if let (Some(filter_log), Some(flow)) = (cos.filter_log, log_flow) {
         let ingress_zone_id = fabric_ingress_zone
             .filter(|id| forwarding.zone_id_to_name.contains_key(id))
             .or_else(|| {

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -459,12 +459,104 @@ fn resolve_cos_tx_selection_internal(
                 meta.ingress_vlan_present != 0,
             )
         });
+        // #5467: a flowless packet (a non-first IP fragment or a non-query
+        // ICMP error/control packet — both carry NO usable L4 ports, #2344 /
+        // #3290) still EGRESSES through the interface `filter output`. Before
+        // this gate the flowless arm returned `drop:false` WITHOUT ever
+        // evaluating the output filter, so an egress `then discard`/`reject`/
+        // `log` term that matched such a packet was silently bypassed —
+        // fail-OPEN. Evaluate the output filter against the packet's own L3
+        // tuple (src/dst/protocol from `meta`; L4 ports forced to 0 since the
+        // header is absent) and honor the verdict exactly as the flow-keyed
+        // path below does, so an L3-matching deny FAILS CLOSED.
+        //
+        // Ports are 0, so a port-BEARING output term never matches a fragment
+        // (preserving the #2357/#3290 guarantee that a port-matching terminal
+        // term does not spuriously drop / misclassify a flowless packet); only
+        // an L3-only (`from source-address`/`destination-address`/`protocol`/
+        // bare `then`) term takes effect. With no matching output term the
+        // result is `drop:false` — the pass-through case is unchanged. Queue
+        // and DSCP-rewrite selection stay exactly as computed above; this gate
+        // ADDS enforcement only, it does not re-classify the fragment's queue.
+        let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
+        let mut drop = false;
+        let mut reject = false;
+        let mut filter_log = None;
+        if crate::filter::interface_output_filter_needs_tx_eval(
+            &forwarding.filter_state,
+            egress_ifindex,
+            is_v6,
+        ) && let Some((src_ip, dst_ip)) = meta.l3_addrs()
+        {
+            let output_filter = if is_v6 {
+                forwarding
+                    .filter_state
+                    .iface_filter_out_v6_fast
+                    .get(&egress_ifindex)
+                    .map(Arc::as_ref)
+            } else {
+                forwarding
+                    .filter_state
+                    .iface_filter_out_v4_fast
+                    .get(&egress_ifindex)
+                    .map(Arc::as_ref)
+            };
+            if let Some(output_filter) = output_filter.filter(|filter| {
+                filter.affects_tx_selection
+                    || filter.has_counter_terms
+                    || filter.has_log_terms
+                    || filter.has_terminal_action_terms
+                    || filter.has_three_color_policer_terms
+            }) {
+                // Mirror the flow-keyed eval entry points below: ports are 0
+                // (L4 absent), `extra` carries the frame-derived is-fragment /
+                // l4-present=false predicates so port/flag/icmp-type terms fail
+                // closed. The counted variants record `then count` exactly once
+                // (this is the only output-filter walk on the flowless path).
+                let output_result = if let Some(now_ns) = now_ns {
+                    crate::filter::evaluate_filter_ref_tx_selection_runtime_counted(
+                        output_filter,
+                        src_ip,
+                        dst_ip,
+                        meta.protocol,
+                        0,
+                        0,
+                        meta.dscp,
+                        extra,
+                        meta.pkt_len as u64,
+                        now_ns,
+                    )
+                } else {
+                    crate::filter::evaluate_filter_ref_tx_selection_counted(
+                        output_filter,
+                        src_ip,
+                        dst_ip,
+                        meta.protocol,
+                        0,
+                        0,
+                        meta.dscp,
+                        extra,
+                        meta.pkt_len as u64,
+                    )
+                };
+                // Same collapse as the flow-keyed path: any non-`Accept`
+                // terminal action or a three-color-policer drop sets `drop`;
+                // `reject` isolates the `then reject` subset. A flowless deny
+                // is always a SILENT drop downstream (a fragment has no L4
+                // header to synthesize a reply from, #3615) — the caller
+                // gates the active reject reply on a real L4 flow.
+                drop = output_result.policer_drop
+                    || output_result.action != crate::filter::FilterAction::Accept;
+                reject = output_result.action == crate::filter::FilterAction::Reject;
+                filter_log = output_result.log_match;
+            }
+        }
         return CoSTxSelection {
             queue_id,
             dscp_rewrite,
-            drop: false,
-            reject: false,
-            filter_log: None,
+            drop,
+            reject,
+            filter_log,
         };
     };
     // `is_v6` derived above from the (post-NAT) egress key, not `meta` (#3642).

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -1758,6 +1758,236 @@ fn resolve_cos_tx_selection_drops_reject_output_filter_without_log() {
     assert_eq!(selection.filter_log, None);
 }
 
+// #5467: build a UserspaceDpMeta for a FLOWLESS packet (non-first fragment /
+// non-query ICMP) — the shim stamps the L3 addresses but there is NO usable L4
+// header, so it reaches `resolve_cos_tx_selection` with `flow_key = None`. The
+// output-filter enforcement gate must reconstruct the L3 tuple from the meta.
+fn flowless_v4_meta(dst: [u8; 4]) -> UserspaceDpMeta {
+    let mut flow_src_addr = [0u8; 16];
+    let mut flow_dst_addr = [0u8; 16];
+    flow_src_addr[..4].copy_from_slice(&[10, 0, 61, 100]);
+    flow_dst_addr[..4].copy_from_slice(&dst);
+    UserspaceDpMeta {
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        dscp: 0,
+        pkt_len: 1514,
+        // A non-first fragment carries NO L4 header: ports absent (0) and
+        // `l4_present = false` so port-bearing terms fail closed.
+        flow_src_addr,
+        flow_dst_addr,
+        ..Default::default()
+    }
+}
+
+// #5467: the frame-derived per-packet match inputs for a flowless (non-first
+// fragment) packet — L4 absent, is-fragment set.
+fn flowless_extra() -> TermMatchExtra<'static> {
+    TermMatchExtra {
+        is_fragment: true,
+        l4_present: false,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn resolve_cos_tx_selection_flowless_enforces_output_discard() {
+    // #5467 RED-on-revert: a flowless packet (flow_key = None) whose L3 tuple
+    // matches an interface output `then discard` term MUST fail CLOSED. Before
+    // the fix the flowless early-return skipped output-filter evaluation and
+    // returned drop:false — a silent egress deny bypass (fail-OPEN).
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-drop-l3".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop-l3".into(),
+            family: "inet".into(),
+            // L3-only term (address + protocol, NO ports) so it matches a
+            // flowless packet whose L4 ports are absent (0).
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-host".into(),
+                destination_addresses: vec!["172.16.80.200/32".into()],
+                destination_constrained: true,
+                protocols: vec!["tcp".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    // Flowless packet whose L3 dst MATCHES the deny term → fail closed.
+    let matched = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        flowless_v4_meta([172, 16, 80, 200]),
+        None,
+        flowless_extra(),
+    );
+    assert!(
+        matched.drop,
+        "#5467: a flowless packet matching an output `then discard` term must drop"
+    );
+    assert!(!matched.reject, "then discard is a silent drop, not a reject");
+    assert_eq!(matched.filter_log, None);
+
+    // Control: a flowless packet that does NOT match any deny term still
+    // egresses (pass-through unchanged, #2357/#3290 preserved).
+    let unmatched = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        flowless_v4_meta([172, 16, 80, 201]),
+        None,
+        flowless_extra(),
+    );
+    assert!(
+        !unmatched.drop,
+        "#5467: a flowless packet not matching any deny term must NOT drop"
+    );
+}
+
+#[test]
+fn resolve_cos_tx_selection_flowless_enforces_output_reject() {
+    // #5467 RED-on-revert: a flowless packet matching an output `then reject`
+    // term must set drop:true AND reject:true (the caller keeps the reject
+    // reply silent for a flowless packet — no L4 to synthesize from — but the
+    // packet is still denied).
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-reject-l3".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-reject-l3".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "reject-host".into(),
+                destination_addresses: vec!["172.16.80.200/32".into()],
+                destination_constrained: true,
+                protocols: vec!["tcp".into()],
+                action: "reject".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let selection = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        flowless_v4_meta([172, 16, 80, 200]),
+        None,
+        flowless_extra(),
+    );
+    assert!(selection.drop, "#5467: flowless `then reject` must drop");
+    assert!(
+        selection.reject,
+        "#5467: flowless `then reject` must set the reject flag"
+    );
+}
+
+#[test]
+fn resolve_cos_tx_selection_flowless_enforces_output_log() {
+    // #5467 RED-on-revert: a flowless packet matching an output `then log`
+    // term must surface the filter-log match (before the fix filter_log was
+    // always None on the flowless path — the log was silently bypassed).
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-log-l3".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-log-l3".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "log-host".into(),
+                destination_addresses: vec!["172.16.80.200/32".into()],
+                destination_constrained: true,
+                protocols: vec!["tcp".into()],
+                action: "accept".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let selection = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        flowless_v4_meta([172, 16, 80, 200]),
+        None,
+        flowless_extra(),
+    );
+    assert!(
+        selection.filter_log.is_some(),
+        "#5467: a flowless packet matching an output `then log` term must log"
+    );
+    assert!(
+        !selection.drop,
+        "a `then accept` + log term must not drop the packet"
+    );
+}
+
+#[test]
+fn resolve_cos_tx_selection_flowless_port_term_does_not_spuriously_drop() {
+    // #5467 / #2357 / #3290: the flowless output-filter gate matches on the L3
+    // tuple with ports FORCED TO 0, so a port-BEARING terminal term never
+    // matches a fragment — it must NOT be spuriously dropped. This guards the
+    // fix from over-dropping legitimate flowless traffic.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-drop-port".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop-port".into(),
+            family: "inet".into(),
+            // Port-bearing terminal term: a flowless packet (port 0, L4 absent)
+            // must NOT match it.
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let selection = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        flowless_v4_meta([172, 16, 80, 200]),
+        None,
+        flowless_extra(),
+    );
+    assert!(
+        !selection.drop,
+        "#5467: a port-bearing output term must NOT drop a flowless (port 0) packet"
+    );
+}
+
 #[test]
 fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filter_exists() {
     let snapshot = ConfigSnapshot {

--- a/userspace-dp/src/afxdp/types/mod.rs
+++ b/userspace-dp/src/afxdp/types/mod.rs
@@ -156,6 +156,44 @@ pub(super) struct ForwardPacketMeta {
     pub(super) dscp: u8,
     pub(super) flow_src_port: u16,
     pub(super) flow_dst_port: u16,
+    // #5467: the shim-stamped L3 (src, dst) addresses, carried through from the
+    // wire `UserspaceDpMeta` so the flowless output-filter enforcement gate
+    // (`resolve_cos_tx_selection_internal`) can evaluate the interface `filter
+    // output` against a fragment / non-query-ICMP packet's own L3 tuple. Zeroed
+    // (unspecified) for a synthetic/test meta, which `l3_addrs()` reports as
+    // absent — leaving the flowless pass-through behavior unchanged.
+    pub(super) flow_src_addr: [u8; 16],
+    pub(super) flow_dst_addr: [u8; 16],
+}
+
+impl ForwardPacketMeta {
+    /// #5467: reconstruct the packet's L3 `(src, dst)` addresses from the
+    /// shim-stamped meta for the flowless output-filter enforcement gate.
+    /// Mirrors [`crate::afxdp::frame::l3_session_flow_from_meta`]: returns
+    /// `None` for a non-IP family or an unspecified address, in which case the
+    /// caller leaves the flowless (default-queue, no-output-filter)
+    /// pass-through behavior unchanged.
+    pub(super) fn l3_addrs(&self) -> Option<(IpAddr, IpAddr)> {
+        let (src_ip, dst_ip) = match self.addr_family as i32 {
+            libc::AF_INET => {
+                let src = self.flow_src_addr.get(..4)?;
+                let dst = self.flow_dst_addr.get(..4)?;
+                (
+                    IpAddr::V4(Ipv4Addr::new(src[0], src[1], src[2], src[3])),
+                    IpAddr::V4(Ipv4Addr::new(dst[0], dst[1], dst[2], dst[3])),
+                )
+            }
+            libc::AF_INET6 => (
+                IpAddr::V6(Ipv6Addr::from(self.flow_src_addr)),
+                IpAddr::V6(Ipv6Addr::from(self.flow_dst_addr)),
+            ),
+            _ => return None,
+        };
+        if src_ip.is_unspecified() || dst_ip.is_unspecified() {
+            return None;
+        }
+        Some((src_ip, dst_ip))
+    }
 }
 
 impl From<UserspaceDpMeta> for ForwardPacketMeta {
@@ -176,6 +214,8 @@ impl From<UserspaceDpMeta> for ForwardPacketMeta {
             dscp: meta.dscp,
             flow_src_port: meta.flow_src_port,
             flow_dst_port: meta.flow_dst_port,
+            flow_src_addr: meta.flow_src_addr,
+            flow_dst_addr: meta.flow_dst_addr,
         }
     }
 }
@@ -206,8 +246,8 @@ impl From<ForwardPacketMeta> for UserspaceDpMeta {
             reserved: 0,
             flow_src_port: meta.flow_src_port,
             flow_dst_port: meta.flow_dst_port,
-            flow_src_addr: [0; 16],
-            flow_dst_addr: [0; 16],
+            flow_src_addr: meta.flow_src_addr,
+            flow_dst_addr: meta.flow_dst_addr,
             config_generation: 0,
             fib_generation: 0,
             reserved2: 0,


### PR DESCRIPTION
## Summary

Closes #5467.

`resolve_cos_tx_selection_internal` (`userspace-dp/src/afxdp/tx/cos_classify.rs`) resolves the egress CoS queue **and** evaluates the interface `filter output` on the TX path. Its **flowless** early-return arm (taken when `flow_key == None`) resolved the BA/DSCP queue but returned `drop:false, reject:false, filter_log:None` **without ever evaluating the output filter**.

A flowless packet is a **non-first IP fragment** or a **non-query ICMP** error/control packet — both carry no usable L4 ports (#2344 / #3290). So such a packet **egressed even when the interface output filter had a matching `then discard`/`reject`/`log` term** — egress deny/reject/log was silently bypassed: a **fail-OPEN** security hole. The flow-keyed path below the early-return already evaluated the output filter; only the flowless arm skipped it.

## Fix

The flowless arm now reconstructs the packet's own **L3 tuple** from the shim-stamped meta (new `ForwardPacketMeta::l3_addrs`, mirroring `frame::l3_session_flow_from_meta`; **L4 ports forced to 0** since the header is absent) and evaluates the output filter through the **same entry point** the flow-keyed path uses (`interface_output_filter_needs_tx_eval` + `evaluate_filter_ref_tx_selection_{,runtime_}counted`), collapsing `drop`/`reject`/`filter_log` **identically** so the two paths agree.

- **Ports are 0**, so a port-BEARING output term never matches a fragment — the #2357/#3290 guarantee that a port-matching terminal term does not spuriously drop / misclassify a flowless packet is **preserved**. Only an L3-only term (`source-address`/`destination-address`/`protocol`/bare `then`) takes effect; with no matching term the packet still egresses (pass-through unchanged).
- **Queue / DSCP-rewrite selection is untouched** — the gate ADDS enforcement only.
- `ForwardPacketMeta` gained `flow_src_addr`/`flow_dst_addr`, copied through from the wire `UserspaceDpMeta` in the `From` impls (**no wire/protocol change**); every existing struct literal uses `..default()`, so the zeroed addrs report as absent via `l3_addrs()`.
- In `forward_request`, `cos.drop` already drops the packet (existing gate); the active reject reply stays gated on a real L4 flow, so a flowless deny remains a **silent** drop (#3615 — a fragment has no L4 header to synthesize a reply from), and a flowless `then log` event is attributed via an L3-only flow.

**How the port-less tuple is evaluated:** the L3 addresses come from the shim-stamped meta (`flow_src_addr`/`flow_dst_addr`, IPv4/IPv6 via `addr_family`); `src_port`/`dst_port` are passed as `0` and the frame-derived `TermMatchExtra` carries `is_fragment=true`/`l4_present=false`, so L3 terms match while port/flag/icmp-type terms fail closed.

## Step 0 (not stale)

Confirmed live on origin/master: the flowless early-return returned `drop:false/reject:false/filter_log:None` with **no** output-filter eval before it; the `has_output_tx_eval` output-filter evaluation runs only on the flow-keyed path *after* the early-return.

## Validation

- `cargo build` clean; `cargo test --release` full suite **3976 passed / 0 failed**.
- 4 new cargo unit tests in `cos_classify_tests.rs`: flowless `then discard` / `reject` / `log` enforcement + a **port-term no-spurious-drop control**.
- **RED-on-revert proven firsthand** (assertion failure, not a build break): restoring the bare early-return fails the discard/reject/log assertions (`drop:false` / `filter_log:None`, fail-open) while the port-term control stays green.

```
resolve_cos_tx_selection_flowless_enforces_output_discard ... FAILED
  #5467: a flowless packet matching an output `then discard` term must drop
resolve_cos_tx_selection_flowless_enforces_output_reject ... FAILED
  #5467: flowless `then reject` must drop
resolve_cos_tx_selection_flowless_enforces_output_log ... FAILED
  #5467: a flowless packet matching an output `then log` term must log
resolve_cos_tx_selection_flowless_port_term_does_not_spuriously_drop ... ok
```

**Cluster smoke DEFERRED** (shim-wall this window) — this is a filter-eval logic fix gated on the cargo RED-on-revert unit test.

## Scope

`userspace-dp` only. No `userspace-xdp`/shim changes (no `make generate`). No wire/protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138bLWwy8YWSmWfWEWqRJqk