### PR TITLE
dataplane/userspace: share key-absent predicate across HA snapshot layers (#6194)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54761,3 +54761,39 @@ top.
 - **File(s)**: pkg/api/config.go,
   pkg/api/config_session_holder_5870_test.go (new),
   pkg/configstore/README.md, _Log.md
+
+## 2026-07-21 — #6194 Layer-2 snapshot key-absent predicate parity
+
+- **Timestamp**: 2026-07-21
+- **Action**: Fix Layer-2/Layer-1 consistency nit — the #5305 transactional
+  cluster-synced install snapshot (`snapshotBPFSessionV4Locked` /
+  `snapshotBPFSessionV6Locked` in `pkg/dataplane/userspace/manager_ha.go`)
+  classified "key absent" with `errors.Is(err, ebpf.ErrKeyNotExist)` ONLY,
+  while the sibling Layer-1 `sessionNotFound` predicate
+  (`pkg/dataplane/session_store.go`) accepts BOTH `ebpf.ErrKeyNotExist` AND
+  `unix.ENOENT`. With the production cilium `bpfShim` the two sentinels never
+  diverge (a missing lookup yields `ErrKeyNotExist`, not bare `ENOENT`) and the
+  Layer-2 direction was already fail-safe, so this is a consistency fix, not a
+  live bug — but the two transaction layers now agree on what "key absent"
+  means. Extracted a package-level `bpfSessionReadAbsent(err)` seam that reuses
+  the EXPORTED shared `dataplane.IsKeyNotFound` predicate (the Layer-1-equivalent
+  `ErrKeyNotExist || ENOENT` set), and routed BOTH snapshot functions through it.
+  Fail-safe direction preserved: any NON-absent read error is still surfaced and
+  the install refused (never broadened to swallow real errors). Restore
+  delete-idempotency checks (`!errors.Is(err, ebpf.ErrKeyNotExist)`) left
+  untouched — distinct operation (DeleteSession, not GetSession), real-map
+  delete-absent returns `ErrKeyNotExist`, and #6194 scopes to the snapshot's
+  read-classification. Fail-on-revert test pins the seam directly (no live map /
+  no root): `bpfSessionReadAbsent` must classify `unix.ENOENT` identically to
+  `ebpf.ErrKeyNotExist` (both absent) and must NOT classify a genuine read error
+  (EFAULT / map-not-found) as absent. Neutralize by reverting
+  `bpfSessionReadAbsent` to `errors.Is(err, ebpf.ErrKeyNotExist)` → the
+  `unix.ENOENT` + `wrapped unix.ENOENT` subtests and the identity assertion go
+  RED (clean assertion failure, not a compile break — `ebpf` stays imported via
+  `mergeHAStateFromMaps` + the restore checks). Validation: `go build ./...`,
+  `go vet ./pkg/dataplane/...`, `go test ./pkg/dataplane/...` (non-root + root
+  incl. the #5305 rollback tests) all pass. Control-plane / unit-provable — no
+  smoke.
+- **File(s)**: pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/snapshot_enoent_consistency_6194_test.go (new),
+  docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -83,6 +83,17 @@ sticky mirror-failed flag but do NOT restore the BPF pre-image. Reverse entries
 are never mirrored to the helper (it synthesizes the reverse companion locally),
 so they take no compensation — they only write the BPF mirror.
 
+The pre-image snapshot's *absent* classification (`snapshotBPFSessionV4Locked` /
+`snapshotBPFSessionV6Locked` → `bpfSessionReadAbsent`) accepts the SAME
+key-not-found error set as the Layer-1 `dataplane.sessionNotFound` predicate —
+`ebpf.ErrKeyNotExist` OR `unix.ENOENT`, via the shared `dataplane.IsKeyNotFound`
+helper (#6194) — so both transaction layers agree on what "key absent" means.
+Any OTHER read error is surfaced and the install is refused (the fail-safe
+direction): the snapshot never guesses a pre-image it could not read. With the
+production cilium `bpfShim` the two sentinels never diverge (a missing lookup
+yields `ErrKeyNotExist`, not bare `ENOENT`), so this is a consistency fix rather
+than a live-bug fix.
+
 Locally-created forward sessions take a parallel path: `SetSessionV4()` /
 `SetSessionV6()` install into the kernel/BPF maps, then mirror the forward
 entry **and a pre-installed reverse companion** (#310 — so the helper holds the

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1141,6 +1141,24 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 	return nil
 }
 
+// bpfSessionReadAbsent reports whether a bpfShim session GET error means the
+// key is ABSENT rather than a hard read failure. The transactional snapshot
+// (#5305) treats an absent pre-image as existed=false with a nil error so a
+// later mirror-failure rollback DELETES the freshly-installed key; any OTHER
+// read error is surfaced so the install is refused rather than leaving an
+// entry that could not be rolled back (the fail-safe direction).
+//
+// It accepts the SAME key-absent error set as the Layer-1
+// dataplane.sessionNotFound predicate — ebpf.ErrKeyNotExist OR unix.ENOENT,
+// via the shared dataplane.IsKeyNotFound helper — so the two transaction
+// layers agree on what "key absent" means (#6194). With the production cilium
+// bpfShim the two sentinels never diverge (a missing lookup yields
+// ErrKeyNotExist, not bare ENOENT), so this is a consistency fix, not a live
+// bug; sharing one predicate removes the latent skew.
+func bpfSessionReadAbsent(err error) bool {
+	return dataplane.IsKeyNotFound(err)
+}
+
 // snapshotBPFSessionV4Locked reads the current BPF-mirror value for key so a
 // failed cluster-synced install can be rolled back to it (#5305). Returns
 // (value, existed, err); a missing key is existed=false with a nil error.
@@ -1149,7 +1167,7 @@ func (m *Manager) SetClusterSyncedSessionV4(key dataplane.SessionKey, val datapl
 func (m *Manager) snapshotBPFSessionV4Locked(key dataplane.SessionKey) (dataplane.SessionValue, bool, error) {
 	val, err := m.bpfShim.GetSessionV4(key)
 	if err != nil {
-		if errors.Is(err, ebpf.ErrKeyNotExist) {
+		if bpfSessionReadAbsent(err) {
 			return dataplane.SessionValue{}, false, nil
 		}
 		return dataplane.SessionValue{}, false, err
@@ -1264,7 +1282,7 @@ func (m *Manager) SetClusterSyncedSessionV6(key dataplane.SessionKeyV6, val data
 func (m *Manager) snapshotBPFSessionV6Locked(key dataplane.SessionKeyV6) (dataplane.SessionValueV6, bool, error) {
 	val, err := m.bpfShim.GetSessionV6(key)
 	if err != nil {
-		if errors.Is(err, ebpf.ErrKeyNotExist) {
+		if bpfSessionReadAbsent(err) {
 			return dataplane.SessionValueV6{}, false, nil
 		}
 		return dataplane.SessionValueV6{}, false, err

--- a/pkg/dataplane/userspace/snapshot_enoent_consistency_6194_test.go
+++ b/pkg/dataplane/userspace/snapshot_enoent_consistency_6194_test.go
@@ -1,0 +1,73 @@
+package userspace
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+)
+
+// TestBPFSessionReadAbsentMatchesLayer1ErrorSet pins the #6194 consistency
+// contract: the Layer-2 transactional-snapshot "key absent" classifier
+// (bpfSessionReadAbsent, used by snapshotBPFSessionV4Locked /
+// snapshotBPFSessionV6Locked) must accept the SAME key-not-found error set as
+// the Layer-1 dataplane.sessionNotFound predicate — ebpf.ErrKeyNotExist OR
+// unix.ENOENT (both, via dataplane.IsKeyNotFound).
+//
+// The snapshot classifies an absent pre-image as existed=false with a nil
+// error, so a subsequent mirror-failure rollback DELETES the freshly-installed
+// key rather than surfacing the read error and refusing the install. If ENOENT
+// is treated as a hard error instead, the install would be refused where
+// Layer-1 would have proceeded — the divergence #6194 closes.
+//
+// bpfShim is a concrete *dataplane.Manager backed by a real cilium map, whose
+// GetSession* returns ErrKeyNotExist (never bare ENOENT) on a miss, so the
+// ENOENT path is not reachable through a live map. This test therefore pins the
+// classification seam directly — no BPF map, no root required.
+//
+// RED-on-revert: change bpfSessionReadAbsent's body in manager_ha.go from
+//
+//	return dataplane.IsKeyNotFound(err)
+//
+// back to the pre-#6194
+//
+//	return errors.Is(err, ebpf.ErrKeyNotExist)
+//
+// and the ENOENT (bare + wrapped) and identity assertions below fail with a
+// clean assertion error — not a compile break (ebpf stays imported via
+// mergeHAStateFromMaps and the restore delete-idempotency checks).
+func TestBPFSessionReadAbsentMatchesLayer1ErrorSet(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantAbsent bool
+	}{
+		{"ebpf.ErrKeyNotExist", ebpf.ErrKeyNotExist, true},
+		{"unix.ENOENT", unix.ENOENT, true},
+		{"wrapped ebpf.ErrKeyNotExist", fmt.Errorf("lookup v4: %w", ebpf.ErrKeyNotExist), true},
+		{"wrapped unix.ENOENT", fmt.Errorf("lookup v4: %w", unix.ENOENT), true},
+		// Fail-safe direction: a genuine read error is NOT "absent" — it must be
+		// surfaced so the install is refused, never silently treated as a
+		// missing pre-image.
+		{"unix.EFAULT", unix.EFAULT, false},
+		{"generic read error", errors.New("sessions map not found"), false},
+		// nil is not a not-found error (the snapshot handles a nil GET as
+		// "found" before consulting this predicate).
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bpfSessionReadAbsent(tc.err); got != tc.wantAbsent {
+				t.Fatalf("bpfSessionReadAbsent(%v) = %v, want %v", tc.err, got, tc.wantAbsent)
+			}
+		})
+	}
+
+	// The ENOENT-absent path must behave IDENTICALLY to the ErrKeyNotExist-absent
+	// path — the whole point of #6194.
+	if got, want := bpfSessionReadAbsent(unix.ENOENT), bpfSessionReadAbsent(ebpf.ErrKeyNotExist); got != want {
+		t.Fatalf("ENOENT/ErrKeyNotExist divergence: bpfSessionReadAbsent(ENOENT)=%v, bpfSessionReadAbsent(ErrKeyNotExist)=%v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- The #5305 transactional cluster-synced session install snapshots the pinned BPF mirror pre-image so a helper-mirror failure can roll the entry back. Its **Layer-2** "key absent" classification (`snapshotBPFSessionV4Locked` / `snapshotBPFSessionV6Locked` in `pkg/dataplane/userspace/manager_ha.go`) matched only `errors.Is(err, ebpf.ErrKeyNotExist)`.
- The sibling **Layer-1** `sessionNotFound` predicate (`pkg/dataplane/session_store.go`) — and the exported `dataplane.IsKeyNotFound` helper it mirrors — accept **both** `ebpf.ErrKeyNotExist` **and** `unix.ENOENT`.
- With the production cilium `bpfShim` the two sentinels never diverge (a missing lookup yields `ErrKeyNotExist`, not bare `ENOENT`) and the Layer-2 direction is already fail-safe, so this is a **consistency fix, not a live bug** — but the two transaction layers should agree on what "key absent" means.
- Extracted a package-level `bpfSessionReadAbsent(err)` seam that reuses the exported shared `dataplane.IsKeyNotFound` predicate, and routed both snapshot functions through it (single source of truth).
- **Fail-safe direction unchanged**: any NON-absent read error is still surfaced and the install refused — the predicate is not broadened to swallow real errors.
- Restore delete-idempotency checks left as-is on purpose: they classify a `DeleteSession` result (not a `GetSession` result), a real-map delete-of-absent returns `ErrKeyNotExist`, and #6194 scopes to the snapshot's read-classification (narrow scope).

## Test plan

- [x] New `TestBPFSessionReadAbsentMatchesLayer1ErrorSet` pins the seam directly — **no live BPF map, no root**. Asserts `unix.ENOENT` classifies identically to `ebpf.ErrKeyNotExist` (both absent, incl. wrapped), and that a genuine read error (`EFAULT` / map-not-found) and `nil` are NOT absent (fail-safe).
- [x] **Fail-on-revert**: reverting `bpfSessionReadAbsent` to `errors.Is(err, ebpf.ErrKeyNotExist)` turns the `unix.ENOENT` + `wrapped unix.ENOENT` subtests and the identity assertion RED — a clean assertion failure, not a compile break (`ebpf` stays imported via `mergeHAStateFromMaps` + the restore checks).
- [x] `go build ./...`, `go vet ./pkg/dataplane/...`
- [x] `go test ./pkg/dataplane/...` (non-root) — pass
- [x] `go test ./pkg/dataplane/userspace/` under root incl. the existing #5305 rollback tests — pass (no regression)
- [x] Doc updated: `docs/session-sync-architecture.md` #5305 section now states the shared key-absent error contract.

## Validation lanes not run

Control-plane / unit-provable classification change — **no smoke**. No dataplane/forwarding behavior changes with the production cilium `bpfShim`.

## Refs

Closes #6194
Refs #5305 (transactional install), #5247 (sticky mirror-failed flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015psGmce9JkdUrAoCijhEEb