### PR TITLE
cluster: re-prime outbound bulk on every both-fabric reconnect (#5480)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-21 — #5480 fix: re-prime outbound bulk on every both-fabric reconnect
+
+- **Timestamp**: 2026-07-21 (fix/5480-reconnect-reprime)
+- **Action**: A survivor skipped re-pushing its authoritative session table when
+  a rebooted peer reconnected, so the standby ended with NO synced sessions and
+  blackholed established flows on the next failover to it. The reconnect bulk was
+  gated on `coldStart := !bulkEverCompleted.Load()` — a sticky, process-local
+  atomic that stays true forever on the survivor even though the peer's table AND
+  the peer's own flag reset on reboot. The handshake carries no peer-cold /
+  boot-incarnation / session-count signal (and an unkeyed dual-accept peer sends
+  no HELLO), so the survivor cannot locally distinguish a rebooted peer from a
+  fabric flap. Fix: on `wasDisconnected` (first connection after a both-fabric
+  disconnect) ALWAYS `doBulkSync`, unconditionally. Re-priming is idempotent
+  (receiver upserts; peer `reconcileStaleSessions` prunes) and a both-fabric
+  outage may have dropped deltas anyway. Bounded — fires only on a both-fabric
+  down→up transition, never a routine single-fabric flip (those still don't
+  re-bulk). Preserves #5450 `forceResync` consume + re-arm-on-failure and the
+  #4360/#4090 `outboundBulkAcked` re-drive (untouched). Tradeoff: reverses the
+  #466 reconnect-skip optimization for the full-reconnect case (correctness over
+  the redundant bulk); the surgical alternative needs a peer boot-incarnation
+  wire field (deferred, tracked on #5480).
+- **Fail-on-revert**: `TestHandleNewConnectionReconnectRePrimesBulkSync`
+  (pkg/cluster) — bulkEverCompleted=true, forceResync=false, drive
+  `handleNewConnection` on a fresh conn, assert `PendingBulkAck()` ok (bulk
+  pushed). Neutralize by re-gating `doBulkSync` on `coldStart || forcedConsumed`
+  → RED (bulk skipped). Verified: exactly 1 test fails on neutralization; cold-
+  start + active-fabric-flip + non-active-redundant siblings stay green.
+- **Validation**: `go build ./...`, `go vet ./pkg/cluster/`, `go test -race
+  ./pkg/cluster/...` all pass. Cluster session-sync → needs a loss-cluster
+  failover smoke (lab-bound, batched by lead).
+- **File(s)**: pkg/cluster/sync_conn.go, pkg/cluster/sync_test.go,
+  docs/session-sync-architecture.md, _Log.md
+
 ## 2026-07-21 — #5674 fix: size synced-import cap to ENTRIES (2×), gate forward-only
 
 - **Timestamp**: 2026-07-21 (fix/5674-synced-import-cap, #6172 hostile-review MAJOR)

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -339,6 +339,41 @@ Important current behavior:
 This exists because failover admission now depends on the standby having both
 sides of the current-generation baseline, not just having received one bulk.
 
+### Reconnect Re-Prime (#5480)
+
+On the **first connection after a full (both-fabric) disconnect**
+(`handleNewConnection`, `wasDisconnected == true`), the survivor **always**
+re-pushes its authoritative session table (`doBulkSync`) — it no longer gates
+that bulk on the sticky, process-local `bulkEverCompleted` flag.
+
+The old gate (`coldStart := !bulkEverCompleted.Load()`) skipped the bulk on any
+reconnect once the survivor had completed one bulk. But `bulkEverCompleted` is
+sticky and per-process: when the **peer** daemon rebooted, its session table AND
+its own flag reset, yet the survivor's flag stayed true — so the survivor logged
+"skipping bulk sync on reconnect (already primed)" and never re-primed the peer.
+The rebooted standby then held **no** synced sessions and blackholed every
+established flow on the next failover to it.
+
+The survivor cannot locally tell a rebooted peer (empty table, needs priming)
+from a pure fabric flap (peer kept its table): the sync handshake
+(`performSyncHandshake`) carries no peer-cold / boot-incarnation / session-count
+signal, and an unkeyed dual-accept peer sends no HELLO at all. So it re-primes
+unconditionally. Re-priming is safe and idempotent — the receiver upserts every
+session and `reconcileStaleSessions` (run at `BulkEnd`) prunes anything the
+survivor no longer owns — and a both-fabric outage may have dropped incremental
+deltas anyway, so the "already primed" assumption does not hold even for a peer
+that never rebooted.
+
+Cost and scope: this fires **only** on a both-fabric down→up transition. A
+routine single-fabric flip does NOT reach this arm (it hits the
+`becameActive`/`else` branches, which still do not re-bulk), so the redundant
+transfer is bounded to genuine full-reconnect events. This intentionally
+reverses the pre-#5480 #466 "skip bulk on reconnect" optimization for the
+`wasDisconnected` case: correctness (a rebooted standby must not blackhole) beats
+one redundant bulk on a full-reconnect flap. A more surgical fix that keeps the
+#466 flap-suppression would need a peer boot-incarnation field in the sync
+handshake — a wire change tracked on #5480 and deferred.
+
 ## Incremental Sweep and Delete Journal
 
 ### Background Sweep
@@ -1279,7 +1314,11 @@ whichever runs first:
   so an eviction during that flush is caught) even when the node is already
   primed (`bulkEverCompleted`),
 
-and it sends a full authoritative `doBulkSync`/`BulkSync` snapshot. The peer's
+and it sends a full authoritative `doBulkSync`/`BulkSync` snapshot. (Since #5480
+the reconnect leg **always** re-primes regardless of `forceResync`, so the CAS
+consume there is retained only to clear the arm, pick the log line, and re-arm on
+bulk failure; the **connected-sweep** leg remains the load-bearing `forceResync`
+path — it is the only way an overflow self-heals without a disconnect.) The peer's
 `reconcileStaleSessions` (run at `BulkEnd`) then DELETES any session absent from
 the snapshot — precisely the sessions the evicted deletes would have torn down.
 On a failed bulk the arm is restored so a later sweep/reconnect retries. Before

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -624,30 +624,56 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 		// Re-read the resync arm AFTER flushDeleteJournal: a rejournalTail
 		// eviction during that flush (or a journalDelete drop while we were
 		// disconnected) arms forceResync, and dropped deletes are only
-		// recoverable via a full authoritative bulk snapshot (#5450). Force the
-		// bulk even when already primed so the peer's reconcileStaleSessions
-		// deletes the sessions we already closed.
+		// recoverable via a full authoritative bulk snapshot (#5450).
 		// Consume the resync arm with CAS (symmetric with syncSweep) BEFORE the
 		// bulk, so a NEW overflow that arms forceResync DURING this bulk survives
 		// to trigger the next resync instead of being cleared by an unconditional
-		// Store(false) (#5450 MINOR 1). coldStart forces a bulk regardless of the
-		// arm; a consumed arm is re-armed on bulk failure so a later
-		// sweep/reconnect retries.
+		// Store(false) (#5450 MINOR 1); a consumed arm is re-armed on bulk
+		// failure so a later sweep/reconnect retries.
 		forcedConsumed := s.forceResync.CompareAndSwap(true, false)
-		if coldStart || forcedConsumed {
-			if forcedConsumed && !coldStart {
-				slog.Warn("cluster sync: forcing full bulk resync on reconnect after delete-journal overflow (standby may retain stale sessions)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
-			} else {
-				slog.Info("cluster sync: starting bulk sync on cold start", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+		// #5480: ALWAYS re-push our authoritative session table on a fresh
+		// connection after a full (both-fabric) disconnect — not only on a
+		// first-ever cold start (bulkEverCompleted false) or a #5450
+		// delete-journal-overflow forced resync. bulkEverCompleted is a sticky,
+		// process-local flag: once the survivor completes one bulk it stays true
+		// forever, so the old `coldStart || forcedConsumed` reconnect gate wrongly
+		// SKIPPED the re-push when the PEER rebooted and lost its session table
+		// (the peer's own flag reset to false, but ours stayed true). The rebooted
+		// peer then sends only its own empty bulk and OnPeerConnected re-pushes
+		// non-session state, so the standby ends up with NO synced sessions — and
+		// blackholes every established flow on the next failover to it.
+		//
+		// The survivor cannot locally tell a rebooted peer (empty table, needs
+		// priming) from a pure fabric flap (peer kept its table): the sync
+		// handshake carries no peer-cold / boot-incarnation / table-count signal,
+		// and an unkeyed dual-accept peer sends no HELLO at all. So it re-primes
+		// unconditionally. Re-priming is safe and idempotent — the receiver
+		// upserts every session and reconcileStaleSessions on the peer prunes what
+		// we no longer own — and a both-fabric disconnect means incremental deltas
+		// may have been missed during the outage, so the "already primed"
+		// assumption no longer holds even for a peer that never rebooted.
+		//
+		// Cost: one redundant full bulk on a genuine both-fabric flap. It is
+		// bounded — this arm fires ONLY on a both-fabric down->up transition, never
+		// on a routine single-fabric flip (those hit the becameActive/else branches
+		// below and still do NOT re-bulk). The blackhole it prevents is far worse
+		// than the redundant transfer (correctness over the optimization). A more
+		// surgical fix that keeps the #466 flap-suppression optimization needs a
+		// peer boot-incarnation field in the sync handshake — a wire change tracked
+		// on #5480 and deferred here.
+		switch {
+		case forcedConsumed && !coldStart:
+			slog.Warn("cluster sync: forcing full bulk resync on reconnect after delete-journal overflow (standby may retain stale sessions)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+		case coldStart:
+			slog.Info("cluster sync: starting bulk sync on cold start", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+		default:
+			slog.Info("cluster sync: re-priming bulk sync on reconnect (peer may have rebooted and lost its session table, #5480)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
+		}
+		if err := s.doBulkSync(); err != nil {
+			slog.Warn("cluster sync: bulk sync failed", "err", err, "fabric", fabricIdx)
+			if forcedConsumed {
+				s.forceResync.Store(true)
 			}
-			if err := s.doBulkSync(); err != nil {
-				slog.Warn("cluster sync: bulk sync failed", "err", err, "fabric", fabricIdx)
-				if forcedConsumed {
-					s.forceResync.Store(true)
-				}
-			}
-		} else {
-			slog.Info("cluster sync: skipping bulk sync on reconnect (already primed)", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
 		}
 	} else if becameActive {
 		slog.Info("cluster sync: active fabric changed, resuming incremental sync", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "active_before", activeBefore, "active_after", activeAfter)

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -4168,9 +4168,24 @@ func TestHandleNewConnectionColdStartTriggersBulkSync(t *testing.T) {
 	}
 }
 
-// TestHandleNewConnectionReconnectSkipsBulkSync verifies that a reconnect
-// after a prior bulk exchange does NOT trigger bulk sync (#466).
-func TestHandleNewConnectionReconnectSkipsBulkSync(t *testing.T) {
+// TestHandleNewConnectionReconnectRePrimesBulkSync is the #5480 RED-on-revert
+// test. A survivor that has already completed one bulk (bulkEverCompleted
+// sticky-true) must STILL re-push its authoritative session table on a fresh
+// both-fabric reconnect, because the peer may have rebooted and lost its table.
+// The survivor cannot locally distinguish a rebooted peer from a fabric flap
+// (the handshake carries no boot-incarnation), so it re-primes unconditionally.
+//
+// This intentionally REVERSES the pre-#5480 #466 optimization (which suppressed
+// the bulk on a routine reconnect): correctness — a rebooted standby must not
+// end up with an empty session table and blackhole on the next failover — beats
+// the one redundant bulk on a genuine both-fabric flap.
+//
+// Neutralization (restores the #5480 bug → this test goes RED): re-gate the
+// doBulkSync in handleNewConnection's wasDisconnected branch back on the sticky
+// flag, i.e. `if coldStart || forcedConsumed { doBulkSync } else { skip }`. With
+// bulkEverCompleted=true and forceResync=false, both are false, so the bulk is
+// skipped and PendingBulkAck() reports no pending epoch.
+func TestHandleNewConnectionReconnectRePrimesBulkSync(t *testing.T) {
 	dp := &mockSweepDP{
 		v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{
 			{SrcIP: [4]byte{10, 0, 0, 1}, DstIP: [4]byte{10, 0, 0, 2}, SrcPort: 1234, DstPort: 80, Protocol: 6}: {
@@ -4181,8 +4196,14 @@ func TestHandleNewConnectionReconnectSkipsBulkSync(t *testing.T) {
 	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
 	ss.IsPrimaryFn = func() bool { return true }
 
-	// Simulate a prior bulk exchange completing.
+	// Survivor state: it has completed a prior bulk (sticky flag true) AND the
+	// #5450 delete-journal-overflow arm is NOT set. So the ONLY thing that can
+	// drive a bulk here is the #5480 unconditional reconnect re-prime — not the
+	// cold-start path and not the forced-resync path.
 	ss.bulkEverCompleted.Store(true)
+	if ss.forceResync.Load() {
+		t.Fatal("precondition: forceResync must be unset so the re-prime is driven by #5480, not #5450")
+	}
 
 	local, peer := net.Pipe()
 	defer peer.Close()
@@ -4203,13 +4224,16 @@ func TestHandleNewConnectionReconnectSkipsBulkSync(t *testing.T) {
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// wasDisconnected=true (no existing connections), but bulkEverCompleted
-	// is true so bulk should be skipped.
+	// wasDisconnected=true (no existing connections). Even though
+	// bulkEverCompleted is sticky-true, the survivor must re-prime the peer.
 	ss.handleNewConnection(ctx, 0, local)
 
-	_, _, ok := ss.PendingBulkAck()
-	if ok {
-		t.Fatal("reconnect after prior bulk exchange should NOT trigger bulk sync (#466)")
+	epoch, _, ok := ss.PendingBulkAck()
+	if !ok {
+		t.Fatal("reconnect after a full disconnect must RE-PUSH the authoritative bulk so a rebooted peer is re-primed (#5480); bulk was wrongly skipped")
+	}
+	if epoch != 1 {
+		t.Fatalf("pending bulk epoch = %d, want 1 (one re-prime bulk sent)", epoch)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary

- A survivor **skipped re-pushing its authoritative session table** when a rebooted peer reconnected, so the standby ended with **no synced sessions** and blackholed every established flow on the next failover to it.
- `handleNewConnection` gated the reconnect bulk on `coldStart := !bulkEverCompleted.Load()` — a **sticky, process-local** atomic. Once the survivor completes one bulk it stays true forever; when the **peer** reboots its table and its own flag reset, but the survivor's flag does not, so the survivor logged "skipping bulk sync on reconnect (already primed)" and never re-primed.
- The survivor cannot locally tell a rebooted peer (empty table) from a fabric flap (peer kept its table): the sync handshake carries **no peer-cold / boot-incarnation / session-count signal**, and an unkeyed dual-accept peer sends no HELLO. So on the first connection after a full (both-fabric) disconnect (`wasDisconnected`), the survivor now **always** re-pushes the bulk (`doBulkSync`).
- Re-priming is safe and idempotent — the receiver upserts every session and `reconcileStaleSessions` (at `BulkEnd`) prunes what the survivor no longer owns — and a both-fabric outage may have dropped deltas anyway, so "already primed" no longer holds even for a peer that never rebooted.

## Scope / tradeoff

- Fires **only** on a both-fabric down→up transition; a routine single-fabric flip hits the `becameActive`/`else` branches and still does **not** re-bulk, so the redundant transfer is bounded to genuine full-reconnect events.
- Intentionally reverses the pre-#5480 **#466** "skip bulk on reconnect" optimization for the `wasDisconnected` case: correctness (a rebooted standby must not blackhole) over one redundant bulk on a full-reconnect flap.
- **Fork / deferred:** the more surgical fix that keeps the #466 flap-suppression needs a **peer boot-incarnation field in the sync handshake** (a wire change) — the approach the issue prescribes. That is a larger change (new HELLO field + length-gating + dual-accept/unkeyed fallback + arch review) and is deferred; this PR ships the smallest **correct** fix with no wire change.
- **#5450** `forceResync` preserved: CAS-consumed before the bulk and re-armed on failure (now used only to clear the arm / pick the log line, since the reconnect leg always re-primes; the connected-sweep leg remains the load-bearing `forceResync` path). **#4360/#4090** `outboundBulkAcked` re-drive is untouched — the two flags are not conflated.

## Test plan

- [x] **Fail-on-revert:** `TestHandleNewConnectionReconnectRePrimesBulkSync` (pkg/cluster) — `bulkEverCompleted=true`, `forceResync=false`, drive `handleNewConnection` on a fresh conn, assert `PendingBulkAck()` reports a pending epoch (bulk pushed). Neutralize by re-gating `doBulkSync` on `coldStart || forcedConsumed` → **RED** (bulk skipped). Verified exactly one test fails on neutralization; the cold-start / active-fabric-flip / non-active-redundant siblings stay green.
- [x] `go build ./...`, `go vet ./pkg/cluster/`, `go test -race ./pkg/cluster/...` — all pass.
- [ ] **Loss-cluster failover smoke** (`make test-failover` / `make test-ha-crash`) — cluster session-sync change, lab-bound; to be batched.

## Docs

- `docs/session-sync-architecture.md`: new "Reconnect Re-Prime (#5480)" subsection + a clarifying note in the "Delete Journal Overflow" (#5450) section on the narrowed reconnect role of `forceResync`.

## Refs

- Closes #5480
- Related: #466 (reconnect-skip optimization, reversed here), #5450 (forceResync), #4360/#4090 (outboundBulkAcked re-drive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QHPeERqiiCc8GeFaELe6z