### PR TITLE
userspace: force resync on undecodable session frame (#5483)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-18 — #5483: undecodable session-sync frame must force a hard sync-break
+
+- **Timestamp**: 2026-07-18 (fix/5483-eventstream-decode-syncbreak)
+- **Action**: The EventStream reader (`pkg/dataplane/userspace/eventstream.go`)
+  handled a COMPLETE-but-undecodable SESSION frame (open/close/update) with
+  `es.DecodeErrors.Add(1); continue` — a silent skip that left the sequence
+  watermark below the hole. A later lossy TELEMETRY frame at seq+1 then only
+  recorded a benign gap, marked itself applied, and let `sendAckIfNeeded`
+  advance the cumulative ACK PAST the unapplied session seq. The Rust replay
+  buffer trims through the ACK watermark (`seq <= acked`), discarding the
+  never-applied session frame, and no later gap fires — the standby silently
+  diverged with no recovery. Fix: route a session-frame decode failure through
+  new `handleSessionDecodeFailure(seq)`, which reuses the #2874 gap sync-break
+  mechanics (bump `SessionSyncResyncs`, call `onFullResync`, return so the reader
+  drops the connection) WITHOUT advancing prevSeq/lastAppliedSeq/ACK past the
+  hole. Scope: SESSION frames only — a telemetry decode failure still skips
+  (best-effort, no HA state). Go-side only; the Rust ACK-trim is watermark-gated
+  and already correct. Docs: `docs/session-sync-architecture.md` FullResync
+  trigger list updated.
+- **File(s)**: `pkg/dataplane/userspace/eventstream.go`,
+  `pkg/dataplane/userspace/eventstream_decode_syncbreak_5483_test.go`,
+  `docs/session-sync-architecture.md`, `_Log.md`
+
 ## 2026-07-18 — #5149: trim_l3_payload must be IP-declared-length authoritative (tunnel L4 checksum over Ethernet slack)
 
 - **Timestamp**: 2026-07-18 (fix/5149-trim-l3-declared-len)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-18 — #6130: undecodable session frame must break the resync/reconnect loop, not withhold the ACK
+
+- **Timestamp**: 2026-07-18 (fix/5483-eventstream-decode-syncbreak, follow-on)
+- **Action**: The first #5483 fix (b9cb3eb34) reused the #2874 gap mechanics
+  verbatim for a decode failure: force a resync, WITHHOLD the ACK, drop the
+  connection. That WEDGED the stream on a PERSISTENTLY-undecodable session frame
+  (codec bug / version-skewed helper). Unlike a gap (frame ABSENT → Rust
+  `replay_buffered` sees `has_gap` and parks a re-baselining barrier), an
+  undecodable frame is PRESENT: the Rust replay buffer re-sends it verbatim and
+  `has_gap` is FALSE, so no barrier parks. Withholding the ACK made the helper
+  re-send the identical frame every reconnect → unbounded busy-loop hammering the
+  shared control socket + slog.Warn flood; worst case a STANDBY (corrective
+  no-op) in pure churn. Fix (#6130): `handleSessionDecodeFailure(seq, *prevSeq)`
+  now ADVANCES the watermark PAST the undecodable frame unconditionally
+  (`markFrameApplied` + prevSeq) and the caller `continue`s (keeps the
+  connection, mirroring the #5362 helper-FullResync path, not the gap path). The
+  ACK then trims the frame (`front.seq <= acked`) so it is never re-sent — one
+  bad frame → exactly one resync; persistent skew → ≤1 resync per
+  `decodeFailureResyncInterval` (2s), the rest counted in
+  `DecodeResyncSuppressed`. Anti-divergence holds: we advance only under cover of
+  a table-truth FullResync (superset of an undecodable OPEN; missed CLOSE
+  degrades to the pre-existing idle-GC self-heal per #2880) — NOT the pre-#5483
+  silent skip. Standby: export early-returns not-primary (cheap no-op) + a
+  decoded delta is itself a no-op there, so advancing loses nothing and cannot
+  spin. Rate-limited resync trigger + WARN (control-socket + log-flood
+  protection). Go-side only. Rewrote the #5483 test to the corrected behavior
+  (advance + connection-survives + recovery frame dispatched) and added
+  `TestEventStreamPersistentUndecodableSessionFramesDoNotLoop_6130` (3 back-to-
+  back undecodable frames → watermark to recovery frame, exactly 1 resync, 2
+  suppressed). Parent-RED verified (target-count 1): reverting the advance +
+  restoring `return` turns both RED via assertion timeout, not a build break.
+  Docs: `docs/session-sync-architecture.md` FullResync section rewritten to state
+  the decode failure does NOT mirror the gap self-heal and how termination is now
+  guaranteed.
+- **File(s)**: `pkg/dataplane/userspace/eventstream.go`,
+  `pkg/dataplane/userspace/protocol.go`,
+  `pkg/dataplane/userspace/eventstream_decode_syncbreak_5483_test.go`,
+  `docs/session-sync-architecture.md`, `_Log.md`
+
 ## 2026-07-18 — #5483: undecodable session-sync frame must force a hard sync-break
 
 - **Timestamp**: 2026-07-18 (fix/5483-eventstream-decode-syncbreak)

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -23,8 +23,9 @@ The current implementation has four distinct pieces:
 
 The older mental model of "bulk once, then background sweep" is incomplete.
 Current failover safety depends on sender-side bulk acknowledgement, the
-continuous lossless userspace event stream (with gap → full-resync, see #2874),
-the demotion peer barrier, and filtered userspace delta replication.
+continuous lossless userspace event stream (with gap OR undecodable session
+frame → full-resync, see #2874 / #5483), the demotion peer barrier, and filtered
+userspace delta replication.
 
 ## Session Representation
 
@@ -634,9 +635,22 @@ post-snapshot sessions.
 
 This is **not** triggered by demotion prep. Its only live caller is
 `handleEventStreamFullResync` → `exportUserspaceOwnerRGSessionsWithConfig`: the
-event stream signals a FullResync after a #2874 sequence gap or a #2442
-delta-ring overflow (loss-of-sync), and the export republishes the full owned set
-from table truth. It is not the same thing as the steady-state delta drain.
+event stream signals a FullResync after a #2874 sequence gap, a #2442
+delta-ring overflow (loss-of-sync), or a #5483 **undecodable session frame**
+(a COMPLETE-but-semantically-rejected open/close/update — same severity as a
+gap, because the standby is missing that frame's session state), and the export
+republishes the full owned set from table truth. It is not the same thing as the
+steady-state delta drain.
+
+The #5483 case closes a silent-divergence hole: the reader used to skip an
+undecodable session frame with `DecodeErrors.Add(1); continue`, leaving the
+sequence watermark below the hole. A later lossy telemetry frame would then
+advance the cumulative ACK past the unapplied session seq, the helper's replay
+buffer would trim over it, and no subsequent gap would fire — so the standby
+diverged with no recovery. `handleSessionDecodeFailure` now forces the same
+resync + reconnect a gap forces and withholds the ACK past the hole. A decode
+failure on a lossy TELEMETRY frame is still tolerated (skipped, watermark
+advanced) — it carries no HA session state.
 
 The `rgIDs` handed to the export are enumerated from the **configured
 redundancy-group set** — `handleEventStreamFullResync` calls

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -647,10 +647,53 @@ undecodable session frame with `DecodeErrors.Add(1); continue`, leaving the
 sequence watermark below the hole. A later lossy telemetry frame would then
 advance the cumulative ACK past the unapplied session seq, the helper's replay
 buffer would trim over it, and no subsequent gap would fire — so the standby
-diverged with no recovery. `handleSessionDecodeFailure` now forces the same
-resync + reconnect a gap forces and withholds the ACK past the hole. A decode
-failure on a lossy TELEMETRY frame is still tolerated (skipped, watermark
-advanced) — it carries no HA session state.
+diverged with no recovery. `handleSessionDecodeFailure` forces a full resync
+from table truth.
+
+**#6130 — how a decode failure terminates (it does NOT mirror the #2874 gap
+self-heal).** The first #5483 fix reused the gap mechanics verbatim: force the
+resync, withhold the ACK, and drop the connection. That WEDGED the stream on a
+persistently-undecodable frame, because a decode failure is fundamentally
+different from a gap:
+
+- A #2874 **gap** self-heals precisely because the frame is **ABSENT**. On
+  reconnect the Rust `replay_buffered` sees `has_gap` (`oldest_buffered >
+  acked+1`) and parks a re-baselining FullResync barrier — the frame cannot be
+  re-sent because it was never buffered.
+- An **undecodable** frame is **PRESENT**. The Rust replay buffer stores encoded
+  frames and re-sends them verbatim; `has_gap` is FALSE for a present seq, so
+  **no** re-baselining barrier is parked. Withholding the ACK therefore makes
+  the helper re-send the identical frame on every reconnect: reconnect → replay
+  N → decode-fail → resync → drop → reconnect — an unbounded busy-loop that
+  hammers the shared control socket and floods the log (worst case on a STANDBY,
+  whose `handleEventStreamFullResync` is a corrective no-op — pure churn). The
+  bulk export (`ExportOwnerRGSessions`) publishes deltas peer-direct and never
+  injects into the local replay buffer, so it cannot evict frame N; only 4096
+  new live frames would — never, under no/low traffic.
+
+#6130 terminates the loop by **advancing the watermark PAST the undecodable
+frame** (unconditionally, on every such frame) and **keeping the connection
+alive** (mirroring the helper-initiated FullResync path #5362, not the gap
+path). The cumulative ACK then moves past seq N, the helper trims it
+(`front.seq <= acked`), and it is never re-sent — so a single bad frame yields
+**exactly one** resync and a persistently-undecodable stream yields at most one
+resync per `decodeFailureResyncInterval` (rate-limited; the rest counted in
+`DecodeResyncSuppressed`).
+
+Advancing past N does **not** reintroduce the #5483 divergence, because we
+advance only under cover of a resync that re-baselines from **table truth**: an
+undecodable OPEN's session is still in the helper table, so the unbounded export
+snapshot is a strict superset of the lost frame's state. An undecodable CLOSE
+degrades to the pre-existing "missed close → idle-GC self-heal" bounded
+staleness (a full owner-RG re-export cannot convey a delete — see #2880 above),
+NOT a permanent divergence. This is unlike the pre-#5483 silent skip, which
+advanced past N with **no** resync at all. **STANDBY:** the export early-returns
+"not primary" (a cheap no-op that never reaches the control socket), and a
+decoded session delta is itself a no-op on a standby (`handleEventStreamDelta`
+drops it for a non-primary), so advancing past the undecodable frame there loses
+nothing and the standby cannot spin. A decode failure on a lossy TELEMETRY frame
+is still tolerated (skipped, watermark advanced) — it carries no HA session
+state.
 
 The `rgIDs` handed to the export are enumerated from the **configured
 redundancy-group set** — `handleEventStreamFullResync` calls

--- a/pkg/dataplane/userspace/eventstream.go
+++ b/pkg/dataplane/userspace/eventstream.go
@@ -95,25 +95,42 @@ type EventStream struct {
 	FramesWritten atomic.Uint64
 	DecodeErrors  atomic.Uint64
 	SeqGaps       atomic.Uint64
-	// SessionSyncResyncs counts how many times a sequence gap on a
-	// correctness-critical session-sync frame (open/close/update) forced a
-	// full bulk re-export + reconnect (#2874). Distinct from SeqGaps, which
-	// also counts benign gaps on telemetry frames (which do NOT force a
-	// resync). A growing value means the helper's lossy producer is dropping
-	// session deltas under channel backpressure.
-	SessionSyncResyncs  atomic.Uint64
-	PolicyDenyEvents    atomic.Uint64
-	ScreenDropEvents    atomic.Uint64
-	ScreenAlarmEvents   atomic.Uint64 // screen event with action=PERMIT (#2298)
-	FilterLogEvents     atomic.Uint64
-	SessionCloseEvents  atomic.Uint64 // #2460: RT_FLOW SESSION_CLOSE frames
-	SessionCreateEvents atomic.Uint64 // #2508: RT_FLOW SESSION_CREATE frames
-	PolicyDenyDrops     atomic.Uint64
-	ScreenDropDrops     atomic.Uint64
-	FilterLogDrops      atomic.Uint64
-	SessionCloseDrops   atomic.Uint64 // #2460
-	SessionCreateDrops  atomic.Uint64 // #2508
-	UnknownFrameDrops   atomic.Uint64
+	// SessionSyncResyncs counts how many times a full bulk re-export was forced
+	// by a correctness-critical session-sync frame (open/close/update): either a
+	// sequence gap (#2874) or a COMPLETE-but-undecodable frame (#5483/#6130).
+	// Distinct from SeqGaps, which also counts benign gaps on telemetry frames
+	// (which do NOT force a resync). A growing value means the helper's lossy
+	// producer is dropping session deltas under channel backpressure, or its
+	// encoder is emitting frames this daemon cannot decode (a codec bug /
+	// version-skewed helper).
+	SessionSyncResyncs atomic.Uint64
+	// DecodeResyncSuppressed counts undecodable SESSION frames whose watermark
+	// was advanced past (loop-break, #6130) but whose full-resync trigger was
+	// rate-limited (a prior decode-failure resync fired within
+	// decodeFailureResyncInterval). A large value alongside SessionSyncResyncs
+	// staying small is the signature of a PERSISTENTLY-undecodable stream that
+	// the rate-limiter is throttling — the resync/reconnect loop the naive
+	// #5483 fix would have produced, now bounded.
+	DecodeResyncSuppressed atomic.Uint64
+	// lastDecodeResyncNanos is the wall-clock nanosecond timestamp of the last
+	// FIRED decode-failure resync. It rate-limits both the onFullResync trigger
+	// (shared control socket — must not be hammered, per CLAUDE.md) and the WARN
+	// log so a persistently-undecodable stream cannot flood either. The watermark
+	// advance in handleSessionDecodeFailure is NOT gated by it — advancing on
+	// every undecodable frame is what breaks the loop (#6130).
+	lastDecodeResyncNanos atomic.Int64
+	PolicyDenyEvents      atomic.Uint64
+	ScreenDropEvents      atomic.Uint64
+	ScreenAlarmEvents     atomic.Uint64 // screen event with action=PERMIT (#2298)
+	FilterLogEvents       atomic.Uint64
+	SessionCloseEvents    atomic.Uint64 // #2460: RT_FLOW SESSION_CLOSE frames
+	SessionCreateEvents   atomic.Uint64 // #2508: RT_FLOW SESSION_CREATE frames
+	PolicyDenyDrops       atomic.Uint64
+	ScreenDropDrops       atomic.Uint64
+	FilterLogDrops        atomic.Uint64
+	SessionCloseDrops     atomic.Uint64 // #2460
+	SessionCreateDrops    atomic.Uint64 // #2508
+	UnknownFrameDrops     atomic.Uint64
 }
 
 // NewEventStream creates an EventStream for the given Unix socket path.
@@ -395,23 +412,24 @@ func (es *EventStream) LastAckedSequence() uint64 {
 
 func (es *EventStream) Status() EventStreamStatus {
 	return EventStreamStatus{
-		FramesRead:          es.FramesRead.Load(),
-		FramesWritten:       es.FramesWritten.Load(),
-		DecodeErrors:        es.DecodeErrors.Load(),
-		SeqGaps:             es.SeqGaps.Load(),
-		SessionSyncResyncs:  es.SessionSyncResyncs.Load(),
-		PolicyDenyEvents:    es.PolicyDenyEvents.Load(),
-		ScreenDropEvents:    es.ScreenDropEvents.Load(),
-		ScreenAlarmEvents:   es.ScreenAlarmEvents.Load(),
-		FilterLogEvents:     es.FilterLogEvents.Load(),
-		SessionCloseEvents:  es.SessionCloseEvents.Load(),
-		SessionCreateEvents: es.SessionCreateEvents.Load(),
-		PolicyDenyDrops:     es.PolicyDenyDrops.Load(),
-		ScreenDropDrops:     es.ScreenDropDrops.Load(),
-		FilterLogDrops:      es.FilterLogDrops.Load(),
-		SessionCloseDrops:   es.SessionCloseDrops.Load(),
-		SessionCreateDrops:  es.SessionCreateDrops.Load(),
-		UnknownFrameDrops:   es.UnknownFrameDrops.Load(),
+		FramesRead:             es.FramesRead.Load(),
+		FramesWritten:          es.FramesWritten.Load(),
+		DecodeErrors:           es.DecodeErrors.Load(),
+		SeqGaps:                es.SeqGaps.Load(),
+		SessionSyncResyncs:     es.SessionSyncResyncs.Load(),
+		DecodeResyncSuppressed: es.DecodeResyncSuppressed.Load(),
+		PolicyDenyEvents:       es.PolicyDenyEvents.Load(),
+		ScreenDropEvents:       es.ScreenDropEvents.Load(),
+		ScreenAlarmEvents:      es.ScreenAlarmEvents.Load(),
+		FilterLogEvents:        es.FilterLogEvents.Load(),
+		SessionCloseEvents:     es.SessionCloseEvents.Load(),
+		SessionCreateEvents:    es.SessionCreateEvents.Load(),
+		PolicyDenyDrops:        es.PolicyDenyDrops.Load(),
+		ScreenDropDrops:        es.ScreenDropDrops.Load(),
+		FilterLogDrops:         es.FilterLogDrops.Load(),
+		SessionCloseDrops:      es.SessionCloseDrops.Load(),
+		SessionCreateDrops:     es.SessionCreateDrops.Load(),
+		UnknownFrameDrops:      es.UnknownFrameDrops.Load(),
 	}
 }
 
@@ -535,16 +553,14 @@ func (es *EventStream) readLoop(ctx context.Context) {
 		case EventTypeSessionOpen, EventTypeSessionUpdate:
 			delta, ok := decodeSessionEvent(payload)
 			if !ok {
-				// #5483: a COMPLETE but semantically undecodable session-sync
-				// frame is a HARD sync break, exactly like a #2874 sequence gap
-				// — it carries session state the standby needs. Skipping it with
-				// `continue` (the pre-#5483 bug) would let a later telemetry
-				// frame advance the cumulative ACK past this seq, trimming the
-				// helper's replay buffer over the unapplied session state and
-				// silently diverging the standby. Force a full resync instead;
-				// do NOT advance prevSeq/lastAppliedSeq/ACK past the hole.
-				es.handleSessionDecodeFailure(seq)
-				return
+				// #5483/#6130: a COMPLETE but semantically undecodable
+				// session-sync frame carries session state the standby needs,
+				// so it forces a full resync — but UNLIKE a #2874 gap the frame
+				// is PRESENT on the wire, so the watermark is advanced past it
+				// (loop-break) and the connection kept alive. See
+				// handleSessionDecodeFailure.
+				es.handleSessionDecodeFailure(seq, &prevSeq)
+				continue
 			}
 			if typ == EventTypeSessionOpen {
 				delta.Event = "open"
@@ -571,11 +587,11 @@ func (es *EventStream) readLoop(ctx context.Context) {
 		case EventTypeSessionClose:
 			delta, ok := decodeSessionCloseEvent(payload)
 			if !ok {
-				// #5483: see the SessionOpen/Update case — an undecodable
-				// session CLOSE frame forces a resync rather than silently
-				// dropping the close and ACKing past it.
-				es.handleSessionDecodeFailure(seq)
-				return
+				// #5483/#6130: see the SessionOpen/Update case — an undecodable
+				// session CLOSE frame forces a resync and advances the watermark
+				// past the present-but-undecodable frame (loop-break).
+				es.handleSessionDecodeFailure(seq, &prevSeq)
+				continue
 			}
 			delta.Event = "close"
 			// #2874: see the SessionOpen/Update case — a session-sync gap forces
@@ -708,47 +724,107 @@ func (es *EventStream) handleSessionSyncGap(expected, got uint64) {
 	}
 }
 
+// decodeFailureResyncInterval rate-limits BOTH the full-resync trigger and the
+// WARN log emitted for a run of COMPLETE-but-undecodable SESSION frames. Under a
+// persistent codec bug / version-skewed helper EVERY session frame is
+// undecodable, so an un-throttled per-frame onFullResync would hammer the shared
+// control socket (which CLAUDE.md forbids at >1/s) and flood the log. Kept
+// comfortably above 1s. The watermark advance is NOT throttled by this.
+const decodeFailureResyncInterval = 2 * time.Second
+
 // handleSessionDecodeFailure responds to a COMPLETE but semantically
 // undecodable session-sync frame (open/close/update) at seq — the #5483 HA
-// data-loss fix. It reuses the #2874 gap sync-break mechanics for a decode
-// rejection of a PRESENT frame.
+// data-loss fix, corrected for the #6130 resync/reconnect loop.
 //
 // A session frame whose length prefix was read in full but that the typed
 // decoder rejects (short/malformed payload, unknown address family) still
 // carries session state the standby needs. The pre-#5483 code skipped it with
-// `es.DecodeErrors.Add(1); continue`, leaving prevSeq/lastAppliedSeq at the
-// contiguous sequence BELOW the hole. A subsequent lossy TELEMETRY frame at
-// seq+1 would then merely record a benign gap, mark itself applied, and let
-// sendAckIfNeeded advance the cumulative ACK PAST this undecodable session seq.
-// The Rust replay buffer (userspace-dp/src/event_stream/mod.rs) trims through
-// the ACK watermark, discarding the never-applied session frame — and because
-// the telemetry frame already advanced prevSeq, no later session frame trips
-// the gap check, so the standby silently diverges with no path to recovery.
+// `es.DecodeErrors.Add(1); continue`, leaving prevSeq/lastAppliedSeq BELOW the
+// hole; a subsequent lossy TELEMETRY frame then advanced the cumulative ACK
+// PAST the undecodable session seq, the Rust replay buffer trimmed the
+// never-applied frame, and the standby silently diverged.
 //
-// This is exactly the divergence handleSessionSyncGap prevents for a producer-
-// DROPPED delta, so the response is identical: bump SessionSyncResyncs, force a
-// full bulk re-export (onFullResync → handleEventStreamFullResync), and return
-// so the reader drops the connection. prevSeq/lastAppliedSeq are NOT advanced
-// past seq, so the cumulative ACK can never move past the undecodable session
-// frame; on reconnect the helper replays from the last CONTIGUOUS ack and the
-// resync re-derives a complete session snapshot from table truth.
+// #5483 (b9cb3eb34) closed that by forcing a resync and NOT advancing the
+// watermark — but that WEDGED the stream on a PERSISTENTLY-undecodable frame.
+// The frame is PRESENT on the wire, not a #2874 gap: the Rust replay buffer
+// (userspace-dp/src/event_stream/mod.rs) stores encoded frames and re-sends
+// them VERBATIM. `replay_buffered` only parks a re-baselining FullResync barrier
+// when a seq is ABSENT (`has_gap` == oldest_buffered > acked+1); a
+// present-but-undecodable frame has NO such backstop. So withholding the ACK
+// made the helper re-send the same frame on every reconnect: reconnect → replay
+// N → decode fail → resync → drop → reconnect, an unbounded busy-loop hammering
+// the control socket and flooding the log (worst case on a STANDBY, whose
+// onFullResync is a corrective no-op — pure churn).
+//
+// #6130 breaks the loop by ADVANCING the watermark PAST the undecodable frame
+// (markFrameApplied + prevSeq), unconditionally, on every undecodable frame.
+// sendAckIfNeeded then ACKs past seq, the helper trims it (`front.seq <=
+// acked`), and it is NEVER re-sent. The connection is KEPT (the caller
+// `continue`s, mirroring the helper-initiated FullResync path #5362) because
+// there is nothing to replay.
+//
+// Anti-divergence — why advancing past seq does NOT reintroduce the #5483 bug:
+// we advance ONLY as part of triggering a FullResync that re-baselines the peer
+// from TABLE TRUTH (onFullResync → handleEventStreamFullResync →
+// ExportOwnerRGSessions, an UNBOUNDED ground-truth snapshot). For an undecodable
+// OPEN the session is still in the helper's table, so the snapshot re-derives it
+// — a strict superset of the lost frame's state. For an undecodable CLOSE the
+// export cannot convey a delete (docs/session-sync-architecture.md #2880), so it
+// degrades to the pre-existing "missed close → idle-GC self-heal" bounded
+// staleness — NOT a permanent divergence. This is fundamentally unlike the
+// pre-#5483 silent skip, which advanced past seq with NO resync at all.
+//
+// The resync trigger + log are RATE-LIMITED (decodeFailureResyncInterval). A
+// single bad frame fires exactly one resync (the realistic non-catastrophic
+// case). A persistent-skew stream fires at most one resync per interval and
+// counts the rest in DecodeResyncSuppressed; each fired resync is a full
+// snapshot, so the peer is re-baselined at ≤1 interval of staleness. A
+// suppressed frame's session, if still live, is re-derived by the next fired
+// resync (or its own subsequent decodable UPDATE, treated as an open). The fire
+// is best-effort: the watermark advances even if onFullResync returns false or
+// there is no callback, because breaking the loop is the hard guarantee and the
+// periodic sweep reconcile + reconnect bulk sync are independent resync
+// backstops.
+//
+// STANDBY: handleEventStreamFullResync early-returns "not primary" (a cheap
+// no-op — it never reaches the control socket), so a standby that reads an
+// undecodable session frame from its OWN helper still advances + rate-limits
+// here and cannot spin. Advancing is divergence-safe on a standby anyway: a
+// decoded session delta is itself a no-op there (handleEventStreamDelta drops it
+// for a non-primary), so nothing is lost by skipping the undecodable one.
 //
 // Scope: SESSION frames ONLY. A decode failure on a lossy TELEMETRY/stats frame
-// stays tolerable to skip (DecodeErrors + drop-counter + markDroppedFrameApplied,
-// which advances the watermark) — the existing severity model. Telemetry is
-// best-effort and carries no HA session state, so skipping one cannot diverge
-// the standby.
-func (es *EventStream) handleSessionDecodeFailure(seq uint64) {
+// stays tolerable to skip (DecodeErrors + drop-counter + markDroppedFrameApplied)
+// — telemetry carries no HA session state.
+func (es *EventStream) handleSessionDecodeFailure(seq uint64, prevSeq *uint64) {
 	es.DecodeErrors.Add(1)
-	es.SessionSyncResyncs.Add(1)
-	slog.Warn("event stream: undecodable session-sync frame; forcing full resync",
-		"seq", seq, "last_applied", es.lastAppliedSeq.Load())
-	es.callbackMu.RLock()
-	onFullResync := es.onFullResync
-	es.callbackMu.RUnlock()
-	if onFullResync != nil {
-		onFullResync()
+
+	// Rate-limited resync trigger + WARN. Fire BEFORE advancing the watermark so
+	// the table-truth snapshot is triggered while lastAppliedSeq still sits below
+	// the hole — the ACK only moves past seq after this returns.
+	nowNanos := time.Now().UnixNano()
+	last := es.lastDecodeResyncNanos.Load()
+	if last == 0 || nowNanos-last >= int64(decodeFailureResyncInterval) {
+		es.lastDecodeResyncNanos.Store(nowNanos)
+		es.SessionSyncResyncs.Add(1)
+		slog.Warn("event stream: undecodable session-sync frame; forcing rate-limited full resync",
+			"seq", seq, "last_applied", es.lastAppliedSeq.Load())
+		es.callbackMu.RLock()
+		onFullResync := es.onFullResync
+		es.callbackMu.RUnlock()
+		if onFullResync != nil {
+			onFullResync()
+		}
+	} else {
+		es.DecodeResyncSuppressed.Add(1)
 	}
+
+	// Loop-break (#6130): advance PAST the present-but-undecodable frame
+	// unconditionally so the cumulative ACK trims it from the helper's replay
+	// buffer and it is never re-sent.
+	*prevSeq = seq
+	es.lastRecvSeq.Store(seq)
+	es.markFrameApplied(seq)
 }
 
 func (es *EventStream) backoffCallbackNotReady(ctx context.Context) {

--- a/pkg/dataplane/userspace/eventstream.go
+++ b/pkg/dataplane/userspace/eventstream.go
@@ -535,8 +535,16 @@ func (es *EventStream) readLoop(ctx context.Context) {
 		case EventTypeSessionOpen, EventTypeSessionUpdate:
 			delta, ok := decodeSessionEvent(payload)
 			if !ok {
-				es.DecodeErrors.Add(1)
-				continue
+				// #5483: a COMPLETE but semantically undecodable session-sync
+				// frame is a HARD sync break, exactly like a #2874 sequence gap
+				// — it carries session state the standby needs. Skipping it with
+				// `continue` (the pre-#5483 bug) would let a later telemetry
+				// frame advance the cumulative ACK past this seq, trimming the
+				// helper's replay buffer over the unapplied session state and
+				// silently diverging the standby. Force a full resync instead;
+				// do NOT advance prevSeq/lastAppliedSeq/ACK past the hole.
+				es.handleSessionDecodeFailure(seq)
+				return
 			}
 			if typ == EventTypeSessionOpen {
 				delta.Event = "open"
@@ -563,8 +571,11 @@ func (es *EventStream) readLoop(ctx context.Context) {
 		case EventTypeSessionClose:
 			delta, ok := decodeSessionCloseEvent(payload)
 			if !ok {
-				es.DecodeErrors.Add(1)
-				continue
+				// #5483: see the SessionOpen/Update case — an undecodable
+				// session CLOSE frame forces a resync rather than silently
+				// dropping the close and ACKing past it.
+				es.handleSessionDecodeFailure(seq)
+				return
 			}
 			delta.Event = "close"
 			// #2874: see the SessionOpen/Update case — a session-sync gap forces
@@ -693,6 +704,49 @@ func (es *EventStream) handleSessionSyncGap(expected, got uint64) {
 		// Best-effort: the reconnect below is the backstop. The helper's own
 		// replay_buffered() also re-issues a FullResync when its window cannot
 		// cover acked+1, so a missed trigger here still self-heals.
+		onFullResync()
+	}
+}
+
+// handleSessionDecodeFailure responds to a COMPLETE but semantically
+// undecodable session-sync frame (open/close/update) at seq — the #5483 HA
+// data-loss fix. It reuses the #2874 gap sync-break mechanics for a decode
+// rejection of a PRESENT frame.
+//
+// A session frame whose length prefix was read in full but that the typed
+// decoder rejects (short/malformed payload, unknown address family) still
+// carries session state the standby needs. The pre-#5483 code skipped it with
+// `es.DecodeErrors.Add(1); continue`, leaving prevSeq/lastAppliedSeq at the
+// contiguous sequence BELOW the hole. A subsequent lossy TELEMETRY frame at
+// seq+1 would then merely record a benign gap, mark itself applied, and let
+// sendAckIfNeeded advance the cumulative ACK PAST this undecodable session seq.
+// The Rust replay buffer (userspace-dp/src/event_stream/mod.rs) trims through
+// the ACK watermark, discarding the never-applied session frame — and because
+// the telemetry frame already advanced prevSeq, no later session frame trips
+// the gap check, so the standby silently diverges with no path to recovery.
+//
+// This is exactly the divergence handleSessionSyncGap prevents for a producer-
+// DROPPED delta, so the response is identical: bump SessionSyncResyncs, force a
+// full bulk re-export (onFullResync → handleEventStreamFullResync), and return
+// so the reader drops the connection. prevSeq/lastAppliedSeq are NOT advanced
+// past seq, so the cumulative ACK can never move past the undecodable session
+// frame; on reconnect the helper replays from the last CONTIGUOUS ack and the
+// resync re-derives a complete session snapshot from table truth.
+//
+// Scope: SESSION frames ONLY. A decode failure on a lossy TELEMETRY/stats frame
+// stays tolerable to skip (DecodeErrors + drop-counter + markDroppedFrameApplied,
+// which advances the watermark) — the existing severity model. Telemetry is
+// best-effort and carries no HA session state, so skipping one cannot diverge
+// the standby.
+func (es *EventStream) handleSessionDecodeFailure(seq uint64) {
+	es.DecodeErrors.Add(1)
+	es.SessionSyncResyncs.Add(1)
+	slog.Warn("event stream: undecodable session-sync frame; forcing full resync",
+		"seq", seq, "last_applied", es.lastAppliedSeq.Load())
+	es.callbackMu.RLock()
+	onFullResync := es.onFullResync
+	es.callbackMu.RUnlock()
+	if onFullResync != nil {
 		onFullResync()
 	}
 }

--- a/pkg/dataplane/userspace/eventstream_decode_syncbreak_5483_test.go
+++ b/pkg/dataplane/userspace/eventstream_decode_syncbreak_5483_test.go
@@ -1,0 +1,239 @@
+package userspace
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestEventStreamUndecodableSessionFrameForcesResync_5483 pins the #5483 fix: a
+// COMPLETE but semantically undecodable SESSION frame (open/close/update) must
+// force the same hard sync-break a #2874 sequence gap forces — it must NOT be
+// silently skipped, and the cumulative ACK must NOT advance past its sequence.
+//
+// The divergence the fix closes (pre-#5483 behaviour):
+//   - seq 1  session open (decodes OK)        -> applied, watermark = 1
+//   - seq 2  session open, UNDECODABLE        -> `DecodeErrors.Add(1); continue`
+//                                                skipped it, leaving prevSeq=1
+//   - seq 3  telemetry frame (decodes OK)     -> only records a benign gap,
+//                                                marks itself applied, advancing
+//                                                lastAppliedSeq to 3
+//     sendAckIfNeeded then ACKs seq 3, the Rust replay buffer trims through 3
+//     (INCLUDING the never-applied session frame 2), and no later gap fires ->
+//     the standby has silently diverged with no recovery.
+//
+// With the fix, seq 2 routes through handleSessionDecodeFailure: SessionSyncResyncs
+// is bumped, onFullResync fires, and the reader returns (drops the connection)
+// WITHOUT advancing the watermark. The queued telemetry frame at seq 3 is never
+// read, so lastAppliedSeq stays at 1 and the ACK never moves past the hole.
+//
+// Fail-on-revert (target-count 1): restore the EventTypeSessionOpen decode-failure
+// arm to `es.DecodeErrors.Add(1); continue`. Then seq 2 is skipped, seq 3 is
+// dispatched and advances lastAppliedSeq to 3, onFullResync is never called, and
+// SessionSyncResyncs stays 0 — turning the resync/onFullResync/watermark
+// assertions RED.
+func TestEventStreamUndecodableSessionFrameForcesResync_5483(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test-events.sock")
+
+	es := NewEventStream(sockPath)
+	es.SetOnEvent(func(uint8, uint64, SessionDeltaInfo) bool { return true })
+	// A telemetry consumer so a surviving seq-3 telemetry frame (the reverted
+	// path) is actually dispatched and advances the watermark.
+	es.SetOnRawDataplaneEvent(func(uint64, []byte) {})
+	var resyncCalled atomic.Bool
+	es.SetOnFullResync(func() bool {
+		resyncCalled.Store(true)
+		return true
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	es.Start(ctx)
+	defer es.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	dl := time.Now().Add(2 * time.Second)
+	for !es.IsConnected() {
+		if time.Now().After(dl) {
+			t.Fatal("not connected")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	sessionPayload := buildSessionOpenV4Payload(
+		6, 1000, 80,
+		[4]byte{10, 0, 1, 1}, [4]byte{10, 0, 2, 1},
+		[4]byte{}, [4]byte{},
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		[6]byte{}, [6]byte{}, [4]byte{},
+	)
+
+	// Establish a contiguous baseline at seq 1 and wait for it to be applied so
+	// the ACK watermark is anchored at 1.
+	if err := writeFrame(conn, EventTypeSessionOpen, 1, sessionPayload); err != nil {
+		t.Fatalf("write seq 1: %v", err)
+	}
+	dl = time.Now().Add(2 * time.Second)
+	for es.lastAppliedSeq.Load() != 1 {
+		if time.Now().After(dl) {
+			t.Fatalf("seq 1 not applied; lastApplied=%d", es.lastAppliedSeq.Load())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// seq 2: a COMPLETE session-open frame (full 64-byte payload, fully read off
+	// the wire) whose content the typed decoder rejects — an invalid address
+	// family makes decodeSessionEvent return ok=false. This is "present but
+	// undecodable", NOT a truncated-on-wire frame.
+	undecodable := append([]byte(nil), sessionPayload...)
+	undecodable[0] = 7 // invalid AddrFamily (valid values are 4/6) -> decode fails
+	if err := writeFrame(conn, EventTypeSessionOpen, 2, undecodable); err != nil {
+		t.Fatalf("write seq 2 (undecodable): %v", err)
+	}
+
+	// seq 3: a valid telemetry frame queued immediately behind the undecodable
+	// session frame. In the reverted (buggy) path this is read on the still-open
+	// connection and advances lastAppliedSeq to 3 — the ACK-past-the-hole that
+	// silently diverges the standby. In the fixed path the connection has already
+	// been dropped, so this frame is never read. The write may error (broken
+	// pipe) once the server closes its side — that is expected; ignore it.
+	telemetryPayload := buildDataplaneEventV4Payload(
+		6, 1111, 443,
+		[4]byte{10, 0, 1, 5}, [4]byte{172, 16, 80, 200},
+		[4]byte{172, 16, 80, 8},
+		40000,
+		1, 2,
+		0, 77,
+		0,
+	)
+	_ = writeFrame(conn, EventFrameTypePolicyDeny, 3, telemetryPayload)
+
+	// Terminal condition: EITHER the fix forced a resync, OR the buggy path let
+	// the watermark advance past the hole. Whichever happens, stop waiting.
+	dl = time.Now().Add(2 * time.Second)
+	for !resyncCalled.Load() && es.lastAppliedSeq.Load() < 3 {
+		if time.Now().After(dl) {
+			t.Fatal("neither resync fired nor watermark advanced within timeout")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Small settle so a mistakenly-dispatched seq 3 has fully advanced the
+	// watermark before we assert (guards against reading mid-dispatch).
+	time.Sleep(50 * time.Millisecond)
+
+	if !resyncCalled.Load() {
+		t.Fatal("undecodable session frame did not trigger onFullResync (#5483): " +
+			"it was silently skipped instead of forcing a hard sync-break")
+	}
+	if got := es.SessionSyncResyncs.Load(); got != 1 {
+		t.Fatalf("SessionSyncResyncs = %d, want 1 (an undecodable session frame "+
+			"must force exactly one resync, like a #2874 gap)", got)
+	}
+	// CORE #5483 invariant: the cumulative ACK/applied watermark must NOT have
+	// advanced past the undecodable session seq (2). It must stay anchored at the
+	// last contiguous sequence (1); a later telemetry frame must not be able to
+	// carry it to 3.
+	if applied := es.lastAppliedSeq.Load(); applied > 1 {
+		t.Fatalf("lastAppliedSeq advanced past the undecodable session frame: "+
+			"got %d, want 1 — the ACK moved past unapplied session state, which "+
+			"lets the Rust replay buffer trim it and silently diverge the standby (#5483)", applied)
+	}
+	if acked := es.lastAckSeq.Load(); acked > 1 {
+		t.Fatalf("ACK advanced past the undecodable session frame: lastAckSeq=%d, want <=1", acked)
+	}
+	// The decode failure is still accounted as a decode error.
+	if got := es.DecodeErrors.Load(); got != 1 {
+		t.Fatalf("DecodeErrors = %d, want 1", got)
+	}
+}
+
+// TestEventStreamUndecodableTelemetryFrameStillSkips_5483 pins the SCOPE of the
+// #5483 fix: the hard sync-break applies to SESSION frames ONLY. A COMPLETE but
+// undecodable TELEMETRY (RT_FLOW) frame stays tolerable to skip — it carries no
+// HA session state, so it must NOT force a resync. The reader accounts it
+// (DecodeErrors + drop counter), advances the watermark past it
+// (markDroppedFrameApplied), and keeps the connection alive.
+//
+// Fail-on-revert guard: if the session hard-break policy were mistakenly widened
+// to telemetry frames, onFullResync would fire and the following telemetry frame
+// would not be dispatched.
+func TestEventStreamUndecodableTelemetryFrameStillSkips_5483(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test-events.sock")
+
+	es := NewEventStream(sockPath)
+	gotSeqs := make(chan uint64, 4)
+	es.SetOnRawDataplaneEvent(func(seq uint64, _ []byte) { gotSeqs <- seq })
+	var resyncCalled atomic.Bool
+	es.SetOnFullResync(func() bool {
+		resyncCalled.Store(true)
+		return true
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	es.Start(ctx)
+	defer es.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	dl := time.Now().Add(2 * time.Second)
+	for !es.IsConnected() {
+		if time.Now().After(dl) {
+			t.Fatal("not connected")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	goodTelemetry := buildDataplaneEventV4Payload(
+		6, 1111, 443,
+		[4]byte{10, 0, 1, 5}, [4]byte{172, 16, 80, 200},
+		[4]byte{172, 16, 80, 8},
+		40000,
+		1, 2,
+		0, 77,
+		0,
+	)
+
+	// seq 1: an undecodable telemetry frame (too short to match the frame's
+	// event-type gate) — skipped, watermark advanced.
+	if err := writeFrame(conn, EventFrameTypePolicyDeny, 1, []byte{4, 6}); err != nil {
+		t.Fatalf("write seq 1 (undecodable telemetry): %v", err)
+	}
+	// seq 2: a valid telemetry frame that must still be dispatched over the
+	// still-alive connection.
+	if err := writeFrame(conn, EventFrameTypePolicyDeny, 2, goodTelemetry); err != nil {
+		t.Fatalf("write seq 2: %v", err)
+	}
+
+	select {
+	case s := <-gotSeqs:
+		if s != 2 {
+			t.Fatalf("dispatched telemetry seq = %d, want 2", s)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("valid telemetry frame after an undecodable telemetry frame was not dispatched")
+	}
+
+	if resyncCalled.Load() {
+		t.Fatal("an undecodable TELEMETRY frame must NOT force a resync (#5483 scope: session frames only)")
+	}
+	if got := es.SessionSyncResyncs.Load(); got != 0 {
+		t.Fatalf("SessionSyncResyncs = %d, want 0 for an undecodable telemetry frame", got)
+	}
+}

--- a/pkg/dataplane/userspace/eventstream_decode_syncbreak_5483_test.go
+++ b/pkg/dataplane/userspace/eventstream_decode_syncbreak_5483_test.go
@@ -9,41 +9,57 @@ import (
 	"time"
 )
 
-// TestEventStreamUndecodableSessionFrameForcesResync_5483 pins the #5483 fix: a
-// COMPLETE but semantically undecodable SESSION frame (open/close/update) must
-// force the same hard sync-break a #2874 sequence gap forces — it must NOT be
-// silently skipped, and the cumulative ACK must NOT advance past its sequence.
+// waitForConnected spins until the helper connection is accepted or the deadline
+// elapses.
+func waitForConnected(t *testing.T, es *EventStream) {
+	t.Helper()
+	dl := time.Now().Add(2 * time.Second)
+	for !es.IsConnected() {
+		if time.Now().After(dl) {
+			t.Fatal("not connected")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestEventStreamUndecodableSessionFrameForcesResyncAndAdvances_5483_6130 pins
+// the corrected fix: a COMPLETE but semantically undecodable SESSION frame must
 //
-// The divergence the fix closes (pre-#5483 behaviour):
-//   - seq 1  session open (decodes OK)        -> applied, watermark = 1
-//   - seq 2  session open, UNDECODABLE        -> `DecodeErrors.Add(1); continue`
-//                                                skipped it, leaving prevSeq=1
-//   - seq 3  telemetry frame (decodes OK)     -> only records a benign gap,
-//                                                marks itself applied, advancing
-//                                                lastAppliedSeq to 3
-//     sendAckIfNeeded then ACKs seq 3, the Rust replay buffer trims through 3
-//     (INCLUDING the never-applied session frame 2), and no later gap fires ->
-//     the standby has silently diverged with no recovery.
+//  1. force a full resync (onFullResync fires, SessionSyncResyncs bumps) — the
+//     #5483 anti-divergence guarantee — AND
+//  2. ADVANCE the watermark PAST its sequence and KEEP the connection alive
+//     (#6130 loop-break), so the helper's replay buffer trims the frame and it
+//     is never re-sent verbatim.
 //
-// With the fix, seq 2 routes through handleSessionDecodeFailure: SessionSyncResyncs
-// is bumped, onFullResync fires, and the reader returns (drops the connection)
-// WITHOUT advancing the watermark. The queued telemetry frame at seq 3 is never
-// read, so lastAppliedSeq stays at 1 and the ACK never moves past the hole.
+// The #6130 defect in the naive #5483 fix (b9cb3eb34): it forced the resync but
+// WITHHELD the ACK and dropped the connection. Because the frame is PRESENT on
+// the wire (not a #2874 gap), the Rust replay buffer re-sends it verbatim on
+// every reconnect and `has_gap` never parks a re-baselining barrier for it — a
+// deterministic resync/reconnect busy-loop. Advancing the watermark under cover
+// of the table-truth resync breaks the loop without reintroducing divergence.
 //
-// Fail-on-revert (target-count 1): restore the EventTypeSessionOpen decode-failure
-// arm to `es.DecodeErrors.Add(1); continue`. Then seq 2 is skipped, seq 3 is
-// dispatched and advances lastAppliedSeq to 3, onFullResync is never called, and
-// SessionSyncResyncs stays 0 — turning the resync/onFullResync/watermark
-// assertions RED.
-func TestEventStreamUndecodableSessionFrameForcesResync_5483(t *testing.T) {
+// Parent-RED map (target-count 1): revert handleSessionDecodeFailure to NOT
+// advance the watermark + have the caller `return` instead of `continue`
+// (restoring b9cb3eb34). Then:
+//   - line "assert applied advanced past the hole" (lastAppliedSeq >= 2) goes
+//     RED: the reverted path leaves lastAppliedSeq stuck at the baseline (1),
+//     because the connection is dropped at seq 2 and the recovery frame at seq 3
+//     is never read.
+//   - the "recovery frame dispatched" assertion also goes RED (seq 3 never
+//     reaches onEvent on the dropped connection).
+//
+// The resync/SessionSyncResyncs/DecodeErrors assertions stay GREEN across the
+// revert, so the advance is the single behaviour under test.
+func TestEventStreamUndecodableSessionFrameForcesResyncAndAdvances_5483_6130(t *testing.T) {
 	dir := t.TempDir()
 	sockPath := filepath.Join(dir, "test-events.sock")
 
 	es := NewEventStream(sockPath)
-	es.SetOnEvent(func(uint8, uint64, SessionDeltaInfo) bool { return true })
-	// A telemetry consumer so a surviving seq-3 telemetry frame (the reverted
-	// path) is actually dispatched and advances the watermark.
-	es.SetOnRawDataplaneEvent(func(uint64, []byte) {})
+	dispatched := make(chan uint64, 4)
+	es.SetOnEvent(func(_ uint8, seq uint64, _ SessionDeltaInfo) bool {
+		dispatched <- seq
+		return true
+	})
 	var resyncCalled atomic.Bool
 	es.SetOnFullResync(func() bool {
 		resyncCalled.Store(true)
@@ -61,16 +77,9 @@ func TestEventStreamUndecodableSessionFrameForcesResync_5483(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	defer conn.Close()
+	waitForConnected(t, es)
 
-	dl := time.Now().Add(2 * time.Second)
-	for !es.IsConnected() {
-		if time.Now().After(dl) {
-			t.Fatal("not connected")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	sessionPayload := buildSessionOpenV4Payload(
+	good := buildSessionOpenV4Payload(
 		6, 1000, 80,
 		[4]byte{10, 0, 1, 1}, [4]byte{10, 0, 2, 1},
 		[4]byte{}, [4]byte{},
@@ -78,87 +87,176 @@ func TestEventStreamUndecodableSessionFrameForcesResync_5483(t *testing.T) {
 		[6]byte{}, [6]byte{}, [4]byte{},
 	)
 
-	// Establish a contiguous baseline at seq 1 and wait for it to be applied so
-	// the ACK watermark is anchored at 1.
-	if err := writeFrame(conn, EventTypeSessionOpen, 1, sessionPayload); err != nil {
+	// seq 1: decodable baseline — establishes the contiguous watermark at 1.
+	if err := writeFrame(conn, EventTypeSessionOpen, 1, good); err != nil {
 		t.Fatalf("write seq 1: %v", err)
 	}
-	dl = time.Now().Add(2 * time.Second)
-	for es.lastAppliedSeq.Load() != 1 {
-		if time.Now().After(dl) {
-			t.Fatalf("seq 1 not applied; lastApplied=%d", es.lastAppliedSeq.Load())
-		}
-		time.Sleep(5 * time.Millisecond)
+	if got := <-dispatched; got != 1 {
+		t.Fatalf("baseline dispatched seq = %d, want 1", got)
 	}
 
-	// seq 2: a COMPLETE session-open frame (full 64-byte payload, fully read off
-	// the wire) whose content the typed decoder rejects — an invalid address
-	// family makes decodeSessionEvent return ok=false. This is "present but
-	// undecodable", NOT a truncated-on-wire frame.
-	undecodable := append([]byte(nil), sessionPayload...)
-	undecodable[0] = 7 // invalid AddrFamily (valid values are 4/6) -> decode fails
+	// seq 2: a COMPLETE session-open frame (full 64-byte payload) with an invalid
+	// address family — decodeSessionEvent returns ok=false. Present-but-
+	// undecodable, NOT truncated on the wire.
+	undecodable := append([]byte(nil), good...)
+	undecodable[0] = 7 // invalid AddrFamily (valid: 4/6) -> decode fails
 	if err := writeFrame(conn, EventTypeSessionOpen, 2, undecodable); err != nil {
 		t.Fatalf("write seq 2 (undecodable): %v", err)
 	}
 
-	// seq 3: a valid telemetry frame queued immediately behind the undecodable
-	// session frame. In the reverted (buggy) path this is read on the still-open
-	// connection and advances lastAppliedSeq to 3 — the ACK-past-the-hole that
-	// silently diverges the standby. In the fixed path the connection has already
-	// been dropped, so this frame is never read. The write may error (broken
-	// pipe) once the server closes its side — that is expected; ignore it.
-	telemetryPayload := buildDataplaneEventV4Payload(
-		6, 1111, 443,
-		[4]byte{10, 0, 1, 5}, [4]byte{172, 16, 80, 200},
-		[4]byte{172, 16, 80, 8},
-		40000,
-		1, 2,
-		0, 77,
-		0,
-	)
-	_ = writeFrame(conn, EventFrameTypePolicyDeny, 3, telemetryPayload)
-
-	// Terminal condition: EITHER the fix forced a resync, OR the buggy path let
-	// the watermark advance past the hole. Whichever happens, stop waiting.
-	dl = time.Now().Add(2 * time.Second)
-	for !resyncCalled.Load() && es.lastAppliedSeq.Load() < 3 {
-		if time.Now().After(dl) {
-			t.Fatal("neither resync fired nor watermark advanced within timeout")
-		}
-		time.Sleep(5 * time.Millisecond)
+	// seq 3: a decodable session frame on the SAME connection. With the fix the
+	// connection survives the undecodable frame and this is dispatched, proving
+	// no reconnect loop and normal recovery. In the reverted (buggy) path the
+	// connection was dropped at seq 2 and this is never read.
+	if err := writeFrame(conn, EventTypeSessionOpen, 3, good); err != nil {
+		t.Fatalf("write seq 3: %v", err)
 	}
-	// Small settle so a mistakenly-dispatched seq 3 has fully advanced the
-	// watermark before we assert (guards against reading mid-dispatch).
-	time.Sleep(50 * time.Millisecond)
 
+	select {
+	case got := <-dispatched:
+		if got != 3 {
+			t.Fatalf("recovery frame dispatched seq = %d, want 3 (connection must survive "+
+				"the undecodable frame — #6130 loop-break)", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovery frame after an undecodable session frame was not dispatched: " +
+			"the connection was dropped (the #6130 resync/reconnect loop), or the watermark " +
+			"was withheld and the frame never advanced")
+	}
+
+	// #5483 anti-divergence: the undecodable frame forced exactly one resync.
 	if !resyncCalled.Load() {
-		t.Fatal("undecodable session frame did not trigger onFullResync (#5483): " +
-			"it was silently skipped instead of forcing a hard sync-break")
+		t.Fatal("undecodable session frame did not trigger onFullResync (#5483)")
 	}
 	if got := es.SessionSyncResyncs.Load(); got != 1 {
-		t.Fatalf("SessionSyncResyncs = %d, want 1 (an undecodable session frame "+
-			"must force exactly one resync, like a #2874 gap)", got)
+		t.Fatalf("SessionSyncResyncs = %d, want 1", got)
 	}
-	// CORE #5483 invariant: the cumulative ACK/applied watermark must NOT have
-	// advanced past the undecodable session seq (2). It must stay anchored at the
-	// last contiguous sequence (1); a later telemetry frame must not be able to
-	// carry it to 3.
-	if applied := es.lastAppliedSeq.Load(); applied > 1 {
-		t.Fatalf("lastAppliedSeq advanced past the undecodable session frame: "+
-			"got %d, want 1 — the ACK moved past unapplied session state, which "+
-			"lets the Rust replay buffer trim it and silently diverge the standby (#5483)", applied)
-	}
-	if acked := es.lastAckSeq.Load(); acked > 1 {
-		t.Fatalf("ACK advanced past the undecodable session frame: lastAckSeq=%d, want <=1", acked)
-	}
-	// The decode failure is still accounted as a decode error.
 	if got := es.DecodeErrors.Load(); got != 1 {
 		t.Fatalf("DecodeErrors = %d, want 1", got)
+	}
+	// #6130 loop-break: the watermark advanced PAST the undecodable seq (2). It is
+	// at 3 here because the recovery frame was applied; the hard invariant is that
+	// it moved past 2, so the helper's replay buffer trims the undecodable frame
+	// (front.seq <= acked) and never re-sends it.
+	if applied := es.lastAppliedSeq.Load(); applied < 2 {
+		t.Fatalf("lastAppliedSeq = %d, want >= 2 — the watermark must advance PAST the "+
+			"present-but-undecodable frame so the helper trims it and does not re-send it "+
+			"verbatim (the #6130 resync/reconnect loop)", applied)
+	}
+}
+
+// TestEventStreamPersistentUndecodableSessionFramesDoNotLoop_6130 is the core
+// #6130 regression: a PERSISTENTLY-undecodable session stream (every session
+// frame rejected, as under a codec bug / version-skewed helper) must NOT wedge.
+// The watermark advances past EVERY undecodable frame on ONE connection (no
+// reconnect churn), and the resync trigger is RATE-LIMITED to a bounded count
+// rather than firing once per frame (which would hammer the shared control
+// socket and flood the log). The stream then recovers on the next decodable
+// frame.
+//
+// Parent-RED map (target-count 1): revert handleSessionDecodeFailure so the
+// caller `return`s without advancing (b9cb3eb34). Then the connection drops at
+// the FIRST undecodable frame (seq 2); seqs 3, 4 and the recovery frame 5 are
+// never read on it, lastAppliedSeq stays at the baseline (1), and the recovery
+// assertion times out — all RED. With the fix all four post-baseline frames are
+// processed on the one connection.
+func TestEventStreamPersistentUndecodableSessionFramesDoNotLoop_6130(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test-events.sock")
+
+	es := NewEventStream(sockPath)
+	dispatched := make(chan uint64, 8)
+	es.SetOnEvent(func(_ uint8, seq uint64, _ SessionDeltaInfo) bool {
+		dispatched <- seq
+		return true
+	})
+	var resyncs atomic.Int64
+	es.SetOnFullResync(func() bool {
+		resyncs.Add(1)
+		return true
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	es.Start(ctx)
+	defer es.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	waitForConnected(t, es)
+
+	good := buildSessionOpenV4Payload(
+		6, 1000, 80,
+		[4]byte{10, 0, 1, 1}, [4]byte{10, 0, 2, 1},
+		[4]byte{}, [4]byte{},
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		[6]byte{}, [6]byte{}, [4]byte{},
+	)
+	undecodable := append([]byte(nil), good...)
+	undecodable[0] = 7 // invalid AddrFamily -> persistent decode failure
+
+	// seq 1: decodable baseline.
+	if err := writeFrame(conn, EventTypeSessionOpen, 1, good); err != nil {
+		t.Fatalf("write seq 1: %v", err)
+	}
+	if got := <-dispatched; got != 1 {
+		t.Fatalf("baseline dispatched seq = %d, want 1", got)
+	}
+
+	// seqs 2..4: three back-to-back undecodable session frames on ONE connection.
+	for seq := uint64(2); seq <= 4; seq++ {
+		if err := writeFrame(conn, EventTypeSessionOpen, seq, undecodable); err != nil {
+			t.Fatalf("write undecodable seq %d: %v", seq, err)
+		}
+	}
+
+	// seq 5: a decodable frame proving the stream recovered on the SAME
+	// connection (no reconnect).
+	if err := writeFrame(conn, EventTypeSessionOpen, 5, good); err != nil {
+		t.Fatalf("write seq 5: %v", err)
+	}
+	select {
+	case got := <-dispatched:
+		if got != 5 {
+			t.Fatalf("recovery frame dispatched seq = %d, want 5", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not recover after persistent undecodable frames: the connection " +
+			"was dropped (the #6130 loop) instead of advancing past each undecodable frame")
+	}
+
+	// Loop-break: the watermark advanced past ALL undecodable frames to the
+	// recovery frame.
+	if applied := es.lastAppliedSeq.Load(); applied < 4 {
+		t.Fatalf("lastAppliedSeq = %d, want >= 4 — the watermark must advance past every "+
+			"persistently-undecodable frame (#6130)", applied)
+	}
+	// All three undecodable frames were accounted.
+	if got := es.DecodeErrors.Load(); got != 3 {
+		t.Fatalf("DecodeErrors = %d, want 3", got)
+	}
+	// Bounded, rate-limited resyncs: the three rapid undecodable frames fall
+	// inside one decodeFailureResyncInterval, so exactly ONE resync fires and the
+	// other two are suppressed — NOT one resync per frame (the control-socket
+	// hammer the loop would produce).
+	if got := resyncs.Load(); got != 1 {
+		t.Fatalf("onFullResync fired %d times, want 1 — the resync must be rate-limited so a "+
+			"persistently-undecodable stream cannot hammer the control socket (#6130)", got)
+	}
+	if got := es.SessionSyncResyncs.Load(); got != 1 {
+		t.Fatalf("SessionSyncResyncs = %d, want 1", got)
+	}
+	if got := es.DecodeResyncSuppressed.Load(); got != 2 {
+		t.Fatalf("DecodeResyncSuppressed = %d, want 2 (the two rate-limited undecodable frames)", got)
 	}
 }
 
 // TestEventStreamUndecodableTelemetryFrameStillSkips_5483 pins the SCOPE of the
-// #5483 fix: the hard sync-break applies to SESSION frames ONLY. A COMPLETE but
+// fix: the hard sync-break applies to SESSION frames ONLY. A COMPLETE but
 // undecodable TELEMETRY (RT_FLOW) frame stays tolerable to skip — it carries no
 // HA session state, so it must NOT force a resync. The reader accounts it
 // (DecodeErrors + drop counter), advances the watermark past it
@@ -191,14 +289,7 @@ func TestEventStreamUndecodableTelemetryFrameStillSkips_5483(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	defer conn.Close()
-
-	dl := time.Now().Add(2 * time.Second)
-	for !es.IsConnected() {
-		if time.Now().After(dl) {
-			t.Fatal("not connected")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForConnected(t, es)
 
 	goodTelemetry := buildDataplaneEventV4Payload(
 		6, 1111, 443,

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1922,23 +1922,24 @@ type SourceNATPoolStatus struct {
 }
 
 type EventStreamStatus struct {
-	FramesRead          uint64 `json:"frames_read,omitempty"`
-	FramesWritten       uint64 `json:"frames_written,omitempty"`
-	DecodeErrors        uint64 `json:"decode_errors,omitempty"`
-	SeqGaps             uint64 `json:"seq_gaps,omitempty"`
-	SessionSyncResyncs  uint64 `json:"session_sync_resyncs,omitempty"` // #2874
-	PolicyDenyEvents    uint64 `json:"policy_deny_events,omitempty"`
-	ScreenDropEvents    uint64 `json:"screen_drop_events,omitempty"`
-	ScreenAlarmEvents   uint64 `json:"screen_alarm_events,omitempty"`
-	FilterLogEvents     uint64 `json:"filter_log_events,omitempty"`
-	SessionCloseEvents  uint64 `json:"session_close_events,omitempty"`  // #2460/#2510
-	SessionCreateEvents uint64 `json:"session_create_events,omitempty"` // #2508/#2510
-	PolicyDenyDrops     uint64 `json:"policy_deny_drops,omitempty"`
-	ScreenDropDrops     uint64 `json:"screen_drop_drops,omitempty"`
-	FilterLogDrops      uint64 `json:"filter_log_drops,omitempty"`
-	SessionCloseDrops   uint64 `json:"session_close_drops,omitempty"`  // #2460/#2510
-	SessionCreateDrops  uint64 `json:"session_create_drops,omitempty"` // #2508/#2510
-	UnknownFrameDrops   uint64 `json:"unknown_frame_drops,omitempty"`
+	FramesRead             uint64 `json:"frames_read,omitempty"`
+	FramesWritten          uint64 `json:"frames_written,omitempty"`
+	DecodeErrors           uint64 `json:"decode_errors,omitempty"`
+	SeqGaps                uint64 `json:"seq_gaps,omitempty"`
+	SessionSyncResyncs     uint64 `json:"session_sync_resyncs,omitempty"`     // #2874/#5483
+	DecodeResyncSuppressed uint64 `json:"decode_resync_suppressed,omitempty"` // #6130
+	PolicyDenyEvents       uint64 `json:"policy_deny_events,omitempty"`
+	ScreenDropEvents       uint64 `json:"screen_drop_events,omitempty"`
+	ScreenAlarmEvents      uint64 `json:"screen_alarm_events,omitempty"`
+	FilterLogEvents        uint64 `json:"filter_log_events,omitempty"`
+	SessionCloseEvents     uint64 `json:"session_close_events,omitempty"`  // #2460/#2510
+	SessionCreateEvents    uint64 `json:"session_create_events,omitempty"` // #2508/#2510
+	PolicyDenyDrops        uint64 `json:"policy_deny_drops,omitempty"`
+	ScreenDropDrops        uint64 `json:"screen_drop_drops,omitempty"`
+	FilterLogDrops         uint64 `json:"filter_log_drops,omitempty"`
+	SessionCloseDrops      uint64 `json:"session_close_drops,omitempty"`  // #2460/#2510
+	SessionCreateDrops     uint64 `json:"session_create_drops,omitempty"` // #2508/#2510
+	UnknownFrameDrops      uint64 `json:"unknown_frame_drops,omitempty"`
 }
 
 type CoSInterfaceStatus struct {


### PR DESCRIPTION
## Summary

- A COMPLETE but semantically **undecodable SESSION frame** (open/update/close) in the `EventStream` reader was silently skipped with `DecodeErrors.Add(1); continue`, leaving the sequence watermark below the hole — a silent HA session-divergence bug distinct from the #2874 gap path (which fires only on a *missing* sequence, not a semantic rejection of a *present* frame).
- **Failure trace:** session frame at seq N fails decode → skipped; a later lossy **TELEMETRY** frame at N+1 records only a benign gap, marks itself applied, and `sendAckIfNeeded` advances the cumulative ACK past N. The Rust replay buffer trims strictly on the daemon ACK watermark (`seq <= acked`, `userspace-dp/src/event_stream/mod.rs`), discarding the never-applied session frame. Telemetry already advanced `prevSeq`, so no later gap fires → the standby has **silently diverged** with no recovery.
- **Fix:** route a session-frame decode failure through new `handleSessionDecodeFailure(seq)`, which reuses the #2874 gap sync-break mechanics — bump `SessionSyncResyncs`, invoke `onFullResync` (full bulk re-export from table truth), and `return` so the reader drops the connection — **without** advancing `prevSeq`/`lastAppliedSeq`/ACK past the hole. On reconnect the helper replays from the last CONTIGUOUS ack and the resync re-derives complete session state.
- **Scope: SESSION frames only.** A decode failure on a lossy TELEMETRY (RT_FLOW) frame stays tolerable to skip (`DecodeErrors` + drop counter + `markDroppedFrameApplied` advances the watermark) — telemetry carries no HA session state, matching the existing #2874 telemetry-gap tolerance.
- **Go-side only:** the Rust ACK-trim is watermark-gated and already correct; withholding the ACK on the Go side keeps the frame in the replay buffer and forces the resync. No Rust change.

## Test plan

- [x] `TestEventStreamUndecodableSessionFrameForcesResync_5483` — feeds a baseline session frame (seq 1, applied), a complete-but-undecodable session-open frame (seq 2, invalid address family), then a valid telemetry frame (seq 3). Asserts `onFullResync` fires, `SessionSyncResyncs==1`, and `lastAppliedSeq`/`lastAckSeq` stay anchored at 1 (the trailing telemetry frame can **not** carry the ACK to 3). **Fail-on-revert:** restoring `DecodeErrors.Add(1); continue` at the session-open arm turns it RED (assertion failure `undecodable session frame did not trigger onFullResync`, not a build break; target-count 1).
- [x] `TestEventStreamUndecodableTelemetryFrameStillSkips_5483` — scope guard: an undecodable telemetry frame is still skipped, the following valid telemetry frame is dispatched, and no resync fires.
- [x] `go test ./pkg/dataplane/...` — full userspace suite green.
- [x] `go test ./pkg/daemon/` (consumer of `EventStream`) — green.
- [x] `go build ./...`, `go vet ./pkg/dataplane/userspace/` — clean.

## HA surface / smoke

This touches **HA session-sync** (the event-stream loss-of-sync → FullResync contract). The fix is unit-provable and the change is confined to the Go reader's decode-failure disposition, but per `CLAUDE.md` any session-sync change should pass a `make test-failover` loss-cluster smoke before merge. **Recommend running `make test-failover` (+ `make test-ha-crash`) before merging.**

## Docs

- `docs/session-sync-architecture.md`: FullResync trigger list now includes the #5483 undecodable-session-frame trigger alongside #2874 (gap) / #2442 (delta-ring overflow), with a note on the closed silent-divergence hole.

Closes #5483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
