### PR TITLE
refactor(userspace-dp): split event_stream/mod.rs into cohesive submodules (#6235)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -56655,3 +56655,13 @@ top.
   re-imports annotated (now serve siblings/tests). Build green.
 - **File(s)**: userspace-dp/src/event_stream/control.rs (new),
   userspace-dp/src/event_stream/mod.rs
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 split — extract the I/O thread (io_thread_main, try_connect,
+  replay_buffered, write_all_backpressured, run_connected_loop) into
+  event_stream/connection.rs (verbatim; reconnect + replay + backpressured
+  connected loop). Widened cross-module fns to pub(super); try_connect stays
+  private. Removed orphaned I/O-thread section comment; annotated the now
+  submodule-only std imports (VecDeque/io/UnixStream/TryRecvError). Build green.
+- **File(s)**: userspace-dp/src/event_stream/connection.rs (new),
+  userspace-dp/src/event_stream/mod.rs

--- a/_Log.md
+++ b/_Log.md
@@ -56646,3 +56646,12 @@ top.
   now serve only siblings/tests via `use super::*`). Build green.
 - **File(s)**: userspace-dp/src/event_stream/drain.rs (new),
   userspace-dp/src/event_stream/mod.rs
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 split — extract control-frame decode + drain/resync state
+  machine (process_control_frames, handle_drain_request) into
+  event_stream/control.rs (verbatim; ACK-window #2959, Pause/Resume, DrainRequest
+  #2876/#2882/#2875). Widened to pub(super); MSG_*/FRAME_HEADER_SIZE codec
+  re-imports annotated (now serve siblings/tests). Build green.
+- **File(s)**: userspace-dp/src/event_stream/control.rs (new),
+  userspace-dp/src/event_stream/mod.rs

--- a/_Log.md
+++ b/_Log.md
@@ -56636,3 +56636,13 @@ top.
   private (only push calls it). Build green.
 - **File(s)**: userspace-dp/src/event_stream/replay.rs (new),
   userspace-dp/src/event_stream/mod.rs
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 split — extract channel-drain mechanics (DrainOutcome,
+  drain_channel_into_write_buf, flush_pending_resync, drain_remaining) into
+  event_stream/drain.rs (verbatim, WRITE_BACKLOG_MAX_BYTES cap enforced there).
+  Widened to pub(super) incl DrainOutcome fields (tests assert them).
+  Consolidated mod.rs internal re-exports under #[allow(unused_imports)] (many
+  now serve only siblings/tests via `use super::*`). Build green.
+- **File(s)**: userspace-dp/src/event_stream/drain.rs (new),
+  userspace-dp/src/event_stream/mod.rs

--- a/_Log.md
+++ b/_Log.md
@@ -56619,3 +56619,11 @@ top.
   re-imports both names. Build green.
 - **File(s)**: userspace-dp/src/event_stream/backlog.rs (new),
   userspace-dp/src/event_stream/mod.rs
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 split — extract release_dataplane_event_queue_budget into
+  event_stream/budget.rs (verbatim; the I/O-thread queue-budget RETIREMENT side,
+  paired with producer.rs admission). Widened private->pub(super); mod.rs
+  re-imports it. Build green.
+- **File(s)**: userspace-dp/src/event_stream/budget.rs (new),
+  userspace-dp/src/event_stream/mod.rs

--- a/_Log.md
+++ b/_Log.md
@@ -56599,3 +56599,13 @@ top.
 - **File(s)**: pkg/routing/tunnel.go, pkg/routing/tunnel_wireguard.go,
   pkg/routing/tunnel_keepalive_runner.go, pkg/snmp/agent.go,
   pkg/snmp/agent_ber.go, pkg/routing/README.md, pkg/snmp/README.md
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 pure code-motion split of event_stream/mod.rs — extract
+  wall-clock conversion into event_stream/clock.rs (NS_PER_SEC +
+  read_mono_and_wall_clocks + monotonic_ns_to_unix_ns/_secs/_secs_subnanos +
+  mono_ns_to_wall_clock_unix_ns, verbatim). mod.rs re-exports the pub(crate)
+  clock fns so callers (afxdp/event_emit.rs, tests) resolve unchanged. Build
+  green.
+- **File(s)**: userspace-dp/src/event_stream/clock.rs (new),
+  userspace-dp/src/event_stream/mod.rs

--- a/_Log.md
+++ b/_Log.md
@@ -56665,3 +56665,17 @@ top.
   submodule-only std imports (VecDeque/io/UnixStream/TryRecvError). Build green.
 - **File(s)**: userspace-dp/src/event_stream/connection.rs (new),
   userspace-dp/src/event_stream/mod.rs
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 split — extract RT_FLOW SESSION_CLOSE/CREATE projection
+  methods (emit_session_close_rt_flow, emit_session_create_rt_flow) into
+  event_stream/rt_flow.rs as a second impl EventStreamWorkerHandle block
+  (verbatim, pub(crate) methods unchanged). Made NS_PER_SEC pub(super) +
+  re-imported (rt_flow tests consume it via super::*). Removed orphan section
+  comment. Updated event_stream/README.md Files section for the new submodule
+  layout. Full cargo test --release: 4214 passed, 0 failed, 2 ignored. mod.rs
+  down to 733 lines (from 2001); all 4 #[inline] preserved, 0 #[cold].
+- **File(s)**: userspace-dp/src/event_stream/rt_flow.rs (new),
+  userspace-dp/src/event_stream/mod.rs,
+  userspace-dp/src/event_stream/clock.rs,
+  userspace-dp/src/event_stream/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -56627,3 +56627,12 @@ top.
   re-imports it. Build green.
 - **File(s)**: userspace-dp/src/event_stream/budget.rs (new),
   userspace-dp/src/event_stream/mod.rs
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 split — extract replay-buffer admission/eviction/retirement
+  (push_replay_frame, evict_replay_frame, pop_replay_frame,
+  release_replay_dataplane_event_queue_budget) into event_stream/replay.rs
+  (verbatim). Widened the three cross-module fns to pub(super); evict stays
+  private (only push calls it). Build green.
+- **File(s)**: userspace-dp/src/event_stream/replay.rs (new),
+  userspace-dp/src/event_stream/mod.rs

