### PR TITLE
daemon: collect and budget the cancelled-apply host-auth closeout (#5874)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54456,3 +54456,27 @@ top.
 - **File(s)**: pkg/cli/cli.go, pkg/cli/cli_request_system.go,
   pkg/daemon/daemon_run.go, pkg/cli/console_zeroize_transaction_5871_test.go (new),
   pkg/cli/README.md, pkg/grpcapi/README.md, pkg/daemon/README.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5874 — surface cancelled-apply host-auth closeout failures + enforce a budget.
+  The post-promotion cancel closeout (`applyHostAuthorizationCloseout`) ran the five
+  credential reconcilers (login/sudoers/absent-user/SSH/root-auth) as best-effort VOIDS
+  and returned only the two nft errors, so a credential-reconcile failure was silently
+  DISCARDED and the cancel reported clean over a host-auth state that never converged;
+  the "bounded" sequence also had no enforced deadline. Fix: the reconcilers (and their
+  helpers `reconcileUserPassword` / `deprovisionLoginUser`) now RETURN their accumulated
+  failures; the closeout runs each owner as a named `hostAuthOwner`, collects a per-owner
+  `hostAuthOwnerOutcome`, and `summarizeHostAuthCloseout` joins every failing OR timed-out
+  owner into the returned error (naming which owner). Added an ENFORCED wall-clock budget
+  (`hostAuthCloseoutBudget`, 30s): `runHostAuthCloseoutOwners` runs each owner under a
+  shared deadline in its own goroutine (sequential, M35 order preserved) so a wedged
+  reconciler is reported timed-out instead of hanging daemon-stop; post-budget owners are
+  reported, never silently skipped. Normal apply path (`applyTailReconciles`) discards the
+  returns (`_ =`) — next-boot convergence covers transient failures there. Fail-on-revert:
+  `TestHostAuthCloseoutSurfacesReconcilerFailure` drives the real reconcileSudoers (unwritable
+  dir) through the closeout and asserts the failure is surfaced+attributed; neutralizing the
+  `case o.err != nil` append in `summarizeHostAuthCloseout` makes exactly that test RED.
+  Plus budget-timeout, owner-wiring, and reconciler-return tests. Unit-provable, no smoke.
+- **File(s)**: pkg/daemon/daemon_apply.go, pkg/daemon/daemon_system.go,
+  pkg/daemon/login_password.go, pkg/daemon/host_auth_closeout_5874_test.go (new),
+  pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -513,6 +513,30 @@ never lock an operator out of a remote box it manages.
     window. `runShutdownSequence` drains `applySem` (bounded by
     `applyCloseoutDrainTimeout`) after `applyCancel()` so that closeout completes
     before teardown/exit.
+    - **Collect-and-budget the closeout (#5874).** The five credential
+      reconcilers were best-effort **voids** whose failures the closeout
+      discarded — it returned only the two nft errors, so a cancel could report
+      clean while a login / sudoers / absent-user / SSH / root-auth reconcile
+      silently failed and the committed host-auth state never actually
+      converged. They now **return** their accumulated failures
+      (`reconcileUserPassword` and `deprovisionLoginUser` too, so a
+      password-write / revocation failure is not re-swallowed); the closeout
+      runs each owner as a named `hostAuthOwner`, records a per-owner
+      `hostAuthOwnerOutcome`, and `summarizeHostAuthCloseout` joins every
+      **failing OR timed-out** owner into the returned error — naming which
+      owner did not reconcile — so `closeoutHostAuthOnCancel` propagates a
+      fail-visible cancel instead of a false-clean one. The "bounded" claim is
+      now an **enforced** wall-clock budget (`hostAuthCloseoutBudget`, 30s):
+      `runHostAuthCloseoutOwners` runs each owner under a shared deadline in its
+      own goroutine (sequentially — the M35 order is load-bearing — but bounded),
+      so a wedged reconciler is reported timed-out (convergence unknown) rather
+      than hanging the daemon-stop path, and owners queued after the budget is
+      exhausted are reported timed-out too, never silently skipped and never
+      launched concurrently with the abandoned owner. On the **normal** apply
+      path (`applyTailReconciles`) the same reconcilers' returns are
+      intentionally discarded (`_ =`) — next-boot convergence still covers a
+      transient failure there; only the daemon-stop cancel, where next-boot
+      convergence does not happen, collects and fails on them.
   - **Early signal capture — startup is abortable (#5807).** The shutdown
     signal context is captured at the **TOP of `Run`** (`startupSignalContext`),
     BEFORE the mutating startup phases (config load + bootstrap → interface

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1047,33 +1047,140 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 // identifies.
 //
 // The steps mirror applyTailReconciles' step 9.5–13 order exactly. Both nft
-// applies fail closed (#3392/#3333) and their errors are returned; the
-// login/credential reconciles (including applyRootAuth, the SOLE manager of
-// root's /etc/shadow password and /root/.ssh/authorized_keys) are best-effort
-// voids there and stay so here. The whole closeout is bounded (two atomic nft
-// loads + local file reconciles, no FRR/netlink reload), so it is safe to run
-// non-cancellably on the daemon-stop path.
+// applies fail closed (#3392/#3333). #5874: the login/credential reconcilers
+// (applySystemLogin, reconcileSudoers, reconcileAbsentLoginUsers, applySSHConfig
+// and applyRootAuth — the SOLE manager of root's /etc/shadow password and
+// /root/.ssh/authorized_keys) were previously best-effort VOIDS here, so a
+// failure to reconcile a credential to the cancelled/target state was silently
+// DISCARDED and the cancel reported clean. They now return their accumulated
+// failures, this closeout COLLECTS a per-owner outcome and SURFACES every
+// failure, and the "bounded" claim is now an ENFORCED wall-clock budget
+// (hostAuthCloseoutBudget) rather than an unbounded best-effort sequence: a
+// wedged reconciler is reported timed-out instead of hanging the daemon-stop
+// path. Still safe to run non-cancellably — no FRR/netlink reload.
+
+// hostAuthOwner is one security-critical host-authorization reconciler run by
+// the #5643/M35 cancel closeout, paired with a stable name so a failure can be
+// attributed to a specific owner (lo0 filter, host-inbound filter, login,
+// sudoers, absent-user revocation, sshd, root-auth).
+type hostAuthOwner struct {
+	name string
+	fn   func(*config.Config) error
+}
+
+// hostAuthOwnerOutcome is one owner's result from the cancel closeout. A nil
+// err with timedOut=false means the owner reconciled to the committed state; a
+// non-nil err means it reported a reconcile failure; timedOut means the
+// closeout budget was exhausted before or while the owner ran, so its
+// convergence is UNKNOWN. Both err and timedOut are fail-visible — the cancel
+// must not report clean when either is set.
+type hostAuthOwnerOutcome struct {
+	name     string
+	err      error
+	timedOut bool
+}
+
+// hostAuthCloseoutBudget bounds the TOTAL wall-clock time the #5643/M35 cancel
+// closeout may spend reconciling host authorization. It is a backstop against a
+// wedged reconciler hanging the daemon-stop path: each external command already
+// carries its own 15s(+5s) ceiling (externalCommandTimeout), but the closeout
+// fans across two nft loads plus five credential reconcilers, so a per-command
+// timeout does not bound the sum. On the cancel path boundedness beats
+// completeness — an owner that outruns the budget is reported timed-out (its
+// convergence unknown) rather than allowed to block shutdown indefinitely. A
+// package var so tests can shrink it. 30s stays well under the daemon-stop
+// window while giving a healthy box (every reconcile completes in ms) enormous
+// headroom.
+var hostAuthCloseoutBudget = 30 * time.Second
+
+// hostAuthCloseoutOwners is the ORDERED list of host-authorization owners the
+// cancel closeout reconciles, mirroring applyTailReconciles' step 9.5–13 order
+// exactly: the two nft filters first (kernel primary enforcement), then the OS
+// login/sudo/absent-user/sshd/root-auth credential reconcilers. Split out as a
+// method so a test can assert every owner — especially the five credential
+// reconcilers whose failures used to be discarded (#5874) — stays wired in.
+func (d *Daemon) hostAuthCloseoutOwners() []hostAuthOwner {
+	return []hostAuthOwner{
+		{"lo0-filter", d.applyLo0Filter},
+		{"host-inbound-filter", d.applyHostInboundFilter},
+		{"system-login", d.applySystemLogin},
+		{"sudoers", d.reconcileSudoers},
+		{"absent-login-users", d.reconcileAbsentLoginUsers},
+		{"ssh-config", d.applySSHConfig},
+		{"root-auth", d.applyRootAuth},
+	}
+}
+
+// runHostAuthCloseoutOwners runs each owner in order under a shared wall-clock
+// budget and returns a per-owner outcome. Owners run SEQUENTIALLY (the M35
+// order is load-bearing) but each in its own goroutine so a wedged owner can be
+// bounded by the budget instead of hanging the daemon-stop path. It preserves
+// the non-cancellable INTENT — the budget does NOT abort on the first owner
+// ERROR (a failed owner is recorded and the next still runs: collect-all-then-
+// report). It only stops launching owners once the TOTAL budget is exhausted;
+// the remaining owners are then recorded timed-out (never silently skipped).
+//
+// When an owner outruns the budget its goroutine is abandoned (at most one at a
+// time — no further owner is launched concurrently). That is acceptable only on
+// the daemon-stop path this serves: every reconciler step is an individually
+// atomic durable write, so an abandoned owner leaves consistent partial state
+// that is HONESTLY reported timed-out (convergence unknown), the fail-visible
+// outcome M35 requires.
+func runHostAuthCloseoutOwners(cfg *config.Config, budget time.Duration, owners []hostAuthOwner) []hostAuthOwnerOutcome {
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	outcomes := make([]hostAuthOwnerOutcome, 0, len(owners))
+	for _, o := range owners {
+		if ctx.Err() != nil {
+			// Budget already exhausted — record timed-out WITHOUT launching the
+			// owner, so it never runs concurrently with an abandoned one.
+			outcomes = append(outcomes, hostAuthOwnerOutcome{name: o.name, timedOut: true})
+			continue
+		}
+		done := make(chan error, 1)
+		go func(fn func(*config.Config) error) { done <- fn(cfg) }(o.fn)
+		select {
+		case err := <-done:
+			outcomes = append(outcomes, hostAuthOwnerOutcome{name: o.name, err: err})
+		case <-ctx.Done():
+			outcomes = append(outcomes, hostAuthOwnerOutcome{name: o.name, timedOut: true})
+		}
+	}
+	return outcomes
+}
+
+// summarizeHostAuthCloseout logs each owner's outcome (fail-visible) and joins
+// every failure — a reconcile error OR a budget timeout — into a single error.
+// A nil return means every host-authorization owner reconciled to the committed
+// config within budget; a non-nil return names WHICH owners did not, and is
+// propagated by closeoutHostAuthOnCancel so the cancel fails visibly instead of
+// reporting clean over a silently-failed credential reconcile (#5874).
+func summarizeHostAuthCloseout(outcomes []hostAuthOwnerOutcome) error {
+	var errs []error
+	for _, o := range outcomes {
+		switch {
+		case o.timedOut:
+			slog.Error("host-authorization cancel closeout: owner did not complete within budget",
+				"owner", o.name, "budget", hostAuthCloseoutBudget)
+			errs = append(errs, fmt.Errorf("host-auth closeout owner %q timed out", o.name))
+		case o.err != nil:
+			slog.Error("host-authorization cancel closeout: owner failed to reconcile",
+				"owner", o.name, "err", o.err)
+			errs = append(errs, fmt.Errorf("host-auth closeout owner %q: %w", o.name, o.err))
+		default:
+			slog.Debug("host-authorization cancel closeout: owner reconciled", "owner", o.name)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (d *Daemon) applyHostAuthorizationCloseout(cfg *config.Config) error {
 	if cfg == nil {
 		return nil
 	}
-	// nft host-authorization: kernel PRIMARY enforcement of lo0 input filter +
-	// zone host-inbound (fail-closed).
-	lo0Err := d.applyLo0Filter(cfg)
-	hostInboundErr := d.applyHostInboundFilter(cfg)
-	// login / credential revocation: OS accounts, stale sudo grants, removed
-	// users' password + authorized_keys, root-login policy, AND root's own
-	// durable credentials. applySSHConfig only writes the sshd PermitRootLogin
-	// drop-in; applyRootAuth (#5276) is the sole manager of root's /etc/shadow
-	// password and /root/.ssh/authorized_keys, so it MUST run here too — else a
-	// committed `delete system root-authentication ssh-keys` leaves the revoked
-	// root key live for the whole stop window (#5643 Gap A).
-	d.applySystemLogin(cfg)
-	d.reconcileSudoers(cfg)
-	d.reconcileAbsentLoginUsers(cfg)
-	d.applySSHConfig(cfg)
-	d.applyRootAuth(cfg)
-	return errors.Join(lo0Err, hostInboundErr)
+	outcomes := runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, d.hostAuthCloseoutOwners())
+	return summarizeHostAuthCloseout(outcomes)
 }
 
 // closeoutHostAuthOnCancel wraps a post-promotion apply-abort error so a #2926
@@ -2375,28 +2482,37 @@ func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, 
 	// 10. Apply system syslog forwarding
 	d.applySystemSyslog(cfg)
 
+	// Steps 11–13 are the login/credential reconcilers. They return their
+	// accumulated failures (#5874) so the cancel closeout can surface them,
+	// but on the NORMAL apply path the returns are intentionally DISCARDED:
+	// the tail is best-effort here because the next boot re-renders login /
+	// sudoers / SSH / root-auth from the active config, so a transient failure
+	// converges (the #2926 next-boot contract). Only the daemon-stop cancel
+	// closeout — where next-boot convergence does NOT happen while the daemon
+	// stays intentionally stopped — collects and fails on these.
+
 	// 11. Apply system login users (create OS accounts, SSH keys)
-	d.applySystemLogin(cfg)
+	_ = d.applySystemLogin(cfg)
 
 	// 11b. Reconcile super-user sudo grants against the CURRENT config so a
 	// class downgrade or user removal REVOKES the stale NOPASSWD grant
 	// (#3889). Runs unconditionally — applySystemLogin returns early when
 	// there are no users, which is exactly the "all users removed" case
 	// that must still sweep stale grants.
-	d.reconcileSudoers(cfg)
+	_ = d.reconcileSudoers(cfg)
 
 	// 11c. Revoke host credentials for any xpf-provisioned login account that
 	// was removed from config (#5128). reconcileSudoers above only revokes the
 	// sudo grant; without this a deprovisioned operator keeps their password
 	// and authorized_keys and can still SSH in. Like reconcileSudoers it MUST
 	// run unconditionally — the "all users removed" case must still revoke.
-	d.reconcileAbsentLoginUsers(cfg)
+	_ = d.reconcileAbsentLoginUsers(cfg)
 
 	// 12. Apply SSH service configuration (root-login)
-	d.applySSHConfig(cfg)
+	_ = d.applySSHConfig(cfg)
 
 	// 13. Apply root authentication (encrypted-password + SSH keys)
-	d.applyRootAuth(cfg)
+	_ = d.applyRootAuth(cfg)
 
 	// 14. Apply syslog file destinations (rsyslog configs)
 	d.applySyslogFiles(cfg)

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -3,6 +3,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -984,9 +985,20 @@ func reconcileSyslogDropins(confDir, prefix string, desired map[string]string) b
 
 // applySystemLogin creates OS user accounts and SSH authorized_keys from
 // system { login { user ... } } configuration.
-func (d *Daemon) applySystemLogin(cfg *config.Config) {
+// applySystemLogin reconciles OS login accounts (create/password/SSH keys)
+// from config. It stays best-effort — a per-user failure is logged and the
+// loop continues to the next user — but it now also ACCUMULATES those
+// failures into the returned error so a caller that needs to know whether the
+// reconcile actually converged (the #5874 cancel closeout) can see them. On
+// the normal apply path the return is intentionally ignored: the next boot
+// re-renders login from the active config, so a transient failure converges
+// (the #2926 next-boot contract). Pure defensive skips (an invalid username
+// refused before any mutation) are NOT accumulated — they are the safe
+// outcome, not an incomplete reconcile.
+func (d *Daemon) applySystemLogin(cfg *config.Config) (err error) {
+	fail := func(e error) { err = errors.Join(err, e) }
 	if cfg.System.Login == nil || len(cfg.System.Login.Users) == 0 {
-		return
+		return nil
 	}
 
 	for _, user := range cfg.System.Login.Users {
@@ -1026,6 +1038,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 			if out, err := runCommandTimeout("useradd", args...); err != nil {
 				slog.Warn("failed to create user",
 					"user", user.Name, "err", err, "output", string(out))
+				fail(fmt.Errorf("create user %s: %w", user.Name, err))
 				continue
 			}
 			slog.Info("created system user", "user", user.Name, "uid", user.UID)
@@ -1037,6 +1050,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 				if err := markProvisioned(user.Name, uid); err != nil {
 					slog.Warn("failed to write provisioned-user marker",
 						"user", user.Name, "err", err)
+					fail(fmt.Errorf("mark provisioned %s: %w", user.Name, err))
 				}
 			}
 		}
@@ -1045,7 +1059,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 		// `chpasswd -e` idiom; idempotent via a direct /etc/shadow read;
 		// D2-locks the account when the directive is removed but ONLY for
 		// the exact xpf-provisioned account (UID-keyed marker).
-		d.reconcileUserPassword(user)
+		fail(d.reconcileUserPassword(user))
 
 		// Super-user sudo grants are reconciled separately by
 		// reconcileSudoers so that a class DOWNGRADE or full user removal
@@ -1074,6 +1088,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 			if !ok {
 				slog.Warn("could not resolve uid/gid for authorized_keys owner; skipping to avoid a root-owned-keys lockout window",
 					"user", user.Name)
+				fail(fmt.Errorf("resolve uid/gid for authorized_keys owner %s", user.Name))
 				continue
 			}
 
@@ -1084,6 +1099,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 			// just-created .ssh directory (Codex r1, fsatomic README).
 			if err := fsatomic.MkdirAllDurable(sshDir, 0700); err != nil {
 				slog.Warn("failed to create .ssh dir", "user", user.Name, "dir", sshDir, "err", err)
+				fail(fmt.Errorf("create .ssh dir for %s: %w", user.Name, err))
 				continue
 			}
 			// Chown the .ssh DIR to the user UNCONDITIONALLY (idempotent),
@@ -1099,6 +1115,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 				slog.Warn("failed to chown ssh dir",
 					"user", user.Name, "dir", sshDir,
 					"err", err, "output", strings.TrimSpace(string(out)))
+				fail(fmt.Errorf("chown .ssh dir for %s: %w", user.Name, err))
 			}
 
 			keysContent := strings.Join(user.SSHKeys, "\n") + "\n"
@@ -1114,6 +1131,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 				if err := fsatomic.WriteFileDurable(keysFile, []byte(keysContent), 0600, fsatomic.WithOwner(uid, gid)); err != nil {
 					slog.Warn("failed to write authorized_keys",
 						"user", user.Name, "err", err)
+					fail(fmt.Errorf("write authorized_keys for %s: %w", user.Name, err))
 					continue
 				}
 				slog.Info("SSH keys updated", "user", user.Name, "keys", len(user.SSHKeys))
@@ -1139,10 +1157,12 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 				case !os.IsNotExist(err):
 					slog.Warn("failed to remove authorized_keys after key list emptied",
 						"user", user.Name, "file", keysFile, "err", err)
+					fail(fmt.Errorf("revoke authorized_keys for %s: %w", user.Name, err))
 				}
 			}
 		}
 	}
+	return err
 }
 
 // sudoersDir is the directory that holds xpf-managed NOPASSWD sudo grants
@@ -1193,7 +1213,8 @@ func defaultValidateSudoersFile(path string) error {
 // sudoersPrefix files are touched. It MUST be called on every apply,
 // independent of applySystemLogin's early return, so the "all users
 // removed" case still revokes stale grants.
-func (d *Daemon) reconcileSudoers(cfg *config.Config) {
+func (d *Daemon) reconcileSudoers(cfg *config.Config) (err error) {
+	fail := func(e error) { err = errors.Join(err, e) }
 	// Desired: an xpf-<user> drop-in for each current super-user account.
 	desired := make(map[string]struct{})
 	if cfg.System.Login != nil {
@@ -1219,6 +1240,7 @@ func (d *Daemon) reconcileSudoers(cfg *config.Config) {
 			if err := writeSudoersGrant(user.Name); err != nil {
 				slog.Warn("failed to write sudoers file",
 					"user", user.Name, "err", err)
+				fail(fmt.Errorf("write sudoers grant for %s: %w", user.Name, err))
 			}
 		}
 	}
@@ -1237,10 +1259,12 @@ func (d *Daemon) reconcileSudoers(cfg *config.Config) {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			slog.Warn("failed to revoke stale sudoers grant",
 				"file", name, "err", err)
+			fail(fmt.Errorf("revoke stale sudoers grant %s: %w", name, err))
 		} else if err == nil {
 			slog.Info("revoked stale super-user sudo grant", "file", name)
 		}
 	}
+	return err
 }
 
 // writeSudoersGrant writes (idempotently) the NOPASSWD grant for one
@@ -1295,7 +1319,8 @@ func writeSudoersGrant(user string) error {
 //     the directive disables password login instead of orphaning a live
 //     credential — but only for the exact xpf-provisioned account (marker
 //     UID matches the current UID) and never on a shadow read error.
-func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
+func (d *Daemon) reconcileUserPassword(user *config.LoginUser) (err error) {
+	fail := func(e error) { err = errors.Join(err, e) }
 	desired := user.EncryptedPassword.Reveal()
 	curUID, uidOK := lookupUID(user.Name)
 	cur, ok := currentShadowHash(user.Name)
@@ -1324,6 +1349,7 @@ func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
 		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
 			slog.Warn("failed to set user password",
 				"user", user.Name, "err", err, "output", strings.TrimSpace(string(out)))
+			fail(fmt.Errorf("set password for %s: %w", user.Name, err))
 		} else {
 			// xpf now manages this exact account's password — mark it so a
 			// later directive removal locks it (covers a pre-existing or
@@ -1332,6 +1358,7 @@ func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
 				if err := markProvisioned(user.Name, curUID); err != nil {
 					slog.Warn("failed to write provisioned-user marker",
 						"user", user.Name, "err", err)
+					fail(fmt.Errorf("mark provisioned %s: %w", user.Name, err))
 				}
 			}
 			slog.Info("user encrypted-password applied", "user", user.Name)
@@ -1345,11 +1372,13 @@ func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
 		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
 			slog.Warn("failed to lock user password",
 				"user", user.Name, "err", err, "output", strings.TrimSpace(string(out)))
+			fail(fmt.Errorf("lock password for %s: %w", user.Name, err))
 		} else {
 			slog.Info("user password locked (no encrypted-password in config)",
 				"user", user.Name)
 		}
 	}
+	return err
 }
 
 // sshdConfPath is the xpf-managed sshd drop-in. Overridable in tests so the
@@ -1395,7 +1424,8 @@ var (
 // its prior content (or removed if there was none, the prior was unreadable,
 // or the restore write itself fails) so a bad config never persists to break
 // the next sshd restart.
-func (d *Daemon) applySSHConfig(cfg *config.Config) {
+func (d *Daemon) applySSHConfig(cfg *config.Config) (retErr error) {
+	fail := func(e error) { retErr = errors.Join(retErr, e) }
 	var ssh *config.SSHServiceConfig
 	if cfg.System.Services != nil {
 		ssh = cfg.System.Services.SSH
@@ -1424,23 +1454,27 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 		// No xpf-managed ssh settings. Remove any existing drop-in and reload
 		// so sshd reverts to base-image defaults. No-op when absent.
 		if !hadDropIn {
-			return
+			return nil
 		}
 		if err := sshdRemoveFile(sshdConfPath); err != nil && !os.IsNotExist(err) {
 			slog.Warn("failed to remove sshd config drop-in", "err", err)
+			// naked return: yields the accumulated named result, not the
+			// block-shadowed err from the `if err := ...` binding above.
+			fail(fmt.Errorf("remove sshd config drop-in: %w", err))
 			return
 		}
 		if out, err := sshdReloadCmd(); err != nil {
 			slog.Error("failed to reload sshd after removing drop-in",
 				"err", err, "output", strings.TrimSpace(string(out)))
+			fail(fmt.Errorf("reload sshd after removing drop-in: %w", err))
 			return
 		}
 		slog.Info("SSH config drop-in removed (reverted to defaults)")
-		return
+		return nil
 	}
 
 	if priorReadable && string(prior) == content {
-		return // no change
+		return nil // no change
 	}
 
 	// Best-effort create the drop-in directory before writing. If this fails
@@ -1449,6 +1483,7 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 	// error.
 	if err := sshdMkdirAll("/etc/ssh/sshd_config.d", 0755); err != nil {
 		slog.Warn("failed to create sshd config drop-in directory", "err", err)
+		fail(fmt.Errorf("create sshd config drop-in directory: %w", err))
 	}
 	// AtomicGeneratedConfig (D2): regenerated each apply and reloaded
 	// immediately. A power-cut loss reverts PermitRootLogin to the base
@@ -1456,6 +1491,7 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 	// FAILS SAFE (more restrictive, never more permissive), so no fsync.
 	if err := sshdWriteFile(sshdConfPath, []byte(content), 0644); err != nil {
 		slog.Warn("failed to write sshd config", "err", err)
+		fail(fmt.Errorf("write sshd config: %w", err))
 		return
 	}
 
@@ -1494,6 +1530,7 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 		slog.Error("sshd config validation failed; SSH drop-in not applied",
 			"err", err, "output", strings.TrimSpace(string(out)))
 		revertDropIn("validation-failed")
+		fail(fmt.Errorf("validate sshd config: %w", err))
 		return
 	}
 
@@ -1504,6 +1541,7 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 		slog.Error("failed to reload sshd",
 			"err", err, "output", strings.TrimSpace(string(out)))
 		revertDropIn("reload-failed")
+		fail(fmt.Errorf("reload sshd: %w", err))
 		// Best-effort reload of the restored content so the running sshd is
 		// not left referencing a drop-in we just rewrote/removed underneath
 		// it. The original reload already failed; a second failure here is
@@ -1517,6 +1555,7 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 	slog.Info("SSH config applied",
 		"root_login", ssh.RootLogin,
 		"key_exchange", strings.Join(ssh.KeyExchange, ","))
+	return nil
 }
 
 // buildSSHDConfig renders the xpf-managed sshd drop-in body from the SSH
@@ -1629,7 +1668,8 @@ func buildSSHDConfig(ssh *config.SSHServiceConfig) string {
 // (no encrypted-password) is still revocable. Idempotent: re-applying with the
 // stanza still absent re-locks nothing (the shadow field is already "!") and
 // removes nothing (the key file is already gone).
-func (d *Daemon) applyRootAuth(cfg *config.Config) {
+func (d *Daemon) applyRootAuth(cfg *config.Config) (retErr error) {
+	fail := func(e error) { retErr = errors.Join(retErr, e) }
 	ra := cfg.System.RootAuthentication
 
 	// A nil stanza means "root-authentication not configured": the desired
@@ -1647,7 +1687,7 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) {
 	// It applies a configured hash (with apply-boundary revalidation + marker)
 	// and, when the password is absent, D2-locks root ONLY if the marker shows
 	// xpf provisioned it — never on a read error, never an already-locked field.
-	d.reconcileUserPassword(&config.LoginUser{Name: "root", EncryptedPassword: password})
+	fail(d.reconcileUserPassword(&config.LoginUser{Name: "root", EncryptedPassword: password}))
 
 	// Keys: write the configured set wholesale, else revoke the xpf-managed file.
 	if len(keys) > 0 {
@@ -1656,6 +1696,9 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) {
 		// (Codex r1).
 		if err := fsatomic.MkdirAllDurable(rootSSHDir, 0700); err != nil {
 			slog.Warn("failed to create /root/.ssh dir", "err", err)
+			// naked return: yields the accumulated named result, not the
+			// block-shadowed err from the `if err := ...` binding.
+			fail(fmt.Errorf("create /root/.ssh dir: %w", err))
 			return
 		}
 		keysContent := strings.Join(keys, "\n") + "\n"
@@ -1667,6 +1710,7 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) {
 			// uid 0) and keeps the install correctly-owned at rename.
 			if err := fsatomic.WriteFileDurable(keysFile, []byte(keysContent), 0600, fsatomic.WithOwner(0, 0)); err != nil {
 				slog.Warn("failed to write root authorized_keys", "err", err)
+				fail(fmt.Errorf("write root authorized_keys: %w", err))
 				return
 			}
 			slog.Info("root SSH keys applied", "keys", len(keys))
@@ -1677,6 +1721,7 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) {
 		// the key apply too so a keys-only root-authentication is revocable.
 		if err := markProvisioned("root", 0); err != nil {
 			slog.Warn("failed to write root provisioned marker", "err", err)
+			fail(fmt.Errorf("mark root provisioned: %w", err))
 		}
 	} else if xpfProvisioned("root", 0) {
 		// Empty/absent key list AND xpf provisioned root: revoke the xpf-managed
@@ -1692,6 +1737,8 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) {
 		case !os.IsNotExist(err):
 			slog.Warn("failed to remove root authorized_keys after key list emptied",
 				"file", keysFile, "err", err)
+			fail(fmt.Errorf("revoke root authorized_keys: %w", err))
 		}
 	}
+	return retErr
 }

--- a/pkg/daemon/host_auth_closeout_5874_test.go
+++ b/pkg/daemon/host_auth_closeout_5874_test.go
@@ -1,0 +1,183 @@
+package daemon
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// noopCloseoutOwner is a host-auth closeout owner that always reconciles
+// cleanly — a stand-in for the owners a given test is not exercising.
+func noopCloseoutOwner(*config.Config) error { return nil }
+
+// TestHostAuthCloseoutSurfacesReconcilerFailure is the #5874 fail-on-revert
+// merge gate. Before the fix the post-promotion cancel closeout ran the five
+// credential reconcilers (login / sudoers / absent-user / SSH / root-auth) as
+// best-effort VOIDS and returned only the two nft errors, so a credential
+// reconcile FAILURE was silently discarded and the cancel reported clean over a
+// host-auth state that never converged. This drives the REAL reconcileSudoers
+// with an unwritable sudoers directory (a genuine durable-write failure for a
+// configured super-user) through the closeout's collect+summarize path and
+// asserts the failure is SURFACED and attributed to the "sudoers" owner.
+//
+// Fail-on-revert (single compiling neutralization): drop the
+// `case o.err != nil` append in summarizeHostAuthCloseout and the closeout
+// returns nil for a failed owner — this test goes RED on the `err == nil`
+// assertion. Control: the same reconcile against a writable dir returns nil.
+func TestHostAuthCloseoutSurfacesReconcilerFailure(t *testing.T) {
+	d := &Daemon{}
+
+	// Failure injection: point reconcileSudoers at a non-existent directory so
+	// its durable grant write fails for a real super-user. validateSudoersFile
+	// is stubbed (unreached — the write fails first — but keeps the test
+	// independent of a host visudo).
+	origDir, origValidate := sudoersDir, validateSudoersFile
+	validateSudoersFile = func(string) error { return nil }
+	defer func() { sudoersDir, validateSudoersFile = origDir, origValidate }()
+	sudoersDir = filepath.Join(t.TempDir(), "missing") // never created → write fails
+
+	cfg := loginCfg(&config.LoginUser{Name: "admin", Class: "super-user"})
+
+	// Only "sudoers" is the real reconciler; the other six owners are clean
+	// no-ops so the assertion isolates the surfaced credential failure.
+	owners := []hostAuthOwner{
+		{"lo0-filter", noopCloseoutOwner},
+		{"host-inbound-filter", noopCloseoutOwner},
+		{"system-login", noopCloseoutOwner},
+		{"sudoers", d.reconcileSudoers}, // REAL reconciler, injected to fail
+		{"absent-login-users", noopCloseoutOwner},
+		{"ssh-config", noopCloseoutOwner},
+		{"root-auth", noopCloseoutOwner},
+	}
+
+	err := summarizeHostAuthCloseout(runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners))
+	if err == nil {
+		t.Fatal("host-auth cancel closeout returned nil despite a sudoers reconcile failure — " +
+			"the credential-reconcile failure was DISCARDED (the #5874 bug)")
+	}
+	if !strings.Contains(err.Error(), "sudoers") {
+		t.Fatalf("closeout error %q does not attribute the failure to the sudoers owner", err)
+	}
+
+	// Control: a writable sudoers dir → the same reconcile succeeds → clean.
+	sudoersDir = t.TempDir()
+	if err := summarizeHostAuthCloseout(runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners)); err != nil {
+		t.Fatalf("closeout returned %v with all owners succeeding, want nil", err)
+	}
+}
+
+// TestHostAuthCloseoutEnforcesBudget proves the closeout is BOUNDED (#5874): a
+// wedged owner that outruns the budget is reported timed-out (fail-visible)
+// rather than allowed to hang the daemon-stop path indefinitely, and every
+// owner queued after the budget is exhausted is reported timed-out too — never
+// silently skipped, and never launched concurrently with the abandoned one.
+func TestHostAuthCloseoutEnforcesBudget(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release) // unblock the wedged goroutine on test exit (no leak)
+
+	wedged := func(*config.Config) error {
+		<-release // block well past the budget
+		return nil
+	}
+	launchedAfter := false
+	afterBudget := func(*config.Config) error { launchedAfter = true; return nil }
+
+	owners := []hostAuthOwner{
+		{"fast", noopCloseoutOwner},
+		{"wedged", wedged},
+		{"after", afterBudget},
+	}
+
+	start := time.Now()
+	outcomes := runHostAuthCloseoutOwners(&config.Config{}, 50*time.Millisecond, owners)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("closeout blocked %v on a wedged owner — the wall-clock budget was not enforced", elapsed)
+	}
+
+	got := map[string]hostAuthOwnerOutcome{}
+	for _, o := range outcomes {
+		got[o.name] = o
+	}
+	if got["fast"].err != nil || got["fast"].timedOut {
+		t.Errorf("fast owner outcome = %+v, want clean (nil err, not timed out)", got["fast"])
+	}
+	if !got["wedged"].timedOut {
+		t.Errorf("wedged owner outcome = %+v, want timedOut", got["wedged"])
+	}
+	if !got["after"].timedOut {
+		t.Errorf("owner queued after budget exhaustion = %+v, want reported timedOut (not silently skipped)", got["after"])
+	}
+	if launchedAfter {
+		t.Error("owner after a budget-exhausting wedge was LAUNCHED — the skip-after-deadline invariant " +
+			"(no concurrent run with the abandoned owner) was violated")
+	}
+
+	// The summary surfaces the timed-out owners as a joined, named error.
+	err := summarizeHostAuthCloseout(outcomes)
+	if err == nil || !strings.Contains(err.Error(), "wedged") || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("summary = %v, want it to name the timed-out wedged owner", err)
+	}
+}
+
+// TestHostAuthCloseoutOwnerWiring guards the owner set: every security-critical
+// host-authorization owner — especially the five credential reconcilers whose
+// failures used to be discarded (#5874) — must stay wired into the closeout, in
+// the M35 tail order (step 9.5–13). Dropping an owner here would silently narrow
+// what a cancel reconciles and re-open a monotonic-revocation gap.
+func TestHostAuthCloseoutOwnerWiring(t *testing.T) {
+	d := &Daemon{}
+	got := d.hostAuthCloseoutOwners()
+	want := []string{
+		"lo0-filter", "host-inbound-filter", "system-login",
+		"sudoers", "absent-login-users", "ssh-config", "root-auth",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("hostAuthCloseoutOwners has %d owners %v, want %d %v", len(got), ownerNames(got), len(want), want)
+	}
+	for i, name := range want {
+		if got[i].name != name {
+			t.Errorf("owner[%d] = %q, want %q", i, got[i].name, name)
+		}
+		if got[i].fn == nil {
+			t.Errorf("owner %q has a nil reconcile fn", name)
+		}
+	}
+}
+
+func ownerNames(owners []hostAuthOwner) []string {
+	names := make([]string, len(owners))
+	for i, o := range owners {
+		names[i] = o.name
+	}
+	return names
+}
+
+// TestReconcileSudoersReturnsWriteFailure pins the #5874 reconciler-side change:
+// reconcileSudoers now RETURNS its accumulated grant-write failures instead of
+// only logging them, so the cancel closeout can attribute a failed sudo-grant
+// reconcile to the sudoers owner. A configured super-user whose grant cannot be
+// written (unwritable dir) yields a non-nil error; the same reconcile against a
+// writable dir returns nil.
+func TestReconcileSudoersReturnsWriteFailure(t *testing.T) {
+	origDir, origValidate := sudoersDir, validateSudoersFile
+	validateSudoersFile = func(string) error { return nil }
+	defer func() { sudoersDir, validateSudoersFile = origDir, origValidate }()
+
+	d := &Daemon{}
+	cfg := loginCfg(&config.LoginUser{Name: "admin", Class: "super-user"})
+
+	sudoersDir = filepath.Join(t.TempDir(), "missing") // never created → write fails
+	if err := d.reconcileSudoers(cfg); err == nil {
+		t.Fatal("reconcileSudoers returned nil despite an unwritable sudoers dir — write failure discarded")
+	}
+
+	sudoersDir = t.TempDir()
+	if err := d.reconcileSudoers(cfg); err != nil {
+		t.Fatalf("reconcileSudoers returned %v with a writable dir, want nil", err)
+	}
+}

--- a/pkg/daemon/login_password.go
+++ b/pkg/daemon/login_password.go
@@ -2,6 +2,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -293,12 +294,18 @@ func managedAuthorizedKeysPath(name string) string {
 // xpf actually provisioned — and deprovisions each marker whose username no
 // longer appears in the config. An out-of-band account (no marker) is never
 // enumerated and never touched.
-func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) {
+// reconcileAbsentLoginUsers revokes credentials for xpf-provisioned accounts
+// no longer in config. It stays best-effort per account but ACCUMULATES each
+// deprovision failure into the returned error so the #5874 cancel closeout can
+// see that a removed user's credentials were NOT actually revoked (a
+// monotonic-revocation gap). The normal apply path ignores the return — the
+// next boot retries deprovision from the active config.
+func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) (retErr error) {
 	entries, err := os.ReadDir(provisionedUsersDir)
 	if err != nil {
 		// No markers yet (fresh install) or unreadable — nothing xpf
 		// provisioned, so nothing to revoke.
-		return
+		return nil
 	}
 
 	// The set of usernames still declared in config; these are kept.
@@ -323,8 +330,9 @@ func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) {
 		if _, keep := desired[name]; keep {
 			continue // still configured — leave it alone
 		}
-		d.deprovisionLoginUser(name)
+		retErr = errors.Join(retErr, d.deprovisionLoginUser(name))
 	}
+	return retErr
 }
 
 // deprovisionLoginUser revokes one removed account's password and managed
@@ -334,7 +342,8 @@ func (d *Daemon) reconcileAbsentLoginUsers(cfg *config.Config) {
 // that cannot be completed safely leaves the marker in place so the next apply
 // retries, and it never removes a credential it did not first verify as
 // xpf-owned. #5128.
-func (d *Daemon) deprovisionLoginUser(name string) {
+func (d *Daemon) deprovisionLoginUser(name string) (retErr error) {
+	fail := func(e error) { retErr = errors.Join(retErr, e) }
 	curUID, found, err := lookupUIDErr(name)
 	if err != nil {
 		// /etc/passwd could not be READ (transient mount/permission/I/O
@@ -349,6 +358,10 @@ func (d *Daemon) deprovisionLoginUser(name string) {
 		// uncertainty is "unknown → retry", never "absent → abandon".
 		slog.Warn("skipping removed-user deprovision: cannot read passwd",
 			"user", name, "err", err)
+		// Fail-visible: an unread identity DB means the removed account's
+		// credential may still be live and was NOT revoked. naked return
+		// yields the accumulated retErr, not the block-local err above.
+		fail(fmt.Errorf("read passwd for removed user %s: %w", name, err))
 		return // keep marker; retry next apply
 	}
 	if !found {
@@ -356,13 +369,13 @@ func (d *Daemon) deprovisionLoginUser(name string) {
 		// userdel. There is nothing to revoke; drop the stale marker so we
 		// stop revisiting it every apply.
 		_ = os.Remove(markerPath(name))
-		return
+		return nil
 	}
 	if !xpfProvisioned(name, curUID) {
 		// Marker missing or its UID no longer matches (the account was
 		// deleted+recreated out of band with a different UID). xpfProvisioned
 		// already cleaned a stale marker inline. NEVER touch a non-xpf account.
-		return
+		return nil
 	}
 
 	// Lock the password (idempotent). Fail-CLOSED on a shadow read error: we
@@ -374,6 +387,7 @@ func (d *Daemon) deprovisionLoginUser(name string) {
 	if !ok {
 		slog.Warn("skipping removed-user deprovision: cannot read shadow",
 			"user", name)
+		fail(fmt.Errorf("read shadow for removed user %s", name))
 		return // keep marker; retry next apply
 	}
 	if !isLockedShadow(cur) {
@@ -381,6 +395,7 @@ func (d *Daemon) deprovisionLoginUser(name string) {
 		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
 			slog.Warn("failed to lock password for removed login user",
 				"user", name, "err", err, "output", strings.TrimSpace(string(out)))
+			fail(fmt.Errorf("lock password for removed user %s: %w", name, err))
 			return // keep marker; retry
 		}
 		slog.Info("locked password for removed login user", "user", name)
@@ -392,6 +407,7 @@ func (d *Daemon) deprovisionLoginUser(name string) {
 	if err := os.Remove(keysFile); err != nil && !os.IsNotExist(err) {
 		slog.Warn("failed to remove authorized_keys for removed login user",
 			"user", name, "file", keysFile, "err", err)
+		fail(fmt.Errorf("remove authorized_keys for removed user %s: %w", name, err))
 		return // keep marker; retry
 	}
 
@@ -401,7 +417,9 @@ func (d *Daemon) deprovisionLoginUser(name string) {
 	if err := os.Remove(markerPath(name)); err != nil && !os.IsNotExist(err) {
 		slog.Warn("failed to remove provenance marker after deprovision",
 			"user", name, "err", err)
+		fail(fmt.Errorf("remove provenance marker for %s: %w", name, err))
 	}
 	slog.Info("deprovisioned removed login user (password locked, keys removed)",
 		"user", name)
+	return retErr
 }


### PR DESCRIPTION
## Summary

- After a promoted apply is **cancelled** at a #2926 boundary, the daemon runs a non-cancellable host-authorization closeout (`applyHostAuthorizationCloseout`, `pkg/daemon/daemon_apply.go`). It returned **only the two nft errors** and ran the five credential reconcilers (`applySystemLogin` / `reconcileSudoers` / `reconcileAbsentLoginUsers` / `applySSHConfig` / `applyRootAuth`) as best-effort **voids**, so a failure to reconcile a credential to the cancelled/target state was **silently discarded** and the cancel reported clean over host-auth state that never converged — a security gap where credential/host-auth revocation could fail invisibly.
- The sequence was called "bounded" with **no enforced deadline**, so a wedged reconciler could hang the daemon-stop path indefinitely.
- **Collect per-owner results.** Each owner is now a named `hostAuthOwner`; `runHostAuthCloseoutOwners` records a `hostAuthOwnerOutcome` per owner and `summarizeHostAuthCloseout` joins every **failing OR timed-out** owner into the returned error, **naming which owner** did not reconcile. `closeoutHostAuthOnCancel` already folds that into the propagated cancel, so a cancel now fails visibly instead of false-clean.
- **Enforce a budget.** `hostAuthCloseoutBudget` (30s) is a shared wall-clock deadline: each owner runs in its own goroutine (sequential — the M35 order is load-bearing — but bounded), so a wedged reconciler is reported **timed-out** (convergence unknown) instead of blocking shutdown. The budget bounds total time and does **not** abort on the first error (collect-all-then-report); post-budget owners are reported timed-out, never silently skipped and never launched concurrently with the abandoned one (its goroutine sends to a buffered channel and exits — no leak).
- The five reconcilers (and their helpers `reconcileUserPassword` / `deprovisionLoginUser`) now **return** their accumulated failures; the **normal** apply path (`applyTailReconciles`) intentionally discards them (`_ =`) since next-boot convergence covers a transient failure there.

## Scope tradeoff (per issue direction)

The reconcilers were void-by-choice (they compute failures and log-and-discard them), not "genuinely void with nothing to collect", so surfacing them is the correct fix rather than the STOP-and-report escape hatch. Blast radius is contained: adding an `error` return does **not** break the ~53 statement-style callers (Go does not flag ignored error returns and there is no errcheck gate), and the best-effort control flow is preserved exactly — only the return value is new.

## Test plan

- [x] `TestHostAuthCloseoutSurfacesReconcilerFailure` — drives the **real** `reconcileSudoers` (unwritable sudoers dir → genuine durable-write failure for a configured super-user) through the closeout; asserts the failure is surfaced and attributed to the `sudoers` owner. Control: writable dir → nil.
- [x] `TestHostAuthCloseoutEnforcesBudget` — a wedged owner is bounded and reported timed-out; a post-budget owner is reported but not launched.
- [x] `TestHostAuthCloseoutOwnerWiring` — all seven owners stay wired in M35 order.
- [x] `TestReconcileSudoersReturnsWriteFailure` — pins the reconciler-side return.
- [x] `go build ./...` + `go vet ./pkg/daemon` clean; daemon suite passes **3 uncached runs**; new tests pass under `-race -count=5`.

**Fail-on-revert (merge gate):** neutralizing the `case o.err != nil` append in `summarizeHostAuthCloseout` (single compiling change) makes **exactly** `TestHostAuthCloseoutSurfacesReconcilerFailure` go RED — verified target-count == 1 across `pkg/daemon`.

Unit-provable: no dataplane/forwarding surface, so **no smoke** required.

## Docs

`pkg/daemon/README.md` — the #5643/M35 closeout bullet gains a #5874 sub-bullet documenting collect-per-owner + enforced budget + normal-path discard.

Closes #5874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96kZKH8gZqNVDbLrb6ZQZ
