### PR TITLE
cluster: decide cold-prime atomically with conn install (#4962)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-22 — #4962: atomic install + cold-prime decision in handleNewConnection
+
+- **Timestamp**: 2026-07-22 (fix/4962-handlenewconnection-race)
+- **Action**: Fixed the async `handleNewConnection` race where two
+  concurrent same-fabric accepts (per-accept goroutine, post-#4370) could
+  DROP the cold-prime bulk. The pre-fix code read `wasDisconnected` under
+  `s.mu` but used it AFTER unlock: accept A installs `connA` from an empty
+  registry and cold-primes it; accept B locks after A, observes `connA`
+  (non-empty registry → `wasDisconnected=false`), closes `connA` (aborting
+  A's in-flight bulk), installs `connB` as the survivor, and hit the
+  `becameActive` branch → NO cold-prime. The surviving `connB` never
+  re-pushed the authoritative session table, so the peer blackholed
+  established flows on the next failover. #4090's survivor re-drive does
+  NOT cover it: A's write failure calls `handleDisconnect(connA)`, a stale
+  disconnect (`conn0==connB`) that is ignored. Fix: extracted `installConn`
+  which wires `conn0`/`conn1` AND computes the `connColdPrimeDecision`
+  under the SAME `s.mu` acquisition, backed by a new `needColdPrime` latch
+  — armed on a full-disconnect→connect edge, consumed only when a bulk
+  SUCCEEDS. `shouldColdPrime = becameActive && needColdPrime`, so a
+  superseding accept INHERITS the outstanding obligation and re-drives the
+  bulk on the survivor. Both attempts serialize on `bulkSendMu` and target
+  `getActiveConn` → idempotent (same correctness-over-optimization tradeoff
+  as #5480). Steady state unchanged: routine single-fabric flips (latch
+  discharged) do not re-bulk.
+- **File(s)**: `pkg/cluster/sync.go` (needColdPrime field),
+  `pkg/cluster/sync_conn.go` (installConn + connColdPrimeDecision + gate),
+  `pkg/cluster/sync_conn_race_4962_test.go` (new, 3 tests incl. -race),
+  `docs/session-sync-architecture.md`, `pkg/cluster/README.md`.
+- **Validation**: `go build ./...` clean; `go vet ./pkg/cluster/` clean;
+  new tests pass under `-race`; full `pkg/cluster` suite green;
+  fail-on-revert confirmed (reverting the decision to
+  `becameActive && wasDisconnected` fails
+  `TestHandleNewConnectionRaceDoesNotAbortWinnerBulk4962`).
+
 ## 2026-07-21 — #6178: input-vlan-map / output-vlan-map honesty gate
 
 - **Timestamp**: 2026-07-21 (fix/6178-vlan-map-honesty-gate)

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -374,6 +374,53 @@ one redundant bulk on a full-reconnect flap. A more surgical fix that keeps the
 #466 flap-suppression would need a peer boot-incarnation field in the sync
 handshake — a wire change tracked on #5480 and deferred.
 
+### Atomic Install + Cold-Prime Decision (#4962)
+
+Post-#4370 `handleNewConnection` runs **per-accept in its own goroutine**, so two
+same-fabric accepts can race. The pre-#4962 code read `wasDisconnected` under
+`s.mu` but **used it after unlock** to gate `OnPeerConnected` + `doBulkSync`.
+From a fully-disconnected registry the two accepts interleave:
+
+- **Accept A** observes the empty registry (`wasDisconnected`), installs `connA`,
+  and starts cold-priming it.
+- **Accept B** locks *after* A, observes `connA` (a **non-empty** registry),
+  closes `connA` (aborting A's in-flight bulk), and installs `connB` as the
+  surviving active connection.
+
+Because B recomputed `wasDisconnected` from the post-supersession registry it saw
+`false`, so B skipped cold-prime and hit the `becameActive` "resume incremental"
+branch. The surviving connection `connB` therefore **never re-pushed the
+authoritative session table** — the peer stayed un-primed and blackholed every
+established flow on the next failover to it. (This is distinct from the #4090
+survivor re-drive: when B closes `connA`, A's write failure calls
+`handleDisconnect(connA)`, which is a **stale** disconnect — `conn0` is already
+`connB` — so it is ignored and #4090 never fires.)
+
+The fix makes the install and the cold-prime decision **atomic** under `s.mu`
+(`installConn`, returning a `connColdPrimeDecision`), backed by a `needColdPrime`
+latch:
+
+- `needColdPrime` is armed under `s.mu` on a full-disconnect→connect edge (both
+  fabric slots were empty) and **consumed only when a cold-prime bulk actually
+  succeeds** (`doBulkSync() == nil`). On failure it stays armed.
+- `shouldColdPrime = becameActive && needColdPrime`, both read under the same
+  lock that installs the connection. A superseding same-fabric accept therefore
+  **inherits** the outstanding obligation instead of dropping it, even though it
+  observes a non-empty registry.
+
+So in the race B now cold-primes `connB`. Both A and B may call `doBulkSync`;
+they serialize on `bulkSendMu` and each targets `getActiveConn` (the survivor),
+so the redundant attempt is idempotent — the same correctness-over-optimization
+tradeoff as #5480. The latch also generalizes the #4090 intent into the accept
+path: if a cold-prime never succeeded, the next connection that becomes the
+active fabric re-drives it. Steady state is unchanged: once a cold-prime
+succeeds the latch clears, and routine single-fabric flips (obligation
+discharged) do not re-bulk.
+
+`needColdPrime` is a plain `atomic.Bool` like `forceResync`; the narrow window
+where a newer full-disconnect epoch's arm is cleared by an older epoch's success
+self-heals via `forceResync` / the #4090 survivor re-drive / the next reconnect.
+
 ## Incremental Sweep and Delete Journal
 
 ### Background Sweep

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -380,6 +380,19 @@ connection is authenticated, then seals every subsequent frame.
   sub-millisecond, so the bound only covers a hung/absent peer, and a
   shorter bound keeps a stalled handshake goroutine within the 5s `Stop`
   budget.
+- **Atomic install + cold-prime decision (#4962).** Because #4370 made
+  `handleNewConnection` per-accept, two same-fabric accepts can race: the
+  loser observes the winner's just-installed connection, closes it
+  (aborting its in-flight cold-prime bulk), and — under the pre-#4962
+  after-unlock `wasDisconnected` read — skipped cold-prime, leaving the
+  **surviving** connection un-primed (peer blackholes on the next
+  failover). `installConn` now wires the connection into `conn0`/`conn1`
+  and computes the cold-prime decision under the **same** `s.mu`
+  acquisition, gated on a `needColdPrime` latch (armed on a
+  full-disconnect→connect edge, consumed only when a bulk succeeds) so the
+  surviving accept **inherits** the outstanding obligation and re-drives
+  the bulk. See `docs/session-sync-architecture.md` → "Atomic Install +
+  Cold-Prime Decision (#4962)".
 
 ## IPsec SA sync
 

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -463,7 +463,7 @@ type SessionSync struct {
 	// debounced goroutine to re-run doBulkSync over the survivor; this CAS
 	// flag bounds it to a single in-flight re-drive so a survivor that ALSO
 	// flaps cannot cause a re-drive storm.
-	bulkRedriveInFlight        atomic.Bool
+	bulkRedriveInFlight atomic.Bool
 	// needColdPrime latches the outstanding cold-prime obligation across the
 	// per-accept goroutines (#4962). It is armed under s.mu on a full
 	// disconnect -> connect transition (both fabric slots were empty) and

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -464,6 +464,24 @@ type SessionSync struct {
 	// flag bounds it to a single in-flight re-drive so a survivor that ALSO
 	// flaps cannot cause a re-drive storm.
 	bulkRedriveInFlight        atomic.Bool
+	// needColdPrime latches the outstanding cold-prime obligation across the
+	// per-accept goroutines (#4962). It is armed under s.mu on a full
+	// disconnect -> connect transition (both fabric slots were empty) and
+	// consumed (cleared) only when a cold-prime bulk actually SUCCEEDS. Because
+	// handleNewConnection now runs per-accept (post-#4370), two same-fabric
+	// accepts can race: the first observes the empty registry and installs, the
+	// second observes the first's connection and supersedes it — closing it and
+	// aborting the first's in-flight cold-prime bulk. The pre-#4962 gate
+	// recomputed wasDisconnected from the post-supersession registry, so the
+	// surviving (second) connection saw a non-empty registry and SKIPPED
+	// cold-prime: the peer never received the authoritative session table and
+	// blackholed established flows on the next failover. The latch lets the
+	// surviving connection INHERIT the obligation and re-drive the bulk. Like
+	// forceResync it is a plain atomic.Bool; the narrow window where a newer
+	// full-disconnect epoch's arm is cleared by an older epoch's success
+	// self-heals via forceResync / the #4090 survivor re-drive / the next
+	// reconnect.
+	needColdPrime              atomic.Bool
 	bulkMu                     sync.Mutex
 	bulkInProgress             bool
 	bulkRecvEpoch              uint64

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -574,39 +574,13 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 		s.handleMessage(conn, pending.typ, pending.payload)
 	}
 
-	s.mu.Lock()
-	wasDisconnected := s.conn0 == nil && s.conn1 == nil
-	activeBefore := -1
-	if s.conn0 != nil {
-		activeBefore = 0
-	} else if s.conn1 != nil {
-		activeBefore = 1
-	}
-	hadConn0 := s.conn0 != nil
-	hadConn1 := s.conn1 != nil
-	switch fabricIdx {
-	case 0:
-		if s.conn0 != nil {
-			s.conn0.Close()
-		}
-		s.conn0 = conn
-	case 1:
-		if s.conn1 != nil {
-			s.conn1.Close()
-		}
-		s.conn1 = conn
-	}
-	activeAfter := -1
-	if s.conn0 != nil {
-		activeAfter = 0
-	} else if s.conn1 != nil {
-		activeAfter = 1
-	}
-	s.stats.Connected.Store(true)
-	s.lastPeerRxMono.Store(MonotonicNanos())
-	s.mu.Unlock()
-	becameActive := activeAfter == fabricIdx
-	slog.Info("cluster sync: handling new connection", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "was_disconnected", wasDisconnected, "active_before", activeBefore, "active_after", activeAfter, "became_active", becameActive, "had_conn0", hadConn0, "had_conn1", hadConn1)
+	// #4962: install the connection and DECIDE cold-prime atomically under
+	// s.mu. Computing the decision after unlock (the pre-#4962 shape) let a
+	// racing same-fabric accept supersede this connection between the unlock and
+	// the decision's use, so the surviving connection could DROP cold-prime (see
+	// installConn / the needColdPrime doc in sync.go).
+	d := s.installConn(fabricIdx, conn)
+	slog.Info("cluster sync: handling new connection", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "was_disconnected", d.wasDisconnected, "active_before", d.activeBefore, "active_after", d.activeAfter, "became_active", d.becameActive, "should_cold_prime", d.shouldColdPrime, "had_conn0", d.hadConn0, "had_conn1", d.hadConn1)
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
@@ -614,8 +588,8 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 	}()
 	s.sendClockSync(conn)
 	coldStart := !s.bulkEverCompleted.Load()
-	if wasDisconnected {
-		slog.Info("cluster sync: first connection after disconnect", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "cold_start", coldStart)
+	if d.shouldColdPrime {
+		slog.Info("cluster sync: driving authoritative cold-prime bulk on active connection", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "cold_start", coldStart, "was_disconnected", d.wasDisconnected)
 		s.flushDeleteJournal()
 		if s.OnPeerConnected != nil {
 			slog.Info("cluster sync: scheduling OnPeerConnected callback", "fabric", fabricIdx)
@@ -674,12 +648,95 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 			if forcedConsumed {
 				s.forceResync.Store(true)
 			}
+		} else {
+			// #4962: the authoritative cold-prime landed on the (surviving)
+			// active connection, discharging the outstanding obligation. Consume
+			// the needColdPrime latch so routine single-fabric flips do NOT
+			// re-bulk; a later full-disconnect epoch re-arms it via installConn.
+			// On FAILURE the latch stays armed, so the next accept that becomes
+			// active re-drives the bulk instead of dropping it.
+			s.needColdPrime.Store(false)
 		}
-	} else if becameActive {
-		slog.Info("cluster sync: active fabric changed, resuming incremental sync", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "active_before", activeBefore, "active_after", activeAfter)
+	} else if d.becameActive {
+		slog.Info("cluster sync: active fabric changed, resuming incremental sync", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "active_before", d.activeBefore, "active_after", d.activeAfter)
 	} else {
 		slog.Info("cluster sync: connection added without bulk sync", "fabric", fabricIdx, "remote", connRemoteAddrString(conn))
 	}
+}
+
+// connColdPrimeDecision is the atomically-computed outcome of installing a sync
+// connection into a fabric slot (#4962): which fabric was active before/after,
+// whether this connection became the active fabric, and whether it must drive
+// the authoritative cold-prime bulk. All fields are derived under s.mu together
+// with the conn0/conn1 install so the decision is consistent with the registry
+// state it was computed from — a racing supersession cannot invalidate it.
+type connColdPrimeDecision struct {
+	wasDisconnected bool
+	becameActive    bool
+	shouldColdPrime bool
+	activeBefore    int
+	activeAfter     int
+	hadConn0        bool
+	hadConn1        bool
+}
+
+// installConn wires conn into the fabric slot (superseding and closing any
+// existing same-fabric connection) and returns the cold-prime decision computed
+// ATOMICALLY with that install under s.mu (#4962).
+//
+// The needColdPrime latch is armed here on a full disconnect -> connect edge
+// (both slots were empty) and consumed by handleNewConnection only when a
+// cold-prime bulk SUCCEEDS. shouldColdPrime is therefore true whenever THIS
+// connection is the active fabric AND a cold-prime is still owed for the current
+// connected epoch — so a second same-fabric accept that supersedes an in-flight
+// cold-prime INHERITS the obligation rather than dropping it. Computing the
+// decision under the same lock that installs the connection is the fix's core:
+// the pre-#4962 code read wasDisconnected under the lock but USED it after
+// unlock, where a concurrent accept could already have changed the registry.
+func (s *SessionSync) installConn(fabricIdx int, conn net.Conn) connColdPrimeDecision {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d := connColdPrimeDecision{activeBefore: -1, activeAfter: -1}
+	d.wasDisconnected = s.conn0 == nil && s.conn1 == nil
+	if s.conn0 != nil {
+		d.activeBefore = 0
+	} else if s.conn1 != nil {
+		d.activeBefore = 1
+	}
+	d.hadConn0 = s.conn0 != nil
+	d.hadConn1 = s.conn1 != nil
+	switch fabricIdx {
+	case 0:
+		if s.conn0 != nil {
+			s.conn0.Close()
+		}
+		s.conn0 = conn
+	case 1:
+		if s.conn1 != nil {
+			s.conn1.Close()
+		}
+		s.conn1 = conn
+	}
+	if s.conn0 != nil {
+		d.activeAfter = 0
+	} else if s.conn1 != nil {
+		d.activeAfter = 1
+	}
+	s.stats.Connected.Store(true)
+	s.lastPeerRxMono.Store(MonotonicNanos())
+	// #4962: arm the cold-prime obligation on a full-disconnect -> connect edge.
+	// The latch outlives this goroutine so a superseding same-fabric accept
+	// still sees the obligation even though it observes a non-empty registry.
+	if d.wasDisconnected {
+		s.needColdPrime.Store(true)
+	}
+	d.becameActive = d.activeAfter == fabricIdx
+	// #4962: commit the decision under the lock. becameActive means this
+	// connection is now the active fabric; needColdPrime means the cold-prime
+	// for this connected epoch has not yet succeeded. Both are read here, atomic
+	// with the install above.
+	d.shouldColdPrime = d.becameActive && s.needColdPrime.Load()
+	return d
 }
 
 func (s *SessionSync) Start(ctx context.Context) error {

--- a/pkg/cluster/sync_conn_race_4962_test.go
+++ b/pkg/cluster/sync_conn_race_4962_test.go
@@ -1,0 +1,172 @@
+package cluster
+
+import (
+	"net"
+	"sync"
+	"testing"
+)
+
+// TestHandleNewConnectionRaceDoesNotAbortWinnerBulk4962 is the #4962
+// fail-on-revert test for the async handleNewConnection cold-prime race.
+//
+// Post-#4370 handleNewConnection runs per-accept in its own goroutine, so two
+// same-fabric accepts can race. From a fully-disconnected registry:
+//
+//   - Accept A observes the empty registry (wasDisconnected), installs connA,
+//     and starts cold-priming connA.
+//   - Accept B locks AFTER A, observes connA (a NON-empty registry), CLOSES
+//     connA (aborting A's in-flight cold-prime bulk), and installs connB as the
+//     surviving active connection.
+//
+// The pre-#4962 code computed the cold-prime decision from wasDisconnected read
+// under the lock but USED after unlock. B saw a non-empty registry so its
+// wasDisconnected was false and it SKIPPED cold-prime entirely — the surviving
+// connection connB never re-pushed the authoritative session table, and the
+// peer blackholed every established flow on the next failover to it.
+//
+// The fix arms a needColdPrime latch on the full-disconnect edge and consumes
+// it only when a cold-prime bulk SUCCEEDS, so the surviving accept B INHERITS
+// the obligation. installConn commits that decision atomically under s.mu.
+//
+// RED-on-revert: change installConn's decision back to the after-unlock shape
+// (`shouldColdPrime = becameActive && wasDisconnected`, i.e. drop the
+// needColdPrime latch) and B — which supersedes A and therefore sees
+// wasDisconnected=false — no longer cold-primes, so the survivor assertion
+// below fires.
+func TestHandleNewConnectionRaceDoesNotAbortWinnerBulk4962(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", nil)
+
+	connA := newPreAuthTestConn("10.0.0.2:5001")
+	connB := newPreAuthTestConn("10.0.0.2:5002")
+
+	// Accept A: first connection after a full disconnect. It becomes the active
+	// fabric and MUST cold-prime.
+	decA := s.installConn(0, connA)
+	if !decA.wasDisconnected {
+		t.Fatalf("accept A must observe a fully-disconnected registry, got %+v", decA)
+	}
+	if !decA.shouldColdPrime {
+		t.Fatalf("accept A (first after full disconnect) must cold-prime, got %+v", decA)
+	}
+	if got := s.getActiveConn(); got != net.Conn(connA) {
+		t.Fatalf("accept A must be installed as the active connection, got %p", got)
+	}
+	if !s.needColdPrime.Load() {
+		t.Fatal("the cold-prime obligation must be armed after the first connection")
+	}
+
+	// Accept B: supersedes A on the SAME fabric while A's cold-prime is still in
+	// flight. It closes connA (aborting A's bulk) and becomes the survivor.
+	decB := s.installConn(0, connB)
+	if got := s.getActiveConn(); got != net.Conn(connB) {
+		t.Fatalf("accept B must supersede A as the active connection, got %p", got)
+	}
+	if !connA.closed.Load() {
+		t.Fatal("accept B must close the superseded connection A")
+	}
+	if decB.wasDisconnected {
+		t.Fatal("accept B observes A's connection, so it must NOT see a disconnected registry")
+	}
+	// The crux: the surviving connection MUST inherit the cold-prime obligation
+	// aborted from A. Dropping it is the #4962 blackhole.
+	if !decB.shouldColdPrime {
+		t.Fatal("#4962: the surviving accept B MUST inherit the cold-prime obligation " +
+			"aborted from A; skipping it leaves the peer un-primed and blackholes " +
+			"established flows on the next failover")
+	}
+	if !s.needColdPrime.Load() {
+		t.Fatal("#4962: the obligation must remain armed until a cold-prime bulk succeeds")
+	}
+}
+
+// TestHandleNewConnectionColdPrimeLatchLifecycle4962 pins the latch lifecycle:
+// armed on the full-disconnect edge, RETAINED across a same-fabric supersession
+// (so the survivor re-drives), consumed only on a successful bulk, and NOT
+// re-driven on a routine single-fabric flip once discharged.
+//
+// RED-on-revert: if installConn armed nothing (no latch) or the survivor's
+// decision keyed on wasDisconnected, the "survivor must cold-prime" assertion
+// fails; if the discharge were unconditional (cleared regardless of bulk
+// outcome), the "steady-state flip does not re-bulk" invariant would be the one
+// pinned by the final assertions.
+func TestHandleNewConnectionColdPrimeLatchLifecycle4962(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", nil)
+
+	// Fresh full-disconnect -> connect on fabric 0 arms the obligation.
+	c0 := newPreAuthTestConn("10.0.0.2:6001")
+	if d := s.installConn(0, c0); !d.shouldColdPrime {
+		t.Fatalf("first connection must cold-prime, got %+v", d)
+	}
+	if !s.needColdPrime.Load() {
+		t.Fatal("obligation must be armed on the full-disconnect edge")
+	}
+
+	// Simulate a SUCCESSFUL cold-prime bulk: handleNewConnection consumes the
+	// latch on doBulkSync() == nil.
+	s.needColdPrime.Store(false)
+
+	// A routine single-fabric flip: fabric 1 comes up while fabric 0 is still
+	// active. It becomes active-eligible but the obligation is discharged, so it
+	// must NOT re-bulk (matches the pre-#4962 becameActive/else behavior).
+	c1 := newPreAuthTestConn("10.0.0.2:6002")
+	d1 := s.installConn(1, c1)
+	if d1.wasDisconnected {
+		t.Fatalf("fabric 1 install with fabric 0 up must not see a disconnected registry, got %+v", d1)
+	}
+	if d1.shouldColdPrime {
+		t.Fatal("a routine fabric flip with the obligation discharged must NOT re-bulk")
+	}
+}
+
+// TestHandleNewConnectionConcurrentAcceptsRetainObligation4962 drives many
+// concurrent same-fabric installs from a disconnected registry under -race. No
+// cold-prime bulk runs (installConn never clears the latch), so the obligation
+// must survive every supersession — a losing accept can never silently drop it.
+// The surviving connection is one of the racers and is the active connection.
+func TestHandleNewConnectionConcurrentAcceptsRetainObligation4962(t *testing.T) {
+	s := NewSessionSync(":0", "10.0.0.2:4785", nil)
+
+	const n = 16
+	conns := make([]*preAuthTestConn, n)
+	for i := range conns {
+		conns[i] = newPreAuthTestConn("10.0.0.2:7000")
+	}
+
+	var wg sync.WaitGroup
+	shouldColdPrimeCount := make([]bool, n)
+	for i := range conns {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			d := s.installConn(0, conns[i])
+			shouldColdPrimeCount[i] = d.shouldColdPrime
+		}(i)
+	}
+	wg.Wait()
+
+	// Every install from the (initially) disconnected registry becomes the
+	// active fabric-0 connection at the instant it holds the lock, so each sees
+	// the armed obligation: shouldColdPrime is true for all of them. Critically,
+	// none observed shouldColdPrime=false while the obligation was outstanding.
+	for i, v := range shouldColdPrimeCount {
+		if !v {
+			t.Fatalf("#4962: concurrent accept %d dropped the cold-prime obligation "+
+				"while it was outstanding (a losing accept must inherit, not skip)", i)
+		}
+	}
+	if !s.needColdPrime.Load() {
+		t.Fatal("#4962: the obligation must remain armed until a bulk succeeds")
+	}
+	// Exactly one connection survives as the active connection.
+	active := s.getActiveConn()
+	found := false
+	for _, c := range conns {
+		if active == net.Conn(c) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("the surviving active connection must be one of the racing accepts")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the async `handleNewConnection` cold-prime race (#4962, codex-176 R8-B1-03). Post-#4370 `handleNewConnection` runs per-accept in its own goroutine, so two same-fabric accepts can race. It read `wasDisconnected` under `s.mu` but **used it after unlock** to gate `OnPeerConnected` + `doBulkSync`.

From a fully-disconnected registry:

- **Accept A** observes the empty registry (`wasDisconnected`), installs `connA`, and starts cold-priming it.
- **Accept B** locks *after* A, observes `connA` (a **non-empty** registry), closes `connA` (aborting A's in-flight cold-prime bulk), and installs `connB` as the surviving active connection.

Because B recomputed `wasDisconnected` from the post-supersession registry it saw `false`, skipped cold-prime, and hit the `becameActive` "resume incremental" branch. The surviving connection `connB` **never re-pushed the authoritative session table**, so the peer blackholed every established flow on the next failover to it. The #4090 survivor re-drive does **not** cover this: A's write failure calls `handleDisconnect(connA)`, a stale disconnect (`conn0` is already `connB`) that is ignored.

## Fix

Make the install and the cold-prime decision **atomic** under `s.mu`:

- Extract `installConn`, which wires `conn0`/`conn1` and returns a `connColdPrimeDecision` computed under the **same lock acquisition**.
- Add a `needColdPrime` latch: armed on a full-disconnect→connect edge, consumed **only when a cold-prime bulk succeeds**.
- `shouldColdPrime = becameActive && needColdPrime`, so a superseding same-fabric accept **inherits** the outstanding obligation and re-drives the bulk on the survivor instead of dropping it.

Both attempts serialize on `bulkSendMu` and target `getActiveConn`, so the redundant attempt is idempotent — the same correctness-over-optimization tradeoff as #5480. Steady state is unchanged: once a cold-prime succeeds the latch clears, and routine single-fabric flips do not re-bulk.

## Validation

- `go build ./...` clean; `go vet ./pkg/cluster/` clean
- New `sync_conn_race_4962_test.go` (3 tests) pass under `-race`; full `pkg/cluster` suite green
- **Fail-on-revert confirmed**: reverting the decision to `becameActive && wasDisconnected` fails `TestHandleNewConnectionRaceDoesNotAbortWinnerBulk4962`

This touches HA session-sync — `make test-failover` should run before merge.

## Docs

- `docs/session-sync-architecture.md` gains an "Atomic Install + Cold-Prime Decision (#4962)" subsection
- `pkg/cluster/README.md` notes it on the #4370 accept-loop bullet

Closes #4962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YY8Y8HDjHpFceXXR5DM93
