### PR TITLE
config: reject unsupported QinQ by canonical VLAN stack (#5879)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54288,3 +54288,20 @@ top.
   `pkg/cluster/sync_bulk.go`,
   `pkg/cluster/sync_failover_config_gen_test.go` (new),
   `docs/sync-protocol.md`, `docs/ha-failover-status.md`
+
+## 2026-07-21 — #5879 canonical per-physical-interface QinQ gate
+- **Timestamp**: 2026-07-21
+- **Action**: Add #5879 canonical QinQ honesty gate. The #2354 gate validated a
+  local `inner-vlan-id` leaf on the committing node's expansion only; QinQ split
+  across the `vlan-tags outer/inner` spelling (incl. two set statements) or living
+  in a peer-only `groups node1` view bypassed commit (verified live: `vlan-tags
+  outer 100 inner 200` and node1-only `inner-vlan-id` both compiled clean). New
+  `validateQinQVLANStackAST` builds each unit's aggregate outer/inner stack across
+  both spellings and rejects any inner tag, evaluated for BOTH node0 and node1
+  effective views (HA-symmetric). Moved QinQ detection out of
+  `validateUnsupportedInterfaceStanzasAST` (H9/H10 stay). New `lenientQinQVLANStack`
+  opt keeps the #1960 warn-on-load posture.
+- **File(s)**: pkg/config/compiler_interfaces_qinq.go (new),
+  pkg/config/compiler_interfaces_unsupported.go, pkg/config/compiler.go,
+  pkg/config/schema_interfaces.go, pkg/config/qinq_canonical_vlan_5879_test.go (new),
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3741,6 +3741,49 @@ reserved for whole-dataplane selection where a rewrite shim
   no-op knob, not a false dataplane/identity promise — and its real
   implementation is split to /research. Regression coverage:
   `pkg/config/compiler_interfaces_unsupported_test.go`.
+- **#2354 / #5879 (canonical per-physical-interface QinQ reject):** the
+  AF_XDP shim's `parse_l2` unwinds exactly ONE VLAN tag, so xpf cannot
+  represent a double-tagged (802.1ad S-tag + 802.1Q C-tag) frame — an inner
+  / second tag is XDP_PASSed to the kernel forwarding path and never
+  firewalled. #2354 rejected the one obvious spelling (a per-unit
+  `inner-vlan-id` leaf) inside `validateUnsupportedInterfaceStanzasAST`, but
+  that validated a LOCAL statement shape on the committing node's own
+  expansion, so two classes of unsupported QinQ bypassed it:
+    - a DIFFERENT inner-tag spelling — `vlan-tags outer <x> inner <y>` (the
+      modern Junos stacked-VLAN syntax) is not in `setSchema` and has no
+      compiler consumer, so it parse-accepted and was silently dropped; the
+      inner half can even be SPLIT across two `set` statements
+      (`vlan-tags outer 100` + `vlan-tags inner 200`), so no single leaf is
+      the recognizable `inner-vlan-id`;
+    - a PEER-ONLY node view — an `inner-vlan-id`/`vlan-tags inner` under
+      `groups node1` + `apply-groups "${node}"` never materializes when the
+      candidate is compiled for node0, so a commit ON node0 accepted a stack
+      that renders unsupported QinQ on node1 (an active/standby posture
+      split — the standby silently PASSes to the kernel what the primary
+      firewalls).
+  #5879 replaces the local `inner-vlan-id` check with a canonical
+  per-physical-interface gate (`validateQinQVLANStackAST`,
+  `compiler_interfaces_qinq.go`): it builds each unit's aggregate outer/inner
+  tag stack across BOTH spellings (`vlan-id`/`inner-vlan-id` AND
+  `vlan-tags outer/inner`, combined onto one statement or split across
+  several) and rejects any unit whose stack carries an inner (second) tag.
+  It runs PRE-expansion beside the tunnel/zone/table-id/unit-alias union
+  gates and evaluates the effective view for EVERY cluster node (the node0
+  AND node1 `${node}`/apply-groups + interface-range expansions), so the
+  accept/reject verdict is HA-symmetric no matter which node commits and a
+  peer-only-group inner tag is caught. Only the two per-node EFFECTIVE views
+  are unioned — deliberately NOT the pre-expansion all-groups "View 1" the
+  sibling collision gates (`#5878`, `#3075`) fold in, because QinQ trips on a
+  SINGLE inner tag and a View-1 union would additionally reject a QinQ stanza
+  staged in a group that NO `apply-groups` references (inert dead config
+  outside any node's effective view). Single 802.1Q tagging via `vlan-id`
+  (with or without `flexible-vlan-tagging`) stays fully supported. Strict on
+  commit / commit-check; downgraded to a warning on the tolerant load /
+  peer-sync paths (`lenientQinQVLANStack`, #1960) so an older-binary-persisted
+  or peer-synced config that silently accepted the inner tag still boots.
+  Because rejection is a compile error, the candidate is never promoted — no
+  partial outer/inner state survives. Regression coverage:
+  `pkg/config/qinq_canonical_vlan_5879_test.go`.
 - **#4027 (interface-range expansion):** `interfaces interface-range
   <name> { member <if>; [member-range <a> to <b>;] <shared cfg> }` is a
   Junos construct that applies a shared configuration block to a SET of
@@ -3801,7 +3844,8 @@ reserved for whole-dataplane selection where a rewrite shim
   roots). **#5744 (the two remaining interface AST pre-walks):** the
   unit-alias collision gate (`validateInterfaceUnitAliasCollisionsAST`,
   `#5631`) and the unsupported-stanza gate
-  (`validateUnsupportedInterfaceStanzasAST`, `#2008`/`#2354`) were the last
+  (`validateUnsupportedInterfaceStanzasAST`, `#2008`; the `#2354` QinQ half
+  has since moved to the `#5879` canonical both-node gate) were the last
   sibling pre-walks still `break`-ing on the first `interfaces` root, so a
   unit-alias collision or an unsupported/silently-dropped stanza placed in a
   SECOND `interfaces` root bypassed them. Both now flatten every

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -478,6 +478,22 @@ type compileOpts struct {
 	// lenientVRRPTrackDuplicates / lenientLogProfileStreamRef.
 	lenientUnsupportedInterfaceStanzas bool
 
+	// lenientQinQVLANStack (#5879) downgrades the canonical per-physical-
+	// interface QinQ / stacked-VLAN honesty gate (validateQinQVLANStackAST:
+	// an aggregate inner/second VLAN tag spelled `inner-vlan-id` OR
+	// `vlan-tags inner`, possibly split across statements or contributed by
+	// a peer-only group) from a hard error to a warning on the tolerant load
+	// / peer-sync paths. The AF_XDP dataplane unwinds a single VLAN tag, so
+	// an inner tag was already silently dropped on every binary up to this
+	// gate; an already-persisted or peer-synced config may carry one, and an
+	// upgrading / receiving node must still boot through it (warn) rather
+	// than fail-closed-on-load (#1960 class). Commit / commit-check stay
+	// strict — a new operator edit whose stacked-VLAN stack the dataplane
+	// cannot honour is rejected loudly. Same doctrine as
+	// lenientUnsupportedInterfaceStanzas (#2008 H9/H10), whose QinQ half this
+	// gate subsumes.
+	lenientQinQVLANStack bool
+
 	// lenientRoutingExportRef (#2144) downgrades the routing-export
 	// cross-reference gate (validateRoutingExportReferencesStrict) from a
 	// hard compile error to a cfg.Warnings entry. Set ONLY on the tolerant
@@ -1984,6 +2000,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientNATPoolAlarmThreshold:           true,
 		lenientNATHostMask:                     true,
 		lenientUnsupportedInterfaceStanzas:     true,
+		lenientQinQVLANStack:                   true,
 		lenientRoutingExportRef:                true,
 		lenientFRRAuthValues:                   true,
 		lenientRouteFilterMatchTypes:           true,
@@ -2277,6 +2294,18 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 		return nil, unitAliasErr
 	}
 
+	// #5879: canonical per-physical-interface QinQ / stacked-VLAN honesty
+	// gate — see compiler_interfaces_qinq.go. Runs PRE-expansion beside the
+	// tunnel/zone/table-id/unit-alias union gates: it expands the candidate
+	// once per cluster node itself (node0 AND node1) so the accept/reject
+	// verdict is identical on both nodes and a peer-only-group or
+	// `vlan-tags`-spelled inner tag is caught. Strict hard-rejects an
+	// unsupported inner tag; lenient warns (#1960).
+	qinqWarnings, qinqErr := validateQinQVLANStackAST(tree, opts.lenientQinQVLANStack)
+	if qinqErr != nil {
+		return nil, qinqErr
+	}
+
 	usedNodeFallback := false
 
 	// Expand groups before compilation — resolve all apply-groups references.
@@ -2304,6 +2333,7 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
+	cfg.Warnings = append(cfg.Warnings, qinqWarnings...)
 	return cfg, nil
 }
 
@@ -2356,6 +2386,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientNATPoolAlarmThreshold:           true,
 		lenientNATHostMask:                     true,
 		lenientUnsupportedInterfaceStanzas:     true,
+		lenientQinQVLANStack:                   true,
 		lenientRoutingExportRef:                true,
 		lenientFRRAuthValues:                   true,
 		lenientRouteFilterMatchTypes:           true,
@@ -2508,6 +2539,17 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 		return nil, unitAliasErr
 	}
 
+	// #5879: canonical per-physical-interface QinQ / stacked-VLAN honesty
+	// gate — see compileConfigWithOpts / compiler_interfaces_qinq.go. Runs
+	// PRE-expansion: it expands the candidate once per cluster node itself
+	// (node0 AND node1) so a peer-only-group or `vlan-tags`-spelled inner tag
+	// is rejected here even when THIS commit compiles nodeID alone. Strict
+	// rejects; lenient warns (#1960).
+	qinqWarnings, qinqErr := validateQinQVLANStackAST(tree, opts.lenientQinQVLANStack)
+	if qinqErr != nil {
+		return nil, qinqErr
+	}
+
 	vars := map[string]string{"node": fmt.Sprintf("node%d", nodeID)}
 	if err := tree.ExpandGroupsWithVars(vars); err != nil {
 		return nil, fmt.Errorf("apply-groups: %w", err)
@@ -2531,6 +2573,7 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
+	cfg.Warnings = append(cfg.Warnings, qinqWarnings...)
 	return cfg, nil
 }
 

--- a/pkg/config/compiler_interfaces_qinq.go
+++ b/pkg/config/compiler_interfaces_qinq.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// compiler_interfaces_qinq.go carries the #5879 canonical per-physical-
+// interface QinQ (stacked-VLAN) honesty gate.
+//
+// Background (#2354): the AF_XDP shim's parse_l2 unwinds exactly ONE VLAN
+// tag, so xpf cannot represent a double-tagged (802.1ad S-tag + 802.1Q
+// C-tag) frame consistently. A committed inner / second tag is a silent
+// functional lie: the frame keeps eth_proto=0x8100, the dispatch `_` arm
+// XDP_PASSes it to the kernel forwarding path, and it is never firewalled.
+// #2354 rejected the one obvious spelling — a per-unit `inner-vlan-id`
+// leaf — at commit.
+//
+// #5879: that gate validated a LOCAL statement SHAPE (a literal
+// `inner-vlan-id` leaf on the committing node's own expansion), not the
+// AGGREGATE effective per-physical-interface VLAN stack. Two classes of
+// unsupported QinQ therefore bypassed it:
+//
+//  1. A DIFFERENT inner-tag spelling. `vlan-tags outer <x> inner <y>` (the
+//     modern Junos stacked-VLAN syntax) is not in setSchema and has no
+//     compiler consumer, so it parse-accepts and is silently dropped — the
+//     #2354 gate never looked at `vlan-tags`. The inner half can even be
+//     SPLIT across two set statements (`vlan-tags outer 100` +
+//     `vlan-tags inner 200`), so no single leaf is the recognizable
+//     `inner-vlan-id` the old gate keyed on.
+//  2. A PEER-ONLY node view. An `inner-vlan-id` (or `vlan-tags inner`)
+//     living under `groups node1` + `apply-groups "${node}"` never
+//     materializes when the candidate is compiled for node0, so a commit
+//     ON node0 accepted a stack that renders unsupported QinQ on node1 — an
+//     active/standby posture disagreement (the standby silently PASSes to
+//     the kernel what the primary firewalls, a zone-policy bypass on one
+//     node of the pair).
+//
+// This gate builds the canonical inner/outer tag stack per (interface,
+// unit) from BOTH the `vlan-id`/`inner-vlan-id` and the `vlan-tags outer/
+// inner` spellings (combined onto one statement OR split across several),
+// and evaluates it against the effective view for EVERY cluster node — the
+// node0 AND node1 `${node}`/apply-groups expansions — so a QinQ stack split
+// across spellings, statements, or a peer-only group is caught on whichever
+// node commits. Any INNER (second) tag is unsupported.
+//
+// Doctrine mirrors #2354 / #1960: strict (commit / commit-check) hard-
+// rejects, naming the interface, unit, and the contributing statement(s);
+// lenient (tolerant load / peer-sync) downgrades to a warning so an
+// already-persisted or peer-synced config an older binary silently accepted
+// still boots. Because rejection is a compile error, the candidate is never
+// promoted — no partial outer/inner state survives a reject.
+//
+// It runs PRE-expansion (like validateZoneIDCollisionAST) because it must
+// expand the candidate once per node ITSELF; wiring it among the
+// pre-expansion gates in BOTH compile entrypoints makes the verdict
+// identical no matter which node commits. The single-node post-expansion
+// #2008 gate (validateUnsupportedInterfaceStanzasAST) no longer checks
+// QinQ — this gate subsumes and strengthens that coverage.
+
+// qinqUnitStack is the canonical VLAN tag stack derived for one logical
+// unit: the rendered outer- and inner-tag statements contributing to it,
+// gathered across every spelling. An empty inner slice means a supported
+// single-tag (or untagged) unit; a non-empty inner slice is unsupported
+// stacked-VLAN.
+type qinqUnitStack struct {
+	outer []string // vlan-id / vlan-tags outer statements
+	inner []string // inner-vlan-id / vlan-tags inner statements
+}
+
+// qinqFinding records one (interface, unit) whose canonical stack carries
+// an unsupported inner tag, with the statements that contributed it.
+type qinqFinding struct {
+	iface string
+	unit  string
+	stack qinqUnitStack
+}
+
+// message renders the operator-facing reject / warn text, naming the
+// interface, unit, and the contributing inner (and any outer) statements so
+// a stack split across two statements or spellings is fully attributable.
+func (f qinqFinding) message() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "interfaces %s unit %s: unsupported QinQ / stacked-VLAN stack — inner (second) tag `%s`",
+		f.iface, f.unit, strings.Join(f.stack.inner, "`, `"))
+	if len(f.stack.outer) > 0 {
+		fmt.Fprintf(&b, " over outer tag `%s`", strings.Join(f.stack.outer, "`, `"))
+	}
+	b.WriteString(" is not enforced by the AF_XDP dataplane (parse_l2 unwinds a single " +
+		"VLAN tag; a double-tagged 802.1ad S-tag + 802.1Q C-tag frame falls to the kernel " +
+		"forwarding path and is never firewalled). Single 802.1Q tagging via `vlan-id` is " +
+		"supported — remove the inner tag (#2354, #5879)")
+	return b.String()
+}
+
+// vlanTagsHasToken reports whether a `vlan-tags` node carries the given
+// keyword (`outer`/`inner`) in EITHER AST shape: the flat / one-line shape
+// packs the keyword into the node's own Keys (`vlan-tags outer 100 inner
+// 200` -> Keys=[vlan-tags outer 100 inner 200]), while a hierarchical
+// `vlan-tags { outer 100; inner 200; }` nests them as child nodes.
+func vlanTagsHasToken(n *Node, token string) bool {
+	for _, k := range n.Keys[1:] {
+		if k == token {
+			return true
+		}
+	}
+	for _, c := range n.Children {
+		if len(c.Keys) > 0 && c.Keys[0] == token {
+			return true
+		}
+	}
+	return false
+}
+
+// renderVLANStmt renders a VLAN-tag statement back to readable text for the
+// reject / warn message, folding any nested children (the hierarchical
+// vlan-tags shape) onto one line.
+func renderVLANStmt(n *Node) string {
+	s := strings.Join(n.Keys, " ")
+	for _, c := range n.Children {
+		s += " " + strings.Join(c.Keys, " ")
+	}
+	return s
+}
+
+// unitVLANStack derives the canonical outer/inner tag stack of a logical-
+// unit node, unioning the `vlan-id`/`inner-vlan-id` spelling and the
+// `vlan-tags outer/inner` spelling (combined or split across statements).
+// A `vlan-tags` node counts as inner if it carries an `inner` keyword
+// (regardless of whether the same node also carries `outer`, i.e. the
+// combined `vlan-tags outer X inner Y` form is inner-bearing); otherwise an
+// `outer`-only `vlan-tags` is a single S-tag and contributes to outer.
+func unitVLANStack(unit *Node) qinqUnitStack {
+	var st qinqUnitStack
+	for _, c := range unit.Children {
+		if len(c.Keys) == 0 {
+			continue
+		}
+		switch c.Keys[0] {
+		case "vlan-id":
+			st.outer = append(st.outer, renderVLANStmt(c))
+		case "inner-vlan-id":
+			st.inner = append(st.inner, renderVLANStmt(c))
+		case "vlan-tags":
+			switch {
+			case vlanTagsHasToken(c, "inner"):
+				st.inner = append(st.inner, renderVLANStmt(c))
+			case vlanTagsHasToken(c, "outer"):
+				st.outer = append(st.outer, renderVLANStmt(c))
+			}
+		}
+	}
+	return st
+}
+
+// collectQinQFromInterfacesNode records every (interface, unit) under one
+// "interfaces" hierarchy node whose canonical VLAN stack carries an
+// unsupported inner tag into out, keyed by interface+unit so a finding
+// present in more than one node view is reported once.
+func collectQinQFromInterfacesNode(ifacesNode *Node, out map[string]qinqFinding) {
+	if ifacesNode == nil {
+		return
+	}
+	for _, iface := range ifacesNode.Children {
+		ifName := iface.Name()
+		if ifName == "" {
+			continue
+		}
+		for _, unit := range iface.Children {
+			if unit.Name() != "unit" {
+				continue
+			}
+			st := unitVLANStack(unit)
+			if len(st.inner) == 0 {
+				continue // supported single-tag / untagged unit
+			}
+			key := ifName + "\x00" + unitIdentity(unit)
+			if _, seen := out[key]; seen {
+				continue
+			}
+			out[key] = qinqFinding{iface: ifName, unit: unitIdentity(unit), stack: st}
+		}
+	}
+}
+
+// collectQinQFindingsForNode expands the candidate tree for chassis-cluster
+// node nodeID and records every (interface, unit) whose canonical stack
+// carries an unsupported inner tag into out. This IS the "aggregate
+// effective view for every cluster node" the #5879 invariant requires: the
+// concrete VLAN stack the compiler would render on node nodeID after
+// `${node}`/apply-groups expansion and interface-range expansion.
+//
+// It is RECURSION-FREE by construction (mirrors emitNodeExpandedZoneNames /
+// collectNodeExpandedInterfaceUnitSpellings): it clones the candidate,
+// expands groups for the node, expands interface ranges (so a range/wildcard
+// member's inner tag is seen exactly as runPreWalkGates would), and reads
+// the tag leaves straight off the expanded AST — it NEVER calls
+// CompileConfig* (which would re-enter this gate). A per-node expansion
+// error contributes NOTHING (non-fatal): a config that legitimately defines
+// only `groups node1` and references `${node}` fails to expand for node0
+// (`undefined group "node0"`), and the real per-node compile path already
+// rejects that on the affected node — this gate must not turn it into a
+// spurious commit failure, and the OTHER node's view still catches an inner
+// tag hidden in the un-expandable group. Every `interfaces` root is unioned
+// (#5744): a split hierarchical config can declare units under a second
+// `interfaces {}` stanza that compileSections still compiles.
+func collectQinQFindingsForNode(tree *ConfigTree, nodeID int, out map[string]qinqFinding) {
+	clone := tree.Clone()
+	vars := map[string]string{"node": fmt.Sprintf("node%d", nodeID)}
+	if err := clone.ExpandGroupsWithVars(vars); err != nil {
+		return
+	}
+	// expandInterfaceRanges mutates the clone in place; its warnings are
+	// emitted on the real path (runPreWalkGates) and discarded here.
+	_ = expandInterfaceRanges(clone)
+	for _, ifaces := range clone.FindChildren("interfaces") {
+		collectQinQFromInterfacesNode(ifaces, out)
+	}
+}
+
+// validateQinQVLANStackAST is the #5879 canonical per-physical-interface
+// QinQ honesty gate. It builds the effective VLAN stack for EVERY cluster
+// node (node0 AND node1 `${node}`/apply-groups expansions) and rejects any
+// unit whose aggregate stack carries an inner / second tag — regardless of
+// whether the inner tag was spelled `inner-vlan-id` or `vlan-tags inner`,
+// combined onto one statement or split across several, or contributed by a
+// peer-only group only the STANDBY node renders.
+//
+// Only the two per-node EFFECTIVE views are unioned (node0 + node1
+// expansion) — deliberately NOT the pre-expansion all-groups "View 1" the
+// sibling union gates (validateInterfaceUnitAliasCollisionsAST #5878,
+// validateZoneIDCollisionAST) also fold in. Those gates need View 1 because
+// their trigger is a COLLISION between two names/spellings, and View 1 keeps
+// a collision hidden in an un-expandable group symmetric across nodes. QinQ
+// trips on a SINGLE inner tag, so a View-1 union would additionally reject a
+// QinQ stanza staged in a group that NO apply-groups references — inert dead
+// config that never renders on any node — which is outside "the aggregate
+// effective view." Both node views are computed on both nodes regardless of
+// which node commits, so the verdict is already HA-symmetric without View 1,
+// and a peer-only APPLIED group's inner tag is caught by the other node's
+// view.
+//
+// Strict (lenient=false): the first offending unit (interface+unit sorted)
+// is a hard compile error, so the candidate is never promoted (no partial
+// outer/inner state survives). Lenient (lenient=true): every offending unit
+// is returned as a warning and compilation continues (the #1960 no-brick
+// tolerant-load / peer-sync contract).
+func validateQinQVLANStackAST(tree *ConfigTree, lenient bool) ([]string, error) {
+	findings := make(map[string]qinqFinding)
+	// The aggregate effective view for every cluster node. Both are pure
+	// functions of the same candidate, so the verdict is identical no matter
+	// which node commits (HA symmetry).
+	collectQinQFindingsForNode(tree, 0, findings)
+	collectQinQFindingsForNode(tree, 1, findings)
+	if len(findings) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(findings))
+	for k := range findings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var warnings []string
+	for _, k := range keys {
+		msg := findings[k].message()
+		if !lenient {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+	}
+	return warnings, nil
+}

--- a/pkg/config/compiler_interfaces_unsupported.go
+++ b/pkg/config/compiler_interfaces_unsupported.go
@@ -23,22 +23,22 @@ import "fmt"
 //     node (programRethMAC, 02:bf:72:CC:RR:NN) and Junos treats the
 //     interface MAC as read-only, so a static override is both
 //     unimplemented and divergent.
-//   - #2354: `interfaces <if> unit <n> inner-vlan-id <x>` — a QinQ /
-//     stacked-VLAN (802.1ad S-tag + 802.1Q C-tag) inner tag. The parser
-//     accepts it and the compiler stores it in Unit.InnerVlanID, but that
-//     field has ZERO dataplane consumers: the AF_XDP shim's parse_l2
-//     unwinds exactly ONE VLAN tag, so a double-tagged frame keeps
-//     eth_proto=0x8100 → the dispatch `_` arm XDP_PASSes it to the kernel
-//     forwarding path, never reaching the userspace firewall. A committed
-//     inner-vlan-id is therefore a false promise of firewalled stacked-
-//     VLAN transit. This gate is the honest-posture half of #2354; the
-//     multi-layer QinQ feature build (two-tag parse/deliver/serialize +
-//     networkd stacked netdev + zone binding on the inner tag) stays
-//     plan-deferred pending operator demand (see the 4-PR decomposition
-//     in the issue). Single 802.1Q / single 802.1ad tagging via `vlan-id`
-//     is fully supported and CORRECT (#2346) — this gate keys strictly on
-//     `inner-vlan-id`, so `flexible-vlan-tagging` WITHOUT an inner tag is
-//     never tripped (Junos-parity, single-tag transit works).
+//   - #2354 / #5879: a QinQ / stacked-VLAN (802.1ad S-tag + 802.1Q C-tag)
+//     inner tag. The AF_XDP shim's parse_l2 unwinds exactly ONE VLAN tag,
+//     so a double-tagged frame keeps eth_proto=0x8100 → the dispatch `_`
+//     arm XDP_PASSes it to the kernel forwarding path, never reaching the
+//     userspace firewall. A committed inner tag is therefore a false
+//     promise of firewalled stacked-VLAN transit. This detection now lives
+//     in the #5879 canonical per-physical-interface gate
+//     (validateQinQVLANStackAST, compiler_interfaces_qinq.go): it keys on
+//     the AGGREGATE effective stack across every spelling
+//     (`inner-vlan-id` AND `vlan-tags outer/inner`), statements split
+//     across a unit, and BOTH cluster-node expansions — catching a
+//     peer-only-group or `vlan-tags`-spelled inner tag the old single-
+//     statement `inner-vlan-id` check here missed. Single 802.1Q tagging
+//     via `vlan-id` (with or without `flexible-vlan-tagging`) stays fully
+//     supported and CORRECT (#2346). The multi-layer QinQ feature build
+//     stays plan-deferred pending operator demand.
 //
 // Why reject at commit (vs the warn-only M1 persist-groups-inheritance
 // or the PR #659 import-compat warnings): M1 is a daemon-behaviour knob
