### PR TITLE
dataplane/userspace: fail closed + roll back on rejected address-only commit apply_snapshot (#4959)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -55990,3 +55990,24 @@ top.
   userspace-dp/src/afxdp/coordinator/mod.rs,
   userspace-dp/src/afxdp/coordinator/tests.rs,
   userspace-dp/src/afxdp/coordinator/README.md
+
+- **Timestamp**: 2026-07-22
+  **Action**: #4959 — address-only commit fail-closed on rejected apply_snapshot.
+  The samePlanRefresh path mutates ingress/local/interface-NAT classifier BPF
+  maps IN PLACE with ctrl enabled, then publishes apply_snapshot; a helper
+  rejection previously left the maps a generation ahead of the applied Rust
+  snapshot with ctrl still enabled (fail-open). Extracted
+  `failClosedUserspaceCtrlMapLocked` (shared classifier fail-closed) and added
+  `publishSnapshotFailClosedLocked`; Compile now routes its publish through it
+  with the samePlanRefresh flag, disabling ctrl (Enabled=0) on a same-plan
+  publish rejection. Chose option (b) — keep the lightweight same-plan fast
+  path — over adding addresses to snapshotBindingPlanKey (option a), which would
+  force every address edit through the bootstrap path (ctrl=0 + binding-row
+  clear = transit blip on every successful commit). Added fail-on-revert test
+  (firsthand-verified RED: ctrl stays Enabled=1 under revert) + a source-guard
+  on the Compile publish site. `go build ./...` + `go test ./pkg/dataplane/...`
+  green; privileged run of the new test passes.
+  **File(s)**: pkg/dataplane/userspace/maps_sync.go,
+  pkg/dataplane/userspace/manager_compile.go,
+  pkg/dataplane/userspace/addr_only_commit_failclosed_4959_test.go,
+  docs/userspace-dataplane-architecture.md

--- a/_Log.md
+++ b/_Log.md
@@ -56011,3 +56011,36 @@ top.
   pkg/dataplane/userspace/manager_compile.go,
   pkg/dataplane/userspace/addr_only_commit_failclosed_4959_test.go,
   docs/userspace-dataplane-architecture.md
+
+- **Timestamp**: 2026-07-22
+  **Action**: #4959 (folded hostile-review finding) — close the residual
+  fail-open at the SECOND apply_snapshot site. `syncSnapshotLocked` (the
+  status-loop deferred-publish resume path) published `apply_snapshot` with a
+  bare `requestLocked`; a rejection returned the error but left `ctrl`
+  Enabled=1. Trigger: an address-only commit landing during the XSK-startup
+  liveness-probe window — `Compile`'s `pendingXSKStartup` branch mutates the
+  classifier maps IN PLACE (`syncUserspaceClassifierMapsFailClosedLocked`) then
+  DEFERS the publish, so when the status loop finishes it via
+  `syncSnapshotLocked` a rejection strands the maps a generation ahead of the
+  applied snapshot (identical #4959 fail-open). Routed that publish through
+  `publishSnapshotFailClosedLocked(&publishSnap, &status, true)`. Verified
+  firsthand that `mapsMutatedInPlace=true` is UNCONDITIONALLY correct there:
+  the `pendingXSKStartup` branch is the sole producer of an unpublished
+  `m.lastSnapshot` ahead of `m.publishedSnapshot` (every other publish site —
+  Compile steady state, route-overlay, policy-scheduler, deferred-worker-arm —
+  advances `publishedSnapshot` only after a successful publish), so no
+  genuinely-fresh publish can reach this site. Added FAIL-ON-REVERT test
+  `TestDeferredPublishRejectedFailsClosed4959` (real seeded userspace_ctrl map
+  + rejecting control server; rejected deferred publish → ctrl Enabled=0;
+  companion success subtest asserts the publish lands and the wrap is
+  transparent) + source-guard `TestSyncSnapshotRoutesPublishThroughFailClosed
+  Helper4959` binding the syncSnapshotLocked publish site. Firsthand-verified
+  privileged: RED on revert (ctrl stays Enabled=1 when the wrap is dropped),
+  GREEN with it; success subtest stays GREEN under both. Pre-existing
+  environment-dependent FAILs in the package (`userspace_ingress_ifaces map not
+  loaded`, XDP-program-execution stat tests) reproduce identically at the
+  committed HEAD without this change. `gofmt` clean; `go build ./...` +
+  `go vet` green.
+  **File(s)**: pkg/dataplane/userspace/process_status.go,
+  pkg/dataplane/userspace/addr_only_commit_failclosed_4959_test.go,
+  docs/userspace-dataplane-architecture.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1235,6 +1235,34 @@ case and an explicit operator `hold-interval` drop (an empty book matches
 nothing — fail-closed for an allowlist, the operator-opted fail-open for a
 denylist).
 
+**Classifier-map publish is a fail-closed transaction (#4959).** The manager
+keeps a `snapshotBindingPlanKey` (`maps_sync.go`) over the worker/ring/
+interface-binding/fabric plan. When a commit does NOT change that key — the
+common **address-only** commit that edits a local address or an interface-NAT
+address — `Compile` takes the lightweight `samePlanRefresh` path: it rewrites
+the ingress / local-address / interface-NAT classifier BPF maps **in place**
+(`syncUserspaceClassifierMapsFailClosedLocked`) rather than re-bootstrapping the
+helper, then publishes the new `apply_snapshot`. The XDP shim reads those
+classifier maps live (kernel-pass vs XSK-redirect, local-vs-interface-NAT
+ownership) while `ctrl.Enabled == 1`. If the helper then **rejects** the
+snapshot (a helper-side validation failure, or any transport error) it keeps
+enforcing the previous-good snapshot — so the freshly-mutated maps would be a
+generation *ahead* of the applied Rust snapshot with the shim still enabled: a
+fail-**open** classifier/snapshot mismatch (wrong kernel delivery / wrong XSK
+steering). The publish therefore routes through `publishSnapshotFailClosedLocked`
+with the `samePlanRefresh` flag: on a same-plan publish error it disables
+`ctrl` (`failClosedUserspaceCtrlMapLocked` → `Enabled=0`) so transit drops to
+the kernel-only fail-closed posture until a subsequent good commit re-publishes
+and re-enables it (`applyHelperStatusLocked`). The full **bootstrap** path
+(binding plan changed) already programs `ctrl.Enabled=0` in
+`programBootstrapMapsLocked` before the publish, so it is fail-closed without
+extra work — which is why the fix keeps the same-plan fast path instead of
+forcing every address edit through a bootstrap (that would clear binding rows
+and blip transit on every successful commit). Distinct from the Rust-side
+reconcile-ordering invariant (#2440/#2444/#3789) above: that one keeps the Rust
+process fail-closed across teardown; this one keeps the **Go-owned classifier
+BPF maps** consistent with the applied snapshot.
+
 #### Capability Check
 
 The manager evaluates the active config to determine whether the userspace

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1263,6 +1263,27 @@ reconcile-ordering invariant (#2440/#2444/#3789) above: that one keeps the Rust
 process fail-closed across teardown; this one keeps the **Go-owned classifier
 BPF maps** consistent with the applied snapshot.
 
+The **same fail-closed transaction covers the deferred-publish resume path.**
+There are two `apply_snapshot` publish sites for a same-plan refresh. `Compile`
+publishes synchronously in the steady state, but during **XSK startup** (the
+liveness-probe window after the initial publish, before liveness is proven or
+failed) it takes the `pendingXSKStartup` branch: it still mutates the classifier
+maps **in place** (`syncUserspaceClassifierMapsFailClosedLocked`) with `ctrl`
+already flipped to `Enabled=1` to probe, but **defers** the publish and returns
+success. The status loop then completes the publish via `syncSnapshotLocked`
+(`process_status.go`). An address-only commit landing inside that window is
+exactly this case: the maps are already a generation ahead, so a rejected
+deferred publish is the identical fail-open. `syncSnapshotLocked` therefore
+routes its publish through `publishSnapshotFailClosedLocked` with
+`mapsMutatedInPlace=true`. That flag is unconditional there because the
+`pendingXSKStartup` branch is the **sole producer** of an unpublished
+`m.lastSnapshot` ahead of `m.publishedSnapshot` — every other publish site
+(`Compile` steady state, route-overlay, policy-scheduler, deferred-worker-arm)
+advances `publishedSnapshot` only *after* a successful publish, so none can
+strand a not-yet-mutated snapshot for the status loop to pick up. On a rejection
+`ctrl` drops to `Enabled=0`; a successful deferred publish is transparent and
+leaves the enable side to `applyHelperStatusLocked`.
+
 #### Capability Check
 
 The manager evaluates the active config to determine whether the userspace

--- a/pkg/dataplane/userspace/addr_only_commit_failclosed_4959_test.go
+++ b/pkg/dataplane/userspace/addr_only_commit_failclosed_4959_test.go
@@ -1,0 +1,203 @@
+// #4959: an address-only commit takes the samePlanRefresh path, which mutates
+// the ingress/local/interface-NAT classifier BPF maps IN PLACE while the XDP
+// shim's ctrl gate is still enabled, then publishes the snapshot to the running
+// Rust helper. Before this fix a REJECTED apply_snapshot returned the error but
+// left the classifier maps on the NEW plan with ctrl STILL ENABLED — the shim
+// then read maps a generation ahead of the applied (previous-good) Rust
+// snapshot, making kernel-pass-vs-XSK-redirect and local-vs-interface-NAT
+// ownership decisions against a plan the helper never accepted (fail OPEN).
+//
+// The fix makes the in-place map refresh + helper publish one fail-closed
+// transaction: on a same-plan publish rejection ctrl is disabled (Enabled=0),
+// dropping transit to the kernel-only fail-closed posture until a subsequent
+// good commit re-publishes and re-enables it.
+//
+// FAIL-ON-REVERT: neutralizing publishSnapshotFailClosedLocked back to
+// `return result, fmt.Errorf("publish userspace snapshot: %w", err)` (i.e.
+// dropping the failClosedUserspaceCtrlMapLocked call on the mapsMutatedInPlace
+// path) leaves ctrl at Enabled=1 after the rejected publish, so
+// TestAddressOnlyCommitRejectedPublishFailsClosed4959 goes RED on its
+// "ctrl.Enabled must be 0" assertion.
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// startArmControlServerReject stands up a unix control socket that decodes the
+// next `n` requests and REJECTS each with OK:false (a helper-side validation
+// failure). This models a running helper that refuses the apply_snapshot while
+// keeping the previous-good snapshot enforced.
+func startArmControlServerReject(t *testing.T, controlSock string, n int) {
+	t.Helper()
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for i := 0; i < n; i++ {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			func() {
+				defer conn.Close()
+				var req ControlRequest
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					return
+				}
+				_ = json.NewEncoder(conn).Encode(ControlResponse{
+					OK:    false,
+					Error: "injected apply_snapshot rejection",
+				})
+			}()
+		}
+	}()
+}
+
+// readCtrlEnabled4959 reads the userspace_ctrl row at key 0 and returns its
+// Enabled field.
+func readCtrlEnabled4959(t *testing.T, ctrlMap *ebpf.Map) uint32 {
+	t.Helper()
+	var ctrl userspaceCtrlValue
+	if err := ctrlMap.Lookup(uint32(0), &ctrl); err != nil {
+		t.Fatalf("read userspace_ctrl: %v", err)
+	}
+	return ctrl.Enabled
+}
+
+// newFailClosedManager4959 builds a Manager wired to a control socket under the
+// short-path directory, with a real userspace_ctrl map seeded Enabled=1 (a
+// running, enabled firewall). Returns the manager, its ctrl map, and a built
+// publish snapshot.
+func newFailClosedManager4959(t *testing.T) (*Manager, *ebpf.Map, ConfigSnapshot, string) {
+	t.Helper()
+	// A SHORT temp-dir prefix (not t.TempDir(), whose long sub-test name would
+	// push the AF_UNIX path past the 108-byte sun_path limit -> "bind: invalid
+	// argument"). Honors TMPDIR (run with TMPDIR=/tmp).
+	dir, err := os.MkdirTemp("", "x4959")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+
+	ctrlMap, _ := injectCtrlAndBindingMaps(t, m)
+	// Seed ctrl as a running, ENABLED firewall (post-same-plan-refresh state:
+	// maps already mutated in place, ctrl left enabled).
+	enabled := userspaceCtrlValue{Enabled: 1, MetadataVersion: userspaceMetadataVersion, Workers: 4, QueueCount: 4}
+	if err := ctrlMap.Update(uint32(0), enabled, ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed userspace_ctrl Enabled=1: %v", err)
+	}
+
+	cfg := &config.Config{}
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 8, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	return m, ctrlMap, *snap, controlSock
+}
+
+func TestAddressOnlyCommitRejectedPublishFailsClosed4959(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+
+	// Core contract: same-plan refresh (maps mutated in place) + a REJECTED
+	// apply_snapshot must fail closed — ctrl disabled — not fail open.
+	t.Run("rejected_publish_disables_ctrl", func(t *testing.T) {
+		m, ctrlMap, snap, controlSock := newFailClosedManager4959(t)
+		// Helper accepts the connection and REJECTS the apply_snapshot (helper-
+		// side validation failure) — the exact fail-open trigger from #4959.
+		startArmControlServerReject(t, controlSock, 1)
+
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 1 {
+			t.Fatalf("precondition: ctrl.Enabled = %d, want 1 (running enabled firewall)", got)
+		}
+
+		var status ProcessStatus
+		m.mu.Lock()
+		err := m.publishSnapshotFailClosedLocked(&snap, &status, true /*mapsMutatedInPlace*/)
+		m.mu.Unlock()
+		if err == nil {
+			t.Fatal("publishSnapshotFailClosedLocked must return the rejection error")
+		}
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 0 {
+			t.Fatalf("ctrl.Enabled = %d after a rejected same-plan publish, want 0 (fail closed); "+
+				"maps were mutated in place and the helper kept the previous-good snapshot, "+
+				"so a still-enabled shim runs classifier maps a generation ahead of the applied "+
+				"snapshot (#4959 fail-open)", got)
+		}
+	})
+
+	// Control: a SUCCESSFUL same-plan publish must leave ctrl untouched (this
+	// method does not manage the enable side — applyHelperStatusLocked does that
+	// downstream). The fix must not turn healthy address commits into a disable.
+	t.Run("successful_publish_keeps_ctrl_enabled", func(t *testing.T) {
+		m, ctrlMap, snap, controlSock := newFailClosedManager4959(t)
+		startArmControlServer(t, controlSock, 1) // responds OK:true
+
+		var status ProcessStatus
+		m.mu.Lock()
+		err := m.publishSnapshotFailClosedLocked(&snap, &status, true /*mapsMutatedInPlace*/)
+		m.mu.Unlock()
+		if err != nil {
+			t.Fatalf("publishSnapshotFailClosedLocked on the success path returned %v, want nil", err)
+		}
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 1 {
+			t.Fatalf("ctrl.Enabled = %d after a successful publish, want 1 (unchanged)", got)
+		}
+	})
+
+	// Bootstrap path (mapsMutatedInPlace=false): the caller already programmed
+	// ctrl.Enabled=0 before the publish, so this method must NOT run the
+	// classifier fail-closed — it just returns the error. Assert it leaves the
+	// (artificially still-enabled) ctrl untouched so the gate is proven specific
+	// to the in-place refresh path.
+	t.Run("bootstrap_path_does_not_failclose", func(t *testing.T) {
+		m, ctrlMap, snap, controlSock := newFailClosedManager4959(t)
+		startArmControlServerReject(t, controlSock, 1)
+
+		var status ProcessStatus
+		m.mu.Lock()
+		err := m.publishSnapshotFailClosedLocked(&snap, &status, false /*mapsMutatedInPlace*/)
+		m.mu.Unlock()
+		if err == nil {
+			t.Fatal("publishSnapshotFailClosedLocked must return the rejection error on the bootstrap path too")
+		}
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 1 {
+			t.Fatalf("ctrl.Enabled = %d, want 1 unchanged; the bootstrap-path publish must not "+
+				"run the in-place classifier fail-closed", got)
+		}
+	})
+}
+
+// TestCompileRoutesPublishThroughFailClosedHelper4959 is a source-level guard so
+// a revert cannot re-inline a bare requestLocked(apply_snapshot) at the Compile
+// publish site and slip past the behavioral test above (which drives the
+// extracted helper directly). Compile's classifier-map publish MUST route
+// through publishSnapshotFailClosedLocked with the samePlanRefresh flag.
+func TestCompileRoutesPublishThroughFailClosedHelper4959(t *testing.T) {
+	t.Parallel()
+	src := goFunctionSource(t, "manager_compile.go", "Compile")
+	if !strings.Contains(src, "publishSnapshotFailClosedLocked(&publishSnap, &status, samePlanRefresh)") {
+		t.Fatalf("Compile must publish the classifier-map snapshot via "+
+			"publishSnapshotFailClosedLocked(..., samePlanRefresh) so a rejected "+
+			"same-plan apply_snapshot fails closed (#4959); got:\n%s", src)
+	}
+}

--- a/pkg/dataplane/userspace/addr_only_commit_failclosed_4959_test.go
+++ b/pkg/dataplane/userspace/addr_only_commit_failclosed_4959_test.go
@@ -201,3 +201,122 @@ func TestCompileRoutesPublishThroughFailClosedHelper4959(t *testing.T) {
 			"same-plan apply_snapshot fails closed (#4959); got:\n%s", src)
 	}
 }
+
+// #4959 (folded review finding): syncSnapshotLocked is the SECOND apply_snapshot
+// site — the status-loop deferred-publish resume path. An address-only commit
+// landing during the XSK-startup liveness-probe window takes the pendingXSKStartup
+// branch of Compile, which mutates the ingress/local/interface-NAT classifier BPF
+// maps IN PLACE (syncUserspaceClassifierMapsFailClosedLocked, ctrl still Enabled=1
+// to probe) then DEFERS the publish. When the status loop later publishes via
+// syncSnapshotLocked, a REJECTED apply_snapshot must fail closed (ctrl Enabled=0),
+// otherwise the shim runs classifier maps a generation ahead of the applied Rust
+// snapshot — the exact #4959 fail-open, as a residual on this second site.
+//
+// FAIL-ON-REVERT: neutralizing the syncSnapshotLocked publish back to a bare
+// `m.requestLocked(ControlRequest{Type: "apply_snapshot", ...}, &status)` (i.e.
+// dropping the publishSnapshotFailClosedLocked(..., true) wrap) leaves ctrl at
+// Enabled=1 after the rejected deferred publish, so
+// TestDeferredPublishRejectedFailsClosed4959/rejected_deferred_publish_disables_ctrl
+// goes RED on its "ctrl.Enabled must be 0" assertion.
+func TestDeferredPublishRejectedFailsClosed4959(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+
+	// seedDeferredPublishState models the manager after an address-only commit
+	// was deferred during XSK startup: an initial snapshot is published
+	// (publishedSnapshot != 0, same binding plan) and XSK liveness is still being
+	// probed (neither proven nor failed), with a newer same-plan snapshot pending
+	// whose classifier maps were already mutated in place. syncSnapshotLocked must
+	// therefore reach the deferred apply_snapshot publish for this snapshot.
+	seedDeferredPublishState := func(m *Manager, snap *ConfigSnapshot) {
+		m.lastSnapshot = snap
+		m.publishedSnapshot = 1
+		m.publishedPlanKey = snapshotBindingPlanKey(snap)
+		m.xskLivenessProven = false
+		m.xskLivenessFailed = false
+	}
+
+	// Core residual contract: a REJECTED deferred publish must fail closed.
+	t.Run("rejected_deferred_publish_disables_ctrl", func(t *testing.T) {
+		m, ctrlMap, snap, controlSock := newFailClosedManager4959(t)
+		snapCopy := snap
+		m.mu.Lock()
+		seedDeferredPublishState(m, &snapCopy)
+		m.mu.Unlock()
+		// The status loop's deferred publish is rejected (helper-side validation
+		// failure) — the exact fail-open trigger, on the second apply site.
+		startArmControlServerReject(t, controlSock, 1)
+
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 1 {
+			t.Fatalf("precondition: ctrl.Enabled = %d, want 1 (running enabled firewall)", got)
+		}
+
+		m.mu.Lock()
+		err := m.syncSnapshotLocked()
+		m.mu.Unlock()
+		if err == nil {
+			t.Fatal("syncSnapshotLocked must return the rejection error")
+		}
+		if got := readCtrlEnabled4959(t, ctrlMap); got != 0 {
+			t.Fatalf("ctrl.Enabled = %d after a rejected deferred publish, want 0 (fail closed); "+
+				"the pendingXSKStartup branch mutated the classifier maps in place and the helper "+
+				"kept the previous-good snapshot, so a still-enabled shim runs classifier maps a "+
+				"generation ahead of the applied snapshot (#4959 fail-open residual)", got)
+		}
+	})
+
+	// No-regression: a SUCCESSFUL deferred publish must land, proving the
+	// fail-closed wrap is transparent on success. The wrap only disables ctrl /
+	// surfaces a publish-rejection error when requestLocked fails; on OK:true it
+	// calls requestLocked exactly as the pre-fix bare publish did and returns
+	// nil. syncSnapshotLocked advances publishedSnapshot immediately after the
+	// successful publish and BEFORE the downstream applyHelperStatusLocked, so a
+	// landed publish (publishedSnapshot == the new generation) proves the wrap
+	// did not reject or short-circuit. applyHelperStatusLocked then touches BPF
+	// maps not injected in this unit harness and may return a "sync helper
+	// status: ... map not loaded" error AFTER the publish already landed; that is
+	// tolerated here exactly as the sibling applyHelperStatusLocked unit tests
+	// do — it is not a publish rejection. (The "success never disables ctrl via
+	// the wrap" guarantee is proven directly by
+	// TestAddressOnlyCommitRejectedPublishFailsClosed4959/successful_publish_keeps_ctrl_enabled,
+	// which drives the same shared helper with mapsMutatedInPlace=true.)
+	t.Run("successful_deferred_publish_lands", func(t *testing.T) {
+		m, _, snap, controlSock := newFailClosedManager4959(t)
+		snapCopy := snap
+		m.mu.Lock()
+		seedDeferredPublishState(m, &snapCopy)
+		m.mu.Unlock()
+		startArmControlServer(t, controlSock, 1) // responds OK:true
+
+		m.mu.Lock()
+		err := m.syncSnapshotLocked()
+		published := m.publishedSnapshot
+		m.mu.Unlock()
+		if published != snapCopy.Generation {
+			t.Fatalf("publishedSnapshot = %d after a successful deferred publish, want %d "+
+				"(the publish must land; the fail-closed wrap must be transparent on success)",
+				published, snapCopy.Generation)
+		}
+		if err != nil && strings.Contains(err.Error(), "publish userspace snapshot") {
+			t.Fatalf("a successful deferred publish must not surface a publish-rejection error: %v", err)
+		}
+	})
+}
+
+// TestSyncSnapshotRoutesPublishThroughFailClosedHelper4959 is a source-level
+// guard binding the SECOND apply_snapshot site. A revert cannot re-inline a bare
+// requestLocked(apply_snapshot) at the syncSnapshotLocked deferred-publish site
+// and slip past the behavioral test above. The deferred-publish path only ever
+// publishes a snapshot whose classifier maps the pendingXSKStartup branch already
+// mutated in place, so it MUST route through publishSnapshotFailClosedLocked with
+// mapsMutatedInPlace hard-coded true.
+func TestSyncSnapshotRoutesPublishThroughFailClosedHelper4959(t *testing.T) {
+	t.Parallel()
+	src := goFunctionSource(t, "process_status.go", "syncSnapshotLocked")
+	if !strings.Contains(src, "publishSnapshotFailClosedLocked(&publishSnap, &status, true)") {
+		t.Fatalf("syncSnapshotLocked must publish the deferred snapshot via "+
+			"publishSnapshotFailClosedLocked(..., true) so a rejected deferred "+
+			"apply_snapshot fails closed (#4959 residual); got:\n%s", src)
+	}
+}

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -329,8 +329,14 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 	// and Go can't track removal of those entries via the index.
 	publishSnap := *snap
 	publishSnap.Neighbors = filterPublishableNeighbors(snap.Neighbors)
-	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: &publishSnap}, &status); err != nil {
-		return result, fmt.Errorf("publish userspace snapshot: %w", err)
+	// #4959: on the samePlanRefresh path the classifier BPF maps were already
+	// mutated IN PLACE above (syncUserspaceClassifierMapsFailClosedLocked) with
+	// ctrl still enabled; publishSnapshotFailClosedLocked disables ctrl if this
+	// publish is rejected so the maps can never run a generation ahead of the
+	// applied Rust snapshot (fail-open). The bootstrap path already set
+	// ctrl.Enabled=0, so it needs no extra fail-closed.
+	if err := m.publishSnapshotFailClosedLocked(&publishSnap, &status, samePlanRefresh); err != nil {
+		return result, err
 	}
 	m.logWgEndpointSetTransitionLocked(&publishSnap, "apply")
 	m.lastSnapshot = snap
@@ -394,6 +400,37 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 	m.cfg = ucfg
 	m.recordApplyResultLocked(dataplane.ApplyResultFromCompileResult(result), caps, snap.Generation)
 	return result, nil
+}
+
+// publishSnapshotFailClosedLocked sends apply_snapshot to the running helper and
+// makes an in-place classifier-map refresh + helper publish one fail-closed
+// transaction (#4959).
+//
+// When mapsMutatedInPlace is true the caller took the samePlanRefresh path: the
+// ingress/local/interface-NAT classifier BPF maps were mutated IN PLACE to the
+// new plan while the XDP shim's ctrl gate is still enabled. If the helper then
+// REJECTS the snapshot (helper-side validation failure, or any transport error)
+// it keeps enforcing the previous-good snapshot, so returning the error while
+// leaving ctrl enabled would run the shim against classifier maps a generation
+// ahead of the applied Rust snapshot — wrong kernel-pass vs XSK-redirect and
+// wrong local-vs-interface-NAT ownership, a fail-OPEN security/availability
+// mismatch instead of the intended previous-good retention. On that path a
+// publish error disables ctrl (failClosedUserspaceCtrlMapLocked) so transit
+// drops to the kernel-only fail-closed posture until a subsequent good commit
+// re-publishes and re-enables it.
+//
+// When mapsMutatedInPlace is false the caller took the full bootstrap path,
+// which already programmed ctrl.Enabled=0 before this publish, so a publish
+// error is already fail-closed and the error is returned unchanged.
+func (m *Manager) publishSnapshotFailClosedLocked(publishSnap *ConfigSnapshot, status *ProcessStatus, mapsMutatedInPlace bool) error {
+	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: publishSnap}, status); err != nil {
+		publishErr := fmt.Errorf("publish userspace snapshot: %w", err)
+		if mapsMutatedInPlace {
+			return m.failClosedUserspaceCtrlMapLocked(publishSnap, publishErr)
+		}
+		return publishErr
+	}
+	return nil
 }
 
 // UpdatePolicyScheduleState republishes the userspace policy snapshot with one

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -265,21 +265,37 @@ func (m *Manager) lookupUserspaceCtrlForFailClosed(ctrlMap *ebpf.Map, key uint32
 
 func (m *Manager) syncUserspaceClassifierMapsFailClosedLocked(snapshot *ConfigSnapshot) error {
 	if err := m.syncUserspaceClassifierMapsLocked(snapshot); err != nil {
-		ctrlMap := m.bpfShim.Map(mapNameUserspaceCtrl)
-		if ctrlMap == nil {
-			return err
-		}
-		var ctrl userspaceCtrlValue
-		zero := uint32(0)
-		if lookupErr := m.lookupUserspaceCtrlForFailClosed(ctrlMap, zero, &ctrl); lookupErr != nil {
-			if errors.Is(lookupErr, ebpf.ErrKeyNotExist) {
-				return err
-			}
-			return m.blindFailClosedUserspaceCtrlLocked(ctrlMap, snapshot, err, lookupErr)
-		}
-		return m.failClosedUserspaceCtrlLocked(ctrlMap, ctrl, err)
+		return m.failClosedUserspaceCtrlMapLocked(snapshot, err)
 	}
 	return nil
+}
+
+// failClosedUserspaceCtrlMapLocked drives the userspace_ctrl shim to the
+// fail-closed state (Enabled=0) so the XDP shim stops redirecting transit to
+// XSK and only passes proven local/control traffic to the kernel. It is the
+// shared fail-closed action for any error that leaves the ingress/local/
+// interface-NAT classifier BPF maps mutated to a plan the running Rust snapshot
+// has NOT accepted: a classifier-map write failure
+// (syncUserspaceClassifierMapsFailClosedLocked) OR a rejected apply_snapshot
+// after an in-place same-plan refresh (#4959). cause is returned, wrapped with
+// any secondary lookup/update error. When the ctrl row is unreadable the blind
+// path reconstructs a disabled row from the snapshot; a genuinely-absent row
+// (fresh boot, never enabled) is already fail-closed and returns cause
+// unchanged.
+func (m *Manager) failClosedUserspaceCtrlMapLocked(snapshot *ConfigSnapshot, cause error) error {
+	ctrlMap := m.bpfShim.Map(mapNameUserspaceCtrl)
+	if ctrlMap == nil {
+		return cause
+	}
+	var ctrl userspaceCtrlValue
+	zero := uint32(0)
+	if lookupErr := m.lookupUserspaceCtrlForFailClosed(ctrlMap, zero, &ctrl); lookupErr != nil {
+		if errors.Is(lookupErr, ebpf.ErrKeyNotExist) {
+			return cause
+		}
+		return m.blindFailClosedUserspaceCtrlLocked(ctrlMap, snapshot, cause, lookupErr)
+	}
+	return m.failClosedUserspaceCtrlLocked(ctrlMap, ctrl, cause)
 }
 
 func (m *Manager) blindFailClosedUserspaceCtrlLocked(

--- a/pkg/dataplane/userspace/process_status.go
+++ b/pkg/dataplane/userspace/process_status.go
@@ -99,8 +99,24 @@ func (m *Manager) syncSnapshotLocked() error {
 		return err
 	}
 	var status ProcessStatus
-	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: &publishSnap}, &status); err != nil {
-		return fmt.Errorf("publish userspace snapshot: %w", err)
+	// #4959: this deferred-publish resume path only ever publishes an
+	// m.lastSnapshot that the pendingXSKStartup branch of Compile left ahead of
+	// m.publishedSnapshot — and that branch ALWAYS mutated the ingress/local/
+	// interface-NAT classifier BPF maps IN PLACE first
+	// (syncUserspaceClassifierMapsFailClosedLocked(snap)) with ctrl still
+	// enabled. It is the sole producer of an unpublished lastSnapshot: every
+	// other publish site (Compile normal path, route-overlay, policy-scheduler,
+	// deferred-worker-arm) advances m.publishedSnapshot only AFTER a successful
+	// publish, so none can strand a same-plan refresh here. An address-only
+	// commit landing during the XSK-startup liveness-probe window (ctrl flipped
+	// to Enabled=1 to probe) is exactly that case. Therefore mapsMutatedInPlace
+	// is unconditionally true here: if the helper REJECTS this publish it keeps
+	// enforcing the previous-good snapshot, so leaving ctrl enabled would run
+	// the shim against classifier maps a generation ahead of the applied Rust
+	// snapshot (fail OPEN). publishSnapshotFailClosedLocked disables ctrl on a
+	// rejection so transit drops to the kernel-only fail-closed posture.
+	if err := m.publishSnapshotFailClosedLocked(&publishSnap, &status, true); err != nil {
+		return err
 	}
 	// #1197 v5 (Codex code-review v4 #1): rebuild listener
 	// caches AFTER successful publish on the deferred-publish


### PR DESCRIPTION
## Problem (#4959, High, dataplane/nat)

An **address-only** commit (edit a local address or an interface-NAT address) leaves the worker/ring/interface-binding/fabric `snapshotBindingPlanKey` unchanged, so `Compile` takes the lightweight `samePlanRefresh` path (`manager_compile.go`). That path rewrites the ingress / local-address / interface-NAT **classifier BPF maps IN PLACE** (`syncUserspaceClassifierMapsFailClosedLocked`, `maps_sync.go`) while the XDP shim's `ctrl` gate is still enabled, then publishes `apply_snapshot`.

If the helper then **rejects** the snapshot (helper-side validation failure, or any transport error), the old code returned the error but left the classifier maps on the **new** plan with **ctrl still enabled**. The helper keeps enforcing the previous-good snapshot, so the shim reads classifier maps a generation *ahead* of the applied Rust snapshot — wrong kernel-pass vs XSK-redirect, wrong local-vs-interface-NAT ownership: a **fail-OPEN** security/availability mismatch instead of the intended previous-good retention.

## Fix — option (b): fail-closed transaction on the fast path

Make the in-place classifier-map refresh + helper publish one fail-closed transaction:

- Extracted `failClosedUserspaceCtrlMapLocked` (the classifier fail-closed action already used on the map-write-error path) so it can be reused.
- Added `publishSnapshotFailClosedLocked(publishSnap, status, mapsMutatedInPlace)`; `Compile` routes its `apply_snapshot` through it with the `samePlanRefresh` flag.
- On a same-plan publish rejection it disables `ctrl` (`Enabled=0`), dropping transit to the kernel-only fail-closed posture until a subsequent good commit re-publishes and re-enables it (`applyHelperStatusLocked`).

**Why (b) not (a):** adding local/interface-NAT addresses to `snapshotBindingPlanKey` would force *every* address edit through the full bootstrap path (`programBootstrapMapsLocked` sets `ctrl.Enabled=0` **and** clears binding rows + zeros the heartbeat), blipping transit on every *successful* address commit — a real regression. The bootstrap path is already fail-closed (it programs `ctrl.Enabled=0` before its publish), so the new helper no-ops there; the fix keeps the fast path and only closes the ctrl gate on rejection.

## Test — fail-on-revert

`addr_only_commit_failclosed_4959_test.go` (real `userspace_ctrl` map seeded `Enabled=1`, control server that rejects `apply_snapshot`):

- **`rejected_publish_disables_ctrl`** — same-plan publish rejection must leave `ctrl.Enabled=0`. **Firsthand-verified RED on revert** (drops the `failClosedUserspaceCtrlMapLocked` call → ctrl stays `Enabled=1`).
- **`successful_publish_keeps_ctrl_enabled`** — happy path leaves ctrl untouched.
- **`bootstrap_path_does_not_failclose`** — fail-closed is specific to the in-place refresh path.
- **`TestCompileRoutesPublishThroughFailClosedHelper4959`** — source-guard binding the Compile publish site to the fail-closed helper (catches a call-site re-inline).

## Docs

Documented the transaction in the Go Manager "Snapshot Protocol" section of `docs/userspace-dataplane-architecture.md`, and distinguished it from the Rust-side reconcile-ordering invariant (#2440/#2444/#3789).

## Validation

- `gofmt` clean; `go build ./...`; `go test ./pkg/dataplane/...` green.
- Privileged run of the new behavioral test passes; goes RED when the fix is neutralized (verified firsthand). The six privileged failures in the broader userspace suite (`userspace_ingress_ifaces map not loaded` / XDP-shim packet tests) are **pre-existing environmental** failures — confirmed identical on pristine `origin/master` — needing the real compiled shim / kernel XDP path this sandbox lacks.

Closes #4959

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StzTEVZ1qZL68onuvH3shi