### PR TITLE
userspace-dp: make descriptor rewrite transactional (#5466)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -51138,3 +51138,46 @@ top.
   **File(s)**: pkg/dataplane/userspace/manager_ha.go,
   pkg/dataplane/userspace/manager_compile.go,
   pkg/dataplane/userspace/manager_ha_clear_debt_5873_test.go (new)
+
+- **Timestamp**: 2026-07-17
+  **Action**: #5466 — make the userspace-dp descriptor rewrite transactional
+  (no UMEM mutation before a possible None bail).
+  **Why**: `apply_rewrite_descriptor` (frame/rewrite/mod.rs) called
+  `rewrite_prepare_eth_from_parts`, which MUTATES the UMEM frame (eth-header
+  write via `write_eth_header_slice`, and in the VLAN-push-no-headroom /
+  unsupported case a payload `frame.copy_within` memmove), BEFORE hitting the
+  non-first-fragment gate and the v4/v6 DMA-race port-mismatch guards that can
+  return None. The flow-cache caller chains
+  `apply_rewrite_descriptor(...).or_else(|| rewrite_forwarded_frame_in_place(...))`,
+  so a None-after-mutation handed the generic fallback a CORRUPTED frame
+  (scribbled L2 / shifted payload) → wrong bytes on the wire / checksum
+  corruption / mis-forwarded packet.
+  **Fix (plan-then-commit split)**: split `rewrite_prepare_eth_from_parts` into
+  a pure `rewrite_plan_eth_from_parts` (no mutation) + a mutating
+  `rewrite_commit_eth_from_plan`; the old name now composes the two so the
+  generic path is byte-identical. Split the v4/v6 arms into read-only
+  `validate_rewrite_descriptor_ipv4/ipv6` (all None-returning gates, returns the
+  rel-L4 offset) + infallible `apply_rewrite_descriptor_ipv4/ipv6` (mutation
+  only). The orchestrator now: plan (no mutation) -> run the fragment gate +
+  family validation against the PRISTINE frame at `plan.l3` -> only then commit
+  the eth rewrite -> apply. Gates read the original L3 payload and use the
+  plan's frame_len/payload_len for length checks; because the commit's memmove
+  is a pure relocation and the eth-header write never touches the L3/L4 region,
+  the gate DECISIONS and the success-path OUTPUT are byte-identical to
+  pre-#5466.
+  **Validation**: `cargo build` clean; `cargo test --release rewrite` +
+  full `cargo test --release` GREEN. Fail-on-revert proven firsthand: with the
+  commit reordered before the gates, `pin_5466_descriptor_fragment_decline`,
+  `pin_5466_descriptor_vlan_push_memmove_decline`,
+  `pin_descriptor_port_mismatch_declines`, and
+  `pin_ttl_expired_declines_l3_untouched` all go RED (`assertion left == right
+  failed` on the full-frame byte-identity check). Cluster smoke DEFERRED
+  (verify-dataplane cpumap false-rejection #5364 blocks loss-cluster deploy);
+  this is a frame-transactionality logic fix gated on the cargo RED-on-revert
+  pins.
+  **File(s)**: userspace-dp/src/afxdp/frame/mod.rs,
+  userspace-dp/src/afxdp/frame/rewrite/mod.rs,
+  userspace-dp/src/afxdp/frame/rewrite/ipv4.rs,
+  userspace-dp/src/afxdp/frame/rewrite/ipv6.rs,
+  userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs,
+  userspace-dp/src/afxdp/frame/README.md

--- a/userspace-dp/src/afxdp/frame/README.md
+++ b/userspace-dp/src/afxdp/frame/README.md
@@ -86,6 +86,26 @@ inspect or rewrite a packet sitting in a UMEM frame.
   `packet_rel_l4_offset_and_protocol` so MSS clamping reaches
   ext-headered v6 SYNs (the shared helper is left unchanged — GRE decap
   and tunnel local-origin read it to forward fragmented inner packets).
+- **The descriptor rewrite is transactional (#5466)**: `rewrite/mod.rs`
+  splits the eth preamble into a pure plan (`rewrite_plan_eth_from_parts`)
+  and a mutating commit (`rewrite_commit_eth_from_plan`, the eth-header
+  write + VLAN-push `copy_within` memmove). ALL bail gates
+  (`is_non_first_fragment`, `validate_rewrite_descriptor_ipv4/ipv6` —
+  header length, TTL/hop-limit, DMA-race port mismatch) run against the
+  PRISTINE frame at `plan.l3` BEFORE the commit. A `None` return therefore
+  leaves the UMEM frame byte-identical, which is required because the flow
+  cache caller chains `apply_rewrite_descriptor(...).or_else(generic)`: a
+  frame mutated before the bail (scribbled L2 / shifted payload) would
+  corrupt the generic fallback's reprocessing. The gates read from the
+  original L3 offset (before the commit's memmove relocates the payload)
+  and use the plan's `frame_len`/`payload_len` for length checks, so their
+  decisions are byte-identical to the pre-#5466 post-commit checks; the
+  infallible `apply_*` mutation half then reproduces the success-path
+  output exactly (guarded by the P-N3 differential + the
+  `pin_5466_*`/`pin_*_declines` fail-on-revert pins). The generic
+  in-place rewrite (`rewrite_forwarded_frame_in_place`) is the TERMINAL
+  fallback and still writes L2 before its own gate — harmless, nothing
+  reprocesses the frame after its `None`.
 - **Port-less protocols never get an L4 port written (#3111)**: only
   TCP/UDP carry a rewritable 16-bit port pair at L4 offset +0/+2. Every
   port-write site — the generic `apply_nat_port_rewrite` and the

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -516,13 +516,36 @@ fn classify_in_place_l2_rewrite(
     Some((rx_addr, InPlaceL2Rewrite::UnsupportedMemmove))
 }
 
+/// The read-only output of `rewrite_plan_eth_from_parts`: the descriptor
+/// rewrite plan plus the ORIGINAL-frame geometry the descriptor fast path
+/// needs to run its bail gates before mutating UMEM (#5466).
+pub(in crate::afxdp::frame) struct EthRewritePlan {
+    /// L3 offset within the ORIGINAL (RX) frame at `desc.addr`. Before the
+    /// commit's VLAN-push memmove relocates the L3 payload, this is where
+    /// the descriptor bail gates must read the IP/L4 header.
+    pub(in crate::afxdp::frame) l3: usize,
+    /// Trimmed L3 payload length (`== frame_len - eth_len`).
+    pub(in crate::afxdp::frame) payload_len: usize,
+    /// Post-commit descriptor result (offsets + L2 classification).
+    pub(in crate::afxdp::frame) prep: RewritePrep,
+}
+
+/// Read-only half of the descriptor rewrite preamble (#5466). Computes the
+/// L3 offset, trimmed payload length, target Ethernet length, TX descriptor
+/// view, and L2-rewrite classification WITHOUT touching the UMEM frame.
+///
+/// Split out of `rewrite_prepare_eth_from_parts` so the descriptor fast path
+/// can run every bail gate (non-first-fragment / header length / TTL / DMA-race
+/// port mismatch) against the pristine frame BEFORE any mutation. A `None`
+/// return from a gate then leaves the frame byte-identical, so the caller's
+/// generic `.or_else(...)` fallback reprocesses an un-corrupted packet.
 #[inline]
-fn rewrite_prepare_eth_from_parts(
+fn rewrite_plan_eth_from_parts(
     area: &MmapArea,
     desc: XdpDesc,
     meta: ForwardPacketMeta,
-    params: RewriteEthParams,
-) -> Option<RewritePrep> {
+    params: &RewriteEthParams,
+) -> Option<EthRewritePlan> {
     let current_len = desc.len as usize;
     let (l3, payload_len) = {
         let frame = area.slice(desc.addr as usize, current_len)?;
@@ -538,9 +561,48 @@ fn rewrite_prepare_eth_from_parts(
     let eth_len = if params.vlan_id > 0 { 18usize } else { 14usize };
     let frame_len = eth_len.checked_add(payload_len)?;
     let (tx_offset, l2_rewrite) = classify_in_place_l2_rewrite(desc.addr, l3, eth_len, frame_len)?;
+    // Fabric-ingress packets already had TTL decremented by the
+    // sending peer (FABRIC_INGRESS_FLAG = 0x80).
+    let skip_ttl = (meta.meta_flags & 0x80) != 0;
+    Some(EthRewritePlan {
+        l3,
+        payload_len,
+        prep: RewritePrep {
+            eth_len,
+            ip_start: eth_len,
+            frame_len,
+            tx_offset,
+            l2_rewrite,
+            apply_nat: params.apply_nat,
+            skip_ttl,
+            vlan_id: params.vlan_id,
+        },
+    })
+}
+
+/// Mutating half of the descriptor rewrite preamble (#5466). Writes the new
+/// Ethernet header and, on the VLAN-push-no-headroom / unsupported paths,
+/// performs the payload `copy_within` memmove. Every write here mutates UMEM,
+/// so this MUST be called only after all descriptor bail gates have passed.
+///
+/// Body is byte-identical to the mutation block of the pre-#5466
+/// `rewrite_prepare_eth_from_parts`, so the generic path (which composes
+/// plan + commit via `rewrite_prepare_eth_from_parts` below) is unchanged.
+#[inline]
+fn rewrite_commit_eth_from_plan(
+    area: &MmapArea,
+    desc: XdpDesc,
+    plan: &EthRewritePlan,
+    params: &RewriteEthParams,
+) -> Option<()> {
+    let l3 = plan.l3;
+    let payload_len = plan.payload_len;
+    let eth_len = plan.prep.eth_len;
+    let frame_len = plan.prep.frame_len;
+    let tx_offset = plan.prep.tx_offset;
 
     if matches!(
-        l2_rewrite,
+        plan.prep.l2_rewrite,
         InPlaceL2Rewrite::VlanPushMemmoveNoHeadroom | InPlaceL2Rewrite::UnsupportedMemmove
     ) {
         let frame_size = UMEM_FRAME_SIZE as u64;
@@ -552,6 +614,12 @@ fn rewrite_prepare_eth_from_parts(
         if frame_len > frame.len() || source_end > frame.len() {
             return None;
         }
+        // NOTE: the two `?` below (get_mut, write_eth_header_slice) run AFTER
+        // this copy_within, but they cannot fail: frame.len() >= frame_len >=
+        // eth_len, and write_eth_header_slice only rejects a buffer shorter
+        // than eth_len. All fallible geometry checks are above this line, so
+        // the transactional guarantee (no mutation before a possible None)
+        // holds — the sole mutation past a possible None is unreachable.
         frame.copy_within(l3..source_end, eth_len);
         write_eth_header_slice(
             frame.get_mut(..eth_len)?,
@@ -570,19 +638,19 @@ fn rewrite_prepare_eth_from_parts(
             params.ether_type,
         )?;
     }
-    // Fabric-ingress packets already had TTL decremented by the
-    // sending peer (FABRIC_INGRESS_FLAG = 0x80).
-    let skip_ttl = (meta.meta_flags & 0x80) != 0;
-    Some(RewritePrep {
-        eth_len,
-        ip_start: eth_len,
-        frame_len,
-        tx_offset,
-        l2_rewrite,
-        apply_nat: params.apply_nat,
-        skip_ttl,
-        vlan_id: params.vlan_id,
-    })
+    Some(())
+}
+
+#[inline]
+fn rewrite_prepare_eth_from_parts(
+    area: &MmapArea,
+    desc: XdpDesc,
+    meta: ForwardPacketMeta,
+    params: RewriteEthParams,
+) -> Option<RewritePrep> {
+    let plan = rewrite_plan_eth_from_parts(area, desc, meta, &params)?;
+    rewrite_commit_eth_from_plan(area, desc, &plan, &params)?;
+    Some(plan.prep)
 }
 
 #[inline]

--- a/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
@@ -388,12 +388,21 @@ fn pin_packet(v6: bool, protocol: u8, ttl: u8, ext: Vec<ExtHdr>) -> ValidPacket 
     })
 }
 
-/// (a) TTL/hop-limit ≤ 1 → BOTH paths decline with bytes from L3
-/// onward untouched. The L2 header IS legitimately scribbled — both
-/// paths write the Ethernet header during `rewrite_prepare_eth*`
-/// BEFORE TTL validation (frame/mod.rs:403/413 via mod.rs:581,
-/// rewrite/mod.rs:56); harmless in production because the caller
-/// drops the frame on `None`.
+/// (a) TTL/hop-limit ≤ 1 → both paths decline.
+///
+/// The GENERIC path (`rewrite_forwarded_frame_in_place`) is the TERMINAL
+/// fallback: it writes the Ethernet header during `rewrite_prepare_eth`
+/// BEFORE its TTL validation, so its L2 header IS scribbled on decline —
+/// harmless because nothing reprocesses the frame after the terminal
+/// `None`. Hence the generic assertion checks L3+ only.
+///
+/// The DESCRIPTOR path is now TRANSACTIONAL (#5466): its bail gates run
+/// against the pristine frame BEFORE `rewrite_commit_eth_from_plan`
+/// mutates anything, so a `None` return leaves the ENTIRE frame (L2
+/// included) byte-identical — required because the caller chains
+/// `apply_rewrite_descriptor(...).or_else(generic)` and a scribbled L2 /
+/// shifted payload would corrupt the generic reprocessing. The descriptor
+/// assertion therefore checks the full frame (FAIL-ON-REVERT for #5466).
 #[test]
 fn pin_ttl_expired_declines_l3_untouched() {
     for v6 in [false, true] {
@@ -429,14 +438,21 @@ fn pin_ttl_expired_declines_l3_untouched() {
             "descriptor path must decline TTL≤1 (v6={v6})"
         );
         let after = area.slice(DIFF_ADDR, pkt.frame.len()).unwrap();
-        assert_eq!(&after[pkt.l3..], &pkt.frame[pkt.l3..]);
+        assert_eq!(
+            after,
+            &pkt.frame[..],
+            "descriptor TTL decline must be transactional (#5466): \
+             full frame byte-identical, incl. L2 (v6={v6})"
+        );
     }
 }
 
-/// (b) Descriptor port-mismatch (DMA-race guard, rewrite/ipv4.rs:36)
-/// → `None` with L3+ untouched. The generic path treats expected
-/// ports differently (post-NAT enforce) — that is exactly why P-N3
-/// runs with `expected_ports = None`.
+/// (b) Descriptor port-mismatch (DMA-race guard,
+/// `validate_rewrite_descriptor_ipv4`) → `None` with the WHOLE frame
+/// byte-identical (#5466 transactional guarantee: the DMA-race gate runs
+/// before any UMEM mutation, so the eth header is NOT scribbled either).
+/// The generic path treats expected ports differently (post-NAT enforce)
+/// — that is exactly why P-N3 runs with `expected_ports = None`.
 #[test]
 fn pin_descriptor_port_mismatch_declines() {
     let pkt = pin_packet(false, PROTO_TCP, 64, Vec::new());
@@ -453,7 +469,153 @@ fn pin_descriptor_port_mismatch_declines() {
         "descriptor must decline on expected-port mismatch"
     );
     let after = area.slice(DIFF_ADDR, pkt.frame.len()).unwrap();
-    assert_eq!(&after[pkt.l3..], &pkt.frame[pkt.l3..]);
+    assert_eq!(
+        after,
+        &pkt.frame[..],
+        "descriptor port-mismatch decline must be transactional (#5466): \
+         full frame byte-identical, incl. L2"
+    );
+}
+
+/// #5466 FAIL-ON-REVERT (fragment): a descriptor rewrite that bails at
+/// the non-first-fragment gate must leave the ENTIRE frame byte-identical.
+/// Before the transactional split, `rewrite_prepare_eth` wrote the new
+/// Ethernet header BEFORE the fragment gate, so the caller's
+/// `.or_else(generic)` fallback reprocessed a scribbled frame. Reverting
+/// the fix (mutate before the gate) makes the full-frame assertion FAIL:
+/// the frame's L2 (DST_MAC/SRC_MAC) would be overwritten by the
+/// descriptor's distinct MACs.
+#[test]
+fn pin_5466_descriptor_fragment_decline_frame_untouched() {
+    let pkt = pin_packet(false, PROTO_TCP, 64, Vec::new()); // v4, l3 = 14
+    let l3 = pkt.l3;
+    let mut bytes = pkt.frame.clone();
+    // Turn the datagram into a NON-first IPv4 fragment: set the
+    // fragment-offset field (IP header bytes 6-7) to a nonzero offset.
+    // `ipv4_is_non_first_fragment` gates on `(frag_off & 0x1FFF) != 0`.
+    bytes[l3 + 6] = 0x00;
+    bytes[l3 + 7] = 0x10; // offset 0x10 → non-first fragment (MF/DF clear)
+    let before = bytes.clone();
+
+    let area = area_with_frame(&bytes);
+    let desc = XdpDesc {
+        addr: DIFF_ADDR as u64,
+        len: bytes.len() as u32,
+        options: 0,
+    };
+    // Descriptor MACs differ from the frame's DST_MAC/SRC_MAC, so a
+    // pre-gate eth write is detectable by the full-frame compare.
+    let rd = make_descriptor(&pkt, NatDecision::default(), 0);
+    assert!(
+        apply_rewrite_descriptor(&area, desc, pkt.meta, &rd, None).is_none(),
+        "descriptor must decline a non-first fragment"
+    );
+    let after = area.slice(DIFF_ADDR, bytes.len()).unwrap();
+    assert_eq!(
+        after,
+        &before[..],
+        "#5466: fragment decline must leave the full frame byte-identical (no eth scribble)"
+    );
+}
+
+/// #5466 FAIL-ON-REVERT (memmove — the worst manifestation): a VLAN push
+/// with no UMEM headroom takes the `copy_within` payload memmove path in
+/// `rewrite_commit_eth_from_plan`. If a bail gate ran AFTER that commit,
+/// the memmove would have SHIFTED the L3 payload and the generic fallback
+/// would reprocess doubly-shifted bytes — unrecoverable corruption. Here
+/// the descriptor bails at the fragment gate; the whole frame must stay
+/// byte-identical (no shift, no L2 scribble). Reverting the fix mutates
+/// (memmove + eth write) before the gate → RED.
+#[test]
+fn pin_5466_descriptor_vlan_push_memmove_decline_frame_untouched() {
+    let pkt = pin_packet(false, PROTO_TCP, 64, Vec::new()); // no VLAN → l3 = 14
+    let l3 = pkt.l3;
+    let mut bytes = pkt.frame.clone();
+    // Non-first fragment so the descriptor bails at the fragment gate.
+    bytes[l3 + 6] = 0x00;
+    bytes[l3 + 7] = 0x10;
+    let before = bytes.clone();
+
+    // Place the frame at a UMEM-frame boundary so a VLAN push (tx = rx - 4)
+    // leaves the current chunk → `VlanPushMemmoveNoHeadroom` → the commit
+    // would `copy_within`. FRAME_BASE == UMEM_FRAME_SIZE.
+    const FRAME_BASE: usize = 4096;
+    let mut area = MmapArea::new(8192).expect("mmap");
+    area.slice_mut(FRAME_BASE, bytes.len())
+        .expect("frame fits area")
+        .copy_from_slice(&bytes);
+    let desc = XdpDesc {
+        addr: FRAME_BASE as u64,
+        len: bytes.len() as u32,
+        options: 0,
+    };
+    // tx_vlan_id > 0 → target eth_len 18 → VLAN push (memmove, no headroom).
+    let rd = make_descriptor(&pkt, NatDecision::default(), 100);
+    assert!(
+        apply_rewrite_descriptor(&area, desc, pkt.meta, &rd, None).is_none(),
+        "descriptor must decline a non-first fragment on the vlan-push memmove path"
+    );
+    let after = area.slice(FRAME_BASE, bytes.len()).unwrap();
+    assert_eq!(
+        after,
+        &before[..],
+        "#5466: memmove-path decline must NOT shift the payload or scribble L2"
+    );
+}
+
+/// #5466 success control: a valid descriptor rewrite still succeeds and
+/// produces output byte-identical to the generic path — the transactional
+/// split must not change any success-path byte. Deterministic companion to
+/// the P-N3 `descriptor_generic_differential` proptest, covering v4, v6,
+/// and the VLAN-push (descriptor-view) success path.
+#[test]
+fn pin_5466_descriptor_success_matches_generic() {
+    for (v6, tx_vlan) in [(false, 0u16), (true, 0u16), (false, 100u16)] {
+        let pkt = pin_packet(v6, PROTO_TCP, 64, Vec::new());
+        let nat = NatDecision {
+            rewrite_src_port: Some(0x5a5a),
+            ..NatDecision::default()
+        };
+        let desc = XdpDesc {
+            addr: DIFF_ADDR as u64,
+            len: pkt.frame.len() as u32,
+            options: 0,
+        };
+
+        let area_g = area_with_frame(&pkt.frame);
+        let generic = rewrite_forwarded_frame_in_place(
+            &area_g,
+            desc,
+            pkt.meta,
+            &make_decision(&pkt, nat, tx_vlan),
+            false,
+            None,
+        )
+        .expect("generic rewrite must succeed");
+
+        let area_d = area_with_frame(&pkt.frame);
+        let fast = apply_rewrite_descriptor(
+            &area_d,
+            desc,
+            pkt.meta,
+            &make_descriptor(&pkt, nat, tx_vlan),
+            None,
+        )
+        .expect("descriptor rewrite must succeed (#5466 success path intact)");
+
+        assert_eq!(
+            generic, fast,
+            "InPlaceRewriteResult must agree (v6={v6}, vlan={tx_vlan})"
+        );
+        let out_g = area_g
+            .slice(generic.offset as usize, generic.len as usize)
+            .unwrap();
+        let out_d = area_d.slice(fast.offset as usize, fast.len as usize).unwrap();
+        assert_eq!(
+            out_g, out_d,
+            "descriptor success output must be byte-identical to generic (v6={v6}, vlan={tx_vlan})"
+        );
+    }
 }
 
 /// (c) NAT64 descriptors decline BEFORE the eth prep (rewrite/mod.rs)

--- a/userspace-dp/src/afxdp/frame/rewrite/ipv4.rs
+++ b/userspace-dp/src/afxdp/frame/rewrite/ipv4.rs
@@ -1,9 +1,14 @@
 //! IPv4 arm of `apply_rewrite_descriptor`.
 //!
-//! Body is byte-identical to the `0x0800` match arm at
-//! `frame/mod.rs:937..1037` before this split. The orchestrator at
-//! `frame/rewrite/mod.rs` validates `RewriteEthParams` via
-//! `rewrite_prepare_eth_from_parts`, then dispatches here.
+//! Split into a read-only `validate_rewrite_descriptor_ipv4` (all
+//! None-returning bail gates) and an infallible
+//! `apply_rewrite_descriptor_ipv4` (mutation only). #5466 requires the
+//! gates to run against the PRISTINE frame BEFORE the eth-header write /
+//! VLAN-push memmove commit, so the orchestrator calls `validate_*` on
+//! the original L3 payload and only calls `apply_*` after the commit —
+//! keeping the rewrite transactional (no UMEM mutation before a possible
+//! `None`). The apply body is byte-identical to the pre-split mutation
+//! block, so the success-path output is unchanged.
 
 use super::super::byte_writes::{
     write_ipv4_dst, write_ipv4_src, write_l4_dst_port, write_l4_src_port,
@@ -12,39 +17,61 @@ use crate::afxdp::{RewriteDescriptor, UserspaceDpMeta, PROTO_TCP, PROTO_UDP};
 use crate::ip_proto::has_l4_ports;
 use std::net::IpAddr;
 
+/// Read-only bail gates for the IPv4 descriptor rewrite. `l3_payload` is
+/// the frame from the L3 offset onward (`&frame[ip..ip + payload_len]`),
+/// so all length checks and byte reads are relative to offset 0 — this
+/// makes the gate decisions identical whether run on the ORIGINAL frame
+/// (pre-commit, at `plan.l3`) or the committed TX frame (at `eth_len`),
+/// because the commit's memmove is a pure relocation. Returns the L4
+/// offset relative to the IP header (the IHL) on success; `None` on any
+/// bail (header too short, TTL expired, DMA-race port mismatch).
 #[inline(always)]
-pub(in crate::afxdp::frame) fn apply_rewrite_descriptor_ipv4(
-    packet: &mut [u8],
-    ip: usize,
+pub(in crate::afxdp::frame) fn validate_rewrite_descriptor_ipv4(
+    l3_payload: &[u8],
     skip_ttl: bool,
-    apply_nat: bool,
     meta: UserspaceDpMeta,
-    rd: &RewriteDescriptor,
     expected_ports: Option<(u16, u16)>,
-) -> Option<()> {
-    if packet.len() < ip + 20 {
+) -> Option<usize> {
+    if l3_payload.len() < 20 {
         return None;
     }
-    let ihl = ((packet[ip] & 0x0f) as usize) * 4;
-    if ihl < 20 || packet.len() < ip + ihl {
+    let ihl = ((l3_payload[0] & 0x0f) as usize) * 4;
+    if ihl < 20 || l3_payload.len() < ihl {
         return None;
     }
-    if !skip_ttl && packet[ip + 8] <= 1 {
+    if !skip_ttl && l3_payload[8] <= 1 {
         return None; // TTL expired
     }
-    let l4 = ip + ihl;
 
     // Port validation (DMA race guard).
     // If ports don't match, fall back to generic path for repair.
     if let Some((exp_src, exp_dst)) = expected_ports {
-        if matches!(meta.protocol, PROTO_TCP | PROTO_UDP) && packet.len() >= l4 + 4 {
-            let cur_src = u16::from_be_bytes([packet[l4], packet[l4 + 1]]);
-            let cur_dst = u16::from_be_bytes([packet[l4 + 2], packet[l4 + 3]]);
+        if matches!(meta.protocol, PROTO_TCP | PROTO_UDP) && l3_payload.len() >= ihl + 4 {
+            let cur_src = u16::from_be_bytes([l3_payload[ihl], l3_payload[ihl + 1]]);
+            let cur_dst = u16::from_be_bytes([l3_payload[ihl + 2], l3_payload[ihl + 3]]);
             if cur_src != exp_src || cur_dst != exp_dst {
                 return None;
             }
         }
     }
+    Some(ihl)
+}
+
+/// Infallible mutation half of the IPv4 descriptor rewrite. MUST be called
+/// only after `validate_rewrite_descriptor_ipv4` cleared the gates; `rel_l4`
+/// is that call's return (the IHL). No path returns `None` — every write is
+/// bounds-safe given the validated `packet.len() >= ip + rel_l4` layout.
+#[inline(always)]
+pub(in crate::afxdp::frame) fn apply_rewrite_descriptor_ipv4(
+    packet: &mut [u8],
+    ip: usize,
+    rel_l4: usize,
+    skip_ttl: bool,
+    apply_nat: bool,
+    meta: UserspaceDpMeta,
+    rd: &RewriteDescriptor,
+) {
+    let l4 = ip + rel_l4;
 
     // NAT: direct byte writes for IP addresses (#963 PR-B
     // helpers). Caller-side `if let Some(IpAddr::V4(_))`
@@ -128,5 +155,4 @@ pub(in crate::afxdp::frame) fn apply_rewrite_descriptor_ipv4(
             }
         }
     }
-    Some(())
 }

--- a/userspace-dp/src/afxdp/frame/rewrite/ipv6.rs
+++ b/userspace-dp/src/afxdp/frame/rewrite/ipv6.rs
@@ -1,9 +1,12 @@
 //! IPv6 arm of `apply_rewrite_descriptor`.
 //!
-//! Body is byte-identical to the `0x86dd` match arm at
-//! `frame/mod.rs:1038..1115` before this split. The orchestrator at
-//! `frame/rewrite/mod.rs` validates `RewriteEthParams` via
-//! `rewrite_prepare_eth_from_parts`, then dispatches here.
+//! Split into a read-only `validate_rewrite_descriptor_ipv6` (all
+//! None-returning bail gates, including the `v6_rel_l4_offset`
+//! extension-header walk) and an infallible
+//! `apply_rewrite_descriptor_ipv6` (mutation only). #5466 requires the
+//! gates to run against the PRISTINE frame BEFORE the eth-header write /
+//! VLAN-push memmove commit. The apply body is byte-identical to the
+//! pre-split mutation block, so success-path output is unchanged.
 
 use super::super::byte_writes::{
     write_ipv6_dst, write_ipv6_src, write_l4_dst_port, write_l4_src_port,
@@ -16,40 +19,63 @@ use crate::afxdp::{
 use crate::ip_proto::has_l4_ports;
 use std::net::IpAddr;
 
+/// Read-only bail gates for the IPv6 descriptor rewrite. `l3_payload` is
+/// the frame from the L3 offset onward (`&frame[ip..ip + payload_len]`),
+/// so every check is relative to offset 0 and yields identical decisions
+/// whether run on the ORIGINAL frame (pre-commit) or the committed TX
+/// frame (the commit's memmove is a pure relocation). Returns the L4
+/// offset relative to the IP header on success; `None` on any bail (header
+/// too short, hop-limit expired, unparseable L4 offset, DMA-race port
+/// mismatch).
 #[inline(always)]
-pub(in crate::afxdp::frame) fn apply_rewrite_descriptor_ipv6(
-    packet: &mut [u8],
-    ip: usize,
+pub(in crate::afxdp::frame) fn validate_rewrite_descriptor_ipv6(
+    l3_payload: &[u8],
     skip_ttl: bool,
-    apply_nat: bool,
     meta: UserspaceDpMeta,
-    rd: &RewriteDescriptor,
     expected_ports: Option<(u16, u16)>,
-) -> Option<()> {
+) -> Option<usize> {
     // No IP header checksum; only L4 pseudo-header changes matter.
-    if packet.len() < ip + 40 {
+    if l3_payload.len() < 40 {
         return None;
     }
-    if !skip_ttl && packet[ip + 7] <= 1 {
+    if !skip_ttl && l3_payload[7] <= 1 {
         return None; // Hop limit expired
     }
 
     // L4 offset from metadata or by parsing extension headers — the
     // shared `v6_rel_l4_offset` helper (#1838) keeps this precedence
     // rule structurally identical to the generic path's.
-    let rel_l4 = v6_rel_l4_offset(&packet[ip..], meta.l3_offset, meta.l4_offset, meta.addr_family)?;
-    let l4 = ip + rel_l4;
+    let rel_l4 =
+        v6_rel_l4_offset(l3_payload, meta.l3_offset, meta.l4_offset, meta.addr_family)?;
 
     // Port validation (DMA race guard).
     if let Some((exp_src, exp_dst)) = expected_ports {
-        if matches!(meta.protocol, PROTO_TCP | PROTO_UDP) && packet.len() >= l4 + 4 {
-            let cur_src = u16::from_be_bytes([packet[l4], packet[l4 + 1]]);
-            let cur_dst = u16::from_be_bytes([packet[l4 + 2], packet[l4 + 3]]);
+        if matches!(meta.protocol, PROTO_TCP | PROTO_UDP) && l3_payload.len() >= rel_l4 + 4 {
+            let cur_src = u16::from_be_bytes([l3_payload[rel_l4], l3_payload[rel_l4 + 1]]);
+            let cur_dst = u16::from_be_bytes([l3_payload[rel_l4 + 2], l3_payload[rel_l4 + 3]]);
             if cur_src != exp_src || cur_dst != exp_dst {
                 return None;
             }
         }
     }
+    Some(rel_l4)
+}
+
+/// Infallible mutation half of the IPv6 descriptor rewrite. MUST be called
+/// only after `validate_rewrite_descriptor_ipv6` cleared the gates; `rel_l4`
+/// is that call's return. No path returns `None` — every write is bounds-safe
+/// given the validated `packet.len() >= ip + 40` / `>= ip + rel_l4` layout.
+#[inline(always)]
+pub(in crate::afxdp::frame) fn apply_rewrite_descriptor_ipv6(
+    packet: &mut [u8],
+    ip: usize,
+    rel_l4: usize,
+    skip_ttl: bool,
+    apply_nat: bool,
+    meta: UserspaceDpMeta,
+    rd: &RewriteDescriptor,
+) {
+    let l4 = ip + rel_l4;
 
     // NAT: direct byte writes for IPv6 addresses (#963 PR-B).
     if apply_nat {
@@ -111,5 +137,4 @@ pub(in crate::afxdp::frame) fn apply_rewrite_descriptor_ipv6(
             packet[l4_csum_off..l4_csum_off + 2].copy_from_slice(&final_csum.to_be_bytes());
         }
     }
-    Some(())
 }

--- a/userspace-dp/src/afxdp/frame/rewrite/mod.rs
+++ b/userspace-dp/src/afxdp/frame/rewrite/mod.rs
@@ -17,12 +17,12 @@
 mod ipv4;
 mod ipv6;
 
-use ipv4::apply_rewrite_descriptor_ipv4;
-use ipv6::apply_rewrite_descriptor_ipv6;
+use ipv4::{apply_rewrite_descriptor_ipv4, validate_rewrite_descriptor_ipv4};
+use ipv6::{apply_rewrite_descriptor_ipv6, validate_rewrite_descriptor_ipv6};
 
 use super::{
-    is_non_first_fragment, rewrite_prepare_eth_from_parts, verify_built_frame_checksums,
-    InPlaceRewriteResult, RewriteEthParams,
+    is_non_first_fragment, rewrite_commit_eth_from_plan, rewrite_plan_eth_from_parts,
+    verify_built_frame_checksums, InPlaceRewriteResult, RewriteEthParams,
 };
 use crate::afxdp::{MmapArea, RewriteDescriptor, UserspaceDpMeta, XdpDesc};
 
@@ -70,56 +70,71 @@ pub(in crate::afxdp) fn apply_rewrite_descriptor(
         return None;
     }
 
-    let prep = rewrite_prepare_eth_from_parts(
-        area,
-        desc,
-        meta.into(),
-        RewriteEthParams {
-            dst_mac: rd.dst_mac,
-            src_mac: rd.src_mac,
-            vlan_id: rd.tx_vlan_id,
-            ether_type: rd.ether_type,
-            apply_nat: !rd.fabric_redirect || rd.apply_nat_on_fabric,
-        },
-    )?;
-    let packet = unsafe { area.slice_mut_unchecked(prep.tx_offset as usize, prep.frame_len)? };
-    let frame_len = prep.frame_len;
-    let ip = prep.ip_start;
-    let skip_ttl = prep.skip_ttl;
-    let apply_nat = prep.apply_nat;
+    let eth_params = RewriteEthParams {
+        dst_mac: rd.dst_mac,
+        src_mac: rd.src_mac,
+        vlan_id: rd.tx_vlan_id,
+        ether_type: rd.ether_type,
+        apply_nat: !rd.fabric_redirect || rd.apply_nat_on_fabric,
+    };
 
-    // #1852: the descriptor fast path applies a precomputed L4-checksum
-    // delta (rd.l4_csum_delta) and inline port writes at the L4 offset,
-    // both of which would corrupt a non-first fragment's payload. Rather
-    // than re-derive the precomputed deltas for the IP-only case, fall
-    // back to the generic path (`rewrite_forwarded_frame_in_place` via
-    // the caller's `.or_else(...)`), which carries the leaf-level
-    // fragment gate. Returning None here preserves the #1838 P-N3
-    // descriptor-vs-generic byte parity (the generic path becomes the
-    // single source of truth for fragments).
-    if ip < packet.len() && is_non_first_fragment(&packet[ip..], meta.addr_family) {
-        return None;
-    }
+    // #5466: make the descriptor rewrite transactional. Compute the eth
+    // rewrite plan WITHOUT mutating UMEM, then run every bail gate
+    // (non-first-fragment, header length, TTL/hop-limit, DMA-race port
+    // mismatch) against the PRISTINE frame. `rewrite_commit_eth_from_plan`
+    // mutates the buffer (eth-header write + VLAN-push memmove), so any gate
+    // that can still return `None` MUST run before the commit — otherwise
+    // the caller's `.or_else(generic-rewrite)` fallback reprocesses a frame
+    // we already clobbered (corrupt eth header / shifted payload). The gates
+    // read the ORIGINAL L3 payload at `plan.l3`; because the commit's memmove
+    // is a pure relocation and the eth-header write never touches the L3/L4
+    // region, these decisions are byte-identical to the post-commit checks
+    // they replace, and `validate_*` returns the L4 offset the infallible
+    // `apply_*` mutation half needs.
+    let plan = rewrite_plan_eth_from_parts(area, desc, meta.into(), &eth_params)?;
+    let skip_ttl = plan.prep.skip_ttl;
+    let apply_nat = plan.prep.apply_nat;
+
+    let rel_l4 = {
+        let frame = area.slice(desc.addr as usize, desc.len as usize)?;
+        let l3_end = plan.l3.checked_add(plan.payload_len)?;
+        let l3_payload = frame.get(plan.l3..l3_end)?;
+        // #1852: the descriptor fast path applies a precomputed L4-checksum
+        // delta and inline port writes at the L4 offset, both of which would
+        // corrupt a non-first fragment's payload. Defer to the generic path
+        // (`rewrite_forwarded_frame_in_place` via the caller's
+        // `.or_else(...)`), which carries the leaf-level fragment gate. This
+        // preserves the #1838 P-N3 descriptor-vs-generic byte parity (the
+        // generic path is the single source of truth for fragments).
+        if !l3_payload.is_empty() && is_non_first_fragment(l3_payload, meta.addr_family) {
+            return None;
+        }
+        match rd.ether_type {
+            0x0800 => {
+                validate_rewrite_descriptor_ipv4(l3_payload, skip_ttl, meta, expected_ports)?
+            }
+            0x86dd => {
+                validate_rewrite_descriptor_ipv6(l3_payload, skip_ttl, meta, expected_ports)?
+            }
+            _ => return None,
+        }
+    };
+
+    // All gates cleared: commit the eth rewrite (first UMEM mutation). From
+    // here NO path returns None — the commit's remaining fallible checks are
+    // frame-geometry checks decided by the plan, and the `apply_*` halves are
+    // infallible (validation already proved the byte layout).
+    rewrite_commit_eth_from_plan(area, desc, &plan, &eth_params)?;
+    let packet = unsafe {
+        area.slice_mut_unchecked(plan.prep.tx_offset as usize, plan.prep.frame_len)?
+    };
+    let frame_len = plan.prep.frame_len;
+    let ip = plan.prep.ip_start;
 
     match rd.ether_type {
-        0x0800 => apply_rewrite_descriptor_ipv4(
-            packet,
-            ip,
-            skip_ttl,
-            apply_nat,
-            meta,
-            rd,
-            expected_ports,
-        )?,
-        0x86dd => apply_rewrite_descriptor_ipv6(
-            packet,
-            ip,
-            skip_ttl,
-            apply_nat,
-            meta,
-            rd,
-            expected_ports,
-        )?,
+        0x0800 => apply_rewrite_descriptor_ipv4(packet, ip, rel_l4, skip_ttl, apply_nat, meta, rd),
+        0x86dd => apply_rewrite_descriptor_ipv6(packet, ip, rel_l4, skip_ttl, apply_nat, meta, rd),
+        // Unreachable: `rd.ether_type` was validated above before the commit.
         _ => return None,
     }
 
@@ -128,8 +143,8 @@ pub(in crate::afxdp) fn apply_rewrite_descriptor(
         verify_built_frame_checksums(&packet[..frame_len]);
     }
     Some(InPlaceRewriteResult {
-        offset: prep.tx_offset,
+        offset: plan.prep.tx_offset,
         len: frame_len as u32,
-        l2_rewrite: prep.l2_rewrite,
+        l2_rewrite: plan.prep.l2_rewrite,
     })
 }


### PR DESCRIPTION
## Problem (#5466)

`apply_rewrite_descriptor` (`userspace-dp/src/afxdp/frame/rewrite/mod.rs`) was **not transactional**. It called `rewrite_prepare_eth_from_parts`, which **mutates the UMEM frame** — `write_eth_header_slice` (always) and, on the VLAN-push-no-headroom / unsupported path, a payload `frame.copy_within(...)` memmove (`frame/mod.rs`) — and only **after** that did the orchestrator hit gates that can still return `None`:

- the non-first-fragment gate, and
- the DMA-race port-mismatch guards in the v4/v6 arms.

The flow-cache caller chains:

```rust
apply_rewrite_descriptor(...).or_else(|| rewrite_forwarded_frame_in_place(...))
```

So when `apply_rewrite_descriptor` returned `None` **after** `prepare_eth` had already rewritten the eth header / shifted the payload, the generic `.or_else` fallback reprocessed a **corrupted frame** → wrong bytes on the wire / checksum corruption / mis-forwarded packet.

## Fix — plan-then-commit split

Decide "can this descriptor rewrite proceed?" fully, then mutate.

- **`frame/mod.rs`**: `rewrite_prepare_eth_from_parts` splits into `rewrite_plan_eth_from_parts` (read-only: L3 offset, payload length, eth length, TX view, L2 classification) + `rewrite_commit_eth_from_plan` (eth-header write + memmove). The old name now composes the two, so the **generic path is unchanged**.
- **`rewrite/ipv4.rs`, `rewrite/ipv6.rs`**: each arm splits into a read-only `validate_rewrite_descriptor_*` (all None-returning gates — header length, TTL/hop-limit, DMA-race port mismatch; returns the L4 offset) + an **infallible** `apply_rewrite_descriptor_*` (mutation only).
- **`rewrite/mod.rs`**: plan (no mutation) → run the fragment gate + family validation against the **pristine** L3 payload at `plan.l3` → only then commit → apply.

### Byte-identical success path
The gates read the original L3 payload and use the plan's `frame_len`/`payload_len` for length checks. Because the commit's memmove is a **pure relocation** and the eth-header write never touches the L3/L4 region, the gate decisions are byte-identical to the pre-#5466 post-commit checks, and the infallible apply half reproduces the prior mutation block verbatim. Guarded by the existing P-N3 descriptor-vs-generic differential plus new deterministic pins.

## Validation

- `cargo build` clean.
- `cargo test --release rewrite`: **88 passed, 0 failed**.
- Full `cargo test --release`: **3979 passed, 0 failed**.
- **Fail-on-revert (firsthand)**: reordering the commit before the gates turns all four decline pins RED on the full-frame byte-identity assertion:
  - `pin_5466_descriptor_fragment_decline_frame_untouched`
  - `pin_5466_descriptor_vlan_push_memmove_decline_frame_untouched` (proves the payload memmove is not applied on a bail)
  - `pin_descriptor_port_mismatch_declines`
  - `pin_ttl_expired_declines_l3_untouched`
- **Cluster smoke DEFERRED**: the verify-dataplane cpumap false-rejection (#5364) blocks loss-cluster deploys. This is a frame-transactionality logic fix gated on the cargo RED-on-revert pins.

Closes #5466

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJL7kGyUPyKJ6RDGVAPAz3