### PR TITLE
daemon: fail closed on dataplane arm/attach failure at boot (#5275)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57374,3 +57374,23 @@ top.
     test/xsk-repro/selftest-compile.sh,
     test/xsk-repro/selftest-skipgate_6289.sh (new),
     test/xsk-repro/README.md, scripts/run-selftests.sh
+
+- **Timestamp**: 2026-07-22
+- **Action**: #5275 fail-closed on dataplane arm/attach failure. #1960/#1993
+    fail closed only on COMPILE failure; a successful compile + Start/
+    LoadUserspaceShim arm failure fell through to applyConfig and degraded the
+    node to a policy-free Linux router (ip_forward=1, FRR advertising,
+    VRRP/VIP/cluster ownership). Added sticky d.dataplaneArmFailed flag +
+    enterDataplaneArmFailedFailClosed handler (disableForwarding, clear FRR
+    managed section, cluster SetArmFailedHold, VRRP teardown), wired at BOTH arm
+    sites (boot + bootstrap-exit), and gated applyKernelTuning / applyFRRConfig /
+    VRRP publish + periodic reconcile on the flag. New cluster armFailedHold
+    election hold. Fail-on-revert unit tests (daemon + cluster), all verified RED
+    on gate revert. README fail-closed section updated.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/bootstrap.go,
+    pkg/daemon/daemon_run_bringup.go, pkg/daemon/daemon_run_naming.go,
+    pkg/daemon/daemon_ha.go, pkg/daemon/daemon_apply_tail.go,
+    pkg/daemon/daemon_system.go, pkg/daemon/daemon_apply_routing.go,
+    pkg/daemon/dataplane_arm_failclosed_5275_test.go, pkg/daemon/README.md,
+    pkg/cluster/manager.go, pkg/cluster/election.go,
+    pkg/cluster/arm_failed_hold.go, pkg/cluster/arm_failed_hold_test.go

--- a/pkg/cluster/arm_failed_hold.go
+++ b/pkg/cluster/arm_failed_hold.go
@@ -1,0 +1,40 @@
+package cluster
+
+// SetArmFailedHold holds this node SECONDARY unconditionally after a dataplane
+// arm/attach failure (#5275). #1960/#1993 fail closed only on a COMPILE failure;
+// a successful compile followed by a Start/LoadUserspaceShim failure leaves the
+// node with no policy-enforcement dataplane, so it must never become primary /
+// own the redundancy groups — the healthy peer owns them.
+//
+// It both BLOCKS future promotions (the election gate checks armFailedHold, like
+// kernelUpgradeHold) and DEMOTES any RG already primary, so the hold is correct
+// regardless of call ordering: the daemon sets it AFTER cluster.Start() may have
+// already run an isolated single-node election that claimed primary (arm failure
+// is only known once setupDataplaneAndInitialConfig / the bootstrap-exit arm has
+// run, which is after cluster.Start()). Mirrors SetKernelUpgradeHold. Idempotent.
+//
+// There is deliberately no runtime clear: d.dp is never rebuilt at runtime, so
+// recovery from an arm failure is a daemon restart (a fresh boot re-attempts the
+// arm and only leaves this hold unset when the dataplane genuinely armed).
+func (m *Manager) SetArmFailedHold() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.armFailedHold = true
+	// Demote any group that is already primary (defense in depth for call
+	// ordering, exactly like SetKernelUpgradeHold). Idempotent: a no-op when
+	// nothing is primary.
+	for _, rg := range m.groups {
+		if rg.State == StatePrimary {
+			rg.State = StateSecondary
+			m.sendEvent(rg.GroupID, StatePrimary, StateSecondary, "dataplane arm-failed hold armed")
+		}
+	}
+}
+
+// ArmFailedHeld reports whether the #5275 dataplane-arm-failed election hold is
+// set. Used by tests and any reconcile that must know the node is fail-closed.
+func (m *Manager) ArmFailedHeld() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.armFailedHold
+}

