### PR TITLE
afxdp: couple libxdp ring ABI to the Rust mirror at build time

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-07-22 — #4976: build-time ABI check for the libxdp ring mirror
+
+- **Timestamp**: 2026-07-22 14:00 PDT (fix/4976-build-abi-check)
+- **Action**: Add a two-sided, build-time ABI check coupling the Rust
+  `XskRingProd`/`XskRingCons` mirror (`userspace-dp/src/xsk_ffi.rs`) to the
+  installed libxdp `struct xsk_ring_{prod,cons}` layout. The Rust side gained
+  a `const _: () = { … }` block asserting `size_of` (48), `align_of` (8) and
+  every field offset (0/4/8/12/16/24/32/40, 64-bit) via `core::mem::offset_of!`.
+  The C bridge (`userspace-dp/csrc/xsk_bridge.c`) gained `_Static_assert`s
+  (`sizeof`/`_Alignof`/`offsetof`) pinning the *installed* libxdp structs to
+  the same numeric contract; these compile under build.rs's `cc` invocation,
+  so a libxdp/header upgrade that reorders or resizes the ring struct now
+  fails the build instead of silently corrupting AF_XDP memory at runtime.
+  Added a named runtime test `xsk_ring_abi_matches_libxdp_contract`
+  (`userspace-dp/src/xsk_ffi_tests.rs`) restating the contract for a
+  human-readable failure. No runtime dataplane behavior change.
+- **Validation**: `cargo build` + `cargo test xsk_` green (9/9). Fail-injected
+  both halves: adding a `u32` field to `XskRingProd` → Rust const block
+  `E0080: xsk ring size drift` (build fails); changing the C `producer` offset
+  assert from 16→999 → `cc` `static assertion failed: "xsk_ring_prod producer"`
+  (build fails). Both reverted; rebuild green.
+- **File(s)**: userspace-dp/src/xsk_ffi.rs, userspace-dp/csrc/xsk_bridge.c,
+  userspace-dp/src/xsk_ffi_tests.rs
+
 ## 2026-07-22 — #4975: index replay-filter drop set in a HashSet
 
 - **Timestamp**: 2026-07-22 13:30 PDT (fix/4975-replay-purge-index)

--- a/userspace-dp/build.rs
+++ b/userspace-dp/build.rs
@@ -16,4 +16,11 @@ fn main() {
     println!("cargo:rustc-link-lib=static=z");
     println!("cargo:rustc-link-lib=static=zstd");
     println!("cargo:rerun-if-changed=csrc/xsk_bridge.c");
+    // #4976: an in-place libxdp header upgrade that reorders/resizes the ring
+    // structs must re-run the C `_Static_assert`s in xsk_bridge.c. Cargo would
+    // otherwise reuse the cached bridge object (the .c file is unchanged) and
+    // silently skip the ABI check on an incremental build — exactly the drift
+    // this gate exists to catch. Track the installed header so a package
+    // upgrade forces a recompile.
+    println!("cargo:rerun-if-changed=/usr/include/xdp/xsk.h");
 }

--- a/userspace-dp/csrc/xsk_bridge.c
+++ b/userspace-dp/csrc/xsk_bridge.c
@@ -14,6 +14,42 @@
 #include <sys/socket.h>
 #include <poll.h>
 #include <unistd.h>
