### PR TITLE
vrrp: RLock cfg.AdvertiseInterval read in advertInterval

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-21 — #6230: RLock cfg.AdvertiseInterval read in advertInterval()
+
+- **Timestamp**: 2026-07-21 (fix/6230-advertinterval-rlock)
+- **Action**: `advertInterval()` (`pkg/vrrp/instance.go`) read
+  `vi.cfg.AdvertiseInterval` with NO lock while the run loop reset the advert
+  timer, but every sibling cfg accessor (`getState`, `masterDownInterval`,
+  `preemptHoldDuration`) snapshots `vi.cfg` under `vi.mu`, and cfg writers
+  (`updateConfig`) mutate it under `vi.mu.Lock()`. Unsynchronized read = a data
+  race `go test -race` flags. Fixed by snapshotting under `vi.mu.RLock()`,
+  releasing before the Duration math (matching the `masterDownInterval` idiom).
+  DEADLOCK FORK handled: `recordMasterAdvert` calls `masterAdverFloor()` →
+  `advertInterval()` while HOLDING `vi.mu.Lock()` (write) — a naive RLock there
+  self-deadlocks. Resolved with the canonical locked-variant split: added
+  `advertIntervalLocked()` (lock-free, caller-holds-vi.mu) + shared
+  `advertIntervalFromMS()` helper; `masterAdverFloor` now calls the Locked
+  variant. The other 6 callers (run-loop, lock free) use the RLock wrapper.
+  Added `pkg/vrrp/instance_advert_interval_race_test.go`:
+  `TestAdvertIntervalNoRace6230` (locked cfg write vs advertInterval reads —
+  fail-on-revert: race fires on the unlocked read) +
+  `TestAdvertIntervalMasterAdverFloorNoDeadlock6230` (guards the
+  recordMasterAdvert-under-Lock path against the deadlock regression). Full
+  `pkg/vrrp` suite green under `-race`.
+- **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/instance_advert_interval_race_test.go,
+  pkg/vrrp/README.md, _Log.md
+
 ## 2026-07-21 — #5152: gate RefreshOwnerRGS liveness re-stamp on forwarding disposition
 
 - **Timestamp**: 2026-07-21 (fix/5152-refresh-owner-rgs-hainactive-guard)

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -566,6 +566,17 @@ pointer means unresolved). The lazy-resolve semantics are preserved —
 the address still becomes available once it is resolvable — and the
 packet hot path stays lock-free, mirroring the `lastDropWarn` atomic.
 
