### PR TITLE
cluster/heartbeat: sign a boot epoch to close the >=65-recording sustained replay (#6169)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57809,3 +57809,17 @@ top.
     pkg/cluster/sync_conn_gen.go,
     pkg/cluster/sync_config_epoch_sweep_race_6284_test.go,
     docs/session-sync-architecture.md, pkg/cluster/README.md
+
+## 2026-07-23 — #6169 heartbeat boot-epoch anti-replay (fix/6169-heartbeat-boot-epoch)
+- **Timestamp**: 2026-07-23
+- **Action**: Added a monotonic-across-reboot boot-epoch counter to the keyed
+  cluster heartbeat, closing the >=65-recording sustained replay the bounded
+  session ring (#5477/#6167) cannot. v2 auth trailer ("XPFE", +8-byte signed
+  epoch); receiver `epochAdmit` rejects any frame below the per-peer high-water
+  epoch; v1-after-v2 rejected as a downgrade; dual-accept migration preserves a
+  mixed-version cluster. Sender epoch = max(persisted+1, wallclock-nanos)
+  persisted via fsatomic (SNMP engineBoots pattern). Fail-on-revert test binds
+  the retired-incarnation reject after ring churn.
+- **File(s)**: pkg/cluster/heartbeat.go, pkg/cluster/heartbeat_epoch.go,
+  pkg/cluster/heartbeat_epoch_test.go, pkg/cluster/manager.go,
+  pkg/cluster/README.md

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -248,11 +248,49 @@ peer liveness (`lastSeen`) or drive election.
   never-seen, so an attacker who captured `heartbeatReplaySessions`+1 (= 65)
   or more distinct incarnations can churn the ring by REPLAY ALONE (no
   reboot, no minting) and SUSTAIN the replay indefinitely; with fewer than
-  65 recordings every retired-session replay is rejected. A complete fix
-  needs a boot-epoch / monotonic-across-reboot counter carried in the frame
-  (a wire change) — tracked as a follow-up. The map still causes NO
-  genuine-peer lockout (an evicted live watermark just makes the peer's next
-  frame never-seen → admitted) and cannot grow memory (fixed 64 slots).
+  65 recordings every retired-session replay is rejected. That residual is
+  now CLOSED by the across-reboot boot epoch (#6169, below). The map still
+  causes NO genuine-peer lockout (an evicted live watermark just makes the
+  peer's next frame never-seen → admitted) and cannot grow memory (fixed 64
+  slots).
+- **Across-reboot boot epoch (#6169) — the complete anti-replay fix.** The
+  bounded ring above cannot close the ≥65-recording sustained replay because
+  it has O(64) memory of retired sessions. `MarshalHeartbeatAuthEpoch` carries
+  a **monotonic-across-reboot boot epoch** in a v2 auth trailer, and the
+  receiver (`heartbeatReceiver.epochAdmit`) rejects any authenticated frame
+  whose epoch is **below the highest it has ever accepted from the peer** — a
+  retired incarnation always carries a lower epoch than the live one, so its
+  replay is rejected with **O(1) state, independent of ring churn**.
+  - **Wire (v2).** A 60-byte trailer `magic "XPFE"(4) + session(8) +
+    counter(8) + epoch(8) + HMAC-SHA256(32)`; the HMAC covers the whole frame
+    plus magic/session/counter/**epoch**, so the epoch cannot be forged. It is
+    parsed by `parseHeartbeatAuth`, which tries the v2 trailer FIRST then the
+    v1 (`heartbeatAuthTrailer`) form, so a mixed-version cluster keeps working:
+    a new receiver reads an old peer's v1 frame, and an old receiver silently
+    ignores the longer v2 trailer (never finds `XPFA` at the v1 offset) — the
+    same additive dual-accept the v1 trailer already had. `verifyHeartbeatMAC`
+    is format-agnostic (it MACs `data[:len-32]`), so a v1 frame whose bytes
+    coincidentally form the v2 magic (≈2⁻³²) fails the v2 MAC and falls through
+    to the correct v1 parse. The never-unsigned-when-keyed invariant holds: the
+    (larger) v2 trailer is reserved up front while building the body.
+  - **Epoch policy (`heartbeatEpochDecision`).** On a MAC-verified frame: a v2
+    frame is accepted only for a fresh (≥ high-water) epoch — a strictly-lower
+    epoch is a retired-incarnation replay and is rejected; a v1 frame (no
+    epoch) is accepted while the peer has NOT yet sent an epoch (rolling
+    upgrade), but once the peer has proven it carries one (`sawEpoch`) a later
+    MAC-valid v1 frame is rejected as a **downgrade** (epoch strip to replay a
+    pre-epoch capture) — mirroring the cleartext-downgrade gate. This composes
+    with `heartbeatAuthDecision`; each stays small and independently tested.
+  - **Sender epoch source (`nextBootEpoch`).** `max(persisted_previous+1,
+    wall_clock_nanos)`, persisted durably to `/var/lib/xpf/ha-boot-epoch` via
+    `fsatomic` (the same persistent-counter pattern as SNMP `engineBoots`).
+    The two terms make it strictly increase across restarts under BOTH a
+    wall-clock step backwards (persisted+1 dominates → no genuine-peer lockout)
+    and a lost state file (wall clock dominates → still above any retired
+    counter). Computed ONCE per daemon incarnation (`heartbeatBootEpoch`,
+    `sync.Once`) and reused across heartbeat restarts (a VRF rebind is the same
+    incarnation); resolved lazily only on the first KEYED send, so an unkeyed
+    cluster never touches the path. A persist failure is non-fatal (logged).
 - **Dual-accept (rolling upgrade), `heartbeatAuthDecision`.** Mirrors
   the #4126 VRRP-checksum dual-accept migration:
   - No local key → accept everything (this node cannot verify; may be

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -86,8 +86,24 @@ const (
 
 	// heartbeatAuthTrailerSize = magic(4) + session(8) + counter(8) + HMAC(32).
 	// session+counter are the anti-replay nonce: a random per-sender-process
-	// session id plus a monotonic per-session counter.
+	// session id plus a monotonic per-session counter. This is the v1 (#4107)
+	// trailer, still emitted by a not-yet-upgraded peer and accepted during a
+	// rolling upgrade.
 	heartbeatAuthTrailerSize = 4 + 8 + 8 + heartbeatAuthMACSize
+
+	// heartbeatAuthEpochMagic marks the #6169 v2 auth trailer, which additionally
+	// carries a monotonic-across-reboot boot epoch. It is DISTINCT from
+	// heartbeatAuthMagic ("XPFA") so a reader can tell a v1 (nonce-only) trailer
+	// from a v2 (epoch) trailer at the tail of the frame, and it is tried BEFORE
+	// the v1 magic during parse. An old reader that only knows v1 ignores the
+	// longer v2 trailer (it looks for "XPFA" at the v1 offset and finds none),
+	// so a v2 frame is wire-compatible with a legacy peer — the same dual-accept
+	// property the v1 trailer has against a fully legacy peer.
+	heartbeatAuthEpochMagic = "XPFE"
+
+	// heartbeatAuthEpochTrailerSize = magic(4) + session(8) + counter(8) +
+	// epoch(8) + HMAC(32).
+	heartbeatAuthEpochTrailerSize = 4 + 8 + 8 + 8 + heartbeatAuthMACSize
 )
 
 // HeartbeatPacket is the wire format for cluster heartbeats.
@@ -442,6 +458,56 @@ func MarshalHeartbeatAuth(pkt *HeartbeatPacket, authKey []byte, session, counter
 	return out
 }
 
+// MarshalHeartbeatAuthEpoch encodes a heartbeat and, when authKey is non-empty,
+// appends the #6169 v2 auth trailer carrying the anti-replay nonce
+// (session,counter) PLUS a monotonic-across-reboot boot epoch. The epoch is
+// SIGNED (inside the HMAC), so an attacker cannot forge a higher epoch, and the
+// receiver rejects any frame whose epoch is below the highest it has accepted
+// from the peer (heartbeatReceiver.epochAdmit). That closes the
+// >=65-recording sustained replay the bounded session ring alone cannot
+// (heartbeatReplaySessions): a retired incarnation always carries a lower epoch
+// than the live one and is rejected regardless of session-ring churn.
+//
+// When authKey is empty the output is byte-identical to MarshalHeartbeat — a
+// node without a key emits legacy frames (dual-accept). This is the v2
+// counterpart of MarshalHeartbeatAuth and preserves its INVARIANT: once a key
+// is configured the returned frame is ALWAYS signed, because the trailer space
+// is reserved WHILE building the body (marshalHeartbeatBody drops best-effort
+// monitors to make room) — a keyed heartbeat is never silently downgraded to
+// unsigned (which an enforcing peer would reject → split-brain). The key is
+// never logged.
+func MarshalHeartbeatAuthEpoch(pkt *HeartbeatPacket, authKey []byte, session, counter, epoch uint64) []byte {
+	if len(authKey) == 0 {
+		return marshalHeartbeatBody(pkt, 0)
+	}
+	// Reserve the (larger) v2 trailer up front so the signed frame is guaranteed
+	// to fit within the frame cap.
+	body := marshalHeartbeatBody(pkt, heartbeatAuthEpochTrailerSize)
+	if len(body)+heartbeatAuthEpochTrailerSize > maxHeartbeatSize {
+		// Unreachable (uint8-bounded RG count + monitors already truncated to
+		// leave the reserve). Guard so a future change can never SILENTLY
+		// downgrade a keyed heartbeat to unsigned. Fail loud and still sign.
+		slog.Error("cluster: keyed heartbeat exceeds frame cap after monitor truncation; signing anyway to preserve the auth invariant",
+			"body_bytes", len(body), "cap", maxHeartbeatSize)
+	}
+	trailer := make([]byte, heartbeatAuthEpochTrailerSize)
+	copy(trailer[0:4], heartbeatAuthEpochMagic)
+	binary.LittleEndian.PutUint64(trailer[4:12], session)
+	binary.LittleEndian.PutUint64(trailer[12:20], counter)
+	binary.LittleEndian.PutUint64(trailer[20:28], epoch)
+	// Sign the body PLUS magic+session+counter+epoch (everything but the digest),
+	// so the nonce, the epoch, and the whole packet are bound by the MAC.
+	mac := hmac.New(sha256.New, authKey)
+	mac.Write(body)
+	mac.Write(trailer[:28])
+	copy(trailer[28:], mac.Sum(nil))
+
+	out := make([]byte, 0, len(body)+heartbeatAuthEpochTrailerSize)
+	out = append(out, body...)
+	out = append(out, trailer...)
+	return out
+}
+
 // heartbeatAuthTrailer locates the auth trailer at the tail of a raw heartbeat
 // frame and returns its nonce. present is false when the frame carries no
 // trailer (a legacy / not-yet-keyed peer).
@@ -473,6 +539,73 @@ func verifyHeartbeatMAC(data, authKey []byte) bool {
 	return hmac.Equal(got, mac.Sum(nil))
 }
 
+// heartbeatAuthInfo is the parsed and (when a key is present) verified auth
+// state of a received heartbeat frame.
+type heartbeatAuthInfo struct {
+	present  bool   // a recognized auth trailer (v1 or v2) sits at the tail
+	macOK    bool   // key non-empty AND the trailer's HMAC verified
+	session  uint64 // anti-replay session id (meaningful when present)
+	counter  uint64 // anti-replay counter (meaningful when present)
+	epoch    uint64 // boot epoch (meaningful when hasEpoch)
+	hasEpoch bool   // the trailer is the #6169 v2 form and carries an epoch
+}
+
+// parseHeartbeatAuth locates and verifies the auth trailer at the tail of a raw
+// heartbeat frame. It tries the v2 (epoch) trailer FIRST, then the v1
+// (nonce-only) trailer, so a mixed-version cluster keeps working during a
+// rolling upgrade: a new receiver reads an old peer's v1 frame, and an old
+// receiver silently ignores a new peer's longer trailer (it never finds the v1
+// magic at the v1 offset), exactly the dual-accept property the v1 trailer
+// already had against a fully legacy peer.
+//
+// verifyHeartbeatMAC is format-agnostic — it recomputes the HMAC over
+// data[:len-32] regardless of trailer layout — so a genuine v2 frame verifies
+// under the v2 interpretation and a genuine v1 frame under the v1
+// interpretation. The v2-first order plus the MAC check means a v1 frame whose
+// body bytes coincidentally form the v2 magic at the v2 offset (≈2^-32) fails
+// the v2 MAC and falls through to the correct v1 parse rather than being
+// wrongly rejected.
+//
+// When key is empty, macOK is false (this node cannot verify and may be the
+// not-yet-keyed side of a rolling upgrade) but present/hasEpoch still reflect
+// the detected format.
+func parseHeartbeatAuth(data, key []byte) heartbeatAuthInfo {
+	if len(data) >= heartbeatAuthEpochTrailerSize {
+		start := len(data) - heartbeatAuthEpochTrailerSize
+		if bytes.Equal(data[start:start+4], []byte(heartbeatAuthEpochMagic)) {
+			info := heartbeatAuthInfo{
+				present:  true,
+				session:  binary.LittleEndian.Uint64(data[start+4 : start+12]),
+				counter:  binary.LittleEndian.Uint64(data[start+12 : start+20]),
+				epoch:    binary.LittleEndian.Uint64(data[start+20 : start+28]),
+				hasEpoch: true,
+				macOK:    len(key) > 0 && verifyHeartbeatMAC(data, key),
+			}
+			// A genuine v2 frame verifies here (or we have no key to verify
+			// with). Only when a key is set AND the v2 MAC failed do we retry as
+			// v1 — the frame may be a v1 frame with a coincidental v2 magic.
+			if info.macOK || len(key) == 0 {
+				return info
+			}
+			if s, c, present := heartbeatAuthTrailer(data); present && verifyHeartbeatMAC(data, key) {
+				return heartbeatAuthInfo{present: true, macOK: true, session: s, counter: c}
+			}
+			// A present-but-unverified v2 trailer: keep it present so the
+			// enforce path REJECTS it rather than treating it as unsigned.
+			return info
+		}
+	}
+	if s, c, present := heartbeatAuthTrailer(data); present {
+		return heartbeatAuthInfo{
+			present: true,
+			session: s,
+			counter: c,
+			macOK:   len(key) > 0 && verifyHeartbeatMAC(data, key),
+		}
+	}
+	return heartbeatAuthInfo{}
+}
+
 // heartbeatReplaySessions bounds how many distinct sender sessions the
 // anti-replay tracker remembers a counter watermark for. Each genuine peer
 // reboot picks a fresh random session (randomSessionID) and consumes one slot;
@@ -502,11 +635,16 @@ func verifyHeartbeatMAC(data, authKey []byte) bool {
 //     (Confirmed empirically: M == heartbeatReplaySessions recordings -> all
 //     replays rejected; M == heartbeatReplaySessions+1 -> sustained admits.)
 //
-// This receiver-only map cannot close that residual completely: a full fix
-// needs a boot-epoch / monotonic-across-reboot counter carried in the frame (a
-// wire change), tracked as a follow-up. It does NOT cause a genuine-peer
-// lockout (an evicted live-peer watermark just makes the peer's next frame
-// never-seen -> admitted) and cannot grow memory (fixed 64-slot array).
+// This receiver-only map cannot close that residual completely on its own: a
+// full fix needs a boot-epoch / monotonic-across-reboot counter carried in the
+// frame (a wire change). That fix SHIPPED in #6169 — MarshalHeartbeatAuthEpoch
+// signs a boot epoch into a v2 trailer and heartbeatReceiver.epochAdmit rejects
+// any frame whose epoch is below the highest accepted from the peer, closing the
+// >= heartbeatReplaySessions+1 sustained replay with O(1) state regardless of
+// ring churn. This ring still gates intra-incarnation (same-epoch) replays and
+// still causes NO genuine-peer lockout (an evicted live-peer watermark just
+// makes the peer's next frame never-seen -> admitted) and cannot grow memory
+// (fixed 64-slot array).
 //
 // 64 slots (64*16 = 1 KiB) bounds memory while forcing an attacker to have
 // captured 65+ distinct daemon incarnations before any replay is sustainable.
@@ -582,6 +720,30 @@ func (a *heartbeatAuthReplay) admit(session, counter uint64) bool {
 	return true
 }
 
+// epochAdmit reports whether an authenticated (MAC-verified) v2 frame's boot
+// epoch is acceptable and, when it is, advances the per-peer high-water epoch.
+// Callers must invoke it only after the MAC has verified — an unauthenticated
+// caller must never mutate epoch state.
+//
+// #6169: a frame whose epoch is STRICTLY BELOW the highest ever accepted from
+// the peer is a replay of a RETIRED incarnation and is rejected — independent
+// of the bounded session ring (heartbeatReplaySessions), so it holds even after
+// >=65 recorded incarnations have churned that ring. The first epoch seen
+// anchors the high-water mark. An EQUAL epoch (another frame from the SAME live
+// incarnation) is admitted — the session+counter ring, not the epoch, is what
+// rejects an intra-incarnation replay. A HIGHER epoch (a genuine reboot with a
+// fresh, strictly-greater boot epoch — see nextBootEpoch) advances the mark.
+func (r *heartbeatReceiver) epochAdmit(epoch uint64) bool {
+	if r.sawEpoch && epoch < r.highEpoch {
+		return false
+	}
+	if epoch > r.highEpoch {
+		r.highEpoch = epoch
+	}
+	r.sawEpoch = true
+	return true
+}
+
 // heartbeatAuthDecision applies the #4107 dual-accept policy for one received
 // heartbeat and returns whether to accept it (and, when rejected, a short
 // reason for logging — never the key or packet bytes).
@@ -617,6 +779,38 @@ func heartbeatAuthDecision(keyConfigured, present, macOK, nonceFresh, peerAuthSe
 	}
 	if peerAuthSeen {
 		return false, "missing auth trailer (enforced: peer previously authenticated)"
+	}
+	return true, ""
+}
+
+// heartbeatEpochDecision applies the #6169 across-reboot boot-epoch policy to
+// one MAC-VERIFIED heartbeat (the caller must only invoke it when macOK). It is
+// composed with heartbeatAuthDecision — the base auth/replay/downgrade policy —
+// so each stays small and independently testable.
+//
+//	hasEpoch      — the frame carried a v2 (epoch-bearing) trailer.
+//	epochFresh    — epochAdmit accepted the epoch (only meaningful when hasEpoch;
+//	                false for a replay of a retired lower-epoch incarnation).
+//	peerEpochSeen — the peer has previously sent a MAC-valid epoch (sawEpoch),
+//	                proving it speaks v2.
+//
+// Policy:
+//   - v2 frame: accept only a fresh epoch; a stale (retired) epoch is a replay.
+//   - v1 frame (no epoch) and the peer never sent an epoch: accept — the peer
+//     has not upgraded to the epoch format yet (rolling upgrade dual-accept).
+//   - v1 frame (no epoch) but the peer HAS sent an epoch: reject — dropping the
+//     epoch once the peer proved it carries one is a downgrade (epoch strip to
+//     replay a captured pre-epoch frame), mirroring the cleartext-downgrade gate
+//     in heartbeatAuthDecision.
+func heartbeatEpochDecision(hasEpoch, epochFresh, peerEpochSeen bool) (bool, string) {
+	if hasEpoch {
+		if !epochFresh {
+			return false, "stale boot epoch (replay of a retired incarnation)"
+		}
+		return true, ""
+	}
+	if peerEpochSeen {
+		return false, "missing boot epoch (enforced: peer previously sent one)"
 	}
 	return true, ""
 }
@@ -678,6 +872,13 @@ type heartbeatReceiver struct {
 	// lazily-arming on-demand fabric RPCs), so it is an atomic.
 	authReplay   heartbeatAuthReplay // per-peer anti-replay watermark
 	peerAuthSeen atomic.Bool         // sticky: peer has sent a valid authed HB
+
+	// #6169 across-reboot boot-epoch anti-replay. Both fields are touched only
+	// from readLoop (like authReplay), so they need no locking. sawEpoch is
+	// sticky: once the peer has proven it carries a boot epoch, a later
+	// MAC-valid frame WITHOUT one is a downgrade (epoch strip) and is rejected.
+	sawEpoch  bool   // a MAC-valid epoch-bearing (v2) frame has been accepted
+	highEpoch uint64 // highest boot epoch accepted from the peer
 }
 
 // peerAuthenticated reports whether the peer has ever sent a valid
@@ -727,7 +928,11 @@ func (s *heartbeatSender) send() {
 	// without a heartbeat restart. Never logged.
 	var data []byte
 	if key := s.mgr.controlLinkAuthKey(); len(key) > 0 {
-		data = MarshalHeartbeatAuth(pkt, key, s.authSession, s.authCounter.Add(1))
+		// #6169: sign with the v2 trailer carrying this incarnation's boot epoch
+		// so the receiver can reject a replayed retired incarnation regardless of
+		// session-ring churn. The epoch is computed once per daemon incarnation
+		// (heartbeatBootEpoch) and reused across heartbeat restarts.
+		data = MarshalHeartbeatAuthEpoch(pkt, key, s.authSession, s.authCounter.Add(1), s.mgr.heartbeatBootEpoch())
 	} else {
 		data = MarshalHeartbeat(pkt)
 	}
@@ -827,17 +1032,30 @@ func (r *heartbeatReceiver) readLoop() {
 		// Dual-accept keeps a mixed-version / not-yet-keyed cluster from
 		// splitting — see heartbeatAuthDecision. The key is never logged.
 		key := r.mgr.controlLinkAuthKey()
-		session, counter, present := heartbeatAuthTrailer(buf[:n])
-		macOK := present && len(key) > 0 && verifyHeartbeatMAC(buf[:n], key)
-		nonceFresh := macOK && r.authReplay.admit(session, counter)
-		accept, reason := heartbeatAuthDecision(len(key) > 0, present, macOK, nonceFresh, r.peerAuthSeen.Load())
+		auth := parseHeartbeatAuth(buf[:n], key)
+		nonceFresh := auth.macOK && r.authReplay.admit(auth.session, auth.counter)
+		accept, reason := heartbeatAuthDecision(len(key) > 0, auth.present, auth.macOK, nonceFresh, r.peerAuthSeen.Load())
+		if accept && auth.macOK {
+			// #6169: on a MAC-verified frame, additionally enforce the
+			// across-reboot boot-epoch bound. epochAdmit mutates the high-water
+			// mark only for a fresh (>= high) epoch, so a frame rejected here has
+			// not advanced any accept-only state. r.sawEpoch is read for the
+			// downgrade gate BEFORE epochAdmit could set it (epochAdmit runs only
+			// for a v2 frame, whose branch does not consult peerEpochSeen).
+			epochFresh := auth.hasEpoch && r.epochAdmit(auth.epoch)
+			var epochReason string
+			accept, epochReason = heartbeatEpochDecision(auth.hasEpoch, epochFresh, r.sawEpoch)
+			if !accept {
+				reason = epochReason
+			}
+		}
 		if !accept {
 			r.recvErrors.Add(1)
 			slog.Warn("cluster: heartbeat auth rejected",
 				"reason", reason, "peer_node", pkt.NodeID)
 			continue
 		}
-		if macOK {
+		if auth.macOK {
 			// The peer proved it holds the key — from now on an
 			// unauthenticated frame from it is a downgrade attack. This also
 			// arms the gRPC fabric listener's downgrade-guard (via

--- a/pkg/cluster/heartbeat_epoch.go
+++ b/pkg/cluster/heartbeat_epoch.go
@@ -1,0 +1,94 @@
+package cluster
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/psaab/xpf/pkg/fsatomic"
+)
+
+// bootEpochPath is where the HA heartbeat boot epoch is persisted. /var/lib/xpf
+// is the persistent runtime-state root xpf already uses for durable identity
+// counters (SNMP engineBoots, the config DB), so a rebooted appliance re-reads
+// the last epoch instead of restarting at zero. Overridable in tests.
+var bootEpochPath = "/var/lib/xpf/ha-boot-epoch"
+
+// nextBootEpoch returns this daemon incarnation's boot epoch: a value that
+// STRICTLY INCREASES across daemon restarts and reboots. It is
+//
+//	max(persisted_previous_epoch + 1, wall_clock_nanoseconds)
+//
+// persisted durably. The two terms cover the two failure modes a single term
+// cannot survive on its own:
+//
+//   - a wall-clock STEP BACKWARDS across a reboot (RTC skew, NTP correction, a
+//     manual set-back): persisted+1 dominates, so the new incarnation is still
+//     strictly higher than the last one — a genuinely rebooted peer is never
+//     mistaken for a replay of its own retired incarnation (no failover wedge).
+//   - a LOST / RESET state file (fresh image, wiped /var/lib): the wall clock
+//     dominates, so the new incarnation is far above any retired low counter
+//     and a replayed old-epoch frame is still below it.
+//
+// This is the SENDER half of the #6169 across-reboot anti-replay. The RECEIVER
+// (heartbeatReceiver.epochAdmit) rejects any authenticated heartbeat whose
+// epoch is below the highest it has accepted from the peer, so a retired
+// incarnation can never be replayed once a newer one has been seen — closing
+// the >=65-recording sustained replay the bounded session ring alone cannot
+// (heartbeatReplaySessions). A persist failure is non-fatal: the returned epoch
+// is still wall-clock-floored and hence monotonic in the common case, but is
+// logged because the NEXT incarnation may not observe it and could repeat a
+// value (which only weakens the defense back toward the ring, never wedges a
+// live peer).
+func nextBootEpoch(path string) uint64 {
+	now := uint64(time.Now().UnixNano())
+
+	var prev uint64
+	if data, err := os.ReadFile(path); err == nil {
+		if n, perr := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64); perr == nil {
+			prev = n
+		} else {
+			slog.Warn("cluster: HA boot-epoch state unreadable; seeding from wall clock",
+				"path", path)
+		}
+	} else if !os.IsNotExist(err) {
+		// A missing file is first boot (prev stays 0 — the wall clock seeds it),
+		// not an error. Any other read error is surfaced but still degrades to
+		// the wall-clock seed rather than failing heartbeat start.
+		slog.Warn("cluster: HA boot-epoch state read error; seeding from wall clock",
+			"path", path, "err", err)
+	}
+
+	epoch := now
+	// prev+1 wraps to 0 only for a corrupt prev == MaxUint64 (~500 years of
+	// nanoseconds away), in which case the wall-clock seed simply wins — a safe
+	// degrade, never a panic.
+	if next := prev + 1; next > epoch {
+		epoch = next
+	}
+
+	if err := fsatomic.MkdirAllDurable(filepath.Dir(path), 0o755); err != nil {
+		slog.Warn("cluster: HA boot-epoch state dir create failed; epoch not persisted",
+			"path", path, "err", err)
+		return epoch
+	}
+	if err := fsatomic.WriteFileDurable(path, []byte(strconv.FormatUint(epoch, 10)+"\n"), 0o644); err != nil {
+		slog.Warn("cluster: HA boot-epoch state persist failed; epoch not persisted",
+			"path", path, "err", err)
+	}
+	return epoch
+}
+
+// heartbeatBootEpoch returns this daemon incarnation's boot epoch, computing it
+// exactly once (bootEpochOnce) and reusing it across heartbeat restarts. It is
+// resolved lazily on the first KEYED heartbeat send, so an unkeyed cluster (and
+// the many unkeyed tests) never touch the persistence path. See nextBootEpoch.
+func (m *Manager) heartbeatBootEpoch() uint64 {
+	m.bootEpochOnce.Do(func() {
+		m.bootEpoch = nextBootEpoch(bootEpochPath)
+	})
+	return m.bootEpoch
+}

--- a/pkg/cluster/heartbeat_epoch_test.go
+++ b/pkg/cluster/heartbeat_epoch_test.go
@@ -1,0 +1,313 @@
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMarshalHeartbeatAuthEpoch_RoundTrip verifies a v2 signed frame carries a
+// detectable, verifiable auth trailer with the boot epoch, while the body still
+// parses. It also confirms the empty-key case is byte-identical legacy.
+func TestMarshalHeartbeatAuthEpoch_RoundTrip(t *testing.T) {
+	key := []byte("cluster-shared-secret")
+	pkt := samplePkt()
+	data := MarshalHeartbeatAuthEpoch(pkt, key, 0xdeadbeef, 7, 0x515151)
+
+	// The body still decodes with the (longer) v2 trailer appended.
+	got, err := UnmarshalHeartbeat(data)
+	if err != nil {
+		t.Fatalf("unmarshal authed frame: %v", err)
+	}
+	if len(got.Groups) != 2 || got.Groups[0].Priority != 200 {
+		t.Errorf("body parse wrong: %+v", got.Groups)
+	}
+	if got.SoftwareVersion != "xpf-test-1" {
+		t.Errorf("software version lost under v2 trailer: %q", got.SoftwareVersion)
+	}
+
+	auth := parseHeartbeatAuth(data, key)
+	if !auth.present || !auth.macOK || !auth.hasEpoch {
+		t.Fatalf("v2 trailer not detected/verified: %+v", auth)
+	}
+	if auth.session != 0xdeadbeef || auth.counter != 7 || auth.epoch != 0x515151 {
+		t.Errorf("parsed (session,counter,epoch) = (%#x,%d,%#x), want (0xdeadbeef,7,0x515151)",
+			auth.session, auth.counter, auth.epoch)
+	}
+
+	// Empty key -> byte-identical legacy frame (dual-accept: a keyless node emits
+	// legacy). This is the same invariant MarshalHeartbeatAuth has.
+	legacy := MarshalHeartbeat(pkt)
+	authless := MarshalHeartbeatAuthEpoch(pkt, nil, 1, 1, 1)
+	if string(authless) != string(legacy) {
+		t.Fatalf("empty key must produce legacy frame (len %d vs %d)", len(authless), len(legacy))
+	}
+}
+
+// TestParseHeartbeatAuth_DualAccept verifies the parser recognises BOTH the v1
+// (nonce-only) and v2 (epoch) trailers and reports a legacy unsigned frame as
+// not present — the rolling-upgrade dual-accept property. A v2 frame verified
+// against the RIGHT key sets macOK; a v1 frame reports hasEpoch=false.
+func TestParseHeartbeatAuth_DualAccept(t *testing.T) {
+	key := []byte("cluster-shared-secret")
+
+	// v1 frame: present, verifiable, no epoch.
+	v1 := MarshalHeartbeatAuth(samplePkt(), key, 0x1111, 3)
+	a1 := parseHeartbeatAuth(v1, key)
+	if !a1.present || !a1.macOK || a1.hasEpoch {
+		t.Errorf("v1 parse: %+v (want present, macOK, !hasEpoch)", a1)
+	}
+	if a1.session != 0x1111 || a1.counter != 3 {
+		t.Errorf("v1 nonce = (%#x,%d), want (0x1111,3)", a1.session, a1.counter)
+	}
+
+	// v2 frame: present, verifiable, epoch.
+	v2 := MarshalHeartbeatAuthEpoch(samplePkt(), key, 0x2222, 4, 999)
+	a2 := parseHeartbeatAuth(v2, key)
+	if !a2.present || !a2.macOK || !a2.hasEpoch || a2.epoch != 999 {
+		t.Errorf("v2 parse: %+v (want present, macOK, hasEpoch, epoch=999)", a2)
+	}
+
+	// Legacy unsigned frame: no trailer.
+	legacy := MarshalHeartbeat(samplePkt())
+	al := parseHeartbeatAuth(legacy, key)
+	if al.present {
+		t.Errorf("legacy unsigned frame reported an auth trailer: %+v", al)
+	}
+
+	// Wrong key: trailer present (format detected) but macOK false. Both v1 and
+	// v2 forms must fail closed.
+	if aw := parseHeartbeatAuth(v2, []byte("attacker")); !aw.present || aw.macOK {
+		t.Errorf("v2 under wrong key: %+v (want present, !macOK)", aw)
+	}
+	if aw := parseHeartbeatAuth(v1, []byte("attacker")); !aw.present || aw.macOK {
+		t.Errorf("v1 under wrong key: %+v (want present, !macOK)", aw)
+	}
+}
+
+// TestHeartbeatEpochAdmit exercises the receiver's boot-epoch high-water logic
+// directly: the first epoch anchors, an equal epoch (another frame from the
+// SAME incarnation) is admitted, a strictly-lower epoch (a retired incarnation)
+// is rejected, and a higher epoch (a genuine reboot) advances the mark.
+func TestHeartbeatEpochAdmit(t *testing.T) {
+	r := &heartbeatReceiver{}
+
+	if !r.epochAdmit(100) {
+		t.Fatal("first epoch must anchor and be admitted")
+	}
+	if !r.epochAdmit(100) {
+		t.Error("equal epoch (same incarnation) must be admitted")
+	}
+	if r.epochAdmit(99) {
+		t.Error("lower epoch (retired incarnation) must be REJECTED")
+	}
+	if !r.epochAdmit(101) {
+		t.Error("higher epoch (genuine reboot) must be admitted")
+	}
+	// The reboot advanced the mark: the previously-live 100 is now retired.
+	if r.epochAdmit(100) {
+		t.Error("epoch below the advanced high-water must be REJECTED")
+	}
+	if r.highEpoch != 101 {
+		t.Errorf("highEpoch = %d, want 101", r.highEpoch)
+	}
+}
+
+// TestHeartbeatEpochDecision pins the #6169 epoch policy truth table. Reverting
+// the enforcement (e.g. always returning accept) flips a REJECT case GREEN.
+func TestHeartbeatEpochDecision(t *testing.T) {
+	cases := []struct {
+		name                                string
+		hasEpoch, epochFresh, peerEpochSeen bool
+		wantAccept                          bool
+	}{
+		{"v2/fresh-epoch", true, true, false, true},
+		{"v2/stale-epoch-replay", true, false, false, false},    // retired incarnation -> REJECT
+		{"v1/peer-not-yet-epoched", false, false, false, true},  // rolling upgrade dual-accept
+		{"v1/downgrade-after-epoch", false, false, true, false}, // epoch strip -> REJECT
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := heartbeatEpochDecision(tc.hasEpoch, tc.epochFresh, tc.peerEpochSeen)
+			if got != tc.wantAccept {
+				t.Fatalf("accept = %v (reason %q), want %v", got, reason, tc.wantAccept)
+			}
+			if !got && reason == "" {
+				t.Error("a rejection must carry a non-empty reason")
+			}
+		})
+	}
+}
+
+// heartbeatGate reconstructs the readLoop auth gate (heartbeat.go readLoop) over
+// a real frame and returns whether the frame would refresh peer liveness. It
+// mutates the receiver's real authReplay / epoch / peerAuthSeen state exactly as
+// the readLoop does, so a test can feed a sequence of frames and observe the
+// cumulative accept/reject decisions.
+func heartbeatGate(r *heartbeatReceiver, key, frame []byte) bool {
+	auth := parseHeartbeatAuth(frame, key)
+	nonceFresh := auth.macOK && r.authReplay.admit(auth.session, auth.counter)
+	accept, _ := heartbeatAuthDecision(len(key) > 0, auth.present, auth.macOK, nonceFresh, r.peerAuthSeen.Load())
+	if accept && auth.macOK {
+		epochFresh := auth.hasEpoch && r.epochAdmit(auth.epoch)
+		accept, _ = heartbeatEpochDecision(auth.hasEpoch, epochFresh, r.sawEpoch)
+	}
+	if auth.macOK {
+		r.peerAuthSeen.Store(true)
+	}
+	return accept
+}
+
+// TestHeartbeatEpochRejectsRetiredIncarnationAfterRingChurn is the #6169
+// fail-on-revert gate — the complete fix for the >=65-recording sustained
+// replay the bounded session ring cannot close (issue body / #6167 residual).
+//
+// Scenario, faithful to the issue: an on-link attacker captured a RETIRED
+// incarnation R (a low boot epoch). Over the cluster's life the peer rebooted
+// heartbeatReplaySessions more times (each a genuinely-new session with a
+// strictly HIGHER epoch), churning the 64-slot session ring so R's watermark is
+// EVICTED. The ring now treats a replay of R as a never-seen session and would
+// ADMIT it — exactly the residual #5477 documented. The boot epoch closes it:
+// R's epoch is below the high-water, so the replay is rejected regardless of
+// ring state.
+//
+// RED-on-revert: neutralising the epoch reject in heartbeatReceiver.epochAdmit
+// (`if r.sawEpoch && epoch < r.highEpoch { return false }`) makes epochAdmit
+// always admit, so the replayed retired frame passes the gate and would refresh
+// liveness / apply its stale role — this test then fails as a clean assertion.
+func TestHeartbeatEpochRejectsRetiredIncarnationAfterRingChurn(t *testing.T) {
+	key := []byte("cluster-shared-secret")
+	const retiredEpoch = 1_000_000
+
+	// Build the retired incarnation's captured frame (epoch below every later
+	// reboot). counter=1 is its first (and here only) recorded frame.
+	const sessR = 0xBADCAFE
+	retired := MarshalHeartbeatAuthEpoch(samplePkt(), key, sessR, 1, retiredEpoch)
+
+	r := &heartbeatReceiver{}
+
+	// 1) The attacker's capture was live once: it is admitted and anchors the
+	// high-water at retiredEpoch. (Model the moment R was the live incarnation.)
+	if !heartbeatGate(r, key, retired) {
+		t.Fatal("R was once the live incarnation and must have been admitted")
+	}
+
+	// 2) heartbeatReplaySessions genuine reboots, each a NEW session with a
+	// strictly HIGHER epoch. These both advance the high-water AND churn the
+	// ring, evicting R's watermark (FIFO after a full ring of newer sessions).
+	for i := 0; i < heartbeatReplaySessions; i++ {
+		sess := uint64(0x10000 + i)
+		epoch := uint64(retiredEpoch + 1 + i)
+		frame := MarshalHeartbeatAuthEpoch(samplePkt(), key, sess, 1, epoch)
+		if !heartbeatGate(r, key, frame) {
+			t.Fatalf("genuine reboot %d (sess %#x, epoch %d) must be admitted", i, sess, epoch)
+		}
+	}
+
+	// Sanity: R's session is now evicted from the ring, so the RING ALONE would
+	// re-admit the replay (this is the exact residual the epoch closes). Prove it
+	// on an independent ring driven with the same churn.
+	var ringOnly heartbeatAuthReplay
+	if !ringOnly.admit(sessR, 1) {
+		t.Fatal("setup: first admit of R must succeed")
+	}
+	for i := 0; i < heartbeatReplaySessions; i++ {
+		ringOnly.admit(uint64(0x10000+i), 1)
+	}
+	if !ringOnly.admit(sessR, 1) {
+		t.Fatal("precondition: after >=64 churned sessions the ring ALONE re-admits the retired replay (the residual the boot epoch must close)")
+	}
+
+	// 3) THE FIX: replay the retired incarnation R. The ring admits it
+	// (never-seen), but its epoch (retiredEpoch) is below the high-water
+	// (retiredEpoch+heartbeatReplaySessions), so the epoch gate REJECTS it.
+	if heartbeatGate(r, key, retired) {
+		t.Error("#6169: replay of a retired (lower-epoch) incarnation must be REJECTED even after >=65 incarnations churn the session ring")
+	}
+	// And a sustained loop stays closed.
+	if heartbeatGate(r, key, retired) {
+		t.Error("#6169: a sustained retired-epoch replay must remain REJECTED")
+	}
+}
+
+// TestHeartbeatEpochDowngradeRejected verifies that once the peer has proven it
+// carries a boot epoch (sent a MAC-valid v2 frame), a later MAC-valid v1 frame
+// WITHOUT an epoch is rejected as a downgrade (epoch strip). Before the peer
+// sends any epoch, a v1 frame is dual-accepted (rolling upgrade). This mirrors
+// the cleartext-downgrade gate: a proven capability cannot be silently dropped.
+func TestHeartbeatEpochDowngradeRejected(t *testing.T) {
+	key := []byte("cluster-shared-secret")
+
+	// A pre-upgrade v1 frame is accepted while the peer has not yet epoched.
+	r := &heartbeatReceiver{}
+	v1early := MarshalHeartbeatAuth(samplePkt(), key, 0x1, 1)
+	if !heartbeatGate(r, key, v1early) {
+		t.Fatal("a v1 frame before any epoch must be dual-accepted (rolling upgrade)")
+	}
+
+	// Peer upgrades: a v2 frame arrives and proves the epoch capability.
+	v2 := MarshalHeartbeatAuthEpoch(samplePkt(), key, 0x2, 1, 500)
+	if !heartbeatGate(r, key, v2) {
+		t.Fatal("the peer's first v2 frame must be admitted")
+	}
+	if !r.sawEpoch {
+		t.Fatal("sawEpoch must latch once a MAC-valid epoch frame is accepted")
+	}
+
+	// Now a MAC-valid v1 frame (no epoch) is a downgrade -> reject.
+	v1late := MarshalHeartbeatAuth(samplePkt(), key, 0x3, 1)
+	if heartbeatGate(r, key, v1late) {
+		t.Error("#6169: a MAC-valid v1 frame after the peer proved it carries an epoch must be REJECTED (epoch strip)")
+	}
+}
+
+// TestNextBootEpoch_Monotonic verifies the sender epoch source strictly
+// increases across successive incarnations (each call = one daemon start) and
+// survives a wall-clock step BACKWARDS via the persisted floor. A missing file
+// is first boot (wall-clock seeded), not an error.
+func TestNextBootEpoch_Monotonic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ha-boot-epoch")
+
+	e1 := nextBootEpoch(path)
+	if e1 == 0 {
+		t.Fatal("first epoch must be non-zero (wall-clock seeded)")
+	}
+	// The file was persisted.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("epoch not persisted: %v", err)
+	}
+
+	e2 := nextBootEpoch(path)
+	if e2 <= e1 {
+		t.Errorf("epoch must strictly increase across restarts: e2=%d <= e1=%d", e2, e1)
+	}
+
+	// Simulate a wall-clock step backwards by planting a persisted value FAR
+	// above the current wall clock: the next epoch must still exceed it
+	// (persisted+1 floor dominates), so a rebooted peer with a skewed clock is
+	// never mistaken for a replay of its own retired incarnation.
+	future := e2 + 1_000_000_000_000
+	if err := os.WriteFile(path, []byte(itoa(future)+"\n"), 0o644); err != nil {
+		t.Fatalf("plant future epoch: %v", err)
+	}
+	e3 := nextBootEpoch(path)
+	if e3 <= future {
+		t.Errorf("persisted floor must dominate a backwards clock: e3=%d <= planted=%d", e3, future)
+	}
+}
+
+// itoa avoids importing strconv in the test just for one conversion.
+func itoa(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for v > 0 {
+		i--
+		b[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(b[i:])
+}

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -206,6 +206,14 @@ type Manager struct {
 	hbPeerAddr     string // last StartHeartbeat peerAddr (for restart)
 	hbVRFDevice    string // last StartHeartbeat vrfDevice (for restart)
 
+	// #6169 boot epoch: a monotonic-across-reboot counter signed into keyed
+	// heartbeats so the peer can reject a replayed retired incarnation. Computed
+	// ONCE per daemon incarnation (bootEpochOnce) and reused across heartbeat
+	// restarts — a VRF rebind / comms restart is the SAME incarnation, so it
+	// keeps the same epoch. See nextBootEpoch and heartbeatReceiver.epochAdmit.
+	bootEpoch     uint64
+	bootEpochOnce sync.Once
+
 	// Sync stats provider (set by daemon after sessionSync creation).
 	syncStats SyncStatsProvider
 


### PR DESCRIPTION
Closes #6169

## STEP 0 — coupling / not-already-fixed determination (firsthand)

This is the **independent complete-fix follow-up named by the #6167 hostile
review**. Verified against `origin/master` (`11e23b49a`):

- **Not already fixed.** `heartbeat.go` on master carries only the v1
  (`XPFA`) nonce trailer; its `heartbeatReplaySessions` doc explicitly states
  the complete fix needs "a boot-epoch / monotonic-across-reboot counter
  carried in the frame (a wire change), tracked as a follow-up."
- **Independent of the held #5078 plan.** #5078 is the **session-sync PSK
  handshake** in `sync_auth.go` (a separate TCP mechanism — reflected nonce,
  directional keys). This PR touches only the UDP heartbeat frame in
  `heartbeat.go`; it does not read or modify `sync_auth.go`.
- **No collision with #5081 / #5086 / #5639.** #5081 is the comms-restart
  transport key in `pkg/daemon` (reconcile, not the wire); #5086's core
  A→B→A ring fix already merged as #5477/#6167 and this PR is its additive
  boot-epoch continuation (does not restructure the ring); #5639 is the
  `peerAuthSeen` sticky-bit lifecycle on comms-recreate (untouched — a new
  `sawEpoch` field is added alongside, not in place of it).

## Problem

#5477 (merged #6167) bounded the anti-replay to a 64-slot per-session
watermark ring, but FIFO eviction is triggered by any never-seen session
**including a replayed retired frame**, so an attacker holding ≥65 distinct
captured incarnations can churn the ring by replay alone and sustain a forged
liveness/election drive indefinitely (empirically: 64 → all rejected, 65 →
sustained admits).

## Fix

A monotonic-across-reboot **boot epoch** signed into the heartbeat frame; the
receiver rejects any authenticated frame whose epoch is below the highest ever
accepted from the peer — O(1) state, independent of ring churn.

- **Wire (v2).** `MarshalHeartbeatAuthEpoch` → 60-byte trailer
  `"XPFE"(4)+session(8)+counter(8)+epoch(8)+HMAC(32)` (epoch inside the MAC).
  `parseHeartbeatAuth` tries v2 then v1 → **dual-accept rolling upgrade**; a
  new receiver reads an old peer's v1 frame, an old receiver ignores the
  longer v2 trailer. `verifyHeartbeatMAC` is format-agnostic, so a v1 frame
  with a coincidental v2 magic (≈2⁻³²) falls through to the correct v1 parse.
  Never-unsigned-when-keyed invariant preserved.
- **Receiver.** `epochAdmit` rejects a strictly-lower epoch (retired
  incarnation), anchors the first, advances on a higher (genuine reboot).
  `heartbeatEpochDecision` composes with `heartbeatAuthDecision`: a v1 frame
  is dual-accepted only until the peer proves it carries an epoch (`sawEpoch`),
  after which a MAC-valid v1 frame is rejected as a **downgrade** (epoch strip).
  The intra-incarnation session+counter ring is unchanged.
- **Sender source.** `nextBootEpoch` = `max(persisted+1, wallclock-nanos)`
  persisted durably to `/var/lib/xpf/ha-boot-epoch` via `fsatomic` (the SNMP
  `engineBoots` pattern). Strictly increases across restarts under **both** a
  wall-clock step backwards (persisted+1 dominates → **no genuine-peer
  lockout**) and a lost state file (wall clock dominates). Computed once per
  incarnation (`sync.Once`), lazy on first keyed send so an unkeyed cluster
  never touches the path; persist failure is non-fatal.

## Fail-on-revert test

`TestHeartbeatEpochRejectsRetiredIncarnationAfterRingChurn` reconstructs the
readLoop gate over real signed frames: it feeds a retired incarnation, churns
`heartbeatReplaySessions` newer sessions to evict it (proven separately that
the ring alone re-admits it), then replays the retired frame and asserts the
epoch gate **rejects** it. **Neutralizing** the `epochAdmit` reject
(`if r.sawEpoch && epoch < r.highEpoch { return false }`) re-admits the replay
→ this test (and `TestHeartbeatEpochAdmit`) go **RED as clean assertion
failures** (verified — no build break). Also: v2 round-trip, dual-accept
parse, epoch-decision truth table, downgrade reject, and `nextBootEpoch`
monotonicity (incl. a simulated backwards-clock).

## Validation

`go build`/`vet`/`test ./pkg/cluster` clean (full suite green); consumers
(`pkg/daemon`, `pkg/grpcapi`, `cmd`) build clean.

**Merge gate:** cluster/heartbeat change → loss-cluster failover smoke required
at merge (parent runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