### PR TITLE
userspace-dp: keep interface-only ECMP members selectable (#5161)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -55189,3 +55189,38 @@ top.
 - **File(s)**: pkg/dataplane/userspace/manager_ha.go,
   pkg/dataplane/userspace/clear_all_multichunk_fastfail_5380_test.go,
   userspace-dp/src/server/README.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5161 fix — interface-only ECMP members no longer starve to
+  width-1. In `select_route_next_hop`'s per-flow `is_live` closure (both the v4
+  and v6 selection sites in `userspace-dp/src/afxdp/forwarding/mod.rs`), a
+  member with `next_hop == None` (a directly-connected / point-to-point "via
+  <if>" candidate) was marked LIVE only if a neighbor for the PER-FLOW
+  destination already existed. The coordinator warmer (`queue_warm_pass`)
+  proactively probes only members with an EXPLICIT `next_hop`, so interface-only
+  members were never warmed; once any explicit-next_hop member resolved, the
+  live set was non-empty and the unresolved interface-only member was
+  permanently excluded → every flow pinned to the explicit member and ECMP
+  collapsed to width-1 (lost multipath). Fix: an up interface-only member
+  (`ifindex > 0`) is LIVE regardless of a pre-existing destination neighbor; the
+  existing MissingNeighbor cold path then resolves each destination lazily per
+  flow (mirroring the single-member interface-only resolution path). WARM-TARGET
+  FORK: the warmer is NOT changed for interface-only members — their warm target
+  is the per-flow destination, a whole prefix unknown at route-sweep time;
+  warming a synthetic address would pollute the neighbor table or never resolve,
+  so lazy per-flow resolution is the only correct mechanism. One added branch on
+  the O(members) per-flow selection path (a cheap early return, no hot-path
+  regression). Fail-on-revert test
+  `ecmp_interface_only_member_is_live_alongside_gateway`
+  (`forwarding/tests.rs`): a MIXED ECMP route (resolved gateway member via
+  ge-0/0/1 ifindex 11 + interface-only member via ge-0/0/2 ifindex 22, no dest
+  neighbor); sweeping 64 per-flow hashes must reach BOTH egress interfaces
+  (width 2) and the interface-only member must forward as MissingNeighbor. RED
+  on revert (neutralize the `if nh.next_hop.is_none() { return nh.ifindex > 0 }`
+  v4 branch): `egress_seen` never contains 22 → width-1 assertion fails. Full
+  release cargo suite validation on disk. Updated the forwarding README ECMP
+  bullet (#2389/#2734) with the shape-aware liveness rule. ECMP/forwarding path
+  — needs a loss-cluster forwarding smoke with a multipath ECMP config (batched).
+- **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md, _Log.md

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -114,7 +114,22 @@ Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
   (`RouteEntryV4::next_hops: Vec<RouteNextHopV4>`). `select_route_next_hop`
   prefers a candidate with a resolved neighbor (so a dead first next-hop
   no longer blackholes a route with a healthy alternate), then distributes
-  across the live candidates by a spread hash. **#2734: the spread key is
+  across the live candidates by a spread hash. **#5161: liveness is
+  next-hop-shape-aware.** A member with an EXPLICIT gateway (`next_hop ==
+  Some`) is live once that gateway's neighbor resolves — the coordinator
+  warmer (`queue_warm_pass`) proactively ARP/ND-probes every explicit
+  next-hop, so a genuinely-dead gateway never resolves and stays correctly
+  skipped. An INTERFACE-ONLY member (`next_hop == None`, a "via <if>"
+  candidate) resolves its neighbor from the PER-FLOW destination itself,
+  which the warmer cannot pre-resolve (the on-link destination is a whole
+  prefix, unknown at route-sweep time — so interface-only members are NOT
+  warmed). Gating such a member on an already-present destination neighbor
+  starved it out of the live set the moment any explicit member resolved,
+  collapsing ECMP to width-1; instead it is live whenever its interface is
+  up (`ifindex > 0`), and the MissingNeighbor cold path resolves each
+  destination lazily per flow (mirroring the single-member interface-only
+  path). Tunnel members use their own type-aware liveness (#2923). **#2734:
+  the spread key is
   per-FLOW.** The session resolution path
   (`lookup_forwarding_resolution_with_dynamic_for_flow`) hashes the forward
   5-tuple with `ecmp_hash_flow` — the SAME per-boot seeded `FxHasher` the

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -2175,6 +2175,22 @@ fn lookup_forwarding_resolution_v4_inner(
                         depth,
                     );
                 }
+                // #5161: an interface-only member (`next_hop == None` — a
+                // directly-connected / point-to-point "via <if>" candidate)
+                // resolves its neighbor from the PER-FLOW destination `ip`, not
+                // a stable gateway. The coordinator warmer cannot pre-resolve
+                // that address (the on-link destination is a whole prefix,
+                // unknown at route-sweep time), so gating liveness on an
+                // already-present destination neighbor drops the member out of
+                // the live set the moment any explicit-next_hop member resolves
+                // — ECMP collapses to width-1. Treat an up interface-only
+                // member as LIVE and let the MissingNeighbor cold path resolve
+                // the destination lazily per flow, mirroring the single-member
+                // resolution path (which forwards a missing-neighbor direct hop
+                // as MissingNeighbor, never a drop).
+                if nh.next_hop.is_none() {
+                    return nh.ifindex > 0;
+                }
                 let target = nh.next_hop.unwrap_or(ip);
                 nh.ifindex > 0
                     && lookup_neighbor_entry(state, dynamic_neighbors, nh.ifindex, IpAddr::V4(target))
@@ -2382,6 +2398,18 @@ fn lookup_forwarding_resolution_v6_inner(
                         nh.tunnel_endpoint_id,
                         depth,
                     );
+                }
+                // #5161: an interface-only member (`next_hop == None`) resolves
+                // its neighbor from the PER-FLOW destination `ip`, which the
+                // warmer cannot pre-resolve (a whole prefix, unknown at
+                // route-sweep time). Gating on an already-present destination
+                // neighbor starves it out of the live set once any
+                // explicit-next_hop member resolves — ECMP collapses to
+                // width-1. Treat an up interface-only member as LIVE; the
+                // MissingNeighbor cold path resolves the destination lazily per
+                // flow. See the v4 twin for the full rationale.
+                if nh.next_hop.is_none() {
+                    return nh.ifindex > 0;
                 }
                 let target = nh.next_hop.unwrap_or(ip);
                 nh.ifindex > 0

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -3838,6 +3838,153 @@ fn ecmp_static_route_retains_all_next_hops_and_skips_dead() {
     );
 }
 
+/// #5161: a MIXED ECMP group of a GATEWAY member (explicit next-hop, already
+/// resolved) plus an INTERFACE-ONLY member (`next_hop == None`, a "via <if>"
+/// candidate whose neighbor is the PER-FLOW destination) must select BOTH
+/// members — ECMP width 2, not collapsed to width-1.
+///
+/// The interface-only member's neighbor is the destination itself, which the
+/// coordinator warmer cannot pre-resolve (it is a whole prefix, unknown at
+/// route-sweep time). The pre-#5161 `is_live` closure gated EVERY direct
+/// member on `neighbor-resolved-on-that-ifindex`, evaluating the target as the
+/// destination for an interface-only member. With the gateway member already
+/// resolved the live set was non-empty, so the unresolved interface-only
+/// member was permanently excluded → every flow pinned to the gateway member
+/// → ECMP starved to width-1.
+///
+/// The fix marks an up interface-only member LIVE (`ifindex > 0`) so it joins
+/// the live set; the MissingNeighbor cold path then resolves the destination
+/// lazily per flow (mirroring the single-member interface-only path). Here the
+/// gateway member (192.0.2.2 via ge-0/0/1, ifindex 11) is resolved and the
+/// interface-only member (via ge-0/0/2, ifindex 22) has NO destination
+/// neighbor. Sweeping distinct per-flow hashes must reach BOTH egress
+/// interfaces, and the interface-only member must forward as MissingNeighbor.
+///
+/// FAIL-ON-REVERT: revert the `if nh.next_hop.is_none() { return nh.ifindex >
+/// 0 }` branch in the v4 selection closure and the interface-only member is
+/// dead again; with the gateway member live, selection collapses to ifindex 11
+/// only, so `egress_seen` never contains 22 (width 1) and the disposition
+/// probe stays None → both interface-only assertions go RED.
+#[test]
+fn ecmp_interface_only_member_is_live_alongside_gateway() {
+    let snapshot = crate::ConfigSnapshot {
+        zones: vec![crate::ZoneSnapshot {
+            name: "wan".to_string(),
+            id: TEST_WAN_ZONE_ID,
+            ..Default::default()
+        }],
+        interfaces: vec![
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1".to_string(),
+                zone: "wan".to_string(),
+                linux_name: "ge-0-0-1".to_string(),
+                ifindex: 11,
+                hardware_addr: "02:00:00:00:00:11".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "192.0.2.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/2".to_string(),
+                zone: "wan".to_string(),
+                linux_name: "ge-0-0-2".to_string(),
+                ifindex: 22,
+                hardware_addr: "02:00:00:00:00:22".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "192.0.3.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+        ],
+        routes: vec![crate::RouteSnapshot {
+            table: "inet.0".to_string(),
+            family: "inet".to_string(),
+            destination: "203.0.113.0/24".to_string(),
+            // Member 0: explicit gateway via ge-0/0/1. Member 1: INTERFACE-ONLY
+            // (empty IP part before '@') via ge-0/0/2 — `next_hop == None`.
+            next_hops: vec![
+                "192.0.2.2@ge-0/0/1".to_string(),
+                "@ge-0/0/2".to_string(),
+            ],
+            discard: false,
+            next_table: String::new(),
+            preference: 5,
+        }],
+        // ONLY the gateway member's neighbor is resolved. The interface-only
+        // member's neighbor (the per-flow destination) is deliberately absent —
+        // it can only resolve lazily once the member is actually selected.
+        neighbors: vec![crate::NeighborSnapshot {
+            interface: "ge-0-0-1".to_string(),
+            ifindex: 11,
+            family: "inet".to_string(),
+            ip: "192.0.2.2".to_string(),
+            mac: "00:11:22:33:44:55".to_string(),
+            state: "reachable".to_string(),
+            router: true,
+            link_local: false,
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+
+    // Sanity: the FIB built member 1 as a genuine interface-only candidate
+    // (`next_hop == None`, ifindex 22). Guards against a future next-hop
+    // string-format change silently turning this into a gateway member (which
+    // would make the test pass trivially).
+    let route = &state.routes_v4.get("inet.0").expect("table")[0];
+    assert_eq!(route.next_hops.len(), 2, "ECMP route must retain both members");
+    assert!(
+        route.next_hops[1].next_hop.is_none() && route.next_hops[1].ifindex == 22,
+        "member 1 must be an interface-only candidate (next_hop==None, ifindex 22)",
+    );
+
+    // Sweep distinct per-flow hashes and collect the set of selected egress
+    // interfaces plus the interface-only member's disposition.
+    let mut egress_seen: std::collections::BTreeSet<i32> = std::collections::BTreeSet::new();
+    let mut interface_only_disposition: Option<ForwardingDisposition> = None;
+    for h in 0u64..64 {
+        let r = lookup_forwarding_resolution_v4(
+            &state,
+            None,
+            Ipv4Addr::new(203, 0, 113, 5),
+            "inet.0",
+            0,
+            true,
+            Some(h),
+        );
+        egress_seen.insert(r.egress_ifindex);
+        if r.egress_ifindex == 22 {
+            interface_only_disposition = Some(r.disposition);
+        }
+    }
+
+    assert!(
+        egress_seen.contains(&11),
+        "gateway member (ifindex 11) must remain selectable",
+    );
+    assert!(
+        egress_seen.contains(&22),
+        "#5161: interface-only member (ifindex 22, next_hop==None) must join the \
+         live ECMP set — not starve to width-1 behind the resolved gateway member",
+    );
+    assert_eq!(
+        egress_seen.len(),
+        2,
+        "ECMP must spread across BOTH members (width 2), not collapse to width-1",
+    );
+    assert_eq!(
+        interface_only_disposition,
+        Some(ForwardingDisposition::MissingNeighbor),
+        "interface-only member forwards via the MissingNeighbor cold path so its \
+         destination resolves lazily per flow",
+    );
+}
+
 /// #2923: a MIXED direct+tunnel ECMP group must select BOTH paths. The
 /// pre-fix liveness closure gated EVERY candidate on `ifindex > 0 &&
 /// neighbor-resolved-on-that-ifindex`. A tunnel next-hop is the logical


### PR DESCRIPTION
## Summary

- An ECMP route mixing an explicit-gateway member with an **interface-only** member (`next_hop == None` — a directly-connected / point-to-point "via `<if>`" candidate) collapsed to **width-1**: the interface-only member was never selected, so every flow pinned to the gateway member and multipath was lost.
- Root cause: `select_route_next_hop`'s per-flow `is_live` closure (v4 + v6 sites in `forwarding/mod.rs`) marked a direct member LIVE only when a neighbor for the resolved target already existed. For an interface-only member the target is the **per-flow destination**, and the coordinator warmer (`queue_warm_pass`) proactively probes only members with an EXPLICIT `next_hop` — so an interface-only member's neighbor is never pre-resolved. Once any explicit member resolved, the live set was non-empty and the interface-only member was permanently excluded.
- Fix: make liveness next-hop-shape-aware. An up interface-only member (`ifindex > 0`) is LIVE regardless of a pre-existing destination neighbor, so it rejoins the live ECMP set and width restores. The existing `MissingNeighbor` cold path then resolves each destination lazily per flow (mirroring the single-member interface-only path). Explicit-gateway members keep their warmer-backed neighbor-exists liveness; tunnel members keep #2923 type-aware liveness.

## Warm-target reasoning (the fork)

The warmer is **deliberately not changed** for interface-only members. Their warm target is the per-flow on-link destination — a whole prefix, not a single address known at route-sweep time. Probing a synthetic address (e.g. the prefix base) would pollute the neighbor table or never resolve, so **lazy per-flow resolution via `MissingNeighbor` is the only correct mechanism**. The selection fix alone fully closes the width-1 starvation.

## Hot-path shape

One added branch on the `O(members)` per-flow selection path — a cheap early return for interface-only members that *skips* the neighbor-map lookup. No per-packet regression.

## Test plan

- [x] Added `ecmp_interface_only_member_is_live_alongside_gateway` (`forwarding/tests.rs`): MIXED ECMP route (resolved gateway via ge-0/0/1 ifindex 11 + interface-only via ge-0/0/2 ifindex 22, no dest neighbor); sweeps 64 per-flow hashes, asserts BOTH egress interfaces reached (width 2) and the interface-only member forwards as `MissingNeighbor`.
- [x] **Fail-on-revert**: neutralize the `if nh.next_hop.is_none() { return nh.ifindex > 0 }` v4 branch → interface-only egress (22) never selected → width-1 assertion goes RED (verified locally).
- [x] Full release `cargo test` suite green on disk: **4072 passed, 0 failed**.
- [ ] Loss-cluster forwarding smoke with a multipath ECMP config — **deferred to batched cluster run** (ECMP/forwarding path; the standard smoke may not exercise a mixed gateway + interface-only ECMP route).

## Docs

Updated the forwarding README ECMP bullet (#2389/#2734) with the shape-aware liveness rule.

## Refs

Closes #5161