### PR TITLE
userspace-dp reconcile: fail closed on post-teardown worker-spawn failure (#4952)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -53453,3 +53453,41 @@ top.
   userspace-dp/src/server/tests.rs,
   userspace-dp/src/server/README.md,
   docs/userspace-dataplane-architecture.md
+
+- **Timestamp**: 2026-07-18
+- **Action**: #4952 — fail closed on POST-teardown worker-spawn failure.
+  `bring_up_workers` (afxdp/coordinator/reconcile/bringup.rs) runs after
+  `tear_down` stopped the old workers; a per-worker `spawn_supervised_worker`
+  (→ pthread_create EAGAIN/ENOMEM) left a queue set with no XSK-bound worker
+  yet the old code returned `()`, only logged, and UNCONDITIONALLY overwrote
+  `last_reconcile_stage` with `spawned:workers=..` — so reconcile returned
+  Ok, the handler acked ok=true AND persisted the broken snapshot (silent
+  forwarding outage, no retry). Fix: `bring_up_workers` now returns
+  `Result<(), String>` — on the FIRST spawn failure it aborts remaining
+  launches, PRESERVES the `spawn_worker_failed:<id>:<err>` stage, skips the
+  aux-thread bring-up, and returns the stage. `reconcile` maps it to the new
+  `ReconcileError::WorkerSpawn` (the only variant raised AFTER teardown).
+  snapshot.rs `apply` full-apply + same-plan-needs_reconcile legs special-case
+  it: ok=false + "worker spawn failed after teardown (...)", refresh_status to
+  the real (broken) per-binding state (no existing_bindings restore), roll the
+  baseline back to the prior snapshot, return BEFORE persist. Sibling handlers
+  (binding/queue/rebind/forwarding, #6134/#6135) already fail closed on any
+  Err — unchanged. Minimal fail-close, NOT full pre-teardown preflight (a real
+  pthread_create can't be probed without spawning, and old workers must free
+  the XSK queue bindings first) — noted as a follow-up. Per-instance
+  `#[cfg(test)] force_worker_spawn_fail` seam. Tests:
+  `reconcile_post_teardown_worker_spawn_failure_fails_closed_4952`
+  (coordinator: Err(WorkerSpawn) + stage preserved) and
+  `post_teardown_spawn_failure_fails_closed_no_persist_4952` (handler:
+  ok=false + state file NOT written + baseline restored + stage preserved).
+  Parent-RED verified: neutralize the propagation → both tests RED (2 failed /
+  0 passed), target-count 1 each. NOT HA — unit-provable via spawn-failure
+  injection; no cluster smoke.
+- **File(s)**: userspace-dp/src/afxdp/coordinator/mod.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/mod.rs,
+  userspace-dp/src/afxdp/coordinator/tests.rs,
+  userspace-dp/src/server/handlers/snapshot.rs,
+  userspace-dp/src/server/tests.rs,
+  userspace-dp/src/afxdp/coordinator/README.md,
+  userspace-dp/src/server/README.md

--- a/userspace-dp/src/afxdp/coordinator/README.md
+++ b/userspace-dp/src/afxdp/coordinator/README.md
@@ -131,3 +131,31 @@ Differences that matter (#1881):
   no split-brain (validation ahead of a stale forwarding table), no
   deleted-neighbor blackhole, no `ok=true` on a rejected snapshot.
   Distinct from #2484 (full-apply teardown) and #2916 (queue replan).
+- **A POST-teardown worker-spawn failure fails closed (#4952).** The
+  #2440/#2484/#3789 fail-closed legs above all abort BEFORE `tear_down`,
+  so the prior workers stay live. `bring_up_workers` runs AFTER teardown:
+  its per-worker `spawn_supervised_worker` (→ `pthread_create`) can return
+  EAGAIN/ENOMEM under resource exhaustion, and the old workers are already
+  gone — a queue set left with no XSK-bound worker is a silent forwarding
+  outage. Pre-#4952 `bring_up_workers` returned `()`, only LOGGED the
+  failure + recorded an exception, then UNCONDITIONALLY overwrote
+  `last_reconcile_stage` with `spawned:workers=..` and returned success —
+  so `reconcile` returned `Ok(())`, the control handler acked `ok=true`,
+  and PERSISTED the broken snapshot as the boot baseline (no retry). Now
+  `bring_up_workers` returns `Result<(), String>`: on the FIRST spawn
+  failure it ABORTS the remaining launches (the data plane is already
+  broken; more XSK-bound workers cannot restore forwarding and only widen
+  the resource pressure), PRESERVES the `spawn_worker_failed:<id>:<err>`
+  stage (no `spawned:..` overwrite), skips the auxiliary-thread bring-up,
+  and returns the stage. `reconcile` maps it to
+  `ReconcileError::WorkerSpawn` — the ONE `ReconcileError` variant raised
+  AFTER teardown (the data plane HAS moved; there is no prior-state restore
+  that brings the torn-down workers back, only fail-closed bookkeeping +
+  a retry/last-good reconcile). Full pre-teardown preflight of the spawn is
+  not tractable (a real `pthread_create` cannot be probed without spawning,
+  and the old workers must free the XSK queue bindings first), so this is
+  the minimal fail-closed guarantee: do not persist a known-broken
+  snapshot. A per-instance `#[cfg(test)] force_worker_spawn_fail` seam
+  drives the regression tests (coordinator-level
+  `reconcile_post_teardown_worker_spawn_failure_fails_closed_4952` +
+  handler-level `post_teardown_spawn_failure_fails_closed_no_persist_4952`).

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -264,6 +264,17 @@ pub struct Coordinator {
     /// release builds.
     #[cfg(test)]
     pub(crate) last_quiesce_ms: u64,
+    /// #4952 test seam (per-instance, NOT a process-global): under
+    /// `cfg(test)`, `bring_up_workers` treats a positive value as N forced
+    /// worker-thread spawn failures — it declines to call
+    /// `spawn_supervised_worker` and synthesizes the EAGAIN/ENOMEM
+    /// `std::io::Error` a real `pthread_create` returns under resource
+    /// exhaustion, decrementing the counter for each planned worker. This
+    /// exercises the POST-TEARDOWN fail-closed propagation deterministically
+    /// (a real spawn failure is not provokable in-process). Always 0 in
+    /// release builds; per-instance so parallel tests never race.
+    #[cfg(test)]
+    pub(crate) force_worker_spawn_fail: u32,
     pub(crate) last_reconcile_stage: String,
     pub(crate) poll_mode: crate::PollMode,
     pub(crate) event_stream: Option<crate::event_stream::EventStreamSender>,
@@ -322,6 +333,8 @@ impl Coordinator {
             reconcile_quiesce_count: 0,
             #[cfg(test)]
             last_quiesce_ms: 0,
+            #[cfg(test)]
+            force_worker_spawn_fail: 0,
             last_reconcile_stage: "idle".to_string(),
             poll_mode: crate::PollMode::BusyPoll,
             event_stream: None,

--- a/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
@@ -18,6 +18,29 @@ use super::super::super::*;
 use super::super::supervisor::{spawn_supervised_aux, spawn_supervised_worker};
 use super::super::{Coordinator, WorkerHandle};
 
+/// Bring up the worker threads for the just-applied snapshot.
+///
+/// #4952: this runs on the POST-TEARDOWN destructive path — `tear_down`
+/// has already stopped the previous workers, so a worker-thread spawn
+/// failure here leaves the affected queue set with NO XSK-bound worker
+/// (a silent forwarding outage). The spawn (`spawn_supervised_worker` ->
+/// `thread::Builder::spawn` -> `pthread_create`) can return EAGAIN/ENOMEM
+/// under resource exhaustion. On the FIRST such failure this ABORTS the
+/// remaining launches (the data plane is already broken — spawning more
+/// XSK-bound workers cannot restore forwarding and only compounds the
+/// pressure), PRESERVES the `spawn_worker_failed:<id>:<err>` stage (it does
+/// NOT overwrite it with `spawned:..`), skips the auxiliary-thread bring-up,
+/// and returns `Err(stage)`. The caller (`reconcile`) maps that to
+/// `ReconcileError::WorkerSpawn` so the control handler fails closed and
+/// does NOT persist the broken snapshot as the boot baseline. On success
+/// returns `Ok(())`.
+///
+/// Full pre-teardown preflight of the spawn is not tractable — a real
+/// `pthread_create` cannot be probed without spawning the thread, and the
+/// old workers must be torn down first to free the XSK queue bindings the
+/// new workers claim. So this is the minimal fail-closed guarantee (do not
+/// persist a known-broken snapshot); a staged spawn-before-teardown is a
+/// possible follow-up.
 pub(super) fn bring_up_workers(
     coord: &mut Coordinator,
     snapshot: &ConfigSnapshot,
@@ -25,7 +48,7 @@ pub(super) fn bring_up_workers(
     fds: ReconcileSnapshotFds,
     ring_entries: usize,
     preserved_synced_sessions: Vec<SyncedSessionEntry>,
-) {
+) -> Result<(), String> {
     let ReconcileSnapshotFds {
         map_fd,
         heartbeat_map_fd,
@@ -256,6 +279,11 @@ pub(super) fn bring_up_workers(
             }
         }
     }
+    // #4952: set on the FIRST worker-spawn failure; carries the preserved
+    // `spawn_worker_failed:<id>:<err>` stage. Once set, the loop breaks
+    // (abort remaining launches) and the tail returns Err(stage) so the
+    // reconcile fails closed instead of persisting a broken snapshot.
+    let mut spawn_failure: Option<String> = None;
     for (worker_id, binding_plans) in workers {
         let plan_count = binding_plans.len();
         let stop = Arc::new(AtomicBool::new(false));
@@ -334,48 +362,66 @@ pub(super) fn bring_up_workers(
         // a helper without re-validating the panic-payload contract.
         let panic_slot = Arc::new(Mutex::new(None::<String>));
         coord.worker_panics.insert(worker_id, panic_slot.clone());
-        let join =
-            spawn_supervised_worker(worker_id, runtime_atomics.clone(), panic_slot, move || {
-                worker_loop(
-                    worker_id,
-                    binding_plans,
-                    shared_validation,
-                    shared_forwarding,
-                    ha_state,
-                    dynamic_neighbors,
-                    neighbor_resolver,
-                    shared_sessions,
-                    shared_nat_sessions,
-                    shared_forward_wire_sessions,
-                    shared_owner_rg_indexes,
-                    slow_path,
-                    local_tunnel_deliveries,
-                    recent_exceptions,
-                    recent_session_deltas,
-                    last_resolution,
-                    commands_clone,
-                    peer_commands_clone,
-                    worker_commands_by_id,
-                    stop_clone,
-                    heartbeat_clone,
-                    session_export_ack_clone,
-                    worker_poll_mode,
-                    dnat_fds,
-                    shared_fabrics,
-                    event_stream_handle,
-                    rg_epochs,
-                    shared_cos_owner_worker_by_queue,
-                    shared_cos_owner_live_by_queue,
-                    shared_cos_root_leases,
-                    shared_cos_exact_backlogs,
-                    shared_cos_queue_leases,
-                    shared_cos_queue_vtime_floors,
-                    shared_mirror_targets,
-                    cos_status_clone,
-                    runtime_atomics_clone,
-                    cold_path_atomics_clone,
-                );
-            });
+        let body = move || {
+            worker_loop(
+                worker_id,
+                binding_plans,
+                shared_validation,
+                shared_forwarding,
+                ha_state,
+                dynamic_neighbors,
+                neighbor_resolver,
+                shared_sessions,
+                shared_nat_sessions,
+                shared_forward_wire_sessions,
+                shared_owner_rg_indexes,
+                slow_path,
+                local_tunnel_deliveries,
+                recent_exceptions,
+                recent_session_deltas,
+                last_resolution,
+                commands_clone,
+                peer_commands_clone,
+                worker_commands_by_id,
+                stop_clone,
+                heartbeat_clone,
+                session_export_ack_clone,
+                worker_poll_mode,
+                dnat_fds,
+                shared_fabrics,
+                event_stream_handle,
+                rg_epochs,
+                shared_cos_owner_worker_by_queue,
+                shared_cos_owner_live_by_queue,
+                shared_cos_root_leases,
+                shared_cos_exact_backlogs,
+                shared_cos_queue_leases,
+                shared_cos_queue_vtime_floors,
+                shared_mirror_targets,
+                cos_status_clone,
+                runtime_atomics_clone,
+                cold_path_atomics_clone,
+            );
+        };
+        // #4952 test seam: force the fallible worker spawn to fail so the
+        // post-teardown fail-closed propagation is unit-verifiable without a
+        // real (unprovokable) pthread_create EAGAIN/ENOMEM. Declines the real
+        // spawn, drops the worker body unspawned, and synthesizes the same
+        // `std::io::Error` a resource-exhausted spawn returns. Always 0 in
+        // release builds (`force_worker_spawn_fail` is `#[cfg(test)]`).
+        #[cfg(test)]
+        let join = if coord.force_worker_spawn_fail > 0 {
+            coord.force_worker_spawn_fail -= 1;
+            drop(body);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "forced worker spawn failure (test seam #4952)",
+            ))
+        } else {
+            spawn_supervised_worker(worker_id, runtime_atomics.clone(), panic_slot, body)
+        };
+        #[cfg(not(test))]
+        let join = spawn_supervised_worker(worker_id, runtime_atomics.clone(), panic_slot, body);
         match join {
             Ok(join) => {
                 eprintln!(
@@ -401,7 +447,8 @@ pub(super) fn bring_up_workers(
                     "xpf-userspace-dp: failed to start worker thread worker_id={} err={}",
                     worker_id, err
                 );
-                coord.last_reconcile_stage = format!("spawn_worker_failed:{worker_id}:{err}");
+                let stage = format!("spawn_worker_failed:{worker_id}:{err}");
+                coord.last_reconcile_stage = stage.clone();
                 // #925 Phase 1: the panic slot was inserted before
                 // spawn; drop it now so a snapshot reader doesn't
                 // see a phantom slot for a worker that never ran.
@@ -412,13 +459,34 @@ pub(super) fn bring_up_workers(
                 coord.worker_exception_rings.remove(&worker_id);
                 coord.worker_last_resolution.remove(&worker_id);
                 if let Ok(mut recent) = coord.recent_exceptions.lock() {
-                    push_recent_exception(
-                        &mut recent,
-                        control_notice_event("", format!("spawn_worker_failed:{worker_id}:{err}")),
-                    );
+                    push_recent_exception(&mut recent, control_notice_event("", stage.clone()));
                 }
+                // #4952: a spawn failed on the POST-TEARDOWN destructive
+                // path — the old workers are gone, so this queue set now has
+                // NO XSK-bound worker (silent forwarding outage). ABORT the
+                // remaining launches (the data plane is already broken;
+                // spawning more XSK-bound workers cannot restore forwarding
+                // and only compounds the resource pressure) and remember the
+                // preserved stage so the tail returns Err and the caller
+                // fails closed instead of persisting a broken snapshot.
+                spawn_failure = Some(stage);
+                break;
             }
         }
+    }
+    // #4952: on a post-teardown spawn failure, PRESERVE the
+    // "spawn_worker_failed:.." stage (do NOT overwrite it with
+    // "spawned:.."), skip the auxiliary-thread bring-up (forwarding is
+    // down — the next successful reconcile starts them), and return the
+    // failure so `reconcile` maps it to `ReconcileError::WorkerSpawn` and
+    // the control handler fails closed, NOT persisting this broken snapshot
+    // as the boot baseline.
+    if let Some(stage) = spawn_failure {
+        eprintln!(
+            "xpf-userspace-dp: worker bring-up FAILED ({stage}); a queue set has no \
+             XSK-bound worker after teardown — failing reconcile closed"
+        );
+        return Err(stage);
     }
     coord.last_reconcile_stage = format!(
         "spawned:workers={}:identities={}:live={}",
@@ -499,6 +567,7 @@ pub(super) fn bring_up_workers(
     // the spawn-pass worker gate).
     coord.reconcile_local_tunnel_sources();
     coord.spawn_wg_control_threads();
+    Ok(())
 }
 
 /// #1830 follow-up (Codex review on PR #1841): array length needed to

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -33,10 +33,18 @@ pub(super) mod teardown;
 /// handler mirror #3766: report `ok=false`, restore the prior snapshot +
 /// status fields, and NOT persist.
 ///
-/// Every variant is raised ONLY by a pre-teardown early return, where
-/// #2440/#2484 keep the prior workers + forwarding + published generation
-/// fully live. The handler restore is therefore a status/bookkeeping
-/// rollback, not a forwarding recovery — the data plane never moved.
+/// The `Integrity` and `MapSetup` variants are raised ONLY by a
+/// pre-teardown early return, where #2440/#2484 keep the prior workers +
+/// forwarding + published generation fully live. For those, the handler
+/// restore is a status/bookkeeping rollback, not a forwarding recovery —
+/// the data plane never moved.
+///
+/// #4952: `WorkerSpawn` is the exception — it is raised AFTER `tear_down`
+/// has already stopped the old workers, so the data plane HAS moved (a
+/// queue set is left with no XSK-bound worker). There is no prior-state
+/// restore that brings the torn-down workers back; the handler still fails
+/// closed (report `ok=false`, do NOT persist the broken snapshot as the
+/// boot baseline) and recovery is a retry / last-good reconcile.
 #[derive(Debug)]
 pub(crate) enum ReconcileError {
     /// A snapshot integrity fault surfaced by the top-of-reconcile policy
@@ -49,6 +57,15 @@ pub(crate) enum ReconcileError {
     /// (defensively unreachable post-#2484). Carries the
     /// `last_reconcile_stage` descriptor for the control-plane error.
     MapSetup(String),
+    /// #4952: a worker thread failed to spawn on the POST-TEARDOWN
+    /// destructive path (`bring_up_workers` -> `spawn_supervised_worker` ->
+    /// `pthread_create` EAGAIN/ENOMEM under resource exhaustion). Unlike the
+    /// two pre-teardown variants above, `tear_down` has already stopped the
+    /// old workers, so the affected queue set has NO XSK-bound worker and
+    /// forwarding is DOWN. Surfaced so the control handler fails closed and
+    /// does NOT persist the broken snapshot as the boot baseline. Carries
+    /// the preserved `spawn_worker_failed:<id>:<err>` stage.
+    WorkerSpawn(String),
 }
 
 impl std::fmt::Display for ReconcileError {
@@ -56,6 +73,7 @@ impl std::fmt::Display for ReconcileError {
         match self {
             ReconcileError::Integrity(err) => write!(f, "{err}"),
             ReconcileError::MapSetup(stage) => write!(f, "map setup failed ({stage})"),
+            ReconcileError::WorkerSpawn(stage) => write!(f, "worker spawn failed ({stage})"),
         }
     }
 }
@@ -347,7 +365,7 @@ impl Coordinator {
             // fail-closed backstop, not a prior-state restore).
             return Err(ReconcileError::MapSetup(self.last_reconcile_stage.clone()));
         };
-        bringup::bring_up_workers(
+        let bringup_result = bringup::bring_up_workers(
             self,
             snapshot,
             bindings,
@@ -355,7 +373,17 @@ impl Coordinator {
             ring_entries,
             preserved.synced_sessions,
         );
+        // Reflect the real per-binding state either way — a partial spawn
+        // (some workers up, then a spawn aborted the rest) still needs the
+        // refresh so status shows which slots came up and which did not.
         self.refresh_bindings(bindings);
-        Ok(())
+        // #4952: a POST-TEARDOWN worker-spawn failure fails the reconcile
+        // closed. `bring_up_workers` preserved the `spawn_worker_failed:..`
+        // stage and returned it; surface it as `ReconcileError::WorkerSpawn`
+        // so the control handler reports ok=false and does NOT persist this
+        // broken snapshot as the boot baseline (the old workers are already
+        // torn down — there is no forwarding to restore, only fail-closed
+        // bookkeeping + a retry/last-good path).
+        bringup_result.map_err(ReconcileError::WorkerSpawn)
     }
 }

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -3520,6 +3520,76 @@ fn reconcile_missing_pin_returns_map_setup_err_3789() {
     }
 }
 
+/// #4952: a worker-thread spawn failure on the POST-TEARDOWN destructive
+/// path (`bring_up_workers` -> `spawn_supervised_worker`) must FAIL CLOSED —
+/// `reconcile` returns `Err(ReconcileError::WorkerSpawn(_))` and
+/// `last_reconcile_stage` RETAINS the `spawn_worker_failed:..` descriptor
+/// (it is NOT overwritten with `spawned:workers=..`).
+///
+/// Before #4952 `bring_up_workers` returned `()`, only LOGGED the spawn
+/// failure + recorded an exception, then unconditionally overwrote the
+/// stage with `spawned:..` and returned success. So a post-teardown
+/// `pthread_create` EAGAIN/ENOMEM left a queue set with NO XSK-bound worker
+/// yet `reconcile` returned `Ok(())` — the control handler then acked
+/// ok=true AND persisted the broken snapshot as the boot baseline (a silent
+/// forwarding outage with no retry). #3789 fail-closes only the PRE-teardown
+/// integrity/map legs, not this post-teardown spawn failure.
+///
+/// The per-instance `force_worker_spawn_fail` seam forces the spawn to
+/// return the EAGAIN/ENOMEM error a resource-exhausted `pthread_create`
+/// returns (unprovokable in-process), so the propagation is unit-verifiable.
+///
+/// Fail-on-revert: revert the propagation (`bring_up_workers` back to `()` +
+/// the unconditional `spawned:..` stage overwrite) and BOTH the
+/// `Err(WorkerSpawn)` match and the `spawn_worker_failed` stage assertion
+/// flip (`reconcile` returns `Ok`, stage becomes `spawned:workers=..`).
+#[test]
+fn reconcile_post_teardown_worker_spawn_failure_fails_closed_4952() {
+    let mut coordinator = Coordinator::new();
+    // One registered binding => exactly one planned worker to spawn.
+    let mut bindings: Vec<BindingStatus> = vec![BindingStatus {
+        slot: 1,
+        worker_id: 0,
+        queue_id: 0,
+        interface: "ge-0-0-0".into(),
+        ifindex: 10,
+        registered: true,
+        ..BindingStatus::default()
+    }];
+    // Force the (only) planned worker's spawn to fail on the post-teardown
+    // path — the fallible step the fix propagates.
+    coordinator.force_worker_spawn_fail = 1;
+
+    // All mandatory pins open so the reconcile clears the pre-teardown
+    // integrity legs, tears down, applies the snapshot, and REACHES the
+    // worker spawn (the destructive path #4952 guards).
+    let snap = mandatory_ok_snapshot(5);
+    let result = coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    assert!(
+        matches!(result, Err(ReconcileError::WorkerSpawn(ref stage)) if !stage.is_empty()),
+        "a post-teardown worker-spawn failure must surface as Err(WorkerSpawn) with a \
+         non-empty stage, got {result:?}"
+    );
+    assert!(
+        coordinator
+            .last_reconcile_stage
+            .starts_with("spawn_worker_failed:"),
+        "the spawn-failure stage must be PRESERVED (not overwritten with spawned:..), got {:?}",
+        coordinator.last_reconcile_stage
+    );
+    assert!(
+        !coordinator.last_reconcile_stage.starts_with("spawned:"),
+        "the reconcile must NOT report a successful spawn after a spawn failure, got {:?}",
+        coordinator.last_reconcile_stage
+    );
+    // The seam consumed its single forced failure (no over-fire).
+    assert_eq!(
+        coordinator.force_worker_spawn_fail, 0,
+        "exactly one forced spawn failure should have been consumed"
+    );
+}
+
 /// #5171: the side-effect-free `validate_snapshot_buildable` gate (used by
 /// the deferred-activation apply path, which never reaches `reconcile`) and
 /// the worker-spawning `reconcile` MUST reject the IDENTICAL non-buildable

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -198,7 +198,26 @@ queues. See PR #1243's kill record for why i40e doesn't reshape.
   `ok=false` + "`<site> reconcile failed: {err}`", refresh status, and return
   BEFORE `wait_for_binding_settle` / `persist_state=true`) instead of the old
   `let _ = reconcile_status_bindings(..)` discard that acked `ok=true` after a
-  failed (re)bind; `rebind::handle` took a `response` parameter for this. When
+  failed (re)bind; `rebind::handle` took a `response` parameter for this.
+  #4952: the reconcile `Err` now also carries `ReconcileError::WorkerSpawn`
+  — the one variant raised AFTER teardown (a `bring_up_workers`
+  `spawn_supervised_worker` / `pthread_create` EAGAIN/ENOMEM leaves a queue
+  set with no XSK-bound worker). The already-accepted-snapshot callers
+  (`set_binding_state` / `set_queue_state` / `rebind` / `set_forwarding_state`)
+  already fail closed on ANY `Err`, so they surface it unchanged. The
+  `apply_snapshot` full-apply and same-plan-`needs_reconcile` legs SPECIAL-CASE
+  it: unlike the pre-teardown integrity/map faults (where the prior workers
+  stayed live and restoring `existing_bindings` is truthful), the old workers
+  are GONE here — so they report `ok=false` + "`worker spawn failed after
+  teardown (...)`", refresh status to the REAL post-teardown per-binding state
+  (they do NOT restore `existing_bindings`), roll the in-memory baseline back
+  to the prior good snapshot + status generation, and return BEFORE
+  `persist_state=true` (the broken snapshot must never become the boot
+  baseline). Pre-#4952 `bring_up_workers` returned `()` and swallowed the
+  spawn error (overwriting `last_reconcile_stage` with `spawned:..`), so the
+  handler acked `ok=true` and persisted a dataplane-down snapshot — a silent
+  forwarding outage with no retry (regression-tested by
+  `post_teardown_spawn_failure_fails_closed_no_persist_4952`). When
   `should_run_afxdp` does NOT hold (forwarding disarmed / unsupported) it
   `stop()`s every worker and then routes the per-binding status through
   `refresh_bindings` — which sends each now-workerless slot through

--- a/userspace-dp/src/server/handlers/snapshot.rs
+++ b/userspace-dp/src/server/handlers/snapshot.rs
@@ -200,11 +200,26 @@ pub(super) fn apply(
                 guard.status.last_snapshot_at = prev_last_snapshot_at;
                 guard.status.capabilities = prev_capabilities;
                 response.ok = false;
-                response.error = format!("snapshot integrity error: {}", err);
-                eprintln!(
-                    "CTRL_REQ: same-plan apply_snapshot rejected (integrity build): {} — keeping previous state",
-                    err
-                );
+                // #4952: distinguish the POST-TEARDOWN worker-spawn failure
+                // (old workers gone, dataplane down — refresh status to the
+                // real per-binding state) from the pre-teardown integrity
+                // faults (prior workers still live). Both fail closed and do
+                // NOT persist; only the message + status refresh differ.
+                if let crate::afxdp::ReconcileError::WorkerSpawn(stage) = &err {
+                    response.error = format!(
+                        "worker spawn failed after teardown ({stage}); dataplane down — snapshot not persisted"
+                    );
+                    refresh_status(guard);
+                    eprintln!(
+                        "CTRL_REQ: same-plan apply_snapshot rejected (post-teardown worker spawn failure): {stage} — dataplane down, NOT persisting"
+                    );
+                } else {
+                    response.error = format!("snapshot integrity error: {}", err);
+                    eprintln!(
+                        "CTRL_REQ: same-plan apply_snapshot rejected (integrity build): {} — keeping previous state",
+                        err
+                    );
+                }
                 return;
             }
         } else {
@@ -324,6 +339,35 @@ pub(super) fn apply(
                 "CTRL_REQ: apply_snapshot defer_workers=true — skipping worker spawn (RETH MAC pending)"
             );
         } else if let Err(err) = reconcile_status_bindings(guard) {
+            if let crate::afxdp::ReconcileError::WorkerSpawn(stage) = &err {
+                // #4952: POST-TEARDOWN worker-spawn failure. Unlike the
+                // pre-teardown integrity/map faults below — where the old
+                // workers + forwarding stayed live and restoring the prior
+                // bindings is truthful — here tear_down already stopped the
+                // old workers and one or more new workers failed to spawn, so
+                // this queue set has NO XSK-bound worker: the data plane is
+                // DOWN. Fail closed so the broken snapshot is NOT persisted as
+                // the boot baseline. Roll the in-memory baseline back to the
+                // prior good snapshot + status generation (a retry / forwarding
+                // toggle then reconciles last-good), but DO NOT restore
+                // existing_bindings — refresh_status must report the REAL
+                // post-teardown per-binding state, not the pre-teardown
+                // workers that no longer exist.
+                guard.snapshot = prev_snapshot;
+                guard.status.last_snapshot_generation = prev_last_snapshot_generation;
+                guard.status.last_fib_generation = prev_last_fib_generation;
+                guard.status.last_snapshot_at = prev_last_snapshot_at;
+                guard.status.capabilities = prev_capabilities;
+                response.ok = false;
+                response.error = format!(
+                    "worker spawn failed after teardown ({stage}); dataplane down — snapshot not persisted"
+                );
+                refresh_status(guard);
+                eprintln!(
+                    "CTRL_REQ: apply_snapshot rejected (post-teardown worker spawn failure): {stage} — dataplane down, NOT persisting"
+                );
+                return;
+            }
             // #3789: full-reconcile leg fail-closed (the #2484 domain, out
             // of #3766's same-plan-refresh scope). reconcile_status_bindings
             // ran the fallible pre-teardown build; on a non-policy integrity

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1114,6 +1114,141 @@ fn apply_snapshot_same_plan_needs_reconcile_build_failure_rejects_and_keeps_prio
     );
 }
 
+/// #4952 POST-TEARDOWN worker-spawn failure fails closed and does NOT
+/// persist. The same-plan-needs-reconcile leg reconciles the ALREADY
+/// registered binding directly (no replan_queues), so with all mandatory
+/// pins open and a buildable snapshot the reconcile clears the pre-teardown
+/// integrity legs, tears down the old workers, and REACHES the fallible
+/// worker spawn. The per-instance `force_worker_spawn_fail` seam forces that
+/// spawn to return EAGAIN/ENOMEM (a real pthread_create failure is not
+/// provokable in-process), leaving the queue set with NO XSK-bound worker.
+///
+/// The handler MUST: (a) report ok=false with a descriptive error, (b) NOT
+/// persist the broken snapshot as the boot baseline (persist_state stays
+/// false -> the state file is never written), and (c) the coordinator's
+/// `last_reconcile_stage` MUST retain the `spawn_worker_failed:..`
+/// descriptor (NOT `spawned:workers=..`).
+///
+/// Fail-on-revert: before #4952 `bring_up_workers` returned () and swallowed
+/// the spawn error (overwriting the stage with `spawned:..`), so
+/// `afxdp.reconcile` returned Ok, the handler acked ok=true, PERSISTED the
+/// snapshot (the state file appears), and advanced the stored baseline to
+/// gen 2. Every assertion below flips.
+#[test]
+fn post_teardown_spawn_failure_fails_closed_no_persist_4952() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+
+    // Prior snapshot deferred workers -> previous_defer_workers=true makes
+    // same_plan_apply_needs_binding_reconcile return true on the next
+    // (non-defer) same-plan apply. Tunnel-only interface set -> the plan
+    // key is address-independent, so gen-1 and gen-2 are same-plan.
+    let prior = ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 1,
+        fib_generation: 1,
+        generated_at: chrono::Utc::now(),
+        defer_workers: true,
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![tunnel_iface_3789("10.0.0.1/24")],
+        ..ConfigSnapshot::default()
+    };
+
+    // Armed + supported + one runnable binding (registered, ifindex>0) so
+    // the needs-reconcile gate fires AND bring_up plans exactly one worker.
+    let status = ProcessStatus {
+        forwarding_armed: true,
+        capabilities: forwarding_caps(),
+        last_snapshot_generation: 1,
+        last_fib_generation: 1,
+        bindings: vec![BindingStatus {
+            slot: 0,
+            registered: true,
+            ifindex: 10,
+            ..BindingStatus::default()
+        }],
+        ..ProcessStatus::default()
+    };
+
+    let state = Arc::new(Mutex::new(ServerState {
+        status,
+        snapshot: Some(prior),
+        afxdp: afxdp::Coordinator::new(),
+        state_writer: Arc::new(StateWriter::new()),
+    }));
+
+    // Force the single planned worker's spawn to fail on the post-teardown
+    // path (the destructive step the fix guards).
+    state.lock().expect("state").afxdp.force_worker_spawn_fail = 1;
+
+    // New same-plan apply: defer_workers=false, VALID address so the
+    // forwarding build SUCCEEDS and the reconcile reaches the worker spawn.
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 2,
+        fib_generation: 2,
+        generated_at: chrono::Utc::now(),
+        defer_workers: false,
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![tunnel_iface_3789("10.0.0.1/24")],
+        ..ConfigSnapshot::default()
+    });
+
+    let state_file = unique_state_file("spawn_fail_4952");
+    assert!(
+        !std::path::Path::new(&state_file).exists(),
+        "precondition: state file must not exist before the request"
+    );
+
+    let response = run_request_on_file(state.clone(), request, &state_file);
+
+    // (a) fail closed with a non-empty, descriptive error.
+    assert!(
+        !response.ok,
+        "a post-teardown worker-spawn failure must report ok=false"
+    );
+    assert!(
+        !response.error.is_empty() && response.error.contains("worker spawn failed"),
+        "unexpected error: {}",
+        response.error
+    );
+
+    // (b) persist_state was NOT set -> the state file was never written.
+    assert!(
+        !std::path::Path::new(&state_file).exists(),
+        "a post-teardown spawn failure must NOT persist the broken snapshot as the boot baseline"
+    );
+
+    let guard = state.lock().expect("state");
+    // The prior (gen 1, deferred) snapshot is still the boot baseline.
+    assert_eq!(
+        guard.snapshot.as_ref().map(|s| s.generation),
+        Some(1),
+        "the rejected snapshot must not overwrite the persisted baseline"
+    );
+    assert!(
+        guard.snapshot.as_ref().is_some_and(|s| s.defer_workers),
+        "the prior (deferred) snapshot must be restored intact"
+    );
+    assert_eq!(
+        guard.status.last_snapshot_generation, 1,
+        "rejected apply must not bump last_snapshot_generation"
+    );
+    // (c) last_reconcile_stage retains the spawn_worker_failed descriptor.
+    assert!(
+        guard
+            .afxdp
+            .last_reconcile_stage
+            .starts_with("spawn_worker_failed:"),
+        "the spawn-failure stage must be preserved (not overwritten with spawned:..), got {:?}",
+        guard.afxdp.last_reconcile_stage
+    );
+
+    let _ = std::fs::remove_file(&state_file);
+}
+
 // --- apply_snapshot deferred-activation integrity build (#5171) ---------
 
 /// #5171 fail-closed DEFERRED apply — MISSING MANDATORY MAP PIN: a


### PR DESCRIPTION
## Problem

`bring_up_workers` (`userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs`) runs on the **destructive** path — `tear_down` has already stopped the previous workers before it spawns the new ones. A per-worker `spawn_supervised_worker` call (→ `pthread_create`) can return `EAGAIN`/`ENOMEM` under resource exhaustion.

Before this change, the `Err(err) =>` arm only **logged** the failure and recorded an exception, then fell through to unconditionally overwrite `last_reconcile_stage` with `"spawned:workers=.."`. `bring_up_workers` returned `()`, `reconcile` returned `Ok(())`, and `reconcile_status_bindings` → `snapshot.rs::reconcile_status_bindings` acked `ok=true` **and PERSISTED the broken snapshot as the boot baseline**.

Result: a post-teardown spawn failure leaves a queue set with **no XSK-bound worker** — a **silent forwarding outage with no retry**. #3789 only fail-closes the *pre-teardown* integrity/map legs, not this post-teardown spawn failure.

## Fix (fail closed on the destructive path)

- **`bring_up_workers` now returns `Result<(), String>`.** On the FIRST spawn failure it **aborts the remaining launches** (the data plane is already broken; spawning more XSK-bound workers cannot restore forwarding and only widens the resource pressure), **preserves** the `spawn_worker_failed:<id>:<err>` stage (no `spawned:..` overwrite), skips the auxiliary-thread bring-up, and returns the stage.
- **`reconcile` maps it to a new `ReconcileError::WorkerSpawn`** — the *only* variant raised AFTER teardown. The data plane HAS moved; there is no prior-state restore that brings the torn-down workers back, so the handler fails closed on bookkeeping and recovery is a retry/last-good reconcile.
- **`snapshot.rs::apply` special-cases `WorkerSpawn`** on the full-apply and same-plan-`needs_reconcile` legs: `ok=false` + descriptive error, `refresh_status` to the REAL post-teardown per-binding state (does NOT restore `existing_bindings` — the old workers are gone), roll the in-memory baseline back to the prior good snapshot, and return **BEFORE** `persist_state=true`. The already-accepted-snapshot handlers (`binding`/`queue`/`rebind`/`forwarding`, #6134/#6135) already fail closed on any `Err` and surface it unchanged.

### Preflight vs minimal fail-close

This is the **minimal correct fix** (do not persist a known-broken snapshot), **not** a full pre-teardown preflight: a real `pthread_create` cannot be probed without spawning the thread, and the old workers must be torn down first to free the XSK queue bindings the new workers claim. A staged spawn-before-teardown is noted as a **possible follow-up**.

## Tests (fail-on-revert)

A per-instance `#[cfg(test)] force_worker_spawn_fail` seam forces the spawn to return the EAGAIN/ENOMEM error deterministically (a real failure is not provokable in-process).

- `reconcile_post_teardown_worker_spawn_failure_fails_closed_4952` (coordinator) — `reconcile` returns `Err(WorkerSpawn)` and `last_reconcile_stage` retains `spawn_worker_failed:` (not `spawned:`).
- `post_teardown_spawn_failure_fails_closed_no_persist_4952` (handler, via `run_request_on_file` through the real dispatcher) — `ok=false` + non-empty error, the state file is **never written** (persist not set), the prior snapshot baseline is restored, and `last_reconcile_stage` retains `spawn_worker_failed:`.

**Parent-RED verified:** neutralizing the fail-closed propagation makes **both** tests RED (2 failed / 0 passed), target-count 1 each.

**Full Rust suite green:** 4121 passed / 0 failed / 2 ignored. Named test run 3× clean (no flake).

## Docs

Updated `userspace-dp/src/afxdp/coordinator/README.md` (new #4952 bullet in the fail-closed section) and `userspace-dp/src/server/README.md` (the `reconcile_status_bindings` persist/fail-close gotcha).

## Scope

Not HA — unit-provable via spawn-failure injection; no cluster smoke required.

Closes #4952

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRaLHRkzR6vPkQEwyMSXVP
