### PR TITLE
userspace-dp: scope IPsec passthrough to a local destination

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-17 — #5620: IPsec passthrough claim needs a local-destination predicate
+
+- **Timestamp**: 2026-07-17 (fix/5620-ipsec-passthrough-local-dest)
+- **Action**: `stage_ipsec_passthrough_check` (Stage 11) claimed ANY
+  ESP/AH/IKE packet the shim steered to the helper for kernel-XFRM
+  passthrough, with no check that the destination was firewall-local — so a
+  TRANSIT UDP/500, UDP/4500 or IPv4 AH packet routed to a remote host was
+  reinjected to the local XFRM stack and SKIPPED transit zone policy
+  (codex-review-181 M03, High). Added a local-destination predicate:
+  `if !worker_ctx.forwarding.owns_configured_ip(flow.dst_ip) { return
+  NotClaimed; }` immediately after the `is_ipsec_traffic` gate and BEFORE the
+  #4323 host-inbound admission block. Stage 11 runs BEFORE NAT resolution
+  (only native-GRE decap precedes it), so `flow.dst_ip` is the RAW dst — but
+  `owns_configured_ip` (`configured_iface_v* ∪ local_v*`) already includes the
+  static-NAT/DNAT externals appended to `local_v*` in `forwarding_build`, so
+  the raw-dst check still claims DNAT/static-NAT-to-self IKE and native-GRE
+  inner local IPsec, and covers the SNAT/WAN interface IP + VIPs that
+  `local_v*` alone excludes. Raw outer ESP was never reachable here (the shim
+  shunts it to the kernel unconditionally), so only the shim-steered UDP-IKE /
+  IPv4-AH transit classes were the live bypass. Preserved the #4323
+  NEW-inbound-IKE host-inbound gate (runs after, only for local-destined IKE).
+- **File(s)**: `userspace-dp/src/afxdp/poll_stages.rs` (predicate + stage doc
+  comment), `userspace-dp/src/afxdp/poll_stages_tests.rs` (retargeted
+  `ipsec_flow` default dst to firewall-local, added `ipsec_flow_to` variant +
+  `run_stage11` harness + `stage_ipsec_passthrough_rejects_remote_transit_dst_5620`
+  RED-on-revert test + `stage_ipsec_passthrough_claims_local_and_nat_to_self_dst_5620`
+  over-reject/DNAT-to-self guard), `userspace-dp/src/afxdp/forwarding/README.md`
+  (#5620 subsection), `docs/host-inbound-service-matrix.md` (SECONDARY-path
+  scope note).
+- **Validation**: `cargo build --release` green; `cargo test --release`
+  poll/forwarding/ipsec filters → 335 passed, 0 failed incl. the 2 new tests
+  and the updated exempt/#4323 tests. RED-on-revert verified firsthand: with
+  the predicate neutralized (`if false && ...`, imports still used), both new
+  tests FAIL while the existing tests stay green.
+
 ## 2026-07-17 — #5658: static block-to-block & DNAT prefix minimum-prefix floor (fail-open on /0)
 
 - **Timestamp**: 2026-07-17 (fix/5658-static-nat-min-prefix-floor)

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -50,7 +50,12 @@ that MUST agree on the token set:
 3. **Rust AF_XDP classifier — SECONDARY enforcement.** The XSK
    local-delivery path, reached only by the subset of host-bound traffic that
    arrives on the AF_XDP fast path (e.g. DNAT/static-NAT to a firewall-local
-   address).
+   address). The IPsec passthrough stage (`stage_ipsec_passthrough_check`) is
+   likewise scoped to a firewall-local destination since #5620: it claims the
+   kernel-XFRM passthrough short-circuit ONLY when `flow.dst_ip` is an address
+   the firewall owns (`owns_configured_ip`), so a TRANSIT ESP/AH/IKE packet
+   routed to a remote host falls through to transit zone policy instead of
+   being reinjected to the local XFRM stack (codex-review-181 M03).
    - `classify_system_service` / `classify_protocol` —
      `userspace-dp/src/afxdp/forwarding/host_inbound.rs`
    - `is_icmp_host_inbound_global_accept` — same file (global ICMP/ND accepts)

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -703,8 +703,40 @@ established/return IKE ride `ct established,related accept` first.
 SECONDARY AF_XDP path (Stage 11) is reached only when IPsec is NOT
 shunted to the kernel: DNAT/static-NAT-to-self IKE, native-GRE inner
 IPsec whose inner destination is a firewall-local address (redirected to
-the XSK and decapped in userspace), and transit/NAT IPv4 AH. The #4323
-gate closes the NEW-inbound-IKE host-inbound parity gap on this path.
+the XSK and decapped in userspace), and transit/NAT IPv4 AH and IKE
+(UDP 500/4500) that the shim steered to the helper. The #4323 gate
+closes the NEW-inbound-IKE host-inbound parity gap on this path.
+
+### #5620: the passthrough claim is scoped to a firewall-local destination
+
+Stage 11 claims the kernel-XFRM passthrough short-circuit ONLY when the
+packet's destination is an address the firewall itself answers for
+(`ForwardingState::owns_configured_ip(flow.dst_ip)` — the configured
+interface IPs incl. the SNAT/WAN IP and VIPs, PLUS the static-NAT/DNAT
+externals appended to `local_v*`). Before #5620 the stage claimed ANY
+ESP/AH/IKE packet the shim steered to the helper regardless of
+destination, so a TRANSIT UDP/500, UDP/4500 or IPv4 AH packet routed to
+a remote host was reinjected to the local XFRM stack and SKIPPED transit
+zone-policy enforcement (codex-review-181 M03; raw outer ESP was never
+affected because the shim shunts it to the kernel unconditionally, so
+only the shim-steered UDP-IKE and IPv4-AH transit classes were
+reachable).
+
+Stage 11 runs BEFORE NAT resolution (only native-GRE decap precedes it),
+so `flow.dst_ip` is the RAW on-the-wire destination. Gating on the raw
+dst is nonetheless correct for the DNAT/static-NAT-to-self cases: the NAT
+externals are already members of `local_v*` (appended in
+`forwarding_build`), so `owns_configured_ip` recognises a DNAT-to-self
+external without needing the post-NAT address. GRE-inner-local IPsec is
+likewise covered — the decapped inner destination is a firewall
+interface address. A remote/transit destination is owned by nobody here,
+so the packet returns `NotClaimed` and continues to normal transit
+forwarding + zone policy. The predicate runs BEFORE the #4323
+host-inbound admission block, which only makes sense for genuinely
+host-inbound (local-destined) IKE. Regression-guarded by
+`stage_ipsec_passthrough_rejects_remote_transit_dst_5620` (remote dst →
+NotClaimed) and `stage_ipsec_passthrough_claims_local_and_nat_to_self_dst_5620`
+(local / WAN-IP / DNAT-to-self dst → Passthrough).
 
 **Zone resolution.** The gate resolves the LOGICAL ingress ifindex +
 from-zone exactly as the local-delivery resolver does

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -941,6 +941,14 @@ pub(super) fn stage_ipsec_passthrough_check(
     // instead continues to transit forwarding + zone-policy evaluation. This
     // gate runs BEFORE the #4323 host-inbound admission block, which only
     // makes sense for genuinely host-inbound (local-destined) IKE.
+    //
+    // Caveat: a DNAT external that maps to ANOTHER host (transit-DNAT IPsec,
+    // e.g. IKE VIP -> internal gateway) is ALSO in `local_v*` (proxy-ARP/ND
+    // ownership), so this raw-dst check still claims it as local passthrough
+    // rather than DNAT-forwarding it onward. That exotic case is UNCHANGED by
+    // #5620 — pre-#5620 Stage 11 claimed ALL IPsec, so it was already
+    // reinjected locally; #5620 only fixes the transit-to-REMOTE bypass and
+    // leaves the transit-DNAT-to-another-host behavior bit-identical.
     if !worker_ctx.forwarding.owns_configured_ip(flow.dst_ip) {
         return IpsecPassthroughOutcome::NotClaimed;
     }

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -896,6 +896,22 @@ pub(super) enum IpsecPassthroughOutcome {
 /// still enforced on the PRIMARY path by the kernel nftables host-inbound chain
 /// (`pkg/daemon/daemon_nft.go`).
 ///
+/// #5620: the kernel-XFRM passthrough short-circuit is claimed ONLY when the
+/// packet's (post-GRE-decap, on-the-wire) destination is an address the
+/// firewall itself answers for (`forwarding.owns_configured_ip` — configured
+/// interface IPs incl. the SNAT/WAN IP and any VIP, plus the static-NAT/DNAT
+/// externals appended to `local_v*`). Stage 11 runs BEFORE NAT resolution, so
+/// `flow.dst_ip` is the RAW destination; because the NAT externals are already
+/// members of the local set, the raw-dst check still recognises the legitimate
+/// SECONDARY-path cases — DNAT/static-NAT-to-self IKE (the external is a
+/// firewall-owned address) and native-GRE-inner local IPsec (the decapped
+/// inner destination is a firewall interface address). A remote / transit ESP,
+/// AH or IKE destination is owned by nobody here → `NotClaimed`, so the packet
+/// is NOT reinjected to the local XFRM stack and instead continues to normal
+/// transit forwarding + zone-policy evaluation. Without this predicate any
+/// ESP/AH/IKE packet — including one transiting to a remote host — bypassed
+/// transit policy.
+///
 /// Non-IPsec packets fall through unchanged (`NotClaimed`).
 #[inline]
 pub(super) fn stage_ipsec_passthrough_check(
@@ -911,6 +927,21 @@ pub(super) fn stage_ipsec_passthrough_check(
     };
     let dst_port = flow.forward_key.dst_port;
     if !is_ipsec_traffic(meta.protocol, dst_port) {
+        return IpsecPassthroughOutcome::NotClaimed;
+    }
+    // #5620: claim the kernel-XFRM passthrough short-circuit ONLY for
+    // IPsec whose destination is a firewall-local address. Stage 11 runs
+    // BEFORE NAT resolution (only GRE decap precedes it), so `flow.dst_ip`
+    // is the RAW on-the-wire destination — but `owns_configured_ip` already
+    // includes the static-NAT/DNAT externals appended to `local_v*`, so this
+    // still claims DNAT/static-NAT-to-self IKE and native-GRE-inner local
+    // IPsec (whose decapped inner dst is a firewall interface address). A
+    // remote / transit ESP/AH/IKE destination is owned by nobody here →
+    // `NotClaimed`, so the packet is NOT reinjected to the local stack and
+    // instead continues to transit forwarding + zone-policy evaluation. This
+    // gate runs BEFORE the #4323 host-inbound admission block, which only
+    // makes sense for genuinely host-inbound (local-destined) IKE.
+    if !worker_ctx.forwarding.owns_configured_ip(flow.dst_ip) {
         return IpsecPassthroughOutcome::NotClaimed;
     }
     // #4323 Option B: gate ONLY a NEW inbound IKE initiation; ESP/AH and every

--- a/userspace-dp/src/afxdp/poll_stages_tests.rs
+++ b/userspace-dp/src/afxdp/poll_stages_tests.rs
@@ -2152,17 +2152,31 @@ fn fabric_ingress_skips_rate_flood_direct_still_counts_4155() {
 //      and leaves non-IPsec traffic untouched (`Continue`).
 // If Option B is ever implemented these tests must be updated deliberately.
 
+/// A firewall-LOCAL-destined IPsec flow. Since #5620, Stage 11 claims the
+/// kernel-XFRM passthrough short-circuit ONLY when `flow.dst_ip` is an address
+/// the firewall owns, so the exemption / host-inbound-gate assertions below —
+/// which are all about LOCAL-destined IPsec — must use a firewall-local
+/// destination. `10.0.61.1` / `2001:559:8585:ef00::1` is the lan interface IP
+/// in both the `nat_snapshot` and `ike_gate_snapshot` fixtures (it lives in
+/// `local_v*` AND `configured_iface_v*`). Remote/transit-destination cases use
+/// [`ipsec_flow_to`] with a non-firewall address.
 fn ipsec_flow(family: i32, protocol: u8, dst_port: u16) -> SessionFlow {
-    let (src_ip, dst_ip) = if family == libc::AF_INET6 {
-        (
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x10)),
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x1)),
-        )
+    let dst_ip = if family == libc::AF_INET6 {
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x559, 0x8585, 0xef00, 0, 0, 0, 0x1))
     } else {
-        (
-            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
-            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
-        )
+        IpAddr::V4(Ipv4Addr::new(10, 0, 61, 1))
+    };
+    ipsec_flow_to(family, protocol, dst_port, dst_ip)
+}
+
+/// As [`ipsec_flow`] but with an explicit destination — used by the #5620
+/// remote/transit-destination tests (a non-firewall dst that `owns_configured_ip`
+/// rejects) and the DNAT-to-self preservation test (a NAT external in `local_v*`).
+fn ipsec_flow_to(family: i32, protocol: u8, dst_port: u16, dst_ip: IpAddr) -> SessionFlow {
+    let src_ip = if family == libc::AF_INET6 {
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x10))
+    } else {
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))
     };
     SessionFlow {
         src_ip,
@@ -2633,4 +2647,230 @@ fn stage_ipsec_passthrough_gates_new_ike_4323() {
         ),
         "raw ESP must stay unconditionally exempt on any zone (#4323)",
     );
+}
+
+/// #5620 test harness: run Stage 11 against `forwarding` with a full but inert
+/// (`slow_path: None`) WorkerContext and return the stage outcome. The frame /
+/// meta are supplied by the caller; the ingress ifindex (24) matches the lan
+/// interface in `nat_snapshot`, so the #4323 host-inbound resolve keys the lan
+/// zone (which carries `system-services all`).
+fn run_stage11(
+    forwarding: &ForwardingState,
+    flow: &SessionFlow,
+    frame: &[u8],
+    meta: UserspaceDpMeta,
+) -> IpsecPassthroughOutcome {
+    let ident = BindingIdentity {
+        slot: 0,
+        queue_id: 0,
+        worker_id: 0,
+        interface: Arc::<str>::from("reth1.0"),
+        ifindex: 24,
+    };
+    let live = BindingLiveState::new();
+    let binding_lookup = WorkerBindingLookup::default();
+    let mirror_targets = MirrorTargetMap::default();
+    let ha_state = BTreeMap::new();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let last_resolution = Arc::new(Mutex::new(None));
+    let peer_worker_commands = Vec::new();
+    let dnat_fds = DnatTableFds::default();
+    let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+    let (event_handle, _event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let worker_ctx = WorkerContext {
+        ident: &ident,
+        binding_lookup: &binding_lookup,
+        mirror_targets: &mirror_targets,
+        forwarding,
+        ha_state: &ha_state,
+        dynamic_neighbors: &dynamic_neighbors,
+        neighbor_resolver: None,
+        shared_sessions: &shared_sessions,
+        shared_nat_sessions: &shared_nat_sessions,
+        shared_forward_wire_sessions: &shared_forward_wire_sessions,
+        shared_owner_rg_indexes: &shared_owner_rg_indexes,
+        slow_path: None,
+        event_stream: Some(&event_handle),
+        local_tunnel_deliveries: &local_tunnel_deliveries,
+        recent_exceptions: &recent_exceptions,
+        last_resolution: &last_resolution,
+        peer_worker_commands: &peer_worker_commands,
+        dnat_fds: &dnat_fds,
+        rg_epochs: &rg_epochs,
+        cold_path_sample_mask: 0xff,
+    };
+    stage_ipsec_passthrough_check(Some(flow), frame, meta, None, &live, &worker_ctx)
+}
+
+/// #5620 RED-on-revert: Stage 11 must NOT claim the kernel-XFRM passthrough
+/// short-circuit for IPsec whose destination is REMOTE (not a firewall-local
+/// address). Before the fix, `is_ipsec_traffic` claimed ANY ESP/AH/IKE packet
+/// regardless of destination, so a TRANSIT ESP/AH/IKE packet was reinjected to
+/// the local XFRM stack and skipped transit zone-policy enforcement.
+///
+/// A remote-destination UDP/500, UDP/4500, IPv4 AH (proto 51), IPv4 ESP
+/// (proto 50) and IPv6 ESP packet must each return `NotClaimed` so it falls
+/// through to normal transit forwarding + policy.
+///
+/// Fail-on-revert: drop the `owns_configured_ip(flow.dst_ip)` predicate in
+/// `stage_ipsec_passthrough_check` and every assertion below flips to
+/// `Passthrough` — the transit-policy bypass returns.
+#[test]
+fn stage_ipsec_passthrough_rejects_remote_transit_dst_5620() {
+    let forwarding = build_forwarding_state(&super::super::test_fixtures::nat_snapshot());
+
+    // Frame bytes are immaterial: the #5620 predicate returns `NotClaimed`
+    // before `classify_ipsec_admission` ever parses the frame. Classification
+    // keys on `meta.protocol` + `flow.forward_key.dst_port` + `flow.dst_ip`.
+    let frame = tcp_v4_frame(
+        Ipv4Addr::new(192, 0, 2, 10),
+        Ipv4Addr::new(198, 51, 100, 1),
+        40000,
+        500,
+        TCP_FLAG_ACK,
+        1,
+        1,
+    );
+    let remote_v4 = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
+    let remote_v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x1));
+
+    // (family, proto, dst_port, remote_dst, label)
+    let cases: [(i32, u8, u16, IpAddr, &str); 5] = [
+        (libc::AF_INET, PROTO_UDP, 500, remote_v4, "IKE UDP/500 v4"),
+        (libc::AF_INET, PROTO_UDP, 4500, remote_v4, "NAT-T UDP/4500 v4"),
+        (libc::AF_INET, PROTO_AH, 0, remote_v4, "AH proto 51 v4"),
+        (libc::AF_INET, PROTO_ESP, 0, remote_v4, "ESP proto 50 v4"),
+        (libc::AF_INET6, PROTO_ESP, 0, remote_v6, "ESP proto 50 v6"),
+    ];
+    for (family, protocol, dst_port, dst_ip, label) in cases {
+        let flow = ipsec_flow_to(family, protocol, dst_port, dst_ip);
+        let mut meta = tcp_v4_meta(&frame, TCP_FLAG_ACK);
+        meta.addr_family = family as u8;
+        meta.protocol = protocol;
+        assert!(
+            matches!(
+                run_stage11(&forwarding, &flow, &frame, meta),
+                IpsecPassthroughOutcome::NotClaimed
+            ),
+            "#5620: remote-destination {label} must NOT be claimed by Stage 11 \
+             (NotClaimed) — it must fall through to transit zone policy, not be \
+             reinjected to the local XFRM stack",
+        );
+    }
+}
+
+/// #5620 over-reject guard + DNAT-to-self preservation: Stage 11 MUST still
+/// claim legitimate LOCAL-destined IPsec after the local-destination predicate
+/// is added. This pins the CRITICAL preservation cases the fix must not break
+/// (breaking VPN termination is worse than the transit bypass):
+///
+///   - ESP to the lan interface IP (`10.0.61.1`, in `local_v*`)          → Passthrough
+///   - ESP to the WAN/SNAT interface IP (`172.16.80.8`) — EXCLUDED from
+///     `local_v*` by the interface-mode-SNAT `nat_translated_local_exclusions`
+///     but present in `configured_iface_v*`, so `owns_configured_ip` still
+///     recognises it (the most common VPN termination address)             → Passthrough
+///   - ESP to a DNAT-to-self external (`203.0.113.9`, appended to `local_v*`
+///     by the DNAT rule's destination address) — proves the RAW pre-NAT dst
+///     check does NOT wrongly reject NAT-to-self                            → Passthrough
+///
+/// A never-configured remote address (`203.0.113.200`) is the control: it is
+/// in neither set → `NotClaimed`, proving the DNAT append (not a blanket
+/// accept) is what claims `203.0.113.9`.
+///
+/// Fail-on-revert: this test guards AGAINST over-reject; it stays GREEN with
+/// the fix and would break if the predicate rejected a firewall-owned dst.
+#[test]
+fn stage_ipsec_passthrough_claims_local_and_nat_to_self_dst_5620() {
+    let mut snap = super::super::test_fixtures::nat_snapshot();
+    // DNAT a public external (UDP/500 IKE) to the firewall itself — NAT-to-self.
+    // The rule's `destination_address` is appended to `local_v4`, so the raw
+    // pre-NAT dst check in Stage 11 recognises it as firewall-local.
+    snap.destination_nat_rules = vec![crate::DestinationNATRuleSnapshot {
+        name: "ike-dnat-to-self".to_string(),
+        from_zone: "wan".to_string(),
+        destination_address: "203.0.113.9".to_string(),
+        destination_port: 500,
+        protocol: "udp".to_string(),
+        pool_address: "10.0.61.1".to_string(),
+        pool_port: 500,
+        ..Default::default()
+    }];
+    let forwarding = build_forwarding_state(&snap);
+    // Precondition: the DNAT external is a firewall-local address; the control
+    // remote address is not.
+    assert!(
+        forwarding
+            .owns_configured_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)))
+    );
+    assert!(
+        !forwarding
+            .owns_configured_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 200)))
+    );
+
+    let frame = tcp_v4_frame(
+        Ipv4Addr::new(192, 0, 2, 10),
+        Ipv4Addr::new(203, 0, 113, 9),
+        40000,
+        500,
+        TCP_FLAG_ACK,
+        1,
+        1,
+    );
+
+    // (dst, expect_passthrough, label)
+    let cases: [(IpAddr, bool, &str); 4] = [
+        (
+            IpAddr::V4(Ipv4Addr::new(10, 0, 61, 1)),
+            true,
+            "lan interface IP (local_v4)",
+        ),
+        (
+            IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            true,
+            "WAN/SNAT interface IP (configured_iface_v4 only)",
+        ),
+        (
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)),
+            true,
+            "DNAT-to-self external (local_v4 via DNAT append)",
+        ),
+        (
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 200)),
+            false,
+            "never-configured remote (control)",
+        ),
+    ];
+    for (dst, expect_passthrough, label) in cases {
+        // Raw ESP: unconditionally exempt from the #4323 host-inbound gate, so
+        // this isolates the #5620 local-destination predicate.
+        let flow = ipsec_flow_to(libc::AF_INET, PROTO_ESP, 0, dst);
+        let mut meta = tcp_v4_meta(&frame, TCP_FLAG_ACK);
+        meta.protocol = PROTO_ESP;
+        let outcome = run_stage11(&forwarding, &flow, &frame, meta);
+        if expect_passthrough {
+            assert!(
+                matches!(outcome, IpsecPassthroughOutcome::Passthrough),
+                "#5620: LOCAL-destined ESP to {label} must stay claimed \
+                 (Passthrough) — over-rejecting it would break VPN termination",
+            );
+        } else {
+            assert!(
+                matches!(outcome, IpsecPassthroughOutcome::NotClaimed),
+                "#5620: ESP to {label} must be NotClaimed (proves the claim is \
+                 scoped to firewall-owned addresses, not a blanket accept)",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem (codex-review-181 M03, High, security)

`stage_ipsec_passthrough_check` (Stage 11, `userspace-dp/src/afxdp/poll_stages.rs`) claimed **any** ESP/AH/IKE packet the AF_XDP shim steered to the helper for kernel-XFRM passthrough — building a synthetic `LocalDelivery` decision and reinjecting via the slow-path TUN — with **no check that the destination was firewall-local**. So a **transit** UDP/500, UDP/4500 or IPv4 AH packet routed to a *remote* host was reinjected to the local XFRM stack and **skipped transit zone-policy enforcement**.

(Raw outer ESP was never reachable here — the shim shunts it to the kernel unconditionally — so the live bypass was the shim-steered UDP-IKE and IPv4-AH transit classes.)

## Fix

Add a local-destination predicate immediately after the `is_ipsec_traffic` gate and **before** the #4323 host-inbound admission block:

```rust
if !worker_ctx.forwarding.owns_configured_ip(flow.dst_ip) {
    return IpsecPassthroughOutcome::NotClaimed;
}
```

A remote/transit destination is owned by nobody → `NotClaimed`, so the packet continues to normal transit forwarding + zone policy instead of being reinjected to the local stack.

### DNAT-to-self is preserved (the delicate part)

Stage 11 runs **before** NAT resolution (only native-GRE decap precedes it in `poll_descriptor`), so `flow.dst_ip` is the **raw** on-the-wire destination. Gating on the raw dst is nonetheless correct: `forwarding_build` appends every static-NAT external and DNAT destination IP to `local_v*`, and `owns_configured_ip` (`configured_iface_v* ∪ local_v*`) unions those with every configured interface IP — including the SNAT/WAN IP and VIPs that `local_v*` alone excludes. So:

- **DNAT/static-NAT-to-self IKE** — the NAT external is in `local_v*` → still `Passthrough`.
- **native-GRE inner local IPsec** — the decapped inner dst is a firewall interface IP → still `Passthrough`.
- **direct-to-interface-IP / WAN-IP / VIP IPsec** — in `configured_iface_v*` → still `Passthrough`.
- **remote/transit** — owned by nobody → `NotClaimed`.

The #4323 NEW-inbound-IKE host-inbound gate is left intact and correctly ordered (it now runs only for genuinely local-destined IKE).

## Tests (fail-on-revert merge gate)

- `stage_ipsec_passthrough_rejects_remote_transit_dst_5620` — remote-dst UDP/500, UDP/4500, IPv4 AH (51), IPv4 ESP (50) and IPv6 ESP each → `NotClaimed`.
- `stage_ipsec_passthrough_claims_local_and_nat_to_self_dst_5620` — over-reject guard: local interface IP, WAN/SNAT IP (`configured_iface` only), and a **DNAT-to-self external** all stay `Passthrough`; a never-configured remote is the `NotClaimed` control.
- Retargeted the shared `ipsec_flow` helper to a firewall-local dst so the existing exempt/#4323 assertions still exercise the passthrough path; added an `ipsec_flow_to` variant + `run_stage11` harness.

**RED-on-revert verified firsthand:** neutralizing the predicate flips both new tests to FAILED while the existing tests stay green. `cargo build --release` green; poll/forwarding/ipsec test filters pass **335/335**.

## Docs

- `userspace-dp/src/afxdp/forwarding/README.md` — new #5620 subsection on the local-destination claim scope.
- `docs/host-inbound-service-matrix.md` — SECONDARY-path scope note.

## Smoke

This changes the live IPsec-passthrough-vs-transit forwarding decision, so it needs a **loss-cluster smoke** (parent will run it).

Closes #5620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdJ2cKkLA2AdbNcKR3N5xF