### PR TITLE
userspace-dp: surface failed reconcile in binding/queue/rebind (#5621)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -53407,3 +53407,31 @@ top.
   userspace-dp/src/afxdp/coordinator/wg_control.rs,
   userspace-dp/src/afxdp/frame/wg.rs, userspace-dp/src/afxdp/wg/tests.rs,
   docs/research/1888-wg-timers/plan.md
+
+- **Timestamp**: 2026-07-18
+- **Action**: #5621 — control-socket handlers now SURFACE a failed
+  `reconcile_status_bindings` instead of discarding it. binding.rs /
+  queue.rs / rebind.rs did `let _ = reconcile_status_bindings(guard)`, so a
+  handler acked `ok=true` even when the reconcile FAILED (mandatory-pin
+  preflight fault or a forwarding-build integrity error on the
+  already-accepted snapshot) — the control-socket caller believed the
+  (re)bind succeeded when it did not. Now on `Err` each reports `ok=false` +
+  the surfaced error, refreshes status, and does NOT `persist_state`;
+  `rebind::handle` gained a `response` parameter (dispatcher call site
+  updated). Success path unchanged (clean reconcile still `ok=true`).
+  `set_forwarding_state` still discards (out of scope — flagged follow-up).
+  Added 3 fail-on-revert tests
+  (`set_binding_state_failed_reconcile_reports_error_5621`,
+  `set_queue_state_failed_reconcile_reports_error_5621`,
+  `rebind_failed_reconcile_reports_error_5621`) — each faults the reconcile
+  with a stored `/33`-address snapshot; reverting a site to `let _ = ...`
+  flips exactly its assertion RED (verified: all-3-reverted → 3 fail, 0
+  collateral; rebind-only-unfixed → only rebind fails). Full suite 4027
+  passed / 0 failed. NOT HA/session-sync — local control-socket reconcile.
+- **File(s)**: userspace-dp/src/server/handlers/binding.rs,
+  userspace-dp/src/server/handlers/queue.rs,
+  userspace-dp/src/server/handlers/rebind.rs,
+  userspace-dp/src/server/handlers/mod.rs,
+  userspace-dp/src/server/tests.rs,
+  userspace-dp/src/server/README.md,
+  docs/userspace-dataplane-architecture.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -316,11 +316,23 @@ leg also restores `status.bindings`) and the bumped status-reporting
 fields (`last_snapshot_generation` / `last_fib_generation` /
 `last_snapshot_at` / `capabilities`), report `ok=false`, and do NOT set
 `persist_state`. Because the reconcile aborts *before* teardown, the
