### PR TITLE
test: deflake event-stream wiring test's fixed 2s deadline

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-18 — #6038: deflake TestWireUserspaceEventStreamCallbacks...WiresSessionAndFullResync (2s deadline races the wiring under load)
+
+- **Timestamp**: 2026-07-18 (fix/6038-eventstream-test-flake)
+- **Action**: Fixed the timing-flaky pkg/daemon test. Root cause (firsthand):
+  the wiring's happy path is ~0.2s because each of the two ACKs (session-open
+  seq 1, full-resync seq 2) is flushed by the eventstream `ackLoop`'s 100ms
+  ticker (`eventstream.go:924`), so two ACKs cost ~200ms. The test's ACK wait
+  (`waitForAckSeqForWiringTest`) and the socket dial loop each capped on a
+  FIXED `time.Now().Add(2 * time.Second)` — only ~1.8s of headroom. Under
+  concurrent build/test load the `ackLoop`/`acceptLoop`/`readLoop` goroutines
+  starve; the ACK slips past the 500ms per-read window repeatedly until the 2s
+  overall cap is exhausted (~4×500ms) → a spurious 2.01s timeout, non-monotonic
+  across commits (the issue's bisect FAIL→pass→FAIL). Fix: added
+  `wiringTestDeadline(t)` returning a GENEROUS cap that tracks `t.Deadline()`
+  (`go test -timeout`, default 10m) less a 5s margin, else a 30s fallback; both
+  the ACK wait and the dial loop now use it. The loops STILL gate on the actual
+  completion event (successful connect, then ACK seq >= want) — only the
+  wall-clock backstop was widened, no assertion weakened, no `#[ignore]`. Also
+  now check `es.Start(ctx)`'s previously-discarded error (Start binds the Unix
+  listener synchronously before the accept loop, so a bind failure should
+  surface directly, not as a confusing dial-loop timeout).
+- **File(s)**: pkg/daemon/userspace_sync_test.go, _Log.md
+- **Validation**: `go build ./...` clean; `go vet ./pkg/daemon/` clean; target
+  test `-count=50` → 50/50 pass; SAME `-count=50` under heavy CPU+build load
+  (GOMAXPROCS=2, 3×nproc busy loops + 3 parallel builds) → 50/50 pass, slowest
+  run 0.22s (no 2s outliers); full `go test ./pkg/daemon/` green. Cap-is-the-
+  lever contrast (per-read forced to 10ms to emulate the load timeout condition,
+  varying ONLY the overall cap): cap=50ms → RED (`read ack frame: i/o timeout`,
+  0.05s); cap=3000ms → GREEN (0.20s) — proving the overall deadline is the sole
+  pass/fail lever the fix widens. The genuine >2s ACK stall is load-dependent /
+  nondeterministic (per the issue's own bisect) and did not reproduce on this
+  box even under extreme oversubscription.
+
 ## 2026-07-18 — #6041: address-only (`port no-translation`) persistent-NAT leases (parity follow-up to #5819)
 
 - **Timestamp**: 2026-07-18 (fix/6041-address-only-persist-nat)

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -78,9 +78,43 @@ func writeEventFrameForWiringTest(t *testing.T, conn net.Conn, typ uint8, seq ui
 	}
 }
 
