### PR TITLE
api: distinct holder identity per REST config session (#6197)

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -12,33 +14,59 @@ import (
 	"github.com/psaab/xpf/pkg/configstore"
 )
 
-// restConfigSessionID is the fixed config-lock holder identity every REST
-// config MUTATION runs under (#5870). REST is stateless across calls, so all
-// REST config edits share ONE logical operator identity that PARTICIPATES in
-// the shared-candidate holder lock, rather than passing the empty session ID
-// that the store treats as its internal/system capability (daemon apply, HA
-// sync, in-process CLI) and which BYPASSES the holder lock entirely.
-//
-// Consequences of routing every REST mutation through this non-empty identity:
-//   - a REST set/delete/commit is REJECTED (ErrConfigLockedByOther) when a CLI
-//     or gRPC configuration session owns the candidate, and symmetrically a
-//     CLI/gRPC mutation is rejected while REST holds it — closing the exact
-//     cross-session candidate-corruption / commit-smuggling hole in #5870.
-//   - the store's sessionID=="" system-bypass semantics are untouched; only the
-//     REST layer stops USING that bypass. Read-only REST endpoints are
-//     unaffected.
-//
-// It is deliberately non-empty and constant. A gRPC config session is keyed by
-// a random per-connection token / peer address (pkg/grpcapi connSessionID), so
-// this literal never collides with a real peer session identity.
-//
-// Statelessness caveat: because REST carries no per-request session token, two
-// concurrent REST clients share this one identity and are NOT mutually
-// excluded from each other (only from CLI/gRPC). Giving each REST caller a
-// distinct token is a REST API contract change (a product decision) tracked
-// separately; this fix closes the cross-transport bypass without expanding
-// scope.
-const restConfigSessionID = "rest"
+// restConfigSessionHeader carries the server-generated identity of a REST
+// configuration session (#6197). POST /config/enter allocates a distinct,
+// unguessable token for each session and returns it as session_id; subsequent
+// holder-scoped requests must echo it in this header. Keeping the identity in
+// a header gives bodyless operations (commit/confirm/exit) and JSON-body
+// operations one uniform contract.
+const restConfigSessionHeader = "X-Config-Session"
+
+const (
+	restConfigSessionPrefix     = "rest-"
+	restConfigSessionTokenBytes = 16
+)
+
+// newRESTConfigSessionID creates a holder identity in a namespace that cannot
+// collide with gRPC's conn-* identities. crypto/rand makes accidental sharing
+// between independent REST clients negligible and prevents one client from
+// guessing another client's holder token.
+func newRESTConfigSessionID() (string, error) {
+	var token [restConfigSessionTokenBytes]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", fmt.Errorf("generate REST config session: %w", err)
+	}
+	return restConfigSessionPrefix + hex.EncodeToString(token[:]), nil
+}
+
+func validRESTConfigSessionID(sessionID string) bool {
+	if !strings.HasPrefix(sessionID, restConfigSessionPrefix) {
+		return false
+	}
+	raw := strings.TrimPrefix(sessionID, restConfigSessionPrefix)
+	if len(raw) != restConfigSessionTokenBytes*2 {
+		return false
+	}
+	_, err := hex.DecodeString(raw)
+	return err == nil
+}
+
+// restConfigSessionID reads and validates the holder identity supplied by a
+// follow-up REST config request. Missing/malformed identities fail closed
+// before the store is called, so they can never reach its sessionID==""
+// internal/system bypass.
+func restConfigSessionID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	sessionID := strings.TrimSpace(r.Header.Get(restConfigSessionHeader))
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "missing "+restConfigSessionHeader+" header")
+		return "", false
+	}
+	if !validRESTConfigSessionID(sessionID) {
+		writeError(w, http.StatusBadRequest, "invalid "+restConfigSessionHeader+" header")
+		return "", false
+	}
+	return sessionID, true
+}
 
 // writeConfigMutationError maps a config-store mutation error to an HTTP
 // status. A holder-lock conflict (ErrConfigLockedByOther) — a REST mutation
@@ -62,25 +90,38 @@ func (s *Server) configHandler(w http.ResponseWriter, _ *http.Request) {
 	writeOK(w, cfg)
 }
 
