### PR TITLE
userspace-dp: bound scalar L4/fragment classifier to IP-declared end (#5568)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-07-18 — #5568 (security): SCALAR L4/fragment classifier bounded to IP-declared datagram end
+
+- **Timestamp**: 2026-07-18 (fix/5568-scalar-l4-declared-bound)
+- **Action**: The scalar L4/fragment inputs in `term_match_extra_from_frame`
+  (+ the `ForwardPacketMeta` twin) derived from the PHYSICAL frame, not the
+  IP-declared datagram end — the residual scalar surface left after #5150
+  clamped the flex byte slices. Attacker Ethernet padding beyond the declared IP
+  length could manufacture ICMP type/code presence, TCP flags, fragment state,
+  and `l4_present` from slack (spurious PERMIT / false DENY / manufactured
+  fragment). Fix = compute `declared_end` (`ip_declared_end` SSOT) FIRST; bound
+  the fragment walkers to `frame.get(l3..declared_end)`; require
+  `l4_offset + 2 <= declared_end` for ICMP type/code and
+  `l4_offset + 14 <= declared_end` (TCP flags byte) for TCP flags, else drop
+  `l4_present` (fail closed). The `parse_embedded_v4`/`parse_embedded_v6` quote
+  parsers bound the inner L4 read/walk to the QUOTED IP's declared length
+  (clamped to the available quote — RFC-minimum truncated quotes NOT rejected).
+  Common no-slack path (`declared_end == frame.len()`) byte-identical. Added
+  fail-on-revert tests (one per axis) + anti-over-gate guards. Full suite 4024
+  passed / 0 failed.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/frame/tests_fragment_term_extra.rs,
+  userspace-dp/src/afxdp/icmp_embed/parse.rs,
+  userspace-dp/src/filter/README.md
+
 ## 2026-07-18 — #5146 (security/correctness): NAT64 first-fragment association published pre-commit
 
 - **Timestamp**: 2026-07-18 (fix/5146-nat64-frag-rollback)

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -582,67 +582,101 @@ fn ip_declared_end(frame: &[u8], l3_offset: usize, addr_family: u8) -> Option<us
     }
 }
 
+/// #5568: the number of L4 (TCP) header bytes that must lie within the
+/// IP-DECLARED datagram before the shim-stamped `tcp_flags` may be trusted for
+/// a `tcp-flags` match. The TCP flags byte is at TCP header offset 13 (RFC
+/// 9293 §3.1), so the declared datagram must reach `l4_offset + 14`. A shorter
+/// declared length means the shim read the flags out of Ethernet slack /
+/// padding, so the tcp-flags terms must fail closed (`l4_present = false`). A
+/// well-formed TCP packet always declares at least a 20-byte L4 header, so this
+/// bound never rejects legitimate traffic.
+const TCP_FLAGS_DECLARED_MIN: usize = 14;
+
 #[inline]
 pub(in crate::afxdp) fn term_match_extra_from_frame(
     frame: &[u8],
     meta: UserspaceDpMeta,
 ) -> crate::filter::TermMatchExtra<'_> {
-    use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6};
-    let l3_packet = frame.get(meta.l3_offset as usize..);
-    let is_fragment = l3_packet.is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
+    use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6, PROTO_TCP};
+    // #5568: derive EVERY scalar L4/fragment input from the IP-DECLARED datagram
+    // end, not the physical frame. The shim stamps `l3_offset`/`l4_offset` from
+    // the raw frame, so attacker-controlled Ethernet padding beyond the declared
+    // IP length would otherwise manufacture fragment status, ICMP type/code, TCP
+    // flags, and `l4_present` out of slack. Compute `declared_end` FIRST (the
+    // #5150 `ip_declared_end` SSOT — also backing the flex slices below), so a
+    // single declared bound governs the whole builder. On the common no-slack
+    // path `declared_end == frame.len()`, so classification is byte-identical.
+    let l3 = meta.l3_offset as usize;
+    let l4 = meta.l4_offset as usize;
+    let declared_end = ip_declared_end(frame, l3, meta.addr_family);
+    // The fragment walkers see ONLY the declared datagram (`l3..declared_end`),
+    // so an IPv6 fragment/extension header lurking in padding beyond the declared
+    // `payload_len` — or an IPv4 `frag_off` in slack — cannot manufacture
+    // fragment state. `frame.get(l3..declared_end)` is None when the frame is too
+    // short to even hold the IP length field (`declared_end == None`), which
+    // fails the fragment bits closed (false) — the same posture the L4 gates take.
+    let l3_declared = declared_end.and_then(|end| frame.get(l3..end));
+    let is_fragment = l3_declared.is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
     // A non-first fragment has no L4 header at `l4_offset` (its bytes are
     // payload) — suppress every L4-derived match input so those terms fail
     // closed. The is-fragment bit above stays as-is (L3-only).
     let non_first_fragment =
