### PR TITLE
nat: reserve address-only source-NAT tokens on the standby (#5338)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -55086,3 +55086,34 @@ top.
   loss-cluster failover smoke (batched).
 - **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/manager.go,
   pkg/vrrp/vip_backup_verify_5482_test.go, pkg/vrrp/README.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5338 — standby reserves ADDRESS-ONLY source-NAT occupancy tokens
+  for synced sessions. `reserve_synced_source_nat_allocation` (userspace-dp,
+  `nat/source.rs`) previously EARLY-RETURNED when the synced decision carried no
+  `rewrite_src_port` (address-only: `port no-translation` / port-less / GRE), so
+  the standby minted NO reverse-identity token. On failover its reverse (1:N)
+  index could not disambiguate the promoted address-only session, and a fresh
+  local address-only flow could claim the same public identity. Added an
+  address-only arm that mirrors the ACTIVE node's #5336/#5341 minting: for a
+  synced decision with `rewrite_src = Some(pool_addr)` and `rewrite_src_port =
+  None`, claim the SAME token via `PortAllocator::reserve_address_only` on the
+  rule whose pool owns `rewrite_src` (no pool-port bit consumed). Composed WITH
+  the just-merged #6207 `deterministic` threading — that flag applies only to the
+  port-bearing `reserve_flow` arm, which is unchanged; an address-only token
+  carries no port bit, so (like #5341) it mints via plain `reserve_address_only`
+  regardless of pool mode. The token is freed by the SAME teardown path
+  (`release_source_nat_allocation` -> `release_flow`, clears `address_only_owners`)
+  — no new delete site. Fail-on-revert test
+  `synced_address_only_session_reserves_reverse_identity_token_5338`
+  (`nat/tests_pool.rs`): reserves a synced address-only session, asserts the
+  standby mints exactly one occupancy token AND a colliding local address-only
+  flow is denied as exhaustion; releasing the synced session frees the token.
+  RED on revert (restore the `rewrite_src_port` skip) with a clean assertion
+  ("standby must mint one address-only occupancy token"), not a compile break.
+  Validated on disk: `cargo build` OK; full `cargo test --release` green (4071
+  lib + 8 + 22 + 1 + 60, 0 failed) across two runs. NAT/dataplane HA path —
+  needs a loss-cluster failover smoke (batched). Updated the synced-reserve
+  contract in `docs/session-sync-architecture.md`.
+- **File(s)**: userspace-dp/src/nat/source.rs,
+  userspace-dp/src/nat/tests_pool.rs, docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -459,13 +459,30 @@ source tuple (reply mis-delivery / a session-hijack surface).
   `owner_by_translated` / `addr_index_by_translated` / `live_by_flow` state a
   normal allocation writes, keyed by the synced session's flow. The sequential
   port cursor (`claim_free_port_locked`) then skips the reserved port, exactly
-  as it already skips a live local allocation (#3047 forward-probe).
+  as it already skips a live local allocation (#3047 forward-probe). The #5178
+  `deterministic` flag mirrors the active node's allocation mode so the standby's
+  release takes `free_no_recycle` for a deterministic-CGNAT reservation.
+- **Address-only reserve (#5338):** an ADDRESS-ONLY decision (`port
+  no-translation` on a port-bearing protocol, or a port-less protocol such as
+  GRE/ESP) carries `rewrite_src` (the pool address) but NO `rewrite_src_port` —
+  the wire keeps the packet's own source port. The active node (#5269/#5336
+  round-robin/persistent, #5341 deterministic) mints a reverse-identity
+  occupancy token for such a flow via `PortAllocator::reserve_address_only`
+  (keyed on protocol, pool address, PRESERVED source port, remote) so its
+  reverse (1:N) index can disambiguate the public tuple. The synced reserve now
+  mirrors that mint on the standby: the address-only arm claims the SAME token on
+  the rule whose pool owns `rewrite_src`, consuming NO pool-port bit. Without it,
+  a promoted standby could not disambiguate the synced address-only session's
+  replies and a fresh local address-only flow could claim the same public
+  identity. Like the port-bearing arm, a collision (a local flow already owns the
+  identity) or a foreign pool address is skipped gracefully.
 - **Release site:** the reservation uses the synced flow key, so the standard
   teardown — `release_source_nat_allocation`, already called on GC reap
   (`reap_expired_sessions`), on a peer delete-sync (`handle_delete_synced`), and
-  on DSCP-filter purge — frees it with no new delete path. A reverse synced
-  entry, an address-only / `port no-translation` decision, or a session with no
-  source NAT reserves nothing.
+  on DSCP-filter purge — frees it with no new delete path (the address-only token
+  is cleared from `address_only_owners` by the same `release_flow`). A reverse
+  synced entry, or a session with no source NAT at all (`rewrite_src` unset),
+  reserves nothing.
 - **Config-drift edge:** if the synced pool address is not a member of any local
   pool (the two nodes' pool config diverged), the reserve is skipped gracefully
   — never a panic, never a reservation on the wrong pool.

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -839,11 +839,32 @@ fn release_source_nat_allocation_with_mode(
 /// (`release_source_nat_allocation`, already called for every reaped or
 /// delete-synced session) frees the reservation — no new delete site.
 ///
-/// A synced session WITHOUT a translated source port (no source NAT, or
-/// address-only / `port no-translation`) reserves nothing. If the synced pool
-/// address is not a member of ANY local pool (config drift between nodes), the
-/// reserve is skipped gracefully — it never panics and never fabricates a
-/// reservation on the wrong pool.
+/// A synced session with NO source NAT at all (`rewrite_src` unset — plain
+/// forwarding) reserves nothing. If the synced pool address is not a member of
+/// ANY local pool (config drift between nodes), the reserve is skipped
+/// gracefully — it never panics and never fabricates a reservation on the wrong
+/// pool.
+///
+/// #5338: an ADDRESS-ONLY source-NAT decision (`port no-translation` on a
+/// port-bearing protocol, or a port-less protocol such as GRE/ESP) carries a
+/// pool `rewrite_src` but NO `rewrite_src_port` — the wire keeps the packet's
+/// own source port. The ACTIVE node (#5336 round-robin/persistent, #5341
+/// deterministic-CGNAT) still MINTS a reverse-identity occupancy token for such
+/// a flow via [`PortAllocator::reserve_address_only`], keyed on the translated
+/// reverse identity (protocol, pool address, PRESERVED source port, remote), so
+/// the reverse (1:N) index can disambiguate which internal flow owns a given
+/// public tuple. The standby must mint the SAME token for a synced address-only
+/// session; otherwise, after failover to it, its reverse index cannot
+/// disambiguate the promoted session (and a fresh local address-only flow could
+/// claim the same public identity the reverse index cannot tell apart). This
+/// mirrors the active-node mint here; NO pool PORT bit is consumed. The token is
+/// freed by the SAME teardown path as a PAT port
+/// (`release_source_nat_allocation` -> `PortAllocator::release_flow`, already
+/// called for every reaped or delete-synced session) — no new delete site. The
+/// #6207 `deterministic` threading applies ONLY to the port-bearing
+/// [`PortAllocator::reserve_flow`] arm; an address-only token carries no port
+/// bit, so — exactly like the active node's #5341 path — it mints via the plain
+/// `reserve_address_only` regardless of the pool's allocation mode.
 pub(crate) fn reserve_synced_source_nat_allocation(
     rules: &[SourceNatRule],
     key: &crate::session::SessionKey,
@@ -856,19 +877,46 @@ pub(crate) fn reserve_synced_source_nat_allocation(
     let Some(rewrite_src) = nat.rewrite_src else {
         return;
     };
-    let Some(rewrite_src_port) = nat.rewrite_src_port else {
-        return;
-    };
-    let translated = TranslatedTuple {
-        ip: rewrite_src,
-        port: rewrite_src_port,
-    };
     let flow = SourceNatFlowKey {
         protocol: key.protocol,
         src_ip: key.src_ip,
         dst_ip: nat.rewrite_dst.unwrap_or(key.dst_ip),
         src_port: key.src_port,
         dst_port: key.dst_port,
+    };
+    // #5338: address-only synced decision (pool address chosen, source port
+    // PRESERVED on the wire). Mint the reverse-identity occupancy token on the
+    // rule whose pool owns `rewrite_src`, mirroring the active node's #5336/#5341
+    // mint so the reverse 1:N index disambiguates identically. A collision on the
+    // standby (`Err` — a local flow already owns the identity) or a foreign pool
+    // address (no pool member) leaves the rule untouched and tries the next,
+    // matching the port-bearing arm's per-rule fall-through and the config-drift
+    // skip.
+    let Some(rewrite_src_port) = nat.rewrite_src_port else {
+        for rule in rules {
+            if !rule.pool_mode {
+                continue;
+            }
+            let in_pool = match rewrite_src {
+                IpAddr::V4(v4) => rule.pool_addresses_v4.iter().any(|a| *a == v4),
+                IpAddr::V6(v6) => rule.pool_addresses_v6.iter().any(|a| *a == v6),
+            };
+            if !in_pool {
+                continue;
+            }
+            if rule
+                .pool_allocator
+                .reserve_address_only(flow, rewrite_src)
+                .is_ok()
+            {
+                break;
+            }
+        }
+        return;
+    };
+    let translated = TranslatedTuple {
+        ip: rewrite_src,
+        port: rewrite_src_port,
     };
     for rule in rules {
         if !rule.pool_mode {

--- a/userspace-dp/src/nat/tests_pool.rs
+++ b/userspace-dp/src/nat/tests_pool.rs
@@ -4226,10 +4226,12 @@ fn synced_deterministic_reservation_not_recycled_5178() {
     );
 }
 
-// #4388: a peer-synced session WITHOUT a source-NAT translation (no
-// rewrite_src / rewrite_src_port — plain forwarding, address-only, or `port
-// no-translation`) reserves nothing. The allocator stays empty and a new flow
-// gets the first pool port.
+// #4388: a peer-synced session WITHOUT any source-NAT translation (no
+// `rewrite_src` at all — plain forwarding) reserves nothing. The allocator stays
+// empty and a new flow gets the first pool port. (An ADDRESS-ONLY decision —
+// `rewrite_src` set, `rewrite_src_port` None — now DOES mint a reverse-identity
+// token per #5338; that case is exercised by
+// `synced_address_only_session_reserves_reverse_identity_token_5338`.)
 #[test]
 fn synced_session_without_nat_reserves_nothing_4388() {
     let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
@@ -4319,6 +4321,106 @@ fn synced_reverse_entry_reserves_nothing_4388() {
         rules[0].pool_allocator.debug_occupied_count(),
         0,
         "a reverse synced entry must not reserve a pool source port"
+    );
+}
+
+// #5338 FAIL-ON-REVERT: a peer-synced ADDRESS-ONLY source-NAT session (`port
+// no-translation` — a pool ADDRESS is chosen but the source port is PRESERVED on
+// the wire, so the decision carries `rewrite_src = Some(pool_addr)` but NO
+// `rewrite_src_port`) must mint the SAME reverse-identity occupancy token on the
+// STANDBY that the active node minted (#5336 round-robin / #5341 deterministic),
+// so the reverse (1:N) index can disambiguate the promoted session after
+// failover.
+//
+// Before the fix `reserve_synced_source_nat_allocation` early-returned when
+// `rewrite_src_port` was None, so the standby minted NO token: its
+// `address_only_owners` map stayed empty and a fresh local address-only flow to
+// the SAME public identity was admitted as an UNOWNED duplicate the reverse
+// index could not tell apart from the synced session — the exact #5269
+// collision class the active node closes. Reverting the address-only arm
+// (restoring the `let Some(rewrite_src_port) = nat.rewrite_src_port else {
+// return; };` skip) makes the "token minted" + "colliding local flow denied"
+// assertions RED.
+#[test]
+fn synced_address_only_session_reserves_reverse_identity_token_5338() {
+    // One-address `port no-translation` pool: address-only, source port preserved.
+    let rules = one_address_notrans_rule();
+
+    // A peer-synced ADDRESS-ONLY session: the active node chose pool address
+    // 203.0.113.1 and PRESERVED the source port (`rewrite_src_port` None).
+    let synced_key = session_key_from_src("10.0.1.100", 12345, "8.8.8.8", 443);
+    let synced_nat = NatDecision {
+        rewrite_src: Some("203.0.113.1".parse().unwrap()),
+        rewrite_src_port: None,
+        ..NatDecision::default()
+    };
+
+    reserve_synced_source_nat_allocation(&rules, &synced_key, synced_nat, false);
+
+    // THE FAIL-ON-REVERT ASSERTION (mint): the standby minted the reverse-
+    // identity token for the synced flow. On revert the map is empty.
+    let synced_flow = SourceNatFlowKey {
+        protocol: PROTO_TCP,
+        src_ip: "10.0.1.100".parse().unwrap(),
+        dst_ip: "8.8.8.8".parse().unwrap(),
+        src_port: 12345,
+        dst_port: 443,
+    };
+    let owners = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(
+        owners.len(),
+        1,
+        "standby must mint one address-only occupancy token for the synced session"
+    );
+    assert_eq!(
+        owners[0].1, synced_flow,
+        "reverse index must resolve to the synced flow"
+    );
+    assert_eq!(
+        owners[0].0.translated_ip,
+        "203.0.113.1".parse::<IpAddr>().unwrap()
+    );
+    // The PRESERVED source port keys the reverse identity.
+    assert_eq!(owners[0].0.translated_port, 12345);
+
+    // No pool PORT bit is consumed (address-only tokens are off the port bitmap).
+    assert_eq!(
+        rules[0].pool_allocator.debug_occupied_count(),
+        0,
+        "an address-only reservation must not claim a pool-port bit"
+    );
+
+    // THE FAIL-ON-REVERT ASSERTION (disambiguation): a fresh LOCAL address-only
+    // flow to the SAME public identity (one-address pool forces 203.0.113.1;
+    // SAME preserved port + remote) must now be DENIED as exhaustion — the
+    // standby already owns that reverse identity from the synced session. On
+    // revert it is `Matched` with `rewrite_src_port: None`, an unowned duplicate
+    // the reverse index cannot disambiguate from the synced session.
+    match addr_only_lookup(&rules, "10.0.1.200", 12345, "8.8.8.8", 443, PROTO_TCP) {
+        SourceNatLookup::Unavailable(f) => assert_eq!(
+            f.reason,
+            SourceNatFailureReason::AllocatorExhausted,
+            "a local flow colliding with the synced reverse identity must fail closed",
+        ),
+        other => panic!("colliding local flow must be denied (exhaustion), got {other:?}"),
+    }
+    // The synced session STILL owns the identity uniquely — the denied local flow
+    // minted nothing.
+    let owners_after = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(
+        owners_after.len(),
+        1,
+        "denied local flow must not add a token"
+    );
+    assert_eq!(owners_after[0].1, synced_flow);
+
+    // Teardown of the synced session (standby reap / delete-sync) frees the token
+    // via the SAME `release_source_nat_allocation` path — no new delete site.
+    release_source_nat_allocation(&rules, &synced_key, synced_nat, false, 1_000);
+    assert_eq!(
+        rules[0].pool_allocator.debug_address_only_owners().len(),
+        0,
+        "releasing the synced session must free its address-only token (no leak)"
     );
 }
 


### PR DESCRIPTION
## Summary

- Follow-up to #5336/#5269. On the ACTIVE node an ADDRESS-ONLY source-NAT translation (`port no-translation` on a port-bearing protocol, or a port-less protocol such as GRE/ESP) selects a pool address but PRESERVES the source port on the wire, so it mints a reverse-identity occupancy TOKEN via `PortAllocator::reserve_address_only` (keyed on protocol, pool address, preserved source port, remote) so the reverse (1:N) index can disambiguate which internal flow owns a given public tuple.
- The analogous HA-sync path on the STANDBY was deferred in #5336: `reserve_synced_source_nat_allocation` (userspace-dp, `nat/source.rs`) early-returned whenever the synced decision carried no `rewrite_src_port` — i.e. for every address-only session. So a standby that imported an address-only source-NAT session minted **no** token. On failover to it, its reverse index could not disambiguate the promoted session, and a fresh local address-only flow could claim the same public identity (the #5269 collision class, cross-node).
- Add an address-only arm to the synced reserve that mirrors the active node's mint: for a synced decision with `rewrite_src = Some(pool_addr)` and `rewrite_src_port = None`, claim the SAME token via `reserve_address_only` on the rule whose pool owns `rewrite_src`, consuming no pool-port bit. A collision or a foreign pool address is skipped gracefully, matching the port-bearing arm.
- **Composes with the just-merged #6207 (#5178) `deterministic` threading**: that flag applies only to the port-bearing `reserve_flow` arm, left unchanged. An address-only token carries no port bit, so — exactly like the active node's #5341 deterministic-CGNAT path — it mints via plain `reserve_address_only` regardless of pool mode.
- The token is freed by the SAME teardown path (`release_source_nat_allocation` -> `release_flow`, which clears `address_only_owners`) already called for every reaped or delete-synced session — no new delete site.

## Test plan

- [x] `synced_address_only_session_reserves_reverse_identity_token_5338` (`nat/tests_pool.rs`): reserve a synced address-only session; assert the standby mints exactly one occupancy token AND a colliding local address-only flow to the same public identity is denied as exhaustion; releasing the synced session frees the token.
- [x] **Fail-on-revert**: restoring the `let Some(rewrite_src_port) = nat.rewrite_src_port else { return; };` skip turns the test RED with a clean assertion (`standby must mint one address-only occupancy token`) — not a compile break.
- [x] `cargo build` OK; full `cargo test --release` green (4071 lib + 8 + 22 + 1 + 60 across all bins, 0 failed) across two consecutive runs.
- [ ] **Deferred — loss-cluster failover smoke**: this is a NAT/dataplane HA path and needs a `make test-failover` on the loss userspace cluster (to be batched).

## Docs

- Updated the synced source-NAT reserve contract (`docs/session-sync-architecture.md`) to document the address-only token minting and drop the stale "address-only reserves nothing" claim.

## Refs

- Closes #5338
- Follow-up from #5336 / #5269 / #5341; composes with #6207 (#5178)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Abs7H9iXq2hvKgu5UH7fLf