### PR TITLE
userspace: bounds-check queue id in ParseQueueCommand

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-21 — #6215: ParseQueueCommand queue-id bounds check
+
+- **Timestamp**: 2026-07-21 (fix/6215-parsequeuecommand-bounds)
+- **Action**: `ParseQueueCommand` parsed the queue id with a raw
+  `strconv.Atoi` and cast straight to `uint32` with no bounds check, so a
+  negative (`-1` → `4294967295`) or oversized value (`5000000000` →
+  truncated `705032704`) wrapped into an out-of-range queue id that steers a
+  queue register/arm op to a wrong/out-of-range worker binding. Added a
+  `parseQueueID` helper mirroring the #5449-hardened `parseBindingSlot`,
+  rejecting negatives and values `>= dataplane.BindingQueuesPerIface` (16, the
+  queue-dimension stride of `idx = ifindex*BindingQueuesPerIface + queue`) —
+  the same cap the #4894 `maps_sync.go` guard already enforces on this exact
+  field. Routed `ParseQueueCommand` through the helper; left the signature and
+  valid-input contract unchanged. Did NOT touch `ParseBindingCommand` /
+  `parseBindingSlot`.
+- **File(s)**: pkg/dataplane/userspace/control.go,
+  pkg/dataplane/userspace/queue_id_bounds_6215_test.go
+- **Validation**: `go build ./...` clean; new
+  `TestParseQueueCommandRejectsOutOfRange6215` passes with the fix and
+  FAILS on revert (raw `Atoi`+`uint32` accepts `-1`/`5000000000`/`16`/`9999`);
+  full `pkg/dataplane/userspace` suite green (TMPDIR=/tmp).
+
 ## 2026-07-21 — #5482 follow-up: two review MAJORs on the BACKUP VIP-verify machinery
 
 - **Timestamp**: 2026-07-21 (fix/5482-vrrp-vip-verify)

--- a/pkg/dataplane/userspace/control.go
+++ b/pkg/dataplane/userspace/control.go
@@ -35,6 +35,28 @@ func parseBindingSlot(arg string) (uint32, error) {
 	return uint32(n), nil
 }
 
+// parseQueueID parses a CLI/gRPC queue-id argument and rejects negatives
+// and values >= dataplane.BindingQueuesPerIface. A valid queue id lives in
+// [0, BindingQueuesPerIface), the queue dimension of the flat binding index
+// formula `idx = ifindex * BindingQueuesPerIface + queue`. This mirrors the
+// #5449-hardened parseBindingSlot and the #4894 queue-dimension guard in
+// maps_sync.go: without the bounds check a "-1" queue passes strconv.Atoi
+// and wraps to 4294967295 on the uint32 cast, and any queue-id >= the stride
+// (16) aliases the adjacent ifindex's queue-0 slot — steering a queue
+// register/arm op to a wrong worker binding. The bound is compared in int
+// space so a value larger than uint32 max cannot alias a valid queue id via
+// truncation.
+func parseQueueID(arg string) (uint32, error) {
+	n, err := strconv.Atoi(arg)
+	if err != nil {
+		return 0, fmt.Errorf("invalid queue: %s", arg)
+	}
+	if n < 0 || n >= int(dataplane.BindingQueuesPerIface) {
+		return 0, fmt.Errorf("queue %d out of range [0, %d)", n, dataplane.BindingQueuesPerIface)
+	}
+	return uint32(n), nil
+}
+
 func ParseForwardingCommand(args []string) (bool, error) {
 	if len(args) != 2 || args[0] != "forwarding" {
 		return false, fmt.Errorf("usage: %s", ForwardingUsage)
@@ -53,15 +75,15 @@ func ParseQueueCommand(args []string) (queueID uint32, registered, armed bool, e
 	if len(args) != 3 || args[0] != "queue" {
 		return 0, false, false, fmt.Errorf("usage: %s", QueueUsage)
 	}
-	queueNum, err := strconv.Atoi(args[1])
+	queueID, err = parseQueueID(args[1])
 	if err != nil {
-		return 0, false, false, fmt.Errorf("invalid queue: %s", args[1])
+		return 0, false, false, err
 	}
 	registered, armed, err = ParseRegistrationOperation(args[2])
 	if err != nil {
 		return 0, false, false, fmt.Errorf("usage: %s", QueueUsage)
 	}
-	return uint32(queueNum), registered, armed, nil
+	return queueID, registered, armed, nil
 }
 
 func ParseBindingCommand(args []string) (slot uint32, registered, armed bool, err error) {

--- a/pkg/dataplane/userspace/queue_id_bounds_6215_test.go
+++ b/pkg/dataplane/userspace/queue_id_bounds_6215_test.go
@@ -1,0 +1,63 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// TestParseQueueCommandRejectsOutOfRange6215 pins the #6215 bounds check on
+// the queue id parsed by ParseQueueCommand. Before the fix the id was read
+// with a raw strconv.Atoi and cast straight to uint32, so a negative ("-1")
+// wrapped to 4294967295 and an oversized value truncated silently — either
+// one steering a queue register/arm op to an out-of-range worker binding.
+// A valid queue id lives in [0, dataplane.BindingQueuesPerIface); ids at or
+// above the stride alias the adjacent ifindex's queue-0 slot (the same
+// failure the #4894 maps_sync guard rejects).
+//
+// Fail-on-revert: restoring the raw `strconv.Atoi(args[1])` + `uint32(...)`
+// path makes the negative and oversized cases parse without error, failing
+// the wantErr assertions below.
+func TestParseQueueCommandRejectsOutOfRange6215(t *testing.T) {
+	tests := []struct {
+		name    string
+		queue   string
+		wantErr bool
+		wantID  uint32
+	}{
+		{name: "negative", queue: "-1", wantErr: true},
+		{name: "oversized_uint32_overflow", queue: "5000000000", wantErr: true},
+		{name: "at_stride", queue: "16", wantErr: true},
+		{name: "above_stride", queue: "9999", wantErr: true},
+		{name: "valid_zero", queue: "0", wantErr: false, wantID: 0},
+		{name: "valid_mid", queue: "3", wantErr: false, wantID: 3},
+		{name: "valid_max", queue: "15", wantErr: false, wantID: 15},
+	}
+	// Guard the boundary constant so a future stride bump keeps the test's
+	// "at_stride"/"valid_max" cases meaningful.
+	if dataplane.BindingQueuesPerIface != 16 {
+		t.Fatalf("test assumes BindingQueuesPerIface==16, got %d", dataplane.BindingQueuesPerIface)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queueID, registered, armed, err := ParseQueueCommand([]string{"queue", tt.queue, "arm"})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseQueueCommand(queue=%s) = (%d,%t,%t,nil), want error",
+						tt.queue, queueID, registered, armed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseQueueCommand(queue=%s) error = %v, want nil", tt.queue, err)
+			}
+			if queueID != tt.wantID {
+				t.Fatalf("ParseQueueCommand(queue=%s) queueID = %d, want %d", tt.queue, queueID, tt.wantID)
+			}
+			if !registered || !armed {
+				t.Fatalf("ParseQueueCommand(queue=%s) = (registered=%t,armed=%t), want (true,true)",
+					tt.queue, registered, armed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`ParseQueueCommand` in `pkg/dataplane/userspace/control.go` parsed the queue id with a raw `strconv.Atoi` and cast the result straight into the `uint32` return with **no bounds check**. A negative id (`-1`) passes `Atoi` and wraps to `4294967295` on the uint32 cast; an oversized id (`5000000000`) truncates to `705032704`. Either value flows into `SetQueueState` → `QueueControlRequest` and indexes a queue register/arm op out of range, steering it to a wrong or nonexistent worker binding.

The sibling `ParseBindingCommand` already routes its slot through the #5449-hardened `parseBindingSlot`, which rejects negative/out-of-range values before the uint32 conversion. `ParseQueueCommand` was never given the same guard.

## Fix

- Add a `parseQueueID` helper mirroring `parseBindingSlot`: reject `n < 0` or `n >= dataplane.BindingQueuesPerIface` (16) in **int space** before converting, so a value larger than uint32 max cannot alias a valid queue id via truncation.
- `BindingQueuesPerIface` is the queue-dimension stride of the flat binding index formula `idx = ifindex*BindingQueuesPerIface + queue`; a queue id at or above the stride aliases the adjacent ifindex's queue-0 slot. This is the **exact cap the #4894 guard in `maps_sync.go` already enforces** on the same field, so the parser and the map-writer now agree on the queue-id domain.
- `ParseBindingCommand` and `parseBindingSlot` are untouched. `ParseQueueCommand` keeps its signature and its behavior for valid input.

## Validation

- `go build ./...` clean.
- New `TestParseQueueCommandRejectsOutOfRange6215` asserts `-1`, `5000000000`, `16`, and `9999` all error while `0`/`3`/`15` still parse and arm.
- **Fails on revert**: reverting to the raw `Atoi`+`uint32` path makes it accept `-1` as `4294967295` and `5000000000` as `705032704` — the test goes red.
- Full `pkg/dataplane/userspace` suite green.

Closes #6215