### PR TITLE
userspace: fence neighbor replace with generation envelope + ACK/retry

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56344,3 +56344,28 @@ top.
   #6312 (JSON resync id-drop), #6313 (reverse-materialize test).
 - **File(s)**: docs/sync-protocol.md, userspace-dp/src/session/README.md,
   userspace-dp/src/session/install.rs, userspace-dp/src/session/tests.rs
+
+## 2026-07-22 — #6034 manager-neighbor replace-generation envelope + ACK/retry
+- **Action**: Follow-up to #5864 (clear-on-empty). Added defense-in-depth to the
+  manager→helper `update_neighbors` push: each authoritative replace now carries
+  a monotonic `neighbor_generation` (Go `Manager.neighborReplaceGen`); the Rust
+  `apply_manager_neighbors(replace, generation, ..)` FENCES a stale/reordered
+  replace (`generation <= applied_manager_generation`) without touching the
+  table and ACKs the applied generation in
+  `ProcessStatus.manager_neighbor_generation`. Both Go senders
+  (RegenerateNeighborSnapshot, BumpFIBGeneration) advance their cached neighbor
+  view only when the ACK confirms the replace landed, otherwise retain retry
+  debt (next regeneration re-diffs). Additive/backward-safe: generation 0
+  bypasses the fence; a missing ACK field decodes 0 → "assume applied". No new
+  control-socket caller; retry piggybacks the existing regeneration cadence.
+  Regenerated the wire golden fixture (one new `process_status` key). Added a Go
+  fail-on-revert test (envelope carry + retry-debt) and Rust fence unit tests.
+- **File(s)**: pkg/dataplane/userspace/{manager,manager_neighbor,manager_generation,protocol}.go,
+  pkg/dataplane/userspace/neighbor_replace_envelope_6034_test.go,
+  userspace-dp/src/protocol/control.rs,
+  userspace-dp/src/afxdp/coordinator/{mod,neighbor_manager,status}.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  userspace-dp/src/server/{helpers,lifecycle}.rs,
+  userspace-dp/src/server/handlers/{mod,neighbors}.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  userspace-dp/src/afxdp/README.md

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -85,16 +85,26 @@ func Boot() dataplane.RuntimeDataPlane {
 type Manager struct {
 	bpfShim *dataplane.Manager
 
-	mu           sync.Mutex
-	sessionMu    sync.Mutex // separate lock for session sync requests (Phase 3)
-	proc         *exec.Cmd
-	cfg          config.UserspaceConfig
-	clusterHA    bool
-	generation   uint64
-	syncCancel   context.CancelFunc
-	lastStatus   ProcessStatus
-	lastSnapshot *ConfigSnapshot
-	lastApply    *dataplane.ApplyResult
+	mu         sync.Mutex
+	sessionMu  sync.Mutex // separate lock for session sync requests (Phase 3)
+	proc       *exec.Cmd
+	cfg        config.UserspaceConfig
+	clusterHA  bool
+	generation uint64
+	// neighborReplaceGen is a dedicated monotonic counter for the #6034
+	// manager-neighbor replace-generation envelope. Every authoritative
+	// update_neighbors replace (RegenerateNeighborSnapshot, BumpFIBGeneration)
+	// allocates the next value and stamps it on the ControlRequest so the
+	// helper can fence a stale/reordered replace and ACK the applied
+	// generation. Distinct from `generation` (the config-snapshot counter):
+	// this only advances on a neighbor push and is never reused, so a retry
+	// always carries a strictly higher generation. Guarded by m.mu (both
+	// senders hold it across the send).
+	neighborReplaceGen uint64
+	syncCancel         context.CancelFunc
+	lastStatus         ProcessStatus
+	lastSnapshot       *ConfigSnapshot
+	lastApply          *dataplane.ApplyResult
 	// lastSnapshotRejectReasons holds the #3261 diagnostic: the reasons the
 	// most recently built snapshot carries unrepresentable policy content that
 	// the helper integrity preflight rejects (previous-good retained, or

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -247,6 +247,9 @@ type Manager struct {
 	// readback faults without a privileged BPF map (#5486). Production leaves
 	// it nil.
 	disableCtrlMapHook ctrlMapUpdater
+	// controlRequestHook replaces requestLocked in unit tests that exercise
+	// manager state transitions without opening a Unix control socket.
+	controlRequestHook func(ControlRequest, *ProcessStatus) error
 
 	// addrListForLocalSyncHook, when non-nil, replaces netlink.AddrList in
 	// buildDesiredLocalAddressSets so tests can inject a transient

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -430,6 +430,14 @@ func (m *Manager) publishSnapshotFailClosedLocked(publishSnap *ConfigSnapshot, s
 		}
 		return publishErr
 	}
+	// #6034: apply_snapshot returns the helper's current neighbor-replace
+	// generation. Seed from that response before returning to Compile, which
+	// exposes m.lastSnapshot (and therefore enables RegenerateNeighborSnapshot)
+	// immediately afterward. Waiting for statusLoop's first 1s tick leaves a
+	// window where a surviving helper can fence this manager's generation 1.
+	if status != nil {
+		m.seedNeighborReplaceGenerationLocked(status.ManagerNeighborGeneration)
+	}
 	return nil
 }
 

--- a/pkg/dataplane/userspace/manager_generation.go
+++ b/pkg/dataplane/userspace/manager_generation.go
@@ -85,13 +85,26 @@ func (m *Manager) BumpFIBGeneration() (uint32, error) {
 	newNeighbors := buildNeighborSnapshots(m.lastSnapshot.Config)
 	if !neighborsEqualForwarding(m.lastSnapshot.Neighbors, newNeighbors) {
 		publishable := filterPublishableNeighbors(newNeighbors)
+		// #6034: stamp a fresh monotonic replace generation (see
+		// RegenerateNeighborSnapshot / Manager.neighborReplaceGen).
+		m.neighborReplaceGen++
+		gen := m.neighborReplaceGen
 		var status ProcessStatus
 		if err := m.requestLocked(ControlRequest{
-			Type:            "update_neighbors",
-			Neighbors:       publishable,
-			NeighborReplace: true,
+			Type:               "update_neighbors",
+			Neighbors:          publishable,
+			NeighborReplace:    true,
+			NeighborGeneration: gen,
 		}, &status); err != nil {
 			slog.Warn("userspace: failed to publish neighbor update", "err", err)
+		} else if status.ManagerNeighborGeneration != 0 && status.ManagerNeighborGeneration < gen {
+			// #6034: the helper fenced this replace as stale. Retain the
+			// cached neighbor view so the next bump re-diffs and retries
+			// with a strictly higher generation. An ACK of 0 = older helper
+			// without ACK support, treated as applied.
+			slog.Warn("userspace: neighbor update not acknowledged; retaining retry debt",
+				"sent_generation", gen,
+				"applied_generation", status.ManagerNeighborGeneration)
 		} else {
 			// Only update cached neighbors after successful publish so
 			// a transient failure doesn't suppress future retries.

--- a/pkg/dataplane/userspace/manager_neighbor.go
+++ b/pkg/dataplane/userspace/manager_neighbor.go
@@ -28,6 +28,15 @@ func filterPublishableNeighbors(neighbors []NeighborSnapshot) []NeighborSnapshot
 	return out
 }
 
+// seedNeighborReplaceGenerationLocked advances the manager's replace counter
+// to the helper's applied-generation fence without ever moving it backwards.
+// Caller must hold m.mu.
+func (m *Manager) seedNeighborReplaceGenerationLocked(appliedGeneration uint64) {
+	if appliedGeneration > m.neighborReplaceGen {
+		m.neighborReplaceGen = appliedGeneration
+	}
+}
+
 // rebuildNeighborIndex updates m.neighborIndex from the current
 // m.lastSnapshot.Neighbors slice. Caller MUST hold m.mu. Called
 // after every assignment to lastSnapshot.Neighbors.

--- a/pkg/dataplane/userspace/manager_neighbor.go
+++ b/pkg/dataplane/userspace/manager_neighbor.go
@@ -90,13 +90,31 @@ func (m *Manager) RegenerateNeighborSnapshot() {
 		return
 	}
 	publishable := filterPublishableNeighbors(newNeighbors)
+	// #6034: stamp a fresh monotonic replace generation so the helper can
+	// fence a stale/reordered replace and ACK the applied generation.
+	m.neighborReplaceGen++
+	gen := m.neighborReplaceGen
 	var status ProcessStatus
 	if err := m.requestLocked(ControlRequest{
-		Type:            "update_neighbors",
-		Neighbors:       publishable,
-		NeighborReplace: true,
+		Type:               "update_neighbors",
+		Neighbors:          publishable,
+		NeighborReplace:    true,
+		NeighborGeneration: gen,
 	}, &status); err != nil {
 		slog.Warn("userspace: failed to publish neighbor regeneration", "err", err)
+		return
+	}
+	// #6034: retain retry debt if the helper did not acknowledge applying
+	// this replace generation. A helper that supports the ACK echoes the
+	// applied generation; a value below `gen` means it fenced the replace
+	// as stale, so we leave the cached neighbor view untouched and the next
+	// regeneration re-diffs and retries with a strictly higher generation.
+	// An ACK of 0 means an older helper without ACK support — assume applied
+	// (preserves pre-#6034 behavior).
+	if status.ManagerNeighborGeneration != 0 && status.ManagerNeighborGeneration < gen {
+		slog.Warn("userspace: neighbor regeneration not acknowledged; retaining retry debt",
+			"sent_generation", gen,
+			"applied_generation", status.ManagerNeighborGeneration)
 		return
 	}
 	m.lastSnapshot.Neighbors = newNeighbors

--- a/pkg/dataplane/userspace/neighbor_replace_envelope_6034_test.go
+++ b/pkg/dataplane/userspace/neighbor_replace_envelope_6034_test.go
@@ -128,6 +128,97 @@ func TestNeighborReplaceEnvelopeCarriesGenerationAndRetainsRetryDebt(t *testing.
 	}
 }
 
+// TestNeighborReplaceGenerationSeedsFromStartupResponseBeforeFirstPush guards
+// the pre-status-tick startup window from #6034. Compile's successful initial
+// apply_snapshot response already carries the surviving helper's replace fence;
+// publishSnapshotFailClosedLocked must consume it before Compile exposes
+// m.lastSnapshot and a neighbor event can trigger the first replace.
+//
+// No status loop is started here. Reverting the startup-response seed makes the
+// first update_neighbors carry generation 1, which the modeled helper fences at
+// 100 while ACKing 100 (the false-success case that prompted this regression).
+func TestNeighborReplaceGenerationSeedsFromStartupResponseBeforeFirstPush(t *testing.T) {
+	const helperFence uint64 = 100
+
+	var (
+		helperMu   sync.Mutex
+		appliedGen uint64 = helperFence
+		requests   []ControlRequest
+	)
+	requestHook := func(req ControlRequest, status *ProcessStatus) error {
+		helperMu.Lock()
+		requests = append(requests, req)
+		if req.Type == "update_neighbors" && req.NeighborGeneration > appliedGen {
+			appliedGen = req.NeighborGeneration
+		}
+		reply := appliedGen
+		helperMu.Unlock()
+		if status != nil {
+			*status = ProcessStatus{PID: 4321, ManagerNeighborGeneration: reply}
+		}
+		return nil
+	}
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.controlRequestHook = requestHook
+	if m.neighborReplaceGen != 0 {
+		t.Fatalf("new manager neighborReplaceGen = %d, want reset value 0", m.neighborReplaceGen)
+	}
+
+	seededNeighbor := NeighborSnapshot{
+		Ifindex: 13,
+		Family:  "inet",
+		IP:      "172.16.80.200",
+		MAC:     "02:aa:bb:cc:dd:ee",
+		State:   "reachable",
+	}
+	startupSnapshot := &ConfigSnapshot{
+		Version:    ProtocolVersion,
+		Generation: 1,
+		Config:     &config.Config{},
+		Neighbors:  []NeighborSnapshot{seededNeighbor},
+	}
+
+	// Mirror Compile's startup ordering under m.mu: consume the successful
+	// apply_snapshot response first, then expose lastSnapshot. There is
+	// deliberately no statusLoop tick between exposure and regeneration.
+	m.mu.Lock()
+	var startupStatus ProcessStatus
+	if err := m.publishSnapshotFailClosedLocked(startupSnapshot, &startupStatus, false); err != nil {
+		m.mu.Unlock()
+		t.Fatalf("startup apply_snapshot: %v", err)
+	}
+	m.lastSnapshot = startupSnapshot
+	m.generation = startupSnapshot.Generation
+	m.mu.Unlock()
+
+	m.RegenerateNeighborSnapshot()
+
+	helperMu.Lock()
+	gotRequests := append([]ControlRequest(nil), requests...)
+	gotApplied := appliedGen
+	helperMu.Unlock()
+	if len(gotRequests) != 2 {
+		t.Fatalf("control requests = %d, want apply_snapshot then update_neighbors: %+v", len(gotRequests), gotRequests)
+	}
+	if gotRequests[0].Type != "apply_snapshot" || gotRequests[1].Type != "update_neighbors" {
+		t.Fatalf("control request order = %q, %q; want apply_snapshot, update_neighbors",
+			gotRequests[0].Type, gotRequests[1].Type)
+	}
+	if got := gotRequests[1].NeighborGeneration; got != helperFence+1 {
+		t.Fatalf("pre-status-tick first neighbor replace generation = %d, want %d (startup fence %d + 1)",
+			got, helperFence+1, helperFence)
+	}
+	if gotApplied != helperFence+1 {
+		t.Fatalf("helper applied generation = %d, want %d", gotApplied, helperFence+1)
+	}
+}
+
 // TestNeighborReplaceGenerationSeedsFromFirstStatus is the restart guard for
 // #6034. A new Manager starts its in-memory replace counter at zero, while a
 // surviving helper can retain a much higher applied-generation fence. The

--- a/pkg/dataplane/userspace/neighbor_replace_envelope_6034_test.go
+++ b/pkg/dataplane/userspace/neighbor_replace_envelope_6034_test.go
@@ -1,0 +1,150 @@
+package userspace
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestNeighborReplaceEnvelopeCarriesGenerationAndRetainsRetryDebt is the #6034
+// fail-on-revert guard for the manager-neighbor replace-generation envelope.
+//
+// It binds BOTH halves of the mechanism:
+//
+//   - ENVELOPE CARRY: an authoritative update_neighbors replace must stamp the
+//     monotonic Manager.neighborReplaceGen onto ControlRequest.NeighborGeneration
+//     so the helper can fence a stale/reordered replace and ACK the applied
+//     generation. Reverting the NeighborGeneration stamp makes the captured
+//     request carry generation 0 and fails the carry assertion.
+//
+//   - RETRY DEBT: when the helper's ACK (ProcessStatus.ManagerNeighborGeneration)
+//     is BELOW the sent generation — i.e. the replace was fenced as stale — the
+//     manager must NOT advance its cached neighbor view, so the next
+//     regeneration re-diffs and retries. Reverting the ACK check makes the
+//     manager advance m.lastSnapshot.Neighbors even on a non-ack and fails the
+//     debt assertion. The complementary sub-case proves a matching ACK DOES
+//     advance the cached view (so the guard cannot be satisfied by never
+//     advancing).
+//
+// The publish path is driven deterministically without kernel neighbor state:
+// a config with no interfaces makes buildNeighborSnapshots return nil, so a
+// seeded non-empty lastSnapshot.Neighbors always diffs and triggers the replace.
+func TestNeighborReplaceEnvelopeCarriesGenerationAndRetainsRetryDebt(t *testing.T) {
+	dir := t.TempDir()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	defer ln.Close()
+
+	var (
+		mu       sync.Mutex
+		requests []ControlRequest
+		ackGen   uint64 // ManagerNeighborGeneration the fake helper reports
+	)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req ControlRequest
+			if err := json.NewDecoder(conn).Decode(&req); err != nil {
+				conn.Close()
+				continue
+			}
+			mu.Lock()
+			requests = append(requests, req)
+			reply := ackGen
+			mu.Unlock()
+			_ = json.NewEncoder(conn).Encode(ControlResponse{
+				OK:     true,
+				Status: &ProcessStatus{PID: 4321, ManagerNeighborGeneration: reply},
+			})
+			conn.Close()
+		}
+	}()
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+
+	seeded := NeighborSnapshot{
+		Ifindex: 13,
+		Family:  "inet",
+		IP:      "172.16.80.200",
+		MAC:     "02:aa:bb:cc:dd:ee",
+		State:   "reachable",
+	}
+
+	newManager := func(ack uint64) *Manager {
+		m := New()
+		m.proc = &exec.Cmd{Process: proc}
+		m.cfg.ControlSocket = controlSock
+		// Empty config -> buildNeighborSnapshots returns nil, so the seeded
+		// (publishable) neighbor always diffs and triggers the replace.
+		m.lastSnapshot = &ConfigSnapshot{
+			Version:    ProtocolVersion,
+			Generation: 1,
+			Config:     &config.Config{},
+			Neighbors:  []NeighborSnapshot{seeded},
+		}
+		m.generation = 1
+		// Pre-seed so the next allocated replace generation is 5 (lets the
+		// debt case report a non-zero ACK of 4 that is strictly below it).
+		m.neighborReplaceGen = 4
+		mu.Lock()
+		ackGen = ack
+		mu.Unlock()
+		return m
+	}
+
+	lastRequestGen := func() uint64 {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(requests) == 0 {
+			t.Fatalf("no update_neighbors request was sent")
+		}
+		return requests[len(requests)-1].NeighborGeneration
+	}
+
+	// --- Sub-case 1: helper fences the replace (ACK below sent gen) ---------
+	// Manager must retain retry debt: cached neighbor view stays seeded.
+	debtMgr := newManager(4)
+	debtMgr.RegenerateNeighborSnapshot()
+
+	if got := lastRequestGen(); got != 5 {
+		t.Fatalf("ENVELOPE CARRY revert: update_neighbors NeighborGeneration = %d, want 5", got)
+	}
+	debtMgr.mu.Lock()
+	debtNeighbors := append([]NeighborSnapshot(nil), debtMgr.lastSnapshot.Neighbors...)
+	debtMgr.mu.Unlock()
+	if len(debtNeighbors) != 1 || debtNeighbors[0] != seeded {
+		t.Fatalf("RETRY DEBT revert: after a fenced replace (ACK 4 < sent 5) lastSnapshot.Neighbors = %+v, "+
+			"want the seeded entry retained so the next regeneration retries", debtNeighbors)
+	}
+
+	// --- Sub-case 2: helper acknowledges the applied generation ------------
+	// Manager must advance its cached view to the new (empty) set.
+	okMgr := newManager(5)
+	okMgr.RegenerateNeighborSnapshot()
+
+	if got := lastRequestGen(); got != 5 {
+		t.Fatalf("ENVELOPE CARRY: update_neighbors NeighborGeneration = %d, want 5", got)
+	}
+	okMgr.mu.Lock()
+	okNeighbors := append([]NeighborSnapshot(nil), okMgr.lastSnapshot.Neighbors...)
+	okMgr.mu.Unlock()
+	if len(okNeighbors) != 0 {
+		t.Fatalf("acknowledged replace (ACK 5 >= sent 5) must advance the cached neighbor view to empty, "+
+			"got %+v", okNeighbors)
+	}
+}

