### PR TITLE
userspace-dp/filter: eliminate per-packet cross-worker Mutex in the three-color policer meter (#5390)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56147,3 +56147,19 @@ top.
   green.
   **File(s)**: pkg/vrrp/instance.go,
   pkg/vrrp/instance_v6_lladdr_advert_5089_test.go, pkg/vrrp/README.md
+
+### 2026-07-22 — #5390 three-color policer lock-free meter
+- **Timestamp**: 2026-07-22
+- **Action**: Eliminated the per-packet cross-worker `Mutex` in the three-color
+  policer meter. `ThreeColorPolicerState` split into an immutable
+  `ThreeColorPolicerConfig` + a `#[repr(align(64))]` `ThreeColorPolicerHot`
+  (both token buckets packed in one `AtomicU64`, per-rate `last_refill_ns`
+  atomics). `meter(&self)` refills via win-the-window timestamp CAS and consumes
+  via bounded `compare_exchange_weak` — no futex. Runtime wrapper drops its
+  `Mutex`; shape reads (`reusable_for`/`status`) are now lock-free. Exact
+  aggregate CIR/PIR/CBS/PBS preserved (shared bucket, byte-granular, sub-byte
+  dust carried by timestamp rewind). Fail-on-revert: source-guard +
+  concurrency test (firsthand RED-on-revert verified: source-guard asserts
+  when the Mutex is re-added).
+- **File(s)**: userspace-dp/src/filter/policer.rs,
+  userspace-dp/src/filter/mod.rs, userspace-dp/src/filter/README.md

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -319,14 +319,32 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   `input_filter_counters` set at seed, #3777), so miss (action-eval) + hits
   (cached replay) still total exactly one per packet.
 - `policer.rs` — the #1375 RFC 2697/2698 three-color meter core. Token
-  math is integer-only (byte/sec rates refilling a scaled `u128` bucket
-  from monotonic nanosecond timestamps). #4514 removed the standalone
-  single-rate `PolicerState` token bucket (its `consume` had zero
-  non-test call sites, so `then policer X` was silently unenforced);
-  legacy single-rate `firewall policer`s are now lowered at compile into
-  this same srTCM core (see `compiler.rs::build_single_rate_policer_state`)
-  so they share the metering, drop-on-exceed, flow-cache handle+replay,
-  and status export path.
+  math is integer-only, byte-granular, and **lock-free** (#5390): the
+  shape (`ThreeColorPolicerConfig`: mode, byte/sec rates, bursts,
+  treatments) is immutable and set at compile; the hot state
+  (`ThreeColorPolicerHot`) is a `#[repr(align(64))]` struct of atomics —
+  both token buckets packed into ONE `AtomicU64` (committed high 32 bits,
+  peak/excess low 32) plus per-rate `last_refill_ns` `AtomicU64`s.
+  `meter(&self)` refills through a win-the-window timestamp CAS and
+  consumes through a bounded `compare_exchange_weak` loop, so the RSS-
+  spread flow aggregate (6 workers on the mlx5 VF) no longer serializes on
+  a per-packet `Mutex` futex. Packing both buckets in one word makes a
+  green consume (which debits committed AND peak in trTCM) atomic; the
+  `afxdp/types/shared_cos_lease` v8 lease is the precedent. The aggregate
+  CIR/PIR/CBS/PBS contract is preserved EXACTLY — all workers meter one
+  shared bucket, only the primitive changed from Mutex to CAS. The sub-
+  byte fractional refill credit the pre-#5390 scaled-`u128` bucket kept in
+  the token count is now carried across refills by rewinding
+  `last_refill_ns` (the #4261 conservation rewind, as
+  `afxdp::cos::token_bucket::refill_cos_tokens` does); bursts clamp to the
+  packed u32 byte range (a Junos burst-size is far below 4 GiB). #4514
+  removed the standalone single-rate `PolicerState` token bucket (its
+  `consume` had zero non-test call sites, so `then policer X` was silently
+  unenforced); legacy single-rate `firewall policer`s are now lowered at
+  compile into this same srTCM core (see
+  `compiler.rs::build_single_rate_policer_state`) so they share the
+  metering, drop-on-exceed, flow-cache handle+replay, and status export
+  path.
 - `tests.rs` — co-located unit tests covering matching ports, prefix
   vectors, TCP flags.
 
@@ -389,11 +407,25 @@ Implemented here:
   (drop all). A non-discard single-rate policer is metered but its marking
   action is inert (same limitation as three-color `then loss-priority`).
 
+Concurrency model (#5390):
+
+- Runtime token state is a **lock-free packed-atomic** token bucket per
+  logical policer — NOT a per-packet `Mutex` (removed in #5390) and NOT a
+  per-worker shard. All workers still meter one SHARED aggregate bucket,
+  so the observable policing rate is the exact configured aggregate
+  CIR/PIR (no per-worker rate division, no RSS-distribution dependence).
+  The metered hot path takes no lock: both buckets live in one `AtomicU64`
+  (`ThreeColorPolicerHot`, `#[repr(align(64))]` to isolate the CAS word
+  from the Relaxed per-color counters) and are refilled/consumed through
+  bounded `compare_exchange_weak` loops. Removing the lock also removed
+  the poison failure mode; the only fail-closed path is the
+  `Unsupported`-mode Red/drop. A per-worker-shard design was rejected
+  because it would divide the observable rate by the worker count and make
+  enforcement depend on RSS flow spread — the CAS approach keeps the exact
+  aggregate contract while eliminating the futex convoy.
+
 Remaining limitations:
 
-- Runtime token state is one `Mutex` per logical policer, not a sharded
-  or packed atomic implementation. This preserves correctness and
-  stable identity but is not the final high-throughput contention model.
 - Equivalent snapshot replacements preserve token buckets and per-color
   counters by reusing the same runtime handle when the name-derived runtime ID
   and shape are unchanged. Shape changes intentionally create a fresh runtime

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -20,7 +20,7 @@ use ipnet::IpNet;
 use std::cell::RefCell;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::ip_proto::proto_number;
 use crate::policy::SnapshotIntegrityError;
@@ -440,7 +440,12 @@ pub(crate) struct ThreeColorPolicerCounters {
 pub(crate) struct ThreeColorPolicerRuntime {
     pub(crate) id: u32,
     pub(crate) name: Arc<str>,
-    state: Mutex<ThreeColorPolicerState>,
+    // #5390: NO `Mutex`. The token-bucket state meters lock-free through CAS
+    // over its own atomics (`filter/policer.rs`), so the RSS-spread flow
+    // aggregate no longer serializes on a per-packet futex. Removing the lock
+    // also removes the poison failure mode entirely; the only fail-closed path
+    // is the `Unsupported`-mode Red/drop inside `meter`.
+    state: ThreeColorPolicerState,
     counters: ThreeColorPolicerCounters,
 }
 
@@ -582,7 +587,7 @@ impl ThreeColorPolicerRuntime {
         Self {
             id,
             name: Arc::<str>::from(name),
-            state: Mutex::new(state),
+            state,
             counters: ThreeColorPolicerCounters::default(),
         }
     }
@@ -593,15 +598,8 @@ impl ThreeColorPolicerRuntime {
         packet_bytes: u64,
         incoming_color: PacketColor,
     ) -> ThreeColorDecision {
-        let decision = self
-            .state
-            .lock()
-            .map(|mut state| state.meter(now_ns, packet_bytes, incoming_color))
-            .unwrap_or_else(|_| ThreeColorDecision {
-                color: PacketColor::Red,
-                dscp_rewrite: None,
-                drop: true,
-            });
+        // #5390: lock-free meter — `&self` CAS over the atomic token bucket.
+        let decision = self.state.meter(now_ns, packet_bytes, incoming_color);
         match decision.color {
             PacketColor::Green => self.counters.green.record(packet_bytes),
             PacketColor::Yellow => self.counters.yellow.record(packet_bytes),
@@ -617,32 +615,22 @@ impl ThreeColorPolicerRuntime {
         if self.id != id {
             return false;
         }
-        self.state
-            .lock()
-            .ok()
-            .is_some_and(|state| state.same_runtime_shape(next_shape))
+        // #5390: shape lives in the immutable `config`; no lock needed.
+        self.state.same_runtime_shape(next_shape)
     }
 
     pub(crate) fn same_runtime_shape_as(&self, other: &Self) -> bool {
         if self.id != other.id || self.name != other.name {
             return false;
         }
-        let Ok(state) = self.state.lock() else {
-            return false;
-        };
-        other
-            .state
-            .lock()
-            .ok()
-            .is_some_and(|other| state.same_runtime_shape(&other))
+        self.state.same_runtime_shape(&other.state)
     }
 
     pub(crate) fn status(&self) -> crate::protocol::ThreeColorPolicerStatus {
-        let (mode, color_blind) = self
-            .state
-            .lock()
-            .map(|state| (state.mode_name().to_string(), state.color_blind()))
-            .unwrap_or_else(|_| ("unknown".to_string(), false));
+        // #5390: shape reads are lock-free (immutable `config`); counters are
+        // Relaxed atomics as before.
+        let mode = self.state.mode_name().to_string();
+        let color_blind = self.state.color_blind();
         crate::protocol::ThreeColorPolicerStatus {
             id: self.id,
             name: self.name.to_string(),

--- a/userspace-dp/src/filter/policer.rs
+++ b/userspace-dp/src/filter/policer.rs
@@ -1,28 +1,91 @@
 // Token-bucket and three-color policer state for the userspace filter path.
+//
+// #5390: the metered hot path is LOCK-FREE. `ThreeColorPolicerState` splits
+// into an immutable `ThreeColorPolicerConfig` (mode/rates/bursts/treatments,
+// set once at compile) and a cache-line-isolated `ThreeColorPolicerHot`
+// carrying only atomics: the two token buckets packed into ONE `AtomicU64`
+// (committed in the high 32 bits, peak/excess in the low 32) plus per-rate
+// `last_refill_ns` `AtomicU64`s. `meter()` is `&self` and mutates state through
+// bounded `compare_exchange_weak` retry loops — the RSS-spread flow aggregate
+// (6 workers on the mlx5 VF) no longer serializes on a per-packet
+// `Mutex<ThreeColorPolicerState>` futex. Both buckets live in the same atomic
+// word so a green consume (which debits committed AND peak in trTCM) commits
+// atomically; the shared-lease v8 pattern (afxdp/types/shared_cos_lease) is the
+// precedent. The aggregate CIR/PIR/CBS/PBS contract is preserved EXACTLY (all
+// workers still meter one shared bucket) — only the synchronization primitive
+// changed from a Mutex to lock-free CAS.
 
-const TOKEN_SCALE: u128 = 1_000_000_000;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-#[inline]
-fn scaled_bytes(bytes: u64) -> u128 {
-    u128::from(bytes) * TOKEN_SCALE
+// #5390: token buckets are byte-granular u32 counts packed two-per-`AtomicU64`.
+// A Junos policer burst-size is bounded far below 4 GiB; clamp to the packed
+// range so pack/unpack never overlaps. (Pre-#5390 the buckets were scaled u128
+// `bytes × 1e9`; the sub-byte fractional credit that scaling preserved is now
+// carried across refills by rewinding `last_refill_ns`, exactly as
+// `afxdp::cos::token_bucket::refill_cos_tokens` does — see `compute_refill_add`.)
+const TOKEN_BYTE_CAP: u64 = u32::MAX as u64;
+
+// `last_refill_ns` sentinel meaning "never metered". A real monotonic
+// `now_ns` (ktime since boot) is never `u64::MAX`, so this cleanly separates
+// the uninitialized bucket from one legitimately stamped at `t == 0` (the
+// unit-test clock starts at 0). On first touch the bucket is already at its
+// burst cap from construction, so the sentinel path only stamps the timestamp
+// and adds no tokens — matching the pre-#5390 `initialized` first-refill.
+const UNINITIALIZED_NS: u64 = u64::MAX;
+
+const NANOS_PER_SEC: u128 = 1_000_000_000;
+
+#[inline(always)]
+fn clamp_burst(bytes: u64) -> u64 {
+    bytes.min(TOKEN_BYTE_CAP)
 }
 
-#[inline]
-fn refill_scaled(rate_bytes_per_sec: u64, elapsed_ns: u64) -> u128 {
-    u128::from(rate_bytes_per_sec) * u128::from(elapsed_ns)
+#[inline(always)]
+fn pack_tokens(committed: u64, peak: u64) -> u64 {
+    debug_assert!(committed <= TOKEN_BYTE_CAP);
+    debug_assert!(peak <= TOKEN_BYTE_CAP);
+    (committed << 32) | (peak & 0xffff_ffff)
 }
 
-#[inline]
-fn capped_add(tokens: u128, add: u128, cap: u128) -> u128 {
-    tokens.saturating_add(add).min(cap)
+#[inline(always)]
+fn unpack_tokens(v: u64) -> (u64, u64) {
+    (v >> 32, v & 0xffff_ffff)
 }
 
-// #4514: the standalone single-rate `PolicerState` token bucket (and its dead
-// `consume`) was removed. Legacy `firewall policer` token buckets are now
-// lowered into the RFC 2697 srTCM `ThreeColorPolicerState` below at compile
-// (see `filter/compiler.rs::build_single_rate_policer_state`), so they share the
-// tested metering, drop-on-exceed, flow-cache handle+replay, and status export
-// path instead of a never-consumed name-keyed map.
+/// Compute the whole-byte token grant for one bucket over `[last_ns, now_ns]`
+/// at `rate_bytes_per_sec`, returning `(added_bytes, advance_to_ns)` or `None`
+/// when the timestamp must NOT advance (no time elapsed, zero rate, or less
+/// than one whole byte accrued — the sub-byte credit keeps accumulating against
+/// the original `last_ns`, the #4261 low-rate dust fix).
+///
+/// `added_bytes` is capped at `TOKEN_BYTE_CAP` so the later `min(space)` at the
+/// call site stays within the packed u32 range; `advance_to_ns` is rewound by
+/// the time-equivalent of the ungranted sub-byte remainder so cumulative grant
+/// equals `floor(total_elapsed × rate / 1e9)` — the same conservation the
+/// pre-#5390 scaled-`u128` bucket had, and the same rewind `refill_cos_tokens`
+/// performs. `rate × elapsed` is computed in `u128` and never overflows for any
+/// `u64` inputs `((2^64-1)^2 < u128::MAX)`.
+#[inline]
+fn compute_refill_add(rate_bytes_per_sec: u64, last_ns: u64, now_ns: u64) -> Option<(u64, u64)> {
+    if now_ns <= last_ns || rate_bytes_per_sec == 0 {
+        return None;
+    }
+    let elapsed_ns = now_ns - last_ns;
+    let scaled = u128::from(elapsed_ns) * u128::from(rate_bytes_per_sec);
+    let added_full = scaled / NANOS_PER_SEC;
+    if added_full == 0 {
+        // No whole byte accrued: leave `last_ns` untouched so the fractional
+        // credit is not discarded (low-rate classes never refill otherwise).
+        return None;
+    }
+    let remainder = scaled - added_full * NANOS_PER_SEC;
+    // `remainder < 1e9` and `rate >= 1`, so `leftover_ns < 1e9` and (since
+    // `added_full >= 1` implies `elapsed_ns >= 1e9 / rate`) `leftover_ns <=
+    // elapsed_ns`; `now_ns - leftover_ns` stays in `[last_ns, now_ns]`.
+    let leftover_ns = (remainder / u128::from(rate_bytes_per_sec)) as u64;
+    let added = added_full.min(u128::from(TOKEN_BYTE_CAP)) as u64;
+    Some((added, now_ns - leftover_ns))
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PacketColor {
@@ -94,37 +157,71 @@ pub(crate) enum PolicerConfigError {
     PeakBurstBelowCommittedBurst,
 }
 
-/// Compact RFC 2697/2698 policer state. All hot fields are numeric so the
-/// state can move to ID-indexed shards without retaining name-keyed lookup.
-#[derive(Clone, Debug)]
-pub(crate) struct ThreeColorPolicerState {
+/// Immutable per-policer shape: mode, rates, (clamped) bursts, color-mode, and
+/// per-color treatments. Set once at compile and only READ on the hot path, so
+/// it carries no interior mutability and drives `same_runtime_shape`. Bursts
+/// are clamped to `TOKEN_BYTE_CAP` for the packed token representation; rates
+/// stay full `u64` (a 100 Gbps policer is ~1.25e10 bytes/s, above `u32::MAX`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ThreeColorPolicerConfig {
     mode: ThreeColorMode,
     color_blind: bool,
     committed_rate_bytes_per_sec: u64,
     committed_burst_bytes: u64,
     peak_or_excess_rate_bytes_per_sec: u64,
     peak_or_excess_burst_bytes: u64,
-    committed_tokens: u128,
-    peak_or_excess_tokens: u128,
-    last_refill_ns: u64,
-    initialized: bool,
     treatments: ThreeColorTreatments,
+}
+
+/// #5390: cache-line-isolated hot state. `#[repr(align(64))]` keeps the CAS
+/// word off the cache line of the runtime's `Relaxed` per-color counters so
+/// contention on one does not false-share the other. `credits` packs both
+/// token buckets (committed high 32 bits, peak/excess low 32) so a green
+/// consume debits both atomically in one CAS. `committed_last_refill_ns` /
+/// `peak_last_refill_ns` are the per-rate refill clocks (srTCM uses only the
+/// committed clock; the excess bucket is fed by committed overflow).
+#[repr(align(64))]
+#[derive(Debug)]
+pub(crate) struct ThreeColorPolicerHot {
+    credits: AtomicU64,
+    committed_last_refill_ns: AtomicU64,
+    peak_last_refill_ns: AtomicU64,
+}
+
+impl ThreeColorPolicerHot {
+    fn new(committed_burst_bytes: u64, peak_or_excess_burst_bytes: u64) -> Self {
+        Self {
+            // Start both buckets at their burst caps (a freshly-installed
+            // policer admits a full burst) — matches the pre-#5390 constructor
+            // that seeded `committed_tokens = scaled(committed_burst)`.
+            credits: AtomicU64::new(pack_tokens(committed_burst_bytes, peak_or_excess_burst_bytes)),
+            committed_last_refill_ns: AtomicU64::new(UNINITIALIZED_NS),
+            peak_last_refill_ns: AtomicU64::new(UNINITIALIZED_NS),
+        }
+    }
+}
+
+/// Compact RFC 2697/2698 policer. Metering is lock-free (`meter(&self)` via CAS
+/// over `hot`); the shape lives in `config`.
+#[derive(Debug)]
+pub(crate) struct ThreeColorPolicerState {
+    config: ThreeColorPolicerConfig,
+    hot: ThreeColorPolicerHot,
 }
 
 impl ThreeColorPolicerState {
     pub(crate) fn fail_closed(color_blind: bool) -> Self {
         Self {
-            mode: ThreeColorMode::Unsupported,
-            color_blind,
-            committed_rate_bytes_per_sec: 0,
-            committed_burst_bytes: 0,
-            peak_or_excess_rate_bytes_per_sec: 0,
-            peak_or_excess_burst_bytes: 0,
-            committed_tokens: 0,
-            peak_or_excess_tokens: 0,
-            last_refill_ns: 0,
-            initialized: true,
-            treatments: ThreeColorTreatments::default(),
+            config: ThreeColorPolicerConfig {
+                mode: ThreeColorMode::Unsupported,
+                color_blind,
+                committed_rate_bytes_per_sec: 0,
+                committed_burst_bytes: 0,
+                peak_or_excess_rate_bytes_per_sec: 0,
+                peak_or_excess_burst_bytes: 0,
+                treatments: ThreeColorTreatments::default(),
+            },
+            hot: ThreeColorPolicerHot::new(0, 0),
         }
     }
 
@@ -158,18 +255,19 @@ impl ThreeColorPolicerState {
         if committed_burst_bytes == 0 || excess_burst_bytes == 0 {
             return Err(PolicerConfigError::ZeroBurst);
         }
+        let committed_burst_bytes = clamp_burst(committed_burst_bytes);
+        let excess_burst_bytes = clamp_burst(excess_burst_bytes);
         Ok(Self {
-            mode: ThreeColorMode::SingleRate,
-            color_blind,
-            committed_rate_bytes_per_sec,
-            committed_burst_bytes,
-            peak_or_excess_rate_bytes_per_sec: 0,
-            peak_or_excess_burst_bytes: excess_burst_bytes,
-            committed_tokens: scaled_bytes(committed_burst_bytes),
-            peak_or_excess_tokens: scaled_bytes(excess_burst_bytes),
-            last_refill_ns: 0,
-            initialized: false,
-            treatments,
+            config: ThreeColorPolicerConfig {
+                mode: ThreeColorMode::SingleRate,
+                color_blind,
+                committed_rate_bytes_per_sec,
+                committed_burst_bytes,
+                peak_or_excess_rate_bytes_per_sec: 0,
+                peak_or_excess_burst_bytes: excess_burst_bytes,
+                treatments,
+            },
+            hot: ThreeColorPolicerHot::new(committed_burst_bytes, excess_burst_bytes),
         })
     }
 
@@ -212,29 +310,35 @@ impl ThreeColorPolicerState {
         if peak_burst_bytes < committed_burst_bytes {
             return Err(PolicerConfigError::PeakBurstBelowCommittedBurst);
         }
+        let committed_burst_bytes = clamp_burst(committed_burst_bytes);
+        let peak_burst_bytes = clamp_burst(peak_burst_bytes);
         Ok(Self {
-            mode: ThreeColorMode::TwoRate,
-            color_blind,
-            committed_rate_bytes_per_sec,
-            committed_burst_bytes,
-            peak_or_excess_rate_bytes_per_sec: peak_rate_bytes_per_sec,
-            peak_or_excess_burst_bytes: peak_burst_bytes,
-            committed_tokens: scaled_bytes(committed_burst_bytes),
-            peak_or_excess_tokens: scaled_bytes(peak_burst_bytes),
-            last_refill_ns: 0,
-            initialized: false,
-            treatments,
+            config: ThreeColorPolicerConfig {
+                mode: ThreeColorMode::TwoRate,
+                color_blind,
+                committed_rate_bytes_per_sec,
+                committed_burst_bytes,
+                peak_or_excess_rate_bytes_per_sec: peak_rate_bytes_per_sec,
+                peak_or_excess_burst_bytes: peak_burst_bytes,
+                treatments,
+            },
+            hot: ThreeColorPolicerHot::new(committed_burst_bytes, peak_burst_bytes),
         })
     }
 
+    /// Meter one packet. Lock-free: refills through per-rate timestamp CAS then
+    /// consumes tokens through a bounded `compare_exchange_weak` loop over the
+    /// packed `credits` word. `&self` (not `&mut self`): the state is shared
+    /// across all workers behind an `Arc` and metered concurrently — the
+    /// #5390 fix that removed the per-packet `Mutex`.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn meter(
-        &mut self,
+        &self,
         now_ns: u64,
         packet_bytes: u64,
         incoming_color: PacketColor,
     ) -> ThreeColorDecision {
-        if self.mode == ThreeColorMode::Unsupported {
+        if self.config.mode == ThreeColorMode::Unsupported {
             return ThreeColorDecision {
                 color: PacketColor::Red,
                 dscp_rewrite: None,
@@ -242,17 +346,13 @@ impl ThreeColorPolicerState {
             };
         }
         self.refill(now_ns);
-        let effective_incoming_color = if self.color_blind {
+        let effective_incoming_color = if self.config.color_blind {
             PacketColor::Green
         } else {
             incoming_color
         };
-        let color = match self.mode {
-            ThreeColorMode::SingleRate => self.meter_sr_tcm(packet_bytes, effective_incoming_color),
-            ThreeColorMode::TwoRate => self.meter_tr_tcm(packet_bytes, effective_incoming_color),
-            ThreeColorMode::Unsupported => PacketColor::Red,
-        };
-        let treatment = self.treatments.treatment_for(color);
+        let color = self.consume(packet_bytes, effective_incoming_color);
+        let treatment = self.config.treatments.treatment_for(color);
         ThreeColorDecision {
             color,
             dscp_rewrite: treatment.dscp_rewrite,
@@ -261,7 +361,7 @@ impl ThreeColorPolicerState {
     }
 
     pub(crate) fn mode_name(&self) -> &'static str {
-        match self.mode {
+        match self.config.mode {
             ThreeColorMode::SingleRate => "single-rate",
             ThreeColorMode::TwoRate => "two-rate",
             ThreeColorMode::Unsupported => "unsupported",
@@ -269,92 +369,237 @@ impl ThreeColorPolicerState {
     }
 
     pub(crate) fn color_blind(&self) -> bool {
-        self.color_blind
+        self.config.color_blind
     }
 
+    /// Two runtimes are shape-equivalent (token/counter state reusable across a
+    /// snapshot refresh) iff their immutable configs match. No lock: `config`
+    /// is plain data.
     pub(crate) fn same_runtime_shape(&self, other: &Self) -> bool {
-        self.mode == other.mode
-            && self.color_blind == other.color_blind
-            && self.committed_rate_bytes_per_sec == other.committed_rate_bytes_per_sec
-            && self.committed_burst_bytes == other.committed_burst_bytes
-            && self.peak_or_excess_rate_bytes_per_sec == other.peak_or_excess_rate_bytes_per_sec
-            && self.peak_or_excess_burst_bytes == other.peak_or_excess_burst_bytes
-            && self.treatments == other.treatments
+        self.config == other.config
     }
 
-    fn refill(&mut self, now_ns: u64) {
-        if !self.initialized {
-            self.initialized = true;
-            self.last_refill_ns = now_ns;
-            self.committed_tokens = scaled_bytes(self.committed_burst_bytes);
-            self.peak_or_excess_tokens = scaled_bytes(self.peak_or_excess_burst_bytes);
-            return;
+    fn refill(&self, now_ns: u64) {
+        match self.config.mode {
+            ThreeColorMode::SingleRate => self.refill_sr_tcm(now_ns),
+            ThreeColorMode::TwoRate => self.refill_tr_tcm(now_ns),
+            ThreeColorMode::Unsupported => {}
         }
-        if now_ns <= self.last_refill_ns {
-            return;
-        }
-
-        let elapsed_ns = now_ns - self.last_refill_ns;
-        match self.mode {
-            ThreeColorMode::SingleRate => self.refill_sr_tcm(elapsed_ns),
-            ThreeColorMode::TwoRate => self.refill_tr_tcm(elapsed_ns),
-            ThreeColorMode::Unsupported => return,
-        }
-        self.last_refill_ns = now_ns;
     }
 
-    fn refill_sr_tcm(&mut self, elapsed_ns: u64) {
-        let refill = refill_scaled(self.committed_rate_bytes_per_sec, elapsed_ns);
-        let committed_cap = scaled_bytes(self.committed_burst_bytes);
-        let excess_cap = scaled_bytes(self.peak_or_excess_burst_bytes);
-        let committed_space = committed_cap.saturating_sub(self.committed_tokens);
-        let committed_add = refill.min(committed_space);
-        self.committed_tokens += committed_add;
-        let excess_add = refill - committed_add;
-        self.peak_or_excess_tokens = capped_add(self.peak_or_excess_tokens, excess_add, excess_cap);
+    /// srTCM refill: the committed bucket fills at CIR; overflow past CBS spills
+    /// into the excess bucket (capped at EBS). One rate → one timestamp.
+    fn refill_sr_tcm(&self, now_ns: u64) {
+        loop {
+            let last = self.hot.committed_last_refill_ns.load(Ordering::Acquire);
+            if last == UNINITIALIZED_NS {
+                if self
+                    .hot
+                    .committed_last_refill_ns
+                    .compare_exchange(UNINITIALIZED_NS, now_ns, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return;
+                }
+                continue;
+            }
+            let Some((added, advance_to)) =
+                compute_refill_add(self.config.committed_rate_bytes_per_sec, last, now_ns)
+            else {
+                return;
+            };
+            if self
+                .hot
+                .committed_last_refill_ns
+                .compare_exchange(last, advance_to, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                // Lost the timestamp advance to another worker — it owns this
+                // window's credit add. Re-observe; no double refill.
+                continue;
+            }
+            // Won the window: add `added` bytes, committed-first, overflow to
+            // excess. Retry the packed-credits CAS until it lands.
+            loop {
+                let credits = self.hot.credits.load(Ordering::Acquire);
+                let (committed, peak) = unpack_tokens(credits);
+                let committed_space = self.config.committed_burst_bytes.saturating_sub(committed);
+                let committed_add = added.min(committed_space);
+                let excess_add = added - committed_add;
+                let excess_space = self
+                    .config
+                    .peak_or_excess_burst_bytes
+                    .saturating_sub(peak);
+                let new_credits =
+                    pack_tokens(committed + committed_add, peak + excess_add.min(excess_space));
+                if self
+                    .hot
+                    .credits
+                    .compare_exchange_weak(credits, new_credits, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return;
+                }
+            }
+        }
     }
 
-    fn refill_tr_tcm(&mut self, elapsed_ns: u64) {
-        self.committed_tokens = capped_add(
-            self.committed_tokens,
-            refill_scaled(self.committed_rate_bytes_per_sec, elapsed_ns),
-            scaled_bytes(self.committed_burst_bytes),
+    /// trTCM refill: committed fills at CIR, peak fills at PIR, independently
+    /// (two rates → two timestamps).
+    fn refill_tr_tcm(&self, now_ns: u64) {
+        self.refill_independent_bucket(now_ns, self.config.committed_rate_bytes_per_sec, true);
+        self.refill_independent_bucket(
+            now_ns,
+            self.config.peak_or_excess_rate_bytes_per_sec,
+            false,
         );
-        self.peak_or_excess_tokens = capped_add(
-            self.peak_or_excess_tokens,
-            refill_scaled(self.peak_or_excess_rate_bytes_per_sec, elapsed_ns),
-            scaled_bytes(self.peak_or_excess_burst_bytes),
-        );
     }
 
-    fn meter_sr_tcm(&mut self, packet_bytes: u64, incoming_color: PacketColor) -> PacketColor {
-        let cost = scaled_bytes(packet_bytes);
-        if incoming_color == PacketColor::Green && self.committed_tokens >= cost {
-            self.committed_tokens -= cost;
-            return PacketColor::Green;
+    /// Refill one independent-rate bucket (`committed` when `is_committed`, else
+    /// `peak`) into its half of the packed `credits` word. Same win-the-window
+    /// timestamp CAS as srTCM; only this bucket's half is mutated so a
+    /// concurrent sibling-bucket refill retries and both converge.
+    fn refill_independent_bucket(&self, now_ns: u64, rate_bytes_per_sec: u64, is_committed: bool) {
+        let (ts, burst) = if is_committed {
+            (
+                &self.hot.committed_last_refill_ns,
+                self.config.committed_burst_bytes,
+            )
+        } else {
+            (
+                &self.hot.peak_last_refill_ns,
+                self.config.peak_or_excess_burst_bytes,
+            )
+        };
+        loop {
+            let last = ts.load(Ordering::Acquire);
+            if last == UNINITIALIZED_NS {
+                if ts
+                    .compare_exchange(UNINITIALIZED_NS, now_ns, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return;
+                }
+                continue;
+            }
+            let Some((added, advance_to)) = compute_refill_add(rate_bytes_per_sec, last, now_ns)
+            else {
+                return;
+            };
+            if ts
+                .compare_exchange(last, advance_to, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                continue;
+            }
+            loop {
+                let credits = self.hot.credits.load(Ordering::Acquire);
+                let (committed, peak) = unpack_tokens(credits);
+                let new_credits = if is_committed {
+                    let space = burst.saturating_sub(committed);
+                    pack_tokens(committed + added.min(space), peak)
+                } else {
+                    let space = burst.saturating_sub(peak);
+                    pack_tokens(committed, peak + added.min(space))
+                };
+                if self
+                    .hot
+                    .credits
+                    .compare_exchange_weak(credits, new_credits, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return;
+                }
+            }
         }
-        if incoming_color != PacketColor::Red && self.peak_or_excess_tokens >= cost {
-            self.peak_or_excess_tokens -= cost;
-            return PacketColor::Yellow;
-        }
-        PacketColor::Red
     }
 
-    fn meter_tr_tcm(&mut self, packet_bytes: u64, incoming_color: PacketColor) -> PacketColor {
-        let cost = scaled_bytes(packet_bytes);
-        if incoming_color == PacketColor::Green
-            && self.peak_or_excess_tokens >= cost
-            && self.committed_tokens >= cost
-        {
-            self.peak_or_excess_tokens -= cost;
-            self.committed_tokens -= cost;
-            return PacketColor::Green;
+    /// Classify + debit one packet against the (already refilled) buckets via a
+    /// bounded CAS loop. Byte-granular thresholds are identical to the pre-#5390
+    /// scaled-`u128` decision (the `× 1e9` scale cancels in every comparison). A
+    /// Red packet consumes nothing, so it returns without a CAS.
+    fn consume(&self, cost: u64, incoming_color: PacketColor) -> PacketColor {
+        loop {
+            let credits = self.hot.credits.load(Ordering::Acquire);
+            let (committed, peak) = unpack_tokens(credits);
+            match self.config.mode {
+                ThreeColorMode::SingleRate => {
+                    if incoming_color == PacketColor::Green && committed >= cost {
+                        let new = pack_tokens(committed - cost, peak);
+                        if self
+                            .hot
+                            .credits
+                            .compare_exchange_weak(
+                                credits,
+                                new,
+                                Ordering::AcqRel,
+                                Ordering::Acquire,
+                            )
+                            .is_ok()
+                        {
+                            return PacketColor::Green;
+                        }
+                        continue;
+                    }
+                    if incoming_color != PacketColor::Red && peak >= cost {
+                        let new = pack_tokens(committed, peak - cost);
+                        if self
+                            .hot
+                            .credits
+                            .compare_exchange_weak(
+                                credits,
+                                new,
+                                Ordering::AcqRel,
+                                Ordering::Acquire,
+                            )
+                            .is_ok()
+                        {
+                            return PacketColor::Yellow;
+                        }
+                        continue;
+                    }
+                    return PacketColor::Red;
+                }
+                ThreeColorMode::TwoRate => {
+                    if incoming_color == PacketColor::Green && peak >= cost && committed >= cost {
+                        let new = pack_tokens(committed - cost, peak - cost);
+                        if self
+                            .hot
+                            .credits
+                            .compare_exchange_weak(
+                                credits,
+                                new,
+                                Ordering::AcqRel,
+                                Ordering::Acquire,
+                            )
+                            .is_ok()
+                        {
+                            return PacketColor::Green;
+                        }
+                        continue;
+                    }
+                    if incoming_color != PacketColor::Red && peak >= cost {
+                        let new = pack_tokens(committed, peak - cost);
+                        if self
+                            .hot
+                            .credits
+                            .compare_exchange_weak(
+                                credits,
+                                new,
+                                Ordering::AcqRel,
+                                Ordering::Acquire,
+                            )
+                            .is_ok()
+                        {
+                            return PacketColor::Yellow;
+                        }
+                        continue;
+                    }
+                    return PacketColor::Red;
+                }
+                ThreeColorMode::Unsupported => return PacketColor::Red,
+            }
         }
-        if incoming_color != PacketColor::Red && self.peak_or_excess_tokens >= cost {
-            self.peak_or_excess_tokens -= cost;
-            return PacketColor::Yellow;
-        }
-        PacketColor::Red
     }
 }
 
@@ -362,6 +607,7 @@ impl ThreeColorPolicerState {
 #[allow(non_snake_case)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn sr_tcm(
         committed_rate_bytes_per_sec: u64,
@@ -397,7 +643,7 @@ mod tests {
 
     #[test]
     fn srTCM_green_yellow_red_at_thresholds() {
-        let mut policer = sr_tcm(100, 100, 50, true);
+        let policer = sr_tcm(100, 100, 50, true);
 
         let green = policer.meter(0, 100, PacketColor::Green);
         let yellow = policer.meter(0, 50, PacketColor::Green);
@@ -410,7 +656,7 @@ mod tests {
 
     #[test]
     fn srTCM_c_overflow_refills_e_bucket() {
-        let mut policer = sr_tcm(100, 100, 200, true);
+        let policer = sr_tcm(100, 100, 200, true);
 
         let first = policer.meter(0, 150, PacketColor::Green);
         assert_eq!(first.color, PacketColor::Yellow);
@@ -424,7 +670,7 @@ mod tests {
 
     #[test]
     fn trTCM_independent_CIR_PIR() {
-        let mut policer = tr_tcm(100, 100, 200, 200, true);
+        let policer = tr_tcm(100, 100, 200, 200, true);
 
         let initial = policer.meter(0, 100, PacketColor::Green);
         assert_eq!(initial.color, PacketColor::Green);
@@ -438,7 +684,7 @@ mod tests {
 
     #[test]
     fn color_aware_never_promotes_incoming_yellow_or_red() {
-        let mut sr_policer = sr_tcm(100, 100, 100, false);
+        let sr_policer = sr_tcm(100, 100, 100, false);
 
         let yellow = sr_policer.meter(0, 50, PacketColor::Yellow);
         let red = sr_policer.meter(0, 50, PacketColor::Red);
@@ -446,7 +692,7 @@ mod tests {
         assert_eq!(yellow.color, PacketColor::Yellow);
         assert_eq!(red.color, PacketColor::Red);
 
-        let mut tr_policer = tr_tcm(100, 100, 100, 100, false);
+        let tr_policer = tr_tcm(100, 100, 100, 100, false);
 
         let yellow = tr_policer.meter(0, 50, PacketColor::Yellow);
         let red = tr_policer.meter(0, 50, PacketColor::Red);
@@ -457,7 +703,7 @@ mod tests {
 
     #[test]
     fn color_blind_ignores_incoming_color() {
-        let mut policer = sr_tcm(100, 100, 100, true);
+        let policer = sr_tcm(100, 100, 100, true);
 
         let green = policer.meter(0, 50, PacketColor::Red);
 
@@ -465,13 +711,17 @@ mod tests {
     }
 
     #[test]
-    fn u128_bucket_math_boundary_inputs() {
-        let mut policer = sr_tcm(u64::MAX, u64::MAX, u64::MAX, true);
-
-        let first = policer.meter(0, u64::MAX, PacketColor::Green);
-        let refilled = policer.meter(u64::MAX, u64::MAX, PacketColor::Green);
-
-        assert_eq!(first.color, PacketColor::Green);
+    fn burst_clamps_to_packed_u32_range_without_panic() {
+        // #5390: bursts beyond the packed u32 byte range clamp rather than
+        // overflow the two-buckets-in-one-u64 layout. A max-realistic frame
+        // still meters green against the (clamped-full) committed bucket, and
+        // the metering never panics on boundary inputs.
+        let policer = sr_tcm(u64::MAX, u64::MAX, u64::MAX, true);
+        let jumbo = policer.meter(0, 9_000, PacketColor::Green);
+        assert_eq!(jumbo.color, PacketColor::Green);
+        // A full-u32 packet still fits the clamped committed bucket after a
+        // refill — no panic, no wraparound.
+        let refilled = policer.meter(1_000_000_000, u32::MAX as u64, PacketColor::Green);
         assert_eq!(refilled.color, PacketColor::Green);
     }
 
@@ -486,7 +736,7 @@ mod tests {
                 treatment
             },
         };
-        let mut policer =
+        let policer =
             ThreeColorPolicerState::sr_tcm_with_treatments(100, 100, 50, true, treatments)
                 .expect("valid srTCM config");
 
@@ -500,5 +750,122 @@ mod tests {
         assert!(!yellow.drop);
         assert_eq!(red.dscp_rewrite, Some(30));
         assert!(red.drop);
+    }
+
+    #[test]
+    fn hot_state_is_cacheline_aligned() {
+        // #5390: the CAS word must sit on its own cache line, isolated from the
+        // runtime's Relaxed per-color counters (no false sharing under load).
+        assert_eq!(std::mem::align_of::<ThreeColorPolicerHot>(), 64);
+    }
+
+    #[test]
+    fn low_rate_refill_carries_sub_byte_dust() {
+        // #4261 conservation, preserved by the byte-granular rewind: a bucket
+        // that accrues < 1 whole byte per meter call must still refill over
+        // time rather than stall (the pre-#5390 scaled-u128 bucket kept the
+        // fraction in the token count; the atomic bucket keeps it in the
+        // rewound timestamp). CIR = 1000 B/s, CBS = 100 B: after draining, a
+        // stream of 1 ns steps (each accruing 1e-6 bytes) must eventually
+        // re-admit green rather than stall forever.
+        let policer = sr_tcm(1000, 100, 100, true);
+        assert_eq!(
+            policer.meter(0, 100, PacketColor::Green).color,
+            PacketColor::Green
+        );
+        // Bucket empty; single-nanosecond ticks each accrue 1e-6 bytes.
+        let mut admitted = 0u64;
+        for step in 1..=200_000_000u64 {
+            if policer.meter(step, 1, PacketColor::Green).color == PacketColor::Green {
+                admitted += 1;
+            }
+            if admitted >= 50 {
+                break;
+            }
+        }
+        assert!(
+            admitted >= 50,
+            "sub-byte dust must accrue into whole-byte green admissions, got {admitted}"
+        );
+    }
+
+    #[test]
+    fn concurrent_meter_is_lock_free_and_preserves_trTCM_thresholds() {
+        // #5390 fail-on-revert: hammer ONE shared policer from many threads
+        // through `&self` metering (the shared-Arc contract the Mutex revert
+        // cannot satisfy — `ThreeColorPolicerState::meter` would be `&mut self`
+        // again and this shared-borrow call would not compile). The aggregate
+        // green bytes must EXACTLY equal the committed burst budget: trTCM color
+        // thresholds hold under concurrent CAS with no torn / lost / double
+        // updates.
+        //
+        // CIR = 1e9 B/s, CBS = 1e6 B, PIR = 2e9 B/s, PBS = 2e6 B. All meters
+        // share now_ns = 0 (no refill), so admitted green bytes are bounded by
+        // the initial committed burst CBS = 1e6 B; the offered load
+        // (8×20000×100 = 16e6 B) far exceeds it, so a correct meter admits
+        // EXACTLY the budget.
+        let policer = Arc::new(tr_tcm(
+            1_000_000_000,
+            1_000_000,
+            2_000_000_000,
+            2_000_000,
+            true,
+        ));
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 20_000;
+        const PKT: u64 = 100;
+        let mut handles = Vec::new();
+        for _ in 0..THREADS {
+            let p = Arc::clone(&policer);
+            handles.push(std::thread::spawn(move || {
+                let mut green_bytes = 0u64;
+                for _ in 0..PER_THREAD {
+                    if p.meter(0, PKT, PacketColor::Green).color == PacketColor::Green {
+                        green_bytes += PKT;
+                    }
+                }
+                green_bytes
+            }));
+        }
+        let total_green: u64 = handles.into_iter().map(|h| h.join().unwrap()).sum();
+        assert_eq!(
+            total_green, 1_000_000,
+            "concurrent green admissions must exactly equal the CBS token budget (no torn CAS)"
+        );
+    }
+
+    #[test]
+    fn meter_hot_path_takes_no_shared_mutex_source_guard() {
+        // #5390 fail-on-revert source guard: bind the metered hot path to the
+        // lock-free design. A revert to `Mutex<ThreeColorPolicerState>` +
+        // `state.lock()` on the meter path reddens this assertion (an assertion
+        // failure, not merely a build break). Mirrors the source-scan guards in
+        // afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs.
+        // The negative (no-Mutex) checks read filter/mod.rs — the runtime
+        // wrapper, a DIFFERENT file — so they never self-match the literals
+        // written in this test's own assertions. The positive (CAS/atomic)
+        // checks read policer.rs (this file), whose real meter code carries
+        // those markers whether or not the test mentions them.
+        use std::path::Path;
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/filter");
+        let policer = std::fs::read_to_string(src.join("policer.rs")).unwrap();
+        let mod_rs = std::fs::read_to_string(src.join("mod.rs")).unwrap();
+
+        assert!(
+            policer.contains("compare_exchange_weak") && policer.contains("AtomicU64"),
+            "policer meter path must use lock-free CAS over atomics (#5390)"
+        );
+        assert!(
+            policer.contains("#[repr(align(64))]"),
+            "hot state must be cache-line isolated from the Relaxed counters (#5390)"
+        );
+        assert!(
+            !mod_rs.contains("Mutex<ThreeColorPolicerState>"),
+            "the three-color policer runtime must not wrap its state in a Mutex (#5390)"
+        );
+        assert!(
+            !mod_rs.contains("self.state.lock()"),
+            "the meter path must not take a per-packet lock (#5390 futex convoy)"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The Junos three-color (trTCM/srTCM) policer held its token-bucket state behind a `std::sync::Mutex` locked on **every metered packet**, with the runtime shared across workers via `Arc<ThreeColorPolicerRuntime>`. A three-color-policer filter on a high-rate interface makes the RSS-spread flow aggregate (6 RX queues → 6 workers on the mlx5 VF) contend on one mutex per packet on the cache-hit replay / TX-selection hot path — a **cross-worker futex convoy** that caps line rate below the configured CIR/PIR and undermines the CoS guarantee-guard (#4246). This violated the per-packet no-lock discipline (`shared_cos_lease` is deliberately lock-free for the same reason).

## Fix — approach (b): lock-free atomic **aggregate** meter

The shared bucket is kept; only the synchronization primitive changes, so the observable policing rate stays the **exact configured aggregate CIR/PIR** — no per-worker rate division, no dependence on RSS flow spread. A per-worker shard was rejected precisely because it would divide the rate by the worker count and make enforcement depend on flow distribution.

- `ThreeColorPolicerState` splits into an immutable `ThreeColorPolicerConfig` (mode/rates/clamped-bursts/treatments; drives `same_runtime_shape`) and a `#[repr(align(64))]` `ThreeColorPolicerHot`: **both token buckets packed into one `AtomicU64`** (committed high 32 bits, peak/excess low 32) plus per-rate `last_refill_ns` atomics. Packing both buckets in one word makes a green consume (debits committed AND peak in trTCM) atomic in a single CAS; `align(64)` isolates the CAS word from the runtime's `Relaxed` per-color counters (kills the false-sharing the issue flagged). Follows the `afxdp/types/shared_cos_lease` v8 pack/CAS precedent.
- `meter()` is now `&self`: refill advances each rate's timestamp with a win-the-window `compare_exchange` (winner owns that window's credit add), then consume classifies + debits via a bounded `compare_exchange_weak` loop. A Red packet consumes nothing and returns without a CAS, so an over-limit flood generates zero atomic traffic.
- Byte-granular buckets replace the scaled-`u128` tokens; the sub-byte fractional refill credit is carried across refills by **rewinding `last_refill_ns`** (the #4261 conservation rewind, as `refill_cos_tokens` does), so cumulative grant still equals `floor(elapsed × rate / 1e9)`. Bursts clamp to the packed u32 byte range (a Junos burst-size is far below 4 GiB); `rate × elapsed` is computed in `u128` and never overflows for `u64` inputs.
- The `ThreeColorPolicerRuntime` wrapper drops its `Mutex`; `meter`/`reusable_for`/`same_runtime_shape_as`/`status` no longer lock. Removing the lock removes the poison failure mode entirely; the only fail-closed path is the `Unsupported`-mode Red/drop, unchanged.

## Rate-semantics impact

None to the observable contract: the aggregate CIR/PIR/CBS/PBS is preserved exactly (all workers meter one shared bucket, byte-granular). Only sub-byte instantaneous rounding differs from the scaled-`u128` bucket, and it is self-correcting via the timestamp rewind. Documented in `filter/README.md` (lock-free concurrency model + per-worker-vs-aggregate rationale).

## Fail-on-revert test

- `meter_hot_path_takes_no_shared_mutex_source_guard` — asserts (reading `filter/mod.rs`, a *different* file, to avoid self-match) that the runtime carries no `Mutex<ThreeColorPolicerState>` and the meter path takes no `self.state.lock()`, plus that `policer.rs` uses `compare_exchange_weak` / `AtomicU64` / `#[repr(align(64))]`.
- `concurrent_meter_is_lock_free_and_preserves_trTCM_thresholds` — 8 threads hammer one shared `Arc`'d policer through `&self` metering; asserts concurrent green admissions exactly equal the CBS token budget (no torn/lost/double CAS). A shared-Mutex revert (`meter` back to `&mut self`) cannot even compile this.

**Firsthand RED-on-revert verified:** re-adding `Mutex<ThreeColorPolicerState>` to the runtime reddens the source guard by **assertion** ("must not wrap its state in a Mutex"), not a build break, while the other 10 tests still pass.

## Validation

- `cargo build` green; `cargo test --release` lib suite green (**4100 passed, 0 failed**) including all 11 `filter::policer` tests. The only full-run failures were `fairness_eval_blackbox` panicking on `No space left on device` (transient `/tmp` exhaustion under parallel load; unrelated to this change — passes 22/22 when re-run alone).

> Hot-path/policer change → parent should run a cluster iperf smoke (ideally with a three-color-policer-configured filter) before merge.

Closes #5390