### PR TITLE
filter: read capability flags off fast map, delete property sets (#6236 PR-2B)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,48 @@
+## 2026-07-23 — #6236 PR-2B: capability-accessor migration + property-set deletion
+
+- **Timestamp**: 2026-07-23 (refactor/6236-pr2b-migrate-delete)
+- **Action**: PR-2B of the #6236 PR-2 filter-flag convergence (A→B→C split;
+  PR-1 dead-field deletion + PR-2A needs_tx_eval foundations already merged).
+  Migrated the four hot per-interface capability accessors to read the mirrored
+  `Filter` flag off `iface_filter_*_fast.get(&ifindex)` instead of a parallel
+  `FxHashSet<i32>`: `interface_filter_affects_route_lookup` (eval.rs),
+  `interface_input_filter_has_dscp_match` /
+  `interface_input_filter_has_per_packet_l4_match` (rotation.rs), and
+  `interface_output_filter_needs_tx_eval` (tx_selection.rs). Accessor SIGNATURES
+  unchanged — consumers (PBR, poll-descriptor, cos_classify, flow_cache)
+  untouched (no single-lookup fold; that is PR-2C). Then DELETED the eight
+  now-unread property sets + the two `has_output_tx_selection_v{4,6}` aggregates
+  (PR-2A already rewired the global TX gate onto `has_output_needs_tx_eval_*`,
+  which subsumes them) + the production-dead accessor
+  `filter_state_has_output_tx_selection`. Removed the compiler `.insert`
+  population for each deleted set and the post-loop `has_output_tx_selection_*`
+  recompute. `FilterState` 25 → 15 fields.
+- **Gate discipline**: landed the equivalence test FIRST in its pre-deletion
+  form (`set.contains(&if) == fast.get(&if).is_some_and(flag)` across all 8
+  sets/flags, both families + directions) and confirmed GREEN before deleting
+  any set; post-deletion it survives as an accessor-vs-fast-map regression pin
+  (`capability_accessors_equal_fast_map_flags_for_unique_ifindices`). Parent-RED:
+  making `interface_filter_affects_route_lookup` read `has_dscp_match_terms`
+  turned 8 route-lookup/PBR tests RED (assertion failures, not build breaks);
+  restored. #1430 cache-sensitivity is bit-identical for unique ifindices and
+  last-wins-consistent for duplicates; #3296 MissingFilterRef guards untouched.
+- **Tests**: full `cargo test --release -- --test-threads=1` GREEN — 4248
+  passed, 0 failed, 2 pre-existing ignored, exit 0. Migrated the tests that
+  inspected the deleted fields onto the accessors / retained aggregate. Docs
+  updated: `filter/README.md`, `filter/mod.rs` + `protocol/security.rs` #1430
+  runbook, and stale mechanism comments in cos_classify/flow_cache tests.
+- **File(s)**: userspace-dp/src/filter/mod.rs,
+    userspace-dp/src/filter/compiler.rs,
+    userspace-dp/src/filter/engine/eval.rs,
+    userspace-dp/src/filter/engine/tx_selection.rs,
+    userspace-dp/src/filter/engine/mod.rs,
+    userspace-dp/src/filter/engine/cache_sensitive/rotation.rs,
+    userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md,
+    userspace-dp/src/protocol/security.rs,
+    userspace-dp/src/afxdp/forwarding_build/tests.rs,
+    userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+    userspace-dp/src/afxdp/flow_cache_tests.rs
+
 ## 2026-07-22 — #6361: three TEST-STRENGTH tightenings on the #6243 map-pin suite
 
 - **Timestamp**: 2026-07-22 (fix/6361-test-tighten → refactor/6243-unify-map-pin-preflight)

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -1125,10 +1125,11 @@ fn dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
             name: "reth1.0".into(),
             ifindex: meta.ingress_ifindex as i32,
             // Step 3: bind the filter as an INPUT filter on the
