### PR TITLE
ra/reth: resolve RETH RA and post-MAC IPv6 repair by vlan-id, not unit number

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57526,3 +57526,24 @@ top.
 - **File(s)**: pkg/daemon/daemon_reth.go,
     pkg/daemon/daemon_apply_dataplane.go,
     pkg/daemon/reth_unit_vlanid_5107_test.go
+
+- **Timestamp**: 2026-07-22
+- **Action**: #5107 fold round 2 (PR #6359, Codex re-review of 8e96f5612).
+    MINOR-2 (MUST-FIX): rethUnitForVlanID's duplicate-vlan-id WARN said "using
+    lowest unit for IPv6 repair", but after fold-1 the IPv6 repair scans ALL
+    matching units — the lowest unit is used only for the netdev name. Reworded
+    to "using lowest unit for the netdev name (all matching units scanned for
+    IPv6 link-local repair)"; updated the dupVIDWarn test constant. MINOR-1
+    (bind the caller): extracted rethSubIfaceLinkLocalRepair(rethCfg, subName)
+    — removeAutoLinkLocal + resolve-by-vlan-id decision + ensureRethLinkLocal —
+    with removeAutoLinkLocalFn/ensureRethLinkLocalFn package-var seams
+    (device_map.go idiom); the post-MAC enumeration loop now delegates in one
+    line. Added TestRethSubIfaceLinkLocalRepairDrivesEnsureByVlanID (spies,
+    no netlink) binding the repair action+ordering+resolution. The residual
+    netlink LinkList/ParentIndex enumeration is the only unbound surface (needs
+    real netlink); noted at the call site. RED-on-revert verified for both new/
+    changed tests then restored. Full pkg/daemon + pkg/config green, vet+gofmt
+    clean.
+- **File(s)**: pkg/daemon/daemon_reth.go,
+    pkg/daemon/daemon_apply_dataplane.go,
+    pkg/daemon/reth_unit_vlanid_5107_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -57506,3 +57506,23 @@ top.
 - **File(s)**: pkg/daemon/daemon_ra.go, pkg/daemon/daemon_reth.go,
     pkg/daemon/daemon_apply_dataplane.go,
     pkg/daemon/reth_unit_vlanid_5107_test.go, docs/ha-cluster-test-plan.md
+
+- **Timestamp**: 2026-07-22
+- **Action**: #5107 fold (PR #6359, Codex MERGE-NEEDS-MINOR). (1) Duplicate-VID
+    robustness: `rethSubIfaceNeedsLinkLocal` now scans ALL units mapped to a
+    vlan-id and returns true if ANY carries IPv6 (was: lowest-only via
+    `rethUnitForVlanID` — skipped repair when the lowest unit was IPv4-only and a
+    higher unit had IPv6). `rethUnitForVlanID` kept (lowest+deterministic+warn)
+    and still called for the existence check + collision log. (2) Bound the
+    production call sites: extracted `rethSubIfaceNameNeedsLinkLocal` seam
+    (parse vlan-id from kernel netdev name + resolve) now called by the post-MAC
+    repair loop in daemon_apply_dataplane.go (removed now-unused strconv import);
+    added TestRethSubIfaceNameNeedsLinkLocal (binds path a) and
+    TestDesiredClusterRAResolvesByVlanID (binds the desiredClusterRA ownership
+    gate — the bonus cluster-RA fix). Updated the dup-VID test to assert the
+    collision WARN via recordingSlogHandler. All three fold neutralizations
+    verified RED then restored. Full pkg/daemon + pkg/config suites green, vet +
+    gofmt clean.
+- **File(s)**: pkg/daemon/daemon_reth.go,
+    pkg/daemon/daemon_apply_dataplane.go,
+    pkg/daemon/reth_unit_vlanid_5107_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -57486,3 +57486,23 @@ top.
     test/xsk-repro/selftest-compile.sh,
     test/xsk-repro/selftest-skipgate_6289.sh (new),
     test/xsk-repro/README.md, scripts/run-selftests.sh
+
+- **Timestamp**: 2026-07-22
+- **Action**: #5107 — fix RETH RA + post-MAC IPv6 repair using logical unit
+    numbers as VLAN IDs. Bug 1: `buildRAConfigs` resolved RA interface names via
+    `config.LinuxIfName(cfg.ResolveReth(...))`, which preserves the UNIT suffix
+    (reth0.80 -> member.80) instead of mapping unit -> configured vlan-id;
+    swapped to `cfg.ResolveKernelIfName` (reth0 unit 80 vlan-id 180 ->
+    member.180), which also matches `rethInterfacesForRG`'s vlan-id suffix so the
+    cluster RA owner match no longer drops the sender. Bug 2: the post-MAC IPv6
+    link-local repair in `daemon_apply_dataplane.go` parsed the vlan-id from the
+    kernel VLAN sub-interface name and indexed `rethCfg.Units[vid]` directly, but
+    Units is keyed by unit number — added `rethUnitForVlanID` (vlan-id -> unit
+    reverse lookup, deterministic lowest-unit on duplicate vlan-id + log) +
+    `rethSubIfaceNeedsLinkLocal` and index Units by the resolved unit. Fixed the
+    misleading `rethUnitHasIPv6` doc comment. Fail-on-revert Go tests in
+    reth_unit_vlanid_5107_test.go (both bugs go RED on revert; verified both
+    directions). Docs: ha-cluster-test-plan.md RA resolution note updated.
+- **File(s)**: pkg/daemon/daemon_ra.go, pkg/daemon/daemon_reth.go,
+    pkg/daemon/daemon_apply_dataplane.go,
+    pkg/daemon/reth_unit_vlanid_5107_test.go, docs/ha-cluster-test-plan.md

--- a/docs/ha-cluster-test-plan.md
+++ b/docs/ha-cluster-test-plan.md
@@ -383,8 +383,15 @@ protocols {
 ```
 
 Flags: M (managed) tells clients to use DHCPv6 for address, O (other) for DNS/domain,
-A (autonomous) allows SLAAC as well. radvd resolves RETH names to physical member
-interfaces via `ResolveReth()` + `LinuxIfName()`.
+A (autonomous) allows SLAAC as well. The embedded RA sender resolves RETH names to
+physical member interfaces via `cfg.ResolveKernelIfName()` in `buildRAConfigs`.
+That resolver maps a logical unit to its configured `vlan-id` for the kernel VLAN
+sub-interface suffix (`reth0 unit 80 vlan-id 180` → `member.180`) — the identity
+chain is logical unit → configured vlan-id → kernel suffix. The earlier
+`ResolveReth()` + `LinuxIfName()` pair preserved the UNIT number as the suffix
+(`member.80`) and bound RA to a nonexistent netdev whenever unit# != vlan-id, and
+it desynced from `rethInterfacesForRG` (which already suffixes by `unit.VlanID`) so
+the cluster RA owner match silently dropped the sender (#5107).
 
 ### DHCP Server (on reth1)
 

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -341,10 +341,15 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 					}
 					removeAutoLinkLocal(subName)
 					// Re-add link-local if this VLAN sub-interface has IPv6.
-					// Extract VLAN ID from sub-interface name (e.g. "ge-7-0-1.100").
+					// The kernel suffix is the unit's vlan-id (e.g.
+					// "ge-7-0-1.180"), but rethCfg.Units is keyed by the
+					// logical unit number, which may differ from the vlan-id
+					// (`unit 80 vlan-id 180`). Resolve the vlan-id back to its
+					// unit before checking for IPv6 — indexing Units[vid]
+					// directly silently skipped the repair (#5107).
 					if dotIdx := strings.LastIndex(subName, "."); dotIdx >= 0 {
 						if vid, err := strconv.Atoi(subName[dotIdx+1:]); err == nil {
-							if rethUnitHasIPv6(rethCfg, vid) {
+							if rethSubIfaceNeedsLinkLocal(rethCfg, vid) {
 								ensureRethLinkLocal(subName)
 							}
 						}

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 	"time"
 
@@ -344,15 +343,12 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 					// The kernel suffix is the unit's vlan-id (e.g.
 					// "ge-7-0-1.180"), but rethCfg.Units is keyed by the
 					// logical unit number, which may differ from the vlan-id
-					// (`unit 80 vlan-id 180`). Resolve the vlan-id back to its
-					// unit before checking for IPv6 — indexing Units[vid]
-					// directly silently skipped the repair (#5107).
-					if dotIdx := strings.LastIndex(subName, "."); dotIdx >= 0 {
-						if vid, err := strconv.Atoi(subName[dotIdx+1:]); err == nil {
-							if rethSubIfaceNeedsLinkLocal(rethCfg, vid) {
-								ensureRethLinkLocal(subName)
-							}
-						}
+					// (`unit 80 vlan-id 180`). rethSubIfaceNameNeedsLinkLocal
+					// parses the vlan-id and resolves it back to its unit(s)
+					// before checking for IPv6 — indexing Units[vid] directly
+					// silently skipped the repair (#5107).
+					if rethSubIfaceNameNeedsLinkLocal(rethCfg, subName) {
+						ensureRethLinkLocal(subName)
 					}
 				}
 			}

--- a/pkg/daemon/daemon_apply_dataplane.go
+++ b/pkg/daemon/daemon_apply_dataplane.go
@@ -338,18 +338,16 @@ func (d *Daemon) applyDataplaneAndHACore(ctx context.Context, cfg *config.Config
 								"iface", subName, "mac", mac)
 						}
 					}
-					removeAutoLinkLocal(subName)
-					// Re-add link-local if this VLAN sub-interface has IPv6.
-					// The kernel suffix is the unit's vlan-id (e.g.
-					// "ge-7-0-1.180"), but rethCfg.Units is keyed by the
-					// logical unit number, which may differ from the vlan-id
-					// (`unit 80 vlan-id 180`). rethSubIfaceNameNeedsLinkLocal
-					// parses the vlan-id and resolves it back to its unit(s)
-					// before checking for IPv6 — indexing Units[vid] directly
-					// silently skipped the repair (#5107).
-					if rethSubIfaceNameNeedsLinkLocal(rethCfg, subName) {
-						ensureRethLinkLocal(subName)
-					}
+					// Strip any stale auto link-local, then re-add a stable one
+					// if this VLAN sub-interface carries IPv6. The kernel suffix
+					// is the unit's vlan-id (e.g. "ge-7-0-1.180"), which may
+					// differ from the logical unit number rethCfg.Units is keyed
+					// by (`unit 80 vlan-id 180`); the repair resolves the vlan-id
+					// back to its unit(s) before checking for IPv6 — indexing
+					// Units[vid] directly silently skipped the repair (#5107).
+					// The whole decision+action lives in rethSubIfaceLinkLocalRepair
+					// (spy-tested); this loop only enumerates the child netdevs.
+					rethSubIfaceLinkLocalRepair(rethCfg, subName)
 				}
 			}
 		}

--- a/pkg/daemon/daemon_ra.go
+++ b/pkg/daemon/daemon_ra.go
@@ -95,9 +95,17 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 		}
 	}
 
-	// Resolve RETH interface names for RA senders (needs real Linux names).
+	// Resolve interface names for RA senders (needs real Linux names).
+	// ResolveKernelIfName maps a logical unit to its configured vlan-id for
+	// the kernel VLAN sub-interface suffix (reth0.80 with `vlan-id 180` →
+	// member.180), whereas the old LinuxIfName(ResolveReth(...)) preserved the
+	// UNIT number as the suffix (member.80) and bound RA to a netdev that does
+	// not exist. It also keeps the resolved name consistent with
+	// rethInterfacesForRG (which already suffixes by unit.VlanID), so the
+	// cluster RA ownership match in desiredClusterRA does not drop the sender
+	// when unit# != vlan-id (#5107).
 	for _, ra := range result {
-		ra.Interface = config.LinuxIfName(cfg.ResolveReth(ra.Interface))
+		ra.Interface = cfg.ResolveKernelIfName(ra.Interface)
 	}
 
 	return result

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -445,13 +445,45 @@ func rethUnitForVlanID(rethCfg *config.InterfaceConfig, vid int) (int, bool) {
 
 // rethSubIfaceNeedsLinkLocal reports whether the RETH VLAN sub-interface whose
 // kernel vlan-id is `vid` carries IPv6 in config and therefore needs its
-// link-local re-added after a post-MAC-programming link cycle. It resolves the
-// vlan-id back to its logical unit first (Units is unit-keyed, not vlan-id
-// keyed) before checking that unit for IPv6 — see rethUnitForVlanID (#5107).
+// link-local re-added after a post-MAC-programming link cycle. The kernel netdev
+// is keyed by vlan-id, but rethCfg.Units is keyed by logical unit number, so the
+// vlan-id must be resolved back to a unit before checking for IPv6 (#5107).
+//
+// rethUnitForVlanID handles the existence check and logs a deterministic warning
+// when several units share this vlan-id. We do NOT trust the single (lowest) unit
+// it returns for the IPv6 decision: a duplicate vlan-id (an invalid config the
+// compiler does not reject for uniqueness) can split addressing so a lower unit
+// is IPv4-only while a higher unit carries IPv6. The one shared kernel netdev
+// needs a link-local if ANY mapped unit has IPv6, so scan them all (#5107 fold).
 func rethSubIfaceNeedsLinkLocal(rethCfg *config.InterfaceConfig, vid int) bool {
-	unitNum, ok := rethUnitForVlanID(rethCfg, vid)
-	if !ok {
+	if _, ok := rethUnitForVlanID(rethCfg, vid); !ok {
 		return false
 	}
-	return rethUnitHasIPv6(rethCfg, unitNum)
+	for unitNum, unit := range rethCfg.Units {
+		if unit == nil || unit.VlanID != vid {
+			continue
+		}
+		if rethUnitHasIPv6(rethCfg, unitNum) {
+			return true
+		}
+	}
+	return false
+}
+
+// rethSubIfaceNameNeedsLinkLocal parses the kernel vlan-id out of a RETH VLAN
+// sub-interface name (e.g. "ge-7-0-1.180") and reports whether that
+// sub-interface needs its IPv6 link-local re-added after a post-MAC link cycle.
+// It is the smallest testable seam over the post-MAC repair decision in
+// applyDataplaneAndHACore, so the production loop and its regression test share
+// one code path (#5107). A name with no numeric vlan-id suffix returns false.
+func rethSubIfaceNameNeedsLinkLocal(rethCfg *config.InterfaceConfig, subName string) bool {
+	dotIdx := strings.LastIndex(subName, ".")
+	if dotIdx < 0 {
+		return false
+	}
+	vid, err := strconv.Atoi(subName[dotIdx+1:])
+	if err != nil {
+		return false
+	}
+	return rethSubIfaceNeedsLinkLocal(rethCfg, vid)
 }

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -437,7 +437,7 @@ func rethUnitForVlanID(rethCfg *config.InterfaceConfig, vid int) (int, bool) {
 		return 0, false
 	}
 	if matches > 1 {
-		slog.Warn("reth: multiple units share a vlan-id; using lowest unit for IPv6 repair",
+		slog.Warn("reth: multiple units share a vlan-id; using lowest unit for the netdev name (all matching units scanned for IPv6 link-local repair)",
 			"iface", rethCfg.Name, "vlan-id", vid, "unit", found)
 	}
 	return found, true
@@ -486,4 +486,27 @@ func rethSubIfaceNameNeedsLinkLocal(rethCfg *config.InterfaceConfig, subName str
 		return false
 	}
 	return rethSubIfaceNeedsLinkLocal(rethCfg, vid)
+}
+
+// removeAutoLinkLocalFn / ensureRethLinkLocalFn are the live wiring for the two
+// netlink side-effects of rethSubIfaceLinkLocalRepair. They are package vars
+// (mirroring the device_map.go seam idiom) so a test can drive the repair
+// decision without real netlink and assert which sub-interface got a link-local.
+var (
+	removeAutoLinkLocalFn = removeAutoLinkLocal
+	ensureRethLinkLocalFn = ensureRethLinkLocal
+)
+
+// rethSubIfaceLinkLocalRepair performs the per-VLAN-sub-interface link-local
+// repair the post-MAC loop in applyDataplaneAndHACore runs for each child of a
+// RETH member: always strip any stale kernel auto link-local, then re-add a
+// stable one IF the sub-interface carries IPv6 in config (resolved vlan-id ->
+// unit, #5107). Extracting the whole decision+action here keeps the netlink
+// enumeration loop a trivial one-line delegation and lets a spy-driven test bind
+// the parse/resolve/scan and the repair ordering without real netlink.
+func rethSubIfaceLinkLocalRepair(rethCfg *config.InterfaceConfig, subName string) {
+	removeAutoLinkLocalFn(subName)
+	if rethSubIfaceNameNeedsLinkLocal(rethCfg, subName) {
+		ensureRethLinkLocalFn(subName)
+	}
 }

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -389,7 +389,10 @@ func rethUnitHasConfiguredLinkLocal(rethCfg *config.InterfaceConfig, unitNum int
 }
 
 // rethUnitHasIPv6 checks whether the RETH config has IPv6 addresses on the
-// given unit number (VLAN ID). Unit 0 is the native/untagged interface.
+// given logical unit number. Unit 0 is the native/untagged interface. The
+// argument is a UNIT number, not a vlan-id — callers that start from a kernel
+// VLAN sub-interface suffix must translate the vlan-id to a unit with
+// rethUnitForVlanID first (#5107).
 func rethUnitHasIPv6(rethCfg *config.InterfaceConfig, unitNum int) bool {
 	unit, ok := rethCfg.Units[unitNum]
 	if !ok {
@@ -401,4 +404,54 @@ func rethUnitHasIPv6(rethCfg *config.InterfaceConfig, unitNum int) bool {
 		}
 	}
 	return unit.DHCPv6
+}
+
+// rethUnitForVlanID reverse-maps a kernel VLAN id to the logical unit number
+// that carries it. RETH VLAN sub-interfaces are named after the unit's
+// configured vlan-id (e.g. kernel "ge-7-0-1.180" for `reth1 unit 80 vlan-id
+// 180`), but rethCfg.Units is keyed by the logical UNIT number (80), not the
+// vlan-id (180). Callers that parse a vid out of a kernel netdev name MUST
+// translate it back to the unit number before indexing Units — indexing
+// Units[vid] directly silently misses whenever unit# != vlan-id (#5107).
+//
+// Returns (unit, true) for the unit whose VlanID == vid. Only units with a
+// matching non-zero VlanID are considered: an untagged unit has no kernel
+// VLAN sub-interface and is repaired on the parent netdev, not this path. If
+// two units share a vlan-id (an invalid config Junos rejects), the lowest
+// unit number wins deterministically and the collision is logged.
+func rethUnitForVlanID(rethCfg *config.InterfaceConfig, vid int) (int, bool) {
+	found := -1
+	matches := 0
+	for unitNum, unit := range rethCfg.Units {
+		// Skip untagged units (VlanID 0): they have no VLAN sub-interface,
+		// so a vlan-id parsed from a kernel netdev suffix never maps to them.
+		if unit == nil || unit.VlanID <= 0 || unit.VlanID != vid {
+			continue
+		}
+		matches++
+		if found < 0 || unitNum < found {
+			found = unitNum
+		}
+	}
+	if found < 0 {
+		return 0, false
+	}
+	if matches > 1 {
+		slog.Warn("reth: multiple units share a vlan-id; using lowest unit for IPv6 repair",
+			"iface", rethCfg.Name, "vlan-id", vid, "unit", found)
+	}
+	return found, true
+}
+
+// rethSubIfaceNeedsLinkLocal reports whether the RETH VLAN sub-interface whose
+// kernel vlan-id is `vid` carries IPv6 in config and therefore needs its
+// link-local re-added after a post-MAC-programming link cycle. It resolves the
+// vlan-id back to its logical unit first (Units is unit-keyed, not vlan-id
+// keyed) before checking that unit for IPv6 — see rethUnitForVlanID (#5107).
+func rethSubIfaceNeedsLinkLocal(rethCfg *config.InterfaceConfig, vid int) bool {
+	unitNum, ok := rethUnitForVlanID(rethCfg, vid)
+	if !ok {
+		return false
+	}
+	return rethUnitHasIPv6(rethCfg, unitNum)
 }

--- a/pkg/daemon/reth_unit_vlanid_5107_test.go
+++ b/pkg/daemon/reth_unit_vlanid_5107_test.go
@@ -113,9 +113,15 @@ func TestRethUnitForVlanID(t *testing.T) {
 	}
 }
 
