### PR TITLE
userspace-dp: deliver drained session deltas before persisting state (#5294)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54994,3 +54994,30 @@ top.
   userspace-dp/src/nat/source.rs, userspace-dp/src/nat64.rs,
   userspace-dp/src/nat/tests_pool.rs, userspace-dp/src/nat64_tests.rs,
   docs/deterministic-nat-cgnat.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: Fix #5294 — pop-then-fallible-write permanently loses a
+  session-delta batch on a state-file error. `drain_session_deltas`
+  (server/handlers/session_deltas.rs) and the owner-RG export mirror
+  (server/handlers/export.rs → owner_rg_collect) DESTRUCTIVELY drain deltas
+  into `response.session_deltas` and set `persist_state`; the dispatcher tail
+  (server/handlers/mod.rs) ran the FALLIBLE `write_state(...)?` BEFORE encoding
+  the response, so a local state-file error short-circuited the send: the batch
+  was popped off the queue yet neither persisted NOR delivered to the peer →
+  permanent HA session divergence (no loss-of-sync latch armed for a write_state
+  failure, unlike the #5290 overflow path). Fix: the dispatcher now ALWAYS
+  encodes+flushes the response (delta order preserved) and only THEN surfaces a
+  persist error to the accept loop — sound because the state file is best-effort
+  observability, not a restore source, and self-corrects on the next periodic
+  write. Single dispatcher-tail change covers BOTH the drain path and the
+  owner-RG export mirror (shared tail). Added a `#[cfg(test)]` Coordinator seam
+  (seed_pending_session_deltas_for_test) + fail-on-revert test
+  `drain_session_deltas_survive_write_state_failure_5294`: rigs write_state to
+  fail (state_file in a nonexistent dir), drains a 5-delta batch through the real
+  handle_stream, and asserts all 5 deltas still reach the peer. RED on revert to
+  pop-then-fallible-write (client read hits EOF — "EOF while parsing a value").
+  Build + targeted test pass; full cargo suite green (4070 lib tests, 0 failed).
+  HA session-sync path — needs loss-cluster failover smoke (batched).
+- **File(s)**: userspace-dp/src/server/handlers/mod.rs,
+  userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/server/tests.rs, userspace-dp/src/server/README.md, _Log.md

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -672,6 +672,19 @@ impl super::Coordinator {
         out
     }
 
+    /// #5294 test seam: insert a live binding at `slot` pre-loaded with `count`
+    /// pending RPC-fallback session deltas, so a server-level test can drive the
+    /// `drain_session_deltas` control verb through the real `handle_stream`
+    /// dispatcher with deltas actually queued. Compiled out of production builds.
+    #[cfg(test)]
+    pub(crate) fn seed_pending_session_deltas_for_test(&mut self, slot: u32, count: usize) {
+        let live = std::sync::Arc::new(crate::afxdp::umem::BindingLiveState::new());
+        for _ in 0..count {
+            live.push_session_delta(crate::protocol::SessionDeltaInfo::default());
+        }
+        self.workers.live.insert(slot, live);
+    }
+
     pub fn worker_heartbeats(&self) -> Vec<chrono::DateTime<Utc>> {
         let now_wall = Utc::now();
         let now_mono = monotonic_nanos();

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -42,6 +42,26 @@ this surface over a Unix socket using a newline-delimited text protocol.
   `handle_stream` dispatcher). One per-verb file per request kind
   (`apply_snapshot`, `set_forwarding_state`, `set_queue_state`,
   `inject_packet`, `stop_workers`, `rebind`, …).
+  - **The state-file persist never gates response delivery (#5294).**
+    `drain_session_deltas` (`handlers/session_deltas.rs`) and the owner-RG
+    export mirror (`handlers/export.rs` → `owner_rg_collect`)
+    DESTRUCTIVELY drain deltas out of the per-binding RPC-fallback buffers /
+    workers into `response.session_deltas` and set `persist_state`. The
+    dispatcher tail used to run the FALLIBLE `write_state(...)?` BEFORE
+    encoding the response, so a local state-file error short-circuited the
+    send: the batch was already popped off the queue yet never reached the
+    peer AND was not persisted — a permanent HA session divergence (the
+    standby never learns those open/close events, the local copy is gone, and
+    no loss-of-sync latch is armed for a `write_state` failure, unlike the
+    #5290 budget-overflow path). The tail now ALWAYS encodes+flushes the
+    response (delta order preserved end-to-end) and only THEN surfaces a
+    persist error to the accept loop (logged). That is sound because the state
+    file is best-effort observability, not a restore source (the Go control
+    plane re-applies the full snapshot on restart) and self-corrects on the
+    next periodic `write_state`. Pinned by
+    `drain_session_deltas_survive_write_state_failure_5294` (a rigged
+    `write_state` failure must still deliver every drained delta; reverting to
+    pop-then-fallible-write drops the batch → EOF on the client read → RED).
 - `helpers.rs` — shared daemon-loop utilities (`replan_queues`,
   `replan_bindings_from_candidates`, `summarize_queues`, capability
   checks).

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -290,9 +290,29 @@ pub(crate) fn handle_stream(
         }
     }
 
-    if persist_state {
-        write_state(state_file, &state)?;
-    }
+    // #5294: the state-file persist must NOT gate delivery of the response.
+    // `drain_session_deltas` (session_deltas::drain) and the owner-RG export
+    // mirror (export::owner_rg_collect) DESTRUCTIVELY drain deltas out of the
+    // per-binding fallback buffers / workers into `response.session_deltas`
+    // before this point and set `persist_state`. The old order ran the FALLIBLE
+    // `write_state` with `?` BEFORE encoding the response, so a local state-file
+    // error short-circuited the send: the deltas were already popped off the
+    // queue yet never reached the peer AND were not persisted — a permanent HA
+    // session divergence (the standby never learns those open/close events and
+    // the local copy is gone), with no loss-of-sync latch armed for a write_state
+    // failure. The state file is best-effort observability, not a restore source
+    // (the Go control plane re-applies the full snapshot on restart) and
+    // self-corrects on the next periodic write_state, so it must never strand an
+    // already-drained delta batch. Attempt the persist first (unchanged
+    // ordering), but ALWAYS encode+flush the response so the drained deltas reach
+    // the peer, then surface any persist error to the accept loop (logged) only
+    // AFTER the response is on the wire. Delta order is preserved end-to-end:
+    // the response carries the batch exactly as drained.
+    let persist_result = if persist_state {
+        write_state(state_file, &state)
+    } else {
+        Ok(())
+    };
 
     let mut writer = BufWriter::new(stream);
     serde_json::to_writer(&mut writer, &response).map_err(|e| format!("encode response: {e}"))?;
@@ -300,5 +320,9 @@ pub(crate) fn handle_stream(
         .write_all(b"\n")
         .map_err(|e| format!("write response newline: {e}"))?;
     writer.flush().map_err(|e| format!("flush response: {e}"))?;
+
+    // #5294: surface a persist failure ONLY after the response — carrying the
+    // drained session deltas — has been flushed to the peer.
+    persist_result?;
     Ok(())
 }

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -3235,3 +3235,88 @@ fn update_neighbors_none_without_replace_is_noop_5864() {
         "non-replace update with no neighbors must not clear the table"
     );
 }
+
+// -------------------------------------------------------------
+// #5294: a state-file write failure must NOT lose a drained
+// session-delta batch (pop-then-fallible-write transactionality).
+// -------------------------------------------------------------
+
+/// #5294 fail-on-revert: `drain_session_deltas` DESTRUCTIVELY pops deltas out of
+/// the per-binding RPC-fallback buffers into `response.session_deltas` and marks
+/// `persist_state`. With the pre-#5294 pop-then-fallible-write order — the
+/// dispatcher ran `write_state(...)?` BEFORE encoding the response — a local
+/// state-file write error short-circuited the send via `?`: the deltas were
+/// already gone from the queue yet never reached the peer AND were not persisted,
+/// a PERMANENT HA session divergence (the standby never learns those open/close
+/// events, the local copy is lost, and no loss-of-sync latch is armed for a
+/// write_state failure). The fix always encodes+flushes the response (carrying
+/// the drained deltas) BEFORE surfacing a persist error, so the peer still
+/// receives every drained delta.
+///
+/// The owner-RG export mirror (`export_owner_rg_sessions` → `owner_rg_collect`)
+/// populates `response.session_deltas` + `persist_state` and flows through the
+/// SAME dispatcher tail, so this single test pins both paths.
+///
+/// Reverting the dispatcher to `write_state(state_file, &state)?` before the send
+/// makes the handler return Err with NOTHING written, so the client read below
+/// hits EOF and the decode `expect` panics — the RED signal.
+#[test]
+fn drain_session_deltas_survive_write_state_failure_5294() {
+    let mut coord = afxdp::Coordinator::new();
+    coord.seed_pending_session_deltas_for_test(0, 5);
+    let state = Arc::new(Mutex::new(ServerState {
+        status: ProcessStatus::default(),
+        snapshot: None,
+        afxdp: coord,
+        state_writer: Arc::new(StateWriter::new()),
+    }));
+
+    // A state_file inside a directory that does not exist makes write_state's
+    // temp-file open fail => write_state returns Err (the local state-file
+    // problem the bug is about), while the ServerState stays otherwise healthy.
+    let bad_state_file = format!(
+        "/nonexistent-xpf-5294-dir-{}/state.json",
+        std::process::id()
+    );
+
+    let mut request = req("drain_session_deltas");
+    request.session_deltas = Some(crate::SessionDeltaDrainRequest { max: 256 });
+
+    let (mut client, server) =
+        std::os::unix::net::UnixStream::pair().expect("control socket pair");
+    let running = Arc::new(AtomicBool::new(true));
+    let handle = {
+        let bad = bad_state_file.clone();
+        std::thread::spawn(move || handle_stream(server, &bad, state, running))
+    };
+
+    serde_json::to_writer(&mut client, &request).expect("write request");
+    std::io::Write::write_all(&mut client, b"\n").expect("newline");
+
+    // The response MUST be delivered even though the persist will fail. On the
+    // pre-#5294 pop-then-fallible-write order the handler returns Err before
+    // writing anything, so this read hits EOF and the decode fails — the RED
+    // signal that a drained delta batch was silently lost.
+    let response: ControlResponse = serde_json::from_reader(std::io::BufReader::new(&client))
+        .expect("drained deltas must reach the peer despite the write_state failure (#5294)");
+
+    let handler_result = handle.join().expect("handler thread");
+
+    // Test premise: write_state actually failed (else we would not be exercising
+    // the failure path at all). The error is surfaced to the accept loop, but
+    // only AFTER the response was flushed.
+    let err = handler_result.expect_err("write_state must fail on a missing state dir");
+    assert!(
+        err.contains("write state file"),
+        "expected a state-file persist error, got: {err}"
+    );
+
+    // The deltas were NOT lost: every drained delta reached the peer.
+    assert!(response.ok, "drained-batch response must report ok");
+    assert_eq!(
+        response.session_deltas.len(),
+        5,
+        "all 5 drained deltas must reach the peer even though the persist failed \
+         — the pre-#5294 pop-then-fallible-write order dropped the whole batch"
+    );
+}


### PR DESCRIPTION
## Summary

- `drain_session_deltas` (`server/handlers/session_deltas.rs`) and the owner-RG export mirror (`server/handlers/export.rs`, `owner_rg_collect`) **destructively** drain deltas out of the per-binding RPC-fallback buffers / workers into `response.session_deltas` and set `persist_state`.
- The `handle_stream` dispatcher tail ran the **fallible** `write_state(...)?` **before** encoding the response. On a local state-file write failure the `?` short-circuited the send: the batch had already been popped off the queue, yet it was **neither persisted nor delivered** to the peer → permanent HA session divergence. Unlike the #5290 budget-overflow path, a `write_state` failure arms **no loss-of-sync latch**, so nothing schedules a recovery resync. Distinct from #2669/#2874/#2962.
- Fix: attempt the persist first (unchanged ordering) but **always encode+flush the response** — carrying the drained deltas in drained order — and surface any persist error to the accept loop (logged) **only after** the response is on the wire. One dispatcher-tail change covers **both** the drain path and the owner-RG export mirror (shared tail).
- Sound because the state file is best-effort observability, **not a restore source** (the Go control plane re-applies the full snapshot on restart) and self-corrects on the next periodic `write_state`. Losing one persist without losing the peer-send costs nothing.

## Shape chosen

Send-response-before-surfacing-persist-error (task option C), implemented minimally at the shared dispatcher tail so the owner-RG mirror is fixed by the same change (SSOT). Delta **order** is preserved end-to-end — the response carries the batch exactly as drained. No coordinator-level restore/re-attribution needed (the fair drain flattens per-binding buffers into one interleaved `Vec`, which makes push-back-to-source fragile; delivering the batch is both simpler and strictly better — the peer gets the deltas).

## Test plan

- [x] `cargo build` clean.
- [x] Added fail-on-revert test `drain_session_deltas_survive_write_state_failure_5294`: a `#[cfg(test)]` Coordinator seam pre-loads a live binding with 5 pending RPC-fallback deltas; the test rigs `write_state` to fail (state_file inside a nonexistent dir), drives the real `drain_session_deltas` verb through `handle_stream`, and asserts **all 5 deltas still reach the peer** (and the handler surfaces the persist error only after delivery).
- [x] **RED on revert** to pop-then-fallible-write: the handler returns `Err` before writing anything, the client read hits EOF (`EOF while parsing a value`) → clean assertion failure.
- [x] Full cargo suite green (4070 lib tests, 0 failed).
- [ ] **HA session-sync path — needs a loss-cluster failover smoke** (`make test-failover` + `make test-ha-crash`). To be batched.

## Docs

Documented the persist-vs-response-delivery contract in `userspace-dp/src/server/README.md` (handlers/ bullet).

## Refs

Closes #5294

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUf4ZxjqHJg2yMxdxZfe49
