### PR TITLE
server: surface failed reconcile in set_forwarding_state (#6135)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -53435,3 +53435,21 @@ top.
   userspace-dp/src/server/tests.rs,
   userspace-dp/src/server/README.md,
   docs/userspace-dataplane-architecture.md
+
+- **Timestamp**: 2026-07-18
+- **Action**: #6135 — set_forwarding_state surfaces failed reconcile (4th
+  site of #5621, excluded from #6134). forwarding::set replaced
+  `let _ = reconcile_status_bindings(guard)` with the Err-fail-closed shape:
+  on Err → response.ok=false + "forwarding reconcile failed: {err}" +
+  refresh_status(guard) + return BEFORE wait_for_binding_settle /
+  persist_state=true. Success path unchanged. Added fail-on-revert test
+  `set_forwarding_state_failed_reconcile_reports_error_6135` (armed +
+  /33-unparseable snapshot → armed reconcile arm returns Err → ok=false).
+  Firsthand full suite: 4028 passed / 0 failed / 2 ignored. Parent-RED:
+  revert-to-discard → exactly 1 fail (the new test, tests.rs:1883,
+  assert !response.ok), 0 collateral. NOT HA/session-sync — local
+  control-socket reconcile; no smoke.
+- **File(s)**: userspace-dp/src/server/handlers/forwarding.rs,
+  userspace-dp/src/server/tests.rs,
+  userspace-dp/src/server/README.md,
+  docs/userspace-dataplane-architecture.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -324,15 +324,17 @@ new config), so there is no rejected snapshot to un-persist. But
 `reconcile_status_bindings` can still return `Err` even for an accepted
 snapshot — the mandatory-pin preflight can fault, or the forwarding build
 can hit a non-policy integrity error. #5621 stops `set_binding_state`,
