### PR TITLE
config: fix stale runtime-chain refs in strict-NAT comment (#6153)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,26 @@
+## 2026-07-21 — #6153: fix stale runtime-chain refs in strict-NAT comment
+
+- **Timestamp**: 2026-07-21 (fix/6153-strict-nat-comment)
+- **Action**: Comment-only doc-accuracy fix in the
+  `validateNATSourceAddressNameReferencesStrict` doc block. Since #4925 the
+  RUNTIME resolution chain is
+  `resolveNATAddressNamePrefixes → expandBookNameRecursive` (the feed-aware
+  recursive expander in `pkg/dataplane/userspace/nat.go`), not
+  `resolveNATAddressNamePrefixes → resolveUserspaceAddressBookEntry`. Updated
+  the two stale runtime-chain refs: (1) the snapshot-build-time chain
+  (`appendNATSourceAddressName → resolveNATAddressNamePrefixes → …`) and
+  (2) the defined-but-unresolvable behavior note (`… returns ok=false` →
+  `expandBookNameRecursive returns an empty prefix list`, matching the new
+  `[]string` signature). Left every STRICT-COMMIT-gate ref intact — the
+  commit gate legitimately uses the static `policyMatchAddressBookResolves`
+  path (unchanged), and the #4925 paragraph that already reads
+  `resolveNATAddressNamePrefixes -> expandBookNameRecursive`. No code/logic
+  change (0 logic delta).
+- **File(s)**: pkg/config/compiler_validate_strict_nat.go
+- **Validation**: `go build ./pkg/config/...` OK, `go vet ./pkg/config/...`
+  OK, `gofmt -l` reports nothing. No parent-RED / test applies to a
+  comment-only change.
+
 ## 2026-07-21 — #6148: de-flake event_stream stalled_consumer liveness under CPU contention
 
 - **Timestamp**: 2026-07-21 (fix/6148-deflake-backpressure-liveness)

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -965,15 +965,16 @@ func validateSourceNATPoolAddressScopeStrict(cfg *Config) error {
 //
 // The name is resolved to concrete prefixes at snapshot-build time
 // (appendNATSourceAddressName → resolveNATAddressNamePrefixes →
-// resolveUserspaceAddressBookEntry). Two distinct failures both translate to a
-// rule that matches NOTHING (fail-closed but SILENT):
+// expandBookNameRecursive, the feed-aware recursive expander since #4925). Two
+// distinct failures both translate to a rule that matches NOTHING (fail-closed
+// but SILENT):
 //
 //   - a wholly UNDEFINED name (a typo) — neither an address-book entry nor a
 //     dynamic-address feed binding; and
 //   - a DEFINED-but-UNRESOLVABLE name (#3425) — a defined `address` with no
 //     prefix (empty Value), a defined-but-EMPTY `address-set`, or a set with a
-//     dangling / member-less expansion. resolveUserspaceAddressBookEntry
-//     returns ok=false for these, so the builder appends the raw (unparseable)
+//     dangling / member-less expansion. expandBookNameRecursive returns an
+//     empty prefix list for these, so the builder appends the raw (unparseable)
 //     token to keep the constraint non-empty and the rule translates no
 //     traffic — exactly the policy-address fail-open class #3149 closes for
 //     security policies, here for NAT.


### PR DESCRIPTION
## Summary

Comment-only doc-accuracy fix (from the #6152/#4925 review, issue #6153).

The `validateNATSourceAddressNameReferencesStrict` doc block in
`pkg/config/compiler_validate_strict_nat.go` described the **runtime**
name-resolution chain as
`resolveNATAddressNamePrefixes → resolveUserspaceAddressBookEntry`. Since
**#4925** the runtime path is
`resolveNATAddressNamePrefixes → expandBookNameRecursive` — the feed-aware
recursive expander in `pkg/dataplane/userspace/nat.go` that now feed-resolves
nested address-set members (verified against origin/master:
`resolveNATAddressNamePrefixes` calls `expandBookNameRecursive`).

## Changes (comment-only, 0 logic delta)

Two stale **runtime-chain** refs updated:

1. The snapshot-build-time chain:
   `appendNATSourceAddressName → resolveNATAddressNamePrefixes → resolveUserspaceAddressBookEntry`
   → `… → expandBookNameRecursive` (feed-aware recursive expander since #4925).
2. The defined-but-unresolvable behavior note: old text said
   `resolveUserspaceAddressBookEntry returns ok=false`; `expandBookNameRecursive`
   has a `[]string` signature, so it "returns an empty prefix list". The builder
   still appends the raw token to keep the constraint non-empty — described
   fail-closed behavior unchanged.

## Scoping

The **STRICT-COMMIT gate** references are left exactly as-is: the commit gate
legitimately uses the static `policyMatchAddressBookResolves` resolution (which
never consults the feed overlay), and the #4925 paragraph that already reads
`resolveNATAddressNamePrefixes -> expandBookNameRecursive`. Only the two
runtime-chain refs were touched.

## Validation

- `go build ./pkg/config/...` — clean
- `go vet ./pkg/config/...` — clean
- `gofmt -l pkg/config/compiler_validate_strict_nat.go` — reports nothing

No parent-RED / test applies to a comment-only change.

Not HA.

Closes #6153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgmqsyXwZVw25adgFgSku2
