### PR TITLE
session: full-pair teardown on translated LocalDelivery deny

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -51795,3 +51795,36 @@ top.
   unrelated to nat).
 - **File(s)**: userspace-dp/src/nat/allocator.rs, userspace-dp/src/nat/tests_pool.rs,
   docs/deterministic-nat-cgnat.md, _Log.md
+
+---
+- **Timestamp**: 2026-07-17
+- **Action**: #5622 — `delete_terminal_filtered_session` (session_glue/mod.rs)
+  now performs a FULL-PAIR teardown + allocator release for translated
+  LocalDelivery terminal hits. The pre-fix helper deleted only the resolved
+  key and released no NAT state, so a translated flow's same-worker
+  forward<->reverse COMPANION entry AND its source-NAT/NAT64 pool RESERVATION
+  leaked on every host-inbound / lo0-input-filter / `to-zone junos-host`
+  terminal deny (the three `poll_descriptor` call sites) — the ordinary idle
+  reap and DSCP-filter purge already release per entry.
+- **Fix**: extracted `delete_terminal_half` (release source-NAT + NAT64
+  allocation self-gated on `is_reverse`; delete map/conntrack aliases; drop
+  worker-local + shared entries; queue `DeleteSynced`; emit close delta).
+  `delete_terminal_filtered_session` recovers the companion via
+  `reverse_session_key(key, decision.nat)` (its own inverse) and runs the half
+  teardown for the resolved key AND the companion — freeing the reservation
+  exactly once (reverse release is a no-op; `release_flow` is idempotent), so
+  no double free. Added `forwarding: &ForwardingState` + `now_ns` params to the
+  4 call sites; the DSCP purge dropped its now-redundant explicit release (the
+  helper owns it).
+- **Tests**: `delete_terminal_filtered_session_releases_companion_and_allocator_5622`
+  reserves a real single-address pool port, installs forward+reverse translated
+  LocalDelivery sessions, drives the terminal hit on BOTH directions, and
+  asserts (a) both entries gone and (b) `used_ports == 0`. RED-verified by
+  neutralizing the companion teardown + allocator release (fails at the
+  companion/used_ports asserts). 5x flake check green.
+- **Validation**: `cargo build` clean; session_glue 88 passed, session 175,
+  nat 746, poll_descriptor 90 — all green.
+- **File(s)**: userspace-dp/src/afxdp/session_glue/mod.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/session_glue/README.md, _Log.md

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1319,10 +1319,12 @@ pub(super) fn poll_binding_process_descriptor(
                                         worker_ctx.shared_forward_wire_sessions,
                                         &worker_ctx.shared_owner_rg_indexes,
                                         worker_ctx.peer_worker_commands,
+                                        worker_ctx.forwarding,
                                         &resolved.key,
                                         resolved.decision,
                                         &resolved.metadata,
                                         resolved.origin,
+                                        now_ns,
                                     );
                                     telemetry.dbg.local += 1;
                                     // #3610/M07: account the host-inbound deny on
@@ -1387,10 +1389,12 @@ pub(super) fn poll_binding_process_descriptor(
                                             worker_ctx.shared_forward_wire_sessions,
                                             &worker_ctx.shared_owner_rg_indexes,
                                             worker_ctx.peer_worker_commands,
+                                            worker_ctx.forwarding,
                                             &resolved.key,
                                             resolved.decision,
                                             &resolved.metadata,
                                             resolved.origin,
+                                            now_ns,
                                         );
                                         telemetry.dbg.local += 1;
                                         telemetry.dbg.policy_deny += 1;
@@ -1441,10 +1445,12 @@ pub(super) fn poll_binding_process_descriptor(
                                 worker_ctx.shared_forward_wire_sessions,
                                 &worker_ctx.shared_owner_rg_indexes,
                                 worker_ctx.peer_worker_commands,
+                                worker_ctx.forwarding,
                                 &resolved.key,
                                 resolved.decision,
                                 &resolved.metadata,
                                 resolved.origin,
+                                now_ns,
                             );
                             telemetry.dbg.local += 1;
                             telemetry.dbg.policy_deny += 1;

--- a/userspace-dp/src/afxdp/session_glue/README.md
+++ b/userspace-dp/src/afxdp/session_glue/README.md
@@ -26,3 +26,37 @@ sees the same sessions the userspace path is processing.
 - Writes to the BPF session map (via `coordinator/bpf_maps.rs` FDs)
   so the eBPF data-display surface mirrors the live userspace
   session table.
