### PR TITLE
userspace-dp: borrow inner packet in native GRE encap (#5381)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test/xsk-repro/xdp-tools*
 /dist/
 # .deb build-staging dir — a sibling of the publish root dist/ (HB165 H-5)
 /dist-deb/
+/target/

--- a/_Log.md
+++ b/_Log.md
@@ -51672,3 +51672,31 @@ top.
   pkg/dataplane/userspace/format/testdata/status_summary.golden,
   pkg/dataplane/userspace/format/status_golden_test.go,
   docs/feature-coverage.md, userspace-dp/src/FEATURES.md
+
+## 2026-07-17 — #5381 native-GRE encap: borrow inner packet, drop redundant `.to_vec()`
+- **Timestamp**: 2026-07-17
+- **Action**: `encapsulate_native_gre_frame` (userspace-dp/src/afxdp/gre.rs)
+  copied the inner packet into a fresh heap `Vec` via `.to_vec()` and THEN
+  `copy_from_slice`'d it into the output frame — two copies + one redundant
+  per-packet heap allocation on the native GRE egress fast path. Confirmed
+  every use of the inner is READ-ONLY across the whole fn body
+  (`packet_trimmed_len`, `inner_tos_byte`, `.len()`, and as the
+  `copy_from_slice` SOURCE into the separately-allocated `out`). Replaced the
+  `.to_vec()` with a borrowed slice into `inner_frame` (`inner_slice` →
+  trim via `packet_trimmed_len` → reslice `&inner_slice[..inner_len]`). The
+  single `copy_from_slice` into `out` remains the only copy; `inner_frame`
+  outlives the borrow and `out` is a distinct allocation, so no aliasing.
+  Wire output is byte-identical — this is a perf fix (one fewer alloc+copy
+  per encapsulated frame). Added a regression guard
+  (`gre_encap_output_is_byte_identical_and_trims_inner_slack`) that feeds an
+  inner buffer with trailing slack beyond its IPv4 total-length and asserts
+  the full emitted frame equals an independently hand-built expected frame
+  (outer eth/VLAN + IPv6 + GRE + TRIMMED inner) and that the slack never
+  leaks. The guard pins output-correctness after the alloc removal (it does
+  NOT go RED on a `.to_vec()` revert — the output is identical either way;
+  the alloc removal is verified by inspection). Full gre/encap module 7/7
+  passed 5× (no flakes); full afxdp::tunnel module 34/34 green. Perf-only —
+  no behavior/doc change beyond _Log.md.
+- **File(s)**:
+  userspace-dp/src/afxdp/gre.rs (borrow inner packet, drop `.to_vec()`),
+  userspace-dp/src/afxdp/tunnel_tests.rs (regression guard test)

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -834,9 +834,16 @@ pub(super) fn encapsulate_native_gre_frame(
         Some(offset) => offset,
         None => inner_meta.l3_offset as usize,
     };
-    let inner_packet = inner_frame.get(inner_l3..)?.to_vec();
-    let inner_len = packet_trimmed_len(&inner_packet, inner_meta.addr_family)?;
-    let inner_packet = &inner_packet[..inner_len];
+    // #5381: borrow the inner packet directly out of `inner_frame` rather
+    // than `.to_vec()`-ing it. Every use below is read-only
+    // (`packet_trimmed_len`, `inner_tos_byte`, `.len()`, and as the
+    // `copy_from_slice` SOURCE into the separately-allocated `out`), so the
+    // heap copy was redundant — the frame is copied exactly once, into
+    // `out`. `inner_frame` outlives the borrow and `out` is a distinct
+    // allocation, so there is no aliasing.
+    let inner_slice = inner_frame.get(inner_l3..)?;
+    let inner_len = packet_trimmed_len(inner_slice, inner_meta.addr_family)?;
+    let inner_packet = &inner_slice[..inner_len];
     // #2303: copy the inner DSCP+ECN onto the outer header (uniform
     // DSCP model + RFC 6040 ECN ingress copy) instead of hardcoding 0.
     let outer_tos = inner_tos_byte(inner_packet, inner_meta.addr_family);

--- a/userspace-dp/src/afxdp/tunnel_tests.rs
+++ b/userspace-dp/src/afxdp/tunnel_tests.rs
@@ -585,6 +585,124 @@ fn inner_tos_byte_reads_ipv4_and_ipv6() {
     );
 }
 
