### PR TITLE
daemon: stop truncating synced session slot in SessionID

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56390,3 +56390,19 @@ top.
   userspace-dp/src/afxdp/worker/{cos_state,mod}.rs,
   userspace-dp/src/afxdp/cos/queue_service/tests/{refund,wakeup}.rs,
   userspace-dp/src/afxdp/cos/README.md
+
+- **Timestamp**: 2026-07-22
+- **Action**: Fix #6198 — HA synced-session SessionID slot truncation. The
+  node-local BPF-ABI conntrack id in daemon_ha_userspace_convert.go composed
+  the id as `now<<16 | slot&0xffff`, masking a uint32 session-table slot to 16
+  bits. With MAX_SESSIONS=10M (needs 24 bits), two sessions whose slots differ
+  only above bit 16 collided on one SessionID (surfaced in show flow / show
+  session / gRPC / REST). Extracted a pure SSOT helper userspaceSyncedSessionID
+  that puts the full uint32 slot in the low 32 bits and the monotonic-seconds
+  timestamp in the high 32 bits (no mask). Updated both V4 and V6 sites.
+  Added a deterministic fail-on-revert test (slot 5 vs 0x10005 must not
+  collide; slot preserved in low 32 bits; near-10M slot round-trips) plus an
+  end-to-end convert-path assertion for V4 and V6. Verified both go RED with
+  the old mask restored. Updated docs/session-sync-architecture.md.
+- **File(s)**: pkg/daemon/daemon_ha_userspace_convert.go,
+  pkg/daemon/userspace_sync_test.go, docs/session-sync-architecture.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -322,7 +322,10 @@ never rejects on it. The path is: the Rust dataplane harvests the id onto
 `SessionDelta.session_id` and writes it as the trailing field of the
 `MSG_SESSION_OPEN` event-stream frame; the daemon decodes it into
 `SessionDeltaInfo.RTFlowSessionID` and stamps `SessionValue{,V6}.RTFlowSessionID`