+// dupVIDWarn is the collision warning rethUnitForVlanID emits when several
+// units share a vlan-id (an invalid config). Kept in one place so the test
+// asserting it stays in lockstep with the production string.
+const dupVIDWarn = "reth: multiple units share a vlan-id; using lowest unit for IPv6 repair"
+
 // TestRethUnitForVlanIDDuplicateDeterministic proves a duplicate vlan-id (an
 // invalid config) resolves deterministically to the lowest unit number
-// regardless of map iteration order.
+// regardless of map iteration order, AND that the collision is logged (an
+// invalid duplicate vlan-id must not pass silently).
 func TestRethUnitForVlanIDDuplicateDeterministic(t *testing.T) {
 	cfg := &config.InterfaceConfig{
 		Name: "reth1",
@@ -124,18 +130,25 @@ func TestRethUnitForVlanIDDuplicateDeterministic(t *testing.T) {
 			90: {Number: 90, VlanID: 200, Addresses: []string{"2001:db8:90::1/64"}},
 		},
 	}
-	// Silence the expected duplicate-vlan-id WARN across the loop.
+	// Capture WARN records so we can assert the deterministic-lowest collision
+	// warning fires exactly once per call.
+	rec := &recordingSlogHandler{level: slog.LevelWarn}
 	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	slog.SetDefault(slog.New(rec))
 	defer slog.SetDefault(prev)
 
 	// Repeat to defeat Go's randomized map iteration order.
-	for i := 0; i < 64; i++ {
+	const iters = 64
+	for i := 0; i < iters; i++ {
 		gotUnit, gotOK := rethUnitForVlanID(cfg, 200)
 		if !gotOK || gotUnit != 70 {
 			t.Fatalf("duplicate vlan-id 200: rethUnitForVlanID = (%d, %v), "+
 				"want (70, true) deterministically (lowest unit)", gotUnit, gotOK)
 		}
+	}
+	if n := rec.count(dupVIDWarn); n != iters {
+		t.Errorf("duplicate-vlan-id warning fired %d times, want %d (once per call)",
+			n, iters)
 	}
 }
 
@@ -185,6 +198,160 @@ func TestRethSubIfaceNeedsLinkLocal(t *testing.T) {
 				tt.name, tt.vid, got, tt.want)
 		}
 	}
