### PR TITLE
userspace-dp: release NAT reservation on transient synced-hit purge (#5295)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54523,3 +54523,27 @@ top.
 - **File(s)**: pkg/config/compiler_interfaces.go,
   pkg/config/compiler_prewalk.go, pkg/config/vrrp_authentication_4288_test.go,
   pkg/config/testdata/golden_4406.json, docs/feature-coverage.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5295 — HA-NAT reservation leak on transient synced-hit purge.
+  `purge_translated_synced_hit` (session_glue/promote.rs) tears down a
+  transient peer-synced translated FORWARD session (RG not locally active) but
+  released NO allocator state, LEAKING the source-NAT / NAT64 pool port that
+  `handle_upsert_synced` reserved at install (reserve_synced_source_nat /
+  reserve_synced_nat64, #4388 / #4512) → standby pool exhaustion under
+  sustained HA churn. Fix: add release_source_nat_allocation +
+  release_nat64_allocation under the same `metadata.is_reverse` ownership
+  guard, exactly as handle_delete_synced / delete_terminal_filtered_session do
+  (signature gains `forwarding` + `now_ns`; single caller in mod.rs updated).
+  Safe against double-free: purge fires only for the forward translated side
+  (is_translated_forward_session_key rejects reverse/alias keys) and
+  release_flow is a no-op when the flow was never tracked. Distinct from #5178
+  (recycle-queue drain gap) — here there was no release call at all. Tests: 3
+  fail-on-revert in session_glue/tests.rs (source-NAT release, NAT64 release,
+  reverse-entry-releases-nothing guard). Neutralizing either release call
+  reddens the matching owning-leg assertion (used_ports stays 1 / NAT64 probe
+  gets 1025). Full cargo suite green (4159 passed).
+- **File(s)**: userspace-dp/src/afxdp/session_glue/promote.rs,
+  userspace-dp/src/afxdp/session_glue/mod.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  userspace-dp/src/afxdp/session_glue/README.md, _Log.md

--- a/userspace-dp/src/afxdp/session_glue/README.md
+++ b/userspace-dp/src/afxdp/session_glue/README.md
@@ -14,7 +14,9 @@ sees the same sessions the userspace path is processing.
 
 | File | Purpose |
 |------|---------|
-| `mod.rs` | Cache-validation helpers (`cached_session_resolution`, `resolution_target_for_session`), plus the BPF session-map mirror writers. |
+| `mod.rs` | Cache-validation helpers (`cached_session_resolution`, `resolution_target_for_session`), `resolve_flow_session_decision`, `delete_terminal_filtered_session`, plus the BPF session-map mirror writers. |
+| `promote.rs` | Synced-session hit handling: `maybe_promote_synced_session` (promote a peer-synced hit to locally-owned) and `purge_translated_synced_hit` (drop + NAT-release a transient alias-owned hit). |
+| `commands/` | Worker-command handlers (`handle_upsert_synced`, `handle_delete_synced`, owner-RG refresh/demote/export). |
 | `tests.rs` | Co-located unit tests for cache validation + mirror semantics. |
 
 ## Where it sits
@@ -60,3 +62,30 @@ owns that now; `release_flow` is idempotent, so a caller that visits both
 halves in turn stays correct. Before #5622 the helper deleted only the
 supplied key and released nothing, leaking the same-worker companion
 entry and the pool port on every translated LocalDelivery terminal deny.
+
+## Transient synced-hit purge (`purge_translated_synced_hit`, #5295)
+
+When a packet hits a peer-synced translated FORWARD session whose RG is
+NOT locally active (`should_keep_synced_hit_transient` in `promote.rs`),
+the hit is kept *transient*: the entry is purged from the worker table,
+the shared HA maps, and the kernel session-map so the local node
+re-resolves instead of forwarding to the wrong node. That purged entry is
+a forward, peer-synced session, so at install `handle_upsert_synced`
+RESERVED its translated `(pool_addr, port)` in this node's LOCAL
+source-NAT / NAT64 allocator (`reserve_synced_source_nat_allocation` /
+`reserve_synced_nat64_allocation`, #4388 / #4512) so a post-failover local
+allocation cannot re-hand the same tuple.
+
+`purge_translated_synced_hit` therefore ALSO releases that reservation —
+`release_source_nat_allocation` + `release_nat64_allocation`, under the
+same `metadata.is_reverse` ownership guard used everywhere the reservation
+is freed (reap, delete-sync, terminal-filtered teardown). The guard and
+`release_flow`'s track-then-free contract make this safe against a
+double-free: the purge fires only for the forward translated side
+(`is_translated_forward_session_key` rejects reverse/alias keys), and
+`release_flow` is a no-op when the flow was never tracked. Before #5295
+the purge dropped the session state but released NOTHING, LEAKING the
+reserved port on every alias-owned transient purge → standby source-NAT /
+NAT64 pool exhaustion under sustained HA churn. Distinct from #5178 (a
+reservation released into a recycle queue the deterministic allocator
+never drains) — here there was simply no release call at all.

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -1180,6 +1180,8 @@ pub(super) fn resolve_flow_session_decision(
                 decision,
                 metadata,
                 origin,
+                forwarding,
+                now_ns,
             );
         }
         let resolved = if keep_transient {

--- a/userspace-dp/src/afxdp/session_glue/promote.rs
+++ b/userspace-dp/src/afxdp/session_glue/promote.rs
@@ -136,13 +136,29 @@ pub(in crate::afxdp::session_glue) fn maybe_promote_synced_session(
 }
 
 /// Purge a translated peer-synced hit: drop the entry from the shared
-/// maps, delete the kernel session-map entry, and remove the local
-/// session-table entry. Used when the local node is not the active
-/// owner of a translated forward session — leaving the hit live would
-/// route traffic to the wrong node.
+/// maps, delete the kernel session-map entry, remove the local
+/// session-table entry, AND return the source-NAT / NAT64 pool
+/// reservation this forward session reserved at install. Used when the
+/// local node is not the active owner of a translated forward session —
+/// leaving the hit live would route traffic to the wrong node.
 ///
-/// Behavior unchanged from the pre-#1346 free function; only the
-/// signature changed (10 → 7 params via `SharedSessionRefs`).
+/// #5295: the purged entry is a peer-synced FORWARD translated session
+/// (the guard below rejects reverse/non-translated keys), so at install
+/// `handle_upsert_synced` reserved its translated `(pool_addr, port)` in
+/// THIS node's local allocator via `reserve_synced_source_nat_allocation`
+/// / `reserve_synced_nat64_allocation`. Tearing the session down without
+/// the matching release LEAKED that reservation — every alias-owned
+/// transient purge burned a pool port, exhausting the standby's source-NAT
+/// / NAT64 pool under sustained HA churn. Mirror the `handle_delete_synced`
+/// (and `delete_terminal_filtered_session`) teardown: release under the
+/// same `metadata.is_reverse` ownership guard so a reverse/alias entry (or
+/// a non-pool / non-reserved session) frees nothing and a double-free is
+/// impossible — `release_flow` is a no-op when the flow was never tracked.
+///
+/// Behavior otherwise unchanged from the pre-#1346 free function; the
+/// signature carries `forwarding` + `now_ns` for the reservation release
+/// (was 7 params, now 9 after the #5295 additions).
+#[allow(clippy::too_many_arguments)]
 pub(in crate::afxdp::session_glue) fn purge_translated_synced_hit(
     sessions: &mut SessionTable,
     session_map_fd: c_int,
@@ -151,6 +167,8 @@ pub(in crate::afxdp::session_glue) fn purge_translated_synced_hit(
     decision: SessionDecision,
     metadata: &SessionMetadata,
     origin: SessionOrigin,
+    forwarding: &ForwardingState,
+    now_ns: u64,
 ) {
     if !origin.is_peer_synced() || !is_translated_forward_session_key(key, decision, metadata) {
         return;
@@ -164,4 +182,22 @@ pub(in crate::afxdp::session_glue) fn purge_translated_synced_hit(
     );
     delete_session_map_entry_for_removed_session(session_map_fd, key, decision, metadata);
     sessions.delete(key);
+    // #5295: return the pool reservation to the local allocator, exactly as
+    // `handle_delete_synced` does on the delete-sync teardown. `is_reverse` is
+    // the ownership guard (a reverse entry owns no source-NAT/NAT64 reservation);
+    // both calls are a no-op for a non-pool / non-reserved session.
+    release_source_nat_allocation(
+        &forwarding.source_nat_rules,
+        key,
+        decision.nat,
+        metadata.is_reverse,
+        now_ns,
+    );
+    crate::nat64::release_nat64_allocation(
+        &forwarding.nat64,
+        key,
+        decision.nat,
+        metadata.is_reverse,
+        now_ns,
+    );
 }

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -6293,3 +6293,321 @@ fn delete_terminal_filtered_session_releases_companion_and_allocator_5622() {
         );
     }
 }
+
+// #5295 FAIL-ON-REVERT: `purge_translated_synced_hit` drops a transient
+// peer-synced translated FORWARD session (the local node is not the active RG
+// owner, so the hit is torn down and re-resolved). At install
+// `handle_upsert_synced` reserved that session's translated `(pool_addr, port)`
+// in THIS node's LOCAL allocator (`reserve_synced_source_nat_allocation` /
+// `reserve_synced_nat64_allocation`). Before #5295 the purge dropped the session
+// state but released NO allocator reservation, so every alias-owned transient
+// purge LEAKED a pool port -> standby source-NAT / NAT64 exhaustion under
+// sustained HA churn. The fix mirrors `handle_delete_synced` /
+// `delete_terminal_filtered_session`: release under the `metadata.is_reverse`
+// ownership guard.
+//
+// PARENT-RED neutralization: delete the `release_source_nat_allocation(...)`
+// call in `purge_translated_synced_hit` -> this test's `used_ports == 0`
+// assertion goes RED (stays 1). (Deleting `release_nat64_allocation(...)`
+// reddens the NAT64 sibling below.)
+#[test]
+fn purge_translated_synced_hit_releases_source_nat_reservation_5295() {
+    // Single-address pool source-NAT rule so the translated flow holds a real
+    // pool port the purge must return.
+    let mut forwarding = ForwardingState::default();
+    forwarding.source_nat_rules = crate::nat::parse_source_nat_rules(&[crate::SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "p".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..crate::SourceNATRuleSnapshot::default()
+    }]);
+
+    // A source-NAT-translated forward flow. The synced session is keyed on its
+    // post-NAT WIRE tuple (`forward_wire_key`: src == pool addr), which is both
+    // what makes `is_translated_forward_session_key` fire AND the key
+    // `handle_upsert_synced` reserved the port under.
+    let orig_key = test_key();
+    let nat = NatDecision {
+        rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+        rewrite_src_port: Some(40000),
+        ..NatDecision::default()
+    };
+    let wire_key = forward_wire_key(&orig_key, nat);
+    let decision = SessionDecision {
+        resolution: test_local_delivery_decision().resolution,
+        nat,
+    };
+    let metadata = test_metadata(); // is_reverse = false
+
+    // Reserve the pool port for the synced forward flow, mirroring
+    // `handle_upsert_synced`'s `reserve_synced_source_nat_allocation`.
+    crate::nat::reserve_synced_source_nat_allocation(
+        &forwarding.source_nat_rules,
+        &wire_key,
+        nat,
+        false,
+    );
+    assert_eq!(
+        crate::nat::source_nat_pool_statuses(&forwarding.source_nat_rules)[0].used_ports,
+        1,
+        "precondition: the synced translated forward flow holds one pool port",
+    );
+
+    // Install the transient synced session under its wire key.
+    let mut sessions = SessionTable::new();
+    assert!(sessions.install_with_protocol_with_origin(
+        wire_key.clone(),
+        decision,
+        metadata.clone(),
+        SessionOrigin::SyncImport,
+        1_000_000,
+        PROTO_TCP,
+        TCP_FLAG_ACK,
+    ));
+    let _ = sessions.drain_deltas(16);
+
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let shared = SharedSessionRefs {
+        sessions: &shared_sessions,
+        nat_sessions: &shared_nat_sessions,
+        forward_wire_sessions: &shared_forward_wire_sessions,
+        owner_rg_indexes: &shared_owner_rg_indexes,
+    };
+
+    purge_translated_synced_hit(
+        &mut sessions,
+        -1,
+        shared,
+        &wire_key,
+        decision,
+        &metadata,
+        SessionOrigin::SyncImport,
+        &forwarding,
+        1_000_000,
+    );
+
+    // (a) existing behaviour: the transient session entry is gone.
+    assert!(
+        sessions.lookup(&wire_key, 1_000_000, TCP_FLAG_ACK).is_none(),
+        "purged transient synced session must be removed from the table",
+    );
+    // (b) THE #5295 FIX: the pool reservation is returned to the allocator.
+    assert_eq!(
+        crate::nat::source_nat_pool_statuses(&forwarding.source_nat_rules)[0].used_ports,
+        0,
+        "purge must release the synced forward flow's source-NAT pool port \
+         (leak on revert)",
+    );
+}
+
+// #5295 FAIL-ON-REVERT (NAT64 leg): the same purge must return a NAT64 forward
+// flow's reserved translated pool port. PARENT-RED neutralization: delete the
+// `release_nat64_allocation(...)` call in `purge_translated_synced_hit` -> the
+// "freed port re-allocatable" assertion goes RED (a fresh flow gets 1025; the
+// reserved 1024 stays leaked).
+#[test]
+fn purge_translated_synced_hit_releases_nat64_reservation_5295() {
+    // Single-address NAT64 pool: every client maps to the same snat_v4, so only
+    // the translated port disambiguates (sharpest collision case).
+    let mut forwarding = ForwardingState::default();
+    forwarding.nat64 = crate::nat64::Nat64State::from_snapshots(&[crate::NAT64RuleSnapshot {
+        name: "nat64-single".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec!["198.51.100.1".to_string()],
+        ..Default::default()
+    }]);
+
+    let snat = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+    // Original v6 flow; the forward NAT64 decision translates to (snat, 1024) —
+    // 1024 is the first sequential NAT64 port, the port a fresh alloc picks first.
+    let orig_key = SessionKey {
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V6("2001:db8::1".parse().unwrap()),
+        dst_ip: IpAddr::V6("64:ff9b::0808:0808".parse().unwrap()),
+        src_port: 5000,
+        dst_port: 443,
+    };
+    let nat = crate::nat64::Nat64State::forward_decision(snat, dst_v4, 1024);
+    let wire_key = forward_wire_key(&orig_key, nat); // post-NAT v4 wire tuple
+    let decision = SessionDecision {
+        resolution: test_local_delivery_decision().resolution,
+        nat,
+    };
+    let metadata = test_metadata();
+
+    // Reserve the NAT64 port under the wire key, mirroring `handle_upsert_synced`.
+    crate::nat64::reserve_synced_nat64_allocation(&forwarding.nat64, &wire_key, nat, false);
+
+    let mut sessions = SessionTable::new();
+    assert!(sessions.install_with_protocol_with_origin(
+        wire_key.clone(),
+        decision,
+        metadata.clone(),
+        SessionOrigin::SyncImport,
+        1_000_000,
+        PROTO_TCP,
+        TCP_FLAG_ACK,
+    ));
+    let _ = sessions.drain_deltas(16);
+
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let shared = SharedSessionRefs {
+        sessions: &shared_sessions,
+        nat_sessions: &shared_nat_sessions,
+        forward_wire_sessions: &shared_forward_wire_sessions,
+        owner_rg_indexes: &shared_owner_rg_indexes,
+    };
+
+    purge_translated_synced_hit(
+        &mut sessions,
+        -1,
+        shared,
+        &wire_key,
+        decision,
+        &metadata,
+        SessionOrigin::SyncImport,
+        &forwarding,
+        1_000_000,
+    );
+
+    // After the purge releases the reservation, a fresh local NAT64 flow re-owns
+    // the freed first port 1024. On revert (no release) 1024 stays reserved and
+    // the fresh flow is pushed to 1025.
+    let (snat2, port2) = forwarding
+        .nat64
+        .allocate_source(
+            0,
+            PROTO_TCP,
+            "2001:db8::2".parse().unwrap(),
+            dst_v4,
+            5000,
+            443,
+            1_000_001,
+        )
+        .expect("probe NAT64 flow allocates");
+    assert_eq!(snat2, snat, "single-address pool => same snat_v4");
+    assert_eq!(
+        port2, 1024,
+        "purge must release the synced NAT64 flow's reserved port 1024 so a \
+         fresh flow re-owns it (leak on revert -> 1025)",
+    );
+}
+
+// #5295: a NON-owning (reverse/alias) purge must release NOTHING and tear down
+// NOTHING. The `is_translated_forward_session_key` guard rejects reverse entries
+// up front, and the release path's own `is_reverse` guard is the second line of
+// defense, so a reverse companion can never double-free the forward flow's
+// reservation. Guard-correctness pin (green before and after the fix), per the
+// #5295 no-double-free requirement.
+#[test]
+fn purge_translated_synced_hit_reverse_entry_releases_nothing_5295() {
+    let mut forwarding = ForwardingState::default();
+    forwarding.source_nat_rules = crate::nat::parse_source_nat_rules(&[crate::SourceNATRuleSnapshot {
+        name: "pool-snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "p".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..crate::SourceNATRuleSnapshot::default()
+    }]);
+
+    let orig_key = test_key();
+    let fwd_nat = NatDecision {
+        rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+        rewrite_src_port: Some(40000),
+        ..NatDecision::default()
+    };
+    let wire_key = forward_wire_key(&orig_key, fwd_nat);
+
+    // The forward flow owns the reservation.
+    crate::nat::reserve_synced_source_nat_allocation(
+        &forwarding.source_nat_rules,
+        &wire_key,
+        fwd_nat,
+        false,
+    );
+    assert_eq!(
+        crate::nat::source_nat_pool_statuses(&forwarding.source_nat_rules)[0].used_ports,
+        1,
+        "precondition: the forward flow holds the pool port",
+    );
+
+    // Drive the purge with the REVERSE companion (is_reverse = true): its key is
+    // the reverse tuple carrying the reversed decision. The purge guard must
+    // reject it, freeing nothing and tearing down nothing.
+    let rev_key = reverse_session_key(&wire_key, fwd_nat);
+    let rev_nat = fwd_nat.reverse(
+        wire_key.src_ip,
+        wire_key.dst_ip,
+        wire_key.src_port,
+        wire_key.dst_port,
+    );
+    let rev_decision = SessionDecision {
+        resolution: test_local_delivery_decision().resolution,
+        nat: rev_nat,
+    };
+    let mut rev_metadata = test_metadata();
+    rev_metadata.is_reverse = true;
+
+    let mut sessions = SessionTable::new();
+    assert!(sessions.install_with_protocol_with_origin(
+        rev_key.clone(),
+        rev_decision,
+        rev_metadata.clone(),
+        SessionOrigin::SyncImport,
+        1_000_000,
+        PROTO_TCP,
+        TCP_FLAG_ACK,
+    ));
+    let _ = sessions.drain_deltas(16);
+
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let shared = SharedSessionRefs {
+        sessions: &shared_sessions,
+        nat_sessions: &shared_nat_sessions,
+        forward_wire_sessions: &shared_forward_wire_sessions,
+        owner_rg_indexes: &shared_owner_rg_indexes,
+    };
+
+    purge_translated_synced_hit(
+        &mut sessions,
+        -1,
+        shared,
+        &rev_key,
+        rev_decision,
+        &rev_metadata,
+        SessionOrigin::SyncImport,
+        &forwarding,
+        1_000_000,
+    );
+
+    // The guard rejected the reverse entry: nothing torn down, reservation intact.
+    assert!(
+        sessions.lookup(&rev_key, 1_000_000, TCP_FLAG_ACK).is_some(),
+        "reverse companion must be left intact by the forward-only purge",
+    );
+    assert_eq!(
+        crate::nat::source_nat_pool_statuses(&forwarding.source_nat_rules)[0].used_ports,
+        1,
+        "a reverse/alias purge must NOT release the forward flow's reservation",
+    );
+}


### PR DESCRIPTION
## Summary

- `purge_translated_synced_hit` (`userspace-dp/src/afxdp/session_glue/promote.rs`) drops a transient peer-synced translated **forward** session when the local node is not the active owner of the session's RG — so the hit is torn down and the flow re-resolved instead of being routed to the wrong node.
- That entry is a forward, peer-synced session, so at install `handle_upsert_synced` **reserved** its translated `(pool_addr, port)` in this node's local source-NAT / NAT64 allocator (`reserve_synced_source_nat_allocation` / `reserve_synced_nat64_allocation`, #4388 / #4512). The purge removed the session state (worker table, shared HA maps, kernel session-map) but performed **no allocator release** — every alias-owned transient purge **leaked** the reserved port, driving the standby toward source-NAT / NAT64 pool exhaustion under sustained HA churn.
- Fix: release the reservation on purge, mirroring `handle_delete_synced` and `delete_terminal_filtered_session` **exactly** — `release_source_nat_allocation` + `release_nat64_allocation` under the same `metadata.is_reverse` ownership guard. The function gains `forwarding` + `now_ns`; the single caller in `resolve_flow_session_decision` already holds both.
- **No double-free:** the purge fires only for the forward translated side (`is_translated_forward_session_key` rejects reverse/alias keys), and `release_flow` is a no-op when the flow was never tracked — a reverse/alias or non-pool session frees nothing.
- Distinct from **#5178** (a deterministic reservation released into a recycle queue the deterministic allocator never drains) — here there was simply no release call at all.

## Hot-path shape

Cold path only — reservation release happens on session teardown (transient purge), not per packet. No new allocations, atomics, or per-packet branches.

## Test plan

- [x] `purge_translated_synced_hit_releases_source_nat_reservation_5295` — pool `used_ports` drops 1 → 0 after purge.
- [x] `purge_translated_synced_hit_releases_nat64_reservation_5295` — the freed NAT64 port 1024 becomes re-allocatable (a leak pushes a fresh flow to 1025).
- [x] `purge_translated_synced_hit_reverse_entry_releases_nothing_5295` — a reverse/alias purge frees nothing and tears nothing down (no-double-free guard).
- [x] **Fail-on-revert verified:** commenting out the `release_source_nat_allocation` call reddens the source-NAT test (`used_ports` stays 1); commenting out `release_nat64_allocation` reddens the NAT64 test (probe gets 1025). Both are clean assertion failures, not compile breaks.
- [x] Full `cargo test --release` suite green — 4159 passed, 0 failed.
- [ ] Loss-cluster smoke — NAT/dataplane path, recommend batched at merge (see below).

## Docs

`userspace-dp/src/afxdp/session_glue/README.md` gains a "Transient synced-hit purge (#5295)" section documenting the NAT-release contract, and the stale Files table is corrected to list `promote.rs` + `commands/`.

## Refs

- Closes #5295
- Related: #4388 / #4512 (the reserve side), #5622 (parallel terminal-filtered teardown release), #5178 (separate recycle-drain gap — not conflated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KuTArhRUZatNvkyZUBZHD