### PR TITLE
fairness: retire vanished queue identities in throughput window

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-18 — #5100: retire vanished queue identities in fairness throughput window
+
+- **Timestamp**: 2026-07-18 (fix/5100-fairness-window-retire)
+- **Action**: The collector's rolling per-queue fairness throughput window
+  (`FairnessThroughputWindow`, consumed under the collector mutex by
+  `emitFairnessThroughputGauges` in `pkg/api/metrics_userspace.go`) never
+  deleted a key from `w.queues`. The seed-all-keys loop appended an empty
+  idle-advancement sample to EVERY historical `(ifindex, queueID)` each
+  update, so a queue that vanished (interface removal / ifindex churn / test
+  namespaces) never drained on its own and lingered for the process lifetime
+  — unbounded memory plus an ever-growing per-scrape seed+sort of the full
+  historical key slice under the mutex. Fix: after `prune`, RETIRE a queue
+  that is absent from the current status AND drained (empty `bytesByFlow`,
+  `bytesByWorker`, and `starvedFlows`). Added `currentQueues` (the identities
+  observed in this update's `FlowWorkerMap` — the sole creator of queue
+  states) and `fairnessQueueThroughputWindow.isDrained()`; the prune loop now
+  `delete(w.queues, key)` for drained-and-absent keys. Retirement is
+  metric-invariant: the scrape already skips queues with empty `bytesByFlow`,
+  so a retired queue produced no gauge sample anyway; a still-active queue is
+  never retired (its window samples keep `bytesByFlow` non-empty); a retired
+  identity that reappears re-registers cleanly via `queueState` with a fresh
+  baseline. Retention is now bounded by currently-observed identities plus one
+  window of recently-active ones.
+- **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`,
+  `pkg/dataplane/userspace/fairness_throughput_test.go`,
+  `docs/cos-traffic-shaping.md`, `_Log.md`
+- **Validation**: `go build`, `go vet`, `go test ./pkg/dataplane/userspace/`
+  (full package green, 14.6s); fairness subset `-count=5` no flakes. New
+  `TestFairnessThroughputWindowRetiresVanishedQueueIdentity` (fail-on-revert:
+  neutralizing the `delete` leaves the vanished key present → FAIL) and
+  `TestFairnessThroughputWindowBoundsMemoryUnderQueueChurn` (200 churned
+  identities → peak `w.queues` size = 2 with the fix, ~200 without).
+
 ## 2026-07-18 — #5290: fair HA session-delta drain + overflow resync latch
 
 - **Timestamp**: 2026-07-18 (fix/5290-drain-deltas-fairness)

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -1215,6 +1215,23 @@ Notes for this specific test:
   missed — and the measurement-only
   `xpf_fairness_equal_flow_unsampled_active_workers` estimator gauge
   (#1304) is unrelated to the removed cap.
+- **Fairness throughput-window retention is bounded (#5100).** The
+  collector's rolling per-queue throughput window (which feeds the
+  `xpf_fairness_saturated` / `xpf_fairness_observed_cov` /
+  `xpf_fairness_starved_flows` gauges and the equal-flow estimator, all
+  keyed by `(ifindex, queue_id)`) now RETIRES a queue identity that has
+  vanished from the current status AND holds no live telemetry — no
+  accumulated flow bytes, worker bytes, or starvation records after the
+  30 s window drains. Previously a `(ifindex, queue_id)` that disappeared
+  (interface removal / ifindex churn / test namespaces) was retained for
+  the process lifetime, so long-running systems accumulated telemetry
+  state and paid an ever-growing per-scrape seed+sort of the full
+  historical key slice under the collector mutex. Retention is now bounded
+  by currently-observed identities plus one window of recently-active
+  ones. Retirement is metric-invariant: a drained queue produces no gauge
+  sample regardless (the scrape skips empty queues), a still-active queue
+  is never retired, and a retired identity that reappears re-registers
+  cleanly with a fresh baseline.
 - `loss-priority` on CoS DSCP rewrite-rules is **enforced** (#3995): the
   userspace dataplane keys the egress DSCP rewrite on
   `(forwarding-class, loss-priority)`, so a rule that rewrites

--- a/pkg/dataplane/userspace/fairness_throughput.go
+++ b/pkg/dataplane/userspace/fairness_throughput.go
@@ -127,6 +127,11 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 		activeWorkerFlows = fairnessQueueActiveWorkerFlows(status, workerSlots)
 	}
 	seen := make(map[fairnessFlowThroughputKey]uint64)
+	// currentQueues holds the (ifindex, queueID) identities observed in
+	// THIS status. A queue state is only ever created from a FlowWorkerMap
+	// row, so this set is the authoritative "still present" signal used to
+	// decide retirement of vanished identities below.
+	currentQueues := make(map[fairnessQueueKey]struct{})
 	sampleQueues := make(map[fairnessQueueKey]struct{}, len(w.queues))
 	for queue := range w.queues {
 		sampleQueues[queue] = struct{}{}
@@ -145,6 +150,7 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 			key.tuple = row.SessionKey
 		}
 		sampleQueues[key.queue] = struct{}{}
+		currentQueues[key.queue] = struct{}{}
 		seen[key] = row.ObservedBytes
 		previous, ok := w.prev[key]
 		w.prev[key] = row.ObservedBytes
@@ -192,8 +198,26 @@ func (w *FairnessThroughputWindow) Update(now time.Time, status ProcessStatus) [
 			})
 		}
 	}
-	for _, state := range w.queues {
+	// Prune expired samples, then retire queue identities that have
+	// vanished from the current status AND hold no live telemetry. Without
+	// this, a (ifindex, queueID) that disappears (interface removal /
+	// ifindex churn) lingers for the process lifetime: the seed-all-keys
+	// loop above keeps appending empty idle-advancement samples to it every
+	// update, so its state never drains on its own, and every scrape below
+	// re-seeds and re-sorts the full historical key slice under the
+	// collector mutex. Retiring drained-and-absent keys bounds both the
+	// memory and the per-scrape cost to currently-observed identities plus
+	// one window of recently-active ones. Retirement cannot change scrape
+	// output: a drained queue (empty bytesByFlow) is skipped by the summary
+	// loop below regardless. A retired key that reappears re-registers
+	// cleanly via queueState with a fresh baseline (its w.prev flow entries
+	// were cleared the same update it vanished, so the first post-reappearance
+	// delta is measured exactly like any first observation).
+	for key, state := range w.queues {
 		state.prune(now.Add(-w.window))
+		if _, current := currentQueues[key]; !current && state.isDrained() {
+			delete(w.queues, key)
+		}
 	}
 
 	keys := make([]fairnessQueueKey, 0, len(w.queues))
@@ -260,6 +284,19 @@ func (q *fairnessQueueThroughputWindow) addSample(sample fairnessThroughputSampl
 	for workerID, delta := range sample.workerDeltas {
 		q.bytesByWorker[workerID] += delta
 	}
+}
+
+// isDrained reports whether the queue window holds no live telemetry:
+// no accumulated flow bytes, worker bytes, or starvation records. A
+// drained queue's remaining samples slice can only contain empty
+// idle-advancement entries, which contribute nothing to any summary
+// (the scrape skips queues whose bytesByFlow is empty). Callers retire a
+// drained queue that is also absent from the current active set so
+// vanished identities do not accumulate for the process lifetime.
+func (q *fairnessQueueThroughputWindow) isDrained() bool {
+	return len(q.bytesByFlow) == 0 &&
+		len(q.bytesByWorker) == 0 &&
+		len(q.starvedFlows) == 0
 }
 
 func (q *fairnessQueueThroughputWindow) prune(cutoff time.Time) {

--- a/pkg/dataplane/userspace/fairness_throughput_test.go
+++ b/pkg/dataplane/userspace/fairness_throughput_test.go
@@ -434,6 +434,160 @@ func TestFairnessThroughputWindowEqualFlowEstimateCapsWorkerIDs(t *testing.T) {
 	}
 }
 
+// TestFairnessThroughputWindowRetiresVanishedQueueIdentity asserts that a
+// (ifindex, queueID) that disappears from the status and then idles past the
+// rolling window is DELETED from w.queues (retired), while a still-active
+// queue is retained. Without retirement the vanished key lingers for the
+// process lifetime: the seed-all-keys idle-advancement loop keeps appending
+// empty samples to it, so its state never drains on its own, and every scrape
+// re-seeds and re-sorts the full historical key slice. Reverting the
+// retirement leaves the vanished key present and fails this test.
+func TestFairnessThroughputWindowRetiresVanishedQueueIdentity(t *testing.T) {
+	window := NewFairnessThroughputWindow(15 * time.Second)
+	now := time.Unix(100, 0)
+	qA := uint8(4)
+	qB := uint8(5)
+	keyA := fairnessQueueKey{ifindex: 80, queueID: qA}
+	keyB := fairnessQueueKey{ifindex: 80, queueID: qB}
+
+	build := func(includeA bool, aBytes, bBytes uint64) ProcessStatus {
+		var flows []FlowWorkerStatus
+		if includeA {
+			flows = append(flows, FlowWorkerStatus{
+				EgressIfindex: 80,
+				CoSQueueID:    &qA,
+				WorkerID:      0,
+				ForwardWireKey: FlowTupleStatus{
+					AddrFamily: 2, Protocol: 6,
+					SrcIP: "10.0.0.1", DstIP: "198.51.100.1",
+					SrcPort: 10001, DstPort: 5201,
+				},
+				ObservedBytes: aBytes,
+			})
+		}
+		flows = append(flows, FlowWorkerStatus{
+			EgressIfindex: 80,
+			CoSQueueID:    &qB,
+			WorkerID:      1,
+			ForwardWireKey: FlowTupleStatus{
+				AddrFamily: 2, Protocol: 6,
+				SrcIP: "10.0.0.2", DstIP: "198.51.100.1",
+				SrcPort: 10002, DstPort: 5201,
+			},
+			ObservedBytes: bBytes,
+		})
+		return ProcessStatus{
+			Workers: 2,
+			CoSInterfaces: []CoSInterfaceStatus{{
+				Ifindex: 80,
+				Queues: []CoSQueueStatus{
+					{QueueID: int(qA), TransmitRateBytes: 500},
+					{QueueID: int(qB), TransmitRateBytes: 500},
+				},
+			}},
+			FlowWorkerMap: flows,
+		}
+	}
+
+	// Baseline observation (no delta yet).
+	window.Update(now, build(true, 1_000, 1_000))
+	// Both queues take a real sample and register in w.queues.
+	window.Update(now.Add(10*time.Second), build(true, 6_000, 6_000))
+	if _, ok := window.queues[keyA]; !ok {
+		t.Fatalf("queue A missing after active sample")
+	}
+	if _, ok := window.queues[keyB]; !ok {
+		t.Fatalf("queue B missing after active sample")
+	}
+
+	// Queue A vanishes from the status but its last sample is still inside
+	// the window: it must be RETAINED (recently active), not retired.
+	window.Update(now.Add(20*time.Second), build(false, 0, 11_000))
+	if _, ok := window.queues[keyA]; !ok {
+		t.Fatalf("queue A retired while still inside the rolling window")
+	}
+
+	// Advance well past the window with A still absent. A's real sample ages
+	// out, draining its state; A is absent from the active set and must be
+	// retired. B stays active and must be retained.
+	got := window.Update(now.Add(100*time.Second), build(false, 0, 16_000))
+	if _, ok := window.queues[keyA]; ok {
+		t.Fatalf("vanished queue A not retired from w.queues after idling past the window")
+	}
+	if _, ok := window.queues[keyB]; !ok {
+		t.Fatalf("active queue B was retired")
+	}
+
+	// Correctness preserved: the retired queue emits no summary, the active
+	// one still does.
+	for _, summary := range got {
+		if summary.QueueID == qA {
+			t.Fatalf("retired queue A still produced a summary: %+v", summary)
+		}
+	}
+	sawB := false
+	for _, summary := range got {
+		if summary.QueueID == qB {
+			sawB = true
+		}
+	}
+	if !sawB {
+		t.Fatalf("active queue B produced no summary: %+v", got)
+	}
+
+	// A retired key that reappears re-registers cleanly with a fresh
+	// baseline (one update to seed w.prev, the next measures a delta).
+	window.Update(now.Add(110*time.Second), build(true, 21_000, 21_000))
+	window.Update(now.Add(120*time.Second), build(true, 26_000, 26_000))
+	if _, ok := window.queues[keyA]; !ok {
+		t.Fatalf("queue A did not re-register after reappearing")
+	}
+}
+
+// TestFairnessThroughputWindowBoundsMemoryUnderQueueChurn drives a long run
+// where a fresh (ifindex, queueID) appears, delivers one real sample, then
+// vanishes forever — the interface-recreation / ifindex-churn pattern from
+// the bug report. With retirement, w.queues is bounded by the active queue
+// plus the handful still inside the rolling window; without it, every churned
+// identity accumulates for the process lifetime (hundreds here).
+func TestFairnessThroughputWindowBoundsMemoryUnderQueueChurn(t *testing.T) {
+	window := NewFairnessThroughputWindow(15 * time.Second)
+	base := time.Unix(100, 0)
+	q := uint8(0)
+	maxSeen := 0
+	// Each identity spans two updates: a baseline observation then a real
+	// delta sample, after which a new ifindex takes over and it never returns.
+	for j := 0; j < 400; j++ {
+		ifindex := 2_000 + j/2
+		observed := uint64(1_000)
+		if j%2 == 1 {
+			observed = 6_000
+		}
+		status := ProcessStatus{
+			Workers: 1,
+			FlowWorkerMap: []FlowWorkerStatus{{
+				EgressIfindex: ifindex,
+				CoSQueueID:    &q,
+				WorkerID:      0,
+				ForwardWireKey: FlowTupleStatus{
+					AddrFamily: 2, Protocol: 6,
+					SrcIP: "10.0.0.1", DstIP: "198.51.100.1",
+					SrcPort: 10001, DstPort: 5201,
+				},
+				ObservedBytes: observed,
+			}},
+		}
+		window.Update(base.Add(time.Duration(j)*10*time.Second), status)
+		if n := len(window.queues); n > maxSeen {
+			maxSeen = n
+		}
+	}
+	t.Logf("peak w.queues size under churn = %d (200 distinct identities churned)", maxSeen)
+	if maxSeen > 8 {
+		t.Fatalf("w.queues grew to %d identities under churn; retirement is not bounding memory", maxSeen)
+	}
+}
+
 func throughputStatus(queueID uint8, firstBytes uint64, secondBytes uint64) ProcessStatus {
 	return ProcessStatus{
 		Workers: 2,


### PR DESCRIPTION
## Problem (#5100)

The collector's rolling per-queue fairness throughput window
(`FairnessThroughputWindow` in `pkg/dataplane/userspace/fairness_throughput.go`,
driven under the collector mutex by `emitFairnessThroughputGauges` in
`pkg/api/metrics_userspace.go`) never deleted a key from `w.queues`. The
seed-all-keys loop appends an empty idle-advancement sample to **every**
historical `(ifindex, queueID)` on each update, so a queue that vanishes
(interface removal / ifindex churn / transient test namespaces) never drains
on its own and is retained for the process lifetime → unbounded memory plus an
ever-growing per-scrape seed+sort of the full historical key slice **under the
collector mutex**.

## Fix

Retire a queue identity that is **absent from the current status AND drained**.
After `prune`, delete a queue whose `bytesByFlow`, `bytesByWorker`, and
`starvedFlows` are all empty and whose key did not appear in this update's
`FlowWorkerMap` (the sole creator of queue states, tracked in a new
`currentQueues` set). A new `isDrained()` helper encapsulates the empty-content
test. Retention is now bounded by currently-observed identities plus one window
of recently-active ones.

**Metric-invariant.** The scrape loop already skips a queue with empty
`bytesByFlow`, so a drained queue produced no gauge sample before retirement
either. A still-active queue keeps non-empty `bytesByFlow` within the window and
is never retired. A retired identity that reappears re-registers cleanly via
`queueState` with a fresh baseline.

## Validation

- `go build`, `go vet`, `go test ./pkg/dataplane/userspace/` — full package
  green (14.6s); fairness subset `-count=5` no flakes.
- **Fail-on-revert:** `TestFairnessThroughputWindowRetiresVanishedQueueIdentity`
  — neutralizing the `delete` leaves the vanished key present → FAIL (verified).
- **Bound guard:** `TestFairnessThroughputWindowBoundsMemoryUnderQueueChurn`
  churns 200 distinct identities; peak `w.queues` size = **2** with the fix,
  ~200 without.
- Docs: `docs/cos-traffic-shaping.md` (measurement-only fairness gauge block) +
  `_Log.md`.

Closes #5100

🤖 Generated with [Claude Code](https://claude.com/claude-code)