### PR TITLE
nat: mint occupancy token on deterministic CGNAT address-only branch

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -52256,3 +52256,40 @@ top.
   pkg/config/compiler_uniformgates.go, pkg/config/compiler_peer_effective_snat.go,
   pkg/config/compiler_nat_source_pool_aggregate_5877_test.go,
   docs/config-schema.md, _Log.md
+
+## 2026-07-18 — #5341: deterministic-CGNAT address-only occupancy token
+
+- **Timestamp**: 2026-07-18
+- **Action**: Fixed the un-tokened deterministic-CGNAT (mode 1) address-only
+  sub-branch — follow-up to #5336's round-robin/persistent #5269 fix. A REAL
+  address-only flow (`port no-translation` on a port-bearing protocol, or a
+  port-less protocol) on a deterministic pool now mints the SAME
+  reverse-identity occupancy token via `PortAllocator::reserve_address_only`,
+  so two subscribers sharing one deterministic external address (same preserved
+  source port + remote) can no longer both receive the identical public reverse
+  tuple the 1:N index cannot disambiguate — the second collides and fails
+  closed as exhaustion, mirroring #5336 exactly. The synthetic tuple-unknown
+  wrapper still mints no token (never a framed flow). The token is freed by the
+  SAME teardown path (`release_source_nat_allocation` → `release_flow`) as the
+  round-robin branch — no new release site, no leak, no double-free.
+- **Scope note**: only ONE site needed the fix. `SourceNatRule` carries only
+  `deterministic_v4`; deterministic v6 (mode 2 / NAPT64) is the NAT64 path
+  (`allocate_nat64_pool_port_deterministic_v6`), which is ALWAYS PAT (returns
+  `(Ipv4Addr, u16)`, always sets `rewrite_src_port`) and has no address-only
+  sub-branch — no token gap there.
+- **Docs**: the #5269/#5336 occupancy-token invariant is documented in the
+  `source.rs`/`allocator.rs` code comments, not the FEATURES.md `nat.rs`
+  config-surface row, so the doc contract for this change is the inline
+  comments — updated the deterministic branch lead comment + added the #5341
+  mint block.
+- **Tests**: `deterministic_cgnat_no_translation_collision_denies_second_flow_5341`
+  (fail-on-revert: A mints token, B collides → exhaustion),
+  `deterministic_cgnat_no_translation_token_released_on_teardown_5341`
+  (release-on-close: token freed, B then succeeds),
+  `deterministic_cgnat_no_translation_distinct_remote_both_succeed_5341`
+  (disambiguation: distinct remotes → distinct reverse identities coexist on
+  one deterministic address). Reverting the mint turns all 3 RED (verified).
+- **Validation**: cargo build clean; `cargo test --bin xpf-userspace-dp nat::`
+  253 passed / 0 failed; new tests 5x flake check all green.
+- **File(s)**: userspace-dp/src/nat/source.rs,
+  userspace-dp/src/nat/tests_pool.rs, _Log.md

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -1279,10 +1279,13 @@ pub(crate) fn match_source_nat_result_for_tuple(
                 // IPv4 fixes both the external pool address and the port block, so
                 // no per-flow log is needed to reverse (external IP, port) back to
                 // the subscriber. Address-only cases (port-less / no-translation /
-                // tuple-unknown) still pick the DETERMINISTIC external address; the
-                // PAT case additionally allocates a port inside the subscriber's
-                // fixed block. An out-of-range subscriber fails closed rather than
-                // silently round-robining.
+                // tuple-unknown) still pick the DETERMINISTIC external address; a
+                // REAL address-only flow additionally mints a reverse-identity
+                // occupancy token so a colliding second flow fails closed (#5341,
+                // mirroring the round-robin/persistent #5269/#5336 fix), while the
+                // synthetic tuple-unknown wrapper mints none. The PAT case allocates
+                // a port inside the subscriber's fixed block. An out-of-range
+                // subscriber fails closed rather than silently round-robining.
                 if let Some(det) = rule.deterministic_v4 {
                     if address_only {
                         let Some((ip_idx, _)) = deterministic_indices_v4(&det, src_v4) else {
@@ -1298,25 +1301,70 @@ pub(crate) fn match_source_nat_result_for_tuple(
                             ));
                         }
                         let pool_addr = rule.pool_addresses_v4[ip_idx];
-                        let port = if tuple_unknown && !rule.no_translation {
-                            match rule.pool_allocator.try_next_port(ip_idx) {
-                                Ok(port) => Some(port),
-                                Err(reason) => {
-                                    return SourceNatLookup::Unavailable(
-                                        SourceNatFailure::for_rule(rule, reason),
-                                    );
+                        if tuple_unknown {
+                            // Synthetic address-only wrapper (protocol == 0, never
+                            // a framed packet): keep the historical round-robin port
+                            // for the non-no-translation case, or preserve (None)
+                            // for no-translation. No occupancy token — there is no
+                            // real flow / reverse session entry to disambiguate and
+                            // the returned port is never written to a frame.
+                            // Symmetric with the round-robin/persistent branch
+                            // below (#5269).
+                            let port = if rule.no_translation {
+                                None
+                            } else {
+                                match rule.pool_allocator.try_next_port(ip_idx) {
+                                    Ok(port) => Some(port),
+                                    Err(reason) => {
+                                        return SourceNatLookup::Unavailable(
+                                            SourceNatFailure::for_rule(rule, reason),
+                                        );
+                                    }
                                 }
+                            };
+                            return SourceNatLookup::Matched(NatDecision {
+                                rewrite_src: Some(IpAddr::V4(pool_addr)),
+                                rewrite_dst: None,
+                                rewrite_src_port: port,
+                                rewrite_dst_port: None,
+                                ..NatDecision::default()
+                            });
+                        }
+                        // #5341: a REAL address-only flow on a DETERMINISTIC-CGNAT
+                        // (mode 1) pool — `port no-translation` on a port-bearing
+                        // protocol, or a port-less protocol (GRE/ESP/...). Like the
+                        // round-robin/persistent branch (#5269, fixed in #5336),
+                        // mint a reverse-identity occupancy token on the chosen
+                        // DETERMINISTIC external address so a second flow that would
+                        // collide on the SAME public reverse tuple (two subscribers
+                        // sharing one deterministic pool address, same preserved
+                        // source port, same remote) is DENIED as exhaustion instead
+                        // of receiving an unowned duplicate the reverse (1:N) index
+                        // cannot disambiguate. The wire packet keeps its own source
+                        // port (rewrite_src_port left None — checksum.rs preserves
+                        // it; the port-less frame rewriter is gated on
+                        // `has_l4_ports`). The token is freed by the SAME teardown
+                        // path (`release_source_nat_allocation` -> `release_flow`)
+                        // as the round-robin branch — no new release site, no leak.
+                        match rule
+                            .pool_allocator
+                            .reserve_address_only(flow, IpAddr::V4(pool_addr))
+                        {
+                            Ok(translated) => {
+                                return SourceNatLookup::Matched(NatDecision {
+                                    rewrite_src: Some(translated.ip),
+                                    rewrite_dst: None,
+                                    rewrite_src_port: None,
+                                    rewrite_dst_port: None,
+                                    ..NatDecision::default()
+                                });
                             }
-                        } else {
-                            None
-                        };
-                        return SourceNatLookup::Matched(NatDecision {
-                            rewrite_src: Some(IpAddr::V4(pool_addr)),
-                            rewrite_dst: None,
-                            rewrite_src_port: port,
-                            rewrite_dst_port: None,
-                            ..NatDecision::default()
-                        });
+                            Err(reason) => {
+                                return SourceNatLookup::Unavailable(
+                                    SourceNatFailure::for_rule(rule, reason),
+                                );
+                            }
+                        }
                     }
                     let translated = match rule.pool_allocator.allocate_deterministic_v4(
                         flow,

--- a/userspace-dp/src/nat/tests_pool.rs
+++ b/userspace-dp/src/nat/tests_pool.rs
@@ -3992,6 +3992,223 @@ fn deterministic_cgnat_v4_fixed_block_per_subscriber_reversible() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #5341: address-only occupancy tokens on the DETERMINISTIC-CGNAT (mode 1)
+// address-only sub-branch.
+//
+// Follow-up to #5336, which minted the #5269 reverse-identity occupancy token
+// on the ROUND-ROBIN/persistent address-only branch. The deterministic-CGNAT
+// (mode 1) `port no-translation` / port-less sub-branch was left UN-tokened: it
+// selected the deterministic external address and returned without claiming the
+// translated reverse identity, so two subscribers sharing one deterministic
+// pool address (same preserved source port + remote) both received the SAME
+// public tuple the reverse (1:N) index cannot disambiguate — the same #5269
+// collision class. The deterministic branch now mints the SAME token (same
+// `reserve_address_only` allocator API, same reservation semantics, freed by
+// the SAME teardown path), closing the gap.
+//
+// blocks_per_ip = 126 (from the #4559 test): sub_idx / 126 = ip_idx, so
+// subscribers 100.64.0.5 (sub_idx 5) and 100.64.0.6 (sub_idx 6) BOTH map to
+// ip_idx 0 -> pool[0] = 203.0.113.1, and collide when they share a preserved
+// source port + remote. 100.64.1.0 (sub_idx 256) maps to ip_idx 2 -> pool[2].
+// ---------------------------------------------------------------------------
+
+fn deterministic_notrans_rule() -> Vec<SourceNatRule> {
+    let host_base = u32::from(Ipv4Addr::new(100, 64, 0, 0));
+    parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "cgnat-notrans".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["100.64.0.0/22".to_string()],
+        pool_name: "cgn-pool".to_string(),
+        pool_addresses: vec![
+            "203.0.113.1/32".to_string(),
+            "203.0.113.2/32".to_string(),
+            "203.0.113.3/32".to_string(),
+            "203.0.113.4/32".to_string(),
+        ],
+        port_low: 1024,
+        port_high: 65535,
+        // `port no-translation` — the source port is PRESERVED, so this is a
+        // REAL address-only flow, not the PAT case.
+        pool_no_translation: true,
+        deterministic_mode: 1,
+        deterministic_block_size: 512,
+        deterministic_blocks_per_ip: 126,
+        deterministic_host_base: host_base,
+        deterministic_host_count: 1024,
+        ..SourceNATRuleSnapshot::default()
+    }])
+}
+
+// #5341 FAIL-ON-REVERT: deterministic-CGNAT pool with `port no-translation`.
+// Subscriber A (100.64.0.5) and subscriber B (100.64.0.6) BOTH map to the same
+// deterministic external address (203.0.113.1). With the same preserved source
+// port + remote they collide on the identical public reverse tuple. A gets the
+// tuple AND an occupancy token; B MUST be denied as exhaustion. Reverting the
+// `reserve_address_only` mint makes B return `Matched` with A's rewrite_src and
+// `rewrite_src_port: None` — an unowned duplicate — turning the `Unavailable`
+// assertion RED. The deterministic rule must be built (gating assertion) so the
+// tested sub-branch is actually the deterministic one.
+#[test]
+fn deterministic_cgnat_no_translation_collision_denies_second_flow_5341() {
+    let rules = deterministic_notrans_rule();
+    assert!(
+        rules[0].deterministic_v4.is_some(),
+        "mode-1 deterministic no-translation snapshot must build a deterministic rule"
+    );
+
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "100.64.0.5",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(
+        a.rewrite_src,
+        Some("203.0.113.1".parse().unwrap()),
+        "subscriber A must translate to its deterministic external address"
+    );
+    // Wire contract (unchanged): `no-translation` PRESERVES the source port.
+    assert_eq!(a.rewrite_src_port, None);
+
+    // The deterministic branch minted exactly one reverse-identity token,
+    // resolving the public tuple to EXACTLY flow A.
+    let flow_a = SourceNatFlowKey {
+        protocol: PROTO_TCP,
+        src_ip: "100.64.0.5".parse().unwrap(),
+        dst_ip: "8.8.8.8".parse().unwrap(),
+        src_port: 12345,
+        dst_port: 443,
+    };
+    let owners = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(
+        owners.len(),
+        1,
+        "deterministic address-only flow A must mint exactly one occupancy token"
+    );
+    assert_eq!(owners[0].1, flow_a, "reverse index must resolve to flow A");
+    assert_eq!(
+        owners[0].0.translated_ip,
+        "203.0.113.1".parse::<IpAddr>().unwrap()
+    );
+    assert_eq!(owners[0].0.translated_port, 12345);
+
+    // Flow B: DIFFERENT subscriber that maps to the SAME deterministic address,
+    // SAME preserved port + SAME remote -> SAME public tuple. Fail closed.
+    match addr_only_lookup(&rules, "100.64.0.6", 12345, "8.8.8.8", 443, PROTO_TCP) {
+        SourceNatLookup::Unavailable(f) => assert_eq!(
+            f.reason,
+            SourceNatFailureReason::AllocatorExhausted,
+            "colliding deterministic address-only flow must fail closed as exhaustion",
+        ),
+        other => panic!("flow B must be denied (exhaustion), got {other:?}"),
+    }
+
+    // The reverse index STILL resolves uniquely to flow A — B minted nothing.
+    let owners_after = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(owners_after.len(), 1, "denied flow B must not add a token");
+    assert_eq!(owners_after[0].1, flow_a);
+
+    // No pool PORT is consumed (address-only tokens are off the port bitmap).
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].used_ports, 0);
+    assert_eq!(status[0].live_flows, 1, "only flow A is tracked");
+}
+
+// #5341: the deterministic address-only token is freed by the SAME teardown
+// path used for PAT ports (`release_source_nat_allocation`), so the colliding
+// identity becomes reusable after the first flow tears down — no leak, no
+// double-free, matching the round-robin branch's token lifecycle.
+#[test]
+fn deterministic_cgnat_no_translation_token_released_on_teardown_5341() {
+    let rules = deterministic_notrans_rule();
+
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "100.64.0.5",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(rules[0].pool_allocator.debug_address_only_owners().len(), 1);
+
+    // Tear down flow A. `release_source_nat_allocation` derives the preserved
+    // port from the flow key (the decision left `rewrite_src_port` unset) and
+    // clears the reverse-identity token.
+    let key_a = session_key_from_src("100.64.0.5", 12345, "8.8.8.8", 443);
+    release_source_nat_allocation(&rules, &key_a, a, false, 1);
+    assert_eq!(
+        rules[0].pool_allocator.debug_address_only_owners().len(),
+        0,
+        "deterministic address-only token must be freed on teardown (no leak)",
+    );
+    assert_eq!(source_nat_pool_statuses(&rules)[0].live_flows, 0);
+
+    // The previously-colliding subscriber B now succeeds (identity is free).
+    let b = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "100.64.0.6",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(b.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(rules[0].pool_allocator.debug_address_only_owners().len(), 1);
+}
+
+// #5341: two subscribers sharing the SAME deterministic external address but
+// talking to DIFFERENT remotes have DISTINCT reverse identities, so both mint
+// their own token and succeed — the token denies only a genuine collision, it
+// does not over-block. Guards against a fix that keys the token on the pool
+// address alone rather than the full reverse tuple.
+#[test]
+fn deterministic_cgnat_no_translation_distinct_remote_both_succeed_5341() {
+    let rules = deterministic_notrans_rule();
+
+    // A: 100.64.0.5 -> 8.8.8.8 (ip_idx 0 -> 203.0.113.1).
+    let a = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "100.64.0.5",
+        12345,
+        "8.8.8.8",
+        443,
+        PROTO_TCP,
+    ));
+    // B: 100.64.0.6 -> 9.9.9.9 (SAME deterministic address, DIFFERENT remote).
+    let b = expect_snat_decision(addr_only_lookup(
+        &rules,
+        "100.64.0.6",
+        12345,
+        "9.9.9.9",
+        443,
+        PROTO_TCP,
+    ));
+    assert_eq!(a.rewrite_src, Some("203.0.113.1".parse().unwrap()));
+    assert_eq!(
+        b.rewrite_src,
+        Some("203.0.113.1".parse().unwrap()),
+        "both subscribers share the deterministic address; distinct remotes keep \
+         their reverse identities distinct"
+    );
+    assert_eq!(a.rewrite_src_port, None);
+    assert_eq!(b.rewrite_src_port, None);
+
+    // Two distinct reverse-identity tokens coexist on the one pool address.
+    assert_eq!(
+        rules[0].pool_allocator.debug_address_only_owners().len(),
+        2,
+        "non-colliding deterministic address-only flows each mint their own token"
+    );
+    let status = source_nat_pool_statuses(&rules);
+    assert_eq!(status[0].used_ports, 0, "address-only tokens claim no pool port");
+    assert_eq!(status[0].live_flows, 2);
+}
+
 // #4559 companion: a pool WITHOUT the deterministic mode is unchanged — it
 // builds a non-deterministic rule (`deterministic_v4 == None`) and round-robins
 // as before. Guards the gate so the deterministic path never engages for a


