### PR TITLE
nat: scope pre-routing DNAT on logical VLAN unit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-17 — #5802: pre-routing NAT scope keys on the LOGICAL VLAN unit, not the physical bind ifindex
+
+- **Timestamp**: 2026-07-17 (fix/5802-vlan-prerouting-nat-scope-logical)
+- **Action**: The inbound DNAT / static-NAT / NPTv6 pre-routing scope lookups
+  in `poll_binding_process_descriptor` (userspace-dp/src/afxdp/poll_descriptor/
+  mod.rs) derived `ingress_zone_name` / `ingress_ifname_dnat` / `ingress_ri_dnat`
+  from the PHYSICAL AF_XDP bind ifindex (`meta.ingress_ifindex`). On a trunk the
+  parent physical netdev carries every VLAN unit's frames, and
+  `ifindex_to_zone_id` / `ifindex_to_config_name` / `ifindex_to_routing_instance`
+  are keyed by the LOGICAL unit ifindex (the physical parent maps only to its
+  FIRST unit), so a packet on one VLAN unit could match (or miss) a scoped NAT
+  rule using the parent/first-unit identity — applying or skipping translation
+  OUTSIDE the configured `from zone` / `from interface` / `from routing-instance`
+  boundary, before the correct logical zone policy ran (a NAT scope-escape). The
+  same miss path LATER resolves the logical VLAN identity for zone-policy /
+  filter / CoS (#3021), so the correct identity was computed but not used for the
+  earlier pre-routing scope. Fix: extract `prerouting_ingress_scope`, which
+  resolves the logical unit via `resolve_ingress_logical_ifindex((bind ifindex,
+  VLAN id))` and reads the zone / config-name / routing-instance from it; the
+  pre-routing site consumes it and threads the resolved `logical_ifindex` into
+  the later zone-pair policy so both sites share ONE ingress identity (no
+  recompute). A fabric-encoded zone override still wins first (unchanged). An
+  untagged port has no `(parent, VLAN)` mapping → logical == physical →
+  byte-identical. Added three RED-on-revert cargo tests
+  (`prerouting_scope_tests`): a zone-scoped DNAT (wrong-APPLY escape), an
+  interface-scoped static DNAT (wrong-SKIP escape), and a non-VLAN control.
+  Reverting the scope to the physical parent makes the two escape tests RED
+  (`left: 11, right: 12` on `logical_ifindex`; `left: "", right: "reth0.50"` on
+  the ifname); the non-VLAN control stays green.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  docs/userspace-dataplane-architecture.md, _Log.md
+- **Validation**: `cargo build` clean; `cargo test --release nat` green (726
+  passed); full `cargo test --release` green except the known pre-existing
+  parallel flake `wg_encap_frame_resolves_outer_route_once_v4` (passes isolated).
+  RED-on-revert captured verbatim. Loss-cluster smoke DEFERRED — cargo covers
+  the logical-scope selection; a VLAN-trunk per-zone NAT cluster test is a
+  possible later add.
+
 ## 2026-07-17 — #5447: NAT64 frag-assoc install prunes EXPIRED before evicting a LIVE entry
 
 - **Timestamp**: 2026-07-17 (fix/5447-nat64-frag-prune-before-evict)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -962,6 +962,27 @@ inbound traffic, the Go compiler validates static-NAT `from-zone` references
 against the defined zones at commit and warns on an undefined zone (mirroring
 the source-NAT zone validation). Junos static NAT has no `to` clause.
 
+**Pre-routing scope keys on the LOGICAL VLAN unit (#5802, security).** The
+inbound DNAT / static-NAT / NPTv6 pre-routing lookups run before the FIB/zone
+lookup, and their `from zone` / `from interface` / `from routing-instance`
+scope is matched against the INGRESS identity — the zone name, config-interface
+name, and routing-instance of the unit that received the frame. That identity
+MUST be the LOGICAL VLAN unit, not the physical AF_XDP bind interface. On a
+trunk the parent physical netdev carries every VLAN unit's frames (see *VLAN
+unit AF_XDP binding target*), and `ifindex_to_zone_id` /
+`ifindex_to_config_name` / `ifindex_to_routing_instance` are keyed by the
+logical unit ifindex — the physical parent maps only to its FIRST unit. The
+pre-routing site resolves the logical unit via `prerouting_ingress_scope`
+(`poll_descriptor/mod.rs`, using `resolve_ingress_logical_ifindex` on the
+`(bind ifindex, VLAN id)` key), the SAME identity the later zone-pair policy /
+input-filter / CoS path uses (#3021). Before #5802 the scope was taken from the
+raw physical `meta.ingress_ifindex`, so on a trunk whose units sit in distinct
+zones / interfaces / routing-instances a packet on one unit could match another
+unit's scoped NAT rule (or miss its own) — applying or skipping translation
+outside the configured `from` boundary, ahead of the correct logical zone
+policy (a NAT scope-escape). An untagged port has no `(parent, VLAN)` mapping,
+so it resolves logical == physical and the scope is byte-identical to pre-#5802.
+
 #### Slow Path (`slowpath.rs`)
 
 A TUN device (`xpf-usp0`) for packets that need kernel processing:

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -682,6 +682,88 @@ fn strict_syn_check_drops_new_flow(protocol: u8, tcp_flags: u8) -> bool {
         && !crate::tcp_flags::has_syn(tcp_flags)
 }
 
+/// #5802: the ingress identity the pre-routing DNAT / static-NAT / NPTv6
+/// scope matches `from zone` / `from interface` / `from routing-instance`
+/// against, resolved from the LOGICAL VLAN unit that received the frame.
+///
+/// The borrowed `&str` fields live for the `forwarding` borrow; `""` = no
+/// scope constraint (unscoped rule, matches every ingress).
+pub(super) struct PreroutingIngressScope<'a> {
+    /// The logical unit ingress ifindex (VLAN sub-interface), or the physical
+    /// bind ifindex for an untagged port. Threaded into the later zone-pair
+    /// policy so the pre-routing NAT scope and the zone policy share ONE
+    /// ingress identity.
+    pub logical_ifindex: i32,
+    /// Ingress zone name (a fabric-encoded override wins, else the logical
+    /// unit's zone).
+    pub zone_name: &'a str,
+    /// Ingress interface config name (e.g. `reth0.50`).
+    pub ifname: &'a str,
+    /// Ingress interface routing-instance (`""` = default VRF).
+    pub routing_instance: &'a str,
+}
+
+/// Resolve the pre-routing NAT scope identity for a received frame.
+///
+/// `ifindex_to_zone_id` / `ifindex_to_config_name` /
+/// `ifindex_to_routing_instance` are keyed by the LOGICAL unit ifindex
+/// (forwarding_build/interfaces.rs); a VLAN sub-interface's physical bind
+/// ifindex maps only to its parent's FIRST unit. #5802: scoping the
+/// pre-routing DNAT/static-NAT/NPTv6 lookups against the raw physical
+/// `meta.ingress_ifindex` on a trunk whose VLAN units sit in distinct zones /
+/// interfaces / routing-instances let a packet on one unit match another
+/// unit's scoped NAT rule (or miss its own) — a NAT scope-escape ahead of the
+/// correct logical zone policy. This resolves the logical unit first (the same
+/// identity the zone-policy / filter / CoS path uses, #3021) and reads the
+/// scope from it. An untagged port has no `(parent, vlan)` mapping, so it
+/// resolves logical == physical and the scope is byte-identical to pre-#5802.
+///
+/// The zone matches a fabric-ingress `zone_override` (peer-encoded) first,
+/// exactly as the pre-#5802 code did; only the physical→logical ifindex used
+/// for the local-unit fallback lookups changes.
+pub(super) fn prerouting_ingress_scope(
+    forwarding: &ForwardingState,
+    physical_ifindex: i32,
+    ingress_vlan_id: u16,
+    zone_override: Option<u16>,
+) -> PreroutingIngressScope<'_> {
+    let logical_ifindex =
+        resolve_ingress_logical_ifindex(forwarding, physical_ifindex, ingress_vlan_id)
+            .unwrap_or(physical_ifindex);
+    // #919: ingress_zone_override is Option<u16>; DNAT/static NAT lookups take
+    // zone names, so resolve ID→name lazily on this miss path. A fabric-encoded
+    // override wins; else resolve the LOGICAL unit's zone (#5802).
+    let zone_name = zone_override
+        .and_then(|id| forwarding.zone_id_to_name.get(&id).map(|s| s.as_str()))
+        .or_else(|| {
+            forwarding
+                .ifindex_to_zone_id
+                .get(&logical_ifindex)
+                .and_then(|id| forwarding.zone_id_to_name.get(id))
+                .map(|s| s.as_str())
+        })
+        .unwrap_or("");
+    // #3096: ingress interface config-name + routing-instance for the DNAT
+    // `from interface` / `from routing-instance` scope. DNAT translates on
+    // inbound, so only the ingress identity matters. Empty = unscoped.
+    let ifname = forwarding
+        .ifindex_to_config_name
+        .get(&logical_ifindex)
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    let routing_instance = forwarding
+        .ifindex_to_routing_instance
+        .get(&logical_ifindex)
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    PreroutingIngressScope {
+        logical_ifindex,
+        zone_name,
+        ifname,
+        routing_instance,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn poll_binding_process_descriptor(
     binding: &mut BindingWorker,
@@ -1537,44 +1619,34 @@ pub(super) fn poll_binding_process_descriptor(
                         // Check DNAT table first (port-based DNAT), then
                         // fall back to static NAT DNAT (IP-only 1:1).
                         // The translated destination affects FIB lookup.
-                        // #919: ingress_zone_override is now Option<u16>;
-                        // DNAT/static NAT lookups still take zone names,
-                        // so resolve ID→name lazily on this miss path.
-                        let ingress_zone_name = ingress_zone_override
-                            .and_then(|id| {
-                                worker_ctx
-                                    .forwarding
-                                    .zone_id_to_name
-                                    .get(&id)
-                                    .map(|s| s.as_str())
-                            })
-                            .or_else(|| {
-                                // #921: ifindex → u16 → name (slow path; DNAT/static-NAT
-                                // takes &str names).
-                                worker_ctx
-                                    .forwarding
-                                    .ifindex_to_zone_id
-                                    .get(&(meta.ingress_ifindex as i32))
-                                    .and_then(|id| worker_ctx.forwarding.zone_id_to_name.get(id))
-                                    .map(|s| s.as_str())
-                            })
-                            .unwrap_or("");
-                        // #3096: ingress interface config-name + routing-instance
-                        // for the DNAT `from interface` / `from routing-instance`
-                        // scope. DNAT translates on inbound, so only the ingress
-                        // identity matters here. Empty = unscoped (pre-#3096).
-                        let ingress_ifname_dnat: &str = worker_ctx
-                            .forwarding
-                            .ifindex_to_config_name
-                            .get(&(meta.ingress_ifindex as i32))
-                            .map(|s| s.as_str())
-                            .unwrap_or("");
-                        let ingress_ri_dnat: &str = worker_ctx
-                            .forwarding
-                            .ifindex_to_routing_instance
-                            .get(&(meta.ingress_ifindex as i32))
-                            .map(|s| s.as_str())
-                            .unwrap_or("");
+                        //
+                        // #5802: derive the pre-routing DNAT/static-NAT/NPTv6
+                        // scope identity from the LOGICAL VLAN unit that received
+                        // the frame, NOT the physical bind `meta.ingress_ifindex`.
+                        // `prerouting_ingress_scope` resolves the logical unit
+                        // ifindex (the same identity the later zone-policy /
+                        // filter / CoS path uses, #3021) and reads the zone /
+                        // config-name / routing-instance the scoped `from zone` /
+                        // `from interface` / `from routing-instance` matches
+                        // against. Scoping on the physical parent let a packet on
+                        // one VLAN unit match another unit's scoped NAT rule (or
+                        // miss its own) on a trunk whose units sit in distinct
+                        // zones / interfaces / routing-instances — a NAT
+                        // scope-escape. Non-VLAN ports resolve logical == physical
+                        // so their behavior is byte-identical. `logical_ifindex`
+                        // is threaded into the zone-pair policy below so both
+                        // sites share ONE logical-unit ingress identity.
+                        let PreroutingIngressScope {
+                            logical_ifindex: ingress_logical,
+                            zone_name: ingress_zone_name,
+                            ifname: ingress_ifname_dnat,
+                            routing_instance: ingress_ri_dnat,
+                        } = prerouting_ingress_scope(
+                            worker_ctx.forwarding,
+                            meta.ingress_ifindex as i32,
+                            meta.ingress_vlan_id,
+                            ingress_zone_override,
+                        );
                         // #3437: the DNAT `match application` term may pin a
                         // source-port (H10) and an ICMP type/code (H11). Supply
                         // the flow's source port and the packet's ICMP
@@ -1920,21 +1992,19 @@ pub(super) fn poll_binding_process_descriptor(
                         // direct from u16 IDs — no String materialisation
                         // on the per-flow miss path.
                         //
-                        // #3021: resolve the LOGICAL ingress ifindex first.
-                        // `ifindex_to_zone_id` is keyed by the logical unit
-                        // ifindex (forwarding_build/interfaces.rs:76); a VLAN
-                        // subinterface's physical bind ifindex maps only to its
-                        // parent's FIRST-subinterface zone, so the raw physical
+                        // #3021: resolve the LOGICAL ingress ifindex for the
+                        // zone-pair policy. `ifindex_to_zone_id` is keyed by the
+                        // logical unit ifindex (forwarding_build/interfaces.rs:76);
+                        // a VLAN subinterface's physical bind ifindex maps only to
+                        // its parent's FIRST-subinterface zone, so the raw physical
                         // index would evaluate the wrong zone-pair policy on a
                         // parent carrying multiple VLAN units in distinct zones.
                         // Mirrors filter.rs / cos_classify.rs; non-VLAN ports
-                        // resolve physical == logical (unchanged).
-                        let ingress_logical = resolve_ingress_logical_ifindex(
-                            worker_ctx.forwarding,
-                            meta.ingress_ifindex as i32,
-                            meta.ingress_vlan_id,
-                        )
-                        .unwrap_or(meta.ingress_ifindex as i32);
+                        // resolve physical == logical (unchanged). #5802: reuse the
+                        // `ingress_logical` resolved once by `prerouting_ingress_scope`
+                        // at the pre-routing DNAT site above — the pre-routing NAT
+                        // scope and the zone-pair policy now share ONE logical-unit
+                        // ingress identity.
                         let (from_zone_id, to_zone_id) = zone_pair_ids_for_flow_with_override(
                             worker_ctx.forwarding,
                             ingress_logical,
@@ -6259,6 +6329,246 @@ mod flowless_local_delivery_tests {
             override_only.disposition,
             ForwardingDisposition::LocalDelivery,
             "override-table-first (the #3600 Note 2 bug) would not deliver",
+        );
+    }
+}
+
+// ===================================================================
+// #5802 — the pre-routing DNAT / static-NAT / NPTv6 scope must key on
+// the LOGICAL VLAN unit that received the frame, resolved through
+// `prerouting_ingress_scope` (which uses `resolve_ingress_logical_-
+// ifindex`), NOT the raw physical `meta.ingress_ifindex`. The three
+// scope maps (`ifindex_to_zone_id` / `ifindex_to_config_name` /
+// `ifindex_to_routing_instance`) are keyed by the logical unit ifindex;
+// a VLAN sub-interface's physical parent maps only to its FIRST unit.
+// Scoping the pre-routing NAT on the physical parent let a packet on
+// one VLAN unit match another unit's scoped NAT rule (or miss its own)
+// on a trunk whose units sit in distinct zones / interfaces — a NAT
+// scope-escape ahead of the correct logical zone policy.
+// ===================================================================
+#[cfg(test)]
+mod prerouting_scope_tests {
+    use super::*;
+    use crate::test_zone_ids::{TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID};
+    use std::net::IpAddr;
+
+    /// nat_snapshot() already carries reth0.80 (logical 12, parent 11,
+    /// VID 80, zone `wan`, the parent's FIRST sub-interface). Add reth0.50
+    /// (logical 13, parent 11, VID 50, zone `lan`) so the physical parent
+    /// 11 carries TWO VLAN units in DISTINCT zones. Add two scoped inbound
+    /// destination-translation rules so both escape directions are covered:
+    ///   - a port-based DNAT scoped `from zone wan` (unit-A's zone), and
+    ///   - a static (1:1) DNAT scoped `from interface reth0.50` (unit-B's
+    ///     OWN interface).
+    fn two_vlan_scoped_nat_snapshot() -> crate::ConfigSnapshot {
+        let mut snap = super::super::test_fixtures::nat_snapshot();
+        snap.interfaces.push(crate::InterfaceSnapshot {
+            name: "reth0.50".to_string(),
+            zone: "lan".to_string(),
+            linux_name: "ge-0-0-0.50".to_string(),
+            ifindex: 13,
+            parent_ifindex: 11,
+            redundancy_group: 1,
+            vlan_id: 50,
+            hardware_addr: "02:bf:72:00:50:08".to_string(),
+            addresses: vec![crate::InterfaceAddressSnapshot {
+                family: "inet".to_string(),
+                address: "172.16.50.8/24".to_string(),
+                scope: 0,
+            }],
+            ..Default::default()
+        });
+        // Port DNAT scoped to unit-A's zone (wan): 172.16.80.200:443/tcp.
+        snap.destination_nat_rules
+            .push(crate::DestinationNATRuleSnapshot {
+                name: "dnat-from-wan".to_string(),
+                from_zone: "wan".to_string(),
+                destination_address: "172.16.80.200".to_string(),
+                destination_port: 443,
+                protocol: "tcp".to_string(),
+                pool_address: "10.0.61.200".to_string(),
+                pool_port: 8443,
+                ..Default::default()
+            });
+        // Static (1:1) DNAT scoped to unit-B's OWN interface (reth0.50).
+        snap.static_nat_rules.push(crate::StaticNATRuleSnapshot {
+            name: "static-from-reth0-50".to_string(),
+            from_interface: "reth0.50".to_string(),
+            external_ip: "172.16.50.200".to_string(),
+            internal_ip: "10.0.61.201".to_string(),
+            ..Default::default()
+        });
+        snap
+    }
+
+    /// #5802 fail-on-revert (wrong-APPLY escape). A DNAT scoped `from zone
+    /// wan` must translate only traffic whose LOGICAL ingress unit is in
+    /// `wan`. A frame arriving on the VID-50 unit (zone `lan`) must be
+    /// scoped OUT. Reverting the fix to scope on the physical parent 11 —
+    /// which inherits unit-A's first-unit `wan` zone — makes the VID-50
+    /// frame WRONGLY match unit-A's DNAT (NAT applied outside its
+    /// configured `from zone`), so the unit-B assertion goes RED.
+    #[test]
+    fn prerouting_dnat_scope_uses_logical_vlan_unit_zone_5802() {
+        let forwarding = build_forwarding_state(&two_vlan_scoped_nat_snapshot());
+
+        // Fixture sanity: parent 11 / VID 80 -> logical 12 (zone wan);
+        // parent 11 / VID 50 -> logical 13 (zone lan). The physical parent
+        // 11 inherits ONLY unit-A's (first sub-interface) zone -> wan.
+        assert_eq!(resolve_ingress_logical_ifindex(&forwarding, 11, 80), Some(12));
+        assert_eq!(resolve_ingress_logical_ifindex(&forwarding, 11, 50), Some(13));
+        assert_eq!(
+            forwarding.ifindex_to_zone_id.get(&12).copied(),
+            Some(TEST_WAN_ZONE_ID)
+        );
+        assert_eq!(
+            forwarding.ifindex_to_zone_id.get(&13).copied(),
+            Some(TEST_LAN_ZONE_ID)
+        );
+        assert_eq!(
+            forwarding.ifindex_to_zone_id.get(&11).copied(),
+            Some(TEST_WAN_ZONE_ID),
+            "the physical parent inherits unit-A's (first-unit) wan zone"
+        );
+
+        let src: IpAddr = "203.0.113.9".parse().unwrap();
+        let dst: IpAddr = "172.16.80.200".parse().unwrap();
+
+        // Unit-A frame (VID 80): scope resolves to wan -> the wan-scoped
+        // DNAT MATCHES its OWN zone's traffic.
+        let scope_a = prerouting_ingress_scope(&forwarding, 11, 80, None);
+        assert_eq!(scope_a.zone_name, "wan");
+        assert_eq!(scope_a.logical_ifindex, 12);
+        let dnat_a = forwarding.dnat_table.lookup_with_counter_scoped(
+            crate::ip_proto::PROTO_TCP,
+            src,
+            dst,
+            51000,
+            443,
+            scope_a.zone_name,
+            scope_a.ifname,
+            scope_a.routing_instance,
+            None,
+        );
+        assert!(
+            dnat_a.is_some(),
+            "unit-A (logical zone wan) must match its own wan-scoped DNAT"
+        );
+
+        // Unit-B frame (VID 50): scope resolves to lan -> the wan-scoped
+        // DNAT is SCOPED OUT. Reverting to the physical parent makes this
+        // resolve to wan and the DNAT WRONGLY matches -> RED (#5802).
+        let scope_b = prerouting_ingress_scope(&forwarding, 11, 50, None);
+        assert_eq!(
+            scope_b.zone_name, "lan",
+            "the VID-50 unit must scope on its OWN logical zone (lan), \
+             not the parent's inherited wan"
+        );
+        assert_eq!(scope_b.logical_ifindex, 13);
+        let dnat_b = forwarding.dnat_table.lookup_with_counter_scoped(
+            crate::ip_proto::PROTO_TCP,
+            src,
+            dst,
+            51000,
+            443,
+            scope_b.zone_name,
+            scope_b.ifname,
+            scope_b.routing_instance,
+            None,
+        );
+        assert!(
+            dnat_b.is_none(),
+            "unit-B (logical zone lan) must NOT match unit-A's wan-scoped \
+             DNAT — a cross-VLAN-unit NAT scope-escape (#5802)"
+        );
+    }
+
+    /// #5802 fail-on-revert (wrong-SKIP escape). A static DNAT scoped
+    /// `from interface reth0.50` must translate the VID-50 unit's OWN
+    /// traffic. The fix derives the logical ifname `reth0.50`, so the
+    /// rule matches. Reverting to the physical parent 11 (which has NO
+    /// config-name -> ifname "") makes the interface-scoped rule WRONGLY
+    /// MISS, so unit-B's own traffic skips its configured translation ->
+    /// the unit-B assertion goes RED.
+    #[test]
+    fn prerouting_static_dnat_scope_uses_logical_vlan_unit_interface_5802() {
+        let forwarding = build_forwarding_state(&two_vlan_scoped_nat_snapshot());
+        let src: IpAddr = "203.0.113.9".parse().unwrap();
+        let ext: IpAddr = "172.16.50.200".parse().unwrap();
+
+        // Unit-B frame (VID 50): ifname resolves to reth0.50 -> its OWN
+        // reth0.50-scoped static DNAT MATCHES.
+        let scope_b = prerouting_ingress_scope(&forwarding, 11, 50, None);
+        assert_eq!(scope_b.ifname, "reth0.50");
+        let static_b = forwarding.static_nat.match_dnat_with_counter_scoped(
+            ext,
+            0,
+            Some(src),
+            scope_b.zone_name,
+            scope_b.ifname,
+            scope_b.routing_instance,
+        );
+        assert!(
+            static_b.is_some(),
+            "unit-B must match its OWN reth0.50-scoped static DNAT (the fix \
+             derives the logical ifname); reverting to the physical parent \
+             yields ifname \"\" and WRONGLY skips the translation (#5802)"
+        );
+
+        // Unit-A frame (VID 80): ifname resolves to reth0.80 -> the
+        // reth0.50-scoped rule is correctly scoped OUT.
+        let scope_a = prerouting_ingress_scope(&forwarding, 11, 80, None);
+        assert_eq!(scope_a.ifname, "reth0.80");
+        let static_a = forwarding.static_nat.match_dnat_with_counter_scoped(
+            ext,
+            0,
+            Some(src),
+            scope_a.zone_name,
+            scope_a.ifname,
+            scope_a.routing_instance,
+        );
+        assert!(
+            static_a.is_none(),
+            "unit-A must NOT match unit-B's reth0.50-scoped static DNAT"
+        );
+    }
+
+    /// #5802 non-VLAN regression: an untagged port (reth1.0, ifindex 24)
+    /// has no `(parent, vlan)` mapping, so `resolve_ingress_logical_-
+    /// ifindex` returns None and `prerouting_ingress_scope` falls back to
+    /// the physical ifindex — the scope identity is byte-identical to
+    /// pre-#5802 (logical == physical).
+    #[test]
+    fn prerouting_scope_non_vlan_unchanged_5802() {
+        let forwarding = build_forwarding_state(&two_vlan_scoped_nat_snapshot());
+        assert_eq!(
+            resolve_ingress_logical_ifindex(&forwarding, 24, 0),
+            Some(24),
+            "an untagged port resolves logical == physical"
+        );
+        let scope = prerouting_ingress_scope(&forwarding, 24, 0, None);
+        assert_eq!(
+            scope.logical_ifindex, 24,
+            "an untagged port scopes on itself (logical == physical)"
+        );
+        assert_eq!(scope.zone_name, "lan");
+        assert_eq!(scope.ifname, "reth1.0");
+        // The derived scope equals the direct physical-keyed lookups (the
+        // pre-#5802 behavior) — non-trunk ingress is unchanged.
+        assert_eq!(
+            forwarding
+                .ifindex_to_config_name
+                .get(&24)
+                .map(|s| s.as_str()),
+            Some(scope.ifname),
+        );
+        assert_eq!(
+            forwarding
+                .ifindex_to_zone_id
+                .get(&24)
+                .and_then(|id| forwarding.zone_id_to_name.get(id))
+                .map(|s| s.as_str()),
+            Some(scope.zone_name),
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a **SECURITY-band NAT scope-escape** (#5802) in the Rust AF_XDP
userspace dataplane. The inbound **DNAT / static-NAT / NPTv6 pre-routing**
scope lookups in `poll_binding_process_descriptor` derived their ingress
zone name, config-interface name, and routing-instance from the **PHYSICAL**
AF_XDP bind ifindex (`meta.ingress_ifindex`).

On a trunk the parent physical netdev carries every VLAN unit's tagged
frames, and the three scope maps (`ifindex_to_zone_id` /
`ifindex_to_config_name` / `ifindex_to_routing_instance`) are keyed by the
**LOGICAL unit ifindex** — the physical parent maps only to its FIRST unit.
So on a trunk whose VLAN units sit in **distinct zones / interfaces /
routing-instances**, a packet on one unit could match (or miss) a scoped
NAT rule using the **parent / first-unit** identity, applying or skipping
destination translation **outside** the configured `from zone` /
`from interface` / `from routing-instance` boundary — *before* the correct
logical zone policy ran.

The same miss path **later** resolves the logical VLAN identity for the
zone-pair policy / input filter / CoS (#3021), so the correct identity was
already computed — just not used for the earlier pre-routing scope.

## Fix

Extract `prerouting_ingress_scope`, which resolves the logical unit via
`resolve_ingress_logical_ifindex` on the `(bind ifindex, VLAN id)` key and
reads the zone / config-name / routing-instance from it. The pre-routing
site consumes it and threads the resolved `logical_ifindex` into the later
zone-pair policy so **both sites share ONE ingress identity** (no recompute
— hot path unchanged). A fabric-encoded zone override still wins first, so
the fabric-ingress path is unchanged. **The pre-routing NAT matching logic
itself is untouched** — only the identity it is scoped against changes.

An untagged port has no `(parent, VLAN)` mapping, so resolve returns `None`
and the scope falls back to the physical ifindex: **logical == physical,
byte-identical to pre-#5802** for every non-trunk ingress.

## Validation

Three RED-on-revert cargo unit tests (`prerouting_scope_tests`):
- **zone-scoped DNAT** (wrong-APPLY escape): a VID-50/`lan` frame must NOT
  match a `wan`-scoped DNAT.
- **interface-scoped static DNAT** (wrong-SKIP escape): a VID-50 frame must
  match its OWN `reth0.50`-scoped rule.
- **non-VLAN control**: logical == physical, byte-identical.

Reverting the scope to the physical parent makes the two escape tests RED
as **assertion failures** (`logical_ifindex` left 11 / right 12; `ifname`
left `""` / right `"reth0.50"`); the non-VLAN control stays green.

- `cargo build` clean
- `cargo test --release nat` green (726 passed)
- full `cargo test --release` green except the known pre-existing parallel
  flake `wg_encap_frame_resolves_outer_route_once_v4` (passes isolated)
- **Loss-cluster smoke DEFERRED** — cargo covers the logical-scope
  selection; a VLAN-trunk per-zone NAT cluster test is a possible later add.

Docs: `docs/userspace-dataplane-architecture.md` (Static NAT zone scoping),
`_Log.md`.

Closes #5802

🤖 Generated with [Claude Code](https://claude.com/claude-code)