### PR TITLE
api: bound natPoolStatsHandler session walk via sessionWalkLimiter (#6216)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-21 — #6216: bound natPoolStatsHandler session walk via sessionWalkLimiter
+
+- **Timestamp**: 2026-07-21 (fix/6216-natpoolstats-limiter)
+- **Action**: `natPoolStatsHandler`'s interface-mode `UsedPorts` accounting
+  (#3417) drove an unbounded `IterateSessions` full-table walk with no
+  admission gate and no context-cancel — unlike every other REST scan endpoint,
+  which draws from the shared `sessionWalkLimiter` (#5708/#5433). A scrape flood
+  of `GET /security/nat/source/pools` could each drive a concurrent unbounded
+  walk, contending with session installs on the shared control socket. Named the
+  ignored `*http.Request`, `AcquireCtx`ed a slot before the walk (429 on
+  over-cap), honored the admission-lease context inside the iterate callback
+  (early-stop on disconnect), and released on every exit path.
+- **File(s)**: pkg/api/nat.go, pkg/api/nat_pool_stats_walk_limiter_6216_test.go,
+  pkg/api/README.md
+- **Validation**: `go build ./...` clean; new
+  `TestNatPoolStatsRespectsWalkLimiter6216` PASSES (429 when the shared slot is
+  held) + existing natPoolStats tests green; firsthand parent-RED confirmed
+  target-count 1. Scoped to the limiter/ctx bound; v6-table counting for
+  interface-mode rows is a separate behavior change, deferred.
+
 ## 2026-07-21 — #6215: ParseQueueCommand queue-id bounds check
 
 - **Timestamp**: 2026-07-21 (fix/6215-parsequeuecommand-bounds)

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -832,6 +832,20 @@ under the daemon's errgroup. Nothing else imports this package.
     longer issue unbounded full-table scans; over-cap gRPC scans return
     `codes.ResourceExhausted`. A mix of REST + gRPC scrapers cannot collectively
     exceed `diagcmd.MaxConcurrentSessionWalks`.
+    **#6216 extends the SAME gate to `natPoolStatsHandler`
+    (`GET /security/nat/source/pools`)**, whose interface-mode `UsedPorts`
+    accounting (#3417 above) drives the identical full conntrack walk via
+    `IterateSessions` and previously bypassed the aggregate bound entirely — a
+    scrape flood of the NAT-pool-stats endpoint could each drive a concurrent
+    unbounded walk, contending with session installs on the shared control
+    socket. The handler now `AcquireCtx`es a slot BEFORE the walk (429 on
+    over-cap: `nat pool stats concurrency limit reached; retry shortly`),
+    honors the returned admission-lease context inside the `IterateSessions`
+    callback (stops early on client disconnect), and releases on every exit
+    path. Pinned by `nat_pool_stats_walk_limiter_6216_test.go` (RED-on-revert).
+    Note: only the interface-mode session-walk arm is gated; the pool-mode rows
+    read the helper's live `SourceNATPoolStatus` (no table walk) and need no
+    admission slot.
     **#5880 makes the shared limiter request-graph-aware to fix a reentrant
     double-acquire.** A REST list/summary/zone-pair handler acquires a slot and
     then delegates IN-PROCESS to the gRPC session service for `include_peer`

--- a/pkg/api/nat.go
+++ b/pkg/api/nat.go
@@ -114,7 +114,7 @@ func (s *Server) natDestHandler(w http.ResponseWriter, _ *http.Request) {
 	writeOK(w, result)
 }
 
-func (s *Server) natPoolStatsHandler(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) natPoolStatsHandler(w http.ResponseWriter, r *http.Request) {
 	cfg := s.store.ActiveConfig()
 	if cfg == nil {
 		writeOK(w, []NATPoolStatsInfo{})
@@ -227,6 +227,21 @@ func (s *Server) natPoolStatsHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 	ruleSetUsed := map[[2]string]int{}
 	if hasInterfaceRule && s.dp != nil && s.dp.IsLoaded() {
+		// #6216: this full-table session walk must draw from the shared
+		// sessionWalkLimiter (#5708/#5433) like every other REST scan
+		// endpoint, so a burst of NAT-pool-stats requests cannot each drive
+		// an unbounded IterateSessions concurrently and starve session
+		// installs / the periodic sweep on the shared control socket. Acquire
+		// once at this external trust boundary and honor the returned
+		// admission-lease context for early cancellation on client disconnect.
+		release, walkCtx, err := sessionWalkLimiter.AcquireCtx(r.Context())
+		if err != nil {
+			writeError(w, http.StatusTooManyRequests,
+				"nat pool stats concurrency limit reached; retry shortly")
+			return
+		}
+		defer release()
+
 		// Map zone ID -> name so the per-session ingress/egress zone IDs can
 		// be attributed to the configured from/to zone pair. Without the zone
 		// map (no apply result yet) attribution is impossible, so rows report
@@ -239,6 +254,9 @@ func (s *Server) natPoolStatsHandler(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 		if err := s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if walkCtx.Err() != nil {
+				return false // client gone / lease cancelled — stop the walk
+			}
 			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 && zoneByID != nil {
 				ruleSetUsed[[2]string{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
 			}

--- a/pkg/api/nat_pool_stats_walk_limiter_6216_test.go
+++ b/pkg/api/nat_pool_stats_walk_limiter_6216_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/diagcmd"
+)
+
+// TestNatPoolStatsRespectsWalkLimiter6216 is a FAIL-ON-REVERT guard for #6216:
+// natPoolStatsHandler's interface-mode full-table session walk must draw from
+// the shared sessionWalkLimiter (#5708/#5433) like every other REST scan
+// endpoint. Before the fix the handler called IterateSessions with no
+// admission gate, so a burst of NAT-pool-stats requests each drove an
+// unbounded concurrent walk, contending with session installs / the periodic
+// sweep on the shared control socket.
+//
+// The test saturates the shared limiter (capacity 1, slot held) and asserts a
+// NAT-pool-stats request is rejected with HTTP 429. Reverting the handler to
+// the ungated IterateSessions makes it proceed to the walk and return 200 —
+// the assertion then fails.
+func TestNatPoolStatsRespectsWalkLimiter6216(t *testing.T) {
+	orig := sessionWalkLimiter
+	t.Cleanup(func() { sessionWalkLimiter = orig })
+	sessionWalkLimiter = diagcmd.NewLimiter(1)
+
+	// Hold the single slot so the handler's AcquireCtx must reject.
+	release, err := sessionWalkLimiter.Acquire()
+	if err != nil {
+		t.Fatalf("pre-acquire the only walk slot: %v", err)
+	}
+	defer release()
+
+	// Interface-mode source-NAT config (hasInterfaceRule=true) + a loaded dp
+	// with SNAT sessions, so the handler reaches the gated walk path.
+	dp := &natIfaceSNATSessionsDP{
+		Manager: dataplane.New(),
+		result: &dataplane.ApplyResult{
+			ZoneIDs: map[string]uint16{"trust": 2, "guest": 4, "wan": 5},
+		},
+	}
+	s := &Server{store: newIfaceNATStatsAPIStore(t), dp: dp}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/nat/source/pools", nil)
+	s.natPoolStatsHandler(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("natPoolStats status = %d while the shared session-walk slot is held; "+
+			"want 429 (handler not bounded by sessionWalkLimiter #6216); body: %s",
+			rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
`natPoolStatsHandler`'s interface-mode `UsedPorts` accounting (#3417) walked the full conntrack table via `IterateSessions` with **no admission gate and no context-cancel** — unlike every other REST session-scan endpoint, which draws a slot from the shared `sessionWalkLimiter` (#5708/#5433). A scrape flood of `GET /security/nat/source/pools` could each drive a concurrent unbounded walk, contending with live session installs / the periodic sweep for the shared control socket, and on an HA pair stealing cycles from session sync.

## Fix
- Name the previously-ignored `*http.Request`; `AcquireCtx` a slot from `sessionWalkLimiter` at the handler's trust boundary **before** the walk.
- Over-cap → **HTTP 429** (`nat pool stats concurrency limit reached; retry shortly`).
- Honor the returned admission-lease context inside the `IterateSessions` callback (stops the walk early on client disconnect); release on every exit path.
- Only the interface-mode walk arm is gated — pool-mode rows read the helper's live `SourceNATPoolStatus` (no table walk), so they need no slot.

## Scope
Limiter + context bound only. Adding v6-table (`IterateSessionsV6`) counting to the interface-mode `UsedPorts` figure is a separate behavior change and is **deferred**.

## Validation
- `go build ./...` clean.
- New `TestNatPoolStatsRespectsWalkLimiter6216`: a NAT-pool-stats request returns **429** while the shared walk slot is held. **Fail-on-revert**: the ungated handler returns 200 → assertion fails. Firsthand parent-RED confirmed target-count 1.
- Existing natPoolStats tests (`InterfaceModePerRuleSet`, `UsesRuntimeStatus`, error-surface) still pass.
- `pkg/api/README.md` admission-bound section updated.

Closes #6216