### PR TITLE
dataplane: make session-value padding explicit for ebpf marshal

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-17 — #6082: bpfSessionValue implicit padding breaks cilium/ebpf batch marshal
+
+- **Timestamp**: 2026-07-17 (fix/6082-session-value-marshal-size)
+- **Action**: The 60s HA session-sync sweep failed EVERY iteration on the loss
+  cluster (both nodes) with `batch lookup sessions: map batch lookup:
+  unmarshaling []dataplane.bpfSessionValue doesn't consume all data`. Root
+  cause (confirmed empirically): cilium/ebpf v0.20 `internal/sysenc.Unmarshal`
+  takes its zero-copy fast path ONLY when `binary.Size(T) == unsafe.Sizeof(T)`
+  (marshal.go:143 + layout.go). `bpfSessionValue`/`V6` carried 7 bytes of
+  IMPLICIT head alignment padding (gaps after State@1, after IsReverse@6-7,
+  before SessionID@12-15) introduced when #5460 widened `flags` __u8->__u16.
+  `unsafe.Sizeof` = 136/184 but `binary.Size` = 129/177, so sysenc fell back to
+  `binary.Decode`, which consumes only 129/177 of each 136/184-byte kernel
+  record → the whole batch errors. Every map read (BatchLookup, Iterate, single
+  Lookup) was affected; the sweep is just where it logged.
+- **Fix**: made all three head-padding gaps EXPLICIT via named `_ [N]byte`
+  fields in `bpfSessionValue` and `bpfSessionValueV6`, mirroring the C
+  `struct session_value{,_v6}` byte layout. binary.Size now == unsafe.Sizeof ==
+  136/184, so the zero-copy path stays engaged. No real field type/order/offset
+  changed; on-map ABI bytes byte-identical (unsafe.Sizeof + every offset
+  unchanged). Blank `_` fields are counted by encoding/binary but do NOT count
+  as "unexported" for the fast path (layout.go:28).
+- **Tests**: added `TestBPFSessionValueMarshalsAtConntrackABISize` (asserts
+  binary.Size == unsafe.Sizeof == 136/184 for both structs — the fail-on-revert
+  guard #6082 needed; verified RED with pads removed while the old
+  unsafe.Sizeof-only ABI test stayed GREEN, proving the old test could not catch
+  it) and `TestBatchLookupSessionsRoundTrip` (real kernel v4/v6 maps: install
+  via Set/toBPF, read back via BatchIterateSessions/V6 + GetSessionV4/V6;
+  skips unprivileged, runs on the privileged cluster where #6082 was seen).
+- **File(s)**: pkg/dataplane/bpf_session_value.go,
+  pkg/dataplane/bpf_session_value_test.go
+- **Validation**: `go build ./...`, `go test ./pkg/dataplane/...`,
+  `go test ./pkg/cluster/... ./pkg/conntrack/...` all green (round-trip skips
+  unprivileged). gofmt -w on both touched files.
+
 ## 2026-07-17 — #5469: write_state serializes+fsyncs OUTSIDE the ServerState lock
 
 - **Timestamp**: 2026-07-17 (fix/5469-writestate-lock-convoy)

--- a/pkg/dataplane/bpf_session_value.go
+++ b/pkg/dataplane/bpf_session_value.go
@@ -55,13 +55,33 @@ var (
 // trailing fields. Keep field-for-field in sync with both SessionValue
 // (types.go) and the C struct (xpf_conntrack.h); the parity test in
 // bpf_session_value_test.go fails if the size drifts from 136.
+//
+// EXPLICIT PADDING (#6082): every byte the C/Go compiler inserts as implicit
+// alignment padding is declared as a named `_ [N]byte` gap. This is NOT
+// cosmetic — cilium/ebpf's map I/O (Lookup / Iterate / BatchLookup, via
+// internal/sysenc.Unmarshal) takes a zero-copy fast path ONLY when
+// binary.Size(T) == unsafe.Sizeof(T) (it compares encoding/binary's field-sum
+// size against the native slice-element size). encoding/binary does not count
+// implicit padding, so with the three head gaps left implicit binary.Size was
+// 129 while unsafe.Sizeof is 136; sysenc then fell back to binary.Decode, which
+// consumes only 129 of every 136 kernel value bytes and fails the whole batch
+// with "unmarshaling []dataplane.bpfSessionValue doesn't consume all data",
+// breaking the 60s HA session-sync sweep. Making the padding explicit keeps
+// binary.Size == unsafe.Sizeof == 136 (blank `_` fields ARE counted by
+// encoding/binary yet do NOT count as "unexported" for the fast path), so the
+// zero-copy path stays engaged. The on-map ABI bytes are unchanged: these pads
+// occupy the exact offsets the compiler already padded, so unsafe.Sizeof and
+// every real field offset are byte-identical to before.
 type bpfSessionValue struct {
 	State uint8
+	_     [1]byte // pad: C aligns __u16 flags after state (#5460 __u16 widen; #6082)
 	// uint16 to match C `struct session_value.flags` (SessFlagNPTV6 = bit 8, #5460).
 	Flags      uint16
 	TCPState   uint8
 	IsReverse  uint8
+	_          [2]byte // pad: C aligns __u32 app_timeout (#6082)
 	AppTimeout uint32
+	_          [4]byte // pad: C aligns __u64 session_id to 8-byte boundary (#6082)
 
 	SessionID uint64
 
@@ -98,14 +118,19 @@ type bpfSessionValue struct {
 
 // bpfSessionValueV6 mirrors C `struct session_value_v6` exactly (184 bytes; 176
 // before the #5460 __u16 flags widen). It is SessionValueV6 without the
-// sync-only trailing fields.
+// sync-only trailing fields. The head padding is declared explicitly for the
+// same cilium/ebpf marshal-size reason as bpfSessionValue (#6082) — see that
+// type's doc comment.
 type bpfSessionValueV6 struct {
 	State uint8
+	_     [1]byte // pad: C aligns __u16 flags after state (#5460 __u16 widen; #6082)
 	// uint16 to match C `struct session_value_v6.flags` (see bpfSessionValue, #5460).
 	Flags      uint16
 	TCPState   uint8
 	IsReverse  uint8
+	_          [2]byte // pad: C aligns __u32 app_timeout (#6082)
 	AppTimeout uint32
+	_          [4]byte // pad: C aligns __u64 session_id to 8-byte boundary (#6082)
 
 	SessionID uint64
 

--- a/pkg/dataplane/bpf_session_value_test.go
+++ b/pkg/dataplane/bpf_session_value_test.go
@@ -1,6 +1,7 @@
 package dataplane
 
 import (
+	"encoding/binary"
 	"testing"
 	"unsafe"
 )
@@ -36,6 +37,113 @@ func TestBPFSessionValueMatchesConntrackABI(t *testing.T) {
 	}
 	if ConntrackSessionValueSizeV6 != conntrackValueSizeV6 {
 		t.Fatalf("ConntrackSessionValueSizeV6 = %d, want %d", ConntrackSessionValueSizeV6, conntrackValueSizeV6)
+	}
+}
+
+// TestBPFSessionValueMarshalsAtConntrackABISize is the fail-on-revert guard for
+// #6082. cilium/ebpf's map I/O (Lookup / Iterate / BatchLookup) unmarshals the
+// on-map value through internal/sysenc.Unmarshal, which only takes the correct
+// zero-copy fast path when encoding/binary's binary.Size(T) equals the native
+// unsafe.Sizeof(T). encoding/binary does NOT count implicit alignment padding,
+// so when the three head-padding gaps (after State, after IsReverse, before
+// SessionID) are left implicit, binary.Size is 129/177 while unsafe.Sizeof is
+// 136/184. sysenc then falls back to binary.Decode, which consumes only
+// binary.Size bytes of every value_size-byte kernel record and fails the batch
+// with "unmarshaling []dataplane.bpfSessionValue doesn't consume all data" —
+// the live HA session-sync sweep breakage.
+//
+// Declaring the padding explicitly (named `_ [N]byte` gaps) makes binary.Size
+// == unsafe.Sizeof == value_size, keeping the fast path engaged. This test goes
+// RED if the explicit pads are removed (reverting to implicit padding), because
+// binary.Size drops back to 129/177. It asserts all three sizes are equal AND
+// equal to the on-map conntrack ABI value_size (136/184) — the exact invariant
+// cilium/ebpf relies on.
+func TestBPFSessionValueMarshalsAtConntrackABISize(t *testing.T) {
+	cases := []struct {
+		name    string
+		native  uintptr
+		binSize int
+		want    int
+	}{
+		{"bpfSessionValue", unsafe.Sizeof(bpfSessionValue{}), binary.Size(bpfSessionValue{}), conntrackValueSizeV4},
+		{"bpfSessionValueV6", unsafe.Sizeof(bpfSessionValueV6{}), binary.Size(bpfSessionValueV6{}), conntrackValueSizeV6},
+	}
+	for _, tc := range cases {
+		if int(tc.native) != tc.want {
+			t.Errorf("unsafe.Sizeof(%s) = %d, want %d (on-map conntrack ABI value_size)", tc.name, tc.native, tc.want)
+		}
+		// The load-bearing #6082 assertion: encoding/binary's field-sum size
+		// must equal the native size, or cilium/ebpf's sysenc falls off the
+		// zero-copy path and mis-sizes every batch element.
+		if tc.binSize != int(tc.native) {
+			t.Errorf("binary.Size(%s) = %d, want %d (== unsafe.Sizeof); implicit padding makes cilium/ebpf "+
+				"mis-marshal the batch element and fail the HA sync sweep (#6082) — declare pads explicitly",
+				tc.name, tc.binSize, tc.native)
+		}
+		if tc.binSize != tc.want {
+			t.Errorf("binary.Size(%s) = %d, want %d (kernel value_size)", tc.name, tc.binSize, tc.want)
+		}
+	}
+}
+
+// TestBatchLookupSessionsRoundTrip drives the actual failing #6082 path: it
+// creates real kernel v4/v6 session HASH maps at the on-map ABI value_size,
+// installs entries through the production Set/toBPF path, then reads them back
+// via the batch sweep (BatchIterateSessions / V6). Before the explicit-padding
+// fix this returns "batch lookup sessions: ... doesn't consume all data". Skips
+// on unprivileged CI (no BPF map create); runs on the privileged cluster where
+// #6082 was observed.
+func TestBatchLookupSessionsRoundTrip(t *testing.T) {
+	m := newClearTestManager(t)
+
+	const flows = 400 // spans multiple 256-entry batch chunks
+	for i := uint32(0); i < flows; i++ {
+		v4 := SessionValue{State: 1, Flags: SessFlagSNAT, TCPState: 2, SessionID: uint64(i) + 1, PolicyID: i, AppID: uint16(i)}
+		if err := m.SetSessionV4(clearTestV4Key(i, false), v4); err != nil {
+			t.Fatalf("set v4 %d: %v", i, err)
+		}
+		v6 := SessionValueV6{State: 1, Flags: SessFlagDNAT, TCPState: 2, SessionID: uint64(i) + 1, PolicyID: i, AppID: uint16(i)}
+		if err := m.SetSessionV6(clearTestV6Key(i, false), v6); err != nil {
+			t.Fatalf("set v6 %d: %v", i, err)
+		}
+	}
+
+	got := map[uint32]SessionValue{}
+	if err := m.BatchIterateSessions(func(k SessionKey, v SessionValue) bool {
+		got[binary.BigEndian.Uint32(k.SrcIP[:])] = v
+		return true
+	}); err != nil {
+		t.Fatalf("BatchIterateSessions (the #6082 failing path): %v", err)
+	}
+	if len(got) != flows {
+		t.Fatalf("BatchIterateSessions returned %d sessions, want %d", len(got), flows)
+	}
+	// Spot-check a value survived the marshal round trip with correct field
+	// offsets (a mis-sized element would smear fields across the boundary).
+	if v, ok := got[7]; !ok || v.SessionID != 8 || v.PolicyID != 7 || v.Flags != SessFlagSNAT || v.AppID != 7 {
+		t.Fatalf("v4 flow 7 round-trip mismatch: %+v (ok=%v)", v, ok)
+	}
+
+	gotV6 := map[uint32]SessionValueV6{}
+	if err := m.BatchIterateSessionsV6(func(k SessionKeyV6, v SessionValueV6) bool {
+		gotV6[binary.BigEndian.Uint32(k.SrcIP[12:])] = v
+		return true
+	}); err != nil {
+		t.Fatalf("BatchIterateSessionsV6 (the #6082 failing path): %v", err)
+	}
+	if len(gotV6) != flows {
+		t.Fatalf("BatchIterateSessionsV6 returned %d sessions, want %d", len(gotV6), flows)
+	}
+	if v, ok := gotV6[7]; !ok || v.SessionID != 8 || v.PolicyID != 7 || v.Flags != SessFlagDNAT || v.AppID != 7 {
+		t.Fatalf("v6 flow 7 round-trip mismatch: %+v (ok=%v)", v, ok)
+	}
+
+	// Single-entry Lookup (GetSessionV4/V6) shares the same sysenc path.
+	if v, err := m.GetSessionV4(clearTestV4Key(9, false)); err != nil || v.SessionID != 10 {
+		t.Fatalf("GetSessionV4 flow 9: v=%+v err=%v", v, err)
+	}
+	if v, err := m.GetSessionV6(clearTestV6Key(9, false)); err != nil || v.SessionID != 10 {
+		t.Fatalf("GetSessionV6 flow 9: v=%+v err=%v", v, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #6082 — a HIGH master regression breaking HA session-sync. The 60s
session-sync sweep failed **every** iteration on the loss cluster (both nodes)
with:

> `cluster sync: sweep v4/v6 iteration failed err="batch lookup sessions: map batch lookup: unmarshaling []dataplane.bpfSessionValue doesn't consume all data"`

Session sync degraded → a redeployed secondary could not become transfer-ready.

## Root cause (confirmed empirically)

cilium/ebpf v0.20 `internal/sysenc.Unmarshal` uses a zero-copy fast path **only
when `binary.Size(T) == unsafe.Sizeof(T)`** (`marshal.go:143`, `layout.go`);
otherwise it falls back to `binary.Decode`.

`bpfSessionValue`/`bpfSessionValueV6` carried **7 bytes of implicit head
alignment padding** (gaps after `State`, after `IsReverse`, before `SessionID`)
introduced when **#5460** widened `flags` `__u8`→`__u16`. `encoding/binary` does
not count implicit padding, so:

| struct | `unsafe.Sizeof` | `binary.Size` (before) |
|---|---|---|
| `bpfSessionValue` | 136 | **129** |
| `bpfSessionValueV6` | 184 | **177** |

`binary.Decode` then consumed only 129/177 of every 136/184-byte kernel record,
leaving unconsumed bytes → the whole batch errored. Every map read (BatchLookup,
Iterate, single Lookup) was affected; the periodic sweep is just where it logged.

## Fix

Declare all three head-padding gaps explicitly as named `_ [N]byte` fields,
mirroring the C `struct session_value{,_v6}` byte layout. `binary.Size` now
equals `unsafe.Sizeof` (136/184), so the zero-copy path stays engaged. Blank
`_` fields are counted by `encoding/binary` but do **not** count as
"unexported" for the fast path.

**No real field type/order/offset changed** — the pads occupy the exact bytes
the compiler already padded, so the on-map ABI is byte-identical (map
`value_size` stays 136/184, Rust side untouched).

## Measured sizes (before → after)

| | unsafe.Sizeof | binary.Size (before) | binary.Size (after) | ebpf element size |
|---|---|---|---|---|
| `bpfSessionValue` | 136 | 129 | **136** | 136 (fast path) |
| `bpfSessionValueV6` | 184 | 177 | **184** | 184 (fast path) |

## Tests

- `TestBPFSessionValueMarshalsAtConntrackABISize` — asserts `binary.Size ==
  unsafe.Sizeof == 136/184` for both structs (the guard #6082 needed). Verified
  **RED** with the pads removed while the old `unsafe.Sizeof`-only ABI test
  stayed **GREEN** — proving the prior test could not catch this.
- `TestBatchLookupSessionsRoundTrip` — drives the real failing path on kernel
  v4/v6 maps (install via `Set`/`toBPF`, read back via
  `BatchIterateSessions`/`V6` + `GetSessionV4`/`V6`). Skips on unprivileged CI;
  runs on the privileged cluster where #6082 was observed.

## Validation

`go build ./...`, `go test ./pkg/dataplane/...`, and
`go test ./pkg/cluster/... ./pkg/conntrack/...` all green (round-trip skips
unprivileged). `gofmt -w` on both touched files.

Closes #6082

🤖 Generated with [Claude Code](https://claude.com/claude-code)