+}
+
+// TestRethSubIfaceNeedsLinkLocalDuplicateVIDAnyIPv6 is the #5107-fold guard: a
+// duplicate vlan-id may split addressing so the LOWEST unit is IPv4-only while a
+// higher unit carries IPv6. The single shared kernel netdev (member.<vid>) still
+// needs a link-local, so rethSubIfaceNeedsLinkLocal must scan ALL units mapped
+// to the vlan-id, not just the deterministic-lowest one.
+//
+// Fail-on-revert: restoring the lowest-only predicate
+// (`u, _ := rethUnitForVlanID(...); return rethUnitHasIPv6(rethCfg, u)`) checks
+// only unit 70 (IPv4-only) for the first config and returns false.
+func TestRethSubIfaceNeedsLinkLocalDuplicateVIDAnyIPv6(t *testing.T) {
+	silenceLogs(t) // duplicate vlan-id emits the expected collision warning
+
+	// Lowest unit IPv4-only, higher unit IPv6 → true.
+	cfgHigh := &config.InterfaceConfig{
+		Name: "reth0",
+		Units: map[int]*config.InterfaceUnit{
+			70: {Number: 70, VlanID: 200, Addresses: []string{"172.16.70.8/24"}},
+			90: {Number: 90, VlanID: 200, Addresses: []string{"2001:db8:90::8/64"}},
+		},
+	}
+	if !rethSubIfaceNeedsLinkLocal(cfgHigh, 200) {
+		t.Errorf("duplicate vlan-id 200, IPv6 on the higher unit: got false, want " +
+			"true (any mapped unit with IPv6 needs the shared netdev's link-local)")
+	}
+
+	// Reversed roles (lowest unit IPv6) → true.
+	cfgLow := &config.InterfaceConfig{
+		Name: "reth0",
+		Units: map[int]*config.InterfaceUnit{
+			70: {Number: 70, VlanID: 200, Addresses: []string{"2001:db8:70::8/64"}},
+			90: {Number: 90, VlanID: 200, Addresses: []string{"172.16.90.8/24"}},
+		},
+	}
+	if !rethSubIfaceNeedsLinkLocal(cfgLow, 200) {
+		t.Errorf("duplicate vlan-id 200, IPv6 on the lower unit: got false, want true")
+	}
+
+	// Neither unit has IPv6 → false.
+	cfgNone := &config.InterfaceConfig{
+		Name: "reth0",
+		Units: map[int]*config.InterfaceUnit{
+			70: {Number: 70, VlanID: 200, Addresses: []string{"172.16.70.8/24"}},
+			90: {Number: 90, VlanID: 200, Addresses: []string{"172.16.90.8/24"}},
+		},
+	}
+	if rethSubIfaceNeedsLinkLocal(cfgNone, 200) {
+		t.Errorf("duplicate vlan-id 200, IPv4-only on both units: got true, want false")
+	}
+}
+
+// TestRethSubIfaceNameNeedsLinkLocal binds the post-MAC IPv6 repair PRODUCTION
+// path in applyDataplaneAndHACore, which routes the whole decision through
+// rethSubIfaceNameNeedsLinkLocal(rethCfg, subName) — parse the vlan-id out of the
+// kernel VLAN sub-interface name and resolve it to the IPv6-bearing unit(s).
+//
+// Fail-on-revert: reverting the vlan-id -> unit resolution (making the seam index
+// Units[vid] directly, e.g. `return rethUnitHasIPv6(rethCfg, vid)`) misses
+// Units[180] and flips the ".180" cases to false.
+func TestRethSubIfaceNameNeedsLinkLocal(t *testing.T) {
+	cfg := &config.InterfaceConfig{
+		Name:            "reth0",
+		RedundancyGroup: 1,
+		Units: map[int]*config.InterfaceUnit{
+			// unit != vlan-id, has IPv6.
+			80: {Number: 80, VlanID: 180, Addresses: []string{
+				"172.16.80.8/24", "2001:db8:80::8/64"}},
+			// unit != vlan-id, IPv4-only.
+			90: {Number: 90, VlanID: 190, Addresses: []string{"172.16.90.8/24"}},
+		},
+	}
+	tests := []struct {
+		subName string
+		want    bool
+	}{
+		// Real kernel VLAN sub-interface names are parent.<vlan-id>.
+		{"ge-7-0-1.180", true},  // node-1 name, vlan-id 180 -> unit 80 (IPv6)
+		{"ge-0-0-2.180", true},  // node-0 name, same result
+		{"ge-7-0-1.190", false}, // vlan-id 190 -> unit 90 (IPv4-only)
+		// A unit-number suffix is NOT a vlan-id — the whole #5107 bug.
+		{"ge-7-0-1.80", false},
+		// No vlan-id suffix: the parent netdev is repaired elsewhere.
+		{"ge-7-0-1", false},
+		// Non-numeric suffix: false, no panic.
+		{"ge-7-0-1.foo", false},
+	}
+	for _, tt := range tests {
+		if got := rethSubIfaceNameNeedsLinkLocal(cfg, tt.subName); got != tt.want {
+			t.Errorf("rethSubIfaceNameNeedsLinkLocal(%q) = %v, want %v",
+				tt.subName, got, tt.want)
+		}
+	}
+}
+
+// TestDesiredClusterRAResolvesByVlanID binds the cluster RA ownership gate in
+// desiredClusterRA (daemon_ra_reconcile.go). An owned RG's RETH interfaces are
+// enumerated by rethInterfacesForRG, which suffixes by unit.VlanID (member.180);
+// buildRAConfigs must resolve the RA interface to the SAME member.180 or the
+// `ownedIfaces[ra.Interface]` match drops the sender. reth0 unit 80 vlan-id 180
+// exercises unit# != vlan-id.
+//
+// Fail-on-revert: reverting buildRAConfigs to
+// `config.LinuxIfName(cfg.ResolveReth(ra.Interface))` resolves reth0.80 to
+// member.80, which misses ownedIfaces[member.180], so desiredClusterRA returns
+// an EMPTY set and the len(desired)==1 assertion fails — binding the bonus
+// cluster-RA-ownership fix, not just buildRAConfigs in isolation.
+func TestDesiredClusterRAResolvesByVlanID(t *testing.T) {
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{Cluster: &config.ClusterConfig{NodeID: 0, ClusterID: 1}},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {
+					Name:            "reth0",
+					RedundancyGroup: 1,
+					Units: map[int]*config.InterfaceUnit{
+						80: {Number: 80, VlanID: 180, Addresses: []string{
+							"172.16.80.8/24", "2001:db8:80::8/64"}},
+					},
+				},
+				"ge-0/0/0": {Name: "ge-0/0/0", RedundantParent: "reth0"},
+				"ge-7/0/0": {Name: "ge-7/0/0", RedundantParent: "reth0"},
+			},
+		},
+		Protocols: config.ProtocolsConfig{
+			RouterAdvertisement: []*config.RAInterfaceConfig{
+				{Interface: "reth0.80"},
+			},
+		},
+	}
+	d := &Daemon{rgStates: make(map[int]*rgStateMachine)}
+	// Own RG1: the node is VRRP master for reth0.
+	d.getOrCreateRGState(1).SetVRRP("reth0", true)
+
+	desired := d.desiredClusterRA(cfg)
+	if len(desired) != 1 {
+		t.Fatalf("desiredClusterRA returned %d RAs, want 1 — the owned reth0.80 "+
+			"sender must survive the ownership match (member.80 misses "+
+			"ownedIfaces[member.180] and drops it)", len(desired))
+	}
+	if desired[0].Interface != "ge-0-0-0.180" {
+		t.Fatalf("owned RA Interface = %q, want ge-0-0-0.180 (vlan-id)",
+			desired[0].Interface)
+	}
+}
+
+// silenceLogs swaps the default slog logger for a discard handler for the
+// duration of the test (restored via Cleanup). Used where a test intentionally
+// drives a duplicate-vlan-id path that logs an expected collision warning.
+func silenceLogs(t *testing.T) {
+	t.Helper()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
 }
 
 // keys returns the set's members for error messages.

