### PR TITLE
userspace-dp: key generated ICMP TE/PTB on logical unit ifindex

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56366,3 +56366,37 @@ top.
   userspace-dp/src/afxdp/worker/{cos_state,mod}.rs,
   userspace-dp/src/afxdp/cos/queue_service/tests/{refund,wakeup}.rs,
   userspace-dp/src/afxdp/cos/README.md
+
+## 2026-07-22 — #6102 generated-ICMP TE/PTB logical-ingress keying
+- **Timestamp**: 2026-07-22
+- **Action**: Fixed the #3026/#3035-adjacent gap where the generated ICMP
+  Time-Exceeded (`icmp::build_local_time_exceeded_request`) and egress-MTU
+  Packet-Too-Big (`tx/dispatch/mod.rs` `compute_forwarded_egress_ptb` build +
+  `enqueue_pending_forwards` classify) paths keyed the `forwarding.egress`
+  feasibility lookup, the reply BUILDERS, and `classify_generated_reply` on the
+  PHYSICAL AF_XDP bind ifindex (`ingress_ident.ifindex`) — all three maps are
+  keyed by the LOGICAL unit ifindex (#6046 established `ingress_ident.ifindex`
+  is physical). On a tagged VLAN sub-if with no untagged parent unit the egress
+  lookup missed → builder `?`-dropped → generated ICMP never produced
+  (traceroute `* * *` / PMTUD blackhole); with a parent it was mis-sourced +
+  mis-classified on the parent's CoS/DSCP/output-filter (fail-closed §6.2
+  boundary gap). Fix mirrors the shipped reject (#3976) / SYN-cookie (#3035)
+  precedent: resolve the logical unit ONCE via `resolve_ingress_logical_ifindex(
+  forwarding, ingress_ident.ifindex, meta.ingress_vlan_id).unwrap_or(physical)`
+  and feed THAT to egress-lookup + build + classify, keeping the PHYSICAL index
+  for the XSK transmit (`target_ifindex`/`tx_ifindex`/`egress_ifindex`) and the
+  #5856 per-zone rate-limit bucket. Rebuilt the vacuous #3026 TE test (it
+  hardcoded `ingress_ident.ifindex = 12` = the logical value, a
+  production-unreachable premise) into a production-reachable fail-on-revert
+  test (physical bind 11, `ingress_logical_ifindex (11,80)→12`, double assertion
+  `is_none()` + `time_exceeded_output_filter_drops == 1`); added a PTB analogue
+  (`ptb_resolves_logical_ingress_for_build_and_classify_6102`) with the same
+  double-assertion shape. Corrected the stale comments/docs (icmp.rs #3026 +
+  #5856 blocks, reject_reply.rs false "TE already passes logical" claim,
+  afxdp/README.md #3026/#3976 entries, generated-reply-rate-limit.md).
+- **File(s)**: userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/tx/dispatch/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs,
+  userspace-dp/src/afxdp/tests_icmp_te.rs,
+  userspace-dp/src/afxdp/tx/dispatch/tests/ptb.rs,
+  userspace-dp/src/afxdp/README.md, docs/generated-reply-rate-limit.md

--- a/docs/generated-reply-rate-limit.md
+++ b/docs/generated-reply-rate-limit.md
@@ -63,16 +63,21 @@ key was an API omission, not absence of attribution). All three reasons now use
     key off), so a VLAN sub-interface keys its OWN zone's bucket and a non-VLAN
     port resolves identically.
   - TimeExceeded (`icmp::build_local_time_exceeded_request`) and PacketTooBig
