### PR TITLE
cos: lease-gate the teardown token give-back mem::take (#6272)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-21 — #6272: teardown mem::take must be lease-gated
+
+- **Timestamp**: 2026-07-21 (fix/6272-teardown-memtake-lease-gate)
+- **Action**: `release_all_cos_queue_leases` (the #5156/#6270 teardown
+  give-back) did an UNCONDITIONAL `core::mem::take(&mut queue.hot.tokens)`
+  for every queue with `hot.tokens > 0`, gating only the CREDIT on
+  `shared_queue_lease.is_some()`. The runtime give-back
+  `refresh_cos_interface_activity` (cos/tx_completion.rs, #4246 R-5(a))
+  instead gates the take ITSELF on `has_lease`, so an un-leased queue keeps
+  its banked burst. Consequence: on a lease-set swap (loop_body persists
+  `cos_interfaces` while rebuilding `cos_fast_interfaces`) a single-owner
+  NON-EXACT UN-LEASED queue's private per-worker burst was zeroed with
+  nothing credited — contradicting the #6270 README/comment. Fix: gate the
+  teardown `mem::take` on lease presence (probe the disjoint
+  `cos_fast_interfaces` field, early-`continue` when un-leased), mirroring
+  the runtime R-5(a) path exactly. Leased queues still drain + credit
+  (`release_unused_v8`) — the #5156 conservation invariant is unchanged.
+- **File(s)**: `userspace-dp/src/afxdp/cos/token_bucket.rs`,
+  `userspace-dp/src/afxdp/cos/token_bucket_tests.rs`,
+  `userspace-dp/src/afxdp/cos/README.md`, `_Log.md`
+- **Validation**: `cargo build` clean; new fail-on-revert test
+  `unleased_nonexact_burst_survives_lease_swap_6272` (un-leased burst
+  survives, leased queue drains + lease recovers to baseline) passes with
+  the fix and FAILS when reverted to the unconditional take (`left: 0,
+  right: 98304`); existing `nonexact_queue_lease_conserved_across_teardown_5156`
+  still passes in both states; full `afxdp::cos::` suite 304 passed.
+
 ## 2026-07-21 — #6226: round-robin address-only SNAT probes the whole pool
 
 - **Timestamp**: 2026-07-21 (fix/6226-address-only-roundrobin)

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -200,11 +200,17 @@ mod.rs for further file-level breakdown.
   `maybe_top_up_cos_queue_lease` → `acquire_via_lease`, gives an emptied
   bank back at runtime in `refresh_cos_interface_activity`, and gives its
   residual bank back at worker exit / binding reset / lease-set swap in
-  `release_all_cos_queue_leases`. Both give-back sites key on lease
-  presence (`shared_queue_lease.is_some()`), NOT on `queue.config.exact`,
-  so a truly un-leased single-owner queue (exact or non-exact) keeps its
-  private per-worker burst. `release_unused_v8` reduces to the legacy
-  `release_unused` for a legacy (v8=None) lease.
+  `release_all_cos_queue_leases`. Both give-back sites gate the
+  `core::mem::take(&mut queue.hot.tokens)` ITSELF on lease presence
+  (`shared_queue_lease.is_some()`), NOT on `queue.config.exact`, so a
+  truly un-leased single-owner queue (exact or non-exact) keeps its
+  private per-worker burst — there is nowhere to give it back. (#6272:
+  the teardown site's take was originally unconditional — only its credit
+  was lease-gated — so an un-leased non-exact queue's banked burst was
+  wrongly zeroed on a lease-set swap; the take is now lease-gated to
+  mirror the runtime `refresh_cos_interface_activity` R-5(a) path.)
+  `release_unused_v8` reduces to the legacy `release_unused` for a legacy
+  (v8=None) lease.
 - `COS_MIN_BURST_BYTES` (64 × MTU) is canonically owned by
   `token_bucket.rs`; siblings import it via the `cos/mod.rs`
   re-export.

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -434,18 +434,38 @@ pub(in crate::afxdp) fn release_all_cos_queue_leases(binding: &mut BindingWorker
                 // credit must be returned here on worker exit / binding
                 // reset / lease-set swap — otherwise the (often reused)
                 // lease Arc stays permanently over-charged and under-
-                // provisions the class. The actual give-back below is still
-                // gated on `shared_queue_lease.is_some()`, so a truly
-                // un-leased queue (single-owner exact OR single-owner
-                // non-exact) just has its now-defunct bucket zeroed with
-                // nothing to credit — mirroring the runtime empty give-back
-                // in `refresh_cos_interface_activity`, which already keys on
-                // lease presence rather than `exact`.
+                // provisions the class. The per-queue loop below gates BOTH
+                // the `mem::take` AND the credit on `shared_queue_lease
+                // .is_some()` (#6272), so a truly un-leased queue (single-
+                // owner exact OR single-owner non-exact) KEEPS its private
+                // per-worker burst — there is nowhere to give it back —
+                // exactly mirroring the runtime empty give-back in
+                // `refresh_cos_interface_activity` (R-5(a)), which already
+                // keys the take on lease presence rather than `exact`.
                 .filter(|(_, queue)| queue.hot.tokens > 0)
                 .map(move |(queue_idx, _)| (root_ifindex, queue_idx))
         })
         .collect::<Vec<_>>();
     for (root_ifindex, queue_idx) in queue_keys {
+        // #6272: gate the `mem::take` ITSELF on lease presence, mirroring the
+        // runtime give-back `refresh_cos_interface_activity` (R-5(a)). An
+        // un-leased queue (single-owner exact OR single-owner non-exact) has
+        // nowhere to return its banked burst, so leave `hot.tokens` intact —
+        // zeroing it would destroy the private per-worker burst on a mere
+        // lease-set swap (loop_body persists `cos_interfaces` while it rebuilds
+        // `cos_fast_interfaces`), contradicting the #6270 contract. The probe
+        // reads the disjoint `cos_fast_interfaces` field, so it coexists with
+        // the `cos_interfaces` mutable borrow below.
+        let has_lease = binding
+            .cos
+            .cos_fast_interfaces
+            .get(&root_ifindex)
+            .and_then(|iface_fast| iface_fast.queue_fast_path.get(queue_idx))
+            .and_then(|queue_fast| queue_fast.shared_queue_lease.as_ref())
+            .is_some();
+        if !has_lease {
+            continue;
+        }
         // Capture the worker id alongside the take — the v8 give-back needs
         // it to re-credit the right per-worker grant slot (#4246 T-1).
         let taken = binding

--- a/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
@@ -773,3 +773,149 @@ fn nonexact_queue_lease_conserved_across_teardown_5156() {
          filter leaves it short by the grant."
     );
 }
+
+// #6272: `release_all_cos_queue_leases` must gate the `mem::take` on lease
+// presence, mirroring the runtime give-back `refresh_cos_interface_activity`
+// (R-5(a)). A single-owner NON-EXACT queue with NO shared lease attached has
+// nowhere to return its banked burst, so its private per-worker `hot.tokens`
+// MUST survive a lease-set swap. Before #6272 the take was unconditional (only
+// the CREDIT was lease-gated), so an un-leased queue's burst was zeroed with
+// nothing credited — contradicting the #6270 README/comment.
+//
+// Two queues on one interface exercise the gate discrimination in a single
+// teardown call:
+//   queue[0] — single-owner non-exact, UN-leased: `hot.tokens` must be left
+//              intact (fail-on-revert: the unconditional take zeroes it).
+//   queue[1] — non-exact, LEASED: still drains + credits (the #6270/#5156
+//              conservation case must keep holding — the lease's drainable
+//              capacity recovers to the pristine baseline).
+#[test]
+fn unleased_nonexact_burst_survives_lease_swap_6272() {
+    use crate::afxdp::cos::builders::build_cos_interface_runtime;
+    use crate::afxdp::types::{CoSInterfaceConfig, CoSOversubscriptionPolicy, FastMap};
+    use crate::afxdp::worker::{BindingWorker, COS_SHARED_EXACT_MIN_RATE_BYTES};
+
+    const IFINDEX: i32 = 77;
+    const UNLEASED_QID: u8 = 3;
+    const LEASED_QID: u8 = 4;
+    const BUFFER_BYTES: u64 = 128 * 1024;
+    // Banked private burst held by the single-owner un-leased queue.
+    const UNLEASED_BURST: u64 = 96 * 1024;
+    // 3 Gbps > COS_SHARED_EXACT_MIN_RATE_BYTES (2.5 Gbps) — both queues are
+    // lease-metering-eligible; the difference is purely whether a shared lease
+    // is attached on the fast path.
+    const RATE_BYTES: u64 = 3_000_000_000 / 8;
+    const SHARDS: usize = 6;
+    const NOW_NS: u64 = 1_000_000_000;
+
+    assert!(
+        RATE_BYTES >= COS_SHARED_EXACT_MIN_RATE_BYTES,
+        "test queues must be lease-metering-eligible"
+    );
+
+    let make_queue = |queue_id: u8| CoSQueueConfig {
+        queue_id,
+        forwarding_class: format!("fc-{queue_id}"),
+        priority: 5,
+        transmit_rate_bytes: RATE_BYTES,
+        guarantee_enabled: true,
+        exact: false,
+        surplus_sharing: false,
+        equal_flow_enforcement: false,
+        equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+        surplus_weight: 1,
+        buffer_bytes: BUFFER_BYTES,
+        dscp_rewrite: None,
+        codel_target_ns: 0,
+    };
+    let cfg = CoSInterfaceConfig {
+        shaping_rate_bytes: 25_000_000_000 / 8,
+        burst_bytes: 256 * 1024,
+        default_queue: UNLEASED_QID,
+        dscp_classifier: String::new(),
+        ieee8021_classifier: String::new(),
+        dscp_queue_by_dscp: [u8::MAX; 64],
+        ieee8021_queue_by_pcp: [u8::MAX; 8],
+        queue_by_forwarding_class: FastMap::default(),
+        // Order MUST match the fast-path queue_entries order below: the
+        // teardown indexes `queue_fast_path` by the `root.queues` position.
+        queues: vec![make_queue(UNLEASED_QID), make_queue(LEASED_QID)],
+        oversubscription_policy: CoSOversubscriptionPolicy::Proportional,
+        oversubscription_guarantee_fraction: 0.0,
+        priority_low_min_share_bytes: 0,
+    };
+
+    fn drain_capacity(lease: &SharedCoSQueueLease, now_ns: u64) -> u64 {
+        let mut total = 0u64;
+        loop {
+            let granted = lease.acquire(now_ns, u64::MAX);
+            if granted == 0 {
+                break;
+            }
+            total = total.saturating_add(granted);
+        }
+        total
+    }
+
+    let mut root = build_cos_interface_runtime(&cfg, NOW_NS);
+
+    // queue[0] (un-leased): give it a private per-worker banked burst.
+    root.queues[0].hot.tokens = UNLEASED_BURST;
+    assert!(!root.queues[0].config.exact, "queue[0] must be non-exact");
+
+    // queue[1] (leased): charge the shared lease via the runtime top-up so its
+    // outstanding grant is meaningful. baseline is the pristine, never-charged
+    // capacity of an identical lease.
+    let baseline_lease = Arc::new(SharedCoSQueueLease::new(RATE_BYTES, BUFFER_BYTES, SHARDS));
+    let baseline_capacity = drain_capacity(&baseline_lease, NOW_NS);
+    assert!(baseline_capacity > 0, "baseline lease must hand out credit");
+
+    let test_lease = Arc::new(SharedCoSQueueLease::new(RATE_BYTES, BUFFER_BYTES, SHARDS));
+    root.queues[1].hot.tokens = 0;
+    let _ = maybe_top_up_cos_queue_lease(&mut root.queues[1], Some(&test_lease), NOW_NS);
+    let charged = root.queues[1].hot.tokens;
+    assert!(charged > 0, "leased queue top-up must acquire tokens");
+
+    // Fast path: queue[0] has NO lease (single-owner), queue[1] carries the
+    // shared lease. Entry order matches `cfg.queues` so the teardown's
+    // per-position `queue_fast_path` lookup lines up with `root.queues`.
+    let fast_interfaces = test_cos_fast_interfaces(
+        IFINDEX,
+        IFINDEX,
+        UNLEASED_QID,
+        vec![
+            (UNLEASED_QID, test_queue_fast_path(false, 0, None, None)),
+            (
+                LEASED_QID,
+                test_queue_fast_path(false, 0, None, Some(test_lease.clone())),
+            ),
+        ],
+        None,
+        None,
+    );
+    let fast_path = fast_interfaces.get(&IFINDEX).expect("test fast path").clone();
+    let mut binding = BindingWorker::new_for_cos_drain_test(0, 0, IFINDEX, root, fast_path);
+
+    release_all_cos_queue_leases(&mut binding);
+
+    let queues = &binding.cos.cos_interfaces.get(&IFINDEX).unwrap().queues;
+    assert_eq!(
+        queues[0].hot.tokens, UNLEASED_BURST,
+        "#6272: a single-owner un-leased non-exact queue's private banked burst \
+         must survive a lease-set swap — the teardown `mem::take` is gated on \
+         lease presence. The unconditional take zeroes it."
+    );
+    assert_eq!(
+        queues[1].hot.tokens, 0,
+        "#6270/#5156: a LEASED non-exact queue still drains its local bucket on \
+         teardown"
+    );
+
+    let conserved_capacity = drain_capacity(&test_lease, NOW_NS);
+    assert_eq!(
+        conserved_capacity, baseline_capacity,
+        "#6270/#5156: the LEASED queue's outstanding grant is credited back on \
+         teardown, so the shared lease recovers to the pristine baseline — the \
+         #6272 gate does not regress leased-queue conservation."
+    );
+}


### PR DESCRIPTION
## Summary

`release_all_cos_queue_leases` (the #5156/#6270 CoS teardown give-back) did an
UNCONDITIONAL `core::mem::take(&mut queue.hot.tokens)` for every queue with
`hot.tokens > 0`, gating only the CREDIT-back on `shared_queue_lease.is_some()`.
The runtime give-back `refresh_cos_interface_activity` (cos/tx_completion.rs,
#4246 R-5(a)) instead gates the `mem::take` **itself** on `has_lease`, so an
un-leased queue keeps its banked burst.

Because of the asymmetry, on a lease-set swap (loop_body persists
`cos_interfaces` while it rebuilds `cos_fast_interfaces`) a single-owner
**non-exact un-leased** queue's private per-worker burst was zeroed with nothing
credited — contradicting #6270's own README ("a truly un-leased single-owner
queue keeps its private per-worker burst") and the in-code comment.

## Fix

Gate the teardown `mem::take` on lease presence too, mirroring the runtime
R-5(a) `has_lease` gate: probe the disjoint `cos_fast_interfaces` field and
early-`continue` for an un-leased queue so its `hot.tokens` is left intact. A
**leased** queue is unchanged — it still drains its local bucket and credits the
outstanding grant back via `release_unused_v8`, so the #5156 conservation
invariant holds exactly. Exact-queue behavior is unchanged.

## Validation

- New colocated fail-on-revert test `unleased_nonexact_burst_survives_lease_swap_6272`:
  one interface with two non-exact queues (queue[0] un-leased + banked burst,
  queue[1] leased + charged via the runtime top-up). After
  `release_all_cos_queue_leases`: un-leased burst survives, leased queue drains
  to 0, shared lease recovers to its pristine baseline. **Passes with the fix;
  FAILS when reverted to the unconditional take (`left: 0, right: 98304`).**
- Existing `nonexact_queue_lease_conserved_across_teardown_5156` still passes in
  both states (leased-conservation unaffected).
- Full `afxdp::cos::` suite: 304 passed.
- `cargo build` clean.
- README contract note reconciled with the now-correct code; `_Log.md` dated bullet.

Closes #6272

🤖 Generated with [Claude Code](https://claude.com/claude-code)