### PR TITLE
vrrp: prepend virtual-router link-local as first IPv6 advert address per RFC 5798 (#5089)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56083,3 +56083,20 @@ top.
   pkg/vrrp suite green (incl. -race).
   **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/instance.go,
   pkg/vrrp/update_instances_test.go, pkg/vrrp/README.md
+
+- **Timestamp**: 2026-07-22 (fix/5089-vrrp-v6-linklocal-advert)
+  **Action**: #5089 — Prepend the virtual-router link-local as the FIRST IPvX
+  address in every IPv6 VRRP advertisement per RFC 5798 §5.2.9/§5.1.1.2. Before
+  this, `sendPacketIPv6` serialized only the configured global VIPs; the
+  link-local was used solely as the outer/checksum source and never appeared in
+  the payload, so address[0] was a global VIP — non-conformant and rejectable by
+  strict vSRX/keepalived-v3 peers. The prepend reuses the exact `srcIP`
+  (getLocalIPv6) fed to the pseudo-header checksum, so address[0] == outer
+  source (#2644) by construction; Marshal derives Count IPvX Addr from
+  len(IPAddresses), so the count bumps in lockstep. IPv4 path untouched. Added
+  fail-on-revert tests `TestSendPacketIPv6PrependsVirtualRouterLinkLocal` and
+  `TestSendPacketIPv6LinkLocalFirstWithMultipleVIPs` (firsthand-verified RED —
+  Count 1 vs 2 / 2 vs 3 — when the prepend is neutralized). Full pkg/vrrp suite
+  green.
+  **File(s)**: pkg/vrrp/instance.go,
+  pkg/vrrp/instance_v6_lladdr_advert_5089_test.go, pkg/vrrp/README.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -543,6 +543,36 @@ load/peer-sync compile paths.
   read raw VRRP frames). The OR-into-type form avoids the fork race a separate
   `fcntl(FD_CLOEXEC)` would open.
 
+### IPv6 advert address list — link-local first (#5089)
+
+RFC 5798 §5.2.9 defines an advertisement's payload as the list of IPvX
+address(es) "associated with the virtual router", and §5.1.1.2 requires an
+IPv6 advert to be **sourced from the virtual router's link-local address**.
+For IPv6 the conformant wire format places that link-local as **address[0]**,
+followed by the configured global VIPs — a strict vSRX/keepalived-v3 peer can
+reject an advert whose first address is a global VIP.
+
+`sendPacketIPv6` (`instance.go`) resolves that link-local as `srcIP`
+(`getLocalIPv6()`, with the #2258 lazy-resolve fallback), uses it as the outer
+IPv6 source and the pseudo-header checksum source (#2644), **and now prepends
+it to `pkt.IPAddresses` ahead of the configured VIPs** before `Marshal`. Three
+invariants hold by construction:
+
+- **address[0] == outer/checksum source.** The prepend reuses the exact `srcIP`
+  fed to the checksum, so the first advertised address is guaranteed identical
+  to the pinned outer source (`IPV6_PKTINFO`) — no independent resolution that
+  could drift.
+- **Count stays consistent.** `Marshal` derives the "Count IPvX Addr" wire byte
+  from `len(IPAddresses)` (`packet.go`), so prepending bumps the count in
+  lockstep with the payload length; the `MinAdvertAddrCount..MaxAdvertAddrCount`
+  guard still applies (a 255-VIP config would push to 256 and be rejected).
+- **IPv4 is untouched.** The prepend lives only in the IPv6 send path; the
+  IPv4 `sendPacket` builder advertises the configured VIPs verbatim.
+
+Guarded by `TestSendPacketIPv6PrependsVirtualRouterLinkLocal` /
+`TestSendPacketIPv6LinkLocalFirstWithMultipleVIPs`, which re-parse the captured
+advert and assert address[0] is the link-local and the Count field includes it.
+
 ### Receiver goroutine model
 
 When AF_PACKET opens (`afPacketFD >= 0`), a single `receiverAfPacket()`

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -2379,6 +2379,21 @@ func (vi *vrrpInstance) sendPacketIPv6(pkt *VRRPPacket) error {
 
 	dstIP := net.ParseIP("ff02::12")
 
+	// RFC 5798 §5.2.9 / §6.1: an IPv6 VRRP advertisement lists ALL of the
+	// virtual router's addresses, and the FIRST IPvX address in the payload
+	// MUST be the virtual router's link-local. srcIP is exactly that
+	// link-local (it is also the outer source and the pseudo-header checksum
+	// source below, #2644), so prepend it ahead of the configured global
+	// VIPs the caller placed in pkt.IPAddresses. Marshal derives the
+	// "Count IPvX Addr" wire field from len(IPAddresses) (packet.go), so
+	// prepending here bumps the count in lockstep — no separate count math.
+	// Build a fresh slice rather than mutating the caller's v6Addrs so a
+	// retried send does not prepend twice.
+	llFirst := make([]net.IP, 0, len(pkt.IPAddresses)+1)
+	llFirst = append(llFirst, srcIP)
+	llFirst = append(llFirst, pkt.IPAddresses...)
+	pkt.IPAddresses = llFirst
+
 	// The pseudo-header checksum inside data is computed over srcIP. The
 	// outer IPv6 source MUST equal srcIP or the receiver's checksum (which
 	// is validated against the actual outer source) mismatches and the

--- a/pkg/vrrp/instance_v6_lladdr_advert_5089_test.go
+++ b/pkg/vrrp/instance_v6_lladdr_advert_5089_test.go
@@ -1,0 +1,170 @@
+package vrrp
+
+import (
+	"net"
+	"testing"
+
+	"golang.org/x/net/ipv6"
+)
+
+// TestSendPacketIPv6PrependsVirtualRouterLinkLocal asserts that an IPv6 VRRP
+// advertisement carries the virtual router's link-local as the FIRST IPvX
+// address in its payload, ahead of the configured global VIPs, and that the
+// header "Count IPvX Addr" field includes it (#5089).
+//
+// RFC 5798 §5.2.9 defines the advertisement address list as "one or more IPvX
+// address(es) that are associated with the virtual router" and §6.1 documents
+// that for IPv6 the virtual router owns a link-local address; §5.1.1.2 further
+// requires the source of an IPv6 advert to be that link-local. RFC 5798 §8.1.2
+// (Backup send/receive) and the reference vSRX/keepalived-v3 wire format place
+// the virtual router's link-local as address[0], followed by the remaining
+// (global) addresses. Serializing only the global VIPs — as xpf did before
+// #5089 — produced a payload whose address[0] was a global VIP, non-conformant
+// and rejectable by strict peers.
+//
+// fail-on-revert: remove the srcIP prepend in sendPacketIPv6 and the serialized
+// payload collapses to [VIP] — address[0] becomes the global VIP (not the
+// link-local), the Count byte drops from 2 to 1, and the "address[0] == outer
+// source" check fails. Every assertion below then goes RED.
+func TestSendPacketIPv6PrependsVirtualRouterLinkLocal(t *testing.T) {
+	const ifIndex = 9
+	ll := net.ParseIP("fe80::abcd") // virtual-router link-local (getLocalIPv6)
+	vip := net.ParseIP("2001:db8::1")
+	if ll == nil || vip == nil {
+		t.Fatal("bad test fixtures")
+	}
+
+	vi := newInstance(
+		Instance{Interface: "reth0", GroupID: 3, Priority: 200,
+			AdvertiseInterval: 1000,
+			VirtualAddresses:  []string{"2001:db8::1/64"}},
+		&net.Interface{Name: "reth0", Index: ifIndex},
+		make(chan VRRPEvent, 1), nil,
+	)
+
+	// Make sendPacketIPv6 believe the IPv6 socket is open without a raw socket
+	// (needs CAP_NET_RAW). The send seam captures the marshaled advert and the
+	// control message the kernel would use to pin the outer source.
+	vi.ipv6Conn = stubPacketConn{}
+	vi.setLocalIPv6(ll)
+
+	var gotData []byte
+	var gotCM *ipv6.ControlMessage
+	vi.ipv6Send = func(data []byte, cm *ipv6.ControlMessage, dst net.Addr) error {
+		gotData = append([]byte(nil), data...)
+		gotCM = cm
+		return nil
+	}
+
+	// The caller (sendAdvert) builds pkt.IPAddresses from the configured global
+	// VIPs only; the link-local prepend happens inside sendPacketIPv6.
+	pkt := &VRRPPacket{
+		VRID:         3,
+		Priority:     200,
+		MaxAdvertInt: 100,
+		IPAddresses:  []net.IP{vip},
+	}
+	if err := vi.sendPacketIPv6(pkt); err != nil {
+		t.Fatalf("sendPacketIPv6: %v", err)
+	}
+	if gotCM == nil || gotCM.Src == nil {
+		t.Fatal("no pinned outer source captured")
+	}
+
+	// Count IPvX Addr wire byte (buf[3]) must include the prepended link-local:
+	// 1 VIP + 1 link-local = 2.
+	if len(gotData) < vrrpHeaderLen {
+		t.Fatalf("advert too short: %d bytes", len(gotData))
+	}
+	if gotData[3] != 2 {
+		t.Fatalf("Count IPvX Addr = %d, want 2 (link-local + 1 VIP) — "+
+			"link-local not prepended (#5089)", gotData[3])
+	}
+
+	// Re-parse the advert exactly as a receiver would: outer source = the
+	// pinned cmsg Src (also the checksum source). Payload length + count must
+	// be self-consistent or ParseVRRPPacket errors.
+	parsed, err := ParseVRRPPacket(gotData, true, gotCM.Src, net.ParseIP("ff02::12"))
+	if err != nil {
+		t.Fatalf("re-parse failed (count/length inconsistent?): %v", err)
+	}
+	if len(parsed.IPAddresses) != 2 {
+		t.Fatalf("payload carries %d addresses, want 2 (link-local + VIP)",
+			len(parsed.IPAddresses))
+	}
+
+	// RFC 5798: address[0] MUST be the virtual router's link-local, and it must
+	// be the SAME address used as the outer/checksum source (getLocalIPv6).
+	if !parsed.IPAddresses[0].Equal(ll) {
+		t.Fatalf("payload address[0] = %v, want virtual-router link-local %v "+
+			"(#5089: link-local must be FIRST)", parsed.IPAddresses[0], ll)
+	}
+	if !parsed.IPAddresses[0].Equal(gotCM.Src) {
+		t.Fatalf("payload address[0] = %v != outer source %v — the first "+
+			"advert address must equal the checksum/link-local source",
+			parsed.IPAddresses[0], gotCM.Src)
+	}
+	// The configured global VIP follows the link-local.
+	if !parsed.IPAddresses[1].Equal(vip) {
+		t.Fatalf("payload address[1] = %v, want configured VIP %v",
+			parsed.IPAddresses[1], vip)
+	}
+}
+
+// TestSendPacketIPv6LinkLocalFirstWithMultipleVIPs confirms the prepend keeps
+// the link-local at index 0 and preserves the configured VIP order behind it,
+// with the Count field covering all of them (#5089).
+func TestSendPacketIPv6LinkLocalFirstWithMultipleVIPs(t *testing.T) {
+	const ifIndex = 9
+	ll := net.ParseIP("fe80::5")
+	vip1 := net.ParseIP("2001:db8::10")
+	vip2 := net.ParseIP("2001:db8::20")
+
+	vi := newInstance(
+		Instance{Interface: "reth1", GroupID: 4, Priority: 150,
+			AdvertiseInterval: 1000,
+			VirtualAddresses:  []string{"2001:db8::10/64", "2001:db8::20/64"}},
+		&net.Interface{Name: "reth1", Index: ifIndex},
+		make(chan VRRPEvent, 1), nil,
+	)
+	vi.ipv6Conn = stubPacketConn{}
+	vi.setLocalIPv6(ll)
+
+	var gotData []byte
+	var gotSrc net.IP
+	vi.ipv6Send = func(data []byte, cm *ipv6.ControlMessage, dst net.Addr) error {
+		gotData = append([]byte(nil), data...)
+		if cm != nil {
+			gotSrc = cm.Src
+		}
+		return nil
+	}
+
+	pkt := &VRRPPacket{
+		VRID:         4,
+		Priority:     150,
+		MaxAdvertInt: 100,
+		IPAddresses:  []net.IP{vip1, vip2},
+	}
+	if err := vi.sendPacketIPv6(pkt); err != nil {
+		t.Fatalf("sendPacketIPv6: %v", err)
+	}
+
+	if gotData[3] != 3 {
+		t.Fatalf("Count IPvX Addr = %d, want 3 (link-local + 2 VIPs)", gotData[3])
+	}
+	parsed, err := ParseVRRPPacket(gotData, true, gotSrc, net.ParseIP("ff02::12"))
+	if err != nil {
+		t.Fatalf("re-parse failed: %v", err)
+	}
+	want := []net.IP{ll, vip1, vip2}
+	if len(parsed.IPAddresses) != len(want) {
+		t.Fatalf("payload carries %d addresses, want %d", len(parsed.IPAddresses), len(want))
+	}
+	for i, w := range want {
+		if !parsed.IPAddresses[i].Equal(w) {
+			t.Fatalf("payload address[%d] = %v, want %v (link-local first, then "+
+				"configured VIP order)", i, parsed.IPAddresses[i], w)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

IPv6 VRRP advertisements serialized only the configured global VIPs. The
virtual-router link-local was used solely as the outer/checksum source and was
never prepended to the advert payload, so the FIRST advertised IPvX address was
a global VIP. RFC 5798 requires the opposite:

- **§5.2.9 (IPvX Address(es))**: *"For IPv6, the first address must be the IPv6
  link-local address associated with the virtual router."*
- **§6.1 (Parameters Per Virtual Router)**: *"The first address must be the
  Link-Local address associated with the virtual router."*

A conformant vSRX / Cisco / keepalived-v3 peer can reject an advert whose
address[0] is a global VIP, silently undermining dual-stack HA while local
xpf-to-xpf tests still pass (both ends misparse identically).

## Fix

`sendPacketIPv6` (`pkg/vrrp/instance.go`) now prepends `srcIP` — the resolved
link-local from `getLocalIPv6()` (with the #2258 lazy-resolve fallback) — ahead
of the configured global VIPs before `Marshal`.

- **address[0] == outer/checksum source.** The prepend reuses the exact `srcIP`
  already fed to the pseudo-header checksum and pinned as the outer source via
  `IPV6_PKTINFO` (#2644), so the first advertised address is guaranteed
  identical to the outer source — no independent resolution that could drift.
- **Count stays consistent.** `Marshal` derives the "Count IPvX Addr" wire byte
  from `len(IPAddresses)` (`packet.go`), so the count bumps in lockstep with the
  payload length; the `MinAdvertAddrCount..MaxAdvertAddrCount` guard still
  applies.
- **IPv4 untouched.** The prepend lives only in the IPv6 send path; `sendPacket`
  advertises the configured VIPs verbatim.
- A fresh slice is built rather than mutating the caller's `v6Addrs`, so a
  retried send never prepends twice.

## Validation

- `go build ./...` green.
- `go test ./pkg/vrrp/...` green (full suite).
- New **fail-on-revert** tests re-parse the captured advert (using the pinned
  cmsg `Src` as the outer source) and assert `address[0]` == link-local ==
  outer source, the trailing VIPs keep order, and the Count field includes the
  link-local:
  - `TestSendPacketIPv6PrependsVirtualRouterLinkLocal`
  - `TestSendPacketIPv6LinkLocalFirstWithMultipleVIPs`

  Firsthand-verified RED when the prepend is neutralized (Count 1 vs 2 and
  2 vs 3).
- `pkg/vrrp/README` documents the IPv6 advert address-list contract.

**VRRP change — the parent runs `test-failover` before merge.**

Closes #5089

🤖 Generated with [Claude Code](https://claude.com/claude-code)