### PR TITLE
tx/cos: fail closed on cached flowless output filter

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,48 @@
+## 2026-07-18 — #6055: harden cached flowless CoS arm against a latent output-filter fail-open
+
+- **Timestamp**: 2026-07-18 (fix/6055-flowless-cos-failopen)
+- **Action**: Follow-up to #5467/#6054. `resolve_cached_cos_tx_selection`'s
+  flowless (`flow_key == None`) arm in `afxdp/tx/cos_classify.rs` returned
+  `drop:false, reject:false, filter_log:None` WITHOUT evaluating the interface
+  `filter output` — the #5467 fix was applied only to
+  `resolve_cos_tx_selection_internal` (the non-cached `_at` path). The cached
+  arm is UNREACHABLE for enforcement today (the seed caller `flow_cache.rs`
+  always passes `Some(&key)`; `mirror/resolver.rs` reads only `.queue_id`), so
+  there is no active bypass — but it is a LATENT fail-open: a future caller
+  reading `.drop`/`.reject` from a `flow_key = None` result silently
+  reintroduces the #5467 egress-deny bypass. Fix: the cached flowless arm now
+  reconstructs the packet's own L3 tuple (`ForwardPacketMeta::from(meta)
+  .l3_addrs()`, ports forced to 0) and evaluates the output filter through the
+  SAME entry the flow-keyed cached arm uses
+  (`interface_output_filter_needs_tx_eval` +
+  `evaluate_filter_ref_tx_selection_cached`), collapsing `drop`/`reject`/
+  `filter_log`/`filter_counters`/`three_color_policers` identically — so an
+  L3-matching egress deny FAILS CLOSED at parity with `_at`. Approach:
+  consult-the-verdict (not decline-shortcut). Ports are 0 so a port-BEARING
+  term never matches (no spurious drop, #2357/#3290 preserved); the cached eval
+  applies `TermMatchExtra::default()` (per-packet-L4 terms fail closed), and the
+  flow-cache SEED path already declines caching for any per-packet-L4 filter, so
+  no such term reaches this arm. `drop` is the OUTPUT terminal action only
+  (policer runs at replay), matching the flow-keyed #3608 convention. Queue /
+  DSCP-rewrite selection untouched — enforcement ADDED only.
+- **Tests**: `cos_classify_tests.rs` — four cached-arm fail-on-revert tests
+  reusing the #5467 `flowless_v4_meta` harness: L3-only `then discard` drops (+
+  non-matching control passes), `then reject` sets drop+reject, `then log`
+  surfaces filter_log, and a port-bearing term does NOT spuriously drop a
+  port-0 flowless packet. RED-on-revert verified: gating the new eval with
+  `false &&` flips the discard/reject/log asserts RED while the port-term
+  control stays green.
+- **Validation**: `cargo build` clean; `cargo test --bin xpf-userspace-dp
+  cos_classify` green (63 passed), 5x flake check all green. Two unrelated
+  failures in the full suite (`protocol::tests::wire_invariant_default_specimens`
+  golden drift, `event_stream ... stalled_consumer` backpressure timing) confirmed
+  PRE-EXISTING on the clean base (stash-and-rerun). rev5467 MINOR 2 (`port_match`
+  not gated on `l4_present`) left as a tracked follow-up — fail-CLOSED,
+  pre-existing on both input (#3291) and this output flowless path.
+- **File(s)**: userspace-dp/src/afxdp/tx/cos_classify.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md
+
 ## 2026-07-18 — #5445: per-packet SessionLookup must not clone the policy_counter Arc
 
 - **Timestamp**: 2026-07-18 (fix/5445-session-metadata-clone)

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -420,6 +420,33 @@ sync.
     keeps the reject reply gated on a real L4 flow — but the packet is still
     dropped, and when a `then log` term matched, the filter-log event is
     attributed via the L3-only flow (`frame::l3_session_flow_from_meta`).
+  - **#6055 — cached flowless TX arm brought to #5467 parity (latent
+    fail-open closed):** the #5467 fix above landed only on
+    `resolve_cos_tx_selection_internal` (the non-cached `_at`/queue-id path).
+    Its sibling `resolve_cached_cos_tx_selection` (the flow-cache SEED / mirror
+    descriptor builder, `afxdp/tx/cos_classify.rs`) kept a flowless
+    (`flow_key = None`) arm that returned `drop:false, reject:false,
+    filter_log:None` WITHOUT evaluating the output filter. That arm is
+    UNREACHABLE for enforcement today (the seed caller always passes
+    `Some(&key)`; the mirror caller reads only `.queue_id`), so there is no
+    active bypass — but any future caller reading `.drop`/`.reject` from a
+    `flow_key = None` result would silently reintroduce the #5467 fail-open.
+    The cached flowless arm now evaluates the output filter through the SAME
+    entry the flow-keyed cached arm uses
+    (`interface_output_filter_needs_tx_eval` +
+    `evaluate_filter_ref_tx_selection_cached`, ports forced to 0) and collapses
+    `drop`/`reject`/`filter_log` identically, so an L3-matching egress deny
+    FAILS CLOSED at parity with `_at`. The cached eval applies
+    `TermMatchExtra::default()` (every per-packet-L4 term fails closed); the
+    flow-cache SEED path already declines caching for any filter carrying such
+    a term (`interface_output_filter_has_per_packet_l4_match`,
+    `afxdp/flow_cache.rs`), so no per-packet-L4 output term ever reaches this
+    arm. The `drop` bit is the OUTPUT terminal action only (a three-color
+    policer runs at replay via `apply_cached_three_color_policers`), matching
+    the flow-keyed arm's #3608 convention. rev5467 MINOR 2 (`port_match` not
+    gated on `l4_present`, an over-block that is fail-CLOSED and pre-existing on
+    both the #3291 input and this output flowless path) is left as a tracked
+    follow-up.
   - **#5690 — generic embedded-ICMP NAT reversal on the flowless arm:** an
     inbound non-query ICMP error (Time-Exceeded, Dest-Unreachable, PTB,
     Parameter-Problem, Redirect) referencing a NAT'd flow is itself FLOWLESS

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -135,14 +135,88 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
                 meta.ingress_vlan_present != 0,
             )
         });
+        // #6055: bring this cached flowless arm to PARITY with the #5467 fix on
+        // `resolve_cos_tx_selection_internal`'s flowless arm. Before this gate the
+        // cached flowless arm returned `drop:false, reject:false, filter_log:None`
+        // WITHOUT ever evaluating the interface `filter output` — a LATENT
+        // fail-open: any caller that reads `.drop`/`.reject` from a `flow_key=None`
+        // result (a future seed/mirror refactor) would silently wave a
+        // would-be-dropped flowless packet (a non-first IP fragment / non-query
+        // ICMP error/control packet, #2344/#3290) past an egress `then discard`/
+        // `reject` term. Evaluate the output filter against the packet's own L3
+        // tuple (src/dst/protocol from `meta`; L4 ports forced to 0 since the
+        // header is absent) and honor the drop/reject/log verdict exactly as the
+        // flow-keyed arm below does, so an L3-matching deny FAILS CLOSED.
+        //
+        // Uses the cache-replay eval (`evaluate_filter_ref_tx_selection_cached`)
+        // the flow-keyed arm uses — it captures `then count`/policer handles into
+        // the descriptor and applies `TermMatchExtra::default()`, which fails
+        // every per-packet-L4 term (tcp-flags/icmp-type/icmp-code/is-fragment/
+        // flex) closed. The flow-cache SEED path already DECLINES caching for a
+        // filter carrying such a term (`interface_output_filter_has_per_packet_l4_match`,
+        // flow_cache.rs), so no per-packet-L4 output term reaches this arm; only
+        // an L3-only (`from source-address`/`destination-address`/`protocol`/bare
+        // `then`) term takes effect, matching the #5467 flowless contract. Ports
+        // are 0, so a port-BEARING term never matches (no spurious drop). The
+        // `drop` bit is the OUTPUT filter's terminal action only (a three-color
+        // policer runs at replay via `apply_cached_three_color_policers`),
+        // identical to the flow-keyed arm's #3608 convention.
+        let is_v6 = meta.addr_family as i32 == libc::AF_INET6;
+        let mut drop = false;
+        let mut reject = false;
+        let mut filter_log = None;
+        let mut filter_counters = crate::filter::CachedFilterCounters::default();
+        let mut three_color_policers = crate::filter::CachedThreeColorPolicers::default();
+        if crate::filter::interface_output_filter_needs_tx_eval(
+            &forwarding.filter_state,
+            egress_ifindex,
+            is_v6,
+        ) && let Some((src_ip, dst_ip)) = ForwardPacketMeta::from(meta).l3_addrs()
+        {
+            let output_filter = if is_v6 {
+                forwarding
+                    .filter_state
+                    .iface_filter_out_v6_fast
+                    .get(&egress_ifindex)
+                    .map(Arc::as_ref)
+            } else {
+                forwarding
+                    .filter_state
+                    .iface_filter_out_v4_fast
+                    .get(&egress_ifindex)
+                    .map(Arc::as_ref)
+            };
+            if let Some(output_filter) = output_filter.filter(|filter| {
+                filter.affects_tx_selection
+                    || filter.has_counter_terms
+                    || filter.has_log_terms
+                    || filter.has_terminal_action_terms
+                    || filter.has_three_color_policer_terms
+            }) {
+                let output_result = crate::filter::evaluate_filter_ref_tx_selection_cached(
+                    output_filter,
+                    src_ip,
+                    dst_ip,
+                    meta.protocol,
+                    0,
+                    0,
+                    meta.dscp,
+                );
+                drop = output_result.action != crate::filter::FilterAction::Accept;
+                reject = output_result.action == crate::filter::FilterAction::Reject;
+                filter_log = output_result.log_match;
+                filter_counters = output_result.counters;
+                three_color_policers = output_result.three_color_policers;
+            }
+        }
         return CachedTxSelectionDescriptor {
             queue_id,
             dscp_rewrite,
-            drop: false,
-            reject: false,
-            filter_counters: crate::filter::CachedFilterCounters::default(),
-            three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
-            filter_log: None,
+            drop,
+            reject,
+            filter_counters,
+            three_color_policers,
+            filter_log,
             // Flowless packets are re-resolved per packet (no cache entry),
             // so there is nothing to mark for hit-path re-classification.
             ba_reclassify: false,

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -1989,6 +1989,182 @@ fn resolve_cos_tx_selection_flowless_port_term_does_not_spuriously_drop() {
 }
 
 #[test]
+fn resolve_cached_cos_tx_selection_flowless_enforces_output_discard() {
+    // #6055 RED-on-revert: the CACHED flowless arm (`resolve_cached_cos_tx_selection`
+    // with flow_key = None) must honor an interface output `then discard` term
+    // against a flowless packet's L3 tuple, exactly like the #5467 fix on the
+    // non-cached `_at` arm. Before this fix the cached flowless arm returned
+    // drop:false WITHOUT evaluating the output filter at all — a LATENT
+    // fail-open. Reverting the hardening back to an unconditional `drop: false`
+    // makes the `matched.drop` assertion below FAIL.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-drop-l3".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop-l3".into(),
+            family: "inet".into(),
+            // L3-only term (address + protocol, NO ports) so it matches a
+            // flowless packet whose L4 ports are absent (0).
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-host".into(),
+                destination_addresses: vec!["172.16.80.200/32".into()],
+                destination_constrained: true,
+                protocols: vec!["tcp".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    // Flowless packet whose L3 dst MATCHES the deny term → must fail closed.
+    let matched =
+        resolve_cached_cos_tx_selection(&forwarding, 202, flowless_v4_meta([172, 16, 80, 200]), None);
+    assert!(
+        matched.drop,
+        "#6055: a flowless cached-arm packet matching an output `then discard` \
+         term must drop (not fail open)"
+    );
+    assert!(!matched.reject, "then discard is a silent drop, not a reject");
+    assert_eq!(matched.filter_log, None);
+
+    // Control: a flowless packet that does NOT match any deny term still
+    // egresses (pass-through unchanged, #2357/#3290 preserved).
+    let unmatched =
+        resolve_cached_cos_tx_selection(&forwarding, 202, flowless_v4_meta([172, 16, 80, 201]), None);
+    assert!(
+        !unmatched.drop,
+        "#6055: a flowless cached-arm packet not matching any deny term must NOT drop"
+    );
+}
+
+#[test]
+fn resolve_cached_cos_tx_selection_flowless_enforces_output_reject() {
+    // #6055 RED-on-revert: the cached flowless arm must set drop:true AND
+    // reject:true for a `then reject` output term (parity with #5467). A revert
+    // to the unconditional `reject: false` makes the reject assertion FAIL.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-reject-l3".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-reject-l3".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "reject-host".into(),
+                destination_addresses: vec!["172.16.80.200/32".into()],
+                destination_constrained: true,
+                protocols: vec!["tcp".into()],
+                action: "reject".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let selection =
+        resolve_cached_cos_tx_selection(&forwarding, 202, flowless_v4_meta([172, 16, 80, 200]), None);
+    assert!(selection.drop, "#6055: flowless cached `then reject` must drop");
+    assert!(
+        selection.reject,
+        "#6055: flowless cached `then reject` must set the reject flag"
+    );
+}
+
+#[test]
+fn resolve_cached_cos_tx_selection_flowless_enforces_output_log() {
+    // #6055 RED-on-revert: a flowless cached-arm packet matching an output
+    // `then log` term must surface the filter-log match (before the fix
+    // filter_log was always None on the cached flowless path — the log was
+    // silently bypassed).
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-log-l3".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-log-l3".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "log-host".into(),
+                destination_addresses: vec!["172.16.80.200/32".into()],
+                destination_constrained: true,
+                protocols: vec!["tcp".into()],
+                action: "accept".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let selection =
+        resolve_cached_cos_tx_selection(&forwarding, 202, flowless_v4_meta([172, 16, 80, 200]), None);
+    assert!(
+        selection.filter_log.is_some(),
+        "#6055: a flowless cached-arm packet matching an output `then log` term must log"
+    );
+    assert!(
+        !selection.drop,
+        "a `then accept` + log term must not drop the packet"
+    );
+}
+
+#[test]
+fn resolve_cached_cos_tx_selection_flowless_port_term_does_not_spuriously_drop() {
+    // #6055 / #2357 / #3290: the cached flowless output gate forces ports to 0,
+    // so a port-BEARING terminal term never matches a fragment — no spurious
+    // drop of legitimate flowless traffic. Guards the hardening from
+    // over-dropping.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-drop-port".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop-port".into(),
+            family: "inet".into(),
+            // Port-bearing terminal term: a flowless packet (port 0, L4 absent)
+            // must NOT match it.
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+
+    let selection =
+        resolve_cached_cos_tx_selection(&forwarding, 202, flowless_v4_meta([172, 16, 80, 200]), None);
+    assert!(
+        !selection.drop,
+        "#6055: a port-bearing output term must NOT drop a flowless (port 0) cached packet"
+    );
+}
+
+#[test]
 fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filter_exists() {
     let snapshot = ConfigSnapshot {
         interfaces: vec![


### PR DESCRIPTION
## Summary

Follow-up to #5467 (fixed in #6054). During rev5467's hostile review of #6054, MINOR 1 flagged that `resolve_cached_cos_tx_selection`'s flowless (`flow_key == None`) arm in `userspace-dp/src/afxdp/tx/cos_classify.rs` returned `drop:false, reject:false, filter_log:None` **without ever evaluating the interface `filter output`** — the #5467 fix landed only on `resolve_cos_tx_selection_internal` (the non-cached `_at` path), leaving this cached sibling asymmetric.

The arm is **unreachable for enforcement today** (the flow-cache SEED caller `flow_cache.rs` always passes `Some(&key)`; `mirror/resolver.rs` reads only `.queue_id`), so there is no active bypass. But it is a **latent fail-open**: any future caller reading `.drop`/`.reject` from a `flow_key = None` result silently reintroduces the #5467 egress-deny bypass on a flowless packet (a non-first IP fragment / non-query ICMP error, #2344/#3290).

## Approach — consult-the-verdict (parity), not decline-shortcut

The output-filter drop/reject verdict **is** available at the flowless arm, so the fix brings it to parity with the flow-keyed arm rather than declining the shortcut:

- Reconstruct the packet's own L3 tuple (`ForwardPacketMeta::from(meta).l3_addrs()`, ports forced to 0).
- Evaluate the output filter through the **same entry** the flow-keyed cached arm uses (`interface_output_filter_needs_tx_eval` + `evaluate_filter_ref_tx_selection_cached`), collapsing `drop`/`reject`/`filter_log`/`filter_counters`/`three_color_policers` identically.
- An L3-matching egress deny now **FAILS CLOSED**.

Ports are 0, so a port-bearing term never matches (no spurious drop — #2357/#3290 preserved). The cached eval applies `TermMatchExtra::default()` (per-packet-L4 terms fail closed), and the SEED path already declines caching for any per-packet-L4 filter, so no such term reaches this arm. `drop` is the OUTPUT terminal action only (a three-color policer runs at replay), matching the flow-keyed #3608 convention. Queue / DSCP-rewrite selection is untouched — enforcement is **added only**.

The flow-keyed arm and the #5467 `_at` behavior are unchanged.

**MINOR 2** (rev5467: `port_match` not gated on `l4_present`) is left as a tracked follow-up — it is fail-CLOSED (over-block, safe direction) and pre-existing on both the #3291 input and this output flowless path.

## Testing

Four cached-arm fail-on-revert tests reuse the #5467 `flowless_v4_meta` harness:
- L3-only `then discard` → `drop:true` (+ non-matching control still egresses)
- `then reject` → `drop:true` **and** `reject:true`
- `then log` → `filter_log` surfaced
- port-bearing term → does **not** spuriously drop a port-0 flowless packet

**RED-on-revert verified**: gating the new eval with `false &&` flips the discard/reject/log asserts RED while the port-term control stays green.

`cargo build` clean; `cargo test --bin xpf-userspace-dp cos_classify` green (63 passed); 5× flake check all green. Two unrelated full-suite failures (`protocol::tests::wire_invariant_default_specimens` golden drift, `event_stream ... stalled_consumer` backpressure timing) confirmed **pre-existing on the clean base** via stash-and-rerun.

Docs: extended the #5467 flowless-TX note in `userspace-dp/src/afxdp/README.md` with the #6055 hardening; `_Log.md` updated.

Closes #6055

🤖 Generated with [Claude Code](https://claude.com/claude-code)