### PR TITLE
dataplane: stop verify false-reject on CPU-sized cpumap pin

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-16 — #5364: stop verify-dataplane false-rejecting rolling deploys on the CPU-sized userspace_cpumap live pin
+
+- **Timestamp**: 2026-07-16 (fix/5364-cpumap-verify-possiblecpu)
+- **Action**: `make cluster-deploy`'s verify-dataplane pre-flight rejected EVERY
+  rolling deploy with `userspace shim map userspace_cpumap is ABI-incompatible
+  with the live pinned map ... MaxEntries embedded=256 pinned=16`. Root cause
+  (corrected from the #5363 "stale 16→256 ABI bump" framing): `userspace_cpumap`
+  is a `BPF_MAP_TYPE_CPUMAP`; the shim declares it `CpuMap::with_max_entries(256,
+  0)` as a TEMPLATE MAX, but cilium/ebpf's `MapSpec.fixupMagicFields` clamps a
+  CPUMAP's `MaxEntries` to `nr_possible_cpus` before it creates OR ABI-compares
+  the map, so a fresh daemon ALWAYS pins it at `nr_possible_cpus` (16 on the loss
+  VMs), never 256. `MapSpec.Compatible` (the exact `ErrMapIncompatible` check the
+  pre-flight predicts) runs the identical clamp, so the real PinByName load
+  compares 16==16 and succeeds — the pre-flight's manual `userspaceMapABIDiff`
+  replicated `Compatible()` but OMITTED the clamp, producing a phantom MaxEntries
+  diff on every deploy. Fix (option a): `validateUserspaceShimLivePins` now
+  resolves the reference `MaxEntries` through `livePinRefABI` +
+  `cpuMapFixupMaxEntries`, which applies cilium/ebpf's CPUMAP clamp
+  (`MustPossibleCPU()`) so the reference matches the shape the loader actually
+  pins. Scoped to the CPUMAP `MaxEntries` axis only — confirmed `userspace_cpumap`
+  is the ONLY CPU-count-sized ABI-checked map (no PerfEventArray/map-of-maps in
+  the shim-declared set or `userspaceShimSharedMapSpecs`; XskMap keeps 4096;
+  per-CPU ARRAY/HASH maps keep declared MaxEntries and replicate the VALUE
+  per-CPU) — so Type/KeySize/ValueSize/Flags and every other map's MaxEntries
+  stay strict. Corrected the `userspaceShimStalePinRemediation` const doc and the
+  #5363 test's cpumap cases (which encoded the false premise) so the full-reload
+  remediation now fires only for a GENUINE cross-version break of a non-cpumap
+  map or a real cpumap Type/KeySize/ValueSize/Flags change. See #5363.
+- **File(s)**: pkg/dataplane/loader_userspace_shim.go,
+  pkg/dataplane/verify_cpumap_possiblecpu_5364_test.go,
+  pkg/dataplane/stalepin_remediation_5363_test.go,
+  pkg/dataplane/README.md, _Log.md
+- **Validation**: `go build ./...` clean, `go vet ./pkg/dataplane` clean,
+  `go test ./pkg/dataplane` green (2.1s). Fail-on-revert proven firsthand:
+  reverting `livePinRefABI(ref)` → `mapABIFromSpec(ref)` makes
+  `TestCPUMapLivePinPossibleCPUAccepted` fail with the exact production symptom
+  (`MaxEntries embedded=256 pinned=16`); restore → green. New guards
+  `TestCPUMapLivePinGenuineBreakStillRejected` and
+  `TestNonCPUMapMaxEntriesStillStrict` keep the relaxation scoped.
+
 ## 2026-07-16 — #5837 rev6052 fold: exclude interface-mode-SNAT-routed addrs from the NAT-interface-address advisory
 
 - **Timestamp**: 2026-07-16 (fix/5837-track1-interface-addr-nat-warning)

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -124,14 +124,34 @@ Guard layers (`build-userspace-xdp.sh`):
    generate-userspace-xdp`." A **live-pin mismatch**
    (`validateUserspaceShimLivePins`) is the OPPOSITE situation: it compares
    this build's embedded shim against the RUNNING (old) daemon's pinned
-   map, so the pin is ALWAYS the stale side — in the upgrade direction
-   (embedded `MaxEntries` > pinned, e.g. the `userspace_cpumap` 16→256
-   bump) AND in a downgrade. The embedded shim is the intended, un-broken
-   target, so `make generate` is the WRONG action; instead it prints
-   `userspaceShimStalePinRemediation`, directing a FULL dataplane reload
-   (stop xpfd so the old pin is released, then start it to load the new
-   shim). A rolling deploy cannot cross a shim-map ABI change because the
-   new map can only be pinned after the stale pin is released.
+   map, so the pin is ALWAYS the stale side. The embedded shim is the
+   intended, un-broken target, so `make generate` is the WRONG action;
+   instead it prints `userspaceShimStalePinRemediation`, directing a FULL
+   dataplane reload (stop xpfd so the old pin is released, then start it to
+   load the new shim). A rolling deploy cannot cross a genuine shim-map ABI
+   change because the new map can only be pinned after the stale pin is
+   released.
+
+   **CPUMAP MaxEntries is CPU-sized, not a stale-pin signal (#5364):**
+   `userspace_cpumap` is a `BPF_MAP_TYPE_CPUMAP`. The shim declares it as
+   `CpuMap::with_max_entries(256, 0)` — a template MAX — but cilium/ebpf's
+   `MapSpec.fixupMagicFields` clamps a CPUMAP's `MaxEntries` to
+   `nr_possible_cpus` before it creates OR ABI-compares the map, so a fresh
+   daemon ALWAYS pins it at `nr_possible_cpus` (16 on the loss VMs), never
+   256. Because `MapSpec.Compatible` (the exact `ErrMapIncompatible` check
+   this pre-flight predicts) runs the identical clamp, the real PinByName
+   load compares `nr_possible_cpus == nr_possible_cpus` and succeeds. The
+   pre-flight therefore resolves the reference `MaxEntries` through
+   `livePinRefABI`, which applies the same clamp for a CPUMAP — so the old
+   "`cpumap=16` pin vs embedded `cpumap=256` shim" diff (mischaracterized as
+   a stale 16→256 ABI bump, which false-rejected EVERY rolling
+   cluster-deploy) is no longer produced. The relaxation is scoped to the
+   `MaxEntries` axis of the CPUMAP only: no other ABI-checked shim map is
+   CPU-count-sized (per-CPU ARRAY/HASH maps keep their declared `MaxEntries`
+   and replicate the VALUE per-CPU; XskMap keeps its declared size), so every
+   other map keeps a strict `MaxEntries` check, and a genuine cpumap
+   Type/KeySize/ValueSize/Flags break still yields the full-reload
+   remediation.
 
    **Residual (documented, not caught here):** a *same-size* Go/Rust
    value **field reorder** — identical `KeySize`/`ValueSize`/`Type`/
@@ -146,7 +166,13 @@ Guard layers (`build-userspace-xdp.sh`):
    `TestVerifyUserspaceShimShrinkEquivalence` proves the verify-only
    hash-map MaxEntries shrink (memory hygiene for live-node
    pre-flights) never changes the verifier verdict, using the
-   preserved incident object in `testdata/`.
+   preserved incident object in `testdata/`. The #5364 cpumap
+   CPU-count-clamp handling is covered by
+   `TestCPUMapLivePinPossibleCPUAccepted` (a CPU-sized cpumap live pin is
+   accepted, not false-rejected), `TestCPUMapLivePinGenuineBreakStillRejected`
+   (a genuine cpumap ValueSize break is still rejected), and
+   `TestNonCPUMapMaxEntriesStillStrict` (no other map's MaxEntries check is
+   weakened).
 
 **Recovery runbook** (symptom: `load Rust xdp_userspace collection:
 ... BPF program is too large. Processed 1000001 insn`, daemon in

--- a/pkg/dataplane/loader_userspace_shim.go
+++ b/pkg/dataplane/loader_userspace_shim.go
@@ -28,15 +28,24 @@ import (
 const (
 	bpfPinPath                       = "/sys/fs/bpf/xpf"
 	userspaceShimGenerateRemediation = "Re-run `make generate-userspace-xdp`."
-	// userspaceShimStalePinRemediation is the remediation for a LIVE-PIN ABI
-	// mismatch (validateUserspaceShimLivePins): the running daemon's pinned map
-	// predates this build's shim-map ABI. That is NOT an embedded-vs-Go SSOT
+	// userspaceShimStalePinRemediation is the remediation for a GENUINE LIVE-PIN
+	// ABI mismatch (validateUserspaceShimLivePins): the running daemon's pinned
+	// map predates this build's shim-map ABI. That is NOT an embedded-vs-Go SSOT
 	// drift — the embedded shim is the intended deploy target and is not broken
 	// — so `make generate` is the WRONG action. A rolling deploy cannot cross a
 	// shim-map ABI change because the new map can only be pinned after the stale
-	// pin is released; the fix is a full dataplane reload. This is the exact
-	// scenario that blocks a cluster stuck on an old cpumap=16 pin vs an
-	// embedded cpumap=256 shim (#5363).
+	// pin is released; the fix is a full dataplane reload.
+	//
+	// #5364: this message is NOT reachable for a userspace_cpumap MaxEntries
+	// gap. That map is a BPF_MAP_TYPE_CPUMAP whose MaxEntries the kernel/loader
+	// clamps to nr_possible_cpus (the shim's `CpuMap::with_max_entries(256, 0)`
+	// is only a template max), so a fresh daemon ALWAYS pins it at
+	// nr_possible_cpus, never 256. livePinRefABI applies the identical clamp to
+	// the reference shape, so the old "cpumap=16 pin vs embedded cpumap=256
+	// shim" diff that #5363 mischaracterized as a stale pin (and that blocked
+	// EVERY rolling cluster-deploy) is no longer produced. This remediation now
+	// fires only for a real cross-version ABI break of a NON-cpumap map, or a
+	// genuine cpumap Type/KeySize/ValueSize/Flags change.
 	userspaceShimStalePinRemediation = "The RUNNING daemon's pinned map predates " +
 		"this build's shim-map ABI. A rolling deploy CANNOT cross a shim-map ABI " +
 		"change: the new map can only be pinned after the stale pin is released. " +
@@ -278,6 +287,45 @@ func mapABIFromSpec(ms *ebpf.MapSpec) userspaceMapABI {
 	}
 }
 
+// livePinRefABI is the reference ABI shape the live-pin comparison diffs against
+// the RUNNING daemon's pinned map. For every map except a BPF_MAP_TYPE_CPUMAP it
+// is the reference spec's shape verbatim (mapABIFromSpec). For a CPUMAP it
+// applies the SAME nr_possible_cpus MaxEntries clamp cilium/ebpf's
+// MapSpec.fixupMagicFields runs before it creates OR ABI-compares the map: a
+// CPUMAP's MaxEntries is clamped to PossibleCPU() (the shim's
+// `CpuMap::with_max_entries(256, 0)` is only a template max cap), so the map is
+// created — and pinned — at nr_possible_cpus, never the .o's 256. MapSpec.Compatible
+// (the exact ErrMapIncompatible check this pre-flight predicts) runs the identical
+// fixup, so without this clamp the pre-flight rejects EVERY rolling deploy on a
+// phantom "MaxEntries embedded=256 pinned=<nr_possible_cpus>" diff even though the
+// real PinByName load compares <nr_possible_cpus>==<nr_possible_cpus> and succeeds
+// (#5364). The relaxation is scoped to CPUMAP: no other ABI-checked shim map is
+// CPU-count-sized — per-CPU ARRAY/HASH maps keep their declared MaxEntries and
+// replicate the VALUE per-CPU, and XskMap keeps its declared size — so every other
+// map keeps a strict MaxEntries check. A genuine cpumap ABI change still diffs on
+// Type/KeySize/ValueSize/Flags (and on MaxEntries when the pin drops below
+// nr_possible_cpus).
+func livePinRefABI(ref *ebpf.MapSpec) userspaceMapABI {
+	abi := mapABIFromSpec(ref)
+	if ref.Type == ebpf.CPUMap {
+		abi.MaxEntries = cpuMapFixupMaxEntries(abi.MaxEntries)
+	}
+	return abi
+}
+
+// cpuMapFixupMaxEntries mirrors the CPUMap arm of cilium/ebpf
+// MapSpec.fixupMagicFields: clamp MaxEntries to nr_possible_cpus when the
+// declared value is 0 or exceeds the CPU count. This is the shape the loader
+// actually creates+pins and the shape MapSpec.Compatible compares against, so
+// the live-pin pre-flight must use it to avoid a false MaxEntries rejection.
+func cpuMapFixupMaxEntries(declared uint32) uint32 {
+	n := uint32(ebpf.MustPossibleCPU())
+	if declared == 0 || declared > n {
+		return n
+	}
+	return declared
+}
+
 // userspaceMapABIDiff reports the first ABI field in which the embedded shim map
 // spec differs from a reference shape (the Go expected shape or the live pinned
 // map), or "" when compatible. It mirrors cilium/ebpf MapSpec.Compatible: Type,
@@ -403,10 +451,13 @@ func userspaceABICheckedPinnedMaps() []string {
 // The reference shape is resolved per map by abiCheckedRefSpec: the embedded
 // shim's own MapSpec for a shim-declared map (dnat_table, dnat_table_v6, the
 // userspace_* maps), else the Go-side SSOT spec for a shared map the loader
-// creates itself (sessions_v6, the HA/counter family). Both are spec-derived
-// (userspaceMapABIDiff(mapABIFromSpec(ref), live)) — never a hardcoded live
-// shape — so a healthy deploy where live pin == the shape that created it
-// yields no diff and only a real cross-version ABI break is caught (#5484).
+// creates itself (sessions_v6, the HA/counter family). The reference ABI is
+// spec-derived via livePinRefABI — never a hardcoded live shape — so a healthy
+// deploy where live pin == the shape that created it yields no diff and only a
+// real cross-version ABI break is caught (#5484). livePinRefABI applies the
+// nr_possible_cpus MaxEntries clamp cilium/ebpf uses for a CPUMAP
+// (userspace_cpumap), so the CPU-count-sized live pin is not mistaken for an
+// ABI break on a rolling deploy (#5364).
 func validateUserspaceShimLivePins(userspaceSpec *ebpf.CollectionSpec, readPin userspacePinnedMapABIReader) error {
 	if readPin == nil {
 		return nil
@@ -424,7 +475,7 @@ func validateUserspaceShimLivePins(userspaceSpec *ebpf.CollectionSpec, readPin u
 		if !exists {
 			continue // fresh node / first load: nothing pinned yet
 		}
-		if diff := userspaceMapABIDiff(mapABIFromSpec(ref), live); diff != "" {
+		if diff := userspaceMapABIDiff(livePinRefABI(ref), live); diff != "" {
 			return fmt.Errorf(
 				"userspace shim map %s is ABI-incompatible with the live pinned map at %s: %s. "+
 					"Loading the new dataplane would fail with ErrMapIncompatible AFTER the running "+

--- a/pkg/dataplane/stalepin_remediation_5363_test.go
+++ b/pkg/dataplane/stalepin_remediation_5363_test.go
@@ -15,11 +15,19 @@ import (
 // remediation must be the full-dataplane-reload guidance, NEVER `make generate`
 // (which would tell the operator to rebuild a shim that is not broken).
 //
-// This is direction-INDEPENDENT: it holds both in the upgrade direction
-// (embedded MaxEntries > pinned — the userspace_cpumap 16→256 bump that blocked
-// a real cluster) AND in a downgrade (embedded < pinned). Both cases exercise
-// the SAME live-pin mismatch branch, so a single stale-pin remediation is
-// correct for the whole branch — no MaxEntries >-vs-< heuristic.
+// This is direction-INDEPENDENT: it holds both when the embedded shape is the
+// larger side AND when it is the smaller side. Both cases exercise the SAME
+// live-pin mismatch branch, so a single stale-pin remediation is correct for
+// the whole branch — no MaxEntries >-vs-< heuristic.
+//
+// #5364 CORRECTION: the userspace_cpumap "16 vs 256 MaxEntries" gap that #5363
+// originally used as its example is NOT a genuine ABI break — a CPUMAP's
+// MaxEntries is clamped to nr_possible_cpus at load, so the map is pinned at
+// nr_possible_cpus and MapSpec.Compatible accepts it. That case is now handled
+// by livePinRefABI and is no longer rejected (see TestCPUMapLivePinPossibleCPU*).
+// The cases below therefore use a genuine cpumap ABI break (a ValueSize change)
+// and a genuine non-cpumap MaxEntries drift, both of which are still stale-pin
+// mismatches that must carry the full-reload remediation.
 //
 // RED-on-revert: with the pre-#5363 code the live-pin error appended
 // userspaceShimGenerateRemediation ("Re-run `make generate-userspace-xdp`."),
@@ -36,24 +44,17 @@ func TestLivePinABIMismatchUsesStalePinRemediation(t *testing.T) {
 		wantDiffFrag string          // substring naming the offending field
 	}{
 		{
-			// The exact #5363 scenario: an old daemon pinned userspace_cpumap
-			// with 16 entries; this build's shim embeds 256. Upgrade direction
-			// (embedded > pinned).
-			name:         "cpumap-upgrade-embedded-gt-pinned",
+			// #5364: a GENUINE cpumap ABI break. The MaxEntries axis is
+			// CPU-count-clamped and no longer diffs (the map is pinned at
+			// nr_possible_cpus), so this uses a ValueSize change — a real
+			// cross-version ABI break that is still a stale-pin mismatch.
+			// The live pin's MaxEntries is nr_possible_cpus (what a fresh
+			// daemon actually pins) so only ValueSize drives the diff.
+			name:         "cpumap-genuine-valuesize-break",
 			mapName:      "userspace_cpumap",
-			embedded:     &ebpf.MapSpec{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 256},
-			pinnedShape:  userspaceMapABI{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 16},
-			wantDiffFrag: "MaxEntries embedded=256 pinned=16",
-		},
-		{
-			// Downgrade direction (embedded < pinned): the pin is STILL the
-			// stale side, so the remediation is STILL a full reload — proving
-			// the fix is direction-independent (no >-vs-< heuristic).
-			name:         "cpumap-downgrade-embedded-lt-pinned",
-			mapName:      "userspace_cpumap",
-			embedded:     &ebpf.MapSpec{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 16},
-			pinnedShape:  userspaceMapABI{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 256},
-			wantDiffFrag: "MaxEntries embedded=16 pinned=256",
+			embedded:     &ebpf.MapSpec{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 8, MaxEntries: 256},
+			pinnedShape:  userspaceMapABI{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: uint32(ebpf.MustPossibleCPU())},
+			wantDiffFrag: "ValueSize embedded=8 pinned=4",
 		},
 		{
 			// A shim-declared shared map (dnat_table): embedded shape is the

--- a/pkg/dataplane/verify_cpumap_possiblecpu_5364_test.go
+++ b/pkg/dataplane/verify_cpumap_possiblecpu_5364_test.go
@@ -1,0 +1,111 @@
+package dataplane
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// TestCPUMapLivePinPossibleCPUAccepted is the #5364 core: the live-pin ABI
+// pre-flight must NOT treat a CPU-count-sized userspace_cpumap live pin as an
+// ABI break. userspace_cpumap is a BPF_MAP_TYPE_CPUMAP; the shim declares it as
+// `CpuMap::with_max_entries(256, 0)` (a template MAX), but cilium/ebpf's
+// MapSpec.fixupMagicFields clamps a CPUMAP's MaxEntries to nr_possible_cpus
+// before it creates OR ABI-compares the map, so a fresh daemon ALWAYS pins it at
+// nr_possible_cpus (16 on the loss VMs), never 256. MapSpec.Compatible — the
+// exact ErrMapIncompatible check this pre-flight predicts — runs the identical
+// clamp, so the real PinByName load compares nr_possible_cpus==nr_possible_cpus
+// and succeeds. The pre-flight must resolve the reference MaxEntries the same way
+// (livePinRefABI) or it false-rejects EVERY rolling cluster-deploy.
+//
+// RED-on-revert: before #5364 the reference used the embedded .o MaxEntries (256)
+// verbatim, so 256-vs-nr_possible_cpus produced a phantom MaxEntries diff and this
+// "must be accepted" assertion flips red (the false-reject returns).
+func TestCPUMapLivePinPossibleCPUAccepted(t *testing.T) {
+	t.Parallel()
+
+	ncpu := uint32(ebpf.MustPossibleCPU())
+	if ncpu >= 256 {
+		t.Skipf("machine reports %d possible CPUs; the shim's 256-entry cpumap template is not clamped below 256 here", ncpu)
+	}
+
+	base := validABIBaseSpec()
+	// Embedded shim declares the cpumap at the 256 template max.
+	base.Maps["userspace_cpumap"] = &ebpf.MapSpec{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: 256}
+
+	// RED-on-revert guard: the base spec passes the legacy presence+MaxEntries
+	// validator, so the ONLY reject signal is the live-pin ABI comparison.
+	if err := legacyPresenceMaxEntriesValidate(base); err != nil {
+		t.Fatalf("legacy validator rejected base (%v); cannot prove RED-on-revert", err)
+	}
+
+	// Live pin is what a fresh daemon actually pinned: nr_possible_cpus.
+	reader := pinReaderWithOverride(base, map[string]userspaceMapABI{
+		"userspace_cpumap": {Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: ncpu},
+	})
+
+	if err := validateUserspaceShimSpecWith(base, reader); err != nil {
+		t.Fatalf("cpumap 256-template embedded vs nr_possible_cpus(%d) live pin must be ACCEPTED "+
+			"(loader clamps CPUMAP MaxEntries to possible-CPU); got: %v", ncpu, err)
+	}
+}
+
+// TestCPUMapLivePinGenuineBreakStillRejected proves the #5364 relaxation is
+// scoped to the MaxEntries axis of a CPUMAP only: a genuine cpumap ABI break —
+// here a ValueSize change — is STILL rejected at the pre-flight and STILL carries
+// the stale-pin remediation. userspaceMapABIDiff checks ValueSize before
+// MaxEntries, so the ValueSize break dominates regardless of the CPU count.
+func TestCPUMapLivePinGenuineBreakStillRejected(t *testing.T) {
+	t.Parallel()
+
+	ncpu := uint32(ebpf.MustPossibleCPU())
+
+	base := validABIBaseSpec()
+	base.Maps["userspace_cpumap"] = &ebpf.MapSpec{Type: ebpf.CPUMap, KeySize: 4, ValueSize: 8, MaxEntries: 256}
+	// MaxEntries matches (clamped 256 == live nr_possible_cpus); ValueSize differs.
+	reader := pinReaderWithOverride(base, map[string]userspaceMapABI{
+		"userspace_cpumap": {Type: ebpf.CPUMap, KeySize: 4, ValueSize: 4, MaxEntries: ncpu},
+	})
+
+	err := validateUserspaceShimSpecWith(base, reader)
+	if err == nil {
+		t.Fatal("genuine cpumap ValueSize break must still be rejected (relaxation is MaxEntries-only)")
+	}
+	for _, want := range []string{"userspace_cpumap", "ValueSize", "ABI-incompatible", userspaceShimStalePinRemediation} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %v, want substring %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "make generate-userspace-xdp") {
+		t.Fatalf("err = %v, live-pin mismatch must NOT tell the operator to rebuild the shim", err)
+	}
+}
+
+// TestNonCPUMapMaxEntriesStillStrict proves the #5364 fix does NOT weaken the
+// MaxEntries check for any non-cpumap ABI-checked map: a real MaxEntries drift on
+// a HASH map (here the shim-declared userspace_sessions) is STILL rejected. Only
+// userspace_cpumap is CPU-count-sized; every other map keeps a strict MaxEntries
+// comparison.
+func TestNonCPUMapMaxEntriesStillStrict(t *testing.T) {
+	t.Parallel()
+
+	base := validABIBaseSpec()
+	// A shim-declared HASH map; embedded shape is the reference for the diff.
+	base.Maps["userspace_sessions"] = &ebpf.MapSpec{Type: ebpf.Hash, KeySize: 16, ValueSize: 1, MaxEntries: 262144}
+	// Live pin drifted to a smaller MaxEntries — a genuine ABI break for a
+	// non-cpumap map, which must NOT be clamped away.
+	reader := pinReaderWithOverride(base, map[string]userspaceMapABI{
+		"userspace_sessions": {Type: ebpf.Hash, KeySize: 16, ValueSize: 1, MaxEntries: 65536},
+	})
+
+	err := validateUserspaceShimSpecWith(base, reader)
+	if err == nil {
+		t.Fatal("non-cpumap MaxEntries drift must still be rejected (strict check preserved)")
+	}
+	for _, want := range []string{"userspace_sessions", "MaxEntries embedded=262144 pinned=65536", "ABI-incompatible"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %v, want substring %q", err, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`make cluster-deploy`'s verify-dataplane pre-flight rejects **every** rolling
deploy with:

```
userspace shim map userspace_cpumap is ABI-incompatible with the live pinned
map ... MaxEntries embedded=256 pinned=16
```

This was mischaracterized (#5363, #1864) as a stale `16→256` ABI drift needing a
full-reload "cross." That is wrong: a full reload does **not** durably fix it —
a fresh daemon re-pins 16 every time.

## Root cause (verified live, 2026-07-16)

`userspace_cpumap` is a `BPF_MAP_TYPE_CPUMAP`. The shim declares it as
`CpuMap::with_max_entries(256, 0)` — a **template max**. cilium/ebpf's
`MapSpec.fixupMagicFields` clamps a CPUMAP's `MaxEntries` to `nr_possible_cpus`
**before it creates OR ABI-compares the map** (`map.go` `case spec.Type ==
CPUMap`), so a fresh daemon always pins the cpumap at `nr_possible_cpus` (16 on
the loss VMs), never 256.

Critically, `MapSpec.Compatible` — the exact `ErrMapIncompatible` check this
pre-flight exists to predict — **also** runs that fixup first, so the real
`NewCollectionWithOptions` PinByName load compares `16 == 16` and succeeds. The
pre-flight's manual `userspaceMapABIDiff` replicated `Compatible()` but *omitted*
the clamp → a phantom `MaxEntries` diff on every deploy → false-rejection.

## Fix (option a)

`validateUserspaceShimLivePins` now resolves the reference `MaxEntries` through
`livePinRefABI` + `cpuMapFixupMaxEntries`, applying cilium/ebpf's CPUMAP clamp
(`MustPossibleCPU()`) so the reference matches the shape the loader actually
pins.

**Scoped to the CPUMAP `MaxEntries` axis only.** `userspace_cpumap` is the ONLY
CPU-count-sized ABI-checked map (no `PerfEventArray`/map-of-maps in the
shim-declared set or `userspaceShimSharedMapSpecs`; `XskMap` keeps its declared
4096; per-CPU ARRAY/HASH maps keep their declared `MaxEntries` and replicate the
VALUE per-CPU). `Type`/`KeySize`/`ValueSize`/`Flags` for the cpumap and every
other map's `MaxEntries` stay strict — a genuine cross-version ABI break is
still caught pre-stop, preserving the #5307/#5484 fail-closed protection.

Also corrected the `userspaceShimStalePinRemediation` const doc and the #5363
test's two cpumap cases (they encoded the now-understood-false premise that
`256`-vs-`16` is a real stale pin), plus `pkg/dataplane/README.md`.

## Validation

- `go build ./...` clean, `go vet ./pkg/dataplane` clean, `go test ./pkg/dataplane` green.
- **Fail-on-revert proven firsthand:** reverting `livePinRefABI(ref)` →
  `mapABIFromSpec(ref)` makes `TestCPUMapLivePinPossibleCPUAccepted` fail with the
  exact production symptom (`MaxEntries embedded=256 pinned=16`); restore → green.
- New guards `TestCPUMapLivePinGenuineBreakStillRejected` (a genuine cpumap
  `ValueSize` break still rejected) and `TestNonCPUMapMaxEntriesStillStrict` (no
  other map's `MaxEntries` check weakened).

Closes #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSpKQsqTCHH7bpYQbLAeKG