--- a/pkg/daemon/reth_unit_vlanid_5107_test.go
+++ b/pkg/daemon/reth_unit_vlanid_5107_test.go
@@ -1,0 +1,197 @@
+package daemon
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestBuildRAConfigsRethUnitVlanIDMismatch is the #5107 bug-1 guard: RA
+// interface resolution must map a RETH logical unit to its configured vlan-id
+// for the kernel VLAN sub-interface suffix, not preserve the unit number.
+//
+// reth0 unit 80 carries `vlan-id 180`, so the kernel sub-interface is
+// member.180. The old resolution (LinuxIfName(ResolveReth(...))) kept the unit
+// suffix and bound RA to member.80, a netdev that does not exist. This also
+// desynced buildRAConfigs from rethInterfacesForRG (which already suffixes by
+// unit.VlanID), silently dropping the sender from the cluster RA owned set.
+//
+// Fail-on-revert: restoring `config.LinuxIfName(cfg.ResolveReth(ra.Interface))`
+// in buildRAConfigs resolves reth0.80 to "ge-0-0-0.80" — the expected
+// "ge-0-0-0.180" is absent and the forbidden "ge-0-0-0.80" appears, failing
+// both assertions.
+func TestBuildRAConfigsRethUnitVlanIDMismatch(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{Cluster: &config.ClusterConfig{NodeID: 0, ClusterID: 1}},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {
+					Name:            "reth0",
+					RedundancyGroup: 1,
+					Units: map[int]*config.InterfaceUnit{
+						// unit == vlan-id (common case, must still work).
+						50: {Number: 50, VlanID: 50, Addresses: []string{
+							"172.16.50.8/24", "2001:db8:50::8/64"}},
+						// unit != vlan-id (the #5107 failure case).
+						80: {Number: 80, VlanID: 180, Addresses: []string{
+							"172.16.80.8/24", "2001:db8:80::8/64"}},
+					},
+				},
+				// Node 0's local member is ge-0/0/0 (slot 0 -> node 0).
+				"ge-0/0/0": {Name: "ge-0/0/0", RedundantParent: "reth0"},
+				"ge-7/0/0": {Name: "ge-7/0/0", RedundantParent: "reth0"},
+			},
+		},
+		Protocols: config.ProtocolsConfig{
+			RouterAdvertisement: []*config.RAInterfaceConfig{
+				{Interface: "reth0.80"},
+				{Interface: "reth0.50"},
+			},
+		},
+	}
+
+	resolved := make(map[string]bool)
+	for _, ra := range d.buildRAConfigs(cfg) {
+		resolved[ra.Interface] = true
+	}
+
+	if !resolved["ge-0-0-0.180"] {
+		t.Errorf("RA on reth0.80 (vlan-id 180) resolved to %v; want the set to "+
+			"include ge-0-0-0.180 (vlan-id), not the unit suffix", keys(resolved))
+	}
+	if resolved["ge-0-0-0.80"] {
+		t.Errorf("RA resolved to ge-0-0-0.80 (unit number) — unit# was used as "+
+			"the kernel VLAN suffix instead of vlan-id 180 (#5107); got %v", keys(resolved))
+	}
+	// Same-value unit (50 == vlan-id 50): no regression.
+	if !resolved["ge-0-0-0.50"] {
+		t.Errorf("RA on reth0.50 (vlan-id 50) resolved to %v; want ge-0-0-0.50",
+			keys(resolved))
+	}
+}
+
+// TestRethUnitForVlanID exercises the vlan-id -> unit reverse lookup that the
+// post-MAC IPv6 link-local repair uses to translate a kernel VLAN suffix back
+// to the logical unit rethCfg.Units is keyed by (#5107 bug 2).
+func TestRethUnitForVlanID(t *testing.T) {
+	cfg := &config.InterfaceConfig{
+		Name:            "reth0",
+		RedundancyGroup: 1,
+		Units: map[int]*config.InterfaceUnit{
+			0:  {Number: 0, VlanID: 0, Addresses: []string{"fe80::aaaa/64"}},
+			50: {Number: 50, VlanID: 50},
+			80: {Number: 80, VlanID: 180}, // unit != vlan-id
+			90: {Number: 90, VlanID: 190},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		vid      int
+		wantUnit int
+		wantOK   bool
+	}{
+		{"mismatch: vlan-id 180 -> unit 80", 180, 80, true},
+		{"same-value: vlan-id 50 -> unit 50", 50, 50, true},
+		{"another mismatch: vlan-id 190 -> unit 90", 190, 90, true},
+		// 80 is a UNIT number, not any unit's vlan-id: must NOT resolve.
+		// The old direct Units[80] index would have matched here.
+		{"unit-number-not-vlan-id: 80 -> miss", 80, 0, false},
+		{"unknown vlan-id: miss", 999, 0, false},
+		// vlan-id 0 is the untagged parent, not a VLAN sub-interface: miss.
+		{"untagged vlan-id 0: miss", 0, 0, false},
+	}
+	for _, tt := range tests {
+		gotUnit, gotOK := rethUnitForVlanID(cfg, tt.vid)
+		if gotUnit != tt.wantUnit || gotOK != tt.wantOK {
+			t.Errorf("%s: rethUnitForVlanID(vid=%d) = (%d, %v), want (%d, %v)",
+				tt.name, tt.vid, gotUnit, gotOK, tt.wantUnit, tt.wantOK)
+		}
+	}
+}
+
+// TestRethUnitForVlanIDDuplicateDeterministic proves a duplicate vlan-id (an
+// invalid config) resolves deterministically to the lowest unit number
+// regardless of map iteration order.
+func TestRethUnitForVlanIDDuplicateDeterministic(t *testing.T) {
+	cfg := &config.InterfaceConfig{
+		Name: "reth1",
+		Units: map[int]*config.InterfaceUnit{
+			70: {Number: 70, VlanID: 200, Addresses: []string{"2001:db8:70::1/64"}},
+			90: {Number: 90, VlanID: 200, Addresses: []string{"2001:db8:90::1/64"}},
+		},
+	}
+	// Silence the expected duplicate-vlan-id WARN across the loop.
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	defer slog.SetDefault(prev)
+
+	// Repeat to defeat Go's randomized map iteration order.
+	for i := 0; i < 64; i++ {
+		gotUnit, gotOK := rethUnitForVlanID(cfg, 200)
+		if !gotOK || gotUnit != 70 {
+			t.Fatalf("duplicate vlan-id 200: rethUnitForVlanID = (%d, %v), "+
+				"want (70, true) deterministically (lowest unit)", gotUnit, gotOK)
+		}
+	}
+}
+
+// TestRethSubIfaceNeedsLinkLocal is the #5107 bug-2 fail-on-revert guard for
+// the post-MAC IPv6 repair decision. The kernel VLAN suffix (vlan-id) must be
+// translated to its logical unit before checking Units for IPv6.
+//
+// Fail-on-revert: replacing rethSubIfaceNeedsLinkLocal's body with the old
+// `return rethUnitHasIPv6(rethCfg, vid)` indexes Units[180], which is absent
+// (Units is keyed by unit 80), so the IPv6-bearing sub-interface is skipped and
+// the vlan-id-180 assertion flips to false.
+func TestRethSubIfaceNeedsLinkLocal(t *testing.T) {
+	cfg := &config.InterfaceConfig{
+		Name:            "reth0",
+		RedundancyGroup: 1,
+		Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, VlanID: 0, Addresses: []string{"fe80::aaaa/64"}},
+			// unit == vlan-id, has IPv6.
+			50: {Number: 50, VlanID: 50, Addresses: []string{
+				"172.16.50.8/24", "2001:db8:50::8/64"}},
+			// unit != vlan-id, has IPv6 (the #5107 failure case).
+			80: {Number: 80, VlanID: 180, Addresses: []string{
+				"172.16.80.8/24", "2001:db8:80::8/64"}},
+			// VLAN sub-interface present but IPv4-only: no link-local needed.
+			90: {Number: 90, VlanID: 190, Addresses: []string{"172.16.90.8/24"}},
+			// DHCPv6 counts as IPv6.
+			100: {Number: 100, VlanID: 200, DHCPv6: true},
+		},
+	}
+
+	tests := []struct {
+		name string
+		vid  int
+		want bool
+	}{
+		{"mismatch unit 80 vlan-id 180 with IPv6", 180, true},
+		{"same-value unit 50 vlan-id 50 with IPv6", 50, true},
+		{"IPv4-only sub-interface vlan-id 190", 190, false},
+		{"DHCPv6 sub-interface vlan-id 200", 200, true},
+		// vid 80 is a unit number, not a vlan-id: no matching sub-interface.
+		{"unit-number 80 is not a vlan-id", 80, false},
+		{"unknown vlan-id", 999, false},
+	}
+	for _, tt := range tests {
+		if got := rethSubIfaceNeedsLinkLocal(cfg, tt.vid); got != tt.want {
+			t.Errorf("%s: rethSubIfaceNeedsLinkLocal(vid=%d) = %v, want %v",
+				tt.name, tt.vid, got, tt.want)
+		}
+	}
+}
+
+// keys returns the set's members for error messages.
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/daemon/reth_unit_vlanid_5107_test.go
+++ b/pkg/daemon/reth_unit_vlanid_5107_test.go
@@ -116,7 +116,7 @@ func TestRethUnitForVlanID(t *testing.T) {
 // dupVIDWarn is the collision warning rethUnitForVlanID emits when several
 // units share a vlan-id (an invalid config). Kept in one place so the test
 // asserting it stays in lockstep with the production string.
-const dupVIDWarn = "reth: multiple units share a vlan-id; using lowest unit for IPv6 repair"
+const dupVIDWarn = "reth: multiple units share a vlan-id; using lowest unit for the netdev name (all matching units scanned for IPv6 link-local repair)"
 
 // TestRethUnitForVlanIDDuplicateDeterministic proves a duplicate vlan-id (an
 // invalid config) resolves deterministically to the lowest unit number
@@ -293,6 +293,61 @@ func TestRethSubIfaceNameNeedsLinkLocal(t *testing.T) {
 	}
 }
 
