### PR TITLE
userspace-dp reconcile: fail closed on post-spawn in-thread worker bind failure (#5143)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,54 @@
+## 2026-07-21 — #5143: fail closed on post-spawn in-thread worker bind failure
+
+- **Timestamp**: 2026-07-21 (fix/5143-worker-readiness-barrier)
+- **Action**: Added a per-worker STARTUP READINESS BARRIER to
+  `bring_up_workers` so a worker that SPAWNS successfully but whose in-thread
+  XSK/UMEM bind fails for one or more planned bindings (setup.rs
+  `create_private_binding_from_plan` Err arm — leaves the binding out of the
+  worker's `bindings` vec) can no longer masquerade as ready on the strength
+  of a live heartbeat alone (the #5143 silent forwarding outage: a queue set
+  with a live worker but no XSK-bound binding, acked ok=true + persisted).
+  HEARTBEAT != READINESS. Each spawned worker now reports its achieved
+  bound-slot set (`WorkerStartupReport` over a per-reconcile `mpsc` channel,
+  sent from `worker_loop` after setup, before the steady loop). After the
+  spawn loop `bring_up_workers` waits under a bounded deadline
+  (`WORKER_STARTUP_BARRIER_TIMEOUT_NS` = 10s; a non-reporting worker is
+  treated as failed, never blocks forever) and requires bound == planned per
+  worker. On any shortfall/timeout it fails CLOSED: `stop_inner(false)` stops
+  + joins the newly-started workers (no leaked live-but-unbound worker),
+  preserves the `worker_bind_incomplete:..` stage, and returns
+  `WorkerBringUpError::BindIncomplete`. `bring_up_workers` return type changed
+  `Result<(), String>` -> `Result<(), WorkerBringUpError>` (new enum: `Spawn`
+  | `BindIncomplete`) so `reconcile` maps each post-teardown class to its own
+  `ReconcileError` variant — new `WorkerBindIncomplete(String)` alongside
+  #4952's `WorkerSpawn`. Composes with #4952 (does NOT replace it): the
+  spawn-failure fast-path still returns before the barrier. The
+  `apply_snapshot` handler's two post-teardown arms (same-plan + full-apply)
+  now fail closed on `WorkerSpawn | WorkerBindIncomplete` identically
+  (ok=false, roll baseline back, refresh status, do NOT persist); only the
+  error verb differs ("worker bind incomplete" vs "worker spawn failed") so
+  the #4952/#6140 wording assertions stay green.
+- **Tests**: `#[cfg(test)] force_worker_bind_incomplete` seam spawns a
+  joinable stub worker that reports a bound set short by one slot, then
+  heartbeats until stopped. Fail-on-revert merge gates:
+  `post_spawn_inthread_bind_failure_fails_closed_5143` (coordinator: asserts
+  Err(WorkerBindIncomplete), stopped/joined workers, stage) and
+  `full_apply_post_spawn_inthread_bind_failure_fails_closed_no_persist_5143`
+  (handler: ok=false, no persist, baseline not advanced). Verified RED-on-
+  revert is an ASSERTION failure (barrier neutralized -> both go RED with
+  "got Ok(())", not a build break), target-count 2. #4952/#6140 tests stay
+  GREEN. Full Rust suite green (4133 passed, 0 failed).
+- **File(s)**: afxdp/types/runtime.rs (WorkerStartupReport),
+  afxdp/worker/loop_body/mod.rs (worker_loop param + send),
+  afxdp/worker/loop_body/setup.rs (Err-arm readiness comment),
+  afxdp/coordinator/mod.rs (force_worker_bind_incomplete seam),
+  afxdp/coordinator/reconcile/bringup.rs (barrier + WorkerBringUpError +
+  collect_worker_startup_readiness), afxdp/coordinator/reconcile/mod.rs
+  (ReconcileError::WorkerBindIncomplete + mapping),
+  server/handlers/snapshot.rs (both post-teardown arms),
+  afxdp/coordinator/tests.rs, server/tests.rs,
+  afxdp/coordinator/README.md, server/README.md.
+
 ## 2026-07-20 — #5098: reset global counter offsets on clear (epoch semantics)
 
 - **Timestamp**: 2026-07-20 (fix/5098-clear-counter-offset)

--- a/userspace-dp/src/afxdp/coordinator/README.md
+++ b/userspace-dp/src/afxdp/coordinator/README.md
@@ -159,3 +159,34 @@ Differences that matter (#1881):
   drives the regression tests (coordinator-level
   `reconcile_post_teardown_worker_spawn_failure_fails_closed_4952` +
   handler-level `post_teardown_spawn_failure_fails_closed_no_persist_4952`).
+- **A POST-SPAWN in-thread worker bind failure fails closed via the
+  startup readiness barrier (#5143). HEARTBEAT != READINESS.** #4952 above
+  catches only the SPAWN failure — the thread that never starts. But a
+  worker that spawns SUCCESSFULLY can still fail its IN-THREAD XSK/UMEM
+  binds inside `worker_loop_setup` (the private-binding `Err` arm records
+  the failure by leaving the binding out of the worker's `bindings` vec)
+  and then enter its steady loop with an EMPTY/PARTIAL binding set — yet it
+  keeps HEARTBEATING, so the thread-death supervisor is satisfied and
+  (pre-#5143) `bring_up_workers` returned `Ok`, the reconcile committed, and
+  the handler ACKed `ok=true` + PERSISTED the snapshot: a SILENT forwarding
+  outage (a queue set with a live worker but no XSK-bound binding). #4952's
+  spawn-error propagation does NOT catch it (the spawn succeeded). Now each
+  newly-started worker REPORTS its actual bound-slot set (a
+  `WorkerStartupReport` over a per-reconcile `mpsc` channel) after its binds
+  and BEFORE its steady loop; after the spawn loop `bring_up_workers` WAITS
+  (bounded by `WORKER_STARTUP_BARRIER_TIMEOUT_NS` = 10s — a worker that
+  never reports in time is treated as failed, it does NOT block forever) and
+  requires `bound == planned` per worker. On ANY shortfall/timeout it FAILS
+  CLOSED: `stop_inner(false)` STOPS + JOINS the newly-started workers (no
+  leaked live-but-unbound worker), preserves the `worker_bind_incomplete:..`
+  stage, and returns `WorkerBringUpError::BindIncomplete`, which `reconcile`
+  maps to `ReconcileError::WorkerBindIncomplete` — the SECOND post-teardown
+  `ReconcileError` variant (alongside `WorkerSpawn`), handled the same way
+  by the control handler (`ok=false`, do NOT persist). `bring_up_workers`
+  now returns `Result<(), WorkerBringUpError>` (was `Result<(), String>`) so
+  the two post-teardown classes map to distinct variants. A per-instance
+  `#[cfg(test)] force_worker_bind_incomplete` seam (spawns a joinable stub
+  worker that reports a bound set short by one slot, then heartbeats until
+  stopped) drives the regression tests (coordinator-level
+  `post_spawn_inthread_bind_failure_fails_closed_5143` + handler-level
+  `full_apply_post_spawn_inthread_bind_failure_fails_closed_no_persist_5143`).

--- a/userspace-dp/src/afxdp/coordinator/README.md
+++ b/userspace-dp/src/afxdp/coordinator/README.md
@@ -142,14 +142,15 @@ Differences that matter (#1881):
   `last_reconcile_stage` with `spawned:workers=..` and returned success —
   so `reconcile` returned `Ok(())`, the control handler acked `ok=true`,
   and PERSISTED the broken snapshot as the boot baseline (no retry). Now
-  `bring_up_workers` returns `Result<(), String>`: on the FIRST spawn
+  `bring_up_workers` returns `Result<(), WorkerBringUpError>`: on the FIRST spawn
   failure it ABORTS the remaining launches (the data plane is already
   broken; more XSK-bound workers cannot restore forwarding and only widen
   the resource pressure), PRESERVES the `spawn_worker_failed:<id>:<err>`
   stage (no `spawned:..` overwrite), skips the auxiliary-thread bring-up,
   and returns the stage. `reconcile` maps it to
-  `ReconcileError::WorkerSpawn` — the ONE `ReconcileError` variant raised
-  AFTER teardown (the data plane HAS moved; there is no prior-state restore
+  `ReconcileError::WorkerSpawn` — one of two `ReconcileError` variants
+  raised AFTER teardown (`WorkerBindIncomplete` (#5143) is the other; the
+  data plane HAS moved; there is no prior-state restore
   that brings the torn-down workers back, only fail-closed bookkeeping +
   a retry/last-good reconcile). Full pre-teardown preflight of the spawn is
   not tractable (a real `pthread_create` cannot be probed without spawning,

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -275,6 +275,18 @@ pub struct Coordinator {
     /// release builds; per-instance so parallel tests never race.
     #[cfg(test)]
     pub(crate) force_worker_spawn_fail: u32,
+    /// #5143 test seam: force the FIRST `force_worker_bind_incomplete` spawned
+    /// workers to report an INCOMPLETE startup bound-slot set (a spawned
+    /// worker whose in-thread XSK/UMEM bind failed for one or more planned
+    /// bindings but keeps heartbeating). Instead of the real `worker_loop`
+    /// (which cannot bind a real XSK in-process), a joinable STUB thread is
+    /// spawned that reports a bound set MISSING one planned slot, then
+    /// heartbeats until stopped — so the post-spawn readiness barrier's
+    /// fail-close + stop/join is unit-verifiable. Distinct from
+    /// `force_worker_spawn_fail` (which fails the spawn itself, pre-report).
+    /// Always 0 in release builds; per-instance so parallel tests never race.
+    #[cfg(test)]
+    pub(crate) force_worker_bind_incomplete: u32,
     pub(crate) last_reconcile_stage: String,
     pub(crate) poll_mode: crate::PollMode,
     pub(crate) event_stream: Option<crate::event_stream::EventStreamSender>,
@@ -335,6 +347,8 @@ impl Coordinator {
             last_quiesce_ms: 0,
             #[cfg(test)]
             force_worker_spawn_fail: 0,
+            #[cfg(test)]
+            force_worker_bind_incomplete: 0,
             last_reconcile_stage: "idle".to_string(),
             poll_mode: crate::PollMode::BusyPoll,
             event_stream: None,

--- a/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
@@ -18,6 +18,39 @@ use super::super::super::*;
 use super::super::supervisor::{spawn_supervised_aux, spawn_supervised_worker};
 use super::super::{Coordinator, WorkerHandle};
 
+/// #5143: how long `bring_up_workers` waits for every newly-started worker to
+/// report its startup readiness (the set of planned bindings whose XSK
+/// actually bound) before it fails the reconcile closed. A worker that never
+/// reports within this bound is treated as failed — the barrier does NOT block
+/// forever. 10s mirrors the HA sync-hold ceiling: comfortably above a healthy
+/// worker's setup cost (per-worker TSC calibration ~10ms + UMEM mmap + XSK
+/// bind, well under a second even for a full 6-queue VF) yet bounded so a hung
+/// worker cannot wedge the control socket indefinitely. The COMMON failure — a
+/// worker that finished setup with a PARTIAL binding set — reports immediately,
+/// so the barrier fails fast without approaching this deadline; only a worker
+/// that dies/hangs inside setup consumes the full budget.
+const WORKER_STARTUP_BARRIER_TIMEOUT_NS: u64 = 10_000_000_000;
+
+/// #5143: the two DISTINCT post-teardown worker-bringup failures, both raised
+/// AFTER `tear_down` has stopped the old workers (so the data plane HAS moved
+/// and there is no prior-state restore — only fail-closed bookkeeping + a
+/// retry/last-good reconcile). `reconcile` maps each to its own
+/// [`ReconcileError`] variant so the control handler can fail closed and NOT
+/// persist the broken snapshot as the boot baseline.
+pub(super) enum WorkerBringUpError {
+    /// #4952: a worker thread failed to SPAWN (`spawn_supervised_worker` ->
+    /// `pthread_create` EAGAIN/ENOMEM). Carries the preserved
+    /// `spawn_worker_failed:<id>:<err>` stage.
+    Spawn(String),
+    /// #5143: a worker SPAWNED successfully but its in-thread XSK/UMEM bind
+    /// did not bring up its FULL planned binding set (a partial/empty bind), or
+    /// it never reported readiness within the bounded deadline. HEARTBEAT !=
+    /// READINESS — a live heartbeat over an incomplete binding set is the
+    /// silent forwarding outage this guards. Carries the
+    /// `worker_bind_incomplete:<id>:..` stage.
+    BindIncomplete(String),
+}
+
 /// Bring up the worker threads for the just-applied snapshot.
 ///
 /// #4952: this runs on the POST-TEARDOWN destructive path — `tear_down`
@@ -30,10 +63,29 @@ use super::super::{Coordinator, WorkerHandle};
 /// XSK-bound workers cannot restore forwarding and only compounds the
 /// pressure), PRESERVES the `spawn_worker_failed:<id>:<err>` stage (it does
 /// NOT overwrite it with `spawned:..`), skips the auxiliary-thread bring-up,
-/// and returns `Err(stage)`. The caller (`reconcile`) maps that to
-/// `ReconcileError::WorkerSpawn` so the control handler fails closed and
-/// does NOT persist the broken snapshot as the boot baseline. On success
-/// returns `Ok(())`.
+/// and returns `Err(WorkerBringUpError::Spawn(stage))`. The caller
+/// (`reconcile`) maps that to `ReconcileError::WorkerSpawn` so the control
+/// handler fails closed and does NOT persist the broken snapshot as the boot
+/// baseline. On success returns `Ok(())`.
+///
+/// #5143: a SPAWN success only proves the thread exists — NOT that its
+/// in-thread XSK/UMEM binds brought up the full planned queue set. A worker
+/// that bound a PARTIAL/EMPTY set still HEARTBEATS, so the thread-death
+/// supervisor is satisfied and (pre-#5143) this returned `Ok`, committing a
+/// silent forwarding outage. #4952's spawn-error propagation does not catch it
+/// (the spawn succeeded). So after the spawn loop this runs a STARTUP READINESS
+/// BARRIER: every spawned worker reports the slot set it actually bound (a
+/// `WorkerStartupReport` over a per-reconcile `mpsc` channel, sent from
+/// `worker_loop` after setup), and the barrier waits — under a bounded deadline
+/// ([`WORKER_STARTUP_BARRIER_TIMEOUT_NS`]; a worker that never reports in time
+/// is treated as failed, NOT blocked forever) — for `bound == planned` per
+/// worker. On ANY shortfall/timeout it FAILS CLOSED: `stop_inner(false)` stops +
+/// joins the newly-started workers (no leaked live-but-unbound worker), preserves
+/// the `worker_bind_incomplete:..` stage, and returns
+/// `Err(WorkerBringUpError::BindIncomplete(stage))`, which `reconcile` maps to
+/// `ReconcileError::WorkerBindIncomplete` (handled the same fail-closed way as
+/// `WorkerSpawn`). HEARTBEAT != READINESS: the reconcile transaction now
+/// requires one READY binding per required plan.
 ///
 /// Full pre-teardown preflight of the spawn is not tractable — a real
 /// `pthread_create` cannot be probed without spawning the thread, and the
@@ -48,7 +100,7 @@ pub(super) fn bring_up_workers(
     fds: ReconcileSnapshotFds,
     ring_entries: usize,
     preserved_synced_sessions: Vec<SyncedSessionEntry>,
-) -> Result<(), String> {
+) -> Result<(), WorkerBringUpError> {
     let ReconcileSnapshotFds {
         map_fd,
         heartbeat_map_fd,
@@ -284,8 +336,25 @@ pub(super) fn bring_up_workers(
     // (abort remaining launches) and the tail returns Err(stage) so the
     // reconcile fails closed instead of persisting a broken snapshot.
     let mut spawn_failure: Option<String> = None;
+    // #5143: per-worker STARTUP READINESS barrier. Each spawned worker reports
+    // (over this channel, after its in-thread binds) the set of planned slots
+    // whose XSK actually bound. `planned_slots_by_worker` records the set the
+    // reconcile DISPATCHED to each worker; `spawned_worker_ids` is the set of
+    // workers whose spawn succeeded (only those are expected to report). After
+    // the spawn loop the barrier waits for every spawned worker's report under
+    // a bounded deadline and checks bound == planned — a heartbeat alone no
+    // longer counts as ready.
+    let (startup_report_tx, startup_report_rx) = mpsc::channel::<WorkerStartupReport>();
+    let mut planned_slots_by_worker: BTreeMap<u32, std::collections::BTreeSet<u32>> =
+        BTreeMap::new();
+    let mut spawned_worker_ids: Vec<u32> = Vec::new();
     for (worker_id, binding_plans) in workers {
         let plan_count = binding_plans.len();
+        // #5143: the slot set this worker is REQUIRED to bind. Captured before
+        // `binding_plans` is moved into the worker body so the barrier can
+        // compare it against the worker's reported bound set.
+        let planned_slots: std::collections::BTreeSet<u32> =
+            binding_plans.iter().map(|plan| plan.status.slot).collect();
         let stop = Arc::new(AtomicBool::new(false));
         let heartbeat = Arc::new(AtomicU64::new(monotonic_nanos()));
         let session_export_ack = Arc::new(AtomicU64::new(0));
@@ -362,6 +431,10 @@ pub(super) fn bring_up_workers(
         // a helper without re-validating the panic-payload contract.
         let panic_slot = Arc::new(Mutex::new(None::<String>));
         coord.worker_panics.insert(worker_id, panic_slot.clone());
+        // #5143: the worker's end of the startup-readiness channel. Moved into
+        // the worker body; `worker_loop` sends the achieved bound-slot set on
+        // it after setup, before entering the steady loop.
+        let startup_report_tx_worker = startup_report_tx.clone();
         let body = move || {
             worker_loop(
                 worker_id,
@@ -401,6 +474,7 @@ pub(super) fn bring_up_workers(
                 cos_status_clone,
                 runtime_atomics_clone,
                 cold_path_atomics_clone,
+                startup_report_tx_worker,
             );
         };
         // #4952 test seam: force the fallible worker spawn to fail so the
@@ -409,8 +483,49 @@ pub(super) fn bring_up_workers(
         // spawn, drops the worker body unspawned, and synthesizes the same
         // `std::io::Error` a resource-exhausted spawn returns. Always 0 in
         // release builds (`force_worker_spawn_fail` is `#[cfg(test)]`).
+        //
+        // #5143 test seam: force a SPAWNED worker to report an INCOMPLETE
+        // startup bound-slot set (a worker whose in-thread XSK/UMEM bind failed
+        // for one or more planned bindings but keeps heartbeating). A real
+        // `worker_loop` cannot bind a real XSK in-process, so instead spawn a
+        // joinable STUB thread that reports a bound set MISSING one planned
+        // slot, then heartbeats until stopped — exercising the readiness
+        // barrier's fail-close + stop/join end to end. Checked BEFORE the
+        // spawn-fail seam so the two are mutually exclusive per worker.
         #[cfg(test)]
-        let join = if coord.force_worker_spawn_fail > 0 {
+        let join = if coord.force_worker_bind_incomplete > 0 {
+            coord.force_worker_bind_incomplete -= 1;
+            drop(body);
+            // Report every planned slot EXCEPT one (`skip(1)`), so with a
+            // single planned binding the reported set is empty and with N it
+            // is short by one — either way bound != planned -> barrier fails
+            // closed.
+            let incomplete_bound: Vec<u32> = planned_slots.iter().copied().skip(1).collect();
+            let stub_stop = stop.clone();
+            let stub_heartbeat = heartbeat.clone();
+            let stub_tx = startup_report_tx.clone();
+            let stub_worker_id = worker_id;
+            spawn_supervised_worker(
+                worker_id,
+                runtime_atomics.clone(),
+                panic_slot,
+                move || {
+                    let _ = stub_tx.send(WorkerStartupReport {
+                        worker_id: stub_worker_id,
+                        bound_slots: incomplete_bound,
+                    });
+                    // Heartbeat while "live-but-unbound" until the barrier
+                    // stops us — bounded so a REVERTED (barrier removed) build
+                    // does not leak a thread forever.
+                    let mut ticks = 0u32;
+                    while !stub_stop.load(std::sync::atomic::Ordering::Relaxed) && ticks < 5_000 {
+                        stub_heartbeat.store(monotonic_nanos(), std::sync::atomic::Ordering::Relaxed);
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                        ticks += 1;
+                    }
+                },
+            )
+        } else if coord.force_worker_spawn_fail > 0 {
             coord.force_worker_spawn_fail -= 1;
             drop(body);
             Err(std::io::Error::new(
@@ -428,6 +543,11 @@ pub(super) fn bring_up_workers(
                     "xpf-userspace-dp: started worker thread worker_id={} planned_bindings={}",
                     worker_id, plan_count
                 );
+                // #5143: this worker spawned, so it is EXPECTED to report its
+                // startup bound-slot set; record its dispatched plan for the
+                // barrier's bound-vs-planned check below.
+                planned_slots_by_worker.insert(worker_id, planned_slots);
+                spawned_worker_ids.push(worker_id);
                 coord.workers.handles.insert(
                     worker_id,
                     WorkerHandle {
@@ -486,7 +606,37 @@ pub(super) fn bring_up_workers(
             "xpf-userspace-dp: worker bring-up FAILED ({stage}); a queue set has no \
              XSK-bound worker after teardown — failing reconcile closed"
         );
-        return Err(stage);
+        return Err(WorkerBringUpError::Spawn(stage));
+    }
+    // #5143: STARTUP READINESS BARRIER. Every worker SPAWNED (the #4952
+    // spawn-failure fast-path above already returned otherwise), but a spawn
+    // only proves the thread exists — NOT that its in-thread XSK/UMEM binds
+    // brought up the full planned queue set. Wait (under a bounded deadline)
+    // for each spawned worker to report the slot set it actually bound, then
+    // require bound == planned. A worker that bound a PARTIAL/EMPTY set (the
+    // #5143 silent forwarding outage: a live-but-unbound worker whose
+    // heartbeat satisfied the supervisor) or never reported in time fails the
+    // reconcile CLOSED — the same post-teardown fail-closed contract #4952
+    // established for spawn failures, extended to the post-spawn bind failure.
+    if let Some(stage) = collect_worker_startup_readiness(
+        &startup_report_rx,
+        &spawned_worker_ids,
+        &planned_slots_by_worker,
+    ) {
+        eprintln!(
+            "xpf-userspace-dp: worker bring-up FAILED ({stage}); a spawned worker did not \
+             bind its full planned queue set after teardown — failing reconcile closed"
+        );
+        // Stop + JOIN the newly-started workers (the teardown path) so no
+        // live-but-unbound worker keeps heartbeating past this fail-closed
+        // reconcile, and clear the coordinator worker state so a retry /
+        // last-good reconcile starts from a coherent baseline. Preserved
+        // synced sessions are kept (`clear_synced_state=false`), matching the
+        // reconcile teardown. `stop_inner` overwrites `last_reconcile_stage`
+        // with "stopped", so restore the diagnostic stage AFTER it.
+        coord.stop_inner(false);
+        coord.last_reconcile_stage = stage.clone();
+        return Err(WorkerBringUpError::BindIncomplete(stage));
     }
     coord.last_reconcile_stage = format!(
         "spawned:workers={}:identities={}:live={}",
@@ -568,6 +718,74 @@ pub(super) fn bring_up_workers(
     coord.reconcile_local_tunnel_sources();
     coord.spawn_wg_control_threads();
     Ok(())
+}
+
+/// #5143: the STARTUP READINESS BARRIER. Wait for every SPAWNED worker to
+/// report the slot set its in-thread XSK/UMEM binds actually brought up, under
+/// a bounded deadline ([`WORKER_STARTUP_BARRIER_TIMEOUT_NS`]), then check
+/// `bound == planned` for each. Returns `None` when every worker bound its full
+/// planned set (the reconcile may proceed), or `Some(stage)` — a
+/// `worker_bind_incomplete:<id>:..` descriptor — on the FIRST worker that bound
+/// a partial/empty set OR never reported in time (fail closed).
+///
+/// The barrier does NOT block forever: it stops waiting at the deadline and
+/// treats any worker with no report as failed. A worker that finished setup
+/// with a partial binding set reports IMMEDIATELY (the common failure), so this
+/// returns fast without approaching the deadline; only a worker that
+/// hangs/dies inside setup consumes the full budget. Reads a moved-value report
+/// off the channel — no shared mutable state, so the channel's send→recv
+/// establishes the happens-before for the reported set.
+fn collect_worker_startup_readiness(
+    startup_report_rx: &mpsc::Receiver<WorkerStartupReport>,
+    spawned_worker_ids: &[u32],
+    planned_slots_by_worker: &BTreeMap<u32, std::collections::BTreeSet<u32>>,
+) -> Option<String> {
+    if spawned_worker_ids.is_empty() {
+        return None;
+    }
+    // Collect one report per spawned worker (last write wins per id) until we
+    // have them all or the deadline elapses.
+    let deadline_ns = monotonic_nanos().saturating_add(WORKER_STARTUP_BARRIER_TIMEOUT_NS);
+    let mut bound_by_worker: BTreeMap<u32, std::collections::BTreeSet<u32>> = BTreeMap::new();
+    while bound_by_worker.len() < spawned_worker_ids.len() {
+        let now = monotonic_nanos();
+        if now >= deadline_ns {
+            break;
+        }
+        match startup_report_rx.recv_timeout(std::time::Duration::from_nanos(deadline_ns - now)) {
+            Ok(report) => {
+                bound_by_worker.insert(report.worker_id, report.bound_slots.into_iter().collect());
+            }
+            // Timed out with reports still outstanding, or every sender was
+            // dropped (a worker panicked in setup before reporting). Either
+            // way the missing worker(s) are treated as failed below.
+            Err(mpsc::RecvTimeoutError::Timeout)
+            | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    for &worker_id in spawned_worker_ids {
+        let planned = planned_slots_by_worker
+            .get(&worker_id)
+            .cloned()
+            .unwrap_or_default();
+        match bound_by_worker.get(&worker_id) {
+            Some(bound) if *bound == planned => {}
+            Some(bound) => {
+                return Some(format!(
+                    "worker_bind_incomplete:{worker_id}:bound={}:planned={}",
+                    bound.len(),
+                    planned.len()
+                ));
+            }
+            None => {
+                return Some(format!(
+                    "worker_bind_incomplete:{worker_id}:timeout:planned={}",
+                    planned.len()
+                ));
+            }
+        }
+    }
+    None
 }
 
 /// #1830 follow-up (Codex review on PR #1841): array length needed to

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -66,6 +66,17 @@ pub(crate) enum ReconcileError {
     /// does NOT persist the broken snapshot as the boot baseline. Carries
     /// the preserved `spawn_worker_failed:<id>:<err>` stage.
     WorkerSpawn(String),
+    /// #5143: a worker SPAWNED successfully on the POST-TEARDOWN path but its
+    /// IN-THREAD XSK/UMEM bind did not bring up its full planned binding set
+    /// (a partial/empty bind), or it never reported startup readiness within
+    /// the bounded barrier deadline. #4952's spawn-error propagation does NOT
+    /// catch this — the spawn SUCCEEDED; the failure is inside the worker
+    /// thread's setup, where a live heartbeat over an incomplete binding set
+    /// used to satisfy the supervisor (the #5143 silent forwarding outage).
+    /// Like `WorkerSpawn` this is raised AFTER teardown (the queue set has no
+    /// XSK-bound worker), so the handler fails closed and does NOT persist the
+    /// broken snapshot. Carries the `worker_bind_incomplete:<id>:..` stage.
+    WorkerBindIncomplete(String),
 }
 
 impl std::fmt::Display for ReconcileError {
@@ -74,6 +85,9 @@ impl std::fmt::Display for ReconcileError {
             ReconcileError::Integrity(err) => write!(f, "{err}"),
             ReconcileError::MapSetup(stage) => write!(f, "map setup failed ({stage})"),
             ReconcileError::WorkerSpawn(stage) => write!(f, "worker spawn failed ({stage})"),
+            ReconcileError::WorkerBindIncomplete(stage) => {
+                write!(f, "worker bind incomplete ({stage})")
+            }
         }
     }
 }
@@ -377,13 +391,20 @@ impl Coordinator {
         // (some workers up, then a spawn aborted the rest) still needs the
         // refresh so status shows which slots came up and which did not.
         self.refresh_bindings(bindings);
-        // #4952: a POST-TEARDOWN worker-spawn failure fails the reconcile
-        // closed. `bring_up_workers` preserved the `spawn_worker_failed:..`
-        // stage and returned it; surface it as `ReconcileError::WorkerSpawn`
-        // so the control handler reports ok=false and does NOT persist this
-        // broken snapshot as the boot baseline (the old workers are already
-        // torn down — there is no forwarding to restore, only fail-closed
-        // bookkeeping + a retry/last-good path).
-        bringup_result.map_err(ReconcileError::WorkerSpawn)
+        // #4952 / #5143: a POST-TEARDOWN worker-bringup failure fails the
+        // reconcile closed. `bring_up_workers` returned the specific failure —
+        // a worker thread that failed to SPAWN (#4952) or a worker that
+        // spawned but bound an INCOMPLETE queue set / never reported readiness
+        // (#5143). Surface each as its own `ReconcileError` variant so the
+        // control handler reports ok=false and does NOT persist this broken
+        // snapshot as the boot baseline (the old workers are already torn down
+        // — there is no forwarding to restore, only fail-closed bookkeeping +
+        // a retry/last-good path).
+        bringup_result.map_err(|err| match err {
+            bringup::WorkerBringUpError::Spawn(stage) => ReconcileError::WorkerSpawn(stage),
+            bringup::WorkerBringUpError::BindIncomplete(stage) => {
+                ReconcileError::WorkerBindIncomplete(stage)
+            }
+        })
     }
 }

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -3590,6 +3590,90 @@ fn reconcile_post_teardown_worker_spawn_failure_fails_closed_4952() {
     );
 }
 
+/// #5143: a worker that SPAWNS successfully on the POST-TEARDOWN path but whose
+/// IN-THREAD XSK/UMEM bind does NOT bring up its full planned binding set (a
+/// partial/empty bind) must FAIL CLOSED — `reconcile` returns
+/// `Err(ReconcileError::WorkerBindIncomplete(_))`, the newly-started workers
+/// are STOPPED + JOINED (no leaked live-but-unbound worker heartbeating past a
+/// fail-closed reconcile), and `last_reconcile_stage` carries the
+/// `worker_bind_incomplete:..` descriptor (NOT `spawned:workers=..`).
+///
+/// This is DISTINCT from #4952: #4952 propagates a worker-thread SPAWN failure
+/// (`pthread_create` EAGAIN/ENOMEM) — the thread never runs. #5143 is the
+/// POST-SPAWN, in-thread bind failure — the spawn SUCCEEDED and the worker
+/// heartbeats, but it bound an incomplete queue set. #4952's spawn-error
+/// propagation does not catch it; the per-worker startup readiness barrier
+/// (HEARTBEAT != READINESS) does.
+///
+/// The per-instance `force_worker_bind_incomplete` seam spawns a joinable STUB
+/// worker that reports a bound set MISSING one planned slot (a real
+/// `worker_loop` cannot bind a real XSK in-process), then heartbeats until the
+/// barrier stops it — so the fail-close + stop/join is unit-verifiable.
+///
+/// Fail-on-revert: remove the readiness barrier (the worker binds partially but
+/// `bring_up_workers` returns Ok and the reconcile commits) and BOTH the
+/// `Err(WorkerBindIncomplete)` match and the stop/join assertions flip
+/// (`reconcile` returns Ok, the stub worker leaks in `workers.handles`, and the
+/// stage becomes `spawned:workers=..`).
+#[test]
+fn post_spawn_inthread_bind_failure_fails_closed_5143() {
+    let mut coordinator = Coordinator::new();
+    // One registered binding => exactly one planned worker to bring up.
+    let mut bindings: Vec<BindingStatus> = vec![BindingStatus {
+        slot: 1,
+        worker_id: 0,
+        queue_id: 0,
+        interface: "ge-0-0-0".into(),
+        ifindex: 10,
+        registered: true,
+        ..BindingStatus::default()
+    }];
+    // Force the (only) planned worker to SPAWN but report an INCOMPLETE bound
+    // set — the post-spawn in-thread bind failure the fix guards.
+    coordinator.force_worker_bind_incomplete = 1;
+
+    // All mandatory pins open so the reconcile clears the pre-teardown
+    // integrity legs, tears down, applies the snapshot, and REACHES the worker
+    // bring-up + readiness barrier.
+    let snap = mandatory_ok_snapshot(5);
+    let result = coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    // (a) fail closed with the typed post-spawn-bind error.
+    assert!(
+        matches!(result, Err(ReconcileError::WorkerBindIncomplete(ref stage)) if !stage.is_empty()),
+        "a post-spawn in-thread bind failure must surface as \
+         Err(WorkerBindIncomplete) with a non-empty stage, got {result:?}"
+    );
+    // The stage identifies the barrier verdict (not a spawn success).
+    assert!(
+        coordinator
+            .last_reconcile_stage
+            .starts_with("worker_bind_incomplete:"),
+        "the bind-incomplete stage must be recorded, got {:?}",
+        coordinator.last_reconcile_stage
+    );
+    assert!(
+        !coordinator.last_reconcile_stage.starts_with("spawned:"),
+        "the reconcile must NOT report a successful spawn after a partial bind, got {:?}",
+        coordinator.last_reconcile_stage
+    );
+    // (c) the newly-started worker was STOPPED + JOINED and its coordinator
+    // state cleared — no leaked live-but-unbound worker.
+    assert!(
+        coordinator.workers.handles.is_empty(),
+        "the partially-bound worker must be stopped/joined (no leaked handle)"
+    );
+    assert!(
+        coordinator.workers.live.is_empty(),
+        "the partially-bound worker's live state must be cleared on fail-close"
+    );
+    // The seam consumed its single forced incomplete report (no over-fire).
+    assert_eq!(
+        coordinator.force_worker_bind_incomplete, 0,
+        "exactly one forced bind-incomplete report should have been consumed"
+    );
+}
+
 /// #5171: the side-effect-free `validate_snapshot_buildable` gate (used by
 /// the deferred-activation apply path, which never reaches `reconcile`) and
 /// the worker-spawning `reconcile` MUST reject the IDENTICAL non-buildable

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -149,6 +149,27 @@ pub(in crate::afxdp) struct BindingPlan {
     pub(in crate::afxdp) shared_umem: SharedUmemBindingPlan,
 }
 
+/// #5143: a newly-started worker's one-shot STARTUP READINESS report,
+/// sent once — after the worker finishes its in-thread XSK/UMEM binds in
+/// `worker_loop_setup` and BEFORE it enters its steady poll loop — back to
+/// `bring_up_workers` over the per-reconcile startup channel.
+///
+/// `bound_slots` is the set of planned binding slots whose XSK actually bound
+/// (derived from the bindings the worker successfully constructed). A worker
+/// whose in-thread bind failed for one or more planned bindings reports a set
+/// SMALLER than its planned set — the setup Err arm records the failure by
+/// OMISSION (the failed binding never enters the worker's `bindings` vec, so
+/// its slot is absent here). The `bring_up_workers` readiness barrier compares
+/// this against the slot set it dispatched to the worker; any shortfall (or a
+/// worker that never reports within the bounded deadline) fails the reconcile
+/// closed. HEARTBEAT != READINESS: a live heartbeat alone no longer satisfies
+/// the reconcile transaction — one READY binding must exist per required plan.
+#[derive(Clone, Debug)]
+pub(in crate::afxdp) struct WorkerStartupReport {
+    pub(in crate::afxdp) worker_id: u32,
+    pub(in crate::afxdp) bound_slots: Vec<u32>,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(in crate::afxdp) enum SharedUmemMode {
     #[default]

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -77,6 +77,12 @@ pub(crate) fn worker_loop(
     // runtime_atomics.publish(). Coordinator status path reads via
     // snapshot() at each /metrics scrape.
     cold_path_atomics: Arc<crate::afxdp::cold_path_hist::WorkerColdPathAtomics>,
+    // #5143: one-shot STARTUP READINESS channel. After the setup phase below
+    // finishes its in-thread XSK/UMEM binds, the worker reports its actual
+    // bound-slot set back to `bring_up_workers` (which waits on this channel
+    // under a bounded deadline before it accepts the generation). Sent ONCE,
+    // before the steady loop — never touched on the hot path.
+    startup_report_tx: std::sync::mpsc::Sender<WorkerStartupReport>,
 ) {
     // #1776: one-shot setup moved verbatim to setup.rs. The returned
     // WorkerLoopSetup is destructured into the same-named locals so
@@ -118,6 +124,23 @@ pub(crate) fn worker_loop(
         &runtime_atomics,
         &cold_path_atomics,
     );
+    // #5143: STARTUP READINESS report. The in-thread XSK/UMEM binds are now
+    // done — `bindings` holds ONLY the planned bindings that actually bound
+    // (setup's Err arm records a bind failure by leaving the failed binding
+    // out of this vec). Report the achieved bound-slot set to the
+    // `bring_up_workers` readiness barrier BEFORE entering the steady loop, so
+    // a worker that came up with an EMPTY/PARTIAL binding set can no longer
+    // masquerade as ready on the strength of a live heartbeat alone (the #5143
+    // silent forwarding outage). Send-failure is harmless: it means the
+    // barrier already gave up on this generation (deadline elapsed) and
+    // dropped the receiver — the worker is about to be stopped/joined anyway.
+    {
+        let bound_slots: Vec<u32> = bindings.iter().map(|binding| binding.slot).collect();
+        let _ = startup_report_tx.send(WorkerStartupReport {
+            worker_id,
+            bound_slots,
+        });
+    }
     const COS_STATUS_INTERVAL_NS: u64 = 100_000_000;
     let mut idle_iters = 0u32;
     let mut poll_start = 0usize;

--- a/userspace-dp/src/afxdp/worker/loop_body/setup.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/setup.rs
@@ -144,6 +144,16 @@ pub(super) fn worker_loop_setup(
         match create_private_binding_from_plan(plan) {
             Ok(binding) => bindings.push(binding),
             Err(err) => {
+                // #5143: an in-thread XSK/UMEM bind failure. Continuing past it
+                // (rather than aborting the whole worker) is intentional — but
+                // the failed binding is NOT pushed into `bindings`, so its slot
+                // is ABSENT from the startup readiness report `worker_loop`
+                // sends to the `bring_up_workers` barrier. That OMISSION is how
+                // the barrier learns this worker came up with a PARTIAL binding
+                // set and fails the reconcile closed (HEARTBEAT != READINESS).
+                // Pre-#5143 this `eprintln!` + `set_error` was the ONLY signal,
+                // and the worker went on heartbeating with an incomplete set —
+                // the silent forwarding outage.
                 eprintln!("xpf-userspace-dp: private binding creation failed: {err}");
                 live.set_error(err.to_string());
             }

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -222,6 +222,20 @@ queues. See PR #1243's kill record for why i40e doesn't reshape.
   full-apply (plan-change) leg by
   `full_apply_post_teardown_spawn_failure_fails_closed_no_persist_6140`
   (#6140 — the full-apply arm was previously covered only transitively).
+  #5143: `ReconcileError::WorkerBindIncomplete` is the SECOND post-teardown
+  variant — a worker that SPAWNED but whose in-thread XSK/UMEM bind did not
+  bring up its full planned queue set (a live-but-unbound worker whose
+  heartbeat used to satisfy the supervisor), caught by `bring_up_workers`'
+  per-worker startup readiness barrier (HEARTBEAT != READINESS). Both
+  `apply_snapshot` legs handle it IDENTICALLY to `WorkerSpawn` (the shared
+  `WorkerSpawn(stage) | WorkerBindIncomplete(stage)` arm): `ok=false`, roll
+  the in-memory baseline back, refresh status to the REAL post-teardown
+  per-binding state, and return BEFORE `persist_state=true`. Only the error
+  verb differs — "`worker bind incomplete after teardown (...)`" vs "`worker
+  spawn failed after teardown (...)`" — so the #4952/#6140 assertions that
+  pin the "worker spawn failed" wording stay green. Regression-tested (full-
+  apply leg) by
+  `full_apply_post_spawn_inthread_bind_failure_fails_closed_no_persist_5143`.
   When
   `should_run_afxdp` does NOT hold (forwarding disarmed / unsupported) it
   `stop()`s every worker and then routes the per-binding status through

--- a/userspace-dp/src/server/handlers/snapshot.rs
+++ b/userspace-dp/src/server/handlers/snapshot.rs
@@ -200,18 +200,32 @@ pub(super) fn apply(
                 guard.status.last_snapshot_at = prev_last_snapshot_at;
                 guard.status.capabilities = prev_capabilities;
                 response.ok = false;
-                // #4952: distinguish the POST-TEARDOWN worker-spawn failure
-                // (old workers gone, dataplane down — refresh status to the
-                // real per-binding state) from the pre-teardown integrity
-                // faults (prior workers still live). Both fail closed and do
-                // NOT persist; only the message + status refresh differ.
-                if let crate::afxdp::ReconcileError::WorkerSpawn(stage) = &err {
+                // #4952 / #5143: distinguish the POST-TEARDOWN worker-bringup
+                // failures (old workers gone, dataplane down — refresh status
+                // to the real per-binding state) from the pre-teardown
+                // integrity faults (prior workers still live). Both
+                // post-teardown classes — a worker that failed to SPAWN
+                // (#4952) and a worker that spawned but bound an INCOMPLETE
+                // queue set / never reported readiness (#5143) — fail closed
+                // the SAME way: refresh status, do NOT persist. Only the
+                // message differs from the pre-teardown integrity faults.
+                if let crate::afxdp::ReconcileError::WorkerSpawn(stage)
+                | crate::afxdp::ReconcileError::WorkerBindIncomplete(stage) = &err
+                {
+                    // Distinct verb per class (the #4952 tests pin "worker
+                    // spawn failed"); both fail closed identically.
+                    let verb = if matches!(err, crate::afxdp::ReconcileError::WorkerBindIncomplete(_))
+                    {
+                        "worker bind incomplete"
+                    } else {
+                        "worker spawn failed"
+                    };
                     response.error = format!(
-                        "worker spawn failed after teardown ({stage}); dataplane down — snapshot not persisted"
+                        "{verb} after teardown ({stage}); dataplane down — snapshot not persisted"
                     );
                     refresh_status(guard);
                     eprintln!(
-                        "CTRL_REQ: same-plan apply_snapshot rejected (post-teardown worker spawn failure): {stage} — dataplane down, NOT persisting"
+                        "CTRL_REQ: same-plan apply_snapshot rejected (post-teardown worker bring-up failure): {stage} — dataplane down, NOT persisting"
                     );
                 } else {
                     response.error = format!("snapshot integrity error: {}", err);
@@ -339,32 +353,44 @@ pub(super) fn apply(
                 "CTRL_REQ: apply_snapshot defer_workers=true — skipping worker spawn (RETH MAC pending)"
             );
         } else if let Err(err) = reconcile_status_bindings(guard) {
-            if let crate::afxdp::ReconcileError::WorkerSpawn(stage) = &err {
-                // #4952: POST-TEARDOWN worker-spawn failure. Unlike the
-                // pre-teardown integrity/map faults below — where the old
-                // workers + forwarding stayed live and restoring the prior
-                // bindings is truthful — here tear_down already stopped the
-                // old workers and one or more new workers failed to spawn, so
-                // this queue set has NO XSK-bound worker: the data plane is
-                // DOWN. Fail closed so the broken snapshot is NOT persisted as
-                // the boot baseline. Roll the in-memory baseline back to the
-                // prior good snapshot + status generation (a retry / forwarding
-                // toggle then reconciles last-good), but DO NOT restore
-                // existing_bindings — refresh_status must report the REAL
-                // post-teardown per-binding state, not the pre-teardown
-                // workers that no longer exist.
+            if let crate::afxdp::ReconcileError::WorkerSpawn(stage)
+            | crate::afxdp::ReconcileError::WorkerBindIncomplete(stage) = &err
+            {
+                // #4952 / #5143: POST-TEARDOWN worker-bringup failure — a
+                // worker that failed to SPAWN (#4952) or one that spawned but
+                // bound an INCOMPLETE queue set / never reported readiness
+                // (#5143). Unlike the pre-teardown integrity/map faults below
+                // — where the old workers + forwarding stayed live and
+                // restoring the prior bindings is truthful — here tear_down
+                // already stopped the old workers and the new bring-up did not
+                // produce a full XSK-bound worker set, so this queue set has NO
+                // XSK-bound worker: the data plane is DOWN. Fail closed so the
+                // broken snapshot is NOT persisted as the boot baseline. Roll
+                // the in-memory baseline back to the prior good snapshot +
+                // status generation (a retry / forwarding toggle then
+                // reconciles last-good), but DO NOT restore existing_bindings —
+                // refresh_status must report the REAL post-teardown per-binding
+                // state, not the pre-teardown workers that no longer exist.
                 guard.snapshot = prev_snapshot;
                 guard.status.last_snapshot_generation = prev_last_snapshot_generation;
                 guard.status.last_fib_generation = prev_last_fib_generation;
                 guard.status.last_snapshot_at = prev_last_snapshot_at;
                 guard.status.capabilities = prev_capabilities;
                 response.ok = false;
+                // Distinct verb per class (the #4952/#6140 tests pin "worker
+                // spawn failed"); both fail closed identically.
+                let verb =
+                    if matches!(err, crate::afxdp::ReconcileError::WorkerBindIncomplete(_)) {
+                        "worker bind incomplete"
+                    } else {
+                        "worker spawn failed"
+                    };
                 response.error = format!(
-                    "worker spawn failed after teardown ({stage}); dataplane down — snapshot not persisted"
+                    "{verb} after teardown ({stage}); dataplane down — snapshot not persisted"
                 );
                 refresh_status(guard);
                 eprintln!(
-                    "CTRL_REQ: apply_snapshot rejected (post-teardown worker spawn failure): {stage} — dataplane down, NOT persisting"
+                    "CTRL_REQ: apply_snapshot rejected (post-teardown worker bring-up failure): {stage} — dataplane down, NOT persisting"
                 );
                 return;
             }

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1474,6 +1474,144 @@ fn full_apply_post_teardown_spawn_failure_fails_closed_no_persist_6140() {
     let _ = std::fs::remove_file(&state_file);
 }
 
+/// #5143: the FULL-APPLY handler leg must fail closed on a POST-SPAWN in-thread
+/// worker BIND failure — distinct from the #4952/#6140 SPAWN failure. A worker
+/// that spawns but binds an INCOMPLETE queue set (a live-but-unbound worker
+/// heartbeating past a broken bring-up) surfaces as
+/// `ReconcileError::WorkerBindIncomplete`, which the handler special-cases the
+/// SAME way as `WorkerSpawn`: report ok=false + "worker bring-up failed after
+/// teardown", NOT persist the broken snapshot as the boot baseline, and roll
+/// the in-memory baseline back to the prior good snapshot + generation. The
+/// `force_worker_bind_incomplete` seam spawns a joinable stub worker that
+/// reports a bound set missing one planned slot (a real XSK cannot bind
+/// in-process), which the readiness barrier catches and fails closed.
+///
+/// Fail-on-revert: neutralize the barrier (the worker binds partially but the
+/// reconcile commits Ok) OR drop the handler's `WorkerBindIncomplete` arm (so
+/// it falls through to refresh_status + persist_state=true with ok=true).
+/// Assertions (a)/(b)/(c)/(d) all flip as ASSERTION failures.
+#[test]
+fn full_apply_post_spawn_inthread_bind_failure_fails_closed_no_persist_5143() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+
+    // Prior snapshot: one binding interface (ge-0/0/1, ifindex 11). Its only
+    // role is to make guard.snapshot Some with a DISTINCT plan key so the new
+    // apply takes the full-apply (non-same-plan) leg.
+    let prior = ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 1,
+        fib_generation: 1,
+        generated_at: chrono::Utc::now(),
+        defer_workers: false,
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![data_iface_6140("ge-0/0/1", "ge-0-0-1", 11)],
+        zones: vec![trust_zone_6140()],
+        ..ConfigSnapshot::default()
+    };
+
+    // New apply: a DIFFERENT binding interface (ge-0/0/2, ifindex 12) -> the
+    // plan key changes -> the full-apply leg runs.
+    let next = ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 2,
+        fib_generation: 2,
+        generated_at: chrono::Utc::now(),
+        defer_workers: false,
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![data_iface_6140("ge-0/0/2", "ge-0-0-2", 12)],
+        zones: vec![trust_zone_6140()],
+        ..ConfigSnapshot::default()
+    };
+
+    assert!(
+        !super::helpers::same_binding_plan(&prior, &next),
+        "the prior/new binding plan keys MUST differ so the handler takes the \
+         full-apply (non-same-plan) leg"
+    );
+
+    let status = ProcessStatus {
+        forwarding_armed: true,
+        capabilities: forwarding_caps(),
+        last_snapshot_generation: 1,
+        last_fib_generation: 1,
+        ..ProcessStatus::default()
+    };
+
+    let state = Arc::new(Mutex::new(ServerState {
+        status,
+        snapshot: Some(prior),
+        afxdp: afxdp::Coordinator::new(),
+        state_writer: Arc::new(StateWriter::new()),
+    }));
+
+    // Force the single planned worker to SPAWN but report an INCOMPLETE bound
+    // set (the post-spawn in-thread bind failure the fix guards).
+    state
+        .lock()
+        .expect("state")
+        .afxdp
+        .force_worker_bind_incomplete = 1;
+
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(next);
+
+    let state_file = unique_state_file("full_apply_bind_incomplete_5143");
+    assert!(
+        !std::path::Path::new(&state_file).exists(),
+        "precondition: state file must not exist before the request"
+    );
+
+    let response = run_request_on_file(state.clone(), request, &state_file);
+
+    // (a) fail closed with a descriptive post-teardown bring-up error.
+    assert!(
+        !response.ok,
+        "a post-spawn in-thread bind failure on the full-apply leg must report ok=false"
+    );
+    assert!(
+        response.error.contains("worker bind incomplete"),
+        "unexpected error: {}",
+        response.error
+    );
+
+    // (b) persist_state was NOT set -> the state file was never written.
+    assert!(
+        !std::path::Path::new(&state_file).exists(),
+        "a full-apply post-spawn bind failure must NOT persist the broken snapshot"
+    );
+
+    let guard = state.lock().expect("state");
+    // (d) the prior (gen 1) snapshot is still the boot baseline; the reported
+    // generation rolled back.
+    assert_eq!(
+        guard.snapshot.as_ref().map(|s| s.generation),
+        Some(1),
+        "the rejected snapshot must not overwrite the persisted baseline"
+    );
+    assert_eq!(
+        guard.status.last_snapshot_generation, 1,
+        "rejected full-apply must not bump last_snapshot_generation"
+    );
+    assert_eq!(
+        guard.status.last_fib_generation, 1,
+        "rejected full-apply must not bump last_fib_generation"
+    );
+    // (c) the coordinator recorded the bind-incomplete verdict (not a spawn
+    // success) and stopped/joined the partially-bound worker.
+    assert!(
+        guard
+            .afxdp
+            .last_reconcile_stage
+            .starts_with("worker_bind_incomplete:"),
+        "the bind-incomplete stage must be preserved (not overwritten with spawned:..), got {:?}",
+        guard.afxdp.last_reconcile_stage
+    );
+
+    let _ = std::fs::remove_file(&state_file);
+}
+
 // --- apply_snapshot deferred-activation integrity build (#5171) ---------
 
 /// #5171 fail-closed DEFERRED apply — MISSING MANDATORY MAP PIN: a


### PR DESCRIPTION
## Problem (#5143, HIGH)

A worker that **spawns successfully** but whose **in-thread XSK/UMEM bind fails** for one or more planned bindings — the `setup.rs` `create_private_binding_from_plan` `Err` arm only `eprintln!` + `live.set_error(...)`, leaves the binding out of the worker's `bindings` vec, and **continues** — enters its steady loop with an EMPTY/PARTIAL binding set and keeps **heartbeating**.

The thread-death supervisor saw the live heartbeat and was satisfied; `bring_up_workers` returned `Ok`, `reconcile` returned `Ok(())`, and the control handler acked `ok=true` and **persisted the snapshot as the boot baseline**. Result: a **silent forwarding outage** — a queue set with a live worker but no XSK-bound binding, and the control plane acks `ok=true`.

**Distinct from #4952.** #4952 propagates a worker-thread *spawn* failure (`pthread_create` EAGAIN/ENOMEM) — the thread never runs. #5143 is the **post-spawn, in-thread bind failure** — the spawn succeeded and the worker heartbeats. #4952's spawn-error propagation does not catch it. **HEARTBEAT != READINESS.**

## Fix — a per-worker startup readiness barrier

- Each newly-started worker reports its **achieved bound-slot set** (`WorkerStartupReport` over a per-reconcile `mpsc` channel, sent from `worker_loop` after setup, before the steady loop). The `setup.rs` `Err` arm records a bind failure by **omission** — the failed binding never enters `bindings`, so its slot is absent from the report.
- After the spawn loop `bring_up_workers` **waits** — bounded by `WORKER_STARTUP_BARRIER_TIMEOUT_NS` (10s; a worker that never reports in time is treated as failed, it does **not** block forever) — and requires `bound == planned` per worker.
- On any shortfall/timeout it **fails closed**: `stop_inner(false)` **stops + joins** the newly-started workers (no leaked live-but-unbound worker), preserves the `worker_bind_incomplete:..` stage, and returns `WorkerBringUpError::BindIncomplete`.

## Composition with #4952 (preserved, not replaced)

- `bring_up_workers` now returns `Result<(), WorkerBringUpError>` (was `Result<(), String>`) with variants `Spawn | BindIncomplete`. `reconcile` maps each post-teardown class to its own `ReconcileError` variant — the new **`WorkerBindIncomplete(String)`** alongside `WorkerSpawn`.
- The spawn-failure fast-path still returns **before** the barrier, so the #4952 path is untouched.
- Both `apply_snapshot` handler arms (same-plan + full-apply) fail closed on `WorkerSpawn | WorkerBindIncomplete` **identically** (ok=false, roll baseline back, refresh status, do NOT persist). Only the error verb differs — `"worker bind incomplete after teardown (...)"` vs `"worker spawn failed after teardown (...)"` — so the #4952/#6140 wording assertions stay green.

## Tests (fail-on-revert merge gate)

A `#[cfg(test)] force_worker_bind_incomplete` seam spawns a **joinable stub worker** that reports a bound set short by one slot, then heartbeats until stopped — so the fail-close + stop/join is unit-verifiable without a real (unprovokable in-process) XSK bind.

- `post_spawn_inthread_bind_failure_fails_closed_5143` (coordinator) — asserts `Err(WorkerBindIncomplete)`, workers **stopped/joined** (`handles`/`live` empty), stage preserved, seam consumed.
- `full_apply_post_spawn_inthread_bind_failure_fails_closed_no_persist_5143` (handler) — asserts `ok=false`, **not persisted**, baseline generation **not advanced**.

**RED-on-revert verified**: neutralizing the barrier makes both tests go RED as **assertion** failures (`got Ok(())`), not a build break; target-count 2. The #4952/#6140 spawn-failure tests stay GREEN. Full Rust cargo suite green (4042 lib + integration tests, 0 failed); named tests pass 3× with no flake.

## Docs

`coordinator/README.md` + `server/README.md` document the post-spawn in-thread bind fail-close via the readiness barrier (HEARTBEAT != READINESS); the `bring_up_workers` module doc describes the barrier and the two post-teardown error variants.

Closes #5143