--- a/_Log.md
+++ b/_Log.md
@@ -56609,3 +56609,13 @@ top.
   green.
 - **File(s)**: userspace-dp/src/event_stream/clock.rs (new),
   userspace-dp/src/event_stream/mod.rs
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6235 split — extract WriteBacklog + WRITE_BACKLOG_MAX_BYTES into
+  event_stream/backlog.rs (verbatim, cursor-backed geometric-compaction backlog,
+  #[inline] preserved on pending_len/is_empty/pending/compact_if_needed). Struct,
+  methods, and compacted_bytes test field widened private->pub(super) so callers
+  (mod.rs connected loop/drain, write_backlog tests) resolve unchanged. mod.rs
+  re-imports both names. Build green.
+- **File(s)**: userspace-dp/src/event_stream/backlog.rs (new),
+  userspace-dp/src/event_stream/mod.rs

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -7,8 +7,40 @@ periodic ACK from the daemon.
 
 ## Files
 
-- `mod.rs` — `EventStreamSender` owns its own I/O thread, connects to
-  the daemon's listener, sends frames, handles reconnect on EPIPE.
+- `mod.rs` — the module facade: `EventStreamSender` (owns the I/O thread),
+  the shared `EventStreamShared` atomics/state, `EventStreamStats`, the
+  `EventStreamWorkerHandle` producer core (sequence reservation/rollback,
+  bounded/lossless channel admission, `push_delta`/`push_delta_lossless`),
+  config constants, and the I/O-thread bootstrap. The transport/producer
+  state machine was split into the cohesive submodules below (#6235, pure
+  code motion); `mod.rs` re-exports the moved helpers so callers and the
+  test tree resolve unchanged.
+- `clock.rs` — monotonic-to-wall-clock conversion for the flow-export wire
+  fields (`read_mono_and_wall_clocks`, `monotonic_ns_to_unix_ns/_secs/
+  _secs_subnanos`, `mono_ns_to_wall_clock_unix_ns`; #2465/#2853/#2470).
+- `backlog.rs` — the cursor-backed `WriteBacklog` (geometric compaction,
+  #4974) and the `WRITE_BACKLOG_MAX_BYTES` cap (#2381).
+- `producer.rs` — non-blocking helper-side producer API for RT_FLOW
+  telemetry: per-kind/per-zone rate limiter, queue-budget ADMISSION and
+  counters, and `try_emit_dataplane_frame` (see below).
+- `rt_flow.rs` — the RT_FLOW SESSION_CLOSE/SESSION_CREATE projection
+  emitters (`emit_session_close_rt_flow`, `emit_session_create_rt_flow`).
+- `connection.rs` — the I/O thread: reconnect loop (`io_thread_main`,
+  `try_connect`), un-ACKed replay (`replay_buffered`), the stop-aware
+  backpressured writer (`write_all_backpressured`, #2877), and the
+  steady-state `run_connected_loop`.
+- `control.rs` — daemon->helper control-frame decode (`process_control_frames`:
+  ACK-window #2959, Pause/Resume) and the DORMANT seq-fenced drain
+  (`handle_drain_request`, #2876/#2882/#2875).
+- `drain.rs` — channel-drain mechanics: `drain_channel_into_write_buf` (the
+  `WRITE_BACKLOG_MAX_BYTES` cap + ordered FullResync merge #5267),
+  `flush_pending_resync`, `DrainOutcome`, and the shutdown `drain_remaining`.
+- `replay.rs` — replay-buffer admission/eviction/retirement
+  (`push_replay_frame`, `evict_replay_frame`, `pop_replay_frame`,
+  `release_replay_dataplane_event_queue_budget`; #2382/#2875).
+- `budget.rs` — the I/O-thread queue-budget RETIREMENT side
+  (`release_dataplane_event_queue_budget`), paired with `producer.rs`
+  admission.
 - `codec.rs` — frame layout: 16-byte header
   `[length:u32 LE][type:u8][reserved:3][seq:u64 LE]` followed by the
   payload. Message types: `MSG_SESSION_OPEN`, `MSG_SESSION_CLOSE`,

--- a/userspace-dp/src/event_stream/backlog.rs
+++ b/userspace-dp/src/event_stream/backlog.rs
@@ -1,0 +1,156 @@
+//! Cursor-backed pending socket-write backlog for the connected I/O loop.
+//!
+//! Pure code motion out of `mod.rs` (#6235); no logic change. The connected
+//! loop (`connection.rs`) and the channel drain (`drain.rs`) keep unwritten
+//! socket bytes in [`WriteBacklog`] between cycles, bounded by
+//! [`WRITE_BACKLOG_MAX_BYTES`].
+
+/// Hard cap on the I/O thread's pending socket-write backlog (`write_buf`).
+///
+/// The bounded mpsc channel (`CHANNEL_CAPACITY`) is the only intended
+/// backpressure surface. Without this cap a wedged daemon (socket open but
+/// not reading → `write_buf` writes return `WouldBlock`) lets the I/O thread
+/// migrate the entire channel into the heap-backed `write_buf` every cycle;
+/// the channel then refills from worker `try_send`, the I/O thread drains it
+/// again, and `write_buf` grows without bound → helper OOM / allocator
+/// pressure on the forwarding plane (#2381). Once the backlog reaches this
+/// cap the I/O thread stops pulling frames out of the channel, so the bounded
+/// channel becomes the real backpressure surface and `try_send` drops (with
+/// the existing `frames_dropped` / per-kind `queue_full` counters) instead of
+/// silently relocating bytes into one unbounded buffer.
+///
+/// `EventFrame::data` is a fixed `[u8; 256]` (see codec.rs), so a fully
+/// drained `CHANNEL_CAPACITY` (8192) channel is at most 8192 × 256 ≈ 2 MiB of
+/// bytes. 16 MiB is therefore ≈ 8× that worst-case channel drain — generous
+/// headroom so transient bursts (plus any in-flight replay/partial-write
+/// remainder) are absorbed losslessly, while a persistently stalled consumer
+/// stays bounded.
+///
+/// The cap is checked at the top of the drain loop, before the in-flight frame
+/// is appended, so the UNWRITTEN backlog can reach at most
+/// `WRITE_BACKLOG_MAX_BYTES` plus one already-pulled max `EventFrame` (≤ 256 B)
+/// before the drain halts — i.e. the bound is `cap + one frame`, not a strict
+/// 16 MiB. The overshoot is bounded and accepted (simpler than a pre-reserve
+/// check); memory is bounded either way.
+///
+/// #4974: the cap and every backpressure decision measure UNWRITTEN bytes
+/// (`WriteBacklog::pending_len()`), not the raw backing-`Vec` length. The
+/// backlog is cursor-backed (`WriteBacklog`): bytes already handed to the
+/// socket sit in a reclaimable prefix and are compacted geometrically, so the
+/// `Vec` can transiently hold up to ~2× the pending length. Accounting on the
+/// raw length would trip the cap early and drift the pause/resume logic.
+pub(super) const WRITE_BACKLOG_MAX_BYTES: usize = 16 * 1024 * 1024;
+
+/// Cursor-backed pending socket-write backlog for the connected I/O loop.
+///
+/// #4974: the connected loop keeps unwritten socket bytes here between cycles.
+/// A slow reader accepts only a few bytes per `write`, leaving a large suffix
+/// for the next cycle. The original code stored the backlog in a bare `Vec<u8>`
+/// and reclaimed each short write with `write_buf.drain(..n)`, which memmoves
+/// the ENTIRE remaining suffix down to offset 0 on every write — O(backlog) per
+/// write, so O(backlog²) total copy work while a slow consumer nibbles through
+/// a multi-MiB backlog, all on the single event I/O thread during exactly the
+/// slow-consumer condition.
+///
+/// Instead we track a `start` cursor into `buf`: `buf[start..]` is the
+/// unwritten pending suffix, `buf[..start]` is written-and-reclaimable. A
+/// successful write of `n` bytes advances `start` in O(1) (no memmove). The
+/// consumed prefix is reclaimed by GEOMETRIC compaction — a single copy of the
+/// pending suffix to offset 0 only once the prefix reaches half the buffer
+/// (`start >= buf.len()/2`). Because a compaction then copies at most `start`
+/// bytes and resets `start` to 0, total compaction work is bounded by the total
+/// bytes ever written (amortized O(1) per write, O(total_bytes) overall), and
+/// `buf.len()` stays within ~2× the pending length (bounded, not the unbounded
+/// growth #2381 guards against). Byte order and exactly-once delivery are
+/// preserved: appends only ever go to the tail and compaction never reorders
+/// the pending suffix.
+pub(super) struct WriteBacklog {
+    /// Backing storage. `buf[start..]` is the unwritten pending suffix.
+    buf: Vec<u8>,
+    /// Offset of the first unwritten byte. Bytes below it were already written
+    /// to the socket and are reclaimable by compaction.
+    start: usize,
+    /// #4974: total bytes moved by geometric compaction, so the amortized
+    /// -linear regression gate can assert bounded copy work. Test-only.
+    #[cfg(test)]
+    pub(super) compacted_bytes: usize,
+}
+
+impl WriteBacklog {
+    pub(super) fn with_capacity(cap: usize) -> Self {
+        Self {
+            buf: Vec::with_capacity(cap),
+            start: 0,
+            #[cfg(test)]
+            compacted_bytes: 0,
+        }
+    }
+
+    /// Unwritten bytes still owed to the socket. This is the value the
+    /// `WRITE_BACKLOG_MAX_BYTES` cap and the pause/backpressure logic use — NOT
+    /// the raw `Vec` length, which also counts the reclaimable written prefix.
+    #[inline]
+    pub(super) fn pending_len(&self) -> usize {
+        self.buf.len() - self.start
+    }
+
+    #[inline]
+    pub(super) fn is_empty(&self) -> bool {
+        self.start >= self.buf.len()
+    }
+
+    /// The unwritten suffix to hand to the next socket `write`.
+    #[inline]
+    pub(super) fn pending(&self) -> &[u8] {
+        &self.buf[self.start..]
+    }
+
+    /// Append freshly produced frame bytes to the pending tail. Reclaims the
+    /// consumed prefix first (geometrically) so the `Vec` tracks the pending
+    /// length rather than the lifetime sum of everything ever queued.
+    pub(super) fn extend_from_slice(&mut self, bytes: &[u8]) {
+        self.compact_if_needed();
+        self.buf.extend_from_slice(bytes);
+    }
+
+    /// Record a successful socket write of `n` bytes. Advances the cursor in
+    /// O(1); when the backlog fully drains it resets without a copy, otherwise
+    /// it compacts geometrically. Replaces the O(backlog) `drain(..n)` memmove.
+    pub(super) fn advance(&mut self, n: usize) {
+        self.start += n;
+        debug_assert!(self.start <= self.buf.len(), "write reported more than pending");
+        if self.start >= self.buf.len() {
+            // Fully drained -- reset to empty without moving any bytes.
+            self.buf.clear();
+            self.start = 0;
+        } else {
+            self.compact_if_needed();
+        }
+    }
+
+    /// Geometric compaction trigger: reclaim the consumed prefix only once it
+    /// reaches half the buffer. At that point the pending suffix being copied is
+    /// no larger than the prefix being discarded, so the copy cost is charged to
+    /// already-consumed bytes and total compaction work stays O(total_bytes).
+    #[inline]
+    fn compact_if_needed(&mut self) {
+        if self.start != 0 && self.start >= self.buf.len() / 2 {
+            self.compact();
+        }
+    }
+
+    /// Move the pending suffix down to offset 0 and drop the consumed prefix.
+    fn compact(&mut self) {
+        if self.start == 0 {
+            return;
+        }
+        let pending = self.buf.len() - self.start;
+        self.buf.copy_within(self.start.., 0);
+        self.buf.truncate(pending);
+        self.start = 0;
+        #[cfg(test)]
+        {
+            self.compacted_bytes += pending;
+        }
+    }
+}

--- a/userspace-dp/src/event_stream/budget.rs
+++ b/userspace-dp/src/event_stream/budget.rs
@@ -1,0 +1,18 @@
+//! Dataplane-event queue-budget release for frames leaving the channel.
+//!
+//! Pure code motion out of `mod.rs` (#6235); no logic change. Queue-budget
+//! ADMISSION happens on producer threads (`producer.rs`); this is the I/O-thread
+//! RETIREMENT side — every telemetry frame that leaves the channel (drained,
+//! replayed, evicted, popped on ACK, or dropped on shutdown) releases exactly
+//! the per-kind budget slot it acquired at emit.
+
+use super::*;
+
+pub(super) fn release_dataplane_event_queue_budget(
+    shared: &Arc<EventStreamShared>,
+    frame: &EventFrame,
+) {
+    if let Some(kind) = frame.dataplane_event_kind() {
+        shared.dataplane_event_queue.release(kind);
+    }
+}

--- a/userspace-dp/src/event_stream/clock.rs
+++ b/userspace-dp/src/event_stream/clock.rs
@@ -7,7 +7,7 @@
 //! the Go side cannot skew the logged event time to consumption time. Pure code
 //! motion out of `mod.rs` (#6235); no logic change.
 
-const NS_PER_SEC: u64 = 1_000_000_000;
+pub(super) const NS_PER_SEC: u64 = 1_000_000_000;
 
 /// #2465: read CLOCK_MONOTONIC (ns) and the wall clock (ns since the Unix
 /// epoch) in one pair so the two are anchored to the same instant. Used to

--- a/userspace-dp/src/event_stream/clock.rs
+++ b/userspace-dp/src/event_stream/clock.rs
@@ -1,0 +1,102 @@
+//! Monotonic-to-wall-clock conversion for event-stream flow-export fields.
+//!
+//! The session table stamps creation/last-seen instants with `CLOCK_MONOTONIC`,
+//! but the RT_FLOW / flow-export wire fields carry absolute Unix wall-clock
+//! values. These helpers anchor a monotonic instant against a single
+//! `(CLOCK_MONOTONIC, CLOCK_REALTIME)` reading so a queued/backlogged delivery on
+//! the Go side cannot skew the logged event time to consumption time. Pure code
+//! motion out of `mod.rs` (#6235); no logic change.
+
+const NS_PER_SEC: u64 = 1_000_000_000;
+
+/// #2465: read CLOCK_MONOTONIC (ns) and the wall clock (ns since the Unix
+/// epoch) in one pair so the two are anchored to the same instant. Used to
+/// convert the session table's monotonic creation/last-seen instants into the
+/// absolute wall-clock values the flow-export wire fields carry. On a clock
+/// read failure both fall back to 0 (→ the Go-side packet-count fallback).
+pub(super) fn read_mono_and_wall_clocks() -> (u64, u64) {
+    let mut mono = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    let mut wall = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    let rc_mono = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut mono) };
+    let rc_wall = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut wall) };
+    if rc_mono != 0 || rc_wall != 0 || mono.tv_sec < 0 || wall.tv_sec < 0 {
+        return (0, 0);
+    }
+    let mono_ns = (mono.tv_sec as u64)
+        .saturating_mul(NS_PER_SEC)
+        .saturating_add(mono.tv_nsec.max(0) as u64);
+    let wall_ns = (wall.tv_sec as u64)
+        .saturating_mul(NS_PER_SEC)
+        .saturating_add(wall.tv_nsec.max(0) as u64);
+    (mono_ns, wall_ns)
+}
+
+/// #2465: convert a monotonic instant (`mono_ns`) to an absolute wall-clock
+/// nanosecond count, anchored against a (`now_mono_ns`, `now_unix_ns`) reading.
+/// `mono_ns == 0` (unknown) maps to 0. The age is clamped at the present so a
+/// monotonic value slightly ahead of `now_mono_ns` (a benign cross-CPU read
+/// skew) cannot push the result into the future.
+pub(crate) fn monotonic_ns_to_unix_ns(mono_ns: u64, now_mono_ns: u64, now_unix_ns: u64) -> u64 {
+    if mono_ns == 0 || now_mono_ns == 0 || now_unix_ns == 0 {
+        return 0;
+    }
+    let age_ns = now_mono_ns.saturating_sub(mono_ns);
+    now_unix_ns.saturating_sub(age_ns)
+}
+
+/// #2465: convert a monotonic instant to absolute wall-clock Unix SECONDS for
+/// the `created` wire field (offset 108, u32). Truncates toward the epoch;
+/// 0/unknown stays 0; values beyond u32 (year 2106) saturate.
+pub(crate) fn monotonic_ns_to_unix_secs(mono_ns: u64, now_mono_ns: u64, now_unix_ns: u64) -> u32 {
+    monotonic_ns_to_unix_secs_subnanos(mono_ns, now_mono_ns, now_unix_ns).0
+}
+
+/// #2853: convert a monotonic instant to absolute wall-clock Unix SECONDS plus
+/// the sub-second NANOSECOND remainder (0..=999_999_999). The integer seconds
+/// ride the `created` wire field (offset 108, u32); the sub-second nanos ride
+/// the SESSION_CLOSE-unused policy_id slot (offset 44, u32) so the Go flow
+/// exporters can build a MILLISECOND-accurate flow StartTime instead of one
+/// truncated to the whole second (the #2853 defect: short flows — DNS, single
+/// HTTP requests — all collapsed onto the same integer-second start).
+///
+/// 0/unknown stays `(0, 0)`; a seconds value beyond u32 (year 2106) saturates
+/// to `(u32::MAX, 0)` so the saturated record carries no misleading remainder.
+pub(crate) fn monotonic_ns_to_unix_secs_subnanos(
+    mono_ns: u64,
+    now_mono_ns: u64,
+    now_unix_ns: u64,
+) -> (u32, u32) {
+    let unix_ns = monotonic_ns_to_unix_ns(mono_ns, now_mono_ns, now_unix_ns);
+    let secs = unix_ns / NS_PER_SEC;
+    if secs > u32::MAX as u64 {
+        return (u32::MAX, 0);
+    }
+    (secs as u32, (unix_ns % NS_PER_SEC) as u32)
+}
+
+/// #2470: convert a CLOCK_MONOTONIC instant (the `now_ns`/`now_secs`-derived
+/// value the worker poll loop hands to the RT_FLOW deny/screen/filter-log
+/// emitters) to an absolute wall-clock Unix nanosecond count, taking a fresh
+/// anchored (`mono`, `wall`) reading here. This is the emission-time
+/// conversion boundary: the deny/screen/filter-log events carry the dataplane
+/// DECISION instant on the wire (offset 0, LE u64, absolute Unix ns — the same
+/// `timestamp_ns` format the SESSION_CLOSE frame uses and the Go decoder
+/// reads), so a queued/backlogged delivery on the Go side cannot skew the
+/// logged event time to consumption time. A 0 `mono_ns` (unknown) or a clock
+/// read failure maps to 0 → the Go side (`pkg/logging/ringbuf.go`) falls back
+/// to receive time, preserving the old behavior only when no real instant is
+/// available.
+///
+/// These events fire on drops / denies / log-matched packets (NOT per normal
+/// packet), so one anchored clock read per emit is acceptable; correctness
+/// (a real decision timestamp) is preferred over saving the read.
+pub(crate) fn mono_ns_to_wall_clock_unix_ns(mono_ns: u64) -> u64 {
+    let (now_mono_ns, now_unix_ns) = read_mono_and_wall_clocks();
+    monotonic_ns_to_unix_ns(mono_ns, now_mono_ns, now_unix_ns)
+}

--- a/userspace-dp/src/event_stream/connection.rs
+++ b/userspace-dp/src/event_stream/connection.rs
@@ -1,0 +1,351 @@
+//! I/O thread: connection lifecycle, reconnect, replay, and the connected loop.
+//!
+//! Pure code motion out of `mod.rs` (#6235); no logic change. `io_thread_main`
+//! owns the reconnect loop; `try_connect` retries the daemon socket;
+//! `replay_buffered` re-sends un-ACKed frames (parking an ordered replay-gap
+//! FullResync barrier, #5267); `write_all_backpressured` is the stop-aware
+//! nonblocking backpressured writer (#2877) shared with the drain path; and
+//! `run_connected_loop` is the steady-state drain/write/read/keepalive cycle.
+
+use super::*;
+
+pub(super) fn io_thread_main(
+    rx: mpsc::Receiver<EventFrame>,
+    shared: Arc<EventStreamShared>,
+    socket_path: String,
+) {
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
+    let mut ctrl_read_buf: Vec<u8> = Vec::with_capacity(128);
+
+    while !shared.stop.load(Ordering::Acquire) {
+        // ---- Connect phase ----
+        let stream = match try_connect(&socket_path, &shared) {
+            Some(s) => s,
+            None => break, // stop requested during connect
+        };
+        stream.set_nonblocking(true).ok();
+        // #5267: `connected` stays set BEFORE `replay_buffered`. It gates only
+        // the LOSSLESS producer path (`send_lossless_encoded` fails closed when
+        // clear); deferring it past the non-gap replay window would make every
+        // worker `push_delta_lossless` return "not connected" mid-reconnect,
+        // which `flush_session_deltas` latches as loss-of-sync -> a spurious
+        // full owner-RG resync on every CLEAN reconnect (the exact churn class
+        // this fix removes). Wire ORDERING is instead guaranteed by allocating
+        // the replay-gap FullResync's seq under `producer_seq_lock` and merging
+        // it into the drain in seq order (below), so the `connected` timing is
+        // orthogonal to ordering.
+        shared.connected.store(true, Ordering::Release);
+        eprintln!("xpf-event-stream: connected to {}", socket_path);
+
+        // #5267: per-connection slot for a replay-gap FullResync barrier.
+        // `replay_buffered` allocates the barrier's seq under `producer_seq_lock`
+        // and PARKS the frame here instead of writing it out of order; the
+        // connected loop's channel drain emits it in seq order relative to the
+        // concurrently-committed deltas. Fresh per connection so a stale barrier
+        // from a prior connection is never re-emitted.
+        let mut pending_resync: Option<EventFrame> = None;
+
+        // Replay buffered events from last acked seq. A replay-buffer gap parks
+        // an ordered FullResync barrier in `pending_resync` rather than writing
+        // it directly ahead of the still-queued lower-seq deltas.
+        let acked = shared.acked_seq.load(Ordering::Acquire);
+        let replay_result =
+            replay_buffered(&stream, &mut replay_buf, acked, &shared, &mut pending_resync);
+        if replay_result.is_err() {
+            shared.connected.store(false, Ordering::Release);
+            eprintln!("xpf-event-stream: replay failed, reconnecting");
+            continue;
+        }
+
+        // ---- Steady-state loop ----
+        ctrl_read_buf.clear(); // discard stale data from previous connection
+        let disconnect = run_connected_loop(
+            &rx,
+            &stream,
+            &shared,
+            &mut replay_buf,
+            &mut ctrl_read_buf,
+            &mut pending_resync,
+            KEEPALIVE_IDLE_INTERVAL,
+        );
+
+        shared.connected.store(false, Ordering::Release);
+        if disconnect {
+            eprintln!("xpf-event-stream: disconnected, will reconnect");
+        }
+    }
+
+    // Drain remaining events on shutdown
+    drain_remaining(&rx, &shared);
+    release_replay_dataplane_event_queue_budget(&shared, &mut replay_buf);
+    shared.connected.store(false, Ordering::Release);
+    eprintln!("xpf-event-stream: I/O thread exiting");
+}
+
+/// Try to connect to the daemon event socket, retrying every 100ms.
+/// Returns None if stop is requested.
+fn try_connect(path: &str, shared: &Arc<EventStreamShared>) -> Option<UnixStream> {
+    loop {
+        if shared.stop.load(Ordering::Acquire) {
+            return None;
+        }
+        match UnixStream::connect(path) {
+            Ok(stream) => return Some(stream),
+            Err(_) => {
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+/// Replay buffered events that are newer than the last acked sequence.
+/// If the replay buffer doesn't cover acked+1, send FullResync.
+pub(super) fn replay_buffered(
+    stream: &UnixStream,
+    replay_buf: &mut VecDeque<EventFrame>,
+    acked_seq: u64,
+    shared: &Arc<EventStreamShared>,
+    pending_resync: &mut Option<EventFrame>,
+) -> io::Result<()> {
+    // One shared deadline bounds the whole replay so a stuck reader cannot hold
+    // the I/O thread for `frames * deadline` (#2877). `write_all_backpressured`
+    // keeps the socket NONBLOCKING (the canonical data-frame mode) and polls
+    // the stop flag each WouldBlock cycle; on stop/deadline/error it returns
+    // Err and the caller reconnects.
+    let deadline = Instant::now() + REPLAY_DRAIN_WRITE_DEADLINE;
+    // Check if replay buffer covers what we need. On a true fresh start
+    // (acked_seq == 0 and no buffered frames), start clean. Otherwise any gap
+    // at acked+1 requires FullResync, including the acked_seq==0 case where an
+    // overrun replay buffer has already trimmed seq 1.
+    let oldest_buffered = replay_buf.front().map(|f| f.seq).unwrap_or(0);
+    let has_gap = (replay_buf.is_empty() && acked_seq > 0) || oldest_buffered > acked_seq + 1;
+    if has_gap {
+        // #5267: allocate the FullResync's seq UNDER `producer_seq_lock` and
+        // PARK the frame in `pending_resync` instead of writing it directly to
+        // the socket. Writing it here (outside the lock, ahead of the channel
+        // drain) put a HIGHER seq on the wire before the lower-seq deltas still
+        // queued in the channel: the Go reader (zero reorder tolerance) then
+        // diagnosed a session-sync gap on the first post-barrier delta and
+        // dropped the connection, churning resyncs on the very HA-recovery
+        // barrier. Holding the lock for JUST the `fetch_add` guarantees every
+        // delta already committed to the channel has a strictly LOWER seq (the
+        // channel commit is atomic under the same lock, #3878) and every delta
+        // committed afterward has a strictly higher seq; the connected loop's
+        // drain then merges this barrier into the write stream in seq order
+        // (`drain_channel_into_write_buf`). The lock is released immediately —
+        // no socket write happens under it, so a wedged reader can never stall
+        // the producers through this path, and there is no lock-ordering cycle
+        // (the section is a single atomic).
+        let seq = {
+            let _guard = shared
+                .producer_seq_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            shared.next_seq.fetch_add(1, Ordering::Relaxed) + 1
+        };
+        *pending_resync = Some(EventFrame::encode_full_resync(seq));
+        eprintln!(
+            "xpf-event-stream: queued ordered FullResync seq {} (buffer gap: acked={}, oldest_buffered={})",
+            seq, acked_seq, oldest_buffered
+        );
+        // Keep the stale replay window until the daemon ACKs the FullResync.
+        // Clearing here can make an acked_seq=0 reconnect look like a clean
+        // fresh start and permanently suppress the required bulk export.
+        // `frames_sent` is bumped when the ordered drain accepts the barrier,
+        // matching producer-frame enqueue accounting. When the stream is
+        // paused that means replay retention rather than a socket write; #5328
+        // tracks the existing Resume path's missing replay-suffix scheduling.
+        return Ok(());
+    }
+
+    // Replay frames newer than acked_seq
+    let mut replayed = 0u64;
+    for frame in replay_buf.iter() {
+        if frame.seq > acked_seq {
+            write_all_backpressured(stream, frame.as_bytes(), shared, deadline)?;
+            replayed += 1;
+        }
+    }
+    if replayed > 0 {
+        shared
+            .frames_replayed
+            .fetch_add(replayed, Ordering::Relaxed);
+        eprintln!("xpf-event-stream: replayed {replayed} events");
+    }
+    Ok(())
+}
+
+/// Write all of `bytes` to the NONBLOCKING `stream`, honoring backpressure
+/// without ever wedging the I/O thread (#2877).
+///
+/// The replay (`replay_buffered`) and drain (`handle_drain_request`) paths must
+/// push frames to a socket whose daemon reader may have stalled. The old
+/// `write_frame_blocking` flipped the socket to BLOCKING and called `write_all`
+/// with no deadline and no stop check, so a stuck reader held the I/O thread in
+/// the blocking write forever — and since `EventStreamSender::stop` joins that
+/// thread, a write-blocked thread could not observe the stop flag and
+/// stop/demotion hung. That violates the slow-consumer invariant in
+/// `docs/session-sync-design.md`: a slow telemetry/session consumer must never
+/// stall the helper.
+///
+/// This writer keeps the socket nonblocking (the same mode the steady-state
+/// data-frame writes use) and, on `WouldBlock`, sleeps `REPLAY_DRAIN_WRITE_POLL`
+/// and retries — polling `shared.stop` every cycle and bailing at `deadline`.
+/// It returns `Err` on stop (Interrupted), deadline (TimedOut), or a real
+/// socket error so the caller reconnects / withholds DrainComplete rather than
+/// blocking indefinitely. `deadline` is shared across all frames in one
+/// replay/drain pass so total time is bounded even if stop is never raised.
+pub(super) fn write_all_backpressured(
+    stream: &UnixStream,
+    bytes: &[u8],
+    shared: &Arc<EventStreamShared>,
+    deadline: Instant,
+) -> io::Result<()> {
+    use std::io::Write;
+    let mut written = 0usize;
+    while written < bytes.len() {
+        if shared.stop.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "event stream stop requested during replay/drain write",
+            ));
+        }
+        match (&*stream).write(&bytes[written..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "event stream replay/drain write returned 0",
+                ));
+            }
+            Ok(n) => written += n,
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "event stream replay/drain write deadline exceeded",
+                    ));
+                }
+                thread::sleep(REPLAY_DRAIN_WRITE_POLL);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Main connected loop. Returns true if we should reconnect, false if stopping.
+pub(super) fn run_connected_loop(
+    rx: &mpsc::Receiver<EventFrame>,
+    stream: &UnixStream,
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+    ctrl_read_buf: &mut Vec<u8>,
+    pending_resync: &mut Option<EventFrame>,
+    keepalive_interval: Duration,
+) -> bool {
+    use std::io::{Read, Write};
+
+    let mut write_buf = WriteBacklog::with_capacity(4096);
+    let mut tmp_read = [0u8; 64];
+    let mut idle_cycles = 0u32;
+    let mut last_write = Instant::now();
+
+    loop {
+        if shared.stop.load(Ordering::Acquire) {
+            return false;
+        }
+
+        let paused = shared.paused.load(Ordering::Acquire);
+
+        let drain = drain_channel_into_write_buf(
+            rx,
+            shared,
+            replay_buf,
+            &mut write_buf,
+            paused,
+            pending_resync,
+        );
+        if drain.disconnected {
+            return false;
+        }
+        let drained_any = drain.drained_any;
+
+        // Write buffered frames to socket. On a partial (short) write we advance
+        // the backlog cursor in O(1) instead of memmoving the whole remaining
+        // suffix to offset 0 on every write (the #4974 O(n^2) drain).
+        if !write_buf.is_empty() {
+            match (&*stream).write(write_buf.pending()) {
+                Ok(n) => {
+                    write_buf.advance(n);
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    // Socket buffer full, keep write_buf for next cycle
+                }
+                Err(_) => {
+                    // Socket error -- disconnect
+                    return true;
+                }
+            }
+        }
+
+        // Read control frames from daemon (non-blocking), accumulating
+        // partial reads so that incomplete frames are not lost.
+        match (&*stream).read(&mut tmp_read) {
+            Ok(0) => {
+                // EOF -- peer closed
+                return true;
+            }
+            Ok(n) => {
+                ctrl_read_buf.extend_from_slice(&tmp_read[..n]);
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                // No data available -- normal
+            }
+            Err(_) => {
+                return true;
+            }
+        }
+
+        // Process complete control frames from accumulated buffer
+        if !ctrl_read_buf.is_empty() {
+            let (action, consumed) =
+                process_control_frames(ctrl_read_buf, shared, rx, stream, replay_buf);
+            if consumed > 0 {
+                ctrl_read_buf.drain(..consumed);
+            }
+            if let Some(reconnect) = action {
+                return reconnect;
+            }
+        }
+
+        // Idle backoff + keepalive
+        if drained_any {
+            idle_cycles = 0;
+            last_write = Instant::now();
+        } else {
+            idle_cycles = idle_cycles.saturating_add(1);
+            if idle_cycles > 10 {
+                // Enqueue a keepalive (prevents idle disconnect on the Go side)
+                // through the SAME `write_buf` backpressure path data frames use
+                // (#2883). The old code called `write_all` directly on the
+                // nonblocking socket and returned true (immediate reconnect) on
+                // ANY error — including `WouldBlock` when the kernel send buffer
+                // is full under a slow reader — bypassing the partial-write /
+                // WouldBlock backpressure and stall accounting and causing
+                // reconnect churn -> replay storms. Routing the keepalive bytes
+                // into `write_buf` makes WouldBlock ordinary backpressure: the
+                // top-of-loop flush retains the remainder for the next cycle,
+                // and a genuinely dead consumer is still detected by the normal
+                // socket-error / EOF path rather than by a false reconnect on
+                // transient fullness.
+                if last_write.elapsed() >= keepalive_interval {
+                    let mut ka = [0u8; FRAME_HEADER_SIZE];
+                    ka[4] = MSG_KEEPALIVE;
+                    write_buf.extend_from_slice(&ka);
+                    last_write = Instant::now();
+                }
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+}

--- a/userspace-dp/src/event_stream/control.rs
+++ b/userspace-dp/src/event_stream/control.rs
@@ -1,0 +1,310 @@
+//! Daemon->helper control-frame decode and the drain/resync state machine.
+//!
+//! Pure code motion out of `mod.rs` (#6235); no logic change. `process_control_frames`
+//! parses the accumulated control-read buffer (ACK watermark validation #2959,
+//! Pause/Resume, DrainRequest) and `handle_drain_request` runs the DORMANT
+//! seq-fenced drain (#2876/#2882/#2875 drain poison). Both write through the
+//! stop-aware backpressured writer so a stuck reader can never wedge the I/O
+//! thread.
+
+use super::*;
+
+/// Process control frames received from the daemon.
+/// Returns (action, bytes_consumed) where action is Some(true) to reconnect,
+/// Some(false) to stop, or None to continue. Only complete frames are consumed;
+/// any trailing partial frame is left for the next read cycle.
+pub(super) fn process_control_frames(
+    data: &[u8],
+    shared: &Arc<EventStreamShared>,
+    rx: &mpsc::Receiver<EventFrame>,
+    stream: &UnixStream,
+    replay_buf: &mut VecDeque<EventFrame>,
+) -> (Option<bool>, usize) {
+    let mut offset = 0;
+    while offset + FRAME_HEADER_SIZE <= data.len() {
+        let payload_len = u32::from_le_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]);
+        // #2879: reject an impossible payload_len BEFORE waiting for the rest of
+        // the frame. The full header is present (loop guard above), so we can
+        // validate the declared length on the header alone, regardless of how
+        // few payload bytes have arrived. Every current daemon->helper opcode is
+        // header-only, so any payload_len beyond MAX_CONTROL_PAYLOAD_LEN can
+        // never form a valid frame. Disconnecting (Some(true) -> reconnect,
+        // which clears ctrl_read_buf) stops a buggy/compromised daemon from
+        // trickling a 1<<30-length header and growing ctrl_read_buf without
+        // bound on the forwarding plane. A legitimately partial header-only
+        // frame still works: a payload_len of 0 passes here, and a split HEADER
+        // never reaches this point (the loop guard requires a full 16-byte
+        // header first). `offset` is returned so any complete frames parsed
+        // before the bad one are still accounted as consumed.
+        if payload_len as usize > MAX_CONTROL_PAYLOAD_LEN {
+            eprintln!(
+                "xpf-event-stream: control frame opcode {} declared payload_len={} \
+                 exceeds max {} -- disconnecting (#2879)",
+                data[offset + 4],
+                payload_len,
+                MAX_CONTROL_PAYLOAD_LEN
+            );
+            return (Some(true), offset);
+        }
+        let frame_len = FRAME_HEADER_SIZE + payload_len as usize;
+        if offset + frame_len > data.len() {
+            break; // incomplete frame -- wait for more data
+        }
+        let msg_type = data[offset + 4];
+        let seq = u64::from_le_bytes([
+            data[offset + 8],
+            data[offset + 9],
+            data[offset + 10],
+            data[offset + 11],
+            data[offset + 12],
+            data[offset + 13],
+            data[offset + 14],
+            data[offset + 15],
+        ]);
+        offset += frame_len;
+
+        match msg_type {
+            MSG_ACK => {
+                // Validate the ACK watermark BEFORE mutating acked_seq or
+                // trimming the replay buffer (#2959). A correct daemon ACKs
+                // only frames it has applied, so the sequence must lie in the
+                // window [acked_seq, next_seq]:
+                //   - seq == acked_seq  -> duplicate ACK, benign no-op
+                //   - seq == next_seq   -> ACK of the latest allocated frame
+                //   - acked < seq < next -> normal forward ACK
+                // A backward ACK (seq < acked_seq) or a future ACK of a
+                // sequence the helper never allocated (seq > next_seq) means
+                // the peer's view is corrupt (buggy / mixed-version /
+                // corrupted listener). Trusting it would poison acked_seq and
+                // trim or permanently suppress replay of frames the daemon has
+                // not actually acknowledged. Fail closed: ignore the impossible
+                // ACK, leave the watermark and replay buffer intact, and
+                // surface it via the invalid_acks counter. Ignoring (rather
+                // than disconnecting) preserves the live connection and avoids
+                // a reconnect-thrash loop against a peer that keeps emitting
+                // bad ACKs; valid ACKs interleaved with the bad ones still
+                // advance the watermark normally.
+                let acked = shared.acked_seq.load(Ordering::Acquire);
+                let next = shared.next_seq.load(Ordering::Acquire);
+                if seq < acked || seq > next {
+                    shared.frames_invalid_acks.fetch_add(1, Ordering::Relaxed);
+                    eprintln!(
+                        "xpf-event-stream: ignoring out-of-range ACK seq={} \
+                         (acked={}, next={})",
+                        seq, acked, next
+                    );
+                } else {
+                    shared.acked_seq.store(seq, Ordering::Release);
+                    // Trim replay buffer: remove frames with seq <= acked
+                    while let Some(front) = replay_buf.front() {
+                        if front.seq <= seq {
+                            pop_replay_frame(shared, replay_buf);
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+            MSG_PAUSE => {
+                // #2875: a fresh pause window starts lossless. Clear any poison
+                // left from a previous drain so only an eviction WITHIN this
+                // pause window can withhold the upcoming DrainComplete.
+                shared
+                    .session_evicted_while_paused
+                    .store(false, Ordering::Release);
+                shared.paused.store(true, Ordering::Release);
+                eprintln!("xpf-event-stream: paused by daemon");
+            }
+            MSG_RESUME => {
+                shared.paused.store(false, Ordering::Release);
+                eprintln!("xpf-event-stream: resumed by daemon");
+                // Flush any buffered-during-pause frames on next write cycle
+            }
+            MSG_DRAIN_REQUEST => {
+                // Drain channel until we have all events up to target seq,
+                // then send DrainComplete.
+                let target_seq = seq;
+                handle_drain_request(target_seq, rx, stream, shared, replay_buf);
+            }
+            _ => {
+                eprintln!("xpf-event-stream: unknown control frame type {}", msg_type);
+            }
+        }
+    }
+    (None, offset)
+}
+
+/// Handle DrainRequest: drain channel, write all buffered events up to target
+/// seq, then send DrainComplete.
+///
+/// RESERVED / DORMANT: the Go daemon never sends `MSG_DRAIN_REQUEST` in
+/// production (`EventStream.SendDrainRequest` has no live caller). Graceful
+/// demotion synchronizes via the session-sync peer barrier plus the continuous
+/// lossless event stream; bulk republish on loss-of-sync uses the unbounded
+/// `ExportOwnerRGSessions` snapshot triggered by a FullResync, not this
+/// seq-fenced drain. This handler (and the `MSG_DRAIN_REQUEST=7` /
+/// `MSG_DRAIN_COMPLETE=8` frames) is retained — hardened by #2876/#2920 — for a
+/// possible future fenced-drain use. See docs/session-sync-architecture.md.
+pub(super) fn handle_drain_request(
+    target_seq: u64,
+    rx: &mpsc::Receiver<EventFrame>,
+    stream: &UnixStream,
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+) {
+    let deadline = Instant::now() + Duration::from_millis(200);
+    let was_paused = shared.paused.load(Ordering::Acquire);
+
+    // Drain channel until we've seen target_seq or timeout. `reached_target`
+    // records whether the fence was actually reached: a timeout below the fence
+    // (#2876) must NOT be reported as a successful DrainComplete, because the
+    // events after the fence have not been flushed to the daemon/peer.
+    let mut reached_target = false;
+    loop {
+        match rx.try_recv() {
+            Ok(frame) => {
+                let frame_seq = frame.seq;
+                push_replay_frame(shared, replay_buf, frame);
+                if frame_seq >= target_seq {
+                    reached_target = true;
+                    break;
+                }
+            }
+            Err(TryRecvError::Empty) => {
+                // Check if we already have the target in replay buf
+                if replay_buf
+                    .back()
+                    .map(|f| f.seq >= target_seq)
+                    .unwrap_or(false)
+                {
+                    reached_target = true;
+                    break;
+                }
+                if Instant::now() >= deadline {
+                    eprintln!(
+                        "xpf-event-stream: drain timeout below fence, highest_seq={} target={}",
+                        replay_buf.back().map(|f| f.seq).unwrap_or(0),
+                        target_seq
+                    );
+                    break;
+                }
+                thread::sleep(Duration::from_micros(100));
+            }
+            Err(TryRecvError::Disconnected) => break,
+        }
+    }
+
+    // Write replay-buffered frames to the socket using the canonical
+    // nonblocking + stop-aware backpressure writer (#2877). The socket stays
+    // nonblocking (the connected loop set it so); a stuck reader can no longer
+    // wedge the I/O thread in a blocking write, and a raised stop flag is
+    // observed within one poll interval. A shared deadline bounds the whole
+    // drain write.
+    let write_deadline = Instant::now() + REPLAY_DRAIN_WRITE_DEADLINE;
+    let mut write_failed = false;
+    // #2882: honor the fence — write only frames UP TO the requested target,
+    // not the whole replay head. DrainRequest is contracted (see
+    // docs/session-sync-design.md) as "flush all buffered events up to target
+    // seq". Frames newer than the fence belong to a later drain/replay;
+    // flushing (and reporting) them here changes the contract to "dump current
+    // replay head", which masks holes and couples demotion correctness to
+    // unrelated later-buffered frames. `drained_up_to` tracks the highest seq
+    // <= target actually written (the replay buffer is seq-ordered).
+    let mut drained_up_to = 0u64;
+    for frame in replay_buf.iter() {
+        if frame.seq > target_seq {
+            continue; // beyond the fence — not part of this drain
+        }
+        if let Err(e) = write_all_backpressured(stream, frame.as_bytes(), shared, write_deadline) {
+            eprintln!("xpf-event-stream: drain write error: {e}");
+            write_failed = true;
+            break;
+        }
+        drained_up_to = frame.seq;
+    }
+
+    // Send DrainComplete ONLY when the target fence was reached AND every frame
+    // up to it was flushed. If the drain timed out below the fence, or a write
+    // failed against a stuck/stopping reader, withhold DrainComplete: the
+    // daemon's SendDrainRequest then times out (or rejects a below-target seq)
+    // and refuses to proceed with demotion, rather than silently losing the
+    // post-fence sessions on failover (#2876/#2877).
+    //
+    // #2882: report the fence the daemon requested, not replay_buf.back().seq
+    // (which could exceed the target). Everything with seq <= target_seq is now
+    // flushed, so report the highest such seq actually written; if the buffer
+    // held nothing at/below the fence (all already ACK-trimmed), the fence is
+    // still satisfied, so report target_seq.
+    let drain_seq = if drained_up_to == 0 {
+        target_seq
+    } else {
+        drained_up_to
+    };
+
+    // #2875: a SESSION-SYNC delta was evicted from the bounded replay buffer
+    // while paused, so this drain window is missing mutations the new owner
+    // needs. The drain is POISONED: it must NOT report DrainComplete (that
+    // would complete demotion with lost sessions on the peer). Checked AFTER
+    // the drain+write loops so an eviction during this drain's own
+    // push_replay_frame calls is also caught.
+    let session_evicted = shared
+        .session_evicted_while_paused
+        .load(Ordering::Acquire);
+
+    if session_evicted {
+        // Surface the poison the same way as #2874 / the replay-gap path: emit
+        // a FullResync so the daemon re-exports full session state. The
+        // daemon's SendDrainRequest receives no DrainComplete, times out, and
+        // refuses to proceed with demotion until the resync re-establishes
+        // state. Allocate a fresh seq (mirrors replay_buffered's resync).
+        let resync_seq = shared.next_seq.fetch_add(1, Ordering::Relaxed) + 1;
+        let resync_frame = EventFrame::encode_full_resync(resync_seq);
+        if let Err(e) =
+            write_all_backpressured(stream, resync_frame.as_bytes(), shared, write_deadline)
+        {
+            eprintln!("xpf-event-stream: drain-poison FullResync write error: {e}");
+        } else {
+            shared.frames_sent.fetch_add(1, Ordering::Relaxed);
+            eprintln!(
+                "xpf-event-stream: drain POISONED -- session delta evicted while paused; \
+                 sent FullResync seq {} instead of DrainComplete (demotion must full-resync)",
+                resync_seq
+            );
+        }
+        // Window consumed: clear so a later clean drain in this pause window can
+        // complete (a fresh session-frame eviction re-poisons).
+        shared
+            .session_evicted_while_paused
+            .store(false, Ordering::Release);
+    } else if reached_target && !write_failed {
+        let complete_frame = EventFrame::encode_drain_complete(drain_seq);
+        if let Err(e) =
+            write_all_backpressured(stream, complete_frame.as_bytes(), shared, write_deadline)
+        {
+            eprintln!("xpf-event-stream: drain complete write error: {e}");
+        } else {
+            shared.frames_sent.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    // Restore pause state
+    if was_paused {
+        shared.paused.store(true, Ordering::Release);
+    }
+
+    if session_evicted {
+        // Already logged above (poison + FullResync).
+    } else if reached_target {
+        eprintln!("xpf-event-stream: drain complete up to seq {}", drain_seq);
+    } else {
+        eprintln!(
+            "xpf-event-stream: drain incomplete (below fence), highest_seq={} target={} -- DrainComplete withheld",
+            drain_seq, target_seq
+        );
+    }
+}

--- a/userspace-dp/src/event_stream/drain.rs
+++ b/userspace-dp/src/event_stream/drain.rs
@@ -1,0 +1,156 @@
+//! Channel-drain mechanics: move produced frames from the bounded mpsc channel
+//! into the pending socket-write backlog and the replay buffer, merge the parked
+//! ordered FullResync barrier (#5267), and drain the channel on shutdown.
+//!
+//! Pure code motion out of `mod.rs` (#6235); no logic change. The
+//! `WRITE_BACKLOG_MAX_BYTES` cap (#2381/#4974) is enforced here on the UNWRITTEN
+//! backlog length so a wedged reader cannot migrate the whole channel into the
+//! heap-backed write backlog.
+
+use super::*;
+
+/// Drain remaining events from the channel on shutdown.
+pub(super) fn drain_remaining(rx: &mpsc::Receiver<EventFrame>, shared: &Arc<EventStreamShared>) {
+    loop {
+        match rx.try_recv() {
+            Ok(frame) => release_dataplane_event_queue_budget(shared, &frame),
+            Err(_) => break,
+        }
+    }
+}
+
+/// Outcome of one channel-drain pass in the connected loop.
+pub(super) struct DrainOutcome {
+    /// At least one frame was pulled from the channel this pass.
+    pub(super) drained_any: bool,
+    /// The channel sender side was dropped (helper shutting down).
+    pub(super) disconnected: bool,
+    /// The write backlog hit `WRITE_BACKLOG_MAX_BYTES` and the drain was
+    /// halted before emptying the channel (stalled-consumer signal). Exposed
+    /// for tests; the loop relies on the side-effect counter.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(super) stalled: bool,
+}
+
+/// Drain the bounded channel into `replay_buf` and (when not paused) into the
+/// pending socket-write backlog `write_buf`.
+///
+/// The drain halts once the UNWRITTEN backlog (`write_buf.pending_len()`, #4974)
+/// reaches `WRITE_BACKLOG_MAX_BYTES` (#2381). Without that cap a wedged daemon
+/// (socket open but not reading → the socket `write` returns `WouldBlock`) lets
+/// this loop migrate the entire bounded channel into the heap-backed `write_buf`
+/// every cycle; the channel then refills from worker `try_send`, the loop drains
+/// it again, and `write_buf` grows without bound → helper OOM / allocator
+/// pressure on the forwarding plane. Halting the drain leaves the frames in the
+/// bounded channel, which becomes the real backpressure surface: worker
+/// `try_send` then fails and increments the existing `frames_dropped` / per-kind
+/// `queue_full` counters (oldest queued/replay frames are preserved; newest
+/// producer events are shed — keeping RT_FLOW current). Each pass that hits the
+/// cap bumps `frames_write_stalled` so a wedged consumer is observable rather
+/// than a silent OOM.
+///
+/// The cap is measured on `pending_len()` (unwritten bytes), not the raw
+/// `WriteBacklog` `Vec` length: the cursor-backed backlog keeps a reclaimable
+/// prefix of already-written bytes, so raw length can sit at ~2× pending until
+/// the next geometric compaction. Measuring raw length would trip the cap early
+/// and drift the pause/resume accounting.
+///
+/// The cap does not apply while paused: paused frames are consumed into the
+/// already-bounded replay buffer only, never into `write_buf`, so they cannot
+/// grow the backlog.
+pub(super) fn drain_channel_into_write_buf(
+    rx: &mpsc::Receiver<EventFrame>,
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+    write_buf: &mut WriteBacklog,
+    paused: bool,
+    pending_resync: &mut Option<EventFrame>,
+) -> DrainOutcome {
+    let mut drained_any = false;
+    loop {
+        // #4974: the cap measures UNWRITTEN bytes (`pending_len`), not the raw
+        // backing-Vec length, which also counts the reclaimable written prefix.
+        if !paused && write_buf.pending_len() >= WRITE_BACKLOG_MAX_BYTES {
+            shared.frames_write_stalled.fetch_add(1, Ordering::Relaxed);
+            return DrainOutcome {
+                drained_any,
+                disconnected: false,
+                stalled: true,
+            };
+        }
+        match rx.try_recv() {
+            Ok(frame) => {
+                drained_any = true;
+                // #5267: flush a parked FullResync barrier just BEFORE the first
+                // channel frame whose seq exceeds it, so the wire stays
+                // monotonic. The barrier's seq was allocated under
+                // `producer_seq_lock`, so every delta already queued has a lower
+                // seq and is emitted first; only a delta committed AFTER the
+                // barrier has a higher seq and must follow it.
+                let flush_before_frame = match pending_resync.as_ref() {
+                    Some(barrier) => frame.seq > barrier.seq,
+                    None => false,
+                };
+                if flush_before_frame {
+                    flush_pending_resync(shared, replay_buf, write_buf, paused, pending_resync);
+                }
+                if !paused {
+                    write_buf.extend_from_slice(frame.as_bytes());
+                }
+                push_replay_frame(shared, replay_buf, frame);
+            }
+            Err(TryRecvError::Empty) => {
+                // Channel fully drained: every delta with a lower seq than the
+                // barrier has been emitted (the barrier is the current max — its
+                // seq was allocated under the producer lock), so it is safe to
+                // flush the barrier now (#5267). Without a trailing higher-seq
+                // delta this is the ONLY place the barrier is emitted.
+                let flushed =
+                    flush_pending_resync(shared, replay_buf, write_buf, paused, pending_resync);
+                return DrainOutcome {
+                    drained_any: drained_any || flushed,
+                    disconnected: false,
+                    stalled: false,
+                };
+            }
+            Err(TryRecvError::Disconnected) => {
+                return DrainOutcome {
+                    drained_any,
+                    disconnected: true,
+                    stalled: false,
+                };
+            }
+        }
+    }
+}
+
+/// #5267: move a parked replay-gap FullResync barrier out of `pending_resync`
+/// into the ordered write/replay path so ACK-trim and a later reconnect treat
+/// it like any other accepted frame while keeping the replay buffer seq-ordered.
+///
+/// `frames_sent` is bumped HERE, when the ordered drain accepts the barrier,
+/// not when `replay_buffered` merely parks it. This matches the existing
+/// producer accounting, which counts a successful channel enqueue before the
+/// socket write. When paused, the barrier is appended to the replay buffer only
+/// (like every other paused frame) and NOT to `write_buf`; a reconnect replays
+/// it, while #5328 tracks the pre-existing defect that plain `MSG_RESUME` does
+/// not schedule the intact paused replay suffix on the same connection.
+/// Returns true if a barrier was consumed into the ordered output/replay path.
+pub(super) fn flush_pending_resync(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+    write_buf: &mut WriteBacklog,
+    paused: bool,
+    pending_resync: &mut Option<EventFrame>,
+) -> bool {
+    if let Some(barrier) = pending_resync.take() {
+        if !paused {
+            write_buf.extend_from_slice(barrier.as_bytes());
+        }
+        shared.frames_sent.fetch_add(1, Ordering::Relaxed);
+        push_replay_frame(shared, replay_buf, barrier);
+        true
+    } else {
+        false
+    }
+}

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -13,6 +13,7 @@ mod backlog;
 mod budget;
 pub(crate) mod codec;
 mod clock;
+mod control;
 mod drain;
 mod producer;
 mod replay;
@@ -25,6 +26,8 @@ mod replay;
 use backlog::{WRITE_BACKLOG_MAX_BYTES, WriteBacklog};
 #[allow(unused_imports)]
 use budget::release_dataplane_event_queue_budget;
+#[allow(unused_imports)]
+use control::{handle_drain_request, process_control_frames};
 #[allow(unused_imports)]
 use drain::{DrainOutcome, drain_channel_into_write_buf, drain_remaining, flush_pending_resync};
 #[allow(unused_imports)]
@@ -45,6 +48,9 @@ pub(crate) use producer::{
 };
 
 use crate::session::{SessionDelta, SessionDeltaKind};
+// FRAME_HEADER_SIZE / MSG_* resolve for the connection + control submodules
+// (each `use super::*`) and the test tree; several are not used by mod.rs itself.
+#[allow(unused_imports)]
 use codec::{FRAME_HEADER_SIZE, MSG_ACK, MSG_DRAIN_REQUEST, MSG_KEEPALIVE, MSG_PAUSE, MSG_RESUME};
 use producer::{DataplaneEventCounters, DataplaneEventQueueBudget, DataplaneEventRateLimiter};
 use rustc_hash::FxHashMap;
@@ -1250,306 +1256,6 @@ fn run_connected_loop(
                 thread::sleep(Duration::from_millis(1));
             }
         }
-    }
-}
-
-/// Process control frames received from the daemon.
-/// Returns (action, bytes_consumed) where action is Some(true) to reconnect,
-/// Some(false) to stop, or None to continue. Only complete frames are consumed;
-/// any trailing partial frame is left for the next read cycle.
-fn process_control_frames(
-    data: &[u8],
-    shared: &Arc<EventStreamShared>,
-    rx: &mpsc::Receiver<EventFrame>,
-    stream: &UnixStream,
-    replay_buf: &mut VecDeque<EventFrame>,
-) -> (Option<bool>, usize) {
-    let mut offset = 0;
-    while offset + FRAME_HEADER_SIZE <= data.len() {
-        let payload_len = u32::from_le_bytes([
-            data[offset],
-            data[offset + 1],
-            data[offset + 2],
-            data[offset + 3],
-        ]);
-        // #2879: reject an impossible payload_len BEFORE waiting for the rest of
-        // the frame. The full header is present (loop guard above), so we can
-        // validate the declared length on the header alone, regardless of how
-        // few payload bytes have arrived. Every current daemon->helper opcode is
-        // header-only, so any payload_len beyond MAX_CONTROL_PAYLOAD_LEN can
-        // never form a valid frame. Disconnecting (Some(true) -> reconnect,
-        // which clears ctrl_read_buf) stops a buggy/compromised daemon from
-        // trickling a 1<<30-length header and growing ctrl_read_buf without
-        // bound on the forwarding plane. A legitimately partial header-only
-        // frame still works: a payload_len of 0 passes here, and a split HEADER
-        // never reaches this point (the loop guard requires a full 16-byte
-        // header first). `offset` is returned so any complete frames parsed
-        // before the bad one are still accounted as consumed.
-        if payload_len as usize > MAX_CONTROL_PAYLOAD_LEN {
-            eprintln!(
-                "xpf-event-stream: control frame opcode {} declared payload_len={} \
-                 exceeds max {} -- disconnecting (#2879)",
-                data[offset + 4],
-                payload_len,
-                MAX_CONTROL_PAYLOAD_LEN
-            );
-            return (Some(true), offset);
-        }
-        let frame_len = FRAME_HEADER_SIZE + payload_len as usize;
-        if offset + frame_len > data.len() {
-            break; // incomplete frame -- wait for more data
-        }
-        let msg_type = data[offset + 4];
-        let seq = u64::from_le_bytes([
-            data[offset + 8],
-            data[offset + 9],
-            data[offset + 10],
-            data[offset + 11],
-            data[offset + 12],
-            data[offset + 13],
-            data[offset + 14],
-            data[offset + 15],
-        ]);
-        offset += frame_len;
-
-        match msg_type {
-            MSG_ACK => {
-                // Validate the ACK watermark BEFORE mutating acked_seq or
-                // trimming the replay buffer (#2959). A correct daemon ACKs
-                // only frames it has applied, so the sequence must lie in the
-                // window [acked_seq, next_seq]:
-                //   - seq == acked_seq  -> duplicate ACK, benign no-op
-                //   - seq == next_seq   -> ACK of the latest allocated frame
-                //   - acked < seq < next -> normal forward ACK
-                // A backward ACK (seq < acked_seq) or a future ACK of a
-                // sequence the helper never allocated (seq > next_seq) means
-                // the peer's view is corrupt (buggy / mixed-version /
-                // corrupted listener). Trusting it would poison acked_seq and
-                // trim or permanently suppress replay of frames the daemon has
-                // not actually acknowledged. Fail closed: ignore the impossible
-                // ACK, leave the watermark and replay buffer intact, and
-                // surface it via the invalid_acks counter. Ignoring (rather
-                // than disconnecting) preserves the live connection and avoids
-                // a reconnect-thrash loop against a peer that keeps emitting
-                // bad ACKs; valid ACKs interleaved with the bad ones still
-                // advance the watermark normally.
-                let acked = shared.acked_seq.load(Ordering::Acquire);
-                let next = shared.next_seq.load(Ordering::Acquire);
-                if seq < acked || seq > next {
-                    shared.frames_invalid_acks.fetch_add(1, Ordering::Relaxed);
-                    eprintln!(
-                        "xpf-event-stream: ignoring out-of-range ACK seq={} \
-                         (acked={}, next={})",
-                        seq, acked, next
-                    );
-                } else {
-                    shared.acked_seq.store(seq, Ordering::Release);
-                    // Trim replay buffer: remove frames with seq <= acked
-                    while let Some(front) = replay_buf.front() {
-                        if front.seq <= seq {
-                            pop_replay_frame(shared, replay_buf);
-                        } else {
-                            break;
-                        }
-                    }
-                }
-            }
-            MSG_PAUSE => {
-                // #2875: a fresh pause window starts lossless. Clear any poison
-                // left from a previous drain so only an eviction WITHIN this
-                // pause window can withhold the upcoming DrainComplete.
-                shared
-                    .session_evicted_while_paused
-                    .store(false, Ordering::Release);
-                shared.paused.store(true, Ordering::Release);
-                eprintln!("xpf-event-stream: paused by daemon");
-            }
-            MSG_RESUME => {
-                shared.paused.store(false, Ordering::Release);
-                eprintln!("xpf-event-stream: resumed by daemon");
-                // Flush any buffered-during-pause frames on next write cycle
-            }
-            MSG_DRAIN_REQUEST => {
-                // Drain channel until we have all events up to target seq,
-                // then send DrainComplete.
-                let target_seq = seq;
-                handle_drain_request(target_seq, rx, stream, shared, replay_buf);
-            }
-            _ => {
-                eprintln!("xpf-event-stream: unknown control frame type {}", msg_type);
-            }
-        }
-    }
-    (None, offset)
-}
-
-/// Handle DrainRequest: drain channel, write all buffered events up to target
-/// seq, then send DrainComplete.
-///
-/// RESERVED / DORMANT: the Go daemon never sends `MSG_DRAIN_REQUEST` in
-/// production (`EventStream.SendDrainRequest` has no live caller). Graceful
-/// demotion synchronizes via the session-sync peer barrier plus the continuous
-/// lossless event stream; bulk republish on loss-of-sync uses the unbounded
-/// `ExportOwnerRGSessions` snapshot triggered by a FullResync, not this
-/// seq-fenced drain. This handler (and the `MSG_DRAIN_REQUEST=7` /
-/// `MSG_DRAIN_COMPLETE=8` frames) is retained — hardened by #2876/#2920 — for a
-/// possible future fenced-drain use. See docs/session-sync-architecture.md.
-fn handle_drain_request(
-    target_seq: u64,
-    rx: &mpsc::Receiver<EventFrame>,
-    stream: &UnixStream,
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-) {
-    let deadline = Instant::now() + Duration::from_millis(200);
-    let was_paused = shared.paused.load(Ordering::Acquire);
-
-    // Drain channel until we've seen target_seq or timeout. `reached_target`
-    // records whether the fence was actually reached: a timeout below the fence
-    // (#2876) must NOT be reported as a successful DrainComplete, because the
-    // events after the fence have not been flushed to the daemon/peer.
-    let mut reached_target = false;
-    loop {
-        match rx.try_recv() {
-            Ok(frame) => {
-                let frame_seq = frame.seq;
-                push_replay_frame(shared, replay_buf, frame);
-                if frame_seq >= target_seq {
-                    reached_target = true;
-                    break;
-                }
-            }
-            Err(TryRecvError::Empty) => {
-                // Check if we already have the target in replay buf
-                if replay_buf
-                    .back()
-                    .map(|f| f.seq >= target_seq)
-                    .unwrap_or(false)
-                {
-                    reached_target = true;
-                    break;
-                }
-                if Instant::now() >= deadline {
-                    eprintln!(
-                        "xpf-event-stream: drain timeout below fence, highest_seq={} target={}",
-                        replay_buf.back().map(|f| f.seq).unwrap_or(0),
-                        target_seq
-                    );
-                    break;
-                }
-                thread::sleep(Duration::from_micros(100));
-            }
-            Err(TryRecvError::Disconnected) => break,
-        }
-    }
-
-    // Write replay-buffered frames to the socket using the canonical
-    // nonblocking + stop-aware backpressure writer (#2877). The socket stays
-    // nonblocking (the connected loop set it so); a stuck reader can no longer
-    // wedge the I/O thread in a blocking write, and a raised stop flag is
-    // observed within one poll interval. A shared deadline bounds the whole
-    // drain write.
-    let write_deadline = Instant::now() + REPLAY_DRAIN_WRITE_DEADLINE;
-    let mut write_failed = false;
-    // #2882: honor the fence — write only frames UP TO the requested target,
-    // not the whole replay head. DrainRequest is contracted (see
-    // docs/session-sync-design.md) as "flush all buffered events up to target
-    // seq". Frames newer than the fence belong to a later drain/replay;
-    // flushing (and reporting) them here changes the contract to "dump current
-    // replay head", which masks holes and couples demotion correctness to
-    // unrelated later-buffered frames. `drained_up_to` tracks the highest seq
-    // <= target actually written (the replay buffer is seq-ordered).
-    let mut drained_up_to = 0u64;
-    for frame in replay_buf.iter() {
-        if frame.seq > target_seq {
-            continue; // beyond the fence — not part of this drain
-        }
-        if let Err(e) = write_all_backpressured(stream, frame.as_bytes(), shared, write_deadline) {
-            eprintln!("xpf-event-stream: drain write error: {e}");
-            write_failed = true;
-            break;
-        }
-        drained_up_to = frame.seq;
-    }
-
-    // Send DrainComplete ONLY when the target fence was reached AND every frame
-    // up to it was flushed. If the drain timed out below the fence, or a write
-    // failed against a stuck/stopping reader, withhold DrainComplete: the
-    // daemon's SendDrainRequest then times out (or rejects a below-target seq)
-    // and refuses to proceed with demotion, rather than silently losing the
-    // post-fence sessions on failover (#2876/#2877).
-    //
-    // #2882: report the fence the daemon requested, not replay_buf.back().seq
-    // (which could exceed the target). Everything with seq <= target_seq is now
-    // flushed, so report the highest such seq actually written; if the buffer
-    // held nothing at/below the fence (all already ACK-trimmed), the fence is
-    // still satisfied, so report target_seq.
-    let drain_seq = if drained_up_to == 0 {
-        target_seq
-    } else {
-        drained_up_to
-    };
-
-    // #2875: a SESSION-SYNC delta was evicted from the bounded replay buffer
-    // while paused, so this drain window is missing mutations the new owner
-    // needs. The drain is POISONED: it must NOT report DrainComplete (that
-    // would complete demotion with lost sessions on the peer). Checked AFTER
-    // the drain+write loops so an eviction during this drain's own
-    // push_replay_frame calls is also caught.
-    let session_evicted = shared
-        .session_evicted_while_paused
-        .load(Ordering::Acquire);
-
-    if session_evicted {
-        // Surface the poison the same way as #2874 / the replay-gap path: emit
-        // a FullResync so the daemon re-exports full session state. The
-        // daemon's SendDrainRequest receives no DrainComplete, times out, and
-        // refuses to proceed with demotion until the resync re-establishes
-        // state. Allocate a fresh seq (mirrors replay_buffered's resync).
-        let resync_seq = shared.next_seq.fetch_add(1, Ordering::Relaxed) + 1;
-        let resync_frame = EventFrame::encode_full_resync(resync_seq);
-        if let Err(e) =
-            write_all_backpressured(stream, resync_frame.as_bytes(), shared, write_deadline)
-        {
-            eprintln!("xpf-event-stream: drain-poison FullResync write error: {e}");
-        } else {
-            shared.frames_sent.fetch_add(1, Ordering::Relaxed);
-            eprintln!(
-                "xpf-event-stream: drain POISONED -- session delta evicted while paused; \
-                 sent FullResync seq {} instead of DrainComplete (demotion must full-resync)",
-                resync_seq
-            );
-        }
-        // Window consumed: clear so a later clean drain in this pause window can
-        // complete (a fresh session-frame eviction re-poisons).
-        shared
-            .session_evicted_while_paused
-            .store(false, Ordering::Release);
-    } else if reached_target && !write_failed {
-        let complete_frame = EventFrame::encode_drain_complete(drain_seq);
-        if let Err(e) =
-            write_all_backpressured(stream, complete_frame.as_bytes(), shared, write_deadline)
-        {
-            eprintln!("xpf-event-stream: drain complete write error: {e}");
-        } else {
-            shared.frames_sent.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-
-    // Restore pause state
-    if was_paused {
-        shared.paused.store(true, Ordering::Release);
-    }
-
-    if session_evicted {
-        // Already logged above (poison + FullResync).
-    } else if reached_target {
-        eprintln!("xpf-event-stream: drain complete up to seq {}", drain_seq);
-    } else {
-        eprintln!(
-            "xpf-event-stream: drain incomplete (below fence), highest_seq={} target={} -- DrainComplete withheld",
-            drain_seq, target_seq
-        );
     }
 }
 

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -10,8 +10,14 @@
 //!   Payload: type-specific binary (see codec module)
 
 pub(crate) mod codec;
+mod clock;
 mod producer;
 
+pub(crate) use clock::{
+    mono_ns_to_wall_clock_unix_ns, monotonic_ns_to_unix_ns, monotonic_ns_to_unix_secs,
+    monotonic_ns_to_unix_secs_subnanos,
+};
+use clock::read_mono_and_wall_clocks;
 pub(crate) use codec::{EventFrame, close_flags};
 use codec::DataplaneEventKind;
 #[allow(unused_imports)] // public API for later policy/screen/filter producer wiring
@@ -32,100 +38,6 @@ use std::sync::mpsc::{self, SyncSender, TryRecvError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-
-const NS_PER_SEC: u64 = 1_000_000_000;
-
-/// #2465: read CLOCK_MONOTONIC (ns) and the wall clock (ns since the Unix
-/// epoch) in one pair so the two are anchored to the same instant. Used to
-/// convert the session table's monotonic creation/last-seen instants into the
-/// absolute wall-clock values the flow-export wire fields carry. On a clock
-/// read failure both fall back to 0 (→ the Go-side packet-count fallback).
-fn read_mono_and_wall_clocks() -> (u64, u64) {
-    let mut mono = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let mut wall = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let rc_mono = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut mono) };
-    let rc_wall = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut wall) };
-    if rc_mono != 0 || rc_wall != 0 || mono.tv_sec < 0 || wall.tv_sec < 0 {
-        return (0, 0);
-    }
-    let mono_ns = (mono.tv_sec as u64)
-        .saturating_mul(NS_PER_SEC)
-        .saturating_add(mono.tv_nsec.max(0) as u64);
-    let wall_ns = (wall.tv_sec as u64)
-        .saturating_mul(NS_PER_SEC)
-        .saturating_add(wall.tv_nsec.max(0) as u64);
-    (mono_ns, wall_ns)
-}
-
-/// #2465: convert a monotonic instant (`mono_ns`) to an absolute wall-clock
-/// nanosecond count, anchored against a (`now_mono_ns`, `now_unix_ns`) reading.
-/// `mono_ns == 0` (unknown) maps to 0. The age is clamped at the present so a
-/// monotonic value slightly ahead of `now_mono_ns` (a benign cross-CPU read
-/// skew) cannot push the result into the future.
-pub(crate) fn monotonic_ns_to_unix_ns(mono_ns: u64, now_mono_ns: u64, now_unix_ns: u64) -> u64 {
-    if mono_ns == 0 || now_mono_ns == 0 || now_unix_ns == 0 {
-        return 0;
-    }
-    let age_ns = now_mono_ns.saturating_sub(mono_ns);
-    now_unix_ns.saturating_sub(age_ns)
-}
-
-/// #2465: convert a monotonic instant to absolute wall-clock Unix SECONDS for
-/// the `created` wire field (offset 108, u32). Truncates toward the epoch;
-/// 0/unknown stays 0; values beyond u32 (year 2106) saturate.
-pub(crate) fn monotonic_ns_to_unix_secs(mono_ns: u64, now_mono_ns: u64, now_unix_ns: u64) -> u32 {
-    monotonic_ns_to_unix_secs_subnanos(mono_ns, now_mono_ns, now_unix_ns).0
-}
-
-/// #2853: convert a monotonic instant to absolute wall-clock Unix SECONDS plus
-/// the sub-second NANOSECOND remainder (0..=999_999_999). The integer seconds
-/// ride the `created` wire field (offset 108, u32); the sub-second nanos ride
-/// the SESSION_CLOSE-unused policy_id slot (offset 44, u32) so the Go flow
-/// exporters can build a MILLISECOND-accurate flow StartTime instead of one
-/// truncated to the whole second (the #2853 defect: short flows — DNS, single
-/// HTTP requests — all collapsed onto the same integer-second start).
-///
-/// 0/unknown stays `(0, 0)`; a seconds value beyond u32 (year 2106) saturates
-/// to `(u32::MAX, 0)` so the saturated record carries no misleading remainder.
-pub(crate) fn monotonic_ns_to_unix_secs_subnanos(
-    mono_ns: u64,
-    now_mono_ns: u64,
-    now_unix_ns: u64,
-) -> (u32, u32) {
-    let unix_ns = monotonic_ns_to_unix_ns(mono_ns, now_mono_ns, now_unix_ns);
-    let secs = unix_ns / NS_PER_SEC;
-    if secs > u32::MAX as u64 {
-        return (u32::MAX, 0);
-    }
-    (secs as u32, (unix_ns % NS_PER_SEC) as u32)
-}
-
-/// #2470: convert a CLOCK_MONOTONIC instant (the `now_ns`/`now_secs`-derived
-/// value the worker poll loop hands to the RT_FLOW deny/screen/filter-log
-/// emitters) to an absolute wall-clock Unix nanosecond count, taking a fresh
-/// anchored (`mono`, `wall`) reading here. This is the emission-time
-/// conversion boundary: the deny/screen/filter-log events carry the dataplane
-/// DECISION instant on the wire (offset 0, LE u64, absolute Unix ns — the same
-/// `timestamp_ns` format the SESSION_CLOSE frame uses and the Go decoder
-/// reads), so a queued/backlogged delivery on the Go side cannot skew the
-/// logged event time to consumption time. A 0 `mono_ns` (unknown) or a clock
-/// read failure maps to 0 → the Go side (`pkg/logging/ringbuf.go`) falls back
-/// to receive time, preserving the old behavior only when no real instant is
-/// available.
-///
-/// These events fire on drops / denies / log-matched packets (NOT per normal
-/// packet), so one anchored clock read per emit is acceptable; correctness
-/// (a real decision timestamp) is preferred over saving the read.
-pub(crate) fn mono_ns_to_wall_clock_unix_ns(mono_ns: u64) -> u64 {
-    let (now_mono_ns, now_unix_ns) = read_mono_and_wall_clocks();
-    monotonic_ns_to_unix_ns(mono_ns, now_mono_ns, now_unix_ns)
-}
 
 /// Idle interval after which the connected loop enqueues a keepalive frame to
 /// keep the Go listener from treating the stream as dead. The keepalive is

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -13,14 +13,22 @@ mod backlog;
 mod budget;
 pub(crate) mod codec;
 mod clock;
+mod drain;
 mod producer;
 mod replay;
 
+// #6235 split: re-export the moved intra-crate helpers back into the
+// `event_stream` namespace so the sibling submodules (each `use super::*`) and
+// the `#[cfg(test)] mod tests` tree resolve them unchanged. Several are consumed
+// only by siblings/tests, not by mod.rs directly.
+#[allow(unused_imports)]
 use backlog::{WRITE_BACKLOG_MAX_BYTES, WriteBacklog};
+#[allow(unused_imports)]
 use budget::release_dataplane_event_queue_budget;
-use replay::{
-    pop_replay_frame, push_replay_frame, release_replay_dataplane_event_queue_budget,
-};
+#[allow(unused_imports)]
+use drain::{DrainOutcome, drain_channel_into_write_buf, drain_remaining, flush_pending_resync};
+#[allow(unused_imports)]
+use replay::{pop_replay_frame, push_replay_frame, release_replay_dataplane_event_queue_budget};
 
 #[allow(unused_imports)] // monotonic_ns_to_unix_secs is consumed only by the rt_flow tests
 pub(crate) use clock::{
@@ -1542,152 +1550,6 @@ fn handle_drain_request(
             "xpf-event-stream: drain incomplete (below fence), highest_seq={} target={} -- DrainComplete withheld",
             drain_seq, target_seq
         );
-    }
-}
-
-/// Drain remaining events from the channel on shutdown.
-fn drain_remaining(rx: &mpsc::Receiver<EventFrame>, shared: &Arc<EventStreamShared>) {
-    loop {
-        match rx.try_recv() {
-            Ok(frame) => release_dataplane_event_queue_budget(shared, &frame),
-            Err(_) => break,
-        }
-    }
-}
-
-/// Outcome of one channel-drain pass in the connected loop.
-struct DrainOutcome {
-    /// At least one frame was pulled from the channel this pass.
-    drained_any: bool,
-    /// The channel sender side was dropped (helper shutting down).
-    disconnected: bool,
-    /// The write backlog hit `WRITE_BACKLOG_MAX_BYTES` and the drain was
-    /// halted before emptying the channel (stalled-consumer signal). Exposed
-    /// for tests; the loop relies on the side-effect counter.
-    #[cfg_attr(not(test), allow(dead_code))]
-    stalled: bool,
-}
-
-/// Drain the bounded channel into `replay_buf` and (when not paused) into the
-/// pending socket-write backlog `write_buf`.
-///
-/// The drain halts once the UNWRITTEN backlog (`write_buf.pending_len()`, #4974)
-/// reaches `WRITE_BACKLOG_MAX_BYTES` (#2381). Without that cap a wedged daemon
-/// (socket open but not reading → the socket `write` returns `WouldBlock`) lets
-/// this loop migrate the entire bounded channel into the heap-backed `write_buf`
-/// every cycle; the channel then refills from worker `try_send`, the loop drains
-/// it again, and `write_buf` grows without bound → helper OOM / allocator
-/// pressure on the forwarding plane. Halting the drain leaves the frames in the
-/// bounded channel, which becomes the real backpressure surface: worker
-/// `try_send` then fails and increments the existing `frames_dropped` / per-kind
-/// `queue_full` counters (oldest queued/replay frames are preserved; newest
-/// producer events are shed — keeping RT_FLOW current). Each pass that hits the
-/// cap bumps `frames_write_stalled` so a wedged consumer is observable rather
-/// than a silent OOM.
-///
-/// The cap is measured on `pending_len()` (unwritten bytes), not the raw
-/// `WriteBacklog` `Vec` length: the cursor-backed backlog keeps a reclaimable
-/// prefix of already-written bytes, so raw length can sit at ~2× pending until
-/// the next geometric compaction. Measuring raw length would trip the cap early
-/// and drift the pause/resume accounting.
-///
-/// The cap does not apply while paused: paused frames are consumed into the
-/// already-bounded replay buffer only, never into `write_buf`, so they cannot
-/// grow the backlog.
-fn drain_channel_into_write_buf(
-    rx: &mpsc::Receiver<EventFrame>,
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-    write_buf: &mut WriteBacklog,
-    paused: bool,
-    pending_resync: &mut Option<EventFrame>,
-) -> DrainOutcome {
-    let mut drained_any = false;
-    loop {
-        // #4974: the cap measures UNWRITTEN bytes (`pending_len`), not the raw
-        // backing-Vec length, which also counts the reclaimable written prefix.
-        if !paused && write_buf.pending_len() >= WRITE_BACKLOG_MAX_BYTES {
-            shared.frames_write_stalled.fetch_add(1, Ordering::Relaxed);
-            return DrainOutcome {
-                drained_any,
-                disconnected: false,
-                stalled: true,
-            };
-        }
-        match rx.try_recv() {
-            Ok(frame) => {
-                drained_any = true;
-                // #5267: flush a parked FullResync barrier just BEFORE the first
-                // channel frame whose seq exceeds it, so the wire stays
-                // monotonic. The barrier's seq was allocated under
-                // `producer_seq_lock`, so every delta already queued has a lower
-                // seq and is emitted first; only a delta committed AFTER the
-                // barrier has a higher seq and must follow it.
-                let flush_before_frame = match pending_resync.as_ref() {
-                    Some(barrier) => frame.seq > barrier.seq,
-                    None => false,
-                };
-                if flush_before_frame {
-                    flush_pending_resync(shared, replay_buf, write_buf, paused, pending_resync);
-                }
-                if !paused {
-                    write_buf.extend_from_slice(frame.as_bytes());
-                }
-                push_replay_frame(shared, replay_buf, frame);
-            }
-            Err(TryRecvError::Empty) => {
-                // Channel fully drained: every delta with a lower seq than the
-                // barrier has been emitted (the barrier is the current max — its
-                // seq was allocated under the producer lock), so it is safe to
-                // flush the barrier now (#5267). Without a trailing higher-seq
-                // delta this is the ONLY place the barrier is emitted.
-                let flushed =
-                    flush_pending_resync(shared, replay_buf, write_buf, paused, pending_resync);
-                return DrainOutcome {
-                    drained_any: drained_any || flushed,
-                    disconnected: false,
-                    stalled: false,
-                };
-            }
-            Err(TryRecvError::Disconnected) => {
-                return DrainOutcome {
-                    drained_any,
-                    disconnected: true,
-                    stalled: false,
-                };
-            }
-        }
-    }
-}
-
-/// #5267: move a parked replay-gap FullResync barrier out of `pending_resync`
-/// into the ordered write/replay path so ACK-trim and a later reconnect treat
-/// it like any other accepted frame while keeping the replay buffer seq-ordered.
-///
-/// `frames_sent` is bumped HERE, when the ordered drain accepts the barrier,
-/// not when `replay_buffered` merely parks it. This matches the existing
-/// producer accounting, which counts a successful channel enqueue before the
-/// socket write. When paused, the barrier is appended to the replay buffer only
-/// (like every other paused frame) and NOT to `write_buf`; a reconnect replays
-/// it, while #5328 tracks the pre-existing defect that plain `MSG_RESUME` does
-/// not schedule the intact paused replay suffix on the same connection.
-/// Returns true if a barrier was consumed into the ordered output/replay path.
-fn flush_pending_resync(
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-    write_buf: &mut WriteBacklog,
-    paused: bool,
-    pending_resync: &mut Option<EventFrame>,
-) -> bool {
-    if let Some(barrier) = pending_resync.take() {
-        if !paused {
-            write_buf.extend_from_slice(barrier.as_bytes());
-        }
-        shared.frames_sent.fetch_add(1, Ordering::Relaxed);
-        push_replay_frame(shared, replay_buf, barrier);
-        true
-    } else {
-        false
     }
 }
 

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -10,11 +10,13 @@
 //!   Payload: type-specific binary (see codec module)
 
 mod backlog;
+mod budget;
 pub(crate) mod codec;
 mod clock;
 mod producer;
 
 use backlog::{WRITE_BACKLOG_MAX_BYTES, WriteBacklog};
+use budget::release_dataplane_event_queue_budget;
 
 #[allow(unused_imports)] // monotonic_ns_to_unix_secs is consumed only by the rt_flow tests
 pub(crate) use clock::{
@@ -1546,12 +1548,6 @@ fn drain_remaining(rx: &mpsc::Receiver<EventFrame>, shared: &Arc<EventStreamShar
             Ok(frame) => release_dataplane_event_queue_budget(shared, &frame),
             Err(_) => break,
         }
-    }
-}
-
-fn release_dataplane_event_queue_budget(shared: &Arc<EventStreamShared>, frame: &EventFrame) {
-    if let Some(kind) = frame.dataplane_event_kind() {
-        shared.dataplane_event_queue.release(kind);
     }
 }
 

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -18,6 +18,7 @@ mod control;
 mod drain;
 mod producer;
 mod replay;
+mod rt_flow;
 
 // #6235 split: re-export the moved intra-crate helpers back into the
 // `event_stream` namespace so the sibling submodules (each `use super::*`) and
@@ -41,8 +42,15 @@ pub(crate) use clock::{
     mono_ns_to_wall_clock_unix_ns, monotonic_ns_to_unix_ns, monotonic_ns_to_unix_secs,
     monotonic_ns_to_unix_secs_subnanos,
 };
+// read_mono_and_wall_clocks / DataplaneEventKind resolve for rt_flow.rs (which
+// `use super::*`) after the #6235 split; mod.rs no longer references them directly.
+// NS_PER_SEC is likewise consumed only by the rt_flow test module via super::*.
+#[allow(unused_imports)]
 use clock::read_mono_and_wall_clocks;
+#[allow(unused_imports)]
+use clock::NS_PER_SEC;
 pub(crate) use codec::{EventFrame, close_flags};
+#[allow(unused_imports)]
 use codec::DataplaneEventKind;
 #[allow(unused_imports)] // public API for later policy/screen/filter producer wiring
 pub(crate) use producer::{
@@ -714,214 +722,6 @@ impl EventStreamWorkerHandle {
                 Some(seq),
             )
         })
-    }
-
-    /// #2460: emit a SESSION_CLOSE RT_FLOW frame (type 14) for a Close delta
-    /// on the raw dataplane-event channel.
-    ///
-    /// This is ADDITIVE to — and must be called ALONGSIDE, never instead of
-    /// — `push_delta`, which carries the unchanged type-2 HA session-sync
-    /// close delta. The RT_FLOW frame drives the Go NetFlow/IPFIX
-    /// session-close exporters (`pkg/daemon/daemon_flowexport.go`), which
-    /// only run on a `Type == "SESSION_CLOSE"` `logging.EventRecord` — a
-    /// record userspace mode never produced before this. The caller
-    /// (`flush_session_deltas`) gates on `delta.kind == Close`, but the
-    /// guard is repeated here so a future caller cannot misuse it on an Open
-    /// delta. Best-effort (`try_send`): a dropped close frame loses only one
-    /// flow-export record, never the HA close delta (a separate frame).
-    /// `app_id` is the application resolved for the closing session's 5-tuple
-    /// by the caller (`flush_session_deltas`) via the same `app_catalog.lookup`
-    /// the forwarding hot path runs — #2520. 0 means UNKNOWN (no catalog
-    /// match), the unchanged behavior.
-    /// `ingress_ifindex` is the closing binding's interface index (#2615); the
-    /// Go side resolves it to the RT_FLOW `packet-incoming-interface`. 0 keeps
-    /// the prior "N/A" rendering.
-    ///
-    /// #3395: `policy_id` is the RE-RESOLVED admitting policy id, computed by the
-    /// caller (`flush_session_deltas`) from the session's bound rule handle
-    /// against the CURRENT rule table — NOT `delta.metadata.policy_id` (which is
-    /// frozen at install and goes stale after a live policy reorder). The caller
-    /// owns re-resolution because only it holds the `ForwardingState`/`PolicyState`
-    /// the lookup needs.
-    pub(crate) fn emit_session_close_rt_flow(
-        &self,
-        delta: &SessionDelta,
-        app_id: u16,
-        ingress_ifindex: u32,
-        policy_id: u32,
-    ) {
-        if delta.kind != SessionDeltaKind::Close {
-            return;
-        }
-        let nat = &delta.decision.nat;
-        // #2465: convert the monotonic creation / last-seen instants on the
-        // close delta to absolute wall-clock values for the wire. The session
-        // table uses CLOCK_MONOTONIC, but the flow record needs an absolute
-        // StartTime (and the EndTime is a wall-clock instant on the Go side),
-        // so we anchor monotonic deltas against a single (mono, wall) reading
-        // taken here at emit time. A 0 created_ns stays 0 on the wire and
-        // triggers the Go-side packet-count fallback.
-        let (now_mono_ns, now_unix_ns) = read_mono_and_wall_clocks();
-        // #2853: carry BOTH the integer Unix second (offset 108) and the
-        // sub-second nanosecond remainder (offset 44, the close-unused policy_id
-        // slot) so the Go exporters render a millisecond-accurate flow
-        // StartTime. The pre-#2853 code stamped only the truncated second, so
-        // every flow opened in the same second shared one start instant.
-        let (created_unix_secs, created_subsec_nanos) =
-            monotonic_ns_to_unix_secs_subnanos(delta.created_ns, now_mono_ns, now_unix_ns);
-        let close_unix_ns =
-            monotonic_ns_to_unix_ns(delta.last_seen_ns, now_mono_ns, now_unix_ns);
-        // #2512: route through the per-kind rate limiter + queue budget +
-        // sent/dropped counters instead of a bare `try_send`. The same mono
-        // clock reading anchors the limiter so a dropped close is counted
-        // under DataplaneEventKind::SessionClose. The frame is encoded only
-        // after the budget passes (seq supplied by the budget path), so a
-        // rate-limited / budget-exhausted close never burns a sequence
-        // number. A dropped close loses only one flow-export record — the
-        // separate type-2 HA close delta (`push_delta`) is untouched.
-        self.try_emit_dataplane_frame(
-            DataplaneEventKind::SessionClose,
-            delta.metadata.ingress_zone,
-            now_mono_ns,
-            |seq| {
-                EventFrame::encode_session_close_rt_flow(
-                    seq,
-                    delta.key.addr_family,
-                    delta.key.protocol,
-                    delta.key.src_ip,
-                    delta.key.dst_ip,
-                    delta.key.src_port,
-                    delta.key.dst_port,
-                    nat.rewrite_src,
-                    nat.rewrite_dst,
-                    nat.rewrite_src_port.unwrap_or(0),
-                    nat.rewrite_dst_port.unwrap_or(0),
-                    delta.metadata.ingress_zone,
-                    delta.metadata.egress_zone,
-                    // #3056: the admitting policy ID, so the SESSION_CLOSE
-                    // RT_FLOW record (and the NetFlow/IPFIX close exporters) name
-                    // the policy that admitted the flow instead of policy 0.
-                    // Rides the trailing [136:140] slot because #2853 took
-                    // [44:48] on a close. #3395: this is the caller's RE-RESOLVED
-                    // id (current positional id of the bound admitting rule),
-                    // not the frozen `delta.metadata.policy_id`, so a live policy
-                    // reorder before the close no longer mis-attributes the
-                    // record.
-                    policy_id,
-                    delta.metadata.owner_rg_id as i16,
-                    // #2508: per-policy RT_FLOW SYSLOG gate byte. The frame is
-                    // sent unconditionally (the Go NetFlow/IPFIX exporter
-                    // accounts every close), but this bit tells the Go
-                    // logEvent path whether to ALSO emit the per-policy
-                    // RT_FLOW_SESSION_CLOSE syslog record.
-                    delta.metadata.log_session_close,
-                    created_unix_secs,
-                    // #2853: sub-second nanosecond remainder of the creation
-                    // instant, rides the [44:48] slot (unused on a close).
-                    created_subsec_nanos,
-                    close_unix_ns,
-                    // #2520: carry the resolved AppID in the [132:134] wire
-                    // slot so SESSION_CLOSE RT_FLOW records (and the
-                    // NetFlow/IPFIX exporters) show the application.
-                    app_id,
-                    // #2615: carry the closing binding's ingress ifindex in
-                    // the [128:132] wire slot so the record shows the
-                    // admitting interface instead of "N/A".
-                    ingress_ifindex,
-                    // #2501: real per-session volume harvested off the
-                    // expiring entry's counters, into the reserved
-                    // [56:64]/[64:72] (forward) and [112:120]/[120:128]
-                    // (reverse) slots.
-                    delta.counters.fwd_packets,
-                    delta.counters.fwd_bytes,
-                    delta.counters.rev_packets,
-                    delta.counters.rev_bytes,
-                    // #2749: observed forward ToS + cumulative TCP control
-                    // bits harvested off the closing entry, and the session's
-                    // resolved egress (output) interface. These drive the
-                    // re-introduced NetFlow v9 / IPFIX close-record fields
-                    // (srcTos/ipClassOfService, tcpControlBits, egressInterface
-                    // / OutputSNMP). A kernel ifindex is positive; a 0/unset or
-                    // negative (no concrete egress, e.g. local delivery)
-                    // resolution maps to 0 — the collector's "unknown
-                    // interface" sentinel.
-                    delta.observed_tos,
-                    delta.observed_tcp_flags,
-                    u32::try_from(delta.decision.resolution.egress_ifindex).unwrap_or(0),
-                    // #4915: the stable session id harvested off the expiring
-                    // entry (0 for a synthesized close with no live entry). Rides
-                    // the additive [152:160] slot so the SESSION_CLOSE record
-                    // carries the same id as this session's SESSION_CREATE.
-                    delta.session_id,
-                )
-            },
-        );
-    }
-
-    /// #2508: emit an RT_FLOW SESSION_CREATE frame (type 15) for a session
-    /// admitted by a policy configured with `then log session-init`. There is
-    /// NO flowexport consumer of session opens, so unlike the close frame this
-    /// is gated entirely at the producer: the caller invokes it only when
-    /// `delta.metadata.log_session_init` is set. The frame rides the same raw
-    /// dataplane-event channel and is formatted as RT_FLOW_SESSION_CREATE by
-    /// the Go logEvent path. Best-effort (`try_send`).
-    /// #2615: `app_id` is the application resolved for the new session's
-    /// 5-tuple (caller runs the same `app_catalog.lookup` the close path uses,
-    /// mirroring #2520) and `ingress_ifindex` is the admitting binding's
-    /// interface index. 0 in either keeps the prior UNKNOWN / N/A rendering.
-    pub(crate) fn emit_session_create_rt_flow(
-        &self,
-        delta: &SessionDelta,
-        app_id: u16,
-        ingress_ifindex: u32,
-    ) {
-        if delta.kind != SessionDeltaKind::Open {
-            return;
-        }
-        let nat = &delta.decision.nat;
-        // #2512: same per-kind budget path as the close frame (see
-        // emit_session_close_rt_flow). SESSION_CREATE is producer-gated by
-        // the caller (only emitted for `log session-init` policies), but it
-        // still rides the shared dataplane-event channel so it MUST honor the
-        // same limiter / budget / counters under
-        // DataplaneEventKind::SessionCreate rather than a bare `try_send`.
-        let (now_mono_ns, _) = read_mono_and_wall_clocks();
-        self.try_emit_dataplane_frame(
-            DataplaneEventKind::SessionCreate,
-            delta.metadata.ingress_zone,
-            now_mono_ns,
-            |seq| {
-                EventFrame::encode_session_create_rt_flow(
-                    seq,
-                    delta.key.addr_family,
-                    delta.key.protocol,
-                    delta.key.src_ip,
-                    delta.key.dst_ip,
-                    delta.key.src_port,
-                    delta.key.dst_port,
-                    nat.rewrite_src,
-                    nat.rewrite_dst,
-                    nat.rewrite_src_port.unwrap_or(0),
-                    nat.rewrite_dst_port.unwrap_or(0),
-                    delta.metadata.ingress_zone,
-                    delta.metadata.egress_zone,
-                    // #3056: the admitting policy ID stamped on the session at
-                    // install, so the SESSION_CREATE RT_FLOW record names the
-                    // policy that admitted the flow instead of policy 0.
-                    delta.metadata.policy_id,
-                    // #2615: ingress ifindex ([128:132]) + resolved AppID
-                    // ([132:134]) so the SESSION_CREATE RT_FLOW record shows
-                    // the admitting interface and application instead of
-                    // N/A / UNKNOWN.
-                    ingress_ifindex,
-                    app_id,
-                    // #4915: the stable session id assigned at install, carried
-                    // in the additive [152:160] slot so this SESSION_CREATE
-                    // record shares an id with its eventual SESSION_CLOSE.
-                    delta.session_id,
-                )
-            },
-        );
     }
 }
 

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -13,6 +13,7 @@ mod backlog;
 mod budget;
 pub(crate) mod codec;
 mod clock;
+mod connection;
 mod control;
 mod drain;
 mod producer;
@@ -26,6 +27,8 @@ mod replay;
 use backlog::{WRITE_BACKLOG_MAX_BYTES, WriteBacklog};
 #[allow(unused_imports)]
 use budget::release_dataplane_event_queue_budget;
+#[allow(unused_imports)]
+use connection::{io_thread_main, replay_buffered, run_connected_loop, write_all_backpressured};
 #[allow(unused_imports)]
 use control::{handle_drain_request, process_control_frames};
 #[allow(unused_imports)]
@@ -54,14 +57,22 @@ use crate::session::{SessionDelta, SessionDeltaKind};
 use codec::{FRAME_HEADER_SIZE, MSG_ACK, MSG_DRAIN_REQUEST, MSG_KEEPALIVE, MSG_PAUSE, MSG_RESUME};
 use producer::{DataplaneEventCounters, DataplaneEventQueueBudget, DataplaneEventRateLimiter};
 use rustc_hash::FxHashMap;
-use std::collections::VecDeque;
-use std::io;
-use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{self, SyncSender, TryRecvError};
+use std::sync::mpsc::{self, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
+// std types consumed by the connection / control / drain / replay submodules
+// (each `use super::*`) after the #6235 split; mod.rs no longer references them
+// directly.
+#[allow(unused_imports)]
+use std::collections::VecDeque;
+#[allow(unused_imports)]
+use std::io;
+#[allow(unused_imports)]
+use std::os::unix::net::UnixStream;
+#[allow(unused_imports)]
+use std::sync::mpsc::TryRecvError;
 
 /// Idle interval after which the connected loop enqueues a keepalive frame to
 /// keep the Go listener from treating the stream as dead. The keepalive is
@@ -911,351 +922,6 @@ impl EventStreamWorkerHandle {
                 )
             },
         );
-    }
-}
-
-// ---------------------------------------------------------------------------
-// I/O thread -- manages connection, writes events, reads control frames
-// ---------------------------------------------------------------------------
-
-fn io_thread_main(
-    rx: mpsc::Receiver<EventFrame>,
-    shared: Arc<EventStreamShared>,
-    socket_path: String,
-) {
-    let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
-    let mut ctrl_read_buf: Vec<u8> = Vec::with_capacity(128);
-
-    while !shared.stop.load(Ordering::Acquire) {
-        // ---- Connect phase ----
-        let stream = match try_connect(&socket_path, &shared) {
-            Some(s) => s,
-            None => break, // stop requested during connect
-        };
-        stream.set_nonblocking(true).ok();
-        // #5267: `connected` stays set BEFORE `replay_buffered`. It gates only
-        // the LOSSLESS producer path (`send_lossless_encoded` fails closed when
-        // clear); deferring it past the non-gap replay window would make every
-        // worker `push_delta_lossless` return "not connected" mid-reconnect,
-        // which `flush_session_deltas` latches as loss-of-sync -> a spurious
-        // full owner-RG resync on every CLEAN reconnect (the exact churn class
-        // this fix removes). Wire ORDERING is instead guaranteed by allocating
-        // the replay-gap FullResync's seq under `producer_seq_lock` and merging
-        // it into the drain in seq order (below), so the `connected` timing is
-        // orthogonal to ordering.
-        shared.connected.store(true, Ordering::Release);
-        eprintln!("xpf-event-stream: connected to {}", socket_path);
-
-        // #5267: per-connection slot for a replay-gap FullResync barrier.
-        // `replay_buffered` allocates the barrier's seq under `producer_seq_lock`
-        // and PARKS the frame here instead of writing it out of order; the
-        // connected loop's channel drain emits it in seq order relative to the
-        // concurrently-committed deltas. Fresh per connection so a stale barrier
-        // from a prior connection is never re-emitted.
-        let mut pending_resync: Option<EventFrame> = None;
-
-        // Replay buffered events from last acked seq. A replay-buffer gap parks
-        // an ordered FullResync barrier in `pending_resync` rather than writing
-        // it directly ahead of the still-queued lower-seq deltas.
-        let acked = shared.acked_seq.load(Ordering::Acquire);
-        let replay_result =
-            replay_buffered(&stream, &mut replay_buf, acked, &shared, &mut pending_resync);
-        if replay_result.is_err() {
-            shared.connected.store(false, Ordering::Release);
-            eprintln!("xpf-event-stream: replay failed, reconnecting");
-            continue;
-        }
-
-        // ---- Steady-state loop ----
-        ctrl_read_buf.clear(); // discard stale data from previous connection
-        let disconnect = run_connected_loop(
-            &rx,
-            &stream,
-            &shared,
-            &mut replay_buf,
-            &mut ctrl_read_buf,
-            &mut pending_resync,
-            KEEPALIVE_IDLE_INTERVAL,
-        );
-
-        shared.connected.store(false, Ordering::Release);
-        if disconnect {
-            eprintln!("xpf-event-stream: disconnected, will reconnect");
-        }
-    }
-
-    // Drain remaining events on shutdown
-    drain_remaining(&rx, &shared);
-    release_replay_dataplane_event_queue_budget(&shared, &mut replay_buf);
-    shared.connected.store(false, Ordering::Release);
-    eprintln!("xpf-event-stream: I/O thread exiting");
-}
-
-/// Try to connect to the daemon event socket, retrying every 100ms.
-/// Returns None if stop is requested.
-fn try_connect(path: &str, shared: &Arc<EventStreamShared>) -> Option<UnixStream> {
-    loop {
-        if shared.stop.load(Ordering::Acquire) {
-            return None;
-        }
-        match UnixStream::connect(path) {
-            Ok(stream) => return Some(stream),
-            Err(_) => {
-                thread::sleep(Duration::from_millis(100));
-            }
-        }
-    }
-}
-
-/// Replay buffered events that are newer than the last acked sequence.
-/// If the replay buffer doesn't cover acked+1, send FullResync.
-fn replay_buffered(
-    stream: &UnixStream,
-    replay_buf: &mut VecDeque<EventFrame>,
-    acked_seq: u64,
-    shared: &Arc<EventStreamShared>,
-    pending_resync: &mut Option<EventFrame>,
-) -> io::Result<()> {
-    // One shared deadline bounds the whole replay so a stuck reader cannot hold
-    // the I/O thread for `frames * deadline` (#2877). `write_all_backpressured`
-    // keeps the socket NONBLOCKING (the canonical data-frame mode) and polls
-    // the stop flag each WouldBlock cycle; on stop/deadline/error it returns
-    // Err and the caller reconnects.
-    let deadline = Instant::now() + REPLAY_DRAIN_WRITE_DEADLINE;
-    // Check if replay buffer covers what we need. On a true fresh start
-    // (acked_seq == 0 and no buffered frames), start clean. Otherwise any gap
-    // at acked+1 requires FullResync, including the acked_seq==0 case where an
-    // overrun replay buffer has already trimmed seq 1.
-    let oldest_buffered = replay_buf.front().map(|f| f.seq).unwrap_or(0);
-    let has_gap = (replay_buf.is_empty() && acked_seq > 0) || oldest_buffered > acked_seq + 1;
-    if has_gap {
-        // #5267: allocate the FullResync's seq UNDER `producer_seq_lock` and
-        // PARK the frame in `pending_resync` instead of writing it directly to
-        // the socket. Writing it here (outside the lock, ahead of the channel
-        // drain) put a HIGHER seq on the wire before the lower-seq deltas still
-        // queued in the channel: the Go reader (zero reorder tolerance) then
-        // diagnosed a session-sync gap on the first post-barrier delta and
-        // dropped the connection, churning resyncs on the very HA-recovery
-        // barrier. Holding the lock for JUST the `fetch_add` guarantees every
-        // delta already committed to the channel has a strictly LOWER seq (the
-        // channel commit is atomic under the same lock, #3878) and every delta
-        // committed afterward has a strictly higher seq; the connected loop's
-        // drain then merges this barrier into the write stream in seq order
-        // (`drain_channel_into_write_buf`). The lock is released immediately —
-        // no socket write happens under it, so a wedged reader can never stall
-        // the producers through this path, and there is no lock-ordering cycle
-        // (the section is a single atomic).
-        let seq = {
-            let _guard = shared
-                .producer_seq_lock
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            shared.next_seq.fetch_add(1, Ordering::Relaxed) + 1
-        };
-        *pending_resync = Some(EventFrame::encode_full_resync(seq));
-        eprintln!(
-            "xpf-event-stream: queued ordered FullResync seq {} (buffer gap: acked={}, oldest_buffered={})",
-            seq, acked_seq, oldest_buffered
-        );
-        // Keep the stale replay window until the daemon ACKs the FullResync.
-        // Clearing here can make an acked_seq=0 reconnect look like a clean
-        // fresh start and permanently suppress the required bulk export.
-        // `frames_sent` is bumped when the ordered drain accepts the barrier,
-        // matching producer-frame enqueue accounting. When the stream is
-        // paused that means replay retention rather than a socket write; #5328
-        // tracks the existing Resume path's missing replay-suffix scheduling.
-        return Ok(());
-    }
-
-    // Replay frames newer than acked_seq
-    let mut replayed = 0u64;
-    for frame in replay_buf.iter() {
-        if frame.seq > acked_seq {
-            write_all_backpressured(stream, frame.as_bytes(), shared, deadline)?;
-            replayed += 1;
-        }
-    }
-    if replayed > 0 {
-        shared
-            .frames_replayed
-            .fetch_add(replayed, Ordering::Relaxed);
-        eprintln!("xpf-event-stream: replayed {replayed} events");
-    }
-    Ok(())
-}
-
-/// Write all of `bytes` to the NONBLOCKING `stream`, honoring backpressure
-/// without ever wedging the I/O thread (#2877).
-///
-/// The replay (`replay_buffered`) and drain (`handle_drain_request`) paths must
-/// push frames to a socket whose daemon reader may have stalled. The old
-/// `write_frame_blocking` flipped the socket to BLOCKING and called `write_all`
-/// with no deadline and no stop check, so a stuck reader held the I/O thread in
-/// the blocking write forever — and since `EventStreamSender::stop` joins that
-/// thread, a write-blocked thread could not observe the stop flag and
-/// stop/demotion hung. That violates the slow-consumer invariant in
-/// `docs/session-sync-design.md`: a slow telemetry/session consumer must never
-/// stall the helper.
-///
-/// This writer keeps the socket nonblocking (the same mode the steady-state
-/// data-frame writes use) and, on `WouldBlock`, sleeps `REPLAY_DRAIN_WRITE_POLL`
-/// and retries — polling `shared.stop` every cycle and bailing at `deadline`.
-/// It returns `Err` on stop (Interrupted), deadline (TimedOut), or a real
-/// socket error so the caller reconnects / withholds DrainComplete rather than
-/// blocking indefinitely. `deadline` is shared across all frames in one
-/// replay/drain pass so total time is bounded even if stop is never raised.
-fn write_all_backpressured(
-    stream: &UnixStream,
-    bytes: &[u8],
-    shared: &Arc<EventStreamShared>,
-    deadline: Instant,
-) -> io::Result<()> {
-    use std::io::Write;
-    let mut written = 0usize;
-    while written < bytes.len() {
-        if shared.stop.load(Ordering::Acquire) {
-            return Err(io::Error::new(
-                io::ErrorKind::Interrupted,
-                "event stream stop requested during replay/drain write",
-            ));
-        }
-        match (&*stream).write(&bytes[written..]) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "event stream replay/drain write returned 0",
-                ));
-            }
-            Ok(n) => written += n,
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                if Instant::now() >= deadline {
-                    return Err(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        "event stream replay/drain write deadline exceeded",
-                    ));
-                }
-                thread::sleep(REPLAY_DRAIN_WRITE_POLL);
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(())
-}
-
-/// Main connected loop. Returns true if we should reconnect, false if stopping.
-fn run_connected_loop(
-    rx: &mpsc::Receiver<EventFrame>,
-    stream: &UnixStream,
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-    ctrl_read_buf: &mut Vec<u8>,
-    pending_resync: &mut Option<EventFrame>,
-    keepalive_interval: Duration,
-) -> bool {
-    use std::io::{Read, Write};
-
-    let mut write_buf = WriteBacklog::with_capacity(4096);
-    let mut tmp_read = [0u8; 64];
-    let mut idle_cycles = 0u32;
-    let mut last_write = Instant::now();
-
-    loop {
-        if shared.stop.load(Ordering::Acquire) {
-            return false;
-        }
-
-        let paused = shared.paused.load(Ordering::Acquire);
-
-        let drain = drain_channel_into_write_buf(
-            rx,
-            shared,
-            replay_buf,
-            &mut write_buf,
-            paused,
-            pending_resync,
-        );
-        if drain.disconnected {
-            return false;
-        }
-        let drained_any = drain.drained_any;
-
-        // Write buffered frames to socket. On a partial (short) write we advance
-        // the backlog cursor in O(1) instead of memmoving the whole remaining
-        // suffix to offset 0 on every write (the #4974 O(n^2) drain).
-        if !write_buf.is_empty() {
-            match (&*stream).write(write_buf.pending()) {
-                Ok(n) => {
-                    write_buf.advance(n);
-                }
-                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    // Socket buffer full, keep write_buf for next cycle
-                }
-                Err(_) => {
-                    // Socket error -- disconnect
-                    return true;
-                }
-            }
-        }
-
-        // Read control frames from daemon (non-blocking), accumulating
-        // partial reads so that incomplete frames are not lost.
-        match (&*stream).read(&mut tmp_read) {
-            Ok(0) => {
-                // EOF -- peer closed
-                return true;
-            }
-            Ok(n) => {
-                ctrl_read_buf.extend_from_slice(&tmp_read[..n]);
-            }
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                // No data available -- normal
-            }
-            Err(_) => {
-                return true;
-            }
-        }
-
-        // Process complete control frames from accumulated buffer
-        if !ctrl_read_buf.is_empty() {
-            let (action, consumed) =
-                process_control_frames(ctrl_read_buf, shared, rx, stream, replay_buf);
-            if consumed > 0 {
-                ctrl_read_buf.drain(..consumed);
-            }
-            if let Some(reconnect) = action {
-                return reconnect;
-            }
-        }
-
-        // Idle backoff + keepalive
-        if drained_any {
-            idle_cycles = 0;
-            last_write = Instant::now();
-        } else {
-            idle_cycles = idle_cycles.saturating_add(1);
-            if idle_cycles > 10 {
-                // Enqueue a keepalive (prevents idle disconnect on the Go side)
-                // through the SAME `write_buf` backpressure path data frames use
-                // (#2883). The old code called `write_all` directly on the
-                // nonblocking socket and returned true (immediate reconnect) on
-                // ANY error — including `WouldBlock` when the kernel send buffer
-                // is full under a slow reader — bypassing the partial-write /
-                // WouldBlock backpressure and stall accounting and causing
-                // reconnect churn -> replay storms. Routing the keepalive bytes
-                // into `write_buf` makes WouldBlock ordinary backpressure: the
-                // top-of-loop flush retains the remainder for the next cycle,
-                // and a genuinely dead consumer is still detected by the normal
-                // socket-error / EOF path rather than by a false reconnect on
-                // transient fullness.
-                if last_write.elapsed() >= keepalive_interval {
-                    let mut ka = [0u8; FRAME_HEADER_SIZE];
-                    ka[4] = MSG_KEEPALIVE;
-                    write_buf.extend_from_slice(&ka);
-                    last_write = Instant::now();
-                }
-                thread::sleep(Duration::from_millis(1));
-            }
-        }
     }
 }
 

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -9,10 +9,14 @@
 //!   Frame header: [length:u32 LE][type:u8][reserved:3][seq:u64 LE]
 //!   Payload: type-specific binary (see codec module)
 