+// --- #5381 native-GRE encap: borrowed inner, single copy ---------------
+//
+// `encapsulate_native_gre_frame` used to `.to_vec()` the inner packet
+// (redundant heap alloc + copy) and THEN `copy_from_slice` it into the
+// output frame — two copies on the egress fast path. #5381 replaces the
+// `.to_vec()` with a borrowed slice into `inner_frame`; every use of the
+// inner is read-only, so the wire output is unchanged and the copy count
+// drops from two to one.
+//
+// This is a PERF fix: reverting to `.to_vec()` produces a byte-identical
+// frame, so a pure byte-equality test cannot go RED on the revert. It is
+// therefore a REGRESSION GUARD — it pins that the alloc removal keeps the
+// built frame byte-for-byte correct. The alloc removal itself is verified
+// by inspection (one fewer `Vec` allocation on the path; see gre.rs). The
+// guard is sharpened against the borrow/reslice math the fix touches: the
+// inner buffer carries trailing slack beyond its IPv4 total-length, and
+// the emitted inner region MUST be the TRIMMED bytes only (the slack must
+// never leak into the encapsulated output).
+#[test]
+fn gre_encap_output_is_byte_identical_and_trims_inner_slack() {
+    // Inner IPv4: 20-byte header declaring total_length = 40, a
+    // distinctive 20-byte payload, then 20 bytes of 0xEE trailing slack
+    // that `packet_trimmed_len` must drop. If the #5381 reslice math were
+    // wrong (wrong offset/length, or slicing the untrimmed backing), the
+    // slack would leak or the payload would shift — this test would fail.
+    let inner_declared = 40usize;
+    let slack = 20usize;
+    let mut inner = vec![0u8; inner_declared + slack];
+    inner[0] = 0x45; // version 4, IHL 5
+    inner[1] = 0x00; // TOS 0 -> outer IPv6 Traffic Class 0
+    inner[2..4].copy_from_slice(&(inner_declared as u16).to_be_bytes()); // total length = 40
+    inner[8] = 64; // TTL
+    inner[9] = PROTO_TCP;
+    inner[12..16].copy_from_slice(&[10, 0, 0, 1]); // src
+    inner[16..20].copy_from_slice(&[10, 0, 0, 2]); // dst
+    for (i, b) in inner[20..40].iter_mut().enumerate() {
+        *b = 0xA0 + i as u8; // distinctive payload pattern
+    }
+    for b in inner[40..].iter_mut() {
+        *b = 0xEE; // trailing slack — must NOT appear in the output
+    }
+    let expected_inner = inner[..inner_declared].to_vec();
+
+    let inner_frame = wrap_raw_ip_packet_for_tunnel(&inner, libc::AF_INET as u8);
+
+    let state = gre1881_state();
+    let decision = SessionDecision {
+        resolution: gre_encap_resolution(),
+        nat: NatDecision::default(),
+    };
+    let mut meta = ForwardPacketMeta::default();
+    meta.addr_family = libc::AF_INET as u8;
+    meta.protocol = PROTO_TCP;
+    meta.l3_offset = 14;
+
+    let out = encapsulate_native_gre_frame(&inner_frame, meta, &decision, &state)
+        .expect("gre encap must build a frame");
+
+    // Independently derive the expected wire frame from the fixture
+    // constants (gre1881 endpoint: IPv6 outer, no key, ttl 64, src
+    // 2001:559:8585:80::8, dst 2602:ffd3:0:2::7; resolution: VLAN 80,
+    // dst_mac 00:11:22:33:44:55, src_mac 02:bf:72:00:50:08).
+    let mut expected = Vec::new();
+    // Ethernet + 802.1Q VLAN-80 tag (18 bytes).
+    expected.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]); // dst mac
+    expected.extend_from_slice(&[0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]); // src mac
+    expected.extend_from_slice(&0x8100u16.to_be_bytes()); // TPID 802.1Q
+    expected.extend_from_slice(&80u16.to_be_bytes()); // TCI: PCP0/DEI0/VID80
+    expected.extend_from_slice(&0x86ddu16.to_be_bytes()); // ethertype IPv6
+    // Outer IPv6 header (40 bytes).
+    let payload_len = (4 + inner_declared) as u16; // GRE(4) + inner
+    expected.push(0x60); // version 6, TC high nibble 0
+    expected.push(0x00); // TC low nibble 0, flow-label high nibble 0
+    expected.push(0x00); // flow label
+    expected.push(0x00); // flow label
+    expected.extend_from_slice(&payload_len.to_be_bytes());
+    expected.push(crate::ip_proto::PROTO_GRE); // next header
+    expected.push(64); // hop limit (endpoint ttl)
+    expected.extend_from_slice(
+        &"2001:559:8585:80::8"
+            .parse::<std::net::Ipv6Addr>()
+            .unwrap()
+            .octets(),
+    );
+    expected.extend_from_slice(
+        &"2602:ffd3:0:2::7"
+            .parse::<std::net::Ipv6Addr>()
+            .unwrap()
+            .octets(),
+    );
+    // GRE header (4 bytes, no key): flags 0x0000, proto 0x0800 (inner IPv4).
+    expected.extend_from_slice(&0x0000u16.to_be_bytes());
+    expected.extend_from_slice(&0x0800u16.to_be_bytes());
+    // Inner packet — TRIMMED (slack dropped).
+    expected.extend_from_slice(&expected_inner);
+
+    assert_eq!(
+        out.len(),
+        18 + 40 + 4 + inner_declared,
+        "frame length = eth/VLAN(18) + IPv6 outer(40) + GRE(4) + trimmed inner(40)"
+    );
+    assert_eq!(
+        out, expected,
+        "#5381: the borrowed-inner encap must emit a byte-identical frame; \
+         the trailing 0xEE slack must be trimmed, not copied"
+    );
+    // Explicit sharpener on the region the fix touches: the inner bytes
+    // land verbatim at offset 62 and carry no slack.
+    assert_eq!(
+        &out[62..], &expected_inner[..],
+        "inner region must equal the trimmed inner packet exactly"
+    );
+    assert!(
+        !out[62..].contains(&0xEE),
+        "trailing slack must never leak into the encapsulated inner"
+    );
+}
+
 // --- #2315 RFC 6040 §4.2 decap-side ECN combine -----------------------
 
 use super::super::gre::{


### PR DESCRIPTION
## Summary

`encapsulate_native_gre_frame` (`userspace-dp/src/afxdp/gre.rs`) copied
the inner packet into a fresh heap `Vec` via `.to_vec()` and **then**
`copy_from_slice`'d it a second time into the output frame — a redundant
per-packet heap allocation plus an extra copy on the native GRE egress
fast path.

Every use of the inner packet across the whole function body is
**read-only**: `packet_trimmed_len`, `inner_tos_byte`, `.len()`, and as
the `copy_from_slice` **source** into the separately-allocated `out`.
Nothing mutates it, so the owned heap copy was never needed.

## Fix

Replace the `.to_vec()` with a borrowed slice into `inner_frame`:

```rust
let inner_slice = inner_frame.get(inner_l3..)?;
let inner_len = packet_trimmed_len(inner_slice, inner_meta.addr_family)?;
let inner_packet = &inner_slice[..inner_len];
```

The single `copy_from_slice` into `out` remains the only copy.
`inner_frame` outlives the borrow and `out` is a distinct allocation, so
there is no aliasing. **One fewer allocation and one fewer full-frame
copy per encapsulated packet.**

## Correctness / test note

The wire output is **byte-identical** — this is a pure performance fix.
The added test
`gre_encap_output_is_byte_identical_and_trims_inner_slack` feeds an inner
buffer with trailing slack beyond its IPv4 total-length and asserts the
emitted frame equals an independently hand-constructed expected frame
(outer eth/VLAN + IPv6 + GRE + the **trimmed** inner) and that the slack
never leaks into the output.

Because reverting to `.to_vec()` yields identical bytes, this guard is a
**regression guard on output-correctness after the alloc removal** — it
does *not* go RED on a `.to_vec()` revert (no fabricated RED). The
allocation removal itself is verified by inspection: one fewer `Vec` on
the path.

## Validation

- `cargo build` clean.
- gre/encap module (7 tests) passed **5 consecutive runs**, no flakes.
- Full `afxdp::tunnel` module (34 tests) green.
- Perf-only: only doc touched is `_Log.md`. Also adds `/target/` to
  `.gitignore` (the worktree build target dir).

Closes #5381

🤖 Generated with [Claude Code](https://claude.com/claude-code)