### PR TITLE
afxdp/tx: define + test TX-status Drop-vs-retry precedence (#6145)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -53720,3 +53720,20 @@ top.
   pkg/dataplane/userspace/process_napi.go,
   pkg/dataplane/userspace/neighbor_prewarm_singleflight_5104_test.go,
   docs/userspace-cold-start-fix-plan.md
+
+## 2026-07-20 — #6145 TX-status Drop-vs-retry precedence
+
+- **Timestamp**: 2026-07-20
+- **Action**: Document + test the `last_error` snapshot precedence
+  (#4971 follow-up). A latched exceptional `TxError::Drop` (mutex
+  `set_error`) OUTRANKS the lock-free `last_tx_retry_status` hint until
+  the binding rebinds (`clear_error`). Chose option (a) — make the
+  stale-masking an intentional, documented, tested invariant (a Drop is
+  rarer + more severe than routine backpressure). No hot-path change.
+- **File(s)**:
+  - `userspace-dp/src/afxdp/umem/snapshot.rs` (expanded precedence comment)
+  - `userspace-dp/src/afxdp/umem/mod.rs` (`last_tx_retry_status` field doc)
+  - `userspace-dp/src/afxdp/umem/tests/snapshot_propagation.rs`
+    (fail-on-revert test `tx_status_drop_error_outranks_retry_hint_until_rebind_6145`)
+  - `userspace-dp/src/afxdp/tx/README.md` (precedence section)
+  - `userspace-dp/src/afxdp/umem/README.md` (snapshot precedence invariant)

--- a/userspace-dp/src/afxdp/tx/README.md
+++ b/userspace-dp/src/afxdp/tx/README.md
@@ -21,6 +21,38 @@ writer to synchronize against.
 | `stats.rs` | Per-frame counters and submit-latency histogram bucketing. The sidecar `&mut [u64]` is non-atomic since it's owner-only. |
 | `tcp_segmentation.rs` | TCP segmentation for forwarded frames (extracted in PR #1199). `#[cold]` — segmentation is the slow path; line-rate flows don't enter it. **#5141:** the local-owner fast-path twin of `frame/tcp_segmentation.rs` — it clamps the segmentable payload to the IP-declared datagram end (`declared_l3_end`, IPv4 `total_len` / IPv6 `40 + payload_len`) instead of the raw `&frame[l3..]` backing, so trailing Ethernet slack / appended bytes are never chunked into fresh checksummed segments. Kept byte-identical to the copy-path twin; the admission gate `forwarded_tcp_may_need_segmentation` in `dispatch/mod.rs` clamps the same way. **#5148:** neither the admission gate NOR the builder segments ANY IP fragment — first or non-first. A fragment (IPv4 MF=1 or offset≠0, or an IPv6 Fragment extension header) still carries the fragment-bearing IP header (Identification / MF / offset), so segmenting it would clone that header into every output while rewriting seq/checksum — overlapping offset-0 pseudo-fragments that break reassembly. The gate uses `is_any_fragment` (was the non-first-only `is_non_first_fragment` before #5148) and the builder repeats the guard (defense in depth); any fragment is routed to the normal forwarding path unchanged, matching the sibling #1852 non-first handling. Segmentation is only for WHOLE (unfragmented) over-MTU TCP datagrams. **#5159:** the egress-MTU lookup now uses the ACTUAL interface MTU — the prior `.unwrap_or_default().max(1280)` floored every plain-interface MTU to 1280, the IPv6 *minimum link* MTU, which is NOT an IPv4 floor (IPv4 min is 68). A valid egress MTU of 68–1279 was raised to 1280, so a non-DF TCP datagram whose L3 length fell in `(real_mtu, 1280]` was never flagged/chunked and was submitted OVERSIZE to AF_XDP TX. All three plain-forward sites drop the floor and treat `0` (no egress entry / unknown MTU) as "don't segment" via the now-live `mtu == 0` guard: the admission gate (`forwarded_tcp_may_need_segmentation`, `dispatch/mod.rs`), this TX builder, and the `frame/tcp_segmentation.rs` copy-path twin — kept byte-identical. Any IPv6-minimum floor belongs at interface config, not the per-packet segmenter. |
 | `transmit/` | XSK TX-ring submit + per-frame recycle. Owns `transmit_batch`, `transmit_prepared_queue`, shared-UMEM-aware prepared recycle helpers, and the `TxError` enum. **#4971:** `TxError::Retry`/`Drop` carry `Copy` reason codes (`TxRetryReason` / `TxDropReason`), NOT heap `String`s — the expected-backpressure retry path recurs every drain pass under ring pressure, so it must be allocation-free. The un-inserted retry tail is restored to `pending` by reverse-popping the staged scratch (`pop()` → new `len()` == popped index), preserving FIFO order with no side `Vec`. |
+
+## TX status precedence: Drop error vs expected-retry hint (#4971 / #6145)
+
+The two TX outcomes reach operator status through **different** channels,
+and the status snapshot has a deliberate precedence between them:
+
+- `TxError::Retry(reason)` — the expected-backpressure path — records its
+  reason lock-free via `BindingLiveState::set_tx_retry_status` (a single
+  `Relaxed` `AtomicU8`). It never takes the `last_error` mutex; the send
+  hot path must stay lock-free / alloc-free.
+- `TxError::Drop(reason)` — the rare exceptional capacity / slice-bounds
+  fault — renders a message into the `last_error` **mutex** via
+  `set_error`.
+
+`BindingLiveState::snapshot()` (`umem/snapshot.rs`, ~1s read side)
+surfaces the retry hint **only as the `last_error` fallback** — i.e. when
+the `last_error` string is empty. A non-empty `last_error` therefore
+**outranks** the live retry hint.
+
+**#6145 — intentional stale-masking.** A latched `TxError::Drop` leaves
+`last_error` non-empty and the ongoing retry path (atomic-only) never
+clears it. So while a Drop is latched, sustained retries afterward keep
+surfacing the **Drop** string, not the current retry reason, until the
+binding rebinds and `clear_error()` wipes both (mutex string + retry
+atomic). This precedence is deliberate: a `TxError::Drop` is rarer and
+more severe than expected backpressure — it flags a real capacity /
+slice fault an operator must see — so it must not be masked by a flood of
+routine retry hints. `clear_error()` (rebind / successful reconcile) is
+the single reset point; a fresh retry recorded after the clear renders
+normally. Pinned by
+`tx_status_drop_error_outranks_retry_hint_until_rebind_6145`
+(`umem/tests/snapshot_propagation.rs`).
 | `test_support.rs` | Test helpers for the per-file unit tests. |
 
 ## Where it sits

--- a/userspace-dp/src/afxdp/tx/README.md
+++ b/userspace-dp/src/afxdp/tx/README.md
@@ -22,6 +22,8 @@ writer to synchronize against.
 | `tcp_segmentation.rs` | TCP segmentation for forwarded frames (extracted in PR #1199). `#[cold]` — segmentation is the slow path; line-rate flows don't enter it. **#5141:** the local-owner fast-path twin of `frame/tcp_segmentation.rs` — it clamps the segmentable payload to the IP-declared datagram end (`declared_l3_end`, IPv4 `total_len` / IPv6 `40 + payload_len`) instead of the raw `&frame[l3..]` backing, so trailing Ethernet slack / appended bytes are never chunked into fresh checksummed segments. Kept byte-identical to the copy-path twin; the admission gate `forwarded_tcp_may_need_segmentation` in `dispatch/mod.rs` clamps the same way. **#5148:** neither the admission gate NOR the builder segments ANY IP fragment — first or non-first. A fragment (IPv4 MF=1 or offset≠0, or an IPv6 Fragment extension header) still carries the fragment-bearing IP header (Identification / MF / offset), so segmenting it would clone that header into every output while rewriting seq/checksum — overlapping offset-0 pseudo-fragments that break reassembly. The gate uses `is_any_fragment` (was the non-first-only `is_non_first_fragment` before #5148) and the builder repeats the guard (defense in depth); any fragment is routed to the normal forwarding path unchanged, matching the sibling #1852 non-first handling. Segmentation is only for WHOLE (unfragmented) over-MTU TCP datagrams. **#5159:** the egress-MTU lookup now uses the ACTUAL interface MTU — the prior `.unwrap_or_default().max(1280)` floored every plain-interface MTU to 1280, the IPv6 *minimum link* MTU, which is NOT an IPv4 floor (IPv4 min is 68). A valid egress MTU of 68–1279 was raised to 1280, so a non-DF TCP datagram whose L3 length fell in `(real_mtu, 1280]` was never flagged/chunked and was submitted OVERSIZE to AF_XDP TX. All three plain-forward sites drop the floor and treat `0` (no egress entry / unknown MTU) as "don't segment" via the now-live `mtu == 0` guard: the admission gate (`forwarded_tcp_may_need_segmentation`, `dispatch/mod.rs`), this TX builder, and the `frame/tcp_segmentation.rs` copy-path twin — kept byte-identical. Any IPv6-minimum floor belongs at interface config, not the per-packet segmenter. |
 | `transmit/` | XSK TX-ring submit + per-frame recycle. Owns `transmit_batch`, `transmit_prepared_queue`, shared-UMEM-aware prepared recycle helpers, and the `TxError` enum. **#4971:** `TxError::Retry`/`Drop` carry `Copy` reason codes (`TxRetryReason` / `TxDropReason`), NOT heap `String`s — the expected-backpressure retry path recurs every drain pass under ring pressure, so it must be allocation-free. The un-inserted retry tail is restored to `pending` by reverse-popping the staged scratch (`pop()` → new `len()` == popped index), preserving FIFO order with no side `Vec`. |
 
+| `test_support.rs` | Test helpers for the per-file unit tests. |
+
 ## TX status precedence: Drop error vs expected-retry hint (#4971 / #6145)
 
 The two TX outcomes reach operator status through **different** channels,
@@ -53,7 +55,6 @@ the single reset point; a fresh retry recorded after the clear renders
 normally. Pinned by
 `tx_status_drop_error_outranks_retry_hint_until_rebind_6145`
 (`umem/tests/snapshot_propagation.rs`).
-| `test_support.rs` | Test helpers for the per-file unit tests. |
 
 ## Where it sits
 

--- a/userspace-dp/src/afxdp/umem/README.md
+++ b/userspace-dp/src/afxdp/umem/README.md
@@ -38,6 +38,19 @@ drop-in for xdpilone), and tracks frame budgets per binding.
   unit tests can exercise worker-owned drain paths without creating
   kernel AF_XDP sockets; production UMEM construction remains
   `WorkerUmem::new`.
+- **Status-snapshot `last_error` precedence (#4971 / #6145).**
+  `snapshot()` (`snapshot.rs`) renders `last_error` from TWO sources with
+  a fixed precedence: the `last_error` **mutex** string (written by the
+  exceptional `TxError::Drop` / bind / reconcile paths via `set_error`)
+  wins whenever non-empty; only when it is empty does the snapshot fall
+  back to the lock-free `last_tx_retry_status` atomic (the expected-TX
+  backpressure hint from #4971). Consequence: a latched `TxError::Drop`
+  **masks** a live retry hint until the binding rebinds and
+  `clear_error()` resets both. This stale-masking is intentional — a
+  Drop is rarer and more severe than routine backpressure — and is
+  pinned by `tx_status_drop_error_outranks_retry_hint_until_rebind_6145`
+  (`tests/snapshot_propagation.rs`). See `../tx/README.md` for the full
+  rationale.
 - In **zero-copy mode on mlx5**, an `XDP_PASS` action permanently
   consumes a fill-ring frame: the kernel holds the UMEM buffer in
   an SKB and never returns it. Sustained traffic drains all 12K+ RX

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -837,9 +837,16 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// `set_tx_retry_status` INSTEAD of taking the `last_error` mutex —
     /// the TX drain path recurs every pass under ring pressure, so a
     /// mutex acquire there is a hot-path cost. Surfaced as the
-    /// `last_error` fallback in the status snapshot (read side, ~1s
+    /// `last_error` FALLBACK in the status snapshot (read side, ~1s
     /// poll), so operator visibility of the backpressure reason is
     /// preserved without any lock on the send hot path.
+    ///
+    /// #6145 — precedence: this hint is surfaced ONLY when the
+    /// `last_error` mutex string is empty. A non-empty `last_error`
+    /// (an exceptional `TxError::Drop`, bind, or reconcile fault)
+    /// OUTRANKS this hint and masks it until `clear_error()` (rebind)
+    /// resets both. That stale-masking is deliberate — a Drop is rarer
+    /// and more severe than expected backpressure. See `snapshot.rs`.
     pub(super) last_tx_retry_status: AtomicU8,
     /// Cross-worker redirect inbox (#706). N producer workers push
     /// redirected `TxRequest`s; the single owner worker drains. Bounded

--- a/userspace-dp/src/afxdp/umem/snapshot.rs
+++ b/userspace-dp/src/afxdp/umem/snapshot.rs
@@ -283,11 +283,30 @@ impl BindingLiveState {
                 self.last_heartbeat.load(Ordering::Relaxed),
                 now_mono,
             ),
-            // #4971: prefer a genuine error string (mutex, written by
-            // the exceptional drop / bind / reconcile paths). If empty,
-            // fall back to the lock-free TX-retry status so an expected
-            // backpressure reason stays visible in `show` output —
-            // without the send hot path ever taking the mutex.
+            // #4971 / #6145: `last_error` precedence — a genuine error
+            // STRING (the mutex, written by the exceptional
+            // drop / bind / reconcile paths via `set_error`) OUTRANKS
+            // the lock-free expected-TX-retry hint. Only when the mutex
+            // string is EMPTY do we fall back to the
+            // `last_tx_retry_status` atomic, so an expected backpressure
+            // reason stays visible in `show` output without the send hot
+            // path ever taking the mutex.
+            //
+            // #6145 — intentional stale-masking: a prior exceptional
+            // `TxError::Drop` (capacity / slice fault) leaves `last_error`
+            // non-empty and is NOT cleared by the ongoing expected-retry
+            // path (which only writes the atomic). So while a Drop error
+            // is latched, sustained retries afterward keep surfacing that
+            // Drop string, NOT the current retry reason, until the binding
+            // rebinds and `clear_error()` wipes BOTH. This precedence is
+            // DELIBERATE: a `TxError::Drop` is rarer and more severe than
+            // expected backpressure (it flags a real capacity /
+            // slice-bounds fault an operator must see), so the
+            // more-severe latched error must not be masked by a flood of
+            // routine retry hints. `clear_error()` (rebind / successful
+            // reconcile) is the single reset point; a fresh retry recorded
+            // AFTER the clear then renders normally. Pinned by
+            // `tx_status_drop_error_outranks_retry_hint_until_rebind_6145`.
             last_error: {
                 let err = self
                     .last_error

--- a/userspace-dp/src/afxdp/umem/tests/snapshot_propagation.rs
+++ b/userspace-dp/src/afxdp/umem/tests/snapshot_propagation.rs
@@ -103,6 +103,83 @@ fn owner_profile_telemetry_is_cacheline_isolated_from_binding_live_state() {
 }
 
 #[test]
+fn tx_status_drop_error_outranks_retry_hint_until_rebind_6145() {
+    // #6145: pin the `last_error` snapshot precedence introduced by
+    // #4971's lock-free TX-retry status. The snapshot renders the
+    // `last_error` mutex string when non-empty, and ONLY falls back to
+    // the `last_tx_retry_status` atomic when that string is empty.
+    //
+    // The property under test: an exceptional `TxError::Drop` error
+    // (written to `last_error` via `set_error`) OUTRANKS the live
+    // expected-retry hint and keeps masking it until the binding
+    // rebinds (`clear_error`). This is deliberate — a Drop flags a real
+    // capacity / slice-bounds fault and is rarer + more severe than
+    // routine backpressure, so it must not be masked by a flood of
+    // retry hints.
+    //
+    // FAIL-ON-REVERT (assertion, NOT a build break — every symbol used
+    // here exists regardless of the precedence branch): inverting the
+    // precedence so the retry atomic wins over a non-empty `last_error`
+    // makes the Phase-3 assertion RED (it would surface the retry
+    // reason instead of the latched Drop message). Removing the
+    // empty-`last_error` fallback entirely makes Phase 2 / Phase 5 RED.
+    use crate::afxdp::tx::{TxDropReason, TxRetryReason};
+
+    let live = BindingLiveState::new();
+
+    // Phase 1 — clean slate: no error, no retry hint → empty.
+    assert!(
+        live.snapshot().last_error.is_empty(),
+        "phase 1: a fresh binding has no last_error and no retry hint"
+    );
+
+    // Phase 2 — an expected retry with an EMPTY last_error renders the
+    // retry reason (the #4971 fallback works).
+    live.set_tx_retry_status(TxRetryReason::NoFreeTxFrame);
+    assert_eq!(
+        live.snapshot().last_error,
+        TxRetryReason::NoFreeTxFrame.as_str(),
+        "phase 2: with last_error empty, the retry hint is the fallback"
+    );
+
+    // Phase 3 — an exceptional Drop latches last_error. Even with the
+    // retry hint still set, the Drop message OUTRANKS the retry reason.
+    let drop_msg =
+        TxDropReason::PreparedSliceOutOfRange { offset: 4096, len: 128 }.message();
+    live.set_error(drop_msg.clone());
+    // Sustained retries keep firing AFTER the Drop latched — they only
+    // touch the lock-free atomic, never clearing last_error.
+    live.set_tx_retry_status(TxRetryReason::TxRingInsertFailed);
+    let snap = live.snapshot();
+    assert_eq!(
+        snap.last_error, drop_msg,
+        "phase 3: a latched Drop error must outrank the live retry hint"
+    );
+    assert_ne!(
+        snap.last_error,
+        TxRetryReason::TxRingInsertFailed.as_str(),
+        "phase 3: the current retry reason must NOT surface while a Drop is latched"
+    );
+
+    // Phase 4 — rebind: clear_error wipes BOTH the mutex string and the
+    // retry atomic (#4971). Snapshot returns to empty.
+    live.clear_error();
+    assert!(
+        live.snapshot().last_error.is_empty(),
+        "phase 4: clear_error (rebind) resets both last_error and the retry hint"
+    );
+
+    // Phase 5 — post-rebind: a fresh retry recorded after the clear now
+    // renders again (last_error empty → fallback live).
+    live.set_tx_retry_status(TxRetryReason::NoPreparedTxFrame);
+    assert_eq!(
+        live.snapshot().last_error,
+        TxRetryReason::NoPreparedTxFrame.as_str(),
+        "phase 5: after rebind, a fresh retry reason surfaces normally"
+    );
+}
+
+#[test]
 fn binding_live_snapshot_propagates_710_drop_counters() {
     // #710: `refresh_bindings` in the coordinator copies
     // `snap.redirect_inbox_overflow_drops`, `pending_tx_local_overflow_drops`,


### PR DESCRIPTION
## Summary

Follow-up to the just-merged #4971. #4971 moved the expected
TX-backpressure retry status off the `last_error` mutex onto a lock-free
`BindingLiveState::last_tx_retry_status` AtomicU8, keeping the send hot
path lock-free / alloc-free. The status snapshot
(`userspace-dp/src/afxdp/umem/snapshot.rs`, ~1s read side) surfaces the
retry reason **only as the `last_error` fallback** — when the
`last_error` mutex string is empty.

That introduced a subtle divergence: previously `last_error` was
continuously refreshed with the retry string during sustained
backpressure; now a prior exceptional `TxError::Drop` (or a stale
bind/reconcile error) that left `last_error` non-empty and was never
cleared keeps surfacing that **stale, more-severe** error in `show`
output instead of the current retry reason — until `clear_error()` runs
on rebind.

## Fix — option (a): document the precedence (lowest-risk)

The issue offered (a) document the precedence or (b) age-out the stale
error. Chose **(a)**: a `TxError::Drop` is a rare exceptional capacity /
slice-bounds fault an operator must see — rarer and more severe than
routine expected backpressure — so surfacing the latched Drop error
until the binding rebinds is the *intended* precedence, not a bug.
Routine retry hints must not mask it. Option (b) was rejected: it adds
read-side timestamp state for no behavioral gain, since masking the
more-severe error is the wanted outcome.

**No runtime logic change** — the snapshot precedence branch is
byte-identical to master (only comments differ). The send hot path stays
lock-free / alloc-free. This PR is documentation + a read-side test.

### Docs (module contract)
- `umem/snapshot.rs` — expanded precedence comment (Drop outranks the
  retry hint; `clear_error()` is the single reset point).
- `umem/mod.rs` — `last_tx_retry_status` field doc cross-references the
  precedence + intentional stale-masking.
- `tx/README.md` — new "TX status precedence: Drop error vs
  expected-retry hint" section.
- `umem/README.md` — snapshot `last_error` precedence invariant.

### Fail-on-revert test (merge gate)
`tx_status_drop_error_outranks_retry_hint_until_rebind_6145`
(`umem/tests/snapshot_propagation.rs`) drives five transitions:

1. clean slate → empty
2. retry hint with empty `last_error` → retry reason renders (the #4971
   fallback)
3. Drop latched via `set_error` + retry still firing → **Drop outranks
   the live retry hint**
4. `clear_error()` (rebind) → both reset → empty
5. post-rebind fresh retry → retry reason renders again

**Parent-RED verified:** inverting the snapshot precedence so the retry
hint wins makes the phase-3 assertion RED — an assertion failure (`phase
3: a latched Drop error must outrank the live retry hint`), not a build
break; target-count 1.

## Validation
- Full `userspace-dp` cargo `--release` suite green: **4070 passed, 0
  failed**.
- Named test passes **3×** for flake.
- **Not HA** — TX-status observability, unit-provable, no cluster smoke
  required.

Closes #6145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUJSNxobqd2RoRMFB693LK
