### PR TITLE
cluster/failover: gate applied-ack on RETH VIP removal (#6177)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57707,3 +57707,21 @@ top.
     README notes this bound.
   **File(s)**: pkg/cluster/failover.go, pkg/cluster/README.md,
     pkg/cluster/failover_lease_5079_test.go, pkg/daemon/daemon_ha_sync.go
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6177 — close the RETH VIP-removal sub-ms two-owner residual
+    left by #5640 (#6174). Added a per-instance VRRP resign-completion
+    barrier (`armResignBarrier`/`markVIPsHeld`/`markVIPsRemoved`,
+    `Manager.ResignRGWait`) closed only when VIPs are PHYSICALLY removed
+    (becomeBackup success or #5482 reconcile); daemon
+    `releaseFailoverActuationAfterResign` defers `signalFailoverActuated`
+    on the RETH path until the barriers close. Hardened
+    `disarmFailoverActuation` to an identity (channel) check so an older
+    timed-out waiter cannot drop a newer same-RG waiter's entry
+    (residual #2). Added daemon-barrier + resign-barrier unit tests
+    (residual #3). Docs: session-sync-architecture.md, pkg/vrrp/README.md.
+  **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/instance_vip.go,
+    pkg/vrrp/manager.go, pkg/vrrp/resign_barrier_6177_test.go,
+    pkg/daemon/daemon_ha.go, pkg/daemon/daemon_ha_sync.go,
+    pkg/daemon/failover_actuation_barrier_6177_test.go,
+    docs/session-sync-architecture.md, pkg/vrrp/README.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -1338,8 +1338,11 @@ The fix gates the applied-ack on a fence-completion barrier:
    `waitFailoverActuated`) after `OnRemoteFailover` succeeds and before sending
    `failoverAckApplied`. It blocks on the barrier channel.
 3. `watchClusterEvents`, at the end of the demotion (non-primary) branch — after
-   `ResignRG` / direct-VIP reconcile / `rg_active` clear — calls
-   `signalFailoverActuated(rgID)`, closing the channel and releasing the ack.
+   the resign is initiated, the direct-VIP reconcile runs, and `rg_active` is
+   cleared — releases the barrier via `signalFailoverActuated(rgID)`. On the
+   direct-VIP path (`reconcileDirectVIPOwnership`) the VIP removal is synchronous,
+   so it signals inline. On the RETH path the release is deferred until the VIPs
+   are physically removed — see the #6177 refinement below.
 4. The wait is bounded by `failoverActuateTimeout` (3s default). A demotion that
    never actuates (superseded reset, event-channel drop) downgrades the ack to
    `failoverAckFailed` so the peer **holds** rather than promoting into the
@@ -1349,6 +1352,48 @@ The fix gates the applied-ack on a fence-completion barrier:
 
 The batch path (`handleRemoteFailoverBatch` / `WaitFailoverAppliedBatch`) applies
 the same per-RG barrier across the whole set.
+
+#### RETH VIP-removal gate + delete-by-key hardening (#6177)
+
+The #5640 hostile review flagged that on the **RETH-VRRP** path (the loss-cluster
+topology) `ResignRG` is non-blocking: it sets VRRP priority to 0 and signals
+`resignCh` **synchronously** (so peers see the resignation immediately), but the
+actual VIP removal (`becomeBackup` → `removeVIPs`) runs **async** on the VRRP
+run-loop. Releasing the applied-ack on resign-*signaled* alone left a sub-ms
+residual two-owner window where the peer promoted while this node still had the
+RETH VIPs on the wire. (Direct-VIP mode has no residual — `reconcileDirectVIPOwnership`
+removes the VIPs synchronously before the signal.)
+
+#6177 closes the window by gating the release on the VIPs being **physically
+removed**:
+
+- Each `vrrpInstance` carries a resign-completion barrier. `becomeMaster` records
+  ownership (`markVIPsHeld`) once a successful VIP add lands; `becomeBackup`
+  releases it (`markVIPsRemoved`) once `removeVIPs` **succeeds**. A removal that
+  fails leaves the barrier armed on purpose — the #5482 stale-VIP reconcile closes
+  it when the deferred removal finally clears, and until then the barrier stays
+  open so the peer holds rather than promoting over a stale VIP (safe-direction).
+- `Manager.ResignRGWait(rgID)` sets priority-0 + triggers resign exactly like
+  `ResignRG`, but arms a barrier on each RETH instance **before** `triggerResign`
+  (so the run-loop's `becomeBackup` cannot close-and-forget it) and returns the
+  per-instance barriers. An instance that does not own the VIPs yields an
+  already-closed barrier (nothing to wait for).
+- `watchClusterEvents` captures those barriers on the Primary→Secondary edge and,
+  instead of signalling inline, hands them to `releaseFailoverActuationAfterResign`
+  on a goroutine (so the event loop never blocks on the run-loop). That goroutine
+  waits for every barrier to close, then calls `signalFailoverActuated`. Its bound
+  is set above the peer-side `failoverActuateTimeout`, so on a stuck removal the
+  peer-side wait times out first and holds — the goroutine never prematurely
+  releases the ack.
+
+The review also flagged a latent **delete-by-key** hazard: `disarmFailoverActuation`
+and the wait's timeout path deleted `failoverActuateWait[rgID]` by key without
+checking channel identity, so an older timed-out waiter could nuke a newer
+same-RG waiter's entry and spuriously fail its ack (unreachable today — the
+initiator serializes per-RG — but latent). `disarmFailoverActuation(rgID, ch)`
+now deletes only when the stored channel is still the exact one the caller
+armed/waited on; `armFailoverActuation` returns that channel so the error and
+timeout paths can pass their own.
 
 Once the RG is marked standby, each worker processes a
 `WorkerCommand::DemoteOwnerRGS` on its packet thread

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -146,22 +146,32 @@ func (d *Daemon) waitLocalFailoverCommitReady(rgIDs []int) error {
 // barrier before waitFailoverActuated observes it. Concurrent same-RG remote
 // failovers are excluded upstream (cluster.failoverInProgress + the sync-layer
 // failover waiters), so a single channel per RG is sufficient (#5640).
-func (d *Daemon) armFailoverActuation(rgID int) {
+func (d *Daemon) armFailoverActuation(rgID int) chan struct{} {
 	d.failoverActuateMu.Lock()
 	if d.failoverActuateWait == nil {
 		d.failoverActuateWait = make(map[int]chan struct{})
 	}
-	d.failoverActuateWait[rgID] = make(chan struct{})
+	ch := make(chan struct{})
+	d.failoverActuateWait[rgID] = ch
 	d.failoverActuateMu.Unlock()
+	return ch
 }
 
 // disarmFailoverActuation drops a barrier that will never be actuated — used
-// when ManualFailover fails to enqueue the demotion (no event will ever fire).
-// It does NOT close the channel: no waiter can be blocked on it because the
-// applied-ack path is not reached on a ManualFailover error.
-func (d *Daemon) disarmFailoverActuation(rgID int) {
+// when ManualFailover fails to enqueue the demotion (no event will ever fire),
+// and by waitFailoverActuated's timeout path. It removes the map entry ONLY when
+// it still holds the exact channel the caller armed/waited on (identity check),
+// so an older, timed-out waiter for the same RG can never nuke a NEWER waiter's
+// entry and spuriously fail its ack (#6177 delete-by-key hardening). A nil ch
+// deletes unconditionally (legacy key-only callers). It does NOT close the
+// channel: no waiter can be blocked on a channel dropped on the error path
+// because the applied-ack path is not reached on a ManualFailover error, and the
+// timeout path has already stopped waiting.
+func (d *Daemon) disarmFailoverActuation(rgID int, ch chan struct{}) {
 	d.failoverActuateMu.Lock()
-	delete(d.failoverActuateWait, rgID)
+	if cur, ok := d.failoverActuateWait[rgID]; ok && (ch == nil || cur == ch) {
+		delete(d.failoverActuateWait, rgID)
+	}
 	d.failoverActuateMu.Unlock()
 }
 
@@ -203,8 +213,10 @@ func (d *Daemon) waitFailoverActuated(rgID int) error {
 		return nil
 	case <-timer.C:
 		// Drop the stranded barrier so a later actuation event does not
-		// close an orphaned channel that no one reads.
-		d.disarmFailoverActuation(rgID)
+		// close an orphaned channel that no one reads. Pass the channel we
+		// waited on so a concurrent newer arm for the same RG is not dropped
+		// (#6177 delete-by-key hardening).
+		d.disarmFailoverActuation(rgID, ch)
 		return fmt.Errorf("timed out waiting for local fence actuation of redundancy group %d", rgID)
 	}
 }
@@ -218,6 +230,46 @@ func (d *Daemon) waitFailoverActuatedBatch(rgIDs []int) error {
 		}
 	}
 	return nil
+}
+
+// releaseFailoverActuationAfterResign releases the #5640 fence-completion barrier
+// for rgID once the RETH resign has PHYSICALLY removed the VIPs (#6177). It runs
+// on its own goroutine so watchClusterEvents never blocks on the VRRP run-loop's
+// async VIP removal. Each barrier in resignBarriers closes when its instance's
+// VIPs are gone (becomeBackup succeeded, or the #5482 stale-VIP reconcile finally
+// cleared a failed removal); an already-closed barrier is an instance that did
+// not own the VIPs. All must close before the applied-ack is released, so the
+// peer only promotes after every RETH VIP for the RG is off this node.
+//
+// If a removal never confirms within the bounded budget — a persistent netlink
+// failure whose async reconcile keeps failing — this returns WITHOUT signaling.
+// The peer-side waitFailoverActuated then times out on its own and the peer HOLDS
+// rather than promotes over a still-present VIP (safe-direction), and its timeout
+// path disarms the barrier, so nothing leaks. The budget is set above the peer's
+// actuation timeout so on a stuck resign the ack side reliably times out first,
+// leaving this purely a cleanup/leak guard. ctx cancellation (daemon shutdown)
+// exits without signaling.
+func (d *Daemon) releaseFailoverActuationAfterResign(ctx context.Context, rgID int, resignBarriers []<-chan struct{}) {
+	budget := d.failoverActuateTimeout
+	if budget <= 0 {
+		budget = 3 * time.Second
+	}
+	budget *= 2
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	for _, ch := range resignBarriers {
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			slog.Warn("cluster: RETH resign VIP-removal did not confirm within the "+
+				"actuation budget; leaving the applied-ack to the peer-side timeout "+
+				"(safe HOLD — peer will not promote over a stale VIP)", "rg", rgID)
+			return
+		}
+	}
+	d.signalFailoverActuated(rgID)
 }
 
 // isRethMasterState returns true when ALL VRRP instances for rgID are MASTER.
@@ -348,10 +400,18 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 				if clusterDemotionEdge && d.dp != nil {
 					d.tryPrepareUserspaceRGDemotion(ev.GroupID)
 				}
+				// #6177: on the RETH-VRRP path the actual VIP removal
+				// (becomeBackup) runs async on the VRRP run-loop, so ResignRG
+				// returns after resign is only SIGNALED. Capture the per-instance
+				// resign-completion barriers so the applied-ack release below waits
+				// for the VIPs to be PHYSICALLY removed, closing the sub-ms two-
+				// owner window. Priority-0 is still set synchronously, so the peer
+				// sees the resignation immediately regardless of the wait.
+				var resignBarriers []<-chan struct{}
 				if !noRethVRRP {
 					if ev.OldState == cluster.StatePrimary &&
 						(ev.NewState == cluster.StateSecondary || ev.NewState == cluster.StateSecondaryHold) {
-						d.vrrpMgr.ResignRG(ev.GroupID)
+						resignBarriers = d.vrrpMgr.ResignRGWait(ev.GroupID)
 					}
 				}
 				// Deactivation: blackhole routes first (if transitioning
@@ -380,13 +440,20 @@ func (d *Daemon) watchClusterEvents(ctx context.Context) {
 					d.reconcileDirectVIPOwnership(ev.GroupID, "cluster-secondary")
 				}
 
-				// #5640: the local demotion is now actuated — VRRP has
-				// resigned to priority-0 (or direct VIP ownership was
-				// reconciled away) and rg_active is cleared. Release any
-				// remote-failover applied-ack that is holding for this fence
-				// so the peer only promotes AFTER this node stopped owning
-				// the RG. Fires for every non-primary edge; unarmed RGs no-op.
-				d.signalFailoverActuated(ev.GroupID)
+				// #5640/#6177: the local demotion is now actuated — release any
+				// remote-failover applied-ack holding for this fence so the peer
+				// only promotes AFTER this node stopped owning the RG. On the
+				// direct-VIP path reconcileDirectVIPOwnership above removed the
+				// VIPs synchronously, so signal now. On the RETH path the VIP
+				// removal runs async on the VRRP run-loop; defer the signal to a
+				// goroutine that waits on the resign-completion barriers so the ack
+				// only releases after the RETH VIPs are PHYSICALLY gone (#6177).
+				// Fires for every non-primary edge; unarmed RGs no-op.
+				if len(resignBarriers) == 0 {
+					d.signalFailoverActuated(ev.GroupID)
+				} else {
+					go d.releaseFailoverActuationAfterResign(ctx, ev.GroupID, resignBarriers)
+				}
 			}
 
 			// Strict VIP ownership: suppress GARP on secondary, allow on primary.

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -994,9 +994,9 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				// enqueues the async demotion event, so watchClusterEvents
 				// cannot actuate-and-forget before WaitFailoverApplied observes
 				// it. The applied-ack (sync layer) then waits on this barrier.
