### PR TITLE
dataplane: report failed helper session revocation on clear-all (#5881)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54416,3 +54416,20 @@ top.
   pkg/config/compiler_interfaces_unsupported.go, pkg/config/compiler.go,
   pkg/config/schema_interfaces.go, pkg/config/qinq_canonical_vlan_5879_test.go (new),
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5881 — propagate authoritative Rust-helper session-delete
+  failures into userspace `Manager.ClearAllSessions` so `clear security flow
+  session all` can no longer report success while the helper keeps forwarding
+  under revoked sessions. `syncSessionRequestsLocked` and
+  `deleteHelperSessionsV4/V6` now return the first helper IPC error (send-all,
+  log-each behaviour preserved); `ClearAllSessions` captures it across chunks
+  and surfaces it (with the mirror's partial v4/v6 counts, matching the #5882
+  non-atomic reporting contract) when the mirror clear itself succeeded. Batch
+  and mirror-upsert callers keep the #5096 best-effort contract (explicit
+  discard). Fail-on-revert test injects a helper-delete IPC failure and asserts
+  a non-nil `ClearAllSessions` error; control path (all deletes succeed) asserts
+  clean success.
+- **File(s)**: pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/clear_all_helper_error_5881_test.go (new),
+  pkg/dataplane/README.md, _Log.md

--- a/pkg/dataplane/README.md
+++ b/pkg/dataplane/README.md
@@ -238,7 +238,18 @@ plus a cluster smoke before merge.
   authoritative Rust-helper delete on each bounded chunk instead of building
   a second full-table key snapshot of its own — the two coexisting full-table
   snapshots (wrapper v4+v6 + shim v4+v6 + DNAT lists) were the ~1 GB RSS spike
