### PR TITLE
filter: remove 8 grep-dead FilterState fields (#6236 PR-1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,65 @@
+## 2026-07-22 — #6236 PR-1: delete 8 grep-proven-dead FilterState fields
+
+- **Timestamp**: 2026-07-22 (refactor/6236-p1-dead-filter-fields)
+- **Action**: Pure-deletion refactor removing eight dead fields from
+  `FilterState` (`userspace-dp/src/filter/mod.rs`) plus their compiler writes.
+  This is PR-1 of the two-PR #6236 plan (`docs/research/6236-filterstate-
+  typed-hooks/plan.md` §3a/§5/§10); it advances but does NOT close #6236 —
+  PR-2 (the input property-set → `Filter`-flag convergence + single-lookup
+  call-site fold) stays in research per the plan-review. Deleted: the four
+  per-interface `"family:name"` name maps `iface_filter_v4` / `iface_filter_v6`
+  / `iface_filter_out_v4` / `iface_filter_out_v6` (`FxHashMap<i32,String>`,
+  zero production readers — one test read each at most); the two input
+  `iface_filter_v{4,6}_affects_tx_selection` sets (`FxHashSet<i32>`, read only
+  by the test-only helper `interface_filter_affects_tx_selection`, itself
+  deleted); and the two `lo0_filter_v{4,6}` qualified-key `String`s, which were
+  compiler intermediates only (used to derive `lo0_filter_v{4,6}_fast`) and are
+  now lifted to compiler locals `lo0_filter_v{4,6}_key`. The struct retains the
+  six `_fast` maps + two lo0 `_fast` Options, the three registries, and all six
+  aggregate booleans (`has_input_tx_selection_*`, `has_output_tx_selection_*`,
+  `has_input_three_color_policer_*`). The LIVE output `iface_filter_out_v{4,6}_
+  needs_tx_eval` sets and the six live input property sets (`_affects_route_
+  lookup`, `_has_dscp_match`, `_has_per_packet_l4_match`) are UNTOUCHED — they
+  are PR-2 scope. Net: **31 → 23 fields**. Files: `filter/mod.rs` (struct),
+  `filter/compiler.rs` (dropped four name-map `.insert`s + two dead-set
+  `.insert`s + lifted lo0 keys to locals), `filter/engine/tx_selection.rs`
+  (deleted the test-only helper), `filter/engine/mod.rs` (dropped its
+  re-export), `filter/tests.rs` (rewrote the two tests that read deleted fields
+  to read the retained fast maps + aggregate; added a `size_of::<FilterState>()`
+  evidence test), `filter/README.md` (#3296 section documents the removal).
+  CRITICAL: the #3296 `MissingFilterRef` fail-closed guards are byte-for-byte
+  unchanged — deleting a name-map `.insert` never touched the `filters.get()`
+  presence check that precedes it, and the retained `has_input_tx_selection_*`
+  aggregate writes are preserved.
+- **Validation**: `cargo build --release` green (exit 0). `cargo clippy
+  --release --all-targets` — the ONLY error is a pre-existing deny-by-default
+  `mut_from_ref` in the UNTOUCHED `afxdp/umem/mmap.rs:150` (`slice_mut_unchecked`
+  is byte-identical on origin/master; no toolchain pin, clippy 1.96.0); my diff
+  introduces ZERO new clippy findings in `filter/`. Plain-build warning count
+  is 176 on master → **175** on this branch (one FEWER — the deleted
+  `interface_filter_affects_tx_selection` re-export). Full `cargo test --release
+  -- --test-threads=1` GREEN from the crate root (disk target
+  `/home/ps/.cache/xpf-cargo-6236p1`, `TMPDIR=/tmp`): **4219 passed, 0 failed,
+  2 ignored** (4128 + 60 + 8 + 22 + 1), REAL cargo exit 0. `size_of::
+  <FilterState>` measured **736 → 496 bytes** (−240; matches the plan estimate)
+  via `filter_state_struct_size_is_reported`. Behavior-preservation proof:
+  (a) independent grep on origin/master shows each of the 8 fields has zero
+  production readers (name maps + lo0 strings = compiler-write + test-read only;
+  the two `_affects_tx_selection` sets read only by the deleted test-only
+  helper); (b) full suite green with the tx_selection helper's test callers
+  rewritten against the retained `filter_state_has_input_tx_selection` aggregate.
+  Fail-on-revert: the retained aggregate wiring is bound by the existing
+  `parse_filter_state_prequalifies_interface_and_lo0_filter_keys` (asserts
+  `has_input_tx_selection_v4`) and `thin_accessor_predicates` (asserts
+  `filter_state_has_input_tx_selection`) — neutralizing the kept
+  `state.has_input_tx_selection_v4 = true;` compiler line drives both RED
+  (verified).
+- **File(s)**: `userspace-dp/src/filter/mod.rs`,
+  `userspace-dp/src/filter/compiler.rs`,
+  `userspace-dp/src/filter/engine/tx_selection.rs`,
+  `userspace-dp/src/filter/engine/mod.rs`,
+  `userspace-dp/src/filter/tests.rs`, `userspace-dp/src/filter/README.md`
+
 ## 2026-07-22 — #6244: typed reconcile progress replaces last_reconcile_stage string
 
 - **Timestamp**: 2026-07-22 (fix/6244-typed-reconcile-progress)

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -707,6 +707,20 @@ peer-sync path. An EMPTY reference (no filter on the hook) is the legitimate
 both lo0 input families. Tests: `missing_filter_ref_3296_*` /
 `defined_filter_ref_3296_compiles_cleanly` in `filter/tests.rs` (fail-on-revert).
 
+The fail-closed contract keys off the RETAINED per-interface fast maps
+(`iface_filter_*_fast`) and, for output hooks, the
+`iface_filter_out_*_needs_tx_eval` sets — the only structures the hot path
+consults. #6236 PR-1 removed the dead parallel bookkeeping that shadowed these:
+the four `"family:name"` name maps (`iface_filter_v4`/`iface_filter_v6`/
+`iface_filter_out_v4`/`iface_filter_out_v6`), the two input
+`iface_filter_v{4,6}_affects_tx_selection` sets (their only reader was a
+test-only helper; production reads the family-wide `has_input_tx_selection_*`
+aggregate), and the two `lo0_filter_v{4,6}` qualified-key Strings (now compiler
+locals used only to look up `lo0_filter_v{4,6}_fast`). The `MissingFilterRef`
+guards are byte-for-byte unchanged — deleting a name-map `.insert` never touched
+the `filters.get()` presence check that precedes it. `FilterState` drops from 31
+to 23 fields with zero live-dataplane behavior change.
+
 Unparseable tcp-flags backstop (#3367): a term whose Junos `tcp-flags`
 expression the Go control plane could not parse into required/forbidden masks
 (disjunction, negated groups, unknown flags) is marked with the

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -159,9 +159,6 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
             let key = qualify_filter_key("inet", &iface.filter_input_v4);
             if let Some(filter) = state.filters.get(&key) {
                 if filter.affects_tx_selection {
-                    state
-                        .iface_filter_v4_affects_tx_selection
-                        .insert(iface.ifindex);
                     state.has_input_tx_selection_v4 = true;
                 }
                 if filter.has_three_color_policer_terms {
@@ -195,7 +192,6 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                     filter: iface.filter_input_v4.clone(),
                 });
             }
-            state.iface_filter_v4.insert(iface.ifindex, key);
         }
         if !iface.filter_output_v4.is_empty() {
             let key = qualify_filter_key("inet", &iface.filter_output_v4);
@@ -227,15 +223,11 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                     filter: iface.filter_output_v4.clone(),
                 });
             }
-            state.iface_filter_out_v4.insert(iface.ifindex, key);
         }
         if !iface.filter_input_v6.is_empty() {
             let key = qualify_filter_key("inet6", &iface.filter_input_v6);
             if let Some(filter) = state.filters.get(&key) {
                 if filter.affects_tx_selection {
-                    state
-                        .iface_filter_v6_affects_tx_selection
-                        .insert(iface.ifindex);
                     state.has_input_tx_selection_v6 = true;
                 }
                 if filter.has_three_color_policer_terms {
@@ -266,7 +258,6 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                     filter: iface.filter_input_v6.clone(),
                 });
             }
-            state.iface_filter_v6.insert(iface.ifindex, key);
         }
         if !iface.filter_output_v6.is_empty() {
             let key = qualify_filter_key("inet6", &iface.filter_output_v6);
@@ -296,16 +287,19 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                     filter: iface.filter_output_v6.clone(),
                 });
             }
-            state.iface_filter_out_v6.insert(iface.ifindex, key);
         }
     }
 
-    state.lo0_filter_v4 = if lo0_filter_v4.is_empty() {
+    // #6236 PR-1: the qualified lo0 keys are compiler intermediates only — they
+    // exist solely to look up lo0_filter_v*_fast and were never read on the
+    // packet path. Keep them as locals; the struct retains only the fast
+    // Option<Arc<Filter>>. The #3296 fail-closed guards below are unchanged.
+    let lo0_filter_v4_key = if lo0_filter_v4.is_empty() {
         String::new()
     } else {
         qualify_filter_key("inet", lo0_filter_v4)
     };
-    state.lo0_filter_v4_fast = state.filters.get(&state.lo0_filter_v4).cloned();
+    state.lo0_filter_v4_fast = state.filters.get(&lo0_filter_v4_key).cloned();
     if !lo0_filter_v4.is_empty() && state.lo0_filter_v4_fast.is_none() {
         // #3296: lo0 host-bound input filter names a filter not in the table.
         // Falling through to the default Accept would leave the routing-engine
@@ -317,12 +311,12 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
             filter: lo0_filter_v4.to_string(),
         });
     }
-    state.lo0_filter_v6 = if lo0_filter_v6.is_empty() {
+    let lo0_filter_v6_key = if lo0_filter_v6.is_empty() {
         String::new()
     } else {
         qualify_filter_key("inet6", lo0_filter_v6)
     };
-    state.lo0_filter_v6_fast = state.filters.get(&state.lo0_filter_v6).cloned();
+    state.lo0_filter_v6_fast = state.filters.get(&lo0_filter_v6_key).cloned();
     if !lo0_filter_v6.is_empty() && state.lo0_filter_v6_fast.is_none() {
         // #3296: lo0 host-bound inet6 input filter missing → fail-open. Refuse.
         return Err(SnapshotIntegrityError::MissingFilterRef {

--- a/userspace-dp/src/filter/engine/mod.rs
+++ b/userspace-dp/src/filter/engine/mod.rs
@@ -33,6 +33,5 @@ pub(crate) use tx_selection::{
     evaluate_filter_ref_tx_selection_runtime_uncounted, evaluate_filter_ref_tx_selection_uncounted,
     evaluate_interface_filter_tx_selection_counted,
     evaluate_interface_output_filter_tx_selection_counted, filter_state_has_input_tx_selection,
-    filter_state_has_output_tx_selection, interface_filter_affects_tx_selection,
-    interface_output_filter_needs_tx_eval,
+    filter_state_has_output_tx_selection, interface_output_filter_needs_tx_eval,
 };

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -372,22 +372,6 @@ pub(crate) fn evaluate_interface_output_filter_tx_selection_counted<'a>(
     )
 }
 
-pub(crate) fn interface_filter_affects_tx_selection(
-    state: &FilterState,
-    ifindex: i32,
-    is_v6: bool,
-) -> bool {
-    if is_v6 {
-        state
-            .iface_filter_v6_affects_tx_selection
-            .contains(&ifindex)
-    } else {
-        state
-            .iface_filter_v4_affects_tx_selection
-            .contains(&ifindex)
-    }
-}
-
 pub(crate) fn interface_output_filter_needs_tx_eval(
     state: &FilterState,
     ifindex: i32,

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -751,12 +751,8 @@ pub(crate) struct FilterState {
         rustc_hash::FxHashMap<String, Arc<ThreeColorPolicerRuntime>>,
     /// Name-derived ID-indexed three-color policer runtimes.
     pub(crate) three_color_policers: Vec<Arc<ThreeColorPolicerRuntime>>,
-    /// Per-interface (ifindex) input filter key for inet.
-    pub(crate) iface_filter_v4: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_v4_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
-    /// Per-interface inet input filters that can affect CoS TX selection.
-    pub(crate) iface_filter_v4_affects_tx_selection: rustc_hash::FxHashSet<i32>,
     /// Whether any inet input filter can affect CoS TX selection.
     pub(crate) has_input_tx_selection_v4: bool,
     /// Whether any inet input filter contains a three-color policer.
@@ -768,12 +764,8 @@ pub(crate) struct FilterState {
     /// Per-interface inet input filters with per-packet L4 match terms (#2362:
     /// tcp-flags / is-fragment / icmp-type / icmp-code). Cache-sensitive.
     pub(crate) iface_filter_v4_has_per_packet_l4_match: rustc_hash::FxHashSet<i32>,
-    /// Per-interface (ifindex) input filter key for inet6.
-    pub(crate) iface_filter_v6: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet6 filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_v6_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
-    /// Per-interface inet6 input filters that can affect CoS TX selection.
-    pub(crate) iface_filter_v6_affects_tx_selection: rustc_hash::FxHashSet<i32>,
     /// Whether any inet6 input filter can affect CoS TX selection.
     pub(crate) has_input_tx_selection_v6: bool,
     /// Whether any inet6 input filter contains a three-color policer.
@@ -784,28 +776,20 @@ pub(crate) struct FilterState {
     pub(crate) iface_filter_v6_has_dscp_match: rustc_hash::FxHashSet<i32>,
     /// Per-interface inet6 input filters with per-packet L4 match terms (#2362).
     pub(crate) iface_filter_v6_has_per_packet_l4_match: rustc_hash::FxHashSet<i32>,
-    /// Per-interface (ifindex) output filter key for inet.
-    pub(crate) iface_filter_out_v4: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet output filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_out_v4_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
     /// Per-interface inet output filters that must still be evaluated in the TX path.
     pub(crate) iface_filter_out_v4_needs_tx_eval: rustc_hash::FxHashSet<i32>,
     /// Whether any inet output filter can affect CoS TX selection.
     pub(crate) has_output_tx_selection_v4: bool,
-    /// Per-interface (ifindex) output filter key for inet6.
-    pub(crate) iface_filter_out_v6: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet6 output filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_out_v6_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
     /// Per-interface inet6 output filters that must still be evaluated in the TX path.
     pub(crate) iface_filter_out_v6_needs_tx_eval: rustc_hash::FxHashSet<i32>,
     /// Whether any inet6 output filter can affect CoS TX selection.
     pub(crate) has_output_tx_selection_v6: bool,
-    /// lo0 inet input filter key.
-    pub(crate) lo0_filter_v4: String,
     /// Direct lo0 inet filter reference for packet hot-path evaluation.
     pub(crate) lo0_filter_v4_fast: Option<Arc<Filter>>,
-    /// lo0 inet6 input filter key.
-    pub(crate) lo0_filter_v6: String,
     /// Direct lo0 inet6 filter reference for packet hot-path evaluation.
     pub(crate) lo0_filter_v6_fast: Option<Arc<Filter>>,
 }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2209,6 +2209,22 @@ fn filter_result_modifiers_roundtrip_5444() {
 }
 
 #[test]
+fn filter_state_struct_size_is_reported() {
+    // #6236 PR-1 evidence: print the compiled size of FilterState so the
+    // dead-field deletion (31 -> 23 fields) is measurable rather than
+    // back-solved. Run with `-- --nocapture` to see the value. The exact
+    // byte count is toolchain-dependent (hashbrown inline size, niche
+    // packing), so this asserts only a loose ceiling that the post-deletion
+    // struct clears; the printed number is the real evidence.
+    let bytes = std::mem::size_of::<FilterState>();
+    println!("FilterState size_of = {bytes} bytes");
+    assert!(
+        bytes <= 736,
+        "FilterState grew past the pre-#6236 footprint ({bytes} bytes)"
+    );
+}
+
+#[test]
 fn parse_filter_state_prequalifies_interface_and_lo0_filter_keys() {
     let ifaces = vec![crate::InterfaceSnapshot {
         name: "reth0.80".into(),
@@ -2251,11 +2267,16 @@ fn parse_filter_state_prequalifies_interface_and_lo0_filter_keys() {
         "protect-re-v6",
     )
     .expect("filter state compiles");
+    // #6236 PR-1: the dead per-interface/lo0 name maps and the dead input
+    // `iface_filter_v4_affects_tx_selection` set are removed. The retained fast
+    // maps carry the resolved `Arc<Filter>` (name is the unqualified filter
+    // name), and the aggregate boolean carries the family-wide tx-selection
+    // fact. The route-lookup and output needs_tx_eval sets are retained (PR-2
+    // scope) and asserted as before.
     assert_eq!(
-        state.iface_filter_v4.get(&7).map(String::as_str),
-        Some("inet:ingress-v4")
+        state.iface_filter_v4_fast.get(&7).map(|f| f.name.as_str()),
+        Some("ingress-v4")
     );
-    assert!(state.iface_filter_v4_affects_tx_selection.contains(&7));
     assert!(state.has_input_tx_selection_v4);
     assert!(state.iface_filter_v4_affects_route_lookup.contains(&7));
     assert!(!state.iface_filter_out_v4_needs_tx_eval.contains(&7));
@@ -2263,11 +2284,20 @@ fn parse_filter_state_prequalifies_interface_and_lo0_filter_keys() {
     assert!(!state.has_output_tx_selection_v4);
     assert!(!state.has_output_tx_selection_v6);
     assert_eq!(
-        state.iface_filter_out_v6.get(&7).map(String::as_str),
-        Some("inet6:egress-v6")
+        state
+            .iface_filter_out_v6_fast
+            .get(&7)
+            .map(|f| f.name.as_str()),
+        Some("egress-v6")
     );
-    assert_eq!(state.lo0_filter_v4, "inet:protect-re");
-    assert_eq!(state.lo0_filter_v6, "inet6:protect-re-v6");
+    assert_eq!(
+        state.lo0_filter_v4_fast.as_ref().map(|f| f.name.as_str()),
+        Some("protect-re")
+    );
+    assert_eq!(
+        state.lo0_filter_v6_fast.as_ref().map(|f| f.name.as_str()),
+        Some("protect-re-v6")
+    );
 }
 
 #[test]
@@ -3642,11 +3672,10 @@ fn thin_accessor_predicates() {
     )
     .expect("filter state compiles");
 
-    // TX-selection accessor reads the TX-selection set, NOT the DSCP set:
-    // true on the TX-only ifindex, false on the DSCP-only ifindex.
-    assert!(interface_filter_affects_tx_selection(&state, 21, false));
-    assert!(!interface_filter_affects_tx_selection(&state, 22, false));
-    assert!(!interface_filter_affects_tx_selection(&state, 21, true));
+    // #6236 PR-1: the per-ifindex `interface_filter_affects_tx_selection`
+    // helper and its dead `iface_filter_v*_affects_tx_selection` sets are
+    // removed. The retained family-wide aggregate carries the same fact: an
+    // inet input filter affects TX selection (v4), none does for inet6.
     assert!(filter_state_has_input_tx_selection(&state, false));
     assert!(!filter_state_has_input_tx_selection(&state, true));
 
@@ -3659,7 +3688,7 @@ fn thin_accessor_predicates() {
     assert!(!interface_output_filter_has_dscp_match(&state, 23, true));
     // No filter bound to an unrelated ifindex.
     assert!(!interface_input_filter_has_dscp_match(&state, 99, false));
-    assert!(!interface_filter_affects_tx_selection(&state, 99, false));
+    assert!(!state.iface_filter_v4_fast.contains_key(&99));
 }
 
 // --- Gap 9: cached-vs-runtime baseline parity for a plain (no-policer) term ---


### PR DESCRIPTION
## PR-1 of 2 — advances #6236, does NOT close it

This is the first of two PRs in the #6236 plan (`docs/research/6236-filterstate-typed-hooks/plan.md` §3a / §5 "Design A" / §10). A **validated, low-risk pure deletion** of eight `FilterState` fields with no production reader. **PR-2** — the input property-set → `Filter`-flag convergence plus the single-lookup call-site fold — stays in research and is intentionally out of scope here.

### What is deleted (all grep-proven dead against `origin/master`)

| Field | Kind | Prod readers |
|---|---|---|
| `iface_filter_v4`, `iface_filter_v6`, `iface_filter_out_v4`, `iface_filter_out_v6` | name maps `FxHashMap<i32,String>` | 0 (test-only) |
| `iface_filter_v4_affects_tx_selection`, `iface_filter_v6_affects_tx_selection` | input property sets | 0 — read only by the test-only helper `interface_filter_affects_tx_selection` (also deleted) |
| `lo0_filter_v4`, `lo0_filter_v6` | qualified-key `String`s | compiler intermediates only — lifted to locals |

**Net: 31 → 23 fields. Measured `size_of::<FilterState>` 736 → 496 bytes** (−240; a clone-cost + clarity win, not a per-packet cache-line change — there is one `FilterState`, cloned on snapshot swap).

### Retained / untouched (PR-2 scope)
- The six `_fast` maps + two lo0 `_fast` Options (the actual hook records).
- The **live** output `iface_filter_out_v{4,6}_needs_tx_eval` sets (consumed by `tx_selection_enabled_v*` — deleting them would fail-open).
- The six live input property sets (`_affects_route_lookup`, `_has_dscp_match`, `_has_per_packet_l4_match`).
- All six aggregate booleans (`has_input_tx_selection_*`, `has_output_tx_selection_*`, `has_input_three_color_policer_*`).

### Invariants preserved
- **#3296 `MissingFilterRef` fail-closed guards are byte-for-byte unchanged** — deleting a name-map `.insert` never touched the `filters.get()` presence check that precedes it. The retained `has_input_tx_selection_*` aggregate writes are preserved. `filter/README.md` §#3296 documents the removal.

### Validation
- `cargo build --release` green (exit 0).
- `cargo clippy --release --all-targets`: **zero new `filter/` findings**. The sole error is a **pre-existing** deny-by-default `mut_from_ref` in the untouched `afxdp/umem/mmap.rs:150` (`slice_mut_unchecked` is byte-identical on `origin/master`; no toolchain pin, clippy 1.96.0). Plain-build warning count drops **176 → 175** (one fewer — the deleted re-export).
- Full `cargo test --release -- --test-threads=1` GREEN from the crate root (disk target, `TMPDIR=/tmp`): **4219 passed, 0 failed, 2 ignored**, real cargo exit 0.
- **Behavior-preservation proof**: (a) independent grep on `origin/master` — each of the 8 fields has zero production readers; (b) full suite green with the tx_selection helper's test callers rewritten against the retained `filter_state_has_input_tx_selection` aggregate.
- **Fail-on-revert**: neutralizing the kept `state.has_input_tx_selection_v4 = true;` compiler line drives both `parse_filter_state_prequalifies_interface_and_lo0_filter_keys` and `thin_accessor_predicates` RED (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)