### PR TITLE
refactor(userspace-dp): outline rare ARP/NDP learning from the pre-cache RX stage

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-22 — #6261: outline rare ARP/NDP learn/program off the pre-cache RX stage
+
+- **Timestamp**: 2026-07-22 (refactor/6261-outline-arp-ndp)
+- **Action**: Behavior-preserving codegen/layout refactor. The ARP-reply
+  and NDP-NA learn-and-program tails inside the inline hot stage
+  `stage_link_layer_classify` (validation gates, #2370 logical-ifindex
+  resolve, #4475 Override read-before-write, #3048 change-detecting
+  `insert_if_changed`, #5288-limited synchronous kernel-neighbor program)
+  were extracted into two dedicated `#[cold] #[inline(never)]` handlers,
+  `outline_arp_reply_learn_and_program` and
+  `outline_ndp_na_learn_and_program`. The `classify_arp` /
+  `parse_ndp_neighbor_advert` parser probes and the EtherType classifier
+  stay inline; the ordinary (non-ARP/NDP) fast path is byte-for-byte
+  unchanged. Gate ordering (insert_if_changed → should_program →
+  add_kernel_neighbor), ARP-recycle vs NDP-continue dispositions, and the
+  `learn_ifindex` (now inlined into each handler) logic are identical to
+  the pre-#6261 inline block. No pending neighbor-generation fix was
+  hidden or reordered — the `mac_change_epoch` / limiter sequence is
+  preserved and made explicit in the handler doc comments. `#[cold]` is a
+  layout hint only; flood bounding stays with the #5288 limiter.
+- **File(s)**: userspace-dp/src/afxdp/poll_stages.rs,
+  userspace-dp/src/afxdp/poll_stages_tests.rs (added
+  `outlined_arp_ndp_handlers_still_learn_and_program_6261`),
+  userspace-dp/src/afxdp/README.md
+- **Validation**: `cargo build` clean; targeted + full cargo suite green
+  (existing ARP/NDP learn/change/own-IP/override/limiter tests are the
+  behavior-preserving gate; new #6261 test asserts both outlined handlers
+  still learn under the logical ifindex and preserve dispositions).
+
 ## 2026-07-22 — #6232: scope-complete Rust heatmap classifier + enforced drift gate
 
 - **Timestamp**: 2026-07-22 (fix/6232-heatmap-audit)

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -37,6 +37,20 @@ sync.
   `(ifindex, ip) -> mac` binding into `dynamic_neighbors` AND the kernel
   neighbor table, so these parsers are a MAC->IP write primitive — they
   MUST fail closed on untrusted input.
+  - **Cold-outlined learn/program tails (`#6261`):** `classify_arp` and
+    `parse_ndp_neighbor_advert` (the EtherType classifier + parser probes)
+    stay inline in the hot `stage_link_layer_classify` stage, but the rare
+    *accepted* ARP-reply and NDP-NA learn-and-program work (unicast/own-IP
+    gates, `#2370` logical-ifindex resolve, `#4475` Override read-before-
+    write, `#3048` `insert_if_changed`, `#5288`-limited kernel program) is
+    moved into two dedicated `#[cold] #[inline(never)]` handlers,
+    `outline_arp_reply_learn_and_program` and
+    `outline_ndp_na_learn_and_program`. This is a pure codegen/layout
+    change — behavior, gate ordering, and dispositions (ARP recycles, NDP
+    continues/transits) are byte-for-byte identical to the pre-#6261 inline
+    block; it only keeps the ordinary (non-ARP/NDP) fast path cache-hot.
+    `#[cold]` is a layout hint, NOT a rate limiter — ARP/NDP flood bounding
+    stays with the `#5288` per-worker `KernelNeighborProgramLimiter`.
   - **MAC-change invalidation (`#3048` / `#5147`):** the learn goes through
     `insert_if_changed`, NOT a plain `insert`, so a MAC change observed
     directly on the wire (e.g. an upstream gateway VRRP failover whose

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -96,80 +96,26 @@ pub(super) fn stage_link_layer_classify(
     // resolve to distinct logical ifindexes (distinct (parent, vlan)
     // keys), so a same-IP-different-subnet neighbor never collides.
     //
-    // The resolve is computed ONLY inside the ARP-reply / NDP-NA learn
-    // arms below, NOT at the top of the stage. This stage runs per-packet
-    // for ALL ingress traffic (before the flow-cache fast path), so the
-    // overwhelming majority of packets (every non-ARP/non-NDP frame,
-    // including flow-cache hits) must skip the FastMap lookup entirely —
-    // they pay zero resolve cost, matching the pre-#2370 data path.
-    let learn_ifindex = || {
-        resolve_ingress_logical_ifindex(
-            worker_ctx.forwarding,
-            meta.ingress_ifindex as i32,
-            meta.ingress_vlan_id,
-        )
-        .unwrap_or(meta.ingress_ifindex as i32)
-    };
+    // #6261: the resolve is computed ONLY inside the outlined ARP-reply /
+    // NDP-NA learn-and-program handlers below, NOT at the top of the
+    // stage. This stage runs per-packet for ALL ingress traffic (before
+    // the flow-cache fast path), so the overwhelming majority of packets
+    // (every non-ARP/non-NDP frame, including flow-cache hits) must skip
+    // the FastMap lookup entirely — they pay zero resolve cost, matching
+    // the pre-#2370 data path. The rare learn-and-program work now lives
+    // in `#[cold] #[inline(never)]` handlers so it does not bloat the
+    // inline hot stage; the ordinary (non-ARP/NDP) fast path is
+    // byte-for-byte unchanged — it only classifies the EtherType and
+    // probes the ARP/NDP parsers, exactly as before.
     match parser::classify_arp(raw_frame) {
         parser::ArpClassification::Reply(arp) => {
-            // #2790: validate the advertised sender protocol address BEFORE
-            // caching it. RFC 826 — a learnable ARP reply must name a single
-            // unicast host. A reply claiming an unspecified / loopback /
-            // multicast / broadcast sender IP would otherwise pollute both
-            // the userspace `dynamic_neighbors` map and the kernel ARP table
-            // (spoofed-reply DoS / routing disruption). Fail closed: recycle
-            // the ARP frame (it never transits) but skip learning, mirroring
-            // the #2369 fail-closed-on-malformed-ARP posture and the cold
-            // neighbor warmer's unicast-only gate.
-            // #2851: anti-poisoning own-IP gate, ADDITIONAL to the #2790
-            // unicast-only gate above. Refuse to learn an ARP reply whose
-            // advertised sender IP equals one of the router's OWN configured
-            // interface IPs. A host on the local link could otherwise send an
-            // unsolicited/spoofed reply claiming our own interface address and
-            // teach us `(ifindex, our_ip) -> attacker_mac` in both
-            // `dynamic_neighbors` and the kernel ARP table (RFC 826 — do not
-            // install a neighbor entry for an address we own). This MUST run
-            // BEFORE the `insert_if_changed` below so a rejected own-IP learn
-            // neither inserts nor bumps `mac_change_epoch` (#3048/#3169).
-            // (Solicited-only learning — only caching replies to probes we
-            // actually sent — is a larger, separate concern, tracked as a
-            // follow-up; this fix is the bounded own-IP rejection.)
-            if neighbor_ip_is_learnable(arp.sender_ip)
-                && !worker_ctx.forwarding.owns_configured_ip(arp.sender_ip)
-            {
-                let ifindex = learn_ifindex();
-                // #3048: route the data-path learn through insert_if_changed
-                // so a MAC change observed directly from an ARP reply
-                // (e.g. an upstream gateway VRRP failover whose reply
-                // traverses our XSK ingress) advances the neighbor
-                // mac_change_epoch and evicts stale cached dst_macs. A plain
-                // insert would silently overwrite the userspace map with the
-                // new MAC, then SHADOW the kernel-monitor RTM_NEWNEIGH that
-                // follows add_kernel_neighbor (the monitor would see
-                // prior == new and not bump), leaving the flow cache stale.
-                let changed = worker_ctx.dynamic_neighbors.insert_if_changed(
-                    (ifindex, arp.sender_ip),
-                    NeighborEntry {
-                        mac: arp.sender_mac,
-                    },
-                );
-                // #5288: gate the kernel-neighbor program (a raw netlink
-                // socket()/sendto()/close() + Vec allocations, on this XSK
-                // worker) behind the per-worker limiter. A same-key/same-MAC
-                // repeat (`!changed`) skips the netlink work entirely — the
-                // amplification an ARP-reply flood relied on — and even a
-                // changed-flood is rate-capped, while a genuine MAC change is
-                // still programmed (retried if rate-limited, never silently
-                // lost). See neighbor_program_limiter.
-                if neigh_limiter.should_program(
-                    (ifindex, arp.sender_ip),
-                    arp.sender_mac,
-                    changed,
-                    now_ns,
-                ) {
-                    add_kernel_neighbor(ifindex, arp.sender_ip, arp.sender_mac);
-                }
-            }
+            // #6261: the accepted ARP-reply learn-and-program tail
+            // (validation gates, #2370 logical-ifindex resolve,
+            // change-detecting learn, #5288-limited kernel program) is
+            // outlined to a #[cold] #[inline(never)] handler. ARP frames
+            // never transit the firewall — recycle either way, preserving
+            // the ARP-recycle semantics.
+            outline_arp_reply_learn_and_program(arp, meta, now_ns, neigh_limiter, worker_ctx);
             return StageOutcome::RecycleAndContinue;
         }
         parser::ArpClassification::OtherArp => {
@@ -177,61 +123,175 @@ pub(super) fn stage_link_layer_classify(
         }
         parser::ArpClassification::NotArp => {}
     }
+    // #6261: the NDP parser probe (`parse_ndp_neighbor_advert`) and its
+    // Target Link-Layer Address destructure stay inline; only the accepted
+    // learn-and-program tail (unicast/own-IP gates, #2370 resolve, #4475
+    // Override=0 read-before-write, change-detecting learn, #5288-limited
+    // program) is outlined to a #[cold] #[inline(never)] handler. NDP
+    // "continue" semantics are unchanged — an NA frame still transits the
+    // firewall (we fall through to `Continue` below regardless of whether
+    // the learn happened).
     if let Some(na) = parser::parse_ndp_neighbor_advert(raw_frame)
         && let Some(mac) = na.target_mac
-        // #2790: same unicast-only gate for the NDP NA target address —
-        // an NA advertising an unspecified / loopback / multicast target
-        // IP is not a learnable neighbor (RFC 4861 §7.2.4 targets are
-        // unicast). The NA frame still transits (falls through below);
-        // only the neighbor write is suppressed.
-        && neighbor_ip_is_learnable(na.target_ip)
-        // #2851: same anti-poisoning own-IP gate as the ARP-reply arm above.
-        // An NDP NA advertising one of the router's OWN configured IPv6
-        // addresses must not be learned — a local attacker could otherwise
-        // poison `(ifindex, our_v6) -> attacker_mac` (RFC 4861: do not learn
-        // an entry for an address we own from an unsolicited advert). Runs
-        // BEFORE the `insert_if_changed` below so a rejected learn neither
-        // inserts nor bumps `mac_change_epoch`.
+    {
+        outline_ndp_na_learn_and_program(na, mac, meta, now_ns, neigh_limiter, worker_ctx);
+    }
+    StageOutcome::Continue(())
+}
+
+/// #6261 — outlined ARP-reply learn-and-program tail of
+/// [`stage_link_layer_classify`].
+///
+/// Split out of the inline pre-flow-cache RX stage into a `#[cold]
+/// #[inline(never)]` handler so the ordinary (non-ARP/NDP) packet fast
+/// path stays cache-hot: an actual ARP *reply* on the data path is rare,
+/// but the inline validation / neighbor-learn / rate-limit / synchronous
+/// kernel-neighbor socket work would otherwise bloat the hot stage.
+///
+/// Behavior is byte-for-byte identical to the pre-#6261 inline block —
+/// this is a pure codegen/layout change, not a logic change:
+///
+/// - #2790: validate the advertised sender protocol address BEFORE
+///   caching it. RFC 826 — a learnable ARP reply must name a single
+///   unicast host. A reply claiming an unspecified / loopback /
+///   multicast / broadcast sender IP would otherwise pollute both the
+///   userspace `dynamic_neighbors` map and the kernel ARP table
+///   (spoofed-reply DoS / routing disruption). Fail closed: the caller
+///   recycles the ARP frame (it never transits) but this handler skips
+///   learning, mirroring the #2369 fail-closed-on-malformed-ARP posture
+///   and the cold neighbor warmer's unicast-only gate.
+/// - #2851: anti-poisoning own-IP gate, ADDITIONAL to the #2790
+///   unicast-only gate. Refuse to learn an ARP reply whose advertised
+///   sender IP equals one of the router's OWN configured interface IPs.
+///   A host on the local link could otherwise send an unsolicited /
+///   spoofed reply claiming our own interface address and teach us
+///   `(ifindex, our_ip) -> attacker_mac` in both `dynamic_neighbors` and
+///   the kernel ARP table (RFC 826 — do not install a neighbor entry for
+///   an address we own). This MUST run BEFORE the `insert_if_changed`
+///   below so a rejected own-IP learn neither inserts nor bumps
+///   `mac_change_epoch` (#3048/#3169).
+/// - #2370: learn under the LOGICAL (L3) ifindex, resolving
+///   `(parent, vlan) -> logical` so the insert key matches the
+///   forwarder's lookup key.
+/// - #3048: route the data-path learn through `insert_if_changed` so a
+///   MAC change observed directly from an ARP reply advances the
+///   neighbor `mac_change_epoch` and evicts stale cached dst_macs.
+/// - #5288: gate the kernel-neighbor program (a raw netlink
+///   socket()/sendto()/close() + Vec allocations) behind the per-worker
+///   limiter. A same-key/same-MAC repeat (`!changed`) skips the netlink
+///   work entirely; even a changed-flood is rate-capped, while a genuine
+///   MAC change is still programmed. `#[cold]` is a layout hint, NOT a
+///   rate limiter — flood bounding stays with this limiter.
+///
+/// The generation (`mac_change_epoch`) / limiter ordering is preserved
+/// exactly: `insert_if_changed` computes `changed` first, then
+/// `should_program` consults it, then `add_kernel_neighbor` runs.
+#[cold]
+#[inline(never)]
+fn outline_arp_reply_learn_and_program(
+    arp: parser::ArpReply,
+    meta: UserspaceDpMeta,
+    now_ns: u64,
+    neigh_limiter: &mut KernelNeighborProgramLimiter,
+    worker_ctx: &WorkerContext,
+) {
+    if neighbor_ip_is_learnable(arp.sender_ip)
+        && !worker_ctx.forwarding.owns_configured_ip(arp.sender_ip)
+    {
+        let ifindex = resolve_ingress_logical_ifindex(
+            worker_ctx.forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32);
+        let changed = worker_ctx.dynamic_neighbors.insert_if_changed(
+            (ifindex, arp.sender_ip),
+            NeighborEntry {
+                mac: arp.sender_mac,
+            },
+        );
+        if neigh_limiter.should_program((ifindex, arp.sender_ip), arp.sender_mac, changed, now_ns) {
+            add_kernel_neighbor(ifindex, arp.sender_ip, arp.sender_mac);
+        }
+    }
+}
+
+/// #6261 — outlined NDP Neighbor-Advertisement learn-and-program tail of
+/// [`stage_link_layer_classify`].
+///
+/// Split out of the inline pre-flow-cache RX stage into a `#[cold]
+/// #[inline(never)]` handler for the same reason as the ARP handler
+/// above. Called with the parsed `na` and its Target Link-Layer Address
+/// `mac` — the caller keeps the inline `parse_ndp_neighbor_advert`
+/// parser probe and the `target_mac` destructure. This handler never
+/// recycles: the NA frame still transits the firewall, so the caller
+/// always returns `StageOutcome::Continue(())`.
+///
+/// Behavior is byte-for-byte identical to the pre-#6261 inline block —
+/// pure codegen/layout change:
+///
+/// - #2790: unicast-only gate for the NA target address — an NA
+///   advertising an unspecified / loopback / multicast target IP is not
+///   a learnable neighbor (RFC 4861 §7.2.4 targets are unicast). Only
+///   the neighbor write is suppressed; the NA frame still transits.
+/// - #2851: same anti-poisoning own-IP gate as the ARP-reply handler —
+///   an NA advertising one of the router's OWN configured IPv6 addresses
+///   must not be learned. Runs BEFORE `insert_if_changed` so a rejected
+///   learn neither inserts nor bumps `mac_change_epoch`.
+/// - #2370: learn under the LOGICAL (L3) ifindex (VLAN sub-interface).
+/// - #4475 (opus-172 H-2): honor the RFC 4861 §7.2.5 Override (O) flag.
+///   An NA with Override=0 MUST NOT overwrite a cached neighbor entry
+///   that maps to a DIFFERENT link-layer address — the unsolicited-NA
+///   next-hop hijack primitive. A legitimate host announcing a
+///   link-layer-address change sets Override=1 (§7.2.6), so an Override=0
+///   NA is only allowed to create a first-time entry or refresh the same
+///   LLA; a live differing LLA is left untouched (this handler returns
+///   without learning — the NA frame still transits). This reads the
+///   per-worker `dynamic_neighbors` snapshot and the `insert_if_changed`
+///   below re-locks the shard, so it is a best-effort gate; the worker is
+///   the sole data-path writer for this key, and the kernel STALE install
+///   (see `DATA_PATH_NEIGH_STATE`) is the second line of defense.
+/// - #3048 / #5288: same change-detecting learn and bounded kernel
+///   program as the ARP handler — an NA flood for a non-owned unicast
+///   target must not storm netlink on the worker.
+///
+/// The generation (`mac_change_epoch`) / limiter ordering is preserved
+/// exactly, and the Override read happens BEFORE the `insert_if_changed`
+/// write, as before.
+#[cold]
+#[inline(never)]
+fn outline_ndp_na_learn_and_program(
+    na: parser::NdpNeighborAdvert,
+    mac: [u8; 6],
+    meta: UserspaceDpMeta,
+    now_ns: u64,
+    neigh_limiter: &mut KernelNeighborProgramLimiter,
+    worker_ctx: &WorkerContext,
+) {
+    if neighbor_ip_is_learnable(na.target_ip)
         && !worker_ctx.forwarding.owns_configured_ip(na.target_ip)
     {
-        let ifindex = learn_ifindex();
-        // #4475 (opus-172 H-2): honor the RFC 4861 §7.2.5 Override (O)
-        // flag. An NA with Override=0 MUST NOT overwrite a cached neighbor
-        // entry that maps to a DIFFERENT link-layer address — that is the
-        // unsolicited-NA next-hop hijack primitive (a local attacker
-        // claiming the WAN gateway's IPv6 with its own MAC). A legitimate
-        // host announcing a link-layer-address change sets Override=1
-        // (§7.2.6), so this blocks the poison while preserving legit
-        // MAC-change propagation (#3048): an Override=0 NA is allowed only
-        // to create a FIRST-TIME entry (no cached MAC) or refresh the SAME
-        // LLA; a live differing LLA is left untouched (the NA frame still
-        // transits — we fall through to `Continue`). This reads the
-        // per-worker `dynamic_neighbors` snapshot and the `insert_if_changed`
-        // below re-locks the shard, so it is a best-effort gate; the worker
-        // is the sole data-path writer for this key, and the kernel STALE
-        // install (see `DATA_PATH_NEIGH_STATE`) is the second line of
-        // defense for any residual race.
+        let ifindex = resolve_ingress_logical_ifindex(
+            worker_ctx.forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32);
         if !na.override_flag
             && worker_ctx
                 .dynamic_neighbors
                 .get(&(ifindex, na.target_ip))
                 .is_some_and(|existing| existing.mac != mac)
         {
-            return StageOutcome::Continue(());
+            return;
         }
-        // #3048: same change-detecting learn for NDP NA — a target-MAC
-        // change observed on the data path must bump mac_change_epoch and
-        // evict stale cached dst_macs (see the ARP-reply arm above).
         let changed = worker_ctx
             .dynamic_neighbors
             .insert_if_changed((ifindex, na.target_ip), NeighborEntry { mac });
-        // #5288: same bounded kernel-program gate as the ARP arm — an NA flood
-        // for a non-owned unicast target must not storm netlink on the worker.
         if neigh_limiter.should_program((ifindex, na.target_ip), mac, changed, now_ns) {
             add_kernel_neighbor(ifindex, na.target_ip, mac);
         }
     }
-    StageOutcome::Continue(())
 }
 
 /// Stage 6 — native GRE decapsulation.

--- a/userspace-dp/src/afxdp/poll_stages_tests.rs
+++ b/userspace-dp/src/afxdp/poll_stages_tests.rs
@@ -863,6 +863,53 @@ fn ndp_learns_vlan_neighbor_under_logical_ifindex_2370() {
     );
 }
 
+/// #6261 outline regression. The ARP-reply and NDP-NA learn-and-program
+/// tails were moved out of the inline `stage_link_layer_classify` into
+/// dedicated `#[cold] #[inline(never)]` handlers
+/// (`outline_arp_reply_learn_and_program` /
+/// `outline_ndp_na_learn_and_program`). That is a pure codegen/layout
+/// change and MUST remain behavior-preserving: driving a valid ARP reply
+/// and a valid NDP NA through the stage must still learn the neighbor
+/// under the LOGICAL ifindex AND preserve the ARP-recycle vs NDP-continue
+/// dispositions. If the extraction ever drops the learn, mis-passes an
+/// argument, or flips a disposition, these asserts fail.
+#[test]
+fn outlined_arp_ndp_handlers_still_learn_and_program_6261() {
+    let forwarding: &'static ForwardingState = Box::leak(Box::new(build_forwarding_state(
+        &super::super::test_fixtures::nat_snapshot(),
+    )));
+    let (ctx, neighbors) = neighbor_learn_ctx(forwarding);
+
+    // ARP reply on VLAN 80 (parent 11 -> logical 12): the outlined ARP
+    // handler must learn AND the stage must still recycle the ARP frame.
+    let arp_ip = Ipv4Addr::new(172, 16, 80, 61);
+    let arp_mac = [0x02, 0x00, 0x00, 0x00, 0x62, 0x61];
+    let arp_outcome = classify(&arp_reply_frame(arp_ip, arp_mac), link_layer_meta(11, 80), ctx);
+    assert!(
+        matches!(arp_outcome, StageOutcome::RecycleAndContinue),
+        "ARP frames must still recycle after outlining (#6261)"
+    );
+    assert_eq!(
+        neighbors.get(&(12, IpAddr::V4(arp_ip))).map(|e| e.mac),
+        Some(arp_mac),
+        "outlined ARP handler must still learn under logical ifindex 12 (#6261)"
+    );
+
+    // NDP NA on VLAN 80: the outlined NDP handler must learn AND the
+    // stage must still Continue (the NA frame transits).
+    let (na_frame, na_ip, na_mac) = ndp_na_frame();
+    let na_outcome = classify(&na_frame, link_layer_meta(11, 80), ctx);
+    assert!(
+        matches!(na_outcome, StageOutcome::Continue(())),
+        "NDP NA must still Continue (transit) after outlining (#6261)"
+    );
+    assert_eq!(
+        neighbors.get(&(12, na_ip)).map(|e| e.mac),
+        Some(na_mac),
+        "outlined NDP handler must still learn under logical ifindex 12 (#6261)"
+    );
+}
+
 /// A `nat_snapshot`-shaped config with TWO VLAN sub-interfaces on the
 /// same physical parent (ifindex 11): `reth0.80` (logical 12, VID 80)
 /// and `reth0.50` (logical 13, VID 50), in different subnets.


