### PR TITLE
daemon: reject out-of-range port in parseSrcPort

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,18 @@
+## 2026-07-21 — #6214 fix: parseSrcPort uint16 accumulator overflow
+
+- **Timestamp**: 2026-07-21 (fix/6214-parsesrcport-overflow)
+- **Action**: `parseSrcPort` in `pkg/daemon/daemon_flow.go` accumulated port
+  digits directly into a `uint16` (`port = port*10 + uint16(c-'0')`), so a port
+  string above 65535 (e.g. "70000") wrapped mod 65536 to 4464 — silently
+  corrupting the source/destination port carried in NetFlow v9 / IPFIX flow
+  records (callers in `daemon_flowexport.go`: SrcPort/DstPort/NATSrcPort/
+  NATDstPort). Fix: accumulate into a `uint32` and reject any value > 65535,
+  returning the existing `0` "no port" sentinel (same value the no-colon path
+  returns). Valid ports 0..65535 parse unchanged. Added fail-on-revert test
+  `TestParseSrcPortRejectsOverflow6214`.
+- **File(s)**: `pkg/daemon/daemon_flow.go` (Edit),
+  `pkg/daemon/parse_srcport_overflow_6214_test.go` (Write)
+
 ## 2026-07-21 — #5482 follow-up: two review MAJORs on the BACKUP VIP-verify machinery
 
 - **Timestamp**: 2026-07-21 (fix/5482-vrrp-vip-verify)

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -473,13 +473,23 @@ func parseSrcPort(addr string) uint16 {
 	// Find last colon
 	for i := len(addr) - 1; i >= 0; i-- {
 		if addr[i] == ':' {
-			var port uint16
+			// Accumulate into a wider integer so an out-of-range port
+			// string does not silently wrap the uint16 accumulator mod
+			// 65536 (e.g. "70000" -> 4464, #6214), which would corrupt
+			// the source/destination port carried in NetFlow v9 / IPFIX
+			// flow records. A real port never exceeds 65535, so treat
+			// anything larger as unparseable and return the 0 "no port"
+			// sentinel (the same value the no-colon path returns).
+			var port uint32
 			for _, c := range addr[i+1:] {
 				if c >= '0' && c <= '9' {
-					port = port*10 + uint16(c-'0')
+					port = port*10 + uint32(c-'0')
+					if port > 65535 {
+						return 0
+					}
 				}
 			}
-			return port
+			return uint16(port)
 		}
 	}
 	return 0

--- a/pkg/daemon/parse_srcport_overflow_6214_test.go
+++ b/pkg/daemon/parse_srcport_overflow_6214_test.go
@@ -1,0 +1,57 @@
+package daemon
+
+import "testing"
+
+// TestParseSrcPortRejectsOverflow6214 guards against the #6214 uint16
+// accumulator overflow in parseSrcPort. Before the fix, digits were
+// accumulated directly into a uint16, so a port string above 65535 wrapped
+// mod 65536 — "70000" produced 4464 — silently corrupting the source /
+// destination port carried in NetFlow v9 / IPFIX flow records.
+//
+// The fix accumulates into a wider integer and rejects any value above
+// 65535 (a real port never exceeds it), returning the 0 "no port" sentinel.
+// This test FAILS if parseSrcPort is reverted to the uint16 accumulator
+// (it would return 4464 for "70000") and PASSES with the fix.
+func TestParseSrcPortRejectsOverflow6214(t *testing.T) {
+	// Overflow cases: must NOT silently wrap. The old uint16 accumulator
+	// returned addr's numeric port mod 65536; assert we never do that.
+	overflow := []struct {
+		addr string
+		wrap uint16 // value the reverted uint16 accumulator would produce
+	}{
+		{"1.2.3.4:70000", 4464},   // 70000 mod 65536 == 4464 (the #6214 bug)
+		{"1.2.3.4:65536", 0},      // first out-of-range value; wraps to 0
+		{"1.2.3.4:99999", 34463},  // 99999 mod 65536 == 34463
+		{"1.2.3.4:4294967296", 0}, // 2^32, also overflows a uint32 accumulator
+	}
+	for _, tc := range overflow {
+		got := parseSrcPort(tc.addr)
+		if got != 0 {
+			t.Errorf("parseSrcPort(%q) = %d, want 0 (out-of-range port must be rejected, not wrapped)", tc.addr, got)
+		}
+		// Explicit guard on the historical wrap value for clarity: even when
+		// the reject sentinel (0) happens to equal the wrap value, the
+		// primary port "70000" -> 4464 case above proves the revert fails.
+		if tc.wrap != 0 && got == tc.wrap {
+			t.Errorf("parseSrcPort(%q) = %d — silently wrapped mod 65536 (the #6214 overflow bug)", tc.addr, tc.wrap)
+		}
+	}
+
+	// Valid ports (0..65535) must still parse exactly as before.
+	valid := []struct {
+		addr string
+		want uint16
+	}{
+		{"1.2.3.4:0", 0},
+		{"1.2.3.4:80", 80},
+		{"1.2.3.4:443", 443},
+		{"1.2.3.4:65535", 65535},
+		{"[2001:db8::1]:8080", 8080}, // last-colon scan lands on the IPv6 port
+		{"no-colon-here", 0},         // absent port -> 0 sentinel
+	}
+	for _, tc := range valid {
+		if got := parseSrcPort(tc.addr); got != tc.want {
+			t.Errorf("parseSrcPort(%q) = %d, want %d", tc.addr, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`parseSrcPort` in `pkg/daemon/daemon_flow.go` accumulated port digits directly into a `uint16` (`port = port*10 + uint16(c-'0')`), so a port string above 65535 wrapped mod 65536 — `"70000"` became `4464`. The callers in `daemon_flowexport.go` feed the result into `SrcPort` / `DstPort` / `NATSrcPort` / `NATDstPort` of the NetFlow v9 / IPFIX `SESSION_CLOSE` record, so a malformed or oversized port string silently corrupted the port reported in exported flow records.

## Fix

Accumulate into a `uint32` and bail as soon as the running value exceeds 65535, returning the existing `0` "no port" sentinel — the same value the no-colon path already returns for an absent port. A real port never exceeds 65535, so an out-of-range value is unparseable, and mapping it to `0` is the least-surprising contract given the function's plain `uint16` return with no error channel. The early bail also keeps the `uint32` accumulator itself from wrapping on absurdly long digit strings. Valid ports (0..65535), the no-colon path, and the IPv6 `[addr]:port` last-colon scan are unchanged.

## Test

`TestParseSrcPortRejectsOverflow6214` (white-box, package `daemon`) asserts `"70000"` / `"99999"` / `"65536"` / `"4294967296"` all return `0` (never the mod-65536 wrap value), and that `"0"` / `"80"` / `"443"` / `"65535"`, the IPv6 form, and a colon-less string still parse correctly.

## Validation

- `go build ./...` clean.
- `go test ./pkg/daemon/` green (with `TMPDIR=/tmp` to avoid the unrelated `sun_path`-108 socket-bind flake).
- Fails-on-revert confirmed: against the reverted `uint16` accumulator, `parseSrcPort("1.2.3.4:70000")` returns `4464` and the test FAILS; with the fix it returns `0` and the test PASSES.

Closes #6214