### PR TITLE
userspace-dp: per-shard neighbor MAC-change epoch (#5147)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -51638,3 +51638,32 @@ top.
   pkg/dataplane/userspace/format/testdata/status_summary.golden,
   pkg/dataplane/userspace/format/status_golden_test.go,
   docs/feature-coverage.md, userspace-dp/src/FEATURES.md
+
+## #5147 — Per-shard neighbor MAC-change epoch (targeted flow-cache invalidation)
+- **Timestamp**: 2026-07-17
+- **Action**: Replace the single global `ShardedNeighborMap.mac_change_epoch`
+  (AtomicU32) with a PER-SHARD `shard_mac_epochs: [AtomicU32; NUM_SHARDS]`. A
+  MAC replacement now bumps only the changed neighbor's shard epoch; a cached
+  flow stamps + re-validates against the epoch of the shard its resolved
+  next-hop `(egress_ifindex, next_hop)` lives in (`FlowCacheEntry
+  .neighbor_shard`). Closes the map-wide cache-thrash / DoS where one on-link
+  IP's MAC flap invalidated every cached flow. Hot-path check stays one
+  indexed relaxed load + compare. Pre-resolve WHOLE-vector snapshot
+  (`snapshot_shard_epochs`) preserves the #3918 TOCTOU fix per shard; #3048
+  eviction of a flow's OWN neighbor is preserved.
+- **File(s)**: userspace-dp/src/afxdp/sharded_neighbor.rs,
+  userspace-dp/src/afxdp/flow_cache.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs,
+  userspace-dp/src/afxdp/sharded_neighbor_tests.rs,
+  userspace-dp/src/afxdp/flow_cache_tests.rs,
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  userspace-dp/src/afxdp/umem/tests/debug_state.rs,
+  userspace-dp/src/afxdp/README.md, docs/flow-cache-simplification.md
+- **Validation**: `cargo build --release` green; `cargo test --release`
+  neighbor+flow_cache 20/20 green. RED-on-revert verified firsthand:
+  neutralizing `bump_shard_epoch` to bump-all-shards (global behavior) turns
+  `unrelated_neighbor_mac_change_does_not_evict_cached_flow` and
+  `mac_change_epoch_isolated_per_shard_across_neighbors` RED while the #3048
+  over-eviction guard stays green.

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -386,14 +386,17 @@ went stale and kept rewriting to the old MAC until the session expired or an
 unrelated config/route event bumped `fib_generation` — blackholing
 long-lived flows.
 
-The fix adds a single monotonic `mac_change_epoch` (`AtomicU32`) to
-`ShardedNeighborMap` (`sharded_neighbor.rs`). It is bumped ONLY when a write
-REPLACES an existing neighbor's hwaddr with a DIFFERENT MAC — never on a
-first insert of a new neighbor (no cached flow can reference a MAC that did
-not previously exist) and never on a same-MAC ARP/NDP refresh (the
-overwhelmingly common case; bumping there would flush the whole flow cache on
-every neighbor refresh and collapse the fast-path hit rate). All FIVE
-neighbor write paths are covered:
+The fix adds monotonic MAC-change epochs to `ShardedNeighborMap`
+(`sharded_neighbor.rs`). **Per #5147 these are PER-SHARD**
+(`shard_mac_epochs: [AtomicU32; NUM_SHARDS]`), not a single global counter:
+a write bumps ONLY the epoch of the shard that holds the changed neighbor
+key. The epoch is bumped ONLY when a write REPLACES an existing neighbor's
+hwaddr with a DIFFERENT MAC — never on a first insert of a new neighbor (no
+cached flow can reference a MAC that did not previously exist) and never on a
+same-MAC ARP/NDP refresh (the overwhelmingly common case; bumping there would
+flush that shard's cached flows on every neighbor refresh and collapse the
+fast-path hit rate). All FIVE neighbor write paths are covered, each bumping
+the specific shard(s) it mutates:
 
 - the netlink monitor (`insert_if_changed`, the primary RTM_NEWNEIGH path);
 - the data-path ARP-reply / NDP-NA learn (`poll_stages.rs`), now routed
@@ -420,10 +423,11 @@ neighbor write paths are covered:
   `remove(old)` BEFORE `insert(new)` under the bulk lock, so the prior MAC
   is already gone by insert time. `bulk_replace_neighbors` therefore
   SNAPSHOTS each incoming key's prior MAC UNDER the bulk lock BEFORE the
-  removes, then bumps the epoch exactly once for the whole batch if any
-  incoming MAC differs from its snapshotted prior (a pure same-MAC refresh
-  and brand-new keys with no prior do NOT bump). HA peer-promoted session
-  closes remain out of scope;
+  removes, then (per #5147) bumps the shard of each key whose incoming MAC
+  differs from its snapshotted prior — one bump per changed shard, deduped
+  via a `[bool; NUM_SHARDS]` mask so two changed keys colliding in one shard
+  bump it once (a pure same-MAC refresh and brand-new keys with no prior do
+  NOT bump). HA peer-promoted session closes remain out of scope;
 - the #1787 RX source-MAC data-path learn (`learn_dynamic_neighbor` in
   `neighbor_dispatch.rs`), now routed through
   `ShardedNeighborMap::learn_pair_if_changed` (#3169). This learn snoops the
@@ -445,66 +449,96 @@ neighbor write paths are covered:
   sighting and same-MAC re-learn add a single Relaxed read per key and no
   bump, matching the per-key semantics.
 
-`FlowCacheEntry` carries a `neighbor_mac_epoch`. The worker fast path
-(`poll_descriptor/flow_cache_hit.rs`) re-reads the epoch on every hit; a
-mismatch (`FlowCacheEntry::neighbor_mac_epoch_stale`) evicts the slot and
-falls through to the slow path, which re-resolves the current MAC. This is
-the same lazy epoch-compare pattern as `rg_epochs` — chosen over an explicit
-cross-worker `FlushFlowCaches` so invalidation is lock-free and self-healing
-on the next packet.
+`FlowCacheEntry` carries a `neighbor_mac_epoch` PLUS (per #5147) a
+`neighbor_shard` — the index of the shard holding this flow's resolved
+next-hop `(egress_ifindex, next_hop)`, precomputed once at cache-miss time
+(`ShardedNeighborMap::shard_index`). The worker fast path
+(`poll_descriptor/flow_cache_hit.rs`) re-reads only THAT shard's epoch on
+every hit (`FlowCacheEntry::neighbor_mac_epoch_stale` → `shard_mac_epoch`, a
+single indexed relaxed load + compare); a mismatch evicts the slot and falls
+through to the slow path, which re-resolves the current MAC. A flow with no
+resolved next-hop (`NEIGHBOR_SHARD_NONE`) has no dynamic-neighbor dependency
+and is never MAC-stale. This is the same lazy epoch-compare pattern as
+`rg_epochs` — chosen over an explicit cross-worker `FlushFlowCaches` so
+invalidation is lock-free and self-healing on the next packet.
 
-**Read-before-resolve (#3918).** The stamped epoch is SNAPSHOTTED BEFORE the
-next-hop MAC is resolved, not re-read at insert time. `poll_descriptor/mod.rs`
-captures `dynamic_neighbors.mac_change_epoch()` into
-`neighbor_mac_epoch_at_resolve` at the top of per-descriptor processing —
-before `resolve_flow_session_decision` / the session-miss
-`finalize_new_flow_ha_resolution` consult the neighbor table — and threads
-that value into `FlowCacheEntry::from_forward_decision` (a `neighbor_mac_epoch`
-value parameter; the constructor has no `dynamic_neighbors` handle, so it
-cannot re-read the live epoch). Re-reading the epoch AT insert time (after the
-resolve) was a TOCTOU that re-opened the #3048 blackhole: a VRRP gateway
-failover landing between the resolve (which read the OLD MAC) and the stamp
-would capture the NEW epoch onto the cached OLD `dst_mac` — a fresh-looking
-stale entry that survives every hit until it ages out. Reading first
-guarantees the stamped epoch is `<=` the epoch observed at resolve time, so
-the MAC-change bump makes the entry stale on its next hit and it re-resolves
-to the new MAC. A Relaxed load suffices: the snapshot and the stamp run on the
-one worker thread (program order sequences the snapshot before the resolve),
-and the neighbor shard `Mutex` — not this counter — synchronizes the MAC
-bytes; the epoch is a monotonic invalidation signal needing only eventual
-cross-thread visibility. Mirrors the #2170/#3912 record-before-use discipline.
+**Read-before-resolve (#3918 / #5147).** The stamped epoch is SNAPSHOTTED
+BEFORE the next-hop MAC is resolved, not re-read at insert time. Because the
+resolved shard is not known until after the resolve, `poll_descriptor/mod.rs`
+snapshots the WHOLE per-shard epoch vector
+(`dynamic_neighbors.snapshot_shard_epochs()` → `neighbor_epoch_snapshot`) at
+the top of per-descriptor processing — before `resolve_flow_session_decision`
+/ the session-miss `finalize_new_flow_ha_resolution` consult the neighbor
+table. After the resolve it extracts the resolved shard's snapshotted value
+(`neighbor_epoch_snapshot.epoch_for(&(egress_ifindex, next_hop))`) and threads
+it into `FlowCacheEntry::from_forward_decision` (a `neighbor_mac_epoch` value
+parameter; the constructor independently derives the matching `neighbor_shard`
+from the same `decision.resolution`, and has no `dynamic_neighbors` handle so
+it cannot re-read the live epoch). Re-reading the shard epoch AT insert time
+(after the resolve) was a TOCTOU that re-opened the #3048 blackhole: a VRRP
+gateway failover landing between the resolve (which read the OLD MAC) and the
+stamp would capture the NEW shard epoch onto the cached OLD `dst_mac` — a
+fresh-looking stale entry that survives every hit until it ages out.
+Snapshotting first guarantees the stamped shard epoch is `<=` the shard epoch
+observed at resolve time, so the MAC-change bump makes the entry stale on its
+next hit and it re-resolves to the new MAC. Relaxed loads suffice: the
+snapshot and the stamp run on the one worker thread (program order sequences
+the snapshot before the resolve), and the neighbor shard `Mutex` — not these
+counters — synchronizes the MAC bytes; the epochs are monotonic invalidation
+signals needing only eventual cross-thread visibility. Mirrors the
+#2170/#3912 record-before-use discipline. The snapshot is NUM_SHARDS relaxed
+loads on the cold cache-miss/resolve path only (established flows hit the
+cache and never reach it).
 
-**Scope / tradeoff (documented per #3048):** the flow cache is keyed by the
-flow 5-tuple, not by next-hop, so next-hop-scoped invalidation is not
-possible without a second index. `mac_change_epoch` is therefore a SINGLE
-global epoch: any genuine neighbor MAC change lazily invalidates ALL cached
-flows (each re-misses once on its next packet and re-resolves). This is the
-"coarser flush" the issue accepts — acceptable because genuine MAC changes
-are rare (failover / NIC swap) while same-MAC refreshes (which never bump)
-are the steady-state norm.
+**Scope / tradeoff (per #5147, superseding the #3048 global epoch):** the
+flow cache is keyed by the flow 5-tuple, not by next-hop, so it cannot key
+invalidation on the exact neighbor. #3048's first cut used a SINGLE global
+epoch, which meant ANY neighbor's MAC change lazily invalidated ALL cached
+flows. That was an attacker-driven cache-thrash / DoS: an on-link sender
+alternating one IP's MAC advanced the global epoch faster than entries could
+warm, collapsing the whole flow cache to ~1 packet (#5147). The fix stamps
+each cached flow with the epoch of the SPECIFIC shard its resolved next-hop
+lives in and bumps only the changed neighbor's shard, so a MAC change on
+neighbor A invalidates a cached flow using neighbor B only if A and B hash to
+the SAME shard (probability 1/NUM_SHARDS = 1/64), never map-wide. This trades
+exact per-neighbor precision for a fixed-size (64-slot) epoch vector that
+keeps the hot-path check to one indexed load — a genuine per-neighbor index
+would require a hashmap probe on every fast-path hit, defeating the flow
+cache. Genuine MAC changes are rare (failover / NIC swap) and same-MAC
+refreshes (which never bump) are the steady-state norm, so the residual
+1/64 same-shard collision costs at most a single spurious re-resolve.
 
-Validation: `mac_change_epoch_*` (sharded_neighbor_tests.rs) cover
-starts-at-zero, no-bump-on-first-insert, no-bump-on-same-mac-refresh,
-bump-on-change (fail-on-revert for `insert_if_changed`), per-key changes
-accumulating on the single global epoch, the three resolver cases
-(first-insert no-bump, change bumps — fail-on-revert for the resolver —,
-epoch-reject no-bump), and the four bulk-replace cases
-(`mac_change_epoch_bulk_replace_*`: change bumps — fail-on-revert for
-`bulk_replace_neighbors` —, same-MAC refresh no-bump, brand-new-keys
-no-bump, and a single bump for a multi-key batch), and the four RX-learn
+Validation: `mac_change_epoch_*` (sharded_neighbor_tests.rs) cover, now
+PER-SHARD via `mac_change_epoch_for(&key)`: starts-at-zero,
+no-bump-on-first-insert, no-bump-on-same-mac-refresh, bump-on-change
+(fail-on-revert for `insert_if_changed`), `mac_change_epoch_isolated_per_
+shard_across_neighbors` (a change on A bumps only A's shard, leaving an
+unrelated neighbor B in a different shard at 0 — the #5147 isolation guard;
+RED under the old global epoch), the three resolver cases (first-insert
+no-bump, change bumps — fail-on-revert for the resolver —, epoch-reject
+no-bump), the bulk-replace cases (`mac_change_epoch_bulk_replace_*`: change
+bumps — fail-on-revert for `bulk_replace_neighbors` —, same-MAC refresh
+no-bump, brand-new-keys no-bump, and `..._bumps_each_changed_shard_once`:
+two distinct-shard keys each bump their own shard once), and the RX-learn
 cases (`mac_change_epoch_rx_learn_*`: first-sighting no-bump, same-MAC
 re-learn no-bump, change bumps — fail-on-revert for `learn_pair_if_changed`
-—, and a single bump for the multi-key #949 pair-write).
-`cached_descriptor_evicted_only_on_neighbor_mac_change`
-(flow_cache_tests.rs) is the end-to-end fail-on-revert: a descriptor stamped
-at the live epoch survives a same-MAC refresh and is evicted on a MAC change.
-Neutralizing either `mac_change_epoch.fetch_add` turns the change/eviction
-assertions RED. `flow_cache_stamps_pre_resolve_epoch_survives_interleaved_
-gateway_failover` (flow_cache_tests.rs) is the #3918 read-before-resolve
-fail-on-revert: it snapshots the epoch, interleaves a gateway-MAC failover
-(bumping the live epoch), stamps a real `from_forward_decision` entry with the
-PRE-resolve snapshot, and asserts the entry is stale on its next hit — and
-that a POST-resolve read (the pre-#3918 bug) would look fresh (the blackhole).
+—, and `..._pair_bumps_each_key_shard`: each key of the #949 pair-write
+bumps its own shard). At the flow-cache layer:
+`cached_descriptor_evicted_only_on_neighbor_mac_change` (flow_cache_tests.rs)
+is the #3048-preserved over-eviction guard — a descriptor stamped against its
+OWN neighbor's shard survives a same-MAC refresh and is evicted on a change
+to that neighbor; `unrelated_neighbor_mac_change_does_not_evict_cached_flow`
+is the #5147 targeted-invalidation guard — with two neighbors A/B in distinct
+shards, changing A evicts F_a (uses A) but leaves F_b (uses B) a cache hit
+(RED under the old global epoch, where both evict). Neutralizing
+`bump_shard_epoch` (or making it bump all shards) turns these RED.
+`flow_cache_stamps_pre_resolve_epoch_survives_interleaved_gateway_failover`
+(flow_cache_tests.rs) is the #3918 read-before-resolve fail-on-revert: it
+snapshots the per-shard epochs, interleaves a gateway-MAC failover (bumping
+the neighbor's shard epoch), stamps a real `from_forward_decision` entry with
+the PRE-resolve snapshot value, and asserts the entry is stale on its next
+hit — and that a POST-resolve read (the pre-#3918 bug) would look fresh (the
+blackhole).
 Reverting the fix so the constructor ignores the caller's pre-resolve epoch
 turns it RED. `flow_cache_normal_resolve_caches_and_serves_neighbor_mac` is
 the companion no-interleave case: a normal resolve must not spuriously evict.

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -37,16 +37,23 @@ sync.
   `(ifindex, ip) -> mac` binding into `dynamic_neighbors` AND the kernel
   neighbor table, so these parsers are a MAC->IP write primitive — they
   MUST fail closed on untrusted input.
-  - **MAC-change invalidation (`#3048`):** the learn goes through
+  - **MAC-change invalidation (`#3048` / `#5147`):** the learn goes through
     `insert_if_changed`, NOT a plain `insert`, so a MAC change observed
     directly on the wire (e.g. an upstream gateway VRRP failover whose
-    ARP reply / NDP NA traverses our XSK) advances the neighbor
-    `mac_change_epoch` and evicts the now-stale cached `dst_mac`. A plain
-    insert would write the new MAC first and then SHADOW the kernel-monitor
-    RTM_NEWNEIGH that follows `add_kernel_neighbor` (the monitor would see
-    `prior == new` and not bump), leaving the flow cache stale until session
-    expiry. See `docs/flow-cache-simplification.md` "Neighbor MAC-change
-    invalidation".
+    ARP reply / NDP NA traverses our XSK) advances that neighbor's
+    **per-shard** MAC-change epoch (`ShardedNeighborMap::shard_mac_epochs`,
+    indexed by the changed neighbor's shard) and evicts the now-stale
+    cached `dst_mac`. Per #5147 the epoch is PER-SHARD, not a single global
+    counter: a cached flow stamps the epoch of the specific shard its
+    resolved next-hop lives in (`FlowCacheEntry::neighbor_shard`) and
+    re-reads only that slot on each hit, so a MAC change to an UNRELATED
+    neighbor (a different shard) no longer evicts it — closing the
+    attacker-driven map-wide cache-thrash where one on-link IP's MAC flap
+    collapsed the whole flow cache. A plain insert would write the new MAC
+    first and then SHADOW the kernel-monitor RTM_NEWNEIGH that follows
+    `add_kernel_neighbor` (the monitor would see `prior == new` and not
+    bump), leaving the flow cache stale until session expiry. See
+    `docs/flow-cache-simplification.md` "Neighbor MAC-change invalidation".
   - **Logical-ifindex keying (`#2370`):** the `ifindex` in that
     `(ifindex, ip)` key is the LOGICAL (L3) ifindex, NOT the physical
     ingress port. For a frame arriving on a VLAN sub-interface,
@@ -165,7 +172,7 @@ sync.
     `(ifindex, our_own_ip) -> attacker_mac`. The gate is the
     `ForwardingState::owns_configured_ip(ip)` predicate, applied at three
     sites BEFORE the cache write (so a rejected own-IP neither inserts nor
-    bumps `mac_change_epoch`):
+    bumps the neighbor's per-shard MAC-change epoch):
       - the ARP-reply arm and the NDP-NA arm of `stage_link_layer_classify`
         (`poll_stages.rs`), and
       - the **RX source-MAC learn path** `learn_dynamic_neighbor`

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -501,16 +501,32 @@ impl FlowCacheEntry {
         let mut input_filter_counters = input_filter_counters;
         input_filter_counters.retain_absent_from(&tx_selection.filter_counters);
         // #5147: the shard of this flow's resolved next-hop neighbor
-        // `(egress_ifindex, next_hop)` — the SAME key `lookup_neighbor_entry`
-        // used to resolve `decision.resolution.neighbor_mac`. `neighbor_shard`
+        // `(neighbor_ifindex, next_hop)`, where `neighbor_ifindex` is the
+        // ifindex the neighbor is actually keyed under in the ShardedNeighborMap
+        // — the OUTER transport ifindex for a tunnel (gr-/wg-) egress, NOT the
+        // logical tunnel `egress_ifindex`. `outer_neighbor_ifindex` returns
+        // `egress_ifindex` unchanged for a direct/connected/static resolution
+        // (identical to the pre-#5147-review behavior) and the outer ifindex for
+        // a tunnel, matching the `(ifindex, ip)` key `insert_if_changed` bumps
+        // on when the kernel updates the OUTER neighbor. Keying on the logical
+        // `egress_ifindex` for tunnels (the review MAJOR) stamped a DIFFERENT
+        // shard than the bump, so a tunnel flow never evicted on its outer
+        // gateway's MAC change — a #3048 stale-MAC blackhole. `neighbor_shard`
         // scopes the MAC-change invalidation: only a change to a neighbor in
-        // THIS shard evicts the entry (targeted, per #5147), not every
-        // neighbor change. A cacheable disposition (ForwardCandidate /
-        // FabricRedirect) always carries a next-hop; the `None` arm marks a
-        // no-dynamic-neighbor-dependency flow that is never MAC-stale.
+        // THIS shard evicts the entry (targeted, per #5147), not every neighbor
+        // change. A cacheable disposition (ForwardCandidate / FabricRedirect)
+        // always carries a next-hop; the `None` arm marks a
+        // no-dynamic-neighbor-dependency flow that is never MAC-stale. NOTE:
+        // this MUST use the IDENTICAL computation as the pre-resolve epoch
+        // snapshot key in poll_descriptor (`outer_neighbor_ifindex(.., None,
+        // ..)`), or the stamped epoch and this shard would key different shards.
         let neighbor_shard = match decision.resolution.next_hop {
             Some(nh) => crate::afxdp::sharded_neighbor::ShardedNeighborMap::shard_index(&(
-                decision.resolution.egress_ifindex,
+                crate::afxdp::forwarding::outer_neighbor_ifindex(
+                    forwarding,
+                    None,
+                    &decision.resolution,
+                ),
                 nh,
             )) as u16,
             None => NEIGHBOR_SHARD_NONE,

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -208,28 +208,56 @@ pub(super) struct FlowCacheEntry {
     /// active window, so a wrapped `current_epoch` can never re-match a
     /// dead flow ("ghost resurrection" over-count).
     pub(super) last_used_epoch: u16,
-    /// #3048: the `ShardedNeighborMap::mac_change_epoch()` value captured
-    /// when this descriptor was built. The descriptor caches the resolved
+    /// #3048/#5147: the per-shard `ShardedNeighborMap` MAC-change epoch
+    /// captured (from the pre-resolve snapshot) when this descriptor was
+    /// built — the epoch of the SPECIFIC shard `neighbor_shard` this flow's
+    /// resolved next-hop lives in. The descriptor caches the resolved
     /// next-hop `dst_mac`; if a kernel ARP/NDP update later REPLACES that
-    /// neighbor's MAC, the neighbor map advances its epoch past this
-    /// stamp. The worker fast path compares the two on every hit
-    /// (`neighbor_mac_epoch_stale`) and evicts a stale descriptor so the
-    /// next packet re-resolves the current MAC — closing the post-failover
+    /// neighbor's MAC, the neighbor map advances ONLY that shard's epoch past
+    /// this stamp. The worker fast path compares the two on every hit
+    /// (`neighbor_mac_epoch_stale`) and evicts a stale descriptor so the next
+    /// packet re-resolves the current MAC — closing the post-failover
     /// stale-MAC blackhole. A periodic refresh that re-learns the SAME MAC
-    /// does NOT advance the epoch, so steady-state traffic never re-misses.
+    /// does NOT advance the epoch, so steady-state traffic never re-misses;
+    /// and a MAC change to an UNRELATED neighbor (a different shard) no longer
+    /// evicts this entry (the #5147 map-wide-thrash fix).
     pub(super) neighbor_mac_epoch: u32,
+    /// #5147: index of the neighbor shard `neighbor_mac_epoch` was stamped
+    /// against — the shard that holds this flow's resolved next-hop
+    /// `(egress_ifindex, next_hop)`. Precomputed once at cache-miss time so
+    /// the fast-path hit is a single indexed atomic load, no hashing.
+    /// `NEIGHBOR_SHARD_NONE` marks a flow with no dynamic-neighbor dependency
+    /// (no resolved next-hop, e.g. a fabric/local disposition); such a flow
+    /// is never MAC-stale.
+    pub(super) neighbor_shard: u16,
 }
 
+/// #5147: sentinel `neighbor_shard` for a cached flow with no resolved
+/// next-hop neighbor (no dynamic-neighbor MAC dependency). Such an entry is
+/// never invalidated by a neighbor MAC change. `NUM_SHARDS` is 64, far below
+/// this value, so it can never collide with a real shard index.
+pub(super) const NEIGHBOR_SHARD_NONE: u16 = u16::MAX;
+
 impl FlowCacheEntry {
-    /// #3048: true when the neighbor table has recorded a genuine MAC
-    /// change since this descriptor was cached, i.e. its captured
-    /// `dst_mac` may be stale. `current` is `dynamic_neighbors
-    /// .mac_change_epoch()` read live on the hot path. Equal epochs (the
-    /// steady-state case, including same-MAC ARP refreshes which never
-    /// advance the counter) keep the entry; an advance evicts it.
+    /// #3048/#5147: true when the neighbor table has recorded a genuine MAC
+    /// change to THIS flow's next-hop neighbor since the descriptor was
+    /// cached, i.e. its captured `dst_mac` may be stale. Reads the live epoch
+    /// of only the flow's own shard (`neighbor_shard`) — a single indexed
+    /// relaxed atomic load + compare on the hot path. Equal epochs (the
+    /// steady-state case, including same-MAC ARP refreshes which never advance
+    /// the counter, AND a MAC change to any neighbor in a DIFFERENT shard)
+    /// keep the entry; an advance of this flow's own shard evicts it. A flow
+    /// with no resolved next-hop (`NEIGHBOR_SHARD_NONE`) has no
+    /// dynamic-neighbor dependency and is never MAC-stale.
     #[inline]
-    pub(super) fn neighbor_mac_epoch_stale(&self, current: u32) -> bool {
-        self.neighbor_mac_epoch != current
+    pub(super) fn neighbor_mac_epoch_stale(
+        &self,
+        neighbors: &crate::afxdp::sharded_neighbor::ShardedNeighborMap,
+    ) -> bool {
+        if self.neighbor_shard == NEIGHBOR_SHARD_NONE {
+            return false;
+        }
+        self.neighbor_mac_epoch != neighbors.shard_mac_epoch(self.neighbor_shard as usize)
     }
 }
 
@@ -472,6 +500,21 @@ impl FlowCacheEntry {
         // recorded once per hit, not twice.
         let mut input_filter_counters = input_filter_counters;
         input_filter_counters.retain_absent_from(&tx_selection.filter_counters);
+        // #5147: the shard of this flow's resolved next-hop neighbor
+        // `(egress_ifindex, next_hop)` — the SAME key `lookup_neighbor_entry`
+        // used to resolve `decision.resolution.neighbor_mac`. `neighbor_shard`
+        // scopes the MAC-change invalidation: only a change to a neighbor in
+        // THIS shard evicts the entry (targeted, per #5147), not every
+        // neighbor change. A cacheable disposition (ForwardCandidate /
+        // FabricRedirect) always carries a next-hop; the `None` arm marks a
+        // no-dynamic-neighbor-dependency flow that is never MAC-stale.
+        let neighbor_shard = match decision.resolution.next_hop {
+            Some(nh) => crate::afxdp::sharded_neighbor::ShardedNeighborMap::shard_index(&(
+                decision.resolution.egress_ifindex,
+                nh,
+            )) as u16,
+            None => NEIGHBOR_SHARD_NONE,
+        };
         Some(Self {
             key: flow.forward_key.clone(),
             ingress_ifindex: meta.ingress_ifindex as i32,
@@ -543,17 +586,20 @@ impl FlowCacheEntry {
             // #1219: 0 = "never touched"; first lookup hit will stamp
             // it with the current epoch.
             last_used_epoch: 0,
-            // #3048/#3918: the neighbor-MAC-change epoch is captured by the
-            // caller BEFORE it resolves the neighbor MAC for `decision`
+            // #3048/#3918/#5147: the neighbor-MAC-change epoch is captured by
+            // the caller BEFORE it resolves the neighbor MAC for `decision`
             // (the caller owns the `dynamic_neighbors` handle) and passed in
-            // as `neighbor_mac_epoch`. Reading it pre-resolve — instead of
-            // re-reading `mac_change_epoch()` after the resolve at stamp time
-            // — closes the resolve→stamp TOCTOU: a MAC change landing between
-            // the resolve and here advances the live epoch past this stamped
-            // (older) value, so the entry is treated stale on its next
-            // fast-path hit (`neighbor_mac_epoch_stale`) and re-resolved to
-            // the current MAC instead of blackholing on the pre-failover MAC.
+            // as `neighbor_mac_epoch` — the pre-resolve snapshot value for the
+            // resolved neighbor's OWN shard (`neighbor_shard`, above). Reading
+            // it pre-resolve — instead of a fresh post-resolve shard read at
+            // stamp time — closes the resolve→stamp TOCTOU: a MAC change
+            // landing between the resolve and here advances the live shard
+            // epoch past this stamped (older) value, so the entry is treated
+            // stale on its next fast-path hit (`neighbor_mac_epoch_stale`) and
+            // re-resolved to the current MAC instead of blackholing on the
+            // pre-failover MAC.
             neighbor_mac_epoch,
+            neighbor_shard,
         })
     }
 }

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -110,6 +110,9 @@ fn make_entry(
         observed_bytes: 0,
         last_used_epoch: 0,
         neighbor_mac_epoch: 0,
+        // #5147: default to no dynamic-neighbor dependency; tests that
+        // exercise MAC-change eviction set `neighbor_shard` explicitly.
+        neighbor_shard: NEIGHBOR_SHARD_NONE,
     }
 }
 
@@ -2634,14 +2637,17 @@ fn flow_cache_not_populated_by_control_segment_via_insertion_site() {
         );
     }
 
-// ── #3048: cached dst_mac eviction on neighbor MAC change ─────────────
+// ── #3048/#5147: cached dst_mac eviction on the flow's OWN neighbor ────
 // End-to-end at the flow-cache layer: a descriptor is stamped with the
-// live neighbor mac_change_epoch at insert. The worker fast path keeps
-// the entry while the epoch is unchanged (same-MAC refresh) and evicts
-// it once the neighbor table records a genuine MAC change. Reverting the
-// `mac_change_epoch.fetch_add` in ShardedNeighborMap::insert_if_changed
-// leaves the epoch at 0 after the change → neighbor_mac_epoch_stale()
-// returns false → the stale dst_mac persists → this test goes RED.
+// per-shard MAC-change epoch of its OWN next-hop neighbor at insert. The
+// worker fast path keeps the entry while that shard's epoch is unchanged
+// (same-MAC refresh) and evicts it once the neighbor table records a
+// genuine MAC change to THIS neighbor. This is the #5147 over-eviction
+// guard IN REVERSE — it proves the targeted scheme still evicts on a real
+// change to the flow's own neighbor (preserving #3048). Reverting the
+// `bump_shard_epoch` in ShardedNeighborMap::insert_if_changed leaves the
+// shard epoch at 0 after the change → neighbor_mac_epoch_stale() returns
+// false → the stale dst_mac persists → this test goes RED.
 #[test]
 fn cached_descriptor_evicted_only_on_neighbor_mac_change() {
     use crate::afxdp::sharded_neighbor::ShardedNeighborMap;
@@ -2653,8 +2659,9 @@ fn cached_descriptor_evicted_only_on_neighbor_mac_change() {
     // Resolve the gateway with its initial MAC (first insert — no bump).
     neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
 
-    // Build a cached forwarding descriptor and stamp it with the live
-    // epoch exactly as poll_descriptor does at insert time.
+    // Build a cached forwarding descriptor and stamp it against the flow's
+    // OWN next-hop shard exactly as poll_descriptor / from_forward_decision
+    // do at insert time (shard of `nh`, that shard's current epoch).
     let stamp = FlowCacheStamp {
         config_generation: 5,
         fib_generation: 3,
@@ -2663,22 +2670,90 @@ fn cached_descriptor_evicted_only_on_neighbor_mac_change() {
         owner_rg_lease_until: 0,
     };
     let mut entry = make_entry(make_key(), stamp, 1);
-    entry.neighbor_mac_epoch = neighbors.mac_change_epoch();
+    entry.neighbor_shard = ShardedNeighborMap::shard_index(&nh) as u16;
+    entry.neighbor_mac_epoch = neighbors.mac_change_epoch_for(&nh);
 
     // Steady state: a same-MAC ARP/NDP refresh must NOT evict the entry.
     neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
     assert!(
-        !entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
+        !entry.neighbor_mac_epoch_stale(&neighbors),
         "same-MAC refresh must not evict the cached descriptor (#3048)"
     );
 
-    // Gateway VRRP failover: the neighbor's MAC changes. The cached
-    // dst_mac is now stale and the entry MUST be evicted so the next
-    // packet re-resolves the current MAC.
+    // Gateway VRRP failover: the flow's OWN neighbor MAC changes. The cached
+    // dst_mac is now stale and the entry MUST be evicted so the next packet
+    // re-resolves the current MAC (#3048 preserved under the #5147 scheme).
     neighbors.insert_if_changed(nh, NeighborEntry { mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x99] });
     assert!(
-        entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
-        "neighbor MAC change must evict the cached stale dst_mac (#3048)"
+        entry.neighbor_mac_epoch_stale(&neighbors),
+        "a MAC change to the flow's own neighbor must evict its stale dst_mac (#3048)"
+    );
+}
+
+// ── #5147: TARGETED invalidation — an unrelated neighbor's MAC change ──
+// must NOT evict a cached flow using a different neighbor. This is the
+// primary fail-on-revert guard for the map-wide-thrash / DoS fix: under
+// the old single global epoch BOTH flows stamped and compared the ONE
+// counter, so changing neighbor A's MAC advanced it and evicted F_b too —
+// the `!f_b...` assertion below would go RED. With per-shard epochs, A's
+// change bumps only A's shard, leaving F_b (a different shard) a cache
+// hit. It exercises the REAL primitives (ShardedNeighborMap per-shard
+// bump + shard_index stamping + neighbor_mac_epoch_stale).
+#[test]
+fn unrelated_neighbor_mac_change_does_not_evict_cached_flow() {
+    use crate::afxdp::sharded_neighbor::ShardedNeighborMap;
+    use crate::afxdp::types::NeighborEntry;
+    use std::net::Ipv4Addr;
+
+    let neighbors = ShardedNeighborMap::new();
+
+    // Two neighbors A and B guaranteed to live in DIFFERENT shards, so a
+    // change to one cannot touch the other's shard epoch.
+    let (na, nb) = {
+        let a = (6i32, IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1)));
+        let base_shard = ShardedNeighborMap::shard_index(&a);
+        let mut b = None;
+        for octet in 2..=254u8 {
+            let cand = (6i32, IpAddr::V4(Ipv4Addr::new(172, 16, 50, octet)));
+            if ShardedNeighborMap::shard_index(&cand) != base_shard {
+                b = Some(cand);
+                break;
+            }
+        }
+        (a, b.expect("distinct-shard neighbor B exists"))
+    };
+    neighbors.insert_if_changed(na, NeighborEntry { mac: [0xaa, 0, 0, 0, 0, 0x01] });
+    neighbors.insert_if_changed(nb, NeighborEntry { mac: [0xbb, 0, 0, 0, 0, 0x02] });
+
+    let stamp = FlowCacheStamp {
+        config_generation: 5,
+        fib_generation: 3,
+        owner_rg_id: 1,
+        owner_rg_epoch: 0,
+        owner_rg_lease_until: 0,
+    };
+    // F_a depends on neighbor A; F_b on neighbor B.
+    let mut f_a = make_entry(make_key(), stamp, 1);
+    f_a.neighbor_shard = ShardedNeighborMap::shard_index(&na) as u16;
+    f_a.neighbor_mac_epoch = neighbors.mac_change_epoch_for(&na);
+    let mut f_b = make_entry(make_key(), stamp, 1);
+    f_b.neighbor_shard = ShardedNeighborMap::shard_index(&nb) as u16;
+    f_b.neighbor_mac_epoch = neighbors.mac_change_epoch_for(&nb);
+
+    // Neighbor A's MAC flaps (an on-link sender alternating one IP's MAC).
+    neighbors.insert_if_changed(na, NeighborEntry { mac: [0xaa, 0, 0, 0, 0, 0x99] });
+
+    // F_a (uses A) is invalidated → re-resolves.
+    assert!(
+        f_a.neighbor_mac_epoch_stale(&neighbors),
+        "a MAC change to A must evict a flow that uses A (#3048)"
+    );
+    // F_b (uses B) is STILL a cache hit — NOT evicted. RED under the old
+    // global epoch (the map-wide-thrash defect).
+    assert!(
+        !f_b.neighbor_mac_epoch_stale(&neighbors),
+        "a MAC change to an UNRELATED neighbor A must NOT evict a flow that \
+         uses neighbor B (#5147 targeted invalidation)"
     );
 }
 
@@ -2709,27 +2784,32 @@ fn flow_cache_stamps_pre_resolve_epoch_survives_interleaved_gateway_failover() {
     use crate::afxdp::types::NeighborEntry;
 
     let neighbors = ShardedNeighborMap::new();
-    let nh = (6i32, IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1)));
+    // The next-hop MUST match the round-trip decision's resolved next-hop
+    // (`egress_ifindex=6`, `next_hop=10.0.1.1`) so `from_forward_decision`
+    // stamps THIS neighbor's shard and the failover below bumps that same
+    // shard.
+    let nh = (6i32, IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)));
     // Gateway resolved with its pre-failover MAC (first insert — no bump).
     neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
 
-    // poll_descriptor snapshots the epoch BEFORE resolving the neighbor MAC.
-    let epoch_at_resolve = neighbors.mac_change_epoch();
+    // poll_descriptor snapshots EVERY shard's epoch BEFORE resolving the
+    // neighbor MAC (the resolved shard is not yet known).
+    let pre_resolve_snapshot = neighbors.snapshot_shard_epochs();
 
     // ── Interleaved VRRP gateway failover ──
     // A kernel ARP/NDP update REPLACES the gateway MAC AFTER the resolve read
     // the old MAC but BEFORE the flow-cache entry is stamped. This advances the
-    // live epoch past the pre-resolve snapshot.
+    // neighbor's shard epoch past the pre-resolve snapshot.
     neighbors.insert_if_changed(nh, NeighborEntry { mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x99] });
     assert_ne!(
-        epoch_at_resolve,
-        neighbors.mac_change_epoch(),
-        "the interleaved failover must advance the live epoch past the \
-         pre-resolve snapshot (otherwise the test proves nothing)"
+        pre_resolve_snapshot.epoch_for(&nh),
+        neighbors.mac_change_epoch_for(&nh),
+        "the interleaved failover must advance the neighbor's shard epoch past \
+         the pre-resolve snapshot (otherwise the test proves nothing)"
     );
 
     // Build + stamp the flow-cache entry exactly as poll_descriptor does after
-    // the resolve: `from_forward_decision` stamps the PRE-RESOLVE snapshot
+    // the resolve: it stamps the resolved shard's PRE-RESOLVE snapshot value
     // (`neighbor_mac_epoch` param), NOT a fresh post-resolve read.
     let (flow, meta, validation, decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     let rg_epochs = default_rg_epochs();
@@ -2747,25 +2827,25 @@ fn flow_cache_stamps_pre_resolve_epoch_survives_interleaved_gateway_failover() {
         &ha_state,
         false,
         &rg_epochs,
-        epoch_at_resolve, // #3918: pre-resolve snapshot, not a post-resolve read
+        pre_resolve_snapshot.epoch_for(&nh), // #3918: pre-resolve shard value
     )
     .expect("v4 round-trip decision is cacheable");
 
-    // On the NEXT fast-path hit the entry's stamped (pre-failover) epoch != the
-    // current live epoch -> treated STALE -> evicted + re-resolved to the new
-    // MAC. This is the fix.
+    // On the NEXT fast-path hit the entry's stamped (pre-failover) shard epoch
+    // != the current live shard epoch -> treated STALE -> evicted + re-resolved
+    // to the new MAC. This is the fix.
     assert!(
-        entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
-        "an entry stamped with the pre-resolve epoch must be stale after an \
+        entry.neighbor_mac_epoch_stale(&neighbors),
+        "an entry stamped with the pre-resolve shard epoch must be stale after an \
          interleaved gateway-MAC failover so the stale dst_mac is re-resolved (#3918)"
     );
 
     // Contrast: the pre-#3918 behavior read the epoch AFTER the resolve (i.e.
-    // after the failover bump modeled above). That post-resolve value EQUALS
-    // the current live epoch, so the stale entry looks FRESH and is never
-    // evicted — the blackhole. Encoding it here makes the revert's failure mode
-    // explicit and guards against a regression that re-reads at stamp time.
-    let post_resolve_read = neighbors.mac_change_epoch();
+    // after the failover bump modeled above). That post-resolve shard value
+    // EQUALS the current live shard epoch, so the stale entry looks FRESH and is
+    // never evicted — the blackhole. Encoding it here makes the revert's failure
+    // mode explicit and guards against a regression that re-reads at stamp time.
+    let post_resolve_snapshot = neighbors.snapshot_shard_epochs();
     let buggy_entry = FlowCacheEntry::from_forward_decision(
         &flow,
         meta,
@@ -2780,11 +2860,11 @@ fn flow_cache_stamps_pre_resolve_epoch_survives_interleaved_gateway_failover() {
         &ha_state,
         false,
         &rg_epochs,
-        post_resolve_read,
+        post_resolve_snapshot.epoch_for(&nh),
     )
     .expect("v4 round-trip decision is cacheable");
     assert!(
-        !buggy_entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
+        !buggy_entry.neighbor_mac_epoch_stale(&neighbors),
         "a POST-resolve stamp (the pre-#3918 bug) looks fresh after failover — \
          this is the stale-MAC blackhole the fix closes (#3918)"
     );
@@ -2800,11 +2880,13 @@ fn flow_cache_normal_resolve_caches_and_serves_neighbor_mac() {
     use crate::afxdp::types::NeighborEntry;
 
     let neighbors = ShardedNeighborMap::new();
-    let nh = (6i32, IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1)));
+    // Match the round-trip decision's resolved next-hop (egress_ifindex=6,
+    // next_hop=10.0.1.1) so the stamped shard matches the mutated neighbor.
+    let nh = (6i32, IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)));
     neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
 
     // Snapshot pre-resolve; NO failover interleaves.
-    let epoch_at_resolve = neighbors.mac_change_epoch();
+    let pre_resolve_snapshot = neighbors.snapshot_shard_epochs();
 
     let (flow, meta, validation, decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     let rg_epochs = default_rg_epochs();
@@ -2822,14 +2904,15 @@ fn flow_cache_normal_resolve_caches_and_serves_neighbor_mac() {
         &ha_state,
         false,
         &rg_epochs,
-        epoch_at_resolve,
+        pre_resolve_snapshot.epoch_for(&nh),
     )
     .expect("v4 round-trip decision is cacheable");
 
-    // A same-MAC refresh does not advance the epoch, so the entry stays fresh.
+    // A same-MAC refresh does not advance the shard epoch, so the entry stays
+    // fresh.
     neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
     assert!(
-        !entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
+        !entry.neighbor_mac_epoch_stale(&neighbors),
         "a normal resolve with no interleaved MAC change must serve the cached \
          entry, not spuriously evict it (#3918)"
     );

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -2917,3 +2917,124 @@ fn flow_cache_normal_resolve_caches_and_serves_neighbor_mac() {
          entry, not spuriously evict it (#3918)"
     );
 }
+
+// ── #5147 review MAJOR: TUNNEL-egress flows must key the MAC-change shard on
+// the OUTER neighbor ifindex, not the logical tunnel egress_ifindex ──
+// A GRE/WireGuard flow resolves its dst_mac from the OUTER transport neighbor,
+// which the kernel keys (and `insert_if_changed` bumps) under
+// `(outer.egress_ifindex, outer_next_hop)`. But the flow-cache entry stamps a
+// `neighbor_shard`; if it derives that shard from the LOGICAL tunnel
+// `egress_ifindex` (gr-/wg-, != the outer ifindex), the stamped shard never
+// advances on the outer gateway's MAC change -> `neighbor_mac_epoch_stale`
+// stays false forever -> the cached descriptor serves the dead gateway MAC
+// until idle timeout (a #3048 stale-MAC blackhole reintroduced for tunnels by
+// the naive per-shard #5147 change). The fix keys the shard on
+// `outer_neighbor_ifindex(.., None, ..)`, which returns the outer ifindex for a
+// tunnel and `egress_ifindex` for a direct resolution.
+//
+// RED-ON-REVERT: reverting either stamp site to `decision.resolution.egress_ifindex`
+// makes `entry.neighbor_shard` the LOGICAL (362) shard, so (1) the structural
+// assert fails (shard != outer shard) and (2) the behavioral assert fails (a
+// bump on the OUTER shard leaves the logical shard's epoch untouched -> not
+// stale -> no eviction).
+#[test]
+fn tunnel_flow_cache_keys_mac_change_shard_on_outer_neighbor_not_logical_ifindex() {
+    use crate::afxdp::sharded_neighbor::ShardedNeighborMap;
+    use crate::afxdp::types::NeighborEntry;
+
+    // GRE state: tunnel endpoint 1 -> logical ifindex 362 (gr-0-0-0), outer
+    // transport egress ifindex 12 (reth0.80 VLAN subif). See
+    // forwarding/tests.rs resolve_tunnel_outer_returns_outer_l3_egress.
+    let forwarding =
+        crate::afxdp::forwarding_build::build_forwarding_state(
+            &crate::afxdp::test_fixtures::native_gre_snapshot(true),
+        );
+
+    // A cacheable v4 forward decision, retargeted as a TUNNEL egress: keep its
+    // resolved next-hop + neighbor_mac + ForwardCandidate disposition, but mark
+    // it tunnel endpoint 1 with the LOGICAL egress ifindex (362) — exactly what
+    // resolve_tunnel_forwarding_resolution produces.
+    let (flow, meta, validation, mut decision, _direct_forwarding, ha_state) =
+        make_v4_round_trip_inputs();
+    decision.resolution.tunnel_endpoint_id = 1;
+    decision.resolution.egress_ifindex = 362;
+    let nh = decision
+        .resolution
+        .next_hop
+        .expect("a cacheable forward decision carries a resolved next-hop");
+
+    // The neighbor's ACTUAL key ifindex is the OUTER transport ifindex (12),
+    // NOT the logical tunnel egress (362).
+    let outer_if =
+        crate::afxdp::forwarding::outer_neighbor_ifindex(&forwarding, None, &decision.resolution);
+    assert_eq!(
+        outer_if, 12,
+        "outer_neighbor_ifindex must resolve tunnel endpoint 1 to its OUTER \
+         transport ifindex (12), not the logical tunnel egress (362)"
+    );
+    let outer_shard = ShardedNeighborMap::shard_index(&(outer_if, nh)) as u16;
+    let logical_shard = ShardedNeighborMap::shard_index(&(362, nh)) as u16;
+    assert_ne!(
+        outer_shard, logical_shard,
+        "test precondition: the outer (12) and logical (362) ifindexes must hash \
+         to DIFFERENT shards for this next-hop, else the test cannot distinguish \
+         the bug from the fix"
+    );
+
+    let rg_epochs = default_rg_epochs();
+    // Stamp the pre-resolve epoch as 0 (a fresh map's baseline); the entry
+    // derives its neighbor_shard internally via outer_neighbor_ifindex.
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(3),
+        Some(7),
+        None,
+        crate::filter::CachedFilterCounters::default(),
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+        0, // #3918 pre-resolve shard epoch (outer shard baseline == 0)
+    )
+    .expect("a tunnel ForwardCandidate decision is cacheable");
+
+    // STRUCTURAL: the entry stamps the OUTER neighbor's shard, not the logical.
+    assert_eq!(
+        entry.neighbor_shard, outer_shard,
+        "a tunnel flow must stamp the OUTER neighbor's shard (ifindex {outer_if}); \
+         stamping the logical tunnel egress ifindex (362) means the flow never \
+         evicts on the outer gateway's MAC change (#5147 review MAJOR / #3048)"
+    );
+    assert_ne!(
+        entry.neighbor_shard, logical_shard,
+        "the stamped shard must NOT be the logical tunnel egress shard"
+    );
+
+    // BEHAVIORAL: a MAC change on the OUTER neighbor evicts the tunnel flow.
+    let neighbors = ShardedNeighborMap::new();
+    assert!(
+        !entry.neighbor_mac_epoch_stale(&neighbors),
+        "a freshly-stamped entry (epoch 0) is not stale against a fresh map"
+    );
+    // First insert = no bump; a REPLACE with a different MAC bumps the OUTER
+    // neighbor's shard (the gateway VRRP-failover event).
+    neighbors.insert_if_changed(
+        (outer_if, nh),
+        NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] },
+    );
+    neighbors.insert_if_changed(
+        (outer_if, nh),
+        NeighborEntry { mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x99] },
+    );
+    assert!(
+        entry.neighbor_mac_epoch_stale(&neighbors),
+        "the tunnel flow MUST be evicted after its OUTER gateway's MAC change — \
+         keying the shard on the logical egress ifindex leaves the logical shard's \
+         epoch untouched by the outer bump, so the stale dst_mac would be served \
+         forever (#5147 review MAJOR)"
+    );
+}

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -2932,11 +2932,17 @@ fn flow_cache_normal_resolve_caches_and_serves_neighbor_mac() {
 // `outer_neighbor_ifindex(.., None, ..)`, which returns the outer ifindex for a
 // tunnel and `egress_ifindex` for a direct resolution.
 //
-// RED-ON-REVERT: reverting either stamp site to `decision.resolution.egress_ifindex`
-// makes `entry.neighbor_shard` the LOGICAL (362) shard, so (1) the structural
-// assert fails (shard != outer shard) and (2) the behavioral assert fails (a
-// bump on the OUTER shard leaves the logical shard's epoch untouched -> not
-// stale -> no eviction).
+// RED-ON-REVERT: this test pins the flow_cache `neighbor_shard` STAMP site
+// (it sets the resolve-time `neighbor_mac_epoch = 0` directly, so it does not
+// exercise the poll_descriptor pre-resolve epoch-snapshot site). Reverting the
+// flow_cache stamp to `decision.resolution.egress_ifindex` makes
+// `entry.neighbor_shard` the LOGICAL (362) shard, so (1) the structural assert
+// fails (shard != outer shard) and (2) the behavioral assert fails (a bump on
+// the OUTER shard leaves the logical shard's epoch untouched -> not stale -> no
+// eviction). The poll_descriptor epoch-snapshot site is keyed identically by
+// construction (the same `outer_neighbor_ifindex(.., None, ..)` call on the
+// same `&decision.resolution`); an independent fail-on-revert test for that
+// second site is a follow-up (#5147 review nit).
 #[test]
 fn tunnel_flow_cache_keys_mac_change_shard_on_outer_neighbor_not_logical_ifindex() {
     use crate::afxdp::sharded_neighbor::ShardedNeighborMap;

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -98,16 +98,17 @@ pub(super) fn stage_flow_cache_hit(
         &worker_ctx.rg_epochs,
         meta.pkt_len,
     ) {
-        // #3048: a kernel ARP/NDP update may have REPLACED this
+        // #3048/#5147: a kernel ARP/NDP update may have REPLACED this
         // descriptor's next-hop MAC since it was cached (gateway VRRP
-        // failover, NIC swap). The neighbor map advances its
-        // mac_change_epoch only on a genuine MAC change — never on a
+        // failover, NIC swap). The neighbor map advances the epoch of the
+        // changed neighbor's SHARD only on a genuine MAC change — never on a
         // same-MAC refresh — so this comparison is free of steady-state
-        // re-misses. A mismatch means the cached dst_mac may be stale;
-        // evict and re-resolve on the slow path. Read the epoch once
-        // before the &cached borrow is needed mutably below.
-        let neighbor_mac_stale =
-            cached.neighbor_mac_epoch_stale(worker_ctx.dynamic_neighbors.mac_change_epoch());
+        // re-misses, and a MAC change to a neighbor in a DIFFERENT shard does
+        // NOT evict this flow (the #5147 map-wide-thrash fix). The check reads
+        // only this flow's own shard slot: a single indexed relaxed atomic
+        // load + compare. A mismatch means the cached dst_mac may be stale;
+        // evict and re-resolve on the slow path.
+        let neighbor_mac_stale = cached.neighbor_mac_epoch_stale(worker_ctx.dynamic_neighbors);
         if neighbor_mac_stale
             || !cached_flow_decision_valid(
                 worker_ctx.forwarding,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -4365,17 +4365,32 @@ pub(super) fn poll_binding_process_descriptor(
                         // resolved next-hop shard from the whole-vector
                         // snapshot taken before the resolve. Computed here,
                         // while `decision` is still owned (it is moved into
-                        // `from_forward_decision` below), from the SAME neighbor
-                        // key `lookup_neighbor_entry` used —
-                        // `(egress_ifindex, next_hop)`. `from_forward_decision`
-                        // independently derives the matching `neighbor_shard`
-                        // from the same `decision.resolution`, so the stamp and
-                        // the hit-path re-read agree on the shard. A resolution
-                        // with no next-hop stamps 0 (paired with a
+                        // `from_forward_decision` below), from the neighbor's
+                        // ACTUAL key ifindex — the OUTER transport ifindex for a
+                        // tunnel egress, the `egress_ifindex` for a direct
+                        // resolution — via `outer_neighbor_ifindex`, the same
+                        // ifindex `insert_if_changed` bumps on. `from_forward_decision`
+                        // derives `neighbor_shard` with the IDENTICAL
+                        // `outer_neighbor_ifindex(.., None, ..)` call, so the
+                        // stamped epoch and the hit-path re-read agree on the
+                        // shard (both `None` for the neighbor handle: the outer
+                        // ifindex is route-derived, so `None` yields the same
+                        // ifindex as the live resolve and keeps the two sites
+                        // coupled). Keying on the logical `egress_ifindex` for
+                        // tunnels was the review MAJOR — it stamped a different
+                        // shard than the bump, so a tunnel flow never evicted on
+                        // its outer gateway's MAC change (#3048 blackhole). A
+                        // resolution with no next-hop stamps 0 (paired with a
                         // `NEIGHBOR_SHARD_NONE` shard → never MAC-stale).
                         let neighbor_mac_epoch_at_resolve = match decision.resolution.next_hop {
-                            Some(nh) => neighbor_epoch_snapshot
-                                .epoch_for(&(decision.resolution.egress_ifindex, nh)),
+                            Some(nh) => neighbor_epoch_snapshot.epoch_for(&(
+                                outer_neighbor_ifindex(
+                                    worker_ctx.forwarding,
+                                    None,
+                                    &decision.resolution,
+                                ),
+                                nh,
+                            )),
                             None => 0,
                         };
                         if !flow_cache_install_failed

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1033,31 +1033,35 @@ pub(super) fn poll_binding_process_descriptor(
                 let mut pre_routing_dnat_counter: Option<
                     std::sync::Arc<crate::nat::NatRuleCounter>,
                 > = None;
-                // #3918: snapshot the neighbor-MAC-change epoch BEFORE the
-                // neighbor MAC that backs this packet's forwarding decision is
-                // resolved. `resolve_flow_session_decision` (session-hit
-                // resolve) and the session-miss `finalize_new_flow_ha_
-                // resolution` below both consult `dynamic_neighbors`; the
-                // flow-cache entry built further down is stamped with THIS
-                // pre-resolve value (passed into `from_forward_decision`).
-                // Reading the epoch here — not after the resolve at stamp
-                // time — closes a TOCTOU that re-opened the #3048 stale-MAC
-                // blackhole: a kernel ARP/NDP update (a VRRP gateway failover
-                // changing the gateway MAC) landing between the resolve and the
-                // stamp would, on a post-resolve read, stamp the NEW epoch onto
-                // the cached OLD dst_mac — a fresh-looking stale entry that
-                // survives every fast-path hit until it ages out (blackhole).
-                // Reading first guarantees the stamped epoch <= the epoch
+                // #3918/#5147: snapshot EVERY shard's neighbor-MAC-change
+                // epoch BEFORE the neighbor MAC that backs this packet's
+                // forwarding decision is resolved. `resolve_flow_session_
+                // decision` (session-hit resolve) and the session-miss
+                // `finalize_new_flow_ha_resolution` below both consult
+                // `dynamic_neighbors`; the flow-cache entry built further down
+                // stamps the resolved shard's PRE-RESOLVE snapshot value
+                // (extracted just before `from_forward_decision`). The resolved
+                // shard is not known until after the resolve, so the whole
+                // vector is snapshotted first. Reading pre-resolve — not a
+                // fresh post-resolve shard read at stamp time — closes a TOCTOU
+                // that re-opened the #3048 stale-MAC blackhole: a kernel
+                // ARP/NDP update (a VRRP gateway failover changing the gateway
+                // MAC) landing between the resolve and the stamp would, on a
+                // post-resolve read, stamp the NEW shard epoch onto the cached
+                // OLD dst_mac — a fresh-looking stale entry that survives every
+                // fast-path hit until it ages out (blackhole). Snapshotting
+                // first guarantees the stamped shard epoch <= the shard epoch
                 // observed at resolve time, so a subsequent MAC-change bump
                 // makes the entry stale on its next hit -> evicted -> re-
-                // resolved to the new MAC. Mirrors the #2170/#3912 record-
-                // before-use discipline. A Relaxed load suffices: this
+                // resolved to the new MAC. Mirrors the #2170/#3912
+                // record-before-use discipline. Relaxed loads suffice: this
                 // snapshot and the stamp run on this one worker thread (program
                 // order sequences the snapshot before the resolve), and the
-                // neighbor shard Mutex — not this counter — synchronizes the
-                // MAC bytes; the epoch is a monotonic invalidation signal that
-                // only needs eventual cross-thread visibility.
-                let neighbor_mac_epoch_at_resolve = worker_ctx.dynamic_neighbors.mac_change_epoch();
+                // neighbor shard Mutex — not these counters — synchronizes the
+                // MAC bytes; the epochs are monotonic invalidation signals that
+                // only need eventual cross-thread visibility. NUM_SHARDS relaxed
+                // loads, on this cold cache-miss/resolve path only.
+                let neighbor_epoch_snapshot = worker_ctx.dynamic_neighbors.snapshot_shard_epochs();
                 let mut decision = if let Some(flow) = flow.as_ref() {
                     if let Some(resolved) = resolve_flow_session_decision(
                         sessions,
@@ -4356,6 +4360,24 @@ pub(super) fn poll_binding_process_descriptor(
                         // invalidation. "No install required" paths
                         // (DNS fast-path, fabric-return) keep the flag
                         // false and cache as before.
+                        //
+                        // #5147: extract the pre-resolve epoch of THIS flow's
+                        // resolved next-hop shard from the whole-vector
+                        // snapshot taken before the resolve. Computed here,
+                        // while `decision` is still owned (it is moved into
+                        // `from_forward_decision` below), from the SAME neighbor
+                        // key `lookup_neighbor_entry` used —
+                        // `(egress_ifindex, next_hop)`. `from_forward_decision`
+                        // independently derives the matching `neighbor_shard`
+                        // from the same `decision.resolution`, so the stamp and
+                        // the hit-path re-read agree on the shard. A resolution
+                        // with no next-hop stamps 0 (paired with a
+                        // `NEIGHBOR_SHARD_NONE` shard → never MAC-stale).
+                        let neighbor_mac_epoch_at_resolve = match decision.resolution.next_hop {
+                            Some(nh) => neighbor_epoch_snapshot
+                                .epoch_for(&(decision.resolution.egress_ifindex, nh)),
+                            None => 0,
+                        };
                         if !flow_cache_install_failed
                             && let Some(flow) = flow.as_ref()
                             && let Some(mut entry) = FlowCacheEntry::from_forward_decision(
@@ -4386,18 +4408,21 @@ pub(super) fn poll_binding_process_descriptor(
                                 worker_ctx.ha_state,
                                 apply_nat_on_fabric,
                                 &worker_ctx.rg_epochs,
-                                // #3048/#3918: stamp the neighbor-MAC-change
-                                // epoch SNAPSHOTTED BEFORE the resolve above
-                                // (`neighbor_mac_epoch_at_resolve`), not a
-                                // fresh post-resolve read. A later kernel
-                                // ARP/NDP MAC change for this descriptor's
-                                // next-hop advances the live epoch past this
+                                // #3048/#3918/#5147: stamp the PER-SHARD
+                                // neighbor-MAC-change epoch snapshotted BEFORE
+                                // the resolve above (the resolved shard's slot
+                                // of `neighbor_epoch_snapshot`), not a fresh
+                                // post-resolve read. A later kernel ARP/NDP MAC
+                                // change to THIS descriptor's next-hop neighbor
+                                // advances that shard's live epoch past this
                                 // stamp, evicting the cached stale dst_mac on
                                 // its next fast-path hit
-                                // (`neighbor_mac_epoch_stale`) — and a MAC
-                                // change racing the resolve is caught too,
-                                // because the pre-resolve snapshot cannot
-                                // already reflect it (closes the TOCTOU).
+                                // (`neighbor_mac_epoch_stale`) — while a change
+                                // to an unrelated neighbor (a different shard)
+                                // leaves this flow cached (#5147). A MAC change
+                                // racing the resolve is caught too, because the
+                                // pre-resolve snapshot cannot already reflect it
+                                // (closes the #3918 TOCTOU).
                                 neighbor_mac_epoch_at_resolve,
                             )
                         {

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -2023,6 +2023,8 @@ fn epoch_based_flow_cache_invalidation_for_demoted_owner_rg() {
         observed_bytes: 0,
         last_used_epoch: 0,
         neighbor_mac_epoch: 0,
+        // #5147: no dynamic-neighbor dependency in this test entry.
+        neighbor_shard: crate::afxdp::flow_cache::NEIGHBOR_SHARD_NONE,
     });
 
     // Before epoch bump, lookup should hit.
@@ -2107,6 +2109,8 @@ fn epoch_based_flow_cache_unrelated_rg_not_invalidated() {
         observed_bytes: 0,
         last_used_epoch: 0,
         neighbor_mac_epoch: 0,
+        // #5147: no dynamic-neighbor dependency in this test entry.
+        neighbor_shard: crate::afxdp::flow_cache::NEIGHBOR_SHARD_NONE,
     });
 
     // Bump epoch for RG 2 (unrelated).

--- a/userspace-dp/src/afxdp/sharded_neighbor.rs
+++ b/userspace-dp/src/afxdp/sharded_neighbor.rs
@@ -48,24 +48,41 @@ impl PaddedShard {
 /// 64-shard mutex map for the dynamic neighbor cache.
 pub(crate) struct ShardedNeighborMap {
     shards: [PaddedShard; NUM_SHARDS],
-    /// #3048: monotonic epoch bumped ONLY when a kernel ARP/NDP update
-    /// REPLACES an existing neighbor's hwaddr with a different MAC
-    /// (gateway VRRP failover, host NIC swap, upstream MAC change). The
-    /// worker flow cache stamps this counter into each cached forwarding
-    /// descriptor and re-reads it on every fast-path hit; a mismatch
-    /// means the descriptor's `dst_mac` may be stale, so the entry is
-    /// evicted and the next packet re-resolves the current MAC.
+    /// #5147: PER-SHARD monotonic MAC-change epochs. Bumped ONLY when a
+    /// kernel ARP/NDP update REPLACES an existing neighbor's hwaddr with a
+    /// different MAC (gateway VRRP failover, host NIC swap, upstream MAC
+    /// change), and ONLY on the epoch of the shard that holds the changed
+    /// neighbor key. The worker flow cache stamps the epoch of the SPECIFIC
+    /// shard its resolved next-hop lives in
+    /// (`FlowCacheEntry::neighbor_shard`) into each cached forwarding
+    /// descriptor and re-reads that one slot on every fast-path hit; a
+    /// mismatch means the descriptor's `dst_mac` may be stale, so the entry
+    /// is evicted and the next packet re-resolves the current MAC.
     ///
-    /// It is deliberately NOT bumped on:
+    /// This replaces the single global `mac_change_epoch` that made ANY
+    /// neighbor's MAC change invalidate EVERY cached flow. An on-link sender
+    /// alternating one IP's MAC advanced that global counter faster than
+    /// entries could warm, collapsing the whole flow cache to ~1 packet
+    /// (attacker-driven cache thrash / DoS, #5147). With a per-shard epoch a
+    /// change on neighbor A evicts a cached flow using neighbor B only in the
+    /// rare event A and B hash to the SAME shard (1/NUM_SHARDS), never
+    /// map-wide.
+    ///
+    /// Same #3048 non-bump discipline, now applied per shard. It is
+    /// deliberately NOT bumped on:
     ///   * a first insert of a brand-new neighbor (no cached flow can
     ///     reference a neighbor that did not previously exist), nor
     ///   * a periodic ARP/NDP REFRESH that re-learns the SAME MAC (the
-    ///     overwhelmingly common case) — bumping there would flush the
-    ///     whole flow cache on every neighbor refresh and collapse the
+    ///     overwhelmingly common case) — bumping there would flush that
+    ///     shard's cached flows on every neighbor refresh and collapse the
     ///     fast-path hit rate.
     /// `insert_if_changed` distinguishes these because it reads the prior
     /// entry under the shard lock before overwriting.
-    mac_change_epoch: AtomicU32,
+    ///
+    /// The fast-path read is a single indexed relaxed atomic load + compare
+    /// (the shard is precomputed at cache-miss time) — allocation-free per
+    /// docs/engineering-style.md hot-path rules.
+    shard_mac_epochs: [AtomicU32; NUM_SHARDS],
 }
 
 /// Shard index for a key. The Knuth multiplier `0x9E3779B97F4A7C15`
@@ -90,17 +107,62 @@ impl ShardedNeighborMap {
     pub(crate) fn new() -> Self {
         Self {
             shards: std::array::from_fn(|_| PaddedShard::new()),
-            mac_change_epoch: AtomicU32::new(0),
+            shard_mac_epochs: std::array::from_fn(|_| AtomicU32::new(0)),
         }
     }
 
-    /// #3048: current neighbor-MAC-change epoch. Read by the worker flow
-    /// cache at descriptor insert (stamp) and on every fast-path hit
-    /// (re-validate). A single relaxed atomic load — mirrors the
-    /// `rg_epochs` lazy-invalidation pattern in `flow_cache.rs`.
+    /// #5147: shard index for a neighbor key. Exposed so the worker flow
+    /// cache can precompute (once, on the cold cache-miss path) the shard
+    /// its resolved next-hop lives in and stamp it onto the cache entry —
+    /// avoiding a hash on every fast-path hit. Same function the map uses
+    /// internally to route a key to its shard, so the stamp and the live
+    /// bump agree on which shard a neighbor belongs to.
     #[inline]
-    pub(crate) fn mac_change_epoch(&self) -> u32 {
-        self.mac_change_epoch.load(Ordering::Relaxed)
+    pub(crate) fn shard_index(key: &(i32, IpAddr)) -> usize {
+        shard_idx(key)
+    }
+
+    /// #5147: current MAC-change epoch for one shard. Read by the worker
+    /// flow cache on every fast-path hit (single indexed relaxed atomic
+    /// load; the shard is precomputed at insert). Mirrors the old global
+    /// `mac_change_epoch` accessor but scoped to the neighbor's own shard.
+    #[inline]
+    pub(crate) fn shard_mac_epoch(&self, shard: usize) -> u32 {
+        self.shard_mac_epochs[shard].load(Ordering::Relaxed)
+    }
+
+    /// #5147: MAC-change epoch for the shard that holds `key`. Convenience
+    /// over `shard_mac_epoch(shard_index(key))`; used by tests and by the
+    /// pre-resolve snapshot's `epoch_for`.
+    #[inline]
+    pub(crate) fn mac_change_epoch_for(&self, key: &(i32, IpAddr)) -> u32 {
+        self.shard_mac_epoch(shard_idx(key))
+    }
+
+    /// #5147/#3918: snapshot every shard's MAC-change epoch at once. The
+    /// worker takes this BEFORE it resolves a packet's next-hop MAC (it does
+    /// not yet know which shard the resolve will land in), then stamps the
+    /// resolved shard's snapshotted value onto the new cache entry. Reading
+    /// pre-resolve — the whole vector — preserves the #3918 resolve→stamp
+    /// TOCTOU fix per shard: the snapshot cannot already reflect a MAC change
+    /// that lands during/after the resolve, so such a change advances the
+    /// live shard epoch past the stamp and the entry is evicted on its next
+    /// hit rather than serving the stale MAC. NUM_SHARDS relaxed loads, on
+    /// the cold cache-miss path only.
+    #[inline]
+    pub(crate) fn snapshot_shard_epochs(&self) -> ShardEpochSnapshot {
+        ShardEpochSnapshot(std::array::from_fn(|i| {
+            self.shard_mac_epochs[i].load(Ordering::Relaxed)
+        }))
+    }
+
+    /// #5147: advance the MAC-change epoch of the shard that holds `key`.
+    /// Called under the shard lock on a genuine MAC replacement so a
+    /// concurrent fast-path hit never observes the new MAC paired with the
+    /// old shard epoch.
+    #[inline]
+    fn bump_shard_epoch(&self, shard: usize) {
+        self.shard_mac_epochs[shard].fetch_add(1, Ordering::Relaxed);
     }
 
     fn lock_shard(
@@ -153,7 +215,8 @@ impl ShardedNeighborMap {
         generation: &std::sync::atomic::AtomicU64,
         expected_generation: u64,
     ) -> bool {
-        let mut shard = self.lock_shard(shard_idx(&key));
+        let idx = shard_idx(&key);
+        let mut shard = self.lock_shard(idx);
         if generation.load(std::sync::atomic::Ordering::Acquire) != expected_generation {
             return false;
         }
@@ -168,7 +231,8 @@ impl ShardedNeighborMap {
         if let Some(prior) = shard.get(&key)
             && prior.mac != val.mac
         {
-            self.mac_change_epoch.fetch_add(1, Ordering::Relaxed);
+            // #5147: bump only THIS neighbor's shard epoch.
+            self.bump_shard_epoch(idx);
         }
         shard.insert(key, val);
         true
@@ -182,7 +246,8 @@ impl ShardedNeighborMap {
         key: (i32, IpAddr),
         val: NeighborEntry,
     ) -> bool {
-        let mut shard = self.lock_shard(shard_idx(&key));
+        let idx = shard_idx(&key);
+        let mut shard = self.lock_shard(idx);
         let prior_mac = shard.get(&key).map(|existing| existing.mac);
         if prior_mac == Some(val.mac) {
             return false;
@@ -196,7 +261,9 @@ impl ShardedNeighborMap {
         // exist. The same-MAC refresh case already returned above.
         if let Some(old_mac) = prior_mac {
             debug_assert_ne!(old_mac, val.mac, "same-MAC case must have returned early");
-            self.mac_change_epoch.fetch_add(1, Ordering::Relaxed);
+            // #5147: bump only THIS neighbor's shard epoch, so a change here
+            // does not invalidate cached flows resolved to other shards.
+            self.bump_shard_epoch(idx);
         }
         shard.insert(key, val);
         true
@@ -269,12 +336,14 @@ impl ShardedNeighborMap {
             // Snapshot the prior MAC for every INCOMING key BEFORE any
             // removal — the replace removes the old entry before the
             // matching insert, so reading after would always miss it.
-            let mut mac_changed = false;
+            // #5147: mark the SHARD of each key that genuinely changed MAC,
+            // so the bump below is per-shard, not a single global epoch.
+            let mut changed_shards = [false; NUM_SHARDS];
             for (ifindex, ip, entry) in insert_entries {
                 if let Some(prior) = bulk.get(&(*ifindex, *ip))
                     && prior.mac != entry.mac
                 {
-                    mac_changed = true;
+                    changed_shards[shard_idx(&(*ifindex, *ip))] = true;
                 }
             }
             for key in remove_keys {
@@ -285,10 +354,15 @@ impl ShardedNeighborMap {
             }
             // Bump under the same bulk lock as the mutation so a
             // concurrent fast-path hit never observes the new MAC with
-            // the old epoch. A single fetch_add covers the whole batch:
-            // the flow-cache invalidation is a coarse global epoch.
-            if mac_changed {
-                self.mac_change_epoch.fetch_add(1, Ordering::Relaxed);
+            // the old epoch. #5147: bump each shard that had a genuine MAC
+            // change exactly once — a change to a neighbor in shard S
+            // invalidates only cached flows resolved to shard S, not the
+            // whole flow cache. (Two changed keys colliding in one shard
+            // bump it once.)
+            for (shard, &changed) in changed_shards.iter().enumerate() {
+                if changed {
+                    self.bump_shard_epoch(shard);
+                }
             }
         });
     }
@@ -321,21 +395,27 @@ impl ShardedNeighborMap {
         val: NeighborEntry,
     ) {
         self.with_all_shards(|bulk| {
-            let mut mac_changed = false;
+            // #5147: mark the SHARD of each key that genuinely changed MAC.
+            // The pair-write can straddle two shards (the physical and the
+            // logical VLAN sub-ifindex hash independently), so a change must
+            // bump each affected shard, not one global epoch.
+            let mut changed_shards = [false; NUM_SHARDS];
             for key in keys {
                 if let Some(prior) = bulk.get(key)
                     && prior.mac != val.mac
                 {
-                    mac_changed = true;
+                    changed_shards[shard_idx(key)] = true;
                 }
             }
             for key in keys {
                 bulk.insert(*key, val);
             }
-            // A single fetch_add covers the whole pair: the flow-cache
-            // invalidation is a coarse global epoch.
-            if mac_changed {
-                self.mac_change_epoch.fetch_add(1, Ordering::Relaxed);
+            // #5147: bump each shard whose neighbor MAC changed exactly once,
+            // so cached flows resolved to an unrelated shard survive.
+            for (shard, &changed) in changed_shards.iter().enumerate() {
+                if changed {
+                    self.bump_shard_epoch(shard);
+                }
             }
         });
     }
@@ -360,6 +440,26 @@ impl ShardedNeighborMap {
 impl Default for ShardedNeighborMap {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// #5147/#3918: an immutable snapshot of every shard's MAC-change epoch,
+/// captured by the worker BEFORE it resolves a packet's next-hop neighbor
+/// MAC. Because the resolved shard is not known until after the resolve, the
+/// worker snapshots the whole vector first, then stamps the resolved shard's
+/// snapshotted value onto the new flow-cache entry (`epoch_for`). Taking the
+/// snapshot pre-resolve preserves the #3918 TOCTOU fix per shard: a MAC
+/// change that lands during/after the resolve cannot already be reflected in
+/// this snapshot, so the entry's stamped epoch is < the live shard epoch and
+/// the entry is evicted on its next hit rather than serving the stale MAC.
+pub(crate) struct ShardEpochSnapshot([u32; NUM_SHARDS]);
+
+impl ShardEpochSnapshot {
+    /// The snapshotted MAC-change epoch for the shard that holds `key` (the
+    /// flow's resolved next-hop `(egress_ifindex, next_hop)`).
+    #[inline]
+    pub(crate) fn epoch_for(&self, key: &(i32, IpAddr)) -> u32 {
+        self.0[shard_idx(key)]
     }
 }
 

--- a/userspace-dp/src/afxdp/sharded_neighbor_tests.rs
+++ b/userspace-dp/src/afxdp/sharded_neighbor_tests.rs
@@ -15,6 +15,21 @@ fn key_v4(ifindex: i32, last_octet: u8) -> (i32, IpAddr) {
     (ifindex, IpAddr::V4(Ipv4Addr::new(10, 0, 0, last_octet)))
 }
 
+/// #5147: two v4 neighbor keys guaranteed to live in DIFFERENT shards. A MAC
+/// change on one bumps only its shard's epoch, so the other's stays put —
+/// the per-neighbor isolation the map-wide-thrash fix provides.
+fn keys_in_distinct_shards() -> ((i32, IpAddr), (i32, IpAddr)) {
+    let base = key_v4(7, 1);
+    let base_shard = ShardedNeighborMap::shard_index(&base);
+    for octet in 2..=255u8 {
+        let cand = key_v4(7, octet);
+        if ShardedNeighborMap::shard_index(&cand) != base_shard {
+            return (base, cand);
+        }
+    }
+    panic!("no distinct-shard key pair found among /24 last octets");
+}
+
 #[test]
 fn get_returns_inserted_value() {
     let map = ShardedNeighborMap::new();
@@ -289,20 +304,23 @@ fn concurrent_per_key_with_bulk_replace_no_deadlock() {
     assert!(map.len() > 0);
 }
 
-// ── #3048: neighbor MAC-change epoch ─────────────────────────────────
-// The worker flow cache stamps `mac_change_epoch()` into each cached
-// forwarding descriptor and re-reads it on every fast-path hit. The
-// epoch MUST advance only on a genuine MAC CHANGE so a stale cached
-// dst_mac is evicted; it MUST NOT advance on a first insert or a
-// same-MAC refresh, or steady-state traffic would re-miss the cache on
-// every neighbor refresh. Reverting any `mac_change_epoch.fetch_add`
-// makes the corresponding "change bumps" assertion fail (RED), so these
-// are the fail-on-revert guards for the #3048 invalidation.
+// ── #3048/#5147: PER-SHARD neighbor MAC-change epoch ──────────────────
+// The worker flow cache stamps the epoch of the SPECIFIC shard its
+// resolved next-hop lives in (`FlowCacheEntry::neighbor_shard`) and
+// re-reads that one slot on every fast-path hit. A shard's epoch MUST
+// advance only on a genuine MAC CHANGE to a neighbor IN THAT SHARD, so a
+// stale cached dst_mac is evicted; it MUST NOT advance on a first insert
+// or a same-MAC refresh, and a change to a neighbor in a DIFFERENT shard
+// MUST leave this shard's epoch untouched (#5147 — the old single global
+// epoch let one neighbor's MAC flap invalidate every cached flow).
+// Reverting any `bump_shard_epoch` makes the corresponding "change bumps"
+// assertion fail (RED); the isolation test fails if a change bumps a
+// shard other than its own.
 
 #[test]
 fn mac_change_epoch_starts_at_zero() {
     let map = ShardedNeighborMap::new();
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&key_v4(7, 42)), 0);
 }
 
 #[test]
@@ -310,9 +328,9 @@ fn mac_change_epoch_not_bumped_on_first_insert() {
     let map = ShardedNeighborMap::new();
     let k = key_v4(7, 42);
     // A brand-new neighbor: no cached flow can reference a MAC that did
-    // not previously exist, so the epoch must stay put.
+    // not previously exist, so the shard epoch must stay put.
     assert!(map.insert_if_changed(k, entry(0xAB)));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
 }
 
 #[test]
@@ -321,10 +339,10 @@ fn mac_change_epoch_not_bumped_on_same_mac_refresh() {
     let k = key_v4(7, 42);
     assert!(map.insert_if_changed(k, entry(0xAB)));
     // The common case: a periodic ARP/NDP refresh re-learning the SAME
-    // MAC must not bump the epoch (else the whole flow cache flushes on
-    // every neighbor refresh and the fast-path hit rate collapses).
+    // MAC must not bump the shard epoch (else that shard's cached flows
+    // flush on every neighbor refresh and the fast-path hit rate collapses).
     assert!(!map.insert_if_changed(k, entry(0xAB)));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
 }
 
 #[test]
@@ -332,35 +350,46 @@ fn mac_change_epoch_bumped_on_mac_change() {
     let map = ShardedNeighborMap::new();
     let k = key_v4(7, 42);
     assert!(map.insert_if_changed(k, entry(0xAB)));
-    assert_eq!(map.mac_change_epoch(), 0);
-    // Genuine MAC change (gateway VRRP failover / NIC swap): the epoch
-    // MUST advance so the worker fast path evicts cached descriptors
-    // holding the old dst_mac. Fail-on-revert guard for insert_if_changed.
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
+    // Genuine MAC change (gateway VRRP failover / NIC swap): this
+    // neighbor's shard epoch MUST advance so the worker fast path evicts
+    // cached descriptors holding the old dst_mac. Fail-on-revert guard for
+    // insert_if_changed's bump_shard_epoch.
     assert!(map.insert_if_changed(k, entry(0xCD)));
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k), 1);
     // A subsequent same-MAC refresh does not advance it further.
     assert!(!map.insert_if_changed(k, entry(0xCD)));
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k), 1);
     // Another distinct change bumps again.
     assert!(map.insert_if_changed(k, entry(0xEF)));
-    assert_eq!(map.mac_change_epoch(), 2);
+    assert_eq!(map.mac_change_epoch_for(&k), 2);
 }
 
 #[test]
-fn mac_change_epoch_per_key_independent_changes_accumulate() {
+fn mac_change_epoch_isolated_per_shard_across_neighbors() {
+    // #5147: the core targeted-invalidation guard. A MAC change on
+    // neighbor A bumps ONLY A's shard epoch; an unrelated neighbor B in a
+    // different shard is untouched. Under the old single global epoch this
+    // test would go RED (B's read would advance too), which is exactly the
+    // map-wide cache-thrash / DoS this fixes.
     let map = ShardedNeighborMap::new();
-    let k1 = key_v4(7, 1);
-    let k2 = key_v4(7, 2);
-    map.insert_if_changed(k1, entry(0x11));
-    map.insert_if_changed(k2, entry(0x22));
-    assert_eq!(map.mac_change_epoch(), 0);
-    // A MAC change on either key bumps the single global epoch (the
-    // flow cache is keyed by flow 5-tuple, not next-hop, so #3048 uses a
-    // coarse global epoch — documented tradeoff).
-    map.insert_if_changed(k1, entry(0x99));
-    assert_eq!(map.mac_change_epoch(), 1);
-    map.insert_if_changed(k2, entry(0x88));
-    assert_eq!(map.mac_change_epoch(), 2);
+    let (a, b) = keys_in_distinct_shards();
+    map.insert_if_changed(a, entry(0x11));
+    map.insert_if_changed(b, entry(0x22));
+    assert_eq!(map.mac_change_epoch_for(&a), 0);
+    assert_eq!(map.mac_change_epoch_for(&b), 0);
+    // Change A's MAC: A's shard advances, B's does not.
+    map.insert_if_changed(a, entry(0x99));
+    assert_eq!(map.mac_change_epoch_for(&a), 1);
+    assert_eq!(
+        map.mac_change_epoch_for(&b),
+        0,
+        "an unrelated neighbor's shard must not advance on A's MAC change (#5147)"
+    );
+    // Change B's MAC: B's shard advances, A's stays at its own value.
+    map.insert_if_changed(b, entry(0x88));
+    assert_eq!(map.mac_change_epoch_for(&b), 1);
+    assert_eq!(map.mac_change_epoch_for(&a), 1);
 }
 
 #[test]
@@ -371,7 +400,7 @@ fn mac_change_epoch_confirmed_resolver_first_insert_no_bump() {
     let generation = AtomicU64::new(5);
     // Resolver servicing a missing next-hop: prior == None, no bump.
     assert!(map.insert_confirmed_if_unchanged(k, entry(0xAB), &generation, 5));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
 }
 
 #[test]
@@ -381,14 +410,14 @@ fn mac_change_epoch_confirmed_resolver_bumps_on_change() {
     let k = key_v4(7, 42);
     let generation = AtomicU64::new(5);
     assert!(map.insert_confirmed_if_unchanged(k, entry(0xAB), &generation, 5));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
     // A confirmed re-resolution observing a different MAC must bump,
     // matching the monitor path. Fail-on-revert guard for the resolver.
     assert!(map.insert_confirmed_if_unchanged(k, entry(0xCD), &generation, 5));
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k), 1);
     // Same MAC re-confirm does not bump.
     assert!(map.insert_confirmed_if_unchanged(k, entry(0xCD), &generation, 5));
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k), 1);
 }
 
 #[test]
@@ -397,7 +426,7 @@ fn mac_change_epoch_bulk_replace_bumps_on_mac_change() {
     let k = key_v4(7, 42);
     // Seed an existing neighbor (e.g. the gateway) at MAC 0xAB.
     map.insert(k, entry(0xAB));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
     // The Go control-plane snapshot push (apply_manager_neighbors with
     // NeighborReplace: true) removes the old key and re-inserts the same
     // key with a DIFFERENT MAC — the VRRP-failover gateway MAC change
@@ -409,7 +438,7 @@ fn mac_change_epoch_bulk_replace_bumps_on_mac_change() {
     let insert = [(7, k.1, entry(0xCD))];
     map.bulk_replace_neighbors(&remove, &insert);
     assert_eq!(map.get(&k), Some(entry(0xCD)));
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k), 1);
 }
 
 #[test]
@@ -417,18 +446,18 @@ fn mac_change_epoch_bulk_replace_no_bump_on_same_mac() {
     let map = ShardedNeighborMap::new();
     let k = key_v4(7, 42);
     map.insert(k, entry(0xAB));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
     // A pure refresh: the snapshot re-learns the SAME MAC for every key.
     // Even though replace removes then re-inserts, the prior-MAC snapshot
-    // (taken before the remove) equals the incoming MAC, so the epoch
-    // must NOT advance — otherwise steady-state Go snapshot pushes would
-    // flush the whole flow cache. This case must stay GREEN when the
-    // bump is neutralized.
+    // (taken before the remove) equals the incoming MAC, so this shard's
+    // epoch must NOT advance — otherwise steady-state Go snapshot pushes
+    // would flush that shard's cached flows. This case must stay GREEN
+    // when the bump is neutralized.
     let remove = [k];
     let insert = [(7, k.1, entry(0xAB))];
     map.bulk_replace_neighbors(&remove, &insert);
     assert_eq!(map.get(&k), Some(entry(0xAB)));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
 }
 
 #[test]
@@ -440,23 +469,26 @@ fn mac_change_epoch_bulk_replace_no_bump_on_brand_new_keys() {
     let insert: Vec<_> = (0..5u8).map(|i| (7, key_v4(7, i).1, entry(0x22))).collect();
     map.bulk_replace_neighbors(&[], &insert);
     assert_eq!(map.len(), 5);
-    assert_eq!(map.mac_change_epoch(), 0);
+    for i in 0..5u8 {
+        assert_eq!(map.mac_change_epoch_for(&key_v4(7, i)), 0);
+    }
 }
 
 #[test]
-fn mac_change_epoch_bulk_replace_single_bump_for_batch() {
+fn mac_change_epoch_bulk_replace_bumps_each_changed_shard_once() {
     let map = ShardedNeighborMap::new();
-    let k1 = key_v4(7, 1);
-    let k2 = key_v4(7, 2);
+    // #5147: two neighbors in DISTINCT shards both change MAC in one
+    // snapshot push. Each changed neighbor bumps its OWN shard exactly once
+    // — not a single shared global epoch — so an unrelated cached flow
+    // (resolved to a third shard) survives.
+    let (k1, k2) = keys_in_distinct_shards();
     map.insert(k1, entry(0x11));
     map.insert(k2, entry(0x22));
-    // Two keys change MAC in one snapshot push. The flow-cache flush is
-    // a coarse global epoch, so the whole batch bumps the epoch exactly
-    // ONCE (not once per changed key).
     let remove = [k1, k2];
-    let insert = [(7, k1.1, entry(0x99)), (7, k2.1, entry(0x88))];
+    let insert = [(k1.0, k1.1, entry(0x99)), (k2.0, k2.1, entry(0x88))];
     map.bulk_replace_neighbors(&remove, &insert);
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k1), 1);
+    assert_eq!(map.mac_change_epoch_for(&k2), 1);
 }
 
 #[test]
@@ -471,17 +503,17 @@ fn mac_change_epoch_confirmed_resolver_epoch_reject_no_bump() {
     // written and the epoch must not move.
     generation.store(6, std::sync::atomic::Ordering::Release);
     assert!(!map.insert_confirmed_if_unchanged(k, entry(0xCD), &generation, 5));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
     assert_eq!(map.get(&k), Some(entry(0xAB)));
 }
 
 // ── #3169: RX source-MAC data-path learn (learn_pair_if_changed) ─────
 // The fifth neighbor-MAC write path. learn_dynamic_neighbor routes its
 // #949 pair-write through learn_pair_if_changed, which must follow the
-// same epoch semantics as the other four paths: a genuine MAC change on
-// an existing dynamic neighbor bumps mac_change_epoch (so a flow-cache
-// dst_mac resolved via the dynamic_neighbors fallback is evicted), while
-// a first sighting and a same-MAC re-learn do not.
+// same per-shard epoch semantics as the other four paths: a genuine MAC
+// change on an existing dynamic neighbor bumps that neighbor's shard epoch
+// (so a flow-cache dst_mac resolved via the dynamic_neighbors fallback is
+// evicted), while a first sighting and a same-MAC re-learn do not.
 
 #[test]
 fn mac_change_epoch_rx_learn_no_bump_on_first_sighting() {
@@ -491,7 +523,7 @@ fn mac_change_epoch_rx_learn_no_bump_on_first_sighting() {
     // MAC for a neighbor that did not exist, so the epoch stays put.
     map.learn_pair_if_changed(&[k], entry(0xAB));
     assert_eq!(map.get(&k), Some(entry(0xAB)));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
 }
 
 #[test]
@@ -503,7 +535,7 @@ fn mac_change_epoch_rx_learn_no_bump_on_same_mac_relearn() {
     // bump, else every RX packet from a known source would flush the
     // flow cache. This case must stay GREEN when the bump is neutralized.
     map.learn_pair_if_changed(&[k], entry(0xAB));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
 }
 
 #[test]
@@ -511,7 +543,7 @@ fn mac_change_epoch_rx_learn_bumps_on_mac_change() {
     let map = ShardedNeighborMap::new();
     let k = key_v4(7, 42);
     map.learn_pair_if_changed(&[k], entry(0xAB));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&k), 0);
     // An RX-learned MAC change for an existing dynamic neighbor (the
     // pair_write_needed gate fires on `current != Some(src_mac)`, not
     // just first sighting). lookup_neighbor_entry falls back to this map
@@ -520,25 +552,30 @@ fn mac_change_epoch_rx_learn_bumps_on_mac_change() {
     // learn_pair_if_changed: neutralizing its fetch_add makes this RED.
     map.learn_pair_if_changed(&[k], entry(0xCD));
     assert_eq!(map.get(&k), Some(entry(0xCD)));
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k), 1);
     // A subsequent same-MAC re-learn does not advance it further.
     map.learn_pair_if_changed(&[k], entry(0xCD));
-    assert_eq!(map.mac_change_epoch(), 1);
+    assert_eq!(map.mac_change_epoch_for(&k), 1);
 }
 
 #[test]
-fn mac_change_epoch_rx_learn_pair_single_bump_for_both_keys() {
+fn mac_change_epoch_rx_learn_pair_bumps_each_key_shard() {
     let map = ShardedNeighborMap::new();
-    // The #949 pair-write installs the same MAC under the physical and
-    // the resolved logical (VLAN sub-) ifindex. Seed both, then change
-    // the MAC on both in one learn: the coarse global epoch bumps exactly
-    // ONCE for the pair, not once per key.
+    // #5147: the #949 pair-write installs the same MAC under the physical
+    // and the resolved logical (VLAN sub-) ifindex, which hash to
+    // independent shards. Seed both, then change the MAC on both in one
+    // learn: each key's own shard epoch must advance (a flow resolved via
+    // either ifindex must be evicted), rather than one shared global epoch.
     let phys = key_v4(7, 42);
     let logical = key_v4(99, 42);
     map.learn_pair_if_changed(&[phys, logical], entry(0xAB));
-    assert_eq!(map.mac_change_epoch(), 0);
+    assert_eq!(map.mac_change_epoch_for(&phys), 0);
+    assert_eq!(map.mac_change_epoch_for(&logical), 0);
     map.learn_pair_if_changed(&[phys, logical], entry(0xCD));
     assert_eq!(map.get(&phys), Some(entry(0xCD)));
     assert_eq!(map.get(&logical), Some(entry(0xCD)));
-    assert_eq!(map.mac_change_epoch(), 1);
+    // Each changed key bumps its own shard (>= 1 covers the case where the
+    // two ifindexes happen to hash to the same shard).
+    assert!(map.mac_change_epoch_for(&phys) >= 1);
+    assert!(map.mac_change_epoch_for(&logical) >= 1);
 }

--- a/userspace-dp/src/afxdp/umem/tests/debug_state.rs
+++ b/userspace-dp/src/afxdp/umem/tests/debug_state.rs
@@ -318,6 +318,8 @@ fn active_flow_debug_test_entry(
         observed_bytes: 0,
         last_used_epoch: 0,
         neighbor_mac_epoch: 0,
+        // #5147: no dynamic-neighbor dependency in this test entry.
+        neighbor_shard: crate::afxdp::flow_cache::NEIGHBOR_SHARD_NONE,
     }
 }
 

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -1554,6 +1554,8 @@ mod reap_flow_cache_tests {
             observed_bytes: 0,
             last_used_epoch: 0,
             neighbor_mac_epoch: 0,
+            // #5147: no dynamic-neighbor dependency in this test entry.
+            neighbor_shard: crate::afxdp::flow_cache::NEIGHBOR_SHARD_NONE,
         });
     }
 


### PR DESCRIPTION
## Problem (#5147)

`ShardedNeighborMap.mac_change_epoch` was a single global `AtomicU32`. Every MAC replacement `fetch_add`'d it, and `flow_cache_hit` compared each cached entry's stamp against that ONE global value — so **any** neighbor's MAC change made **every** cached flow stale on its next hit. An on-link sender alternating one IP's MAC advances the global epoch faster than entries warm → the flow cache collapses to ~1 packet (attacker-driven cache thrash / DoS).

## Fix — targeted (per-shard) invalidation

Replace the single global epoch with a per-shard vector `shard_mac_epochs: [AtomicU32; NUM_SHARDS]`. A MAC replacement bumps **only** the epoch of the shard holding the changed neighbor key (all five write paths covered, each bumping the specific shard(s) it mutates). A cached flow stamps + re-validates against the epoch of the **specific shard its resolved next-hop `(egress_ifindex, next_hop)` lives in** (new `FlowCacheEntry::neighbor_shard`, precomputed once at cache-miss time from `decision.resolution`).

Result: a MAC change on neighbor A invalidates a cached flow using neighbor B only if A and B hash to the **same** shard (1/64), never map-wide.

- **Hot path stays cheap:** `neighbor_mac_epoch_stale` reads only the flow's own shard slot — one indexed relaxed atomic load + compare, allocation-free. A true per-neighbor index would need a hashmap probe on every hit, defeating the flow cache. (Issue explicitly endorses the "per-key/sharded" direction.)
- **#3918 TOCTOU preserved per shard:** the resolved shard is unknown until after the resolve, so `poll_descriptor` snapshots the whole per-shard vector (`snapshot_shard_epochs`) BEFORE the resolve and stamps the resolved shard's snapshotted value. A MAC change landing during/after the resolve can't already be in the snapshot → advances the live shard epoch past the stamp → evicted next hit. `NUM_SHARDS` relaxed loads, cold cache-miss path only.
- **#3048 preserved:** a real MAC change to a flow's OWN neighbor still evicts it.

## Fail-on-revert tests (merge gate)

- `unrelated_neighbor_mac_change_does_not_evict_cached_flow` (flow_cache_tests.rs) — F_a (uses A) + F_b (uses B, distinct shard); change A's MAC ⇒ F_a re-resolves **AND F_b is still a cache hit**. RED under the old global epoch.
- `mac_change_epoch_isolated_per_shard_across_neighbors` (sharded_neighbor_tests.rs) — a change on A bumps only A's shard.
- `cached_descriptor_evicted_only_on_neighbor_mac_change` — #3048 over-eviction guard (own-neighbor change still evicts).

Verified firsthand: neutralizing `bump_shard_epoch` to bump-all-shards (the old global behavior) turns both isolation guards RED while the #3048 guard stays green.

## Validation

`cargo build --release` green; full `cargo test --release` green **except** a pre-existing, unrelated protocol-wire fixture drift (`nat64_*` counters present in origin/master source but absent from the committed fixture — this branch touches zero protocol files). Docs updated: `docs/flow-cache-simplification.md`, `userspace-dp/src/afxdp/README.md`.

Closes #5147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)