@@ -155,29 +155,15 @@ func validateUnsupportedInterfaceStanzasAST(nodes []*Node, lenient bool) ([]stri
 				}
 			}
 
-			// #2354: a QinQ / stacked-VLAN inner tag on the unit. The
-			// AF_XDP shim parses exactly one VLAN tag, so a double-tagged
-			// (S-tag + C-tag) frame is XDP_PASSed to the kernel and never
-			// firewalled — Unit.InnerVlanID has no dataplane consumer.
-			// Committing it is a false promise of firewalled stacked-VLAN
-			// transit. Keyed strictly on `inner-vlan-id` so single-tag
-			// `vlan-id` / `flexible-vlan-tagging` (both supported, #2346)
-			// are never tripped.
-			for _, c := range unit.Children {
-				if c.Name() == "inner-vlan-id" {
-					iv := nodeVal(c)
-					if err := emit(
-						"interfaces %s unit %s: `inner-vlan-id %s` (QinQ / "+
-							"stacked-VLAN inner tag) is not enforced by the AF_XDP "+
-							"dataplane — a double-tagged (802.1ad S-tag + 802.1Q "+
-							"C-tag) frame is parsed as a single tag and falls to the "+
-							"kernel forwarding path, never firewalled; single 802.1Q "+
-							"tagging via `vlan-id` is supported — remove it (#2354)",
-						ifName, unitID, iv); err != nil {
-						return nil, err
-					}
-				}
-			}
+			// #2354 QinQ / stacked-VLAN detection MOVED to the #5879
+			// canonical per-physical-interface gate
+			// (validateQinQVLANStackAST, compiler_interfaces_qinq.go). That
+			// gate keys on the AGGREGATE effective stack across every VLAN
+			// spelling (`inner-vlan-id` AND `vlan-tags outer/inner`), split
+			// statements, and BOTH cluster-node expansions — the single-
+			// statement `inner-vlan-id` check that lived here could not see
+			// a peer-only-group or `vlan-tags`-spelled inner tag. Nothing
+			// QinQ is checked in this post-expansion single-node walk.
 
 			// H9: a per-unit ARP policer under family inet / inet6.
 			for _, fam := range unit.Children {

--- a/pkg/config/qinq_canonical_vlan_5879_test.go
+++ b/pkg/config/qinq_canonical_vlan_5879_test.go
@@ -1,0 +1,196 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #5879: the unsupported-QinQ honesty gate must validate the
+// AGGREGATE canonical per-physical-interface VLAN stack — across every tag
+// spelling, statements split across a unit, and BOTH cluster-node effective
+// views — not just a single literal `inner-vlan-id` leaf on the committing
+// node's own expansion (the #2354 gate's blind spot).
+//
+// Before #5879 two classes of unsupported stacked-VLAN bypassed commit:
+//
+//   1. `vlan-tags outer <x> inner <y>` (the modern Junos QinQ spelling) is
+//      not in setSchema and has no compiler consumer, so it parse-accepted
+//      and was silently DROPPED — the #2354 gate only looked at
+//      `inner-vlan-id`. The inner half can even be split across two set
+//      statements, so no single leaf is the recognizable `inner-vlan-id`.
+//   2. An `inner-vlan-id` living under `groups node1` + `apply-groups
+//      "${node}"` never materializes when the candidate is compiled for
+//      node0, so a commit ON node0 accepted a stack that renders
+//      unsupported QinQ on node1 (an active/standby posture split).
+//
+// FAIL-ON-REVERT: dropping the `vlan-tags` inner branch of unitVLANStack
+// turns the split/combined vlan-tags rejects GREEN-accept (RED here);
+// dropping the node1 view in validateQinQVLANStackAST turns the peer-only
+// reject GREEN-accept (RED here).
+
+// mustReject5879 asserts the strict generic compile (CompileConfig) rejects
+// the tree with a #5879 QinQ error.
+func mustReject5879(t *testing.T, tree *ConfigTree) {
+	t.Helper()
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected strict compile to reject unsupported QinQ, got nil error")
+	}
+	if !strings.Contains(err.Error(), "#5879") || !strings.Contains(err.Error(), "QinQ") {
+		t.Fatalf("reject error %q does not name the #5879 QinQ gate", err.Error())
+	}
+}
+
+// mustAcceptNoQinQ asserts the strict generic compile accepts the tree and
+// records no #5879 QinQ warning — the scoped-gate control proving a
+// legitimate single-tag config is not caught.
+func mustAcceptNoQinQ(t *testing.T, tree *ConfigTree) *Config {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected strict compile to accept supported VLAN config, got %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#5879") {
+			t.Fatalf("supported VLAN config must not warn #5879, got %q", w)
+		}
+	}
+	return cfg
+}
+
+// TestQinQVlanTagsSplitAcrossStatementsRejected_5879 is the primary
+// fail-on-revert: an inner tag spelled via `vlan-tags`, SPLIT across two set
+// statements so neither statement alone is the `inner-vlan-id` the old gate
+// keyed on, is rejected at commit. Control: the outer half alone (a single
+// S-tag) still compiles.
+func TestQinQVlanTagsSplitAcrossStatementsRejected_5879(t *testing.T) {
+	// Non-tautological baseline: the outer `vlan-tags` statement ALONE is a
+	// single tag and must compile clean (the gate keys on the INNER tag).
+	mustAcceptNoQinQ(t, flatTreeFromSets(t,
+		"set interfaces ge-0/0/0 flexible-vlan-tagging",
+		"set interfaces ge-0/0/0 unit 0 vlan-tags outer 100",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	))
+	// Adding the inner half — a SEPARATE statement — makes the aggregate
+	// stack unsupported QinQ and hard-rejects.
+	mustReject5879(t, flatTreeFromSets(t,
+		"set interfaces ge-0/0/0 flexible-vlan-tagging",
+		"set interfaces ge-0/0/0 unit 0 vlan-tags outer 100",
+		"set interfaces ge-0/0/0 unit 0 vlan-tags inner 200",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	))
+}
+
+// TestQinQVlanTagsCombinedRejected_5879 — the inner tag spelled via the
+// single-statement `vlan-tags outer X inner Y` form (which the #2354 gate
+// never inspected) is rejected, in both flat-set and hierarchical shapes.
+func TestQinQVlanTagsCombinedRejected_5879(t *testing.T) {
+	mustReject5879(t, flatTreeFromSets(t,
+		"set interfaces ge-0/0/0 flexible-vlan-tagging",
+		"set interfaces ge-0/0/0 unit 0 vlan-tags outer 100 inner 200",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	))
+	mustReject5879(t, hierTree(t, `interfaces {
+    ge-0/0/0 {
+        flexible-vlan-tagging;
+        unit 0 {
+            vlan-tags outer 100 inner 200;
+            family inet { address 10.0.1.1/24; }
+        }
+    }
+}`))
+}
+
+// TestQinQVlanTagsOuterOnlyAccepted_5879 pins the scope: a single S-tag via
+// `vlan-tags outer` (no inner) is NOT QinQ and must stay accepted — the gate
+// keys on the inner (second) tag, not on the presence of `vlan-tags`.
+func TestQinQVlanTagsOuterOnlyAccepted_5879(t *testing.T) {
+	mustAcceptNoQinQ(t, flatTreeFromSets(t,
+		"set interfaces ge-0/0/0 flexible-vlan-tagging",
+		"set interfaces ge-0/0/0 unit 0 vlan-tags outer 100",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	))
+	// A plain single 802.1Q `vlan-id` (the fully-supported common case).
+	mustAcceptNoQinQ(t, flatTreeFromSets(t,
+		"set interfaces ge-0/0/0 unit 0 vlan-id 100",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	))
+}
+
+// TestQinQPeerOnlyGroupRejectedOnCommittingNode_5879 is the second
+// fail-on-revert: an `inner-vlan-id` that only materializes in the node1
+// (standby) effective view — it lives under `groups node1` applied through
+// `apply-groups "${node}"` — is rejected when the config is compiled FOR
+// NODE 0 (the primary's commit). The primary's own expansion has no inner
+// tag, so only the both-node union catches it.
+func TestQinQPeerOnlyGroupRejectedOnCommittingNode_5879(t *testing.T) {
+	src := `groups {
+    node0 {
+        interfaces {
+            ge-0/0/0 { unit 0 { vlan-id 100; family inet { address 10.0.1.1/24; } } }
+        }
+    }
+    node1 {
+        interfaces {
+            ge-0/0/0 { unit 0 { vlan-id 100; inner-vlan-id 200; family inet { address 10.0.1.1/24; } } }
+        }
+    }
+}
+apply-groups "${node}";
+chassis { cluster { node 0; } }`
+	tree := hierTree(t, src)
+
+	// Committing AS NODE 0: node0's own view is single-tag (clean), but the
+	// node1 effective view is unsupported QinQ — the both-node union rejects.
+	if _, err := CompileConfigForNode(tree, 0); err == nil {
+		t.Fatalf("commit as node0 must reject a QinQ that renders only in the node1 view")
+	} else if !strings.Contains(err.Error(), "#5879") || !strings.Contains(err.Error(), "ge-0/0/0") {
+		t.Fatalf("node0-commit reject %q does not name the #5879 QinQ gate / interface", err.Error())
+	}
+	// Committing AS NODE 1 also rejects (its own view is QinQ) — proving the
+	// verdict is node-symmetric, not a node0-only artifact.
+	if _, err := CompileConfigForNode(tree, 1); err == nil {
+		t.Fatalf("commit as node1 must reject its own QinQ view")
+	}
+
+	// Control: the SAME structure with node1 also single-tag (no inner) must
+	// compile clean for both nodes — proving the reject is the inner tag, not
+	// the group scaffolding.
+	clean := hierTree(t, `groups {
+    node0 { interfaces { ge-0/0/0 { unit 0 { vlan-id 100; family inet { address 10.0.1.1/24; } } } } }
+    node1 { interfaces { ge-0/0/0 { unit 0 { vlan-id 100; family inet { address 10.0.1.1/24; } } } } }
+}
+apply-groups "${node}";
+chassis { cluster { node 0; } }`)
+	if _, err := CompileConfigForNode(clean, 0); err != nil {
+		t.Fatalf("single-tag node-scoped config must compile for node0: %v", err)
+	}
+	if _, err := CompileConfigForNode(clean, 1); err != nil {
+		t.Fatalf("single-tag node-scoped config must compile for node1: %v", err)
+	}
+}
+
+// TestQinQGateLenientWarnsNoBrick_5879 — the tolerant load / peer-sync path
+// (#1960) downgrades an unsupported QinQ stack (here the `vlan-tags` inner
+// spelling) to a warning and still compiles, so a config an older binary
+// silently accepted never bricks an upgrading / receiving node.
+func TestQinQGateLenientWarnsNoBrick_5879(t *testing.T) {
+	cfg, err := CompileConfigLenient(flatTreeFromSets(t,
+		"set interfaces ge-0/0/0 flexible-vlan-tagging",
+		"set interfaces ge-0/0/0 unit 0 vlan-tags outer 100 inner 200",
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+	))
+	if err != nil {
+		t.Fatalf("lenient compile must not brick on an unsupported QinQ stack: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#5879") && strings.Contains(w, "ge-0/0/0") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile must warn about the unsupported QinQ stack; warnings = %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -116,11 +116,15 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 		},
 		// inner-vlan-id stays typed (range-validated) so a malformed value
 		// still reports a clean error, but a well-formed inner tag is
-		// HARD-REJECTED at commit by the #2354 honest-posture gate
-		// (validateUnsupportedInterfaceStanzasAST): the AF_XDP dataplane does
-		// not enforce QinQ / stacked-VLAN transit, so committing an inner tag
-		// would be a false promise. Single 802.1Q tagging via vlan-id is
-		// supported.
+		// HARD-REJECTED at commit by the #5879 canonical per-physical-
+		// interface QinQ gate (validateQinQVLANStackAST, compiler_interfaces_
+		// qinq.go — the #2354 honest-posture gate, generalized to the
+		// aggregate stack across every spelling and both cluster-node views):
+		// the AF_XDP dataplane does not enforce QinQ / stacked-VLAN transit,
+		// so committing an inner tag would be a false promise. The modern
+		// `vlan-tags outer/inner` spelling is intentionally NOT a setSchema
+		// leaf (advertising an unsupported feature would mislead) — the same
+		// gate rejects it. Single 802.1Q tagging via vlan-id is supported.
 		"inner-vlan-id": {
 			desc:          "Inner VLAN ID (QinQ; NOT enforced — rejected at commit, #2354)",
 			args:          1,


### PR DESCRIPTION
Closes #5879

## Summary

- The #2354 unsupported-QinQ honesty gate validated a **local statement shape** — a literal `inner-vlan-id` leaf on the committing node's own `${node}`/apply-groups expansion — not the **aggregate effective per-physical-interface VLAN stack**. Two classes of unsupported stacked-VLAN bypassed a strict commit (both verified live against the real `CheckText` commit path).
- **`vlan-tags outer/inner` spelling.** The modern Junos QinQ syntax is not a `setSchema` leaf and has no compiler consumer, so it parse-accepts and is silently dropped — the #2354 gate only looked at `inner-vlan-id`. The inner half can even be **split across two set statements** (`vlan-tags outer 100` + `vlan-tags inner 200`), so no single leaf is the recognizable `inner-vlan-id`.
- **Peer-only node view.** An `inner-vlan-id`/`vlan-tags inner` under `groups node1` + `apply-groups "${node}"` never materializes when the candidate is compiled for node0, so a commit **on node0 accepted a stack that renders unsupported QinQ on node1** — the AF_XDP dataplane unwinds one VLAN tag and `XDP_PASS`es the double-tagged frame to the kernel, unfirewalled, so the standby silently forwards what the primary firewalls (zone-policy bypass / active-standby posture split).
- New `validateQinQVLANStackAST` (`compiler_interfaces_qinq.go`) builds each unit's **canonical outer/inner tag stack** across both spellings (combined onto one statement or split across several) and rejects any unit whose stack carries an inner (second) tag, naming the contributing statements. It runs **pre-expansion** beside the tunnel/zone/table-id/unit-alias union gates and evaluates the effective view for **every cluster node** (node0 **and** node1 expansions + interface-range expansion), so the verdict is HA-symmetric no matter which node commits.
- The QinQ detection is removed from `validateUnsupportedInterfaceStanzasAST` (its H9/H10 `mac` / `policer arp` rejects stay). Strict on commit / commit-check; downgraded to a warning on the tolerant load / peer-sync paths via the new `lenientQinQVLANStack` opt (#1960 no-brick). Rejection is a compile error, so the candidate is never promoted — no partial outer/inner state survives.

## Design note — why only the two per-node effective views (no "View 1")

The sibling union gates (`#5878` unit-alias, `#3075` zone-id) also fold in a pre-expansion **all-groups** "View 1" because their trigger is a *collision between two names* and View 1 keeps a collision hidden in an un-expandable group symmetric. QinQ trips on a **single** inner tag, so a View-1 union would additionally reject a QinQ stanza staged in a group that **no** `apply-groups` references — inert dead config outside any node's effective view. Both node views are computed on both nodes regardless of which commits, so the verdict is already HA-symmetric, and a peer-only *applied* group's inner tag is caught by the other node's view. This is the precise reading of the issue's "aggregate effective view for every cluster node."

## Test plan

- [x] `pkg/config/qinq_canonical_vlan_5879_test.go`:
  - `TestQinQVlanTagsSplitAcrossStatementsRejected_5879` — inner tag split across two `vlan-tags` statements is rejected; outer-half-alone control compiles.
  - `TestQinQVlanTagsCombinedRejected_5879` — `vlan-tags outer X inner Y` rejected (flat-set + hierarchical).
  - `TestQinQPeerOnlyGroupRejectedOnCommittingNode_5879` — `inner-vlan-id` only in `groups node1` is rejected on the **node0** commit (`CompileConfigForNode(tree, 0)`); node-symmetric; single-tag control accepts.
  - `TestQinQVlanTagsOuterOnlyAccepted_5879` / `TestQinQGateLenientWarnsNoBrick_5879` — scope + no-brick controls.
- [x] Existing `#2354` (`compiler_interfaces_unsupported_test.go`) and `#5744` all-roots coverage stays green.
- [x] `go build ./...`; `go test ./pkg/config/... ./pkg/configstore/...` pass (new tests 3× non-flake).
- [x] **Parent-RED:** disabling the `vlan-tags` inner branch of `unitVLANStack` turns the split/combined rejects RED as assertion failures; dropping `collectQinQFindingsForNode(tree, 1, findings)` turns the peer-only reject RED — each a single compiling neutralization, clean assertion failure (target-count 1 each).
- **Deploy / smoke:** none. This is config-time validation only (no dataplane / runtime surface), so no cluster smoke lane applies.

## Refs

- #2354 (original single-statement QinQ reject, generalized here)
- #5878 / #3075 (sibling both-node / union pre-expansion gates this models on)
- #1960 (fail-closed-on-load / warn-on-tolerant-load doctrine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7aSWEYQZgsak4CVVfurio
