### PR TITLE
userspace-dp event-stream: cursor-backed write backlog (amortized-linear) (#4974)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -53477,3 +53477,33 @@ top.
   userspace-dp/src/server/tests.rs,
   userspace-dp/src/server/README.md,
   docs/userspace-dataplane-architecture.md
+- **Timestamp**: 2026-07-18
+- **Action**: #4974 — event-stream connected loop: replace the O(n^2)
+  prefix-drain write backlog with a cursor-backed `WriteBacklog`. The old
+  code stored pending socket bytes in a bare `Vec<u8>` and reclaimed each
+  successful short write with `write_buf.drain(..n)`, memmoving the entire
+  remaining suffix to offset 0 every write — O(backlog) per write, so
+  O(backlog^2) total copy work under a slow reader, on the single event
+  I/O thread. New `WriteBacklog` tracks a `start` cursor: `advance(n)`
+  moves it in O(1); the consumed prefix is reclaimed by GEOMETRIC
+  compaction (one copy of the pending suffix once `start >= len/2`), so
+  copy work is amortized O(1)/write and O(total_bytes) overall, and the
+  backing Vec stays within ~2x the pending length. The
+  `WRITE_BACKLOG_MAX_BYTES` cap + pause/backpressure now measure
+  `pending_len()` (unwritten = Vec.len()-start), not the raw Vec length,
+  so the cap does not trip early. Byte order + exactly-once preserved.
+  Added tests: `partial_write_backlog_is_amortized_linear_4974` (asserts
+  compaction copy work <= 3x total bytes; reverting advance to per-write
+  drain(..n) blows the bound RED), `partial_write_backlog_preserves_byte_
+  order_4974`, `pending_len_tracks_unwritten_bytes_not_raw_vec_4974`.
+  Updated the three existing cap tests + two replay_budget drain callers
+  to the WriteBacklog API. Rust suite green; new tests 3x no flake.
+  Parent-RED verified: reverting advance to drain(..n) makes the
+  amortized test RED, target-count 1. NOT HA (local event I/O-thread
+  algorithmics).
+- **File(s)**: userspace-dp/src/event_stream/mod.rs,
+  userspace-dp/src/event_stream/tests/write_backlog.rs,
+  userspace-dp/src/event_stream/tests/mod.rs,
+  userspace-dp/src/event_stream/tests/backpressure.rs,
+  userspace-dp/src/event_stream/tests/replay_budget.rs,
+  userspace-dp/src/event_stream/README.md

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -396,7 +396,7 @@ cluster-scoped.
   channel) in `drain_channel_into_write_buf()`. The cap is checked at the
   top of the drain loop, so the effective bound is `cap + one max
   EventFrame` (≤ 256 B) — the in-flight frame already pulled may carry
-  `write_buf` just past 16 MiB before the drain halts. A wedged daemon
+  the backlog just past 16 MiB before the drain halts. A wedged daemon
   (socket open but not
   reading → `write_buf` writes return `WouldBlock`) would otherwise let
   the I/O thread migrate the whole channel into the heap-backed
@@ -414,6 +414,29 @@ cluster-scoped.
   already-bounded replay buffer, never to `write_buf`. **Invariant: the
   data plane never stalls because a telemetry consumer is slow; a stuck
   consumer degrades telemetry (counted drops), nothing else.**
