### PR TITLE
userspace-dp NAT: mixed-set partial-resolution test + strict-NAT comment fix (#6143)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -53839,3 +53839,26 @@ top.
     (fail-on-revert test `tx_status_drop_error_outranks_retry_hint_until_rebind_6145`)
   - `userspace-dp/src/afxdp/tx/README.md` (precedence section)
   - `userspace-dp/src/afxdp/umem/README.md` (snapshot precedence invariant)
+
+- **Timestamp**: 2026-07-20
+- **Action**: #6143 — two non-blocking follow-ups from the #6142/#4925
+  NAT feed-nested-set review. (1) Test-coverage: add a fail-on-revert
+  pin that a NAT `match {source,destination}-address-name` referencing a
+  mixed address-SET `{resolvable-static-member, unresolvable-non-feed
+  token}` PARTIALLY resolves on the lenient/peer-sync runtime path — it
+  carries the static member's prefixes and stays NON-EMPTY (fail-closed,
+  no match-any widening), matching the security-policy runtime path. The
+  #4925 SSOT expander (expandBookNameRecursive) drops the unresolvable
+  member instead of the old static resolver's poison-the-whole-set.
+  Verified RED on a static-resolver revert (whole set poisons → raw
+  set-name token / dropped DNAT row). (2) Doc: reword the stale
+  strict-NAT comment so it is clear it describes the STRICT-COMMIT gate
+  behavior ONLY and that the LENIENT runtime path now feed-resolves
+  nested set members (#4925). Test + comment only; no production logic
+  change. Not HA (no cluster smoke).
+- **File(s)**:
+  - `pkg/dataplane/userspace/nat_mixed_static_unresolvable_set_6143_test.go`
+    (new fail-on-revert test
+    `Test_nat_mixed_static_and_unresolvable_set_partial_resolves_6143`)
+  - `pkg/config/compiler_validate_strict_nat.go` (strict-vs-runtime
+    comment reword in `validateNATSourceAddressNameReferencesStrict`)

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -987,9 +987,20 @@ func validateSourceNATPoolAddressScopeStrict(cfg *Config) error {
 // binding is ACCEPTED — the static book expansion is empty but
 // resolveNATAddressNamePrefixes unions the live feed overlay at runtime, so the
 // rule does carry prefixes. Mirrors validatePolicyMatchAddressesStrict's
-// AddressBindings carve-out; deliberately scoped to the DIRECT reference (a
-// feed member NESTED in an address-set is still poisoned by the static
-// resolver — the anti-Option-C guardrail, identical to the policy path).
+// AddressBindings carve-out; deliberately scoped to the DIRECT reference. At
+// THIS strict commit gate a feed member NESTED in an address-set is NOT covered
+// by the carve-out: nested membership is judged by the static
+// policyMatchAddressBookResolves check (which never consults the feed overlay),
+// so a set whose only resolvable content is a feed member is still rejected at
+// commit — the anti-Option-C guardrail, identical to the policy path.
+//
+// This paragraph describes the STRICT-COMMIT gate behavior ONLY. Since #4925 the
+// LENIENT runtime resolver (resolveNATAddressNamePrefixes ->
+// expandBookNameRecursive, pkg/dataplane/userspace/nat.go) DOES feed-resolve
+// nested set members via the policy SSOT expander, so at RUNTIME a mixed
+// static+feed set partially resolves (it carries the resolvable members'
+// prefixes) instead of being poisoned whole. The commit gate is intentionally
+// stricter than the runtime path; this comment does not change that behavior.
 //
 // On the tolerant load / peer-sync paths the call site downgrades to a warning
 // (opts.lenientFirewallRefs) so an already-persisted or peer-synced config

--- a/pkg/dataplane/userspace/nat_mixed_static_unresolvable_set_6143_test.go
+++ b/pkg/dataplane/userspace/nat_mixed_static_unresolvable_set_6143_test.go
@@ -1,0 +1,209 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6143 (follow-up to #4925): a NAT `match {source,destination}-address-name`
+// reference to an address-SET that mixes a RESOLVABLE STATIC member with a
+// genuinely-UNRESOLVABLE NON-FEED token must PARTIALLY resolve on the lenient /
+// peer-sync runtime path — it carries the static member's prefixes while the
+// unresolvable token is silently dropped. This is the SSOT expander's behavior
+// (expandBookNameRecursive, adopted by resolveNATAddressNamePrefixes in #4925),
+// and it matches the security-policy runtime path.
+//
+// This is SAFE: the constraint stays NON-EMPTY (the static prefix), so the rule
+// never widens to match-any; the strict commit gate
+// (validateNATSourceAddressNameReferencesStrict / policyMatchAddressBookResolves)
+// still rejects such a config at commit. The existing dead_set_fails_closed pin
+// (nat_feed_nested_set_4925_test.go) only covers the ALL-unresolvable case; this
+// pins the MIXED static+unresolvable case #4925 changed as a side effect.
+//
+// Fail-on-revert: reverting resolveNATAddressNamePrefixes to the old static
+// resolveUserspaceAddressBookEntry resolver makes the mixed set POISON on the
+// unresolvable "ghost" member — the whole set resolves to nothing, the append
+// helper falls back to the raw set-name token, and the "static member 10.20.0.0/16
+// is present" assertions below go RED.
+
+// mixedStaticGhostAddressBook builds an address book with two sets, each mixing
+// one resolvable static member with the unresolvable non-feed token "ghost":
+//   - "mixed-static-ghost": { static-a = 10.20.0.0/16, ghost } — CIDR member for
+//     the SNAT source/destination + DNAT source-constraint cases.
+//   - "mixed-host-ghost":   { host-a  = 10.30.0.9/32,  ghost } — host member for
+//     the DNAT destination-translation case (one table row per host).
+//
+// "ghost" is neither a static address, nor a set, nor a feed binding — the
+// genuinely-unresolvable member that the OLD static resolver poisoned the whole
+// set on.
+func mixedStaticGhostAddressBook() *config.AddressBook {
+	return &config.AddressBook{
+		Addresses: map[string]*config.Address{
+			"static-a": {Name: "static-a", Value: "10.20.0.0/16"},
+			"host-a":   {Name: "host-a", Value: "10.30.0.9/32"},
+		},
+		AddressSets: map[string]*config.AddressSet{
+			"mixed-static-ghost": {Name: "mixed-static-ghost", Addresses: []string{"static-a", "ghost"}},
+			"mixed-host-ghost":   {Name: "mixed-host-ghost", Addresses: []string{"host-a", "ghost"}},
+		},
+	}
+}
+
+func Test_nat_mixed_static_and_unresolvable_set_partial_resolves_6143(t *testing.T) {
+	// A live overlay for an UNRELATED feed, so the resolver's overlay path is
+	// exercised but has nothing to contribute to either mixed set (neither
+	// references "bad-feed"). Assertions below confirm the unrelated feed does
+	// not leak into these sets.
+	overlay := map[string][]string{"bad-feed": {"198.51.100.0/24"}}
+
+	// --- SNAT source-address-name -> mixed static+ghost set ---
+	t.Run("snat_source_mixed_static_ghost", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = mixedStaticGhostAddressBook()
+		cfg.Security.NAT.Source = []*config.NATRuleSet{
+			{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "mixed-src",
+					Match: config.NATMatch{SourceAddressName: "mixed-static-ghost"},
+					Then:  config.NATThen{Type: config.NATSource, Interface: true},
+				},
+			}},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		got := snatSourceAddrs(snap, "mixed-src")
+		if !contains(got, "10.20.0.0/16") {
+			t.Fatalf("mixed static+unresolvable SET must PARTIALLY resolve to the static "+
+				"member's prefix, got %v (missing => whole set poisoned by the "+
+				"unresolvable member => static-resolver revert / #6143 regression)", got)
+		}
+		if len(got) == 0 {
+			t.Fatal("source list collapsed to empty (match-any) — fail-OPEN; a partially " +
+				"resolvable set must stay non-empty (#6143)")
+		}
+		if contains(got, "0.0.0.0/0") || contains(got, "::/0") {
+			t.Fatalf("partial resolution must not widen to match-any, got %v", got)
+		}
+		if contains(got, "mixed-static-ghost") || contains(got, "ghost") {
+			t.Fatalf("partial resolution must not carry the raw set-name / unresolvable "+
+				"token (that is the poisoned static-resolver fallback), got %v", got)
+		}
+		if contains(got, "198.51.100.0/24") {
+			t.Fatalf("an unrelated feed's prefixes must not leak into this set, got %v", got)
+		}
+	})
+
+	// --- SNAT destination-address-name -> mixed static+ghost set ---
+	t.Run("snat_dest_mixed_static_ghost", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = mixedStaticGhostAddressBook()
+		cfg.Security.NAT.Source = []*config.NATRuleSet{
+			{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "mixed-dst",
+					Match: config.NATMatch{DestinationAddressName: "mixed-static-ghost"},
+					Then:  config.NATThen{Type: config.NATSource, Interface: true},
+				},
+			}},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		got := snatDestAddrs(snap, "mixed-dst")
+		if !contains(got, "10.20.0.0/16") {
+			t.Fatalf("SNAT destination-address-name mixed static+unresolvable SET must "+
+				"PARTIALLY resolve to the static member's prefix, got %v (#6143)", got)
+		}
+		if len(got) == 0 {
+			t.Fatal("destination list collapsed to empty (match-any) — fail-OPEN (#6143)")
+		}
+		if contains(got, "0.0.0.0/0") || contains(got, "::/0") {
+			t.Fatalf("partial resolution must not widen to match-any, got %v", got)
+		}
+		if contains(got, "mixed-static-ghost") || contains(got, "ghost") {
+			t.Fatalf("partial resolution must not carry the raw set-name / unresolvable "+
+				"token, got %v", got)
+		}
+	})
+
+	// --- DNAT source-address-name (the #2394 source constraint on a
+	// destination-translation rule) -> mixed static+ghost set ---
+	t.Run("dnat_source_mixed_static_ghost", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = mixedStaticGhostAddressBook()
+		cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+			Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+			RuleSets: []*config.NATRuleSet{
+				{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+					{
+						Name: "mixed-src-dnat",
+						Match: config.NATMatch{
+							SourceAddressName:  "mixed-static-ghost",
+							DestinationAddress: "198.51.100.9",
+							Protocol:           "tcp",
+							DestinationPort:    443,
+						},
+						Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+					},
+				}},
+			},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		var got []string
+		for _, s := range snap.DestinationNAT {
+			if s.Name == "mixed-src-dnat" {
+				got = s.SourceAddresses
+				break
+			}
+		}
+		if !contains(got, "10.20.0.0/16") {
+			t.Fatalf("DNAT source-address-name mixed static+unresolvable SET must PARTIALLY "+
+				"resolve to the static member's prefix, got %v (#6143)", got)
+		}
+		if len(got) == 0 {
+			t.Fatal("DNAT source constraint collapsed to empty (match-any) — fail-OPEN (#6143)")
+		}
+		if contains(got, "mixed-static-ghost") || contains(got, "ghost") {
+			t.Fatalf("partial resolution must not carry the raw set-name / unresolvable "+
+				"token, got %v", got)
+		}
+	})
+
+	// --- DNAT destination-address-name -> mixed static+ghost set ---
+	// The static host row must still install (one table row per resolvable host);
+	// the rule must NOT be continue-skipped and must NOT widen.
+	t.Run("dnat_dest_mixed_static_ghost", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.AddressBook = mixedStaticGhostAddressBook()
+		cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+			Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+			RuleSets: []*config.NATRuleSet{
+				{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+					{
+						Name: "mixed-dst-dnat",
+						Match: config.NATMatch{
+							DestinationAddressName: "mixed-host-ghost",
+							Protocol:               "tcp",
+							DestinationPort:        443,
+						},
+						Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+					},
+				}},
+			},
+		}
+		snap := natFeedSnapHelper(t, cfg, overlay)
+		var got []string
+		for _, s := range snap.DestinationNAT {
+			if s.Name == "mixed-dst-dnat" {
+				got = append(got, s.DestinationAddress)
+			}
+		}
+		if !contains(got, "10.30.0.9") {
+			t.Fatalf("DNAT destination-address-name mixed static+unresolvable SET must "+
+				"install the static host row (partial resolution), got %v (empty => whole "+
+				"set poisoned => rule dropped => static-resolver revert / #6143 regression)", got)
+		}
+		if len(got) == 0 {
+			t.Fatal("DNAT destination mixed set installed NO row — the partially resolvable " +
+				"set must keep the static host (#6143)")
+		}
+	})
+}


### PR DESCRIPTION
Two non-blocking MINOR follow-ups from the merged #6142/#4925 NAT
feed-nested-set review. This PR is **test + comment only — no production
logic change.**

## Item 1 — test-coverage (mixed static+unresolvable-non-feed set)

#4925 rewired NAT `match {source,destination}-address-name` to reuse the
policy SSOT `expandBookNameRecursive`
(`resolveNATAddressNamePrefixes`). A side effect: a mixed address-set
`{resolvable-static-member, unresolvable-non-feed-token}` now **partially
resolves** on the lenient / peer-sync runtime path — it returns the
static member's prefixes and silently drops the unresolvable token —
instead of the old static resolver's poison-the-whole-set.

This is **safe**: the constraint stays non-empty and never widens to
match-any; the strict commit gate (`policyMatchAddressBookResolves`)
still rejects such a set; and it matches the security-policy runtime
path. But it was **untested** — the existing `dead_set_fails_closed` pin
only covers the ALL-unresolvable case.

New test `Test_nat_mixed_static_and_unresolvable_set_partial_resolves_6143`:
a `{static-a, ghost}` mixed set referenced by SNAT **and** DNAT rules via
both `source-address-name` and `destination-address-name`. It asserts the
static member's prefixes / DNAT rows resolve, the constraint stays
non-empty, and no match-any (`0.0.0.0/0` / `::/0`) or raw set/`ghost`
token leaks in.

**Genuine fail-on-revert:** reverting `resolveNATAddressNamePrefixes` to
the static `resolveUserspaceAddressBookEntry` poisons the whole mixed set
on the unresolvable member, and all four sub-assertions go RED — verified
(the static-resolver revert yields the raw `[mixed-static-ghost]` token
and an empty DNAT row). There is no code change for this item; it pins
existing merged behavior.

## Item 2 — stale comment (doc accuracy)

The comment in `validateNATSourceAddressNameReferencesStrict`
(`pkg/config/compiler_validate_strict_nat.go`) said a feed member nested
in an address-set "is still poisoned by the static resolver", which now
reads as if the runtime still poisons. Reworded to make explicit that the
paragraph describes the **STRICT-COMMIT gate only** (the gate judges
nested membership via the static `policyMatchAddressBookResolves`, which
never consults the feed overlay) and that since #4925 the **lenient
runtime** resolver feed-resolves nested set members. The strict-commit
behavior is unchanged.

## Validation

- `go test ./pkg/dataplane/userspace/... ./pkg/config/...` — green.
- Named test passes 3× (no flake).
- `gofmt` + `go vet` clean.
- Fail-on-revert confirmed by temporarily swapping the runtime resolver
  for the static one (all four sub-assertions RED), then reverted so the
  committed tree only carries the test + comment.
- Not HA — no cluster smoke required.

Closes #6143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gdGe6TgfZczKXoJLHK8Gj
