### PR TITLE
config: reject mixed-family GRE outer source/destination at commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-17 — #5162: GRE tunnel with mixed-family outer source/destination commits clean then silently drops
+
+- **Timestamp**: 2026-07-17 (fix/5162-gre-outer-family-gate)
+- **Action**: added a cross-field outer-family gate for non-WireGuard
+  tunnels. A GRE/IPIP tunnel whose outer `tunnel source` and `tunnel
+  destination` are different address families (v4 src + v6 dst, or the
+  reverse) passed per-leaf validation and COMMITTED CLEAN, but the Go
+  snapshot producer tags the endpoint `inet6` when EITHER endpoint is v6,
+  so the Rust GRE encoder hit the AF_INET6 arm, found a v4 endpoint, and
+  returned None → every encapsulated packet was silently dropped. New Go
+  strict commit gate `validateTunnelOuterFamilyStrict` (mirrors the
+  WireGuard endpoint-family gate — one encap = one outer family) rejects
+  the mixed pair at commit / commit-check and downgrades to a warning on
+  the tolerant load / peer-sync path (`lenientTunnelOuterFamily`, #1960
+  no-brick). Rust `populate_tunnel_endpoints` gains a helper-boundary
+  backstop that SKIPS a mixed-family non-WG row with a loud `eprintln!`
+  (mirrors the WG hydrate row-drop / allowed-ips skip-and-continue) for a
+  mixed-version peer-sync / corrupt snapshot the Go gate cannot cover.
+  Fail-on-revert tests verified RED both sides (Go commit-path reject,
+  Rust row-skip).
+- **File(s)**:
+  pkg/config/compiler_validate_tunnel_family.go (new gate),
+  pkg/config/compiler_tailgates.go (wire gate after the WG gate),
+  pkg/config/compiler.go (`lenientTunnelOuterFamily` flag + both lenient
+    entry points),
+  pkg/config/compiler_validate_tunnel_family_5162_test.go (new Go tests),
+  userspace-dp/src/afxdp/forwarding_build/tunnels.rs (Rust backstop skip),
+  userspace-dp/src/afxdp/forwarding_build/tests.rs (3 new Rust tests),
+  docs/feature-coverage.md (GRE row same-outer-family note)
+
 ## 2026-07-17 — #5620: IPsec passthrough claim needs a local-destination predicate
 
 - **Timestamp**: 2026-07-17 (fix/5620-ipsec-passthrough-local-dest)

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -355,7 +355,7 @@ The exact admission boundary is documented in
 | Screen/IDS (16 checks) | Yes; userspace SYN-cookie runtime is wired |
 | Firewall filters + policers | Filters yes; three-color policers admitted for the reviewed color-blind `then discard` slice; broader color-aware and non-drop action work is tracked as production hardening |
 | TCP MSS clamping | Yes |
-| GRE tunnel transit | Yes (passthrough) |
+| GRE tunnel transit | Yes (passthrough). **Same-outer-family required (#5162):** a GRE/IPIP tunnel's outer `tunnel source` and `tunnel destination` must be the SAME address family (both IPv4 or both IPv6). A mixed pair (v4 source + v6 destination, or the reverse) passes per-leaf validation but the snapshot producer tags it `inet6` whenever either endpoint is v6, so the encoder hits the AF_INET6 arm, finds the v4 endpoint, and silently drops every encapsulated packet. It is HARD-REJECTED at strict commit (`validateTunnelOuterFamilyStrict`, mirroring the WireGuard endpoint-family gate — one encap = one outer family), downgraded to a warning on the tolerant load / peer-sync path (#1960 no-brick), and the Rust `populate_tunnel_endpoints` independently SKIPS a mixed-family non-WG row with a loud diagnostic so a peer-synced degenerate row installs nothing rather than a blackhole |
 | IPsec / XFRM | Yes (passthrough) |
 | VLANs (802.1Q) | Yes |
 | Flow export (NetFlow v9) | Yes |

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1041,6 +1041,18 @@ type compileOpts struct {
 	// reconcile is dup-pubkey-safe, so a leniently-loaded bad config is
 	// inert. Same doctrine as lenientNATHostMask.
 	lenientWireguardPeers bool
+	// lenientTunnelOuterFamily (#5162) downgrades the non-WireGuard tunnel
+	// outer-family cross-field gate (validateTunnelOuterFamilyStrict) from a
+	// hard compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects a GRE/IPIP tunnel whose outer source
+	// and destination are different address families (a mixed pair commits
+	// clean but the dataplane silently drops every encapsulated packet). The
+	// tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config still BOOTS (#1960 no-brick) —
+	// the Rust populate_tunnel_endpoints independently skips a mixed-family
+	// non-WG row (fail-closed with a loud eprintln), so a leniently-loaded
+	// bad tunnel is inert. Same doctrine as lenientWireguardPeers.
+	lenientTunnelOuterFamily bool
 	// lenientPolicyZoneRefs (#2401) downgrades the security-policy
 	// zone-pair reference gate (validatePolicyZoneReferencesStrict) from a
 	// hard compile error to a cfg.Warnings entry. The strict commit /
@@ -2009,6 +2021,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRouteDispositionConflict:        true,
 		lenientDHCPStaticBindings:              true,
 		lenientWireguardPeers:                  true,
+		lenientTunnelOuterFamily:               true,
 		lenientPolicyZoneRefs:                  true,
 		lenientZoneCount:                       true,
 		lenientWebManagementAuth:               true,
@@ -2380,6 +2393,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRouteDispositionConflict:        true,
 		lenientDHCPStaticBindings:              true,
 		lenientWireguardPeers:                  true,
+		lenientTunnelOuterFamily:               true,
 		lenientPolicyZoneRefs:                  true,
 		lenientZoneCount:                       true,
 		lenientWebManagementAuth:               true,

--- a/pkg/config/compiler_tailgates.go
+++ b/pkg/config/compiler_tailgates.go
@@ -195,6 +195,26 @@ func runTailGates(cfg *Config, opts compileOpts) error {
 	}
 	cfg.Warnings = append(cfg.Warnings, wgPeerWarnings...)
 
+	// #5162: non-WireGuard tunnel outer-family cross-field gate. A GRE/IPIP
+	// tunnel whose OUTER source and destination are different address
+	// families (v4 source + v6 destination, or the reverse) passes per-leaf
+	// validation and COMMITS CLEAN, but the snapshot producer tags the
+	// endpoint `inet6` when EITHER endpoint is v6, so the Rust GRE encoder
+	// hits the AF_INET6 arm, finds a v4 endpoint, and returns None → every
+	// encapsulated packet is silently dropped. Strict (commit /
+	// commit-check): hard-reject the mixed-family pair, mirroring the
+	// WireGuard endpoint-family gate above (one encap = one outer family).
+	// Lenient (load / peer-sync): warn so a config committed before this
+	// gate existed still boots — the Rust helper independently skips a
+	// mixed-family non-WG row (forwarding_build/tunnels.rs), so the bad
+	// tunnel is inert rather than a silent blackhole. Runs after the WG gate
+	// so a WG-specific error still wins the first-error slot.
+	tunnelFamilyWarnings, err := validateTunnelOuterFamilyStrict(cfg, opts.lenientTunnelOuterFamily)
+	if err != nil {
+		return err
+	}
+	cfg.Warnings = append(cfg.Warnings, tunnelFamilyWarnings...)
+
 	// #1892: retired DPDK-era `system dataplane` knobs (cores, memory,
 	// socket-mem, rx-mode, ports) parse for stored-config compatibility
 	// but configure nothing — warn so the operator knows the stanza is

--- a/pkg/config/compiler_validate_tunnel_family.go
+++ b/pkg/config/compiler_validate_tunnel_family.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"sort"
+)
+
+// validateTunnelOuterFamilyStrict enforces the cross-field outer-family
+// invariant on every non-WireGuard tunnel (#5162): the OUTER source and
+// OUTER destination of a GRE/IPIP tunnel must be the SAME address family.
+//
+// The defect this closes: per-leaf validation accepts a v4 source and a
+// v6 destination independently (each is a valid IP literal), so a mixed
+// pair COMMITS CLEAN. The Go snapshot producer
+// (pkg/dataplane/userspace/tunnels.go) then tags the endpoint `inet6` if
+// EITHER endpoint is v6, and the Rust populate_tunnel_endpoints trusts
+// that declared family. The GRE encoder subsequently hits the AF_INET6
+// arm, finds a v4 endpoint, and returns None → every encapsulated packet
+// is SILENTLY dropped with no operator signal. This mirrors the sibling
+// WireGuard cross-field family gate (validateWireguardPeersStrict:
+// endpoint-bearing peers must agree on outer family — one UDP socket =
+// one family) but applies it to the GRE/IPIP outer source/destination
+// pair, which had no such gate.
+//
+// WireGuard is intentionally skipped here: a WG tunnel carries no
+// Source/Destination pair (the peer endpoint lives in WgPeers), and its
+// outer family is already validated by validateWireguardPeersStrict.
+//
+// Strict (commit / commit-check): hard-reject a mixed-family pair naming
+// the tunnel and the two families, so the operator sees the
+// misconfiguration and it never reaches the dataplane to drop silently.
+// Lenient (load / peer-sync): downgrade to a warning so a config
+// committed before this gate existed (or synced from a peer running an
+// older build) still BOOTS (#1960 no-brick) — the Rust helper
+// independently skips a mixed-family non-WG row (fail-closed with a loud
+// eprintln, forwarding_build/tunnels.rs), so the leniently-loaded bad
+// tunnel is inert rather than a silent inet6-tagged blackhole.
+func validateTunnelOuterFamilyStrict(cfg *Config, lenient bool) ([]string, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	var warnings []string
+
+	// Deterministic iteration order so the first reported error is stable
+	// across runs and both HA nodes report identically.
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, name)
+	}
+	sort.Strings(ifNames)
+
+	emit := func(label string, err error) error {
+		if err == nil {
+			return nil
+		}
+		if lenient {
+			warnings = append(warnings, fmt.Sprintf("tunnel %s: %v", label, err))
+			return nil
+		}
+		return fmt.Errorf("tunnel %s: %w", label, err)
+	}
+
+	for _, ifName := range ifNames {
+		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil {
+			continue
+		}
+		if ifc.Tunnel != nil {
+			label := tunnelLabel(ifName, -1, ifc.Tunnel)
+			if err := emit(label, validateOneTunnelOuterFamily(ifc.Tunnel)); err != nil {
+				return warnings, err
+			}
+		}
+		unitNums := make([]int, 0, len(ifc.Units))
+		for n := range ifc.Units {
+			unitNums = append(unitNums, n)
+		}
+		sort.Ints(unitNums)
+		for _, n := range unitNums {
+			unit := ifc.Units[n]
+			if unit == nil || unit.Tunnel == nil {
+				continue
+			}
+			label := tunnelLabel(ifName, n, unit.Tunnel)
+			if err := emit(label, validateOneTunnelOuterFamily(unit.Tunnel)); err != nil {
+				return warnings, err
+			}
+		}
+	}
+	return warnings, nil
+}
+
+// validateOneTunnelOuterFamily checks the outer source/destination family
+// agreement of a single tunnel. Returns nil for WireGuard (no
+// Source/Destination pair; family validated by
+// validateWireguardPeersStrict), for a tunnel missing either endpoint
+// (the emitter's source/dest gate declines to emit a half-configured
+// non-WG endpoint, so it never reaches the dataplane), and for an
+// unparseable endpoint (a malformed literal cannot be classified — that
+// is a separate schema-level concern, not a cross-field family
+// mismatch). It rejects ONLY a pair where both endpoints parse to
+// concrete IPs of DIFFERENT families.
+func validateOneTunnelOuterFamily(tc *TunnelConfig) error {
+	if tc == nil || tc.Mode == "wireguard" {
+		return nil
+	}
+	if tc.Source == "" || tc.Destination == "" {
+		return nil
+	}
+	src := net.ParseIP(tc.Source)
+	dst := net.ParseIP(tc.Destination)
+	if src == nil || dst == nil {
+		return nil
+	}
+	srcV6 := src.To4() == nil
+	dstV6 := dst.To4() == nil
+	if srcV6 != dstV6 {
+		return fmt.Errorf(
+			"outer source %s (%s) and destination %s (%s) are different address families; "+
+				"a GRE/IPIP tunnel encapsulates in ONE outer IP family, so both endpoints "+
+				"must be IPv4 or both IPv6 (a mixed pair commits clean but the dataplane "+
+				"silently drops every encapsulated packet, #5162)",
+			tc.Source, familyName(srcV6), tc.Destination, familyName(dstV6))
+	}
+	return nil
+}
+
+// familyName renders the operator-facing family label for a tunnel
+// endpoint from the "is IPv6" boolean.
+func familyName(isV6 bool) string {
+	if isV6 {
+		return "IPv6"
+	}
+	return "IPv4"
+}