-        l3_packet.is_some_and(|packet| is_non_first_fragment(packet, meta.addr_family));
-    // #2449: a TRUNCATED (non-fragmented) ICMP/ICMPv6 frame may be shorter than
-    // `l4_offset + 2`, so the type/code bytes are absent. Reading them with
-    // `.unwrap_or(0)` would yield (0, 0) while `l4_present` stayed true — a
-    // crafted short ICMP packet would then spuriously match `icmp-type 0 /
-    // icmp-code 0` (Echo Reply). Detect the truncation and fail closed: force
-    // (0, 0, 0) AND drop `l4_present` so the L4 matcher rejects the term.
-    // `icmp_type_code_truncated` is false for non-ICMP protocols (those never
-    // read the bytes) and for non-first fragments (handled above).
+        l3_declared.is_some_and(|packet| is_non_first_fragment(packet, meta.addr_family));
+    // #2449 + #5568: ICMP/ICMPv6 type+code occupy the first 2 L4 bytes; they are
+    // present ONLY if the DECLARED datagram reaches `l4 + 2`. The pre-#5568 gate
+    // used the physical `frame.len()`, so Ethernet padding beyond a short declared
+    // length (e.g. an IPv4 total-length of 20 with no declared ICMP body) could
+    // read `type/code` — turning a non-match into a spurious `icmp-type 8`
+    // (echo-request) PERMIT or false DENY. `declared_end == None` (frame too short
+    // to hold the IP length field) fails closed.
     let icmp_type_code_present = matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6)
         && !non_first_fragment
-        && (frame.len() >= (meta.l4_offset as usize).saturating_add(2));
-    let l4_truncated = matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6)
+        && declared_end.is_some_and(|end| l4.saturating_add(2) <= end);
+    let l4_truncated_icmp = matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6)
         && !non_first_fragment
         && !icmp_type_code_present;
+    // #5568: the shim-stamped `tcp_flags` is trustworthy only if the DECLARED
+    // datagram reaches the TCP flags byte (`l4 + TCP_FLAGS_DECLARED_MIN`). A short
+    // / padded TCP frame whose declared length stops before the flags byte had
+    // those flags read from slack, so the tcp-flags terms must fail closed. A
+    // legitimate TCP packet always declares >= 20 L4 bytes, so this never rejects
+    // real traffic. `declared_end == None` fails closed.
+    let tcp_flags_present = meta.protocol == PROTO_TCP
+        && !non_first_fragment
+        && declared_end.is_some_and(|end| l4.saturating_add(TCP_FLAGS_DECLARED_MIN) <= end);
+    let l4_truncated_tcp =
+        meta.protocol == PROTO_TCP && !non_first_fragment && !tcp_flags_present;
     let (tcp_flags, icmp_type, icmp_code) = if non_first_fragment {
         (0, 0, 0)
     } else if icmp_type_code_present {
-        let l4 = meta.l4_offset as usize;
+        // Safe: `l4 + 2 <= declared_end <= frame.len()`, so both bytes lie in the
+        // frame AND within the declared datagram (never slack).
         (
             meta.tcp_flags,
             frame.get(l4).copied().unwrap_or(0),
             frame.get(l4.wrapping_add(1)).copied().unwrap_or(0),
         )
-    } else if l4_truncated {
-        // Truncated ICMP — no real type/code bytes. Fail closed.
+    } else if l4_truncated_tcp {
+        // TCP flags byte lies beyond the declared datagram — the shim read them
+        // from slack. Fail closed (0 flags; `l4_present` dropped below).
+        (0, 0, 0)
+    } else if l4_truncated_icmp {
+        // Truncated/padded ICMP — no real type/code bytes. Fail closed.
         (0, 0, 0)
     } else {
         (meta.tcp_flags, 0, 0)
     };
