### PR TITLE
userspace-dp: budget + resume the conntrack last-seen refresh across ticks (#5287)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-22 — #5287: budget + resume the conntrack last_seen refresh
+
+- **Timestamp**: 2026-07-22 (fix/5287-conntrack-refresh-budget)
+- **Action**: Converted `refresh_bpf_conntrack_last_seen` from a full-table
+  single pass (2 syscalls per forward entry, up to 131072 entries in one
+  uninterrupted burst between RX/TX polls — a periodic latency spike on the
+  low-latency worker core) into an incremental, budgeted, resumable slice.
+  - **Primitive**: added `SessionTable::iter_with_idle_budgeted(cursor, budget,
+    now, f) -> next_cursor` — walks the `entries` slab by STABLE integer
+    handle, examines at most `budget` slots from `cursor`, returns the next
+    cursor (0 on cycle completion). No allocation, no atomics.
+  - **Refresh**: `refresh_bpf_conntrack_last_seen` now takes `(cursor, budget)`
+    and returns the next cursor; closure body unchanged.
+  - **Driver**: the worker loop keeps a persistent `ct_refresh_cursor`, drives
+    one slice per `CT_SLICE_INTERVAL_NS` (100ms) with budget
+    `CT_REFRESH_SLICE_BUDGET` (2048), and paces successive full-table CYCLES to
+    `CT_REFRESH_WINDOW_NS` (10s) so small/idle tables are not over-refreshed
+    (steady-state syscall rate unchanged from the old 10s cadence). At the
+    131072 cap a full cycle spans ~64 slices (~6.4s ≤ 10s window).
+  - **Tests (FAIL-ON-REVERT, assertion-based)**:
+    `session::tests::iter_with_idle_budgeted_bounds_and_resumes_full_coverage`
+    (≤budget per slice, resumes >1 slice, full coverage in one cycle) and
+    `afxdp::bpf_map::tests::refresh_bpf_conntrack_last_seen_is_budgeted_across_slices`
+    (production function: first slice returns cursor==budget, cycle spans >1
+    slice). Verified firsthand: neutralizing the budget to a single pass
+    reddens both via assertion (not build break); restored.
+  - **Validation**: `cargo build` green; full `cargo test --release` green.
+  **File(s)**: userspace-dp/src/session/lookup.rs,
+  userspace-dp/src/afxdp/bpf_map/mod.rs,
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+  userspace-dp/src/session/tests.rs,
+  userspace-dp/src/afxdp/bpf_map_tests.rs,
+  userspace-dp/src/session/README.md
+
 ## 2026-07-22 — #5274: HA session-sync config-epoch guard (stale permit across the HA boundary)
 
 - **Timestamp**: 2026-07-22 (fix/5274-ha-session-config-epoch)

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -372,7 +372,14 @@ pub(super) fn delete_bpf_conntrack_entry(
 /// `last_seen` will NOT cause premature expiry. This refresh is purely for
 /// diagnostic accuracy.
 ///
-/// Called from the worker loop piggy-backing on the session GC interval (~1s).
+/// #5287: this is an INCREMENTAL, budgeted slice — NOT a full-table pass. It
+/// refreshes at most `budget` slab slots starting at `cursor` and returns the
+/// next cursor for the following slice (0 once a full-table cycle completes).
+/// The worker loop drives one slice per ~100ms and paces successive cycles to
+/// the ~10s freshness window, so the whole table still gets refreshed within
+/// that window but the per-tick cost is hard-bounded instead of the old
+/// tens-of-thousands-of-syscalls single burst that stalled the low-latency
+/// core. See `SessionTable::iter_with_idle_budgeted` and the worker loop.
 ///
 /// #3395: `policy` is the CURRENT snapshot's `PolicyState`. For every refreshed
 /// forward entry the live-row `policy_id` is RE-RESOLVED from the session's
@@ -390,10 +397,12 @@ pub(super) fn refresh_bpf_conntrack_last_seen(
     sessions: &crate::session::SessionTable,
     policy: &crate::policy::PolicyState,
     now_ns: u64,
-) {
+    cursor: usize,
+    budget: usize,
+) -> usize {
     let now_secs = now_ns / 1_000_000_000;
 
-    sessions.iter_with_idle(now_ns, |key, _decision, metadata, idle_ns, counters| {
+    sessions.iter_with_idle_budgeted(cursor, budget, now_ns, |key, _decision, metadata, idle_ns, counters| {
         // Only refresh forward entries — reverse entries mirror the forward.
         // #2501: the forward SessionEntry carries BOTH directions' counters
         // (the reverse entry shares them via the canonical forward key the
@@ -489,7 +498,7 @@ pub(super) fn refresh_bpf_conntrack_last_seen(
             }
             _ => {}
         }
-    });
+    })
 }
 
 pub(super) fn publish_session_map_entry_for_session(

--- a/userspace-dp/src/afxdp/bpf_map_tests.rs
+++ b/userspace-dp/src/afxdp/bpf_map_tests.rs
@@ -415,3 +415,103 @@ fn build_conntrack_value_stamps_stable_session_id_v6() {
         "v6 conntrack mirror must carry the stable session id, not 0"
     );
 }
+
+// #5287 FAIL-ON-REVERT: `refresh_bpf_conntrack_last_seen` is an INCREMENTAL,
+// budgeted slice — NOT a full-table pass. It must advance a persistent cursor
+// by at most `budget` slab slots per call and resume across calls, so no single
+// packet-loop tick walks the whole table (the old behaviour did tens of
+// thousands of synchronous BPF syscalls between two RX/TX polls, spiking
+// latency near the 131072-entry cap).
+//
+// With fd=-1 no BPF syscalls run, but the walk still advances the cursor, so
+// the budget/continuation contract is observable directly: the first slice from
+// the top returns a cursor advanced by EXACTLY the budget (it does not wrap to 0
+// while the table still has unwalked slots), and draining a full cycle takes
+// MORE THAN ONE slice. Reverting the refresh to the unbounded single-pass scan
+// makes the first call walk the whole table and wrap to 0 -> the `== BUDGET`
+// assertion reddens.
+#[test]
+fn refresh_bpf_conntrack_last_seen_is_budgeted_across_slices() {
+    use crate::session::SessionTable;
+    let mut table = SessionTable::new();
+    const N: usize = 40;
+    const BUDGET: usize = 8;
+    assert!(N > BUDGET, "test only meaningful when the table exceeds one slice");
+
+    let install_time = 1_000_000_000u64;
+    for i in 0..N {
+        let key = SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: 6,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            src_port: 10_000 + i as u16, // distinct 5-tuples -> distinct forward entries
+            dst_port: 443,
+        };
+        let decision = SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::ForwardCandidate,
+                local_ifindex: 0,
+                egress_ifindex: 12,
+                tx_ifindex: 12,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1))),
+                neighbor_mac: Some([0, 1, 2, 3, 4, 5]),
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision::default(),
+        };
+        let metadata = SessionMetadata {
+            ingress_zone: TEST_LAN_ZONE_ID,
+            egress_zone: TEST_WAN_ZONE_ID,
+            owner_rg_id: 1,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+            log_session_init: false,
+            log_session_close: false,
+            policy_id: 0,
+            inactivity_timeout_ns: None,
+            policy_counter_idx: 0,
+            policy_counter: None,
+        };
+        assert!(table.install_with_protocol(key, decision, metadata, install_time, 6, 0x10));
+    }
+
+    let policy = crate::policy::PolicyState::default();
+    let now = install_time + 5_000_000_000;
+
+    // First slice from the top: cursor advances by EXACTLY the budget and does
+    // NOT wrap (the table still has N - BUDGET unwalked slots). fd=-1 => no BPF
+    // I/O, but the cursor bookkeeping is exercised.
+    let c1 = refresh_bpf_conntrack_last_seen(-1, -1, &table, &policy, now, 0, BUDGET);
+    assert_eq!(
+        c1, BUDGET,
+        "first slice must be bounded to the budget, not a full single-pass scan"
+    );
+
+    // Draining a full cycle takes >1 slice; each returned cursor advances by at
+    // most BUDGET until it wraps to 0.
+    let mut cursor = c1;
+    let mut slices = 1usize;
+    for _ in 0..1024 {
+        let next = refresh_bpf_conntrack_last_seen(-1, -1, &table, &policy, now, cursor, BUDGET);
+        slices += 1;
+        if next != 0 {
+            assert!(
+                next.saturating_sub(cursor) <= BUDGET,
+                "slice advanced {} past budget {BUDGET}",
+                next.saturating_sub(cursor),
+            );
+        }
+        cursor = next;
+        if cursor == 0 {
+            break; // full-table cycle completed
+        }
+    }
+    assert!(
+        slices > 1,
+        "full table must span more than one budgeted slice, got {slices}"
+    );
+}

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -254,11 +254,33 @@ pub(crate) fn worker_loop(
     #[cfg(feature = "debug-log")]
     let mut stall_reported = false;
     const DBG_REPORT_INTERVAL_NS: u64 = 1_000_000_000; // 1 second
-    // Throttle for BPF conntrack last_seen refresh (~10s).
-    // Keeps `show security flow session` idle times accurate without
-    // per-second syscall overhead per session.  See issue #333.
-    const CT_REFRESH_INTERVAL_NS: u64 = 10_000_000_000;
-    let mut last_ct_refresh_ns: u64 = 0;
+    // BPF conntrack last_seen refresh (#333, made incremental in #5287).
+    // Keeps `show security flow session` idle times / volume accurate without
+    // per-second syscall overhead per session.
+    //
+    // #5287: the refresh is now a budgeted, resumable slice instead of one
+    // full-table pass. Near the 131072-entry cap the old single pass did a BPF
+    // lookup + update per forward entry (tens of thousands of synchronous
+    // kernel crossings) between two RX/TX polls — a deterministic per-interval
+    // latency spike on this low-latency core. Now each slice refreshes at most
+    // CT_REFRESH_SLICE_BUDGET slab slots from a persistent cursor
+    // (`ct_refresh_cursor`) and resumes on the next slice, at CT_SLICE_INTERVAL_NS
+    // cadence, with RX/TX/heartbeat interleaved between slices. Successive
+    // full-table CYCLES are paced to CT_REFRESH_WINDOW_NS so a small or idle
+    // table is not over-refreshed (steady-state syscall rate is unchanged from
+    // the old 10s full-table cadence). Freshness/latency tradeoff: at the
+    // 131072 default cap and 100ms cadence a full cycle spans ~64 slices
+    // (~6.4s <= the 10s window); if `max_sessions` is raised far above the
+    // default a cycle stretches past the window (freshness degrades gracefully),
+    // but the per-slice cost stays hard-bounded at CT_REFRESH_SLICE_BUDGET — no
+    // single tick ever stalls the core again.
+    const CT_REFRESH_WINDOW_NS: u64 = 10_000_000_000; // full-table freshness target
+    const CT_SLICE_INTERVAL_NS: u64 = 100_000_000; // 100ms between slices
+    const CT_REFRESH_SLICE_BUDGET: usize = 2048; // max slab slots per slice
+    let mut last_ct_slice_ns: u64 = 0;
+    let mut ct_cycle_start_ns: u64 = 0;
+    // Persistent slab-index cursor: 0 means "between cycles / at the top".
+    let mut ct_refresh_cursor: usize = 0;
     // #869: worker-runtime telemetry.  Local counters, published to
     // `runtime_atomics` on the ~1s cadence below.
     use crate::afxdp::worker_runtime::{
@@ -788,12 +810,29 @@ pub(crate) fn worker_loop(
                     .fetch_add(local_expired, Ordering::Relaxed);
             }
         }
-        // Periodically refresh last_seen in BPF conntrack entries so Go-side
+        // Incrementally refresh last_seen in BPF conntrack entries so Go-side
         // callers of IterateSessions (CLI, gRPC, Prometheus) see accurate
-        // session idle times.  Issue #333.
-        if loop_now_ns.saturating_sub(last_ct_refresh_ns) >= CT_REFRESH_INTERVAL_NS {
-            last_ct_refresh_ns = loop_now_ns;
-            refresh_bpf_conntrack_last_seen(
+        // session idle times.  Issue #333; budgeted/resumable per #5287.
+        //
+        // #5287: drive at most one budgeted slice per CT_SLICE_INTERVAL_NS.
+        // `should_slice` is true while a cycle is in flight (cursor != 0, keep
+        // draining the table) OR once the freshness window has elapsed since the
+        // last cycle started (time to begin a fresh cycle). The `&&` short-
+        // circuits on the cheap cursor compare in the common between-cycles idle
+        // case, so the per-tick cost stays one integer compare plus one u64
+        // subtract — no allocation, no regression to the empty/idle table.
+        let should_slice = ct_refresh_cursor != 0
+            || loop_now_ns.saturating_sub(ct_cycle_start_ns) >= CT_REFRESH_WINDOW_NS;
+        if should_slice
+            && loop_now_ns.saturating_sub(last_ct_slice_ns) >= CT_SLICE_INTERVAL_NS
+        {
+            last_ct_slice_ns = loop_now_ns;
+            // Stamp the cycle start on the FIRST slice of a cycle (cursor at the
+            // top) so successive cycles are paced to the freshness window.
+            if ct_refresh_cursor == 0 {
+                ct_cycle_start_ns = loop_now_ns;
+            }
+            ct_refresh_cursor = refresh_bpf_conntrack_last_seen(
                 conntrack_v4_fd,
                 conntrack_v6_fd,
                 &sessions,
@@ -801,6 +840,8 @@ pub(crate) fn worker_loop(
                 // current rule table from the session's bound rule handle.
                 &forwarding.policy,
                 loop_now_ns,
+                ct_refresh_cursor,
+                CT_REFRESH_SLICE_BUDGET,
             );
         }
         // Check if fabric links were updated by the coordinator (e.g. after

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -438,16 +438,58 @@ reverse→forward. No allocation, no atomic, no cross-core traffic.
 
 Surfacing (no new wire field):
 
-- `refresh_bpf_conntrack_last_seen` (afxdp/bpf_map, ~1s GC cadence) writes
-  the counters into the BPF conntrack map value, so `show security flow
-  session` reports live volume (Go reads `FwdBytes`/`FwdPackets`/… from
-  that map today);
+- `refresh_bpf_conntrack_last_seen` (afxdp/bpf_map, budgeted slice — see
+  "Budgeted last_seen refresh" below) writes the counters into the BPF
+  conntrack map value, so `show security flow session` reports live volume
+  (Go reads `FwdBytes`/`FwdPackets`/… from that map today);
 - the close `SessionDelta` snapshots the entry's counters at expiry, and
   `emit_session_close_rt_flow` writes them into the SESSION_CLOSE RT_FLOW
   frame's already-reserved `[56:64]`/`[64:72]` (forward) and
   `[112:120]`/`[120:128]` (reverse) wire slots — the slots the Go
   `logging.DecodeRawEventRecord` already parses (previously hard-zeroed),
   so NetFlow/IPFIX close records carry real volume.
+
+## Budgeted last_seen refresh (#5287)
+
+`refresh_bpf_conntrack_last_seen` mirrors each forward session's `last_seen`,
+`policy_id` and byte/packet counters into the BPF conntrack map so the Go
+`IterateSessions` surfaces (CLI, gRPC, Prometheus) read accurate idle time and
+volume. It does one BPF `lookup + update` per forward entry.
+
+The refresh used to walk the WHOLE table in one uninterrupted pass. Near the
+`DEFAULT_MAX_SESSIONS` (131072) cap that is tens of thousands of synchronous
+kernel crossings executed between two RX/TX polls — a deterministic
+per-interval latency spike on the low-latency worker core, exactly under the
+high-session load where service and heartbeat stability matter (issue #5287).
+
+It is now an **incremental, budgeted slice** driven by
+`SessionTable::iter_with_idle_budgeted`:
+
+- **Persistent cursor.** The cursor is a stable `entries` slab index (slab
+  handles do not renumber across insert/remove — a removed slot goes vacant and
+  is reused). The worker loop keeps it in `ct_refresh_cursor` and passes it back
+  each slice, so the walk resumes exactly where it stopped.
+- **Hard per-slice budget.** Each slice examines at most `CT_REFRESH_SLICE_BUDGET`
+  (2048) slab slots — bounding BOTH the index scan and the per-entry syscalls,
+  regardless of the occupied/vacant/forward/reverse mix. No allocation; the
+  per-tick added cost is one integer compare plus one `saturating_sub` in the
+  common between-cycles idle case.
+- **Window-paced cycles.** The worker drives one slice per `CT_SLICE_INTERVAL_NS`
+  (100ms) while a cycle is in flight, and paces successive full-table CYCLES to
+  `CT_REFRESH_WINDOW_NS` (10s). A small or idle table is walked in one short
+  slice per 10s — the steady-state syscall rate is unchanged from the old 10s
+  full-table cadence, so the common case is not regressed.
+
+**Freshness/latency tradeoff.** At the 131072 default cap and 100ms cadence a
+full cycle spans ~64 slices (~6.4s ≤ the 10s freshness window), so the whole
+table is still refreshed within the window. If `max_sessions` is raised far
+above the default a cycle stretches past 10s (freshness degrades gracefully),
+but the per-slice cost stays hard-bounded at `CT_REFRESH_SLICE_BUDGET` — no
+single loop tick ever walks the whole table again. Because a session installed
+into an already-passed slot mid-cycle isn't re-visited until the next cycle,
+freshness is best-effort diagnostic (the entry already gets `last_seen` stamped
+at install via `publish_bpf_conntrack_entry`; the Go GC has `SkipSweep` set, so
+a stale `last_seen` never causes premature expiry).
 
 ## Standby retention (#2120)
 
@@ -825,10 +867,11 @@ maps that `rule_id` to its CURRENT positional id via an O(1) per-snapshot
 `rule_id → policy_id` map and is called at the two LOCAL publish surfaces where
 the value is otherwise frozen:
 
-1. **Live-session rows** — `refresh_bpf_conntrack_last_seen` (~1s GC cadence)
-   re-stamps the BPF conntrack value's `policy_id` from the bound handle against
-   the current `PolicyState`. (SESSION_CREATE is emitted at install, where the
-   positional id is already correct — no re-resolution needed.)
+1. **Live-session rows** — `refresh_bpf_conntrack_last_seen` (budgeted slice —
+   see "Budgeted last_seen refresh" below) re-stamps the BPF conntrack value's
+   `policy_id` from the bound handle against the current `PolicyState`.
+   (SESSION_CREATE is emitted at install, where the positional id is already
+   correct — no re-resolution needed.)
 2. **RT_FLOW SESSION_CLOSE** — `flush_session_deltas` re-resolves and passes the
    id to `emit_session_close_rt_flow` (the close path already holds
    `forwarding.policy`, so this needs no new plumbing). The frozen

--- a/userspace-dp/src/session/lookup.rs
+++ b/userspace-dp/src/session/lookup.rs
@@ -437,15 +437,15 @@ impl SessionTable {
         }
     }
 
-    /// Iterate over all session entries with idle time (in nanoseconds) and,
-    /// since #2501, the per-direction byte/packet counters.
+    /// Iterate over ALL session entries in one pass with idle time (in
+    /// nanoseconds) and, since #2501, the per-direction byte/packet counters.
     ///
-    /// `refresh_bpf_conntrack_last_seen` (afxdp/bpf_map) is the sole
-    /// production caller: it mirrors `idle_ns` (→ `last_seen`) and the
-    /// `SessionCounters` (→ fwd/rev packet+byte fields) into the BPF
-    /// conntrack map on the ~1s GC cadence so `show security flow session`
-    /// surfaces live idle time AND volume. Cold path: a `Copy` of the
-    /// four-`u64` counter snapshot per session on top of the idle-time walk.
+    /// #5287: the production `refresh_bpf_conntrack_last_seen` no longer uses
+    /// this unbounded full-table walk — it drives `iter_with_idle_budgeted`
+    /// (below) so no single packet-loop tick scans the whole table. This method
+    /// is retained as the simple full-walk primitive used by the idle-time unit
+    /// tests; hence it is test-only in non-`test` builds.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn iter_with_idle(
         &self,
         now_ns: u64,
@@ -458,5 +458,64 @@ impl SessionTable {
                 f(key, entry.decision, &entry.metadata, idle_ns, entry.counters);
             }
         }
+    }
+
+    /// #5287: budgeted, resumable variant of `iter_with_idle`.
+    ///
+    /// `iter_with_idle` walks the ENTIRE table in one uninterrupted pass. Its
+    /// sole caller `refresh_bpf_conntrack_last_seen` does a BPF lookup + update
+    /// per forward entry, so near the 131072-entry cap that pass is tens of
+    /// thousands of synchronous kernel crossings executed between two RX/TX
+    /// polls — a deterministic per-interval latency spike on a low-latency core
+    /// (issue #5287).
+    ///
+    /// This variant bounds the work per call. It walks the `entries` slab by
+    /// its STABLE integer handle (the slab index is stable across
+    /// insert/remove — a removed slot goes vacant and is reused, it does not
+    /// renumber live handles), starting at `cursor` and examining at most
+    /// `budget` slots. `cursor` is therefore a persistent iterator position:
+    /// the caller passes back the returned value on the next slice and the walk
+    /// resumes exactly where it stopped, spreading a full-table pass across many
+    /// packet-loop ticks.
+    ///
+    /// Returns the next cursor to resume from. It returns 0 once the walk
+    /// reaches the end of the slab's index space, i.e. a full-table cycle just
+    /// completed — the caller uses that edge to pace the next cycle. A `cursor`
+    /// past the current end (the table/slab shrank since the last slice)
+    /// restarts the cycle from 0.
+    ///
+    /// The budget counts examined slab SLOTS (occupied or vacant), not just
+    /// forward entries, so both the index scan and the per-entry callback cost
+    /// are hard-bounded by `budget` regardless of the occupied/vacant mix.
+    /// `f` is invoked only for occupied slots (at most `budget` times). No
+    /// allocation, no atomics — a bounded index walk plus one `saturating_sub`
+    /// per occupied slot.
+    pub fn iter_with_idle_budgeted(
+        &self,
+        cursor: usize,
+        budget: usize,
+        now_ns: u64,
+        mut f: impl FnMut(&SessionKey, SessionDecision, &SessionMetadata, u64, SessionCounters),
+    ) -> usize {
+        let cap = self.entries.capacity();
+        // Empty slab or a degenerate zero budget: no progress, restart at 0 so
+        // the caller never gets wedged at a stale non-zero cursor.
+        if cap == 0 || budget == 0 {
+            return 0;
+        }
+        // A cursor past the end (slab capacity shrank, or a stale save)
+        // restarts the cycle from the top rather than skipping the whole table.
+        let start = if cursor >= cap { 0 } else { cursor };
+        let end = start.saturating_add(budget).min(cap);
+        for idx in start..end {
+            if let Some(record) = self.entries.get(idx) {
+                let entry = &record.entry;
+                let idle_ns = now_ns.saturating_sub(entry.last_seen_ns);
+                f(&record.key, entry.decision, &entry.metadata, idle_ns, entry.counters);
+            }
+        }
+        // Wrap to 0 on cycle completion so the caller can detect "table fully
+        // walked" and pace the next cycle to the freshness window.
+        if end >= cap { 0 } else { end }
     }
 }

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -3340,6 +3340,68 @@ fn iter_with_idle_reflects_last_seen_update() {
 }
 
 #[test]
+fn iter_with_idle_budgeted_bounds_and_resumes_full_coverage() {
+    // #5287: the budgeted refresh walk must (1) examine AT MOST `budget` slab
+    // slots per slice, (2) RESUME from the returned cursor, and (3) cover EVERY
+    // forward entry within one full cycle. Reverting the walk to the unbounded
+    // single-pass scan reddens the per-slice bound assertion (a single call
+    // would then examine all N > BUDGET entries).
+    let mut table = SessionTable::new();
+    const N: usize = 25;
+    const BUDGET: usize = 8;
+    assert!(N > BUDGET, "test only meaningful when the table exceeds one slice");
+
+    let install_time = 1_000_000_000u64;
+    let mut installed = std::collections::HashSet::new();
+    for i in 0..N {
+        let mut key = key_v4();
+        key.src_port = 10_000 + i as u16; // distinct 5-tuples -> distinct forward entries
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_time,
+            PROTO_TCP,
+            0x10,
+        ));
+        installed.insert(key);
+    }
+
+    let now = install_time + 5_000_000_000;
+    let mut cursor = 0usize;
+    let mut seen = std::collections::HashSet::new();
+    let mut slices = 0usize;
+    // Bounded loop guards against a non-advancing cursor hanging the test.
+    for _ in 0..1024 {
+        let mut this_slice = 0usize;
+        let next = table.iter_with_idle_budgeted(cursor, BUDGET, now, |k, _d, meta, _idle, _c| {
+            this_slice += 1;
+            if !meta.is_reverse {
+                seen.insert(k.clone());
+            }
+        });
+        // (1) Hard per-slice bound — THE fail-on-revert assertion. An unbounded
+        // single pass processes all N (> BUDGET) entries in one call.
+        assert!(
+            this_slice <= BUDGET,
+            "slice examined {this_slice} slots, exceeds budget {BUDGET}",
+        );
+        slices += 1;
+        cursor = next;
+        if cursor == 0 {
+            break; // returned-to-top => a full-table cycle completed
+        }
+    }
+    // (2) The full table spanned MORE THAN ONE slice (resumed across ticks).
+    assert!(
+        slices > 1,
+        "full table must span >1 slice at N={N} budget={BUDGET}, got {slices}",
+    );
+    // (3) One cycle refreshed EVERY installed forward entry exactly once.
+    assert_eq!(seen, installed, "one cycle must cover every forward entry");
+}
+
+#[test]
 fn refresh_local_skips_peer_synced_entries() {
     let mut table = SessionTable::new();
     let key = key_v4();


### PR DESCRIPTION
## Problem
`refresh_bpf_conntrack_last_seen` walked the COMPLETE worker-owned session table doing a BPF lookup + update per forward v4/v6 entry, run synchronously from the packet loop in one uninterrupted pass. Near the 131072-entry cap that is tens of thousands of synchronous kernel crossings between two RX/TX polls — a deterministic per-interval latency spike on the low-latency worker core, exactly under the high-session load where service and heartbeat stability matter (and a possible false worker-stall trigger).

Location (origin/master): `userspace-dp/src/afxdp/bpf_map/mod.rs` refresh, `userspace-dp/src/afxdp/worker/loop_body/mod.rs` call site.

## Fix
Incremental, budgeted, resumable slice:

- **`SessionTable::iter_with_idle_budgeted(cursor, budget, now, f) -> next_cursor`** — walks the `entries` slab by its **stable** integer handle, examines at most `budget` slots from `cursor`, returns the next cursor (0 on cycle completion). Budget bounds both the index scan and the per-entry syscalls; `f` runs only for occupied slots. No allocation, no atomics.
- **`refresh_bpf_conntrack_last_seen`** now takes `(cursor, budget)` and returns the next cursor; the per-entry closure is unchanged.
- **Worker loop** keeps a persistent `ct_refresh_cursor`, drives one slice per `CT_SLICE_INTERVAL_NS` (100ms) with `CT_REFRESH_SLICE_BUDGET` (2048) while a cycle is in flight, and paces successive full-table cycles to `CT_REFRESH_WINDOW_NS` (10s). A small/idle table is walked in one short slice per window, so **steady-state syscall rate is unchanged from the old 10s cadence** — the common/idle case is not regressed. Per-tick added cost is one integer compare + one `saturating_sub` (the `should_slice` short-circuit).

### Freshness/latency tradeoff
At the 131072 default cap and 100ms cadence a full cycle spans ~64 slices (~6.4s ≤ the 10s freshness window), so the whole table is still refreshed within the window. If `max_sessions` is raised far above the default a cycle stretches past 10s (freshness degrades gracefully), but the per-slice cost stays hard-bounded — no single loop tick ever walks the whole table again. A session installed into an already-passed slot mid-cycle waits until the next cycle, so freshness is best-effort diagnostic (the entry already gets `last_seen` at install, and the Go GC has `SkipSweep` set, so a stale `last_seen` never causes premature expiry).

## Tests (fail-on-revert, assertion-based)
Verified firsthand that neutralizing the budget to a single pass reddens **both** via assertion (not a build break), then restored:

- `session::tests::iter_with_idle_budgeted_bounds_and_resumes_full_coverage` — seeds N=25 forward entries > budget 8; asserts ≤ budget examined per slice, resumes across >1 slice, and one cycle covers every forward entry.
- `afxdp::bpf_map::tests::refresh_bpf_conntrack_last_seen_is_budgeted_across_slices` — drives the production refresh (fd=-1, no BPF I/O) over N=40; asserts the first slice returns `cursor == budget` (not a wrapped full pass) and a full cycle spans > 1 slice.

## Docs
`session/README.md` gains a "Budgeted last_seen refresh (#5287)" section (cursor/budget/window invariants + tradeoff); two stale "~1s GC cadence" mentions corrected.

## Validation
`cargo build` green; full `cargo test --release` green (no new warnings vs baseline).

Note: hot-path-adjacent dataplane change — a cluster iperf smoke may be warranted before merge.

Closes #5287