### PR TITLE
configstore: stamp config-sync applied marker under applySem (#6296)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57547,3 +57547,26 @@ top.
 - **File(s)**: pkg/daemon/daemon_reth.go,
     pkg/daemon/daemon_apply_dataplane.go,
     pkg/daemon/reth_unit_vlanid_5107_test.go
+
+- **Timestamp**: 2026-07-22
+- **Action**: #6296 — stamp the config-sync applied marker INSIDE syncAndApply
+    under applySem, keyed to a digest captured for the config it applied, rather
+    than in handleConfigSync AFTER applySem release keyed to a re-read of
+    s.active. Closes the MINOR TOCTOU where a concurrent secondary-side promoter
+    (local commit / commit-confirmed rollback) mutating s.active in the release
+    window could make the marker key the wrong, never-applied active digest ->
+    false convergence on a later re-push. Added configstore.ActiveDigest (returns
+    configTextDigest(s.active.Format()), the ActiveApplied space) + MarkAppliedDigest
+    (stamps a caller-captured digest; empty = no-op). syncAndApply captures the
+    digest right after SyncApply and replays it in the armedActive deferred only
+    on retErr==nil (preserving the prior full-success gate). Removed the
+    post-release MarkActiveApplied in handleConfigSync. Fail-on-revert: daemon
+    test drives handleConfigSync with an injected promoter mutating s.active->cfgB
+    inside applyBodyForTest and asserts the marker keys the applied cfgA (RED when
+    reverted to post-release s.active stamp); store test binds the capture/replay
+    pair + empty no-op. Docs updated (configstore README, sync-protocol.md).
+- **File(s)**: pkg/configstore/store.go,
+    pkg/configstore/applied_digest_6296_test.go,
+    pkg/daemon/daemon_apply_commit.go, pkg/daemon/daemon_ha_sync.go,
+    pkg/daemon/configsync_markapplied_6296_test.go,
+    pkg/configstore/README.md, docs/sync-protocol.md

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -518,11 +518,16 @@ finished applying (a transient networkd/nft/IPsec tail error) as converged: the
 primary's same-generation re-push would take the fast path, return `nil`, and
 advance the high-water past a config whose dataplane never converged — a standby
 that acks a generation it never applied and can expose stale/disarmed forwarding
-at failover. `ActiveApplied()` is a config-text digest the daemon stamps
-(`MarkActiveApplied`) ONLY after a fully-successful apply — the boot apply
-(`applyConfig`), a committed config (`applyAndSyncCommitted`), and a peer
-config-sync (`handleConfigSync` after `syncAndApply` returns nil). It is FALSE in
-the window between promotion and a successful apply, so a re-push of a
+at failover. `ActiveApplied()` is a config-text digest the daemon stamps ONLY
+after a fully-successful apply — the boot apply (`applyConfig`) and a committed
+config (`applyAndSyncCommitted`) stamp `MarkActiveApplied` while holding the
+apply semaphore, and a peer config-sync stamps it from INSIDE `syncAndApply`
+(#6296): it captures the digest of the tree `SyncApply` promoted via
+`ActiveDigest` and replays it via `MarkAppliedDigest` on full success, both under
+the apply semaphore, rather than re-reading `s.active` after the semaphore is
+released (where a concurrent secondary-side promoter could have mutated it into a
+different, never-applied tree). It is FALSE in the window between promotion and a
+successful apply, so a re-push of a
 promoted-but-unapplied config falls through to `syncAndApply` and RE-ATTEMPTS the
 apply (reconcile retry) instead of being swallowed as converged. Because the
 marker is keyed on the config text, a stale value can only make the shortcut MORE
@@ -604,8 +609,9 @@ daemon-stop context abort (#2926) — where the config is not live-forwarding an
 the invalidators are correctly skipped; on those `syncAndApply` returns a nil
 config plus the error. Any other tail error is surfaced (joined with any partial
 #5578 invalidation error) AFTER the invalidators run, so the high-water mark does
-not advance. On such a non-fatal tail error the daemon does NOT stamp
-`MarkActiveApplied` (that runs only when `syncAndApply` returns nil), so
+not advance. On such a non-fatal tail error `syncAndApply` does NOT stamp the
+applied marker (`MarkAppliedDigest` runs only when its deferred sees `retErr ==
+nil` — no fatal or non-fatal apply error and no partial invalidation; #6296), so
 `ActiveApplied()` stays false and the primary's re-push does NOT take the
 active-text fast path (#4957): it re-enters `syncAndApply` and RE-ATTEMPTS the
 apply and the invalidators, completing the reconcile/finalization the tail error

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -110,19 +110,32 @@ inline archive-site passwords).
   `CommitCheck`, `CommitConfirmed`, `Rollback`, `ListHistory`,
   `EnterConfigure`, `EnterConfigureSession`,
   `EnterConfigureExclusive`, `ExitConfigure`, `SyncApply`,
-  `MarkActiveApplied`, `ActiveApplied`. (See
+  `MarkActiveApplied`, `ActiveApplied`, `ActiveDigest`,
+  `MarkAppliedDigest`. (See
   `store.go` for the full surface — there's no shorthand
   `Candidate()` or `History()`; use the `Show*` / `List*` forms.)
-- `MarkActiveApplied` / `ActiveApplied` — the #4957 applied-config marker.
+- `MarkActiveApplied` / `MarkAppliedDigest` / `ActiveApplied` / `ActiveDigest` —
+  the #4957 applied-config marker (+ the #6296 capture/replay pair).
   `SyncApply` (and `Commit`/`Load`) promote `s.active` BEFORE the daemon runs
   the apply and, under the #1799 degrade-not-fail doctrine, do NOT roll it back
   on an apply failure — so a config can be the active tree yet never have
-  converged on the dataplane. The daemon calls `MarkActiveApplied` after a
+  converged on the dataplane. The daemon stamps the marker after a
   fully-successful `applyConfigLocked` (boot, commit, config-sync); `ActiveApplied`
   reports whether the CURRENT active text matches that last-applied digest.
   `pkg/daemon` `handleConfigSync` ANDs its active-text convergence shortcut with
   `ActiveApplied()` so a promoted-but-unapplied synced config is not treated as
-  converged (the HA config high-water then stays pinned until a retry lands). The
+  converged (the HA config high-water then stays pinned until a retry lands).
+  Two ways to stamp: `MarkActiveApplied` re-reads `s.active` at call time (the
+  boot/commit paths use it while holding the apply semaphore, when active is
+  stable); `MarkAppliedDigest` stamps a digest the caller CAPTURED earlier via
+  `ActiveDigest`, for the exact config it applied. The config-sync receive path
+  (`daemon.syncAndApply`) uses the capture/replay pair (#6296): it captures the
+  digest right after `SyncApply` promotes the peer config and replays it on full
+  success, both under the apply semaphore — so a concurrent secondary-side
+  promoter (a local commit / commit-confirmed rollback) mutating `s.active` in
+  what used to be a post-semaphore-release window can no longer make the marker
+  key a different, never-applied tree. `ActiveDigest` returns exactly the value
+  `ActiveApplied` compares against (`configTextDigest(s.active.Format())`). The
   marker is keyed on config text, so a stale value can only cause an idempotent
   re-apply, never a false convergence.
 - `MaxConfigSize` (16 MiB) + `checkConfigSize` — `store.go`. The

--- a/pkg/configstore/applied_digest_6296_test.go
+++ b/pkg/configstore/applied_digest_6296_test.go
@@ -1,0 +1,81 @@
+package configstore
+
+import "testing"
+
+// TestMarkAppliedDigest_KeysCapturedNotCurrentActive locks the #6296 store
+// contract: MarkAppliedDigest stamps a digest the caller CAPTURED earlier (via
+// ActiveDigest, under its own apply serialization) rather than re-reading
+// s.active. So when a concurrent promoter mutates s.active between the capture
+// and the stamp, the marker still keys the config that was actually applied —
+// not whatever active drifted to. This is the store-level property behind the
+// daemon relocation of the config-sync stamp into syncAndApply.
+//
+// Contrast MarkActiveApplied (re-reads s.active at call time): TestActiveApplied
+// (#4957) covers that path. Here we prove the capture/replay pair keys the
+// captured tree even across an intervening promotion.
+func TestMarkAppliedDigest_KeysCapturedNotCurrentActive(t *testing.T) {
+	s := newTestStore(t)
+
+	confA := "system {\n    host-name applied-a;\n}\n"
+	confB := "system {\n    host-name promoter-b;\n}\n"
+
+	// Promote + capture the digest of config A (what the caller "applied").
+	if _, err := s.SyncApply(confA, nil); err != nil {
+		t.Fatalf("SyncApply(A): %v", err)
+	}
+	if s.ActiveApplied() {
+		t.Fatal("promoted-but-unstamped A must not read applied")
+	}
+	capturedA := s.ActiveDigest()
+	if capturedA == "" {
+		t.Fatal("ActiveDigest must be non-empty for a promoted config")
+	}
+
+	// A concurrent promoter lands and mutates active to a DIFFERENT config B
+	// BEFORE the applied marker is stamped.
+	if _, err := s.SyncApply(confB, nil); err != nil {
+		t.Fatalf("SyncApply(B): %v", err)
+	}
+
+	// Stamp the digest captured for A. Because MarkAppliedDigest keys the CAPTURED
+	// value (not a re-read of s.active == B), the current active B must NOT read
+	// as applied — B's apply never happened.
+	s.MarkAppliedDigest(capturedA)
+	if s.ActiveApplied() {
+		t.Fatal("#6296: MarkAppliedDigest(capturedA) must key A's digest, so the " +
+			"concurrently-promoted active B must not read applied")
+	}
+
+	// Restore active to A (the config that WAS applied): now the captured marker
+	// matches and ActiveApplied() reads true — proving the stamp keyed A, and that
+	// ActiveDigest lives in the same space ActiveApplied compares against.
+	if _, err := s.SyncApply(confA, nil); err != nil {
+		t.Fatalf("SyncApply(A again): %v", err)
+	}
+	if !s.ActiveApplied() {
+		t.Fatal("#6296: after restoring active to the applied config A, the marker " +
+			"captured for A must read as applied")
+	}
+}
+
+// TestMarkAppliedDigest_EmptyIsNoOp locks that an empty captured digest does not
+// clear or overwrite an existing marker (the defensive nil-active path in
+// syncAndApply must not disarm a previously-applied config).
+func TestMarkAppliedDigest_EmptyIsNoOp(t *testing.T) {
+	s := newTestStore(t)
+
+	conf := "system {\n    host-name node-x;\n}\n"
+	if _, err := s.SyncApply(conf, nil); err != nil {
+		t.Fatalf("SyncApply: %v", err)
+	}
+	s.MarkAppliedDigest(s.ActiveDigest())
+	if !s.ActiveApplied() {
+		t.Fatal("setup: config must read applied after stamping its captured digest")
+	}
+
+	// An empty stamp must leave the marker intact.
+	s.MarkAppliedDigest("")
+	if !s.ActiveApplied() {
+		t.Fatal("#6296: MarkAppliedDigest(\"\") must be a no-op, not clear the marker")
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -789,3 +789,42 @@ func (s *Store) ActiveApplied() bool {
 	}
 	return s.appliedDigest == configTextDigest(s.active.Format())
 }
+
+// ActiveDigest returns the convergence digest of the CURRENT active config
+// text — exactly the value ActiveApplied() compares appliedDigest against
+// (configTextDigest(s.active.Format()), the ShowActive render). It lets a
+// caller CAPTURE the digest of the config it is about to apply, under its own
+// apply serialization, and stamp that captured value later via
+// MarkAppliedDigest — instead of re-reading s.active at stamp time. A concurrent
+// promoter (a local commit / commit-confirmed rollback) that mutated s.active
+// between the apply and a post-serialization stamp would otherwise make
+// MarkActiveApplied key the marker to a different, never-applied tree (the #6296
+// TOCTOU). Empty when active is nil (nothing to have applied).
+func (s *Store) ActiveDigest() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.active == nil {
+		return ""
+	}
+	return configTextDigest(s.active.Format())
+}
+
+// MarkAppliedDigest records that the config whose convergence digest is
+// `digest` has completed a full apply to the dataplane/kernel (#6296). Unlike
+// MarkActiveApplied — which re-reads s.active at call time — it stamps a digest
+// the caller captured earlier (via ActiveDigest) for the exact tree it applied.
+// So a stamp taken after the apply serialization is released, or one racing a
+// concurrent promoter that mutated s.active in that window, cannot key the
+// marker to a different, never-applied tree. The cluster config-sync path
+// (daemon.syncAndApply) captures the digest right after SyncApply promotes the
+// peer config — while still holding the apply semaphore — and replays it here on
+// full success. An empty digest is a no-op (nothing was captured / applied); it
+// deliberately does NOT clear a prior digest.
+func (s *Store) MarkAppliedDigest(digest string) {
+	if digest == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.appliedDigest = digest
+}

--- a/pkg/daemon/configsync_markapplied_6296_test.go
+++ b/pkg/daemon/configsync_markapplied_6296_test.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestHandleConfigSync_AppliedMarkerKeysAppliedConfigNotRacedActive is the
+// #6296 regression. Before the fix, handleConfigSync stamped the applied marker
+// (MarkActiveApplied) AFTER syncAndApply had RELEASED applySem, and
+// MarkActiveApplied re-read s.active at stamp time. A concurrent secondary-side
+// promoter (a local commit / commit-confirmed rollback) landing in that
+// post-release window mutated s.active, so the stamp keyed the WRONG (never-
+// applied-through-this-path) active digest — a later re-push of that exact text
+// would then be falsely treated as converged and advance the config high-water
+// past a config the dataplane never converged.
+//
+// The fix relocates the stamp INTO syncAndApply, under applySem, keyed to a
+// digest captured for the exact config SyncApply promoted (ActiveDigest ->
+// MarkAppliedDigest). This test simulates the concurrent promoter by mutating
+// s.active to a DIFFERENT config from inside the apply body (applyBodyForTest),
+// which — for BOTH the old and new code — runs before the applied-marker stamp.
+// It then asserts the marker reflects the config that was APPLIED (cfgA), not
+// the promoter's raced config (cfgB).
+//
+// Fail-on-revert:
+//   - Reverting the stamp to a post-applySem-release MarkActiveApplied() in
+//     handleConfigSync keys the marker to s.active == cfgB at stamp time, so
+//     ActiveApplied() reads TRUE for cfgB (which was never applied) — the first
+//     assertion goes RED.
+//   - Removing the stamp entirely leaves the marker unset, so restoring active
+//     to the applied config cfgA reads FALSE — the second assertion goes RED.
+func TestHandleConfigSync_AppliedMarkerKeysAppliedConfigNotRacedActive(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "config.db"))
+
+	// The canonical hierarchical text a primary pushes for each config. cfgA is
+	// the config this sync APPLIES; cfgB is what a concurrent promoter races into
+	// s.active before the applied marker is stamped.
+	cfgA := renderSyncedConfigText(t, "system host-name applied-a")
+	cfgB := renderSyncedConfigText(t, "system host-name promoter-b")
+
+	var promoterFired bool
+	d := &Daemon{
+		// No cluster manager: standalone passes the config-authority guard and
+		// makes the topology/identity preflights no-ops. No dataplane: the deferred
+		// session invalidation short-circuits (nil dp).
+		store:    store,
+		applySem: semaphore.NewWeighted(1),
+	}
+	// The apply-body seam replaces the real reconcile pipeline. It also injects
+	// the concurrent promoter EXACTLY ONCE: after syncAndApply's SyncApply(cfgA)
+	// promoted active to A (and, under the fix, after ActiveDigest captured A's
+	// digest), a secondary-side promoter lands and mutates s.active to B. In BOTH
+	// old and new code this runs before the applied-marker stamp, so it isolates
+	// which config the stamp keys.
+	d.applyBodyForTest = func(*config.Config) {
+		if promoterFired {
+			return
+		}
+		promoterFired = true
+		if _, err := store.SyncApply(cfgB, nil); err != nil {
+			t.Errorf("injected promoter SyncApply(cfgB): %v", err)
+		}
+	}
+
+	if err := d.handleConfigSync(cfgA); err != nil {
+		t.Fatalf("handleConfigSync(cfgA): %v", err)
+	}
+	if !promoterFired {
+		t.Fatal("test setup: apply body (and the injected promoter) never ran — " +
+			"the sync must have reached applyConfigLocked")
+	}
+	if got := store.ShowActive(); got != cfgB {
+		t.Fatalf("test setup: expected active to be the promoter's cfgB, got:\n%s", got)
+	}
+
+	// s.active is now cfgB (the promoter's config), which was NEVER applied
+	// through the daemon apply path. The applied marker must therefore NOT report
+	// the current active as applied: with the fix it keyed cfgA's captured digest,
+	// so ActiveApplied() (which compares against the CURRENT active == cfgB) is
+	// false. Reverting to the post-release MarkActiveApplied() keys cfgB and this
+	// reads TRUE — RED.
+	if store.ActiveApplied() {
+		t.Fatal("#6296: applied marker must NOT key the concurrently-promoted, " +
+			"never-applied active (cfgB); it must key the config syncAndApply " +
+			"actually applied (cfgA)")
+	}
+
+	// Positive: restore active to cfgA (the config that WAS applied) with a bare
+	// store promotion that does NOT re-stamp the marker. Now ActiveApplied() must
+	// read TRUE, proving the marker keyed cfgA's digest. Under a revert that
+	// removed the stamp the marker is unset, so this reads FALSE — RED.
+	if _, err := store.SyncApply(cfgA, nil); err != nil {
+		t.Fatalf("restore active to cfgA: %v", err)
+	}
+	if !store.ActiveApplied() {
+		t.Fatal("#6296: applied marker must key the digest of the config that was " +
+			"applied (cfgA) — restoring active to cfgA must read as applied")
+	}
+}

--- a/pkg/daemon/daemon_apply_commit.go
+++ b/pkg/daemon/daemon_apply_commit.go
@@ -422,6 +422,21 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 	// between the apply and here cannot re-introduce the skip. It does NOT run on
 	// a genuinely-fatal apply (see below), where the config is not live-forwarding
 	// and there is no session state to invalidate.
+
+	// #6296: capture the convergence digest of the tree SyncApply just promoted,
+	// while applySem is still held and BEFORE applyConfigLocked. The applied
+	// marker is stamped from this captured value in the deferred below (only on
+	// full success), so it records the config THIS sync actually applied — not a
+	// re-read of s.active at stamp time. Before #6296 handleConfigSync stamped
+	// MarkActiveApplied() AFTER syncAndApply released applySem, keyed to whatever
+	// s.active was then: a concurrent secondary-side promoter (a local commit /
+	// commit-confirmed rollback) landing in that post-release window, whose own
+	// apply then failed non-fatally, could make the stamp key the WRONG
+	// (unapplied) active digest, and a later re-push of that text would be falsely
+	// treated as converged (TOCTOU). ActiveDigest keys the same space
+	// ActiveApplied() reads (configTextDigest(s.active.Format())).
+	appliedDigest := d.store.ActiveDigest()
+
 	var armedActive bool
 	defer func() {
 		if !armedActive {
@@ -446,6 +461,19 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 		// documented end-state follow-up.)
 		d.deviceMapPassiveAdmissionAlarm(compiled)
 		retErr = errors.Join(retErr, clearErr)
+		// #6296: stamp the applied marker HERE — inside syncAndApply while
+		// applySem is still held (this defer runs before the applySem.Release
+		// defer registered above), keyed to the digest captured above from the
+		// tree SyncApply promoted. Stamp only on FULL success (retErr == nil after
+		// the clearErr join: no fatal or non-fatal apply error AND no partial
+		// session-invalidation), matching the prior handleConfigSync gate which
+		// stamped MarkActiveApplied only when syncAndApply returned nil. A no-op
+		// on empty digest (nil-active defensive path) or a non-nil retErr leaves
+		// the prior digest, so a config whose apply did not fully converge is never
+		// marked applied — the #4957 invariant handleConfigSync's shortcut relies on.
+		if retErr == nil {
+			d.store.MarkAppliedDigest(appliedDigest)
+		}
 	}()
 
 	// #5564: capture the apply error instead of returning early on ANY error.

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -579,14 +579,14 @@ func (d *Daemon) handleConfigSync(configText string) error {
 		slog.Error("cluster: config sync apply failed", "err", err)
 		return err
 	}
-	// #4957: the sync applied to completion (syncAndApply returned nil, so both
-	// the dataplane apply and the session invalidation succeeded). Record the
-	// active config as applied so a duplicate re-push takes the converged
-	// shortcut above — and, conversely, so a config that only PROMOTED active but
-	// failed to apply does NOT, keeping the high-water pinned until a retry lands.
-	if d.store != nil {
-		d.store.MarkActiveApplied()
-	}
+	// #4957/#6296: on full success syncAndApply itself stamps the applied marker
+	// — from a digest captured for the config it applied, while still holding
+	// applySem — so a duplicate re-push takes the converged shortcut above, and a
+	// config that only PROMOTED active but failed to apply does NOT (keeping the
+	// high-water pinned until a retry lands). The stamp moved INTO syncAndApply
+	// (from a post-applySem-release MarkActiveApplied here) so a concurrent
+	// secondary-side promoter mutating s.active in the release window can no
+	// longer make the marker key the wrong, unapplied active digest (#6296).
 	slog.Info("cluster: config sync applied successfully")
 	return nil
 }


### PR DESCRIPTION
Closes #6296

## Problem (STEP-0 evidence, verified on current origin/master)

`handleConfigSync` (`pkg/daemon/daemon_ha_sync.go`) stamped the #4957
applied-config marker by calling `d.store.MarkActiveApplied()` **after**
`syncAndApply` had returned and **released `d.applySem`**, and
`MarkActiveApplied` re-reads `s.active` at stamp time:

```go
if _, err := d.syncAndApply(context.Background(), configText, nil); err != nil { ... }
// ...applySem already released...
if d.store != nil {
    d.store.MarkActiveApplied()   // re-reads s.active
}
```

`configstore.MarkActiveApplied` stamps `configTextDigest(s.active.Format())`.
This opens a narrow TOCTOU: a concurrent **secondary-side promoter** (a
local commit, or a commit-confirmed rollback — both mutate `s.active`)
landing in the post-`applySem`-release window promotes `s.active` to a
different config. Under the #1799 degrade-not-fail doctrine a promoter
whose own apply then fails non-fatally leaves that tree **active but
unapplied**. The stray `MarkActiveApplied` then stamps the **wrong,
never-applied** active digest, and a later re-push of that exact text
takes `handleConfigSync`'s converged shortcut (`activeText == incomingText
&& ActiveApplied()`), advancing the config high-water past a config whose
dataplane never converged — a stale/disarmed standby, visible at failover.

LOW / architecturally-unlikely: needs secondary-side local config
activity racing the sync, a µs window, a failing apply, and the primary
re-pushing that exact text. A #4957 follow-up hardening.

## Fix

Stamp **inside `syncAndApply`, under `applySem`**, keyed to the config it
actually applied — not a post-release re-read of `s.active`. The other
two stamp sites (`applyConfig`, `applyAndSyncCommitted`) already stamp
under `applySem` with a stable active and are unchanged.

- New `configstore.ActiveDigest()` returns
  `configTextDigest(s.active.Format())` — exactly the value
  `ActiveApplied()` compares against (same text-space as `ShowActive`).
- New `configstore.MarkAppliedDigest(digest)` stamps a **caller-captured**
  digest (empty = no-op; does not clear a prior digest).
- `syncAndApply` captures the digest right after `SyncApply` promotes the
  peer config (`chassisPreserve` is always nil for its sole caller, so
  `s.active` == the parse of `configText`) and replays it from the
  `armedActive` deferred **only when `retErr == nil`** — preserving the
  prior full-success gate (no fatal/non-fatal apply error, no partial
  session invalidation). The `armedActive` defer runs before the
  `applySem.Release` defer, so the stamp is under the semaphore.
- The post-release `MarkActiveApplied` in `handleConfigSync` is removed.

## Tests (fail-on-revert)

- **`pkg/daemon` `TestHandleConfigSync_AppliedMarkerKeysAppliedConfigNotRacedActive`** —
  drives `handleConfigSync(cfgA)` with an injected promoter that mutates
  `s.active` to `cfgB` from inside `applyBodyForTest` (which runs before
  the stamp in both old and new code), then asserts the marker keys the
  **applied** config: the racing active `cfgB` must **not** read applied,
  and restoring active to `cfgA` **must**.
  RED neutralization: reverting the two daemon files to origin/master
  (post-release `MarkActiveApplied` keyed to `s.active == cfgB`) makes
  `ActiveApplied()` read TRUE for `cfgB` → the first assertion fails
  (`applied marker must NOT key the concurrently-promoted... active`).
  Verified by restoring origin/master then reinstating the fix.
- **`pkg/configstore` `TestMarkAppliedDigest_KeysCapturedNotCurrentActive`** —
  binds the store capture/replay contract directly: capture cfgA's
  digest, promote cfgB, stamp the captured digest → cfgB reads
  not-applied; restore cfgA → applied.
  RED neutralization: if `MarkAppliedDigest` keyed current `s.active`
  (like `MarkActiveApplied`) it would stamp cfgB and the "cfgB must not
  read applied" assertion fails.
- **`pkg/configstore` `TestMarkAppliedDigest_EmptyIsNoOp`** — an empty
  captured digest must not clear an existing marker.

## Docs

`pkg/configstore/README.md` and `docs/sync-protocol.md` updated to
describe the capture/replay pair and the stamp-location move.

## Validation

`go build` + `go vet` + `gofmt` clean; full `pkg/configstore` and
`pkg/daemon` suites green.

HA-adjacent (config-sync path). A failover / config-sync cluster smoke
may be advisable before merge (parent's call); the change is behind the
existing `applyBodyForTest`-drivable seam and preserves the full-success
stamp gate, so it is not expected to alter forwarding behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