### PR TITLE
docs: fix TE/PTB per-zone bucket granularity claim

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -52399,3 +52399,31 @@ top.
   bytes change → no cluster smoke required (#5611 exemption).
 - **File(s)**: userspace-dp/src/nptv6.rs, userspace-dp/src/nptv6_tests.rs,
   _Log.md
+
+## 2026-07-18 — #6046 TE/PTB per-zone bucket doc/comment accuracy (doc-only)
+- **Timestamp**: 2026-07-18
+- **Action**: Corrected the #5856 per-zone ICMP TE/PTB bucket docs + comments,
+  which OVERCLAIMED per-VLAN-subinterface granularity. Verified firsthand that
+  the TE/PTB generators key the per-zone bucket on the PHYSICAL ingress bind
+  ifindex (`ingress_ident.ifindex`, the fixed per-binding socket-bind port) via
+  `ifindex_to_zone_id` WITHOUT calling `resolve_ingress_logical_ifindex`, so VLAN
+  sub-interfaces on the same physical port SHARE that port's TE/PTB bucket. Only
+  the Reject path resolves the LOGICAL unit (`logical_ingress_ifindex`) and thus
+  gets per-sub-interface granularity. Kept the correct framing: the per-zone split
+  is still correct and strictly better than the pre-#5856 single global bucket.
+- **Evidence** (all origin/master @ cdd26a5): TE bucket keys physical at
+  `icmp.rs:231-235` (`ifindex_to_zone_id.get(&ingress_ident.ifindex)`, no
+  resolve); PTB bucket keys physical at `tx/dispatch/mod.rs:277-281`;
+  `ingress_ident` = `worker_ctx.ident` = `binding.identity()` = physical
+  socket-bind ifindex (`worker/mod.rs:855-863`, `641`; `lifecycle.rs:170-172`;
+  `bringup.rs:66-72`). Reject resolves logical at
+  `poll_descriptor/reject_reply.rs:272-274` then keys the bucket on it at
+  `:398-402`; reject is invoked with the physical `binding.ifindex`
+  (`poll_descriptor/mod.rs:1280`). `ifindex_to_zone_id` is keyed by the LOGICAL
+  `iface.ifindex`, physical parent inherits only the FIRST sub-if's zone
+  (`forwarding_build/interfaces.rs:81-91`).
+- **Change**: comment/doc-only — NO code logic touched. `cargo build` clean;
+  `git diff` shows only `//` comment hunks in the two .rs files + the .md.
+- **File(s)**: docs/generated-reply-rate-limit.md,
+  userspace-dp/src/afxdp/icmp.rs, userspace-dp/src/afxdp/tx/dispatch/mod.rs,
+  _Log.md

--- a/docs/generated-reply-rate-limit.md
+++ b/docs/generated-reply-rate-limit.md
@@ -54,13 +54,25 @@ key was an API omission, not absence of attribution). All three reasons now use
   validated zone set as `zone_id_to_name`. Cardinality = configured zones (the Go
   control plane caps distinct zones at `MaxUsableZoneID = 65533`), so it is
   config-bounded, never attacker-growable.
