### PR TITLE
afxdp/cos: reuse per-worker batch deques on shaped-TX path (#4973)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56344,3 +56344,25 @@ top.
   #6312 (JSON resync id-drop), #6313 (reverse-materialize test).
 - **File(s)**: docs/sync-protocol.md, userspace-dp/src/session/README.md,
   userspace-dp/src/session/install.rs, userspace-dp/src/session/tests.rs
+
+## 2026-07-22 — #4973 CoS shaped-TX batch deque reuse (allocation-free)
+- **Action**: `build_cos_batch_from_queue` no longer `VecDeque::new()`s a batch
+  deque per selected batch on the non-exact shaped-TX path. Added two per-worker
+  reusable deques (`cos_local_batch_scratch` / `cos_prepared_batch_scratch` on
+  `WorkerCos`) that are `mem::take`n into the built `CoSBatch` (arm-specific
+  `clear()` at entry) and drained + stored back by the submit handler —
+  `apply_cos_*_result` / `restore_cos_*_items` now return the emptied deque,
+  `restore_cos_*_items_inner` drain via `&mut`, and `submit_local` /
+  `submit_prepared` store it into the scratch field. Threaded the scratch through
+  `build_nonexact_cos_batch` (disjoint-field split-borrow) →
+  `select_nonexact_cos_guarantee_batch_into` / `select_cos_surplus_batch_filtered`;
+  the old public selectors kept their allocating signatures as test wrappers.
+  Mirrors the #4972 `released_queue_leases_scratch` pattern. Added two
+  RED-on-revert tests pinning that each arm clears the reused scratch; verified
+  both go RED with the `clear()` neutralized. Full cos suite green (587 lib
+  tests + doc-drift).
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_service/{mod,submit_local,
+  submit_prepared}.rs, userspace-dp/src/afxdp/cos/tx_completion.rs,
+  userspace-dp/src/afxdp/worker/{cos_state,mod}.rs,
+  userspace-dp/src/afxdp/cos/queue_service/tests/{refund,wakeup}.rs,
+  userspace-dp/src/afxdp/cos/README.md

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -99,6 +99,19 @@ mod.rs for further file-level breakdown.
   binding is the same worker that owns the queue's
   `FlowFairState`; therefore `observed_bps` updates and reads do not
   need atomic synchronization.
+- **Per-worker batch deques (#4973).** The non-exact shaped-TX path
+  (`build_cos_batch_from_queue`, driven by `drain_shaped_tx` →
+  `select_nonexact_cos_guarantee_batch_into` /
+  `select_cos_surplus_batch_filtered`) no longer `VecDeque::new()`s a batch
+  deque per selected batch. Two reusable deques (`cos_local_batch_scratch` /
+  `cos_prepared_batch_scratch` on `WorkerCos`) are `mem::take`n into the built
+  `CoSBatch`, then drained empty and stored back by the submit handler
+  (`submit_local` / `submit_prepared`, via the now-returning
+  `apply_cos_*_result` / `restore_cos_*_items`), retaining the ring-buffer
+  allocation across drains — allocation-free after warmup. Each arm `clear()`s
+  its scratch at entry so a store-back that left residue (a queue-torn-down
+  early return returns the deque undrained) cannot leak into the next batch.
+  Mirrors the #4972 `released_queue_leases_scratch` reuse pattern.
 - **V_min cadence persists across drain calls (#2624).** The
   cross-worker V_min sync (`cos_queue_v_min_continue` → the expensive
   `participating_v_min_snapshot` Acquire-load scan of every peer

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -289,25 +289,56 @@ fn build_nonexact_cos_batch(
         .get(&root_ifindex)
         .map(|iface_fast| iface_fast.queue_fast_path.as_slice())
         .unwrap_or(&[]);
+    // #4973: split-borrow the per-worker reusable Local/Prepared batch deques
+    // from their disjoint `WorkerCos` fields alongside the `cos_interfaces`
+    // mutable borrow (the same disjoint-field borrow-split `queue_fast_path` /
+    // `shared_exact_backlog` above already rely on). The selected batch build
+    // `mem::take`s the matching deque into the `CoSBatch`; the submit handler
+    // drains it empty and stores it back, so the shaped-TX drain reuses the
+    // ring-buffer allocation instead of `VecDeque::new()`ing per batch.
+    // Borrow the fields directly (not through an intermediate `&mut
+    // binding.cos`, which would conflict with the still-live shared borrow of
+    // `binding.cos.cos_fast_interfaces` held by `queue_fast_path`). An explicit
+    // `match` (not `.or_else`) keeps the surplus fallback out of a closure that
+    // would try to re-capture the scratch references.
     let selected = {
+        let local_scratch = &mut binding.cos.cos_local_batch_scratch;
+        let prepared_scratch = &mut binding.cos.cos_prepared_batch_scratch;
         let root = binding.cos.cos_interfaces.get_mut(&root_ifindex)?;
-        select_nonexact_cos_guarantee_batch(root, queue_fast_path, now_ns).or_else(|| {
-            // Strict priority applies to surplus service only. Non-exact
-            // queues with explicit transmit-rate guarantees keep their
-            // guarantee pass. Residual/best-effort surplus remains
-            // work-conserving, but while exact queues are backlogged it may
-            // consume only the residual root rate after backlogged exact
-            // guarantee rates are reserved.
-            let exact_demand_mask = root_exact_demand_queue_mask(root) | peer_exact_demand_mask;
-            let exact_demand_rate = exact_demand_rate_bytes_for_mask(root, exact_demand_mask);
-            let nonexact_budget = nonexact_surplus_budget_under_exact_demand(
-                root,
-                now_ns,
-                exact_demand_rate,
-                shared_exact_backlog.map(|backlog| &**backlog),
-            );
-            select_cos_surplus_batch_filtered(root, now_ns, true, nonexact_budget)
-        })
+        match select_nonexact_cos_guarantee_batch_into(
+            root,
+            queue_fast_path,
+            now_ns,
+            local_scratch,
+            prepared_scratch,
+        ) {
+            Some(batch) => Some(batch),
+            None => {
+                // Strict priority applies to surplus service only. Non-exact
+                // queues with explicit transmit-rate guarantees keep their
+                // guarantee pass. Residual/best-effort surplus remains
+                // work-conserving, but while exact queues are backlogged it may
+                // consume only the residual root rate after backlogged exact
+                // guarantee rates are reserved.
+                let exact_demand_mask =
+                    root_exact_demand_queue_mask(root) | peer_exact_demand_mask;
+                let exact_demand_rate = exact_demand_rate_bytes_for_mask(root, exact_demand_mask);
+                let nonexact_budget = nonexact_surplus_budget_under_exact_demand(
+                    root,
+                    now_ns,
+                    exact_demand_rate,
+                    shared_exact_backlog.map(|backlog| &**backlog),
+                );
+                select_cos_surplus_batch_filtered(
+                    root,
+                    now_ns,
+                    true,
+                    nonexact_budget,
+                    local_scratch,
+                    prepared_scratch,
+                )
+            }
+        }
     };
     if selected.is_some() {
         refresh_cos_interface_activity(binding, root_ifindex);
@@ -609,6 +640,11 @@ pub(in crate::afxdp) fn select_cos_guarantee_batch_with_fast_path(
         return None;
     }
     let start = root.legacy_guarantee_rr % queue_count;
+    // #4973: this legacy test-only selector does not thread worker scratch, so
+    // it uses throwaway batch deques. Production reuse lives on the
+    // `_into` / `_filtered` selectors driven by `build_nonexact_cos_batch`.
+    let mut local_scratch = VecDeque::new();
+    let mut prepared_scratch = VecDeque::new();
     for offset in 0..queue_count {
         let queue_idx = (start + offset) % queue_count;
         let queue = &mut root.queues[queue_idx];
@@ -684,6 +720,8 @@ pub(in crate::afxdp) fn select_cos_guarantee_batch_with_fast_path(
             root.tokens,
             guarantee_budget,
             CoSServicePhase::Guarantee,
+            &mut local_scratch,
+            &mut prepared_scratch,
         ) {
             return Some(batch);
         }
@@ -1364,11 +1402,37 @@ fn select_exact_cos_guarantee_queue_waterfill(
 // independently of the exact pass via `nonexact_guarantee_rr` — a service
 // event on an exact queue does not advance this cursor, so non-exact RR
 // order is stable across bursts of exact-queue activity.
+//
+// #4973: the production drain (`build_nonexact_cos_batch`) calls
+// `select_nonexact_cos_guarantee_batch_into` with the per-worker reusable batch
+// deques so `build_cos_batch_from_queue` does not `VecDeque::new()` per batch.
+// This thin wrapper preserves the original allocating signature for unit tests
+// that do not thread worker scratch.
+#[cfg(test)]
 #[inline]
 pub(in crate::afxdp) fn select_nonexact_cos_guarantee_batch(
     root: &mut CoSInterfaceRuntime,
     queue_fast_path: &[WorkerCoSQueueFastPath],
     now_ns: u64,
+) -> Option<CoSBatch> {
+    let mut local_scratch = VecDeque::new();
+    let mut prepared_scratch = VecDeque::new();
+    select_nonexact_cos_guarantee_batch_into(
+        root,
+        queue_fast_path,
+        now_ns,
+        &mut local_scratch,
+        &mut prepared_scratch,
+    )
+}
+
+#[inline]
+pub(in crate::afxdp) fn select_nonexact_cos_guarantee_batch_into(
+    root: &mut CoSInterfaceRuntime,
+    queue_fast_path: &[WorkerCoSQueueFastPath],
+    now_ns: u64,
+    local_scratch: &mut VecDeque<TxRequest>,
+    prepared_scratch: &mut VecDeque<PreparedTxRequest>,
 ) -> Option<CoSBatch> {
     let queue_count = root.queues.len();
     if queue_count == 0 {
@@ -1439,6 +1503,8 @@ pub(in crate::afxdp) fn select_nonexact_cos_guarantee_batch(
             root.tokens,
             guarantee_budget,
             CoSServicePhase::Guarantee,
+            local_scratch,
+            prepared_scratch,
         ) {
             return Some(batch);
         }
@@ -1446,12 +1512,26 @@ pub(in crate::afxdp) fn select_nonexact_cos_guarantee_batch(
     None
 }
 
+// #4973: unit-test-facing surplus selector. The production drain calls
+// `select_cos_surplus_batch_filtered` directly with the per-worker reusable
+// batch deques; this wrapper allocates throwaway deques so tests keep the
+// original allocating signature.
+#[cfg(test)]
 #[inline]
 pub(in crate::afxdp) fn select_cos_surplus_batch(
     root: &mut CoSInterfaceRuntime,
     now_ns: u64,
 ) -> Option<CoSBatch> {
-    select_cos_surplus_batch_filtered(root, now_ns, true, None)
+    let mut local_scratch = VecDeque::new();
+    let mut prepared_scratch = VecDeque::new();
+    select_cos_surplus_batch_filtered(
+        root,
+        now_ns,
+        true,
+        None,
+        &mut local_scratch,
+        &mut prepared_scratch,
+    )
 }
 
 #[inline]
@@ -1460,6 +1540,8 @@ fn select_cos_surplus_batch_filtered(
     now_ns: u64,
     allow_nonexact: bool,
     nonexact_surplus_budget: Option<u64>,
+    local_scratch: &mut VecDeque<TxRequest>,
+    prepared_scratch: &mut VecDeque<PreparedTxRequest>,
 ) -> Option<CoSBatch> {
     for priority in 0..COS_PRIORITY_LEVELS {
         let indices_len = root.queue_indices_by_priority[priority].len();
@@ -1535,6 +1617,8 @@ fn select_cos_surplus_batch_filtered(
                 root.tokens,
                 secondary_budget,
                 CoSServicePhase::Surplus,
+                local_scratch,
+                prepared_scratch,
             ) {
                 return Some(batch);
             }
@@ -1776,12 +1860,22 @@ fn subtract_direct_cos_queue_bytes(
 }
 
 #[inline]
+// #4973: `local_scratch` / `prepared_scratch` are the per-worker reusable
+// batch deques (WorkerCos state). The selected arm `clear()`s its scratch at
+// entry (defensive — a submit-side store-back leaves it empty, but a stale
+// element from a torn-down-queue early-return would otherwise corrupt this
+// batch), fills it, and `mem::take`s it into the `CoSBatch`. The submit
+// handler drains it empty and stores it back, so the ring-buffer allocation is
+// retained across drains instead of a `VecDeque::new()` per selected batch. The
+// non-selected arm's scratch is left untouched (keeps its capacity).
 fn build_cos_batch_from_queue(
     queue: &mut CoSQueueRuntime,
     queue_idx: usize,
     root_budget: u64,
     secondary_budget: u64,
     phase: CoSServicePhase,
+    local_scratch: &mut VecDeque<TxRequest>,
+    prepared_scratch: &mut VecDeque<PreparedTxRequest>,
 ) -> Option<CoSBatch> {
     // #3968: clear the pop-snapshot stack at batch start — the
     // non-exact analog of the clear `drain_exact_local_items_to_scratch_flow_fair`
@@ -1808,11 +1902,11 @@ fn build_cos_batch_from_queue(
     let head = cos_queue_front(queue)?;
     match head {
         CoSPendingTxItem::Local(_) => {
-            let mut items = VecDeque::new();
+            local_scratch.clear();
             let mut remaining_root = root_budget;
             let mut remaining_secondary = secondary_budget;
             let mut batch_bytes = 0u64;
-            while items.len() < TX_BATCH_SIZE {
+            while local_scratch.len() < TX_BATCH_SIZE {
                 // #1763 Lever A — fused select+pop. Peek returns the
                 // min-finish bucket id; if we commit to popping, reuse
                 // that exact bucket (no re-scan). No queue mutation
@@ -1833,7 +1927,7 @@ fn build_cos_batch_from_queue(
                 match cos_queue_pop_known_bucket(queue, bucket, u64::MAX) {
                     Some(CoSPendingTxItem::Local(req)) => {
                         batch_bytes = batch_bytes.saturating_add(len);
-                        items.push_back(req);
+                        local_scratch.push_back(req);
                     }
                     Some(other) => {
                         cos_queue_push_front(queue, other);
@@ -1842,23 +1936,23 @@ fn build_cos_batch_from_queue(
                     None => break,
                 }
             }
-            if items.is_empty() {
+            if local_scratch.is_empty() {
                 None
             } else {
                 Some(CoSBatch::Local {
                     queue_idx,
                     phase,
                     batch_bytes,
-                    items,
+                    items: core::mem::take(local_scratch),
                 })
             }
         }
         CoSPendingTxItem::Prepared(_) => {
-            let mut items = VecDeque::new();
+            prepared_scratch.clear();
             let mut remaining_root = root_budget;
             let mut remaining_secondary = secondary_budget;
             let mut batch_bytes = 0u64;
-            while items.len() < TX_BATCH_SIZE {
+            while prepared_scratch.len() < TX_BATCH_SIZE {
                 // #1763 Lever A — fused select+pop (Prepared arm). See
                 // the Local arm above for the no-mutation invariant.
                 let Some((bucket, front)) = cos_queue_peek_min_bucket(queue, u64::MAX) else {
@@ -1876,7 +1970,7 @@ fn build_cos_batch_from_queue(
                 match cos_queue_pop_known_bucket(queue, bucket, u64::MAX) {
                     Some(CoSPendingTxItem::Prepared(req)) => {
                         batch_bytes = batch_bytes.saturating_add(len);
-                        items.push_back(req);
+                        prepared_scratch.push_back(req);
                     }
                     Some(other) => {
                         cos_queue_push_front(queue, other);
@@ -1885,14 +1979,14 @@ fn build_cos_batch_from_queue(
                     None => break,
                 }
             }
-            if items.is_empty() {
+            if prepared_scratch.is_empty() {
                 None
             } else {
                 Some(CoSBatch::Prepared {
                     queue_idx,
                     phase,
                     batch_bytes,
-                    items,
+                    items: core::mem::take(prepared_scratch),
                 })
             }
         }

--- a/userspace-dp/src/afxdp/cos/queue_service/submit_local.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/submit_local.rs
@@ -84,7 +84,11 @@ pub(super) fn submit_local(
         }
         n
     };
-    match transmit_batch(binding, &mut items, now_ns, shared_recycles) {
+    // #4973: capture the batch outcome so the drained `items` deque can be
+    // stored back into the per-worker Local batch scratch after the match. The
+    // transmit/apply/restore path empties `items` and returns it, retaining the
+    // ring-buffer allocation `build_cos_batch_from_queue` reused.
+    let made_progress = match transmit_batch(binding, &mut items, now_ns, shared_recycles) {
         Ok((packets, bytes)) => {
             // #5157: snapshot the committed identities (ORIGINAL-input
             // positions transmit_batch actually shipped) into a local
@@ -103,7 +107,7 @@ pub(super) fn submit_local(
                 committed_len, packets as usize,
                 "committed identity count must equal the transmitted packet count",
             );
-            apply_cos_send_result(
+            items = apply_cos_send_result(
                 binding,
                 root_ifindex,
                 queue_idx,
@@ -188,7 +192,7 @@ pub(super) fn submit_local(
             // #4971: expected TX backpressure — record the reason
             // lock-free instead of taking the `last_error` mutex.
             binding.live.set_tx_retry_status(reason);
-            restore_cos_local_items(binding, root_ifindex, queue_idx, batch_bytes, items);
+            items = restore_cos_local_items(binding, root_ifindex, queue_idx, batch_bytes, items);
             cos_batch_tx_made_progress(Err(TxError::Retry(reason)))
         }
         Err(TxError::Drop(reason)) => {
@@ -204,28 +208,39 @@ pub(super) fn submit_local(
             // #4971: exceptional drop path (rare) still renders the
             // diagnostic message via the mutex-backed set_error.
             binding.live.set_error(reason.message());
-            restore_cos_local_items(binding, root_ifindex, queue_idx, batch_bytes, items);
+            items = restore_cos_local_items(binding, root_ifindex, queue_idx, batch_bytes, items);
             cos_batch_tx_made_progress(Err(TxError::Drop(reason)))
         }
-    }
+    };
+    // #4973: return the drained batch deque to the per-worker Local batch
+    // scratch so the next shaped-TX drain reuses its capacity instead of
+    // allocating a fresh `VecDeque`.
+    binding.cos.cos_local_batch_scratch = items;
+    made_progress
 }
 
 // Moved from queue_service/mod.rs (pre-refactor L1488-L1509). Sole
 // caller is submit_local's Err arms above; the *_inner variant lives
 // in tx_completion and is still reached via super::.
+//
+// #4973: returns the drained (now-empty) `retry` deque so the submit handler
+// can reclaim it as the per-worker Local batch scratch. On the queue-torn-down
+// early return the deque is returned undrained (its items are dropped by the
+// next `build_cos_batch_from_queue` `clear()`, exactly as the previous by-value
+// drop dropped them — the queue is gone).
 fn restore_cos_local_items(
     binding: &mut BindingWorker,
     root_ifindex: i32,
     queue_idx: usize,
     batch_bytes: u64,
-    retry: VecDeque<TxRequest>,
-) {
+    mut retry: VecDeque<TxRequest>,
+) -> VecDeque<TxRequest> {
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
-            return;
+            return retry;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            let retry_bytes = restore_cos_local_items_inner(queue, retry);
+            let retry_bytes = restore_cos_local_items_inner(queue, &mut retry);
             queue.hot.queued_bytes = queue
                 .hot
                 .queued_bytes
@@ -234,4 +249,5 @@ fn restore_cos_local_items(
         }
     }
     refresh_cos_interface_activity(binding, root_ifindex);
+    retry
 }

--- a/userspace-dp/src/afxdp/cos/queue_service/submit_prepared.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/submit_prepared.rs
@@ -55,9 +55,12 @@ pub(super) fn submit_prepared(
         }
         n
     };
-    match transmit_prepared_queue(binding, &mut items, now_ns, shared_recycles) {
+    // #4973: capture the batch outcome so the drained `items` deque can be
+    // stored back into the per-worker Prepared batch scratch after the match,
+    // retaining the ring-buffer allocation `build_cos_batch_from_queue` reused.
+    let made_progress = match transmit_prepared_queue(binding, &mut items, now_ns, shared_recycles) {
         Ok((packets, bytes)) => {
-            apply_cos_prepared_result(
+            items = apply_cos_prepared_result(
                 binding,
                 root_ifindex,
                 queue_idx,
@@ -125,7 +128,7 @@ pub(super) fn submit_prepared(
             // #4971: expected TX backpressure — lock-free status, no
             // `last_error` mutex on the send hot path.
             binding.live.set_tx_retry_status(reason);
-            restore_cos_prepared_items(
+            items = restore_cos_prepared_items(
                 binding,
                 root_ifindex,
                 queue_idx,
@@ -143,7 +146,7 @@ pub(super) fn submit_prepared(
             // #4971: exceptional drop path (rare) still renders the
             // diagnostic message via the mutex-backed set_error.
             binding.live.set_error(reason.message());
-            restore_cos_prepared_items(
+            items = restore_cos_prepared_items(
                 binding,
                 root_ifindex,
                 queue_idx,
@@ -152,24 +155,35 @@ pub(super) fn submit_prepared(
             );
             cos_batch_tx_made_progress(Err(TxError::Drop(reason)))
         }
-    }
+    };
+    // #4973: return the drained batch deque to the per-worker Prepared batch
+    // scratch so the next shaped-TX drain reuses its capacity instead of
+    // allocating a fresh `VecDeque`.
+    binding.cos.cos_prepared_batch_scratch = items;
+    made_progress
 }
 
 // Moved from queue_service/mod.rs (pre-refactor L1511-L1532). Sole
 // caller is submit_prepared's Err arms above.
+//
+// #4973: returns the drained (now-empty) `retry` deque so the submit handler
+// can reclaim it as the per-worker Prepared batch scratch. On the
+// queue-torn-down early return the deque is returned undrained (its items are
+// dropped by the next `build_cos_batch_from_queue` `clear()`, exactly as the
+// previous by-value drop dropped them — the queue is gone).
 fn restore_cos_prepared_items(
     binding: &mut BindingWorker,
     root_ifindex: i32,
     queue_idx: usize,
     batch_bytes: u64,
-    retry: VecDeque<PreparedTxRequest>,
-) {
+    mut retry: VecDeque<PreparedTxRequest>,
+) -> VecDeque<PreparedTxRequest> {
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
-            return;
+            return retry;
         };
         if let Some(queue) = root.queues.get_mut(queue_idx) {
-            let retry_bytes = restore_cos_prepared_items_inner(queue, retry);
+            let retry_bytes = restore_cos_prepared_items_inner(queue, &mut retry);
             queue.hot.queued_bytes = queue
                 .hot
                 .queued_bytes
@@ -178,4 +192,5 @@ fn restore_cos_prepared_items(
         }
     }
     refresh_cos_interface_activity(binding, root_ifindex);
+    retry
 }

--- a/userspace-dp/src/afxdp/cos/queue_service/tests/refund.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests/refund.rs
@@ -66,6 +66,12 @@ fn build_cos_batch_clears_pop_snapshot_stack_across_batches() {
         cos_queue_push_back(queue, test_flow_cos_item(src_port, 100));
     }
 
+    // #4973: this test drives build_cos_batch_from_queue directly (no submit),
+    // so it passes throwaway batch scratch deques instead of the per-worker
+    // WorkerCos scratch the production drain threads.
+    let mut local_scratch = VecDeque::new();
+    let mut prepared_scratch = VecDeque::new();
+
     // Batch 1: build_cos_batch_from_queue pops TX_BATCH_SIZE items,
     // pushing one rollback snapshot per pop. Budgets = u64::MAX so
     // nothing caps the batch below the frame-count bound.
@@ -75,6 +81,8 @@ fn build_cos_batch_clears_pop_snapshot_stack_across_batches() {
         u64::MAX,
         u64::MAX,
         CoSServicePhase::Guarantee,
+        &mut local_scratch,
+        &mut prepared_scratch,
     )
     .expect("first batch built");
     let batch1_len = match &batch1 {
@@ -108,6 +116,8 @@ fn build_cos_batch_clears_pop_snapshot_stack_across_batches() {
         u64::MAX,
         u64::MAX,
         CoSServicePhase::Guarantee,
+        &mut local_scratch,
+        &mut prepared_scratch,
     )
     .expect("second batch built");
     let batch2_len = match &batch2 {
@@ -132,6 +142,162 @@ fn build_cos_batch_clears_pop_snapshot_stack_across_batches() {
             .capacity(),
         pre_cap,
         "#3968: stack must not realloc past TX_BATCH_SIZE",
+    );
+}
+
+/// #4973: `build_cos_batch_from_queue` reuses a per-worker scratch deque
+/// (`mem::take`n from `WorkerCos` at build, drained and stored back by the
+/// submit handler). It MUST `clear()` that scratch at batch entry: a stale
+/// element left resident — e.g. from a queue-torn-down submit early return that
+/// stores the deque back undrained — would otherwise be emitted as the FIRST
+/// item of the NEXT batch, corrupting its contents while `batch_bytes` counts
+/// only the freshly popped items.
+///
+/// RED-on-revert: drop the `local_scratch.clear()` in the Local arm and the
+/// built batch carries the pre-seeded 9999-byte stale request ahead of the ten
+/// real items (len 11, first item = the marker); both assertions fail.
+#[test]
+fn build_cos_batch_local_clears_reused_scratch_between_batches() {
+    let mut root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "best-effort".into(),
+            priority: 5,
+            transmit_rate_bytes: 1_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: false,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: 8 * 1024 * 1024,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    enable_test_flow_fair(&mut root.queues[0]);
+
+    // Ten real 100-byte Local items across two flows (well under TX_BATCH_SIZE
+    // so the queue drains fully into one batch).
+    let real_items = 10usize;
+    for i in 0..real_items {
+        let src_port = if i % 2 == 0 { 9001u16 } else { 9002u16 };
+        cos_queue_push_back(&mut root.queues[0], test_flow_cos_item(src_port, 100));
+    }
+
+    // Pre-seed the reusable Local scratch with a STALE 9999-byte request,
+    // modelling a store-back that left residue behind.
+    let mut local_scratch = VecDeque::new();
+    let mut prepared_scratch = VecDeque::new();
+    match test_flow_cos_item(7777, 9999) {
+        CoSPendingTxItem::Local(stale) => local_scratch.push_back(stale),
+        CoSPendingTxItem::Prepared(_) => unreachable!("test_flow_cos_item yields Local"),
+    }
+
+    let batch = build_cos_batch_from_queue(
+        &mut root.queues[0],
+        0,
+        u64::MAX,
+        u64::MAX,
+        CoSServicePhase::Guarantee,
+        &mut local_scratch,
+        &mut prepared_scratch,
+    )
+    .expect("local batch built");
+
+    let items = match &batch {
+        CoSBatch::Local { items, .. } => items,
+        CoSBatch::Prepared { .. } => panic!("expected a Local batch"),
+    };
+    assert_eq!(
+        items.len(),
+        real_items,
+        "the reused scratch must be cleared: only freshly popped queue items \
+         appear, never the pre-seeded stale request",
+    );
+    assert!(
+        items.iter().all(|req| req.bytes.len() == 100),
+        "no batch item may carry the 9999-byte stale marker",
+    );
+    // The taken scratch is left empty in the field (mem::take), and the built
+    // deque owns the ten real items.
+    assert!(
+        local_scratch.is_empty(),
+        "the scratch is mem::taken into the batch, leaving the field empty",
+    );
+}
+
+/// #4973: the Prepared arm of `build_cos_batch_from_queue` shares the same
+/// clear-at-entry contract as the Local arm above; pin it independently so a
+/// revert of only `prepared_scratch.clear()` is still caught RED.
+#[test]
+fn build_cos_batch_prepared_clears_reused_scratch_between_batches() {
+    let mut root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "best-effort".into(),
+            priority: 5,
+            transmit_rate_bytes: 1_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: false,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: 8 * 1024 * 1024,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    enable_test_flow_fair(&mut root.queues[0]);
+
+    // Ten real 100-byte Prepared items across two flows.
+    let real_items = 10usize;
+    for i in 0..real_items {
+        let src_port = if i % 2 == 0 { 9001u16 } else { 9002u16 };
+        cos_queue_push_back(
+            &mut root.queues[0],
+            test_flow_prepared_cos_item(src_port, 100, 4096 + i as u64 * 4096),
+        );
+    }
+
+    let mut local_scratch = VecDeque::new();
+    let mut prepared_scratch = VecDeque::new();
+    match test_flow_prepared_cos_item(7777, 9999, 512) {
+        CoSPendingTxItem::Prepared(stale) => prepared_scratch.push_back(stale),
+        CoSPendingTxItem::Local(_) => unreachable!("test_flow_prepared_cos_item yields Prepared"),
+    }
+
+    let batch = build_cos_batch_from_queue(
+        &mut root.queues[0],
+        0,
+        u64::MAX,
+        u64::MAX,
+        CoSServicePhase::Guarantee,
+        &mut local_scratch,
+        &mut prepared_scratch,
+    )
+    .expect("prepared batch built");
+
+    let items = match &batch {
+        CoSBatch::Prepared { items, .. } => items,
+        CoSBatch::Local { .. } => panic!("expected a Prepared batch"),
+    };
+    assert_eq!(
+        items.len(),
+        real_items,
+        "the reused prepared scratch must be cleared: only freshly popped \
+         queue items appear, never the pre-seeded stale request",
+    );
+    assert!(
+        items.iter().all(|req| req.len == 100),
+        "no batch item may carry the 9999-byte stale marker",
+    );
+    assert!(
+        prepared_scratch.is_empty(),
+        "the scratch is mem::taken into the batch, leaving the field empty",
     );
 }
 

--- a/userspace-dp/src/afxdp/cos/queue_service/tests/wakeup.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests/wakeup.rs
@@ -130,7 +130,7 @@ fn restore_cos_local_items_marks_queue_runnable_after_retry() {
         },
         queue_lease_v8: None,
     };
-    let retry = VecDeque::from([TxRequest {
+    let mut retry = VecDeque::from([TxRequest {
         bytes: vec![0; 1500],
         expected_ports: None,
         expected_addr_family: libc::AF_INET as u8,
@@ -143,7 +143,7 @@ fn restore_cos_local_items_marks_queue_runnable_after_retry() {
         enqueue_ns: 0,
     }]);
 
-    let retry_bytes = restore_cos_local_items_inner(&mut queue, retry);
+    let retry_bytes = restore_cos_local_items_inner(&mut queue, &mut retry);
 
     assert_eq!(queue.hot.items.len(), 1);
     assert_eq!(retry_bytes, 1500);
@@ -203,7 +203,7 @@ fn restore_cos_prepared_items_marks_queue_runnable_after_retry() {
         },
         queue_lease_v8: None,
     };
-    let retry = VecDeque::from([PreparedTxRequest {
+    let mut retry = VecDeque::from([PreparedTxRequest {
         offset: 64,
         len: 1500,
         recycle: PreparedTxRecycle::FreeTxFrame,
@@ -218,7 +218,7 @@ fn restore_cos_prepared_items_marks_queue_runnable_after_retry() {
         enqueue_ns: 0,
     }]);
 
-    let retry_bytes = restore_cos_prepared_items_inner(&mut queue, retry);
+    let retry_bytes = restore_cos_prepared_items_inner(&mut queue, &mut retry);
 
     assert_eq!(queue.hot.items.len(), 1);
     assert_eq!(retry_bytes, 1500);

--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -827,6 +827,13 @@ pub(in crate::afxdp) fn refresh_cos_interface_activity(
     binding.cos.released_queue_leases_scratch = released_queue_leases;
 }
 
+// #4973: returns the drained (now-empty) `retry` deque so the CoSBatch submit
+// handler can store it back into the per-worker Local batch scratch, reusing the
+// ring-buffer allocation. On the queue-torn-down early return the deque is
+// returned undrained (its items are dropped by the next `build_cos_batch_from_queue`
+// `clear()`, exactly as the previous by-value drop dropped them — the queue is
+// gone, so those items were already unrecoverable). Behavior is otherwise
+// identical; only the deque's ownership is threaded back out.
 #[inline]
 pub(in crate::afxdp) fn apply_cos_send_result(
     binding: &mut BindingWorker,
@@ -835,8 +842,8 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     phase: CoSServicePhase,
     batch_bytes: u64,
     sent_bytes: u64,
-    retry: VecDeque<TxRequest>,
-) {
+    mut retry: VecDeque<TxRequest>,
+) -> VecDeque<TxRequest> {
     // #4265 (R-2): the serviced queue's shared lease is debited in the
     // Guarantee phase regardless of `exact` — a non-exact guaranteed
     // sharded queue now carries a legacy lease that meters its class-wide
@@ -866,7 +873,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
     let peer_exact_demand_mask = peer_exact_demand_queue_mask(binding, root_ifindex);
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
-            return;
+            return retry;
         };
         let exact_demand_mask = exact_backlog_queue_mask(root) | peer_exact_demand_mask;
         let exact_demand_rate =
@@ -884,7 +891,7 @@ pub(in crate::afxdp) fn apply_cos_send_result(
                 && !queue.config.exact
                 && matches!(phase, CoSServicePhase::Surplus)
                 && exact_demand_rate > 0;
-            let retry_bytes = restore_cos_local_items_inner(queue, retry);
+            let retry_bytes = restore_cos_local_items_inner(queue, &mut retry);
             queue.hot.queued_bytes = queue
                 .hot
                 .queued_bytes
@@ -944,8 +951,13 @@ pub(in crate::afxdp) fn apply_cos_send_result(
         maybe_consume_exact_queue_lease(shared_queue_lease, phase, sent_bytes);
     }
     refresh_cos_interface_activity(binding, root_ifindex);
+    // #4973: hand the drained deque back for batch-scratch reuse.
+    retry
 }
 
+// #4973: prepared variant of `apply_cos_send_result` — returns the drained
+// deque so the submit handler can reuse it as the per-worker Prepared batch
+// scratch. See `apply_cos_send_result` for the ownership rationale.
 #[inline]
 pub(in crate::afxdp) fn apply_cos_prepared_result(
     binding: &mut BindingWorker,
@@ -954,8 +966,8 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     phase: CoSServicePhase,
     batch_bytes: u64,
     sent_bytes: u64,
-    retry: VecDeque<PreparedTxRequest>,
-) {
+    mut retry: VecDeque<PreparedTxRequest>,
+) -> VecDeque<PreparedTxRequest> {
     // #4265 (R-2): the serviced queue's shared lease is debited in the
     // Guarantee phase regardless of `exact` — a non-exact guaranteed
     // sharded queue now carries a legacy lease that meters its class-wide
@@ -983,7 +995,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
     let peer_exact_demand_mask = peer_exact_demand_queue_mask(binding, root_ifindex);
     {
         let Some(root) = binding.cos.cos_interfaces.get_mut(&root_ifindex) else {
-            return;
+            return retry;
         };
         let exact_demand_mask = exact_backlog_queue_mask(root) | peer_exact_demand_mask;
         let exact_demand_rate =
@@ -1001,7 +1013,7 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
                 && !queue.config.exact
                 && matches!(phase, CoSServicePhase::Surplus)
                 && exact_demand_rate > 0;
-            let retry_bytes = restore_cos_prepared_items_inner(queue, retry);
+            let retry_bytes = restore_cos_prepared_items_inner(queue, &mut retry);
             queue.hot.queued_bytes = queue
                 .hot
                 .queued_bytes
@@ -1063,12 +1075,19 @@ pub(in crate::afxdp) fn apply_cos_prepared_result(
         maybe_consume_exact_queue_lease(shared_queue_lease, phase, sent_bytes);
     }
     refresh_cos_interface_activity(binding, root_ifindex);
+    // #4973: hand the drained deque back for batch-scratch reuse.
+    retry
 }
 
+// #4973: `retry` is drained in place (`&mut`) rather than consumed by value, so
+// the caller (`apply_cos_send_result` / the submit-side restore wrapper) keeps
+// ownership of the now-empty deque and can hand it back to the per-worker batch
+// scratch, retaining its ring-buffer allocation. `pop_back` still empties it, so
+// behavior is identical; only the ownership transfer moved to the caller.
 #[inline]
 pub(in crate::afxdp) fn restore_cos_local_items_inner(
     queue: &mut CoSQueueRuntime,
-    mut retry: VecDeque<TxRequest>,
+    retry: &mut VecDeque<TxRequest>,
 ) -> u64 {
     let mut retry_bytes = 0u64;
     while let Some(req) = retry.pop_back() {
@@ -1084,7 +1103,7 @@ pub(in crate::afxdp) fn restore_cos_local_items_inner(
 #[inline]
 pub(in crate::afxdp) fn restore_cos_prepared_items_inner(
     queue: &mut CoSQueueRuntime,
-    mut retry: VecDeque<PreparedTxRequest>,
+    retry: &mut VecDeque<PreparedTxRequest>,
 ) -> u64 {
     let mut retry_bytes = 0u64;
     while let Some(req) = retry.pop_back() {

--- a/userspace-dp/src/afxdp/worker/cos_state.rs
+++ b/userspace-dp/src/afxdp/worker/cos_state.rs
@@ -54,4 +54,15 @@ pub(crate) struct WorkerCos {
     /// heap-allocate per settle — it is `mem::take`n out, filled, drained by
     /// reference, and stored back to retain capacity across calls.
     pub(crate) released_queue_leases_scratch: Vec<(usize, usize, u64)>,
+    /// #4973: reusable per-worker Local/Prepared batch deques for the shaped-TX
+    /// path. `build_cos_batch_from_queue` used to `VecDeque::new()` a fresh
+    /// deque per selected batch, so `drain_shaped_tx` heap-allocated on every
+    /// non-exact drain. These two scratch deques are `mem::take`n out at batch
+    /// build (cleared, filled with the selected items, moved into the
+    /// `CoSBatch`), then drained empty by the submit handler and stored back so
+    /// the ring-buffer allocation is retained across drains. Only ONE of the
+    /// two is consumed per batch (the head item's variant decides), so the
+    /// other keeps its capacity untouched. Allocation-free after warmup.
+    pub(crate) cos_local_batch_scratch: std::collections::VecDeque<TxRequest>,
+    pub(crate) cos_prepared_batch_scratch: std::collections::VecDeque<PreparedTxRequest>,
 }

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -544,6 +544,8 @@ impl BindingWorker {
                 cos_wheel_ticks_advanced_max: 0,
                 cos_queue_lease_undergrants: CoSQueueLeaseUndergrantCounters::default(),
                 released_queue_leases_scratch: Vec::new(),
+                cos_local_batch_scratch: VecDeque::new(),
+                cos_prepared_batch_scratch: VecDeque::new(),
             },
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
@@ -693,6 +695,8 @@ impl BindingWorker {
                 cos_wheel_ticks_advanced_max: 0,
                 cos_queue_lease_undergrants: CoSQueueLeaseUndergrantCounters::default(),
                 released_queue_leases_scratch: Vec::new(),
+                cos_local_batch_scratch: VecDeque::new(),
+                cos_prepared_batch_scratch: VecDeque::new(),
             },
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),
@@ -815,6 +819,8 @@ impl BindingWorker {
                 cos_wheel_ticks_advanced_max: 0,
                 cos_queue_lease_undergrants: CoSQueueLeaseUndergrantCounters::default(),
                 released_queue_leases_scratch: Vec::new(),
+                cos_local_batch_scratch: VecDeque::new(),
+                cos_prepared_batch_scratch: VecDeque::new(),
             },
             scratch: WorkerScratch {
                 scratch_recycle: Vec::with_capacity(RX_BATCH_SIZE as usize),


### PR DESCRIPTION
## Summary

`build_cos_batch_from_queue` allocated a fresh `VecDeque` per selected batch on the non-exact shaped-TX path (the `Local(_)` and `Prepared(_)` arms each `let mut items = VecDeque::new();`). `drain_shaped_tx` calls it repeatedly, so a saturated non-exact queue paid a heap allocation (plus growth reallocs) on **every** guarantee/surplus drain — the deque's capacity flowed into the `CoSBatch`, was drained by the submit handler, and dropped, never returned to worker state.

This adds two reusable **per-worker** deques to `WorkerCos` (`cos_local_batch_scratch` / `cos_prepared_batch_scratch`) that round-trip build → submit → back, so the shaped-TX drain is allocation-free after warmup. Mirrors the `released_queue_leases_scratch` reuse pattern that just landed in #4972.

## Mechanism

- **Build side**: `build_cos_batch_from_queue` `clear()`s the matching scratch at entry, fills it, and `mem::take`s it into the `CoSBatch`. Only the head item's variant is consumed per batch; the other arm's scratch keeps its capacity untouched.
- **Submit side**: `apply_cos_send_result` / `apply_cos_prepared_result` now **return** the drained deque (were `()`, consuming by value); `restore_cos_*_items_inner` and the submit-side restore wrappers drain via `&mut` so the caller keeps ownership. `submit_local` / `submit_prepared` capture the emptied deque and store it back into the `WorkerCos` field.
- **Threading**: the scratch reaches build via `build_nonexact_cos_batch` — a disjoint-field split-borrow of the two scratch fields alongside the `cos_interfaces` mutable borrow (the same borrow-split `queue_fast_path` already uses) — passed through new `select_nonexact_cos_guarantee_batch_into` and the extended `select_cos_surplus_batch_filtered`. The old public selectors keep their allocating signatures as thin `#[cfg(test)]` wrappers, so the ~30 unit-test call sites are unchanged.

## Behavior preservation

Batch contents, order, and submit semantics are **identical** — only the deque's ownership round-trips through worker state instead of being allocated and dropped. The `clear()` at build entry defends against a queue-torn-down submit early return that stores the deque back undrained: its stale items are dropped at the next build, exactly as the previous by-value drop dropped them (the queue is gone, so those items were already unrecoverable).

## Validation

- **Full `cos` cargo suite green**: 587 lib tests (incl. the 2 new) + `cos_doc_drift` guard, 0 failures. Release build clean.
- **Two RED-on-revert tests** (`build_cos_batch_local_clears_reused_scratch_between_batches`, `build_cos_batch_prepared_clears_reused_scratch_between_batches`): pre-seed the reused scratch with a stale 9999-byte marker and assert the built batch contains only freshly popped queue items. **Verified both go RED** when the respective arm's `clear()` is neutralized (genuine assertion failure, not a build break).
- **Not directly unit-assertable**: "no allocation on the hot path." The per-class CoS iperf3 smoke on the loss userspace cluster is the real throughput validation — the parent runs it.

## Sites pooled

Both `build_cos_batch_from_queue` arms (Local + Prepared), covering the two production drain selectors (`select_nonexact_cos_guarantee_batch_into` guarantee pass, `select_cos_surplus_batch_filtered` surplus pass).

Docs: updated `userspace-dp/src/afxdp/cos/README.md` batch-model notes.

Closes #4973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPzTZcLFKw3dL6x1XDEoJm