--- a/pkg/config/compiler_validate_tunnel_family_5162_test.go
+++ b/pkg/config/compiler_validate_tunnel_family_5162_test.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasFamilyMismatch reports whether err carries the #5162 mixed-family
+// tunnel rejection message.
+func hasFamilyMismatch(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "different address families")
+}
+
+// treeFromSet builds a ConfigTree from flat-set commands via the
+// ParseSetCommand + SetPath loop (the dual-AST gotcha: NEVER NewParser
+// for newline-separated set lines). Used by the lenient-path case, which
+// needs CompileConfigLenient rather than compileSet's strict CompileConfig.
+func treeFromSet(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%v): %v", path, err)
+		}
+	}
+	return tree
+}
+
+// TestTunnelOuterFamilyGate exercises the #5162 cross-field outer-family
+// gate directly: a mixed-family GRE outer pair (both orders, interface-
+// and unit-level) is rejected on the strict path and downgraded to a
+// warning on the lenient path, while a same-family v4/v4 and v6/v6 pair
+// (and a WireGuard tunnel, which carries no Source/Destination) are
+// accepted. This is the fail-on-revert guard for the gate function.
+func TestTunnelOuterFamilyGate(t *testing.T) {
+	// (a) v4 source + v6 destination, interface-level → strict reject.
+	cfgA := &Config{}
+	cfgA.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"gr-0/0/0": {Name: "gr-0/0/0", Tunnel: &TunnelConfig{
+			Mode: "gre", Source: "192.0.2.1", Destination: "2001:db8::1"}},
+	}
+	if _, err := validateTunnelOuterFamilyStrict(cfgA, false); !hasFamilyMismatch(err) {
+		t.Fatalf("(a) v4-src/v6-dst GRE must be rejected, got %v", err)
+	}
+
+	// (b) reverse order: v6 source + v4 destination → strict reject.
+	cfgB := &Config{}
+	cfgB.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"gr-0/0/0": {Name: "gr-0/0/0", Tunnel: &TunnelConfig{
+			Mode: "gre", Source: "2001:db8::1", Destination: "192.0.2.1"}},
+	}
+	if _, err := validateTunnelOuterFamilyStrict(cfgB, false); !hasFamilyMismatch(err) {
+		t.Fatalf("(b) v6-src/v4-dst GRE must be rejected, got %v", err)
+	}
+
+	// (c) same-family v4/v4 → no error (over-reject guard).
+	cfgC := &Config{}
+	cfgC.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"gr-0/0/0": {Name: "gr-0/0/0", Tunnel: &TunnelConfig{
+			Mode: "gre", Source: "192.0.2.1", Destination: "192.0.2.2"}},
+	}
+	if w, err := validateTunnelOuterFamilyStrict(cfgC, false); err != nil || len(w) != 0 {
+		t.Fatalf("(c) v4/v4 GRE must commit clean, got err=%v warns=%v", err, w)
+	}
+
+	// (d) same-family v6/v6 → no error (over-reject guard).
+	cfgD := &Config{}
+	cfgD.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"gr-0/0/0": {Name: "gr-0/0/0", Tunnel: &TunnelConfig{
+			Mode: "gre", Source: "2001:db8::1", Destination: "2001:db8::2"}},
+	}
+	if w, err := validateTunnelOuterFamilyStrict(cfgD, false); err != nil || len(w) != 0 {
+		t.Fatalf("(d) v6/v6 GRE must commit clean, got err=%v warns=%v", err, w)
+	}
+
+	// (e) unit-level mixed pair → strict reject naming the tunnel.
+	cfgE := &Config{}
+	cfgE.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"gr-0/0/0": {Name: "gr-0/0/0", Units: map[int]*InterfaceUnit{
+			0: {Tunnel: &TunnelConfig{Mode: "gre", Source: "192.0.2.1", Destination: "2001:db8::1"}},
+		}},
+	}
+	if _, err := validateTunnelOuterFamilyStrict(cfgE, false); !hasFamilyMismatch(err) {
+		t.Fatalf("(e) unit-level mixed GRE must be rejected, got %v", err)
+	}
+
+	// (f) WireGuard tunnel (no Source/Destination) → skipped, no error.
+	cfgF := &Config{}
+	cfgF.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"wg0": {Name: "wg0", Tunnel: &TunnelConfig{Mode: "wireguard"}},
+	}
+	if w, err := validateTunnelOuterFamilyStrict(cfgF, false); err != nil || len(w) != 0 {
+		t.Fatalf("(f) WireGuard tunnel must be skipped, got err=%v warns=%v", err, w)
+	}
+
+	// (g) lenient path: the mixed pair downgrades to a warning, no error
+	// (#1960 no-brick — the Rust helper skips the row independently).
+	if w, err := validateTunnelOuterFamilyStrict(cfgA, true); err != nil {
+		t.Fatalf("(g) lenient must not reject a mixed pair, got %v", err)
+	} else if len(w) == 0 || !strings.Contains(w[0], "different address families") {
+		t.Fatalf("(g) lenient must warn on a mixed pair, got %v", w)
+	}
+}
+
+// TestGRETunnelMixedOuterFamilyRejectedAtCommit is the end-to-end
+// fail-on-revert guard: the gate is wired into the strict commit path
+// (CompileConfig) so a mixed-family GRE tunnel is HARD-REJECTED at commit
+// instead of committing clean and silently dropping every encap. It also
+// pins the over-reject guard (same-family tunnels still commit) and the
+// #1960 lenient-load downgrade.
+func TestGRETunnelMixedOuterFamilyRejectedAtCommit(t *testing.T) {
+	// Mixed v4 source + v6 destination → rejected at strict commit.
+	if _, err := compileSet(t, []string{
+		"set interfaces gr-0/0/0 tunnel source 192.0.2.1",
+		"set interfaces gr-0/0/0 tunnel destination 2001:db8::1",
+	}); !hasFamilyMismatch(err) {
+		t.Fatalf("mixed v4/v6 GRE must be rejected at commit, got %v", err)
+	}
+
+	// Reverse: v6 source + v4 destination → rejected at strict commit.
+	if _, err := compileSet(t, []string{
+		"set interfaces gr-0/0/0 tunnel source 2001:db8::1",
+		"set interfaces gr-0/0/0 tunnel destination 192.0.2.1",
+	}); !hasFamilyMismatch(err) {
+		t.Fatalf("mixed v6/v4 GRE must be rejected at commit, got %v", err)
+	}
+
+	// Over-reject guard: a same-family v4/v4 GRE tunnel commits clean.
+	if _, err := compileSet(t, []string{
+		"set interfaces gr-0/0/0 tunnel source 192.0.2.1",
+		"set interfaces gr-0/0/0 tunnel destination 192.0.2.2",
+	}); err != nil {
+		t.Fatalf("v4/v4 GRE must commit clean, got %v", err)
+	}
+
+	// Over-reject guard: a same-family v6/v6 GRE tunnel commits clean.
+	if _, err := compileSet(t, []string{
+		"set interfaces gr-0/0/0 tunnel source 2001:db8::1",
+		"set interfaces gr-0/0/0 tunnel destination 2001:db8::2",
+	}); err != nil {
+		t.Fatalf("v6/v6 GRE must commit clean, got %v", err)
+	}
+
+	// Lenient load path: the same mixed config warns (does not reject) so
+	// an upgraded / peer-synced node still boots (#1960).
+	tree := treeFromSet(t, []string{
+		"set interfaces gr-0/0/0 tunnel source 192.0.2.1",
+		"set interfaces gr-0/0/0 tunnel destination 2001:db8::1",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load must not reject a mixed GRE tunnel, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "different address families") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient load must surface a mixed-family warning, got %v", cfg.Warnings)
+	}
+}

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -3385,6 +3385,98 @@ fn tunnel_ttl_negative_maps_to_default_not_zero() {
     );
 }
 
