### PR TITLE
cli: route console zeroize through daemon reset transaction (#5871)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54305,3 +54305,28 @@ top.
   pkg/config/compiler_interfaces_unsupported.go, pkg/config/compiler.go,
   pkg/config/schema_interfaces.go, pkg/config/qinq_canonical_vlan_5879_test.go (new),
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5871 — route interactive-CLI `request system zeroize` through the
+  daemon's coordinated factory-reset transaction. Pre-fix the console called the
+  wipe primitive DIRECTLY (`zeroizeFullWipe` -> `grpcapi.PerformZeroizeWipe`),
+  bypassing the daemon apply-gate + terminal reset generation the gRPC path uses
+  (`SystemAction{zeroize}` -> `runZeroize` -> `ZeroizeFn` -> `d.factoryReset`).
+  So a console zeroize erased state out-of-band: a concurrent commit / HA-sync /
+  reconcile could re-persist the just-erased `.configdb` SSOT or re-render the
+  wiped secrets while the console reported a clean reset (#5890 had already
+  unified the WIPE file-set; this closes the TRANSACTION/fencing gap). Fix: added
+  `CLI.factoryResetFn` + `SetFactoryResetFn`, wired by the daemon to
+  `d.factoryReset` (the SAME function as gRPC `ZeroizeFn`); `performConsoleZeroize`
+  now runs the wipe THROUGH it (acquires `d.applySem`, enters the reset
+  generation BEFORE erasing). Nil hook = CLI spawned outside the daemon (offline
+  recovery / unit test) -> explicit ungated direct-wipe fallback (no reconcile
+  loop to race), mirroring `runZeroize`'s `zeroizeFn==nil` path; still
+  fail-CLOSED, still stops the daemon only on full success. Fail-on-revert test
+  `TestConsoleZeroizeRoutesThroughDaemonTransaction_5871` binds
+  `performConsoleZeroize`'s `factoryResetFn` route; two more pin
+  transaction/removal-failure surfacing fail-CLOSED. Unit-provable (no smoke —
+  in-process wiring + seam spies).
+- **File(s)**: pkg/cli/cli.go, pkg/cli/cli_request_system.go,
+  pkg/daemon/daemon_run.go, pkg/cli/console_zeroize_transaction_5871_test.go (new),
+  pkg/cli/README.md, pkg/grpcapi/README.md, pkg/daemon/README.md, _Log.md

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -52,6 +52,22 @@ sibling files (same package, so unexported helpers stay reachable):
     reboot into a half-wiped, secret-retaining state). The `#5554`/`#5280`
     configured-root resolution (a non-default `-config` erases its own root,
     not a hardcoded `/etc/xpf`) is preserved inside `zeroizeConfigRoot`.
+  - **`zeroize` runs THROUGH the daemon's coordinated factory-reset
+    transaction (#5871), not out-of-band.** `performConsoleZeroize` routes the
+    wipe through `factoryResetFn` — wired by the daemon to `d.factoryReset`
+    via `SetFactoryResetFn`, the SAME gate the gRPC path uses as
+    `grpcapi.Config.ZeroizeFn`. The transaction acquires the daemon apply
+    semaphore (draining any in-flight apply, blocking a concurrent one) and
+    enters the terminal reset generation BEFORE erasing, so no concurrent /
+    subsequent commit / HA-sync / reconcile re-persists the erased `.configdb`
+    SSOT or re-renders the wiped secrets. The pre-#5871 console called the
+    wipe DIRECTLY (ungated), so a concurrent writer could re-create just-erased
+    state while the console reported a clean reset. `factoryResetFn` is nil
+    only when the CLI is spawned OUTSIDE the daemon (offline recovery / unit
+    test): there is no reconcile loop to race, so the ungated direct wipe is
+    the explicit, reduced-guarantee fallback (mirroring
+    `grpcapi.runZeroize`'s `zeroizeFn==nil` path) — still fail-CLOSED and
+    still stops the daemon only on a fully-successful reset.
 - `cli_request_security.go` — `request security ipsec|policies|wireguard`.
 
 The security-sensitive `--` end-of-options separators in the diagcmd/tcpdump

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -111,6 +111,22 @@ type CLI struct {
 	commitFn          func(ctx context.Context, comment string) (*config.Config, error)
 	commitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
 
+	// factoryResetFn routes `request system zeroize` through the DAEMON's
+	// coordinated factory-reset transaction (#5871) — the SAME gate the gRPC
+	// zeroize path uses (grpcapi.Config.ZeroizeFn -> daemon.factoryReset). It
+	// acquires the daemon's apply semaphore (draining any in-flight apply,
+	// blocking a concurrent one) and enters the terminal reset generation BEFORE
+	// the wipe closure runs, so no concurrent/subsequent commit / HA-sync /
+	// reconcile re-persists the erased .configdb SSOT or re-renders the wiped
+	// secrets (frr.conf / swanctl PSKs / Kea / login accounts). The wipe closure
+	// it receives is the shared grpcapi.PerformZeroizeWipe primitive (via the
+	// zeroizeFullWipe seam), so the console and gRPC paths run an identical,
+	// single-source-of-truth reset under identical fencing. Nil ONLY when the CLI
+	// is spawned OUTSIDE the daemon (offline recovery / unit test): there is no
+	// running reconcile loop to race, so performConsoleZeroize falls back to an
+	// ungated direct wipe, mirroring grpcapi.runZeroize's zeroizeFn==nil path.
+	factoryResetFn func(ctx context.Context, wipe func() error) error
+
 	// Fabric peer dialing for cluster-wide queries (fab0 + optional fab1).
 	fabricPeerAddrFn func() []string
 	fabricVRFDevice  string
@@ -306,6 +322,19 @@ func (c *CLI) SetCommitFns(
 ) {
 	c.commitFn = commitFn
 	c.commitConfirmedFn = commitConfirmedFn
+}
+
+// SetFactoryResetFn wires the daemon's coordinated factory-reset transaction
+// (#5871) so the in-process `request system zeroize` runs its wipe under the
+// daemon apply gate + terminal reset generation, IDENTICAL to the gRPC zeroize
+// path (grpcapi.Config.ZeroizeFn -> daemon.factoryReset — the same function).
+// Without it a console zeroize erased state out-of-band, so a concurrent commit
+// / HA-sync / reconcile could re-create the just-wiped .configdb SSOT or
+// re-render the erased secrets. Leave unset for a CLI spawned outside the daemon
+// (offline recovery / unit test): performConsoleZeroize then falls back to an
+// ungated direct wipe (no reconcile loop is running to race).
+func (c *CLI) SetFactoryResetFn(fn func(ctx context.Context, wipe func() error) error) {
+	c.factoryResetFn = fn
 }
 
 // SetFabricPeer configures fabric peer dialing for cluster-wide queries.

--- a/pkg/cli/cli_request_system.go
+++ b/pkg/cli/cli_request_system.go
@@ -161,12 +161,37 @@ var zeroizeStopDaemon = func() error {
 // (zeroizeConfigRoot, #5554/#5684), failing CLOSED if it cannot be determined,
 // so a non-default `-config` erases the right directory (never a hardcoded
 // /etc/xpf). It then stops the daemon.
+//
+// #5871: the wipe runs THROUGH the daemon's coordinated factory-reset
+// transaction (factoryResetFn -> daemon.factoryReset, the SAME gate the gRPC
+// ZeroizeFn path uses) so the console gets IDENTICAL fencing: the transaction
+// acquires the daemon apply semaphore (draining any in-flight apply, blocking a
+// concurrent one) and enters the terminal reset generation BEFORE erasing, so no
+// commit / HA-sync / reconcile re-persists the erased .configdb SSOT or
+// re-renders the wiped secrets. The pre-#5871 console called zeroizeFullWipe
+// DIRECTLY (ungated), so a concurrent writer could re-create just-erased state
+// while the console reported a clean reset — the security bug this closes.
 func (c *CLI) performConsoleZeroize() error {
 	configDir, configBase, err := c.zeroizeConfigRoot()
 	if err != nil {
 		return err
 	}
-	if err := zeroizeFullWipe(configDir, configBase); err != nil {
+	// The shared full factory-reset wipe primitive (config state + tls/ +
+	// rendered service configs [frr/swanctl/kea] + provisioned login accounts +
+	// config archive + BPF pins + networkd), #5890.
+	wipe := func() error { return zeroizeFullWipe(configDir, configBase) }
+
+	// Route through the daemon's coordinated transaction when wired. When it is
+	// nil the CLI is spawned OUTSIDE the daemon (offline recovery / unit test) —
+	// no reconcile loop is running to race, so the ungated direct wipe is the
+	// honest fallback, mirroring grpcapi.runZeroize's zeroizeFn==nil path. Either
+	// way the wipe/transaction error is surfaced fail-CLOSED (never discarded) and
+	// the daemon is stopped ONLY on a fully-successful reset.
+	run := wipe
+	if c.factoryResetFn != nil {
+		run = func() error { return c.factoryResetFn(context.Background(), wipe) }
+	}
+	if err := run(); err != nil {
 		return fmt.Errorf("zeroize: factory reset did not fully complete: %w", err)
 	}
 	_ = zeroizeStopDaemon()

--- a/pkg/cli/console_zeroize_transaction_5871_test.go
+++ b/pkg/cli/console_zeroize_transaction_5871_test.go
@@ -1,0 +1,167 @@
+package cli
+
+// #5871: the interactive-console `request system zeroize` must run its wipe
+// THROUGH the daemon's coordinated factory-reset transaction (factoryResetFn ->
+// daemon.factoryReset, the SAME gate the gRPC ZeroizeFn path uses), not as an
+// independent out-of-band wipe. The transaction acquires the daemon apply
+// semaphore and enters the terminal reset generation BEFORE erasing, so no
+// concurrent/subsequent commit / HA-sync / reconcile can re-create the
+// just-erased .configdb SSOT or re-render the wiped secrets while the console
+// reports a clean reset. #5890 already unified the WIPE primitive; these tests
+// pin that the console runs it under the daemon's FENCING transaction and
+// surfaces a transaction/removal failure fail-CLOSED.
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// TestConsoleZeroizeRoutesThroughDaemonTransaction_5871 is the fail-on-revert
+// pin for #5871: when the daemon has wired factoryResetFn, the console MUST run
+// the wipe inside that coordinated transaction (the apply-gate + terminal reset
+// generation), not call the wipe directly/ungated.
+//
+// FAIL-ON-REVERT: reverting performConsoleZeroize to call zeroizeFullWipe
+// directly (the pre-#5871 ungated path) makes factoryResetFn never fire, so
+// `enteredTransaction` stays false and the assertion goes RED.
+func TestConsoleZeroizeRoutesThroughDaemonTransaction_5871(t *testing.T) {
+	c := &CLI{store: newConfigStore(t, filepath.Join(t.TempDir(), "site.conf"))}
+
+	var enteredTransaction, wipedAtAll, wipedInsideTransaction, stopped bool
+	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
+	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
+	zeroizeFullWipe = func(string, string) error {
+		wipedAtAll = true
+		// Records that the wipe ran only AFTER the transaction was entered —
+		// proving fencing (apply-gate + reset generation) precedes erasure.
+		if enteredTransaction {
+			wipedInsideTransaction = true
+		}
+		return nil
+	}
+	zeroizeStopDaemon = func() error { stopped = true; return nil }
+
+	// Spy coordinated transaction: mirrors daemon.factoryReset's contract —
+	// enters the gate, then runs the wipe closure while "held".
+	c.factoryResetFn = func(_ context.Context, wipe func() error) error {
+		enteredTransaction = true
+		return wipe()
+	}
+
+	if err := c.performConsoleZeroize(); err != nil {
+		t.Fatalf("performConsoleZeroize: %v", err)
+	}
+	if !enteredTransaction {
+		t.Fatal("console zeroize did NOT route through the daemon's coordinated " +
+			"factory-reset transaction (#5871): it ran the wipe ungated, bypassing " +
+			"the apply-gate + terminal reset generation")
+	}
+	if !wipedAtAll {
+		t.Fatal("console zeroize never ran the shared wipe primitive")
+	}
+	if !wipedInsideTransaction {
+		t.Fatal("console zeroize ran the wipe OUTSIDE the coordinated transaction " +
+			"(fencing not applied before erasure)")
+	}
+	if !stopped {
+		t.Fatal("console zeroize did not stop the daemon after a successful reset")
+	}
+}
+
+// TestConsoleZeroizeSurfacesTransactionFailure_5871 pins fail-CLOSED behavior
+// through the transaction path: a factory-reset transaction FAILURE (e.g. the
+// apply semaphore could not be acquired, or a rendered-config removal inside the
+// wipe failed) must be SURFACED to the operator, never discarded, and the daemon
+// must NOT be stopped (a half-reset box must stay recoverable rather than reboot
+// into a partial, secret-retaining reset).
+func TestConsoleZeroizeSurfacesTransactionFailure_5871(t *testing.T) {
+	c := &CLI{store: newConfigStore(t, filepath.Join(t.TempDir(), "site.conf"))}
+
+	// A removal failure inside the wipe, propagated by the transaction — the
+	// exact "reconciler/removal FAILURE surfaced (not discarded)" contract.
+	removalErr := errors.New("remove rendered frr.conf failed")
+	var enteredTransaction, stopped bool
+	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
+	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
+	zeroizeFullWipe = func(string, string) error { return removalErr }
+	zeroizeStopDaemon = func() error { stopped = true; return nil }
+
+	c.factoryResetFn = func(_ context.Context, wipe func() error) error {
+		enteredTransaction = true
+		// daemon.factoryReset propagates the wipe error (and exits the reset
+		// generation) — the console must not swallow it.
+		return wipe()
+	}
+
+	err := c.performConsoleZeroize()
+	if !enteredTransaction {
+		t.Fatal("console zeroize did not route through the coordinated transaction (#5871)")
+	}
+	if err == nil || !errors.Is(err, removalErr) {
+		t.Fatalf("console zeroize must surface a removal/transaction failure "+
+			"fail-closed (not discard it), got %v", err)
+	}
+	if stopped {
+		t.Fatal("console zeroize stopped the daemon despite an incomplete reset " +
+			"(would reboot into a partial, secret-retaining state)")
+	}
+}
+
+// TestConsoleZeroizeSurfacesGateAcquireFailure_5871 pins that a transaction that
+// fails BEFORE the wipe (e.g. the apply-gate acquire is cancelled, or a factory
+// reset is already in progress) is surfaced fail-CLOSED and never runs the wipe
+// or stops the daemon.
+func TestConsoleZeroizeSurfacesGateAcquireFailure_5871(t *testing.T) {
+	c := &CLI{store: newConfigStore(t, filepath.Join(t.TempDir(), "site.conf"))}
+
+	gateErr := errors.New("apply gate: context canceled")
+	var wiped, stopped bool
+	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
+	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
+	zeroizeFullWipe = func(string, string) error { wiped = true; return nil }
+	zeroizeStopDaemon = func() error { stopped = true; return nil }
+
+	// The transaction fails to enter the gate and never invokes the wipe closure.
+	c.factoryResetFn = func(context.Context, func() error) error { return gateErr }
+
+	err := c.performConsoleZeroize()
+	if err == nil || !errors.Is(err, gateErr) {
+		t.Fatalf("console zeroize must surface an apply-gate acquire failure "+
+			"fail-closed, got %v", err)
+	}
+	if wiped {
+		t.Fatal("console zeroize ran the wipe even though the transaction never entered the gate")
+	}
+	if stopped {
+		t.Fatal("console zeroize stopped the daemon despite a failed transaction")
+	}
+}
+
+// TestConsoleZeroizeOfflineFallbackUngatedWipe_5871 pins the explicit
+// offline-recovery fallback: a CLI spawned OUTSIDE the daemon has no
+// factoryResetFn wired, so performConsoleZeroize runs the shared wipe directly
+// (no reconcile loop is running to race) and still surfaces failures / stops the
+// daemon on success. This documents the reduced-guarantee path is deliberate,
+// not a silent partial best-effort.
+func TestConsoleZeroizeOfflineFallbackUngatedWipe_5871(t *testing.T) {
+	c := &CLI{store: newConfigStore(t, filepath.Join(t.TempDir(), "site.conf"))}
+	// factoryResetFn deliberately left nil (no daemon).
+
+	var wiped, stopped bool
+	origWipe, origStop := zeroizeFullWipe, zeroizeStopDaemon
+	t.Cleanup(func() { zeroizeFullWipe, zeroizeStopDaemon = origWipe, origStop })
+	zeroizeFullWipe = func(string, string) error { wiped = true; return nil }
+	zeroizeStopDaemon = func() error { stopped = true; return nil }
+
+	if err := c.performConsoleZeroize(); err != nil {
+		t.Fatalf("performConsoleZeroize (offline fallback): %v", err)
+	}
+	if !wiped {
+		t.Fatal("offline-fallback console zeroize did not run the shared wipe primitive")
+	}
+	if !stopped {
+		t.Fatal("offline-fallback console zeroize did not stop the daemon after success")
+	}
+}

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -441,8 +441,13 @@ never lock an operator out of a remote box it manages.
 - `commitFn` and `commitConfirmedFn` are passed to `pkg/cli` and
   `pkg/grpcapi`; they hold the apply semaphore across the commit + apply
   pair so concurrent committers serialize.
-- **Factory-reset gate (`factoryReset`, wired as `grpcapi.Config.ZeroizeFn`,
-  #5281).** A gRPC `zeroize` no longer erases state out-of-band. `factoryReset`
+- **Factory-reset gate (`factoryReset`, wired as `grpcapi.Config.ZeroizeFn`
+  AND as the in-process CLI's `cli.SetFactoryResetFn`, #5281/#5871).** Neither
+  a gRPC `zeroize` nor an interactive-console `request system zeroize` erases
+  state out-of-band any more: BOTH route the wipe through this one
+  `factoryReset` transaction (#5871 wired the console — `daemon_run.go`
+  `shell.SetFactoryResetFn(d.factoryReset)` — through the same gate the gRPC
+  server already used). `factoryReset`
   acquires the SAME `applySem` commit/apply/HA-sync serialize on (draining any
   in-flight apply), enters a **terminal reset generation** (`d.resetting`,
   `isResetting`/`enterResetGeneration`/`exitResetGeneration`) BEFORE running the

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -738,6 +738,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// shellCommitConfirmedFn seams so it is fail-on-revert covered
 		// (#5961, configsync_transport_5054_test.go).
 		shell.SetCommitFns(d.shellCommitFn(), d.shellCommitConfirmedFn())
+		// #5871: route the in-process `request system zeroize` through the
+		// daemon's coordinated factory-reset transaction — the SAME function wired
+		// into the gRPC server as grpcapi.Config.ZeroizeFn. factoryReset takes
+		// d.applySem (draining any in-flight apply) and enters the terminal reset
+		// generation BEFORE the wipe, so a console zeroize can no longer erase
+		// state out-of-band while a concurrent commit / HA-sync / reconcile
+		// re-creates the just-erased .configdb SSOT or re-renders the wiped secrets.
+		shell.SetFactoryResetFn(d.factoryReset)
 		shell.SetRPMResultsFn(func() []*rpm.ProbeResult {
 			if d.rpm != nil {
 				return d.rpm.Results()

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -150,11 +150,22 @@ contract.
   the SAME primitive `runZeroize` runs — so both paths erase an IDENTICAL
   single-source-of-truth OWNED-artifact set and cannot diverge again. The
   console keeps its own root resolution (`cli.zeroizeConfigRoot`, #5554/
-  #5684) and daemon stop; it does NOT take the gRPC apply-gate (it runs
-  in-process and stops xpfd itself). The rendered/BPF/networkd leg targets
-  in `performZeroizeWipe` are package vars so the full primitive is
-  hermetically testable end-to-end (no real `/etc`) — production paths
-  unchanged.
+  #5684) and daemon stop. **The console also runs the wipe THROUGH the
+  daemon's coordinated factory-reset transaction (#5871).** It does not dial
+  gRPC (it is in-process); instead the daemon wires the SAME `factoryReset`
+  gate it wires into the gRPC server as `ZeroizeFn` into the CLI via
+  `cli.SetFactoryResetFn(d.factoryReset)`, and `cli.performConsoleZeroize`
+  routes the wipe closure through it. So the console wipe now takes
+  `d.applySem` and enters the terminal reset generation BEFORE erasing —
+  identical fencing to the gRPC path — closing the pre-#5871 window where an
+  ungated console wipe let a concurrent commit / HA-sync / reconcile re-create
+  the just-erased `.configdb` SSOT or re-render the wiped secrets. When the
+  CLI is spawned OUTSIDE the daemon (offline recovery / unit test)
+  `factoryResetFn` is nil and the console falls back to the ungated direct
+  wipe (no reconcile loop is running to race), mirroring `runZeroize`'s
+  `zeroizeFn==nil` fallback. The rendered/BPF/networkd leg targets in
+  `performZeroizeWipe` are package vars so the full primitive is hermetically
+  testable end-to-end (no real `/etc`) — production paths unchanged.
 - **Zeroize erases the CONFIGURED config root, not a hardcoded `/etc/xpf`
   (#5280).** `runZeroize` resolves the config root from
   `configstore.Store.ConfigPath()` — the daemon's `-config` path, the SAME


### PR DESCRIPTION
## Summary

- The interactive-console `request system zeroize` ran its wipe **out-of-band**: `performConsoleZeroize` called the shared wipe primitive (`zeroizeFullWipe` → `grpcapi.PerformZeroizeWipe`) **directly**, bypassing the daemon's coordinated factory-reset **transaction** the gRPC path uses (`SystemAction{zeroize}` → `runZeroize` → `ZeroizeFn` → `d.factoryReset`).
- That transaction takes the daemon apply semaphore (draining any in-flight apply, blocking a concurrent one) and enters the **terminal reset generation BEFORE erasing**, so no concurrent/subsequent commit / HA-sync / reconcile can re-persist the just-erased `.configdb` SSOT or re-render the wiped secrets (frr.conf / swanctl PSKs / Kea / login accounts).
- Without it a console zeroize could report a clean factory reset while a racing writer re-created prior-tenant state on disk — a re-tenant / RMA **secret-residue** bug. #5890 already unified the WIPE *file-set*; this closes the remaining **transaction / fencing** divergence.
- Fix: add `CLI.factoryResetFn` + `SetFactoryResetFn`, wired by the daemon (`daemon_run.go`) to `d.factoryReset` — the SAME function already wired into the gRPC server as `grpcapi.Config.ZeroizeFn`. `performConsoleZeroize` now runs the wipe THROUGH it, so the console gets identical fencing.
- Nil hook = CLI spawned **outside** the daemon (offline recovery / unit test): no reconcile loop to race → explicit ungated direct-wipe fallback, mirroring `runZeroize`'s `zeroizeFn==nil` path. Either path is fail-CLOSED (wipe/transaction error surfaced, never discarded) and stops the daemon only on a fully-successful reset.

## Divergence pinned (file:line)

- **CLI (pre-fix, ungated):** `pkg/cli/cli_request_system.go` `performConsoleZeroize` → `zeroizeFullWipe(configDir, configBase)` called directly.
- **gRPC (gated):** `pkg/grpcapi/server_diag_system_action.go` `runZeroize` → `s.zeroizeFn(ctx, wipe)` = `pkg/daemon/daemon_apply.go` `factoryReset` (acquires `d.applySem`, `enterResetGeneration()`, then wipe).

## Test plan

- [x] `TestConsoleZeroizeRoutesThroughDaemonTransaction_5871` — **fail-on-revert pin**: wires a spy transaction; asserts the console runs the wipe *inside* it. Reverting `performConsoleZeroize` to the ungated direct wipe makes the spy never fire → assertion RED.
- [x] `TestConsoleZeroizeSurfacesTransactionFailure_5871` — an in-wipe removal failure propagated by the transaction is surfaced fail-CLOSED; daemon not stopped.
- [x] `TestConsoleZeroizeSurfacesGateAcquireFailure_5871` — an apply-gate acquire failure is surfaced fail-CLOSED; wipe never runs; daemon not stopped.
- [x] `TestConsoleZeroizeOfflineFallbackUngatedWipe_5871` — explicit offline (no-daemon) fallback still wipes + stops on success.
- [x] Existing #5890 / #5554 console-zeroize tests still green (unchanged wipe file-set + fail-closed root resolution).
- [x] `go build ./...`, `go vet` (only a pre-existing unreachable-code warning in `cli.go`, present on `origin/master`), `go test ./pkg/cli/... ./pkg/grpcapi/... ./pkg/daemon/...` green (3×).

**Parent-RED recipe:** neutralize `performConsoleZeroize` to call `wipe()` directly (drop the `factoryResetFn` route) — compiles clean; makes exactly the 3 routing/failure `_5871` tests RED as **assertions** (the offline-fallback test stays green since its hook is nil).

Unit-provable — no smoke needed (in-process daemon↔CLI wiring + package-var seam spies; no dataplane/forwarding change).

Closes #5871

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fx6PdXBrJ4LkXmekcRx27P
