### PR TITLE
cluster: clear dormant transfer-out lease on ResetFailover (#6301 item 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57673,3 +57673,16 @@ top.
 - **File(s)**: pkg/daemon/daemon_reth.go,
     pkg/daemon/daemon_apply_dataplane.go,
     pkg/daemon/reth_unit_vlanid_5107_test.go
+
+- **Timestamp**: 2026-07-22
+  **Action**: #6301 item 1 — clear the dormant remoteTransferOutLease entry in
+    ResetFailover (map hygiene, mirrors the ManualFailover / ForceSecondary /
+    ManualFailoverBatch reset paths) with a fail-on-revert test. Item 2
+    (lease-sizing hardening) DROPPED as unnecessary: the fixed 20s
+    failover-ACK cap (failoverAckTimeout, sync.go) bounds a real commit's
+    arrival latency to ~20s+settle (< the existing 26s lease), so a large
+    failoverActuateTimeout cannot delay a real commit past the lease — it
+    times the requester out (no commit), the case the lease already handles.
+    README notes this bound.
+  **File(s)**: pkg/cluster/failover.go, pkg/cluster/README.md,
+    pkg/cluster/failover_lease_5079_test.go, pkg/daemon/daemon_ha_sync.go

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -707,12 +707,19 @@ outside the monitor loop:
   already rides the failover request/commit payloads), so no mixed-base
   compatibility concern, and it defends against requester death/partition that an
   abort frame could not. Only a REMOTE transfer-out arms a lease; `ManualFailover`
-  / `ManualFailoverBatch` / `ForceSecondary` clear any stale entry at the demotion
-  site so a deliberate operator or ISSU hold is never auto-restored. The lease
+  / `ManualFailoverBatch` / `ForceSecondary` / `ResetFailover` clear any stale
+  entry at their demotion/reset site so a deliberate operator or ISSU hold is
+  never auto-restored (`ResetFailover` clears it for map hygiene — its restore is
+  already gated on `ManualFailover`, which the reset clears; #6301). The lease
   duration (`SetRemoteTransferOutLeaseDuration`, default
   `DefaultRemoteTransferOutLease` = 30s, floored at 15s) is sized above the
   requester's worst-case post-ACK commit latency (local commit-ready settle +
-  commit round-trip) so a legitimate slow commit never trips it. reqID is threaded
+  commit round-trip) so a legitimate slow commit never trips it. The upstream 20s
+  failover-ACK cap (`failoverAckTimeout`, `sync.go`) further bounds this: if the
+  owner's actuation barrier delays the applied-ack past 20s the requester times
+  out and sends NO commit — the exact stranded case the lease-expiry restore
+  handles — so a large `failoverActuateTimeout` cannot delay a real commit past
+  the lease. reqID is threaded
   into `OnRemoteFailover`/`OnRemoteFailoverBatch`/`OnRemoteFailoverCommit`/
   `OnRemoteFailoverCommitBatch` (`sync.go`) to arm/clear it.
 - HA delete-sync callbacks fire from the GC loop. They must not block, and

--- a/pkg/cluster/failover.go
+++ b/pkg/cluster/failover.go
@@ -190,6 +190,13 @@ func (m *Manager) ResetFailover(rgID int) error {
 	}
 	rg.ManualFailover = false
 	rg.ManualFailoverAt = time.Time{}
+	// Drop any armed remote transfer-out lease for this RG, mirroring the
+	// ManualFailover / ForceSecondary(ISSU) / ManualFailoverBatch reset paths.
+	// The lease's electRG auto-restore is gated on ManualFailover, so a leftover
+	// entry is inert once we clear the hold here — but leaving it in the maps
+	// lets repeated resets accumulate dormant entries. Clearing it keeps the
+	// lease maps in lockstep with ManualFailover on every reset path (#6301).
+	m.clearRemoteTransferOutLeaseLocked(rgID)
 	// Invalidate any in-flight ManualFailover / ManualFailoverBatch whose
 	// pre-failover hook released m.mu: bump the per-RG failover generation so
 	// its post-hook re-check abandons the trailing SecondaryHold write instead

--- a/pkg/cluster/failover_lease_5079_test.go
+++ b/pkg/cluster/failover_lease_5079_test.go
@@ -144,6 +144,54 @@ func TestLocalManualFailoverClearsRemoteTransferOutLease(t *testing.T) {
 	}
 }
 