+// wiringTestDeadline returns a generous absolute deadline for the event-stream
+// wiring poll loops (socket connect, then the per-seq ACK wait). Those loops
+// already gate on the actual completion event — a successful connect, then an
+// ACK frame with seq >= want — so this cap is only a backstop against a genuine
+// hang, NOT the mechanism that decides success. It is deliberately large so it
+// never fires from mere goroutine-scheduling latency under concurrent
+// build/test load.
+//
+// #6038: the previous fixed 2s cap left only ~1.8s of headroom over the ~0.2s
+// happy path (each ACK is flushed by the eventstream ackLoop's 100ms ticker, so
+// the two ACKs cost ~200ms). On a loaded box the ackLoop / acceptLoop / readLoop
+// goroutines starve, the flush slips past 2s, and the loop tripped a spurious
+// 2.01s timeout — non-monotonic across commits, the signature of a load-racing
+// deadline rather than a product regression. Gating on the actual ACK with a
+// generous cap removes the wall-clock race without weakening any assertion.
+//
+// When `go test -timeout` is in effect (the default is 10m) the cap tracks that
+// deadline less a small margin, so a real hang fails HERE with a precise message
+// just before the whole test binary is killed; with `-timeout 0` it falls back
+// to a fixed generous window.
+func wiringTestDeadline(t *testing.T) time.Time {
+	t.Helper()
+	const (
+		fallback = 30 * time.Second
+		margin   = 5 * time.Second
+	)
+	if d, ok := t.Deadline(); ok {
+		if capped := d.Add(-margin); capped.After(time.Now()) {
+			return capped
+		}
+	}
+	return time.Now().Add(fallback)
+}
+
 func waitForAckSeqForWiringTest(t *testing.T, conn net.Conn, want uint64) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := wiringTestDeadline(t)
 	for {
 		if err := conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
 			t.Fatalf("set read deadline: %v", err)
@@ -972,7 +1006,13 @@ func TestWireUserspaceEventStreamCallbacksStandaloneWiresSessionAndFullResync(t 
 	es := dpuserspace.NewEventStream(socketPath)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	es.Start(ctx)
+	// Start binds the Unix listener synchronously before launching the accept
+	// loop, so a successful return means the socket is connectable. #6038: check
+	// the error instead of discarding it — a silent bind failure would otherwise
+	// surface only as a confusing dial-loop timeout below.
+	if err := es.Start(ctx); err != nil {
+		t.Fatalf("start event stream: %v", err)
+	}
 	defer es.Close()
 
 	d := &Daemon{}
@@ -982,8 +1022,11 @@ func TestWireUserspaceEventStreamCallbacksStandaloneWiresSessionAndFullResync(t 
 
 	var conn net.Conn
 	var err error
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	// #6038: gate on a successful connect with a generous cap (see
+	// wiringTestDeadline) instead of a fixed 2s wall-clock that races the
+	// listener under load.
+	dialDeadline := wiringTestDeadline(t)
+	for time.Now().Before(dialDeadline) {
 		conn, err = net.Dial("unix", socketPath)
 		if err == nil {
 			break


### PR DESCRIPTION
## Summary

Fixes #6038 — `TestWireUserspaceEventStreamCallbacksStandaloneWiresSessionAndFullResync` is timing-flaky on master: it fails non-monotonically across commits with a runtime that jumps from ~0.2s (pass) to ~2.01s (fail), the signature of a fixed ~2s deadline exceeded under load rather than a product regression.

## Root cause (firsthand)

The wiring's happy path costs **~0.2s** because each of the two ACKs (session-open seq 1, full-resync seq 2) is flushed by the eventstream `ackLoop`'s **100ms ticker** (`pkg/dataplane/userspace/eventstream.go`), so two ACKs cost ~200ms. Both the ACK wait (`waitForAckSeqForWiringTest`) and the socket dial loop capped on a fixed `time.Now().Add(2 * time.Second)` — only ~1.8s of headroom. Under concurrent build/test load the `ackLoop`/`acceptLoop`/`readLoop` goroutines starve; the ACK slips past the 500ms per-read window repeatedly until the 2s overall cap is exhausted (~4×500ms), and the loop trips a spurious 2.01s timeout.

## Fix

- Add `wiringTestDeadline(t)`: a generous cap that tracks the test's own deadline (`go test -timeout`, default 10m) less a 5s margin, or a 30s fallback under `-timeout 0`. The ACK wait and the dial loop now use it.
- The loops **still gate on the actual completion event** — a successful connect, then an ACK with `seq >= want` — so no assertion is weakened and the test is not `#[ignore]`d; only the wall-clock backstop is widened so scheduling latency under load can't race it. A real hang now fails with a precise message just before the test binary's own timeout.
- Also check `es.Start(ctx)`'s previously-discarded error (Start binds the listener synchronously before the accept loop, so a bind failure surfaces directly rather than as a confusing dial-loop timeout).

Test-only change; no production code touched.

## Validation

- `go build ./...` clean; `go vet ./pkg/daemon/` clean.
- Target test **`-count=50` → 50/50 pass** (idle).
- **Same `-count=50` under heavy CPU+build load** (GOMAXPROCS=2, 3×nproc busy loops + 3 parallel `go build ./...`) → **50/50 pass, slowest run 0.22s, no 2s outliers**.
- Full `go test ./pkg/daemon/` green.
- **Cap-is-the-lever contrast** (per-read forced to 10ms to emulate the load timeout condition, varying only the overall cap): cap=50ms → **RED** (`read ack frame: i/o timeout`, 0.05s); cap=3000ms → **GREEN** (0.20s) — proving the overall deadline is the sole pass/fail lever the fix widens.

The genuine >2s ACK stall is load-dependent / nondeterministic (per the issue's own bisect FAIL→pass→FAIL) and did not reproduce on this box even under extreme oversubscription; the fix removes the wall-clock lever regardless.

Closes #6038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wMxwEcvZXYnr9XBzG9T2N
