### PR TITLE
nat: O(1) deterministic reverse + checked port_of (#5660)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -51729,3 +51729,32 @@ top.
   `unrelated_neighbor_mac_change_does_not_evict_cached_flow` and
   `mac_change_epoch_isolated_per_shard_across_neighbors` RED while the #3048
   over-eviction guard stays green.
+
+## 2026-07-17 — #5660 nat/allocator bounded-hardening (2 items)
+- **Timestamp**: 2026-07-17
+- **Action**: Item 1 — replace the O(N) `pool_v4.iter().position()` linear scan
+  in `reverse_deterministic_v4`/`reverse_deterministic_v6` with an O(1)
+  `PoolReverseIndex` (`FxHashMap<Ipv4Addr,u32>`) built once by
+  `build_pool_reverse_index()`. Verified the pool is an ARBITRARY, possibly
+  non-contiguous ordered Vec (NAT64 parses pool strings; tests use gapped
+  `[198.51.100.1, .5]`), so a direct `translated_ip - pool_base` subtraction
+  would be wrong — first-match hash mirrors `position()` exactly. Reverse is the
+  provable inverse of the forward `pool_v4[ip_idx]` selection.
+- **Action**: Item 2 — `AddressOccupancy::port_of` now range-checks the offset
+  before the `u32 -> u16` narrowing (returns `Option<u16>`, `None` when
+  `offset >= range`) so an out-of-range value is REJECTED, not silently
+  truncated into a valid-looking wrong port. The sole claim-path caller holds
+  `offset < range`, so no behavior change on the hot path.
+- **Tests**: added `deterministic_reverse_v4_o1_index_is_exact_inverse_across_pool_boundaries`
+  (round-trips every subscriber over a NON-CONTIGUOUS pool covering ip_idx
+  0/mid/last — RED-verified against the contiguous-subtraction shortcut:
+  `Some(8)` vs `Some(1)` for 10.0.0.9) and
+  `port_of_rejects_out_of_range_offset_no_silent_truncation` (RED-verified by
+  neutralizing the guard: `Some(2048)` vs `None`). Updated the 7 existing
+  reverse-test call sites to build the index once. 5x flake check green.
+- **Validation**: `cargo build` clean; full `nat` suite 746 passed; full
+  userspace-dp suite 3931 passed (the 2 failing `protocol wire golden` +
+  `backpressure` tests pre-exist on the base commit with my changes stashed —
+  unrelated to nat).
+- **File(s)**: userspace-dp/src/nat/allocator.rs, userspace-dp/src/nat/tests_pool.rs,
+  docs/deterministic-nat-cgnat.md, _Log.md

--- a/docs/deterministic-nat-cgnat.md
+++ b/docs/deterministic-nat-cgnat.md
@@ -255,6 +255,14 @@ subscriber = ntohl(host_base) + sub_idx        # subscriber IP
 This allows ISP logging of just `(public_ip, port_range, subscriber)` tuples
 at pool configuration time, instead of per-session SNAT logs.
 
+`lookup(public_ip)` is an O(1) hash into a reverse index built ONCE from the
+ordered pool (`build_pool_reverse_index`, #5660), not a per-lookup linear scan
+of the pool (which could be up to `MAX_POOL_PREFIX_HOSTS` = 65536 addresses on
+the reverse/session-miss cold path). The pool is an arbitrary, possibly
+non-contiguous ordered list — `ip_idx` is a POSITION in that list, so a direct
+`public_ip - pool_base` subtraction would be wrong; the index maps each pool
+address to the same position the forward path selects with `pool_v4[ip_idx]`.
+
 ## Userspace Dataplane Implementation (#4559)
 
 Both the IPv4 (mode 1) and the IPv6/NAPT64 (mode 2) paths are implemented in the
@@ -270,7 +278,7 @@ reused while a session is alive.
 | `pkg/dataplane/userspace/nat_source.go` | `deterministicSourceNATFields()` precomputes `mode`/`block_size`/`blocks_per_ip`/`host_base` (host-order u32)/`host_count` from the pool + the defaulted port range, and stamps them on `SourceNATRuleSnapshot`. IPv4 host → mode 1; an IPv6 host takes the NAT64 (mode 2) path below, not this one. |
 | `pkg/dataplane/userspace/protocol.go` | `SourceNATRuleSnapshot` gains the five additive `deterministic_*` wire fields (omitempty, #1961 skew-safe). |
 | `userspace-dp/src/protocol/nat.rs` | Rust mirror of the wire fields (`#[serde(default)]` — an old control plane omits them → round-robin). |
-| `userspace-dp/src/nat/allocator.rs` | `DeterministicV4` params; `deterministic_indices_v4()` (subscriber IPv4 → `(ip_idx, block_idx)`); `allocate_deterministic_v4()` (claims the first free port in the subscriber's block against the live owner map, collision-free); `reverse_deterministic_v4()` (`(external IP, port)` → subscriber IPv4, no per-flow state). A deterministic allocation is NOT recycled on release (its block is re-scanned directly), so a deterministic-only pool never grows the recycle queue. |
+| `userspace-dp/src/nat/allocator.rs` | `DeterministicV4` params; `deterministic_indices_v4()` (subscriber IPv4 → `(ip_idx, block_idx)`); `allocate_deterministic_v4()` (claims the first free port in the subscriber's block against the live owner map, collision-free); `reverse_deterministic_v4()` (`(external IP, port)` → subscriber IPv4, no per-flow state — the external-IP→`ip_idx` step is an O(1) `PoolReverseIndex` hash built once by `build_pool_reverse_index()`, #5660, not a per-lookup pool scan). A deterministic allocation is NOT recycled on release (its block is re-scanned directly), so a deterministic-only pool never grows the recycle queue. |
 | `userspace-dp/src/nat/source.rs` | Builds `SourceNatRule.deterministic_v4` from the snapshot (mode 1 only) and routes a deterministic-pool match through `allocate_deterministic_v4` instead of the round-robin allocator. An out-of-range subscriber fails CLOSED (`DeterministicSubscriberOutOfRange`) rather than silently round-robining. |
 
 ### Mode 2 (IPv6 subscriber / NAPT64, NAT64 forward path)
@@ -280,7 +288,7 @@ reused while a session is alive.
 | `pkg/dataplane/userspace/nat64.go` | `deterministicNAT64V6Fields()` computes `block_size`/`blocks_per_ip` (against the FIXED NAT64 range)/`host_prefix_len` (32 or 64)/`host_base_v6` from the referenced source pool, and `buildNAT64Snapshots` stamps them on `NAT64RuleSnapshot`. Only a `/32`-or-`/64` IPv6 host referenced by a NAT64 rule-set yields the params; anything else stays zero (round-robin + advisory). |
 | `pkg/dataplane/userspace/protocol.go` | `NAT64RuleSnapshot` gains the four additive `deterministic_*` wire fields (omitempty, #1961 skew-safe). |
 | `userspace-dp/src/protocol/nat.rs` | Rust mirror of the four NAT64 wire fields (`#[serde(default)]`). |
-| `userspace-dp/src/nat/allocator.rs` | `DeterministicV6` params; `deterministic_indices_v6()` (IPv6 subscriber → `(ip_idx, block_idx)` from the 32-bit word after the prefix — offset 4 for `/32`, offset 8 for `/64`; #4863 rejects sources whose prefix bytes before the subscriber word differ from `host_base`, so an out-of-prefix source sharing the subscriber word fails CLOSED instead of stealing the in-prefix subscriber's block); `allocate_deterministic_v6()` (mirrors the v4 claim, collision-free, not recycled); `reverse_deterministic_v6()` (`(external IPv4, port)` → subscriber IPv6 prefix, no per-flow state). |
+| `userspace-dp/src/nat/allocator.rs` | `DeterministicV6` params; `deterministic_indices_v6()` (IPv6 subscriber → `(ip_idx, block_idx)` from the 32-bit word after the prefix — offset 4 for `/32`, offset 8 for `/64`; #4863 rejects sources whose prefix bytes before the subscriber word differ from `host_base`, so an out-of-prefix source sharing the subscriber word fails CLOSED instead of stealing the in-prefix subscriber's block); `allocate_deterministic_v6()` (mirrors the v4 claim, collision-free, not recycled); `reverse_deterministic_v6()` (`(external IPv4, port)` → subscriber IPv6 prefix, no per-flow state — same O(1) `PoolReverseIndex` for the external-IP→`ip_idx` step, #5660). |
 | `userspace-dp/src/nat64.rs` | `Nat64Prefix` gains `deterministic_v6: Option<DeterministicV6>`, built from the snapshot at `from_snapshots` time (`host_count` derived from the parsed pool size, pool-bounded). `allocate_source` routes through `allocate_deterministic_v6` when set. An out-of-range subscriber fails CLOSED. |
 | `pkg/config/compiler_validate_warn.go` | The #4560 advisory is narrowed to residual UNENFORCEABLE deterministic pools only (an IPv6 host not referenced by a NAT64 rule-set, or an unsupported prefix length); an enforced mode-1 or mode-2 pool no longer warns (`deterministicIPv4Enforced` / `deterministicNAPT64Enforced`). |
 

--- a/userspace-dp/src/nat/allocator.rs
+++ b/userspace-dp/src/nat/allocator.rs
@@ -231,16 +231,46 @@ pub(crate) fn deterministic_indices_v4(
     Some((ip_idx, block_idx))
 }
 
+/// #5660: O(1) reverse index for a deterministic-NAT external pool. Maps each
+/// external pool IPv4 address to its position in the ordered `pool_v4` list —
+/// the SAME index the forward path selects with `pool_v4[ip_idx]`. It replaces
+/// the reverse path's `pool_v4.iter().position()` linear scan (up to
+/// `MAX_POOL_PREFIX_HOSTS` = 65536 addresses) with a single hash lookup.
+///
+/// The pool is an ARBITRARY, possibly non-contiguous ordered address list (the
+/// NAT64 path builds it by parsing configured pool strings, and a source-NAT
+/// pool may span several disjoint ranges), so `ip_idx` is a POSITION in the
+/// list, not an arithmetic offset from a base — a direct `translated_ip -
+/// pool_base` subtraction would be wrong. Build this ONCE at prefix/rule build
+/// time with [`build_pool_reverse_index`] and reuse it for every reverse
+/// lookup; rebuilding it per lookup is O(N) again (and allocates). First
+/// occurrence of a (pathologically) duplicated pool address wins, exactly
+/// mirroring the `position()` first-match semantics it replaces.
+pub(crate) type PoolReverseIndex = FxHashMap<Ipv4Addr, u32>;
+
+/// #5660: build the [`PoolReverseIndex`] from an ordered deterministic-NAT
+/// external pool. First-match wins for a duplicated address (matches the
+/// `position()` scan this replaces).
+pub(crate) fn build_pool_reverse_index(pool_v4: &[Ipv4Addr]) -> PoolReverseIndex {
+    let mut index = FxHashMap::default();
+    index.reserve(pool_v4.len());
+    for (idx, &addr) in pool_v4.iter().enumerate() {
+        index.entry(addr).or_insert(idx as u32);
+    }
+    index
+}
+
 /// #4559: reverse a deterministic translated `(external pool IP, port)` back to
 /// the subscriber's internal IPv4 with NO per-flow state — the CGN-compliance
-/// property that motivates deterministic NAT. `pool_v4` is the rule's ordered
-/// external-address list (same order the forward path indexes); `port_low` is
-/// the pool's low port. Returns `None` when the tuple does not fall in the
-/// deterministic space (unknown external IP, port below `port_low`, or a
-/// block/subscriber index out of range).
+/// property that motivates deterministic NAT. `pool_index` is the pool's O(1)
+/// reverse index ([`build_pool_reverse_index`], keyed by the same ordered
+/// external-address list the forward path indexes); `port_low` is the pool's
+/// low port. Returns `None` when the tuple does not fall in the deterministic
+/// space (unknown external IP, port below `port_low`, or a block/subscriber
+/// index out of range).
 pub(crate) fn reverse_deterministic_v4(
     params: &DeterministicV4,
-    pool_v4: &[Ipv4Addr],
+    pool_index: &PoolReverseIndex,
     port_low: u16,
     translated_ip: Ipv4Addr,
     translated_port: u16,
@@ -248,7 +278,7 @@ pub(crate) fn reverse_deterministic_v4(
     if params.block_size == 0 {
         return None;
     }
-    let ip_idx = pool_v4.iter().position(|&a| a == translated_ip)?;
+    let ip_idx = *pool_index.get(&translated_ip)?;
     if translated_port < port_low {
         return None;
     }
@@ -257,7 +287,7 @@ pub(crate) fn reverse_deterministic_v4(
     if block_idx >= params.blocks_per_ip as u32 {
         return None;
     }
-    let sub_idx = (ip_idx as u32)
+    let sub_idx = ip_idx
         .checked_mul(params.blocks_per_ip as u32)?
         .checked_add(block_idx)?;
     if sub_idx >= params.host_count {
@@ -371,16 +401,17 @@ pub(crate) fn deterministic_indices_v6(
 
 /// #4559: reverse a deterministic translated `(external IPv4 pool address,
 /// port)` back to the subscriber's IPv6 prefix with NO per-flow state — the
-/// CGN-compliance property that motivates deterministic NAPT64. `pool_v4` is
-/// the prefix's ordered external-address list (same order the forward path
-/// indexes); `port_low` is the allocator's low port. The recovered address is
-/// the subscriber PREFIX (network base + subscriber word, trailing
-/// interface-identifier bytes left as the base's — zero for a network base):
-/// the deterministic unit is the subscriber prefix, not the full /128 host.
-/// Returns `None` when the tuple does not fall in the deterministic space.
+/// CGN-compliance property that motivates deterministic NAPT64. `pool_index` is
+/// the prefix's O(1) reverse index ([`build_pool_reverse_index`], keyed by the
+/// same ordered external-address list the forward path indexes); `port_low` is
+/// the allocator's low port. The recovered address is the subscriber PREFIX
+/// (network base + subscriber word, trailing interface-identifier bytes left as
+/// the base's — zero for a network base): the deterministic unit is the
+/// subscriber prefix, not the full /128 host. Returns `None` when the tuple
+/// does not fall in the deterministic space.
 pub(crate) fn reverse_deterministic_v6(
     params: &DeterministicV6,
-    pool_v4: &[Ipv4Addr],
+    pool_index: &PoolReverseIndex,
     port_low: u16,
     translated_ip: Ipv4Addr,
     translated_port: u16,
@@ -388,7 +419,7 @@ pub(crate) fn reverse_deterministic_v6(
     if params.block_size == 0 {
         return None;
     }
-    let ip_idx = pool_v4.iter().position(|&a| a == translated_ip)?;
+    let ip_idx = *pool_index.get(&translated_ip)?;
     if translated_port < port_low {
         return None;
     }
@@ -397,7 +428,7 @@ pub(crate) fn reverse_deterministic_v6(
     if block_idx >= params.blocks_per_ip as u32 {
         return None;
     }
-    let sub_idx = (ip_idx as u32)
+    let sub_idx = ip_idx
         .checked_mul(params.blocks_per_ip as u32)?
         .checked_add(block_idx)?;
     if sub_idx >= params.host_count {
@@ -499,9 +530,20 @@ impl AddressOccupancy {
         (off < self.range).then_some(off)
     }
 
+    /// Map a bitmap `offset` back to its wire port. #5660: the offset is
+    /// range-checked before the `u32 -> u16` narrowing so an out-of-range value
+    /// is REJECTED (`None`) rather than silently truncated into a valid-looking
+    /// but WRONG port. `offset < range` guarantees `port_low + offset <=
+    /// port_high <= u16::MAX`, so the cast neither truncates nor overflows; a
+    /// bare `offset as u16` would wrap (e.g. `65536 + k` -> `k`) and forge a
+    /// port `port_low + k` inside the pool. Callers on the claim path already
+    /// hold `offset < range`, so this returns `Some` for every legitimate claim.
     #[inline]
-    fn port_of(&self, offset: u32) -> u16 {
-        self.port_low + offset as u16
+    fn port_of(&self, offset: u32) -> Option<u16> {
+        if offset >= self.range {
+            return None;
+        }
+        Some(self.port_low + offset as u16)
     }
 
     /// CAS-set the bit at `offset`. Returns true iff this call transitioned it
@@ -558,7 +600,8 @@ impl AddressOccupancy {
             // (fresh), but an out-of-band occupant (reserve/persistent/HA) may
             // have set it — then CAS fails and we advance to the next offset.
             if self.claim_offset(cur) {
-                return Some(self.port_of(cur));
+                // `cur < self.range` (checked above), so `port_of` is `Some`.
+                return self.port_of(cur);
             }
         }
 
@@ -787,6 +830,18 @@ impl PortAllocator {
             },
             None => false,
         }
+    }
+
+    /// Test-only: map a bitmap `offset` to its port on pool address
+    /// `addr_index`, exercising the #5660 range-checked `port_of`. Returns
+    /// `None` for an unknown address OR an out-of-range offset (the value a bare
+    /// `offset as u16` would silently truncate).
+    #[cfg(test)]
+    pub(super) fn debug_port_of(&self, addr_index: usize, offset: u32) -> Option<u16> {
+        self.shared
+            .occupancy
+            .get(addr_index)
+            .and_then(|occ| occ.port_of(offset))
     }
 
     /// Test-only: total occupied ports across all pool addresses.

--- a/userspace-dp/src/nat/tests_pool.rs
+++ b/userspace-dp/src/nat/tests_pool.rs
@@ -8,8 +8,9 @@
 
 use super::allocator::{
     ALLOCATION_GC_BUDGET, DeterministicV4, DeterministicV6, NS_PER_SEC, PersistentLease,
-    PersistentSourceKey, PoolAddressFamily, TranslatedTuple, deterministic_indices_v6,
-    reverse_deterministic_v4, reverse_deterministic_v6, sticky_pool_index,
+    PersistentSourceKey, PoolAddressFamily, TranslatedTuple, build_pool_reverse_index,
+    deterministic_indices_v4, deterministic_indices_v6, reverse_deterministic_v4,
+    reverse_deterministic_v6, sticky_pool_index,
 };
 use super::source::{
     PersistentNatPermit, SOURCE_NAT_PROTO_ANY, SourceNatFailureReason, SourceNatFlowKey,
@@ -3915,6 +3916,10 @@ fn deterministic_cgnat_v4_fixed_block_per_subscriber_reversible() {
         "mode-1 IPv4 deterministic snapshot must build a deterministic rule"
     );
 
+    // #5660: the reverse path indexes the pool via the O(1) reverse map built
+    // once from the ordered pool, not a per-lookup linear scan.
+    let pool_index = build_pool_reverse_index(&pool);
+
     let alloc = |src: &str, dst: &str, sport: u16| -> (Ipv4Addr, u16) {
         let mut counter = None;
         let d = expect_snat_decision(match_source_nat_result_for_tuple(
@@ -3962,12 +3967,12 @@ fn deterministic_cgnat_v4_fixed_block_per_subscriber_reversible() {
 
     // Reverse: (external IP, port) -> subscriber, no per-flow state.
     assert_eq!(
-        reverse_deterministic_v4(&det, &pool, 1024, a_ip, a_port),
+        reverse_deterministic_v4(&det, &pool_index, 1024, a_ip, a_port),
         Some(Ipv4Addr::new(100, 64, 0, 5)),
         "reverse must recover subscriber A from (external IP, port) alone"
     );
     assert_eq!(
-        reverse_deterministic_v4(&det, &pool, 1024, a2_ip, a2_port),
+        reverse_deterministic_v4(&det, &pool_index, 1024, a2_ip, a2_port),
         Some(Ipv4Addr::new(100, 64, 0, 5)),
         "the second flow reverses to the same subscriber A"
     );
@@ -3981,7 +3986,7 @@ fn deterministic_cgnat_v4_fixed_block_per_subscriber_reversible() {
         "subscriber B port {b_port} must fall in its deterministic block [3072,3583]"
     );
     assert_eq!(
-        reverse_deterministic_v4(&det, &pool, 1024, b_ip, b_port),
+        reverse_deterministic_v4(&det, &pool_index, 1024, b_ip, b_port),
         Some(Ipv4Addr::new(100, 64, 1, 0)),
         "reverse must recover subscriber B"
     );
@@ -4065,6 +4070,8 @@ fn deterministic_napt64_v6_fixed_block_per_subscriber_reversible() {
     };
     // One shared allocator sized like the NAT64 per-prefix allocator.
     let alloc = PortAllocator::new(pool.len(), 1024, 65535);
+    // #5660: O(1) reverse index over the ordered pool (built once, reused).
+    let pool_index = build_pool_reverse_index(&pool);
 
     let alloc_for = |src: &str, sport: u16| -> (Ipv4Addr, u16) {
         let flow = SourceNatFlowKey {
@@ -4103,12 +4110,12 @@ fn deterministic_napt64_v6_fixed_block_per_subscriber_reversible() {
 
     // Reverse: (external IPv4, port) -> subscriber prefix, no per-flow state.
     assert_eq!(
-        reverse_deterministic_v6(&det, &pool, 1024, a_ip, a_port),
+        reverse_deterministic_v6(&det, &pool_index, 1024, a_ip, a_port),
         Some("2001:db8:0:5::".parse().unwrap()),
         "reverse must recover subscriber A from (external IPv4, port) alone"
     );
     assert_eq!(
-        reverse_deterministic_v6(&det, &pool, 1024, a2_ip, a2_port),
+        reverse_deterministic_v6(&det, &pool_index, 1024, a2_ip, a2_port),
         Some("2001:db8:0:5::".parse().unwrap()),
         "the second flow reverses to the same subscriber A"
     );
@@ -4122,7 +4129,7 @@ fn deterministic_napt64_v6_fixed_block_per_subscriber_reversible() {
         "subscriber B port {b_port} must fall in its deterministic block [3072,3583]"
     );
     assert_eq!(
-        reverse_deterministic_v6(&det, &pool, 1024, b_ip, b_port),
+        reverse_deterministic_v6(&det, &pool_index, 1024, b_ip, b_port),
         Some("2001:db8:0:100::".parse().unwrap()),
         "reverse must recover subscriber B"
     );
@@ -4219,6 +4226,8 @@ fn deterministic_napt64_v6_rejects_out_of_prefix_shared_word() {
     // allocation CLOSED (no external tuple handed out, so no lying reverse
     // map), while the in-prefix source still allocates and reverses correctly.
     let alloc = PortAllocator::new(pool.len(), 1024, 65535);
+    // #5660: O(1) reverse index over the ordered pool (built once, reused).
+    let pool_index = build_pool_reverse_index(&pool);
     let flow_for = |src: &str| SourceNatFlowKey {
         protocol: PROTO_TCP,
         src_ip: IpAddr::V6(src.parse().expect("src")),
@@ -4251,9 +4260,127 @@ fn deterministic_napt64_v6_rejects_out_of_prefix_shared_word() {
     };
     assert_eq!(ext_ip, pool[0], "in-prefix subscriber 5 maps to pool[0]");
     assert_eq!(
-        reverse_deterministic_v6(&det, &pool, 1024, ext_ip, ok.port),
+        reverse_deterministic_v6(&det, &pool_index, 1024, ext_ip, ok.port),
         Some("2001:db8:0:5::".parse().unwrap()),
         "the reverse map recovers the true in-prefix subscriber"
+    );
+}
+
+// #5660: the O(1) reverse index must be the EXACT inverse of the forward
+// deterministic mapping across EVERY subscriber and pool-address position — idx
+// 0 (first), the middle addresses, and the LAST address. The pool here is
+// deliberately NON-CONTIGUOUS (gaps between 10.0.0.1/.9/.100/.200), which is the
+// realistic shape (NAT64 parses arbitrary pool strings; source-NAT pools span
+// disjoint ranges). This is the guard against the tempting-but-WRONG "O(1)"
+// shortcut of `translated_ip - pool_base`: a contiguous-subtraction reverse
+// would attribute .9/.100/.200 to the wrong index and turn this RED. Both the
+// old `position()` scan and the new hash index satisfy this round-trip, so it is
+// a correctness guard for the refactor (the perf change itself is unobservable).
+#[test]
+fn deterministic_reverse_v4_o1_index_is_exact_inverse_across_pool_boundaries() {
+    // Non-contiguous 4-address pool. block_size 4, blocks_per_ip 3 -> each pool
+    // address serves 3 subscriber blocks; host_count = 4 * 3 = 12 subscribers.
+    let pool = [
+        Ipv4Addr::new(10, 0, 0, 1),
+        Ipv4Addr::new(10, 0, 0, 9),
+        Ipv4Addr::new(10, 0, 0, 100),
+        Ipv4Addr::new(10, 0, 0, 200),
+    ];
+    let port_low = 1024u16;
+    let host_base = u32::from(Ipv4Addr::new(100, 64, 0, 0));
+    let det = DeterministicV4 {
+        block_size: 4,
+        blocks_per_ip: 3,
+        host_base,
+        host_count: 12,
+    };
+    let pool_index = build_pool_reverse_index(&pool);
+
+    // Every subscriber (sub_idx 0..host_count) round-trips forward -> reverse.
+    // sub_idx spans ip_idx 0 (first), 1, 2 (middle), and 3 (last).
+    for sub_idx in 0..det.host_count {
+        let src = Ipv4Addr::from(host_base + sub_idx);
+        let (ip_idx, block_idx) =
+            deterministic_indices_v4(&det, src).expect("in-range subscriber maps forward");
+        assert_eq!(ip_idx, (sub_idx / 3) as usize, "forward ip_idx");
+        let external = pool[ip_idx];
+        // Confirm the reverse index recovers the SAME position the forward used.
+        assert_eq!(
+            pool_index.get(&external).copied(),
+            Some(ip_idx as u32),
+            "reverse index must return the forward pool position for {external}"
+        );
+        // The whole port block reverses to the same subscriber.
+        let block_start = port_low as u32 + block_idx * det.block_size as u32;
+        for p in block_start..block_start + det.block_size as u32 {
+            let port = p as u16;
+            assert_eq!(
+                reverse_deterministic_v4(&det, &pool_index, port_low, external, port),
+                Some(src),
+                "reverse of (external {external}, port {port}) must recover subscriber {src}"
+            );
+        }
+    }
+
+    // Idx 0 / middle / last explicitly, as the ticket calls out.
+    for &ip_idx in &[0usize, 1, 2, 3] {
+        let external = pool[ip_idx];
+        let expected_sub = (ip_idx as u32) * det.blocks_per_ip as u32; // block_idx 0
+        let expected_src = Ipv4Addr::from(host_base + expected_sub);
+        assert_eq!(
+            reverse_deterministic_v4(&det, &pool_index, port_low, external, port_low),
+            Some(expected_src),
+            "pool boundary idx {ip_idx} ({external}) reverses to {expected_src}"
+        );
+    }
+
+    // An external IP NOT in the pool is rejected (the reverse index misses).
+    assert_eq!(
+        reverse_deterministic_v4(
+            &det,
+            &pool_index,
+            port_low,
+            Ipv4Addr::new(10, 0, 0, 2),
+            port_low,
+        ),
+        None,
+        "an address absent from the pool must not reverse to any subscriber"
+    );
+}
+
+// #5660 RED-on-revert (item 2): `AddressOccupancy::port_of` must REJECT an
+// offset outside the port range instead of silently truncating it through the
+// `u32 -> u16` cast into a valid-looking but WRONG port. Removing the range
+// guard (keeping the `Option` shape, e.g. `if false && offset >= self.range`)
+// makes the out-of-range asserts below return `Some(<forged port>)` and turns
+// this RED — a bare `offset as u16` wraps `65536 + k` back to `k`, forging the
+// port `port_low + k` inside the pool.
+#[test]
+fn port_of_rejects_out_of_range_offset_no_silent_truncation() {
+    // port_low 1024, port_high 2047 -> range 1024 (offsets 0..=1023 valid).
+    let alloc = PortAllocator::new(1, 1024, 2047);
+
+    // In-range offsets map to the exact wire port (no truncation).
+    assert_eq!(alloc.debug_port_of(0, 0), Some(1024), "offset 0 -> port_low");
+    assert_eq!(
+        alloc.debug_port_of(0, 1023),
+        Some(2047),
+        "last valid offset -> port_high"
+    );
+
+    // offset == range is one past the end: rejected, not wrapped to port_low.
+    assert_eq!(
+        alloc.debug_port_of(0, 1024),
+        None,
+        "offset == range must be rejected"
+    );
+
+    // The truncation forgery: offset 65536+5 casts (as u16) to 5, which would
+    // forge the VALID in-range port 1029. The range check rejects it instead.
+    assert_eq!(
+        alloc.debug_port_of(0, 65536 + 5),
+        None,
+        "an offset whose u16 truncation forges a valid port must be rejected"
     );
 }
 


### PR DESCRIPTION
## Summary

`#5660` nat/allocator bounded-hardening cohort — two avoidable sharp edges on the deterministic-NAT paths.

### Item 1 — deterministic reverse is O(N)
`reverse_deterministic_v4`/`reverse_deterministic_v6` recovered the pool index with `pool_v4.iter().position(|&a| a == translated_ip)` — a linear scan of up to `MAX_POOL_PREFIX_HOSTS` (65536) external addresses on the reverse/session-miss cold path.

**Pool representation verified first:** the pool is an **arbitrary, possibly non-contiguous** ordered `Vec` (the NAT64 path builds it by parsing configured pool strings — tests use gapped `[198.51.100.1, .5]`; a source-NAT pool may span disjoint ranges). So `ip_idx` is a **position** in the list, and a direct `translated_ip - pool_base` subtraction would be **wrong**.

Fix: replace the scan with an O(1) `PoolReverseIndex` (`FxHashMap<Ipv4Addr,u32>`) built **once** by `build_pool_reverse_index()` and reused for every reverse lookup. It is the provable inverse of the forward `pool_v4[ip_idx]` selection; first-match wins for a (pathological) duplicated pool address, exactly mirroring the `position()` semantics it replaces.

### Item 2 — unchecked `port_of` u32→u16 cast
`AddressOccupancy::port_of` cast `offset as u16` with no range check, so an out-of-range offset would silently truncate (`65536+k` wraps to `k`) and forge a valid-looking but **wrong** port `port_low + k`. It now returns `Option<u16>`, rejecting `offset >= range` before the narrowing. The sole claim-path caller already holds `offset < range`, so the hot path is unchanged.

## Tests
- `deterministic_reverse_v4_o1_index_is_exact_inverse_across_pool_boundaries` — round-trips **every** subscriber forward→reverse over a deliberately **non-contiguous** pool covering `ip_idx` 0 (first) / middle / last. RED-verified against the tempting contiguous-subtraction shortcut (`Some(8)` vs `Some(1)` for `10.0.0.9`).
- `port_of_rejects_out_of_range_offset_no_silent_truncation` — behaviorally **RED-on-revert**: neutralizing the guard yields `Some(2048)` vs `None`.
- 7 existing reverse-test call sites updated to build the index once.

## Validation
- `cargo build` clean; full `nat` suite **746 passed**; 5× flake check on the new tests green.
- Both RED-on-revert paths verified firsthand as **assertion failures** (not build breaks).
- The two pre-existing full-suite failures (protocol wire golden fixture + backpressure timing) reproduce on the base commit with these changes stashed — **unrelated to nat**.

Docs: `docs/deterministic-nat-cgnat.md` reverse-mapping section + component rows updated for the O(1) reverse index.

Closes #5660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi