### PR TITLE
grpcapi: remove key-only account authorized_keys at factory reset (#6190)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54733,3 +54733,44 @@ top.
 - **File(s)**: pkg/grpcapi/server_diag_zeroize.go,
   pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go (new),
   docs/system-login.md, _Log.md
+
+## 2026-07-21 — #6201 fold: retain keys marker on a real key-removal error (PR #6201 / Closes #6190)
+- **Timestamp**: 2026-07-21
+- **Action**: Fold a hostile-reviewer fail-closed-parity finding into PR #6201.
+  `zeroizeSweepProvisionedKeys` (pkg/grpcapi/server_diag_zeroize.go) dropped the
+  keys MARKER even when `os.Remove(keysFile)` returned a REAL (non-ErrNotExist)
+  error — an immutable `chattr +i` file, an ENOTDIR/ENOTEMPTY path shape, an I/O
+  error. On such a failure the xpf-written authorized_keys SURVIVES but the marker
+  was removed anyway, so a retried factory reset no longer re-enumerates the
+  account (marker gone) → the prior tenant's SSH key persists with no retry
+  evidence. This DIVERGED from the day-2 `deprovisionLoginUser`
+  (pkg/daemon/login_password.go ~:548-556), which KEEPS the provenance markers and
+  retries on a real key-removal error. The registry teardown's identical shape is
+  safe only because `userdel -r` backstops key removal by deleting the whole home
+  tree; this key-only sweep has NO such backstop, so it must RETAIN the marker on a
+  real key-removal error. Fix: extracted `zeroizeRemoveKeyFileThenMarker`
+  (one-source-of-truth per engineering-style "helpers over duplication") that
+  removes the key file, surfaces any error via fail(), and drops the marker ONLY
+  when the removal SUCCEEDED or returned os.ErrNotExist. Wired into BOTH the
+  proven-owned (`default`, curUID==recordedUID) and genuinely-absent (`!curFound`)
+  branches. lookupErr / markerErr / UID-mismatch branches unchanged (already
+  retain correctly). Tests (fail-on-revert), extend
+  pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go:
+  TestZeroizeKeyOnlyRetainsMarkerOnKeyRemovalError (proven-owned/default branch) +
+  TestZeroizeKeyOnlyOrphanRetainsMarkerOnKeyRemovalError (orphan/!curFound branch)
+  — each seeds a proven/absent key-only account, makes authorized_keys a NON-EMPTY
+  DIRECTORY so os.Remove fails ENOTEMPTY (real error, root-free), runs the sweep,
+  and asserts the MARKER is RETAINED + the error is surfaced. RED-on-revert
+  (new retain binding): revert the helper's gated marker removal to unconditional
+  `fail(os.Remove(markerFile))` → exactly those 2 tests go RED; the #6190
+  happy-path test is UNAFFECTED (verified — the gate only diverges on the failure
+  path). The existing happy-path
+  TestZeroizeRemovesKeyOnlyAccountAuthorizedKeys and
+  TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys still pass; their RED-on-revert
+  doc was updated for the helper refactor. Validation: TMPDIR=/tmp
+  GOCACHE=/tmp/gc6201fix GOTMPDIR=/tmp go build ./... ; go vet ./pkg/grpcapi/ ;
+  go test ./pkg/grpcapi/... ./pkg/daemon/... — all pass (exit 0). Control-plane /
+  unit-provable — NO smoke.
+- **File(s)**: pkg/grpcapi/server_diag_zeroize.go,
+  pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go,
+  docs/system-login.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -54691,3 +54691,45 @@ top.
 - **File(s)**: pkg/api/config.go,
   pkg/api/config_session_holder_5870_test.go (new),
   pkg/configstore/README.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: Fix #6190 — remove a key-only account's xpf-written
+  authorized_keys at factory reset (zeroize)
+- **Details**: `zeroizeTearDownProvisionedUsers` removed
+  `/home/<name>/.ssh/authorized_keys` ONLY for accounts in the
+  `provisioned-users` REGISTRY. A pre-existing (operator / prior-tenant)
+  account configured with `system login user <name> authentication ssh-*` and
+  NO encrypted-password gets a `provisioned-keys` marker but NO registry marker
+  (`applySystemLogin` writes `markProvisioned` only in the useradd branch;
+  `reconcileUserPassword` only on a password apply). Such a KEY-ONLY account is
+  never iterated by the registry loop, so the #6183 fix correctly swept its keys
+  MARKER but the actual xpf-written authorized_keys FILE was never removed — the
+  prior tenant retained SSH login on that account after a "factory reset" (the
+  #4598 credential-leak class). This is ASYMMETRIC with the day-2 path:
+  `reconcileAbsentLoginUsers` enumerates the UNION `provisionedNames()` and
+  `deprovisionLoginUser` DOES remove that key file, gated on `keyProvisioned`.
+  Fix: phase (C) of `zeroizeLoginAccounts` now sweeps the keys root via a new
+  `zeroizeSweepProvisionedKeys` (replacing the marker-only
+  `zeroizeSweepResourceMarkerRoot` on that root) which, in addition to erasing
+  each `provisioned-keys` marker, removes the xpf-written
+  `/home/<name>/.ssh/authorized_keys` FILE — mirroring `deprovisionLoginUser`'s
+  `keyProvisioned`-gated `os.Remove(managedAuthorizedKeysPath(name))`. It is
+  UID-gated and fail-closed (mirrors the registry teardown / #5496): the file is
+  removed only when the live `/etc/passwd` UID equals the keys marker's recorded
+  UID; a proven UID-mismatch (out-of-band recreate whose authorized_keys belongs
+  to someone else) is left intact with the marker RETAINED; an unreadable passwd
+  / unparseable marker fails closed (retain + surface); an account whose registry
+  teardown was RETAINED (#6183) is skipped entirely so its marker AND key file
+  stay consistent; `root` is skipped (its keys live at /root/.ssh, revoked in
+  place by `zeroizeRootLoginAccount`). An operator's own (unmarked)
+  authorized_keys is never touched — only what xpf wrote. Tests (fail-on-revert):
+  pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go —
+  TestZeroizeRemovesKeyOnlyAccountAuthorizedKeys (RED count 1 when the
+  default-branch `fail(os.Remove(keysFile))` is neutralized) +
+  TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys (retained-set +
+  UID-mismatch operator-key preservation). Validation: go build ./..., go vet
+  ./pkg/grpcapi/, go test ./pkg/grpcapi/... ./pkg/daemon/... all pass.
+  Control-plane / unit-provable — NO smoke.
+- **File(s)**: pkg/grpcapi/server_diag_zeroize.go,
+  pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go (new),
+  docs/system-login.md, _Log.md

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -290,6 +290,33 @@ too (`zeroizeLoginAccounts`, same error-surfacing discipline):
   for a fail-closed registry retry, so an account's three markers stay together)
   and drops the roots, so no marker survives in **any** of the three roots —
   mirroring the daemon's own `forgetProvenance`.
+- **Key-only accounts' `authorized_keys` is removed too (#6190).** The account
+  loop removes `authorized_keys` only for accounts in the `provisioned-users`
+  registry, but a **key-only** account — a pre-existing operator/prior-tenant
+  account xpf only added an SSH key to (`system login user <name> authentication
+  ssh-*` with **no** `encrypted-password`) — gets a `provisioned-keys` marker and
+  **no** registry marker (`applySystemLogin` writes `markProvisioned` only in the
+  useradd branch; `reconcileUserPassword` only on a password apply). The registry
+  loop never iterates it, so before #6190 the marker was swept (#5841/#6183) but
+  the xpf-written `/home/<name>/.ssh/authorized_keys` **file** was not — the prior
+  tenant kept SSH login on that account after a "factory reset", the #4598
+  credential-leak class, **asymmetric** with the day-2 path
+  (`reconcileAbsentLoginUsers` enumerates the **union** `provisionedNames()` and
+  `deprovisionLoginUser` **does** remove that key file, gated on
+  `keyProvisioned`). `zeroizeSweepProvisionedKeys` closes the asymmetry: it
+  removes the xpf-written key **file** for every account with a `provisioned-keys`
+  marker (the union delta the registry loop misses), **UID-gated and
+  fail-closed** — the file is removed only when the live `/etc/passwd` UID equals
+  the keys marker's recorded UID (a proven **UID-mismatch** is an out-of-band
+  recreate whose `authorized_keys` belongs to someone else → left intact, marker
+  retained), an unreadable passwd / unparseable marker **fails closed** (retain,
+  surface the error), and an account whose registry teardown was **retained** is
+  skipped entirely so its marker and key file stay consistent. `root` is never a
+  key-only account (`applyRootAuth` writes the registry marker alongside the key
+  marker) and its keys live at `/root/.ssh`, so this sweep never touches a
+  `/home/root` key file — root is revoked in place by `zeroizeRootLoginAccount`.
+  An **operator's own** (unmarked) `authorized_keys` is never touched — only what
+  xpf wrote.
 - **Ownership uncertainty fails CLOSED (#5496).** Deciding "is this the account
   xpf provisioned?" needs two reads — the live UID (`/etc/passwd`) and the
   recorded UID (the marker). If **either** cannot be resolved — `/etc/passwd`

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -316,7 +316,17 @@ too (`zeroizeLoginAccounts`, same error-surfacing discipline):
   marker) and its keys live at `/root/.ssh`, so this sweep never touches a
   `/home/root` key file — root is revoked in place by `zeroizeRootLoginAccount`.
   An **operator's own** (unmarked) `authorized_keys` is never touched — only what
-  xpf wrote.
+  xpf wrote. On a **real key-removal error** (an immutable file, an
+  `ENOTDIR`/`ENOTEMPTY` path shape, an I/O error) the key **file survives**, so
+  the keys marker is **retained** and the error surfaced (`reset incomplete`), so
+  a retried reset re-enumerates the account and re-attempts — mirroring the day-2
+  `deprovisionLoginUser` contract, which keeps the markers and retries on a real
+  `authorized_keys` removal error (#6201). The account-registry teardown may drop
+  its marker after a key-removal error only because `userdel -r` backstops the
+  removal by deleting the whole home tree; this key-only sweep has **no** such
+  backstop, so dropping the marker while the key survives would strand the prior
+  tenant's SSH key with no retry evidence (`zeroizeRemoveKeyFileThenMarker` gates
+  both the proven-owned and genuinely-absent branches).
 - **Ownership uncertainty fails CLOSED (#5496).** Deciding "is this the account
   xpf provisioned?" needs two reads — the live UID (`/etc/passwd`) and the
   recorded UID (the marker). If **either** cannot be resolved — `/etc/passwd`

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -583,10 +583,22 @@ func zeroizeLookupUIDErr(name string) (uid int, found bool, err error) {
 // residue, and because reconcileAbsentLoginUsers unions all three roots, a
 // re-tenant's reused-UID account colliding with a surviving marker would be
 // deprovisioned despite xpf never provisioning it. After the registry loop,
-// zeroizeSweepResourceMarkerRoot erases every marker in the two resource roots
-// (keeping only names retained for a fail-closed registry retry) and drops the
-// roots, so no marker survives in ANY of the three roots. This mirrors the
-// daemon's own forgetProvenance, which already drops all three per account.
+// zeroizeSweepResourceMarkerRoot (passwords) and zeroizeSweepProvisionedKeys
+// (keys) erase every marker in the two resource roots (keeping only names
+// retained for a fail-closed registry retry) and drop the roots, so no marker
+// survives in ANY of the three roots. This mirrors the daemon's own
+// forgetProvenance, which already drops all three per account.
+//
+// #6190 key-only accounts. The registry loop removes authorized_keys only for
+// accounts in provisioned-users, so a KEY-ONLY account — a pre-existing
+// operator/prior-tenant account xpf only added an SSH key to (a provisioned-keys
+// marker, NO registry marker) — keeps its xpf-written authorized_keys after the
+// reset, leaving the prior tenant SSH login (the #4598 leak class, asymmetric
+// with the day-2 deprovisionLoginUser that enumerates the UNION and DOES remove
+// that file). zeroizeSweepProvisionedKeys therefore removes the xpf-written
+// /home/<name>/.ssh/authorized_keys FILE (UID-gated, fail-closed) alongside the
+// keys marker — never an operator's own key file, and never a key file whose
+// account's teardown was retained.
 //
 // Discipline mirrors zeroizeConfigDir / zeroizeRenderedConfigs: os.ErrNotExist
 // is never an error (an already-absent artifact is the goal), removal is
@@ -640,9 +652,17 @@ func zeroizeLoginAccounts() error {
 	// (C) #5841: erase the two resource-specific ownership roots
 	// (provisioned-passwords, provisioned-keys) too, so a factory reset leaves NO
 	// per-account marker in ANY of the three roots — no residue for a re-tenant's
-	// reused-UID account to collide with.
+	// reused-UID account to collide with. The KEYS root additionally removes the
+	// xpf-written authorized_keys FILE itself, not just the marker (#6190): a
+	// KEY-ONLY account (a pre-existing operator/prior-tenant account xpf only
+	// added an SSH key to — a provisioned-keys marker but NO provisioned-users
+	// registry entry) is never iterated by the registry loop above, so its
+	// xpf-written key file would otherwise survive the reset and leave the prior
+	// tenant SSH login — the #4598 credential-leak class, asymmetric with the
+	// day-2 deprovisionLoginUser which enumerates the UNION and DOES remove that
+	// file.
 	zeroizeSweepResourceMarkerRoot(zeroizeProvisionedPasswordsDir(), retained, fail)
-	zeroizeSweepResourceMarkerRoot(zeroizeProvisionedKeysDir(), retained, fail)
+	zeroizeSweepProvisionedKeys(zeroizeProvisionedKeysDir(), retained, fail)
 	return firstErr
 }
 
@@ -755,14 +775,16 @@ func zeroizeTearDownProvisionedUsers(entries []os.DirEntry, retained map[string]
 }
 
 // zeroizeSweepResourceMarkerRoot erases the resource-specific ownership markers
-// (#5841) in dir — provisioned-passwords or provisioned-keys — as part of a
-// factory reset, then drops the now-empty root. Without this the two resource
-// roots the #5841 split introduced SURVIVE a zeroize: each per-account UID
-// marker is #5869/#5871-class residue, and because reconcileAbsentLoginUsers
-// unions all three roots, a re-tenant's reused-UID account colliding with a
-// surviving marker would be deprovisioned (its password locked, its
-// authorized_keys deleted) despite xpf never provisioning it — the exact
-// overclaim #5841 exists to kill, resurrected on a "factory-reset" box.
+// (#5841) in dir — the provisioned-passwords root — as part of a factory reset,
+// then drops the now-empty root. (The provisioned-keys root has its own sweep,
+// zeroizeSweepProvisionedKeys, which additionally removes the xpf-written
+// authorized_keys FILE — #6190.) Without this the resource root the #5841 split
+// introduced SURVIVES a zeroize: each per-account UID marker is
+// #5869/#5871-class residue, and because reconcileAbsentLoginUsers unions all
+// three roots, a re-tenant's reused-UID account colliding with a surviving
+// marker would be deprovisioned (its password locked) despite xpf never
+// provisioning it — the exact overclaim #5841 exists to kill, resurrected on a
+// "factory-reset" box.
 //
 // A marker whose name is in retained (its account-registry teardown was KEPT
 // for a fail-closed retry) is LEFT so the account's three markers stay together
@@ -786,6 +808,132 @@ func zeroizeSweepResourceMarkerRoot(dir string, retained map[string]struct{}, fa
 			continue // this account's registry teardown was retained (fail-closed)
 		}
 		fail(os.Remove(filepath.Join(dir, name)))
+	}
+	// Drop the now-(hopefully-)empty root; a retained marker leaves it non-empty,
+	// which is fine and must not gate the factory reset.
+	_ = os.Remove(dir)
+}
+
+// zeroizeSweepProvisionedKeys is the KEYS-root counterpart of
+// zeroizeSweepResourceMarkerRoot (#6190). In ADDITION to erasing each
+// provisioned-keys marker, it removes the xpf-written
+// /home/<name>/.ssh/authorized_keys the marker proves xpf installed — the FILE
+// itself, not just the ownership marker.
+//
+// Why a distinct sweep. The account-registry teardown
+// (zeroizeTearDownProvisionedUsers) already removes authorized_keys for every
+// account in the provisioned-users REGISTRY, but a KEY-ONLY account — a
+// pre-existing operator/prior-tenant account xpf only added an SSH key to
+// (`system login user <name> authentication ssh-*` with NO encrypted-password)
+// — gets a provisioned-keys marker and NO registry marker (applySystemLogin
+// writes markProvisioned only in the useradd branch; reconcileUserPassword only
+// on a password apply). Such an account is never iterated by the registry loop,
+// so before #6190 its xpf-written authorized_keys SURVIVED a factory reset and
+// the prior tenant kept SSH login on that account — the #4598 credential-leak
+// class, asymmetric with the day-2 path (reconcileAbsentLoginUsers enumerates
+// the UNION provisionedNames() and deprovisionLoginUser DOES remove that key
+// file, gated on keyProvisioned). This sweep closes the asymmetry: it enumerates
+// the keys root (the union delta the registry loop misses) and removes the file,
+// mirroring deprovisionLoginUser's keyProvisioned-gated
+// os.Remove(managedAuthorizedKeysPath(name)).
+//
+// Ownership discipline — remove ONLY what xpf wrote, mirroring the registry
+// teardown's UID-gated fail-closed rules (#5496):
+//   - retained: an account whose registry teardown was KEPT for a fail-closed
+//     retry keeps ALL its state consistent — its key marker AND key file are
+//     left untouched (#6190 retained-set preservation). It is skipped entirely.
+//   - root: root's authorized_keys is at /root/.ssh, NOT /home/root, and is
+//     revoked by zeroizeRootLoginAccount in the registry phase (#5520); this
+//     sweep NEVER touches a /home/root key file. The root keys marker itself is
+//     still erased here (residue) when root's revocation succeeded (root not in
+//     retained). Root is never a key-only account (applyRootAuth writes the
+//     registry marker alongside the key marker), so it is always torn down by
+//     the registry phase.
+//   - UID gate: the key file is removed only when the live /etc/passwd UID for
+//     name equals the keys marker's recorded UID — the account xpf actually
+//     wrote the key for. A proven UID-MISMATCH is an out-of-band userdel+recreate
+//     (the current authorized_keys belongs to SOMEONE ELSE), so it is left
+//     intact, the anomaly surfaced, and the marker RETAINED — never delete an
+//     operator's keys.
+//   - Uncertainty (passwd unreadable / marker unparseable) FAILS CLOSED: surface
+//     the error, retain the marker, remove nothing.
+//   - Genuinely absent (passwd read OK, name gone out of band): remove any
+//     orphaned xpf key residue (the marker proves xpf wrote it) and drop the
+//     stale marker.
+//
+// os.ErrNotExist is never an error; removal is best-effort past a single failure
+// but the FIRST real error is surfaced via fail so a silently-incomplete sweep
+// is not reported as a clean reset. Discipline mirrors zeroizeConfigDir /
+// zeroizeTearDownProvisionedUsers.
+func zeroizeSweepProvisionedKeys(dir string, retained map[string]struct{}, fail func(error)) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		fail(err) // absent root → ErrNotExist, excluded by fail()
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if _, keep := retained[name]; keep {
+			// Registry teardown retained this account (fail-closed): keep ALL its
+			// state consistent — leave its key marker AND its key file untouched
+			// so a retried zeroize re-attempts with the account's markers intact.
+			continue
+		}
+		markerFile := filepath.Join(dir, name)
+
+		if name == "root" {
+			// Root's key file lives at /root/.ssh and is revoked by
+			// zeroizeRootLoginAccount in the registry phase (#5520), never at
+			// /home/root. Only erase root's keys marker here (residue); never
+			// touch a /home/root key file.
+			fail(os.Remove(markerFile))
+			continue
+		}
+
+		keysFile := filepath.Join(zeroizeHomeBase, name, ".ssh", "authorized_keys")
+		recordedUID, markerErr := readProvisionedMarkerUID(markerFile)
+		curUID, curFound, lookupErr := zeroizeLookupUIDErr(name)
+
+		switch {
+		case lookupErr != nil:
+			// /etc/passwd unreadable, OR its UID field for this account is
+			// malformed: the identity database is UNKNOWN. FAIL CLOSED (#5496) —
+			// surface the error, remove nothing, and RETAIN the key marker so a
+			// retry re-attempts once passwd is readable again.
+			slog.Error("zeroize: cannot resolve key-only account UID from passwd; retaining key marker, reset incomplete",
+				"user", name, "err", lookupErr)
+			fail(lookupErr)
+		case markerErr != nil:
+			// The keys marker itself is unreadable/unparseable: we cannot resolve
+			// OUR recorded UID, so we cannot prove the live authorized_keys is the
+			// one xpf wrote. FAIL CLOSED — surface, retain the marker, remove nothing.
+			slog.Error("zeroize: cannot read provisioned-keys marker; retaining key marker, reset incomplete",
+				"user", name, "err", markerErr)
+			fail(markerErr)
+		case !curFound:
+			// passwd READ OK and the account is genuinely ABSENT — an out-of-band
+			// userdel. Remove any orphaned xpf-written key residue (the marker
+			// proves xpf wrote it) and drop the stale marker.
+			fail(os.Remove(keysFile))
+			fail(os.Remove(markerFile))
+		case curUID != recordedUID:
+			// Proven UID-mismatch: the live account under this name has a DIFFERENT
+			// UID than the one xpf wrote the key for — an out-of-band
+			// userdel+recreate. The current authorized_keys belongs to SOMEONE
+			// ELSE, so NEVER remove it. Surface the unresolved condition and RETAIN
+			// the marker (mirrors the registry teardown's mismatch branch, #5496).
+			slog.Warn("zeroize: provisioned-keys marker UID mismatch (account recreated out of band); authorized_keys left untouched, reset incomplete",
+				"user", name, "markerUID", recordedUID, "liveUID", curUID)
+			fail(fmt.Errorf("zeroize: key-only account %q live UID %d != provisioned-keys marker UID %d (out-of-band recreate); left untouched", name, curUID, recordedUID))
+		default:
+			// curUID == recordedUID → the exact account xpf wrote the key for.
+			// Remove the xpf-written authorized_keys, then drop the marker.
+			fail(os.Remove(keysFile))
+			fail(os.Remove(markerFile))
+		}
 	}
 	// Drop the now-(hopefully-)empty root; a retained marker leaves it non-empty,
 	// which is fine and must not gate the factory reset.

--- a/pkg/grpcapi/server_diag_zeroize.go
+++ b/pkg/grpcapi/server_diag_zeroize.go
@@ -861,6 +861,16 @@ func zeroizeSweepResourceMarkerRoot(dir string, retained map[string]struct{}, fa
 //     orphaned xpf key residue (the marker proves xpf wrote it) and drop the
 //     stale marker.
 //
+// In BOTH the proven-owned (default) and genuinely-absent (!curFound) branches
+// the keys marker is dropped ONLY when the authorized_keys removal SUCCEEDED (or
+// the file was already absent). On a REAL key-removal error the key SURVIVES, so
+// the marker is RETAINED and the error surfaced so a retried reset re-enumerates
+// the account — the retain-on-error contract lives in
+// zeroizeRemoveKeyFileThenMarker (#6201, day-2 deprovisionLoginUser parity;
+// unlike the account-registry teardown there is no userdel -r key-removal
+// backstop, so dropping the marker on a surviving key would strand the prior
+// tenant's SSH key with no retry evidence).
+//
 // os.ErrNotExist is never an error; removal is best-effort past a single failure
 // but the FIRST real error is surfaced via fail so a silently-incomplete sweep
 // is not reported as a clean reset. Discipline mirrors zeroizeConfigDir /
@@ -916,9 +926,12 @@ func zeroizeSweepProvisionedKeys(dir string, retained map[string]struct{}, fail 
 		case !curFound:
 			// passwd READ OK and the account is genuinely ABSENT — an out-of-band
 			// userdel. Remove any orphaned xpf-written key residue (the marker
-			// proves xpf wrote it) and drop the stale marker.
-			fail(os.Remove(keysFile))
-			fail(os.Remove(markerFile))
+			// proves xpf wrote it), then drop the stale marker — but ONLY when the
+			// key removal SUCCEEDED (or the file was already absent). On a real
+			// key-removal error the residue SURVIVES, so RETAIN the marker so a
+			// retried reset re-enumerates this account instead of forgetting the
+			// still-present key (zeroizeRemoveKeyFileThenMarker, #6201).
+			zeroizeRemoveKeyFileThenMarker(name, keysFile, markerFile, fail)
 		case curUID != recordedUID:
 			// Proven UID-mismatch: the live account under this name has a DIFFERENT
 			// UID than the one xpf wrote the key for — an out-of-band
@@ -930,14 +943,55 @@ func zeroizeSweepProvisionedKeys(dir string, retained map[string]struct{}, fail 
 			fail(fmt.Errorf("zeroize: key-only account %q live UID %d != provisioned-keys marker UID %d (out-of-band recreate); left untouched", name, curUID, recordedUID))
 		default:
 			// curUID == recordedUID → the exact account xpf wrote the key for.
-			// Remove the xpf-written authorized_keys, then drop the marker.
-			fail(os.Remove(keysFile))
-			fail(os.Remove(markerFile))
+			// Remove the xpf-written authorized_keys, then drop the marker — but
+			// ONLY when the key removal SUCCEEDED (or the file was already absent).
+			// On a real key-removal error (an immutable file, an ENOTDIR/ENOTEMPTY
+			// path shape, an I/O error) the key SURVIVES, so RETAIN the marker so a
+			// retried reset re-enumerates and re-attempts the removal
+			// (zeroizeRemoveKeyFileThenMarker, #6201).
+			zeroizeRemoveKeyFileThenMarker(name, keysFile, markerFile, fail)
 		}
 	}
 	// Drop the now-(hopefully-)empty root; a retained marker leaves it non-empty,
 	// which is fine and must not gate the factory reset.
 	_ = os.Remove(dir)
+}
+
+// zeroizeRemoveKeyFileThenMarker removes an xpf-written authorized_keys file for
+// a provisioned-keys account and drops its keys marker ONLY when that removal
+// SUCCEEDED or the file was already absent (os.ErrNotExist). On a REAL
+// key-removal error (an immutable `chattr +i` file, an ENOTDIR/ENOTEMPTY path
+// shape, an I/O error) the key SURVIVES, so the marker is RETAINED and the error
+// surfaced via fail — a retried factory reset then re-enumerates the account
+// (the keys marker is what makes it discoverable) and re-attempts the removal
+// (#6201).
+//
+// This mirrors the day-2 deprovisionLoginUser contract
+// (pkg/daemon/login_password.go): on a real os.Remove(authorized_keys) error it
+// KEEPS the provenance markers and returns to retry next apply, rather than
+// forgetting the account with a live key on disk. Dropping the keys marker while
+// the key file survives would strand the prior tenant's SSH key with no retry
+// evidence. The account-registry teardown (zeroizeTearDownProvisionedUsers) can
+// drop its marker unconditionally after a key-removal error only because its
+// `userdel -r` backstops the removal by deleting the whole home tree; this
+// key-only sweep has NO such backstop, so the retain-on-error gate is
+// load-bearing.
+//
+// os.ErrNotExist is not an error (an already-absent key/marker is the goal) — it
+// is excluded by fail() and, treated as success here, does not block the marker
+// removal.
+func zeroizeRemoveKeyFileThenMarker(name, keysFile, markerFile string, fail func(error)) {
+	keyErr := os.Remove(keysFile)
+	fail(keyErr)
+	if keyErr == nil || errors.Is(keyErr, os.ErrNotExist) {
+		// Key removed (or already absent): safe to forget the account.
+		fail(os.Remove(markerFile))
+		return
+	}
+	// Real key-removal error: the key file SURVIVES. Retain the marker so a
+	// retried reset re-enumerates this account (fail-closed, day-2 parity).
+	slog.Error("zeroize: failed to remove key-only account authorized_keys; retaining key marker, reset incomplete",
+		"user", name, "file", keysFile, "err", keyErr)
 }
 
 // readProvisionedMarkerUID reads a provenance marker file and returns the UID

--- a/pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go
+++ b/pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go
@@ -1,0 +1,170 @@
+package grpcapi
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #6190: a KEY-ONLY account's xpf-written authorized_keys survived a factory
+// reset. The factory-reset login teardown (zeroizeLoginAccounts) removes
+// authorized_keys only for accounts in the provisioned-users REGISTRY. But a
+// pre-existing (operator / prior-tenant) account configured with `system login
+// user <name> authentication ssh-*` and NO encrypted-password gets a
+// provisioned-keys marker and NO registry marker (applySystemLogin writes
+// markProvisioned only in the useradd branch; reconcileUserPassword only on a
+// password apply). Such a KEY-ONLY account is never iterated by the registry
+// loop, so before #6190 the #6183 fix correctly swept its keys MARKER but the
+// actual xpf-written authorized_keys FILE was never removed — the prior tenant
+// retained SSH login on that account after a "factory reset" (the #4598
+// credential-leak class). This is ASYMMETRIC with the day-2 path
+// (reconcileAbsentLoginUsers enumerates the UNION provisionedNames() and
+// deprovisionLoginUser DOES remove that key file).
+//
+// The fix (zeroizeSweepProvisionedKeys) removes the xpf-written key FILE for
+// every account with a provisioned-keys marker (union enumeration), UID-gated
+// and fail-closed, while preserving the retained-set (#6183) semantics and never
+// touching an operator's own (unmarked) key file.
+
+// TestZeroizeRemovesKeyOnlyAccountAuthorizedKeys pins the #6190 fix: a live
+// key-only account (provisioned-keys marker + xpf-written authorized_keys, NO
+// registry/password marker) has BOTH its marker AND its authorized_keys removed
+// by the factory-reset teardown, while a NON-provisioned operator account's own
+// key file (no marker) is left untouched. No userdel fires — xpf only added a
+// key, it did not create the account.
+//
+// RED on revert (two equivalent neutralizations, both clean assertion failures,
+// neither a compile break):
+//
+//   - Surgical (target count 1): comment out the single
+//     `fail(os.Remove(keysFile))` in zeroizeSweepProvisionedKeys' `default`
+//     (UID-match) branch — the exact key-file removal this account exercises.
+//     `keysFile` stays used by the genuinely-absent branch, so it still compiles;
+//     the keyonly marker is still swept, but the xpf-written authorized_keys FILE
+//     SURVIVES, so `assertAbsent(keyonlyKeys)` here goes RED. Exactly this test
+//     fails — target count 1.
+//   - Broad (target count 2): revert the phase-(C) keys-root sweep call in
+//     zeroizeLoginAccounts from `zeroizeSweepProvisionedKeys(...)` back to
+//     `zeroizeSweepResourceMarkerRoot(zeroizeProvisionedKeysDir(), retained,
+//     fail)` (the marker-only sweep). That also drops the UID-gated fail-closed
+//     retention, so BOTH this test (key file survives) AND
+//     TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys (the UID-mismatch marker
+//     is erased instead of retained) go RED — target count 2.
+//
+// No other test seeds a key-only account and asserts its key-file removal.
+func TestZeroizeRemovesKeyOnlyAccountAuthorizedKeys(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	keyDir := filepath.Join(root, "provisioned-keys")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	// /etc/passwd: the key-only account (live at UID 1500) + an operator's OWN
+	// account (no marker of any kind).
+	mustWriteFile(t, passwdPath, []byte(
+		"keyonly:x:1500:1500:keyonly:/home/keyonly:/bin/bash\n"+
+			"operator:x:1000:1000:operator:/home/operator:/bin/bash\n"))
+
+	// KEY-ONLY provenance: a provisioned-keys marker ONLY (no provisioned-users
+	// registry marker, no provisioned-passwords marker) — exactly what a
+	// `ssh-*`-only `system login user` produces on a pre-existing account.
+	keyonlyMarker := filepath.Join(keyDir, "keyonly")
+	mustWriteFile(t, keyonlyMarker, []byte("1500"))
+
+	// The xpf-written authorized_keys for the key-only account — the artifact the
+	// registry-only teardown misses (the leak).
+	keyonlyKeys := filepath.Join(homeBase, "keyonly", ".ssh", "authorized_keys")
+	mustWriteFile(t, keyonlyKeys, []byte("ssh-ed25519 AAAAxpf keyonly\n"))
+
+	// An operator's OWN authorized_keys with NO marker in any root — xpf never
+	// wrote it, so it MUST survive (the core "only what xpf wrote" invariant).
+	operatorKeys := filepath.Join(homeBase, "operator", ".ssh", "authorized_keys")
+	mustWriteFile(t, operatorKeys, []byte("ssh-ed25519 AAAAop operator\n"))
+
+	// setZeroizeLoginPaths points zeroizeProvisionedUsersDir at provDir; the two
+	// resource roots are computed as its siblings, so this single seam relocates
+	// all three roots (incl. keyDir) under the throwaway tree together.
+	deleted := setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err != nil {
+		t.Fatalf("zeroizeLoginAccounts returned error: %v", err)
+	}
+
+	// No userdel: xpf did not create the account, it only added a key. (Mirrors
+	// deprovisionLoginUser where ownsAccount=false → no userdel.)
+	if len(*deleted) != 0 {
+		t.Errorf("userdel invoked %v for a key-only account; want none (xpf only added a key)", *deleted)
+	}
+
+	// The #6190 fix: the xpf-written key file AND its marker are gone.
+	assertAbsent(t, keyonlyKeys)   // RED on revert of the key-file removal
+	assertAbsent(t, keyonlyMarker) // marker swept (already worked pre-#6190)
+	assertAbsent(t, keyDir)        // now-empty keys root dropped
+
+	// Safety: the operator's own (unmarked) key file is untouched.
+	assertPresent(t, operatorKeys)
+}
+
+// TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys pins the two non-destructive
+// paths of the #6190 sweep, so a key file is only ever removed for the exact
+// account xpf wrote it for:
+//
+//   - Retained-set preservation (#6183): an account whose REGISTRY teardown is
+//     RETAINED for a fail-closed retry keeps ALL its state consistent — its keys
+//     marker AND its key file are left untouched by the keys sweep. Here `retain`
+//     has a registry marker whose recorded UID (3000) mismatches its live UID
+//     (3001), so the registry teardown reports the anomaly and retains its
+//     markers; the keys sweep must then skip it entirely.
+//   - UID-mismatch operator-key protection: `stalekey` is a KEY-ONLY account
+//     whose keys marker (2000) mismatches its live UID (2001) — an out-of-band
+//     userdel+recreate. Its current authorized_keys belongs to SOMEONE ELSE, so
+//     the sweep must leave the file AND retain the marker rather than delete an
+//     operator's keys.
+//
+// zeroizeLoginAccounts returns a non-nil error (both are surfaced fail-closed
+// conditions), which is the expected outcome — the point of this test is the
+// non-destructive preservation, not a clean reset.
+func TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	keyDir := filepath.Join(root, "provisioned-keys")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	// retain: registry marker UID 3000 but live UID 3001 (out-of-band recreate) →
+	// registry teardown retains. It also carries a keys marker + a key file.
+	// stalekey: KEY-ONLY, keys marker UID 2000 but live UID 2001 (recreate).
+	mustWriteFile(t, passwdPath, []byte(
+		"retain:x:3001:3001:retain:/home/retain:/bin/bash\n"+
+			"stalekey:x:2001:2001:stalekey:/home/stalekey:/bin/bash\n"))
+
+	retainUsersMarker := filepath.Join(provDir, "retain")
+	retainKeyMarker := filepath.Join(keyDir, "retain")
+	mustWriteFile(t, retainUsersMarker, []byte("3000")) // != live 3001 → retained
+	mustWriteFile(t, retainKeyMarker, []byte("3000"))
+	retainKeys := filepath.Join(homeBase, "retain", ".ssh", "authorized_keys")
+	mustWriteFile(t, retainKeys, []byte("ssh-ed25519 AAAAnew retain-newowner\n"))
+
+	stalekeyMarker := filepath.Join(keyDir, "stalekey")
+	mustWriteFile(t, stalekeyMarker, []byte("2000")) // != live 2001 → mismatch
+	stalekeyKeys := filepath.Join(homeBase, "stalekey", ".ssh", "authorized_keys")
+	mustWriteFile(t, stalekeyKeys, []byte("ssh-ed25519 AAAAnew stalekey-newowner\n"))
+
+	_ = setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("zeroizeLoginAccounts with retained + UID-mismatch key markers returned nil; want the unresolved conditions surfaced")
+	}
+
+	// Retained account (registry teardown kept): key marker AND key file preserved
+	// so the account's markers stay together for a retry.
+	assertPresent(t, retainUsersMarker)
+	assertPresent(t, retainKeyMarker) // keys sweep skipped it (retained)
+	assertPresent(t, retainKeys)      // someone else's recreated home — untouched
+
+	// UID-mismatch key-only account: the recreated owner's keys and the marker are
+	// left intact (never delete an operator's keys).
+	assertPresent(t, stalekeyKeys)
+	assertPresent(t, stalekeyMarker)
+}

--- a/pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go
+++ b/pkg/grpcapi/zeroize_login_keyonly_authkeys_6190_test.go
@@ -32,25 +32,29 @@ import (
 // key file (no marker) is left untouched. No userdel fires — xpf only added a
 // key, it did not create the account.
 //
-// RED on revert (two equivalent neutralizations, both clean assertion failures,
-// neither a compile break):
+// RED on revert of the #6190 key-file-removal binding (clean assertion failures,
+// no compile break). The key removal now lives in the shared
+// zeroizeRemoveKeyFileThenMarker helper (#6201):
 //
-//   - Surgical (target count 1): comment out the single
-//     `fail(os.Remove(keysFile))` in zeroizeSweepProvisionedKeys' `default`
-//     (UID-match) branch — the exact key-file removal this account exercises.
-//     `keysFile` stays used by the genuinely-absent branch, so it still compiles;
-//     the keyonly marker is still swept, but the xpf-written authorized_keys FILE
-//     SURVIVES, so `assertAbsent(keyonlyKeys)` here goes RED. Exactly this test
-//     fails — target count 1.
-//   - Broad (target count 2): revert the phase-(C) keys-root sweep call in
-//     zeroizeLoginAccounts from `zeroizeSweepProvisionedKeys(...)` back to
+//   - Surgical: make the helper's `os.Remove(keysFile)` a no-op (e.g. replace it
+//     with `keyErr := error(nil)`). It still compiles; the keyonly marker is
+//     still swept, but the xpf-written authorized_keys FILE SURVIVES, so
+//     `assertAbsent(keyonlyKeys)` here goes RED (the canonical #6190 pin). The
+//     #6201 retain tests also trip, since a no-op removal leaves keyErr nil and
+//     the marker is dropped on the failing-key accounts they seed.
+//   - Broad: revert the phase-(C) keys-root sweep call in zeroizeLoginAccounts
+//     from `zeroizeSweepProvisionedKeys(...)` back to
 //     `zeroizeSweepResourceMarkerRoot(zeroizeProvisionedKeysDir(), retained,
-//     fail)` (the marker-only sweep). That also drops the UID-gated fail-closed
-//     retention, so BOTH this test (key file survives) AND
-//     TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys (the UID-mismatch marker
-//     is erased instead of retained) go RED — target count 2.
+//     fail)` (the marker-only sweep). The key file is never touched (survives)
+//     AND the UID-gated fail-closed retention is dropped, so this test,
+//     TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys, and the #6201 retain
+//     tests all go RED.
 //
-// No other test seeds a key-only account and asserts its key-file removal.
+// The #6201 retain-on-error binding (the marker is RETAINED on a real key-removal
+// error) has its own tests below — TestZeroizeKeyOnlyRetainsMarkerOnKeyRemovalError
+// and TestZeroizeKeyOnlyOrphanRetainsMarkerOnKeyRemovalError — whose neutralization
+// (revert the helper's marker gate to an unconditional `fail(os.Remove(markerFile))`)
+// leaves this happy-path test unaffected.
 func TestZeroizeRemovesKeyOnlyAccountAuthorizedKeys(t *testing.T) {
 	root := t.TempDir()
 	provDir := filepath.Join(root, "provisioned-users")
@@ -167,4 +171,107 @@ func TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys(t *testing.T) {
 	// left intact (never delete an operator's keys).
 	assertPresent(t, stalekeyKeys)
 	assertPresent(t, stalekeyMarker)
+}
+
+// TestZeroizeKeyOnlyRetainsMarkerOnKeyRemovalError pins the #6201 retain-on-error
+// gap in the proven-owned (default) branch of zeroizeSweepProvisionedKeys. A
+// key-only account is PROVEN-OWNED (live /etc/passwd UID == keys-marker UID), so
+// the sweep tries to remove its xpf-written authorized_keys and then drop the
+// keys marker. If the key removal hits a REAL error (an immutable file, an
+// ENOTDIR/ENOTEMPTY path shape, an I/O error) the key SURVIVES. The marker must
+// then be RETAINED — mirroring the day-2 deprovisionLoginUser contract, which
+// KEEPS the provenance markers and retries on a real authorized_keys removal
+// error — so a retried factory reset re-enumerates the account (the keys marker
+// is what makes a key-only account discoverable) and re-attempts the removal.
+// Dropping the marker while the key file survives would strand the prior tenant's
+// SSH key with no retry evidence, and unlike the account-registry teardown there
+// is no `userdel -r` backstop that would delete the whole home tree.
+//
+// The removal error is constructed WITHOUT root by making the authorized_keys
+// PATH a non-empty DIRECTORY: os.Remove on a non-empty directory returns
+// ENOTEMPTY, a real (non-ErrNotExist) error, so the retain-on-error gate fires.
+//
+// RED on revert: change zeroizeRemoveKeyFileThenMarker's gated marker removal
+// back to the unconditional `fail(os.Remove(markerFile))`. The key removal still
+// fails (surfaced), but the marker is then dropped anyway, so
+// `assertPresent(keyonlyMarker)` here goes RED. The #6190 happy-path test
+// (successful key removal, keyErr == nil) is UNAFFECTED — the gate only diverges
+// on the key-removal failure path.
+func TestZeroizeKeyOnlyRetainsMarkerOnKeyRemovalError(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	keyDir := filepath.Join(root, "provisioned-keys")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	// Proven-owned key-only account: live at UID 1500, keys marker records 1500,
+	// NO registry / password marker → the default (UID-match) branch of the sweep.
+	mustWriteFile(t, passwdPath, []byte(
+		"keyonly:x:1500:1500:keyonly:/home/keyonly:/bin/bash\n"))
+	keyonlyMarker := filepath.Join(keyDir, "keyonly")
+	mustWriteFile(t, keyonlyMarker, []byte("1500"))
+
+	// Make authorized_keys a NON-EMPTY DIRECTORY so os.Remove(keysFile) fails with
+	// ENOTEMPTY — a real, non-ErrNotExist key-removal error, no root required.
+	keyonlyKeys := filepath.Join(homeBase, "keyonly", ".ssh", "authorized_keys")
+	mustWriteFile(t, filepath.Join(keyonlyKeys, "sentinel"), []byte("blocks os.Remove\n"))
+
+	_ = setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	// The reset is reported INCOMPLETE: the key-removal error is surfaced.
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("zeroizeLoginAccounts returned nil despite an unremovable key file; want the key-removal error surfaced")
+	}
+
+	// The #6201 fix: the key marker is RETAINED (still present) so a retried reset
+	// re-enumerates this account. Before the fix the marker was dropped even though
+	// the key file survived, losing the retry evidence.
+	assertPresent(t, keyonlyMarker) // RED on revert of the retain-on-error gate
+	assertPresent(t, keyonlyKeys)   // the surviving (unremovable) key dir
+}
+
+// TestZeroizeKeyOnlyOrphanRetainsMarkerOnKeyRemovalError pins the SAME
+// retain-on-error contract in the genuinely-absent (!curFound) branch of
+// zeroizeSweepProvisionedKeys. Here the account is gone from /etc/passwd (an
+// out-of-band userdel) but an xpf-written authorized_keys residue and its keys
+// marker remain. The sweep removes the orphaned residue and drops the stale
+// marker — but ONLY when the residue removal succeeded. On a real removal error
+// the residue SURVIVES (a prior-tenant key still on disk), so the marker is
+// RETAINED so a retried reset re-attempts, exactly as in the proven-owned branch.
+//
+// RED on revert: same neutralization as the proven-owned test — revert
+// zeroizeRemoveKeyFileThenMarker's gated marker removal to unconditional. The
+// orphan residue removal fails (surfaced), the marker is dropped anyway, and
+// `assertPresent(orphanMarker)` goes RED.
+func TestZeroizeKeyOnlyOrphanRetainsMarkerOnKeyRemovalError(t *testing.T) {
+	root := t.TempDir()
+	provDir := filepath.Join(root, "provisioned-users")
+	keyDir := filepath.Join(root, "provisioned-keys")
+	sudoersDir := filepath.Join(root, "sudoers.d")
+	homeBase := filepath.Join(root, "home")
+	passwdPath := filepath.Join(root, "passwd")
+
+	// /etc/passwd is READABLE but does NOT contain "orphan": the account is
+	// genuinely absent (curFound=false, lookupErr=nil) → the !curFound branch.
+	mustWriteFile(t, passwdPath, []byte(
+		"someoneelse:x:1000:1000:someoneelse:/home/someoneelse:/bin/bash\n"))
+
+	// Orphaned keys marker + xpf-written key residue for the absent account.
+	orphanMarker := filepath.Join(keyDir, "orphan")
+	mustWriteFile(t, orphanMarker, []byte("1600"))
+
+	// Residue authorized_keys as a NON-EMPTY DIRECTORY → os.Remove fails ENOTEMPTY.
+	orphanKeys := filepath.Join(homeBase, "orphan", ".ssh", "authorized_keys")
+	mustWriteFile(t, filepath.Join(orphanKeys, "sentinel"), []byte("blocks os.Remove\n"))
+
+	_ = setZeroizeLoginPaths(t, provDir, sudoersDir, homeBase, passwdPath)
+
+	if err := zeroizeLoginAccounts(); err == nil {
+		t.Fatalf("zeroizeLoginAccounts returned nil despite an unremovable orphan key residue; want the removal error surfaced")
+	}
+
+	// The marker is RETAINED so the surviving orphan residue is re-attempted.
+	assertPresent(t, orphanMarker) // RED on revert of the retain-on-error gate
+	assertPresent(t, orphanKeys)   // the surviving (unremovable) residue dir
 }


### PR DESCRIPTION
## Summary

- **Fixes a factory-reset credential leak (#6190).** A pre-existing (operator / prior-tenant) account configured with `system login user <name> authentication ssh-*` and **no** `encrypted-password` gets a `provisioned-keys` marker but **no** `provisioned-users` registry marker (`applySystemLogin` writes `markProvisioned` only in the useradd branch; `reconcileUserPassword` only on a password apply). The zeroize teardown removed `~/.ssh/authorized_keys` only for **registry**-marked accounts, so this **key-only** account's xpf-written `authorized_keys` **file** survived a factory reset — the prior tenant kept SSH login on that account (the #4598 credential-leak class). The #6183 fix already sweeps the keys **marker**; this closes the residual **file** leak.
- **Asymmetry closed.** The day-2 path (`reconcileAbsentLoginUsers`) enumerates the **union** `provisionedNames()` and `deprovisionLoginUser` **does** remove that key file, gated on `keyProvisioned`. This PR makes the factory-reset teardown mirror it.
- **Fix.** Phase (C) of `zeroizeLoginAccounts` now sweeps the `provisioned-keys` root via a new `zeroizeSweepProvisionedKeys` (replacing the marker-only `zeroizeSweepResourceMarkerRoot` on that root). Alongside erasing each keys marker it removes the xpf-written `/home/<name>/.ssh/authorized_keys` **file** — the union delta the registry loop misses — mirroring `deprovisionLoginUser`'s `keyProvisioned`-gated `os.Remove(managedAuthorizedKeysPath(name))`.

## Safety (preserves retained-set #6183 + fail-closed #5496)

- **UID-gated:** the file is removed only when the live `/etc/passwd` UID equals the keys marker's recorded UID. A proven **UID-mismatch** is an out-of-band recreate whose `authorized_keys` belongs to someone else → left intact, marker **retained**.
- **Only what xpf wrote:** an operator's own (unmarked) `authorized_keys` is never enumerated, never touched.
- **Fail-closed on uncertainty:** unreadable `/etc/passwd` or unparseable keys marker → retain the marker, surface the error (a partial reset is never reported clean).
- **Retained accounts skipped:** an account whose registry teardown was kept for a fail-closed retry keeps its keys marker **and** key file untouched.
- **root skipped:** root is never key-only (`applyRootAuth` writes both markers) and its keys live at `/root/.ssh`, revoked in place by `zeroizeRootLoginAccount` — this sweep never touches a `/home/root` key file.

## Test plan

- [x] `TestZeroizeRemovesKeyOnlyAccountAuthorizedKeys` — live key-only account: asserts marker **and** file removed, no `userdel`, operator's own key file survives. **Fail-on-revert:** neutralizing the `default`-branch `fail(os.Remove(keysFile))` makes exactly this test RED (clean assertion failure — `keysFile` stays used by the absent branch, so it still compiles). Target count 1.
- [x] `TestZeroizeKeyOnlyRetainedAndMismatchPreserveKeys` — retained-set preservation + UID-mismatch operator-key protection.
- [x] `go build ./...`, `go vet ./pkg/grpcapi/`, `go test ./pkg/grpcapi/... ./pkg/daemon/...` all pass.
- **No smoke:** control-plane / unit-provable, no dataplane or forwarding surface.

## Docs

- `docs/system-login.md` factory-reset section documents the key-file removal, UID-gating, fail-closed, retained-skip, and root/operator exclusions.

## Refs

- Closes #6190
- Related: #6183 (keys-marker sweep), #5841 (resource marker roots), #4598 (login-account teardown), #5496 (fail-closed uncertainty), #5520 (root in-place revocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FPXzWVE4nowUCSfNZCsJP