### PR TITLE
test/xsk-repro: two LOW robustness follow-ups — umem-fail leak + link-probe SKIP gate (#6289)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57304,3 +57304,36 @@ top.
   - **File(s)**: userspace-dp/src/filter/engine/cache_sensitive.rs,
     userspace-dp/src/filter/engine/cache_sensitive/rotation.rs (new),
     userspace-dp/src/filter/README.md
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6289 — two LOW robustness follow-ups in test/xsk-repro (from the
+    #4906 xsk-repro safety cohort hostile review). Neither is a firewall clobber
+    nor a false-PASS; both are error-path/robustness hardening on root-only
+    AF_XDP diagnostic tooling.
+    M1 (umem/alloc-failure leaked our attached XDP program): in
+    libbpf_xsk_shared_test.c, after load_xdp attached xdp_pass_redirect to the
+    owner (and any distinct secondary) interface, an unchecked aligned_alloc
+    NULL or an xsk_umem__create failure did `return 1` WITHOUT reaching the
+    detach — leaking our program (only possible on a non-firewall iface; a
+    firewall iface EBUSY's in load_xdp). Factored the detach into a shared
+    detach_ours() helper; the aligned_alloc-NULL and xsk_umem__create-failure
+    paths now call it (and free the UMEM area) before returning, and the normal
+    exit calls the same helper. Gate: -Wall -Wextra -Werror build keeps the
+    refactor clean; the leak path is only reachable via a real AF_XDP/allocator
+    failure so it is verified manually (documented in README, not a fabricated
+    unit test).
+    M2 (selftest-compile.sh SKIP gate probed headers but not static libs): the
+    gate probed only header syntax (-fsyntax-only) but `make check` links static
+    archives (-Wl,-Bstatic -lxdp -lbpf -lelf -lz -lzstd). A headers-present /
+    static-archive-missing host passed the SKIP gate then FAILed the link →
+    false-RED. Gate now probes a trial LINK with the same static-archive flags
+    and honors $CC like the Makefile. Fail-on-revert gate:
+    selftest-skipgate_6289.sh — hermetic (fake cc: headers-present /
+    static-missing), asserts the script SKIPs (exit 77) via the link probe;
+    reverting the probe to -fsyntax-only makes the script reach `make check` and
+    exit 1 → gate RED (verified both directions). Registered under `make
+    selftest` (run-selftests.sh); full selftest suite 44 passed / 0 failed.
+- **File(s)**: test/xsk-repro/libbpf_xsk_shared_test.c,
+    test/xsk-repro/selftest-compile.sh,
+    test/xsk-repro/selftest-skipgate_6289.sh (new),
+    test/xsk-repro/README.md, scripts/run-selftests.sh

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -148,6 +148,10 @@ run_shell scripts/dist/selftest.sh
 # (HC-081 uninitialized-counter false PASS). SKIPs on a host without a C
 # toolchain / libbpf-dev / libxdp-dev / xxd.
 run_shell test/xsk-repro/selftest-compile.sh
+# #6289 M2: the selftest-compile.sh SKIP gate must probe a trial LINK (static
+# archives), not just header syntax, so a headers-present/static-missing host
+# SKIPs cleanly instead of false-RED. Hermetic (fake cc); SKIPs without make/xxd.
+run_shell test/xsk-repro/selftest-skipgate_6289.sh
 
 # ── summary ──
 printf '\n\033[1m== selftest summary ==\033[0m\n'

--- a/test/xsk-repro/README.md
+++ b/test/xsk-repro/README.md
@@ -93,3 +93,40 @@ safety/false-result defects (Codex review 175, C175-HC-001/025/069/081/090/091/
   PASS reflected only the owner. The secondary now has its own (disjoint) UMEM
   frames primed, is polled and recycled, and its receive count is folded into
   PASS/FAIL; a distinct secondary interface also gets the redirect program.
+
+### Robustness follow-ups (#6289)
+
+Two LOW robustness follow-ups from the #4906 hostile review (neither a
+firewall-clobber nor a false-PASS — the safety-critical properties above all
+hold):
+
+- **M1 — umem/alloc-failure path leaked our attached XDP program.** In
+  `libbpf_xsk_shared_test.c`, after `load_xdp` attached our
+  `xdp_pass_redirect` to the owner (and, for a distinct secondary interface,
+  the secondary), an `aligned_alloc` NULL (previously unchecked) or an
+  `xsk_umem__create` failure did `return 1` WITHOUT reaching the detach —
+  leaving our program attached. (Not a firewall clobber: attach only succeeds
+  on an EMPTY hook via `UPDATE_IF_NOEXIST`, so a firewall interface would have
+  already `EBUSY`'d in `load_xdp`; the leak was only possible on a non-firewall
+  interface.) The detach is now factored into `detach_ours()` and the
+  `aligned_alloc` NULL and `xsk_umem__create` failure paths both call it (and
+  free the UMEM area) before returning. **Gate:** the `-Wall -Wextra -Werror`
+  build (`make check` / `selftest-compile.sh`) keeps the refactor clean; the
+  leak path itself is only reachable via a real AF_XDP / allocator failure, so
+  it is verified manually — run the shared test against a non-firewall
+  interface with an artificially failing UMEM (e.g. an over-large `NUM_FRAMES`
+  so `xsk_umem__create` fails) and confirm `bpftool net` shows no leftover
+  `xdp_pass_redirect` on the interface afterward.
+- **M2 — `selftest-compile.sh` SKIP gate probed headers but not static libs.**
+  The gate probed only header syntax (`-fsyntax-only` on `<bpf/bpf.h>` /
+  `<xdp/xsk.h>`) but `make check` links against static archives
+  (`-Wl,-Bstatic -lxdp -lbpf -lelf -lz -lzstd`). A host with dev HEADERS but a
+  MISSING static archive (e.g. no `libzstd.a`) passed the SKIP gate then FAILed
+  the link → a false-RED for this leg. The gate now probes a trial LINK with
+  the same static-archive flags (and honors `$CC` like the Makefile), so such a
+  host SKIPs cleanly. **Gate:** `selftest-skipgate_6289.sh` — a hermetic
+  fail-on-revert test that points `selftest-compile.sh` at a fake compiler
+  modelling exactly that host (headers present, static archive missing) and
+  asserts the script SKIPs (exit 77) via the link probe; reverting the fix
+  (probe back to `-fsyntax-only`) makes the script reach `make check` and exit
+  1 instead → the gate goes RED. Registered under `make selftest`.

--- a/test/xsk-repro/libbpf_xsk_shared_test.c
+++ b/test/xsk-repro/libbpf_xsk_shared_test.c
@@ -84,6 +84,24 @@ static int load_xdp(int ifindex, int *map_fd_out)
 }
 
 /*
+ * #4906 HC-101 / #6289 M1: detach only our own program, and only if it is still
+ * ours, on both interfaces we attached to. XDP_FLAGS_REPLACE + old_prog_fd makes
+ * the kernel refuse if something else now owns the hook. Shared by the normal
+ * exit path AND the early umem/alloc-failure exits so a failed setup never leaks
+ * our attached program on the owner (and possibly secondary) interface.
+ */
+static void detach_ours(int ifindex, int sec_ifindex, int sec_attached,
+                        int prog_fd)
+{
+    LIBBPF_OPTS(bpf_xdp_attach_opts, dopts, .old_prog_fd = prog_fd);
+    if (bpf_xdp_detach(ifindex, XDP_FLAGS_REPLACE, &dopts))
+        fprintf(stderr, "  owner XDP detach skipped/failed — hook not ours\n");
+    if (sec_attached &&
+        bpf_xdp_detach(sec_ifindex, XDP_FLAGS_REPLACE, &dopts))
+        fprintf(stderr, "  secondary XDP detach skipped/failed — hook not ours\n");
+}
+
+/*
  * #4906 HC-069: drain up to BATCH_SIZE descriptors from an RX ring, count them,
  * and recycle the chunk-aligned frame bases back to `fill`. The previous code
  * released the RX descriptors BEFORE reading them and used xsk_ring_cons__comp_addr
@@ -355,6 +373,15 @@ int main(int argc, char **argv)
 
     /* Create UMEM */
     void *umem_area = aligned_alloc(getpagesize(), NUM_FRAMES * FRAME_SIZE);
+    /* #6289 M1: aligned_alloc() can return NULL. An unchecked NULL flows into
+     * xsk_umem__create below and, on its failure, the old code did `return 1`
+     * WITHOUT reaching the detach — leaking OUR program on the owner (and any
+     * secondary) interface. Detach before exiting. */
+    if (!umem_area) {
+        fprintf(stderr, "umem_area alloc failed\n");
+        detach_ours(ifindex, sec_ifindex, sec_attached, prog_fd);
+        return 1;
+    }
     struct xsk_ring_prod umem_fill;
     struct xsk_ring_cons umem_comp;
     struct xsk_umem *umem;
@@ -367,7 +394,11 @@ int main(int argc, char **argv)
     if (xsk_umem__create(&umem, umem_area,
                           (unsigned long long)NUM_FRAMES * FRAME_SIZE,
                           &umem_fill, &umem_comp, &ucfg)) {
+        /* #6289 M1: detach our program (and free the UMEM area) before exiting
+         * so the umem-failure path does not leak it on the interface(s). */
         fprintf(stderr, "umem create failed\n");
+        free(umem_area);
+        detach_ours(ifindex, sec_ifindex, sec_attached, prog_fd);
         return 1;
     }
     printf("umem created\n");
@@ -401,15 +432,10 @@ int main(int argc, char **argv)
         waitpid(child, NULL, 0);
     }
 
-    /* #4906 HC-101: detach only our own program, and only if still ours, on
-     * both interfaces we attached to. XDP_FLAGS_REPLACE + old_prog_fd makes the
-     * kernel refuse if something else now owns the hook. */
-    LIBBPF_OPTS(bpf_xdp_attach_opts, dopts, .old_prog_fd = prog_fd);
-    if (bpf_xdp_detach(ifindex, XDP_FLAGS_REPLACE, &dopts))
-        fprintf(stderr, "  owner XDP detach skipped/failed — hook not ours\n");
-    if (sec_attached &&
-        bpf_xdp_detach(sec_ifindex, XDP_FLAGS_REPLACE, &dopts))
-        fprintf(stderr, "  secondary XDP detach skipped/failed — hook not ours\n");
+    /* #4906 HC-101 / #6289 M1: detach only our own program, and only if still
+     * ours, on both interfaces we attached to (see detach_ours — the same path
+     * the early umem/alloc-failure exits take). */
+    detach_ours(ifindex, sec_ifindex, sec_attached, prog_fd);
     xsk_umem__delete(umem);
     free(umem_area);
 

--- a/test/xsk-repro/selftest-compile.sh
+++ b/test/xsk-repro/selftest-compile.sh
@@ -16,23 +16,36 @@ set -u
 HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 cd "$HERE" || { echo "FATAL: cannot cd to $HERE" >&2; exit 1; }
 
+# Honor $CC (defaulting to cc) like the Makefile's `CC ?= cc`, so the SKIP
+# probe and `make check` use the SAME compiler/toolchain. The #6289 M2 gate
+# test drives this by pointing CC at a fake compiler.
+CC=${CC:-cc}
+
 # --- tool gate ---
-for tool in cc make xxd; do
+for tool in "$CC" make xxd; do
 	command -v "$tool" >/dev/null 2>&1 || {
 		echo "SKIP: $tool not installed"
 		exit 77
 	}
 done
-# Header gate: probe the two headers the reproducers include.
+# Link gate (#6289 M2): probe a trial LINK against the SAME static archives
+# `make check` links, not just header syntax. The static build recipe
+# (Makefile LIBS_SHARED) links `-Wl,-Bstatic -lxdp -lbpf -lelf -lz -lzstd`; a
+# host with the dev HEADERS present but a static archive MISSING (e.g. no
+# libzstd.a) passed the old header-only -fsyntax-only probe and then FAILed the
+# `make check` static link → a false-RED for this leg. Probing the actual link
+# makes such a host SKIP cleanly. -o /dev/null discards the trial binary.
 if ! printf '#include <bpf/bpf.h>\n#include <xdp/xsk.h>\nint main(void){return 0;}\n' \
-	| cc -x c -fsyntax-only - >/dev/null 2>&1; then
-	echo "SKIP: libbpf-dev / libxdp-dev headers not available"
+	| "$CC" -x c - -o /dev/null \
+		-Wl,-Bstatic -lxdp -lbpf -lelf -lz -lzstd -Wl,-Bdynamic -lpthread \
+		>/dev/null 2>&1; then
+	echo "SKIP: libbpf-dev / libxdp-dev headers or static archives not available"
 	exit 77
 fi
 
 # --- the actual gate: strict-warning build must succeed ---
 rc=0
-if out=$(make -s check 2>&1); then
+if out=$(make -s check CC="$CC" 2>&1); then
 	echo "PASS: xsk-repro strict-warning build"
 else
 	rc=1

--- a/test/xsk-repro/selftest-skipgate_6289.sh
+++ b/test/xsk-repro/selftest-skipgate_6289.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Fail-on-revert gate for #6289 M2: selftest-compile.sh must probe a trial LINK
+# (against the static archives `make check` links), NOT just header syntax, so a
+# host with dev HEADERS present but a static archive MISSING (e.g. no libzstd.a)
+# SKIPs cleanly instead of proceeding to `make check` and producing a false-RED.
+#
+# Method (hermetic — needs no real libbpf/libxdp): point selftest-compile.sh at
+# a FAKE compiler that models exactly that host —
+#   * `-fsyntax-only`   -> exit 0   (headers "present")
+#   * any real compile/link -> exit 1 (static archive "missing")
+# With the fix, the LINK probe runs the real compile/link and FAILs under the
+# fake cc, so the script SKIPs (exit 77) with the link-probe message BEFORE it
+# ever reaches `make check`.
+#
+# Revert direction (why this binds): revert the fix so the probe is
+# `-fsyntax-only` again — the fake cc exits 0 there ("headers present"), the
+# script proceeds to `make check`, and make invokes the fake cc for the real
+# build, which exits 1 -> `make check` FAILs -> the script exits 1 (FAIL), not
+# 77. The exit==77 assertion below then goes RED. That is the fail-on-revert.
+#
+# Tool-gated: SKIPs (exit 77) when make / xxd are unavailable, because the
+# script-under-test's own tool gate would then SKIP for a DIFFERENT reason and
+# this test could not attribute the SKIP to the link probe.
+set -u
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$HERE" || { echo "FATAL: cannot cd to $HERE" >&2; exit 1; }
+
+SUT="$HERE/selftest-compile.sh"
+[ -f "$SUT" ] || { echo "SKIP: selftest-compile.sh not present"; exit 77; }
+
+# The script-under-test's tool gate probes make + xxd before the link probe; if
+# either is missing it SKIPs for that reason and we cannot bind the link probe.
+for tool in make xxd; do
+	command -v "$tool" >/dev/null 2>&1 || {
+		echo "SKIP: $tool not installed (cannot reach the link probe)"
+		exit 77
+	}
+done
+
+WORK=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+# Fake compiler: headers present (syntax-only OK), static archive missing (any
+# real compile or link fails). Mirrors a host that passes a header-only probe
+# but fails the static link.
+cat > "$WORK/fakecc" <<'EOF'
+#!/bin/sh
+for a in "$@"; do
+	[ "$a" = "-fsyntax-only" ] && exit 0
+done
+echo "fakecc: cannot find -lzstd (static archive missing)" >&2
+exit 1
+EOF
+chmod +x "$WORK/fakecc"
+
+out=$(CC="$WORK/fakecc" sh "$SUT" 2>&1)
+rc=$?
+
+fail=0
+if [ "$rc" -ne 77 ]; then
+	echo "FAIL: expected SKIP (exit 77) from the link probe, got exit $rc" >&2
+	fail=1
+fi
+# Attribute the SKIP to the LINK probe (not the tool gate) via its message.
+if ! printf '%s\n' "$out" | grep -qi 'static archives not available'; then
+	echo "FAIL: SKIP did not come from the link probe (missing 'static archives" \
+	     "not available' message)" >&2
+	fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+	printf '%s\n' "$out" | sed 's/^/      /' >&2
+	echo "FAIL: #6289 M2 link-probe SKIP gate" >&2
+	exit 1
+fi
+
+echo "PASS: #6289 M2 link-probe SKIP gate (headers-present/static-missing -> SKIP)"
+exit 0


### PR DESCRIPTION
## Summary

Two non-blocking LOW robustness follow-ups from the #4906 xsk-repro safety
cohort hostile review (tracked in #6289). Neither is a firewall clobber nor a
false-PASS — the safety-critical properties of #4906 all still hold. Both are
error-path / robustness hardening on the root-only AF_XDP reproducer diagnostic
tooling in `test/xsk-repro`.

## M1 — shared-test umem/alloc-failure path leaked our attached XDP program

`libbpf_xsk_shared_test.c`: after `load_xdp()` attached our `xdp_pass_redirect`
to the owner interface (and, for a distinct secondary interface, the secondary),
an unchecked `aligned_alloc()` NULL or an `xsk_umem__create()` failure did
`return 1` **without** reaching the detach at the end of `main()` — leaving our
program attached.

- **Not a firewall clobber:** attach only succeeds on an EMPTY hook via
  `UPDATE_IF_NOEXIST`, so a firewall interface would already have `EBUSY`'d in
  `load_xdp()`; the leak was only possible on a non-firewall interface.
- **Fix:** the detach is factored into a shared `detach_ours()` helper. The
  `aligned_alloc`-NULL check and the `xsk_umem__create`-failure path both call it
  (freeing the UMEM area first) before returning; the normal exit calls the same
  helper.

## M2 — `selftest-compile.sh` SKIP gate probed headers but not static libs

The gate probed only header syntax (`-fsyntax-only` on `<bpf/bpf.h>` /
`<xdp/xsk.h>`), but `make check` links against static archives (Makefile
`LIBS_SHARED`: `-Wl,-Bstatic -lxdp -lbpf -lelf -lz -lzstd`). A host with the dev
HEADERS present but a static archive MISSING (e.g. no `libzstd.a`) passed the
SKIP gate then FAILed the link → a false-RED for this leg.

- **Fix:** the gate now probes a trial LINK with the same static-archive flags
  (and honors `$CC` like the Makefile's `CC ?= cc`), so such a host SKIPs cleanly.

## Regression gates

- **M1:** the `-Wall -Wextra -Werror` build (`make check` / `selftest-compile.sh`)
  keeps the `detach_ours` refactor clean. The leak path itself is only reachable
  via a real AF_XDP / allocator failure, so it is verified **manually**
  (documented in `test/xsk-repro/README.md`) rather than via a fabricated unit
  test that would not genuinely bind it.
- **M2:** `selftest-skipgate_6289.sh` — a **hermetic fail-on-revert** test that
  points `selftest-compile.sh` at a fake compiler modelling exactly the
  headers-present / static-archive-missing host (syntax-only OK, any real
  compile/link fails) and asserts the script SKIPs (exit 77) via the link probe.
  Reverting the fix (probe back to `-fsyntax-only`) makes the script reach
  `make check` and exit 1 instead → the gate goes RED. **Both directions
  verified.** Registered under `make selftest`.

## Validation

- `make check` strict-warning build: PASS
- Both xsk-repro selftest legs: PASS
- Full `make selftest` suite: **44 passed / 0 skipped / 0 failed** on a
  fully-provisioned host
- Fail-on-revert verified in both directions for M2 (fixed → SKIP 77; reverted →
  FAIL 1)

Test-tooling only — no HA / cluster / dataplane / control-plane code touched.

Closes #6289
