### PR TITLE
configstore: fence synchronous ArchiveConfig against the zeroize archive fence (#6185)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-22 — #6185: fence synchronous ArchiveConfig against the zeroize fence
+
+- **Timestamp**: 2026-07-22 (fix/6185-archiveconfig-fence)
+- **Action**: Fenced the SYNCHRONOUS archive path (`Store.ArchiveConfig`,
+  `pkg/configstore/store_persist.go`) against the #5869/#6182 zeroize archive
+  fence. #6182 fenced + joined the ASYNC fire-and-forget `writeArchive`
+  goroutine (`archiveFenced` + `archiveWG`), but `ArchiveConfig` did NOT consult
+  the fence and was NOT tracked by the WaitGroup. It has zero production callers
+  today, but if it were ever wired to an operator command (e.g. `request system
+  configuration archive`) a fenced-window call would `os.MkdirAll` + rewrite the
+  archive dir after `FactoryResetArchiveDir` erased it — recreating a
+  `config-<ts>.<seq>.conf` snapshot of the PRIOR tenant's full config text
+  (cleartext IKE PSKs, WireGuard keys, SNMP communities) — reopening the #5869
+  re-tenant residue for that path. `ArchiveConfig` now (1) no-ops when the fence
+  is set (checked under `s.mu`, mirroring the async launch guard) and (2)
+  `archiveWG.Add(1)`s under the lock guarded by `!archiveFenced` and `Done()`s
+  after the off-lock write, so a concurrent `QuiesceArchival` JOINS an in-flight
+  synchronous write before the wipe. Lock discipline matches the async path: the
+  fence read + Add run under the RLock (mutually exclusive with QuiesceArchival's
+  write-Lock fence-set), so the Add/Wait ordering stays race-free and no deadlock
+  (writeArchive never touches `s.mu`). Routed the sync path through the existing
+  `archiveWriteBarrier` seam so the JOIN is deterministically testable.
+- **Tests**: `pkg/configstore/archiveconfig_fence_6185_test.go` (new) —
+  `TestArchiveConfigFencedDoesNotRecreateArchiveDir` (MANDATORY fail-on-revert:
+  QuiesceArchival sets fence → ArchiveConfig must NOT recreate the dir;
+  neutralizing the fence guard → RED, dir reappears with the snapshot),
+  `TestArchiveConfigUnfencedArchivesNormally` (control: un-fenced sync path still
+  writes one snapshot carrying the config text),
+  `TestQuiesceArchivalJoinsInflightSyncArchiveConfig` (JOIN fail-on-revert:
+  removing the `archiveWG.Add(1)` → QuiesceArchival returns before joining → RED),
+  and `TestResumeArchivalReenablesCommitArchival` (#6185 note 2: fence → prove a
+  fenced commit does NOT archive → ResumeArchival clears the fence → a subsequent
+  commit archives normally; WaitGroup reusable, no corrupt state). Verified RED on
+  revert for both fences; `go build ./...`, `go vet`, `go test -race
+  ./pkg/configstore/...` full suite pass, 5x non-flake.
+- **File(s)**: pkg/configstore/store_persist.go, pkg/configstore/store_commit.go,
+  pkg/configstore/archiveconfig_fence_6185_test.go (new),
+  docs/system-login.md, pkg/configstore/README.md, _Log.md
+
 ## 2026-07-22 — #6114: mirror flow-cache HOT path samples before reserving
 
 - **Timestamp**: 2026-07-22 (fix/6114-mirror-sample-before-cas)

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -415,6 +415,15 @@ through that single shared primitive so they wipe the same archive.
   **fail-closed recoverable wipe** the daemon stays up and resumes normal work, so
   it also `ResumeArchival()`s (clears the fence); on a **successful** wipe the
   daemon is stopped and the fence stays latched.
+  - **Synchronous `Store.ArchiveConfig` is fenced too (#6185).** The same fence
+    now also gates the **synchronous** archive path. `Store.ArchiveConfig` has
+    **zero** production callers today, but if it were ever wired to an operator
+    command (e.g. `request system configuration archive`) an unfenced call could
+    run **after** the fence was set and the archive dir erased, `os.MkdirAll` it
+    back, and drop a prior-tenant snapshot — reopening the residue for that path.
+    It now (1) **no-ops** when the fence is set and (2) registers itself in
+    `archiveWG` when it is not, so a concurrent `QuiesceArchival` **joins** an
+    in-flight synchronous write before the wipe, exactly like the async writer.
 
 **Privileged-subcommand exception — `monitor traffic` (#4067).** Almost
 every command is gated on the top-level word alone, but `monitor traffic`

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -586,6 +586,25 @@ per-path:
   (`DefaultArchiveDir` = `/var/lib/xpf/archive`); a custom / remote /
   compliance archive destination is not provably xpf-owned, so it is
   SKIPPED with a warning rather than blindly deleted.
+- **Archive-writer fence + join (#5869 / #6182, extended in #6185).**
+  Erasing the directory is not enough — an archive writer can recreate it
+  AFTER the wipe. Auto-archive launches a fire-and-forget writer goroutine
+  per commit (`commitWithDescriptionLocked`) and `writeArchive` starts with
+  `os.MkdirAll(archiveDir)`, so a writer scheduled just before a `zeroize`
+  could resume after `FactoryResetArchiveDir` removed the archive dir and
+  drop a `config-<ts>.<seq>.conf` snapshot of the PRIOR tenant's full config
+  text back on disk — re-tenant secret residue. `Store` gains `archiveWG`
+  (tracks in-flight writers) and `archiveFenced` (a one-way latch).
+  `QuiesceArchival()` sets the fence under `s.mu` (no NEW writer launches;
+  the `Add`/`Wait` ordering is race-free) then `archiveWG.Wait()` JOINS every
+  in-flight writer — the load-bearing half, since a fence alone cannot close
+  the write-after-wipe window. `ResumeArchival()` clears the fence only on the
+  fail-closed recoverable path. **#6185:** the SYNCHRONOUS `Store.ArchiveConfig`
+  path (zero production callers today) now honors the SAME fence — it no-ops
+  when fenced and registers in `archiveWG` when not, so a future operator
+  wiring (`request system configuration archive`) cannot bypass the zeroize
+  fence. `daemon.factoryReset` calls `QuiesceArchival()` after entering the
+  reset generation and before the wipe.
 - **`CommitConfirmed` ordering.** Confirm state is only touched after
   the persist succeeds: on failure the rollback timer is NOT armed and
   an existing pending confirm (timer + rollback target) is left fully

--- a/pkg/configstore/archiveconfig_fence_6185_test.go
+++ b/pkg/configstore/archiveconfig_fence_6185_test.go
@@ -1,0 +1,274 @@
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// archiveSecret6185 stands in for any prior-tenant secret that lands in an
+// archived config snapshot (IKE PSK, WireGuard private key, SNMP community).
+// The synchronous ArchiveConfig path drops the same 0600 copies of the full
+// committed config TEXT the async writer does, so a resurrected archive carries
+// such leaves in cleartext.
+const archiveSecret6185 = "PRIOR-TENANT-SECRET-6185"
+
+// commitSecret6185 commits a config carrying a recognizable secret so a leaked
+// archive is detectable, mirroring the #5869 residue shape.
+func commitSecret6185(t *testing.T, s *Store, marker string) {
+	t.Helper()
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("system host-name " + marker); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	// Release the configure lock so a later commit in the same test can
+	// re-enter (the fence→resume cycle commits twice).
+	s.ExitConfigure()
+}
+
+// TestArchiveConfigFencedDoesNotRecreateArchiveDir pins the #6185 fix: the
+// SYNCHRONOUS archive path (Store.ArchiveConfig) must honor the #5869/#6182
+// archive fence exactly like the async auto-archive launch guard. ArchiveConfig
+// has ZERO production callers today, but if it is ever wired to an operator
+// command (e.g. `request system configuration archive`) a call that ran AFTER a
+// factory reset (zeroize) set the fence and erased the archive directory would
+// MkdirAll it back and drop a config-<ts>.<seq>.conf snapshot of the PRIOR
+// tenant's full config text — the exact re-tenant secret residue #5869 closed
+// for the async path.
+//
+// RED on revert: neutralize the `if s.archiveFenced.Load() { ... return nil }`
+// guard at the top of ArchiveConfig. The fenced call then falls through to
+// writeArchive, whose os.MkdirAll recreates the archive directory the zeroize
+// was erasing — the Stat assertion below trips (the directory reappears).
+func TestArchiveConfigFencedDoesNotRecreateArchiveDir(t *testing.T) {
+	// ArchiveConfig writes to the explicit archiveDir argument, so a throwaway
+	// subdir that does not exist yet is enough — no DefaultArchiveDir repoint.
+	dir := filepath.Join(t.TempDir(), "archive")
+
+	s := newTestStore(t)
+	commitSecret6185(t, s, archiveSecret6185)
+
+	// Zeroize sequence: fence archival. With no async writer outstanding
+	// (SetArchiveConfig was never called, so no commit launched one) the JOIN in
+	// QuiesceArchival returns immediately; only the fence remains set.
+	s.QuiesceArchival()
+
+	// The synchronous archive path must now be a silent no-op and MUST NOT
+	// recreate the archive directory the wipe is erasing.
+	if err := s.ArchiveConfig(dir, 10); err != nil {
+		t.Fatalf("fenced ArchiveConfig should be a silent no-op, got err: %v", err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		names := archiveDirEntries(dir)
+		t.Fatalf("fenced ArchiveConfig recreated the archive directory (zeroize "+
+			"secret residue): stat err=%v, entries=%v", err, names)
+	}
+}
+
+// TestArchiveConfigUnfencedArchivesNormally is the CONTROL for the fence guard:
+// with no fence set, the synchronous ArchiveConfig path still writes exactly one
+// snapshot carrying the committed config text. It proves the #6185 guard
+// defaults to ALLOWING archival (the fence starts false) and that the added
+// archiveWG.Add/Done tracking did not break the ordinary synchronous path.
+func TestArchiveConfigUnfencedArchivesNormally(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "archive")
+
+	s := newTestStore(t)
+	commitSecret6185(t, s, archiveSecret6185)
+
+	if err := s.ArchiveConfig(dir, 10); err != nil {
+		t.Fatalf("un-fenced ArchiveConfig: %v", err)
+	}
+
+	// Synchronous path: the write has completed by the time ArchiveConfig
+	// returns, so no polling is needed.
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("archive directory not created by un-fenced ArchiveConfig: %v", err)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("un-fenced ArchiveConfig must write exactly one snapshot, got %d", len(ents))
+	}
+	body, err := os.ReadFile(filepath.Join(dir, ents[0].Name()))
+	if err != nil {
+		t.Fatalf("read archive file: %v", err)
+	}
+	if !strings.Contains(string(body), archiveSecret6185) {
+		t.Fatalf("archive did not capture the committed config text; got:\n%s", body)
+	}
+}
+
+// TestQuiesceArchivalJoinsInflightSyncArchiveConfig pins the JOIN half of the
+// #6185 fix for the synchronous path: an ArchiveConfig call that has already
+// passed the fence check (fence was false when it captured the config) and is
+// MID-WRITE must be JOINED by a concurrent QuiesceArchival before the wipe, so
+// the write cannot land AFTER the archive directory is erased. The fence alone
+// cannot close this write-after-wipe window — only tracking the synchronous
+// writer in archiveWG (Add before the write, Done after) lets QuiesceArchival
+// wait it out.
+//
+// The writer is held mid-flight at archiveWriteBarrier — deliberately PAST the
+// fence check — so the fence cannot mask a missing join.
+//
+// RED on revert: neutralize the `s.archiveWG.Add(1)` in ArchiveConfig.
+// QuiesceArchival's Wait() then sees a zero counter and returns immediately
+// (the wipe runs while the writer is still blocked), so `done` fires before the
+// writer is released — tripping the "QuiesceArchival returned before joining"
+// assertion below.
+func TestQuiesceArchivalJoinsInflightSyncArchiveConfig(t *testing.T) {
+	dir := useTempArchiveDefault(t) // archive dir == the ownership-guarded default so FactoryResetArchiveDir actually wipes
+
+	s := newTestStore(t)
+	commitSecret6185(t, s, archiveSecret6185)
+
+	// Hold the synchronous archive writer MID-FLIGHT: past the fence check (so
+	// the fence cannot mask a missing join) and before the actual write.
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var once sync.Once
+	old := archiveWriteBarrier
+	archiveWriteBarrier = func() {
+		once.Do(func() { close(started) })
+		<-release
+	}
+	t.Cleanup(func() { archiveWriteBarrier = old })
+
+	// Launch the synchronous archive. It Add(1)s to archiveWG under the store
+	// lock (fence is false), then blocks in the barrier past the fence check.
+	archiveErr := make(chan error, 1)
+	go func() { archiveErr <- s.ArchiveConfig(dir, 10) }()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("synchronous archive writer never reached the barrier")
+	}
+
+	// Run the daemon's factory-reset sequence: QuiesceArchival (fence + JOIN)
+	// then the archive-dir wipe. QuiesceArchival must block joining the in-flight
+	// synchronous writer, so drive it from a goroutine.
+	done := make(chan struct{})
+	go func() {
+		s.QuiesceArchival()             // JOIN: with the fix, blocks until the writer is done
+		_ = FactoryResetArchiveDir(dir) // wipe: RemoveAll + parent fsync
+		close(done)
+	}()
+
+	// QuiesceArchival must be BLOCKED joining the in-flight synchronous writer:
+	// the wipe must not run yet. Without the archiveWG.Add(1) in ArchiveConfig,
+	// QuiesceArchival returns immediately and `done` fires here — the exact race.
+	select {
+	case <-done:
+		t.Fatal("QuiesceArchival returned before joining the in-flight synchronous " +
+			"ArchiveConfig — the wipe raced the write (missing archiveWG tracking)")
+	case <-time.After(100 * time.Millisecond):
+		// Still blocked in Wait() — the join is holding, as intended.
+	}
+
+	// Release the writer; it writes then Done()s, QuiesceArchival's Wait returns,
+	// and the wipe runs AFTER the write — so the write is erased, no residue.
+	close(release)
+
+	if err := <-archiveErr; err != nil {
+		t.Fatalf("synchronous ArchiveConfig: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("factory-reset sequence (QuiesceArchival + wipe) did not complete")
+	}
+
+	// The write landed BEFORE the wipe (QuiesceArchival joined it), so the wipe
+	// erased it: no archive directory / prior-tenant snapshot survives.
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		names := archiveDirEntries(dir)
+		t.Fatalf("archive directory survived zeroize after a joined synchronous "+
+			"write: stat err=%v, entries=%v", err, names)
+	}
+}
+
+// TestResumeArchivalReenablesCommitArchival covers the #6185 second note: the
+// only prior fail-path test (pkg/daemon factory_reset_5281_test.go) drives a
+// bare Daemon{} with a nil store, so it exercises the `d.store != nil` guard —
+// NOT the real fence-clear in ResumeArchival. This drives the store directly:
+// fence archival (as a factory reset would), prove the fence blocks a commit's
+// auto-archive, then ResumeArchival (the fail-closed recoverable wipe path) and
+// prove the fence is cleared AND a subsequent commit archives normally again —
+// the WaitGroup is reusable and no state is corrupt.
+func TestResumeArchivalReenablesCommitArchival(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "archive")
+
+	s := newTestStore(t)
+	s.SetArchiveConfig(dir, 10)
+
+	// Fence archival, as daemon.factoryReset does before the wipe.
+	s.QuiesceArchival()
+	if !s.archiveFenced.Load() {
+		t.Fatal("QuiesceArchival did not set the archive fence")
+	}
+
+	// While fenced, a commit must NOT launch/write an auto-archive: the launch
+	// guard reads the fence under s.mu.
+	commitSecret6185(t, s, archiveSecret6185+"-fenced")
+	time.Sleep(200 * time.Millisecond) // give any (erroneously launched) writer time
+	s.archiveWG.Wait()                 // join anything in flight (there should be none)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		names := archiveDirEntries(dir)
+		t.Fatalf("a fenced commit archived (zeroize residue window): entries=%v", names)
+	}
+
+	// Fail-closed recoverable wipe path: the daemon stays up and resumes normal
+	// config work, so it clears the fence.
+	s.ResumeArchival()
+	if s.archiveFenced.Load() {
+		t.Fatal("ResumeArchival did not clear the archive fence")
+	}
+
+	// A subsequent commit must archive normally again — the WaitGroup is reusable
+	// (its counter returned to zero and Wait() completed), the fence is cleared,
+	// and no state is corrupt.
+	commitSecret6185(t, s, archiveSecret6185+"-resumed")
+
+	deadline := time.Now().Add(2 * time.Second)
+	var ents []os.DirEntry
+	for time.Now().Before(deadline) {
+		if e, err := os.ReadDir(dir); err == nil && len(e) >= 1 {
+			ents = e
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("post-resume commit must archive exactly one snapshot, got %d", len(ents))
+	}
+	body, err := os.ReadFile(filepath.Join(dir, ents[0].Name()))
+	if err != nil {
+		t.Fatalf("read archive file: %v", err)
+	}
+	if !strings.Contains(string(body), archiveSecret6185+"-resumed") {
+		t.Fatalf("post-resume archive did not capture the committed config text; got:\n%s", body)
+	}
+}
+
+// archiveDirEntries lists an archive directory's file names for failure
+// messages; it returns nil when the directory is absent.
+func archiveDirEntries(dir string) []string {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(ents))
+	for _, e := range ents {
+		names = append(names, e.Name())
+	}
+	return names
+}

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -37,12 +37,13 @@ var (
 	rbRemove           = os.Remove
 )
 