### PR DESCRIPTION
Closes #6261 (Audit-183 cohort, tracker #6269).

## What

`stage_link_layer_classify` is an inline pre-flow-cache RX stage that
runs per-packet for **all** ingress traffic. Its accepted ARP-reply and
NDP-NA arms inlined the full learn-and-program tail — unicast/own-IP
validation, `#2370` logical-ifindex resolve, `#4475` Override
read-before-write, `#3048` change-detecting `insert_if_changed`, and the
`#5288`-limited synchronous kernel-neighbor socket/send/close. That work
is rare (an actual ARP reply / NDP advertisement on the data path) but
bloats the hot stage and pushes the ordinary packet path off cache.

This extracts both tails into dedicated `#[cold] #[inline(never)]`
handlers, `outline_arp_reply_learn_and_program` and
`outline_ndp_na_learn_and_program`, called from
`stage_link_layer_classify` in the same place with the same arguments and
effects. The EtherType classifier and parser probes (`classify_arp` /
`parse_ndp_neighbor_advert`) stay inline; the ordinary (non-ARP/NDP) fast
path is byte-for-byte unchanged.

## Why it is behavior-preserving (pure codegen/layout change)

- All validation gates, the rate limiter, and the send path are
  identical to the pre-refactor inline block.
- **Gate ordering preserved exactly:** `insert_if_changed` computes
  `changed` first → `should_program` consults it → `add_kernel_neighbor`
  runs. The generation (`mac_change_epoch`) / limiter sequence and the
  `#4475` Override read-before-write are unchanged and now spelled out in
  the handler doc comments, so **no pending neighbor-generation fix is
  hidden or reordered**.