+mod backlog;
 pub(crate) mod codec;
 mod clock;
 mod producer;
 
+use backlog::{WRITE_BACKLOG_MAX_BYTES, WriteBacklog};
+
+#[allow(unused_imports)] // monotonic_ns_to_unix_secs is consumed only by the rt_flow tests
 pub(crate) use clock::{
     mono_ns_to_wall_clock_unix_ns, monotonic_ns_to_unix_ns, monotonic_ns_to_unix_secs,
     monotonic_ns_to_unix_secs_subnanos,
@@ -66,156 +70,6 @@ const REPLAY_BUFFER_CAPACITY: usize = 4096;
 /// raises it deliberately, rather than the parser silently honoring an arbitrary
 /// 32-bit length.
 const MAX_CONTROL_PAYLOAD_LEN: usize = 0;
-
-/// Hard cap on the I/O thread's pending socket-write backlog (`write_buf`).
-///
-/// The bounded mpsc channel (`CHANNEL_CAPACITY`) is the only intended
-/// backpressure surface. Without this cap a wedged daemon (socket open but
-/// not reading → `write_buf` writes return `WouldBlock`) lets the I/O thread
-/// migrate the entire channel into the heap-backed `write_buf` every cycle;
-/// the channel then refills from worker `try_send`, the I/O thread drains it
-/// again, and `write_buf` grows without bound → helper OOM / allocator
-/// pressure on the forwarding plane (#2381). Once the backlog reaches this
-/// cap the I/O thread stops pulling frames out of the channel, so the bounded
-/// channel becomes the real backpressure surface and `try_send` drops (with
-/// the existing `frames_dropped` / per-kind `queue_full` counters) instead of
-/// silently relocating bytes into one unbounded buffer.
-///
-/// `EventFrame::data` is a fixed `[u8; 256]` (see codec.rs), so a fully
-/// drained `CHANNEL_CAPACITY` (8192) channel is at most 8192 × 256 ≈ 2 MiB of
-/// bytes. 16 MiB is therefore ≈ 8× that worst-case channel drain — generous
-/// headroom so transient bursts (plus any in-flight replay/partial-write
-/// remainder) are absorbed losslessly, while a persistently stalled consumer
-/// stays bounded.
-///
-/// The cap is checked at the top of the drain loop, before the in-flight frame
-/// is appended, so the UNWRITTEN backlog can reach at most
-/// `WRITE_BACKLOG_MAX_BYTES` plus one already-pulled max `EventFrame` (≤ 256 B)
-/// before the drain halts — i.e. the bound is `cap + one frame`, not a strict
-/// 16 MiB. The overshoot is bounded and accepted (simpler than a pre-reserve
-/// check); memory is bounded either way.
-///
-/// #4974: the cap and every backpressure decision measure UNWRITTEN bytes
-/// (`WriteBacklog::pending_len()`), not the raw backing-`Vec` length. The
-/// backlog is cursor-backed (`WriteBacklog`): bytes already handed to the
-/// socket sit in a reclaimable prefix and are compacted geometrically, so the
-/// `Vec` can transiently hold up to ~2× the pending length. Accounting on the
-/// raw length would trip the cap early and drift the pause/resume logic.
-const WRITE_BACKLOG_MAX_BYTES: usize = 16 * 1024 * 1024;
-
-/// Cursor-backed pending socket-write backlog for the connected I/O loop.
-///
-/// #4974: the connected loop keeps unwritten socket bytes here between cycles.
-/// A slow reader accepts only a few bytes per `write`, leaving a large suffix
-/// for the next cycle. The original code stored the backlog in a bare `Vec<u8>`
-/// and reclaimed each short write with `write_buf.drain(..n)`, which memmoves
-/// the ENTIRE remaining suffix down to offset 0 on every write — O(backlog) per
-/// write, so O(backlog²) total copy work while a slow consumer nibbles through
-/// a multi-MiB backlog, all on the single event I/O thread during exactly the
-/// slow-consumer condition.
-///
-/// Instead we track a `start` cursor into `buf`: `buf[start..]` is the
-/// unwritten pending suffix, `buf[..start]` is written-and-reclaimable. A
-/// successful write of `n` bytes advances `start` in O(1) (no memmove). The
-/// consumed prefix is reclaimed by GEOMETRIC compaction — a single copy of the
-/// pending suffix to offset 0 only once the prefix reaches half the buffer
-/// (`start >= buf.len()/2`). Because a compaction then copies at most `start`
-/// bytes and resets `start` to 0, total compaction work is bounded by the total
-/// bytes ever written (amortized O(1) per write, O(total_bytes) overall), and
-/// `buf.len()` stays within ~2× the pending length (bounded, not the unbounded
-/// growth #2381 guards against). Byte order and exactly-once delivery are
-/// preserved: appends only ever go to the tail and compaction never reorders
-/// the pending suffix.
-struct WriteBacklog {
-    /// Backing storage. `buf[start..]` is the unwritten pending suffix.
-    buf: Vec<u8>,
-    /// Offset of the first unwritten byte. Bytes below it were already written
-    /// to the socket and are reclaimable by compaction.
-    start: usize,
-    /// #4974: total bytes moved by geometric compaction, so the amortized
-    /// -linear regression gate can assert bounded copy work. Test-only.
-    #[cfg(test)]
-    compacted_bytes: usize,
-}
-
-impl WriteBacklog {
-    fn with_capacity(cap: usize) -> Self {
-        Self {
-            buf: Vec::with_capacity(cap),
-            start: 0,
-            #[cfg(test)]
-            compacted_bytes: 0,
-        }
-    }
-
-    /// Unwritten bytes still owed to the socket. This is the value the
-    /// `WRITE_BACKLOG_MAX_BYTES` cap and the pause/backpressure logic use — NOT
-    /// the raw `Vec` length, which also counts the reclaimable written prefix.
-    #[inline]
-    fn pending_len(&self) -> usize {
-        self.buf.len() - self.start
-    }
-
-    #[inline]
-    fn is_empty(&self) -> bool {
-        self.start >= self.buf.len()
-    }
-
-    /// The unwritten suffix to hand to the next socket `write`.
-    #[inline]
-    fn pending(&self) -> &[u8] {
-        &self.buf[self.start..]
-    }
-
-    /// Append freshly produced frame bytes to the pending tail. Reclaims the
-    /// consumed prefix first (geometrically) so the `Vec` tracks the pending
-    /// length rather than the lifetime sum of everything ever queued.
-    fn extend_from_slice(&mut self, bytes: &[u8]) {
-        self.compact_if_needed();
-        self.buf.extend_from_slice(bytes);
-    }
-
-    /// Record a successful socket write of `n` bytes. Advances the cursor in
-    /// O(1); when the backlog fully drains it resets without a copy, otherwise
-    /// it compacts geometrically. Replaces the O(backlog) `drain(..n)` memmove.
-    fn advance(&mut self, n: usize) {
-        self.start += n;
-        debug_assert!(self.start <= self.buf.len(), "write reported more than pending");
-        if self.start >= self.buf.len() {
-            // Fully drained -- reset to empty without moving any bytes.
-            self.buf.clear();
-            self.start = 0;
-        } else {
-            self.compact_if_needed();
-        }
-    }
-
-    /// Geometric compaction trigger: reclaim the consumed prefix only once it
-    /// reaches half the buffer. At that point the pending suffix being copied is
-    /// no larger than the prefix being discarded, so the copy cost is charged to
-    /// already-consumed bytes and total compaction work stays O(total_bytes).
-    #[inline]
-    fn compact_if_needed(&mut self) {
-        if self.start != 0 && self.start >= self.buf.len() / 2 {
-            self.compact();
-        }
-    }
-
-    /// Move the pending suffix down to offset 0 and drop the consumed prefix.
-    fn compact(&mut self) {
-        if self.start == 0 {
-            return;
-        }
-        let pending = self.buf.len() - self.start;
-        self.buf.copy_within(self.start.., 0);
-        self.buf.truncate(pending);
-        self.start = 0;
-        #[cfg(test)]
-        {
-            self.compacted_bytes += pending;
-        }
-    }
-}
 
 /// Upper bound for explicit lossless queueing operations such as full
 /// session export on connect. Normal packet-path delta export remains

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -14,9 +14,13 @@ mod budget;
 pub(crate) mod codec;
 mod clock;
 mod producer;
+mod replay;
 
 use backlog::{WRITE_BACKLOG_MAX_BYTES, WriteBacklog};
 use budget::release_dataplane_event_queue_budget;
+use replay::{
+    pop_replay_frame, push_replay_frame, release_replay_dataplane_event_queue_budget,
+};
 
 #[allow(unused_imports)] // monotonic_ns_to_unix_secs is consumed only by the rt_flow tests
 pub(crate) use clock::{
@@ -1685,74 +1689,6 @@ fn flush_pending_resync(
     } else {
         false
     }
-}
-
-fn push_replay_frame(
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-    frame: EventFrame,
-) {
-    if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
-        // Buffer-full eviction: the oldest accepted-and-enqueued frame is
-        // dropped before the daemon ACKed it. It was already counted in
-        // `frames_sent`, so it must be counted as a telemetry loss here
-        // (#2382). This is distinct from ACK-trim / shutdown drain, which
-        // remove frames via `pop_replay_frame` WITHOUT bumping the eviction
-        // counter (an ACKed frame is delivered, not lost).
-        evict_replay_frame(shared, replay_buf);
-    }
-    replay_buf.push_back(frame);
-}
-
-/// Evict the oldest replay frame because the buffer wrapped at capacity. This
-/// is the ONLY telemetry-loss removal path: it increments
-/// `frames_replay_evicted` (#2382) in addition to releasing the queue budget.
-fn evict_replay_frame(
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-) -> Option<EventFrame> {
-    let frame = pop_replay_frame(shared, replay_buf);
-    if let Some(evicted) = frame.as_ref() {
-        shared
-            .frames_replay_evicted
-            .fetch_add(1, Ordering::Relaxed);
-        // #2875: evicting a SESSION-SYNC delta WHILE PAUSED loses a session
-        // mutation the future owner needs to take over cleanly. Poison the
-        // pending demotion drain so `handle_drain_request` withholds
-        // DrainComplete and forces a FullResync instead of silently
-        // completing demotion. Telemetry eviction is a tolerated loss and
-        // must NOT poison (no spurious resync). Read `paused` here so the
-        // poison fires for evictions both in the connected-loop paused drain
-        // and in the drain-request drain loop (both run while paused).
-        if evicted.is_session_sync() && shared.paused.load(Ordering::Acquire) {
-            shared
-                .session_evicted_while_paused
-                .store(true, Ordering::Release);
-        }
-    }
-    frame
-}
-
-/// Remove the oldest replay frame and release its queue budget WITHOUT
-/// counting it as an eviction. Used by ACK-trim (the frame was acknowledged —
-/// delivered, not lost) and shutdown drain. The buffer-full loss path is
-/// `evict_replay_frame`.
-fn pop_replay_frame(
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-) -> Option<EventFrame> {
-    let frame = replay_buf.pop_front();
-    if let Some(frame) = frame.as_ref() {
-        release_dataplane_event_queue_budget(shared, frame);
-    }
-    frame
-}
-
-fn release_replay_dataplane_event_queue_budget(
-    shared: &Arc<EventStreamShared>,
-    replay_buf: &mut VecDeque<EventFrame>,
-) {
-    while pop_replay_frame(shared, replay_buf).is_some() {}
 }
 
 // ---------------------------------------------------------------------------

