### PR TITLE
cluster: fence config-sync installs during apply (#6284 item 2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57707,3 +57707,19 @@ top.
     README notes this bound.
   **File(s)**: pkg/cluster/failover.go, pkg/cluster/README.md,
     pkg/cluster/failover_lease_5079_test.go, pkg/daemon/daemon_ha_sync.go
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6284 item 2 — close the residual config-epoch sweep-vs-advance
+    race. Added an apply-in-progress fence (`applyingConfigGen`) raised by
+    `configApplyLoop` before `OnConfigReceived` (the sweep runs inside it) and
+    lowered only after the high-water advances (success) or the apply fails.
+    `configEpochStale` now refuses against `max(applyingConfigGen,
+    lastAppliedConfigGen)` (fence read first) so an older-epoch install racing
+    the sub-µs window is refused against the applying generation instead of
+    admitted against the stale high-water. `resetRecvGen` clears the fence
+    alongside the high-water. Item 1 (reverse active/active direction) stays a
+    documented fail-OPEN residual. Fail-on-revert tests + docs updated.
+  **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_conn_config.go,
+    pkg/cluster/sync_conn_gen.go,
+    pkg/cluster/sync_config_epoch_sweep_race_6284_test.go,
+    docs/session-sync-architecture.md, pkg/cluster/README.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -306,6 +306,51 @@ non-authority's sessions carry the authority-independent seed epoch and the
 guard is inert for them (no false reject), which is acceptable because config
 changes originate on the authority.
 
+#### Apply-in-progress fence — sweep-vs-advance window (#6284, item 2)
+
+The bare epoch compare above (`ConfigEpoch < lastAppliedConfigGen`) closes the
+gap only once `lastAppliedConfigGen` has advanced — but the high-water advances
+**after** `OnConfigReceived` returns, while the deleted-policy sweep
+(`clearSessionsForDeletedPolicies`) runs **inside** it. That leaves a residual
+sub-µs window on the receiver: the moment between the sweep completing and the
+high-water advancing. A session install racing on the `receiveLoop` in that
+window is compared against the STALE high-water and wrongly admitted — reviving
+exactly the permit the just-run sweep invalidated.
+
+The apply-in-progress fence (`applyingConfigGen`) closes it. The single-consumer
+`configApplyLoop` raises the fence to the generation it is about to apply
+**before** calling `OnConfigReceived` (so it covers the whole apply, including
+the sweep) and lowers it to 0 only **after** the high-water advances on success
+(or immediately on an apply failure). `configEpochStale` refuses against
+`max(applyingConfigGen, lastAppliedConfigGen)`, reading the fence **first** so
+that on the success release order (high-water stored, then fence cleared) a
+reader observing `fence == 0` has necessarily already observed the advanced
+high-water — the effective refusal threshold never dips across the window.
+
+Ordering and correctness:
+
+- **No stale permit.** From before the sweep starts until the high-water
+  advances, an install stamped with an epoch older than the applying generation
+  is refused, so it can never land after the sweep against a stale high-water.
+- **No false reject.** The fence refuses only STRICTLY-older epochs. A session
+  the peer stamped with the CURRENT generation (equal to the one being applied)
+  is still admitted, exactly like the post-advance steady state; a transiently
+  refused older session is re-sent by the peer's next sweep.
+- **Apply failure.** The high-water deliberately stays put (M-2/#4151) and the
+  fence simply drops, restoring the pre-apply admission posture — the fence is
+  never held against a generation that never took effect.
+- **Bulk re-prime.** `resetRecvGen` clears the fence alongside the high-water so
+  a rebooted peer's lower-generation re-prime is accepted (the same
+  accept-everything reset the high-water already performs).
+
+**Item 1 (deferred, documented residual).** The guard still covers only the
+config-authority → peer direction (the primary that admits the session is also
+the RG0 config-sync authority). A non-authority's sessions carry the
+authority-independent seed epoch, so the guard is inert for the reverse
+direction in an active/active deployment (fail-OPEN). Closing it requires a
+bidirectional config-generation namespace that #5274 deliberately scoped out (a
+design-heavy change, not part of #6284 item 2); it remains tracked on #6284.
+
 ### RT_FLOW Session Id (#5212)
 
 The dataplane assigns each session a STABLE id (`SessionTable::alloc_session_id`)

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -812,6 +812,19 @@ outside the monitor loop:
   *local* commit counter (`Manager.bumpGeneration`) that is not cross-node
   comparable, so the receiver rejects the stale install BEFORE forwarding it to
   the helper, and no config-epoch field or guard is added on the Rust side.
+  **Apply-in-progress fence (#6284, item 2):** the bare `epoch <
+  lastAppliedConfigGen` compare closes the gap only once the high-water has
+  advanced, but the high-water advances AFTER `OnConfigReceived` returns while
+  the `clearSessionsForDeletedPolicies` sweep runs INSIDE it — leaving a sub-µs
+  window where a racing install is admitted against the stale high-water.
+  `configApplyLoop` raises `applyingConfigGen` to the generation it is applying
+  BEFORE the apply and lowers it only AFTER the high-water advances (success) or
+  the apply fails; `configEpochStale` refuses against `max(applyingConfigGen,
+  lastAppliedConfigGen)` (fence read first), so an older-epoch install racing the
+  window is refused against the applying generation instead of admitted. The
+  guard still covers only the config-authority → peer direction; the reverse
+  active/active direction stays a documented fail-OPEN residual on #6284 (item 1,
+  needs a bidirectional config-gen namespace #5274 scoped out).
 - **RT_FLOW session id (#5212)**: distinct from BOTH the synthesized BPF-ABI
   `SessionID` (`now<<16|slot`, node-local) AND the per-key install generation,
   every session install carries the ORIGINATING node's stable RT_FLOW session id

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -573,6 +573,19 @@ type SessionSync struct {
 	// config).
 	configGenCounter     atomic.Uint64
 	lastAppliedConfigGen atomic.Uint64
+	// applyingConfigGen is the apply-in-progress config fence (#6284, item 2).
+	// The single-consumer configApplyLoop sets it to the generation it is about
+	// to apply BEFORE calling OnConfigReceived (which runs the receiver's
+	// clearSessionsForDeletedPolicies sweep) and clears it to 0 only AFTER the
+	// high-water (lastAppliedConfigGen) has advanced on success, or immediately
+	// on an apply failure. The config-epoch install guard (configEpochStale)
+	// folds this into its refusal threshold so a synced session stamped with an
+	// epoch older than the generation being applied — one racing the sub-µs
+	// window between the sweep completing and the high-water advancing — is
+	// refused NOW instead of admitted against the not-yet-advanced high-water
+	// (the residual stale-permit window #5274 left open). 0 means no apply is in
+	// flight (or a gen==0 legacy apply, which carries no comparable epoch).
+	applyingConfigGen atomic.Uint64
 	// lastRecvConfigGen is the highest config generation this node has RECEIVED
 	// from the peer (recorded at enqueue in the syncMsgConfig handler, BEFORE
 	// apply). It is the receiver's local view of the config sender's current

--- a/pkg/cluster/sync_config_epoch_sweep_race_6284_test.go
+++ b/pkg/cluster/sync_config_epoch_sweep_race_6284_test.go
@@ -1,0 +1,220 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #6284 item 2 — the residual sweep-vs-advance stale-permit race the #5274
+// config-epoch guard left open.
+//
+// The config high-water (lastAppliedConfigGen) advances only AFTER
+// OnConfigReceived returns nil, but the deleted-policy sweep
+// (clearSessionsForDeletedPolicies) runs INSIDE OnConfigReceived. So there is a
+// sub-µs window — sweep completed, high-water not yet advanced — in which a
+// synced session install racing on the receiveLoop is compared against the
+// STALE high-water and wrongly admitted, reviving a permit the just-run sweep
+// invalidated.
+//
+// The apply-in-progress fence (applyingConfigGen, set for the whole apply)
+// closes it: during the window configEpochStale refuses an older-epoch install
+// against the generation being applied instead of the not-yet-advanced
+// high-water. These tests drive the real configApplyLoop and perform the racing
+// install AT the exact interleaving point (inside OnConfigReceived), so they
+// deterministically reproduce the window. Reverting the fence (installs
+// compared against lastAppliedConfigGen alone) admits the stale permit and they
+// fail RED.
+//
+// The install writes the mock dataplane's plain session map on the
+// configApplyLoop goroutine, so the admission OUTCOME is read on that same
+// goroutine and handed to the test goroutine over a channel (a happens-before
+// edge) rather than reading the map cross-goroutine — production installs run
+// on the receiveLoop against the real locked dataplane, not this unsynchronized
+// mock map.
+
+// waitFenceCleared polls the apply-in-progress fence until it drops to 0 (the
+// last atomic store on both the success and failure config-apply paths), so the
+// post-apply high-water/fence assertions observe the completed apply without
+// racing the loop. All accesses are atomic.
+func waitFenceCleared(t *testing.T, s *SessionSync) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.applyingConfigGen.Load() == 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("apply-in-progress fence never cleared (still %d)", s.applyingConfigGen.Load())
+}
+
+// windowProbe captures the state observed AT the racing-install interleaving
+// point, inside OnConfigReceived (the sweep window).
+type windowProbe struct {
+	highWater     uint64
+	fence         uint64
+	staleAdmitted bool
+	curAdmitted   bool
+}
+
+// TestConfigApplyFenceRefusesStaleInstallDuringSweep6284 is the v4 RED-on-revert
+// test for item 2. Inside the gen-8 apply (fence raised, high-water still 5) a
+// stale-epoch install (epoch 6, older than the applying gen but NEWER than the
+// pre-apply high-water) must be REFUSED, while a current-epoch install
+// (epoch 8) must still be ADMITTED — proving the fence refuses only
+// strictly-older epochs and never falsely rejects a current-generation session.
+func TestConfigApplyFenceRefusesStaleInstallDuringSweep6284(t *testing.T) {
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", dp)
+
+	// This node has already applied config generation 5.
+	ss.lastAppliedConfigGen.Store(5)
+
+	staleKey := configEpochKeyV4(46001) // epoch 6 < applying gen 8, > applied 5
+	curKey := configEpochKeyV4(46002)   // epoch 8 == applying gen 8
+
+	probeCh := make(chan windowProbe, 1)
+
+	// OnConfigReceived models the config-apply body: the deleted-policy sweep
+	// runs here, and two synced installs race in during the SAME window (after
+	// the sweep, before the high-water advances). At this point the fence is
+	// raised to gen 8 and the high-water is still 5.
+	ss.OnConfigReceived = func(_ string) error {
+		// STALE: epoch 6 is older than the generation being applied. Against
+		// the not-yet-advanced high-water (5) it would be admitted; the fence
+		// must refuse it (max(fence 8, high-water 5) = 8, and 6 < 8).
+		installWithConfigEpochV4(ss, staleKey, 6)
+		// CURRENT: epoch 8 equals the generation being applied — must be
+		// admitted (equality is not staleness; the config still admits it).
+		installWithConfigEpochV4(ss, curKey, 8)
+		_, stale := dp.v4sessions[staleKey]
+		_, cur := dp.v4sessions[curKey]
+		probeCh <- windowProbe{
+			highWater:     ss.lastAppliedConfigGen.Load(),
+			fence:         ss.applyingConfigGen.Load(),
+			staleAdmitted: stale,
+			curAdmitted:   cur,
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ss.configApplyLoop(ctx)
+
+	ss.configApplyCh <- configApplyItem{gen: 8, text: "config-C8"}
+
+	p := <-probeCh
+	// Sanity: the install genuinely raced the pre-advance window.
+	if p.highWater != 5 {
+		t.Fatalf("high-water advanced to %d before the apply completed — test not exercising the window", p.highWater)
+	}
+	if p.fence != 8 {
+		t.Fatalf("apply-in-progress fence = %d, want 8 during the apply (fence not raised)", p.fence)
+	}
+	// The stale-epoch install racing the sweep MUST have been refused.
+	if p.staleAdmitted {
+		t.Fatal("stale-epoch install racing the config-apply sweep was admitted against the not-yet-advanced high-water (#6284 item-2 window)")
+	}
+	// The current-epoch install MUST have been admitted (no false rejection).
+	if !p.curAdmitted {
+		t.Fatal("current-epoch install (epoch 8 == applying gen 8) was wrongly refused by the fence")
+	}
+	if got := ss.stats.SessionsStaleConfigIgnored.Load(); got != 1 {
+		t.Fatalf("SessionsStaleConfigIgnored = %d, want 1 (the fence refused the racing stale install)", got)
+	}
+
+	// After a successful apply the high-water advanced and the fence dropped.
+	waitFenceCleared(t, ss)
+	if got := ss.lastAppliedConfigGen.Load(); got != 8 {
+		t.Fatalf("high-water must advance to 8 after a successful apply, got %d", got)
+	}
+}
+
+// TestConfigApplyFenceRefusesStaleInstallDuringSweep6284V6 mirrors the guard on
+// the v6 install path — configEpochStale is shared, but this proves the v6
+// admission (installClusterSyncedV6) honors the fence identically.
+func TestConfigApplyFenceRefusesStaleInstallDuringSweep6284V6(t *testing.T) {
+	dp := &mockSweepDP{v6sessions: map[dataplane.SessionKeyV6]dataplane.SessionValueV6{}}
+	ss := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", dp)
+	ss.lastAppliedConfigGen.Store(5)
+
+	staleKey := configEpochKeyV6(46101)
+	curKey := configEpochKeyV6(46102)
+
+	probeCh := make(chan windowProbe, 1)
+
+	ss.OnConfigReceived = func(_ string) error {
+		installWithConfigEpochV6(ss, staleKey, 6)
+		installWithConfigEpochV6(ss, curKey, 8)
+		_, stale := dp.v6sessions[staleKey]
+		_, cur := dp.v6sessions[curKey]
+		probeCh <- windowProbe{staleAdmitted: stale, curAdmitted: cur}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ss.configApplyLoop(ctx)
+
+	ss.configApplyCh <- configApplyItem{gen: 8, text: "config-C8"}
+
+	p := <-probeCh
+	if p.staleAdmitted {
+		t.Fatal("stale-epoch v6 install racing the config-apply sweep was admitted against the not-yet-advanced high-water (#6284 item-2 window)")
+	}
+	if !p.curAdmitted {
+		t.Fatal("current-epoch v6 install (epoch 8 == applying gen 8) was wrongly refused by the fence")
+	}
+	if got := ss.stats.SessionsStaleConfigIgnored.Load(); got != 1 {
+		t.Fatalf("SessionsStaleConfigIgnored = %d, want 1 after the v6 stale reject", got)
+	}
+	waitFenceCleared(t, ss)
+}
+
+// TestConfigApplyFenceDroppedOnApplyFailure6284 asserts the fence is released
+// when the apply FAILS, so an older-epoch install is not permanently refused
+// against a generation that never took effect. The high-water deliberately
+// stays put (M-2/#4151); after the failed apply an epoch-6 install (older than
+// the failed gen 8 but not older than the retained high-water 5) is admitted
+// again, matching the pre-apply posture. The post-failure install runs on the
+// test goroutine (the loop is idle), so the mock map is touched by one
+// goroutine only.
+func TestConfigApplyFenceDroppedOnApplyFailure6284(t *testing.T) {
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", dp)
+	ss.lastAppliedConfigGen.Store(5)
+
+	rec := &configRecorder{failN: 1} // fail the gen-8 apply
+	ss.OnConfigReceived = rec.record
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ss.configApplyLoop(ctx)
+
+	ss.configApplyCh <- configApplyItem{gen: 8, text: "config-C8"}
+	drainConfigApply(t, ss)
+	waitFenceCleared(t, ss)
+
+	// The failed apply left the high-water at 5 and dropped the fence.
+	if got := ss.lastAppliedConfigGen.Load(); got != 5 {
+		t.Fatalf("failed apply must retain the high-water at 5 (M-2/#4151), got %d", got)
+	}
+	if got := ss.applyingConfigGen.Load(); got != 0 {
+		t.Fatalf("apply-in-progress fence must drop to 0 after a failed apply, got %d", got)
+	}
+
+	// An epoch-6 install (> retained high-water 5) is now admitted again — the
+	// fence is not holding it against the generation that never applied.
+	key := configEpochKeyV4(46201)
+	installWithConfigEpochV4(ss, key, 6)
+	if _, ok := dp.v4sessions[key]; !ok {
+		t.Fatal("epoch-6 install refused after a FAILED gen-8 apply — the fence must not hold against a generation that never took effect")
+	}
+	if got := ss.stats.SessionsStaleConfigIgnored.Load(); got != 0 {
+		t.Fatalf("SessionsStaleConfigIgnored = %d, want 0 after a failed apply (no stale reject)", got)
+	}
+}

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -72,6 +72,29 @@ func (s *SessionSync) recordAppliedConfigGen(gen uint64) {
 	}
 }
 
+// beginConfigApply raises the apply-in-progress fence to gen for the duration
+// of an apply (#6284, item 2). It is set BEFORE OnConfigReceived runs — so it
+// covers the whole apply, including the receiver's clearSessionsForDeletedPolicies
+// sweep — and configEpochStale folds max(fence, high-water) into its refusal
+// threshold. A gen==0 (legacy/unconditional) apply carries no comparable epoch,
+// so the fence stays 0 and no install is refused on its account. Called ONLY
+// from the single-consumer configApplyLoop, so the store needs no CAS.
+func (s *SessionSync) beginConfigApply(gen uint64) {
+	s.applyingConfigGen.Store(gen)
+}
+
+// endConfigApply lowers the apply-in-progress fence (#6284, item 2). On a
+// SUCCESSFUL apply the caller advances the high-water (recordAppliedConfigGen)
+// FIRST and only then calls this, so the effective refusal threshold
+// max(fence, high-water) never dips between the sweep and the high-water
+// advance — closing the residual window. On an apply FAILURE the high-water
+// deliberately stays put (M-2/#4151) and the fence is simply dropped, restoring
+// the pre-apply admission posture (the transiently-refused installs are re-sent
+// by the peer's next sweep). Called ONLY from configApplyLoop.
+func (s *SessionSync) endConfigApply() {
+	s.applyingConfigGen.Store(0)
+}
+
 // configApplyLoop is the single ordered consumer of config-sync messages
 // (#3931). It drains configApplyCh in receive order and attempts a config only
 // when shouldApplyConfigGen accepts its generation, so a reordered older config
@@ -103,6 +126,14 @@ func (s *SessionSync) configApplyLoop(ctx context.Context) {
 				// re-applies on the primary's next push of this generation.
 				continue
 			}
+			// #6284 item 2: fence installs against the generation being applied
+			// for the ENTIRE apply. The clearSessionsForDeletedPolicies sweep
+			// runs inside OnConfigReceived, so a synced session stamped with an
+			// older epoch that races the sub-µs gap between the sweep and the
+			// high-water advance must be refused now — the fence makes
+			// configEpochStale refuse it against the applying generation rather
+			// than admit it against the not-yet-advanced high-water.
+			s.beginConfigApply(item.gen)
 			if err := s.OnConfigReceived(item.text); err != nil {
 				// The apply did not take effect (compile/promote failure or a
 				// transient RG0-primary rejection). Do NOT advance the
@@ -121,11 +152,17 @@ func (s *SessionSync) configApplyLoop(ctx context.Context) {
 				// above (surfaced in cluster status), not this log.
 				slog.Debug("cluster sync: config apply failed — retaining prior high-water so the peer re-push re-converges",
 					"incoming_gen", item.gen, "last_applied_gen", s.lastAppliedConfigGen.Load(), "size", len(item.text), "err", err)
+				// #6284: drop the fence — the high-water intentionally stays put
+				// (M-2/#4151), so restore the pre-apply admission posture.
+				s.endConfigApply()
 				continue
 			}
 			// Apply confirmed — advance the high-water so a duplicate re-push of
-			// the same generation is correctly skipped as stale.
+			// the same generation is correctly skipped as stale, THEN drop the
+			// fence. Advancing first keeps the effective refusal threshold
+			// max(fence, high-water) from dipping in the release window (#6284).
 			s.recordAppliedConfigGen(item.gen)
+			s.endConfigApply()
 		}
 	}
 }

--- a/pkg/cluster/sync_conn_gen.go
+++ b/pkg/cluster/sync_conn_gen.go
@@ -352,6 +352,14 @@ func (s *SessionSync) resetRecvGen() {
 	// CURRENT config (pushConfigToPeer sends ShowActive), so the newest
 	// content still wins.
 	s.lastAppliedConfigGen.Store(0)
+	// #6284: drop the apply-in-progress fence alongside the high-water so a
+	// concurrent bulk re-prime restores the accept-everything posture the reset
+	// intends. A re-prime admits the rebooted peer's lower-generation set; a
+	// stale fence from an apply that raced the reset would otherwise keep
+	// refusing it. configApplyLoop may re-raise the fence on its next apply —
+	// the same benign race the high-water reset already has with a concurrent
+	// advance — and the re-primed installs are re-sent by the next sweep.
+	s.applyingConfigGen.Store(0)
 	// #5563: reset the received-config high-water alongside the applied mark so
 	// the manual-failover readiness gate's applied<=received invariant holds
 	// across the reset window. The reconnect re-push then re-establishes both
@@ -401,8 +409,27 @@ func (s *SessionSync) resetRecvGen() {
 // as before (rolling-upgrade safe). The check is authoritative here in the Go
 // cluster layer: the #3931 namespace lives entirely in SessionSync, and the
 // receiver refuses BEFORE forwarding the install to the userspace helper.
+//
+// #6284 item 2: the refusal threshold is max(applyingConfigGen, lastApplied-
+// ConfigGen), not the high-water alone. configApplyLoop raises the fence
+// (applyingConfigGen) to the generation it is applying BEFORE running the
+// clearSessionsForDeletedPolicies sweep and lowers it only AFTER the high-water
+// advances (success) or the apply fails, so during that whole window an install
+// stamped with an older epoch is refused against the applying generation
+// instead of admitted against the not-yet-advanced high-water. The fence is
+// read FIRST and folded with a max: on the success-release ordering (high-water
+// stored, THEN fence cleared) this guarantees a reader that observes fence==0
+// has already observed the advanced high-water, so the effective threshold
+// never dips — closing the sub-µs sweep-vs-advance stale-permit race.
 func (s *SessionSync) configEpochStale(epoch uint64) bool {
-	return epoch != 0 && epoch < s.lastAppliedConfigGen.Load()
+	if epoch == 0 {
+		return false
+	}
+	barrier := s.applyingConfigGen.Load()
+	if applied := s.lastAppliedConfigGen.Load(); applied > barrier {
+		barrier = applied
+	}
+	return epoch < barrier
 }
 
 func (s *SessionSync) installClusterSyncedV4(key dataplane.SessionKey, val dataplane.SessionValue) {


### PR DESCRIPTION
## Summary

Closes the residual sweep-vs-advance stale-permit race in the #5274 HA
config-epoch guard (issue #6284, **item 2 only**).

The config-epoch guard (`configEpochStale`) refuses a synced session install
whose `ConfigEpoch` is strictly older than the receiver's
`lastAppliedConfigGen`, so a session admitted under an old config that lands
after the newer config's `clearSessionsForDeletedPolicies` sweep is dropped
instead of forwarded as a stale permit after failover.

But the high-water advances **after** `OnConfigReceived` returns, while the
sweep runs **inside** it (`handleConfigSync` → `syncAndApply` → commit). That
leaves a residual sub-µs window on the receiver — sweep completed, high-water
not yet advanced — in which a synced install racing on the `receiveLoop` is
compared against the STALE high-water and wrongly admitted, reviving the exact
permit the just-run sweep invalidated.

## Fix — apply-in-progress fence

`configApplyLoop` raises `applyingConfigGen` to the generation it is about to
apply **before** calling `OnConfigReceived` (so the fence covers the whole
apply, including the sweep) and lowers it to 0 only **after** the high-water
advances on success, or immediately on an apply failure. `configEpochStale`
refuses against `max(applyingConfigGen, lastAppliedConfigGen)`, reading the
fence **first** so that on the success release order (high-water stored, then
fence cleared) a reader observing `fence==0` has necessarily already observed
the advanced high-water — the effective refusal threshold never dips across the
window.

- **No stale permit** — from before the sweep starts until the high-water
  advances, an install stamped with an epoch older than the applying generation
  is refused.
- **No false reject** — the fence refuses only STRICTLY-older epochs; a
  current-generation install is still admitted (equality is not staleness), and
  a transiently refused older session is re-sent by the peer's next sweep.
- **Apply failure** — the high-water deliberately stays put (M-2/#4151) and the
  fence drops, restoring the pre-apply posture; the fence is never held against
  a generation that never took effect.
- **Bulk re-prime** — `resetRecvGen` clears the fence alongside the high-water.

## Scope — item 1 deferred

This PR **advances #6284** (does not fully close it). Item 1 — the reverse
active/active, non-authority direction — is **not** addressed here: it requires
the bidirectional config-generation namespace that #5274 deliberately scoped
out (a design-heavy change, not this PR), and remains a documented fail-OPEN
residual tracked on #6284. The guard still covers only the
config-authority → peer direction.

## Tests (fail-on-revert)

`pkg/cluster/sync_config_epoch_sweep_race_6284_test.go` drives the real
`configApplyLoop` and performs the racing install at the exact interleaving
point (inside `OnConfigReceived`, i.e. the sweep window). Reverting
`configEpochStale` to compare against `lastAppliedConfigGen` alone admits the
stale permit:

```
--- FAIL: TestConfigApplyFenceRefusesStaleInstallDuringSweep6284
    stale-epoch install racing the config-apply sweep was admitted against the
    not-yet-advanced high-water (#6284 item-2 window)
--- FAIL: TestConfigApplyFenceRefusesStaleInstallDuringSweep6284V6
```

Companion tests assert no false-reject of the current-generation install and
that the fence drops on apply failure. All run clean under `-race`.

## Validation

- `go test ./pkg/cluster/... ./pkg/daemon/... ./pkg/configstore/...` — pass
- `go test -race ./pkg/cluster/ -run 6284` — pass
- `go vet` + `gofmt` — clean
- Docs: `docs/session-sync-architecture.md` (new "Apply-in-progress fence"
  subsection + item-1 deferral note) and `pkg/cluster/README.md` updated.

HA/config-sync-adjacent → **failover/config-sync smoke advisable at merge**
(parent runs it).