-    // #5150: clamp the flexible-match-range byte slices to the IP-DECLARED
-    // datagram end (`l3_offset + IP total length`, clamped to `frame.len()`),
-    // NOT the physical frame end. Slicing to `frame.len()` exposed
-    // attacker-controlled bytes in Ethernet slack (padding beyond the declared
-    // IP length) to a byte-offset filter match — a match-on-padding /
-    // filter-evasion bug. `None` (frame too short to hold the IP length field)
-    // fails both slices closed, like a frame shorter than l3_offset.
-    let l3 = meta.l3_offset as usize;
-    let declared_end = ip_declared_end(frame, l3, meta.addr_family);
     crate::filter::TermMatchExtra {
         tcp_flags,
         is_fragment,
         icmp_type,
         icmp_code,
-        // The L4 header is absent on a non-first fragment OR a truncated ICMP
-        // frame (#2449). The matcher gates tcp-flags / icmp-type / icmp-code on
-        // this (a zeroed icmp byte is otherwise a valid icmp-type 0 / icmp-code
-        // 0 match).
-        l4_present: !non_first_fragment && !l4_truncated,
+        // The L4 header is absent on a non-first fragment, a truncated/padded ICMP
+        // (type/code past the declared end, #2449/#5568), or a truncated/padded
+        // TCP (flags byte past the declared end, #5568). The matcher gates
+        // tcp-flags / icmp-type / icmp-code on this (a zeroed icmp byte is
+        // otherwise a valid icmp-type 0 / icmp-code 0 match).
+        l4_present: !non_first_fragment && !l4_truncated_icmp && !l4_truncated_tcp,
         // #3077: the L3 header slice (match-start layer-3) backs the
         // flexible-match-range byte-offset match. The byte offset is relative to
         // the start of the IP header. #5150: the slice ends at the IP-declared
@@ -651,7 +685,7 @@ pub(in crate::afxdp) fn term_match_extra_from_frame(
         // l3_offset (declared_end < l3 → invalid range) OR `declared_end` is
         // None, in which case the matcher's bounds check fails the flex term
         // closed.
-        flex_l3: declared_end.and_then(|end| frame.get(l3..end)),
+        flex_l3: l3_declared,
         // #3232: the L4 header slice (match-start layer-4) backs a layer-4
         // flexible-match-range. The byte offset is relative to the start of the
         // transport header (`meta.l4_offset`). A NON-FIRST fragment carries no
@@ -665,7 +699,7 @@ pub(in crate::afxdp) fn term_match_extra_from_frame(
         flex_l4: if non_first_fragment {
             None
         } else {
-            declared_end.and_then(|end| frame.get(meta.l4_offset as usize..end))
+            declared_end.and_then(|end| frame.get(l4..end))
         },
     }
 }
@@ -683,55 +717,65 @@ pub(in crate::afxdp) fn term_match_extra_from_frame_fwd(
     frame: &[u8],
     meta: ForwardPacketMeta,
 ) -> crate::filter::TermMatchExtra<'_> {
-    use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6};
-    let l3_packet = frame.get(meta.l3_offset as usize..);
-    let is_fragment = l3_packet.is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
+    use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6, PROTO_TCP};
+    // #5568: the ForwardPacketMeta builder MUST stay identical to
+    // `term_match_extra_from_frame` — derive every scalar from the IP-declared
+    // datagram end, not the physical frame, so a CoS-action byte/scalar match on
+    // this TX-selection path cannot read Ethernet slack.
+    let l3 = meta.l3_offset as usize;
+    let l4 = meta.l4_offset as usize;
+    let declared_end = ip_declared_end(frame, l3, meta.addr_family);
+    let l3_declared = declared_end.and_then(|end| frame.get(l3..end));
+    let is_fragment = l3_declared.is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
     let non_first_fragment =
-        l3_packet.is_some_and(|packet| is_non_first_fragment(packet, meta.addr_family));
-    // #2449: see `term_match_extra_from_frame` — same truncated-ICMP fail-closed
-    // guard. A frame shorter than `l4_offset + 2` has no real type/code bytes.
+        l3_declared.is_some_and(|packet| is_non_first_fragment(packet, meta.addr_family));
+    // #2449 + #5568: see `term_match_extra_from_frame` — declared-end-bounded
+    // ICMP type/code presence and TCP-flags presence. Physical `frame.len()` is
+    // NOT consulted, so padding beyond a short declared length cannot manufacture
+    // an L4 scalar.
     let icmp_type_code_present = matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6)
         && !non_first_fragment
-        && (frame.len() >= (meta.l4_offset as usize).saturating_add(2));
-    let l4_truncated = matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6)
+        && declared_end.is_some_and(|end| l4.saturating_add(2) <= end);
+    let l4_truncated_icmp = matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6)
         && !non_first_fragment
         && !icmp_type_code_present;
+    let tcp_flags_present = meta.protocol == PROTO_TCP
+        && !non_first_fragment
+        && declared_end.is_some_and(|end| l4.saturating_add(TCP_FLAGS_DECLARED_MIN) <= end);
+    let l4_truncated_tcp =
+        meta.protocol == PROTO_TCP && !non_first_fragment && !tcp_flags_present;
     let (tcp_flags, icmp_type, icmp_code) = if non_first_fragment {
         (0, 0, 0)
     } else if icmp_type_code_present {
-        let l4 = meta.l4_offset as usize;
         (
             meta.tcp_flags,
             frame.get(l4).copied().unwrap_or(0),
             frame.get(l4.wrapping_add(1)).copied().unwrap_or(0),
         )
-    } else if l4_truncated {
+    } else if l4_truncated_tcp {
+        (0, 0, 0)
+    } else if l4_truncated_icmp {
         (0, 0, 0)
     } else {
         (meta.tcp_flags, 0, 0)
     };
-    // #5150: same IP-declared-end clamp as the input-filter builder above — the
-    // two builders MUST stay identical. Without it a CoS-action byte-match on
-    // this TX-selection path would read Ethernet slack (match-on-padding).
-    let l3 = meta.l3_offset as usize;
-    let declared_end = ip_declared_end(frame, l3, meta.addr_family);
     crate::filter::TermMatchExtra {
         tcp_flags,
         is_fragment,
         icmp_type,
         icmp_code,
-        l4_present: !non_first_fragment && !l4_truncated,
+        l4_present: !non_first_fragment && !l4_truncated_icmp && !l4_truncated_tcp,
         // #3077 / #5150: L3 header slice for flexible-match-range (see the
         // input-filter builder above), clamped to the IP-declared datagram end.
         // Same fail-closed-on-too-short/None bounds check applies.
-        flex_l3: declared_end.and_then(|end| frame.get(l3..end)),
+        flex_l3: l3_declared,
         // #3232 / #5150: L4 header slice for a layer-4 flexible-match-range (see
         // the input-filter builder above), clamped to the IP-declared datagram
         // end. None on a non-first fragment so a layer-4 flex term fails closed.
         flex_l4: if non_first_fragment {
             None
         } else {
-            declared_end.and_then(|end| frame.get(meta.l4_offset as usize..end))
+            declared_end.and_then(|end| frame.get(l4..end))
         },
     }
 }

