### PR TITLE
userspace-dp/mirror: sample before admit_mirror_clone_to_live CAS on the flow-cache hot path (#6114)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,50 @@
+## 2026-07-22 — #6114: mirror flow-cache HOT path samples before reserving
+
+- **Timestamp**: 2026-07-22 (fix/6114-mirror-sample-before-cas)
+- **Action**: Reordered the ESTABLISHED-FLOW HOT PATH mirror admission
+  (`poll_descriptor/flow_cache_hit.rs`) — the real remaining #5167 site
+  surfaced by #6113 — to run the worker-local sampler BEFORE the shared
+  `admit_mirror_clone_to_live` reservation, matching the #6113 fix on the
+  dispatch path. Reserving first hit a true-shared AcqRel CAS on the target's
+  `pending_tx_admitted` (#4096) for EVERY established-flow packet (and a
+  second AcqRel RMW to release the unused reservation for a non-sampled
+  packet), so acknowledged cross-core true-sharing scaled O(PPS) instead of
+  the sample rate O(PPS/R) on the path that dominates sustained high-PPS
+  mirror. Extracted the ordering into ONE shared
+  `sample_then_admit_mirror_clone` (`mirror/resolver.rs`, returning
+  `MirrorSampleAdmission::{NotSampled, Sampled(Result<...>)}`) that BOTH the
+  hot path and `enqueue_sampled_mirror_clone_to_live` call — a single tested
+  home for the invariant so it cannot silently diverge again.
+- **Intent resolution (#6114 question)**: the prior admit-first behavior
+  (documented by `sampled_live_mirror_queue_full_does_not_advance_sampler`:
+  "a full-queue packet must not consume a mirror sample") was adjudicated a
+  SECOND instance of the #5167 bug, not a real requirement. Budget
+  preservation only has effect during a pressure event where clones are
+  already being dropped, is statistically irrelevant to a 1-in-N decimation
+  of an inherently lossy clone stream, and #5167/#6113 already chose
+  sample-first for the identical shared-CAS tradeoff on the dispatch path. So
+  the ordering is flipped to sample-first and the test re-asserts it.
+- **Tests** (`mirror/mod_tests.rs`):
+  - `flow_cache_nonsampled_does_not_reserve_full_queue_6114` (FAIL-ON-REVERT,
+    the #6113-shape analog): full clone queue + a NON-sampled packet → `None`
+    with `mirror_drops_queue_full == 0` and the pre-fill untouched (nothing
+    shared reserved). Revert to reserve-before-sample → admit fails on the
+    full queue → `Some(QueueFullCrossWorker)` + drop counter bumped → RED.
+  - `sampled_live_mirror_queue_full_advances_sampler_for_selected_6114`
+    (flipped from `..._does_not_advance_sampler`): a SELECTED packet on a full
+    queue advances the sampler (counter 0→1) THEN reports the queue-full
+    pressure. Revert leaves the counter at 0 → RED.
+  - GREEN: `cargo test --release mirror::` = 26 passed. RED-on-revert proven
+    firsthand: reverting `sample_then_admit_mirror_clone` to CAS-before-sample
+    → both tests FAILED (counter left=0 want 1; result left=Some(QueueFull)
+    want None), restored → GREEN.
+- **File(s)**: userspace-dp/src/afxdp/mirror/resolver.rs,
+  userspace-dp/src/afxdp/mirror/mod.rs,
+  userspace-dp/src/afxdp/mirror/fast_path.rs,
+  userspace-dp/src/afxdp/mirror/mod_tests.rs,
+  userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs,
+  docs/userspace-dataplane-gaps.md
+
 ## 2026-07-22 — #5287: budget + resume the conntrack last_seen refresh
 
 - **Timestamp**: 2026-07-22 (fix/5287-conntrack-refresh-budget)

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -78,22 +78,31 @@ Port mirroring now has snapshot/wire plumbing plus a bounded runtime slice
 that samples and queues discardable full-L2 mirror clones with drop counters.
 Runtime coverage includes the pending-forward path, self-target flow-cache
 mirror surface, deferred neighbor-resolution retry path, CoS-bound reserve
-handling, and mirror-specific counter attribution. **#5167 (PARTIAL — dispatch
-path only, #6113): both branches of `enqueue_sampled_mirror_clone`
-(`mirror/fast_path.rs`) now run the worker-local sampler (`mirror_sample_allows`)
-BEFORE reserving the target clone queue. That function is the DISPATCH path
-(session-miss / neighbor-resolution-retry); its cross-worker (to-live) branch
-previously reserved first (`admit_mirror_clone_to_live`, a true-shared AcqRel CAS
-on the target's `pending_tx_admitted`, #4096) and sampled second, so acknowledged
-cross-core true-sharing scaled with the FULL unsampled ingress rate O(PPS)
-instead of the sample rate O(PPS/R). Sample-first means a non-sampled packet no
-longer reserves, copies, or reports clone-queue pressure for a clone it will not
-send. NOT YET FIXED: the ESTABLISHED-FLOW HOT PATH
-(`poll_descriptor/flow_cache_hit.rs:386-398`) still inlines the same
-reserve-before-sample ordering, and sustained high-PPS mirror is dominated by
-flow-cache HITS — so the O(PPS/R) scaling goal is NOT yet met on the dominant
-path (tracked #6114). The dead-code `enqueue_sampled_mirror_clone_to_live`
-sibling shares the anti-pattern but has no live caller.** The
+handling, and mirror-specific counter attribution. **#5167 sample-before-reserve
+(COMPLETE across dispatch + hot path). Ordering invariant: on every mirror
+surface the worker-local sampler (`mirror_sample_allows`) runs BEFORE reserving
+the cross-worker clone queue (`admit_mirror_clone_to_live`, a true-shared AcqRel
+CAS on the target's `pending_tx_admitted`, #4096 — an unused reservation costs a
+second AcqRel RMW on its `PendingTxAdmission` Drop). Reserve-before-sample made
+acknowledged cross-core true-sharing scale with the FULL unsampled ingress rate
+O(PPS) instead of the sample rate O(PPS/R); sample-first means a non-sampled
+packet touches nothing shared — no reserve, no copy, no clone-queue pressure
+report. #6113 (#5167) fixed the DISPATCH path (both branches of
+`enqueue_sampled_mirror_clone`, `mirror/fast_path.rs` — session-miss /
+neighbor-resolution-retry). #6114 (#5167) fixes the remaining LIVE site, the
+ESTABLISHED-FLOW HOT PATH (`poll_descriptor/flow_cache_hit.rs`), which dominates
+sustained high-PPS mirror, plus the `enqueue_sampled_mirror_clone_to_live` sibling
+that shares it. Both now route the ordering through one shared
+`sample_then_admit_mirror_clone` (`mirror/resolver.rs`) so the invariant has a
+single tested home and cannot silently diverge again. Intent note: the earlier
+"admit-first preserves sample budget on a full queue" behavior (documented by
+`sampled_live_mirror_queue_full_does_not_advance_sampler`) was adjudicated a
+SECOND instance of the #5167 bug, not a real requirement — budget preservation
+only matters during a pressure event where clones are already dropped, is
+statistically irrelevant to a 1-in-N decimation of a lossy clone stream, and cost
+an O(PPS) shared-CAS hit on the dominant path; the test is flipped to assert
+sample-first (a SELECTED packet advances the sampler, then reports the full-queue
+pressure).** The
 `deriveUserspaceCapabilities()` gate has been removed; #1376 is closed for the
 feature-gap audit, and the #1477 final-validation artifact set is closed.
 Any further mirror-fidelity and pressure-survival work is production hardening,

--- a/userspace-dp/src/afxdp/mirror/fast_path.rs
+++ b/userspace-dp/src/afxdp/mirror/fast_path.rs
@@ -253,22 +253,26 @@ pub(in crate::afxdp) fn enqueue_sampled_mirror_clone_to_live(
     flow_key: Option<&SessionKey>,
 ) -> Option<MirrorCloneResult> {
     let config = resolve_mirror_config(forwarding, ingress_ifindex, ingress_vlan_id)?;
-    let cos_queue_id = mirror_cos_queue_id(forwarding, config.output_ifindex, meta, flow_key);
-    let admission = match admit_mirror_clone_to_live(
+    // #6114: sample BEFORE reserving the contended cross-worker clone queue
+    // (see `sample_then_admit_mirror_clone`). A non-sampled packet returns
+    // `None` having touched nothing shared — no reservation, no copy, no
+    // clone-queue pressure report.
+    let admission = match sample_then_admit_mirror_clone(
+        config.rate,
+        sample_counter,
         mirror_targets,
         resolve_tx_binding_ifindex(forwarding, config.output_ifindex),
         ingress_queue_id,
         frame.len(),
     ) {
-        Ok(admission) => admission,
-        Err(result) => {
+        MirrorSampleAdmission::NotSampled => return None,
+        MirrorSampleAdmission::Sampled(Ok(admission)) => admission,
+        MirrorSampleAdmission::Sampled(Err(result)) => {
             record_mirror_clone_result(live, result, frame.len());
             return Some(result);
         }
     };
-    if !mirror_sample_allows(config.rate, sample_counter) {
-        return None;
-    }
+    let cos_queue_id = mirror_cos_queue_id(forwarding, config.output_ifindex, meta, flow_key);
     let result = enqueue_admitted_mirror_clone_to_live(
         admission,
         config,

--- a/userspace-dp/src/afxdp/mirror/mod.rs
+++ b/userspace-dp/src/afxdp/mirror/mod.rs
@@ -18,6 +18,7 @@ pub(in crate::afxdp) use fast_path::{
 };
 pub(in crate::afxdp) use resolver::{
     admit_mirror_clone_to_live, mirror_cos_queue_id, record_mirror_clone_result,
+    sample_then_admit_mirror_clone, MirrorSampleAdmission,
 };
 // Sibling-only helper (mirror-module-internal). A plain (private) `use` keeps
 // it out of the wider `crate::afxdp` surface while still letting the fast

--- a/userspace-dp/src/afxdp/mirror/mod_tests.rs
+++ b/userspace-dp/src/afxdp/mirror/mod_tests.rs
@@ -564,8 +564,22 @@ fn sampled_live_mirror_sampler_denial_does_not_enqueue() {
     assert!(queued.is_empty());
 }
 
+// #6114 intent resolution: this test previously asserted admit-FIRST ordering
+// (`..._queue_full_does_not_advance_sampler`) as intended — a full-queue packet
+// must not "consume a mirror sample". #6114 determined that is a SECOND instance
+// of the #5167 bug, not a real requirement: the flow-cache surface reserves the
+// contended cross-worker clone queue (`admit_mirror_clone_to_live`, a true-shared
+// AcqRel CAS on `pending_tx_admitted`, #4096) for EVERY established-flow packet,
+// so acknowledged cross-core true-sharing scaled O(PPS) instead of O(PPS/R) on
+// the dominant path. "Preserving sample budget on a full queue" only matters
+// during a pressure event where clones are already being dropped, is
+// statistically irrelevant to a 1-in-N decimation of a lossy clone stream, and
+// #5167 already chose sample-first for the identical shared-CAS tradeoff in
+// `enqueue_sampled_mirror_clone`. So the ordering is flipped to sample-first
+// (via `sample_then_admit_mirror_clone`): a SELECTED packet advances the sampler
+// and THEN reports the full-queue pressure.
 #[test]
-fn sampled_live_mirror_queue_full_does_not_advance_sampler() {
+fn sampled_live_mirror_queue_full_advances_sampler_for_selected_6114() {
     let ingress_live = BindingLiveState::new();
     let target_live = Arc::new(BindingLiveState::new());
     target_live.set_max_pending_tx(1);
@@ -593,6 +607,9 @@ fn sampled_live_mirror_queue_full_does_not_advance_sampler() {
             rate: 4,
         },
     );
+    // rate=4 + counter=0 -> mirror_sample_allows == true (this packet IS
+    // selected). Sample-first advances the sampler BEFORE it discovers the
+    // full queue.
     let mut sample_counter = 0;
 
     let result = enqueue_sampled_mirror_clone_to_live(
@@ -610,8 +627,9 @@ fn sampled_live_mirror_queue_full_does_not_advance_sampler() {
 
     assert_eq!(result, Some(MirrorCloneResult::QueueFullCrossWorker));
     assert_eq!(
-        sample_counter, 0,
-        "full live target must fail before consuming a mirror sample"
+        sample_counter, 1,
+        "#6114: a SELECTED packet advances the sampler before the full-queue \
+         admit fails (sample-first); reverting to admit-first leaves it at 0"
     );
     assert_eq!(
         ingress_live.mirror_drops_queue_full.load(Ordering::Relaxed),
@@ -630,6 +648,100 @@ fn sampled_live_mirror_queue_full_does_not_advance_sampler() {
         0,
         "mirror backpressure must not pollute target redirect overflow counters"
     );
+    let mut queued = VecDeque::new();
+    target_live.take_pending_tx_into(&mut queued);
+    assert_eq!(
+        queued.pop_front().expect("original request").bytes,
+        vec![0x33; 64]
+    );
+    assert!(queued.is_empty());
+}
+
+/// #6114 FAIL-ON-REVERT: a NON-sampled packet on the flow-cache mirror surface
+/// must NOT reserve the (full) cross-worker clone queue. This is the flow-cache
+/// analog of #6113's `cross_worker_nonsampled_does_not_reserve_full_queue_5167`,
+/// and it guards the ordering used by BOTH `enqueue_sampled_mirror_clone_to_live`
+/// and the established-flow HOT path (`poll_descriptor/flow_cache_hit.rs`), which
+/// share `sample_then_admit_mirror_clone`.
+///
+/// With sample-first, a non-sampled packet returns `None` having touched nothing
+/// shared: no `admit_mirror_clone_to_live` reservation, no clone-queue pressure
+/// counter, the pre-fill untouched, and only the worker-local sampler advanced.
+/// Reverting to reserve-before-sample makes the packet call
+/// `admit_mirror_clone_to_live` on the full queue and return
+/// `Some(QueueFullCrossWorker)` while bumping `mirror_drops_queue_full` — a
+/// non-sampled packet reporting clone-queue pressure it should never touch -> RED.
+#[test]
+fn flow_cache_nonsampled_does_not_reserve_full_queue_6114() {
+    let ingress_live = BindingLiveState::new();
+    let target_live = Arc::new(BindingLiveState::new());
+    // Drive the cross-worker clone queue to its admission cap.
+    target_live.set_max_pending_tx(1);
+    assert!(
+        target_live
+            .try_enqueue_tx_owned(test_tx_request(0x33, 22))
+            .is_ok()
+    );
+    let mut mirror_targets = MirrorTargetMap::default();
+    mirror_targets.insert(
+        &BindingIdentity {
+            slot: 9,
+            queue_id: 0,
+            worker_id: 1,
+            interface: Arc::<str>::from("mirror-out"),
+            ifindex: 22,
+        },
+        target_live.clone(),
+    );
+    let mut forwarding = ForwardingState::default();
+    forwarding.mirror_configs.insert(
+        11,
+        MirrorRuntimeConfig {
+            output_ifindex: 22,
+            rate: 2,
+        },
+    );
+    // rate=2 + counter=1 -> mirror_sample_allows == false (this packet is NOT
+    // selected).
+    let mut sample_counter = 1;
+
+    let result = enqueue_sampled_mirror_clone_to_live(
+        &ingress_live,
+        &mirror_targets,
+        &forwarding,
+        11,
+        0,
+        0,
+        &mut sample_counter,
+        &[0x44; 80],
+        test_meta(),
+        None,
+    );
+
+    assert_eq!(
+        result, None,
+        "#6114: a non-sampled packet must NOT reserve the full clone queue \
+         (sample-first); reverting to admit-first returns \
+         Some(QueueFullCrossWorker)"
+    );
+    assert_eq!(
+        sample_counter, 2,
+        "the worker-local sampler still advances for the declined packet"
+    );
+    assert_eq!(
+        ingress_live.mirror_drops_queue_full.load(Ordering::Relaxed),
+        0,
+        "#6114: a non-sampled packet must not report clone-queue pressure"
+    );
+    assert_eq!(
+        ingress_live
+            .mirror_drops_queue_full_cross_worker
+            .load(Ordering::Relaxed),
+        0
+    );
+    assert_eq!(ingress_live.mirrored_packets.load(Ordering::Relaxed), 0);
+    // The pre-fill is the only queued request; the non-sampled packet reserved
+    // nothing.
     let mut queued = VecDeque::new();
     target_live.take_pending_tx_into(&mut queued);
     assert_eq!(

--- a/userspace-dp/src/afxdp/mirror/resolver.rs
+++ b/userspace-dp/src/afxdp/mirror/resolver.rs
@@ -45,6 +45,51 @@ pub(in crate::afxdp) fn admit_mirror_clone_to_live(
         .map_err(|_| MirrorCloneResult::QueueFullCrossWorker)
 }
 
+/// Outcome of the mirror sample-then-admit decision (#6114). Splitting the
+/// worker-local sampler from the cross-worker reservation lets a caller run the
+/// cheap sampler FIRST and only touch the contended clone queue for a packet
+/// that is actually selected.
+pub(in crate::afxdp) enum MirrorSampleAdmission {
+    /// The worker-local sampler declined this packet. Nothing shared was
+    /// touched: no reservation, no copy, no clone-queue pressure report.
+    NotSampled,
+    /// The packet was selected. Carries the reservation outcome: `Ok` holds a
+    /// reserved live clone-queue slot, `Err` reports why admission failed
+    /// (e.g. `QueueFullCrossWorker`).
+    Sampled(Result<PendingTxAdmission, MirrorCloneResult>),
+}
+
+// #6114 / #5167: run the worker-local sampler BEFORE reserving the contended
+// cross-worker clone queue. `admit_mirror_clone_to_live` performs a true-shared
+// AcqRel CAS on the target's `pending_tx_admitted` (#4096), and dropping an
+// unused reservation costs a second AcqRel RMW (the `PendingTxAdmission` Drop
+// release). Reserving BEFORE sampling made acknowledged cross-core true-sharing
+// scale with the FULL unsampled ingress rate O(PPS) instead of the sample rate
+// O(PPS/R), so sampling could not bound clone cost. Sample-first: a non-sampled
+// packet advances only the worker-local `sample_counter` and returns
+// `NotSampled` having touched nothing shared. This is the single home for the
+// ordering invariant shared by the established-flow HOT path
+// (`poll_descriptor/flow_cache_hit.rs`) and `enqueue_sampled_mirror_clone_to_live`.
+#[inline]
+pub(in crate::afxdp) fn sample_then_admit_mirror_clone(
+    rate: u32,
+    sample_counter: &mut u64,
+    mirror_targets: &MirrorTargetMap,
+    mirror_tx_ifindex: i32,
+    ingress_queue_id: u32,
+    frame_len: usize,
+) -> MirrorSampleAdmission {
+    if !mirror_sample_allows(rate, sample_counter) {
+        return MirrorSampleAdmission::NotSampled;
+    }
+    MirrorSampleAdmission::Sampled(admit_mirror_clone_to_live(
+        mirror_targets,
+        mirror_tx_ifindex,
+        ingress_queue_id,
+        frame_len,
+    ))
+}
+
 #[inline]
 pub(in crate::afxdp) fn mirror_cos_queue_id(
     forwarding: &ForwardingState,

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -386,7 +386,22 @@ pub(super) fn stage_flow_cache_hit(
                 );
                 let mut mirror_next_counter = None;
                 let mut mirror_admission = mirror_config.and_then(|config| {
-                    let admission = admit_mirror_clone_to_live(
+                    // #6114: sample BEFORE reserving the contended cross-worker
+                    // clone queue on this established-flow HOT path. Reserving
+                    // first (`admit_mirror_clone_to_live`, a true-shared AcqRel
+                    // CAS on the target's `pending_tx_admitted`, #4096) made
+                    // every established-flow packet hit the shared cacheline
+                    // even when it would not be sampled — O(PPS) cross-core
+                    // true-sharing instead of the sample rate O(PPS/R). A LOCAL
+                    // counter copy defers the commit: `mirror_next_counter` is
+                    // applied to `*mirror_sample_counter` only if the in-place
+                    // rewrite below succeeds (the fallback path re-runs mirror
+                    // selection), preserving today's "no fast-path advance on
+                    // rewrite miss" behavior.
+                    let mut next_counter = *mirror_sample_counter;
+                    let admission = sample_then_admit_mirror_clone(
+                        config.rate,
+                        &mut next_counter,
                         worker_ctx.mirror_targets,
                         resolve_tx_binding_ifindex(
                             worker_ctx.forwarding,
@@ -395,18 +410,10 @@ pub(super) fn stage_flow_cache_hit(
                         worker_ctx.ident.queue_id,
                         packet_frame.len(),
                     );
+                    mirror_next_counter = Some(next_counter);
                     match admission {
-                        Ok(admission) => {
-                            let mut next_counter = *mirror_sample_counter;
-                            if mirror_sample_allows(config.rate, &mut next_counter) {
-                                mirror_next_counter = Some(next_counter);
-                                Some((config, Ok(admission)))
-                            } else {
-                                mirror_next_counter = Some(next_counter);
-                                None
-                            }
-                        }
-                        Err(result) => Some((config, Err(result))),
+                        MirrorSampleAdmission::NotSampled => None,
+                        MirrorSampleAdmission::Sampled(result) => Some((config, result)),
                     }
                 });
                 let mirror_frame_len = packet_frame.len();


### PR DESCRIPTION
## Summary

Fixes #6114. Completes the #5167 sample-before-reserve reorder on the mirror
clone path by fixing the remaining **live** site: the ESTABLISHED-FLOW HOT
PATH (`poll_descriptor/flow_cache_hit.rs`).

#5167 (PR #6113) reordered the cross-worker branch of
`enqueue_sampled_mirror_clone` to run the worker-local sampler **before** the
shared `admit_mirror_clone_to_live` reservation, bounding acknowledged
cross-core true-sharing on the clone queue to the sample rate O(PPS/R) rather
than the full ingress rate O(PPS). #6113 scoped itself to the dispatch path and
flagged the hot path — which dominates sustained high-PPS mirror and still
reserved-before-sampled — as the real remaining #5167 site.

## Fix

`admit_mirror_clone_to_live` performs a true-shared AcqRel CAS on the target's
`pending_tx_admitted` (#4096), and dropping an unused reservation costs a second
AcqRel RMW on the `PendingTxAdmission` Drop — so the old ordering hit the shared
cacheline **twice** for every non-sampled established-flow packet. Sample-first
means a non-sampled packet advances only the worker-local sampler and touches
nothing shared.

The ordering is extracted into one shared `#[inline]`
`sample_then_admit_mirror_clone` (`mirror/resolver.rs`), returning
`MirrorSampleAdmission::{NotSampled, Sampled(Result<…>)}`. Both the hot path and
the `enqueue_sampled_mirror_clone_to_live` sibling call it, so the invariant has
a single tested home and cannot silently diverge again. The hot path keeps its
local-counter deferral (`mirror_next_counter` commits only if the in-place
rewrite succeeds), so rewrite-miss behavior is unchanged. Mirror semantics —
which packets get mirrored, admission/live-budget accounting, drop-on-full — are
otherwise unchanged; only the ordering changes so the shared CAS is skipped for
non-sampled packets.

## Intent resolution (the #6114 question)

The issue asked whether the flow-cache surface genuinely needs admit-first (to
"preserve sample budget on a full queue", documented by
`sampled_live_mirror_queue_full_does_not_advance_sampler`) or is a second
instance of the #5167 bug. **Adjudicated: a second instance of the bug.** Budget
preservation only has effect during a pressure event where clones are already
being dropped, is statistically irrelevant to a 1-in-N decimation of an
inherently lossy clone stream, and cost an O(PPS) shared-CAS hit on the dominant
path; #5167/#6113 already chose sample-first for the identical shared-CAS
tradeoff on the dispatch path. The test is flipped to assert sample-first (with
a comment explaining the resolution so a future reader doesn't re-introduce
admit-first).

## Tests (`mirror/mod_tests.rs`)

- **`flow_cache_nonsampled_does_not_reserve_full_queue_6114`** (FAIL-ON-REVERT,
  the #6113-shape analog): full clone queue + a NON-sampled packet → `None`,
  `mirror_drops_queue_full == 0`, pre-fill untouched (nothing shared reserved).
  Revert to reserve-before-sample → admit fails on the full queue →
  `Some(QueueFullCrossWorker)` + drop counter bumped → **RED**.
- **`sampled_live_mirror_queue_full_advances_sampler_for_selected_6114`**
  (flipped from `…_does_not_advance_sampler`): a SELECTED packet on a full queue
  advances the sampler (0→1) then reports queue-full pressure. Revert leaves the
  counter at 0 → **RED**.

**Validation**: `cargo build` clean; `cargo test --release` green (4096 lib
tests + mirror suite 26 passed). **RED-on-revert proven firsthand** by reverting
`sample_then_admit_mirror_clone` to CAS-before-sample (both tests FAILED —
counter `left=0 want 1`; result `left=Some(QueueFullCrossWorker) want None`),
then restored to GREEN. Docs updated in `docs/userspace-dataplane-gaps.md`
(mirror ordering invariant now COMPLETE across dispatch + hot path).

**Smoke**: hot-path dataplane change — a cluster iperf3 smoke is warranted
before merge (the shared CAS is only *skipped* for non-sampled packets; mirror
selection/enqueue is observably unit-proven, but this touches the established-
flow forwarding fast path).

Closes #6114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