-				d.armFailoverActuation(rgID)
+				armed := d.armFailoverActuation(rgID)
 				if err := d.cluster.ManualFailover(rgID); err != nil {
-					d.disarmFailoverActuation(rgID)
+					d.disarmFailoverActuation(rgID, armed)
 					slog.Warn("cluster: remote failover failed", "rg", rgID, "err", err)
 					return err
 				}
@@ -1016,13 +1016,16 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				}
 				slog.Info("cluster: remote batch failover request from peer", "rgs", rgIDs, "req_id", reqID)
 				// #5640: arm every member's fence barrier before the batch
-				// demotion enqueues its per-RG events.
+				// demotion enqueues its per-RG events. Keep each armed channel so
+				// the error-path disarm drops exactly what it armed, never a newer
+				// concurrent arm for the same RG (#6177 delete-by-key hardening).
+				armed := make(map[int]chan struct{}, len(rgIDs))
 				for _, rgID := range rgIDs {
-					d.armFailoverActuation(rgID)
+					armed[rgID] = d.armFailoverActuation(rgID)
 				}
 				if err := d.cluster.ManualFailoverBatch(rgIDs); err != nil {
 					for _, rgID := range rgIDs {
-						d.disarmFailoverActuation(rgID)
+						d.disarmFailoverActuation(rgID, armed[rgID])
 					}
 					slog.Warn("cluster: remote batch failover failed", "rgs", rgIDs, "err", err)
 					return err

--- a/pkg/daemon/failover_actuation_barrier_6177_test.go
+++ b/pkg/daemon/failover_actuation_barrier_6177_test.go
@@ -1,0 +1,185 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// #6177 — the daemon-side companion to the VRRP resign-completion barrier.
+//
+// The #5640 fence-completion barrier (armFailoverActuation / waitFailoverActuated
+// / signalFailoverActuated) withholds the peer's remote-failover applied-ack until
+// the local demotion is actuated. #6177 (a) gates the RETH release on the VRRP
+// resign VIPs being PHYSICALLY removed (releaseFailoverActuationAfterResign waits
+// on the resign barriers) and (b) hardens disarm to an identity check so an older
+// timed-out waiter can never drop a newer waiter's entry. These tests exercise
+// the daemon barrier directly — the coverage gap #5640's hostile review flagged
+// (residual #3) — with no cluster or VRRP manager.
+
+// TestReleaseFailoverActuationWaitsForResign_6177 is the primary fail-on-revert
+// guard: the applied-ack must NOT release until the RETH resign barrier closes
+// (VIPs physically removed), then it releases cleanly.
+//
+// RED on revert: making releaseFailoverActuationAfterResign call
+// signalFailoverActuated without first waiting on the resign barriers (the
+// pre-#6177 behavior, where watchClusterEvents signalled immediately after the
+// non-blocking ResignRG) releases the ack inside the 150ms window below — the
+// "released before the RETH resign completed" assertion then fires.
+func TestReleaseFailoverActuationWaitsForResign_6177(t *testing.T) {
+	d := &Daemon{failoverActuateTimeout: 5 * time.Second}
+	const rg = 1
+	d.armFailoverActuation(rg)
+
+	ackErr := make(chan error, 1)
+	go func() { ackErr <- d.waitFailoverActuated(rg) }()
+
+	resign := make(chan struct{})
+	go d.releaseFailoverActuationAfterResign(context.Background(), rg, []<-chan struct{}{resign})
+
+	// The ack is held while the RETH VIP removal is still in flight.
+	select {
+	case err := <-ackErr:
+		t.Fatalf("applied-ack released before the RETH resign completed (the #6177 window): err=%v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(resign) // VIPs physically removed
+	select {
+	case err := <-ackErr:
+		if err != nil {
+			t.Fatalf("ack should release cleanly once the resign completed, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ack never released after the resign barrier closed")
+	}
+}
+
+// TestReleaseFailoverActuation_TimeoutLeavesAckToPeerSide_6177 pins the safe-
+// direction leak guard: if a resign barrier never closes (a persistent VIP-remove
+// failure), releaseFailoverActuationAfterResign must NOT signal — it leaves the
+// ack to the peer-side waitFailoverActuated timeout so the peer HOLDS rather than
+// promotes over a stale VIP. The barrier entry therefore stays armed (the peer
+// side, not this goroutine, disarms it on its own timeout).
+func TestReleaseFailoverActuation_TimeoutLeavesAckToPeerSide_6177(t *testing.T) {
+	// budget = 2 * failoverActuateTimeout = 40ms, so the release goroutine gives
+	// up quickly for the test.
+	d := &Daemon{failoverActuateTimeout: 20 * time.Millisecond}
+	const rg = 2
+	ch := d.armFailoverActuation(rg)
+
+	stuck := make(chan struct{}) // never closes — removal never confirms
+	done := make(chan struct{})
+	go func() {
+		d.releaseFailoverActuationAfterResign(context.Background(), rg, []<-chan struct{}{stuck})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("release goroutine did not give up on the stuck barrier")
+	}
+
+	// It must not have signalled: the entry the peer side waits on is intact.
+	d.failoverActuateMu.Lock()
+	cur, present := d.failoverActuateWait[rg]
+	d.failoverActuateMu.Unlock()
+	if !present || cur != ch {
+		t.Fatal("release goroutine signalled/dropped the barrier on timeout; the peer-side " +
+			"timeout must own the safe HOLD, not a premature release")
+	}
+}
+
+// TestFailoverActuationBarrier_SignalReleasesAndCleansUp_6177 pins the arm →
+// wait → signal → cleanup semantics (residual #3 coverage): the waiter releases
+// with no error and the barrier entry is deleted (no stale-channel leak).
+func TestFailoverActuationBarrier_SignalReleasesAndCleansUp_6177(t *testing.T) {
+	d := &Daemon{failoverActuateTimeout: 2 * time.Second}
+	const rg = 7
+	d.armFailoverActuation(rg)
+
+	ackErr := make(chan error, 1)
+	go func() { ackErr <- d.waitFailoverActuated(rg) }()
+	d.signalFailoverActuated(rg)
+
+	select {
+	case err := <-ackErr:
+		if err != nil {
+			t.Fatalf("signal path: want nil, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("signalFailoverActuated did not release the waiter")
+	}
+
+	d.failoverActuateMu.Lock()
+	_, present := d.failoverActuateWait[rg]
+	d.failoverActuateMu.Unlock()
+	if present {
+		t.Fatal("signalFailoverActuated must delete the barrier entry (no stale-channel leak)")
+	}
+}
+
+// TestFailoverActuationBarrier_TimeoutDowngradesAndCleansUp_6177 pins the
+// bounded-wait downgrade: with no actuation signal the waiter returns an error
+// (the ack downgrades to failed instead of hanging) and the stranded barrier is
+// disarmed.
+func TestFailoverActuationBarrier_TimeoutDowngradesAndCleansUp_6177(t *testing.T) {
+	d := &Daemon{failoverActuateTimeout: 40 * time.Millisecond}
+	const rg = 8
+	d.armFailoverActuation(rg)
+
+	if err := d.waitFailoverActuated(rg); err == nil {
+		t.Fatal("waitFailoverActuated must return an error when the demotion is never actuated")
+	}
+
+	d.failoverActuateMu.Lock()
+	_, present := d.failoverActuateWait[rg]
+	d.failoverActuateMu.Unlock()
+	if present {
+		t.Fatal("the timeout path must disarm the stranded barrier (no stale-channel leak)")
+	}
+}
+
+// TestFailoverActuationDisarmIdentityChecked_6177 is the delete-by-key hardening
+// fail-on-revert guard (residual #2): a disarm keyed on an OLDER waiter's channel
+// must not delete a NEWER overlapping waiter's entry.
+//
+// RED on revert: dropping the identity check in disarmFailoverActuation (reverting
+// to the key-only `delete(d.failoverActuateWait, rgID)`) deletes ch2 — the
+// assertion that the newer entry survives then fails, and the newer ack would
+// spuriously fail.
+func TestFailoverActuationDisarmIdentityChecked_6177(t *testing.T) {
+	d := &Daemon{}
+	const rg = 5
+	ch1 := d.armFailoverActuation(rg)
+	ch2 := d.armFailoverActuation(rg) // a newer overlapping waiter replaced the entry
+	if ch1 == ch2 {
+		t.Fatal("each arm must create a distinct channel")
+	}
+
+	// The older waiter's timeout-disarm passes ITS channel (ch1); the entry now
+	// holds ch2, so nothing must be deleted.
+	d.disarmFailoverActuation(rg, ch1)
+
+	d.failoverActuateMu.Lock()
+	cur, present := d.failoverActuateWait[rg]
+	d.failoverActuateMu.Unlock()
+	if !present || cur != ch2 {
+		t.Fatal("a disarm keyed on a stale channel deleted the newer waiter's entry " +
+			"(#6177 delete-by-key hazard): the newer ack would spuriously fail")
+	}
+
+	// The newer waiter still releases normally through signal.
+	ackErr := make(chan error, 1)
+	go func() { ackErr <- d.waitFailoverActuated(rg) }()
+	d.signalFailoverActuated(rg)
+	select {
+	case err := <-ackErr:
+		if err != nil {
+			t.Fatalf("newer waiter: want nil, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("newer waiter never released")
+	}
+}

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -90,6 +90,19 @@ This is the package that drives chassis-cluster failover.
   instances.
 - `ResignRG(rgID int)` — `manager.go`. Forces this node out of master
   for the given redundancy group ID.
+- `ResignRGWait(rgID int) []<-chan struct{}` — `manager.go`. Same resign
+  as `ResignRG` (priority-0 + `triggerResign`, both synchronous) but
+  arms a per-instance resign-completion barrier BEFORE `triggerResign`
+  and returns one channel per RETH instance. Each closes once that
+  instance's VIPs are PHYSICALLY removed (`becomeBackup` succeeded, or
+  the #5482 stale-VIP reconcile finally cleared a failed removal); a
+  non-owner yields an already-closed channel. The daemon waits on these
+  before releasing the peer's remote-failover applied-ack so the peer
+  never promotes into a two-owner window while this node still owns the
+  RETH VIPs (#6177 — closes the sub-ms residual left by #5640; the async
+  VIP removal on the run-loop meant `ResignRG` returned after resign was
+  only *signaled*). `markVIPsHeld`/`markVIPsRemoved` maintain the
+  barrier's ownership fact off the `vipMu` TOCTOU path.
 
 ## File layout
 

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -255,6 +255,27 @@ type vrrpInstance struct {
 	// before the reconcile goroutine starts; the goroutine only reads it.
 	vipReconcileBackoff time.Duration
 
+	// resignBarrierMu guards vipsHeld and resignBarrierCh — the resign-completion
+	// barrier the daemon's #5640 fence-completion actuation barrier waits on so the
+	// peer's remote-failover applied-ack is not released until this node's RETH VIPs
+	// are PHYSICALLY removed, not merely resign-signaled (#6177). ResignRG signals
+	// resignCh and sets priority-0 synchronously, but the actual VIP removal
+	// (becomeBackup → removeVIPs) runs async on the run-loop; releasing the ack on
+	// resign-signaled alone left a sub-ms two-owner window where the peer promoted
+	// while this node still owned the VIPs. armResignBarrier registers a waiter
+	// BEFORE triggerResign; markVIPsRemoved closes it once the VIPs actually clear.
+	//
+	// vipsHeld is the barrier's ownership fact: true once a successful becomeMaster
+	// has actuated the VIP set, false once becomeBackup (or the #5482 stale-VIP
+	// reconcile) has removed it. armResignBarrier short-circuits to an already-
+	// closed channel when vipsHeld is false — the demotion has already actuated (or
+	// this node never owned the VIPs), so there is nothing to wait for. Guarded by a
+	// dedicated mutex, kept off the vipMu TOCTOU path (#5082/#5482) so the barrier
+	// bookkeeping never perturbs the VIP-actuation revalidation.
+	resignBarrierMu sync.Mutex
+	vipsHeld        bool
+	resignBarrierCh chan struct{}
+
 	// netlink seams for VIP actuation. Production leaves them nil and the
 	// helpers call netlink live; unit tests inject them to drive addVIPs down
 	// a chosen success/failure path without a real kernel interface (#5082).
@@ -376,6 +397,62 @@ func (vi *vrrpInstance) triggerResign() {
 	select {
 	case vi.resignCh <- struct{}{}:
 	default:
+	}
+}
+
+// armResignBarrier registers (or returns the existing) resign-completion barrier
+// for this instance (#6177). If the instance does not currently own the VIP set —
+// vipsHeld is false because it is already BACKUP or never promoted — the demotion
+// has already actuated, so an already-closed channel is returned and the caller
+// does not wait. Otherwise the returned channel closes once markVIPsRemoved fires
+// (becomeBackup removed the VIPs, or the #5482 stale-VIP reconcile finally
+// cleared them). The manager MUST call this BEFORE triggerResign: registering
+// under resignBarrierMu while vipsHeld is still true, before the run-loop can run
+// becomeBackup, guarantees the barrier is observed and cannot be closed-and-
+// forgotten. If becomeBackup already ran (vipsHeld now false), the short-circuit
+// returns closed — no lost wakeup either way because the fact flip and the close
+// in markVIPsRemoved happen under the same lock.
+func (vi *vrrpInstance) armResignBarrier() <-chan struct{} {
+	vi.resignBarrierMu.Lock()
+	defer vi.resignBarrierMu.Unlock()
+	if !vi.vipsHeld {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	if vi.resignBarrierCh == nil {
+		vi.resignBarrierCh = make(chan struct{})
+	}
+	return vi.resignBarrierCh
+}
+
+// markVIPsHeld records that this instance now owns the VIP set — a successful
+// becomeMaster has actuated it (#6177). A resign barrier armed afterward waits
+// for the matching markVIPsRemoved. Kept separate from the vipMu-guarded actuation
+// so the barrier bookkeeping never perturbs the #5082/#5482 VIP TOCTOU logic.
+func (vi *vrrpInstance) markVIPsHeld() {
+	vi.resignBarrierMu.Lock()
+	vi.vipsHeld = true
+	vi.resignBarrierMu.Unlock()
+}
+
+// markVIPsRemoved records that this instance no longer owns the VIP set and
+// releases any resign-completion barrier armed for it (#6177). Called from the
+// becomeBackup demotion path once removeVIPs SUCCEEDS, and from the #5482 stale-
+// VIP reconcile once a deferred removal finally clears — so the barrier is a true
+// "VIPs physically removed" gate, never merely "resign signaled". A removal that
+// keeps failing leaves the barrier open on purpose: the daemon's actuation wait
+// times out and the peer HOLDS rather than promotes over a stale VIP (safe-
+// direction). Idempotent: the channel is nil-ed under the lock so a second call
+// never double-closes.
+func (vi *vrrpInstance) markVIPsRemoved() {
+	vi.resignBarrierMu.Lock()
+	vi.vipsHeld = false
+	ch := vi.resignBarrierCh
+	vi.resignBarrierCh = nil
+	vi.resignBarrierMu.Unlock()
+	if ch != nil {
+		close(ch)
 	}
 }
 
@@ -1327,6 +1404,10 @@ func (vi *vrrpInstance) becomeMaster() bool {
 	}
 	vi.vipMu.Unlock()
 
+	// VIPs actuated — record ownership so a later resign barrier waits for the
+	// matching removal before the daemon releases the peer's applied-ack (#6177).
+	vi.markVIPsHeld()
+
 	vi.sendAdvert(pri)
 	vi.emitEvent()
 	vi.garpEpoch.Add(1)
@@ -1366,7 +1447,16 @@ func (vi *vrrpInstance) becomeBackup(masterDownTimer, advertTimer *time.Timer) {
 	slog.Info("vrrp: transitioning to BACKUP",
 		"key", vi.key())
 	vi.setState(StateBackup)
-	vi.surfaceStaleVIP(vi.removeVIPs(), "becomeBackup")
+	removeErr := vi.removeVIPs()
+	if removeErr == nil {
+		// VIPs are physically gone — release any #6177 resign barrier so the
+		// daemon's actuation wait (and thus the peer's applied-ack) only fires
+		// after this node stopped owning the RG. On a removal FAILURE the barrier
+		// stays armed: the async #5482 reconcile below closes it once the stale
+		// VIP finally clears, and until then the peer HOLDS (safe-direction).
+		vi.markVIPsRemoved()
+	}
+	vi.surfaceStaleVIP(removeErr, "becomeBackup")
 	advertTimer.Stop()
 	masterDownTimer.Reset(vi.masterDownInterval())
 	// A MASTER stepping down to a worthy higher/tie-break master begins a

--- a/pkg/vrrp/instance_vip.go
+++ b/pkg/vrrp/instance_vip.go
@@ -118,6 +118,10 @@ func (vi *vrrpInstance) scheduleVIPRemoveReconcile() {
 				continue
 			}
 			vi.vipDiverged.Store(false)
+			// The deferred VIP removal finally cleared — release any #6177 resign
+			// barrier that becomeBackup left armed when its synchronous removal
+			// failed, so the peer's applied-ack now fires (the VIPs are truly gone).
+			vi.markVIPsRemoved()
 			slog.Info("vrrp: stale-VIP remove reconcile succeeded",
 				"key", vi.key(), "attempt", attempt)
 			return

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -719,9 +719,34 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 // Used when cluster state transitions from Primary to Secondary
 // (manual failover, weight drop, etc.) in non-preempt mode.
 func (m *Manager) ResignRG(rgID int) {
+	m.resignRGInstances(rgID, false)
+}
+
+// ResignRGWait resigns every RETH instance for the redundancy group exactly like
+// ResignRG, and additionally returns one resign-completion barrier per instance
+// (#6177). Each barrier closes when that instance's VIPs are PHYSICALLY removed
+// (becomeBackup succeeded, or the #5482 stale-VIP reconcile finally cleared a
+// failed removal), or is already closed when the instance did not own the VIPs.
+// The caller waits on the returned barriers before releasing the peer's remote-
+// failover applied-ack so the peer never promotes into a two-owner window while
+// this node still owns the RETH VIPs. Priority-0 is still set and adverts still
+// go out synchronously, so peers see the resignation immediately regardless of
+// how long the VIP removal takes.
+func (m *Manager) ResignRGWait(rgID int) []<-chan struct{} {
+	return m.resignRGInstances(rgID, true)
+}
+
+// resignRGInstances sets priority 0 and triggers resign on every RETH instance
+// for rgID. When arm is true it registers a resign-completion barrier on each
+// instance BEFORE triggering the resign and returns the barriers; when false it
+// returns nil (the reconcile-driven ResignRG path needs no completion signal).
+// Arming before triggerResign is load-bearing: the barrier must be observable to
+// the run-loop's becomeBackup so the VIP-removal completion cannot be lost.
+func (m *Manager) resignRGInstances(rgID int, arm bool) []<-chan struct{} {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	vrid := 100 + rgID
+	var barriers []<-chan struct{}
 	for _, vi := range m.instances {
 		if isRethInstance(vi.cfg) && vi.cfg.GroupID == vrid {
 			// Set priority to 0 BEFORE triggering resign. Without this,
@@ -731,9 +756,15 @@ func (m *Manager) ResignRG(rgID int) {
 			vi.mu.Lock()
 			vi.cfg.Priority = 0
 			vi.mu.Unlock()
+			// Arm the completion barrier BEFORE triggerResign so the run-loop's
+			// becomeBackup cannot close-and-forget it before it is registered.
+			if arm {
+				barriers = append(barriers, vi.armResignBarrier())
+			}
 			vi.triggerResign()
 		}
 	}
+	return barriers
 }
 
 // UpdateRGPriority immediately sets the VRRP priority for all instances

--- a/pkg/vrrp/resign_barrier_6177_test.go
+++ b/pkg/vrrp/resign_barrier_6177_test.go
@@ -1,0 +1,272 @@
+package vrrp
+
+import (
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #6177 — close the RETH VIP-removal sub-ms two-owner residual left by #5640.
+//
+// #5640 (#6174) withheld the remote-failover applied-ack until the demotion was
+// ACTUATED. On the RETH-VRRP path ResignRG only SIGNALS the resign (priority-0 +
+// resignCh) synchronously; the actual VIP removal (becomeBackup → removeVIPs)
+// runs async on the run-loop. Releasing the ack on resign-signaled alone left a
+// sub-ms window where the peer promoted while this node still owned the VIPs.
+//
+// The fix adds a per-instance resign-completion barrier: armResignBarrier
+// registers a waiter BEFORE triggerResign, and markVIPsRemoved closes it once the
+// VIPs are PHYSICALLY gone (becomeBackup succeeded, or the #5482 stale-VIP
+// reconcile finally cleared a failed removal). The daemon waits on the barrier
+// before releasing the applied-ack. These tests drive the netlink seams so the
+// removal path runs without a real interface.
+
+// newResignBarrierInstance builds a MASTER instance that already owns its VIP set
+// (vipsHeld=true, as a successful becomeMaster would leave it) whose VIP removal
+// is governed by delFn. fam/rgID let the manager-level test build a RETH instance
+// (Family=="") in the right redundancy group (VRID = 100 + rgID).
+func newResignBarrierInstance(t *testing.T, name, fam string, rgID int, delFn func(*netlink.Addr) error) (*vrrpInstance, chan VRRPEvent) {
+	t.Helper()
+	eventCh := make(chan VRRPEvent, 8)
+	vi := newInstance(Instance{
+		Interface:         name,
+		GroupID:           100 + rgID,
+		Priority:          200,
+		Family:            fam,
+		AdvertiseInterval: 1000,
+		VirtualAddresses:  []string{"10.0.61.1/24"},
+	}, &net.Interface{Name: name}, eventCh, nil)
+	vi.linkByNameFn = func(n string) (netlink.Link, error) { return fiveZeroEightTwoLink(n), nil }
+	vi.addrAddFn = func(netlink.Link, *netlink.Addr) error { return nil }
+	vi.addrDelFn = func(_ netlink.Link, a *netlink.Addr) error { return delFn(a) }
+	// Simulate the post-promotion state: MASTER, owning the VIP set.
+	vi.setState(StateMaster)
+	vi.markVIPsHeld()
+	t.Cleanup(func() {
+		select {
+		case <-vi.stopCh:
+		default:
+			close(vi.stopCh)
+		}
+	})
+	return vi, eventCh
+}
+
+func isBarrierClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func awaitBarrierClosed(t *testing.T, ch <-chan struct{}, within time.Duration, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(within):
+		t.Fatalf("%s: resign barrier never closed within %s", what, within)
+	}
+}
+
+// TestResignBarrier_ClosesOnBecomeBackupRemoval_6177 is the primary fail-on-revert
+// guard: a barrier armed while the instance still owns its VIPs must stay OPEN
+// until becomeBackup has removed them, then close. This is the difference between
+// "resign signaled" and "VIPs physically removed" that #6177 closes.
+//
+// RED on revert: deleting the `vi.markVIPsRemoved()` call from becomeBackup's
+// clean-removal branch (so the barrier is never signaled) leaves the armed
+// channel open forever — awaitBarrierClosed then fails.
+func TestResignBarrier_ClosesOnBecomeBackupRemoval_6177(t *testing.T) {
+	vi, _ := newResignBarrierInstance(t, "xpf-6177-a0", "inet", 1, func(*netlink.Addr) error {
+		return nil // clean removal
+	})
+
+	ch := vi.armResignBarrier()
+	if isBarrierClosed(ch) {
+		t.Fatal("resign barrier closed while the instance still owns its VIPs — the ack " +
+			"would release before the RETH VIPs were removed (the #6177 window)")
+	}
+
+	mdt := time.NewTimer(time.Hour)
+	defer mdt.Stop()
+	adv := time.NewTimer(time.Hour)
+	defer adv.Stop()
+	vi.becomeBackup(mdt, adv)
+
+	awaitBarrierClosed(t, ch, time.Second, "clean becomeBackup removal")
+	vi.resignBarrierMu.Lock()
+	held := vi.vipsHeld
+	vi.resignBarrierMu.Unlock()
+	if held {
+		t.Fatal("vipsHeld must be cleared once becomeBackup removed the VIPs")
+	}
+}
+
+// TestResignBarrier_AlreadyBackupShortCircuits_6177 pins the fast path: an
+// instance that does NOT own the VIP set (already BACKUP / never promoted) has
+// already actuated its demotion, so armResignBarrier must return an already-closed
+// channel — the caller must not wait for a becomeBackup that will never run
+// (otherwise the daemon's actuation wait would hang until its timeout).
+//
+// RED on revert: dropping the `if !vi.vipsHeld { ...closed... }` short-circuit in
+// armResignBarrier (always returning a fresh open channel) leaves this channel
+// open — the assertion below then fails.
+func TestResignBarrier_AlreadyBackupShortCircuits_6177(t *testing.T) {
+	vi, _ := newResignBarrierInstance(t, "xpf-6177-b0", "inet", 1, func(*netlink.Addr) error {
+		return nil
+	})
+	// Not an owner: BACKUP, VIPs already gone.
+	vi.setState(StateBackup)
+	vi.markVIPsRemoved()
+
+	ch := vi.armResignBarrier()
+	if !isBarrierClosed(ch) {
+		t.Fatal("armResignBarrier must return an already-closed channel when the instance " +
+			"does not own the VIP set — a non-owner has nothing to wait for")
+	}
+}
+
+// TestResignBarrier_FailedRemovalKeepsBarrierOpen_6177 pins the safe-direction on
+// a netlink removal FAILURE: becomeBackup must NOT close the barrier while a stale
+// VIP is still on the wire — the barrier stays open so the peer HOLDS rather than
+// promotes over a VIP this node still answers for.
+//
+// RED on revert: removing the `if removeErr == nil` guard around
+// `vi.markVIPsRemoved()` in becomeBackup (closing the barrier unconditionally)
+// closes it despite the removal failure — the assertion below then fails.
+func TestResignBarrier_FailedRemovalKeepsBarrierOpen_6177(t *testing.T) {
+	vi, _ := newResignBarrierInstance(t, "xpf-6177-c0", "inet", 1, func(*netlink.Addr) error {
+		return errors.New("injected netlink AddrDel failure")
+	})
+	// Keep the async reconcile from racing the assertion: a long backoff means
+	// the first reconcile attempt fires well after this synchronous check.
+	vi.vipReconcileBackoff = time.Hour
+
+	ch := vi.armResignBarrier()
+	mdt := time.NewTimer(time.Hour)
+	defer mdt.Stop()
+	adv := time.NewTimer(time.Hour)
+	defer adv.Stop()
+	vi.becomeBackup(mdt, adv)
+
+	if isBarrierClosed(ch) {
+		t.Fatal("resign barrier closed despite the VIP removal FAILING — the ack would " +
+			"release while a stale VIP is still on the wire (two-owner hazard)")
+	}
+	if got := vi.vipRemoveFailures.Load(); got != 1 {
+		t.Fatalf("expected the removal failure to be surfaced (vipRemoveFailures=1), got %d", got)
+	}
+}
+
+// TestResignBarrier_ReconcileClosesBarrier_6177 pins the deferred close: when
+// becomeBackup's synchronous removal fails, the #5482 stale-VIP reconcile that
+// finally clears the VIP must release the barrier — so the gate is a true "VIPs
+// physically removed" signal even across a transient netlink failure.
+//
+// RED on revert: removing the `vi.markVIPsRemoved()` added to the reconcile
+// success path in scheduleVIPRemoveReconcile leaves the barrier open forever —
+// awaitBarrierClosed then fails.
+func TestResignBarrier_ReconcileClosesBarrier_6177(t *testing.T) {
+	var calls atomic.Int32
+	vi, _ := newResignBarrierInstance(t, "xpf-6177-d0", "inet", 1, func(*netlink.Addr) error {
+		// Fail the synchronous becomeBackup removal, succeed on the reconcile.
+		if calls.Add(1) == 1 {
+			return errors.New("injected transient netlink AddrDel failure")
+		}
+		return nil
+	})
+	vi.vipReconcileBackoff = 5 * time.Millisecond
+
+	ch := vi.armResignBarrier()
+	mdt := time.NewTimer(time.Hour)
+	defer mdt.Stop()
+	adv := time.NewTimer(time.Hour)
+	defer adv.Stop()
+	vi.becomeBackup(mdt, adv)
+
+	if isBarrierClosed(ch) {
+		t.Fatal("barrier must not close on the failed synchronous removal")
+	}
+	// The async reconcile succeeds on its next attempt and must release the barrier.
+	awaitBarrierClosed(t, ch, 2*time.Second, "stale-VIP reconcile success")
+}
+
+// TestResignRGWait_ArmsBarriersAndTriggersResign_6177 pins the manager-level
+// contract: ResignRGWait sets priority-0, signals resignCh, and returns one open
+// barrier per RETH instance that still owns its VIPs — the barrier that the
+// daemon waits on before releasing the applied-ack. Only the target RG's
+// instances are affected.
+//
+// RED on revert: if resignRGInstances armed the barrier AFTER triggerResign (or
+// not at all), the returned barrier would be missing/already-forgotten; if
+// ResignRGWait returned no barriers the daemon would signal immediately — the
+// gating assertion (barrier closes only after becomeBackup) then regresses.
+func TestResignRGWait_ArmsBarriersAndTriggersResign_6177(t *testing.T) {
+	m := NewManager()
+	// RETH instances (Family=="") — vi1 in RG1 owns VIPs, vi2 in RG2 must be
+	// untouched by a RG1 resign.
+	vi1, _ := newResignBarrierInstance(t, "eth0", "", 1, func(*netlink.Addr) error { return nil })
+	vi2, _ := newResignBarrierInstance(t, "eth1", "", 2, func(*netlink.Addr) error { return nil })
+	m.mu.Lock()
+	m.instances = map[instanceKey]*vrrpInstance{
+		{iface: "eth0", groupID: 101}: vi1,
+		{iface: "eth1", groupID: 102}: vi2,
+	}
+	m.mu.Unlock()
+
+	barriers := m.ResignRGWait(1)
+	if len(barriers) != 1 {
+		t.Fatalf("ResignRGWait(1) returned %d barriers, want 1 (only the RG1 instance)", len(barriers))
+	}
+	if len(vi1.resignCh) != 1 {
+		t.Error("vi1 (RG1) should have been signaled to resign")
+	}
+	if len(vi2.resignCh) != 0 {
+		t.Error("vi2 (RG2) must NOT be signaled by a RG1 resign")
+	}
+	vi1.mu.Lock()
+	pri := vi1.cfg.Priority
+	vi1.mu.Unlock()
+	if pri != 0 {
+		t.Errorf("ResignRGWait must set priority 0 synchronously, got %d", pri)
+	}
+
+	// The barrier gates on VIP removal: open now, closes only after becomeBackup.
+	if isBarrierClosed(barriers[0]) {
+		t.Fatal("barrier closed before the RETH VIPs were removed — the ack would release early")
+	}
+	mdt := time.NewTimer(time.Hour)
+	defer mdt.Stop()
+	adv := time.NewTimer(time.Hour)
+	defer adv.Stop()
+	vi1.becomeBackup(mdt, adv)
+	awaitBarrierClosed(t, barriers[0], time.Second, "ResignRGWait barrier after becomeBackup")
+}
+
+// TestResignRGWait_NonOwnerBarrierAlreadyClosed_6177 pins that ResignRGWait does
+// not hang for an instance that never owned the VIPs: a BACKUP RETH instance
+// yields an already-closed barrier so the daemon releases the ack immediately for
+// that RG (no false hold).
+func TestResignRGWait_NonOwnerBarrierAlreadyClosed_6177(t *testing.T) {
+	m := NewManager()
+	vi, _ := newResignBarrierInstance(t, "eth0", "", 3, func(*netlink.Addr) error { return nil })
+	vi.setState(StateBackup)
+	vi.markVIPsRemoved() // not an owner
+	m.mu.Lock()
+	m.instances = map[instanceKey]*vrrpInstance{{iface: "eth0", groupID: 103}: vi}
+	m.mu.Unlock()
+
+	barriers := m.ResignRGWait(3)
+	if len(barriers) != 1 {
+		t.Fatalf("want 1 barrier, got %d", len(barriers))
+	}
+	if !isBarrierClosed(barriers[0]) {
+		t.Fatal("a non-owner instance must yield an already-closed barrier so the ack is not held")
+	}
+}


### PR DESCRIPTION
Closes #6177

## Summary

Closes the three residuals the #5640 (#6174) hostile review flagged on the
failover ack-before-fence two-owner fix.

### STEP-0 evidence (window still open on master @ 42a895443)

The RETH async-VIP-removal window is confirmed open on current master:

- `pkg/daemon/daemon_ha.go` — demotion branch calls `d.vrrpMgr.ResignRG(ev.GroupID)`
  (non-blocking) and then, at the end of the branch, `d.signalFailoverActuated(ev.GroupID)`
  releases the applied-ack.
- `pkg/vrrp/manager.go` `ResignRG` — sets VRRP priority-0 and `triggerResign()`
  **synchronously**, both non-blocking.
- `pkg/vrrp/instance.go` — the run-loop drains `resignCh` (`case <-vi.resignCh`) →
  `becomeBackup` → `removeVIPs`, i.e. the actual VIP removal runs **async** on the
  VRRP run-loop.

So the ack releases after resign is only *signaled* + priority-0 set, before the
RETH VIPs are physically removed — the sub-ms residual two-owner window. Direct-VIP
mode (`reconcileDirectVIPOwnership`) removes VIPs synchronously, so it has no
residual.

## Fix

**Residual 1 — RETH VIP-removal gate (primary).** A per-instance resign-completion
barrier: `armResignBarrier` registers a waiter before `triggerResign`;
`markVIPsHeld` records ownership on a successful `becomeMaster`; `markVIPsRemoved`
releases it once `removeVIPs` **succeeds**. A failed removal keeps the barrier
armed — the existing #5482 stale-VIP reconcile closes it when the deferred removal
finally clears, and until then the peer HOLDS rather than promotes over a stale VIP
(safe-direction). `Manager.ResignRGWait` returns the per-instance barriers;
`watchClusterEvents` hands them to `releaseFailoverActuationAfterResign` on a
goroutine (so the event loop never blocks) which signals the fence only after every
barrier closes. Priority-0 is still set synchronously, so peers see the resignation
immediately regardless of the wait. The barrier bookkeeping uses a dedicated mutex,
kept off the `vipMu` #5082/#5482 TOCTOU path.

**Residual 2 — delete-by-key hardening.** `disarmFailoverActuation(rgID, ch)` now
deletes the barrier map entry only when it still holds the exact channel the caller
armed/waited on; `armFailoverActuation` returns that channel so the error and
timeout paths pass their own. An older timed-out waiter can no longer nuke a newer
same-RG waiter's entry (latent today — the initiator serializes per-RG).

**Residual 3 — daemon-barrier unit test.** Added direct coverage for the novel
concurrency code (arm/signal/wait/timeout/cleanup) plus the VIP-removal gate.

## Fail-on-revert tests (each verified RED on neutralization)

`pkg/vrrp/resign_barrier_6177_test.go`:
- `TestResignBarrier_ClosesOnBecomeBackupRemoval_6177` — barrier stays open until
  becomeBackup removes VIPs. RED: delete `markVIPsRemoved()` from becomeBackup's
  clean-removal branch → barrier never closes.
- `TestResignBarrier_AlreadyBackupShortCircuits_6177` — a non-owner yields an
  already-closed barrier. RED: drop the `if !vipsHeld` short-circuit in
  `armResignBarrier`.
- `TestResignBarrier_FailedRemovalKeepsBarrierOpen_6177` — a failed removal keeps
  the barrier open (safe HOLD). RED: remove the `if removeErr == nil` guard so
  becomeBackup closes unconditionally.
- `TestResignBarrier_ReconcileClosesBarrier_6177` — the #5482 reconcile closes the
  barrier once a deferred removal finally clears. RED: remove `markVIPsRemoved()`
  from the reconcile success path.
- `TestResignRGWait_ArmsBarriersAndTriggersResign_6177` /
  `TestResignRGWait_NonOwnerBarrierAlreadyClosed_6177` — manager-level arm-before-
  resign, priority-0, RG scoping, non-owner short-circuit.

`pkg/daemon/failover_actuation_barrier_6177_test.go`:
- `TestReleaseFailoverActuationWaitsForResign_6177` — the applied-ack is held until
  the resign barrier closes. RED: make `releaseFailoverActuationAfterResign` signal
  without waiting (pre-#6177 behavior).
- `TestReleaseFailoverActuation_TimeoutLeavesAckToPeerSide_6177` — a stuck barrier
  leaves the ack to the peer-side timeout (no premature release).
- `TestFailoverActuationBarrier_SignalReleasesAndCleansUp_6177` /
  `TestFailoverActuationBarrier_TimeoutDowngradesAndCleansUp_6177` — arm → signal /
  timeout → release/downgrade + no stale-channel leak (residual #3 coverage).
- `TestFailoverActuationDisarmIdentityChecked_6177` — an older waiter's disarm does
  not drop a newer waiter's entry. RED: revert `disarmFailoverActuation` to the
  key-only `delete(...)`.

## Validation

- `go test ./pkg/vrrp/... ./pkg/daemon/...` passes; `go vet` + `gofmt` clean;
  `go build ./pkg/... ./cmd/...` clean.
- Each fix verified fail-on-revert (neutralize → bound test RED → revert → green).

## Docs

- `docs/session-sync-architecture.md` — the #5640 section extended with the #6177
  RETH VIP-removal gate + delete-by-key hardening, and point 3 corrected to note the
  RETH deferral vs the synchronous direct-VIP signal.
- `pkg/vrrp/README.md` — documents `ResignRGWait`.

## Smoke

Touches VRRP/failover — **loss-cluster failover smoke required at merge**
(`make test-failover`). Parent runs it.