### PR TITLE
cluster: fence remote-failover applied-ack on demotion actuation (#5640)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54288,3 +54288,32 @@ top.
   `pkg/cluster/sync_bulk.go`,
   `pkg/cluster/sync_failover_config_gen_test.go` (new),
   `docs/sync-protocol.md`, `docs/ha-failover-status.md`
+
+## 2026-07-21 — #5640: fence remote-failover applied-ack on local demotion actuation
+
+- **Timestamp**: 2026-07-21 (fix/5640-failover-ack-after-fence)
+- **Action**: SECURITY (HA two-owner window). `handleRemoteFailover` replied
+  `failoverAckApplied` the instant `OnRemoteFailover` (→ `cluster.ManualFailover`)
+  returned. `ManualFailover` sets `StateSecondaryHold` and only ENQUEUES an async
+  demotion event (`sendEvent`); the fence (`ResignRG` priority-0 advert + VIP
+  removal + `rg_active` clear) is actuated later by the daemon's
+  `watchClusterEvents` consumer. The premature ack let the sender run
+  `commitRequestedPeerFailover` and become primary (adds VIPs, GARP) while the
+  old owner still advertised MASTER — two external RG owners (duplicate GARP /
+  VIP ownership / traffic). Fix gates the applied-ack on a fence-completion
+  barrier: daemon `OnRemoteFailover`/`OnRemoteFailoverBatch` `armFailoverActuation`
+  BEFORE `ManualFailover` enqueues (so the signal can't be missed);
+  `handleRemoteFailover` calls the new `WaitFailoverApplied` hook
+  (`waitFailoverActuated`) before acking; `watchClusterEvents` calls
+  `signalFailoverActuated` at the end of the demotion branch (after resign /
+  rg_active clear). Bounded by `failoverActuateTimeout` (3s) → downgrade to
+  `failoverAckFailed` so the peer HOLDS rather than joins split-brain. Batch path
+  covered symmetrically. Normal-path latency unchanged (barrier releases on
+  local resign). Fail-on-revert tests bind the two ack-gate lines.
+- **File(s)**: `pkg/cluster/sync.go` (WaitFailoverApplied/Batch hooks),
+  `pkg/cluster/sync_failover.go` (ack gate in handleRemoteFailover[Batch]),
+  `pkg/daemon/daemon.go` (barrier fields + init),
+  `pkg/daemon/daemon_ha.go` (arm/disarm/signal/wait helpers + signal in
+  watchClusterEvents), `pkg/daemon/daemon_ha_sync.go` (arm in closures + hook
+  wiring), `pkg/cluster/sync_test.go` (new fence-ack tests),
+  `docs/session-sync-architecture.md`

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -1080,6 +1080,46 @@ Manual failover uses the same demotion-prep path via
 peer not quiescent, barrier ack timeout). The cluster state machine can retry
 admission on retryable errors instead of proceeding unsafely.
 
+### Remote-failover applied-ack is fenced on local demotion actuation (#5640)
+
+When the peer requests this node to transfer an RG out of primary, the receiver
+runs `OnRemoteFailover` → `cluster.ManualFailover`, which sets the RG to
+`StateSecondaryHold` and **enqueues** an async demotion event onto the manager
+event channel (`sendEvent`) before returning. The actual fence — `ResignRG`
+(VRRP priority-0 advert + VIP removal) and `rg_active` clear — is actuated later
+by the daemon's `watchClusterEvents` consumer, not synchronously inside
+`ManualFailover`.
+
+`handleRemoteFailover` (`pkg/cluster/sync_failover.go`) therefore must **not**
+reply `failoverAckApplied` the instant `OnRemoteFailover` returns: the sender
+treats that ack as authorization to run `commitRequestedPeerFailover` and become
+primary. Acking before the local event consumer has run left a window where the
+peer promoted (adds VIPs, sends GARP) while the old owner still advertised as
+MASTER and owned the VIPs — two external owners of the RG (duplicate GARP / VIP
+ownership / traffic).
+
+The fix gates the applied-ack on a fence-completion barrier:
+
+1. The daemon `OnRemoteFailover`/`OnRemoteFailoverBatch` closures call
+   `armFailoverActuation(rgID)` — registering a per-RG channel — **before**
+   `ManualFailover` enqueues the demotion event, so the actuation signal can
+   never be missed. A `ManualFailover` error disarms the barrier.
+2. `handleRemoteFailover` calls the `WaitFailoverApplied` hook (wired to
+   `waitFailoverActuated`) after `OnRemoteFailover` succeeds and before sending
+   `failoverAckApplied`. It blocks on the barrier channel.
+3. `watchClusterEvents`, at the end of the demotion (non-primary) branch — after
+   `ResignRG` / direct-VIP reconcile / `rg_active` clear — calls
+   `signalFailoverActuated(rgID)`, closing the channel and releasing the ack.
+4. The wait is bounded by `failoverActuateTimeout` (3s default). A demotion that
+   never actuates (superseded reset, event-channel drop) downgrades the ack to
+   `failoverAckFailed` so the peer **holds** rather than promoting into the
+   two-owner window — safety over latency in the race. On the normal path the
+   barrier releases as soon as the local resign completes, so failover latency is
+   unchanged.
+
+The batch path (`handleRemoteFailoverBatch` / `WaitFailoverAppliedBatch`) applies
+the same per-RG barrier across the whole set.
+
 Once the RG is marked standby, each worker processes a
 `WorkerCommand::DemoteOwnerRGS` on its packet thread
 (`afxdp/session_glue/commands/demote_owner_rgs.rs`, `handle_demote_owner_rgs`):

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -349,6 +349,22 @@ type SessionSync struct {
 	OnRemoteFailoverBatch func(rgIDs []int) error
 	// OnRemoteFailoverCommitBatch finalizes a previously acknowledged multi-RG handoff.
 	OnRemoteFailoverCommitBatch func(rgIDs []int) error
+	// WaitFailoverApplied, if set, blocks until the local node has ACTUATED
+	// the transfer-out just requested via OnRemoteFailover for one RG — i.e.
+	// the async demotion event has been consumed and the old owner fenced
+	// (VRRP resigned to priority-0 / VIPs removed / rg_active cleared). It
+	// gates the failoverAckApplied reply so the peer cannot promote while this
+	// node still externally owns the RG. OnRemoteFailover only ENQUEUES the
+	// demotion event and returns; acking before this barrier opened a
+	// two-owner window (duplicate GARP / VIP ownership / traffic) — #5640. A
+	// non-nil error (fence not actuated within the daemon's bounded timeout)
+	// downgrades the ack to failoverAckFailed so the peer holds instead of
+	// promoting into the two-owner window.
+	WaitFailoverApplied func(rgID int) error
+	// WaitFailoverAppliedBatch is the multi-RG counterpart of
+	// WaitFailoverApplied: it blocks until every RG in the batch has been
+	// fenced before the batch failoverAckApplied reply is sent (#5640).
+	WaitFailoverAppliedBatch func(rgIDs []int) error
 	// OnFenceReceived requests this node to disable all RGs.
 	OnFenceReceived func()
 	// OnPrepareActivation asks the peer to pre-warm neighbors for the given RG.

--- a/pkg/cluster/sync_failover.go
+++ b/pkg/cluster/sync_failover.go
@@ -433,6 +433,20 @@ func (s *SessionSync) handleRemoteFailover(conn net.Conn, rgID int, reqID uint64
 		s.sendFailoverResult(conn, syncMsgFailoverAck, rgID, reqID, status, err.Error())
 		return
 	}
+	// #5640: OnRemoteFailover only ENQUEUES the async demotion event; the old
+	// owner is not fenced (VRRP resigned / VIPs removed) until the daemon's
+	// event consumer actuates it. Acking applied here let the peer promote
+	// while this node still owned the RG → a two-owner window. Gate the
+	// applied-ack on the fence-completion barrier; if the fence does not
+	// actuate within the bounded timeout, downgrade to failed so the peer
+	// holds rather than joining a split-brain.
+	if s.WaitFailoverApplied != nil {
+		if err := s.WaitFailoverApplied(rgID); err != nil {
+			slog.Warn("cluster sync: remote failover fence barrier failed", "rg", rgID, "req_id", reqID, "err", err)
+			s.sendFailoverResult(conn, syncMsgFailoverAck, rgID, reqID, failoverAckFailed, err.Error())
+			return
+		}
+	}
 	s.sendFailoverResult(conn, syncMsgFailoverAck, rgID, reqID, failoverAckApplied, "")
 }
 func (s *SessionSync) handleRemoteFailoverBatch(conn net.Conn, rgIDs []int, reqID uint64) {
@@ -447,6 +461,16 @@ func (s *SessionSync) handleRemoteFailoverBatch(conn net.Conn, rgIDs []int, reqI
 		}
 		s.sendFailoverBatchResult(conn, syncMsgFailoverBatchAck, rgIDs, reqID, status, err.Error())
 		return
+	}
+	// #5640: gate the batch applied-ack on every RG being fenced. See
+	// handleRemoteFailover for the two-owner rationale — a batch handoff that
+	// acks before actuation opens the same window across the whole set.
+	if s.WaitFailoverAppliedBatch != nil {
+		if err := s.WaitFailoverAppliedBatch(rgIDs); err != nil {
+			slog.Warn("cluster sync: remote batch failover fence barrier failed", "rgs", rgIDs, "req_id", reqID, "err", err)
+			s.sendFailoverBatchResult(conn, syncMsgFailoverBatchAck, rgIDs, reqID, failoverAckFailed, err.Error())
+			return
+		}
 	}
 	s.sendFailoverBatchResult(conn, syncMsgFailoverBatchAck, rgIDs, reqID, failoverAckApplied, "")
 }

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -3412,6 +3412,180 @@ func TestHandleMessageFailoverDoesNotBlockReceiveLoop(t *testing.T) {
 	close(release)
 }
 