+#include <stddef.h>
+
+/*
+ * ── Build-time ABI coupling (#4976) ───────────────────────────────────
+ *
+ * The Rust side (src/xsk_ffi.rs) hand-mirrors these libxdp ring structs as
+ * `XskRingProd`/`XskRingCons` and hands zeroed boxes of them to the creation
+ * functions below for libxdp to populate in place as native
+ * `struct xsk_ring_{prod,cons}`. Nothing else couples the *installed* libxdp
+ * layout (this translation unit compiles against /usr/include/xdp/xsk.h) to
+ * that independent Rust copy. A libxdp/header package upgrade that reorders
+ * or resizes the ring struct would otherwise silently turn a clean rebuild
+ * into out-of-bounds writes / misread indices at runtime.
+ *
+ * These assertions pin the installed `struct xsk_ring_{prod,cons}` to a fixed
+ * 64-bit ABI contract; src/xsk_ffi.rs pins its Rust mirror to the SAME
+ * numbers. If a libxdp upgrade changes the ring layout, this file fails to
+ * compile (via build.rs's cc invocation) and the build stops here. Keep these
+ * numbers in lockstep with the `const _` assertions in src/xsk_ffi.rs.
+ */
+_Static_assert(sizeof(void *) == 8, "xsk ring ABI assumes 64-bit pointers");
+
+#define XSK_RING_ABI_ASSERT(T)                                                 \
+    _Static_assert(sizeof(struct T) == 48, #T " size drift vs Rust mirror");   \
+    _Static_assert(_Alignof(struct T) == 8, #T " align drift vs Rust mirror"); \
+    _Static_assert(offsetof(struct T, cached_prod) == 0, #T " cached_prod");   \
+    _Static_assert(offsetof(struct T, cached_cons) == 4, #T " cached_cons");   \
+    _Static_assert(offsetof(struct T, mask) == 8, #T " mask");                 \
+    _Static_assert(offsetof(struct T, size) == 12, #T " size");                \
+    _Static_assert(offsetof(struct T, producer) == 16, #T " producer");        \
+    _Static_assert(offsetof(struct T, consumer) == 24, #T " consumer");        \
+    _Static_assert(offsetof(struct T, ring) == 32, #T " ring");                \
+    _Static_assert(offsetof(struct T, flags) == 40, #T " flags")
+
+XSK_RING_ABI_ASSERT(xsk_ring_prod);
+XSK_RING_ABI_ASSERT(xsk_ring_cons);
 
 /* ── UMEM creation / destruction ──────────────────────────────────── */
 

--- a/userspace-dp/src/xsk_ffi.rs
+++ b/userspace-dp/src/xsk_ffi.rs
@@ -52,6 +52,60 @@ pub(crate) struct XskSocketOpaque {
 unsafe impl Send for XskRingProd {}
 unsafe impl Send for XskRingCons {}
 
+// ── Build-time ABI coupling to libxdp's ring structs (#4976) ──────────
+//
+// `XskRingProd`/`XskRingCons` above hand-mirror libxdp's
+// `struct xsk_ring_prod`/`xsk_ring_cons` (the `DEFINE_XSK_RING` macro in
+// `/usr/include/xdp/xsk.h`). Rust allocates zeroed boxes of these
+// (see `Umem::new` / `Socket::create`) and hands them to libxdp's C
+// creation functions via `csrc/xsk_bridge.c`, which populates them in
+// place as native libxdp structs. Nothing otherwise couples the installed
+// libxdp layout to this independent Rust copy: a libxdp/header package
+// upgrade that reorders or resizes the ring struct — a routine ops event
+// given the project's image-baking + kernel/OS upgrades (#1930) — would
+// turn a clean rebuild into out-of-bounds writes / misread indices in the
+// AF_XDP ownership core (silent memory corruption, not a bind error).
+//
+// This const block pins the Rust mirror to a fixed 64-bit ABI contract.
+// `csrc/xsk_bridge.c` pins the *installed libxdp* structs to the SAME
+// numbers with `_Static_assert`. The two halves couple all three copies
+// (installed header ↔ C bridge ↔ Rust mirror) through one shared numeric
+// contract: any layout drift on either side fails the build here instead
+// of corrupting memory at runtime. Keep these numbers in lockstep with the
+// `_Static_assert`s in `csrc/xsk_bridge.c`.
+const _: () = {
+    // The fixed pointer-field offsets below assume 64-bit pointers, which
+    // is the only target the AF_XDP dataplane builds for.
+    assert!(
+        core::mem::size_of::<*const u32>() == 8,
+        "xsk ring ABI assumes 64-bit pointers"
+    );
+
+    macro_rules! assert_xsk_ring_layout {
+        ($t:ty) => {
+            assert!(
+                core::mem::size_of::<$t>() == 48,
+                "xsk ring size drift vs libxdp DEFINE_XSK_RING"
+            );
+            assert!(
+                core::mem::align_of::<$t>() == 8,
+                "xsk ring align drift vs libxdp DEFINE_XSK_RING"
+            );
+            assert!(core::mem::offset_of!($t, cached_prod) == 0, "cached_prod offset drift");
+            assert!(core::mem::offset_of!($t, cached_cons) == 4, "cached_cons offset drift");
+            assert!(core::mem::offset_of!($t, mask) == 8, "mask offset drift");
+            assert!(core::mem::offset_of!($t, size) == 12, "size offset drift");
+            assert!(core::mem::offset_of!($t, producer) == 16, "producer offset drift");
+            assert!(core::mem::offset_of!($t, consumer) == 24, "consumer offset drift");
+            assert!(core::mem::offset_of!($t, ring) == 32, "ring offset drift");
+            assert!(core::mem::offset_of!($t, flags) == 40, "flags offset drift");
+        };
+    }
+
+    assert_xsk_ring_layout!(XskRingProd);
+    assert_xsk_ring_layout!(XskRingCons);
+};
+
 unsafe extern "C" {
     fn bridge_xsk_umem_create(
         umem_out: *mut *mut XskUmemOpaque,

--- a/userspace-dp/src/xsk_ffi_tests.rs
+++ b/userspace-dp/src/xsk_ffi_tests.rs
@@ -218,3 +218,48 @@ fn read_rx_release_advances_consumer_through_mut_ref() {
     // consumer pointer advanced by the two released descriptors.
     assert_eq!(unsafe { *rx.ring.consumer }, 2);
 }
+
+// ── libxdp ring ABI contract (#4976) ─────────────────────────────
+//
+// The authoritative guard is the `const _` block in `xsk_ffi.rs` (fails
+// the build on drift) plus the `_Static_assert`s in `csrc/xsk_bridge.c`
+// (fail the build if the *installed* libxdp layout drifts). This runtime
+// test restates the same contract as a named, discoverable check: if the
+// Rust mirror is ever re-laid-out without updating the contract, the const
+// block already refuses to compile this crate — but this test also gives a
+// human-readable failure naming the exact field that moved.
+#[test]
+fn xsk_ring_abi_matches_libxdp_contract() {
+    use core::mem::{align_of, offset_of, size_of};
+
+    // 64-bit pointer width underpins the fixed pointer-field offsets.
+    assert_eq!(size_of::<*const u32>(), 8, "AF_XDP dataplane is 64-bit only");
+
+    for (name, sz, al) in [
+        ("XskRingProd", size_of::<XskRingProd>(), align_of::<XskRingProd>()),
+        ("XskRingCons", size_of::<XskRingCons>(), align_of::<XskRingCons>()),
+    ] {
+        assert_eq!(sz, 48, "{name} size drift vs libxdp DEFINE_XSK_RING");
+        assert_eq!(al, 8, "{name} align drift vs libxdp DEFINE_XSK_RING");
+    }
+
+    // Field offsets — must match libxdp's `DEFINE_XSK_RING` in xsk.h and
+    // the `_Static_assert`s in csrc/xsk_bridge.c.
+    assert_eq!(offset_of!(XskRingProd, cached_prod), 0, "prod.cached_prod");
+    assert_eq!(offset_of!(XskRingProd, cached_cons), 4, "prod.cached_cons");
+    assert_eq!(offset_of!(XskRingProd, mask), 8, "prod.mask");
+    assert_eq!(offset_of!(XskRingProd, size), 12, "prod.size");
+    assert_eq!(offset_of!(XskRingProd, producer), 16, "prod.producer");
+    assert_eq!(offset_of!(XskRingProd, consumer), 24, "prod.consumer");
+    assert_eq!(offset_of!(XskRingProd, ring), 32, "prod.ring");
+    assert_eq!(offset_of!(XskRingProd, flags), 40, "prod.flags");
+
+    assert_eq!(offset_of!(XskRingCons, cached_prod), 0, "cons.cached_prod");
+    assert_eq!(offset_of!(XskRingCons, cached_cons), 4, "cons.cached_cons");
+    assert_eq!(offset_of!(XskRingCons, mask), 8, "cons.mask");
+    assert_eq!(offset_of!(XskRingCons, size), 12, "cons.size");
+    assert_eq!(offset_of!(XskRingCons, producer), 16, "cons.producer");
+    assert_eq!(offset_of!(XskRingCons, consumer), 24, "cons.consumer");
+    assert_eq!(offset_of!(XskRingCons, ring), 32, "cons.ring");
+    assert_eq!(offset_of!(XskRingCons, flags), 40, "cons.flags");
+}


### PR DESCRIPTION
## Problem

`userspace-dp/src/xsk_ffi.rs` hand-mirrors libxdp's `struct xsk_ring_prod`/`xsk_ring_cons` (the `DEFINE_XSK_RING` macro in `/usr/include/xdp/xsk.h`) as `XskRingProd`/`XskRingCons`. Rust allocates zeroed boxes of these and hands them to libxdp's C creation functions via `csrc/xsk_bridge.c`, which populates them in place as native libxdp structs.

Nothing coupled the *installed* libxdp layout to this independent Rust copy: `build.rs` compiled the bridge against the installed header but carried **no `sizeof`/`offsetof` assertion**. A libxdp/header package upgrade that reordered or resized the ring struct — a routine ops event given the project's image-baking and kernel/OS upgrades (#1930) — would turn a clean rebuild into out-of-bounds writes / misread indices in the AF_XDP ownership core: silent memory corruption, not a bind error, and hard to diagnose from Rust.

## Fix

A two-sided, **build-time** ABI check binding all three copies (installed header, C bridge, Rust mirror) through one shared numeric contract:

- **Rust** (`src/xsk_ffi.rs`): a `const _: () = { … }` block asserts `size_of` (48), `align_of` (8) and every field offset (`0/4/8/12/16/24/32/40` on 64-bit) via `core::mem::offset_of!`. Drift in the Rust mirror fails const evaluation.
- **C** (`csrc/xsk_bridge.c`): `_Static_assert`s on `sizeof`/`_Alignof`/`offsetof` pin the *installed* `struct xsk_ring_{prod,cons}` to the same numbers. They compile under `build.rs`'s `cc` invocation, so a header layout change fails the build.
- **Test** (`src/xsk_ffi_tests.rs`): a named `xsk_ring_abi_matches_libxdp_contract` restates the contract so a drift also yields a human-readable, field-level failure.

Compile-time gate only — **no runtime dataplane behavior change**. The guard is self-documenting inline (both files cross-reference the issue and carry a "keep in lockstep" note); no existing module doc covers the xsk FFI bridge.

## Validation

`cargo build` and `cargo test xsk_` green (9/9). Fail-injected both halves to confirm the gate trips on drift and passes when correct:

- Adding a `u32` field to `XskRingProd` → Rust const block `E0080: xsk ring size drift vs libxdp DEFINE_XSK_RING` (build fails).
- Changing the C `producer` offset assert from `16` to `999` → `cc` `error: static assertion failed: "xsk_ring_prod producer"` (build fails).

Both injections reverted; rebuild green.

Closes #4976