### PR TITLE
daemon: parse PCI function field as decimal in enp naming

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56344,3 +56344,17 @@ top.
   #6312 (JSON resync id-drop), #6313 (reverse-materialize test).
 - **File(s)**: docs/sync-protocol.md, userspace-dp/src/session/README.md,
   userspace-dp/src/session/install.rs, userspace-dp/src/session/tests.rs
+
+## 2026-07-22 — #6204: pciAddrToEnp parses PCI function as decimal
+- **Action**: Fixed `pciAddrToEnp` (pkg/daemon/daemon_reth.go) to parse the PCI
+  FUNCTION field base-10 instead of base-16. systemd's ID_NET_NAME_PATH builtin
+  scans the sysfs address with `sscanf("%x:%x:%x.%u")` — domain/bus/slot HEX,
+  function DECIMAL — matching the kernel's `"%04x:%02x:%02x.%d"` sysfs naming
+  (verified against systemd source + kernel uapi/linux/pci.h). The prior hex
+  parse matched only for single-digit funcs 0-9; a func >= 10 (ARI / SR-IOV
+  multi-function, e.g. `0000:65:00.10`) was misread as 0x10=16 → enp101s0f16
+  instead of enp101s0f10, resolving the wrong RETH member. Corrected the
+  function's doc comment (it wrongly claimed all four fields were hex). Added a
+  fail-on-revert table test asserting func>=10 decimal names; reverting to
+  base-16 goes RED while func<10 rows stay green.
+- **File(s)**: pkg/daemon/daemon_reth.go, pkg/daemon/pci_enp_name_6204_test.go

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -119,9 +119,20 @@ func pciAddrFromPath(path string) string {
 // name is the bare enp<bus>s<slot>[f<func>]. On multi-PCI-domain hardware
 // (domain != 0, e.g. 10000:01:00.0) the domain disambiguates two NICs that sit
 // at the same bus/slot in different domains; dropping it here would collide
-// them onto one name and resolve the wrong RETH member. systemd scans the
-// sysfs address fields as hex and prints them decimal, so parse hex / render
-// decimal for every component (domain, bus, slot, func) to match.
+// them onto one name and resolve the wrong RETH member.
+//
+// Field bases must match systemd exactly. systemd's ID_NET_NAME_PATH builtin
+// parses the sysfs address with sscanf("%x:%x:%x.%u"): domain, bus and slot
+// are HEX, but the FUNCTION is DECIMAL. This mirrors the kernel, which formats
+// the sysfs PCI directory name as "%04x:%02x:%02x.%d" — hex domain/bus/slot,
+// decimal function. Every field is then rendered decimal in the name
+// (P%u / p%u / s%u / f%u). So: parse domain/bus/slot base-16, parse func
+// base-10, render all decimal. Parsing func as hex (the pre-#6204 bug) only
+// matched systemd for single-digit funcs 0-9 — where hex and decimal coincide
+// — but diverged for any func >= 10 (ARI / SR-IOV multi-function devices),
+// e.g. sysfs "0000:65:00.10" (func 10) would be misread as 0x10=16 and yield
+// enp101s0f16 instead of systemd's enp101s0f10, resolving the wrong RETH
+// member.
 func pciAddrToEnp(pciAddr string) string {
 	parts := strings.SplitN(pciAddr, ":", 3)
 	if len(parts) != 3 {
@@ -143,7 +154,10 @@ func pciAddrToEnp(pciAddr string) string {
 	if err != nil {
 		return ""
 	}
-	fn, err := strconv.ParseUint(sf[1], 16, 8)
+	// Function is DECIMAL in the sysfs name (kernel "%d", systemd "%u"),
+	// unlike the hex domain/bus/slot above. Parse base-10 to match. Base 8
+	// covers the full 8-bit ARI function range (0-255).
+	fn, err := strconv.ParseUint(sf[1], 10, 8)
 	if err != nil {
 		return ""
 	}

--- a/pkg/daemon/pci_enp_name_6204_test.go
+++ b/pkg/daemon/pci_enp_name_6204_test.go
@@ -1,0 +1,95 @@
+package daemon
+
+import "testing"
+
+// #6204: pciAddrToEnp must reproduce the exact predictable interface name
+// systemd assigns (ID_NET_NAME_PATH), because deriveKernelName feeds the
+// result into the RETH-member OriginalName= lookup. systemd parses the sysfs
+// PCI address with sscanf("%x:%x:%x.%u") — domain/bus/slot HEX, but the
+// FUNCTION DECIMAL — matching the kernel's "%04x:%02x:%02x.%d" sysfs naming.
+//
+// The pre-#6204 code parsed the function base-16. That coincided with systemd
+// only for single-digit functions 0-9 (where hex and decimal are identical),
+// but diverged for any function >= 10 (ARI / SR-IOV multi-function devices):
+// sysfs "0000:65:00.10" (decimal function 10) was misread as 0x10 = 16 and
+// produced enp101s0f16 instead of systemd's enp101s0f10, resolving the wrong
+// RETH member.
+//
+// FAIL-ON-REVERT: the func >= 10 cases below assert the DECIMAL name. Reverting
+// the function parse to base-16 (strconv.ParseUint(sf[1], 16, 8)) turns func
+// "10" into 16 and func "15" into 21, so those rows go RED.
+func TestPCIAddrToEnpFunctionIsDecimal(t *testing.T) {
+	tests := []struct {
+		name    string
+		pciAddr string
+		want    string
+	}{
+		// --- func >= 10: the #6204 regression guard (hex vs decimal diverge) ---
+		{
+			name:    "ARI function 10 renders decimal, not hex 0x10=16",
+			pciAddr: "0000:65:00.10",
+			want:    "enp101s0f10",
+		},
+		{
+			name:    "ARI function 15 renders decimal, not hex 0x15=21",
+			pciAddr: "0000:65:00.15",
+			want:    "enp101s0f15",
+		},
+		{
+			name:    "ARI function 42 on bus 0x08",
+			pciAddr: "0000:08:00.42",
+			want:    "enp8s0f42",
+		},
+		// --- func < 10: base-agnostic single digit, must still hold ---
+		{
+			name:    "func 0 is suppressed for a non-multifunction name",
+			pciAddr: "0000:08:00.0",
+			want:    "enp8s0",
+		},
+		{
+			name:    "single-digit func 3 unchanged",
+			pciAddr: "0000:08:00.3",
+			want:    "enp8s0f3",
+		},
+		{
+			name:    "single-digit func 7 (max standard PCI split) unchanged",
+			pciAddr: "0000:65:00.7",
+			want:    "enp101s0f7",
+		},
+		// --- domain/bus/slot stay HEX (unchanged by #6204) ---
+		{
+			name:    "hex bus 0x3b -> decimal 59",
+			pciAddr: "0000:3b:00.0",
+			want:    "enp59s0",
+		},
+		{
+			name:    "hex slot 0x1f -> decimal 31, func 1",
+			pciAddr: "0000:08:1f.1",
+			want:    "enp8s31f1",
+		},
+		{
+			name:    "non-zero domain prepended as decimal (hex 0x10000=65536)",
+			pciAddr: "10000:01:00.0",
+			want:    "enP65536p1s0",
+		},
+		{
+			name:    "non-zero domain with func 10 keeps decimal func",
+			pciAddr: "0001:65:00.10",
+			want:    "enP1p101s0f10",
+		},
+		// --- malformed input returns "" (unchanged) ---
+		{
+			name:    "missing function separator -> empty",
+			pciAddr: "0000:65:0000",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pciAddrToEnp(tt.pciAddr); got != tt.want {
+				t.Fatalf("pciAddrToEnp(%q) = %q, want %q", tt.pciAddr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem (#6204)

`pciAddrToEnp` (`pkg/daemon/daemon_reth.go`) synthesizes systemd's
`ID_NET_NAME_PATH` predictable interface name (`enp<bus>s<slot>f<func>`) so
`deriveKernelName` can match it against the live NIC for the RETH-member
`OriginalName=` lookup. The synthesized name **must** be bit-identical to what
systemd actually assigns, or the RETH member binds the wrong interface (or none).

**Root cause:** the function parsed the PCI **FUNCTION** field as hex:

```go
fn, err := strconv.ParseUint(sf[1], 16, 8)  // WRONG: function is decimal
```

systemd's builtin parses the sysfs address with `sscanf("%x:%x:%x.%u")` —
**domain/bus/slot are hex, but the function is decimal** — mirroring the kernel,
which formats the sysfs PCI directory name as `"%04x:%02x:%02x.%d"` (hex
domain/bus/slot, **decimal** function). Every field is then rendered decimal in
the name.

Parsing the function base-16 coincides with systemd only for single-digit
functions 0-9 (hex==decimal there) — every function on a standard 3-bit
`PCI_FUNC` device — so it went unnoticed. It **diverges for any function ≥ 10**,
the decimal range reachable on ARI / SR-IOV multi-function devices: sysfs
`0000:65:00.10` (function 10) was misread as `0x10 = 16` → `enp101s0f16`
instead of systemd's `enp101s0f10`, resolving the **wrong RETH member**.

The function's doc comment also wrongly asserted all four fields were hex — that
stale claim was the origin of the bug; it's corrected here.

## Fix

- Parse the function field **base-10** (domain/bus/slot stay base-16, which
  already matched systemd). Rendering was already decimal (`f%d`), so only the
  parse base changes.
- Correct the doc comment to state the exact per-field bases and why.

## Test (fail-on-revert)

New table test `TestPCIAddrToEnpFunctionIsDecimal` in
`pkg/daemon/pci_enp_name_6204_test.go`:

- **func ≥ 10 rows** assert the decimal name (`0000:65:00.10` → `enp101s0f10`,
  `.15` → `f15`, `.42` → `f42`). Reverting the parse to base-16 turns these into
  `f16`/`f21`/`f66` → **RED** (verified).
- **func < 10** (base-agnostic), **hex bus 0x3b→59 / slot 0x1f→31**, **non-zero
  domain**, and **func-0 suppression** rows pin the unchanged behavior and stay
  green under the revert.

## Validation

- `go build ./...` — clean
- `go test ./pkg/daemon/...` — pass; new test run 5× — pass
- `go vet ./pkg/daemon/` — clean
- Fail-on-revert confirmed: base-16 → 4 func≥10 rows RED, func<10 rows green
- Field bases verified against systemd `udev-builtin-net_id.c`
  (`get_pci_slot_specifiers`, `sscanf("%x:%x:%x.%u")`) and the kernel's
  `include/uapi/linux/pci.h`.

Pure string-parsing fix — no dataplane, wire, or config-schema impact, so no
cluster smoke required. It does affect live RETH/interface binding on hardware
with PCI function ≥ 10 (ARI/SR-IOV), where the pre-fix name pointed at the wrong
NIC. No separate doc file describes the PCI→enp parse algorithm; the function's
doc comment is that documentation and is updated in this change.

Closes #6204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1fpF8G8gfzoZrswo7FThz