-            // ingress interface. The snapshot compiler in
-            // userspace-dp/src/filter/compiler.rs populates the
-            // per-interface has_dscp_match set
-            // (FilterState.iface_filter_v4_has_dscp_match).
+            // ingress interface. Since #6236 PR-2B the
+            // `interface_input_filter_has_dscp_match` accessor reads the
+            // `has_dscp_match_terms` flag off the per-interface fast map
+            // (FilterState.iface_filter_v4_fast) — the parallel has_dscp_match
+            // set was deleted.
             filter_input_v4: "lan-runbook-input".into(),
             ..Default::default()
         }],

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -2298,8 +2298,8 @@ fn build_forwarding_state_enables_tx_selection_when_cos_interfaces_exist() {
 /// the aggregate clears, the gate disables, and this counter-only filter's
 /// `then count` would silently stop being enforced on the TX path. It also pins
 /// that the new single aggregate subsumes the OLD two-clause gate — the old
-/// `has_output_tx_selection_v4` clause is `false` here (counter-only), so only
-/// the `needs_tx_eval` superset keeps the gate armed.
+/// `affects_tx_selection` clause is `false` here (counter-only), so only the
+/// `needs_tx_eval` superset keeps the gate armed.
 #[test]
 fn build_forwarding_state_enables_tx_selection_for_counter_only_output_filter() {
     let snapshot = ConfigSnapshot {
@@ -2325,8 +2325,15 @@ fn build_forwarding_state_enables_tx_selection_for_counter_only_output_filter() 
     // affects_tx_selection is false (no forwarding-class / dscp-rewrite), so the
     // OLD has_output_tx_selection clause does NOT arm the gate — only the
     // needs_tx_eval superset (which covers `then count`) does.
+    // #6236 PR-2B: `has_output_tx_selection_v4` is deleted; read the
+    // `affects_tx_selection` flag off the output fast-map filter to make the
+    // same point — a counter-only filter does not affect tx-selection.
     assert!(
-        !state.filter_state.has_output_tx_selection_v4,
+        !state
+            .filter_state
+            .iface_filter_out_v4_fast
+            .get(&7)
+            .is_some_and(|f| f.affects_tx_selection),
         "counter-only filter does not affect tx-selection"
     );
     assert!(
@@ -2342,12 +2349,15 @@ fn build_forwarding_state_enables_tx_selection_for_counter_only_output_filter() 
     assert!(!state.tx_selection_enabled_v6);
 }
 
-/// #6236 PR-2A equivalence: on a NORMAL (unique-ifindex) compiled state the new
+/// #6236 PR-2A/2B equivalence: on a NORMAL (unique-ifindex) compiled state the
 /// `has_output_needs_tx_eval_*` aggregate is bit-equivalent to the OLD two-clause
-/// gate it replaces — `has_output_tx_selection_* OR !needs_tx_eval-set.is_empty()`.
-/// The `iface_filter_out_*_needs_tx_eval` sets still exist in PR-2A, so this
-/// asserts the replacement is behavior-preserving across a mix of output-filter
-/// shapes (tx-selection, counter-only, terminal-only, and plain accept).
+/// gate it replaced — `has_output_tx_selection_* OR !needs_tx_eval-set.is_empty()`.
+/// PR-2B deleted both `has_output_tx_selection_*` and the
+/// `iface_filter_out_*_needs_tx_eval` sets, so the two original clauses are
+/// reconstructed here independently from the retained output fast maps (an
+/// `affects_tx_selection` scan for the first clause, a `needs_tx_eval()` scan for
+/// the second). Exercises a mix of output-filter shapes (tx-selection,
+/// counter-only, terminal-only, and plain accept).
 #[test]
 fn has_output_needs_tx_eval_matches_old_two_clause_gate() {
     let snapshot = ConfigSnapshot {
@@ -2423,10 +2433,26 @@ fn has_output_needs_tx_eval_matches_old_two_clause_gate() {
     };
 
     let fs = build_forwarding_state(&snapshot).filter_state;
-    let old_gate_v4 =
-        fs.has_output_tx_selection_v4 || !fs.iface_filter_out_v4_needs_tx_eval.is_empty();
-    let old_gate_v6 =
-        fs.has_output_tx_selection_v6 || !fs.iface_filter_out_v6_needs_tx_eval.is_empty();
+    // #6236 PR-2B: reconstruct the two original clauses from the retained output
+    // fast maps — clause 1 = old `has_output_tx_selection_*` (any output filter
+    // affects tx-selection); clause 2 = old `!needs_tx_eval-set.is_empty()` (any
+    // output filter needs a TX walk).
+    let old_gate_v4 = fs
+        .iface_filter_out_v4_fast
+        .values()
+        .any(|f| f.affects_tx_selection)
+        || fs
+            .iface_filter_out_v4_fast
+            .values()
+            .any(|f| f.needs_tx_eval());
+    let old_gate_v6 = fs
+        .iface_filter_out_v6_fast
+        .values()
+        .any(|f| f.affects_tx_selection)
+        || fs
+            .iface_filter_out_v6_fast
+            .values()
+            .any(|f| f.needs_tx_eval());
     assert_eq!(
         fs.has_output_needs_tx_eval_v4, old_gate_v4,
         "new v4 aggregate must equal the old two-clause gate"

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -351,7 +351,7 @@ pub(super) fn evaluate_dscp_sensitive_input_filter_on_session_hit(
     // (tcp-flags / is-fragment / icmp-type / icmp-code). Both classes vary per
     // packet within a flow, so the first-packet decision must not be replayed.
     // The extra-build stays AFTER this gate so the common no-such-filter case
-    // pays only two FxHashSet lookups (this function is #[inline] on the hot
+    // pays only two FxHashMap lookups (this function is #[inline] on the hot
     // session-hit path).
     if !crate::filter::interface_input_filter_has_dscp_match(
         &forwarding.filter_state,

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -2366,17 +2366,18 @@ fn resolve_cached_cos_tx_selection_flowless_captures_counter_only_output_filter(
     // Every existing flowless output-filter canary uses a terminal (discard /
     // reject) or log term, so dropping `has_counter_terms` from
     // `Filter::needs_tx_eval()` leaves them GREEN — the flowless CACHED
-    // needs_tx_eval predicate at cos_classify.rs:225 (and its compile-time
-    // `iface_filter_out_v4_needs_tx_eval` set-insert gate) was NOT bound by a
-    // counter-only canary. This test binds it: the filter is counter-only
-    // (has_counter_terms=true; affects_tx_selection / has_log_terms /
-    // has_terminal_action_terms / has_three_color_policer_terms all false), so
+    // needs_tx_eval predicate at cos_classify.rs:225 (and the
+    // `interface_output_filter_needs_tx_eval` accessor it gates on, which since
+    // #6236 PR-2B reads `Filter::needs_tx_eval()` off the output fast map) was
+    // NOT bound by a counter-only canary. This test binds it: the filter is
+    // counter-only (has_counter_terms=true; affects_tx_selection / has_log_terms
+    // / has_terminal_action_terms / has_three_color_policer_terms all false), so
     // `needs_tx_eval()` reduces to has_counter_terms alone.
     //
     // RED-on-revert: dropping `has_counter_terms` from `Filter::needs_tx_eval()`
-    // drops ifindex 202 from `iface_filter_out_v4_needs_tx_eval` (the outer gate)
-    // AND fails the inner `.filter(|f| f.needs_tx_eval())` at :225, so the output
-    // filter is never walked, `filter_counters` comes back empty, and the
+    // makes `interface_output_filter_needs_tx_eval(202)` return false (the outer
+    // gate) AND fails the inner `.filter(|f| f.needs_tx_eval())` at :225, so the
+    // output filter is never walked, `filter_counters` comes back empty, and the
     // assertion below FAILS.
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {
@@ -2443,8 +2444,9 @@ fn resolve_cos_tx_selection_flowless_counts_counter_only_output_filter() {
     // (`resolve_cos_tx_selection`, flow_key = None) must fire a `then count` on
     // an interface output filter whose ONLY TX-relevant property is the counter.
     // Binds the flowless RUNTIME needs_tx_eval predicate at cos_classify.rs:655
-    // (and its `iface_filter_out_v4_needs_tx_eval` outer gate) to
-    // has_counter_terms — the existing flowless canaries (terminal / log) do not.
+    // (and its `interface_output_filter_needs_tx_eval` accessor gate, fast-map
+    // backed since #6236 PR-2B) to has_counter_terms — the existing flowless
+    // canaries (terminal / log) do not.
     //
     // RED-on-revert: dropping `has_counter_terms` from `Filter::needs_tx_eval()`
     // skips the output-filter walk, the `then count` term never fires, and the

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -708,15 +708,15 @@ both lo0 input families. Tests: `missing_filter_ref_3296_*` /
 `defined_filter_ref_3296_compiles_cleanly` in `filter/tests.rs` (fail-on-revert).
 
 The fail-closed contract keys off the RETAINED per-interface fast maps
-(`iface_filter_*_fast`) and, for output hooks, the
-`iface_filter_out_*_needs_tx_eval` sets — the structures the per-interface hot
-path consults. (#6236 PR-2A additionally re-anchors the FAMILY-WIDE global TX
-gate onto the `has_output_needs_tx_eval_*` aggregate; see "Output-filter
-TX-eval predicate and aggregates (#6236 PR-2A)" below. The per-interface
-`iface_filter_out_*_needs_tx_eval` sets are still populated and consulted by the
-`interface_output_filter_needs_tx_eval` accessor in PR-2A — PR-2B migrates that
-accessor onto the fast map and deletes the sets.) #6236 PR-1 removed the dead
-parallel bookkeeping that shadowed these:
+(`iface_filter_*_fast`) — the structures the per-interface hot path consults —
+and the FAMILY-WIDE global TX gate keys off the `has_output_needs_tx_eval_*`
+aggregate (#6236 PR-2A; see "Output-filter TX-eval predicate and aggregates"
+below). #6236 PR-2B deleted the parallel per-interface property sets
+(`iface_filter_v{4,6}_affects_route_lookup` / `_has_dscp_match` /
+`_has_per_packet_l4_match` and `iface_filter_out_{v4,v6}_needs_tx_eval`); every
+capability accessor now reads the mirrored `Filter` flag off the fast-map entry,
+so a single `.get()` returns the filter and every derived flag. #6236 PR-1
+removed the dead parallel bookkeeping that shadowed these:
 the four `"family:name"` name maps (`iface_filter_v4`/`iface_filter_v6`/
 `iface_filter_out_v4`/`iface_filter_out_v6`), the two input
 `iface_filter_v{4,6}_affects_tx_selection` sets (their only reader was a
@@ -727,42 +727,55 @@ guards are byte-for-byte unchanged — deleting a name-map `.insert` never touch
 the `filters.get()` presence check that precedes it. `FilterState` drops from 31
 to 23 fields with zero live-dataplane behavior change.
 
-### Output-filter TX-eval predicate and aggregates (#6236 PR-2A)
+### Output-filter TX-eval predicate and aggregates (#6236 PR-2A/2B)
 
 An output filter must still be walked on the TX path when it can change or
 observe the packet: CoS/DSCP tx-selection, a `then count`, a `then log`, a
 terminal (non-`accept`) action, or a three-color policer. That five-flag OR is
 now the **single** `Filter::needs_tx_eval()` method (`filter/mod.rs`), the SOLE
-definition. Every consumer routes through it — the compiler's
-`iface_filter_out_*_needs_tx_eval` set-insert, the `has_output_needs_tx_eval_*`
-aggregates, and all four `cos_classify` TX arms (cached/runtime ×
-flow-keyed/flowless) — so the composite can never drift between the compile path
-and the hot path.
+definition. Every consumer routes through it — the
+`interface_output_filter_needs_tx_eval` accessor (fast-map backed since PR-2B),
+the `has_output_needs_tx_eval_*` aggregates, and all four `cos_classify` TX arms
+(cached/runtime × flow-keyed/flowless) — so the composite can never drift
+between the compile path and the hot path.
 
-**Aggregate-from-final-map rule.** Every family-wide `FilterState` aggregate
-(`has_input_tx_selection_*`, `has_input_three_color_policer_*`,
-`has_output_tx_selection_*`, and the new `has_output_needs_tx_eval_*`) is
-recomputed **after** the interface loop from the FINAL fast maps via
-`iface_filter_*_fast.values().any(..)`, NOT accumulated monotonically inside the
-loop. The fast maps overwrite last-wins on a duplicate ifindex, so a positive
-filter followed by a non-sensitive filter at the same ifindex must not leave a
-stale-true aggregate; deriving each aggregate from the final map makes it agree
-with the filter the hot path actually evaluates. For the common unique-ifindex
-case this is bit-identical to the old in-loop OR (only the duplicate-ifindex
-drift case changes, and it changes to the correct value).
+**Capability accessors read the fast map (#6236 PR-2B).** The four hot
+per-interface capability prechecks — `interface_filter_affects_route_lookup`,
+`interface_input_filter_has_dscp_match`,
+`interface_input_filter_has_per_packet_l4_match`, and
+`interface_output_filter_needs_tx_eval` — read the mirrored `Filter` flag off
+`iface_filter_*_fast.get(&ifindex)` (e.g. `.is_some_and(|f| f.has_dscp_match_terms)`)
+rather than a parallel `FxHashSet<i32>`. PR-2B deleted those eight property sets
+(`iface_filter_v{4,6}_affects_route_lookup` / `_has_dscp_match` /
+`_has_per_packet_l4_match` and `iface_filter_out_{v4,v6}_needs_tx_eval`). For a
+unique ifindex the fast-map read is bit-identical to the old `set.contains`
+(the set was populated iff the same `Filter` flag was set); for a duplicate
+ifindex the fast map is the last-wins canonical source, so the precheck now
+agrees with the filter the evaluator that follows actually walks. `FilterState`
+drops from 25 to 15 fields.
+
+**Aggregate-from-final-map rule.** Every retained family-wide `FilterState`
+aggregate (`has_input_tx_selection_*`, `has_input_three_color_policer_*`, and
+`has_output_needs_tx_eval_*`) is recomputed **after** the interface loop from the
+FINAL fast maps via `iface_filter_*_fast.values().any(..)`, NOT accumulated
+monotonically inside the loop. The fast maps overwrite last-wins on a duplicate
+ifindex, so a positive filter followed by a non-sensitive filter at the same
+ifindex must not leave a stale-true aggregate; deriving each aggregate from the
+final map makes it agree with the filter the hot path actually evaluates. For the
+common unique-ifindex case this is bit-identical to the old in-loop OR (only the
+duplicate-ifindex drift case changes, and it changes to the correct value).
 
 **Global TX gate.** `forwarding_build` computes the family-wide
 `tx_selection_enabled_v{4,6}` gate that short-circuits the entire `cos_classify`
-TX path. Its output clause is now the single `has_output_needs_tx_eval_*`
-aggregate, which SUBSUMES both the old `has_output_tx_selection_*` clause AND the
-old `!iface_filter_out_*_needs_tx_eval.is_empty()` clause (because
+TX path. Its output clause is the single `has_output_needs_tx_eval_*` aggregate,
+which SUBSUMES both the old `has_output_tx_selection_*` clause AND the old
+`!iface_filter_out_*_needs_tx_eval.is_empty()` clause (because
 `needs_tx_eval ⊇ affects_tx_selection`, also covering counter/log/terminal/
 policer). This is behavior-equivalent — a counter/log/terminal/policer-only
 output filter keeps the gate armed, so its enforcement never fails open — and
-cannot be tricked by a duplicate-ifindex overwrite. `has_output_tx_selection_*`
-and its production-dead accessor `filter_state_has_output_tx_selection` become
-unused-in-production once the gate stops reading them; PR-2A retains them (still
-recomputed, still test-asserted) for PR-2B to delete alongside the property sets.
+cannot be tricked by a duplicate-ifindex overwrite. PR-2A rewired the gate onto
+this aggregate; PR-2B then deleted the now-unread `has_output_tx_selection_*`
+fields and their production-dead accessor `filter_state_has_output_tx_selection`.
 
 Unparseable tcp-flags backstop (#3367): a term whose Junos `tcp-flags`
 expression the Go control plane could not parse into required/forbidden masks

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -163,19 +163,10 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 // are recomputed from the FINAL fast map after this loop so a
                 // duplicate-ifindex last-wins overwrite cannot strand a
                 // stale-true aggregate. Do not OR them in here.
-                if filter.affects_route_lookup {
-                    state
-                        .iface_filter_v4_affects_route_lookup
-                        .insert(iface.ifindex);
-                }
-                if filter.has_dscp_match_terms {
-                    state.iface_filter_v4_has_dscp_match.insert(iface.ifindex);
-                }
-                if filter.has_per_packet_l4_match_terms {
-                    state
-                        .iface_filter_v4_has_per_packet_l4_match
-                        .insert(iface.ifindex);
-                }
+                // #6236 PR-2B: the per-interface capability sets
+                // (affects_route_lookup / has_dscp_match / has_per_packet_l4_match)
+                // are gone — the accessors read the flag off the fast map entry,
+                // so populating the fast map below is the only per-interface work.
                 state
                     .iface_filter_v4_fast
                     .insert(iface.ifindex, filter.clone());
@@ -195,15 +186,11 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
         if !iface.filter_output_v4.is_empty() {
             let key = qualify_filter_key("inet", &iface.filter_output_v4);
             if let Some(filter) = state.filters.get(&key) {
-                // #6236 PR-2A: the set-insert predicate is now the sole
-                // Filter::needs_tx_eval() definition (was an inline five-flag OR).
-                // has_output_tx_selection_v4 / has_output_needs_tx_eval_v4 are
-                // recomputed from the FINAL fast map after this loop.
-                if filter.needs_tx_eval() {
-                    state
-                        .iface_filter_out_v4_needs_tx_eval
-                        .insert(iface.ifindex);
-                }
+                // #6236 PR-2B: the per-interface `iface_filter_out_v4_needs_tx_eval`
+                // set is gone — `interface_output_filter_needs_tx_eval` reads
+                // `Filter::needs_tx_eval()` off this fast-map entry. The
+                // `has_output_needs_tx_eval_v4` aggregate is recomputed from the
+                // FINAL fast map after this loop.
                 state
                     .iface_filter_out_v4_fast
                     .insert(iface.ifindex, filter.clone());
@@ -224,19 +211,8 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
             if let Some(filter) = state.filters.get(&key) {
                 // #6236 PR-2A: aggregates recomputed from the FINAL fast map
                 // after this loop (see the inet input block above).
-                if filter.affects_route_lookup {
-                    state
-                        .iface_filter_v6_affects_route_lookup
-                        .insert(iface.ifindex);
-                }
-                if filter.has_dscp_match_terms {
-                    state.iface_filter_v6_has_dscp_match.insert(iface.ifindex);
-                }
-                if filter.has_per_packet_l4_match_terms {
-                    state
-                        .iface_filter_v6_has_per_packet_l4_match
-                        .insert(iface.ifindex);
-                }
+                // #6236 PR-2B: per-interface capability sets deleted — accessors
+                // read the flag off the fast-map entry.
                 state
                     .iface_filter_v6_fast
                     .insert(iface.ifindex, filter.clone());
@@ -253,13 +229,10 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
         if !iface.filter_output_v6.is_empty() {
             let key = qualify_filter_key("inet6", &iface.filter_output_v6);
             if let Some(filter) = state.filters.get(&key) {
-                // #6236 PR-2A: sole Filter::needs_tx_eval() predicate; aggregates
-                // recomputed from the FINAL fast map after this loop.
-                if filter.needs_tx_eval() {
-                    state
-                        .iface_filter_out_v6_needs_tx_eval
-                        .insert(iface.ifindex);
-                }
+                // #6236 PR-2B: per-interface `iface_filter_out_v6_needs_tx_eval`
+                // set deleted (see the inet output block above); the
+                // `has_output_needs_tx_eval_v6` aggregate is recomputed from the
+                // FINAL fast map after this loop.
                 state
                     .iface_filter_out_v6_fast
                     .insert(iface.ifindex, filter.clone());
@@ -301,14 +274,9 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
         .iface_filter_v6_fast
         .values()
         .any(|f| f.has_three_color_policer_terms);
-    state.has_output_tx_selection_v4 = state
-        .iface_filter_out_v4_fast
-        .values()
-        .any(|f| f.affects_tx_selection);
-    state.has_output_tx_selection_v6 = state
-        .iface_filter_out_v6_fast
-        .values()
-        .any(|f| f.affects_tx_selection);
+    // #6236 PR-2B: `has_output_tx_selection_v*` is deleted — the global TX gate
+    // reads only `has_output_needs_tx_eval_*` (which is a superset), so the
+    // `affects_tx_selection`-only aggregate is no longer computed.
     state.has_output_needs_tx_eval_v4 = state
         .iface_filter_out_v4_fast
         .values()

--- a/userspace-dp/src/filter/engine/cache_sensitive/rotation.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive/rotation.rs
@@ -214,11 +214,16 @@ pub(crate) fn interface_input_filter_has_dscp_match(
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    if is_v6 {
-        state.iface_filter_v6_has_dscp_match.contains(&ifindex)
+    // #6236 PR-2B: read `has_dscp_match_terms` off the fast map (mirrors the
+    // OUTPUT accessor below), replacing the parallel
+    // `iface_filter_v*_has_dscp_match` set. #1430 cache-sensitivity is preserved
+    // bit-for-bit: the set was populated iff `filter.has_dscp_match_terms`.
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex)
     } else {
-        state.iface_filter_v4_has_dscp_match.contains(&ifindex)
-    }
+        state.iface_filter_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|filter| filter.has_dscp_match_terms)
 }
 
 pub(crate) fn interface_output_filter_has_dscp_match(
@@ -287,15 +292,16 @@ pub(crate) fn interface_input_filter_has_per_packet_l4_match(
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    if is_v6 {
-        state
-            .iface_filter_v6_has_per_packet_l4_match
-            .contains(&ifindex)
+    // #6236 PR-2B: read `has_per_packet_l4_match_terms` off the fast map,
+    // replacing the parallel `iface_filter_v*_has_per_packet_l4_match` set
+    // (mirrors the OUTPUT accessor below). #1430/#2362 cache-sensitivity is
+    // preserved bit-for-bit for a unique ifindex.
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex)
     } else {
-        state
-            .iface_filter_v4_has_per_packet_l4_match
-            .contains(&ifindex)
-    }
+        state.iface_filter_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|filter| filter.has_per_packet_l4_match_terms)
 }
 
 pub(crate) fn interface_output_filter_has_per_packet_l4_match(

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -1091,13 +1091,15 @@ pub(crate) fn interface_filter_affects_route_lookup(
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    if is_v6 {
-        state
-            .iface_filter_v6_affects_route_lookup
-            .contains(&ifindex)
+    // #6236 PR-2B: read the flag off the per-interface fast map instead of a
+    // parallel `iface_filter_v*_affects_route_lookup` set. The set was populated
+    // iff `filter.affects_route_lookup`, so `get().is_some_and(..)` is
+    // bit-identical for a unique ifindex and last-wins-consistent for a
+    // duplicate — agreeing with the filter the eval that follows actually runs.
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex)
     } else {
-        state
-            .iface_filter_v4_affects_route_lookup
-            .contains(&ifindex)
-    }
+        state.iface_filter_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|filter| filter.affects_route_lookup)
 }

--- a/userspace-dp/src/filter/engine/mod.rs
+++ b/userspace-dp/src/filter/engine/mod.rs
@@ -33,5 +33,5 @@ pub(crate) use tx_selection::{
     evaluate_filter_ref_tx_selection_runtime_uncounted, evaluate_filter_ref_tx_selection_uncounted,
     evaluate_interface_filter_tx_selection_counted,
     evaluate_interface_output_filter_tx_selection_counted, filter_state_has_input_tx_selection,
-    filter_state_has_output_tx_selection, interface_output_filter_needs_tx_eval,
+    interface_output_filter_needs_tx_eval,
 };

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -377,11 +377,17 @@ pub(crate) fn interface_output_filter_needs_tx_eval(
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    if is_v6 {
-        state.iface_filter_out_v6_needs_tx_eval.contains(&ifindex)
+    // #6236 PR-2B: read `Filter::needs_tx_eval()` off the output fast map,
+    // replacing the parallel `iface_filter_out_v*_needs_tx_eval` set. The set
+    // was populated iff `filter.needs_tx_eval()`, so `get().is_some_and(..)` is
+    // bit-identical for a unique ifindex and agrees with the last-wins filter
+    // the TX evaluator actually walks for a duplicate.
+    let filter = if is_v6 {
+        state.iface_filter_out_v6_fast.get(&ifindex)
     } else {
-        state.iface_filter_out_v4_needs_tx_eval.contains(&ifindex)
-    }
+        state.iface_filter_out_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|filter| filter.needs_tx_eval())
 }
 
 #[inline]
@@ -393,11 +399,8 @@ pub(crate) fn filter_state_has_input_tx_selection(state: &FilterState, is_v6: bo
     }
 }
 
-#[inline]
-pub(crate) fn filter_state_has_output_tx_selection(state: &FilterState, is_v6: bool) -> bool {
-    if is_v6 {
-        state.has_output_tx_selection_v6
-    } else {
-        state.has_output_tx_selection_v4
-    }
-}
+// #6236 PR-2B: `filter_state_has_output_tx_selection` (and the
+// `has_output_tx_selection_v*` fields it read) are deleted. PR-2A already
+// rewired the global TX gate onto `has_output_needs_tx_eval_*`, which subsumes
+// the old `affects_tx_selection`-only aggregate; the accessor had no production
+// consumer left.

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -74,10 +74,12 @@ pub(crate) enum FilterAction {
 //       lookup. File a tracker issue against session/key.rs.
 //
 //   (b) NOT in cache key (cache-sensitive) — wire the #1430
-//       runbook: per-interface FilterState.iface_filter_v{4,6}_has_<X>_match
-//       set, Filter.has_<X>_match_terms aggregate flag, flow-cache
-//       insertion gate at afxdp/flow_cache.rs:297-309, established-
-//       session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
+//       runbook: Filter.has_<X>_match_terms flag (read per-interface
+//       off FilterState.iface_filter_v{4,6}_fast via the
+//       interface_input_filter_has_<X>_match accessor — the parallel
+//       per-interface has_<X>_match sets were deleted in #6236 PR-2B),
+//       flow-cache insertion gate at afxdp/flow_cache.rs:297-309,
+//       established-session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
 //       forwarding rotation purge at afxdp/worker/loop_body/mod.rs:295-330,
 //       and tests at afxdp/flow_cache_tests.rs.
 //
@@ -778,44 +780,39 @@ pub(crate) struct FilterState {
     pub(crate) has_input_tx_selection_v4: bool,
     /// Whether any inet input filter contains a three-color policer.
     pub(crate) has_input_three_color_policer_v4: bool,
-    /// Per-interface inet input filters that can affect route-table selection.
-    pub(crate) iface_filter_v4_affects_route_lookup: rustc_hash::FxHashSet<i32>,
-    /// Per-interface inet input filters with DSCP match terms.
-    pub(crate) iface_filter_v4_has_dscp_match: rustc_hash::FxHashSet<i32>,
-    /// Per-interface inet input filters with per-packet L4 match terms (#2362:
-    /// tcp-flags / is-fragment / icmp-type / icmp-code). Cache-sensitive.
-    pub(crate) iface_filter_v4_has_per_packet_l4_match: rustc_hash::FxHashSet<i32>,
+    // #6236 PR-2B: the per-interface inet input capability sets
+    // (`iface_filter_v4_affects_route_lookup`, `iface_filter_v4_has_dscp_match`,
+    // `iface_filter_v4_has_per_packet_l4_match`) are deleted — every accessor now
+    // reads the mirrored `Filter` flag off `iface_filter_v4_fast`.
     /// Direct per-interface inet6 filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_v6_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
     /// Whether any inet6 input filter can affect CoS TX selection.
     pub(crate) has_input_tx_selection_v6: bool,
     /// Whether any inet6 input filter contains a three-color policer.
     pub(crate) has_input_three_color_policer_v6: bool,
-    /// Per-interface inet6 input filters that can affect route-table selection.
-    pub(crate) iface_filter_v6_affects_route_lookup: rustc_hash::FxHashSet<i32>,
-    /// Per-interface inet6 input filters with DSCP match terms.
-    pub(crate) iface_filter_v6_has_dscp_match: rustc_hash::FxHashSet<i32>,
-    /// Per-interface inet6 input filters with per-packet L4 match terms (#2362).
-    pub(crate) iface_filter_v6_has_per_packet_l4_match: rustc_hash::FxHashSet<i32>,
+    // #6236 PR-2B: the per-interface inet6 input capability sets are deleted —
+    // the accessors read the mirrored `Filter` flag off `iface_filter_v6_fast`
+    // (same as the inet input block above).
     /// Direct per-interface inet output filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_out_v4_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
-    /// Per-interface inet output filters that must still be evaluated in the TX path.
-    pub(crate) iface_filter_out_v4_needs_tx_eval: rustc_hash::FxHashSet<i32>,
-    /// Whether any inet output filter can affect CoS TX selection.
-    pub(crate) has_output_tx_selection_v4: bool,
+    // #6236 PR-2B: `iface_filter_out_v4_needs_tx_eval` (per-interface set) and
+    // `has_output_tx_selection_v4` (aggregate) are deleted. The
+    // `interface_output_filter_needs_tx_eval` accessor reads
+    // `Filter::needs_tx_eval()` off `iface_filter_out_v4_fast`, and the global TX
+    // gate reads the `has_output_needs_tx_eval_v4` aggregate (PR-2A) which
+    // subsumes the deleted `affects_tx_selection`-only aggregate.
     /// #6236 PR-2A: whether any inet output filter needs a TX-path walk
     /// (`Filter::needs_tx_eval` — CoS/DSCP tx-selection, counter, log, terminal
     /// action, or three-color policer). Recomputed from the FINAL output fast map
     /// so a duplicate-ifindex last-wins overwrite cannot leave a stale-true
-    /// aggregate; it subsumes both `has_output_tx_selection_v4` and the
-    /// `iface_filter_out_v4_needs_tx_eval` set non-emptiness in the global gate.
+    /// aggregate. It is the SOLE output clause of the global TX gate: it subsumes
+    /// both the old `affects_tx_selection`-only aggregate and the old
+    /// per-interface needs-tx-eval set non-emptiness (both deleted in PR-2B).
     pub(crate) has_output_needs_tx_eval_v4: bool,
     /// Direct per-interface inet6 output filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_out_v6_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
-    /// Per-interface inet6 output filters that must still be evaluated in the TX path.
-    pub(crate) iface_filter_out_v6_needs_tx_eval: rustc_hash::FxHashSet<i32>,
-    /// Whether any inet6 output filter can affect CoS TX selection.
-    pub(crate) has_output_tx_selection_v6: bool,
+    // #6236 PR-2B: `iface_filter_out_v6_needs_tx_eval` and
+    // `has_output_tx_selection_v6` are deleted (see the inet output block above).
     /// #6236 PR-2A: inet6 mirror of `has_output_needs_tx_eval_v4`.
     pub(crate) has_output_needs_tx_eval_v6: bool,
     /// Direct lo0 inet filter reference for packet hot-path evaluation.

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -795,7 +795,7 @@ pub(crate) struct FilterState {
     // (same as the inet input block above).
     /// Direct per-interface inet output filter reference for packet hot-path evaluation.
     pub(crate) iface_filter_out_v4_fast: rustc_hash::FxHashMap<i32, Arc<Filter>>,
-    // #6236 PR-2B: `iface_filter_out_v4_needs_tx_eval` (per-interface set) and
+    // #6236 PR-2B: `iface_filter_out_v4_needs_tx_eval` (the former per-interface FxHashSet) and
     // `has_output_tx_selection_v4` (aggregate) are deleted. The
     // `interface_output_filter_needs_tx_eval` accessor reads
     // `Filter::needs_tx_eval()` off `iface_filter_out_v4_fast`, and the global TX

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2469,10 +2469,12 @@ fn duplicate_ifindex_output_filter_aggregate_is_last_wins() {
     assert!(!interface_output_filter_needs_tx_eval(&state, 7, false));
 }
 
-/// #6236 PR-2B equivalence gate. This test was landed FIRST in the pre-deletion
-/// form (`set.contains(&if) == fast.get(&if).is_some_and(flag)`) and confirmed
-/// green to PROVE the accessor body-swap is behavior-preserving BEFORE any of
-/// the eight property sets were removed. Post-deletion it survives as an
+/// #6236 PR-2B equivalence gate. During development this assertion was written
+/// and confirmed green in the pre-deletion form
+/// (`set.contains(&if) == fast.get(&if).is_some_and(flag)`) to PROVE the
+/// accessor body-swap is behavior-preserving before the eight property sets
+/// were removed; that pre-deletion form is not a separate commit in this
+/// squashed PR. Post-deletion it survives as an
 /// accessor-semantics regression pin: for a normally compiled `FilterState`
 /// (unique ifindices) each migrated capability accessor returns exactly the
 /// mirrored `Filter` flag off the per-interface fast map, across both families

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2276,18 +2276,20 @@ fn parse_filter_state_prequalifies_interface_and_lo0_filter_keys() {
     // `iface_filter_v4_affects_tx_selection` set are removed. The retained fast
     // maps carry the resolved `Arc<Filter>` (name is the unqualified filter
     // name), and the aggregate boolean carries the family-wide tx-selection
-    // fact. The route-lookup and output needs_tx_eval sets are retained (PR-2
-    // scope) and asserted as before.
+    // fact. #6236 PR-2B: the route-lookup and output needs_tx_eval property sets
+    // are deleted — the capability facts are now read through the migrated
+    // accessors (which read the flag off the fast map) and the retained
+    // `has_output_needs_tx_eval_*` aggregate.
     assert_eq!(
         state.iface_filter_v4_fast.get(&7).map(|f| f.name.as_str()),
         Some("ingress-v4")
     );
     assert!(state.has_input_tx_selection_v4);
-    assert!(state.iface_filter_v4_affects_route_lookup.contains(&7));
-    assert!(!state.iface_filter_out_v4_needs_tx_eval.contains(&7));
-    assert!(!state.iface_filter_out_v6_needs_tx_eval.contains(&7));
-    assert!(!state.has_output_tx_selection_v4);
-    assert!(!state.has_output_tx_selection_v6);
+    assert!(interface_filter_affects_route_lookup(&state, 7, false));
+    assert!(!interface_output_filter_needs_tx_eval(&state, 7, false));
+    assert!(!interface_output_filter_needs_tx_eval(&state, 7, true));
+    assert!(!state.has_output_needs_tx_eval_v4);
+    assert!(!state.has_output_needs_tx_eval_v6);
     assert_eq!(
         state
             .iface_filter_out_v6_fast
@@ -2333,7 +2335,9 @@ fn accept_only_output_filter_does_not_need_tx_eval() {
     .expect("filter state compiles");
 
     assert!(!interface_output_filter_needs_tx_eval(&state, 7, false));
-    assert!(!filter_state_has_output_tx_selection(&state, false));
+    // #6236 PR-2B: `filter_state_has_output_tx_selection` is deleted; an
+    // accept-only output filter leaves the retained needs-tx-eval aggregate false.
+    assert!(!state.has_output_needs_tx_eval_v4);
 }
 
 /// #6236 PR-2A parent-RED anchor: a `then count`-only OUTPUT filter (no
@@ -2380,23 +2384,27 @@ fn counter_only_output_filter_needs_tx_eval_and_sets_aggregate() {
         !filter.affects_tx_selection,
         "counter is not a tx-selection action"
     );
-    // Accessor reads the set, which the compiler populates via needs_tx_eval().
+    // #6236 PR-2B: the accessor now reads `Filter::needs_tx_eval()` off the
+    // output fast-map entry (the set is deleted).
     assert!(interface_output_filter_needs_tx_eval(&state, 7, false));
     // Aggregate recomputed from the FINAL output fast map.
     assert!(state.has_output_needs_tx_eval_v4);
-    // needs_tx_eval strictly supersets affects_tx_selection.
-    assert!(!state.has_output_tx_selection_v4);
+    // needs_tx_eval strictly supersets affects_tx_selection — read the flag off
+    // the fast-map filter now that `has_output_tx_selection_v4` is deleted.
+    assert!(!filter.affects_tx_selection);
 }
 
-/// #6236 PR-2A blocker-#1 pin: a duplicate ifindex where a needs-tx-eval output
-/// filter is followed by a plain-accept one at the SAME ifindex+family+direction.
-/// The fast map overwrites last-wins (holds the SECOND, plain filter); the
-/// `has_output_needs_tx_eval_v4` aggregate — recomputed from the FINAL map, NOT
-/// accumulated in-loop — therefore reads FALSE, agreeing with the filter the hot
-/// path actually evaluates. The monotonic `iface_filter_out_v4_needs_tx_eval`
-/// set still carries the stale ifindex (union kept the first); this documents
-/// exactly the §5.1 divergence the recompute closes. The snapshot still compiles
-/// Ok (last-wins canonical, NOT reject-fail-closed).
+/// #6236 PR-2A blocker-#1 pin (updated for PR-2B): a duplicate ifindex where a
+/// needs-tx-eval output filter is followed by a plain-accept one at the SAME
+/// ifindex+family+direction. The fast map overwrites last-wins (holds the
+/// SECOND, plain filter); the `has_output_needs_tx_eval_v4` aggregate —
+/// recomputed from the FINAL map, NOT accumulated in-loop — therefore reads
+/// FALSE, agreeing with the filter the hot path actually evaluates. PR-2B
+/// deleted the monotonic `iface_filter_out_v4_needs_tx_eval` set, so the
+/// migrated `interface_output_filter_needs_tx_eval` accessor now also reads the
+/// last-wins fast-map filter → FALSE (part c), closing the §5.1 divergence at
+/// the per-interface level too. The snapshot still compiles Ok (last-wins
+/// canonical, NOT reject-fail-closed).
 #[test]
 fn duplicate_ifindex_output_filter_aggregate_is_last_wins() {
     let ifaces = vec![
@@ -2453,10 +2461,278 @@ fn duplicate_ifindex_output_filter_aggregate_is_last_wins() {
         !state.has_output_needs_tx_eval_v4,
         "aggregate must derive from the final last-wins filter"
     );
-    // (c) the monotonic set still carries the stale ifindex — this is the exact
-    // divergence the recompute fixes at the aggregate level (PR-2B deletes the
-    // set and migrates the accessor).
-    assert!(state.iface_filter_out_v4_needs_tx_eval.contains(&7));
+    // (c) #6236 PR-2B: the monotonic set is deleted and the accessor now reads
+    // `Filter::needs_tx_eval()` off the last-wins fast-map entry — so it returns
+    // FALSE, agreeing with the (plain) filter the TX path actually evaluates.
+    // This is exactly the divergence the fold closes: before PR-2B the set
+    // `.contains(&7)` was stale-true while the fast map held the plain filter.
+    assert!(!interface_output_filter_needs_tx_eval(&state, 7, false));
+}
+
+/// #6236 PR-2B equivalence gate. This test was landed FIRST in the pre-deletion
+/// form (`set.contains(&if) == fast.get(&if).is_some_and(flag)`) and confirmed
+/// green to PROVE the accessor body-swap is behavior-preserving BEFORE any of
+/// the eight property sets were removed. Post-deletion it survives as an
+/// accessor-semantics regression pin: for a normally compiled `FilterState`
+/// (unique ifindices) each migrated capability accessor returns exactly the
+/// mirrored `Filter` flag off the per-interface fast map, across both families
+/// and both directions. If any accessor drifts to the wrong flag/map this fails.
+#[test]
+fn capability_accessors_equal_fast_map_flags_for_unique_ifindices() {
+    let ifaces = vec![
+        // input v4 / v6 route-lookup (routing-instance term)
+        crate::InterfaceSnapshot {
+            name: "a".into(),
+            ifindex: 10,
+            filter_input_v4: "pbr4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "b".into(),
+            ifindex: 11,
+            filter_input_v6: "pbr6".into(),
+            ..Default::default()
+        },
+        // input v4 / v6 DSCP match
+        crate::InterfaceSnapshot {
+            name: "c".into(),
+            ifindex: 20,
+            filter_input_v4: "dscp4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "d".into(),
+            ifindex: 21,
+            filter_input_v6: "dscp6".into(),
+            ..Default::default()
+        },
+        // input v4 / v6 per-packet L4 match (tcp-flags)
+        crate::InterfaceSnapshot {
+            name: "e".into(),
+            ifindex: 30,
+            filter_input_v4: "ppl4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "f".into(),
+            ifindex: 31,
+            filter_input_v6: "ppl6".into(),
+            ..Default::default()
+        },
+        // output v4 (counter) / v6 (log) → needs_tx_eval
+        crate::InterfaceSnapshot {
+            name: "g".into(),
+            ifindex: 40,
+            filter_output_v4: "count4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "h".into(),
+            ifindex: 41,
+            filter_output_v6: "log6".into(),
+            ..Default::default()
+        },
+        // plain-accept input+output (no capability flag) — negative side
+        crate::InterfaceSnapshot {
+            name: "i".into(),
+            ifindex: 50,
+            filter_input_v4: "plain4".into(),
+            filter_input_v6: "plain6".into(),
+            filter_output_v4: "plain4".into(),
+            filter_output_v6: "plain6".into(),
+            ..Default::default()
+        },
+    ];
+    let state = parse_filter_state(
+        &[
+            FirewallFilterSnapshot {
+                name: "pbr4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    routing_instance: "ri".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "pbr6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    routing_instance: "ri".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "dscp4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    dscp_values: vec![46],
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "dscp6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    dscp_values: vec![46],
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "ppl4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    protocols: vec!["tcp".into()],
+                    tcp_flags: Some(0x02),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "ppl6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    protocols: vec!["tcp".into()],
+                    tcp_flags: Some(0x02),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "count4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    count: "c4".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "log6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    log: true,
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "plain4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "plain6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    ..Default::default()
+                }],
+            },
+        ],
+        &[],
+        &ifaces,
+        "",
+        "",
+    )
+    .expect("filter state compiles");
+
+    // Probe every used ifindex plus absent ones (0, 1, 99) so both the positive
+    // and negative sides of the equivalence are exercised.
+    let probe: [i32; 12] = [10, 11, 20, 21, 30, 31, 40, 41, 50, 99, 0, 1];
+    for &ifx in &probe {
+        assert_eq!(
+            interface_filter_affects_route_lookup(&state, ifx, false),
+            state
+                .iface_filter_v4_fast
+                .get(&ifx)
+                .is_some_and(|f| f.affects_route_lookup),
+            "v4 affects_route_lookup accessor != fast-map flag at {ifx}"
+        );
+        assert_eq!(
+            interface_filter_affects_route_lookup(&state, ifx, true),
+            state
+                .iface_filter_v6_fast
+                .get(&ifx)
+                .is_some_and(|f| f.affects_route_lookup),
+            "v6 affects_route_lookup accessor != fast-map flag at {ifx}"
+        );
+        assert_eq!(
+            interface_input_filter_has_dscp_match(&state, ifx, false),
+            state
+                .iface_filter_v4_fast
+                .get(&ifx)
+                .is_some_and(|f| f.has_dscp_match_terms),
+            "v4 has_dscp_match accessor != fast-map flag at {ifx}"
+        );
+        assert_eq!(
+            interface_input_filter_has_dscp_match(&state, ifx, true),
+            state
+                .iface_filter_v6_fast
+                .get(&ifx)
+                .is_some_and(|f| f.has_dscp_match_terms),
+            "v6 has_dscp_match accessor != fast-map flag at {ifx}"
+        );
+        assert_eq!(
+            interface_input_filter_has_per_packet_l4_match(&state, ifx, false),
+            state
+                .iface_filter_v4_fast
+                .get(&ifx)
+                .is_some_and(|f| f.has_per_packet_l4_match_terms),
+            "v4 has_per_packet_l4_match accessor != fast-map flag at {ifx}"
+        );
+        assert_eq!(
+            interface_input_filter_has_per_packet_l4_match(&state, ifx, true),
+            state
+                .iface_filter_v6_fast
+                .get(&ifx)
+                .is_some_and(|f| f.has_per_packet_l4_match_terms),
+            "v6 has_per_packet_l4_match accessor != fast-map flag at {ifx}"
+        );
+        assert_eq!(
+            interface_output_filter_needs_tx_eval(&state, ifx, false),
+            state
+                .iface_filter_out_v4_fast
+                .get(&ifx)
+                .is_some_and(|f| f.needs_tx_eval()),
+            "v4 out needs_tx_eval accessor != fast-map flag at {ifx}"
+        );
+        assert_eq!(
+            interface_output_filter_needs_tx_eval(&state, ifx, true),
+            state
+                .iface_filter_out_v6_fast
+                .get(&ifx)
+                .is_some_and(|f| f.needs_tx_eval()),
+            "v6 out needs_tx_eval accessor != fast-map flag at {ifx}"
+        );
+    }
+
+    // Sanity: the fixture actually drives a positive result on every
+    // accessor/flag pair (otherwise the equivalence above is vacuously true).
+    assert!(interface_filter_affects_route_lookup(&state, 10, false));
+    assert!(interface_filter_affects_route_lookup(&state, 11, true));
+    assert!(interface_input_filter_has_dscp_match(&state, 20, false));
+    assert!(interface_input_filter_has_dscp_match(&state, 21, true));
+    assert!(interface_input_filter_has_per_packet_l4_match(&state, 30, false));
+    assert!(interface_input_filter_has_per_packet_l4_match(&state, 31, true));
+    assert!(interface_output_filter_needs_tx_eval(&state, 40, false));
+    assert!(interface_output_filter_needs_tx_eval(&state, 41, true));
 }
 
 #[test]
@@ -4530,8 +4806,13 @@ fn per_packet_match_marks_filter_cache_sensitive() {
     }];
     let state =
         parse_filter_state(&filters, &[], &interfaces, "", "").expect("filter state compiles");
+    // #6236 PR-2B: read the `has_per_packet_l4_match_terms` flag off the fast
+    // map (the `iface_filter_v4_has_per_packet_l4_match` set is deleted).
     assert!(
-        state.iface_filter_v4_has_per_packet_l4_match.contains(&7),
+        state
+            .iface_filter_v4_fast
+            .get(&7)
+            .is_some_and(|f| f.has_per_packet_l4_match_terms),
         "interface input filter with a tcp-flags term must be marked per-packet-L4 cache-sensitive"
     );
     assert!(interface_input_filter_has_per_packet_l4_match(

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -135,10 +135,12 @@ pub(crate) struct FirewallFilterSnapshot {
 //       lookup. File a tracker issue against session/key.rs.
 //
 //   (b) NOT in cache key (cache-sensitive) — wire the #1430
-//       runbook: per-interface FilterState.iface_filter_v{4,6}_has_<X>_match
-//       set, Filter.has_<X>_match_terms aggregate flag, flow-cache
-//       insertion gate at afxdp/flow_cache.rs:297-309, established-
-//       session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
+//       runbook: Filter.has_<X>_match_terms flag (read per-interface
+//       off FilterState.iface_filter_v{4,6}_fast via the
+//       interface_input_filter_has_<X>_match accessor — the parallel
+//       per-interface has_<X>_match sets were deleted in #6236 PR-2B),
+//       flow-cache insertion gate at afxdp/flow_cache.rs:297-309,
+//       established-session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
 //       forwarding rotation purge at afxdp/worker/loop_body/mod.rs:295-330,
 //       and tests at afxdp/flow_cache_tests.rs.
 //


### PR DESCRIPTION
**Part 2B of the #6236 PR-2 convergence — advances #6236, does NOT close it** (PR-2C, the single-lookup fold, remains).

## What
Removes the live redundancy behind #6236 PR-2: eight per-ifindex `FxHashSet<i32>` "property sets" that each re-encoded an immutable `Filter` flag already carried by the `Arc<Filter>` in the per-interface fast map.

- **Migrate the four hot capability accessors** to read the flag off `iface_filter_*_fast.get(&ifindex)` instead of a parallel set (signatures unchanged — consumers untouched, no single-lookup fold):
  - `interface_filter_affects_route_lookup` → `f.affects_route_lookup`
  - `interface_input_filter_has_dscp_match` → `f.has_dscp_match_terms`
  - `interface_input_filter_has_per_packet_l4_match` → `f.has_per_packet_l4_match_terms`
  - `interface_output_filter_needs_tx_eval` → `f.needs_tx_eval()`
- **Delete** the eight sets, the two `has_output_tx_selection_v{4,6}` aggregates (PR-2A rewired the global TX gate onto `has_output_needs_tx_eval_*`, which subsumes them), and the production-dead accessor `filter_state_has_output_tx_selection`. Remove the compiler `.insert` population + the post-loop `has_output_tx_selection_*` recompute.
- `FilterState` **25 → 15 fields**.

## Correctness
- **#1430 cache-sensitivity bit-identical**: the set was populated iff the same `Filter` flag was set, so `fast.get().is_some_and(flag)` is identical for a unique ifindex and last-wins-consistent for a duplicate (agrees with the filter the evaluator actually walks).
- **#3296 MissingFilterRef** fail-closed guards untouched — deleting a `.insert` never touched the `filters.get()` presence check.
- Aggregate-false fast branch and the global-gate semantics preserved (PR-2A).

## Validation (equivalence-before-delete gate)
- **Equivalence test landed FIRST** in pre-deletion form (`set.contains(&if) == fast.get(&if).is_some_and(flag)` across all 8 sets/flags, both families + directions) and confirmed **green before any deletion**; post-deletion it survives as an accessor-vs-fast-map regression pin (`capability_accessors_equal_fast_map_flags_for_unique_ifindices`).
- **Parent-RED**: making `interface_filter_affects_route_lookup` read `has_dscp_match_terms` turned 8 route-lookup/PBR tests RED (assertion failures, not build breaks); restored.
- Full `cargo test --release -- --test-threads=1`: **4248 passed, 0 failed**, 2 pre-existing ignored.

## Docs
`filter/README.md`, the #1430 runbook (`filter/mod.rs` + `protocol/security.rs`), and stale mechanism comments in cos_classify/flow_cache tests all re-anchored to the fast-map source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)