### PR TITLE
session: reverse companion inherits app inactivity timeout

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-07-21 — #5153: reverse companion inherits forward application inactivity_timeout_ns
+
+- **Timestamp**: 2026-07-21 (fix/5153-reverse-companion-inactivity-timeout)
+- **Action**: `build_reverse_session_from_forward_match`
+  (`userspace-dp/src/afxdp/shared_ops.rs`) hardcoded
+  `inactivity_timeout_ns: None` while inheriting every other forward-match
+  metadatum (log/policy/NAT64). `companion_keeps_alive` (expire.rs) keeps an
+  idle-crossed half alive using the companion's OWN `expires_after_ns` — derived
+  from `inactivity_timeout_ns` via `session_timeout_ns` — so the reverse
+  companion of a 30s per-application flow fell back to the global timeout (e.g.
+  300s) and extended stale-state retention beyond the app's configured idle
+  window (residual of #3227/#3301/#4380). Changed the field to inherit
+  `forward_match.metadata.inactivity_timeout_ns`, matching the surrounding
+  field-inheritance idiom; `companion_keeps_alive` semantics unchanged.
+- **File(s)**: userspace-dp/src/afxdp/shared_ops.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  userspace-dp/src/session/README.md, _Log.md
+- **Validation**: `cargo build` clean (pre-existing warnings only); new
+  `reverse_companion_inherits_forward_inactivity_timeout_5153` +
+  `build_reverse_session_carries_inactivity_timeout_5153` PASS. Fail-on-revert
+  confirmed — both FAIL when the field is reverted to hardcoded `None`. A
+  forward match with no per-app override still yields `None` (global timeout),
+  bit-identical to prior behavior.
+
 ## 2026-07-21 — #6216: bound natPoolStatsHandler session walk via sessionWalkLimiter
 
 - **Timestamp**: 2026-07-21 (fix/6216-natpoolstats-limiter)

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -3368,6 +3368,104 @@ fn synthesized_synced_reverse_entry_inherits_nat64_reverse_4565() {
     assert_eq!(reverse.key.dst_ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)));
 }
 
