### PR TITLE
userspace-dp/io_uring: move deferred writes to a ring-owned in-flight registry (#5800)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54174,3 +54174,38 @@ top.
     section: explicit-arm-path enforcement of the required-protocol gate)
   **Action**: Fold #6162 review MINOR — update afxdp/README.md neighbor-limiter section from "256-slot direct-mapped" + open #6129 caveat to the 64-bucket x 4-way set-associative description with the bounded-residual note (stale-doc module-contract fix)
   **File(s)**: userspace-dp/src/afxdp/README.md
+
+## 2026-07-21 — #5800 io_uring write in-flight registry (UAF fix)
+- **Timestamp**: 2026-07-21
+- **Action**: Close the retry-ceiling/fatal-ring use-after-free in the shared
+  io_uring write loop. `write_all` now takes the packet buffer BY VALUE, tags
+  every submission with a ring-global monotonic `user_data` (fail-closed on
+  wrap), and on retry-exhaustion / fatal-ring returns `WriteResult::Deferred`
+  only AFTER moving the owned buffer into a ring-owned `InflightRegistry` — the
+  buffer is never freed while an SQE may reference it. Deferred buffers are
+  released only on a reaped terminal CQE, a bounded teardown drain (AsyncCancel +
+  observe BOTH the cancel CQE and the target write's terminal CQE), or ring-fd
+  close (RingWriter field order drops the ring before the registry). Migrated
+  BOTH callers (slow-path TUN writes + positioned state-file writes) to
+  `RingWriter` + `WriteResult`. Added fail-on-revert tests driving the FakeRing
+  seam (ceiling EINTR / transient EAGAIN / permanent EBADF defer-not-free,
+  cancellation race, stale-CQE non-misattribution, id-wrap fail-closed, teardown
+  drain, fatal-ring retain). Parent-RED: neutralizing `reg.defer(slot)` →
+  `drop(slot)` turns 9 registry-invariant tests RED as clean assertion failures.
+  Full userspace-dp suite green (4054 lib tests); primary regression 5/5
+  non-flaky. Retry-exhaustion/error branches only — healthy write path unchanged
+  (Done/short-write/EINTR-then-success paths preserved).
+- **File(s)**:
+  - `userspace-dp/src/io_uring_write.rs` (InflightRegistry, RingWriter,
+    WriteResult, ring-global id, teardown drain, reap_matching ReapError)
+  - `userspace-dp/src/io_uring_write_tests.rs` (FakeRing cancel/drain seam +
+    #5800 defer/teardown/id-wrap tests; realistic pending-cancel modelling)
+  - `userspace-dp/src/slowpath.rs` (WriteMode::IoUring(RingWriter),
+    classify_io_uring_write over WriteResult, retire_ring_to_sync simplified)
+  - `userspace-dp/src/slowpath_tests.rs` (classify tests over WriteResult;
+    new non-fatal-deferral-keeps-iouring test)
+  - `userspace-dp/src/state_writer.rs` (WriteMode::IoUring(RingWriter),
+    IoUringPersist enum, persist_with_io_uring by-value + Deferred handling)
+  - `userspace-dp/src/state_writer_tests.rs` (RingWriter construction)
+  - `docs/xdp-io-uring-userspace-dataplane.md` (#5800 registry contract)
+  - `docs/pr/5800-iouring-inflight-registry/plan.md` (plan + deviations)

--- a/docs/pr/5800-iouring-inflight-registry/plan.md
+++ b/docs/pr/5800-iouring-inflight-registry/plan.md
@@ -1,0 +1,117 @@
+# #5800 — io_uring write: ring-owned in-flight registry (UAF fix)
+
+## Goal
+Close the memory-lifetime violation in `userspace-dp/src/io_uring_write.rs`:
+`write_all()` submits a Write SQE that borrows the caller's buffer; on
+`MAX_WAIT_RETRIES` exhaustion (or a fatal ring error) it returns while the SQE
+may still be in flight, and the caller frees the buffer → UAF-class disclosure /
+corruption / crash. Also: `user_data` restarts at `1` every call → a stale CQE
+can alias a later call.
+
+## Required invariants (issue = spec)
+1. Never return while an in-flight SQE references caller-borrowed storage.
+2. Release a buffer owner only after ONE terminal state: matching CQE reaped,
+   cancellation CQE reaped, OR ring teardown/drain proving no kernel refs.
+3. `user_data` unique for the ring lifetime; wrap fail-closed.
+4. Fatal-ring handling retains all in-flight owned buffers until teardown/drain.
+5. The latency ceiling may stop a worker; it may NOT weaken memory lifetime.
+
+## Approach
+Introduce a **ring-owned in-flight registry** that OWNS the packet bytes and
+vends a **ring-global monotonic `user_data`**. `write_all` takes the buffer by
+value (`Vec<u8>`); moving a `Vec` preserves its heap allocation address, so the
+SQE pointer stays valid when the buffer is moved into the registry.
+
+- `InflightRegistry { next_id: u64, inflight: Vec<InFlightWrite> }`.
+  - `alloc_id()` monotonic from 1; returns `None` when the space is exhausted
+    (never wraps back through 0 or reuses a live id) → `write_all` fails closed
+    WITHOUT submitting (invariant 3).
+  - `reap_ready(port)` — non-blocking: pop ready CQEs, RELEASE the matching
+    registry entry (drop its buffer — the kernel is done), discard true stale.
+    Called at the top of every `write_all` and inside `reap_matching`'s reap
+    loop so a deferred op's completion frees its buffer opportunistically.
+  - `drain_for_teardown(port)` — bounded: submit an `AsyncCancel` for every live
+    entry, then reap until BOTH the cancel's CQE AND the target write's terminal
+    CQE are observed before dropping each buffer (cancellation submission alone
+    is insufficient). Ceiling-bounded; un-drained entries are RETAINED (freed
+    only when the registry drops, i.e. AFTER the ring fd closes).
+- `write_all(port, reg, data: Vec<u8>, positioned, label) -> WriteResult`:
+  - `Done(Vec<u8>)` — every byte written + matching CQE reaped; buffer safe.
+  - `NothingWritten(Vec<u8>, msg)` — nothing on the fd (push fail / kernel error
+    / zero byte / id-exhaustion); buffer handed back; sync-retry safe.
+  - `Transferred(Vec<u8>, msg)` — packet-fd partial: reaped (terminal) so buffer
+    safe, but re-send would corrupt → caller drops, never retries.
+  - `Deferred { id, message, fatal_ring }` — NOT terminal (ceiling / fatal ring):
+    buffer MOVED into `reg`; caller must not free/retry.
+- `reap_matching` returns `Result<i32, ReapError{message, fatal_ring}>`;
+  `fatal_ring` = `is_permanent(errno)`.
+- `RingWriter { ring: IoUring, inflight: InflightRegistry }` bundles the
+  persistent ring + registry. **Field order is load-bearing** (invariant 4):
+  `ring` drops first (close fd → kernel cancels+waits in-flight ops), THEN
+  `inflight` drops (frees buffers, no kernel ref can remain). `Drop` also runs a
+  best-effort bounded `drain_for_teardown`.
+
+## Both callers (acceptance: TUN packet writes AND positioned state writes)
+- **Slow path** (`slowpath.rs`): `WriteMode::IoUring(RingWriter)`. `req.bytes`
+  moves into `RingWriter::write`. New status counter `deferred_inflight`; a
+  `Deferred{fatal_ring:true}` demotes to sync (mirrors #2958/#0faef94). A pure
+  `classify_slow_path(&WriteResult) -> SlowPathAction` replaces
+  `decide_sync_fallback` (keeps the #2477 sync-only-when-nothing-written
+  decision unit-testable without a ring).
+- **State writer** (`state_writer.rs`): `WriteMode::IoUring(RingWriter)`.
+  `req.data: Vec<u8>` threads by value; `NothingWritten` hands it back for the
+  sync fallback; `Deferred` demotes to sync and returns an error (NO sync
+  retry — ambiguous). `Done` hands the buffer back so a `finalize_durably`
+  failure can still sync-retry.
+
+## Tests (fail-on-revert; drive the FakeRing seam)
+- ceiling EINTR → entry OWNED in registry post-exhaustion (not freed) until a
+  later reap/teardown releases it (invariant 1/5) — binds the defer branch.
+- repeated transient (EAGAIN) → same.
+- permanent error after submission (EBADF) → Deferred{fatal_ring:true}, retained.
+- cancellation race: drain releases only after BOTH cancel CQE + target CQE.
+- stale CQE not misattributed (retain existing test intent).
+- id-wrap fail-closed: alloc_id at u64::MAX → next None → NothingWritten, no submit.
+- regression: buffer stays owned after exhaustion until terminal completion.
+Each new test binds a specific production line; neutralizing that line (a
+COMPILING neutralization) turns exactly that test RED as an assertion failure.
+
+## Alternatives rejected
+- Copy-on-defer into the registry: WRONG — the SQE points at the caller's
+  allocation, not the copy; the caller still frees the referenced memory.
+- Caller-side retain (tell caller "in flight, don't free"): the issue mandates a
+  ring-owned registry, and it centralises the lifetime proof + teardown drain.
+- Rely on `IoUring` Drop alone for teardown: the kernel's ring-exit cancel+wait
+  may be deferred off the close() path, so Drop order is necessary but the
+  explicit bounded cancel-drain is what PROVES no refs in the common case.
+
+## Docs
+Update `docs/xdp-io-uring-userspace-dataplane.md` (slow-path write section) to
+describe the in-flight registry + ring-global id + teardown drain.
+
+## Implementation notes / deviations from the sketch above
+- Kept the existing `classify_io_uring_write` / `SlowPathWriteOutcome` names
+  (rather than introducing `classify_slow_path` / `SlowPathAction`) — the
+  existing #5172 shape already carries `ring_terminal` + `demotion_cause`, so the
+  four outcomes map onto it cleanly and the existing demotion tests keep binding.
+- **No new `deferred_inflight` WIRE counter.** Adding a field to
+  `protocol::control::SlowPathStatus` is a wire-contract change that forces
+  regenerating the `protocol_wire_v1.json` golden fixture — out of scope for a
+  UAF lifetime fix (engineering-style: narrow scope; wire changes get their own
+  PR). The acceptance criterion "slow-path status distinguishes deferred
+  in-flight ownership / successful completion / cancellation / fatal ring
+  teardown" is met by the internal `SlowPathWriteOutcome` classification plus the
+  operator-visible `last_error` (a `Deferred` now names the parked in-flight id)
+  and the existing drop / write-error counters. A deferred packet is counted as a
+  drop (it did not reliably reach the TUN).
+- State writer: a `Deferred` FAILS the persist (its buffer is parked in the ring,
+  not sync-retried — the buffer is no longer ours and the op may be in flight)
+  and demotes to sync; a `NothingWritten` or a durable-finalize failure hands the
+  buffer back for a synchronous rewrite to a FRESH temp (preserving the #2958
+  fallback for every reaped-terminal outcome). `Transferred` is unreachable for a
+  positioned write and is mapped defensively onto the sync-retry path.
+- FakeRing seam: `push_cancel` queues the cancel's (and, when modelled, the
+  target write's) completion as PENDING, surfaced only on a subsequent SUCCESSFUL
+  `submit_and_wait_one`. This models the kernel (a cancel is reaped only once a
+  wait submits it) and is what lets `fatal_ring_drain_retains_buffer` prove a dead
+  ring cannot reap — its parked buffer is retained until registry drop.

--- a/docs/xdp-io-uring-userspace-dataplane.md
+++ b/docs/xdp-io-uring-userspace-dataplane.md
@@ -438,34 +438,57 @@ This is where io_uring is a real win.
 
 The slow-path reinjector (`src/slowpath.rs`) writes reinjected local/exception
 frames to a TUN device, preferring io_uring and falling back to a synchronous
-`write()`. Its `WriteMode` (`IoUring` | `SyncFallback`) is governed by three
-linked invariants:
+`write()`. The shared io_uring write loop lives in `src/io_uring_write.rs` and is
+also used by the state writer. Its `WriteMode` (`IoUring(RingWriter)` |
+`SyncFallback`) is governed by these linked invariants:
 
+- **Ring-owned in-flight registry + buffer lifetime (#5800, replaces the #2297
+  ceiling hole).** `write_all` takes the packet buffer BY VALUE. Every submitted
+  write is tagged with a ring-global, monotonically increasing `user_data` id
+  (never restarting per call, so a leftover CQE from an earlier call can never
+  alias a later one; the id space is fail-closed on wrap). A write that cannot be
+  proven terminal before the loop must return — the `MAX_WAIT_RETRIES` retry
+  ceiling was hit, or the ring returned a fatal OS error — is `Deferred`: its
+  owned buffer is MOVED into the ring's `InflightRegistry` (moving a `Vec`
+  preserves the heap address the SQE points at) and stays owned there. It is
+  never freed while an SQE may still reference it. A deferred buffer is released
+  only when ONE terminal state is observed: its matching write CQE is reaped
+  (opportunistically at the top of the next write), a teardown drain cancels the
+  op AND observes both the cancel's completion and the target write's terminal
+  CQE, or the ring fd closes (`RingWriter` field order drops the ring — kernel
+  cancel+wait — before the registry frees buffers). The old code returned at the
+  ceiling and let the caller free the buffer with the SQE possibly still in
+  flight (a UAF-class disclosure/corruption); the fix moves ownership instead of
+  weakening lifetime.
 - **Per-call fallback (#2477).** An io_uring failure that put NOTHING on the TUN
-  (`WriteError::NothingWritten`, `safe_to_retry`) is rescued by a synchronous
-  write of the SAME packet — the frame is still deliverable. An
-  ambiguous/partial failure (`WriteError::Transferred`) is DROPPED, never
-  sync-resent: bytes may be in flight, so re-sending would double-transmit
-  (truncated frame + duplicate to local BGP/OSPF listeners).
+  (`WriteResult::NothingWritten`) hands the owned buffer back and is rescued by a
+  synchronous write of the SAME packet — the frame is still deliverable. A
+  reaped packet-fd partial (`WriteResult::Transferred`) is DROPPED, never
+  sync-resent: bytes are already on the device, so re-sending would
+  double-transmit (truncated frame + duplicate to local BGP/OSPF listeners). A
+  `Deferred` write is also dropped (no sync-resend — the buffer is parked and the
+  op may be in flight).
 - **Runtime demotion (#5172, mirrors state_writer #2958).** A structured
-  per-write outcome separates packet-transfer certainty from RING HEALTH. On a
-  TERMINAL ring failure — an ambiguous submit/reap, i.e. the ring is wedged (a
-  partial write cannot occur on an atomic TUN write, so `Transferred` here means
-  the transport, not the packet) — the worker retires the ring ONCE: it drops
-  the `IoUring` (closing its fd, which the kernel uses to cancel outstanding
-  SQEs) and flips `WriteMode` to `SyncFallback` plus reports `mode = "sync"`.
-  Every later packet then takes the sync branch directly instead of retrying the
-  broken ring (which otherwise degrades BGP/OSPF/mgmt/local traffic). The
-  demotion is PERMANENT (no cooldown re-promotion — avoids flapping).
-- **Transient does NOT demote.** A `safe_to_retry` failure the sync fallback
-  rescued keeps io_uring live — a momentary blip must not abandon the ring.
-- **Buffer lifetime (#2297).** The current packet's buffer outlives the ring
-  drop (the worker loop owns it until after the demotion applies), so no kernel
-  reference can dangle across the retirement.
+  per-write outcome separates packet-transfer certainty from RING HEALTH. A
+  `Deferred { fatal_ring: true }` — the ring fd itself is dead — retires the ring
+  ONCE: dropping the `RingWriter` runs a bounded teardown drain and closes the
+  ring fd (which frees any parked buffer safely), then `WriteMode` flips to
+  `SyncFallback` and reports `mode = "sync"`. Every later packet then takes the
+  sync branch directly instead of retrying the broken ring (which otherwise
+  degrades BGP/OSPF/mgmt/local traffic). The demotion is PERMANENT (no cooldown
+  re-promotion — avoids flapping).
+- **Transient does NOT demote.** A `NothingWritten` the sync fallback rescued, or
+  a bare retry-ceiling `Deferred { fatal_ring: false }` (an EINTR storm), keeps
+  io_uring live — a momentary blip must not abandon the ring; the parked buffer
+  is reclaimed on a later write's opportunistic reap.
 
 Unlike `state_writer`, the slow path's `active` flag tracks TUN/worker liveness,
 not io_uring, so a demotion flips `mode` but leaves `active` set — the path is
-still up, just in sync mode.
+still up, just in sync mode. The state writer applies the SAME registry contract
+for its positioned temp-file writes: a `Deferred` write fails the persist (its
+buffer is parked, not sync-retried) and demotes to sync; a `NothingWritten` or a
+durable-finalize failure hands the buffer back for a synchronous rewrite to a
+fresh temp.
 
 Important:
 

--- a/userspace-dp/src/io_uring_write.rs
+++ b/userspace-dp/src/io_uring_write.rs
@@ -19,46 +19,55 @@
 //!       punted write is still in flight, the kernel reads freed userspace
 //!       memory.
 //!
-//! The fix here keeps the SQE-in-flight invariant the callers always assumed:
-//! under normal operation the function does not return until every SQE it
-//! submitted has been reaped. The sole escape hatch is a hard retry ceiling
-//! (`MAX_WAIT_RETRIES`) that converts a pathological never-ending EINTR storm
-//! into an `Err` so a worker cannot wedge forever; reaching it requires
-//! thousands of consecutive interrupted/failed waits with the CQE still
-//! unreaped, which is astronomically improbable. See the per-`Err` notes on
-//! [`reap_matching`] for what each ceiling return implies for the buffer.
+//! ## #5800 — in-flight registry closes the retry-ceiling UAF
 //!
-//!   * `EINTR` (and any wait error) RETRIES the wait instead of returning. The
-//!     `io-uring` crate's `submit_and_wait` derives `to_submit` from the
-//!     current SQ length, so once the SQE has been consumed by the kernel the
-//!     retry degrades to a wait-only `io_uring_enter(0, 1, GETEVENTS)` — it
-//!     does not double-submit.
-//!   * Each submission carries a distinct, monotonically increasing
-//!     `user_data`. The reap loop matches the CQE by `user_data`; a stale CQE
-//!     left over from a prior interrupted submission can no longer be
-//!     mis-attributed to this write — it is recognised and skipped.
-//!   * Because the function only returns after the matching CQE is reaped, the
-//!     caller's buffer provably outlives every kernel reference to it, closing
-//!     the UAF window.
+//! The #2297 fix kept the SQE-in-flight invariant under normal operation, but
+//! left one hole: the hard retry ceiling (`MAX_WAIT_RETRIES`) returned `Err`
+//! WITHOUT proving the matching CQE was reaped or the SQE cancelled, and the
+//! caller then freed the buffer while the kernel might still dereference it (a
+//! UAF-class disclosure/corruption/crash under sustained signal/error pressure).
+//! The tag also restarted at `1` every call, so an abandoned completion could
+//! alias a later call's CQE.
 //!
-//! Error classification (two further defects, fixed together):
+//! The fix moves ownership instead of weakening lifetime. A ring-owned
+//! [`InflightRegistry`] OWNS the packet bytes and vends a ring-global
+//! monotonically increasing `user_data`. [`write_all`] takes the buffer BY
+//! VALUE; because moving a `Vec` preserves its heap allocation address, the SQE
+//! pointer stays valid when the buffer is moved into the registry. On retry
+//! exhaustion (or a fatal ring error) `write_all` returns
+//! [`WriteResult::Deferred`] only AFTER the buffer has moved into the registry —
+//! it is never freed while an SQE may reference it (invariant 1/5). Deferred
+//! buffers are released only when ONE terminal state is observed:
 //!
-//!   * #2477 — retry safety. On failure [`write_all`] returns a [`WriteError`]
-//!     that tells the caller whether a synchronous retry from offset 0 is safe.
-//!     `NothingWritten` (submit-queue full, a kernel completion error, a
-//!     zero-byte completion) put nothing on the fd → safe to sync-retry.
-//!     `Transferred` (a packet-fd partial write, or an ambiguous submit/wait
-//!     error where the SQE may be in flight) means bytes are — or may be —
-//!     already on the device → the caller MUST drop, never re-send. The TUN slow
-//!     path uses this so its io_uring→sync fallback cannot double-transmit a
-//!     packet; the state writer (a true byte stream, no sync fallback) ignores
-//!     it.
-//!   * #2478 — permanent-error fast-fail. [`reap_matching`] no longer
-//!     re-spins the submit/wait on a PERMANENT OS error (a bad/closed ring fd,
-//!     EINVAL, EFAULT, …) — those return the same error forever and would burn a
-//!     full core through the `MAX_WAIT_RETRIES` ceiling. [`is_permanent`]
-//!     classifies the errno; permanent errors return immediately, transient ones
-//!     (EINTR/EAGAIN) retry after a `yield_now`.
+//!   * the matching write CQE is reaped ([`InflightRegistry::reap_ready`], run
+//!     opportunistically at the top of every write and inside the reap loop), or
+//!   * the ring is torn down and drained ([`InflightRegistry::drain_for_teardown`]
+//!     submits an `AsyncCancel` per live entry and observes BOTH the cancel CQE
+//!     AND the target write's terminal CQE before freeing — cancellation
+//!     SUBMISSION alone is insufficient), or
+//!   * the ring fd is closed: [`RingWriter`]'s field order drops the ring BEFORE
+//!     the registry, so the kernel's ring-exit cancel+wait completes before any
+//!     buffer is freed (invariant 2/4).
+//!
+//! Ring-global ids (never restarting per call, [`InflightRegistry::alloc_id`])
+//! close the stale-CQE aliasing hole; the id space is fail-closed on wrap
+//! (invariant 3) — `alloc_id` returns `None` at exhaustion and `write_all`
+//! refuses to submit rather than reuse a possibly-live id.
+//!
+//! Error classification (two further defects, retained from #2477/#2478):
+//!
+//!   * #2477 — retry safety. On failure [`write_all`] reports whether a
+//!     synchronous retry from offset 0 is safe. [`WriteResult::NothingWritten`]
+//!     (submit-queue full, a kernel completion error, a zero-byte completion,
+//!     id-space exhaustion) put nothing on the fd → safe to sync-retry, and the
+//!     owned buffer is handed back so the caller can retry without re-allocating.
+//!     [`WriteResult::Transferred`] (a packet-fd partial write) means bytes are
+//!     already on the device → the caller MUST drop, never re-send.
+//!   * #2478 — permanent-error fast-fail. [`reap_matching`] does not re-spin the
+//!     submit/wait on a PERMANENT OS error (a bad/closed ring fd, EINVAL,
+//!     EFAULT, …); [`is_permanent`] classifies the errno. A permanent error is
+//!     reported as [`WriteResult::Deferred`] with `fatal_ring = true` (the buffer
+//!     is retained pending teardown), transient ones retry after a `yield_now`.
 
 use io_uring::{IoUring, opcode, types};
 use std::io;
@@ -73,7 +82,7 @@ pub(crate) struct Completion {
 
 /// Abstraction over the ring operations the write loop needs. Implemented for
 /// real `io_uring::IoUring` (see `IoUringPort`) and by test fakes so the
-/// retry/drain logic is exercisable without a live io_uring.
+/// retry/drain/cancel logic is exercisable without a live io_uring.
 pub(crate) trait RingPort {
     /// Push a `Write` SQE for `buf` at file `offset`, tagged with `user_data`.
     /// `offset` is `None` for stream writes (TUN) and `Some(n)` for positioned
@@ -85,6 +94,12 @@ pub(crate) trait RingPort {
         offset: Option<u64>,
     ) -> Result<(), String>;
 
+    /// Push an `AsyncCancel` SQE (tagged `user_data`) targeting the in-flight
+    /// write whose `user_data == target`. Used only by teardown drain: it nudges
+    /// the kernel to complete a still-outstanding write so its terminal CQE
+    /// surfaces and its buffer can be released.
+    fn push_cancel(&mut self, user_data: u64, target: u64) -> Result<(), String>;
+
     /// Submit any queued SQEs and wait for at least one completion. Mirrors
     /// `io_uring::IoUring::submit_and_wait(1)`: it may return
     /// `ErrorKind::Interrupted` (EINTR) with the SQE already in flight.
@@ -95,54 +110,208 @@ pub(crate) trait RingPort {
     fn next_completion(&mut self) -> Option<Completion>;
 }
 
-/// Result of [`write_all`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum WriteOutcome {
-    /// All `data.len()` bytes were written.
-    Done,
+/// Result of [`write_all`] / [`RingWriter::write`]. Every variant except
+/// [`WriteResult::Deferred`] is TERMINAL for the buffer — the kernel holds no
+/// further reference, so the owned `Vec<u8>` is handed back for the caller to
+/// reuse or drop. `Deferred` means the op did NOT reach a terminal state: the
+/// buffer has been moved into the ring's [`InflightRegistry`] and stays owned
+/// there until a later reap or a teardown drain releases it.
+#[derive(Debug)]
+pub(crate) enum WriteResult {
+    /// Every `data.len()` byte was written AND the matching CQE was reaped. The
+    /// buffer is safe to drop or reuse.
+    Done(Vec<u8>),
+    /// Nothing reached the fd (submit-queue full, a kernel completion error, a
+    /// zero-byte completion, or id-space exhaustion). A synchronous retry from
+    /// offset 0 is safe; the buffer is handed back so the caller need not
+    /// re-allocate.
+    NothingWritten(Vec<u8>, String),
+    /// Bytes ARE (or may be) on the device: a packet-fd short write placed
+    /// `0 < n < len` bytes on the TUN as a truncated frame. The CQE was reaped
+    /// so the buffer is terminal and handed back, but re-sending the whole
+    /// packet would duplicate it — the caller MUST drop, never sync-retry.
+    Transferred(Vec<u8>, String),
+    /// The op did NOT reach a terminal state (retry-budget exhaustion or a fatal
+    /// ring error). The buffer has been MOVED into the ring's registry (keyed by
+    /// `id`) and stays owned there until its terminal CQE is reaped or the ring
+    /// is torn down and drained. `fatal_ring` = the ring fd itself is dead → the
+    /// caller should tear the ring down. The caller must NOT free the buffer and
+    /// must NOT synchronously retry (the write may be in flight).
+    Deferred {
+        id: u64,
+        message: String,
+        fatal_ring: bool,
+    },
 }
 
-/// Failure of [`write_all`] / [`write_all_to_fd`], carrying enough state for the
-/// caller to decide whether a synchronous retry is safe.
+/// A submitted write whose owned buffer the kernel may still reference. Held by
+/// the ring-owned [`InflightRegistry`] from the moment a write is deferred until
+/// its op reaches a terminal state. Moving this value (e.g. into the registry's
+/// `Vec`) moves only the `Vec<u8>` handle — the heap bytes the SQE points at do
+/// NOT move — so the kernel's pointer stays valid across the move.
+struct InFlightWrite {
+    id: u64,
+    bytes: Vec<u8>,
+}
+
+/// Ring-owned registry of writes whose buffers must outlive every kernel
+/// reference to them, plus the vendor of the ring-global `user_data` id.
 ///
-/// The distinction matters for a packet-oriented fd (the TUN slow path, #2477):
-/// a synchronous fallback must NEVER re-send a packet whose bytes the io_uring
-/// path already placed on the device, or the TUN sees a truncated frame followed
-/// by a duplicate full frame.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum WriteError {
-    /// Nothing was transferred — the io_uring path failed before (or while)
-    /// putting any bytes on the fd (submit-queue full, the kernel completion
-    /// reported an error, or a zero-byte completion). A synchronous retry from
-    /// offset 0 is safe: no bytes are on the device yet.
-    NothingWritten(String),
-    /// Bytes were (or may have been) transferred and a retry would corrupt the
-    /// stream. Two cases:
-    ///   * a packet-fd short write — `0 < n < len` bytes are already on the TUN
-    ///     as a truncated frame; re-sending the whole packet would duplicate it;
-    ///   * an ambiguous submit/wait error after the SQE was submitted — the
-    ///     write may be in flight, so a retry could double-transmit.
-    /// The caller MUST drop the packet, never fall back to a synchronous write.
-    Transferred(String),
+/// Buffers are moved in ([`Self::defer`]) only when [`write_all`] must return
+/// before its op reached a terminal state. They are released — the owned buffer
+/// dropped — only when ONE terminal state is observed: the matching write CQE is
+/// reaped ([`Self::reap_ready`]) or a teardown drain proves no kernel reference
+/// remains ([`Self::drain_for_teardown`], or the ring fd closing before the
+/// registry drops).
+pub(crate) struct InflightRegistry {
+    /// Next `user_data` to hand out. Monotonic from 1; 0 is the stale/uninit
+    /// sentinel and is never a valid id. Fail-closed on wrap (invariant 3).
+    next_id: u64,
+    /// Owned buffers for writes still considered in flight.
+    inflight: Vec<InFlightWrite>,
 }
 
-impl WriteError {
-    /// True when a synchronous retry from offset 0 is safe (nothing is on the
-    /// fd yet). Only [`WriteError::NothingWritten`] qualifies.
-    pub(crate) fn safe_to_retry(&self) -> bool {
-        matches!(self, WriteError::NothingWritten(_))
-    }
+/// Bound on wait retries so a pathological always-EINTR storm cannot wedge a
+/// worker forever. EINTR under normal signal pressure resolves in one or two
+/// retries; this ceiling is generous.
+const MAX_WAIT_RETRIES: u32 = 4096;
 
-    pub(crate) fn message(&self) -> &str {
-        match self {
-            WriteError::NothingWritten(m) | WriteError::Transferred(m) => m,
+impl InflightRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            next_id: 1,
+            inflight: Vec::new(),
         }
     }
-}
 
-impl std::fmt::Display for WriteError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.message())
+    /// Hand out the next ring-global `user_data`. Returns `None` when the id
+    /// space is exhausted (would wrap back through 0) — the caller then fails
+    /// closed and does NOT submit, so a possibly-live id is never reused
+    /// (invariant 3). At ~1e9 ids/s this takes ~584 years to reach.
+    fn alloc_id(&mut self) -> Option<u64> {
+        if self.next_id == 0 {
+            // Wrapped past u64::MAX on a prior call — space exhausted.
+            return None;
+        }
+        let id = self.next_id;
+        // Advances to 0 after handing out u64::MAX; the next call fails closed.
+        self.next_id = self.next_id.wrapping_add(1);
+        Some(id)
+    }
+
+    /// Move an owned buffer into the registry (it stays owned until a terminal
+    /// state releases it). Called only on the deferral path.
+    fn defer(&mut self, slot: InFlightWrite) {
+        self.inflight.push(slot);
+    }
+
+    /// Number of buffers still owned (in flight) — a test observability hook for
+    /// asserting the deferral/teardown invariants without a live io_uring.
+    #[cfg(test)]
+    pub(crate) fn inflight_len(&self) -> usize {
+        self.inflight.len()
+    }
+
+    /// Release the registry entry whose write id == `user_data`, dropping its
+    /// owned buffer (the kernel is done with it). Returns true if an entry was
+    /// released. A `user_data` matching no live entry is a true stale/leftover
+    /// (or a cancel CQE) and is not our concern here.
+    fn release_matching(&mut self, user_data: u64) -> bool {
+        if let Some(pos) = self.inflight.iter().position(|e| e.id == user_data) {
+            // swap_remove drops the InFlightWrite -> frees its buffer.
+            self.inflight.swap_remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Non-blocking: reap every completion currently ready, releasing the owned
+    /// buffer of any deferred entry whose terminal CQE has surfaced and
+    /// discarding true stale completions. Bounds registry growth after a
+    /// transient storm and doubles as the pre-submit stale drain: called at the
+    /// top of [`write_all`] and again inside [`reap_matching`] right after a new
+    /// SQE is pushed (before the wait), where no CQE for the current id can yet
+    /// exist so nothing of ours is consumed.
+    fn reap_ready(&mut self, port: &mut dyn RingPort) {
+        while let Some(cqe) = port.next_completion() {
+            self.release_matching(cqe.user_data);
+        }
+    }
+
+    /// Teardown drain (bounded). For every still-live entry, submit an
+    /// `AsyncCancel` targeting its write id, then reap until BOTH the cancel's
+    /// completion AND the target write's terminal CQE are observed — proving the
+    /// kernel holds no further reference — before dropping the buffer. Releasing
+    /// a buffer hinges on the TARGET WRITE's terminal CQE (cancellation
+    /// SUBMISSION or even its own completion is insufficient). Bounded by
+    /// `MAX_WAIT_RETRIES`; if the ceiling is hit, or the ring is fatally dead,
+    /// the still-live entries are RETAINED (never freed early) — their buffers
+    /// are freed only when the registry itself drops, which for [`RingWriter`]
+    /// happens AFTER the ring fd is closed (invariant 4).
+    ///
+    /// Returns the number of entries released by this drain (for tests).
+    fn drain_for_teardown(&mut self, port: &mut dyn RingPort) -> usize {
+        let start = self.inflight.len();
+        if start == 0 {
+            return 0;
+        }
+
+        // Snapshot the live write ids and submit one cancel per entry. Record
+        // the cancel ids so their completions are recognised (and observed)
+        // rather than mistaken for stale. The write ids are monotonic and never
+        // reused, so a cancel can never target a reused id.
+        let targets: Vec<u64> = self.inflight.iter().map(|e| e.id).collect();
+        let mut pending_cancels: Vec<u64> = Vec::with_capacity(targets.len());
+        for target in targets {
+            match self.alloc_id() {
+                Some(cancel_id) => {
+                    if port.push_cancel(cancel_id, target).is_ok() {
+                        pending_cancels.push(cancel_id);
+                    }
+                }
+                // Id space exhausted: cannot cancel. Fall through to a best-
+                // effort reap of any already-ready terminal CQEs.
+                None => break,
+            }
+        }
+
+        let mut waits = 0u32;
+        while !self.inflight.is_empty() {
+            // Reap everything ready: a write id releases its buffer; a cancel id
+            // is marked observed; anything else is stale and discarded.
+            while let Some(cqe) = port.next_completion() {
+                if !self.release_matching(cqe.user_data) {
+                    if let Some(pos) =
+                        pending_cancels.iter().position(|c| *c == cqe.user_data)
+                    {
+                        pending_cancels.swap_remove(pos);
+                    }
+                }
+            }
+            if self.inflight.is_empty() {
+                break;
+            }
+            match port.submit_and_wait_one() {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                Err(err) => {
+                    if is_permanent(&err) {
+                        // The ring fd is dead: no further CQE can surface. Retain
+                        // the remaining entries; they free when the registry
+                        // drops (after the ring fd closes), which is when the
+                        // kernel can no longer reference them.
+                        break;
+                    }
+                    std::thread::yield_now();
+                }
+            }
+            waits += 1;
+            if waits >= MAX_WAIT_RETRIES {
+                break;
+            }
+        }
+        start - self.inflight.len()
     }
 }
 
@@ -164,14 +333,27 @@ impl RingPort for IoUringPort<'_> {
             entry = entry.offset(off);
         }
         let entry = entry.build().user_data(user_data);
-        // SAFETY: `buf` outlives the completion. `write_all` does not return
-        // until the matching CQE is reaped (the #2297 invariant), so the kernel
-        // holds no dangling reference once we return to the caller.
+        // SAFETY: `buf` (owned by the caller's `InFlightWrite`) outlives the
+        // completion. `write_all` either reaps the matching CQE before returning
+        // OR moves the owning buffer into the ring's registry (#5800), so the
+        // kernel never holds a dangling reference once we return to the caller.
         unsafe {
             self.ring
                 .submission()
                 .push(&entry)
                 .map_err(|_| "io_uring submit queue full".to_string())
+        }
+    }
+
+    fn push_cancel(&mut self, user_data: u64, target: u64) -> Result<(), String> {
+        let entry = opcode::AsyncCancel::new(target).build().user_data(user_data);
+        // SAFETY: AsyncCancel references only a `user_data` value, not user
+        // memory, so there is no buffer-lifetime obligation for this SQE.
+        unsafe {
+            self.ring
+                .submission()
+                .push(&entry)
+                .map_err(|_| "io_uring submit queue full (cancel)".to_string())
         }
     }
 
@@ -187,121 +369,197 @@ impl RingPort for IoUringPort<'_> {
     }
 }
 
-/// Write all of `data` to `fd` through `ring`, with the #2297 EINTR-retry /
-/// stale-CQE-drain / buffer-lifetime guarantees. `positioned` selects a
-/// file-offset write (regular file) vs. a stream write (TUN device).
+/// A persistent io_uring plus its in-flight owned-buffer registry (#5800). Both
+/// slow-path callers own one of these across their lifetime.
 ///
-/// Returns once every byte is written AND every SQE this call submitted has
-/// been reaped, so `data` may be dropped safely on return.
-///
-/// On failure the [`WriteError`] reports whether a synchronous retry is safe —
-/// see [`WriteError::safe_to_retry`] / #2477. The state writer ignores this
-/// (it has no sync fallback); the TUN slow path uses it to avoid double-sending
-/// a packet whose bytes are already on the device.
-pub(crate) fn write_all_to_fd(
-    ring: &mut IoUring,
-    fd: i32,
-    data: &[u8],
-    positioned: bool,
-    label: &str,
-) -> Result<(), WriteError> {
-    let mut port = IoUringPort { ring, fd };
-    write_all(&mut port, data, positioned, label).map(|_| ())
+/// **Field order is load-bearing (invariant 4).** `ring` (field 0) drops BEFORE
+/// `inflight` (field 1). Dropping `ring` closes the io_uring fd, which makes the
+/// kernel cancel and wait for every in-flight op; only THEN does `inflight` drop
+/// and free the buffers, by which point no kernel reference can remain. Do not
+/// reorder these fields.
+pub(crate) struct RingWriter {
+    ring: IoUring,
+    inflight: InflightRegistry,
+}
+
+impl RingWriter {
+    /// Create a ring with `entries` submission slots plus its registry.
+    pub(crate) fn new(entries: u32) -> io::Result<Self> {
+        Ok(Self {
+            ring: IoUring::new(entries)?,
+            inflight: InflightRegistry::new(),
+        })
+    }
+
+    /// Write all of `data` to `fd`. `positioned` selects a file-offset write
+    /// (regular file / state writer) vs. a stream write (TUN device). See
+    /// [`WriteResult`] for the buffer-ownership contract of each variant.
+    pub(crate) fn write(
+        &mut self,
+        fd: i32,
+        data: Vec<u8>,
+        positioned: bool,
+        label: &str,
+    ) -> WriteResult {
+        let mut port = IoUringPort {
+            ring: &mut self.ring,
+            fd,
+        };
+        write_all(&mut port, &mut self.inflight, data, positioned, label)
+    }
+}
+
+impl Drop for RingWriter {
+    fn drop(&mut self) {
+        // Best-effort bounded drain: submit cancels and observe the target
+        // writes' terminal CQEs so buffers are freed cleanly. Even if the drain
+        // hits its ceiling (or the ring is fatally dead), correctness holds: the
+        // ring fd closes when `self.ring` drops immediately after this returns,
+        // which makes the kernel cancel+wait every in-flight op, and only THEN
+        // does `self.inflight` drop and free any straggler buffers. Disjoint
+        // field borrows let the drain hold `&mut ring` and `&mut inflight` at
+        // once without moving out of `self`.
+        let ring = &mut self.ring;
+        let inflight = &mut self.inflight;
+        let mut port = IoUringPort { ring, fd: -1 };
+        inflight.drain_for_teardown(&mut port);
+    }
+}
+
+/// Terminal error from [`reap_matching`]: the op did not reach a reaped terminal
+/// state within the retry ceiling, or the ring returned a fatal error.
+struct ReapError {
+    message: String,
+    /// The ring fd itself is dead (a permanent OS error) — the caller should
+    /// tear it down. `false` = a transient/interrupt storm hit the ceiling; the
+    /// ring is otherwise healthy.
+    fatal_ring: bool,
 }
 
 /// Drive `port` to write all of `data`, advancing `offset` only by bytes a
 /// completion that MATCHES our own submission reports. `positioned` selects a
 /// file-offset write (state writer) vs. a stream write (TUN slow path).
 ///
-/// Invariants this upholds (the #2297 fix):
-///   * does not return while an SQE we submitted is still in flight — on any
-///     submit/wait error we keep waiting until the matching CQE is reaped. The
-///     one exception is the `MAX_WAIT_RETRIES` ceiling in [`reap_matching`],
-///     which returns `Err` after thousands of consecutive interrupted/failed
-///     waits to avoid wedging a worker forever; in that (astronomically rare)
-///     case the SQE may still be outstanding when the buffer is dropped — the
-///     same residual UAF window the pre-#2297 code always had, now bounded to a
-///     storm that should never occur in practice rather than every EINTR;
-///   * advances `offset` only by a CQE whose `user_data` matches the current
-///     submission, so a stale leftover CQE cannot corrupt the offset;
-///   * the caller's `data` buffer therefore outlives every kernel reference
-///     except in the bounded ceiling case above.
+/// The owned `data` buffer is parked in a local [`InFlightWrite`] so the SQE
+/// references the exact allocation that can be moved — intact — into `reg` if
+/// the op cannot be proven terminal before we must return (#5800). No return
+/// path frees a buffer while an SQE may reference it: a reaped terminal state
+/// hands the buffer back; a non-terminal state moves it into `reg`.
 pub(crate) fn write_all(
     port: &mut dyn RingPort,
-    data: &[u8],
+    reg: &mut InflightRegistry,
+    data: Vec<u8>,
     positioned: bool,
     label: &str,
-) -> Result<WriteOutcome, WriteError> {
+) -> WriteResult {
+    // Reclaim any previously-deferred buffers whose terminal CQE has surfaced.
+    reg.reap_ready(port);
+
     let mut offset = 0usize;
-    // Distinct tag per submission. Start at 1 so a zero `user_data` (the value
-    // an uninitialised / pre-existing CQE would carry) is never a valid match.
-    let mut tag: u64 = 1;
+    // Park the owned buffer so the SQE points at the exact allocation we can
+    // move into `reg` on deferral. A `Vec` move preserves the heap address, so
+    // the SQE pointer stays valid across `reg.defer(slot)`.
+    let mut slot = InFlightWrite {
+        id: 0,
+        bytes: data,
+    };
 
-    while offset < data.len() {
-        let chunk = &data[offset..];
+    while offset < slot.bytes.len() {
+        let id = match reg.alloc_id() {
+            Some(id) => id,
+            None => {
+                // Id space exhausted (invariant 3): fail closed. Nothing was
+                // submitted for this chunk, so nothing is on the fd — safe to
+                // sync-retry, and we hand the buffer back.
+                return WriteResult::NothingWritten(
+                    slot.bytes,
+                    format!("{label} io_uring user_data space exhausted"),
+                );
+            }
+        };
+        slot.id = id;
         let file_offset = if positioned { Some(offset as u64) } else { None };
+
         // A push failure means the SQE was never submitted — nothing is on the
-        // fd, so a synchronous retry from offset 0 is safe (#2477). For a packet
-        // fd this is always the first (only) chunk, so `offset == 0` and a
-        // retry-from-0 is sound.
-        port.push_write(tag, chunk, file_offset)
-            .map_err(WriteError::NothingWritten)?;
+        // fd, so a synchronous retry from offset 0 is safe (#2477).
+        if let Err(e) = port.push_write(id, &slot.bytes[offset..], file_offset) {
+            return WriteResult::NothingWritten(slot.bytes, e);
+        }
 
-        // Submit + reap exactly the completion for THIS submission. The
-        // closure below loops on the wait so an EINTR (or any wait error) does
-        // not leave the SQE outstanding. A reap error is AMBIGUOUS: the SQE was
-        // already submitted, so the write may be in flight and a retry could
-        // double-transmit on a packet fd — classify it as `Transferred` (drop,
-        // never sync-retry).
-        let res = reap_matching(port, tag, label).map_err(WriteError::Transferred)?;
-
-        if res < 0 {
-            // The kernel completion reported a write error: nothing was placed
-            // on the fd, so a synchronous retry from offset 0 is safe.
-            return Err(WriteError::NothingWritten(format!(
-                "{label} io_uring write failed: {}",
-                io::Error::from_raw_os_error(-res)
-            )));
-        }
-        if res == 0 {
-            // Zero bytes transferred — safe to retry synchronously.
-            return Err(WriteError::NothingWritten(format!(
-                "{label} io_uring short write: 0"
-            )));
-        }
-        let n = res as usize;
-        // A non-positioned (stream-mode) write targets a packet-oriented fd:
-        // the TUN slow path (#2407). One submission is one L3 packet. A short
-        // CQE count must NOT resubmit the remainder — re-writing `data[n..]`
-        // would inject the leftover bytes as a SECOND, malformed packet. Treat
-        // a partial as an unsendable packet and drop it (Err) — and because
-        // `0 < n < len` bytes are ALREADY on the TUN, classify it as
-        // `Transferred` so the caller does NOT fall back to a synchronous write
-        // (which would re-send the whole packet → truncated frame + duplicate,
-        // #2477). Positioned writes (a regular file — the state writer) are a
-        // true byte stream and DO resume from `offset + n`.
-        if !positioned && n < data.len() {
-            return Err(WriteError::Transferred(format!(
-                "{label} io_uring short write on packet fd: wrote {n} of {} bytes (packet dropped)",
-                data.len()
-            )));
-        }
-        offset += n;
-        // Advance the tag so the next submission's CQE cannot be confused with
-        // this one's (and a leftover CQE from this one cannot be reused).
-        tag = tag.wrapping_add(1);
-        if tag == 0 {
-            tag = 1;
+        match reap_matching(port, reg, id, label) {
+            Ok(res) => {
+                if res < 0 {
+                    // The kernel completion reported a write error: nothing was
+                    // placed on the fd, so a synchronous retry from 0 is safe.
+                    return WriteResult::NothingWritten(
+                        slot.bytes,
+                        format!(
+                            "{label} io_uring write failed: {}",
+                            io::Error::from_raw_os_error(-res)
+                        ),
+                    );
+                }
+                if res == 0 {
+                    // Zero bytes transferred — safe to retry synchronously.
+                    return WriteResult::NothingWritten(
+                        slot.bytes,
+                        format!("{label} io_uring short write: 0"),
+                    );
+                }
+                let n = res as usize;
+                // A non-positioned (stream-mode) write targets a packet-oriented
+                // fd: the TUN slow path (#2407). One submission is one L3 packet;
+                // a short count must NOT resubmit the remainder (that would inject
+                // `data[n..]` as a SECOND malformed packet). Drop it. Because
+                // `0 < n < len` bytes are ALREADY on the TUN, classify as
+                // `Transferred` (the caller must not sync-retry — that would
+                // re-send the whole packet, #2477). The CQE was reaped, so the
+                // buffer is terminal and handed back. Positioned writes (a
+                // regular file) are a true byte stream and DO resume from
+                // `offset + n`.
+                if !positioned && n < slot.bytes.len() {
+                    let total = slot.bytes.len();
+                    return WriteResult::Transferred(
+                        slot.bytes,
+                        format!(
+                            "{label} io_uring short write on packet fd: wrote {n} of {total} bytes (packet dropped)"
+                        ),
+                    );
+                }
+                offset += n;
+                // Loop for the next chunk (positioned resume). The next chunk
+                // gets a fresh ring-global id, so a leftover CQE from this chunk
+                // cannot be reused.
+            }
+            Err(ReapError {
+                message,
+                fatal_ring,
+            }) => {
+                // The op did NOT reach a reaped terminal state: the SQE may still
+                // be in flight referencing `slot.bytes`. Move the buffer into the
+                // ring's registry so it stays owned until its CQE is reaped or the
+                // ring is torn down and drained. NEVER free it here (invariant
+                // 1/4/5).
+                let id = slot.id;
+                reg.defer(slot);
+                return WriteResult::Deferred {
+                    id,
+                    message,
+                    fatal_ring,
+                };
+            }
         }
     }
-    Ok(WriteOutcome::Done)
+    // All bytes written and reaped: the buffer is terminal, handed back.
+    WriteResult::Done(slot.bytes)
 }
 
 /// True when `err` is a PERMANENT OS failure that a retry cannot recover from
 /// (a bad/closed ring fd, an invalid argument, a faulting buffer). Retrying
 /// these would just re-spin at 100% CPU through the `MAX_WAIT_RETRIES` ceiling
-/// (#2478), so [`reap_matching`] returns immediately on them. EINTR/EAGAIN (and
-/// any unrecognised errno) are treated as TRANSIENT and retried.
+/// (#2478), so [`reap_matching`] returns immediately on them and marks the ring
+/// fatal. EINTR/EAGAIN (and any unrecognised errno) are treated as TRANSIENT and
+/// retried.
 fn is_permanent(err: &io::Error) -> bool {
     match err.raw_os_error() {
         Some(e) => matches!(
@@ -322,64 +580,72 @@ fn is_permanent(err: &io::Error) -> bool {
 }
 
 /// Submit the queued SQE and reap the completion whose `user_data == want`,
-/// retrying the wait on `EINTR`/error so the in-flight SQE is never abandoned.
-/// Stale completions (a different `user_data`, e.g. a leftover from a prior
-/// interrupted call) are drained and discarded rather than mis-attributed.
+/// retrying the wait on `EINTR`/transient error so the in-flight SQE is never
+/// abandoned. A completion whose `user_data` matches a DEFERRED registry entry
+/// releases that entry's buffer; anything else non-matching is a true stale
+/// leftover and is discarded — neither is ever mis-attributed to `want`.
 ///
 /// A PERMANENT submit/wait error (bad ring fd, EINVAL, EFAULT, …) returns
-/// immediately instead of re-spinning through `MAX_WAIT_RETRIES` at 100% CPU
-/// (#2478); a TRANSIENT error yields the core before retrying.
-fn reap_matching(port: &mut dyn RingPort, want: u64, label: &str) -> Result<i32, String> {
-    // First, drain any already-ready stale completions so a leftover CQE from a
-    // previously interrupted submission can never be returned as ours. At this
-    // point the SQE for `want` has been pushed but NOT yet submitted/waited on,
-    // so nothing in the completion queue can carry `want` — everything ready is
-    // necessarily a leftover and safe to discard.
-    drain_stale(port);
+/// immediately with `fatal_ring = true` instead of re-spinning through the
+/// ceiling at 100% CPU (#2478); a TRANSIENT error yields the core before
+/// retrying and, on ceiling exhaustion, returns `fatal_ring = false`. In BOTH
+/// error cases the caller defers the buffer — it is never freed here.
+fn reap_matching(
+    port: &mut dyn RingPort,
+    reg: &mut InflightRegistry,
+    want: u64,
+    label: &str,
+) -> Result<i32, ReapError> {
+    // Pre-submit drain: the SQE for `want` has been pushed but NOT yet submitted/
+    // waited on, so nothing in the completion queue can carry `want`. Release any
+    // deferred entry whose CQE is ready and discard leftovers so a stale CQE can
+    // never be returned as ours. (`want` is a freshly allocated id, never in the
+    // registry, so this cannot touch our own op.)
+    reg.reap_ready(port);
 
-    // Bound the wait retries so a pathological always-EINTR storm cannot wedge
-    // the worker forever. EINTR under normal signal pressure resolves in one or
-    // two retries; this ceiling is generous.
-    const MAX_WAIT_RETRIES: u32 = 4096;
     let mut waits = 0u32;
 
     loop {
         match port.submit_and_wait_one() {
             Ok(()) => {}
             Err(err) if err.kind() == io::ErrorKind::Interrupted => {
-                // EINTR: the SQE is already submitted (the enter syscall
-                // flushed the SQ before sleeping). Retry the WAIT — the io-uring
-                // crate recomputes to_submit from the now-empty SQ, so this is
+                // EINTR: the SQE is already submitted (the enter syscall flushed
+                // the SQ before sleeping). Retry the WAIT — the io-uring crate
+                // recomputes to_submit from the now-empty SQ, so this is
                 // wait-only and does not double-submit.
                 waits += 1;
                 if waits >= MAX_WAIT_RETRIES {
-                    return Err(format!(
-                        "{label} io_uring wait interrupted repeatedly ({waits} EINTR)"
-                    ));
+                    return Err(ReapError {
+                        message: format!(
+                            "{label} io_uring wait interrupted repeatedly ({waits} EINTR)"
+                        ),
+                        fatal_ring: false,
+                    });
                 }
                 continue;
             }
             Err(err) => {
                 // A PERMANENT error (bad/closed ring fd, EINVAL, EFAULT, …)
-                // returns the SAME error on every retry. Looping on it just
-                // burns a full core through the MAX_WAIT_RETRIES ceiling without
-                // making progress (#2478) — fail fast instead. The caller drops
-                // the packet; leaving the ring "desynchronised" is moot when the
-                // ring fd itself is dead.
+                // returns the SAME error on every retry. Looping on it just burns
+                // a full core through the ceiling without making progress (#2478)
+                // — fail fast and mark the ring fatal so the caller tears it down.
                 if is_permanent(&err) {
-                    return Err(format!(
-                        "{label} io_uring permanent submit/wait error: {err}"
-                    ));
+                    return Err(ReapError {
+                        message: format!("{label} io_uring permanent submit/wait error: {err}"),
+                        fatal_ring: true,
+                    });
                 }
                 // A TRANSIENT wait error (e.g. EAGAIN): the SQE may still be in
-                // flight. Keep waiting for it to drain rather than returning and
-                // leaving the ring desynchronised for the next write — but yield
-                // the core first so a burst of transient failures does not
-                // tight-spin at 100% CPU before the ceiling.
+                // flight. Keep waiting rather than abandoning it — but yield the
+                // core first so a burst does not tight-spin at 100% CPU before the
+                // ceiling.
                 std::thread::yield_now();
                 waits += 1;
                 if waits >= MAX_WAIT_RETRIES {
-                    return Err(format!("{label} io_uring submit/wait: {err}"));
+                    return Err(ReapError {
+                        message: format!("{label} io_uring submit/wait: {err}"),
+                        fatal_ring: false,
+                    });
                 }
                 continue;
             }
@@ -390,27 +656,19 @@ fn reap_matching(port: &mut dyn RingPort, want: u64, label: &str) -> Result<i32,
             if cqe.user_data == want {
                 return Ok(cqe.result);
             }
-            // Stale CQE from a prior interrupted submission — discard it.
+            // Not ours: release a deferred registry buffer if it matches, else
+            // discard the leftover. Either way keep looking for `want`.
+            reg.release_matching(cqe.user_data);
         }
         // submit_and_wait(1) returned Ok but our completion was not among the
-        // ready ones (only stale ones were). Wait again for ours.
+        // ready ones (only stale/deferred ones were). Wait again for ours.
         waits += 1;
         if waits >= MAX_WAIT_RETRIES {
-            return Err(format!("{label} io_uring completion never matched"));
+            return Err(ReapError {
+                message: format!("{label} io_uring completion never matched"),
+                fatal_ring: false,
+            });
         }
-    }
-}
-
-/// Discard every completion currently ready. Called by [`reap_matching`] only
-/// at the point right after the current SQE is pushed but BEFORE it is submitted
-/// or waited on, so no completion for the current tag can exist yet — everything
-/// ready is necessarily a leftover from a prior interrupted call and is dropped
-/// unconditionally. This is a full drain, not a keep-one-matching drain: there
-/// is nothing to keep, and [`reap_matching`] re-checks `user_data` on the real
-/// reap anyway, so a wrap-around tag collision is still caught there.
-fn drain_stale(port: &mut dyn RingPort) {
-    while let Some(_cqe) = port.next_completion() {
-        // Drop stale completion.
     }
 }
 

--- a/userspace-dp/src/io_uring_write_tests.rs
+++ b/userspace-dp/src/io_uring_write_tests.rs
@@ -16,34 +16,46 @@ struct FakeRing {
     in_flight: VecDeque<u64>,
     /// Completions ready to be reaped.
     ready: VecDeque<Completion>,
-    /// Number of `push_write` calls — i.e. SQEs submitted.
+    /// Number of `push_write` calls — i.e. write SQEs submitted.
     push_calls: usize,
-    /// `user_data` tags this fake itself materialised from `in_flight`
-    /// (i.e. completions for SQEs we really submitted). A pre-seeded stale
-    /// completion's tag is NOT in here, so we can tell, at reap time,
-    /// whether a popped completion is a real one of ours.
+    /// Number of `push_cancel` calls.
+    cancel_calls: usize,
+    /// Recorded (cancel_id, target) pairs for every `push_cancel` — lets a test
+    /// assert the drain cancelled the exact deferred write id (#5800).
+    cancels: Vec<(u64, u64)>,
+    /// When true (default), a `push_cancel` also materialises the TARGET write's
+    /// terminal CQE (modelling the kernel completing a cancelled op) so the
+    /// drain can release it. When false, only the cancel's OWN completion
+    /// surfaces on `push_cancel` — the target write's terminal CQE must arrive
+    /// separately (a later successful wait), modelling a cancellation RACE where
+    /// the cancel completes before the write does.
+    cancel_completes_target: bool,
+    /// `user_data` tags this fake itself materialised (real completions for SQEs
+    /// we really submitted). A pre-seeded stale completion's tag is NOT in here,
+    /// so a reaped popped completion can be told apart from a stale.
     real_tags: std::collections::HashSet<u64>,
-    /// Running total of `res` for REAL completions that the consumer popped
-    /// and consumed. `reap_matching` discards non-matching (stale) CQEs and
-    /// only ever advances `offset` by a CQE whose `user_data` matches its
-    /// current tag — which is always one of `real_tags`. So this sum equals
-    /// the byte total `write_all` actually applied to its offset.
+    /// Running total of `res` for REAL completions the consumer popped. Because
+    /// `reap_matching` only advances `offset` by a CQE whose `user_data` matches
+    /// its current tag (always one of `real_tags`), this equals the byte total
+    /// `write_all` actually applied to its offset.
     accepted_bytes: i64,
-    /// Stale completions to inject AHEAD of the real one on the i-th
-    /// SUCCESSFUL wait. Unlike `with_stale` (which pre-seeds the ready queue
-    /// so `drain_stale` evicts it before the reap loop runs), these surface
-    /// during the wait, so the leftover sits in the completion queue
-    /// alongside the real CQE and the REAP-LOOP user_data match is what must
-    /// skip it. `None` for a given wait injects nothing.
+    /// Stale completions to inject AHEAD of the real one on the i-th SUCCESSFUL
+    /// wait (surfaces alongside the real CQE so the REAP-LOOP user_data match is
+    /// what must skip it). `None` for a given wait injects nothing.
     stale_on_wait: VecDeque<Option<Completion>>,
     /// Number of `submit_and_wait_one` calls — the spin counter for #2478.
-    /// A permanent error must return after exactly ONE wait, not loop to the
-    /// `MAX_WAIT_RETRIES` ceiling.
     wait_calls: usize,
-    /// When set, every wait beyond the scripted `wait_script` returns this
-    /// errno (instead of materialising a completion). Models a ring fd that
-    /// keeps returning the SAME error — the #2478 tight-spin condition.
+    /// When set, every wait beyond the scripted `wait_script` returns this errno
+    /// (instead of materialising a completion). Models a ring fd that keeps
+    /// returning the SAME error — the #2478 tight-spin / #5800 stuck-ring case.
     repeat_err: Option<i32>,
+    /// Completions QUEUED by `push_cancel` but not yet reapable: a cancel is only
+    /// submitted (and its completion reaped) by a subsequent SUCCESSFUL
+    /// `submit_and_wait_one`. They flush into `ready` on the next successful wait.
+    /// A fatal ring (whose every wait returns a permanent error) therefore never
+    /// surfaces them — so `drain_for_teardown` cannot "reap" a completion the real
+    /// kernel could not, and the parked buffer is correctly retained.
+    pending_cqes: VecDeque<Completion>,
 }
 
 impl FakeRing {
@@ -54,16 +66,21 @@ impl FakeRing {
             in_flight: VecDeque::new(),
             ready: VecDeque::new(),
             push_calls: 0,
+            cancel_calls: 0,
+            cancels: Vec::new(),
+            cancel_completes_target: true,
             real_tags: std::collections::HashSet::new(),
             accepted_bytes: 0,
             stale_on_wait: VecDeque::new(),
             wait_calls: 0,
             repeat_err: None,
+            pending_cqes: VecDeque::new(),
         }
     }
 
-    /// Make every wait past the script return `errno` forever (no
-    /// completion). Used to drive the #2478 permanent/transient spin tests.
+    /// Make every wait past the script return `errno` forever (no completion).
+    /// Drives the #2478 permanent/transient spin tests and the #5800 stuck-ring
+    /// deferral tests.
     fn with_repeat_err(mut self, errno: i32) -> Self {
         self.repeat_err = Some(errno);
         self
@@ -74,28 +91,46 @@ impl FakeRing {
         self
     }
 
-    /// Inject a stale completion ahead of the real one on each successful
-    /// wait. Entry `i` (a `Some(_)`) is pushed to the FRONT of the ready
-    /// queue just before the i-th successful wait materialises its real CQE,
-    /// so the reap loop encounters `[stale, real]` and must match on
-    /// `user_data` to skip the stale. `None` injects nothing for that wait.
     fn with_stale_on_wait(mut self, stale: Vec<Option<Completion>>) -> Self {
         self.stale_on_wait = stale.into_iter().collect();
         self
     }
 
-    /// Byte total of REAL (matched) completions the consumer accepted. A
-    /// stale-CQE misattribution would show here as a wrong sum (e.g. the
-    /// stale 9999) because only matched CQEs are supposed to advance offset.
+    /// Cancellation-race mode: a `push_cancel` surfaces ONLY the cancel's own
+    /// completion; the target write's terminal CQE must arrive on a later wait.
+    fn cancel_leaves_target_inflight(mut self) -> Self {
+        self.cancel_completes_target = false;
+        self
+    }
+
     fn accepted_bytes(&self) -> i64 {
         self.accepted_bytes
     }
 
-    /// On a successful wait: inject this wait's scripted stale CQE (if any)
-    /// at the FRONT of the ready queue, then materialise one in-flight SQE's
-    /// real completion at the BACK. The result is `[stale, real]` so the
-    /// reap loop must skip the stale by `user_data` to find the real one.
+    /// Materialise the terminal CQE for every still-in-flight SQE (result `res`),
+    /// as a REAL completion. Test helper to drive a deferred write to a terminal
+    /// state after `write_all` parked it — the completion the retried/stuck wait
+    /// never surfaced now becomes reapable via `reap_ready`.
+    fn complete_inflight_now(&mut self, res: i32) {
+        while let Some(ud) = self.in_flight.pop_front() {
+            self.real_tags.insert(ud);
+            self.ready.push_back(Completion {
+                user_data: ud,
+                result: res,
+            });
+        }
+    }
+
+    /// On a successful wait: inject this wait's scripted stale CQE (if any) at
+    /// the FRONT of the ready queue, then materialise one in-flight SQE's real
+    /// completion at the BACK — `[stale, real]` so the reap loop must skip the
+    /// stale by `user_data`.
     fn materialise_on_successful_wait(&mut self) {
+        // A successful wait actually submits/reaps: flush any cancel/terminal
+        // CQEs queued by `push_cancel` (their completions surface only now).
+        while let Some(cqe) = self.pending_cqes.pop_front() {
+            self.ready.push_back(cqe);
+        }
         if let Some(Some(stale)) = self.stale_on_wait.pop_front() {
             self.ready.push_front(stale);
         }
@@ -122,6 +157,33 @@ impl RingPort for FakeRing {
         Ok(())
     }
 
+    fn push_cancel(&mut self, user_data: u64, target: u64) -> Result<(), String> {
+        self.cancel_calls += 1;
+        self.cancels.push((user_data, target));
+        // The cancel op is only SUBMITTED — and its completion only reapable — by
+        // a later SUCCESSFUL wait. Queue it as pending rather than making it
+        // immediately ready, so a fatal ring (every wait errors) never surfaces
+        // it (invariant 4: the parked buffer is retained, not released).
+        self.pending_cqes.push_back(Completion {
+            user_data,
+            result: 0,
+        });
+        if self.cancel_completes_target {
+            // Model the kernel completing the cancelled write: pull the target
+            // out of in_flight and QUEUE its terminal CQE (result -ECANCELED),
+            // also surfaced only on the next successful wait.
+            if let Some(pos) = self.in_flight.iter().position(|id| *id == target) {
+                self.in_flight.remove(pos);
+                self.real_tags.insert(target);
+                self.pending_cqes.push_back(Completion {
+                    user_data: target,
+                    result: -libc::ECANCELED,
+                });
+            }
+        }
+        Ok(())
+    }
+
     fn submit_and_wait_one(&mut self) -> io::Result<()> {
         self.wait_calls += 1;
         match self.wait_script.pop_front() {
@@ -131,10 +193,6 @@ impl RingPort for FakeRing {
             }
             Some(Err(e)) => Err(e),
             None => {
-                // Script exhausted: if a repeating errno was configured, keep
-                // returning it (no completion) so the caller's retry loop is
-                // exercised (#2478). Otherwise behave as a successful wait
-                // that materialises an in-flight completion if any, else Ok.
                 if let Some(errno) = self.repeat_err {
                     return Err(io::Error::from_raw_os_error(errno));
                 }
@@ -146,14 +204,8 @@ impl RingPort for FakeRing {
 
     fn next_completion(&mut self) -> Option<Completion> {
         let cqe = self.ready.pop_front();
-        // Account a REAL (matched) completion as accepted. `reap_matching`
-        // only ever advances `offset` by a CQE whose `user_data` matches its
-        // tag, and a matching tag is always one we materialised, so summing
-        // popped real completions equals the byte total applied to `offset`.
-        // Stale (pre-seeded) completions are not in `real_tags` and so do
-        // not contribute — exactly the misattribution this test guards.
         if let Some(c) = cqe {
-            if self.real_tags.contains(&c.user_data) {
+            if self.real_tags.contains(&c.user_data) && c.result > 0 {
                 self.accepted_bytes += i64::from(c.result);
             }
         }
@@ -165,162 +217,125 @@ fn eintr() -> io::Result<()> {
     Err(io::Error::from_raw_os_error(libc::EINTR))
 }
 
+fn os_err(errno: i32) -> io::Result<()> {
+    Err(io::Error::from_raw_os_error(errno))
+}
+
+// ---------------------------------------------------------------------------
+// Healthy-path / #2297 / #2407 / #2477 behaviour (adapted to WriteResult)
+// ---------------------------------------------------------------------------
+
 #[test]
 fn single_write_completes() {
     let mut ring = FakeRing::new(vec![Ok(())], vec![4]);
-    let out = write_all(&mut ring, &[0u8; 4], false, "test").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "test");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(ring.push_calls, 1);
+    assert_eq!(reg.inflight_len(), 0, "a completed write parks nothing");
 }
 
 /// Positioned (regular-file / state-writer) stream write: a short count
 /// legitimately resumes from `offset + n` because a file IS a byte stream.
 #[test]
 fn positioned_short_write_advances_and_resubmits() {
-    // First completion reports 2 of 4 bytes; second reports the remaining 2.
     let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![2, 2]);
-    let out = write_all(&mut ring, &[0u8; 4], true, "state").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], true, "state");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(ring.push_calls, 2);
 }
 
-/// #2407 fail-on-revert: a non-positioned (TUN, packet-oriented) write that
-/// reports a SHORT count must NOT resubmit the remainder — doing so would
-/// inject `data[n..]` as a second corrupt packet. It must return Err after
-/// exactly ONE push, never a second `data[n..]` write.
-///
-/// If the packet-fd guard is reverted (the loop resumes from `offset + n`
-/// for non-positioned writes), the fake materialises the SECOND CQE (4),
-/// `push_calls` becomes 2, and the call returns Ok — both asserts fail.
+/// #2407 fail-on-revert: a non-positioned (TUN) write that reports a SHORT
+/// count must NOT resubmit the remainder — it returns `Transferred` after
+/// exactly ONE push.
 #[test]
 fn packet_short_write_drops_no_remainder_resubmit() {
-    // Script a second successful wait + a second result so a (buggy)
-    // resubmit WOULD succeed and complete — proving the guard, not a lack of
-    // script, is what stops the corrupting remainder write.
     let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![2, 2]);
-    let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
-    assert!(
-        err.message().contains("short write on packet fd"),
-        "partial packet write must be a drop, got: {err}"
-    );
-    // #2477: a packet-fd partial write put bytes on the TUN, so it MUST
-    // classify as `Transferred` (NOT safe to retry) — otherwise the
-    // slow-path caller would sync-retry and re-send the whole packet.
-    assert!(
-        matches!(err, WriteError::Transferred(_)),
-        "a packet-fd partial write must be Transferred, got: {err:?}"
-    );
-    assert!(
-        !err.safe_to_retry(),
-        "a packet-fd partial write must NOT be safe to sync-retry (#2477)"
-    );
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    match &out {
+        WriteResult::Transferred(_buf, msg) => {
+            assert!(
+                msg.contains("short write on packet fd"),
+                "partial packet write must be a drop, got: {msg}"
+            );
+        }
+        other => panic!("a packet-fd partial write must be Transferred, got: {other:?}"),
+    }
     assert_eq!(
         ring.push_calls, 1,
         "a packet-fd short write must NOT resubmit the remainder (corruption)"
     );
-    // Only the first (partial) CQE may have been accepted; the corrupting
-    // second chunk's bytes must never be applied.
     assert_eq!(
         ring.accepted_bytes(),
         2,
         "no remainder bytes may be written after a partial packet write"
     );
+    assert_eq!(reg.inflight_len(), 0, "a reaped partial parks nothing");
 }
 
 /// A non-positioned FULL write still succeeds in one push (no regression).
 #[test]
 fn packet_full_write_succeeds() {
     let mut ring = FakeRing::new(vec![Ok(())], vec![4]);
-    let out = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(ring.push_calls, 1);
 }
 
 /// #2407: EINTR on a packet write retries the WAIT (not a re-push) and then
-/// reaps the full count — the whole packet is written with one submission.
+/// reaps the full count.
 #[test]
 fn packet_eintr_retries_whole_no_corruption() {
     let mut ring = FakeRing::new(vec![eintr(), Ok(())], vec![4]);
-    let out = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(
         ring.push_calls, 1,
         "EINTR retry must be wait-only, never a remainder re-push"
     );
     assert_eq!(ring.accepted_bytes(), 4);
+    assert_eq!(reg.inflight_len(), 0);
 }
 
-/// The core #2297 regression: an EINTR on the wait must NOT abandon the SQE
-/// and must NOT cause a stale/short offset. The retried wait reaps the real
-/// completion and the full byte count is applied.
+/// The core #2297 regression: an EINTR on the wait must NOT abandon the SQE and
+/// must NOT cause a stale/short offset.
 #[test]
 fn eintr_retries_wait_and_writes_full_count() {
-    // wait #1 -> EINTR (SQE still in flight, no completion yet),
-    // wait #2 -> Ok (completion for the same SQE, res = 8).
     let mut ring = FakeRing::new(vec![eintr(), Ok(())], vec![8]);
-    let out = write_all(&mut ring, &[0u8; 8], false, "test").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
-    // Exactly one SQE was pushed: the EINTR retry must be wait-only, never
-    // a re-push (re-pushing would double-submit / double-count).
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 8], false, "test");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(ring.push_calls, 1, "EINTR retry must not re-submit the SQE");
 }
 
-/// Counter-factual: prove the pre-fix behaviour WOULD corrupt the offset and
-/// that BOTH stale defences in the fix — the `drain_stale` pre-drain AND the
-/// `user_data` match inside the reap loop — genuinely matter. The buffer is
-/// two chunks (8 bytes, real results 4 then 4), so a CORRECT run pushes a
-/// SECOND SQE and applies exactly 8 bytes; a stale-CQE misattribution
-/// finishes in one push with an overshot offset.
-///
-/// Two stale CQEs (`user_data = 999`, `res = 9999`) are placed to exercise
-/// each defence:
-///   * one PRE-SEEDED in the ready queue (`with_stale`) — defended by the
-///     `drain_stale` call at the top of `reap_matching`;
-///   * one INJECTED ahead of the first real CQE DURING the wait
-///     (`with_stale_on_wait`) — surfaces after `drain_stale` has run, so the
-///     reap loop sees `[stale, real]` and ONLY the `user_data == want` match
-///     stops it from returning the stale 9999.
-///
-/// Fail-on-revert (verified): reverting `reap_matching` to reap the head CQE
-/// unconditionally (dropping the `user_data` match) makes the reap loop
-/// return the injected stale's `res = 9999`; `offset` jumps past the buffer,
-/// the loop ends after a SINGLE push, the second chunk is never written, and
-/// the real completion is abandoned. So buggy code yields `push_calls == 1`
-/// (assert wants 2) and an accepted-byte total that is not 8 — both fail.
-///
-/// The fake also sums the `res` of every ACCEPTED (matched) completion so the
-/// test asserts the exact applied byte total, not just the push count: a
-/// misattribution shows up as a wrong running total even if the push count
-/// happened to coincide.
+/// Counter-factual: prove BOTH stale defences — the `reap_ready` pre-drain AND
+/// the `user_data` match inside the reap loop — genuinely matter. Two stale
+/// CQEs (`user_data = 999`, `res = 9999`) are placed to exercise each defence.
 #[test]
 fn stale_cqe_is_not_misattributed() {
     let stale = || Completion {
-        user_data: 999, // not a tag this call will ever use
+        user_data: 999,
         result: 9999,
     };
-    // Two-chunk write: real results 4 then 4. Both staged stale CQEs must be
-    // skipped for the second push to ever happen.
     let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![4, 4])
-        // Defended by drain_stale (already ready before the first wait).
+        // Defended by the `reap_ready` pre-drain (already ready before the write).
         .with_stale(vec![stale()])
-        // Defended by the reap-loop user_data match (surfaces during the
-        // first wait, ahead of the real CQE).
+        // Defended by the reap-loop user_data match (surfaces during the first
+        // wait, ahead of the real CQE).
         .with_stale_on_wait(vec![Some(stale()), None]);
-    // Positioned (file/state-writer) write: a short count legitimately
-    // resumes from offset+n, so the two-chunk resume here exercises the
-    // stale-CQE defences across both pushes. (A non-positioned/TUN partial
-    // would drop at the first chunk — that's the #2407 packet semantics,
-    // covered by `packet_short_write_drops_no_remainder_resubmit`.)
-    let out = write_all(&mut ring, &[0u8; 8], true, "test").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
-    // A misattributed stale CQE (res=9999) would overshoot offset and finish
-    // in ONE push; the correct path needs TWO.
+    let mut reg = InflightRegistry::new();
+    // Positioned write: a short count legitimately resumes, so the two-chunk
+    // resume exercises the stale-CQE defences across both pushes.
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 8], true, "test");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(
         ring.push_calls, 2,
         "stale CQE must be skipped; second chunk must still be written"
     );
-    // The accepted completions must sum to exactly the buffer length — never
-    // the stale 9999 — proving only our own CQEs advanced the offset.
     assert_eq!(
         ring.accepted_bytes(),
         8,
@@ -328,60 +343,56 @@ fn stale_cqe_is_not_misattributed() {
     );
 }
 
-/// A write error (negative res) surfaces as Err, not a silent advance.
+/// A write error (negative res) surfaces as NothingWritten (safe to sync-retry).
 #[test]
-fn negative_result_is_error() {
+fn negative_result_is_nothing_written() {
     let mut ring = FakeRing::new(vec![Ok(())], vec![-libc::EIO]);
-    let err = write_all(&mut ring, &[0u8; 4], false, "test").unwrap_err();
-    assert!(
-        err.message().contains("io_uring write failed"),
-        "got: {err}"
-    );
-    // The kernel completion errored — nothing reached the fd, so a
-    // synchronous retry from offset 0 is safe (#2477).
-    assert!(
-        err.safe_to_retry(),
-        "a kernel completion error transferred nothing; sync-retry must be safe"
-    );
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "test");
+    match out {
+        WriteResult::NothingWritten(_buf, msg) => {
+            assert!(msg.contains("io_uring write failed"), "got: {msg}");
+        }
+        other => panic!("a kernel completion error must be NothingWritten, got: {other:?}"),
+    }
+    assert_eq!(reg.inflight_len(), 0);
 }
 
-/// res == 0 is a short write and must be an error, not an infinite loop.
+/// res == 0 is a short write → NothingWritten, not an infinite loop.
 #[test]
-fn zero_result_is_short_write_error() {
+fn zero_result_is_nothing_written() {
     let mut ring = FakeRing::new(vec![Ok(())], vec![0]);
-    let err = write_all(&mut ring, &[0u8; 4], false, "test").unwrap_err();
-    assert!(err.message().contains("short write"), "got: {err}");
-    // Zero bytes transferred — safe to retry synchronously (#2477).
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "test");
     assert!(
-        err.safe_to_retry(),
-        "a zero-byte completion must be safe to retry"
+        matches!(out, WriteResult::NothingWritten(_, ref m) if m.contains("short write")),
+        "got: {out:?}"
     );
 }
 
-/// Several EINTRs in a row still converge — the loop keeps waiting.
 #[test]
 fn repeated_eintr_eventually_completes() {
     let mut ring = FakeRing::new(vec![eintr(), eintr(), eintr(), Ok(())], vec![16]);
-    let out = write_all(&mut ring, &[0u8; 16], false, "test").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 16], false, "test");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(ring.push_calls, 1);
+    assert_eq!(reg.inflight_len(), 0);
 }
 
-/// Positioned writes (state writer) advance the file offset across chunks.
 #[test]
 fn positioned_multi_chunk() {
     let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![3, 3]);
-    let out = write_all(&mut ring, &[0u8; 6], true, "state").unwrap();
-    assert_eq!(out, WriteOutcome::Done);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 6], true, "state");
+    assert!(matches!(out, WriteResult::Done(_)));
     assert_eq!(ring.push_calls, 2);
 }
 
-fn os_err(errno: i32) -> io::Result<()> {
-    Err(io::Error::from_raw_os_error(errno))
-}
+// ---------------------------------------------------------------------------
+// #2478 errno classification (retained), now feeding the #5800 deferral
+// ---------------------------------------------------------------------------
 
-/// #2478 errno classification: the permanent set returns from the retry
-/// loop, the transient set keeps retrying.
 #[test]
 fn is_permanent_classifies_errnos() {
     for e in [
@@ -405,70 +416,295 @@ fn is_permanent_classifies_errnos() {
             "errno {e} must be transient"
         );
     }
-    // A non-OS io::Error has no errno — treated as transient (bounded by the
-    // retry ceiling) rather than misclassified as permanent.
-    assert!(!is_permanent(&io::Error::new(
-        io::ErrorKind::Other,
-        "no errno"
-    )));
+    assert!(!is_permanent(&io::Error::new(io::ErrorKind::Other, "no errno")));
 }
 
-/// #2478 fail-on-revert: a PERMANENT submit/wait error (EBADF) must return
-/// after exactly ONE `submit_and_wait_one` call — never tight-spin up to the
-/// MAX_WAIT_RETRIES (4096) ceiling at 100% CPU.
+// ---------------------------------------------------------------------------
+// #5800 — retry exhaustion / fatal ring DEFER the owned buffer, never free it
+// ---------------------------------------------------------------------------
+
+/// #5800 fail-on-revert (the core regression): a repeated-EINTR storm that hits
+/// the `MAX_WAIT_RETRIES` ceiling must NOT free the buffer. `write_all` returns
+/// `Deferred` only after the owned buffer has moved into the registry, so the
+/// buffer stays OWNED (inflight_len == 1) until a later terminal completion.
 ///
-/// `repeat_err` makes every wait return EBADF forever. With the old
-/// unconditional-retry arm, `wait_calls` would reach 4096 before the ceiling
-/// gives up (the assert `== 1` fails). With the fix, `is_permanent(EBADF)`
-/// returns immediately on the first wait.
+/// This binds `reg.defer(slot)` in `write_all`'s reap-error arm. Neutralising
+/// that line (e.g. `drop(slot)` in place of `reg.defer(slot)`) frees the buffer
+/// at exhaustion, so `inflight_len` is 0 and BOTH asserts below go RED as clean
+/// assertion failures.
 #[test]
-fn permanent_error_returns_without_spinning() {
-    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EBADF);
-    let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
-    assert!(
-        err.message().contains("permanent submit/wait error"),
-        "got: {err}"
-    );
-    // The single load-bearing assertion: ONE wait, not 4096.
+fn eintr_ceiling_defers_buffer_not_freed() {
+    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EINTR);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    match &out {
+        WriteResult::Deferred {
+            fatal_ring,
+            message,
+            ..
+        } => {
+            assert!(!fatal_ring, "an EINTR storm is not a fatal ring");
+            assert!(message.contains("interrupted"), "got: {message}");
+        }
+        other => panic!("retry-ceiling exhaustion must Defer the buffer, got: {other:?}"),
+    }
     assert_eq!(
-        ring.wait_calls, 1,
-        "a permanent error must fail fast after one wait, not spin to the ceiling"
+        reg.inflight_len(),
+        1,
+        "the owned buffer must remain in the registry after ceiling exhaustion (not freed)"
     );
-    // A permanent submit/wait error is ambiguous about the SQE, so it is
-    // `Transferred` (no sync-retry) — consistent with the #2477 contract.
-    assert!(matches!(err, WriteError::Transferred(_)));
+    assert_eq!(
+        ring.wait_calls,
+        super::MAX_WAIT_RETRIES as usize,
+        "the EINTR ceiling bounds the wait, exactly MAX_WAIT_RETRIES"
+    );
 }
 
-/// #2478 complement: a TRANSIENT error (EAGAIN) is NOT permanent, so the loop
-/// keeps retrying and DOES reach the MAX_WAIT_RETRIES ceiling rather than
-/// returning on the first wait. This proves the classification actually
-/// gates the behaviour (and that transient errors are not fast-failed).
+/// #5800: after the buffer is deferred, a later terminal completion releases it
+/// — the deferred buffer stays owned right up until its CQE is reaped. This is
+/// the "held until terminal completion/teardown" half of the invariant.
 #[test]
-fn transient_error_retries_to_ceiling() {
+fn deferred_buffer_released_on_terminal_completion() {
+    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EINTR);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    assert!(matches!(out, WriteResult::Deferred { .. }));
+    assert_eq!(reg.inflight_len(), 1, "buffer owned after exhaustion");
+
+    // The write's terminal CQE finally surfaces (the storm cleared). A plain
+    // reap_ready (no submit_and_wait) must release the buffer.
+    ring.complete_inflight_now(4);
+    reg.reap_ready(&mut ring);
+    assert_eq!(
+        reg.inflight_len(),
+        0,
+        "the deferred buffer must be released once its terminal CQE is reaped"
+    );
+}
+
+/// #5800: repeated TRANSIENT errors (EAGAIN) also defer (never free). The ring
+/// is not fatal, so `fatal_ring == false` and the wait loops to the ceiling.
+#[test]
+fn transient_error_ceiling_defers_buffer() {
     let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EAGAIN);
-    let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
-    assert!(err.message().contains("submit/wait"), "got: {err}");
-    // It looped to the ceiling (4096) rather than bailing on wait #1.
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    match &out {
+        WriteResult::Deferred { fatal_ring, .. } => assert!(!fatal_ring),
+        other => panic!("a transient-error ceiling must Defer, got: {other:?}"),
+    }
+    assert_eq!(reg.inflight_len(), 1, "transient exhaustion must not free the buffer");
     assert!(
-        ring.wait_calls >= 4096,
-        "a transient error must keep retrying to the ceiling, got {} waits",
+        ring.wait_calls >= super::MAX_WAIT_RETRIES as usize,
+        "a transient error retries to the ceiling, got {} waits",
         ring.wait_calls
     );
 }
 
-/// A single EINTR followed by a permanent EBADF returns on the permanent
-/// error — EINTR retried (wait #1), EBADF fast-failed (wait #2). Confirms the
-/// permanent check sits on the catch-all arm, not the EINTR arm.
+/// #5800 + #2478: a PERMANENT submit/wait error (EBADF) fast-fails after exactly
+/// ONE wait AND retains the buffer with `fatal_ring = true` (the caller tears
+/// the ring down). The #2478 fast-fail must not free the buffer.
 #[test]
-fn eintr_then_permanent_returns_promptly() {
-    let mut ring = FakeRing::new(vec![os_err(libc::EINTR)], vec![]).with_repeat_err(libc::EBADF);
-    let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
-    assert!(
-        err.message().contains("permanent submit/wait error"),
-        "got: {err}"
+fn permanent_error_defers_buffer_and_fast_fails() {
+    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EBADF);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    match &out {
+        WriteResult::Deferred {
+            fatal_ring,
+            message,
+            ..
+        } => {
+            assert!(fatal_ring, "a permanent ring error must mark fatal_ring");
+            assert!(message.contains("permanent submit/wait error"), "got: {message}");
+        }
+        other => panic!("a permanent error must Defer with fatal_ring, got: {other:?}"),
+    }
+    assert_eq!(
+        ring.wait_calls, 1,
+        "a permanent error must fail fast after one wait, not spin to the ceiling (#2478)"
     );
     assert_eq!(
-        ring.wait_calls, 2,
-        "EINTR retries once, then the permanent EBADF fast-fails — two waits total"
+        reg.inflight_len(),
+        1,
+        "a permanent error must RETAIN the in-flight buffer pending teardown (#5800)"
     );
+}
+
+/// A single EINTR then a permanent EBADF: EINTR retried (wait #1), EBADF
+/// fast-failed (wait #2). Confirms the permanent check sits on the catch-all
+/// arm and still defers the buffer.
+#[test]
+fn eintr_then_permanent_defers_promptly() {
+    let mut ring = FakeRing::new(vec![os_err(libc::EINTR)], vec![]).with_repeat_err(libc::EBADF);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    assert!(matches!(out, WriteResult::Deferred { fatal_ring: true, .. }));
+    assert_eq!(ring.wait_calls, 2, "EINTR retries once, then EBADF fast-fails");
+    assert_eq!(reg.inflight_len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// #5800 — ring-global id uniqueness + fail-closed wrap (invariant 3)
+// ---------------------------------------------------------------------------
+
+/// #5800: `user_data` is ring-global and monotonic — it does NOT restart per
+/// call, so a leftover CQE from an earlier call cannot alias a later call.
+#[test]
+fn user_data_is_ring_global_monotonic() {
+    let mut reg = InflightRegistry::new();
+    assert_eq!(reg.alloc_id(), Some(1));
+    assert_eq!(reg.alloc_id(), Some(2));
+
+    // Two successive single-byte writes on the SAME registry must draw DISTINCT
+    // ids (3 then 4), not both restart at 1.
+    let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![1, 1]);
+    let _ = write_all(&mut ring, &mut reg, vec![0u8; 1], false, "a");
+    let _ = write_all(&mut ring, &mut reg, vec![0u8; 1], false, "b");
+    assert_eq!(reg.alloc_id(), Some(5), "ids must keep advancing across calls");
+}
+
+/// #5800 fail-on-revert (invariant 3): the id space is fail-closed at the wrap
+/// boundary. `alloc_id` hands out u64::MAX, then refuses (None) rather than wrap
+/// back through 0 and reuse a possibly-live id.
+#[test]
+fn alloc_id_fails_closed_on_wrap() {
+    let mut reg = InflightRegistry::new();
+    reg.next_id = u64::MAX;
+    assert_eq!(reg.alloc_id(), Some(u64::MAX), "the last id is handed out");
+    assert_eq!(reg.next_id, 0, "the counter wraps to the exhausted sentinel");
+    assert_eq!(reg.alloc_id(), None, "exhausted: must fail closed, never reuse");
+    assert_eq!(reg.alloc_id(), None, "stays exhausted");
+}
+
+/// #5800: when the id space is exhausted, `write_all` fails closed WITHOUT
+/// submitting anything — nothing reaches the fd (NothingWritten, push_calls 0).
+#[test]
+fn write_all_fails_closed_when_id_space_exhausted() {
+    let mut ring = FakeRing::new(vec![Ok(())], vec![4]);
+    let mut reg = InflightRegistry::new();
+    reg.next_id = 0; // pretend the space is already exhausted
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "test");
+    assert!(
+        matches!(out, WriteResult::NothingWritten(_, ref m) if m.contains("space exhausted")),
+        "got: {out:?}"
+    );
+    assert_eq!(ring.push_calls, 0, "an exhausted id space must not submit an SQE");
+}
+
+// ---------------------------------------------------------------------------
+// #5800 — teardown drain + cancellation (invariant 2/4)
+// ---------------------------------------------------------------------------
+
+/// #5800: `drain_for_teardown` submits an AsyncCancel for each deferred write id
+/// and releases its buffer once the target write's terminal CQE is reaped.
+#[test]
+fn drain_cancels_and_releases_deferred_buffer() {
+    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EINTR);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    let deferred_id = match out {
+        WriteResult::Deferred { id, .. } => id,
+        other => panic!("expected Deferred, got: {other:?}"),
+    };
+    assert_eq!(reg.inflight_len(), 1);
+
+    // The EINTR storm cleared: give the teardown drain a successful wait so its
+    // submitted cancel — and the target write's terminal CQE — can be reaped
+    // (a real cancel completes only once a wait submits it).
+    ring.repeat_err = None;
+
+    let released = reg.drain_for_teardown(&mut ring);
+    assert_eq!(released, 1, "drain must release the one deferred buffer");
+    assert_eq!(reg.inflight_len(), 0, "no buffer may survive a completed drain");
+    assert_eq!(ring.cancel_calls, 1, "drain must submit exactly one cancel");
+    assert_eq!(
+        ring.cancels[0].1, deferred_id,
+        "the cancel must target the exact deferred write id"
+    );
+}
+
+/// #5800 (cancellation race): observing the CANCEL's completion alone must NOT
+/// release the buffer — only the TARGET write's terminal CQE does. With the
+/// cancel completing first, the buffer stays owned until the write CQE arrives.
+///
+/// `release_matching` is the release predicate: it matches only WRITE ids, so a
+/// cancel id leaves the entry owned; the write id releases it.
+#[test]
+fn cancel_completion_alone_does_not_release() {
+    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EINTR);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    let write_id = match out {
+        WriteResult::Deferred { id, .. } => id,
+        other => panic!("expected Deferred, got: {other:?}"),
+    };
+    // A cancel id (not a write id) must not release the entry.
+    let cancel_id = 999_999u64;
+    assert!(!reg.release_matching(cancel_id), "a cancel CQE matches no write id");
+    assert_eq!(
+        reg.inflight_len(),
+        1,
+        "the cancel's own completion must NOT release the buffer (invariant 2)"
+    );
+    // The target write's terminal CQE releases it.
+    assert!(reg.release_matching(write_id), "the write's terminal CQE releases it");
+    assert_eq!(reg.inflight_len(), 0);
+}
+
+/// #5800 (cancellation race via the real drain): even when the cancel CQE
+/// surfaces BEFORE the target write's terminal CQE, the drain releases the
+/// buffer only after the write CQE arrives (on a later wait), never on the
+/// cancel alone.
+#[test]
+fn drain_waits_for_target_cqe_not_just_cancel() {
+    let mut ring = FakeRing::new(vec![], vec![])
+        // Storm to force the defer, and a race where the cancel completes first.
+        .with_repeat_err(libc::EINTR)
+        .cancel_leaves_target_inflight();
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    assert!(matches!(out, WriteResult::Deferred { .. }));
+
+    // repeat_err(EINTR) would keep the drain waiting forever, so clear it: the
+    // drain's first wait then materialises the still-in-flight target write's
+    // terminal CQE, which is what actually releases the buffer.
+    ring.repeat_err = None;
+    ring.wait_script.push_back(Ok(()));
+
+    let released = reg.drain_for_teardown(&mut ring);
+    assert_eq!(released, 1, "the buffer is released on the target write's CQE");
+    assert_eq!(reg.inflight_len(), 0);
+    assert_eq!(ring.cancel_calls, 1, "the drain cancelled the deferred write");
+}
+
+/// #5800 (invariant 4): a FATAL ring cannot be drained (every wait returns the
+/// permanent error), so `drain_for_teardown` RETAINS the buffer — it is never
+/// freed early. The straggler is freed only when the registry itself drops
+/// (after the ring fd closes).
+#[test]
+fn fatal_ring_drain_retains_buffer() {
+    let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EBADF);
+    let mut reg = InflightRegistry::new();
+    let out = write_all(&mut ring, &mut reg, vec![0u8; 4], false, "slow-path");
+    assert!(matches!(out, WriteResult::Deferred { fatal_ring: true, .. }));
+    assert_eq!(reg.inflight_len(), 1);
+
+    let released = reg.drain_for_teardown(&mut ring);
+    assert_eq!(released, 0, "a fatal ring cannot prove release — retain the buffer");
+    assert_eq!(
+        reg.inflight_len(),
+        1,
+        "invariant 4: the buffer is retained until teardown/registry-drop, never freed early"
+    );
+}
+
+/// A drain with nothing in flight is a no-op (no cancels, no waits).
+#[test]
+fn drain_empty_is_noop() {
+    let mut ring = FakeRing::new(vec![], vec![]);
+    let mut reg = InflightRegistry::new();
+    assert_eq!(reg.drain_for_teardown(&mut ring), 0);
+    assert_eq!(ring.cancel_calls, 0);
+    assert_eq!(ring.wait_calls, 0);
 }

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -1,4 +1,4 @@
-use io_uring::IoUring;
+use crate::io_uring_write::WriteResult;
 use std::fs::OpenOptions;
 use std::io;
 use std::os::unix::fs::OpenOptionsExt;
@@ -162,7 +162,7 @@ impl RateLimiter {
 }
 
 enum WriteMode {
-    IoUring(IoUring),
+    IoUring(crate::io_uring_write::RingWriter),
     SyncFallback,
 }
 
@@ -496,7 +496,7 @@ fn slow_path_worker(name: &str, mtu: i32, rx: Receiver<PacketRequest>, status: A
     status.set_device_name(&actual_name);
     status.active.store(true, Ordering::Relaxed);
 
-    let mut mode = match IoUring::new(256) {
+    let mut mode = match crate::io_uring_write::RingWriter::new(256) {
         Ok(ring) => {
             status.set_mode("io_uring");
             WriteMode::IoUring(ring)
@@ -510,13 +510,15 @@ fn slow_path_worker(name: &str, mtu: i32, rx: Receiver<PacketRequest>, status: A
 
     while let Ok(req) = rx.recv() {
         status.queued_packets.fetch_sub(1, Ordering::Relaxed);
-        // `req` (and `req.bytes`) stays owned by this loop iteration until the
-        // end of the body — AFTER `apply_slowpath_outcome` may drop the ring on
-        // a terminal demotion. That ordering is what upholds the #2297
-        // buffer-lifetime invariant across a demotion: closing the ring fd
-        // cancels any still-outstanding SQE while its buffer is still alive.
-        let outcome = write_packet_with_mode(&mut mode, tun.as_raw_fd(), &req.bytes);
-        apply_slowpath_outcome(outcome, &mut mode, req.bytes.len(), &status);
+        // The owned packet buffer MOVES into the write path. In io_uring mode a
+        // Deferred outcome moves it into the ring's in-flight registry (retained
+        // until its CQE is reaped or the ring is torn down and drained) rather
+        // than freeing it here — the #5800 buffer-lifetime invariant. A reaped
+        // terminal outcome (Done / NothingWritten / Transferred) hands the buffer
+        // back, and it is dropped when this iteration ends.
+        let bytes_len = req.bytes.len();
+        let outcome = write_packet_with_mode(&mut mode, tun.as_raw_fd(), req.bytes);
+        apply_slowpath_outcome(outcome, &mut mode, bytes_len, &status);
     }
     status.active.store(false, Ordering::Relaxed);
 }
@@ -553,56 +555,99 @@ struct SlowPathWriteOutcome {
 fn write_packet_with_mode(
     mode: &mut WriteMode,
     fd: i32,
-    bytes: &[u8],
+    bytes: Vec<u8>,
 ) -> SlowPathWriteOutcome {
     match mode {
         WriteMode::IoUring(ring) => {
-            classify_io_uring_write(write_packet_io_uring(ring, fd, bytes), || {
-                write_packet_sync(fd, bytes)
-            })
+            // Move the owned buffer into the ring. A stream write to the packet
+            // TUN (no file offset). On a Deferred outcome the ring KEEPS the
+            // buffer in its in-flight registry (never freed while an SQE may
+            // reference it, #5800); a NothingWritten hands it back for the
+            // synchronous fallback.
+            let result = ring.write(fd, bytes, false, "slow-path");
+            classify_io_uring_write(result, |b| write_packet_sync(fd, &b))
         }
         WriteMode::SyncFallback => SlowPathWriteOutcome {
-            result: write_packet_sync(fd, bytes),
+            result: write_packet_sync(fd, &bytes),
             ring_terminal: false,
             demotion_cause: None,
         },
     }
 }
 
-/// Classify a single io_uring write attempt into a [`SlowPathWriteOutcome`]
-/// (#5172). Separates packet-transfer certainty (delegated to the #2477
-/// [`decide_sync_fallback`] decision) from ring health:
+/// Classify a single io_uring [`WriteResult`] into a [`SlowPathWriteOutcome`]
+/// (#5172 + #5800). Separates packet-transfer certainty (the #2477 sync-fallback
+/// decision) from ring health, and distinguishes the four outcomes the acceptance
+/// criteria require: successful completion, deferred in-flight ownership,
+/// cancellation/partial transfer, and fatal ring teardown.
 ///
-///   * `Ok` — delivered via io_uring; ring healthy.
-///   * `Err(NothingWritten)` (`safe_to_retry`) — nothing reached the TUN, so a
-///     synchronous retry from offset 0 rescues THIS packet. TRANSIENT: the ring
-///     may be momentarily full or hit a per-packet completion error; keep
-///     io_uring mode (do not demote).
-///   * `Err(Transferred)` (not `safe_to_retry`) — the submit/reap was ambiguous,
-///     so bytes may be in flight on the ring; the packet is DROPPED (no-retry —
-///     re-sending could double-transmit). On a packet-oriented TUN a partial
-///     write cannot occur (the kernel writes a whole packet or fails), so this
-///     variant means the io_uring transport itself is wedged: TERMINAL — demote.
+///   * `Done` — delivered via io_uring; ring healthy. No sync fallback.
+///   * `NothingWritten` — nothing reached the TUN (submit-queue full, a per-packet
+///     completion error, a zero-byte completion, or id-space exhaustion). The
+///     returned buffer feeds a synchronous retry that rescues THIS packet.
+///     TRANSIENT: keep io_uring mode (do not demote on a momentary blip, #2477).
+///   * `Transferred` — a packet-fd partial write: `0 < n < len` bytes are already
+///     on the TUN and the CQE was REAPED (terminal, buffer safe). Re-sending the
+///     whole packet would duplicate it → DROP, no sync retry. The ring reaped
+///     cleanly, so it is NOT demoted.
+///   * `Deferred` — the op did NOT reach a reaped terminal state, so the buffer
+///     has been MOVED into the ring's in-flight registry (retained, not freed) and
+///     the packet did not reliably reach the TUN → DROP (no sync retry; the write
+///     may be in flight). A FATAL ring (dead fd, `fatal_ring = true`) is TERMINAL
+///     — demote to sync so later packets stop hitting a dead ring. A bare
+///     retry-ceiling storm (`fatal_ring = false`) keeps io_uring: the ring is
+///     otherwise healthy and the parked buffer is reclaimed on a later write's
+///     reap.
 ///
-/// Factored so the classification is unit-testable without a live ring or TUN.
+/// The `sync_fallback` thunk receives the handed-back buffer (only the
+/// `NothingWritten` arm invokes it). Factored so the classification is
+/// unit-testable without a live ring or TUN.
 fn classify_io_uring_write<F>(
-    io_result: Result<(), crate::io_uring_write::WriteError>,
+    result: WriteResult,
     sync_fallback: F,
 ) -> SlowPathWriteOutcome
 where
-    F: FnOnce() -> Result<(), String>,
+    F: FnOnce(Vec<u8>) -> Result<(), String>,
 {
-    let ring_terminal = matches!(&io_result, Err(err) if !err.safe_to_retry());
-    let demotion_cause = match &io_result {
-        Err(err) if !err.safe_to_retry() => Some(format!(
-            "slow-path io_uring ring failure, demoting to sync: {err}"
-        )),
-        _ => None,
-    };
-    SlowPathWriteOutcome {
-        result: decide_sync_fallback(io_result, sync_fallback),
-        ring_terminal,
-        demotion_cause,
+    match result {
+        WriteResult::Done(_bytes) => SlowPathWriteOutcome {
+            result: Ok(()),
+            ring_terminal: false,
+            demotion_cause: None,
+        },
+        WriteResult::NothingWritten(bytes, _msg) => SlowPathWriteOutcome {
+            // Nothing on the fd — the sync fallback rescues this packet from the
+            // returned buffer. The ring stays live (transient, not a demotion).
+            result: sync_fallback(bytes),
+            ring_terminal: false,
+            demotion_cause: None,
+        },
+        WriteResult::Transferred(_bytes, msg) => SlowPathWriteOutcome {
+            // Bytes already on the TUN (reaped, terminal). Drop, never re-send.
+            // The ring is healthy — not a demotion.
+            result: Err(msg),
+            ring_terminal: false,
+            demotion_cause: None,
+        },
+        WriteResult::Deferred {
+            id,
+            message,
+            fatal_ring,
+        } => {
+            // The buffer is parked in the ring's registry (retained, not freed);
+            // `id` identifies the parked in-flight write so an operator can
+            // correlate it with the teardown drain. Only a FATAL ring demotes; a
+            // retry-ceiling storm keeps io_uring.
+            let message = format!("{message} (in-flight id {id}, buffer retained)");
+            let demotion_cause = fatal_ring.then(|| {
+                format!("slow-path io_uring ring failure, demoting to sync: {message}")
+            });
+            SlowPathWriteOutcome {
+                result: Err(message),
+                ring_terminal: fatal_ring,
+                demotion_cause,
+            }
+        }
     }
 }
 
@@ -657,25 +702,17 @@ fn apply_slowpath_outcome(
     }
 }
 
-/// Retire the io_uring ring to [`WriteMode::SyncFallback`] (#5172).
+/// Retire the io_uring ring to [`WriteMode::SyncFallback`] (#5172 + #5800).
 ///
-/// Best-effort drains any completions already posted, then overwrites `*mode`,
-/// which DROPS the ring and closes its fd. The fd close is the authoritative
-/// retirement: the kernel cancels any SQE still outstanding when the ring fd
-/// closes. The current packet's buffer is still owned by the caller at this
-/// point (the worker loop drops `req` only after `apply_slowpath_outcome`
-/// returns), so no kernel reference can outlive the buffer — the #2297
-/// buffer-lifetime invariant holds across the demotion. No re-promotion.
+/// Overwriting `*mode` DROPS the [`RingWriter`], whose `Drop` runs a bounded
+/// teardown drain (submit an AsyncCancel per still-in-flight entry, observe each
+/// target write's terminal CQE) and then closes the ring fd. The fd close makes
+/// the kernel cancel and wait for every outstanding op, and the in-flight
+/// registry — dropped AFTER the ring by field order — frees any straggler buffer
+/// only then, so no kernel reference can outlive a buffer across the demotion
+/// (the #5800 buffer-lifetime invariant, now covering the parked-buffer case the
+/// pre-#5800 code could not). No re-promotion (avoids flapping).
 fn retire_ring_to_sync(mode: &mut WriteMode) {
-    if let WriteMode::IoUring(ring) = mode {
-        // Bounded best-effort CQE drain (the ring holds at most its 256 entries,
-        // and the slow path keeps a single write in flight). Mirrors the
-        // `ring.completion().next()` idiom used by `io_uring_write`.
-        let mut drained = 0;
-        while drained < 4096 && ring.completion().next().is_some() {
-            drained += 1;
-        }
-    }
     *mode = WriteMode::SyncFallback;
 }
 
@@ -846,42 +883,6 @@ pub(crate) fn write_packet_nonblocking(fd: i32, bytes: &[u8]) -> io::Result<()> 
         // write is one packet, never a partial-offset resubmit.
         unsafe { libc::write(fd, bytes.as_ptr().cast::<libc::c_void>(), buf_len) }
     })
-}
-
-fn write_packet_io_uring(
-    ring: &mut IoUring,
-    fd: i32,
-    bytes: &[u8],
-) -> Result<(), crate::io_uring_write::WriteError> {
-    // Stream write to the TUN device (no file offset). The shared loop retries
-    // the wait on EINTR rather than abandoning an in-flight SQE, matches the
-    // completion by user_data so a stale CQE cannot corrupt the offset, and
-    // returns only after the matching CQE is reaped so `bytes` outlives every
-    // kernel reference (#2297).
-    crate::io_uring_write::write_all_to_fd(ring, fd, bytes, false, "slow-path")
-}
-
-/// The #2477 fallback DECISION, factored out so it is unit-testable without a
-/// live io_uring ring or TUN fd. Given the io_uring write `result` and a
-/// `sync_fallback` thunk, only invokes the synchronous fallback when the
-/// io_uring failure transferred NOTHING (`safe_to_retry`). A partial transfer —
-/// or an ambiguous in-flight error — drops the packet so the whole frame is
-/// never re-sent on top of bytes already on the TUN.
-fn decide_sync_fallback<F>(
-    result: Result<(), crate::io_uring_write::WriteError>,
-    sync_fallback: F,
-) -> Result<(), String>
-where
-    F: FnOnce() -> Result<(), String>,
-{
-    match result {
-        Ok(()) => Ok(()),
-        Err(err) if err.safe_to_retry() => sync_fallback(),
-        // Bytes are (or may be) already on the TUN — re-sending would
-        // double-transmit / corrupt the device. Drop the packet (the caller
-        // counts it as a write error + drop).
-        Err(err) => Err(err.to_string()),
-    }
 }
 
 pub(crate) fn open_tun(name: &str) -> Result<(std::fs::File, String), String> {

--- a/userspace-dp/src/slowpath_tests.rs
+++ b/userspace-dp/src/slowpath_tests.rs
@@ -784,25 +784,26 @@ fn ifreq_carries_mtu_value() {
     assert_eq!(ifr.name_string(), "xpf-usp0");
 }
 
-use crate::io_uring_write::WriteError;
+use crate::io_uring_write::WriteResult;
 use std::cell::Cell;
 
-/// #2477 fail-on-revert: a PARTIAL io_uring write (`WriteError::Transferred`)
-/// already placed bytes on the packet-oriented TUN. The fallback decision
-/// MUST NOT invoke the synchronous write — doing so re-sends the whole frame
-/// on top of the truncated one (truncated + duplicate delivery).
+/// #2477 fail-on-revert: a PARTIAL io_uring write (`WriteResult::Transferred`)
+/// already placed bytes on the packet-oriented TUN. Classification MUST NOT
+/// invoke the synchronous write — doing so re-sends the whole frame on top of
+/// the truncated one (truncated + duplicate delivery).
 ///
 /// The sync-fallback thunk records whether it ran. With the old behaviour
-/// (`io_uring().or_else(|_| sync)` — i.e. sync on ANY error), the thunk would
-/// fire for this partial and the assertions below fail.
+/// (sync on ANY error), the thunk would fire for this partial and the assertions
+/// below fail.
 #[test]
 fn partial_iouring_write_does_not_sync_fallback() {
     let sync_ran = Cell::new(false);
-    let res = decide_sync_fallback(
-        Err(WriteError::Transferred(
+    let outcome = classify_io_uring_write(
+        WriteResult::Transferred(
+            vec![0u8; 1400],
             "slow-path io_uring short write on packet fd: wrote 40 of 1400 bytes".to_string(),
-        )),
-        || {
+        ),
+        |_b| {
             sync_ran.set(true);
             Ok(())
         },
@@ -813,44 +814,54 @@ fn partial_iouring_write_does_not_sync_fallback() {
              packet on top of the bytes already on the TUN double-transmits (#2477)"
     );
     assert!(
-        res.is_err(),
+        outcome.result.is_err(),
         "the partial packet must be DROPPED (Err), not silently succeeded"
+    );
+    assert!(
+        !outcome.ring_terminal,
+        "a reaped partial is a packet anomaly, not a ring death — keep io_uring"
     );
 }
 
-/// #2477 fail-on-revert: an ambiguous reap error where the SQE may be in
-/// flight is also `Transferred` — never sync-retry (could double-transmit).
+/// #5800: an ambiguous reap where the SQE may still be in flight is now a
+/// `Deferred` (the owned buffer is parked in the ring's registry, not handed
+/// back) — never sync-retry (the buffer is no longer ours and a re-send could
+/// double-transmit).
 #[test]
 fn ambiguous_reap_error_does_not_sync_fallback() {
     let sync_ran = Cell::new(false);
-    let res = decide_sync_fallback(
-        Err(WriteError::Transferred(
-            "slow-path io_uring submit/wait: some wait error".to_string(),
-        )),
-        || {
+    let outcome = classify_io_uring_write(
+        WriteResult::Deferred {
+            id: 7,
+            message: "slow-path io_uring wait interrupted repeatedly (4096 EINTR)".to_string(),
+            fatal_ring: false,
+        },
+        |_b| {
             sync_ran.set(true);
             Ok(())
         },
     );
     assert!(
         !sync_ran.get(),
-        "an in-flight-ambiguous error must not sync-retry"
+        "an in-flight-ambiguous (deferred) error must not sync-retry"
     );
-    assert!(res.is_err());
+    assert!(outcome.result.is_err());
 }
 
-/// Complement: a ZERO-byte io_uring failure (`WriteError::NothingWritten`)
-/// put nothing on the TUN, so the synchronous fallback MUST run — the packet
-/// is still deliverable and dropping it would be a regression.
+/// Complement: a ZERO-byte io_uring failure (`WriteResult::NothingWritten`) put
+/// nothing on the TUN, so the synchronous fallback MUST run from the handed-back
+/// buffer — the packet is still deliverable and dropping it would be a regression.
 #[test]
 fn zero_byte_iouring_failure_does_sync_fallback() {
     let sync_ran = Cell::new(false);
-    let res = decide_sync_fallback(
-        Err(WriteError::NothingWritten(
+    let outcome = classify_io_uring_write(
+        WriteResult::NothingWritten(
+            vec![0u8; 64],
             "slow-path io_uring write failed: Input/output error".to_string(),
-        )),
-        || {
+        ),
+        |b| {
             sync_ran.set(true);
+            assert_eq!(b.len(), 64, "the handed-back buffer feeds the sync retry");
             Ok(())
         },
     );
@@ -859,7 +870,7 @@ fn zero_byte_iouring_failure_does_sync_fallback() {
         "a zero-byte io_uring failure transferred nothing — sync-retry MUST run"
     );
     assert!(
-        res.is_ok(),
+        outcome.result.is_ok(),
         "the sync fallback succeeded, so the result is Ok"
     );
 }
@@ -868,7 +879,7 @@ fn zero_byte_iouring_failure_does_sync_fallback() {
 #[test]
 fn successful_iouring_write_skips_sync_fallback() {
     let sync_ran = Cell::new(false);
-    let res = decide_sync_fallback(Ok(()), || {
+    let outcome = classify_io_uring_write(WriteResult::Done(vec![0u8; 4]), |_b| {
         sync_ran.set(true);
         Ok(())
     });
@@ -876,7 +887,7 @@ fn successful_iouring_write_skips_sync_fallback() {
         !sync_ran.get(),
         "a successful io_uring write must not sync-retry"
     );
-    assert!(res.is_ok());
+    assert!(outcome.result.is_ok());
 }
 
 // ── #5172: io_uring WriteMode must DEMOTE to SyncFallback after a TERMINAL
@@ -884,35 +895,38 @@ fn successful_iouring_write_skips_sync_fallback() {
 // broken ring (which degrades BGP/OSPF/mgmt/local traffic). Mirrors the
 // state_writer #2958 runtime-demotion, adding a terminal-vs-transient split. ──
 
-/// #5172: `classify_io_uring_write` separates packet-transfer certainty from
-/// ring health. A TERMINAL (ambiguous / wedged) io_uring failure — `Transferred`,
-/// NOT `safe_to_retry` — must (a) flag `ring_terminal` so the loop demotes, and
-/// (b) DROP the packet WITHOUT invoking the sync fallback (the current ambiguous
-/// packet may be in flight; re-sending it would double-transmit — NO-RETRY).
+/// #5172 + #5800: `classify_io_uring_write` separates packet-transfer certainty
+/// from ring health. A FATAL ring — `WriteResult::Deferred { fatal_ring: true }`,
+/// the owned buffer parked in the registry pending teardown — must (a) flag
+/// `ring_terminal` so the loop demotes, and (b) DROP the packet WITHOUT invoking
+/// the sync fallback (the deferred write may be in flight and the buffer is
+/// retained by the ring — re-sending would double-transmit, NO-RETRY).
 #[test]
 fn classify_terminal_ring_failure_flags_demote_and_does_not_resend() {
     let sync_ran = Cell::new(false);
     let outcome = classify_io_uring_write(
-        Err(WriteError::Transferred(
-            "slow-path io_uring submit/wait: ring wedged".to_string(),
-        )),
-        || {
+        WriteResult::Deferred {
+            id: 3,
+            message: "slow-path io_uring permanent submit/wait error: EBADF".to_string(),
+            fatal_ring: true,
+        },
+        |_b| {
             sync_ran.set(true);
             Ok(())
         },
     );
     assert!(
         outcome.ring_terminal,
-        "an ambiguous/wedged io_uring failure must be classified TERMINAL so the \
-         worker demotes to sync (#5172)"
+        "a fatal io_uring ring failure must be classified TERMINAL so the worker \
+         demotes to sync (#5172)"
     );
     assert!(
         !sync_ran.get(),
-        "the current ambiguous packet must NOT be sync-resent (no double-transmit)"
+        "the deferred (in-flight) packet must NOT be sync-resent (no double-transmit)"
     );
     assert!(
         outcome.result.is_err(),
-        "the ambiguous packet is dropped (no-retry), so the result is Err"
+        "the deferred packet is dropped (no-retry), so the result is Err"
     );
     assert!(
         outcome.demotion_cause.is_some(),
@@ -921,24 +935,25 @@ fn classify_terminal_ring_failure_flags_demote_and_does_not_resend() {
 }
 
 /// #5172 (complement / #2477 preserved): a TRANSIENT io_uring failure —
-/// `NothingWritten`, `safe_to_retry` — put nothing on the TUN, so the per-call
-/// sync fallback rescues THIS packet and the ring is NOT demoted (do not abandon
-/// io_uring on a momentary blip). `ring_terminal` must be false.
+/// `NothingWritten` — put nothing on the TUN, so the per-call sync fallback
+/// rescues THIS packet and the ring is NOT demoted (do not abandon io_uring on a
+/// momentary blip). `ring_terminal` must be false.
 #[test]
 fn classify_transient_ring_failure_keeps_iouring_and_rescues_packet() {
     let sync_ran = Cell::new(false);
     let outcome = classify_io_uring_write(
-        Err(WriteError::NothingWritten(
+        WriteResult::NothingWritten(
+            vec![0u8; 128],
             "slow-path io_uring write failed: Input/output error".to_string(),
-        )),
-        || {
+        ),
+        |_b| {
             sync_ran.set(true);
             Ok(())
         },
     );
     assert!(
         !outcome.ring_terminal,
-        "a safe-to-retry io_uring failure is TRANSIENT — keep io_uring, do not demote"
+        "a nothing-written io_uring failure is TRANSIENT — keep io_uring, do not demote"
     );
     assert!(
         sync_ran.get(),
@@ -948,10 +963,42 @@ fn classify_transient_ring_failure_keeps_iouring_and_rescues_packet() {
     assert!(outcome.demotion_cause.is_none());
 }
 
+/// #5800 fail-on-revert: a NON-fatal retry-ceiling deferral drops the packet but
+/// KEEPS io_uring — the ring is otherwise healthy and the parked buffer is
+/// reclaimed on a later write's reap. `ring_terminal` must be false, the sync
+/// fallback must NOT run, and no demotion cause is recorded. Neutralising the
+/// `ring_terminal: fatal_ring` line in `classify_io_uring_write` (e.g. hardcoding
+/// `true`) would demote on every EINTR storm, turning this RED.
+#[test]
+fn classify_nonfatal_deferral_keeps_iouring_and_drops_packet() {
+    let sync_ran = Cell::new(false);
+    let outcome = classify_io_uring_write(
+        WriteResult::Deferred {
+            id: 9,
+            message: "slow-path io_uring wait interrupted repeatedly (4096 EINTR)".to_string(),
+            fatal_ring: false,
+        },
+        |_b| {
+            sync_ran.set(true);
+            Ok(())
+        },
+    );
+    assert!(
+        !outcome.ring_terminal,
+        "a bare EINTR-ceiling storm is not a fatal ring — keep io_uring (#5800)"
+    );
+    assert!(!sync_ran.get(), "a deferred packet is not sync-resent");
+    assert!(outcome.result.is_err(), "the deferred packet is dropped");
+    assert!(
+        outcome.demotion_cause.is_none(),
+        "no demotion on a non-fatal deferral"
+    );
+}
+
 /// #5172: a successful io_uring write is healthy — no demotion, no cause.
 #[test]
 fn classify_successful_write_is_healthy() {
-    let outcome = classify_io_uring_write(Ok(()), || Ok(()));
+    let outcome = classify_io_uring_write(WriteResult::Done(vec![0u8; 4]), |_b| Ok(()));
     assert!(!outcome.ring_terminal);
     assert!(outcome.result.is_ok());
     assert!(outcome.demotion_cause.is_none());
@@ -970,7 +1017,7 @@ fn terminal_ring_failure_demotes_write_mode_to_sync() {
     // that state. If the kernel cannot provide a ring (older CI), the demotion
     // path is unreachable — skip rather than give a false pass (mirrors the
     // state_writer #2958 demotion test).
-    let ring = match IoUring::new(256) {
+    let ring = match crate::io_uring_write::RingWriter::new(256) {
         Ok(r) => r,
         Err(_) => {
             eprintln!("io_uring unavailable on this kernel; skipping demotion test");
@@ -1030,7 +1077,7 @@ fn terminal_ring_failure_demotes_write_mode_to_sync() {
 /// momentary blip, which this catches (mode must stay IoUring).
 #[test]
 fn transient_outcome_does_not_demote_write_mode() {
-    let ring = match IoUring::new(256) {
+    let ring = match crate::io_uring_write::RingWriter::new(256) {
         Ok(r) => r,
         Err(_) => {
             eprintln!("io_uring unavailable on this kernel; skipping no-demote test");

--- a/userspace-dp/src/state_writer.rs
+++ b/userspace-dp/src/state_writer.rs
@@ -1,4 +1,4 @@
-use io_uring::IoUring;
+use crate::io_uring_write::{RingWriter, WriteResult};
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
 use std::io;
@@ -157,7 +157,7 @@ fn instance_is_alive(inst: ProcInstance) -> bool {
 }
 
 enum WriteMode {
-    IoUring(IoUring),
+    IoUring(RingWriter),
     SyncFallback,
 }
 
@@ -194,7 +194,7 @@ impl StateWriter {
         thread::Builder::new()
             .name("xpf-state-writer".to_string())
             .spawn(move || {
-                let mut write_mode = match IoUring::new(8) {
+                let mut write_mode = match RingWriter::new(8) {
                     Ok(ring) => {
                         active_bg.store(true, Ordering::Relaxed);
                         if let Ok(mut m) = mode_bg.lock() {
@@ -224,7 +224,7 @@ impl StateWriter {
                     if swept.insert(req.path.clone()) {
                         sweep_stale_temps(&req.path);
                     }
-                    let outcome = persist_with_mode(&mut write_mode, &req.path, &req.data);
+                    let outcome = persist_with_mode(&mut write_mode, &req.path, req.data);
                     let result = apply_outcome(
                         outcome,
                         &mut write_mode,
@@ -287,20 +287,22 @@ struct PersistOutcome {
     demotion_cause: Option<String>,
 }
 
-fn persist_with_mode(mode: &mut WriteMode, path: &str, data: &[u8]) -> PersistOutcome {
+fn persist_with_mode(mode: &mut WriteMode, path: &str, data: Vec<u8>) -> PersistOutcome {
     match mode {
         WriteMode::IoUring(ring) => match persist_with_io_uring(ring, path, data) {
-            Ok(()) => PersistOutcome {
+            IoUringPersist::Done => PersistOutcome {
                 result: Ok(()),
                 io_uring_failed: false,
                 demotion_cause: None,
             },
-            Err(ring_err) => {
-                // io_uring failed at runtime. Fall back to a sync write for THIS
-                // request, but flag the failure so the writer loop demotes the
-                // mode persistently (status + no future ring attempts).
+            IoUringPersist::Retry(bytes, ring_err) => {
+                // io_uring failed but nothing durable landed AND the buffer was
+                // handed back (a reaped terminal failure). Fall back to a sync
+                // write to a FRESH temp for THIS request from the returned buffer,
+                // and flag the failure so the writer loop demotes the mode
+                // persistently (status + no future ring attempts).
                 let cause = format!("io_uring write failed, demoting to sync: {ring_err}");
-                let result = persist_sync(path, data)
+                let result = persist_sync(path, &bytes)
                     .map_err(|sync_err| format!("{ring_err}; {sync_err}"));
                 PersistOutcome {
                     result,
@@ -308,9 +310,25 @@ fn persist_with_mode(mode: &mut WriteMode, path: &str, data: &[u8]) -> PersistOu
                     demotion_cause: Some(cause),
                 }
             }
+            IoUringPersist::Deferred(ring_err) => {
+                // The write did NOT reach a terminal state: its buffer is RETAINED
+                // in the ring's in-flight registry (never freed while an SQE may
+                // reference it, #5800) and cannot be synchronously retried — the
+                // buffer is no longer ours and the op may be in flight. Fail this
+                // write and demote; dropping the RingWriter on demotion runs the
+                // teardown drain and closes the ring fd, which is what frees the
+                // parked buffer safely.
+                let cause =
+                    format!("io_uring write deferred (buffer retained), demoting to sync: {ring_err}");
+                PersistOutcome {
+                    result: Err(cause.clone()),
+                    io_uring_failed: true,
+                    demotion_cause: Some(cause),
+                }
+            }
         },
         WriteMode::SyncFallback => PersistOutcome {
-            result: persist_sync(path, data),
+            result: persist_sync(path, &data),
             io_uring_failed: false,
             demotion_cause: None,
         },
@@ -369,7 +387,28 @@ fn apply_outcome(
     outcome.result
 }
 
-fn persist_with_io_uring(ring: &mut IoUring, path: &str, data: &[u8]) -> Result<(), String> {
+/// Outcome of one io_uring state-file write attempt (#5800). Distinguishes a
+/// reaped TERMINAL failure whose buffer was handed back (safe to sync-retry to a
+/// FRESH temp) from a DEFERRED write whose buffer the ring RETAINED in its
+/// in-flight registry (must NOT sync-retry — the op may be in flight and the
+/// buffer is no longer ours to re-send).
+enum IoUringPersist {
+    /// The write completed and the temp was durably finalized.
+    Done,
+    /// The io_uring path failed (submit error, kernel completion error, zero-byte
+    /// completion, id-space exhaustion, temp-open failure, or a durable-finalize
+    /// failure) but transferred nothing durable AND handed the owned buffer back.
+    /// The buffer feeds a synchronous rewrite to a fresh temp. Carries
+    /// (buffer, cause).
+    Retry(Vec<u8>, String),
+    /// The write did NOT reach a reaped terminal state: the owned buffer has been
+    /// MOVED into the ring's in-flight registry (retained until its CQE is reaped
+    /// or the ring is torn down and drained). The write FAILS — no sync retry (the
+    /// buffer is gone and the SQE may still be in flight). Carries the cause.
+    Deferred(String),
+}
+
+fn persist_with_io_uring(ring: &mut RingWriter, path: &str, data: Vec<u8>) -> IoUringPersist {
     // Each write gets a PRIVATE temp path (pid + monotonic counter), created
     // with O_EXCL so two concurrent writers — even different helper processes
     // racing the same destination during a restart/upgrade handover — can never
@@ -377,16 +416,59 @@ fn persist_with_io_uring(ring: &mut IoUring, path: &str, data: &[u8]) -> Result<
     // publishes onto `path` (last-writer-wins on the final file is acceptable;
     // crossed bytes under a successful rename are not, #2705).
     let tmp = temporary_path(path);
-    let file = OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .open(&tmp)
-        .map_err(|e| format!("open temp state file {}: {e}", tmp.display()))?;
-    let result = (|| {
-        write_all_with_ring(ring, file.as_raw_fd(), data)?;
-        finalize_durably(&file, &tmp, path)
-    })();
-    cleanup_on_error(&tmp, result)
+    let file = match OpenOptions::new().create_new(true).write(true).open(&tmp) {
+        Ok(f) => f,
+        Err(e) => {
+            // The temp was never created — nothing is on disk and the buffer is
+            // intact, so hand it back for a synchronous retry.
+            return IoUringPersist::Retry(
+                data,
+                format!("open temp state file {}: {e}", tmp.display()),
+            );
+        }
+    };
+    // The owned buffer MOVES into the ring. A positioned (file-offset) byte-stream
+    // write: a short count legitimately resumes from `offset + n`, so a partial is
+    // never `Transferred` here. On a Deferred outcome the ring RETAINS the buffer
+    // (never freed while an SQE may reference it, #5800).
+    match ring.write(file.as_raw_fd(), data, true, "state") {
+        WriteResult::Done(bytes) => {
+            // The bytes are on the temp file and the write CQE was reaped. Apply
+            // the durability contract (fsync + rename + parent-dir fsync). A
+            // finalize failure hands the buffer back so the sync fallback can
+            // rewrite a fresh temp.
+            match finalize_durably(&file, &tmp, path) {
+                Ok(()) => IoUringPersist::Done,
+                Err(e) => {
+                    let _ = fs::remove_file(&tmp);
+                    IoUringPersist::Retry(bytes, e)
+                }
+            }
+        }
+        WriteResult::NothingWritten(bytes, msg) => {
+            // Nothing reached the temp — discard it and hand the buffer back.
+            let _ = fs::remove_file(&tmp);
+            IoUringPersist::Retry(bytes, msg)
+        }
+        WriteResult::Transferred(bytes, msg) => {
+            // Unreachable for a positioned write (a short count resumes via the
+            // offset, never `Transferred`). Handle defensively: the CQE was reaped
+            // (buffer terminal), the partial temp is discarded, and a sync rewrite
+            // to a fresh temp is safe.
+            let _ = fs::remove_file(&tmp);
+            IoUringPersist::Retry(bytes, msg)
+        }
+        WriteResult::Deferred { id, message, .. } => {
+            // The write did not reach a terminal state and its buffer is parked in
+            // the ring's registry (retained, not freed); `id` identifies the
+            // parked write for teardown correlation. Discard the partial temp; do
+            // NOT sync-retry (the buffer is gone and the op may be in flight). The
+            // caller demotes to sync, which drops the RingWriter (teardown drain +
+            // ring-fd close) and frees the parked buffer safely.
+            let _ = fs::remove_file(&tmp);
+            IoUringPersist::Deferred(format!("{message} (in-flight id {id}, buffer retained)"))
+        }
+    }
 }
 
 fn persist_sync(path: &str, data: &[u8]) -> Result<(), String> {
@@ -448,19 +530,6 @@ fn sync_parent_dir(dest: &str) -> Result<(), String> {
         File::open(dir).map_err(|e| format!("open parent dir {} for fsync: {e}", dir.display()))?;
     sync_all(&dir_file).map_err(|e| format!("fsync parent dir {}: {e}", dir.display()))?;
     Ok(())
-}
-
-fn write_all_with_ring(ring: &mut IoUring, fd: i32, data: &[u8]) -> Result<(), String> {
-    // Positioned write to the temp state file. The shared loop retries the wait
-    // on EINTR rather than abandoning an in-flight SQE, matches the completion
-    // by user_data so a stale CQE cannot corrupt the file offset, and returns
-    // only after the matching CQE is reaped so `data` outlives every kernel
-    // reference (#2297).
-    // The state writer is a positioned (byte-stream) write with no synchronous
-    // fallback, so it does not consume the `WriteError` retry-safety
-    // classification (#2477) — collapse it to the error message.
-    crate::io_uring_write::write_all_to_fd(ring, fd, data, true, "state")
-        .map_err(|e| e.to_string())
 }
 
 /// Process-global monotonic counter that makes every temp path produced by this

--- a/userspace-dp/src/state_writer_tests.rs
+++ b/userspace-dp/src/state_writer_tests.rs
@@ -622,7 +622,7 @@ fn runtime_io_uring_failure_demotes_to_sync_permanently() {
     // ring (older CI), the demotion path is unreachable, so skip rather than
     // give a false pass — production always starts in io_uring when a ring
     // is available, which is the scenario this regression guards.
-    let ring = match IoUring::new(8) {
+    let ring = match crate::io_uring_write::RingWriter::new(8) {
         Ok(r) => r,
         Err(_) => {
             eprintln!("io_uring unavailable on this kernel; skipping demotion test");
@@ -673,7 +673,7 @@ fn runtime_io_uring_failure_demotes_to_sync_permanently() {
     // the sync branch (io_uring_failed=false) and actually persists. With
     // the demotion reverted, `mode` would still be IoUring here and this
     // write would route through the ring.
-    let next = persist_with_mode(&mut mode, &dest_str, b"after demotion");
+    let next = persist_with_mode(&mut mode, &dest_str, b"after demotion".to_vec());
     assert!(next.result.is_ok(), "post-demotion write must succeed");
     assert!(
         !next.io_uring_failed,


### PR DESCRIPTION
## Summary

- Closes a retry-ceiling / fatal-ring **use-after-free** in the shared io_uring
  write loop (`userspace-dp/src/io_uring_write.rs`). `write_all` submitted a
  Write SQE that borrowed the caller's slice, but `reap_matching` returned after
  `MAX_WAIT_RETRIES` interrupted/transient waits **without** proving the matching
  CQE was reaped or the SQE cancelled. The slow-path caller then freed
  `req.bytes` while the kernel might still dereference that address → packet-data
  disclosure/corruption, helper crash, or UB under sustained signal/error
  pressure. The per-call `user_data` also restarted at `1`, so an abandoned
  completion could alias a later call's CQE.
- **Move ownership instead of weakening lifetime.** `write_all` now takes the
  buffer **by value** and every submission draws a **ring-global monotonic**
  `user_data` from an `InflightRegistry` (fail-closed on wrap). On retry-ceiling
  exhaustion or a fatal OS error it returns `WriteResult::Deferred` **only after**
  moving the owned buffer into the registry (a `Vec` move preserves the heap
  address the SQE points at). The buffer is never freed while an SQE may
  reference it.
- A deferred buffer is released only on **one terminal state**: its matching
  write CQE is reaped (opportunistically at the top of the next write), a bounded
  teardown drain cancels the op and observes **both** the cancel's completion AND
  the target write's terminal CQE, or the ring fd closes — `RingWriter` field
  order drops the ring (kernel cancel+wait) **before** the registry frees buffers.
- Applied to **both** callers: slow-path TUN packet writes (`slowpath.rs`) and
  positioned state-file writes (`state_writer.rs`).

## Invariants (issue = spec)

1. Never return while an in-flight SQE references caller-borrowed storage — the
   buffer is moved into the registry before `Deferred` returns. ✔
2. Release only after one terminal state (reaped CQE / cancel+target CQE /
   ring-teardown drain). ✔
3. `user_data` is ring-global and fail-closed on wrap (`alloc_id` returns `None`;
   `write_all` refuses to submit). ✔
4. Fatal-ring handling retains all in-flight buffers until teardown/registry drop
   (field order: ring fd closes before registry frees). ✔
5. The latency ceiling stops a synchronous waiter but does **not** free a
   possibly-referenced buffer. ✔

## Caller behaviour

- **Slow path**: `classify_io_uring_write` maps `Done` → injected,
  `NothingWritten` → sync-rescue from the handed-back buffer (ring stays live),
  `Transferred` → drop (reaped partial, ring healthy), `Deferred` → drop; only
  `Deferred { fatal_ring: true }` demotes to sync (dropping the `RingWriter` runs
  the teardown drain + closes the fd, freeing any parked buffer safely). A bare
  EINTR-ceiling `Deferred { fatal_ring: false }` keeps io_uring; the parked
  buffer is reclaimed on a later write's reap.
- **State writer**: a `Deferred` **fails** the persist (buffer parked, not
  sync-retried) and demotes; a `NothingWritten` or a durable-finalize failure
  hands the buffer back for a synchronous rewrite to a **fresh** temp (preserving
  the #2958 fallback for every reaped-terminal outcome).

## Scope note

No new **wire** counter was added: extending `protocol::control::SlowPathStatus`
would force regenerating the `protocol_wire_v1.json` golden fixture — a
wire-contract change out of scope for a UAF lifetime fix. "Slow-path status
distinguishes deferred / completed / cancelled / fatal-teardown" is satisfied by
the internal `SlowPathWriteOutcome` classification, the operator-visible
`last_error` (a `Deferred` now names the parked in-flight id), and the existing
drop / write-error counters.

## Test plan

- [x] `cargo test io_uring_write` — 25 tests, all green. Fail-on-revert tests
  drive the `#[cfg(test)]` FakeRing seam:
  - ceiling EINTR / transient EAGAIN / permanent EBADF all **DEFER** (buffer
    stays owned, `inflight_len == 1`), never free;
  - deferred buffer released on a later terminal completion;
  - teardown drain cancels and releases only on the **target write's** terminal
    CQE — a cancel-first race retains until then; the cancel's own completion
    alone does not release;
  - a **fatal ring cannot be drained** and RETAINS the buffer until registry drop;
  - stale CQEs are not misattributed; the id space fails closed on wrap.
- [x] Slow-path + state-writer caller tests migrated to `WriteResult`
  (`classify_*`, demotion, and a new non-fatal-deferral-keeps-io_uring test).
- [x] Full `userspace-dp` release suite green (4054 lib tests, 0 failed).
- [x] Primary regression (`eintr_ceiling_defers_buffer_not_freed`) run 5× —
  non-flaky.
- **Parent-RED recipe:** neutralize `reg.defer(slot)` → `drop(slot)` in
  `write_all`'s reap-error arm (a compiling change) → **9** registry-invariant
  tests go RED as clean assertion failures.
- Not run: cluster smoke. This changes only the retry-exhaustion / error branches
  of the io_uring write path (fatal-ring / EINTR-storm); the healthy write path
  (Done / short-write / EINTR-then-success) is behaviourally unchanged, and the
  logic is fully unit-provable via the ring seam.

Closes #5800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpL2Q1QFhLXrVFm7tcS28E