+// TestRethSubIfaceLinkLocalRepairDrivesEnsureByVlanID binds the per-sub-interface
+// repair ACTION that the post-MAC loop in applyDataplaneAndHACore delegates to:
+// removeAutoLinkLocal runs for every child (unconditional stale-LL strip) and
+// ensureRethLinkLocal runs ONLY when the resolved vlan-id carries IPv6. The two
+// netlink side-effects are swapped for spies so the decision path (parse +
+// vlan-id->unit resolve + all-units scan + repair ordering) is driven without
+// real netlink. The remaining unbound surface is just the netlink LinkList/
+// ParentIndex enumeration, which the loop delegates to this function in one line.
+//
+// Fail-on-revert: reverting rethSubIfaceNameNeedsLinkLocal's resolution to index
+// Units[vid] directly (`return rethUnitHasIPv6(rethCfg, vid)`) drops the ".180"
+// ensure (Units[180] is absent), so `ensured` no longer equals ["ge-7-0-1.180"].
+func TestRethSubIfaceLinkLocalRepairDrivesEnsureByVlanID(t *testing.T) {
+	var removed, ensured []string
+	origRemove := removeAutoLinkLocalFn
+	origEnsure := ensureRethLinkLocalFn
+	removeAutoLinkLocalFn = func(n string) { removed = append(removed, n) }
+	ensureRethLinkLocalFn = func(n string) { ensured = append(ensured, n) }
+	t.Cleanup(func() {
+		removeAutoLinkLocalFn = origRemove
+		ensureRethLinkLocalFn = origEnsure
+	})
+
+	cfg := &config.InterfaceConfig{
+		Name:            "reth0",
+		RedundancyGroup: 1,
+		Units: map[int]*config.InterfaceUnit{
+			// vlan-id 180 (!= unit 80), has IPv6.
+			80: {Number: 80, VlanID: 180, Addresses: []string{
+				"172.16.80.8/24", "2001:db8:80::8/64"}},
+			// vlan-id 190 (!= unit 90), IPv4-only.
+			90: {Number: 90, VlanID: 190, Addresses: []string{"172.16.90.8/24"}},
+		},
+	}
+
+	// Kernel VLAN sub-interface names the enumeration loop would hand us.
+	for _, sub := range []string{"ge-7-0-1.180", "ge-7-0-1.190", "ge-7-0-1.80"} {
+		rethSubIfaceLinkLocalRepair(cfg, sub)
+	}
+
+	// Stale-LL strip is unconditional: every child.
+	wantRemoved := []string{"ge-7-0-1.180", "ge-7-0-1.190", "ge-7-0-1.80"}
+	if !equalStrs(removed, wantRemoved) {
+		t.Errorf("removeAutoLinkLocalFn calls = %v, want %v (every child)",
+			removed, wantRemoved)
+	}
+	// ensure only for the IPv6-bearing vlan-id 180 -> unit 80. Not .190
+	// (IPv4-only) and not .80 (a unit number, not a vlan-id).
+	wantEnsured := []string{"ge-7-0-1.180"}
+	if !equalStrs(ensured, wantEnsured) {
+		t.Errorf("ensureRethLinkLocalFn calls = %v, want %v (only the IPv6 vlan-id)",
+			ensured, wantEnsured)
+	}
+}
+
 // TestDesiredClusterRAResolvesByVlanID binds the cluster RA ownership gate in
 // desiredClusterRA (daemon_ra_reconcile.go). An owned RG's RETH interfaces are
 // enumerated by rethInterfacesForRG, which suffixes by unit.VlanID (member.180);
