### PR TITLE
userspace-dp: singleflight-guard + bound the neighbor prewarm scan (#5104)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -53617,3 +53617,28 @@ top.
   userspace-dp/src/server/tests.rs,
   userspace-dp/src/afxdp/coordinator/README.md,
   userspace-dp/src/server/README.md
+
+- **Timestamp**: 2026-07-18
+- **Action**: #5104 — singleflight-guard + bound the userspace-dp neighbor
+  prewarm scan. The status loop kicked a FULL async neighbor-resolve scan every
+  1s for the first 60s (then 10s standby) with NO in-flight guard; each scan did
+  route-indexed NeighList dumps and spawned ONE goroutine PER TARGET. Under slow
+  netlink / a large RIB, scans OVERLAPPED, multiplying concurrent scans and
+  unbounded probe goroutines — self-amplifying control-plane load delaying
+  apply/status/recovery. Fix: (1) lock-free `neighborPrewarmInFlight` atomic.Bool
+  CAS singleflight guard in `proactiveNeighborResolveAsyncLocked` (coalesce
+  overlapping ticks; cleared via defer so a panic also clears); (2) each scan
+  runs under a 15s `neighborPrewarmDeadline` context, checked between netlink
+  dumps so slow netlink can't pin the guard; (3) `runBoundedNeighborProbes`
+  fixed 8-worker pool replaces goroutine-per-target; (4) one
+  `NeighList(FAMILY_ALL)` dump per link index per scan (was per-route re-dump).
+  Injectable `neighborPrewarmScan` seam for deterministic tests. Merge-gate
+  regression `TestNeighborPrewarmSingleflightCoalescesOverlappingTicks5104`
+  (RED-on-revert verified: neutralize CAS → peak concurrent scans = 2, want 1;
+  assertion failure not build break, target-count 1) + bounded-pool +
+  ctx-cancel tests. Validated with `go test -race` (full pkg green, named 3x),
+  gofmt + go vet clean. NOT HA-smoke — guard is unit-provable.
+- **File(s)**: pkg/dataplane/userspace/manager.go,
+  pkg/dataplane/userspace/process_napi.go,
+  pkg/dataplane/userspace/neighbor_prewarm_singleflight_5104_test.go,
+  docs/userspace-cold-start-fix-plan.md

--- a/docs/userspace-cold-start-fix-plan.md
+++ b/docs/userspace-cold-start-fix-plan.md
@@ -56,6 +56,29 @@ The following changes were directionally correct and should be kept:
 4. Go-side proactive neighbor refresh
    - manager periodically reads the kernel neighbor table
    - manager pushes neighbor snapshots to the helper
+   - **#5104 — the status-loop async prewarm scan is now bounded.** The status
+     loop (`process_status.go`) kicks `proactiveNeighborResolveAsyncLocked`
+     every 1s for the first 60s, then every 10s on HA standby. Each scan does
+     route-indexed neighbor dumps and a probe sweep, which can outlast its tick
+     under slow netlink or a large RIB. The prewarm is now:
+     - **singleflight** — a lock-free `neighborPrewarmInFlight` CAS guard
+       (`manager.go`) coalesces overlapping ticks onto the running scan; a
+       second scan never starts while one is in flight. The guard clears when
+       the scan goroutine returns (via `defer`, so a panic also clears it).
+     - **deadline-bounded** — each scan runs under a
+       `neighborPrewarmDeadline` (15s) context and checks it between netlink
+       dumps, so a slow netlink layer cannot pin the guard indefinitely; the
+       next tick spawns a fresh scan. (vishvananda/netlink calls are not
+       context-cancelable mid-syscall, so the deadline bounds the between-dump
+       loop, not a single wedged syscall.)
+     - **bounded probe pool** — `runBoundedNeighborProbes` (`process_napi.go`)
+       fans probes out through a fixed `neighborPrewarmProbeWorkers` (8) pool
+       instead of one goroutine per target, so a large resolve set cannot
+       multiply goroutines every tick.
+     - **one neighbor dump per link per scan** — the scan caches
+       `NeighList(FAMILY_ALL)` per link index, collapsing the old
+       per-route re-dump.
+     Regression: `neighbor_prewarm_singleflight_5104_test.go`.
 
 5. Rust-side dynamic learning paths
    - netlink neighbor monitor

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -250,6 +250,23 @@ type Manager struct {
 
 	rgTransitionInFlight atomic.Bool // set before syncHAStateLocked, cleared on completion
 
+	// neighborPrewarmInFlight is the #5104 singleflight guard for the async
+	// neighbor-resolve prewarm scan spawned by the status loop. The loop kicks
+	// a full scan every 1s for the first 60s (then every 10s on HA standby); a
+	// scan does route-indexed NeighList dumps and a bounded probe sweep. Under
+	// slow netlink or a large RIB a scan can outlast its tick, so this flag
+	// coalesces overlapping ticks onto the running scan: CAS false->true before
+	// spawning, cleared (via defer) when the scan goroutine returns. Lock-free
+	// (like rgTransitionInFlight) because the clear happens off m.mu in the
+	// background scan goroutine.
+	neighborPrewarmInFlight atomic.Bool
+	// neighborPrewarmScan runs one prewarm scan. Indirected through a field so
+	// tests can inject a deterministic/blocking scan to exercise the #5104
+	// singleflight coalescing without real netlink. nil-safe at the call site:
+	// it defaults to proactiveNeighborResolveAsync when unset, so bare
+	// &Manager{} literals still work.
+	neighborPrewarmScan func(ctx context.Context, cfg *config.Config)
+
 	// Counter delta tracking: previous binding counter totals for computing
 	// deltas to write into BPF counter maps (#332).
 	prevBindingCounters userspaceCounterSnapshot

--- a/pkg/dataplane/userspace/neighbor_prewarm_singleflight_5104_test.go
+++ b/pkg/dataplane/userspace/neighbor_prewarm_singleflight_5104_test.go
@@ -1,0 +1,176 @@
+package userspace
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestNeighborPrewarmSingleflightCoalescesOverlappingTicks5104 is the #5104
+// merge-gate regression. The status loop kicks proactiveNeighborResolveAsyncLocked
+// every 1s for the first 60s (then every 10s on HA standby); a single scan can
+// outlast its tick under slow netlink or a large RIB. Without the singleflight
+// guard, overlapping ticks multiplied concurrent scans (and probe goroutines) —
+// self-amplifying control-plane load. This test fires overlapping ticks while a
+// scan is artificially in flight (blocked in an injected seam) and asserts that
+// only ONE scan runs. Reverting the CAS guard in
+// proactiveNeighborResolveAsyncLocked makes this go RED (started/peak > 1).
+func TestNeighborPrewarmSingleflightCoalescesOverlappingTicks5104(t *testing.T) {
+	var (
+		started    atomic.Int32
+		concurrent atomic.Int32
+		peak       atomic.Int32
+	)
+	entered := make(chan struct{}, 32)
+	release := make(chan struct{})
+
+	m := &Manager{
+		lastSnapshot: &ConfigSnapshot{Config: &config.Config{}},
+	}
+	m.neighborPrewarmScan = func(ctx context.Context, cfg *config.Config) {
+		started.Add(1)
+		c := concurrent.Add(1)
+		for { // record the concurrency peak
+			p := peak.Load()
+			if c <= p || peak.CompareAndSwap(p, c) {
+				break
+			}
+		}
+		entered <- struct{}{}
+		<-release
+		concurrent.Add(-1)
+	}
+
+	tick := func() {
+		m.mu.Lock()
+		m.proactiveNeighborResolveAsyncLocked()
+		m.mu.Unlock()
+	}
+
+	// First tick starts a scan that blocks in the seam, holding the guard.
+	tick()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first prewarm scan never started")
+	}
+
+	// Overlapping ticks while scan 1 is DEFINITIVELY in flight (blocked on
+	// release). The singleflight guard must coalesce all of these.
+	for i := 0; i < 5; i++ {
+		tick()
+	}
+
+	// Give any erroneously-spawned scan time to reach the seam and bump the
+	// peak. With the guard in place, none spawn and this drains nothing.
+	select {
+	case <-entered:
+		// A second scan reached the seam — the guard failed to coalesce.
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	if got := peak.Load(); got != 1 {
+		t.Fatalf("concurrent prewarm scans peaked at %d, want 1 (#5104 singleflight guard must coalesce overlapping ticks)", got)
+	}
+	if got := started.Load(); got != 1 {
+		t.Fatalf("prewarm scans started = %d, want 1 (overlapping ticks must coalesce onto the running scan)", got)
+	}
+	if !m.neighborPrewarmInFlight.Load() {
+		t.Fatal("singleflight guard cleared while a scan is still in flight")
+	}
+
+	// Release the in-flight scan; the guard must clear so a later tick runs a
+	// fresh scan (coalescing is transient, not permanent).
+	close(release)
+	deadline := time.Now().Add(2 * time.Second)
+	for m.neighborPrewarmInFlight.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("singleflight guard never cleared after the scan returned")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	tick()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-release tick did not start a fresh scan")
+	}
+	if got := started.Load(); got != 2 {
+		t.Fatalf("prewarm scans started = %d after release, want 2", got)
+	}
+	// Let the last scan finish so the goroutine doesn't linger past the test.
+	// release is already closed, so its <-release returns immediately.
+}
+
+// TestNeighborProbePoolBounded5104 asserts the #5104 bounded probe pool: N
+// resolve targets fan out to at most neighborPrewarmProbeWorkers concurrent
+// probes (previously ONE goroutine per target, unbounded). Reverting
+// runBoundedNeighborProbes to an unbounded goroutine-per-target loop drives the
+// concurrency peak well past the worker cap and makes this RED.
+func TestNeighborProbePoolBounded5104(t *testing.T) {
+	const (
+		workers    = 4
+		numTargets = 200
+	)
+	var (
+		concurrent atomic.Int32
+		peak       atomic.Int32
+		total      atomic.Int32
+	)
+	targets := make([]neighborProbeTarget, 0, numTargets)
+	for i := 0; i < numTargets; i++ {
+		targets = append(targets, neighborProbeTarget{
+			iface: "ge-0-0-0",
+			ip:    fmt.Sprintf("10.0.0.%d", i%254+1),
+		})
+	}
+	probe := func(iface string, target net.IP) {
+		total.Add(1)
+		c := concurrent.Add(1)
+		for {
+			p := peak.Load()
+			if c <= p || peak.CompareAndSwap(p, c) {
+				break
+			}
+		}
+		time.Sleep(time.Millisecond) // hold the slot so overlap manifests
+		concurrent.Add(-1)
+	}
+
+	runBoundedNeighborProbes(context.Background(), targets, workers, probe)
+
+	if got := total.Load(); got != numTargets {
+		t.Fatalf("probed %d targets, want %d (all targets must be probed)", got, numTargets)
+	}
+	if got := peak.Load(); got > workers {
+		t.Fatalf("probe concurrency peaked at %d, want <= %d (#5104 bounded pool)", got, workers)
+	}
+	if got := peak.Load(); got < 1 {
+		t.Fatalf("probe concurrency peaked at %d, want >= 1", got)
+	}
+}
+
+// TestNeighborProbePoolStopsOnCanceledContext5104 locks the ctx cancellation
+// wiring: a cancelled/expired scan context stops the probe sweep instead of
+// firing every target.
+func TestNeighborProbePoolStopsOnCanceledContext5104(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var total atomic.Int32
+	targets := []neighborProbeTarget{
+		{iface: "ge-0-0-0", ip: "10.0.0.1"},
+		{iface: "ge-0-0-0", ip: "10.0.0.2"},
+	}
+	runBoundedNeighborProbes(ctx, targets, 4, func(string, net.IP) { total.Add(1) })
+
+	if got := total.Load(); got != 0 {
+		t.Fatalf("canceled context still fired %d probes, want 0", got)
+	}
+}

--- a/pkg/dataplane/userspace/process_napi.go
+++ b/pkg/dataplane/userspace/process_napi.go
@@ -1,9 +1,11 @@
 package userspace
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -273,14 +275,53 @@ func sendUDPProbeForNAPI(iface string, target net.IP, port uint16) {
 	}
 }
 
