### PR TITLE
slowpath: reconcile live TUN MTU on day-2 config change

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-18 — #5801: day-2 slow-path TUN MTU reconcile
+
+- **Timestamp**: 2026-07-18 (fix/5801-slowpath-mtu-reconcile)
+- **Action**: The persistent slow-path reinjector (`SlowPathReinjector`) is
+  preserved across snapshot reconciles, and its TUN MTU + immutable `mtu` field
+  were programmed only at creation (#2408). A valid day-2 config raising a
+  data-interface MTU updated the accepted snapshot but NOT the live TUN, so
+  reinjected frames above the old ceiling dropped persistently (`MtuExceeded`)
+  until helper restart — the reconcile path only WARNED. Fix: give the
+  reinjector a reconcile op that reprograms the live TUN and converges its
+  state. `SharedStatus::reprogram_mtu_status` is the day-2 sibling of
+  `apply_mtu_status`: on success it advances `live_mtu` and clears `degraded`;
+  on a FAILED `SIOCSIFMTU` it KEEPS the current live MTU (the running TUN
+  retains its last-programmed value — NOT the 1500 creation fallback), marks
+  degraded, and records the error. `SlowPathReinjector::reconcile_mtu` reads the
+  live device name, calls that helper, and stores the installed MTU into the now
+  interior-mutable `mtu: AtomicI64` field so `mtu()`, `live_mtu`, and enqueue
+  admission agree. In `apply_snapshot` the preserved-reinjector branch now calls
+  the extracted `reconcile_preserved_slow_path_mtu` seam (passing
+  `slowpath::set_if_mtu`) instead of only warning — deduped per distinct desired
+  value via `last_slow_path_mtu_warned` so a steady-state reconcile loop does
+  not re-issue the ioctl.
+- **Fail-on-revert tests**: `slowpath::tests::reprogram_mtu_status_advances_on_success`,
+  `reprogram_mtu_status_keeps_live_on_failure`,
+  `reconcile_mtu_reprograms_live_tun_and_admission`, and
+  `afxdp::coordinator::reconcile::snapshot::slow_path_mtu_tests::day2_mtu_increase_reprograms_preserved_reinjector`.
+  Programmer is an injected seam (no real `SIOCSIFMTU`; unit tests run without
+  CAP_NET_ADMIN). Neutralizing the fix (reconcile → no-op, failure arm → 1500
+  fallback, wiring → warn-only) turns 3 of the 4 RED (`left: 1500, right: 9000`);
+  the success-arm companion stays green. Restored fix: `test result: ok. 4
+  passed; 0 failed`.
+- **Validation**: `cargo build` clean; `cargo test --release slowpath` →
+  `35 passed; 0 failed`; the 4 new tests green by explicit filter.
+- **File(s)**: userspace-dp/src/slowpath.rs, userspace-dp/src/slowpath_tests.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs,
+  docs/userspace-dataplane-architecture.md, _Log.md
+
 ## 2026-07-18 — #5290: fair HA session-delta drain + overflow resync latch
 
 - **Timestamp**: 2026-07-18 (fix/5290-drain-deltas-fairness)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1014,16 +1014,29 @@ A TUN device (`xpf-usp0`) for packets that need kernel processing:
     `pkg/dataplane/userspace/protocol.go` SlowPathStatus, tag-matched) and
     surface in `show ... slow path` output: a `Slow path DEGRADED: true` line,
     the live MTU, and the MTU-exceeded drop counter.