+`advertInterval()` is a third cross-goroutine hazard (#6230). The
+run-loop goroutine calls it on every advert-timer reset to read
+`cfg.AdvertiseInterval`, while cfg writers (`updateConfig`) mutate `cfg`
+under `vi.mu.Lock()`. The read was unlocked — a data race `go test
+-race` flags — where every sibling accessor (`getState`,
+`masterDownInterval`, `preemptHoldDuration`) already snapshots `cfg`
+under `vi.mu`. It now RLocks like they do. The one caller that already
+holds the write lock, `recordMasterAdvert` → `masterAdverFloor`, reads
+via the lock-free `advertIntervalLocked` variant instead — re-taking the
+RLock under the held `Lock()` would self-deadlock.
+
 #### Source re-resolution on address change (#2528)
 
 The lazy-resolve above only fires when the cached source is **nil**

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -730,9 +730,34 @@ func (vi *vrrpInstance) setState(s VRRPState) {
 }
 
 // advertInterval returns the advertisement interval as a Duration.
-// AdvertiseInterval is in milliseconds.
+// AdvertiseInterval is in milliseconds. The cfg field is snapshotted under
+// vi.mu.RLock() — mirroring the other config accessors (masterDownInterval,
+// preemptHoldDuration) — so a concurrent locked config update cannot race the
+// read that go test -race would otherwise flag (#6230). The lock is released
+// before the Duration math, matching the masterDownInterval idiom.
+//
+// Callers that ALREADY hold vi.mu (masterAdverFloor, reached from
+// recordMasterAdvert under vi.mu.Lock) MUST use advertIntervalLocked instead:
+// re-taking the RLock while the write lock is held would deadlock.
 func (vi *vrrpInstance) advertInterval() time.Duration {
+	vi.mu.RLock()
 	ms := vi.cfg.AdvertiseInterval
+	vi.mu.RUnlock()
+	return advertIntervalFromMS(ms)
+}
+
+// advertIntervalLocked returns the advertisement interval as a Duration for
+// callers that already hold vi.mu (read or write). It performs the same read as
+// advertInterval WITHOUT taking the lock, for paths that run under vi.mu.Lock
+// (recordMasterAdvert → masterAdverFloor); calling advertInterval there would
+// deadlock on the RLock (#6230).
+func (vi *vrrpInstance) advertIntervalLocked() time.Duration {
+	return advertIntervalFromMS(vi.cfg.AdvertiseInterval)
+}
+
+// advertIntervalFromMS converts a configured advertise interval in
+// milliseconds (0 or negative → the 1000 ms default) to a Duration.
+func advertIntervalFromMS(ms int) time.Duration {
 	if ms <= 0 {
 		ms = 1000
 	}
@@ -1762,10 +1787,12 @@ func (vi *vrrpInstance) recordMasterAdvert(pkt *VRRPPacket) {
 // masterAdverFloor is the minimum interval a learned Master_Adver_Interval may
 // take (#4548). It is the node's own configured advertise interval
 // (cfg.AdvertiseInterval, defaulting to 1000 ms when unset — see advertInterval)
-// with an absolute minLearnedMasterAdverInterval backstop. Reads cfg, which is
-// immutable after construction, so it is safe to call while holding vi.mu.
+// with an absolute minLearnedMasterAdverInterval backstop. Its sole caller,
+// recordMasterAdvert, already holds vi.mu.Lock, so it reads the interval via
+// advertIntervalLocked — calling the RLock-taking advertInterval here would
+// self-deadlock against the held write lock (#6230).
 func (vi *vrrpInstance) masterAdverFloor() time.Duration {
-	floor := vi.advertInterval()
+	floor := vi.advertIntervalLocked()
 	if floor < minLearnedMasterAdverInterval {
 		floor = minLearnedMasterAdverInterval
 	}

--- a/pkg/vrrp/instance_advert_interval_race_test.go
+++ b/pkg/vrrp/instance_advert_interval_race_test.go
@@ -1,0 +1,102 @@
+package vrrp
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// #6230: advertInterval() read vi.cfg.AdvertiseInterval with NO lock while the
+// run loop reset the advert timer, but every other cfg accessor snapshots
+// vi.cfg under vi.mu (getState, masterDownInterval, preemptHoldDuration) and
+// cfg writers mutate it under vi.mu.Lock(). That unsynchronized read is a data
+// race the Go memory model forbids and `go test -race` flags. The fix snapshots
+// AdvertiseInterval under vi.mu.RLock() (advertInterval), while the ONE caller
+// that already holds the write lock — recordMasterAdvert → masterAdverFloor —
+// reads via advertIntervalLocked so it does not self-deadlock on the RLock.
+//
+// These tests are the fail-on-revert gate. The race detector reports on the
+// FIRST unsynchronized concurrent access, so a few thousand tightly interleaved
+// iterations suffice and stay fast even under -race.
+
+// TestAdvertIntervalNoRace6230 drives a LOCKED write of cfg.AdvertiseInterval
+// (the config-update discipline every cfg writer, e.g. updateConfig, follows)
+// concurrently with advertInterval() reads from a second goroutine. Under -race
+// it is CLEAN with the RLock fix and DETECTS the race if advertInterval() is
+// reverted to the unlocked read of vi.cfg.AdvertiseInterval.
+func TestAdvertIntervalNoRace6230(t *testing.T) {
+	vi := &vrrpInstance{cfg: Instance{Interface: "ge-0-0-2", GroupID: 1, AdvertiseInterval: 30}}
+
+	const iters = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: a locked config update mutating AdvertiseInterval, mirroring the
+	// vi.mu.Lock() discipline every cfg writer uses.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			vi.mu.Lock()
+			if i%2 == 0 {
+				vi.cfg.AdvertiseInterval = 30
+			} else {
+				vi.cfg.AdvertiseInterval = 100
+			}
+			vi.mu.Unlock()
+		}
+	}()
+
+	// Reader: the run-loop advert-timer reset path. The value is always one of
+	// the two writer-set intervals — a torn read would surface as neither.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if d := vi.advertInterval(); d != 30*time.Millisecond && d != 100*time.Millisecond {
+				t.Errorf("advertInterval() = %v, want 30ms or 100ms", d)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestAdvertIntervalMasterAdverFloorNoDeadlock6230 guards the non-obvious half
+// of the #6230 fix. recordMasterAdvert holds vi.mu.Lock() when it reaches
+// masterAdverFloor, so masterAdverFloor MUST read the interval via
+// advertIntervalLocked. If it were reverted to call the RLock-taking
+// advertInterval, the RLock requested under the held write lock would
+// self-deadlock and this test would hang until the go-test timeout kills it.
+// Running it alongside a concurrent advertInterval() reader also exercises the
+// RLock/Lock interleave without a race.
+func TestAdvertIntervalMasterAdverFloorNoDeadlock6230(t *testing.T) {
+	vi := &vrrpInstance{cfg: Instance{Interface: "ge-0-0-2", GroupID: 1, AdvertiseInterval: 30}}
+
+	// A non-zero-priority advert with a valid Max Adver Int drives
+	// recordMasterAdvert down the masterAdverFloor path (MaxAdvertInt > 0).
+	pkt := &VRRPPacket{VRID: 1, Priority: 100, MaxAdvertInt: 5}
+
+	const iters = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// recordMasterAdvert takes vi.mu.Lock() and, still holding it, calls
+	// masterAdverFloor → advertIntervalLocked. Deadlocks if that reverts to
+	// advertInterval's RLock.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			vi.recordMasterAdvert(pkt)
+		}
+	}()
+
+	// Concurrent RLock reader of the same interval field.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_ = vi.advertInterval()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
`advertInterval()` (`pkg/vrrp/instance.go`) read `vi.cfg.AdvertiseInterval` with **no lock** while the run loop reset the advert timer on every state transition, but every sibling cfg accessor snapshots `vi.cfg` under `vi.mu` (`getState`, `masterDownInterval`, `preemptHoldDuration`) and cfg writers (`updateConfig`) mutate it under `vi.mu.Lock()`. The unsynchronized read is a data race the Go memory model forbids and `go test -race` flags — `advertInterval()` was the lone outlier (#6230).

## Fix
- Snapshot `AdvertiseInterval` under `vi.mu.RLock()`, releasing before the `time.Duration` math (matches the `masterDownInterval` idiom).
- **Deadlock fork handled.** `recordMasterAdvert` holds `vi.mu.Lock()` (write) and, still holding it, calls `masterAdverFloor()` → `advertInterval()`. A naive `RLock` there self-deadlocks (`sync.RWMutex` refuses an RLock while a writer holds the lock). Resolved with the canonical **locked-variant split**: `advertIntervalLocked()` reads the field lock-free (caller must already hold `vi.mu`) + a shared `advertIntervalFromMS()` helper for the 1000 ms default. `masterAdverFloor` uses the lock-free variant; the other six call sites (run-loop, lock not held) use the RLock wrapper.
- `AdvertiseInterval` is never mutated after construction, so no torn read occurs in practice on amd64 — this fixes the race the detector reports (a real CI signal), not a live failover defect. Severity: LOW, per the issue.

## Tests (`pkg/vrrp/instance_advert_interval_race_test.go`)
- `TestAdvertIntervalNoRace6230` — locked write of `cfg.AdvertiseInterval` concurrent with `advertInterval()` reads. **Fail-on-revert verified**: the race detector fires and the test FAILS when `advertInterval()` is reverted to the unlocked read.
- `TestAdvertIntervalMasterAdverFloorNoDeadlock6230` — exercises the `recordMasterAdvert`-under-`Lock()` path to guard the deadlock invariant against regression.
- Full `pkg/vrrp` suite passes under `-race`.

## Docs
`pkg/vrrp/README.md` — documented alongside the sibling rxDrop/localIP race notes.

Closes #6230

🤖 Generated with [Claude Code](https://claude.com/claude-code)