-restore is a status/bookkeeping rollback — the data plane never moved. The
-sibling control-socket handlers that reconcile the ALREADY-accepted stored
-snapshot (`set_queue_state`, `set_binding_state`, `rebind`,
-`set_forwarding_state`) explicitly discard the outcome: they introduce no
-new snapshot to reject.
+restore is a status/bookkeeping rollback — the data plane never moved.
+
+The sibling control-socket handlers reconcile the ALREADY-accepted stored
+snapshot (a registration toggle / rebind / forwarding-state change, not a
+new config), so there is no rejected snapshot to un-persist. But
+`reconcile_status_bindings` can still return `Err` even for an accepted
+snapshot — the mandatory-pin preflight can fault, or the forwarding build
+can hit a non-policy integrity error. #5621 stops `set_binding_state`,
+`set_queue_state`, and `rebind` from **discarding** that `Err`: on failure
+they report `ok=false` + the surfaced error, refresh status, and do NOT
+`persist_state`, so the control-socket caller no longer mistakes a failed
+(re)bind for success (previously the `let _ = reconcile_status_bindings(..)`
+discard acked `ok=true` regardless). `rebind::handle` gained a `response`
+parameter to carry the error. `set_forwarding_state` still discards the
+outcome (its arm/disarm reconcile takes the disarmed `Ok` path on disarm and
+surfaces a build reject via each binding's `last_error` on arm) — bringing
+it into the same fail-surfacing shape is a scoped follow-up.
 
 Regression coverage: `coordinator/tests.rs`
 (`reconcile_build_failure_returns_integrity_err_and_keeps_prior_generation_3789`,
@@ -334,7 +346,14 @@ makes `ok=false` / prior-snapshot-kept assertions flip). The
 `apply_snapshot_same_plan_clearing_defer_workers_reconcile_abort_fails_closed_3789`
 test (renamed from `…_reconciles_bindings`, which previously codified the
 swallow) now asserts the deferred-binding reconcile is triggered but the
-missing-pin abort fails closed.
+missing-pin abort fails closed. The #5621 sibling-handler coverage lives in
+`server/tests.rs`
+(`set_binding_state_failed_reconcile_reports_error_5621`,
+`set_queue_state_failed_reconcile_reports_error_5621`,
+`rebind_failed_reconcile_reports_error_5621` — each faults the reconcile
+with a stored `/33`-address snapshot and pins `ok=false`; reverting the
+matching handler to `let _ = reconcile_status_bindings(..)` flips exactly
+its assertion RED).
 
 #### Per-Packet Processing Pipeline
 

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -189,8 +189,15 @@ queues. See PR #1243's kill record for why i40e doesn't reshape.
   snapshot + status fields and reporting `ok=false` instead of persisting
   the rejected snapshot (see `docs/userspace-dataplane-architecture.md`,
   "Control-plane handler observes the reconcile outcome"). The
-  already-accepted-snapshot callers (`set_queue_state`, `set_binding_state`,
-  `rebind`, `set_forwarding_state`) discard the outcome. When
+  already-accepted-snapshot callers reconcile a registration toggle / rebind
+  / forwarding-state change, not a new config, so there is no rejected
+  snapshot to un-persist — but the reconcile can still fault (mandatory-pin
+  preflight / forwarding-build integrity error). #5621: `set_binding_state`,
+  `set_queue_state`, and `rebind` now SURFACE that `Err` (report `ok=false` +
+  the error, refresh status, do NOT `persist_state`) instead of the old
+  `let _ = reconcile_status_bindings(..)` discard that acked `ok=true` after a
+  failed (re)bind; `rebind::handle` took a `response` parameter for this.
+  `set_forwarding_state` still discards the outcome (scoped follow-up). When
   `should_run_afxdp` does NOT hold (forwarding disarmed / unsupported) it
   `stop()`s every worker and then routes the per-binding status through
   `refresh_bindings` — which sends each now-workerless slot through

--- a/userspace-dp/src/server/handlers/binding.rs
+++ b/userspace-dp/src/server/handlers/binding.rs
@@ -31,9 +31,23 @@ pub(super) fn set(
         if registration_changed {
             // #3789: re-binds the ALREADY-ACCEPTED stored snapshot (a
             // binding registration toggle, not a new config), so a build
-            // reject cannot introduce a rejected snapshot here — discard
-            // the outcome explicitly.
-            let _ = reconcile_status_bindings(guard);
+            // reject cannot introduce a rejected snapshot here.
+            //
+            // #5621: the reconcile itself can still FAIL — the mandatory-pin
+            // preflight can fault, or the forwarding build can hit a
+            // non-policy integrity error on the already-accepted snapshot.
+            // Discarding that Err made the handler ack ok=true while the
+            // AF_XDP sockets were NOT actually rebound, so the control-socket
+            // caller believed the reconcile succeeded when it did not.
+            // Surface the failure: report ok=false + the error, refresh
+            // status so `show` reflects the real per-binding state, and do
+            // NOT persist a success we didn't achieve.
+            if let Err(err) = reconcile_status_bindings(guard) {
+                response.ok = false;
+                response.error = format!("binding reconcile failed: {err}");
+                refresh_status(guard);
+                return;
+            }
             wait_for_binding_settle(guard, Duration::from_secs(2));
         }
         refresh_status(guard);

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -242,7 +242,7 @@ pub(crate) fn handle_stream(
                 // handle. The blocking push loop runs after the lock drops.
                 all_export = export::all_kick(&mut guard, &mut response);
             }
-            "rebind" => rebind::handle(&mut guard, &mut persist_state),
+            "rebind" => rebind::handle(&mut guard, &mut response, &mut persist_state),
             "stop_workers" => stop_workers::handle(&mut guard, &mut persist_state),
             "shutdown" => {
                 guard.afxdp.stop_with_event_stream();

--- a/userspace-dp/src/server/handlers/queue.rs
+++ b/userspace-dp/src/server/handlers/queue.rs
@@ -38,9 +38,23 @@ pub(super) fn set(
         if registration_changed {
             // #3789: this reconcile re-binds the ALREADY-ACCEPTED stored
             // snapshot (a queue registration toggle, not a new config), so
-            // a build reject cannot introduce a rejected snapshot here —
-            // discard the outcome explicitly.
-            let _ = reconcile_status_bindings(guard);
+            // a build reject cannot introduce a rejected snapshot here.
+            //
+            // #5621: the reconcile itself can still FAIL — the mandatory-pin
+            // preflight can fault, or the forwarding build can hit a
+            // non-policy integrity error on the already-accepted snapshot.
+            // Discarding that Err made the handler ack ok=true while the
+            // AF_XDP sockets were NOT actually rebound, so the control-socket
+            // caller believed the reconcile succeeded when it did not.
+            // Surface the failure: report ok=false + the error, refresh
+            // status so `show` reflects the real per-binding state, and do
+            // NOT persist a success we didn't achieve.
+            if let Err(err) = reconcile_status_bindings(guard) {
+                response.ok = false;
+                response.error = format!("queue reconcile failed: {err}");
+                refresh_status(guard);
+                return;
+            }
             wait_for_binding_settle(guard, Duration::from_secs(2));
         }
         refresh_status(guard);

--- a/userspace-dp/src/server/handlers/rebind.rs
+++ b/userspace-dp/src/server/handlers/rebind.rs
@@ -3,8 +3,13 @@
 
 use super::super::helpers::{reconcile_status_bindings, refresh_status};
 use super::super::ServerState;
+use crate::ControlResponse;
 
-pub(super) fn handle(guard: &mut ServerState, persist_state: &mut bool) {
+pub(super) fn handle(
+    guard: &mut ServerState,
+    response: &mut ControlResponse,
+    persist_state: &mut bool,
+) {
     // After a link DOWN/UP cycle (e.g. RETH MAC programming),
     // the kernel destroys the XSK receive queue.  Clear binding
     // state and reconcile to recreate the AF_XDP sockets from
@@ -46,8 +51,23 @@ pub(super) fn handle(guard: &mut ServerState, persist_state: &mut bool) {
     // #3789: rebind re-creates the AF_XDP sockets for the ALREADY-ACCEPTED
     // stored snapshot after a link DOWN/UP cycle — it does not introduce a
     // new config, so a reconcile reject cannot persist a rejected snapshot
-    // here. Discard the outcome explicitly.
-    let _ = reconcile_status_bindings(guard);
+    // here.
+    //
+    // #5621: the reconcile itself can still FAIL — the mandatory-pin preflight
+    // can fault, or the forwarding build can hit a non-policy integrity error
+    // on the already-accepted snapshot. Discarding that Err made rebind ack
+    // ok=true while the AF_XDP sockets were NOT recreated, so the
+    // control-socket caller believed the rebind succeeded when it did not.
+    // Surface the failure: report ok=false + the error, refresh status so
+    // `show` reflects the real per-binding state, and do NOT persist a success
+    // we didn't achieve.
+    if let Err(err) = reconcile_status_bindings(guard) {
+        response.ok = false;
+        response.error = format!("rebind reconcile failed: {err}");
+        refresh_status(guard);
+        eprintln!("rebind: reconcile failed: {err}");
+        return;
+    }
     refresh_status(guard);
     *persist_state = true;
     eprintln!(

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1729,6 +1729,136 @@ fn set_queue_state_toggles_armed_on_known_queue() {
     );
 }
 
+// --- #5621: control-socket handlers must SURFACE a failed reconcile ------
+//
+// binding.rs / queue.rs / rebind.rs used to `let _ =
+// reconcile_status_bindings(guard)` — discarding the `Result`. When the
+// reconcile FAILED (a mandatory-pin preflight fault, or a forwarding-build
+// integrity error on the ALREADY-ACCEPTED snapshot) the handler still acked
+// ok=true, so the control-socket caller believed the AF_XDP sockets were
+// (re)bound when they were not. These tests fault the reconcile with a stored
+// snapshot whose forwarding build fails (an unparseable /33 interface address —
+// the #3789 fixture) and pin ok=false + the surfaced error. Reverting the
+// matching site to `let _ = reconcile_status_bindings(...)` flips the
+// assertion RED (target-count 1 per site): the discard restores ok=true.
+// Distinct from #5143 (that was the apply_snapshot rejected-snapshot leg).
+
+/// A stored snapshot whose forwarding build FAILS (unparseable `/33` address).
+/// With `forwarding_armed` + `forwarding_supported`, `reconcile_status_bindings`
+/// takes the armed arm and `afxdp.reconcile` returns `Err` on this snapshot —
+/// the same fault the #3789 apply-leg tests use.
+fn failing_reconcile_snapshot() -> crate::ConfigSnapshot {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 7,
+        fib_generation: 7,
+        generated_at: chrono::Utc::now(),
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![tunnel_iface_3789("10.0.0.0/33")],
+        ..ConfigSnapshot::default()
+    }
+}
+
+/// Armed + forwarding-supported helper carrying a stored snapshot that will
+/// fault the reconcile. The already-accepted snapshot models the #5621
+/// scenario: a registration toggle / rebind re-runs the reconcile, which
+/// faults, and the handler must NOT report success.
+fn armed_state_with_failing_reconcile(bindings: Vec<BindingStatus>) -> Arc<Mutex<ServerState>> {
+    Arc::new(Mutex::new(ServerState {
+        status: ProcessStatus {
+            forwarding_armed: true,
+            capabilities: forwarding_caps(),
+            bindings,
+            ..ProcessStatus::default()
+        },
+        snapshot: Some(failing_reconcile_snapshot()),
+        afxdp: afxdp::Coordinator::new(),
+        state_writer: Arc::new(StateWriter::new()),
+    }))
+}
+
+#[test]
+fn set_binding_state_failed_reconcile_reports_error_5621() {
+    // registered toggles false -> true so `registration_changed` fires the
+    // reconcile; the stored bad snapshot makes that reconcile return Err.
+    let state = armed_state_with_failing_reconcile(vec![BindingStatus {
+        slot: 0,
+        registered: false,
+        ifindex: 10,
+        ..BindingStatus::default()
+    }]);
+    let mut request = req("set_binding_state");
+    request.binding = Some(BindingControlRequest {
+        slot: 0,
+        registered: true,
+        armed: true,
+    });
+    let response = run_request(state, request);
+    assert!(
+        !response.ok,
+        "#5621: set_binding_state must report ok=false when the reconcile fails"
+    );
+    assert!(
+        response.error.contains("binding reconcile failed"),
+        "unexpected error: {}",
+        response.error
+    );
+}
+
+#[test]
+fn set_queue_state_failed_reconcile_reports_error_5621() {
+    // registered toggles false -> true so `registration_changed` fires the
+    // reconcile; the stored bad snapshot makes that reconcile return Err.
+    let state = armed_state_with_failing_reconcile(vec![BindingStatus {
+        slot: 0,
+        queue_id: 2,
+        registered: false,
+        ifindex: 10,
+        ..BindingStatus::default()
+    }]);
+    let mut request = req("set_queue_state");
+    request.queue = Some(QueueControlRequest {
+        queue_id: 2,
+        registered: true,
+        armed: true,
+    });
+    let response = run_request(state, request);
+    assert!(
+        !response.ok,
+        "#5621: set_queue_state must report ok=false when the reconcile fails"
+    );
+    assert!(
+        response.error.contains("queue reconcile failed"),
+        "unexpected error: {}",
+        response.error
+    );
+}
+
+#[test]
+fn rebind_failed_reconcile_reports_error_5621() {
+    // rebind unconditionally reconciles; the stored bad snapshot makes that
+    // reconcile return Err. Before #5621 rebind::handle took no `response`
+    // and always acked ok=true.
+    let state = armed_state_with_failing_reconcile(vec![BindingStatus {
+        slot: 0,
+        registered: true,
+        ifindex: 10,
+        ..BindingStatus::default()
+    }]);
+    let response = run_request(state, req("rebind"));
+    assert!(
+        !response.ok,
+        "#5621: rebind must report ok=false when the reconcile fails"
+    );
+    assert!(
+        response.error.contains("rebind reconcile failed"),
+        "unexpected error: {}",
+        response.error
+    );
+}
+
 #[test]
 fn stop_workers_clears_socket_fields_on_all_bindings() {
     // stop_workers must tear down per-binding socket state so the


### PR DESCRIPTION
## Summary

- The control-socket handlers `set_binding_state`, `set_queue_state`, and `rebind` discarded the `reconcile_status_bindings` result with `let _ = reconcile_status_bindings(guard)`.
- `reconcile_status_bindings` returns `Result<(), afxdp::ReconcileError>` and can fail even for an **already-accepted** stored snapshot — the mandatory-pin preflight can fault, or the forwarding build can hit a non-policy integrity error.
- Discarding that `Err` let the handler ack `ok=true` after a reconcile that actually **failed**, so the control-socket caller believed the AF_XDP sockets were (re)bound when they were not.
- Fix: on `Err`, set `response.ok = false` + a surfaced error, refresh status, and do **not** `persist_state`. `rebind::handle` gained a `response: &mut ControlResponse` parameter (dispatcher call site updated). Success path unchanged — a clean reconcile still returns `ok=true`.
- `reconcile_status_bindings`' own two-arm behavior is untouched; only the call-site discards change. **Not HA/session-sync** — this is the local control-socket reconcile path.

## Scope

- Applies to the three sites named in the issue: `binding.rs`, `queue.rs`, `rebind.rs`.
- `set_forwarding_state` (`forwarding.rs:39`) is an **identical sibling** discard site, left out of this issue's scope — its arm/disarm reconcile takes the disarmed `Ok` path on disarm and surfaces a build reject via each binding's `last_error` on arm. Bringing it into the same fail-surfacing shape is a scoped follow-up.

## Test plan

- [x] Added 3 fail-on-revert tests in `server/tests.rs`, each faulting the reconcile with a stored `/33`-address snapshot (the #3789 fixture) and pinning `ok=false` + the surfaced error:
  - `set_binding_state_failed_reconcile_reports_error_5621`
  - `set_queue_state_failed_reconcile_reports_error_5621`
  - `rebind_failed_reconcile_reports_error_5621`
- [x] Parent-RED map (target-count 1 per site), verified firsthand:
  - All three sites reverted to `let _ = reconcile_status_bindings(..)` → **exactly 3 fail, 0 collateral**.
  - `rebind` body-only un-fixed (binding/queue fixed) → **only** `rebind_failed_reconcile_reports_error_5621` fails.
- [x] Full cargo suite: **4027 passed, 0 failed, 2 ignored** (`cargo test --release --bin xpf-userspace-dp`).

## Smoke assessment

No smoke run. This is a control-socket handler status/error-reporting change on the **local** reconcile path — it does not touch the packet forwarding fast path, HA/session-sync, VRRP, or failover. The success path (clean reconcile → `ok=true`, persist, worker bring-up) is byte-unchanged; only the previously-swallowed `Err` now sets `ok=false` and skips persist. No dataplane/throughput behavior changes.

## Docs

- `userspace-dp/src/server/README.md` and `docs/userspace-dataplane-architecture.md` updated to record that binding/queue/rebind now surface the reconcile error.

## Refs

- Closes #5621
- Distinct from #5143 (apply_snapshot rejected-snapshot leg) and #3789 (the apply legs that already propagate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upk6ikSZswYx9cAj5HXCke