### PR TITLE
afxdp/cos: drop per-packet Arc clones + settlement lease-return Vec alloc (#4972)

### DIFF
--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -264,13 +264,17 @@ fn build_nonexact_cos_batch(
     root_ifindex: i32,
     now_ns: u64,
 ) -> Option<CoSBatch> {
+    // #4972: borrow the shared exact-backlog `Arc` from the disjoint
+    // `cos_fast_interfaces` field rather than cloning it per non-exact
+    // batch build. It coexists with the `cos_interfaces` mutable borrow
+    // below — the same borrow-split `queue_fast_path` (a few lines down)
+    // already relies on.
     let shared_exact_backlog = binding
         .cos
         .cos_fast_interfaces
         .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_exact_backlog.clone());
+        .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref());
     let peer_exact_demand_mask = shared_exact_backlog
-        .as_ref()
         .map(|backlog| backlog.peer_exact_demand_queue_mask(binding.slot))
         .unwrap_or(0);
     // #4265 (R-2): the non-exact guarantee refill now routes through the
@@ -300,7 +304,7 @@ fn build_nonexact_cos_batch(
                 root,
                 now_ns,
                 exact_demand_rate,
-                shared_exact_backlog.as_deref(),
+                shared_exact_backlog.map(|backlog| &**backlog),
             );
             select_cos_surplus_batch_filtered(root, now_ns, true, nonexact_budget)
         })

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -434,18 +434,22 @@ pub(in crate::afxdp) fn prime_cos_root_for_service(
     root_ifindex: i32,
     now_ns: u64,
 ) -> bool {
+    // #4972: borrow the root lease from the disjoint `cos_fast_interfaces`
+    // field rather than cloning the `Arc` per prime call. The mutable
+    // borrow below is of the separate `cos_interfaces` field, so the
+    // read-borrow coexists (same borrow-split the exact paths use).
     let shared_root_lease = binding
         .cos
         .cos_fast_interfaces
         .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_root_lease.clone());
+        .and_then(|iface_fast| iface_fast.shared_root_lease.as_ref());
     let ticks_advanced;
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
             return false;
         };
         ticks_advanced = advance_cos_timer_wheel(root, now_ns);
-        if let Some(shared_root_lease) = shared_root_lease.as_ref() {
+        if let Some(shared_root_lease) = shared_root_lease {
             maybe_top_up_cos_root_lease(root, shared_root_lease, now_ns);
         }
     }
@@ -736,8 +740,15 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
 ) {
     let mut new_nonempty = 0usize;
     let mut new_runnable = 0usize;
-    // (queue_idx, worker_id, released_bytes)
-    let mut released_queue_leases = Vec::<(usize, usize, u64)>::new();
+    // (queue_idx, worker_id, released_bytes). #4972: reuse the per-binding
+    // scratch Vec instead of heap-allocating one per settle. `mem::take`
+    // swaps in an empty Vec (no alloc) and hands us the retained-capacity
+    // buffer; it is stored back at the end of the function. The deferred-
+    // return structure (lease re-credits run after the `cos_interfaces`
+    // mutable borrow ends) is preserved EXACTLY — only the allocation is
+    // removed.
+    let mut released_queue_leases = core::mem::take(&mut binding.cos.released_queue_leases_scratch);
+    released_queue_leases.clear();
     let old_nonempty = binding
         .cos
         .cos_interfaces
@@ -799,7 +810,7 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
         release_cos_root_lease(binding, root_ifindex);
     }
     if let Some(iface_fast) = binding.cos.cos_fast_interfaces.get(&root_ifindex) {
-        for (queue_idx, worker_id, released) in released_queue_leases {
+        for &(queue_idx, worker_id, released) in &released_queue_leases {
             if let Some(shared_queue_lease) = iface_fast
                 .queue_fast_path
                 .get(queue_idx)
@@ -811,6 +822,9 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
             }
         }
     }
+    // #4972: return the scratch buffer (with its retained capacity) so the
+    // next settle reuses the allocation instead of making a fresh one.
+    binding.cos.released_queue_leases_scratch = released_queue_leases;
 }
 
 #[inline]
@@ -833,11 +847,16 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     // the #915 rationale).
     let mut lease_consume_queue_idx = None;
     let binding_slot = binding.slot;
+    // #4972: borrow the shared exact-backlog `Arc` from the disjoint
+    // `cos_fast_interfaces` field instead of cloning it per settlement.
+    // The mutable borrow below is of `cos_interfaces` (a separate field),
+    // and `peer_exact_demand_queue_mask` takes `&BindingWorker`, so the
+    // read-borrow held across both is sound.
     let shared_exact_backlog = binding
         .cos
         .cos_fast_interfaces
         .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_exact_backlog.clone());