--- a/userspace-dp/src/afxdp/frame/tests_fragment_term_extra.rs
+++ b/userspace-dp/src/afxdp/frame/tests_fragment_term_extra.rs
@@ -782,3 +782,198 @@ fn build_tunnel_egress_non_first_fragment_skips_forced_l4_recompute() {
     );
 }
 
+
+// #5568 (security — SCALAR classification from physical slack): the scalar L4
+// inputs (ICMP type/code presence, TCP flags, fragment status, l4_present) MUST
+// derive from the IP-DECLARED datagram end, not the physical frame. Attacker
+// Ethernet padding beyond the declared IP length must NOT manufacture an L4
+// match. #5150 already clamped the flex BYTE SLICES; these guard the residual
+// SCALAR surface. Each test goes RED if the derivation reverts to `frame.len()`
+// (ICMP/TCP presence) or the raw `frame.get(l3..)` slice (fragment walk).
+
+// PRIMARY parent-RED gate (#5568): an Ethernet-minimum IPv4 frame declaring
+// total-length 20 (a bare IP header, NO declared ICMP body) with bytes `8, 0`
+// (echo-request type/code) sitting in the PADDING at the shim-stamped l4_offset
+// must NOT surface l4_present / icmp_type — else a permit constrained to
+// echo-request wrongly matches and a deny false-drops. Reverting the
+// `l4 + 2 <= declared_end` gate to `frame.len() >= l4 + 2` makes l4_present true
+// and icmp_type == 8, and THIS test goes RED (target-count 1 for the ICMP axis).
+#[test]
+fn term_extra_icmp_type_from_ethernet_slack_beyond_declared_end_fails_closed() {
+    // Declared datagram: 20-byte IPv4 header, total-length 20 (frag_v4_packet
+    // with an empty payload), proto ICMP. NO L4 header in the declared datagram.
+    let datagram = frag_v4_packet(PROTO_ICMP, 0x0000, &[]);
+    assert_eq!(datagram.len(), 20, "declared datagram is a bare IP header");
+    let mut frame = vec![0u8; 14]; // ethernet header
+    frame.extend_from_slice(&datagram);
+    // Ethernet SLACK past the declared IP length: `8, 0` = ICMP echo-request
+    // type/code, plus filler so the physical frame reaches l4_offset + 2.
+    frame.extend_from_slice(&[8, 0, 0, 0, 0, 0, 0, 0]);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 14 + 20, // 34 — points at the slack; the declared end is 34 too
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert!(
+        !extra.l4_present,
+        "type/code lies in Ethernet slack beyond the declared IP length \
+         (total-length 20) → l4_present MUST be false so an echo-request-\
+         constrained permit does not match and a deny does not false-drop; \
+         reverting the declared_end gate to frame.len() makes this true"
+    );
+    assert_eq!(
+        extra.icmp_type, 0,
+        "the `8` (echo-request) in Ethernet slack must NOT be read as icmp_type"
+    );
+    assert_eq!(extra.icmp_code, 0);
+}
+
+
+// #5568 TCP axis (target-count 1): an IPv4 frame declaring total-length 20 (no
+// declared TCP header) whose shim-stamped tcp_flags = SYN was read from padding.
+// The declared datagram does not reach the TCP flags byte, so l4_present MUST be
+// false and tcp_flags MUST be suppressed. Reverting the #5568 TCP declared-length
+// gate (there was no TCP L4-presence gate before) leaves l4_present true and
+// tcp_flags == SYN → RED.
+#[test]
+fn term_extra_tcp_flags_from_ethernet_slack_beyond_declared_end_fails_closed() {
+    let datagram = frag_v4_packet(PROTO_TCP, 0x0000, &[]);
+    assert_eq!(datagram.len(), 20);
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&datagram);
+    // Physical slack covering a full pseudo-TCP header (>= 14 bytes so the flags
+    // byte at l4 + 13 is physically present but NOT within the declared datagram).
+    frame.extend_from_slice(&[0u8; 20]);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 14 + 20, // 34 — declared end is also 34
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x02, // SYN, as if the shim read it from the slack
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert!(
+        !extra.l4_present,
+        "the declared datagram (total-length 20) contains no TCP flags byte → \
+         l4_present MUST be false so a `tcp-flags syn` term fails closed; \
+         reverting the #5568 TCP declared-length gate leaves l4_present true"
+    );
+    assert_eq!(
+        extra.tcp_flags, 0,
+        "shim-stamped SYN was read from Ethernet slack and must not be exposed"
+    );
+}
+
+
+// #5568 IPv6 fragment axis (target-count 1): an IPv6 fixed header with
+// payload_len 0 (declared datagram = 40 bytes) whose next-header is Hop-by-Hop
+// (0, a walkable extension header). Ethernet SLACK past byte 40 forges a HbH
+// option whose next-header is Fragment (44). The unbounded ext-header walk would
+// chase the slack and set is_fragment = true; bounding the walk to the declared
+// datagram (40 bytes) stops it. Reverting the fragment walker to the raw
+// frame.get(l3..) slice manufactures a fragment → RED.
+#[test]
+fn term_extra_ipv6_fragment_from_ethernet_slack_beyond_declared_end_not_manufactured() {
+    let mut ipv6 = vec![0u8; 40];
+    ipv6[0] = 0x60;
+    ipv6[6] = 0; // next header = Hop-by-Hop (walkable)
+    ipv6[7] = 64; // hop limit
+    ipv6[8..24].copy_from_slice(&[0x20; 16]); // src
+    ipv6[24..40].copy_from_slice(&[0x30; 16]); // dst
+    // payload_len (bytes 4..6) stays 0 → declared datagram end = l3 + 40.
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&ipv6);
+    // Ethernet slack forging an 8-byte HbH option: next-header = 44 (Fragment).
+    frame.extend_from_slice(&[44, 0, 0, 0, 0, 0, 0, 0]);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 14 + 40,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP, // irrelevant to is_fragment (addr_family-driven)
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert!(
+        !extra.is_fragment,
+        "the Fragment header lives in Ethernet slack beyond the declared \
+         payload_len (0) → is_fragment MUST stay false; reverting the fragment \
+         walker to the raw frame.get(l3..) slice manufactures a fragment"
+    );
+}
+
+
+// #5568 anti-over-gate: a well-formed TCP packet (declared total-length covers
+// the 20-byte TCP header) keeps l4_present true and the shim-stamped flags —
+// proving the new TCP declared-length gate does not reject legitimate traffic.
+#[test]
+fn term_extra_full_tcp_keeps_l4_present_and_flags() {
+    let mut tcp = vec![0u8; 20];
+    tcp[13] = 0x12; // SYN|ACK
+    let datagram = frag_v4_packet(PROTO_TCP, 0x0000, &tcp);
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&datagram);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 14 + 20,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x12,
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert!(extra.l4_present, "full TCP packet → l4_present true (no over-reject)");
+    assert_eq!(extra.tcp_flags, 0x12, "authoritative shim flags preserved");
+}
+
+
+// #5568 anti-over-gate: a REAL IPv6 fragment (fragment header within the declared
+// payload_len) is still classified is_fragment = true — the declared-end bound
+// excludes slack, never a legitimately-declared fragment header.
+#[test]
+fn term_extra_ipv6_real_fragment_still_detected_no_slack() {
+    let datagram = frag_v6_packet(PROTO_TCP, Some(0x0001), &[0u8; 8]);
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&datagram);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 14 + 40 + 8, // past the fragment header
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert!(
+        extra.is_fragment,
+        "a real (declared) IPv6 fragment is still detected"
+    );
+}
+
+
+// #5568: the ForwardPacketMeta (CoS / TX-selection) twin builder MUST apply the
+// identical declared-end gate — otherwise a CoS-action scalar match on that path
+// reads Ethernet slack. Mirrors the primary ICMP axis on the fwd builder.
+#[test]
+fn term_extra_fwd_icmp_type_from_slack_beyond_declared_end_fails_closed() {
+    let datagram = frag_v4_packet(PROTO_ICMP, 0x0000, &[]);
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&datagram);
+    frame.extend_from_slice(&[8, 0, 0, 0]);
+    let meta = ForwardPacketMeta {
+        l3_offset: 14,
+        l4_offset: 14 + 20,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        ..ForwardPacketMeta::default()
+    };
+    let extra = term_match_extra_from_frame_fwd(&frame, meta);
+    assert!(
+        !extra.l4_present,
+        "fwd twin must fail closed on slack icmp type/code (identical to the input builder)"
+    );
+    assert_eq!(extra.icmp_type, 0);
+}
+