-  - **Set once at creation:** the MTU is programmed when the worker opens
+  - **Day-2 reconcile (#5801):** the MTU is programmed when the worker opens
     the TUN (first apply, i.e. `apply_snapshot`'s `preserved_slow_path ==
-    None` branch). Later reconciles preserve the running reinjector and do
-    NOT re-open the device, so a config MTU INCREASE applied while the daemon
-    is running does NOT reprogram the live TUN until the slow path is
-    recreated — a process restart, or the slow path going inactive->active.
-    First-boot jumbo configs are fully covered. When a later reconcile sees a
-    snapshot MTU different from the live TUN's creation MTU, the reconcile
-    path emits a one-shot (per distinct value) `xpf-ha:` warning so the
-    stale-until-restart window is diagnosable rather than silent.
+    None` branch). Later reconciles PRESERVE the running reinjector rather
+    than re-opening the device, so a config MTU change committed while the
+    daemon is running would leave the live TUN at its startup ceiling — the
+    accepted snapshot then advertises a jumbo MTU while reinjected frames
+    above the old ceiling drop persistently (`MtuExceeded`) until restart.
+    The reconcile path now CONVERGES the live TUN instead of only warning:
+    when `snapshot.slow_path_mtu()` differs from the preserved reinjector's
+    current `mtu()`, `apply_snapshot` calls
+    `reconcile_preserved_slow_path_mtu`, which invokes
+    `SlowPathReinjector::reconcile_mtu` to reprogram the live device via
+    `SIOCSIFMTU` and update the reinjector's `mtu()`, `live_mtu`, and enqueue
+    admission together. First-boot jumbo configs remain covered by the
+    creation branch. The reconcile is deduped per distinct desired value
+    (`last_slow_path_mtu_warned`) so a steady-state reconcile loop over an
+    unchanged snapshot does not re-issue the ioctl every tick. A failed
+    `SIOCSIFMTU` on reconcile is non-fatal and, unlike the creation path,
+    KEEPS the current live MTU (`SharedStatus::reprogram_mtu_status`; the
+    running TUN retains whatever it was last programmed with rather than
+    resetting to 1500), marks the path DEGRADED, records the error, and lets
+    the next distinct desired value retry — so `mtu()`, `live_mtu`, degraded
+    state, and admission stay in agreement after every reconcile.
 - **Reverse-path filter (#2378):** reinjected IPv4 replies arrive on the
   TUN but their reverse route still points at the real egress interface,
   so `open_tun` writes `conf/<dev>/rp_filter=0`. The kernel, however, uses

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -401,6 +401,50 @@ fn open_optional_map(
     }
 }
 
+/// #5801 day-2 slow-path MTU reconcile decision, extracted from
+/// [`apply_snapshot`] so the "reprogram the preserved TUN vs. skip" logic is
+/// unit-testable without constructing a full [`Coordinator`].
+///
+/// The reinjector is preserved across snapshot reconciles, so a config MTU
+/// change committed after startup must reprogram the RUNNING TUN — otherwise
+/// the accepted snapshot advertises a jumbo MTU while the live TUN stays at its
+/// startup ceiling and reinjected frames above it drop persistently until xpfd
+/// restart. When `desired_mtu` differs from the reinjector's current MTU this
+/// calls [`SlowPathReinjector::reconcile_mtu`] to reprogram the live device and
+/// converge `mtu()`/`live_mtu`/enqueue admission.
+///
+/// `last_acted` dedups the attempt to once per distinct desired value (as the
+/// old warn-only path did) so a steady-state reconcile loop over an unchanged
+/// snapshot does not re-issue `SIOCSIFMTU` every tick — important when a
+/// program persistently fails (the reinjector's MTU stays at the old value, so
+/// the raw `desired != mtu()` guard alone would retry on every reconcile).
+/// `programmer` is the `SIOCSIFMTU` seam (`set_if_mtu` in production; injectable
+/// in tests). Returns true when a reprogram was attempted this call.
+pub(super) fn reconcile_preserved_slow_path_mtu(
+    slow_path: &SlowPathReinjector,
+    desired_mtu: i32,
+    last_acted: &mut i32,
+    programmer: impl FnOnce(&str, i32) -> Result<(), String>,
+) -> bool {
+    if desired_mtu == slow_path.mtu() || desired_mtu == *last_acted {
+        return false;
+    }
+    let live = slow_path.reconcile_mtu(desired_mtu, programmer);
+    if live == desired_mtu {
+        eprintln!(
+            "xpf-ha: slow-path TUN MTU reconciled to {desired_mtu} after a day-2 \
+             config change (#5801); reinjected frames up to {desired_mtu} bytes \
+             are now accepted."
+        );
+    }
+    // A failed SIOCSIFMTU already logged + marked the path degraded inside
+    // reconcile_mtu, which kept the old live MTU. Record the attempted value so
+    // a steady-state reconcile loop does not re-issue the ioctl; the next
+    // DISTINCT desired value retries.
+    *last_acted = desired_mtu;
+    true
+}
+
 pub(super) fn apply_snapshot(
     coord: &mut Coordinator,
     snapshot: &ConfigSnapshot,
@@ -479,23 +523,19 @@ pub(super) fn apply_snapshot(
         .forwarding
         .store(Arc::new(coord.forwarding.clone()));
     coord.slow_path = if let Some(slow_path) = preserved_slow_path {
-        // #2408: the live TUN keeps the MTU it was created with — the
-        // preserved reinjector is NOT re-opened, so a config MTU increase
-        // applied after the daemon is running does not reprogram the running
-        // TUN until the slow path is recreated (process restart, or the slow
-        // path going inactive->active). First-boot jumbo configs ARE covered
-        // (they hit the else branch below). Warn once per distinct value so a
-        // steady-state reconcile loop does not flood.
-        let desired_mtu = snapshot.slow_path_mtu();
-        if desired_mtu != slow_path.mtu() && desired_mtu != coord.last_slow_path_mtu_warned {
-            eprintln!(
-                "xpf-ha: slow-path TUN MTU stays {} (config now wants {}); the live TUN is not reprogrammed until the slow path is recreated (xpfd restart). Reinjected frames larger than {} will drop on the slow path until then.",
-                slow_path.mtu(),
-                desired_mtu,
-                slow_path.mtu()
-            );
-            coord.last_slow_path_mtu_warned = desired_mtu;
-        }
+        // #5801: the preserved reinjector kept the MTU its TUN was created
+        // with. A day-2 config MTU change updates the accepted snapshot but
+        // NOT the live TUN unless we reprogram it here — otherwise reinjected
+        // frames above the startup ceiling drop persistently until xpfd
+        // restart. Reprogram the live TUN (and the reinjector's mtu()/
+        // live_mtu/admission) to converge, instead of only warning (#2408).
+        // First-boot jumbo configs still hit the else branch below.
+        reconcile_preserved_slow_path_mtu(
+            &slow_path,
+            snapshot.slow_path_mtu(),
+            &mut coord.last_slow_path_mtu_warned,
+            crate::slowpath::set_if_mtu,
+        );
         coord.last_slow_path_status = slow_path.status();
         Some(slow_path)
     } else {
@@ -529,4 +569,58 @@ pub(super) fn apply_snapshot(
     // never stranded behind an FD-open failure. Hand the secured FDs to
     // the bring-up phase.
     Some(fds)
+}
+
+#[cfg(test)]
+mod slow_path_mtu_tests {
+    use super::reconcile_preserved_slow_path_mtu;
+    use crate::slowpath::SlowPathReinjector;
+
+    /// #5801 fail-on-revert (WIRING): a day-2 snapshot MTU increase over a
+    /// PRESERVED reinjector must reprogram the live TUN through
+    /// `reconcile_preserved_slow_path_mtu` — the seam `apply_snapshot` calls in
+    /// place of the old warn-only branch. A SUCCEEDING programmer is injected so
+    /// no real `SIOCSIFMTU` is issued (unit tests run without CAP_NET_ADMIN);
+    /// the assertions are on the reinjector's converged state, which drives
+    /// enqueue admission. If the reconcile is reverted to warn-only, `mtu()`
+    /// stays at the 1500 startup ceiling and every assertion below fails.
+    #[test]
+    fn day2_mtu_increase_reprograms_preserved_reinjector() {
+        // Constructing the reinjector spawns a worker that tries to open the
+        // TUN; whether that open succeeds is irrelevant here — the reconcile
+        // path uses the injected programmer and asserts on mtu()/live_mtu,
+        // which are set synchronously and read lock-free.
+        let reinjector =
+            SlowPathReinjector::new("xpf-usp-wire0", 1500).expect("construct reinjector");
+        assert_eq!(reinjector.mtu(), 1500, "reinjector starts at the 1500 ceiling");
+
+        let mut last_acted = 0i32;
+        let acted =
+            reconcile_preserved_slow_path_mtu(&reinjector, 9000, &mut last_acted, |_n, _m| Ok(()));
+        assert!(acted, "a day-2 MTU rise must trigger a live-TUN reconcile");
+        assert_eq!(
+            reinjector.mtu(),
+            9000,
+            "the preserved reinjector's live MTU is reprogrammed to the new ceiling"
+        );
+        assert_eq!(
+            reinjector.status().live_mtu,
+            9000,
+            "enqueue admission (live_mtu) converges to the new ceiling"
+        );
+        assert!(
+            !reinjector.status().degraded,
+            "a successful reconcile is not degraded"
+        );
+        assert_eq!(last_acted, 9000, "the attempted value is recorded for dedup");
+
+        // A steady-state re-apply with the SAME desired value must NOT re-issue
+        // the ioctl (the programmer panics if invoked): both the `desired ==
+        // mtu()` and `desired == last_acted` guards short-circuit.
+        let acted_again =
+            reconcile_preserved_slow_path_mtu(&reinjector, 9000, &mut last_acted, |_n, _m| {
+                panic!("must not reprogram when the desired MTU is unchanged");
+            });
+        assert!(!acted_again, "an unchanged MTU must not reconcile again");
+    }
 }

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -244,6 +244,42 @@ impl SharedStatus {
         }
     }
 
+    /// Reprogram the live TUN MTU on a day-2 reconcile (#5801) and update
+    /// status, returning the live MTU now in effect.
+    ///
+    /// This is the day-2 sibling of [`Self::apply_mtu_status`]. The creation
+    /// path falls a FAILED program back to the kernel-default 1500 because the
+    /// TUN was just created at 1500. On a reconcile the running TUN already
+    /// carries whatever MTU it was last programmed with, so a failed
+    /// `SIOCSIFMTU` must KEEP the existing `live_mtu` (resetting it to 1500
+    /// would wrongly refuse frames the device can still carry). On success
+    /// `live_mtu` advances to `desired_mtu` and `degraded` clears; on failure
+    /// `live_mtu` is unchanged, `degraded` is set, and the error is recorded.
+    fn reprogram_mtu_status(
+        &self,
+        name: &str,
+        desired_mtu: i32,
+        programmer: impl FnOnce(&str, i32) -> Result<(), String>,
+    ) -> i32 {
+        match programmer(name, desired_mtu) {
+            Ok(()) => {
+                self.live_mtu.store(desired_mtu as i64, Ordering::Relaxed);
+                self.degraded.store(false, Ordering::Relaxed);
+                desired_mtu
+            }
+            Err(err) => {
+                let live = self.live_mtu.load(Ordering::Relaxed) as i32;
+                eprintln!(
+                    "xpf-slowpath: reconcile MTU {desired_mtu} on {name}: {err} \
+                     (slow-path DEGRADED: live TUN stays at {live}; frames > {live} refused)"
+                );
+                self.set_last_error(err);
+                self.degraded.store(true, Ordering::Relaxed);
+                live
+            }
+        }
+    }
+
     fn set_mode(&self, mode: &str) {
         if let Ok(mut value) = self.mode.lock() {
             *value = mode.to_string();
@@ -295,12 +331,14 @@ pub struct SlowPathReinjector {
     tx: SyncSender<PacketRequest>,
     limiter: Mutex<RateLimiter>,
     status: Arc<SharedStatus>,
-    /// MTU the slow-path TUN was programmed with at creation (#2408). The TUN
-    /// MTU is set once when the worker opens the device; a later config MTU
-    /// change is NOT applied to the live TUN (the reinjector is preserved
-    /// across reconciles), so the reconcile path compares this against the
-    /// new snapshot MTU to warn the operator (see `apply_snapshot`).
-    mtu: i32,
+    /// MTU the live slow-path TUN is currently programmed with. Set at
+    /// creation (#2408) and, on a day-2 config MTU change (#5801), updated by
+    /// [`Self::reconcile_mtu`]: the reinjector is PRESERVED across snapshot
+    /// reconciles, so a later MTU change must reprogram the RUNNING TUN and
+    /// record the new value here so `mtu()`, `live_mtu`, and enqueue admission
+    /// stay in agreement. `AtomicI64` (mirroring `SharedStatus::live_mtu`) so
+    /// `mtu()`/`reconcile_mtu` need no `&mut` on the Arc-shared reinjector.
+    mtu: AtomicI64,
 }
 
 impl SlowPathReinjector {
@@ -326,13 +364,53 @@ impl SlowPathReinjector {
                 DEFAULT_RATE_LIMIT_BYTES_PER_SEC,
             )),
             status,
-            mtu,
+            mtu: AtomicI64::new(mtu as i64),
         })
     }
 
-    /// The MTU the slow-path TUN was programmed with at creation (#2408).
+    /// The MTU the live slow-path TUN is currently programmed with. Equals the
+    /// creation MTU (#2408) until a day-2 [`Self::reconcile_mtu`] reprograms it
+    /// (#5801).
     pub fn mtu(&self) -> i32 {
-        self.mtu
+        self.mtu.load(Ordering::Relaxed) as i32
+    }
+
+    /// Reprogram the live slow-path TUN to `desired_mtu` on a day-2 config MTU
+    /// change (#5801) and return the MTU now in effect.
+    ///
+    /// The reinjector is preserved across snapshot reconciles, so a config MTU
+    /// change committed after startup does NOT reach the running TUN unless the
+    /// live device is reprogrammed here. This:
+    ///   1. reprograms the live TUN via `programmer` (`set_if_mtu`/`SIOCSIFMTU`
+    ///      in production; injectable in tests),
+    ///   2. updates `live_mtu`/`degraded` from the result so enqueue admission
+    ///      (which reads `live_mtu`) converges, and
+    ///   3. records the installed MTU as this reinjector's `mtu()`.
+    ///
+    /// A failed `SIOCSIFMTU` is non-fatal: [`SharedStatus::reprogram_mtu_status`]
+    /// KEEPS the current live MTU (the running TUN retains whatever it was last
+    /// programmed with — it is NOT reset to the 1500 creation default), marks
+    /// the path DEGRADED, and records the error; `mtu()` then reports the
+    /// retained value, so `mtu()`, `live_mtu`, and admission still agree.
+    pub(crate) fn reconcile_mtu(
+        &self,
+        desired_mtu: i32,
+        programmer: impl FnOnce(&str, i32) -> Result<(), String>,
+    ) -> i32 {
+        let name = self
+            .status
+            .device_name
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default();
+        let live = self
+            .status
+            .reprogram_mtu_status(&name, desired_mtu, programmer);
+        // Record what was ACTUALLY installed (== desired on success, or the
+        // retained live MTU on a failed program) so mtu() never over-reports a
+        // ceiling the device cannot honour.
+        self.mtu.store(live as i64, Ordering::Relaxed);
+        live
     }
 
     pub fn enqueue(&self, bytes: Vec<u8>) -> Result<EnqueueOutcome, String> {
@@ -825,7 +903,7 @@ fn set_if_up(name: &str) -> Result<(), String> {
 /// `mtu` must be > 0; a non-positive value is a programming error and is
 /// rejected without touching the device. Returns `Err` (caller logs and
 /// continues) on socket/ioctl failure.
-fn set_if_mtu(name: &str, mtu: i32) -> Result<(), String> {
+pub(crate) fn set_if_mtu(name: &str, mtu: i32) -> Result<(), String> {
     if mtu <= 0 {
         return Err(format!("invalid MTU {mtu} for {name}"));
     }

--- a/userspace-dp/src/slowpath_tests.rs
+++ b/userspace-dp/src/slowpath_tests.rs
@@ -138,6 +138,110 @@ fn enqueue_refuses_frame_above_live_mtu() {
     );
 }
 
+/// #5801 fail-on-revert: a day-2 reconcile that raises the MTU must advance the
+/// live MTU and clear degraded on a SUCCESSFUL program (the day-2 sibling of
+/// `apply_mtu_status_clean_on_success`).
+#[test]
+fn reprogram_mtu_status_advances_on_success() {
+    let status = SharedStatus::new(); // live_mtu starts at the 1500 default
+    let live = status.reprogram_mtu_status("xpf-usp0", 9000, |name, mtu| {
+        assert_eq!(name, "xpf-usp0");
+        assert_eq!(mtu, 9000);
+        Ok(())
+    });
+    assert_eq!(live, 9000, "a successful reconcile installs the desired MTU");
+    let snap = status.snapshot();
+    assert!(!snap.degraded, "a successful reconcile is not degraded");
+    assert_eq!(snap.live_mtu, 9000, "live MTU converges to the new ceiling");
+}
+
+/// #5801 fail-on-revert: a FAILED day-2 reconcile must KEEP the current live
+/// MTU — unlike the creation-time `apply_mtu_status`, which falls a failure
+/// back to the 1500 kernel default because the TUN was just created at 1500. On
+/// a reconcile the running TUN already carries its last-programmed MTU, so
+/// resetting `live_mtu` to 1500 would wrongly refuse frames the device can
+/// still carry. If `reprogram_mtu_status` reverts to the creation-path 1500
+/// fallback (or to `apply_mtu_status`), the retained-MTU assertion fails.
+#[test]
+fn reprogram_mtu_status_keeps_live_on_failure() {
+    let status = SharedStatus::new();
+    // Simulate a TUN already reconciled up to a 9000 jumbo ceiling.
+    status.live_mtu.store(9000, Ordering::Relaxed);
+    status.degraded.store(false, Ordering::Relaxed);
+
+    // A later reconcile whose SIOCSIFMTU fails must leave the live MTU at 9000
+    // (the running TUN is unchanged), mark degraded, and record the error.
+    let live = status.reprogram_mtu_status("xpf-usp0", 4000, |_name, _mtu| {
+        Err("SIOCSIFMTU xpf-usp0 mtu=4000: Operation not permitted".to_string())
+    });
+    assert_eq!(
+        live, 9000,
+        "a failed reconcile retains the current live MTU, not the 1500 default"
+    );
+    let snap = status.snapshot();
+    assert_eq!(snap.live_mtu, 9000, "live MTU is unchanged on a failed program");
+    assert!(snap.degraded, "a failed reconcile marks the path degraded");
+    assert!(
+        !snap.last_error.is_empty(),
+        "the ioctl error is recorded for the operator"
+    );
+}
+
+/// #5801 fail-on-revert (METHOD): a day-2 reconcile on the PRESERVED reinjector
+/// must reprogram its live MTU field AND converge enqueue admission, so a frame
+/// between the old (1500) and new (9000) ceiling is no longer MTU-refused. An
+/// injected SUCCEEDING programmer stands in for the real `SIOCSIFMTU` (unit
+/// tests run without CAP_NET_ADMIN). With the bug (reconcile is a no-op) `mtu()`
+/// and `live_mtu` stay at 1500 and the 8000-byte frame stays `MtuExceeded`, so
+/// the post-reconcile assertions fail.
+#[test]
+fn reconcile_mtu_reprograms_live_tun_and_admission() {
+    let reinjector =
+        SlowPathReinjector::new("xpf-usp-recon0", 1500).expect("construct reinjector");
+    // Force the deterministic 1500 startup state (the worker may not have run,
+    // and without CAP_NET_ADMIN its TUN open fails — irrelevant to the MTU
+    // admission gate, which is driven entirely by status.live_mtu).
+    reinjector
+        .status
+        .live_mtu
+        .store(DEFAULT_TUN_MTU as i64, Ordering::Relaxed);
+    reinjector.status.degraded.store(false, Ordering::Relaxed);
+    assert_eq!(reinjector.mtu(), 1500, "reinjector starts at the 1500 ceiling");
+
+    // Pre: an 8000-byte frame (between the old 1500 and new 9000 ceiling) is
+    // MTU-refused. This return path precedes the tx channel, so it is
+    // independent of whether the worker's TUN actually opened.
+    let before = reinjector.enqueue(vec![0u8; 8000]).expect("enqueue pre-reconcile");
+    assert!(
+        matches!(before, EnqueueOutcome::MtuExceeded),
+        "an 8000-byte frame must be MTU-refused while the live TUN is 1500"
+    );
+
+    // Day-2 reconcile 1500 -> 9000 with a SUCCEEDING injected programmer.
+    let live = reinjector.reconcile_mtu(9000, |_name, _mtu| Ok(()));
+    assert_eq!(live, 9000, "a successful reconcile installs the desired MTU");
+    assert_eq!(
+        reinjector.mtu(),
+        9000,
+        "reconcile updates the reinjector's live mtu() field"
+    );
+    let snap = reinjector.status();
+    assert_eq!(snap.live_mtu, 9000, "live_mtu converges to the new ceiling");
+    assert!(!snap.degraded, "a successful reconcile is not degraded");
+
+    // Post: the same 8000-byte frame is NO LONGER MTU-refused. Depending on
+    // whether the worker's TUN opened, enqueue now returns Accepted (worker
+    // alive) or a worker-not-running Err (the worker could not open the TUN in
+    // this environment) — either way it is NOT the MtuExceeded outcome the
+    // pre-reconcile 1500 state produced. If the reconcile were a no-op the live
+    // MTU would still be 1500 and this WOULD be MtuExceeded.
+    let after = reinjector.enqueue(vec![0u8; 8000]);
+    assert!(
+        !matches!(after, Ok(EnqueueOutcome::MtuExceeded)),
+        "after reconcile to 9000 the 8000-byte frame must not be MTU-refused"
+    );
+}
+
 #[test]
 fn rate_limiter_refills_after_window() {
     // Token-bucket: drain the 1-token budget, then advance the injected


### PR DESCRIPTION
## Problem

The persistent slow-path reinjector (`SlowPathReinjector`) is preserved across snapshot reconciles, and its TUN MTU + immutable `mtu` field were programmed only at creation (#2408). A valid day-2 config that **raises** a data-interface MTU updates the accepted snapshot but **not** the live slow-path TUN — the reconcile path only *warned*. So reinjected frames above the old ceiling are refused at enqueue (`MtuExceeded`) persistently until helper restart: the accepted snapshot advertises a jumbo MTU while the live TUN stays at its startup value (a config-convergence failure + availability blackhole after a routine committed change).

Evidence on master (`3821cd9d`): `slowpath.rs:294-355` (creation-only MTU, enqueue drop above `live_mtu`); `snapshot.rs:481-508` (preserve + warn-only, apply MTU only on new reinjector).

## Fix

Converge the live TUN on reconcile instead of only warning:

- **`SharedStatus::reprogram_mtu_status`** — day-2 sibling of the creation-path `apply_mtu_status`. Success advances `live_mtu` + clears `degraded`. A failed `SIOCSIFMTU` **keeps** the current live MTU (the running TUN retains its last-programmed value — *not* the 1500 creation fallback), marks `degraded`, records the error.
- **`SlowPathReinjector::reconcile_mtu`** — reads the live device name, calls that helper, and records the installed MTU into the now interior-mutable `mtu: AtomicI64` field, so `mtu()`, `live_mtu`, and enqueue admission agree after every reconcile.
- **`apply_snapshot`** preserved-reinjector branch now calls the extracted `reconcile_preserved_slow_path_mtu` seam (passing `set_if_mtu`) instead of only warning. Deduped per distinct desired value via `last_slow_path_mtu_warned` so a steady-state reconcile loop does not re-issue the ioctl; a failed program retries on the next distinct value. First-boot jumbo configs stay covered by the new-reinjector branch.

## Tests (fail-on-revert)

An injected `programmer` seam makes the field-update + admission convergence unit-testable without a real `SIOCSIFMTU` (unit tests run without CAP_NET_ADMIN):

- `slowpath::tests::reprogram_mtu_status_advances_on_success`
- `slowpath::tests::reprogram_mtu_status_keeps_live_on_failure`
- `slowpath::tests::reconcile_mtu_reprograms_live_tun_and_admission`
- `afxdp::coordinator::reconcile::snapshot::slow_path_mtu_tests::day2_mtu_increase_reprograms_preserved_reinjector` (wiring)

Neutralizing the fix (reconcile → no-op, failure arm → 1500 fallback, wiring → warn-only) turns **3 of 4 RED** (`left: 1500, right: 9000`); the success-arm companion stays green. Restored: `test result: ok. 4 passed; 0 failed`.

## Validation

`cargo build` clean; `cargo test --release slowpath` → **35 passed; 0 failed**. Doc updated: `docs/userspace-dataplane-architecture.md` (slow-path TUN MTU section).

Closes #5801

🤖 Generated with [Claude Code](https://claude.com/claude-code)