### PR TITLE
userspace-dp/HA: carry RT_FLOW session id across the session-sync wire (#5212)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56218,3 +56218,15 @@ top.
   pkg/dataplane/types.go, pkg/dataplane/userspace/{protocol,eventstream,manager_ha,*_test}.go,
   pkg/cluster/{sync_protocol,README,sync_*_test}.go, pkg/daemon/{daemon_ha_userspace_convert,userspace_sync_test}.go,
   docs/{sync-protocol,session-sync-architecture}.md
+
+## 2026-07-22 — #6309 (#5212) review fold: honest session-id caveat
+- **Action**: Folded rev6309 MERGE-NEEDS-MINOR findings — corrected the FALSE
+  "disjoint id slice" claim in docs/sync-protocol.md, session/README.md, and the
+  install.rs adopt comment to state the honest metadata-only, not-globally-unique
+  caveat (worker<<48|counter has no node discriminator; adopted id can collide
+  with a local same-worker id in active/active — observability-only). Tightened
+  the adopt test (worker 7→3, honest comment). Added the JSON-leg caveat to
+  emit_open_delta_with_origin. Filed follow-ups #6311 (node-bit namespace fix),
+  #6312 (JSON resync id-drop), #6313 (reverse-materialize test).
+- **File(s)**: docs/sync-protocol.md, userspace-dp/src/session/README.md,
+  userspace-dp/src/session/install.rs, userspace-dp/src/session/tests.rs

--- a/_Log.md
+++ b/_Log.md
@@ -56186,3 +56186,35 @@ top.
   when the Mutex is re-added).
 - **File(s)**: userspace-dp/src/filter/policer.rs,
   userspace-dp/src/filter/mod.rs, userspace-dp/src/filter/README.md