-func (s *Server) configEnterHandler(w http.ResponseWriter, _ *http.Request) {
-	// #5870: acquire the candidate lock under the fixed REST identity so a REST
-	// config session participates in holder enforcement (a concurrent CLI/gRPC
-	// session that owns the candidate makes this return ErrConfigLocked → 409),
-	// instead of the empty-session internal acquire that recorded no holder.
-	if err := s.store.EnterConfigureSession(restConfigSessionID); err != nil {
+func (s *Server) configEnterHandler(w http.ResponseWriter, r *http.Request) {
+	// An absent header starts a new session. Supplying the token returned by an
+	// earlier successful enter re-enters that same session and refreshes its
+	// idle lease; a different token remains a conflicting entrant.
+	sessionID := strings.TrimSpace(r.Header.Get(restConfigSessionHeader))
+	if sessionID == "" {
+		var err error
+		sessionID, err = newRESTConfigSessionID()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	} else if !validRESTConfigSessionID(sessionID) {
+		writeError(w, http.StatusBadRequest, "invalid "+restConfigSessionHeader+" header")
+		return
+	}
+
+	if err := s.store.EnterConfigureSession(sessionID); err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return
 	}
-	writeOK(w, map[string]string{"status": "ok"})
+	writeOK(w, map[string]string{"status": "ok", "session_id": sessionID})
 }
 
-func (s *Server) configExitHandler(w http.ResponseWriter, _ *http.Request) {
-	// #5870: release ONLY the REST-held lock. Session-scoped exit is a no-op
-	// when a CLI/gRPC session owns the candidate, so a REST /config/exit can no
-	// longer force-clear another session's in-progress candidate (the previous
-	// unconditional ExitConfigure was itself a facet of the bypass). A wedged
-	// REST lock is still reclaimed by the #4476 idle-lease reaper.
-	s.store.ExitConfigureSession(restConfigSessionID)
+func (s *Server) configExitHandler(w http.ResponseWriter, r *http.Request) {
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
+	// Release only the candidate held by this REST session. A stale or foreign
+	// token cannot clear another client's work.
+	s.store.ExitConfigureSession(sessionID)
 	writeOK(w, map[string]string{"status": "ok"})
 }
 
@@ -101,7 +142,11 @@ func (s *Server) configSetHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.SetFromInputAs(restConfigSessionID, req.Input); err != nil {
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
+	if err := s.store.SetFromInputAs(sessionID, req.Input); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -117,7 +162,11 @@ func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.DeleteFromInputAs(restConfigSessionID, req.Input); err != nil {
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
+	if err := s.store.DeleteFromInputAs(sessionID, req.Input); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -138,7 +187,11 @@ func (s *Server) configDeactivateHandler(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.DeactivateFromInputAs(restConfigSessionID, req.Input); err != nil {
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
+	if err := s.store.DeactivateFromInputAs(sessionID, req.Input); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -156,7 +209,11 @@ func (s *Server) configActivateHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "input required")
 		return
 	}
-	if err := s.store.ActivateFromInputAs(restConfigSessionID, req.Input); err != nil {
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
+	if err := s.store.ActivateFromInputAs(sessionID, req.Input); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -164,12 +221,16 @@ func (s *Server) configActivateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
 	// #5870: only the config-lock holder may commit the shared candidate. Reject
 	// a REST commit before it can confirm/apply another (CLI/gRPC) session's
 	// pending work — the empty-session commit path previously let a stateless
 	// REST caller smuggle another operator's staged edits into an applied
 	// commit. Mirrors the gRPC Commit gate (pkg/grpcapi/server_config.go).
-	if err := s.store.EnsureConfigHolder(restConfigSessionID); err != nil {
+	if err := s.store.EnsureConfigHolder(sessionID); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -180,7 +241,7 @@ func (s *Server) configCommitHandler(w http.ResponseWriter, r *http.Request) {
 	// them AND clears the timer (#3861), so they are committed rather than
 	// silently dropped.
 	if s.store.IsConfirmPending() && !s.store.IsDirty() {
-		if err := s.store.ConfirmCommitAs(restConfigSessionID); err != nil {
+		if err := s.store.ConfirmCommitAs(sessionID); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
@@ -227,9 +288,13 @@ func (s *Server) configRollbackHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("invalid n %d: rollback index must be non-negative (0 = revert to active)", req.N))
 		return
 	}
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
 	// #5870: rollback replaces the candidate, so it runs under the REST holder
 	// identity and is rejected when a CLI/gRPC session owns the candidate.
-	if err := s.store.RollbackAs(restConfigSessionID, req.N); err != nil {
+	if err := s.store.RollbackAs(sessionID, req.N); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -353,17 +418,21 @@ func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "content required")
 		return
 	}
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
 
 	// #5870: load* is a candidate mutation, so it runs under the REST holder
 	// identity and is rejected when a CLI/gRPC session owns the candidate.
 	switch req.Mode {
 	case "override":
-		if err := s.store.LoadOverrideAs(restConfigSessionID, req.Content); err != nil {
+		if err := s.store.LoadOverrideAs(sessionID, req.Content); err != nil {
 			writeConfigMutationError(w, err)
 			return
 		}
 	case "merge", "":
-		if err := s.store.LoadMergeAs(restConfigSessionID, req.Content); err != nil {
+		if err := s.store.LoadMergeAs(sessionID, req.Content); err != nil {
 			writeConfigMutationError(w, err)
 			return
 		}
@@ -372,7 +441,7 @@ func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 		// replays flat lines through applyEditLine so a body with
 		// `deactivate <path>` lines round-trips to inactive nodes (#2008 H1).
 		// Applied-count is log-only to keep the response shape stable.
-		count, err := s.store.LoadSetAs(restConfigSessionID, req.Content)
+		count, err := s.store.LoadSetAs(sessionID, req.Content)
 		if err != nil {
 			writeConfigMutationError(w, err)
 			return
@@ -390,9 +459,13 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 	if !decodeJSONBody(w, r, &req) {
 		return
 	}
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
 	// #5870: only the config-lock holder may commit the shared candidate.
 	// Mirrors the gRPC CommitConfirmed gate.
-	if err := s.store.EnsureConfigHolder(restConfigSessionID); err != nil {
+	if err := s.store.EnsureConfigHolder(sessionID); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -413,11 +486,15 @@ func (s *Server) configCommitConfirmedHandler(w http.ResponseWriter, r *http.Req
 	writeOK(w, commitResponseFromConfig(compiled))
 }
 
-func (s *Server) configConfirmHandler(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) configConfirmHandler(w http.ResponseWriter, r *http.Request) {
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
 	// #5870: confirming a pending commit-confirmed is a holder-scoped op — only
 	// the REST-held candidate may be confirmed from REST; a CLI/gRPC holder's
 	// pending window is rejected (ErrConfigLockedByOther → 409).
-	if err := s.store.ConfirmCommitAs(restConfigSessionID); err != nil {
+	if err := s.store.ConfirmCommitAs(sessionID); err != nil {
 		writeConfigMutationError(w, err)
 		return
 	}
@@ -469,11 +546,15 @@ func (s *Server) configAnnotateHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, Response{Error: "path and comment are required"})
 		return
 	}
+	sessionID, ok := restConfigSessionID(w, r)
+	if !ok {
+		return
+	}
 	pathParts := strings.Fields(req.Path)
 	// #5870: annotate mutates the candidate, so it runs under the REST holder
 	// identity and is rejected when a CLI/gRPC session owns the candidate. A
 	// holder conflict maps to 409 Conflict; other errors stay 400.
-	if err := s.store.AnnotateAs(restConfigSessionID, pathParts, req.Comment); err != nil {
+	if err := s.store.AnnotateAs(sessionID, pathParts, req.Comment); err != nil {
 		status := http.StatusBadRequest
 		if errors.Is(err, configstore.ErrConfigLockedByOther) {
 			status = http.StatusConflict

--- a/pkg/api/config_activate_test.go
+++ b/pkg/api/config_activate_test.go
@@ -38,6 +38,7 @@ func TestConfigDeactivateHandlerMarksInactive(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/deactivate",
 		strings.NewReader(`{"input":"system name-server 9.9.9.9"}`))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configDeactivateHandler(rr, req)
 	if rr.Code != 200 {
 		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
@@ -62,6 +63,7 @@ func TestConfigActivateHandlerClearsInactive(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/activate",
 		strings.NewReader(`{"input":"system name-server 9.9.9.9"}`))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configActivateHandler(rr, req)
 	if rr.Code != 200 {
 		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
@@ -84,6 +86,7 @@ func TestConfigLoadHandlerModeSet(t *testing.T) {
 	body := `{"mode":"set","content":"set system host-name keep\nset system name-server 9.9.9.9\ndeactivate system name-server 9.9.9.9"}`
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/load", strings.NewReader(body))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configLoadHandler(rr, req)
 	if rr.Code != 200 {
 		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())

--- a/pkg/api/config_commit_test.go
+++ b/pkg/api/config_commit_test.go
@@ -69,6 +69,7 @@ func TestConfigCommitHandlerRejectsRetiredEBPF(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/commit", nil)
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configCommitHandler(rr, req)
 
 	body := rr.Body.String()
@@ -92,6 +93,7 @@ func TestConfigCommitConfirmedHandlerRejectsRetiredEBPF(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/commit-confirmed",
 		strings.NewReader(`{"minutes":10}`))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configCommitConfirmedHandler(rr, req)
 
 	body := rr.Body.String()

--- a/pkg/api/config_load_bodycap_hb164_test.go
+++ b/pkg/api/config_load_bodycap_hb164_test.go
@@ -52,6 +52,7 @@ func TestConfigLoadHandlerAcceptsNormalBody(t *testing.T) {
 	body := `{"mode":"set","content":"set system host-name fw"}`
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/load", strings.NewReader(body))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configLoadHandler(rr, req)
 	if rr.Code != 200 {
 		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())

--- a/pkg/api/config_session_holder_5870_test.go
+++ b/pkg/api/config_session_holder_5870_test.go
@@ -21,9 +21,8 @@ import (
 // configuration session legitimately OWNED, corrupting or smuggling changes into
 // another operator's session.
 //
-// These tests go RED (assertion failure, not compile break) when the fix is
-// neutralized by reverting restConfigSessionID to "" in config.go: the empty
-// identity re-enables the store's system bypass, so the rejected mutations
+// These tests go RED if the REST handlers pass an empty identity: the empty
+// value re-enables the store's system bypass, so the rejected mutations
 // wrongly succeed and stomp / smuggle the held candidate.
 
 // TestRESTConfigSetDeleteRejectedWhenOtherSessionHoldsCandidate simulates a
@@ -49,6 +48,7 @@ func TestRESTConfigSetDeleteRejectedWhenOtherSessionHoldsCandidate(t *testing.T)
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/set",
 		strings.NewReader(`{"input":"system host-name stomped-by-rest"}`))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configSetHandler(rr, req)
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("REST set while CLI holds candidate: status = %d, want 409; body: %s",
@@ -59,6 +59,7 @@ func TestRESTConfigSetDeleteRejectedWhenOtherSessionHoldsCandidate(t *testing.T)
 	rr = httptest.NewRecorder()
 	req = httptest.NewRequest("POST", "/api/v1/config/delete",
 		strings.NewReader(`{"input":"system host-name"}`))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configDeleteHandler(rr, req)
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("REST delete while CLI holds candidate: status = %d, want 409; body: %s",
@@ -104,7 +105,9 @@ func TestRESTConfigCommitRejectedWhenOtherSessionHoldsCandidate(t *testing.T) {
 	}
 
 	rr := httptest.NewRecorder()
-	s.configCommitHandler(rr, httptest.NewRequest("POST", "/api/v1/config/commit", nil))
+	req := withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/commit", nil), testRESTConfigSessionID)
+	s.configCommitHandler(rr, req)
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("REST commit while CLI holds candidate: status = %d, want 409; body: %s",
 			rr.Code, rr.Body.String())
@@ -124,17 +127,14 @@ func TestRESTConfigMutationAllowedAndHoldsLock(t *testing.T) {
 	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
 	s := &Server{store: store}
 
-	// REST enters config mode under its own fixed identity.
-	rr := httptest.NewRecorder()
-	s.configEnterHandler(rr, httptest.NewRequest("POST", "/api/v1/config/enter", nil))
-	if rr.Code != http.StatusOK {
-		t.Fatalf("REST enter: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
-	}
+	// REST enters config mode under its own server-generated identity.
+	sessionID := enterRESTConfigSession(t, s, "")
 
 	// REST set succeeds — REST is the holder.
-	rr = httptest.NewRecorder()
+	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/set",
 		strings.NewReader(`{"input":"system host-name rest-owned"}`))
+	withRESTConfigSession(req, sessionID)
 	s.configSetHandler(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("REST set as holder: status = %d, want 200; body: %s", rr.Code, rr.Body.String())

--- a/pkg/api/config_session_holder_6197_test.go
+++ b/pkg/api/config_session_holder_6197_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+const testRESTConfigSessionID = "rest-00000000000000000000000000000001"
+
+func withRESTConfigSession(req *http.Request, sessionID string) *http.Request {
+	req.Header.Set(restConfigSessionHeader, sessionID)
+	return req
+}
+
+func enterRESTConfigSession(t *testing.T, s *Server, sessionID string) string {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/config/enter", nil)
+	if sessionID != "" {
+		withRESTConfigSession(req, sessionID)
+	}
+	rr := httptest.NewRecorder()
+	s.configEnterHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST enter: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			SessionID string `json:"session_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode REST enter response: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success || !validRESTConfigSessionID(resp.Data.SessionID) {
+		t.Fatalf("REST enter returned invalid session identity: %q; body: %s",
+			resp.Data.SessionID, rr.Body.String())
+	}
+	return resp.Data.SessionID
+}
+
+func exitRESTConfigSession(t *testing.T, s *Server, sessionID string) {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/exit", nil), sessionID)
+	s.configExitHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST exit: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRESTConfigSessionsAreMutuallyExcluded is the fail-on-revert guard for
+// #6197. It obtains two independently issued REST identities, lets session A
+// hold and edit the candidate, then proves session B cannot set or commit it.
+// Replacing the request token with the old shared holder identity "rest" makes
+// both B operations succeed and turns this test RED.
+func TestRESTConfigSessionsAreMutuallyExcluded(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	commitCalled := false
+	s := &Server{
+		store: store,
+		commitFn: func(context.Context, string) (*config.Config, error) {
+			commitCalled = true
+			return store.Commit()
+		},
+	}
+
+	// Obtain B's server-issued identity, release it, then let independently
+	// issued session A become the live holder.
+	sessionB := enterRESTConfigSession(t, s, "")
+	exitRESTConfigSession(t, s, sessionB)
+	sessionA := enterRESTConfigSession(t, s, "")
+	if sessionA == sessionB {
+		t.Fatalf("independent REST enters shared session identity %q", sessionA)
+	}
+	rr := httptest.NewRecorder()
+	req := withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/enter", nil), sessionB)
+	s.configEnterHandler(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("REST B enter while A holds candidate: status = %d, want 409; body: %s",
+			rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	req = withRESTConfigSession(httptest.NewRequest("POST", "/api/v1/config/set",
+		strings.NewReader(`{"input":"system host-name held-by-rest-a"}`)), sessionA)
+	s.configSetHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("REST A set: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	before := store.ShowCandidateSet()
+
+	rr = httptest.NewRecorder()
+	req = withRESTConfigSession(httptest.NewRequest("POST", "/api/v1/config/set",
+		strings.NewReader(`{"input":"system host-name stomped-by-rest-b"}`)), sessionB)
+	s.configSetHandler(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("REST B set while A holds candidate: status = %d, want 409; body: %s",
+			rr.Code, rr.Body.String())
+	}
+	if after := store.ShowCandidateSet(); after != before {
+		t.Fatalf("REST B set changed A's candidate:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+
+	rr = httptest.NewRecorder()
+	req = withRESTConfigSession(
+		httptest.NewRequest("POST", "/api/v1/config/commit", nil), sessionB)
+	s.configCommitHandler(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("REST B commit while A holds candidate: status = %d, want 409; body: %s",
+			rr.Code, rr.Body.String())
+	}
+	if commitCalled {
+		t.Fatal("REST B commit invoked commit callback while A held the candidate")
+	}
+}

--- a/pkg/api/config_session_holder_6197_test.go
+++ b/pkg/api/config_session_holder_6197_test.go
@@ -60,8 +60,8 @@ func exitRESTConfigSession(t *testing.T, s *Server, sessionID string) {
 // TestRESTConfigSessionsAreMutuallyExcluded is the fail-on-revert guard for
 // #6197. It obtains two independently issued REST identities, lets session A
 // hold and edit the candidate, then proves session B cannot set or commit it.
-// Replacing the request token with the old shared holder identity "rest" makes
-// both B operations succeed and turns this test RED.
+// Reverting to a single shared valid holder identity (so A and B are no longer
+// distinguished) makes both B operations succeed and turns this test RED.
 func TestRESTConfigSessionsAreMutuallyExcluded(t *testing.T) {
 	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
 	commitCalled := false

--- a/pkg/api/http_dos_hardening_4150_test.go
+++ b/pkg/api/http_dos_hardening_4150_test.go
@@ -111,6 +111,7 @@ func TestConfigMutationNormalBodySucceedsM7(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/v1/config/set",
 		strings.NewReader(`{"input":"system host-name capped-ok"}`))
+	withRESTConfigSession(req, testRESTConfigSessionID)
 	s.configSetHandler(rr, req)
 
 	if rr.Code != 200 {

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -291,8 +291,8 @@ proposed config against LIVE hardware while the operator is still connected.
 Candidate mutations (`Set`/`Delete`/`LoadOverride`/`LoadMerge`/`LoadSet`/
 `Deactivate`/`Activate`/`Copy`/`Rename`/`Insert`/`Annotate`/`Rollback`) do
 NOT take the daemon apply semaphore, and internal callers pass
-`sessionID == ""` which bypasses config-lock holder enforcement (REST now
-carries the fixed `restConfigSessionID` holder identity instead, #5870, but
+`sessionID == ""` which bypasses config-lock holder enforcement (REST instead
+carries its server-generated per-session holder identity, #5870/#6197, but
 same-session and internal concurrency remain). So a concurrent edit could land
 between the daemon's pre-flight of candidate C1 and `Commit`'s promotion, and
 the daemon would persist+apply an unexamined C2 — a management-lockout-gate
@@ -326,10 +326,9 @@ commit-confirmed (the active config) is stable across the transaction because
 every path that mutates `active` runs under the daemon apply semaphore the
 commit path holds from pre-flight through promotion.
 
-Scope: REST config mutations now carry a fixed holder identity that
-participates in the config-lock gate (#5870, see "Config-lock ownership gate"),
-but a per-REST-caller session token / ETag semantics remain a separate
-follow-up; generation binding is the invariant required even for
+Scope: REST config mutations carry a server-generated per-session holder
+identity that participates in the config-lock gate (#5870/#6197, see
+"Config-lock ownership gate"). Generation binding remains necessary for
 same-session/internal concurrent callers.
 
 ## Persist-failure semantics (#1799)
@@ -873,26 +872,26 @@ Two deliberate bypasses keep the internal paths working:
   `EnterConfigureSession`, so it cannot manufacture an empty-holder state to
   slip through.
 
-**REST config mutations no longer use the empty-session bypass (#5870).**
+**REST config mutations use distinct holder identities (#5870, #6197).**
 Originally the stateless REST config endpoints (`pkg/api/config.go`) called the
 plain methods with `sessionID == ""`, so a remote REST caller silently wielded
 the internal/system bypass and could Set/Delete/Load/Rollback/Commit a candidate
 that a CLI or gRPC session legitimately held. Every REST config
 enter/set/delete/deactivate/activate/load/annotate/rollback/commit/
-commit-confirmed/confirm now runs under a fixed non-empty holder identity,
-`restConfigSessionID` (`"rest"`), routed through the `*As` variants and the
-`EnsureConfigHolder` commit gate. A REST mutation is therefore rejected with
-`ErrConfigLockedByOther` (mapped to HTTP 409 Conflict) when another session owns
-the candidate, and symmetrically a CLI/gRPC mutation is rejected while REST
-holds it; `/config/exit` releases only the REST-held lock via
-`ExitConfigureSession` instead of force-clearing any holder. The store's
-`sessionID == ""` semantics are unchanged — only the REST layer stopped using
-them; read-only REST endpoints are unaffected. Because REST is stateless and
-carries no per-request token, two concurrent REST clients share this single
-`"rest"` identity and are not mutually excluded from each other (only from
-CLI/gRPC) — a distinct per-caller REST session token is the separate follow-up
-noted in "Generation-bound commit transaction" above. A wedged REST lock is
-still reclaimed by the #4476 idle-lease reaper.
+commit-confirmed/confirm is routed through the `*As` variants and the
+`EnsureConfigHolder` commit gate. `POST /api/v1/config/enter` generates a
+distinct 128-bit identity, returns it as `data.session_id`, and records it as
+the holder. The client must send that value in the `X-Config-Session` header on
+subsequent holder-scoped requests (including exit); enter accepts an existing
+valid token only to re-enter the same session and refresh its idle lease.
+A mutation from a different REST client, or from CLI/gRPC, is rejected with
+`ErrConfigLockedByOther` (HTTP 409 Conflict), and CLI/gRPC is symmetrically
+rejected while REST holds the candidate. Missing or malformed REST tokens fail
+with HTTP 400 before reaching the store, so they cannot become the
+`sessionID == ""` internal/system bypass. `/config/exit` releases only the
+matching holder through `ExitConfigureSession`. Read-only endpoints are
+unaffected, and a wedged REST lock is still reclaimed by the #4476 idle-lease
+reaper.
 
 Like `ErrClusterReadOnly`, `ErrConfigLockedByOther` is `errors.Is`-matchable;
 it is transient (the holder commits or exits). The internal `SyncApply` /

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -750,7 +750,7 @@ ends (`configLockStatsHandler`'s `ConnEnd` in `pkg/grpcapi`, #5849, calls
 never on per-RPC cancellation, so a cancelled unary no longer discards the
 connection's candidate). The **REST** config
 path has no such hook: `POST /api/v1/config/enter`
-(`configEnterHandler`) takes the global lock with an empty holder, and a
+(`configEnterHandler`) takes the global lock with a per-session holder token (#6197; historically an empty holder, which #6196/#6197 replaced), and a
 stateless HTTP client that never calls `/config/exit` leaves it held. On
 its own that wedged every CLI/gRPC/REST config edit with `ErrConfigLocked`
 until `clear system config-lock` or a daemon restart — a management-plane

--- a/pkg/configstore/store_lock.go
+++ b/pkg/configstore/store_lock.go
@@ -36,8 +36,7 @@ func (s *Store) ensureWritableLocked() error {
 // MUST hold s.mu.
 //
 // Two deliberate bypasses:
-//   - sessionID == "" is the internal/system capability (daemon apply, the
-//     stateless REST config-enter path, HA sync, in-process CLI, tests). These
+//   - sessionID == "" is the internal/system capability (daemon apply, HA sync, in-process CLI, tests). These
 //     do not carry a peer session and must not be blocked.
 //   - a lock with no recorded holder (effectiveHolderLocked() == "", i.e. the
 //     internal/local EnterConfigure() path) is not owned by any session, so a


### PR DESCRIPTION
#6196 gave REST config mutations a fixed holder identity so REST can't stomp a CLI/gRPC-held candidate, but all REST callers shared it — two concurrent REST clients weren't mutually excluded. This assigns each REST config session a distinct holder identity: a second concurrent REST client gets 409 against the first's candidate (like REST-vs-CLI/gRPC), preserving the #6196 cross-transport exclusion.

Fail-on-revert test in config_session_holder_6197_test.go. Implemented via Codex, gated by parent-RED + hostile review (Codex + AGY).

Closes #6197