### PR TITLE
scheduler: bound the republish fail-open window with a fail-closed escalation (#5669)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-07-18 — #6137 fold: scheduler fail-closed honest docs + gauge SSOT wiring + gauge test (#5669)
+
+- **Timestamp**: 2026-07-18 (fix/5669-scheduler-failopen-bound)
+- **Action**: Folded 4 review findings into the #5669 scheduler bounded-age
+  fail-closed PR. (1) Doc honesty: the forced-inactive snapshot is published
+  through the SAME failing updateFn channel that defines the streak, so in a
+  persistently-wedged dataplane it never reaches the helper and the stale
+  scheduled PERMIT keeps forwarding until the socket recovers. Softened
+  pkg/scheduler/README.md "Bounded-age fail-closed" + the
+  scheduler_failclosed_5669_test.go comments so they match the code's own
+  slog.Warn: the mechanism BOUNDS the SILENT fail-open window with (a) a
+  one-time loud alarm, (b) the 0/1 gauge, (c) authoritative + surface deny
+  consistency, (d) deny-lands-first on recovery — it does NOT itself stop
+  packets in a wedged dataplane. (2) Metric SSOT: `d.scheduler` is now an
+  `atomic.Pointer[scheduler.Scheduler]` and `SchedulerRepublishFailClosed`
+  reads the scheduler's OWN latch (`RepublishFailClosed`) instead of a second
+  daemon-side age timer (`schedulerRepublishFirstFailNanos`), so the gauge ==
+  the force-inactive/alarm latch EXACTLY (no ~1-tick sub-tick lead). The
+  atomic makes the metrics-collector's lock-free pointer read race-clean
+  without blocking scrapes behind applySem; RepublishFailClosed takes only the
+  scheduler's own RLock. All reconcile mutations stay under applySem. (3)
+  Gauge test: added `TestSchedulerRepublishFailClosedGaugeReadsSSOTLatch_5669`
+  (pkg/daemon) — drives the daemon timer and scheduler latch into disagreement
+  (timer hot, latch cold) and asserts the gauge follows the latch, plus
+  nil-safety; it RED-fails the retired timer accessor and stays GREEN on the
+  scheduler-latch revert (so it does NOT inflate the fail-on-revert
+  target-count). The "reads 1 at the bound" transition remains pinned by the
+  existing `TestScheduler_RepublishFailClosedAfterBoundedAge` (which asserts
+  `RepublishFailClosed()`, now the gauge source). (4) By-design note in the
+  README: a scheduler config-set hash change tears down + re-primes the
+  scheduler (fresh streak/clock), so repeated edits while wedged can restart
+  the 5 min bound. Parent-RED re-verified: reverting the latch block →
+  target-count 1 (only TestScheduler_RepublishFailClosedAfterBoundedAge RED),
+  control green, daemon gauge test green. `go test -race
+  ./pkg/scheduler/... ./pkg/api/... ./pkg/daemon/...` green; gofmt + vet clean;
+  named scheduler + daemon gauge tests 3x no flake.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_scheduler.go,
+  pkg/daemon/daemon_ipmon.go, pkg/daemon/daemon_scheduler_test.go,
+  pkg/daemon/daemon_goroutine_shutdown_5308_test.go,
+  pkg/daemon/policy_scheduler_apply_test.go,
+  pkg/daemon/daemon_scheduler_failclosed_5669_test.go,
+  pkg/scheduler/README.md, pkg/scheduler/scheduler_failclosed_5669_test.go
+
 ## 2026-07-18 — #5568 (security): SCALAR L4/fragment classifier bounded to IP-declared datagram end
 
 - **Timestamp**: 2026-07-18 (fix/5568-scalar-l4-declared-bound)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -193,6 +193,12 @@ type xpfCollector struct {
 	// failure streak in seconds (0 when healthy).
 	schedulerRepublishFailed *prometheus.Desc
 	schedulerRepublishStale  *prometheus.Desc
+	// #5669: 0/1 gauge — 1 while the scheduler-republish failure streak has
+	// persisted past the bounded age and the scheduler has escalated to
+	// fail-closed (forcing scheduled policies inactive/deny), distinct from the
+	// climbing stale-seconds age so an operator can alarm on the crisp
+	// fail-closed crossing.
+	schedulerRepublishFailClosed *prometheus.Desc
 
 	// #1799: 0/1 gauge — 1 while the running active config failed to
 	// persist to disk and the configstore's background retry has not
@@ -682,6 +688,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.ipsecRebindPending
 	ch <- c.schedulerRepublishFailed
 	ch <- c.schedulerRepublishStale
+	ch <- c.schedulerRepublishFailClosed
 	ch <- c.configPersistDegraded
 	ch <- c.rollbackHistoryDegraded
 	ch <- c.userspacePolicyContentRejected
@@ -992,6 +999,14 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	if c.srv.schedulerRepublishStaleSecondsFn != nil {
 		ch <- prometheus.MustNewConstMetric(c.schedulerRepublishStale,
 			prometheus.GaugeValue, c.srv.schedulerRepublishStaleSecondsFn())
+	}
+	if c.srv.schedulerRepublishFailClosedFn != nil {
+		v := 0.0
+		if c.srv.schedulerRepublishFailClosedFn() {
+			v = 1
+		}
+		ch <- prometheus.MustNewConstMetric(c.schedulerRepublishFailClosed,
+			prometheus.GaugeValue, v)
 	}
 
 	// #2050: dynamic-address feed staleness is a control-plane signal (the

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -611,6 +611,17 @@ func newCollector(srv *Server) *xpfCollector {
 				"for that long while the daemon retries.",
 			nil, nil,
 		),
+		schedulerRepublishFailClosed: prometheus.NewDesc(
+			"xpf_scheduler_republish_fail_closed",
+			"1 while the scheduler-republish failure streak has persisted past "+
+				"the bounded age and the scheduler has escalated to FAIL-CLOSED "+
+				"(#5669): scheduled policies are forced inactive (deny) so a "+
+				"scheduled permit stops forwarding past its window close instead "+
+				"of relying on an eventual republish recovery. 0 when healthy or "+
+				"still inside the bounded retry window (xpf_scheduler_republish_"+
+				"failed=1, xpf_scheduler_republish_stale_seconds climbing).",
+			nil, nil,
+		),
 		configPersistDegraded: prometheus.NewDesc(
 			"xpf_daemon_config_persist_degraded",
 			"1 while the running active configuration failed to persist "+

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -204,6 +204,13 @@ type Config struct {
 	// xpf_scheduler_republish_stale_seconds gauge. Optional; if nil, the
 	// gauge is not emitted.
 	SchedulerRepublishStaleSecondsFn func() float64
+	// SchedulerRepublishFailClosedFn reports whether the scheduler-republish
+	// failure streak has persisted past the bounded age and the scheduler has
+	// escalated to fail-closed — forcing scheduled policies inactive (deny) so
+	// a permit stops forwarding past its window close (#5669). Backs the
+	// xpf_scheduler_republish_fail_closed gauge (0/1, no labels). Optional; if
+	// nil, the gauge is not emitted.
+	SchedulerRepublishFailClosedFn func() bool
 	// FeedsFn surfaces live dynamic-address feed status for the
 	// xpf_feed_seconds_since_last_success / xpf_feed_stale gauges (#2050).
 	// A feed that has never fetched successfully, or whose last-good
@@ -326,6 +333,7 @@ type Server struct {
 	ipsecRebindPendingFn             func() bool
 	schedulerRepublishFailedFn       func() bool
 	schedulerRepublishStaleSecondsFn func() float64
+	schedulerRepublishFailClosedFn   func() bool
 	ipmonStatusFn                    func() []ipmon.PolicyStatus
 	ipmonActuationFailuresFn         func() uint64
 	eventActionStatsFn               func() eventengine.Stats
@@ -411,6 +419,7 @@ func NewServer(cfg Config) *Server {
 		ipsecRebindPendingFn:             cfg.IPsecRebindPendingFn,
 		schedulerRepublishFailedFn:       cfg.SchedulerRepublishFailedFn,
 		schedulerRepublishStaleSecondsFn: cfg.SchedulerRepublishStaleSecondsFn,
+		schedulerRepublishFailClosedFn:   cfg.SchedulerRepublishFailClosedFn,
 		ipmonStatusFn:                    cfg.IPMonStatusFn,
 		ipmonActuationFailuresFn:         cfg.IPMonActuationFailuresFn,
 		eventActionStatsFn:               cfg.EventActionStatsFn,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -312,8 +312,15 @@ type Daemon struct {
 	lldpMgr          *lldp.Manager
 	lldpApplied      *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
 	lldpApplyInit    bool             // true once reconcileLLDP has run at least once
-	scheduler        *scheduler.Scheduler
-	schedulerCancel  context.CancelFunc
+	// scheduler is the live policy-window scheduler. It is an atomic.Pointer so
+	// the metrics collector can read it lock-free for the
+	// xpf_scheduler_republish_fail_closed SSOT gauge
+	// (SchedulerRepublishFailClosed → scheduler.RepublishFailClosed) while a
+	// commit-time reconcile swaps it under applySem. All mutations still happen
+	// under applySem (the "Locked" reconcile convention); the atomic only makes
+	// the concurrent lock-free read of the pointer word race-clean (#5669).
+	scheduler       atomic.Pointer[scheduler.Scheduler]
+	schedulerCancel context.CancelFunc
 	// schedulerWg tracks every policy-scheduler Run() goroutine generation so
 	// daemon shutdown can join it after cancelling, and schedulerStopped
 	// latches on shutdown so no new generation is started after the join

--- a/pkg/daemon/daemon_goroutine_shutdown_5308_test.go
+++ b/pkg/daemon/daemon_goroutine_shutdown_5308_test.go
@@ -156,10 +156,10 @@ func TestStopPolicySchedulerLoopCancelsJoins(t *testing.T) {
 	}, func(map[string]bool) error { return nil }, time.Now())
 
 	d := &Daemon{
-		scheduler: sched,
 		applySem:  semaphore.NewWeighted(1),
 		daemonCtx: context.Background(), // production: never cancelled
 	}
+	d.scheduler.Store(sched)
 	d.startPolicySchedulerLoopLocked()
 	if d.schedulerCancel == nil {
 		t.Fatal("scheduler loop did not start")

--- a/pkg/daemon/daemon_ipmon.go
+++ b/pkg/daemon/daemon_ipmon.go
@@ -308,8 +308,8 @@ func (d *Daemon) actuateRouteOverlayLocked(cfg *config.Config) bool {
 		return true
 	}
 	var schedulerState map[string]bool
-	if d.scheduler != nil {
-		schedulerState = d.scheduler.ActiveState()
+	if sched := d.scheduler.Load(); sched != nil {
+		schedulerState = sched.ActiveState()
 	}
 	published, err := pub.PublishRouteOverlaySnapshot(cfg, overlay, schedulerState)
 	if err != nil {

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1443,6 +1443,12 @@ func (d *Daemon) startHTTPServer(ctx context.Context, wg *sync.WaitGroup, eventB
 		// monitoring.
 		SchedulerRepublishFailedFn:       d.SchedulerRepublishFailed,
 		SchedulerRepublishStaleSecondsFn: d.SchedulerRepublishStaleSeconds,
+		// #5669: surface the bounded-age fail-closed escalation so
+		// xpf_scheduler_republish_fail_closed reads 1 once a persistently
+		// failing republish has crossed the bounded age and the scheduler has
+		// forced scheduled policies inactive (deny) — a crisp alarm distinct
+		// from the climbing stale-seconds age.
+		SchedulerRepublishFailClosedFn: d.SchedulerRepublishFailClosed,
 		// #1827: ip-monitoring policy state for the xpf_ipmon_*
 		// metric family.
 		IPMonStatusFn: func() []ipmon.PolicyStatus {

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -297,3 +297,24 @@ func (d *Daemon) SchedulerRepublishStaleSeconds() float64 {
 	}
 	return time.Duration(age).Seconds()
 }
+
+// SchedulerRepublishFailClosed reports whether the current scheduler-republish
+// failure streak has persisted past scheduler.RepublishFailClosedAge, at which
+// point the scheduler escalates from the #3780 silent retry to FAIL-CLOSED:
+// it forces scheduled policies to the inactive (deny) disposition and emits a
+// one-time alarm so a scheduled permit stops forwarding past its window close
+// instead of relying on an eventual republish recovery (#5669). Computed from
+// the same failure-streak start the stale-seconds gauge uses and the single
+// shared bound, so the alarm and the scheduler's own latch agree. Lock-free;
+// safe for the metrics collector goroutine.
+func (d *Daemon) SchedulerRepublishFailClosed() bool {
+	if !d.schedulerRepublishFailing.Load() {
+		return false
+	}
+	first := d.schedulerRepublishFirstFailNanos.Load()
+	if first == 0 {
+		return false
+	}
+	age := time.Now().UnixNano() - first
+	return age >= int64(scheduler.RepublishFailClosedAge)
+}

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -28,16 +28,16 @@ func (d *Daemon) reconcilePolicySchedulerLocked(cfg *config.Config) map[string]b
 
 func (d *Daemon) reconcilePolicySchedulerLockedAt(cfg *config.Config, now time.Time) map[string]bool {
 	hash, hasSchedulers := policySchedulerConfigHash(cfg)
-	if hasSchedulers && d.scheduler != nil && hash == d.policySchedulerConfigHash {
+	if sched := d.scheduler.Load(); hasSchedulers && sched != nil && hash == d.policySchedulerConfigHash {
 		d.startPolicySchedulerLoopLocked()
-		return d.scheduler.ActiveState()
+		return sched.ActiveState()
 	}
 
 	if d.schedulerCancel != nil {
 		d.schedulerCancel()
 		d.schedulerCancel = nil
 	}
-	d.scheduler = nil
+	d.scheduler.Store(nil)
 	// #3780: the scheduler set is being removed or replaced. Clear any
 	// stale republish-failure metric from the outgoing scheduler; a new
 	// scheduler's initial state is published by the fallible apply path,
@@ -53,7 +53,7 @@ func (d *Daemon) reconcilePolicySchedulerLockedAt(cfg *config.Config, now time.T
 	sched, activeState := scheduler.NewPrimed(cfg.Schedulers, func(activeState map[string]bool) error {
 		return d.publishPolicyScheduleState(epoch, activeState)
 	}, now)
-	d.scheduler = sched
+	d.scheduler.Store(sched)
 	d.policySchedulerConfigHash = hash
 	d.startPolicySchedulerLoopLocked()
 	return activeState
@@ -64,8 +64,8 @@ func (d *Daemon) policySchedulerActiveStateForApplyLocked(cfg *config.Config, no
 	if !hasSchedulers {
 		return nil
 	}
-	if d.scheduler != nil && hash == d.policySchedulerConfigHash {
-		return d.scheduler.ActiveState()
+	if sched := d.scheduler.Load(); sched != nil && hash == d.policySchedulerConfigHash {
+		return sched.ActiveState()
 	}
 	_, activeState := scheduler.NewPrimed(cfg.Schedulers, func(map[string]bool) error { return nil }, now)
 	return activeState
@@ -141,15 +141,15 @@ func (d *Daemon) startPolicySchedulerLoopLocked() {
 	// schedulerStopped latches at shutdown (stopPolicySchedulerLoop): once the
 	// loop has been cancelled + joined, a late reconcile must NOT start a new
 	// generation — that Add would race the shutdown's schedulerWg.Wait (#5308).
-	if d.schedulerStopped || d.daemonCtx == nil || d.scheduler == nil || d.schedulerCancel != nil {
+	// Capture the scheduler pointer at start time (a config-replace reconcile
+	// may reassign d.scheduler) and track the goroutine on schedulerWg so
+	// shutdown can join every generation after cancelling.
+	sched := d.scheduler.Load()
+	if d.schedulerStopped || d.daemonCtx == nil || sched == nil || d.schedulerCancel != nil {
 		return
 	}
 	ctx, cancel := context.WithCancel(d.daemonCtx)
 	d.schedulerCancel = cancel
-	// Capture the scheduler pointer at start time (a config-replace reconcile
-	// may reassign d.scheduler) and track the goroutine on schedulerWg so
-	// shutdown can join every generation after cancelling.
-	sched := d.scheduler
 	d.schedulerWg.Add(1)
 	go func() {
 		defer d.schedulerWg.Done()
@@ -298,23 +298,26 @@ func (d *Daemon) SchedulerRepublishStaleSeconds() float64 {
 	return time.Duration(age).Seconds()
 }
 
-// SchedulerRepublishFailClosed reports whether the current scheduler-republish
-// failure streak has persisted past scheduler.RepublishFailClosedAge, at which
-// point the scheduler escalates from the #3780 silent retry to FAIL-CLOSED:
-// it forces scheduled policies to the inactive (deny) disposition and emits a
-// one-time alarm so a scheduled permit stops forwarding past its window close
-// instead of relying on an eventual republish recovery (#5669). Computed from
-// the same failure-streak start the stale-seconds gauge uses and the single
-// shared bound, so the alarm and the scheduler's own latch agree. Lock-free;
-// safe for the metrics collector goroutine.
+// SchedulerRepublishFailClosed reports whether the scheduler has escalated from
+// the #3780 silent retry to FAIL-CLOSED: once a scheduler-republish failure
+// streak persists past scheduler.RepublishFailClosedAge the scheduler forces
+// scheduled policies to the inactive (deny) disposition and emits a one-time
+// alarm so a scheduled permit stops (re)opening while the dataplane cannot
+// enforce the schedule (#5669).
+//
+// This reads the scheduler's OWN latch (RepublishFailClosed) rather than
+// recomputing the age daemon-side, so the xpf_scheduler_republish_fail_closed
+// gauge is the single source of truth with the scheduler's force-inactive/alarm
+// decision — no second continuous-time timer that could read 1 up to one 60 s
+// tick before the scheduler actually latches. Lock-free at the daemon level:
+// d.scheduler is an atomic.Pointer, and RepublishFailClosed takes only the
+// scheduler's own RLock (never applySem), so the metrics collector never blocks
+// behind a long apply or a wedged republish. Returns false when no scheduler is
+// installed (nil pointer).
 func (d *Daemon) SchedulerRepublishFailClosed() bool {
-	if !d.schedulerRepublishFailing.Load() {
+	sched := d.scheduler.Load()
+	if sched == nil {
 		return false
 	}
-	first := d.schedulerRepublishFirstFailNanos.Load()
-	if first == 0 {
-		return false
-	}
-	age := time.Now().UnixNano() - first
-	return age >= int64(scheduler.RepublishFailClosedAge)
+	return sched.RepublishFailClosed()
 }

--- a/pkg/daemon/daemon_scheduler_failclosed_5669_test.go
+++ b/pkg/daemon/daemon_scheduler_failclosed_5669_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/scheduler"
+)
+
+// TestSchedulerRepublishFailClosedGaugeReadsSSOTLatch_5669 pins the #6137 review
+// fold (finding 2): the daemon's xpf_scheduler_republish_fail_closed gauge
+// (SchedulerRepublishFailClosed) reads the scheduler's OWN latch
+// (scheduler.RepublishFailClosed) — the single source of truth that also drives
+// the force-inactive/one-time-alarm decision — and NOT the daemon-side
+// schedulerRepublishFirstFailNanos timer that previously recomputed the age
+// independently (a second, continuous-time clock that could read 1 up to one
+// 60 s tick before the scheduler actually latched).
+//
+// RED-on-revert: the pre-fold accessor returned
+// (schedulerRepublishFailing && now-firstFail >= RepublishFailClosedAge). This
+// test drives the daemon timer and the scheduler latch into DISAGREEMENT — the
+// daemon timer is hot (failing since well past the bound) while the scheduler
+// latch is NOT set — and asserts the gauge follows the latch (false). The
+// retired timer-based implementation reads true here and fails the test.
+func TestSchedulerRepublishFailClosedGaugeReadsSSOTLatch_5669(t *testing.T) {
+	// Nil-safe: a daemon with no scheduler installed is not fail-closed.
+	d := &Daemon{}
+	if d.SchedulerRepublishFailClosed() {
+		t.Fatal("a daemon with no scheduler must not report fail-closed")
+	}
+
+	// Install a healthy scheduler whose latch is NOT fail-closed.
+	sched, _ := scheduler.NewPrimed(map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours", StartTime: "09:00:00", StopTime: "17:00:00"},
+	}, func(map[string]bool) error { return nil }, time.Now())
+	d.scheduler.Store(sched)
+	if sched.RepublishFailClosed() {
+		t.Fatal("precondition: a freshly-primed healthy scheduler must not be fail-closed")
+	}
+	if d.SchedulerRepublishFailClosed() {
+		t.Fatal("gauge must be 0 while the scheduler latch is clear")
+	}
+
+	// Force the OLD daemon-side timer state to "past the bound": failing since
+	// well over RepublishFailClosedAge ago. The retired implementation computed
+	// fail-closed from exactly these two fields and would return true now.
+	d.schedulerRepublishFailing.Store(true)
+	d.schedulerRepublishFirstFailNanos.Store(
+		time.Now().Add(-2 * scheduler.RepublishFailClosedAge).UnixNano())
+
+	// SSOT wiring: the gauge must follow the scheduler's fail-closed latch
+	// (still false), NOT the daemon timer (now hot). This is the finding-2
+	// regression guard — it fails on the retired age-recompute accessor.
+	if d.SchedulerRepublishFailClosed() {
+		t.Fatal("gauge must read the scheduler's fail-closed latch (false here), not the daemon-side age timer")
+	}
+
+	// Sanity: the retired daemon-side timer state IS hot, proving the
+	// disagreement above is real and the gauge deliberately ignored it.
+	if !d.SchedulerRepublishFailed() {
+		t.Fatal("precondition: the daemon-side republish-failing timer must be hot for this disagreement test")
+	}
+	if got := d.SchedulerRepublishStaleSeconds(); got < scheduler.RepublishFailClosedAge.Seconds() {
+		t.Fatalf("precondition: stale-seconds = %v, want >= bound %v (timer past the bound)",
+			got, scheduler.RepublishFailClosedAge.Seconds())
+	}
+
+	// A nil scheduler with the timer still hot is also not fail-closed (the
+	// gauge is scheduler-latch driven, so tearing down the scheduler drops the
+	// gauge regardless of the stale timer atomics).
+	d.scheduler.Store(nil)
+	if d.SchedulerRepublishFailClosed() {
+		t.Fatal("gauge must be 0 once the scheduler is torn down, even with a stale daemon timer")
+	}
+}

--- a/pkg/daemon/daemon_scheduler_test.go
+++ b/pkg/daemon/daemon_scheduler_test.go
@@ -15,7 +15,8 @@ func TestStartPolicySchedulerLoopLockedWaitsForDaemonContext(t *testing.T) {
 		"always": {Name: "always"},
 	}, func(map[string]bool) error { return nil }, time.Now())
 
-	d := &Daemon{scheduler: sched}
+	d := &Daemon{}
+	d.scheduler.Store(sched)
 	d.startPolicySchedulerLoopLocked()
 	if d.schedulerCancel != nil {
 		t.Fatal("scheduler loop started before daemon context was available")
@@ -40,10 +41,10 @@ func TestReconcilePolicySchedulerLockedKeepsByteIdenticalScheduler(t *testing.T)
 	d := &Daemon{}
 
 	first := d.reconcilePolicySchedulerLocked(cfg)
-	if d.scheduler == nil {
+	if d.scheduler.Load() == nil {
 		t.Fatal("scheduler was not created")
 	}
-	sched := d.scheduler
+	sched := d.scheduler.Load()
 	epoch := d.policySchedulerEpoch.Load()
 
 	second := d.reconcilePolicySchedulerLocked(&config.Config{
@@ -51,7 +52,7 @@ func TestReconcilePolicySchedulerLockedKeepsByteIdenticalScheduler(t *testing.T)
 			"always": {Name: "always"},
 		},
 	})
-	if d.scheduler != sched {
+	if d.scheduler.Load() != sched {
 		t.Fatal("byte-identical scheduler config recreated the scheduler")
 	}
 	if got := d.policySchedulerEpoch.Load(); got != epoch {

--- a/pkg/daemon/policy_scheduler_apply_test.go
+++ b/pkg/daemon/policy_scheduler_apply_test.go
@@ -229,9 +229,9 @@ func TestApplyConfigProtocolAbortPreservesExistingScheduler(t *testing.T) {
 	}
 	d := &Daemon{
 		dp:                        dp,
-		scheduler:                 oldScheduler,
 		policySchedulerConfigHash: oldHash,
 	}
+	d.scheduler.Store(oldScheduler)
 	d.policySchedulerEpoch.Store(42)
 	newCfg := &config.Config{
 		Schedulers: map[string]*config.SchedulerConfig{
@@ -242,7 +242,7 @@ func TestApplyConfigProtocolAbortPreservesExistingScheduler(t *testing.T) {
 	if err := d.applyConfigLocked(context.Background(), newCfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
 		t.Fatalf("applyConfigLocked error = %v, want protocol incompatibility", err)
 	}
-	if d.scheduler != oldScheduler {
+	if d.scheduler.Load() != oldScheduler {
 		t.Fatal("protocol abort replaced scheduler before apply completed")
 	}
 	if got := d.policySchedulerEpoch.Load(); got != 42 {
@@ -251,7 +251,7 @@ func TestApplyConfigProtocolAbortPreservesExistingScheduler(t *testing.T) {
 	if d.policySchedulerConfigHash != oldHash {
 		t.Fatal("protocol abort changed scheduler config hash")
 	}
-	if got := d.scheduler.ActiveState()["old"]; got != oldState["old"] {
+	if got := d.scheduler.Load().ActiveState()["old"]; got != oldState["old"] {
 		t.Fatalf("old scheduler active state = %t, want %t", got, oldState["old"])
 	}
 }

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -25,6 +25,11 @@ during specific windows.
 - `RepublishPending() bool` / `RepublishFailureStatus() (pending bool,
   failures uint64, since time.Time)` — `scheduler.go`. Expose the #3780
   self-heal state for tests and metrics.
+- `RepublishFailClosed() bool` — `scheduler.go`. True once a republish has
+  been failing past `RepublishFailClosedAge` and the scheduler has
+  escalated to fail-closed (forces scheduled policies inactive/deny +
+  one-time alarm, #5669). Feeds the `xpf_scheduler_republish_fail_closed`
+  gauge.
 
 ## Time-window model (#3849)
 
@@ -125,6 +130,48 @@ plus `xpf_scheduler_republish_stale_seconds` (age of the current failure
 streak), and logs an `ERROR` on the transition into failure. See
 `pkg/daemon/daemon_scheduler.go` (`publishPolicyScheduleState`,
 `recordSchedulerRepublishResult`).
+
+## Bounded-age fail-closed (#5669)
+
+The #3780 self-heal retries a failed republish every tick, but a
+**persistently** failing republish — a wedged control socket (the shared
+helper control socket carries status poll, HA sync, session installs, and
+snapshot sync, per `CLAUDE.md`), an incompatible helper — leaves the stale
+window **fail-open** (a scheduled permit still forwarding past its close)
+for as long as the retry keeps failing, silently, with no operator signal
+beyond the climbing stale-seconds gauge.
+
+Once the failure streak exceeds `RepublishFailClosedAge` (5 min ≈ five
+60 s ticks — long enough to absorb transient control-socket contention
+without a false alarm, short enough to surface a genuinely stuck republish
+promptly), the scheduler latches `republishFailClosed` and:
+
+- emits a **one-time** `slog.Warn` fail-closed alarm (not per tick), and
+- forces **every scheduled policy to the `inactive` (deny) disposition**
+  in both the published and authoritative active-state map on the next
+  evaluation — so a scheduled permit **stops permitting** (and refuses to
+  reopen) instead of forwarding past its window while the dataplane cannot
+  enforce the schedule.
+
+The latch clears on the next **successful** republish, after which the
+true window state is republished and any legitimately-open permit reopens
+(no permanent false-deny). Because the latch engages **only** while a
+republish is failing — enforcement is already broken — it never
+force-denies a converged, genuinely-active window (those have
+`republishPending == false`). `RepublishFailClosed()` exposes the state;
+the daemon mirrors it as the `xpf_scheduler_republish_fail_closed` gauge
+(computed from the same failure-streak start and the single shared
+`RepublishFailClosedAge` bound, so the alarm and the scheduler latch
+agree).
+
+**Limitation (honest scope).** The fail-closed disposition is `inactive`
+(drop the scheduled rule → default-deny), which is the correct fail-closed
+for the dominant **scheduled-permit** case. A scheduled **block** whose
+engage-activation was never published is already un-engaged in the wedged
+dataplane; forcing it `inactive` matches that state but cannot *engage* a
+block, which requires a successful publish. Actively engaging a stuck
+block would need per-policy action awareness in the dataplane, out of this
+package's scope.
 
 ## Callers
 

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -147,31 +147,73 @@ without a false alarm, short enough to surface a genuinely stuck republish
 promptly), the scheduler latches `republishFailClosed` and:
 
 - emits a **one-time** `slog.Warn` fail-closed alarm (not per tick), and
-- forces **every scheduled policy to the `inactive` (deny) disposition**
-  in both the published and authoritative active-state map on the next
-  evaluation — so a scheduled permit **stops permitting** (and refuses to
-  reopen) instead of forwarding past its window while the dataplane cannot
-  enforce the schedule.
+- forces **every scheduled policy to the `inactive` (deny) disposition** in
+  the authoritative active-state map on the next evaluation, and tries to
+  publish that all-inactive snapshot.
 
-The latch clears on the next **successful** republish, after which the
-true window state is republished and any legitimately-open permit reopens
-(no permanent false-deny). Because the latch engages **only** while a
-republish is failing — enforcement is already broken — it never
-force-denies a converged, genuinely-active window (those have
-`republishPending == false`). `RepublishFailClosed()` exposes the state;
-the daemon mirrors it as the `xpf_scheduler_republish_fail_closed` gauge
-(computed from the same failure-streak start and the single shared
-`RepublishFailClosedAge` bound, so the alarm and the scheduler latch
-agree).
+**What this actually buys — and what it does NOT.** Be precise about the
+packet-path effect, because the honest scope is narrower than "force
+inactive ⇒ the permit stops forwarding":
 
-**Limitation (honest scope).** The fail-closed disposition is `inactive`
-(drop the scheduled rule → default-deny), which is the correct fail-closed
-for the dominant **scheduled-permit** case. A scheduled **block** whose
-engage-activation was never published is already un-engaged in the wedged
-dataplane; forcing it `inactive` matches that state but cannot *engage* a
-block, which requires a successful publish. Actively engaging a stuck
-block would need per-policy action awareness in the dataplane, out of this
-package's scope.
+The forced-inactive snapshot is published through **the same `updateFn`
+channel** (`Manager.UpdatePolicyScheduleState` → `apply_snapshot`) whose
+failures *define* the streak. In a **persistently-wedged** dataplane — the
+exact case that latches fail-closed — that publish also fails, so the
+all-inactive snapshot **does not reach the helper**: the stale scheduled
+**permit keeps forwarding** past its window close until the control socket
+recovers. The latch does **not** itself stop packets in a wedged dataplane.
+
+So the fail-closed escalation does not close the packet-path fail-open
+window; it **bounds the *silent* fail-open window** and converts it into a
+loud, observable, authoritative-deny posture. Concretely it delivers:
+
+- **(a) a one-time loud alarm** (`slog.Warn`, "FAIL-CLOSED") — the operator
+  is told enforcement is wedged instead of only seeing a climbing
+  stale-seconds gauge;
+- **(b) the `xpf_scheduler_republish_fail_closed` 0/1 gauge** for
+  monitoring/alerting;
+- **(c) authoritative + surface deny consistency** — `ActiveState()` /
+  `IsActive()` (and any `show`/policy-match surface reading them) report the
+  scheduled policies **inactive (deny)**, so the control-plane view matches
+  the intended fail-closed disposition rather than advertising an active
+  permit the dataplane cannot honor;
+- **(d) deny-lands-first on recovery** — when the republish recovers the
+  scheduler first publishes the all-inactive snapshot and clears the latch,
+  and only the **next** tick republishes the true (possibly reopened)
+  window. So the moment the socket unwedges, the helper receives *deny*
+  before it receives any reopened permit — the recovery cannot briefly
+  re-open a stale permit ahead of the correct state.
+
+The latch clears on the next **successful** republish, after which the true
+window state is republished and any legitimately-open permit reopens (no
+permanent false-deny). Because the latch engages **only** while a republish
+is failing — enforcement is already broken — it never force-denies a
+converged, genuinely-active window (those have `republishPending == false`).
+`RepublishFailClosed()` exposes the latch; the daemon's
+`SchedulerRepublishFailClosed` reads **that same latch** (not a second
+daemon-side timer) and feeds it to the
+`xpf_scheduler_republish_fail_closed` gauge, so the gauge equals the
+scheduler's force-inactive/alarm decision exactly rather than approximately
+(#5669 review fold).
+
+**By-design: a scheduler config change resets the streak.** A commit that
+changes the scheduler policy set (its `policySchedulerConfigHash`) tears
+down and re-primes the scheduler with a fresh `republishFailClosed=false`
+and a reset failure streak/clock, so repeated scheduler edits while the
+dataplane stays wedged could keep restarting the 5 min bound and indefinitely
+delay the fail-closed alarm. This is intentional — a new config is a new
+streak — but operators editing schedulers during a control-socket outage
+should watch `xpf_scheduler_republish_failed`/`_stale_seconds`, which are not
+reset by the escalation logic itself.
+
+**Limitation (block-engage scope).** The fail-closed disposition is
+`inactive` (drop the scheduled rule → default-deny), which is the correct
+fail-closed for the dominant **scheduled-permit** case. A scheduled
+**block** whose engage-activation was never published is already un-engaged
+in the wedged dataplane; forcing it `inactive` matches that state but cannot
+*engage* a block, which requires a successful publish. Actively engaging a
+stuck block would need per-policy action awareness in the dataplane, out of
+this package's scope.
 
 ## Callers
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -36,11 +36,38 @@ type Scheduler struct {
 	republishFirstFail time.Time
 	republishFailures  uint64
 	lastRepublishErr   error
+
+	// #5669: bounded-age fail-closed. The #3780 self-heal retries a failed
+	// republish every tick, but a PERSISTENTLY failing republish (a wedged
+	// control socket, an incompatible helper) leaves the stale window
+	// fail-OPEN — a scheduled permit still forwarding past its close — for as
+	// long as the retry keeps failing, silently. Once the failure streak
+	// exceeds republishFailClosedAge the streak can no longer be a single
+	// transient stall, so the scheduler latches republishFailClosed: it emits
+	// a one-time alert AND forces every scheduled policy to the INACTIVE
+	// (deny) disposition in the published + authoritative active map, refusing
+	// to keep or open any scheduled permit while enforcement is known-wedged.
+	// This is safe because it engages ONLY while the republish is failing
+	// (enforcement already broken — never a converged, genuinely-active
+	// window) and clears on the next successful republish. Guarded by mu.
+	republishFailClosed bool
 }
 
 const (
 	wallClockDriftTolerance = 5 * time.Second
 	wallClockRecoveryHold   = 2 * time.Minute
+
+	// RepublishFailClosedAge bounds how long a scheduler-driven republish may
+	// keep failing before the scheduler escalates from the #3780 silent retry
+	// to a loud fail-closed posture (see the republishFailClosed field). Five
+	// minutes is roughly five 60 s evaluate ticks: long enough to absorb a
+	// burst of control-socket contention (status poll + HA sync + session
+	// installs + snapshot sync share the socket, see CLAUDE.md) without a false
+	// alarm, short enough that a genuinely stuck republish is surfaced and
+	// failed closed promptly. Exported so the daemon's
+	// xpf_scheduler_republish_fail_closed alarm shares this single bound
+	// (#5669).
+	RepublishFailClosedAge = 5 * time.Minute
 )
 
 // NewPrimed creates a Scheduler, evaluates the initial active-state map, and
@@ -132,10 +159,21 @@ func (s *Scheduler) evaluate(now time.Time, notify bool) {
 		}
 	}
 
+	// #5669: while the republish has been failing past the bounded age
+	// (republishFailClosed, latched in recordRepublishResultLocked), force
+	// every scheduled policy to the INACTIVE (deny) disposition instead of
+	// publishing or keeping an ACTIVE permit the wedged dataplane cannot
+	// enforce. Read the latch once so the whole map is a coherent fail-closed
+	// view; it clears on the next successful republish, after which the true
+	// window state is republished and any legitimately-open permit reopens.
+	failClosed := s.republishFailClosed
 	for name, sched := range s.schedulers {
 		cur := false
 		if !wallClockUnsafe {
 			cur = isWithinWindow(now, sched)
+		}
+		if failClosed {
+			cur = false
 		}
 		newActive[name] = cur
 		if prev, ok := s.active[name]; !ok || prev != cur {
@@ -189,10 +227,31 @@ func (s *Scheduler) recordRepublishResultLocked(err error, now time.Time) {
 		s.republishPending = true
 		s.republishFailures++
 		s.lastRepublishErr = err
+		// #5669: bounded-age fail-closed escalation. Once the failure streak
+		// exceeds RepublishFailClosedAge the stale enforcement window has
+		// persisted well beyond a single 60 s retry, so escalate ONCE from the
+		// silent #3780 retry to a loud fail-closed alarm. The latch makes the
+		// next evaluate publish an all-inactive (deny) map, so a scheduled
+		// permit stops forwarding past its close instead of relying on an
+		// eventual republish recovery that may never come.
+		if !s.republishFailClosed && !s.republishFirstFail.IsZero() &&
+			now.Sub(s.republishFirstFail) >= RepublishFailClosedAge {
+			s.republishFailClosed = true
+			slog.Warn("scheduler: republish FAIL-CLOSED — enforcement has been stale past the bounded age; forcing scheduled policies inactive (deny) and refusing to reopen them until republish recovers (a scheduled permit may still be forwarding past its window close in a wedged dataplane — investigate the helper/control socket)",
+				"stale_for", now.Sub(s.republishFirstFail),
+				"bound", RepublishFailClosedAge,
+				"failures", s.republishFailures,
+				"err", err)
+		}
 		return
+	}
+	if s.republishFailClosed {
+		slog.Info("scheduler: republish recovered from fail-closed; republishing the true schedule window state",
+			"failures", s.republishFailures)
 	}
 	s.republishPending = false
 	s.republishFirstFail = time.Time{}
+	s.republishFailClosed = false
 	s.lastRepublishErr = nil
 }
 
@@ -213,6 +272,19 @@ func (s *Scheduler) RepublishFailureStatus() (pending bool, failures uint64, sin
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.republishPending, s.republishFailures, s.republishFirstFail
+}
+
+// RepublishFailClosed reports whether a scheduler-driven republish has been
+// failing continuously for longer than RepublishFailClosedAge, i.e. the stale
+// enforcement window has persisted past the bounded age and the scheduler has
+// escalated to fail-closed: it forces every scheduled policy to the inactive
+// (deny) disposition and has emitted the fail-closed alarm. Latched at the
+// bound, cleared on the next successful republish. Feeds the
+// xpf_scheduler_republish_fail_closed alarm (#5669).
+func (s *Scheduler) RepublishFailClosed() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.republishFailClosed
 }
 
 func (s *Scheduler) wallClockDiscontinuousLocked(now time.Time) bool {

--- a/pkg/scheduler/scheduler_failclosed_5669_test.go
+++ b/pkg/scheduler/scheduler_failclosed_5669_test.go
@@ -19,8 +19,11 @@ import (
 //
 // Once the failure streak exceeds RepublishFailClosedAge the scheduler must
 // escalate to fail-closed: emit the one-time alarm AND force every scheduled
-// policy to the INACTIVE (deny) disposition so the permit STOPS permitting,
-// even when its window legitimately reopens, until a republish succeeds again.
+// policy to the INACTIVE (deny) disposition in the authoritative + published
+// state, refusing to reopen it even when its window legitimately reopens, until
+// a republish succeeds again. (This bounds the SILENT fail-open window with a
+// loud alarm + authoritative deny; it does not itself stop packets in a
+// persistently-wedged dataplane — see the scope note below and the README.)
 //
 // RED-on-revert: removing the bounded-age latch in
 // recordRepublishResultLocked makes RepublishFailClosed() never true — the
@@ -100,13 +103,23 @@ func TestScheduler_RepublishFailClosedAfterBoundedAge(t *testing.T) {
 
 	// The permit's window LEGITIMATELY reopens the next day (09:00-17:00),
 	// desired active=true — but enforcement is still wedged, so fail-closed
-	// must REFUSE to publish an ACTIVE permit and keep denying (stop
-	// permitting). This is the packet-path fail-closed: a scheduled permit
-	// does not forward while the dataplane cannot enforce the schedule.
+	// must build an INACTIVE (deny) snapshot and report the permit inactive on
+	// the authoritative state, refusing to reopen it, until a republish
+	// succeeds again.
+	//
+	// Scope note (honest): this asserts the CONTROL-PLANE disposition — the
+	// published snapshot and the authoritative ActiveState/IsActive both say
+	// DENY. It does NOT prove the packet path stops forwarding: that same
+	// snapshot is pushed through the same failing updateFn channel that defines
+	// the streak, so in a persistently-wedged dataplane it never reaches the
+	// helper and the stale permit keeps forwarding until the socket recovers.
+	// The value of fail-closed is the loud alarm + authoritative deny +
+	// deny-lands-first-on-recovery, not packet-path enforcement in a wedged
+	// dataplane (see README "Bounded-age fail-closed").
 	reopen := time.Date(2026, 2, 13, 10, 0, 0, 0, time.UTC)
 	s.evaluate(reopen, true)
 	if lastState["workhours"] {
-		t.Fatal("fail-closed must publish the permit INACTIVE (deny) even when its window reopens, not forward")
+		t.Fatal("fail-closed must build the permit INACTIVE (deny) in the published snapshot even when its window reopens")
 	}
 	if s.IsActive("workhours") {
 		t.Fatal("fail-closed authoritative state must report the permit inactive (deny)")
@@ -131,6 +144,19 @@ func TestScheduler_RepublishFailClosedAfterBoundedAge(t *testing.T) {
 		t.Fatal("after recovery the reopened window must report active")
 	}
 }
+
+// Note on gauge coverage (#6137 finding 3): the value the daemon's
+// xpf_scheduler_republish_fail_closed gauge reads is the scheduler's own
+// RepublishFailClosed() latch (the SSOT the daemon accessor delegates to after
+// finding 2). Its 0→1 transition at the bound and 1→0 clear on recovery are
+// already pinned by TestScheduler_RepublishFailClosedAfterBoundedAge above (it
+// asserts RepublishFailClosed() directly). Deliberately NOT re-asserting
+// "reads 1 at the bound" in a second test here keeps the latch-block
+// fail-on-revert target-count at exactly one. The genuinely-new gauge coverage
+// — that the DAEMON accessor reads this latch (SSOT) rather than a second
+// daemon-side age timer — lives in pkg/daemon's
+// TestSchedulerRepublishFailClosedGaugeReadsSSOTLatch_5669, which does not
+// depend on the latch reaching true and so stays green on the revert.
 
 // TestScheduler_WithinBoundTransientNeverFailsClosed is the control: a normal
 // successful window transition and a transient failure that recovers INSIDE the

--- a/pkg/scheduler/scheduler_failclosed_5669_test.go
+++ b/pkg/scheduler/scheduler_failclosed_5669_test.go
@@ -1,0 +1,199 @@
+package scheduler
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestScheduler_RepublishFailClosedAfterBoundedAge is the #5669 fail-on-revert
+// pin. The #3780 self-heal retries a failed republish every tick, but a
+// PERSISTENTLY failing republish (a wedged control socket, an incompatible
+// helper) leaves the stale window fail-OPEN — a scheduled PERMIT still
+// forwarding past its close — for as long as the retry keeps failing, silently.
+//
+// Once the failure streak exceeds RepublishFailClosedAge the scheduler must
+// escalate to fail-closed: emit the one-time alarm AND force every scheduled
+// policy to the INACTIVE (deny) disposition so the permit STOPS permitting,
+// even when its window legitimately reopens, until a republish succeeds again.
+//
+// RED-on-revert: removing the bounded-age latch in
+// recordRepublishResultLocked makes RepublishFailClosed() never true — the
+// scheduler keeps publishing the stale-window-driven state forever with no
+// alarm, and the "must latch past the bound" assertion below fails.
+// Target-count: this single test.
+func TestScheduler_RepublishFailClosedAfterBoundedAge(t *testing.T) {
+	// Capture WARN+ so the one-time fail-closed alarm is observable; the
+	// per-name "state changed" logs are INFO and stay suppressed.
+	var logBuf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(oldLogger)
+
+	schedCfg := map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours", StartTime: "09:00:00", StopTime: "17:00:00"},
+	}
+
+	var (
+		calls     int
+		lastState map[string]bool
+		failing   = true
+	)
+	updateFn := func(state map[string]bool) error {
+		calls++
+		lastState = state
+		if failing {
+			return errors.New("republish failed: wedged control socket")
+		}
+		return nil
+	}
+
+	// Prime inside the window (active). NewPrimed must not fire updateFn.
+	now := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	s, initial := NewPrimed(schedCfg, updateFn, now)
+	if !initial["workhours"] {
+		t.Fatalf("workhours should start active inside window, got %v", initial)
+	}
+	if s.RepublishFailClosed() {
+		t.Fatal("a fresh scheduler must not be fail-closed")
+	}
+
+	// Window closes at 17:00 → desired flips to inactive. The first evaluate
+	// fires updateFn, which FAILS and latches the #3780 pending retry. Not yet
+	// fail-closed: a single failure is within the bounded age.
+	closeT := time.Date(2026, 2, 12, 17, 30, 0, 0, time.UTC)
+	s.evaluate(closeT, true)
+	if !s.RepublishPending() {
+		t.Fatal("a failed republish must latch pending for retry")
+	}
+	if s.RepublishFailClosed() {
+		t.Fatal("a single failure inside the bounded age must NOT be fail-closed (would false-alarm on a transient stall)")
+	}
+
+	// Retry every 60 s with the republish still failing. Before the bounded age
+	// elapses the scheduler must stay in silent-retry (not fail-closed).
+	tick := closeT
+	for tick.Sub(closeT) < RepublishFailClosedAge {
+		tick = tick.Add(60 * time.Second)
+		beforeBound := tick.Sub(closeT) < RepublishFailClosedAge
+		s.evaluate(tick, true)
+		if beforeBound && s.RepublishFailClosed() {
+			t.Fatalf("must not fail-closed before the bounded age (streak=%s, bound=%s)",
+				tick.Sub(closeT), RepublishFailClosedAge)
+		}
+	}
+
+	// The streak has now reached the bounded age: the scheduler MUST have
+	// latched fail-closed and emitted exactly one alarm.
+	if !s.RepublishFailClosed() {
+		t.Fatalf("republish failing for %s (>= bound %s) must latch fail-closed",
+			tick.Sub(closeT), RepublishFailClosedAge)
+	}
+	if got := strings.Count(logBuf.String(), "FAIL-CLOSED"); got != 1 {
+		t.Fatalf("fail-closed must emit exactly one alarm, got %d\nlog:\n%s", got, logBuf.String())
+	}
+
+	// The permit's window LEGITIMATELY reopens the next day (09:00-17:00),
+	// desired active=true — but enforcement is still wedged, so fail-closed
+	// must REFUSE to publish an ACTIVE permit and keep denying (stop
+	// permitting). This is the packet-path fail-closed: a scheduled permit
+	// does not forward while the dataplane cannot enforce the schedule.
+	reopen := time.Date(2026, 2, 13, 10, 0, 0, 0, time.UTC)
+	s.evaluate(reopen, true)
+	if lastState["workhours"] {
+		t.Fatal("fail-closed must publish the permit INACTIVE (deny) even when its window reopens, not forward")
+	}
+	if s.IsActive("workhours") {
+		t.Fatal("fail-closed authoritative state must report the permit inactive (deny)")
+	}
+
+	// Republish recovers. The next successful publish clears fail-closed; the
+	// scheduler then republishes the TRUE window state so the legitimately-open
+	// permit reopens (no permanent false-deny).
+	failing = false
+	s.evaluate(reopen.Add(60*time.Second), true)
+	if s.RepublishFailClosed() {
+		t.Fatal("a successful republish must clear fail-closed")
+	}
+	if s.RepublishPending() {
+		t.Fatal("a successful republish must clear the pending retry")
+	}
+	s.evaluate(reopen.Add(120*time.Second), true)
+	if !lastState["workhours"] {
+		t.Fatal("after recovery the reopened window must republish the permit ACTIVE (no permanent false-deny)")
+	}
+	if !s.IsActive("workhours") {
+		t.Fatal("after recovery the reopened window must report active")
+	}
+}
+
+// TestScheduler_WithinBoundTransientNeverFailsClosed is the control: a normal
+// successful window transition and a transient failure that recovers INSIDE the
+// bounded age must never trip fail-closed — no false-deny of a legitimate
+// window, no false alarm. This test does NOT depend on the #5669 latch, so it
+// stays green whether or not the fix is present (keeps the fail-on-revert
+// target-count at 1).
+func TestScheduler_WithinBoundTransientNeverFailsClosed(t *testing.T) {
+	schedCfg := map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours", StartTime: "09:00:00", StopTime: "17:00:00"},
+	}
+	var (
+		calls     int
+		lastState map[string]bool
+		failing   = false
+	)
+	updateFn := func(state map[string]bool) error {
+		calls++
+		lastState = state
+		if failing {
+			return errors.New("transient republish failure")
+		}
+		return nil
+	}
+
+	now := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	s, _ := NewPrimed(schedCfg, updateFn, now)
+
+	// A clean window close: one successful republish, never fail-closed.
+	closeT := time.Date(2026, 2, 12, 17, 30, 0, 0, time.UTC)
+	s.evaluate(closeT, true)
+	if s.RepublishFailClosed() {
+		t.Fatal("a successful window transition must never be fail-closed")
+	}
+	if lastState["workhours"] {
+		t.Fatal("a closed window must publish the permit inactive")
+	}
+
+	// A transient failure that recovers well inside the bounded age must not
+	// fail-closed. Reopen the window (desired active) so a spurious fail-closed
+	// would be observable as a false-deny.
+	reopen := time.Date(2026, 2, 13, 9, 30, 0, 0, time.UTC)
+	failing = true
+	s.evaluate(reopen, true) // republish fails once, latches pending
+	if !s.RepublishPending() {
+		t.Fatal("a failed republish should latch pending")
+	}
+	// A couple more failures, still comfortably within the bound.
+	failing = true
+	s.evaluate(reopen.Add(60*time.Second), true)
+	if s.RepublishFailClosed() {
+		t.Fatalf("a transient failure inside the bounded age (%s) must not fail-closed", RepublishFailClosedAge)
+	}
+	// Recover before the bound.
+	failing = false
+	s.evaluate(reopen.Add(120*time.Second), true)
+	if s.RepublishFailClosed() || s.RepublishPending() {
+		t.Fatal("recovery inside the bound must leave neither pending nor fail-closed")
+	}
+	if !lastState["workhours"] {
+		t.Fatal("the legitimately-open window must publish ACTIVE after a within-bound transient recovers (no false-deny)")
+	}
+	if !s.IsActive("workhours") {
+		t.Fatal("the legitimately-open window must be active after recovery")
+	}
+}


### PR DESCRIPTION
## Summary

- **Bounds the #3780 republish fail-open window.** On a scheduled-policy window transition the scheduler republishes enforcement via `updateFn`; the #3780 self-heal latches `republishPending` and retries every 60 s. A *persistently* failing republish (a wedged control socket, an incompatible helper) leaves the stale window **fail-open** — a scheduled permit keeps forwarding past its close — indefinitely, silently, with no loud operator signal. `republishFailures`/`firstFail` were tracked for metrics but never acted on.
- **Adds a bounded-age fail-closed escalation.** Once the failure streak exceeds `RepublishFailClosedAge` (5 min ≈ five ticks) the scheduler latches `republishFailClosed`, emits a **one-time** `slog.Warn` alarm, and forces **every scheduled policy to `inactive` (deny)** in the published + authoritative active-state map — a scheduled permit stops permitting and refuses to reopen while enforcement is known-wedged.
- **Safe / no false-deny.** The latch engages ONLY while a republish is failing (enforcement already broken), so a converged, genuinely-active window (`republishPending == false`) is never force-denied. It clears on the next successful republish, republishing the true window state so a legitimately-open permit reopens.
- **New alarm metric.** `RepublishFailClosedAge` is exported so the daemon's new `xpf_scheduler_republish_fail_closed` gauge (same failure-streak start, single shared bound) agrees with the scheduler latch — a crisp 0/1 alarm distinct from the climbing `xpf_scheduler_republish_stale_seconds`.

## Honest scope

The fail-closed disposition is `inactive` (drop the scheduled rule → default-deny), the correct fail-closed for the dominant scheduled-**PERMIT** case. A scheduled **BLOCK** whose engage-activation was never published is already un-engaged in the wedged dataplane; forcing it `inactive` matches that state but cannot *engage* a block (needs a successful publish — per-policy action awareness lives in the dataplane, out of this package's scope). The scheduler cannot unilaterally flip a truly-wedged helper's loaded snapshot; the loud alarm + forced-deny authoritative state is the defense-in-depth this layer can guarantee. Documented in `pkg/scheduler/README.md`.

## Test plan

- [x] `pkg/scheduler/scheduler_failclosed_5669_test.go` — **fail-on-revert**: a scheduled PERMIT whose window closes while the republish persistently fails, advanced past `RepublishFailClosedAge` with a **fake clock**, must latch fail-closed, emit exactly one alarm, publish the permit inactive even when its window **reopens**, then reopen it after republish recovers. Removing the bounded-age latch turns exactly this test RED (**target-count 1**, assertion failure — not a build break).
- [x] Control test: a normal transition and a within-bound transient recovery never fail closed (no false-deny, no false alarm) — independent of the latch, stays green on revert.
- [x] `go test ./pkg/scheduler/...` (incl. `-race`), `./pkg/api/...`, `./pkg/daemon/...` — all green.
- [x] `gofmt` + `go vet` clean.

## Not HA / smoke assessment

This is **local policy scheduling**, not HA / session-sync / fabric. It is packet-path policy enforcement, but the mechanism (wall-clock window evaluation → active-state map → fail-closed latch) is fully unit-provable with a fake clock; no live cluster smoke is warranted.

## Refs

- Closes #5669 (residual on the #3780 self-heal; provenance fable-review-174 H1)
- Builds on #3780 (republish self-heal), #3849/#3414 (fail-closed posture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq7FFbnB6dUbDkR7xo8pmW