### PR TITLE
userspace-dp: persist state file outside the ServerState lock

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-17 — #5469: write_state serializes+fsyncs OUTSIDE the ServerState lock
+
+- **Timestamp**: 2026-07-17 (fix/5469-writestate-lock-convoy)
+- **Action**: `write_state` (userspace-dp state-file persist) held the
+  `ServerState` lock across `refresh_status`, `serde_json::to_vec_pretty` over
+  the whole `ProcessStatus` + `ConfigSnapshot`, AND `StateWriter::persist`
+  (file + parent-dir fsync). The fallback session-delta poll sets
+  `persist_state` on every nonempty request, so under session churn each delta
+  poll serialized+fsynced the full state while holding the lock that also gates
+  snapshot apply, status, and HA/control ops → lock convoy + delayed control
+  ops (same class as configstore #4829). Shrank the critical section: split out
+  `build_state_payload(&mut ServerState)` (the ONLY guard-touching half — runs
+  `refresh_status`, clones `status` + `snapshot` into an owned
+  `OwnedStatePayload`) and `OwnedStatePayload::encode()` (owns its data → cannot
+  reach the guard). `write_state` now holds the lock only for
+  `build_state_payload` + a cheap Arc bump of the writer handle, DROPS the
+  guard, then runs `encode()` (`to_vec_pretty`) and `persist` lock-free.
+  Confirmed `persist` is atomic (temp+rename via `finalize_durably`) and
+  single-writer-thread FIFO, so concurrent lock-free writers never tear the
+  file — last-writer-wins, transient staleness self-corrects on the next
+  periodic write. Byte-for-byte identical encoding to pre-#5469. Fail-on-revert
+  test `write_state_releases_lock_before_persist` uses a same-thread `try_lock`
+  probe at the persist point (a non-reentrant `Mutex` grants it only if the
+  guard was truly dropped); verified RED when the guard is put back across
+  persist. Ran server::tests 5× (67 passed, no flakes). Two full-suite
+  failures (`wire_invariant_default_specimens`,
+  `stalled_consumer_..._backlog_unbounded`) are pre-existing: the wire fixture
+  drift is from #25afac254 NAT64 `BindingStatus` counters (untouched here),
+  fails deterministically in isolation; the backpressure test is a known timing
+  flake (FAIL/OK/FAIL in isolation). Neither touches server/helpers.
+- **File(s)**:
+  userspace-dp/src/server/helpers.rs (split write_state + owned payload + test
+    probe),
+  userspace-dp/src/server/tests.rs (fail-on-revert test),
+  userspace-dp/src/server/README.md (helpers.rs write_state lock-discipline note),
+  _Log.md
+
 ## 2026-07-17 — #5163: zone-counter fold must be lock-free (no per-batch global mutex)
 
 - **Timestamp**: 2026-07-17 (fix/5163-zone-counter-contention)

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -45,6 +45,25 @@ this surface over a Unix socket using a newline-delimited text protocol.
 - `helpers.rs` — shared daemon-loop utilities (`replan_queues`,
   `replan_bindings_from_candidates`, `summarize_queues`, capability
   checks).
+  - **`write_state` holds the `ServerState` lock only to snapshot, not to
+    persist (#5469).** Persisting the state file used to run
+    `refresh_status`, `serde_json::to_vec_pretty` over the whole
+    `ProcessStatus` + `ConfigSnapshot`, AND `StateWriter::persist` (file +
+    parent-dir fsync) all under the `ServerState` lock. Because the fallback
+    session-delta poll sets `persist_state` on every nonempty request, under
+    session churn each delta poll serialized+fsynced the full state while
+    holding the lock that also gates snapshot apply, status, and HA/control
+    ops — a lock convoy. `write_state` now holds the lock ONLY long enough to
+    `refresh_status` and clone a minimal owned payload (`build_state_payload`,
+    the sole guard-touching half) plus a cheap Arc bump of the writer handle,
+    then DROPS the guard before `encode()` (the `to_vec_pretty`) and
+    `persist`. All persists still funnel through `StateWriter`'s single writer
+    thread and publish via temp+atomic-rename (`finalize_durably`), so
+    concurrent lock-free writers never tear the file; semantics are
+    last-writer-wins and any transient staleness self-corrects on the next
+    periodic write. `write_state_releases_lock_before_persist` is the
+    fail-on-revert guard (a same-thread `try_lock` at the persist point, which
+    a non-reentrant `Mutex` grants only if the guard was truly dropped).
 - `tests.rs` — colocated unit tests for the dispatcher, the per-verb
   handler error/gating arms, and the pure helper predicates (#1653
   §3.1). Handlers are driven through the real `handle_stream` call site

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -1280,25 +1280,123 @@ pub(crate) fn rx_queue_count(name: &str) -> usize {
     count.max(1)
 }
 
-pub(crate) fn write_state(state_file: &str, state: &Arc<Mutex<ServerState>>) -> Result<(), String> {
-    #[derive(Serialize)]
-    struct Payload<'a> {
-        status: &'a ProcessStatus,
-        snapshot: &'a Option<ConfigSnapshot>,
-    }
+/// Owned, point-in-time copy of the state that gets persisted to the state
+/// file. Cloned out of `ServerState` under the lock (`build_state_payload`) so
+/// the expensive serialization and the fsync in `persist` run WITHOUT holding
+/// the `ServerState` lock (#5469). Because this owns its data, `encode` cannot
+/// reach the guard — the type structure is the proof that serialization happens
+/// lock-free.
+struct OwnedStatePayload {
+    status: ProcessStatus,
+    snapshot: Option<ConfigSnapshot>,
+}
 
-    let mut guard = state.lock().expect("state poisoned");
-    refresh_status(&mut guard);
-    let payload = Payload {
-        status: &guard.status,
-        snapshot: &guard.snapshot,
+impl OwnedStatePayload {
+    /// Encode to the exact bytes written to the state file. Operates purely on
+    /// owned data with no `ServerState` guard in scope, so it can never run
+    /// under the lock. Byte-for-byte identical to the pre-#5469 encoding
+    /// (`to_vec_pretty` of the same two fields, trailing newline).
+    fn encode(&self) -> Result<Vec<u8>, String> {
+        #[derive(Serialize)]
+        struct Payload<'a> {
+            status: &'a ProcessStatus,
+            snapshot: &'a Option<ConfigSnapshot>,
+        }
+        let payload = Payload {
+            status: &self.status,
+            snapshot: &self.snapshot,
+        };
+        let mut bytes =
+            serde_json::to_vec_pretty(&payload).map_err(|e| format!("encode state: {e}"))?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+}
+
+/// Lock-scoped half of `write_state`: refresh the status and clone the minimal
+/// owned payload. This is the ONLY part of a state write that touches the
+/// `ServerState` guard — it takes `&mut ServerState` (the guarded data), so a
+/// caller must hold the lock to reach it, and it returns owned data the caller
+/// can persist after dropping the guard.
+fn build_state_payload(state: &mut ServerState) -> OwnedStatePayload {
+    refresh_status(state);
+    OwnedStatePayload {
+        status: state.status.clone(),
+        snapshot: state.snapshot.clone(),
+    }
+}
+
+pub(crate) fn write_state(state_file: &str, state: &Arc<Mutex<ServerState>>) -> Result<(), String> {
+    // Critical section (#5469): hold the `ServerState` lock ONLY long enough to
+    // refresh status and snapshot an owned, point-in-time payload, plus a cheap
+    // Arc bump for the writer handle. That lock also gates snapshot apply,
+    // status, and HA/control ops, so serializing the full ProcessStatus +
+    // ConfigSnapshot and driving `persist` (which does file + parent-dir fsync)
+    // under it created a lock convoy: the fallback session-delta poll sets
+    // `persist_state` on every nonempty request, so under session churn each
+    // delta poll serialized+fsynced the whole state while holding the lock,
+    // delaying every other control op that needs it.
+    let (payload, writer) = {
+        let mut guard = state.lock().expect("state poisoned");
+        let payload = build_state_payload(&mut guard);
+        let writer = guard.state_writer.clone();
+        (payload, writer)
+        // Guard dropped here: encode() + persist() below run lock-free.
     };
-    let data = serde_json::to_vec_pretty(&payload).map_err(|e| format!("encode state: {e}"))?;
-    let mut bytes = data;
-    bytes.push(b'\n');
-    guard
-        .state_writer
+
+    let bytes = payload.encode()?;
+
+    // Fail-on-revert probe (#5469): with the guard block above closed, this
+    // thread must NOT hold the `ServerState` lock at the persist point. std
+    // `Mutex` is non-reentrant, so a same-thread `try_lock` here succeeds only
+    // if the guard was truly dropped; revert the guard back across persist and
+    // the recorded value flips, turning `write_state_releases_lock_before_persist`
+    // RED. Compiled out of production builds.
+    #[cfg(test)]
+    record_pre_persist_lock_state(state);
+
+    // Serialization + fsync happen with the `ServerState` lock RELEASED. All
+    // persists funnel through StateWriter's single writer thread and publish via
+    // temp+atomic-rename (`finalize_durably`), so concurrent writers never tear
+    // the file; the effective semantics are last-writer-wins, and any transient
+    // staleness self-corrects on the next periodic write_state.
+    writer
         .persist(state_file, bytes)
         .map_err(|e| format!("write state file: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Records, per write_state-driving thread, whether the `ServerState` lock
+    /// was free at the pre-persist point (see `record_pre_persist_lock_state`).
+    /// Thread-local so parallel test threads never cross-contaminate.
+    static PRE_PERSIST_LOCK_FREE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Test seam for the #5469 fail-on-revert guard. Runs on `write_state`'s own
+/// thread, after the lock-scoped payload build and before `persist`. A
+/// same-thread `try_lock` succeeds ONLY if the guard was already dropped (std
+/// `Mutex` is non-reentrant), so the recorded flag proves persist runs outside
+/// the critical section.
+#[cfg(test)]
+fn record_pre_persist_lock_state(state: &Arc<Mutex<ServerState>>) {
+    let free = state.try_lock().is_ok();
+    PRE_PERSIST_LOCK_FREE.with(|c| c.set(Some(free)));
+}
+
+/// Reset the pre-persist lock probe for the current thread before driving a
+/// `write_state` under test.
+#[cfg(test)]
+pub(crate) fn clear_pre_persist_lock_probe() {
+    PRE_PERSIST_LOCK_FREE.with(|c| c.set(None));
+}
+
+/// Take the value recorded by the last `write_state` on the current thread:
+/// `Some(true)` if the lock was free at the persist point, `Some(false)` if it
+/// was still held (the #5469 regression), `None` if no probe ran.
+#[cfg(test)]
+pub(crate) fn take_pre_persist_lock_free() -> Option<bool> {
+    PRE_PERSIST_LOCK_FREE.with(|c| c.take())
 }

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -9,9 +9,9 @@
 // predicates.
 
 use super::helpers::{
-    bindings_settled, build_synced_session_entry, forwarding_unsupported_error,
-    parse_session_sync_mac, reconcile_status_bindings, set_bindings_forwarding_armed,
-    should_run_afxdp,
+    bindings_settled, build_synced_session_entry, clear_pre_persist_lock_probe,
+    forwarding_unsupported_error, parse_session_sync_mac, reconcile_status_bindings,
+    set_bindings_forwarding_armed, should_run_afxdp, take_pre_persist_lock_free, write_state,
 };
 use super::{handle_stream, ServerState};
 use crate::state_writer::StateWriter;
@@ -2334,6 +2334,29 @@ fn update_fabrics_unchanged_set_does_not_rewrite_state_file() {
     assert_eq!(
         before, after,
         "an unchanged update_fabrics must not rewrite the state file"
+    );
+    let _ = std::fs::remove_file(&state_file);
+}
+
+/// #5469 fail-on-revert: `write_state` must hold the `ServerState` lock ONLY
+/// long enough to refresh status and clone the owned payload — the expensive
+/// serialization and the `persist` fsync must run with the lock RELEASED. The
+/// pre-persist probe records, on `write_state`'s own thread, whether the lock
+/// was free at the persist point (std `Mutex` is non-reentrant, so a same-thread
+/// `try_lock` succeeds only if the guard was dropped). Revert the guard back
+/// across `persist` (the lock-convoy bug) and the probe records `false`, turning
+/// this test RED.
+#[test]
+fn write_state_releases_lock_before_persist() {
+    let state = new_state(ProcessStatus::default());
+    let state_file = unique_state_file("lock-free-persist");
+    clear_pre_persist_lock_probe();
+    write_state(&state_file, &state).expect("write_state must succeed");
+    let lock_free =
+        take_pre_persist_lock_free().expect("write_state must run the pre-persist lock probe");
+    assert!(
+        lock_free,
+        "write_state must drop the ServerState guard before serialization + persist (#5469)"
     );
     let _ = std::fs::remove_file(&state_file);
 }


### PR DESCRIPTION
## Problem

`write_state` (userspace-dp state-file persist, `server/helpers.rs`) held the
`ServerState` lock across **all three** expensive steps:

1. `refresh_status` (mutates status),
2. `serde_json::to_vec_pretty` over the entire `ProcessStatus` + `ConfigSnapshot`,
3. `StateWriter::persist` — which blocks the caller until the writer thread
   completes a **file + parent-dir fsync**.

The fallback session-delta poll sets `persist_state = true` on every nonempty
request, so under session churn **each delta poll serialized+fsynced the whole
state while holding the lock** that also gates snapshot apply, status, and
HA/control ops → a lock convoy that delays control operations. Same
anti-pattern class as configstore #4829 (different component/lock).

## Fix

Shrink the critical section so **only the snapshot** happens under the lock; the
serialization and fsync run lock-free:

- `build_state_payload(&mut ServerState)` — the ONLY guard-touching half. Runs
  `refresh_status`, then clones `status` + `snapshot` into an owned
  `OwnedStatePayload`.
- `OwnedStatePayload::encode()` — owns its data, takes **no** guard, so the type
  structure itself proves serialization can't run under the lock. Byte-for-byte
  identical to the pre-change encoding.
- `write_state` now holds the lock only for `build_state_payload` + a cheap
  `Arc` bump of the writer handle, **drops the guard**, then `encode()` +
  `persist()` run with the lock released.

### Correctness / ordering

`StateWriter::persist` funnels all writes through a **single writer thread**
(mpsc FIFO) and publishes via **temp + atomic rename** (`finalize_durably`:
fsync temp → rename → fsync parent dir). So concurrent lock-free writers **never
tear** the file. Semantics become last-writer-wins, matching the pre-change
last-writer-under-lock behavior; any transient staleness self-corrects on the
next periodic `write_state`. Lifecycle startup/shutdown writes are
single-threaded (the session thread joins before the shutdown write), so only
the two steady-state accept-loop threads can race — both periodic status writes.

`persist` **is** atomic-rename based, so the separate-writer-mutex variant was
not needed.

## Fail-on-revert test

`write_state_releases_lock_before_persist`: a **same-thread `try_lock`** probe
fires at the persist point. A non-reentrant std `Mutex` grants it only if the
guard was truly dropped, so the test records `true` on the fixed code and
`false` if someone puts the guard back across persist. **Verified RED** with the
guard held across persist, GREEN with the fix.

## Validation

- `make`/`cargo build` clean (warnings pre-existing).
- `server::tests` run **5×**: 67 passed each time, no flakes.
- Full `cargo test` tail: 3927 passed. The two failures are **pre-existing and
  unrelated** — `wire_invariant_default_specimens` is stale-fixture drift from
  the NAT64 `BindingStatus` counters (`25afac254`; deterministic in isolation,
  no protocol struct touched here) and
  `stalled_consumer_..._backlog_unbounded` is a known `event_stream` timing
  flake (FAIL/OK/FAIL in isolation). Neither touches `server/helpers`.
- Docs: `server/README.md` `helpers.rs` bullet + `_Log.md`.

Closes #5469

🤖 Generated with [Claude Code](https://claude.com/claude-code)