- ARP-recycle vs NDP-continue dispositions preserved (caller still
  recycles ARP frames and lets NDP NAs transit).
- The old `learn_ifindex` closure became a direct
  `resolve_ingress_logical_ifindex(...).unwrap_or(...)` inside each
  handler, so the logical-ifindex resolve is still computed **only** on
  the ARP/NDP arms, never on the ordinary path.
- `#[cold]` is a layout hint, **not** a rate limiter — ARP/NDP flood
  bounding stays with the `#5288` per-worker
  `KernelNeighborProgramLimiter`.

## Validation

- `cargo build` clean — no borrow/lifetime issues (handlers take
  `&WorkerContext` + `Copy` `meta` by value, no captured refs).
- Full release cargo suite green: **4217 passed, 0 failed**
  (`--test-threads=1`).
- The existing ARP/NDP learn/change/own-IP/override/limiter tests are the
  behavior-preserving gate. Added
  `outlined_arp_ndp_handlers_still_learn_and_program_6261` asserting both
  outlined handlers still learn under the logical ifindex and keep the
  recycle/continue dispositions.
- Updated `userspace-dp/src/afxdp/README.md` and `_Log.md`.

> Note: this touches the RX hot path, so a loss-cluster iperf smoke
> before merge is warranted (parent-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Esaj3z7qQVuYxK2zdtdP6E