--- a/userspace-dp/src/afxdp/icmp_embed/parse.rs
+++ b/userspace-dp/src/afxdp/icmp_embed/parse.rs
@@ -73,13 +73,32 @@ pub(in crate::afxdp::icmp_embed) fn parse_embedded_v4(
         frame[embedded_ip_start + 19],
     );
     let l4_off = embedded_ip_start + ihl;
+    // #5568: bound the quoted-inner L4 read by the QUOTED IPv4 datagram's
+    // declared total-length, not merely the outer backing frame. An ICMP error
+    // whose outer frame carries slack/padding beyond the quoted datagram's
+    // declared length would otherwise have those bytes read as inner ports — a
+    // manufactured embedded-session tuple that could touch an existing session.
+    // The quoted datagram ends at `embedded_ip_start + total_len`; the port read
+    // must lie within it. A quote whose declared length legitimately EXCEEDS the
+    // available bytes (an RFC-792 minimum, intentionally truncated quote) is NOT
+    // rejected: `total_len` is large, so the window check passes and `frame.get`
+    // then bounds the read to what is actually present.
+    let inner_total =
+        u16::from_be_bytes([frame[embedded_ip_start + 2], frame[embedded_ip_start + 3]]) as usize;
+    let inner_declared_end = embedded_ip_start.saturating_add(inner_total);
     let (src_port, dst_port) = if matches!(proto, PROTO_TCP | PROTO_UDP) {
+        if l4_off.saturating_add(4) > inner_declared_end {
+            return None;
+        }
         let bytes = frame.get(l4_off..l4_off + 4)?;
         (
             u16::from_be_bytes([bytes[0], bytes[1]]),
             u16::from_be_bytes([bytes[2], bytes[3]]),
         )
     } else if matches!(proto, PROTO_ICMP) {
+        if l4_off.saturating_add(6) > inner_declared_end {
+            return None;
+        }
         let bytes = frame.get(l4_off + 4..l4_off + 6)?;
         (u16::from_be_bytes([bytes[0], bytes[1]]), 0)
     } else {
@@ -184,7 +203,21 @@ pub(in crate::afxdp::icmp_embed) fn parse_embedded_v6(
     if frame.len() < embedded_ip_start + 48 {
         return None;
     }
-    let (rel_l4, proto) = parse_embedded_v6_l4(frame.get(embedded_ip_start..)?)?;
+    // #5568: bound BOTH the quoted-inner extension-header walk AND the L4 read by
+    // the QUOTED IPv6 datagram's declared length (`embedded_ip_start + 40 +
+    // payload_len`), clamped to the available quote bytes — not the raw outer
+    // frame. Otherwise outer-frame slack/padding beyond the quoted datagram could
+    // be walked as ext headers and read as inner ports (a manufactured
+    // embedded-session tuple). A truncated RFC-minimum quote whose declared
+    // `payload_len` exceeds the available bytes is NOT rejected: the clamp keeps
+    // the slice at `frame.len()` there, identical to the pre-#5568 read.
+    let inner_payload_len =
+        u16::from_be_bytes([frame[embedded_ip_start + 4], frame[embedded_ip_start + 5]]) as usize;
+    let inner_declared_end = embedded_ip_start
+        .saturating_add(40)
+        .saturating_add(inner_payload_len)
+        .min(frame.len());
+    let (rel_l4, proto) = parse_embedded_v6_l4(frame.get(embedded_ip_start..inner_declared_end)?)?;
     let src_wire = Ipv6Addr::from(
         <[u8; 16]>::try_from(&frame[embedded_ip_start + 8..embedded_ip_start + 24]).ok()?,
     );
@@ -193,12 +226,18 @@ pub(in crate::afxdp::icmp_embed) fn parse_embedded_v6(
     ));
     let l4_off = embedded_ip_start + rel_l4;
     let (src_port, dst_port) = if matches!(proto, PROTO_TCP | PROTO_UDP) {
+        if l4_off.saturating_add(4) > inner_declared_end {
+            return None;
+        }
         let bytes = frame.get(l4_off..l4_off + 4)?;
         (
             u16::from_be_bytes([bytes[0], bytes[1]]),
             u16::from_be_bytes([bytes[2], bytes[3]]),
         )
     } else if matches!(proto, PROTO_ICMPV6) {
+        if l4_off.saturating_add(6) > inner_declared_end {
+            return None;
+        }
         let bytes = frame.get(l4_off + 4..l4_off + 6)?;
         (u16::from_be_bytes([bytes[0], bytes[1]]), 0)
     } else {
@@ -428,6 +467,46 @@ mod embedded_v6_parse_tests {
             parse_embedded_v6_l4(&embedded_v6(&[hbh], esp)).expect("ESP after one EH resolves");
         assert_eq!((rel, proto), (48, esp));
     }
+
+    // #5568 IPv6 sibling (embedded-session tuple from slack): a quoted inner
+    // IPv6 datagram declaring payload_len 0 (declared datagram = 40 bytes, NO L4)
+    // whose next-header is TCP. Outer-frame slack past byte 40 forges ports. The
+    // parser MUST bound BOTH the ext-header walk AND the L4 read by the quoted
+    // datagram's declared length and refuse. Reverting to the outer-frame bound
+    // returns Some(_) with the forged ports → RED.
+    #[test]
+    fn embedded_v6_ports_from_slack_beyond_declared_end_not_manufactured() {
+        let mut inner = vec![0u8; 40];
+        inner[0] = 0x60;
+        inner[6] = PROTO_TCP; // next header = TCP directly
+        // payload_len (bytes 4..6) stays 0 → declared datagram end = 40.
+        inner[8..24].copy_from_slice(&[0x20; 16]);
+        inner[24..40].copy_from_slice(&[0x30; 16]);
+        // Forged ports in the outer slack beyond the declared datagram.
+        inner.extend_from_slice(&[0x30, 0x39, 0x14, 0x51, 0, 0, 0, 0]);
+        assert!(
+            parse_embedded_v6(&inner, 0).is_none(),
+            "ports in slack beyond the quoted IPv6 payload_len (0) must not be read"
+        );
+    }
+
+    // #5568 anti-over-gate (IPv6): a truncated RFC-minimum quote whose declared
+    // payload_len (1280) legitimately EXCEEDS the quoted bytes must STILL parse
+    // its quoted ports — the declared-length bound clamps to the available quote,
+    // it does not reject a legitimately-truncated quote.
+    #[test]
+    fn embedded_v6_truncated_quote_still_parses() {
+        let mut inner = vec![0u8; 40];
+        inner[0] = 0x60;
+        inner[6] = PROTO_TCP;
+        inner[4..6].copy_from_slice(&1280u16.to_be_bytes()); // original datagram was large
+        inner[8..24].copy_from_slice(&[0x20; 16]);
+        inner[24..40].copy_from_slice(&[0x30; 16]);
+        inner.extend_from_slice(&[0x11, 0x11, 0x22, 0x22, 0, 0, 0, 1]); // 8 quoted L4 bytes
+        let hdr =
+            parse_embedded_v6(&inner, 0).expect("truncated RFC-minimum v6 quote must still parse");
+        assert_eq!((hdr.src_port, hdr.dst_port), (0x1111, 0x2222));
+    }
 }
 
 #[cfg(test)]
@@ -473,5 +552,52 @@ mod embedded_v4_fragment_tests {
                 "quoted non-first fragment (frag_off {frag_off:#06x}) must not parse"
             );
         }
