### PR TITLE
cos: conserve shared non-exact queue lease at init and teardown

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-21 — #5156: conserve the shared non-exact CoS queue lease at init AND teardown
+
+- **Timestamp**: 2026-07-21 (fix/5156-cos-nonexact-lease-conservation)
+- **Action**: Fixed a two-sided lease-conservation asymmetry for non-exact
+  lease-metered CoS queues (the sharded `shared_exact` non-exact guaranteed
+  queue that draws from a shared legacy `SharedCoSQueueLease`, #4265). Init
+  half: `build_cos_interface_runtime` (`cos/builders.rs`) pre-filled each
+  non-exact worker replica's token bucket with full `buffer_bytes`,
+  UN-metered by the shared lease — so `buffer_bytes × N_workers` entered
+  circulation with no matching `outstanding` charge, defeating the #4265
+  metering at startup. Teardown half: `release_all_cos_queue_leases`
+  (`cos/token_bucket.rs`) filtered `queue.config.exact && queue.hot.tokens
+  > 0`, so a non-exact queue's leased tokens were NEVER returned to the
+  lease at worker exit / binding reset / lease-set swap — the (often
+  reused) lease Arc stayed permanently over-charged and under-provisioned
+  the class. Made the two symmetric: a non-exact lease-metered queue now
+  starts at 0 local tokens (metered via the lease at runtime, exactly like
+  exact) and its residual bank is returned at teardown. Both sites now gate
+  on the SINGLE new predicate `CoSQueueConfig::is_shared_lease_metered()`
+  (`types/cos.rs`), which the coordinator's lease-build condition
+  (`coordinator/cos_leases.rs`) was refactored to use too — eliminating the
+  drift between the two encodings of "is this non-exact queue lease-metered"
+  that caused the bug. The teardown filter drops the `exact` gate and relies
+  on the existing lease-presence check in the release body (mirroring the
+  runtime empty give-back in `refresh_cos_interface_activity`, #4265, which
+  already keys on lease presence not `exact`). Conservation invariant
+  restored: every byte a non-exact lease-metered queue's `hot.tokens` holds
+  is acquired through — and returned to — the shared lease.
+- **File(s)**: userspace-dp/src/afxdp/types/cos.rs (new
+  `is_shared_lease_metered` predicate), userspace-dp/src/afxdp/cos/builders.rs
+  (init: 0 tokens for lease-metered non-exact), userspace-dp/src/afxdp/cos/token_bucket.rs
+  (teardown: widen give-back filter), userspace-dp/src/afxdp/coordinator/cos_leases.rs
+  (use shared predicate), userspace-dp/src/afxdp/cos/token_bucket_tests.rs
+  (fail-on-revert test `nonexact_queue_lease_conserved_across_teardown_5156`),
+  userspace-dp/src/afxdp/cos/README.md (lease-conservation contract).
+- **Validation**: `cargo test --bin xpf-userspace-dp` — 4079 passed, 0 failed.
+  New test verified fail-on-revert for BOTH halves independently: reverting
+  the teardown filter to exact-only FAILS the conservation assertion;
+  reverting the init to exact-only-zero FAILS the 0-token init assertion.
+
 ## 2026-07-21 — #5152: gate RefreshOwnerRGS liveness re-stamp on forwarding disposition
 
 - **Timestamp**: 2026-07-21 (fix/5152-refresh-owner-rgs-hainactive-guard)

--- a/userspace-dp/src/afxdp/coordinator/cos_leases.rs
+++ b/userspace-dp/src/afxdp/coordinator/cos_leases.rs
@@ -667,10 +667,12 @@ pub(super) fn build_shared_cos_queue_leases_reusing_existing(
                 // accounting hole. `active_shards` sizing means a worker
                 // join/leave rebuilds the lease via `matches_config`, the
                 // same discipline the exact v8 lease uses.
-                if !queue.guarantee_enabled
-                    || queue.transmit_rate_bytes
-                        < crate::afxdp::worker::COS_SHARED_EXACT_MIN_RATE_BYTES
-                {
+                // #5156: single source of truth for "non-exact queue is
+                // lease-metered" — the runtime builder gates its 0-token
+                // init on the SAME predicate, so the lease's init charge and
+                // teardown give-back stay symmetric. `transmit_rate_bytes ==
+                // 0` was already excluded by the guard above.
+                if !queue.is_shared_lease_metered() {
                     continue;
                 }
                 if let Some(lease) = existing.get(&key).filter(|lease| {

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -181,6 +181,30 @@ mod.rs for further file-level breakdown.
   per-root residual bucket. Exact queues that explicitly enable
   `surplus-sharing` remain eligible for surplus service outside the
   non-exact residual budget.
+- **Shared queue-lease conservation for non-exact lease-metered queues
+  (#4265 / #5156).** A non-exact GUARANTEED queue whose configured rate
+  trips `COS_SHARED_EXACT_MIN_RATE_BYTES` runs the sharded `shared_exact`
+  execution policy: it drains locally on EVERY worker, so the coordinator
+  attaches a shared legacy `SharedCoSQueueLease` and its class-wide
+  admission is metered through that lease instead of a private per-worker
+  bucket. `CoSQueueConfig::is_shared_lease_metered()` (in `types/cos.rs`)
+  is the SINGLE source of truth for "this non-exact queue is
+  lease-metered" — the coordinator
+  (`build_shared_cos_queue_leases_reusing_existing`) and the runtime
+  builder (`build_cos_interface_runtime`) both gate on it, so the lease's
+  init charge and teardown give-back stay symmetric. The conservation
+  invariant: every byte the queue's `hot.tokens` ever holds is acquired
+  through — and returned to — the shared lease's `outstanding` word.
+  Concretely such a queue starts at 0 local tokens (like an exact queue,
+  NOT pre-filled `buffer_bytes`), acquires its bank through
+  `maybe_top_up_cos_queue_lease` → `acquire_via_lease`, gives an emptied
+  bank back at runtime in `refresh_cos_interface_activity`, and gives its
+  residual bank back at worker exit / binding reset / lease-set swap in
+  `release_all_cos_queue_leases`. Both give-back sites key on lease
+  presence (`shared_queue_lease.is_some()`), NOT on `queue.config.exact`,
+  so a truly un-leased single-owner queue (exact or non-exact) keeps its
+  private per-worker burst. `release_unused_v8` reduces to the legacy
+  `release_unused` for a legacy (v8=None) lease.
 - `COS_MIN_BURST_BYTES` (64 × MTU) is canonically owned by
   `token_bucket.rs`; siblings import it via the `cos/mod.rs`
   re-export.

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -200,9 +200,23 @@ pub(in crate::afxdp) fn build_cos_interface_runtime(
                     // no parent shaping rate). Pre-fill tokens to the
                     // buffer cap; otherwise an exact queue starts at 0
                     // and waits forever for a top-up that never arrives.
+                    //
+                    // #5156 (init half): a non-exact LEASE-METERED queue
+                    // (`is_shared_lease_metered`) also starts at 0, exactly
+                    // like exact. Its buffer_bytes are then acquired through
+                    // the shared queue lease at runtime
+                    // (`maybe_top_up_cos_queue_lease` -> `acquire_via_lease`),
+                    // charging the lease's `outstanding` word. Pre-filling
+                    // it un-metered (the old `else` arm) put buffer_bytes ×
+                    // N_workers into circulation with no matching shared
+                    // charge, defeating the #4265 metering at startup and
+                    // leaving the teardown give-back nothing consistent to
+                    // return. Only a truly un-leased non-exact queue
+                    // (single-owner low-rate: a private per-worker bucket,
+                    // no shared lease) keeps pre-filling its burst.
                     tokens: if queue.transmit_rate_bytes == 0 {
                         queue.buffer_bytes.max(COS_MIN_BURST_BYTES)
-                    } else if queue.exact {
+                    } else if queue.exact || queue.is_shared_lease_metered() {
                         0
                     } else {
                         queue.buffer_bytes.max(COS_MIN_BURST_BYTES)

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -427,7 +427,21 @@ pub(in crate::afxdp) fn release_all_cos_queue_leases(binding: &mut BindingWorker
             root.queues
                 .iter()
                 .enumerate()
-                .filter(|(_, queue)| queue.config.exact && queue.hot.tokens > 0)
+                // #5156 (teardown half): give back EVERY queue that holds
+                // banked tokens, not just exact ones. A non-exact
+                // lease-metered queue (#4265) acquires its buffer_bytes
+                // through the shared lease at runtime, so its outstanding
+                // credit must be returned here on worker exit / binding
+                // reset / lease-set swap — otherwise the (often reused)
+                // lease Arc stays permanently over-charged and under-
+                // provisions the class. The actual give-back below is still
+                // gated on `shared_queue_lease.is_some()`, so a truly
+                // un-leased queue (single-owner exact OR single-owner
+                // non-exact) just has its now-defunct bucket zeroed with
+                // nothing to credit — mirroring the runtime empty give-back
+                // in `refresh_cos_interface_activity`, which already keys on
+                // lease presence rather than `exact`.
+                .filter(|(_, queue)| queue.hot.tokens > 0)
                 .map(move |(queue_idx, _)| (root_ifindex, queue_idx))
         })
         .collect::<Vec<_>>();

--- a/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
@@ -616,3 +616,160 @@ fn cos_refill_ns_until_covers_all_branches() {
     assert_eq!(cos_refill_ns_until(0, 1, 3), Some(333_333_334));
     assert_eq!(cos_refill_ns_until(0, 2, 3), Some(666_666_667));
 }
+
+// #5156: the shared non-exact queue lease must be conserved across a
+// worker init -> top-up -> teardown cycle. A non-exact GUARANTEED queue
+// whose rate trips COS_SHARED_EXACT_MIN_RATE_BYTES is lease-metered
+// (`is_shared_lease_metered`): the coordinator attaches a shared legacy
+// `SharedCoSQueueLease` so its class-wide admission is metered, exactly
+// like exact queues. Two halves of the asymmetry are exercised here:
+//
+//   Init half   — `build_cos_interface_runtime` must start such a queue's
+//                 token bucket at 0 (metered via the lease at runtime),
+//                 NOT pre-fill `buffer_bytes` un-metered. On revert to the
+//                 old `else` arm the queue starts at `buffer_bytes` and the
+//                 first assertion fails.
+//
+//   Teardown half — `release_all_cos_queue_leases` must give the queue's
+//                 outstanding leased tokens back to the shared lease. On
+//                 revert to the `queue.config.exact && ...` filter the
+//                 non-exact queue is skipped, the lease stays permanently
+//                 over-charged, and its post-teardown drainable capacity is
+//                 short by the outstanding grant — the conservation
+//                 assertion fails.
+#[test]
+fn nonexact_queue_lease_conserved_across_teardown_5156() {
+    use crate::afxdp::cos::builders::build_cos_interface_runtime;
+    use crate::afxdp::types::{CoSInterfaceConfig, CoSOversubscriptionPolicy, FastMap};
+    use crate::afxdp::worker::{BindingWorker, COS_SHARED_EXACT_MIN_RATE_BYTES};
+
+    const IFINDEX: i32 = 42;
+    const QUEUE_ID: u8 = 5;
+    const BUFFER_BYTES: u64 = 128 * 1024;
+    // 3 Gbps > COS_SHARED_EXACT_MIN_RATE_BYTES (2.5 Gbps) — a lease-metered
+    // non-exact guaranteed queue.
+    const RATE_BYTES: u64 = 3_000_000_000 / 8;
+    const SHARDS: usize = 6;
+    const NOW_NS: u64 = 1_000_000_000;
+
+    assert!(
+        RATE_BYTES >= COS_SHARED_EXACT_MIN_RATE_BYTES,
+        "test queue must be lease-metered"
+    );
+
+    let make_cfg = || CoSInterfaceConfig {
+        shaping_rate_bytes: 25_000_000_000 / 8,
+        burst_bytes: 256 * 1024,
+        default_queue: QUEUE_ID,
+        dscp_classifier: String::new(),
+        ieee8021_classifier: String::new(),
+        dscp_queue_by_dscp: [u8::MAX; 64],
+        ieee8021_queue_by_pcp: [u8::MAX; 8],
+        queue_by_forwarding_class: FastMap::default(),
+        queues: vec![CoSQueueConfig {
+            queue_id: QUEUE_ID,
+            forwarding_class: "iperf-b".into(),
+            priority: 5,
+            transmit_rate_bytes: RATE_BYTES,
+            guarantee_enabled: true,
+            exact: false,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: BUFFER_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+        oversubscription_policy: CoSOversubscriptionPolicy::Proportional,
+        oversubscription_guarantee_fraction: 0.0,
+        priority_low_min_share_bytes: 0,
+    };
+
+    // Drain a lease's full outstanding-credit capacity at a fixed clock.
+    fn drain_capacity(lease: &SharedCoSQueueLease, now_ns: u64) -> u64 {
+        let mut total = 0u64;
+        loop {
+            let granted = lease.acquire(now_ns, u64::MAX);
+            if granted == 0 {
+                break;
+            }
+            total = total.saturating_add(granted);
+        }
+        total
+    }
+
+    // --- Init half: the lease-metered non-exact queue starts at 0. ---
+    let mut root = build_cos_interface_runtime(&make_cfg(), NOW_NS);
+    assert_eq!(
+        root.queues[0].hot.tokens, 0,
+        "#5156 init: a lease-metered non-exact queue must start with 0 local \
+         tokens (metered via the shared lease), not a pre-filled buffer_bytes bank"
+    );
+
+    // Baseline capacity of a pristine, never-charged lease.
+    let baseline_lease = Arc::new(SharedCoSQueueLease::new(RATE_BYTES, BUFFER_BYTES, SHARDS));
+    let baseline_capacity = drain_capacity(&baseline_lease, NOW_NS);
+    assert!(baseline_capacity > 0, "baseline lease must hand out credit");
+
+    // Control: a lease charged but NOT torn down loses exactly the grant —
+    // proves the conservation assertion below is non-vacuous. The charge is
+    // whatever the runtime top-up moved into the queue's local bucket.
+    let leaked_lease = Arc::new(SharedCoSQueueLease::new(RATE_BYTES, BUFFER_BYTES, SHARDS));
+    let _ = maybe_top_up_cos_queue_lease(&mut root.queues[0], Some(&leaked_lease), NOW_NS);
+    let charged = root.queues[0].hot.tokens;
+    assert!(
+        charged > 0,
+        "runtime top-up must acquire leased tokens for the non-exact queue"
+    );
+    let leaked_capacity = drain_capacity(&leaked_lease, NOW_NS);
+    assert_eq!(
+        leaked_capacity,
+        baseline_capacity - charged,
+        "a charged-but-not-released lease must be short by the outstanding grant"
+    );
+
+    // --- Teardown half: release_all_cos_queue_leases returns the grant. ---
+    let test_lease = Arc::new(SharedCoSQueueLease::new(RATE_BYTES, BUFFER_BYTES, SHARDS));
+    // Re-run the top-up against the lease that IS attached to the fast path,
+    // so the queue's outstanding charge lives on `test_lease`.
+    root.queues[0].hot.tokens = 0;
+    let charged2 = {
+        let _ = maybe_top_up_cos_queue_lease(&mut root.queues[0], Some(&test_lease), NOW_NS);
+        root.queues[0].hot.tokens
+    };
+    assert!(charged2 > 0, "second top-up must also charge the lease");
+
+    let fast_interfaces = test_cos_fast_interfaces(
+        IFINDEX,
+        IFINDEX,
+        QUEUE_ID,
+        vec![(
+            QUEUE_ID,
+            test_queue_fast_path(false, 0, None, Some(test_lease.clone())),
+        )],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&IFINDEX).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, IFINDEX, root, fast_path);
+
+    release_all_cos_queue_leases(&mut binding);
+
+    assert_eq!(
+        binding.cos.cos_interfaces.get(&IFINDEX).unwrap().queues[0]
+            .hot
+            .tokens,
+        0,
+        "teardown must drain the queue's local token bucket"
+    );
+
+    let conserved_capacity = drain_capacity(&test_lease, NOW_NS);
+    assert_eq!(
+        conserved_capacity, baseline_capacity,
+        "#5156 teardown: after release_all_cos_queue_leases the shared lease's \
+         drainable capacity must fully recover to the pristine baseline — the \
+         non-exact queue's outstanding grant was returned. The exact-only \
+         filter leaves it short by the grant."
+    );
+}

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -295,6 +295,39 @@ pub(in crate::afxdp) struct CoSQueueConfig {
     pub(in crate::afxdp) codel_target_ns: u64,
 }
 
+impl CoSQueueConfig {
+    /// A non-exact GUARANTEED queue whose configured rate trips
+    /// `COS_SHARED_EXACT_MIN_RATE_BYTES` runs the sharded `shared_exact`
+    /// execution policy: it drains locally on EVERY worker rather than
+    /// being funnelled to one owner. The coordinator therefore attaches a
+    /// shared legacy `SharedCoSQueueLease` so the class-wide guarantee
+    /// admission is metered to the configured rate instead of admitting at
+    /// `N_workers × rate` (#4265).
+    ///
+    /// This predicate is the SINGLE source of truth for "is this non-exact
+    /// queue lease-metered?". Two sites must agree on it, and they used to
+    /// diverge (the #5156 asymmetry): the coordinator uses it to decide
+    /// whether to build the lease
+    /// (`build_shared_cos_queue_leases_reusing_existing`), and the runtime
+    /// builder uses it to start such a queue's token bucket at 0 (metered
+    /// via the lease at runtime) instead of pre-filling `buffer_bytes`
+    /// un-metered. Keeping both sites on one predicate is what makes the
+    /// lease's init charge and teardown give-back symmetric: every byte the
+    /// queue's `hot.tokens` ever holds is acquired through — and returned
+    /// to — the shared lease.
+    ///
+    /// Returns false for exact queues (their lease is a v8 lease built on
+    /// a separate branch and their bucket already starts at 0) and for
+    /// single-owner low-rate non-exact queues (no lease; a private
+    /// per-worker bucket is correct and must keep pre-filling its burst).
+    pub(in crate::afxdp) fn is_shared_lease_metered(&self) -> bool {
+        !self.exact
+            && self.guarantee_enabled
+            && self.transmit_rate_bytes
+                >= crate::afxdp::worker::COS_SHARED_EXACT_MIN_RATE_BYTES
+    }
+}
+
 pub(in crate::afxdp) const COS_FAST_QUEUE_INDEX_MISS: u16 = u16::MAX;
 
 /// Number of SFQ flow buckets per flow-fair CoS queue.


### PR DESCRIPTION
## Summary

Fixes a two-sided lease-conservation asymmetry for **non-exact lease-metered** CoS queues — the sharded `shared_exact` non-exact guaranteed queue that draws from a shared legacy `SharedCoSQueueLease` (#4265). The lease's init charge and teardown give-back disagreed, so the shared queue lease was not conserved.

### Init half (`cos/builders.rs`)
`build_cos_interface_runtime` pre-filled each non-exact worker replica's token bucket with full `buffer_bytes`, **un-metered** by the shared lease. That put `buffer_bytes × N_workers` into circulation with no matching `outstanding` charge — defeating the #4265 metering at startup and leaving the teardown give-back nothing consistent to return.

### Teardown half (`cos/token_bucket.rs`)
`release_all_cos_queue_leases` filtered on `queue.config.exact && queue.hot.tokens > 0`, so a non-exact queue's leased tokens were **never** returned to the lease at worker exit / binding reset / lease-set swap. The (often reused) lease `Arc` stayed permanently over-charged and under-provisioned the class.

## Fix
Make the two symmetric. A non-exact lease-metered queue now:
- **starts at 0** local tokens (metered via the lease at runtime, exactly like an exact queue), and
- **returns its residual bank** at teardown.

Both sites gate on one new predicate — `CoSQueueConfig::is_shared_lease_metered()` (`types/cos.rs`) — which the coordinator's lease-build condition (`coordinator/cos_leases.rs`) was refactored to use too. That removes the **two independent encodings** of "is this non-exact queue lease-metered" whose drift caused the bug. The teardown filter drops the `exact` gate and relies on the existing lease-presence check in the release body, mirroring the runtime empty give-back in `refresh_cos_interface_activity` (#4265), which already keys on lease presence rather than `exact`. `release_unused_v8` reduces to the legacy `release_unused` for a legacy (v8=None) lease, so a truly un-leased single-owner queue keeps its private per-worker burst intact.

**Conservation invariant restored:** every byte a non-exact lease-metered queue's `hot.tokens` ever holds is acquired through — and returned to — the shared lease's `outstanding` word.

## Conservation model confirmed
Non-exact queues **are** meant to be lease-metered — but only the sharded ones (`guarantee_enabled && rate >= COS_SHARED_EXACT_MIN_RATE_BYTES`). The shared lease is NOT an exact-only concept: `#4265` already attached a legacy lease to these queues and metered their runtime refill + empty give-back (in `refresh_cos_interface_activity`) on lease presence, not `exact`. The init prefill and the teardown filter were the two spots that never got the #4265 treatment. Single-owner low-rate non-exact queues stay un-leased (private per-worker bucket) and correctly keep pre-filling their burst — the predicate returns false for them.

## Test
`nonexact_queue_lease_conserved_across_teardown_5156` (`token_bucket_tests.rs`) drives an init → top-up → teardown cycle and asserts the shared lease's drainable capacity fully recovers to a pristine baseline. Verified **fail-on-revert for both halves independently**:
- revert teardown filter → exact-only ⇒ conservation assertion FAILS
- revert init → exact-only-zero ⇒ 0-token init assertion FAILS

Full suite: `cargo test --bin xpf-userspace-dp` → **4079 passed, 0 failed**.

## Docs
`cos/README.md` gains a lease-conservation contract bullet; `_Log.md` dated entry.

Closes #5156

🤖 Generated with [Claude Code](https://claude.com/claude-code)