+- **Cursor-backed write backlog — amortized-linear drain (#4974).** The
+  pending backlog is a `WriteBacklog` (cursor over a `Vec<u8>`), not a
+  bare `Vec`. Each successful short socket write advances a `start`
+  cursor in O(1) (`write_buf.advance(n)`) instead of memmoving the whole
+  remaining suffix to offset 0 (`write_buf.drain(..n)`). Under a slow
+  reader that accepts only a few bytes per write, the old `drain(..n)`
+  was O(backlog) per write → O(backlog²) total copy work on the single
+  event I/O thread during exactly the slow-consumer condition. The
+  consumed prefix is reclaimed by GEOMETRIC compaction — one copy of the
+  (smaller) pending suffix once `start ≥ len/2` — so total compaction
+  work is O(total bytes) and per-write cost is amortized O(1), while the
+  backing `Vec` stays within ~2× the pending length (bounded, distinct
+  from the #2381 unbounded-growth failure). **The `WRITE_BACKLOG_MAX_BYTES`
+  cap and every pause/backpressure decision now measure the UNWRITTEN
+  length (`write_buf.pending_len()` = `Vec.len() − start`), not the raw
+  `Vec` length** — measuring the raw length would trip the cap early and
+  drift the pause/resume accounting because it also counts the
+  reclaimable written prefix. Byte order and exactly-once delivery are
+  unchanged: appends only ever go to the tail and compaction never
+  reorders the pending suffix. Regression gate:
+  `partial_write_backlog_is_amortized_linear_4974` asserts total
+  compaction copy work stays within a linear (3×) bound; reverting
+  `advance` to a per-write `drain(..n)` memmove blows it.
 - **Lossless-demotion fence for session deltas (#2875). RESERVED/DORMANT —
   not wired to the live demotion path; see the codec note above.** A paused
   drain is the stable window the future owner reads before demotion completes

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -177,12 +177,133 @@ const MAX_CONTROL_PAYLOAD_LEN: usize = 0;
 /// stays bounded.
 ///
 /// The cap is checked at the top of the drain loop, before the in-flight frame
-/// is appended, so `write_buf` can reach at most `WRITE_BACKLOG_MAX_BYTES` plus
-/// one already-pulled max `EventFrame` (≤ 256 B) before the drain halts — i.e.
-/// the bound is `cap + one frame`, not a strict 16 MiB. The overshoot is
-/// bounded and accepted (simpler than a pre-reserve check); memory is bounded
-/// either way.
+/// is appended, so the UNWRITTEN backlog can reach at most
+/// `WRITE_BACKLOG_MAX_BYTES` plus one already-pulled max `EventFrame` (≤ 256 B)
+/// before the drain halts — i.e. the bound is `cap + one frame`, not a strict
+/// 16 MiB. The overshoot is bounded and accepted (simpler than a pre-reserve
+/// check); memory is bounded either way.
+///
+/// #4974: the cap and every backpressure decision measure UNWRITTEN bytes
+/// (`WriteBacklog::pending_len()`), not the raw backing-`Vec` length. The
+/// backlog is cursor-backed (`WriteBacklog`): bytes already handed to the
+/// socket sit in a reclaimable prefix and are compacted geometrically, so the
+/// `Vec` can transiently hold up to ~2× the pending length. Accounting on the
+/// raw length would trip the cap early and drift the pause/resume logic.
 const WRITE_BACKLOG_MAX_BYTES: usize = 16 * 1024 * 1024;
+
+/// Cursor-backed pending socket-write backlog for the connected I/O loop.
+///
+/// #4974: the connected loop keeps unwritten socket bytes here between cycles.
+/// A slow reader accepts only a few bytes per `write`, leaving a large suffix
+/// for the next cycle. The original code stored the backlog in a bare `Vec<u8>`
+/// and reclaimed each short write with `write_buf.drain(..n)`, which memmoves
+/// the ENTIRE remaining suffix down to offset 0 on every write — O(backlog) per
+/// write, so O(backlog²) total copy work while a slow consumer nibbles through
+/// a multi-MiB backlog, all on the single event I/O thread during exactly the
+/// slow-consumer condition.
+///
+/// Instead we track a `start` cursor into `buf`: `buf[start..]` is the
+/// unwritten pending suffix, `buf[..start]` is written-and-reclaimable. A
+/// successful write of `n` bytes advances `start` in O(1) (no memmove). The
+/// consumed prefix is reclaimed by GEOMETRIC compaction — a single copy of the
+/// pending suffix to offset 0 only once the prefix reaches half the buffer
+/// (`start >= buf.len()/2`). Because a compaction then copies at most `start`
+/// bytes and resets `start` to 0, total compaction work is bounded by the total
+/// bytes ever written (amortized O(1) per write, O(total_bytes) overall), and
+/// `buf.len()` stays within ~2× the pending length (bounded, not the unbounded
+/// growth #2381 guards against). Byte order and exactly-once delivery are
+/// preserved: appends only ever go to the tail and compaction never reorders
+/// the pending suffix.
+struct WriteBacklog {
+    /// Backing storage. `buf[start..]` is the unwritten pending suffix.
+    buf: Vec<u8>,
+    /// Offset of the first unwritten byte. Bytes below it were already written
+    /// to the socket and are reclaimable by compaction.
+    start: usize,
+    /// #4974: total bytes moved by geometric compaction, so the amortized
+    /// -linear regression gate can assert bounded copy work. Test-only.
+    #[cfg(test)]
+    compacted_bytes: usize,
+}
+
+impl WriteBacklog {
+    fn with_capacity(cap: usize) -> Self {
+        Self {
+            buf: Vec::with_capacity(cap),
+            start: 0,
+            #[cfg(test)]
+            compacted_bytes: 0,
+        }
+    }
+
+    /// Unwritten bytes still owed to the socket. This is the value the
+    /// `WRITE_BACKLOG_MAX_BYTES` cap and the pause/backpressure logic use — NOT
+    /// the raw `Vec` length, which also counts the reclaimable written prefix.
+    #[inline]
+    fn pending_len(&self) -> usize {
+        self.buf.len() - self.start
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.start >= self.buf.len()
+    }
+
+    /// The unwritten suffix to hand to the next socket `write`.
+    #[inline]
+    fn pending(&self) -> &[u8] {
+        &self.buf[self.start..]
+    }
+
+    /// Append freshly produced frame bytes to the pending tail. Reclaims the
+    /// consumed prefix first (geometrically) so the `Vec` tracks the pending
+    /// length rather than the lifetime sum of everything ever queued.
+    fn extend_from_slice(&mut self, bytes: &[u8]) {
+        self.compact_if_needed();
+        self.buf.extend_from_slice(bytes);
+    }
+
+    /// Record a successful socket write of `n` bytes. Advances the cursor in
+    /// O(1); when the backlog fully drains it resets without a copy, otherwise
+    /// it compacts geometrically. Replaces the O(backlog) `drain(..n)` memmove.
+    fn advance(&mut self, n: usize) {
+        self.start += n;
+        debug_assert!(self.start <= self.buf.len(), "write reported more than pending");
+        if self.start >= self.buf.len() {
+            // Fully drained -- reset to empty without moving any bytes.
+            self.buf.clear();
+            self.start = 0;
+        } else {
+            self.compact_if_needed();
+        }
+    }
+
+    /// Geometric compaction trigger: reclaim the consumed prefix only once it
+    /// reaches half the buffer. At that point the pending suffix being copied is
+    /// no larger than the prefix being discarded, so the copy cost is charged to
+    /// already-consumed bytes and total compaction work stays O(total_bytes).
+    #[inline]
+    fn compact_if_needed(&mut self) {
+        if self.start != 0 && self.start >= self.buf.len() / 2 {
+            self.compact();
+        }
+    }
+
+    /// Move the pending suffix down to offset 0 and drop the consumed prefix.
+    fn compact(&mut self) {
+        if self.start == 0 {
+            return;
+        }
+        let pending = self.buf.len() - self.start;
+        self.buf.copy_within(self.start.., 0);
+        self.buf.truncate(pending);
+        self.start = 0;
+        #[cfg(test)]
+        {
+            self.compacted_bytes += pending;
+        }
+    }
+}
 
 /// Upper bound for explicit lossless queueing operations such as full
 /// session export on connect. Normal packet-path delta export remains
@@ -1244,7 +1365,7 @@ fn run_connected_loop(
 ) -> bool {
     use std::io::{Read, Write};
 
-    let mut write_buf: Vec<u8> = Vec::with_capacity(4096);
+    let mut write_buf = WriteBacklog::with_capacity(4096);
     let mut tmp_read = [0u8; 64];
     let mut idle_cycles = 0u32;
     let mut last_write = Instant::now();
@@ -1269,16 +1390,13 @@ fn run_connected_loop(
         }
         let drained_any = drain.drained_any;
 
-        // Write buffered frames to socket
+        // Write buffered frames to socket. On a partial (short) write we advance
+        // the backlog cursor in O(1) instead of memmoving the whole remaining
+        // suffix to offset 0 on every write (the #4974 O(n^2) drain).
         if !write_buf.is_empty() {
-            match (&*stream).write(&write_buf) {
+            match (&*stream).write(write_buf.pending()) {
                 Ok(n) => {
-                    if n < write_buf.len() {
-                        // Partial write -- keep remainder
-                        write_buf.drain(..n);
-                    } else {
-                        write_buf.clear();
-                    }
+                    write_buf.advance(n);
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                     // Socket buffer full, keep write_buf for next cycle
@@ -1684,19 +1802,25 @@ struct DrainOutcome {
 /// Drain the bounded channel into `replay_buf` and (when not paused) into the
 /// pending socket-write backlog `write_buf`.
 ///
-/// The drain halts once `write_buf` reaches `WRITE_BACKLOG_MAX_BYTES` (#2381).
-/// Without that cap a wedged daemon (socket open but not reading → the socket
-/// `write` returns `WouldBlock`) lets this loop migrate the entire bounded
-/// channel into the heap-backed `write_buf` every cycle; the channel then
-/// refills from worker `try_send`, the loop drains it again, and `write_buf`
-/// grows without bound → helper OOM / allocator pressure on the forwarding
-/// plane. Halting the drain leaves the frames in the bounded channel, which
-/// becomes the real backpressure surface: worker `try_send` then fails and
-/// increments the existing `frames_dropped` / per-kind `queue_full` counters
-/// (oldest queued/replay frames are preserved; newest producer events are
-/// shed — keeping RT_FLOW current). Each pass that hits the cap bumps
-/// `frames_write_stalled` so a wedged consumer is observable rather than a
-/// silent OOM.
+/// The drain halts once the UNWRITTEN backlog (`write_buf.pending_len()`, #4974)
+/// reaches `WRITE_BACKLOG_MAX_BYTES` (#2381). Without that cap a wedged daemon
+/// (socket open but not reading → the socket `write` returns `WouldBlock`) lets
+/// this loop migrate the entire bounded channel into the heap-backed `write_buf`
+/// every cycle; the channel then refills from worker `try_send`, the loop drains
+/// it again, and `write_buf` grows without bound → helper OOM / allocator
+/// pressure on the forwarding plane. Halting the drain leaves the frames in the
+/// bounded channel, which becomes the real backpressure surface: worker
+/// `try_send` then fails and increments the existing `frames_dropped` / per-kind
+/// `queue_full` counters (oldest queued/replay frames are preserved; newest
+/// producer events are shed — keeping RT_FLOW current). Each pass that hits the
+/// cap bumps `frames_write_stalled` so a wedged consumer is observable rather
+/// than a silent OOM.
+///
+/// The cap is measured on `pending_len()` (unwritten bytes), not the raw
+/// `WriteBacklog` `Vec` length: the cursor-backed backlog keeps a reclaimable
+/// prefix of already-written bytes, so raw length can sit at ~2× pending until
+/// the next geometric compaction. Measuring raw length would trip the cap early
+/// and drift the pause/resume accounting.
 ///
 /// The cap does not apply while paused: paused frames are consumed into the
 /// already-bounded replay buffer only, never into `write_buf`, so they cannot
@@ -1705,13 +1829,15 @@ fn drain_channel_into_write_buf(
     rx: &mpsc::Receiver<EventFrame>,
     shared: &Arc<EventStreamShared>,
     replay_buf: &mut VecDeque<EventFrame>,
-    write_buf: &mut Vec<u8>,
+    write_buf: &mut WriteBacklog,
     paused: bool,
     pending_resync: &mut Option<EventFrame>,
 ) -> DrainOutcome {
     let mut drained_any = false;
     loop {
-        if !paused && write_buf.len() >= WRITE_BACKLOG_MAX_BYTES {
+        // #4974: the cap measures UNWRITTEN bytes (`pending_len`), not the raw
+        // backing-Vec length, which also counts the reclaimable written prefix.
+        if !paused && write_buf.pending_len() >= WRITE_BACKLOG_MAX_BYTES {
             shared.frames_write_stalled.fetch_add(1, Ordering::Relaxed);
             return DrainOutcome {
                 drained_any,
@@ -1780,7 +1906,7 @@ fn drain_channel_into_write_buf(
 fn flush_pending_resync(
     shared: &Arc<EventStreamShared>,
     replay_buf: &mut VecDeque<EventFrame>,
-    write_buf: &mut Vec<u8>,
+    write_buf: &mut WriteBacklog,
     paused: bool,
     pending_resync: &mut Option<EventFrame>,
 ) -> bool {

--- a/userspace-dp/src/event_stream/tests/backpressure.rs
+++ b/userspace-dp/src/event_stream/tests/backpressure.rs
@@ -85,7 +85,8 @@ fn write_backlog_cap_halts_drain_and_counts_stall() {
 
     // Simulate a wedged consumer: the backlog is already at the cap because
     // prior socket writes returned WouldBlock.
-    let mut write_buf: Vec<u8> = vec![0u8; WRITE_BACKLOG_MAX_BYTES];
+    let mut write_buf = WriteBacklog::with_capacity(WRITE_BACKLOG_MAX_BYTES);
+    write_buf.extend_from_slice(&vec![0u8; WRITE_BACKLOG_MAX_BYTES]);
 
     let outcome = drain_channel_into_write_buf(&rx, &shared, &mut replay_buf, &mut write_buf, false, &mut None);
 
@@ -93,7 +94,7 @@ fn write_backlog_cap_halts_drain_and_counts_stall() {
     assert!(!outcome.disconnected);
     assert!(!outcome.drained_any, "no frame may move into a full backlog");
     assert_eq!(
-        write_buf.len(),
+        write_buf.pending_len(),
         WRITE_BACKLOG_MAX_BYTES,
         "backlog must not grow past the cap"
     );
@@ -121,7 +122,8 @@ fn write_backlog_stall_makes_channel_the_backpressure_surface() {
         shared: shared.clone(),
     };
     let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
-    let mut write_buf: Vec<u8> = vec![0u8; WRITE_BACKLOG_MAX_BYTES];
+    let mut write_buf = WriteBacklog::with_capacity(WRITE_BACKLOG_MAX_BYTES);
+    write_buf.extend_from_slice(&vec![0u8; WRITE_BACKLOG_MAX_BYTES]);
 
     // Fill the channel to capacity.
     for seq in 1..=capacity as u64 {
@@ -155,7 +157,8 @@ fn paused_drain_ignores_backlog_cap_and_never_stalls() {
     let (tx, rx) = mpsc::sync_channel::<EventFrame>(8);
     let shared = Arc::new(EventStreamShared::new());
     let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
-    let mut write_buf: Vec<u8> = vec![0u8; WRITE_BACKLOG_MAX_BYTES];
+    let mut write_buf = WriteBacklog::with_capacity(WRITE_BACKLOG_MAX_BYTES);
+    write_buf.extend_from_slice(&vec![0u8; WRITE_BACKLOG_MAX_BYTES]);
 
     for seq in 1..=3u64 {
         tx.send(EventFrame::encode_drain_complete(seq))
@@ -166,7 +169,7 @@ fn paused_drain_ignores_backlog_cap_and_never_stalls() {
     assert!(!outcome.stalled, "paused drain must not stall on the cap");
     assert!(outcome.drained_any);
     assert_eq!(
-        write_buf.len(),
+        write_buf.pending_len(),
         WRITE_BACKLOG_MAX_BYTES,
         "paused frames must not be added to the write backlog"
     );

--- a/userspace-dp/src/event_stream/tests/mod.rs
+++ b/userspace-dp/src/event_stream/tests/mod.rs
@@ -131,3 +131,4 @@ mod replay_budget;
 mod backpressure;
 mod control_frames;
 mod drain;
+mod write_backlog;

--- a/userspace-dp/src/event_stream/tests/replay_budget.rs
+++ b/userspace-dp/src/event_stream/tests/replay_budget.rs
@@ -116,7 +116,7 @@ fn test_replay_gap_at_zero_ack_sends_full_resync() {
     // Drain an empty channel: the parked barrier flushes into the write path in
     // order (it is the current max seq) and reaches the socket.
     let (_tx, rx) = mpsc::sync_channel::<EventFrame>(8);
-    let mut write_buf: Vec<u8> = Vec::new();
+    let mut write_buf = WriteBacklog::with_capacity(4096);
     let outcome = drain_channel_into_write_buf(
         &rx,
         &shared,
@@ -130,7 +130,9 @@ fn test_replay_gap_at_zero_ack_sends_full_resync() {
     (&helper_side)
         .set_nonblocking(false)
         .expect("blocking for the write");
-    (&helper_side).write_all(&write_buf).expect("write barrier");
+    (&helper_side)
+        .write_all(write_buf.pending())
+        .expect("write barrier");
 
     let mut hdr = [0u8; FRAME_HEADER_SIZE];
     daemon_side.read_exact(&mut hdr).expect("full resync frame");
@@ -191,7 +193,7 @@ fn test_full_resync_orders_after_channel_backlog_5267() {
     // Drain the backlog. Under the fix the drain merges the parked barrier LAST,
     // so write_buf holds 11,12,13,14 in order; under a revert the barrier is not
     // parked and write_buf holds only 11,12,13 (14 is already on the socket).
-    let mut write_buf: Vec<u8> = Vec::new();
+    let mut write_buf = WriteBacklog::with_capacity(4096);
     let _ = drain_channel_into_write_buf(
         &rx,
         &shared,
@@ -210,7 +212,9 @@ fn test_full_resync_orders_after_channel_backlog_5267() {
     (&helper_side)
         .set_nonblocking(false)
         .expect("blocking for the write");
-    (&helper_side).write_all(&write_buf).expect("write frames");
+    (&helper_side)
+        .write_all(write_buf.pending())
+        .expect("write frames");
 
     let mut wire: Vec<(u8, u64)> = Vec::new();
     for _ in 0..4 {

--- a/userspace-dp/src/event_stream/tests/write_backlog.rs
+++ b/userspace-dp/src/event_stream/tests/write_backlog.rs
@@ -1,0 +1,150 @@
+// #4974: cursor-backed pending socket-write backlog (`WriteBacklog`).
+//
+// The connected I/O loop stores unwritten socket bytes in `WriteBacklog`
+// between cycles. A slow reader accepts only a few bytes per `write`, leaving a
+// large suffix for the next cycle. The pre-#4974 code kept the backlog in a
+// bare `Vec<u8>` and reclaimed each short write with `write_buf.drain(..n)`,
+// which memmoves the ENTIRE remaining suffix down to offset 0 on every write —
+// O(backlog) per write, O(backlog^2) total copy work while a slow consumer
+// nibbles a multi-MiB backlog. The cursor-backed backlog advances a start
+// index in O(1) and reclaims the consumed prefix by GEOMETRIC compaction, so
+// total compaction copy work is bounded LINEARLY by the bytes ever queued.
+
+use super::*;
+
+/// Regression gate: driving thousands of small partial writes through a large
+/// backlog must keep total compaction copy work within a LINEAR bound. The
+/// pre-#4974 per-write `drain(..n)` memmove is O(backlog^2) and blows the bound
+/// by orders of magnitude, so reverting `WriteBacklog::advance` to a per-write
+/// full memmove turns THIS test RED (target-count 1).
+#[test]
+fn partial_write_backlog_is_amortized_linear_4974() {
+    let mut backlog = WriteBacklog::with_capacity(4096);
+
+    // A representative event-frame worth of bytes.
+    let frame = vec![0xABu8; 200];
+    // The slow reader accepts only a small, fixed chunk per write cycle.
+    const CHUNK: usize = 128;
+
+    let mut total_appended: usize = 0;
+
+    // Preload a large backlog so the suffix a per-write drain(..n) would memmove
+    // is big (~1.2 MiB). start stays 0 here, so no compaction fires yet.
+    for _ in 0..6_000 {
+        backlog.extend_from_slice(&frame);
+        total_appended += frame.len();
+    }
+
+    // Nibble the backlog down in many small partial writes while a slow producer
+    // keeps appending — the connected loop under a persistently slow reader.
+    let mut writes = 0u64;
+    let mut appends_left = 3_000u32;
+    while !backlog.is_empty() {
+        let n = CHUNK.min(backlog.pending_len());
+        backlog.advance(n);
+        writes += 1;
+        if appends_left > 0 && writes % 4 == 0 {
+            backlog.extend_from_slice(&frame);
+            total_appended += frame.len();
+            appends_left -= 1;
+        }
+    }
+
+    assert!(
+        writes > 5_000,
+        "test must exercise many partial writes, got {writes}"
+    );
+    // Geometric compaction MUST have run (otherwise the backlog would have grown
+    // the Vec without reclaiming the written prefix).
+    assert!(
+        backlog.compacted_bytes > 0,
+        "geometric compaction must have reclaimed the consumed prefix"
+    );
+
+    // Linear bound: geometric compaction copies at most ~1x the total bytes ever
+    // queued; assert a generous 3x ceiling. A per-write drain(..n) memmove copies
+    // a multi-KiB..MiB suffix on each of the >5000 writes and exceeds this by
+    // orders of magnitude.
+    let bound = total_appended.saturating_mul(3);
+    assert!(
+        backlog.compacted_bytes <= bound,
+        "compaction copy work {} must stay within the linear bound {} (3x total \
+         {}); a per-write drain(..n) memmove blows this",
+        backlog.compacted_bytes,
+        bound,
+        total_appended,
+    );
+}
+
+/// Correctness: bytes handed to the socket (the `pending()` prefixes consumed by
+/// `advance`) must equal the appended input exactly — in order, none dropped,
+/// duplicated, or reordered — across interleaved appends and short partial
+/// writes that exercise compaction while the backlog both grows and shrinks.
+#[test]
+fn partial_write_backlog_preserves_byte_order_4974() {
+    let mut backlog = WriteBacklog::with_capacity(16);
+    let mut produced: Vec<u8> = Vec::new();
+    let mut consumed: Vec<u8> = Vec::new();
+
+    let mut next: u32 = 0;
+    for round in 0..2_000u32 {
+        // Append 1..=3 "frames" of unique, monotonically increasing bytes.
+        let n_frames = (round % 3) + 1;
+        for _ in 0..n_frames {
+            let mut frame = [0u8; 7];
+            for b in frame.iter_mut() {
+                *b = (next & 0xFF) as u8;
+                next = next.wrapping_add(1);
+            }
+            backlog.extend_from_slice(&frame);
+            produced.extend_from_slice(&frame);
+        }
+        // Consume up to 5 bytes via a short write (the slow-reader partial write).
+        if !backlog.is_empty() {
+            let take = 5.min(backlog.pending_len());
+            consumed.extend_from_slice(&backlog.pending()[..take]);
+            backlog.advance(take);
+        }
+    }
+    // Drain whatever remains.
+    while !backlog.is_empty() {
+        let take = 5.min(backlog.pending_len());
+        consumed.extend_from_slice(&backlog.pending()[..take]);
+        backlog.advance(take);
+    }
+
+    assert_eq!(
+        consumed.len(),
+        produced.len(),
+        "no bytes may be lost or duplicated"
+    );
+    assert_eq!(consumed, produced, "bytes must emerge in order, unmodified");
+    assert!(backlog.is_empty(), "backlog fully drained");
+    assert_eq!(backlog.pending_len(), 0, "pending length is zero when empty");
+}
+
+/// `pending_len()` (unwritten bytes), not the raw Vec length, is the value the
+/// `WRITE_BACKLOG_MAX_BYTES` cap measures. After a partial write advances the
+/// cursor, pending_len must drop by exactly the written amount even though the
+/// consumed prefix is still physically resident until the next compaction.
+#[test]
+fn pending_len_tracks_unwritten_bytes_not_raw_vec_4974() {
+    let mut backlog = WriteBacklog::with_capacity(64);
+    backlog.extend_from_slice(&[1u8; 100]);
+    assert_eq!(backlog.pending_len(), 100);
+
+    // A short write of 10 bytes: cursor advances, 10 fewer unwritten bytes. The
+    // written prefix is not yet reclaimed, but the cap-facing length must be 90.
+    backlog.advance(10);
+    assert_eq!(
+        backlog.pending_len(),
+        90,
+        "cap accounting must count only unwritten bytes"
+    );
+    assert!(!backlog.is_empty());
+
+    // Fully drain: pending_len falls to 0 and the backlog resets without a copy.
+    backlog.advance(90);
+    assert_eq!(backlog.pending_len(), 0);
+    assert!(backlog.is_empty());
+}


### PR DESCRIPTION
## Problem

`userspace-dp/src/event_stream/mod.rs` — the connected event I/O loop stored
pending socket bytes in a bare `Vec<u8>` (`write_buf`, cap
`WRITE_BACKLOG_MAX_BYTES` = 16 MiB) and reclaimed each successful short write
with `write_buf.drain(..n)`. `drain(..n)` **memmoves the entire remaining
suffix down to offset 0 on every write**. A slow reader that repeatedly accepts
only a few bytes per `write` therefore causes O(backlog) copy work per write →
**O(backlog²) total copy work** while nibbling a multi-MiB backlog, all on the
single event I/O thread, during exactly the slow-consumer condition.

Distinct from #2381 (CLOSED — that added the byte cap); this fixes the
algorithmic cost **inside** the cap.

## Fix

Replace the raw `Vec` with a cursor-backed `WriteBacklog`:

- `buf[start..]` is the unwritten pending suffix; `buf[..start]` is
  written-and-reclaimable.
- A successful write advances `start` in **O(1)** (`advance(n)`) instead of
  memmoving — mirrors the existing `written`-cursor pattern at the other write
  site (`replay/drain`).
- The consumed prefix is reclaimed by **geometric compaction**: one copy of the
  (smaller) pending suffix, only once `start ≥ len/2`. Total compaction work is
  **O(total_bytes)**, per-write cost is amortized **O(1)**, and the backing
  `Vec` stays within ~2× the pending length (bounded — distinct from the #2381
  unbounded-growth failure).
- **Cap accounting now measures unwritten bytes.** The cap check and the
  pause/backpressure logic use `write_buf.pending_len()` (= `Vec.len() − start`),
  not the raw `Vec` length (which also counts the reclaimable written prefix).
  Measuring the raw length would trip the cap early and drift the pause/resume
  accounting.
- Byte order and exactly-once delivery preserved: appends only ever go to the
  tail; compaction never reorders the pending suffix.

Single-threaded-simple (event I/O thread); no new locks.

## Tests

- **`partial_write_backlog_is_amortized_linear_4974`** (regression gate) — drives
  >5000 small partial writes into a large backlog and asserts total compaction
  copy work stays within a **linear (3×) bound**. Instruments a `#[cfg(test)]`
  `compacted_bytes` counter. Reverting `advance` to a per-write `drain(..n)`
  memmove blows the bound by ~1677× → **RED, target-count 1** (87 pass / 1 fail
  in `event_stream`, no collateral).
- **`partial_write_backlog_preserves_byte_order_4974`** — interleaved appends +
  short writes; bytes emerge in order, none lost/duplicated/reordered; backlog
  empties.
- **`pending_len_tracks_unwritten_bytes_not_raw_vec_4974`** — cap-facing length
  counts only unwritten bytes after a partial write.
- The three existing cap/pause tests + two `replay_budget` drain callers move to
  the `WriteBacklog` API (cap now asserted via `pending_len()`).

## Validation

- Full Rust suite green: **4032 passed / 0 failed / 2 ignored** (main binary),
  4123 across all test binaries.
- New tests 3× — no flake.
- Parent-RED verified: reverting `advance` → `drain(..n)` fails exactly the
  amortized test, target-count 1.
- **Not HA** — local event I/O-thread algorithmics, unit-provable. (A wedged
  reader can force an HA session resync as a *downstream symptom*, but the fix
  itself is local backlog I/O; no cluster smoke needed.)

## Docs

`event_stream/mod.rs` module doc + `event_stream/README.md` updated for the
cursor-backed backlog, amortized-linear cost, and the unwritten-length cap
semantics.

Closes #4974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Voe9w1kac9vLVhoAiTgri4
