### PR TITLE
vrrp: verify VIP release before publishing BACKUP role (#5482)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-21 — #5482 follow-up: two review MAJORs on the BACKUP VIP-verify machinery
+
+- **Timestamp**: 2026-07-21 (fix/5482-vrrp-vip-verify)
+- **Action**: A hostile review of PR #6208 found two compounding MAJOR bugs on
+  the new #5482 BACKUP-side VIP-remove-verification machinery. (1) **False
+  divergence on absent VIP:** `removeVIPsLocked` treated only ENODEV/ENOENT
+  ("not found"/"no such") as benign-already-absent, but the kernel returns
+  **EADDRNOTAVAIL** ("cannot assign requested address") when AddrDel targets an
+  absent address — the common case. On a fresh boot / restart-as-backup the
+  run-startup BACKUP removal runs against VIPs that were never present → every
+  AddrDel returned EADDRNOTAVAIL → `vipDiverged` set + reconcile scheduled that
+  retried the still-absent addr to exhaustion → the divergence flag stuck TRUE
+  for the daemon's life, cry-wolfing the diagnostic. Fixed by adding
+  `errors.Is(err, unix.EADDRNOTAVAIL)` (+ string fallback) to the benign set.
+  (2) **Re-promotion TOCTOU:** the reconcile guarded with
+  `if getState() != StateBackup` OUTSIDE `vipMu`, and `removeVIPs` did no
+  state/gen recheck under the lock, so a `becomeMaster` (which does
+  `setState(MASTER)`→`vipMu`→`addVIPsLocked`) could interleave between the
+  reconcile's check and its lock acquisition and the reconcile would strip the
+  VIP the new MASTER just added (self-blackhole). Fixed by routing the reconcile
+  through a new `removeVIPsIfBackup(gen)` that re-validates
+  `state == BACKUP && ownerGen == gen` UNDER `vipMu` before deleting (mirrors
+  `reconcileVIP`'s #5082 capture+recheck), aborting with `errReconcileSuperseded`
+  on a racing re-promotion; the reconcile captures the tenure `gen` at schedule
+  time. No deadlock — `vipMu`→`vi.mu` order matches `reconcileVIP`; `becomeMaster`
+  never holds both. Added two fail-on-revert tests:
+  `TestBackupRemoveAbsentVIPNoDivergence_5482` (table: EADDRNOTAVAIL errno +
+  "cannot assign requested address" string — RED: vipRemoveFailures=1/vipDiverged
+  when EADDRNOTAVAIL dropped from benign set) and
+  `TestBackupVIPReconcileAbortsOnRepromotion_5482` (state→MASTER and
+  BACKUP→MASTER→BACKUP gen-advance arms — RED: AddrDel fires / err=nil when the
+  under-`vipMu` recheck removed). Original 3 #5482 tests stay green. Build +
+  `go vet` + `go test -race ./pkg/vrrp/...` pass. VRRP/HA — needs a loss-cluster
+  failover smoke (batched).
+- **File(s)**: pkg/vrrp/instance.go,
+  pkg/vrrp/vip_backup_verify_5482_test.go, pkg/vrrp/README.md, _Log.md
+
 ## 2026-07-21 — #5480 fix: re-prime outbound bulk on every both-fabric reconnect
 
 - **Timestamp**: 2026-07-21 (fix/5480-reconnect-reprime)

--- a/_Log.md
+++ b/_Log.md
@@ -54994,3 +54994,31 @@ top.
   userspace-dp/src/nat/source.rs, userspace-dp/src/nat64.rs,
   userspace-dp/src/nat/tests_pool.rs, userspace-dp/src/nat64_tests.rs,
   docs/deterministic-nat-cgnat.md, _Log.md
+- **Timestamp**: 2026-07-21 17:10
+- **Action**: #5482 — BACKUP-side symmetry of the #5082 fail-closed MASTER
+  path. `becomeMaster` was already fail-closed (rolls back + reverts to
+  BACKUP + returns false when the VIP add fails), but `becomeBackup` (and
+  the run-startup BACKUP entry) still called the VOID `removeVIPs` and then
+  `emitEvent` UNCONDITIONALLY. The daemon consumes the BACKUP event to inject
+  blackholes + clear `rg_active`, so a swallowed netlink removal failure left
+  this now-BACKUP node still answering ARP for a VIP it no longer owns —
+  duplicate-address hazard against the new master, and a silent role/VIP
+  divergence. Made `removeVIPs`/`removeVIPsLocked` return the first genuine
+  AddrDel failure (an unresolvable link or "not found"/"already gone" stays a
+  non-error — no live address to strand). `becomeBackup` and the run-startup
+  entry now route the result through `surfaceStaleVIP`: on failure bump a
+  monotonic `vipRemoveFailures` counter, set `vipDiverged`, log at Error, and
+  `scheduleVIPRemoveReconcile` — a bounded async retry (5×, per-instance
+  backoff, stops on re-promotion to MASTER or shutdown) that clears the stale
+  VIP and resets `vipDiverged`. BACKUP is STILL emitted (we ARE stepping down;
+  withholding it risks split-brain) and the clean path is unchanged, so the
+  ~60 ms failover / no-master semantics are preserved. Shutdown/rollback
+  removeVIPs sites handle the new error (Warn / explicit best-effort discard).
+  Added fail-on-revert test file `vip_backup_verify_5482_test.go`:
+  `TestBecomeBackupSurfacesVIPRemoveFailure_5482` (primary — RED on revert:
+  vipRemoveFailures=0 vs want 1 when the surfacing is reverted to void
+  removeVIPs), plus a clean-path control and an async self-heal test. Build +
+  `go vet` + `go test -race ./pkg/vrrp/...` pass. VRRP/HA path — needs a
+  loss-cluster failover smoke (batched).
+- **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/manager.go,
+  pkg/vrrp/vip_backup_verify_5482_test.go, pkg/vrrp/README.md, _Log.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -148,6 +148,25 @@ This is the package that drives chassis-cluster failover.
 - Async GARP: first pair <1 ms; remaining sent at 50 ms intervals in a
   background goroutine. Critical path stays addVIPs → sendAdvert →
   emitEvent (sync), then `go sendGARP(false)` (async).
+- Verified role publication (#5082 MASTER, #5482 BACKUP): a role is
+  published via `emitEvent` only after the kernel VIP set agrees with it.
+  The daemon consumes the event to flip `rg_active`, drop/inject
+  blackholes, and start/stop per-RG services, so a role that diverges
+  from the on-wire VIP state blackholes traffic. On the **MASTER** side
+  `becomeMaster` is fail-closed: `addVIPsLocked` returns a structured
+  `vipActuationResult`, and if any required VIP fails to actuate (or a
+  concurrent demotion bumped `ownerGen`) it rolls back the partial adds,
+  reverts to `StateBackup`, emits **BACKUP**, and returns `false` — it
+  never advertises or emits MASTER for an ownership it cannot back. On
+  the **BACKUP** side `becomeBackup` still emits BACKUP (we ARE stepping
+  down — withholding it risks split-brain), but `removeVIPs` now returns
+  its netlink failure and `surfaceStaleVIP` records it (a
+  `vipRemoveFailures` counter + `vipDiverged` flag + Error log) and
+  schedules a bounded async reconcile — so a swallowed removal no longer
+  silently leaves this BACKUP still answering ARP for a VIP it lost
+  (duplicate-address hazard vs the new master). Neither path adds latency
+  on the clean case (the `vipMu` lock is uncontended), so the ~60 ms
+  failover timing is unchanged.
 - GARP suppression gates: `sendGARP(force)` has two gates — a per-epoch
   dedup (`garpEpoch`/`lastGARPEpoch`, one burst per transition) and a
   500 ms time dampener (`lastGARPTime`/`garpDampened`, storm control for

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -167,6 +167,28 @@ This is the package that drives chassis-cluster failover.
   (duplicate-address hazard vs the new master). Neither path adds latency
   on the clean case (the `vipMu` lock is uncontended), so the ~60 ms
   failover timing is unchanged.
+  - **Already-absent AddrDel is NOT a divergence.** `removeVIPsLocked`
+    treats ENODEV/ENOENT ("not found"/"no such") **and EADDRNOTAVAIL**
+    ("cannot assign requested address", the common already-absent errno)
+    as benign — the VIP was never on the interface. Without EADDRNOTAVAIL
+    a fresh boot / restart-as-backup (whose run-startup BACKUP removal runs
+    against VIPs that are not present) would set `vipDiverged` on EVERY
+    clean boot and the reconcile would retry the still-absent address to
+    exhaustion, leaving the operator-facing flag stuck TRUE — cry-wolfing
+    the exact diagnostic this machinery provides. Detection is
+    `errors.Is(err, unix.EADDRNOTAVAIL)` plus a belt-and-suspenders string
+    match.
+  - **The reconcile is re-promotion safe.** The stale-VIP reconcile runs on
+    a background goroutine; `becomeMaster` runs `setState(MASTER)` (bumping
+    `ownerGen`) BEFORE it takes `vipMu` to re-add the VIP. The reconcile
+    therefore removes VIPs through `removeVIPsIfBackup(gen)`, which
+    re-validates `state == BACKUP && ownerGen == gen` **UNDER `vipMu`**
+    (mirroring `reconcileVIP`'s capture+recheck) and aborts
+    (`errReconcileSuperseded`, no delete) on a racing re-promotion —
+    otherwise the reconcile could strip the VIP a re-promoted MASTER just
+    added (a MASTER self-blackhole). The old bare `removeVIPs` checked state
+    OUTSIDE the lock, leaving a TOCTOU window between the check and the lock
+    acquisition.
 - GARP suppression gates: `sendGARP(force)` has two gates — a per-epoch
   dedup (`garpEpoch`/`lastGARPEpoch`, one burst per transition) and a
   500 ms time dampener (`lastGARPTime`/`garpDampened`, storm control for

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -3,6 +3,7 @@ package vrrp
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -2087,6 +2088,38 @@ func (vi *vrrpInstance) surfaceStaleVIP(err error, where string) {
 	vi.scheduleVIPRemoveReconcile()
 }
 
+// errReconcileSuperseded signals that the stale-VIP reconcile observed a
+// re-promotion — state != BACKUP or the ownership generation advanced past the
+// tenure that scheduled it — while holding vipMu, so it aborted the delete
+// rather than stripping a VIP a concurrent becomeMaster just re-added (#5482
+// re-promotion TOCTOU). It is a control signal, not a failure: the goroutine
+// returns and does NOT bump vipRemoveFailures.
+var errReconcileSuperseded = errors.New("vrrp: stale-VIP reconcile superseded by re-promotion")
+
+// removeVIPsIfBackup atomically re-validates, UNDER vipMu, that this instance is
+// still the same BACKUP tenure identified by wantGen before removing the VIP set
+// (#5482 re-promotion TOCTOU fix). It mirrors reconcileVIP's capture+recheck-
+// under-lock: becomeMaster runs setState(MASTER) — which bumps ownerGen — BEFORE
+// it takes vipMu to add the VIP, so a state+generation recheck under the SAME
+// vipMu hold that would perform the delete reliably detects a racing re-promotion.
+// Without it the reconcile's bare removeVIPs (state checked OUTSIDE the lock)
+// could interleave between the check and the lock acquisition and delete the VIP
+// becomeMaster just added — a MASTER self-blackhole until the next ReconcileVIPs.
+//
+// Returns errReconcileSuperseded (no delete performed) when state != BACKUP or
+// ownerGen advanced past wantGen; otherwise returns the removeVIPsLocked outcome.
+func (vi *vrrpInstance) removeVIPsIfBackup(wantGen uint64) error {
+	vi.vipMu.Lock()
+	defer vi.vipMu.Unlock()
+	// Recheck under the lock: setState bumps ownerGen independently of vipMu, so
+	// a demotion/re-promotion that raced in is observed here even though it
+	// happened while we held vipMu (identical to reconcileVIP's revalidation).
+	if vi.getState() != StateBackup || vi.ownerGen.Load() != wantGen {
+		return errReconcileSuperseded
+	}
+	return vi.removeVIPsLocked(nil)
+}
+
 // scheduleVIPRemoveReconcile launches a bounded background retry that re-attempts
 // the VIP removal that failed during a BACKUP transition (#5482). The BACKUP role
 // is already published (we ARE a backup); this goroutine drives the kernel VIP
@@ -2095,11 +2128,20 @@ func (vi *vrrpInstance) surfaceStaleVIP(err error, where string) {
 // MASTER (it then WANTS the VIP) or the instance shuts down. Per-attempt failures
 // are logged but do NOT bump vipRemoveFailures — that counter stays a clean count
 // of BACKUP transitions whose synchronous removal failed.
+//
+// Re-promotion TOCTOU (#5482): the removal runs through removeVIPsIfBackup, which
+// re-validates state + ownerGen UNDER vipMu before deleting. Capturing the tenure
+// generation here (right after the failing BACKUP transition, which already ran
+// setState(StateBackup)) lets the retry abort if a later becomeMaster re-owns the
+// VIP — otherwise the reconcile could strip a re-promoted MASTER's VIP.
 func (vi *vrrpInstance) scheduleVIPRemoveReconcile() {
 	backoff := vi.vipReconcileBackoff
 	if backoff <= 0 {
 		backoff = defaultVIPReconcileBackoff
 	}
+	// Identity of the BACKUP tenure that failed its synchronous removal. The
+	// reconcile deletes VIPs on behalf of THIS tenure only.
+	gen := vi.ownerGen.Load()
 	go func() {
 		for attempt := 1; attempt <= vipRemoveReconcileMax; attempt++ {
 			select {
@@ -2107,11 +2149,17 @@ func (vi *vrrpInstance) scheduleVIPRemoveReconcile() {
 				return
 			case <-time.After(backoff):
 			}
-			// Re-promoted to MASTER mid-retry → we now WANT the VIP; stop.
-			if vi.getState() != StateBackup {
+			// The state/gen recheck and the delete are atomic under vipMu inside
+			// removeVIPsIfBackup, so a concurrent becomeMaster (setState(MASTER)
+			// → vipMu → addVIPsLocked) cannot interleave between the recheck and
+			// the delete and lose the re-added VIP.
+			err := vi.removeVIPsIfBackup(gen)
+			if errors.Is(err, errReconcileSuperseded) {
+				// Re-promoted to MASTER (or a newer tenure began) → we now WANT
+				// the VIP; the new tenure owns the divergence decision. Stop.
 				return
 			}
-			if err := vi.removeVIPs(); err != nil {
+			if err != nil {
 				slog.Warn("vrrp: stale-VIP remove reconcile attempt failed",
 					"key", vi.key(), "attempt", attempt, "err", err)
 				continue
@@ -2446,9 +2494,12 @@ func (vi *vrrpInstance) removeVIPs() error {
 // It returns the first genuine removal failure so becomeBackup can detect a VIP
 // that is still on the wire (#5482). A benign case is NOT an error: an
 // unresolvable interface means the address is gone with the link (best-effort
-// teardown cleanup), and a "not found"/"no such" AddrDel means the address is
-// already absent — neither leaves a stale VIP answering ARP. Only an AddrDel that
-// fails against a resolvable interface is a real divergence.
+// teardown cleanup), and an already-absent AddrDel — ENODEV/ENOENT
+// ("not found"/"no such") OR EADDRNOTAVAIL ("cannot assign requested address",
+// the common already-absent errno on a clean boot) — means the address was never
+// on the interface. Neither leaves a stale VIP answering ARP, so neither is a
+// divergence. Only an AddrDel that fails for another reason against a resolvable
+// interface is a real divergence.
 func (vi *vrrpInstance) removeVIPsLocked(vips []string) error {
 	if vips == nil {
 		vips = vi.cfg.VirtualAddresses
@@ -2471,8 +2522,25 @@ func (vi *vrrpInstance) removeVIPsLocked(vips []string) error {
 			continue
 		}
 		if err := vi.nlAddrDel(link, addr); err != nil {
-			// Ignore "not found" — may have been removed already.
-			if strings.Contains(err.Error(), "not found") ||
+			// Benign already-absent cases: the address is not on the interface,
+			// so there is no stale VIP left answering ARP. The kernel signals an
+			// absent address several ways on AddrDel:
+			//   - ENODEV/ENOENT → "not found"/"no such" (the original checks)
+			//   - EADDRNOTAVAIL → "cannot assign requested address" — the MOST
+			//     common already-absent errno. A fresh boot / restart-as-backup
+			//     runs the run-startup BACKUP removal (and becomeBackup) against
+			//     VIPs that were NEVER on the interface, so every AddrDel returns
+			//     EADDRNOTAVAIL. Treating that as a real failure would flag
+			//     vipDiverged on EVERY clean boot and the reconcile would retry
+			//     the still-absent address to exhaustion, leaving the operator-
+			//     facing divergence flag stuck TRUE for the daemon's life —
+			//     cry-wolfing the exact diagnostic #5482 exists to provide.
+			// errors.Is unwraps the netlink errno even when it is annotated with
+			// NLMSGERR_ATTR TLV text; the string check is a belt-and-suspenders
+			// match for wrappers that only expose Error().
+			if errors.Is(err, unix.EADDRNOTAVAIL) ||
+				strings.Contains(err.Error(), "cannot assign requested address") ||
+				strings.Contains(err.Error(), "not found") ||
 				strings.Contains(err.Error(), "no such") {
 				continue
 			}

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -240,6 +240,27 @@ type vrrpInstance struct {
 	// post-programRethMAC reconcile), so it adds no latency to ~60ms failover.
 	vipMu sync.Mutex
 
+	// VIP/role divergence accounting for the BACKUP side (#5482). becomeMaster
+	// is already fail-closed (#5082): it refuses to publish MASTER when the VIP
+	// add fails. The symmetric BACKUP hazard remained: becomeBackup published the
+	// BACKUP role via emitEvent even when removeVIPs failed, so a swallowed
+	// netlink error left this now-BACKUP node still answering ARP for a VIP it no
+	// longer owns (duplicate-address hazard against the new master). We must still
+	// publish BACKUP (we ARE stepping down — refusing to emit risks split-brain),
+	// so instead of hiding the failure we surface it: vipRemoveFailures is a
+	// monotonic count of BACKUP transitions whose synchronous VIP removal failed,
+	// and vipDiverged flags that a stale VIP may still be on the wire (cleared once
+	// an async reconcile removes it). Atomic so log/test readers stay lock-free.
+	vipRemoveFailures atomic.Uint64
+	vipDiverged       atomic.Bool
+
+	// vipReconcileBackoff overrides the spacing between stale-VIP remove-reconcile
+	// retries (#5482). Zero ⇒ defaultVIPReconcileBackoff. A per-instance field
+	// (not a package var) so unit tests shorten it without a shared-global data
+	// race against another instance's still-running reconcile goroutine. Set once
+	// before the reconcile goroutine starts; the goroutine only reads it.
+	vipReconcileBackoff time.Duration
+
 	// netlink seams for VIP actuation. Production leaves them nil and the
 	// helpers call netlink live; unit tests inject them to drive addVIPs down
 	// a chosen success/failure path without a real kernel interface (#5082).
@@ -1118,8 +1139,12 @@ func (vi *vrrpInstance) run() {
 	// Transition to Backup state.
 	// Remove any stale VIPs that may be on the interface from a previous
 	// daemon run or config apply. This ensures BACKUP nodes don't have VIPs.
-	vi.removeVIPs()
+	// setState precedes surfaceStaleVIP so the async reconcile's state guard sees
+	// BACKUP; a swallowed removal failure here would start us as a BACKUP still
+	// answering ARP for a stale VIP (#5482).
+	staleErr := vi.removeVIPs()
 	vi.setState(StateBackup)
+	vi.surfaceStaleVIP(staleErr, "run-startup")
 	vi.emitEvent()
 
 	// Use an extended initial masterDown timer when preempt is disabled
@@ -1167,7 +1192,12 @@ func (vi *vrrpInstance) run() {
 				for i := 0; i < 3; i++ {
 					vi.sendAdvert(0)
 				}
-				vi.removeVIPs()
+				// Best-effort at process exit: log a removal failure but do not
+				// schedule a reconcile (stopCh is closed, the run-loop is ending).
+				if err := vi.removeVIPs(); err != nil {
+					slog.Warn("vrrp: VIP removal failed during resignation shutdown",
+						"key", vi.key(), "err", err)
+				}
 				return
 			case pkt := <-vi.rxCh:
 				vi.handleMasterRx(pkt, masterDownTimer, advertTimer)
@@ -1960,7 +1990,10 @@ func (vi *vrrpInstance) becomeMaster() bool {
 		// with the run-loop's masterDownTimer retry — no parallel state system.
 		// (superseded is captured before the setState bump below so the log
 		// reflects the true reason, not the revert's own generation bump.)
-		vi.removeVIPsLocked(res.applied)
+		// Rollback is best-effort — a failure is reported by the fail-closed Error
+		// log below (applied/failed lists) and we are already reverting to BACKUP,
+		// so there is no control-flow decision to make on it.
+		_ = vi.removeVIPsLocked(res.applied)
 		vi.setState(StateBackup)
 		vi.vipMu.Unlock()
 		slog.Error("vrrp: VIP actuation failed, not claiming ownership (fail-closed)",
@@ -1998,11 +2031,21 @@ func (vi *vrrpInstance) rearmForRetry(masterDownTimer *time.Timer) {
 }
 
 // becomeBackup transitions to Backup state: remove VIPs, reset timers.
+//
+// Verified BACKUP ownership (#5482): the BACKUP-side symmetry of the #5082
+// fail-closed MASTER path. We ARE stepping down (a superior/equal master is
+// taking over), so publishing BACKUP is the honest role — refusing to emit would
+// risk split-brain. But the pre-#5482 code called the VOID removeVIPs and emitted
+// BACKUP unconditionally, so a swallowed netlink removal failure left this
+// now-BACKUP node still answering ARP for the VIP (duplicate-address hazard vs
+// the new master). surfaceStaleVIP records the divergence loudly and schedules an
+// async reconcile so the stale VIP clears without a silent hazard, while
+// emitEvent still publishes the true BACKUP state.
 func (vi *vrrpInstance) becomeBackup(masterDownTimer, advertTimer *time.Timer) {
 	slog.Info("vrrp: transitioning to BACKUP",
 		"key", vi.key())
 	vi.setState(StateBackup)
-	vi.removeVIPs()
+	vi.surfaceStaleVIP(vi.removeVIPs(), "becomeBackup")
 	advertTimer.Stop()
 	masterDownTimer.Reset(vi.masterDownInterval())
 	// A MASTER stepping down to a worthy higher/tie-break master begins a
@@ -2013,6 +2056,75 @@ func (vi *vrrpInstance) becomeBackup(masterDownTimer, advertTimer *time.Timer) {
 	vi.skipNextPreemptHold = false
 	vi.mu.Unlock()
 	vi.emitEvent()
+}
+
+// vipRemoveReconcileMax bounds the async retry that clears a stale VIP left on a
+// now-BACKUP node when the synchronous removeVIPs failed (#5482).
+const vipRemoveReconcileMax = 5
+
+// defaultVIPReconcileBackoff spaces the stale-VIP remove retries in production:
+// a transient netlink failure clears within ~1s without hammering the kernel.
+// Per-instance override via vipReconcileBackoff (tests shorten it).
+const defaultVIPReconcileBackoff = 200 * time.Millisecond
+
+// surfaceStaleVIP records and self-heals a failed VIP removal on a BACKUP-side
+// transition (#5482). It is a no-op on nil err (a clean removal clears the
+// divergence flag). On a real failure it bumps the monotonic vipRemoveFailures
+// counter, sets vipDiverged, logs at Error, and launches a bounded async retry so
+// the stale VIP is cleared without leaving a silent duplicate-address hazard. The
+// caller MUST have already published the BACKUP state (setState) so the retry's
+// state guard sees BACKUP. `where` identifies the call site in logs.
+func (vi *vrrpInstance) surfaceStaleVIP(err error, where string) {
+	if err == nil {
+		vi.vipDiverged.Store(false)
+		return
+	}
+	vi.vipRemoveFailures.Add(1)
+	vi.vipDiverged.Store(true)
+	slog.Error("vrrp: VIP remove failed on BACKUP transition; a stale VIP may "+
+		"remain on this now-BACKUP node — scheduling reconcile",
+		"key", vi.key(), "where", where, "err", err)
+	vi.scheduleVIPRemoveReconcile()
+}
+
+// scheduleVIPRemoveReconcile launches a bounded background retry that re-attempts
+// the VIP removal that failed during a BACKUP transition (#5482). The BACKUP role
+// is already published (we ARE a backup); this goroutine drives the kernel VIP
+// state back into agreement with that role WITHOUT blocking the run-loop, and
+// clears vipDiverged on success. It stops early if the node is re-promoted to
+// MASTER (it then WANTS the VIP) or the instance shuts down. Per-attempt failures
+// are logged but do NOT bump vipRemoveFailures — that counter stays a clean count
+// of BACKUP transitions whose synchronous removal failed.
+func (vi *vrrpInstance) scheduleVIPRemoveReconcile() {
+	backoff := vi.vipReconcileBackoff
+	if backoff <= 0 {
+		backoff = defaultVIPReconcileBackoff
+	}
+	go func() {
+		for attempt := 1; attempt <= vipRemoveReconcileMax; attempt++ {
+			select {
+			case <-vi.stopCh:
+				return
+			case <-time.After(backoff):
+			}
+			// Re-promoted to MASTER mid-retry → we now WANT the VIP; stop.
+			if vi.getState() != StateBackup {
+				return
+			}
+			if err := vi.removeVIPs(); err != nil {
+				slog.Warn("vrrp: stale-VIP remove reconcile attempt failed",
+					"key", vi.key(), "attempt", attempt, "err", err)
+				continue
+			}
+			vi.vipDiverged.Store(false)
+			slog.Info("vrrp: stale-VIP remove reconcile succeeded",
+				"key", vi.key(), "attempt", attempt)
+			return
+		}
+		slog.Error("vrrp: stale-VIP remove reconcile exhausted retries; a VIP may "+
+			"remain on this BACKUP node until the next transition",
+			"key", vi.key())
+	}()
 }
 
 // emitEvent sends a state change event to the manager's event channel.
@@ -2318,43 +2430,60 @@ func (vi *vrrpInstance) addVIPsLocked() vipActuationResult {
 // removeVIPs removes ALL configured virtual IP addresses from the interface.
 // It acquires vipMu so it is safe to call from the run-loop (becomeBackup, run
 // startup/shutdown) without interleaving a concurrent ReconcileVIPs add (#5082).
-func (vi *vrrpInstance) removeVIPs() {
+// It returns the first genuine netlink removal failure (nil on success) so a
+// BACKUP-side caller can surface a stale VIP instead of swallowing it (#5482).
+func (vi *vrrpInstance) removeVIPs() error {
 	vi.vipMu.Lock()
-	vi.removeVIPsLocked(nil)
-	vi.vipMu.Unlock()
+	defer vi.vipMu.Unlock()
+	return vi.removeVIPsLocked(nil)
 }
 
 // removeVIPsLocked removes the given VIPs (nil ⇒ all configured VirtualAddresses)
 // from the interface via netlink. The caller MUST hold vipMu. Passing a subset
 // (res.applied) lets a failed/superseded actuation roll back exactly the
 // addresses it added.
-func (vi *vrrpInstance) removeVIPsLocked(vips []string) {
+//
+// It returns the first genuine removal failure so becomeBackup can detect a VIP
+// that is still on the wire (#5482). A benign case is NOT an error: an
+// unresolvable interface means the address is gone with the link (best-effort
+// teardown cleanup), and a "not found"/"no such" AddrDel means the address is
+// already absent — neither leaves a stale VIP answering ARP. Only an AddrDel that
+// fails against a resolvable interface is a real divergence.
+func (vi *vrrpInstance) removeVIPsLocked(vips []string) error {
 	if vips == nil {
 		vips = vi.cfg.VirtualAddresses
 	}
 	if len(vips) == 0 {
-		return
+		return nil
 	}
 	link, err := vi.nlLinkByName(vi.cfg.Interface)
 	if err != nil {
+		// Interface gone/mid-rename → no live address to strand; best-effort.
 		slog.Debug("vrrp: failed to find interface for VIP remove",
 			"key", vi.key(), "err", err)
-		return
+		return nil
 	}
+	var firstErr error
 	for _, vip := range vips {
 		addr, err := netlink.ParseAddr(vip)
 		if err != nil {
+			// A malformed VIP was never actuated, so it is not on the wire.
 			continue
 		}
 		if err := vi.nlAddrDel(link, addr); err != nil {
 			// Ignore "not found" — may have been removed already.
-			if !strings.Contains(err.Error(), "not found") &&
-				!strings.Contains(err.Error(), "no such") {
-				slog.Debug("vrrp: failed to remove VIP",
-					"key", vi.key(), "vip", vip, "err", err)
+			if strings.Contains(err.Error(), "not found") ||
+				strings.Contains(err.Error(), "no such") {
+				continue
+			}
+			slog.Debug("vrrp: failed to remove VIP",
+				"key", vi.key(), "vip", vip, "err", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("del vip %q: %w", vip, err)
 			}
 		}
 	}
+	return firstErr
 }
 
 // minGARPInterval is the minimum spacing between GARP bursts (dampening).

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -808,7 +808,8 @@ func (vi *vrrpInstance) reconcileVIP() {
 	// flipped state). If superseded, undo the re-added VIPs and do NOT GARP —
 	// announcing a VIP we no longer own is the split-routing hazard this closes.
 	if vi.getState() != StateMaster || vi.ownerGen.Load() != gen {
-		vi.removeVIPsLocked(res.applied)
+		// Best-effort rollback; the Warn below reports the rolled-back set.
+		_ = vi.removeVIPsLocked(res.applied)
 		vi.vipMu.Unlock()
 		slog.Warn("vrrp: ReconcileVIPs superseded by demotion; rolled back re-added VIPs, GARP suppressed",
 			"key", vi.key(), "rolled_back", res.applied)

--- a/pkg/vrrp/vip_backup_verify_5482_test.go
+++ b/pkg/vrrp/vip_backup_verify_5482_test.go
@@ -1,0 +1,192 @@
+package vrrp
+
+import (
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #5482 — the BACKUP-side symmetry of the #5082 fail-closed MASTER path.
+//
+// becomeMaster was already fail-closed (#5082): it refuses to publish MASTER when
+// the VIP add fails (vip_gen_5082_test.go pins that). The symmetric hazard
+// remained on the BACKUP side: becomeBackup called the VOID removeVIPs and then
+// emitEvent UNCONDITIONALLY, so a swallowed netlink removal failure left this
+// now-BACKUP node still answering ARP for a VIP it no longer owns — the daemon
+// made the RG BACKUP (blackholes injected, rg_active cleared) while the VIP was
+// still on the wire, a duplicate-address hazard against the new master.
+//
+// The fix makes removeVIPs return the netlink failure and has becomeBackup
+// surfaceStaleVIP it: bump a failure counter, set vipDiverged, log at Error, and
+// schedule an async reconcile that clears the stale VIP. BACKUP is still emitted
+// (we ARE stepping down — refusing to emit would risk split-brain), so the
+// divergence is no longer SILENT and it self-heals.
+//
+// The tests drive the netlink seams (linkByNameFn/addrDelFn) so the removal path
+// runs without a real interface. becomeBackup performs no network I/O of its own.
+
+// newBackupTestInstance builds a MASTER instance whose VIP netlink removal is
+// governed by delFn, so becomeBackup exercises the surfacing path deterministically.
+func newBackupTestInstance(t *testing.T, name string, delFn func(*netlink.Addr) error) (*vrrpInstance, chan VRRPEvent) {
+	t.Helper()
+	eventCh := make(chan VRRPEvent, 8)
+	vi := newInstance(Instance{
+		Interface:         name,
+		GroupID:           1,
+		Priority:          100,
+		Family:            "inet",
+		AdvertiseInterval: 1000,
+		VirtualAddresses:  []string{"10.0.61.1/24"},
+	}, &net.Interface{Name: name}, eventCh, nil)
+	// Interface resolves; removal outcome is dictated by delFn.
+	vi.linkByNameFn = func(n string) (netlink.Link, error) {
+		return fiveZeroEightTwoLink(n), nil
+	}
+	vi.addrAddFn = func(netlink.Link, *netlink.Addr) error { return nil }
+	vi.addrDelFn = func(_ netlink.Link, a *netlink.Addr) error { return delFn(a) }
+	vi.setState(StateMaster) // becomeBackup is a real demotion FROM MASTER
+	// Stop any async reconcile goroutine promptly at test end.
+	t.Cleanup(func() {
+		select {
+		case <-vi.stopCh:
+		default:
+			close(vi.stopCh)
+		}
+	})
+	return vi, eventCh
+}
+
+func drainForBackupEvent(t *testing.T, eventCh chan VRRPEvent) bool {
+	t.Helper()
+	for {
+		select {
+		case ev := <-eventCh:
+			if ev.State == StateBackup {
+				return true
+			}
+		default:
+			return false
+		}
+	}
+}
+
+// TestBecomeBackupSurfacesVIPRemoveFailure_5482 is the fail-on-revert guard: with
+// the netlink AddrDel primitive rigged to fail, becomeBackup must SURFACE the
+// removal failure (vipRemoveFailures bumped, vipDiverged set) rather than
+// silently publishing a clean BACKUP role while the VIP is still on the wire.
+// BACKUP is still emitted (we are stepping down).
+//
+// RED on revert: replacing `vi.surfaceStaleVIP(vi.removeVIPs(), "becomeBackup")`
+// with the pre-fix `vi.removeVIPs()` (discarding the error, matching the old void
+// removeVIPs + unconditional emit) leaves vipRemoveFailures at 0 and vipDiverged
+// false — this test then fails on the vipRemoveFailures assertion.
+func TestBecomeBackupSurfacesVIPRemoveFailure_5482(t *testing.T) {
+	vi, eventCh := newBackupTestInstance(t, "xpf-5482-a0", func(*netlink.Addr) error {
+		return errors.New("injected netlink AddrDel failure")
+	})
+
+	mdt := time.NewTimer(time.Hour)
+	defer mdt.Stop()
+	adv := time.NewTimer(time.Hour)
+	defer adv.Stop()
+
+	vi.becomeBackup(mdt, adv)
+
+	// The honest BACKUP role is still published — never withhold the step-down.
+	if got := vi.getState(); got != StateBackup {
+		t.Fatalf("state = %v, want StateBackup — becomeBackup must still step down", got)
+	}
+	if !drainForBackupEvent(t, eventCh) {
+		t.Fatal("becomeBackup did not emit a BACKUP event — the step-down must be published")
+	}
+	// ...but the removal failure is SURFACED, not swallowed.
+	if got := vi.vipRemoveFailures.Load(); got != 1 {
+		t.Fatalf("becomeBackup swallowed the VIP remove failure: vipRemoveFailures = %d, "+
+			"want 1 — the control-plane published BACKUP while a stale VIP remained on "+
+			"the wire (#5482 silent role/VIP divergence)", got)
+	}
+	if !vi.vipDiverged.Load() {
+		t.Fatal("vipDiverged must be set when the VIP remove fails on the BACKUP transition")
+	}
+}
+
+// TestBecomeBackupCleanRemovalNoDivergence_5482 is the non-tautological control:
+// when AddrDel SUCCEEDS, becomeBackup must NOT bump the failure counter or flag a
+// divergence. This proves the surfacing is gated on the ACTUAL netlink outcome,
+// not fired unconditionally.
+func TestBecomeBackupCleanRemovalNoDivergence_5482(t *testing.T) {
+	vi, eventCh := newBackupTestInstance(t, "xpf-5482-b0", func(*netlink.Addr) error {
+		return nil // clean removal
+	})
+
+	mdt := time.NewTimer(time.Hour)
+	defer mdt.Stop()
+	adv := time.NewTimer(time.Hour)
+	defer adv.Stop()
+
+	vi.becomeBackup(mdt, adv)
+
+	if got := vi.getState(); got != StateBackup {
+		t.Fatalf("state = %v, want StateBackup", got)
+	}
+	if !drainForBackupEvent(t, eventCh) {
+		t.Fatal("becomeBackup did not emit a BACKUP event")
+	}
+	if got := vi.vipRemoveFailures.Load(); got != 0 {
+		t.Fatalf("vipRemoveFailures = %d, want 0 on a clean removal — surfacing must "+
+			"be gated on the real netlink outcome", got)
+	}
+	if vi.vipDiverged.Load() {
+		t.Fatal("vipDiverged must stay false when the VIP removal succeeds")
+	}
+}
+
+// TestBackupStaleVIPReconcileSelfHeals_5482 proves the divergence self-heals: the
+// first AddrDel fails (becomeBackup flags vipDiverged) and a later one succeeds,
+// so the scheduled async reconcile clears vipDiverged without a further BACKUP
+// transition. Without the reconcile the flag would stay set forever.
+func TestBackupStaleVIPReconcileSelfHeals_5482(t *testing.T) {
+	var calls atomic.Int32
+	vi, _ := newBackupTestInstance(t, "xpf-5482-c0", func(*netlink.Addr) error {
+		if calls.Add(1) == 1 {
+			return errors.New("injected transient netlink AddrDel failure")
+		}
+		return nil // subsequent attempts succeed
+	})
+	// Shorten the retry backoff (per-instance, no shared global) so the async
+	// reconcile fires quickly. Set before becomeBackup starts the goroutine.
+	vi.vipReconcileBackoff = 5 * time.Millisecond
+
+	mdt := time.NewTimer(time.Hour)
+	defer mdt.Stop()
+	adv := time.NewTimer(time.Hour)
+	defer adv.Stop()
+
+	vi.becomeBackup(mdt, adv)
+
+	// Immediately after the (failed) synchronous removal, the divergence is flagged.
+	if vi.vipRemoveFailures.Load() != 1 || !vi.vipDiverged.Load() {
+		t.Fatalf("expected surfaced divergence after the failed removal: "+
+			"vipRemoveFailures=%d vipDiverged=%v", vi.vipRemoveFailures.Load(), vi.vipDiverged.Load())
+	}
+
+	// The async reconcile retries the removal; the second AddrDel succeeds and
+	// clears vipDiverged.
+	deadline := time.Now().Add(2 * time.Second)
+	for vi.vipDiverged.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("vipDiverged never cleared — the async stale-VIP reconcile did not self-heal")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// vipRemoveFailures is a clean count of failed BACKUP transitions — the retry
+	// attempts must NOT inflate it.
+	if got := vi.vipRemoveFailures.Load(); got != 1 {
+		t.Fatalf("vipRemoveFailures = %d, want 1 — retry attempts must not bump the "+
+			"transition-failure counter", got)
+	}
+}

--- a/pkg/vrrp/vip_backup_verify_5482_test.go
+++ b/pkg/vrrp/vip_backup_verify_5482_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // #5482 — the BACKUP-side symmetry of the #5082 fail-closed MASTER path.
@@ -188,5 +189,125 @@ func TestBackupStaleVIPReconcileSelfHeals_5482(t *testing.T) {
 	if got := vi.vipRemoveFailures.Load(); got != 1 {
 		t.Fatalf("vipRemoveFailures = %d, want 1 — retry attempts must not bump the "+
 			"transition-failure counter", got)
+	}
+}
+
+// TestBackupRemoveAbsentVIPNoDivergence_5482 is the fail-on-revert guard for the
+// EADDRNOTAVAIL false-divergence bug. The kernel returns EADDRNOTAVAIL ("cannot
+// assign requested address") when AddrDel targets an address that is NOT present
+// — the most common already-absent errno. On a fresh boot / restart-as-backup the
+// run-startup BACKUP removal (and becomeBackup) run against VIPs that were never
+// on the interface, so every AddrDel returns EADDRNOTAVAIL. That is a benign
+// already-absent case, NOT a divergence: it must NOT bump vipRemoveFailures or set
+// vipDiverged.
+//
+// RED on revert: dropping `errors.Is(err, unix.EADDRNOTAVAIL)` (and the "cannot
+// assign requested address" string) from the benign already-absent set in
+// removeVIPsLocked makes EADDRNOTAVAIL a real failure → surfaceStaleVIP bumps
+// vipRemoveFailures to 1 and sets vipDiverged → both sub-cases fail. This
+// cry-wolfs the divergence flag on EVERY clean boot.
+func TestBackupRemoveAbsentVIPNoDivergence_5482(t *testing.T) {
+	// Both detection arms: the raw errno (realistic netlink path) and the
+	// Error()-string form (a wrapper that only exposes the message).
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"eaddrnotavail-errno", unix.EADDRNOTAVAIL},
+		{"cannot-assign-string", errors.New("cannot assign requested address")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			absent := tc.err
+			vi, eventCh := newBackupTestInstance(t, "xpf-5482-"+tc.name, func(*netlink.Addr) error {
+				return absent
+			})
+
+			mdt := time.NewTimer(time.Hour)
+			defer mdt.Stop()
+			adv := time.NewTimer(time.Hour)
+			defer adv.Stop()
+
+			vi.becomeBackup(mdt, adv)
+
+			// The honest BACKUP role is still published.
+			if got := vi.getState(); got != StateBackup {
+				t.Fatalf("state = %v, want StateBackup", got)
+			}
+			if !drainForBackupEvent(t, eventCh) {
+				t.Fatal("becomeBackup did not emit a BACKUP event")
+			}
+			// Removing an ABSENT VIP is not a divergence.
+			if got := vi.vipRemoveFailures.Load(); got != 0 {
+				t.Fatalf("removing an absent VIP (%v) flagged a bogus remove failure: "+
+					"vipRemoveFailures = %d, want 0 — an already-absent AddrDel "+
+					"(EADDRNOTAVAIL) must be benign, else every clean boot cry-wolfs "+
+					"the divergence flag (#5482)", absent, got)
+			}
+			if vi.vipDiverged.Load() {
+				t.Fatalf("removing an absent VIP (%v) set vipDiverged — a fresh boot / "+
+					"restart-as-backup must not report a stuck divergence", absent)
+			}
+		})
+	}
+}
+
+// TestBackupVIPReconcileAbortsOnRepromotion_5482 is the fail-on-revert guard for
+// the re-promotion TOCTOU. The stale-VIP reconcile runs on a background goroutine
+// while becomeMaster runs on the run-loop. becomeMaster does setState(MASTER)
+// (bumping ownerGen) BEFORE it takes vipMu to re-add the VIP, so the reconcile's
+// remove MUST re-validate state + ownerGen under vipMu and abort if the node was
+// re-promoted — otherwise it strips the VIP becomeMaster just added (MASTER
+// self-blackhole). removeVIPsIfBackup is that atomic gate.
+//
+// The test drives the gate directly for determinism (racing the async goroutine
+// would be flaky). It covers BOTH revalidation arms:
+//   - state flipped to MASTER (the direct re-promotion)
+//   - state is BACKUP again but ownerGen advanced (a MASTER tenure intervened:
+//     BACKUP→MASTER→BACKUP — the new tenure owns the divergence decision)
+//
+// RED on revert: removing the `state != BACKUP || ownerGen != wantGen` recheck in
+// removeVIPsIfBackup makes it call removeVIPsLocked unconditionally → AddrDel
+// fires on the re-owned VIP → delCalls > 0 and the returned error is not
+// errReconcileSuperseded → both sub-cases fail.
+func TestBackupVIPReconcileAbortsOnRepromotion_5482(t *testing.T) {
+	var delCalls atomic.Int32
+	vi, _ := newBackupTestInstance(t, "xpf-5482-repromo", func(*netlink.Addr) error {
+		delCalls.Add(1)
+		return nil
+	})
+
+	// Identity of the BACKUP tenure that scheduled the reconcile.
+	vi.setState(StateBackup)
+	gen := vi.ownerGen.Load()
+
+	// Scenario 1: re-promotion to MASTER. becomeMaster ran setState(MASTER)
+	// (ownerGen bumped) and re-added the VIP under vipMu; the stale reconcile from
+	// the old BACKUP tenure must abort rather than strip that VIP.
+	vi.setState(StateMaster)
+	if err := vi.removeVIPsIfBackup(gen); !errors.Is(err, errReconcileSuperseded) {
+		t.Fatalf("removeVIPsIfBackup must abort on re-promotion to MASTER: err = %v, "+
+			"want errReconcileSuperseded", err)
+	}
+	if got := delCalls.Load(); got != 0 {
+		t.Fatalf("reconcile stripped a re-owned MASTER's VIP: AddrDel called %d times, "+
+			"want 0 — re-promotion TOCTOU self-blackhole (#5482)", got)
+	}
+
+	// Scenario 2: state is BACKUP again but ownerGen advanced past the captured
+	// tenure (BACKUP→MASTER→BACKUP). The stale reconcile must still abort — the new
+	// BACKUP tenure ran its own surfaceStaleVIP and owns the divergence decision.
+	vi.setState(StateBackup)
+	if vi.ownerGen.Load() == gen {
+		t.Fatalf("test setup: ownerGen did not advance across the intervening MASTER "+
+			"tenure (gen still %d) — the ownerGen arm would not be exercised", gen)
+	}
+	if err := vi.removeVIPsIfBackup(gen); !errors.Is(err, errReconcileSuperseded) {
+		t.Fatalf("removeVIPsIfBackup must abort when ownerGen advanced past the "+
+			"scheduling tenure: err = %v, want errReconcileSuperseded", err)
+	}
+	if got := delCalls.Load(); got != 0 {
+		t.Fatalf("stale-tenure reconcile deleted a VIP after ownerGen advanced: "+
+			"AddrDel called %d times, want 0", got)
 	}
 }


### PR DESCRIPTION
## Summary

- **#5482 remaining gap (BACKUP side).** `becomeMaster` was already fail-closed by **#5082** — it refuses to publish MASTER when the VIP add fails (rolls back, reverts to `StateBackup`, returns `false`). The **symmetric BACKUP hazard remained unfixed**: `becomeBackup` (and the run-startup BACKUP entry) called the **void** `removeVIPs` and then `emitEvent` **unconditionally**.
- The daemon consumes the BACKUP event to inject blackhole routes and clear `rg_active` (`pkg/daemon/daemon_ha.go`), so a swallowed netlink removal failure left this now-BACKUP node **still answering ARP for a VIP it no longer owns** — a duplicate-address hazard against the new master and a silent control-plane/kernel divergence.
- `removeVIPs`/`removeVIPsLocked` now **return** the first genuine `AddrDel` failure. Benign cases stay non-errors: an unresolvable interface (address gone with the link) and a `not found`/`no such` delete (already absent) leave no stale VIP, so only an `AddrDel` failing against a **resolvable** interface is reported.
- `becomeBackup` and the run-startup entry route the result through the new `surfaceStaleVIP`: bump a monotonic `vipRemoveFailures` counter, set `vipDiverged`, log at **Error**, and `scheduleVIPRemoveReconcile` — a bounded async retry (5 attempts, per-instance backoff, stops on re-promotion to MASTER or shutdown) that clears the stale VIP and resets `vipDiverged`.

## Failure policy (the crux)

BACKUP is **still emitted** — we ARE stepping down, and withholding the event would risk split-brain / a no-master gap, which is worse than a transient stale VIP. The fix makes the divergence **loud and self-healing** instead of silent, without changing the ~60ms failover path (the `vipMu` lock is uncontended on the clean path, and the reconcile is async). This mirrors the #5082 MASTER-side policy from the opposite direction: MASTER refuses to publish an ownership it can't back; BACKUP publishes the honest step-down but never silently strands the VIP.

## Test plan

- [x] `pkg/vrrp/vip_backup_verify_5482_test.go`:
  - `TestBecomeBackupSurfacesVIPRemoveFailure_5482` (**fail-on-revert**) — rigs the netlink `AddrDel` seam to fail; asserts BACKUP is still emitted **and** the failure is surfaced (`vipRemoveFailures == 1`, `vipDiverged` set).
  - `TestBecomeBackupCleanRemovalNoDivergence_5482` — non-tautological control: on a clean removal the counter/flag stay at zero.
  - `TestBackupStaleVIPReconcileSelfHeals_5482` — first delete fails, later succeeds; the async reconcile clears `vipDiverged`.
- [x] `go build ./...`, `go vet ./pkg/vrrp/`, `go test -race ./pkg/vrrp/...` — all pass.
- [ ] **Loss-cluster failover smoke** (`make test-failover` / `test-ha-crash`) — VRRP/HA path; to be batched by the reviewer/lead.

**Parent RED-on-revert:** replace `vi.surfaceStaleVIP(vi.removeVIPs(), "becomeBackup")` in `becomeBackup` with the pre-fix `vi.removeVIPs()` (discarding the error) → still compiles → `TestBecomeBackupSurfacesVIPRemoveFailure_5482` fails on `vipRemoveFailures = 0, want 1` (clean assertion, not a build break).

## Docs

`pkg/vrrp/README.md` — added a "Verified role publication (#5082 MASTER, #5482 BACKUP)" bullet documenting the role/VIP-agreement contract on both transition sides.

## Refs

Closes #5482 · symmetric to #5082 (MASTER-side fail-closed) · consumer: `pkg/daemon/daemon_ha.go` MASTER/BACKUP event handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)