### PR TITLE
userspace-dp: publish NAT64 first-fragment assoc only post-commit (#5146)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-18 — #5146 (security/correctness): NAT64 first-fragment association published pre-commit
+
+- **Timestamp**: 2026-07-18 (fix/5146-nat64-frag-rollback)
+- **Action**: `nat64_install_forward_fragment_assoc` (the #2562 cross-family
+  fragment cache) was called at NAT64 source-allocation time — BEFORE the flow
+  commits. The hop-limit ICMP-TE bounce, the `can_admit` admission preflight, and
+  the install-partial arm each `rollback_nat64_allocation` (releases the pool port
+  ONLY), so a pre-published association stayed LIVE ~2s (NAT64_FRAG_TTL_NS) with
+  NO exact-key remove. A non-first fragment of a rolled-back first fragment then
+  inherited a rolled-back verdict AND the now-reusable translation (cross-flow
+  NAT64 fragment ambiguity under port reuse). Fix = Option A: DELAY the install to
+  the single POST-COMMIT site (inside `if forward_installed`, next to the ordinary
+  same-family `nat_install_forward_fragment_assoc`); helper now self-gates on
+  `decision.nat.nat64` so both installs share one commit site and exactly one
+  fires. Every rollback arm (ICMP-TE / admission / install-partial / track-false)
+  now leaves NO live association; the committed success path still publishes
+  (#2562/#6095 preserved). NOT HA — Nat64FragAssoc is per-process, never synced.
+  Added 2 poll-path tests through `poll_binding_process_descriptor`: SUCCESS
+  (committed first fragment publishes 1 assoc, non-first inherits + translates)
+  and FAIL-ON-REVERT (can_admit-refused first fragment leaves 0 assoc; non-first
+  misses — `nat64_translations == 0`, drops fail-closed). Reverting the fix →
+  rollback test RED at the `frag_assoc.len() == 0` assertion (`left: 1`),
+  target-count 1; success test stays green.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/tests_nat64_tunnel.rs,
+  docs/pr/5146-nat64-frag-rollback/plan.md
+
 ## 2026-07-18 — #5268 (High, security): RX-VLAN-offload-disable is a fail-closed activation precondition
 
 - **Timestamp**: 2026-07-18 (fix/5268-rxvlan-failclosed)

--- a/docs/pr/5146-nat64-frag-rollback/plan.md
+++ b/docs/pr/5146-nat64-frag-rollback/plan.md
@@ -1,0 +1,79 @@
+# #5146 — NAT64 first-fragment association published pre-commit
+
+## Problem
+
+`nat64_install_forward_fragment_assoc` (the #2562 cross-family fragment
+cache) was called at NAT64 **source-allocation** time — inside the
+`Ok((snat_v4, translated_port))` arm right after
+`decision.nat = Nat64State::forward_decision(...)` — which is BEFORE the
+flow commits. The commit gates that follow it are:
+
+- the hop-limit / ICMP-TE bounce (`build_local_time_exceeded_request`),
+- the `sessions.can_admit` admission preflight,
+- the forward session install.
+
+Every one of those has a rollback arm that calls
+`crate::nat64::rollback_nat64_allocation`, which releases **only the pool
+port**. `Nat64FragAssoc` had no exact-key remove, so a pre-published
+association stayed LIVE for `NAT64_FRAG_TTL_NS` (~2s). A non-first
+fragment of a rolled-back / dropped first fragment then:
+
+1. inherited a **rolled-back decision** (a verdict the anchor did not
+   commit to), and
+2. inherited a **released, now-reusable translation** (the pool port was
+   freed and can be handed to a different flow) → cross-flow NAT64
+   fragment ambiguity under port reuse.
+
+Invariant violated: shared fragment state must become visible ONLY after
+the anchor fragment commits to the outcome it authorizes.
+
+## Fix — Option A (delay the install to post-commit)
+
+Move the install to the single POST-COMMIT site — inside
+`if forward_installed { ... }`, next to the ordinary same-family install
+`nat_install_forward_fragment_assoc`. A rolled-back / dropped / denied
+first fragment never publishes an association.
+
+- `nat64_install_forward_fragment_assoc` now self-gates on
+  `decision.nat.nat64` (mirrors the ordinary-NAT helper's inverse gate),
+  so both installs can be called at the one commit site and exactly one
+  populates the table.
+- Removed the pre-commit call; the NAT64 `Ok` arm still returns its
+  `Nat64ReverseInfo`.
+
+### Enumerated rollback arms now leaving NO live association
+
+| Arm | Site | Reaches post-commit install? |
+|---|---|---|
+| hop-limit ICMP-TE bounce | rollback @ `local_icmp_te` Some | No — never enters the `else` that installs |
+| `can_admit` refusal | rollback @ admission preflight | No — `continue`s before install |
+| install-partial (post-`can_admit`, impossible-by-construction) | rollback @ `!forward_installed` | No — `continue`s before install |
+| `track_in_userspace == false` (LocalDelivery / DNS fast-path) | rollback @ else | N/A — install helper's ForwardCandidate gate already blocked it; NAT64 self-gate also blocks DNS fast-path |
+| **commit** (`forward_installed == true`) | POST-COMMIT install | **Yes — the only path that publishes** |
+
+## Not HA
+
+`Nat64FragAssoc` is per-process (Arc-shared across workers, NOT
+session-synced — nat64.rs lines 325-331: "HA does NOT sync it: transient,
+sub-second"). No wire-protocol / session-sync surface is touched.
+
+## Test (fail-on-revert, target-count 1)
+
+`src/afxdp/tests_nat64_tunnel.rs`, driven through the real
+`poll_binding_process_descriptor`:
+
+- `nat64_committed_first_fragment_publishes_frag_assoc_and_nonfirst_inherits_5146`
+  (SUCCESS path preserved): a committed NAT64 first fragment publishes
+  exactly one association (`frag_assoc.len() == 1`) and a non-first
+  fragment inherits + is NAT64-translated (`nat64_translations == 1`).
+- `nat64_rolled_back_first_fragment_publishes_no_frag_assoc_5146`
+  (FAIL-ON-REVERT): a NAT64 first fragment refused at `can_admit`
+  (`set_max_sessions_for_test(0)`) leaves `frag_assoc.len() == 0`, and a
+  subsequent non-first fragment MISSES — `nat64_translations == 0` (does
+  not inherit the released translation) and drops fail-closed
+  (`dbg.tx == 0`, no v6 route for the synthetic prefix).
+
+Reverting the fix (pre-commit install) makes the rolled-back first
+fragment publish → `frag_assoc.len() == 1` and the non-first fragment
+inherit + translate → `nat64_translations == 1`: both assertions flip
+RED. Exactly one test.

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -76,6 +76,19 @@ use filter::{
 /// missing neighbor) is never cached, so a non-first fragment then misses and
 /// drops fail-closed. Only a first fragment (offset 0, MF=1) installs; a
 /// non-first fragment can never populate the table.
+///
+/// #5146: called ONLY at the POST-COMMIT install site (after `can_admit` passes
+/// AND the forward session install succeeds), NOT at NAT64 source-allocation
+/// time. Publishing pre-commit left the association LIVE behind every rollback
+/// arm (hop-limit ICMP-TE bounce, admission refusal, install-partial), and the
+/// rollback releases only the pool port — so a non-first fragment of a
+/// rolled-back first fragment inherited a rolled-back verdict AND a now-reusable
+/// translation (cross-flow NAT64 fragment ambiguity under port reuse). Moving
+/// the install to the commit point makes the association visible ONLY on the
+/// outcome the anchor fragment actually authorized. Self-gated on
+/// `decision.nat.nat64` so it is safe to call unconditionally at the shared
+/// commit site next to `nat_install_forward_fragment_assoc`; the two are
+/// mutually exclusive (NAT64 vs ordinary same-family), so exactly one fires.
 #[inline]
 fn nat64_install_forward_fragment_assoc(
     forwarding: &ForwardingState,
@@ -84,6 +97,13 @@ fn nat64_install_forward_fragment_assoc(
     decision: &SessionDecision,
     now_ns: u64,
 ) {
+    // #5146: only a genuine NAT64 (cross-family) decision installs here. The
+    // ordinary same-family NAT / NPTv6 association is installed by
+    // `nat_install_forward_fragment_assoc` (which self-gates the other way), so
+    // both can be called at one commit site and exactly one populates the table.
+    if !decision.nat.nat64 {
+        return;
+    }
     if decision.resolution.disposition != ForwardingDisposition::ForwardCandidate
         || decision.resolution.neighbor_mac.is_none()
     {
@@ -2926,24 +2946,22 @@ pub(super) fn poll_binding_process_descriptor(
                                                 dst_v4,
                                                 translated_port,
                                             );
-                                            // #2562: if THIS is a first fragment
-                                            // (offset 0, MF=1), install the
-                                            // fragment association so its
-                                            // non-first fragments inherit this
-                                            // translation instead of dropping
-                                            // fail-closed (#4617). No-op for a
-                                            // non-fragmented / atomic packet.
-                                            if let Some(l3_packet) =
-                                                packet_frame.get(meta.l3_offset as usize..)
-                                            {
-                                                nat64_install_forward_fragment_assoc(
-                                                    worker_ctx.forwarding,
-                                                    l3_packet,
-                                                    meta.addr_family as i32,
-                                                    &decision,
-                                                    now_ns,
-                                                );
-                                            }
+                                            // #2562/#5146: the first-fragment
+                                            // association is NO LONGER installed
+                                            // here. Source allocation is not the
+                                            // commit point — the flow can still be
+                                            // rolled back (hop-limit ICMP-TE,
+                                            // admission refusal, install-partial),
+                                            // and the rollback releases only the
+                                            // pool port, leaving a pre-published
+                                            // association live to hand a non-first
+                                            // fragment a rolled-back verdict + a
+                                            // now-reusable translation (#5146). The
+                                            // install moved to the POST-COMMIT site
+                                            // (inside `if forward_installed`),
+                                            // alongside the ordinary-NAT install,
+                                            // so it is published ONLY on the
+                                            // outcome the anchor authorized.
                                             Some(Nat64ReverseInfo {
                                                 orig_src_v6,
                                                 orig_dst_v6,
@@ -3299,6 +3317,30 @@ pub(super) fn poll_binding_process_descriptor(
                                         if let Some(l3_packet) =
                                             packet_frame.get(meta.l3_offset as usize..)
                                         {
+                                            // #5146: publish the NAT64 (cross-
+                                            // family) first-fragment association
+                                            // ONLY now — the flow has COMMITTED
+                                            // (past `can_admit` and a successful
+                                            // forward session install). Publishing
+                                            // it at source-allocation time left the
+                                            // association live behind every
+                                            // rollback arm (hop-limit ICMP-TE,
+                                            // admission refusal, install-partial),
+                                            // and the rollback releases only the
+                                            // pool port — so a non-first fragment
+                                            // of a rolled-back first fragment
+                                            // inherited a rolled-back verdict AND a
+                                            // now-reusable translation (#5146). Both
+                                            // helpers self-gate (NAT64 vs ordinary
+                                            // same-family), so exactly one fires for
+                                            // a given committed first fragment.
+                                            nat64_install_forward_fragment_assoc(
+                                                worker_ctx.forwarding,
+                                                l3_packet,
+                                                meta.addr_family as i32,
+                                                &decision,
+                                                now_ns,
+                                            );
                                             nat_install_forward_fragment_assoc(
                                                 worker_ctx.forwarding,
                                                 l3_packet,

--- a/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
+++ b/userspace-dp/src/afxdp/tests_nat64_tunnel.rs
@@ -1070,3 +1070,241 @@ fn nat64_missing_neighbor_denied_no_fail_closed_drop_5174() {
     assert_eq!(sessions.len(), 0);
     assert!(binding.pending_neigh.is_empty());
 }
+
+// =====================================================================
+// #5146: NAT64 first-fragment association is published ONLY post-commit
+// =====================================================================
+//
+// The first-fragment association (the #2562 cross-family fragment cache) must
+// become visible ONLY after the anchor first fragment COMMITS to the outcome it
+// authorizes — i.e. past `can_admit` AND a successful forward session install.
+// Before #5146 the install fired at NAT64 source-allocation time (pre-commit);
+// a subsequent rollback (hop-limit ICMP-TE, admission refusal, install-partial)
+// released only the pool port and left the association LIVE for ~2s. A non-first
+// fragment of that rolled-back datagram then inherited a rolled-back verdict AND
+// a now-reusable translation — cross-flow NAT64 fragment ambiguity under port
+// reuse. These two tests pin both directions of the invariant through the real
+// `poll_binding_process_descriptor` path.
+
+/// eth(14) + IPv6(40, next-header 44 Fragment) + Fragment(8) + TCP(20).
+/// `frag_off` is the IPv6 Fragment-Header offset/flags word: `0x0001` => offset
+/// 0, MF=1 (FIRST fragment — installs); `0x0008` => offset 1 (8-octet units),
+/// MF=0 (NON-first fragment — flowless, consults only). `ident` is the 32-bit
+/// Fragment Identification shared by every fragment of one datagram. src is a
+/// lan v6 host; dst is the NAT64 synthetic prefix `64:ff9b::808:808` (extracts
+/// 8.8.8.8). For a first fragment the trailing 20 bytes are a real TCP header
+/// (sport/dport); for a non-first fragment they are opaque payload (#2344 — never
+/// read as L4 ports).
+fn nat64_v6_frag_frame(
+    frag_off: u16,
+    ident: u32,
+    src: Ipv6Addr,
+    dst: Ipv6Addr,
+    src_port: u16,
+    dst_port: u16,
+) -> Vec<u8> {
+    let mut f = vec![
+        0x02, 0xbf, 0x72, 0x01, 0x00, 0x01, 0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5, 0x86, 0xdd,
+    ];
+    let mut ip = vec![0u8; 40];
+    ip[0] = 0x60; // version 6
+    let payload_len = (8 + 20) as u16; // fragment header + TCP
+    ip[4..6].copy_from_slice(&payload_len.to_be_bytes());
+    ip[6] = 44; // next header = Fragment
+    ip[7] = 64; // hop limit (> 1: no ICMP-TE)
+    ip[8..24].copy_from_slice(&src.octets());
+    ip[24..40].copy_from_slice(&dst.octets());
+    f.extend_from_slice(&ip);
+    // Fragment extension header (8 bytes).
+    let mut frag = [0u8; 8];
+    frag[0] = PROTO_TCP; // next header after the fragment header
+    frag[2..4].copy_from_slice(&frag_off.to_be_bytes());
+    frag[4..8].copy_from_slice(&ident.to_be_bytes());
+    f.extend_from_slice(&frag);
+    // TCP header (20 bytes). A transit router does not verify the ingress L4
+    // checksum, so it is left 0 (matches the #5689 udp_frag fixture).
+    let mut tcp = vec![0u8; 20];
+    tcp[0..2].copy_from_slice(&src_port.to_be_bytes());
+    tcp[2..4].copy_from_slice(&dst_port.to_be_bytes());
+    tcp[3 + 9] = 0x50; // data offset (byte 12)
+    tcp[13] = TCP_FLAG_SYN;
+    tcp[14..16].copy_from_slice(&0xfaf0u16.to_be_bytes());
+    f.extend_from_slice(&tcp);
+    f
+}
+
+/// Metadata for a v6 NAT64 fragment: the L4 header sits after the 8-byte
+/// Fragment extension header, so `l4_offset = 14 + 40 + 8 = 62`.
+fn nat64_v6_frag_meta(frame_len: usize) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        ingress_ifindex: 24,
+        l3_offset: 14,
+        l4_offset: 62,
+        payload_offset: 82,
+        pkt_len: (frame_len - 14) as u16,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        config_generation: 7,
+        fib_generation: 9,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+fn nat64_frag_snapshot() -> ConfigSnapshot {
+    let mut snapshot = nat_snapshot();
+    snapshot.nat64_rules = vec![crate::protocol::NAT64RuleSnapshot {
+        name: "nat64".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec!["172.16.80.50".to_string()],
+        no_v6_frag_header: false,
+        ..Default::default()
+    }];
+    // Drop the v6 default route: the synthetic `64:ff9b::/96` NAT64 prefix is
+    // never v6-routable in production (it is a translation prefix, not a
+    // forwardable v6 destination). Without this, the fixture's `::/0` route
+    // would forward a MISSED NAT64 non-first fragment UNTRANSLATED instead of
+    // dropping it fail-closed (#4617). The NAT64 FORWARD resolves the extracted
+    // IPv4 dst (8.8.8.8) via inet.0, so a COMMITTED first fragment still
+    // translates + forwards; only the association-less v6 miss loses its route.
+    snapshot.routes.retain(|r| r.family != "inet6");
+    snapshot
+}
+
+// #5146 SUCCESS path (the #2562/#6095 feature must survive the fix): a COMMITTED
+// NAT64 first fragment DOES publish its association, and a non-first fragment of
+// the same datagram inherits the translation and forwards. If this went RED the
+// fix would have broken legitimate NAT64 fragment forwarding.
+#[test]
+fn nat64_committed_first_fragment_publishes_frag_assoc_and_nonfirst_inherits_5146() {
+    let forwarding = build_forwarding_state(&nat64_frag_snapshot());
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+    sessions.set_max_sessions_for_test(16);
+
+    let src: Ipv6Addr = "2001:559:8585:ef00::102".parse().expect("src v6");
+    let dst: Ipv6Addr = "64:ff9b::808:808".parse().expect("nat64 dst (extracts 8.8.8.8)");
+
+    // FIRST fragment (offset 0, MF=1). Runs the full ported cold path: NAT64
+    // source allocation, admission, forward+reverse install, THEN (post-commit)
+    // the first-fragment association install.
+    let first = nat64_v6_frag_frame(0x0001, 0x1234_5678, src, dst, 12345, 443);
+    let (b1, dbg1) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &first,
+        nat64_v6_frag_meta(first.len()),
+    );
+    assert_eq!(dbg1.tx, 1, "the committed NAT64 first fragment must translate + forward");
+    assert_eq!(b1.nat64_translations, 1, "the first fragment is NAT64-translated");
+    assert_eq!(sessions.len(), 2, "NAT64 forward + reverse install below cap");
+    assert_eq!(
+        forwarding.nat64.frag_assoc.len(),
+        1,
+        "#5146: a COMMITTED NAT64 first fragment MUST publish exactly one association \
+         (the #2562 feature — RED if the post-commit install is removed)"
+    );
+
+    // NON-first fragment (offset 1, SAME ident) is flowless: it consults the
+    // association and inherits the first fragment's NAT64 translation.
+    let non_first = nat64_v6_frag_frame(0x0008, 0x1234_5678, src, dst, 0, 0);
+    let (b2, dbg2) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &non_first,
+        nat64_v6_frag_meta(non_first.len()),
+    );
+    assert_eq!(
+        dbg2.tx, 1,
+        "#5146: the non-first fragment must INHERIT the committed association and forward"
+    );
+    assert_eq!(
+        b2.nat64_translations, 1,
+        "#5146: the inherited non-first fragment must be NAT64-translated (the #2562 feature)"
+    );
+}
+
+// #5146 FAIL-ON-REVERT: a NAT64 first fragment whose flow is ROLLED BACK (the
+// session table is at cap, so `can_admit` refuses) must leave NO live fragment
+// association, and a subsequent non-first fragment of the same datagram must
+// MISS (drop fail-closed) rather than inherit the released translation.
+//
+// RED on revert: with the pre-commit install (association published at NAT64
+// source-allocation time, before `can_admit`), the rolled-back first fragment
+// still publishes -> `frag_assoc.len() == 1` -> the `== 0` assertion goes RED,
+// and the non-first fragment inherits + forwards -> the `dbg2.tx == 0`
+// assertion goes RED. Target-count 1 (this single test).
+#[test]
+fn nat64_rolled_back_first_fragment_publishes_no_frag_assoc_5146() {
+    let forwarding = build_forwarding_state(&nat64_frag_snapshot());
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+    // Cap 0: the forward session `can_admit` preflight refuses, so the NAT64
+    // forward flow is ROLLED BACK (pool port released) after source allocation.
+    sessions.set_max_sessions_for_test(0);
+
+    let src: Ipv6Addr = "2001:559:8585:ef00::102".parse().expect("src v6");
+    let dst: Ipv6Addr = "64:ff9b::808:808".parse().expect("nat64 dst (extracts 8.8.8.8)");
+
+    // FIRST fragment (offset 0, MF=1) — admission-refused, rolled back.
+    let first = nat64_v6_frag_frame(0x0001, 0x0bad_f00d, src, dst, 12345, 443);
+    let (_b1, dbg1) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &first,
+        nat64_v6_frag_meta(first.len()),
+    );
+    assert_eq!(dbg1.tx, 0, "a refused NAT64 first fragment must not forward");
+    assert_eq!(sessions.admission_refused(), 1, "the flow must hit the can_admit rollback arm");
+    assert_eq!(
+        forwarding.nat64.frag_assoc.len(),
+        0,
+        "#5146: a ROLLED-BACK NAT64 first fragment must publish NO association \
+         (RED on revert: the pre-commit install leaves 1 live association behind \
+          the released pool port)"
+    );
+
+    // NON-first fragment (offset 1, SAME ident). With no live association it
+    // MISSES and drops fail-closed (#4617) — it must NOT inherit the released
+    // translation. Cap is irrelevant to a flowless fragment (it installs no
+    // session), so raise it to isolate the miss from any admission effect.
+    sessions.set_max_sessions_for_test(16);
+    let non_first = nat64_v6_frag_frame(0x0008, 0x0bad_f00d, src, dst, 0, 0);
+    let (b2, dbg2) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &non_first,
+        nat64_v6_frag_meta(non_first.len()),
+    );
+    assert_eq!(
+        b2.nat64_translations, 0,
+        "#5146: a non-first fragment of a rolled-back first fragment must NOT inherit the \
+         released NAT64 translation (RED on revert: the pre-commit association makes it \
+         inherit + translate -> 1)"
+    );
+    assert_eq!(
+        dbg2.tx, 0,
+        "#5146: with no association to inherit and no v6 route for the synthetic NAT64 \
+         prefix, the missed non-first fragment drops fail-closed (#4617)"
+    );
+    assert_eq!(
+        forwarding.nat64.frag_assoc.len(),
+        0,
+        "#5146: the consult miss must not resurrect an association"
+    );
+}

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -307,9 +307,15 @@ pub(crate) struct Nat64ReverseInfo {
 //     the key and derives the synthetic-prefix v4 dst identically for both).
 //     This is the same inherent NAT + fragmentation + ident-reuse hazard
 //     RFC 6864 describes, not a new exposure.
-//   * ONLY a first fragment (offset 0, MF=1, admitted + resolved) INSTALLS an
-//     entry. Non-first fragments only CONSULT — the load-bearing DoS property:
-//     an attacker cannot grow the table with cheap headerless fragments.
+//   * ONLY a first fragment (offset 0, MF=1, admitted + resolved + COMMITTED)
+//     INSTALLS an entry. #5146: the install fires at the POST-COMMIT site (after
+//     `can_admit` passes AND the forward session install succeeds), NOT at NAT64
+//     source-allocation time — a first fragment that is then rolled back
+//     (hop-limit ICMP-TE, admission refusal, install-partial) never publishes an
+//     association, so a non-first fragment cannot inherit a rolled-back verdict +
+//     a released (reusable) translation. Non-first fragments only CONSULT — the
+//     load-bearing DoS property: an attacker cannot grow the table with cheap
+//     headerless fragments.
 //   * BOUNDED: a fixed shard count x a fixed per-shard cap, LRU eviction, no
 //     growth. Short TTL (~2s): we ASSOCIATE, we do not RFC-reassemble — real
 //     fragments of one datagram arrive within microseconds-milliseconds; the


### PR DESCRIPTION
## Summary

- The #2562 cross-family NAT64 fragment association (`Nat64FragAssoc`) was installed at NAT64 **source-allocation** time — before the flow commits. Each commit gate that follows has a rollback arm (`rollback_nat64_allocation`) that releases **only the pool port**; `Nat64FragAssoc` has no exact-key remove, so a pre-published association stayed **live ~2s** (`NAT64_FRAG_TTL_NS`).
- A non-first fragment of a **rolled-back / dropped** first fragment then inherited a **rolled-back verdict AND a released, now-reusable translation** → cross-flow NAT64 fragment ambiguity under port reuse.
- **Fix (option A — delay the install):** move the install to the single **post-commit** site (inside `if forward_installed`, next to the ordinary same-family `nat_install_forward_fragment_assoc`). The helper now self-gates on `decision.nat.nat64`, so both installs share one commit site and exactly one fires. A rolled-back/dropped/denied first fragment never publishes.
- **Success path preserved (#2562/#6095):** a committed first fragment still publishes its association, so real non-first fragments still inherit the translation.

## Invariant

Shared fragment state becomes visible ONLY after the anchor fragment commits to the outcome it authorizes.

## Enumerated rollback arms — none now leaves a live association

| Arm | Reaches the post-commit install? |
|---|---|
| hop-limit / ICMP-TE bounce | No — never enters the `else` that installs |
| `can_admit` admission refusal | No — `continue`s before install |
| install-partial (post-`can_admit`, impossible-by-construction) | No — `continue`s before install |
| `track_in_userspace == false` (LocalDelivery / DNS fast-path) | N/A — the helper's ForwardCandidate + `nat64` gates already block it |
| **commit** (`forward_installed == true`) | **Yes — the only path that publishes** |

## Not HA

`Nat64FragAssoc` is per-process (Arc-shared across workers, **never session-synced** — see nat64.rs "HA does NOT sync it: transient, sub-second"). No wire-protocol / session-sync surface is touched.

## Test plan

Both driven through the real `poll_binding_process_descriptor`:

- [x] `nat64_committed_first_fragment_publishes_frag_assoc_and_nonfirst_inherits_5146` (success): a committed first fragment publishes exactly one association (`frag_assoc.len() == 1`); a non-first fragment inherits and is NAT64-translated (`nat64_translations == 1`).
- [x] `nat64_rolled_back_first_fragment_publishes_no_frag_assoc_5146` (fail-on-revert): a `can_admit`-refused first fragment leaves `frag_assoc.len() == 0`; a subsequent non-first fragment misses (`nat64_translations == 0`, drops fail-closed).
- [x] **Parent-RED (target-count 1):** reverting `poll_descriptor/mod.rs` to `origin/master` (fix removed, tests kept) fails **exactly** `nat64_rolled_back_first_fragment_publishes_no_frag_assoc_5146` at the `frag_assoc.len() == 0` assertion (`left: 1`); the success test stays green.
- [x] Full `xpf-userspace-dp` suite: **4005 passed / 2 ignored**. The one unrelated flake — `event_stream::tests::backpressure::stalled_consumer_does_not_grow_backlog_unbounded_end_to_end` (a timing test in an unrelated subsystem) — passes **3/3 in isolation**; it flakes only under full-suite parallel CPU load and cannot be affected by a NAT64 fragment change.

## Deploy validation

Not run in this PR (implement + test + PR scope). Suggested smoke before merge: `make cluster-deploy` on the loss userspace cluster + a v6→v4 NAT64 fragmented-flow exercise. This is a cold-path NAT64 change; **not** HA/session-sync, so `test-failover` is not required.

Closes #5146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e6RSZEmqmWKmrnHGPZmpb