+// neighborPrewarmDeadline bounds one async prewarm scan (#5104). It caps how
+// long the singleflight guard can be held: the scan checks the context between
+// netlink dumps and stops issuing more once the deadline passes, so a slow
+// netlink layer or a large RIB cannot pin the guard indefinitely — the next
+// tick spawns a fresh scan.
+const neighborPrewarmDeadline = 15 * time.Second
+
+// neighborPrewarmProbeWorkers caps the concurrent ICMP probe goroutines a
+// single scan spawns (#5104). Before this, a scan launched ONE goroutine per
+// resolve target, so a large neighbor/route set multiplied unbounded goroutines
+// on every tick. A fixed pool keeps cold-path work bounded regardless of RIB
+// size.
+const neighborPrewarmProbeWorkers = 8
+
 // proactiveNeighborResolveAsyncLocked is the non-blocking version that
 // fires probes in background goroutines. Used by the status loop.
+//
+// #5104: at most ONE scan runs at a time. The status loop kicks this every 1s
+// for the first 60s (then every 10s on HA standby); under slow netlink or a
+// large RIB a scan can outlast its tick. Without a guard, overlapping ticks
+// multiplied concurrent scans and probe goroutines — self-amplifying
+// control-plane load that delayed apply/status/recovery. The singleflight CAS
+// coalesces overlapping ticks onto the running scan; the guard is cleared when
+// the scan goroutine returns (via defer, so a panic also clears it).
 func (m *Manager) proactiveNeighborResolveAsyncLocked() {
 	if m.lastSnapshot == nil || m.lastSnapshot.Config == nil {
 		return
 	}
+	// Singleflight: skip this tick if a scan is already in flight. CAS is
+	// lock-free so the background scan can clear it without taking m.mu.
+	if !m.neighborPrewarmInFlight.CompareAndSwap(false, true) {
+		return
+	}
 	cfg := m.lastSnapshot.Config
-	go proactiveNeighborResolveAsync(cfg)
+	scan := m.neighborPrewarmScan
+	if scan == nil {
+		scan = proactiveNeighborResolveAsync
+	}
+	go func() {
+		defer m.neighborPrewarmInFlight.Store(false)
+		// Deadline-bound the scan so a wedged/slow netlink dump can't hold the
+		// singleflight guard forever; on deadline the scan stops issuing work,
+		// returns, clears the guard, and the next tick retries.
+		ctx, cancel := context.WithTimeout(context.Background(), neighborPrewarmDeadline)
+		defer cancel()
+		scan(ctx, cfg)
+	}()
 }
 
 type neighborProbeTarget struct {
@@ -288,11 +329,65 @@ type neighborProbeTarget struct {
 	ip    string
 }
 
-func proactiveNeighborResolveAsync(cfg *config.Config) {
+// runBoundedNeighborProbes fires one ICMP/NDP probe per target through a
+// fixed-size worker pool (#5104). It replaces the previous unbounded
+// goroutine-per-target fan-out so N resolve targets spawn at most `workers`
+// concurrent probes. It stops early once ctx is cancelled/expired, and waits
+// for the in-flight probes to drain before returning.
+func runBoundedNeighborProbes(ctx context.Context, targets []neighborProbeTarget, workers int, probe func(iface string, target net.IP)) {
+	if workers < 1 {
+		workers = 1
+	}
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	for _, t := range targets {
+		if ctx.Err() != nil {
+			break
+		}
+		targetIP := net.ParseIP(t.ip)
+		if targetIP == nil {
+			continue
+		}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		}
+		wg.Add(1)
+		go func(iface string, ip net.IP) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			probe(iface, ip)
+		}(t.iface, targetIP)
+	}
+	wg.Wait()
+}
+
+func proactiveNeighborResolveAsync(ctx context.Context, cfg *config.Config) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	seen := make(map[string]bool)
 	targetSet := make(map[string]struct{})
 	var targets []neighborProbeTarget