-`set_queue_state`, and `rebind` from **discarding** that `Err`: on failure
-they report `ok=false` + the surfaced error, refresh status, and do NOT
-`persist_state`, so the control-socket caller no longer mistakes a failed
-(re)bind for success (previously the `let _ = reconcile_status_bindings(..)`
-discard acked `ok=true` regardless). `rebind::handle` gained a `response`
-parameter to carry the error. `set_forwarding_state` still discards the
-outcome (its arm/disarm reconcile takes the disarmed `Ok` path on disarm and
-surfaces a build reject via each binding's `last_error` on arm) — bringing
-it into the same fail-surfacing shape is a scoped follow-up.
+`set_queue_state`, and `rebind` (#6134) — plus `set_forwarding_state`
+(#6135, the 4th site #5621 had excluded) — from **discarding** that `Err`:
+on failure they report `ok=false` + "`<site> reconcile failed: {err}`",
+refresh status, and return BEFORE `wait_for_binding_settle` /
+`persist_state=true`, so the control-socket caller no longer mistakes a
+failed (re)bind / forwarding reconcile for success (previously the
+`let _ = reconcile_status_bindings(..)` discard acked `ok=true` regardless).
+`rebind::handle` gained a `response` parameter to carry the error;
+`set_forwarding_state`'s `set` already had one. Note the arm=false (disarm)
+path still succeeds — `reconcile_status_bindings` takes the disarmed `Ok`
+teardown arm — so only an arm reconcile can surface an `Err` here.
 
 Regression coverage: `coordinator/tests.rs`
 (`reconcile_build_failure_returns_integrity_err_and_keeps_prior_generation_3789`,
@@ -350,9 +352,10 @@ missing-pin abort fails closed. The #5621 sibling-handler coverage lives in
 `server/tests.rs`
 (`set_binding_state_failed_reconcile_reports_error_5621`,
 `set_queue_state_failed_reconcile_reports_error_5621`,
-`rebind_failed_reconcile_reports_error_5621` — each faults the reconcile
-with a stored `/33`-address snapshot and pins `ok=false`; reverting the
-matching handler to `let _ = reconcile_status_bindings(..)` flips exactly
+`rebind_failed_reconcile_reports_error_5621`, and
+`set_forwarding_state_failed_reconcile_reports_error_6135` — each faults the
+reconcile with a stored `/33`-address snapshot and pins `ok=false`; reverting
+the matching handler to `let _ = reconcile_status_bindings(..)` flips exactly
 its assertion RED).
 
 #### Per-Packet Processing Pipeline

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -193,11 +193,12 @@ queues. See PR #1243's kill record for why i40e doesn't reshape.
   / forwarding-state change, not a new config, so there is no rejected
   snapshot to un-persist — but the reconcile can still fault (mandatory-pin
   preflight / forwarding-build integrity error). #5621: `set_binding_state`,
-  `set_queue_state`, and `rebind` now SURFACE that `Err` (report `ok=false` +
-  the error, refresh status, do NOT `persist_state`) instead of the old
+  `set_queue_state`, and `rebind` (#6134) — and `set_forwarding_state`
+  (#6135, the 4th site #5621 had excluded) — now SURFACE that `Err` (report
+  `ok=false` + "`<site> reconcile failed: {err}`", refresh status, and return
+  BEFORE `wait_for_binding_settle` / `persist_state=true`) instead of the old
   `let _ = reconcile_status_bindings(..)` discard that acked `ok=true` after a
-  failed (re)bind; `rebind::handle` took a `response` parameter for this.
-  `set_forwarding_state` still discards the outcome (scoped follow-up). When
+  failed (re)bind; `rebind::handle` took a `response` parameter for this. When
   `should_run_afxdp` does NOT hold (forwarding disarmed / unsupported) it
   `stop()`s every worker and then routes the per-binding status through
   `refresh_bindings` — which sends each now-workerless slot through

--- a/userspace-dp/src/server/handlers/forwarding.rs
+++ b/userspace-dp/src/server/handlers/forwarding.rs
@@ -32,11 +32,24 @@ pub(super) fn set(
     guard.status.forwarding_armed = forwarding_req.armed;
     set_bindings_forwarding_armed(&mut guard.status, forwarding_req.armed);
     // #3789: arming/disarming reconciles the ALREADY-ACCEPTED stored
-    // snapshot (a forwarding-state toggle, not a new config). A build
-    // reject here would surface via the per-binding last_error, and there
-    // is no newly-supplied snapshot to reject — discard the outcome
-    // explicitly.
-    let _ = reconcile_status_bindings(guard);
+    // snapshot (a forwarding-state toggle, not a new config), so a build
+    // reject cannot introduce a rejected snapshot here.
+    //
+    // #6135 (4th site of #5621): the reconcile itself can still FAIL — the
+    // mandatory-pin preflight can fault, or the forwarding build can hit a
+    // non-policy integrity error on the already-accepted snapshot. Discarding
+    // that Err made this handler ack ok=true while the AF_XDP sockets were NOT
+    // actually reconciled to the new forwarding state, so the control-socket
+    // caller believed the reconcile succeeded when it did not. Surface the
+    // failure: report ok=false + the error, refresh status so `show` reflects
+    // the real per-binding state, and do NOT persist a success we didn't
+    // achieve (return BEFORE wait_for_binding_settle / persist_state=true).
+    if let Err(err) = reconcile_status_bindings(guard) {
+        response.ok = false;
+        response.error = format!("forwarding reconcile failed: {err}");
+        refresh_status(guard);
+        return;
+    }
     if forwarding_req.armed {
         wait_for_binding_settle(guard, Duration::from_secs(2));
     }

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1860,6 +1860,38 @@ fn rebind_failed_reconcile_reports_error_5621() {
 }
 
 #[test]
+fn set_forwarding_state_failed_reconcile_reports_error_6135() {
+    // #6135 (the 4th site of #5621, excluded from the #6134 fix): the
+    // set_forwarding_state handler used to `let _ =
+    // reconcile_status_bindings(guard)`, acking ok=true even when the reconcile
+    // of the ALREADY-ACCEPTED snapshot FAILED (a mandatory-pin preflight fault
+    // or a forwarding-build integrity error). Arm forwarding on a registered
+    // binding so the handler keeps forwarding_armed=true; the stored bad
+    // snapshot (unparseable /33 interface address) makes
+    // reconcile_status_bindings take the armed arm and return Err. Reverting
+    // the matching site to `let _ = reconcile_status_bindings(...)` restores
+    // ok=true and flips this assertion RED (target-count 1).
+    let state = armed_state_with_failing_reconcile(vec![BindingStatus {
+        slot: 0,
+        registered: true,
+        ifindex: 10,
+        ..BindingStatus::default()
+    }]);
+    let mut request = req("set_forwarding_state");
+    request.forwarding = Some(ForwardingControlRequest { armed: true });
+    let response = run_request(state, request);
+    assert!(
+        !response.ok,
+        "#6135: set_forwarding_state must report ok=false when the reconcile fails"
+    );
+    assert!(
+        response.error.contains("forwarding reconcile failed"),
+        "unexpected error: {}",
+        response.error
+    );
+}
+
+#[test]
 fn stop_workers_clears_socket_fields_on_all_bindings() {
     // stop_workers must tear down per-binding socket state so the
     // subsequent rebind recreates fresh AF_XDP sockets.


### PR DESCRIPTION
## Summary

- `set_forwarding_state` (`userspace-dp/src/server/handlers/forwarding.rs`) was the **4th and final site** of the #5621 defect. #6134 fixed the other three (`set_binding_state`, `set_queue_state`, `rebind`); #5621 explicitly excluded this one, tracked as #6135.
- The handler ran `let _ = reconcile_status_bindings(guard);`, **discarding the `Result`**. When the reconcile of the ALREADY-accepted stored snapshot FAILED (mandatory-pin preflight fault, or a forwarding-build integrity error hit on arm), the handler still acked `ok=true` — so the control-socket caller believed forwarding was reconciled to the new armed/disarmed state when it was not.
- Fix mirrors #6134 **exactly**: on `Err` → `response.ok=false` + `"forwarding reconcile failed: {err}"` + `refresh_status(guard)` + `return` **BEFORE** `wait_for_binding_settle` / `persist_state=true`. The success path (clean reconcile → `ok=true` + settle + persist) is unchanged.
- `reconcile_status_bindings`' own two-arm behavior is untouched; the disarm path still takes the infallible teardown `Ok` arm, so only an **arm** reconcile can surface an `Err` here. `forwarding::set` already carried the `response: &mut ControlResponse` parameter, so **no dispatcher change** was needed (unlike `rebind` in #6134).
- Module docs that enumerated the sites (`userspace-dp/src/server/README.md`, `docs/userspace-dataplane-architecture.md`) said `set_forwarding_state` "still discards the outcome (scoped follow-up)" — now recorded as fixed under #6135, with the new test added to the coverage list.

## Test plan

- [x] Added fail-on-revert test `set_forwarding_state_failed_reconcile_reports_error_6135` (modeled on #6134's `set_binding_state_failed_reconcile_reports_error_5621`): armed + forwarding-supported state carrying the #3789 `/33`-unparseable-`IpNet` snapshot drives `set_forwarding_state` with `armed=true` → `reconcile_status_bindings` takes the armed arm → `afxdp.reconcile` returns `Err`. Pins `ok=false` + `"forwarding reconcile failed"`.
- [x] **Parent-RED (target-count 1):** reverting the site to `let _ = reconcile_status_bindings(..)` fails **exactly 1** test — `set_forwarding_state_failed_reconcile_reports_error_6135` panics at `tests.rs:1883` (`assert!(!response.ok)`); **0 collateral**. Restoring the fix returns the suite to green.
- [x] Firsthand full suite: `cargo test --release --bin xpf-userspace-dp` → **4028 passed / 0 failed / 2 ignored**.
- [x] **NOT** an HA / session-sync / fabric change (local control-socket reconcile propagation), so **no cluster smoke required** per the engineering-style validation matrix.

## Refs

- Closes #6135
- Mirrors #6134 (merged) — the binding/queue/rebind sites of #5621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ha9zpUVVRSgcF3ayT1RWtw