### PR TITLE
cluster: reqID-bound rollback restores demoted owner on requester-side failover abort (#5079)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -55990,3 +55990,25 @@ top.
   userspace-dp/src/afxdp/coordinator/mod.rs,
   userspace-dp/src/afxdp/coordinator/tests.rs,
   userspace-dp/src/afxdp/coordinator/README.md
+
+- **Timestamp**: 2026-07-22
+  **Action**: #5079 — owner-side transfer-out lease so a requester-side
+  post-ACK failover abort/crash cannot strand the demoted owner secondary.
+  `RequestPeerFailover` demotes the remote owner (ManualFailover, VRRP resign)
+  on the ACK, before the requester's own commit checks; `abortRequestedPeerFailover`
+  rolled back only the requester locally — no abort frame reached the owner and no
+  lease auto-restored it, so an abort/crash/fabric-loss left both nodes secondary
+  (electRG's dual-resign guard never fires against a healthy-secondary peer).
+  Fix: reqID-bound auto-restore lease armed on the owner when a REMOTE request
+  demotes an RG (ArmRemoteTransferOutLease), cleared reqID-bound on the matching
+  commit (ClearRemoteTransferOutLease); electRG restores the owner on lease expiry.
+  Receiver-only self-heal (reqID already on the wire — no new frame, no mixed-base
+  risk). reqID threaded into OnRemoteFailover*/Commit* callbacks. ManualFailover/
+  Batch/ForceSecondary clear any stale lease so operator/ISSU holds are never
+  auto-restored. Fail-on-revert test firsthand-verified RED
+  (TestRemoteTransferOutLeaseRestoresOwnerWhenNoCommitArrives + batch).
+  Full pkg/cluster + pkg/daemon suites green; go vet clean.
+  **File(s)**: pkg/cluster/failover.go, pkg/cluster/election.go,
+  pkg/cluster/manager.go, pkg/cluster/sync.go, pkg/cluster/sync_failover.go,
+  pkg/cluster/failover_lease_5079_test.go, pkg/cluster/sync_test.go,
+  pkg/cluster/README.md, pkg/daemon/daemon_ha_sync.go

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -33,7 +33,13 @@ locating any symbol below is now a matter of opening the named file.
   `abortRequestedPeerFailover`, `notePeerTransferCommitted`,
   `FinalizePeerTransferOut`, `FenceStatus`), the batch variants
   (`ManualFailoverBatch`, `RequestPeerFailoverBatch`,
-  `FinalizePeerTransferOutBatch`, etc.), and all transfer-commit
+  `FinalizePeerTransferOutBatch`, etc.), the owner-side
+  transfer-out lease (`ArmRemoteTransferOutLease`,
+  `ClearRemoteTransferOutLease`,
+  `SetRemoteTransferOutLeaseDuration`,
+  `clearRemoteTransferOutLeaseLocked`,
+  `manualFailoverRestoreWeightLocked`; see "Owner-side
+  transfer-out lease" below), and all transfer-commit
   state machine `*Locked` helpers
   (`applyPeerTransferOutOverrideLocked`,
   `clearPeerTransferOutOverrideLocked`,
@@ -676,6 +682,34 @@ outside the monitor loop:
   write (single-RG returns nil; batch skips that member) if it changed. Keep
   `failoverInProgress` cleaned up on every exit path so a superseded failover
   cannot wedge the next one.
+- **Owner-side transfer-out lease — a requester-side abort must not strand the
+  demoted owner (#5079).** `RequestPeerFailover` drives the remote owner through
+  `ManualFailover` (SecondaryHold, VRRP resigned) on the ACK, BEFORE the
+  requester runs its own post-ACK readiness/commit checks. If a requester-side
+  step fails after the ACK, `abortRequestedPeerFailover` rolls back only the
+  requester's LOCAL override — it sends no abort frame to the owner, and the
+  requester may roll back to a HEALTHY secondary. The pre-existing dual-resign
+  guard in `electRG` never rescues this: it clears `ManualFailover` only when the
+  PEER is itself resigned (weight 0) or in secondary-hold, not when the requester
+  is a healthy secondary — so the owner would sit in secondary-hold forever and
+  the cluster is left with NO primary (both secondary). Fix: the owner arms a
+  **reqID-bound auto-restore lease** (`ArmRemoteTransferOutLease`) when a REMOTE
+  request demotes it; the matching commit clears it (`ClearRemoteTransferOutLease`,
+  reqID-bound so a stale commit cannot clear a newer request's lease). If the
+  lease expires with no commit — abort, requester crash, or fabric loss — `electRG`
+  restores the owner (clears `ManualFailover`, restores monitor-derived weight,
+  re-elects). This is receiver-only self-healing: NO new wire frame (the reqID
+  already rides the failover request/commit payloads), so no mixed-base
+  compatibility concern, and it defends against requester death/partition that an
+  abort frame could not. Only a REMOTE transfer-out arms a lease; `ManualFailover`
+  / `ManualFailoverBatch` / `ForceSecondary` clear any stale entry at the demotion
+  site so a deliberate operator or ISSU hold is never auto-restored. The lease
+  duration (`SetRemoteTransferOutLeaseDuration`, default
+  `DefaultRemoteTransferOutLease` = 30s, floored at 15s) is sized above the
+  requester's worst-case post-ACK commit latency (local commit-ready settle +
+  commit round-trip) so a legitimate slow commit never trips it. reqID is threaded
+  into `OnRemoteFailover`/`OnRemoteFailoverBatch`/`OnRemoteFailoverCommit`/
+  `OnRemoteFailoverCommitBatch` (`sync.go`) to arm/clear it.
 - HA delete-sync callbacks fire from the GC loop. They must not block, and
   must log at `slog.Debug` — earlier `slog.Info` flooded at 15 req/s and
   drowned out real diagnostics (per CLAUDE.md logging rules).

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -65,34 +65,46 @@ func (m *Manager) electRG(rg *RedundancyGroupState, peerGroup *PeerGroupState) (
 	// transfer-out or weight=0 state and immediately re-elects itself as
 	// primary, defeating the handoff.
 	if rg.ManualFailover {
-		peerResigned := peerGroup != nil && peerGroup.Weight <= 0
-		peerTransferOut := peerGroup != nil && peerGroup.State == StateSecondaryHold
-		if !peerResigned && !peerTransferOut {
-			return electNoChange, ""
+		// Owner-side transfer-out lease (#5079). A peer-requested transfer-out
+		// demoted us BEFORE the requester ran its own post-ACK commit checks. If
+		// the requester aborted after the ACK — or crashed / lost the fabric — it
+		// sent no commit AND no abort, and it may have rolled back to a HEALTHY
+		// secondary, a state the dual-resign guard below never rescues (that guard
+		// needs the peer resigned or itself in secondary-hold). Once the lease
+		// expires with no commit, restore ourselves so a failed coordinated
+		// failover cannot leave both nodes secondary. A committed transfer clears
+		// the lease first (reqID-bound), so this never fires on a real handoff.
+		if until, leased := m.remoteTransferOutLeaseUntil[rg.GroupID]; leased && !time.Now().Before(until) {
+			slog.Warn("cluster: remote transfer-out lease expired without commit, restoring",
+				"rg", rg.GroupID, "req_id", m.remoteTransferOutLeaseReqID[rg.GroupID])
+			m.clearRemoteTransferOutLeaseLocked(rg.GroupID)
+			rg.ManualFailover = false
+			rg.ManualFailoverAt = time.Time{}
+			m.manualFailoverRestoreWeightLocked(rg)
+			clearedManualFailover = true
+			// Fall through to normal priority/tie-break election below.
+		} else {
+			peerResigned := peerGroup != nil && peerGroup.Weight <= 0
+			peerTransferOut := peerGroup != nil && peerGroup.State == StateSecondaryHold
+			if !peerResigned && !peerTransferOut {
+				return electNoChange, ""
+			}
+			if time.Since(rg.ManualFailoverAt) < 2*time.Second {
+				return electNoChange, ""
+			}
+			// The peer has also yielded for >2s. Clear manual failover and
+			// restore weight so normal election can promote one node.
+			slog.Info("cluster: clearing manual failover (peer also yielded)",
+				"rg", rg.GroupID,
+				"peer_state", peerGroup.State.String(),
+				"peer_weight", peerGroup.Weight)
+			rg.ManualFailover = false
+			rg.ManualFailoverAt = time.Time{}
+			// Recalculate weight (recalcWeight calls runElection which would
+			// recurse back to electRG).
+			m.manualFailoverRestoreWeightLocked(rg)
+			clearedManualFailover = true
 		}
-		if time.Since(rg.ManualFailoverAt) < 2*time.Second {
-			return electNoChange, ""
-		}
-		// The peer has also yielded for >2s. Clear manual failover and
-		// restore weight so normal election can promote one node.
-		slog.Info("cluster: clearing manual failover (peer also yielded)",
-			"rg", rg.GroupID,
-			"peer_state", peerGroup.State.String(),
-			"peer_weight", peerGroup.Weight)
-		rg.ManualFailover = false
-		rg.ManualFailoverAt = time.Time{}
-		// Recalculate weight inline (recalcWeight calls runElection
-		// which would recurse back to electRG).
-		totalLost := 0
-		for _, iface := range rg.MonitorFails {
-			key := monitorKey{rgID: rg.GroupID, iface: iface}
-			totalLost += m.monitorWeights[key]
-		}
-		rg.Weight = 255 - totalLost
-		if rg.Weight < 0 {
-			rg.Weight = 0
-		}
-		clearedManualFailover = true
 	}
 
 	localWeight := rg.Weight

--- a/pkg/cluster/failover.go
+++ b/pkg/cluster/failover.go
@@ -118,6 +118,11 @@ func (m *Manager) ManualFailover(rgID int) error {
 		return nil
 	}
 	oldState := rg.State
+	// A fresh manual failover supersedes any prior remote transfer-out lease on
+	// this RG. The remote path re-arms via ArmRemoteTransferOutLease after this
+	// returns; a local operator failover leaves it cleared so its deliberate
+	// hold is never auto-restored (#5079).
+	m.clearRemoteTransferOutLeaseLocked(rgID)
 	rg.ManualFailover = true
 	rg.ManualFailoverAt = time.Now()
 	rg.State = StateSecondaryHold
@@ -145,6 +150,9 @@ func (m *Manager) ForceSecondary() error {
 			continue
 		}
 		oldState := rg.State
+		// ISSU force-secondary is a deliberate drain; drop any remote
+		// transfer-out lease so it is never auto-restored (#5079).
+		m.clearRemoteTransferOutLeaseLocked(rg.GroupID)
 		rg.Weight = 0
 		rg.ManualFailover = true
 		rg.ManualFailoverAt = time.Now()
@@ -361,6 +369,96 @@ func (m *Manager) notePeerTransferCommitted(rgID int) {
 	m.peerGroups[rgID] = peerGroup
 }
 
+// =============================================================================
+// Owner-side transfer-out lease (#5079).
+//
+// A peer-requested transfer-out demotes this node to secondary-hold BEFORE the
+// requester runs its own post-ACK commit checks. If a requester-side step fails
+// after the ACK, the requester rolls back only its LOCAL override
+// (abortRequestedPeerFailover) and sends no abort frame — and if the requester
+// crashes or the fabric drops, no commit ever arrives either. Without a bound
+// the demoted owner sits in secondary-hold forever while its peer is a healthy
+// secondary, stranding the cluster with no primary (both nodes secondary). The
+// existing dual-resign guard in electRG does NOT rescue this case: it only
+// clears ManualFailover when the peer itself is resigned (weight 0) or in
+// secondary-hold, not when the requester aborted back to a healthy secondary.
+//
+// The lease is armed when a REMOTE failover request demotes the RG and is
+// cleared on the matching commit (reqID-bound). If it expires with no commit,
+// electRG restores the owner. A local operator ManualFailover / ISSU
+// ForceSecondary clears any stale lease so their deliberate holds are never
+// auto-restored.
+// =============================================================================
+
+// SetRemoteTransferOutLeaseDuration overrides how long an armed remote
+// transfer-out lease survives without a commit before electRG restores the
+// owner. The daemon sizes this above its configured local commit-ready settle
+// window plus the commit round-trip so the lease never fires on an in-flight
+// commit. Values below minRemoteTransferOutLease are floored.
+func (m *Manager) SetRemoteTransferOutLeaseDuration(d time.Duration) {
+	if d < minRemoteTransferOutLease {
+		d = minRemoteTransferOutLease
+	}
+	m.mu.Lock()
+	m.remoteTransferOutLease = d
+	m.mu.Unlock()
+}
+
+// ArmRemoteTransferOutLease binds an auto-restore lease to each RG that a peer
+// request has just demoted, so a requester-side post-ACK abort/crash cannot
+// strand the owner secondary (#5079). Only RGs actually holding ManualFailover
+// are armed — a demotion superseded by a concurrent reset (which cleared the
+// hold) leaves no lease, so the owner is never spuriously restored.
+func (m *Manager) ArmRemoteTransferOutLease(rgIDs []int, reqID uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	until := time.Now().Add(m.remoteTransferOutLease)
+	for _, rgID := range rgIDs {
+		rg, ok := m.groups[rgID]
+		if !ok || !rg.ManualFailover {
+			continue
+		}
+		m.remoteTransferOutLeaseUntil[rgID] = until
+		m.remoteTransferOutLeaseReqID[rgID] = reqID
+		slog.Info("cluster: armed remote transfer-out lease",
+			"rg", rgID, "req_id", reqID, "expires_in", m.remoteTransferOutLease.String())
+	}
+}
+
+// ClearRemoteTransferOutLease disarms the lease for an RG once the transfer-out
+// is committed. It is reqID-bound: a stale/duplicate commit carrying an older
+// request ID must not clear a newer request's lease. A commit for the current
+// lease's reqID always clears it.
+func (m *Manager) ClearRemoteTransferOutLease(rgID int, reqID uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if cur, ok := m.remoteTransferOutLeaseReqID[rgID]; ok && cur != reqID {
+		return
+	}
+	m.clearRemoteTransferOutLeaseLocked(rgID)
+}
+
+func (m *Manager) clearRemoteTransferOutLeaseLocked(rgID int) {
+	delete(m.remoteTransferOutLeaseUntil, rgID)
+	delete(m.remoteTransferOutLeaseReqID, rgID)
+}
+
+// manualFailoverRestoreWeightLocked recomputes an RG's monitor-derived weight
+// after ManualFailover is cleared. It is used by BOTH the dual-resign guard and
+// the transfer-out lease expiry in electRG; it deliberately does NOT run
+// election (recalcWeight would recurse back into electRG). Caller holds m.mu.
+func (m *Manager) manualFailoverRestoreWeightLocked(rg *RedundancyGroupState) {
+	totalLost := 0
+	for _, iface := range rg.MonitorFails {
+		key := monitorKey{rgID: rg.GroupID, iface: iface}
+		totalLost += m.monitorWeights[key]
+	}
+	rg.Weight = 255 - totalLost
+	if rg.Weight < 0 {
+		rg.Weight = 0
+	}
+}
+
 // FinalizePeerTransferOut completes a previously acknowledged transfer-out
 // after the peer commits ownership on the sync channel.
 func (m *Manager) FinalizePeerTransferOut(rgID int) error {
@@ -541,6 +639,9 @@ func (m *Manager) ManualFailoverBatch(rgIDs []int) error {
 			continue
 		}
 		oldState := rg.State
+		// Fresh batch failover supersedes any prior remote transfer-out lease;
+		// the remote path re-arms after this returns (#5079).
+		m.clearRemoteTransferOutLeaseLocked(rgID)
 		rg.ManualFailover = true
 		rg.ManualFailoverAt = now
 		rg.State = StateSecondaryHold

--- a/pkg/cluster/failover_lease_5079_test.go
+++ b/pkg/cluster/failover_lease_5079_test.go
@@ -1,0 +1,190 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRemoteTransferOutLeaseRestoresOwnerWhenNoCommitArrives is the #5079
+// fail-on-revert guard. A peer failover request demotes this node to
+// secondary-hold and arms a reqID-bound auto-restore lease. The requester then
+// aborts after the ACK (or crashes / loses the fabric): it sends no commit AND
+// no abort frame, and rolls back to a HEALTHY secondary. Before the lease this
+// stranded the cluster with both nodes secondary forever — the pre-existing
+// dual-resign 2s guard never rescues it because a healthy secondary peer is
+// neither resigned (weight 0) nor in secondary-hold. Once the lease expires with
+// no commit, electRG restores the owner.
+//
+// Revert the electRG lease-expiry branch and this test goes RED: the owner stays
+// secondary-hold against the healthy-secondary peer.
+func TestRemoteTransferOutLeaseRestoresOwnerWhenNoCommitArrives(t *testing.T) {
+	m := NewManager(0, 1)
+	// Owner outranks the peer so, once the hold clears, normal election promotes
+	// the owner back to primary.
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	// Peer failover request → demote to secondary-hold, then arm the lease
+	// exactly as the daemon's OnRemoteFailover wiring does.
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("ManualFailover() error = %v", err)
+	}
+	<-m.Events()
+	m.ArmRemoteTransferOutLease([]int{0}, 42)
+
+	m.mu.Lock()
+	m.groups[0].Ready = true
+	m.groups[0].ReadySince = time.Now().Add(-time.Hour)
+	m.groups[0].ReadinessReasons = nil
+	m.mu.Unlock()
+
+	// Requester aborted post-ACK, sent no commit, and is a healthy secondary.
+	pkt := &HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 0, Priority: 100, Weight: 255, State: uint8(StateSecondary)},
+		},
+	}
+	m.handlePeerHeartbeat(pkt)
+	if m.IsLocalPrimary(0) {
+		t.Fatal("owner must stay secondary-hold while the transfer-out lease is live")
+	}
+
+	// Prove the pre-existing dual-resign 2s guard does NOT rescue this: age past
+	// the 2s window while the lease is still live — still stranded.
+	m.mu.Lock()
+	m.groups[0].ManualFailoverAt = time.Now().Add(-3 * time.Second)
+	m.mu.Unlock()
+	m.handlePeerHeartbeat(pkt)
+	if m.IsLocalPrimary(0) {
+		t.Fatal("dual-resign 2s guard must not restore against a healthy-secondary peer")
+	}
+
+	// Expire the lease with no commit; the owner must reclaim primary.
+	m.mu.Lock()
+	m.remoteTransferOutLeaseUntil[0] = time.Now().Add(-time.Second)
+	m.mu.Unlock()
+	m.handlePeerHeartbeat(pkt)
+
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("owner must reclaim primary once the transfer-out lease expires without a commit")
+	}
+	m.mu.Lock()
+	_, leaseLeft := m.remoteTransferOutLeaseUntil[0]
+	manual := m.groups[0].ManualFailover
+	m.mu.Unlock()
+	if leaseLeft {
+		t.Fatal("expired lease must be cleared after restore")
+	}
+	if manual {
+		t.Fatal("ManualFailover must be cleared after lease restore")
+	}
+}
+
+// TestRemoteTransferOutLeaseClearIsReqIDBound verifies a stale/duplicate commit
+// carrying an older request ID cannot clear a newer request's lease, while the
+// matching commit does.
+func TestRemoteTransferOutLeaseClearIsReqIDBound(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("ManualFailover() error = %v", err)
+	}
+	<-m.Events()
+	m.ArmRemoteTransferOutLease([]int{0}, 42)
+
+	// Stale commit for a different request must not clear the lease.
+	m.ClearRemoteTransferOutLease(0, 41)
+	m.mu.Lock()
+	_, stillLeased := m.remoteTransferOutLeaseUntil[0]
+	m.mu.Unlock()
+	if !stillLeased {
+		t.Fatal("a stale reqID must not clear a newer lease")
+	}
+
+	// The matching commit clears it.
+	m.ClearRemoteTransferOutLease(0, 42)
+	m.mu.Lock()
+	_, leasedAfter := m.remoteTransferOutLeaseUntil[0]
+	m.mu.Unlock()
+	if leasedAfter {
+		t.Fatal("the matching reqID must clear the lease")
+	}
+}
+
+// TestLocalManualFailoverClearsRemoteTransferOutLease verifies a deliberate
+// operator failover supersedes any stale remote transfer-out lease, so an
+// operator (or ISSU) hold is never auto-restored underneath them.
+func TestLocalManualFailoverClearsRemoteTransferOutLease(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("ManualFailover() error = %v", err)
+	}
+	<-m.Events()
+	m.ArmRemoteTransferOutLease([]int{0}, 7)
+
+	// A fresh local manual failover supersedes the lease (no re-arm follows).
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("second ManualFailover() error = %v", err)
+	}
+	m.mu.Lock()
+	_, leased := m.remoteTransferOutLeaseUntil[0]
+	m.mu.Unlock()
+	if leased {
+		t.Fatal("a fresh local manual failover must clear any stale remote transfer-out lease")
+	}
+}
+
+// TestRemoteTransferOutLeaseRestoresBatchOwners exercises the multi-RG path: a
+// batch transfer-out arms a lease per RG, and expiry restores every member.
+func TestRemoteTransferOutLeaseRestoresBatchOwners(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(1, false, map[int]int{0: 200}),
+		makeRG(2, false, map[int]int{0: 200}),
+	)
+	m.UpdateConfig(cfg)
+	<-m.Events()
+	<-m.Events()
+
+	if err := m.ManualFailoverBatch([]int{1, 2}); err != nil {
+		t.Fatalf("ManualFailoverBatch() error = %v", err)
+	}
+	<-m.Events()
+	<-m.Events()
+	m.ArmRemoteTransferOutLease([]int{1, 2}, 99)
+
+	m.mu.Lock()
+	for _, id := range []int{1, 2} {
+		m.groups[id].Ready = true
+		m.groups[id].ReadySince = time.Now().Add(-time.Hour)
+		m.groups[id].ReadinessReasons = nil
+		m.remoteTransferOutLeaseUntil[id] = time.Now().Add(-time.Second)
+	}
+	m.mu.Unlock()
+
+	pkt := &HeartbeatPacket{
+		NodeID:    1,
+		ClusterID: 1,
+		Groups: []HeartbeatGroup{
+			{GroupID: 1, Priority: 100, Weight: 255, State: uint8(StateSecondary)},
+			{GroupID: 2, Priority: 100, Weight: 255, State: uint8(StateSecondary)},
+		},
+	}
+	m.handlePeerHeartbeat(pkt)
+
+	for _, id := range []int{1, 2} {
+		if !m.IsLocalPrimary(id) {
+			t.Fatalf("rg %d must reclaim primary after batch transfer-out lease expiry", id)
+		}
+	}
+}

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -152,7 +152,25 @@ type Manager struct {
 	// immediately re-promote the old primary.
 	localTransferOutHoldUntil map[int]time.Time
 	peerTransferOutPrevious   map[int]peerGroupSnapshot
-	peerMonitors              []InterfaceMonitorInfo
+	// remoteTransferOutLeaseUntil bounds how long a peer-REQUESTED transfer-out
+	// keeps this node parked in secondary-hold without a commit. It is armed
+	// (ArmRemoteTransferOutLease) when a remote failover request demotes an RG
+	// via ManualFailover, and cleared on the matching commit
+	// (ClearRemoteTransferOutLease, reqID-bound). If the lease expires with no
+	// commit — a requester-side post-ACK abort/crash/partition that never sent
+	// (or could not send) the commit — electRG auto-restores this node so a
+	// failed coordinated failover cannot strand the cluster with both nodes
+	// secondary (#5079). Only a REMOTE transfer-out arms a lease; a local
+	// operator ManualFailover / ISSU ForceSecondary clears any stale entry so
+	// their deliberate holds are never auto-restored. Read/written under m.mu.
+	remoteTransferOutLeaseUntil map[int]time.Time
+	remoteTransferOutLeaseReqID map[int]uint64
+	// remoteTransferOutLease is how long an armed lease survives without a
+	// commit before electRG restores the owner. Sized above the requester's
+	// worst-case post-ACK commit latency; see DefaultRemoteTransferOutLease and
+	// SetRemoteTransferOutLeaseDuration.
+	remoteTransferOutLease time.Duration
+	peerMonitors           []InterfaceMonitorInfo
 
 	// lastDupNodeIDWarn rate-limits the duplicate-node-id warning (#4549 F11).
 	// A peer advertising the local node's own node-id is an invalid cluster
@@ -315,6 +333,21 @@ const DefaultPreManualFailoverRetryInterval = 500 * time.Millisecond
 const minTransferCommitGracePeriod = 10 * time.Second
 const transferCommitHeartbeatSlack = 5 * time.Second
 
+// DefaultRemoteTransferOutLease bounds how long a peer-requested transfer-out
+// keeps a demoted owner in secondary-hold without a commit before electRG
+// auto-restores it (#5079). The requester commits within its local
+// commit-ready settle window (localFailoverCommitTimeout, default 3s) plus the
+// commit round-trip, so 30s leaves ~10x headroom for a legitimate slow commit
+// while bounding a stranded-secondary outage to tens of seconds instead of
+// forever. The daemon raises this via SetRemoteTransferOutLeaseDuration when a
+// larger commit timeout is configured so the lease never fires on an in-flight
+// commit.
+const DefaultRemoteTransferOutLease = 30 * time.Second
+
+// minRemoteTransferOutLease floors SetRemoteTransferOutLeaseDuration so a
+// misconfigured tiny value cannot abort a legitimate in-flight commit.
+const minRemoteTransferOutLease = 15 * time.Second
+
 // NewManager creates a new cluster manager.
 func NewManager(nodeID, clusterID int) *Manager {
 	return &Manager{
@@ -329,6 +362,9 @@ func NewManager(nodeID, clusterID int) *Manager {
 		peerTransferCommitGraceUntil:   make(map[int]time.Time),
 		localTransferOutHoldUntil:      make(map[int]time.Time),
 		peerTransferOutPrevious:        make(map[int]peerGroupSnapshot),
+		remoteTransferOutLeaseUntil:    make(map[int]time.Time),
+		remoteTransferOutLeaseReqID:    make(map[int]uint64),
+		remoteTransferOutLease:         DefaultRemoteTransferOutLease,
 		localHAProtocolVersion:         CurrentHAProtocolVersion,
 		hbInterval:                     DefaultHeartbeatInterval,
 		hbThreshold:                    DefaultHeartbeatThreshold,

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -352,13 +352,18 @@ type SessionSync struct {
 	// seed Kea on takeover. Fires after the peer*DHCPLeases store is updated.
 	OnDHCPLeasesReceived func(family int, leases []dhcpserver.SyncLease)
 	// OnRemoteFailover is called when the peer requests a transfer-out for one RG.
-	OnRemoteFailover func(rgID int) error
+	// reqID is the request-scoped identifier carried on the wire; the demoted
+	// owner binds its auto-restore lease to it so a stale commit cannot clear a
+	// newer request's lease (#5079).
+	OnRemoteFailover func(rgID int, reqID uint64) error
 	// OnRemoteFailoverCommit finalizes the demoted side of an acknowledged handoff.
-	OnRemoteFailoverCommit func(rgID int) error
+	// reqID identifies the request being committed so the owner can clear the
+	// matching auto-restore lease (#5079).
+	OnRemoteFailoverCommit func(rgID int, reqID uint64) error
 	// OnRemoteFailoverBatch is called when the peer requests a multi-RG transfer-out.
-	OnRemoteFailoverBatch func(rgIDs []int) error
+	OnRemoteFailoverBatch func(rgIDs []int, reqID uint64) error
 	// OnRemoteFailoverCommitBatch finalizes a previously acknowledged multi-RG handoff.
-	OnRemoteFailoverCommitBatch func(rgIDs []int) error
+	OnRemoteFailoverCommitBatch func(rgIDs []int, reqID uint64) error
 	// WaitFailoverApplied, if set, blocks until the local node has ACTUATED
 	// the transfer-out just requested via OnRemoteFailover for one RG — i.e.
 	// the async demotion event has been consumed and the old owner fenced

--- a/pkg/cluster/sync_failover.go
+++ b/pkg/cluster/sync_failover.go
@@ -425,7 +425,7 @@ func (s *SessionSync) handleRemoteFailover(conn net.Conn, rgID int, reqID uint64
 		s.sendFailoverResult(conn, syncMsgFailoverAck, rgID, reqID, failoverAckFailed, "no remote failover handler")
 		return
 	}
-	if err := s.OnRemoteFailover(rgID); err != nil {
+	if err := s.OnRemoteFailover(rgID, reqID); err != nil {
 		status := failoverAckFailed
 		if errors.Is(err, ErrRemoteFailoverRejected) {
 			status = failoverAckRejected
@@ -454,7 +454,7 @@ func (s *SessionSync) handleRemoteFailoverBatch(conn net.Conn, rgIDs []int, reqI
 		s.sendFailoverBatchResult(conn, syncMsgFailoverBatchAck, rgIDs, reqID, failoverAckFailed, "no remote batch failover handler")
 		return
 	}
-	if err := s.OnRemoteFailoverBatch(rgIDs); err != nil {
+	if err := s.OnRemoteFailoverBatch(rgIDs, reqID); err != nil {
 		status := failoverAckFailed
 		if errors.Is(err, ErrRemoteFailoverRejected) {
 			status = failoverAckRejected
@@ -479,7 +479,7 @@ func (s *SessionSync) handleRemoteFailoverCommit(conn net.Conn, rgID int, reqID 
 		s.sendFailoverResult(conn, syncMsgFailoverCommitAck, rgID, reqID, failoverAckFailed, "no remote failover commit handler")
 		return
 	}
-	if err := s.OnRemoteFailoverCommit(rgID); err != nil {
+	if err := s.OnRemoteFailoverCommit(rgID, reqID); err != nil {
 		status := failoverAckFailed
 		if errors.Is(err, ErrRemoteFailoverRejected) {
 			status = failoverAckRejected
@@ -494,7 +494,7 @@ func (s *SessionSync) handleRemoteFailoverCommitBatch(conn net.Conn, rgIDs []int
 		s.sendFailoverBatchResult(conn, syncMsgFailoverBatchCommitAck, rgIDs, reqID, failoverAckFailed, "no remote batch failover commit handler")
 		return
 	}
-	if err := s.OnRemoteFailoverCommitBatch(rgIDs); err != nil {
+	if err := s.OnRemoteFailoverCommitBatch(rgIDs, reqID); err != nil {
 		status := failoverAckFailed
 		if errors.Is(err, ErrRemoteFailoverRejected) {
 			status = failoverAckRejected

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -3640,7 +3640,7 @@ func TestHandleMessageFailoverDoesNotBlockReceiveLoop(t *testing.T) {
 	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
 	started := make(chan int, 1)
 	release := make(chan struct{})
-	ss.OnRemoteFailover = func(rgID int) error {
+	ss.OnRemoteFailover = func(rgID int, reqID uint64) error {
 		started <- rgID
 		<-release
 		return nil
@@ -3723,7 +3723,7 @@ func TestHandleRemoteFailoverWithholdsAckUntilFenced(t *testing.T) {
 
 	// OnRemoteFailover models ManualFailover: it enqueues the async demotion
 	// and returns immediately (the node is NOT yet fenced here).
-	ss.OnRemoteFailover = func(rgID int) error { return nil }
+	ss.OnRemoteFailover = func(rgID int, reqID uint64) error { return nil }
 
 	// WaitFailoverApplied models the daemon barrier that blocks until
 	// watchClusterEvents actuates the demotion.
@@ -3799,7 +3799,7 @@ func TestHandleRemoteFailoverBatchWithholdsAckUntilFenced(t *testing.T) {
 	ss.stats.Connected.Store(true)
 
 	rgIDs := []int{1, 2}
-	ss.OnRemoteFailoverBatch = func([]int) error { return nil }
+	ss.OnRemoteFailoverBatch = func([]int, uint64) error { return nil }
 
 	fenced := make(chan struct{})
 	waitEntered := make(chan struct{}, 1)
@@ -4195,8 +4195,10 @@ func TestSendFailoverCommitWaitsForAck(t *testing.T) {
 func TestHandleRemoteFailoverCommitInvokesCallback(t *testing.T) {
 	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
 	done := make(chan int, 1)
-	ss.OnRemoteFailoverCommit = func(rgID int) error {
+	gotReqID := make(chan uint64, 1)
+	ss.OnRemoteFailoverCommit = func(rgID int, reqID uint64) error {
 		done <- rgID
+		gotReqID <- reqID
 		return nil
 	}
 
@@ -4213,12 +4215,17 @@ func TestHandleRemoteFailoverCommitInvokesCallback(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("remote failover commit callback did not run")
 	}
+	// #5079: the commit's request ID must reach the callback so the owner can
+	// clear the matching auto-restore lease.
+	if got := <-gotReqID; got != 99 {
+		t.Fatalf("callback reqID = %d, want 99", got)
+	}
 }
 
 func TestHandleRemoteFailoverBatchInvokesCallback(t *testing.T) {
 	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
 	done := make(chan []int, 1)
-	ss.OnRemoteFailoverBatch = func(rgIDs []int) error {
+	ss.OnRemoteFailoverBatch = func(rgIDs []int, reqID uint64) error {
 		done <- append([]int(nil), rgIDs...)
 		return nil
 	}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -985,11 +985,11 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			// already transitioned to secondary — blindly calling
 			// ManualFailover would cause dual-resign (both nodes secondary)
 			// and a 30-second traffic blackhole.
-			ss.OnRemoteFailover = func(rgID int) error {
+			ss.OnRemoteFailover = func(rgID int, reqID uint64) error {
 				if !d.cluster.IsLocalPrimary(rgID) {
 					return fmt.Errorf("%w: redundancy group %d", cluster.ErrRemoteFailoverRejected, rgID)
 				}
-				slog.Info("cluster: remote failover request from peer", "rg", rgID)
+				slog.Info("cluster: remote failover request from peer", "rg", rgID, "req_id", reqID)
 				// #5640: arm the fence-completion barrier BEFORE ManualFailover
 				// enqueues the async demotion event, so watchClusterEvents
 				// cannot actuate-and-forget before WaitFailoverApplied observes
@@ -1000,15 +1000,21 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					slog.Warn("cluster: remote failover failed", "rg", rgID, "err", err)
 					return err
 				}
+				// #5079: bind an auto-restore lease to this request. If the
+				// requester aborts after this ACK (or crashes / loses the fabric)
+				// and never sends a commit, electRG restores us when the lease
+				// expires so a failed coordinated failover cannot strand us
+				// secondary. The matching commit clears the lease.
+				d.cluster.ArmRemoteTransferOutLease([]int{rgID}, reqID)
 				return nil
 			}
-			ss.OnRemoteFailoverBatch = func(rgIDs []int) error {
+			ss.OnRemoteFailoverBatch = func(rgIDs []int, reqID uint64) error {
 				for _, rgID := range rgIDs {
 					if !d.cluster.IsLocalPrimary(rgID) {
 						return fmt.Errorf("%w: redundancy group %d", cluster.ErrRemoteFailoverRejected, rgID)
 					}
 				}
-				slog.Info("cluster: remote batch failover request from peer", "rgs", rgIDs)
+				slog.Info("cluster: remote batch failover request from peer", "rgs", rgIDs, "req_id", reqID)
 				// #5640: arm every member's fence barrier before the batch
 				// demotion enqueues its per-RG events.
 				for _, rgID := range rgIDs {
@@ -1021,13 +1027,27 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 					slog.Warn("cluster: remote batch failover failed", "rgs", rgIDs, "err", err)
 					return err
 				}
+				// #5079: bind auto-restore leases to this request across the set.
+				d.cluster.ArmRemoteTransferOutLease(rgIDs, reqID)
 				return nil
 			}
-			ss.OnRemoteFailoverCommit = func(rgID int) error {
-				return d.cluster.FinalizePeerTransferOut(rgID)
+			ss.OnRemoteFailoverCommit = func(rgID int, reqID uint64) error {
+				if err := d.cluster.FinalizePeerTransferOut(rgID); err != nil {
+					return err
+				}
+				// #5079: the transfer committed — drop the auto-restore lease so
+				// it can never fire on a legitimately completed handoff.
+				d.cluster.ClearRemoteTransferOutLease(rgID, reqID)
+				return nil
 			}
-			ss.OnRemoteFailoverCommitBatch = func(rgIDs []int) error {
-				return d.cluster.FinalizePeerTransferOutBatch(rgIDs)
+			ss.OnRemoteFailoverCommitBatch = func(rgIDs []int, reqID uint64) error {
+				if err := d.cluster.FinalizePeerTransferOutBatch(rgIDs); err != nil {
+					return err
+				}
+				for _, rgID := range rgIDs {
+					d.cluster.ClearRemoteTransferOutLease(rgID, reqID)
+				}
+				return nil
 			}
 			// #5640: gate the transfer-out applied-ack on the local demotion
 			// actually being actuated (VRRP resigned / rg_active cleared),
@@ -1044,6 +1064,11 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetPeerFailoverCommitBatchFunc(ss.SendFailoverCommitBatch)
 			d.cluster.SetPreManualFailoverHook(d.prepareUserspaceManualFailover)
 			d.cluster.SetLocalTransferCommitReadyHook(d.waitLocalFailoverCommitReady)
+			// #5079: size the owner-side transfer-out lease above the requester's
+			// worst-case post-ACK commit latency — the local commit-ready settle
+			// window (localFailoverCommitTimeout) plus the commit round-trip — so
+			// a legitimate slow commit never trips it. The cluster floors it.
+			d.cluster.SetRemoteTransferOutLeaseDuration(2*d.localFailoverCommitTimeout + 20*time.Second)
 			d.cluster.SetTransferReadinessFunc(d.userspaceTransferReadiness)
 			d.cluster.SetPeerTimeoutGuard(d.shouldSuppressPeerHeartbeatTimeout)
 			// #1792: while our heartbeat sockets restart (VRF rebind),


### PR DESCRIPTION
## Problem (#5079, codex-review-177 `[A5-b1-F2]`)

`RequestPeerFailover` drives the remote owner through `ManualFailover`
(SecondaryHold, VRRP resigned) on the ACK — **before** the requester runs its own
post-ACK readiness/commit checks. If a requester-side step fails after the ACK,
`abortRequestedPeerFailover` rolls back only the requester's **local** override:
no abort frame reaches the owner, and no lease auto-restores it. The requester may
also roll back to a *healthy secondary*, and `electRG`'s dual-resign guard clears
the owner's `ManualFailover` only when the **peer** is resigned (weight 0) or in
secondary-hold — never when the peer is a healthy secondary. So an abort, requester
crash, or fabric loss left the demoted owner stuck in secondary-hold indefinitely
and the cluster with **no primary (both nodes secondary)** — a persistent outage
from a coordinated operation.

Firsthand re-verified on current `origin/master` (`69b61d906`): `abortRequestedPeerFailover`
is still local-only, there is no `syncMsgFailoverAbort`, and no lease/expiry restores
the owner (the #5640 fence barrier only gates the applied-ack; it does not restore).

## Fix — owner-side reqID-bound auto-restore lease

- The owner arms a **reqID-bound lease** when a **remote** request demotes an RG
  (`ArmRemoteTransferOutLease`), and clears it **reqID-bound** on the matching commit
  (`ClearRemoteTransferOutLease` — a stale commit cannot clear a newer request's lease).
- If the lease expires with no commit, `electRG` restores the owner: clears
  `ManualFailover`, restores monitor-derived weight, and re-elects.
- **Receiver-only self-heal:** the reqID already rides the failover request/commit
  payloads, so there is **no new wire frame** and no mixed-base compatibility concern,
  and it defends against requester death/partition that an abort frame could not survive.
- reqID threaded into `OnRemoteFailover{,Batch}` / `OnRemoteFailoverCommit{,Batch}`.
- Only a **remote** transfer-out arms a lease; `ManualFailover` / `ManualFailoverBatch` /
  `ForceSecondary` clear any stale entry at the demotion site, so a deliberate operator
  or ISSU hold is never auto-restored.
- Lease duration (`SetRemoteTransferOutLeaseDuration`, default 30s floored at 15s) is
  sized above the requester's worst-case post-ACK commit latency (local commit-ready
  settle + commit round-trip) so a legitimate slow commit never trips it.

## Fail-on-revert tests (`failover_lease_5079_test.go`)

- `TestRemoteTransferOutLeaseRestoresOwnerWhenNoCommitArrives` — single-RG; also asserts
  the pre-existing 2s dual-resign guard does **not** rescue a healthy-secondary peer.
- `TestRemoteTransferOutLeaseRestoresBatchOwners` — multi-RG.
- `TestRemoteTransferOutLeaseClearIsReqIDBound` — reqID-bound clear.
- `TestLocalManualFailoverClearsRemoteTransferOutLease` — operator/ISSU hold not auto-restored.

**Firsthand-verified RED-on-revert:** neutralizing only the `electRG` lease-expiry
branch makes the single-RG and batch tests fail with the exact "must reclaim primary"
assertion.

## Validation

- `go build ./...` green; `go vet ./pkg/cluster/... ./pkg/daemon/...` clean.
- Full `pkg/cluster` and `pkg/daemon` suites green.
- Docs: `pkg/cluster/README.md` gains the owner-side transfer-out lease contract
  (file map + gotchas).

> Failover-protocol change — the parent should run `make test-failover` before merge.

Closes #5079

🤖 Generated with [Claude Code](https://claude.com/claude-code)