-// archiveWriteBarrier is a test-only seam (#5869) invoked by the async
-// auto-archive goroutine AFTER the archive fence check and BEFORE the actual
-// write. Production is a no-op. A test overrides it to hold a writer
-// MID-FLIGHT — deliberately PAST the fence check, so the fence cannot mask it —
-// to prove QuiesceArchival JOINS an in-flight writer (not merely fences future
-// ones) before a factory reset erases the archive directory. Never mutated by
+// archiveWriteBarrier is a test-only seam (#5869) invoked AFTER the archive
+// fence check and BEFORE the actual write by BOTH archive writers: the async
+// auto-archive goroutine and the synchronous Store.ArchiveConfig path (#6185).
+// Production is a no-op. A test overrides it to hold a writer MID-FLIGHT —
+// deliberately PAST the fence check, so the fence cannot mask it — to prove
+// QuiesceArchival JOINS an in-flight writer (not merely fences future ones)
+// before a factory reset erases the archive directory. Never mutated by
 // production code.
 var archiveWriteBarrier = func() {}
 

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -523,18 +523,54 @@ func (s *Store) ResumeArchival() {
 // text and the timestamp are captured together under the lock so the
 // written archive matches the config that was active at the call (#3441 H4),
 // then the actual write happens off-lock via writeArchive.
+//
+// #6185: this SYNCHRONOUS archive path honors the #5869/#6182 archive fence
+// exactly like the async auto-archive launch guard. It has zero production
+// callers today, but if it is ever wired to an operator command (e.g.
+// `request system configuration archive`) an unfenced call could run AFTER a
+// factory reset (zeroize) has set the fence and erased the archive directory —
+// writeArchive would MkdirAll it back and drop a config-<ts>.<seq>.conf
+// snapshot of the PRIOR tenant's full config text (cleartext IKE PSKs,
+// WireGuard keys, SNMP communities) on a re-tenanted device, reopening the
+// exact residue #5869 closed for the async path. So it (1) no-ops when the
+// fence is set and (2) registers itself in archiveWG when it is not, so a
+// concurrent QuiesceArchival JOINs an in-flight synchronous write before the
+// wipe — the fence alone cannot close the write-after-wipe window.
 func (s *Store) ArchiveConfig(archiveDir string, maxArchives int) error {
-	// Capture the text, timestamp AND the monotonic seq together under the
-	// lock (#3441 H4, Codex MAJOR): the previous code called time.Now()
-	// AFTER releasing the lock, an ordering race that could mislabel the
-	// archive relative to a concurrent commit. Capturing all three under
-	// the lock matches the commit path and keeps (ts,seq) consistent with
-	// the actual active-config snapshot.
+	// Capture the fence check, the text, timestamp, the monotonic seq AND the
+	// writer registration (archiveWG.Add) together under the lock. The seq/ts
+	// capture matches the commit path (#3441 H4, Codex MAJOR): the previous
+	// code called time.Now() AFTER releasing the lock, an ordering race that
+	// could mislabel the archive relative to a concurrent commit.
+	//
+	// #6185: the fence read and the Add(1) run under s.mu guarded by
+	// !archiveFenced, exactly like the async launch guard, so the Add/Wait
+	// ordering stays race-free: QuiesceArchival sets archiveFenced under s.mu
+	// (write lock) before it Wait()s, and that write lock is mutually exclusive
+	// with this RLock — so a concurrent QuiesceArchival either observes this
+	// writer in archiveWG and JOINs it (we Added before it took the write lock)
+	// or sets the fence first and we no-op (we read fenced=true and never Add).
+	// The counter can never rise from zero concurrently with Wait.
 	s.mu.RLock()
+	if s.archiveFenced.Load() {
+		// A factory reset is erasing the archive directory; do not recreate it.
+		s.mu.RUnlock()
+		return nil
+	}
 	data := s.active.Format()
 	ts := time.Now()
 	seq := s.archiveSeq.Add(1)
+	s.archiveWG.Add(1)
 	s.mu.RUnlock()
+	// The write happens off-lock (writeArchive never touches s.mu, so a
+	// concurrent QuiesceArchival Wait()ing on archiveWG cannot deadlock on the
+	// store lock), and Done fires only after it completes so the JOIN covers
+	// the whole MkdirAll + atomic write.
+	defer s.archiveWG.Done()
+	// #6185: the same test-only seam the async writer uses, letting a test hold
+	// this synchronous writer MID-FLIGHT (past the fence check) to prove
+	// QuiesceArchival JOINS it before a wipe. Production is a no-op.
+	archiveWriteBarrier()
 	return writeArchive(archiveDir, maxArchives, data, ts, seq)
 }
 


### PR DESCRIPTION
## Summary

The #5869 archive-writer fence (merged as **#6182**) tracks and joins the **async** fire-and-forget `writeArchive` goroutine, so a factory reset (zeroize) can fence + drain outstanding writers **before** it erases the archive directory. Without it, a writer resuming after the wipe would `os.MkdirAll` the directory back and drop a `config-<ts>.<seq>.conf` snapshot of the **prior tenant's** full config text (cleartext IKE PSKs, WireGuard keys, SNMP communities) — re-tenant secret residue.

That fix covered only the async path. **`Store.ArchiveConfig` — the SYNCHRONOUS archive path — did NOT consult `archiveFenced` and was NOT tracked by `archiveWG`.** It has **zero production callers today**, so it is not a live vector, but it is a latent trap: if it is ever wired to an operator command (e.g. `request system configuration archive`) a call in the zeroize window would **bypass the fence** and recreate the archive dir after the wipe, reopening the #5869 residue for that path.

## Fix

Fence `ArchiveConfig` on `archiveFenced`, mirroring the async launch guard exactly:

- **No-op (`return nil`) when the fence is set** — a factory reset is erasing the archive directory, so do not recreate it.
- **When not fenced, `archiveWG.Add(1)` under `s.mu` guarded by `!archiveFenced`, then `Done()` after the off-lock write**, so a concurrent `QuiesceArchival` **JOINS** an in-flight synchronous write before the wipe. The fence read + `Add` run under the `RLock`, which is mutually exclusive with `QuiesceArchival`'s write-`Lock` fence-set, so the `Add`/`Wait` ordering stays race-free and the counter never rises from zero concurrently with `Wait`. `writeArchive` never touches `s.mu`, so the join cannot deadlock on the store lock.
- The synchronous path is routed through the existing `archiveWriteBarrier` test seam (production no-op) so the JOIN is deterministically testable.

## STEP 0

Confirmed on current `origin/master` (`506a38227`): `ArchiveConfig` at `store_persist.go:526` did **not** check `archiveFenced` and was **not** tracked by `archiveWG` — the gap the issue describes. Not already fixed.

## Test plan (`pkg/configstore/archiveconfig_fence_6185_test.go`, new)

- [x] `TestArchiveConfigFencedDoesNotRecreateArchiveDir` — **mandatory fail-on-revert**: `QuiesceArchival` sets the fence, then `ArchiveConfig` must NOT recreate the archive dir. Neutralizing the fence guard makes it **RED** (dir reappears with the prior-tenant snapshot). Verified under `-race`.
- [x] `TestArchiveConfigUnfencedArchivesNormally` — control: the un-fenced synchronous path still writes exactly one snapshot carrying the committed config text.
- [x] `TestQuiesceArchivalJoinsInflightSyncArchiveConfig` — pins the JOIN: the writer is held mid-flight **past** the fence check; `QuiesceArchival` must block joining it before the wipe. Removing `archiveWG.Add(1)` makes it **RED** (QuiesceArchival returns before joining).
- [x] `TestResumeArchivalReenablesCommitArchival` — **#6185 note 2**: fence archival, prove a fenced commit does NOT archive, `ResumeArchival` clears the fence, and a subsequent commit archives normally (WaitGroup reusable, no corrupt state). The prior fail-path test (`pkg/daemon` `factory_reset_5281_test.go`) drove a bare `Daemon{}` with a nil store — exercising the `d.store != nil` guard, NOT the real fence-clear.
- [x] `go build ./...`, `go vet ./pkg/configstore/...`, `go test -race ./pkg/configstore/...` (full suite) pass; **both** fail-on-revert targets verified RED; new tests pass **5× `-race` non-flake**.
- Control-plane lifecycle fix, no dataplane/forwarding surface — **no smoke**.

## Docs

- `docs/system-login.md` — extended the #5869 zeroize-contract bullet with the synchronous-path fence.
- `pkg/configstore/README.md` — added the archive-writer fence + join bullet to the zeroize section.

Closes #6185

🤖 Generated with [Claude Code](https://claude.com/claude-code)