+        .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref());
     let peer_exact_backlogged = binding
         .cos
         .cos_fast_interfaces
@@ -894,7 +913,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
             maybe_demote_drained_best_effort(queue);
         }
         if debit_nonexact_surplus_budget {
-            if let Some(backlog) = shared_exact_backlog.as_ref() {
+            if let Some(backlog) = shared_exact_backlog {
                 backlog.consume_residual_surplus_budget(sent_bytes);
             } else {
                 root.nonexact_surplus_under_exact_tokens = root
@@ -947,11 +966,14 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     // the #915 rationale).
     let mut lease_consume_queue_idx = None;
     let binding_slot = binding.slot;
+    // #4972: borrow the shared exact-backlog `Arc` from the disjoint
+    // `cos_fast_interfaces` field instead of cloning it per settlement
+    // (see `apply_cos_send_result` for the borrow-split rationale).
     let shared_exact_backlog = binding
         .cos
         .cos_fast_interfaces
         .get(&root_ifindex)
-        .and_then(|iface_fast| iface_fast.shared_exact_backlog.clone());
+        .and_then(|iface_fast| iface_fast.shared_exact_backlog.as_ref());
     let peer_exact_backlogged = binding
         .cos
         .cos_fast_interfaces
@@ -1010,7 +1032,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
             maybe_demote_drained_best_effort(queue);
         }
         if debit_nonexact_surplus_budget {
-            if let Some(backlog) = shared_exact_backlog.as_ref() {
+            if let Some(backlog) = shared_exact_backlog {
                 backlog.consume_residual_surplus_budget(sent_bytes);
             } else {
                 root.nonexact_surplus_under_exact_tokens = root

--- a/userspace-dp/src/afxdp/tx/dispatch/cos.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/cos.rs
@@ -27,13 +27,18 @@ pub(super) fn cos_queue_fast_path_for_request<'a>(
 }
 
 #[inline]
-pub(super) fn cos_owner_live_for_request(
-    cos_fast_interfaces: &FastMap<i32, WorkerCoSInterfaceFastPath>,
+pub(super) fn cos_owner_live_for_request<'a>(
+    cos_fast_interfaces: &'a FastMap<i32, WorkerCoSInterfaceFastPath>,
     egress_ifindex: i32,
     requested_queue_id: Option<u8>,
-) -> Option<Arc<BindingLiveState>> {
+) -> Option<&'a Arc<BindingLiveState>> {
+    // #4972: return a borrow of the map-owned owner `Arc`, not a
+    // per-request clone. Both callers only need a reference — a
+    // pointer-eq (`Arc::ptr_eq`) and `enqueue_tx_owned(&self)` — so an
+    // owned `Arc` was a needless per-eligible-packet refcount bump on a
+    // cross-worker-shared atomic.
     cos_queue_fast_path_for_request(cos_fast_interfaces, egress_ifindex, requested_queue_id)
-        .and_then(|queue_fast| queue_fast.owner_live.clone())
+        .and_then(|queue_fast| queue_fast.owner_live.as_ref())
 }
 
 /// #1598 (secondary fix): does this request target a queue that runs
@@ -123,7 +128,7 @@ pub(super) fn enqueue_local_request_to_target_or_owner(
         req.cos_queue_id,
     );
     if let Some(owner_live) = owner_live {
-        if !Arc::ptr_eq(&owner_live, &target_binding.live) {
+        if !Arc::ptr_eq(owner_live, &target_binding.live) {
             return owner_live.enqueue_tx_owned(req);
         }
     }

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -742,7 +742,6 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                     request.decision.resolution.egress_ifindex,
                     request.cos_queue_id,
                 )
-                .as_ref()
                 .is_none_or(|live| Arc::ptr_eq(live, &target_binding.live));
 
                 /*

--- a/userspace-dp/src/afxdp/tx/dispatch/tests/cos_shared_exact.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/tests/cos_shared_exact.rs
@@ -166,3 +166,53 @@ fn shared_exact_policy_handles_unknown_queue() {
         "an unknown egress_ifindex must not be reported as shared_exact policy"
     );
 }
+
+#[test]
+fn cos_owner_live_for_request_borrows_map_owned_arc() {
+    // #4972: `cos_owner_live_for_request` now returns a *borrow* of the
+    // map-owned owner `Arc` rather than a per-eligible-packet clone. Both
+    // callers only need a reference — `enqueue_local_request_to_target_or_
+    // owner` for an `Arc::ptr_eq` + `enqueue_tx_owned(&self)`, and the
+    // in-place-rewrite `owner_matches_target` gate for a bare `Arc::ptr_eq`.
+    // The borrow-vs-clone distinction is a compile-time guarantee (the
+    // return type is `Option<&Arc<..>>`); this test pins the *contract*
+    // those callers depend on: the returned reference identifies the exact
+    // `Arc` stored in the fast-path table (ptr-eq true), so the routing
+    // decision is byte-identical to the pre-#4972 owned-clone behavior.
+    use crate::afxdp::tx::test_support::{test_cos_fast_interfaces, test_queue_fast_path};
+
+    let owner_live = Arc::new(BindingLiveState::new());
+    let other_live = Arc::new(BindingLiveState::new());
+    let ifaces = test_cos_fast_interfaces(
+        80,
+        11,
+        4,
+        vec![
+            (
+                4,
+                test_queue_fast_path(false, 7, Some(owner_live.clone()), None),
+            ),
+            (5, test_queue_fast_path(false, 7, None, None)),
+        ],
+        None,
+        None,
+    );
+
+    // Queue 4 has an owner: the returned reference is ptr-eq to the exact
+    // Arc held in the map (same allocation), not a distinct one.
+    let got = cos_owner_live_for_request(&ifaces, 80, Some(4)).expect("owner present");
+    assert!(
+        Arc::ptr_eq(got, &owner_live),
+        "must reference the map-owned owner Arc"
+    );
+    assert!(
+        !Arc::ptr_eq(got, &other_live),
+        "must not reference an unrelated Arc"
+    );
+
+    // Queue 5 has no owner: None (request funnels / stays local).
+    assert!(cos_owner_live_for_request(&ifaces, 80, Some(5)).is_none());
+    // Unknown queue id and unknown egress ifindex: None.
+    assert!(cos_owner_live_for_request(&ifaces, 80, Some(42)).is_none());
+    assert!(cos_owner_live_for_request(&ifaces, 999, Some(4)).is_none());
+}

--- a/userspace-dp/src/afxdp/worker/cos_state.rs
+++ b/userspace-dp/src/afxdp/worker/cos_state.rs
@@ -47,4 +47,11 @@ pub(crate) struct WorkerCos {
     /// under-grant attribution flushed from the guarantee-selector
     /// telemetry (`record_cos_queue_lease_acquire`).
     pub(crate) cos_queue_lease_undergrants: CoSQueueLeaseUndergrantCounters,
+    /// #4972: reusable scratch buffer for `refresh_cos_interface_activity`
+    /// deferred queue-lease returns `(queue_idx, worker_id, released_bytes)`.
+    /// The deferral is a borrow-order requirement (the returns run after the
+    /// `cos_interfaces` mutable borrow ends), but the buffer itself must not
+    /// heap-allocate per settle — it is `mem::take`n out, filled, drained by
+    /// reference, and stored back to retain capacity across calls.
+    pub(crate) released_queue_leases_scratch: Vec<(usize, usize, u64)>,
 }

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -543,6 +543,7 @@ impl BindingWorker {
                 cos_wheel_ticks_advanced_total: 0,
                 cos_wheel_ticks_advanced_max: 0,
                 cos_queue_lease_undergrants: CoSQueueLeaseUndergrantCounters::default(),
+                released_queue_leases_scratch: Vec::new(),
             },
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
@@ -691,6 +692,7 @@ impl BindingWorker {
                 cos_wheel_ticks_advanced_total: 0,
                 cos_wheel_ticks_advanced_max: 0,
                 cos_queue_lease_undergrants: CoSQueueLeaseUndergrantCounters::default(),
+                released_queue_leases_scratch: Vec::new(),
             },
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
@@ -812,6 +814,7 @@ impl BindingWorker {
                 cos_wheel_ticks_advanced_total: 0,
                 cos_wheel_ticks_advanced_max: 0,
                 cos_queue_lease_undergrants: CoSQueueLeaseUndergrantCounters::default(),
+                released_queue_leases_scratch: Vec::new(),
             },
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),


### PR DESCRIPTION
## Summary

Hot-path allocation reduction on the CoS TX path (#4972). Every eligible
forwarded packet and every TX-completion settlement was cloning
cross-worker-shared `Arc`s (refcount bumps on shared atomics) and one
settle path heap-allocated a Vec per call. Every clone was used only for
a `&self` read or an `Arc::ptr_eq`, and the leases/backlog live in a
struct field (`cos_fast_interfaces`) disjoint from the mutably-borrowed
`cos_interfaces` — so the reads become borrows via the same field split
`queue_service`/`queue_fast_path` already prove works.

**CoS behavior — shaping, ordering, lease accounting, cross-worker
settlement — is preserved EXACTLY.** No pointer-eq semantics, no
settlement outcome, no operation ordering changed; only the clones/allocs
were removed.

## Converted sites

| Site | Before | After |
|------|--------|-------|
| `tx/dispatch/cos.rs` `cos_owner_live_for_request` | `owner_live.clone()` per eligible packet | returns `Option<&Arc<..>>` borrowed from the map |
| `tx/dispatch/cos.rs` `enqueue_local_request_to_target_or_owner` | `Arc::ptr_eq(&owner_live, ..)` on owned clone | `Arc::ptr_eq(owner_live, ..)` on borrow; `enqueue_tx_owned(&self)` unchanged |
| `tx/dispatch/mod.rs` `owner_matches_target` gate | `.as_ref().is_none_or(ptr_eq)` on owned clone | `.is_none_or(ptr_eq)` directly on borrow |
| `cos/tx_completion.rs` `prime_cos_root_for_service` | `shared_root_lease.clone()` | `.as_ref()` held across the `cos_interfaces` timer-wheel mutation |
| `cos/tx_completion.rs` `apply_cos_send_result` (Local settle) | `shared_exact_backlog.clone()` | `.as_ref()` across `peer_exact_demand_queue_mask(&self)` + settle block |
| `cos/tx_completion.rs` `apply_cos_prepared_result` (Prepared settle) | `shared_exact_backlog.clone()` | `.as_ref()` (same split) |
| `cos/queue_service/mod.rs` `build_nonexact_cos_batch` | `shared_exact_backlog.clone()` per non-exact batch | `.as_ref()`, coexisting with the `cos_interfaces` mut borrow like the adjacent `queue_fast_path` slice |
| `cos/tx_completion.rs` `refresh_cos_interface_activity` | fresh `Vec<(usize,usize,u64)>` per settle | `mem::take`s a per-binding `WorkerCos` scratch buffer, drains by reference, stores it back (retains capacity) |

### Why the borrows are sound
`cos_fast_interfaces` (owner_live / shared_root_lease / shared_exact_backlog
source) and `cos_interfaces` (mutated during the settle) are distinct
struct fields, so a read-borrow of one coexists with a mutable borrow of
the other. The helpers held across the read-borrow
(`peer_exact_demand_queue_mask`, `publish_cos_exact_backlog`) take
`&BindingWorker`. All lease/backlog operations (`consume`, `publish`,
`peer_exact_demand_queue_mask`, `consume_residual_surplus_budget`,
`release_unused_v8`) and `enqueue_tx_owned` take `&self`.

### Vec reuse preserves ordering exactly
The deferred lease-return in `refresh_cos_interface_activity` is a
borrow-order requirement — the re-credits must run *after* the
`cos_interfaces` mutable borrow ends, strictly after
`publish_cos_exact_backlog` / `release_cos_root_lease`. That deferral and
its operation order are unchanged; only the per-call heap allocation is
eliminated by reusing a scratch buffer that keeps its capacity across
calls.

### Out of scope
`cos/cross_binding.rs` per-packet `frame.to_vec()` (#6310) and its
local `owner_live.clone()` are in functions this PR does not touch —
left alone per the issue scoping.

## Validation

- `cargo build --release`: clean (only the pre-existing crate warnings).
- Rust suites green against the change (single-threaded to avoid the
  unrelated known-flaky WG test): `cos` **585 passed** / 0 failed (incl.
  the new test), `dispatch` **63**, `tx_completion` **28**,
  `queue_service` **87**, `cross_binding` **24** — 0 failures.

### Fail-on-revert coverage (honest scope)
A "no allocation" property isn't directly unit-testable here. Added
`cos_owner_live_for_request_borrows_map_owned_arc`, which pins the
**ptr-eq contract** the two dispatch callers depend on: the returned
reference is `Arc::ptr_eq` to the exact map-owned `Arc` (and `None` for
an owner-less queue / unknown queue-id / unknown ifindex). The
borrow-vs-clone change is enforced at compile time by the `&Arc` return
type. The settlement clone->borrow and the Vec-reuse are behavior-
preserving by construction (identical `&self` calls, identical operation
order) and are covered indirectly by the green CoS settlement suites;
the **per-class CoS iperf smoke is the real validation** (parent-owned).

> [!NOTE]
> This is a CoS hot-path change — the parent will run the mandatory
> per-class CoS iperf smoke on the loss userspace cluster.

Closes #4972