### PR TITLE
cluster: arm full resync on delete-journal overflow

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-17 — #5450: delete-journal overflow must arm a full bulk resync
+
+- **Timestamp**: 2026-07-17 (fix/5450-delete-journal-reconcile)
+- **Action**: On a full/disconnected send stream the delete journal
+  (`pkg/cluster/sync_conn.go`) evicts the OLDEST queued session-delete records
+  to stay under `deleteJournalCap`. Dropped deletes were counted
+  (`DeletesDropped`) but never otherwise recovered — the standby kept the
+  sessions the primary already closed until the next unrelated full bulk
+  reconcile, which under an extended control-link partition with high churn
+  could be far away (ghost sessions → wrong forwarding + inflated session
+  count). Fix: added a `forceResync atomic.Bool`; both drop sites
+  (`journalDelete` append-past-cap and `rejournalTail` re-journal-past-cap) now
+  arm it via a shared `armDeleteResync()` CAS (pure atomic under
+  `deleteJournalMu` — no I/O, idempotent, armed once per overflow episode). It
+  is consumed by whichever runs first: the connected sweep (`syncSweep`) or the
+  next reconnect (`handleNewConnection`, re-read AFTER `flushDeleteJournal` so an
+  eviction during that flush is caught), each firing a full authoritative
+  `doBulkSync` even when already primed. The peer's `reconcileStaleSessions` at
+  `BulkEnd` then deletes exactly the sessions absent from the snapshot. On a
+  failed bulk the arm is restored so a later sweep/reconnect retries.
+  `forceResync` is kept DISTINCT from `bulkEverCompleted` (daemon reads it for
+  VRRP sync-hold gating) and from `syncBackfillNeeded` (re-drives INSTALLS only
+  — a dropped delete has no live session to re-derive).
+- **File(s)**: pkg/cluster/sync.go (field), pkg/cluster/sync_conn.go
+  (armDeleteResync, journalDelete, rejournalTail, syncSweep,
+  handleNewConnection), pkg/cluster/sync_test.go
+  (TestDeleteJournalOverflowArmsForceResync, fail-on-revert),
+  docs/session-sync-architecture.md.
+- **Validation**: `go build ./...` clean; `go test ./pkg/cluster/...` green
+  (incl. `-race`); fail-on-revert confirmed (removing the rejournalTail
+  arm fails `rejournal_overflow_arms`). Failover smoke advised on the loss
+  userspace cluster (parent to run) — this touches session-sync.
+
 ## 2026-07-17 — #5163: zone-counter fold must be lock-free (no per-batch global mutex)
 
 - **Timestamp**: 2026-07-17 (fix/5163-zone-counter-contention)

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -319,7 +319,9 @@ un-sent tail at the front of the ring (FIFO-preserving, evicting the oldest on
 overflow) so they replay on the next reconnect flush — the same
 journal-on-failure contract `QueueDeleteV4`/`V6` use for runtime deletes (#2121
 fixed an earlier silent drop here). Genuine loss only occurs at the journal cap