+/// #5162: a non-WireGuard tunnel whose outer source and destination are
+/// DIFFERENT address families (v4 source + v6 destination) is skipped by
+/// `populate_tunnel_endpoints` — a helper-boundary backstop for a
+/// mixed-version peer-sync / corrupt snapshot the Go commit gate
+/// (`validateTunnelOuterFamilyStrict`) did not reject. Before the fix such
+/// a row was tagged `inet6` (Go picks inet6 if EITHER endpoint is v6) and
+/// installed, then silently dropped every encap in the GRE AF_INET6 arm.
+/// fail-on-revert: removing the family-mismatch skip installs the endpoint
+/// and this `assert!(!contains_key)` goes red.
+#[test]
+fn tunnel_mixed_outer_family_is_skipped() {
+    let snapshot = ConfigSnapshot {
+        tunnel_endpoints: vec![crate::protocol::snapshot::TunnelEndpointSnapshot {
+            id: 12,
+            interface: "gr-0/0/0".into(),
+            ifindex: 53,
+            mode: "gre".into(),
+            // Go would tag this `inet6` (destination is v6); the source is v4.
+            outer_family: "inet6".into(),
+            source: "203.0.113.1".into(),
+            destination: "2001:db8::1".into(),
+            ttl: 64,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert!(
+        !state.tunnel_endpoints.contains_key(&12),
+        "a mixed-family (v4 src / v6 dst) GRE endpoint must be skipped, not installed"
+    );
+    // And it must not be indexed for GRE decap either.
+    assert!(
+        !state
+            .gre_decap_index
+            .values()
+            .any(|ids| ids.contains(&12)),
+        "a skipped mixed-family endpoint must not enter the GRE decap index"
+    );
+}
+
+/// #5162 anti-over-reject: a same-family (v4 src / v4 dst) GRE tunnel still
+/// installs exactly. Guards the family-mismatch skip from swallowing a
+/// legitimate same-family tunnel.
+#[test]
+fn tunnel_same_outer_family_builds_exactly() {
+    let snapshot = ConfigSnapshot {
+        tunnel_endpoints: vec![crate::protocol::snapshot::TunnelEndpointSnapshot {
+            id: 13,
+            interface: "gr-0/0/0".into(),
+            ifindex: 54,
+            mode: "gre".into(),
+            outer_family: "inet".into(),
+            source: "203.0.113.1".into(),
+            destination: "198.51.100.1".into(),
+            ttl: 64,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert!(
+        state.tunnel_endpoints.contains_key(&13),
+        "a same-family v4/v4 GRE endpoint must install"
+    );
+}
+
+/// #5162 anti-over-reject: a same-family (v6 src / v6 dst) GRE tunnel still
+/// installs exactly.
+#[test]
+fn tunnel_same_outer_family_v6_builds_exactly() {
+    let snapshot = ConfigSnapshot {
+        tunnel_endpoints: vec![crate::protocol::snapshot::TunnelEndpointSnapshot {
+            id: 14,
+            interface: "gr-0/0/0".into(),
+            ifindex: 55,
+            mode: "gre".into(),
+            outer_family: "inet6".into(),
+            source: "2001:db8::1".into(),
+            destination: "2001:db8::2".into(),
+            ttl: 64,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert!(
+        state.tunnel_endpoints.contains_key(&14),
+        "a same-family v6/v6 GRE endpoint must install"
+    );
+}
+
 /// #2410: a CoS forwarding-class queue id outside 0..=255 fails the
 /// snapshot CLOSED via `CosQueueIdOutOfRange`. fail-on-revert: restoring
 /// the `filter_map` range check silently DROPS the class, the build

--- a/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
@@ -40,6 +40,25 @@ pub(super) fn populate_tunnel_endpoints(
             let Ok(destination) = endpoint.destination.parse::<IpAddr>() else {
                 continue;
             };
+            // #5162: a non-WireGuard tunnel encapsulates in ONE outer IP
+            // family, so the outer source and destination MUST be the same
+            // family. The Go commit gate (validateTunnelOuterFamilyStrict)
+            // rejects a mixed pair, but a config synced from an older peer
+            // (pre-#5162) or a corrupt snapshot can still carry one — and the
+            // Go producer tags such a row `inet6` when EITHER endpoint is v6,
+            // which drives the GRE encoder into the AF_INET6 arm where the v4
+            // endpoint yields None → a SILENT per-packet drop. Skip the
+            // degenerate row loudly here instead so it installs nothing rather
+            // than a blackhole (fail-closed, mirroring the WG hydrate
+            // row-drop and the allowed-ips prefix-drop skip-and-continue
+            // posture in this file).
+            if source.is_ipv6() != destination.is_ipv6() {
+                eprintln!(
+                    "xpf-userspace-dp: tunnel endpoint {} outer source {} and destination {} are different address families; skipping this endpoint (a GRE/IPIP tunnel encapsulates in one outer family — #5162)",
+                    endpoint.id, source, destination
+                );
+                continue;
+            }
             (source, destination)
         };
         let outer_family = match (endpoint.outer_family.as_str(), destination) {


### PR DESCRIPTION
## Problem (#5162)

A GRE/IPIP tunnel whose **outer** `tunnel source` and `tunnel destination`
are different address families (v4 source + v6 destination, or the reverse)
passed per-leaf validation and **committed clean**, then silently dropped
every encapsulated packet.

Each endpoint is independently a valid IP literal, so nothing rejected the
mixed pair. The Go snapshot producer (`pkg/dataplane/userspace/tunnels.go`)
tags the endpoint `inet6` whenever **either** endpoint is v6, so the Rust
GRE encoder hits the `AF_INET6` arm, finds the v4 endpoint, and returns
`None` — a per-packet blackhole with no operator signal. Only WireGuard
peers had a cross-field family validator; the GRE/IPIP outer pair had none.

## Fix

Add the missing cross-field gate, mirroring the existing WireGuard
endpoint-family validator (`validateWireguardPeersStrict`) — one
encapsulation = one outer transport family.

- **Go commit gate** `validateTunnelOuterFamilyStrict`
  (`pkg/config/compiler_validate_tunnel_family.go`), wired into
  `runTailGates` right after the WireGuard gate. Rejects a non-WireGuard
  tunnel whose outer source/destination parse to different families.
  WireGuard is skipped (no source/destination pair). A same-family v4/v4
  or v6/v6 tunnel still commits + forwards (over-reject guarded).
- **Strict vs lenient:** strict commit / commit-check hard-reject; the
  tolerant load / peer-sync path downgrades to a warning via the new
  `lenientTunnelOuterFamily` flag (#1960 no-brick).
- **Rust backstop:** `populate_tunnel_endpoints`
  (`forwarding_build/tunnels.rs`) skips a mixed-family non-WG row with a
  loud `eprintln!` (mirrors the WG hydrate row-drop / allowed-ips
  skip-and-continue) — covers a mixed-version HA peer-sync / corrupt
  snapshot the Go gate cannot see, so a degenerate row installs nothing
  rather than a silent `inet6`-tagged blackhole.

## Fail-on-revert tests (merge gate)

- Go `TestGRETunnelMixedOuterFamilyRejectedAtCommit` — mixed v4/v6 **and**
  v6/v4 GRE tunnels are rejected at strict commit; same-family v4/v4 and
  v6/v6 still commit clean; lenient load downgrades to a warning.
- Go `TestTunnelOuterFamilyGate` — direct gate-function coverage (both
  orders, interface + unit level, WireGuard skip, over-reject guards).
- Rust `tunnel_mixed_outer_family_is_skipped` + two anti-over-reject
  (`tunnel_same_outer_family_builds_exactly`, `..._v6_...`).

Verified firsthand: neutralizing the Go gate reds the commit-reject test;
neutralizing the Rust skip reds `tunnel_mixed_outer_family_is_skipped`.

## Validation

- Go: `go build ./...` + `go test ./pkg/config/... ./pkg/dataplane/...`
  green (including the #4406 tail-gate golden test).
- Rust: `cargo build --release` + `cargo test --release tunnel` green.

Closes #5162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsM8tMf2CtukbP5A6erGvW