### PR TITLE
userspace-dp/CoS: bound timer-wheel catch-up on parked far-future queue (#5803)

### DIFF
--- a/userspace-dp/src/afxdp/cos/tx_completion.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion.rs
@@ -227,8 +227,8 @@ pub(in crate::afxdp) fn normalize_cos_queue_state(queue: &mut CoSQueueRuntime) {
     mark_cos_queue_runnable(queue);
 }
 
-/// Advance the interface timer wheel to `now_ns`, one 50 µs tick per
-/// loop iteration. Returns the number of ticks advanced by THIS call
+/// Advance the interface timer wheel to `now_ns`. Returns the number
+/// of ticks advanced by THIS call
 /// (`now_tick - current_tick` at entry) — the #1782 Step-1 §4(i)
 /// catch-up instrument. The return value is computed once before the
 /// loop (O(1), no extra clock reads) and reports the TRUE lag even
@@ -241,8 +241,10 @@ pub(in crate::afxdp) fn normalize_cos_queue_state(queue: &mut CoSQueueRuntime) {
 /// wheel horizon — the first shaped drain after a long per-worker
 /// idle period — the per-tick loop is pure O(lag) catch-up (~111 s of
 /// 50 µs ticks replayed for one cold connect in the Step-1 evidence).
-/// `snap_cos_timer_wheel_over_horizon` replaces it with an O(slots)
-/// snap when no queue is parked. In-horizon lag
+/// `snap_cos_timer_wheel_over_horizon` replaces it with an
+/// O(slots + queues) snap. Parked queues that are already due
+/// are woken, while future parks are reinserted from their absolute
+/// wake ticks against the snapped current tick. In-horizon lag
 /// (`<= COS_TIMER_WHEEL_TOTAL_HORIZON_TICKS`) always takes the
 /// existing per-tick loop unchanged.
 #[inline]
@@ -250,27 +252,37 @@ pub(in crate::afxdp) fn advance_cos_timer_wheel(
     root: &mut CoSInterfaceRuntime,
     now_ns: u64,
 ) -> u64 {
+    advance_cos_timer_wheel_counting_iterations(root, now_ns).0
+}
+
+/// Implementation split out so regression tests can distinguish the
+/// true elapsed-tick telemetry from the amount of synchronous per-tick
+/// work. The second tuple field is optimized away in production callers.
+#[inline]
+fn advance_cos_timer_wheel_counting_iterations(
+    root: &mut CoSInterfaceRuntime,
+    now_ns: u64,
+) -> (u64, u64) {
     let now_tick = cos_tick_for_ns(now_ns);
     let ticks_advanced = now_tick.saturating_sub(root.timer_wheel.current_tick);
-    if ticks_advanced > COS_TIMER_WHEEL_TOTAL_HORIZON_TICKS
-        && snap_cos_timer_wheel_over_horizon(root, now_tick)
-    {
-        return ticks_advanced;
+    if ticks_advanced > COS_TIMER_WHEEL_TOTAL_HORIZON_TICKS {
+        snap_cos_timer_wheel_over_horizon(root, now_tick);
+        return (ticks_advanced, 0);
     }
+    let mut iterations = 0;
     while root.timer_wheel.current_tick < now_tick {
+        iterations += 1;
         root.timer_wheel.current_tick = root.timer_wheel.current_tick.saturating_add(1);
         if root.timer_wheel.current_tick % COS_TIMER_WHEEL_L0_SLOTS as u64 == 0 {
             cascade_cos_timer_wheel_level1(root);
         }
         wake_due_cos_timer_slot(root);
     }
-    ticks_advanced
+    (ticks_advanced, iterations)
 }
 
-/// #1782 Step-2 (§5.2 mechanism (i)): O(slots) wheel catch-up for an
-/// over-horizon lag. Returns `true` if the wheel was snapped to
-/// `now_tick` (caller skips the per-tick loop), `false` to fall back
-/// to the existing O(lag) loop.
+/// #1782 Step-2 (§5.2 mechanism (i)), extended by #5803: bounded wheel
+/// catch-up for an over-horizon lag.
 ///
 /// Correctness (plan Codex F1 + AGY F1 fold): the "wheel is empty at
 /// idle" shortcut is FALSE — `park_cos_queue` pushes queue indices
@@ -278,46 +290,20 @@ pub(in crate::afxdp) fn advance_cos_timer_wheel(
 /// queue flags, never the slot vectors; stale entries are filtered
 /// lazily by the `parked`/`wheel_level`/`wheel_slot` checks in
 /// `wake_due_cos_timer_slot` / `cascade_cos_timer_wheel_level1`. So
-/// the snap (option (a)) first verifies NO queue is parked: with no
-/// parked queue, EVERY wheel entry is stale (`!parked` fails the lazy
-/// filter), so the per-tick loop's only effects over an over-horizon
-/// lag are (1) emptying every slot vector — the loop visits all L0
-/// slots and cascades all L1 slots, see
-/// `COS_TIMER_WHEEL_TOTAL_HORIZON_TICKS` — and (2) setting
-/// `current_tick = now_tick`. The snap performs exactly those two
-/// effects, touching no queue state, so it is behavior-identical by
-/// construction.
-///
-/// Scope of the `false` fallback (Codex PR #1854 r1 — the original
-/// "naturally bounded" claim was FALSE and is retracted): park wake
-/// ticks are NOT statically bounded by the wheel horizon. The wake
-/// tick is `now + deficit/rate` with an uncapped refill time
-/// (`queue_service/mod.rs` park site, `token_bucket.rs` refill), and
-/// the config accepts rates as low as 1 B/s (`transmit-rate 8`),
-/// where a 1500-byte head parks ~30,000,000 ticks (~25 min) out. A
-/// worker that goes fully idle while such a queue is parked CAN
-/// therefore re-enter the O(lag) per-tick loop on its next drain —
-/// the snap deliberately does not cover that state, because re-arming
-/// parked entries against the snapped tick requires the absolute
-/// wake-tick bookkeeping of plan option (b), reviewed as
-/// not-worth-the-risk for a pathological-config-only residual. What
-/// the snap DOES cover is the proven production mechanism (#1782
-/// Step-1 evidence): a fully idle worker has no backlog, hence no
-/// parked queue, and snaps in O(slots). For ordinary configured rates
-/// a parked queue's wake is near-term and the owner's drain priming
-/// (`cos_root_can_service_after_prime`) keeps the wheel advancing, so
-/// the fallback loop stays short in practice. No debug assertion: the
-/// parked+huge-lag state is legitimate (low-rate configs), and the
-/// fallback test constructs it deliberately.
+/// The snap clears all old slot entries and sets `current_tick =
+/// now_tick`. It then rebuilds every valid parked entry from the
+/// queue's absolute `next_wakeup_tick`: due queues wake immediately,
+/// and future queues are re-parked through `park_cos_queue`, which
+/// re-derives their level and slot relative to the new tick. This is
+/// the same final state as visiting every elapsed tick, including for
+/// wake ticks far beyond the wheel horizon, but costs O(slots + queue
+/// count) rather than O(elapsed ticks).
 ///
 /// Cold-path-only: reached only when lag > ~3.28 s, i.e. the first
 /// shaped drain after idle. `Vec::clear` frees nothing (capacity
 /// retained) — no allocation either way.
 #[cold]
-fn snap_cos_timer_wheel_over_horizon(root: &mut CoSInterfaceRuntime, now_tick: u64) -> bool {
-    if root.queues.iter().any(|queue| queue.hot.parked) {
-        return false;
-    }
+fn snap_cos_timer_wheel_over_horizon(root: &mut CoSInterfaceRuntime, now_tick: u64) {
     for slot in root.timer_wheel.level0.iter_mut() {
         slot.clear();
     }
@@ -325,7 +311,31 @@ fn snap_cos_timer_wheel_over_horizon(root: &mut CoSInterfaceRuntime, now_tick: u
         slot.clear();
     }
     root.timer_wheel.current_tick = now_tick;
-    true
+
+    let mut rearm = core::mem::take(&mut root.timer_wheel.scratch.rearm);
+    let mut wake = core::mem::take(&mut root.timer_wheel.scratch.wake);
+    rearm.clear();
+    wake.clear();
+    for (queue_idx, queue) in root.queues.iter().enumerate() {
+        if !queue.hot.parked {
+            continue;
+        }
+        if queue.hot.next_wakeup_tick <= now_tick {
+            wake.push(queue_idx);
+        } else {
+            rearm.push((queue_idx, queue.hot.next_wakeup_tick));
+        }
+    }
+    for queue_idx in wake.iter().copied() {
+        wake_cos_queue(root, queue_idx);
+    }
+    for (queue_idx, wake_tick) in rearm.iter().copied() {
+        park_cos_queue(root, queue_idx, wake_tick);
+    }
+    rearm.clear();
+    wake.clear();
+    root.timer_wheel.scratch.rearm = rearm;
+    root.timer_wheel.scratch.wake = wake;
 }
 
 fn cascade_cos_timer_wheel_level1(root: &mut CoSInterfaceRuntime) {

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -790,8 +790,9 @@ fn timer_wheel_wakes_short_parked_queue() {
 }
 
 // #1782 Step-1 (i): the advance return value is the per-call tick
-// catch-up instrument — `now_tick - current_tick` at entry, the exact
-// iteration count of the O(lag) loop.
+// catch-up instrument — `now_tick - current_tick` at entry. It remains
+// the true elapsed lag even when an over-horizon advance skips the
+// per-tick loop.
 #[test]
 fn advance_cos_timer_wheel_returns_ticks_advanced() {
     let mut root = test_cos_interface_runtime(0);
@@ -915,17 +916,10 @@ fn timer_wheel_over_horizon_snap_clears_stale_entries_and_reports_true_lag() {
     assert_eq!(root.runnable_queues, 1);
 }
 
-// #1782 Step-2 (i) test 3: a parked queue + over-horizon lag refuses
-// the snap and falls back to the existing O(lag) loop, which wakes
-// the due park correctly. This state is LEGITIMATE in production
-// (Codex PR #1854 r1): park wake ticks are uncapped `deficit/rate`
-// refill times, so pathologically low configured rates (the schema
-// accepts 1 B/s) can park a queue far beyond the wheel horizon while
-// the worker idles — the accepted residual documented at
-// `snap_cos_timer_wheel_over_horizon`. This test pins that the
-// fallback stays correct when it arises.
+// #5803: a parked queue that became due during an over-horizon idle
+// gap must wake as part of the snap, without per-tick replay.
 #[test]
-fn timer_wheel_over_horizon_parked_queue_falls_back_to_per_tick_loop() {
+fn timer_wheel_over_horizon_snap_wakes_due_parked_queue() {
     let mut root = test_cos_interface_runtime(0);
     root.queues[0].hot.items.push_back(test_cos_item(1500));
     root.queues[0].hot.queued_bytes = 1500;
@@ -935,18 +929,78 @@ fn timer_wheel_over_horizon_parked_queue_falls_back_to_per_tick_loop() {
     park_cos_queue(&mut root, 0, 5);
 
     let lag_ticks = COS_TIMER_WHEEL_TOTAL_HORIZON_TICKS + 1_000;
-    assert_eq!(
-        advance_cos_timer_wheel(&mut root, lag_ticks * COS_TIMER_WHEEL_TICK_NS),
-        lag_ticks,
-        "fallback path tick accounting unchanged"
-    );
+    let (ticks_advanced, iterations) =
+        advance_cos_timer_wheel_counting_iterations(&mut root, lag_ticks * COS_TIMER_WHEEL_TICK_NS);
+    assert_eq!(ticks_advanced, lag_ticks);
+    assert_eq!(iterations, 0, "over-horizon advance must snap");
     assert_eq!(root.timer_wheel.current_tick, lag_ticks);
-    // The due park was woken by the loop, not dropped by a snap.
+    // The due park was woken by the snap, not dropped during rebuild.
     assert!(!root.queues[0].hot.parked);
     assert!(root.queues[0].hot.runnable);
     assert_eq!(root.runnable_queues, 1);
     assert!(root.timer_wheel.level0.iter().all(|slot| slot.is_empty()));
     assert!(root.timer_wheel.level1.iter().all(|slot| slot.is_empty()));
+}
+
+// #5803 fail-on-revert: a 1 B/s queue can park tens of millions of
+// 50 us ticks ahead. If its worker idles with that queue parked, an
+// over-horizon advance must remain bounded and must re-derive the
+// future wake slot against the snapped tick. Restoring the old
+// parked-queue refusal makes `iterations == elapsed_ticks` and turns
+// the bounded-work assertion red.
+#[test]
+fn timer_wheel_advance_parked_far_future_queue_is_bounded_and_wakes_on_time() {
+    let mut root = test_cos_interface_runtime(0);
+    root.queues[0].hot.items.push_back(test_cos_item(1500));
+    root.queues[0].hot.queued_bytes = 1500;
+    root.queues[0].hot.runnable = true;
+    root.nonempty_queues = 1;
+    root.runnable_queues = 1;
+
+    let wake_tick = 30_000_000u64;
+    park_cos_queue(&mut root, 0, wake_tick);
+    let elapsed_ticks = 2_226_212u64;
+    assert!(elapsed_ticks > COS_TIMER_WHEEL_TOTAL_HORIZON_TICKS);
+    assert!(wake_tick > elapsed_ticks + COS_TIMER_WHEEL_TOTAL_HORIZON_TICKS);
+
+    let (ticks_advanced, iterations) = advance_cos_timer_wheel_counting_iterations(
+        &mut root,
+        elapsed_ticks * COS_TIMER_WHEEL_TICK_NS,
+    );
+    assert_eq!(ticks_advanced, elapsed_ticks);
+    assert!(
+        iterations < elapsed_ticks / 1_000,
+        "catch-up work must be bounded: {iterations} iterations for {elapsed_ticks} elapsed ticks"
+    );
+    assert!(root.queues[0].hot.parked);
+    assert!(!root.queues[0].hot.runnable);
+    assert_eq!(root.queues[0].hot.next_wakeup_tick, wake_tick);
+    let (level, slot) = cos_timer_wheel_level_and_slot(elapsed_ticks, wake_tick);
+    assert_eq!(root.queues[0].hot.wheel_level, level);
+    assert_eq!(root.queues[0].hot.wheel_slot, slot);
+    assert_eq!(root.timer_wheel.level1[slot], vec![0]);
+
+    let (_, iterations) = advance_cos_timer_wheel_counting_iterations(
+        &mut root,
+        (wake_tick - 1) * COS_TIMER_WHEEL_TICK_NS,
+    );
+    assert_eq!(iterations, 0, "second over-horizon advance must also snap");
+    assert!(root.queues[0].hot.parked, "queue must not wake early");
+    assert_eq!(root.queues[0].hot.wheel_level, 0);
+    assert_eq!(
+        root.queues[0].hot.wheel_slot,
+        (wake_tick % COS_TIMER_WHEEL_L0_SLOTS as u64) as usize
+    );
+
+    let (_, iterations) =
+        advance_cos_timer_wheel_counting_iterations(&mut root, wake_tick * COS_TIMER_WHEEL_TICK_NS);
+    assert_eq!(iterations, 1);
+    assert!(
+        !root.queues[0].hot.parked,
+        "queue must wake at its due tick"
+    );
+    assert!(root.queues[0].hot.runnable);
+    assert_eq!(root.runnable_queues, 1);
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -825,7 +825,7 @@ fn advance_cos_timer_wheel_returns_ticks_advanced() {
 // #1782 Step-2 (i) test 1: lag exactly EQUAL to the wheel horizon
 // with a parked queue takes the existing per-tick loop and wakes the
 // due park exactly as before. NOTE (Codex r1 Low): because this test
-// parks a queue, it exercises the parked-refusal path, NOT the `>`
+// parks a queue, it exercises the strict >-horizon fast-forward boundary, NOT the `>`
 // vs `>=` gate boundary — with no parked queue, snap and loop are
 // state-indistinguishable at exactly-horizon lag (both empty every
 // slot and land on the same tick; AGY r1 confirmed `>=` would also


### PR DESCRIPTION
The CoS timer-wheel cold-start snapped an over-horizon wheel only when no queue was parked; a valid very-low-rate parked queue + an idle→resume replayed every elapsed 50us tick synchronously on the packet worker (~30M iterations / ~25 min stall). Bound the catch-up: fast-forward the wheel when the elapsed gap exceeds the horizon and re-derive the parked wake slot, preserving shaping correctness.

Fail-on-revert test in tx_completion_tests.rs. Implemented via Codex, gated by parent-RED + hostile review (Codex + AGY) + per-class CoS iperf smoke.

Closes #5803