### PR TITLE
nptv6: lock wildcard-vs-concrete overlap-reject edge (#5176 follow-up)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -52326,3 +52326,39 @@ top.
   253 passed / 0 failed; new tests 5x flake check all green.
 - **File(s)**: userspace-dp/src/nat/source.rs,
   userspace-dp/src/nat/tests_pool.rs, _Log.md
+
+## 2026-07-18 — #5611: lock the NPTv6 wildcard-vs-concrete overlap-reject edge
+- **Timestamp**: 2026-07-18
+- **Action**: Test-coverage lock-in follow-up to #5176 (PR #5610). The NPTv6
+  `from_zone` scope-overlap gate `zones_conflict(a,b) = a.is_empty() ||
+  b.is_empty() || a == b` correctly REJECTS a wildcard (`from_zone=""`) rule
+  overlapping a concrete-zone rule with the same prefix (the empty short-circuit
+  → conflict → snapshot rejected) and a same-concrete-zone duplicate (the `a==b`
+  arm), but neither edge had an explicit regression-locking test. Existing
+  overlap tests use both-empty `from_zone`; the split-horizon test covers the
+  distinct-non-empty ADMIT. Added two fail-on-revert tests to lock both reject
+  paths. COVERAGE ONLY — no production behavior change.
+- **Tests** (userspace-dp/src/nptv6_tests.rs):
+  - `nptv6_wildcard_vs_concrete_same_prefix_rejected_5611` (:923) — wildcard +
+    concrete same internal `fd00:1::/48`, distinct external prefixes, BOTH
+    argument orderings (wildcard-first and concrete-first) → `expect_err`
+    `Nptv6OverlappingPrefix`. Binds the empty short-circuit and argument-order
+    symmetry (an asymmetric simplification checking only one side's emptiness is
+    caught). Goes RED under the `zones_conflict -> a == b` neutralization.
+  - `nptv6_same_concrete_zone_same_prefix_rejected_5611` (:963) — `untrust` +
+    `untrust` same internal prefix → `expect_err`. Guards the `a == b` arm
+    (stays GREEN under the `a==b` neutralization, RED if the equality arm is
+    dropped).
+- **Docs**: added a `#4339` fail-closed doc paragraph above `zones_conflict`
+  (nptv6.rs) — the `a == b` arm also rejects a degenerate same-name/same-prefix
+  duplicate a Go scope-expansion (#4339) could emit; a fail-CLOSED config
+  rejection (keeps prior live state), never a translation bypass.
+- **Validation** (release, uncontended target dir): baseline GREEN
+  `test result: ok. 2 passed; 0 failed`; neutralized `zones_conflict -> a == b`
+  → `nptv6_wildcard_vs_concrete_same_prefix_rejected_5611 ... FAILED`,
+  `test result: FAILED. 1 passed; 1 failed`; restored production
+  `test result: ok. 2 passed; 0 failed`. Full `cargo test --release nptv6`
+  module GREEN (44 passed, 0 failed) with fmt clean. Test-only + no forwarding
+  bytes change → no cluster smoke required (#5611 exemption).
+- **File(s)**: userspace-dp/src/nptv6.rs, userspace-dp/src/nptv6_tests.rs,
+  _Log.md

--- a/userspace-dp/src/nptv6.rs
+++ b/userspace-dp/src/nptv6.rs
@@ -503,6 +503,12 @@ fn find_overlap(
 /// packet carries exactly one relevant zone, so two rules conflict only when
 /// either scope is a wildcard (empty) or both name the same zone. Two distinct
 /// non-empty zones are disjoint — legitimate split-horizon.
+///
+/// #4339 fail-closed note: the `a == b` arm also rejects a degenerate
+/// same-name/same-prefix duplicate that a Go scope-expansion (#4339) could emit
+/// lowering to the SAME zone — there is no name-identity skip. That is a
+/// fail-CLOSED config rejection (the snapshot is dropped and the previous live
+/// state kept), never a translation bypass.
 #[inline]
 fn zones_conflict(a: &str, b: &str) -> bool {
     a.is_empty() || b.is_empty() || a == b

--- a/userspace-dp/src/nptv6_tests.rs
+++ b/userspace-dp/src/nptv6_tests.rs
@@ -909,6 +909,79 @@ fn nptv6_wildcard_from_zone_matches_any_zone_5176() {
     assert!(state.translate_outbound(&mut c, "whatever"));
 }
 
+// #5611 fail-on-revert: a WILDCARD (`from_zone = ""`) rule and a CONCRETE-zone
+// rule sharing the same INTERNAL prefix (distinct external prefixes) DO overlap
+// — the wildcard matches EVERY zone, so it can match the same packet the
+// concrete rule matches and first-match resolution would be order-dependent.
+// The empty short-circuit in `zones_conflict` (`a.is_empty() || b.is_empty()`)
+// makes this a conflict, so `try_from_snapshots` must reject the whole snapshot.
+// Both argument orderings are exercised so an asymmetric simplification that
+// inspects only one side's emptiness (e.g. only `candidate_zone.is_empty()`) is
+// caught. Neutralize the short-circuits — make `zones_conflict` return `a == b`
+// (nptv6.rs) — and this test goes RED: the wildcard-vs-concrete pair is admitted.
+#[test]
+fn nptv6_wildcard_vs_concrete_same_prefix_rejected_5611() {
+    let wildcard = Nptv6RuleSnapshot {
+        name: "wildcard".to_string(),
+        from_zone: String::new(),
+        internal_prefix: "fd00:1::/48".to_string(),
+        external_prefix: "2001:db8:1::/48".to_string(),
+    };
+    let concrete = Nptv6RuleSnapshot {
+        name: "scoped-untrust".to_string(),
+        from_zone: "untrust".to_string(),
+        internal_prefix: "fd00:1::/48".to_string(),
+        external_prefix: "2001:db8:2::/48".to_string(),
+    };
+
+    // Wildcard first, concrete second — reject on the internal (outbound) prefix.
+    let err = Nptv6State::try_from_snapshots(&[wildcard.clone(), concrete.clone()])
+        .expect_err("wildcard + concrete same-prefix pair must reject");
+    assert!(
+        matches!(err, SnapshotIntegrityError::Nptv6OverlappingPrefix { .. }),
+        "expected Nptv6OverlappingPrefix, got {err:?}"
+    );
+
+    // Reversed — concrete first, wildcard second — must ALSO reject (the wildcard
+    // is now the candidate; pins argument-order symmetry of `zones_conflict`).
+    let err = Nptv6State::try_from_snapshots(&[concrete, wildcard])
+        .expect_err("concrete + wildcard same-prefix pair must also reject");
+    assert!(
+        matches!(err, SnapshotIntegrityError::Nptv6OverlappingPrefix { .. }),
+        "expected Nptv6OverlappingPrefix, got {err:?}"
+    );
+}
+
+// #5611 fail-on-revert: two rules scoped to the SAME concrete zone ("untrust")
+// with the same INTERNAL prefix (distinct external prefixes) overlap — a single
+// untrust packet matches both, so first-match resolution is order-dependent.
+// The `a == b` arm of `zones_conflict` makes this a conflict and the snapshot
+// must reject. This is the same-concrete-zone duplicate edge, distinct from the
+// both-wildcard reject the existing `overlapping_prefixes_rejected_*` tests
+// cover and from the distinct-non-empty-zone ADMIT of the split-horizon test.
+#[test]
+fn nptv6_same_concrete_zone_same_prefix_rejected_5611() {
+    let err = Nptv6State::try_from_snapshots(&[
+        Nptv6RuleSnapshot {
+            name: "untrust-a".to_string(),
+            from_zone: "untrust".to_string(),
+            internal_prefix: "fd00:1::/48".to_string(),
+            external_prefix: "2001:db8:1::/48".to_string(),
+        },
+        Nptv6RuleSnapshot {
+            name: "untrust-b".to_string(),
+            from_zone: "untrust".to_string(),
+            internal_prefix: "fd00:1::/48".to_string(),
+            external_prefix: "2001:db8:2::/48".to_string(),
+        },
+    ])
+    .expect_err("same-zone same-prefix duplicate must reject");
+    assert!(
+        matches!(err, SnapshotIntegrityError::Nptv6OverlappingPrefix { .. }),
+        "expected Nptv6OverlappingPrefix, got {err:?}"
+    );
+}
+
 /// Compute ones-complement sum of 8 words (for checksum neutrality test).
 fn ones_complement_sum(words: &[u16; 8]) -> u16 {
     let mut sum: u32 = 0;


### PR DESCRIPTION
## Summary

Test-coverage lock-in follow-up to #5176 (merged via PR #5610). **Coverage only — no production behavior change.**

The NPTv6 `from_zone` scope-overlap gate

```rust
zones_conflict(a, b) = a.is_empty() || b.is_empty() || a == b
```

correctly **rejects** a wildcard (`from_zone=""`) rule that overlaps a concrete-zone rule with the same prefix (the empty short-circuit forces a conflict → `try_from_snapshots` rejects the snapshot) and a same-concrete-zone duplicate (the `a == b` arm). Neither reject edge had an explicit regression-locking test — the existing overlap tests use a both-empty `from_zone`, and the split-horizon test covers the distinct-non-empty **ADMIT**. A future refactor that dropped the empty short-circuit would silently admit an order-dependent wildcard-vs-concrete overlap with no test to catch it.

## Changes

- **`nptv6_wildcard_vs_concrete_same_prefix_rejected_5611`** — wildcard + concrete-zone rule sharing the same internal `/48` (distinct external prefixes), checked in **both** argument orderings, must reject with `Nptv6OverlappingPrefix`. Binds the empty short-circuit **and** the argument-order symmetry of `zones_conflict` (an asymmetric simplification checking only one side's emptiness is caught).
- **`nptv6_same_concrete_zone_same_prefix_rejected_5611`** — two rules scoped to the same concrete zone with the same internal prefix must reject. Guards the `a == b` arm.
- **Doc**: a `#4339` fail-closed note above `zones_conflict` — the `a == b` arm also rejects a degenerate same-name/same-prefix duplicate a Go scope-expansion (#4339) could emit; a fail-**CLOSED** config rejection (keeps prior live state), never a translation bypass.

## Fail-on-revert proof (release, uncontended target dir)

| Phase | `zones_conflict` body | Result |
|-------|-----------------------|--------|
| baseline | `a.is_empty() \|\| b.is_empty() \|\| a == b` | `test result: ok. 2 passed; 0 failed` |
| **neutralized** | `a == b` | `nptv6_wildcard_vs_concrete_same_prefix_rejected_5611 ... FAILED` → `test result: FAILED. 1 passed; 1 failed` |
| restored | `a.is_empty() \|\| b.is_empty() \|\| a == b` | `test result: ok. 2 passed; 0 failed` |

The wildcard-vs-concrete test genuinely binds the empty short-circuit (goes RED on the neutralization); the same-concrete test correctly stays GREEN under `a==b` because it guards that arm specifically. Full `cargo test --release nptv6` module: 44 passed, 0 failed; `cargo fmt --check` clean.

Test-only, no forwarding bytes changed → no cluster smoke required.

Closes #5611

🤖 Generated with [Claude Code](https://claude.com/claude-code)
