### PR TITLE
configstore: fence archive writers against zeroize (#5869)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54456,3 +54456,27 @@ top.
 - **File(s)**: pkg/cli/cli.go, pkg/cli/cli_request_system.go,
   pkg/daemon/daemon_run.go, pkg/cli/console_zeroize_transaction_5871_test.go (new),
   pkg/cli/README.md, pkg/grpcapi/README.md, pkg/daemon/README.md, _Log.md
+
+## 2026-07-21 — #5869 archival zeroize-race fence (security)
+
+- **Timestamp**: 2026-07-21
+- **Action**: Fence + join the fire-and-forget config-archive writer against
+  factory-reset (zeroize). Auto-archive launches an UNTRACKED goroutine per
+  commit (`commitWithDescriptionLocked`) that `os.MkdirAll`s the archive dir;
+  the #5281 reset generation gated the daemon's config writers but not this
+  configstore goroutine, so a writer resuming AFTER `FactoryResetArchiveDir`
+  removed `/var/lib/xpf/archive` could recreate a `config-<ts>.<seq>.conf`
+  snapshot of the PRIOR tenant's full config text (cleartext IKE PSK / WG keys /
+  SNMP communities) — re-tenant secret residue. Added `Store.archiveWG` +
+  `archiveFenced`, tracked the writer, gated its launch and its write on the
+  fence, and added `Store.QuiesceArchival()` (set fence under s.mu, then
+  `archiveWG.Wait()`) + `Store.ResumeArchival()`. `daemon.factoryReset` now
+  quiesces archival after entering the reset generation and before the wipe, and
+  resumes it on the fail-closed recoverable path. Fail-on-revert test pins the
+  JOIN (`archiveWG.Wait()`); neutralizing that single line → RED (writer
+  resurrects the archive after the wipe). Control proves normal archival still
+  writes. Unit-provable (in-package barrier seam), no smoke.
+- **File(s)**: pkg/configstore/store.go, pkg/configstore/store_commit.go,
+  pkg/configstore/store_persist.go, pkg/daemon/daemon_apply.go,
+  pkg/configstore/factory_reset_archival_fence_5869_test.go (new),
+  docs/system-login.md, _Log.md

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -344,6 +344,25 @@ through that single shared primitive so they wipe the same archive.
 - **Error surfacing.** A deletion or final directory-fsync failure is surfaced
   (folded into the wipe result / returned by the CLI), so a `zeroize` that could
   not fully erase the archive is never reported as a clean factory reset.
+- **In-flight archive-writer fence + join (#5869).** Erasing the directory is not
+  enough: auto-archive launches a **fire-and-forget writer goroutine** per commit
+  (`commitWithDescriptionLocked`), and `writeArchive` starts with
+  `os.MkdirAll(archiveDir)`. The #5281 terminal reset generation gates the
+  daemon's config writers but **not** that configstore-owned goroutine, so a
+  writer scheduled just before a `zeroize` could resume **after**
+  `FactoryResetArchiveDir` removed the directory and **recreate** a
+  `config-<ts>.<seq>.conf` snapshot of the **prior tenant's** full config text —
+  re-tenant secret residue, a zeroize that did not actually erase everything. The
+  daemon's factory-reset transaction (`daemon.factoryReset`) now calls
+  `store.QuiesceArchival()` **after** entering the reset generation and **before**
+  the wipe: it sets a one-way **archive fence** (a new/not-yet-written writer
+  no-ops instead of recreating the archive) and **joins** every in-flight writer
+  (`archiveWG.Wait()`) that has already begun, so once it returns no writer can
+  recreate the directory the wipe is about to erase. The join is the load-bearing
+  half — it closes the write-after-wipe window a fence alone cannot. On a
+  **fail-closed recoverable wipe** the daemon stays up and resumes normal work, so
+  it also `ResumeArchival()`s (clears the fence); on a **successful** wipe the
+  daemon is stopped and the fence stays latched.
 
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`

--- a/pkg/configstore/factory_reset_archival_fence_5869_test.go
+++ b/pkg/configstore/factory_reset_archival_fence_5869_test.go
@@ -1,0 +1,169 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// archiveSecret5869 stands in for any prior-tenant secret that lands in an
+// archived config snapshot. writeArchive drops 0600 copies of the full
+// committed config TEXT, so a resurrected archive carries such leaves in
+// cleartext (IKE PSK, WireGuard private key, SNMP community).
+const archiveSecret5869 = "PRIOR-TENANT-SECRET-5869"
+
+// TestQuiesceArchivalJoinsInflightWriterBeforeWipe pins the #5869 fix: a
+// factory reset must JOIN an in-flight async archive writer before it erases the
+// archive directory, so a writer that has already started cannot recreate a
+// config-<ts>.<seq>.conf snapshot of the PRIOR tenant's config AFTER the wipe —
+// zeroize secret residue on a re-tenanted device.
+//
+// Auto-archive launches a fire-and-forget writer goroutine per commit
+// (commitWithDescriptionLocked). The #5281 terminal reset generation gates the
+// daemon's config writers but NOT that configstore-owned goroutine, so before
+// #5869 a writer scheduled just before a zeroize could resume after
+// FactoryResetArchiveDir removed /var/lib/xpf/archive and MkdirAll + write the
+// prior tenant's archive right back.
+//
+// This reproduces the exact race deterministically: a commit launches the
+// writer, the writer blocks MID-FLIGHT at archiveWriteBarrier — deliberately
+// PAST the goroutine fence check, so the fence cannot mask a missing join — and
+// then the daemon's factory-reset sequence runs QuiesceArchival() (fence + JOIN)
+// followed by the archive-dir wipe. The writer is released only after
+// QuiesceArchival has begun joining it.
+//
+// RED on revert: neutralize the `s.archiveWG.Wait()` line in QuiesceArchival
+// (the JOIN). QuiesceArchival then returns without waiting, the wipe runs while
+// the writer is still blocked, and when the writer is released it MkdirAll's the
+// archive dir and writes the prior-tenant snapshot AFTER the wipe — the file
+// survives and the assertions below trip.
+func TestQuiesceArchivalJoinsInflightWriterBeforeWipe(t *testing.T) {
+	dir := useTempArchiveDefault(t) // archive dir == the ownership-guarded default
+
+	s := newTestStore(t)
+	s.SetArchiveConfig(dir, 10)
+
+	// Hold the archive writer MID-FLIGHT: past the fence check (so the fence
+	// cannot mask a missing join) and before the actual write.
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var once sync.Once
+	old := archiveWriteBarrier
+	archiveWriteBarrier = func() {
+		once.Do(func() { close(started) })
+		<-release
+	}
+	t.Cleanup(func() { archiveWriteBarrier = old })
+
+	// A commit whose config text carries a recognizable secret launches the
+	// writer (Commit -> CommitWithDescription("") archives).
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("system host-name " + archiveSecret5869); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Wait until the writer is blocked in the barrier (in-flight, past the fence).
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("archive writer never reached the barrier")
+	}
+
+	// Run the daemon's factory-reset sequence: QuiesceArchival (fence + JOIN)
+	// then the archive-dir wipe. QuiesceArchival blocks joining the in-flight
+	// writer, so drive it from a goroutine and release the writer once the join
+	// is under way.
+	done := make(chan struct{})
+	go func() {
+		s.QuiesceArchival()             // JOIN: with the fix, blocks until the writer is done
+		_ = FactoryResetArchiveDir(dir) // wipe: RemoveAll + parent fsync
+		close(done)
+	}()
+
+	// Give the factory-reset goroutine a moment to run, then release the writer.
+	// With the fix QuiesceArchival is now blocked in Wait() joining this writer,
+	// so the wipe runs only after the write. WITHOUT the join QuiesceArchival
+	// returns immediately and the wipe has already run against the absent dir by
+	// now — the exact race — so the writer, once released, recreates the archive
+	// AFTER the wipe.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	// Wait for the writer goroutine itself to fully finish (in-package access to
+	// the tracking WaitGroup) BEFORE asserting. This is what makes the revert
+	// deterministically RED: without the JOIN in QuiesceArchival, `done` fires
+	// early (before the writer is released), so the assertion must independently
+	// wait out the writer's post-wipe recreation instead of racing it.
+	s.archiveWG.Wait()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("factory-reset sequence (QuiesceArchival + wipe) did not complete")
+	}
+
+	// The archive directory — and any prior-tenant snapshot in it — must be gone.
+	if ents, err := os.ReadDir(dir); err == nil {
+		names := make([]string, 0, len(ents))
+		for _, e := range ents {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("archive directory recreated after zeroize: a resumed writer resurrected the prior-tenant archive: %v", names)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("archive directory still present after zeroize (stat err=%v)", err)
+	}
+}
+
+// TestAutoArchiveStillWritesWithoutQuiesce is the CONTROL: a normal commit (no
+// factory reset) still archives. It proves the #5869 launch guard defaults to
+// ALLOWING archival (the fence starts false) and that tracking the writer in the
+// WaitGroup did not break the ordinary auto-archive path. It polls for the async
+// writer's output (mirroring TestAutoArchiveCapturesCommittedTreeNoOverwrite)
+// rather than draining via QuiesceArchival — the latter would fence a
+// not-yet-started writer into a no-op and race this control.
+func TestAutoArchiveStillWritesWithoutQuiesce(t *testing.T) {
+	dir := useTempArchiveDefault(t)
+
+	s := newTestStore(t)
+	s.SetArchiveConfig(dir, 10)
+
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("system host-name " + archiveSecret5869); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Let the async writer finish.
+	deadline := time.Now().Add(2 * time.Second)
+	var ents []os.DirEntry
+	for time.Now().Before(deadline) {
+		if e, err := os.ReadDir(dir); err == nil && len(e) >= 1 {
+			ents = e
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("normal commit must archive exactly one snapshot, got %d", len(ents))
+	}
+	body, err := os.ReadFile(filepath.Join(dir, ents[0].Name()))
+	if err != nil {
+		t.Fatalf("read archive file: %v", err)
+	}
+	if !strings.Contains(string(body), archiveSecret5869) {
+		t.Fatalf("archive did not capture the committed config text; got:\n%s", body)
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -223,6 +223,27 @@ type Store struct {
 	// sort/prune order (it dominates the lexical compare).
 	archiveSeq atomic.Uint64
 
+	// archiveWG tracks the in-flight async auto-archive writer goroutines
+	// (#5869). Each archiving commit Add(1)s before it launches the
+	// fire-and-forget writer; QuiesceArchival Wait()s on it so a factory reset
+	// can JOIN every writer that has already started before it erases the
+	// archive directory. Without the join an untracked writer could resume
+	// AFTER FactoryResetArchiveDir removed /var/lib/xpf/archive and recreate a
+	// config-<ts>.<seq>.conf snapshot of the PRIOR tenant's full config text
+	// (cleartext IKE PSKs, WireGuard keys, SNMP communities) — zeroize secret
+	// residue on a re-tenanted device.
+	archiveWG sync.WaitGroup
+
+	// archiveFenced is set true by QuiesceArchival at the start of a factory
+	// reset (#5869). Once set, no NEW archive writer is launched (the commit
+	// launch guard reads it under s.mu, so the Add/Wait ordering is race-free)
+	// and an already-launched writer that has not yet written no-ops instead of
+	// recreating the archive the zeroize is about to erase. It is a one-way
+	// latch for the terminal reset path; ResumeArchival clears it only on the
+	// fail-closed recoverable-wipe path so a daemon that stays up keeps
+	// archiving normally.
+	archiveFenced atomic.Bool
+
 	// rollbackPersistDegraded records that the most recent
 	// saveRollbackFiles() failed to durably write a rollback slot or sync
 	// the directory (#3441 L1). The commit itself still succeeds — the

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -37,6 +37,15 @@ var (
 	rbRemove           = os.Remove
 )
 
+// archiveWriteBarrier is a test-only seam (#5869) invoked by the async
+// auto-archive goroutine AFTER the archive fence check and BEFORE the actual
+// write. Production is a no-op. A test overrides it to hold a writer
+// MID-FLIGHT — deliberately PAST the fence check, so the fence cannot mask it —
+// to prove QuiesceArchival JOINS an in-flight writer (not merely fences future
+// ones) before a factory reset erases the archive directory. Never mutated by
+// production code.
+var archiveWriteBarrier = func() {}
+
 // maxCommitDescriptionBytes bounds the operator-supplied commit description
 // (the `commit comment` text) that is recorded verbatim in the in-memory
 // history entry and the durable JSONL audit journal.
@@ -255,7 +264,15 @@ func (s *Store) commitWithDescriptionLocked(description string) (*config.Config,
 	// same-second commits wrote the same path (later overwrote earlier).
 	// The nanosecond timestamp makes the filename unique per commit (no
 	// overwrite) and correctly labels the captured tree.
-	if s.archiveDir != "" {
+	//
+	// #5869: skip launching a writer once the archive fence is set (a factory
+	// reset is erasing the archive directory) and TRACK every writer we do
+	// launch in s.archiveWG so QuiesceArchival can JOIN it before the wipe. The
+	// launch guard and the Add(1) run under s.mu (held across
+	// commitWithDescriptionLocked), and QuiesceArchival sets the fence under the
+	// same lock before it Wait()s — so no Add can start after the fence, and the
+	// WaitGroup counter never rises from zero concurrently with Wait.
+	if s.archiveDir != "" && !s.archiveFenced.Load() {
 		dir := s.archiveDir
 		max := s.archiveMax
 		if max <= 0 {
@@ -264,7 +281,18 @@ func (s *Store) commitWithDescriptionLocked(description string) (*config.Config,
 		data := s.active.Format()
 		ts := time.Now()
 		seq := s.archiveSeq.Add(1)
+		s.archiveWG.Add(1)
 		go func() {
+			defer s.archiveWG.Done()
+			// #5869: re-check the fence inside the goroutine. A writer that
+			// observes it (a factory reset began after this commit launched the
+			// writer, before it reached the write) MUST NOT recreate the archive
+			// directory the wipe is about to erase — that would resurrect the
+			// prior tenant's config secrets on a re-tenanted device.
+			if s.archiveFenced.Load() {
+				return
+			}
+			archiveWriteBarrier()
 			if err := writeArchive(dir, max, data, ts, seq); err != nil {
 				slog.Warn("auto-archive failed", "err", err)
 			}

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -471,6 +471,54 @@ func (s *Store) SetArchiveConfig(dir string, max int) {
 	s.archiveMax = max
 }
 
+// QuiesceArchival fences and drains the async auto-archive writers so a
+// factory-reset caller can guarantee the archive directory it is about to erase
+// is not recreated by a resumed writer (#5869). Auto-archive launches a
+// fire-and-forget writer goroutine per commit (commitWithDescriptionLocked);
+// the #5281 terminal reset generation gates the daemon's config writers but NOT
+// this configstore-owned goroutine, so a writer that resumes after
+// FactoryResetArchiveDir removed /var/lib/xpf/archive would MkdirAll it again
+// and drop a config-<ts>.<seq>.conf snapshot of the PRIOR tenant's full config
+// text (cleartext IKE PSKs, WireGuard keys, SNMP communities) — zeroize secret
+// residue on a re-tenanted device. QuiesceArchival closes that window in two
+// steps:
+//
+//  1. Set the archive fence under s.mu, so no NEW writer is launched by a later
+//     commit (the launch guard reads it under the same lock) and an
+//     already-launched writer that has not yet written no-ops.
+//  2. Wait for every in-flight writer that has already passed the fence check
+//     (a mid-write writer executing writeArchive's MkdirAll + atomic write) to
+//     finish, so none is still running when the caller erases the archive
+//     directory. This JOIN is what defeats the write-after-wipe race the fence
+//     alone cannot: a writer already past the fence check would otherwise
+//     recreate the archive concurrently with, or after, the wipe.
+//
+// The Add/Wait ordering is race-free: every archiveWG.Add(1) runs under s.mu
+// guarded by !archiveFenced, and this method sets archiveFenced under s.mu
+// before Wait, so the WaitGroup counter can never rise from zero concurrently
+// with Wait. It is idempotent and a no-op when no writer is outstanding. The
+// daemon's factory-reset transaction (daemon.factoryReset) calls it AFTER
+// entering the terminal reset generation (which blocks new commits) and BEFORE
+// the wipe, so once it returns the archive directory can be erased with no
+// writer left to recreate it.
+func (s *Store) QuiesceArchival() {
+	s.mu.Lock()
+	s.archiveFenced.Store(true)
+	s.mu.Unlock()
+	s.archiveWG.Wait()
+}
+
+// ResumeArchival clears the archive fence set by QuiesceArchival (#5869). It is
+// called ONLY on the fail-closed recoverable-wipe path: daemon.factoryReset
+// exits the terminal reset generation on a wipe error so the box stays up and
+// normal config work resumes, and without re-enabling archival a failed zeroize
+// would permanently disable config archival on a still-running daemon. On a
+// SUCCESSFUL wipe the daemon is stopped, so the fence is deliberately left
+// latched and this is never called.
+func (s *Store) ResumeArchival() {
+	s.archiveFenced.Store(false)
+}
+
 // ArchiveConfig saves a timestamped copy of the active config. The active
 // text and the timestamp are captured together under the lock so the
 // written archive matches the config that was active at the call (#3441 H4),

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -216,6 +216,11 @@ func (d *Daemon) exitResetGeneration() { d.resetting.Store(false) }
 //  2. Enter the terminal reset generation BEFORE the wipe, so a writer that
 //     acquires applySem AFTER this returns (a periodic reconciler, a late
 //     commit, a shutdown-time apply) short-circuits on errDaemonResetting.
+//  2a. Quiesce config archival (#5869): the reset generation gates the daemon's
+//     config writers but NOT the configstore-owned fire-and-forget archive
+//     goroutine, so fence + JOIN it here before the wipe erases the archive
+//     directory — otherwise a resumed writer would recreate a prior-tenant
+//     config archive after FactoryResetArchiveDir removed it.
 //  3. Run the wipe while holding applySem.
 //     - On FAILURE: exit the reset generation and release applySem (deferred)
 //     so the half-reset box is recoverable and a retry can run, and return
@@ -230,7 +235,27 @@ func (d *Daemon) factoryReset(ctx context.Context, wipe func() error) error {
 	}
 	defer d.applySem.Release(1)
 	d.enterResetGeneration()
+	// #5869: fence + drain the async config-archive writers BEFORE the wipe
+	// erases /var/lib/xpf/archive. Auto-archive launches a fire-and-forget
+	// configstore goroutine per commit that the #5281 reset generation does NOT
+	// cover: a commit's writer that resumes after FactoryResetArchiveDir removed
+	// the archive dir would MkdirAll it again and drop a config-<ts>.<seq>.conf
+	// snapshot of the PRIOR tenant's full config text (cleartext IKE PSKs,
+	// WireGuard keys, SNMP communities) — zeroize secret residue on a
+	// re-tenanted device. QuiesceArchival sets the archive fence (new /
+	// not-yet-written writers no-op) and JOINS any in-flight writer, so once it
+	// returns no writer can recreate the archive the wipe is about to erase.
+	// (Nil-store guard: unit tests drive factoryReset on a bare Daemon.)
+	if d.store != nil {
+		d.store.QuiesceArchival()
+	}
 	if err := wipe(); err != nil {
+		// Fail-closed recoverable path: the daemon stays up and resumes normal
+		// config work, so re-enable archival too (a SUCCESSFUL wipe instead
+		// stops the daemon, leaving the fence latched). #5869.
+		if d.store != nil {
+			d.store.ResumeArchival()
+		}
 		d.exitResetGeneration()
 		return err
 	}


### PR DESCRIPTION
## Summary

- **Security (zeroize secret residue).** Commit archival launches an **untracked** fire-and-forget goroutine per commit (`commitWithDescriptionLocked` → `go writeArchive(...)`), and `writeArchive` starts with `os.MkdirAll(archiveDir)`. Factory reset (zeroize) removes the archive dir via `configstore.FactoryResetArchiveDir` but never cancels or joins those writers. The #5281 terminal reset generation gates the daemon's config writers but **not** this configstore-owned goroutine — so a writer scheduled just before a zeroize can resume **after** the wipe removed `/var/lib/xpf/archive`, `MkdirAll` it again, and drop a `config-<ts>.<seq>.conf` snapshot of the **prior tenant's** full config text (cleartext IKE PSKs, WireGuard keys, SNMP communities) back on disk. A zeroize that did not actually erase everything.
- **Fix — track + fence + join.** `Store` gains `archiveWG` (tracks in-flight writers) and `archiveFenced` (a one-way latch). The archiving commit `Add(1)`s and gates its launch **and** its write on the fence, all under `s.mu`. `QuiesceArchival()` sets the fence under `s.mu` (no new writer launches; `Add`/`Wait` ordering race-free) then `archiveWG.Wait()` **joins** every in-flight writer. `ResumeArchival()` clears the fence only on the fail-closed recoverable-wipe path.
- **Wiring.** `daemon.factoryReset` calls `QuiesceArchival()` **after** entering the reset generation and **before** the wipe, and `ResumeArchival()` on wipe failure. Both the gRPC `ZeroizeFn` path and the console `#5871 factoryResetFn` path route the wipe through this transaction, so both are covered.
- **The join is load-bearing.** The fence alone cannot close the write-after-wipe window: a writer already past the fence check would otherwise recreate the archive concurrently with, or after, the wipe. `archiveWG.Wait()` is what guarantees no writer is still running when the wipe erases the directory.

## Pinned sites (origin/master @ `3bf7257ec`)

- Untracked writer: `pkg/configstore/store_commit.go:267` (`go func(){ writeArchive(...) }`), writer at `pkg/configstore/store_persist.go:508` (`os.MkdirAll` + atomic write).
- Zeroize archive removal: `pkg/configstore/factory_reset.go:73` `FactoryResetArchiveDir` (`RemoveAll` + fsync), reached from `pkg/grpcapi/server_diag_zeroize.go:793` `performZeroizeWipe`.
- Reset-generation transaction (does **not** cover archival): `pkg/daemon/daemon_apply.go:219` `factoryReset`.

## Test plan

- [x] `TestQuiesceArchivalJoinsInflightWriterBeforeWipe` — reproduces the race deterministically (commit launches writer → writer blocks mid-flight *past* the fence check via the `archiveWriteBarrier` seam → factory-reset sequence runs `QuiesceArchival` + `FactoryResetArchiveDir`), asserts **no archive dir/file survives**. Pins the JOIN.
- [x] **Parent-RED:** neutralizing the single line `s.archiveWG.Wait()` in `QuiesceArchival` → the released writer resurrects the prior-tenant archive after the wipe → test RED as an assertion (target-count = 1; control stays green).
- [x] `TestAutoArchiveStillWritesWithoutQuiesce` — control: a normal commit (no zeroize) still archives exactly one snapshot carrying the config text.
- [x] `go build ./...`, `go vet ./pkg/configstore/... ./pkg/daemon/...`
- [x] `go test -race ./pkg/configstore/` (full suite) and `go test -race ./pkg/daemon/` (full suite) — both pass; new tests pass `-race -count=3` non-flake.
- Unit-provable (in-package barrier seam + in-process daemon wiring); **no smoke** — this is a control-plane lifecycle fix with no dataplane/forwarding surface.

## Docs

- `docs/system-login.md` — added the **in-flight archive-writer fence + join (#5869)** bullet to the "Local config-archive erasure (#5186)" zeroize-contract section.

## Refs

- Closes #5869
- Builds on #5281 (terminal reset generation), #5871 (console zeroize transaction), #5186 (archive erasure).
