### PR TITLE
userspace-dp: cap budgeted conntrack refresh walk to the live high-watermark (#6297)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-22 — #6297: cap budgeted conntrack refresh walk to the live high-watermark
+
+- **Timestamp**: 2026-07-22 (fix/6297-conntrack-refresh-watermark)
+- **Action**: `SessionTable::iter_with_idle_budgeted` bounded its round-robin
+  refresh walk to `entries.capacity()`. The slab is monotonic (no
+  `shrink_to_fit`), so after a session-count high-watermark drains, each 10s
+  cycle re-walked the full doubled capacity — mostly-vacant slots (#5287 M1
+  follow-up). Added a monotonic `slot_high_watermark` field (`1 + the highest
+  slot the slab ever handed out`), bumped on every insert via a new
+  `insert_record` choke point (fresh install, synced import, restore_entry),
+  never shrunk on removal. The walk now bounds to
+  `min(slot_high_watermark, capacity())`, wrapping at the peak live extent
+  instead of the doubled capacity. INVARIANT (documented on the field + walk):
+  the watermark is always `>= 1 + every occupied slot index`, so the shorter
+  walk can never skip a live session's `last_seen` refresh (which would look
+  idle → premature expiry). Added two fail-on-revert tests: (1) fill 100 /
+  drain to 3, assert a full budgeted sweep examines exactly the watermark and
+  `< capacity()` (reverting to `capacity()` reddens it — verified RED); (2) a
+  sole live session pinned at the top slot far above `len()` is still refreshed
+  by a full sweep (guards the never-below-a-live-slot invariant).
+- **Validation**: `cargo build --release` clean; `iter_with_idle` (5) +
+  `refresh` (38) + full `session::tests` (168) all green; both new tests 5/5
+  stable; temp-revert of the bound to `capacity()` confirmed the drain test
+  goes RED at the `examined < capacity` assertion.
+- **File(s)**: userspace-dp/src/session/mod.rs,
+  userspace-dp/src/session/install.rs, userspace-dp/src/session/lookup.rs,
+  userspace-dp/src/session/tests.rs, userspace-dp/src/session/README.md
+
 ## 2026-07-22 — #6114: mirror flow-cache HOT path samples before reserving
 
 - **Timestamp**: 2026-07-22 (fix/6114-mirror-sample-before-cas)

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -492,6 +492,18 @@ It is now an **incremental, budgeted slice** driven by
   `CT_REFRESH_WINDOW_NS` (10s). A small or idle table is walked in one short
   slice per 10s — the steady-state syscall rate is unchanged from the old 10s
   full-table cadence, so the common case is not regressed.
+- **Live-extent bound (#6297).** A cycle ends at the slab's live-extent
+  high-watermark (`SessionTable::slot_high_watermark` = `1 + the highest slot
+  index ever handed out`), NOT `entries.capacity()`. The slab never shrinks, so
+  after a session-count spike drains, `capacity()` stays at the doubled peak and
+  a capacity-bound walk would re-scan tens of thousands of now-vacant slots
+  every cycle. The watermark is bumped on every insert (`insert_record`) and is
+  never shrunk on removal. INVARIANT: it is always `>= 1 + every currently-
+  occupied slot index`, so bounding the walk to it can never skip a live
+  session's `last_seen` refresh (which would look idle and expire early). A
+  slightly-high watermark after a drain only costs a few skipped vacant visits;
+  a stale-LOW one would be a premature-expiry correctness bug, so the watermark
+  only ever grows.
 
 **Freshness/latency tradeoff.** At the 131072 default cap and 100ms cadence a
 full cycle spans ~64 slices (~6.4s ≤ the 10s freshness window), so the whole

--- a/userspace-dp/src/session/install.rs
+++ b/userspace-dp/src/session/install.rs
@@ -203,7 +203,10 @@ impl SessionTable {
                 session_id,
             },
         };