-(distinct from the node-local BPF-ABI `SessionID`, which stays `now<<16|Slot`);
+(distinct from the node-local BPF-ABI `SessionID`, composed `now<<32|Slot` —
+the slot fills the low 32 bits, up from the old `now<<16|slot&0xffff`, which
+truncated any slot past 65535 and collided sessions whose slots differed only
+above bit 16 given the 10M-slot table, #6198);
 `SessionSync` carries it as the trailing wire field; the peer daemon forwards it
 on `SessionSyncRequest.session_id`; and the peer helper's
 `upsert_synced_with_origin` ADOPTS it (stamping the imported `SessionEntry`)

--- a/pkg/daemon/daemon_ha_userspace_convert.go
+++ b/pkg/daemon/daemon_ha_userspace_convert.go
@@ -34,6 +34,26 @@ func daemonMonotonicSeconds() uint64 {
 	return uint64(ts.Sec)
 }
 
+// userspaceSyncedSessionID composes the node-local BPF-ABI conntrack id stamped
+// onto a peer-synced session from the daemon monotonic clock and the
+// originating helper's session-table slot.
+//
+// The slot occupies the full low 32 bits and the monotonic-seconds timestamp
+// the high 32 bits. SessionDeltaInfo.Slot is a uint32 index into the
+// MAX_SESSIONS = 10,000,000 (bpf/headers/xpf_common.h) conntrack table, so a
+// live slot needs up to 24 bits. The previous `slot & 0xffff` composition kept
+// only the low 16 bits, so two distinct sessions whose slots differed solely
+// above bit 16 (e.g. 5 and 0x10005) collided on one SessionID when imported in
+// the same monotonic second (#6198). Reserving the full low 32 bits for the
+// slot removes the truncation for any uint32 slot while preserving the id's
+// rough monotonicity and node-local uniqueness. This is NOT the cross-node
+// RT_FLOW correlation id — that is carried separately in RTFlowSessionID
+// (#5212); SessionID here is a node-local identifier surfaced in
+// `show flow`/`show session` and the gRPC/REST session views.
+func userspaceSyncedSessionID(now uint64, slot uint32) uint64 {
+	return now<<32 | uint64(slot)
+}
+
 func userspaceSessionTimeout(proto uint8) uint32 {
 	switch proto {
 	case 6:
@@ -183,8 +203,10 @@ func userspaceSessionFromDeltaV4(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValue{
 		State: 4, // SESS_STATE_ESTABLISHED
-		// SessionID is the BPF-ABI conntrack id (node-local now<<16|Slot).
-		SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff),
+		// SessionID is the node-local BPF-ABI conntrack id (now<<32|Slot; the
+		// slot fills the low 32 bits so a >16-bit slot no longer truncates and
+		// collides, #6198).
+		SessionID: userspaceSyncedSessionID(now, delta.Slot),
 		// #5212: the ORIGINATING node's stable RT_FLOW session id (distinct from
 		// SessionID above). Carried across the cluster sync wire so a peer-synced
 		// session adopts it and its SESSION_CREATE/CLOSE records correlate across
@@ -284,8 +306,10 @@ func userspaceSessionFromDeltaV6(delta dpuserspace.SessionDeltaInfo, zoneIDs map
 	now := daemonMonotonicSeconds()
 	val := dataplane.SessionValueV6{
 		State: 4, // SESS_STATE_ESTABLISHED
-		// SessionID is the BPF-ABI conntrack id (node-local now<<16|Slot).
-		SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff),
+		// SessionID is the node-local BPF-ABI conntrack id (now<<32|Slot; the
+		// slot fills the low 32 bits so a >16-bit slot no longer truncates and
+		// collides, #6198).
+		SessionID: userspaceSyncedSessionID(now, delta.Slot),
 		// #5212: the ORIGINATING node's stable RT_FLOW session id (see V4) —
 		// adopted by a peer-synced session so its RT_FLOW records correlate
 		// across HA nodes; 0 on a legacy helper => fresh local id on import.

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -425,6 +425,91 @@ func TestUserspaceHAProtocolMismatchReason(t *testing.T) {
 	}
 }
 
+// TestUserspaceSyncedSessionIDNoSlotTruncation guards #6198: a peer-synced
+// session's node-local SessionID must not truncate the originating helper's
+// session-table slot to 16 bits. SessionDeltaInfo.Slot is a uint32 index into
+// the MAX_SESSIONS = 10,000,000 conntrack table, so two live slots routinely
+// differ only above bit 16. The old `now<<16 | slot&0xffff` composition
+// collapsed those onto one SessionID. Reverting to that mask makes the collide
+// assertion RED.
+func TestUserspaceSyncedSessionIDNoSlotTruncation(t *testing.T) {
+	const now = uint64(0x1234_5678) // fixed monotonic seconds — occupies high 32 bits
+	const (
+		slotLow  = uint32(5)       // 0x00005
+		slotHigh = uint32(0x10005) // differs from slotLow only above bit 16
+	)
+
+	idLow := userspaceSyncedSessionID(now, slotLow)
+	idHigh := userspaceSyncedSessionID(now, slotHigh)
+
+	if idLow == idHigh {
+		t.Fatalf("slots %#x and %#x collided on SessionID %#x — 16-bit truncation regressed",
+			slotLow, slotHigh, idLow)
+	}
+	// The full uint32 slot must survive in the low 32 bits, independent of now.
+	if got := uint32(idHigh); got != slotHigh {
+		t.Fatalf("slot not preserved in low 32 bits: got %#x want %#x (id %#x)", got, slotHigh, idHigh)
+	}
+	if got := uint32(idLow); got != slotLow {
+		t.Fatalf("slot not preserved in low 32 bits: got %#x want %#x (id %#x)", got, slotLow, idLow)
+	}
+	// A slot near the 10M capacity ceiling (needs 24 bits) must round-trip.
+	const slotNearMax = uint32(9_999_999)
+	if got := uint32(userspaceSyncedSessionID(now, slotNearMax)); got != slotNearMax {
+		t.Fatalf("near-capacity slot truncated: got %#x want %#x", got, slotNearMax)
+	}
+	// The timestamp must land above the slot so distinct seconds stay distinct.
+	if idLow>>32 != now {
+		t.Fatalf("timestamp not in high 32 bits: got %#x want %#x", idLow>>32, now)
+	}
+}
+
+// TestUserspaceSessionFromDeltaPreservesFullSlot asserts BOTH convert paths
+// (v4 + v6) route the SessionID through userspaceSyncedSessionID so a >16-bit
+// slot survives end to end. Under the fixed composition the full uint32 slot is
+// always the low 32 bits regardless of the monotonic clock; the old mask put
+// now's low bits there instead (#6198), so this is RED on revert.
+func TestUserspaceSessionFromDeltaPreservesFullSlot(t *testing.T) {
+	zoneIDs := map[string]uint16{"lan": 1, "wan": 2}
+	const slot = uint32(0x10005) // needs > 16 bits; masked to 5 by the old bug
+
+	deltaV4 := dpuserspace.SessionDeltaInfo{
+		Event:       "open",
+		AddrFamily:  dataplane.AFInet,
+		Protocol:    6,
+		Slot:        slot,
+		SrcIP:       "10.0.61.102",
+		DstIP:       "172.16.80.200",
+		SrcPort:     12345,
+		DstPort:     5201,
+		IngressZone: "lan",
+		EgressZone:  "wan",
+	}
+	if _, val, ok := userspaceSessionFromDeltaV4(deltaV4, zoneIDs); !ok {
+		t.Fatal("expected v4 delta to convert")
+	} else if got := uint32(val.SessionID); got != slot {
+		t.Fatalf("v4 SessionID low 32 bits = %#x, want full slot %#x (id %#x)", got, slot, val.SessionID)
+	}
+
+	deltaV6 := dpuserspace.SessionDeltaInfo{
+		Event:       "open",
+		AddrFamily:  dataplane.AFInet6,
+		Protocol:    6,
+		Slot:        slot,
+		SrcIP:       "2001:559:8585:bf01::102",
+		DstIP:       "2001:559:8585:80::200",
+		SrcPort:     12345,
+		DstPort:     5201,
+		IngressZone: "lan",
+		EgressZone:  "wan",
+	}
+	if _, val, ok := userspaceSessionFromDeltaV6(deltaV6, zoneIDs); !ok {
+		t.Fatal("expected v6 delta to convert")
+	} else if got := uint32(val.SessionID); got != slot {
+		t.Fatalf("v6 SessionID low 32 bits = %#x, want full slot %#x (id %#x)", got, slot, val.SessionID)
+	}
+}
+
 func TestUserspaceSessionFromDeltaV4CarriesTunnelEndpointMetadata(t *testing.T) {
 	zoneIDs := map[string]uint16{"lan": 1, "sfmix": 2}
 	delta := dpuserspace.SessionDeltaInfo{


### PR DESCRIPTION
## Problem (#6198)

`daemon/daemon_ha_userspace_convert.go` built the node-local BPF-ABI conntrack id for a peer-synced session as:

```go
SessionID: uint64(now)<<16 | uint64(delta.Slot&0xffff)
```

at both the v4 (`userspaceSessionFromDeltaV4`) and v6 (`userspaceSessionFromDeltaV6`) import sites.

`SessionDeltaInfo.Slot` is a **uint32** index into the conntrack table, and `MAX_SESSIONS = 10,000,000` (`bpf/headers/xpf_common.h`, needs 24 bits). Masking the slot to 16 bits meant two distinct sessions whose slots differ **only above bit 16** (e.g. `5` and `0x10005`) collapse onto the **same** `SessionID` when imported in the same monotonic second. That id is surfaced to operators in `show flow` / `show session` and on the gRPC/REST session views, where it is documented as a unique identifier — so the truncation is a real defect at scale.

### Verification against current master (STEP 0)
Re-verified on current `origin/master` (0af7fe7576): #5212 added a **separate** `RTFlowSessionID` field for cross-node RT_FLOW correlation but did **not** touch the `SessionID` composition — the `delta.Slot&0xffff` truncation is still present at both sites. No code decodes the `now<<16|slot` structure back out (grep confirmed), so widening the layout is safe.

## Fix

Extract the composition into a single pure SSOT helper and reserve the **full low 32 bits** for the slot, with the monotonic-seconds timestamp in the high 32 bits (no mask):

```go
func userspaceSyncedSessionID(now uint64, slot uint32) uint64 {
    return now<<32 | uint64(slot)
}
```

This removes the truncation for any uint32 slot while preserving the id's rough monotonicity and node-local uniqueness. `SessionID` stays a node-local id — distinct from the cross-node `RTFlowSessionID` (#5212). Both v4 and v6 sites now route through the helper.

## Tests (fail-on-revert)

- `TestUserspaceSyncedSessionIDNoSlotTruncation` — slots `5` and `0x10005` must **not** collide; full slot survives in low 32 bits; a near-10M slot round-trips; timestamp lands in high 32 bits. Deterministic (fixed `now`), independent of the wall clock.
- `TestUserspaceSessionFromDeltaPreservesFullSlot` — end-to-end through both convert paths: `val.SessionID & 0xffffffff == slot` for a `>16`-bit slot.

Both go **RED** with the old `slot & 0xffff` mask restored (verified: `slots 0x5 and 0x10005 collided on SessionID 0x123456780005`) and green with the fix. Ran 5× clean. Full `pkg/daemon/...` and `pkg/dataplane/...` suites pass.

## Docs
Updated `docs/session-sync-architecture.md`, which documented the old `now<<16|Slot` composition.

## Notes
Control-plane id composition only — does **not** change the HA sync wire (`RTFlowSessionID` and `SessionSyncRequest.session_id` are untouched), so no dataplane/failover smoke required.

Closes #6198

🤖 Generated with [Claude Code](https://claude.com/claude-code)