-- At each generator call site the ingress **from-zone** is resolved from the
-  LOGICAL ingress unit ifindex via `ifindex_to_zone_id` (the same SSOT the reply
-  build and output classify key off, so a VLAN sub-interface keys its own zone's
-  bucket, and a non-VLAN port resolves identically through the parent mapping):
-  - Reject — `poll_descriptor::reject_reply::enqueue_reject_reply` (`logical_ingress_ifindex`).
-  - TimeExceeded — `icmp::build_local_time_exceeded_request` (`ingress_ident.ifindex`).
-  - PacketTooBig — the TX dispatch PTB path (`ingress_ident.ifindex`).
+- At each generator call site the ingress **from-zone** is resolved via
+  `ifindex_to_zone_id`, but the two paths key that map by DIFFERENT ifindexes, so
+  their per-zone granularity differs:
+  - Reject — `poll_descriptor::reject_reply::enqueue_reject_reply` resolves the
+    LOGICAL ingress unit ifindex first (`resolve_ingress_logical_ifindex` →
+    `logical_ingress_ifindex`, the same SSOT the reply build and output classify
+    key off), so a VLAN sub-interface keys its OWN zone's bucket and a non-VLAN
+    port resolves identically.
+  - TimeExceeded (`icmp::build_local_time_exceeded_request`) and PacketTooBig
+    (the TX dispatch PTB path) key on the PHYSICAL ingress bind ifindex
+    (`ingress_ident.ifindex`, the fixed per-binding socket-bind port) WITHOUT
+    resolving the logical unit. For an untagged port physical == logical, so the
+    zone is exact; but VLAN sub-interfaces on the same physical port all resolve
+    through that port's `ifindex_to_zone_id` entry (the physical parent inherits
+    its FIRST sub-interface's zone — `forwarding_build/interfaces.rs`), so they
+    SHARE the physical port's TE/PTB bucket rather than getting a per-sub-interface
+    one. This is still correct and strictly better than the pre-#5856 single
+    global bucket (distinct physical ingress ports no longer starve each other);
+    it is simply coarser than the Reject path's per-logical-unit granularity.
 - An unzoned (id 0) or otherwise-unknown from-zone falls back to the reason's
   process-global `{REJECT,TIME_EXCEEDED,PACKET_TOO_BIG}_FALLBACK_BUCKET` — a real
   bucket, so the gate is **never fail-open** and never panics on a missing key.

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -211,13 +211,21 @@ pub(super) fn build_local_time_exceeded_request(
     // `TimeExceeded` rate-limited counter (inside the gate).
     //
     // #5856: the bucket is now PER INGRESS (from) ZONE, not a single global one
-    // — resolved from the LOGICAL ingress unit ifindex (`ingress_ident.ifindex`,
-    // the same SSOT the v4/v6 reply build + #3026 output-classify key off) via
-    // `ifindex_to_zone_id`, exactly as the #3618 reject path does. Before #5856
-    // one shared global TE bucket let a low-TTL flood ingressing ONE zone drain
-    // it and suppress legitimate traceroute for EVERY other zone. An unzoned /
-    // unknown ingress interface (id 0) falls back to the shared
-    // `TIME_EXCEEDED_FALLBACK_BUCKET` (never fail-open).
+    // — resolved from the PHYSICAL ingress bind ifindex (`ingress_ident.ifindex`,
+    // the fixed per-binding socket-bind port, the same value the v4/v6 reply
+    // build + #3026 output-classify pass) via `ifindex_to_zone_id`. Unlike the
+    // #3618 reject path, this site does NOT call `resolve_ingress_logical_ifindex`:
+    // a VLAN sub-interface resolves through its physical parent's
+    // `ifindex_to_zone_id` entry (the parent inherits its first sub-interface's
+    // zone), so VLAN sub-interfaces on the same physical port SHARE that port's
+    // TE bucket rather than getting a per-sub-interface one. For an untagged port
+    // physical == logical, so the zone is exact. Before #5856 one shared global TE
+    // bucket let a low-TTL flood ingressing ONE physical port drain it and
+    // suppress legitimate traceroute for EVERY other port/zone; the per-zone split
+    // is still correct and strictly better (distinct physical ingress ports no
+    // longer starve each other), just coarser than the reject path's
+    // per-logical-unit granularity. An unzoned / unknown ingress interface (id 0)
+    // falls back to the shared `TIME_EXCEEDED_FALLBACK_BUCKET` (never fail-open).
     //
     // #5567: the token was previously consumed BEFORE the egress lookup + build.
     // A flood of reply-eligible-but-UNBUILDABLE triggers on one interface

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -228,11 +228,18 @@ fn compute_forwarded_egress_ptb(
             // dropped below (`mtu_signalled`), so this never
             // falls through to forward the MTU-violating frame.
             // #5856: the bucket is PER INGRESS (from) ZONE,
-            // resolved from `ingress_ident.ifindex` via
-            // `ifindex_to_zone_id` exactly as the #3618 reject
-            // path does, so an oversized-DF flood ingressing ONE
-            // zone can no longer drain a single global bucket and
-            // suppress legitimate PMTUD for every OTHER zone. An
+            // resolved from the PHYSICAL ingress bind ifindex
+            // `ingress_ident.ifindex` via `ifindex_to_zone_id`. This
+            // site does NOT resolve the logical unit like the #3618
+            // reject path does, so VLAN sub-interfaces on one physical
+            // port SHARE that port's PTB bucket (the physical parent
+            // inherits its first sub-interface's zone); an untagged
+            // port has physical == logical, so its zone is exact. Even
+            // so an oversized-DF flood ingressing ONE physical port can
+            // no longer drain a single global bucket and suppress
+            // legitimate PMTUD for every OTHER port/zone — strictly
+            // better than the pre-#5856 global bucket, just coarser than
+            // the reject path's per-logical-unit granularity. An
             // unzoned / unknown ingress (id 0) falls back to the
             // shared `PACKET_TOO_BIG_FALLBACK_BUCKET`.
             if !ptb_reply_suppressed(source_frame, ptb_meta, l3, forwarding) {
@@ -271,9 +278,12 @@ fn compute_forwarded_egress_ptb(
                 // token is NOT consumed. Either way the oversized original is
                 // still dropped below (`mtu_signalled`), so the trigger
                 // disposition is unchanged. #5856: the token is taken from the
-                // ingress zone's per-zone PTB bucket, resolved from
-                // `ingress_ident.ifindex` via `ifindex_to_zone_id` (unzoned /
-                // unknown → the shared `PACKET_TOO_BIG_FALLBACK_BUCKET`).
+                // ingress zone's per-zone PTB bucket, resolved from the PHYSICAL
+                // ingress bind ifindex `ingress_ident.ifindex` via
+                // `ifindex_to_zone_id` — NOT the logical unit (unlike the #3618
+                // reject path), so VLAN sub-interfaces on one physical port share
+                // that port's bucket (unzoned / unknown → the shared
+                // `PACKET_TOO_BIG_FALLBACK_BUCKET`).
                 let from_zone_id = forwarding
                     .ifindex_to_zone_id
                     .get(&ingress_ident.ifindex)


### PR DESCRIPTION
## Summary

Documentation/comment-only fix. The #5856 per-zone ICMP Time-Exceeded /
Packet-Too-Big (TE/PTB) bucket docs and the two generator-site comments
**overclaimed** the zone-key granularity — they described
`ingress_ident.ifindex` as "the LOGICAL ingress unit ifindex" and said a VLAN
sub-interface "keys its own zone's bucket ... exactly as the #3618 reject path
does". That is wrong for the TE/PTB generators.

**No behavioral defect** — the per-zone split is still correct and strictly
better than the pre-#5856 single global bucket. Only the docs/comments misstated
the per-VLAN-subinterface granularity.

## Ground truth (verified firsthand @ origin/master `cdd26a5`)

The TE/PTB generators key the per-zone bucket on the **PHYSICAL** ingress bind
ifindex, without resolving the logical unit; only the **Reject** path resolves
the logical unit.

- **TE** keys the bucket at `userspace-dp/src/afxdp/icmp.rs:231-235` —
  `ifindex_to_zone_id.get(&ingress_ident.ifindex)`, no `resolve_ingress_logical_ifindex`.
- **PTB** keys the bucket at `userspace-dp/src/afxdp/tx/dispatch/mod.rs:277-281` — same pattern.
- `ingress_ident` = `worker_ctx.ident` = `binding.identity()`
  (`worker/mod.rs:855-863`) whose `ifindex` is the physical socket-bind port
  (`worker/mod.rs:641`, `lifecycle.rs:170-172`, `coordinator/reconcile/bringup.rs:66-72`) —
  fixed per binding, so it is not a per-packet logical unit.
- **Reject** DOES resolve the logical unit: `poll_descriptor/reject_reply.rs:272-274`
  calls `resolve_ingress_logical_ifindex`, then keys the bucket on
  `logical_ingress_ifindex` at `:398-402`. It is invoked with the physical
  `binding.ifindex` (`poll_descriptor/mod.rs:1280`).
- `ifindex_to_zone_id` is keyed by the LOGICAL `iface.ifindex`; the physical
  parent inherits only its FIRST sub-interface's zone
  (`forwarding_build/interfaces.rs:81-91`).

**Consequence:** VLAN sub-interfaces on the same physical port SHARE that port's
TE/PTB bucket, whereas the Reject path gets per-sub-interface buckets.

## Corrected locations

- `docs/generated-reply-rate-limit.md` — the per-reason resolution bullet and the
  `#5856` section.
- `userspace-dp/src/afxdp/icmp.rs` — the `#5856` TE bucket comment.
- `userspace-dp/src/afxdp/tx/dispatch/mod.rs` — both `#5856` PTB bucket comments.

## Validation

- Comment/doc-only — **no code logic touched**. `git diff` shows only `//` comment
  hunks in the two `.rs` files plus the markdown doc.
- `cargo build` clean (disk-backed target dir).

Closes #6046

🤖 Generated with [Claude Code](https://claude.com/claude-code)