### PR TITLE
afxdp: bound worker-loop lossless delta send below heartbeat (#5468)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,56 @@
+## 2026-07-18 — #5468 (PR #6085 fold): bound the AGGREGATE worker-loop lossless wait (resync/export), not just per-call
+
+- **Timestamp**: 2026-07-18 (fix/5468-lossless-worker-stall, folding rev5468 review finding #2)
+- **Action**: The initial #5468 fix bounded each individual `flush_session_deltas`
+  lossless send to `WORKER_LOSSLESS_QUEUE_BUDGET` (~1 s). But the drain region on
+  the worker loop calls `flush_session_deltas` MANY times per iteration: the
+  steady-state drain is one call, yet the #2442 loss-of-sync resync and the #2653
+  command export (`take_delta_loss` → `chunked_drain_as_you_export!` →
+  `drain_and_flush_all!`, `worker/loop_body/mod.rs`) call it ONCE PER 256-delta
+  batch across the whole owned-session set. For K owned sessions that is ~K/256
+  calls; at ~1 budget each an unread peer would still stall the worker ~(K/256)
+  budgets — past K≈1280 (5 batches) that re-crosses `HEARTBEAT_STALE_AFTER` and
+  re-triggers the SAME spurious failover, now via the resync path. A single
+  dropped incremental delta arms a full-K resync, so the trigger is trivial and
+  the amplification real.
+  Fix: a per-drain-cycle `worker_lossless_wedged: &mut bool` latch, declared
+  before the flush macro, reset at the top of each worker-loop iteration, and
+  threaded through EVERY `flush_session_deltas` call (both `flush_drained_session_
+  deltas!` arms). `flush_session_deltas` seeds `event_stream_out_of_sync` from the
+  latch and writes it back: the first wedged batch waits one budget and sets the
+  latch; every later call this cycle inherits it and SKIPS the lossless wait
+  entirely (never re-attempts a push), while still draining each delta to the
+  per-binding live RPC buffer, the shared conntrack/session tables, peer-worker
+  delete replication, and best-effort RT_FLOW. So the AGGREGATE worker-loop
+  lossless WAIT per drain cycle is ~1 budget regardless of K, for both the
+  incremental push and the resync/export. Every wedged batch still returns
+  out-of-sync, so the loss-of-sync latch stays set and the resync RETRIES next
+  cycle (deliver-or-resync, never a silent drop). This preserves the #2653
+  command export's live-buffer completeness and its `session_export_ack` contract
+  (only the WAIT is skipped, not the drain) — which a literal early-exit of the
+  resync loop would have broken.
+- **File(s)**: userspace-dp/src/afxdp/session_delta.rs (aggregate `worker_lossless_
+  wedged` in/out param + seed/writeback), userspace-dp/src/afxdp/worker/loop_body/
+  mod.rs (per-cycle latch decl + reset + threading through both flush macro arms),
+  userspace-dp/src/afxdp/session_glue/tests.rs (new fail-on-revert aggregate test
+  `resync_export_aggregate_lossless_wait_is_bounded_below_heartbeat` + 6 existing
+  call-site updates), docs/session-sync-architecture.md + event_stream/README.md
+  (corrected the "one lossless wait per drain cycle even on a wedged consumer"
+  overstatement to the true aggregate guarantee).
+- **Validation**: `cargo build` green (no new warnings). New test drives 8 resync
+  batches (>1280 sessions at 256/batch) against a connected-but-unread full
+  channel sharing one wedge latch and asserts the aggregate stays < HEARTBEAT_
+  STALE_AFTER; it completes in ~1.00 s (fix collapses to ~1 budget). Reverting the
+  aggregate inheritance (`= *worker_lossless_wedged` → `= false`) makes it take
+  8.00 s (~8× budget) and FAIL the bounded assertion, while the sibling per-call
+  test still passes — a clean assertion RED, not a build break. event_stream /
+  session / session_glue / worker / ha suites green (worker+ha+session_glue: 158
+  passing); 5× flake check on the new + existing #5468 tests green (~1.00 s each).
+  Pre-existing env-flaky test `stalled_consumer_does_not_grow_backlog_unbounded_
+  end_to_end` fails at the base SHA (ac229897f) too (verified via stash) — it
+  never calls `flush_session_deltas`, unrelated to this change. Loss-cluster
+  failover smoke advised (parent to run).
+
 ## 2026-07-17 — #5468: bound the worker-loop lossless session-delta send below HEARTBEAT_STALE_AFTER
 
 - **Timestamp**: 2026-07-17 (fix/5468-lossless-worker-stall)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-17 — #5468: bound the worker-loop lossless session-delta send below HEARTBEAT_STALE_AFTER
+
+- **Timestamp**: 2026-07-17 (fix/5468-lossless-worker-stall)
+- **Action**: `flush_session_deltas` runs on the packet worker loop and routed
+  correctness-critical HA session open/close deltas through the LOSSLESS
+  event-stream producer `push_delta_lossless` (#2874), which retries a full
+  channel up to `LOSSLESS_QUEUE_TIMEOUT` = 5 s. That equals `HEARTBEAT_STALE_AFTER`
+  (5 s), so a connected-but-UNREAD peer (slow/stalled reader, queue full) could
+  block the worker loop the full 5 s → the loop stops stamping its heartbeat →
+  the peer marks this node stale → false liveness loss / spurious failover.
+  Fix: added `EventStreamWorkerHandle::push_delta_lossless_within(delta, zone,
+  budget)` (parameterizes `send_lossless_encoded`'s deadline) and a new
+  `WORKER_LOSSLESS_QUEUE_BUDGET` const (= `HEARTBEAT_STALE_AFTER / 5`, ~1 s, with
+  a compile-time `assert!` it stays ≤ half the stale threshold). `flush_session_deltas`
+  now uses the bounded variant; on the bounded timeout it latches loss-of-sync
+  exactly as before (`set_delta_loss` → `take_delta_loss` full owner-RG resync),
+  so losslessness is preserved (deliver-or-resync, never a silent drop). The
+  off-worker-loop exporters (`AllSessionsExport::push` bulk export,
+  `push_purge_close_deltas` tunnel-remap purge) keep the 5 s `LOSSLESS_QUEUE_TIMEOUT`
+  via `push_delta_lossless` — they run off the packet loop so the heartbeat is
+  unaffected.
+- **File(s)**: userspace-dp/src/afxdp/mod.rs (WORKER_LOSSLESS_QUEUE_BUDGET +
+  static assert), userspace-dp/src/event_stream/mod.rs (timeout param on
+  send_lossless_encoded, push_delta_lossless_within, test_worker_handle_connected
+  seam), userspace-dp/src/afxdp/session_delta.rs (bounded call at the worker
+  loop), userspace-dp/src/afxdp/session_glue/tests.rs (fail-on-revert test:
+  connected+full queue → bounded return + loss-of-sync latch), event_stream
+  README + docs/session-sync-architecture.md.
+- **Validation**: `cargo build` green; new test
+  `flush_session_deltas_full_queue_send_is_bounded_and_latches_out_of_sync`
+  passes in ~1 s (waits the budget then latches); reverting the worker-loop call
+  to unbounded `push_delta_lossless` makes it take 5.0 s and FAIL the bounded
+  assertion. event_stream/session_delta/ha/session suites green (203 + 172
+  passing); 5× flake check green. Pre-existing env-flaky test
+  `stalled_consumer_does_not_grow_backlog_unbounded_end_to_end` fails at the
+  BASE SHA too (verified via stash) — unrelated to this change. Loss-cluster
+  failover smoke advised (parent to run).
+
 ## 2026-07-17 — #5469: write_state serializes+fsyncs OUTSIDE the ServerState lock
 
 - **Timestamp**: 2026-07-17 (fix/5469-writestate-lock-convoy)

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -709,6 +709,24 @@ lock scope changes). Event-stream ordering stays governed by `producer_seq_lock`
 inside `push_delta_lossless`, not the `ServerState` lock, so releasing the latter
 does not affect the lossless seq contract (#2874 / #3878).
 
+**The steady-state worker-loop lossless push is time-BOUNDED (#5468).** The
+incremental path — `flush_session_deltas`, which runs directly on the packet
+worker loop — must NOT use the 5 s `LOSSLESS_QUEUE_TIMEOUT`. That timeout equals
+`HEARTBEAT_STALE_AFTER` (5 s), so a connected-but-UNREAD peer (a slow/stalled
+reader whose lossless channel is full) that blocked the worker for the full 5 s
+would stop the loop stamping its per-binding heartbeat; the peer then sees this
+node as stale and triggers a **false failover** — the exact defect #5468
+describes. The worker loop therefore calls `push_delta_lossless_within` with a
+short `WORKER_LOSSLESS_QUEUE_BUDGET` (one fifth of `HEARTBEAT_STALE_AFTER`,
+~1 s), leaving ~5× headroom for the rest of the loop iteration plus the
+heartbeat map write. On the bounded timeout the delta is **not** dropped: the
+same `set_delta_loss` / `take_delta_loss` latch fires and forces a full owner-RG
+resync (deliver-or-resync, the #2874 losslessness contract). Only the
+off-worker-loop exporters — `AllSessionsExport::push` (bulk export on connect,
+above) and `push_purge_close_deltas` (tunnel-remap purge, below) — keep the 5 s
+`LOSSLESS_QUEUE_TIMEOUT` via `push_delta_lossless`; they run off the packet loop
+so a long backpressure wait there does not threaten the worker heartbeat.
+
 ### Delta-ring overflow → loss-of-sync resync (#2442)
 
 Each worker buffers session open/close deltas in an in-worker ring

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -709,8 +709,8 @@ lock scope changes). Event-stream ordering stays governed by `producer_seq_lock`
 inside `push_delta_lossless`, not the `ServerState` lock, so releasing the latter
 does not affect the lossless seq contract (#2874 / #3878).
 
-**The steady-state worker-loop lossless push is time-BOUNDED (#5468).** The
-incremental path — `flush_session_deltas`, which runs directly on the packet
+**The worker-loop lossless push is time-BOUNDED per drain cycle (#5468).** Every
+lossless send `flush_session_deltas` makes — it runs directly on the packet
 worker loop — must NOT use the 5 s `LOSSLESS_QUEUE_TIMEOUT`. That timeout equals
 `HEARTBEAT_STALE_AFTER` (5 s), so a connected-but-UNREAD peer (a slow/stalled
 reader whose lossless channel is full) that blocked the worker for the full 5 s
@@ -721,11 +721,35 @@ short `WORKER_LOSSLESS_QUEUE_BUDGET` (one fifth of `HEARTBEAT_STALE_AFTER`,
 ~1 s), leaving ~5× headroom for the rest of the loop iteration plus the
 heartbeat map write. On the bounded timeout the delta is **not** dropped: the
 same `set_delta_loss` / `take_delta_loss` latch fires and forces a full owner-RG
-resync (deliver-or-resync, the #2874 losslessness contract). Only the
-off-worker-loop exporters — `AllSessionsExport::push` (bulk export on connect,
-above) and `push_purge_close_deltas` (tunnel-remap purge, below) — keep the 5 s
-`LOSSLESS_QUEUE_TIMEOUT` via `push_delta_lossless`; they run off the packet loop
-so a long backpressure wait there does not threaten the worker heartbeat.
+resync (deliver-or-resync, the #2874 losslessness contract).
+
+The per-call budget alone is **not** sufficient, because the drain region calls
+`flush_session_deltas` many times per iteration: the steady-state drain is one
+call, but the #2442 loss-of-sync resync and the #2653 command export
+(`take_delta_loss` → `chunked_drain_as_you_export!` → `drain_and_flush_all!`,
+`worker/loop_body/mod.rs`) call it ONCE PER 256-delta batch across the entire
+owned-session set. For K owned sessions that is ~K/256 calls, so at one budget
+each an unread peer would still stall the worker ~(K/256) budgets — past K≈1280
+(5 batches) that re-crosses `HEARTBEAT_STALE_AFTER` and re-triggers the same
+spurious failover **via the resync path**. The bound is therefore an AGGREGATE
+one: a per-drain-cycle `worker_lossless_wedged` latch, reset at the top of every
+loop iteration and threaded through every `flush_session_deltas` call, caps the
+whole cycle at ~one budget total. The first wedged batch waits one budget and
+sets the latch; every later call this cycle inherits it and SKIPS the lossless
+wait entirely (it never re-attempts a push), while still draining each delta to
+its other consumers — the per-binding live RPC buffer, the shared
+conntrack/session tables, peer-worker delete replication, and best-effort
+RT_FLOW. Every wedged batch still returns out-of-sync, so the loss-of-sync latch
+stays set and the resync simply RETRIES next cycle until the consumer drains
+(deliver-or-resync, never a silent drop). Net guarantee: the worker loop's total
+lossless WAIT per drain cycle is ~1 budget **regardless of the owned-session
+count K** — for both the incremental push and the resync/export.
+
+Only the off-worker-loop exporters — `AllSessionsExport::push` (bulk export on
+connect, above) and `push_purge_close_deltas` (tunnel-remap purge, below) — keep
+the 5 s `LOSSLESS_QUEUE_TIMEOUT` via `push_delta_lossless`; they run off the
+packet loop so a long backpressure wait there does not threaten the worker
+heartbeat.
 
 ### Delta-ring overflow → loss-of-sync resync (#2442)
 

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -370,6 +370,29 @@ const HEARTBEAT_UPDATE_INTERVAL_NS: u64 = 250_000_000;
 const HEARTBEAT_GRACE_PERIOD_NS: u64 = 6_000_000_000; // 6 seconds
 const TX_WAKE_MIN_INTERVAL_NS: u64 = 50_000;
 const HEARTBEAT_STALE_AFTER: Duration = Duration::from_secs(5);
+/// #5468: upper bound on the worker-loop lossless session-delta send
+/// (`flush_session_deltas` -> `EventStreamWorkerHandle::push_delta_lossless_within`).
+///
+/// `flush_session_deltas` runs on the packet worker loop, so a connected-but-
+/// unread peer (a slow/stalled reader whose lossless queue is full) must not be
+/// able to block the loop for the full 5 s `LOSSLESS_QUEUE_TIMEOUT`: that
+/// exceeds `HEARTBEAT_STALE_AFTER`, so the loop stops stamping its heartbeat,
+/// the peer marks this node stale, and a spurious failover fires. Bounding the
+/// worker-side wait to one fifth of the stale threshold leaves 5x headroom for
+/// the rest of the loop iteration plus the heartbeat map write, while still
+/// tolerating realistic transient reader pauses (a healthy consumer drains the
+/// channel in microseconds). On timeout the caller latches loss-of-sync (a full
+/// owner-RG resync via `take_delta_loss`), so the #2874 losslessness contract is
+/// preserved (deliver-or-resync, never a silent drop). The off-worker-loop bulk
+/// export/purge paths keep the longer `LOSSLESS_QUEUE_TIMEOUT`.
+const WORKER_LOSSLESS_QUEUE_BUDGET: Duration =
+    Duration::from_nanos((HEARTBEAT_STALE_AFTER.as_nanos() / 5) as u64);
+// Compile-time invariant: the worker-side lossless budget must stay well below
+// the heartbeat-stale threshold, or the fix regresses into the #5468 stall.
+const _: () = assert!(
+    WORKER_LOSSLESS_QUEUE_BUDGET.as_nanos() * 2 <= HEARTBEAT_STALE_AFTER.as_nanos(),
+    "WORKER_LOSSLESS_QUEUE_BUDGET must be well below HEARTBEAT_STALE_AFTER (#5468)"
+);
 const MAX_RECENT_EXCEPTIONS: usize = 32;
 const MAX_RECENT_SESSION_DELTAS: usize = 64;
 const MAX_PENDING_SESSION_DELTAS: usize = 4096;

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -80,7 +80,10 @@ pub(super) fn flush_session_deltas(
     // further lossless pushes this batch — the full owner-RG resync the caller
     // schedules supersedes the remaining incremental deltas, and this bounds the
     // worst-case producer backpressure to a single lossless wait per drain
-    // cycle even when the consumer is genuinely wedged.
+    // cycle even when the consumer is genuinely wedged. #5468: that single wait
+    // is itself bounded to `WORKER_LOSSLESS_QUEUE_BUDGET` (well below
+    // `HEARTBEAT_STALE_AFTER`), so the worst case is one short worker stall per
+    // drain cycle rather than a full 5 s heartbeat-threatening block.
     let mut event_stream_out_of_sync = false;
     for delta in deltas {
         // #919/#922: emit both the resolved zone NAMES (legacy field,
@@ -195,8 +198,20 @@ pub(super) fn flush_session_deltas(
             // re-derives a complete session view. The RT_FLOW telemetry frames
             // below stay best-effort (`try_send`) — a dropped flow-export record
             // is not a correctness loss and must not force a resync.
+            //
+            // #5468: this runs on the PACKET WORKER LOOP, so the lossless send is
+            // BOUNDED to `WORKER_LOSSLESS_QUEUE_BUDGET` (well below
+            // `HEARTBEAT_STALE_AFTER`) instead of the 5 s `LOSSLESS_QUEUE_TIMEOUT`.
+            // A connected-but-unread peer (full lossless queue) that blocked the
+            // worker for the full 5 s would stop the loop stamping its heartbeat,
+            // the peer would mark this node stale, and a spurious failover would
+            // fire. On the bounded timeout we latch out-of-sync exactly as on any
+            // other lossless failure — deliver-or-resync, never a silent drop, so
+            // the #2874 losslessness contract holds.
             if !event_stream_out_of_sync {
-                if let Err(err) = es.push_delta_lossless(delta, zone_name_to_id) {
+                if let Err(err) =
+                    es.push_delta_lossless_within(delta, zone_name_to_id, WORKER_LOSSLESS_QUEUE_BUDGET)
+                {
                     event_stream_out_of_sync = true;
                     eprintln!(
                         "xpf-event-stream: HA session-sync delta could not be queued losslessly ({err}); latching out-of-sync to force a full owner-RG resync"

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -52,6 +52,25 @@ pub(super) fn purge_queued_flows_for_closed_deltas(
 // disconnected) — #2874. The caller latches loss-of-sync so the worker loop
 // re-exports the full owner-RG snapshot (the #2442 recovery path) and the peer
 // re-derives a complete session view instead of silently missing the delta.
+//
+// #5468 (aggregate bound): `worker_lossless_wedged` is an in/out per-drain-cycle
+// latch shared by EVERY `flush_session_deltas` call the worker loop makes in one
+// iteration (the steady-state incremental drain, the #2442 loss-of-sync resync,
+// AND the #2653 command export). Each individual call already bounds its lossless
+// backpressure to a single `WORKER_LOSSLESS_QUEUE_BUDGET` wait, but the resync /
+// export paths call this ONCE PER 256-delta batch across the entire owned-session
+// set — so for K owned sessions an unread peer would cost ~(K/256) budgets of
+// worker-loop stall, re-crossing `HEARTBEAT_STALE_AFTER` for large K and
+// re-triggering the SAME spurious failover via the resync path. To bound the
+// AGGREGATE, the first wedged call sets `*worker_lossless_wedged`; every
+// subsequent call this cycle inherits it and SKIPS the lossless wait entirely
+// (it never attempts a push, so no further budget is spent), while still draining
+// each delta to its other consumers — the per-binding live RPC buffer, the shared
+// conntrack/session tables, peer-worker delete replication, and the best-effort
+// RT_FLOW frames. Losslessness is preserved: every wedged call still returns
+// `true` so the caller keeps the loss-of-sync latch set and the resync retries
+// next cycle (deliver-or-resync, never a silent drop). Net effect: the worker
+// loop's total lossless WAIT per drain cycle is ~1 budget regardless of K.
 pub(super) fn flush_session_deltas(
     ident: &BindingIdentity,
     live: Option<&BindingLiveState>,
@@ -72,6 +91,8 @@ pub(super) fn flush_session_deltas(
     peer_worker_commands: &[Arc<Mutex<VecDeque<WorkerCommand>>>],
     event_stream: &Option<crate::event_stream::EventStreamWorkerHandle>,
     forwarding: &ForwardingState,
+    // #5468: per-drain-cycle aggregate lossless-wedge latch (see doc above).
+    worker_lossless_wedged: &mut bool,
 ) -> bool {
     let zone_name_to_id = &forwarding.zone_name_to_id;
     let zone_id_to_name = &forwarding.zone_id_to_name;
@@ -84,7 +105,13 @@ pub(super) fn flush_session_deltas(
     // is itself bounded to `WORKER_LOSSLESS_QUEUE_BUDGET` (well below
     // `HEARTBEAT_STALE_AFTER`), so the worst case is one short worker stall per
     // drain cycle rather than a full 5 s heartbeat-threatening block.
-    let mut event_stream_out_of_sync = false;
+    //
+    // #5468 (aggregate): seed the flag from the per-drain-cycle wedge latch so a
+    // resync/export that calls this once per 256-delta batch does NOT pay a fresh
+    // budget wait on every batch. If a prior batch this cycle already wedged, we
+    // start out-of-sync and never attempt another lossless push — the aggregate
+    // worker-loop wait stays ~1 budget regardless of the owned-session count K.
+    let mut event_stream_out_of_sync = *worker_lossless_wedged;
     for delta in deltas {
         // #919/#922: emit both the resolved zone NAMES (legacy field,
         // empty when the ID is unknown) and the u16 IDs. New daemons
@@ -365,6 +392,13 @@ pub(super) fn flush_session_deltas(
                 );
             }
         }
+    }
+    // #5468: propagate this batch's wedge into the per-drain-cycle latch so the
+    // NEXT `flush_session_deltas` call this cycle (the next resync/export batch)
+    // inherits it and skips the lossless wait — bounding the aggregate worker-loop
+    // wait to ~1 budget regardless of the owned-session count.
+    if event_stream_out_of_sync {
+        *worker_lossless_wedged = true;
     }
     event_stream_out_of_sync
 }

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -5191,6 +5191,7 @@ fn flush_session_deltas_without_binding_reaches_global_consumers() {
         ifindex: -1,
     };
     let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
+    let mut worker_lossless_wedged = false;
     flush_session_deltas(
         &ident,
         None,
@@ -5207,6 +5208,7 @@ fn flush_session_deltas_without_binding_reaches_global_consumers() {
         &peer_worker_commands,
         &None,
         &forwarding,
+        &mut worker_lossless_wedged,
     );
 
     // Binding-independent consumer 1: shared session table cleared.
@@ -5331,6 +5333,7 @@ fn flush_session_deltas_rt_flow_app_id_uses_post_nat_dst_port() {
             ifindex: 7,
         };
         let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
+        let mut worker_lossless_wedged = false;
         flush_session_deltas(
             &ident,
             None,
@@ -5347,6 +5350,7 @@ fn flush_session_deltas_rt_flow_app_id_uses_post_nat_dst_port() {
             &peer_worker_commands,
             &Some(handle),
             &forwarding,
+            &mut worker_lossless_wedged,
         );
         let frames: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         let payload = frames
@@ -5463,6 +5467,7 @@ fn flush_session_deltas_session_close_reresolves_policy_id_after_reorder() {
         ifindex: 7,
     };
     let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
+    let mut worker_lossless_wedged = false;
     flush_session_deltas(
         &ident,
         None,
@@ -5479,6 +5484,7 @@ fn flush_session_deltas_session_close_reresolves_policy_id_after_reorder() {
         &peer_worker_commands,
         &Some(handle),
         &forwarding,
+        &mut worker_lossless_wedged,
     );
     let frames: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
     let payload = frames
@@ -5553,6 +5559,7 @@ fn flush_session_deltas_event_stream_drop_latches_out_of_sync() {
         ifindex: -1,
     };
     let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
+    let mut worker_lossless_wedged = false;
     let out_of_sync = flush_session_deltas(
         &ident,
         None,
@@ -5569,6 +5576,7 @@ fn flush_session_deltas_event_stream_drop_latches_out_of_sync() {
         &peer_worker_commands,
         &event_stream,
         &forwarding,
+        &mut worker_lossless_wedged,
     );
 
     assert!(
@@ -5662,6 +5670,7 @@ fn flush_session_deltas_full_queue_send_is_bounded_and_latches_out_of_sync() {
     let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
 
     let start = std::time::Instant::now();
+    let mut worker_lossless_wedged = false;
     let out_of_sync = flush_session_deltas(
         &ident,
         None,
@@ -5678,6 +5687,7 @@ fn flush_session_deltas_full_queue_send_is_bounded_and_latches_out_of_sync() {
         &peer_worker_commands,
         &event_stream,
         &forwarding,
+        &mut worker_lossless_wedged,
     );
     let elapsed = start.elapsed();
 
@@ -5698,6 +5708,140 @@ fn flush_session_deltas_full_queue_send_is_bounded_and_latches_out_of_sync() {
     assert!(
         elapsed < HEARTBEAT_STALE_AFTER,
         "worker-loop lossless send ({elapsed:?}) must never reach HEARTBEAT_STALE_AFTER ({HEARTBEAT_STALE_AFTER:?}) -> the peer would mark this node stale and fail over (#5468)"
+    );
+}
+
+/// #5468 FAIL-ON-REVERT (aggregate): bounding a SINGLE `flush_session_deltas`
+/// call to `WORKER_LOSSLESS_QUEUE_BUDGET` (the sibling test above) is not enough.
+/// The #2442 loss-of-sync resync (`take_delta_loss` -> `chunked_drain_as_you_
+/// export!` -> `drain_and_flush_all!` in worker/loop_body/mod.rs) and the #2653
+/// command export call `flush_session_deltas` ONCE PER 256-delta batch across the
+/// ENTIRE owned-session set. For K owned sessions that is ~K/256 calls; at ~1
+/// budget each an unread peer would cost ~(K/256) budgets of worker-loop stall.
+/// With `WORKER_LOSSLESS_QUEUE_BUDGET` = `HEARTBEAT_STALE_AFTER`/5, any K past
+/// ~1280 (5 batches) re-crosses `HEARTBEAT_STALE_AFTER` and re-triggers the SAME
+/// spurious failover — the #5468 gap, unfixed for the under-load resync case.
+///
+/// The fix threads a per-drain-cycle `worker_lossless_wedged` latch through every
+/// `flush_session_deltas` call the worker makes in one iteration: the FIRST wedge
+/// waits one budget and sets the latch; every subsequent call inherits it and
+/// SKIPS the lossless wait entirely (still draining to the other consumers). So
+/// the aggregate worker-loop lossless wait collapses to ~1 budget regardless of
+/// K, while every wedged batch still returns `true` (keeps the loss-of-sync latch
+/// set -> the resync retries next cycle; deliver-or-resync, never a silent drop).
+///
+/// This drives BATCHES > 5 calls (>1280 sessions at 256/batch) sharing ONE
+/// `worker_lossless_wedged`, against a CONNECTED-but-UNREAD full channel, and
+/// asserts the TOTAL time stays well below `HEARTBEAT_STALE_AFTER`.
+///
+/// RED on revert: seeding `event_stream_out_of_sync = false` instead of
+/// `*worker_lossless_wedged` (i.e. dropping the aggregate inheritance) makes each
+/// of the BATCHES calls pay its own full budget wait, so the total is ~BATCHES
+/// budgets — past `HEARTBEAT_STALE_AFTER` — and both time assertions fail.
+#[test]
+fn resync_export_aggregate_lossless_wait_is_bounded_below_heartbeat() {
+    let key = test_key();
+    let decision = test_decision();
+    let metadata = test_metadata();
+
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+    let recent_session_deltas = Arc::new(Mutex::new(VecDeque::new()));
+    let forwarding = ForwardingState::default();
+
+    // CONNECTED handle with a tiny channel filled to capacity; `_rx` is never
+    // drained so the channel stays full (models a connected-but-unread peer).
+    let capacity = 4usize;
+    let (handle, _rx) = crate::event_stream::test_worker_handle_connected(
+        capacity,
+        crate::event_stream::DataplaneEventRateLimitConfig::default(),
+    );
+
+    let open = SessionDelta {
+        kind: SessionDeltaKind::Open,
+        key: key.clone(),
+        decision,
+        metadata,
+        origin: SessionOrigin::ForwardFlow,
+        fabric_redirect_sync: false,
+        created_ns: 0,
+        last_seen_ns: 0,
+        counters: crate::session::SessionCounters::default(),
+        observed_tos: 0,
+        observed_tcp_flags: 0,
+        session_id: 0,
+    };
+    for _ in 0..capacity {
+        handle.push_delta(&open, &forwarding.zone_name_to_id);
+    }
+
+    let event_stream = Some(handle);
+    let ident = BindingIdentity {
+        slot: 0,
+        queue_id: 0,
+        worker_id: 0,
+        interface: Arc::<str>::from(""),
+        ifindex: -1,
+    };
+    let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
+
+    // >5 batches: at 256 deltas/batch this is >1280 owned sessions, the point at
+    // which the UNBOUNDED aggregate (one budget per batch) crosses
+    // HEARTBEAT_STALE_AFTER. Each call carries a single delta — the per-call cost
+    // is one budget wait whether the batch holds 1 or 256 deltas, so one delta
+    // faithfully models one 256-delta resync batch.
+    const BATCHES: usize = 8;
+    let mut worker_lossless_wedged = false;
+    let start = std::time::Instant::now();
+    let mut all_latched = true;
+    for _ in 0..BATCHES {
+        let out_of_sync = flush_session_deltas(
+            &ident,
+            None,
+            -1,
+            -1,
+            -1,
+            &dnat_fds,
+            std::slice::from_ref(&open),
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &recent_session_deltas,
+            &peer_worker_commands,
+            &event_stream,
+            &forwarding,
+            &mut worker_lossless_wedged,
+        );
+        all_latched &= out_of_sync;
+    }
+    let elapsed = start.elapsed();
+
+    assert!(
+        all_latched,
+        "every wedged resync batch must return out-of-sync so the loss-of-sync latch stays set and the resync retries next cycle — never a silent drop (#2874/#5468)"
+    );
+    assert!(
+        worker_lossless_wedged,
+        "the per-drain-cycle wedge latch must stay set across the resync batches"
+    );
+    // The AGGREGATE across all BATCHES calls must stay well below the heartbeat-
+    // stale threshold. Reverting the aggregate inheritance makes it ~BATCHES
+    // budgets (~8x), far past HEARTBEAT_STALE_AFTER.
+    assert!(
+        elapsed < HEARTBEAT_STALE_AFTER,
+        "aggregate resync lossless wait across {BATCHES} batches ({elapsed:?}) must stay < HEARTBEAT_STALE_AFTER ({HEARTBEAT_STALE_AFTER:?}); dropping the per-cycle wedge inheritance regresses #5468 via the resync path (worker stalls ~{BATCHES}x budget -> false liveness loss)"
+    );
+    // Tight bound: the fix collapses the whole resync's lossless wait to ~1 budget
+    // (only the first batch waits). A 3x-budget ceiling separates the fix (~1x)
+    // from the reverted per-batch waits (~BATCHES x) with generous anti-flake margin.
+    assert!(
+        elapsed < WORKER_LOSSLESS_QUEUE_BUDGET * 3,
+        "aggregate resync lossless wait ({elapsed:?}) must collapse to ~1 WORKER_LOSSLESS_QUEUE_BUDGET ({:?}), not scale with the owned-session count (#5468)",
+        WORKER_LOSSLESS_QUEUE_BUDGET
     );
 }
 
@@ -5774,6 +5918,7 @@ fn close_delta_deletes_dnat_table_entry_for_snat_flow() {
         let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = vec![];
         let recent_session_deltas = Arc::new(Mutex::new(VecDeque::new()));
         let forwarding = ForwardingState::default();
+        let mut worker_lossless_wedged = false;
         flush_session_deltas(
             &ident,
             None,
@@ -5790,6 +5935,7 @@ fn close_delta_deletes_dnat_table_entry_for_snat_flow() {
             &peer_worker_commands,
             &None,
             &forwarding,
+            &mut worker_lossless_wedged,
         );
     };
 

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -5587,6 +5587,120 @@ fn flush_session_deltas_event_stream_drop_latches_out_of_sync() {
     );
 }
 
+/// #5468 FAIL-ON-REVERT: `flush_session_deltas` runs on the packet worker loop,
+/// so a session-sync delta that cannot be queued to a CONNECTED-but-UNREAD peer
+/// (a slow/stalled reader whose lossless queue is full) must NOT block the loop
+/// for the full 5 s `LOSSLESS_QUEUE_TIMEOUT`. That exceeds `HEARTBEAT_STALE_AFTER`
+/// (5 s), so the loop would stop stamping its heartbeat, the peer would mark this
+/// node stale, and a spurious failover would fire.
+///
+/// This builds a CONNECTED handle whose bounded channel is FILLED to capacity
+/// (the `Receiver` is never drained), so the lossless send exercises the bounded
+/// backpressure retry loop — not the immediate `!connected` early return the
+/// sibling `..._drop_latches_out_of_sync` test uses. The assertions are:
+///   1. the worker-side send returns WELL BELOW `HEARTBEAT_STALE_AFTER` (bounded
+///      to ~`WORKER_LOSSLESS_QUEUE_BUDGET`), and
+///   2. on that bounded timeout it LATCHES loss-of-sync (`flush_session_deltas`
+///      returns `true`) so the worker forces a full owner-RG resync — never a
+///      silent drop (the #2874 losslessness contract).
+///
+/// RED on revert: restoring the worker-loop call to the unbounded
+/// `es.push_delta_lossless(...)` (which waits the full 5 s `LOSSLESS_QUEUE_TIMEOUT`)
+/// makes `elapsed` ≈ 5 s and the bounded-time assertion fails.
+#[test]
+fn flush_session_deltas_full_queue_send_is_bounded_and_latches_out_of_sync() {
+    let key = test_key();
+    let decision = test_decision();
+    let metadata = test_metadata();
+
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+    let recent_session_deltas = Arc::new(Mutex::new(VecDeque::new()));
+    let forwarding = ForwardingState::default();
+
+    // CONNECTED handle with a tiny channel; `_rx` is intentionally never read so
+    // the channel fills and stays full (models an unread peer).
+    let capacity = 4usize;
+    let (handle, _rx) = crate::event_stream::test_worker_handle_connected(
+        capacity,
+        crate::event_stream::DataplaneEventRateLimitConfig::default(),
+    );
+
+    let open = SessionDelta {
+        kind: SessionDeltaKind::Open,
+        key: key.clone(),
+        decision,
+        metadata,
+        origin: SessionOrigin::ForwardFlow,
+        fabric_redirect_sync: false,
+        created_ns: 0,
+        last_seen_ns: 0,
+        counters: crate::session::SessionCounters::default(),
+        observed_tos: 0,
+        observed_tcp_flags: 0,
+        session_id: 0,
+    };
+
+    // Saturate the channel: fill every slot with a best-effort filler push so the
+    // subsequent worker-loop lossless send finds it Full and enters the bounded
+    // retry loop.
+    for _ in 0..capacity {
+        handle.push_delta(&open, &forwarding.zone_name_to_id);
+    }
+
+    let event_stream = Some(handle);
+    let ident = BindingIdentity {
+        slot: 0,
+        queue_id: 0,
+        worker_id: 0,
+        interface: Arc::<str>::from(""),
+        ifindex: -1,
+    };
+    let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
+
+    let start = std::time::Instant::now();
+    let out_of_sync = flush_session_deltas(
+        &ident,
+        None,
+        -1,
+        -1,
+        -1,
+        &dnat_fds,
+        &[open],
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &recent_session_deltas,
+        &peer_worker_commands,
+        &event_stream,
+        &forwarding,
+    );
+    let elapsed = start.elapsed();
+
+    assert!(
+        out_of_sync,
+        "a session-sync delta that cannot be queued losslessly to a full/unread peer must latch out-of-sync (force a full owner-RG resync), not be silently dropped (#2874/#5468)"
+    );
+    // The worker-side send must be bounded WELL BELOW the heartbeat-stale
+    // threshold. `WORKER_LOSSLESS_QUEUE_BUDGET` is one fifth of
+    // HEARTBEAT_STALE_AFTER, so a 2x-budget ceiling cleanly separates the fix
+    // (~1x budget) from the reverted 5 s block (~5x budget).
+    assert!(
+        elapsed < WORKER_LOSSLESS_QUEUE_BUDGET * 2,
+        "worker-loop lossless send must be bounded to ~WORKER_LOSSLESS_QUEUE_BUDGET ({:?}), took {:?}; reverting to the unbounded 5 s LOSSLESS_QUEUE_TIMEOUT regresses #5468 (worker stalls past HEARTBEAT_STALE_AFTER -> false liveness loss)",
+        WORKER_LOSSLESS_QUEUE_BUDGET,
+        elapsed
+    );
+    assert!(
+        elapsed < HEARTBEAT_STALE_AFTER,
+        "worker-loop lossless send ({elapsed:?}) must never reach HEARTBEAT_STALE_AFTER ({HEARTBEAT_STALE_AFTER:?}) -> the peer would mark this node stale and fail over (#5468)"
+    );
+}
+
 /// #2979 FAIL-ON-REVERT: a Close delta for an SNAT'd session must delete the
 /// dynamic reverse-NAT `dnat_table` entry that `publish_dnat_table_entry`
 /// inserted at session install. The maps are `BPF_MAP_TYPE_HASH` (non-LRU,

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -122,6 +122,22 @@ pub(crate) fn worker_loop(
     let mut idle_iters = 0u32;
     let mut poll_start = 0usize;
     let mut shared_recycles = Vec::with_capacity((RX_BATCH_SIZE as usize).saturating_mul(2));
+    // #5468: per-drain-cycle aggregate lossless-wedge latch. `flush_session_deltas`
+    // bounds each individual lossless send to `WORKER_LOSSLESS_QUEUE_BUDGET`, but
+    // the #2442 loss-of-sync resync and the #2653 command export call it ONCE PER
+    // 256-delta batch across the whole owned-session set — so an unread peer would
+    // otherwise cost ~(K/256) budgets of worker-loop stall for K owned sessions,
+    // re-crossing HEARTBEAT_STALE_AFTER for large K and re-triggering the SAME
+    // spurious failover via the resync path. Seeded false at the top of every loop
+    // iteration below and threaded through EVERY `flush_session_deltas` call this
+    // cycle: the first wedge sets it, and later batches inherit it and skip the
+    // lossless wait (still draining to the live buffers / shared tables / peer
+    // delete replication), so the aggregate worker-loop lossless wait stays ~1
+    // budget regardless of K. The loss-of-sync latch still fires on every wedged
+    // batch, so the resync retries next cycle (deliver-or-resync, never a drop).
+    // Declared uninitialized: the loop-top reset below is the first write every
+    // iteration, so a healthy consumer never inherits a stale wedge.
+    let mut worker_lossless_wedged: bool;
     // #2669: flush a freshly-drained delta batch to its consumers. Used at
     // all three drain sites (resync macro, exported-sequences branch, else
     // branch). The drain that produced `$deltas` already popped them off the
@@ -158,6 +174,7 @@ pub(crate) fn worker_loop(
                         &peer_worker_commands,
                         &event_stream,
                         forwarding.as_ref(),
+                        &mut worker_lossless_wedged,
                     )
                 }
                 None => {
@@ -184,6 +201,7 @@ pub(crate) fn worker_loop(
                         &peer_worker_commands,
                         &event_stream,
                         forwarding.as_ref(),
+                        &mut worker_lossless_wedged,
                     )
                 }
             };
@@ -239,6 +257,12 @@ pub(crate) fn worker_loop(
     const WR_PUBLISH_INTERVAL_NS: u64 = 1_000_000_000;
     while !stop.load(Ordering::Relaxed) {
         let loop_now_ns = monotonic_nanos();
+        // #5468: reset the per-drain-cycle aggregate lossless-wedge latch. It is
+        // threaded through every `flush_session_deltas` call this iteration (the
+        // steady-state drain, the #2442 resync, and the #2653 export) so the
+        // FIRST wedge caps the whole cycle's lossless wait at ~1 budget; a fresh
+        // iteration must start un-wedged so a healthy consumer pays no penalty.
+        worker_lossless_wedged = false;
         // #869: attribute elapsed delta to the previous loop's state.
         {
             let delta = loop_now_ns.saturating_sub(wr_last_loop_ns);

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -329,8 +329,22 @@ cluster-scoped.
   drives the existing #2442 `take_delta_loss` resync (a full owner-RG
   snapshot re-export). It stops attempting further lossless pushes for the
   rest of that drain batch, so the worst-case backpressure is one lossless
-  wait (`LOSSLESS_QUEUE_TIMEOUT`) per drain cycle even on a wedged consumer —
-  the snapshot supersedes the remaining incremental deltas. The RT_FLOW
+  wait per drain cycle even on a wedged consumer — the snapshot supersedes
+  the remaining incremental deltas.
+  - **#5468: the worker-loop lossless wait is BOUNDED.** `flush_session_deltas`
+    runs on the packet worker loop, so it uses `push_delta_lossless_within`
+    with a short `WORKER_LOSSLESS_QUEUE_BUDGET` (one fifth of
+    `HEARTBEAT_STALE_AFTER`, ~1 s) instead of the 5 s `LOSSLESS_QUEUE_TIMEOUT`.
+    A connected-but-UNREAD peer (slow/stalled reader, queue full) that blocked
+    the worker for the full 5 s would stop the loop stamping its heartbeat, the
+    peer would then see this node as stale (`HEARTBEAT_STALE_AFTER` = 5 s) and
+    trigger a FALSE failover. On the bounded timeout the delta is not dropped —
+    the same loss-of-sync latch fires and forces a full resync (deliver-or-
+    resync). Only the off-worker-loop paths (bulk export on connect
+    `AllSessionsExport::push`, tunnel-remap purge `push_purge_close_deltas`)
+    keep the longer 5 s `LOSSLESS_QUEUE_TIMEOUT` via `push_delta_lossless`,
+    since they run with the worker heartbeat unaffected.
+  The RT_FLOW
   SESSION_CLOSE/SESSION_CREATE telemetry frames (types 14/15) stay
   best-effort (`try_send` via the per-kind budget) — a dropped flow-export
   record is not a correctness loss and MUST NOT force a resync.

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -327,23 +327,40 @@ cluster-scoped.
   genuinely wedged consumer), `flush_session_deltas` returns `true` and the
   worker loop latches loss-of-sync via `SessionTable::set_delta_loss`, which
   drives the existing #2442 `take_delta_loss` resync (a full owner-RG
-  snapshot re-export). It stops attempting further lossless pushes for the
-  rest of that drain batch, so the worst-case backpressure is one lossless
-  wait per drain cycle even on a wedged consumer — the snapshot supersedes
-  the remaining incremental deltas.
-  - **#5468: the worker-loop lossless wait is BOUNDED.** `flush_session_deltas`
-    runs on the packet worker loop, so it uses `push_delta_lossless_within`
-    with a short `WORKER_LOSSLESS_QUEUE_BUDGET` (one fifth of
-    `HEARTBEAT_STALE_AFTER`, ~1 s) instead of the 5 s `LOSSLESS_QUEUE_TIMEOUT`.
-    A connected-but-UNREAD peer (slow/stalled reader, queue full) that blocked
-    the worker for the full 5 s would stop the loop stamping its heartbeat, the
-    peer would then see this node as stale (`HEARTBEAT_STALE_AFTER` = 5 s) and
-    trigger a FALSE failover. On the bounded timeout the delta is not dropped —
-    the same loss-of-sync latch fires and forces a full resync (deliver-or-
-    resync). Only the off-worker-loop paths (bulk export on connect
-    `AllSessionsExport::push`, tunnel-remap purge `push_purge_close_deltas`)
-    keep the longer 5 s `LOSSLESS_QUEUE_TIMEOUT` via `push_delta_lossless`,
-    since they run with the worker heartbeat unaffected.
+  snapshot re-export). Within a single `flush_session_deltas` call it stops
+  attempting further lossless pushes for the rest of that batch, so one call
+  incurs at most one lossless wait — the snapshot supersedes the remaining
+  incremental deltas.
+  - **#5468: the worker-loop lossless wait is BOUNDED — per call AND in
+    aggregate.** `flush_session_deltas` runs on the packet worker loop, so it
+    uses `push_delta_lossless_within` with a short `WORKER_LOSSLESS_QUEUE_BUDGET`
+    (one fifth of `HEARTBEAT_STALE_AFTER`, ~1 s) instead of the 5 s
+    `LOSSLESS_QUEUE_TIMEOUT`. A connected-but-UNREAD peer (slow/stalled reader,
+    queue full) that blocked the worker for the full 5 s would stop the loop
+    stamping its heartbeat, the peer would then see this node as stale
+    (`HEARTBEAT_STALE_AFTER` = 5 s) and trigger a FALSE failover. On the bounded
+    timeout the delta is not dropped — the same loss-of-sync latch fires and
+    forces a full resync (deliver-or-resync).
+    - The per-call bound is NOT enough on its own: the drain region calls
+      `flush_session_deltas` once for the steady-state batch, but the #2442
+      resync and the #2653 command export call it ONCE PER 256-delta batch
+      across the whole owned-session set (`chunked_drain_as_you_export!` →
+      `drain_and_flush_all!`). For K owned sessions that is ~K/256 calls, so at
+      one budget each an unread peer would still stall the worker ~(K/256)
+      budgets — past K≈1280 that re-crosses `HEARTBEAT_STALE_AFTER` and
+      re-triggers the same false failover via the resync path. The worker loop
+      therefore threads a per-drain-cycle `worker_lossless_wedged` latch through
+      every `flush_session_deltas` call: the first wedged batch waits one budget
+      and sets it; every later call this cycle inherits it and SKIPS the
+      lossless wait entirely (still draining each delta to the live RPC buffer,
+      the shared conntrack/session tables, and peer-worker delete replication).
+      So the AGGREGATE worker-loop lossless wait per drain cycle is ~1 budget
+      regardless of K; every wedged batch still returns out-of-sync, so the
+      latch stays set and the resync RETRIES next cycle (never a silent drop).
+    - Only the off-worker-loop paths (bulk export on connect
+      `AllSessionsExport::push`, tunnel-remap purge `push_purge_close_deltas`)
+      keep the longer 5 s `LOSSLESS_QUEUE_TIMEOUT` via `push_delta_lossless`,
+      since they run with the worker heartbeat unaffected.
   The RT_FLOW
   SESSION_CLOSE/SESSION_CREATE telemetry frames (types 14/15) stay
   best-effort (`try_send` via the per-kind budget) — a dropped flow-export

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -487,6 +487,23 @@ pub(crate) fn test_worker_handle(
     (EventStreamWorkerHandle { tx, shared }, rx)
 }
 
+/// #5468 test seam: build a CONNECTED worker handle (connected flag forced
+/// `true`) whose bounded mpsc channel has `capacity` slots. The returned
+/// `Receiver` is never drained by the test, so filling the channel to capacity
+/// models a connected-but-unread peer — exactly the state that drives the
+/// bounded backpressure retry loop in `push_delta_lossless_within` (rather than
+/// the immediate `!connected` early return that `test_worker_handle` exercises).
+/// The `Receiver` must be kept alive so the channel stays connected.
+#[cfg(test)]
+pub(crate) fn test_worker_handle_connected(
+    capacity: usize,
+    config: DataplaneEventRateLimitConfig,
+) -> (EventStreamWorkerHandle, mpsc::Receiver<EventFrame>) {
+    let (handle, rx) = test_worker_handle(capacity, config);
+    handle.shared.connected.store(true, Ordering::Release);
+    (handle, rx)
+}
+
 // ---------------------------------------------------------------------------
 // EventStreamWorkerHandle -- lightweight clone for worker threads
 // ---------------------------------------------------------------------------
@@ -602,14 +619,24 @@ impl EventStreamWorkerHandle {
     /// for frames whose seq came from `next_seq()` (roll it back on a drop,
     /// #3878 F-153) and `None` for control frames that carry a fixed, non-
     /// allocated seq (e.g. `DrainComplete`).
-    fn send_lossless_encoded<F>(&self, mut encode: F) -> Result<(), String>
+    ///
+    /// `timeout` bounds the total backpressure wait before this gives up and
+    /// returns `Err`. Off-worker-loop callers (bulk export on connect, the
+    /// tunnel-remap purge) pass the full `LOSSLESS_QUEUE_TIMEOUT` (5 s). The
+    /// packet-worker-loop caller (`flush_session_deltas` via
+    /// `push_delta_lossless_within`) passes a SHORT budget well below
+    /// `HEARTBEAT_STALE_AFTER` so a connected-but-unread peer cannot stall the
+    /// worker past the heartbeat-stale threshold and self-inflict a spurious
+    /// failover (#5468). Either way the give-up is a genuine `Err` the caller
+    /// latches as loss-of-sync (forcing a full resync) — never a silent drop.
+    fn send_lossless_encoded<F>(&self, timeout: Duration, mut encode: F) -> Result<(), String>
     where
         F: FnMut() -> (EventFrame, Option<u64>),
     {
         if !self.shared.connected.load(Ordering::Acquire) {
             return Err("event stream not connected".to_string());
         }
-        let deadline = Instant::now() + LOSSLESS_QUEUE_TIMEOUT;
+        let deadline = Instant::now() + timeout;
         loop {
             // Raw `tx.try_send` (NOT `try_send_frame`): a `Full` here is a
             // RETRY, not a drop, so it must not bump `frames_dropped` — the
@@ -686,7 +713,7 @@ impl EventStreamWorkerHandle {
     /// `send_lossless_encoded` closure.
     #[cfg_attr(not(test), allow(dead_code))]
     fn send_frame_lossless(&self, frame: EventFrame) -> Result<(), String> {
-        self.send_lossless_encoded(move || (frame.clone(), None))
+        self.send_lossless_encoded(LOSSLESS_QUEUE_TIMEOUT, move || (frame.clone(), None))
     }
 
     fn encode_delta_frame(
@@ -736,7 +763,30 @@ impl EventStreamWorkerHandle {
         delta: &SessionDelta,
         zone_name_to_id: &FxHashMap<String, u16>,
     ) -> Result<(), String> {
-        self.send_lossless_encoded(|| {
+        self.push_delta_lossless_within(delta, zone_name_to_id, LOSSLESS_QUEUE_TIMEOUT)
+    }
+
+    /// #5468: worker-loop variant of [`push_delta_lossless`] that bounds the
+    /// backpressure wait to `budget` instead of the fixed 5 s
+    /// `LOSSLESS_QUEUE_TIMEOUT`.
+    ///
+    /// `flush_session_deltas` runs on the packet worker loop, so a
+    /// connected-but-unread peer (a slow/stalled reader whose channel is full)
+    /// must NOT be able to block the loop for the full `LOSSLESS_QUEUE_TIMEOUT`
+    /// — that exceeds `HEARTBEAT_STALE_AFTER`, so the peer marks this node stale
+    /// and triggers a false failover. The caller passes a `budget` well below
+    /// the heartbeat-stale threshold (`WORKER_LOSSLESS_QUEUE_BUDGET`); on
+    /// timeout this returns `Err` exactly like the 5 s path and the caller
+    /// latches loss-of-sync (a full owner-RG resync). Losslessness is preserved
+    /// — the delta is either delivered or a resync is forced, never a silent
+    /// drop (the #2874 contract).
+    pub(crate) fn push_delta_lossless_within(
+        &self,
+        delta: &SessionDelta,
+        zone_name_to_id: &FxHashMap<String, u16>,
+        budget: Duration,
+    ) -> Result<(), String> {
+        self.send_lossless_encoded(budget, || {
             let seq = self.next_seq();
             (
                 Self::encode_delta_frame(seq, delta, zone_name_to_id),


### PR DESCRIPTION
## Summary

Closes #5468.

`flush_session_deltas` runs on the **packet worker loop** and routes correctness-critical HA session open/close deltas through the LOSSLESS event-stream producer `push_delta_lossless` (#2874). That producer retries a full channel up to `LOSSLESS_QUEUE_TIMEOUT` = **5 s**, which equals `HEARTBEAT_STALE_AFTER` (5 s). A connected-but-**unread** peer (a slow/stalled reader whose lossless queue is full) can therefore block the worker loop for the full 5 s. During that block the loop stops stamping its per-binding heartbeat → the peer marks this node stale → **false liveness loss / spurious failover**.

## Fix

Bound the worker-side send instead of blocking 5 s:

- New `EventStreamWorkerHandle::push_delta_lossless_within(delta, zone, budget)` parameterizes `send_lossless_encoded`'s deadline (the existing `push_delta_lossless` now delegates with the 5 s default).
- New `WORKER_LOSSLESS_QUEUE_BUDGET` const = `HEARTBEAT_STALE_AFTER / 5` (~1 s), with a **compile-time `assert!`** that it stays ≤ half the stale threshold.
- `flush_session_deltas` uses the bounded variant. On the bounded timeout it latches loss-of-sync exactly as before (`set_delta_loss` → `take_delta_loss` full owner-RG resync), so the **#2874 losslessness contract is preserved**: the delta is either delivered or a resync is forced — **never silently dropped**.

Only the incremental worker-loop path is bounded. The off-worker-loop exporters keep the 5 s `LOSSLESS_QUEUE_TIMEOUT` via `push_delta_lossless` — `AllSessionsExport::push` (bulk export on connect) and `push_purge_close_deltas` (tunnel-remap purge) run off the packet loop, so a long backpressure wait there does not threaten the worker heartbeat.

## Validation

- `cargo build` green.
- **Fail-on-revert test** `flush_session_deltas_full_queue_send_is_bounded_and_latches_out_of_sync`: fills a **connected** handle's channel to capacity (unread peer) and asserts `flush_session_deltas` returns within ~1× budget (`< 2× budget`) **and** latches out-of-sync. Reverting the worker-loop call to unbounded `push_delta_lossless` makes it block **5.0 s** and fail the bounded assertion (verified).
- `event_stream` / `session_delta` / `ha` / `session` suites green (203 + 172 passing); **5× flake check** green.
- The env-flaky end-to-end test `stalled_consumer_does_not_grow_backlog_unbounded_end_to_end` fails at the **base SHA too** (verified via stash) — pre-existing, unrelated to this change.

## Smoke note

This touches HA session-delta / failover liveness. A **loss-cluster failover smoke** is advised (parent to run) — I did not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)