### PR DESCRIPTION
## Summary

Follow-up to PR #5336 (merged), which closed the #5269 unowned-ambiguous-tuple
collision for the **round-robin/persistent** source-NAT pool address-only branch
by minting a reverse-identity occupancy token. During that hostile review, an
analogous **un-tokened** path was found in the **deterministic-CGNAT (mode 1)**
address-only sub-branch (`nat/source.rs` `match_source_nat_result_for_tuple`) and
deferred to this issue.

The deterministic address-only sub-branch selected the deterministic external
pool address and returned its `NatDecision` **without** minting a token. So
deterministic CGNAT with `port no-translation` (or a port-less protocol) was
exposed to the SAME #5269 collision: two subscribers that map to one shared
deterministic external address, using the same preserved source port to the same
remote, both received the identical public reverse tuple `(pool_addr,
preserved_port, remote)` the 1:N reverse index cannot disambiguate — so the later
flow's replies were mis-delivered under the first session.

## Fix

Replicate the #5336 pattern exactly — no new mechanism. A REAL
(non-tuple-unknown) address-only flow on a deterministic pool now mints the
**same** token via `PortAllocator::reserve_address_only(flow,
IpAddr::V4(pool_addr))`:

- a genuinely-colliding second flow is **DENIED as exhaustion** instead of handed
  an unowned duplicate;
