### PR TITLE
vrrp: apply day-2 advertise-interval + gratuitous-arp-count changes (#5087)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -55990,3 +55990,23 @@ top.
   userspace-dp/src/afxdp/coordinator/mod.rs,
   userspace-dp/src/afxdp/coordinator/tests.rs,
   userspace-dp/src/afxdp/coordinator/README.md
+
+- **Timestamp**: 2026-07-22 (#5087)
+  **Action**: Apply day-2 `reth-advertise-interval` and `gratuitous-arp-count`
+  changes to running VRRP instances. The `UpdateInstances` no-change gate now
+  compares `AdvertiseInterval` and `GARPCount`, so a commit changing only
+  either field breaks the `continue // No change` shortcut and takes the
+  in-place `updateConfig` arm; `updateConfig` copies both into the running
+  instance's `cfg`. No explicit timer poke is needed — the MASTER advert timer
+  re-arms via `advertTimer.Reset(vi.advertInterval())` on its next fire, the
+  BACKUP master-down horizon re-reads `cfg.AdvertiseInterval` through
+  `masterDownInterval()`, and the next failover's `sendGARP` re-reads
+  `cfg.GARPCount`. Before this fix the stale advert timer / wire value and GARP
+  burst count persisted until an unrelated restart while config reported
+  success. Added fail-on-revert tests
+  `TestUpdateInstances_AdvertiseIntervalOnlyAppliedInPlace` and
+  `TestUpdateInstances_GARPCountOnlyAppliedInPlace` (firsthand-verified RED
+  when either the gate comparison or the updateConfig copy is reverted). Full
+  pkg/vrrp suite green (incl. -race).
+  **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/instance.go,
+  pkg/vrrp/update_instances_test.go, pkg/vrrp/README.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -47,7 +47,18 @@ This is the package that drives chassis-cluster failover.
   transient member-link failure (carrier flap, mid-rename by networkd)
   therefore leaves the old instance running and advertising its old VIPs
   rather than orphaning the RG out of election. Priority/preempt/track
-  changes still update in-place (no restart, no master-down gap).
+  and the wire/timer/burst fields **advertise-interval** and
+  **gratuitous-arp-count** update in-place (no restart, no master-down
+  gap): the no-change gate compares `AdvertiseInterval` and `GARPCount`
+  so a day-2 commit changing only `reth-advertise-interval` or
+  `gratuitous-arp-count` is detected (not shortcut as no-change), and
+  `updateConfig` copies both into the running instance's `cfg` (#5087).
+  Neither needs an explicit timer poke — the MASTER advert timer
+  re-arms via `advertTimer.Reset(vi.advertInterval())` on its next
+  fire, the BACKUP master-down horizon re-reads `cfg.AdvertiseInterval`
+  through `masterDownInterval()`, and the next failover's `sendGARP`
+  re-reads `cfg.GARPCount`. Before #5087 the stale value persisted
+  until an unrelated restart.
   **Ifindex drift (#2294):** before the no-change / in-place branch, a
   cheap tolerant `name→ifindex` probe compares the live kernel ifindex
   against the one the instance's sockets are bound to. A member netdev

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -533,8 +533,9 @@ func (vi *vrrpInstance) key() string {
 	return StateKey(vi.cfg.Interface, vi.cfg.GroupID, vi.cfg.Family)
 }
 
-// updateConfig updates priority, preempt, and interface-tracking config
-// in-place without restarting.
+// updateConfig updates priority, preempt, interface-tracking,
+// advertise-interval, and gratuitous-ARP-count config in-place without
+// restarting.
 //
 // It runs on the manager goroutine, NOT the run-loop goroutine that owns the
 // preemptHoldTimer (#2900). It therefore mutates cfg under mu and then signals
@@ -542,11 +543,23 @@ func (vi *vrrpInstance) key() string {
 // the run loop tears down an in-flight hold whose premise the new config has
 // invalidated (preempt disabled, priority demoted, or hold-time changed). This
 // keeps all preemptHoldTimer Stop/Reset calls on the single run-loop goroutine.
+//
+// AdvertiseInterval and GARPCount are copied so a day-2 change reaches the
+// running instance (#5087). Both are re-read from cfg by the run loop and the
+// failover path, so no explicit timer poke is needed: the MASTER advert timer
+// re-arms via advertTimer.Reset(vi.advertInterval()) on its next fire, the
+// BACKUP master-down horizon re-reads cfg.AdvertiseInterval via
+// masterDownInterval(), and the next failover's sendGARP re-reads
+// cfg.GARPCount. Before this copy a commit changing only
+// reth-advertise-interval or gratuitous-arp-count left the running instance at
+// its stale value until an unrelated restart.
 func (vi *vrrpInstance) updateConfig(cfg Instance) {
 	vi.mu.Lock()
 	vi.cfg.Priority = cfg.Priority
 	vi.cfg.Preempt = cfg.Preempt
 	vi.cfg.PreemptHoldTime = cfg.PreemptHoldTime
+	vi.cfg.AdvertiseInterval = cfg.AdvertiseInterval
+	vi.cfg.GARPCount = cfg.GARPCount
 	vi.cfg.TrackInterface = cfg.TrackInterface
 	vi.cfg.TrackPriorityCost = cfg.TrackPriorityCost
 	vi.desiredPreempt = cfg.Preempt

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -560,21 +560,31 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 			}
 
 			// Check if config changed (and the live ifindex is unchanged).
+			// AdvertiseInterval (advert timer / masterDown / wire Max-Adver-Int)
+			// and GARPCount (per-VIP gratuitous-ARP burst on failover) are wire/
+			// timer/burst fields the run loop re-reads from cfg, so a day-2 change
+			// to EITHER must break the no-change shortcut and take the in-place
+			// updateConfig arm below — otherwise a commit changing only
+			// reth-advertise-interval or gratuitous-arp-count is silently dropped
+			// until an unrelated restart (#5087).
 			if !ifindexChanged &&
 				existing.cfg.Priority == inst.Priority &&
 				existing.cfg.Preempt == inst.Preempt &&
 				existing.cfg.PreemptHoldTime == inst.PreemptHoldTime &&
+				existing.cfg.AdvertiseInterval == inst.AdvertiseInterval &&
+				existing.cfg.GARPCount == inst.GARPCount &&
 				existing.cfg.TrackInterface == inst.TrackInterface &&
 				existing.cfg.TrackPriorityCost == inst.TrackPriorityCost &&
 				vipsEqual(existing.cfg.VirtualAddresses, inst.VirtualAddresses) {
 				continue // No change.
 			}
-			// If only priority/preempt/tracking changed (and the ifindex is
-			// unchanged), update in-place without stopping. Restarting would
-			// cause a 3s master-down gap where the node falsely becomes
-			// MASTER before hearing the peer. An ifindex change is NOT
-			// in-place-updatable — it requires a fresh socket — so it skips
-			// this arm and falls through to the build-before-teardown path.
+			// If only priority/preempt/tracking/advertise-interval/GARP-count
+			// changed (and the ifindex is unchanged), update in-place without
+			// stopping. Restarting would cause a 3s master-down gap where the
+			// node falsely becomes MASTER before hearing the peer. An ifindex
+			// change is NOT in-place-updatable — it requires a fresh socket — so
+			// it skips this arm and falls through to the build-before-teardown
+			// path.
 			if !ifindexChanged && vipsEqual(existing.cfg.VirtualAddresses, inst.VirtualAddresses) {
 				slog.Info("vrrp: priority update", "key", existing.key(),
 					"old_pri", existing.cfg.Priority, "new_pri", inst.Priority)

--- a/pkg/vrrp/update_instances_test.go
+++ b/pkg/vrrp/update_instances_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/vishvananda/netlink"
 )
@@ -596,6 +597,145 @@ func TestUpdateInstances_IfindexUnchanged_PriorityOnlyStaysInPlace(t *testing.T)
 	}
 	if got.cfg.Priority != 150 {
 		t.Fatalf("in-place update did not apply priority: got %d, want 150", got.cfg.Priority)
+	}
+}
+
+// TestUpdateInstances_AdvertiseIntervalOnlyAppliedInPlace is the #5087
+// fail-on-revert pin for reth-advertise-interval. A commit that changes ONLY
+// the advertise-interval (VIPs + ifindex + priority + preempt + tracking all
+// unchanged) must NOT hit the no-change shortcut: the running instance's
+// cfg.AdvertiseInterval must be updated in place so the advert timer re-arms to
+// the new interval on its next fire.
+//
+// REVERT NEUTRALIZATION (firsthand-verified RED both ways):
+//   - Drop `existing.cfg.AdvertiseInterval == inst.AdvertiseInterval` from the
+//     no-change gate in UpdateInstances → an interval-only delta matches the
+//     shortcut, `continue // No change` runs, updateConfig is never called, and
+//     cfg.AdvertiseInterval stays 1000 → the assertions below fire.
+//   - Drop `vi.cfg.AdvertiseInterval = cfg.AdvertiseInterval` from updateConfig
+//     → the gate detects the change and takes the in-place arm, but the field
+//     is never copied, so cfg.AdvertiseInterval stays 1000 → same RED.
+//
+// The advertInterval() assertion pins the run loop's actual timer source: the
+// MASTER select re-arms via advertTimer.Reset(vi.advertInterval()), so proving
+// advertInterval() now yields the new Duration proves the timer re-arms to the
+// new interval — not merely that a struct field was written.
+func TestUpdateInstances_AdvertiseIntervalOnlyAppliedInPlace(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	m.resolveIface = func(name string) (*net.Interface, error) {
+		return &net.Interface{Name: name, Index: 5}, nil
+	}
+
+	key := instanceKey{iface: "reth0.50", groupID: 101}
+	orig := seedRunningInstance(m, key, Instance{
+		Interface:         "reth0.50",
+		GroupID:           101,
+		Priority:          200,
+		Preempt:           true,
+		AdvertiseInterval: 1000, // day-1 interval (1s)
+		GARPCount:         3,
+		VirtualAddresses:  []string{"172.16.50.1/24"},
+	}, 5)
+
+	// Day-2 change: only reth-advertise-interval moves 1000ms → 30ms.
+	desired := []*Instance{{
+		Interface:         "reth0.50",
+		GroupID:           101,
+		Priority:          200,
+		Preempt:           true,
+		AdvertiseInterval: 30,
+		GARPCount:         3,
+		VirtualAddresses:  []string{"172.16.50.1/24"},
+	}}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	// The delta must take the cheap in-place path, not a socket-churning restart.
+	open, run, stop := rec.snapshot()
+	if open != 0 || run != 0 || stop != 0 {
+		t.Fatalf("advertise-interval-only delta must stay in-place: open=%d run=%d stop=%d, want 0/0/0", open, run, stop)
+	}
+	m.mu.RLock()
+	got := m.instances[key]
+	m.mu.RUnlock()
+	if got != orig {
+		t.Fatal("advertise-interval-only delta replaced the instance (should be in-place)")
+	}
+
+	// THE PIN: the running instance picked up the new interval. RED if either
+	// the no-change gate or the updateConfig copy is reverted.
+	if got.cfg.AdvertiseInterval != 30 {
+		t.Fatalf("in-place update did not apply advertise-interval: got %d, want 30", got.cfg.AdvertiseInterval)
+	}
+	// The advert timer re-arms to this Duration on its next fire (the run loop's
+	// advertTimer.Reset(vi.advertInterval()) source).
+	if iv := got.advertInterval(); iv != 30*time.Millisecond {
+		t.Fatalf("advertInterval() = %v, want 30ms — advert timer would not re-arm to the new interval", iv)
+	}
+}
+
+// TestUpdateInstances_GARPCountOnlyAppliedInPlace is the #5087 fail-on-revert
+// pin for gratuitous-arp-count. A commit changing ONLY gratuitous-arp-count
+// (everything else unchanged) must update the running instance's cfg.GARPCount
+// in place so the NEXT failover's sendGARP burst uses the new count — sendGARP
+// re-reads vi.cfg.GARPCount on every call.
+//
+// REVERT NEUTRALIZATION: identical to the advertise-interval pin — dropping
+// `existing.cfg.GARPCount == inst.GARPCount` from the no-change gate makes a
+// count-only delta hit the `continue // No change` shortcut, and dropping
+// `vi.cfg.GARPCount = cfg.GARPCount` from updateConfig leaves the field stale
+// after the in-place arm runs. Either way cfg.GARPCount stays 3 → RED.
+func TestUpdateInstances_GARPCountOnlyAppliedInPlace(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	m.resolveIface = func(name string) (*net.Interface, error) {
+		return &net.Interface{Name: name, Index: 5}, nil
+	}
+
+	key := instanceKey{iface: "reth0.50", groupID: 101}
+	orig := seedRunningInstance(m, key, Instance{
+		Interface:         "reth0.50",
+		GroupID:           101,
+		Priority:          200,
+		Preempt:           true,
+		AdvertiseInterval: 30,
+		GARPCount:         3, // day-1 default burst
+		VirtualAddresses:  []string{"172.16.50.1/24"},
+	}, 5)
+
+	// Day-2 change: only gratuitous-arp-count moves 3 → 5.
+	desired := []*Instance{{
+		Interface:         "reth0.50",
+		GroupID:           101,
+		Priority:          200,
+		Preempt:           true,
+		AdvertiseInterval: 30,
+		GARPCount:         5,
+		VirtualAddresses:  []string{"172.16.50.1/24"},
+	}}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	open, run, stop := rec.snapshot()
+	if open != 0 || run != 0 || stop != 0 {
+		t.Fatalf("gratuitous-arp-count-only delta must stay in-place: open=%d run=%d stop=%d, want 0/0/0", open, run, stop)
+	}
+	m.mu.RLock()
+	got := m.instances[key]
+	m.mu.RUnlock()
+	if got != orig {
+		t.Fatal("gratuitous-arp-count-only delta replaced the instance (should be in-place)")
+	}
+
+	// THE PIN: the running instance picked up the new burst count. RED if either
+	// the no-change gate or the updateConfig copy is reverted.
+	if got.cfg.GARPCount != 5 {
+		t.Fatalf("in-place update did not apply gratuitous-arp-count: got %d, want 5", got.cfg.GARPCount)
 	}
 }
 


### PR DESCRIPTION
## Problem (#5087)

A commit changing **only** `reth-advertise-interval` or
`gratuitous-arp-count` was silently ignored until an unrelated restart.
`Manager.UpdateInstances`'s no-change gate compared only
Priority/Preempt/PreemptHoldTime/TrackInterface/TrackPriorityCost/VIPs, so an
interval-only or count-only delta matched the gate and hit `continue // No
change`. Even had the gate detected the change, the in-place `updateConfig` did
not copy `AdvertiseInterval` or `GARPCount`, so the running instance kept its
stale advert timer / wire value and GARP burst count while config reported
success — a stale HA failure-detection / neighbor-convergence posture.

## Fix

- **No-change gate** (`manager.go`): add `AdvertiseInterval` and `GARPCount` to
  the equality comparison so a change to either breaks the shortcut and takes
  the cheap in-place arm (no socket-churning restart, no master-down gap).
- **In-place `updateConfig`** (`instance.go`): copy both fields into the
  running instance's `cfg`.

No explicit timer poke is needed — the run loop and failover path re-read these
fields from `cfg` on the fly:
- MASTER advert timer re-arms via `advertTimer.Reset(vi.advertInterval())` on
  its next fire → new interval takes effect within one advert period.
- BACKUP master-down horizon re-reads `cfg.AdvertiseInterval` through
  `masterDownInterval()`.
- Next failover's `sendGARP` re-reads `cfg.GARPCount`.

## Fail-on-revert tests

`TestUpdateInstances_AdvertiseIntervalOnlyAppliedInPlace` and
`TestUpdateInstances_GARPCountOnlyAppliedInPlace`: each seeds a running
instance, pushes a delta changing only the one field, asserts the in-place path
(open/run/stop == 0/0/0, same instance) and that the running `cfg` value
updated. The advertise-interval test additionally pins `advertInterval()` (the
run loop's `advertTimer.Reset` source) to the new Duration — proving the timer
re-arms, not merely that a struct field was written.

Both tests go **RED** when either the gate comparison **or** the `updateConfig`
copy is reverted — verified firsthand, both reverts independently
(`got 1000, want 30` / `got 3, want 5`).

## Validation

- `go build ./...` clean.
- `go test ./pkg/vrrp/...` green, including `-race`.
- Firsthand RED-on-revert confirmed for both fix halves.
- Updated `pkg/vrrp/README.md` day-2 in-place-update contract.

NOTE: VRRP change → `make test-failover` may be warranted before merge.

Closes #5087