--- a/pkg/dataplane/userspace/neighbor_replace_envelope_6034_test.go
+++ b/pkg/dataplane/userspace/neighbor_replace_envelope_6034_test.go
@@ -1,13 +1,12 @@
 package userspace
 
 import (
-	"encoding/json"
-	"net"
+	"context"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -36,41 +35,21 @@ import (
 // a config with no interfaces makes buildNeighborSnapshots return nil, so a
 // seeded non-empty lastSnapshot.Neighbors always diffs and triggers the replace.
 func TestNeighborReplaceEnvelopeCarriesGenerationAndRetainsRetryDebt(t *testing.T) {
-	dir := t.TempDir()
-	controlSock := filepath.Join(dir, "control.sock")
-	ln, err := net.Listen("unix", controlSock)
-	if err != nil {
-		t.Fatalf("listen control socket: %v", err)
-	}
-	defer ln.Close()
-
 	var (
 		mu       sync.Mutex
 		requests []ControlRequest
 		ackGen   uint64 // ManagerNeighborGeneration the fake helper reports
 	)
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			var req ControlRequest
-			if err := json.NewDecoder(conn).Decode(&req); err != nil {
-				conn.Close()
-				continue
-			}
-			mu.Lock()
-			requests = append(requests, req)
-			reply := ackGen
-			mu.Unlock()
-			_ = json.NewEncoder(conn).Encode(ControlResponse{
-				OK:     true,
-				Status: &ProcessStatus{PID: 4321, ManagerNeighborGeneration: reply},
-			})
-			conn.Close()
+	requestHook := func(req ControlRequest, status *ProcessStatus) error {
+		mu.Lock()
+		requests = append(requests, req)
+		reply := ackGen
+		mu.Unlock()
+		if status != nil {
+			*status = ProcessStatus{PID: 4321, ManagerNeighborGeneration: reply}
 		}
-	}()
+		return nil
+	}
 
 	proc, err := os.FindProcess(os.Getpid())
 	if err != nil {
@@ -88,7 +67,7 @@ func TestNeighborReplaceEnvelopeCarriesGenerationAndRetainsRetryDebt(t *testing.
 	newManager := func(ack uint64) *Manager {
 		m := New()
 		m.proc = &exec.Cmd{Process: proc}
-		m.cfg.ControlSocket = controlSock
+		m.controlRequestHook = requestHook
 		// Empty config -> buildNeighborSnapshots returns nil, so the seeded
 		// (publishable) neighbor always diffs and triggers the replace.
 		m.lastSnapshot = &ConfigSnapshot{
@@ -146,5 +125,120 @@ func TestNeighborReplaceEnvelopeCarriesGenerationAndRetainsRetryDebt(t *testing.
 	if len(okNeighbors) != 0 {
 		t.Fatalf("acknowledged replace (ACK 5 >= sent 5) must advance the cached neighbor view to empty, "+
 			"got %+v", okNeighbors)
+	}
+}
+
+// TestNeighborReplaceGenerationSeedsFromFirstStatus is the restart guard for
+// #6034. A new Manager starts its in-memory replace counter at zero, while a
+// surviving helper can retain a much higher applied-generation fence. The
+// first status poll must seed the manager from that fence before the next
+// replace is allocated, so the helper accepts generation 101 rather than
+// fencing generation 1.
+func TestNeighborReplaceGenerationSeedsFromFirstStatus(t *testing.T) {
+	var (
+		helperMu   sync.Mutex
+		appliedGen uint64 = 100
+	)
+	statusSeen := make(chan struct{}, 1)
+	neighborReq := make(chan ControlRequest, 1)
+	requestHook := func(req ControlRequest, status *ProcessStatus) error {
+		helperMu.Lock()
+		switch req.Type {
+		case "status":
+			select {
+			case statusSeen <- struct{}{}:
+			default:
+			}
+		case "update_neighbors":
+			// Model the helper's strict fence: only a generation above the
+			// persisted high-water mark is applied.
+			if req.NeighborGeneration > appliedGen {
+				appliedGen = req.NeighborGeneration
+			}
+			select {
+			case neighborReq <- req:
+			default:
+			}
+		}
+		reply := appliedGen
+		helperMu.Unlock()
+		if status != nil {
+			*status = ProcessStatus{PID: 4321, ManagerNeighborGeneration: reply}
+		}
+		return nil
+	}
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	m := New()
+	m.proc = &exec.Cmd{Process: proc}
+	m.controlRequestHook = requestHook
+	if m.neighborReplaceGen != 0 {
+		t.Fatalf("new manager neighborReplaceGen = %d, want reset value 0", m.neighborReplaceGen)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		m.statusLoop(ctx)
+		close(loopDone)
+	}()
+	select {
+	case <-statusSeen:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-loopDone
+		t.Fatal("timed out waiting for first helper status poll")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		m.mu.Lock()
+		seededGen := m.neighborReplaceGen
+		m.mu.Unlock()
+		if seededGen == 100 {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			<-loopDone
+			t.Fatalf("neighborReplaceGen after first status = %d, want seeded helper generation 100", seededGen)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-loopDone
+
+	seededNeighbor := NeighborSnapshot{
+		Ifindex: 13,
+		Family:  "inet",
+		IP:      "172.16.80.200",
+		MAC:     "02:aa:bb:cc:dd:ee",
+		State:   "reachable",
+	}
+	m.lastSnapshot = &ConfigSnapshot{
+		Version:    ProtocolVersion,
+		Generation: 1,
+		Config:     &config.Config{},
+		Neighbors:  []NeighborSnapshot{seededNeighbor},
+	}
+	m.generation = 1
+	m.RegenerateNeighborSnapshot()
+
+	select {
+	case req := <-neighborReq:
+		if req.NeighborGeneration != 101 {
+			t.Fatalf("first neighbor replace generation = %d, want 101 (helper fence 100 + 1)", req.NeighborGeneration)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for neighbor replace")
+	}
+	helperMu.Lock()
+	gotApplied := appliedGen
+	helperMu.Unlock()
+	if gotApplied != 101 {
+		t.Fatalf("helper applied generation = %d, want 101", gotApplied)
 	}
 }

--- a/pkg/dataplane/userspace/process_control.go
+++ b/pkg/dataplane/userspace/process_control.go
@@ -217,6 +217,9 @@ func (m *Manager) requestSessionSync(req ControlRequest) error {
 }
 
 func (m *Manager) requestLocked(req ControlRequest, status *ProcessStatus) error {
+	if m.controlRequestHook != nil {
+		return m.controlRequestHook(req, status)
+	}
 	resp, err := m.requestDetailedLocked(req)
 	if err != nil {
 		return err

--- a/pkg/dataplane/userspace/process_status.go
+++ b/pkg/dataplane/userspace/process_status.go
@@ -165,6 +165,13 @@ func (m *Manager) statusLoop(ctx context.Context) {
 			prevActiveSig := activeHAGroupSignature(m.haGroups)
 			var status ProcessStatus
 			if err := m.requestLocked(ControlRequest{Type: "status"}, &status); err == nil {
+				// #6034: the helper's replace-generation fence can outlive this
+				// Manager (for example across a future reconnect/ISSU). Resume from
+				// its applied generation before any reconciliation on this tick can
+				// publish another neighbor replace. m.mu is held for the whole poll.
+				if status.ManagerNeighborGeneration > m.neighborReplaceGen {
+					m.neighborReplaceGen = status.ManagerNeighborGeneration
+				}
 				if err := m.applyHelperStatusLocked(&status); err != nil {
 					slog.Warn("userspace dataplane status sync failed", "err", err)
 				} else {

--- a/pkg/dataplane/userspace/process_status.go
+++ b/pkg/dataplane/userspace/process_status.go
@@ -169,9 +169,7 @@ func (m *Manager) statusLoop(ctx context.Context) {
 				// Manager (for example across a future reconnect/ISSU). Resume from
 				// its applied generation before any reconciliation on this tick can
 				// publish another neighbor replace. m.mu is held for the whole poll.
-				if status.ManagerNeighborGeneration > m.neighborReplaceGen {
-					m.neighborReplaceGen = status.ManagerNeighborGeneration
-				}
+				m.seedNeighborReplaceGenerationLocked(status.ManagerNeighborGeneration)
 				if err := m.applyHelperStatusLocked(&status); err != nil {
 					slog.Warn("userspace dataplane status sync failed", "err", err)
 				} else {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1427,14 +1427,26 @@ type ProcessStatus struct {
 	// boundary), and post-preflight partial-install residuals (expected
 	// 0 forever; nonzero = preflight/install pairing bug). omitempty for
 	// mixed Rust/Go daemon back-compat (older helpers omit the keys).
-	SessionCreateDrops             uint64      `json:"session_create_drops,omitempty"`
-	SessionInstallAdmissionRefused uint64      `json:"session_install_admission_refused,omitempty"`
-	SessionInstallPartial          uint64      `json:"session_install_partial,omitempty"`
-	FlowCacheCapacity              uint64      `json:"flow_cache_capacity,omitempty"`
-	NeighborCacheCapacity          uint64      `json:"neighbor_cache_capacity,omitempty"`
-	NeighborGeneration             uint64      `json:"neighbor_generation,omitempty"`
-	RouteEntries                   int         `json:"route_entries,omitempty"`
-	WorkerHeartbeats               []time.Time `json:"worker_heartbeats,omitempty"`
+	SessionCreateDrops             uint64 `json:"session_create_drops,omitempty"`
+	SessionInstallAdmissionRefused uint64 `json:"session_install_admission_refused,omitempty"`
+	SessionInstallPartial          uint64 `json:"session_install_partial,omitempty"`
+	FlowCacheCapacity              uint64 `json:"flow_cache_capacity,omitempty"`
+	NeighborCacheCapacity          uint64 `json:"neighbor_cache_capacity,omitempty"`
+	NeighborGeneration             uint64 `json:"neighbor_generation,omitempty"`
+	// ManagerNeighborGeneration is the helper's ACK (#6034) of the highest
+	// authoritative manager-neighbor REPLACE generation it has applied. It
+	// echoes the NeighborGeneration the manager stamps on each
+	// update_neighbors replace (distinct from NeighborGeneration above, which
+	// is the dynamic ARP/NDP resolver epoch). The send path advances its
+	// cached neighbor view only when this ACK confirms the replace landed
+	// (>= the sent generation); a lower value means the helper fenced the
+	// replace as stale, so the manager retains retry debt and re-diffs on the
+	// next regeneration. omitempty for mixed Rust/Go back-compat: an older
+	// helper omits it (decodes 0), which the send path treats as "no ACK
+	// support, assume applied" to preserve pre-#6034 behavior.
+	ManagerNeighborGeneration uint64      `json:"manager_neighbor_generation,omitempty"`
+	RouteEntries              int         `json:"route_entries,omitempty"`
+	WorkerHeartbeats          []time.Time `json:"worker_heartbeats,omitempty"`
 	// #869: per-worker busy/idle runtime telemetry.
 	WorkerRuntime []WorkerRuntimeStatus `json:"worker_runtime,omitempty"`
 	HAGroups      []HAGroupStatus       `json:"ha_groups,omitempty"`
@@ -1577,7 +1589,7 @@ type ProcessStatus struct {
 	// scan/upstream-outage failure mode). Separate from
 	// PendingNeighDuplicateDropsTotal (the key was already pending —
 	// normal cold-start coalescing).
-	PendingNeighCapacityDropsTotal uint64   `json:"pending_neigh_capacity_drops_total,omitempty"`
+	PendingNeighCapacityDropsTotal uint64 `json:"pending_neigh_capacity_drops_total,omitempty"`
 	// #5673: cumulative data-path neighbor learns refused because the shared
 	// dynamic-neighbor map's target shard was at MAX_DYNAMIC_NEIGHBORS_PER_SHARD.
 	// Source-address learning runs on RX before screen/policy admission, so a

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -870,6 +870,38 @@ sync.
 - `types/` — shared structs: `BindingPlan`, `BindingStatus`,
   `WorkerRuntimeAtomics`, `SharedCoSQueueLease`, `BatchCounters`, …
 
+## Manager-neighbor replace generation envelope (#5864 → #6034)
+
+The Go control plane pushes an authoritative manager-neighbor table to the
+helper over the `update_neighbors` control message (handler
+`server/handlers/neighbors.rs`, applied by
+`Coordinator::apply_manager_neighbors`). This is the "Go-snapshot" neighbor
+write path (the fourth MAC→IP write path — the in-process monitor, the
+data-path learn, and the on-demand resolver are the others).
+
+- **#5864 clear-on-empty:** an authoritative `neighbor_replace = true` with an
+  empty publishable set must CLEAR the table. The Go side dropped `omitempty`
+  on `Neighbors`, and the handler applies a clear on absent/`null`/`[]` under
+  replace instead of early-returning.
+- **#6034 replace-generation envelope + ACK/retry:** each authoritative replace
+  carries a monotonically increasing `neighbor_generation`
+  (`Manager.neighborReplaceGen`, Go). `apply_manager_neighbors(replace,
+  generation, ..)` REJECTS a replace whose `generation <= last applied`
+  (`NeighborManager::applied_manager_generation`) — a stale / reordered
+  delivery must not clobber a newer table — and returns `false` without
+  touching the table. This is defense-in-depth: the single synchronous control
+  socket does not itself reorder. The applied generation is ACK'd back in
+  `ProcessStatus.manager_neighbor_generation` (distinct from
+  `neighbor_generation`, the dynamic ARP/NDP resolver epoch); the Go send path
+  advances its cached neighbor view only when the ACK confirms the replace
+  landed (`>=` the sent generation), otherwise it RETAINS retry debt and the
+  next event-driven / 60s-safety regeneration re-diffs and retries with a
+  strictly higher generation. **Backward-compatible:** a `generation == 0`
+  (unversioned / pre-#6034) push bypasses the fence and never advances it, and
+  an older helper that omits the ACK field decodes 0 on the Go side → "no ACK
+  support, assume applied" (pre-#6034 behavior). The retry piggybacks the
+  existing regeneration cadence — it adds NO new control-socket caller.
+
 ## Worker command-queue poison policy (#1790 → #1807)
 
 Coordinator↔worker commands flow through per-worker

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -435,11 +435,35 @@ impl Coordinator {
         &self.forwarding.zone_name_to_id
     }
 
+    /// Apply an authoritative manager-neighbor push from the Go control
+    /// plane. Returns `true` if the push was applied, `false` if it was
+    /// FENCED as a stale / reordered replace (#6034).
+    ///
+    /// `generation` is the monotonically increasing replace generation the
+    /// Go manager stamps on each `update_neighbors` message. When non-zero,
+    /// a replace whose generation is <= the last applied one is rejected
+    /// WITHOUT touching the table — this guards against an out-of-order or
+    /// duplicated delivery clobbering a newer table (defense-in-depth; the
+    /// synchronous single control socket does not itself reorder). A
+    /// generation of 0 means an unversioned (pre-#6034) sender and is always
+    /// applied without advancing the fence, for backward compatibility.
     pub fn apply_manager_neighbors(
         &mut self,
         replace: bool,
+        generation: u64,
         neighbors: &[(i32, IpAddr, NeighborEntry)],
-    ) {
+    ) -> bool {
+        // #6034: replace-generation fence. Reject a stale / reordered
+        // authoritative replace before mutating any neighbor state.
+        if generation != 0
+            && generation
+                <= self
+                    .neighbors
+                    .applied_manager_generation
+                    .load(Ordering::Acquire)
+        {
+            return false;
+        }
         let old_manager_keys = if replace {
             self.neighbors
                 .manager_keys
@@ -487,6 +511,14 @@ impl Coordinator {
             self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
         }
         self.neighbors.generation.fetch_add(1, Ordering::Relaxed);
+        // #6034: advance the applied replace generation so a later stale /
+        // reordered replace is fenced. Only versioned pushes move it.
+        if generation != 0 {
+            self.neighbors
+                .applied_manager_generation
+                .store(generation, Ordering::Release);
+        }
+        true
     }
 
     pub(crate) fn stop_inner(&mut self, clear_synced_state: bool) {

--- a/userspace-dp/src/afxdp/coordinator/neighbor_manager.rs
+++ b/userspace-dp/src/afxdp/coordinator/neighbor_manager.rs
@@ -38,6 +38,15 @@ pub(in crate::afxdp) const WARM_GC_MAX_AGE_NS: u64 = 300_000_000_000;
 pub(crate) struct NeighborManager {
     pub(crate) dynamic: Arc<ShardedNeighborMap>,
     pub(crate) generation: Arc<AtomicU64>,
+    /// #6034: highest authoritative manager-neighbor REPLACE generation
+    /// applied so far. The Go manager stamps a monotonically increasing
+    /// `neighbor_generation` on every `update_neighbors` replace;
+    /// `apply_manager_neighbors` REJECTS a replace whose generation is
+    /// <= this value (stale / reordered delivery must not clobber a newer
+    /// table) and advances it on accept. 0 = no versioned replace applied
+    /// yet; a generation-0 (unversioned / pre-#6034) push bypasses the
+    /// fence and never advances it.
+    pub(crate) applied_manager_generation: Arc<AtomicU64>,
     pub(crate) manager_keys: Arc<Mutex<FastSet<(i32, IpAddr)>>>,
     pub(crate) monitor_stop: Option<Arc<AtomicBool>>,
     /// #5165: join handle for the neighbor-monitor thread. Retained (like the
@@ -115,6 +124,7 @@ impl NeighborManager {
         Self {
             dynamic: Arc::new(ShardedNeighborMap::new()),
             generation: Arc::new(AtomicU64::new(0)),
+            applied_manager_generation: Arc::new(AtomicU64::new(0)),
             manager_keys: Arc::new(Mutex::new(FastSet::default())),
             monitor_stop: None,
             monitor_join: None,

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -19,6 +19,18 @@ impl super::Coordinator {
         (entries, generation)
     }
 
+    /// #6034: the highest authoritative manager-neighbor REPLACE generation
+    /// applied so far (ACK'd back to the Go manager in `ProcessStatus`).
+    /// Distinct from `dynamic_neighbor_status`'s resolver epoch — this only
+    /// advances on an accepted versioned `update_neighbors` replace and lets
+    /// the manager confirm a clear/replace landed (retaining retry debt on a
+    /// non-advanced ACK).
+    pub fn last_applied_manager_neighbor_generation(&self) -> u64 {
+        self.neighbors
+            .applied_manager_generation
+            .load(Ordering::Relaxed)
+    }
+
     /// #5673: cumulative data-path neighbor learns refused by the aggregate
     /// dynamic-neighbor map cap (`MAX_DYNAMIC_NEIGHBORS_PER_SHARD`). The
     /// counter is a single map-wide atomic (the map is shared across all

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -511,6 +511,7 @@ fn manager_neighbor_replace_preserves_packet_learned_entries() {
 
     coordinator.apply_manager_neighbors(
         true,
+        0,
         &[(
             13,
             IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
@@ -560,6 +561,7 @@ fn manager_neighbor_replace_overrides_snapshot_neighbor_entry() {
 
     coordinator.apply_manager_neighbors(
         true,
+        0,
         &[(
             13,
             target,
@@ -597,7 +599,7 @@ fn manager_neighbor_replace_removes_snapshot_seeded_neighbor_entry() {
         })
         .expect("refresh_runtime_snapshot must succeed");
 
-    coordinator.apply_manager_neighbors(true, &[]);
+    coordinator.apply_manager_neighbors(true, 0, &[]);
 
     assert!(
         lookup_neighbor_entry(
@@ -616,6 +618,7 @@ fn refresh_runtime_snapshot_clears_old_manager_neighbor_cache_entries() {
     let target = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
     coordinator.apply_manager_neighbors(
         true,
+        0,
         &[(
             13,
             target,
@@ -646,6 +649,95 @@ fn refresh_runtime_snapshot_clears_old_manager_neighbor_cache_entries() {
         )
         .is_none()
     );
+}
+
+// #6034 fail-on-revert guard: the replace-generation fence must REJECT a stale
+// or reordered authoritative replace (generation <= last applied) without
+// clobbering the newer table, ACCEPT a strictly higher generation, and expose
+// the applied generation for the manager ACK. Reverting the fence in
+// apply_manager_neighbors lets the stale replace overwrite the table and fails
+// the "must not clobber" assertions.
+#[test]
+fn manager_neighbor_replace_generation_fences_stale_and_reordered() {
+    let mut coordinator = Coordinator::new();
+    let target = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
+    let mac_a = NeighborEntry {
+        mac: [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+    };
+    let mac_b = NeighborEntry {
+        mac: [0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb],
+    };
+
+    let lookup_mac = |coordinator: &Coordinator| {
+        lookup_neighbor_entry(
+            &coordinator.forwarding,
+            Some(coordinator.dynamic_neighbors_ref()),
+            13,
+            target,
+        )
+        .expect("manager neighbor entry present")
+        .mac
+    };
+
+    // Generation 5 applies and advances the ACK.
+    assert!(coordinator.apply_manager_neighbors(true, 5, &[(13, target, mac_a)]));
+    assert_eq!(coordinator.last_applied_manager_neighbor_generation(), 5);
+    assert_eq!(lookup_mac(&coordinator), mac_a.mac);
+
+    // A reordered / stale replace at generation 4 is REJECTED; table unchanged.
+    assert!(!coordinator.apply_manager_neighbors(true, 4, &[(13, target, mac_b)]));
+    assert_eq!(coordinator.last_applied_manager_neighbor_generation(), 5);
+    assert_eq!(
+        lookup_mac(&coordinator),
+        mac_a.mac,
+        "a stale replace must not clobber the newer table"
+    );
+
+    // A duplicate at the SAME generation 5 is also rejected (fence is `<=`).
+    assert!(!coordinator.apply_manager_neighbors(true, 5, &[(13, target, mac_b)]));
+    assert_eq!(lookup_mac(&coordinator), mac_a.mac);
+
+    // A strictly higher generation 6 applies and advances the ACK.
+    assert!(coordinator.apply_manager_neighbors(true, 6, &[(13, target, mac_b)]));
+    assert_eq!(coordinator.last_applied_manager_neighbor_generation(), 6);
+    assert_eq!(lookup_mac(&coordinator), mac_b.mac);
+}
+
+// #6034: a generation-0 (unversioned / pre-#6034) push bypasses the fence and
+// is always applied, and it does NOT disturb the applied-generation ACK — so a
+// mixed-version older manager keeps working unchanged.
+#[test]
+fn manager_neighbor_unversioned_generation_bypasses_fence() {
+    let mut coordinator = Coordinator::new();
+    let target = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
+    let mac_a = NeighborEntry {
+        mac: [0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa],
+    };
+    let mac_b = NeighborEntry {
+        mac: [0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb],
+    };
+    let lookup_mac = |coordinator: &Coordinator| {
+        lookup_neighbor_entry(
+            &coordinator.forwarding,
+            Some(coordinator.dynamic_neighbors_ref()),
+            13,
+            target,
+        )
+        .expect("manager neighbor entry present")
+        .mac
+    };
+
+    assert!(coordinator.apply_manager_neighbors(true, 9, &[(13, target, mac_a)]));
+    assert_eq!(coordinator.last_applied_manager_neighbor_generation(), 9);
+
+    // Unversioned push (generation 0) applies regardless and leaves the fence.
+    assert!(coordinator.apply_manager_neighbors(true, 0, &[(13, target, mac_b)]));
+    assert_eq!(
+        coordinator.last_applied_manager_neighbor_generation(),
+        9,
+        "an unversioned push must not advance the applied-generation ACK"
+    );
+    assert_eq!(lookup_mac(&coordinator), mac_b.mac);
 }
 
 #[test]

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -205,6 +205,16 @@ pub(crate) struct ProcessStatus {
     pub neighbor_cache_capacity: usize,
     #[serde(rename = "neighbor_generation", default)]
     pub neighbor_generation: u64,
+    /// #6034: ACK of the highest authoritative manager-neighbor REPLACE
+    /// generation the helper has applied. Distinct from
+    /// `neighbor_generation` (the dynamic ARP/NDP resolver epoch): this
+    /// echoes the `neighbor_generation` field the Go manager stamps on an
+    /// `update_neighbors` replace so the manager can confirm the clear /
+    /// replace landed and retain retry debt otherwise. Additive / defaulted:
+    /// an older helper omits it (Go decodes 0 → treats as "no ACK support,
+    /// assume applied", preserving pre-#6034 behavior).
+    #[serde(rename = "manager_neighbor_generation", default)]
+    pub manager_neighbor_generation: u64,
     #[serde(rename = "route_entries", default)]
     pub route_entries: usize,
     #[serde(rename = "worker_heartbeats", default)]

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -174,9 +174,12 @@ pub(crate) fn handle_stream(
                     refresh_status(&mut guard);
                 }
             }
-            "update_neighbors" => {
-                neighbors::update(&mut guard, request.neighbors.as_ref(), neighbor_replace)
-            }
+            "update_neighbors" => neighbors::update(
+                &mut guard,
+                request.neighbors.as_ref(),
+                request.neighbor_generation,
+                neighbor_replace,
+            ),
             "bump_fib_generation" => snapshot::bump_fib(
                 &mut guard,
                 request.snapshot.as_ref(),

--- a/userspace-dp/src/server/handlers/neighbors.rs
+++ b/userspace-dp/src/server/handlers/neighbors.rs
@@ -8,6 +8,7 @@ use crate::{afxdp, NeighborSnapshot};
 pub(super) fn update(
     guard: &mut ServerState,
     neighbors: Option<&Vec<NeighborSnapshot>>,
+    generation: u64,
     replace: bool,
 ) {
     // #5864: an authoritative replace with zero entries must CLEAR the
@@ -38,6 +39,20 @@ pub(super) fn update(
         }
         resolved.push((neigh.ifindex, ip, afxdp::NeighborEntry { mac }));
     }
-    guard.afxdp.apply_manager_neighbors(replace, &resolved);
+    // #6034: carry the replace-generation envelope. `apply_manager_neighbors`
+    // fences a stale / reordered replace (generation <= last applied) and
+    // returns false without touching the table; `refresh_status` still runs so
+    // the ACK (ProcessStatus.manager_neighbor_generation) reflects the current
+    // applied generation and the Go manager can retain retry debt.
+    let applied = guard
+        .afxdp
+        .apply_manager_neighbors(replace, generation, &resolved);
+    if !applied {
+        eprintln!(
+            "update_neighbors: fenced stale replace generation {} (last applied {})",
+            generation,
+            guard.afxdp.last_applied_manager_neighbor_generation()
+        );
+    }
     refresh_status(guard);
 }

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -44,6 +44,10 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     let (neighbor_entries, neighbor_generation) = state.afxdp.dynamic_neighbor_status();
     state.status.neighbor_entries = neighbor_entries;
     state.status.neighbor_generation = neighbor_generation;
+    // #6034: ACK the highest applied authoritative manager-neighbor replace
+    // generation so the Go manager can confirm a clear/replace landed.
+    state.status.manager_neighbor_generation =
+        state.afxdp.last_applied_manager_neighbor_generation();
     // #710: cluster-wide aggregate of cross-worker CoS no-owner-binding
     // drops. The per-binding increment site is mechanical; this is the
     // only operator-facing surface for the counter.

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -213,6 +213,7 @@ pub(crate) fn run() -> Result<(), String> {
             flow_cache_capacity: 0,
             neighbor_cache_capacity: 0,
             neighbor_generation: 0,
+            manager_neighbor_generation: 0,
             route_entries: 0,
             worker_heartbeats: Vec::new(),
             worker_runtime: Vec::new(),

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -858,6 +858,7 @@
     "last_cache_flush_at": 0,
     "last_fib_generation": 0,
     "last_snapshot_generation": 0,
+    "manager_neighbor_generation": 0,
     "max_sessions": 0,
     "nat_reverse_key_collisions": 0,
     "nat_reverse_key_shared_displacements_total": 0,


### PR DESCRIPTION
## Summary

Follow-up to #5864 (which fixed the acute clear-on-empty bug). Adds the
deferred robustness envelope to the manager→helper `update_neighbors`
push so a lost/reordered neighbor replace is detected and retried rather
than silently leaving the helper table stale.

This is a **local Go-daemon → local `userspace-dp` control-socket**
change (daemon + helper deploy in lockstep from the same build), so
there is no cross-node mixed-version flag-day. The envelope is still
additive + defaulted for safety.

## What changed

**Wire (both sides, additive):**
- Each authoritative replace stamps a monotonic `neighbor_generation`
  from a dedicated `Manager.neighborReplaceGen` counter (guarded by
  `m.mu`, never reused → a retry always carries a strictly higher gen).
- `ProcessStatus` gains `manager_neighbor_generation` — the helper's ACK
  of the highest applied replace generation. Distinct from
  `neighbor_generation` (the dynamic ARP/NDP resolver epoch).

**Helper (Rust):** `apply_manager_neighbors(replace, generation, ..)`
REJECTS a replace whose `generation <= applied_manager_generation`
(stale/reordered must not clobber a newer table) without touching the
table, and ACKs the applied generation. `generation == 0` (unversioned)
bypasses the fence. Defense-in-depth — the single synchronous control
socket does not itself reorder.

**Manager (Go):** both senders (`RegenerateNeighborSnapshot`,
`BumpFIBGeneration`) advance their cached neighbor view only when the ACK
confirms the replace landed (`>=` sent gen); a lower non-zero ACK means
the helper fenced it, so the manager **retains retry debt** and the next
event-driven / 60s-safety regeneration re-diffs and retries with a higher
generation. An ACK of 0 (older helper) is treated as applied → pre-#6034
behavior preserved.

**Contention:** no new control-socket caller — the generation rides the
existing `update_neighbors` requests and retry piggybacks the existing
regeneration cadence.

## Tests
- Go `TestNeighborReplaceEnvelopeCarriesGenerationAndRetainsRetryDebt` —
  fail-on-revert binding **both** the envelope carry (request carries the
  generation) and the retry-debt trigger (fenced ACK → cached view
  retained; matching ACK → advanced).
- Rust fence unit tests: stale/reordered reject, same-gen reject,
  higher-gen accept, unversioned bypass, applied-generation ACK getter.
- Regenerated `protocol_wire_v1.json` (one new `process_status` key);
  `wire_invariant_default_specimens` passes.
- `go test ./pkg/dataplane/... ./pkg/cluster/...` and the Rust
  `manager_neighbor` suite pass.

## Docs
- `userspace-dp/src/afxdp/README.md`: new "Manager-neighbor replace
  generation envelope (#5864 → #6034)" section.

## HA note
Touches the HA neighbor-sync path — **`make test-failover` required
before merge** (parent to run).

Closes #6034

🤖 Generated with [Claude Code](https://claude.com/claude-code)