+
+## Terminal-filtered session teardown (`delete_terminal_filtered_session`, #5622)
+
+When an *established* LocalDelivery session re-evaluates a terminal gate
+on the session-HIT path and is now denied — host-inbound admission,
+an lo0 input filter, or a `to-zone junos-host` policy (the three
+`poll_descriptor` call sites) — the session is torn down. Because a
+translated flow is TWO independent entries (forward `is_reverse=false`
++ reverse companion `is_reverse=true`) and the hit can land on EITHER,
+the teardown must resolve and remove BOTH halves and release the
+NAT pool reservation, exactly like the ordinary idle reap
+(`worker/loop_body::reap_expired_sessions`) and the DSCP-filter purge
+(`purge_sessions_for_input_dscp_filter_revalidation`) do per entry.
+
+`delete_terminal_filtered_session` therefore:
+
+- recovers the companion key with `reverse_session_key(key, decision.nat)`
+  (its own inverse given the reversed decision, so it yields the forward
+  key from a reverse hit and vice-versa — the same hop
+  `companion_keeps_alive`/`account_packet` use);
+- runs `delete_terminal_half` for the resolved key AND (if present) the
+  companion. Each half releases its source-NAT / NAT64 allocation
+  (`release_source_nat_allocation`/`release_nat64_allocation`, both
+  self-gated on `is_reverse` and keyed on the forward flow — so the pair
+  frees the reservation EXACTLY ONCE, no double free), deletes the live
+  BPF session-map + conntrack aliases, drops the worker-local table entry
+  and the shared HA maps, queues the cross-worker `DeleteSynced`, and
+  emits its close delta (suppressed for the reverse half).
+
+The DSCP purge no longer releases allocations separately — the helper
+owns that now; `release_flow` is idempotent, so a caller that visits both
+halves in turn stays correct. Before #5622 the helper deleted only the
+supplied key and released nothing, leaking the same-worker companion
+entry and the pool port on every translated LocalDelivery terminal deny.

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -352,22 +352,12 @@ pub(super) fn purge_sessions_for_input_dscp_filter_revalidation(
     });
     let purged = stale.len();
     for (key, decision, metadata, origin) in stale {
-        release_source_nat_allocation(
-            &forwarding.source_nat_rules,
-            &key,
-            decision.nat,
-            metadata.is_reverse,
-            now_ns,
-        );
-        // #4381: also return the purged NAT64 forward flow's translated pool
-        // port (self-gated on the forward NAT64 entry).
-        crate::nat64::release_nat64_allocation(
-            &forwarding.nat64,
-            &key,
-            decision.nat,
-            metadata.is_reverse,
-            now_ns,
-        );
+        // #5622: `delete_terminal_filtered_session` now owns the per-entry
+        // source-NAT / NAT64 release AND the forward<->reverse companion
+        // teardown, so the purge no longer releases separately (that would
+        // double-process the pair). Both halves of a translated flow are in
+        // `stale`; the helper is idempotent, so whichever half is visited first
+        // frees the shared reservation once and the second visit is a no-op.
         delete_terminal_filtered_session(
             sessions,
             session_map_fd,
@@ -378,10 +368,12 @@ pub(super) fn purge_sessions_for_input_dscp_filter_revalidation(
             shared_forward_wire_sessions,
             shared_owner_rg_indexes,
             peer_worker_commands,
+            forwarding,
             &key,
             decision,
             &metadata,
             origin,
+            now_ns,
         );
     }
     purged
@@ -443,6 +435,7 @@ pub(in crate::afxdp::session_glue) fn publish_worker_session_map_entry(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn delete_terminal_filtered_session(
     sessions: &mut SessionTable,
     session_map_fd: c_int,
@@ -453,11 +446,120 @@ pub(super) fn delete_terminal_filtered_session(
     shared_forward_wire_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     shared_owner_rg_indexes: &SharedSessionOwnerRgIndexes,
     peer_worker_commands: &[Arc<Mutex<VecDeque<WorkerCommand>>>],
+    forwarding: &ForwardingState,
     key: &SessionKey,
     decision: SessionDecision,
     metadata: &SessionMetadata,
     origin: SessionOrigin,
+    now_ns: u64,
 ) {
+    // #5622: a translated LocalDelivery terminal hit (host-inbound deny, lo0
+    // input-filter deny, or `to-zone junos-host` deny on the session-HIT path)
+    // can fire on EITHER the forward or the reverse companion entry. The
+    // pre-#5622 body deleted ONLY the supplied key and released NO allocator
+    // state, so the same-worker forward<->reverse COMPANION entry AND the
+    // source-NAT / NAT64 pool RESERVATION were both left behind — a resource
+    // leak the ordinary idle reap (`reap_expired_sessions`) and the DSCP-filter
+    // purge (`purge_sessions_for_input_dscp_filter_revalidation`) already avoid
+    // by releasing per entry. Tear down BOTH halves and release each allocation
+    // exactly as the reap path does per `ExpiredSession`.
+    //
+    // The companion key is recovered with `reverse_session_key(key, nat)` from
+    // the resolved entry's OWN nat decision — the transform is its own inverse
+    // given the reversed decision, so it yields the forward key from a reverse
+    // hit and the reverse key from a forward hit (the same hop
+    // `companion_keeps_alive` / `account_packet` use). The allocation release
+    // self-gates on `is_reverse` and keys on the forward flow, so freeing both
+    // halves returns the reservation EXACTLY ONCE (the reverse call is a no-op)
+    // — no double free. `release_flow` is idempotent (returns false when the
+    // flow was already freed), so a caller that hands both halves in turn (the
+    // DSCP purge) stays correct too.
+    let companion_key = reverse_session_key(key, decision.nat);
+    let companion = if companion_key != *key {
+        sessions.entry_with_origin(&companion_key)
+    } else {
+        None
+    };
+
+    delete_terminal_half(
+        sessions,
+        session_map_fd,
+        conntrack_v4_fd,
+        conntrack_v6_fd,
+        shared_sessions,
+        shared_nat_sessions,
+        shared_forward_wire_sessions,
+        shared_owner_rg_indexes,
+        peer_worker_commands,
+        forwarding,
+        key,
+        decision,
+        metadata,
+        origin,
+        now_ns,
+    );
+
+    if let Some((companion_decision, companion_metadata, companion_origin)) = companion {
+        delete_terminal_half(
+            sessions,
+            session_map_fd,
+            conntrack_v4_fd,
+            conntrack_v6_fd,
+            shared_sessions,
+            shared_nat_sessions,
+            shared_forward_wire_sessions,
+            shared_owner_rg_indexes,
+            peer_worker_commands,
+            forwarding,
+            &companion_key,
+            companion_decision,
+            &companion_metadata,
+            companion_origin,
+            now_ns,
+        );
+    }
+}
+
+/// #5622: tear down ONE direction of a terminal-filtered session — release its
+/// source-NAT / NAT64 pool reservation (self-gated on `is_reverse`, so only the
+/// forward half actually frees), drop its live BPF/session-map + conntrack
+/// aliases, remove it from the worker-local table + the shared HA maps, queue
+/// the cross-worker `DeleteSynced`, and emit its close delta (suppressed for a
+/// reverse entry). Called once per direction by `delete_terminal_filtered_session`
+/// so a translated LocalDelivery terminal hit performs the SAME full-pair
+/// teardown the idle reap and DSCP purge do.
+#[allow(clippy::too_many_arguments)]
+fn delete_terminal_half(
+    sessions: &mut SessionTable,
+    session_map_fd: c_int,
+    conntrack_v4_fd: c_int,
+    conntrack_v6_fd: c_int,
+    shared_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_forward_wire_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
+    shared_owner_rg_indexes: &SharedSessionOwnerRgIndexes,
+    peer_worker_commands: &[Arc<Mutex<VecDeque<WorkerCommand>>>],
+    forwarding: &ForwardingState,
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: &SessionMetadata,
+    origin: SessionOrigin,
+    now_ns: u64,
+) {
+    release_source_nat_allocation(
+        &forwarding.source_nat_rules,
+        key,
+        decision.nat,
+        metadata.is_reverse,
+        now_ns,
+    );
+    crate::nat64::release_nat64_allocation(
+        &forwarding.nat64,
+        key,
+        decision.nat,
+        metadata.is_reverse,
+        now_ns,
+    );
     delete_session_map_entry_for_removed_session_with_origin(
         session_map_fd,
         key,
@@ -476,12 +578,7 @@ pub(super) fn delete_terminal_filtered_session(
         key,
     );
     replicate_session_delete(peer_worker_commands, key);
-    sessions.emit_close_delta_with_origin(
-        key.clone(),
-        decision,
-        metadata.clone(),
-        origin,
-    );
+    sessions.emit_close_delta_with_origin(key.clone(), decision, metadata.clone(), origin);
 }
 
 /// #2442: the filter half of `export_forward_sessions_for_owner_rgs`. Walks the

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -5864,3 +5864,167 @@ fn refresh_owner_rgs_active_owner_local_delivery_publishes_kernel_local_4805() {
         "owner-active synced LocalDelivery keeps the kernel-local publish path"
     );
 }
+
+// #5622 FAIL-ON-REVERT: a translated LocalDelivery terminal hit (host-inbound
+// deny, lo0 input-filter deny, or `to-zone junos-host` deny on the session-HIT
+// path) must tear down BOTH the forward and the reverse companion session
+// entries AND release the source-NAT pool reservation — matching the ordinary
+// idle reap and the DSCP-filter purge. The pre-#5622 helper deleted ONLY the
+// resolved key and released NO allocator state, so the same-worker companion
+// entry AND the pool port both leaked. This drives the terminal teardown on
+// BOTH a forward hit and a reverse hit (the finding's `K=F` and `K=R` legs) and
+// asserts (a) the companion entry is gone and (b) the allocator reservation is
+// freed. Reverting the fix (companion left installed / pool port not returned)
+// turns the companion + `used_ports` assertions RED.
+#[test]
+fn delete_terminal_filtered_session_releases_companion_and_allocator_5622() {
+    for hit_reverse in [false, true] {
+        // A single-address pool source-NAT rule so the translated flow holds a
+        // real pool port that the teardown must return.
+        let mut forwarding = ForwardingState::default();
+        forwarding.source_nat_rules = crate::nat::parse_source_nat_rules(&[
+            crate::SourceNATRuleSnapshot {
+                name: "pool-snat".to_string(),
+                from_zone: "lan".to_string(),
+                to_zone: "wan".to_string(),
+                source_addresses: vec!["0.0.0.0/0".to_string()],
+                pool_name: "p".to_string(),
+                pool_addresses: vec!["203.0.113.1/32".to_string()],
+                port_low: 1024,
+                port_high: 65535,
+                ..crate::SourceNATRuleSnapshot::default()
+            },
+        ]);
+
+        // Forward: a source-NAT-translated flow that is locally delivered.
+        let fwd_key = test_key();
+        let fwd_nat = NatDecision {
+            rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+            rewrite_src_port: Some(40000),
+            ..NatDecision::default()
+        };
+        let fwd_decision = SessionDecision {
+            resolution: test_local_delivery_decision().resolution,
+            nat: fwd_nat,
+        };
+        let fwd_metadata = test_metadata();
+
+        // Reverse companion: keyed on the return tuple, carrying the reversed
+        // NAT decision + `is_reverse = true` — exactly how the reverse half is
+        // installed in production.
+        let rev_key = reverse_session_key(&fwd_key, fwd_nat);
+        let rev_nat = fwd_nat.reverse(
+            fwd_key.src_ip,
+            fwd_key.dst_ip,
+            fwd_key.src_port,
+            fwd_key.dst_port,
+        );
+        let rev_decision = SessionDecision {
+            resolution: fwd_decision.resolution,
+            nat: rev_nat,
+        };
+        let mut rev_metadata = test_metadata();
+        rev_metadata.is_reverse = true;
+
+        // Reserve the pool port for the forward flow (the reservation the
+        // forward-half teardown's `release_source_nat_allocation` must free).
+        crate::nat::reserve_synced_source_nat_allocation(
+            &forwarding.source_nat_rules,
+            &fwd_key,
+            fwd_nat,
+            false,
+        );
+        assert_eq!(
+            crate::nat::source_nat_pool_statuses(&forwarding.source_nat_rules)[0].used_ports,
+            1,
+            "precondition: the translated forward flow holds one pool port",
+        );
+
+        let mut sessions = SessionTable::new();
+        assert!(sessions.install_with_protocol_with_origin(
+            fwd_key.clone(),
+            fwd_decision,
+            fwd_metadata.clone(),
+            SessionOrigin::LocalMiss,
+            1,
+            PROTO_TCP,
+            TCP_FLAG_SYN,
+        ));
+        assert!(sessions.install_with_protocol_with_origin(
+            rev_key.clone(),
+            rev_decision,
+            rev_metadata.clone(),
+            SessionOrigin::LocalMiss,
+            1,
+            PROTO_TCP,
+            TCP_FLAG_SYN,
+        ));
+        assert!(sessions.entry_with_origin(&fwd_key).is_some());
+        assert!(sessions.entry_with_origin(&rev_key).is_some());
+        let _ = sessions.drain_deltas(16);
+
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+
+        // Drive the terminal hit on the requested direction. Either half may be
+        // the packet that re-evaluates the (now-deny) terminal gate.
+        let (hit_key, hit_decision, hit_metadata) = if hit_reverse {
+            (rev_key.clone(), rev_decision, rev_metadata.clone())
+        } else {
+            (fwd_key.clone(), fwd_decision, fwd_metadata.clone())
+        };
+        delete_terminal_filtered_session(
+            &mut sessions,
+            -1,
+            -1,
+            -1,
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &peer_worker_commands,
+            &forwarding,
+            &hit_key,
+            hit_decision,
+            &hit_metadata,
+            SessionOrigin::LocalMiss,
+            2,
+        );
+
+        // (a) BOTH the resolved entry and its same-worker companion are gone.
+        assert!(
+            sessions.entry_with_origin(&fwd_key).is_none(),
+            "hit_reverse={hit_reverse}: forward entry must be torn down",
+        );
+        assert!(
+            sessions.entry_with_origin(&rev_key).is_none(),
+            "hit_reverse={hit_reverse}: reverse companion entry must be torn down",
+        );
+        // (b) the NAT pool reservation is released exactly once (no leak).
+        assert_eq!(
+            crate::nat::source_nat_pool_statuses(&forwarding.source_nat_rules)[0].used_ports,
+            0,
+            "hit_reverse={hit_reverse}: the translated flow's pool port must be freed",
+        );
+        // A single forward-direction Close delta is emitted regardless of which
+        // half took the terminal hit — the reverse-hit path now fires the
+        // forward companion's close (the pre-#5622 helper dropped it when K=R).
+        let deltas = sessions.drain_deltas(16);
+        let closes: Vec<_> = deltas
+            .iter()
+            .filter(|d| d.kind == SessionDeltaKind::Close)
+            .collect();
+        assert_eq!(
+            closes.len(),
+            1,
+            "hit_reverse={hit_reverse}: exactly one forward Close delta expected",
+        );
+        assert_eq!(
+            closes[0].key, fwd_key,
+            "hit_reverse={hit_reverse}: the Close delta is on the forward key",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`delete_terminal_filtered_session` (`userspace-dp/src/afxdp/session_glue/mod.rs`) tore down a translated LocalDelivery session on a terminal deny (host-inbound admission, lo0 input filter, or `to-zone junos-host` policy — the three `poll_descriptor` session-HIT call sites) by deleting **only the resolved key** and releasing **no allocator state**.

A translated flow is two independent entries — the forward (`is_reverse=false`) and its reverse companion — and the terminal hit can land on **either**. So the old helper leaked, on every such deny:

- the same-worker forward↔reverse **companion** session entry, and
- the source-NAT / NAT64 pool **reservation** (translated port/address).

Both are released per-entry by the ordinary idle reap (`reap_expired_sessions`) and the DSCP-filter purge (`purge_sessions_for_input_dscp_filter_revalidation`); the terminal path was the odd one out. When the hit landed on the reverse half (`K=R`) it also emitted no close delta at all.

## Fix

- Extract `delete_terminal_half`: release the source-NAT/NAT64 allocation (both self-gated on `is_reverse`, keyed on the forward flow), delete the live BPF session-map + conntrack aliases, drop the worker-local table entry + shared HA maps, queue `DeleteSynced`, and emit the close delta.
- `delete_terminal_filtered_session` recovers the companion via `reverse_session_key(key, decision.nat)` (its own inverse given the reversed decision) and runs the half teardown for the resolved key **and** the companion. The reservation is freed **exactly once** — the reverse-half release is a no-op and `release_flow` is idempotent, so **no double free**.
- The helper gains `forwarding` + `now_ns` params, threaded from `worker_ctx` at the three `poll_descriptor` call sites. The DSCP purge dropped its now-redundant explicit release (the helper owns per-entry release now).

## Validation

- `cargo build` clean.
- New **fail-on-revert** test `delete_terminal_filtered_session_releases_companion_and_allocator_5622` reserves a real single-address pool port, installs forward+reverse translated LocalDelivery sessions, drives the terminal hit on **both** directions, and asserts (a) both entries gone and (b) `used_ports == 0`. RED-verified by neutralizing the companion teardown + allocator release. **5×** flake check green.
- Suites green: session_glue 88, session 175, nat 746, poll_descriptor 90.

Provenance: codex-review-181 finding A1-b02-F2 (M07). Nearest issues #5295/#5566 are adjacent, not dups.

Closes #5622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi