### PR TITLE
vrrp: gate RGVRRPReady on every desired RETH key, not one (#5641)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54662,3 +54662,25 @@ top.
 - **File(s)**: pkg/config/compiler_interfaces.go,
   pkg/config/compiler_prewalk.go, pkg/config/vrrp_authentication_4288_test.go,
   pkg/config/testdata/golden_4406.json, docs/feature-coverage.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5641 — RGVRRPReady false-ready on partial RG build. RGVRRPReady
+  returned (true, nil) as soon as ONE VRRP instance existed for the RG's VRID
+  (100+rgID), even when another DESIRED key for that RG failed to build
+  (interface resolve / socket bind / family capability). An RG commonly has
+  several desired RETH keys under one VRID — a VLAN-tagged reth emits one
+  instance per sub-interface (reth0.50 + reth0.80) — so a sibling key's dark
+  VIP was reported healthy and the cluster state machine could release the sync
+  hold / preempt / claim ownership while a VIP never advertised. Fix:
+  UpdateInstances now records m.unbuiltDesired (the desiredMap-vs-m.instances
+  diff, annotated with the captured resolve/socket reason) each pass;
+  RGVRRPReady returns (false, reasons) naming any un-built desired RETH key for
+  the RG. Build-before-teardown (#2156) survivors keep their key in m.instances
+  and are correctly NOT flagged (RG still in election on its old VIP set).
+  RGVRRPReady stays a pure readiness READ — no advert timing / socket / failover
+  datapath change. Fail-on-revert test TestUpdateInstances_PartialBuild_RGNotReady
+  (two keys, one socket-fail) goes RED (clean assertion failure) if the
+  m.unbuiltDesired scan in RGVRRPReady is neutralized. Validated: go build ./...,
+  go vet ./pkg/vrrp/, full pkg/vrrp + pkg/daemon suites pass.
+- **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/update_instances_test.go,
+  pkg/vrrp/README.md, _Log.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -65,6 +65,16 @@ This is the package that drives chassis-cluster failover.
   priority/preempt/tracking and re-applies sync-hold suppression, so a
   rebind cannot spuriously preempt or break the sync hold; RG role is
   driven separately by the cluster heartbeat / debounced priority.
+  **Desired-vs-built record (#5641):** each pass recomputes
+  `m.unbuiltDesired` — the desired keys with no live instance — so
+  `RGVRRPReady` can refuse a partially-built RG (see the
+  build-before-teardown invariant below).
+- `RGVRRPReady(rgID int, hasRETH bool) (bool, []string)` — `manager.go`.
+  Returns ready only when EVERY desired RETH key for the RG (VRID
+  `100+rgID`) has a live instance AND at least one instance exists (or the
+  RG has no RETH interfaces). A desired key that failed to build
+  (resolve / socket / family capability) makes it `(false, reasons)`
+  naming the un-built key (#5641).
 - `ReleaseSyncHold()` — `manager.go`. No-arg; releases hold for all
   instances.
 - `ResignRG(rgID int)` — `manager.go`. Forces this node out of master
@@ -682,7 +692,22 @@ dataplane reuses this Go walker, and do NOT try to consolidate them.
   same key (the proof step opens the socket but does NOT start `run()`;
   only the commit step stops the old, swaps, and starts the new). On a
   build failure no placeholder is added to `m.instances`, so
-  `RGVRRPReady` / `States` / `InstanceStates` / `Status` stay truthful.
+  `States` / `InstanceStates` / `Status` stay truthful. **`RGVRRPReady`
+  needs more than that (#5641):** an RG usually has SEVERAL desired RETH
+  keys under one VRID (a VLAN-tagged reth emits one instance per
+  sub-interface — `reth0.50` + `reth0.80` — and reths can share the RG),
+  so "one instance exists for the VRID" does NOT prove the RG is fully
+  built. `UpdateInstances` records every desired key with no live instance
+  in `m.unbuiltDesired` (the `desiredMap`-vs-`m.instances` diff, with the
+  captured resolve/socket reason), and `RGVRRPReady` returns
+  `(false, reasons)` naming any un-built key for the RG. This closes the
+  false-ready hole where a sibling member/VLAN-sub/family key failed to
+  build, its VIP was dark, yet the cluster state machine released the sync
+  hold / preempted / claimed ownership. A build failure that leaves the
+  OLD instance advertising (the case above) keeps its key in `m.instances`
+  and is therefore NOT flagged — the RG is still in election, just on its
+  previous VIP set. `RGVRRPReady` remains a pure readiness READ (no advert
+  timing / socket / datapath change).
   Bounded self-recovery comes from the daemon's 2s
   `reconcileRGStateLoop`, which re-drives `reconcileVRRPInstances` →
   `UpdateInstances` every tick; a deferred restart retries (and succeeds)

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -174,6 +174,20 @@ type Manager struct {
 	// reconcile on that first event instead. Guarded by mu.
 	desiredIfaces map[string]struct{}
 
+	// unbuiltDesired records the desired VRRP keys from the most recent
+	// UpdateInstances that have NO live instance in m.instances — a key whose
+	// build failed (interface resolve failure / socket bind failure / family
+	// capability failure) or that was never yet built. It is the source of
+	// truth RGVRRPReady consults so a PARTIALLY-built RG is not reported ready
+	// (#5641): before this, RGVRRPReady returned READY as soon as ANY single
+	// instance existed for the RG's VRID, so if one of several desired member /
+	// VLAN-sub / family keys failed to build, its VIP was silently dark while
+	// the cluster state machine released the sync hold / preempted / claimed
+	// ownership. The value is a human-readable failure reason. Recomputed
+	// wholesale each reconcile off the authoritative desiredMap-vs-m.instances
+	// diff, so a key that recovers on a later pass clears itself. Guarded by mu.
+	unbuiltDesired map[instanceKey]string
+
 	// resolveLinkName maps a kernel ifindex to its current link NAME. The
 	// addr-watcher (#2707) calls it ONLY on a cached-ifindex miss — when an
 	// address event arrives for an ifindex no instance is bound to. A
@@ -214,6 +228,7 @@ func (m *Manager) SetOnEventDrop(fn func()) {
 func NewManager() *Manager {
 	return &Manager{
 		instances:          make(map[instanceKey]*vrrpInstance),
+		unbuiltDesired:     make(map[instanceKey]string),
 		eventCh:            make(chan VRRPEvent, 256),
 		watcherStop:        make(chan struct{}),
 		linkNames:          make(map[int]string),
@@ -283,6 +298,10 @@ func (m *Manager) Stop() {
 		instances[k] = v
 	}
 	m.instances = make(map[instanceKey]*vrrpInstance)
+	// Drop the desired-vs-built record too (#5641): with no instances left it
+	// must not report stale un-built keys as un-ready across a Stop()/Start()
+	// reuse; the next UpdateInstances recomputes it wholesale.
+	m.unbuiltDesired = make(map[instanceKey]string)
 	// Capture a CONSISTENT once/channel pair (and the channel) under the lock
 	// so the close below operates on a matched generation. This keeps the
 	// realistic sequential reuse correct: Stop() closes generation N's
@@ -497,6 +516,15 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 		}
 	}
 
+	// buildFailReason records, per desired key, WHY its build did not complete
+	// on this pass (resolve / socket / family capability). It annotates the
+	// #5641 unbuilt-desired record computed after the loop; keys that build
+	// successfully are absent. A key whose build fails while an OLD instance
+	// keeps advertising (build-before-teardown, #2156) stays in m.instances
+	// under its key and is therefore NOT counted as unbuilt below — the RG is
+	// still in election with its previous VIP set, not dark.
+	buildFailReason := make(map[instanceKey]string)
+
 	// Add or update instances.
 	for key, inst := range desiredMap {
 		existing, ok := m.instances[key]
@@ -595,13 +623,17 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 		// a brand-new key is simply not created yet. The 2s reconcile re-drive
 		// (daemon reconcileVRRPInstances) and the two existing UpdateInstances
 		// callers retry until the interface returns. No placeholder state is
-		// added, so RGVRRPReady and the other map readers stay truthful. This
-		// resolve is the authoritative one bound into the new instance; the
-		// #2294 drift probe above is only a cheap detector.
+		// added to m.instances; a brand-new key with no live instance is instead
+		// recorded in m.unbuiltDesired below (#5641) so RGVRRPReady reports the
+		// RG NOT ready while a sibling VIP is dark, rather than reporting ready
+		// off the mere existence of one built key. This resolve is the
+		// authoritative one bound into the new instance; the #2294 drift probe
+		// above is only a cheap detector.
 		iface, err := m.resolveIface(inst.Interface)
 		if err != nil {
 			slog.Warn("vrrp: interface not found, keeping existing instance",
 				"interface", inst.Interface, "have_existing", ok, "err", err)
+			buildFailReason[key] = fmt.Sprintf("interface %q resolve failed: %v", inst.Interface, err)
 			continue
 		}
 
@@ -629,6 +661,7 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 		if err := m.openInstanceSocket(vi); err != nil {
 			slog.Warn("vrrp: failed to open socket, keeping existing instance",
 				"interface", inst.Interface, "have_existing", ok, "err", err)
+			buildFailReason[key] = fmt.Sprintf("interface %q socket open failed: %v", inst.Interface, err)
 			continue
 		}
 
@@ -643,6 +676,28 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 		m.instances[key] = vi
 		m.runInstance(vi)
 	}
+
+	// #5641: record every desired key that has NO live instance after this
+	// reconcile so RGVRRPReady can refuse to report a partially-built RG as
+	// ready. The authoritative test is desiredMap-vs-m.instances (not "did a
+	// continue fire"): a key kept alive by the build-before-teardown path is
+	// still in m.instances and correctly excluded, while a brand-new key or a
+	// sibling member/VLAN-sub/family key that failed to build is flagged with
+	// its captured reason (or a generic fallback if it was omitted upstream,
+	// e.g. the out-of-range VRID guard). Replaced wholesale so recovered keys
+	// clear.
+	unbuilt := make(map[instanceKey]string, len(buildFailReason))
+	for key := range desiredMap {
+		if _, built := m.instances[key]; built {
+			continue
+		}
+		reason := buildFailReason[key]
+		if reason == "" {
+			reason = "instance not built"
+		}
+		unbuilt[key] = reason
+	}
+	m.unbuiltDesired = unbuilt
 
 	return nil
 }
@@ -814,19 +869,49 @@ func (m *Manager) SetGARPSuppression(rgID int, suppress bool) {
 	}
 }
 
-// RGVRRPReady returns whether at least one VRRP instance exists and is
-// running for the given redundancy group. The RG ID is mapped to VRID
-// as 100 + rgID (the standard RETH VRID convention).
-// hasRETH indicates whether the RG has any RETH interfaces configured.
-// Returns (true, nil) if ready, (false, reasons) if not.
+// RGVRRPReady reports whether EVERY desired VRRP instance for the given
+// redundancy group has a live state machine — not merely whether one exists.
+// The RG ID is mapped to VRID as 100 + rgID (the standard RETH VRID
+// convention). hasRETH indicates whether the RG has any RETH interfaces
+// configured. Returns (true, nil) if ready, (false, reasons) if not.
+//
+// #5641: an RG commonly has SEVERAL desired RETH keys under one VRID — a
+// VLAN-tagged reth yields one instance per sub-interface (reth0.50, reth0.80),
+// and multiple reths can share the RG. If one key's build failed (interface
+// resolve failure / socket bind failure / family capability failure) its VIP
+// is dark even though a sibling instance for the same VRID is live. Reporting
+// READY off the mere existence of one instance let the cluster state machine
+// release the sync hold / preempt / claim ownership while that VIP never
+// advertised. This consults m.unbuiltDesired (populated by UpdateInstances) so
+// any un-built desired key for the RG forces (false, reasons) naming it. This
+// is a pure readiness READ; it does not touch advert timing, sockets, or the
+// failover datapath.
 func (m *Manager) RGVRRPReady(rgID int, hasRETH bool) (bool, []string) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	vrid := 100 + rgID
+
+	// A desired RETH key for this RG that failed to build leaves a dark VIP.
+	// RETH keys carry an empty family; VRID == 100+rgID maps a key to this RG.
+	// A family-tagged generic VRRP key that happens to share the numeric VRID
+	// is a separate election domain and must not gate this RG.
+	var unready []string
+	for key, reason := range m.unbuiltDesired {
+		if key.family == "" && key.groupID == vrid {
+			unready = append(unready, fmt.Sprintf(
+				"vrrp: desired RETH instance %s (VRID %d) not built: %s",
+				key.iface, vrid, reason))
+		}
+	}
+	if len(unready) > 0 {
+		sort.Strings(unready) // deterministic reasons for logs/tests
+		return false, unready
+	}
+
 	for _, vi := range m.instances {
 		if isRethInstance(vi.cfg) && vi.cfg.GroupID == vrid {
-			return true, nil // instance exists for this RG
+			return true, nil // an instance exists AND no desired key is un-built
 		}
 	}
 

--- a/pkg/vrrp/update_instances_test.go
+++ b/pkg/vrrp/update_instances_test.go
@@ -2,6 +2,7 @@ package vrrp
 
 import (
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -307,6 +308,106 @@ func TestUpdateInstances_NewKeyFailureNoPhantom(t *testing.T) {
 	}
 	if ready, _ := m.RGVRRPReady(1, true); !ready {
 		t.Fatal("RGVRRPReady(1) should be true after the retry created the instance")
+	}
+}
+
+// TestUpdateInstances_PartialBuild_RGNotReady is the #5641 fail-on-revert
+// pin. An RG commonly has SEVERAL desired RETH keys under ONE VRID: a
+// VLAN-tagged reth yields one instance per sub-interface (reth0.50 + reth0.80),
+// both GroupID 100+rgID, and reths can share the RG. When ONE key's build
+// fails (resolve / socket / family capability) its VIP is dark even though the
+// sibling instance for the same VRID is live and advertising. RGVRRPReady must
+// report the RG NOT ready and name the un-built key — otherwise the cluster
+// state machine releases the sync hold / preempts / claims ownership while a
+// desired VIP never advertises.
+//
+// REVERT NEUTRALIZATION (firsthand parent-RED): in RGVRRPReady delete the
+// m.unbuiltDesired scan — the `for key, reason := range m.unbuiltDesired { … }`
+// loop through `if len(unready) > 0 { … return false, unready }`. RGVRRPReady
+// then finds the built reth0.50 instance and returns (true, nil), so the
+// `if ready` assertion below fires: a clean assertion failure, not a compile
+// break. (Neutralizing `m.unbuiltDesired = unbuilt` at the end of
+// UpdateInstances produces the identical RED.)
+func TestUpdateInstances_PartialBuild_RGNotReady(t *testing.T) {
+	m, _ := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	// Fail the socket for reth0.80 ONLY; reth0.50 builds normally. Both are
+	// RETH keys (empty family) under VRID 101 → RG 1.
+	m.openInstanceSocket = func(vi *vrrpInstance) error {
+		if vi.cfg.Interface == "reth0.80" {
+			return errSocketOpenFailed
+		}
+		return nil
+	}
+
+	desired := []*Instance{
+		{
+			Interface:        "reth0.50",
+			GroupID:          101,
+			Priority:         200,
+			Preempt:          true,
+			VirtualAddresses: []string{"172.16.50.8/24"},
+		},
+		{
+			Interface:        "reth0.80",
+			GroupID:          101,
+			Priority:         200,
+			Preempt:          true,
+			VirtualAddresses: []string{"172.16.80.8/24"},
+		},
+	}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	// Exactly one sibling built; the other is dark (no phantom placeholder).
+	m.mu.RLock()
+	_, has50 := m.instances[instanceKey{iface: "reth0.50", groupID: 101}]
+	_, has80 := m.instances[instanceKey{iface: "reth0.80", groupID: 101}]
+	n := len(m.instances)
+	m.mu.RUnlock()
+	if !has50 {
+		t.Fatal("reth0.50 should have built")
+	}
+	if has80 {
+		t.Fatal("reth0.80 build was injected to fail but an instance exists")
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 live instance, got %d", n)
+	}
+
+	// THE PIN: a partially-built RG must report NOT ready, naming the un-built
+	// key. Pre-fix this returned (true, nil) off the built reth0.50 sibling.
+	ready, reasons := m.RGVRRPReady(1, true)
+	if ready {
+		t.Fatal("RGVRRPReady(1) must be FALSE while reth0.80's VIP is dark (partial build)")
+	}
+	if len(reasons) == 0 {
+		t.Fatal("RGVRRPReady(1) must return a reason naming the un-built key")
+	}
+	joined := strings.Join(reasons, " ")
+	if !strings.Contains(joined, "reth0.80") {
+		t.Fatalf("readiness reasons must name the un-built key reth0.80, got: %v", reasons)
+	}
+	if strings.Contains(joined, "reth0.50") {
+		t.Fatalf("readiness reasons wrongly named the BUILT sibling reth0.50: %v", reasons)
+	}
+
+	// Recovery: let reth0.80 build too. Every desired key now has a live
+	// instance → the RG is ready with no reasons and the unbuilt record clears.
+	m.openInstanceSocket = func(vi *vrrpInstance) error { return nil }
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances (recovery): %v", err)
+	}
+	m.mu.RLock()
+	n = len(m.instances)
+	m.mu.RUnlock()
+	if n != 2 {
+		t.Fatalf("expected both instances after recovery, got %d", n)
+	}
+	if ready, reasons := m.RGVRRPReady(1, true); !ready || reasons != nil {
+		t.Fatalf("RGVRRPReady(1) must be (true, nil) once every desired key built: ready=%v reasons=%v", ready, reasons)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `RGVRRPReady(rgID, hasRETH)` reported an RG **ready** as soon as ONE VRRP instance existed for the RG's VRID (`100+rgID`) — it never checked whether **every desired** VRRP key for the RG was actually built.
- An RG commonly has several desired RETH keys under one VRID: a VLAN-tagged reth emits one instance per sub-interface (`reth0.50` + `reth0.80`), and multiple reths can share the RG. If one desired key's build failed (interface **resolve** failure / socket **bind** failure / **family** capability failure), its VIP was silently dark while `RGVRRPReady` still reported the RG healthy.
- The cluster takeover-readiness gate (`takeoverReadinessForRG`, `pkg/daemon/daemon_ha_vip.go`) then let the state machine release the sync hold / preempt / claim ownership while a configured VIP never advertised.

## Fix

- The manager kept **no per-key record** of desired-vs-built (`desiredMap` is local to `UpdateInstances`; only successfully-built instances land in `m.instances`). This adds that record.
- `UpdateInstances` now recomputes `m.unbuiltDesired` each pass as the `desiredMap`-vs-`m.instances` diff, annotated with the captured resolve/socket failure reason.
- `RGVRRPReady` returns `(false, reasons)` naming any un-built desired RETH key for the RG (`family=="" && groupID==100+rgID`), and `(true, nil)` only when every desired key has a live instance (or the RG has no RETH requirement).
- The `desiredMap`-vs-`m.instances` diff is the authoritative test, **not** "did a build `continue` fire": a key kept alive by the **build-before-teardown** path (#2156) stays in `m.instances` and is therefore **not** flagged — the RG is still in election on its previous VIP set. The #2156 truthfulness guarantee is preserved.
- `Stop()` clears `m.unbuiltDesired` alongside `m.instances` so a `Stop()/Start()` reuse never reports stale un-built keys.

## Datapath safety

This is a **pure readiness READ**. It does not touch advert timing, socket handling, `becomeMaster`/`becomeBackup`, or any failover datapath — the ~60ms failover is unaffected; only the readiness **report** becomes honest.

## Test plan

- [x] `TestUpdateInstances_PartialBuild_RGNotReady` (new, `pkg/vrrp/update_instances_test.go`) — drives the real `UpdateInstances` diff via the injectable lifecycle seams with two desired RETH keys under VRID 101, fails `reth0.80`'s socket, asserts `RGVRRPReady(1, true)` is `false` naming `reth0.80` (not the built `reth0.50` sibling), then `(true, nil)` after `reth0.80` recovers.
- [x] **Fail-on-revert:** deleting the `m.unbuiltDesired` scan in `RGVRRPReady` makes it find the built sibling and return `(true, nil)` → clean assertion failure at the "must be FALSE" check (not a compile break). Verified RED then restored.
- [x] `go build ./...`, `go vet ./pkg/vrrp/`
- [x] full `pkg/vrrp` and `pkg/daemon` suites pass
- [ ] loss-cluster failover smoke — pkg/vrrp change; to be gated by the team lead through a batched `make test-failover`.

## Docs

`pkg/vrrp/README.md`: build-before-teardown invariant + new `RGVRRPReady` API bullet describe the desired-vs-built record.

## Refs

Closes #5641. Related: #132, #2156 (build-before-teardown), #5083 (dual-stack family key), #5481/#5482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01At4T479y8VsmoKMXCXV4XN