### PR TITLE
userspace-dp/tunnel: correct stale peer-import comment on local-origin GRE session seed (#6224)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-07-22 — #6224: correct stale "peer-seeded import" comment on the local-origin GRE session-seed path
+
+- **Timestamp**: 2026-07-22 (fix/6224-tunnel-syncimport-timeout)
+- **Action**: verify-then-fix-or-close. Adversarially confirmed that
+  `build_local_origin_tunnel_tx_request` (tunnel.rs:583) is the LOCAL-ORIGIN
+  (host-outbound) GRE encapsulation path, not a peer HA-sync import: it runs
+  no security policy / application match (`resolve_tunnel_forwarding_resolution`
+  is route/next-hop/neighbor only; `policy_id: 0` hardcoded), so there is NO
+  admitting application to source a per-app `inactivity_timeout_ns` from. The
+  `None` (global per-protocol timeout) is functionally and Junos-correct. The
+  defect is only the misleading comment block (copy-pasted the
+  #2508/#3056/#3227/#3073 "peer-seeded import ... does not cross the HA wire
+  yet" rationale onto a path that is not a wire path at all). Rewrote the
+  comment to state the real reason; added a contract-pinning test
+  (`local_origin_tunnel_session_uses_global_timeout_no_policy_match_6224`) that
+  goes RED if a future change stamps a bogus per-app timeout / non-zero policy
+  attribution on this path. No code-behavior change; no wire change.
+- **File(s)**: userspace-dp/src/afxdp/tunnel.rs,
+  userspace-dp/src/afxdp/frame/tests_native_gre_ecn.rs,
+  userspace-dp/src/session/README.md
+
 ## 2026-07-22 — #5274: HA session-sync config-epoch guard (stale permit across the HA boundary)
 
 - **Timestamp**: 2026-07-22 (fix/5274-ha-session-config-epoch)

--- a/userspace-dp/src/afxdp/frame/tests_native_gre_ecn.rs
+++ b/userspace-dp/src/afxdp/frame/tests_native_gre_ecn.rs
@@ -264,6 +264,67 @@ fn local_origin_tunnel_tx_request_encapsulates_raw_ip_for_active_owner() {
 }
 
 
+// #6224: the LOCAL-ORIGIN (host-outbound) GRE encapsulation path runs no
+// security policy / application match — `resolve_tunnel_forwarding_resolution`
+// is route/next-hop/neighbor resolution only, and Junos runs no security
+// policy on firewall-self-originated traffic. There is therefore no admitting
+// application to source a per-application `inactivity_timeout_ns` from (nor an
+// admitting policy for `policy_id` / the hit-counter handle). The correct value
+// is `None`, so `session_timeout_ns` ages the session on the GLOBAL
+// per-protocol timeout. This pins that contract: it goes RED if a future change
+// stamps a bogus per-app timeout (or a non-zero policy attribution) onto this
+// path — the exact mis-"fix" the #6224 stale comment invited. The reverse
+// companion is checked for consistency: it inherits the forward's `None`
+// (#5153/#6223 builder), so both halves stay on the global timeout — this is
+// NOT the #5153 forward-has-value / reverse-hardcoded-None inconsistency.
+#[test]
+fn local_origin_tunnel_session_uses_global_timeout_no_policy_match_6224() {
+    let state = build_forwarding_state(&native_gre_snapshot(true));
+    let ha_state = BTreeMap::from([(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let packet = build_icmp_echo_frame_v4(
+        Ipv4Addr::new(10, 255, 192, 42),
+        Ipv4Addr::new(10, 255, 192, 41),
+        64,
+    );
+    let plan = build_local_origin_tunnel_tx_request(
+        &packet[14..],
+        1,
+        &state,
+        &ha_state,
+        &dynamic_neighbors,
+    )
+    .expect("local-origin tunnel tx request");
+
+    // Forward half: no admitting application/policy on the local-origin path.
+    assert_eq!(
+        plan.session_entry.metadata.inactivity_timeout_ns, None,
+        "local-origin GRE session must age on the global per-protocol timeout \
+         (no admitting application to source a per-app idle timeout)"
+    );
+    assert_eq!(
+        plan.session_entry.metadata.policy_id, 0,
+        "local-origin GRE session runs no policy match (no admitting policy ID)"
+    );
+    assert!(
+        plan.session_entry.metadata.policy_counter.is_none(),
+        "local-origin GRE session runs no policy match (no hit-counter handle)"
+    );
+
+    // Reverse companion: consistent with the forward half (both None). NOT the
+    // #5153 shape (forward real value / reverse hardcoded None).
+    let reverse = plan
+        .reverse_session_entry
+        .as_ref()
+        .expect("active owner synthesizes a reverse companion");
+    assert!(reverse.metadata.is_reverse);
+    assert_eq!(
+        reverse.metadata.inactivity_timeout_ns, None,
+        "reverse companion inherits the forward half's global timeout"
+    );
+}
+
+
 #[test]
 fn local_origin_tunnel_tx_request_rejects_inactive_owner() {
     let state = build_forwarding_state(&native_gre_snapshot(true));

--- a/userspace-dp/src/afxdp/tunnel.rs
+++ b/userspace-dp/src/afxdp/tunnel.rs
@@ -570,20 +570,33 @@ pub(super) fn build_local_origin_tunnel_tx_request(
             fabric_ingress: false,
             is_reverse: false,
             nat64_reverse: None,
-            // #2508: tunnel sync-import sessions carry no local per-policy
-            // `then log` selection (see server/helpers.rs note).
+            // #6224: this is the LOCAL-ORIGIN (host-outbound) GRE encapsulation
+            // path — the firewall's own kernel-routed traffic read off the TUN
+            // device (`local_tunnel_source_loop`), NOT a peer HA-sync import.
+            // `resolve_tunnel_forwarding_resolution` does route/next-hop/neighbor
+            // resolution ONLY; no security policy or application term is matched
+            // here (Junos runs no security policy on firewall-self-originated
+            // traffic). There is therefore no admitting policy/application to
+            // source the per-policy `then log` selection, the policy ID, the
+            // per-application idle timeout, or the hit-counter handle from.
+            // Zeroed policy fields and the global per-protocol idle timeout
+            // (`inactivity_timeout_ns: None` -> `session_timeout_ns` falls back
+            // to the per-protocol default) are the correct values for
+            // self-originated traffic; a per-app timeout would only differ if an
+            // admitting application existed, which it does not. The
+            // `origin: SessionOrigin::SyncImport` tag below is an install-path
+            // plumbing artifact (it reaches the uncapped coordinator-authoritative
+            // install path, see session_glue/mod.rs), NOT a peer wire import.
+            //
+            // (The earlier #2508/#3056/#3227/#3073 comments here mis-described
+            // this path as "peer-seeded import ... does not cross the HA wire
+            // yet". The real peer-import path — server/helpers.rs — DOES stamp
+            // all of these from `SessionSyncRequest` post-#3301; this path is
+            // simply not a wire path, so nothing crosses to read.)
             log_session_init: false,
             log_session_close: false,
-            // #3056: tunnel sync-import sessions are seeded from the peer, which
-            // ran the admitting policy; the local policy ID is unknown here.
             policy_id: 0,
-            // #3227: peer-seeded import; the per-app idle timeout does not
-            // cross the HA wire yet, so age on the global timeout until a
-            // real-traffic refresh re-stamps it.
             inactivity_timeout_ns: None,
-            // #3073: peer-seeded import; the hit-counter handle does not cross
-            // the HA wire yet, so this flow counts nothing locally until a
-            // real-traffic re-evaluation re-stamps a handle.
             policy_counter_idx: 0,
             policy_counter: None,
         },

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -99,6 +99,19 @@ failover without waiting for a real-traffic refresh. An old peer omits the
 field (`serde(default)` 0 → `None` → the global timeout), bit-identical to
 pre-#3301 (rolling-upgrade safe).
 
+**Not every `SyncImport` entry is a wire import (#6224).** The local-origin
+GRE encapsulation path (`build_local_origin_tunnel_tx_request`, tunnel.rs)
+seeds a session for the firewall's OWN kernel-routed traffic read off a TUN
+device and tags it `SessionOrigin::SyncImport` purely to reach the uncapped
+coordinator-authoritative install path — it is not a peer wire import and has
+no `SessionSyncRequest`. That path runs no security policy / application match
+(forwarding-only resolution; `policy_id: 0`), so there is no admitting
+application to source a per-app `inactivity_timeout_ns` from: it correctly
+stamps `None` (the global per-protocol timeout) rather than reading the wire
+override, and its synthesized reverse companion inherits that `None`. This is
+the correct value for self-originated traffic, not the #5153 forward-has-value
+/ reverse-hardcoded-`None` inconsistency.
+
 **TCP opening / half-open state (#3152).** A TCP session created by a
 bare SYN (SYN set, ACK clear) starts in the OPENING (half-open) state
 (`SessionEntry.established == false`) and is reaped on the short


### PR DESCRIPTION
## Summary — verify-then-fix-or-close (#6224)

`build_local_origin_tunnel_tx_request` (`userspace-dp/src/afxdp/tunnel.rs`) hardcodes `inactivity_timeout_ns: None` under a `#3227` comment: *"peer-seeded import; the per-app idle timeout does not cross the HA wire yet."* A #6223/#5153 hostile reviewer flagged this as the analogous per-app-timeout drop to the reverse-companion bug, assuming this is a peer HA-sync import that could read the synced timeout.

**Verification (independently, adversarially confirmed) shows the comment is wrong, not the code — this is the issue's own option 3.**

## Finding

- **Not a peer import — it's the LOCAL-ORIGIN (host-outbound) GRE path.** The only caller is `local_tunnel_source_loop`, spawned as the *"GRE local-origin thread"* (`coordinator/tunnel_supervision.rs`), reading the firewall's own kernel-routed traffic off a TUN device. There is no `SessionSyncRequest` anywhere on this path. The `origin: SessionOrigin::SyncImport` tag is an install-path plumbing artifact (it reaches the uncapped coordinator-authoritative install path), not a peer wire import — the README already classifies "tunnel decap" as a local-origin, generation-0 entry.
- **No policy/application match runs here.** `resolve_tunnel_forwarding_resolution` is route/next-hop/neighbor resolution only, and `policy_id` is hardcoded `0`. The per-application inactivity timeout is a property of the policy-matched application (`PolicyEvaluationResult.inactivity_timeout`, resolved only inside `try_match_rule`); there is no standalone tuple→timeout resolver. Junos runs no security policy on firewall-self-originated traffic, so there is **no admitting application** to source a per-app timeout (or policy ID, log selection, or hit-counter handle) from.
- **`None` is correct.** `session_timeout_ns` falls back to the global per-protocol timeout when the override is `None`; a per-app value would only differ if an admitting application existed, which it does not. The synthesized reverse companion inherits the forward's `None` (#5153/#6223 builder), so both halves stay consistent — this is **not** the #5153 forward-has-value / reverse-hardcoded-`None` inconsistency.
- The **real** peer-import path (`server/helpers.rs`) *does* stamp all of these from `SessionSyncRequest` post-#3301, so *"does not cross the HA wire yet"* is doubly wrong here. The stale framing had contaminated the whole `SessionMetadata` comment block (#2508 log selection, #3056 policy_id, #3227 timeout, #3073 counter).

## Change

- Rewrite the misleading comment block to state the real reason (local-origin / host-outbound GRE — no policy match ⇒ no admitting application/policy/log/counter; zeroed policy fields and the global timeout are correct). **No code-behavior change; no wire change.**
- Add `local_origin_tunnel_session_uses_global_timeout_no_policy_match_6224` (`tests_native_gre_ecn.rs`) pinning the contract: the local-origin plan's forward and reverse halves both carry `inactivity_timeout_ns: None`, `policy_id: 0`, and no counter handle. It goes **RED** if a future change stamps a bogus per-app timeout or non-zero policy attribution on this path (verified firsthand: injecting `Some(30s)` fails it — `left: Some(30000000000)` / `right: None` — then reverted).
- `session/README.md`: note that not every `SessionOrigin::SyncImport` entry is a wire import.

## Validation

- `cargo build` clean (pre-existing warnings only).
- `cargo test --release` green including the new test (4092/4093; the one failure, `wg_encap_frame_resolves_outer_route_once_v4`, is a **pre-existing parallel-test race** on the shared global `OUTER_ROUTE_RESOLVE_COUNT` atomic in unrelated WireGuard code — passes in isolation; the GRE path this PR touches never increments that counter).
- Firsthand RED-on-inject confirmed then reverted.
- No Go/wire change — `protocol_wire_v1` untouched, so no HA session-sync surface is affected.

Closes #6224
