### PR TITLE
userspace-dp: fail-closed host-inbound on empty-zone addressed iface (#5659)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,21 @@
-## 2026-07-17 — #5659: empty-zone addressed-interface host-inbound fail-closed backstop
+## 2026-07-17 — #5659 fold: widen lifeline predicate to mirror userspaceSkipsIngressInterface
 
+- **Timestamp**: 2026-07-17 (fix/5659-empty-zone-host-inbound-failclosed, review fold)
+- **Action**: Folded the sole substantive finding from the independent hostile
+  review of PR #6065. `is_host_inbound_lifeline` matched only the exact `fxp0` /
+  `em0` names + `fab*`, NARROWER than the authoritative Go SSOT
+  `userspaceSkipsIngressInterface` (maps_sync.go), which excludes `fxp*` / `em*`
+  / `fab*` prefixes PLUS `lo0`. In the exact future case this backstop hardens
+  (a change binds a zoneless-addressed interface), the narrow predicate would
+  arm a deny sentinel on an unzoned-addressed `lo0` (router-id / BGP
+  `update-source` loopback) or an `fxp1` / `em1` → strand SSH/BGP-to-loopback /
+  break the HA heartbeat. Widened the predicate to
+  `starts_with("fxp") || starts_with("em") || starts_with("fab") || == "lo0"`,
+  documented the SSOT it mirrors + which arms are moot/handled-elsewhere, added a
+  `lo0`-no-sentinel test case, and updated forwarding/README.md.
+- **File(s)**: userspace-dp/src/afxdp/forwarding_build/interfaces.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md
 - **Timestamp**: 2026-07-17 (fix/5659-empty-zone-host-inbound-failclosed)
 - **Action**: Closed the #2391 fail-closed-symmetry gap where an ADDRESSED
   interface with an EMPTY `security-zone` string is skipped by the

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-17 — #5659: empty-zone addressed-interface host-inbound fail-closed backstop
+
+- **Timestamp**: 2026-07-17 (fix/5659-empty-zone-host-inbound-failclosed)
+- **Action**: Closed the #2391 fail-closed-symmetry gap where an ADDRESSED
+  interface with an EMPTY `security-zone` string is skipped by the
+  `!iface.zone.is_empty()`-guarded zone-id backstop, resolving to the global
+  `zone_id 0` while its IP is still registered into `local_v4`/`local_v6`.
+  `host_inbound_admits(0)` would then hit the `None => true` global-zone admit
+  arm and admit every host-bound service (SSH/NETCONF/BGP/SNMP). Fix:
+  `populate_interfaces` now inserts an EMPTY `ZoneHostInbound` sentinel into
+  `ifindex_host_inbound` keyed by the interface's logical ifindex, so the
+  ingress-interface-keyed `host_inbound_admits_iface` DENIES host-bound services
+  on it. Scoped to unzoned + local-registered + no explicit override + non-
+  lifeline (fxp0/em0/fab*). Keying by ifindex (not `zone_host_inbound[0]`)
+  preserves the genuinely-global zone_id-0 admit path (ND/PMTUD control + a
+  legitimately-zoneless NON-addressed control interface). Global ICMP/ND/PMTUD
+  accepts (checked before the set) unaffected. Fail-closed-SYMMETRY / defense-in-
+  depth: reachability is bind-gated today (`buildUserspaceBindNetdevs` skips a
+  zoneless interface); this closes the asymmetry so a future bind-a-zoneless
+  change or a #3719 quarantine path cannot become a live host-inbound bypass.
+  Rust-only (helper-boundary backstop, matching #2391/#2409); Go side unchanged.
+  RED-on-revert test `empty_zone_addressed_interface_denies_host_inbound`
+  (forwarding_build/tests.rs) verified: fails at the SSH-deny assertion when the
+  sentinel insert is neutralized.
+- **File(s)**: userspace-dp/src/afxdp/forwarding_build/interfaces.rs,
+  userspace-dp/src/afxdp/forwarding/host_inbound.rs (doc),
+  userspace-dp/src/afxdp/forwarding_build/tests.rs (test),
+  userspace-dp/src/afxdp/forwarding/README.md (doc), _Log.md
+
 ## 2026-07-17 — #5658: static block-to-block & DNAT prefix minimum-prefix floor (fail-open on /0)
 
 - **Timestamp**: 2026-07-17 (fix/5658-static-nat-min-prefix-floor)

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -459,7 +459,7 @@ selects only WHICH tokens a zone admits, never WHETHER it is enforced.
 Consequently `None`
 now means only a genuinely unknown / global ingress zone (id not in the table),
 which keeps the admit default. The global ICMP/ND/PMTUD accepts precede the
-per-zone deny, and lifeline interfaces (fxp0/em0/fab*) never reach this AF_XDP
+per-zone deny, and lifeline interfaces (`fxp*`/`em*`/`fab*`/`lo0`) never reach this AF_XDP
 classifier (the kernel serves their host-bound traffic and excludes them from
 the deny address sets), so the default-deny cannot strand management or break
 HA.
@@ -479,8 +479,12 @@ so the ingress-interface-keyed `host_inbound_admits_iface` DENIES host-bound
 services there. The insert is scoped to an interface that (a) is unzoned, (b)
 actually registered a `local_v4`/`local_v6` target, (c) has no explicit
 per-interface `host_inbound_configured` override (never clobber the operator's
-set), and (d) is not a lifeline (fxp0/em0/fab*, matched by base name — never arm
-a deny on a management/HA link). Keying by ifindex — rather than inserting
+set), and (d) is not a lifeline (`fxp*`/`em*`/`fab*` prefixes plus `lo0`, matched
+by base name to mirror the authoritative Go SSOT `userspaceSkipsIngressInterface`
+— never arm a deny on a management/HA/loopback link; the earlier `fxp0`/`em0`-only
+form was narrower than the SSOT and would have stranded an unzoned-addressed `lo0`
+router-id/BGP-`update-source` loopback in the exact future case this backstop
+hardens). Keying by ifindex — rather than inserting
 `zone_host_inbound[0]` — deliberately leaves the genuinely-global `zone_id 0`
 path untouched, so a legitimately-zoneless NON-addressed control interface keeps
 its admit default and the global ICMP/ND/PMTUD accepts (checked before the set)

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -462,7 +462,36 @@ which keeps the admit default. The global ICMP/ND/PMTUD accepts precede the
 per-zone deny, and lifeline interfaces (fxp0/em0/fab*) never reach this AF_XDP
 classifier (the kernel serves their host-bound traffic and excludes them from
 the deny address sets), so the default-deny cannot strand management or break
-HA. Token
+HA.
+
+**Empty-zone addressed-interface backstop (#5659).** The #2391 zone-id backstop
+in `forwarding_build::interfaces::populate_interfaces` (fail-closed on a
+NON-EMPTY unknown zone name) is guarded by `!iface.zone.is_empty()`, so an
+ADDRESSED interface with an EMPTY `security-zone` string is skipped: it gets no
+`ifindex_to_zone_id` entry and resolves to the global `zone_id 0`, while its IP
+is STILL registered into `local_v4`/`local_v6` as a local-delivery target. On
+its own that would let `host_inbound_admits(0)` hit the `None => true`
+global-zone admit arm and admit every host-bound service (SSH/NETCONF/BGP/SNMP)
+on that interface — an asymmetry vs the #2391/#3405 fail-closed posture. To
+restore symmetry, `populate_interfaces` inserts an EMPTY `ZoneHostInbound`
+sentinel into `ifindex_host_inbound` keyed by that interface's logical ifindex,
+so the ingress-interface-keyed `host_inbound_admits_iface` DENIES host-bound
+services there. The insert is scoped to an interface that (a) is unzoned, (b)
+actually registered a `local_v4`/`local_v6` target, (c) has no explicit
+per-interface `host_inbound_configured` override (never clobber the operator's
+set), and (d) is not a lifeline (fxp0/em0/fab*, matched by base name — never arm
+a deny on a management/HA link). Keying by ifindex — rather than inserting
+`zone_host_inbound[0]` — deliberately leaves the genuinely-global `zone_id 0`
+path untouched, so a legitimately-zoneless NON-addressed control interface keeps
+its admit default and the global ICMP/ND/PMTUD accepts (checked before the set)
+still deliver control traffic. Reachability today is bind-gated
+(`buildUserspaceBindNetdevs` skips a zoneless interface), so this is a
+fail-closed-SYMMETRY / defense-in-depth hardening: it closes the asymmetry so a
+future change that binds a zoneless-addressed interface (or a quarantine path,
+#3719, that keeps an interface bound while stripping its zone) cannot silently
+become a host-inbound bypass.
+
+Token
 classification covers the common Junos `system-services` (ssh, ping, dns,
 dhcp/dhcpv6, ike, ntp, snmp, ...) and `protocols` (ospf, bgp,
 router-discovery, ...) names; `system-services all` / `any-service`

--- a/userspace-dp/src/afxdp/forwarding/host_inbound.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound.rs
@@ -497,6 +497,14 @@ pub(in crate::afxdp) fn host_inbound_admits(
         // security zone). Such traffic keeps the admit default — narrowing it is
         // out of scope for the configured-zone default-deny fix and risks
         // breaking ND / control delivery on the global context.
+        //
+        // #5659: an ADDRESSED interface with an EMPTY security-zone also resolves
+        // to id 0 here, but its host-inbound is denied WITHOUT touching this
+        // global admit arm — `populate_interfaces` inserts an empty
+        // `ZoneHostInbound` sentinel into `ifindex_host_inbound` keyed by that
+        // interface's ifindex, so the ingress-interface-keyed
+        // `host_inbound_admits_iface` denies it while this zone-only path (and a
+        // legitimately-zoneless NON-addressed control interface) keeps admit.
         None => true,
         // A configured zone — including one with no `host-inbound-traffic` stanza
         // (empty set) — denies anything its set does not admit (#3405).

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -357,28 +357,44 @@ pub(in crate::afxdp) fn connected_route_tables(routing_instance: &str) -> (Strin
     }
 }
 
-/// #5659: base-name lifeline match, mirroring the UNCONDITIONAL defaults of the
-/// Go SSOT `config.HostInboundLifelineInterface` (fxp0 / em0 / fab*). A lifeline
-/// interface's host-bound traffic is served UNCONDITIONALLY by the kernel path
-/// (excluded from the AF_XDP host-inbound deny sets), so the empty-zone
-/// fail-closed backstop in [`populate_interfaces`] must never arm a deny
-/// sentinel for one — that would strand management / break the HA heartbeat the
-/// moment a future change bound it.
+/// #5659: base-name lifeline match, mirroring the NAME/prefix exclusions of the
+/// authoritative Go SSOT `userspaceSkipsIngressInterface`
+/// (pkg/dataplane/userspace/maps_sync.go): the `fxp*` / `em*` / `fab*` prefixes
+/// plus `lo0`. A lifeline interface's host-bound traffic is served
+/// UNCONDITIONALLY by the kernel path (excluded from the AF_XDP host-inbound
+/// deny sets), so the empty-zone fail-closed backstop in [`populate_interfaces`]
+/// must never arm a deny sentinel for one — that would strand management / break
+/// the HA heartbeat the moment a future change bound it.
+///
+/// The earlier form matched only the exact `fxp0` / `em0` names, which was
+/// NARROWER than the SSOT and would arm a deny sentinel on an unzoned+addressed
+/// `lo0` (a router-id / BGP `update-source` loopback) or an `fxp1` / `em1` in
+/// the exact future case this backstop hardens — reintroducing a
+/// management-strand. The remaining arms of `userspaceSkipsIngressInterface` are
+/// handled elsewhere or moot here:
+///   - the mgmt/control-ZONE arm is unreachable — the sentinel branch already
+///     requires an EMPTY zone;
+///   - the `LocalFabric != ""` (fabric parent) arm is subsumed by the `fab*`
+///     prefix, so a fabric parent that gains an L3 address stays exempt;
+///   - the `Tunnel` arm is inert — a tunnel interface is likewise excluded from
+///     the AF_XDP ingress-ifindex map by the same SSOT, so a sentinel on one is
+///     never consulted.
 ///
 /// The config-derived control/fabric names (#3277: a renamed `control-interface`
-/// / non-default fabric) are NOT mirrored here because the snapshot does not
-/// carry them. That is safe: such a renamed lifeline is zoneless and thus not
-/// AF_XDP-bound today (`buildUserspaceBindNetdevs` skips a zoneless interface),
-/// so a missed match leaves an INERT sentinel that is never consulted — and the
-/// canonical em0/fab*/fxp0 names (the only ones present in default configs) are
-/// matched. The unit suffix is stripped so `em0.0` / `fab1.0` match too.
+/// / non-default fabric) are still NOT mirrored here because the snapshot does
+/// not carry them; that stays safe only because such a renamed lifeline is
+/// zoneless and thus not AF_XDP-bound today (`buildUserspaceBindNetdevs` skips a
+/// zoneless interface), so a missed match leaves an INERT sentinel that is never
+/// consulted. If a future change binds a zoneless interface, this predicate MUST
+/// be reconciled with `userspaceSkipsIngressInterface` (add a parity test). The
+/// unit suffix is stripped so `em0.0` / `fab1.0` / `lo0.0` match too.
 fn is_host_inbound_lifeline(name: &str) -> bool {
     let base = match name.split_once('.') {
         Some((b, _)) => b,
         None => name,
     }
     .trim();
-    base == "fxp0" || base == "em0" || base.starts_with("fab")
+    base.starts_with("fxp") || base.starts_with("em") || base.starts_with("fab") || base == "lo0"
 }
 
 pub(in crate::afxdp) fn pick_interface_v4(iface: &InterfaceSnapshot) -> Option<Ipv4Addr> {

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -125,6 +125,12 @@ pub(super) fn populate_interfaces(
         // prefix owned by a different routing-instance.
         let (connected_table_v4, connected_table_v6) =
             connected_route_tables(&iface.routing_instance);
+        // #5659: track whether this interface registered at least one
+        // local-delivery target (an address that landed in local_v4/local_v6,
+        // NOT one routed into interface_nat_*). Only such an addressed
+        // local-delivery target is a host-inbound exposure worth the empty-zone
+        // fail-closed sentinel installed after this loop.
+        let mut registered_local = false;
         for addr in &iface.addresses {
             // #2409: fail CLOSED on an unparseable interface address rather
             // than silently `continue`-ing past it. The pre-fix skip lost the
@@ -151,6 +157,7 @@ pub(super) fn populate_interfaces(
                         state.interface_nat_v4.insert(v4.addr(), iface.ifindex);
                     } else {
                         state.local_v4.insert(v4.addr());
+                        registered_local = true;
                         // #3769: record the interface host address's owning
                         // table for the table-scoped local-delivery DECISION.
                         // Keyed by the HOST `.addr()`, NOT the (masked)
@@ -177,6 +184,7 @@ pub(super) fn populate_interfaces(
                         state.interface_nat_v6.insert(v6.addr(), iface.ifindex);
                     } else {
                         state.local_v6.insert(v6.addr());
+                        registered_local = true;
                         // #3769: record the interface host address's owning
                         // table (see the v4 arm).
                         state
@@ -193,6 +201,56 @@ pub(super) fn populate_interfaces(
                     });
                 }
             }
+        }
+        // #5659: empty-zone host-inbound fail-closed backstop — SYMMETRY with
+        // the #2391 non-empty-unknown-zone backstop above. That backstop is
+        // guarded by `!iface.zone.is_empty()`, so an ADDRESSED interface with an
+        // EMPTY security-zone string is skipped: no `ifindex_to_zone_id` entry ->
+        // ingress resolves to zone_id 0, while its IP is STILL registered into
+        // local_v4/local_v6 as a local-delivery target. `host_inbound_admits(0)`
+        // then hits the `None => true` global-zone admit arm and would admit
+        // every host-bound service (SSH/NETCONF/BGP/SNMP...), breaking the
+        // fail-closed symmetry #2391/#3405 established.
+        //
+        // Fix: insert an EMPTY `ZoneHostInbound` sentinel keyed by this
+        // interface's LOGICAL ifindex, so the ingress-interface-keyed
+        // `host_inbound_admits_iface` (the local-delivery poll path's entry
+        // point) DENIES host-bound services for a packet ingressing on it. The
+        // global ICMP/ND/PMTUD accepts (`is_icmp_host_inbound_global_accept`,
+        // checked BEFORE the set in `host_inbound_admits_iface`) still deliver
+        // control traffic. Keying by ifindex — NOT by inserting zone_host_inbound
+        // at id 0 — deliberately leaves the genuinely-global zone_id 0 path
+        // (`host_inbound_admits` with no matching ifindex override) untouched, so
+        // a legitimately-zoneless NON-addressed control interface keeps its admit
+        // default.
+        //
+        // Scope guards:
+        //   - registered_local: only an interface that actually registered a
+        //     local_v4/local_v6 target is a host-inbound exposure. A fully
+        //     NAT-excluded (interface_nat only) or address-less interface is not.
+        //   - !iface.host_inbound_configured: an explicit per-interface override
+        //     already inserted its own (possibly deny-all) `ifindex_host_inbound`
+        //     entry above; never clobber the operator's configured admit set.
+        //   - !is_host_inbound_lifeline: fxp0/em0/fab* are served UNCONDITIONALLY
+        //     (kernel path, excluded from the AF_XDP deny sets). Never arm a deny
+        //     sentinel for a lifeline — doing so would strand management / break
+        //     HA heartbeat the moment a future change bound one.
+        //
+        // Reachability today is bind-gated (`buildUserspaceBindNetdevs` skips a
+        // zoneless interface), so this is a fail-closed-SYMMETRY / defense-in-
+        // depth hardening, not a live bypass: it closes the asymmetry so any
+        // future change that binds a zoneless-addressed interface (or a quarantine
+        // path, cf. #3719, that keeps an interface bound while stripping its zone)
+        // cannot silently become a host-inbound bypass.
+        if iface.zone.is_empty()
+            && registered_local
+            && !iface.host_inbound_configured
+            && !is_host_inbound_lifeline(&iface.name)
+        {
+            state
+                .ifindex_host_inbound
+                .entry(iface.ifindex)
+                .or_default();
         }
     }
 
@@ -297,6 +355,30 @@ pub(in crate::afxdp) fn connected_route_tables(routing_instance: &str) -> (Strin
             format!("{routing_instance}.inet6.0"),
         )
     }
+}
+
+/// #5659: base-name lifeline match, mirroring the UNCONDITIONAL defaults of the
+/// Go SSOT `config.HostInboundLifelineInterface` (fxp0 / em0 / fab*). A lifeline
+/// interface's host-bound traffic is served UNCONDITIONALLY by the kernel path
+/// (excluded from the AF_XDP host-inbound deny sets), so the empty-zone
+/// fail-closed backstop in [`populate_interfaces`] must never arm a deny
+/// sentinel for one — that would strand management / break the HA heartbeat the
+/// moment a future change bound it.
+///
+/// The config-derived control/fabric names (#3277: a renamed `control-interface`
+/// / non-default fabric) are NOT mirrored here because the snapshot does not
+/// carry them. That is safe: such a renamed lifeline is zoneless and thus not
+/// AF_XDP-bound today (`buildUserspaceBindNetdevs` skips a zoneless interface),
+/// so a missed match leaves an INERT sentinel that is never consulted — and the
+/// canonical em0/fab*/fxp0 names (the only ones present in default configs) are
+/// matched. The unit suffix is stripped so `em0.0` / `fab1.0` match too.
+fn is_host_inbound_lifeline(name: &str) -> bool {
+    let base = match name.split_once('.') {
+        Some((b, _)) => b,
+        None => name,
+    }
+    .trim();
+    base == "fxp0" || base == "em0" || base.starts_with("fab")
 }
 
 pub(in crate::afxdp) fn pick_interface_v4(iface: &InterfaceSnapshot) -> Option<Ipv4Addr> {

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1535,6 +1535,167 @@ fn build_forwarding_state_nil_zone_default_denies() {
     );
 }
 
+// #5659: an ADDRESSED interface with an EMPTY security-zone string registers its
+// IP into local_v4/local_v6 (a local-delivery target) but is skipped by the
+// #2391 zone-id backstop (guarded by `!iface.zone.is_empty()`), so it resolves to
+// zone_id 0. Without the empty-zone fail-closed sentinel, the ingress-interface-
+// keyed `host_inbound_admits_iface` falls back to `host_inbound_admits(0)` which
+// hits the `None => true` global-zone admit arm and would admit EVERY host-bound
+// service on that interface. The fix inserts an empty `ZoneHostInbound` sentinel
+// keyed by the interface's ifindex so host-bound services are DENIED there.
+//
+// Fail-on-revert: removing the sentinel insert in `populate_interfaces`
+// (forwarding_build/interfaces.rs) makes `host_inbound_admits_iface(unzoned)`
+// admit SSH/BGP again -> the deny assertions below turn RED. The ICMP/ND accepts
+// and the genuinely-global zone_id 0 path (no ifindex override) stay untouched,
+// and the em0 lifeline keeps its unconditional admit -> those anti-over-reject
+// assertions guard the fix's scope.
+#[test]
+fn empty_zone_addressed_interface_denies_host_inbound() {
+    use crate::ZoneSnapshot;
+    use crate::afxdp::forwarding::{host_inbound_admits, host_inbound_admits_iface};
+    use crate::protocol::snapshot::InterfaceAddressSnapshot;
+
+    const UNZONED_IFINDEX: i32 = 80;
+    const EM0_IFINDEX: i32 = 81;
+    const TRUST_IFINDEX: i32 = 82;
+    const PROTO_TCP: u8 = 6;
+    const PROTO_ICMP: u8 = 1;
+    const PROTO_ICMP6: u8 = 58;
+
+    let snapshot = ConfigSnapshot {
+        zones: vec![ZoneSnapshot {
+            name: "trust".into(),
+            id: 22,
+            host_inbound_configured: true,
+            host_inbound_system_services: vec!["ssh".into()],
+            ..Default::default()
+        }],
+        interfaces: vec![
+            // The gap: an ADDRESSED interface with NO security-zone.
+            InterfaceSnapshot {
+                name: "ge-0/0/9".into(),
+                zone: String::new(),
+                ifindex: UNZONED_IFINDEX,
+                hardware_addr: "02:00:00:00:00:80".into(),
+                addresses: vec![
+                    InterfaceAddressSnapshot {
+                        family: "inet".into(),
+                        address: "10.0.99.1/24".into(),
+                        ..Default::default()
+                    },
+                    InterfaceAddressSnapshot {
+                        family: "inet6".into(),
+                        address: "2001:db8:99::1/64".into(),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+            // A zoneless-addressed LIFELINE (em0) must NOT get a deny sentinel —
+            // its host traffic is served unconditionally.
+            InterfaceSnapshot {
+                name: "em0".into(),
+                zone: String::new(),
+                ifindex: EM0_IFINDEX,
+                hardware_addr: "02:00:00:00:00:81".into(),
+                addresses: vec![InterfaceAddressSnapshot {
+                    family: "inet".into(),
+                    address: "10.99.0.1/24".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            // A normally-zoned addressed interface — unaffected.
+            InterfaceSnapshot {
+                name: "ge-0/0/8".into(),
+                zone: "trust".into(),
+                ifindex: TRUST_IFINDEX,
+                hardware_addr: "02:00:00:00:00:82".into(),
+                addresses: vec![InterfaceAddressSnapshot {
+                    family: "inet".into(),
+                    address: "10.0.61.1/24".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let state = build_forwarding_state(&snapshot);
+
+    // Precondition: the unzoned interface's IPs ARE registered as local-delivery
+    // targets (the exposure the sentinel closes), and it resolved to zone_id 0
+    // (no ifindex_to_zone_id entry).
+    assert!(
+        state.local_v4.contains(&"10.0.99.1".parse::<Ipv4Addr>().unwrap()),
+        "unzoned interface v4 IP must be a local-delivery target"
+    );
+    assert!(
+        state
+            .local_v6
+            .contains(&"2001:db8:99::1".parse::<std::net::Ipv6Addr>().unwrap()),
+        "unzoned interface v6 IP must be a local-delivery target"
+    );
+    assert!(
+        !state.ifindex_to_zone_id.contains_key(&UNZONED_IFINDEX),
+        "unzoned interface must resolve to zone_id 0 (no zone-id entry)"
+    );
+
+    // The FIX: a host-bound service ingressing on the unzoned interface is DENIED
+    // (empty sentinel), even though its resolved zone id is the global 0.
+    assert!(
+        !host_inbound_admits_iface(&state, UNZONED_IFINDEX, 0, PROTO_TCP, 22, false, 0),
+        "empty-zone addressed interface must DENY host-bound ssh (tcp/22) — #5659"
+    );
+    assert!(
+        !host_inbound_admits_iface(&state, UNZONED_IFINDEX, 0, PROTO_TCP, 179, false, 0),
+        "empty-zone addressed interface must DENY host-bound bgp (tcp/179) — #5659"
+    );
+
+    // ICMP error/PMTUD (v4 type 3) and IPv6 ND (type 135) STILL admitted globally
+    // on the unzoned interface — the sentinel must not black-hole control traffic.
+    assert!(
+        host_inbound_admits_iface(&state, UNZONED_IFINDEX, 0, PROTO_ICMP, 0, false, 3),
+        "ICMPv4 destination-unreachable stays globally admitted on the unzoned interface"
+    );
+    assert!(
+        host_inbound_admits_iface(&state, UNZONED_IFINDEX, 0, PROTO_ICMP6, 0, true, 135),
+        "IPv6 Neighbor Solicitation stays globally admitted on the unzoned interface"
+    );
+
+    // Scope guard 1: the genuinely-global zone_id 0 path (no ifindex override)
+    // KEEPS its admit default — a legitimately-zoneless NON-addressed control
+    // interface is not affected. This is why the sentinel is keyed by ifindex, not
+    // inserted into zone_host_inbound at id 0.
+    assert!(
+        host_inbound_admits(&state, 0, PROTO_TCP, 22, false, 0),
+        "global zone_id 0 (zone-only path) keeps the admit default — not broken by #5659"
+    );
+
+    // Scope guard 2: the em0 lifeline is zoneless+addressed but must NOT get a
+    // deny sentinel — its host traffic is served unconditionally.
+    assert!(
+        !state.ifindex_host_inbound.contains_key(&EM0_IFINDEX),
+        "em0 lifeline must not get an empty-zone deny sentinel (#5659 scope)"
+    );
+    assert!(
+        host_inbound_admits_iface(&state, EM0_IFINDEX, 0, PROTO_TCP, 22, false, 0),
+        "em0 lifeline keeps its unconditional admit"
+    );
+
+    // Anti-over-reject: the normal trust zone still admits its configured ssh.
+    assert!(
+        host_inbound_admits_iface(&state, TRUST_IFINDEX, 22, PROTO_TCP, 22, false, 0),
+        "configured trust zone still admits ssh (tcp/22)"
+    );
+    assert!(
+        !host_inbound_admits_iface(&state, TRUST_IFINDEX, 22, PROTO_TCP, 179, false, 0),
+        "configured trust zone (ssh only) still denies bgp (tcp/179)"
+    );
+}
+
 // #3299: `host-inbound-traffic protocols bfd` must admit multi-hop BFD control
 // (UDP 4784, RFC 5883) in addition to single-hop control (3784) + echo (3785).
 // Multi-hop BFD (for multi-hop BGP / BFD over multi-hop static routes) carries

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1559,6 +1559,7 @@ fn empty_zone_addressed_interface_denies_host_inbound() {
     const UNZONED_IFINDEX: i32 = 80;
     const EM0_IFINDEX: i32 = 81;
     const TRUST_IFINDEX: i32 = 82;
+    const LO0_IFINDEX: i32 = 83;
     const PROTO_TCP: u8 = 6;
     const PROTO_ICMP: u8 = 1;
     const PROTO_ICMP6: u8 = 58;
@@ -1602,6 +1603,22 @@ fn empty_zone_addressed_interface_denies_host_inbound() {
                 addresses: vec![InterfaceAddressSnapshot {
                     family: "inet".into(),
                     address: "10.99.0.1/24".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            // #5659 fold: a zoneless-addressed lo0 loopback (router-id / BGP
+            // update-source) is a LIFELINE and must NOT get a deny sentinel —
+            // the earlier fxp0/em0-only predicate missed lo0 and would have
+            // stranded BGP-to-loopback the moment a future change bound it.
+            InterfaceSnapshot {
+                name: "lo0".into(),
+                zone: String::new(),
+                ifindex: LO0_IFINDEX,
+                hardware_addr: "02:00:00:00:00:83".into(),
+                addresses: vec![InterfaceAddressSnapshot {
+                    family: "inet".into(),
+                    address: "10.255.0.1/32".into(),
                     ..Default::default()
                 }],
                 ..Default::default()
@@ -1683,6 +1700,19 @@ fn empty_zone_addressed_interface_denies_host_inbound() {
     assert!(
         host_inbound_admits_iface(&state, EM0_IFINDEX, 0, PROTO_TCP, 22, false, 0),
         "em0 lifeline keeps its unconditional admit"
+    );
+
+    // Scope guard 3 (#5659 fold): lo0 is zoneless+addressed but is a lifeline
+    // per the widened predicate (mirrors `userspaceSkipsIngressInterface`), so it
+    // must NOT get a deny sentinel and must keep admitting host-bound bgp — the
+    // earlier fxp0/em0-only predicate would have armed a strand-management deny.
+    assert!(
+        !state.ifindex_host_inbound.contains_key(&LO0_IFINDEX),
+        "lo0 loopback lifeline must not get an empty-zone deny sentinel (#5659 fold)"
+    );
+    assert!(
+        host_inbound_admits_iface(&state, LO0_IFINDEX, 0, PROTO_TCP, 179, false, 0),
+        "lo0 loopback keeps host-bound bgp admit (router-id / update-source)"
     );
 
     // Anti-over-reject: the normal trust zone still admits its configured ssh.


### PR DESCRIPTION
## Summary

Closes the #2391 fail-closed-symmetry gap in the userspace-dp snapshot
builder: the helper-boundary backstop that fails a NON-EMPTY unknown zone
name closed is guarded by `!iface.zone.is_empty()`, so an **addressed**
interface with an **empty** `security-zone` string is skipped. It gets no
`ifindex_to_zone_id` entry and resolves to the global `zone_id 0`, while
its IP is still registered into `local_v4`/`local_v6` as a local-delivery
target. `host_inbound_admits(0)` then hits the `None => true` global-zone
admit arm and would admit **every** host-bound service (SSH/NETCONF/BGP/
SNMP…) on that interface — an asymmetry that breaks the fail-closed posture
#2391/#3405 established.

## Fix (approach (b): sentinel-deny, keyed by ifindex)

`populate_interfaces` (`forwarding_build/interfaces.rs`) now inserts an
**empty `ZoneHostInbound` sentinel** into `ifindex_host_inbound` keyed by
the interface's logical ifindex, so the ingress-interface-keyed
`host_inbound_admits_iface` (the local-delivery poll path's entry point)
**denies** host-bound services for a packet ingressing on it.

Scoped to an interface that is:
- **unzoned** (`iface.zone.is_empty()`),
- actually **registered a `local_v4`/`local_v6` target** (a real host-inbound
  exposure — a fully NAT-excluded or address-less iface is not),
- has **no explicit `host_inbound_configured` override** (never clobber the
  operator's per-interface set), and
- is **not a lifeline** (fxp0/em0/fab*, base-name match — never arm a deny on
  a management/HA link the moment a future change bound it).

### Why (b) sentinel-deny over (a) fail-closed snapshot, and why ifindex-keyed

Keying by **ifindex** — rather than inserting `zone_host_inbound[0]` or
failing the whole snapshot closed — is what preserves ND/PMTUD and the
genuinely-global path safely:

- The **global ICMP/ND/PMTUD accepts** (`is_icmp_host_inbound_global_accept`)
  are checked *before* the admission set in `host_inbound_admits_iface`, so
  control traffic is never black-holed.
- The **genuinely-global `zone_id 0` path** (`host_inbound_admits` with no
  matching ifindex override) is left **untouched**, so a legitimately-zoneless
  **non-addressed** control interface used only for ND/global control keeps its
  admit default. Inserting `zone_host_inbound[0]` would have denied that control
  interface's host-bound traffic — exactly what the issue says not to change.
- A hard snapshot-fail (a) would take the whole config down on a benign
  operator misconfiguration (an addressed iface that simply lacks a zone),
  which is a worse operational failure mode than a scoped per-interface deny.

## Reachability / honest framing

This is a **fail-closed-SYMMETRY / defense-in-depth** hardening, **not** a
confirmed live bypass. The runtime is bind-gated today:
`buildUserspaceBindNetdevs` skips `iface.Zone == ""`, so a plain
unzoned-addressed data interface is not AF_XDP-bound and its ingress goes to
the kernel path, not this userspace check. The fix closes the asymmetry so
any **future** change that binds a zoneless-addressed interface (or a
quarantine path, cf. `pkg/config/zoneid.go` #3719, that keeps an interface
bound while stripping its zone) cannot silently become a host-inbound bypass.

## Scope

Rust-only helper-boundary backstop, matching the #2391/#2409 pattern. The Go
control plane faithfully ships the raw config (`Zone: zoneByInterface[name]`
== "" when unzoned) and is the primary gate; it is **unchanged** — the
asymmetry is at the helper boundary and is fixed there.

## Test (RED-on-revert merge gate)

`empty_zone_addressed_interface_denies_host_inbound`
(`forwarding_build/tests.rs`):
- unzoned addressed interface → `local_v4`/`local_v6` populated AND
  resolves to `zone_id 0` (no `ifindex_to_zone_id` entry),
- `host_inbound_admits_iface(unzoned, 0, …)` **denies** SSH (tcp/22) and
  BGP (tcp/179),
- ICMPv4 destination-unreachable (type 3) and IPv6 Neighbor Solicitation
  (type 135) **stay admitted** (global accept),
- scope guards: the **global `zone_id 0` zone-only path still admits**, the
  **em0 lifeline gets no sentinel** and keeps its unconditional admit, and a
  normal trust zone still admits its configured ssh / denies bgp.

Neutralizing the sentinel insert turns the SSH/BGP deny assertions RED
(verified firsthand). Rust release build + `forwarding_build` /
`host_inbound` / `interfaces` module suites green.

## Docs

- `userspace-dp/src/afxdp/forwarding/README.md` — new "Empty-zone
  addressed-interface backstop (#5659)" paragraph in the host-inbound section.
- `host_inbound.rs` — cross-reference on the `None => true` arm noting the
  empty-zone case is denied at the ifindex level without touching the arm.
- `docs/host-inbound-service-matrix.md` unchanged: it documents the
  token→port matrix, not zone-id resolution.

Closes #5659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDVZdMNFDRWg6nkunsXHEY