--- a/userspace-dp/src/event_stream/replay.rs
+++ b/userspace-dp/src/event_stream/replay.rs
@@ -1,0 +1,80 @@
+//! Replay-buffer admission, eviction, and budget-accounted retirement.
+//!
+//! Pure code motion out of `mod.rs` (#6235); no logic change. The I/O thread
+//! keeps accepted-and-enqueued frames in a bounded `VecDeque` replay buffer so a
+//! reconnect can re-send everything the daemon has not yet ACKed. This module
+//! owns admission (`push_replay_frame`), the two removal paths (buffer-full
+//! `evict_replay_frame` which counts a telemetry loss, and the non-loss
+//! `pop_replay_frame` used by ACK-trim / shutdown), and the shutdown bulk drain
+//! (`release_replay_dataplane_event_queue_budget`). Every removal releases the
+//! frame's dataplane-event queue budget exactly once (#2382 / #2875 contract).
+
+use super::*;
+
+pub(super) fn push_replay_frame(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+    frame: EventFrame,
+) {
+    if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
+        // Buffer-full eviction: the oldest accepted-and-enqueued frame is
+        // dropped before the daemon ACKed it. It was already counted in
+        // `frames_sent`, so it must be counted as a telemetry loss here
+        // (#2382). This is distinct from ACK-trim / shutdown drain, which
+        // remove frames via `pop_replay_frame` WITHOUT bumping the eviction
+        // counter (an ACKed frame is delivered, not lost).
+        evict_replay_frame(shared, replay_buf);
+    }
+    replay_buf.push_back(frame);
+}
+
+/// Evict the oldest replay frame because the buffer wrapped at capacity. This
+/// is the ONLY telemetry-loss removal path: it increments
+/// `frames_replay_evicted` (#2382) in addition to releasing the queue budget.
+fn evict_replay_frame(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+) -> Option<EventFrame> {
+    let frame = pop_replay_frame(shared, replay_buf);
+    if let Some(evicted) = frame.as_ref() {
+        shared
+            .frames_replay_evicted
+            .fetch_add(1, Ordering::Relaxed);
+        // #2875: evicting a SESSION-SYNC delta WHILE PAUSED loses a session
+        // mutation the future owner needs to take over cleanly. Poison the
+        // pending demotion drain so `handle_drain_request` withholds
+        // DrainComplete and forces a FullResync instead of silently
+        // completing demotion. Telemetry eviction is a tolerated loss and
+        // must NOT poison (no spurious resync). Read `paused` here so the
+        // poison fires for evictions both in the connected-loop paused drain
+        // and in the drain-request drain loop (both run while paused).
+        if evicted.is_session_sync() && shared.paused.load(Ordering::Acquire) {
+            shared
+                .session_evicted_while_paused
+                .store(true, Ordering::Release);
+        }
+    }
+    frame
+}
+
+/// Remove the oldest replay frame and release its queue budget WITHOUT
+/// counting it as an eviction. Used by ACK-trim (the frame was acknowledged —
+/// delivered, not lost) and shutdown drain. The buffer-full loss path is
+/// `evict_replay_frame`.
+pub(super) fn pop_replay_frame(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+) -> Option<EventFrame> {
+    let frame = replay_buf.pop_front();
+    if let Some(frame) = frame.as_ref() {
+        release_dataplane_event_queue_budget(shared, frame);
+    }
+    frame
+}
+
+pub(super) fn release_replay_dataplane_event_queue_budget(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+) {
+    while pop_replay_frame(shared, replay_buf).is_some() {}
+}

