### PR TITLE
configstore/ha: do not treat a promoted-but-unapplied synced config as converged (#4957)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-22 — #4957: HA config-sync — do not treat a promoted-but-unapplied config as converged
+
+- **Timestamp**: 2026-07-22 (fix/4957-ha-configsync-unapplied-converged)
+- **Action**: `handleConfigSync`'s active-text convergence shortcut treated a
+  config that `SyncApply` promoted to `s.active` but whose `applyConfigLocked`
+  FAILED (non-fatal networkd/nft/IPsec tail error, never rolled back under the
+  #1799 degrade-not-fail doctrine) as converged: the primary's same-generation
+  re-push took the fast path, returned nil, advanced the config high-water, and
+  the reconcile retry never ran — a standby that acks a generation it never
+  finished applying. Fix (option c, least-invasive, respects degrade-not-fail):
+  added a `configstore` applied-config digest (`MarkActiveApplied`/`ActiveApplied`)
+  stamped ONLY after a fully-successful apply (boot `applyConfig`, commit
+  `applyAndSyncCommitted`, sync `handleConfigSync`), and ANDed the shortcut with
+  `ActiveApplied()`. A promoted-but-unapplied config now falls through and
+  RE-ATTEMPTS the apply; an already-applied config still shortcuts on reconnect
+  (no redundant re-apply). Text-keyed marker → stale value is fail-safe (at most
+  one idempotent re-apply, never a false convergence). Did not roll back
+  `s.active` (option a) — that fights the degrade-not-fail store-converges-to-peer
+  design and the #5564 armedActive invalidator that reads `s.active`.
+- **File(s)**: `pkg/configstore/store.go` (field + `MarkActiveApplied`/
+  `ActiveApplied`/`configTextDigest`), `pkg/daemon/daemon_ha_sync.go` (shortcut
+  gate + stamp on nil), `pkg/daemon/daemon_apply.go` (`applyConfig` +
+  `applyAndSyncCommitted` stamp on success), `pkg/configstore/applied_marker_4957_test.go`
+  (store contract test), `pkg/daemon/configsync_unapplied_4957_test.go`
+  (fail-on-revert), `pkg/daemon/config_sync_test.go` (updated to the
+  applied-not-just-active contract), `docs/sync-protocol.md`,
+  `pkg/configstore/README.md`.
+- **Validation**: `go build ./...`; `go test ./pkg/configstore/... ./pkg/daemon/...
+  ./pkg/cluster/...` green; `go vet` clean; fail-on-revert confirmed firsthand
+  (drop the `ActiveApplied()` gate → `TestHandleConfigSync_PromotedButUnappliedIsNotConverged`
+  RED at "applyConfigLocked calls = 1, want 2").
+
 ## 2026-07-22 — #5274: HA session-sync config-epoch guard (stale permit across the HA boundary)
 
 - **Timestamp**: 2026-07-22 (fix/5274-ha-session-config-epoch)

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -455,6 +455,32 @@ reintroduced on the *receiver* by the #3931 ordering guard). This preserves the
 (nil = store promoted + applied; error = not applied) is exactly what gates the
 mark, so the high-water always reflects the config actually in effect.
 
+**Applied-not-just-active convergence shortcut (#4957).** `handleConfigSync`
+short-circuits a re-push whose text already matches the active config so a
+duplicate does not re-run the whole reconcile. That shortcut is gated on
+**both** `activeText == incomingText` **and** `store.ActiveApplied()`, not on
+active-text equality alone. `configstore.SyncApply` promotes `s.active` to the
+peer config BEFORE `applyConfigLocked` runs and — under the #1799
+degrade-not-fail doctrine — does NOT roll `s.active` back when the apply fails.
+So active-text equality alone would treat a config that was PROMOTED but never
+finished applying (a transient networkd/nft/IPsec tail error) as converged: the
+primary's same-generation re-push would take the fast path, return `nil`, and
+advance the high-water past a config whose dataplane never converged — a standby
+that acks a generation it never applied and can expose stale/disarmed forwarding
+at failover. `ActiveApplied()` is a config-text digest the daemon stamps
+(`MarkActiveApplied`) ONLY after a fully-successful apply — the boot apply
+(`applyConfig`), a committed config (`applyAndSyncCommitted`), and a peer
+config-sync (`handleConfigSync` after `syncAndApply` returns nil). It is FALSE in
+the window between promotion and a successful apply, so a re-push of a
+promoted-but-unapplied config falls through to `syncAndApply` and RE-ATTEMPTS the
+apply (reconcile retry) instead of being swallowed as converged. Because the
+marker is keyed on the config text, a stale value can only make the shortcut MORE
+conservative (one idempotent re-apply), never falsely converged; and because the
+boot/commit/sync apply paths all stamp it, an already-applied config still takes
+the shortcut on a reconnect (which zeroes the generation high-water, so the
+primary re-pushes the current generation even when nothing changed) rather than
+pointlessly re-applying a live config.
+
 The last-applied high-water mark is reset to 0 on a peer bulk re-prime
 (`resetRecvGen`, fired on `BulkStart`) so a **rebooted primary** — whose
 monotonic counter restarts lower — is accepted instead of refused as stale
@@ -526,8 +552,14 @@ FATAL classes — a required-protocol-gate error (dataplane DISARMED, #2138) and
 daemon-stop context abort (#2926) — where the config is not live-forwarding and
 the invalidators are correctly skipped; on those `syncAndApply` returns a nil
 config plus the error. Any other tail error is surfaced (joined with any partial
-#5578 invalidation error) AFTER the invalidators run, so the high-water mark still
-does not advance and the primary's re-push re-converges the mark on the fast path.
+#5578 invalidation error) AFTER the invalidators run, so the high-water mark does
+not advance. On such a non-fatal tail error the daemon does NOT stamp
+`MarkActiveApplied` (that runs only when `syncAndApply` returns nil), so
+`ActiveApplied()` stays false and the primary's re-push does NOT take the
+active-text fast path (#4957): it re-enters `syncAndApply` and RE-ATTEMPTS the
+apply and the invalidators, completing the reconcile/finalization the tail error
+left unfinished — rather than the pre-#4957 behavior where the fast path returned
+nil and advanced the mark over a config the dataplane never finished applying.
 
 ## Full-set state-sync ordering (#5706)
 

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -109,9 +109,22 @@ inline archive-site passwords).
   `ShowActive`, `ActiveConfig`, `ActiveTree`, `Commit`,
   `CommitCheck`, `CommitConfirmed`, `Rollback`, `ListHistory`,
   `EnterConfigure`, `EnterConfigureSession`,
-  `EnterConfigureExclusive`, `ExitConfigure`, `SyncApply`. (See
+  `EnterConfigureExclusive`, `ExitConfigure`, `SyncApply`,
+  `MarkActiveApplied`, `ActiveApplied`. (See
   `store.go` for the full surface — there's no shorthand
   `Candidate()` or `History()`; use the `Show*` / `List*` forms.)
+- `MarkActiveApplied` / `ActiveApplied` — the #4957 applied-config marker.
+  `SyncApply` (and `Commit`/`Load`) promote `s.active` BEFORE the daemon runs
+  the apply and, under the #1799 degrade-not-fail doctrine, do NOT roll it back
+  on an apply failure — so a config can be the active tree yet never have
+  converged on the dataplane. The daemon calls `MarkActiveApplied` after a
+  fully-successful `applyConfigLocked` (boot, commit, config-sync); `ActiveApplied`
+  reports whether the CURRENT active text matches that last-applied digest.
+  `pkg/daemon` `handleConfigSync` ANDs its active-text convergence shortcut with
+  `ActiveApplied()` so a promoted-but-unapplied synced config is not treated as
+  converged (the HA config high-water then stays pinned until a retry lands). The
+  marker is keyed on config text, so a stale value can only cause an idempotent
+  re-apply, never a false convergence.
 - `MaxConfigSize` (16 MiB) + `checkConfigSize` — `store.go`. The
   transport-independent input-size ceiling checked at the head of every
   parse entry point: `LoadOverride`, `LoadMerge`, `LoadSet`, the HA

--- a/pkg/configstore/applied_marker_4957_test.go
+++ b/pkg/configstore/applied_marker_4957_test.go
@@ -1,0 +1,54 @@
+package configstore
+
+import "testing"
+
+// TestActiveApplied_TracksPromotionVsApply locks the #4957 store contract that
+// handleConfigSync's converged shortcut relies on: SyncApply promotes s.active
+// to the peer config, but ActiveApplied() stays FALSE until the daemon confirms
+// the apply via MarkActiveApplied(). A promoted-but-unapplied config must never
+// read as applied, and a subsequent promotion of a DIFFERENT config must reset
+// the applied state (the marker is keyed on the active config text).
+func TestActiveApplied_TracksPromotionVsApply(t *testing.T) {
+	s := newTestStore(t)
+
+	// A fresh store has never applied anything.
+	if s.ActiveApplied() {
+		t.Fatal("fresh store: ActiveApplied must be false before any apply")
+	}
+
+	// Promote config A via SyncApply (the HA config-sync ingress). This mirrors
+	// the daemon flow: the store promotes active BEFORE the daemon runs the apply.
+	confA := "system {\n    host-name node-a;\n}\n"
+	if _, err := s.SyncApply(confA, nil); err != nil {
+		t.Fatalf("SyncApply(A): %v", err)
+	}
+	if s.ActiveApplied() {
+		t.Fatal("after SyncApply(A) but before MarkActiveApplied: must read NOT applied (#4957)")
+	}
+
+	// The daemon confirms the apply succeeded.
+	s.MarkActiveApplied()
+	if !s.ActiveApplied() {
+		t.Fatal("after MarkActiveApplied: the active config must read applied")
+	}
+
+	// Promote a DIFFERENT config B: the applied marker (keyed on active text) must
+	// no longer match, so B reads as not-yet-applied until its own apply lands.
+	confB := "system {\n    host-name node-b;\n}\n"
+	if _, err := s.SyncApply(confB, nil); err != nil {
+		t.Fatalf("SyncApply(B): %v", err)
+	}
+	if s.ActiveApplied() {
+		t.Fatal("after promoting B: the stale A marker must not read B as applied (#4957)")
+	}
+
+	// Re-promoting the SAME text A after B was applied+marked also reads
+	// not-applied (the marker is for B now), proving the check is text-keyed.
+	s.MarkActiveApplied() // mark B applied
+	if _, err := s.SyncApply(confA, nil); err != nil {
+		t.Fatalf("SyncApply(A again): %v", err)
+	}
+	if s.ActiveApplied() {
+		t.Fatal("after re-promoting A over an applied B: must read NOT applied until A re-applies")
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -18,6 +18,8 @@
 package configstore
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -253,6 +255,23 @@ type Store struct {
 	// and a journal entry so the loss is visible instead of warning-only.
 	// Cleared by the next fully-successful saveRollbackFiles().
 	rollbackPersistDegraded bool
+
+	// appliedDigest is the digest of the active config TEXT that most recently
+	// completed a full apply to the dataplane/kernel (#4957). It is written by
+	// the daemon (MarkActiveApplied) ONLY after applyConfigLocked returns success
+	// for the current active config — at boot, on a committed config, and after a
+	// peer config-sync. It is INTENTIONALLY not reset by a bare promotion: SyncApply
+	// (and Commit/Load) promote s.active BEFORE the apply runs and, under the #1799
+	// degrade-not-fail doctrine, do NOT roll s.active back when the subsequent apply
+	// FAILS. So a config can be the active tree yet never have converged on the
+	// dataplane. handleConfigSync's active-text convergence shortcut therefore ANDs
+	// ActiveApplied() with its active==incoming check: a promoted-but-unapplied
+	// synced config is NOT treated as converged, so the config high-water does not
+	// advance past it and the primary's same-generation re-push re-attempts the
+	// apply instead of being swallowed as a duplicate (the #4957 fail-open). Because
+	// the marker is keyed on the config text, a stale value can only make the
+	// shortcut MORE conservative (one idempotent re-apply), never falsely converged.
+	appliedDigest string
 }
 
 // New creates a new config store. It fails closed when the .configdb
@@ -729,4 +748,44 @@ func (s *Store) SyncApply(content string, chassisPreserve func(*config.ConfigTre
 
 	s.saveRollbackFiles()
 	return compiled, nil
+}
+
+// configTextDigest returns a stable hex digest of a rendered config's text,
+// whitespace-normalized so it matches the ShowActive()/incoming-text comparison
+// handleConfigSync already performs (both sides are the canonical hierarchical
+// render a primary pushes via ShowActive).
+func configTextDigest(text string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(text)))
+	return hex.EncodeToString(sum[:])
+}
+
+// MarkActiveApplied records that the CURRENT active config has completed a full
+// apply to the dataplane/kernel (#4957). The daemon calls it after a successful
+// applyConfigLocked for the active config — the boot apply, a committed config,
+// and a peer config-sync. It stamps the digest of the active text so a later
+// ActiveApplied() can tell whether the tree that is active NOW is the one that
+// converged. A no-op is safe if active is nil (nothing to have applied).
+func (s *Store) MarkActiveApplied() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active == nil {
+		s.appliedDigest = ""
+		return
+	}
+	s.appliedDigest = configTextDigest(s.active.Format())
+}
+
+// ActiveApplied reports whether the CURRENT active config is the one that most
+// recently completed a full apply (#4957). It is FALSE in the window after active
+// has been promoted (SyncApply/Commit/Load) but before the subsequent apply
+// succeeds — including the #4957 case where a peer-synced config was promoted to
+// active but its apply FAILED and was never rolled back (degrade-not-fail). A nil
+// active, or a never-applied store, reads as not-applied.
+func (s *Store) ActiveApplied() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.active == nil || s.appliedDigest == "" {
+		return false
+	}
+	return s.appliedDigest == configTextDigest(s.active.Format())
 }

--- a/pkg/daemon/config_sync_test.go
+++ b/pkg/daemon/config_sync_test.go
@@ -84,6 +84,12 @@ func TestHandleConfigSync_SkipsWhenConfigAlreadyMatchesActive(t *testing.T) {
 	if _, err := store.Commit(); err != nil {
 		t.Fatalf("Commit: %v", err)
 	}
+	// #4957: the converged shortcut now requires the active config to have been
+	// APPLIED, not merely to match by text (a promoted-but-unapplied synced config
+	// must NOT read as converged). This test commits directly through the store,
+	// bypassing the daemon apply path that stamps the marker, so establish it
+	// explicitly to represent an already-applied active config.
+	store.MarkActiveApplied()
 	active := store.ShowActive()
 	historyLen := len(store.ListHistory())
 

--- a/pkg/daemon/configsync_unapplied_4957_test.go
+++ b/pkg/daemon/configsync_unapplied_4957_test.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// renderSyncedConfigText returns the canonical hierarchical text a cluster
+// primary would push over config-sync for the given flat `set` lines. The
+// primary sends d.store.ShowActive(), so a faithful test must feed the SAME
+// canonical render (not raw set commands) into handleConfigSync, whose
+// convergence shortcut compares against ShowActive().
+func renderSyncedConfigText(t *testing.T, setLines ...string) string {
+	t.Helper()
+	s := newConfigStore(t, filepath.Join(t.TempDir(), "render.db"))
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, line := range setLines {
+		if err := s.SetFromInput(line); err != nil {
+			t.Fatalf("SetFromInput(%q): %v", line, err)
+		}
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return s.ShowActive()
+}
+
+// TestHandleConfigSync_PromotedButUnappliedIsNotConverged is the #4957
+// regression. configstore.SyncApply promotes s.active to the peer config BEFORE
+// applyConfigLocked runs and, under the #1799 degrade-not-fail doctrine, does
+// NOT roll s.active back when the apply FAILS (a transient networkd/nft/IPsec
+// tail error). Before the fix, handleConfigSync's convergence shortcut keyed on
+// active-text equality alone: the primary's same-generation re-push saw
+// active==incoming, returned nil, and the config high-water advanced — treating
+// a config whose dataplane never converged as applied. The standby then acked a
+// generation it never finished applying and could expose stale/disarmed
+// forwarding at failover.
+//
+// The fix ANDs the shortcut with store.ActiveApplied(), a marker stamped ONLY
+// after a fully-successful apply. So a re-push of a promoted-but-unapplied
+// config must fall through and RE-ATTEMPT the apply (reconcile retry) rather
+// than be swallowed as a duplicate.
+//
+// Fail-on-revert: the second sync's assertion that applyConfigLocked is invoked
+// a SECOND time goes RED if the ActiveApplied() gate is removed — the reverted
+// shortcut returns nil on active-text equality and never retries the apply.
+func TestHandleConfigSync_PromotedButUnappliedIsNotConverged(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+
+	var applyCalls int
+	d := &Daemon{
+		// No cluster manager: standalone passes the config-authority guard, and a
+		// standalone (non-cluster) config makes the topology/identity preflights
+		// no-ops. No dataplane: the deferred session invalidation short-circuits.
+		store:    store,
+		applySem: semaphore.NewWeighted(1),
+		// The seam replaces the real reconcile pipeline: count every attempt.
+		applyBodyForTest: func(*config.Config) { applyCalls++ },
+	}
+
+	// A NON-FATAL apply error (not a required-protocol-gate disarm and not a
+	// context abort): the #4957 class. The config stays active + armed,
+	// syncAndApply returns the error, and handleConfigSync returns it so the
+	// high-water does NOT advance and the peer re-pushes the same generation.
+	transient := errors.New("transient networkd tail error")
+
+	// The canonical text a primary pushes for this config.
+	cfgB := renderSyncedConfigText(t, "system host-name synced-b")
+
+	// --- Delivery 1: apply FAILS (transient tail error). ---
+	d.applyErrForTest = transient
+	if err := d.handleConfigSync(cfgB); err == nil {
+		t.Fatal("first sync: expected an error from the failed apply (high-water must not advance)")
+	}
+	if applyCalls != 1 {
+		t.Fatalf("first sync: applyConfigLocked calls = %d, want 1", applyCalls)
+	}
+	// Degrade-not-fail: SyncApply promoted active to B despite the failed apply,
+	// but the config is NOT applied.
+	if store.ShowActive() == "" {
+		t.Fatal("first sync: active should have been promoted to the synced config")
+	}
+	if store.ActiveApplied() {
+		t.Fatal("first sync: a promoted-but-unapplied config must not read as applied")
+	}
+
+	// --- Delivery 2: primary re-pushes the SAME config (same generation). ---
+	// With the fix the shortcut is suppressed (active matches but was never
+	// applied), so the reconcile retry runs. Let the retry succeed this time.
+	d.applyErrForTest = nil
+	if err := d.handleConfigSync(cfgB); err != nil {
+		t.Fatalf("second sync: reconcile retry must succeed, got %v", err)
+	}
+	if applyCalls != 2 {
+		t.Fatalf("second sync: applyConfigLocked calls = %d, want 2 — the reconcile retry "+
+			"must run, NOT be shortcut-as-converged (#4957 fail-on-revert)", applyCalls)
+	}
+	if !store.ActiveApplied() {
+		t.Fatal("second sync: a successfully-applied config must read as applied")
+	}
+
+	// --- Delivery 3: now genuinely converged. A re-push MUST take the shortcut
+	// and not re-apply, else every reconnect re-applies a live config. ---
+	if err := d.handleConfigSync(cfgB); err != nil {
+		t.Fatalf("third sync: converged re-push error = %v", err)
+	}
+	if applyCalls != 2 {
+		t.Fatalf("third sync: applyConfigLocked calls = %d, want 2 — an applied config "+
+			"must take the converged shortcut (no redundant re-apply)", applyCalls)
+	}
+}

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -122,6 +122,19 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 	// context — byte-identical to the pre-#2926 behavior.
 	if err := d.applyConfigLocked(context.Background(), cfg); err != nil {
 		slog.Warn("apply config failed", "err", err)
+		return
+	}
+	// #4957: the active config completed a full apply through the boot /
+	// background (DHCP callback, feed, config-poll, in-process CLI commit,
+	// rollback) path. Stamp it applied so a peer config-sync of the same text
+	// takes handleConfigSync's converged shortcut instead of pointlessly
+	// re-applying an already-live config on every reconnect (the config
+	// high-water resets on reconnect, so the primary re-pushes the current
+	// generation even when nothing changed). A FAILED apply above returns
+	// early and leaves the prior digest, so a config that never converged is
+	// never marked applied — the same #4957 invariant handleConfigSync relies on.
+	if d.store != nil {
+		d.store.MarkActiveApplied()
 	}
 }
 
@@ -474,7 +487,17 @@ func (d *Daemon) applyAndSyncCommitted(oldActive, compiled *config.Config, syncP
 	if syncPeer {
 		d.pushCommittedConfigToPeer()
 	}
-	return compiled, errors.Join(applyErr, clearErr)
+	joined := errors.Join(applyErr, clearErr)
+	// #4957: a fully-successful commit apply (no fatal apply error, no partial
+	// session-invalidation) means the committed active config has converged on the
+	// dataplane. Stamp it applied so that if THIS node later becomes secondary and
+	// the new primary syncs this same config back, handleConfigSync's converged
+	// shortcut recognizes it without a redundant re-apply. A non-nil joined error
+	// leaves the prior digest — the config did not fully converge.
+	if joined == nil && d.store != nil {
+		d.store.MarkActiveApplied()
+	}
+	return compiled, joined
 }
 
 // applyErrSkipsPeerSync reports whether an applyConfigLocked error means the

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -549,8 +549,19 @@ func (d *Daemon) handleConfigSync(configText string) error {
 	if d.store != nil {
 		activeText := strings.TrimSpace(d.store.ShowActive())
 		incomingText := strings.TrimSpace(configText)
-		if activeText == incomingText {
-			slog.Info("cluster: skipping config sync apply (config already matches active)",
+		// #4957: the shortcut requires BOTH that the incoming config is the active
+		// tree AND that the active tree actually completed its apply. SyncApply
+		// promotes s.active BEFORE applyConfigLocked and (per the #1799
+		// degrade-not-fail doctrine) does NOT roll it back on a non-fatal apply
+		// failure, so active-text equality alone would treat a promoted-but-
+		// UNAPPLIED config as converged: the primary's same-generation re-push
+		// would take this fast path, return nil, and advance the config high-water
+		// past a config whose dataplane never converged (a stale/disarmed standby
+		// that reports the generation applied — visible at failover). Gating on
+		// ActiveApplied() lets a re-push of a config whose prior apply failed fall
+		// through to syncAndApply and RE-ATTEMPT the apply instead.
+		if activeText == incomingText && d.store.ActiveApplied() {
+			slog.Info("cluster: skipping config sync apply (config already matches active and is applied)",
 				"size", len(configText))
 			// Already converged to this config — a nil return lets the
 			// high-water advance so a duplicate re-push is correctly skipped.
@@ -567,6 +578,14 @@ func (d *Daemon) handleConfigSync(configText string) error {
 	if _, err := d.syncAndApply(context.Background(), configText, nil); err != nil {
 		slog.Error("cluster: config sync apply failed", "err", err)
 		return err
+	}
+	// #4957: the sync applied to completion (syncAndApply returned nil, so both
+	// the dataplane apply and the session invalidation succeeded). Record the
+	// active config as applied so a duplicate re-push takes the converged
+	// shortcut above — and, conversely, so a config that only PROMOTED active but
+	// failed to apply does NOT, keeping the high-water pinned until a retry lands.
+	if d.store != nil {
+		d.store.MarkActiveApplied()
 	}
 	slog.Info("cluster: config sync applied successfully")
 	return nil


### PR DESCRIPTION
## Problem (#4957, High)

`handleConfigSync`'s active-text convergence shortcut treated a config that
`configstore.SyncApply` promoted to `s.active` but whose `applyConfigLocked`
**failed** as converged — advancing the HA config high-water past a config the
dataplane never finished applying.

`SyncApply` promotes `s.active` to the peer config **before** the daemon runs
`applyConfigLocked`, and under the #1799 degrade-not-fail doctrine does **not**
roll `s.active` back on an apply failure (a transient networkd/nft/IPsec tail
error). So the store's active text equals the incoming text even though the
config never converged. The shortcut keyed on active-text equality alone:

- Delivery N promotes C1 → `applyConfigLocked` fails → high-water stays N-1.
- Primary re-pushes the **same** generation → `activeText == incomingText` →
  returns nil → high-water advances to N.
- The M-2/#4151 reconcile retry is defeated; the standby acks a generation it
  never applied → stale/disarmed forwarding at failover.

## Fix (option c — least-invasive, respects degrade-not-fail)

Add an applied-config marker to the store, keyed on the active config **text**,
stamped **only** after a fully-successful apply, and AND the shortcut with it.

- `configstore`: `MarkActiveApplied` / `ActiveApplied` (+ `configTextDigest`).
  `ActiveApplied()` is FALSE in the window between a promotion and a successful
  apply, so a promoted-but-unapplied config never reads as converged. Text-keyed
  ⇒ a stale value can only cause one idempotent re-apply, never a false
  convergence.
- `daemon`: `handleConfigSync` gates the shortcut on `ActiveApplied()` and stamps
  the marker only after `syncAndApply` returns nil (full apply + full session
  invalidation). A re-push of a failed-apply config now falls through and
  **re-attempts** the apply.
- `daemon`: `applyConfig` (boot/DHCP/feed/rollback) and `applyAndSyncCommitted`
  (operator commit) also stamp on success, so an already-applied config still
  takes the shortcut on a reconnect (which zeroes the generation high-water)
  instead of re-applying a live config, and a post-failover role flip does not
  spuriously re-apply.

Did **not** roll back `s.active` on apply error — that fights the
degrade-not-fail store-converges-to-peer design and the #5564 `armedActive`
invalidator (which reads `s.active`). Does not touch `lastAppliedConfigGen`; the
just-merged #5274 config-epoch guard is unaffected and in fact strengthened (the
high-water now advances only when a config truly applied).

## Tests

- `TestHandleConfigSync_PromotedButUnappliedIsNotConverged` — **fail-on-revert**:
  sync with a failing apply, then re-sync the same text, asserting the reconcile
  retry runs (`applyConfigLocked calls == 2`). Dropping the `ActiveApplied()`
  gate makes the second sync take the buggy shortcut (`calls == 1`) → RED
  (**confirmed firsthand**).
- `TestActiveApplied_TracksPromotionVsApply` — store-contract test.
- `TestHandleConfigSync_SkipsWhenConfigAlreadyMatchesActive` — updated to the
  applied-not-just-active contract.

Docs: `docs/sync-protocol.md` (convergence shortcut + #5564 tail),
`pkg/configstore/README.md` (new API).

## Validation

`go build ./...`; `go test ./pkg/configstore/... ./pkg/daemon/... ./pkg/cluster/...`
green; `go vet` clean. HA config-sync change → parent should run
`make test-failover` before merge.

Closes #4957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDnPeHmytykdea5wmSwefv