### PR TITLE
cluster: add config epoch to HA session-sync envelope (#5274)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,53 @@
+## 2026-07-22 — #5274: HA session-sync config-epoch guard (stale permit across the HA boundary)
+
+- **Timestamp**: 2026-07-22 (fix/5274-ha-session-config-epoch)
+- **Action**: Added a config epoch to the HA session-sync envelope so the
+  standby refuses a session admitted under a config the receiver has since
+  superseded (immediate policy invalidation across the HA boundary). The
+  primary admits a session under config A, commits config B (which DENIES it),
+  and config B is applied on the standby — but a delayed config-A session
+  install landing after the standby's `clearSessionsForDeletedPolicies` sweep
+  installed a STALE PERMIT the standby forwarded under after failover.
+  - **Wire**: new length-gated trailing `ConfigEpoch uint64` on the peer↔peer
+    session payload (`encode/decodeSessionV4Payload`/`V6`), appended after the
+    #3301 (V4) / #4565 (V6) trailing fields. Old decoders read 0 (legacy /
+    check disabled) — additive, no version bump.
+  - **Field**: `SessionValue.ConfigEpoch` / `SessionValueV6.ConfigEpoch`
+    (userspace-sync-only HA metadata, NOT in the BPF/C conntrack ABI).
+  - **Stamp (sender)**: `stampInstallGenV4/V6` sets `ConfigEpoch =
+    configGenCounter.Load()` — the #3931 config-sync generation held at queue
+    time. All send paths (incremental, sweep, bulk) route through these.
+  - **Guard (receiver)**: `installClusterSyncedV4/V6` → new `configEpochStale`
+    refuses an install whose epoch is strictly older than `lastAppliedConfigGen`
+    and bumps a new `SessionsStaleConfigIgnored` counter, BEFORE forwarding to
+    the helper. Both stamp and compare live in the same #3931 sender→receiver
+    namespace, so the cross-node comparison is meaningful.
+  - **Design decision (Go-cluster-authoritative, Rust untouched)**: the config
+    epoch's only cross-node-comparable namespace is the #3931 config-sync
+    generation, which lives entirely in `pkg/cluster`. The userspace helper's
+    `config_generation` is a *local* commit counter (`Manager.bumpGeneration`),
+    independent per node and NOT comparable — so the helper cannot host this
+    guard. The receiver rejects the stale install before it reaches the helper;
+    no `config_epoch` field/guard is added to `SessionSyncRequest` or `ha.rs`
+    (that would be a dead field, or a per-key guard provably redundant with the
+    #2170 generation guard). This deviates from the issue's cited `protocol.go`/
+    `ha.rs` locations, which conflated the Go→Rust helper envelope with the
+    cross-node peer wire.
+  - **Tests** (`pkg/cluster/sync_config_epoch_5274_test.go`):
+    `TestStaleConfigEpochSessionRejected5274{,V6}` (guard reject/accept +
+    counter, fail-on-revert verified RED), `TestSessionWireRoundTripConfigEpoch5274{V4,V6}`
+    (wire round-trip + legacy truncation), `TestConfigEpochStampedAtQueueTime5274`,
+    `TestConfigEpochNoRejectAgainstZeroBaseline5274`. Updated the #3301/#4565/
+    cross-version legacy-truncation offsets in `sync_gen_guard_test.go` (+8 for
+    the new trailing field).
+  - **Docs**: `docs/session-sync-architecture.md` (Config-Epoch Guard section +
+    Session Value note), `pkg/cluster/README.md` (guard bullet),
+    `docs/sync-protocol.md` (Config-Epoch Guard section + stats-table counter).
+- **File(s)**: pkg/dataplane/types.go, pkg/cluster/sync_protocol.go,
+  pkg/cluster/sync_conn.go, pkg/cluster/sync.go,
+  pkg/cluster/sync_config_epoch_5274_test.go, pkg/cluster/sync_gen_guard_test.go,
+  docs/session-sync-architecture.md, pkg/cluster/README.md, docs/sync-protocol.md
+
 ## 2026-07-22 — #5615: direct GRE-decap fail-on-revert tests for the #5140 inner-read sites
 
 - **Timestamp**: 2026-07-22 (test/5615-gre-decap-inner-read-coverage)

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -48,7 +48,11 @@ entry locally.
 
 The session value includes state, policy, timestamps, counters, NAT fields,
 reverse key, and a cached forwarding result (`FibIfindex`, MACs, VLAN,
-generation).
+generation). It also carries a `ConfigEpoch` (#5274) — the config-sync
+generation (#3931) the sender held when it queued the session — used by the
+receive-side config-epoch guard (see "Config-Epoch Guard" below). Both
+`Generation` and `ConfigEpoch` are userspace-sync-only metadata; neither is part
+of the on-map BPF conntrack ABI (`bpfSessionValue`).
 
 ### Userspace Mirror
 
@@ -248,6 +252,53 @@ says are peer-owned.
 
 Important detail: zones missing from the frozen snapshot are conservatively kept
 instead of deleted.
+
+### Config-Epoch Guard (#5274)
+
+The receiver applies a synced session install (bulk or incremental) through
+`installClusterSyncedV4`/`V6`. Before it forwards the install to the dataplane
+it runs two independent admission checks:
+
+1. **Install-generation guard (#2170)** — per-key: refuse a strictly-older
+   `Generation` for the same 5-tuple so the per-key stored generation never
+   regresses (`InstallsStaleIgnored`).
+2. **Config-epoch guard (#5274)** — global: refuse a session whose
+   `ConfigEpoch` is strictly older than the receiver's `lastAppliedConfigGen`
+   (`SessionsStaleConfigIgnored`).
+
+The config-epoch guard closes the immediate-policy-invalidation gap across the
+HA boundary. Without it, the primary could admit a session under config A, then
+commit config B (which DENIES that session); config B is config-synced and
+applied on the standby (running `clearSessionsForDeletedPolicies`), but a
+delayed config-A session install that arrives **after** that sweep is installed
+anyway — a stale permit. The standby would then forward under the revoked
+config-A decision after failover.
+
+The epoch is stamped by the SENDER at queue time (`stampInstallGen*` sets
+`ConfigEpoch = configGenCounter.Load()`), and compared by the RECEIVER against
+`lastAppliedConfigGen`. Both live in the **same** #3931 config-sync-generation
+namespace (the sender's monotonic counter, which the receiver applies and
+records), so the comparison is meaningful across nodes. A session still present
+in the sender's table when it is queued has survived the sender's own
+config-apply sweep, so it is legitimately admitted under the current config; the
+receiver refuses it only once IT has applied a **strictly newer** config that
+supersedes the stamped epoch. `ConfigEpoch == 0` (a pre-#5274 peer, or a
+local-origin entry) disables the check — rolling-upgrade safe. On reconnect the
+receiver resets `lastAppliedConfigGen` to 0 (`resetRecvGen`), so bulk re-sync
+after a peer reboot is never falsely rejected (the reset makes the compare
+baseline 0 until the peer re-pushes its current config).
+
+**Enforcement is authoritative in the Go cluster layer, not the userspace
+helper.** The #3931 config-sync-generation namespace lives entirely in
+`SessionSync`; the helper's own `config_generation` is a *local* commit counter
+(`Manager.bumpGeneration`) whose value is independent per node and therefore not
+cross-node comparable. The receiver rejects a stale-epoch install BEFORE it ever
+reaches the helper, so the helper needs no config-epoch field or guard. This
+guard covers the config-authority → peer direction (the issue's scenario, where
+the primary that admits the session is also the RG0 config-sync authority); a
+non-authority's sessions carry the authority-independent seed epoch and the
+guard is inert for them (no false reject), which is acceptable because config
+changes originate on the authority.
 
 ## Sync Readiness and Bulk Priming
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -310,6 +310,53 @@ V6}` (drives the real sender enqueue + receiver apply in wire order),
 `TestDeleteGenerationStrictlyGreaterThanInstall{V4,V6}` in
 `pkg/cluster/sync_gen_guard_test.go`.
 
+## Config-Epoch Guard (#5274)
+
+Distinct from the per-key install generation (#2170), every **session** message
+carries a length-gated trailing `ConfigEpoch uint64` (LE), appended after the
+#3301 `AppTimeout`/`PolicyCounterIdx` block on V4 and after the #4565
+`Nat64SnatV4` on V6. An old decoder stops before it and reads `ConfigEpoch == 0`
+(`if off+8 <= len(payload)` block in `decodeSession*Payload`); a new decoder
+reading an old, shorter payload also sees 0 — rolling-upgrade safe, no version
+bump (the same additive-trailing-field discipline as #2170/#3301/#4565).
+
+**Purpose.** It closes the immediate-policy-invalidation gap across the HA
+boundary. The primary admits a session under config A, then commits config B
+(which DENIES it). Config B is config-synced and applied on the standby (which
+runs `clearSessionsForDeletedPolicies`), but a delayed config-A session install
+that arrives **after** that sweep would otherwise install a stale permit that
+the standby forwards under after failover.
+
+**Semantics (sender, `pkg/cluster`).** `stampInstallGen*` stamps every queued
+session with `ConfigEpoch = configGenCounter.Load()` — the #3931 config-sync
+generation this node currently holds. A session still present in the local table
+when it is queued has survived this node's own config-apply sweep, so it is
+legitimately admitted under the current config.
+
+**Semantics (receiver, `pkg/cluster`).** `installClusterSynced*` refuses an
+install whose `ConfigEpoch` is **strictly older** than `lastAppliedConfigGen`
+(`SessionsStaleConfigIgnored++`) and drops it BEFORE forwarding to the helper.
+Both stamp and compare are in the SAME sender→receiver #3931 namespace (the
+sender's monotonic counter, which the receiver applies via the config-sync path
+and records as `lastAppliedConfigGen`), so the cross-node comparison is
+meaningful. `ConfigEpoch == 0` (legacy peer / local-origin) disables the check;
+the `resetRecvGen` bulk barrier zeroes `lastAppliedConfigGen`, so a rebooted-peer
+cold re-prime is never falsely rejected.
+
+**Authority is the Go cluster layer, NOT the userspace helper.** Unlike #2170's
+`Generation` — which the helper mirrors and re-enforces per key — the config
+epoch is a GLOBAL check against the receiver's current applied config, and the
+only cross-node-comparable namespace is the #3931 config-sync generation, which
+lives entirely in `SessionSync`. The helper's own `config_generation` is a
+*local* commit counter (`Manager.bumpGeneration`) that is independent per node
+and therefore cannot host this guard, so no `config_epoch` field is added to
+`SessionSyncRequest` or `ha.rs`. Regression coverage:
+`TestStaleConfigEpochSessionRejected5274{,V6}`,
+`TestSessionWireRoundTripConfigEpoch5274{V4,V6}`,
+`TestConfigEpochStampedAtQueueTime5274`, and
+`TestConfigEpochNoRejectAgainstZeroBaseline5274` in
+`pkg/cluster/sync_config_epoch_5274_test.go`.
+
 ## Config Payload (Variable)
 
 UTF-8 text of the full Junos-format configuration followed by a trailing
@@ -828,6 +875,7 @@ All counters are `atomic.Uint64` / `atomic.Bool`, lock-free:
 | SessionsSent | Sessions queued to sendCh |
 | SessionsReceived | Session messages received from peer |
 | SessionsInstalled | Sessions successfully written to BPF map |
+| SessionsStaleConfigIgnored | Session installs refused by the #5274 config-epoch guard: the peer stamped a config epoch (#3931 `configGenCounter`) strictly older than this node's `lastAppliedConfigGen`, so a newer config that may deny the session is already applied here (a stale permit across the HA boundary) |
 | DeletesSent | Delete messages queued |
 | DeletesReceived | Delete messages received |
 | BulkSyncs | Completed bulk sync operations |

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -746,6 +746,26 @@ outside the monitor loop:
   check→Put→record apply sequence is not held under one `recvGenMu` acquisition;
   it is safe because the per-peer receive path is single-threaded over the single
   active fabric (#2198 F3).
+- **Config-epoch guard (#5274)**: distinct from the per-key install generation,
+  every session install carries a `ConfigEpoch` — the #3931 config-sync
+  generation (`configGenCounter`) the sender held when it queued the session
+  (`stampInstallGen*`), as a length-gated trailing `uint64` on the session wire
+  (`sync_protocol.go`). The receiver (`installClusterSynced*`) refuses an install
+  whose epoch is **strictly older** than its `lastAppliedConfigGen`
+  (`SessionsStaleConfigIgnored`), because the peer has since committed — and this
+  node has applied — a newer config that may DENY the session. This closes the
+  immediate-policy-invalidation gap: a session admitted under config A that lands
+  after config B's `clearSessionsForDeletedPolicies` sweep is a stale permit the
+  standby would otherwise forward under after failover. Both the stamp
+  (`configGenCounter`) and the compare (`lastAppliedConfigGen`) are in the SAME
+  sender→receiver #3931 namespace, so the comparison is meaningful across nodes.
+  `epoch == 0` (legacy peer / local-origin) disables the check (rolling-upgrade
+  safe); the reconnect `resetRecvGen` zeroes `lastAppliedConfigGen` so a
+  rebooted-peer bulk re-prime is never falsely rejected. **The guard is
+  Go-cluster-authoritative** — the userspace helper's `config_generation` is a
+  *local* commit counter (`Manager.bumpGeneration`) that is not cross-node
+  comparable, so the receiver rejects the stale install BEFORE forwarding it to
+  the helper, and no config-epoch field or guard is added on the Rust side.
 - Dual-active overlap is intentional: primary sets `rg_active=true`
   immediately on becoming master; secondary defers `rg_active=false` until
   it sees the VRRP BACKUP event. Brief overlap, never both inactive.

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -153,6 +153,15 @@ type SyncStats struct {
 	// the per-key stored generation monotonic so a later stale delete can
 	// still be matched and refused.
 	InstallsStaleIgnored atomic.Uint64
+	// SessionsStaleConfigIgnored counts session installs refused by the #5274
+	// config-epoch guard: the peer stamped the session with the config-sync
+	// generation (#3931) it held at admit time, and that epoch was strictly
+	// OLDER than this node's lastAppliedConfigGen — i.e. the peer has since
+	// committed (and this node applied) a newer config that may DENY the
+	// session. Refusing the install prevents a stale PERMIT from landing after
+	// this node's clearSessionsForDeletedPolicies sweep for the newer config
+	// (the immediate-policy-invalidation gap across the HA boundary).
+	SessionsStaleConfigIgnored atomic.Uint64
 	// GenMapOverflow counts how many times a #2170 generation map (sender
 	// echo or receiver stored) was at genGuardMapCap and a NEW key therefore
 	// could not be recorded (#2198 F1). The key degrades to gen-0 (safe,
@@ -182,40 +191,41 @@ type SyncStats struct {
 // SyncStatsSnapshot is a point-in-time copy of SyncStats with plain
 // non-atomic fields, safe to copy by value and pass across API boundaries.
 type SyncStatsSnapshot struct {
-	SessionsSent           uint64
-	SessionsReceived       uint64
-	SessionsInstalled      uint64
-	DeletesSent            uint64
-	DeletesReceived        uint64
-	BulkSyncs              uint64
-	ConfigsSent            uint64
-	ConfigsReceived        uint64
-	ConfigsStaleIgnored    uint64
-	ConfigsApplyFailed     uint64
-	IPsecSASent            uint64
-	IPsecSAReceived        uint64
-	IPsecSAStaleIgnored    uint64
-	DHCPLeasesSent         uint64
-	DHCPLeasesReceived     uint64
-	DHCPLeasesStaleIgnored uint64
-	DHCPLeasesSeeded       uint64
-	FencesSent             uint64
-	FencesReceived         uint64
-	Errors                 uint64
-	DeletesDropped         uint64
-	DeletesStaleIgnored    uint64
-	InstallsStaleIgnored   uint64
-	GenMapOverflow         uint64
-	PreAuthRejected        uint64
-	Connected              bool
-	ActiveFabric           int
-	BulkSyncStartTime      int64
-	BulkSyncEndTime        int64
-	BulkSyncSessions       uint64
-	LastConfigSyncTime     int64
-	LastConfigSyncSize     uint64
-	LastFenceSeq           uint64
-	LastFenceAckAt         int64
+	SessionsSent               uint64
+	SessionsReceived           uint64
+	SessionsInstalled          uint64
+	DeletesSent                uint64
+	DeletesReceived            uint64
+	BulkSyncs                  uint64
+	ConfigsSent                uint64
+	ConfigsReceived            uint64
+	ConfigsStaleIgnored        uint64
+	ConfigsApplyFailed         uint64
+	IPsecSASent                uint64
+	IPsecSAReceived            uint64
+	IPsecSAStaleIgnored        uint64
+	DHCPLeasesSent             uint64
+	DHCPLeasesReceived         uint64
+	DHCPLeasesStaleIgnored     uint64
+	DHCPLeasesSeeded           uint64
+	FencesSent                 uint64
+	FencesReceived             uint64
+	Errors                     uint64
+	DeletesDropped             uint64
+	DeletesStaleIgnored        uint64
+	InstallsStaleIgnored       uint64
+	SessionsStaleConfigIgnored uint64
+	GenMapOverflow             uint64
+	PreAuthRejected            uint64
+	Connected                  bool
+	ActiveFabric               int
+	BulkSyncStartTime          int64
+	BulkSyncEndTime            int64
+	BulkSyncSessions           uint64
+	LastConfigSyncTime         int64
+	LastConfigSyncSize         uint64
+	LastFenceSeq               uint64
+	LastFenceAckAt             int64
 }
 
 // TransferReadinessSnapshot captures session-sync state that determines whether
@@ -872,7 +882,7 @@ func (s *SessionSync) Stats() SyncStatsSnapshot {
 		activeFabric = -1
 	}
 	s.mu.Unlock()
-	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
+	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), ConfigsApplyFailed: s.stats.ConfigsApplyFailed.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), IPsecSAStaleIgnored: s.stats.IPsecSAStaleIgnored.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesStaleIgnored: s.stats.DHCPLeasesStaleIgnored.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), SessionsStaleConfigIgnored: s.stats.SessionsStaleConfigIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), PreAuthRejected: s.stats.PreAuthRejected.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
 }
 
 // IsConnected reports whether a peer sync connection is currently established.

--- a/pkg/cluster/sync_config_epoch_5274_test.go
+++ b/pkg/cluster/sync_config_epoch_5274_test.go
@@ -1,0 +1,279 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #5274 — HA session-sync config-epoch guard tests.
+//
+// The peer stamps every synced session with the #3931 config-sync generation
+// it held at admit/queue time (SessionValue.ConfigEpoch, stampInstallGen*).
+// The receiver refuses an install whose epoch is STRICTLY OLDER than its own
+// lastAppliedConfigGen — the peer has since committed (and this node applied) a
+// newer config that may DENY the session, so a delayed stale-permit install
+// that lands after clearSessionsForDeletedPolicies is dropped
+// (SessionsStaleConfigIgnored). These tests FAIL RED if either the wire
+// carry (sync_protocol.go) or the receiver guard (installClusterSynced*) is
+// reverted.
+
+// configEpochKeyV4 builds a distinct v4 key per sub-case (varying src port) so
+// the #2170 per-key install-generation guard never interferes with the
+// config-epoch admission being exercised.
+func configEpochKeyV4(srcPort uint16) dataplane.SessionKey {
+	return dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 0, 1},
+		DstIP:    [4]byte{172, 16, 80, 200},
+		SrcPort:  srcPort,
+		DstPort:  5201,
+	}
+}
+
+func configEpochKeyV6(srcPort uint16) dataplane.SessionKeyV6 {
+	k := dataplane.SessionKeyV6{Protocol: 6, SrcPort: srcPort, DstPort: 5201}
+	k.SrcIP[15] = 1
+	k.DstIP[15] = 2
+	return k
+}
+
+// installWithConfigEpochV4 drives the real apply layer with an explicit
+// admitting config epoch, as if the value had arrived off the wire (decode
+// sets val.ConfigEpoch). Generation is left 0 so ONLY the config-epoch guard
+// governs admission.
+func installWithConfigEpochV4(ss *SessionSync, key dataplane.SessionKey, epoch uint64) {
+	val := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 1, EgressZone: 2}
+	val.ConfigEpoch = epoch
+	ss.installClusterSyncedV4(key, val)
+}
+
+func installWithConfigEpochV6(ss *SessionSync, key dataplane.SessionKeyV6, epoch uint64) {
+	val := dataplane.SessionValueV6{State: dataplane.SessStateEstablished, IngressZone: 1, EgressZone: 2}
+	val.ConfigEpoch = epoch
+	ss.installClusterSyncedV6(key, val)
+}
+
+// TestStaleConfigEpochSessionRejected5274 is the immediate-policy-invalidation
+// race: the peer admitted a session under config epoch E1, this node has since
+// applied a strictly-newer config (lastAppliedConfigGen = E2 > E1) that may
+// DENY it, and the delayed install arrives AFTER this node's config-apply
+// sweep. The stale-epoch install MUST be refused; a current/newer/legacy-epoch
+// install MUST be accepted. Reverting the installClusterSyncedV4 guard installs
+// the stale permit and this fails RED.
+func TestStaleConfigEpochSessionRejected5274(t *testing.T) {
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+
+	// This node has applied config generation 10 (the peer committed a newer
+	// config and it was config-synced + applied here).
+	ss.lastAppliedConfigGen.Store(10)
+
+	// STALE: admitted under epoch 5 < 10 — must be REFUSED (a stale permit).
+	staleKey := configEpochKeyV4(10001)
+	installWithConfigEpochV4(ss, staleKey, 5)
+	if _, ok := dp.v4sessions[staleKey]; ok {
+		t.Fatal("stale-config-epoch session (epoch 5 < applied 10) was wrongly installed")
+	}
+	if got := ss.stats.SessionsStaleConfigIgnored.Load(); got != 1 {
+		t.Fatalf("SessionsStaleConfigIgnored = %d, want 1 after the stale reject", got)
+	}
+
+	// CURRENT: admitted under epoch 10 == applied 10 — must be ACCEPTED
+	// (equality is not staleness; the config still admits it).
+	curKey := configEpochKeyV4(10002)
+	installWithConfigEpochV4(ss, curKey, 10)
+	if _, ok := dp.v4sessions[curKey]; !ok {
+		t.Fatal("current-config-epoch session (epoch 10 == applied 10) was wrongly refused")
+	}
+
+	// NEWER: admitted under epoch 15 > applied 10 (this node has not yet
+	// applied the peer's newest config) — must be ACCEPTED.
+	newKey := configEpochKeyV4(10003)
+	installWithConfigEpochV4(ss, newKey, 15)
+	if _, ok := dp.v4sessions[newKey]; !ok {
+		t.Fatal("newer-config-epoch session (epoch 15 > applied 10) was wrongly refused")
+	}
+
+	// LEGACY: epoch 0 (a pre-#5274 peer, or local-origin) disables the check —
+	// must be ACCEPTED unconditionally (rolling-upgrade safe).
+	legacyKey := configEpochKeyV4(10004)
+	installWithConfigEpochV4(ss, legacyKey, 0)
+	if _, ok := dp.v4sessions[legacyKey]; !ok {
+		t.Fatal("legacy epoch-0 session was wrongly refused (config-epoch check must be disabled for 0)")
+	}
+
+	// Only the single stale install was ignored.
+	if got := ss.stats.SessionsStaleConfigIgnored.Load(); got != 1 {
+		t.Fatalf("SessionsStaleConfigIgnored = %d, want 1 (only the stale install)", got)
+	}
+}
+
+// TestStaleConfigEpochSessionRejected5274V6 mirrors the v4 guard on the v6
+// apply path.
+func TestStaleConfigEpochSessionRejected5274V6(t *testing.T) {
+	dp := &mockSweepDP{v6sessions: map[dataplane.SessionKeyV6]dataplane.SessionValueV6{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.lastAppliedConfigGen.Store(10)
+
+	staleKey := configEpochKeyV6(20001)
+	installWithConfigEpochV6(ss, staleKey, 5)
+	if _, ok := dp.v6sessions[staleKey]; ok {
+		t.Fatal("stale-config-epoch v6 session (epoch 5 < applied 10) was wrongly installed")
+	}
+	if got := ss.stats.SessionsStaleConfigIgnored.Load(); got != 1 {
+		t.Fatalf("SessionsStaleConfigIgnored = %d, want 1 after the v6 stale reject", got)
+	}
+
+	curKey := configEpochKeyV6(20002)
+	installWithConfigEpochV6(ss, curKey, 10)
+	if _, ok := dp.v6sessions[curKey]; !ok {
+		t.Fatal("current-config-epoch v6 session (epoch 10 == applied 10) was wrongly refused")
+	}
+
+	legacyKey := configEpochKeyV6(20003)
+	installWithConfigEpochV6(ss, legacyKey, 0)
+	if _, ok := dp.v6sessions[legacyKey]; !ok {
+		t.Fatal("legacy epoch-0 v6 session was wrongly refused")
+	}
+}
+
+// TestConfigEpochNoRejectAgainstZeroBaseline5274 documents that with no config
+// generation held locally (fresh node, lastAppliedConfigGen == 0) the guard
+// admits everything — the check is a strict "older than a KNOWN newer config"
+// test, never a reject against the zero baseline.
+func TestConfigEpochNoRejectAgainstZeroBaseline5274(t *testing.T) {
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	// lastAppliedConfigGen defaults to 0.
+
+	key := configEpochKeyV4(30001)
+	installWithConfigEpochV4(ss, key, 7)
+	if _, ok := dp.v4sessions[key]; !ok {
+		t.Fatal("session refused against a zero applied-config baseline (guard must only reject a KNOWN-newer config)")
+	}
+	if got := ss.stats.SessionsStaleConfigIgnored.Load(); got != 0 {
+		t.Fatalf("SessionsStaleConfigIgnored = %d, want 0 with no applied config", got)
+	}
+}
+
+// TestSessionWireRoundTripConfigEpoch5274V4 asserts the admitting config epoch
+// round-trips on the cluster session-sync wire as a length-gated trailing
+// field, AND a legacy payload truncated before the #5274 block still decodes
+// (epoch 0, other fields preserved). Reverting the sync_protocol.go
+// encode/decode drops the value and this fails RED.
+func TestSessionWireRoundTripConfigEpoch5274V4(t *testing.T) {
+	key := configEpochKeyV4(40001)
+	val := dataplane.SessionValue{
+		State:            dataplane.SessStateEstablished,
+		IngressZone:      1,
+		EgressZone:       2,
+		PolicyID:         42,
+		Generation:       0xDEADBEEFCAFE,
+		AppTimeout:       30,
+		PolicyCounterIdx: 7,
+		ConfigEpoch:      0x1122334455667788,
+	}
+	payload := encodeSessionV4Payload(key, val)
+	dKey, dVal, ok := decodeSessionV4Payload(payload)
+	if !ok {
+		t.Fatal("decode failed")
+	}
+	if dKey != key {
+		t.Fatalf("key mismatch: %+v vs %+v", dKey, key)
+	}
+	if dVal.ConfigEpoch != val.ConfigEpoch {
+		t.Fatalf("ConfigEpoch round-trip = %#x, want %#x", dVal.ConfigEpoch, val.ConfigEpoch)
+	}
+	// Prior trailing fields must be unaffected by the appended epoch.
+	if dVal.Generation != val.Generation || dVal.AppTimeout != 30 || dVal.PolicyCounterIdx != 7 {
+		t.Fatalf("adjacent trailing fields corrupted: gen=%#x appto=%d idx=%d",
+			dVal.Generation, dVal.AppTimeout, dVal.PolicyCounterIdx)
+	}
+
+	// Mixed-version: truncate the trailing 8-byte #5274 config epoch (an old
+	// peer stops after PolicyCounterIdx). Decode must still succeed with epoch
+	// 0 and the #3301 fields + Generation preserved.
+	legacy := payload[:len(payload)-8]
+	_, lVal, ok := decodeSessionV4Payload(legacy)
+	if !ok {
+		t.Fatal("legacy (truncated) decode failed")
+	}
+	if lVal.ConfigEpoch != 0 {
+		t.Fatalf("legacy frame ConfigEpoch = %#x, want 0", lVal.ConfigEpoch)
+	}
+	if lVal.Generation != val.Generation || lVal.PolicyCounterIdx != 7 {
+		t.Fatalf("legacy frame corrupted prior fields: gen=%#x idx=%d", lVal.Generation, lVal.PolicyCounterIdx)
+	}
+}
+
+func TestSessionWireRoundTripConfigEpoch5274V6(t *testing.T) {
+	key := configEpochKeyV6(40002)
+	val := dataplane.SessionValueV6{
+		State:            dataplane.SessStateEstablished,
+		IngressZone:      1,
+		EgressZone:       2,
+		PolicyID:         99,
+		Generation:       0x0102030405060708,
+		AppTimeout:       45,
+		PolicyCounterIdx: 11,
+		Nat64SnatV4:      [4]byte{192, 0, 2, 9},
+		ConfigEpoch:      0x99aabbccddeeff00,
+	}
+	payload := encodeSessionV6Payload(key, val)
+	_, dVal, ok := decodeSessionV6Payload(payload)
+	if !ok {
+		t.Fatal("decode failed")
+	}
+	if dVal.ConfigEpoch != val.ConfigEpoch {
+		t.Fatalf("ConfigEpoch round-trip = %#x, want %#x", dVal.ConfigEpoch, val.ConfigEpoch)
+	}
+	// The #4565 NAT64 pool source (the trailing field before the epoch) must
+	// be intact.
+	if dVal.Nat64SnatV4 != val.Nat64SnatV4 {
+		t.Fatalf("Nat64SnatV4 corrupted by appended epoch: got %v want %v", dVal.Nat64SnatV4, val.Nat64SnatV4)
+	}
+	if dVal.Generation != val.Generation || dVal.PolicyCounterIdx != 11 {
+		t.Fatalf("adjacent trailing fields corrupted: gen=%#x idx=%d", dVal.Generation, dVal.PolicyCounterIdx)
+	}
+
+	// Mixed-version: truncate the trailing 8-byte epoch (an old peer stops
+	// after Nat64SnatV4). Decode still succeeds with epoch 0 and NAT64 source
+	// preserved.
+	legacy := payload[:len(payload)-8]
+	_, lVal, ok := decodeSessionV6Payload(legacy)
+	if !ok {
+		t.Fatal("legacy (truncated) v6 decode failed")
+	}
+	if lVal.ConfigEpoch != 0 {
+		t.Fatalf("legacy v6 frame ConfigEpoch = %#x, want 0", lVal.ConfigEpoch)
+	}
+	if lVal.Nat64SnatV4 != val.Nat64SnatV4 {
+		t.Fatalf("legacy v6 frame Nat64SnatV4 corrupted: got %v want %v", lVal.Nat64SnatV4, val.Nat64SnatV4)
+	}
+}
+
+// TestConfigEpochStampedAtQueueTime5274 asserts the sender stamps the current
+// config-sync generation (#3931 configGenCounter) onto every queued session
+// (stampInstallGen*), so the receiver has an epoch to guard against. Reverting
+// the stamp leaves ConfigEpoch 0 (guard permanently disabled) and this fails
+// RED.
+func TestConfigEpochStampedAtQueueTime5274(t *testing.T) {
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.configGenCounter.Store(77)
+
+	key := configEpochKeyV4(50001)
+	val := dataplane.SessionValue{State: dataplane.SessStateEstablished}
+	ss.stampInstallGenV4(key, &val)
+	if val.ConfigEpoch != 77 {
+		t.Fatalf("stampInstallGenV4 ConfigEpoch = %d, want 77 (current configGenCounter)", val.ConfigEpoch)
+	}
+
+	keyV6 := configEpochKeyV6(50002)
+	valV6 := dataplane.SessionValueV6{State: dataplane.SessStateEstablished}
+	ss.stampInstallGenV6(keyV6, &valV6)
+	if valV6.ConfigEpoch != 77 {
+		t.Fatalf("stampInstallGenV6 ConfigEpoch = %d, want 77", valV6.ConfigEpoch)
+	}
+}

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -126,6 +126,15 @@ func (g *fullSetSeqGuard) reset() {
 func (s *SessionSync) stampInstallGenV4(key dataplane.SessionKey, val *dataplane.SessionValue) {
 	g := s.nextInstallGen()
 	val.Generation = g
+	// #5274: stamp the admitting config epoch = the config-sync generation
+	// (#3931) this node currently holds. A session still present in the local
+	// table when it is queued has survived this node's own config-apply
+	// clearSessionsForDeletedPolicies sweep, so it is admitted under the
+	// current config; the receiver refuses it only once IT applies a strictly
+	// newer config (lastAppliedConfigGen advances past this epoch). configGen
+	// and lastAppliedConfigGen are the SAME sender→receiver namespace, so the
+	// comparison is meaningful across the HA boundary.
+	val.ConfigEpoch = s.configGenCounter.Load()
 	s.genSentMu.Lock()
 	if s.genSentV4 == nil {
 		s.genSentV4 = make(map[dataplane.SessionKey]uint64)
@@ -139,6 +148,8 @@ func (s *SessionSync) stampInstallGenV4(key dataplane.SessionKey, val *dataplane
 func (s *SessionSync) stampInstallGenV6(key dataplane.SessionKeyV6, val *dataplane.SessionValueV6) {
 	g := s.nextInstallGen()
 	val.Generation = g
+	// #5274: stamp the admitting config epoch (see stampInstallGenV4).
+	val.ConfigEpoch = s.configGenCounter.Load()
 	s.genSentMu.Lock()
 	if s.genSentV6 == nil {
 		s.genSentV6 = make(map[dataplane.SessionKeyV6]uint64)
@@ -383,6 +394,24 @@ func (s *SessionSync) resetRecvGen() {
 // also serialize unrelated keys and block on dataplane I/O under the lock,
 // which is not worth it for a race that the single-active-fabric invariant
 // already precludes.
+// configEpochStale reports whether a synced session admitted under config
+// epoch `epoch` must be REFUSED because this node has since applied a STRICTLY
+// newer config (#5274). The peer stamps the session with the #3931 config-sync
+// generation it held when it queued the session (stampInstallGen*);
+// lastAppliedConfigGen is the highest config generation THIS node has applied
+// from that same peer, so the two are directly comparable in one
+// sender→receiver namespace. A newer config the peer committed AND this node
+// applied may DENY the session, and this node's clearSessionsForDeletedPolicies
+// sweep for that config already ran — so installing the delayed session would
+// revive a stale PERMIT the config invalidated. epoch==0 (a legacy/pre-#5274
+// peer, or a local-origin entry) disables the check, unconditionally admitting
+// as before (rolling-upgrade safe). The check is authoritative here in the Go
+// cluster layer: the #3931 namespace lives entirely in SessionSync, and the
+// receiver refuses BEFORE forwarding the install to the userspace helper.
+func (s *SessionSync) configEpochStale(epoch uint64) bool {
+	return epoch != 0 && epoch < s.lastAppliedConfigGen.Load()
+}
+
 func (s *SessionSync) installClusterSyncedV4(key dataplane.SessionKey, val dataplane.SessionValue) {
 	if s.sessions == nil {
 		return
@@ -392,6 +421,12 @@ func (s *SessionSync) installClusterSyncedV4(key dataplane.SessionKey, val datap
 		s.stats.InstallsStaleIgnored.Add(1)
 		slog.Debug("cluster sync: ignored stale-generation v4 install",
 			"incoming_gen", val.Generation)
+		return
+	}
+	if s.configEpochStale(val.ConfigEpoch) {
+		s.stats.SessionsStaleConfigIgnored.Add(1)
+		slog.Debug("cluster sync: ignored stale-config-epoch v4 install (peer moved to a newer config that may deny this session)",
+			"session_config_epoch", val.ConfigEpoch, "applied_config_gen", s.lastAppliedConfigGen.Load())
 		return
 	}
 	if err := s.sessions.PutClusterSyncedV4(key, val); err == nil {
@@ -415,6 +450,12 @@ func (s *SessionSync) installClusterSyncedV6(key dataplane.SessionKeyV6, val dat
 		s.stats.InstallsStaleIgnored.Add(1)
 		slog.Debug("cluster sync: ignored stale-generation v6 install",
 			"incoming_gen", val.Generation)
+		return
+	}
+	if s.configEpochStale(val.ConfigEpoch) {
+		s.stats.SessionsStaleConfigIgnored.Add(1)
+		slog.Debug("cluster sync: ignored stale-config-epoch v6 install (peer moved to a newer config that may deny this session)",
+			"session_config_epoch", val.ConfigEpoch, "applied_config_gen", s.lastAppliedConfigGen.Load())
 		return
 	}
 	if err := s.sessions.PutClusterSyncedV6(key, val); err == nil {

--- a/pkg/cluster/sync_gen_guard_test.go
+++ b/pkg/cluster/sync_gen_guard_test.go
@@ -356,10 +356,11 @@ func TestSessionWireRoundTripPolicyFields3301V4(t *testing.T) {
 		t.Fatalf("Generation round-trip = %#x, want %#x", dVal.Generation, val.Generation)
 	}
 
-	// Mixed-version: truncate the trailing 8-byte #3301 block (an old peer
-	// stops after Generation). Decode must still succeed with the new fields
-	// at 0 and Generation preserved.
-	legacy := payload[:len(payload)-8]
+	// Mixed-version: truncate the trailing #3301 block (8 bytes) AND the #5274
+	// ConfigEpoch (8 bytes) so the frame ends after Generation (an old peer
+	// that stops there). Decode must still succeed with the new fields at 0 and
+	// Generation preserved.
+	legacy := payload[:len(payload)-16]
 	_, lVal, ok := decodeSessionV4Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -401,10 +402,10 @@ func TestSessionWireRoundTripPolicyFields3301V6(t *testing.T) {
 		t.Fatalf("Generation round-trip = %#x, want %#x", dVal.Generation, val.Generation)
 	}
 
-	// Drop the #3301 AppTimeout+PolicyCounterIdx (8 bytes) AND the #4565
-	// trailing Nat64SnatV4 (4 bytes) to simulate a pre-#3301 peer that omits all
-	// three additive trailing fields.
-	legacy := payload[:len(payload)-12]
+	// Drop the #3301 AppTimeout+PolicyCounterIdx (8 bytes), the #4565 trailing
+	// Nat64SnatV4 (4 bytes), AND the #5274 ConfigEpoch (8 bytes) to simulate a
+	// pre-#3301 peer that omits all of the additive trailing fields.
+	legacy := payload[:len(payload)-20]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -436,8 +437,10 @@ func TestSessionWireRoundTripNat64SnatV4_4565(t *testing.T) {
 		t.Fatalf("Nat64SnatV4 round-trip = %v, want [203 0 113 5]", dVal.Nat64SnatV4)
 	}
 
-	// Legacy (pre-#4565) peer omits the trailing 4 bytes -> all-zero (not NAT64).
-	legacy := payload[:len(payload)-4]
+	// Legacy (pre-#4565) peer omits the trailing Nat64SnatV4 (4 bytes) — and,
+	// being older, the #5274 ConfigEpoch (8 bytes) too — so truncate both to
+	// reach an after-#3301 frame -> Nat64SnatV4 all-zero (not NAT64).
+	legacy := payload[:len(payload)-12]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -479,10 +482,10 @@ func TestCrossVersionShortPayloadDecode(t *testing.T) {
 	key := gen2170KeyV4()
 	val := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 1, EgressZone: 2, Generation: 42}
 	full := encodeSessionV4Payload(key, val)
-	// Simulate a pre-#2170 OLD encoder: drop the trailing 16 bytes (the
-	// #2170 generation u64 + the #3301 AppTimeout/PolicyCounterIdx block) so
-	// the payload ends at FibGen.
-	short := full[:len(full)-16]
+	// Simulate a pre-#2170 OLD encoder: drop the trailing 24 bytes (the
+	// #2170 generation u64 + the #3301 AppTimeout/PolicyCounterIdx block + the
+	// #5274 ConfigEpoch u64) so the payload ends at FibGen.
+	short := full[:len(full)-24]
 	_, dVal, ok := decodeSessionV4Payload(short)
 	if !ok {
 		t.Fatal("short (legacy) payload should still decode")

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -96,9 +96,10 @@ func encodeSessionV4Payload(key dataplane.SessionKey, val dataplane.SessionValue
 	keySize := 16
 	valSize := 160
 	// +8 for the #2170 install Generation, +8 for the #3301 trailing
-	// AppTimeout(u32)+PolicyCounterIdx(u32). All length-gated: an old decoder
-	// stops after the field it knows and ignores the rest.
-	buf := make([]byte, keySize+valSize+8+8)
+	// AppTimeout(u32)+PolicyCounterIdx(u32), +8 for the #5274 ConfigEpoch. All
+	// length-gated: an old decoder stops after the field it knows and ignores
+	// the rest.
+	buf := make([]byte, keySize+valSize+8+8+8)
 	off := 0
 	copy(buf[off:], key.SrcIP[:])
 	off += 4
@@ -188,6 +189,13 @@ func encodeSessionV4Payload(key dataplane.SessionKey, val dataplane.SessionValue
 	off += 4
 	binary.LittleEndian.PutUint32(buf[off:], val.PolicyCounterIdx)
 	off += 4
+	// #5274: admitting config epoch (length-gated trailing field). The cluster
+	// receiver refuses an install whose epoch is strictly older than its
+	// lastAppliedConfigGen (a stale permit across a config that now denies the
+	// session). Old decoders stop after PolicyCounterIdx and ignore it; absent
+	// => 0 (legacy peer / check disabled).
+	binary.LittleEndian.PutUint64(buf[off:], val.ConfigEpoch)
+	off += 8
 	return buf[:off]
 }
 func encodeSessionV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) []byte {
@@ -295,6 +303,11 @@ func encodeSessionV6Payload(key dataplane.SessionKeyV6, val dataplane.SessionVal
 	// An old decoder stops after PolicyCounterIdx and ignores it (=> not NAT64).
 	copy(buf[off:off+4], val.Nat64SnatV4[:])
 	off += 4
+	// #5274: admitting config epoch (length-gated trailing field; see
+	// encodeSessionV4Payload). Old decoders stop after Nat64SnatV4 and ignore
+	// it; absent => 0 (legacy peer / check disabled).
+	binary.LittleEndian.PutUint64(buf[off:], val.ConfigEpoch)
+	off += 8
 	return buf[:off]
 }
 
@@ -457,6 +470,12 @@ func decodeSessionV4Payload(payload []byte) (dataplane.SessionKey, dataplane.Ses
 		val.PolicyCounterIdx = binary.LittleEndian.Uint32(payload[off:])
 		off += 4
 	}
+	// #5274: admitting config epoch (length-gated; absent → 0 = legacy peer /
+	// config-epoch check disabled).
+	if off+8 <= len(payload) {
+		val.ConfigEpoch = binary.LittleEndian.Uint64(payload[off:])
+		off += 8
+	}
 	return key, val, true
 }
 
@@ -581,6 +600,12 @@ func decodeSessionV6Payload(payload []byte) (dataplane.SessionKeyV6, dataplane.S
 	if off+4 <= len(payload) {
 		copy(val.Nat64SnatV4[:], payload[off:off+4])
 		off += 4
+	}
+	// #5274: admitting config epoch (length-gated; absent → 0 = legacy peer /
+	// config-epoch check disabled).
+	if off+8 <= len(payload) {
+		val.ConfigEpoch = binary.LittleEndian.Uint64(payload[off:])
+		off += 8
 	}
 	return key, val, true
 }

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -85,6 +85,24 @@ type SessionValue struct {
 	// (default policy / non-policy-forwarded), the rolling-upgrade-safe
 	// default for an old peer that omits it.
 	PolicyCounterIdx uint32
+
+	// ConfigEpoch is the #5274 admitting config epoch: the value of the HA
+	// config-sync generation (#3931 configGenCounter) the SENDER held when it
+	// queued this session for sync. The cluster receiver rejects an install
+	// whose ConfigEpoch is STRICTLY OLDER than its own lastAppliedConfigGen —
+	// the peer has since committed (and this node has applied) a newer config
+	// that may DENY the session, so a delayed stale-permit install that lands
+	// after the receiver's clearSessionsForDeletedPolicies scan is refused
+	// (SessionsStaleConfigIgnored). Like Generation/PolicyCounterIdx it is
+	// userspace-sync-only HA metadata carried as a length-gated trailing field
+	// in encodeSessionV4Payload; it is NOT part of the BPF/C conntrack ABI
+	// (bpfSessionValue) and MUST NOT be added to it. A value of 0 means
+	// "unknown / legacy peer" and disables the config-epoch check (the
+	// rolling-upgrade-safe default an old peer omits). The epoch is only
+	// cross-node comparable in the #3931 config-sync-generation namespace,
+	// which is authoritative in the Go cluster layer — see
+	// SessionSync.installClusterSyncedV4 for the guard.
+	ConfigEpoch uint64
 }
 
 // SessionKeyV6 mirrors the C struct session_key_v6 (5-tuple with 128-bit IPs).
@@ -161,6 +179,16 @@ type SessionValueV6 struct {
 	// (bpfSessionValueV6) and MUST NOT be added to it. All-zero => not NAT64
 	// (the rolling-upgrade-safe default an old peer omits).
 	Nat64SnatV4 [4]byte
+
+	// ConfigEpoch: see SessionValue.ConfigEpoch (#5274). The #3931 config-sync
+	// generation the sender held when it queued this session; the cluster
+	// receiver refuses an install whose epoch is strictly older than its
+	// lastAppliedConfigGen (a stale permit across a config that now denies it).
+	// Userspace-sync-only HA metadata carried as a length-gated trailing field
+	// in encodeSessionV6Payload; NOT part of the BPF/C conntrack ABI
+	// (bpfSessionValueV6) and MUST NOT be added to it. 0 = unknown/legacy peer
+	// (check disabled), the rolling-upgrade-safe default.
+	ConfigEpoch uint64
 }
 
 // ZoneConfig mirrors the C struct zone_config.


### PR DESCRIPTION
## Problem (#5274)

The HA session-sync envelope carried only the per-key install generation (#2170), never the **config epoch**. The cluster receive path queues config-apply asynchronously while session imports continue, and the receiver rejected only a strictly-older per-key generation. So:

1. Primary admits a session under config **A**.
2. Primary commits config **B** (which DENIES that session); B is config-synced.
3. Standby applies B and runs `clearSessionsForDeletedPolicies`.
4. A **delayed config-A session install** arrives **after** that sweep → installed anyway → a **stale permit** the standby forwards under after failover.

This broke immediate policy invalidation across the HA boundary. Distinct from #5084 (config-item peer-boot epoch) and #2170 (per-key install generation).

## Fix

Carry an admitting config epoch on the session and reject a stale one at the receiver:

- **`SessionValue{,V6}.ConfigEpoch`** — userspace-sync-only HA metadata (like `Generation`/`PolicyCounterIdx`); NOT part of the BPF/C conntrack ABI.
- **Peer wire** — a length-gated trailing `ConfigEpoch uint64` appended after the #3301 (V4) / #4565 (V6) trailing fields in `encode/decodeSessionV4Payload`/`V6`. Old decoders read `0` (legacy / check disabled) — additive, rolling-upgrade safe, **no version bump**.
- **Sender** — `stampInstallGenV4/V6` stamps `ConfigEpoch = configGenCounter.Load()` (the #3931 config-sync generation held at queue time). All send paths (incremental, sweep, bulk) route through these.
- **Receiver** — `installClusterSyncedV4/V6` refuses an install whose `ConfigEpoch` is strictly older than `lastAppliedConfigGen` (via new `configEpochStale`) and bumps `SessionsStaleConfigIgnored`, **before** forwarding to the userspace helper. Both stamp and compare live in the same #3931 sender→receiver namespace, so the cross-node comparison is meaningful. The reconnect `resetRecvGen` zeroes `lastAppliedConfigGen`, so a rebooted-peer bulk re-prime is never falsely rejected.

## Design decision — guard is Go-cluster-authoritative; Rust untouched

The issue cited `protocol.go` (the Go→Rust helper `SessionSyncRequest`) and `ha.rs` as the fix locations. After studying the code, **the guard cannot live on the Rust side**: the config epoch's only cross-node-comparable namespace is the #3931 config-sync generation, which lives **entirely in `pkg/cluster`** (`configGenCounter` / `lastAppliedConfigGen`). The userspace helper's own `config_generation` is a **local** commit counter (`Manager.bumpGeneration`), independent per node and therefore **not** comparable across the HA boundary.

So the receiver rejects the stale install in `pkg/cluster` **before** it reaches the helper — no `config_epoch` field/guard is added to `SessionSyncRequest` or `ha.rs`. Carrying it there would be a dead field (decoded, unused), or a per-key guard **provably redundant** with the #2170 generation guard (a later same-key install always has both a higher generation *and* ≥ config epoch). The essential cross-node wire is the **peer↔peer TCP protocol** (`sync_protocol.go`), which is Go↔Go and is where the field lives.

## Tests (fail-on-revert)

`pkg/cluster/sync_config_epoch_5274_test.go`:
- `TestStaleConfigEpochSessionRejected5274{,V6}` — stale epoch REJECTED, current/newer/legacy ACCEPTED, `SessionsStaleConfigIgnored` counted. **Verified RED** when the guard is neutralized.
- `TestSessionWireRoundTripConfigEpoch5274{V4,V6}` — wire round-trip + legacy-truncation (old peer → epoch 0, adjacent fields intact).
- `TestConfigEpochStampedAtQueueTime5274`, `TestConfigEpochNoRejectAgainstZeroBaseline5274`.

Updated the #3301/#4565/cross-version legacy-truncation offsets in `sync_gen_guard_test.go` (+8 for the new trailing field). `go build ./...`, `go vet ./pkg/cluster/`, and `go test ./pkg/cluster/ ./pkg/dataplane/...` all pass.

## Docs

`docs/session-sync-architecture.md` (Config-Epoch Guard section + Session Value note), `pkg/cluster/README.md` (guard bullet), `docs/sync-protocol.md` (Config-Epoch Guard section + `SessionsStaleConfigIgnored` stats-table entry).

Closes #5274

🤖 Generated with [Claude Code](https://claude.com/claude-code)