### PR TITLE
daemon: honor PCI domain in pciAddrToEnp RETH name derivation (#6199)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54797,3 +54797,22 @@ top.
 - **File(s)**: pkg/dataplane/userspace/manager_ha.go,
   pkg/dataplane/userspace/snapshot_enoent_consistency_6194_test.go (new),
   docs/session-sync-architecture.md, _Log.md
+
+- **Timestamp**: 2026-07-21 15:59
+- **Action**: #6199 — pciAddrToEnp now honors the PCI domain. Was
+  `strings.SplitN(pciAddr, ":", 3)` using only parts[1] (bus) + parts[2]
+  (slot.func) and DISCARDING parts[0] (domain). On multi-PCI-domain hardware
+  (domain != 0000, e.g. 10000:01:00.0) systemd's ID_NET_NAME_PATH encodes the
+  domain as a `P<domain>` segment — `en[P<domain>]p<bus>s<slot>[f<func>]` per
+  systemd.net-naming-scheme(7) ("The PCI domain is only prepended when it is
+  not 0") — so two NICs at the same bus/slot in different domains collided
+  onto one name and resolved the wrong RETH member. Fix parses parts[0] as hex
+  and emits `enP<domain>...` for non-zero domain; domain 0000 stays
+  bit-identical to the historical `enp<bus>s<slot>[f<func>]`. All components
+  hex-in / decimal-out to match systemd's `%x` scan / `%u` print. Added
+  fail-on-revert test (domain-0 pinned GREEN, domain-N + collision RED when the
+  domain segment is neutralized). Build + vet + full pkg/daemon suite pass.
+  Unit-provable — no smoke.
+- **File(s)**: pkg/daemon/daemon_reth.go,
+  pkg/daemon/daemon_reth_pciaddr_6199_test.go (new), pkg/daemon/README.md,
+  _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -278,6 +278,16 @@ based on PCI bus order plus the cluster node ID. RETH members match by
 between physical and virtual at boot, and `ensureRethLinkOriginalName()`
 auto-fixes stale `.link` files.
 
+`deriveKernelName()` synthesizes that predictable kernel name from a NIC's
+sysfs PCI address via `pciAddrToEnp()`, which mirrors systemd's
+`ID_NET_NAME_PATH` scheme (`systemd.net-naming-scheme(7)`):
+`en[P<domain>]p<bus>s<slot>[f<func>]`. The `P<domain>` segment is present
+ONLY when the PCI domain is non-zero, so single-domain systems (domain 0000
+— the test VM and loss cluster) keep the bare `enp<bus>s<slot>[f<func>]`
+form, while multi-PCI-domain hardware gets the domain prefix that stops two
+NICs at the same bus/slot in different domains from resolving to the same
+name (#6199). All fields are parsed hex / rendered decimal to match systemd.
+
 Any interface not declared in the active config is brought down and given
 `ActivationPolicy=always-down` in networkd — EXCEPT the #1922 protected set
 (see below).

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -109,9 +109,26 @@ func pciAddrFromPath(path string) string {
 
 // pciAddrToEnp converts a PCI address like "0000:08:00.0" to a predictable
 // network name like "enp8s0".
+//
+// The result must match the kernel's systemd-predictable interface name so it
+// can be compared against the live NIC (deriveKernelName feeds it into the
+// RETH-member OriginalName= lookup). systemd's ID_NET_NAME_PATH scheme
+// (systemd.net-naming-scheme(7)) is en[P<domain>]p<bus>s<slot>[f<func>]: the
+// "P<domain>" segment is prepended ONLY when the PCI domain is non-zero. For
+// the common single-domain case (domain 0000) the domain is omitted, so the
+// name is the bare enp<bus>s<slot>[f<func>]. On multi-PCI-domain hardware
+// (domain != 0, e.g. 10000:01:00.0) the domain disambiguates two NICs that sit
+// at the same bus/slot in different domains; dropping it here would collide
+// them onto one name and resolve the wrong RETH member. systemd scans the
+// sysfs address fields as hex and prints them decimal, so parse hex / render
+// decimal for every component (domain, bus, slot, func) to match.
 func pciAddrToEnp(pciAddr string) string {
 	parts := strings.SplitN(pciAddr, ":", 3)
 	if len(parts) != 3 {
+		return ""
+	}
+	domain, err := strconv.ParseUint(parts[0], 16, 32)
+	if err != nil {
 		return ""
 	}
 	bus, err := strconv.ParseUint(parts[1], 16, 16)
@@ -130,10 +147,15 @@ func pciAddrToEnp(pciAddr string) string {
 	if err != nil {
 		return ""
 	}
-	if fn > 0 {
-		return fmt.Sprintf("enp%ds%df%d", bus, slot, fn)
+	name := "en"
+	if domain > 0 {
+		name += fmt.Sprintf("P%d", domain)
 	}
-	return fmt.Sprintf("enp%ds%d", bus, slot)
+	name += fmt.Sprintf("p%ds%d", bus, slot)
+	if fn > 0 {
+		name += fmt.Sprintf("f%d", fn)
+	}
+	return name
 }
 
 // rethLinkOps groups the netlink primitives that renameRethMember and

--- a/pkg/daemon/daemon_reth_pciaddr_6199_test.go
+++ b/pkg/daemon/daemon_reth_pciaddr_6199_test.go
@@ -1,0 +1,67 @@
+package daemon
+
+import "testing"
+
+// TestPCIAddrToEnp_Domain_6199 is the #6199 fail-on-revert pin for
+// pciAddrToEnp's PCI-domain handling.
+//
+// Before the fix, pciAddrToEnp discarded parts[0] (the PCI domain) and always
+// emitted enp<bus>s<slot>[f<func>]. That is correct for the common
+// single-domain case (domain 0000, which systemd also omits), but on
+// multi-PCI-domain hardware (domain != 0) systemd encodes the domain as a
+// "P<domain>" segment — ID_NET_NAME_PATH = en[P<domain>]p<bus>s<slot>[f<func>]
+// per systemd.net-naming-scheme(7), where "The PCI domain is only prepended
+// when it is not 0." Two NICs at the same bus/slot in different domains would
+// then collide onto one predictable name, resolving the wrong RETH member.
+//
+// systemd scans the sysfs address fields as hex and renders them decimal, so
+// domain 0x10000 (sysfs "10000") becomes "P65536".
+//
+// Fail-on-revert: suppress the domain segment in pciAddrToEnp (e.g. change
+// `if domain > 0 {` to `if false {`, or delete the `name += fmt.Sprintf(
+// "P%d", domain)` line). The two domain_* subtests below go RED — the domain-N
+// output regresses to the bare enp<bus>s<slot> form and collides with domain 0
+// — while the domain0_* subtests (the pinned common case) stay GREEN. Clean
+// assertion failure, not a compile break.
+func TestPCIAddrToEnp_Domain_6199(t *testing.T) {
+	tests := []struct {
+		name string
+		pci  string
+		want string
+	}{
+		// Domain 0000: bare enp<bus>s<slot>[f<func>]. These MUST stay
+		// bit-identical to the pre-fix output — the single-domain deployments
+		// (test VM, loss cluster) are all domain 0 and must not regress.
+		{"domain0_basic", "0000:08:00.0", "enp8s0"},
+		{"domain0_slot1", "0000:01:00.0", "enp1s0"},
+		{"domain0_func1", "0000:03:00.1", "enp3s0f1"},
+		// Non-zero domain: systemd prepends P<domain> (decimal) ->
+		// enP<domain>p<bus>s<slot>[f<func>]. 0x10000 == 65536.
+		{"domainN_65536", "10000:01:00.0", "enP65536p1s0"},
+		// Non-zero domain AND non-zero function together.
+		{"domainN_func1", "0001:03:00.1", "enP1p3s0f1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pciAddrToEnp(tt.pci); got != tt.want {
+				t.Fatalf("pciAddrToEnp(%q) = %q, want %q", tt.pci, got, tt.want)
+			}
+		})
+	}
+
+	// The domain must actually disambiguate: two NICs at the same bus/slot in
+	// different PCI domains must NOT map to the same predictable name.
+	if a, b := pciAddrToEnp("10000:01:00.0"), pciAddrToEnp("0000:01:00.0"); a == b {
+		t.Fatalf("PCI-domain collision: pciAddrToEnp(10000:01:00.0)=%q == pciAddrToEnp(0000:01:00.0)=%q", a, b)
+	}
+	if a, b := pciAddrToEnp("0001:03:00.1"), pciAddrToEnp("0000:03:00.1"); a == b {
+		t.Fatalf("PCI-domain collision (func): pciAddrToEnp(0001:03:00.1)=%q == pciAddrToEnp(0000:03:00.1)=%q", a, b)
+	}
+
+	// Preserve the existing guards: malformed input still returns "".
+	for _, bad := range []string{"", "notpci", "0000:zz:00.0", "0000:01:00", "0000:01:zz.0", "0000:01:00.z"} {
+		if got := pciAddrToEnp(bad); got != "" {
+			t.Fatalf("pciAddrToEnp(%q) = %q, want \"\" (malformed input guard)", bad, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `pciAddrToEnp` (`pkg/daemon/daemon_reth.go`) split a sysfs PCI address `DOMAIN:BUS:SLOT.FUNC` but used only `parts[1]` (bus) + `parts[2]` (slot.func), **discarding `parts[0]` (the PCI domain)** — it always emitted `enp<bus>s<slot>[f<func>]`.
- Correct for the common single-domain case (domain `0000`, which systemd also omits), but on **multi-PCI-domain hardware** (domain != `0000`, e.g. `10000:01:00.0`) systemd encodes the domain in the name. Two NICs at the same bus/slot in different domains collided onto one name here → `deriveKernelName` → the RETH-member `OriginalName=` lookup resolved the **wrong member** (or failed to match the real kernel name).
- Fix incorporates the domain per systemd's `ID_NET_NAME_PATH` scheme (`systemd.net-naming-scheme(7)`): `en[P<domain>]p<bus>s<slot>[f<func>]`, where *"The PCI domain is only prepended when it is not 0."* Domain `0000` stays **bit-identical** to the prior output; a non-zero domain gets the `enP<domain>...` prefix.
- systemd scans the sysfs fields as hex and renders them decimal (`%x` scan / `%u` print) — so the domain is parsed hex / rendered decimal, matching the convention already used for bus/slot/func (`0x10000` → `P65536`). All existing guards (SplitN length, every `ParseUint` error → `""`) preserved.

## Authoritative source for the non-zero-domain form

`systemd.net-naming-scheme(7)` — `ID_NET_NAME_PATH = prefix[Pdomain]pbus sslot[ffunction]...`, and: *"The PCI domain is only prepended when it is not 0."* Matches systemd's `net_id` builtin (`names_pci` / `dev_pci_slot`), which scans `%x:%x:%x.%u` and prints `P%u` decimal for the domain.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/daemon/`
- [x] `go test ./pkg/daemon/...` — full suite green
- [x] **Fail-on-revert** (`daemon_reth_pciaddr_6199_test.go`): neutralizing `if domain > 0 {` → `if false {` turns `TestPCIAddrToEnp_Domain_6199` **RED** (subtests `domainN_65536`, `domainN_func1`, plus the domain-collision assertion) while the `domain0_*` subtests stay **GREEN** — the common case is pinned. Clean assertion failure, not a compile break.

## Scope / risk

Control-plane, unit-provable. Domain-0 deployments (test VM, loss cluster) are unaffected — output bit-identical. No smoke required.

## Docs

`pkg/daemon/README.md` interface-management section updated to document the domain-aware derivation and its systemd source.

Closes #6199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFDKZr9LXfoiWmwyHjyzTV