### PR TITLE
daemon: reject day-2 cluster node-id/cluster-id change (#6192)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54691,3 +54691,42 @@ top.
 - **File(s)**: pkg/api/config.go,
   pkg/api/config_session_holder_5870_test.go (new),
   pkg/configstore/README.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #6192 — reject a day-2 chassis cluster node-id / cluster-id
+  change at commit time (restart boundary). `cluster.NewManager(nodeID,
+  clusterID)` is constructed once at boot (daemon_run.go:1868); the only
+  day-2 reconcile path, `Manager.UpdateConfig` (pkg/cluster/group_state.go),
+  reconciles ONLY redundancy groups and never re-reads m.nodeID/m.clusterID,
+  so a day-2 commit changing node-id or cluster-id was accepted + promoted
+  while the running manager kept its OLD identity (heartbeat NodeID/ClusterID,
+  RETH virtual MAC, election tie-break, FPC naming) — a silent partial no-op
+  (new identity only takes effect on restart), the same false-success class
+  #5840 fixed for the standalone<->cluster flip. Mirrored #6189/#5840's
+  fail-closed restart boundary: added sibling `clusterIdentityCommitPreflight`
+  + `errClusterIdentityRequiresRestart` sentinel in
+  cluster_topology_preflight.go, wired at the SAME 3 sites as the topology
+  gate (commitAndApply, commitConfirmedAndApply, and fail-closed in the
+  peer-sync replay syncAndApply) BEFORE store promotion / any dataplane
+  mutation. Fires only when a cluster runtime EXISTS (d.cluster != nil) AND
+  the candidate is still clustered — the standalone<->cluster flip (incl. the
+  #4179 config-less node) stays owned by clusterTopologyCommitPreflight; an
+  intra-identity edit (same node-id AND cluster-id) passes and reconciles
+  live. No legitimate boot/bootstrap path is falsely rejected (boot LOAD
+  reaches applyConfigLocked not commitAndApply; bootstrap plain commit refused
+  earlier by inBootstrap()); steady-state peer-sync passes (synced text
+  compiles for the local node → node-id resolves to this node's running id,
+  cluster-id is the shared value). Fail-on-revert test
+  TestClusterIdentityDay2ChangeRejected: neutralize by adding `return nil` at
+  the top of clusterIdentityCommitPreflight → 1 RED (assertion at
+  cluster_identity_preflight_6192_test.go:48, "node-id ... must be REJECTED"),
+  clean assertion not a build break. Validation: TMPDIR=/tmp-class
+  GOCACHE=... go build ./..., go vet ./pkg/daemon/, go test -race
+  ./pkg/daemon/... ./pkg/cluster/... all pass (initial run hit a full-/tmp
+  tmpfs — env, not a regression; re-ran on disk-backed /var/tmp, green).
+  Control-plane / unit-provable, rejection before any mutation (per #6189
+  precedent) — NO smoke.
+- **File(s)**: pkg/daemon/cluster_topology_preflight.go,
+  pkg/daemon/daemon_apply.go,
+  pkg/daemon/cluster_identity_preflight_6192_test.go (new),
+  docs/ha-no-hitless-restart.md, _Log.md

--- a/docs/ha-no-hitless-restart.md
+++ b/docs/ha-no-hitless-restart.md
@@ -120,3 +120,59 @@ First-class live day-2 construction/teardown of the cluster runtime
   arming the live dataplane.
 - Intra-mode commits (desired mode matches the running runtime) are
   unaffected.
+
+## Node-id / cluster-id changes require a restart (#6192)
+
+Changing `chassis cluster node-id` or `cluster-id` on a **running
+clustered node** is a restart-boundary change of the same class as the
+standalone<->cluster flip above, for the same boot-baked-runtime reason.
+`cluster.NewManager(nodeID, clusterID)` is called **exactly once, at
+process startup** (`pkg/daemon/daemon_run.go:1868`), with the boot
+config's identity. `Manager.UpdateConfig` — the only day-2 reconcile
+path — reconciles **only the redundancy groups**
+(`pkg/cluster/group_state.go`); it never re-reads `m.nodeID` or
+`m.clusterID`. (Fabric / heartbeat-transport / control-interface
+identity *is* reconciled live — `daemon_apply.go`, #87 — so only the
+node-id / cluster-id **identity** is boot-baked.)
+
+So a day-2 commit that changes the node-id or cluster-id used to be
+accepted and promoted, while the running manager kept its **old**
+identity — heartbeat `NodeID`/`ClusterID`, the RETH virtual MAC
+(`02:bf:72:CC:RR:NN`, cluster-id + node-id derived), the election
+tie-break, and FPC/slot naming. The new identity took effect **only on
+restart**: a silent partial no-op, the same false-success the #5840
+topology gate closes for the mode flip.
+
+A live re-key of the write-once-at-boot manager is unsafe for the same
+reason #5840 declined to (de)construct it live: `d.cluster` is read bare,
+without a lifecycle lock, from many sites, and its identity feeds the
+heartbeat writer, the RETH MAC, and the election already running under
+other goroutines. Instead, `clusterIdentityCommitPreflight` **rejects the
+identity change before any store promotion or dataplane mutation** — wired
+into `commitAndApply` / `commitConfirmedAndApply` beside the topology
+gate, and fail-closed in the peer-sync replay path `syncAndApply` — and
+directs the operator to restart `xpfd` into the new cluster identity (or
+make the change with the system offline). The gate fires only when a
+cluster runtime exists (`d.cluster != nil`) **and** the candidate is still
+clustered; the standalone<->cluster flip (either direction, including the
+#4179 config-less node) stays owned by `clusterTopologyCommitPreflight`.
+An **intra-identity** edit (same node-id **and** cluster-id — a
+redundancy-group / interface / policy change) passes untouched and
+reconciles live.
+
+### Acceptance criteria (identity change, #6192)
+
+- A day-2 commit that changes `chassis cluster node-id` or `cluster-id`
+  on a running clustered node (`d.cluster != nil`) is rejected with a
+  restart-required diagnostic before store promotion; the candidate is
+  not promoted.
+- An intra-identity commit (same node-id and cluster-id) is unaffected.
+- The standalone<->cluster transition remains owned by the #5840
+  topology gate; the identity gate is a no-op when there is no running
+  manager or the candidate is standalone.
+- No legitimate boot/bootstrap or steady-state peer-sync path is falsely
+  rejected: the boot LOAD reaches `applyConfigLocked` (not
+  `commitAndApply`), a bootstrap plain commit is refused earlier by
+  `inBootstrap()`, and a synced commit compiles for the local node so
+  node-id resolves to this node's running id and cluster-id is the shared
+  value.

--- a/pkg/daemon/cluster_identity_preflight_6192_test.go
+++ b/pkg/daemon/cluster_identity_preflight_6192_test.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"golang.org/x/sync/semaphore"
+)
+
+// clusterCfgID builds a compiled-shaped clustered config with an explicit
+// node-id / cluster-id, matching what CompileCandidateGen produces for the
+// commit preflight (Chassis.Cluster populated with the resolved identity).
+func clusterCfgID(nodeID, clusterID int) *config.Config {
+	cfg := &config.Config{}
+	cfg.Chassis.Cluster = &config.ClusterConfig{ClusterID: clusterID, NodeID: nodeID}
+	return cfg
+}
+
+// TestClusterIdentityDay2ChangeRejected is the #6192 fail-on-revert gate.
+//
+// cluster.NewManager(nodeID, clusterID) is constructed exactly once at boot
+// (daemon_run.go:1868); Manager.UpdateConfig reconciles only redundancy groups
+// and never re-reads node-id / cluster-id. So a day-2 commit that CHANGES
+// `chassis cluster node-id` or `cluster-id` is silently accepted while the
+// running manager keeps its OLD identity — a partial no-op that takes effect
+// only on restart (the same false-success class #5840 fixed for the topology
+// flip). clusterIdentityCommitPreflight rejects it BEFORE store promotion / any
+// dataplane mutation, comparing the RUNNING manager identity (d.cluster) to the
+// candidate.
+//
+// Reverting the fix (clusterIdentityCommitPreflight returns nil, or dropping
+// either half of the identity comparison) makes the FIRST assertion below RED as
+// an assertion — exactly one test binds the production reject line. The
+// commitAndApply leg then proves the preflight is wired into the commit path and
+// that a rejected identity change promotes NOTHING.
+func TestClusterIdentityDay2ChangeRejected(t *testing.T) {
+	running := cluster.NewManager(0 /*nodeID*/, 1 /*clusterID*/)
+
+	// --- Direct preflight: the precise binding (running-vs-candidate). ---
+	// node-id change (0 -> 1), cluster-id unchanged: the #6192 bug.
+	err := clusterIdentityCommitPreflight(running, clusterCfgID(1 /*node*/, 1 /*cluster*/))
+	if err == nil {
+		t.Fatal("changing chassis cluster node-id on a running clustered node must be " +
+			"REJECTED (the boot-constructed HA manager cannot be re-keyed live)")
+	}
+	if !errors.Is(err, errClusterIdentityRequiresRestart) {
+		t.Fatalf("rejection must wrap the identity-restart sentinel; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "node-id") ||
+		!strings.Contains(err.Error(), "cluster-id") ||
+		!strings.Contains(err.Error(), "restart") {
+		t.Fatalf("rejection must carry an actionable node-id/cluster-id/restart "+
+			"diagnostic; got %q", err.Error())
+	}
+
+	// cluster-id change (1 -> 2), node-id unchanged: the primary reachable case
+	// (cluster-id is read straight from config, never stamped, and no existing
+	// compile gate catches it).
+	if cerr := clusterIdentityCommitPreflight(running, clusterCfgID(0 /*node*/, 2 /*cluster*/)); cerr == nil ||
+		!errors.Is(cerr, errClusterIdentityRequiresRestart) {
+		t.Fatalf("changing chassis cluster cluster-id on a running clustered node must be "+
+			"REJECTED with the identity-restart sentinel; got %v", cerr)
+	}
+
+	// --- Controls: an intra-identity edit (same node-id AND cluster-id) passes. ---
+	if aerr := clusterIdentityCommitPreflight(running, clusterCfgID(0, 1)); aerr != nil {
+		t.Fatalf("same node-id + cluster-id must be accepted (intra-identity edit); got %v", aerr)
+	}
+
+	// --- Scope: cases the topology gate (#5840) owns are no-ops here. ---
+	// No running HA manager + clustered candidate: the standalone->cluster /
+	// #4179 config-less transition is the topology gate's job, not this one.
+	if nerr := clusterIdentityCommitPreflight(nil /*running*/, clusterCfgID(1, 2)); nerr != nil {
+		t.Fatalf("nil running manager must be a no-op here (topology gate owns it); got %v", nerr)
+	}
+	// Running HA manager + standalone candidate: the cluster->standalone teardown
+	// is likewise the topology gate's job.
+	if serr := clusterIdentityCommitPreflight(running, standaloneCfg()); serr != nil {
+		t.Fatalf("standalone candidate must be a no-op here (topology gate owns it); got %v", serr)
+	}
+
+	// --- Wiring: commitAndApply rejects a day-2 cluster-id change, promotes nothing. ---
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	// Commit a clustered active (node 0 / cluster-id 1) to mirror a running
+	// clustered node's on-disk state.
+	if err := store.SetFromInput("chassis cluster cluster-id 1"); err != nil {
+		t.Fatalf("set cluster-id 1: %v", err)
+	}
+	if err := store.SetFromInput("chassis cluster node 0"); err != nil {
+		t.Fatalf("set node 0: %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("commit clustered active: %v", err)
+	}
+	if active := store.ActiveConfig(); !clusterTopologyConfigured(active) ||
+		active.Chassis.Cluster.ClusterID != 1 {
+		t.Fatalf("precondition: active must be clustered cluster-id 1; got %+v", active)
+	}
+	// Still in configuration mode — stage a cluster-id CHANGE (1 -> 2) as the
+	// candidate. commitAndApply performs the commit; the preflight must reject
+	// before promotion.
+	if err := store.SetFromInput("chassis cluster cluster-id 2"); err != nil {
+		t.Fatalf("set cluster-id 2: %v", err)
+	}
+
+	d := &Daemon{store: store, applySem: semaphore.NewWeighted(1), cluster: running}
+	_, capErr := d.commitAndApply(context.Background(), "change cluster-id", false)
+	if capErr == nil || !errors.Is(capErr, errClusterIdentityRequiresRestart) {
+		t.Fatalf("commitAndApply of a day-2 cluster-id change must be rejected with the "+
+			"identity-restart sentinel; got %v", capErr)
+	}
+	// The candidate must NOT have been promoted: active still holds cluster-id 1.
+	if active := store.ActiveConfig(); !clusterTopologyConfigured(active) ||
+		active.Chassis.Cluster.ClusterID != 1 {
+		t.Fatalf("a rejected identity change must NOT promote the candidate; "+
+			"active cluster-id should still be 1, got %+v", active)
+	}
+}

--- a/pkg/daemon/cluster_topology_preflight.go
+++ b/pkg/daemon/cluster_topology_preflight.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
 )
 
@@ -99,4 +100,71 @@ func clusterTopologyCommitPreflight(runtimeClusterActive bool, newCfg *config.Co
 		"clustered system cannot tear down the HA runtime without a restart. "+
 		"Restart xpfd into the standalone configuration: %w",
 		errClusterTopologyRequiresRestart)
+}
+
+// errClusterIdentityRequiresRestart is the #6192 sibling of
+// errClusterTopologyRequiresRestart: a day-2 commit that CHANGES the running
+// cluster's node-id or cluster-id cannot re-key the boot-constructed HA manager
+// live, so it is rejected with a restart-required diagnostic. Callers surface it
+// verbatim to the operator (CLI/gRPC/REST); tests match it with errors.Is.
+var errClusterIdentityRequiresRestart = errors.New(
+	"chassis cluster node-id / cluster-id change requires a restart into the new identity")
+
+// clusterIdentityCommitPreflight is the #6192 node-id / cluster-id restart
+// boundary — a sibling of clusterTopologyCommitPreflight (#5840) covering the
+// same boot-baked-runtime class the topology gate does NOT.
+//
+// cluster.NewManager(nodeID, clusterID) is called EXACTLY ONCE, at daemon
+// startup (pkg/daemon/daemon_run.go:1868), with the boot config's identity.
+// Manager.UpdateConfig — the only day-2 reconcile path — reconciles ONLY the
+// redundancy groups (pkg/cluster/group_state.go); it never re-reads m.nodeID or
+// m.clusterID. So a day-2 commit that CHANGES `chassis cluster node-id` or
+// `cluster-id` is accepted and promoted, but the running manager keeps its OLD
+// identity — heartbeat NodeID/ClusterID, RETH virtual MAC (02:bf:72:CC:RR:NN),
+// election tie-break, FPC/slot naming — and the new identity takes effect only
+// on restart. That is a silent partial no-op: the same false-success class #5840
+// fixed for the standalone<->cluster topology flip.
+//
+// A live re-key of the write-once-at-boot manager is UNSAFE for the same reason
+// #5840 declined to (de)construct it live: d.cluster is read bare, without a
+// lifecycle lock, from ~129 sites, and its identity feeds the heartbeat writer,
+// VRRP RETH MAC, and election already running under other goroutines. So we
+// REJECT the identity change at commit time — BEFORE store promotion and any
+// dataplane mutation — and direct the operator to restart into the new identity.
+//
+// Scope. This gate fires ONLY when a cluster runtime EXISTS (running != nil)
+// AND the candidate is still clustered. The standalone<->cluster flip in either
+// direction — including the #4179 config-less node (nil runtime, clustered
+// desire) — is owned by clusterTopologyCommitPreflight and handled there; when
+// running is nil or the candidate drops the cluster, this gate is a no-op and
+// the topology gate decides. An intra-identity edit (same node-id AND
+// cluster-id, e.g. a redundancy-group / interface / policy change) passes
+// untouched and reconciles live.
+//
+// No legitimate boot/bootstrap path is falsely rejected, for the same reasons as
+// #5840: the boot config LOAD reaches applyConfigLocked, not commitAndApply, and
+// a bootstrap plain commit is refused earlier by the inBootstrap() gate. In
+// steady state a peer-synced commit also passes — the synced text compiles for
+// the LOCAL node, so node-id resolves to this node's running id and cluster-id
+// is the shared value; the gate rejects only when the operator actually re-keys
+// the identity, which requires a restart on both nodes regardless.
+func clusterIdentityCommitPreflight(running *cluster.Manager, newCfg *config.Config) error {
+	if running == nil || !clusterTopologyConfigured(newCfg) {
+		// No running HA manager, or the candidate is not clustered: the
+		// standalone<->cluster topology gate owns these cases.
+		return nil
+	}
+	cc := newCfg.Chassis.Cluster
+	runNode, runCluster := running.NodeID(), running.ClusterID()
+	if cc.NodeID == runNode && cc.ClusterID == runCluster {
+		// Identity unchanged: an intra-identity edit reconciles live.
+		return nil
+	}
+	return fmt.Errorf("commit rejected: changing chassis cluster identity from "+
+		"node-id %d / cluster-id %d to node-id %d / cluster-id %d cannot re-key the "+
+		"running HA manager — its node/cluster identity (heartbeat, RETH virtual MAC, "+
+		"election tie-break, FPC naming) is constructed only at daemon startup. "+
+		"Restart xpfd into the new cluster identity, or make the change with the "+
+		"system offline: %w",
+		runNode, runCluster, cc.NodeID, cc.ClusterID, errClusterIdentityRequiresRestart)
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -404,6 +404,14 @@ func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer bo
 			if terr := clusterTopologyCommitPreflight(d.cluster != nil, cand); terr != nil {
 				return terr
 			}
+			// #6192: reject a day-2 node-id / cluster-id change on a running
+			// clustered node BEFORE promotion — the boot-constructed HA manager
+			// cannot be re-keyed live (its identity feeds heartbeat, RETH MAC,
+			// election). The topology gate above already handled the
+			// standalone<->cluster flip; this covers the same-mode identity edit.
+			if ierr := clusterIdentityCommitPreflight(d.cluster, cand); ierr != nil {
+				return ierr
+			}
 			return d.deviceMapCommitPreflight(cand, nil)
 		},
 		func(gen uint64) (*config.Config, error) { return d.store.CommitWithDescriptionGen(comment, gen) },
@@ -567,6 +575,23 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 		return nil, terr
 	}
 
+	// #6192: fail closed on a peer-synced node-id / cluster-id identity change,
+	// mirroring the topology backstop above. SyncApply has already promoted the
+	// peer config to active, but the boot-constructed HA manager cannot be
+	// re-keyed live (heartbeat/RETH-MAC/election identity is boot-only). Return
+	// BEFORE applyConfigLocked so the live dataplane is never armed under a
+	// mismatched identity; a restart re-applies the now-active config through the
+	// boot path. In a healthy cluster this is unreachable — the synced text
+	// compiles for the LOCAL node, so node-id resolves to this node's running id
+	// and cluster-id is the shared value — but it is a defense-in-depth backstop
+	// against a divergent replay.
+	if ierr := clusterIdentityCommitPreflight(d.cluster, compiled); ierr != nil {
+		slog.Error("cluster: refusing to apply a peer-synced node-id/cluster-id "+
+			"identity change live; a restart is required to re-key the HA manager",
+			"err", ierr)
+		return nil, ierr
+	}
+
 	// #5564: SyncApply (above) has ALREADY promoted the peer config to active,
 	// and once applyConfigLocked arms the dataplane snapshot this node is
 	// forwarding under it. The three session invalidators
@@ -694,6 +719,13 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 			// reject it up front while the operator is still connected.
 			if terr := clusterTopologyCommitPreflight(d.cluster != nil, cand); terr != nil {
 				return terr
+			}
+			// #6192: same node-id / cluster-id restart boundary as commitAndApply.
+			// The rollback target on a confirm timeout is the current active
+			// config, so a rejected identity change is not confirmable either —
+			// reject it up front while the operator is still connected.
+			if ierr := clusterIdentityCommitPreflight(d.cluster, cand); ierr != nil {
+				return ierr
 			}
 			return d.deviceMapCommitPreflight(cand, d.store.ActiveConfig())
 		},


### PR DESCRIPTION
## Summary

- `cluster.NewManager(nodeID, clusterID)` is constructed **exactly once at daemon startup** (`pkg/daemon/daemon_run.go:1868`) with the boot config's identity. The only day-2 reconcile path, `Manager.UpdateConfig` (`pkg/cluster/group_state.go`), reconciles **only the redundancy groups** and never re-reads `m.nodeID`/`m.clusterID`.
- So a day-2 `commit` that changed `chassis cluster node-id` or `cluster-id` was **accepted and promoted** while the running manager kept its **old** identity — heartbeat `NodeID`/`ClusterID`, the RETH virtual MAC (`02:bf:72:CC:RR:NN`), the election tie-break, FPC/slot naming. The new identity took effect only on restart: a **silent partial no-op**, the same false-success class the #5840 topology gate closes for the standalone↔cluster flip. This is the sibling boot-baked-runtime case #6189/#5840 did not yet cover.
- Fix mirrors the #5840/#6189 fail-closed restart boundary rather than attempting an unsafe live re-key of the write-once-at-boot manager (read bare from many sites; its identity feeds the heartbeat writer, RETH MAC, and election running under other goroutines). Adds `clusterIdentityCommitPreflight` + `errClusterIdentityRequiresRestart` and wires it at the **same three sites** as the topology gate — `commitAndApply`, `commitConfirmedAndApply`, and fail-closed in the peer-sync replay path `syncAndApply` — **before store promotion / any dataplane mutation**, with an actionable "restart into the new cluster identity" diagnostic.

## Scope / false-reject safety

- Fires **only** when a cluster runtime exists (`d.cluster != nil`) **and** the candidate is still clustered. The standalone↔cluster flip in either direction (including the #4179 config-less node) stays owned by `clusterTopologyCommitPreflight`.
- An **intra-identity** edit (same node-id **and** cluster-id — a redundancy-group / interface / policy change) passes untouched and reconciles live.
- No legitimate boot/bootstrap path is falsely rejected: boot LOAD reaches `applyConfigLocked` (not `commitAndApply`); a bootstrap plain commit is refused earlier by `inBootstrap()`; and during bootstrap `d.cluster` is nil so the gate is a no-op.
- Steady-state peer-sync passes: the synced text compiles for the **local** node, so node-id resolves to this node's running id and cluster-id is the shared value; the gate rejects only a genuine operator re-key (which needs a restart on both nodes regardless).

## Test plan

- [x] `TestClusterIdentityDay2ChangeRejected` (new, `pkg/daemon/cluster_identity_preflight_6192_test.go`): direct preflight rejects a node-id change and a cluster-id change (wrapping `errClusterIdentityRequiresRestart`, node-id/cluster-id/restart diagnostic); accepts an intra-identity edit; no-op for the topology-gate-owned cases (nil runtime, standalone candidate); and an end-to-end `commitAndApply` leg proving a day-2 cluster-id change is rejected before promotion (active still holds cluster-id 1).
- [x] **Fail-on-revert**: neutralize by adding a leading `return nil` to `clusterIdentityCommitPreflight` → **1 RED**, a clean assertion at `cluster_identity_preflight_6192_test.go:48` ("changing chassis cluster node-id … must be REJECTED"), not a build break.
- [x] `go build ./...`, `go vet ./pkg/daemon/`, `go test -race ./pkg/daemon/... ./pkg/cluster/...` all pass. (First run hit a full `/tmp` tmpfs — an env issue, not a regression — re-ran on disk-backed tmp, green.)
- Control-plane, unit-provable, rejection before any mutation (per the #6189 precedent) — **no smoke required**.

## Docs

- `docs/ha-no-hitless-restart.md`: new "Node-id / cluster-id changes require a restart (#6192)" section + acceptance criteria, alongside the #5840 topology-transition contract.

## Refs

- Sibling of #6189 (#5840 `clusterTopologyCommitPreflight`); #4179 config-less node; #87 fabric/heartbeat identity is reconciled live (this is specifically node-id/cluster-id).

Closes #6192

🤖 Generated with [Claude Code](https://claude.com/claude-code)