+	// #5104: cache ONE neighbor dump per link index per scan. The route loop
+	// below previously re-dumped the neighbor table per route (often re-dumping
+	// the same link many times on a large RIB). Caching collapses that to one
+	// NeighList(FAMILY_ALL) per link per scan.
+	linkNeighCache := make(map[int][]netlink.Neigh)
+	neighborsForLink := func(linkIndex int) []netlink.Neigh {
+		if cached, ok := linkNeighCache[linkIndex]; ok {
+			return cached
+		}
+		neighs, _ := netlink.NeighList(linkIndex, netlink.FAMILY_ALL)
+		linkNeighCache[linkIndex] = neighs
+		return neighs
+	}
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
+		if ctx.Err() != nil {
+			return
+		}
 		base := config.LinuxIfName(ifName)
 		seen[base] = true // include base interface for route-GW probing
 		for _, unit := range ifc.Units {
@@ -305,30 +400,30 @@ func proactiveNeighborResolveAsync(cfg *config.Config) {
 			if err != nil || link == nil {
 				continue
 			}
-			for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
-				neighs, err := netlink.NeighList(link.Attrs().Index, family)
-				if err != nil {
+			for _, n := range neighborsForLink(link.Attrs().Index) {
+				if n.IP == nil || n.IP.IsLinkLocalUnicast() {
 					continue
 				}
-				for _, n := range neighs {
-					if n.IP == nil || n.IP.IsLinkLocalUnicast() {
+				if n.HardwareAddr == nil || len(n.HardwareAddr) == 0 ||
+					n.State == netlink.NUD_STALE || n.State == netlink.NUD_FAILED {
+					key := linuxName + "|" + n.IP.String()
+					if _, ok := targetSet[key]; ok {
 						continue
 					}
-					if n.HardwareAddr == nil || len(n.HardwareAddr) == 0 ||
-						n.State == netlink.NUD_STALE || n.State == netlink.NUD_FAILED {
-						key := linuxName + "|" + n.IP.String()
-						if _, ok := targetSet[key]; ok {
-							continue
-						}
-						targetSet[key] = struct{}{}
-						targets = append(targets, neighborProbeTarget{iface: linuxName, ip: n.IP.String()})
-					}
+					targetSet[key] = struct{}{}
+					targets = append(targets, neighborProbeTarget{iface: linuxName, ip: n.IP.String()})
 				}
 			}
 		}
 	}
+	if ctx.Err() != nil {
+		return
+	}
 	routes, _ := netlink.RouteList(nil, netlink.FAMILY_ALL)
 	for _, r := range routes {
+		if ctx.Err() != nil {
+			return
+		}
 		if r.Gw == nil || r.Gw.IsLinkLocalUnicast() {
 			continue
 		}
@@ -340,9 +435,8 @@ func proactiveNeighborResolveAsync(cfg *config.Config) {
 		if !seen[ifName] {
 			continue
 		}
-		existing, _ := netlink.NeighList(r.LinkIndex, netlink.FAMILY_ALL)
 		found := false
-		for _, n := range existing {
+		for _, n := range neighborsForLink(r.LinkIndex) {
 			if n.IP.Equal(r.Gw) && n.HardwareAddr != nil && len(n.HardwareAddr) > 0 &&
 				n.State != netlink.NUD_FAILED {
 				found = true
@@ -359,12 +453,5 @@ func proactiveNeighborResolveAsync(cfg *config.Config) {
 		targetSet[key] = struct{}{}
 		targets = append(targets, neighborProbeTarget{iface: ifName, ip: r.Gw.String()})
 	}
-	for _, t := range targets {
-		go func(iface, ip string) {
-			targetIP := net.ParseIP(ip)
-			if targetIP != nil {
-				sendICMPProbeFromManager(iface, targetIP)
-			}
-		}(t.iface, t.ip)
-	}
+	runBoundedNeighborProbes(ctx, targets, neighborPrewarmProbeWorkers, sendICMPProbeFromManager)
 }


### PR DESCRIPTION
## Problem (#5104, verified on origin/master 865fad679)

The manager status loop launched a **full async neighbor-resolve prewarm
scan on every 1s tick for the first 60s** (then every 10s on HA standby)
with **no in-flight guard**. Each scan did route-indexed `NeighList` dumps
and spawned **one goroutine per resolve target**. Under slow netlink or a
large RIB a scan can outlast its tick, so scans **overlapped** — multiplying
concurrent scans and probe goroutines (target dedup was per-scan only). This
turned HA readiness warming into self-amplifying control-plane load, delaying
apply/status/recovery.

## Fix

Bound the cold-path work per status tick:

1. **Singleflight** — a lock-free `neighborPrewarmInFlight` `atomic.Bool` CAS
   guard in `proactiveNeighborResolveAsyncLocked` coalesces overlapping ticks
   onto the running scan; a second scan never starts while one is in flight.
   The guard clears when the scan goroutine returns (`defer`, so a panic also
   clears it), matching the existing `rgTransitionInFlight` pattern.
2. **Deadline + cancellation** — each scan runs under a 15s
   `neighborPrewarmDeadline` context and checks it between netlink dumps, so a
   slow netlink layer cannot pin the guard indefinitely; the next tick spawns
   a fresh scan. (vishvananda/netlink calls are not context-cancelable
   mid-syscall, so the deadline bounds the between-dump loop, not a single
   wedged syscall.)
3. **Bounded probe pool** — `runBoundedNeighborProbes` fans probes out through
   a fixed 8-worker pool (`neighborPrewarmProbeWorkers`) instead of one
   goroutine per target.
4. **One dump per link per scan** — the scan caches `NeighList(FAMILY_ALL)`
   per link index, collapsing the old per-route re-dump.

An injectable `neighborPrewarmScan` seam allows deterministic tests without
real netlink.

## Test (merge gate)

`TestNeighborPrewarmSingleflightCoalescesOverlappingTicks5104` fires
overlapping ticks while a scan is artificially in flight (blocked in the
injected seam) and asserts **only one scan runs** (peak concurrent scans == 1,
started == 1). Companion tests assert the **bounded probe pool** (200 targets →
peak ≤ 4 workers) and the **ctx-cancel** wiring.

- **Parent-RED verified**: neutralizing the CAS guard makes the named test RED
  (`concurrent prewarm scans peaked at 2, want 1`) as an **assertion failure**,
  not a build break. target-count = 1.

## Validation

- `go test -race ./pkg/dataplane/userspace/...` — full package green; named
  test x3 for flake.
- `gofmt` + `go vet` clean.

## Docs

`docs/userspace-cold-start-fix-plan.md` records the singleflight + bounded +
deadline-bounded prewarm behavior.

## HA / smoke assessment

This touches the HA-readiness-warming path, but the guard is unit-provable via
the injected scan seam and the fix only *reduces* control-plane load without
changing the probe behavior (same `sendICMPProbeFromManager` per target). No
loss-cluster smoke warranted.

Closes #5104