+    }
+
+    // #5568 (security — embedded-session tuple from slack): an ICMP error quotes
+    // an inner IPv4 datagram declaring total-length 20 (a bare IP header, NO L4).
+    // Outer-frame slack/padding beyond the quoted datagram forges TCP ports of an
+    // existing session. The parser MUST bound the L4 read by the quoted IP's
+    // declared total-length and refuse — else the forged ports drive a bogus
+    // embedded-session/NAT match. Reverting to the outer-frame-only bound returns
+    // Some(_) with the forged ports → RED (embedded axis, target-count 1).
+    #[test]
+    fn embedded_v4_ports_from_slack_beyond_declared_end_not_manufactured() {
+        let mut inner = vec![0u8; 20];
+        inner[0] = 0x45;
+        inner[2..4].copy_from_slice(&20u16.to_be_bytes()); // total-length 20 — no L4
+        inner[9] = PROTO_TCP;
+        inner[12..16].copy_from_slice(&[10, 0, 0, 1]);
+        inner[16..20].copy_from_slice(&[10, 0, 0, 2]);
+        // Outer slack past the declared inner datagram: forged src/dst ports
+        // (12345 / 5201) that would look like an existing session tuple.
+        inner.extend_from_slice(&[0x30, 0x39, 0x14, 0x51, 0, 0, 0, 0]);
+        assert!(
+            parse_embedded_v4(&inner, 0).is_none(),
+            "ports lie in slack beyond the quoted IP's declared total-length (20) — \
+             the parser must not manufacture an embedded-session tuple from them"
+        );
+    }
+
+    // #5568 anti-over-gate: a legitimate ICMP error quotes only the inner IP
+    // header + first 8 bytes (RFC 792 minimum). The inner ORIGINAL total-length
+    // (1500) legitimately EXCEEDS the quoted bytes — the parser must still read
+    // the 8 quoted L4 bytes (ports), NOT reject the quote.
+    #[test]
+    fn embedded_v4_truncated_rfc_minimum_quote_still_parses() {
+        let mut inner = vec![0u8; 20];
+        inner[0] = 0x45;
+        inner[2..4].copy_from_slice(&1500u16.to_be_bytes()); // original datagram was large
+        inner[9] = PROTO_TCP;
+        inner[12..16].copy_from_slice(&[10, 0, 0, 1]);
+        inner[16..20].copy_from_slice(&[10, 0, 0, 2]);
+        inner.extend_from_slice(&[0x11, 0x11, 0x22, 0x22, 0, 0, 0, 1]); // the 8 quoted bytes
+        let hdr =
+            parse_embedded_v4(&inner, 0).expect("truncated RFC-minimum quote must still parse");
+        assert_eq!(
+            (hdr.src_port, hdr.dst_port),
+            (0x1111, 0x2222),
+            "the quoted ports are within the (large) declared length → read them"
+        );
     }
 }

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -484,6 +484,27 @@ the live frame.)
 `(0, 0, 0)` AND drop `l4_present`, failing the icmp-type/code terms closed rather
 than spuriously matching `icmp-type 0` / `icmp-code 0`.
 