--- a/userspace-dp/src/event_stream/rt_flow.rs
+++ b/userspace-dp/src/event_stream/rt_flow.rs
@@ -1,0 +1,221 @@
+//! RT_FLOW session create/close projection.
+//!
+//! Pure code motion out of `mod.rs` (#6235); no logic change. These two
+//! `EventStreamWorkerHandle` emitters project a session-sync `SessionDelta` into
+//! the RT_FLOW SESSION_CLOSE (type 14) / SESSION_CREATE (type 15) wire frames the
+//! Go NetFlow/IPFIX and per-policy syslog exporters consume. Both route through
+//! the shared per-kind rate-limiter + queue-budget path (`try_emit_dataplane_frame`
+//! in producer.rs), anchoring monotonic session instants to wall-clock via
+//! clock.rs at emit time (#2465/#2853).
+
+use super::*;
+
+impl EventStreamWorkerHandle {
+    /// #2460: emit a SESSION_CLOSE RT_FLOW frame (type 14) for a Close delta
+    /// on the raw dataplane-event channel.
+    ///
+    /// This is ADDITIVE to — and must be called ALONGSIDE, never instead of
+    /// — `push_delta`, which carries the unchanged type-2 HA session-sync
+    /// close delta. The RT_FLOW frame drives the Go NetFlow/IPFIX
+    /// session-close exporters (`pkg/daemon/daemon_flowexport.go`), which
+    /// only run on a `Type == "SESSION_CLOSE"` `logging.EventRecord` — a
+    /// record userspace mode never produced before this. The caller
+    /// (`flush_session_deltas`) gates on `delta.kind == Close`, but the
+    /// guard is repeated here so a future caller cannot misuse it on an Open
+    /// delta. Best-effort (`try_send`): a dropped close frame loses only one
+    /// flow-export record, never the HA close delta (a separate frame).
+    /// `app_id` is the application resolved for the closing session's 5-tuple
+    /// by the caller (`flush_session_deltas`) via the same `app_catalog.lookup`
+    /// the forwarding hot path runs — #2520. 0 means UNKNOWN (no catalog
+    /// match), the unchanged behavior.
+    /// `ingress_ifindex` is the closing binding's interface index (#2615); the
+    /// Go side resolves it to the RT_FLOW `packet-incoming-interface`. 0 keeps
+    /// the prior "N/A" rendering.
+    ///
+    /// #3395: `policy_id` is the RE-RESOLVED admitting policy id, computed by the
+    /// caller (`flush_session_deltas`) from the session's bound rule handle
+    /// against the CURRENT rule table — NOT `delta.metadata.policy_id` (which is
+    /// frozen at install and goes stale after a live policy reorder). The caller
+    /// owns re-resolution because only it holds the `ForwardingState`/`PolicyState`
+    /// the lookup needs.
+    pub(crate) fn emit_session_close_rt_flow(
+        &self,
+        delta: &SessionDelta,
+        app_id: u16,
+        ingress_ifindex: u32,
+        policy_id: u32,
+    ) {
+        if delta.kind != SessionDeltaKind::Close {
+            return;
+        }
+        let nat = &delta.decision.nat;
+        // #2465: convert the monotonic creation / last-seen instants on the
+        // close delta to absolute wall-clock values for the wire. The session
+        // table uses CLOCK_MONOTONIC, but the flow record needs an absolute
+        // StartTime (and the EndTime is a wall-clock instant on the Go side),
+        // so we anchor monotonic deltas against a single (mono, wall) reading
+        // taken here at emit time. A 0 created_ns stays 0 on the wire and
+        // triggers the Go-side packet-count fallback.
+        let (now_mono_ns, now_unix_ns) = read_mono_and_wall_clocks();
+        // #2853: carry BOTH the integer Unix second (offset 108) and the
+        // sub-second nanosecond remainder (offset 44, the close-unused policy_id
+        // slot) so the Go exporters render a millisecond-accurate flow
+        // StartTime. The pre-#2853 code stamped only the truncated second, so
+        // every flow opened in the same second shared one start instant.
+        let (created_unix_secs, created_subsec_nanos) =
+            monotonic_ns_to_unix_secs_subnanos(delta.created_ns, now_mono_ns, now_unix_ns);
+        let close_unix_ns =
+            monotonic_ns_to_unix_ns(delta.last_seen_ns, now_mono_ns, now_unix_ns);
+        // #2512: route through the per-kind rate limiter + queue budget +
+        // sent/dropped counters instead of a bare `try_send`. The same mono
+        // clock reading anchors the limiter so a dropped close is counted
+        // under DataplaneEventKind::SessionClose. The frame is encoded only
+        // after the budget passes (seq supplied by the budget path), so a
+        // rate-limited / budget-exhausted close never burns a sequence
+        // number. A dropped close loses only one flow-export record — the
+        // separate type-2 HA close delta (`push_delta`) is untouched.
+        self.try_emit_dataplane_frame(
+            DataplaneEventKind::SessionClose,
+            delta.metadata.ingress_zone,
+            now_mono_ns,
+            |seq| {
+                EventFrame::encode_session_close_rt_flow(
+                    seq,
+                    delta.key.addr_family,
+                    delta.key.protocol,
+                    delta.key.src_ip,
+                    delta.key.dst_ip,
+                    delta.key.src_port,
+                    delta.key.dst_port,
+                    nat.rewrite_src,
+                    nat.rewrite_dst,
+                    nat.rewrite_src_port.unwrap_or(0),
+                    nat.rewrite_dst_port.unwrap_or(0),
+                    delta.metadata.ingress_zone,
+                    delta.metadata.egress_zone,
+                    // #3056: the admitting policy ID, so the SESSION_CLOSE
+                    // RT_FLOW record (and the NetFlow/IPFIX close exporters) name
+                    // the policy that admitted the flow instead of policy 0.
+                    // Rides the trailing [136:140] slot because #2853 took
+                    // [44:48] on a close. #3395: this is the caller's RE-RESOLVED
+                    // id (current positional id of the bound admitting rule),
+                    // not the frozen `delta.metadata.policy_id`, so a live policy
+                    // reorder before the close no longer mis-attributes the
+                    // record.
+                    policy_id,
+                    delta.metadata.owner_rg_id as i16,
+                    // #2508: per-policy RT_FLOW SYSLOG gate byte. The frame is
+                    // sent unconditionally (the Go NetFlow/IPFIX exporter
+                    // accounts every close), but this bit tells the Go
+                    // logEvent path whether to ALSO emit the per-policy
+                    // RT_FLOW_SESSION_CLOSE syslog record.
+                    delta.metadata.log_session_close,
+                    created_unix_secs,
+                    // #2853: sub-second nanosecond remainder of the creation
+                    // instant, rides the [44:48] slot (unused on a close).
+                    created_subsec_nanos,
+                    close_unix_ns,
+                    // #2520: carry the resolved AppID in the [132:134] wire
+                    // slot so SESSION_CLOSE RT_FLOW records (and the
+                    // NetFlow/IPFIX exporters) show the application.
+                    app_id,
+                    // #2615: carry the closing binding's ingress ifindex in
+                    // the [128:132] wire slot so the record shows the
+                    // admitting interface instead of "N/A".
+                    ingress_ifindex,
+                    // #2501: real per-session volume harvested off the
+                    // expiring entry's counters, into the reserved
+                    // [56:64]/[64:72] (forward) and [112:120]/[120:128]
+                    // (reverse) slots.
+                    delta.counters.fwd_packets,
+                    delta.counters.fwd_bytes,
+                    delta.counters.rev_packets,
+                    delta.counters.rev_bytes,
+                    // #2749: observed forward ToS + cumulative TCP control
+                    // bits harvested off the closing entry, and the session's
+                    // resolved egress (output) interface. These drive the
+                    // re-introduced NetFlow v9 / IPFIX close-record fields
+                    // (srcTos/ipClassOfService, tcpControlBits, egressInterface
+                    // / OutputSNMP). A kernel ifindex is positive; a 0/unset or
+                    // negative (no concrete egress, e.g. local delivery)
+                    // resolution maps to 0 — the collector's "unknown
+                    // interface" sentinel.
+                    delta.observed_tos,
+                    delta.observed_tcp_flags,
+                    u32::try_from(delta.decision.resolution.egress_ifindex).unwrap_or(0),
+                    // #4915: the stable session id harvested off the expiring
+                    // entry (0 for a synthesized close with no live entry). Rides
+                    // the additive [152:160] slot so the SESSION_CLOSE record
+                    // carries the same id as this session's SESSION_CREATE.
+                    delta.session_id,
+                )
+            },
+        );
+    }
+
+    /// #2508: emit an RT_FLOW SESSION_CREATE frame (type 15) for a session
+    /// admitted by a policy configured with `then log session-init`. There is
+    /// NO flowexport consumer of session opens, so unlike the close frame this
+    /// is gated entirely at the producer: the caller invokes it only when
+    /// `delta.metadata.log_session_init` is set. The frame rides the same raw
+    /// dataplane-event channel and is formatted as RT_FLOW_SESSION_CREATE by
+    /// the Go logEvent path. Best-effort (`try_send`).
+    /// #2615: `app_id` is the application resolved for the new session's
+    /// 5-tuple (caller runs the same `app_catalog.lookup` the close path uses,
+    /// mirroring #2520) and `ingress_ifindex` is the admitting binding's
+    /// interface index. 0 in either keeps the prior UNKNOWN / N/A rendering.
+    pub(crate) fn emit_session_create_rt_flow(
+        &self,
+        delta: &SessionDelta,
+        app_id: u16,
+        ingress_ifindex: u32,
+    ) {
+        if delta.kind != SessionDeltaKind::Open {
+            return;
+        }
+        let nat = &delta.decision.nat;
+        // #2512: same per-kind budget path as the close frame (see
+        // emit_session_close_rt_flow). SESSION_CREATE is producer-gated by
+        // the caller (only emitted for `log session-init` policies), but it
+        // still rides the shared dataplane-event channel so it MUST honor the
+        // same limiter / budget / counters under
+        // DataplaneEventKind::SessionCreate rather than a bare `try_send`.
+        let (now_mono_ns, _) = read_mono_and_wall_clocks();
+        self.try_emit_dataplane_frame(
+            DataplaneEventKind::SessionCreate,
+            delta.metadata.ingress_zone,
+            now_mono_ns,
+            |seq| {
+                EventFrame::encode_session_create_rt_flow(
+                    seq,
+                    delta.key.addr_family,
+                    delta.key.protocol,
+                    delta.key.src_ip,
+                    delta.key.dst_ip,
+                    delta.key.src_port,
+                    delta.key.dst_port,
+                    nat.rewrite_src,
+                    nat.rewrite_dst,
+                    nat.rewrite_src_port.unwrap_or(0),
+                    nat.rewrite_dst_port.unwrap_or(0),
+                    delta.metadata.ingress_zone,
+                    delta.metadata.egress_zone,
+                    // #3056: the admitting policy ID stamped on the session at
+                    // install, so the SESSION_CREATE RT_FLOW record names the
+                    // policy that admitted the flow instead of policy 0.
+                    delta.metadata.policy_id,
+                    // #2615: ingress ifindex ([128:132]) + resolved AppID
+                    // ([132:134]) so the SESSION_CREATE RT_FLOW record shows
+                    // the admitting interface and application instead of
+                    // N/A / UNKNOWN.
+                    ingress_ifindex,
+                    app_id,
+                    // #4915: the stable session id assigned at install, carried
+                    // in the additive [152:160] slot so this SESSION_CREATE
+                    // record shares an id with its eventual SESSION_CLOSE.
+                    delta.session_id,
+                )
+            },
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Pure code-motion split of `userspace-dp/src/event_stream/mod.rs` (2001 lines on
current `origin/master`, not the older audit-base SHA) into cohesive submodules
per the issue's named owners. No logic, signature, or wire-behavior change —
fns/types moved verbatim, `#[inline]` attributes preserved exactly, visibility
widened only where an intra-crate caller crossed a new module boundary.

`mod.rs` drops **2001 → 733 lines** (facade: `EventStreamSender` + I/O-thread
bootstrap, `EventStreamShared`, `EventStreamStats`, the `EventStreamWorkerHandle`
producer core, and config constants). It re-exports the moved helpers so all
callers and the `#[cfg(test)] mod tests` tree (which reach them via
`use super::*`) resolve unchanged.

## Submodule layout

| File | Responsibility | LOC |
|------|----------------|-----|
| `mod.rs` | facade + shared state + producer core + bootstrap | 733 |
| `clock.rs` | monotonic→wall-clock conversion (#2465/#2853/#2470) | 102 |
| `backlog.rs` | cursor-backed `WriteBacklog` + cap (#4974/#2381) | 156 |
| `rt_flow.rs` | RT_FLOW SESSION_CLOSE/CREATE projection emitters | 221 |
| `connection.rs` | I/O thread: reconnect, replay, backpressured connected loop (#2877/#2883) | 351 |
| `control.rs` | control-frame decode + drain/resync state machine (#2959/#2876/#2882/#2875) | 310 |
| `drain.rs` | channel-drain mechanics + ordered FullResync merge (#5267/#2381) | 156 |
| `replay.rs` | replay-buffer admission/eviction/retirement (#2382/#2875) | 80 |
| `budget.rs` | I/O-thread queue-budget retirement (pairs producer.rs admission) | 18 |

`producer.rs` (pre-existing, 466 lines) is unchanged; per the issue amendment it
already owns rate limiting, queue-budget admission, and `try_emit_dataplane_frame`.

## Validation

- One commit per extracted submodule; **each commit builds** (`cargo build`).
- Full suite green from the crate root:
  `TMPDIR=/tmp cargo test --release` → **4214 passed, 0 failed, 2 ignored**
  (covers the state-machine tests the issue names: reconnect, partial write,
  drain, resync, replay eviction, queue full, stop, and every budget-release
  path).
- **All 4 `#[inline]` attributes preserved (0 lost); no `#[cold]` existed.**
- A canonical line-level diff (visibility prefixes / `use` / comments / blanks
  stripped) between origin `mod.rs` and the union of the new files shows **zero
  logic differences** — only signature line-wraps, added `#[allow(unused_imports)]`
  annotations, re-export continuation lines, and the extra `impl` block braces
  from splitting the rt_flow methods.
- `event_stream/README.md` Files section updated for the new layout.

Closes #6235