### PR TITLE
daemon: per-owner recover + fail-visible in host-auth closeout; log actual budget (#6184)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-22 — #6184: host-auth cancel closeout — per-owner panic recover + log actual budget
+
+- **Timestamp**: 2026-07-22 (fix/6184-host-auth-closeout-recover)
+- **Action**: Two LOW hardenings from the #6181/#5874 hostile review of the
+  cancelled-apply host-authorization closeout.
+  (1) Item 1 — per-owner defer/recover in `runHostAuthCloseoutOwners`: each
+  owner's goroutine now recovers a panic in its reconcile, logs it with the
+  owner id, and routes it through `done` as that owner's FAIL-VISIBLE error
+  (`host-auth closeout owner %q panicked: %v`) so `summarizeHostAuthCloseout`
+  joins it. Without it a single owner panic unwound its goroutine with no
+  recover and crashed the whole daemon-stop path, taking down the remaining
+  owners and the process — the opposite of the M35 fail-visible discipline.
+  `done` is buffered and fn's own send is skipped on panic, so the recover is
+  the sole send (no double-send).
+  (2) Item 2 — `summarizeHostAuthCloseout` now takes the wall-clock `budget`
+  and logs it in the "did not complete within budget" line instead of the
+  package global `hostAuthCloseoutBudget`; production still passes the global,
+  but a non-default (test/future) budget is now reported honestly. Threaded
+  the budget through the sole production caller and the three existing test
+  callers.
+- **Tests**: new `host_auth_closeout_6184_test.go` — fail-on-revert gates.
+  `TestHostAuthCloseoutRecoversPerOwnerPanic6184` (item 1): panic in the
+  middle owner; asserts batch does not crash, owners on both sides run, the
+  panicking owner is fail-visible + named in the join. RED-on-revert = the
+  removed-recover build stays clean (fmt/slog still used) but the owner panic
+  crashes `go test` (verified `panic: boom in owner closeout` → FAIL).
+  `TestHostAuthCloseoutLogsActualBudget6184` (item 2): captures slog records,
+  asserts the timed-out line logs budget=20ms (the passed budget), not the
+  30s global; RED-on-revert = clean assertion (`budget = 30s, want 20ms`).
+  Both 3x green, full `pkg/daemon` green under `-race`, gofmt + vet clean.
+  No design/state doc covers this closeout (contract lives in the
+  daemon_apply_hostauth.go doc-comments, updated here); control-plane
+  closeout, unit-provable — not HA / no smoke.
+- **File(s)**: pkg/daemon/daemon_apply_hostauth.go,
+  pkg/daemon/host_auth_closeout_6184_test.go (new),
+  pkg/daemon/host_auth_closeout_5874_test.go
+
 ## 2026-07-22 — #6241: typed worker-launch bundles (replace 38-arg positional worker_loop)
 
 - **Timestamp**: 2026-07-22 (refactor/6241-typed-launch-bundles)

--- a/pkg/daemon/daemon_apply_hostauth.go
+++ b/pkg/daemon/daemon_apply_hostauth.go
@@ -77,6 +77,15 @@ func (d *Daemon) hostAuthCloseoutOwners() []hostAuthOwner {
 // atomic durable write, so an abandoned owner leaves consistent partial state
 // that is HONESTLY reported timed-out (convergence unknown), the fail-visible
 // outcome M35 requires.
+//
+// Each owner's goroutine carries a defer/recover (#6184): a panic in one owner's
+// reconcile is recovered, logged with the owner id, and converted into that
+// owner's fail-visible reconcile error (routed through `done`, so the select
+// records it as o.err exactly like a returned error). Without the recover an
+// owner panic would unwind the goroutine and crash the whole daemon-stop path,
+// taking down the remaining owners and the process — the opposite of the M35
+// fail-VISIBLE, one-owner-at-a-time discipline. The recover keeps the batch and
+// the process alive and surfaces the panicking owner as a named failure.
 func runHostAuthCloseoutOwners(cfg *config.Config, budget time.Duration, owners []hostAuthOwner) []hostAuthOwnerOutcome {
 	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
@@ -90,7 +99,21 @@ func runHostAuthCloseoutOwners(cfg *config.Config, budget time.Duration, owners 
 			continue
 		}
 		done := make(chan error, 1)
-		go func(fn func(*config.Config) error) { done <- fn(cfg) }(o.fn)
+		go func(name string, fn func(*config.Config) error) {
+			// #6184: recover a panic in this owner's reconcile so it fails
+			// VISIBLE (recorded as this owner's error and joined by
+			// summarizeHostAuthCloseout) instead of crashing the daemon-stop
+			// path and skipping the remaining owners. `done` is buffered and
+			// fn's own send is skipped when it panics, so this is the sole send.
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("host-authorization cancel closeout: owner panicked",
+						"owner", name, "panic", r)
+					done <- fmt.Errorf("host-auth closeout owner %q panicked: %v", name, r)
+				}
+			}()
+			done <- fn(cfg)
+		}(o.name, o.fn)
 		select {
 		case err := <-done:
 			outcomes = append(outcomes, hostAuthOwnerOutcome{name: o.name, err: err})
@@ -107,13 +130,19 @@ func runHostAuthCloseoutOwners(cfg *config.Config, budget time.Duration, owners 
 // config within budget; a non-nil return names WHICH owners did not, and is
 // propagated by closeoutHostAuthOnCancel so the cancel fails visibly instead of
 // reporting clean over a silently-failed credential reconcile (#5874).
-func summarizeHostAuthCloseout(outcomes []hostAuthOwnerOutcome) error {
+//
+// budget is the wall-clock budget the outcomes were produced under — the value
+// actually passed to runHostAuthCloseoutOwners — so the timed-out log line
+// reports the REAL budget in effect, not the package global (#6184). Production
+// passes hostAuthCloseoutBudget; a test that shrinks the budget sees its own
+// value in the log instead of a misleading 30s.
+func summarizeHostAuthCloseout(outcomes []hostAuthOwnerOutcome, budget time.Duration) error {
 	var errs []error
 	for _, o := range outcomes {
 		switch {
 		case o.timedOut:
 			slog.Error("host-authorization cancel closeout: owner did not complete within budget",
-				"owner", o.name, "budget", hostAuthCloseoutBudget)
+				"owner", o.name, "budget", budget)
 			errs = append(errs, fmt.Errorf("host-auth closeout owner %q timed out", o.name))
 		case o.err != nil:
 			slog.Error("host-authorization cancel closeout: owner failed to reconcile",
@@ -131,7 +160,7 @@ func (d *Daemon) applyHostAuthorizationCloseout(cfg *config.Config) error {
 		return nil
 	}
 	outcomes := runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, d.hostAuthCloseoutOwners())
-	return summarizeHostAuthCloseout(outcomes)
+	return summarizeHostAuthCloseout(outcomes, hostAuthCloseoutBudget)
 }
 
 // closeoutHostAuthOnCancel wraps a post-promotion apply-abort error so a #2926

--- a/pkg/daemon/host_auth_closeout_5874_test.go
+++ b/pkg/daemon/host_auth_closeout_5874_test.go
@@ -53,7 +53,7 @@ func TestHostAuthCloseoutSurfacesReconcilerFailure(t *testing.T) {
 		{"root-auth", noopCloseoutOwner},
 	}
 
-	err := summarizeHostAuthCloseout(runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners))
+	err := summarizeHostAuthCloseout(runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners), hostAuthCloseoutBudget)
 	if err == nil {
 		t.Fatal("host-auth cancel closeout returned nil despite a sudoers reconcile failure — " +
 			"the credential-reconcile failure was DISCARDED (the #5874 bug)")
@@ -64,7 +64,7 @@ func TestHostAuthCloseoutSurfacesReconcilerFailure(t *testing.T) {
 
 	// Control: a writable sudoers dir → the same reconcile succeeds → clean.
 	sudoersDir = t.TempDir()
-	if err := summarizeHostAuthCloseout(runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners)); err != nil {
+	if err := summarizeHostAuthCloseout(runHostAuthCloseoutOwners(cfg, hostAuthCloseoutBudget, owners), hostAuthCloseoutBudget); err != nil {
 		t.Fatalf("closeout returned %v with all owners succeeding, want nil", err)
 	}
 }
@@ -118,7 +118,7 @@ func TestHostAuthCloseoutEnforcesBudget(t *testing.T) {
 	}
 
 	// The summary surfaces the timed-out owners as a joined, named error.
-	err := summarizeHostAuthCloseout(outcomes)
+	err := summarizeHostAuthCloseout(outcomes, 50*time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "wedged") || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("summary = %v, want it to name the timed-out wedged owner", err)
 	}

--- a/pkg/daemon/host_auth_closeout_6184_test.go
+++ b/pkg/daemon/host_auth_closeout_6184_test.go
@@ -1,0 +1,175 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestHostAuthCloseoutRecoversPerOwnerPanic6184 is the #6184 item-1 fail-on-
+// revert merge gate. Each host-auth closeout owner runs in its own goroutine;
+// before the fix a PANIC in one owner's reconcile unwound the goroutine with no
+// recover and crashed the whole daemon-stop path — taking down the process and
+// every remaining owner, the opposite of the M35 fail-VISIBLE discipline. The
+// per-owner defer/recover in runHostAuthCloseoutOwners recovers the panic, logs
+// it with the owner id, and records it as that owner's fail-visible reconcile
+// error so the batch and the process survive and the failure is surfaced.
+//
+// This asserts (a) the batch does NOT crash and the panic is surfaced in the
+// joined summary error, (b) the owners on BOTH sides of the panicking one still
+// run to completion, and (c) the panicking owner is FAIL-VISIBLE — a non-nil,
+// named err (not timed-out, not silently clean).
+//
+// Fail-on-revert: delete the defer/recover block in runHostAuthCloseoutOwners
+// and the owner's panic propagates out of its goroutine, aborting the `go test`
+// process (SIGABRT / exit 2) before these assertions run — the package goes RED.
+// It is NOT a build break: removing the block leaves no unused import (fmt and
+// slog remain used by summarizeHostAuthCloseout), so the RED is the genuine
+// crash the fix prevents, not a false compile red.
+func TestHostAuthCloseoutRecoversPerOwnerPanic6184(t *testing.T) {
+	beforeRan, afterRan := false, false
+	before := func(*config.Config) error { beforeRan = true; return nil }
+	panicky := func(*config.Config) error { panic("boom in owner closeout") }
+	after := func(*config.Config) error { afterRan = true; return nil }
+
+	owners := []hostAuthOwner{
+		{"before", before},
+		{"panicky", panicky},
+		{"after", after},
+	}
+
+	// Without the recover this call crashes the process instead of returning.
+	outcomes := runHostAuthCloseoutOwners(&config.Config{}, hostAuthCloseoutBudget, owners)
+
+	// (b) owners on both sides of the panic ran to completion.
+	if !beforeRan {
+		t.Error("owner before the panicking one did not run")
+	}
+	if !afterRan {
+		t.Error("owner after the panicking one did not run — a panic in one owner " +
+			"skipped the remaining owners (per-owner recover missing)")
+	}
+
+	got := map[string]hostAuthOwnerOutcome{}
+	for _, o := range outcomes {
+		got[o.name] = o
+	}
+
+	// (c) the panicking owner is fail-visible: non-nil err, not timed-out.
+	po, ok := got["panicky"]
+	if !ok {
+		t.Fatal("panicking owner has no recorded outcome")
+	}
+	if po.err == nil {
+		t.Error("panicking owner outcome has nil err — the panic was silently swallowed, not fail-visible")
+	}
+	if po.timedOut {
+		t.Error("panicking owner marked timedOut, want a fail-visible reconcile error")
+	}
+
+	// (a) the batch did not crash and the failure is surfaced, named, in the join.
+	err := summarizeHostAuthCloseout(outcomes, hostAuthCloseoutBudget)
+	if err == nil {
+		t.Fatal("summary returned nil despite a panicking owner — the panic failure was not surfaced")
+	}
+	if !strings.Contains(err.Error(), "panicky") || !strings.Contains(err.Error(), "panicked") {
+		t.Errorf("summary error %q does not name the panicking owner and its panic", err)
+	}
+
+	// The clean owners are not falsely marked failed by the neighbouring panic.
+	if got["before"].err != nil || got["before"].timedOut {
+		t.Errorf("clean owner 'before' outcome = %+v, want clean", got["before"])
+	}
+	if got["after"].err != nil || got["after"].timedOut {
+		t.Errorf("clean owner 'after' outcome = %+v, want clean", got["after"])
+	}
+}
+
+// budgetCaptureHandler is a minimal slog.Handler that records each emitted
+// record's message and attributes so a test can assert on a logged value
+// (here the "budget" duration attr) without depending on text formatting.
+type budgetCaptureHandler struct {
+	mu      *sync.Mutex
+	records *[]map[string]slog.Value
+}
+
+func (h budgetCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h budgetCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := map[string]slog.Value{"msg": slog.StringValue(r.Message)}
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value
+		return true
+	})
+	h.mu.Lock()
+	*h.records = append(*h.records, attrs)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h budgetCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h budgetCaptureHandler) WithGroup(string) slog.Handler      { return h }
+
+// TestHostAuthCloseoutLogsActualBudget6184 is the #6184 item-2 fail-on-revert
+// gate. summarizeHostAuthCloseout logged the package global hostAuthCloseoutBudget
+// (30s) in the "did not complete within budget" line rather than the budget the
+// outcomes were actually produced under, so a non-default budget (a shrunk test
+// budget, or any future non-30s production value) was reported misleadingly.
+// The budget is now threaded in and logged.
+//
+// This runs the closeout under an explicit 20ms budget with a wedged owner that
+// times out, captures the emitted slog records, and asserts the timed-out record
+// carries budget=20ms — the value passed in — not the 30s global.
+//
+// Fail-on-revert: change the log arg back to hostAuthCloseoutBudget and the
+// captured budget attr becomes 30s, failing the `got == wantBudget` assertion
+// (RED). A plain assertion, not a crash or build break.
+func TestHostAuthCloseoutLogsActualBudget6184(t *testing.T) {
+	var mu sync.Mutex
+	var recs []map[string]slog.Value
+	prev := slog.Default()
+	slog.SetDefault(slog.New(budgetCaptureHandler{mu: &mu, records: &recs}))
+	defer slog.SetDefault(prev)
+
+	const wantBudget = 20 * time.Millisecond
+	if wantBudget == hostAuthCloseoutBudget {
+		t.Fatalf("test budget %v must differ from the global %v to distinguish them",
+			wantBudget, hostAuthCloseoutBudget)
+	}
+
+	release := make(chan struct{})
+	defer close(release) // unblock the wedged goroutine on exit (no leak)
+	wedged := func(*config.Config) error { <-release; return nil }
+	owners := []hostAuthOwner{{"wedged", wedged}}
+
+	outcomes := runHostAuthCloseoutOwners(&config.Config{}, wantBudget, owners)
+	if err := summarizeHostAuthCloseout(outcomes, wantBudget); err == nil {
+		t.Fatal("summary returned nil, want the wedged owner reported timed-out")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var found bool
+	for _, rec := range recs {
+		if !strings.Contains(rec["msg"].String(), "did not complete within budget") {
+			continue
+		}
+		found = true
+		bv, ok := rec["budget"]
+		if !ok {
+			t.Fatal("timed-out log record has no budget attribute")
+		}
+		if got := bv.Duration(); got != wantBudget {
+			t.Errorf("timed-out log record budget = %v, want the actual budget %v "+
+				"(the global %v is logged instead — #6184 item 2)", got, wantBudget, hostAuthCloseoutBudget)
+		}
+	}
+	if !found {
+		t.Fatal("no 'did not complete within budget' record was emitted for the wedged owner")
+	}
+}


### PR DESCRIPTION
## Summary

Two LOW hardenings from the #6181/#5874 hostile review of the
cancelled-apply host-authorization closeout
(`pkg/daemon/daemon_apply_hostauth.go`). The closeout is correct and
merged; these align it with the M35 fail-visible discipline and fix a
misleading log value.

### Item 1 — per-owner defer/recover (hardening)

Each host-auth owner (two nft filters + five credential reconcilers)
runs in its own goroutine under a shared wall-clock budget. There was
**no per-owner recover**, so a panic in one owner's reconcile unwound
its goroutine with no interceptor and **crashed the entire daemon-stop
path** — taking down the remaining owners and the process. That is the
opposite of M35's intent (a failing owner is FAIL-VISIBLE, collected and
surfaced in the returned error, one owner at a time).

`runHostAuthCloseoutOwners` now wraps each owner's goroutine in a
`defer/recover` that logs the panic with the owner id and routes it
through the buffered `done` channel as that owner's reconcile error
(`host-auth closeout owner %q panicked: %v`). The `select` records it as
`o.err` exactly like a returned error, and `summarizeHostAuthCloseout`
joins it. `fn`'s own send is skipped when it panics, so the recover is
the sole send on `done` (no double-send). The batch and the process
survive; the panicking owner is surfaced as a named failure and the
owners on both sides still run to completion.

### Item 2 — log the actual budget, not the global (cosmetic/correctness)

`summarizeHostAuthCloseout` logged the package global
`hostAuthCloseoutBudget` (30s) in the "did not complete within budget"
line rather than the budget the outcomes were actually produced under.
Production always passes the global so it was harmless there, but any
non-default budget (a shrunk test budget, or a future non-30s production
value) was reported misleadingly. The budget is now a parameter and
logged directly; threaded through the sole production caller and the
three existing test callers.

## Tests (fail-on-revert merge gates, run under `-race`)

New `pkg/daemon/host_auth_closeout_6184_test.go`:

- **`TestHostAuthCloseoutRecoversPerOwnerPanic6184`** (item 1): a panic
  in the middle owner; asserts (a) the batch does not crash and the
  panic is surfaced in the joined summary, (b) the owners on both sides
  still run to completion, (c) the panicking owner is FAIL-VISIBLE (a
  non-nil, named `err`, not timed-out). **RED-on-revert**: removing the
  defer/recover still BUILDS clean (`fmt`/`slog` remain used by
  `summarizeHostAuthCloseout`, so not a false compile red) but the owner
  panic propagates out of its goroutine and aborts `go test` (verified
  `panic: boom in owner closeout` → FAIL) — the genuine crash the fix
  prevents.
- **`TestHostAuthCloseoutLogsActualBudget6184`** (item 2): captures slog
  records and asserts the timed-out line logs `budget=20ms` (the passed
  budget), not the 30s global. **RED-on-revert** is a clean assertion
  (`budget = 30s, want 20ms`).

## Validation

- Both named tests 3× green.
- Full `pkg/daemon` suite green under `-race` (`go test -race ./pkg/daemon/...`).
- gofmt + go vet clean.
- No design/state doc covers this closeout — its contract lives in the
  `daemon_apply_hostauth.go` doc-comments, updated here.
- Control-plane closeout, unit-provable; not HA / dataplane, so no cluster smoke.

Closes #6184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ
