### PR TITLE
test: make event_stream stalled-consumer backpressure test host-independent (#6103)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-18 — #6103: deterministic-fix event_stream stalled-consumer backpressure test (host socket-buffer dependency)
+
+- **Timestamp**: 2026-07-18 (fix/6103-eventstream)
+- **Action**: `event_stream::tests::backpressure::stalled_consumer_does_not_
+  grow_backlog_unbounded_end_to_end` failed 10/10 on pristine origin/master
+  on this host. Root cause (confirmed, not guessed): the test wedges an
+  AF_UNIX reader so `write()` returns `WouldBlock` and the I/O thread's
+  `write_buf` backs up to the 16 MiB `WRITE_BACKLOG_MAX_BYTES` cap. But the
+  test only pumps `3 × 16 MiB ≈ 48 MiB` of frames, and this fleet tunes
+  `net.core.{r,w}mem_default = 67108864` (64 MiB), so a wedged AF_UNIX
+  socketpair absorbs ~53 MiB before `WouldBlock` (measured) — MORE than the
+  pump — so `write_buf` never accumulates, the cap is never hit,
+  `frames_write_stalled` stays 0, and the `> 0` assertion fails. Instrumented
+  run confirmed `sent_ok=3.05M`, `frames_dropped=97k`, `frames_write_stalled=0`.
+  This is a host-sysctl-dependent deterministic failure of the TEST's hidden
+  assumption (small default socket buffer), NOT a product backpressure
+  regression — the product cap works (proven by the 4 unit-level backpressure
+  tests and by fail-on-revert below).
+- **Fix**: shrink both ends of the test socketpair (`SO_SNDBUF` on the writer,
+  `SO_RCVBUF` on the reader) to 64 KiB via `libc::setsockopt` before wedging,
+  so a non-reading peer backs up after ~108 KiB regardless of host tuning.
+  Test-only change; product code untouched.
+- **Validation**: 10/10 green alone (0.34 s each, was 5.5 s failing); full
+  `event_stream::` module 85/85 in-suite; fail-on-revert — disabling the
+  `write_buf.len() >= WRITE_BACKLOG_MAX_BYTES` cap makes the test FAIL again
+  (`must trip the backlog cap`, bounded ~48 MiB write_buf, no OOM).
+- **Docs**: no change needed — `event_stream/README.md` documents the PRODUCT
+  cap semantics, which this test-determinism fix does not alter.
+- **File(s)**: userspace-dp/src/event_stream/tests/backpressure.rs, _Log.md
+
 ## 2026-07-18 — #6103: regen stale wire_invariant fixture (missing #5623/#5625 nat64 fields)
 
 - **Timestamp**: 2026-07-18 03:53 PDT (fix/6103-wire-fixture)

--- a/userspace-dp/src/event_stream/tests/backpressure.rs
+++ b/userspace-dp/src/event_stream/tests/backpressure.rs
@@ -3,6 +3,44 @@
 // Split from event_stream/tests.rs (#4664).
 
 use super::*;
+use std::os::unix::io::AsRawFd;
+
+/// Force a small kernel socket buffer on both ends of a test AF_UNIX pair.
+///
+/// The end-to-end wedged-reader test relies on a never-reading peer causing
+/// `write()` to return `WouldBlock` quickly, so the I/O thread's `write_buf`
+/// backs up and reaches `WRITE_BACKLOG_MAX_BYTES`. That only happens if the
+/// kernel socket buffer is SMALLER than the volume we pump. Linux defaults are
+/// ~208 KiB, but a host that tunes `net.core.{r,w}mem_default` high (this test
+/// fleet runs on boxes set to 64 MiB) lets a wedged AF_UNIX socket absorb
+/// ~53 MiB before `WouldBlock` — MORE than the frames the test pumps — so the
+/// backlog never fills and the cap under test is never reached (#6103, a
+/// host-sysctl-dependent deterministic failure, not a product regression).
+///
+/// Requesting 64 KiB (the kernel doubles it and enforces a floor, yielding an
+/// effective ~100-130 KiB) makes the wedged reader back up well below the
+/// 16 MiB cap regardless of the host default, so the test is deterministic.
+fn shrink_socket_buffers(reader: &UnixStream, writer: &UnixStream) {
+    let sz: libc::c_int = 64 * 1024;
+    // AF_UNIX stream send is gated by the sender's SO_SNDBUF and the peer's
+    // SO_RCVBUF; shrink both so neither can hide the backpressure.
+    for (fd, opt) in [
+        (writer.as_raw_fd(), libc::SO_SNDBUF),
+        (reader.as_raw_fd(), libc::SO_RCVBUF),
+    ] {
+        // SAFETY: `fd` is a valid, open socket borrowed for this call only.
+        let rc = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                opt,
+                &sz as *const libc::c_int as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 0, "setsockopt(SO_*BUF) must succeed on the test socket");
+    }
+}
 
 
 #[test]
