### PR TITLE
filter: intern modifier fields as Arc<str> to kill per-packet clone

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-17 — #5444: filter modifier propagation is Arc<str>, not per-packet String clone
+
+- **Timestamp**: 2026-07-17 (fix/5444-filter-modifier-clone)
+- **Action**: `merge_matched_modifiers` (userspace-dp filter action-eval hot
+  path, runs per matched term on every input/output/lo0 filter walk)
+  heap-cloned two owned `String` fields (`policer_name`, `routing_instance`)
+  into the per-packet `FilterResult` for EVERY matched term — two allocation
+  +copy events on the filter fast path. Converted `FilterTerm.policer_name`
+  and `FilterTerm.routing_instance` from `String` to `Arc<str>` (interned once
+  at compile time in `compiler.rs`, mirroring the existing
+  `forwarding_class: Arc<str>`), and `FilterResult.policer_name` /
+  `.routing_instance` from `String` to `Option<Arc<str>>` (mirroring the #5151
+  `forwarding_class: Option<Arc<str>>` pattern). The merge is now a refcount
+  bump; the accumulator default and the non-routing reset are zero-alloc
+  (`None`) instead of `String::new()`. Output is byte-identical — the same
+  policer/routing-instance/forwarding-class values flow downstream. Verified
+  no non-test consumer reads either FilterResult field (the live routing-
+  instance override rides the separate `FilterRoutingInstanceResult<'a>` with
+  its `&'a str`, untouched); neither field is mutated in place; the config-
+  owned source outlives every FilterResult. `cache_sensitive.rs` term-compare
+  (`Arc<str> == Arc<str>`) and PBR evaluators (`&*term.routing_instance`)
+  adjusted. Two test asserts on `FilterResult.routing_instance` moved from
+  `.is_empty()` to `.is_none()`.
+- **File(s)**: userspace-dp/src/filter/mod.rs,
+  userspace-dp/src/filter/compiler.rs,
+  userspace-dp/src/filter/engine/eval.rs, userspace-dp/src/filter/tests.rs
+- **Validation**: `cargo build` clean; filter suite 189 tests green, run 5×
+  no flakes; new perf-with-correctness-guard test
+  `filter_result_modifiers_roundtrip_5444` asserts all three modifiers round-
+  trip into FilterResult on a match and default to `None` on a miss (NOT a
+  RED-on-revert — values are byte-identical either way; it guards against a
+  future refactor silently dropping a modifier). Grepped the changed fn: the
+  three remaining `.clone()` are all `Arc<str>` refcount bumps, zero
+  `String::`/`.to_string()`. Two full-suite failures
+  (`wire_invariant_default_specimens` nat64 stats fixture drift,
+  `stalled_consumer_...backlog_unbounded_end_to_end` backpressure timing) are
+  PRE-EXISTING — reproduced identically with this change stashed; unrelated to
+  the filter module. Perf-only change with byte-identical output, so no
+  design-doc/contract update needed (the #5444 in-code comments, mirroring the
+  #5151/#5857 precedent, are the documentation surface).
+
 ## 2026-07-17 — #5469: write_state serializes+fsyncs OUTSIDE the ServerState lock
 
 - **Timestamp**: 2026-07-17 (fix/5469-writestate-lock-convoy)

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -947,9 +947,12 @@ fn parse_term(
         count: snap.count.clone(),
         has_count: !snap.count.is_empty(),
         log: snap.log,
-        policer_name: snap.policer.clone(),
+        // #5444: intern the modifier strings into `Arc<str>` once at compile
+        // time (mirrors `forwarding_class`) so per-packet propagation into the
+        // FilterResult accumulator is a refcount bump, not a String heap copy.
+        policer_name: Arc::<str>::from(snap.policer.as_str()),
         three_color_policer: three_color_policers.get(&snap.policer).cloned(),
-        routing_instance: snap.routing_instance.clone(),
+        routing_instance: Arc::<str>::from(snap.routing_instance.as_str()),
         forwarding_class: Arc::<str>::from(snap.forwarding_class.as_str()),
         dscp_rewrite,
         counter: Arc::new(FilterTermCounter::default()),

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -212,11 +212,16 @@ fn merge_matched_modifiers(
         acc.dscp_rewrite = Some(rewrite);
     }
     acc.policer_drop |= policer_action.drop;
+    // #5444: `policer_name`/`routing_instance` are `Arc<str>` (interned at
+    // compile time), so these writes are refcount bumps — NOT per-packet String
+    // heap allocations. Mirrors the `forwarding_class` clone below (#5151); the
+    // Arc clone only runs when a term ACTUALLY sets the modifier, and `None` on
+    // the default/reset preserves the old empty-`""` "unset" meaning.
     if !term.policer_name.is_empty() {
-        acc.policer_name = term.policer_name.clone();
+        acc.policer_name = Some(term.policer_name.clone());
     }
     if !term.routing_instance.is_empty() {
-        acc.routing_instance = term.routing_instance.clone();
+        acc.routing_instance = Some(term.routing_instance.clone());
     }
     if !term.forwarding_class.is_empty() {
         // #5151: clone the Arc only when a term ACTUALLY sets a forwarding-class
@@ -387,7 +392,7 @@ fn evaluate_filter_ref_non_routing_counted_v4(
         merge_matched_modifiers(&mut acc, filter, term, None, packet_bytes);
         // This loop variant never carries a routing-instance through the
         // result (it defers to the routing-instance evaluator); keep that.
-        acc.routing_instance = String::new();
+        acc.routing_instance = None;
         if !term.continue_term {
             acc.action = term.action;
             if !always_count && term.action != FilterAction::Accept {
@@ -480,7 +485,7 @@ fn evaluate_filter_ref_non_routing_counted_v6(
         // #5857: the non-routing input-filter evaluator does NOT meter its
         // policer here (it is metered in the tx-selection walk); pass None.
         merge_matched_modifiers(&mut acc, filter, term, None, packet_bytes);
-        acc.routing_instance = String::new();
+        acc.routing_instance = None;
         if !term.continue_term {
             acc.action = term.action;
             if !always_count && term.action != FilterAction::Accept {
@@ -582,7 +587,7 @@ fn evaluate_filter_ref_routing_instance_counted_v4<'a>(
             continue;
         }
         let routing_instance =
-            (!term.routing_instance.is_empty()).then_some(term.routing_instance.as_str())?;
+            (!term.routing_instance.is_empty()).then_some(&*term.routing_instance)?;
         // The routing-instance term itself may also carry `then log`; latest
         // matched wins so it supersedes any earlier fall-through log.
         if let Some(lm) = filter_log_match(filter, term) {
@@ -637,7 +642,7 @@ fn evaluate_filter_ref_routing_instance_counted_v6<'a>(
             continue;
         }
         let routing_instance =
-            (!term.routing_instance.is_empty()).then_some(term.routing_instance.as_str())?;
+            (!term.routing_instance.is_empty()).then_some(&*term.routing_instance)?;
         if let Some(lm) = filter_log_match(filter, term) {
             acc_log = Some(lm);
         }

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -250,9 +250,14 @@ pub(crate) struct FilterTerm {
     pub(crate) count: String,
     pub(crate) has_count: bool,
     pub(crate) log: bool,
-    pub(crate) policer_name: String,
+    // #5444: `policer_name`/`routing_instance` are `Arc<str>` (like
+    // `forwarding_class`) so `merge_matched_modifiers` propagates them into the
+    // per-packet `FilterResult` with a refcount bump instead of a String heap
+    // allocation+copy on every matched term. Config-owned, set once at compile
+    // time, read-only downstream.
+    pub(crate) policer_name: Arc<str>,
     pub(crate) three_color_policer: Option<Arc<ThreeColorPolicerRuntime>>,
-    pub(crate) routing_instance: String,
+    pub(crate) routing_instance: Arc<str>,
     pub(crate) forwarding_class: Arc<str>,
     pub(crate) dscp_rewrite: Option<u8>,
     pub(crate) counter: Arc<FilterTermCounter>,
@@ -836,7 +841,12 @@ impl FilterState {
 pub(crate) struct FilterResult {
     pub(crate) action: FilterAction,
     pub(crate) dscp_rewrite: Option<u8>,
-    pub(crate) policer_name: String,
+    // #5444: `None` == no policer matched (semantically identical to the
+    // historical empty `""`). `Option<Arc<str>>` mirrors `forwarding_class`
+    // (#5151): the accumulator init and the non-routing reset are zero-alloc
+    // (`None`), and a matched `then policer` term propagates it with an Arc
+    // refcount bump instead of a String heap allocation on the packet path.
+    pub(crate) policer_name: Option<Arc<str>>,
     // #5857: OR of every matched term's three-color-policer drop decision. Only
     // the METERED walk (`evaluate_lo0_filter_counted` with `now_ns = Some`, the
     // lo0 host-bound path) sets this; the shared action-eval walk leaves it false
@@ -846,7 +856,9 @@ pub(crate) struct FilterResult {
     // to a silent `Discard` when this is set — enforcing the configured
     // control-plane rate limit that was previously inert on host-bound traffic.
     pub(crate) policer_drop: bool,
-    pub(crate) routing_instance: String,
+    // #5444: `Option<Arc<str>>` for the same reason as `policer_name` above —
+    // refcount-bump propagation, zero-alloc `None` default/reset.
+    pub(crate) routing_instance: Option<Arc<str>>,
     // #5151: `None` == no forwarding-class matched (semantically identical to
     // the historical empty `""`). Mirrors TxSelection/CachedTxSelection which
     // already use `Option<Arc<str>>` — the accumulator init no longer allocates
@@ -913,10 +925,14 @@ impl Default for FilterResult {
         Self {
             action: FilterAction::Accept,
             dscp_rewrite: None,
-            policer_name: String::new(),
+            // #5444: zero-alloc default — no String buffer allocated on the
+            // warmed packet path. A matching `then policer` term sets `Some(..)`
+            // in `merge_matched_modifiers` (Arc refcount bump).
+            policer_name: None,
             // #5857: no policer drop by default; set only by the metered lo0 walk.
             policer_drop: false,
-            routing_instance: String::new(),
+            // #5444: zero-alloc default, as `policer_name` above.
+            routing_instance: None,
             // #5151: zero-alloc default — no Arc header/data block allocated on
             // the warmed packet path. A matching `then forwarding-class` term
             // sets `Some(..)` in `merge_matched_modifiers`.

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2130,6 +2130,84 @@ fn filter_result_forwarding_class_defaults_none_zero_alloc() {
     assert_eq!(no_fc.forwarding_class, None);
 }
 
+/// #5444: a matched term's `policer`, `routing-instance`, and
+/// `forwarding-class` modifiers round-trip into the FilterResult accumulator.
+///
+/// This is a PERF change with a CORRECTNESS guard — NOT a RED-on-revert. The
+/// fix converts the two owned `String` modifier slots
+/// (`FilterTerm`/`FilterResult` `policer_name` and `routing_instance`) to
+/// reference-counted `Arc<str>` so `merge_matched_modifiers` propagates them
+/// with a refcount bump instead of a per-packet String heap allocation+copy on
+/// the filter fast path. The VALUES carried are byte-identical either way, so a
+/// revert to `String` would still pass this test. It exists so a future
+/// refactor of the modifier merge cannot silently drop or mis-propagate a
+/// modifier, and to pin the zero-alloc `None` default on the no-match path.
+#[test]
+fn filter_result_modifiers_roundtrip_5444() {
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "ge-0/0/0.0".into(),
+        ifindex: 9,
+        filter_input_v4: "steer".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "steer".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "mark".into(),
+                action: "accept".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["5201".into()],
+                policer: "p-lo".into(),
+                routing_instance: "blue".into(),
+                forwarding_class: "assured".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &ifaces,
+        "",
+        "",
+    )
+    .expect("filter state compiles");
+
+    // A matching flow carries all three modifiers into the FilterResult.
+    let matched = evaluate_interface_filter(
+        &state,
+        9,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(matched.action, FilterAction::Accept);
+    assert_eq!(matched.policer_name.as_deref(), Some("p-lo"));
+    assert_eq!(matched.routing_instance.as_deref(), Some("blue"));
+    assert_eq!(matched.forwarding_class.as_deref(), Some("assured"));
+
+    // A non-matching flow leaves every modifier at the zero-alloc default None.
+    let unmatched = evaluate_interface_filter(
+        &state,
+        9,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        22,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(unmatched.policer_name, None);
+    assert_eq!(unmatched.routing_instance, None);
+    assert_eq!(unmatched.forwarding_class, None);
+}
+
 #[test]
 fn parse_filter_state_prequalifies_interface_and_lo0_filter_keys() {
     let ifaces = vec![crate::InterfaceSnapshot {
@@ -3373,7 +3451,9 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         NonRoutingCountPolicy::Always,
     );
     assert_eq!(pbr.action, FilterAction::Accept);
-    assert!(pbr.routing_instance.is_empty());
+    // #5444: FilterResult.routing_instance is Option<Arc<str>>; the non-routing
+    // evaluator resets it to None (it defers PBR to the routing-instance eval).
+    assert!(pbr.routing_instance.is_none());
     let filter = state.iface_filter_v4_fast.get(&12).expect("input filter");
     assert_eq!(filter.terms[0].counter.packets.load(Ordering::Relaxed), 0);
 
@@ -7654,7 +7734,9 @@ fn pbr_miss_path_counts_fallthrough_term_exactly_once() {
         policy,
     );
     assert_eq!(precheck.action, FilterAction::Accept);
-    assert!(precheck.routing_instance.is_empty());
+    // #5444: FilterResult.routing_instance is Option<Arc<str>>; None on the
+    // non-routing precheck (the PBR override rides FilterRoutingInstanceResult).
+    assert!(precheck.routing_instance.is_none());
 
     // Step 2 — routing-instance evaluator (route override). It owns the count.
     let routing = evaluate_interface_filter_routing_instance_event_counted(


### PR DESCRIPTION
## Summary

`merge_matched_modifiers` (userspace-dp filter action-eval hot path — runs per
matched term on every input/output/lo0 filter walk) heap-cloned two owned
`String` fields, `policer_name` and `routing_instance`, into the per-packet
`FilterResult` for **every** matched term: two allocation+copy events on the
filter fast path (the `forwarding_class` Arc clone beside them is already just a
refcount bump).

This converts the modifier fields to reference-counted strings so the merge is a
refcount bump instead of a heap alloc+copy:

- `FilterTerm.policer_name` / `.routing_instance`: `String` → `Arc<str>`,
  interned once at compile time in `parse_term` (mirrors the existing
  `forwarding_class: Arc<str>`).
- `FilterResult.policer_name` / `.routing_instance`: `String` → `Option<Arc<str>>`,
  mirroring the #5151 `forwarding_class: Option<Arc<str>>` pattern — the
  accumulator default and the non-routing reset are zero-alloc `None` instead of
  `String::new()`.

## Why it's semantics-preserving

Output is **byte-identical** — the same policer / routing-instance /
forwarding-class values flow to their downstream lookups. Confirmed:

- No non-test consumer reads either `FilterResult` field. The live
  routing-instance (PBR) override rides the **separate**
  `FilterRoutingInstanceResult<'a>` (with its `&'a str`), which is untouched.
- Neither field is mutated in place.
- The config-owned source (`Filter`/`FilterTerm`) outlives every `FilterResult`.
- `cache_sensitive.rs` term compare (`Arc<str> == Arc<str>`) and the PBR
  evaluators (`&*term.routing_instance`) are adjusted; two
  `FilterResult.routing_instance` asserts move from `.is_empty()` to `.is_none()`.

## Validation

- `cargo build` clean; filter suite **189 tests green, run 5× with no flakes**.
- New **perf-with-correctness-guard** test `filter_result_modifiers_roundtrip_5444`
  asserts all three modifiers round-trip into `FilterResult` on a match and
  default to `None` on a miss. This is **not a RED-on-revert** — the values are
  byte-identical whether the field is `String` or `Arc<str>`; it guards a future
  refactor from silently dropping a modifier.
- Grepped the changed fn: the three remaining `.clone()` are all `Arc<str>`
  refcount bumps — zero `String::`/`.to_string()`.
- Two full-suite failures (`wire_invariant_default_specimens` — a NAT64
  stats-counter fixture drift; `stalled_consumer...backlog_unbounded_end_to_end`
  — a backpressure timing test) are **pre-existing**, reproduced identically with
  this change stashed, and unrelated to the filter module.
- Perf-only with byte-identical output → no design-doc update needed; the `#5444`
  in-code comments (mirroring #5151/#5857) are the documentation surface, and
  `_Log.md` records the change.

Closes #5444

🤖 Generated with [Claude Code](https://claude.com/claude-code)