### PR TITLE
afxdp: atomic (preflight-then-commit) in-place frame rewrite (#4965)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,55 @@
+## 2026-07-21 — #4965: atomic (preflight-then-commit) generic in-place frame rewrite
+
+- **Timestamp**: 2026-07-21 (fix/4965-atomic-frame-rewrite)
+- **Action**: Made `rewrite_forwarded_frame_in_place` (the generic in-place
+  frame rewrite — the packet-forwarding hot path) transactional, mirroring the
+  #5466 descriptor fast-path split. ASSESSMENT: #5466 already made the
+  DESCRIPTOR path (`apply_rewrite_descriptor`) atomic — it validates every bail
+  gate against the pristine frame before `rewrite_commit_eth_from_plan`. But the
+  GENERIC path was still `rewrite_prepare_eth` (plan+COMMIT: eth-header write +
+  VLAN-push `copy_within` memmove) THEN `rewrite_apply_v4/v6`, which can still
+  decline (TTL/hop-limit, malformed IHL, IPv6 ext-chain, truncated-L4 NAT
+  checksum) AFTER the commit and after `apply_nat_ipv4/ipv6` wrote IP/port
+  bytes. Both declining callers re-read the SAME UMEM: the flow-cache
+  `apply_rewrite_descriptor(...).or_else(generic)` fallback then
+  `build_live_forward_request_from_frame(packet_frame)`
+  (`poll_descriptor/flow_cache_hit.rs`), and `tx/dispatch/mod.rs` runs
+  `build_forwarded_frame_from_frame(source_frame)` over the same `ingress_area`
+  slice on a generic `None` — so a decline left a scribbled L2 / shifted payload
+  / partial NAT+checksum that got reprocessed as a corrupt packet.
+  FIX: `rewrite_forwarded_frame_in_place` now computes the eth plan
+  (`rewrite_plan_eth_from_parts`, read-only), runs `validate_generic_rewrite_v4`
+  / `validate_generic_rewrite_v6` (read-only preflight covering EVERY `?` in
+  `rewrite_apply_v4/v6` — header length, TTL, `v6_rel_l4_offset` ext-chain, and
+  the L4-checksum-in-bounds gate derived from the SAME
+  `l4_checksum_field_delta_v4/v6` SSOT the mutation half writes at) against the
+  PRISTINE L3 payload at `plan.l3`, and only then commits + applies. The
+  `apply_*` bodies are UNCHANGED, so the success-path output is byte-identical;
+  only failing inputs now decline before any mutation, leaving the frame
+  byte-for-byte unchanged. Split the old `rewrite_prepare_eth` into a read-only
+  `rewrite_eth_params` (deleted the now-dead `rewrite_prepare_eth` /
+  `rewrite_prepare_eth_from_parts`). Re-exported `l4_checksum_field_delta_v4/v6`
+  from `checksum.rs` at `pub(in crate::afxdp::frame)`.
+  VALIDATION: `cargo test --release frame::` 368/368 green (incl. the P-N3
+  `descriptor_generic_differential` byte-parity proptest); new fail-on-revert
+  `declined_rewrite_leaves_umem_byte_identical_4965` passes 3×; parent-RED
+  verified — reverting to commit-before-check makes BOTH the new test AND the
+  updated `pin_ttl_expired_declines_l3_untouched` (now full-frame) fail with
+  `assertion left == right` (not a build break). Full `cargo test --release`
+  suite green.
+- **File(s)**:
+  - `userspace-dp/src/afxdp/frame/mod.rs` (preflight-then-commit restructure of
+    `rewrite_forwarded_frame_in_place`; new `rewrite_eth_params` +
+    `validate_generic_rewrite_v4/v6`; removed `rewrite_prepare_eth`/
+    `rewrite_prepare_eth_from_parts`; import `l4_checksum_field_delta_v4/v6`)
+  - `userspace-dp/src/afxdp/frame/checksum.rs` (re-export the two L4-checksum
+    field-delta SSOT helpers)
+  - `userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs` (new fail-on-revert
+    `declined_rewrite_leaves_umem_byte_identical_4965`; strengthened
+    `pin_ttl_expired_declines_l3_untouched` generic assertion to full-frame)
+  - `userspace-dp/src/afxdp/frame/README.md` (atomicity invariant now covers
+    BOTH in-place rewrites — #5466 descriptor + #4965 generic)
+
 ## 2026-07-20 — #5098: reset global counter offsets on clear (epoch semantics)
 
 - **Timestamp**: 2026-07-20 (fix/5098-clear-counter-offset)

--- a/userspace-dp/src/afxdp/frame/README.md
+++ b/userspace-dp/src/afxdp/frame/README.md
@@ -86,26 +86,43 @@ inspect or rewrite a packet sitting in a UMEM frame.
   `packet_rel_l4_offset_and_protocol` so MSS clamping reaches
   ext-headered v6 SYNs (the shared helper is left unchanged — GRE decap
   and tunnel local-origin read it to forward fragmented inner packets).
-- **The descriptor rewrite is transactional (#5466)**: `rewrite/mod.rs`
-  splits the eth preamble into a pure plan (`rewrite_plan_eth_from_parts`)
-  and a mutating commit (`rewrite_commit_eth_from_plan`, the eth-header
-  write + VLAN-push `copy_within` memmove). ALL bail gates
-  (`is_non_first_fragment`, `validate_rewrite_descriptor_ipv4/ipv6` —
-  header length, TTL/hop-limit, DMA-race port mismatch) run against the
-  PRISTINE frame at `plan.l3` BEFORE the commit. A `None` return therefore
-  leaves the UMEM frame byte-identical, which is required because the flow
-  cache caller chains `apply_rewrite_descriptor(...).or_else(generic)`: a
-  frame mutated before the bail (scribbled L2 / shifted payload) would
-  corrupt the generic fallback's reprocessing. The gates read from the
-  original L3 offset (before the commit's memmove relocates the payload)
-  and use the plan's `frame_len`/`payload_len` for length checks, so their
-  decisions are byte-identical to the pre-#5466 post-commit checks; the
-  infallible `apply_*` mutation half then reproduces the success-path
-  output exactly (guarded by the P-N3 differential + the
-  `pin_5466_*`/`pin_*_declines` fail-on-revert pins). The generic
-  in-place rewrite (`rewrite_forwarded_frame_in_place`) is the TERMINAL
-  fallback and still writes L2 before its own gate — harmless, nothing
-  reprocesses the frame after its `None`.
+- **Both in-place rewrites are transactional / preflight-then-commit
+  (#5466 descriptor, #4965 generic)**: `rewrite/mod.rs` splits the eth
+  preamble into a pure plan (`rewrite_plan_eth_from_parts`) and a mutating
+  commit (`rewrite_commit_eth_from_plan`, the eth-header write + VLAN-push
+  `copy_within` memmove). ALL bail gates run against the PRISTINE frame at
+  `plan.l3` BEFORE the commit, so a `None` return leaves the UMEM frame
+  byte-identical (L2 included). This is the ATOMICITY INVARIANT: a declined
+  rewrite mutates ZERO UMEM bytes.
+    - **Descriptor fast path** (`apply_rewrite_descriptor`, #5466): gates are
+      `is_non_first_fragment` + `validate_rewrite_descriptor_ipv4/ipv6`
+      (header length, TTL/hop-limit, DMA-race port mismatch).
+    - **Generic in-place rewrite** (`rewrite_forwarded_frame_in_place`,
+      #4965): gates are `validate_generic_rewrite_v4/v6` (header length,
+      TTL/hop-limit, IPv6 ext-chain L4-offset resolvability via
+      `v6_rel_l4_offset`, and — when NAT folds into the L4 checksum — the
+      checksum field at `ihl/rel_l4 + {16 TCP, 6 UDP, 2 ICMPv6}` being in
+      bounds, derived from the SAME `l4_checksum_field_delta_v4/v6` SSOT the
+      mutation half writes at). The validators cover EVERY `?` in
+      `rewrite_apply_v4/v6` (`apply_nat_ipv4/ipv6`,
+      `adjust_ipv4_header_checksum`, `recompute_l4_checksum_*`), so the
+      post-commit `apply_*` calls can no longer decline — no UMEM byte is
+      mutated before any possible `None`.
+  Atomicity is REQUIRED because BOTH declining callers re-read the same UMEM:
+  the flow cache chains `apply_rewrite_descriptor(...).or_else(generic)`
+  (`poll_descriptor/flow_cache_hit.rs`) and, on a generic `None`, falls into
+  the `build_live_forward_request_from_frame(packet_frame, ...)` path; and
+  `tx/dispatch/mod.rs` runs `build_forwarded_frame_from_frame(source_frame)`
+  over the SAME `ingress_area` slice after a generic `None`. A frame mutated
+  before the bail (scribbled L2 / shifted payload / partial NAT+checksum)
+  would corrupt that reprocessing (the #4965 bug). The gates read from the
+  original L3 offset (before the commit's memmove relocates the payload) and
+  use the plan's `frame_len`/`payload_len` for length checks, so their
+  decisions are byte-identical to the pre-split post-commit checks; the
+  `apply_*` mutation halves reproduce the success-path output exactly
+  (guarded by the P-N3 differential + the `pin_5466_*` /
+  `declined_rewrite_leaves_umem_byte_identical_4965` /
+  `pin_*_declines` fail-on-revert pins).
 - **Port-less protocols never get an L4 port written (#3111)**: only
   TCP/UDP carry a rewritable 16-bit port pair at L4 offset +0/+2. Every
   port-write site — the generic `apply_nat_port_rewrite` and the

--- a/userspace-dp/src/afxdp/frame/checksum.rs
+++ b/userspace-dp/src/afxdp/frame/checksum.rs
@@ -40,8 +40,13 @@ pub(in crate::afxdp::frame) enum ChecksumFamily {
 /// never carry ICMPv6, and the IPv4 NAT adjust paths call the v4 helpers
 /// without protocol filtering, so a stray ICMPv6 arm would adjust at
 /// `ihl + 2` for protocol 58 instead of no-op'ing — a live behavior change.
+// #4965: re-exported to `frame::mod` so the generic-rewrite preflight
+// validator (`validate_generic_rewrite_v4`) derives the L4-checksum-field
+// bound from the SAME per-protocol SSOT the mutation half uses — the
+// preflight's "is the L4 checksum in bounds" gate can never drift from
+// where the checksum adjust actually writes.
 #[inline(always)]
-fn l4_checksum_field_delta_v4(protocol: u8) -> Option<usize> {
+pub(in crate::afxdp::frame) fn l4_checksum_field_delta_v4(protocol: u8) -> Option<usize> {
     match protocol {
         PROTO_TCP => Some(16),
         PROTO_UDP => Some(6),
@@ -52,8 +57,10 @@ fn l4_checksum_field_delta_v4(protocol: u8) -> Option<usize> {
 /// Per-protocol delta of the L4 checksum field from the start of the IPv6
 /// L4 header (add the fixed 40-byte IPv6 header to get the packet offset).
 /// `None` => no adjusted L4 checksum field (unknown) → caller no-ops.
+// #4965: re-exported alongside the v4 helper (same SSOT rationale) for the
+// generic-rewrite preflight's v6 L4-checksum bound.
 #[inline(always)]
-fn l4_checksum_field_delta_v6(protocol: u8) -> Option<usize> {
+pub(in crate::afxdp::frame) fn l4_checksum_field_delta_v6(protocol: u8) -> Option<usize> {
     match protocol {
         PROTO_TCP => Some(16),
         PROTO_UDP => Some(6),

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -45,7 +45,8 @@ use byte_writes::{
 // wider visibility than its own.
 use checksum::{
     ChecksumFamily, adjust_l4_checksum_ipv6_addr_bytes, adjust_zero_checksum_illegal,
-    checksum_family_of, l4_udp_checksum_optional,
+    checksum_family_of, l4_checksum_field_delta_v4, l4_checksum_field_delta_v6,
+    l4_udp_checksum_optional,
 };
 pub(in crate::afxdp) use checksum::{
     adjust_ipv4_header_checksum, adjust_l4_checksum_ipv4, adjust_l4_checksum_ipv4_dst,
@@ -641,26 +642,20 @@ fn rewrite_commit_eth_from_plan(
     Some(())
 }
 
+/// Read-only derivation of the Ethernet rewrite parameters (dst/src MAC,
+/// tx VLAN, ether_type, whether NAT applies) from the forwarding decision.
+///
+/// #4965: split out of the old `rewrite_prepare_eth` so the generic in-place
+/// rewrite can compute the eth plan and run its v4/v6 preflight WITHOUT
+/// mutating UMEM — mirroring the #5466 descriptor fast path. Touches no
+/// frame bytes; a `None` (missing neighbor/src MAC, or an unknown address
+/// family) is a pure decline that leaves the frame byte-identical.
 #[inline]
-fn rewrite_prepare_eth_from_parts(
-    area: &MmapArea,
-    desc: XdpDesc,
-    meta: ForwardPacketMeta,
-    params: RewriteEthParams,
-) -> Option<RewritePrep> {
-    let plan = rewrite_plan_eth_from_parts(area, desc, meta, &params)?;
-    rewrite_commit_eth_from_plan(area, desc, &plan, &params)?;
-    Some(plan.prep)
-}
-
-#[inline]
-fn rewrite_prepare_eth(
-    area: &MmapArea,
-    desc: XdpDesc,
+fn rewrite_eth_params(
     meta: ForwardPacketMeta,
     decision: &SessionDecision,
     apply_nat_on_fabric: bool,
-) -> Option<RewritePrep> {
+) -> Option<RewriteEthParams> {
     let dst_mac = decision.resolution.neighbor_mac?;
     let (src_mac, vlan_id, apply_nat) =
         if decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
@@ -681,18 +676,108 @@ fn rewrite_prepare_eth(
         libc::AF_INET6 => 0x86dd,
         _ => return None,
     };
-    rewrite_prepare_eth_from_parts(
-        area,
-        desc,
-        meta,
-        RewriteEthParams {
-            dst_mac,
-            src_mac,
-            vlan_id,
-            ether_type,
-            apply_nat,
-        },
-    )
+    Some(RewriteEthParams {
+        dst_mac,
+        src_mac,
+        vlan_id,
+        ether_type,
+        apply_nat,
+    })
+}
+
+/// Read-only preflight of the IPv4 generic in-place rewrite (#4965).
+///
+/// Returns `None` for EXACTLY the inputs on which `rewrite_apply_v4` would
+/// return `None` — but here against the PRISTINE L3 payload, BEFORE
+/// `rewrite_commit_eth_from_plan` mutates any UMEM byte. Gates, in the same
+/// order the mutation half checks them:
+///   1. L3 payload shorter than the minimum IPv4 header (20).
+///   2. Malformed IHL (< 20, or longer than the payload).
+///   3. TTL/hop-limit expiry (unless the sender already decremented — fabric
+///      ingress, `skip_ttl`).
+///   4. When NAT folds a change into the L4 checksum, the checksum field at
+///      `ihl + {16 TCP, 6 UDP}` must be in bounds; otherwise the post-commit
+///      `apply_nat_ipv4` adjust would decline. A non-first fragment carries no
+///      L4 header (the bytes are payload) — the NAT leaf skips the L4 fold
+///      there, so no bound is required and none is imposed.
+///
+/// `l3_payload` is `&frame[l3 .. l3 + payload_len]` at the ORIGINAL offset;
+/// because the commit's VLAN-push memmove is a pure relocation, these
+/// byte-for-byte reads decide identically to the post-commit checks they
+/// replace. The success path is therefore unchanged; only the FAILING inputs
+/// now decline before any mutation, leaving the frame byte-identical.
+#[inline]
+fn validate_generic_rewrite_v4(
+    l3_payload: &[u8],
+    meta: ForwardPacketMeta,
+    nat: NatDecision,
+    apply_nat: bool,
+    skip_ttl: bool,
+) -> Option<()> {
+    if l3_payload.len() < 20 {
+        return None;
+    }
+    let ihl = ((l3_payload[0] & 0x0f) as usize) * 4;
+    if ihl < 20 || l3_payload.len() < ihl {
+        return None;
+    }
+    if !skip_ttl && l3_payload[8] <= 1 {
+        return None; // TTL expired
+    }
+    if apply_nat && nat != NatDecision::default() && !ipv4_is_non_first_fragment(l3_payload) {
+        if let Some(delta) = l4_checksum_field_delta_v4(meta.protocol) {
+            // `apply_nat_ipv4` reads/writes the L4 checksum at `ihl + delta`
+            // (address-change fold and/or port rewrite). If the 2-byte field
+            // is truncated the adjust returns None — hoist that decline here.
+            if l3_payload.len() < ihl + delta + 2 {
+                return None;
+            }
+        }
+    }
+    Some(())
+}
+
+/// Read-only preflight of the IPv6 generic in-place rewrite (#4965). Mirror
+/// of `validate_generic_rewrite_v4` for IPv6:
+///   1. L3 payload shorter than the fixed 40-byte IPv6 header.
+///   2. Hop-limit expiry (unless `skip_ttl`).
+///   3. Extension-chain L4 offset unresolvable (malformed/over-limit chain) —
+///      `v6_rel_l4_offset` is the SAME SSOT the mutation half uses.
+///   4. When NAT folds into the L4 checksum at `rel_l4 + {16 TCP, 6 UDP,
+///      2 ICMPv6}`, that field must be in bounds; non-first fragments skip
+///      the fold and impose no bound.
+///
+/// Returns the resolved `rel_l4` on success so the caller can prove the offset
+/// was validated pre-commit; `rewrite_apply_v6` re-derives the identical value
+/// (same bytes, same meta) after the commit.
+#[inline]
+fn validate_generic_rewrite_v6(
+    l3_payload: &[u8],
+    meta: ForwardPacketMeta,
+    nat: NatDecision,
+    apply_nat: bool,
+    skip_ttl: bool,
+) -> Option<usize> {
+    if l3_payload.len() < 40 {
+        return None;
+    }
+    if !skip_ttl && l3_payload[7] <= 1 {
+        return None; // hop limit expired
+    }
+    let rel_l4 = v6_rel_l4_offset(
+        l3_payload,
+        meta.l3_offset,
+        meta.l4_offset,
+        meta.addr_family,
+    )?;
+    if apply_nat && nat != NatDecision::default() && !ipv6_is_non_first_fragment(l3_payload) {
+        if let Some(delta) = l4_checksum_field_delta_v6(meta.protocol) {
+            if l3_payload.len() < rel_l4 + delta + 2 {
+                return None;
+            }
+        }
+    }
+    Some(rel_l4)
 }
 
 #[inline]
@@ -829,7 +914,56 @@ pub(super) fn rewrite_forwarded_frame_in_place(
     expected_ports: Option<(u16, u16)>,
 ) -> Option<InPlaceRewriteResult> {
     let meta = meta.into();
-    let prep = rewrite_prepare_eth(area, desc, meta, decision, apply_nat_on_fabric)?;
+    // #4965: preflight-then-commit, mirroring the #5466 descriptor fast path.
+    // Compute the eth rewrite plan and run EVERY fallible v4/v6 gate against
+    // the PRISTINE frame BEFORE `rewrite_commit_eth_from_plan` mutates any
+    // UMEM byte (eth-header write + VLAN-push `copy_within` memmove). A `None`
+    // from any gate then leaves the frame byte-identical, so the callers that
+    // re-read the SAME UMEM after a decline — the flow-cache
+    // `apply_rewrite_descriptor(...).or_else(generic)` fallback
+    // (`poll_descriptor/flow_cache_hit.rs`) and the tx-dispatch
+    // `build_forwarded_frame_from_frame(source_frame)` reinject
+    // (`tx/dispatch/mod.rs`) — reprocess an un-corrupted packet, honoring the
+    // zero-copy ownership contract.
+    let eth_params = rewrite_eth_params(meta, decision, apply_nat_on_fabric)?;
+    let plan = rewrite_plan_eth_from_parts(area, desc, meta, &eth_params)?;
+    {
+        // Read-only bail gates against the ORIGINAL L3 payload at `plan.l3`.
+        // The commit's memmove is a pure relocation, so these byte reads
+        // decide identically to `rewrite_apply_v4/v6`'s post-commit checks.
+        let frame = area.slice(desc.addr as usize, desc.len as usize)?;
+        let l3_end = plan.l3.checked_add(plan.payload_len)?;
+        let l3_payload = frame.get(plan.l3..l3_end)?;
+        match meta.addr_family as i32 {
+            libc::AF_INET => validate_generic_rewrite_v4(
+                l3_payload,
+                meta,
+                decision.nat,
+                plan.prep.apply_nat,
+                plan.prep.skip_ttl,
+            )?,
+            libc::AF_INET6 => {
+                // Discard the resolved `rel_l4` — `rewrite_apply_v6` re-derives
+                // the identical offset post-commit; the validator call is here
+                // only to run (and possibly decline on) the ext-chain walk.
+                validate_generic_rewrite_v6(
+                    l3_payload,
+                    meta,
+                    decision.nat,
+                    plan.prep.apply_nat,
+                    plan.prep.skip_ttl,
+                )?;
+            }
+            _ => return None,
+        }
+    }
+    // All gates cleared: commit the eth rewrite (first UMEM mutation). From
+    // here NO path returns None — the preflight proved the byte layout, so the
+    // `rewrite_apply_v4/v6` `?` below can no longer fire (every remaining
+    // fallible op — `apply_nat_ipv4/ipv6`, `adjust_ipv4_header_checksum`,
+    // `recompute_l4_checksum_*`, `v6_rel_l4_offset` — was validated above).
+    rewrite_commit_eth_from_plan(area, desc, &plan, &eth_params)?;
+    let prep = plan.prep;
     let packet = unsafe { area.slice_mut_unchecked(prep.tx_offset as usize, prep.frame_len)? };
     match meta.addr_family as i32 {
         libc::AF_INET => rewrite_apply_v4(

--- a/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
@@ -388,21 +388,23 @@ fn pin_packet(v6: bool, protocol: u8, ttl: u8, ext: Vec<ExtHdr>) -> ValidPacket 
     })
 }
 
-/// (a) TTL/hop-limit ≤ 1 → both paths decline.
+/// (a) TTL/hop-limit ≤ 1 → both paths decline, BOTH transactionally.
 ///
-/// The GENERIC path (`rewrite_forwarded_frame_in_place`) is the TERMINAL
-/// fallback: it writes the Ethernet header during `rewrite_prepare_eth`
-/// BEFORE its TTL validation, so its L2 header IS scribbled on decline —
-/// harmless because nothing reprocesses the frame after the terminal
-/// `None`. Hence the generic assertion checks L3+ only.
-///
-/// The DESCRIPTOR path is now TRANSACTIONAL (#5466): its bail gates run
+/// BOTH in-place rewrites are now TRANSACTIONAL: their bail gates run
 /// against the pristine frame BEFORE `rewrite_commit_eth_from_plan`
 /// mutates anything, so a `None` return leaves the ENTIRE frame (L2
-/// included) byte-identical — required because the caller chains
-/// `apply_rewrite_descriptor(...).or_else(generic)` and a scribbled L2 /
-/// shifted payload would corrupt the generic reprocessing. The descriptor
-/// assertion therefore checks the full frame (FAIL-ON-REVERT for #5466).
+/// included) byte-identical — required because the callers re-read the
+/// SAME UMEM after a decline (the flow cache chains
+/// `apply_rewrite_descriptor(...).or_else(generic)` then reprocesses via
+/// `build_live_forward_request_from_frame`; `tx/dispatch` reprocesses via
+/// `build_forwarded_frame_from_frame(source_frame)`), and a scribbled L2 /
+/// shifted payload would corrupt that reprocessing.
+///   - DESCRIPTOR path (`apply_rewrite_descriptor`): #5466.
+///   - GENERIC path (`rewrite_forwarded_frame_in_place`): #4965 — the
+///     `validate_generic_rewrite_v4/v6` preflight now runs the TTL gate
+///     before the eth commit, so its L2 is NO LONGER scribbled on decline.
+/// Both assertions therefore check the FULL frame (FAIL-ON-REVERT for
+/// #5466 descriptor + #4965 generic).
 #[test]
 fn pin_ttl_expired_declines_l3_untouched() {
     for v6 in [false, true] {
@@ -426,9 +428,10 @@ fn pin_ttl_expired_declines_l3_untouched() {
         );
         let after = area.slice(DIFF_ADDR, pkt.frame.len()).unwrap();
         assert_eq!(
-            &after[pkt.l3..],
-            &pkt.frame[pkt.l3..],
-            "generic decline must leave L3+ untouched (v6={v6})"
+            after,
+            &pkt.frame[..],
+            "#4965: generic TTL decline must be transactional — full frame \
+             byte-identical, incl. L2 (v6={v6})"
         );
 
         let area = area_with_frame(&pkt.frame);
@@ -443,6 +446,185 @@ fn pin_ttl_expired_declines_l3_untouched() {
             &pkt.frame[..],
             "descriptor TTL decline must be transactional (#5466): \
              full frame byte-identical, incl. L2 (v6={v6})"
+        );
+    }
+}
+
+/// #4965 FAIL-ON-REVERT: the generic in-place rewrite
+/// (`rewrite_forwarded_frame_in_place`) is transactional — for EVERY decline
+/// reason the full UMEM frame AND a sentinel region around it stay
+/// byte-identical. Before #4965 `rewrite_prepare_eth` committed the eth header
+/// (and, on the no-headroom VLAN push, the payload `copy_within` memmove) and
+/// `apply_nat_ipv4/v6` wrote IP/port bytes BEFORE their fallible checks, so a
+/// decline left a scribbled L2 / shifted payload / partial NAT+checksum — which
+/// the flow-cache `.or_else(generic)` fallback and the tx-dispatch
+/// `build_forwarded_frame_from_frame(source_frame)` reinject then re-read as a
+/// corrupt packet. Reverting the preflight (commit-before-check) makes an
+/// assertion FAIL: the mutated bytes differ from the input.
+///
+/// Covers: TTL/hop-limit expiry (v4/v6), malformed IHL, truncated L4 checksum
+/// with an ADDRESS NAT (old code writes the IP address then declines at the L4
+/// checksum adjust — the "partially-adjusted NAT+checksum" corruption, v4/v6),
+/// the VLAN-push-no-headroom memmove path (the worst manifestation — a pre-check
+/// memmove shifts the payload), and the descriptor-declines-then-`.or_else`
+/// chain. (Unknown-address-family declines in `rewrite_eth_params` before any
+/// byte is touched, so it was already atomic and is not a revert-sensitive
+/// case.)
+#[test]
+fn declined_rewrite_leaves_umem_byte_identical_4965() {
+    const SENTINEL: u8 = 0xA5;
+    const AREA: usize = 4096;
+
+    // A SENTINEL-filled area with the frame at DIFF_ADDR; returns the area and
+    // a whole-area snapshot so a decline can be checked against the ENTIRE area
+    // (frame region unchanged + the surrounding sentinel intact — catches any
+    // OOB write leaked past the frame).
+    fn sentinel_area(frame: &[u8]) -> (MmapArea, Vec<u8>) {
+        let mut area = MmapArea::new(AREA).expect("mmap");
+        for b in area.slice_mut(0, AREA).unwrap().iter_mut() {
+            *b = SENTINEL;
+        }
+        area.slice_mut(DIFF_ADDR, frame.len())
+            .unwrap()
+            .copy_from_slice(frame);
+        let snapshot = area.slice(0, AREA).unwrap().to_vec();
+        (area, snapshot)
+    }
+
+    fn assert_generic_declines_untouched(pkt: &ValidPacket, nat: NatDecision, label: &str) {
+        let (area, snapshot) = sentinel_area(&pkt.frame);
+        let desc = XdpDesc {
+            addr: DIFF_ADDR as u64,
+            len: pkt.frame.len() as u32,
+            options: 0,
+        };
+        let decision = make_decision(pkt, nat, 0);
+        assert!(
+            rewrite_forwarded_frame_in_place(&area, desc, pkt.meta, &decision, false, None)
+                .is_none(),
+            "generic must decline: {label}"
+        );
+        assert_eq!(
+            area.slice(0, AREA).unwrap(),
+            &snapshot[..],
+            "#4965: declined generic rewrite must leave UMEM byte-identical (frame + sentinel): {label}"
+        );
+    }
+
+    // (1) TTL / hop-limit ≤ 1 — v4 + v6, with a port NAT decision present.
+    for v6 in [false, true] {
+        let pkt = pin_packet(v6, PROTO_TCP, 1, Vec::new());
+        let nat = NatDecision {
+            rewrite_src_port: Some(0x3333),
+            ..NatDecision::default()
+        };
+        assert_generic_declines_untouched(&pkt, nat, if v6 { "ttl v6" } else { "ttl v4" });
+    }
+
+    // (2) Malformed IHL (v4): drop the IHL nibble below 5 (< 20 bytes).
+    {
+        let mut pkt = pin_packet(false, PROTO_TCP, 64, Vec::new());
+        pkt.frame[pkt.l3] = 0x44; // version 4, IHL 4 → 16 bytes < 20
+        assert_generic_declines_untouched(&pkt, NatDecision::default(), "malformed ihl");
+    }
+
+    // (3) Truncated L4 checksum field with an ADDRESS NAT. Under the reverted
+    //     (commit-before-check) code the eth header is committed and
+    //     `apply_nat_ipv4/v6` WRITES the new IP source, THEN declines at the L4
+    //     checksum adjust (`packet.get(csum_off..csum_off+2)` OOB) — leaving a
+    //     scribbled L2 + partially-rewritten IP. The preflight declines first.
+    {
+        // v4: keep the full IPv4 header (20) but only 16 L4 bytes → the TCP
+        // checksum at ihl+16 (=36) needs 38 bytes of L3 payload; we give 36.
+        let mut pkt = pin_packet(false, PROTO_TCP, 64, Vec::new());
+        pkt.frame.truncate(pkt.l3 + 36);
+        let nat = NatDecision {
+            rewrite_src: Some(IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7))),
+            ..NatDecision::default()
+        };
+        assert_generic_declines_untouched(&pkt, nat, "v4 truncated l4 csum + addr nat");
+    }
+    {
+        // v6: keep the fixed 40-byte header but only 16 L4 bytes → the TCP
+        // checksum at rel_l4+16 (=56) needs 58 bytes of L3 payload; give 56.
+        let mut pkt = pin_packet(true, PROTO_TCP, 64, Vec::new());
+        pkt.frame.truncate(pkt.l3 + 56);
+        let nat = NatDecision {
+            rewrite_src: Some(IpAddr::V6("2001:db8::7".parse().unwrap())),
+            ..NatDecision::default()
+        };
+        assert_generic_declines_untouched(&pkt, nat, "v6 truncated l4 csum + addr nat");
+    }
+
+    // (4) VLAN-push-no-headroom memmove path + a TTL decline — the worst
+    //     manifestation. Under the reverted code the commit `copy_within`
+    //     SHIFTS the L3 payload by 4 (and writes the new eth header) BEFORE the
+    //     TTL gate declines, so the fallback reprocesses a doubly-shifted frame.
+    {
+        const FRAME_BASE: usize = 4096; // == UMEM_FRAME_SIZE
+        const BIG: usize = 8192;
+        let pkt = pin_packet(false, PROTO_TCP, 1, Vec::new()); // no VLAN → l3 = 14, TTL=1
+        let mut area = MmapArea::new(BIG).expect("mmap");
+        for b in area.slice_mut(0, BIG).unwrap().iter_mut() {
+            *b = SENTINEL;
+        }
+        area.slice_mut(FRAME_BASE, pkt.frame.len())
+            .unwrap()
+            .copy_from_slice(&pkt.frame);
+        let snapshot = area.slice(0, BIG).unwrap().to_vec();
+        let desc = XdpDesc {
+            addr: FRAME_BASE as u64,
+            len: pkt.frame.len() as u32,
+            options: 0,
+        };
+        // tx_vlan_id = 100 → target eth_len 18 → VLAN push; rx-4 leaves the
+        // UMEM chunk → VlanPushMemmoveNoHeadroom (the memmove path).
+        let decision = make_decision(&pkt, NatDecision::default(), 100);
+        assert!(
+            rewrite_forwarded_frame_in_place(&area, desc, pkt.meta, &decision, false, None)
+                .is_none(),
+            "generic must decline TTL≤1 on the vlan-push memmove path"
+        );
+        assert_eq!(
+            area.slice(0, BIG).unwrap(),
+            &snapshot[..],
+            "#4965: memmove-path decline must NOT shift the payload or scribble L2"
+        );
+    }
+
+    // (5) The descriptor-declines-then-`.or_else(generic)` chain (exactly the
+    //     flow-cache composition). A non-first fragment makes the descriptor
+    //     path decline (transactional per #5466); TTL≤1 makes the generic
+    //     fallback decline. Both must be atomic so the chained `None` leaves
+    //     the frame pristine for the caller's subsequent reprocessing.
+    {
+        let mut pkt = pin_packet(false, PROTO_TCP, 1, Vec::new()); // TTL = 1
+        let l3 = pkt.l3;
+        pkt.frame[l3 + 6] = 0x00;
+        pkt.frame[l3 + 7] = 0x10; // fragment-offset nonzero → non-first fragment
+        let (area, snapshot) = sentinel_area(&pkt.frame);
+        let desc = XdpDesc {
+            addr: DIFF_ADDR as u64,
+            len: pkt.frame.len() as u32,
+            options: 0,
+        };
+        let nat = NatDecision {
+            rewrite_src_port: Some(0x3333),
+            ..NatDecision::default()
+        };
+        let rd = make_descriptor(&pkt, nat, 0);
+        let decision = make_decision(&pkt, nat, 0);
+        let result = apply_rewrite_descriptor(&area, desc, pkt.meta, &rd, None).or_else(|| {
+            rewrite_forwarded_frame_in_place(&area, desc, pkt.meta, &decision, false, None)
+        });
+        assert!(
+            result.is_none(),
+            "descriptor (fragment) then generic (TTL) must both decline"
+        );
+        assert_eq!(
+            area.slice(0, AREA).unwrap(),
+            &snapshot[..],
+            "#4965: descriptor-decline → or_else(generic)-decline must leave UMEM byte-identical"
         );
     }
 }


### PR DESCRIPTION
## Problem (#4965)

The generic in-place frame rewrite `rewrite_forwarded_frame_in_place` (the packet-forwarding hot path) mutated UMEM bytes **before** a fallible check could decline, and a fallback graph then re-read the already-mutated frame → packet corruption, violating the zero-copy ownership contract.

`rewrite_prepare_eth` composed a read-only plan with a **commit** (eth-header write + VLAN-push `copy_within` payload memmove), then `rewrite_apply_v4/v6` ran and could still return `None` — TTL/hop-limit expiry, malformed IHL, unresolvable IPv6 ext-chain L4 offset, or a truncated L4 checksum during `apply_nat_ipv4/ipv6` — **after** the commit and after the NAT helpers wrote IP/port bytes.

Both declining callers re-read the **same** UMEM:
- **flow cache** (`poll_descriptor/flow_cache_hit.rs`): `apply_rewrite_descriptor(...).or_else(generic)`, then on a generic `None` reprocesses via `build_live_forward_request_from_frame(packet_frame)`.
- **tx dispatch** (`tx/dispatch/mod.rs`): on a generic `None`, runs `build_forwarded_frame_from_frame(source_frame)` over the same `ingress_area` slice.

So a declined rewrite left a scribbled L2 / shifted payload / partial NAT+checksum that got reprocessed as a corrupt packet (double VLAN memmove, garbled NAT).

## Assessment

The codebase evolved since the issue was filed: **#5466 already made the descriptor fast path (`apply_rewrite_descriptor`) transactional** — it validates every bail gate against the pristine frame before `rewrite_commit_eth_from_plan` (the `EthRewritePlan` split). The **generic path was the remaining gap** — still commit-before-check. This PR makes the generic path transactional the same way.

## Fix — preflight-then-commit

`rewrite_forwarded_frame_in_place` now:
1. derives eth params (`rewrite_eth_params`, read-only),
2. computes the eth plan (`rewrite_plan_eth_from_parts`, read-only),
3. runs `validate_generic_rewrite_v4/v6` against the **pristine** L3 payload at `plan.l3` — a read-only preflight covering **every** `?` in `rewrite_apply_v4/v6` (header length, TTL, `v6_rel_l4_offset` ext-chain, and the L4-checksum-field-in-bounds gate derived from the **same** `l4_checksum_field_delta_v4/v6` SSOT the mutation half writes at),
4. only then commits + applies.

The commit's memmove is a pure relocation and the eth-header write never touches L3/L4, so the preflight's byte reads decide identically to the post-commit checks they replace. The `apply_*` bodies are **unchanged** → the success-path output is byte-for-byte identical; only failing inputs decline before any mutation, leaving the frame byte-identical for the `.or_else` fallback / reinject.

Split the old `rewrite_prepare_eth` into read-only `rewrite_eth_params` (removed it + the now-dead `rewrite_prepare_eth_from_parts`). Re-exported `l4_checksum_field_delta_v4/_v6` so the preflight's L4 bound cannot drift from where the checksum adjust writes.

## Test (merge gate)

`declined_rewrite_leaves_umem_byte_identical_4965` asserts that for **every** decline reason — TTL/hop-limit (v4+v6), malformed IHL, truncated-L4-checksum with an address NAT (v4+v6, the "partially-adjusted NAT+checksum" case), the VLAN-push-no-headroom memmove path, and the descriptor-declines-then-`.or_else(generic)`-declines chain — the full UMEM frame **and a sentinel region around it** stay byte-identical.

**Parent-RED verified:** reverting the preflight (commit-before-check) makes this test AND the strengthened full-frame `pin_ttl_expired_declines_l3_untouched` fail with `assertion left == right` (a genuine assertion failure, not a build break); the revert still compiles (43 passed / 2 failed). target-count = the two atomicity assertions.

## Validation

- `cargo test --release` full suite **green (4041 passed, 0 failed)**, incl. the P-N3 `descriptor_generic_differential` byte-parity proptest.
- Named test passes **3×** deterministically.

## Docs

`frame/README.md` atomicity invariant updated: **both** in-place rewrites are now preflight-then-commit (#5466 descriptor + #4965 generic); a declined rewrite mutates zero UMEM bytes; the fallback graph is safe.

## Smoke

This **is** the packet-forwarding rewrite hot path. A byte-level regression corrupts packets — the change is a restructure for atomicity that preserves the success-path output byte-identically (guarded by the P-N3 differential), but a loss-cluster iperf smoke (v4+v6, push/reverse) is warranted before merge. I (the parent) will run/batch it.

Closes #4965

🤖 Generated with [Claude Code](https://claude.com/claude-code)