-  that #5304 removed.
+  that #5304 removed. In userspace mode the Rust helper is AUTHORITATIVE (it
+  owns packet forwarding; the BPF table is a read model), so the wrapper's
+  `ClearAllSessions` propagates a helper-delete IPC failure as a non-nil error
+  rather than losing it in a log line (#5881): a failed authoritative
+  revocation must not report success while the helper keeps forwarding under
+  the "cleared" session. The bpf mirror's partial (v4, v6) counts are still
+  returned alongside that error — the same non-atomic clear-all reporting
+  contract the API handlers honor for a mid-clear mirror failure (#5882). A
+  mirror-side error still takes precedence. The batch delete path
+  (`BatchDeleteSessions{,V6}`) keeps the #5096 best-effort contract — the
+  periodic session sync and GC delta reconcile a transient helper miss — so it
+  discards the helper-delete error; only the operator clear-all propagates it.
 - Session domain adapters: `SessionStoreOf`, `TelemetryOf`, and
   `NewDataPlaneSessionStore`. The generic `DataPlane` adapter preserves the
   batch-iteration fast path and centralizes cluster/GC companion ownership:

--- a/pkg/dataplane/userspace/clear_all_helper_error_5881_test.go
+++ b/pkg/dataplane/userspace/clear_all_helper_error_5881_test.go
@@ -1,0 +1,182 @@
+// #5881: in userspace mode the Rust helper owns AUTHORITATIVE forwarding
+// session state; the BPF maps are mirrors. ClearAllSessions clears the mirror
+// and issues a per-chunk authoritative "delete" to the helper, but before this
+// fix a helper-delete IPC failure was only logged inside the sync path and
+// could not affect the returned error — so `clear security flow session all`
+// reported SUCCESS while the helper kept forwarding under the supposedly
+// revoked sessions. This binds the propagation: a helper-delete failure must
+// surface as a non-nil ClearAllSessions error (with the mirror's partial counts
+// still returned, matching the #5882 non-atomic clear-all reporting contract),
+// and the all-succeed control path must still report clean success.
+//
+// FAIL-ON-REVERT: neutralizing the propagation in ClearAllSessions (dropping
+// the `if helperErr != nil { return ... }` block so the method returns a nil
+// error whenever the mirror clear succeeded) makes the injected-failure subtest
+// go RED on its "returned nil error despite a helper-delete IPC failure"
+// assertion. Reverting deleteHelperSessions*/syncSessionRequestsLocked back to
+// their void signatures re-breaks the same assertion.
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// fakeHelperSessionSocket is a stand-in for the Rust helper's session control
+// socket. Unlike fakeHelperDeleteRecorder it can be configured to FAIL every
+// sync_session request (respond OK:false) so a test can drive the helper-IPC-
+// failure path of ClearAllSessions, or accept them (OK:true) for the control.
+type fakeHelperSessionSocket struct {
+	ln   net.Listener
+	mu   sync.Mutex
+	fail bool
+	reqs int
+}
+
+func startFakeHelperSessionSocket(t *testing.T, sockPath string, fail bool) *fakeHelperSessionSocket {
+	t.Helper()
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen helper session socket: %v", err)
+	}
+	f := &fakeHelperSessionSocket{ln: ln, fail: fail}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					return
+				}
+				f.mu.Lock()
+				f.reqs++
+				fail := f.fail
+				f.mu.Unlock()
+				resp := ControlResponse{OK: true}
+				if req.SessionSync != nil && fail {
+					resp = ControlResponse{OK: false, Error: "injected helper delete failure"}
+				}
+				// The client blocks on this response, so by the time the
+				// adapter call returns the request above is fully handled.
+				_ = json.NewEncoder(conn).Encode(resp)
+			}()
+		}
+	}()
+	return f
+}
+
+func (f *fakeHelperSessionSocket) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reqs
+}
+
+// seedOneSessionPerFamily installs one v4 and one v6 forward session in the
+// mirror so the clear has authoritative helper deletes to issue.
+func seedOneSessionPerFamily5881(t *testing.T, m *Manager) {
+	t.Helper()
+	v4 := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 61, 77},
+		DstIP:    [4]byte{172, 16, 80, 200},
+		SrcPort:  hostToNetwork16(51000),
+		DstPort:  hostToNetwork16(443),
+		Protocol: 6,
+	}
+	if err := m.bpfShim.SetSessionV4(v4, dataplane.SessionValue{}); err != nil {
+		t.Fatalf("seed v4 session: %v", err)
+	}
+	var s6, d6 [16]byte
+	copy(s6[:], net.ParseIP("2001:559:8585:ef00::77").To16())
+	copy(d6[:], net.ParseIP("2001:559:8585:80::200").To16())
+	v6 := dataplane.SessionKeyV6{
+		SrcIP:    s6,
+		DstIP:    d6,
+		SrcPort:  hostToNetwork16(41000),
+		DstPort:  hostToNetwork16(443),
+		Protocol: 6,
+	}
+	if err := m.bpfShim.SetSessionV6(v6, dataplane.SessionValueV6{}); err != nil {
+		t.Fatalf("seed v6 session: %v", err)
+	}
+}
+
+func newClearManager5881(t *testing.T) (*Manager, *LegacyDataPlaneAdapter, string) {
+	t.Helper()
+	// A SHORT temp-dir prefix (not t.TempDir(), which embeds the long
+	// sub-test name) keeps the AF_UNIX socket path under the 108-byte
+	// sun_path limit — the "bind: invalid argument" trap. Respects TMPDIR
+	// (run with TMPDIR=/tmp), so a long system TMPDIR does not push us over.
+	dir, err := os.MkdirTemp("", "x5881")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+	m := New()
+	m.proc = &exec.Cmd{}
+	m.cfg.ControlSocket = controlSock
+	injectSessionMaps(t, m)
+	seedOneSessionPerFamily5881(t, m)
+	return m, NewLegacyDataPlaneAdapter(m), filepath.Join(dir, "userspace-dp-sessions.sock")
+}
+
+func TestClearAllSessionsSurfacesHelperDeleteError5881(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+
+	// A helper-delete IPC failure must be REPORTED. A clean nil return here is
+	// the security bug: the mirror is empty (looks revoked) while the
+	// authoritative helper may still be forwarding under the "cleared" session.
+	t.Run("helper_delete_failure_is_reported", func(t *testing.T) {
+		m, adapter, sessionSock := newClearManager5881(t)
+		fake := startFakeHelperSessionSocket(t, sessionSock, true)
+
+		v4, v6, err := adapter.ClearAllSessions()
+		if err == nil {
+			t.Fatal("ClearAllSessions returned nil error despite a helper-delete IPC failure — a revoked session may still be forwarding (#5881)")
+		}
+		if fake.requestCount() == 0 {
+			t.Fatal("helper never received a delete request; the test did not exercise the propagation path")
+		}
+		// Mirror-clear behaviour is preserved: the read model is emptied and
+		// the partial counts are still returned alongside the error (#5882).
+		if v4 != 1 || v6 != 1 {
+			t.Errorf("counts = (%d, %d), want (1, 1) surfaced alongside the error", v4, v6)
+		}
+		if mv4, mv6 := m.bpfShim.SessionCount(); mv4 != 0 || mv6 != 0 {
+			t.Errorf("mirror not cleared: count = (%d, %d), want (0, 0)", mv4, mv6)
+		}
+	})
+
+	// Control: when every authoritative helper delete succeeds, the clear is a
+	// clean success — the fix must not turn healthy clears into errors.
+	t.Run("all_deletes_succeed_is_success", func(t *testing.T) {
+		m, adapter, sessionSock := newClearManager5881(t)
+		startFakeHelperSessionSocket(t, sessionSock, false)
+
+		v4, v6, err := adapter.ClearAllSessions()
+		if err != nil {
+			t.Fatalf("ClearAllSessions returned error on the all-succeed path: %v", err)
+		}
+		if v4 != 1 || v6 != 1 {
+			t.Errorf("counts = (%d, %d), want (1, 1)", v4, v6)
+		}
+		if mv4, mv6 := m.bpfShim.SessionCount(); mv4 != 0 || mv6 != 0 {
+			t.Errorf("mirror not cleared: count = (%d, %d), want (0, 0)", mv4, mv6)
+		}
+	})
+}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1077,8 +1077,10 @@ func (m *Manager) mirrorSessionPairV4(key dataplane.SessionKey, val dataplane.Se
 		revVal.FibGen = 0
 		reqs = append(reqs, m.buildSessionSyncRequestV4("upsert", val.ReverseKey, &revVal))
 	}
-	// Snapshot reads are complete; transmit both requests in sequence.
-	m.syncSessionRequestsLocked(reqs...)
+	// Snapshot reads are complete; transmit both requests in sequence. The
+	// mirror upsert is best-effort (the periodic session sync reconciles a
+	// transient miss), so the helper IPC error is intentionally discarded.
+	_ = m.syncSessionRequestsLocked(reqs...)
 }
 
 func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val dataplane.SessionValue) error {
@@ -1151,8 +1153,10 @@ func (m *Manager) mirrorSessionPairV6(key dataplane.SessionKeyV6, val dataplane.
 		revVal.FibGen = 0
 		reqs = append(reqs, m.buildSessionSyncRequestV6("upsert", val.ReverseKey, &revVal))
 	}
-	// Snapshot reads are complete; transmit both requests in sequence.
-	m.syncSessionRequestsLocked(reqs...)
+	// Snapshot reads are complete; transmit both requests in sequence. The
+	// mirror upsert is best-effort (the periodic session sync reconciles a
+	// transient miss), so the helper IPC error is intentionally discarded.
+	_ = m.syncSessionRequestsLocked(reqs...)
 }
 
 func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) error {
@@ -1246,14 +1250,20 @@ func (m *Manager) BatchDeleteSessions(keys []dataplane.SessionKey) (int, error) 
 	// a batch where a key vanished concurrently returns ErrKeyNotExist with a
 	// partial count, and the helper delete of an already-absent key is a no-op,
 	// so skipping on error would strand the still-present helper sessions.
-	m.deleteHelperSessionsV4(keys)
+	//
+	// The batch path (policy invalidation, cluster-stale sweep) keeps the
+	// #5096 best-effort contract — the periodic session sync and GC delta
+	// reconcile a transient helper miss — so the helper IPC error is
+	// intentionally discarded here. The operator clear-all path propagates it
+	// instead (ClearAllSessions, #5881).
+	_ = m.deleteHelperSessionsV4(keys)
 	return deleted, err
 }
 
 // BatchDeleteSessionsV6 is the IPv6 analogue of BatchDeleteSessions (#5096).
 func (m *Manager) BatchDeleteSessionsV6(keys []dataplane.SessionKeyV6) (int, error) {
 	deleted, err := m.bpfShim.BatchDeleteSessionsV6(keys)
-	m.deleteHelperSessionsV6(keys)
+	_ = m.deleteHelperSessionsV6(keys)
 	return deleted, err
 }
 
@@ -1272,33 +1282,61 @@ func (m *Manager) BatchDeleteSessionsV6(keys []dataplane.SessionKeyV6) (int, err
 // a per-chunk callback: it collects a bounded chunk, deletes it from the mirror,
 // and hands that same bounded chunk here for deletion on the helper, so neither
 // side ever holds more than one chunk of keys. deleteHelperSessions{V4,V6} keeps
-// the #5096 chunked-transmission behaviour (sessionHelperDeleteChunk). Returns
-// the bpf mirror's (v4, v6, err) counts unchanged.
+// the #5096 chunked-transmission behaviour (sessionHelperDeleteChunk).
+//
+// The Rust helper is AUTHORITATIVE in userspace mode — it owns packet
+// lookup/forwarding while the BPF mirror is a read model. A helper-delete IPC
+// failure therefore means a session the operator asked to revoke may still be
+// forwarding, even though the mirror was emptied. Losing that error (as the
+// pre-#5881 void callbacks did) let `clear security flow session all` report
+// success while sessions lived on — a security bug. So the first helper-delete
+// error is captured across chunks and, when the mirror clear itself succeeded,
+// surfaced as ClearAllSessions's returned error. The bpf mirror's partial
+// (v4, v6) counts are still returned alongside the error, matching the #5882
+// non-atomic clear-all reporting contract, so a caller learns what the mirror
+// side revoked while also learning the authoritative revocation is unconfirmed.
+// A mirror-side error still takes precedence and is returned as before.
 func (m *Manager) ClearAllSessions() (int, int, error) {
-	return m.bpfShim.ClearAllSessionsChunked(
-		func(keys []dataplane.SessionKey) { m.deleteHelperSessionsV4(keys) },
-		func(keys []dataplane.SessionKeyV6) { m.deleteHelperSessionsV6(keys) },
+	var helperErr error
+	recordHelperErr := func(err error) {
+		if err != nil && helperErr == nil {
+			helperErr = err
+		}
+	}
+	v4, v6, mirrorErr := m.bpfShim.ClearAllSessionsChunked(
+		func(keys []dataplane.SessionKey) { recordHelperErr(m.deleteHelperSessionsV4(keys)) },
+		func(keys []dataplane.SessionKeyV6) { recordHelperErr(m.deleteHelperSessionsV6(keys)) },
 	)
+	if mirrorErr != nil {
+		return v4, v6, mirrorErr
+	}
+	if helperErr != nil {
+		return v4, v6, fmt.Errorf("clear-all: authoritative helper session revocation failed: %w", helperErr)
+	}
+	return v4, v6, nil
 }
 
 // deleteHelperSessionsV4 tells the Rust helper to delete every key so the batch
 // and clear session paths converge the helper's authoritative session table
 // with the BPF mirror (#5096). Requests are transmitted in bounded chunks (see
 // sessionHelperDeleteChunk) so a large clear does not monopolize the shared
-// control socket. A helper IPC error is logged inside syncSessionRequestsLocked
-// but is not fatal — mirroring the singular DeleteSession path, which likewise
-// treats the helper delete as best-effort (the periodic session sync and GC
-// delta reconcile any transient miss). A "delete" request built with a nil
-// value carries only the 5-tuple, so no snapshot read happens under m.mu.
-func (m *Manager) deleteHelperSessionsV4(keys []dataplane.SessionKey) {
+// control socket. A "delete" request built with a nil value carries only the
+// 5-tuple, so no snapshot read happens under m.mu.
+//
+// It returns the FIRST helper IPC error across all chunks (nil if all
+// succeeded, or if there is no live helper). The best-effort batch callers
+// discard it; ClearAllSessions propagates it so a failed authoritative
+// revocation is reported rather than reported as success (#5881).
+func (m *Manager) deleteHelperSessionsV4(keys []dataplane.SessionKey) error {
 	if len(keys) == 0 {
-		return
+		return nil
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.proc == nil {
-		return
+		return nil
 	}
+	var firstErr error
 	for start := 0; start < len(keys); start += sessionHelperDeleteChunk {
 		end := start + sessionHelperDeleteChunk
 		if end > len(keys) {
@@ -1308,20 +1346,24 @@ func (m *Manager) deleteHelperSessionsV4(keys []dataplane.SessionKey) {
 		for i := start; i < end; i++ {
 			reqs = append(reqs, m.buildSessionSyncRequestV4("delete", keys[i], nil))
 		}
-		m.syncSessionRequestsLocked(reqs...)
+		if err := m.syncSessionRequestsLocked(reqs...); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
+	return firstErr
 }
 
 // deleteHelperSessionsV6 is the IPv6 analogue of deleteHelperSessionsV4 (#5096).
-func (m *Manager) deleteHelperSessionsV6(keys []dataplane.SessionKeyV6) {
+func (m *Manager) deleteHelperSessionsV6(keys []dataplane.SessionKeyV6) error {
 	if len(keys) == 0 {
-		return
+		return nil
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.proc == nil {
-		return
+		return nil
 	}
+	var firstErr error
 	for start := 0; start < len(keys); start += sessionHelperDeleteChunk {
 		end := start + sessionHelperDeleteChunk
 		if end > len(keys) {
@@ -1331,8 +1373,11 @@ func (m *Manager) deleteHelperSessionsV6(keys []dataplane.SessionKeyV6) {
 		for i := start; i < end; i++ {
 			reqs = append(reqs, m.buildSessionSyncRequestV6("delete", keys[i], nil))
 		}
-		m.syncSessionRequestsLocked(reqs...)
+		if err := m.syncSessionRequestsLocked(reqs...); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
+	return firstErr
 }
 
 func (m *Manager) syncSessionV4Locked(op string, key dataplane.SessionKey, val *dataplane.SessionValue) error {
@@ -1551,11 +1596,19 @@ func (m *Manager) syncSessionRequestLocked(req SessionSyncRequest) error {
 // uninterrupted prior m.mu hold so a forward/reverse companion pair is
 // resolved against one consistent snapshot (#5007). Sending both requests
 // under a single unlock also keeps the pair's transmit contiguous.
-func (m *Manager) syncSessionRequestsLocked(reqs ...SessionSyncRequest) {
+//
+// It attempts EVERY request even when an earlier one fails (so a bulk
+// revocation drops as many helper sessions as it can) and returns the FIRST
+// helper IPC error encountered, or nil if all succeeded. Best-effort mirror
+// callers (mirrorSessionPair*, batch delete) discard the result; the
+// authoritative clear-all path (#5881) propagates it so a failed helper
+// revocation is reported instead of masquerading as success.
+func (m *Manager) syncSessionRequestsLocked(reqs ...SessionSyncRequest) error {
 	if len(reqs) == 0 {
-		return
+		return nil
 	}
 	m.mu.Unlock()
+	var firstErr error
 	for i := range reqs {
 		ctrlReq := ControlRequest{
 			Type:           "sync_session",
@@ -1564,9 +1617,13 @@ func (m *Manager) syncSessionRequestsLocked(reqs ...SessionSyncRequest) {
 		}
 		if err := m.requestSessionSync(ctrlReq); err != nil {
 			slog.Debug("userspace session sync mirror failed", "operation", reqs[i].Operation, "err", err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	m.mu.Lock()
+	return firstErr
 }
 
 func (m *Manager) zoneNameByID(zoneID uint16) string {


### PR DESCRIPTION
## Summary

- In userspace mode the Rust helper is **authoritative** for forwarding session state; BPF maps are a read model. `Manager.ClearAllSessions` cleared the mirror and issued per-chunk authoritative helper deletes, but a helper-delete IPC failure was only logged at Debug and could not affect the returned error.
- The void call chain (`deleteHelperSessionsV4/V6` → `syncSessionRequestsLocked`) meant `clear security flow session all` reported **success while the helper kept forwarding under the supposedly revoked sessions** — a security bug.
- Fix: `syncSessionRequestsLocked` and `deleteHelperSessionsV4/V6` now return the first helper IPC error (send-all, log-each behaviour preserved); `ClearAllSessions` captures it across the v4+v6 chunk callbacks and returns a non-nil error when the mirror clear itself succeeded.
- Partial mirror `(v4, v6)` counts are still returned alongside the error, matching the #5882 non-atomic clear-all reporting contract. A mirror-side error still takes precedence.
- The batch delete path (`BatchDeleteSessions{,V6}`) and mirror-upsert path keep the #5096 best-effort contract (periodic sync + GC reconcile a transient miss) and explicitly discard the helper-delete error; only the operator clear-all propagates it.

## Scope

The broader per-domain structured result the issue sketches (separate helper/mirror/DNAT/peer status + degraded readiness) is a larger design. This PR is the focused fix for the false-success report. Widening the batch/mirror paths to hard failure is a behaviour choice left to a follow-up.

## Test plan

- [x] `TestClearAllSessionsSurfacesHelperDeleteError5881` — a fake helper session socket that fails every `sync_session` request drives `ClearAllSessions` and asserts a **non-nil error** (injected-failure subtest), with the mirror still emptied and partial counts surfaced; the control subtest (helper accepts every delete) asserts clean success.
- [x] Fail-on-revert verified: neutralizing the propagation in `ClearAllSessions` (drop the `helperErr` return) **compiles** and flips the injected-failure subtest RED on a clean assertion while the control subtest stays green.
- [x] `go build ./...`, `go vet ./pkg/dataplane/userspace/` clean.
- [x] Related clear tests pass under sudo (BPF-map memlock): `TestClearAllSessionsDeliversEveryKeyToHelper5304`, `TestBatchAndClearRouteToHelper5096`, plus the full session/HA/mirror test subset (3× non-flake).
- Unit-provable control-plane error propagation — **no cluster smoke required**. (Pre-existing env failure `TestUserspaceXDPNDPUsesCPUMapWhenAvailable` reproduces on pristine origin/master and is unrelated to this change.)

## Refs

Closes #5881 · Aligns with #5882 (non-atomic clear-all partial-count reporting) · #5096 (helper-delete plumbing) · #5304 (bounded clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