-and is counted in `DeletesDropped`.
+and is counted in `DeletesDropped`; a cap eviction now also arms a full bulk
+resync so the standby reconciles the evicted deletes (#5450, see "Delete Journal
+Overflow" below).
 
 Because deletes are key-only on the peer (no generation/session-identity guard
 yet), a re-journaled delete that replays after a same-key replacement session
@@ -1026,9 +1028,32 @@ the lower-latency userspace delta path scoped to the AF_XDP helper.
 
 ### Delete Journal Overflow
 
-The delete journal is bounded. Extended disconnects with high churn can evict
-old deletes. The next bulk reconciliation eventually cleans this up, but not
-immediately.
+The delete journal is bounded (`deleteJournalCap`, default 10000). Extended
+disconnects with high churn can push it past the cap, evicting the oldest queued
+deletes. Those evicted records are session teardowns the standby still needs;
+they are already gone from the primary's local table, so no incremental install
+sweep can re-derive them.
+
+**Recovery (#5450):** whenever an eviction actually DROPS records — in either
+`journalDelete` (append past cap) or `rejournalTail` (re-journal-on-failure past
+cap) — the drop site arms `forceResync` (a single atomic, CAS-armed once per
+overflow episode; counted in `DeletesDropped`). `forceResync` is consumed by
+whichever runs first:
+
+- the periodic sweep (`syncSweep`) while connected, or
+- the next reconnect (`handleNewConnection`, re-read AFTER `flushDeleteJournal`
+  so an eviction during that flush is caught) even when the node is already
+  primed (`bulkEverCompleted`),
+
+and it sends a full authoritative `doBulkSync`/`BulkSync` snapshot. The peer's
+`reconcileStaleSessions` (run at `BulkEnd`) then DELETES any session absent from
+the snapshot — precisely the sessions the evicted deletes would have torn down.
+On a failed bulk the arm is restored so a later sweep/reconnect retries. Before
+#5450 an overflow only self-healed at the next unrelated full bulk reconcile,
+which could be far away, so the standby carried ghost sessions (wrong forwarding
++ inflated session count) for a long time. `forceResync` is deliberately kept
+distinct from `bulkEverCompleted` (which the daemon reads for VRRP sync-hold
+gating) and from `syncBackfillNeeded` (which only re-drives INSTALLS).
 
 ### Counter Divergence
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -137,10 +137,10 @@ type SyncStats struct {
 	// standby's held set for a family.
 	DHCPLeasesStaleIgnored atomic.Uint64
 	DHCPLeasesSeeded       atomic.Uint64
-	FencesSent         atomic.Uint64
-	FencesReceived     atomic.Uint64
-	Errors             atomic.Uint64
-	DeletesDropped     atomic.Uint64
+	FencesSent             atomic.Uint64
+	FencesReceived         atomic.Uint64
+	Errors                 atomic.Uint64
+	DeletesDropped         atomic.Uint64
 	// DeletesStaleIgnored counts deletes refused by the #2170 install-
 	// generation guard: a journaled/deferred delete whose generation was
 	// strictly older than the currently-installed same-key entry. A nonzero
@@ -174,16 +174,16 @@ type SyncStats struct {
 // SyncStatsSnapshot is a point-in-time copy of SyncStats with plain
 // non-atomic fields, safe to copy by value and pass across API boundaries.
 type SyncStatsSnapshot struct {
-	SessionsSent         uint64
-	SessionsReceived     uint64
-	SessionsInstalled    uint64
-	DeletesSent          uint64
-	DeletesReceived      uint64
-	BulkSyncs            uint64
-	ConfigsSent          uint64
-	ConfigsReceived      uint64
-	ConfigsStaleIgnored  uint64
-	ConfigsApplyFailed   uint64
+	SessionsSent           uint64
+	SessionsReceived       uint64
+	SessionsInstalled      uint64
+	DeletesSent            uint64
+	DeletesReceived        uint64
+	BulkSyncs              uint64
+	ConfigsSent            uint64
+	ConfigsReceived        uint64
+	ConfigsStaleIgnored    uint64
+	ConfigsApplyFailed     uint64
 	IPsecSASent            uint64
 	IPsecSAReceived        uint64
 	IPsecSAStaleIgnored    uint64
@@ -191,22 +191,22 @@ type SyncStatsSnapshot struct {
 	DHCPLeasesReceived     uint64
 	DHCPLeasesStaleIgnored uint64
 	DHCPLeasesSeeded       uint64
-	FencesSent           uint64
-	FencesReceived       uint64
-	Errors               uint64
-	DeletesDropped       uint64
-	DeletesStaleIgnored  uint64
-	InstallsStaleIgnored uint64
-	GenMapOverflow       uint64
-	Connected            bool
-	ActiveFabric         int
-	BulkSyncStartTime    int64
-	BulkSyncEndTime      int64
-	BulkSyncSessions     uint64
-	LastConfigSyncTime   int64
-	LastConfigSyncSize   uint64
-	LastFenceSeq         uint64
-	LastFenceAckAt       int64
+	FencesSent             uint64
+	FencesReceived         uint64
+	Errors                 uint64
+	DeletesDropped         uint64
+	DeletesStaleIgnored    uint64
+	InstallsStaleIgnored   uint64
+	GenMapOverflow         uint64
+	Connected              bool
+	ActiveFabric           int
+	BulkSyncStartTime      int64
+	BulkSyncEndTime        int64
+	BulkSyncSessions       uint64
+	LastConfigSyncTime     int64
+	LastConfigSyncSize     uint64
+	LastFenceSeq           uint64
+	LastFenceAckAt         int64
 }
 
 // TransferReadinessSnapshot captures session-sync state that determines whether
@@ -340,9 +340,20 @@ type SessionSync struct {
 	// IsPrimaryFn reports whether the local node is primary for the default sync scope.
 	IsPrimaryFn func() bool
 	// IsPrimaryForRGFn reports whether the local node is primary for a given RG.
-	IsPrimaryForRGFn     func(rgID int) bool
-	lastSweepTime        uint64
-	syncBackfillNeeded   atomic.Bool
+	IsPrimaryForRGFn   func(rgID int) bool
+	lastSweepTime      uint64
+	syncBackfillNeeded atomic.Bool
+	// forceResync arms a full authoritative bulk resync after a delete-journal
+	// overflow dropped session-delete records the standby still needs (#5450).
+	// It is DISTINCT from syncBackfillNeeded: that flag re-drives the INSTALL
+	// sweep (re-sends live sessions), but a dropped delete is a teardown for a
+	// session that no longer exists locally, so no install sweep can re-derive
+	// it — the only recovery is a full BulkSync so the peer's
+	// reconcileStaleSessions deletes the sessions the primary already closed.
+	// Armed once per overflow episode (CAS) by rejournalTail/journalDelete and
+	// consumed by whichever of the sweep loop (syncSweep) or the next reconnect
+	// (handleNewConnection) runs first.
+	forceResync          atomic.Bool
 	lastNewCounter       uint64
 	lastClosedCounter    uint64
 	lastSweepEmpty       bool

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -603,10 +603,23 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 			slog.Info("cluster sync: scheduling OnPeerConnected callback", "fabric", fabricIdx)
 			go s.OnPeerConnected()
 		}
-		if coldStart {
-			slog.Info("cluster sync: starting bulk sync on cold start", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+		// Re-read the resync arm AFTER flushDeleteJournal: a rejournalTail
+		// eviction during that flush (or a journalDelete drop while we were
+		// disconnected) arms forceResync, and dropped deletes are only
+		// recoverable via a full authoritative bulk snapshot (#5450). Force the
+		// bulk even when already primed so the peer's reconcileStaleSessions
+		// deletes the sessions we already closed.
+		forced := s.forceResync.Load()
+		if coldStart || forced {
+			if forced && !coldStart {
+				slog.Warn("cluster sync: forcing full bulk resync on reconnect after delete-journal overflow (standby may retain stale sessions)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+			} else {
+				slog.Info("cluster sync: starting bulk sync on cold start", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+			}
 			if err := s.doBulkSync(); err != nil {
 				slog.Warn("cluster sync: bulk sync failed", "err", err, "fabric", fabricIdx)
+			} else {
+				s.forceResync.Store(false)
 			}
 		} else {
 			slog.Info("cluster sync: skipping bulk sync on reconnect (already primed)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
@@ -807,6 +820,20 @@ func (s *SessionSync) syncSweep() int {
 	if s.sessions == nil {
 		return 0
 	}
+	// #5450: a delete-journal overflow (rejournalTail/journalDelete dropped
+	// records) armed forceResync — the standby may still hold sessions the
+	// primary already closed. Recover by sending a full authoritative bulk
+	// snapshot so the peer's reconcileStaleSessions deletes them. Consume the
+	// arm exactly once (CAS true->false); re-arm on failure so a later sweep or
+	// reconnect retries. flushDeleteJournal already ran this tick, so any tail
+	// still queued replays before this snapshot's window closes.
+	if s.forceResync.CompareAndSwap(true, false) {
+		slog.Warn("cluster sync: forcing full bulk resync after delete-journal overflow (standby may retain stale sessions)")
+		if err := s.doBulkSync(); err != nil {
+			s.forceResync.Store(true)
+			slog.Warn("cluster sync: forced resync bulk failed, will retry", "err", err)
+		}
+	}
 	if s.lastSweepEmpty && !s.syncBackfillNeeded.Load() {
 		if s.telemetry != nil {
 			newCtr, err1 := s.telemetry.GlobalCounter(dataplane.GlobalCtrSessionsNew)
@@ -970,21 +997,44 @@ func (s *SessionSync) QueueDeleteV6(key dataplane.SessionKeyV6) {
 	}
 }
 
+// armDeleteResync marks that a delete-journal overflow dropped session-delete
+// records the standby still needs, arming a full authoritative bulk resync
+// (#5450). It is a pure atomic CAS — safe to call while holding
+// deleteJournalMu because it never blocks and performs no I/O — and idempotent:
+// repeated drops in one overflow episode re-arm the already-set flag as a
+// no-op. The arm is consumed once by whichever of the sweep loop (syncSweep) or
+// the next reconnect (handleNewConnection) runs first; both send a full
+// BulkSync so the peer's reconcileStaleSessions deletes the sessions the
+// primary already closed. Returns true only on the false->true transition so
+// the caller can log the episode exactly once (outside the lock).
+func (s *SessionSync) armDeleteResync() bool {
+	return s.forceResync.CompareAndSwap(false, true)
+}
+
 // journalDelete stores a delete message in the bounded ring buffer for replay
-// on reconnect. If the journal is full, the oldest entry is evicted and
-// DeletesDropped is incremented.
+// on reconnect. If the journal is full, the oldest entry is evicted,
+// DeletesDropped is incremented, and a full bulk resync is armed (#5450) so the
+// standby does not silently retain the session the evicted delete would have
+// torn down.
 func (s *SessionSync) journalDelete(msg []byte) {
 	s.deleteJournalMu.Lock()
-	defer s.deleteJournalMu.Unlock()
 	cap := s.deleteJournalCap
 	if cap <= 0 {
 		cap = deleteJournalDefaultCap
 	}
+	armed := false
 	if len(s.deleteJournal) >= cap {
 		s.deleteJournal = s.deleteJournal[1:]
 		s.stats.DeletesDropped.Add(1)
+		armed = s.armDeleteResync()
 	}
 	s.deleteJournal = append(s.deleteJournal, msg)
+	s.deleteJournalMu.Unlock()
+	if armed {
+		slog.Warn("cluster sync: delete journal full, evicted oldest delete and armed full bulk resync to reconcile standby",
+			"deletes_dropped_total", s.stats.DeletesDropped.Load(),
+			"journal_cap", cap)
+	}
 }
 
 func (s *SessionSync) flushDeleteJournal() {
@@ -1060,6 +1110,14 @@ func (s *SessionSync) rejournalTail(tail [][]byte) {
 	}
 	dropped := total - capN
 	s.stats.DeletesDropped.Add(uint64(dropped))
+	// #5450: the evicted deletes are session teardowns the standby still needs;
+	// they are gone from our local table, so no incremental install sweep can
+	// re-derive them. Arm a full authoritative bulk resync (consumed by the
+	// sweep loop / next reconnect) so the peer's reconcileStaleSessions deletes
+	// the sessions we already closed instead of carrying ghosts until the next
+	// far-off full reconcile. Pure atomic CAS under deleteJournalMu — no I/O,
+	// idempotent, armed once per overflow episode.
+	s.armDeleteResync()
 	merged := make([][]byte, 0, capN)
 	if dropped < len(tail) {
 		// Drop the oldest prefix of the tail; keep the rest plus all of the

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -609,17 +609,24 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 		// recoverable via a full authoritative bulk snapshot (#5450). Force the
 		// bulk even when already primed so the peer's reconcileStaleSessions
 		// deletes the sessions we already closed.
-		forced := s.forceResync.Load()
-		if coldStart || forced {
-			if forced && !coldStart {
+		// Consume the resync arm with CAS (symmetric with syncSweep) BEFORE the
+		// bulk, so a NEW overflow that arms forceResync DURING this bulk survives
+		// to trigger the next resync instead of being cleared by an unconditional
+		// Store(false) (#5450 MINOR 1). coldStart forces a bulk regardless of the
+		// arm; a consumed arm is re-armed on bulk failure so a later
+		// sweep/reconnect retries.
+		forcedConsumed := s.forceResync.CompareAndSwap(true, false)
+		if coldStart || forcedConsumed {
+			if forcedConsumed && !coldStart {
 				slog.Warn("cluster sync: forcing full bulk resync on reconnect after delete-journal overflow (standby may retain stale sessions)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
 			} else {
 				slog.Info("cluster sync: starting bulk sync on cold start", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
 			}
 			if err := s.doBulkSync(); err != nil {
 				slog.Warn("cluster sync: bulk sync failed", "err", err, "fabric", fabricIdx)
-			} else {
-				s.forceResync.Store(false)
+				if forcedConsumed {
+					s.forceResync.Store(true)
+				}
 			}
 		} else {
 			slog.Info("cluster sync: skipping bulk sync on reconnect (already primed)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -2702,6 +2702,88 @@ func TestRejournalTailFIFOPrependAndOverflow(t *testing.T) {
 	})
 }
 
+// TestDeleteJournalOverflowArmsForceResync is the #5450 fail-on-revert guard: a
+// delete-journal overflow that DROPS session-delete records must arm a full
+// authoritative bulk resync (forceResync) so the standby re-learns the true
+// session set and stops carrying the sessions the evicted deletes would have
+// torn down. A rejournal / journal that stays within cap (no drops) must NOT
+// arm. Reverting the armDeleteResync() call in rejournalTail/journalDelete
+// makes this fail.
+func TestDeleteJournalOverflowArmsForceResync(t *testing.T) {
+	mk := func(n int) []byte { return encodeDeleteV4(deleteKeyN(n), 0) }
+
+	// rejournalTail WITHOUT overflow: fits within cap, drops nothing, must not
+	// arm the resync.
+	t.Run("rejournal_no_overflow_not_armed", func(t *testing.T) {
+		ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+		ss.deleteJournalCap = 10
+		ss.deleteJournal = [][]byte{mk(1), mk(2)}
+		ss.rejournalTail([][]byte{mk(3), mk(4), mk(5)})
+		if ss.stats.DeletesDropped.Load() != 0 {
+			t.Fatalf("precondition: expected 0 dropped, got %d", ss.stats.DeletesDropped.Load())
+		}
+		if ss.forceResync.Load() {
+			t.Fatal("forceResync armed without any dropped deletes")
+		}
+	})
+
+	// rejournalTail WITH overflow: exceeds cap, drops records, must arm the
+	// resync so the standby's reconcileStaleSessions runs on the next bulk.
+	t.Run("rejournal_overflow_arms", func(t *testing.T) {
+		ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+		ss.deleteJournalCap = 2
+		ss.deleteJournal = [][]byte{mk(1), mk(2), mk(3)}
+		ss.rejournalTail([][]byte{mk(4), mk(5), mk(6)})
+		if ss.stats.DeletesDropped.Load() == 0 {
+			t.Fatal("precondition: expected drops on overflow, got 0")
+		}
+		if !ss.forceResync.Load() {
+			t.Fatal("forceResync NOT armed after rejournalTail dropped records (#5450 regression)")
+		}
+	})
+
+	// journalDelete WITH overflow (via QueueDeleteV4 while disconnected): the
+	// second drop site must arm the resync too.
+	t.Run("journal_delete_overflow_arms", func(t *testing.T) {
+		ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+		ss.deleteJournalCap = 5
+		for i := 0; i < 8; i++ {
+			ss.QueueDeleteV4(dataplane.SessionKey{
+				SrcIP:    [4]byte{10, 0, 1, byte(i)},
+				Protocol: 6,
+				SrcPort:  uint16(1000 + i),
+				DstPort:  80,
+			})
+		}
+		if ss.stats.DeletesDropped.Load() == 0 {
+			t.Fatal("precondition: expected drops after 8 deletes into cap-5 journal, got 0")
+		}
+		if !ss.forceResync.Load() {
+			t.Fatal("forceResync NOT armed after journalDelete evicted records (#5450 regression)")
+		}
+	})
+
+	// journalDelete WITHOUT overflow: within cap, drops nothing, must not arm.
+	t.Run("journal_delete_no_overflow_not_armed", func(t *testing.T) {
+		ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+		ss.deleteJournalCap = 16
+		for i := 0; i < 4; i++ {
+			ss.QueueDeleteV4(dataplane.SessionKey{
+				SrcIP:    [4]byte{10, 0, 2, byte(i)},
+				Protocol: 6,
+				SrcPort:  uint16(2000 + i),
+				DstPort:  443,
+			})
+		}
+		if ss.stats.DeletesDropped.Load() != 0 {
+			t.Fatalf("precondition: expected 0 dropped, got %d", ss.stats.DeletesDropped.Load())
+		}
+		if ss.forceResync.Load() {
+			t.Fatal("forceResync armed without any dropped deletes")
+		}
+	})
+}
+
 // TestDeleteJournalFlushAllFit: with room in the send queue, every
 // journaled delete is enqueued and the journal empties.
 func TestDeleteJournalFlushAllFit(t *testing.T) {


### PR DESCRIPTION
## Problem (#5450)

On a full/disconnected send stream the cluster session-sync **delete
journal** evicts the OLDEST queued session-delete records to stay under
`deleteJournalCap`. Both drop sites — `journalDelete` (append past cap)
and `rejournalTail` (re-journal-on-failure past cap) — counted the loss
in `DeletesDropped` but did nothing else. The evicted records are session
teardowns the standby still needs, and they are already gone from the
primary's local table, so **no incremental install sweep can re-derive
them** (`syncBackfillNeeded` only re-drives INSTALLS). The standby kept
the sessions the primary had already closed until the next unrelated full
bulk reconcile — which under an extended control-link partition with high
churn can be far away — carrying ghost sessions (wrong forwarding on
failover + inflated session count) for a long time.

## Fix

Add a `forceResync atomic.Bool` armed by both drop sites via a shared
`armDeleteResync()` CAS (pure atomic under `deleteJournalMu` — no I/O,
never blocks the send path, idempotent, armed once per overflow episode).
It is consumed by whichever runs first:

- the connected periodic sweep (`syncSweep`), or
- the next reconnect (`handleNewConnection`), re-read **after**
  `flushDeleteJournal` so an eviction during that flush is caught,

each firing a full authoritative `doBulkSync` even when already primed
(`bulkEverCompleted`). The peer's `reconcileStaleSessions` at `BulkEnd`
then deletes exactly the sessions absent from the snapshot. On a failed
bulk the arm is restored so a later sweep/reconnect retries.

`forceResync` is kept distinct from `bulkEverCompleted` (daemon reads it
for VRRP sync-hold gating — clearing it as a side effect would wrongly
signal "never primed") and from `syncBackfillNeeded` (INSTALL re-drive
only).

## Validation

- `go build ./...` clean; `go vet ./pkg/cluster/` clean.
- `go test ./pkg/cluster/...` green, including `-race`.
- New `TestDeleteJournalOverflowArmsForceResync` fail-on-revert guard
  across both drop sites (overflow arms; no-overflow does not). Removing
  the `rejournalTail` arming line fails `rejournal_overflow_arms`.
- Docs: `docs/session-sync-architecture.md` "Delete Journal Overflow"
  rewritten; `_Log.md` updated.
- **Failover smoke on the loss userspace cluster is advised** (touches
  session sync) — parent to run.

Closes #5450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi