### PR TITLE
dataplane/userspace: roll back BPF mirror on synced-session helper failure (#5305)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54594,3 +54594,33 @@ top.
 - **File(s)**: pkg/config/compiler_interfaces.go,
   pkg/config/compiler_prewalk.go, pkg/config/vrrp_authentication_4288_test.go,
   pkg/config/testdata/golden_4406.json, docs/feature-coverage.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5305 — cluster-synced session install made transactional (BPF
+  pre-image rollback on helper mirror failure). `SetClusterSyncedSessionV4/V6`
+  wrote the pinned BPF session mirror FIRST, then mirrored to the Rust helper;
+  on helper failure they recorded the mirror failure and returned but LEFT the
+  BPF entry installed — a split truth the GC / fallback bulk export could
+  propagate as if the install succeeded, producing nondeterministic HA session
+  ownership after takeover. The store's snapshot/rollback machinery
+  (session_store.go) never fired for this path because the installer's
+  `return err` runs before the store appends the forward pre-image to `written`.
+  Fix: for forward entries, snapshot the BPF pre-image (value-or-absence) BEFORE
+  the write and, on mirror failure, RESTORE it (rewrite prior value / delete if
+  absent), joining any compensation error with the mirror error. Snapshot +
+  write + mirror + compensate now run under one `m.mu` hold (was: BPF write
+  outside the lock) so the sequence is atomic w.r.t. other m.mu paths; per-peer
+  apply loop is single-threaded so no same-key race. Reverse entries (never
+  mirrored) just write BPF and return. Health behavior preserved:
+  recordSessionMirrorFailureLocked (#5247 takeover-disarm) and
+  recordSessionMirrorSuccessLocked (sticky-clear on real success) unchanged.
+  New snapshotBPFSessionV4/V6Locked + restoreBPFSessionV4/V6Locked helpers.
+  Tests: synced_session_bpf_rollback_5305_test.go —
+  TestSetClusterSyncedSessionV4/V6RollsBackOrphanOnMirrorFailure (absent→deleted,
+  prior→restored) + TestSetClusterSyncedSessionRollbackSuccessPathUnregressed.
+  Parent-RED: no-op the restore helpers → 2 tests (4 subtests) fail on assertion.
+  Validated: build + vet clean; focused userspace session/mirror suite green;
+  the 6 pre-existing userspace XDP-shim-load failures reproduce on origin/master.
+- **File(s)**: pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/synced_session_bpf_rollback_5305_test.go,
+  docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -62,6 +62,27 @@ installed into both places:
 install, they clear the cached FIB result so the receiving node recomputes
 node-local forwarding.
 
+**#5305 — the forward install is transactional.** A forward cluster-synced
+install writes the pinned BPF session mirror FIRST, then mirrors the entry to
+the Rust helper. If the helper mirror fails (connect/write/decode), the install
+RESTORES the BPF pre-image before returning — it rewrites the prior value, or
+DELETES the key if it was absent — so a failed install leaves the BPF map
+exactly as it was. Without this, the pinned map would hold a session the helper
+never received: a split truth the GC and the fallback bulk export
+(`ExportOwnerRGSessions`) would propagate as if the install had succeeded,
+producing nondeterministic HA session ownership after takeover. The pre-image
+snapshot, the BPF write, the helper mirror, and the compensating restore all run
+under `m.mu`, so the sequence is atomic against any other `m.mu`-holding path;
+the per-peer receiver apply loop is single-threaded (`installClusterSyncedV4` in
+`pkg/cluster/sync_conn.go`), so no concurrent install of the same key races. The
+existing health behavior is preserved: `recordSessionMirrorFailureLocked` still
+fires on the failure (takeover stays disarmed until the socket is proven healthy
+again), and `recordSessionMirrorSuccessLocked` still clears the sticky #5247 flag
+only on a genuine success. This is distinct from #5247/#5255, which self-heal the
+sticky mirror-failed flag but do NOT restore the BPF pre-image. Reverse entries
+are never mirrored to the helper (it synthesizes the reverse companion locally),
+so they take no compensation — they only write the BPF mirror.
+
 Locally-created forward sessions take a parallel path: `SetSessionV4()` /
 `SetSessionV6()` install into the kernel/BPF maps, then mirror the forward
 entry **and a pre-installed reverse companion** (#310 — so the helper holds the

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1090,27 +1090,86 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 	installVal.FibDmac = [6]byte{}
 	installVal.FibSmac = [6]byte{}
 	installVal.FibGen = 0
-	if err := m.bpfShim.SetSessionV4(key, installVal); err != nil {
-		return err
-	}
 	// The helper already synthesizes the correct reverse companion from the
 	// forward cluster-synced entry using local forwarding and HA state. An
 	// explicit reverse cluster update can overwrite that locally-derived
-	// companion with peer NAT/FIB metadata, so only mirror forward entries.
+	// companion with peer NAT/FIB metadata, so only mirror forward entries. A
+	// reverse entry is never mirrored, so there is no mirror failure to
+	// compensate: write the BPF mirror and return.
 	if !shouldMirrorUserspaceSession(val.IsReverse) {
-		return nil
+		return m.bpfShim.SetSessionV4(key, installVal)
 	}
+	// Forward entry: make the install transactional (#5305). Capture the
+	// pre-image of the BPF session entry BEFORE writing it, then mirror to the
+	// helper. On mirror failure RESTORE the pre-image (rewrite the prior value,
+	// or DELETE the key if it was absent) so a failed cluster-synced install
+	// leaves the BPF map exactly as it was. Otherwise the pinned map holds a
+	// session the helper never received — a split truth the GC and fallback
+	// bulk export would propagate as if the install had succeeded, producing
+	// nondeterministic HA session ownership after takeover.
+	//
+	// snapshot + write + mirror + compensate run under m.mu so the sequence is
+	// atomic w.r.t. any other m.mu-holding path; the per-peer receiver apply
+	// loop is single-threaded (pkg/cluster/sync_conn.go installClusterSyncedV4),
+	// so no concurrent install of the SAME key races. syncSessionV4Locked drops
+	// m.mu only for the socket send and reacquires it before returning, so the
+	// compensate that follows still observes our own BPF write.
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	prior, hadPrior, err := m.snapshotBPFSessionV4Locked(key)
+	if err != nil {
+		// The pre-image could not be read; refuse the install rather than write
+		// an entry that could not later be rolled back on a mirror failure.
+		return fmt.Errorf("snapshot synced v4 session pre-image: %w", err)
+	}
+	if err := m.bpfShim.SetSessionV4(key, installVal); err != nil {
+		return err
+	}
 	if err := m.syncSessionV4Locked("upsert", key, &installVal); err != nil {
 		m.recordSessionMirrorFailureLocked(err)
 		slog.Debug("userspace: session mirror failed", "err", err)
-		return fmt.Errorf("mirror synced v4 session to userspace helper: %w", err)
+		compErr := m.restoreBPFSessionV4Locked(key, prior, hadPrior)
+		return errors.Join(
+			fmt.Errorf("mirror synced v4 session to userspace helper: %w", err),
+			compErr,
+		)
 	}
 	// A successful mirror proves the helper session socket is healthy again;
 	// clear any sticky failure so the standby regains takeover-readiness
 	// without waiting for a helper restart (#5247).
 	m.recordSessionMirrorSuccessLocked()
+	return nil
+}
+
+// snapshotBPFSessionV4Locked reads the current BPF-mirror value for key so a
+// failed cluster-synced install can be rolled back to it (#5305). Returns
+// (value, existed, err); a missing key is existed=false with a nil error.
+// Named "Locked" for the m.mu convention of the compensation sequence — it
+// touches only the independently-locked bpfShim map, not m.mu directly.
+func (m *Manager) snapshotBPFSessionV4Locked(key dataplane.SessionKey) (dataplane.SessionValue, bool, error) {
+	val, err := m.bpfShim.GetSessionV4(key)
+	if err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return dataplane.SessionValue{}, false, nil
+		}
+		return dataplane.SessionValue{}, false, err
+	}
+	return val, true, nil
+}
+
+// restoreBPFSessionV4Locked reverts the BPF session entry for key to the
+// pre-install snapshot: rewrite the prior value, or delete the key if it was
+// absent (#5305). Deleting an already-absent key is treated as success.
+func (m *Manager) restoreBPFSessionV4Locked(key dataplane.SessionKey, prior dataplane.SessionValue, hadPrior bool) error {
+	if hadPrior {
+		if err := m.bpfShim.SetSessionV4(key, prior); err != nil {
+			return fmt.Errorf("restore synced v4 session pre-image: %w", err)
+		}
+		return nil
+	}
+	if err := m.bpfShim.DeleteSession(key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		return fmt.Errorf("remove orphan synced v4 session: %w", err)
+	}
 	return nil
 }
 
@@ -1166,23 +1225,65 @@ func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val data
 	installVal.FibDmac = [6]byte{}
 	installVal.FibSmac = [6]byte{}
 	installVal.FibGen = 0
+	// Reverse entries are never mirrored (see SetClusterSyncedSessionV4): write
+	// the BPF mirror and return — no mirror failure to compensate.
+	if !shouldMirrorUserspaceSession(val.IsReverse) {
+		return m.bpfShim.SetSessionV6(key, installVal)
+	}
+	// Forward entry: transactional install (#5305) — the IPv6 analogue of
+	// SetClusterSyncedSessionV4. Snapshot the BPF pre-image, write, mirror, and
+	// restore the pre-image on mirror failure so a failed install never leaves
+	// an orphan split-truth BPF entry the helper never received.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	prior, hadPrior, err := m.snapshotBPFSessionV6Locked(key)
+	if err != nil {
+		return fmt.Errorf("snapshot synced v6 session pre-image: %w", err)
+	}
 	if err := m.bpfShim.SetSessionV6(key, installVal); err != nil {
 		return err
 	}
-	if !shouldMirrorUserspaceSession(val.IsReverse) {
-		return nil
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	if err := m.syncSessionV6Locked("upsert", key, &installVal); err != nil {
 		m.recordSessionMirrorFailureLocked(err)
 		slog.Debug("userspace: session mirror failed", "err", err)
-		return fmt.Errorf("mirror synced v6 session to userspace helper: %w", err)
+		compErr := m.restoreBPFSessionV6Locked(key, prior, hadPrior)
+		return errors.Join(
+			fmt.Errorf("mirror synced v6 session to userspace helper: %w", err),
+			compErr,
+		)
 	}
 	// A successful mirror proves the helper session socket is healthy again;
 	// clear any sticky failure so the standby regains takeover-readiness
 	// without waiting for a helper restart (#5247).
 	m.recordSessionMirrorSuccessLocked()
+	return nil
+}
+
+// snapshotBPFSessionV6Locked is the IPv6 sibling of snapshotBPFSessionV4Locked
+// (#5305).
+func (m *Manager) snapshotBPFSessionV6Locked(key dataplane.SessionKeyV6) (dataplane.SessionValueV6, bool, error) {
+	val, err := m.bpfShim.GetSessionV6(key)
+	if err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return dataplane.SessionValueV6{}, false, nil
+		}
+		return dataplane.SessionValueV6{}, false, err
+	}
+	return val, true, nil
+}
+
+// restoreBPFSessionV6Locked is the IPv6 sibling of restoreBPFSessionV4Locked
+// (#5305).
+func (m *Manager) restoreBPFSessionV6Locked(key dataplane.SessionKeyV6, prior dataplane.SessionValueV6, hadPrior bool) error {
+	if hadPrior {
+		if err := m.bpfShim.SetSessionV6(key, prior); err != nil {
+			return fmt.Errorf("restore synced v6 session pre-image: %w", err)
+		}
+		return nil
+	}
+	if err := m.bpfShim.DeleteSessionV6(key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		return fmt.Errorf("remove orphan synced v6 session: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/dataplane/userspace/synced_session_bpf_rollback_5305_test.go
+++ b/pkg/dataplane/userspace/synced_session_bpf_rollback_5305_test.go
@@ -1,0 +1,260 @@
+package userspace
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// newMirrorFailManager5305 builds a Manager whose helper session mirror FAILS:
+// m.proc is set (so syncSession*Locked does not early-return nil) but no
+// listener exists on the derived session socket, so the mirror connect fails.
+// Real in-memory BPF session maps are injected so the pinned mirror can be read
+// back to assert the transactional rollback (#5305).
+func newMirrorFailManager5305(t *testing.T) *Manager {
+	t.Helper()
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	dir := t.TempDir()
+	m := New()
+	m.proc = &exec.Cmd{}
+	// No listener at <dir>/userspace-dp-sessions.sock -> mirror connect fails.
+	m.cfg.ControlSocket = filepath.Join(dir, "control.sock")
+	injectSessionMaps(t, m)
+	return m
+}
+
+// newMirrorOKManager5305 builds a Manager with a live session helper socket
+// that acknowledges every mirror request, so the mirror SUCCEEDS.
+func newMirrorOKManager5305(t *testing.T) *Manager {
+	t.Helper()
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	dir := t.TempDir()
+	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+	ln, err := net.Listen("unix", sessionSock)
+	if err != nil {
+		t.Fatalf("listen session socket: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				var req ControlRequest
+				_ = json.NewDecoder(conn).Decode(&req)
+				_ = json.NewEncoder(conn).Encode(ControlResponse{OK: true})
+			}()
+		}
+	}()
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: 1}}
+	m.cfg.ControlSocket = filepath.Join(dir, "control.sock")
+	injectSessionMaps(t, m)
+	return m
+}
+
+func rollbackKeyV4() dataplane.SessionKey {
+	return dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 61, 102},
+		DstIP:    [4]byte{172, 16, 80, 200},
+		SrcPort:  hostToNetwork16(5201),
+		DstPort:  hostToNetwork16(55340),
+		Protocol: 6,
+	}
+}
+
+func rollbackKeyV6() dataplane.SessionKeyV6 {
+	var srcIP, dstIP [16]byte
+	copy(srcIP[:], net.ParseIP("2001:db8:61::102").To16())
+	copy(dstIP[:], net.ParseIP("2001:db8:80::200").To16())
+	return dataplane.SessionKeyV6{
+		SrcIP:    srcIP,
+		DstIP:    dstIP,
+		SrcPort:  hostToNetwork16(5201),
+		DstPort:  hostToNetwork16(55340),
+		Protocol: 6,
+	}
+}
+
+// TestSetClusterSyncedSessionV4RollsBackOrphanOnMirrorFailure pins the #5305
+// transactional-install contract: when the helper mirror upsert fails, the
+// forward cluster-synced install must leave the pinned BPF session map EXACTLY
+// as it was — a previously-absent key stays absent (no orphan), a key with a
+// prior value is restored to that prior value (not the failed install value).
+//
+// RED-on-revert: neutralize the compensation by deleting the
+// `compErr := m.restoreBPFSessionV4Locked(...)` call in SetClusterSyncedSessionV4
+// (return just the mirror error). The absent-key sub-case then finds the orphan
+// installVal still present, and the prior-value sub-case finds it overwritten by
+// installVal, so both assertions fail.
+func TestSetClusterSyncedSessionV4RollsBackOrphanOnMirrorFailure(t *testing.T) {
+	key := rollbackKeyV4()
+
+	t.Run("absent-key-deleted", func(t *testing.T) {
+		m := newMirrorFailManager5305(t)
+		val := dataplane.SessionValue{IsReverse: 0, IngressZone: 1, EgressZone: 2}
+
+		err := m.SetClusterSyncedSessionV4(key, val)
+		if err == nil {
+			t.Fatal("SetClusterSyncedSessionV4() = nil, want mirror failure")
+		}
+		// The orphan must not survive: the key was absent, so it must be gone.
+		if _, getErr := m.bpfShim.GetSessionV4(key); !errors.Is(getErr, ebpf.ErrKeyNotExist) {
+			t.Fatalf("BPF entry survived a failed install: GetSessionV4 err = %v, want ErrKeyNotExist", getErr)
+		}
+		// Health behavior preserved: takeover stays disarmed.
+		if !m.sessionMirrorFailed {
+			t.Fatal("sessionMirrorFailed = false, want true")
+		}
+		if m.sessionMirrorErr == "" {
+			t.Fatal("sessionMirrorErr is empty, want non-empty")
+		}
+	})
+
+	t.Run("prior-value-restored", func(t *testing.T) {
+		m := newMirrorFailManager5305(t)
+		// Seed a distinguishable prior value directly on the BPF mirror.
+		prior := dataplane.SessionValue{IsReverse: 0, IngressZone: 7, EgressZone: 9, PolicyID: 111}
+		if err := m.bpfShim.SetSessionV4(key, prior); err != nil {
+			t.Fatalf("seed prior BPF entry: %v", err)
+		}
+		want, err := m.bpfShim.GetSessionV4(key) // canonical round-tripped prior
+		if err != nil {
+			t.Fatalf("read seeded prior: %v", err)
+		}
+
+		// A failing install with a DIFFERENT value must not survive.
+		val := dataplane.SessionValue{IsReverse: 0, IngressZone: 1, EgressZone: 2, PolicyID: 222}
+		if err := m.SetClusterSyncedSessionV4(key, val); err == nil {
+			t.Fatal("SetClusterSyncedSessionV4() = nil, want mirror failure")
+		}
+
+		got, err := m.bpfShim.GetSessionV4(key)
+		if err != nil {
+			t.Fatalf("prior BPF entry vanished after failed install: %v", err)
+		}
+		if got != want {
+			t.Fatalf("BPF entry not restored to prior value: got %+v, want %+v", got, want)
+		}
+	})
+}
+
+// TestSetClusterSyncedSessionV6RollsBackOrphanOnMirrorFailure is the IPv6
+// analogue (#5305). Same RED-on-revert: drop restoreBPFSessionV6Locked.
+func TestSetClusterSyncedSessionV6RollsBackOrphanOnMirrorFailure(t *testing.T) {
+	key := rollbackKeyV6()
+
+	t.Run("absent-key-deleted", func(t *testing.T) {
+		m := newMirrorFailManager5305(t)
+		val := dataplane.SessionValueV6{IsReverse: 0, IngressZone: 1, EgressZone: 2}
+
+		err := m.SetClusterSyncedSessionV6(key, val)
+		if err == nil {
+			t.Fatal("SetClusterSyncedSessionV6() = nil, want mirror failure")
+		}
+		if _, getErr := m.bpfShim.GetSessionV6(key); !errors.Is(getErr, ebpf.ErrKeyNotExist) {
+			t.Fatalf("BPF entry survived a failed install: GetSessionV6 err = %v, want ErrKeyNotExist", getErr)
+		}
+		if !m.sessionMirrorFailed {
+			t.Fatal("sessionMirrorFailed = false, want true")
+		}
+		if m.sessionMirrorErr == "" {
+			t.Fatal("sessionMirrorErr is empty, want non-empty")
+		}
+	})
+
+	t.Run("prior-value-restored", func(t *testing.T) {
+		m := newMirrorFailManager5305(t)
+		prior := dataplane.SessionValueV6{IsReverse: 0, IngressZone: 7, EgressZone: 9, PolicyID: 111}
+		if err := m.bpfShim.SetSessionV6(key, prior); err != nil {
+			t.Fatalf("seed prior BPF entry: %v", err)
+		}
+		want, err := m.bpfShim.GetSessionV6(key)
+		if err != nil {
+			t.Fatalf("read seeded prior: %v", err)
+		}
+
+		val := dataplane.SessionValueV6{IsReverse: 0, IngressZone: 1, EgressZone: 2, PolicyID: 222}
+		if err := m.SetClusterSyncedSessionV6(key, val); err == nil {
+			t.Fatal("SetClusterSyncedSessionV6() = nil, want mirror failure")
+		}
+
+		got, err := m.bpfShim.GetSessionV6(key)
+		if err != nil {
+			t.Fatalf("prior BPF entry vanished after failed install: %v", err)
+		}
+		if got != want {
+			t.Fatalf("BPF entry not restored to prior value: got %+v, want %+v", got, want)
+		}
+	})
+}
+
+// TestSetClusterSyncedSessionRollbackSuccessPathUnregressed proves the fix does
+// NOT regress the success path: a mirror that succeeds still installs the
+// forward entry into the BPF map and clears the sticky mirror-failure flag
+// (#5247). Both address families.
+func TestSetClusterSyncedSessionRollbackSuccessPathUnregressed(t *testing.T) {
+	t.Run("v4", func(t *testing.T) {
+		m := newMirrorOKManager5305(t)
+		// A prior transient failure latched the sticky flag.
+		m.recordSessionMirrorFailureLocked(errors.New("transient control-socket failure"))
+
+		key := rollbackKeyV4()
+		val := dataplane.SessionValue{IsReverse: 0, IngressZone: 1, EgressZone: 2, PolicyID: 42}
+		if err := m.SetClusterSyncedSessionV4(key, val); err != nil {
+			t.Fatalf("SetClusterSyncedSessionV4: %v", err)
+		}
+		got, err := m.bpfShim.GetSessionV4(key)
+		if err != nil {
+			t.Fatalf("forward entry not installed on success path: %v", err)
+		}
+		if got.PolicyID != 42 || got.IngressZone != 1 || got.EgressZone != 2 {
+			t.Fatalf("installed value = %+v, want PolicyID=42 zones 1/2", got)
+		}
+		if m.sessionMirrorFailed {
+			t.Fatal("sessionMirrorFailed = true after successful mirror, want false (#5247)")
+		}
+		if m.sessionMirrorErr != "" {
+			t.Fatalf("sessionMirrorErr = %q after successful mirror, want empty", m.sessionMirrorErr)
+		}
+	})
+
+	t.Run("v6", func(t *testing.T) {
+		m := newMirrorOKManager5305(t)
+		m.recordSessionMirrorFailureLocked(errors.New("transient control-socket failure"))
+
+		key := rollbackKeyV6()
+		val := dataplane.SessionValueV6{IsReverse: 0, IngressZone: 1, EgressZone: 2, PolicyID: 42}
+		if err := m.SetClusterSyncedSessionV6(key, val); err != nil {
+			t.Fatalf("SetClusterSyncedSessionV6: %v", err)
+		}
+		got, err := m.bpfShim.GetSessionV6(key)
+		if err != nil {
+			t.Fatalf("forward entry not installed on success path: %v", err)
+		}
+		if got.PolicyID != 42 || got.IngressZone != 1 || got.EgressZone != 2 {
+			t.Fatalf("installed value = %+v, want PolicyID=42 zones 1/2", got)
+		}
+		if m.sessionMirrorFailed {
+			t.Fatal("sessionMirrorFailed = true after successful mirror, want false (#5247)")
+		}
+		if m.sessionMirrorErr != "" {
+			t.Fatalf("sessionMirrorErr = %q after successful mirror, want empty", m.sessionMirrorErr)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Cluster-synced forward session installs (`SetClusterSyncedSessionV4/V6`) wrote the pinned BPF session mirror **first**, then mirrored to the Rust helper. On helper mirror failure they recorded the failure and returned an error but **left the BPF entry installed** — a split truth the GC and fallback bulk export (`ExportOwnerRGSessions`) would propagate as if the install had succeeded, producing nondeterministic HA session ownership after takeover.
- The store's snapshot/rollback machinery (`session_store.go`) never covered this path: the installer's `return err` runs before the store journals the forward pre-image into its `written` set. Distinct from #5247/#5255 (which self-heal the sticky HEALTH flag but do not restore the BPF pre-image).
- **Fix — transactional forward install.** Snapshot the BPF pre-image (prior value, or absence) **before** the write; on mirror failure **restore** it (rewrite prior / delete if absent), joining the compensation error with the mirror error so the original is never masked.
- **Ordering.** Snapshot + write + mirror + compensate now run under one `m.mu` hold (the BPF write was previously outside the lock), atomic w.r.t. any other `m.mu` path. The per-peer receiver apply loop is single-threaded (`installClusterSyncedV4`), so no same-key race; `syncSession*Locked` drops `m.mu` only for the socket send and reacquires before returning, so the compensate still observes our own write. Reverse entries (never mirrored) just write BPF and return.
- **Health preserved.** `recordSessionMirrorFailureLocked` still fires (takeover stays disarmed); `recordSessionMirrorSuccessLocked` still clears the #5247 sticky flag only on genuine success.

## Test plan

- [x] `synced_session_bpf_rollback_5305_test.go`: with a rigged failing helper mirror — absent key → **deleted** (no orphan); prior value → **restored**; success path still installs the forward entry + clears the sticky flag; both V4 and V6.
- [x] Parent-RED: no-op the `restoreBPFSession{V4,V6}Locked` bodies → `TestSetClusterSyncedSessionV4RollsBackOrphanOnMirrorFailure` and `TestSetClusterSyncedSessionV6RollsBackOrphanOnMirrorFailure` (4 subtests) fail on a clean assertion; success-path test unaffected.
- [x] `go build ./...` + `go vet ./pkg/dataplane/...` clean.
- [x] Focused userspace session/mirror/rollback suite green — existing mirror-failure/success/reverse tests unregressed; `pkg/dataplane` `PutClusterSynced*` tests pass.
- [ ] **HA session-sync path — needs a loss-cluster failover smoke** (`make test-failover` / `test-ha-crash`); to be batched.

Note: the 6 pre-existing userspace XDP-shim-load test failures in this env (`userspace_ingress_ifaces map not loaded`, XDP program stats) reproduce identically on `origin/master` and are unrelated.

## Docs

- `docs/session-sync-architecture.md` (Userspace Mirror) documents the #5305 transactional-install contract.

## Refs

Closes #5305

🤖 Generated with [Claude Code](https://claude.com/claude-code)