+- **Timestamp**: 2026-07-22 (#5212)
+- **Action**: Carry the RT_FLOW stable session id across the HA session-sync
+  wire so a peer-synced session ADOPTS the originating node's id instead of
+  minting a fresh node-local one on import (completes the #4915 cross-node
+  follow-up). BOTH-SIDES additive length-gated trailing field (mirrors the
+  #4565 snat_v4 / #5274 config-epoch discipline). Rust: `SessionInstall.session_id`
+  + `SyncedSessionEntry.session_id`; `upsert_synced_with_origin` stamps the wire
+  id when non-zero else `alloc_session_id()`; `encode_session_open` appends the
+  trailing u64 (threaded from `SessionDelta.session_id`); `emit_open_delta_with_origin`
+  looks the id up off the live table for the owner-RG cold-sync export;
+  `build_synced_session_entry` reads `SessionSyncRequest.session_id`. Go: added
+  `RTFlowSessionID` to `SessionValue`/`SessionValueV6` (distinct from the BPF-ABI
+  `SessionID`) + `SessionDeltaInfo` + `SessionSyncRequest`; wire encode/decode in
+  `sync_protocol.go` (V4+V6, appended after ConfigEpoch); `decodeSessionEvent`
+  decode; `buildSessionSyncRequestV4/V6` + `userspaceSessionFromDeltaV4/V6` stamp.
+  Regenerated `protocol_wire_v1.json`; fixed the six pre-existing
+  legacy-truncation tests whose `-N` byte counts shifted by the new trailing
+  field. Fail-on-revert tests (all firsthand RED-verified):
+  `synced_import_adopts_peer_session_id_5212`,
+  `test_encode_session_open_carries_session_id_5212`,
+  `TestSessionWireRoundTripRTFlowSessionID5212{V4,V6}`,
+  `TestDecodeSessionEventRTFlowSessionID5212`,
+  `TestBuildSessionSyncRequestCarriesRTFlowSessionID5212`,
+  `TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212`.
+  **File(s)**: userspace-dp/src/session/{ctx,install,tests,README}.rs/md,
+  userspace-dp/src/afxdp/{worker/mod,session_glue/*,shared_ops,tunnel,forwarding/mod,poll_descriptor/mod,ha}.rs,
+  userspace-dp/src/event_stream/{mod,codec/session_sync,codec/codec_tests}.rs,
+  userspace-dp/src/protocol/control.rs, userspace-dp/src/server/helpers.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/types.go, pkg/dataplane/userspace/{protocol,eventstream,manager_ha,*_test}.go,
+  pkg/cluster/{sync_protocol,README,sync_*_test}.go, pkg/daemon/{daemon_ha_userspace_convert,userspace_sync_test}.go,
+  docs/{sync-protocol,session-sync-architecture}.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -50,9 +50,15 @@ The session value includes state, policy, timestamps, counters, NAT fields,
 reverse key, and a cached forwarding result (`FibIfindex`, MACs, VLAN,
 generation). It also carries a `ConfigEpoch` (#5274) — the config-sync
 generation (#3931) the sender held when it queued the session — used by the
-receive-side config-epoch guard (see "Config-Epoch Guard" below). Both
-`Generation` and `ConfigEpoch` are userspace-sync-only metadata; neither is part
-of the on-map BPF conntrack ABI (`bpfSessionValue`).
+receive-side config-epoch guard (see "Config-Epoch Guard" below), and a
+`RTFlowSessionID` (#5212) — the ORIGINATING node's stable RT_FLOW session id
+(`SessionTable::alloc_session_id`, distinct from the node-local BPF-ABI
+`SessionID`) — which the importing node ADOPTS so a session's RT_FLOW
+SESSION_CREATE (origin node) and SESSION_CLOSE (peer, after failover) share one
+correlatable id across HA nodes (see "RT_FLOW Session Id" below). All three of
+`Generation`, `ConfigEpoch`, and `RTFlowSessionID` are userspace-sync-only
+metadata carried as length-gated trailing wire fields; none is part of the on-map
+BPF conntrack ABI (`bpfSessionValue`).
 
 ### Userspace Mirror
 
@@ -299,6 +305,32 @@ the primary that admits the session is also the RG0 config-sync authority); a
 non-authority's sessions carry the authority-independent seed epoch and the
 guard is inert for them (no false reject), which is acceptable because config
 changes originate on the authority.
+
+### RT_FLOW Session Id (#5212)
+
+The dataplane assigns each session a STABLE id (`SessionTable::alloc_session_id`)
+that it stamps on its RT_FLOW SESSION_CREATE/SESSION_CLOSE records (#4915). That
+id is node-local: before #5212 a peer-synced session was assigned a FRESH id on
+import, so a session that opened on the primary and closed on the standby after a
+failover carried DIFFERENT ids on the two nodes, breaking cross-node log/event
+correlation. #5212 carries the originating node's id on the session-sync wire as
+a length-gated trailing `RTFlowSessionID uint64` (appended after the #5274
+`ConfigEpoch`), and the importing node ADOPTS it.
+
+Unlike the config-epoch guard, this is pure identity carriage — the receiver
+never rejects on it. The path is: the Rust dataplane harvests the id onto
+`SessionDelta.session_id` and writes it as the trailing field of the
+`MSG_SESSION_OPEN` event-stream frame; the daemon decodes it into
+`SessionDeltaInfo.RTFlowSessionID` and stamps `SessionValue{,V6}.RTFlowSessionID`
+(distinct from the node-local BPF-ABI `SessionID`, which stays `now<<16|Slot`);
+`SessionSync` carries it as the trailing wire field; the peer daemon forwards it
+on `SessionSyncRequest.session_id`; and the peer helper's
+`upsert_synced_with_origin` ADOPTS it (stamping the imported `SessionEntry`)
+instead of allocating a fresh local id. A zero id (legacy peer / no live entry)
+falls back to `alloc_session_id()` — rolling-upgrade safe. Because the id is
+worker-namespaced, adopting the peer's id verbatim keeps it unique across the
+importing node's shared-nothing worker tables. The standby's SESSION_CLOSE
+RT_FLOW then correlates with the primary's SESSION_CREATE.
 
 ## Sync Readiness and Bulk Priming
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -357,6 +357,49 @@ and therefore cannot host this guard, so no `config_epoch` field is added to
 `TestConfigEpochNoRejectAgainstZeroBaseline5274` in
 `pkg/cluster/sync_config_epoch_5274_test.go`.
 
+## RT_FLOW Session Id (#5212)
+
+Every **session** message carries a length-gated trailing `RTFlowSessionID
+uint64` (LE), appended **after** the #5274 `ConfigEpoch` on BOTH V4 and V6. An
+old decoder stops before it and reads `RTFlowSessionID == 0` (`if off+8 <=
+len(payload)` block in `decodeSession*Payload`); a new decoder reading an old,
+shorter payload also sees 0 — rolling-upgrade safe, no version bump (the same
+additive-trailing-field discipline as #2170/#3301/#4565/#5274).
+
+**Purpose.** The dataplane assigns each session a STABLE id
+(`SessionTable::alloc_session_id`, `(worker_id << 48) | counter`) and stamps it on
+its RT_FLOW SESSION_CREATE/SESSION_CLOSE records (#4915). That id is NODE-LOCAL:
+before #5212 a peer-synced session was assigned a FRESH id on import, so a session
+that opened on the primary and closed on the standby after a failover carried
+DIFFERENT ids on the two nodes and cross-node log/event correlation broke. #5212
+carries the originating node's id across the sync wire so the importing node
+ADOPTS it — the two nodes emit RT_FLOW records for the same session under one id.
+
+**End-to-end path (both sides).** Rust `SessionDelta.session_id` → the
+`MSG_SESSION_OPEN` event-stream frame's trailing `session_id` u64
+(`encode_session_open`) → Go `SessionDeltaInfo.RTFlowSessionID`
+(`decodeSessionEvent`) → `SessionValue{,V6}.RTFlowSessionID`
+(`userspaceSessionFromDelta*`, distinct from the BPF-ABI `SessionID`) → this
+length-gated trailing wire field (`encode/decodeSessionV{4,6}Payload`) → the peer
+Go `SessionSyncRequest.session_id` (`buildSessionSyncRequest*`) → the Rust helper
+`build_synced_session_entry` → `SessionInstall::session_id`. On import,
+`upsert_synced_with_origin` ADOPTS the wire id when non-zero and only falls back
+to `alloc_session_id()` for a legacy peer (id 0). The id is worker-namespaced, so
+adopting the peer's id verbatim keeps it unique across the importing node's tables
+(the peer's worker occupies a disjoint slice of the id space).
+
+**Additive, not a guard.** Unlike #5274's `ConfigEpoch`, this field is pure
+identity carriage — no receiver rejects on it. `RTFlowSessionID == 0` (legacy
+peer, or a synthesized delta with no live entry) simply falls back to a fresh
+local id. Regression coverage:
+`TestSessionWireRoundTripRTFlowSessionID5212{V4,V6}` in
+`pkg/cluster/sync_rtflow_session_id_5212_test.go`,
+`TestDecodeSessionEventRTFlowSessionID5212` /
+`TestBuildSessionSyncRequestCarriesRTFlowSessionID5212` in
+`pkg/dataplane/userspace`, `TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212`
+in `pkg/daemon`, and the Rust `synced_import_adopts_peer_session_id_5212` /
+`test_encode_session_open_carries_session_id_5212`.
+
 ## Config Payload (Variable)
 
 UTF-8 text of the full Junos-format configuration followed by a trailing

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -384,9 +384,17 @@ length-gated trailing wire field (`encode/decodeSessionV{4,6}Payload`) → the p
 Go `SessionSyncRequest.session_id` (`buildSessionSyncRequest*`) → the Rust helper
 `build_synced_session_entry` → `SessionInstall::session_id`. On import,
 `upsert_synced_with_origin` ADOPTS the wire id when non-zero and only falls back
-to `alloc_session_id()` for a legacy peer (id 0). The id is worker-namespaced, so
-adopting the peer's id verbatim keeps it unique across the importing node's tables
-(the peer's worker occupies a disjoint slice of the id space).
+to `alloc_session_id()` for a legacy peer (id 0). The id is adopted verbatim so
+the same logical session carries the SAME id on both nodes — that cross-node
+correlation is the entire point. It is a **metadata-only** stamp (RT_FLOW
+correlation and the `show security flow session` mirror id), NEVER a lookup key
+or slab handle, so adoption cannot affect forwarding, security, or memory
+safety. It is **not globally unique**: the `worker_id<<48 | counter` namespace
+carries no node discriminator and both nodes run the same worker set, so in an
+active/active cluster an adopted id can collide with a local same-worker id (a
+duplicate correlation stamp — observability-only, bounded). A node-discriminator
+bit that makes adoption globally collision-free is tracked as a follow-up
+(#6311).
 
 **Additive, not a guard.** Unlike #5274's `ConfigEpoch`, this field is pure
 identity carriage — no receiver rejects on it. `RTFlowSessionID == 0` (legacy

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -800,6 +800,20 @@ outside the monitor loop:
   *local* commit counter (`Manager.bumpGeneration`) that is not cross-node
   comparable, so the receiver rejects the stale install BEFORE forwarding it to
   the helper, and no config-epoch field or guard is added on the Rust side.
+- **RT_FLOW session id (#5212)**: distinct from BOTH the synthesized BPF-ABI
+  `SessionID` (`now<<16|slot`, node-local) AND the per-key install generation,
+  every session install carries the ORIGINATING node's stable RT_FLOW session id
+  (`SessionValue{,V6}.RTFlowSessionID`, the dataplane's
+  `SessionTable::alloc_session_id` value) as a length-gated trailing `uint64` on
+  the session wire (`sync_protocol.go`, appended after the #5274 `ConfigEpoch`).
+  Unlike the guards above this is pure identity carriage — the receiver never
+  rejects on it. The peer helper's `upsert_synced_with_origin` ADOPTS the id on
+  import (via `SessionSyncRequest.session_id` → `build_synced_session_entry`)
+  instead of minting a fresh node-local one, so a session's RT_FLOW
+  SESSION_CREATE (origin node) and SESSION_CLOSE (peer, after failover) share one
+  correlatable id across HA nodes. `id == 0` (legacy peer / synthesized delta)
+  falls back to a fresh local id (rolling-upgrade safe). Full path:
+  `docs/sync-protocol.md` "RT_FLOW Session Id (#5212)".
 - Dual-active overlap is intentional: primary sets `rg_active=true`
   immediately on becoming master; secondary defers `rg_active=false` until
   it sees the VRRP BACKUP event. Brief overlap, never both inactive.

--- a/pkg/cluster/sync_config_epoch_5274_test.go
+++ b/pkg/cluster/sync_config_epoch_5274_test.go
@@ -191,10 +191,11 @@ func TestSessionWireRoundTripConfigEpoch5274V4(t *testing.T) {
 			dVal.Generation, dVal.AppTimeout, dVal.PolicyCounterIdx)
 	}
 
-	// Mixed-version: truncate the trailing 8-byte #5274 config epoch (an old
-	// peer stops after PolicyCounterIdx). Decode must still succeed with epoch
-	// 0 and the #3301 fields + Generation preserved.
-	legacy := payload[:len(payload)-8]
+	// Mixed-version: truncate the trailing #5274 config epoch (8 bytes) AND the
+	// #5212 RTFlowSessionID (8 bytes) so the frame ends after PolicyCounterIdx
+	// (an old peer that stops there). Decode must still succeed with epoch 0 and
+	// the #3301 fields + Generation preserved.
+	legacy := payload[:len(payload)-16]
 	_, lVal, ok := decodeSessionV4Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -237,10 +238,11 @@ func TestSessionWireRoundTripConfigEpoch5274V6(t *testing.T) {
 		t.Fatalf("adjacent trailing fields corrupted: gen=%#x idx=%d", dVal.Generation, dVal.PolicyCounterIdx)
 	}
 
-	// Mixed-version: truncate the trailing 8-byte epoch (an old peer stops
-	// after Nat64SnatV4). Decode still succeeds with epoch 0 and NAT64 source
+	// Mixed-version: truncate the trailing epoch (8 bytes) AND the #5212
+	// RTFlowSessionID (8 bytes) so the frame ends after Nat64SnatV4 (an old peer
+	// stops there). Decode still succeeds with epoch 0 and NAT64 source
 	// preserved.
-	legacy := payload[:len(payload)-8]
+	legacy := payload[:len(payload)-16]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) v6 decode failed")

--- a/pkg/cluster/sync_gen_guard_test.go
+++ b/pkg/cluster/sync_gen_guard_test.go
@@ -356,11 +356,11 @@ func TestSessionWireRoundTripPolicyFields3301V4(t *testing.T) {
 		t.Fatalf("Generation round-trip = %#x, want %#x", dVal.Generation, val.Generation)
 	}
 
-	// Mixed-version: truncate the trailing #3301 block (8 bytes) AND the #5274
-	// ConfigEpoch (8 bytes) so the frame ends after Generation (an old peer
-	// that stops there). Decode must still succeed with the new fields at 0 and
-	// Generation preserved.
-	legacy := payload[:len(payload)-16]
+	// Mixed-version: truncate the trailing #3301 block (8 bytes), the #5274
+	// ConfigEpoch (8 bytes) AND the #5212 RTFlowSessionID (8 bytes) so the frame
+	// ends after Generation (an old peer that stops there). Decode must still
+	// succeed with the new fields at 0 and Generation preserved.
+	legacy := payload[:len(payload)-24]
 	_, lVal, ok := decodeSessionV4Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -403,9 +403,10 @@ func TestSessionWireRoundTripPolicyFields3301V6(t *testing.T) {
 	}
 
 	// Drop the #3301 AppTimeout+PolicyCounterIdx (8 bytes), the #4565 trailing
-	// Nat64SnatV4 (4 bytes), AND the #5274 ConfigEpoch (8 bytes) to simulate a
-	// pre-#3301 peer that omits all of the additive trailing fields.
-	legacy := payload[:len(payload)-20]
+	// Nat64SnatV4 (4 bytes), the #5274 ConfigEpoch (8 bytes) AND the #5212
+	// RTFlowSessionID (8 bytes) to simulate a pre-#3301 peer that omits all of
+	// the additive trailing fields.
+	legacy := payload[:len(payload)-28]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -438,9 +439,10 @@ func TestSessionWireRoundTripNat64SnatV4_4565(t *testing.T) {
 	}
 
 	// Legacy (pre-#4565) peer omits the trailing Nat64SnatV4 (4 bytes) — and,
-	// being older, the #5274 ConfigEpoch (8 bytes) too — so truncate both to
-	// reach an after-#3301 frame -> Nat64SnatV4 all-zero (not NAT64).
-	legacy := payload[:len(payload)-12]
+	// being older, the #5274 ConfigEpoch (8 bytes) and the #5212 RTFlowSessionID
+	// (8 bytes) too — so truncate all three to reach an after-#3301 frame ->
+	// Nat64SnatV4 all-zero (not NAT64).
+	legacy := payload[:len(payload)-20]
 	_, lVal, ok := decodeSessionV6Payload(legacy)
 	if !ok {
 		t.Fatal("legacy (truncated) decode failed")
@@ -482,10 +484,11 @@ func TestCrossVersionShortPayloadDecode(t *testing.T) {
 	key := gen2170KeyV4()
 	val := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 1, EgressZone: 2, Generation: 42}
 	full := encodeSessionV4Payload(key, val)
-	// Simulate a pre-#2170 OLD encoder: drop the trailing 24 bytes (the
+	// Simulate a pre-#2170 OLD encoder: drop the trailing 32 bytes (the
 	// #2170 generation u64 + the #3301 AppTimeout/PolicyCounterIdx block + the
-	// #5274 ConfigEpoch u64) so the payload ends at FibGen.
-	short := full[:len(full)-24]
+	// #5274 ConfigEpoch u64 + the #5212 RTFlowSessionID u64) so the payload ends
+	// at FibGen.
+	short := full[:len(full)-32]
 	_, dVal, ok := decodeSessionV4Payload(short)
 	if !ok {
 		t.Fatal("short (legacy) payload should still decode")

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -96,10 +96,10 @@ func encodeSessionV4Payload(key dataplane.SessionKey, val dataplane.SessionValue
 	keySize := 16
 	valSize := 160
 	// +8 for the #2170 install Generation, +8 for the #3301 trailing
-	// AppTimeout(u32)+PolicyCounterIdx(u32), +8 for the #5274 ConfigEpoch. All
-	// length-gated: an old decoder stops after the field it knows and ignores
-	// the rest.
-	buf := make([]byte, keySize+valSize+8+8+8)
+	// AppTimeout(u32)+PolicyCounterIdx(u32), +8 for the #5274 ConfigEpoch, +8 for
+	// the #5212 RTFlowSessionID. All length-gated: an old decoder stops after the
+	// field it knows and ignores the rest.
+	buf := make([]byte, keySize+valSize+8+8+8+8)
 	off := 0
 	copy(buf[off:], key.SrcIP[:])
 	off += 4
@@ -195,6 +195,13 @@ func encodeSessionV4Payload(key dataplane.SessionKey, val dataplane.SessionValue
 	// session). Old decoders stop after PolicyCounterIdx and ignore it; absent
 	// => 0 (legacy peer / check disabled).
 	binary.LittleEndian.PutUint64(buf[off:], val.ConfigEpoch)
+	off += 8
+	// #5212: the originating node's stable RT_FLOW session id (length-gated
+	// trailing field). A peer-synced session ADOPTS this id on import instead of
+	// minting a fresh node-local one, so its RT_FLOW SESSION_CREATE/CLOSE records
+	// correlate across HA nodes. Old decoders stop after ConfigEpoch and ignore
+	// it; absent => 0 (legacy peer / fresh-local-id fallback).
+	binary.LittleEndian.PutUint64(buf[off:], val.RTFlowSessionID)
 	off += 8
 	return buf[:off]
 }
@@ -307,6 +314,11 @@ func encodeSessionV6Payload(key dataplane.SessionKeyV6, val dataplane.SessionVal
 	// encodeSessionV4Payload). Old decoders stop after Nat64SnatV4 and ignore
 	// it; absent => 0 (legacy peer / check disabled).
 	binary.LittleEndian.PutUint64(buf[off:], val.ConfigEpoch)
+	off += 8
+	// #5212: originating node's stable RT_FLOW session id (length-gated trailing
+	// field; see encodeSessionV4Payload). Old decoders stop after ConfigEpoch;
+	// absent => 0 (legacy peer / fresh-local-id fallback on import).
+	binary.LittleEndian.PutUint64(buf[off:], val.RTFlowSessionID)
 	off += 8
 	return buf[:off]
 }
@@ -476,6 +488,12 @@ func decodeSessionV4Payload(payload []byte) (dataplane.SessionKey, dataplane.Ses
 		val.ConfigEpoch = binary.LittleEndian.Uint64(payload[off:])
 		off += 8
 	}
+	// #5212: originating node's stable RT_FLOW session id (length-gated; absent →
+	// 0 = legacy peer, receiver allocs a fresh local id on import).
+	if off+8 <= len(payload) {
+		val.RTFlowSessionID = binary.LittleEndian.Uint64(payload[off:])
+		off += 8
+	}
 	return key, val, true
 }
 
@@ -605,6 +623,12 @@ func decodeSessionV6Payload(payload []byte) (dataplane.SessionKeyV6, dataplane.S
 	// config-epoch check disabled).
 	if off+8 <= len(payload) {
 		val.ConfigEpoch = binary.LittleEndian.Uint64(payload[off:])
+		off += 8
+	}
+	// #5212: originating node's stable RT_FLOW session id (length-gated; absent →
+	// 0 = legacy peer, receiver allocs a fresh local id on import).
+	if off+8 <= len(payload) {
+		val.RTFlowSessionID = binary.LittleEndian.Uint64(payload[off:])
 		off += 8
 	}
 	return key, val, true

--- a/pkg/cluster/sync_rtflow_session_id_5212_test.go
+++ b/pkg/cluster/sync_rtflow_session_id_5212_test.go
@@ -1,0 +1,122 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// rtflowKeyV4 / rtflowKeyV6 mint distinct 5-tuples for the #5212 wire tests.
+func rtflowKeyV4(srcPort uint16) dataplane.SessionKey {
+	return dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 0, 2},
+		DstIP:    [4]byte{172, 16, 80, 201},
+		SrcPort:  srcPort,
+		DstPort:  5201,
+	}
+}
+
+func rtflowKeyV6(srcPort uint16) dataplane.SessionKeyV6 {
+	k := dataplane.SessionKeyV6{Protocol: 6, SrcPort: srcPort, DstPort: 5201}
+	k.SrcIP[15] = 3
+	k.DstIP[15] = 4
+	return k
+}
+
+// TestSessionWireRoundTripRTFlowSessionID5212V4 asserts the originating node's
+// stable RT_FLOW session id round-trips on the cluster session-sync wire as a
+// length-gated trailing field (appended after the #5274 ConfigEpoch), AND a
+// legacy payload truncated before the #5212 block still decodes (id 0, prior
+// fields preserved). Reverting the sync_protocol.go encode/decode drops the
+// value and this fails RED.
+func TestSessionWireRoundTripRTFlowSessionID5212V4(t *testing.T) {
+	key := rtflowKeyV4(41001)
+	val := dataplane.SessionValue{
+		State:            dataplane.SessStateEstablished,
+		IngressZone:      1,
+		EgressZone:       2,
+		PolicyID:         42,
+		Generation:       0xDEADBEEFCAFE,
+		AppTimeout:       30,
+		PolicyCounterIdx: 7,
+		ConfigEpoch:      0x1122334455667788,
+		// The originating node's stable id: worker 7 in the high 16 bits.
+		RTFlowSessionID: (7 << 48) | 0x0000_0000_1234_5678,
+	}
+	payload := encodeSessionV4Payload(key, val)
+	dKey, dVal, ok := decodeSessionV4Payload(payload)
+	if !ok {
+		t.Fatal("decode failed")
+	}
+	if dKey != key {
+		t.Fatalf("key mismatch: %+v vs %+v", dKey, key)
+	}
+	if dVal.RTFlowSessionID != val.RTFlowSessionID {
+		t.Fatalf("RTFlowSessionID round-trip = %#x, want %#x", dVal.RTFlowSessionID, val.RTFlowSessionID)
+	}
+	// The #5274 config epoch (the trailing field before the id) must be intact.
+	if dVal.ConfigEpoch != val.ConfigEpoch || dVal.Generation != val.Generation || dVal.PolicyCounterIdx != 7 {
+		t.Fatalf("adjacent trailing fields corrupted: epoch=%#x gen=%#x idx=%d",
+			dVal.ConfigEpoch, dVal.Generation, dVal.PolicyCounterIdx)
+	}
+
+	// Mixed-version: truncate the trailing 8-byte #5212 id (an old peer stops
+	// after ConfigEpoch). Decode must still succeed with id 0 and the epoch +
+	// prior fields preserved.
+	legacy := payload[:len(payload)-8]
+	_, lVal, ok := decodeSessionV4Payload(legacy)
+	if !ok {
+		t.Fatal("legacy (truncated) decode failed")
+	}
+	if lVal.RTFlowSessionID != 0 {
+		t.Fatalf("legacy frame RTFlowSessionID = %#x, want 0", lVal.RTFlowSessionID)
+	}
+	if lVal.ConfigEpoch != val.ConfigEpoch {
+		t.Fatalf("legacy frame corrupted the ConfigEpoch: got %#x want %#x", lVal.ConfigEpoch, val.ConfigEpoch)
+	}
+}
+
+func TestSessionWireRoundTripRTFlowSessionID5212V6(t *testing.T) {
+	key := rtflowKeyV6(41002)
+	val := dataplane.SessionValueV6{
+		State:            dataplane.SessStateEstablished,
+		IngressZone:      1,
+		EgressZone:       2,
+		PolicyID:         99,
+		Generation:       0x0102030405060708,
+		AppTimeout:       45,
+		PolicyCounterIdx: 11,
+		Nat64SnatV4:      [4]byte{192, 0, 2, 9},
+		ConfigEpoch:      0x99aabbccddeeff00,
+		RTFlowSessionID:  (3 << 48) | 0x0000_0000_0000_002a,
+	}
+	payload := encodeSessionV6Payload(key, val)
+	_, dVal, ok := decodeSessionV6Payload(payload)
+	if !ok {
+		t.Fatal("decode failed")
+	}
+	if dVal.RTFlowSessionID != val.RTFlowSessionID {
+		t.Fatalf("RTFlowSessionID round-trip = %#x, want %#x", dVal.RTFlowSessionID, val.RTFlowSessionID)
+	}
+	// The #5274 epoch and #4565 NAT64 pool source (the fields before the id) must
+	// be intact.
+	if dVal.ConfigEpoch != val.ConfigEpoch || dVal.Nat64SnatV4 != val.Nat64SnatV4 {
+		t.Fatalf("adjacent trailing fields corrupted by appended id: epoch=%#x snat=%v",
+			dVal.ConfigEpoch, dVal.Nat64SnatV4)
+	}
+
+	// Mixed-version: truncate the trailing 8-byte id (an old peer stops after
+	// ConfigEpoch). Decode still succeeds with id 0 and the epoch preserved.
+	legacy := payload[:len(payload)-8]
+	_, lVal, ok := decodeSessionV6Payload(legacy)
+	if !ok {
+		t.Fatal("legacy (truncated) v6 decode failed")
+	}
+	if lVal.RTFlowSessionID != 0 {
+		t.Fatalf("legacy v6 frame RTFlowSessionID = %#x, want 0", lVal.RTFlowSessionID)
+	}
+	if lVal.ConfigEpoch != val.ConfigEpoch {
+		t.Fatalf("legacy v6 frame corrupted the ConfigEpoch: got %#x want %#x", lVal.ConfigEpoch, val.ConfigEpoch)
+	}
+}

--- a/pkg/daemon/daemon_ha_userspace_convert.go
+++ b/pkg/daemon/daemon_ha_userspace_convert.go
@@ -182,14 +182,20 @@ func userspaceSessionFromDeltaV4(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValue{
-		State:       4, // SESS_STATE_ESTABLISHED
-		SessionID:   uint64(now)<<16 | uint64(delta.Slot&0xffff),
-		Created:     now,
-		LastSeen:    now,
-		Timeout:     userspaceSessionTimeout(delta.Protocol),
-		IngressZone: ingressZone,
-		EgressZone:  egressZone,
-		ReverseKey:  userspaceReverseKeyV4(key, delta),
+		State: 4, // SESS_STATE_ESTABLISHED
+		// SessionID is the BPF-ABI conntrack id (node-local now<<16|Slot).
+		SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff),
+		// #5212: the ORIGINATING node's stable RT_FLOW session id (distinct from
+		// SessionID above). Carried across the cluster sync wire so a peer-synced
+		// session adopts it and its SESSION_CREATE/CLOSE records correlate across
+		// nodes. 0 on a legacy helper => a fresh local id is allocated on import.
+		RTFlowSessionID: delta.RTFlowSessionID,
+		Created:         now,
+		LastSeen:        now,
+		Timeout:         userspaceSessionTimeout(delta.Protocol),
+		IngressZone:     ingressZone,
+		EgressZone:      egressZone,
+		ReverseKey:      userspaceReverseKeyV4(key, delta),
 	}
 	if delta.TunnelEndpointID != 0 {
 		val.LogFlags |= dataplane.LogFlagUserspaceTunnelEndpoint
@@ -277,14 +283,19 @@ func userspaceSessionFromDeltaV6(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValueV6{
-		State:       4, // SESS_STATE_ESTABLISHED
-		SessionID:   uint64(now)<<16 | uint64(delta.Slot&0xffff),
-		Created:     now,
-		LastSeen:    now,
-		Timeout:     userspaceSessionTimeout(delta.Protocol),
-		IngressZone: ingressZone,
-		EgressZone:  egressZone,
-		ReverseKey:  userspaceReverseKeyV6(key, delta),
+		State: 4, // SESS_STATE_ESTABLISHED
+		// SessionID is the BPF-ABI conntrack id (node-local now<<16|Slot).
+		SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff),
+		// #5212: the ORIGINATING node's stable RT_FLOW session id (see V4) —
+		// adopted by a peer-synced session so its RT_FLOW records correlate
+		// across HA nodes; 0 on a legacy helper => fresh local id on import.
+		RTFlowSessionID: delta.RTFlowSessionID,
+		Created:         now,
+		LastSeen:        now,
+		Timeout:         userspaceSessionTimeout(delta.Protocol),
+		IngressZone:     ingressZone,
+		EgressZone:      egressZone,
+		ReverseKey:      userspaceReverseKeyV6(key, delta),
 	}
 	if delta.TunnelEndpointID != 0 {
 		val.LogFlags |= dataplane.LogFlagUserspaceTunnelEndpoint

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -175,6 +175,48 @@ func (f *fakeUserspaceSessionExporter) ExportOwnerRGSessions(rgIDs []int, max ui
 	return append([]dpuserspace.SessionDeltaInfo(nil), f.deltas...), dpuserspace.ProcessStatus{}, nil
 }
 
+// TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212 verifies the delta ->
+// SessionValue conversion stamps the originating node's stable RT_FLOW session
+// id (delta.RTFlowSessionID) onto SessionValue{,V6}.RTFlowSessionID (distinct
+// from the BPF-ABI SessionID) so it rides the cluster sync wire and the peer
+// adopts it. Reverting the stamp leaves it 0 and this fails RED.
+func TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+	wantID := uint64(7)<<48 | 0x1234_5678
+
+	deltaV4 := dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: 2, Protocol: 6,
+		SrcIP: "10.0.61.102", DstIP: "172.16.80.200", SrcPort: 12345, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", EgressIfindex: 12,
+		RTFlowSessionID: wantID,
+	}
+	_, valV4, ok := userspaceSessionFromDeltaV4(deltaV4, zoneIDs)
+	if !ok {
+		t.Fatal("expected v4 delta to convert")
+	}
+	if valV4.RTFlowSessionID != wantID {
+		t.Fatalf("v4 RTFlowSessionID = %#x, want %#x", valV4.RTFlowSessionID, wantID)
+	}
+	// The BPF-ABI SessionID stays a distinct node-local now<<16|Slot value.
+	if valV4.SessionID == wantID {
+		t.Fatal("RTFlowSessionID must be distinct from the BPF-ABI SessionID")
+	}
+
+	deltaV6 := dpuserspace.SessionDeltaInfo{
+		Event: "open", AddrFamily: 10, Protocol: 6,
+		SrcIP: "2001:db8::1", DstIP: "2001:db8::2", SrcPort: 12345, DstPort: 5201,
+		IngressZone: "lan", EgressZone: "wan", EgressIfindex: 12,
+		RTFlowSessionID: wantID,
+	}
+	_, valV6, ok := userspaceSessionFromDeltaV6(deltaV6, zoneIDs)
+	if !ok {
+		t.Fatal("expected v6 delta to convert")
+	}
+	if valV6.RTFlowSessionID != wantID {
+		t.Fatalf("v6 RTFlowSessionID = %#x, want %#x", valV6.RTFlowSessionID, wantID)
+	}
+}
+
 func TestUserspaceSessionFromDeltaV4(t *testing.T) {
 	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
 	delta := dpuserspace.SessionDeltaInfo{

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -103,6 +103,27 @@ type SessionValue struct {
 	// which is authoritative in the Go cluster layer — see
 	// SessionSync.installClusterSyncedV4 for the guard.
 	ConfigEpoch uint64
+
+	// RTFlowSessionID is the #5212 ORIGINATING node's stable RT_FLOW session id
+	// (the Rust dataplane's SessionTable.alloc_session_id value: the assigning
+	// worker's id in the high 16 bits + a per-worker monotonic counter). The
+	// dataplane assigns it at install and stamps it on every RT_FLOW
+	// SESSION_CREATE/CLOSE record (#4915); this field carries it across the HA
+	// session-sync wire so a PEER-SYNCED session ADOPTS the originating node's id
+	// instead of minting a fresh node-local one on import. A session that opens
+	// on the primary and closes on the peer after a failover then emits its
+	// SESSION_CREATE and SESSION_CLOSE records under ONE correlatable id across
+	// both nodes. Distinct from the BPF-ABI SessionID above (that is the Go
+	// dataplane's own conntrack id, now<<16|Slot in userspace mode — node-local
+	// by construction). Like Generation/ConfigEpoch this is userspace-sync-only
+	// HA metadata carried as a length-gated trailing field in the encode*Payload
+	// functions; it is NOT part of the BPF/C conntrack ABI and MUST NOT be added
+	// to it. 0 = "no id carried" (a legacy peer that omits the field, or a
+	// synthesized delta with no live entry): the receiver falls back to a fresh
+	// locally-allocated id, bit-identical to the pre-#5212 import
+	// (rolling-upgrade safe). A real id is never 0 (the allocator counter starts
+	// at 1), so the sentinel is unambiguous.
+	RTFlowSessionID uint64
 }
 
 // SessionKeyV6 mirrors the C struct session_key_v6 (5-tuple with 128-bit IPs).
@@ -189,6 +210,27 @@ type SessionValueV6 struct {
 	// (bpfSessionValueV6) and MUST NOT be added to it. 0 = unknown/legacy peer
 	// (check disabled), the rolling-upgrade-safe default.
 	ConfigEpoch uint64
+
+	// RTFlowSessionID is the #5212 ORIGINATING node's stable RT_FLOW session id
+	// (the Rust dataplane's SessionTable.alloc_session_id value: the assigning
+	// worker's id in the high 16 bits + a per-worker monotonic counter). The
+	// dataplane assigns it at install and stamps it on every RT_FLOW
+	// SESSION_CREATE/CLOSE record (#4915); this field carries it across the HA
+	// session-sync wire so a PEER-SYNCED session ADOPTS the originating node's id
+	// instead of minting a fresh node-local one on import. A session that opens
+	// on the primary and closes on the peer after a failover then emits its
+	// SESSION_CREATE and SESSION_CLOSE records under ONE correlatable id across
+	// both nodes. Distinct from the BPF-ABI SessionID above (that is the Go
+	// dataplane's own conntrack id, now<<16|Slot in userspace mode — node-local
+	// by construction). Like Generation/ConfigEpoch this is userspace-sync-only
+	// HA metadata carried as a length-gated trailing field in the encode*Payload
+	// functions; it is NOT part of the BPF/C conntrack ABI and MUST NOT be added
+	// to it. 0 = "no id carried" (a legacy peer that omits the field, or a
+	// synthesized delta with no live entry): the receiver falls back to a fresh
+	// locally-allocated id, bit-identical to the pre-#5212 import
+	// (rolling-upgrade safe). A real id is never 0 (the allocator counter starts
+	// at 1), so the sentinel is unambiguous.
+	RTFlowSessionID uint64
 }
 
 // ZoneConfig mirrors the C struct zone_config.

--- a/pkg/dataplane/userspace/eventstream.go
+++ b/pkg/dataplane/userspace/eventstream.go
@@ -1398,6 +1398,14 @@ func decodeSessionEvent(payload []byte) (SessionDeltaInfo, bool) {
 		}
 		off += 4
 	}
+	// #5212: trailing stable RT_FLOW session id (u64 LE), length-gated. Carried so
+	// a peer-synced session adopts the originating node's id, making its
+	// SESSION_CREATE/CLOSE RT_FLOW records correlatable across HA nodes. An old
+	// helper omits it (=> 0, the standby allocs a fresh local id — pre-#5212).
+	if off+8 <= len(payload) {
+		d.RTFlowSessionID = binary.LittleEndian.Uint64(payload[off : off+8])
+		off += 8
+	}
 
 	return d, true
 }

--- a/pkg/dataplane/userspace/eventstream_test.go
+++ b/pkg/dataplane/userspace/eventstream_test.go
@@ -226,6 +226,43 @@ func TestDecodeSessionEventNat64_4565(t *testing.T) {
 	}
 }
 
+// TestDecodeSessionEventRTFlowSessionID5212 verifies the trailing u64 RT_FLOW
+// session id (the LAST open-frame field, after the #4565 snat_v4) decodes into
+// SessionDeltaInfo.RTFlowSessionID, and a legacy frame that omits it decodes to
+// 0 (the standby then allocs a fresh local id). Reverting the eventstream.go
+// decode drops the id and this fails RED.
+func TestDecodeSessionEventRTFlowSessionID5212(t *testing.T) {
+	// v6 SESSION_OPEN layout (see TestDecodeSessionEventNat64_4565): off reaches
+	// 140 after the #4565 snat_v4; the #5212 session id occupies [140:148].
+	payload := make([]byte, 148)
+	payload[0] = 6 // AddrFamily = v6
+	payload[1] = 6 // Protocol = TCP
+	// Originating node's stable id: worker 7 high bits + counter 0x2a.
+	wantID := uint64(7)<<48 | 0x2a
+	binary.LittleEndian.PutUint64(payload[140:148], wantID)
+
+	d, ok := decodeSessionEvent(payload)
+	if !ok {
+		t.Fatal("decodeSessionEvent returned false")
+	}
+	if d.RTFlowSessionID != wantID {
+		t.Fatalf("d.RTFlowSessionID = %#x, want %#x", d.RTFlowSessionID, wantID)
+	}
+
+	// A legacy frame that omits the trailing id (stops after snat_v4) decodes to
+	// 0 — the standby falls back to a fresh local id (rolling-upgrade safe).
+	legacy := make([]byte, 140)
+	legacy[0] = 6
+	legacy[1] = 6
+	dl, ok := decodeSessionEvent(legacy)
+	if !ok {
+		t.Fatal("decodeSessionEvent returned false for legacy frame")
+	}
+	if dl.RTFlowSessionID != 0 {
+		t.Fatalf("legacy frame RTFlowSessionID = %#x, want 0", dl.RTFlowSessionID)
+	}
+}
+
 func TestDecodeSessionEventV4(t *testing.T) {
 	payload := buildSessionOpenV4Payload(
 		6,          // TCP

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1616,6 +1616,9 @@ func (m *Manager) buildSessionSyncRequestV4(op string, key dataplane.SessionKey,
 		req.PolicyID = val.PolicyID
 		req.PolicyCounterIdx = val.PolicyCounterIdx
 		req.InactivityTimeout = val.AppTimeout
+		// #5212: carry the originating node's stable RT_FLOW session id so the
+		// peer helper adopts it on import instead of minting a fresh local id.
+		req.RTFlowSessionID = val.RTFlowSessionID
 		if val.Flags&dataplane.SessFlagSNAT == 0 {
 			req.NATSrcIP = ""
 			req.NATSrcPort = 0
@@ -1699,6 +1702,8 @@ func (m *Manager) buildSessionSyncRequestV6(op string, key dataplane.SessionKeyV
 		if val.Nat64SnatV4 != ([4]byte{}) {
 			req.Nat64SnatV4 = net.IP(val.Nat64SnatV4[:]).String()
 		}
+		// #5212: carry the originating node's stable RT_FLOW session id (see V4).
+		req.RTFlowSessionID = val.RTFlowSessionID
 		if val.Flags&dataplane.SessFlagSNAT == 0 {
 			req.NATSrcIP = ""
 			req.NATSrcPort = 0

--- a/pkg/dataplane/userspace/manager_sessionsync_test.go
+++ b/pkg/dataplane/userspace/manager_sessionsync_test.go
@@ -281,6 +281,42 @@ func TestBuildSessionSyncRequestV6CarriesNat64SnatV4_4565(t *testing.T) {
 	}
 }
 
+// TestBuildSessionSyncRequestCarriesRTFlowSessionID5212 verifies the manager
+// forwards the originating node's stable RT_FLOW session id (SessionValue{,V6}.
+// RTFlowSessionID) onto the SessionSyncRequest (JSON session_id) for both
+// families so the peer helper adopts it on import. Reverting the copy leaves the
+// field 0 (omitted) and this fails RED.
+func TestBuildSessionSyncRequestCarriesRTFlowSessionID5212(t *testing.T) {
+	m := &Manager{bpfShim: dataplane.New()}
+	wantID := uint64(7)<<48 | 0x1234_5678
+
+	key := dataplane.SessionKey{Protocol: 6}
+	val := &dataplane.SessionValue{IngressZone: 1, EgressZone: 2, RTFlowSessionID: wantID}
+	req := m.buildSessionSyncRequestV4("upsert", key, val)
+	if req.RTFlowSessionID != wantID {
+		t.Fatalf("v4 req.RTFlowSessionID = %#x, want %#x", req.RTFlowSessionID, wantID)
+	}
+	if js, _ := json.Marshal(req); !strings.Contains(string(js), `"session_id":`) {
+		t.Fatalf("v4 wire JSON missing session_id: %s", js)
+	}
+
+	keyV6 := dataplane.SessionKeyV6{Protocol: 6}
+	valV6 := &dataplane.SessionValueV6{IngressZone: 1, EgressZone: 2, RTFlowSessionID: wantID}
+	reqV6 := m.buildSessionSyncRequestV6("upsert", keyV6, valV6)
+	if reqV6.RTFlowSessionID != wantID {
+		t.Fatalf("v6 req.RTFlowSessionID = %#x, want %#x", reqV6.RTFlowSessionID, wantID)
+	}
+
+	// A session with no id (0) omits the key from the wire (rolling-upgrade safe).
+	reqPlain := m.buildSessionSyncRequestV4("upsert", key, &dataplane.SessionValue{IngressZone: 1, EgressZone: 2})
+	if reqPlain.RTFlowSessionID != 0 {
+		t.Fatalf("plain req.RTFlowSessionID = %#x, want 0", reqPlain.RTFlowSessionID)
+	}
+	if js, _ := json.Marshal(reqPlain); strings.Contains(string(js), "session_id") {
+		t.Fatalf("zero-id wire JSON must omit session_id: %s", js)
+	}
+}
+
 func TestBuildSessionSyncRequestV4PreservesBothNatLegs(t *testing.T) {
 	m := &Manager{bpfShim: dataplane.New()}
 	key := dataplane.SessionKey{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -2998,6 +2998,16 @@ type SessionSyncRequest struct {
 	// decodes it via serde(default) to "" (not NAT64), bit-identical to
 	// pre-#4565 (rolling-upgrade safe).
 	Nat64SnatV4 string `json:"nat64_snat_v4,omitempty"`
+	// #5212: the ORIGINATING node's stable RT_FLOW session id (the dataplane's
+	// alloc_session_id value). Carried so a peer-PROMOTED session ADOPTS the
+	// originating node's id rather than minting a fresh node-local one on import
+	// — its RT_FLOW SESSION_CREATE (origin node) and SESSION_CLOSE (possibly the
+	// peer, after failover) then share one correlatable id. The helper stamps it
+	// onto the imported entry (build_synced_session_entry). omitempty is safe —
+	// an old helper without the key decodes it via serde(default) to 0, the "no
+	// id carried" sentinel that falls back to a fresh local id (rolling-upgrade
+	// safe). The Rust side declares `#[serde(rename = "session_id", default)]`.
+	RTFlowSessionID uint64 `json:"session_id,omitempty"`
 }
 
 type SessionDeltaInfo struct {
@@ -3065,6 +3075,14 @@ type SessionDeltaInfo struct {
 	// forward v6 key (the orig v6 src/dst ARE the key; dst_v4 is the /96 low 32).
 	Nat64       bool   `json:"nat64,omitempty"`
 	Nat64SnatV4 string `json:"nat64_snat_v4,omitempty"`
+	// #5212: the ORIGINATING node's stable RT_FLOW session id, decoded from the
+	// trailing u64 of the binary open frame (after the #4565 snat_v4). Stamped
+	// onto the synced SessionValue{,V6}.RTFlowSessionID by daemon_ha_userspace.go
+	// so the cluster sync wire and the peer helper carry it, letting a
+	// peer-synced session adopt the originating node's id (SESSION_CREATE/CLOSE
+	// correlate across HA nodes). Absent on an old helper => 0, the standby
+	// allocs a fresh local id (pre-#5212 behavior, rolling-upgrade safe).
+	RTFlowSessionID uint64 `json:"rt_flow_session_id,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1931,6 +1931,12 @@ pub(super) fn install_helper_local_session_on_miss(
         tcp_flags,
         // Local forwarding-learn entry: no peer install generation (#2170).
         generation: 0,
+        // #5212: a local-origin shared-map publish. The stable id is carried on
+        // the wire straight off the live entry by the incremental Open delta
+        // (`install_with_protocol_with_origin`) / the owner-RG cold-sync export
+        // (`emit_open_delta_with_origin`), not via this shared replica — so 0
+        // here (a cross-worker materialize of this entry re-allocs a local id).
+        session_id: 0,
     };
     // #1789: count a failed helper-local session publish (same
     // shim-missing-key consequence as every other publish site).

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2320,6 +2320,7 @@ fn helper_local_session_on_miss_clears_stale_shared_aliases() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
 
     // Install with SyncImport origin so take_synced_local recognizes

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -894,6 +894,7 @@ impl super::Coordinator {
             protocol: PROTO_TCP,
             tcp_flags: 0,
             generation: 0,
+            session_id: 0,
         });
     }
 }

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -267,6 +267,7 @@ fn update_ha_state_prewarms_split_rg_reverse_sessions_on_activation() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &coordinator.sessions.synced,
@@ -375,6 +376,7 @@ fn update_ha_state_demotion_recovers_from_poisoned_worker_command_mutex() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &coordinator.sessions.synced,
@@ -493,6 +495,7 @@ fn prewarm_recovers_from_poisoned_shared_session_mutex() {
         protocol: PROTO_TCP,
         tcp_flags: 0x10,
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &coordinator.sessions.synced,
@@ -652,6 +655,7 @@ fn synced_entry_with_generation(generation: u64) -> SyncedSessionEntry {
         protocol: PROTO_TCP,
         tcp_flags: 0,
         generation,
+        session_id: 0,
     }
 }
 
@@ -734,6 +738,7 @@ fn synced_entry_port(port: u16, generation: u64) -> SyncedSessionEntry {
         protocol: PROTO_TCP,
         tcp_flags: 0x10,
         generation,
+        session_id: 0,
     }
 }
 
@@ -937,6 +942,7 @@ fn synced_snat_entry() -> SyncedSessionEntry {
         protocol: PROTO_TCP,
         tcp_flags: 0,
         generation: 0,
+        session_id: 0,
     }
 }
 
@@ -1098,6 +1104,7 @@ fn coordinator_with_tunnel_session(tunnel_endpoint_id: u16) -> (Coordinator, Ses
         protocol: PROTO_TCP,
         tcp_flags: 0x10,
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &coordinator.sessions.synced,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -3506,6 +3506,10 @@ pub(super) fn poll_binding_process_descriptor(
                                             tcp_flags: meta.tcp_flags,
                                             // Local forward-flow learn (#2170): no peer gen.
                                             generation: 0,
+                                            // #5212: local-origin shared publish; the id
+                                            // rides the wire off the live entry via the
+                                            // Open delta, not this replica (0 here).
+                                            session_id: 0,
                                         };
                                         // #1789: count failed publishes so
                                         // map-at-capacity / stale-fd
@@ -3839,6 +3843,10 @@ pub(super) fn poll_binding_process_descriptor(
                                             tcp_flags: meta.tcp_flags,
                                             // Local reverse-flow learn (#2170): no peer gen.
                                             generation: 0,
+                                            // #5212: a reverse companion never emits
+                                            // RT_FLOW (is_reverse skip) and gets its own
+                                            // fresh id at install — no carried id.
+                                            session_id: 0,
                                         };
                                         publish_shared_session(
                                             worker_ctx.shared_sessions,
@@ -5749,6 +5757,8 @@ pub(super) fn poll_binding_process_descriptor(
                                         tcp_flags: meta.tcp_flags,
                                         // Local missing-neighbor seed (#2170): no peer gen.
                                         generation: 0,
+                                        // #5212: local-origin seed; no carried id (0).
+                                        session_id: 0,
                                     };
                                     publish_shared_session(
                                         worker_ctx.shared_sessions,

--- a/userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs
+++ b/userspace-dp/src/afxdp/session_glue/commands/upsert_synced.rs
@@ -71,6 +71,9 @@ pub(in crate::afxdp::session_glue) fn handle_upsert_synced(
             now_ns,
             protocol: entry.protocol,
             tcp_flags: entry.tcp_flags,
+            // #5212: carry the peer's stable RT_FLOW id from the synced entry so
+            // the standby ADOPTS it (non-zero on a wire import; 0 => local alloc).
+            session_id: entry.session_id,
         },
         allow_replace_local,
     ) {

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -792,6 +792,9 @@ pub(super) fn apply_worker_commands(
                         now_ns,
                         protocol: entry.protocol,
                         tcp_flags: entry.tcp_flags,
+                        // #5212: preserve the entry's id (a local-tunnel replica
+                        // carries 0 => fresh local alloc, the pre-#5212 behavior).
+                        session_id: entry.session_id,
                     },
                     /* allow_replace_local = */ true,
                 );
@@ -1103,6 +1106,10 @@ fn materialize_shared_session_hit(
                 now_ns,
                 protocol: replica.protocol,
                 tcp_flags,
+                // #5212: a reactive materialize of a shared-map hit inherits the
+                // shared entry's id — the peer's id for a synced session (so the
+                // eventual close correlates), 0 for a local entry (fresh alloc).
+                session_id: replica.session_id,
             },
             false,
         );

--- a/userspace-dp/src/afxdp/session_glue/promote.rs
+++ b/userspace-dp/src/afxdp/session_glue/promote.rs
@@ -122,6 +122,11 @@ pub(in crate::afxdp::session_glue) fn maybe_promote_synced_session(
             tcp_flags,
             // Local shared-promote: no peer install generation (#2170).
             generation: 0,
+            // #5212: promote re-publishes an entry already live in the table;
+            // its stable id is preserved on the entry itself (the promote Open
+            // delta reads it via `entry_by_key`), so this shared replica needs
+            // no id (0 = "alloc a fresh local id" on any re-import).
+            session_id: 0,
         };
         publish_shared_session(
             shared.sessions,

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -481,6 +481,7 @@ fn resolve_flow_session_decision_promotes_stale_fabric_shared_hit_to_local_owner
         tcp_flags: 0x18,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &shared_sessions,
@@ -558,6 +559,7 @@ fn lookup_session_across_scopes_returns_shared_entry() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
     let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -633,6 +635,7 @@ fn lookup_session_across_scopes_returns_shared_forward_wire_entry() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let translated_key = forward_wire_key(&key, decision.nat);
     let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -731,6 +734,7 @@ fn lookup_session_across_scopes_prefers_shared_entry_over_fabric_wire_placeholde
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
     let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -785,6 +789,7 @@ fn lookup_forward_nat_across_scopes_returns_shared_nat_entry() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let reply_key = reverse_session_key(&key, decision.nat);
     let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -834,6 +839,7 @@ fn lookup_forward_nat_across_scopes_prefers_shared_entry_over_fabric_wire_placeh
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let reply_key = reverse_session_key(&key, decision.nat);
     let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -903,6 +909,7 @@ fn lookup_forward_nat_across_scopes_returns_shared_canonical_reverse_entry() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let canonical_reply = reverse_canonical_key(&key, decision.nat);
     let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -942,6 +949,7 @@ fn publish_and_remove_shared_session_tracks_forward_wire_alias() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let translated_key = forward_wire_key(&key, decision.nat);
 
@@ -993,6 +1001,7 @@ fn publish_and_remove_shared_session_tracks_canonical_reverse_alias() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let canonical_reply = reverse_canonical_key(&key, decision.nat);
 
@@ -1041,6 +1050,7 @@ fn publish_and_remove_shared_session_tracks_owner_rg_indexes() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let forward_wire = forward_wire_key(&key, decision.nat);
     let reverse_wire = reverse_session_key(&key, decision.nat);
@@ -1133,6 +1143,7 @@ fn publish_shared_session_reindexes_owner_rg_on_replace() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
 
     publish_shared_session(
@@ -1185,6 +1196,7 @@ fn publish_shared_session_heals_missing_owner_rg_index_on_same_owner_update() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
 
     publish_shared_session(
@@ -1241,6 +1253,7 @@ fn resolve_flow_session_decision_uses_canonical_key_for_translated_forward_hit()
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
     let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
@@ -1317,6 +1330,7 @@ fn resolve_flow_session_decision_promotes_translated_shared_hit_on_active_fabric
         tcp_flags: 0x18,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let mut forwarding = test_forwarding_state_with_fabric();
     forwarding.connected_v4.push(ConnectedRouteV4 {
@@ -1502,6 +1516,7 @@ fn resolve_flow_session_decision_keeps_translated_shared_hit_transient_on_inacti
         tcp_flags: 0x18,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let mut forwarding = test_forwarding_state_with_fabric();
     forwarding.connected_v4.push(ConnectedRouteV4 {
@@ -1586,6 +1601,7 @@ fn resolve_flow_session_decision_keeps_translated_shared_hit_transient_on_inacti
         tcp_flags: 0x18,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let mut forwarding = test_forwarding_state_with_fabric();
     forwarding.connected_v4.push(ConnectedRouteV4 {
@@ -1757,6 +1773,7 @@ fn apply_worker_commands_replaces_stale_local_session_for_inactive_owner_rg() {
             tcp_flags: 0x10,
             // #2170 test fixture: no peer install generation.
             generation: 0,
+            session_id: 0,
         }));
     let mut ha_state = BTreeMap::new();
     ha_state.insert(1, inactive_ha_runtime(0));
@@ -1822,6 +1839,7 @@ fn apply_worker_commands_preserves_local_session_for_active_owner_rg() {
             tcp_flags: 0x10,
             // #2170 test fixture: no peer install generation.
             generation: 0,
+            session_id: 0,
         }));
     let mut ha_state = BTreeMap::new();
     ha_state.insert(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000));
@@ -2454,6 +2472,7 @@ fn demote_shared_owner_rgs_preserves_reverse_entries_and_marks_all_synced() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let reverse = SyncedSessionEntry {
         key: reverse_session_key(&forward.key, forward.decision.nat),
@@ -2467,6 +2486,7 @@ fn demote_shared_owner_rgs_preserves_reverse_entries_and_marks_all_synced() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &shared_sessions,
@@ -2534,6 +2554,7 @@ fn demoted_shared_local_forward_session_enters_reverse_prewarm_index() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     entry.metadata.owner_rg_id = 1;
 
@@ -2586,6 +2607,7 @@ fn prewarm_reverse_synced_sessions_after_demotion_recomputes_split_owner_reverse
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     entry.metadata.owner_rg_id = 1;
 
@@ -3268,6 +3290,7 @@ fn synthesized_synced_reverse_entry_preserves_fabric_ingress_and_reverse_flag() 
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
 
     let reverse = synthesized_synced_reverse_entry(
@@ -3338,6 +3361,7 @@ fn synthesized_synced_reverse_entry_inherits_nat64_reverse_4565() {
         protocol: PROTO_TCP,
         tcp_flags: 0x10,
         generation: 0,
+        session_id: 0,
     };
 
     let reverse = synthesized_synced_reverse_entry(
@@ -3398,6 +3422,7 @@ fn reverse_companion_inherits_forward_inactivity_timeout_5153() {
         protocol: PROTO_TCP,
         tcp_flags: 0x10,
         generation: 0,
+        session_id: 0,
     };
 
     let reverse =
@@ -3481,6 +3506,7 @@ fn synthesized_synced_reverse_entry_tracks_local_client_when_owner_rg_active() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let mut ha_state = BTreeMap::new();
     ha_state.insert(1, active_ha_runtime(1));
@@ -3513,6 +3539,7 @@ fn synthesized_synced_reverse_entry_uses_fabric_redirect_when_client_rg_inactive
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let mut ha_state = BTreeMap::new();
     ha_state.insert(1, active_ha_runtime(1));
@@ -3741,6 +3768,7 @@ fn prewarm_reverse_synced_sessions_for_owner_rgs_adds_reverse_companion() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &shared_sessions,
@@ -3810,6 +3838,7 @@ fn prewarm_reverse_synced_sessions_for_owner_rgs_restores_shared_promote_forward
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &shared_sessions,
@@ -3887,6 +3916,7 @@ fn prewarm_reverse_synced_sessions_recomputes_when_reverse_owner_rg_activates() 
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     entry.metadata.owner_rg_id = 1;
     publish_shared_session(
@@ -3951,6 +3981,7 @@ fn reverse_prewarm_index_tracks_split_reverse_owner_rg_candidate() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     entry.metadata.owner_rg_id = 1;
 
@@ -4055,6 +4086,7 @@ fn republish_bpf_session_entries_covers_all_sessions_in_owner_rg_index() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     // Publish to shared table + sessions index (but NOT reverse_prewarm).
     publish_shared_session(
@@ -4155,6 +4187,7 @@ fn synced_session_hit_recomputes_local_resolution_after_failover() {
             tcp_flags: 0x10,
             // #2170 test fixture: no peer install generation.
             generation: 0,
+            session_id: 0,
         },
     );
     let peer_worker_commands = Vec::new();
@@ -4285,6 +4318,7 @@ fn apply_worker_commands_dispatch_order_pin_with_demote_dedup() {
         tcp_flags: 0x10,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
 
     // Build a minimal TxRequest for the EnqueueShapedLocal step.
@@ -4548,6 +4582,7 @@ fn test_synced_entry() -> SyncedSessionEntry {
         tcp_flags: TCP_FLAG_ACK,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     }
 }
 
@@ -4676,6 +4711,7 @@ fn w3_forward_entry(src_host: u8, src_port: u16, snat_ip: Ipv4Addr) -> SyncedSes
         tcp_flags: 0x02,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     }
 }
 
@@ -4855,6 +4891,7 @@ fn shared_nat_displacement_counter_counts_collisions_not_republishes() {
         tcp_flags: 0x02,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let mut direct = dnat.clone();
     direct.key.dst_ip = backend;
@@ -4993,6 +5030,7 @@ fn local_tunnel_pair() -> (SyncedSessionEntry, SyncedSessionEntry) {
         tcp_flags: TCP_FLAG_ACK,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let reverse = synthesized_synced_reverse_entry(
         &forwarding,
@@ -5248,6 +5286,7 @@ fn flush_session_deltas_without_binding_reaches_global_consumers() {
         protocol: PROTO_TCP,
         tcp_flags: 0x10,
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &shared_sessions,

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -781,6 +781,7 @@ pub(super) fn synthesized_synced_reverse_entry(
         // #2170: the reverse companion inherits the forward entry's install
         // generation so a delete refusal is consistent across both halves.
         generation: entry.generation,
+        session_id: 0,
     })
 }
 
@@ -879,6 +880,7 @@ pub(super) fn install_reverse_session_from_forward_match(
             tcp_flags,
             // Local reverse-flow learning: no peer install generation (#2170).
             generation: 0,
+            session_id: 0,
         };
         publish_shared_session(
             shared_sessions,

--- a/userspace-dp/src/afxdp/tests_bind_forward.rs
+++ b/userspace-dp/src/afxdp/tests_bind_forward.rs
@@ -1174,6 +1174,7 @@ fn synced_replica_entry_keeps_peer_synced_entries_promotable() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let replica = synced_replica_entry(&entry);
     assert!(replica.origin.is_peer_synced());
@@ -1223,6 +1224,7 @@ fn synced_replica_entry_marks_local_entries_worker_local() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let replica = synced_replica_entry(&entry);
     assert_eq!(replica.origin, SessionOrigin::WorkerLocalImport);
@@ -1274,6 +1276,7 @@ fn reconcile_stop_preserves_shared_synced_sessions() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &coordinator.sessions.synced,
@@ -1336,6 +1339,7 @@ fn replay_synced_sessions_requeues_preserved_entries_for_new_workers() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let worker_command_queues = BTreeMap::from([
         (0u32, Arc::new(Mutex::new(VecDeque::new()))),

--- a/userspace-dp/src/afxdp/tests_decap_dnat_table.rs
+++ b/userspace-dp/src/afxdp/tests_decap_dnat_table.rs
@@ -213,6 +213,7 @@ fn replay_filter_drops_purged_forward_and_derived_reverse_companion() {
             tcp_flags: 0,
             // #2170 test fixture: no peer install generation.
             generation: 0,
+            session_id: 0,
         };
     let unrelated_key = SessionKey {
         src_port: 23456,

--- a/userspace-dp/src/afxdp/tests_embedded_poll_filter.rs
+++ b/userspace-dp/src/afxdp/tests_embedded_poll_filter.rs
@@ -134,6 +134,7 @@ fn embedded_icmp_nat_match_uses_shared_nat_session_for_ipv4() {
         tcp_flags: 0,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
     let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
@@ -1841,6 +1842,7 @@ fn poll_descriptor_lo0_filter_drops_cached_local_delivery_session_hit() {
         tcp_flags: TCP_FLAG_SYN,
         // #2170 test fixture: no peer install generation.
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &shared_sessions,

--- a/userspace-dp/src/afxdp/tests_gre_local_delivery.rs
+++ b/userspace-dp/src/afxdp/tests_gre_local_delivery.rs
@@ -782,6 +782,7 @@ fn poll_descriptor_junos_host_deny_drops_local_delivery_session_hit() {
         protocol: PROTO_TCP,
         tcp_flags: TCP_FLAG_SYN,
         generation: 0,
+        session_id: 0,
     };
     publish_shared_session(
         &shared_sessions,

--- a/userspace-dp/src/afxdp/tunnel.rs
+++ b/userspace-dp/src/afxdp/tunnel.rs
@@ -611,6 +611,7 @@ pub(super) fn build_local_origin_tunnel_tx_request(
         },
         // Locally decapsulated tunnel session: no peer install generation (#2170).
         generation: 0,
+        session_id: 0,
     };
     let reverse_session_entry = synthesized_synced_reverse_entry(
         forwarding,

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -376,6 +376,18 @@ pub(crate) struct SyncedSessionEntry {
     /// when BOTH the stored and incoming generations are non-zero, so
     /// local-origin entries fall back to today's unconditional behavior.
     pub(crate) generation: u64,
+    /// #5212: the originating node's STABLE RT_FLOW session id (`alloc_session_id`
+    /// namespace) carried across the HA session-sync wire. Populated (non-zero)
+    /// only on a peer-synced FORWARD import off the wire (`build_synced_session_entry`),
+    /// where it is threaded onto the imported entry so the standby ADOPTS the
+    /// peer's id instead of minting a fresh local one — the standby's
+    /// SESSION_CLOSE RT_FLOW then correlates with the primary's SESSION_CREATE
+    /// across HA nodes. Local-origin publishes (forwarding learn, tunnel,
+    /// promote) and synthesized reverse companions leave this 0: the incremental
+    /// Open delta carries the real id straight off the live entry
+    /// (`install_with_protocol_with_origin`), and a 0 here on any import path
+    /// falls back to `alloc_session_id()` (rolling-upgrade safe).
+    pub(crate) session_id: u64,
 }
 
 impl BindingWorker {

--- a/userspace-dp/src/event_stream/codec/codec_tests.rs
+++ b/userspace-dp/src/event_stream/codec/codec_tests.rs
@@ -647,6 +647,7 @@ fn test_encode_session_open_v4() {
         &test_metadata(),
         &zones,
         false,
+        0,
     );
 
     // Check header
@@ -689,7 +690,7 @@ fn test_encode_session_open_zone_id_above_255() {
     md.ingress_zone = 300;
     md.egress_zone = 1000;
     let frame =
-        EventFrame::encode_session_open(1, &test_key_v4(), &test_decision(), &md, &zones, false);
+        EventFrame::encode_session_open(1, &test_key_v4(), &test_decision(), &md, &zones, false, 0);
     let p = &frame.data[FRAME_HEADER_SIZE..];
     assert_eq!(u16::from_le_bytes([p[27], p[28]]), 300); // IngressZoneID u16
     assert_eq!(u16::from_le_bytes([p[29], p[30]]), 1000); // EgressZoneID u16
@@ -717,7 +718,7 @@ fn test_encode_session_open_carries_log_flags() {
     md.log_session_init = true;
     md.log_session_close = true;
     let frame =
-        EventFrame::encode_session_open(1, &test_key_v4(), &test_decision(), &md, &zones, false);
+        EventFrame::encode_session_open(1, &test_key_v4(), &test_decision(), &md, &zones, false, 0);
     let p = &frame.data[FRAME_HEADER_SIZE..];
     assert_eq!(
         p[26] & FLAG_LOG_SESSION_INIT,
@@ -740,6 +741,7 @@ fn test_encode_session_open_carries_log_flags() {
         &md_close,
         &zones,
         false,
+        0,
     );
     let pc = &frame_close.data[FRAME_HEADER_SIZE..];
     assert_eq!(pc[26] & FLAG_LOG_SESSION_INIT, 0);
@@ -753,6 +755,7 @@ fn test_encode_session_open_carries_log_flags() {
         &test_metadata(),
         &zones,
         false,
+        0,
     );
     let pn = &frame_none.data[FRAME_HEADER_SIZE..];
     assert_eq!(pn[26] & (FLAG_LOG_SESSION_INIT | FLAG_LOG_SESSION_CLOSE), 0);
@@ -781,28 +784,87 @@ fn test_encode_session_open_carries_nat64_flag_and_snat_v4() {
         src_port: 5001,
         dst_port: 80,
     };
-    let frame = EventFrame::encode_session_open(1, &key, &decision, &md, &zones, false);
+    let frame = EventFrame::encode_session_open(1, &key, &decision, &md, &zones, false, 0);
     let payload = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
     assert_eq!(
         payload[26] & FLAG_NAT64,
         FLAG_NAT64,
         "nat64 decision must set flags bit 1<<5"
     );
-    // Trailing 4 bytes are the pool source (appended last).
+    // snat_v4 sits at [n-12 .. n-8]: #5212 appended an 8-byte session_id after
+    // the 4-byte snat_v4, so snat_v4 is no longer the last field.
     let n = payload.len();
     assert_eq!(
-        &payload[n - 4..n],
+        &payload[n - 12..n - 8],
         &[203, 0, 113, 5],
-        "trailing snat_v4 must be the translated pool source"
+        "snat_v4 must be the translated pool source (before the trailing id)"
     );
 
-    // A non-NAT64 v4 session: flag clear, trailing snat_v4 all-zero.
+    // A non-NAT64 v4 session: flag clear, snat_v4 all-zero.
     let frame_plain =
-        EventFrame::encode_session_open(2, &test_key_v4(), &test_decision(), &md, &zones, false);
+        EventFrame::encode_session_open(2, &test_key_v4(), &test_decision(), &md, &zones, false, 0);
     let pp = &frame_plain.data[FRAME_HEADER_SIZE..frame_plain.len as usize];
     assert_eq!(pp[26] & FLAG_NAT64, 0, "non-nat64 must leave the flag clear");
     let m = pp.len();
-    assert_eq!(&pp[m - 4..m], &[0, 0, 0, 0], "non-nat64 trailing snat is zero");
+    assert_eq!(&pp[m - 12..m - 8], &[0, 0, 0, 0], "non-nat64 snat is zero");
+}
+
+// #5212 RED-on-revert: the originating node's stable RT_FLOW session id rides the
+// open frame as the LAST trailing field (u64 LE, appended after the #4565
+// snat_v4) so a peer-synced session ADOPTS it and its RT_FLOW SESSION_CREATE /
+// SESSION_CLOSE records correlate across HA nodes. Reverting the encode (or
+// dropping the `session_id` argument threading) leaves the id off the wire and
+// this fails RED.
+#[test]
+fn test_encode_session_open_carries_session_id_5212() {
+    let zones = test_zone_map();
+    let md = test_metadata();
+
+    // A peer-namespaced id (worker 7 high bits) on a plain v4 session.
+    let session_id: u64 = (7u64 << 48) | 0x1234_5678;
+    let frame = EventFrame::encode_session_open(
+        1,
+        &test_key_v4(),
+        &test_decision(),
+        &md,
+        &zones,
+        false,
+        session_id,
+    );
+    let payload = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
+    let n = payload.len();
+    // The LAST 8 bytes are the session id (LE); the 4 bytes before it are the
+    // #4565 snat_v4 (all-zero for this non-NAT64 v4 session), which must be
+    // undisturbed by the appended id.
+    assert_eq!(
+        u64::from_le_bytes(payload[n - 8..n].try_into().unwrap()),
+        session_id,
+        "the trailing u64 must carry the stable session id"
+    );
+    assert_eq!(
+        &payload[n - 12..n - 8],
+        &[0, 0, 0, 0],
+        "the snat_v4 field must still precede the session id, unchanged"
+    );
+
+    // A zero id (a synthesized/no-entry emit) writes zero — the Go decoder then
+    // length-reads 0 and the standby allocs a fresh local id.
+    let frame0 = EventFrame::encode_session_open(
+        2,
+        &test_key_v4(),
+        &test_decision(),
+        &md,
+        &zones,
+        false,
+        0,
+    );
+    let p0 = &frame0.data[FRAME_HEADER_SIZE..frame0.len as usize];
+    let n0 = p0.len();
+    assert_eq!(
+        u64::from_le_bytes(p0[n0 - 8..n0].try_into().unwrap()),
+        0,
+        "a zero session id writes zero on the wire"
+    );
 }
 
 // #3301: the admitting policy's firewall metadata (policy_id,
@@ -818,15 +880,16 @@ fn test_encode_session_open_carries_policy_fields_3301() {
     md.policy_counter_idx = 7;
     md.inactivity_timeout_ns = Some(30 * 1_000_000_000);
     let frame =
-        EventFrame::encode_session_open(1, &test_key_v4(), &test_decision(), &md, &zones, false);
+        EventFrame::encode_session_open(1, &test_key_v4(), &test_decision(), &md, &zones, false, 0);
     let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
     // #3301 trailing block: policy_id, policy_counter_idx, inactivity_timeout
-    // (seconds), each u32 LE. #4565 appended a further 4-byte snat_v4 AFTER this
-    // block, so the policy fields are now at [n-16 .. n-4] (snat_v4 = last 4).
+    // (seconds), each u32 LE. #4565 appended a 4-byte snat_v4 AFTER this block
+    // and #5212 appended a further 8-byte session_id AFTER that, so the policy
+    // fields are now at [n-24 .. n-12] (snat_v4 = [n-12 .. n-8], id = last 8).
     let n = p.len();
-    let policy_id = u32::from_le_bytes(p[n - 16..n - 12].try_into().unwrap());
-    let counter_idx = u32::from_le_bytes(p[n - 12..n - 8].try_into().unwrap());
-    let inact_secs = u32::from_le_bytes(p[n - 8..n - 4].try_into().unwrap());
+    let policy_id = u32::from_le_bytes(p[n - 24..n - 20].try_into().unwrap());
+    let counter_idx = u32::from_le_bytes(p[n - 20..n - 16].try_into().unwrap());
+    let inact_secs = u32::from_le_bytes(p[n - 16..n - 12].try_into().unwrap());
     assert_eq!(policy_id, 42, "policy_id must ride the open frame");
     assert_eq!(counter_idx, 7, "policy_counter_idx must ride the open frame");
     assert_eq!(inact_secs, 30, "inactivity_timeout (ns->s) must ride the open frame");
@@ -839,12 +902,14 @@ fn test_encode_session_open_carries_policy_fields_3301() {
         &test_metadata(),
         &zones,
         false,
+        0,
     );
     let pn = &frame_none.data[FRAME_HEADER_SIZE..frame_none.len as usize];
     let m = pn.len();
+    // Shifted by the #4565 snat_v4 (4) + #5212 session_id (8) trailing fields.
+    assert_eq!(u32::from_le_bytes(pn[m - 24..m - 20].try_into().unwrap()), 0);
+    assert_eq!(u32::from_le_bytes(pn[m - 20..m - 16].try_into().unwrap()), 0);
     assert_eq!(u32::from_le_bytes(pn[m - 16..m - 12].try_into().unwrap()), 0);
-    assert_eq!(u32::from_le_bytes(pn[m - 12..m - 8].try_into().unwrap()), 0);
-    assert_eq!(u32::from_le_bytes(pn[m - 8..m - 4].try_into().unwrap()), 0);
 }
 
 #[test]
@@ -857,6 +922,7 @@ fn test_encode_session_open_v6() {
         &test_metadata(),
         &zones,
         false,
+        0,
     );
 
     let p = &frame.data[FRAME_HEADER_SIZE..];
@@ -915,7 +981,7 @@ fn test_encode_session_open_high_ifindex_v4() {
     metadata.owner_rg_id = 40000; // > i16::MAX
 
     let frame =
-        EventFrame::encode_session_open(1, &test_key_v4(), &decision, &metadata, &zones, false);
+        EventFrame::encode_session_open(1, &test_key_v4(), &decision, &metadata, &zones, false, 0);
     let p = &frame.data[FRAME_HEADER_SIZE..];
 
     // i32 LE reads recover the exact values; an i16 encode could not.

--- a/userspace-dp/src/event_stream/codec/session_sync.rs
+++ b/userspace-dp/src/event_stream/codec/session_sync.rs
@@ -21,6 +21,7 @@ impl EventFrame {
         metadata: &SessionMetadata,
         _zone_name_to_id: &FxHashMap<String, u16>,
         fabric_redirect_sync: bool,
+        session_id: u64,
     ) -> Self {
         let mut buf = [0u8; 256];
         let mut pos = FRAME_HEADER_SIZE; // skip header, fill later
@@ -181,6 +182,19 @@ impl EventFrame {
         };
         buf[pos..pos + 4].copy_from_slice(&snat_v4);
         pos += 4;
+
+        // #5212: [+16:+24] the ORIGINATING node's stable RT_FLOW session id (u64
+        // LE), trailing/length-gated after the #4565 snat_v4 like every field
+        // since #3301. Carried so a peer-synced session ADOPTS this id on import
+        // (Go decodes it into SessionDeltaInfo.RTFlowSessionID ->
+        // SessionValue{,V6}.RTFlowSessionID -> SessionSyncRequest.session_id ->
+        // build_synced_session_entry), making its SESSION_CREATE (origin node)
+        // and SESSION_CLOSE (possibly the peer, post-failover) share one
+        // correlatable id. 0 = "no id" (a synthesized/no-entry emit, or a bulk
+        // export of an entry that vanished); an old Go decoder length-skips
+        // these 8 bytes and the standby allocs a fresh local id.
+        buf[pos..pos + 8].copy_from_slice(&session_id.to_le_bytes());
+        pos += 8;
 
         // Write header
         let payload_len = (pos - FRAME_HEADER_SIZE) as u32;

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -850,6 +850,9 @@ impl EventStreamWorkerHandle {
                 &delta.metadata,
                 zone_name_to_id,
                 delta.fabric_redirect_sync,
+                // #5212: the delta's stable RT_FLOW session id, carried on the
+                // HA session-sync open frame so the peer adopts it on import.
+                delta.session_id,
             ),
             SessionDeltaKind::Close => EventFrame::encode_session_close(
                 seq,

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -1094,6 +1094,22 @@ pub(crate) struct SessionSyncRequest {
     /// old peer that omits it, decoding to "not NAT64" (rolling-upgrade safe).
     #[serde(rename = "nat64_snat_v4", default)]
     pub nat64_snat_v4: String,
+    /// #5212: the ORIGINATING node's stable RT_FLOW session id
+    /// (`SessionTable::alloc_session_id` namespace: worker id in the high 16
+    /// bits + a per-worker monotonic counter). Carried across the cross-node HA
+    /// wire so a peer-synced session ADOPTS the originating node's id rather than
+    /// minting a fresh node-local one on import — the standby's SESSION_CLOSE
+    /// RT_FLOW record then correlates with the primary's SESSION_CREATE across
+    /// both HA nodes (an operator or a collector merging both streams sees one
+    /// id per logical session). The receiver stamps this onto the imported entry
+    /// (`build_synced_session_entry` -> `SessionInstall::session_id` ->
+    /// `upsert_synced_with_origin`) when non-zero, else falls back to a fresh
+    /// local id. `serde(default)` => 0 on an old peer that omits the field,
+    /// which is the "no id carried" sentinel (a real id is never 0 — the
+    /// allocator's counter starts at 1), bit-identical to the pre-#5212
+    /// fresh-local-id import (rolling-upgrade safe).
+    #[serde(rename = "session_id", default)]
+    pub session_id: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -621,6 +621,14 @@ pub(crate) fn build_synced_session_entry(
         origin: crate::session::SessionOrigin::SyncImport,
         // #2170: carry the peer's install generation onto the helper entry.
         generation: req.generation,
+        // #5212: carry the ORIGINATING node's stable RT_FLOW session id off the
+        // wire so this peer-synced session ADOPTS the peer's id instead of
+        // minting a fresh node-local one on import (`upsert_synced_with_origin`).
+        // A session that opens on the primary and closes here after a failover
+        // therefore emits SESSION_CREATE/CLOSE RT_FLOW records under ONE id
+        // across both nodes. An old peer omits the field => serde(default) 0,
+        // which falls back to `alloc_session_id()` (rolling-upgrade safe).
+        session_id: req.session_id,
     })
 }
 

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -1037,9 +1037,12 @@ trailing u64 in `encodeSessionV{4,6}Payload`, after the #5274 `ConfigEpoch`) →
 `upsert_synced_with_origin` ADOPTS the wire id (`SessionInstall::session_id`) when
 it is non-zero, and only falls back to `alloc_session_id()` for a legacy peer
 (wire id 0). The standby's SESSION_CLOSE RT_FLOW then carries the SAME id the
-primary's SESSION_CREATE did. The id is worker-namespaced, so importing the
-peer's id verbatim keeps it unique across this node's tables (the peer's worker
-occupies a disjoint id slice). Pinned by
+primary's SESSION_CREATE did. The id is a metadata-only correlation stamp (never
+a lookup key), adopted verbatim for that cross-node correlation. It is NOT
+globally unique — the `worker_id<<48 | counter` namespace has no node
+discriminator and both nodes run the same worker set, so in active/active an
+adopted id can collide with a local same-worker id (observability-only, bounded;
+a node-discriminator bit is tracked as #6311). Pinned by
 `session::tests::synced_import_adopts_peer_session_id_5212`,
 `test_encode_session_open_carries_session_id_5212`, and the Go
 `TestSessionWireRoundTripRTFlowSessionID5212{V4,V6}` /

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -997,12 +997,13 @@ to put on the wire.
 
 - **Generation** — `SessionTable::alloc_session_id` (called once per fresh
   install in `install_with_protocol_with_origin`, and once per peer-synced
-  import in `upsert_synced_with_origin`) returns `(worker_id << 48) | counter`,
-  the per-worker counter starting at 1. The worker id (set at worker setup via
-  `set_worker_id`) namespaces the id so it is unique across the node's
-  shared-nothing per-worker `SessionTable`s; the counter is monotonic, so a
-  reused 5-tuple (same worker) gets a DISTINCT id. `0` is reserved as the wire
-  "unknown" sentinel — a real id is never 0.
+  import in `upsert_synced_with_origin` **only when no wire id was carried** —
+  see #5212 below) returns `(worker_id << 48) | counter`, the per-worker counter
+  starting at 1. The worker id (set at worker setup via `set_worker_id`)
+  namespaces the id so it is unique across the node's shared-nothing per-worker
+  `SessionTable`s; the counter is monotonic, so a reused 5-tuple (same worker)
+  gets a DISTINCT id. `0` is reserved as the wire "unknown" sentinel — a real id
+  is never 0.
 - **Storage** — write-once on `SessionEntry.session_id`, never re-stamped, so a
   session's create and close read the same value.
 - **Wire** — harvested onto the Open/Close `SessionDelta.session_id` and encoded
@@ -1022,19 +1023,36 @@ to put on the wire.
 still accepts an old helper's 144/152-byte frames (id absent → ordinal
 fallback), and an old daemon ignores the trailing 8 bytes.
 
-**Scope — two documented follow-ups.** (1) Cross-HA-node id IDENTITY: a
-peer-synced session is assigned a FRESH node-local id on import, so a session
-that opens on the primary and closes on the standby after a failover carries
-different ids on the two nodes. Making them identical needs the id on the
-session-sync wire (a second additive wire growth), like the #3395 P2
-policy-id-on-wire deferral above. (2) RESOLVED in #5213: `show security flow
-session` now shows the SAME id the RT_FLOW frames carry. `publish_conntrack`
-(`build_conntrack_value_v4`/`_v6`) stamps the conntrack-map `session_id` from
-`SessionTable::session_id_for(&forward_key)` at each live-session-create publish
-site, and `cli_show_flow.go` renders `val.SessionID` (via `flowSessionDisplayID`),
-keeping the `cli_show_flow.go` iteration-index fallback ONLY when
-`val.SessionID == 0` (an absent/legacy id). Additive and node-local-safe.
-Follow-up (1) above (cross-HA-node id IDENTITY) is still open.
+**Scope — both documented follow-ups now RESOLVED.** (1) Cross-HA-node id
+IDENTITY — **RESOLVED in #5212.** Before #5212 a peer-synced session was assigned
+a FRESH node-local id on import, so a session that opened on the primary and
+closed on the standby after a failover carried different ids on the two nodes.
+#5212 carries the originating node's id on the HA session-sync wire as a
+length-gated trailing field (both sides, mirroring the #4565/#5274 discipline):
+`SessionDelta.session_id` → the MSG_SESSION_OPEN frame's trailing `session_id`
+u64 (`encode_session_open`) → Go `SessionDeltaInfo.RTFlowSessionID` →
+`SessionValue{,V6}.RTFlowSessionID` → the cluster sync wire (a length-gated
+trailing u64 in `encodeSessionV{4,6}Payload`, after the #5274 `ConfigEpoch`) →
+`SessionSyncRequest.session_id` → `build_synced_session_entry`. On import,
+`upsert_synced_with_origin` ADOPTS the wire id (`SessionInstall::session_id`) when
+it is non-zero, and only falls back to `alloc_session_id()` for a legacy peer
+(wire id 0). The standby's SESSION_CLOSE RT_FLOW then carries the SAME id the
+primary's SESSION_CREATE did. The id is worker-namespaced, so importing the
+peer's id verbatim keeps it unique across this node's tables (the peer's worker
+occupies a disjoint id slice). Pinned by
+`session::tests::synced_import_adopts_peer_session_id_5212`,
+`test_encode_session_open_carries_session_id_5212`, and the Go
+`TestSessionWireRoundTripRTFlowSessionID5212{V4,V6}` /
+`TestDecodeSessionEventRTFlowSessionID5212` /
+`TestBuildSessionSyncRequestCarriesRTFlowSessionID5212` /
+`TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212`. (2) RESOLVED in #5213:
+`show security flow session` now shows the SAME id the RT_FLOW frames carry.
+`publish_conntrack` (`build_conntrack_value_v4`/`_v6`) stamps the conntrack-map
+`session_id` from `SessionTable::session_id_for(&forward_key)` at each
+live-session-create publish site, and `cli_show_flow.go` renders `val.SessionID`
+(via `flowSessionDisplayID`), keeping the `cli_show_flow.go` iteration-index
+fallback ONLY when `val.SessionID == 0` (an absent/legacy id). Additive and
+node-local-safe.
 
 ## Per-IP session-limit lifecycle (#2134; #3122 peer-synced fix; #2128 leak-fix preserved)
 

--- a/userspace-dp/src/session/ctx.rs
+++ b/userspace-dp/src/session/ctx.rs
@@ -36,6 +36,16 @@ pub(crate) struct SessionInstall {
     pub(crate) now_ns: u64,
     pub(crate) protocol: u8,
     pub(crate) tcp_flags: u8,
+    /// #5212: the ORIGINATING node's stable RT_FLOW session id, carried across
+    /// the HA session-sync wire so a peer-synced session ADOPTS the peer's id
+    /// rather than minting a fresh node-local one — making the SESSION_CREATE
+    /// (emitted on the origin node) and the SESSION_CLOSE (which may be emitted
+    /// on the peer after a failover) share one correlatable id across both
+    /// nodes. 0 means "no id carried" (a legacy peer that predates the wire
+    /// field, or a locally-generated upsert such as a tunnel replica): the
+    /// receiver falls back to `alloc_session_id()` (pre-#5212 behavior,
+    /// rolling-upgrade safe). Only `upsert_synced_with_origin` consults it.
+    pub(crate) session_id: u64,
 }
 
 /// In-place update or promotion of an existing session. Carries a

--- a/userspace-dp/src/session/install.rs
+++ b/userspace-dp/src/session/install.rs
@@ -279,6 +279,10 @@ impl SessionTable {
                 now_ns,
                 protocol,
                 tcp_flags,
+                // #5212: this legacy convenience wrapper carries no wire id, so
+                // the receiver allocs a fresh node-local one (the real HA path
+                // threads the peer's id via `handle_upsert_synced`).
+                session_id: 0,
             },
             allow_replace_local,
         )
@@ -298,6 +302,7 @@ impl SessionTable {
             now_ns,
             protocol,
             tcp_flags,
+            session_id: wire_session_id,
         } = req;
         // Reject peer data that would clobber a locally-owned session
         // unless explicitly allowed (e.g. during HA activation).
@@ -313,14 +318,24 @@ impl SessionTable {
         // key_to_handle mapping internally before returning None.
         let _previous = self.remove_entry(&key);
         let epoch = self.next_epoch();
-        // #4915: a peer-synced import gets a FRESH node-local session id. The
-        // peer's original id is not carried on the HA session-sync wire, so a
-        // session that opens on the primary and closes on the standby after a
-        // failover carries different ids on the two nodes — a documented
-        // follow-up (cross-node id identity needs a session-sync wire change).
-        // A node-local id still fixes same-node create/close correlation and
-        // matches this node's own live-session view.
-        let session_id = self.alloc_session_id();
+        // #5212 (completes the #4915 follow-up): ADOPT the originating node's
+        // session id when it rides the HA session-sync wire, so a session that
+        // opens on the primary and closes on the standby after a failover
+        // carries the SAME RT_FLOW id on both nodes (cross-node log/event
+        // correlation). The id is namespaced by the originating worker's high
+        // 16 bits, so importing it verbatim keeps it unique across this node's
+        // shared-nothing worker tables too (the peer's worker id occupies a
+        // disjoint slice of the id space from any locally-alloc'd id). A zero
+        // wire id (a legacy peer that predates the field, or a locally-generated
+        // upsert such as a tunnel replica) falls back to a FRESH node-local id
+        // via `alloc_session_id()` — the pre-#5212 behavior (rolling-upgrade
+        // safe). 0 is never a real id (the allocator starts its counter at 1),
+        // so the sentinel is unambiguous.
+        let session_id = if wire_session_id != 0 {
+            wire_session_id
+        } else {
+            self.alloc_session_id()
+        };
         let record = SessionRecord {
             key: key.clone(),
             entry: SessionEntry {
@@ -435,6 +450,15 @@ impl SessionTable {
         if metadata.is_reverse {
             return;
         }
+        // #5212: this is the owner-RG bulk/cold-sync export path (a live local
+        // session re-announced as an Open delta so a freshly-connected or
+        // failed-back peer picks it up). Unlike the #2465 timestamps/counters,
+        // the STABLE session id IS recoverable — the entry is still live in this
+        // table — so look it up by key and carry it on the wire, letting the
+        // peer adopt the same id it will emit its own RT_FLOW records under
+        // (`session_id_for` returns 0 if the key is somehow absent, the safe
+        // fallback-to-local-alloc sentinel).
+        let session_id = self.session_id_for(&key);
         self.push_delta(SessionDelta {
             kind: SessionDeltaKind::Open,
             key,
@@ -451,9 +475,9 @@ impl SessionTable {
             // #2749: explicit Open-delta emit, no entry in hand.
             observed_tos: 0,
             observed_tcp_flags: 0,
-            // #4915: no backing entry in hand on this explicit-emit path, so no
-            // stable id is available — 0 keeps the "unknown" wire sentinel.
-            session_id: 0,
+            // #5212: the stable id of the exported entry (0 if absent), so the
+            // peer adopts it rather than minting a fresh node-local id.
+            session_id,
         });
     }
 

--- a/userspace-dp/src/session/install.rs
+++ b/userspace-dp/src/session/install.rs
@@ -322,10 +322,13 @@ impl SessionTable {
         // session id when it rides the HA session-sync wire, so a session that
         // opens on the primary and closes on the standby after a failover
         // carries the SAME RT_FLOW id on both nodes (cross-node log/event
-        // correlation). The id is namespaced by the originating worker's high
-        // 16 bits, so importing it verbatim keeps it unique across this node's
-        // shared-nothing worker tables too (the peer's worker id occupies a
-        // disjoint slice of the id space from any locally-alloc'd id). A zero
+        // correlation). The id is a metadata-only stamp (RT_FLOW correlation +
+        // the show-session mirror id) — NEVER a lookup key or slab handle — so
+        // adopting it verbatim cannot affect forwarding/security/memory. It is
+        // NOT globally unique: the worker_id<<48|counter namespace has no node
+        // discriminator and both nodes run the same worker set, so in
+        // active/active an adopted id can collide with a local same-worker id
+        // (observability-only; a node-discriminator bit is tracked as #6311). A zero
         // wire id (a legacy peer that predates the field, or a locally-generated
         // upsert such as a tunnel replica) falls back to a FRESH node-local id
         // via `alloc_session_id()` — the pre-#5212 behavior (rolling-upgrade
@@ -457,7 +460,9 @@ impl SessionTable {
         // table — so look it up by key and carry it on the wire, letting the
         // peer adopt the same id it will emit its own RT_FLOW records under
         // (`session_id_for` returns 0 if the key is somehow absent, the safe
-        // fallback-to-local-alloc sentinel).
+        // fallback-to-local-alloc sentinel). NB: only the event-stream leg of
+        // this owner-RG export carries the id; the JSON resync leg still drops
+        // it (#6312).
         let session_id = self.session_id_for(&key);
         self.push_delta(SessionDelta {
             kind: SessionDeltaKind::Open,

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -386,7 +386,10 @@ fn session_id_namespaces_worker_in_high_bits() {
 // zero wire id (a legacy peer that predates the field) falls back to a fresh
 // local alloc. Reverting the stamp in `upsert_synced_with_origin` (back to an
 // unconditional `alloc_session_id()`) flips the first assertion RED: the adopted
-// id would be a local worker-2 id, not the peer's worker-7 id.
+// id would be a local worker-2 id, not the peer's worker-3 id. A distinct worker
+// only keeps that revert assertion unambiguous — the id space is NOT partitioned
+// by node, so a peer id in the SAME worker index collides with a local id in
+// active/active (an accepted observability-only limitation, #6311).
 #[test]
 fn synced_import_adopts_peer_session_id_5212() {
     let mut table = SessionTable::new();
@@ -394,9 +397,11 @@ fn synced_import_adopts_peer_session_id_5212() {
     table.set_worker_id(2);
     let now = 1_000_000_000u64;
 
-    // A peer-originated id in worker 7's namespace — a slice of the id space
-    // this node's own allocator never mints.
-    let peer_id: u64 = (7u64 << 48) | 42;
+    // A peer-originated id, adopted verbatim. Worker 3 (distinct from this
+    // node's local worker 2) only keeps the revert assertion unambiguous — the
+    // namespace has no node discriminator, so a same-worker peer id would
+    // collide with a local id (#6311).
+    let peer_id: u64 = (3u64 << 48) | 42;
     let key = key_v4();
     assert!(table.upsert_synced_with_origin(
         SessionInstall {

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -379,6 +379,71 @@ fn session_id_namespaces_worker_in_high_bits() {
     );
 }
 
+// #5212 RED-on-revert: a peer-synced import ADOPTS the originating node's stable
+// session id carried on the HA session-sync wire (SessionInstall.session_id)
+// instead of minting a fresh node-local one, so the standby's SESSION_CLOSE
+// RT_FLOW record correlates with the primary's SESSION_CREATE across HA nodes. A
+// zero wire id (a legacy peer that predates the field) falls back to a fresh
+// local alloc. Reverting the stamp in `upsert_synced_with_origin` (back to an
+// unconditional `alloc_session_id()`) flips the first assertion RED: the adopted
+// id would be a local worker-2 id, not the peer's worker-7 id.
+#[test]
+fn synced_import_adopts_peer_session_id_5212() {
+    let mut table = SessionTable::new();
+    // Local allocations would land in this node's worker-2 id namespace.
+    table.set_worker_id(2);
+    let now = 1_000_000_000u64;
+
+    // A peer-originated id in worker 7's namespace — a slice of the id space
+    // this node's own allocator never mints.
+    let peer_id: u64 = (7u64 << 48) | 42;
+    let key = key_v4();
+    assert!(table.upsert_synced_with_origin(
+        SessionInstall {
+            key: key.clone(),
+            decision: decision(),
+            metadata: metadata(),
+            origin: SessionOrigin::SyncImport,
+            now_ns: now,
+            protocol: PROTO_TCP,
+            tcp_flags: 0x10,
+            session_id: peer_id,
+        },
+        false,
+    ));
+    assert_eq!(
+        table.session_id_for(&key),
+        peer_id,
+        "a peer-synced session must ADOPT the wire session id, not alloc a fresh local one"
+    );
+
+    // A second synced session carrying NO wire id (a legacy peer) falls back to a
+    // FRESH LOCAL id: non-zero, in this node's (worker-2) namespace, and never
+    // the peer's id.
+    let key2 = key_v6();
+    assert!(table.upsert_synced_with_origin(
+        SessionInstall {
+            key: key2.clone(),
+            decision: decision(),
+            metadata: metadata(),
+            origin: SessionOrigin::SyncImport,
+            now_ns: now,
+            protocol: PROTO_UDP,
+            tcp_flags: 0,
+            session_id: 0,
+        },
+        false,
+    ));
+    let local_id = table.session_id_for(&key2);
+    assert_ne!(local_id, 0, "a zero wire id must fall back to a fresh non-zero local id");
+    assert_ne!(local_id, peer_id, "the fallback must be a fresh LOCAL id, not the peer's");
+    assert_eq!(
+        local_id >> 48,
+        2,
+        "the fallback id must be namespaced to this node's worker (2)"
+    );
+}
+
 // === #4380 symmetric idle-timer (forward↔reverse companion) tests =========
 //
 // A flow is TWO independent entries that age independently. Junos measures a
@@ -5735,6 +5800,7 @@ fn session_limit_ha_import_promote_demote_count() {
             now_ns: now,
             protocol: PROTO_TCP,
             tcp_flags: 0x10,
+            session_id: 0,
         },
         false,
     ));
@@ -5816,6 +5882,7 @@ fn session_limit_synced_sessions_enforced_after_failover() {
                 now_ns: now,
                 protocol: PROTO_TCP,
                 tcp_flags: 0x10,
+                session_id: 0,
             },
             false,
         ));
@@ -5863,6 +5930,7 @@ fn session_limit_synced_reimport_nets_to_one() {
                 now_ns: now + t * 1_000_000,
                 protocol: PROTO_TCP,
                 tcp_flags: 0x10,
+                session_id: 0,
             },
             true,
         ));
@@ -5899,6 +5967,7 @@ fn session_limit_synced_reverse_import_excluded() {
             now_ns: now,
             protocol: PROTO_TCP,
             tcp_flags: 0x10,
+            session_id: 0,
         },
         false,
     ));
@@ -6070,6 +6139,7 @@ fn session_limit_counts_match_live_counted_entries_invariant() {
             now_ns: now,
             protocol: PROTO_TCP,
             tcp_flags: 0x10,
+            session_id: 0,
         },
         false,
     );
@@ -6275,6 +6345,7 @@ fn session_limit_backcount_on_enable_covers_preexisting_sessions() {
             now_ns: now,
             protocol: PROTO_TCP,
             tcp_flags: 0x10,
+            session_id: 0,
         },
         false,
     );

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -1059,6 +1059,7 @@
     "policy_counter_idx": 0,
     "policy_id": 0,
     "protocol": 0,
+    "session_id": 0,
     "src_ip": "",
     "src_mac": "",
     "src_port": 0,


### PR DESCRIPTION
## Summary

Closes #5212.

PR #5211 (#4915) assigns a node-unique stable session id in the dataplane
(`SessionTable::alloc_session_id`: worker id in the high 16 bits + a per-worker
counter) and stamps it on every RT_FLOW SESSION_CREATE/CLOSE record. That id was
**node-local**: a peer-synced session was assigned a FRESH id on import
(`upsert_synced_with_origin`), so a session that opened on the primary and closed
on the standby after a failover carried **different** ids on the two nodes and
cross-node log/event correlation broke.

This change carries the originating node's id across the HA session-sync wire so
the importing node **adopts** it instead of minting a fresh local one. A session
that opens on the primary and closes on the peer after a failover now emits its
SESSION_CREATE and SESSION_CLOSE records under **one correlatable id** across
both nodes.

## Both-sides wire change (mirrors #4565 snat_v4 / #5274 config-epoch)

Additive, length-gated trailing field — no version bump, rolling-upgrade safe.

**Rust dataplane** (`userspace-dp`)
- `encode_session_open` appends the id as a trailing `u64` (LE) **after** the
  #4565 `snat_v4`, threaded from `SessionDelta.session_id`;
  `emit_open_delta_with_origin` looks it up off the live table so the owner-RG
  cold-sync export carries it too.
- `SessionInstall.session_id` + `SyncedSessionEntry.session_id`;
  `upsert_synced_with_origin` **adopts** the wire id when non-zero, else falls
  back to `alloc_session_id()` (legacy peer / tunnel replica). The id is
  worker-namespaced so adopting the peer's id verbatim stays unique across this
  node's tables.
- `SessionSyncRequest.session_id` (serde default 0) → `build_synced_session_entry`.
- Regenerated `protocol_wire_v1.json`.

**Go control plane**
- `SessionValue`/`SessionValueV6` gain `RTFlowSessionID` — **distinct** from the
  BPF-ABI `SessionID` (the node-local conntrack id, `now<<16|Slot`). Not part of
  the BPF/C conntrack ABI (`bpfSessionValue`), so the marshal-size invariant is
  preserved.
- `sync_protocol.go` encodes/decodes it as a length-gated trailing `u64` (LE)
  after the #5274 `ConfigEpoch` on **both V4 and V6**.
- `decodeSessionEvent` → `SessionDeltaInfo.RTFlowSessionID`;
  `userspaceSessionFromDeltaV4/V6` stamp `SessionValue`;
  `buildSessionSyncRequestV4/V6` forward `SessionSyncRequest.session_id`.

## Backward safety

Both the encode and decode of every hop are bound by tests (no one-sided field —
the #1961 no-transit hazard). A mixed-version / `session_id == 0` peer that omits
the field is handled at every layer: the Go decoders length-gate (`if off+8 <=
len(payload)`) and read 0; `upsert_synced_with_origin` falls back to a fresh local
id on 0. A real id is never 0 (the allocator counter starts at 1), so the sentinel
is unambiguous. The six pre-existing legacy-truncation/trailing-offset tests
(#2170/#3301/#4565/#5274) were updated for the shifted field ordering.

## Fail-on-revert tests (firsthand RED-verified)

Rust
- `event_stream::codec::tests::test_encode_session_open_carries_session_id_5212`
  (encode side)
- `session::tests::synced_import_adopts_peer_session_id_5212` (adopt side + 0 → fresh-local fallback)

Go
- `TestSessionWireRoundTripRTFlowSessionID5212V4/V6` (cluster wire round-trip + legacy-truncation reads 0)
- `TestDecodeSessionEventRTFlowSessionID5212` (open-frame decode)
- `TestBuildSessionSyncRequestCarriesRTFlowSessionID5212` (manager forward)
- `TestUserspaceSessionFromDeltaCarriesRTFlowSessionID5212` (delta → SessionValue stamp)

## Testing

- Go: `pkg/cluster`, `pkg/grpcapi`, `pkg/dataplane/...`, `pkg/daemon/...` all green.
- Rust: `cargo test --release -- --skip install_session_serializes` (skips the
  known flaky WG-engine test #6157).
- Cross-language contract: `wire_invariant_default_specimens` passes against the
  regenerated `protocol_wire_v1.json`.

**NOTE:** HA session-sync wire change — `make test-failover` smoke is required
before merge (owned by the reviewer).

## Docs

`docs/sync-protocol.md` (new "RT_FLOW Session Id" section),
`docs/session-sync-architecture.md`, `pkg/cluster/README.md`, and
`userspace-dp/src/session/README.md` (marks the #4915 cross-node follow-up
RESOLVED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