- a non-colliding flow (distinct preserved port / pool address / remote) mints
  its own token and succeeds;
- the synthetic tuple-unknown wrapper still mints **no** token (never a framed
  flow / real session);
- the token is freed by the **SAME** teardown path
  (`release_source_nat_allocation` → `release_flow`) as the round-robin branch —
  no new release site, no leak, no double-free.

### Scope: one site only

`SourceNatRule` carries only `deterministic_v4`. Deterministic v6 (mode 2 /
NAPT64) is the NAT64 path (`allocate_nat64_pool_port_deterministic_v6`), which is
**always PAT** (returns a translated `(Ipv4Addr, u16)`, always sets
`rewrite_src_port`) and has no address-only sub-branch — no token gap there.

## Tests (fail-on-revert)

- `deterministic_cgnat_no_translation_collision_denies_second_flow_5341` — A
  mints exactly one token resolving the public tuple to A; B (same deterministic
  address + preserved port + remote) fails closed as `AllocatorExhausted`.
- `deterministic_cgnat_no_translation_token_released_on_teardown_5341` — the
  token is freed on teardown (no leak); the previously-colliding B then succeeds.
- `deterministic_cgnat_no_translation_distinct_remote_both_succeed_5341` — two
  subscribers on one deterministic address with **distinct remotes** keep
  distinct reverse identities and both coexist (no over-block).

Reverting the mint (restoring the un-tokened return) turns **all three RED**
(verified). 5× flake check on the new tests all green.

## Validation

- `cargo build` clean (pre-existing warnings only)
- `cargo test --bin xpf-userspace-dp nat::` → **253 passed / 0 failed**
- Docs: the #5269/#5336 occupancy-token invariant is documented in the
  `source.rs`/`allocator.rs` code comments (not the FEATURES.md `nat.rs`
  config-surface row), so the doc contract for this change is the updated inline
  comments; `_Log.md` updated.

Closes #5341

🤖 Generated with [Claude Code](https://claude.com/claude-code)