@@ -352,6 +407,19 @@ func silenceLogs(t *testing.T) {
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	t.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+// equalStrs reports whether two string slices are equal in order and contents.
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // keys returns the set's members for error messages.


### PR DESCRIPTION
Closes #5107

## Problem

RETH logical units may carry a `vlan-id` that differs from the unit number
(valid Junos, e.g. `reth0 unit 80 vlan-id 180`). Two daemon paths conflated the
logical-unit identity with the vlan-id, so IPv6 RA and neighbor discovery
silently failed on such configs — especially after a RETH MAC link cycle
(RETH-recovery-adjacent).

Identity chain: **logical unit → configured vlan-id → kernel suffix.**

### STEP-0 evidence (master `394f53fa3`, both bugs present)

1. **RA name resolution kept the unit suffix.**
   `pkg/daemon/daemon_ra.go:100`
   ```go
   ra.Interface = config.LinuxIfName(cfg.ResolveReth(ra.Interface))
   ```
   `ResolveReth("reth0.80")` → `member.80` (unit suffix preserved), so RA bound
   to a netdev that does not exist. The real kernel VLAN sub-interface is
   `member.180`. Worse, `rethInterfacesForRG` (`pkg/daemon/daemon_ha.go:1039`)
   already suffixes by `unit.VlanID` (`member.180`), so the cluster RA owner
   match in `desiredClusterRA` (`ownedIfaces[ra.Interface]`) compared
   `member.180` against `member.80` and **dropped the sender entirely** on the
   cluster path when unit# != vlan-id.

2. **Post-MAC IPv6 repair did the inverse error.**
   `pkg/daemon/daemon_apply_dataplane.go:344-350` (the cited
   `daemon_apply.go:936-941` was stale)
   ```go
   if vid, err := strconv.Atoi(subName[dotIdx+1:]); err == nil {
       if rethUnitHasIPv6(rethCfg, vid) {   // vid=180 indexed into Units[180]
           ensureRethLinkLocal(subName)
       }
   }
   ```
   `subName` is a kernel VLAN sub-interface (`ge-7-0-1.180`); the parsed vid
   (180) was passed to `rethUnitHasIPv6`, which indexes `rethCfg.Units[180]`.
   `Units` is keyed by the **unit number (80)**, so the lookup missed and
   `ensureRethLinkLocal` was skipped → sub-interface came up with no link-local
   → `bpf_fib_lookup` returns `NO_NEIGH`.

## Fix

- **RA:** swap to `cfg.ResolveKernelIfName` (`pkg/config/types.go:172`), whose
  documented contract maps unit → configured vlan-id for the kernel suffix
  (`reth0.80` → `member.180`) and keeps `buildRAConfigs` consistent with
  `rethInterfacesForRG`, so the cluster owner match no longer drops the sender.
  Centralized in `buildRAConfigs`, so every caller (standalone
  `daemon_apply_routing.go`, cluster reconcile, HA goodbye) benefits, and plain
  VLAN interfaces with unit# != vlan-id are fixed too.
- **Post-MAC repair:** add `rethUnitForVlanID` (vlan-id → unit reverse lookup;
  ignores untagged units; resolves a duplicate vlan-id — an invalid config Junos
  rejects — to the lowest unit number deterministically with a `slog.Warn`) plus
  `rethSubIfaceNeedsLinkLocal`, and index `Units` by the resolved unit. Corrected
  the misleading `rethUnitHasIPv6` doc comment ("given unit number (VLAN ID)").

The common case (unit# == vlan-id) round-trips identically through both
resolvers — no behavior change.

## Tests (fail-on-revert) — `pkg/daemon/reth_unit_vlanid_5107_test.go`

- `TestBuildRAConfigsRethUnitVlanIDMismatch` — RA on `reth0.80` (vlan-id 180)
  resolves to `ge-0-0-0.180`, NOT `ge-0-0-0.80`; same-value `reth0.50` → `.50`.
- `TestRethUnitForVlanID` — vlan-id 180 → unit 80; vlan-id 50 → unit 50;
  **unit-number 80 is not a vlan-id → miss** (the key discriminator vs the old
  direct `Units[vid]` index); unknown/untagged → miss.
- `TestRethUnitForVlanIDDuplicateDeterministic` — duplicate vlan-id → lowest unit
  deterministically across 64 randomized map iterations.
- `TestRethSubIfaceNeedsLinkLocal` — IPv6 and DHCPv6 sub-interfaces need a
  link-local; IPv4-only does not; unit-number-as-vid → no repair.

**Parent-RED recipe (verified both directions):**
- Bug 1: restore `ra.Interface = config.LinuxIfName(cfg.ResolveReth(ra.Interface))`
  in `daemon_ra.go` → `TestBuildRAConfigsRethUnitVlanIDMismatch` fails
  (resolves `ge-0-0-0.80`).
- Bug 2: replace `rethSubIfaceNeedsLinkLocal`'s body with
  `return rethUnitHasIPv6(rethCfg, vid)` → `TestRethSubIfaceNeedsLinkLocal`
  fails (`vid=180` misses `Units[180]`).

`go test ./pkg/daemon/... ./pkg/config/...` and `go vet` pass (the one
`event_stream` socket-bind failure under my long `GOTMPDIR` is the known
`sun_path` 108-limit issue, green under a short TMPDIR — not a regression).
`gofmt` clean.

## Docs

`docs/ha-cluster-test-plan.md` RA-resolution note updated from
`ResolveReth() + LinuxIfName()` to `ResolveKernelIfName()` with the identity
chain. The resolver's own contract (`ResolveKernelIfName` doc comment in
`types.go`) already specified the correct unit → vlan-id mapping; this PR brings
the daemon RA/repair paths into line with it.

## Merge note

This is RETH / RA-recovery-adjacent — a loss-cluster failover + IPv6-RA smoke is
advisable at merge (PARENT runs it).