@@ -145,6 +183,10 @@ fn stalled_consumer_does_not_grow_backlog_unbounded_end_to_end() {
     // channel (frames_dropped grows, stalls counted) instead of migrating
     // every frame into an unbounded write_buf.
     let (daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    // Force a small kernel socket buffer so the wedged reader trips `WouldBlock`
+    // (and thus the write-backlog cap) independent of the host's tuned
+    // `net.core.{r,w}mem_default`; see `shrink_socket_buffers` (#6103).
+    shrink_socket_buffers(&daemon_side, &helper_side);
     helper_side.set_nonblocking(true).unwrap();
     // Never read on the daemon side: let the socket buffer wedge.
 


### PR DESCRIPTION
## Summary

Fixes the remaining half of #6103: the event_stream backpressure
end-to-end test `stalled_consumer_does_not_grow_backlog_unbounded_end_to_end`
failed **deterministically (10/10)** on pristine `origin/master`
(independently reported by the #5289 and #5689 engineer agents).

## Classification: deterministic host-dependency in the TEST — not a product regression

The test wedges an AF_UNIX reader so the I/O thread's socket `write()`
returns `WouldBlock`, backing its `write_buf` up to the 16 MiB
`WRITE_BACKLOG_MAX_BYTES` cap (which sets `frames_write_stalled`). It
pumps only `3 × 16 MiB ≈ 48 MiB` of frames and silently assumes the
kernel socket buffer is the small Linux default (~208 KiB).

This test fleet tunes `net.core.{r,w}mem_default = 67108864` (**64 MiB**),
so a wedged AF_UNIX socketpair absorbs **~53 MiB** before `WouldBlock`
(measured empirically) — *more* than the ~48 MiB pumped. Every frame
lands in the kernel socket buffer, `write()` always succeeds, `write_buf`
never accumulates, the cap is never reached, `frames_write_stalled` stays
0, and the `> 0` assertion fails.

Instrumented run at the failure point:
`sent_ok=3.05M`, `frames_dropped=97k`, `frames_write_stalled=0`.

The **product backpressure logic is correct** — proven by the four
unit-level backpressure tests (which drive `drain_channel_into_write_buf`
directly) and by the fail-on-revert check below.

## Fix (test-only)

Shrink both ends of the test socketpair — `SO_SNDBUF` on the writer,
`SO_RCVBUF` on the reader — to 64 KiB via `libc::setsockopt` before the
reader wedges, so a non-reading peer backs up after ~108 KiB regardless
of the host's `net.core.*mem_default`. Product code untouched; the
assertion is unchanged (not weakened, not `#[ignore]`d).

## Validation

- **10/10 green alone** — 0.34 s each (was 5.5 s while failing).
- **In-suite**: full `event_stream::` module passes **85/85**.
- **Fail-on-revert**: neutralizing the
  `write_buf.len() >= WRITE_BACKLOG_MAX_BYTES` cap makes the test FAIL
  again (`must trip the backlog cap`), with `write_buf` bounded to the
  ~48 MiB pump (no OOM) — the test still genuinely binds the product cap.
- **Docs**: `event_stream/README.md` documents the *product* cap
  semantics, which this determinism fix does not change — no doc update
  required.

Closes #6103

🤖 Generated with [Claude Code](https://claude.com/claude-code)