### PR TITLE
api: subject REST config mutations to the holder lock (#5870)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54662,3 +54662,32 @@ top.
 - **File(s)**: pkg/config/compiler_interfaces.go,
   pkg/config/compiler_prewalk.go, pkg/config/vrrp_authentication_4288_test.go,
   pkg/config/testdata/golden_4406.json, docs/feature-coverage.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5870 — REST candidate mutations bypassed the config-session
+  holder lock. The REST config endpoints (`pkg/api/config.go`) called the store
+  with an empty session ID, which the store treats as its internal/system
+  capability (daemon apply / HA sync) and which BYPASSES the #5059 candidate
+  holder lock. A remote, stateless REST caller could therefore Set/Delete/Load/
+  Rollback/Commit a candidate that a CLI or gRPC configuration session
+  legitimately OWNED — corrupting a peer's candidate or smuggling their staged
+  edits into an applied commit. Fix: route every REST config MUTATION
+  (enter/set/delete/deactivate/activate/load/annotate/rollback/commit/
+  commit-confirmed/confirm) through the session-scoped `*As` variants +
+  `EnsureConfigHolder` commit gate under a fixed non-empty holder identity,
+  `restConfigSessionID` ("rest"). A REST mutation is now rejected with
+  `ErrConfigLockedByOther` → HTTP 409 when another session owns the candidate,
+  and symmetrically CLI/gRPC is rejected while REST holds it; `/config/exit`
+  releases only the REST-held lock (`ExitConfigureSession`) instead of
+  force-clearing any holder. The store's `sessionID == ""` system-bypass
+  semantics are untouched; read-only REST endpoints are unaffected. Session
+  model: fixed shared REST identity (REST is stateless); two concurrent REST
+  clients share "rest" and are not mutually excluded — a per-caller REST token
+  is a separate product follow-up. Tests (fail-on-revert; neutralize by setting
+  `restConfigSessionID = ""` → 3 RED): pkg/api/config_session_holder_5870_test.go.
+  Validation: go build ./..., go vet ./pkg/api/ ./pkg/configstore/, go test
+  ./pkg/api/... ./pkg/configstore/... all pass. Control-plane / unit-provable —
+  no smoke.
+- **File(s)**: pkg/api/config.go,
+  pkg/api/config_session_holder_5870_test.go (new),
+  pkg/configstore/README.md, _Log.md

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -9,7 +9,49 @@ import (
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
 )
+
+// restConfigSessionID is the fixed config-lock holder identity every REST
+// config MUTATION runs under (#5870). REST is stateless across calls, so all
+// REST config edits share ONE logical operator identity that PARTICIPATES in
+// the shared-candidate holder lock, rather than passing the empty session ID
+// that the store treats as its internal/system capability (daemon apply, HA
+// sync, in-process CLI) and which BYPASSES the holder lock entirely.
+//
+// Consequences of routing every REST mutation through this non-empty identity:
+//   - a REST set/delete/commit is REJECTED (ErrConfigLockedByOther) when a CLI
+//     or gRPC configuration session owns the candidate, and symmetrically a
+//     CLI/gRPC mutation is rejected while REST holds it — closing the exact
+//     cross-session candidate-corruption / commit-smuggling hole in #5870.
+//   - the store's sessionID=="" system-bypass semantics are untouched; only the
+//     REST layer stops USING that bypass. Read-only REST endpoints are
+//     unaffected.
+//
+// It is deliberately non-empty and constant. A gRPC config session is keyed by
+// a random per-connection token / peer address (pkg/grpcapi connSessionID), so
+// this literal never collides with a real peer session identity.
+//
+// Statelessness caveat: because REST carries no per-request session token, two
+// concurrent REST clients share this one identity and are NOT mutually
+// excluded from each other (only from CLI/gRPC). Giving each REST caller a
+// distinct token is a REST API contract change (a product decision) tracked
+// separately; this fix closes the cross-transport bypass without expanding
+// scope.
+const restConfigSessionID = "rest"
+
+// writeConfigMutationError maps a config-store mutation error to an HTTP
+// status. A holder-lock conflict (ErrConfigLockedByOther) — a REST mutation
+// attempted while a CLI/gRPC session owns the shared candidate (#5870) — is a
+// 409 Conflict, matching configEnterHandler's lock response; every other error
+// (parse/validation/not-in-config-mode) stays a 400 Bad Request.
+func writeConfigMutationError(w http.ResponseWriter, err error) {
+	if errors.Is(err, configstore.ErrConfigLockedByOther) {
+		writeError(w, http.StatusConflict, err.Error())
+		return
+	}
+	writeError(w, http.StatusBadRequest, err.Error())
+}
 
 func (s *Server) configHandler(w http.ResponseWriter, _ *http.Request) {
 	cfg := s.store.ActiveConfig()
@@ -21,7 +63,11 @@ func (s *Server) configHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) configEnterHandler(w http.ResponseWriter, _ *http.Request) {
-	if err := s.store.EnterConfigure(); err != nil {
+	// #5870: acquire the candidate lock under the fixed REST identity so a REST
+	// config session participates in holder enforcement (a concurrent CLI/gRPC
+	// session that owns the candidate makes this return ErrConfigLocked → 409),
+	// instead of the empty-session internal acquire that recorded no holder.
+	if err := s.store.EnterConfigureSession(restConfigSessionID); err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return
 	}
@@ -29,7 +75,12 @@ func (s *Server) configEnterHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) configExitHandler(w http.ResponseWriter, _ *http.Request) {
-	s.store.ExitConfigure()
+	// #5870: release ONLY the REST-held lock. Session-scoped exit is a no-op
+	// when a CLI/gRPC session owns the candidate, so a REST /config/exit can no
+	// longer force-clear another session's in-progress candidate (the previous
+	// unconditional ExitConfigure was itself a facet of the bypass). A wedged
+	// REST lock is still reclaimed by the #4476 idle-lease reaper.
+	s.store.ExitConfigureSession(restConfigSessionID)
 	writeOK(w, map[string]string{"status": "ok"})
 }
 
@@ -50,8 +101,8 @@ func (s *Server) configSetHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.SetFromInput(req.Input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if err := s.store.SetFromInputAs(restConfigSessionID, req.Input); err != nil {
+		writeConfigMutationError(w, err)
 		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
@@ -66,8 +117,8 @@ func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.DeleteFromInput(req.Input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if err := s.store.DeleteFromInputAs(restConfigSessionID, req.Input); err != nil {
+		writeConfigMutationError(w, err)
 		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
@@ -87,8 +138,8 @@ func (s *Server) configDeactivateHandler(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.DeactivateFromInput(req.Input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if err := s.store.DeactivateFromInputAs(restConfigSessionID, req.Input); err != nil {
+		writeConfigMutationError(w, err)
 		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
@@ -105,21 +156,31 @@ func (s *Server) configActivateHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.ActivateFromInput(req.Input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if err := s.store.ActivateFromInputAs(restConfigSessionID, req.Input); err != nil {
+		writeConfigMutationError(w, err)
 		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
 }
 
 func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
+	// #5870: only the config-lock holder may commit the shared candidate. Reject
+	// a REST commit before it can confirm/apply another (CLI/gRPC) session's
+	// pending work — the empty-session commit path previously let a stateless
+	// REST caller smuggle another operator's staged edits into an applied
+	// commit. Mirrors the gRPC Commit gate (pkg/grpcapi/server_config.go).
+	if err := s.store.EnsureConfigHolder(restConfigSessionID); err != nil {
+		writeConfigMutationError(w, err)
+		return
+	}
+
 	// Bare commit during a pending commit-confirmed window (#4000). Confirm
 	// the pending config only when the candidate is UNCHANGED; new staged
 	// edits fall through to the normal commit below, where commitFn applies
 	// them AND clears the timer (#3861), so they are committed rather than
 	// silently dropped.
 	if s.store.IsConfirmPending() && !s.store.IsDirty() {
-		if err := s.store.ConfirmCommit(); err != nil {
+		if err := s.store.ConfirmCommitAs(restConfigSessionID); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
@@ -166,8 +227,10 @@ func (s *Server) configRollbackHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("invalid n %d: rollback index must be non-negative (0 = revert to active)", req.N))
 		return
 	}
-	if err := s.store.Rollback(req.N); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	// #5870: rollback replaces the candidate, so it runs under the REST holder
+	// identity and is rejected when a CLI/gRPC session owns the candidate.
+	if err := s.store.RollbackAs(restConfigSessionID, req.N); err != nil {
+		writeConfigMutationError(w, err)
 		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
@@ -291,15 +354,17 @@ func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #5870: load* is a candidate mutation, so it runs under the REST holder
+	// identity and is rejected when a CLI/gRPC session owns the candidate.
 	switch req.Mode {
 	case "override":
-		if err := s.store.LoadOverride(req.Content); err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+		if err := s.store.LoadOverrideAs(restConfigSessionID, req.Content); err != nil {
+			writeConfigMutationError(w, err)
 			return
 		}
 	case "merge", "":
-		if err := s.store.LoadMerge(req.Content); err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+		if err := s.store.LoadMergeAs(restConfigSessionID, req.Content); err != nil {
+			writeConfigMutationError(w, err)
 			return
 		}
 	case "set":
@@ -307,9 +372,9 @@ func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 		// replays flat lines through applyEditLine so a body with
 		// `deactivate <path>` lines round-trips to inactive nodes (#2008 H1).
 		// Applied-count is log-only to keep the response shape stable.
-		count, err := s.store.LoadSet(req.Content)
+		count, err := s.store.LoadSetAs(restConfigSessionID, req.Content)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+			writeConfigMutationError(w, err)
 			return
 		}
 		slog.Info("load set applied", "commands", count)
@@ -323,6 +388,12 @@ func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Request) {
 	var req CommitConfirmedRequest
 	if !decodeJSONBody(w, r, &req) {
+		return
+	}
+	// #5870: only the config-lock holder may commit the shared candidate.
+	// Mirrors the gRPC CommitConfirmed gate.
+	if err := s.store.EnsureConfigHolder(restConfigSessionID); err != nil {
+		writeConfigMutationError(w, err)
 		return
 	}
 	if s.commitConfirmedFn == nil {
@@ -343,8 +414,11 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) configConfirmHandler(w http.ResponseWriter, _ *http.Request) {
-	if err := s.store.ConfirmCommit(); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	// #5870: confirming a pending commit-confirmed is a holder-scoped op — only
+	// the REST-held candidate may be confirmed from REST; a CLI/gRPC holder's
+	// pending window is rejected (ErrConfigLockedByOther → 409).
+	if err := s.store.ConfirmCommitAs(restConfigSessionID); err != nil {
+		writeConfigMutationError(w, err)
 		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})
@@ -396,8 +470,15 @@ func (s *Server) configAnnotateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	pathParts := strings.Fields(req.Path)
-	if err := s.store.Annotate(pathParts, req.Comment); err != nil {
-		writeJSON(w, http.StatusBadRequest, Response{Error: err.Error()})
+	// #5870: annotate mutates the candidate, so it runs under the REST holder
+	// identity and is rejected when a CLI/gRPC session owns the candidate. A
+	// holder conflict maps to 409 Conflict; other errors stay 400.
+	if err := s.store.AnnotateAs(restConfigSessionID, pathParts, req.Comment); err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, configstore.ErrConfigLockedByOther) {
+			status = http.StatusConflict
+		}
+		writeJSON(w, status, Response{Error: err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, Response{Success: true})

--- a/pkg/api/config_session_holder_5870_test.go
+++ b/pkg/api/config_session_holder_5870_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #5870: the REST config MUTATION endpoints must run under a NON-empty session
+// identity that participates in the shared-candidate holder lock. Before the
+// fix they called the store with an empty session ID, which the store treats as
+// its internal/system capability and which BYPASSES the holder lock — so a
+// stateless REST caller could Set/Delete/Commit the candidate a CLI or gRPC
+// configuration session legitimately OWNED, corrupting or smuggling changes into
+// another operator's session.
+//
+// These tests go RED (assertion failure, not compile break) when the fix is
+// neutralized by reverting restConfigSessionID to "" in config.go: the empty
+// identity re-enables the store's system bypass, so the rejected mutations
+// wrongly succeed and stomp / smuggle the held candidate.
+
+// TestRESTConfigSetDeleteRejectedWhenOtherSessionHoldsCandidate simulates a
+// CLI/gRPC session holding the candidate (a non-empty session acquires the lock
+// and stages an edit), then asserts a REST set AND a REST delete are rejected
+// with a holder conflict and the held candidate is left untouched.
+func TestRESTConfigSetDeleteRejectedWhenOtherSessionHoldsCandidate(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	const cliSession = "cli-session-1"
+	if err := store.EnterConfigureSession(cliSession); err != nil {
+		t.Fatalf("EnterConfigureSession(%q): %v", cliSession, err)
+	}
+	// The holder stages an edit into the shared candidate.
+	if err := store.SetFromInputAs(cliSession, "system host-name held-by-cli"); err != nil {
+		t.Fatalf("held-session SetFromInputAs: %v", err)
+	}
+	before := store.ShowCandidateSet()
+
+	s := &Server{store: store}
+
+	// A REST set targeting the same subtree must be rejected — REST is not the
+	// holder — with 409 Conflict (ErrConfigLockedByOther).
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/set",
+		strings.NewReader(`{"input":"system host-name stomped-by-rest"}`))
+	s.configSetHandler(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("REST set while CLI holds candidate: status = %d, want 409; body: %s",
+			rr.Code, rr.Body.String())
+	}
+
+	// A REST delete of the held node must likewise be rejected.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/v1/config/delete",
+		strings.NewReader(`{"input":"system host-name"}`))
+	s.configDeleteHandler(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("REST delete while CLI holds candidate: status = %d, want 409; body: %s",
+			rr.Code, rr.Body.String())
+	}
+
+	// The held session's candidate is byte-for-byte unchanged by the rejected
+	// REST mutations.
+	after := store.ShowCandidateSet()
+	if after != before {
+		t.Fatalf("REST mutation stomped the held candidate:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if strings.Contains(after, "stomped-by-rest") {
+		t.Fatalf("REST set smuggled a node into the held candidate:\n%s", after)
+	}
+	if !strings.Contains(after, "held-by-cli") {
+		t.Fatalf("REST delete removed the held session's staged node:\n%s", after)
+	}
+}
+
+// TestRESTConfigCommitRejectedWhenOtherSessionHoldsCandidate asserts a REST
+// commit is rejected — and the daemon commit callback is NEVER invoked — while
+// a CLI/gRPC session owns the candidate with staged edits. This is the
+// commit-smuggling facet of #5870: without the holder gate, a stateless REST
+// commit would apply another operator's pending work.
+func TestRESTConfigCommitRejectedWhenOtherSessionHoldsCandidate(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	const cliSession = "cli-session-1"
+	if err := store.EnterConfigureSession(cliSession); err != nil {
+		t.Fatalf("EnterConfigureSession(%q): %v", cliSession, err)
+	}
+	if err := store.SetFromInputAs(cliSession, "system host-name staged-by-cli"); err != nil {
+		t.Fatalf("held-session SetFromInputAs: %v", err)
+	}
+
+	var commitCalled bool
+	s := &Server{
+		store: store,
+		commitFn: func(context.Context, string) (*config.Config, error) {
+			commitCalled = true
+			return store.Commit()
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	s.configCommitHandler(rr, httptest.NewRequest("POST", "/api/v1/config/commit", nil))
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("REST commit while CLI holds candidate: status = %d, want 409; body: %s",
+			rr.Code, rr.Body.String())
+	}
+	if commitCalled {
+		t.Fatalf("REST commit smuggled the CLI session's staged edits into an applied commit " +
+			"(commitFn was invoked despite a non-holder REST caller)")
+	}
+}
+
+// TestRESTConfigMutationAllowedAndHoldsLock asserts the REST path works normally
+// when no other session holds the candidate (REST enter acquires the lock, REST
+// set applies), AND that REST then genuinely PARTICIPATES as the holder: a
+// foreign CLI/gRPC session is rejected while REST owns the candidate (the
+// symmetric half of the holder contract).
+func TestRESTConfigMutationAllowedAndHoldsLock(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	s := &Server{store: store}
+
+	// REST enters config mode under its own fixed identity.
+	rr := httptest.NewRecorder()
+	s.configEnterHandler(rr, httptest.NewRequest("POST", "/api/v1/config/enter", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST enter: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	// REST set succeeds — REST is the holder.
+	rr = httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/set",
+		strings.NewReader(`{"input":"system host-name rest-owned"}`))
+	s.configSetHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST set as holder: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if out := store.ShowCandidateSet(); !strings.Contains(out, "rest-owned") {
+		t.Fatalf("REST set did not apply to the candidate:\n%s", out)
+	}
+
+	// A foreign CLI/gRPC session must now be rejected — REST owns the candidate.
+	err := store.SetFromInputAs("cli-foreign", "system host-name cli-stomp")
+	if err == nil {
+		t.Fatal("foreign CLI set succeeded while REST holds the candidate; " +
+			"REST is not participating in the holder lock")
+	}
+	if !errors.Is(err, configstore.ErrConfigLockedByOther) {
+		t.Fatalf("foreign CLI set error = %v; want ErrConfigLockedByOther", err)
+	}
+	if out := store.ShowCandidateSet(); strings.Contains(out, "cli-stomp") {
+		t.Fatalf("foreign CLI set stomped the REST-held candidate:\n%s", out)
+	}
+}

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -277,11 +277,13 @@ itself — the #1956 device-map management-lockout gate, which resolves the
 proposed config against LIVE hardware while the operator is still connected.
 Candidate mutations (`Set`/`Delete`/`LoadOverride`/`LoadMerge`/`LoadSet`/
 `Deactivate`/`Activate`/`Copy`/`Rename`/`Insert`/`Annotate`/`Rollback`) do
-NOT take the daemon apply semaphore, and REST/internal callers pass
-`sessionID == ""` which bypasses config-lock holder enforcement. So a
-concurrent edit could land between the daemon's pre-flight of candidate C1 and
-`Commit`'s promotion, and the daemon would persist+apply an unexamined C2 — a
-management-lockout-gate bypass (examined generation != promoted generation).
+NOT take the daemon apply semaphore, and internal callers pass
+`sessionID == ""` which bypasses config-lock holder enforcement (REST now
+carries the fixed `restConfigSessionID` holder identity instead, #5870, but
+same-session and internal concurrency remain). So a concurrent edit could land
+between the daemon's pre-flight of candidate C1 and `Commit`'s promotion, and
+the daemon would persist+apply an unexamined C2 — a management-lockout-gate
+bypass (examined generation != promoted generation).
 
 The fix is a monotonic **candidate generation token** (`candidateGen`, bumped
 via `bumpCandidateGenLocked` under `s.mu.Lock` at EVERY candidate change:
@@ -311,7 +313,9 @@ commit-confirmed (the active config) is stable across the transaction because
 every path that mutates `active` runs under the daemon apply semaphore the
 commit path holds from pre-flight through promotion.
 
-Scope: REST configuration-session identity / ETag semantics remain a separate
+Scope: REST config mutations now carry a fixed holder identity that
+participates in the config-lock gate (#5870, see "Config-lock ownership gate"),
+but a per-REST-caller session token / ETag semantics remain a separate
 follow-up; generation binding is the invariant required even for
 same-session/internal concurrent callers.
 
@@ -827,17 +831,36 @@ of these, so a second remote session is rejected with `ErrConfigLockedByOther`
 
 Two deliberate bypasses keep the internal paths working:
 
-- **`sessionID == ""` is the internal/system capability** — the in-process
-  CLI, the stateless REST config-enter path (no per-session holder, #4476),
-  HA sync, and tests all call the plain (non-`As`) methods, which delegate
-  with an empty session and skip the ownership check. This is why the local
-  CLI and REST behavior is bit-identical to before #5059.
+- **`sessionID == ""` is the internal/system capability** — daemon apply, HA
+  sync, the in-process CLI, and tests all call the plain (non-`As`) methods,
+  which delegate with an empty session and skip the ownership check.
 - **A lock with no recorded holder** (`effectiveHolderLocked() == ""`, i.e.
   the internal/local `EnterConfigure()` path) is not owned by any session, so
   a user session is not blocked from it. A remote gRPC caller always carries a
   non-empty `connSessionID` (its connection-scoped id, #5849) and records it on
   `EnterConfigureSession`, so it cannot manufacture an empty-holder state to
   slip through.
+
+**REST config mutations no longer use the empty-session bypass (#5870).**
+Originally the stateless REST config endpoints (`pkg/api/config.go`) called the
+plain methods with `sessionID == ""`, so a remote REST caller silently wielded
+the internal/system bypass and could Set/Delete/Load/Rollback/Commit a candidate
+that a CLI or gRPC session legitimately held. Every REST config
+enter/set/delete/deactivate/activate/load/annotate/rollback/commit/
+commit-confirmed/confirm now runs under a fixed non-empty holder identity,
+`restConfigSessionID` (`"rest"`), routed through the `*As` variants and the
+`EnsureConfigHolder` commit gate. A REST mutation is therefore rejected with
+`ErrConfigLockedByOther` (mapped to HTTP 409 Conflict) when another session owns
+the candidate, and symmetrically a CLI/gRPC mutation is rejected while REST
+holds it; `/config/exit` releases only the REST-held lock via
+`ExitConfigureSession` instead of force-clearing any holder. The store's
+`sessionID == ""` semantics are unchanged — only the REST layer stopped using
+them; read-only REST endpoints are unaffected. Because REST is stateless and
+carries no per-request token, two concurrent REST clients share this single
+`"rest"` identity and are not mutually excluded from each other (only from
+CLI/gRPC) — a distinct per-caller REST session token is the separate follow-up
+noted in "Generation-bound commit transaction" above. A wedged REST lock is
+still reclaimed by the #4476 idle-lease reaper.
 
 Like `ErrClusterReadOnly`, `ErrConfigLockedByOther` is `errors.Is`-matchable;
 it is transient (the holder commits or exits). The internal `SyncApply` /


### PR DESCRIPTION
## Summary

- REST config endpoints (`pkg/api/config.go`) called the configstore with an **empty session ID**, which the store (#5059) treats as its internal/system capability (daemon apply, HA sync) that **BYPASSES** the candidate holder lock. A remote, stateless REST caller could therefore Set/Delete/Load/Rollback/Commit the shared candidate while a CLI or gRPC configuration session legitimately **owned** it — corrupting a peer's candidate, smuggling their staged edits into an applied commit, or (via the unconditional `/config/exit` → `ExitConfigure`) force-clearing any holder's in-progress candidate.
- Fix: introduce a fixed non-empty REST holder identity, `restConfigSessionID` (`"rest"`), and route every REST config **mutation** through the session-scoped `*As` variants + the `EnsureConfigHolder` commit gate, mirroring the gRPC handlers.
- A REST mutation is now **rejected** with `ErrConfigLockedByOther` → **HTTP 409 Conflict** (`writeConfigMutationError`) when a CLI/gRPC session owns the candidate, and symmetrically a CLI/gRPC mutation is rejected while REST holds it. `/config/exit` releases only the REST-held lock (`ExitConfigureSession`); a wedged REST lock is still reclaimed by the #4476 idle-lease reaper.
- The store's `sessionID == ""` system-bypass semantics are **untouched** — only the REST layer stopped using them. Read-only REST endpoints are unaffected.

## Session-lifecycle model (the design fork)

REST is stateless across calls, so this uses a **single fixed shared REST identity** (`"rest"`). This closes the cross-transport bypass (REST vs CLI/gRPC — the exact issue). Because REST carries no per-request token, **two concurrent REST clients share `"rest"` and are not mutually excluded from each other** (only from CLI/gRPC) — no worse than today, where they already share the single candidate with zero holder enforcement. Giving each REST caller a distinct **session token** is a REST API contract change (a product decision) and is left as a **separate follow-up**, per scope discipline. Flagged here rather than guessed.

## Test plan

- [x] `pkg/api/config_session_holder_5870_test.go` (new, fail-on-revert):
  - `TestRESTConfigSetDeleteRejectedWhenOtherSessionHoldsCandidate` — CLI session (non-empty) holds + stages an edit; REST set AND delete return 409; held candidate byte-for-byte untouched.
  - `TestRESTConfigCommitRejectedWhenOtherSessionHoldsCandidate` — commit-smuggling guard: REST commit returns 409 and `commitFn` is **never** invoked.
  - `TestRESTConfigMutationAllowedAndHoldsLock` — REST enter+set succeeds with no other holder, and a foreign CLI session is then rejected (REST genuinely holds the lock).
  - **Neutralization** (`restConfigSessionID = ""`) turns all three RED as clean assertion failures.
- [x] `go build ./...`, `go vet ./pkg/api/ ./pkg/configstore/`, `go test ./pkg/api/... ./pkg/configstore/...` all pass.
- Control-plane / unit-provable — **no smoke needed**.

## Docs

- `pkg/configstore/README.md` — the #5059 "Config-lock ownership gate" and the "Generation-bound commit transaction" sections updated: REST mutations no longer use the empty-session bypass; documented the fixed-identity model and the per-caller-token follow-up.

## Refs

Closes #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeisHoXyKBKQJDYo4j9SPx