### PR TITLE
nat: round-robin address-only SNAT probes the whole pool

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-07-21 — #6226: round-robin address-only SNAT probes the whole pool
+
+- **Timestamp**: 2026-07-21 (fix/6226-address-only-roundrobin)
+- **Action**: The non-deterministic, non-persistent address-only source-NAT
+  branch (`port no-translation` / port-less protocols) SINGLE-PROBED one
+  round-robin-chosen pool address and falsely returned `AllocatorExhausted`
+  (→ drop) on a reverse-tuple collision while sibling pool IPs were FREE for
+  that remote. The port-translating path (`allocate_translation`) already loops
+  over the whole pool; the address-only path lacked that loop. Added
+  `reserve_address_only_roundrobin` (allocator.rs, co-located with
+  `reserve_address_only`): loops `for offset in 0..(if address_persistent {1}
+  else {family_len})` from the round-robin start (`start_abs`, already resolved
+  via `address_index` so the shared counter advances exactly once per flow —
+  same as the old single probe), mints the reverse-identity token on the FIRST
+  address whose identity is free, and returns exhaustion ONLY when every pool
+  address collides. Swapped in at the two non-persistent address-only call sites
+  in source.rs (v4 + v6). The minted token is byte-identical to
+  `reserve_address_only`'s (`address_only = true`, `persistent_key = None`,
+  `addr_index = 0`, `translated = (chosen address, preserved id)`), so the SAME
+  `release_flow`/`rollback_flow` teardown frees it — no new leak, no new delete
+  site. Kept single-probe for `address-persistent` (sticky-by-source is
+  intended). Deterministic-CGNAT (#5341) and address-only persistent-NAT (#6041)
+  branches untouched.
+- **File(s)**: `userspace-dp/src/nat/allocator.rs`,
+  `userspace-dp/src/nat/source.rs`, `userspace-dp/src/nat/tests_pool.rs`,
+  `docs/userspace-dataplane-architecture.md`
+- **Validation**: `cargo build` clean; new fail-on-revert test
+  `address_only_roundrobin_probes_free_sibling_5341adjacent_6226` (2-address
+  pool [A1,A2], port-less GRE; F2 to a different remote advances the shared
+  round-robin counter so F3 rolls back onto the F1-owned A1; F3 must map to the
+  free sibling A2) PASSES with the fix and FAILS (`expect_snat_decision` panics
+  on `AllocatorExhausted`) when reverted to single-probe. Full `nat::` suite
+  green (265 tests), including all #5341 / #6041 / #5269 / address-persistent
+  tests.
+
 ## 2026-07-21 — #5152: gate RefreshOwnerRGS liveness re-stamp on forwarding disposition
 
 - **Timestamp**: 2026-07-21 (fix/5152-refresh-owner-rgs-hainactive-guard)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -702,7 +702,23 @@ the NAT module applies it:
   only the in-code "is this unknown?" test moved out-of-band. `port
   no-translation` preserves the
   id just as it preserves a TCP/UDP source port. By default, pool address
-  selection is round-robin within the packet address family. With global source
+  selection is round-robin within the packet address family. For an
+  address-only flow (`port no-translation` / a port-less protocol) the
+  round-robin selection **probes the whole pool from its round-robin start**
+  (`reserve_address_only_roundrobin`), mirroring the port-translating
+  `allocate_translation` loop: if the chosen address's reverse identity
+  `(protocol, pool_addr, preserved id, remote)` is already owned by a different
+  flow for this remote, it rotates to the next pool address and mints the token
+  on the FIRST free sibling, failing as exhaustion **only** when every pool
+  address collides. Before #6226 the address-only branch single-probed one
+  round-robin address and falsely returned exhaustion (→ drop) the moment that
+  one address collided, even though a sibling address was free for the same
+  remote — the shared round-robin counter is oblivious to per-remote occupancy,
+  so any unrelated flow advancing it could land a later flow on an owned
+  address. An `address-persistent` pool keeps its single-probe contract (the
+  sticky address is intentional, not round-robin); the deterministic-CGNAT
+  (#5341) and address-only persistent-NAT (#6041) branches likewise single-probe
+  their chosen address. With global source
   NAT `address-persistent`, the userspace dataplane hashes a domain-tag seed,
   address family, and canonical source IP bytes with a seeded non-cryptographic
   FxHash (`rustc_hash`) to choose a stable pool index (userspace-v2; #2349

--- a/userspace-dp/src/nat/allocator.rs
+++ b/userspace-dp/src/nat/allocator.rs
@@ -1783,6 +1783,114 @@ impl PortAllocator {
         Ok(translated)
     }
 
+    /// #6226: reserve a non-deterministic, non-persistent ADDRESS-ONLY token
+    /// probing the WHOLE pool from the round-robin start, mirroring the
+    /// port-translating [`allocate_translation`] loop.
+    ///
+    /// The pre-#6226 caller picked ONE round-robin address via [`address_index`]
+    /// and called [`reserve_address_only`] on it — a single probe that returned
+    /// `AllocatorExhausted` (→ drop) the moment that one address's reverse
+    /// identity collided for this remote, even though a SIBLING pool address was
+    /// free for the same remote. The shared round-robin counter is oblivious to
+    /// per-remote occupancy, so an unrelated flow advancing it trivially lands a
+    /// later flow on an already-owned address. This loops from the caller's
+    /// round-robin start (`start_abs`, already resolved via [`address_index`] so
+    /// the counter is advanced EXACTLY ONCE per flow — same as the old single
+    /// probe) across every pool address and mints the token on the FIRST address
+    /// whose reverse identity is free; it fails as exhaustion ONLY when EVERY
+    /// pool address collides for this remote.
+    ///
+    /// `address_persistent` keeps the single-probe contract for sticky-by-source
+    /// pools (`address_attempts == 1`): the sticky address is intentional, not
+    /// round-robin, so it is not rotated away from on a collision. The
+    /// deterministic-CGNAT (#5341) and address-only persistent-NAT (#6041)
+    /// branches are untouched — they correctly single-probe their chosen address.
+    ///
+    /// The minted token is byte-identical to [`reserve_address_only`]'s
+    /// (`translated = (chosen address, preserved source port)`, `address_only =
+    /// true`, `persistent_key = None`, `addr_index = 0`), so the SAME
+    /// `release_flow`/`rollback_flow` teardown frees it — no new leak, no new
+    /// delete site. Idempotent re-entry (a racing second packet of the same
+    /// flow) returns the existing translation regardless of the round-robin
+    /// start.
+    pub(super) fn reserve_address_only_roundrobin(
+        &self,
+        flow: SourceNatFlowKey,
+        family_addresses: PoolAddressFamily<'_>,
+        family_offset: usize,
+        start_abs: usize,
+        address_persistent: bool,
+    ) -> Result<TranslatedTuple, super::source::SourceNatFailureReason> {
+        let family_len = family_addresses.len();
+        if family_len == 0 {
+            return Err(super::source::SourceNatFailureReason::WrongAddressFamily);
+        }
+        let start_rel = start_abs.saturating_sub(family_offset) % family_len;
+        // Sticky-by-source pools single-probe their chosen address; round-robin
+        // pools rotate through the whole pool (mirrors `allocate_translation`).
+        let address_attempts = if address_persistent { 1 } else { family_len };
+
+        let mut live = self.shared.live.lock().unwrap_or_else(|e| e.into_inner());
+        // Idempotent re-entry: a second packet of the same flow (racing session
+        // install) reuses its first decision rather than re-keying.
+        if let Some(existing) = live.live_by_flow.get(&flow) {
+            self.shared.reuses_total.fetch_add(1, Ordering::Relaxed);
+            return Ok(existing.translated);
+        }
+        // Global flow-table cap (the address-only token lives in `live_by_flow`);
+        // one successful probe inserts exactly one entry, so check it once here.
+        if live.live_by_flow.len() >= self.shared.max_tracked_flows {
+            self.shared.exhaustion_total.fetch_add(1, Ordering::Relaxed);
+            return Err(super::source::SourceNatFailureReason::AllocatorExhausted);
+        }
+        // Probe each pool address from the round-robin start; the FIRST whose
+        // reverse identity is free for this remote wins.
+        for offset in 0..address_attempts {
+            let rel = (start_rel + offset) % family_len;
+            let translated_ip = family_addresses.ip_at(rel);
+            let rkey = AddressOnlyReverseKey {
+                protocol: flow.protocol,
+                translated_ip,
+                translated_port: flow.src_port,
+                dst_ip: flow.dst_ip,
+                dst_port: flow.dst_port,
+            };
+            if live.address_only_owners.contains_key(&rkey) {
+                // This address's reverse identity is owned by a DIFFERENT flow
+                // for this remote — try the next sibling instead of dropping.
+                continue;
+            }
+            let translated = TranslatedTuple {
+                ip: translated_ip,
+                // Port-bearing protocols preserve their source port; a port-less
+                // protocol carries 0. NOT written to the wire (the caller leaves
+                // `rewrite_src_port` unset); it keys the reverse identity and lets
+                // the SAME `release_flow` free the token.
+                port: flow.src_port,
+            };
+            live.address_only_owners.insert(rkey, flow);
+            live.live_by_flow.insert(
+                flow,
+                LiveAllocation {
+                    translated,
+                    persistent_key: None,
+                    // No pool-port bit is claimed for an address-only token.
+                    addr_index: 0,
+                    deterministic: false,
+                    address_only: true,
+                },
+            );
+            self.shared
+                .allocations_total
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(translated);
+        }
+        // Every pool address's reverse identity is already owned by a different
+        // flow for this remote — genuine address-only exhaustion.
+        self.shared.exhaustion_total.fetch_add(1, Ordering::Relaxed);
+        Err(super::source::SourceNatFailureReason::AllocatorExhausted)
+    }
+
     /// #6041: reserve an ADDRESS-ONLY PERSISTENT-NAT lease for a `port
     /// no-translation` (or port-less) flow whose pool also configures
     /// `persistent-nat`. Unlike [`reserve_address_only`] (the per-flow #5269

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -1512,8 +1512,21 @@ pub(crate) fn match_source_nat_result_for_tuple(
                             now_ns,
                         )
                     } else {
-                        rule.pool_allocator
-                            .reserve_address_only(flow, IpAddr::V4(pool_addr))
+                        // #6226: probe the WHOLE pool from the round-robin start
+                        // (`addr_idx`) so a colliding reverse identity on the
+                        // chosen address rotates to a FREE sibling instead of
+                        // falsely exhausting. `addr_idx` already advanced the
+                        // round-robin counter above; the loop does not advance it
+                        // again. `pool_addr` (= pool_addresses_v4[addr_idx]) is
+                        // the loop's first probe — identical to the old single
+                        // probe when it is free.
+                        rule.pool_allocator.reserve_address_only_roundrobin(
+                            flow,
+                            PoolAddressFamily::V4(&rule.pool_addresses_v4),
+                            0,
+                            addr_idx,
+                            rule.address_persistent,
+                        )
                     };
                     match reserved {
                         Ok(translated) => {
@@ -1610,8 +1623,19 @@ pub(crate) fn match_source_nat_result_for_tuple(
                             now_ns,
                         )
                     } else {
-                        rule.pool_allocator
-                            .reserve_address_only(flow, IpAddr::V6(pool_addr))
+                        // #6226: probe the WHOLE pool from the round-robin start
+                        // (`addr_idx`, absolute over the combined v4+v6 index
+                        // space) so a colliding reverse identity on the chosen
+                        // address rotates to a FREE sibling instead of falsely
+                        // exhausting. `addr_idx` already advanced the round-robin
+                        // counter above; the loop does not advance it again.
+                        rule.pool_allocator.reserve_address_only_roundrobin(
+                            flow,
+                            PoolAddressFamily::V6(&rule.pool_addresses_v6),
+                            v6_offset,
+                            addr_idx,
+                            rule.address_persistent,
+                        )
                     };
                     match reserved {
                         Ok(translated) => {

--- a/userspace-dp/src/nat/tests_pool.rs
+++ b/userspace-dp/src/nat/tests_pool.rs
@@ -1021,6 +1021,82 @@ fn pool_snat_no_translation_two_address_pool_both_succeed_5269() {
     );
 }
 
+// #6226 FAIL-ON-REVERT: the round-robin (non-deterministic, non-persistent)
+// address-only branch must probe the WHOLE pool, not single-probe one
+// round-robin-chosen address. A 2-address pool [A1,A2], port-less GRE
+// (address-only), non-persistent. F1 (S1->R) takes A1 and owns the reverse
+// identity (GRE,A1,-,R). F2 (S2->R2, a DIFFERENT remote) advances the SHARED
+// round-robin counter so F3 rolls back onto A1. F3 (S3->R, the SAME remote as
+// F1) would COLLIDE on A1's reverse identity — but A2 is FREE for remote R, so
+// the round-robin loop must place F3 on the free sibling A2 rather than dropping
+// it. The shared counter is oblivious to per-remote occupancy, so an unrelated
+// flow (F2) advancing it trivially lands F3 on an already-owned address — the
+// #6226 false-exhaustion.
+//
+// Reverting to the single-probe `reserve_address_only(flow, pool_addr)` makes F3
+// return `Unavailable(AllocatorExhausted)` -> `expect_snat_decision` panics ->
+// RED. This is adjacent to but distinct from the deterministic-CGNAT (#5341) and
+// address-only persistent-NAT (#6041) branches, which correctly single-probe.
+#[test]
+fn address_only_roundrobin_probes_free_sibling_5341adjacent_6226() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-rr".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "my-pool".to_string(),
+        pool_addresses: vec!["203.0.113.1/32".to_string(), "203.0.113.2/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+
+    let a1: IpAddr = "203.0.113.1".parse().unwrap();
+    let a2: IpAddr = "203.0.113.2".parse().unwrap();
+
+    // F1: GRE S1 (10.0.1.100) -> R (8.8.8.8). Round-robin counter 0 -> A1; owns
+    // the reverse identity (GRE, A1, port-less, 8.8.8.8).
+    let d1 = expect_snat_decision(addr_only_lookup(
+        &rules, "10.0.1.100", 0, "8.8.8.8", 0, PROTO_GRE,
+    ));
+    assert_eq!(d1.rewrite_src, Some(a1), "F1 takes the first pool address A1");
+    assert_eq!(d1.rewrite_src_port, None, "port-less GRE preserves the wire port");
+
+    // F2: GRE S2 (10.0.1.101) -> R2 (9.9.9.9), a DIFFERENT remote. Its sole job is
+    // to advance the SHARED round-robin counter (1 -> 2) so F3 rolls back onto A1.
+    // Distinct remote -> distinct identity -> admitted on A2 without colliding.
+    let d2 = expect_snat_decision(addr_only_lookup(
+        &rules, "10.0.1.101", 0, "9.9.9.9", 0, PROTO_GRE,
+    ));
+    assert_eq!(d2.rewrite_src, Some(a2), "F2 advances the counter onto A2");
+
+    // F3: GRE S3 (10.0.1.102) -> R (8.8.8.8), the SAME remote + port-less identity
+    // as F1. The round-robin counter (now 2, 2 % 2 == 0) points back at A1, whose
+    // reverse identity F1 already owns. The pre-#6226 single probe returns
+    // AllocatorExhausted here even though A2 is FREE for remote R; the fix probes
+    // the whole pool and maps F3 to the free sibling A2.
+    let d3 = expect_snat_decision(addr_only_lookup(
+        &rules, "10.0.1.102", 0, "8.8.8.8", 0, PROTO_GRE,
+    ));
+    assert_eq!(
+        d3.rewrite_src,
+        Some(a2),
+        "F3 must map to the FREE sibling A2, not exhaust on the owned A1",
+    );
+    assert_ne!(
+        d3.rewrite_src, d1.rewrite_src,
+        "F3 must not collide onto F1's address A1",
+    );
+    assert_eq!(d3.rewrite_src_port, None, "port-less GRE preserves the wire port");
+
+    // Three distinct live reverse identities, no false exhaustion, no pool port
+    // consumed (address-only tokens are off the port bitmap).
+    let owners = rules[0].pool_allocator.debug_address_only_owners();
+    assert_eq!(owners.len(), 3, "F1, F2, F3 each own a distinct reverse identity");
+    assert_eq!(source_nat_pool_statuses(&rules)[0].used_ports, 0);
+    assert_eq!(source_nat_pool_statuses(&rules)[0].live_flows, 3);
+}
+
 // ---------------------------------------------------------------------------
 // #6041: address-only ("port no-translation") PERSISTENT-NAT leases.
 //


### PR DESCRIPTION
## Summary

The non-deterministic, non-persistent **address-only** source-NAT branch (`port no-translation` on a port-bearing protocol, or a port-less protocol such as GRE/ESP/HOPOPT) single-probed **one** round-robin-chosen pool address and returned `AllocatorExhausted` (→ **drop**) on a reverse-tuple collision **while sibling pool IPs were FREE for that remote**. The shared round-robin counter is oblivious to per-remote occupancy, so any unrelated flow through a rule sharing the allocator advances it and can land a later flow on an already-owned address — a trivially common false exhaustion that fails closed on legitimate traffic despite free capacity.

The port-translating path (`allocate_translation`) already loops over the whole pool; the address-only path lacked that loop.

## Fix

- **New allocator method** `reserve_address_only_roundrobin` (co-located with `reserve_address_only` in `allocator.rs`) mirrors the PAT loop: probes each pool address from the caller's round-robin start (`start_abs`, already resolved via `address_index` so the shared counter advances **exactly once** per flow — identical to the old single probe), mints the reverse-identity token on the **first** address whose identity is free for this remote, and returns `AllocatorExhausted` **only** when every pool address collides.
- **Two swap sites** in `source.rs` — the non-persistent address-only v4 (`:1516`) and v6 (`:1614`) call sites.
- The minted token is **byte-identical** to `reserve_address_only`'s (`address_only = true`, `persistent_key = None`, `addr_index = 0`, `translated = (chosen address, preserved id)`), so the same `release_flow`/`rollback_flow` teardown frees it — **no new leak, no new delete site**. A colliding probe `continue`s before any insert or counter bump, so a failed attempt mints nothing.

## Not touched (correctly single-probe)

- `address-persistent` pools keep the single-probe contract (`address_attempts == 1`) — sticky-by-source is intended.
- Deterministic-CGNAT (**#5341**) and address-only persistent-NAT (**#6041**) branches unchanged.

## Validation

- `cargo build` clean.
- **Fail-on-revert test** `address_only_roundrobin_probes_free_sibling_5341adjacent_6226`: 2-address pool `[A1,A2]`, port-less GRE; F2 to a different remote advances the shared round-robin counter so F3 rolls back onto the F1-owned A1; F3 must map to the free sibling A2, not exhaust. **PASSES** with the fix; **FAILS** (`expect_snat_decision` panics on `AllocatorExhausted`) when reverted to single-probe.
- Full `nat::` suite green (**265 tests**), including all #5341 / #6041 / #5269 / address-persistent tests.
- Updated `docs/userspace-dataplane-architecture.md` source-NAT pool-selection section.

Closes #6226

🤖 Generated with [Claude Code](https://claude.com/claude-code)