+// #5153: the synthesized/failover reverse companion must inherit the forward
+// session's per-application `inactivity_timeout_ns`. Both halves of one
+// stateful flow share the admitting application, so the app's idle window
+// governs either direction. `companion_keeps_alive` (expire.rs) keeps an
+// idle-crossed half alive using the companion's OWN `expires_after_ns`
+// (derived from this field); dropping it to `None` let the reverse companion
+// fall back to the global timeout and extended a short app timeout (e.g. 30s)
+// toward the global one (e.g. 300s) — stale-state retention beyond the
+// configured window. RED-on-revert: restoring `inactivity_timeout_ns: None` in
+// build_reverse_session_from_forward_match makes the inheritance assertion
+// fail.
+#[test]
+fn reverse_companion_inherits_forward_inactivity_timeout_5153() {
+    let forwarding = test_forwarding_state();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+
+    // 30s per-application idle timeout stamped on the forward session (the
+    // value `session_timeout_ns` would use for `expires_after_ns`).
+    const APP_TIMEOUT_NS: u64 = 30_000_000_000;
+    let mut metadata = test_metadata();
+    metadata.inactivity_timeout_ns = Some(APP_TIMEOUT_NS);
+
+    let entry = SyncedSessionEntry {
+        key: test_key(),
+        decision: test_decision(),
+        metadata,
+        origin: SessionOrigin::SyncImport,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+        generation: 0,
+    };
+
+    let reverse =
+        synthesized_synced_reverse_entry(&forwarding, &BTreeMap::new(), &dynamic_neighbors, &entry, 1)
+            .expect("reverse companion");
+
+    assert!(reverse.metadata.is_reverse);
+    assert_eq!(
+        reverse.metadata.inactivity_timeout_ns,
+        Some(APP_TIMEOUT_NS),
+        "reverse companion must inherit the forward session's per-app idle \
+         timeout, not fall back to the global timeout"
+    );
+}
+
+// #5153: the direct `build_reverse_session_from_forward_match` builder must
+// also carry the forward match's `inactivity_timeout_ns` through (the
+// synthesized-sync path above and the live reverse-install path share this
+// builder). A forward match with NO per-app override still yields `None`
+// (global timeout), the common bit-identical case.
+#[test]
+fn build_reverse_session_carries_inactivity_timeout_5153() {
+    let forwarding = test_forwarding_state();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+
+    const APP_TIMEOUT_NS: u64 = 30_000_000_000;
+    let mut metadata = test_metadata();
+    metadata.inactivity_timeout_ns = Some(APP_TIMEOUT_NS);
+
+    let reverse = build_reverse_session_from_forward_match(
+        &forwarding,
+        &BTreeMap::new(),
+        &dynamic_neighbors,
+        ForwardSessionMatch {
+            key: test_key(),
+            decision: test_decision(),
+            metadata,
+        },
+        1,
+        0,
+    );
+    assert_eq!(
+        reverse.metadata.inactivity_timeout_ns,
+        Some(APP_TIMEOUT_NS),
+        "builder must inherit the forward match's per-app idle timeout"
+    );
+
+    // No per-app override on the forward match → reverse companion stays global
+    // (`None`), bit-identical to the pre-#5153 behavior.
+    let reverse_global = build_reverse_session_from_forward_match(
+        &forwarding,
+        &BTreeMap::new(),
+        &dynamic_neighbors,
+        ForwardSessionMatch {
+            key: test_key(),
+            decision: test_decision(),
+            metadata: test_metadata(),
+        },
+        1,
+        0,
+    );
+    assert_eq!(
+        reverse_global.metadata.inactivity_timeout_ns, None,
+        "a forward match with no per-app override keeps the reverse companion \
+         on the global timeout"
+    );
+}
+
 #[test]
 fn synthesized_synced_reverse_entry_tracks_local_client_when_owner_rg_active() {
     let forwarding = test_forwarding_state();

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -713,7 +713,20 @@ pub(super) fn build_reverse_session_from_forward_match(
         // materialized reverse companion attributes the same policy in its
         // BPF-compat conntrack row.
         policy_id: forward_match.metadata.policy_id,
-        inactivity_timeout_ns: None,
+        // #5153: inherit the forward session's per-application idle timeout so
+        // the reverse companion ages on the admitting app's window, not the
+        // global timeout. Both halves of one stateful flow share the same
+        // application, so the app's `inactivity-timeout` governs either
+        // direction. `companion_keeps_alive` (expire.rs) uses the companion's
+        // OWN `expires_after_ns` — derived from this field via
+        // `session_timeout_ns` — to decide whether to keep the idle-crossed
+        // forward half alive; hardcoding `None` here made the reverse
+        // companion's window fall back to the global timeout (e.g. 300s),
+        // extending a 30s app timeout toward the global one. `None` for every
+        // forward session with no per-app override (the forward metadata
+        // carries `None`), bit-identical to the prior behavior. Residual of
+        // #3227/#3301/#4380.
+        inactivity_timeout_ns: forward_match.metadata.inactivity_timeout_ns,
         // #3073: inherit the admitting rule's hit-counter handle from the
         // forward session so a materialized reverse companion's reply traffic
         // counts against the same policy. #3322: inherit the reorder-stable

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -304,6 +304,21 @@ per idle-crossed entry, in the GC pass only — the per-packet forwarding path i
 unchanged (the alternative, refreshing the companion on every reverse packet,
 would add a hot-path re-bucket).
 
+**Reverse companion honors the app idle window (#5153).** Because the probe
+compares the companion against `companion.expires_after_ns`, the reverse
+companion built by `build_reverse_session_from_forward_match`
+(`afxdp/shared_ops.rs`, the synthesized/failover and live reverse-install
+path) inherits the forward session's per-application `inactivity_timeout_ns`
+alongside the other metadata (log/policy/NAT64). Both halves of one flow share
+the admitting application, so `session_timeout_ns` derives the SAME
+`expires_after_ns` for either direction. Before #5153 the reverse companion
+hardcoded `inactivity_timeout_ns: None`, so its window fell back to the global
+per-protocol timeout; `companion_keeps_alive` then kept a short-timeout forward
+half alive on the companion's longer global window — stale-state retention
+beyond the app's configured idle timeout (residual of #3227/#3301/#4380). A
+forward session with no per-app override still yields `None` on the reverse
+companion (global timeout), bit-identical to the prior behavior.
+
 **Seconds→nanoseconds bound (#2441).** Configured TCP/UDP/ICMP timeouts
 arrive in the snapshot as `u64` seconds and are converted in
 `SessionTimeouts::from_seconds`. The conversion uses `checked_mul` and


### PR DESCRIPTION
## Summary

`build_reverse_session_from_forward_match` (`userspace-dp/src/afxdp/shared_ops.rs`) inherits the forward match's log/policy/NAT64 metadata but hardcoded `inactivity_timeout_ns: None` on the synthesized/failover (and live) reverse companion.

`companion_keeps_alive` (`session/expire.rs`) keeps an idle-crossed half alive using the companion's **own** `expires_after_ns`, which `session_timeout_ns` derives from `inactivity_timeout_ns`. With the reverse companion's field forced to `None`, its window fell back to the global per-protocol timeout, so a 30s per-application idle timeout was extended toward the 300s global one whenever the reverse half was treated as authoritative — stale-state retention beyond the app's configured idle window. Residual of #3227/#3301/#4380.

## Fix

Inherit `forward_match.metadata.inactivity_timeout_ns`, mirroring the adjacent field-inheritance idiom (both halves of one flow share the admitting application, so the app idle window governs either direction). `companion_keeps_alive` semantics are unchanged — only the dropped field is restored. A forward session with no per-app override still yields `None` (global timeout), bit-identical to prior behavior and rolling-upgrade safe.

Failover-safe: the reverse companion is built on the synthesized/failover HA-sync path (`synthesized_synced_reverse_entry`) and the live reverse-install path, both of which route through the fixed builder.

## Validation

- `cargo build` clean (pre-existing warnings only).
- New colocated tests, both PASS and **FAIL on revert** to hardcoded `None`:
  - `reverse_companion_inherits_forward_inactivity_timeout_5153` — full synthesized-sync path.
  - `build_reverse_session_carries_inactivity_timeout_5153` — direct builder, plus a no-override → `None` control.
- Documented in the `companion_keeps_alive` section of `userspace-dp/src/session/README.md`.

Closes #5153