-        let raw = self.entries.insert(record);
+        // #6297: route every slab insert through `insert_record` so the
+        // live-extent high-watermark (the budgeted refresh walk's bound) is
+        // advanced to cover this new slot.
+        let raw = self.insert_record(record);
         let handle: u32 = raw.try_into().expect("slab handle exceeds u32");
         self.key_to_handle.insert(key.clone(), handle);
         self.index_forward_nat_key(&key, handle, decision, &metadata);
@@ -418,7 +421,10 @@ impl SessionTable {
                 session_id,
             },
         };
-        let raw = self.entries.insert(record);
+        // #6297: route every slab insert through `insert_record` so the
+        // live-extent high-watermark (the budgeted refresh walk's bound) is
+        // advanced to cover this new slot.
+        let raw = self.insert_record(record);
         let handle: u32 = raw.try_into().expect("slab handle exceeds u32");
         let index_key = key.clone();
         self.key_to_handle.insert(key, handle);

--- a/userspace-dp/src/session/lookup.rs
+++ b/userspace-dp/src/session/lookup.rs
@@ -479,10 +479,18 @@ impl SessionTable {
     /// packet-loop ticks.
     ///
     /// Returns the next cursor to resume from. It returns 0 once the walk
-    /// reaches the end of the slab's index space, i.e. a full-table cycle just
+    /// reaches the end of the LIVE EXTENT, i.e. a full-table cycle just
     /// completed — the caller uses that edge to pace the next cycle. A `cursor`
-    /// past the current end (the table/slab shrank since the last slice)
+    /// past the current end (the live extent shrank since the last slice)
     /// restarts the cycle from 0.
+    ///
+    /// #6297: the cycle end is `slot_high_watermark` (`1 + the highest slot
+    /// index the slab has ever handed out`), NOT `entries.capacity()`. The slab
+    /// never shrinks, so after a session-count spike drains, `capacity()` stays
+    /// at the doubled peak; walking to `capacity()` would re-scan tens of
+    /// thousands of now-vacant slots every cycle. The watermark tracks the true
+    /// live extent (always <= `capacity()`) and is >= 1 + every occupied slot
+    /// index, so a shorter walk still visits every live session.
     ///
     /// The budget counts examined slab SLOTS (occupied or vacant), not just
     /// forward entries, so both the index scan and the per-entry callback cost
@@ -497,14 +505,27 @@ impl SessionTable {
         now_ns: u64,
         mut f: impl FnMut(&SessionKey, SessionDecision, &SessionMetadata, u64, SessionCounters),
     ) -> usize {
-        let cap = self.entries.capacity();
-        // Empty slab or a degenerate zero budget: no progress, restart at 0 so
-        // the caller never gets wedged at a stale non-zero cursor.
+        // #6297: bound the round-robin walk to the live-extent
+        // high-watermark, NOT the monotonic `entries.capacity()`. The slab
+        // never shrinks, so after a session-count spike drains, `capacity()`
+        // stays at the doubled peak and this walk would re-visit tens of
+        // thousands of now-vacant slots every 10s cycle. `slot_high_watermark`
+        // is `1 + the highest slot the slab has ever handed out` (bumped on
+        // every insert via `insert_record`, never shrunk on removal) and is
+        // always <= `capacity()`, so the `min` is defensive. Because the
+        // watermark is >= 1 + every OCCUPIED slot index, no live session is
+        // ever above `cap` — a shorter walk can never skip an entry's
+        // last_seen refresh (which would look idle and expire early).
+        let cap = self.slot_high_watermark.min(self.entries.capacity());
+        // Empty slab (no slot ever handed out) or a degenerate zero budget: no
+        // progress, restart at 0 so the caller never gets wedged at a stale
+        // non-zero cursor.
         if cap == 0 || budget == 0 {
             return 0;
         }
-        // A cursor past the end (slab capacity shrank, or a stale save)
-        // restarts the cycle from the top rather than skipping the whole table.
+        // A cursor past the end (the live extent shrank below a saved cursor,
+        // or a stale save) restarts the cycle from the top rather than
+        // skipping the whole table.
         let start = if cursor >= cap { 0 } else { cursor };
         let end = start.saturating_add(budget).min(cap);
         for idx in start..end {

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -514,6 +514,26 @@ pub(crate) struct SessionTable {
     /// #964 Step 1: slab-allocated session storage. Indexed by u32
     /// handle. Replaces the prior `sessions: FxHashMap<Key, Entry>`.
     entries: slab::Slab<SessionRecord>,
+    /// #6297: high-watermark of the live slot extent — `1 + the highest
+    /// slot index this slab has ever handed out`. The budgeted conntrack
+    /// refresh (`iter_with_idle_budgeted`) bounds its round-robin walk to
+    /// this instead of `entries.capacity()`. The slab NEVER shrinks
+    /// (`capacity()` is monotonic, no `shrink_to_fit`), so after a
+    /// session-count spike drains, `capacity()` stays at the doubled peak
+    /// and the walk re-visits tens of thousands of now-vacant slots every
+    /// 10s cycle. The watermark tracks the true peak extent instead, which
+    /// is <= `capacity()` (the Vec doubles past the peak), so the walk
+    /// wraps at the live extent.
+    ///
+    /// INVARIANT: `slot_high_watermark >= 1 + every currently-occupied slot
+    /// index` at all times. Maintained by bumping it on every insert
+    /// (`insert_record`); it is NEVER shrunk on removal. A slightly-high
+    /// watermark only costs a few skipped vacant visits (safe), but if it
+    /// EVER dropped below a live slot, that session's `last_seen` would
+    /// stop being mirrored into the BPF conntrack map and the entry would
+    /// look idle — a premature-expiry correctness bug. So: only grow it,
+    /// never let it fall below an occupied slot.
+    slot_high_watermark: usize,
     /// #964 Step 1: forward-key → handle. Replaces the
     /// `sessions` HashMap's key-to-entry mapping.
     key_to_handle: SeededKeyMap<u32>,
@@ -690,6 +710,10 @@ impl SessionTable {
             // review finding) — the prior FxHashMap grew on demand,
             // so match that to keep baseline RSS unchanged.
             entries: slab::Slab::new(),
+            // #6297: no slots handed out yet — an empty slab has a live
+            // extent of 0, so the budgeted refresh walk is a no-op until
+            // the first install bumps this via `insert_record`.
+            slot_high_watermark: 0,
             // #2364: SessionKey-keyed indices use the per-boot secret seed
             // so attacker-chosen 5-tuples cannot construct collision chains.
             // `state` is the shared `FxSeededState` (carries the seed; a
@@ -941,6 +965,22 @@ impl SessionTable {
         self.max_sessions
     }
 
+    /// #6297 test helper: the monotonic backing-slab capacity. The budgeted
+    /// refresh walk deliberately does NOT bound to this after a drain — it
+    /// bounds to `slot_high_watermark` instead. Used by the fail-on-revert
+    /// test to assert the walk visits < `capacity()` slots.
+    #[cfg(test)]
+    pub(crate) fn entries_capacity_for_test(&self) -> usize {
+        self.entries.capacity()
+    }
+
+    /// #6297 test helper: the live-extent high-watermark the budgeted refresh
+    /// walk bounds to (`1 + the highest slot index ever handed out`).
+    #[cfg(test)]
+    pub(crate) fn slot_high_watermark_for_test(&self) -> usize {
+        self.slot_high_watermark
+    }
+
     /// #1760: cumulative NAT reverse-key displacement events on
     /// `nat_reverse_index` (see the field doc). Published per-worker on
     /// the ~1 Hz runtime cadence and aggregated into
@@ -955,6 +995,29 @@ impl SessionTable {
     // of the impl uses these short forms instead of repeating
     // `self.key_to_handle.get(key).and_then(|h| self.entries.get(*h as usize))`
     // throughout 30+ call sites.
+
+    /// #6297: insert a record into the session slab and advance the
+    /// live-extent high-watermark. This is the SOLE slab-insert choke
+    /// point so the `slot_high_watermark` invariant holds for every insert
+    /// path (fresh install, synced import, and the test-only
+    /// `restore_entry`). The slab hands back the slot index it used —
+    /// reusing a vacant slot from its free list when one exists, extending
+    /// the backing Vec otherwise — so `raw + 1` is the extent this record
+    /// occupies. Bumping the watermark to at least that guarantees
+    /// `slot_high_watermark >= 1 + every occupied slot index`, which the
+    /// budgeted refresh walk relies on to never skip a live session. Just a
+    /// compare-and-maybe-store on the hot install path; no allocation.
+    #[inline]
+    fn insert_record(&mut self, record: SessionRecord) -> usize {
+        let raw = self.entries.insert(record);
+        // Only grows, never shrinks — see the `slot_high_watermark` field
+        // doc for why a stale-low watermark would be a correctness bug but
+        // a slightly-high one is merely a few wasted vacant visits.
+        if raw + 1 > self.slot_high_watermark {
+            self.slot_high_watermark = raw + 1;
+        }
+        raw
+    }
 
     /// Resolve the slab handle for a forward-key direct lookup.
     /// Returns None if the key isn't installed.
@@ -1774,7 +1837,10 @@ impl SessionTable {
             key: key.clone(),
             entry,
         };
-        let raw = self.entries.insert(record);
+        // #6297: same slab-insert choke point as the production installs —
+        // keep the live-extent high-watermark correct even on this
+        // test-only restore path.
+        let raw = self.insert_record(record);
         let handle: u32 = raw.try_into().expect("slab handle exceeds u32");
         self.key_to_handle.insert(key.clone(), handle);
         // Clone metadata + decision out of the slab record for

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -3471,6 +3471,181 @@ fn iter_with_idle_budgeted_bounds_and_resumes_full_coverage() {
     assert_eq!(seen, installed, "one cycle must cover every forward entry");
 }
 
+/// #6297: drive `iter_with_idle_budgeted` a full cycle at budget=1 and return
+/// the number of slab SLOTS examined (occupied + vacant) over that cycle — i.e.
+/// the walk's effective bound. Budget=1 examines exactly slot `cursor` per call
+/// and returns `cursor + 1` (or 0 when that reaches the bound), so the call
+/// count equals the examined-slot count. Precondition: a non-empty walk extent
+/// (the empty-slab fast path returns 0 immediately, which this helper cannot
+/// distinguish from a 1-slot cycle).
+fn count_full_budgeted_sweep(table: &SessionTable, now_ns: u64) -> usize {
+    let mut cursor = 0usize;
+    let mut examined = 0usize;
+    // The extent can never exceed capacity(); cap the loop generously above it
+    // so a non-advancing cursor panics instead of spinning forever.
+    let guard = table.entries_capacity_for_test() + 8;
+    for _ in 0..guard {
+        let next = table.iter_with_idle_budgeted(cursor, 1, now_ns, |_, _, _, _, _| {});
+        examined += 1;
+        if next == 0 {
+            return examined;
+        }
+        cursor = next;
+    }
+    panic!("budgeted sweep did not complete within {guard} slices");
+}
+
+#[test]
+fn iter_with_idle_budgeted_bounds_to_high_watermark_after_drain() {
+    // #6297: the budgeted refresh walk must bound its round-robin sweep to the
+    // LIVE-EXTENT high-watermark (1 + the highest slot ever handed out), NOT the
+    // monotonic slab `capacity()`. The slab never shrinks, so after a
+    // session-count spike drains, `capacity()` overshoots the peak extent (the
+    // backing Vec doubles past it) and a capacity-bound walk re-scans vacant
+    // slots every cycle. Reverting the bound to `entries.capacity()` reddens the
+    // `examined < capacity` assertion below.
+    let mut table = SessionTable::new();
+
+    // Fill to a NON-power-of-two session count so the backing Vec's doubling
+    // leaves capacity() STRICTLY above the watermark (the peak extent).
+    const N: usize = 100;
+    let install_time = 1_000_000_000u64;
+    let mut keys = Vec::with_capacity(N);
+    for i in 0..N {
+        let mut key = key_v4();
+        key.src_port = 10_000 + i as u16; // distinct 5-tuples -> distinct entries
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_time,
+            PROTO_TCP,
+            0x10,
+        ));
+        // Fresh slab, no prior vacancies -> installs land at contiguous slots
+        // 0..N in call order.
+        assert_eq!(
+            table.handle_for_key(&key),
+            Some(i as u32),
+            "install {i} expected to land at slot {i}",
+        );
+        keys.push(key);
+    }
+
+    let watermark = table.slot_high_watermark_for_test();
+    let capacity = table.entries_capacity_for_test();
+    assert_eq!(watermark, N, "watermark must be 1 + the top occupied slot");
+    assert!(
+        capacity > watermark,
+        "test needs a doubling gap: capacity {capacity} must exceed watermark \
+         {watermark} (choose a non-power-of-two N)",
+    );
+
+    // Drain almost everything. capacity() AND the watermark are both monotonic,
+    // so they stay put; only len() collapses -> the mostly-vacant slab the issue
+    // describes.
+    for key in keys.iter().take(N - 3) {
+        table.delete(key);
+    }
+    assert_eq!(table.len(), 3, "drained to a near-empty table");
+    assert_eq!(
+        table.entries_capacity_for_test(),
+        capacity,
+        "slab capacity is monotonic — it never shrinks on drain",
+    );
+    assert_eq!(
+        table.slot_high_watermark_for_test(),
+        watermark,
+        "watermark is monotonic — not shrunk on removal (see the invariant)",
+    );
+
+    // Count the slots EXAMINED over one full cycle.
+    let now = install_time + 5_000_000_000;
+    let examined = count_full_budgeted_sweep(&table, now);
+
+    // THE fail-on-revert assertions: the walk stops at the live extent, not the
+    // doubled capacity.
+    assert_eq!(
+        examined, watermark,
+        "walk must examine exactly the high-watermark extent ({watermark}), got {examined}",
+    );
+    assert!(
+        examined < capacity,
+        "walk examined {examined} slots — must be < the monotonic capacity \
+         {capacity} (reverting the bound to capacity() breaks this)",
+    );
+}
+
+#[test]
+fn iter_with_idle_budgeted_never_skips_a_live_session_above_the_len() {
+    // #6297 correctness guard: the high-watermark bound must NEVER drop below a
+    // live slot, or that session's last_seen would stop being mirrored into the
+    // BPF conntrack map and the entry would look idle and expire early. Engineer
+    // a table whose SOLE live session sits at a high slot far above len(), then
+    // assert a full budgeted sweep still refreshes it. A bound that under-shot
+    // (e.g. to len()) would skip it.
+    let mut table = SessionTable::new();
+    const N: usize = 64;
+    let install_time = 1_000_000_000u64;
+    let mut keys = Vec::with_capacity(N);
+    for i in 0..N {
+        let mut key = key_v4();
+        key.src_port = 20_000 + i as u16;
+        assert!(table.install_with_protocol(
+            key.clone(),
+            decision(),
+            metadata(),
+            install_time,
+            PROTO_TCP,
+            0x10,
+        ));
+        assert_eq!(table.handle_for_key(&key), Some(i as u32));
+        keys.push(key);
+    }
+    let watermark = table.slot_high_watermark_for_test();
+    assert_eq!(watermark, N);
+
+    // Remove every session EXCEPT the one at the top slot (N-1). len() collapses
+    // to 1 while the live session stays at slot N-1, far above len().
+    let survivor = keys[N - 1].clone();
+    for key in keys.iter().take(N - 1) {
+        table.delete(key);
+    }
+    assert_eq!(table.len(), 1);
+    assert_eq!(
+        table.handle_for_key(&survivor),
+        Some((N - 1) as u32),
+        "survivor must still occupy the top slot",
+    );
+    // Watermark unchanged (monotonic) and strictly above the survivor's slot.
+    assert_eq!(table.slot_high_watermark_for_test(), watermark);
+    assert!(watermark > (N - 1));
+
+    // A full budgeted sweep MUST refresh the survivor.
+    let now = install_time + 5_000_000_000;
+    let mut cursor = 0usize;
+    let mut refreshed = false;
+    for _ in 0..(table.entries_capacity_for_test() + 8) {
+        let next = table.iter_with_idle_budgeted(cursor, 8, now, |k, _d, _m, _idle, _c| {
+            if k == &survivor {
+                refreshed = true;
+            }
+        });
+        cursor = next;
+        if cursor == 0 {
+            break;
+        }
+    }
+    assert!(
+        refreshed,
+        "the live session at slot {} (len={}, watermark={}) must be refreshed — \
+         the bound must never drop below a live slot",
+        N - 1,
+        table.len(),
+        watermark,
+    );
+}
+
 #[test]
 fn refresh_local_skips_peer_synced_entries() {
     let mut table = SessionTable::new();


### PR DESCRIPTION
## Problem

The budgeted conntrack refresh (`SessionTable::iter_with_idle_budgeted`,
driven by `refresh_bpf_conntrack_last_seen` at ~1 slice/100ms) bounded its
round-robin walk to `entries.capacity()`. The session slab is monotonic (no
`shrink_to_fit`), so after a session-count **high-watermark drains**,
`capacity()` stays at the doubled peak and every 10s cycle re-walks the full
historical capacity — revisiting tens of thousands of now-vacant slots
(`get(idx)` → `None`, skipped).

Vacant visits are syscall-free and the per-slice cost is hard-bounded at 2048
slots, so this is **wasted iteration, not a correctness bug** (#5287 M1
follow-up, MINOR efficiency).

## Fix

Track a live-extent high-watermark on the slab — `slot_high_watermark` =
`1 + the highest slot index the slab has ever handed out` — and bound the walk
to `min(slot_high_watermark, capacity())`, so the cursor wraps at the peak live
extent instead of the doubled capacity. Because the backing Vec doubles past
the peak, the watermark is strictly below `capacity()` whenever the peak
session count was not an exact power of two — the common sub-max drain scenario
the issue targets.

The watermark is maintained through a single `insert_record` slab-insert choke
point (fresh install, synced import, and the test-only `restore_entry` all
route through it): bumped on every insert, **never shrunk on removal**.

### Correctness invariant

> `slot_high_watermark >= 1 + every currently-occupied slot index` at all times.

Documented on the field and the walk. A slightly-high watermark after a drain
only costs a few skipped vacant visits (safe); a stale-**low** one would stop
refreshing a live session's `last_seen`, making it look idle and expire early —
a real correctness bug from a MINOR optimization. So the watermark only ever
grows.

## Tests (fail-on-revert)

- **`iter_with_idle_budgeted_bounds_to_high_watermark_after_drain`** — fill 100
  sessions / drain to 3, then assert a full budgeted sweep examines exactly the
  high-watermark extent and strictly fewer than `capacity()` slots. Reverting
  the bound to `entries.capacity()` reddens the `examined < capacity` assertion
  (verified RED locally).
- **`iter_with_idle_budgeted_never_skips_a_live_session_above_the_len`** — pin
  the sole surviving live session at the top slot far above `len()`, then assert
  a full sweep still refreshes it — guards the never-below-a-live-slot invariant
  against any future under-shoot.

## Validation

- `cargo build --release` clean.
- `iter_with_idle` (5), `refresh` (38), and the full `session::tests` module
  (168) all pass.
- Both new tests pass 5/5.
- Temp-revert of the bound to `capacity()` confirmed the drain test goes RED at
  the `examined < capacity` assertion.

Hot-path note: the only added hot-path cost is one integer compare (and a rare
store) per session install; the walk itself is unchanged apart from a cheaper
bound. Module doc updated in `userspace-dp/src/session/README.md`.

Closes #6297