### PR TITLE
userspace: fast-fail bulk session-sync on a hung helper (#5380)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -55153,3 +55153,39 @@ top.
   pkg/dataplane/userspace/manager_ha.go,
   pkg/dataplane/userspace/sync_socket_fastfail_5380_test.go,
   userspace-dp/src/server/README.md, _Log.md
+
+- **Timestamp**: 2026-07-21 (PR #6212 fold)
+- **Action**: Fold a hostile-review finding into PR #6212 (#5380): the fast-fail
+  `break` added earlier only aborted the 256-request loop INSIDE a single
+  `deleteHelperSessionsV4/V6` call. `ClearAllSessions` drives the helper delete
+  through `m.bpfShim.ClearAllSessionsChunked`, which invokes the two delete
+  callbacks ONCE PER 4096-key mirror chunk (v4 chunks, then v6). The callbacks
+  return void, so the inner abort did not propagate: a full clear-all under a
+  hung helper still paid ~one round-trip deadline PER chunk (~10M/4096 ≈ 2440
+  chunks/family ≈ ~2 h/family), not "one deadline total" as the PR claimed.
+  Guarded both closures with `helperDown()` (`errors.Is(helperErr,
+  errSessionHelperUnreachable)`): once a TRANSPORT failure is recorded the
+  remaining chunks skip the helper delete, bringing clear-all to ~one deadline
+  total. The BPF mirror still clears fully (the shim deletes each chunk BEFORE
+  invoking the callback); `helperErr` stays set so the #5881 error-propagation
+  and #5882 partial-count contracts are intact. Only the wrapped sentinel trips
+  the skip — an app-level `!resp.OK` rejection is NOT wrapped, so a live helper
+  that refuses one delete keeps clearing the batch (#5881). Fail-on-revert test
+  `TestClearAllSessionsFastFailsAcrossChunksOnHungHelper5380`
+  (`clear_all_multichunk_fastfail_5380_test.go`): one v4 + one v6 mirror session
+  → two delete callbacks against a counting hung helper; guarded pays ~one
+  shrunk 400ms deadline and dials the helper ONCE (v6 chunk skipped), unguarded
+  pays ~two deadlines and dials twice. RED on revert (neutralize `helperDown`):
+  elapsed 801ms > 650ms bound AND acceptCount 2 ≠ 1. Verified under sudo (BPF
+  memlock): the new test + #5380 + #5881 all GREEN; neutralizing `helperDown`
+  reddens the new test; neutralizing the original inner `break` reddens
+  `TestSyncSessionRequestsLockedFastFailsOnHungHelper5380` (1.505s) while the
+  new test stays GREEN (independent bindings). 6 XDP-shim tests
+  (TestApplyHelperStatus*/TestUserspaceXDP*/TestXSKLiveness*) fail identically
+  at the pristine PR head — pre-existing, need real XDP program load, unrelated.
+  Updated the `ClearAllSessions` doc comment + `userspace-dp/src/server/README.md`
+  so the documented clear-all contract matches (~one deadline total). HA
+  session-sync path — needs a loss-cluster failover smoke (batched).
+- **File(s)**: pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/clear_all_multichunk_fastfail_5380_test.go,
+  userspace-dp/src/server/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -55117,3 +55117,39 @@ top.
   contract in `docs/session-sync-architecture.md`.
 - **File(s)**: userspace-dp/src/nat/source.rs,
   userspace-dp/src/nat/tests_pool.rs, docs/session-sync-architecture.md, _Log.md
+
+- **Timestamp**: 2026-07-21 18:52
+- **Action**: #5380 — fast-fail bulk session-sync mirror on a hung/unreachable
+  helper. The per-request dial timeout (2s) + round-trip deadline (3s) already
+  existed on the dedicated session socket (`requestSessionSync`,
+  `process_control.go`), so ONE request already fails in bounded time. The
+  residual bug was the BATCH multiplication: `syncSessionRequestsLocked` loops
+  over up to `sessionHelperDeleteChunk` (256) requests, and under a hung helper
+  (accepts but never replies) each paid the FULL 3s deadline — 256 × 3s ≈ 13 min
+  per chunk while repeatedly holding `sessionMu`, starving live session installs
+  (the CLAUDE.md control-socket-contention concern). Fix: wrap the three
+  transport-layer failures (dial/write/read) with a new
+  `errSessionHelperUnreachable` sentinel; `syncSessionRequestsLocked` and the
+  `deleteHelperSessionsV4/V6` chunk loops abort on the first such error so the
+  whole batch (and a full clear-all) costs ~one round-trip deadline, not one per
+  request/chunk. Application-level rejections (helper alive, `resp.OK=false`) are
+  NOT wrapped, so the #5881 best-effort "drop as many as we can" + error-report
+  contract is preserved. Confirmed the session socket is one-request-per-
+  connection (`handle_stream`), so connection reuse would break framing — noted
+  as a non-fix. Named the dial/round-trip bounds as package vars
+  (`sessionSyncDialTimeout` / `sessionSyncRoundtripDeadline`) so the regression
+  test can shrink them. Fail-on-revert test
+  `TestSyncSessionRequestsLockedFastFailsOnHungHelper5380`
+  (`sync_socket_fastfail_5380_test.go`): a hung listener accepts but never
+  replies; a 10-request batch must return within 500ms (~one shrunk 150ms
+  deadline) AND carry `errSessionHelperUnreachable`. RED on revert (drop the
+  `errors.Is(err, errSessionHelperUnreachable) { break }`): batch takes 1.505s
+  (10 × 150ms) and blows the bound — a clean elapsed assertion, not a compile
+  break. Validated on disk: `go build ./...`, `go vet`, full
+  `pkg/dataplane/userspace` suite green. HA session-sync path — needs a
+  loss-cluster failover smoke (batched). Documented the Go-side batch fast-fail
+  contract in `userspace-dp/src/server/README.md`.
+- **File(s)**: pkg/dataplane/userspace/process_control.go,
+  pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/sync_socket_fastfail_5380_test.go,
+  userspace-dp/src/server/README.md, _Log.md

--- a/pkg/dataplane/userspace/clear_all_multichunk_fastfail_5380_test.go
+++ b/pkg/dataplane/userspace/clear_all_multichunk_fastfail_5380_test.go
@@ -1,0 +1,160 @@
+// #5380 residual: the fast-fail `break` inside deleteHelperSessions{V4,V6}
+// only aborts the 256-request loop of a SINGLE call. ClearAllSessions drives
+// the helper delete through ClearAllSessionsChunked, which invokes the delete
+// callback ONCE PER mirror chunk (sessionClearSnapshotChunk = 4096 keys) — and
+// once per family (v4 chunks, then v6 chunks). Because the callbacks return
+// void, an inner abort does not propagate: without the ClearAllSessions
+// helperDown() guard the shim keeps handing every remaining chunk to a hung
+// helper, so a full clear-all still paid ~one round-trip deadline PER chunk
+// (~2440 chunks/family on a max table ≈ hours), not "one deadline total".
+//
+// This binds the OUTER guard. A mirror seeded with one v4 and one v6 session
+// produces exactly two delete callbacks (one v4 chunk, then one v6 chunk)
+// against a HUNG helper (accepts but never replies). With the guard the v4
+// chunk's transport failure is recorded and the v6 chunk SKIPS its helper
+// delete: the helper socket is dialed once and the clear pays ~one deadline.
+// Without the guard both chunks dial the hung helper: two dials, ~two
+// deadlines.
+//
+// FAIL-ON-REVERT: delete the `if helperDown() { return }` guard from the two
+// ClearAllSessionsChunked closures in ClearAllSessions (or make helperDown()
+// always false) and this test goes RED — the v6 chunk dials the hung helper
+// too (helperDials == 2, not 1) and the elapsed doubles to ~2 * the shrunk
+// deadline, blowing the bound. A clean structural + elapsed assertion, not a
+// compile break. The #5881 propagation (helperErr still set) and the
+// app-rejection-continues path are unaffected — only a TRANSPORT failure trips
+// the skip.
+package userspace
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/rlimit"
+)
+
+// countingHungSessionSocket binds the dedicated session socket, ACCEPTS every
+// connection, and parks it without reading or replying — a helper whose
+// session thread is wedged. It records how many connections were accepted so a
+// test can prove which chunks actually dialed the helper (a skipped chunk
+// never dials).
+type countingHungSessionSocket struct {
+	ln      net.Listener
+	mu      sync.Mutex
+	accepts int
+	held    []net.Conn
+}
+
+func startCountingHungSessionSocket(t *testing.T, sockPath string) *countingHungSessionSocket {
+	t.Helper()
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen hung session socket: %v", err)
+	}
+	c := &countingHungSessionSocket{ln: ln}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.mu.Lock()
+			c.accepts++
+			c.held = append(c.held, conn)
+			c.mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		c.mu.Lock()
+		for _, h := range c.held {
+			_ = h.Close()
+		}
+		c.mu.Unlock()
+	})
+	return c
+}
+
+func (c *countingHungSessionSocket) acceptCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.accepts
+}
+
+func TestClearAllSessionsFastFailsAcrossChunksOnHungHelper5380(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+
+	// One v4 + one v6 mirror session → two delete callbacks (a v4 chunk then a
+	// v6 chunk). newClearManager5881 sets m.proc, injects real session maps,
+	// and seeds the pair; the short-prefix mkdtemp keeps the AF_UNIX path under
+	// the 108-byte sun_path limit (run with TMPDIR=/tmp).
+	m, adapter, sessionSock := newClearManager5881(t)
+	sock := startCountingHungSessionSocket(t, sessionSock)
+
+	// Shrink the per-request bounds so the batch timing is fast to measure. The
+	// dial succeeds (the socket accepts), so the round-trip deadline is what a
+	// hung chunk pays.
+	origDial, origRT := sessionSyncDialTimeout, sessionSyncRoundtripDeadline
+	sessionSyncDialTimeout = 400 * time.Millisecond
+	sessionSyncRoundtripDeadline = 400 * time.Millisecond
+	t.Cleanup(func() {
+		sessionSyncDialTimeout = origDial
+		sessionSyncRoundtripDeadline = origRT
+	})
+
+	type result struct {
+		v4, v6  int
+		err     error
+		elapsed time.Duration
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		v4, v6, err := adapter.ClearAllSessions()
+		resCh <- result{v4: v4, v6: v6, err: err, elapsed: time.Since(start)}
+	}()
+
+	// Bound sits between one and two shrunk deadlines: the guarded clear pays
+	// ~one deadline (the v4 chunk) and skips the v6 helper delete; the unfixed
+	// clear pays ~two (v4 + v6 chunk). The 5s watchdog guarantees the suite
+	// never hangs on the pathological regression.
+	const bound = 650 * time.Millisecond
+	select {
+	case res := <-resCh:
+		if res.elapsed > bound {
+			t.Fatalf("ClearAllSessions took %v against a hung helper; want <%v. "+
+				"The v6 chunk is still dialing the hung helper after the v4 chunk "+
+				"recorded a transport failure — the ClearAllSessions helperDown() "+
+				"guard is missing, so clear-all pays ~one deadline PER chunk (#5380)",
+				res.elapsed, bound)
+		}
+		// Structural, jitter-free RED signal: only the v4 chunk dials the helper;
+		// the v6 chunk short-circuits, so the hung socket sees exactly ONE accept.
+		if got := sock.acceptCount(); got != 1 {
+			t.Fatalf("hung helper accepted %d connections; want 1 (v4 chunk only). "+
+				"The v6 chunk dialed the hung helper too — the helperDown() guard "+
+				"does not skip remaining chunks after a transport failure (#5380)", got)
+		}
+		// #5881 contract intact: the transport failure is still surfaced (the
+		// wrapped sentinel), and the mirror's partial counts still come back.
+		if !errors.Is(res.err, errSessionHelperUnreachable) {
+			t.Fatalf("expected the clear-all error to carry errSessionHelperUnreachable "+
+				"(the authoritative revocation is unconfirmed), got %v", res.err)
+		}
+		if res.v4 != 1 || res.v6 != 1 {
+			t.Errorf("counts = (%d, %d), want (1, 1) surfaced alongside the error (#5882)", res.v4, res.v6)
+		}
+		if mv4, mv6 := m.bpfShim.SessionCount(); mv4 != 0 || mv6 != 0 {
+			t.Errorf("mirror not cleared: count = (%d, %d), want (0, 0) — the skip must "+
+				"only bypass the HELPER delete, never the mirror clear", mv4, mv6)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("ClearAllSessions did not return within 5s against a hung helper; "+
+			"the per-chunk helper delete is not short-circuiting (#5380)")
+	}
+}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1465,8 +1465,16 @@ func (m *Manager) deleteHelperSessionsV4(keys []dataplane.SessionKey) error {
 		for i := start; i < end; i++ {
 			reqs = append(reqs, m.buildSessionSyncRequestV4("delete", keys[i], nil))
 		}
-		if err := m.syncSessionRequestsLocked(reqs...); err != nil && firstErr == nil {
-			firstErr = err
+		if err := m.syncSessionRequestsLocked(reqs...); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			// Helper unreachable/hung: stop chunking. Every remaining chunk
+			// would fast-fail identically, so a large clear (10M keys ≈ 40K
+			// chunks) does not spend one round-trip deadline PER chunk (#5380).
+			if errors.Is(err, errSessionHelperUnreachable) {
+				break
+			}
 		}
 	}
 	return firstErr
@@ -1492,8 +1500,14 @@ func (m *Manager) deleteHelperSessionsV6(keys []dataplane.SessionKeyV6) error {
 		for i := start; i < end; i++ {
 			reqs = append(reqs, m.buildSessionSyncRequestV6("delete", keys[i], nil))
 		}
-		if err := m.syncSessionRequestsLocked(reqs...); err != nil && firstErr == nil {
-			firstErr = err
+		if err := m.syncSessionRequestsLocked(reqs...); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			// Helper unreachable/hung: stop chunking (see deleteHelperSessionsV4).
+			if errors.Is(err, errSessionHelperUnreachable) {
+				break
+			}
 		}
 	}
 	return firstErr
@@ -1716,12 +1730,23 @@ func (m *Manager) syncSessionRequestLocked(req SessionSyncRequest) error {
 // resolved against one consistent snapshot (#5007). Sending both requests
 // under a single unlock also keeps the pair's transmit contiguous.
 //
-// It attempts EVERY request even when an earlier one fails (so a bulk
-// revocation drops as many helper sessions as it can) and returns the FIRST
-// helper IPC error encountered, or nil if all succeeded. Best-effort mirror
-// callers (mirrorSessionPair*, batch delete) discard the result; the
-// authoritative clear-all path (#5881) propagates it so a failed helper
-// revocation is reported instead of masquerading as success.
+// It attempts every request as long as the helper keeps answering — an
+// APPLICATION-level rejection of one request (helper alive, resp.OK=false) does
+// not stop the loop, so a bulk revocation drops as many helper sessions as it
+// can. It returns the FIRST helper IPC error encountered, or nil if all
+// succeeded. Best-effort mirror callers (mirrorSessionPair*, batch delete)
+// discard the result; the authoritative clear-all path (#5881) propagates it so
+// a failed helper revocation is reported instead of masquerading as success.
+//
+// #5380: if a request fails at the TRANSPORT layer (dial/write/read wrapped
+// with errSessionHelperUnreachable), the helper is down or hung and every
+// remaining request in this batch would pay the full per-request deadline too.
+// A bulk delete chunk is up to sessionHelperDeleteChunk (256) requests, so
+// looping on would stall bulk session ops — and repeatedly hold sessionMu,
+// starving live session installs — for ~256 * sessionSyncRoundtripDeadline
+// (~13 min). So the batch fast-fails: it stops after the first transport
+// failure and returns it. The mirror is best-effort — the periodic sweep
+// retries once the helper is healthy again.
 func (m *Manager) syncSessionRequestsLocked(reqs ...SessionSyncRequest) error {
 	if len(reqs) == 0 {
 		return nil
@@ -1738,6 +1763,11 @@ func (m *Manager) syncSessionRequestsLocked(reqs ...SessionSyncRequest) error {
 			slog.Debug("userspace session sync mirror failed", "operation", reqs[i].Operation, "err", err)
 			if firstErr == nil {
 				firstErr = err
+			}
+			// Helper unreachable/hung: abort the batch instead of paying the
+			// per-request deadline once per remaining request (#5380).
+			if errors.Is(err, errSessionHelperUnreachable) {
+				break
 			}
 		}
 	}

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1415,6 +1415,11 @@ func (m *Manager) BatchDeleteSessionsV6(keys []dataplane.SessionKeyV6) (int, err
 // non-atomic clear-all reporting contract, so a caller learns what the mirror
 // side revoked while also learning the authoritative revocation is unconfirmed.
 // A mirror-side error still takes precedence and is returned as before.
+//
+// #5380 residual: the per-chunk callbacks skip the helper delete once a
+// transport failure is recorded, so a full clear-all under a hung helper pays
+// ~one round-trip deadline total rather than one per 4096-key mirror chunk.
+// See the helperDown guard below.
 func (m *Manager) ClearAllSessions() (int, int, error) {
 	var helperErr error
 	recordHelperErr := func(err error) {
@@ -1422,9 +1427,38 @@ func (m *Manager) ClearAllSessions() (int, int, error) {
 			helperErr = err
 		}
 	}
+	// Fast-fail the WHOLE clear-all once the helper transport is down, not just
+	// the 256-request loop inside a single deleteHelperSessions call (#5380
+	// only aborted that inner loop). ClearAllSessionsChunked invokes these
+	// callbacks ONCE PER sessionClearSnapshotChunk (4096-key) mirror chunk, and
+	// the callbacks return void, so an inner abort does not propagate up: the
+	// shim keeps handing every remaining chunk to a hung helper. A max table is
+	// ~10M keys / 4096 ≈ 2440 chunks per family, so without this guard a
+	// clear-all under a hung helper still pays ~one round-trip deadline PER
+	// chunk (~2 h/family) even though each chunk's own delete already
+	// fast-fails. Once a TRANSPORT failure has been recorded, skip the helper
+	// delete for the remaining chunks so the clear-all pays ~one deadline
+	// total. Only errSessionHelperUnreachable (a hung/unreachable helper) trips
+	// the skip; an application-level rejection (helper alive, resp.OK=false) is
+	// NOT wrapped as the sentinel, so a live helper that refuses one delete
+	// keeps clearing the rest of the batch (#5881). The BPF mirror still clears
+	// fully — the shim deletes each chunk BEFORE invoking the callback — and
+	// helperErr stays set, so the #5881 error-propagation and #5882
+	// partial-count contracts are unchanged.
+	helperDown := func() bool { return errors.Is(helperErr, errSessionHelperUnreachable) }
 	v4, v6, mirrorErr := m.bpfShim.ClearAllSessionsChunked(
-		func(keys []dataplane.SessionKey) { recordHelperErr(m.deleteHelperSessionsV4(keys)) },
-		func(keys []dataplane.SessionKeyV6) { recordHelperErr(m.deleteHelperSessionsV6(keys)) },
+		func(keys []dataplane.SessionKey) {
+			if helperDown() {
+				return
+			}
+			recordHelperErr(m.deleteHelperSessionsV4(keys))
+		},
+		func(keys []dataplane.SessionKeyV6) {
+			if helperDown() {
+				return
+			}
+			recordHelperErr(m.deleteHelperSessionsV6(keys))
+		},
 	)
 	if mirrorErr != nil {
 		return v4, v6, mirrorErr

--- a/pkg/dataplane/userspace/process_control.go
+++ b/pkg/dataplane/userspace/process_control.go
@@ -56,6 +56,32 @@ const (
 	controlMaxDeadline = 120 * time.Second
 )
 
+// errSessionHelperUnreachable classifies a session-socket round-trip that
+// failed at the TRANSPORT layer (dial, write, or read) rather than being
+// rejected by the helper's handler. syncSessionRequestsLocked uses it to abort
+// a bulk batch early (#5380): if one request cannot complete a round-trip, the
+// helper is down or hung and every remaining request in the same batch would
+// pay the full per-request deadline too. A bulk delete chunk is up to
+// sessionHelperDeleteChunk (256) requests, so without the early abort a single
+// hung helper stalls the whole batch for ~256 * sessionSyncRoundtripDeadline
+// (~13 min) while repeatedly holding sessionMu — starving live session
+// installs. An APPLICATION-level rejection (the helper answered but set
+// resp.OK=false for this one request) is NOT wrapped with this sentinel, so the
+// batch keeps going: the helper is alive and only this request was refused.
+var errSessionHelperUnreachable = errors.New("session helper unreachable")
+
+// sessionSyncDialTimeout and sessionSyncRoundtripDeadline bound a single
+// session-socket round-trip so a hung helper fails one mirror request in a few
+// seconds instead of the OS default (which can be minutes). They match the
+// per-session control-socket convention (2s dial, controlBaseDeadline 3s
+// round-trip). They are package vars, not consts, ONLY so the #5380 hung-helper
+// regression test can shrink them to keep its bulk-batch timing fast; nothing
+// in production mutates them.
+var (
+	sessionSyncDialTimeout       = 2 * time.Second
+	sessionSyncRoundtripDeadline = controlBaseDeadline
+)
+
 // controlRoundtripDeadline sizes the control-socket read/write deadline to the
 // serialized request length so a large apply_snapshot is not falsely timed out
 // (#4036). It is a pure function of the body length: a sub-1-MiB request keeps
@@ -162,18 +188,24 @@ func (m *Manager) requestSessionSync(req ControlRequest) error {
 	}
 	m.sessionMu.Lock()
 	defer m.sessionMu.Unlock()
-	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	// A bounded dial + round-trip deadline so a hung helper (accepts the
+	// connection but never reads/replies) fails THIS request in a few seconds
+	// instead of the OS default. Transport failures (dial/write/read) are
+	// wrapped with errSessionHelperUnreachable so a bulk caller can abort the
+	// rest of the batch instead of paying this deadline once per request
+	// (#5380).
+	conn, err := net.DialTimeout("unix", sockPath, sessionSyncDialTimeout)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: dial session socket: %w", errSessionHelperUnreachable, err)
 	}
 	defer conn.Close()
-	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	_ = conn.SetDeadline(time.Now().Add(sessionSyncRoundtripDeadline))
 	if err := json.NewEncoder(conn).Encode(&req); err != nil {
-		return err
+		return fmt.Errorf("%w: write session request: %w", errSessionHelperUnreachable, err)
 	}
 	var resp ControlResponse
 	if err := json.NewDecoder(bufio.NewReader(conn)).Decode(&resp); err != nil {
-		return err
+		return fmt.Errorf("%w: read session response: %w", errSessionHelperUnreachable, err)
 	}
 	if !resp.OK {
 		if resp.Error == "" {

--- a/pkg/dataplane/userspace/sync_socket_fastfail_5380_test.go
+++ b/pkg/dataplane/userspace/sync_socket_fastfail_5380_test.go
@@ -1,0 +1,142 @@
+// #5380: syncSessionRequestsLocked mirrors a batch of session-sync requests to
+// the Rust helper by dialing the dedicated session control socket once PER
+// request. Each request already fails in bounded time (sessionSyncDialTimeout +
+// sessionSyncRoundtripDeadline), but before this fix the batch loop paid that
+// deadline ONCE PER request: a hung helper (accepts the connection but never
+// reads or replies) made an N-request batch block for N * the round-trip
+// deadline. A bulk delete chunk is up to sessionHelperDeleteChunk (256)
+// requests, so a single hung helper stalled bulk session ops — while repeatedly
+// holding sessionMu, starving live session installs — for minutes.
+//
+// The fix wraps a transport-layer round-trip failure (dial/write/read) with
+// errSessionHelperUnreachable and aborts the batch on the first such error, so
+// a hung helper costs ~one round-trip deadline for the WHOLE batch, not one per
+// request. The mirror is best-effort; the periodic sweep retries once the
+// helper is healthy.
+//
+// FAIL-ON-REVERT: delete the `if errors.Is(err, errSessionHelperUnreachable) {
+// break }` fast-fail in syncSessionRequestsLocked and this test goes RED — the
+// batch reverts to N per-request deadlines and blows the elapsed bound (it
+// takes ~n * shrunk-deadline instead of ~one).
+package userspace
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// startHungSessionSocket binds the dedicated session socket and ACCEPTS
+// connections but never reads or responds — reproducing a helper whose session
+// thread is wedged. A client dial succeeds (the kernel/handler accepts) and the
+// client's read then blocks until its own deadline fires, which is exactly the
+// per-request stall the batch loop must not pay once per request.
+func startHungSessionSocket(t *testing.T, sockPath string) {
+	t.Helper()
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen hung session socket: %v", err)
+	}
+	var mu sync.Mutex
+	var held []net.Conn
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Park the connection without reading or writing so the client's
+			// round-trip stalls until its read deadline.
+			mu.Lock()
+			held = append(held, c)
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		mu.Lock()
+		for _, c := range held {
+			_ = c.Close()
+		}
+		mu.Unlock()
+	})
+}
+
+func TestSyncSessionRequestsLockedFastFailsOnHungHelper5380(t *testing.T) {
+	// A SHORT temp-dir prefix (not t.TempDir(), which embeds the long test
+	// name) keeps the AF_UNIX path under the 108-byte sun_path limit — the
+	// "bind: invalid argument" trap. Respects TMPDIR (run with TMPDIR=/tmp).
+	dir, err := os.MkdirTemp("", "x5380")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	controlSock := filepath.Join(dir, "control.sock")
+	sessionSock := filepath.Join(dir, "userspace-dp-sessions.sock")
+	startHungSessionSocket(t, sessionSock)
+
+	// Shrink the per-request bounds so the batch timing is fast to measure. The
+	// dial succeeds (the socket accepts), so it is the round-trip deadline that
+	// dominates the hung-helper stall.
+	origDial, origRT := sessionSyncDialTimeout, sessionSyncRoundtripDeadline
+	sessionSyncDialTimeout = 150 * time.Millisecond
+	sessionSyncRoundtripDeadline = 150 * time.Millisecond
+	t.Cleanup(func() {
+		sessionSyncDialTimeout = origDial
+		sessionSyncRoundtripDeadline = origRT
+	})
+
+	m := New()
+	m.cfg.ControlSocket = controlSock
+
+	// A batch of n requests. With the fast-fail the batch stops after the first
+	// transport failure (~one round-trip deadline). Without it, every request
+	// pays the deadline: ~n * 150ms = 1.5s.
+	const n = 10
+	reqs := make([]SessionSyncRequest, n)
+	for i := range reqs {
+		reqs[i] = SessionSyncRequest{Operation: "delete"}
+	}
+
+	type result struct {
+		elapsed time.Duration
+		err     error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		m.mu.Lock()
+		err := m.syncSessionRequestsLocked(reqs...)
+		m.mu.Unlock()
+		resCh <- result{elapsed: time.Since(start), err: err}
+	}()
+
+	// Bound is ~3x one shrunk deadline: comfortably above a single request's
+	// stall (plus jitter) and far below the n-deadline (1.5s) the unfixed batch
+	// would take. The 5s watchdog guarantees the suite never hangs even on the
+	// pathological unbounded regression.
+	const bound = 500 * time.Millisecond
+	select {
+	case res := <-resCh:
+		if res.elapsed > bound {
+			t.Fatalf("syncSessionRequestsLocked took %v for %d hung requests; want <%v. "+
+				"The batch is paying the per-request round-trip deadline once PER request — "+
+				"the errSessionHelperUnreachable fast-fail break is missing (#5380)",
+				res.elapsed, n, bound)
+		}
+		// The batch aborted BECAUSE the helper was unreachable — prove the
+		// returned error carries the sentinel so callers (clear-all #5881) still
+		// report the failure rather than masquerading it as success.
+		if !errors.Is(res.err, errSessionHelperUnreachable) {
+			t.Fatalf("expected errSessionHelperUnreachable from a hung helper, got %v", res.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("syncSessionRequestsLocked did not return within 5s for %d hung requests; "+
+			"the batch is not fast-failing on an unreachable helper (#5380)", n)
+	}
+}

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -300,3 +300,16 @@ queues. See PR #1243's kill record for why i40e doesn't reshape.
   snapshot sync, and forwarding sync. The control channel is still
   shared by those other callers; adding a new caller there at >1 Hz
   can still starve the other low-frequency control operations.
+  - Each session round-trip is one-request-per-connection: the Go side
+    dials this socket, sends one newline-framed request, reads one
+    response, and closes. If this thread is hung (accepts but never
+    replies), the Go side bounds a single round-trip with a dial timeout
+    plus a read/write deadline (`sessionSyncDialTimeout` /
+    `sessionSyncRoundtripDeadline`, `pkg/dataplane/userspace`). A **bulk**
+    Go caller (batch/clear session delete, up to 256 requests per chunk)
+    additionally fast-fails the whole batch on the first transport failure
+    (`errSessionHelperUnreachable`) instead of paying that deadline once
+    per request, so a hung helper cannot stall bulk session ops — nor
+    repeatedly hold the Go-side `sessionMu` and starve live installs — for
+    minutes (#5380). The session mirror is best-effort; the periodic sweep
+    retries once this thread is healthy again.

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -311,5 +311,11 @@ queues. See PR #1243's kill record for why i40e doesn't reshape.
     (`errSessionHelperUnreachable`) instead of paying that deadline once
     per request, so a hung helper cannot stall bulk session ops — nor
     repeatedly hold the Go-side `sessionMu` and starve live installs — for
-    minutes (#5380). The session mirror is best-effort; the periodic sweep
-    retries once this thread is healthy again.
+    minutes (#5380). Clear-all (`ClearAllSessions`) walks the mirror one
+    4096-key chunk at a time and issues a helper delete per chunk, so it
+    additionally guards the per-chunk delete on the same sentinel: once a
+    transport failure is recorded the remaining chunks skip the helper delete
+    (the BPF mirror still clears fully), bringing a full clear-all under a hung
+    helper to ~one round-trip deadline total rather than one per chunk
+    (~2440 chunks/family on a max table). The session mirror is best-effort;
+    the periodic sweep retries once this thread is healthy again.


### PR DESCRIPTION
## Summary

- The dedicated session-install socket already bounds a **single** round-trip (`requestSessionSync`: 2s dial timeout + 3s read/write deadline), so one mirror request against a hung helper fails in seconds. The residual bug is the **batch multiplication**.
- `syncSessionRequestsLocked` dials a fresh connection **per request**; the bulk delete/clear paths hand it up to `sessionHelperDeleteChunk` (256) requests per chunk. Under a hung helper (accepts the connection but never reads/replies) every request paid the full 3s deadline → ~256 × 3s ≈ **13 min per chunk**, while repeatedly holding `sessionMu` and starving live session installs (the control-socket-contention failure mode the dedicated socket exists to avoid).
- **Fix (first commit):** classify a round-trip failure by layer. Dial/write/read failures are wrapped with a new `errSessionHelperUnreachable` sentinel; `syncSessionRequestsLocked` and the `deleteHelperSessions{V4,V6}` chunk loops **abort the batch on the first such error**, so a single bulk delete (and each individual `deleteHelperSessions*` call) costs ~one round-trip deadline instead of one per request.
- **Fold (second commit — review finding):** that inner break only aborts the 256-request loop inside a *single* `deleteHelperSessions*` call. `ClearAllSessions` drives the helper delete through `ClearAllSessionsChunked`, which invokes the two delete callbacks **once per 4096-key mirror chunk** (all v4 chunks, then v6); the callbacks return void, so the inner abort did not propagate. A max ~10M-key table is ~2440 chunks/family, so a full clear-all under a hung helper still paid ~one deadline **per chunk** (~2 h/family) — not "one deadline total". The two `ClearAllSessionsChunked` closures now guard on `helperDown()` (`errors.Is(helperErr, errSessionHelperUnreachable)`): once a transport failure is recorded the remaining chunks **skip the helper delete**, so clear-all now genuinely pays ~one deadline total. The BPF mirror still clears fully (the shim deletes each chunk *before* the callback) and `helperErr` stays set, so the #5881 error-propagation and #5882 partial-count contracts are unchanged.
- **Best-effort preserved:** an application-level rejection (helper answered, `resp.OK=false` for one request) is **not** wrapped, so both the batch loop and the clear-all skip keep going and the #5881 "drop as many helper sessions as we can" + error-propagation contract is intact. The periodic sweep retries once the helper is healthy.
- The session socket is **one-request-per-connection** (`handle_stream` reads one newline-framed request, replies, closes), so connection reuse across a batch would break framing — the fast-fail is the correct minimal fix.
- The dial timeout / round-trip deadline are named as package vars (`sessionSyncDialTimeout` / `sessionSyncRoundtripDeadline`) so the regression tests can shrink them.

## Test plan

- [x] `TestSyncSessionRequestsLockedFastFailsOnHungHelper5380`: a listener that accepts but never replies; a 10-request batch must return within ~one shrunk deadline (500ms bound) **and** carry `errSessionHelperUnreachable`.
  - **Fail-on-revert:** drop the `if errors.Is(err, errSessionHelperUnreachable) { break }` in `syncSessionRequestsLocked` → batch takes 10 × 150ms = **1.505s**, blows the bound, RED. A clean elapsed assertion, not a compile break.
- [x] `TestClearAllSessionsFastFailsAcrossChunksOnHungHelper5380` (the fold): one v4 + one v6 mirror session → two delete callbacks against a **counting** hung helper. With the guard the v4 chunk records the transport failure and the v6 chunk skips its helper delete — the helper socket is dialed **once** and the clear pays ~one shrunk 400ms deadline; the error still carries `errSessionHelperUnreachable` and the mirror is emptied (counts `(1, 1)`).
  - **Fail-on-revert:** neutralize `helperDown()` → the v6 chunk dials the hung helper too (`acceptCount` 2, not 1) and elapsed doubles to **~801ms**, blowing the 650ms bound, RED. Independent of the first binding: neutralizing the inner break reddens the first test while this one stays green.
- [x] `go build ./...`, `go vet ./pkg/dataplane/userspace/`; the new test + the existing #5380 fast-fail and #5881 clear-all partial-count tests all pass under sudo (BPF memlock). The pre-existing XDP-shim binding tests (`TestApplyHelperStatus*` / `TestUserspaceXDP*` / `TestXSKLiveness*`) fail identically at the pristine PR head — they need a real XDP program load, unrelated to this change.
- [ ] **Loss-cluster failover smoke** — HA session-sync path; batched with other HA PRs.

## Docs

- Documented the Go-side batch fast-fail contract in `userspace-dp/src/server/README.md` (the dedicated-session-socket bullet), including the clear-all per-4096-key-chunk guard.
- Updated the `ClearAllSessions` doc comment so the documented clear-all contract matches (~one deadline total under a hung helper).

## Refs

Closes #5380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJDerLwq5YudtJ2qLW9Ze4