+// TestResetFailoverClearsRemoteTransferOutLease is the #6301 fail-on-revert
+// guard. A peer failover request demotes this node and arms a reqID-bound
+// auto-restore lease. An operator then runs `request ... reset`
+// (ResetFailover), which clears ManualFailover — but before #6301 it left the
+// remoteTransferOutLease{Until,ReqID} entry dormant in the maps. Repeated
+// resets accumulate dead entries. ResetFailover must clear the lease too,
+// mirroring the ManualFailover / ForceSecondary(ISSU) / ManualFailoverBatch
+// reset paths, so the lease maps stay in lockstep with ManualFailover.
+//
+// Revert the clearRemoteTransferOutLeaseLocked call added to ResetFailover and
+// this test goes RED: the lease entry survives the reset.
+func TestResetFailoverClearsRemoteTransferOutLease(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200}))
+	m.UpdateConfig(cfg)
+	<-m.Events()
+
+	if err := m.ManualFailover(0); err != nil {
+		t.Fatalf("ManualFailover() error = %v", err)
+	}
+	<-m.Events()
+	m.ArmRemoteTransferOutLease([]int{0}, 13)
+
+	// Sanity: the lease is armed before the reset.
+	m.mu.Lock()
+	_, untilBefore := m.remoteTransferOutLeaseUntil[0]
+	_, reqIDBefore := m.remoteTransferOutLeaseReqID[0]
+	m.mu.Unlock()
+	if !untilBefore || !reqIDBefore {
+		t.Fatal("precondition: remote transfer-out lease must be armed before ResetFailover")
+	}
+
+	if err := m.ResetFailover(0); err != nil {
+		t.Fatalf("ResetFailover() error = %v", err)
+	}
+
+	m.mu.Lock()
+	_, untilAfter := m.remoteTransferOutLeaseUntil[0]
+	_, reqIDAfter := m.remoteTransferOutLeaseReqID[0]
+	m.mu.Unlock()
+	if untilAfter {
+		t.Fatal("ResetFailover must clear the remote transfer-out lease Until entry")
+	}
+	if reqIDAfter {
+		t.Fatal("ResetFailover must clear the remote transfer-out lease ReqID entry")
+	}
+}
+
 // TestRemoteTransferOutLeaseRestoresBatchOwners exercises the multi-RG path: a
 // batch transfer-out arms a lease per RG, and expiry restores every member.
 func TestRemoteTransferOutLeaseRestoresBatchOwners(t *testing.T) {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -1067,7 +1067,11 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			// #5079: size the owner-side transfer-out lease above the requester's
 			// worst-case post-ACK commit latency — the local commit-ready settle
 			// window (localFailoverCommitTimeout) plus the commit round-trip — so
-			// a legitimate slow commit never trips it. The cluster floors it.
+			// a legitimate slow commit never trips it. The cluster floors it. The
+			// upstream 20s failover-ACK cap (failoverAckTimeout, sync.go) bounds
+			// the actuation-barrier contribution: if the owner takes longer than
+			// 20s to ack, the requester times out and sends NO commit, so a large
+			// failoverActuateTimeout cannot delay a real commit past this lease.
 			d.cluster.SetRemoteTransferOutLeaseDuration(2*d.localFailoverCommitTimeout + 20*time.Second)
 			d.cluster.SetTransferReadinessFunc(d.userspaceTransferReadiness)
 			d.cluster.SetPeerTimeoutGuard(d.shouldSuppressPeerHeartbeatTimeout)


### PR DESCRIPTION
Closes #6301

MINOR #5079 follow-up — **item 1 only**. Item 2 (optional lease-sizing
hardening) is **deferred as unnecessary**; a separate tracking issue captures
Codex's analysis (see below). HA-adjacent (cluster failover) — a loss-cluster
failover smoke may be advisable at merge (PARENT decides).

## Item 1 — clear dormant lease entry in ResetFailover
`ResetFailover` cleared `rg.ManualFailover` but left the
`remoteTransferOutLease{Until,ReqID}` map entry for that RG in place. The
lease's `electRG` auto-restore is gated on `ManualFailover` (which the reset
clears), so a leftover entry is inert today — but repeated `request ... reset`
calls accumulate dormant entries in the lease maps. `ResetFailover` now calls
`clearRemoteTransferOutLeaseLocked(rgID)`, mirroring the `ManualFailover` /
`ForceSecondary`(ISSU) / `ManualFailoverBatch` reset paths so the lease maps
stay in lockstep with `ManualFailover` on every reset path. No behavior change.

### Fail-on-revert test
`pkg/cluster` `TestResetFailoverClearsRemoteTransferOutLease`: arms a lease for
RG 0, calls `ResetFailover`, asserts both lease maps are cleared.
**Neutralization:** comment out the added
`clearRemoteTransferOutLeaseLocked(rgID)` call → RED (`ResetFailover must clear
the remote transfer-out lease Until entry`).

## Item 2 — DEFERRED as unnecessary (firsthand trace)
Item 2 proposed sizing the lease as `failoverActuateTimeout +
localFailoverCommitTimeout + localFailoverCommitDelay + slack` to defend a
`failoverActuateTimeout ≫ commitTimeout` config. A firsthand trace shows this
is a non-problem:

- `failoverAckTimeout = 20 * time.Second` is a **fixed constant**
  (`pkg/cluster/sync.go:89`), independent of `failoverActuateTimeout`.
- The requester's `SendFailover`/`SendFailoverBatch` wait for the owner's
  applied-ack with that 20s timer. The owner sends the ack only **after** its
  actuation barrier (`WaitFailoverApplied` = `waitFailoverActuated`, bounded by
  `failoverActuateTimeout`), which runs **inside** the requester's 20s ack-wait
  window.
- `RequestPeerFailover` does `reqID, err := fn(rgID); if err != nil { return
  err }` — on ack timeout it returns **without ever sending a commit**.

So if the actuation barrier delays the ack past ~20s, the requester times out
and sends no commit — the exact stranded-secondary case the lease-expiry
restore already handles. A real commit therefore only follows an ack that
arrived within 20s, bounding commit-arrival latency to **≈ 20s +
localFailoverCommitTimeout + localFailoverCommitDelay + net ≈ 23.2s** under the
default config, which the **existing 26s lease already exceeds**. A large
`failoverActuateTimeout` cannot delay a real commit past the lease. Dropped;
tracking issue filed for item 2 with this analysis.

## Validation
- `go test ./pkg/cluster/... ./pkg/daemon/...` green.
- `go vet` + `gofmt` clean.
- `pkg/cluster/README.md` updated: `ResetFailover` added to the lease-clearing
  set, and the 20s ACK-cap bound on commit-arrival documented.