### PR TITLE
cos: re-walk ingress input filter on the pre-NAT tuple

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -55304,3 +55304,35 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
   userspace-dp/src/afxdp/forwarding/tests.rs,
   userspace-dp/src/afxdp/forwarding/README.md, _Log.md
+
+- **Timestamp**: 2026-07-21
+- **Action**: #5158 — ingress input-filter re-walk was using the POST-NAT wire
+  key. `forward_request` / `neighbor_dispatch` / the `flow_cache` seed build
+  `tx_selection_wire_key = forward_wire_key(forward_key, decision.nat)` (post-NAT,
+  correct for the egress OUTPUT filter per #3642) and passed it as the SOLE
+  flow_key into the CoS resolver — which reuses it for the ingress INPUT-filter
+  re-walk (`#hb166 T-3`, cached + runtime). Junos applies input filters BEFORE
+  NAT, so a NAT'd flow re-evaluated the ingress term against post-NAT
+  addresses/ports and MISSED its ingress forwarding-class / dscp-rewrite /
+  three-color policer. Split the resolver contract: `resolve_cos_tx_selection_at`
+  / `resolve_cached_cos_tx_selection` now delegate to internal impls taking BOTH
+  a post-NAT egress key (output filter + BA/queue) and a pre-NAT ingress key
+  (input re-walk: family gate, iface-filter lookup, 5-tuple). Existing single-key
+  entry points pass the same key for both (behaviour-preserving; ~46 callers/
+  tests untouched). New `resolve_cos_tx_selection_at_prenat` /
+  `resolve_cached_cos_tx_selection_prenat` route the three post-NAT callers to
+  the pre-NAT `forward_key` for the ingress leg. Fail-on-revert test
+  `ingress_input_filter_rewalk_uses_prenat_key_5158` (colocated): ingress term
+  matches dst-port 443; DNAT'd egress wire key carries dst-port 8443 — pre-NAT
+  key hits EF queue 1, post-NAT key misses → default queue 0. Verified RED under
+  a simulated revert (`ingress_key = flow_key`): runtime returns Some(0) ≠
+  Some(1). Full userspace-dp cargo suite green (4076 passed). Updated
+  filter/README.md with the pre-NAT ingress-key contract. CoS×NAT hot path —
+  parent runs a CoS smoke before merge.
+- **File(s)**: userspace-dp/src/afxdp/tx/cos_classify.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+  userspace-dp/src/afxdp/tx/mod.rs,
+  userspace-dp/src/afxdp/forward_request.rs,
+  userspace-dp/src/afxdp/neighbor_dispatch.rs,
+  userspace-dp/src/afxdp/flow_cache.rs,
+  userspace-dp/src/filter/README.md, _Log.md

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -522,12 +522,20 @@ impl FlowCacheEntry {
         // is never cached (`should_cache` excludes it), so this only rewrites
         // the SNAT/DNAT address/port fields; the cache LOOKUP `key` below stays
         // the pre-NAT tuple (matched against the parsed ingress flow).
+        // #5158: the post-NAT wire key is correct for the egress OUTPUT filter,
+        // but the ingress INPUT filter matched this packet on its PRE-NAT ingress
+        // tuple (Junos applies input filters BEFORE NAT). Seed the cached
+        // descriptor with the post-NAT wire key for TX selection and the pre-NAT
+        // `forward_key` as the ingress re-walk key so a NAT'd flow's cached
+        // descriptor still carries the ingress `then forwarding-class` /
+        // dscp-rewrite / three-color policer.
         let tx_selection_wire_key = forward_wire_key(&flow.forward_key, decision.nat);
-        let tx_selection = resolve_cached_cos_tx_selection(
+        let tx_selection = resolve_cached_cos_tx_selection_prenat(
             forwarding,
             decision.resolution.egress_ifindex,
             meta,
             Some(&tx_selection_wire_key),
+            Some(&flow.forward_key),
         );
         // #3777: the cos TX-selection rebuild folds an interface INPUT filter's
         // `then count` handles into `tx_selection.filter_counters` when the

--- a/userspace-dp/src/afxdp/forward_request.rs
+++ b/userspace-dp/src/afxdp/forward_request.rs
@@ -203,8 +203,16 @@ pub(super) fn build_live_forward_request_from_frame(
     // The stored `PendingForwardRequest.flow_key` below stays the PRE-NAT key
     // (CoS flow-bucket hashing / session glue key it consistently with the
     // in-place fast path).
+    //
+    // #5158: the post-NAT wire key is CORRECT for the egress OUTPUT filter, but
+    // the ingress INPUT filter matched this packet on its PRE-NAT ingress tuple
+    // (Junos applies input filters BEFORE NAT). Pass the post-NAT wire key for
+    // TX selection and the pre-NAT session `forward_key` as the ingress re-walk
+    // key so a NAT'd flow still picks up an ingress `then forwarding-class` /
+    // dscp-rewrite / three-color policer (`resolve_cos_tx_selection_at_prenat`).
     let tx_selection_wire_key =
         tx_selection_flow.map(|flow| forward_wire_key(&flow.forward_key, decision.nat));
+    let ingress_flow_key = tx_selection_flow.map(|flow| &flow.forward_key);
     let cos = precomputed_tx_selection
         .map(|selection| CoSTxSelection {
             queue_id: selection.queue_id,
@@ -217,11 +225,12 @@ pub(super) fn build_live_forward_request_from_frame(
             filter_log: selection.filter_log,
         })
         .unwrap_or_else(|| {
-            resolve_cos_tx_selection_at(
+            resolve_cos_tx_selection_at_prenat(
                 forwarding,
                 decision.resolution.egress_ifindex,
                 meta,
                 tx_selection_wire_key.as_ref(),
+                ingress_flow_key,
                 // #2362 fold B: build the fragment-safe per-packet match inputs
                 // from the live frame so a `from { tcp-flags ... } then
                 // forwarding-class X` (or is-fragment / icmp-type) output filter

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -304,15 +304,19 @@ pub(super) fn retry_pending_neigh(
         // frame — the egress output filter must match the POST-NAT on-wire tuple.
         // Derive the egress wire key from the pre-NAT buffered key + this frame's
         // NAT decision (apply-to-this-packet form, correct for both directions).
+        // #5158: pass the POST-NAT wire key for the egress output filter but the
+        // pre-NAT buffered `flow_key` as the ingress re-walk key — the ingress
+        // INPUT filter matched this packet on its pre-NAT tuple.
         let tx_selection_wire_key = pkt
             .flow_key
             .as_ref()
             .map(|key| crate::session::forward_wire_key(key, decision.nat));
-        let cos = resolve_cos_tx_selection_at(
+        let cos = resolve_cos_tx_selection_at_prenat(
             forwarding,
             decision.resolution.egress_ifindex,
             pkt.meta,
             tx_selection_wire_key.as_ref(),
+            pkt.flow_key.as_ref(),
             cos_extra,
             now_ns,
         );

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -104,6 +104,42 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
     meta: UserspaceDpMeta,
     flow_key: Option<&SessionKey>,
 ) -> CachedTxSelectionDescriptor {
+    // Non-NAT / single-key callers: the ingress input-filter re-walk uses the
+    // same tuple as the output filter (there is no post-NAT/pre-NAT split).
+    resolve_cached_cos_tx_selection_impl(forwarding, egress_ifindex, meta, flow_key, flow_key)
+}
+
+/// #5158: cached-seed TX-selection variant for the POST-NAT transit forward
+/// path. `egress_wire_key` (the post-NAT on-wire tuple, #3642) drives the
+/// egress OUTPUT filter + CoS queue selection; `ingress_flow_key` (the PRE-NAT
+/// ingress tuple the input filter originally matched) drives the ingress INPUT
+/// filter re-walk. The flow-cache seed (`flow_cache.rs`) builds the post-NAT
+/// wire key with `forward_wire_key` and passes the pre-NAT session
+/// `forward_key` as `ingress_flow_key`, so NAT'd traffic still picks up an
+/// ingress `then forwarding-class` / dscp-rewrite / three-color policer.
+pub(in crate::afxdp) fn resolve_cached_cos_tx_selection_prenat(
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    meta: UserspaceDpMeta,
+    egress_wire_key: Option<&SessionKey>,
+    ingress_flow_key: Option<&SessionKey>,
+) -> CachedTxSelectionDescriptor {
+    resolve_cached_cos_tx_selection_impl(
+        forwarding,
+        egress_ifindex,
+        meta,
+        egress_wire_key,
+        ingress_flow_key,
+    )
+}
+
+fn resolve_cached_cos_tx_selection_impl(
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    meta: UserspaceDpMeta,
+    flow_key: Option<&SessionKey>,
+    ingress_flow_key: Option<&SessionKey>,
+) -> CachedTxSelectionDescriptor {
     let iface = forwarding.cos.interfaces.get(&egress_ifindex);
     let Some(flow_key) = flow_key else {
         // #hb166 T-6(m): fragments / flowless packets carry no 5-tuple but
@@ -228,15 +264,25 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
     // differs from the ingress meta family; `flow_key` is already unwrapped to
     // the egress wire key here, so its `addr_family` is the correct egress one.
     let is_v6 = flow_key.addr_family as i32 == libc::AF_INET6;
+    // #5158: the ingress INPUT filter matched the packet on its PRE-NAT ingress
+    // tuple (Junos applies input filters BEFORE NAT), so its re-walk below runs
+    // on the pre-NAT `ingress_flow_key` and the ingress-side family, NOT the
+    // post-NAT egress wire key `flow_key`/`is_v6` (#3642, correct only for the
+    // OUTPUT filter). For a non-NAT flow both keys — and both families — match.
+    let ingress_key = ingress_flow_key.unwrap_or(flow_key);
+    let ingress_is_v6 = ingress_key.addr_family as i32 == libc::AF_INET6;
     let has_output_tx_eval = crate::filter::interface_output_filter_needs_tx_eval(
         &forwarding.filter_state,
         egress_ifindex,
         is_v6,
     );
     let has_input_tx_selection =
-        crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, is_v6);
+        crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, ingress_is_v6);
     let has_input_three_color_policer =
-        crate::filter::filter_state_has_input_three_color_policer(&forwarding.filter_state, is_v6);
+        crate::filter::filter_state_has_input_three_color_policer(
+            &forwarding.filter_state,
+            ingress_is_v6,
+        );
     if iface.is_none()
         && !has_output_tx_eval
         && !has_input_tx_selection
@@ -305,7 +351,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
             meta.ingress_vlan_id,
         )
         .unwrap_or(meta.ingress_ifindex as i32);
-        let ingress_filter = if is_v6 {
+        let ingress_filter = if ingress_is_v6 {
             forwarding
                 .filter_state
                 .iface_filter_v6_fast
@@ -321,13 +367,15 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
         if let Some(ingress_filter) = ingress_filter.filter(|filter| {
             filter.affects_tx_selection || filter.has_three_color_policer_terms
         }) {
+            // #5158: re-walk on the PRE-NAT ingress tuple, not `flow_key` (the
+            // post-NAT egress wire key the output filter used above).
             let ingress_result = crate::filter::evaluate_filter_ref_tx_selection_cached(
                 ingress_filter,
-                flow_key.src_ip,
-                flow_key.dst_ip,
-                flow_key.protocol,
-                flow_key.src_port,
-                flow_key.dst_port,
+                ingress_key.src_ip,
+                ingress_key.dst_ip,
+                ingress_key.protocol,
+                ingress_key.src_port,
+                ingress_key.dst_port,
                 meta.dscp,
             );
             effective_dscp_rewrite = effective_dscp_rewrite.or(ingress_result.dscp_rewrite);
@@ -454,7 +502,16 @@ pub(in crate::afxdp) fn resolve_cos_tx_selection(
     flow_key: Option<&SessionKey>,
     extra: crate::filter::TermMatchExtra,
 ) -> CoSTxSelection {
-    resolve_cos_tx_selection_internal(forwarding, egress_ifindex, meta, flow_key, extra, None)
+    // Non-NAT / single-key callers: ingress input re-walk shares the output tuple.
+    resolve_cos_tx_selection_internal(
+        forwarding,
+        egress_ifindex,
+        meta,
+        flow_key,
+        flow_key,
+        extra,
+        None,
+    )
 }
 
 pub(in crate::afxdp) fn resolve_cos_tx_selection_at(
@@ -470,6 +527,37 @@ pub(in crate::afxdp) fn resolve_cos_tx_selection_at(
         egress_ifindex,
         meta,
         flow_key,
+        flow_key,
+        extra,
+        Some(now_ns),
+    )
+}
+
+/// #5158: TX-selection variant for the POST-NAT transit forward path. The
+/// egress OUTPUT filter and CoS queue selection run on `egress_wire_key` (the
+/// post-NAT on-wire tuple, #3642); the ingress INPUT filter re-walk runs on
+/// `ingress_flow_key` (the PRE-NAT ingress tuple the input filter originally
+/// matched). Callers that build a post-NAT `forward_wire_key` for TX selection
+/// (`forward_request`, `neighbor_dispatch` buffered-frame retransmit) pass the
+/// pre-NAT session `forward_key` as `ingress_flow_key` so NAT'd traffic still
+/// picks up an ingress `then forwarding-class` / dscp-rewrite / three-color
+/// policer. `None`/`None` degrades to the flowless path exactly as the single-
+/// key entry points do.
+pub(in crate::afxdp) fn resolve_cos_tx_selection_at_prenat(
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    meta: impl Into<ForwardPacketMeta>,
+    egress_wire_key: Option<&SessionKey>,
+    ingress_flow_key: Option<&SessionKey>,
+    extra: crate::filter::TermMatchExtra,
+    now_ns: u64,
+) -> CoSTxSelection {
+    resolve_cos_tx_selection_internal(
+        forwarding,
+        egress_ifindex,
+        meta,
+        egress_wire_key,
+        ingress_flow_key,
         extra,
         Some(now_ns),
     )
@@ -480,6 +568,7 @@ fn resolve_cos_tx_selection_internal(
     egress_ifindex: i32,
     meta: impl Into<ForwardPacketMeta>,
     flow_key: Option<&SessionKey>,
+    ingress_flow_key: Option<&SessionKey>,
     extra: crate::filter::TermMatchExtra,
     now_ns: Option<u64>,
 ) -> CoSTxSelection {
@@ -634,15 +723,25 @@ fn resolve_cos_tx_selection_internal(
         };
     };
     // `is_v6` derived above from the (post-NAT) egress key, not `meta` (#3642).
+    // #5158: the ingress INPUT filter matched the packet on its PRE-NAT ingress
+    // tuple (Junos applies input filters BEFORE NAT), so its re-walk below runs
+    // on the pre-NAT `ingress_flow_key` and the ingress-side family, NOT the
+    // post-NAT egress wire key `flow_key`/`is_v6`. For a non-NAT flow both keys —
+    // and both families — match, so this is a no-op there.
+    let ingress_key = ingress_flow_key.unwrap_or(flow_key);
+    let ingress_is_v6 = ingress_key.addr_family as i32 == libc::AF_INET6;
     let has_output_tx_eval = crate::filter::interface_output_filter_needs_tx_eval(
         &forwarding.filter_state,
         egress_ifindex,
         is_v6,
     );
     let has_input_tx_selection =
-        crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, is_v6);
+        crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, ingress_is_v6);
     let has_input_three_color_policer =
-        crate::filter::filter_state_has_input_three_color_policer(&forwarding.filter_state, is_v6);
+        crate::filter::filter_state_has_input_three_color_policer(
+            &forwarding.filter_state,
+            ingress_is_v6,
+        );
     if iface.is_none()
         && !has_output_tx_eval
         && !has_input_tx_selection
@@ -695,7 +794,7 @@ fn resolve_cos_tx_selection_internal(
         0
     };
     let ingress_filter = if need_ingress_eval {
-        if is_v6 {
+        if ingress_is_v6 {
             forwarding
                 .filter_state
                 .iface_filter_v6_fast
@@ -770,14 +869,16 @@ fn resolve_cos_tx_selection_internal(
         // METER the ingress three-color policer, so it MUST NOT re-record the
         // count — use the counter-suppressed variant (the policer meter still
         // runs via the threaded now_ns).
+        // #5158: re-walk on the PRE-NAT ingress tuple, not `flow_key` (the
+        // post-NAT egress wire key the output filter used above).
         let ingress_result = if let Some(now_ns) = now_ns {
             crate::filter::evaluate_filter_ref_tx_selection_runtime_uncounted(
                 ingress_filter,
-                flow_key.src_ip,
-                flow_key.dst_ip,
-                flow_key.protocol,
-                flow_key.src_port,
-                flow_key.dst_port,
+                ingress_key.src_ip,
+                ingress_key.dst_ip,
+                ingress_key.protocol,
+                ingress_key.src_port,
+                ingress_key.dst_port,
                 meta.dscp,
                 extra,
                 meta.pkt_len as u64,
@@ -786,11 +887,11 @@ fn resolve_cos_tx_selection_internal(
         } else {
             crate::filter::evaluate_filter_ref_tx_selection_uncounted(
                 ingress_filter,
-                flow_key.src_ip,
-                flow_key.dst_ip,
-                flow_key.protocol,
-                flow_key.src_port,
-                flow_key.dst_port,
+                ingress_key.src_ip,
+                ingress_key.dst_ip,
+                ingress_key.protocol,
+                ingress_key.src_port,
+                ingress_key.dst_port,
                 meta.dscp,
                 extra,
                 meta.pkt_len as u64,

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -1469,6 +1469,200 @@ fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exis
     assert!(!cached.filter_counters.is_empty());
 }
 
+// #5158: the ingress INPUT filter matched the packet on its PRE-NAT ingress
+// tuple (Junos applies input filters BEFORE NAT). The transit forward path
+// (`forward_request` / `neighbor_dispatch` / the `flow_cache` seed) builds a
+// POST-NAT `forward_wire_key` for the egress OUTPUT filter + TX selection
+// (#3642), then hands it to the CoS resolver. Before this fix that SAME post-NAT
+// key was reused for the ingress input-filter re-walk, so a NAT'd flow's ingress
+// `then forwarding-class` / dscp-rewrite / three-color policer was evaluated
+// against the post-NAT addresses/ports and MISSED. The split entry points
+// (`resolve_cos_tx_selection_at_prenat` / `resolve_cached_cos_tx_selection_prenat`)
+// re-walk the ingress filter on the pre-NAT `ingress_flow_key` while keeping the
+// output filter on the post-NAT egress wire key.
+//
+// FAIL-ON-REVERT: the ingress term matches destination-port 443; the modelled
+// DNAT rewrote the egress wire key's destination port to 8443. Feeding the
+// pre-NAT key (dst 443) to the re-walk hits the EF forwarding-class (queue 1);
+// reusing the post-NAT egress key (dst 8443) misses the term and falls back to
+// the default queue (0). Reverting the fix (re-walk on the post-NAT key) flips
+// the `Some(1)` assertions to `Some(0)`.
+#[test]
+fn ingress_input_filter_rewalk_uses_prenat_key_5158() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![
+            InterfaceSnapshot {
+                name: "reth1.0".into(),
+                ifindex: 101,
+                parent_ifindex: 5,
+                vlan_id: 0,
+                hardware_addr: "02:bf:72:00:61:01".into(),
+                filter_input_v4: "cos-classify".into(),
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "reth0.0".into(),
+                ifindex: 202,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                cos_shaping_rate_bytes_per_sec: 10_000_000,
+                cos_shaping_burst_bytes: 256_000,
+                cos_scheduler_map: "wan-map".into(),
+                ..Default::default()
+            },
+        ],
+        filters: vec![FirewallFilterSnapshot {
+            name: "cos-classify".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "voice".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "accept".into(),
+                forwarding_class: "expedited-forwarding".into(),
+                ..Default::default()
+            }],
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![
+                CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                },
+                CoSForwardingClassSnapshot {
+                    name: "expedited-forwarding".into(),
+                    queue: 1,
+                },
+            ],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+            schedulers: vec![
+                CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 4_000_000,
+                    transmit_rate_percent: 0.0,
+                    transmit_rate_exact: false,
+                    priority: "low".into(),
+                    buffer_size_bytes: 128_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+                CoSSchedulerSnapshot {
+                    name: "ef-sched".into(),
+                    transmit_rate_bytes: 6_000_000,
+                    transmit_rate_percent: 0.0,
+                    transmit_rate_exact: false,
+                    priority: "strict-high".into(),
+                    buffer_size_bytes: 64_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+            ],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    },
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "expedited-forwarding".into(),
+                        scheduler: "ef-sched".into(),
+                    },
+                ],
+            }],
+        }),
+        ..Default::default()
+    };
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let meta = UserspaceDpMeta {
+        ingress_ifindex: 5,
+        ingress_vlan_id: 0,
+        addr_family: libc::AF_INET as u8,
+        dscp: 0,
+        ..Default::default()
+    };
+    // PRE-NAT ingress tuple — destination-port 443, matches the ingress term.
+    let ingress_key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+        src_port: 12345,
+        dst_port: 443,
+    };
+    // POST-NAT egress wire tuple — DNAT rewrote the destination port to 8443, so
+    // it no longer matches the ingress term's destination-port 443.
+    let egress_wire_key = SessionKey {
+        dst_port: 8443,
+        ..ingress_key.clone()
+    };
+    let now_ns = 1_000_000u64;
+
+    // Runtime path: the ingress re-walk MUST use the pre-NAT key -> EF queue 1.
+    let runtime = resolve_cos_tx_selection_at_prenat(
+        &forwarding,
+        202,
+        meta,
+        Some(&egress_wire_key),
+        Some(&ingress_key),
+        TermMatchExtra::default(),
+        now_ns,
+    );
+    assert_eq!(
+        runtime.queue_id,
+        Some(1),
+        "runtime ingress input-filter re-walk must match the PRE-NAT tuple (dst 443)",
+    );
+
+    // Cached-seed path: same contract.
+    let cached = resolve_cached_cos_tx_selection_prenat(
+        &forwarding,
+        202,
+        meta,
+        Some(&egress_wire_key),
+        Some(&ingress_key),
+    );
+    assert_eq!(
+        cached.queue_id,
+        Some(1),
+        "cached ingress input-filter re-walk must match the PRE-NAT tuple (dst 443)",
+    );
+
+    // Positive control: reusing the POST-NAT egress key for the ingress re-walk
+    // (the pre-#5158 behaviour) misses the term (dst 8443) and falls back to the
+    // default queue. Proves the assertions above bind to the pre-NAT tuple.
+    let reverted_runtime = resolve_cos_tx_selection_at_prenat(
+        &forwarding,
+        202,
+        meta,
+        Some(&egress_wire_key),
+        Some(&egress_wire_key),
+        TermMatchExtra::default(),
+        now_ns,
+    );
+    assert_eq!(
+        reverted_runtime.queue_id,
+        Some(0),
+        "post-NAT key misses the ingress term -> default queue (documents the bug)",
+    );
+    let reverted_cached = resolve_cached_cos_tx_selection_prenat(
+        &forwarding,
+        202,
+        meta,
+        Some(&egress_wire_key),
+        Some(&egress_wire_key),
+    );
+    assert_eq!(reverted_cached.queue_id, Some(0));
+}
+
 #[test]
 fn resolve_cached_cos_tx_selection_keeps_counter_only_output_filter_hits() {
     let snapshot = ConfigSnapshot {

--- a/userspace-dp/src/afxdp/tx/mod.rs
+++ b/userspace-dp/src/afxdp/tx/mod.rs
@@ -33,8 +33,9 @@ pub(super) mod tcp_segmentation;
 pub(in crate::afxdp) use cos_classify::cos_queue_dscp_rewrite;
 pub(super) use cos_classify::{
     CoSTxSelection, GeneratedReplyVerdict, classify_generated_reply, enqueue_local_into_cos,
-    reclassify_cached_ba_queue, resolve_cached_cos_tx_selection, resolve_cos_queue_id,
-    resolve_cos_tx_selection, resolve_cos_tx_selection_at,
+    reclassify_cached_ba_queue, resolve_cached_cos_tx_selection,
+    resolve_cached_cos_tx_selection_prenat, resolve_cos_queue_id, resolve_cos_tx_selection,
+    resolve_cos_tx_selection_at, resolve_cos_tx_selection_at_prenat,
 };
 // Private use, not a re-export: a `pub(super) use` of a `pub(super)`
 // item triggers E0364. drain.rs reaches this through `use super::*;`.

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -86,10 +86,29 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   ingress `meta.addr_family` — a v6→v4 flow evaluates the v4 output
   filter against the v4 tuple. The pre-NAT `flow_key` is still stored on
   the pending request for CoS flow-bucket hashing / session glue, so the
-  hash bucketing is unchanged. (An input-filter forwarding-class /
-  three-color policer carried to the TX leg when NO output filter exists
-  is likewise evaluated on the wire key; this is a rare corner and the
-  policer meters the on-wire egress volume.)
+  hash bucketing is unchanged.
+
+  **The ingress INPUT filter re-walk keeps the PRE-NAT tuple (#5158).**
+  The post-NAT wire key above is correct ONLY for the egress OUTPUT
+  filter. The same `resolve_cos_tx_selection_*` call ALSO re-walks the
+  ingress interface input filter to pick up an input-filter
+  `then forwarding-class` / dscp-rewrite / three-color policer (the
+  `#hb166 T-3` leg, folded with `.or()` so an output-filter class still
+  wins). Junos applies input filters BEFORE NAT, so that re-walk must
+  match the ORIGINAL ingress tuple — feeding it the post-NAT wire key
+  made a NAT'd flow miss its ingress classification/policer entirely. The
+  transit callers that build a post-NAT `forward_wire_key`
+  (`afxdp/forward_request.rs`, `afxdp/neighbor_dispatch.rs`, the
+  `afxdp/flow_cache.rs` seed) therefore call the split entry points
+  `resolve_cos_tx_selection_at_prenat` /
+  `resolve_cached_cos_tx_selection_prenat`, passing the post-NAT wire key
+  as the egress/output key and the pre-NAT session `forward_key` as the
+  `ingress_flow_key`. The resolver evaluates the ingress input filter
+  (its family gate, interface-filter lookup, and 5-tuple) on the pre-NAT
+  key and the output filter + BA/queue selection on the post-NAT key. For
+  a non-NAT flow both keys are identical, so the single-key entry points
+  (`resolve_cos_tx_selection` / `_at`, `resolve_cached_cos_tx_selection`)
+  pass the same key for both stages — behaviour-preserving.
 
   **Fall-through terms (`then next term` / modifier-only) (#2544).**
   "First-match-wins" applies only to TERMINATING terms. A term whose


### PR DESCRIPTION
## Summary

`forward_request`, `neighbor_dispatch`, and the `flow_cache` seed derive a **post-NAT** wire key — `forward_wire_key(forward_key, decision.nat)` — and pass it as the *sole* `flow_key` into the CoS TX-selection resolver. That is correct for the egress **OUTPUT** filter (#3642: Junos applies output filters *after* NAT), but the resolver reuses the **same** key for the ingress **INPUT-filter re-walk** (the `#hb166 T-3` forwarding-class / dscp-rewrite / three-color-policer leg, cached + runtime). Junos applies input filters *before* NAT, so a NAT'd flow re-evaluated the ingress term against **post-NAT** addresses/ports and **missed** its ingress forwarding-class, DSCP rewrite, and three-color policer.

## Fix

Split the resolver contract into a **post-NAT egress key** (output filter + BA/queue selection) and a **pre-NAT ingress key** (input-filter re-walk: family gate, interface-filter lookup, and 5-tuple):

- Internal cached + runtime impls now take both keys.
- Existing single-key entry points (`resolve_cos_tx_selection` / `_at`, `resolve_cached_cos_tx_selection`) pass the same key for both stages → every non-NAT caller and all existing tests are **behaviour-preserving** (~46 call sites untouched).
- New `resolve_cos_tx_selection_at_prenat` / `resolve_cached_cos_tx_selection_prenat` route the three post-NAT transit callers to the pre-NAT session `forward_key` for the ingress leg while keeping the post-NAT wire key for the output filter.

Deriving the ingress family from the pre-NAT key also fixes the NAT64 corner (v6 ingress → v4 egress): the ingress input filter is now selected/matched on the v6 ingress tuple. Same-family SNAT/DNAT is unaffected by the family change.

## Test

Fail-on-revert `ingress_input_filter_rewalk_uses_prenat_key_5158`: an ingress input filter matches destination-port 443 → forwarding-class `expedited-forwarding` (queue 1); the modelled DNAT rewrote the egress wire key's destination port to 8443. The runtime and cached split resolvers must hit queue 1 via the pre-NAT key; a positive control feeds the post-NAT key as the ingress key and confirms it misses the term (default queue 0). Reverting the fix (re-walk on the post-NAT key) flips both `Some(1)` assertions to `Some(0)` — **verified RED under a simulated revert**. Full userspace-dp cargo suite green (4076 passed).

Updated `filter/README.md` with the pre-NAT ingress-key contract.

Closes #5158