+**#5568 (SCALAR declared-length bound).** #2449 keyed the ICMP presence test on
+the physical `frame.len()`; #5568 keys EVERY scalar L4/fragment input on the
+IP-DECLARED datagram end (`ip_declared_end` — the same SSOT that bounds the
+#5150 flex slices), computed FIRST in both frame builders. The shim stamps
+`l3_offset`/`l4_offset` from the raw frame, so without this, attacker-controlled
+Ethernet padding beyond the declared IP length manufactures a scalar match out of
+slack. Concretely: (a) the fragment walkers (`is_any_fragment` /
+`is_non_first_fragment`) see only `frame.get(l3..declared_end)`, so an IPv6
+fragment/extension header lurking in padding beyond `payload_len` — or an IPv4
+`frag_off` in slack — cannot manufacture fragment state; (b) ICMP type/code
+presence requires `l4_offset + 2 <= declared_end`; (c) TCP flags require
+`l4_offset + TCP_FLAGS_DECLARED_MIN (14) <= declared_end` (the flags byte at TCP
+offset 13) — a short/padded TCP frame whose declared length stops before the
+flags byte drops `l4_present`, failing tcp-flags terms closed. On the common
+no-slack path `declared_end == frame.len()`, so classification is byte-identical.
+The sibling `parse_embedded_v4`/`parse_embedded_v6` quote parsers
+(`icmp_embed/parse.rs`) apply the same bound to the QUOTED inner datagram's
+declared length (clamped to the available quote — a legitimately-truncated
+RFC-792 minimum quote whose original length exceeds the quoted bytes is NOT
+rejected), so outer-frame padding cannot manufacture an embedded-session tuple.
+
 **Meta-only builder (`term_match_extra_from_meta`, #3008 — meta sibling of
 #2449).** A few cold TX-selection callers (re-derived locally-generated replies,
 ARP/NDP-deferred forwards, control-plane injects;


### PR DESCRIPTION
## Summary

- The scalar L4/fragment match inputs built by `term_match_extra_from_frame` (and its `ForwardPacketMeta` twin) derived from the **physical frame** — `frame.len()` for ICMP type/code presence and a raw `frame.get(l3..)` slice for the fragment walkers — not the **IP-declared datagram end**. This is the residual SCALAR surface left after #5150 clamped the flexible-match BYTE SLICES.
- The shim stamps `l3_offset`/`l4_offset` from the raw frame, so attacker-influenced Ethernet padding beyond the declared IP length could manufacture ICMP type/code presence, TCP flags, fragment status, and `l4_present` out of slack — feeding a spurious PERMIT, a false DROP, a manufactured fragment classification, an established-session touch, or misleading policy/filter counters/logs. Downstream scalar consumers (`policy_packet_icmp`, input/lo0 filter, host-inbound) read these scalars, so fixing the builder fixes them.
- **Fix:** compute the family-aware `declared_end` first (reusing the existing `ip_declared_end` SSOT that also bounds the #5150 flex slices), then derive every scalar from it:
  - fragment walkers see `frame.get(l3..declared_end)` — a fragment/extension header in slack cannot manufacture fragment state;
  - ICMP type/code presence requires `l4_offset + 2 <= declared_end`;
  - TCP flags require `l4_offset + 14 <= declared_end` (flags byte at TCP offset 13), else `l4_present = false`.
  - `declared_end == None` fails closed. Common no-slack path (`declared_end == frame.len()`) is byte-identical.
- Apply the same declared-inner bound to `parse_embedded_v4`/`parse_embedded_v6`: bound the inner L4 read + IPv6 ext-header walk by the QUOTED datagram's declared length, clamped to the available quote — so outer-frame padding cannot be read as inner ports (a manufactured embedded-session tuple). A legitimately-truncated RFC-792 minimum quote is **not** rejected.

## Hot-path shape

Cold classification path only (per-packet on filter/policy/host-inbound eval). One extra `ip_declared_end` call is now shared across the fragment walkers, the L4-presence gates, and the flex slices (previously computed once for flex only) — net zero additional work on the common path; a couple of `<=` comparisons replace the old `frame.len()` compare.

## Test plan

- [x] Fail-on-revert tests, one canonical test per axis (each goes RED if the derivation reverts to physical length; verified by single-line reverts — target-count 1 per axis):
  - `term_extra_icmp_type_from_ethernet_slack_beyond_declared_end_fails_closed` (**primary parent-RED gate**)
  - `term_extra_tcp_flags_from_ethernet_slack_beyond_declared_end_fails_closed`
  - `term_extra_ipv6_fragment_from_ethernet_slack_beyond_declared_end_not_manufactured`
  - `embedded_v4_ports_from_slack_beyond_declared_end_not_manufactured` (+ v6 sibling)
- [x] Anti-over-gate guards: full TCP keeps `l4_present`/flags; real IPv6 fragment still detected; truncated RFC-minimum v4/v6 quotes still parse their ports; `_fwd` twin identical.
- [x] Full `xpf-userspace-dp` suite: **4024 passed, 0 failed, 2 ignored**.
- Dataplane classification is unit-provable (pure byte-buffer functions); not an HA change, so no cluster failover smoke required. Live-traffic smoke not run in this environment.

## Refs

Closes #5568. Sibling of #5150 (flex byte-slice clamp) / #2361 (declared-end port parse) / #2449 (truncated-ICMP fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ugzzer38MZ7Ck72zhCdvgT