### PR TITLE
dataplane/userspace: reset global counter offsets on clear (#5098)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-20 — #5098: reset global counter offsets on clear (epoch semantics)
+
+- **Timestamp**: 2026-07-20 (fix/5098-clear-counter-offset)
+- **Action**: Fixed the userspace-mode snap-back where cleared global
+  RX/TX/drop/session totals immediately reverted to their pre-clear value.
+  `ReadGlobalCounter` merges the per-CPU `global_counters` BPF array sum with an
+  in-memory `userspaceCounterOffsets` entry that `IncrementGlobalCounter` /
+  `syncBPFCountersLocked` ACCUMULATE (not overwrite) for userspace-forwarded
+  packets; `ClearGlobalCounters`/`ClearAllCounters` zeroed only the BPF array, so
+  the offset half survived and the read snapped back. `ClearGlobalCounters` now
+  drops the whole offset map FIRST under `m.mu` (the same lock guarding every
+  offset read/write) — and no longer errors when the BPF map is absent
+  (userspace-only runtime), mirroring `ClearZoneCounters`/`ClearNATRuleCounters`.
+  `ClearAllCounters` inherits it via `ClearGlobalCounters`; the userspace
+  `Manager.ClearAllCounters` additionally rebases `prevBindingCounters` to the
+  last-recorded cumulative so the next 1/s poll's delta measures traffic strictly
+  after the clear (no stale delta re-fold). Corrected the false
+  policycounters.go comment that claimed `bpfShim.ClearAllCounters()` already
+  zeroed the offset map. Fail-on-revert merge gate
+  `Test_clear_global_counters_resets_userspace_offset_5098` (mapless, always
+  runs): seeds an offset via IncrementGlobalCounter AND a helper poll, clears via
+  BOTH `ClearGlobalCounters` and the operator `ClearAllCounters` path, asserts the
+  offset resets to 0 and a post-clear delta restarts from zero. Sibling
+  `Test_clear_global_counters_read_equation_zero_5098` (dataplane pkg, privileged;
+  SKIPs unprivileged) pins the full `ReadGlobalCounter` array+offset==0 equation.
+  Doc: userspace-dataplane-gaps.md gains a "Global counter clear is an epoch"
+  bullet.
+- **Validation**: full `pkg/dataplane/...` suite green under `-race`; named test
+  3x no flake; consumer pkgs (cli/api/grpcapi/daemon) green; gofmt + go vet clean;
+  `go build ./...` clean. Parent-RED: disabling the offset reset makes both
+  subtests RED (offset==100, cleared total snaps back); disabling the
+  prevBindingCounters rebase makes the delta subtest RED (reads 50, want 30) —
+  assertion failures, not build breaks; target-count 1 named test (+1 skipped
+  privileged sibling). NOT HA (counter clear path; unit-provable, no cluster smoke).
+- **File(s)**: pkg/dataplane/maps_counters.go,
+  pkg/dataplane/userspace/policycounters.go,
+  pkg/dataplane/maps_counters_clear_5098_test.go,
+  pkg/dataplane/userspace/manager_counters_test.go,
+  docs/userspace-dataplane-gaps.md
+
 ## 2026-07-18 — #4925: NAT feed-resolves nested address-set members in match address-name
 
 - **Timestamp**: 2026-07-18 (fix/4925-nat-feed-nested-set)

--- a/_Log.md
+++ b/_Log.md
@@ -53760,3 +53760,36 @@ top.
   pkg/dataplane/userspace/process_napi.go,
   pkg/dataplane/userspace/neighbor_prewarm_singleflight_5104_test.go,
   docs/userspace-cold-start-fix-plan.md
+
+- **Timestamp**: 2026-07-20
+- **Action**: #5098 review fold — make ClearAllCounters offset-reset +
+  baseline-rebase atomic vs the 1/s status poll. Hostile review found a
+  lock-ordering gap that defeated the PR's "epoch atomicity": Phase-1 offset
+  reset (`bpfShim.ClearAllCounters`, DATAPLANE m.mu) ran OUTSIDE the userspace
+  m.mu, while Phase-2 baseline rebase (`prevBindingCounters`) ran under it. A
+  poll mid-cycle (holding userspace m.mu, `syncBPFCountersLocked` ->
+  `IncrementGlobalCounter` pending) could re-add `cur-stale_baseline` into the
+  just-zeroed offset AFTER Phase 1 but BEFORE Phase 2 — the rebase does not
+  re-zero the offset, leaving a small constant residual (~1 poll interval of
+  pre-clear traffic) on cleared global RX/TX/drop/session totals until the next
+  clear. FIX (option a): moved `m.mu.Lock()` to the top so the WHOLE method —
+  `bpfShim.ClearAllCounters` offset reset through the `prevBindingCounters`
+  rebase — is one userspace-m.mu critical section the poll cannot interleave
+  with. Lock order stays userspace->dataplane (matches the poll), deadlock-free;
+  the clearHelper*Locked helpers assume the lock held and never re-lock.
+  Also corrected the oversold `ClearGlobalCounters` comment: point (b) holds
+  because the userspace helper records forwarded packets ONLY in the offset map
+  (BPF array always 0 in this runtime), not because offset-reset and array-zero
+  are co-locked (they are not). Added a test-only `syncBPFCountersPreIncrement
+  Observer` seam. Merge-gate regression `Test_clear_all_counters_offset_atomic
+  _vs_status_poll_5098` drives a concurrent clear through that seam and asserts
+  post-clear offset == 0 (RED-on-revert verified: move the reset back outside
+  the lock -> offset residual = 50, assertion failure not build break). Plus
+  `Test_clear_all_counters_concurrent_poll_race_5098` (-race deadlock/data-race
+  coverage). Existing `Test_clear_global_counters_resets_userspace_offset_5098`
+  + its revert-RED still hold. Validated: `go test -race ./pkg/dataplane/...`
+  full green, named tests 3x, gofmt + go vet clean. NOT HA-smoke — unit-provable.
+- **File(s)**: pkg/dataplane/userspace/policycounters.go,
+  pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/manager_counters_test.go,
+  pkg/dataplane/maps_counters.go

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -175,6 +175,24 @@ counters (see below).
   different zones cannot be split by logical unit, so DERIVE would mis-attribute
   — worse than the honest hot-path accounting that #3651 now does.
 
+- **Global counter clear is an epoch (#5098).** `ReadGlobalCounter` returns the
+  per-CPU `global_counters` BPF array sum PLUS an in-memory `userspaceCounterOffsets`
+  entry. `IncrementGlobalCounter` — driven by `syncBPFCountersLocked` — ACCUMULATES
+  each 1/s helper delta (`cur - prevBindingCounters`) into that offset so
+  userspace-forwarded packets (RX/TX, aggregate/per-reason drops #4477/#3343/#3326,
+  SYN-cookie, NAT64) that bypass the BPF pipeline are reflected. This is an
+  ACCUMULATE, not an absolute overwrite like the NAT (#2218) and per-zone (#3651)
+  offset stores — so a clear must zero the offset explicitly or the cleared total
+  snaps straight back on the next read. `ClearGlobalCounters` now drops the whole
+  offset map first (under the same `m.mu` that guards every offset read/write, and
+  even without a loaded BPF map — parity with `ClearZoneCounters`/
+  `ClearNATRuleCounters`), and `ClearAllCounters` inherits it; the userspace
+  `ClearAllCounters` also rebases `prevBindingCounters` to the last-recorded
+  cumulative so the next poll's delta measures traffic strictly AFTER the clear.
+  There is no `clear_global_counters` helper IPC: the helper's cumulative binding
+  counters keep climbing from launch, and the rebased delta baseline (not an IPC
+  reset) is what makes the cleared value stick.
+
 ## Retirement History (closed)
 
 The #1373 eBPF retirement is complete. This section is a record of the closed

--- a/pkg/dataplane/maps_counters.go
+++ b/pkg/dataplane/maps_counters.go
@@ -150,10 +150,33 @@ func (m *Manager) ClearZoneCounterOffsets() {
 }
 
 // ClearGlobalCounters zeroes all global counter entries.
+//
+// A counter clear is an EPOCH operation: every source ReadGlobalCounter merges
+// must move to zero together. ReadGlobalCounter returns the per-CPU BPF array
+// sum PLUS the in-memory userspaceCounterOffsets entry (IncrementGlobalCounter
+// accumulates the helper-forwarded deltas there so userspace-forwarded packets
+// that bypass the BPF pipeline are still reflected). Zeroing only the BPF array
+// therefore let a cleared global RX/TX/drop/session total snap straight back to
+// its pre-clear value on the next read (#5098) — the offset half survived.
+//
+// Drop the offset map FIRST, under the same m.mu that guards every
+// IncrementGlobalCounter/ReadGlobalCounter access, so (a) the clear takes
+// effect on the read path even without a loaded BPF map (userspace-only
+// runtime), mirroring ClearZoneCounters/ClearNATRuleCounters, and (b) a
+// concurrent ReadGlobalCounter cannot merge a stale offset with a zeroed array.
+// This method clears every index [0,GlobalCtrMax) — exactly the set the offset
+// map can hold — so the whole map is reset.
 func (m *Manager) ClearGlobalCounters() error {
+	m.mu.Lock()
+	m.userspaceCounterOffsets = nil
+	m.mu.Unlock()
+
 	zm, ok := m.maps["global_counters"]
 	if !ok {
-		return fmt.Errorf("global_counters map not found")
+		// Userspace-only runtime with no BPF map loaded: the offset reset above
+		// is the meaningful clear, so a missing array is not an error (parity
+		// with ClearZoneCounters/ClearNATRuleCounters).
+		return nil
 	}
 	numCPUs := ebpf.MustPossibleCPU()
 	zero := make([]uint64, numCPUs)

--- a/pkg/dataplane/maps_counters.go
+++ b/pkg/dataplane/maps_counters.go
@@ -162,8 +162,15 @@ func (m *Manager) ClearZoneCounterOffsets() {
 // Drop the offset map FIRST, under the same m.mu that guards every
 // IncrementGlobalCounter/ReadGlobalCounter access, so (a) the clear takes
 // effect on the read path even without a loaded BPF map (userspace-only
-// runtime), mirroring ClearZoneCounters/ClearNATRuleCounters, and (b) a
-// concurrent ReadGlobalCounter cannot merge a stale offset with a zeroed array.
+// runtime), mirroring ClearZoneCounters/ClearNATRuleCounters, and (b) in the
+// userspace runtime the per-CPU BPF array is always 0 — the helper forwards
+// packets outside the BPF pipeline and records them ONLY in the offset map,
+// never the array — so once the offset is dropped a concurrent
+// ReadGlobalCounter merges 0 (offset) + 0 (array) = 0. Note the offset reset
+// and the BPF-array zero below are NOT co-locked: the reset happens under m.mu,
+// the array zeroing after it is released. That is safe here ONLY because the
+// array stays 0 in this runtime; were the array ever non-zero, a read racing
+// between the two steps could briefly merge a zeroed offset with a stale array.
 // This method clears every index [0,GlobalCtrMax) — exactly the set the offset
 // map can hold — so the whole map is reset.
 func (m *Manager) ClearGlobalCounters() error {

--- a/pkg/dataplane/maps_counters_clear_5098_test.go
+++ b/pkg/dataplane/maps_counters_clear_5098_test.go
@@ -1,0 +1,78 @@
+package dataplane
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// Test_clear_global_counters_read_equation_zero_5098 pins the #5098 fix against
+// the FULL ReadGlobalCounter read equation: the per-CPU BPF array sum PLUS the
+// in-memory userspaceCounterOffsets entry. Before #5098 ClearGlobalCounters
+// zeroed only the BPF array, so a cleared total snapped back to the surviving
+// offset on the next read.
+//
+// This needs a real PERCPU_ARRAY map, so it skips on an unprivileged host (no
+// BPF map creation). The always-on fail-on-revert gate lives in the userspace
+// package (Test_clear_global_counters_resets_userspace_offset_5098), which keys
+// on the offset half without a map.
+func Test_clear_global_counters_read_equation_zero_5098(t *testing.T) {
+	gc, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.PerCPUArray,
+		KeySize:    4,
+		ValueSize:  8,
+		MaxEntries: GlobalCtrMax,
+	})
+	if err != nil {
+		skipIfBPFUnavailable(t, "new global_counters map", err)
+	}
+	t.Cleanup(func() { gc.Close() })
+
+	m := &Manager{maps: map[string]*ebpf.Map{"global_counters": gc}}
+
+	const idx = GlobalCtrRxPackets
+
+	// Seed BOTH halves of the read equation: a per-CPU BPF array value and an
+	// in-memory userspace offset.
+	numCPUs := ebpf.MustPossibleCPU()
+	arr := make([]uint64, numCPUs)
+	arr[0] = 7
+	if err := gc.Update(idx, arr, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed global_counters array: %v", err)
+	}
+	if err := m.IncrementGlobalCounter(idx, 100); err != nil {
+		t.Fatalf("seed offset: %v", err)
+	}
+
+	got, err := m.ReadGlobalCounter(idx)
+	if err != nil {
+		t.Fatalf("ReadGlobalCounter (seed): %v", err)
+	}
+	if got != 107 {
+		t.Fatalf("ReadGlobalCounter (seed) = %d, want 107 (array 7 + offset 100)", got)
+	}
+
+	if err := m.ClearGlobalCounters(); err != nil {
+		t.Fatalf("ClearGlobalCounters: %v", err)
+	}
+	got, err = m.ReadGlobalCounter(idx)
+	if err != nil {
+		t.Fatalf("ReadGlobalCounter (post-clear): %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("ReadGlobalCounter after clear = %d, want 0 "+
+			"(cleared total snaps back — #5098 offset reset reverted?)", got)
+	}
+
+	// A new offset after the clear accrues from zero (epoch restarted).
+	if err := m.IncrementGlobalCounter(idx, 5); err != nil {
+		t.Fatalf("post-clear IncrementGlobalCounter: %v", err)
+	}
+	got, err = m.ReadGlobalCounter(idx)
+	if err != nil {
+		t.Fatalf("ReadGlobalCounter (post-clear accrual): %v", err)
+	}
+	if got != 5 {
+		t.Fatalf("ReadGlobalCounter after post-clear accrual = %d, want 5", got)
+	}
+}

--- a/pkg/dataplane/userspace/manager_counters_test.go
+++ b/pkg/dataplane/userspace/manager_counters_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -581,6 +582,156 @@ func Test_clear_global_counters_resets_userspace_offset_5098(t *testing.T) {
 				"(delta baseline not rebased — #5098 prevBindingCounters revert?)", got)
 		}
 	})
+}
+
+// Test_clear_all_counters_offset_atomic_vs_status_poll_5098 is the #5098
+// review-fold regression gate for the lock-ordering residual. It proves the
+// global-counter offset reset and the delta-baseline rebase inside
+// ClearAllCounters run as ONE userspace-m.mu critical section that a concurrent
+// status poll cannot interleave with.
+//
+// Reproduction of the pre-fold hazard: a status poll (statusLoop) holds the
+// userspace m.mu across its whole cycle and, near the end,
+// syncBPFCountersLocked -> IncrementGlobalCounter accumulates its
+// cur-prevBindingCounters delta into the offset map (under the DATAPLANE m.mu).
+// Before the fold, ClearAllCounters reset the offset via bpfShim.ClearAllCounters
+// OUTSIDE the userspace m.mu, so it could zero the offset AFTER a mid-cycle poll
+// had already computed its delta but BEFORE that poll applied it — the poll then
+// re-added the delta into the just-zeroed offset, and the baseline rebase did
+// not re-zero it, leaving a persistent residual on the cleared totals.
+//
+// The test drives that exact interleaving deterministically via the
+// syncBPFCountersPreIncrementObserver seam: the observer fires while the poll
+// still holds the userspace m.mu and has advanced its baseline but not yet
+// applied the delta. It launches a concurrent ClearAllCounters there. With the
+// fold, that clear parks on the userspace m.mu and only runs (offset reset +
+// baseline rebase, atomically) after the poll releases it, so the offset ends at
+// 0. Reverting the fold — moving bpfShim.ClearAllCounters back outside the lock —
+// lets the residual reappear and fails the final assertion.
+func Test_clear_all_counters_offset_atomic_vs_status_poll_5098(t *testing.T) {
+	const rxIdx = dataplane.GlobalCtrRxPackets
+	m := New()
+
+	mkStatus := func(rx uint64) *ProcessStatus {
+		return &ProcessStatus{Bindings: []BindingStatus{{Slot: 0, RXPackets: rx}}}
+	}
+	// poll runs the REAL syncBPFCountersLocked so the pre-increment seam fires,
+	// exactly like the 1/s status poll.
+	poll := func(rx uint64) {
+		t.Helper()
+		status := mkStatus(rx)
+		m.mu.Lock()
+		m.recordHelperStatusLocked(status)
+		m.syncBPFCountersLocked(status)
+		m.mu.Unlock()
+	}
+
+	// First poll seeds prevBindingCounters=100 and the offset=100.
+	poll(100)
+	if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 100 {
+		t.Fatalf("seed rx offset = %d, want 100", got)
+	}
+
+	clearDone := make(chan error, 1)
+	var once sync.Once
+	syncBPFCountersPreIncrementObserver = func() {
+		once.Do(func() {
+			// Launch the clear while THIS poll still holds the userspace m.mu and
+			// is mid-sync (baseline advanced, IncrementGlobalCounter pending).
+			go func() { clearDone <- m.ClearAllCounters() }()
+			// Give the concurrent clear time to reach its offset reset. Pre-fold
+			// that reset lands here (it needs only the dataplane m.mu); post-fold
+			// the clear is parked on the userspace m.mu and this sleep is idle.
+			time.Sleep(100 * time.Millisecond)
+		})
+	}
+	defer func() { syncBPFCountersPreIncrementObserver = nil }()
+
+	// Second poll: cur=150, prev=100 -> delta=+50. Fires the seam (launching the
+	// concurrent clear), then applies IncrementGlobalCounter(rxIdx, 50).
+	poll(150)
+
+	if err := <-clearDone; err != nil &&
+		!strings.Contains(err.Error(), "interface_counters map not found") {
+		t.Fatalf("concurrent ClearAllCounters: unexpected error: %v", err)
+	}
+
+	// Atomic offset-reset + baseline-rebase ran entirely after the poll released
+	// m.mu, so the cleared offset is 0. A residual here means the clear's Phase-1
+	// reset slipped in mid-poll (fold reverted).
+	if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 0 {
+		t.Fatalf("rx offset after concurrent clear = %d, want 0 "+
+			"(residual — ClearAllCounters offset/baseline atomicity fold reverted?)", got)
+	}
+}
+
+// Test_clear_all_counters_concurrent_poll_race_5098 hammers ClearAllCounters
+// concurrently with a simulated 1/s status poll under -race. The offset reset
+// (dataplane m.mu) and the poll's IncrementGlobalCounter (dataplane m.mu) share
+// the dataplane lock, so the pre-fold bug was a lock-ORDERING residual, not a
+// data race; this test therefore does not detect the residual on its own (the
+// deterministic sibling above does). Its jobs are (1) prove the fold's
+// userspace->dataplane lock order never inverts into a deadlock — the test
+// completing at all is the proof — and (2) let -race confirm no path touches the
+// offset map unsynchronized. The final quiescent clear pins offset==0.
+func Test_clear_all_counters_concurrent_poll_race_5098(t *testing.T) {
+	const rxIdx = dataplane.GlobalCtrRxPackets
+	m := New()
+
+	mkStatus := func(rx uint64) *ProcessStatus {
+		return &ProcessStatus{Bindings: []BindingStatus{{Slot: 0, RXPackets: rx}}}
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var rx uint64
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			rx += 7
+			status := mkStatus(rx)
+			m.mu.Lock()
+			m.recordHelperStatusLocked(status)
+			m.syncBPFCountersLocked(status)
+			m.mu.Unlock()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := m.ClearAllCounters(); err != nil &&
+				!strings.Contains(err.Error(), "interface_counters map not found") {
+				t.Errorf("ClearAllCounters: %v", err)
+				return
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if err := m.ClearAllCounters(); err != nil &&
+		!strings.Contains(err.Error(), "interface_counters map not found") {
+		t.Fatalf("final ClearAllCounters: %v", err)
+	}
+	if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 0 {
+		t.Fatalf("rx offset after final clear = %d, want 0", got)
+	}
 }
 
 func TestSafeDelta(t *testing.T) {

--- a/pkg/dataplane/userspace/manager_counters_test.go
+++ b/pkg/dataplane/userspace/manager_counters_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -448,6 +449,138 @@ func TestSyncBPFCountersMirrorsNATRuleCounters(t *testing.T) {
 	if got != (dataplane.CounterValue{}) {
 		t.Fatalf("counter 1 after clear = %+v, want zero", got)
 	}
+}
+
+// Test_clear_global_counters_resets_userspace_offset_5098 is the #5098
+// fail-on-revert merge gate. ReadGlobalCounter returns the per-CPU BPF array sum
+// PLUS the in-memory userspaceCounterOffsets entry that IncrementGlobalCounter
+// and the 1/s status poll (syncBPFCountersLocked) accrue for userspace-forwarded
+// packets that bypass the BPF pipeline. Before #5098 neither ClearGlobalCounters
+// nor ClearAllCounters reset that offset map, so a cleared global RX/TX/drop/
+// session total snapped straight back to its pre-clear value on the next read.
+//
+// The gate is deliberately mapless (no BPF privileges required): it keys on
+// ReadUserspaceCounterOffset, which is exactly the offset half ReadGlobalCounter
+// merges on top of the (zeroed) BPF array — so the assertion runs everywhere,
+// not only on a privileged host. The full ReadGlobalCounter read equation
+// (array + offset == 0) is pinned by the sibling dataplane-package test
+// Test_clear_global_counters_read_equation_zero_5098.
+//
+// Reverting the offset reset in dataplane.Manager.ClearGlobalCounters fails the
+// post-clear "offset == 0" assertions; reverting the prevBindingCounters rebase
+// in userspace.Manager.ClearAllCounters fails the post-clear delta assertion.
+func Test_clear_global_counters_resets_userspace_offset_5098(t *testing.T) {
+	const rxIdx = dataplane.GlobalCtrRxPackets
+	const txIdx = dataplane.GlobalCtrTxPackets
+
+	t.Run("ClearGlobalCounters_resets_offset_and_restarts_accrual", func(t *testing.T) {
+		m := New()
+
+		// Seed a non-zero offset the way userspace-forwarded accounting does.
+		if err := m.bpfShim.IncrementGlobalCounter(rxIdx, 100); err != nil {
+			t.Fatalf("seed IncrementGlobalCounter: %v", err)
+		}
+		if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 100 {
+			t.Fatalf("seed rx offset = %d, want 100", got)
+		}
+
+		// The clear must drop the offset, not just the BPF array. Mapless, so the
+		// BPF-array zero is skipped and the offset reset is the whole clear.
+		if err := m.bpfShim.ClearGlobalCounters(); err != nil {
+			t.Fatalf("ClearGlobalCounters: %v", err)
+		}
+		if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 0 {
+			t.Fatalf("rx offset after ClearGlobalCounters = %d, want 0 "+
+				"(cleared total snaps back — #5098 offset reset reverted?)", got)
+		}
+
+		// A NEW delta after the clear accrues from zero, not on top of the stale
+		// pre-clear value.
+		if err := m.bpfShim.IncrementGlobalCounter(rxIdx, 42); err != nil {
+			t.Fatalf("post-clear IncrementGlobalCounter: %v", err)
+		}
+		if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 42 {
+			t.Fatalf("rx offset after post-clear accrual = %d, want 42 "+
+				"(offset did not restart from zero)", got)
+		}
+	})
+
+	t.Run("ClearAllCounters_resets_offset_and_rebases_delta_baseline", func(t *testing.T) {
+		m := New()
+
+		mkStatus := func(rx, tx uint64) *ProcessStatus {
+			return &ProcessStatus{Bindings: []BindingStatus{
+				{Slot: 0, RXPackets: rx, TXPackets: tx},
+			}}
+		}
+		// poll advances lastStatus AND accrues the helper delta into the offset
+		// (recording prevBindingCounters), exactly like the 1/s status poll.
+		poll := func(rx, tx uint64) {
+			t.Helper()
+			status := mkStatus(rx, tx)
+			m.mu.Lock()
+			m.recordHelperStatusLocked(status)
+			m.syncBPFCountersLocked(status)
+			m.mu.Unlock()
+		}
+		// record advances lastStatus WITHOUT a counter sync — what a status poll
+		// or a prior domain-scoped clear (e.g. `clear policies counters`) does.
+		record := func(rx, tx uint64) {
+			t.Helper()
+			status := mkStatus(rx, tx)
+			m.mu.Lock()
+			m.recordHelperStatusLocked(status)
+			m.mu.Unlock()
+		}
+
+		// First poll seeds the offset with the full cumulative (prev starts at 0).
+		poll(100, 80)
+		if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 100 {
+			t.Fatalf("seed rx offset = %d, want 100", got)
+		}
+		if got := m.bpfShim.ReadUserspaceCounterOffset(txIdx); got != 80 {
+			t.Fatalf("seed tx offset = %d, want 80", got)
+		}
+
+		// A later status refresh advances lastStatus past prevBindingCounters
+		// without a counter sync. This makes the prevBindingCounters rebase
+		// observable: the clear must adopt this fresher cumulative (120/90) as the
+		// new epoch baseline, not the stale poll-time baseline (100/80).
+		record(120, 90)
+
+		// Operator clear-all. Mapless, bpfShim.ClearInterfaceCounters returns a
+		// benign "interface_counters map not found"; the offset/baseline
+		// invariants under test are unaffected, so tolerate only that error.
+		if err := m.ClearAllCounters(); err != nil &&
+			!strings.Contains(err.Error(), "interface_counters map not found") {
+			t.Fatalf("ClearAllCounters: unexpected error: %v", err)
+		}
+		if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 0 {
+			t.Fatalf("rx offset after ClearAllCounters = %d, want 0 "+
+				"(cleared total snaps back — #5098 offset reset reverted?)", got)
+		}
+		if got := m.bpfShim.ReadUserspaceCounterOffset(txIdx); got != 0 {
+			t.Fatalf("tx offset after ClearAllCounters = %d, want 0 "+
+				"(cleared total snaps back — #5098 offset reset reverted?)", got)
+		}
+
+		// A subsequent poll with a HIGHER cumulative advances from zero by the
+		// POST-clear delta only. The helper keeps counting from launch, so the
+		// cumulative goes 120 -> 150 (a +30 post-clear delta). With the baseline
+		// rebased to the cumulative-at-clear (120/90), the offset reads 30/20. If
+		// prevBindingCounters were left at the stale poll-time baseline (100/80),
+		// the delta would be 50/30 and the cleared counter would jump past its
+		// pre-clear value.
+		poll(150, 110)
+		if got := m.bpfShim.ReadUserspaceCounterOffset(rxIdx); got != 30 {
+			t.Fatalf("rx offset after post-clear poll = %d, want 30 "+
+				"(delta baseline not rebased — #5098 prevBindingCounters revert?)", got)
+		}
+		if got := m.bpfShim.ReadUserspaceCounterOffset(txIdx); got != 20 {
+			t.Fatalf("tx offset after post-clear poll = %d, want 20 "+
+				"(delta baseline not rebased — #5098 prevBindingCounters revert?)", got)
+		}
+	})
 }
 
 func TestSafeDelta(t *testing.T) {

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -897,6 +897,16 @@ func sumBindingCounters(status *ProcessStatus) userspaceCounterSnapshot {
 	return s
 }
 
+// syncBPFCountersPreIncrementObserver is a test-only seam: it fires inside
+// syncBPFCountersLocked after the delta baseline has advanced
+// (prevBindingCounters = cur) but BEFORE the IncrementGlobalCounter loop
+// applies those deltas to the offset map. It is nil in production (the only
+// runtime cost is a nil check on the 1/s counter sync). The #5098 review-fold
+// atomicity test uses it to drive a concurrent ClearAllCounters through the
+// exact window a status poll can be interrupted at, proving the clear cannot
+// leave a residual in the just-reset offset.
+var syncBPFCountersPreIncrementObserver func()
+
 // syncBPFCountersLocked computes counter deltas since the last status poll
 // and writes them into the BPF global_counters per-CPU array map.
 // This ensures that packets forwarded by the userspace helper (which bypass
@@ -962,6 +972,10 @@ func (m *Manager) syncBPFCountersLocked(status *ProcessStatus) {
 			index: dataplane.ScreenReasonCounters[i].Index,
 			delta: safeDelta(cur.screenReasonDrops[i], prev.screenReasonDrops[i]),
 		})
+	}
+
+	if syncBPFCountersPreIncrementObserver != nil {
+		syncBPFCountersPreIncrementObserver()
 	}
 
 	for _, d := range deltas {

--- a/pkg/dataplane/userspace/policycounters.go
+++ b/pkg/dataplane/userspace/policycounters.go
@@ -311,6 +311,13 @@ func (m *Manager) ClearPolicyCounters() error {
 func (m *Manager) ClearAllCounters() error {
 	var errs []error
 	if m.bpfShim != nil {
+		// bpfShim.ClearAllCounters() zeroes the BPF per-CPU counter arrays AND,
+		// via ClearGlobalCounters, the in-memory global counter offset map
+		// (userspaceCounterOffsets) that ReadGlobalCounter merges on top of the
+		// array (#5098). Before #5098 only the array was zeroed, so a cleared
+		// global RX/TX/drop/session total snapped straight back to its pre-clear
+		// value because the accumulated offset half survived. It also drops the
+		// per-zone (#3643) and flood offset maps.
 		if err := m.bpfShim.ClearAllCounters(); err != nil {
 			errs = append(errs, err)
 		}
@@ -318,14 +325,15 @@ func (m *Manager) ClearAllCounters() error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
 	if err := m.clearHelperPolicyCountersLocked(); err != nil {
 		errs = append(errs, err)
 	}
 	// #2218: a clear-all must also reset the helper NAT translation hit store,
 	// otherwise the per-rule NAT totals snap back on the next status poll (the
 	// helper reports cumulative-since-start and syncBPFCountersLocked overwrites
-	// the offset absolutely). bpfShim.ClearAllCounters() already zeroed the Go
-	// offset map; this sends the clear_nat_counters IPC.
+	// the offset absolutely). This sends the clear_nat_counters IPC so the helper
+	// store resets and the next poll re-mirrors 0 onto the offset.
 	if err := m.clearHelperNATCountersLocked(); err != nil {
 		errs = append(errs, err)
 	}
@@ -333,10 +341,22 @@ func (m *Manager) ClearAllCounters() error {
 	// otherwise the per-zone totals snap back on the next status poll (the
 	// helper reports cumulative-since-start and syncBPFCountersLocked overwrites
 	// the offset absolutely). bpfShim.ClearAllCounters() already zeroed the Go
-	// offset map; this sends the clear_zone_counters IPC.
+	// zone offset map (via ClearZoneCounters); this sends the clear_zone_counters
+	// IPC so the helper store resets too.
 	if err := m.clearHelperZoneCountersLocked(); err != nil {
 		errs = append(errs, err)
 	}
+
+	// #5098: restart the global-counter delta epoch. syncBPFCountersLocked
+	// ACCUMULATES each 1/s helper delta (cur - prevBindingCounters) into the
+	// global offset map that bpfShim.ClearAllCounters() just reset to zero —
+	// unlike the NAT/zone stores above, which overwrite absolutely. Rebase the
+	// baseline to the last-recorded cumulative so the next poll measures traffic
+	// strictly AFTER the clear; leaving prevBindingCounters below the current
+	// cumulative would fold the pre-clear span back in as one large delta on the
+	// next poll. Done last so it captures the freshest helper status, and under
+	// the m.mu held here — the same lock syncBPFCountersLocked mutates it under.
+	m.prevBindingCounters = sumBindingCounters(&m.lastStatus)
 	return errors.Join(errs...)
 }
 

--- a/pkg/dataplane/userspace/policycounters.go
+++ b/pkg/dataplane/userspace/policycounters.go
@@ -310,6 +310,34 @@ func (m *Manager) ClearPolicyCounters() error {
 
 func (m *Manager) ClearAllCounters() error {
 	var errs []error
+
+	// #5098 (review fold): hold the userspace m.mu across the ENTIRE method so
+	// the global-counter offset reset (inside bpfShim.ClearAllCounters) and the
+	// delta-baseline rebase (m.prevBindingCounters, at the end) land in ONE
+	// critical section that the 1/s status poll cannot interleave with. The poll
+	// (statusLoop) holds this SAME userspace m.mu across its whole cycle and only
+	// near the end calls syncBPFCountersLocked -> IncrementGlobalCounter, which
+	// ACCUMULATES cur-prevBindingCounters into the offset map. Before this fold
+	// the offset reset ran OUTSIDE the userspace lock (bpfShim.ClearAllCounters
+	// takes only the DATAPLANE m.mu), so a poll mid-cycle could re-add a
+	// stale-baseline delta into the freshly-zeroed offset AFTER the reset but
+	// BEFORE the baseline rebase — the rebase does not re-zero the offset, so the
+	// cleared global RX/TX/drop/session totals kept a small constant residual
+	// (bounded by ~1 poll interval of pre-clear traffic) until the next clear.
+	// Serializing the whole method under m.mu makes that interleaving impossible:
+	// the poll either fully completes before the clear starts, or runs entirely
+	// after it (offset already 0, baseline already rebased), so the next delta
+	// measures strictly post-clear traffic.
+	//
+	// Lock order is userspace m.mu -> dataplane m.mu: bpfShim.ClearAllCounters
+	// (via ClearGlobalCounters) and the poll's IncrementGlobalCounter both take
+	// the dataplane m.mu only while the userspace m.mu is held, matching the
+	// poll's order, so this cannot deadlock. Nothing reached under the userspace
+	// m.mu here re-takes it — the clearHelper*Locked helpers assume it is held
+	// and never re-lock; the bpfShim methods touch only the dataplane m.mu.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.bpfShim != nil {
 		// bpfShim.ClearAllCounters() zeroes the BPF per-CPU counter arrays AND,
 		// via ClearGlobalCounters, the in-memory global counter offset map
@@ -322,9 +350,6 @@ func (m *Manager) ClearAllCounters() error {
 			errs = append(errs, err)
 		}
 	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if err := m.clearHelperPolicyCountersLocked(); err != nil {
 		errs = append(errs, err)
@@ -356,6 +381,10 @@ func (m *Manager) ClearAllCounters() error {
 	// cumulative would fold the pre-clear span back in as one large delta on the
 	// next poll. Done last so it captures the freshest helper status, and under
 	// the m.mu held here — the same lock syncBPFCountersLocked mutates it under.
+	// Because the offset reset above (bpfShim.ClearAllCounters) now runs under
+	// this SAME m.mu (see the method header), the reset and this rebase form one
+	// atomic epoch restart: the poll cannot slip an IncrementGlobalCounter delta
+	// between them, so no residual survives.
 	m.prevBindingCounters = sumBindingCounters(&m.lastStatus)
 	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Problem

`ReadGlobalCounter` (`pkg/dataplane/maps_counters.go`) returns the per-CPU
`global_counters` BPF array sum **plus** an in-memory `userspaceCounterOffsets`
entry. `IncrementGlobalCounter` — driven by the 1/s status poll's
`syncBPFCountersLocked` — **accumulates** each helper delta (`cur -
prevBindingCounters`) into that offset so userspace-forwarded packets (RX/TX,
aggregate/per-reason drops, SYN-cookie, NAT64) that bypass the BPF pipeline are
reflected.

Neither `ClearGlobalCounters` nor `ClearAllCounters` ever reset that offset map —
they zeroed only the BPF per-CPU array and the helper policy/NAT/zone stores. So
in userspace mode a cleared global RX/TX/drop/session total **snapped straight
back** to its pre-clear value on the next read: the accumulated offset half
survived. The `policycounters.go` comment falsely claimed
`bpfShim.ClearAllCounters()` had already zeroed the offset map.

## Fix

A counter clear is an **epoch** operation: every source the read equation merges
must move to zero under the same lock and order.

- `ClearGlobalCounters` now drops the whole offset map **first**, under the
  `m.mu` that guards every `IncrementGlobalCounter`/`ReadGlobalCounter` access —
  so the clear takes effect even without a loaded BPF map (userspace-only
  runtime, parity with `ClearZoneCounters`/`ClearNATRuleCounters`) and a
  concurrent `ReadGlobalCounter` cannot merge a zeroed array with a stale offset.
  A missing `global_counters` map is no longer a hard error (the offset reset is
  the meaningful clear in userspace mode).
- `ClearAllCounters` inherits the reset via `ClearGlobalCounters`.
- The userspace `Manager.ClearAllCounters` additionally rebases
  `prevBindingCounters` to the last-recorded cumulative, so the next poll's delta
  measures traffic strictly **after** the clear rather than folding the pre-clear
  span back in.
- Corrected the false `policycounters.go` comment.

## Tests

- **`Test_clear_global_counters_resets_userspace_offset_5098`** (userspace pkg,
  mapless, **always runs** — the merge gate): seeds an offset via
  `IncrementGlobalCounter` **and** a helper poll, clears via **both**
  `ClearGlobalCounters` and the operator `ClearAllCounters` path, asserts the
  offset resets to 0 and a post-clear delta restarts from zero.
- **`Test_clear_global_counters_read_equation_zero_5098`** (dataplane pkg,
  privileged; skips on unprivileged hosts): pins the full `ReadGlobalCounter`
  array+offset == 0 read equation.

**Parent-RED verified** (assertion failures, not build breaks): disabling the
offset reset makes both subtests RED (offset snaps back to 100); disabling the
`prevBindingCounters` rebase makes the delta subtest RED (reads 50, want 30).

## Validation

Full `pkg/dataplane/...` suite green under `-race`; named test 3× no flake;
`cli`/`api`/`grpcapi`/`daemon` consumers green; `gofmt` + `go vet` clean;
`go build ./...` clean.

**Not HA** — counter clear path, unit-provable, no cluster smoke required.

Docs: `docs/userspace-dataplane-gaps.md` gains a "Global counter clear is an
epoch (#5098)" bullet.

Closes #5098