--- a/pkg/cluster/arm_failed_hold_test.go
+++ b/pkg/cluster/arm_failed_hold_test.go
@@ -1,0 +1,65 @@
+package cluster
+
+import "testing"
+
+// TestElection_ArmFailedHold_IsolatedStaysSecondary is the #5275 cluster gate:
+// a node whose dataplane failed to ARM at boot must never own the RGs, even
+// ISOLATED (no peer) where a normal node auto-promotes to primary via the
+// single-node election. It has no policy-enforcement forwarding, so the healthy
+// peer must own the redundancy groups.
+//
+// FAIL-ON-REVERT: delete the `|| m.armFailedHold` clause from BOTH election
+// gates (electRG + electSingleNode) in election.go and this goes RED — the
+// isolated node wins the single-node election and IsLocalPrimary reports true.
+func TestElection_ArmFailedHold_IsolatedStaysSecondary(t *testing.T) {
+	m := NewManager(0, 1)
+	m.SetArmFailedHold() // dataplane arm failed at boot
+	if !m.ArmFailedHeld() {
+		t.Fatal("SetArmFailedHold must make ArmFailedHeld report true")
+	}
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+
+	// An ordinary isolated node would win the single-node election and be
+	// primary. The hold must keep it secondary even with no peer in sight.
+	if m.IsLocalPrimary(0) {
+		t.Fatal("arm-failed hold must keep an isolated node SECONDARY (it cannot forward)")
+	}
+
+	// A peer timeout re-runs election; the hold must still keep us secondary
+	// (it is NOT auto-cleared the way ManualFailover is for an isolated node —
+	// recovery from an arm failure is a daemon restart, not a runtime clear).
+	m.handlePeerTimeout()
+	if m.IsLocalPrimary(0) {
+		t.Fatal("arm-failed hold must survive a re-election (no runtime auto-clear)")
+	}
+}
+
+// TestElection_ArmFailedHold_DemotesAlreadyPrimary covers the call-ordering
+// case the daemon actually hits: cluster.Start() runs an isolated single-node
+// election and claims primary BEFORE the arm result is known (the arm happens
+// after cluster.Start() in setupDataplaneAndInitialConfig). SetArmFailedHold
+// must DEMOTE the already-primary group, not merely block future promotions.
+//
+// FAIL-ON-REVERT: delete the demotion loop in SetArmFailedHold and this goes
+// RED — the group set primary before the hold stays primary.
+func TestElection_ArmFailedHold_DemotesAlreadyPrimary(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	// Isolated node — wins the single-node election and is primary.
+	if !m.IsLocalPrimary(0) {
+		t.Fatal("precondition: isolated node should be primary before the hold")
+	}
+	drainEvents(m, 4)
+
+	m.SetArmFailedHold()
+	if m.IsLocalPrimary(0) {
+		t.Fatal("SetArmFailedHold must DEMOTE an already-primary group")
+	}
+	// And it must stay secondary across a re-election.
+	m.handlePeerTimeout()
+	if m.IsLocalPrimary(0) {
+		t.Fatal("held node must stay secondary after re-election")
+	}
+}

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -48,7 +48,11 @@ func (m *Manager) electRG(rg *RedundancyGroupState, peerGroup *PeerGroupState) (
 	// candidate with a broken dataplane must NEVER become primary even if it
 	// can't see the peer, or it would blackhole traffic (r2 AGY Critical). It is
 	// cleared only by promote/rejoin/revert (KernelUpgradeHoldClear).
-	if m.kernelUpgradeHold {
+	//
+	// #5275: armFailedHold is the same "hold SECONDARY unconditionally" gate for a
+	// boot whose dataplane failed to arm — a node with no policy-enforcement
+	// forwarding must never win election / own the RGs.
+	if m.kernelUpgradeHold || m.armFailedHold {
 		return electNoChange, ""
 	}
 
@@ -409,7 +413,11 @@ func (m *Manager) electSingleNode() {
 	// The hold is NOT auto-cleared (unlike ManualFailover), so an isolated
 	// candidate with a broken dataplane never claims primary. Cleared only by
 	// promote/rejoin/revert.
-	if m.kernelUpgradeHold {
+	//
+	// #5275: armFailedHold holds SECONDARY for the same reason on a boot whose
+	// dataplane failed to arm — the isolated single-node path is exactly where a
+	// broken node would otherwise auto-promote with no peer to hold it back.
+	if m.kernelUpgradeHold || m.armFailedHold {
 		return
 	}
 	for _, rg := range m.groups {

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -126,6 +126,16 @@ type Manager struct {
 	// Start() on a candidate boot; cleared by promote/rejoin/revert.
 	kernelUpgradeHold bool
 
+	// armFailedHold, when set, unconditionally holds this node SECONDARY in
+	// election (#5275): a boot whose dataplane failed to ARM (Start/attach) has
+	// NO policy-enforcement forwarding, so it must never become primary / own the
+	// RGs — the healthy peer owns them. Like kernelUpgradeHold (and unlike
+	// ManualFailover) it is NOT auto-cleared for an isolated node, so a broken
+	// node that cannot see the peer still cannot claim primary and blackhole
+	// traffic. There is no runtime clear: d.dp is never rebuilt at runtime, so
+	// recovery is a daemon restart. See SetArmFailedHold.
+	armFailedHold bool
+
 	// Peer state tracking (heartbeat).
 	peerAlive    bool
 	peerEverSeen bool // true once first heartbeat received; distinguishes "never heard" from "lost"

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -511,6 +511,52 @@ never lock an operator out of a remote box it manages.
       drop (peer hold-down then carries transit on the partner). A unit-ordering
       change (`xpfd` clears FRR before FRR forms peerings) would shrink the
       window further but is a separable follow-up, not required for the Go fix.
+- **Fail-closed on dataplane ARM failure (#5275, mirroring the #1960/#1993
+  compile-failure contract onto the arm path):** #1960/#1993 fail closed ONLY on
+  a COMPILE failure. A SUCCESSFUL compile followed by a dataplane arm/attach
+  failure (`d.dp.Start()` / `LoadUserspaceShim`) bypassed that gate: the code set
+  `d.dp = nil`, logged "config-only mode", and FELL THROUGH to `applyConfig`,
+  which enabled transit forwarding (`enableForwarding` in `initManagers`, re-armed
+  by `applyKernelTuning`'s `ip_forward=1` at the apply tail), published the FRR
+  managed section, and took VRRP/VIP/cluster ownership. A cold boot with a valid
+  persisted config whose AF_XDP attach failed therefore came up as a **plain
+  Linux router enforcing ZERO security policy** while still routing and
+  advertising. There are TWO arm sites with this shape: the boot arm
+  (`armBuiltDataplaneAndApplyBootConfig`, split out of
+  `setupDataplaneAndInitialConfig`) and the bootstrap-exit arm
+  (`runBootstrapExitStartup`).
+  - **The sticky `d.dataplaneArmFailed` atomic** is set at either arm site (via
+    `enterDataplaneArmFailedFailClosed`) and gates every config-driven ownership
+    publish so no later apply/reconcile re-opens the hole: `applyKernelTuning`
+    does not re-enable `ip_forward` (the enable is factored into the
+    `enableTransitForwardingSysctls` seam), `applyRoutingRules` skips the
+    `applyFRRConfig` publish, and both the VRRP tail (`applyTailReconciles`) and
+    the periodic `reconcileVRRPInstances` keep the desired VRRP set EMPTY. `d.dp`
+    is never rebuilt at runtime, so recovery is a **daemon restart** (a fresh boot
+    re-attempts the arm); a commit while arm-failed stays fail-closed.
+  - **`enterDataplaneArmFailedFailClosed` immediate actions:** `disableForwarding`
+    (clears ONLY the two transit-forwarding sysctls — the mgmt-VRF `l3mdev`
+    knobs stay so SSH/console survive), `clearFRRManagedSectionOnFailClosedBoot`
+    ("dataplane-arm-failed" — shares the #1993 two-stage `failClosedBootShouldClearFRR`
+    live-forwarding probe, so a genuine hitless crash-survivor still forwarding
+    keeps advertising), `cluster.SetArmFailedHold()` (a new unconditional
+    SECONDARY election hold, mirroring `SetKernelUpgradeHold` — it BLOCKS future
+    promotions AND DEMOTES any RG already primary, since `cluster.Start()` may have
+    run an isolated single-node election before the arm result was known; covers
+    the no-reth-vrrp / direct-announce cluster mode where VIP ownership follows
+    cluster state), and `vrrpMgr.UpdateInstances(nil)` (tears down VRRP so the peer
+    masters the VIPs; covers RETH VRRP mode).
+  - **Management lifeline preserved (mirrors #1960):** the boot arm SKIPS
+    `applyConfig` (freeze in last-known-good networkd `.link`/`.network`), only the
+    transit-forwarding sysctls are cleared, and the console stays reachable — fail
+    closed means no TRANSIT forwarding + no route advertisement + no HA VIP
+    takeover, NOT a dead box. Tests: `dataplane_arm_failclosed_5275_test.go`
+    (boot-arm skips `applyConfig`; the handler's immediate actions; the
+    `applyKernelTuning` / `applyTailReconciles` VRRP / `applyRoutingRules` FRR
+    gates, each fail-on-revert) and `pkg/cluster/arm_failed_hold_test.go` (the
+    election hold keeps an isolated node SECONDARY and demotes an already-primary
+    RG). This touches VRRP/HA/forwarding, so a loss-cluster `make test-failover`
+    smoke gates the merge.
 - **Bootstrap mode** (`d.bootstrapMode` atomic): runs gRPC/REST/CLI normally
   but SUPPRESSES interface takeover ACTIONS — the full rename loop, host
   tunables, `enableForwarding`, dataplane arm (`dp.Start`), the boot-time

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -530,7 +530,23 @@ func (d *Daemon) runBootstrapTeardownSteps() []bootstrapTeardownStep {
 // re-attempts. Management reachability beats a perfectly-clean FRR reload, so
 // boot must proceed regardless.
 func (d *Daemon) clearFRRForFailClosedBoot(compileFailed bool) {
-	if !compileFailed || d.frr == nil {
+	if !compileFailed {
+		return
+	}
+	d.clearFRRManagedSectionOnFailClosedBoot("compile-failed")
+}
+
+// clearFRRManagedSectionOnFailClosedBoot strips the last-good xpf-managed FRR
+// section on a fail-closed boot, gated on the same two-stage live-forwarding
+// decision (failClosedBootShouldClearFRR) so a genuine hitless crash-survivor
+// still forwarding keeps advertising. It is shared by the two fail-closed
+// triggers: a COMPILE failure (#1993, reason "compile-failed") and a dataplane
+// arm/attach failure (#5275, reason "dataplane-arm-failed"). In both cases the
+// node has no live policy-enforcement dataplane, so advertising last-good
+// prefixes would route transit into a blackhole instead of the HA partner. The
+// `reason` is logged. A nil d.frr (NoDataplane / pre-manager) is a safe no-op.
+func (d *Daemon) clearFRRManagedSectionOnFailClosedBoot(reason string) {
+	if d.frr == nil {
 		return
 	}
 	if !d.failClosedBootShouldClearFRR() {
@@ -539,15 +555,59 @@ func (d *Daemon) clearFRRForFailClosedBoot(compileFailed bool) {
 	if err := d.frr.Clear(); err != nil {
 		// Includes ErrFRRReloadDegraded — log, do not abort boot.
 		slog.Warn("fail-closed boot: failed to clear FRR managed section; node may still "+
-			"advertise last-good routes to peers until the operator fixes the config and "+
-			"'commit confirmed'; if the managed section was already stripped on disk, a later "+
-			"FRR restart will still converge",
-			"err", err, "pin_dir", userspaceShimLinkPinDir)
+			"advertise last-good routes to peers until the operator fixes the condition; "+
+			"if the managed section was already stripped on disk, a later FRR restart will "+
+			"still converge",
+			"reason", reason, "err", err, "pin_dir", userspaceShimLinkPinDir)
 		return
 	}
-	slog.Warn("fail-closed boot: cleared FRR managed section so peers fail over to the HA " +
-		"partner instead of blackholing transit to this unarmed node. The first compilable " +
-		"'commit confirmed' re-installs the managed section.")
+	slog.Warn("fail-closed boot: cleared FRR managed section so peers fail over to the HA "+
+		"partner instead of blackholing transit to this unarmed node; the first commit that "+
+		"re-arms a policy-enforcement dataplane re-installs the managed section",
+		"reason", reason)
+}
+
+// enterDataplaneArmFailedFailClosed is the #5275 fail-closed handler for a
+// SUCCESSFUL compile whose dataplane failed to ARM (Start/LoadUserspaceShim).
+// #1960/#1993 fail closed ONLY on a compile failure; a compile-success +
+// arm-failure previously set d.dp=nil, logged "config-only mode", and FELL
+// THROUGH to applyConfig, degrading the node to a policy-free Linux router that
+// still enabled transit forwarding, advertised routes via FRR, and took
+// VRRP/VIP/cluster ownership. This mirrors the #1960 contract onto the
+// arm-failure path.
+//
+// Called from BOTH arm sites — the boot arm (setupDataplaneAndInitialConfig) and
+// the bootstrap-exit arm (runBootstrapExitStartup). It sets the sticky
+// d.dataplaneArmFailed flag (which gates every config-driven ownership publish so
+// no later apply re-opens the hole) and takes the immediate fail-closed actions:
+//
+//   - disable transit forwarding — manager-init already ran enableForwarding
+//     because a successful compile is NOT bootstrap, so ip_forward was set to 1;
+//     reverse it. Only the two forwarding sysctls are cleared, so the mgmt-VRF
+//     l3mdev / accept_local knobs stay intact and the mgmt/console lifeline is
+//     reachable.
+//   - strip the FRR managed section (route advertisement) via the #1993 seam.
+//   - hold the cluster SECONDARY so the healthy peer owns the RGs (covers the
+//     no-reth-vrrp / direct-announce cluster mode where VIP ownership follows
+//     cluster state, not VRRP).
+//   - tear down VRRP instances so this node stops advertising and the peer
+//     masters the VIPs (covers RETH VRRP mode).
+//
+// d.dp is never rebuilt at runtime, so recovery is a daemon restart; the flag
+// keeps a commit-while-arm-failed fail-closed rather than re-opening the hole.
+func (d *Daemon) enterDataplaneArmFailedFailClosed() {
+	d.dataplaneArmFailed.Store(true)
+	disableForwarding()
+	d.clearFRRManagedSectionOnFailClosedBoot("dataplane-arm-failed")
+	if d.cluster != nil {
+		d.cluster.SetArmFailedHold()
+	}
+	if d.vrrpMgr != nil {
+		if err := d.vrrpMgr.UpdateInstances(nil); err != nil {
+			slog.Warn("fail-closed (#5275): could not tear down VRRP instances after "+
+				"dataplane arm failure", "err", err)
+		}
+	}
 }
 
 // failClosedBootShouldClearFRR is the pure two-stage decision behind

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -889,6 +889,20 @@ type Daemon struct {
 	// every subsystem.
 	bootstrapMode atomic.Bool
 
+	// dataplaneArmFailed is the #5275 sticky fail-closed flag. It is set when a
+	// SUCCESSFUL config compile is followed by a dataplane arm/attach failure
+	// (Start/LoadUserspaceShim) — the case #1960/#1993 do NOT cover, since they
+	// fail closed only on a COMPILE failure. When set, the node has NO
+	// policy-enforcement dataplane, so every config-driven ownership publish must
+	// fail closed: applyKernelTuning must not re-enable transit forwarding,
+	// applyFRRConfig must not advertise routes, and the VRRP tail + periodic
+	// reconcileVRRPInstances must not (re-)create VRRP instances. Set once from
+	// enterDataplaneArmFailedFailClosed (at either arm site) and read on every
+	// apply/reconcile, so an atomic avoids a lock on the read path. d.dp is never
+	// rebuilt at runtime, so recovery is a daemon restart (a fresh boot
+	// re-attempts the arm); it is intentionally never cleared at runtime.
+	dataplaneArmFailed atomic.Bool
+
 	// emptyHANamingPending is the #4179 one-shot flag for the HA-guard
 	// EMPTY-config takeover. A node with /etc/xpf/node-id but no committed
 	// config resolves NOT-bootstrap (computeBootClass HA-node guard) and names

--- a/pkg/daemon/daemon_apply_routing.go
+++ b/pkg/daemon/daemon_apply_routing.go
@@ -207,7 +207,15 @@ func (d *Daemon) applyRoutingRules(cfg *config.Config, commitOverlay []config.Ro
 	// step 1.95, so an operator commit while a policy is FAILED
 	// preserves a still-valid injected failover route and drops
 	// removed/edited entries on the commit itself.
-	if d.frr != nil {
+	if d.frr != nil && d.dataplaneArmFailed.Load() {
+		// #5275: no policy-enforcement dataplane armed — do NOT advertise routes.
+		// The managed section was already stripped by
+		// enterDataplaneArmFailedFailClosed; publishing it again here (on a
+		// bootstrap-exit or recovery-commit apply) would route transit into a
+		// blackhole instead of the HA partner. Skip the publish entirely so the
+		// section stays cleared until a restart re-arms the dataplane.
+		slog.Warn("fail-closed (#5275): skipping FRR managed-section publish — dataplane not armed")
+	} else if d.frr != nil {
 		// The full apply path deliberately warns-and-continues on an FRR
 		// reload error (a transient FRR hiccup must not fail an
 		// otherwise-valid operator commit; the in-manager degraded-retry

--- a/pkg/daemon/daemon_apply_tail.go
+++ b/pkg/daemon/daemon_apply_tail.go
@@ -40,12 +40,20 @@ import (
 // preserves the explicit operand order
 // (#1778/#2987/#4433/#5083/#5310/#5679/#5696/#5700).
 func (d *Daemon) applyTailReconciles(cfg *config.Config, networkdErr, applyErr, dhcpServerErr, ipsecErr, ifaceErr, routeLeakErr, routingRuleErr, mgmtRouteErr, vrfErr error) error {
-	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
+	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances.
+	//
+	// #5275: suppress ALL VRRP ownership when the dataplane failed to arm — a
+	// policy-free node must not advertise VRRP or take VIPs. Leaving the desired
+	// set empty tears down / never re-creates any instances a continuing
+	// (bootstrap-exit) or recovery-commit apply would otherwise publish.
 	var vrrpErr error
-	vrrpInstances := vrrp.CollectInstances(cfg)
-	if d.cluster != nil {
-		localPri := d.cluster.LocalPriorities()
-		vrrpInstances = append(vrrpInstances, vrrp.CollectRethInstances(cfg, localPri)...)
+	var vrrpInstances []*vrrp.Instance
+	if !d.dataplaneArmFailed.Load() {
+		vrrpInstances = vrrp.CollectInstances(cfg)
+		if d.cluster != nil {
+			localPri := d.cluster.LocalPriorities()
+			vrrpInstances = append(vrrpInstances, vrrp.CollectRethInstances(cfg, localPri)...)
+		}
 	}
 	if err := d.vrrpMgr.UpdateInstances(vrrpInstances); err != nil {
 		slog.Warn("failed to update VRRP instances", "err", err)

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -655,6 +655,18 @@ func (d *Daemon) reconcileVRRPInstances() {
 	if d.vrrpMgr == nil || d.store == nil {
 		return
 	}
+	// #5275: with no policy-enforcement dataplane armed, this node must NOT own
+	// any VRRP VIPs (it cannot enforce policy). The periodic reconcile reads the
+	// still-non-nil ActiveConfig (a successful compile), so without this gate it
+	// would re-create the very instances enterDataplaneArmFailedFailClosed tore
+	// down. Keep the desired set EMPTY so the peer masters the VIPs. Sticky until
+	// a restart re-arms the dataplane.
+	if d.dataplaneArmFailed.Load() {
+		if err := d.vrrpMgr.UpdateInstances(nil); err != nil {
+			slog.Warn("fail-closed (#5275): reconcile could not tear down VRRP instances", "err", err)
+		}
+		return
+	}
 	cfg := d.store.ActiveConfig()
 	if cfg == nil {
 		return

--- a/pkg/daemon/daemon_run_bringup.go
+++ b/pkg/daemon/daemon_run_bringup.go
@@ -487,39 +487,7 @@ func (d *Daemon) setupDataplaneAndInitialConfig() error {
 		// arm it on the first confirmed commit (C1: construct always, arm
 		// only when not bootstrap). The control plane (gRPC/REST/CLI) is
 		// started later regardless.
-		if d.inBootstrap() {
-			slog.Info("bootstrap mode: dataplane arm and boot-time config apply suppressed")
-		} else {
-			if d.dp != nil {
-				if err := d.dp.Start(d.daemonCtx); err != nil {
-					slog.Warn("failed to start dataplane, running in config-only mode",
-						"err", err)
-					d.dp = nil
-				} else {
-					// natSeeder is satisfied by both *dataplane.Manager
-					// (legacy eBPF — SeedNATPortCounters in maps_nat.go,
-					// SeedSessionIDCounter in maps_session.go) and the userspace
-					// *LegacyDataPlaneAdapter (via embedded bpfShim). The
-					// seed methods are no-ops on the userspace fast path
-					// but harmless to invoke. The legacyDP() round-trip is
-					// no longer required (#1519).
-					if seeder, ok := d.dp.(natSeeder); ok {
-						seeder.SeedNATPortCounters()
-						nodeID := 0
-						if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
-							nodeID = cfg.Chassis.Cluster.NodeID
-						}
-						seeder.SeedSessionIDCounter(nodeID)
-					}
-				}
-			}
-			// Apply current config — needed even in config-only mode so that
-			// VRFs, interfaces, and routing are configured before cluster comms.
-			if cfg := d.store.ActiveConfig(); cfg != nil {
-				slog.Info("applying active configuration")
-				d.applyConfig(cfg)
-			}
-		}
+		d.armBuiltDataplaneAndApplyBootConfig()
 	}
 	// #1715: the boot-time DNS reconcile (inside the apply above) ran
 	// before DHCP clients start, so its empty-merge policy was
@@ -537,6 +505,68 @@ func (d *Daemon) setupDataplaneAndInitialConfig() error {
 		d.reconcileBlackholeRoutes()
 	}
 	return nil
+}
+
+// armBuiltDataplaneAndApplyBootConfig arms the already-built dataplane backend
+// (unless bootstrap suppresses it) and runs the boot-time applyConfig — UNLESS
+// the arm fails, in which case it FAILS CLOSED (#5275) instead of degrading to a
+// policy-free kernel router. Split out of setupDataplaneAndInitialConfig so the
+// arm→fail-closed decision is unit-tested with a fake backend whose Start()
+// fails, without a live AF_XDP attach (buildRuntimeDataPlane needs root/XDP).
+//
+// #1922 Item 2: in bootstrap mode do NOT arm (AF_XDP attach) and do NOT run the
+// boot-time applyConfig — the backend object stays constructed (d.dp != nil) so
+// the bootstrap-exit reconcile arms it on the first confirmed commit.
+func (d *Daemon) armBuiltDataplaneAndApplyBootConfig() {
+	if d.inBootstrap() {
+		slog.Info("bootstrap mode: dataplane arm and boot-time config apply suppressed")
+		return
+	}
+	armFailed := false
+	if d.dp != nil {
+		if err := d.dp.Start(d.daemonCtx); err != nil {
+			// #5275: a SUCCESSFUL compile whose dataplane did not arm must FAIL
+			// CLOSED exactly like the #1960 compile-failure boot — NOT degrade to
+			// a policy-free kernel router. The pre-#5275 code set d.dp=nil, logged
+			// "config-only mode", and FELL THROUGH to applyConfig, which enabled
+			// transit forwarding, published the FRR managed section, and took
+			// VRRP/VIP/cluster ownership on a node enforcing ZERO security policy.
+			slog.Error("failed to arm dataplane at boot; failing closed "+
+				"(no transit forwarding, no route advertisement, no HA/VIP takeover) "+
+				"until a policy-enforcement dataplane arms — management stays "+
+				"reachable for in-band recovery", "err", err)
+			d.dp = nil
+			armFailed = true
+		} else if seeder, ok := d.dp.(natSeeder); ok {
+			// natSeeder is satisfied by both *dataplane.Manager (legacy eBPF —
+			// SeedNATPortCounters in maps_nat.go, SeedSessionIDCounter in
+			// maps_session.go) and the userspace *LegacyDataPlaneAdapter (via
+			// embedded bpfShim). The seed methods are no-ops on the userspace fast
+			// path but harmless to invoke. The legacyDP() round-trip is no longer
+			// required (#1519).
+			seeder.SeedNATPortCounters()
+			nodeID := 0
+			if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Chassis.Cluster != nil {
+				nodeID = cfg.Chassis.Cluster.NodeID
+			}
+			seeder.SeedSessionIDCounter(nodeID)
+		}
+	}
+	if armFailed {
+		// #5275: fail closed and SKIP the boot applyConfig — no VRF/interface/
+		// routing/FRR/VRRP/cluster takeover is published. Management freezes in
+		// last-known-good networkd state (mirrors #1960). The sticky
+		// d.dataplaneArmFailed flag keeps every later apply/reconcile fail-closed.
+		d.enterDataplaneArmFailedFailClosed()
+		return
+	}
+	// Apply current config — needed even in config-only mode (a retired-backend
+	// build) so that VRFs, interfaces, and routing are configured before cluster
+	// comms.
+	if cfg := d.store.ActiveConfig(); cfg != nil {
+		slog.Info("applying active configuration")
+		d.applyConfig(cfg)
+	}
 }
 
 // isInteractive returns true if stdin is a real terminal (not /dev/null or a pipe).
@@ -567,4 +597,27 @@ func enableForwarding() {
 		}
 	}
 	slog.Info("IP forwarding enabled, RA acceptance disabled")
+}
+
+// writeForwardingSysctl applies a transit-forwarding sysctl (ip_forward / ipv6
+// forwarding). It is a package var so the #5275 fail-closed forwarding decision
+// (disableForwarding + the applyKernelTuning gate) is unit-testable without
+// touching /proc. Warns-and-continues on error, matching enableForwarding.
+var writeForwardingSysctl = func(path, val string) {
+	if err := os.WriteFile(path, []byte(val), 0644); err != nil {
+		slog.Warn("failed to set forwarding sysctl", "path", path, "err", err)
+	}
+}
+
+// disableForwarding is the #5275 fail-closed inverse of enableForwarding's
+// forwarding knobs: it clears ONLY the two transit-forwarding sysctls (IPv4
+// ip_forward and IPv6 all/forwarding) so the kernel does not route unpoliced
+// transit on a node with no policy-enforcement dataplane. It deliberately leaves
+// the management-plane sysctls (tcp/udp_l3mdev_accept for SSH on the mgmt VRF,
+// accept_ra=0, accept_local) untouched so the console/mgmt lifeline stays
+// reachable — fail closed means no TRANSIT forwarding, not a dead box.
+func disableForwarding() {
+	writeForwardingSysctl("/proc/sys/net/ipv4/ip_forward", "0\n")
+	writeForwardingSysctl("/proc/sys/net/ipv6/conf/all/forwarding", "0\n")
+	slog.Warn("transit IP forwarding disabled (fail-closed, #5275): dataplane not armed")
 }

--- a/pkg/daemon/daemon_run_naming.go
+++ b/pkg/daemon/daemon_run_naming.go
@@ -229,9 +229,20 @@ func (d *Daemon) runBootstrapExitStartup(cfg *config.Config) {
 	// constructed at boot (C1) but never started in bootstrap mode.
 	if d.dp != nil {
 		if err := d.dp.Start(d.daemonCtx); err != nil {
-			slog.Warn("bootstrap exit: failed to start dataplane, running in config-only mode",
+			// #5275: the bootstrap-exit arm has the SAME hole as the boot arm —
+			// a successful compile whose dataplane fails to attach must fail
+			// closed, not fall through and let applyConfigLocked's continuing
+			// reconcile enable forwarding + publish FRR/VRRP/cluster ownership on
+			// a policy-free node. The sticky flag set here gates every ownership
+			// publish in the reconcile that follows this call (applyKernelTuning
+			// forwarding, applyFRRConfig, the VRRP tail), so no ownership is
+			// taken; the immediate actions disable forwarding, clear FRR, hold
+			// the cluster SECONDARY, and tear down VRRP.
+			slog.Error("bootstrap exit: failed to arm dataplane; failing closed "+
+				"(no transit forwarding, no route advertisement, no HA/VIP takeover)",
 				"err", err)
 			d.dp = nil
+			d.enterDataplaneArmFailedFailClosed()
 		} else {
 			if seeder, ok := d.dp.(natSeeder); ok {
 				seeder.SeedNATPortCounters()

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -534,16 +534,34 @@ func (d *Daemon) applyKernelTuning(cfg *config.Config) {
 		}
 	}
 
-	// Enable IP forwarding (required for firewall operation)
+	// Enable IP forwarding (required for firewall operation) — UNLESS the
+	// dataplane failed to arm (#5275). A node with no policy-enforcement
+	// dataplane must not route unpoliced transit, so leave ip_forward at the
+	// fail-closed value that enterDataplaneArmFailedFailClosed set. This is the
+	// "applyKernelTuning re-writes ip_forward=1 at the apply tail" re-arm the
+	// issue calls out; the gate stops a continuing (bootstrap-exit) or
+	// recovery-commit apply from re-opening the hole.
+	if d.dataplaneArmFailed.Load() {
+		slog.Warn("fail-closed (#5275): not re-enabling ip_forward — dataplane not armed")
+		return
+	}
+	enableTransitForwardingSysctls()
+}
+
+// enableTransitForwardingSysctls sets the two transit-forwarding sysctls to 1
+// (idempotent — a write is skipped when the value is already 1). It is a package
+// var so the #5275 fail-closed gate in applyKernelTuning is unit-testable
+// (assert this is NOT invoked when the dataplane is unarmed) without depending on
+// the host's /proc/sys/net/ipv4/ip_forward, which on a firewall dev box is
+// already 1 and would mask the gate.
+var enableTransitForwardingSysctls = func() {
 	for _, path := range []string{
 		"/proc/sys/net/ipv4/ip_forward",
 		"/proc/sys/net/ipv6/conf/all/forwarding",
 	} {
 		current, _ := os.ReadFile(path)
 		if strings.TrimSpace(string(current)) != "1" {
-			if err := os.WriteFile(path, []byte("1\n"), 0644); err != nil {
-				slog.Warn("failed to enable forwarding", "path", path, "err", err)
-			}
+			writeForwardingSysctl(path, "1\n")
 		}
 	}
 }

--- a/pkg/daemon/dataplane_arm_failclosed_5275_test.go
+++ b/pkg/daemon/dataplane_arm_failclosed_5275_test.go
@@ -1,0 +1,283 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/frr"
+	"github.com/psaab/xpf/pkg/networkd"
+	"github.com/psaab/xpf/pkg/vrrp"
+	"golang.org/x/sync/semaphore"
+)
+
+// armFailTestDP is a runtime dataplane whose Start() (the AF_XDP arm /
+// LoadUserspaceShim attach) fails, to exercise the #5275 fail-closed path
+// without a live dataplane. Every other method is inherited from
+// runtimeOnlyApplyTestDP.
+type armFailTestDP struct {
+	runtimeOnlyApplyTestDP
+	startErr error
+}
+
+func (d *armFailTestDP) Start(context.Context) error { return d.startErr }
+
+// captureForwardingSysctls redirects writeForwardingSysctl into a map for the
+// duration of the test so the fail-closed forwarding decision is observable
+// without touching /proc.
+func captureForwardingSysctls(t *testing.T) map[string]string {
+	t.Helper()
+	got := make(map[string]string)
+	prev := writeForwardingSysctl
+	writeForwardingSysctl = func(path, val string) { got[path] = val }
+	t.Cleanup(func() { writeForwardingSysctl = prev })
+	return got
+}
+
+// TestEnterDataplaneArmFailedFailClosed_ImmediateActions_5275 pins the immediate
+// fail-closed actions the handler takes when a successful compile is followed by
+// a dataplane arm failure: the sticky flag is set, transit forwarding is
+// disabled (ip_forward=0), the FRR managed section is stripped, and the cluster
+// is held SECONDARY.
+//
+// FAIL-ON-REVERT: delete any one of the four actions in
+// enterDataplaneArmFailedFailClosed (bootstrap.go) and the matching assertion
+// below goes RED — e.g. dropping disableForwarding() leaves ip_forward unwritten,
+// dropping SetArmFailedHold() leaves ArmFailedHeld() false, dropping the
+// clearFRR call leaves the managed section on disk.
+func TestEnterDataplaneArmFailedFailClosed_ImmediateActions_5275(t *testing.T) {
+	fwd := captureForwardingSysctls(t)
+	// No pinned XDP links (cold boot) → FRR clear takes the stage-1 path.
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return false, nil })
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+
+	d := &Daemon{
+		frr:     frr.NewForTest(confPath, rec),
+		cluster: cluster.NewManager(0, 1),
+		vrrpMgr: vrrp.NewManager(),
+	}
+
+	d.enterDataplaneArmFailedFailClosed()
+
+	if !d.dataplaneArmFailed.Load() {
+		t.Fatal("enterDataplaneArmFailedFailClosed must set the sticky dataplaneArmFailed flag")
+	}
+	if got := fwd["/proc/sys/net/ipv4/ip_forward"]; strings.TrimSpace(got) != "0" {
+		t.Fatalf("transit forwarding must be DISABLED (ip_forward=0); got %q", got)
+	}
+	if got := fwd["/proc/sys/net/ipv6/conf/all/forwarding"]; strings.TrimSpace(got) != "0" {
+		t.Fatalf("IPv6 forwarding must be DISABLED; got %q", got)
+	}
+	if strings.Contains(readConf(t, confPath), sentinel) {
+		t.Fatalf("FRR managed section (route advertisement) must be stripped on arm failure; frr.conf still has %q", sentinel)
+	}
+	if !d.cluster.ArmFailedHeld() {
+		t.Fatal("cluster must be held SECONDARY (ArmFailedHeld) so the healthy peer owns the RGs")
+	}
+}
+
+// TestBootArmFailure_SkipsApplyConfig_5275 is the boot-arm wiring proof. When the
+// boot-time arm fails, armBuiltDataplaneAndApplyBootConfig must fail closed and
+// SKIP the boot applyConfig entirely — no VRF/interface/routing/FRR/VRRP/cluster
+// takeover is published on a policy-free node.
+//
+// FAIL-ON-REVERT: change the arm-failure branch back to the pre-#5275 behavior
+// (set d.dp=nil and fall through to applyConfig) and this goes RED — the
+// applyBodyForTest recorder is invoked and the flag is never set.
+func TestBootArmFailure_SkipsApplyConfig_5275(t *testing.T) {
+	captureForwardingSysctls(t) // swallow the disableForwarding writes
+
+	// A committed active config so the pre-#5275 fall-through WOULD reach
+	// applyConfig (ActiveConfig() != nil).
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, line := range []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
+		"set security zones security-zone trust interfaces ge-0/0/0.0",
+	} {
+		if err := store.SetFromInput(line); err != nil {
+			t.Fatalf("SetFromInput(%q): %v", line, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if store.ActiveConfig() == nil {
+		t.Fatal("precondition: committed store must expose a non-nil ActiveConfig")
+	}
+
+	applyCalled := false
+	d := &Daemon{
+		dp:       &armFailTestDP{startErr: errors.New("xsk bind: operation not permitted")},
+		store:    store,
+		applySem: semaphore.NewWeighted(1),
+	}
+	d.applyBodyForTest = func(*config.Config) { applyCalled = true }
+
+	d.armBuiltDataplaneAndApplyBootConfig()
+
+	if applyCalled {
+		t.Fatal("boot arm failure must SKIP applyConfig (no ownership publish); applyConfig was called")
+	}
+	if !d.dataplaneArmFailed.Load() {
+		t.Fatal("boot arm failure must set the sticky dataplaneArmFailed flag")
+	}
+	if d.dp != nil {
+		t.Fatal("boot arm failure must clear d.dp (config-only), got non-nil")
+	}
+}
+
+// withForwardingEnableProbe swaps the transit-forwarding-enable seam for a
+// recorder so the #5275 applyKernelTuning gate is testable without depending on
+// the host's /proc/sys/net/ipv4/ip_forward (already 1 on a firewall dev box).
+func withForwardingEnableProbe(t *testing.T) *bool {
+	t.Helper()
+	called := false
+	prev := enableTransitForwardingSysctls
+	enableTransitForwardingSysctls = func() { called = true }
+	t.Cleanup(func() { enableTransitForwardingSysctls = prev })
+	return &called
+}
+
+// TestApplyKernelTuning_ArmFailed_DoesNotReenableForwarding_5275 pins that the
+// apply-tail kernel tuning does NOT re-arm ip_forward=1 while the dataplane is
+// unarmed — the exact "applyKernelTuning re-writes ip_forward=1 at the apply
+// tail" re-arm the issue calls out, which a bootstrap-exit or recovery-commit
+// apply would otherwise hit.
+//
+// FAIL-ON-REVERT: delete the `if d.dataplaneArmFailed.Load() { ... return }`
+// gate in applyKernelTuning (daemon_system.go) and this goes RED — the
+// transit-forwarding-enable seam is invoked.
+func TestApplyKernelTuning_ArmFailed_DoesNotReenableForwarding_5275(t *testing.T) {
+	enabled := withForwardingEnableProbe(t)
+	d := &Daemon{}
+	d.dataplaneArmFailed.Store(true)
+
+	d.applyKernelTuning(&config.Config{})
+
+	if *enabled {
+		t.Fatal("fail-closed applyKernelTuning must NOT re-enable transit forwarding")
+	}
+}
+
+// TestApplyKernelTuning_Armed_ReenablesForwarding_5275 is the negative control:
+// with the flag UNSET, applyKernelTuning re-enables forwarding as before, so the
+// gate above is not a blanket disable.
+func TestApplyKernelTuning_Armed_ReenablesForwarding_5275(t *testing.T) {
+	enabled := withForwardingEnableProbe(t)
+	d := &Daemon{} // dataplaneArmFailed == false
+
+	d.applyKernelTuning(&config.Config{})
+
+	if !*enabled {
+		t.Fatal("armed applyKernelTuning must re-enable transit forwarding")
+	}
+}
+
+// TestApplyTailReconciles_ArmFailed_SuppressesVRRP_5275 proves the commit/apply
+// tail publishes NO VRRP instances when the dataplane failed to arm. It reuses
+// the #5083 duplicate-identity config: without the fail-closed gate the tail
+// collects the colliding instances and UpdateInstances REJECTS them, failing the
+// commit; with the gate the desired set is empty, so there is no collision and
+// no VRRP ownership.
+//
+// FAIL-ON-REVERT: delete the `if !d.dataplaneArmFailed.Load()` guard around the
+// VRRP collection in applyTailReconciles (daemon_apply_tail.go) and this goes
+// RED — the duplicate-identity collision returns a non-nil commit error.
+func TestApplyTailReconciles_ArmFailed_SuppressesVRRP_5275(t *testing.T) {
+	installFakeNetworkctl(t)
+	captureForwardingSysctls(t)
+
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
+
+	d := &Daemon{
+		dp:       &runtimeOnlyApplyTestDP{},
+		networkd: networkd.NewInDir(t.TempDir()),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+	d.dataplaneArmFailed.Store(true)
+
+	group := func(vip string) map[string]*config.VRRPGroup {
+		return map[string]*config.VRRPGroup{
+			vip + "_grp5": {ID: 5, VirtualAddresses: []string{vip}},
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/0": {
+			Name: "ge-0/0/0",
+			Units: map[int]*config.InterfaceUnit{
+				100: {Number: 100, VlanID: 100, VRRPGroups: group("10.0.0.1/24")},
+				200: {Number: 200, VlanID: 100, VRRPGroups: group("10.0.1.1/24")},
+			},
+		},
+	}
+
+	err := d.applyTailReconciles(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil && strings.Contains(err.Error(), "duplicate VRRP instance identity") {
+		t.Fatalf("fail-closed tail must NOT collect/publish VRRP instances; got collision error: %v", err)
+	}
+	if states := d.vrrpMgr.States(); len(states) != 0 {
+		t.Fatalf("fail-closed tail must install no VRRP runtime state; got %v", states)
+	}
+}
+
+// TestApplyRoutingRules_ArmFailed_SkipsFRRPublish_5275 proves the apply path does
+// NOT re-publish the FRR managed section (route advertisement) while the
+// dataplane is unarmed — so a bootstrap-exit or recovery-commit apply cannot
+// re-open the route-advertisement hole the immediate handler closed.
+//
+// FAIL-ON-REVERT: delete the `d.dataplaneArmFailed.Load()` branch guarding the
+// applyFRRConfig publish in applyRoutingRules (daemon_apply_routing.go) and this
+// goes RED — applyFRRConfig runs and the recording executor logs a reload.
+func TestApplyRoutingRules_ArmFailed_SkipsFRRPublish_5275(t *testing.T) {
+	confPath, _ := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+	d := &Daemon{
+		frr:   frr.NewForTest(confPath, rec),
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		// d.routing left nil: the ip-rule reconciles below the FRR block
+		// nil-guard, so the FRR publish decision is exercised in isolation.
+	}
+	d.dataplaneArmFailed.Store(true)
+
+	if err := d.applyRoutingRules(&config.Config{}, nil); err != nil {
+		t.Fatalf("applyRoutingRules returned error: %v", err)
+	}
+
+	if rec.ReloadCalls != 0 {
+		t.Fatalf("fail-closed apply must NOT publish/reload FRR; got %d reloads", rec.ReloadCalls)
+	}
+}
+
+// TestApplyRoutingRules_Armed_PublishesFRR_5275 is the negative control: with the
+// flag UNSET the FRR managed section is published as before (the gate is not a
+// blanket skip).
+func TestApplyRoutingRules_Armed_PublishesFRR_5275(t *testing.T) {
+	confPath, _ := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+	d := &Daemon{
+		frr:   frr.NewForTest(confPath, rec),
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+	}
+
+	if err := d.applyRoutingRules(&config.Config{}, nil); err != nil {
+		t.Fatalf("applyRoutingRules returned error: %v", err)
+	}
+
+	if rec.ReloadCalls == 0 {
+		t.Fatal("armed apply must publish/reload FRR; got 0 reloads")
+	}
+}


### PR DESCRIPTION
Closes #5275

## The hole (STEP-0 evidence, verified on current origin/master)

#1960/#1993 fail closed **only on a config COMPILE failure**. A successful
compile followed by a dataplane **arm/attach** failure bypassed that gate. On
`origin/master`:

- `pkg/daemon/daemon_run_bringup.go` (boot arm) — `d.dp.Start()` fails →
  `slog.Warn("...config-only mode")` → `d.dp = nil` → **falls through** to
  `d.applyConfig(cfg)`.
- `pkg/daemon/daemon_run_naming.go:231` (bootstrap-exit arm) — same shape; on
  failure `applyConfigLocked`'s continuing reconcile still publishes ownership
  (the `daemon_run.go:372` note flags this).
- `initManagers` already ran `enableForwarding()` (a successful compile is **not**
  bootstrap), and `applyKernelTuning` re-writes `ip_forward=1` at the apply tail
  (`pkg/daemon/daemon_system.go`).
- `clearFRRForFailClosedBoot(configCompileFailed=false)` is a **no-op** on this
  path, so `applyConfig` re-publishes the FRR managed section.
- The periodic `reconcileVRRPInstances` reads the still-non-nil `ActiveConfig`, so
  VRRP/VIP ownership is (re)created even independently of the boot apply.

Net: a cold boot with a valid persisted config whose AF_XDP attach fails comes up
as a **plain Linux router enforcing ZERO security policy** — `ip_forward=1`, FRR
advertising, VRRP/VIP/cluster ownership held. Confirmed NOT already fixed: none of
the `failClosedBoot*` seams key on an arm failure.

## The fix

Mirror the #1960 fail-closed contract onto the arm-failure path (both arm sites):

- Sticky `d.dataplaneArmFailed` atomic, set at either arm site via
  `enterDataplaneArmFailedFailClosed`. `d.dp` is never rebuilt at runtime →
  recovery is a **daemon restart**; a commit while arm-failed stays fail-closed.
- Immediate actions: `disableForwarding` (only the two transit sysctls — mgmt-VRF
  `l3mdev`/SSH knobs stay), `clearFRRManagedSectionOnFailClosedBoot` (shares the
  #1993 live-forwarding probe), `cluster.SetArmFailedHold` (new unconditional
  SECONDARY election hold — blocks promotion AND demotes an already-primary RG;
  covers no-reth-vrrp/direct-announce mode), `vrrpMgr.UpdateInstances(nil)`
  (covers RETH VRRP mode).
- Gate every config-driven ownership publish on the flag: boot arm **skips**
  `applyConfig` (freeze in last-known-good networkd); `applyKernelTuning` does not
  re-enable `ip_forward`; `applyRoutingRules` skips the FRR publish; the VRRP tail
  and periodic reconcile keep the desired VRRP set empty.

Management stays reachable — fail closed = no transit forwarding, no route
advertisement, no HA VIP takeover; **not** a dead box.

## Fail-on-revert tests + parent-RED recipe

`pkg/daemon/dataplane_arm_failclosed_5275_test.go`:

- `TestBootArmFailure_SkipsApplyConfig_5275` — RED if the `if armFailed { enter;
  return }` branch in `armBuiltDataplaneAndApplyBootConfig` falls through to
  `applyConfig` (neutralize: `if false && armFailed {`).
- `TestEnterDataplaneArmFailedFailClosed_ImmediateActions_5275` — RED if any of
  `disableForwarding` / `clearFRR` / `SetArmFailedHold` is dropped from the
  handler (neutralize: delete `disableForwarding()` → `ip_forward=0` assert RED).
- `TestApplyKernelTuning_ArmFailed_DoesNotReenableForwarding_5275` — RED if the
  `if d.dataplaneArmFailed.Load() { return }` gate in `applyKernelTuning` is
  removed (neutralize: `if false {`).
- `TestApplyTailReconciles_ArmFailed_SuppressesVRRP_5275` — RED if the
  `if !d.dataplaneArmFailed.Load()` VRRP-collect guard is removed (neutralize:
  `if true {`); the #5083 duplicate-identity config then fails the commit.
- `TestApplyRoutingRules_ArmFailed_SkipsFRRPublish_5275` — RED if the
  `d.frr != nil && d.dataplaneArmFailed.Load()` FRR-skip branch is removed
  (neutralize: `&& false`).
- Negative controls (`_Armed_`) confirm the gates are not blanket disables.

`pkg/cluster/arm_failed_hold_test.go`:

- `TestElection_ArmFailedHold_IsolatedStaysSecondary` — RED if the
  `|| m.armFailedHold` clause is removed from the election gates.
- `TestElection_ArmFailedHold_DemotesAlreadyPrimary` — RED if the demotion loop in
  `SetArmFailedHold` is removed.

All neutralizations verified RED locally; restored to green.

Run: `GOCACHE=/dev/shm/gc-5275 GOTMPDIR=/dev/shm go test ./pkg/daemon/... ./pkg/cluster/... 2>&1 | tail`
(use a short `TMPDIR=/tmp` — the `event_stream` unix-socket test hits the
`sun_path` 108-char limit under a long GOTMPDIR; unrelated to this change).

## Smoke

This touches VRRP/HA/forwarding, so a loss-cluster `make test-failover` smoke is
required at merge — the **parent** runs it. Not claimed merge-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ
