### PR TITLE
userspace-dp/eventstream: recover oversized/framing-desync frames via resync, not a replay loop (#6132)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54031,3 +54031,33 @@ top.
     `Test_nat_mixed_static_and_unresolvable_set_partial_resolves_6143`)
   - `pkg/config/compiler_validate_strict_nat.go` (strict-vs-runtime
     comment reword in `validateNATSourceAddressNameReferencesStrict`)
+
+## 2026-07-21 — #6132 eventstream oversized/framing-desync resync recovery
+- **Timestamp**: 2026-07-21
+- **Action**: Fix the EventStream reader's oversized/framing-desync guard
+  (`length > 1024`) so a persistently-oversized/corrupt session frame recovers
+  via a rate-limited full resync instead of the pre-#6132 bare `return` that
+  dropped the connection forever. That bare return had the SAME replay-loop
+  pathology #6130 fixed for the undecodable-decode path: the frame is PRESENT on
+  the wire, the Rust replay buffer re-sends it verbatim (no `has_gap` barrier),
+  so drop -> reconnect -> replay -> drop stormed the shared control socket.
+  New `handleOversizedFrame` reuses the #6130 machinery: extracted
+  `triggerRateLimitedResync` (shared onFullResync + `decodeFailureResyncInterval`
+  rate-limiter + `SessionSyncResyncs`/`DecodeResyncSuppressed`), advances the
+  watermark PAST the (aligned-header) seq (loop-break), and re-aligns the byte
+  stream by trust in the LENGTH — discard within `maxDiscardableOversizedFrameBytes`
+  and KEEP the connection, else flush the advanced ACK and drop to re-establish
+  framing on reconnect (bounded). Security posture preserved: the corrupt frame
+  is REFUSED (never decoded/applied), superseded by the table-truth resync.
+  Fail-on-revert tests (target-count: the single guard call site) go RED as an
+  assertion failure when the bare `return` is restored. Not HA (event-stream
+  reader; unit-provable, no cluster smoke).
+- **File(s)**:
+  - `pkg/dataplane/userspace/eventstream.go` (oversized guard call site;
+    new `handleOversizedFrame` + `maxDiscardableOversizedFrameBytes`; extracted
+    `triggerRateLimitedResync`; `handleSessionDecodeFailure` now calls it)
+  - `pkg/dataplane/userspace/eventstream_oversized_framing_resync_6132_test.go`
+    (new fail-on-revert tests
+    `Test_oversized_session_frame_recovers_via_resync_not_replay_loop_6132`,
+    `Test_persistent_oversized_session_frames_do_not_replay_loop_6132`)
+  - `docs/session-sync-architecture.md` (#6132 recovery paragraph + trigger-list)

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -636,10 +636,12 @@ post-snapshot sessions.
 This is **not** triggered by demotion prep. Its only live caller is
 `handleEventStreamFullResync` → `exportUserspaceOwnerRGSessionsWithConfig`: the
 event stream signals a FullResync after a #2874 sequence gap, a #2442
-delta-ring overflow (loss-of-sync), or a #5483 **undecodable session frame**
+delta-ring overflow (loss-of-sync), a #5483 **undecodable session frame**
 (a COMPLETE-but-semantically-rejected open/close/update — same severity as a
-gap, because the standby is missing that frame's session state), and the export
-republishes the full owned set from table truth. It is not the same thing as the
+gap, because the standby is missing that frame's session state), or a #6132
+**oversized / framing-desynced frame** (a refused frame whose declared length
+exceeds the sanity bound), and the export republishes the full owned set from
+table truth. It is not the same thing as the
 steady-state delta drain.
 
 The #5483 case closes a silent-divergence hole: the reader used to skip an
@@ -694,6 +696,31 @@ drops it for a non-primary), so advancing past the undecodable frame there loses
 nothing and the standby cannot spin. A decode failure on a lossy TELEMETRY frame
 is still tolerated (skipped, watermark advanced) — it carries no HA session
 state.
+
+**#6132 — the oversized / framing-desync guard has the SAME replay loop, fixed
+the same way.** The reader's length sanity check (`length > 1024`; the helper's
+largest legitimate frame is a <=256B session event) used to do a bare `return`,
+dropping the connection on any oversized declared length. That is the identical
+pathology: the frame is **PRESENT** on the wire, the Rust replay buffer re-sends
+it verbatim with no `has_gap` barrier, so a persistently-oversized / framing-
+corrupt frame at seq N produced the same drop → reconnect → replay → drop storm
+`#6130` eliminated for the undecodable-decode path. `handleOversizedFrame` now
+recovers via the shared `triggerRateLimitedResync` machinery (same
+`onFullResync`, same `decodeFailureResyncInterval` rate-limiter, same
+`SessionSyncResyncs` / `DecodeResyncSuppressed` accounting) instead of an
+unbounded reconnect loop. The header is written atomically and the reader
+consumes exactly `length` payload bytes per frame, so the header stays aligned
+and this frame's `seq` is trustworthy; the watermark is advanced PAST it (the
+loop-break — the helper trims it and never re-sends it) and the payload is
+handled by trust in the LENGTH: a length within
+`maxDiscardableOversizedFrameBytes` is a trusted frame boundary, so the reader
+discards exactly that many bytes to re-align on the next header and KEEPS the
+connection (no drop); a length above the ceiling (or a failed drain) is not
+trusted to re-align the byte stream, so the reader flushes the advanced ACK and
+drops the connection to re-establish framing on reconnect — bounded, because the
+ACK moved past the frame so it is trimmed, not replayed. The **security posture
+is preserved**: the corrupt frame is REFUSED — never decoded or applied as valid
+session state — it is superseded by the table-truth resync.
 
 The `rgIDs` handed to the export are enumerated from the **configured
 redundancy-group set** — `handleEventStreamFullResync` calls

--- a/pkg/dataplane/userspace/eventstream.go
+++ b/pkg/dataplane/userspace/eventstream.go
@@ -528,11 +528,18 @@ func (es *EventStream) readLoop(ctx context.Context) {
 		typ := hdr[4]
 		seq := binary.LittleEndian.Uint64(hdr[8:16])
 
-		// Sanity check payload length (max 256 bytes for session events).
+		// Sanity check payload length (max 256 bytes for session events). An
+		// oversized declared length is a corrupt / framing-desynced frame. Do NOT
+		// drop the connection forever (the pre-#6132 bare `return`): the helper's
+		// Rust replay buffer re-sends a PRESENT frame verbatim on reconnect with no
+		// gap self-heal barrier, so a persistently-oversized frame produced the same
+		// drop -> reconnect -> replay storm #6130 fixed for the undecodable-decode
+		// path. handleOversizedFrame recovers via a rate-limited resync instead.
 		if length > 1024 {
-			slog.Warn("event stream: oversized frame", "length", length, "type", typ)
-			es.DecodeErrors.Add(1)
-			return
+			if !es.handleOversizedFrame(conn, length, typ, seq, &prevSeq) {
+				return
+			}
+			continue
 		}
 
 		// Read payload.
@@ -802,12 +809,33 @@ func (es *EventStream) handleSessionDecodeFailure(seq uint64, prevSeq *uint64) {
 	// Rate-limited resync trigger + WARN. Fire BEFORE advancing the watermark so
 	// the table-truth snapshot is triggered while lastAppliedSeq still sits below
 	// the hole — the ACK only moves past seq after this returns.
+	es.triggerRateLimitedResync("undecodable session-sync frame", seq)
+
+	// Loop-break (#6130): advance PAST the present-but-undecodable frame
+	// unconditionally so the cumulative ACK trims it from the helper's replay
+	// buffer and it is never re-sent.
+	*prevSeq = seq
+	es.lastRecvSeq.Store(seq)
+	es.markFrameApplied(seq)
+}
+
+// triggerRateLimitedResync fires a full resync (onFullResync) plus a WARN for a
+// REFUSED correctness-critical session-sync frame — an undecodable frame
+// (#6130) or an oversized/framing-desynced frame (#6132). The trigger and log
+// are rate-limited by decodeFailureResyncInterval off the shared
+// lastDecodeResyncNanos timestamp so a persistently-bad stream cannot hammer the
+// shared control socket (CLAUDE.md forbids >1/s) or flood the log: a fired call
+// bumps SessionSyncResyncs and re-baselines the peer from table truth; a
+// suppressed call bumps DecodeResyncSuppressed. The caller is responsible for
+// the loop-break (advancing the watermark past the refused frame) — this only
+// performs the shared, rate-limited resync side.
+func (es *EventStream) triggerRateLimitedResync(reason string, seq uint64) {
 	nowNanos := time.Now().UnixNano()
 	last := es.lastDecodeResyncNanos.Load()
 	if last == 0 || nowNanos-last >= int64(decodeFailureResyncInterval) {
 		es.lastDecodeResyncNanos.Store(nowNanos)
 		es.SessionSyncResyncs.Add(1)
-		slog.Warn("event stream: undecodable session-sync frame; forcing rate-limited full resync",
+		slog.Warn("event stream: "+reason+"; forcing rate-limited full resync",
 			"seq", seq, "last_applied", es.lastAppliedSeq.Load())
 		es.callbackMu.RLock()
 		onFullResync := es.onFullResync
@@ -818,13 +846,84 @@ func (es *EventStream) handleSessionDecodeFailure(seq uint64, prevSeq *uint64) {
 	} else {
 		es.DecodeResyncSuppressed.Add(1)
 	}
+}
 
-	// Loop-break (#6130): advance PAST the present-but-undecodable frame
-	// unconditionally so the cumulative ACK trims it from the helper's replay
-	// buffer and it is never re-sent.
+// maxDiscardableOversizedFrameBytes bounds how many payload bytes the reader will
+// read-and-discard to skip past an oversized-but-well-framed frame and re-align
+// on the next header (#6132). The helper writes atomic, correctly-length-
+// prefixed frames whose largest legitimate payload is a session event (<=256B),
+// so the 1024 guard already flags anything larger as corrupt / over-max. A
+// declared length still within this ceiling is trusted as a real frame boundary
+// (a version-skewed / buggy encoder emitting an over-max but correctly-prefixed
+// frame): the reader discards exactly that many bytes on the live connection.
+// A declared length ABOVE this ceiling is NOT trusted to re-align the byte stream
+// (draining it could block the reader on a desynced / pathologically-large
+// length), so the reader drops the connection to re-establish framing on
+// reconnect rather than discarding blindly.
+const maxDiscardableOversizedFrameBytes = 64 * 1024
+
+// handleOversizedFrame recovers from an oversized / framing-desynced frame
+// (declared length > the 1024 sanity bound) WITHOUT the pre-#6132
+// drop-the-connection-forever replay loop — the framing-path analog of the
+// #6130 undecodable-decode fix.
+//
+// The pre-#6132 guard did a bare `return`, dropping the connection on any
+// declared length > 1024. Because the helper's Rust replay buffer re-sends a
+// PRESENT frame verbatim on reconnect (no `has_gap` self-heal barrier for a
+// present-but-corrupt frame — the exact pathology #6130 fixed for the
+// undecodable path), a persistently-oversized / framing-corrupt frame at seq N
+// produced a deterministic drop -> reconnect -> replay -> drop storm that
+// hammered the shared control socket and flooded the log.
+//
+// The helper writes whole `[header|payload]` frames and the reader consumes
+// exactly `length` payload bytes per frame, so the header (and thus this frame's
+// `seq`/`typ`) stays aligned frame-to-frame and is trustworthy; only the payload
+// SIZE is anomalous. Recovery mirrors #6130 and preserves the security posture —
+// the corrupt frame is NEVER decoded or applied, it is REFUSED and superseded by
+// a resync:
+//   - Trigger a rate-limited full resync so the peer is re-baselined from table
+//     truth (onFullResync -> ExportOwnerRGSessions, an unbounded ground-truth
+//     snapshot), superseding whatever the refused frame carried.
+//   - Advance the sequence watermark PAST this frame so the helper's cumulative
+//     ACK trims it and it is NOT re-sent verbatim — the loop-break.
+//
+// The byte-stream re-alignment differs by trust in the LENGTH:
+//   - length <= maxDiscardableOversizedFrameBytes: the frame boundary is trusted;
+//     discard exactly `length` bytes to land on the next header and KEEP the
+//     connection (returns true -> caller `continue`s). No drop.
+//   - length above the ceiling, or a failed drain (short / desynced stream): the
+//     length is not trusted to re-align the byte stream, so flush the advanced
+//     ACK (so the helper trims the frame) and drop the connection (returns false
+//     -> caller returns) to re-establish framing cleanly on reconnect. The
+//     advance + flushed ACK make the drop bounded — the frame is trimmed, not
+//     replayed into another drop.
+func (es *EventStream) handleOversizedFrame(conn net.Conn, length uint32, typ uint8, seq uint64, prevSeq *uint64) bool {
+	slog.Warn("event stream: oversized frame", "length", length, "type", typ, "seq", seq)
+	es.DecodeErrors.Add(1)
+	es.triggerRateLimitedResync("oversized/framing-desync frame", seq)
+
+	// Loop-break: advance the watermark PAST this frame (its aligned-header seq is
+	// trustworthy) so the helper trims it and never re-sends it verbatim.
 	*prevSeq = seq
 	es.lastRecvSeq.Store(seq)
 	es.markFrameApplied(seq)
+
+	// Oversized-but-well-framed: the declared length is a trusted frame boundary
+	// (within the discard ceiling). Drain exactly that many bytes to re-align on
+	// the next header and KEEP the connection.
+	if length <= maxDiscardableOversizedFrameBytes {
+		if _, err := io.CopyN(io.Discard, conn, int64(length)); err == nil {
+			return true
+		}
+		// Drain failed (short / desynced stream) — fall through to the drop path
+		// below to re-establish framing on reconnect.
+	}
+
+	// Genuine framing desync (untrusted length, or a failed drain): re-establish
+	// framing by dropping the connection. Flush the advanced ACK first so the
+	// helper trims the frame — the drop is bounded, not a replay loop.
+	es.sendAckIfNeeded()
+	return false
 }
 
 func (es *EventStream) backoffCallbackNotReady(ctx context.Context) {

--- a/pkg/dataplane/userspace/eventstream_oversized_framing_resync_6132_test.go
+++ b/pkg/dataplane/userspace/eventstream_oversized_framing_resync_6132_test.go
@@ -1,0 +1,243 @@
+package userspace
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Test_oversized_session_frame_recovers_via_resync_not_replay_loop_6132 pins the
+// #6132 fix: a session frame whose DECLARED length exceeds the sanity bound
+// (`length > 1024`) — an oversized / framing-corrupt frame — must NOT drop the
+// connection forever in a replay loop. Like #6130's undecodable-decode path, the
+// frame is PRESENT on the wire, so the helper's Rust replay buffer re-sends it
+// verbatim on reconnect with no `has_gap` self-heal barrier; the pre-#6132 bare
+// `return` therefore produced a deterministic drop -> reconnect -> replay -> drop
+// storm.
+//
+// The recovery must:
+//  1. force a rate-limited full resync (onFullResync fires, SessionSyncResyncs
+//     bumps) so the peer is re-baselined from table truth — the corrupt frame is
+//     REFUSED, never decoded or applied (security posture preserved); AND
+//  2. ADVANCE the watermark PAST the oversized frame and KEEP the connection
+//     alive (well-framed sub-path: the declared length is within the discard
+//     ceiling, so the reader drains it and re-aligns on the next header), so a
+//     following frame is consumed on the SAME connection.
+//
+// Parent-RED map (target-count 1): revert handleOversizedFrame's call site to the
+// pre-#6132 bare `return` (`slog.Warn(...); es.DecodeErrors.Add(1); return`).
+// Then:
+//   - the connection drops at the oversized frame (seq 2), the recovery frame
+//     (seq 3) is never read, and the "recovery frame dispatched" assertion TIMES
+//     OUT (RED, assertion failure); AND
+//   - lastAppliedSeq stays at the baseline (1) — the "watermark advanced past the
+//     hole" assertion (>= 2) goes RED.
+//
+// The resync / SessionSyncResyncs / DecodeErrors assertions also exercise the new
+// path, but the connection-survival + watermark-advance are the behaviours the
+// revert breaks.
+func Test_oversized_session_frame_recovers_via_resync_not_replay_loop_6132(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test-events.sock")
+
+	es := NewEventStream(sockPath)
+	dispatched := make(chan uint64, 4)
+	es.SetOnEvent(func(_ uint8, seq uint64, _ SessionDeltaInfo) bool {
+		dispatched <- seq
+		return true
+	})
+	var resyncCalled atomic.Bool
+	es.SetOnFullResync(func() bool {
+		resyncCalled.Store(true)
+		return true
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	es.Start(ctx)
+	defer es.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	waitForConnected(t, es)
+
+	good := buildSessionOpenV4Payload(
+		6, 1000, 80,
+		[4]byte{10, 0, 1, 1}, [4]byte{10, 0, 2, 1},
+		[4]byte{}, [4]byte{},
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		[6]byte{}, [6]byte{}, [4]byte{},
+	)
+
+	// seq 1: decodable baseline — establishes the contiguous watermark at 1.
+	if err := writeFrame(conn, EventTypeSessionOpen, 1, good); err != nil {
+		t.Fatalf("write seq 1: %v", err)
+	}
+	if got := <-dispatched; got != 1 {
+		t.Fatalf("baseline dispatched seq = %d, want 1", got)
+	}
+
+	// seq 2: an oversized session frame — declared length 2000 bytes, above the
+	// 1024 sanity bound but within the discard ceiling (well-framed: the payload
+	// is really 2000 bytes on the wire, so draining it re-aligns cleanly on the
+	// next header). The reader must REFUSE it (never decode) yet keep the
+	// connection.
+	oversized := make([]byte, 2000)
+	if err := writeFrame(conn, EventTypeSessionOpen, 2, oversized); err != nil {
+		t.Fatalf("write seq 2 (oversized): %v", err)
+	}
+
+	// seq 3: a decodable session frame on the SAME connection. With the fix the
+	// connection survives the oversized frame and this is dispatched, proving no
+	// reconnect loop and normal recovery. In the reverted (buggy) path the
+	// connection was dropped at seq 2 and this is never read.
+	if err := writeFrame(conn, EventTypeSessionOpen, 3, good); err != nil {
+		t.Fatalf("write seq 3: %v", err)
+	}
+
+	select {
+	case got := <-dispatched:
+		if got != 3 {
+			t.Fatalf("recovery frame dispatched seq = %d, want 3 (connection must survive "+
+				"the oversized frame — #6132 loop-break)", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovery frame after an oversized session frame was not dispatched: the " +
+			"connection was dropped (the #6132 drop -> reconnect -> replay loop) instead of " +
+			"discarding the oversized frame and advancing past it")
+	}
+
+	// Anti-divergence: the oversized frame forced exactly one resync (rate-limited),
+	// re-baselining the peer from table truth.
+	if !resyncCalled.Load() {
+		t.Fatal("oversized session frame did not trigger onFullResync (#6132)")
+	}
+	if got := es.SessionSyncResyncs.Load(); got != 1 {
+		t.Fatalf("SessionSyncResyncs = %d, want 1", got)
+	}
+	if got := es.DecodeErrors.Load(); got != 1 {
+		t.Fatalf("DecodeErrors = %d, want 1", got)
+	}
+	// Loop-break: the watermark advanced PAST the oversized seq (2). It is at 3
+	// here because the recovery frame was applied; the hard invariant is that it
+	// moved past 2, so the helper's replay buffer trims the oversized frame
+	// (front.seq <= acked) and never re-sends it.
+	if applied := es.lastAppliedSeq.Load(); applied < 2 {
+		t.Fatalf("lastAppliedSeq = %d, want >= 2 — the watermark must advance PAST the "+
+			"oversized frame so the helper trims it and does not re-send it verbatim "+
+			"(the #6132 replay loop)", applied)
+	}
+}
+
+// Test_persistent_oversized_session_frames_do_not_replay_loop_6132 is the
+// persistent-stream variant: a run of oversized session frames (as a
+// version-skewed / buggy encoder would emit) must NOT wedge the stream. The
+// watermark advances past EVERY oversized frame on ONE connection (no reconnect
+// churn), the resync trigger is RATE-LIMITED to a bounded count rather than
+// firing once per frame (which would hammer the shared control socket and flood
+// the log), and the stream recovers on the next decodable frame.
+//
+// Parent-RED map (target-count 1): revert the call site to the pre-#6132 bare
+// `return`. The connection then drops at the FIRST oversized frame (seq 2); seqs
+// 3, 4 and the recovery frame 5 are never read on it, lastAppliedSeq stays at the
+// baseline (1), and the recovery assertion times out — all RED.
+func Test_persistent_oversized_session_frames_do_not_replay_loop_6132(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test-events.sock")
+
+	es := NewEventStream(sockPath)
+	dispatched := make(chan uint64, 8)
+	es.SetOnEvent(func(_ uint8, seq uint64, _ SessionDeltaInfo) bool {
+		dispatched <- seq
+		return true
+	})
+	var resyncs atomic.Int64
+	es.SetOnFullResync(func() bool {
+		resyncs.Add(1)
+		return true
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	es.Start(ctx)
+	defer es.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	waitForConnected(t, es)
+
+	good := buildSessionOpenV4Payload(
+		6, 1000, 80,
+		[4]byte{10, 0, 1, 1}, [4]byte{10, 0, 2, 1},
+		[4]byte{}, [4]byte{},
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		[6]byte{}, [6]byte{}, [4]byte{},
+	)
+	oversized := make([]byte, 2000) // declared length 2000 > 1024, within ceiling
+
+	// seq 1: decodable baseline.
+	if err := writeFrame(conn, EventTypeSessionOpen, 1, good); err != nil {
+		t.Fatalf("write seq 1: %v", err)
+	}
+	if got := <-dispatched; got != 1 {
+		t.Fatalf("baseline dispatched seq = %d, want 1", got)
+	}
+
+	// seqs 2..4: three back-to-back oversized session frames on ONE connection.
+	for seq := uint64(2); seq <= 4; seq++ {
+		if err := writeFrame(conn, EventTypeSessionOpen, seq, oversized); err != nil {
+			t.Fatalf("write oversized seq %d: %v", seq, err)
+		}
+	}
+
+	// seq 5: a decodable frame proving the stream recovered on the SAME connection
+	// (no reconnect).
+	if err := writeFrame(conn, EventTypeSessionOpen, 5, good); err != nil {
+		t.Fatalf("write seq 5: %v", err)
+	}
+	select {
+	case got := <-dispatched:
+		if got != 5 {
+			t.Fatalf("recovery frame dispatched seq = %d, want 5", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not recover after persistent oversized frames: the connection " +
+			"was dropped (the #6132 loop) instead of advancing past each oversized frame")
+	}
+
+	// Loop-break: the watermark advanced past ALL oversized frames to the recovery
+	// frame.
+	if applied := es.lastAppliedSeq.Load(); applied < 4 {
+		t.Fatalf("lastAppliedSeq = %d, want >= 4 — the watermark must advance past every "+
+			"persistently-oversized frame (#6132)", applied)
+	}
+	// All three oversized frames were accounted.
+	if got := es.DecodeErrors.Load(); got != 3 {
+		t.Fatalf("DecodeErrors = %d, want 3", got)
+	}
+	// Bounded, rate-limited resyncs: the three rapid oversized frames fall inside
+	// one decodeFailureResyncInterval, so exactly ONE resync fires and the other
+	// two are suppressed — NOT one resync per frame (the control-socket hammer the
+	// loop would produce).
+	if got := resyncs.Load(); got != 1 {
+		t.Fatalf("onFullResync fired %d times, want 1 — the resync must be rate-limited so a "+
+			"persistently-oversized stream cannot hammer the control socket (#6132)", got)
+	}
+	if got := es.SessionSyncResyncs.Load(); got != 1 {
+		t.Fatalf("SessionSyncResyncs = %d, want 1", got)
+	}
+	if got := es.DecodeResyncSuppressed.Load(); got != 2 {
+		t.Fatalf("DecodeResyncSuppressed = %d, want 2 (the two rate-limited oversized frames)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #6130/#5483. The EventStream reader's payload-length sanity
guard (`length > 1024`; the helper's largest legitimate frame is a
<=256B session event) did a bare `return`, dropping the helper
connection on any oversized declared length. That is the SAME
replay-loop pathology #6130 fixed for the undecodable-decode path, but
on the **framing-desync** path:

- A persistently-oversized / framing-corrupt session frame at seq N
  drops the connection.
- On reconnect the Rust replay buffer re-sends frame N **verbatim** (the
  frame is PRESENT, not a #2874 gap, so `has_gap` never parks a
  re-baselining barrier).
- The guard fires again → drop → reconnect → replay → a deterministic
  storm that hammers the shared control socket and floods the log.

## Fix

`handleOversizedFrame` applies the #6130 analog, reusing the shared
machinery via an extracted `triggerRateLimitedResync` (`onFullResync` +
`decodeFailureResyncInterval` rate-limiter + `SessionSyncResyncs` /
`DecodeResyncSuppressed` accounting), which `handleSessionDecodeFailure`
now also calls:

- **Rate-limited full resync** re-baselines the peer from table truth
  (`ExportOwnerRGSessions`, an unbounded ground-truth snapshot),
  superseding whatever the refused frame carried.
- **Advance the watermark PAST the frame** — the helper writes atomic,
  correctly-length-prefixed frames, so the header stays aligned and this
  frame's `seq` is trustworthy; the cumulative ACK then trims the frame
  and it is never re-sent. This is the loop-break.
- **Re-align the byte stream by trust in the LENGTH**: a length within
  `maxDiscardableOversizedFrameBytes` (64KB) is a trusted frame
  boundary, so discard exactly that many bytes to land on the next
  header and KEEP the connection; a length above the ceiling (or a
  failed drain) is not trusted to re-align the byte stream, so flush the
  advanced ACK and drop the connection to re-establish framing on
  reconnect — bounded, because the frame is trimmed, not replayed into
  another drop.

**Security posture preserved**: the corrupt frame is REFUSED — never
decoded or applied as valid session state — it is superseded by the
table-truth resync, not admitted.

## Tests (fail-on-revert merge gate)

- `Test_oversized_session_frame_recovers_via_resync_not_replay_loop_6132`
- `Test_persistent_oversized_session_frames_do_not_replay_loop_6132`

Both drive oversized session frames and assert the reader recovers on
the SAME connection (advance-past + rate-limited resync) and keeps
consuming subsequent frames rather than looping. Reverting the guard to
the bare `return` makes both go RED as an **assertion failure** (recovery
frame never dispatched; watermark stuck at the baseline), target-count 1
(the single guard call site).

## Validation

- `go test -race ./pkg/dataplane/userspace/...` green, including the
  pre-existing #6130/#5483 tests (confirming the `triggerRateLimitedResync`
  extraction is behaviour-preserving).
- Named tests 3× for flake; `gofmt` + `go vet` clean.
- RED-on-revert verified (assertion failure, not a build break).
- Not HA in the cluster-smoke sense — event-stream reader, unit-provable.

## Docs

`docs/session-sync-architecture.md` gains the #6132 recovery section
alongside the #6130 one, plus the FullResync trigger-list update.

Closes #6132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NunHxT3hLaEUzkqre6XS8K
