### PR TITLE
userspace-dp NAT: feed-resolve nested address-set members in match address-name (#4925)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-18 — #4925: NAT feed-resolves nested address-set members in match address-name
+
+- **Timestamp**: 2026-07-18 (fix/4925-nat-feed-nested-set)
+- **Action**: Closed the fail-closed parity gap where a NAT `match
+  {source,destination}-address-name` reference to an address-SET whose MEMBER
+  is a dynamic-address feed resolved to NO feed prefixes (static
+  `resolveUserspaceAddressBookEntry` never consulted feedOverlay for nested
+  members and poisoned the whole set on the unresolvable feed member;
+  feedOverlay is keyed by the direct feed name, not the containing set). Rewired
+  `resolveNATAddressNamePrefixes` to reuse the SAME feed-aware recursive
+  `expandBookNameRecursive` the security-policy path uses (#3294 SSOT), sorting +
+  deduping the union to keep the static resolver's output shape (the #2416
+  exact-slice pins stay byte-identical). Fail-closed preserved: an empty set /
+  a set whose only member is a genuinely unresolvable non-feed token still
+  yields no match (raw book-name token, unmatchable), never widening to
+  match-any. Added fail-on-revert tests
+  `Test_nat_source_address_name_set_with_feed_member_resolved_4925` /
+  `Test_nat_dest_address_name_set_with_feed_member_resolved_4925` (SNAT+DNAT,
+  source+destination, feed-only AND mixed static+feed sets) plus a fail-closed
+  pin `Test_nat_address_name_set_unresolvable_nonfeed_member_fails_closed_4925`.
+  Validation: full pkg/dataplane/userspace suite green; 4925 tests 3x no flake;
+  gofmt + go vet clean. Parent-RED: reverting the resolver to the static
+  expander makes exactly the two "resolved" tests RED (target-count 2, 0
+  collateral) while the fail-closed pin + all pre-existing #3303/#3425/#2416
+  tests stay green. NOT HA (config compilation; unit-provable, no cluster smoke).
+- **File(s)**: pkg/dataplane/userspace/nat.go,
+  pkg/dataplane/userspace/nat_feed_nested_set_4925_test.go,
+  docs/feature-gaps.md
+
 ## 2026-07-18 — #6137 fold: scheduler fail-closed honest docs + gauge SSOT wiring + gauge test (#5669)
 
 - **Timestamp**: 2026-07-18 (fix/5669-scheduler-failopen-bound)

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -154,8 +154,16 @@ feed-backed binding now merges that member's live feed prefixes into the set's
 address-book row (the feed-aware `expandBookNameRecursive`) — a `deny
 <set-containing-a-feed>` enforces the feed portion instead of under-denying it,
 and a DIRECT feed reference now also COMMITS under strict validation (the #2008
-`bookNames` one-liner). The NAT path's recursive (feed-member-in-an-address-set)
-resolution remains a tracked residual (it was deliberately out of #3294 scope).
+`bookNames` one-liner). #4925 closes the last piece of this parity: the NAT
+path's recursive (feed-member-in-an-address-set) case is no longer a residual —
+`resolveNATAddressNamePrefixes` now resolves a NAT `match
+source-address-name` / `match destination-address-name` reference through the
+SAME `expandBookNameRecursive` expander, so a NAT rule scoped to an address-SET
+whose member is a feed (feed-only OR mixed static+feed) resolves that nested
+member's live feed prefixes exactly as the policy path does. Fail-closed is
+preserved: a set whose only member is a genuinely unresolvable non-feed token
+still yields no match (the raw book-name token keeps the constraint non-empty
+and unmatchable) rather than widening to match-any.
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -1,6 +1,7 @@
 package userspace
 
 import (
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,56 +25,64 @@ func natCounterID(ids map[string]uint32, natType, ruleSet, rule string) uint32 {
 }
 
 // resolveNATAddressNamePrefixes resolves a NAT `match {source,destination}-
-// address-name` reference into concrete prefixes, unioning the static global
-// address-book expansion (resolveUserspaceAddressBookEntry) with the live
-// dynamic-address feed overlay (#2049 / #3303). feedOverlay maps a
+// address-name` reference into concrete prefixes using the SAME feed-aware
+// recursive address-book expander the security-policy path uses
+// (expandBookNameRecursive, policies_addrbook.go). feedOverlay maps a
 // `security dynamic-address address-name ... profile <feed>` binding to its
 // live feed-backed CIDR strings (resolved by the daemon from
 // feeds.Manager.SnapshotForBindings).
 //
-// Before #3303 the NAT snapshot builders never received feedOverlay, so a NAT
-// rule scoped to a feed-backed address-name resolved STATIC-ONLY and matched
-// nothing on live feed content — contradicting the docs claim that feeds are
-// enforced via "policy/NAT address-name bindings". This brings NAT into line
-// with the policy path (buildAddressBookTableWithFeeds), which also merges
-// feedOverlay[name] into a name's content.
+// The expander merges feedOverlay at the top level AND at every nested
+// address-set MEMBER, so one operator-authored address object resolves to the
+// same prefixes across NAT and policy:
+//   - a DIRECT `match ...-address-name <feed-name>` reference resolves its live
+//     feed prefixes (the #3303 NAT-side gap),
+//   - a reference to an address-SET whose member is feed-backed now resolves the
+//     nested member's feed prefixes too (#4925) — feed-only members AND mixed
+//     static+feed sets,
+//   - a name that is BOTH a static address and a feed binding accumulates both.
 //
-// It is NOT a byte-for-byte mirror of that path: the policy builder
-// family-splits the feed CIDRs and re-sorts/dedups across the static+feed union
-// (it must, to assign a content-hash ID), whereas this helper appends the feed
-// strings to the prefix list directly. That difference is functionally inert —
-// feeds.Manager.SnapshotForBindings already returns the overlay CIDRs sorted
-// and deduped, and the NAT consumer treats the list as an unordered prefix set
-// (duplicates contribute no extra table entry, ordering is irrelevant) — so no
-// re-dedup or family-split is needed here.
+// Before #4925 this helper called the STATIC resolveUserspaceAddressBookEntry
+// expander, which never consulted feedOverlay for nested members and POISONED
+// the whole set on an unresolvable feed member (feedOverlay is keyed by the
+// direct feed name, e.g. "bad-feed", NOT by the containing set "bad-set"). A NAT
+// rule scoped to a set with a feed member therefore resolved to no prefixes and
+// silently matched nothing — diverging from the feed-aware security-policy path
+// (#3294 closed the nested-member case there via expandBookNameRecursive; the
+// NAT path was left as a tracked residual). #4925 reuses that same SSOT expander
+// so the divergence is gone.
 //
-// The recursive case — an address-SET whose member is feed-backed — is NOT
-// resolved here (the static resolveUserspaceAddressBookEntry expander poisons
-// the whole set on an unresolvable feed member and never consults the overlay).
-// #3294 closed this for the SECURITY-POLICY path (the feed-aware
-// expandBookNameRecursive now merges nested feed members into the policy
-// address-book row), but the NAT path was deliberately left out of #3294 scope
-// (the converged plan, constraint 5 / open-question 4) and remains a tracked
-// residual. A DIRECT `match ...-address-name <feed-name>` reference is fully
-// resolved here, which was the #3303 NAT-side gap.
+// Fail-closed is preserved. A set with NO resolvable member (an empty set, or a
+// set whose only member is a genuinely unresolvable NON-feed token) yields NO
+// prefixes here; the append helpers then keep the constraint non-empty with the
+// raw book-name token so the rule matches NOTHING — it never widens to match-any.
+//
+// The output is sorted + deduped to match the static resolver's shape (so the
+// already-green #2416 exact-slice pins stay byte-identical); the NAT consumer
+// treats the list as an unordered prefix set (duplicates contribute no extra
+// table entry, ordering is irrelevant), so this canonicalization is inert.
 func resolveNATAddressNamePrefixes(cfg *config.Config, feedOverlay map[string][]string, name string) []string {
-	var out []string
-	if values, ok := resolveUserspaceAddressBookEntry(cfg, name); ok {
-		out = append(out, values...)
+	if cfg == nil || name == "" {
+		return nil
 	}
-	if feeds := feedOverlay[name]; len(feeds) > 0 {
-		out = append(out, feeds...)
+	visited := make(map[string]bool)
+	out := expandBookNameRecursive(cfg.Security.AddressBook, feedOverlay, name, visited, 0)
+	if len(out) == 0 {
+		return nil
 	}
-	return out
+	sort.Strings(out)
+	return slices.Compact(out)
 }
 
 // appendNATSourceAddressName resolves a NAT rule's `match source-address-name
 // <book-entry>` into concrete source prefixes and appends them to the rule's
 // source list (#2416). It reuses resolveNATAddressNamePrefixes — the same
-// static-book expander the security-policy snapshot path uses, now unioned with
-// the dynamic-address feed overlay (#3303) — so a name-scoped NAT rule carries
-// the entry's prefixes (static AND feed-backed) into the #2394 source
-// constraint instead of publishing an empty (match-any) source list.
+// feed-aware recursive expander the security-policy snapshot path uses
+// (expandBookNameRecursive), which unions the static address book with the
+// dynamic-address feed overlay at the top level AND at nested address-set
+// members (#3303 direct feed, #4925 nested-set feed member) — so a name-scoped
+// NAT rule carries the entry's prefixes (static AND feed-backed) into the #2394
+// source constraint instead of publishing an empty (match-any) source list.
 //
 // Fail-closed on an unknown / unresolvable name: the raw token is appended so
 // the source list stays NON-EMPTY (source_constrained stays true on the Rust
@@ -98,9 +107,11 @@ func appendNATSourceAddressName(cfg *config.Config, feedOverlay map[string][]str
 // appends them to the rule's destination list (#3229). It is the destination
 // twin of appendNATSourceAddressName and shares the same expander
 // (resolveNATAddressNamePrefixes) the security-policy and source-address-name
-// paths use — static address book unioned with the dynamic-address feed overlay
-// (#3303) — so a name-scoped destination matches the same prefixes a literal
-// `match destination-address` would, including feed-backed members.
+// paths use — the feed-aware recursive expandBookNameRecursive, static address
+// book unioned with the dynamic-address feed overlay at the top level and at
+// nested address-set members (#3303 direct feed, #4925 nested-set feed member) —
+// so a name-scoped destination matches the same prefixes a literal `match
+// destination-address` would, including feed-backed members nested in a set.
 //
 // Fail-closed on an unknown / unresolvable name: the raw token is appended so
 // the destination list stays NON-EMPTY (the rule does not collapse to no

--- a/pkg/dataplane/userspace/nat_feed_nested_set_4925_test.go
+++ b/pkg/dataplane/userspace/nat_feed_nested_set_4925_test.go
@@ -1,0 +1,330 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #4925: a NAT `match {source,destination}-address-name` reference to an
+// address-SET whose MEMBER is a dynamic-address feed must resolve the nested
+// member's live feed overlay prefixes — closing the fail-closed parity gap with
+// the security-policy path, which has been feed-aware for nested set members
+// since #3294 (expandBookNameRecursive). Before #4925 the NAT resolver called
+// the STATIC resolveUserspaceAddressBookEntry expander, which never consulted
+// feedOverlay for nested members and (crucially) keyed the overlay by the direct
+// feed name, not by the containing set — so a `match source-address-name
+// bad-set` where bad-set contains feed member bad-feed resolved to NO feed
+// prefixes and the rule silently matched nothing.
+//
+// These are the fail-on-revert pins. Reverting resolveNATAddressNamePrefixes to
+// the static resolveUserspaceAddressBookEntry + direct feedOverlay[name] lookup
+// makes every "must resolve feed prefixes" assertion below RED:
+//   - the static expander poisons bad-set on the unresolvable feed member,
+//   - feedOverlay["bad-set"] is empty (the overlay is keyed by "bad-feed"),
+//   - so the SNAT source/dest constraint falls back to the raw "bad-set" token
+//     (matches nothing) and the DNAT rule installs no table row.
+//
+// The fail-closed cases (a set whose only member is a genuinely unresolvable
+// NON-feed token) must STILL yield no match — the fix must not turn a
+// fail-closed miss into a fail-open match-anything.
+
+// feedNestedSetAddressBook builds an address book with:
+//   - "feed-only-set": an address-set whose ONLY member is the feed binding
+//     "bad-feed" (no static content); the feed prefixes reach the set only via
+//     the nested-member overlay merge.
+//   - "mixed-set": an address-set with a static member ("static-a" =
+//     10.20.0.0/16) AND the feed binding "bad-feed"; both must resolve.
+//   - "dead-set": an address-set whose only member is "ghost", a name that is
+//     neither a static address, nor a set, nor a feed — the fail-closed case.
+func feedNestedSetAddressBook() *config.AddressBook {
+	return &config.AddressBook{
+		Addresses: map[string]*config.Address{
+			"static-a": {Name: "static-a", Value: "10.20.0.0/16"},
+		},
+		AddressSets: map[string]*config.AddressSet{
+			"feed-only-set": {Name: "feed-only-set", Addresses: []string{"bad-feed"}},
+			"mixed-set":     {Name: "mixed-set", Addresses: []string{"static-a", "bad-feed"}},
+			"dead-set":      {Name: "dead-set", Addresses: []string{"ghost"}},
+		},
+	}
+}
+
+// nat_source_address_name_set_with_feed_member_resolved_4925 drives the full
+// public snapshot path for BOTH a feed-only set and a mixed static+feed set,
+// on SNAT and DNAT, matching source-address-name AND destination-address-name.
+func Test_nat_source_address_name_set_with_feed_member_resolved_4925(t *testing.T) {
+	overlay := map[string][]string{"bad-feed": {"198.51.100.0/24", "203.0.113.7/32"}}
+
+	// --- SNAT source-address-name -> feed-only set ---
+	t.Run("snat_source_feed_only_set", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = feedNestedSetAddressBook()
+		cfg.Security.NAT.Source = []*config.NATRuleSet{
+			{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "set-feed-src",
+					Match: config.NATMatch{SourceAddressName: "feed-only-set"},
+					Then:  config.NATThen{Type: config.NATSource, Interface: true},
+				},
+			}},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		got := snatSourceAddrs(snap, "set-feed-src")
+		if !contains(got, "198.51.100.0/24") || !contains(got, "203.0.113.7/32") {
+			t.Fatalf("SNAT source-address-name -> feed-only SET must resolve the nested "+
+				"feed member's prefixes, got %v (missing => nested feed member not "+
+				"resolved => #4925 regression)", got)
+		}
+		if contains(got, "feed-only-set") {
+			t.Fatalf("SNAT source list must not carry the raw set-name token "+
+				"(fail-closed fallback => nested feed member unresolved), got %v", got)
+		}
+	})
+
+	// --- SNAT source-address-name -> mixed static+feed set ---
+	t.Run("snat_source_mixed_set", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = feedNestedSetAddressBook()
+		cfg.Security.NAT.Source = []*config.NATRuleSet{
+			{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "set-mixed-src",
+					Match: config.NATMatch{SourceAddressName: "mixed-set"},
+					Then:  config.NATThen{Type: config.NATSource, Interface: true},
+				},
+			}},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		got := snatSourceAddrs(snap, "set-mixed-src")
+		if !contains(got, "10.20.0.0/16") {
+			t.Fatalf("mixed SET must keep the static member prefix, got %v", got)
+		}
+		if !contains(got, "198.51.100.0/24") || !contains(got, "203.0.113.7/32") {
+			t.Fatalf("mixed SET must ALSO resolve the nested feed member's prefixes, "+
+				"got %v (#4925)", got)
+		}
+		if contains(got, "mixed-set") || contains(got, "bad-feed") {
+			t.Fatalf("mixed SET source list must not carry the raw set/feed name token, got %v", got)
+		}
+	})
+
+	// --- SNAT destination-address-name -> feed-only set ---
+	t.Run("snat_dest_feed_only_set", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = feedNestedSetAddressBook()
+		cfg.Security.NAT.Source = []*config.NATRuleSet{
+			{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "set-feed-dst",
+					Match: config.NATMatch{DestinationAddressName: "feed-only-set"},
+					Then:  config.NATThen{Type: config.NATSource, Interface: true},
+				},
+			}},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		got := snatDestAddrs(snap, "set-feed-dst")
+		if !contains(got, "198.51.100.0/24") || !contains(got, "203.0.113.7/32") {
+			t.Fatalf("SNAT destination-address-name -> feed-only SET must resolve the "+
+				"nested feed member's prefixes, got %v (#4925)", got)
+		}
+		if contains(got, "feed-only-set") {
+			t.Fatalf("SNAT destination list must not carry the raw set-name token, got %v", got)
+		}
+	})
+
+	// --- DNAT source-address-name -> mixed static+feed set (the #2394 source
+	// constraint on a destination-translation rule) ---
+	t.Run("dnat_source_mixed_set", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = feedNestedSetAddressBook()
+		cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+			Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+			RuleSets: []*config.NATRuleSet{
+				{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+					{
+						Name: "set-src-dnat",
+						Match: config.NATMatch{
+							SourceAddressName:  "mixed-set",
+							DestinationAddress: "198.51.100.9",
+							Protocol:           "tcp",
+							DestinationPort:    443,
+						},
+						Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+					},
+				}},
+			},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		var got []string
+		for _, s := range snap.DestinationNAT {
+			if s.Name == "set-src-dnat" {
+				got = s.SourceAddresses
+				break
+			}
+		}
+		if !contains(got, "10.20.0.0/16") {
+			t.Fatalf("DNAT source-address-name mixed SET must keep the static member, got %v", got)
+		}
+		if !contains(got, "198.51.100.0/24") || !contains(got, "203.0.113.7/32") {
+			t.Fatalf("DNAT source-address-name mixed SET must resolve the nested feed "+
+				"member's prefixes, got %v (#4925)", got)
+		}
+		if contains(got, "mixed-set") || contains(got, "bad-feed") {
+			t.Fatalf("DNAT source list must not carry the raw set/feed token, got %v", got)
+		}
+	})
+}
+
+// nat_dest_address_name_set_with_feed_member_resolved_4925 pins the DNAT
+// destination-translation path: a `match destination-address-name <set>` whose
+// set contains a feed member must install one table row per feed host. This is
+// the case that installed NO row at all before #4925 (the destination resolves
+// to nothing -> the rule is continue-skipped).
+func Test_nat_dest_address_name_set_with_feed_member_resolved_4925(t *testing.T) {
+	overlay := map[string][]string{"bad-feed": {"198.51.100.42/32", "198.51.100.43/32"}}
+
+	t.Run("dnat_dest_feed_only_set", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = feedNestedSetAddressBook()
+		cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+			Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+			RuleSets: []*config.NATRuleSet{
+				{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+					{
+						Name: "set-dst-dnat",
+						Match: config.NATMatch{
+							DestinationAddressName: "feed-only-set",
+							Protocol:               "tcp",
+							DestinationPort:        443,
+						},
+						Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+					},
+				}},
+			},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		var got []string
+		for _, s := range snap.DestinationNAT {
+			if s.Name == "set-dst-dnat" {
+				got = append(got, s.DestinationAddress)
+			}
+		}
+		if !contains(got, "198.51.100.42") || !contains(got, "198.51.100.43") {
+			t.Fatalf("DNAT destination-address-name -> feed-only SET must install one "+
+				"table entry per nested feed host, got %v (empty => nested feed member "+
+				"unresolved => rule dropped => #4925 regression)", got)
+		}
+	})
+
+	t.Run("dnat_dest_mixed_set", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = &config.AddressBook{
+			Addresses: map[string]*config.Address{
+				"host-a": {Name: "host-a", Value: "10.30.0.9/32"},
+			},
+			AddressSets: map[string]*config.AddressSet{
+				"mixed-dst": {Name: "mixed-dst", Addresses: []string{"host-a", "bad-feed"}},
+			},
+		}
+		cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+			Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+			RuleSets: []*config.NATRuleSet{
+				{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+					{
+						Name: "set-dst-mixed-dnat",
+						Match: config.NATMatch{
+							DestinationAddressName: "mixed-dst",
+							Protocol:               "tcp",
+							DestinationPort:        443,
+						},
+						Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+					},
+				}},
+			},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		var got []string
+		for _, s := range snap.DestinationNAT {
+			if s.Name == "set-dst-mixed-dnat" {
+				got = append(got, s.DestinationAddress)
+			}
+		}
+		if !contains(got, "10.30.0.9") {
+			t.Fatalf("DNAT destination mixed SET must install the static host row, got %v", got)
+		}
+		if !contains(got, "198.51.100.42") || !contains(got, "198.51.100.43") {
+			t.Fatalf("DNAT destination mixed SET must ALSO install the nested feed host "+
+				"rows, got %v (#4925)", got)
+		}
+	})
+}
+
+// Test_nat_address_name_set_unresolvable_nonfeed_member_fails_closed_4925 pins
+// that the #4925 fix does NOT weaken fail-closed: a set whose ONLY member is a
+// genuinely unresolvable NON-feed token ("ghost") yields no feed prefixes, so
+// the SNAT constraint carries the raw set token (matches nothing) and the DNAT
+// rule installs no row. It must NOT fail-open to match-anything.
+func Test_nat_address_name_set_unresolvable_nonfeed_member_fails_closed_4925(t *testing.T) {
+	// Non-empty overlay for a DIFFERENT feed, so the resolver's overlay path is
+	// live but has nothing to contribute to "dead-set" (whose member "ghost" is
+	// not a feed).
+	overlay := map[string][]string{"bad-feed": {"198.51.100.0/24"}}
+
+	t.Run("snat_source_dead_set_fails_closed", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = feedNestedSetAddressBook()
+		cfg.Security.NAT.Source = []*config.NATRuleSet{
+			{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "dead-scope",
+					Match: config.NATMatch{SourceAddressName: "dead-set"},
+					Then:  config.NATThen{Type: config.NATSource, Interface: true},
+				},
+			}},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		got := snatSourceAddrs(snap, "dead-scope")
+		if len(got) == 0 {
+			t.Fatal("source list collapsed to empty (match-any) — fail-OPEN; an " +
+				"unresolvable non-feed set member must stay non-empty + unmatchable (#4925)")
+		}
+		if !contains(got, "dead-set") {
+			t.Fatalf("source list must carry the raw unmatchable set token to fail "+
+				"closed, got %v", got)
+		}
+		// Must NOT have leaked any other feed's prefixes into this set.
+		if contains(got, "198.51.100.0/24") {
+			t.Fatalf("unrelated feed prefixes must not leak into an unrelated set, got %v", got)
+		}
+	})
+
+	t.Run("dnat_dest_dead_set_fails_closed", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = feedNestedSetAddressBook()
+		cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+			Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+			RuleSets: []*config.NATRuleSet{
+				{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+					{
+						Name: "dead-scope-dnat",
+						Match: config.NATMatch{
+							DestinationAddressName: "dead-set",
+							Protocol:               "tcp",
+							DestinationPort:        443,
+						},
+						Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+					},
+				}},
+			},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		for _, s := range snap.DestinationNAT {
+			if s.Name == "dead-scope-dnat" {
+				t.Fatalf("a DNAT rule whose only destination-address-name resolves to an "+
+					"unresolvable non-feed set member must emit NO snapshot entry "+
+					"(match-nothing), got %+v — fail-OPEN otherwise (#4925)", s)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Problem

A NAT `match {source,destination}-address-name` reference to an
address-SET whose MEMBER is a dynamic-address feed resolved to **no** feed
prefixes. `resolveNATAddressNamePrefixes` (`pkg/dataplane/userspace/nat.go`)
called the STATIC `resolveUserspaceAddressBookEntry` expander, which:

- never consults `feedOverlay` for nested set members, and
- poisons the whole set on an unresolvable feed member,

while `feedOverlay` is keyed by the **direct feed name** (e.g. `bad-feed`),
not the containing set (`bad-set`). So a rule `match source-address-name
bad-set` where `bad-set` contains feed member `bad-feed` yielded no feed
prefixes → SNAT fell back to an unmatchable raw token, DNAT installed no
table row.

This is **fail-closed** (not a security widening) but it **diverged** from the
security-policy path, which has been feed-aware for nested set members since
**#3294** (`expandBookNameRecursive`). One operator-authored address object thus
had different dataplane meaning across NAT vs policy — and the NAT rule silently
disabled after HA sync / lenient reload while the direct-feed tests (#3303)
stayed green.

## Fix

Rewire `resolveNATAddressNamePrefixes` to reuse the **same** feed-aware
recursive `expandBookNameRecursive` the policy path uses (the #3294 SSOT the
issue points to). The walk merges `feedOverlay` at the top level **and** at
every nested member, so a feed-only set and a mixed static+feed set both resolve
the nested member's live feed prefixes. The union is sorted + deduped to
preserve the static resolver's output shape, so the #2416 exact-slice pins stay
byte-identical and the direct-feed (#3303) / direct address-name paths do not
regress.

**Fail-closed preserved.** An empty set, or a set whose only member is a
genuinely unresolvable non-feed token, yields no prefixes; the append helpers
keep the constraint non-empty with the raw book-name token so the rule matches
NOTHING rather than widening to match-any.

## Tests (fail-on-revert merge gate)

- `Test_nat_source_address_name_set_with_feed_member_resolved_4925` — SNAT
  source/destination-address-name + DNAT source-address-name, feed-only AND
  mixed static+feed sets; asserts resolved prefixes include the nested feed
  overlay.
- `Test_nat_dest_address_name_set_with_feed_member_resolved_4925` — DNAT
  destination-address-name installs one table row per nested feed host
  (feed-only AND mixed set).
- `Test_nat_address_name_set_unresolvable_nonfeed_member_fails_closed_4925` —
  a set whose only member is unresolvable/non-feed still yields no match.

**Parent-RED verified:** reverting the resolver to the static expander makes
exactly the two "resolved" tests RED (target-count 2, 0 collateral); the
fail-closed pin and the pre-existing #3303 / #3425 / #2416 tests stay green.

## Validation

- `go test ./pkg/dataplane/userspace/...` green; the #4925 tests run 3× with no
  flake.
- `gofmt` + `go vet` clean on touched files.
- Config compilation only (unit-provable) — **not HA**, no cluster smoke
  required.

## Docs

Updated `docs/feature-gaps.md` (the "tracked residual" note) and the `nat.go`
comment block to reflect nested feed-backed set members are now feed-resolved.

Closes #4925

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwCNoNvtYXGtRoG2Nmuwrk
