### PR TITLE
filter: fold co-located per-interface lookups to one .get() (#6236 PR-2C)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57752,3 +57752,31 @@ top.
     README notes this bound.
   **File(s)**: pkg/cluster/failover.go, pkg/cluster/README.md,
     pkg/cluster/failover_lease_5079_test.go, pkg/daemon/daemon_ha_sync.go
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6236 PR-2C — fold co-located per-interface fast-map lookups into
+    ONE `.get()` per call site via shared pure `&Filter` evaluator cores. Added
+    `Filter::varies_per_packet_within_flow()` (SOLE has_dscp||has_l4 OR core) +
+    accessor `interface_input_filter_varies_per_packet`; the session-hit re-eval
+    gate (poll_descriptor/filter.rs) folds its two DSCP/L4 prechecks to one.
+    Added borrow accessors `interface_filter_route_lookup_affecting` (route-lookup
+    precheck, bool = `.is_some()` of it) + `&Filter` core
+    `evaluate_filter_ref_routing_instance_event_counted`; PBR (forwarding/pbr.rs)
+    shares ONE lookup between precheck + routing-instance eval. Added
+    `interface_output_filter_needing_tx_eval` (needs_tx_eval borrow gate, bool =
+    `.is_some()`); all four cos_classify TX arms fold their bool-precheck +
+    separate `.get()` + redundant `.filter(needs_tx_eval)` to one borrow. PR-2A
+    `has_output_needs_tx_eval_*` aggregate short-circuit untouched. Behavior-
+    preserving for unique ifindices, last-wins for dup. Added fail-on-revert
+    equivalence test `pr2c_folded_single_lookup_equals_two_lookup_path`.
+  **File(s)**: userspace-dp/src/filter/mod.rs,
+    userspace-dp/src/filter/engine/mod.rs,
+    userspace-dp/src/filter/engine/eval.rs,
+    userspace-dp/src/filter/engine/tx_selection.rs,
+    userspace-dp/src/filter/engine/cache_sensitive.rs,
+    userspace-dp/src/filter/engine/cache_sensitive/rotation.rs,
+    userspace-dp/src/afxdp/forwarding/pbr.rs,
+    userspace-dp/src/afxdp/poll_descriptor/filter.rs,
+    userspace-dp/src/afxdp/tx/cos_classify.rs,
+    userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md,
+    userspace-dp/src/protocol/security.rs

--- a/_Log.md
+++ b/_Log.md
@@ -57780,3 +57780,14 @@ top.
     userspace-dp/src/afxdp/tx/cos_classify.rs,
     userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md,
     userspace-dp/src/protocol/security.rs
+  **Review-fold (Codex MINOR)**: the `#[cfg(test)]`
+    `interface_output_filter_needs_tx_eval` and the production
+    `interface_filter_affects_route_lookup` bool accessors were delegating to
+    the folded borrow accessors (`.is_some()` of them), making two
+    equivalence-test comparison legs tautological (`X == X`). Restored each to an
+    INDEPENDENT single lookup (own `.get()` on the fast map + flag read) so the
+    old-vs-new equivalence gate is genuine; behavior-identical (still one lookup
+    each). Parent-RED: neutralising the folded output accessor
+    (`needs_tx_eval`→`affects_route_lookup`) now REDs
+    `pr2c_folded_single_lookup_equals_two_lookup_path` ("left false != right
+    true"), proving the restored leg binds. Full cargo 4249/0.

--- a/userspace-dp/src/afxdp/forwarding/pbr.rs
+++ b/userspace-dp/src/afxdp/forwarding/pbr.rs
@@ -57,35 +57,39 @@ pub(in crate::afxdp) fn ingress_route_table_override(
     )
     .unwrap_or(meta.ingress_ifindex as i32);
     let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
-    if !crate::filter::interface_filter_affects_route_lookup(
+    // #6236 PR-2C: the `affects_route_lookup` precheck and the routing-instance
+    // evaluation used to look the SAME ingress ifindex up twice on the input fast
+    // map. Fold to ONE `.get()`: borrow the route-lookup-affecting filter (the
+    // precheck is now `.is_some()` of this same lookup+gate) and evaluate off
+    // that borrow. `None` collapses the precheck-false and no-filter cases — both
+    // return RouteOverride::None, exactly as before.
+    let Some(filter) = crate::filter::interface_filter_route_lookup_affecting(
         &forwarding.filter_state,
         ingress_ifindex,
         is_v6,
-    ) {
+    ) else {
         return RouteOverride::None;
-    }
+    };
     // #2362: PBR terms may carry per-packet L4 match conditions (tcp-flags /
     // is-fragment / icmp-type / icmp-code); build the extra inputs so a
     // `from { tcp-flags ...; } then routing-instance ...` term matches exactly
-    // the authored packets.
+    // the authored packets. Built AFTER the precheck so a non-route-lookup-
+    // affecting filter pays no extra-build.
     let extra = crate::afxdp::frame::term_match_extra_from_frame(frame, meta);
-    let routing_result =
-        match crate::filter::evaluate_interface_filter_routing_instance_event_counted(
-            &forwarding.filter_state,
-            ingress_ifindex,
-            is_v6,
-            flow.src_ip,
-            flow.dst_ip,
-            meta.protocol,
-            flow.forward_key.src_port,
-            flow.forward_key.dst_port,
-            meta.dscp,
-            extra,
-            meta.pkt_len as u64,
-        ) {
-            Some(result) => result,
-            None => return RouteOverride::None,
-        };
+    let routing_result = match crate::filter::evaluate_filter_ref_routing_instance_event_counted(
+        filter,
+        flow.src_ip,
+        flow.dst_ip,
+        meta.protocol,
+        flow.forward_key.src_port,
+        flow.forward_key.dst_port,
+        meta.dscp,
+        extra,
+        meta.pkt_len as u64,
+    ) {
+        Some(result) => result,
+        None => return RouteOverride::None,
+    };
     // #4392: a matched PBR routing-instance term may ALSO carry a drop action
     // (`then { routing-instance X; reject | discard; }`). Such a term is a DENY,
     // NOT a forward: the routing-instance override must NOT be applied. On the

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -21,9 +21,11 @@
 //   - evaluate_dscp_sensitive_input_filter_on_session_hit runs per
 //     packet on the session-hit path for DSCP-sensitive-filter configs
 //     (flow_cache.rs:285 does not cache those). It stays #[inline] so
-//     the cheap interface_input_filter_has_dscp_match guard folds in
-//     and returns None with no call when no DSCP filter is configured.
-//     The post-guard body calls the cold evaluate_non_pbr_input_filter.
+//     the cheap interface_input_filter_varies_per_packet guard folds in
+//     (a single fast-map lookup evaluating the #1430 DSCP OR #2362
+//     per-packet-L4 OR, #6236 PR-2C) and returns None with no call when
+//     no such filter is configured. The post-guard body calls the cold
+//     evaluate_non_pbr_input_filter.
 //   - evaluate_non_pbr_input_filter / _log_only,
 //     emit_input_filter_log_match, apply_lo0_filter_action are the
 //     rare/exception bodies: #[cold] #[inline(never)] for .text.unlikely
@@ -350,14 +352,14 @@ pub(super) fn evaluate_dscp_sensitive_input_filter_on_session_hit(
     // carries EITHER a DSCP match term OR a per-packet L4 match term
     // (tcp-flags / is-fragment / icmp-type / icmp-code). Both classes vary per
     // packet within a flow, so the first-packet decision must not be replayed.
-    // The extra-build stays AFTER this gate so the common no-such-filter case
-    // pays only two FxHashMap lookups (this function is #[inline] on the hot
-    // session-hit path).
-    if !crate::filter::interface_input_filter_has_dscp_match(
-        &forwarding.filter_state,
-        ingress_ifindex,
-        is_v6,
-    ) && !crate::filter::interface_input_filter_has_per_packet_l4_match(
+    // #6236 PR-2C: fold the two per-flag prechecks (which each looked the same
+    // ingress ifindex up on the same-family input fast map) into ONE lookup that
+    // evaluates the `has_dscp_match_terms || has_per_packet_l4_match_terms` OR
+    // (`Filter::varies_per_packet_within_flow`) off a single borrow. The
+    // extra-build stays AFTER this gate so the common no-such-filter case pays
+    // ONE FxHashMap lookup (this function is #[inline] on the hot session-hit
+    // path).
+    if !crate::filter::interface_input_filter_varies_per_packet(
         &forwarding.filter_state,
         ingress_ifindex,
         is_v6,

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -203,41 +203,30 @@ fn resolve_cached_cos_tx_selection_impl(
         let mut filter_log = None;
         let mut filter_counters = crate::filter::CachedFilterCounters::default();
         let mut three_color_policers = crate::filter::CachedThreeColorPolicers::default();
-        if crate::filter::interface_output_filter_needs_tx_eval(
+        // #6236 PR-2C: fold the `needs_tx_eval` precheck and the output-filter
+        // fetch into ONE lookup — `interface_output_filter_needing_tx_eval`
+        // borrows the filter gated on `Filter::needs_tx_eval()`, replacing the
+        // separate bool accessor + `.get()` + re-`filter(needs_tx_eval)`.
+        if let Some(output_filter) = crate::filter::interface_output_filter_needing_tx_eval(
             &forwarding.filter_state,
             egress_ifindex,
             is_v6,
         ) && let Some((src_ip, dst_ip)) = ForwardPacketMeta::from(meta).l3_addrs()
         {
-            let output_filter = if is_v6 {
-                forwarding
-                    .filter_state
-                    .iface_filter_out_v6_fast
-                    .get(&egress_ifindex)
-                    .map(Arc::as_ref)
-            } else {
-                forwarding
-                    .filter_state
-                    .iface_filter_out_v4_fast
-                    .get(&egress_ifindex)
-                    .map(Arc::as_ref)
-            };
-            if let Some(output_filter) = output_filter.filter(|filter| filter.needs_tx_eval()) {
-                let output_result = crate::filter::evaluate_filter_ref_tx_selection_cached(
-                    output_filter,
-                    src_ip,
-                    dst_ip,
-                    meta.protocol,
-                    0,
-                    0,
-                    meta.dscp,
-                );
-                drop = output_result.action != crate::filter::FilterAction::Accept;
-                reject = output_result.action == crate::filter::FilterAction::Reject;
-                filter_log = output_result.log_match;
-                filter_counters = output_result.counters;
-                three_color_policers = output_result.three_color_policers;
-            }
+            let output_result = crate::filter::evaluate_filter_ref_tx_selection_cached(
+                output_filter,
+                src_ip,
+                dst_ip,
+                meta.protocol,
+                0,
+                0,
+                meta.dscp,
+            );
+            drop = output_result.action != crate::filter::FilterAction::Accept;
+            reject = output_result.action == crate::filter::FilterAction::Reject;
+            filter_log = output_result.log_match;
+            filter_counters = output_result.counters;
+            three_color_policers = output_result.three_color_policers;
         }
         return CachedTxSelectionDescriptor {
             queue_id,
@@ -265,11 +254,18 @@ fn resolve_cached_cos_tx_selection_impl(
     // OUTPUT filter). For a non-NAT flow both keys — and both families — match.
     let ingress_key = ingress_flow_key.unwrap_or(flow_key);
     let ingress_is_v6 = ingress_key.addr_family as i32 == libc::AF_INET6;
-    let has_output_tx_eval = crate::filter::interface_output_filter_needs_tx_eval(
+    // #6236 PR-2C: one lookup for both the gate and the walk. The borrow is gated
+    // on `Filter::needs_tx_eval()`, so `has_output_tx_eval` is just `.is_some()`
+    // and `output_filter` needs no second `.get()` or re-`filter(needs_tx_eval)`.
+    // The PR-2A `has_output_needs_tx_eval_*` aggregate already short-circuited the
+    // whole path upstream (`tx_selection_enabled`), so this per-interface lookup
+    // only runs when a needs-tx-eval filter exists SOMEWHERE.
+    let output_filter = crate::filter::interface_output_filter_needing_tx_eval(
         &forwarding.filter_state,
         egress_ifindex,
         is_v6,
     );
+    let has_output_tx_eval = output_filter.is_some();
     let has_input_tx_selection =
         crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, ingress_is_v6);
     let has_input_three_color_policer =
@@ -284,25 +280,7 @@ fn resolve_cached_cos_tx_selection_impl(
     {
         return CachedTxSelectionDescriptor::default();
     }
-    let output_filter = if has_output_tx_eval {
-        if is_v6 {
-            forwarding
-                .filter_state
-                .iface_filter_out_v6_fast
-                .get(&egress_ifindex)
-                .map(Arc::as_ref)
-        } else {
-            forwarding
-                .filter_state
-                .iface_filter_out_v4_fast
-                .get(&egress_ifindex)
-                .map(Arc::as_ref)
-        }
-    } else {
-        None
-    };
     let output_result = output_filter
-        .filter(|filter| filter.needs_tx_eval())
         .map(|filter| {
             crate::filter::evaluate_filter_ref_tx_selection_cached(
                 filter,
@@ -633,68 +611,55 @@ fn resolve_cos_tx_selection_internal(
         let mut drop = false;
         let mut reject = false;
         let mut filter_log = None;
-        if crate::filter::interface_output_filter_needs_tx_eval(
+        // #6236 PR-2C: fold the `needs_tx_eval` precheck and the output-filter
+        // fetch into ONE lookup (see the cached flowless arm above).
+        if let Some(output_filter) = crate::filter::interface_output_filter_needing_tx_eval(
             &forwarding.filter_state,
             egress_ifindex,
             is_v6,
         ) && let Some((src_ip, dst_ip)) = meta.l3_addrs()
         {
-            let output_filter = if is_v6 {
-                forwarding
-                    .filter_state
-                    .iface_filter_out_v6_fast
-                    .get(&egress_ifindex)
-                    .map(Arc::as_ref)
+            // Mirror the flow-keyed eval entry points below: ports are 0
+            // (L4 absent), `extra` carries the frame-derived is-fragment /
+            // l4-present=false predicates so port/flag/icmp-type terms fail
+            // closed. The counted variants record `then count` exactly once
+            // (this is the only output-filter walk on the flowless path).
+            let output_result = if let Some(now_ns) = now_ns {
+                crate::filter::evaluate_filter_ref_tx_selection_runtime_counted(
+                    output_filter,
+                    src_ip,
+                    dst_ip,
+                    meta.protocol,
+                    0,
+                    0,
+                    meta.dscp,
+                    extra,
+                    meta.pkt_len as u64,
+                    now_ns,
+                )
             } else {
-                forwarding
-                    .filter_state
-                    .iface_filter_out_v4_fast
-                    .get(&egress_ifindex)
-                    .map(Arc::as_ref)
+                crate::filter::evaluate_filter_ref_tx_selection_counted(
+                    output_filter,
+                    src_ip,
+                    dst_ip,
+                    meta.protocol,
+                    0,
+                    0,
+                    meta.dscp,
+                    extra,
+                    meta.pkt_len as u64,
+                )
             };
-            if let Some(output_filter) = output_filter.filter(|filter| filter.needs_tx_eval()) {
-                // Mirror the flow-keyed eval entry points below: ports are 0
-                // (L4 absent), `extra` carries the frame-derived is-fragment /
-                // l4-present=false predicates so port/flag/icmp-type terms fail
-                // closed. The counted variants record `then count` exactly once
-                // (this is the only output-filter walk on the flowless path).
-                let output_result = if let Some(now_ns) = now_ns {
-                    crate::filter::evaluate_filter_ref_tx_selection_runtime_counted(
-                        output_filter,
-                        src_ip,
-                        dst_ip,
-                        meta.protocol,
-                        0,
-                        0,
-                        meta.dscp,
-                        extra,
-                        meta.pkt_len as u64,
-                        now_ns,
-                    )
-                } else {
-                    crate::filter::evaluate_filter_ref_tx_selection_counted(
-                        output_filter,
-                        src_ip,
-                        dst_ip,
-                        meta.protocol,
-                        0,
-                        0,
-                        meta.dscp,
-                        extra,
-                        meta.pkt_len as u64,
-                    )
-                };
-                // Same collapse as the flow-keyed path: any non-`Accept`
-                // terminal action or a three-color-policer drop sets `drop`;
-                // `reject` isolates the `then reject` subset. A flowless deny
-                // is always a SILENT drop downstream (a fragment has no L4
-                // header to synthesize a reply from, #3615) — the caller
-                // gates the active reject reply on a real L4 flow.
-                drop = output_result.policer_drop
-                    || output_result.action != crate::filter::FilterAction::Accept;
-                reject = output_result.action == crate::filter::FilterAction::Reject;
-                filter_log = output_result.log_match;
-            }
+            // Same collapse as the flow-keyed path: any non-`Accept`
+            // terminal action or a three-color-policer drop sets `drop`;
+            // `reject` isolates the `then reject` subset. A flowless deny
+            // is always a SILENT drop downstream (a fragment has no L4
+            // header to synthesize a reply from, #3615) — the caller
+            // gates the active reject reply on a real L4 flow.
+            drop = output_result.policer_drop
+                || output_result.action != crate::filter::FilterAction::Accept;
+            reject = output_result.action == crate::filter::FilterAction::Reject;
+            filter_log = output_result.log_match;
         }
         return CoSTxSelection {
             queue_id,
@@ -712,11 +677,15 @@ fn resolve_cos_tx_selection_internal(
     // and both families — match, so this is a no-op there.
     let ingress_key = ingress_flow_key.unwrap_or(flow_key);
     let ingress_is_v6 = ingress_key.addr_family as i32 == libc::AF_INET6;
-    let has_output_tx_eval = crate::filter::interface_output_filter_needs_tx_eval(
+    // #6236 PR-2C: one lookup for both the gate and the walk (see the cached
+    // flow-keyed arm above). The PR-2A `has_output_needs_tx_eval_*` aggregate
+    // (`tx_selection_enabled`) already short-circuited the whole path upstream.
+    let output_filter = crate::filter::interface_output_filter_needing_tx_eval(
         &forwarding.filter_state,
         egress_ifindex,
         is_v6,
     );
+    let has_output_tx_eval = output_filter.is_some();
     let has_input_tx_selection =
         crate::filter::filter_state_has_input_tx_selection(&forwarding.filter_state, ingress_is_v6);
     let has_input_three_color_policer =
@@ -737,23 +706,6 @@ fn resolve_cos_tx_selection_internal(
             filter_log: None,
         };
     }
-    let output_filter = if has_output_tx_eval {
-        if is_v6 {
-            forwarding
-                .filter_state
-                .iface_filter_out_v6_fast
-                .get(&egress_ifindex)
-                .map(Arc::as_ref)
-        } else {
-            forwarding
-                .filter_state
-                .iface_filter_out_v4_fast
-                .get(&egress_ifindex)
-                .map(Arc::as_ref)
-        }
-    } else {
-        None
-    };
     // #hb166 T-3: evaluate the INGRESS input filter for its forwarding-class /
     // dscp-rewrite whenever an input tx-selection filter (or an input
     // three-color policer) exists — INCLUDING when an OUTPUT filter is also
@@ -792,9 +744,9 @@ fn resolve_cos_tx_selection_internal(
     } else {
         None
     };
-    let output_result = if let Some(output_filter) =
-        output_filter.filter(|filter| filter.needs_tx_eval())
-    {
+    // #6236 PR-2C: `output_filter` is already gated on `needs_tx_eval()` by
+    // `interface_output_filter_needing_tx_eval`, so no second `.filter()`.
+    let output_result = if let Some(output_filter) = output_filter {
         if let Some(now_ns) = now_ns {
             crate::filter::evaluate_filter_ref_tx_selection_runtime_counted(
                 output_filter,

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -754,6 +754,44 @@ ifindex the fast map is the last-wins canonical source, so the precheck now
 agrees with the filter the evaluator that follows actually walks. `FilterState`
 drops from 25 to 15 fields.
 
+**Co-located lookups fold to one (#6236 PR-2C).** After PR-2B a call site that
+checks N flags of the same ifindex paid N separate `iface_filter_*_fast.get()`
+lookups. PR-2C folds each co-located multi-flag check into ONE `.get()` that
+borrows `Option<&Arc<Filter>>` and evaluates every needed flag off that single
+borrow, through shared pure `&Filter` evaluator cores so the folded site and the
+per-flag accessor can never drift:
+
+- **Route-lookup / PBR precheck** (`afxdp/forwarding/pbr.rs`): the
+  `affects_route_lookup` precheck and the routing-instance evaluator used to look
+  the same ingress ifindex up twice on the input fast map. The SOLE lookup+gate
+  is now `interface_filter_route_lookup_affecting` (returns the borrowed
+  route-lookup-affecting `&Filter`); the bool `interface_filter_affects_route_lookup`
+  is `.is_some()` of it, and the PBR site feeds the borrow straight into the new
+  `&Filter` core `evaluate_filter_ref_routing_instance_event_counted`. One lookup.
+- **Session-hit DSCP/L4 re-eval gate** (`afxdp/poll_descriptor/filter.rs`): the
+  `has_dscp_match` + `has_per_packet_l4_match` prechecks fold to one lookup of
+  `interface_input_filter_varies_per_packet`, which reads the SOLE OR core
+  `Filter::varies_per_packet_within_flow()`. The flow-cache decline gate
+  (`afxdp/flow_cache.rs`) still consults the two per-flag accessors individually
+  (input **and** output directions), so they stay live.
+- **CoS TX-selection output arms** (`afxdp/tx/cos_classify.rs`, all four
+  cached/runtime × flow-keyed/flowless): the `needs_tx_eval` bool precheck + the
+  separate output-filter `.get()` + a redundant `.filter(needs_tx_eval)` fold to
+  one `interface_output_filter_needing_tx_eval` borrow (gated on
+  `Filter::needs_tx_eval()`; the bool `interface_output_filter_needs_tx_eval` is
+  `.is_some()` of it). The PR-2A family-wide `has_output_needs_tx_eval_*`
+  aggregate still short-circuits the whole TX path (`tx_selection_enabled_*`)
+  BEFORE any per-interface lookup — that fast branch is unchanged.
+
+The fold is behavior-preserving: for a unique ifindex the single borrow is the
+same `Arc<Filter>` the second lookup would have returned; the fast map is the
+last-wins SSOT for a duplicate. Anti-drift invariant: the accessor is
+`map.get(&if).is_some_and(|f| core(f))` and the folded site evaluates `core(f)`
+off the borrow — BOTH through the same `&Filter` core
+(`affects_route_lookup` field / `varies_per_packet_within_flow()` /
+`needs_tx_eval()`), pinned by `pr2c_folded_single_lookup_equals_two_lookup_path`
+in `filter/tests.rs`.
+
 **Aggregate-from-final-map rule.** Every retained family-wide `FilterState`
 aggregate (`has_input_tx_selection_*`, `has_input_three_color_policer_*`, and
 `has_output_needs_tx_eval_*`) is recomputed **after** the interface loop from the

--- a/userspace-dp/src/filter/engine/cache_sensitive.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive.rs
@@ -24,7 +24,8 @@ mod rotation;
 pub(crate) use rotation::{
     input_dscp_filter_families_changed, input_per_packet_l4_filter_families_changed,
     interface_input_filter_has_dscp_match, interface_input_filter_has_per_packet_l4_match,
-    interface_output_filter_has_dscp_match, interface_output_filter_has_per_packet_l4_match,
+    interface_input_filter_varies_per_packet, interface_output_filter_has_dscp_match,
+    interface_output_filter_has_per_packet_l4_match,
 };
 
 pub(crate) fn evaluate_filter_ref_tx_selection_cached(

--- a/userspace-dp/src/filter/engine/cache_sensitive/rotation.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive/rotation.rs
@@ -317,6 +317,29 @@ pub(crate) fn interface_output_filter_has_per_packet_l4_match(
     filter.is_some_and(|filter| filter.has_per_packet_l4_match_terms)
 }
 
+/// #6236 PR-2C: single-lookup fold of the #1430 DSCP + #2362 per-packet-L4
+/// INPUT-filter "verdict varies per packet" gate. Reads
+/// `Filter::varies_per_packet_within_flow()` (the SOLE `has_dscp_match_terms ||
+/// has_per_packet_l4_match_terms` OR) off ONE `iface_filter_v{4,6}_fast.get(&
+/// ifindex)`, replacing the two separate lookups the folded session-hit re-eval
+/// gate (`afxdp/poll_descriptor/filter.rs`) used to pay
+/// (`interface_input_filter_has_dscp_match` + `..._has_per_packet_l4_match`).
+/// Equal by construction to the OR of those two per-flag accessors — which the
+/// flow-cache decline gate (`afxdp/flow_cache.rs`) still consults individually,
+/// keeping them live.
+pub(crate) fn interface_input_filter_varies_per_packet(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> bool {
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex)
+    } else {
+        state.iface_filter_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|filter| filter.varies_per_packet_within_flow())
+}
+
 #[cfg(test)]
 mod cache_sensitive_2400_tests {
     use super::super::super::super::*;

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -1132,11 +1132,21 @@ pub(crate) fn interface_filter_affects_route_lookup(
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    // #6236 PR-2C: thin `.is_some()` view over the borrow accessor below (the
-    // SOLE lookup+gate). Retained for the poll-descriptor session-miss
-    // counter-policy precheck (`evaluate_non_pbr_input_filter`), which needs only
-    // the bool, not the filter.
-    interface_filter_route_lookup_affecting(state, ifindex, is_v6).is_some()
+    // #6236 PR-2C: independent single lookup — its OWN `.get()` on the
+    // per-interface input fast map, then the `affects_route_lookup` flag.
+    // Retained for the poll-descriptor session-miss counter-policy precheck
+    // (`evaluate_non_pbr_input_filter`), which needs only the bool, not the
+    // filter — AND as the INDEPENDENT reference the accessor-equivalence tests
+    // compare the folded borrow accessor `interface_filter_route_lookup_affecting`
+    // against. Delegating to that accessor would make the comparison tautological
+    // (`X == X`); this re-derives the flag by its own lookup. Same single-lookup
+    // cost either way.
+    let filter = if is_v6 {
+        state.iface_filter_v6_fast.get(&ifindex)
+    } else {
+        state.iface_filter_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|f| f.affects_route_lookup)
 }
 
 /// #6236 PR-2C: single-lookup borrow of the per-interface input filter for this

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -879,6 +879,12 @@ pub(crate) fn evaluate_interface_filter_log_match(
     )
 }
 
+// #6236 PR-2C: this `(state, ifindex, ..)` map-lookup wrapper is now test-only —
+// production (afxdp/forwarding/pbr.rs) shares the borrow from
+// `interface_filter_route_lookup_affecting` into the `&Filter` core
+// `evaluate_filter_ref_routing_instance_event_counted` (one lookup). `#[cfg(test)]`
+// keeps the wrapper out of the shipped binary.
+#[cfg(test)]
 pub(crate) fn evaluate_interface_filter_routing_instance_counted<'a>(
     state: &'a FilterState,
     ifindex: i32,
@@ -908,6 +914,11 @@ pub(crate) fn evaluate_interface_filter_routing_instance_counted<'a>(
     .map(|result| result.routing_instance)
 }
 
+// #6236 PR-2C: test-only map-lookup wrapper (see
+// `evaluate_interface_filter_routing_instance_counted` above); production shares
+// the borrow into the `&Filter` core below. `#[cfg(test)]` keeps it out of the
+// shipped binary.
+#[cfg(test)]
 pub(crate) fn evaluate_interface_filter_routing_instance_event_counted<'a>(
     state: &'a FilterState,
     ifindex: i32,
@@ -926,9 +937,39 @@ pub(crate) fn evaluate_interface_filter_routing_instance_event_counted<'a>(
     } else {
         state.iface_filter_v4_fast.get(&ifindex).map(Arc::as_ref)
     };
-    let Some(filter) = filter else {
-        return None;
-    };
+    let filter = filter?;
+    evaluate_filter_ref_routing_instance_event_counted(
+        filter,
+        src_ip,
+        dst_ip,
+        protocol,
+        src_port,
+        dst_port,
+        dscp,
+        extra,
+        packet_bytes,
+    )
+}
+
+/// #6236 PR-2C: `&Filter`-taking core of the routing-instance evaluator — the
+/// `(src, dst)`-family dispatch, extracted so the PBR call site
+/// (`afxdp/forwarding/pbr.rs`) can share the SAME borrow the
+/// `affects_route_lookup` precheck already took
+/// ([`interface_filter_route_lookup_affecting`]) instead of re-looking-up the
+/// ifindex. The map-lookup wrapper above and the folded PBR site both funnel
+/// through this one body, so the precheck-then-evaluate pair pays a single
+/// `.get()`.
+pub(crate) fn evaluate_filter_ref_routing_instance_event_counted<'a>(
+    filter: &'a Filter,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    extra: TermMatchExtra<'_>,
+    packet_bytes: u64,
+) -> Option<FilterRoutingInstanceResult<'a>> {
     match (src_ip, dst_ip) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_routing_instance_counted_v4(
             filter,
@@ -1091,15 +1132,36 @@ pub(crate) fn interface_filter_affects_route_lookup(
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    // #6236 PR-2B: read the flag off the per-interface fast map instead of a
-    // parallel `iface_filter_v*_affects_route_lookup` set. The set was populated
-    // iff `filter.affects_route_lookup`, so `get().is_some_and(..)` is
-    // bit-identical for a unique ifindex and last-wins-consistent for a
-    // duplicate — agreeing with the filter the eval that follows actually runs.
+    // #6236 PR-2C: thin `.is_some()` view over the borrow accessor below (the
+    // SOLE lookup+gate). Retained for the poll-descriptor session-miss
+    // counter-policy precheck (`evaluate_non_pbr_input_filter`), which needs only
+    // the bool, not the filter.
+    interface_filter_route_lookup_affecting(state, ifindex, is_v6).is_some()
+}
+
+/// #6236 PR-2C: single-lookup borrow of the per-interface input filter for this
+/// family, gated on `affects_route_lookup`. This is the SOLE lookup+gate — the
+/// bool precheck [`interface_filter_affects_route_lookup`] is `.is_some()` of
+/// it, and the PBR call site (`afxdp/forwarding/pbr.rs`) borrows the returned
+/// `&Filter` straight into [`evaluate_filter_ref_routing_instance_event_counted`]
+/// so the precheck and the routing-instance evaluation share ONE `.get()`
+/// instead of looking the same ifindex up twice (the PR-2B two-lookup shape).
+///
+/// Behavior is identical to the two-lookup path: for a unique ifindex the borrow
+/// is the same `Arc<Filter>` the evaluator's own lookup would return; for a
+/// duplicate ifindex the fast map is the last-wins SSOT, so the precheck agrees
+/// with the filter the evaluator walks.
+pub(crate) fn interface_filter_route_lookup_affecting(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> Option<&Filter> {
     let filter = if is_v6 {
         state.iface_filter_v6_fast.get(&ifindex)
     } else {
         state.iface_filter_v4_fast.get(&ifindex)
     };
-    filter.is_some_and(|filter| filter.affects_route_lookup)
+    filter
+        .map(Arc::as_ref)
+        .filter(|filter| filter.affects_route_lookup)
 }

--- a/userspace-dp/src/filter/engine/mod.rs
+++ b/userspace-dp/src/filter/engine/mod.rs
@@ -14,16 +14,25 @@ pub(crate) use cache_sensitive::{
     evaluate_filter_ref_tx_selection_cached, evaluate_interface_input_filter_counters_cached,
     input_dscp_filter_families_changed, input_per_packet_l4_filter_families_changed,
     interface_input_filter_has_dscp_match, interface_input_filter_has_per_packet_l4_match,
-    interface_output_filter_has_dscp_match, interface_output_filter_has_per_packet_l4_match,
+    interface_input_filter_varies_per_packet, interface_output_filter_has_dscp_match,
+    interface_output_filter_has_per_packet_l4_match,
 };
 pub(crate) use eval::{
-    evaluate_filter, evaluate_filter_counted, evaluate_interface_filter,
-    evaluate_interface_filter_counted, evaluate_interface_filter_log_match,
-    evaluate_interface_filter_non_routing_counted,
+    evaluate_filter, evaluate_filter_counted, evaluate_filter_ref_routing_instance_event_counted,
+    evaluate_interface_filter, evaluate_interface_filter_counted,
+    evaluate_interface_filter_log_match, evaluate_interface_filter_non_routing_counted,
+    evaluate_interface_output_filter, evaluate_interface_output_filter_counted, evaluate_lo0_filter,
+    evaluate_lo0_filter_counted, evaluate_lo0_filter_log_match,
+    interface_filter_affects_route_lookup, interface_filter_route_lookup_affecting,
+    NonRoutingCountPolicy,
+};
+// #6236 PR-2C: the `(state, ifindex, ..)` routing-instance map-lookup wrappers
+// are test-only now — production shares the `interface_filter_route_lookup_affecting`
+// borrow into the `&Filter` core `evaluate_filter_ref_routing_instance_event_counted`.
+#[cfg(test)]
+pub(crate) use eval::{
     evaluate_interface_filter_routing_instance_counted,
-    evaluate_interface_filter_routing_instance_event_counted, evaluate_interface_output_filter,
-    evaluate_interface_output_filter_counted, evaluate_lo0_filter, evaluate_lo0_filter_counted,
-    evaluate_lo0_filter_log_match, interface_filter_affects_route_lookup, NonRoutingCountPolicy,
+    evaluate_interface_filter_routing_instance_event_counted,
 };
 pub(crate) use policer::{
     apply_cached_three_color_policers, filter_state_has_input_three_color_policer,
@@ -33,5 +42,9 @@ pub(crate) use tx_selection::{
     evaluate_filter_ref_tx_selection_runtime_uncounted, evaluate_filter_ref_tx_selection_uncounted,
     evaluate_interface_filter_tx_selection_counted,
     evaluate_interface_output_filter_tx_selection_counted, filter_state_has_input_tx_selection,
-    interface_output_filter_needs_tx_eval,
+    interface_output_filter_needing_tx_eval,
 };
+// #6236 PR-2C: the `needs_tx_eval` bool is a test-only `.is_some()` view over
+// `interface_output_filter_needing_tx_eval` (production takes the borrow).
+#[cfg(test)]
+pub(crate) use tx_selection::interface_output_filter_needs_tx_eval;

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -372,22 +372,44 @@ pub(crate) fn evaluate_interface_output_filter_tx_selection_counted<'a>(
     )
 }
 
+/// #6236 PR-2C: test-only `.is_some()` view over
+/// [`interface_output_filter_needing_tx_eval`]. Every production consumer now
+/// takes the borrow directly, so this bool has no runtime caller — it survives
+/// only to pin the accessor-equivalence tests (`filter/tests.rs`) against the
+/// fast-map flag. `#[cfg(test)]` keeps it out of the shipped binary.
+#[cfg(test)]
 pub(crate) fn interface_output_filter_needs_tx_eval(
     state: &FilterState,
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    // #6236 PR-2B: read `Filter::needs_tx_eval()` off the output fast map,
-    // replacing the parallel `iface_filter_out_v*_needs_tx_eval` set. The set
-    // was populated iff `filter.needs_tx_eval()`, so `get().is_some_and(..)` is
-    // bit-identical for a unique ifindex and agrees with the last-wins filter
-    // the TX evaluator actually walks for a duplicate.
+    interface_output_filter_needing_tx_eval(state, ifindex, is_v6).is_some()
+}
+
+/// #6236 PR-2C: single-lookup borrow of the per-interface OUTPUT filter for this
+/// family, gated on `Filter::needs_tx_eval()`. This is the SOLE lookup+gate —
+/// every `cos_classify` TX arm borrows the returned `&Filter` straight into the
+/// tx-selection evaluator so the needs-tx-eval gate and the walk share ONE
+/// `.get()` (PR-2B ran the gate and the fetch as two separate lookups of the
+/// same ifindex, then re-checked `needs_tx_eval()` on the borrow). The
+/// test-only [`interface_output_filter_needs_tx_eval`] bool is `.is_some()` of
+/// this same lookup+gate.
+///
+/// The PR-2A family-wide `has_output_needs_tx_eval_*` aggregate still
+/// short-circuits the whole `cos_classify` TX path upstream
+/// (`tx_selection_enabled_v{4,6}`), BEFORE this per-interface lookup ever runs —
+/// this fold does not touch that gate.
+pub(crate) fn interface_output_filter_needing_tx_eval(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> Option<&Filter> {
     let filter = if is_v6 {
         state.iface_filter_out_v6_fast.get(&ifindex)
     } else {
         state.iface_filter_out_v4_fast.get(&ifindex)
     };
-    filter.is_some_and(|filter| filter.needs_tx_eval())
+    filter.map(Arc::as_ref).filter(|filter| filter.needs_tx_eval())
 }
 
 #[inline]

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -372,18 +372,28 @@ pub(crate) fn evaluate_interface_output_filter_tx_selection_counted<'a>(
     )
 }
 
-/// #6236 PR-2C: test-only `.is_some()` view over
-/// [`interface_output_filter_needing_tx_eval`]. Every production consumer now
-/// takes the borrow directly, so this bool has no runtime caller — it survives
-/// only to pin the accessor-equivalence tests (`filter/tests.rs`) against the
-/// fast-map flag. `#[cfg(test)]` keeps it out of the shipped binary.
+/// #6236 PR-2C: test-only reference implementing the OLD independent two-step
+/// lookup — its OWN `.get()` on the per-interface output fast map, then
+/// `Filter::needs_tx_eval()` on the borrow. Every production consumer now takes
+/// the folded borrow accessor [`interface_output_filter_needing_tx_eval`]
+/// directly, so this bool has no runtime caller — it survives only as the
+/// INDEPENDENT reference the accessor-equivalence tests (`filter/tests.rs`)
+/// compare the folded path against. A delegating `.is_some()` view over the
+/// borrow accessor would make that comparison tautological (`X == X`), so the
+/// reference deliberately re-derives the flag by an independent lookup.
+/// `#[cfg(test)]` keeps it out of the shipped binary.
 #[cfg(test)]
 pub(crate) fn interface_output_filter_needs_tx_eval(
     state: &FilterState,
     ifindex: i32,
     is_v6: bool,
 ) -> bool {
-    interface_output_filter_needing_tx_eval(state, ifindex, is_v6).is_some()
+    let filter = if is_v6 {
+        state.iface_filter_out_v6_fast.get(&ifindex)
+    } else {
+        state.iface_filter_out_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|f| f.needs_tx_eval())
 }
 
 /// #6236 PR-2C: single-lookup borrow of the per-interface OUTPUT filter for this

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -78,10 +78,15 @@ pub(crate) enum FilterAction {
 //       off FilterState.iface_filter_v{4,6}_fast via the
 //       interface_input_filter_has_<X>_match accessor — the parallel
 //       per-interface has_<X>_match sets were deleted in #6236 PR-2B),
-//       flow-cache insertion gate at afxdp/flow_cache.rs:297-309,
-//       established-session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
-//       forwarding rotation purge at afxdp/worker/loop_body/mod.rs:295-330,
-//       and tests at afxdp/flow_cache_tests.rs.
+//       flow-cache insertion gate at afxdp/flow_cache.rs (per-flag,
+//       input + output direction), established-session re-evaluation at
+//       afxdp/poll_descriptor/filter.rs (the DSCP + per-packet-L4
+//       prechecks fold to ONE lookup of
+//       interface_input_filter_varies_per_packet — the
+//       Filter.varies_per_packet_within_flow() OR core — since #6236
+//       PR-2C), forwarding rotation purge at
+//       afxdp/worker/loop_body/mod.rs, and tests at
+//       afxdp/flow_cache_tests.rs.
 //
 // Skipping this classification SILENTLY breaks flow-cache: a
 // first-packet decision gets reused for later packets that can
@@ -429,6 +434,26 @@ impl Filter {
             || self.has_log_terms
             || self.has_terminal_action_terms
             || self.has_three_color_policer_terms
+    }
+
+    /// #6236 PR-2C: the #1430/#2362 "this filter's per-packet verdict is NOT a
+    /// pure function of the flow-cache 5-tuple" predicate. A DSCP match term
+    /// (#1430) or a per-packet L4 match term (#2362: tcp-flags / is-fragment /
+    /// icmp-type / icmp-code) keys off a field outside the 5-tuple, so a
+    /// first-packet decision must not be replayed: the flow-cache declines and
+    /// the session-hit path re-evaluates.
+    ///
+    /// This is the SOLE definition of the `has_dscp_match_terms ||
+    /// has_per_packet_l4_match_terms` OR. The single-lookup accessor
+    /// `interface_input_filter_varies_per_packet` and the folded session-hit
+    /// re-eval gate (`afxdp/poll_descriptor/filter.rs`) both evaluate it off ONE
+    /// borrowed `&Filter`, so they cannot drift from the per-flag accessors
+    /// (`interface_input_filter_has_dscp_match` /
+    /// `interface_input_filter_has_per_packet_l4_match`) that the flow-cache
+    /// decline gate (`afxdp/flow_cache.rs`) still consults individually.
+    #[inline]
+    pub(crate) fn varies_per_packet_within_flow(&self) -> bool {
+        self.has_dscp_match_terms || self.has_per_packet_l4_match_terms
     }
 }
 

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2737,6 +2737,330 @@ fn capability_accessors_equal_fast_map_flags_for_unique_ifindices() {
     assert!(interface_output_filter_needs_tx_eval(&state, 41, true));
 }
 
+/// #6236 PR-2C fail-on-revert equivalence gate. PR-2C folds the co-located
+/// multi-flag hot-path checks into ONE `.get()` per call site via shared pure
+/// `&Filter` evaluator cores. This test proves each folded single-lookup path
+/// returns EXACTLY the value the pre-fold two-lookup path returned, for
+/// representative filters (DSCP-only, L4-only, both, needs-tx-eval, none) across
+/// both families and both directions.
+///
+/// The three cores under test:
+///   1. route-lookup: `interface_filter_route_lookup_affecting(..).is_some()`
+///      == the bool precheck, AND the borrow feeds the routing-instance
+///      evaluator core so `evaluate_filter_ref_routing_instance_event_counted`
+///      (one lookup) == `evaluate_interface_filter_routing_instance_event_counted`
+///      (its own lookup).
+///   2. DSCP/L4: `interface_input_filter_varies_per_packet` (the folded session-
+///      hit re-eval gate) == `has_dscp_match(..) || has_per_packet_l4_match(..)`.
+///   3. needs-tx-eval: `interface_output_filter_needing_tx_eval(..).is_some()`
+///      == the bool accessor `interface_output_filter_needs_tx_eval`.
+///
+/// Reverts that make a core read the wrong flag, or drop one of the two OR'd
+/// flags (`Filter::varies_per_packet_within_flow`), fail this test at a
+/// representative ifindex.
+#[test]
+fn pr2c_folded_single_lookup_equals_two_lookup_path() {
+    let ifaces = vec![
+        // input v4/v6 DSCP-only
+        crate::InterfaceSnapshot {
+            name: "dscp-a".into(),
+            ifindex: 100,
+            filter_input_v4: "dscp4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "dscp-b".into(),
+            ifindex: 101,
+            filter_input_v6: "dscp6".into(),
+            ..Default::default()
+        },
+        // input v4/v6 per-packet-L4-only (tcp-flags)
+        crate::InterfaceSnapshot {
+            name: "l4-a".into(),
+            ifindex: 110,
+            filter_input_v4: "ppl4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "l4-b".into(),
+            ifindex: 111,
+            filter_input_v6: "ppl6".into(),
+            ..Default::default()
+        },
+        // input v4/v6 BOTH DSCP and per-packet-L4 on one term
+        crate::InterfaceSnapshot {
+            name: "both-a".into(),
+            ifindex: 120,
+            filter_input_v4: "both4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "both-b".into(),
+            ifindex: 121,
+            filter_input_v6: "both6".into(),
+            ..Default::default()
+        },
+        // input v4/v6 route-lookup-affecting (routing-instance PBR term)
+        crate::InterfaceSnapshot {
+            name: "pbr-a".into(),
+            ifindex: 130,
+            filter_input_v4: "pbr4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "pbr-b".into(),
+            ifindex: 131,
+            filter_input_v6: "pbr6".into(),
+            ..Default::default()
+        },
+        // output v4 (counter) / v6 (log) → needs_tx_eval
+        crate::InterfaceSnapshot {
+            name: "out-a".into(),
+            ifindex: 140,
+            filter_output_v4: "count4".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "out-b".into(),
+            ifindex: 141,
+            filter_output_v6: "log6".into(),
+            ..Default::default()
+        },
+        // plain input+output both families (no capability flag) — negative side
+        crate::InterfaceSnapshot {
+            name: "plain".into(),
+            ifindex: 150,
+            filter_input_v4: "plain4".into(),
+            filter_input_v6: "plain6".into(),
+            filter_output_v4: "plain4".into(),
+            filter_output_v6: "plain6".into(),
+            ..Default::default()
+        },
+    ];
+    let dscp_term = |dscp: bool, l4: bool| FirewallTermSnapshot {
+        name: "t".into(),
+        action: "accept".into(),
+        dscp_values: if dscp { vec![46] } else { vec![] },
+        protocols: if l4 { vec!["tcp".into()] } else { vec![] },
+        tcp_flags: if l4 { Some(0x02) } else { None },
+        ..Default::default()
+    };
+    let state = parse_filter_state(
+        &[
+            FirewallFilterSnapshot {
+                name: "dscp4".into(),
+                family: "inet".into(),
+                terms: vec![dscp_term(true, false)],
+            },
+            FirewallFilterSnapshot {
+                name: "dscp6".into(),
+                family: "inet6".into(),
+                terms: vec![dscp_term(true, false)],
+            },
+            FirewallFilterSnapshot {
+                name: "ppl4".into(),
+                family: "inet".into(),
+                terms: vec![dscp_term(false, true)],
+            },
+            FirewallFilterSnapshot {
+                name: "ppl6".into(),
+                family: "inet6".into(),
+                terms: vec![dscp_term(false, true)],
+            },
+            FirewallFilterSnapshot {
+                name: "both4".into(),
+                family: "inet".into(),
+                terms: vec![dscp_term(true, true)],
+            },
+            FirewallFilterSnapshot {
+                name: "both6".into(),
+                family: "inet6".into(),
+                terms: vec![dscp_term(true, true)],
+            },
+            FirewallFilterSnapshot {
+                name: "pbr4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    routing_instance: "ri".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "pbr6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    routing_instance: "ri".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "count4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    count: "c4".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "log6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    log: true,
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "plain4".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "plain6".into(),
+                family: "inet6".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "t".into(),
+                    action: "accept".into(),
+                    ..Default::default()
+                }],
+            },
+        ],
+        &[],
+        &ifaces,
+        "",
+        "",
+    )
+    .expect("filter state compiles");
+
+    // Probe every used ifindex plus absent ones so both sides of each
+    // equivalence are exercised.
+    let probe: [i32; 15] = [
+        100, 101, 110, 111, 120, 121, 130, 131, 140, 141, 150, 0, 1, 999, 42,
+    ];
+    for &ifx in &probe {
+        for is_v6 in [false, true] {
+            // Core 1a: route-lookup borrow `.is_some()` == the bool precheck.
+            let borrow = interface_filter_route_lookup_affecting(&state, ifx, is_v6);
+            assert_eq!(
+                borrow.is_some(),
+                interface_filter_affects_route_lookup(&state, ifx, is_v6),
+                "route-lookup borrow.is_some() != bool precheck at {ifx} v6={is_v6}"
+            );
+            // The borrow, when present, is a route-lookup-affecting filter.
+            if let Some(filter) = borrow {
+                assert!(
+                    filter.affects_route_lookup,
+                    "route-lookup borrow returned a non-affecting filter at {ifx} v6={is_v6}"
+                );
+            }
+
+            // Core 2: the folded DSCP||L4 gate == OR of the two per-flag
+            // accessors the flow-cache decline gate still uses individually.
+            assert_eq!(
+                interface_input_filter_varies_per_packet(&state, ifx, is_v6),
+                interface_input_filter_has_dscp_match(&state, ifx, is_v6)
+                    || interface_input_filter_has_per_packet_l4_match(&state, ifx, is_v6),
+                "varies_per_packet != (has_dscp || has_l4) at {ifx} v6={is_v6}"
+            );
+
+            // Core 3: needs-tx-eval borrow `.is_some()` == the bool accessor,
+            // and the borrow, when present, actually needs a TX walk.
+            let out_borrow = interface_output_filter_needing_tx_eval(&state, ifx, is_v6);
+            assert_eq!(
+                out_borrow.is_some(),
+                interface_output_filter_needs_tx_eval(&state, ifx, is_v6),
+                "needs-tx-eval borrow.is_some() != bool accessor at {ifx} v6={is_v6}"
+            );
+            if let Some(filter) = out_borrow {
+                assert!(
+                    filter.needs_tx_eval(),
+                    "needs-tx-eval borrow returned a filter that does not need eval at {ifx} v6={is_v6}"
+                );
+            }
+        }
+    }
+
+    // Core 1b: the routing-instance evaluator core off the shared borrow returns
+    // the same override the two-lookup entry point returns, for the v4 and v6
+    // route-lookup-affecting interfaces. A `routing-instance ri; accept` term
+    // with no `from` match steers every packet.
+    for &(ifx, is_v6, src, dst) in &[
+        (
+            130i32,
+            false,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        ),
+        (
+            131i32,
+            true,
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2)),
+        ),
+    ] {
+        let two_lookup = evaluate_interface_filter_routing_instance_event_counted(
+            &state,
+            ifx,
+            is_v6,
+            src,
+            dst,
+            PROTO_TCP,
+            40000,
+            5201,
+            0,
+            TermMatchExtra::default(),
+            1400,
+        );
+        let borrow = interface_filter_route_lookup_affecting(&state, ifx, is_v6)
+            .expect("route-lookup-affecting filter present");
+        let single_lookup = evaluate_filter_ref_routing_instance_event_counted(
+            borrow,
+            src,
+            dst,
+            PROTO_TCP,
+            40000,
+            5201,
+            0,
+            TermMatchExtra::default(),
+            1400,
+        );
+        assert_eq!(
+            two_lookup.map(|r| r.routing_instance),
+            single_lookup.map(|r| r.routing_instance),
+            "routing-instance override diverged between one- and two-lookup paths at {ifx} v6={is_v6}"
+        );
+        assert_eq!(
+            single_lookup.map(|r| r.routing_instance),
+            Some("ri"),
+            "expected the fixture PBR term to steer to `ri` at {ifx} v6={is_v6}"
+        );
+    }
+
+    // Sanity: the fixture drives a positive result on each folded core so the
+    // equivalences above are not vacuously true.
+    assert!(interface_filter_route_lookup_affecting(&state, 130, false).is_some());
+    assert!(interface_filter_route_lookup_affecting(&state, 131, true).is_some());
+    assert!(interface_input_filter_varies_per_packet(&state, 100, false)); // dscp-only
+    assert!(interface_input_filter_varies_per_packet(&state, 110, false)); // l4-only
+    assert!(interface_input_filter_varies_per_packet(&state, 120, false)); // both
+    assert!(interface_input_filter_varies_per_packet(&state, 121, true)); // both v6
+    assert!(!interface_input_filter_varies_per_packet(&state, 150, false)); // plain
+    assert!(interface_output_filter_needing_tx_eval(&state, 140, false).is_some());
+    assert!(interface_output_filter_needing_tx_eval(&state, 141, true).is_some());
+    assert!(interface_output_filter_needing_tx_eval(&state, 150, false).is_none());
+}
+
 #[test]
 fn interface_filter_routing_instance_counted_returns_matching_override() {
     let ifaces = vec![crate::InterfaceSnapshot {

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -139,10 +139,15 @@ pub(crate) struct FirewallFilterSnapshot {
 //       off FilterState.iface_filter_v{4,6}_fast via the
 //       interface_input_filter_has_<X>_match accessor — the parallel
 //       per-interface has_<X>_match sets were deleted in #6236 PR-2B),
-//       flow-cache insertion gate at afxdp/flow_cache.rs:297-309,
-//       established-session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
-//       forwarding rotation purge at afxdp/worker/loop_body/mod.rs:295-330,
-//       and tests at afxdp/flow_cache_tests.rs.
+//       flow-cache insertion gate at afxdp/flow_cache.rs (per-flag,
+//       input + output direction), established-session re-evaluation at
+//       afxdp/poll_descriptor/filter.rs (the DSCP + per-packet-L4
+//       prechecks fold to ONE lookup of
+//       interface_input_filter_varies_per_packet — the
+//       Filter.varies_per_packet_within_flow() OR core — since #6236
+//       PR-2C), forwarding rotation purge at
+//       afxdp/worker/loop_body/mod.rs, and tests at
+//       afxdp/flow_cache_tests.rs.
 //
 // Skipping this classification SILENTLY breaks flow-cache: a
 // first-packet decision gets reused for later packets that can


### PR DESCRIPTION
## #6236 PR-2C — fold co-located per-interface fast-map lookups to ONE `.get()`

Final increment of #6236 (the FilterState parallel-hook-map → fast-map
convergence). **Closes #6236.** PR-2A (aggregate gate) and PR-2B (accessor
migration + property-set deletion) merged as #6364.

### What & why
After PR-2B each capability accessor did its own
`iface_filter_*_fast.get(&ifindex)` and read one flag off the returned
`&Arc<Filter>`. A hot call site that checks N flags of the same ifindex paid
N separate map lookups. PR-2C folds each co-located multi-flag check into
**one** `.get()` that borrows `Option<&Arc<Filter>>` and evaluates every needed
flag off that single borrow, through shared pure `&Filter` **evaluator cores**
so the folded site and the per-flag accessor can never drift.

**Evaluator cores (anti-drift): the accessor is `map.get(&if).is_some_and(core)`
and the folded site evaluates `core` off the same borrow — BOTH through the same
core.**
- route-lookup — `affects_route_lookup` field; `interface_filter_route_lookup_affecting`
  is the SOLE lookup+gate (returns the borrow), bool `interface_filter_affects_route_lookup`
  = `.is_some()` of it; new `&Filter` core `evaluate_filter_ref_routing_instance_event_counted`.
- DSCP/L4 — `Filter::varies_per_packet_within_flow()` (`has_dscp_match_terms || has_per_packet_l4_match_terms`);
  read via `interface_input_filter_varies_per_packet`.
- needs-tx-eval — existing `Filter::needs_tx_eval()`; `interface_output_filter_needing_tx_eval`
  returns the gated borrow, bool `interface_output_filter_needs_tx_eval` = `.is_some()`.

### Folded call sites
- **poll_descriptor/filter.rs** session-hit re-eval gate: the DSCP + per-packet-L4
  prechecks (the common no-such-filter case paid 2 via `!A && !B`) → one lookup.
  The flow-cache decline gate (flow_cache.rs) still uses the two per-flag
  accessors individually (input **and** output), so they stay live.
- **forwarding/pbr.rs**: the `affects_route_lookup` precheck and the
  routing-instance evaluator looked the same ingress ifindex up twice → one
  borrow feeds the `&Filter` core.
- **tx/cos_classify.rs** (all four cached/runtime × flow-keyed/flowless arms):
  bool precheck + separate `.get()` + redundant `.filter(needs_tx_eval)` → one
  borrow. **PR-2A `has_output_needs_tx_eval_*` aggregate short-circuit
  (`tx_selection_enabled_*`) is UNCHANGED** and still fires before any
  per-interface lookup.

### Behavior
**Behavior-preserving for unique ifindices** — the single borrow is the same
`Arc<Filter>` the second lookup would have returned. **Last-wins for a duplicate
ifindex** (the fast map is the SSOT; PR-2 accepted last-wins). #1430/#2362
flow-cache decline gate, #3296 MissingFilterRef paths, and the PR-2A global TX
gate are untouched.

Folding removed the last production caller from three now-test-only map-lookup
wrappers (`interface_output_filter_needs_tx_eval` bool,
`evaluate_interface_filter_routing_instance_{event_,}counted`); they are
`#[cfg(test)]`-gated (with their engine re-exports) so they stay out of the
shipped binary but still back the accessor-equivalence pins.

### Lookup-count reduction (value story)
Per packet, when the relevant filter is attached:

| path | before | after |
|------|--------|-------|
| session-hit DSCP/L4 gate | 2 lookups | 1 |
| PBR route-lookup precheck | 2 lookups | 1 |
| CoS TX output arm (×4) | 2 lookups + 2 `needs_tx_eval()` (5-way OR) evals | 1 + 1 |

A fully-loaded transit packet drops from **6 → 3** redundant per-interface
fast-map lookups across the three gates, plus one fewer 5-way OR on the CoS arm.
(A criterion harness is impractical for this bin crate; this is the exact
per-path lookup-count argument.)

### Parent-RED (fail-on-revert)
Added `pr2c_folded_single_lookup_equals_two_lookup_path` — proves each folded
single-lookup path == the two-lookup path for DSCP-only / L4-only / both /
needs-tx-eval / none across v4+v6 and both directions, and that the shared
borrow feeds the routing-instance core to the same override.

- **Neutralization 1** (drop the L4 disjunct from `varies_per_packet_within_flow`)
  → equivalence test RED: `assertion failed: varies_per_packet != (has_dscp || has_l4) at 110` (assertion, not build break). Restored.
- **Neutralization 2+3** (route-lookup + needs_tx_eval borrow gates → wrong flag)
  → **66 tests RED** across the full suite: the equivalence test, the PR-2B
  `capability_accessors_equal_fast_map_flags_for_unique_ifindices` pin, 7 PBR
  route-steering tests (`tests_parse_forward_pbr::*`), ~25 `cos_classify` output-filter
  tests, plus reject-reply / bind-forward / fragment tests. Restored.

### Validation
- `cargo build --release`: exit 0, **160 warnings (down from the 162 baseline** —
  the cfg-gating removed a pre-existing test-only warning too); none of the PR-2C
  symbols flagged.
- Full `cargo test --release -- --test-threads=1`: **4249 passed, 0 failed, 2 ignored**
  (4158 main + 60 + 8 + 22 + 1). Known timing flakes (`wg::engine`, `slowpath`)
  passed this run and pass isolated regardless.
- Docs: filter/README.md PR-2C fold section + evaluator-core anti-drift invariant;
  #1430/#1431 cache-key runbook in filter/mod.rs and protocol/security.rs note the fold.

Not merged; no cluster smoke run (parent owns the mandatory CoS smoke + merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hqxUQtZKq5rGeTvgaTgMR