+// readFramesInto spawns a goroutine that reads whole sync frames from conn and
+// pushes them to out until the connection errors. Unlike readSyncMessage it
+// never t.Fatal's on a (deliberate) read stall, so a test can assert the
+// ABSENCE of a frame within a window.
+func readFramesInto(conn net.Conn, out chan<- syncFrame) {
+	go func() {
+		for {
+			var hdr [syncHeaderSize]byte
+			if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+				return
+			}
+			plen := binary.LittleEndian.Uint32(hdr[8:12])
+			pl := make([]byte, plen)
+			if _, err := io.ReadFull(conn, pl); err != nil {
+				return
+			}
+			out <- syncFrame{typ: hdr[4], payload: pl}
+		}
+	}()
+}
+
+type syncFrame struct {
+	typ     uint8
+	payload []byte
+}
+
+// TestHandleRemoteFailoverWithholdsAckUntilFenced pins the #5640 fix: the
+// receiver of a remote failover request (the OLD owner) must NOT reply
+// failoverAckApplied until its local demotion has been ACTUATED (VRRP resigned
+// / rg_active cleared). OnRemoteFailover only enqueues the async demotion
+// event; acking before the fence let the peer promote while this node still
+// owned the RG — a two-owner window (duplicate GARP / VIP ownership).
+//
+// Fail-on-revert: delete the `s.WaitFailoverApplied` gate in
+// handleRemoteFailover and the applied-ack is sent immediately after
+// OnRemoteFailover returns — the first select below then observes the ack
+// while the fence is still blocked and fails RED as a clean assertion.
+func TestHandleRemoteFailoverWithholdsAckUntilFenced(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+
+	ss.mu.Lock()
+	ss.conn0 = local
+	ss.mu.Unlock()
+	ss.stats.Connected.Store(true)
+
+	// OnRemoteFailover models ManualFailover: it enqueues the async demotion
+	// and returns immediately (the node is NOT yet fenced here).
+	ss.OnRemoteFailover = func(rgID int) error { return nil }
+
+	// WaitFailoverApplied models the daemon barrier that blocks until
+	// watchClusterEvents actuates the demotion.
+	fenced := make(chan struct{})
+	waitEntered := make(chan struct{}, 1)
+	ss.WaitFailoverApplied = func(rgID int) error {
+		if rgID != 7 {
+			return fmt.Errorf("unexpected rg %d", rgID)
+		}
+		select {
+		case waitEntered <- struct{}{}:
+		default:
+		}
+		<-fenced
+		return nil
+	}
+
+	frames := make(chan syncFrame, 4)
+	readFramesInto(peer, frames)
+
+	go ss.handleRemoteFailover(local, 7, 42)
+
+	// The applied-ack must be WITHHELD while the fence has not actuated. On a
+	// reverted build the ack is sent immediately and this fails RED.
+	select {
+	case f := <-frames:
+		status := uint8(255)
+		if len(f.payload) >= 2 {
+			status = f.payload[1]
+		}
+		t.Fatalf("failover ack (type=%d status=%d) sent before fence actuated: two-owner window (#5640)", f.typ, status)
+	case <-time.After(200 * time.Millisecond):
+		// good — ack withheld pending fence
+	}
+
+	// Positive control: the handler is blocked in the fence barrier.
+	select {
+	case <-waitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not enter WaitFailoverApplied barrier")
+	}
+
+	// Actuate the fence; the applied-ack must now be delivered.
+	close(fenced)
+	select {
+	case f := <-frames:
+		if f.typ != syncMsgFailoverAck {
+			t.Fatalf("frame type = %d, want failover ack %d", f.typ, syncMsgFailoverAck)
+		}
+		if len(f.payload) < 2 || f.payload[0] != 7 {
+			t.Fatalf("ack payload = %v, want rg=7", f.payload)
+		}
+		if f.payload[1] != failoverAckApplied {
+			t.Fatalf("ack status = %d, want applied %d", f.payload[1], failoverAckApplied)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("applied-ack not delivered after fence actuated")
+	}
+}
+
+// TestHandleRemoteFailoverBatchWithholdsAckUntilFenced is the batch counterpart
+// of the #5640 fix, pinning the WaitFailoverAppliedBatch gate in
+// handleRemoteFailoverBatch.
+func TestHandleRemoteFailoverBatchWithholdsAckUntilFenced(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+
+	ss.mu.Lock()
+	ss.conn0 = local
+	ss.mu.Unlock()
+	ss.stats.Connected.Store(true)
+
+	rgIDs := []int{1, 2}
+	ss.OnRemoteFailoverBatch = func([]int) error { return nil }
+
+	fenced := make(chan struct{})
+	waitEntered := make(chan struct{}, 1)
+	ss.WaitFailoverAppliedBatch = func([]int) error {
+		select {
+		case waitEntered <- struct{}{}:
+		default:
+		}
+		<-fenced
+		return nil
+	}
+
+	frames := make(chan syncFrame, 4)
+	readFramesInto(peer, frames)
+
+	go ss.handleRemoteFailoverBatch(local, rgIDs, 43)
+
+	select {
+	case f := <-frames:
+		t.Fatalf("batch failover ack (type=%d) sent before fence actuated: two-owner window (#5640)", f.typ)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	select {
+	case <-waitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not enter WaitFailoverAppliedBatch barrier")
+	}
+
+	close(fenced)
+	select {
+	case f := <-frames:
+		if f.typ != syncMsgFailoverBatchAck {
+			t.Fatalf("frame type = %d, want batch failover ack %d", f.typ, syncMsgFailoverBatchAck)
+		}
+		_, status, _, _, err := decodeFailoverBatchAckPayload(f.payload)
+		if err != nil {
+			t.Fatalf("decode batch ack: %v", err)
+		}
+		if status != failoverAckApplied {
+			t.Fatalf("batch ack status = %d, want applied %d", status, failoverAckApplied)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("batch applied-ack not delivered after fence actuated")
+	}
+}
+
 func TestSendFailoverWaitsForAck(t *testing.T) {
 	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
 	local, peer := net.Pipe()

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -775,6 +775,20 @@ type Daemon struct {
 	// readiness bit flips so the VRRP/direct-ownership side effects that set
 	// the bit have a chance to propagate before the peer finalizes demotion.
 	localFailoverCommitDelay time.Duration
+	// failoverActuateMu guards failoverActuateWait. The map holds, per RG, a
+	// channel that watchClusterEvents closes once it has ACTUATED a demotion
+	// (VRRP resign to priority-0 / rg_active clear). armFailoverActuation
+	// registers a fresh channel BEFORE ManualFailover enqueues the demotion
+	// event, so the close can never be missed; waitFailoverActuated blocks the
+	// remote-failover applied-ack on that close. This closes the #5640
+	// two-owner window where the peer promoted off an ack sent before this
+	// (old-owner) node had actually resigned.
+	failoverActuateMu   sync.Mutex
+	failoverActuateWait map[int]chan struct{}
+	// failoverActuateTimeout bounds waitFailoverActuated so a demotion event
+	// that is never actuated (superseded reset, event-channel drop) downgrades
+	// the ack to failed instead of hanging the peer's failover request.
+	failoverActuateTimeout time.Duration
 	// Test hooks for direct-mode VIP ownership reconciliation.
 	directAddVIPsFn        func(int) int
 	directRemoveVIPsFn     func(int) int
@@ -1038,6 +1052,8 @@ func New(opts Options) (*Daemon, error) {
 		localFailoverCommitReady:   make(map[int]bool),
 		localFailoverCommitTimeout: 3 * time.Second,
 		localFailoverCommitDelay:   200 * time.Millisecond,
+		failoverActuateWait:        make(map[int]chan struct{}),
+		failoverActuateTimeout:     3 * time.Second,
 		userspaceDemotionPrepUntil: make(map[int]time.Time),
 		applySem:                   semaphore.NewWeighted(1),
 	}, nil

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -139,6 +139,87 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 	}
 }
 
+// armFailoverActuation registers a fence-completion barrier for rgID before a
+// remote-requested transfer-out enqueues its async demotion event. It MUST be
+// called before cluster.ManualFailover so the demotion actuation
+// (watchClusterEvents → signalFailoverActuated) cannot close-and-forget the
+// barrier before waitFailoverActuated observes it. Concurrent same-RG remote
+// failovers are excluded upstream (cluster.failoverInProgress + the sync-layer
+// failover waiters), so a single channel per RG is sufficient (#5640).
+func (d *Daemon) armFailoverActuation(rgID int) {
+	d.failoverActuateMu.Lock()
+	if d.failoverActuateWait == nil {
+		d.failoverActuateWait = make(map[int]chan struct{})
+	}
+	d.failoverActuateWait[rgID] = make(chan struct{})
+	d.failoverActuateMu.Unlock()
+}
+
+// disarmFailoverActuation drops a barrier that will never be actuated — used
+// when ManualFailover fails to enqueue the demotion (no event will ever fire).
+// It does NOT close the channel: no waiter can be blocked on it because the
+// applied-ack path is not reached on a ManualFailover error.
+func (d *Daemon) disarmFailoverActuation(rgID int) {
+	d.failoverActuateMu.Lock()
+	delete(d.failoverActuateWait, rgID)
+	d.failoverActuateMu.Unlock()
+}
+
+// signalFailoverActuated marks rgID's demotion as actuated (VRRP resigned /
+// rg_active cleared) and releases any waiter. It is idempotent: the channel is
+// deleted under the lock, so a second demotion event for the same RG is a
+// no-op and never double-closes. Safe to call for every non-primary cluster
+// event — an unarmed RG simply has no channel to close.
+func (d *Daemon) signalFailoverActuated(rgID int) {
+	d.failoverActuateMu.Lock()
+	ch := d.failoverActuateWait[rgID]
+	delete(d.failoverActuateWait, rgID)
+	d.failoverActuateMu.Unlock()
+	if ch != nil {
+		close(ch)
+	}
+}
+
+// waitFailoverActuated blocks until the local demotion for rgID has been
+// actuated (barrier closed by signalFailoverActuated) or the bounded timeout
+// elapses. A nil barrier means the actuation already completed (or was never
+// armed) — return immediately. This gates the remote-failover applied-ack so
+// the peer never promotes into a two-owner window (#5640).
+func (d *Daemon) waitFailoverActuated(rgID int) error {
+	d.failoverActuateMu.Lock()
+	ch := d.failoverActuateWait[rgID]
+	d.failoverActuateMu.Unlock()
+	if ch == nil {
+		return nil
+	}
+	timeout := d.failoverActuateTimeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ch:
+		return nil
+	case <-timer.C:
+		// Drop the stranded barrier so a later actuation event does not
+		// close an orphaned channel that no one reads.
+		d.disarmFailoverActuation(rgID)
+		return fmt.Errorf("timed out waiting for local fence actuation of redundancy group %d", rgID)
+	}
+}
+
+// waitFailoverActuatedBatch blocks until every RG in the batch has been fenced,
+// or returns the first RG's timeout (#5640).
+func (d *Daemon) waitFailoverActuatedBatch(rgIDs []int) error {
+	for _, rgID := range rgIDs {
+		if err := d.waitFailoverActuated(rgID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // isRethMasterState returns true when ALL VRRP instances for rgID are MASTER.
 // Returns false if no instances exist for the RG.
 func (d *Daemon) isRethMasterState(rgID int) bool {
@@ -298,6 +379,14 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 				if noRethVRRP {
 					d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-secondary")
 				}
+
+				// #5640: the local demotion is now actuated — VRRP has
+				// resigned to priority-0 (or direct VIP ownership was
+				// reconciled away) and rg_active is cleared. Release any
+				// remote-failover applied-ack that is holding for this fence
+				// so the peer only promotes AFTER this node stopped owning
+				// the RG. Fires for every non-primary edge; unarmed RGs no-op.
+				d.signalFailoverActuated(ev.GroupID)
 			}
 
 			// Strict VIP ownership: suppress GARP on secondary, allow on primary.

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -854,7 +854,13 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					return fmt.Errorf("%w: redundancy group %d", cluster.ErrRemoteFailoverRejected, rgID)
 				}
 				slog.Info("cluster: remote failover request from peer", "rg", rgID)
+				// #5640: arm the fence-completion barrier BEFORE ManualFailover
+				// enqueues the async demotion event, so watchClusterEvents
+				// cannot actuate-and-forget before WaitFailoverApplied observes
+				// it. The applied-ack (sync layer) then waits on this barrier.
+				d.armFailoverActuation(rgID)
 				if err := d.cluster.ManualFailover(rgID); err != nil {
+					d.disarmFailoverActuation(rgID)
 					slog.Warn("cluster: remote failover failed", "rg", rgID, "err", err)
 					return err
 				}
@@ -867,7 +873,15 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					}
 				}
 				slog.Info("cluster: remote batch failover request from peer", "rgs", rgIDs)
+				// #5640: arm every member's fence barrier before the batch
+				// demotion enqueues its per-RG events.
+				for _, rgID := range rgIDs {
+					d.armFailoverActuation(rgID)
+				}
 				if err := d.cluster.ManualFailoverBatch(rgIDs); err != nil {
+					for _, rgID := range rgIDs {
+						d.disarmFailoverActuation(rgID)
+					}
 					slog.Warn("cluster: remote batch failover failed", "rgs", rgIDs, "err", err)
 					return err
 				}
@@ -879,6 +893,12 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.sessionSync.OnRemoteFailoverCommitBatch = func(rgIDs []int) error {
 				return d.cluster.FinalizePeerTransferOutBatch(rgIDs)
 			}
+			// #5640: gate the transfer-out applied-ack on the local demotion
+			// actually being actuated (VRRP resigned / rg_active cleared),
+			// closing the two-owner window where the peer promoted off an ack
+			// sent before this node had resigned.
+			d.sessionSync.WaitFailoverApplied = d.waitFailoverActuated
+			d.sessionSync.WaitFailoverAppliedBatch = d.waitFailoverActuatedBatch
 
 			// Wire peer failover sender so cluster Manager can send remote
 			// failover requests via the fabric sync connection.


### PR DESCRIPTION
## Summary

- **Security / HA two-owner window (M32/High, codex-review-181).**
  `handleRemoteFailover` replied `failoverAckApplied` the moment
  `OnRemoteFailover` returned. That handler routes to
  `cluster.ManualFailover`, which sets the RG to `StateSecondaryHold` and only
  **enqueues** an async demotion event (`Manager.sendEvent`). The fence that
  actually removes this node as an external owner — `ResignRG` (VRRP
  priority-0 advert + VIP removal) and the `rg_active` clear — is actuated
  later by the daemon's `watchClusterEvents` consumer, **not** synchronously
  inside `ManualFailover`.
- The sender treats the applied-ack as authorization to run
  `commitRequestedPeerFailover` and become primary (adds VIPs, sends GARP).
  Acking before the local consumer ran left a window where the peer promoted
  while the **old owner still advertised MASTER and owned the VIPs** — two
  external owners of the RG at once (duplicate GARP / VIP ownership / split
  traffic).
- **Fix:** gate the applied-ack on a fence-completion barrier.

## Pinned ordering (before → after)

`OnRemoteFailover → cluster.ManualFailover` sets `StateSecondaryHold` +
`sendEvent` (async), then returns (`pkg/cluster/failover.go:120-129`). The fence
is actuated in `watchClusterEvents` (`pkg/daemon/daemon_ha.go`) — `ResignRG`
(`pkg/vrrp/manager.go:656`, sets priority 0 + `triggerResign`) then `rg_active`
clear. **Before:** `handleRemoteFailover` sent `failoverAckApplied`
(`sync_failover.go:436`) immediately after `OnRemoteFailover` returned —
ack-then-actuate. **After:** the ack waits on the fence-completion barrier —
actuate-then-ack.

## Mechanism

1. Daemon `OnRemoteFailover`/`OnRemoteFailoverBatch` closures call
   `armFailoverActuation(rgID)` **before** `ManualFailover` enqueues the
   demotion event, so the actuation signal can never be missed (a
   `ManualFailover` error disarms it).
2. `handleRemoteFailover` calls the new `WaitFailoverApplied` hook (wired to
   `waitFailoverActuated`) after `OnRemoteFailover` succeeds and before sending
   `failoverAckApplied`.
3. `watchClusterEvents` calls `signalFailoverActuated(rgID)` at the end of the
   demotion (non-primary) branch — after `ResignRG` / direct-VIP reconcile /
   `rg_active` clear — closing the barrier and releasing the ack.
4. Bounded by `failoverActuateTimeout` (3s default): a demotion that never
   actuates (superseded reset, event-channel drop) downgrades the ack to
   `failoverAckFailed` so the peer **holds** rather than joining a split-brain —
   safety over latency in the race. Normal-path latency is unchanged (the
   barrier releases as soon as the local resign completes).
5. Batch path (`handleRemoteFailoverBatch` / `WaitFailoverAppliedBatch`) applies
   the same per-RG barrier across the whole set.

## Test plan

- [x] `TestHandleRemoteFailoverWithholdsAckUntilFenced` — drives
  `handleRemoteFailover` with a blocked fence barrier; asserts **no**
  applied-ack is observable while the fence is blocked, then that the
  applied-ack is delivered once the fence actuates. Binds
  `sync_failover.go:443` (`WaitFailoverApplied` gate).
- [x] `TestHandleRemoteFailoverBatchWithholdsAckUntilFenced` — batch
  counterpart; binds `sync_failover.go:468` (`WaitFailoverAppliedBatch` gate).
- [x] **Fail-on-revert (PARENT-RED):** deleting the single-RG gate block makes
  `TestHandleRemoteFailoverWithholdsAckUntilFenced` fail RED — `failover ack
  (type=16 status=0) sent before fence actuated: two-owner window (#5640)`
  (clean assertion; type 16 = `syncMsgFailoverAck`, status 0 =
  `failoverAckApplied`). Deleting the batch gate reds the batch test (type 21 =
  `syncMsgFailoverBatchAck`). Each test target-count = 1.
- [x] `go build ./...`, `go vet ./pkg/cluster/... ./pkg/daemon/...`
- [x] `go test -race ./pkg/cluster/...` and `./pkg/daemon/...` pass; new tests
  3× non-flake under `-race`.

## Validation not run in this env

- **Loss-cluster failover smoke** (`make cluster-deploy` + `make test-failover`)
  is REQUIRED before merge — this touches the failover ack/fence ordering. The
  smoke proves a normal failover still transfers ownership cleanly with no
  two-owner window; the barrier itself is unit-proven here.

## Refs

- Closes #5640
- Adjacent (distinct, not addressed here): #5079/#5479, #5482, #4867

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFpJZcCwcjJYzoSXFUGEPo