-    (the TX dispatch PTB path) key on the PHYSICAL ingress bind ifindex
-    (`ingress_ident.ifindex`, the fixed per-binding socket-bind port) WITHOUT
-    resolving the logical unit. For an untagged port physical == logical, so the
-    zone is exact; but VLAN sub-interfaces on the same physical port all resolve
-    through that port's `ifindex_to_zone_id` entry (the physical parent inherits
-    its FIRST sub-interface's zone — `forwarding_build/interfaces.rs`), so they
-    SHARE the physical port's TE/PTB bucket rather than getting a per-sub-interface
-    one. This is still correct and strictly better than the pre-#5856 single
-    global bucket (distinct physical ingress ports no longer starve each other);
-    it is simply coarser than the Reject path's per-logical-unit granularity.
+    (the TX dispatch PTB path) key the RATE-LIMIT BUCKET on the PHYSICAL ingress
+    bind ifindex (`ingress_ident.ifindex`, the fixed per-binding socket-bind
+    port) WITHOUT resolving the logical unit. For an untagged port physical ==
+    logical, so the zone is exact; but VLAN sub-interfaces on the same physical
+    port all resolve through that port's `ifindex_to_zone_id` entry (the physical
+    parent inherits its FIRST sub-interface's zone — `forwarding_build/interfaces.rs`),
+    so they SHARE the physical port's TE/PTB bucket rather than getting a
+    per-sub-interface one. This is still correct and strictly better than the
+    pre-#5856 single global bucket (distinct physical ingress ports no longer
+    starve each other); it is simply coarser than the Reject path's
+    per-logical-unit granularity. **This physical bucket keying is deliberate and
+    distinct from the reply BUILD + output CLASSIFY, which (post-#6102) DO resolve
+    the logical unit** via `resolve_ingress_logical_ifindex` — so a tagged sub-if
+    sources its reply from its own address/VLAN and enforces its own output
+    filter / CoS, while the per-zone amplification bound stays per-physical-port.
 - An unzoned (id 0) or otherwise-unknown from-zone falls back to the reason's
   process-global `{REJECT,TIME_EXCEEDED,PACKET_TOO_BIG}_FALLBACK_BUCKET` — a real
   bucket, so the gate is **never fail-open** and never panics on a missing key.

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -94,12 +94,23 @@ sync.
         ifindex before the `ifindex_to_zone_id` lookup, so the correct
         screen profile applies (a parent-zone miss would otherwise SKIP
         screening entirely, or apply the wrong profile).
-      - **#3026 — generated ICMP error:** `icmp.rs` classifies the
-        generated reply (CoS queue / DSCP rewrite / output filter) on the
-        LOGICAL egress unit ifindex (`ingress_ident.ifindex`, the key for
-        `forwarding.egress`), NOT the physical `target_ifindex` /
-        `bind_ifindex`. `target_ifindex` (physical) is still used for the
-        XSK transmit.
+      - **#3026 / #6102 — generated ICMP error (Time Exceeded + egress-MTU
+        Packet-Too-Big):** `icmp.rs`
+        (`build_local_time_exceeded_request`) and the TX dispatch PTB path
+        (`compute_forwarded_egress_ptb` build + `enqueue_pending_forwards`
+        classify) resolve the LOGICAL egress unit ifindex once via the SSOT
+        (`resolve_ingress_logical_ifindex`, from the physical
+        `ingress_ident.ifindex` + `meta.ingress_vlan_id`) and key the egress
+        lookup, the reply BUILD, and the output-filter/CoS classify off THAT,
+        NOT the physical `ingress_ident.ifindex` / `target_ifindex` /
+        `bind_ifindex`. #6102 fixed the pre-existing gap where both keyed on
+        the physical index (the #3026 comment even mislabelled it "the LOGICAL
+        egress ifindex"): on a tagged sub-if with no untagged parent the egress
+        lookup missed and the generated ICMP was silently dropped (traceroute
+        `* * *` / PMTUD blackhole); with a parent it was mis-classified on the
+        parent's filter/CoS. `target_ifindex` (physical) is still used for the
+        XSK transmit, and the #5856 per-zone rate-limit bucket deliberately
+        stays keyed on the PHYSICAL `ingress_ident.ifindex`.
       - **#3035 — generated SYN-cookie / reject reply:**
         `poll_descriptor/cookie_reply.rs` (SYN-cookie SYN-ACK / ACK-RST)
         and `poll_descriptor/reject_reply.rs` (policy/filter `reject` TCP
@@ -122,7 +133,9 @@ sync.
         entry, the ICMP source and the VLAN tag were the parent's, not the
         sub-if's. The TCP RST build is self-contained (it reflects the
         inbound frame, no egress lookup) and is unaffected; this mirrors
-        the Time Exceeded builder, which already passed the logical unit.
+        the Time Exceeded / Packet-Too-Big builders, which resolve the same
+        logical unit (#6102 — before that fix they wrongly keyed the physical
+        index).
       - **#3609 — per-interface host-inbound override:** the local-delivery
         host-inbound gate (`poll_descriptor/filter.rs::host_inbound_gated_lo0_action`
         → `forwarding::host_inbound_admits_iface`) looks up

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -181,12 +181,32 @@ pub(super) fn build_local_time_exceeded_request(
     if !can_generate_icmp_error_reply(frame, meta, forwarding) {
         return None;
     }
+    // #6102: resolve the LOGICAL ingress unit ONCE. `forwarding.egress`, the
+    // v4/v6 reply builders (each does `forwarding.egress.get(&ingress_ifindex)`),
+    // and `classify_generated_reply` are ALL keyed by the logical unit ifindex;
+    // `ingress_ident.ifindex` is the PHYSICAL AF_XDP bind port (#6046), which
+    // for a VLAN sub-interface is the physical PARENT — not this unit. Keying
+    // the build/classify on the physical index silently dropped the generated
+    // ICMP on a tagged sub-if with no untagged parent unit (egress miss →
+    // `?`-drop → traceroute `* * *` / PMTUD blackhole) and mis-classified it on
+    // one with a parent (parent's CoS / DSCP-rewrite / output filter). This
+    // mirrors the shipped reject (#3976) / SYN-cookie (#3035) precedent:
+    // resolve logical for build+classify, keep the PHYSICAL index for the XSK
+    // transmit (`target_ifindex`/`tx_ifindex`) and the #5856 per-zone rate-limit
+    // bucket below. For an untagged port logical == physical, so this is a
+    // literal no-op there.
+    let logical_ingress = resolve_ingress_logical_ifindex(
+        forwarding,
+        ingress_ident.ifindex,
+        meta.ingress_vlan_id,
+    )
+    .unwrap_or(ingress_ident.ifindex);
     // #5567: prove the reply FEASIBLE before touching the rate-limit token.
     // The egress lookup below and the v4/v6 builder each return None (a drop)
     // when the reply CANNOT be produced — no egress object for the ingress
-    // ifindex, no primary address of the inbound family, or an unparseable
+    // unit, no primary address of the inbound family, or an unparseable
     // trigger. Building first makes the build itself the feasibility proof.
-    let egress = forwarding.egress.get(&ingress_ident.ifindex)?;
+    let egress = forwarding.egress.get(&logical_ingress)?;
     let target_ifindex = if egress.bind_ifindex > 0 {
         egress.bind_ifindex
     } else {
@@ -194,10 +214,10 @@ pub(super) fn build_local_time_exceeded_request(
     };
     let prebuilt_frame = match meta.addr_family as i32 {
         libc::AF_INET => {
-            build_local_time_exceeded_v4(frame, meta, ingress_ident.ifindex, forwarding)
+            build_local_time_exceeded_v4(frame, meta, logical_ingress, forwarding)
         }
         libc::AF_INET6 => {
-            build_local_time_exceeded_v6(frame, meta, ingress_ident.ifindex, forwarding)
+            build_local_time_exceeded_v6(frame, meta, logical_ingress, forwarding)
         }
         _ => return None,
     }?;
@@ -212,9 +232,11 @@ pub(super) fn build_local_time_exceeded_request(
     //
     // #5856: the bucket is now PER INGRESS (from) ZONE, not a single global one
     // — resolved from the PHYSICAL ingress bind ifindex (`ingress_ident.ifindex`,
-    // the fixed per-binding socket-bind port, the same value the v4/v6 reply
-    // build + #3026 output-classify pass) via `ifindex_to_zone_id`. Unlike the
-    // #3618 reject path, this site does NOT call `resolve_ingress_logical_ifindex`:
+    // the fixed per-binding socket-bind port) via `ifindex_to_zone_id`. This is
+    // deliberately DISTINCT from the #6102 `logical_ingress` that keys the v4/v6
+    // reply build + #3026 output-classify: the rate-limit bucket stays PHYSICAL
+    // (per-physical-port), while build/classify resolve the logical unit. Unlike
+    // the #3618 reject path, this site does NOT call `resolve_ingress_logical_ifindex`:
     // a VLAN sub-interface resolves through its physical parent's
     // `ifindex_to_zone_id` entry (the parent inherits its first sub-interface's
     // zone), so VLAN sub-interfaces on the same physical port SHARE that port's
@@ -255,17 +277,21 @@ pub(super) fn build_local_time_exceeded_request(
     // flow could wrongly drop the ICMP error. A parse failure of our own
     // built bytes fails CLOSED (drop + dedicated counter, §6.2).
     //
-    // #3026: classify on the LOGICAL egress ifindex (`ingress_ident.ifindex`,
-    // the unit ifindex that keys `forwarding.egress`), NOT `target_ifindex`.
-    // CoS interfaces (forwarding_build/cos.rs) and output filters
-    // (filter/compiler.rs) are keyed by the logical unit ifindex; on a VLAN
-    // subinterface `bind_ifindex` (hence `target_ifindex`) is the physical
-    // parent index, so classifying by it missed the subinterface's CoS
-    // queue / DSCP rewrite / output filter. `target_ifindex` (physical) is
-    // still used for the XSK transmit below. For a non-VLAN port the logical
-    // and physical indexes coincide, so this is a no-op there.
+    // #3026/#6102: classify on the LOGICAL egress ifindex (`logical_ingress`,
+    // resolved above via `resolve_ingress_logical_ifindex`), NOT the physical
+    // `ingress_ident.ifindex` and NOT `target_ifindex`. CoS interfaces
+    // (forwarding_build/cos.rs) and output filters (filter/compiler.rs) are
+    // keyed by the logical unit ifindex; on a VLAN subinterface both the
+    // physical bind port (`ingress_ident.ifindex`) and `target_ifindex`
+    // (`egress.bind_ifindex`) are the physical parent, so classifying by
+    // either missed the subinterface's CoS queue / DSCP rewrite / output
+    // filter (#6102: pre-fix this passed the physical `ingress_ident.ifindex`,
+    // which the #3026 comment wrongly called "the LOGICAL egress ifindex").
+    // `target_ifindex` (physical) is still used for the XSK transmit below. For
+    // a non-VLAN port the logical and physical indexes coincide, so this is a
+    // no-op there.
     let verdict =
-        classify_generated_reply(forwarding, ingress_ident.ifindex, &prebuilt_frame, now_ns);
+        classify_generated_reply(forwarding, logical_ingress, &prebuilt_frame, now_ns);
     if verdict.drop {
         counters.touched = true;
         if verdict.parse_error {

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -261,11 +261,13 @@ fn enqueue_reject_reply(
     // fallback were the parent's, not this unit's → wrong-source / untagged
     // reply dropped on the tagged link. Keying the build off the logical unit
     // ifindex sources the ICMP reply from the sub-if's own primary address and
-    // its own `vlan_id`, mirroring the Time Exceeded builder
-    // (`build_local_time_exceeded_request`), which already passes
-    // `ingress_ident.ifindex` (the logical unit). The TCP RST builder is
-    // self-contained (it reflects the inbound frame, no egress lookup), so it
-    // is unaffected. The physical `ingress_ifindex` is still used for the
+    // its own `vlan_id`, mirroring the Time Exceeded / Packet-Too-Big builders,
+    // which resolve the same logical unit before their egress lookup
+    // (`build_local_time_exceeded_request` / `compute_forwarded_egress_ptb`,
+    // #6102 — before that fix they wrongly passed the PHYSICAL
+    // `ingress_ident.ifindex`). The TCP RST builder is self-contained (it
+    // reflects the inbound frame, no egress lookup), so it is unaffected. The
+    // physical `ingress_ifindex` is still used for the
     // `TxRequest.egress_ifindex` (the XSK transmit device) below. For a
     // non-VLAN port the logical and physical indexes coincide, so this is a
     // no-op there.

--- a/userspace-dp/src/afxdp/tests_icmp_te.rs
+++ b/userspace-dp/src/afxdp/tests_icmp_te.rs
@@ -377,16 +377,31 @@ fn build_local_time_exceeded_request_ignores_trigger_matching_output_filter() {
 
 
 /// #3026 LITERAL fail-on-revert. Drives the real
-/// `build_local_time_exceeded_request` with a VLAN egress where the LOGICAL
-/// unit (ifindex 12) carries an output `then discard protocol icmp` filter
-/// but the PHYSICAL parent (bind_ifindex 11) does NOT. The fix classifies the
-/// generated ICMP reply on the LOGICAL egress ifindex (`ingress_ident.ifindex`
-/// = 12), so the filter fires and the reply is dropped. If the production site
-/// is reverted to classify on `target_ifindex` (= egress.bind_ifindex = the
-/// physical parent 11, which has no filter), the reply is NOT dropped, the
-/// builder returns `Some`, and the `request.is_none()` assert fails RED.
+/// #6102 fail-on-revert (production-reachable rebuild of the vacuous #3026
+/// test): `build_local_time_exceeded_request` on a real VLAN sub-interface.
+/// The ingress AF_XDP binding is the PHYSICAL parent port (ifindex 11) — the
+/// value `ingress_ident.ifindex` genuinely holds in production (#6046) — while
+/// the tagged unit reth0.80 is the LOGICAL unit (ifindex 12) that keys
+/// `forwarding.egress` and the output filter. The daemon's
+/// `ingress_logical_ifindex` map resolves `(physical 11, vlan 80) -> logical
+/// 12`. The unit (12) carries an output `then discard protocol icmp` filter;
+/// the physical parent (11) carries NONE and has NO egress entry.
+///
+/// The fix resolves the logical unit ONCE (`resolve_ingress_logical_ifindex`)
+/// and feeds it to the egress lookup, the reply builders, and
+/// `classify_generated_reply`. The double assertion catches every partial and
+/// full revert to the physical `ingress_ident.ifindex`:
+///   - revert the CLASSIFY only  -> build on 12 (Some), classify on physical 11
+///     (no filter) -> reply ADMITTED -> `request.is_none()` FAILS RED.
+///   - revert the EGRESS LOOKUP or a BUILDER only -> `egress.get(11)` = None ->
+///     builder `?`-drops -> `request` is None but the drop is a BUILD-fail, not
+///     a filter drop -> `time_exceeded_output_filter_drops == 0` FAILS RED.
+///   - full revert to physical -> same build-fail drop -> counter 0 FAILS RED.
+/// The counter assertion is what distinguishes a filter drop (fix working) from
+/// a build-fail drop (a reverted egress/builder), so `is_none()` alone can
+/// never pass vacuously.
 #[test]
-fn build_local_time_exceeded_request_classifies_on_logical_egress_3026() {
+fn build_local_time_exceeded_request_resolves_logical_ingress_for_classify_6102() {
     // #5567: the reply must be built + pass the token before the output-filter
     // classify runs, so this drop-attribution test needs a non-empty bucket.
     let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
@@ -394,10 +409,13 @@ fn build_local_time_exceeded_request_classifies_on_logical_egress_3026() {
     let dst_ip = Ipv4Addr::new(1, 1, 1, 1);
     // TRIGGER is a UDP flow; the generated reply is ICMP (proven elsewhere).
     let frame = build_udp_frame_v4_full([0x00, 0x25, 0x90, 0x12, 0x34, 0x56], client_ip, dst_ip, 1);
+    // PHYSICAL ingress bind port 11, tagged VLAN 80 — exactly what the shim
+    // reports for a frame arriving on reth0.80 (`ingress_vlan_id` = 80).
     let meta = UserspaceDpMeta {
         l3_offset: 14,
         l4_offset: 34,
-        ingress_ifindex: 5,
+        ingress_ifindex: 11,
+        ingress_vlan_id: 80,
         addr_family: libc::AF_INET as u8,
         protocol: PROTO_UDP,
         pkt_len: 128,
@@ -408,14 +426,15 @@ fn build_local_time_exceeded_request_classifies_on_logical_egress_3026() {
         len: frame.len() as u32,
         options: 0,
     };
-    // The egress is resolved on the LOGICAL unit ifindex 12 (reth0.80) — the
-    // value the builder uses as ingress_ident.ifindex to key forwarding.egress.
+    // The AF_XDP binding is the PHYSICAL parent (ifindex 11) — the fixed
+    // per-binding socket-bind port. The logical unit (12) is NOT this value;
+    // the fix must resolve it from `(11, 80)` before keying egress/classify.
     let ingress_ident = BindingIdentity {
         slot: 0,
         queue_id: 7,
         worker_id: 0,
-        interface: Arc::<str>::from("reth0.80"),
-        ifindex: 12,
+        interface: Arc::<str>::from("reth0"),
+        ifindex: 11,
     };
     let flow = icmp_suppress_flow_v4(client_ip, dst_ip);
     // OUTPUT filter on the LOGICAL VLAN unit (ifindex 12) with a terminal
@@ -450,8 +469,10 @@ fn build_local_time_exceeded_request_classifies_on_logical_egress_3026() {
         tx_selection_enabled_v4: true,
         ..ForwardingState::default()
     };
-    // Egress keyed by the LOGICAL ifindex 12; bind_ifindex 11 is the physical
-    // parent (= target_ifindex, the pre-fix classification key).
+    // Egress keyed by the LOGICAL ifindex 12 ONLY; bind_ifindex 11 is the
+    // physical parent (= target_ifindex, the XSK transmit device). There is NO
+    // egress entry for the physical parent 11, so a physical-keyed egress
+    // lookup (a reverted fix) misses and the builder `?`-drops.
     forwarding.egress.insert(
         12,
         EgressInterface {
@@ -465,6 +486,9 @@ fn build_local_time_exceeded_request_classifies_on_logical_egress_3026() {
             primary_v6: None,
         },
     );
+    // The daemon-built `(physical bind, vlan) -> logical unit` map
+    // (interfaces.rs:291-301). This is the SSOT the fix resolves through.
+    forwarding.ingress_logical_ifindex.insert((11, 80), 12);
 
     let mut counters = BatchCounters::default();
     let request = build_local_time_exceeded_request(
@@ -483,12 +507,15 @@ fn build_local_time_exceeded_request_classifies_on_logical_egress_3026() {
     assert!(
         request.is_none(),
         "the VLAN unit's OWN output filter (on logical ifindex 12) must drop \
-         the generated ICMP reply (#3026); classifying on the physical parent \
-         (bind_ifindex 11, no filter) would wrongly admit it"
+         the generated ICMP reply (#6102); classifying on the physical parent \
+         (ingress_ident.ifindex 11, no filter) would wrongly admit it"
     );
     assert_eq!(
         counters.time_exceeded_output_filter_drops, 1,
-        "the logical-egress output-filter drop must land on the TE counter"
+        "the logical-egress output-filter drop must land on the TE counter — a \
+         value of 0 means the egress lookup/builder was keyed on the physical \
+         parent 11 (no egress entry) and the reply was BUILD-dropped, not \
+         filter-dropped (a reverted #6102 fix)"
     );
     assert_eq!(counters.generated_reply_classify_parse_errors, 0);
 }

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -255,18 +255,35 @@ fn compute_forwarded_egress_ptb(
                 // false-deny DoS). Mirrors the reject path's #3656 H11
                 // build-before-consume ordering; the suppression gate above
                 // still runs first, so no token is spent on a suppressed PTB.
+                // #6102: resolve the LOGICAL ingress unit for the reply BUILD.
+                // `build_frag_needed_v4`/`build_packet_too_big_v6` each do
+                // `forwarding.egress.get(&ingress_ifindex)` — egress is keyed by
+                // the logical unit ifindex, while `ingress_ident.ifindex` is the
+                // PHYSICAL bind port (#6046, a VLAN sub-if's physical parent).
+                // Passing the physical index silently dropped the PTB on a
+                // tagged sub-if with no untagged parent unit (egress miss →
+                // `?`-drop → PMTUD blackhole). Mirrors the reject (#3976) /
+                // cookie (#3035) precedent; the PHYSICAL index stays for the XSK
+                // transmit and the #5856 per-zone bucket below. Untagged: logical
+                // == physical (no-op).
+                let logical_ingress = resolve_ingress_logical_ifindex(
+                    forwarding,
+                    ingress_ident.ifindex,
+                    ptb_meta.ingress_vlan_id,
+                )
+                .unwrap_or(ingress_ident.ifindex);
                 let built = match meta.addr_family as i32 {
                     libc::AF_INET => build_frag_needed_v4(
                         source_frame,
                         ptb_meta,
-                        ingress_ident.ifindex,
+                        logical_ingress,
                         forwarding,
                         next_hop_mtu,
                     ),
                     libc::AF_INET6 => build_packet_too_big_v6(
                         source_frame,
                         ptb_meta,
-                        ingress_ident.ifindex,
+                        logical_ingress,
                         forwarding,
                         next_hop_mtu as u32,
                     ),
@@ -1298,16 +1315,29 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
             // by its OWN egress 5-tuple + egress interface, exactly like the
             // ICMP/ICMPv6 Time Exceeded (#2238), policy-`reject`, and
             // SYN-cookie generators. The PTB is L2-reflected back out the
-            // ingress interface, so `ingress_ident.ifindex` IS the egress (the
-            // same interface used for the enqueue below). Pre-#2328 the PTB
-            // enqueued an UNCLASSIFIED TxRequest (`cos_queue_id: None,
-            // dscp_rewrite: None`), so an output firewall filter terminal
-            // `discard`/`reject` keyed on the generated ICMP tuple never fired
-            // and CoS forwarding-class / DSCP rewrite were skipped. A parse
-            // failure of our own built bytes fails CLOSED (drop + dedicated
-            // parse-error counter, §6.2) rather than leaking past the filter.
+            // ingress interface. Pre-#2328 the PTB enqueued an UNCLASSIFIED
+            // TxRequest (`cos_queue_id: None, dscp_rewrite: None`), so an output
+            // firewall filter terminal `discard`/`reject` keyed on the generated
+            // ICMP tuple never fired and CoS forwarding-class / DSCP rewrite were
+            // skipped. A parse failure of our own built bytes fails CLOSED (drop
+            // + dedicated parse-error counter, §6.2) rather than leaking past the
+            // filter.
+            //
+            // #6102: `classify_generated_reply` is keyed by the LOGICAL unit
+            // ifindex, but `ingress_ident.ifindex` is the PHYSICAL bind port
+            // (#6046, a VLAN sub-if's physical parent). Resolve the logical unit
+            // so a tagged sub-if's OWN output filter / CoS is enforced (pre-fix
+            // the parent's — or first sub-if's — filter was applied). The
+            // enqueue below stays on the PHYSICAL `ingress_ident.ifindex` (the
+            // XSK transmit device). Untagged: logical == physical (no-op).
+            let logical_ingress = resolve_ingress_logical_ifindex(
+                forwarding,
+                ingress_ident.ifindex,
+                request.meta.ingress_vlan_id,
+            )
+            .unwrap_or(ingress_ident.ifindex);
             let verdict =
-                classify_generated_reply(forwarding, ingress_ident.ifindex, &ptb_bytes, now_ns);
+                classify_generated_reply(forwarding, logical_ingress, &ptb_bytes, now_ns);
             if verdict.drop {
                 counters.touched = true;
                 if verdict.parse_error {

--- a/userspace-dp/src/afxdp/tx/dispatch/tests/ptb.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/tests/ptb.rs
@@ -91,6 +91,22 @@ fn run_ptb_dispatch_with_forwarding(
     BatchCounters,
     Vec<String>,
 ) {
+    run_ptb_dispatch_with_forwarding_and_vlan(forwarding, 0)
+}
+
+/// #6102: PTB e2e harness variant that stamps the ingress frame's meta with a
+/// VLAN id, so a test can drive a tagged sub-interface through the physical
+/// bind port (ifindex 11) and exercise `resolve_ingress_logical_ifindex` in
+/// both the PTB build and classify sites.
+fn run_ptb_dispatch_with_forwarding_and_vlan(
+    forwarding: ForwardingState,
+    ingress_vlan_id: u16,
+) -> (
+    Vec<BindingWorker>,
+    DebugPollCounters,
+    BatchCounters,
+    Vec<String>,
+) {
     let mut bindings = vec![
         BindingWorker::new_for_mirror_test(0, 0, 11, 0),
         BindingWorker::new_for_mirror_test(1, 0, 22, 0),
@@ -114,6 +130,7 @@ fn run_ptb_dispatch_with_forwarding(
     req.meta.l3_offset = 14;
     req.meta.l4_offset = 34;
     req.meta.pkt_len = (frame.len() - 14) as u16;
+    req.meta.ingress_vlan_id = ingress_vlan_id;
     let mut pending = vec![req];
     let mut post_recycles = Vec::new();
     let ingress_ident = bindings[0].identity();
@@ -315,6 +332,107 @@ fn ptb_dropped_by_egress_output_filter_discard() {
     // recycled exactly once — no leak past the fail-closed drop.
     assert_eq!(bindings[1].tx_pipeline.pending_tx_local.len(), 0);
     assert_eq!(bindings[1].tx_pipeline.pending_tx_prepared.len(), 0);
+    assert_eq!(ingress_recycled_count(&bindings[0]), 1);
+    assert!(reasons.iter().any(|r| r == "egress_mtu_exceeded"));
+}
+
+/// #6102 forwarding state: a tagged VLAN sub-interface. The ingress AF_XDP
+/// binding is the PHYSICAL parent (ifindex 11); the reflected-reply egress and
+/// its output filter live on the LOGICAL unit (ifindex 12, reth0.80). There is
+/// NO egress entry for the physical parent 11 — so a physical-keyed build (a
+/// reverted #6102 fix) misses and the PTB is silently build-dropped. The
+/// daemon's `ingress_logical_ifindex` map resolves `(11, 80) -> 12`.
+fn forwarding_for_ptb_vlan_subif_6102(mtu: usize) -> ForwardingState {
+    // Base carries the FORWARD egress (ifindex 80, small MTU) that triggers the
+    // PTB; it does NOT add an egress for the physical ingress parent 11.
+    let mut forwarding = test_forwarding_with_egress_mtu(mtu);
+    // The reflected reply's egress, keyed by the LOGICAL unit 12 ONLY.
+    forwarding.egress.insert(
+        12,
+        EgressInterface {
+            bind_ifindex: 11,
+            vlan_id: 80,
+            mtu: 1500,
+            src_mac: [0x02, 0xbf, 0x72, 0x00, 0x80, 0x08],
+            zone_id: TEST_WAN_ZONE_ID,
+            redundancy_group: 0,
+            primary_v4: Some(std::net::Ipv4Addr::new(172, 16, 80, 8)),
+            primary_v6: None,
+        },
+    );
+    // Daemon-built `(physical bind, vlan) -> logical unit` map (the SSOT the fix
+    // resolves through, interfaces.rs:291-301).
+    forwarding.ingress_logical_ifindex.insert((11, 80), 12);
+    // OUTPUT `then discard protocol icmp` on the LOGICAL unit 12 ONLY; the
+    // physical parent 11 carries no filter and no egress.
+    forwarding.filter_state = crate::filter::parse_filter_state(
+        &[crate::FirewallFilterSnapshot {
+            name: "ptb-out".into(),
+            family: "inet".into(),
+            terms: vec![crate::FirewallTermSnapshot {
+                name: "drop-icmp".into(),
+                action: "discard".into(),
+                protocols: vec!["icmp".into()],
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[crate::InterfaceSnapshot {
+            name: "reth0.80".into(),
+            ifindex: 12,
+            parent_ifindex: 11,
+            vlan_id: 80,
+            filter_output_v4: "ptb-out".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    )
+    .expect("filter state compiles");
+    forwarding.tx_selection_enabled_v4 = true;
+    forwarding
+}
+
+/// #6102 fail-on-revert (PTB analogue of the Time Exceeded test): the generated
+/// egress-MTU PTB on a tagged VLAN sub-interface must be BUILT from and
+/// CLASSIFIED on the LOGICAL unit (ifindex 12), resolved from the physical bind
+/// port (ifindex 11) + `ingress_vlan_id` 80 — not the physical
+/// `ingress_ident.ifindex`. The unit's OWN output `then discard protocol icmp`
+/// filter drops the PTB. The double assertion (`len == 0` AND
+/// `ptb_output_filter_drops == 1`) fails RED on every revert to the physical
+/// index:
+///   - revert the BUILD to physical 11 -> `egress.get(11)` = None -> PTB never
+///     built -> nothing enqueued but `ptb_output_filter_drops == 0` FAILS RED
+///     (this is the primary silent-drop bug the fix closes).
+///   - revert the CLASSIFY to physical 11 -> PTB built on 12 but classified on
+///     11 (no filter) -> PTB ENQUEUED -> `len == 0` FAILS RED.
+#[test]
+fn ptb_resolves_logical_ingress_for_build_and_classify_6102() {
+    // #5567: the PTB must be built + pass the token before the output-filter
+    // classify runs, so this drop-attribution test needs a non-empty bucket.
+    let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
+    let (bindings, _dbg, counters, reasons) =
+        run_ptb_dispatch_with_forwarding_and_vlan(forwarding_for_ptb_vlan_subif_6102(1400), 80);
+    // Built on logical unit 12 (egress miss on physical 11 would have dropped
+    // it) and dropped by unit 12's OWN output `discard` (a physical-keyed
+    // classify on parent 11 would have wrongly admitted it).
+    assert_eq!(
+        bindings[0].tx_pipeline.pending_tx_local.len(),
+        0,
+        "the VLAN unit's output `then discard protocol icmp` (logical ifindex 12) \
+         must drop the generated PTB (#6102); classifying on the physical parent \
+         11 (no filter) would wrongly enqueue it"
+    );
+    assert_eq!(
+        counters.ptb_output_filter_drops, 1,
+        "the logical-egress output-filter drop must land on ptb_output_filter_drops \
+         — a value of 0 means the PTB build was keyed on the physical parent 11 \
+         (no egress entry) and was BUILD-dropped, not filter-dropped (a reverted \
+         #6102 fix)"
+    );
+    assert_eq!(counters.generated_reply_classify_parse_errors, 0);
+    // The oversized original is still dropped (PMTUD) and recycled once.
+    assert_eq!(bindings[1].tx_pipeline.pending_tx_local.len(), 0);
     assert_eq!(ingress_recycled_count(&bindings[0]), 1);
     assert!(reasons.iter().any(|r| r == "egress_mtu_exceeded"));
 }


### PR DESCRIPTION
## Summary

The locally-generated ICMP **Time-Exceeded** (`icmp::build_local_time_exceeded_request`) and **egress-MTU Packet-Too-Big** (`tx/dispatch/mod.rs` `compute_forwarded_egress_ptb` build + `enqueue_pending_forwards` classify) paths fed the **PHYSICAL** AF_XDP bind ifindex (`ingress_ident.ifindex`) to three maps that are all keyed by the **LOGICAL** unit ifindex:

- the `forwarding.egress` feasibility lookup,
- the ICMP reply **builders** (`build_local_time_exceeded_v4/v6`, `build_frag_needed_v4`, `build_packet_too_big_v6`), and
- `classify_generated_reply` (output-filter / CoS).

#6046 established that `ingress_ident.ifindex` is the fixed per-binding socket-bind port — for a VLAN sub-interface that is the physical **parent**, not the tagged unit.

### Impact
- **Silent drop (primary):** a tagged sub-if with no untagged parent unit → `egress.get(physical)` = `None` → builder `?`-drops → generated ICMP never produced → **traceroute `* * *` / PMTUD blackhole**.
- **Wrong-unit classification (secondary):** a sub-if with an untagged parent → reply sourced from the parent's address and classified with the parent's CoS / DSCP-rewrite / **output filter** — a fail-closed §6.2 output-filter-boundary granularity gap.
- Untagged ports: logical == physical → literal no-op.

## Fix

Mirror the shipped reject (#3976) / SYN-cookie (#3035) precedent: resolve the logical unit **once per path** via `resolve_ingress_logical_ifindex(forwarding, ingress_ident.ifindex, meta.ingress_vlan_id).unwrap_or(physical)` and feed **that** to the egress lookup + build + classify.

**Deliberately kept PHYSICAL (unchanged):**
- the #5856 per-zone rate-limit bucket (`ifindex_to_zone_id` keyed on `ingress_ident.ifindex`) — per-physical-port amplification bound,
- the XSK transmit indexes (`target_ifindex` / `tx_ifindex`),
- the HA resolution `egress_ifindex` (owner-RG attribution byte-identical).

No new functions, no signature changes, no control-flow changes.

## Tests (fail-on-revert)

- **Rebuilt the vacuous #3026 TE test.** The old test hardcoded `ingress_ident.ifindex = 12` (the *logical* value) while `meta.ingress_ifindex = 5` — a production-unreachable premise, so the physical-keyed code accidentally worked. Rebuilt to the production shape (physical bind `11`, `ingress_logical_ifindex (11,80)→12`, egress keyed on logical `12` only) with a **double assertion** — `request.is_none()` **and** `time_exceeded_output_filter_drops == 1`.
- **Added a PTB analogue** (`ptb_resolves_logical_ingress_for_build_and_classify_6102`) with the same double-assertion shape (`len == 0` **and** `ptb_output_filter_drops == 1`).

The counter assertion distinguishes a *filter drop* (fix working) from a *build-fail drop* (a reverted egress lookup), so `is_none()` / `len == 0` can never pass vacuously.

## Validation

- `cargo test --release time_exceeded` → **21 passed**; `ptb` → **57 passed**.
- Both new tests pass **5/5** on the fixed code.
- **RED-on-revert proven:** reverting only the two production files to `origin/master` (keeping the tests) makes both new tests fail an **assertion** (`... output-filter drop must land on the counter — value 0 means BUILD-dropped, a reverted #6102 fix`), not a build break.

Comments/docs corrected: `icmp.rs` (#3026 + #5856 blocks), `reject_reply.rs` (its stale "the TE builder already passes the logical unit" claim), `afxdp/README.md` (#3026/#3976 entries), `docs/generated-reply-rate-limit.md` (bucket stays physical while build/classify resolve logical).

> Note for the reviewer: this touches the fail-closed §6.2 output-filter boundary, so it carries the mandatory independent hostile review. The decisive loss-cluster VLAN-sub-if smoke (traceroute + PMTUD on `reth0.80`, v4+v6, generated ICMP captured tagged VID 80) is deferred to the parent per the research plan.

Closes #6102

🤖 Generated with [Claude Code](https://claude.com/claude-code)