### PR TITLE
cluster: gate manual failover on standby config generation (#5563)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54265,3 +54265,20 @@ top.
   - `userspace-dp/src/state_writer_tests.rs` (RingWriter construction)
   - `docs/xdp-io-uring-userspace-dataplane.md` (#5800 registry contract)
   - `docs/pr/5800-iouring-inflight-registry/plan.md` (plan + deviations)
+
+## 2026-07-21 — #5563 manual-failover config-generation staleness gate
+- **Timestamp**: 2026-07-21
+- **Action**: Gate manual/planned failover readiness on config-sync
+  generation so a config-stale standby is not promoted onto an older
+  policy set (fail-open after tightening, false-deny after loosening).
+  Added `lastRecvConfigGen` received high-water (recorded in the
+  `syncMsgConfig` handler before apply), carried it plus
+  `lastAppliedConfigGen` into `TransferReadinessSnapshot`
+  (`PeerConfigGen`/`AppliedConfigGen`), added `ConfigStale()` +
+  `ReadyForManualFailover` refusal + `Reason()` text, reset the received
+  mark alongside the applied mark in `resetRecvGen`. Planned/manual path
+  only; unplanned/crash path deliberately not gated.
+- **File(s)**: `pkg/cluster/sync.go`, `pkg/cluster/sync_conn.go`,
+  `pkg/cluster/sync_bulk.go`,
+  `pkg/cluster/sync_failover_config_gen_test.go` (new),
+  `docs/sync-protocol.md`, `docs/ha-failover-status.md`

--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -54,6 +54,16 @@ yet. Here is what is true today:
 - Planned failover decoupled from bulk sync (PR #407) — barrier ack
   proves peer is current, no bulk-sync gate
 - Transfer readiness surfaced separately from takeover readiness (PR #402)
+- Manual/planned failover refuses a config-stale standby (#5563): transfer
+  readiness now also gates on the config-sync generation. A standby that has
+  received a newer config generation from the primary than it has successfully
+  applied (`PeerConfigGen > AppliedConfigGen` in `TransferReadinessSnapshot`) is
+  reported not transfer-ready, so `request chassis cluster failover` will not
+  promote it onto a stale policy set (fail-open after a tightening commit,
+  false-deny after a loosening one). A legitimate same-generation failover still
+  proceeds; the unplanned/crash path is not gated. Surfaced in
+  `show chassis cluster status` transfer-readiness reason as "standby config
+  stale: applied gen=N behind peer committed gen=M"
 - HA configs that use per-pool source NAT `persistent-nat` are not admitted to
   userspace forwarding because persistent-NAT leases are helper-local allocator
   state and are not HA-synchronized (#1449)

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -415,6 +415,32 @@ monotonic counter restarts lower — is accepted instead of refused as stale
 config after a reconnect is always the peer's *current* config
 (`pushConfigToPeer` sends `ShowActive`), so the newest content still wins.
 
+**Manual-failover config-staleness gate (#5563).** A second high-water mark,
+`lastRecvConfigGen`, records the highest generation this node has *received*
+from the peer (advanced in the `syncMsgConfig` handler at enqueue, BEFORE
+apply, even if the ordered apply queue is full and the payload is dropped). It
+is the receiver's local view of the config *sender's* current committed
+generation. `TransferReadiness` carries both marks (`PeerConfigGen =
+lastRecvConfigGen`, `AppliedConfigGen = lastAppliedConfigGen`), and
+`ReadyForManualFailover` refuses promotion when `PeerConfigGen >
+AppliedConfigGen` — i.e. the standby has received a newer config than it has
+successfully applied. Promoting a config-stale standby runs an OLDER
+policy/zone/application snapshot than the operator committed: **fail-open** after
+a tightening commit (admits traffic the operator denied) and **false-deny** after
+a loosening commit (drops traffic the operator allowed). The gate is scoped to
+this genuine behind-the-primary case: a legitimate same-generation failover
+(`applied == received`) stays ready, and a legacy/fresh peer (both marks 0) is
+never blocked. `resetRecvGen` zeroes `lastRecvConfigGen` alongside
+`lastAppliedConfigGen`, so the `applied <= received` invariant holds across a
+reconnect re-prime. This is a **planned/manual** readiness gate only; the
+UNPLANNED/crash failover path is not gated (a stale-standby crash-takeover is a
+separate availability-vs-security tradeoff — the alternative is a total outage).
+The residual window is narrow: a config committed on the primary but whose
+`syncMsgConfig` frame has not yet reached the standby is not yet reflected in
+`lastRecvConfigGen`, so a promotion in that sub-millisecond window still sees the
+prior generation — a strict improvement over the pre-#5563 behavior, which never
+checked config generation at all.
+
 **Wire compatibility.** #3931 deliberately does NOT bump
 `SessionSyncWireVersion`: the framing is additive and self-detecting via the
 magic, and that gate governs whether SESSIONS sync at all across a mixed-base

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -220,6 +220,16 @@ type SyncStatsSnapshot struct {
 
 // TransferReadinessSnapshot captures session-sync state that determines whether
 // manual failover can proceed without depending on bootstrap timing.
+//
+// #5563: it also carries the config-sync generations so a planned/manual
+// failover refuses to promote a config-stale standby. PeerConfigGen is the
+// highest config generation this node has RECEIVED from the peer (the config
+// sender's current committed generation as observed by the receiver);
+// AppliedConfigGen is the highest generation this node has SUCCESSFULLY
+// applied. When PeerConfigGen > AppliedConfigGen the standby is running an
+// older policy/zone/application snapshot than the primary committed —
+// promoting it fail-opens after a tightening commit and false-denies after a
+// loosening commit.
 type TransferReadinessSnapshot struct {
 	Connected             bool
 	PendingBulkAckEpoch   uint64
@@ -227,12 +237,29 @@ type TransferReadinessSnapshot struct {
 	BulkReceiveInProgress bool
 	BulkReceiveEpoch      uint64
 	BulkReceiveSessions   int
+	PeerConfigGen         uint64
+	AppliedConfigGen      uint64
+}
+
+// ConfigStale reports whether this node has received a newer config generation
+// from the peer than it has successfully applied — i.e. it is behind the
+// primary's committed config. A legacy peer (or a fresh node that has neither
+// received nor applied any generation) reports both generations as 0, which is
+// NOT stale, so the gate stays scoped to the genuine behind-the-primary case
+// and never blanket-blocks (#5563).
+func (s TransferReadinessSnapshot) ConfigStale() bool {
+	return s.PeerConfigGen > s.AppliedConfigGen
 }
 
 // ReadyForManualFailover reports whether the sync path is settled enough to
 // use as a manual-failover transport without waiting for bootstrap work.
+//
+// #5563: a standby that has received a newer config generation than it has
+// applied is refused — a planned/manual promotion must not run a stale
+// security policy. The unplanned/crash failover path is a separate
+// availability-vs-security tradeoff and is NOT gated here.
 func (s TransferReadinessSnapshot) ReadyForManualFailover() bool {
-	return s.PendingBulkAckEpoch == 0 && !s.BulkReceiveInProgress
+	return s.PendingBulkAckEpoch == 0 && !s.BulkReceiveInProgress && !s.ConfigStale()
 }
 
 // Reason explains the current transfer-readiness blocker, if any.
@@ -246,6 +273,8 @@ func (s TransferReadinessSnapshot) Reason() string {
 		return fmt.Sprintf("peer still receiving outbound bulk epoch=%d age=%s", s.PendingBulkAckEpoch, age.Round(100*time.Millisecond))
 	case s.BulkReceiveInProgress:
 		return fmt.Sprintf("local bulk receive still in progress epoch=%d sessions=%d", s.BulkReceiveEpoch, s.BulkReceiveSessions)
+	case s.ConfigStale():
+		return fmt.Sprintf("standby config stale: applied gen=%d behind peer committed gen=%d", s.AppliedConfigGen, s.PeerConfigGen)
 	default:
 		return ""
 	}
@@ -495,7 +524,16 @@ type SessionSync struct {
 	// config).
 	configGenCounter     atomic.Uint64
 	lastAppliedConfigGen atomic.Uint64
-	configApplyCh        chan configApplyItem
+	// lastRecvConfigGen is the highest config generation this node has RECEIVED
+	// from the peer (recorded at enqueue in the syncMsgConfig handler, BEFORE
+	// apply). It is the receiver's local view of the config sender's current
+	// committed generation and is the high-water the manual-failover readiness
+	// gate compares against lastAppliedConfigGen (#5563). Reset to 0 alongside
+	// lastAppliedConfigGen on a peer bulk re-prime (resetRecvGen) so the
+	// applied<=received invariant holds after a reboot restarts the sender's
+	// monotonic counter lower.
+	lastRecvConfigGen atomic.Uint64
+	configApplyCh     chan configApplyItem
 
 	// #5706 full-set state-sync ordering guard (IPsec SA + DHCP leases).
 	//
@@ -698,6 +736,7 @@ func (s *SessionSync) initGenState() {
 	// next commit/reconnect re-push (see the syncMsgConfig handler).
 	s.configGenCounter.Store(seed)
 	s.lastAppliedConfigGen.Store(0)
+	s.lastRecvConfigGen.Store(0)
 	s.configApplyCh = make(chan configApplyItem, 64)
 	// #5706: the full-set (IPsec/DHCP) ordering incarnation is this process's
 	// construction seed — constant for the process lifetime and, within a boot,

--- a/pkg/cluster/sync_bulk.go
+++ b/pkg/cluster/sync_bulk.go
@@ -216,7 +216,9 @@ func (s *SessionSync) PendingBulkAck() (epoch uint64, age time.Duration, ok bool
 }
 
 // TransferReadiness snapshots the sync state that makes manual failover
-// timing-sensitive: an unacked outbound bulk or an in-progress inbound bulk.
+// timing-sensitive: an unacked outbound bulk, an in-progress inbound bulk, or
+// (#5563) a config-stale standby that has received a newer config generation
+// from the peer than it has successfully applied.
 func (s *SessionSync) TransferReadiness() TransferReadinessSnapshot {
 	snap := TransferReadinessSnapshot{
 		Connected: s.stats.Connected.Load(),
@@ -230,6 +232,13 @@ func (s *SessionSync) TransferReadiness() TransferReadinessSnapshot {
 	snap.BulkReceiveEpoch = s.bulkRecvEpoch
 	snap.BulkReceiveSessions = len(s.bulkRecvV4) + len(s.bulkRecvV6)
 	s.bulkMu.Unlock()
+	// #5563: config-sync generations for the planned-failover staleness gate.
+	// PeerConfigGen is the highest generation received from the peer (its
+	// current committed config as observed here); AppliedConfigGen is the
+	// highest generation successfully applied. A receiver behind the primary
+	// (PeerConfigGen > AppliedConfigGen) is refused promotion.
+	snap.PeerConfigGen = s.lastRecvConfigGen.Load()
+	snap.AppliedConfigGen = s.lastAppliedConfigGen.Load()
 	return snap
 }
 

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -348,6 +348,11 @@ func (s *SessionSync) resetRecvGen() {
 	// CURRENT config (pushConfigToPeer sends ShowActive), so the newest
 	// content still wins.
 	s.lastAppliedConfigGen.Store(0)
+	// #5563: reset the received-config high-water alongside the applied mark so
+	// the manual-failover readiness gate's applied<=received invariant holds
+	// across the reset window. The reconnect re-push then re-establishes both
+	// (received on receive, applied on successful apply).
+	s.lastRecvConfigGen.Store(0)
 	// #5706: reset the full-set (IPsec/DHCP) ordering high-water marks for the
 	// same reason. A reconnecting peer that OS-rebooted restarts its monotonic
 	// incarnation LOWER; without this reset the guard would refuse its fresh
@@ -1730,6 +1735,17 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 		configText, gen := decodeConfigPayload(payload)
 		s.stats.LastConfigSyncSize.Store(uint64(len(configText)))
 		slog.Info("cluster sync: config received from peer", "size", len(configText), "gen", gen)
+		// #5563: advance the received-config high-water BEFORE enqueue. This is
+		// the receiver's view of the peer's current committed generation and
+		// gates manual-failover readiness against lastAppliedConfigGen. Record it
+		// even if the enqueue below drops the payload (queue full) so the standby
+		// stays flagged config-stale until the apply actually lands on a re-push.
+		// The receiveLoop is single-threaded per connection, so the load/store
+		// pair needs no CAS; guard on gen>current to keep it a monotonic max
+		// against a reordered older frame.
+		if gen > s.lastRecvConfigGen.Load() {
+			s.lastRecvConfigGen.Store(gen)
+		}
 		// #3931: enqueue onto the single-consumer ordered apply queue instead
 		// of spawning a racing `go OnConfigReceived`. The receiveLoop is
 		// single-threaded per connection, so this preserves receive order;

--- a/pkg/cluster/sync_failover_config_gen_test.go
+++ b/pkg/cluster/sync_failover_config_gen_test.go
@@ -1,0 +1,147 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5563 — planned/manual failover readiness must refuse a config-stale standby.
+//
+// Before this fix, TransferReadinessSnapshot.ReadyForManualFailover() was
+// defined SOLELY in terms of session bulk state (PendingBulkAckEpoch /
+// BulkReceiveInProgress). It carried NEITHER the config sender's current
+// committed generation NOR the receiver's successfully-applied generation, so a
+// standby could be promoted while running an OLDER policy/zone/application
+// snapshot than the primary committed: fail-open after a tightening commit,
+// false-deny after a loosening commit. These tests pin the config-generation
+// gate. They are written so that reverting the gate makes them RED as clean
+// assertion failures.
+
+// TestReadyForManualFailoverConfigStaleGate is the canonical fail-on-revert
+// pin. It binds the config-staleness term in
+// TransferReadinessSnapshot.ReadyForManualFailover() (the `!s.ConfigStale()`
+// conjunct in pkg/cluster/sync.go). Neutralizing that term — e.g. dropping
+// `&& !s.ConfigStale()` or forcing ConfigStale() to return false — turns the
+// "behind" assertion below from a refusal into a promotion, failing this test.
+func TestReadyForManualFailoverConfigStaleGate(t *testing.T) {
+	// Standby has RECEIVED a newer config generation from the peer than it has
+	// APPLIED: promoting it now would run the stale (pre-commit) policy.
+	behind := TransferReadinessSnapshot{PeerConfigGen: 7, AppliedConfigGen: 6}
+	if !behind.ConfigStale() {
+		t.Fatal("applied gen 6 behind peer committed gen 7 must report ConfigStale()=true")
+	}
+	if behind.ReadyForManualFailover() {
+		t.Fatal("config-stale standby (applied 6 < peer 7) must NOT be ready for manual failover")
+	}
+	if got := behind.Reason(); !strings.Contains(got, "config stale") {
+		t.Fatalf("blocker reason must explain config staleness, got %q", got)
+	}
+
+	// Control: a LEGITIMATE same-generation failover — the standby has applied
+	// everything the primary committed — must still be ready. The gate is
+	// scoped to the genuine behind-the-primary case, not a blanket block.
+	caughtUp := TransferReadinessSnapshot{PeerConfigGen: 7, AppliedConfigGen: 7}
+	if caughtUp.ConfigStale() {
+		t.Fatal("applied gen == peer committed gen must NOT be config-stale")
+	}
+	if !caughtUp.ReadyForManualFailover() {
+		t.Fatal("caught-up standby (applied 7 == peer 7) must remain ready — gate must not blanket-block")
+	}
+	if got := caughtUp.Reason(); got != "" {
+		t.Fatalf("caught-up standby must have no blocker reason, got %q", got)
+	}
+
+	// Control: a fresh node or a legacy (gen-0) peer reports both generations as
+	// 0, which is NOT stale — the config gate must not fire and strand it.
+	fresh := TransferReadinessSnapshot{}
+	if fresh.ConfigStale() {
+		t.Fatal("fresh/legacy standby (both gen 0) must NOT be config-stale")
+	}
+	if !fresh.ReadyForManualFailover() {
+		t.Fatal("fresh/legacy standby (both gen 0) must remain ready")
+	}
+}
+
+// TestReadyForManualFailoverConfigGateIndependentOfBulk proves the config gate
+// is an ADDITIONAL, independent blocker: a standby whose session bulk state is
+// fully settled is still refused when it is config-stale.
+func TestReadyForManualFailoverConfigGateIndependentOfBulk(t *testing.T) {
+	settledButStale := TransferReadinessSnapshot{
+		Connected:        true,
+		PeerConfigGen:    12,
+		AppliedConfigGen: 11,
+		// No pending bulk ack, no bulk receive in progress: session state is
+		// settled, so ONLY the config gate can block here.
+	}
+	if settledButStale.ReadyForManualFailover() {
+		t.Fatal("bulk-settled but config-stale standby must NOT be ready — config gate is independent of bulk state")
+	}
+}
+
+// TestTransferReadinessCarriesConfigGenerations drives the real receive path:
+// a config-sync message advances the received-config high-water
+// (lastRecvConfigGen) in the syncMsgConfig handler, and TransferReadiness()
+// surfaces it as PeerConfigGen alongside the applied high-water. Because the
+// apply loop is not running here, AppliedConfigGen stays behind, so the
+// snapshot must report not-ready. This binds both the receive-handler
+// high-water recording and the TransferReadiness() field population.
+func TestTransferReadinessCarriesConfigGenerations(t *testing.T) {
+	dp := &mockSweepDP{}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+
+	// Peer commits and pushes config generation 7. The receive handler records
+	// it as the received high-water (before apply).
+	ss.handleMessage(nil, syncMsgConfig, encodeConfigPayload("set system host-name node0\n", 7))
+
+	snap := ss.TransferReadiness()
+	if snap.PeerConfigGen != 7 {
+		t.Fatalf("TransferReadiness must report received config gen 7, got %d", snap.PeerConfigGen)
+	}
+	if snap.AppliedConfigGen != 0 {
+		t.Fatalf("no apply has completed, applied gen must be 0, got %d", snap.AppliedConfigGen)
+	}
+	if snap.ReadyForManualFailover() {
+		t.Fatal("standby that received gen 7 but applied 0 must NOT be ready for manual failover")
+	}
+	if got := snap.Reason(); !strings.Contains(got, "config stale") {
+		t.Fatalf("reason must explain config staleness, got %q", got)
+	}
+
+	// Once the apply lands (high-water advances to the received generation), the
+	// standby is config-caught-up and readiness returns.
+	ss.recordAppliedConfigGen(7)
+	snap = ss.TransferReadiness()
+	if snap.AppliedConfigGen != 7 {
+		t.Fatalf("after apply, applied gen must be 7, got %d", snap.AppliedConfigGen)
+	}
+	if !snap.ReadyForManualFailover() {
+		t.Fatalf("caught-up standby must be ready, reason=%q", snap.Reason())
+	}
+}
+
+// TestResetRecvGenClearsReceivedConfigHighWater guards the applied<=received
+// invariant across a peer bulk re-prime. resetRecvGen() zeroes BOTH the applied
+// mark and the received high-water; if only the applied mark were reset, the
+// snapshot would spuriously report the node config-stale (received>applied)
+// after every reconnect until the re-push landed.
+func TestResetRecvGenClearsReceivedConfigHighWater(t *testing.T) {
+	dp := &mockSweepDP{}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+
+	ss.handleMessage(nil, syncMsgConfig, encodeConfigPayload("cfg", 9))
+	ss.recordAppliedConfigGen(9)
+	if snap := ss.TransferReadiness(); snap.ConfigStale() {
+		t.Fatalf("applied==received must not be stale before reset, got peer=%d applied=%d",
+			snap.PeerConfigGen, snap.AppliedConfigGen)
+	}
+
+	ss.resetRecvGen()
+	snap := ss.TransferReadiness()
+	if snap.PeerConfigGen != 0 || snap.AppliedConfigGen != 0 {
+		t.Fatalf("resetRecvGen must zero BOTH config generations, got peer=%d applied=%d",
+			snap.PeerConfigGen, snap.AppliedConfigGen)
+	}
+	if snap.ConfigStale() {
+		t.Fatal("after resetRecvGen both generations are 0 — must not report config-stale")
+	}
+}


### PR DESCRIPTION
## Summary

- Manual/planned failover readiness (`TransferReadinessSnapshot` /
  `ReadyForManualFailover`) was defined SOLELY in terms of session bulk
  state. It carried neither the config sender's committed generation nor
  the receiver's applied generation, so a standby could be promoted while
  running a STALE policy/zone/application snapshot: **fail-open** after a
  tightening commit (admits denied traffic), **false-deny** after a
  loosening commit (drops allowed traffic).
- Track a received-config high-water `lastRecvConfigGen` (advanced in the
  `syncMsgConfig` handler at enqueue, **before** apply, even if the apply
  queue is full) — the receiver's local view of the sender's current
  committed generation, alongside the existing applied high-water
  `lastAppliedConfigGen` (#3931).
- `TransferReadiness` now carries both (`PeerConfigGen` /
  `AppliedConfigGen`); `ReadyForManualFailover` refuses promotion when
  `PeerConfigGen > AppliedConfigGen` (new `ConfigStale()` helper);
  `Reason()` explains the blocker.
- `resetRecvGen` zeroes `lastRecvConfigGen` alongside
  `lastAppliedConfigGen`, so the `applied <= received` invariant holds
  across a reconnect bulk re-prime.

## Correctness / scope

- **Legitimate same-generation failover still promotes** (`applied ==
  received` → ready). The gate is not a blanket block: a legacy/fresh
  peer (both marks 0) is never blocked.
- **Planned/manual only.** The UNPLANNED/crash failover path is *not*
  gated — a stale-standby crash-takeover is a separate
  availability-vs-security tradeoff (the alternative there is a total
  outage), so it is left as-is and called out here.
- **Residual window** (documented, acceptable): a config committed on the
  primary whose `syncMsgConfig` frame has not yet reached the standby is
  not yet in `lastRecvConfigGen`, so a promotion in that sub-millisecond
  window still sees the prior generation. This is a strict improvement
  over the prior behavior, which never checked config generation at all.
  A wire-level round-trip to source the sender's live counter at
  check-time would add a blocking control-socket request to a 1/s-polled
  readiness path (CLAUDE.md control-socket contention rule) and is out of
  scope.

## Pinned generation sources

- Sender committed gen (as observed by receiver): `lastRecvConfigGen`,
  advanced in the `syncMsgConfig` handler, `pkg/cluster/sync_conn.go`.
- Receiver applied gen: `lastAppliedConfigGen`, advanced by
  `recordAppliedConfigGen`, `pkg/cluster/sync_conn.go` (#3931/#4151).
- Snapshot population: `TransferReadiness`, `pkg/cluster/sync_bulk.go`.
- Gate: `ReadyForManualFailover` / `ConfigStale`, `pkg/cluster/sync.go`.

## Test plan

- [x] `pkg/cluster/sync_failover_config_gen_test.go` (new):
  - `TestReadyForManualFailoverConfigStaleGate` — canonical fail-on-revert
    binder: applied-behind-received → not ready; same-gen → ready;
    both-0 → ready; reason text.
  - `TestReadyForManualFailoverConfigGateIndependentOfBulk` — config gate
    fires even when bulk state is fully settled.
  - `TestTransferReadinessCarriesConfigGenerations` — drives the real
    receive path (`handleMessage` → `syncMsgConfig`), asserts
    `TransferReadiness` surfaces the received gen and blocks until
    `recordAppliedConfigGen` catches up.
  - `TestResetRecvGenClearsReceivedConfigHighWater` — reset zeroes both
    marks (invariant guard).
- [x] `go build ./...` clean.
- [x] `go test -race ./pkg/cluster/... ./pkg/daemon/...` green (cluster
  suite 3× non-flake).
- **Parent-RED recipe:** in `ReadyForManualFailover`
  (`pkg/cluster/sync.go`) drop the `&& !s.ConfigStale()` conjunct →
  `TestReadyForManualFailoverConfigStaleGate` (+ two siblings) fail as
  clean assertion failures (line 34: "config-stale standby ... must NOT
  be ready"), no build break; restoring the conjunct returns green.
- **Loss-cluster failover smoke recommended** (not run here): a
  same-generation `make test-failover` proves a legitimate failover still
  promotes (the gate is scoped); the stale-generation refusal is
  unit-proven.

## Docs

- `docs/sync-protocol.md` — the `lastRecvConfigGen` high-water, the
  refusal semantics, scope, and residual window.
- `docs/ha-failover-status.md` — operator-facing transfer-readiness
  reason string.

Closes #5563
