### PR TITLE
config: #5717 C-CONFIG cohort — display-set parity, signed-port test unmask, feed diagnostics

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57870,3 +57870,23 @@ top.
     pkg/config/compiler_uniformgates.go,
     pkg/config/compiler_feed_diag_failclosed_5717_test.go,
     docs/config-schema.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #5717 PR #6372 Codex review-fold (MERGE-NEEDS-MINOR ×2).
+    MINOR-1: FormatPathSet suffix-align was a heuristic that over-strips when a
+    multi-key terminal is matched by only its first key AND the path tail equals
+    its full keys (filter NAMED `term` holding a term NAMED `term`,
+    `... filter term term term`). Replaced the inference with navigatePath's TRUE
+    consumed width: added navigatePathWidth (returns (matches, width)),
+    navigatePath now a thin wrapper; FormatPathSet uses path[:len(path)-width].
+    RED-on-revert: restoring suffix-align drops a `term` on the
+    `... filter term term` scope. MINOR-2: added a malformed-feed-url subtest
+    (http://%) to the shared fail-closed assertion (the :226 rewording had no
+    regression binding) and corrected the stale #5183 malformed-url fail-open
+    comment (:195) to the #5645 fail-closed sequence. RED-on-revert: reverting
+    the malformed-url wording to fail-open fails the new subtest.
+  **File(s)**: pkg/config/ast.go, pkg/config/ast_format.go,
+    pkg/config/ast_format_pathset_ancestor_5717_test.go,
+    pkg/config/compiler_validate_strict_observability.go,
+    pkg/config/compiler_feed_diag_failclosed_5717_test.go,
+    docs/config-schema.md

--- a/_Log.md
+++ b/_Log.md
@@ -57846,3 +57846,27 @@ top.
     pkg/cluster/sync_conn_gen.go,
     pkg/cluster/sync_config_epoch_sweep_race_6284_test.go,
     docs/session-sync-architecture.md, pkg/cluster/README.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #5717 C-CONFIG cohort (codex-182) — fixed 3 real+driveable
+    survivors. (1) FormatPathSet scoped display-set dropped an ancestor token
+    when an ancestor argument equaled the terminal node's first key (A3-b00-C001
+    display half; copy half already fixed by #5822): strip terminal keys from
+    the RIGHT (suffix-aligned) instead of first-key search from the LEFT.
+    (2) C2 signed-port NAT test masking: added a terminal action + specific
+    diagnostic assertion so a NAT-match port-parse regression is no longer
+    masked by the #5628 missing-action gate. (3) C3 stale feed diagnostics:
+    rewrote the undefined-feed-name / endpoint-less / malformed-url errors and
+    sibling comments to the #5645 fail-closed sequence (omitted ->
+    __unsupported_address__ -> whole-snapshot preflight reject ->
+    previous-good/default-deny) + an error-message assertion. Deferred C1
+    (lenient contradictory-NAT migration contract — design-heavy, HA-coupled)
+    and C4 (strongSwan swanctl integration — needs charon container absent from
+    env). All three fixes verified RED-on-revert.
+  **File(s)**: pkg/config/ast_format.go,
+    pkg/config/ast_format_pathset_ancestor_5717_test.go,
+    pkg/config/compiler_signed_port_3606_test.go,
+    pkg/config/compiler_validate_strict_observability.go,
+    pkg/config/compiler_uniformgates.go,
+    pkg/config/compiler_feed_diag_failclosed_5717_test.go,
+    docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -880,24 +880,31 @@ display-set round-trip, policy match `source-address`, block-shape
 `system-services` member toggle, single-value-leaf and keyed-entry
 non-regression).
 
-**Scoped display-set parent prefix: strip the terminal node's keys from the
-RIGHT, not the first-key match from the LEFT (#5717).** `FormatPathSet`
-(`ast_format.go`, the `show configuration <path> | display set` renderer)
-reconstructs the leading prefix for each emitted `set` line by removing the
-matched terminal node's keys from the scoped path. It previously searched the
-path left-to-right for the FIRST token equal to the matched node's first key and
-stopped there, so an ANCESTOR argument equal to that key truncated the prefix and
-dropped the ancestor token — a security zone NAMED `interfaces` holding an
-`interfaces` stanza rendered `set security zones security-zone interfaces
-ge-0/0/9.0` (one `interfaces` missing), a malformed line that reloads as a
-different object. `navigatePath` consumes the trailing path tokens into the
-terminal node, so the fix strips the node's keys from the RIGHT (suffix-aligned
-to tolerate a partial multi-key terminal match), keeping every ancestor token.
-This is the display-side twin of the copy-side #5822 fix (`CopyPath` first-keyword
-`insertNode`); both are the codex-182 A3-b00-C001 AST path-identity cohort.
-Covered by `pkg/config/ast_format_pathset_ancestor_5717_test.go` (zone-named-
-`interfaces` round-trip + policy-named-`then` prefix; fail-on-revert restores the
-left-search truncation).
+**Scoped display-set parent prefix: use `navigatePath`'s TRUE consumed width,
+not a key-token heuristic (#5717).** `FormatPathSet` (`ast_format.go`, the
+`show configuration <path> | display set` renderer) reconstructs the leading
+prefix for each emitted `set` line by removing the matched terminal node's tokens
+from the scoped path. Two heuristics both failed on legal repeated names:
+searching the path left-to-right for the FIRST token equal to the matched node's
+first key dropped an ancestor token when an ANCESTOR argument equaled that key (a
+security zone NAMED `interfaces` holding an `interfaces` stanza rendered
+`set security zones security-zone interfaces ge-0/0/9.0`, one `interfaces`
+missing); suffix-aligning the node's WHOLE keys against the path over-stripped
+when an ancestor value repeated the node's keys (a firewall filter NAMED `term`
+holding a term NAMED `term`, `... filter term term term`, scoped to
+`... filter term term` — the `term term` node matched by only its first key, but
+the path tail `["term","term"]` also equalled its full keys). The robust fix
+exposes the exact number of trailing path tokens `navigatePath` consumed into the
+terminal node — `navigatePathWidth` (`ast.go`) returns `(matches, width)`, and
+`navigatePath` is now a thin wrapper — so the parent prefix is
+`path[:len(path)-width]` from the TRUE width (a single-key bare-keyword terminal
+consumes ONE token even when its full Keys are longer). This is the display-side
+twin of the copy-side #5822 fix (`CopyPath` first-keyword `insertNode`); both are
+the codex-182 A3-b00-C001 AST path-identity cohort. Covered by
+`pkg/config/ast_format_pathset_ancestor_5717_test.go` (zone-named-`interfaces`
+round-trip, policy-named-`then` prefix, and every scoped depth of the
+filter-`term`/term-`term` chain; fail-on-revert restores the token-heuristic and
+drops a token).
 
 **Rename-side contract: resolve the SPECIFIC named sibling by full identity
 (#3982).** `rename <old> to <new>` (`RenamePath`, `ast_edit.go`) is the same

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -880,6 +880,25 @@ display-set round-trip, policy match `source-address`, block-shape
 `system-services` member toggle, single-value-leaf and keyed-entry
 non-regression).
 
+**Scoped display-set parent prefix: strip the terminal node's keys from the
+RIGHT, not the first-key match from the LEFT (#5717).** `FormatPathSet`
+(`ast_format.go`, the `show configuration <path> | display set` renderer)
+reconstructs the leading prefix for each emitted `set` line by removing the
+matched terminal node's keys from the scoped path. It previously searched the
+path left-to-right for the FIRST token equal to the matched node's first key and
+stopped there, so an ANCESTOR argument equal to that key truncated the prefix and
+dropped the ancestor token — a security zone NAMED `interfaces` holding an
+`interfaces` stanza rendered `set security zones security-zone interfaces
+ge-0/0/9.0` (one `interfaces` missing), a malformed line that reloads as a
+different object. `navigatePath` consumes the trailing path tokens into the
+terminal node, so the fix strips the node's keys from the RIGHT (suffix-aligned
+to tolerate a partial multi-key terminal match), keeping every ancestor token.
+This is the display-side twin of the copy-side #5822 fix (`CopyPath` first-keyword
+`insertNode`); both are the codex-182 A3-b00-C001 AST path-identity cohort.
+Covered by `pkg/config/ast_format_pathset_ancestor_5717_test.go` (zone-named-
+`interfaces` round-trip + policy-named-`then` prefix; fail-on-revert restores the
+left-search truncation).
+
 **Rename-side contract: resolve the SPECIFIC named sibling by full identity
 (#3982).** `rename <old> to <new>` (`RenamePath`, `ast_edit.go`) is the same
 read-all-siblings class as the delete/deactivate fixes above, but on a

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -188,6 +188,24 @@ func cloneNodes(nodes []*Node) []*Node {
 // matching both ["from-zone","untrust","to-zone","trust"] and
 // ["from-zone","untrust","to-zone","dmz"]), all matches are returned.
 func navigatePath(nodes []*Node, path []string) []*Node {
+	matches, _ := navigatePathWidth(nodes, path)
+	return matches
+}
+
+// navigatePathWidth is navigatePath plus the number of trailing `path` tokens
+// the terminal match consumed into matches[0]'s keys (0 when nothing matched).
+// FormatPathSet needs the EXACT consumed width to rebuild the parent prefix:
+// a terminal node can be matched by only its FIRST key — the single-key
+// bare-keyword terminal returns every same-keyword sibling and consumes ONE
+// token even when the node's full Keys are longer — so inferring the width by
+// suffix-matching the node's keys against the path over-strips when an ancestor
+// value repeats the node's keys. A firewall filter NAMED `term` holding a term
+// NAMED `term` (`... filter term term term then accept`) scoped to `... filter
+// term term` matched the `term term` node by its first key (width 1), but a
+// suffix match found the node's whole `["term","term"]` at the path tail and
+// dropped an ancestor `term` (#5717 codex-182 A3-b00-C001 fold). Returning the
+// true consumed width removes the inference.
+func navigatePathWidth(nodes []*Node, path []string) ([]*Node, int) {
 	current := nodes
 	i := 0
 	for i < len(path) {
@@ -223,7 +241,7 @@ func navigatePath(nodes []*Node, path []string) []*Node {
 				}
 				i += consumed
 				if i >= len(path) {
-					return matched
+					return matched, consumed
 				}
 				// Intermediate descent: continue against the UNION of
 				// every same-prefix sibling's children, not just
@@ -263,9 +281,9 @@ func navigatePath(nodes []*Node, path []string) []*Node {
 				}
 			}
 			if len(all) == 0 {
-				return nil
+				return nil, 0
 			}
-			return all
+			return all, 1
 		}
 		// Intermediate single-key descent: continue against the UNION of
 		// every same-keyword sibling's children, not just the first, so a
@@ -280,12 +298,12 @@ func navigatePath(nodes []*Node, path []string) []*Node {
 			}
 		}
 		if len(sibs) == 0 {
-			return nil
+			return nil, 0
 		}
 		i++
 		current = unionChildren(sibs)
 	}
-	return nil
+	return nil, 0
 }
 
 // unionChildren concatenates the children of every node in sibling order.

--- a/pkg/config/ast_format.go
+++ b/pkg/config/ast_format.go
@@ -182,28 +182,22 @@ func (t *ConfigTree) FormatPathSet(path []string) string {
 	if len(path) == 0 {
 		return t.FormatSet()
 	}
-	matches := navigatePath(t.Children, path)
+	matches, width := navigatePathWidth(t.Children, path)
 	if len(matches) == 0 {
 		return ""
 	}
 	// Compute the parent prefix: the path elements BEFORE the matched terminal
-	// node's keys. navigatePath consumed the trailing tokens of `path` into the
-	// terminal node, so strip the node's keys from the RIGHT. The pre-#5717 code
-	// searched for the node's first key from the LEFT and stopped at its FIRST
-	// occurrence, so an ANCESTOR argument equal to that key (e.g. a security zone
-	// NAMED "interfaces" holding an `interfaces` stanza) truncated the prefix and
-	// emitted a malformed, non-round-trippable set line that dropped the ancestor
-	// token (codex-182 A3-b00-C001, #5717). Shrink k until the path suffix aligns
-	// with the node's leading keys to tolerate a partial multi-key terminal match.
-	mk := matches[0].Keys
-	k := len(mk)
-	if k > len(path) {
-		k = len(path)
-	}
-	for k > 0 && !keysEqual(path[len(path)-k:], mk[:k]) {
-		k--
-	}
-	parentPrefix := append([]string(nil), path[:len(path)-k]...)
+	// node. navigatePath consumed exactly `width` trailing `path` tokens into the
+	// terminal node's keys, so the prefix is the leading part of `path` with that
+	// width stripped from the RIGHT. Using the TRUE consumed width — rather than
+	// the node's first key from the LEFT (pre-#5717) or a suffix match of the
+	// node's whole keys (the first #5717 cut) — is the only reconstruction that
+	// stays correct when an ancestor value repeats the terminal node's keys: a
+	// zone NAMED "interfaces" holding an `interfaces` stanza (single-key terminal,
+	// width 1) and a filter NAMED `term` holding a term NAMED `term` (`... filter
+	// term term term`, width 1) both broke the earlier heuristics
+	// (codex-182 A3-b00-C001, #5717).
+	parentPrefix := append([]string(nil), path[:len(path)-width]...)
 	var b strings.Builder
 	for _, n := range matches {
 		prefix := append(append([]string{}, parentPrefix...), n.Keys...)

--- a/pkg/config/ast_format.go
+++ b/pkg/config/ast_format.go
@@ -186,15 +186,24 @@ func (t *ConfigTree) FormatPathSet(path []string) string {
 	if len(matches) == 0 {
 		return ""
 	}
-	// Compute parent prefix: path elements before the matched node's first key.
-	var parentPrefix []string
-	firstKey := matches[0].Keys[0]
-	for _, p := range path {
-		if p == firstKey {
-			break
-		}
-		parentPrefix = append(parentPrefix, p)
+	// Compute the parent prefix: the path elements BEFORE the matched terminal
+	// node's keys. navigatePath consumed the trailing tokens of `path` into the
+	// terminal node, so strip the node's keys from the RIGHT. The pre-#5717 code
+	// searched for the node's first key from the LEFT and stopped at its FIRST
+	// occurrence, so an ANCESTOR argument equal to that key (e.g. a security zone
+	// NAMED "interfaces" holding an `interfaces` stanza) truncated the prefix and
+	// emitted a malformed, non-round-trippable set line that dropped the ancestor
+	// token (codex-182 A3-b00-C001, #5717). Shrink k until the path suffix aligns
+	// with the node's leading keys to tolerate a partial multi-key terminal match.
+	mk := matches[0].Keys
+	k := len(mk)
+	if k > len(path) {
+		k = len(path)
 	}
+	for k > 0 && !keysEqual(path[len(path)-k:], mk[:k]) {
+		k--
+	}
+	parentPrefix := append([]string(nil), path[:len(path)-k]...)
 	var b strings.Builder
 	for _, n := range matches {
 		prefix := append(append([]string{}, parentPrefix...), n.Keys...)

--- a/pkg/config/ast_format_pathset_ancestor_5717_test.go
+++ b/pkg/config/ast_format_pathset_ancestor_5717_test.go
@@ -62,6 +62,46 @@ func TestFormatPathSetAncestorEqualsKey_5717(t *testing.T) {
 	}
 }
 
+// The multi-key repeated-key case (codex-182 fold): a firewall filter NAMED
+// `term` holding a term NAMED `term`. The full render is
+// `set firewall family inet filter term term term then accept`. Scoping to
+// `... filter term term` matches the `term term` node by only its FIRST key (a
+// single-key bare-keyword terminal, true consumed width 1), but the path's last
+// TWO tokens `["term","term"]` also equal the node's whole Keys — so the first
+// #5717 cut (suffix-align the node's keys against the path) over-stripped and
+// dropped an ancestor `term`. The width-based reconstruction uses navigatePath's
+// TRUE consumed width and keeps every token. Both `filter <name>` and
+// `term <name>` accept `term` as a legal name (schema_cos.go).
+//
+// RED-on-revert: replace the width-based parentPrefix with the suffix-align
+// heuristic and the `... filter term term` scope drops a `term`.
+func TestFormatPathSetRepeatedMultiKey_5717(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set firewall family inet filter term term term then accept",
+	})
+	full := "set firewall family inet filter term term term then accept"
+
+	// Every scoped depth into the repeated-`term` chain must render the full,
+	// round-trippable statement — none may drop a `term`.
+	scopes := [][]string{
+		{"firewall", "family", "inet", "filter", "term"},                         // the filter named term
+		{"firewall", "family", "inet", "filter", "term", "term"},                 // + the term named term (single-key terminal, width 1)
+		{"firewall", "family", "inet", "filter", "term", "term", "term"},         // full term identity (multi-key terminal, width 2)
+		{"firewall", "family", "inet", "filter", "term", "term", "term", "then"}, // the then action
+	}
+	for _, path := range scopes {
+		got := strings.TrimSpace(tree.FormatPathSet(path))
+		if got != full {
+			t.Fatalf("FormatPathSet(%v) dropped a token:\n got: %q\nwant: %q", path, got, full)
+		}
+		// Round-trip the emitted line.
+		rt := buildTreeFromSet(t, []string{got})
+		if back := strings.TrimSpace(rt.FormatPathSet(scopes[len(scopes)-1])); back != full {
+			t.Fatalf("round-trip of %v diverged:\n got: %q\nwant: %q", path, back, full)
+		}
+	}
+}
+
 // A second shape: an ancestor policy NAMED after a descendant keyword. Here the
 // term is named "match" (a legal Junos name) and the matched leaf keyword is
 // also reachable such that a naive first-key search truncates the prefix.

--- a/pkg/config/ast_format_pathset_ancestor_5717_test.go
+++ b/pkg/config/ast_format_pathset_ancestor_5717_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5717 / codex-182 A3-b00-C001 (display half): a path-scoped
+// `show configuration <path> | display set` (FormatPathSet) reconstructed the
+// parent prefix by searching the display path for the FIRST token equal to the
+// matched node's first key and stopping there. When an ANCESTOR argument equals
+// that key — e.g. a security zone NAMED "interfaces" that holds an `interfaces`
+// stanza, or a policy/term whose name equals a child keyword — the prefix was
+// truncated at the ancestor and the emitted set line dropped the ancestor token,
+// producing a malformed, NON-round-trippable line that pointed at a different
+// object if replayed.
+//
+// The copy half of the same cohort (CopyPath first-keyword insertNode) was
+// already repaired by #5822; this guards the display half.
+//
+// RED-on-revert: restore the left-to-right "stop at first token == firstKey"
+// prefix derivation in FormatPathSet and these round-trip assertions fail — the
+// ancestor "interfaces"/"trust" token disappears from the emitted set line.
+
+func mustParse5717(t *testing.T, src string) *ConfigTree {
+	t.Helper()
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	return tree
+}
+
+func TestFormatPathSetAncestorEqualsKey_5717(t *testing.T) {
+	// A security zone whose NAME equals the child keyword `interfaces`.
+	src := `security {
+    zones {
+        security-zone interfaces {
+            interfaces {
+                ge-0/0/9.0;
+            }
+        }
+    }
+}`
+	tree := mustParse5717(t, src)
+	path := []string{"security", "zones", "security-zone", "interfaces", "interfaces"}
+	got := strings.TrimSpace(tree.FormatPathSet(path))
+
+	// The correct, round-trippable line retains BOTH the zone-name token and the
+	// `interfaces` stanza keyword.
+	want := "set security zones security-zone interfaces interfaces ge-0/0/9.0"
+	if got != want {
+		t.Fatalf("FormatPathSet dropped the ancestor token:\n got: %q\nwant: %q", got, want)
+	}
+
+	// The emitted set line must round-trip: re-parsing it (flat-set path, via
+	// ParseSetCommand + SetPath per the project's flat-set testing rule) and
+	// re-rendering reproduces the same statement (proves it is not malformed).
+	rtTree := buildTreeFromSet(t, []string{got})
+	if back := strings.TrimSpace(rtTree.FormatPathSet(path)); back != want {
+		t.Fatalf("round-trip diverged:\n got: %q\nwant: %q", back, want)
+	}
+}
+
+// A second shape: an ancestor policy NAMED after a descendant keyword. Here the
+// term is named "match" (a legal Junos name) and the matched leaf keyword is
+// also reachable such that a naive first-key search truncates the prefix.
+func TestFormatPathSetPolicyNameEqualsKey_5717(t *testing.T) {
+	// Policy NAMED "then" holding a `then permit` action: the matched node's
+	// first key `then` also appears earlier as the policy name.
+	src := `security {
+    policies {
+        from-zone trust to-zone untrust {
+            policy then {
+                then {
+                    permit;
+                }
+            }
+        }
+    }
+}`
+	tree := mustParse5717(t, src)
+	path := []string{
+		"security", "policies", "from-zone", "trust", "to-zone", "untrust",
+		"policy", "then", "then",
+	}
+	got := strings.TrimSpace(tree.FormatPathSet(path))
+	want := "set security policies from-zone trust to-zone untrust policy then then permit"
+	if got != want {
+		t.Fatalf("FormatPathSet dropped the policy-name token:\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/pkg/config/compiler_feed_diag_failclosed_5717_test.go
+++ b/pkg/config/compiler_feed_diag_failclosed_5717_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5717 / codex-182 C3: after #5645 the runtime is fail-CLOSED for an
+// unresolvable dynamic-address feed binding — the name is omitted, lowers to
+// the __unsupported_address__ sentinel, and the userspace snapshot preflight
+// REJECTS the whole publication so the dataplane retains previous-good or
+// fresh-boot default-deny. The strict commit diagnostics, however, still told
+// the operator the OPPOSITE failure mode ("would resolve to an empty address
+// set — a feed-backed policy would silently match nothing", i.e. fail-open).
+// That stale explanation can drive the wrong remediation during a rejected
+// commit or feed-outage investigation.
+//
+// These assertions pin the corrected #5645 fail-closed wording so a future
+// posture change that reverts a diagnostic back to the fail-open framing (or
+// forgets to update it alongside the enforcement path) fails loudly here.
+//
+// RED-on-revert: restore any of the pre-#5645 "silently match nothing" /
+// "resolve to an empty address set" fail-open error strings and the
+// fails-CLOSED / sentinel substring assertions below fail.
+
+func TestFeedDiagnosticsAreFailClosed_5717(t *testing.T) {
+	// The strict feed-name cross-reference diagnostic (undefined feed-name).
+	t.Run("undefined-feed-name", func(t *testing.T) {
+		tree := buildTreeFromSet(t, []string{
+			"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			// Typo: references "malwrae", which no server declares.
+			"set security dynamic-address address-name bad-actors profile feed-name malwrae",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("CompileConfig should reject an undefined feed-name reference")
+		}
+		assertFailClosedFeedDiag_5717(t, err.Error())
+	})
+
+	// The strict feed-server endpoint diagnostic (endpoint-less server: a
+	// bound address-name is unresolvable because the server registers no feed).
+	t.Run("endpoint-less-server", func(t *testing.T) {
+		tree := buildTreeFromSet(t, []string{
+			// No url and no hostname => resolveBaseURL == "" => server skipped.
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("CompileConfig should reject an endpoint-less feed-server")
+		}
+		assertFailClosedFeedDiag_5717(t, err.Error())
+	})
+}
+
+// assertFailClosedFeedDiag_5717 verifies a feed diagnostic describes the #5645
+// fail-closed enforcement path and NOT the pre-#5645 fail-open framing.
+func assertFailClosedFeedDiag_5717(t *testing.T, msg string) {
+	t.Helper()
+	// Must describe fail-closed enforcement.
+	for _, want := range []string{"fails CLOSED", "__unsupported_address__", "#5645"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("feed diagnostic must describe the #5645 fail-closed path; missing %q in:\n%s", want, msg)
+		}
+	}
+	// Must NOT assert the stale fail-open framing. "silently match nothing"
+	// alone is the pre-#5645 wording; the corrected text only ever uses it
+	// under an explicit "not"/"NOT" negation, so a bare occurrence is stale.
+	if idx := strings.Index(msg, "silently match nothing"); idx >= 0 {
+		pre := msg[:idx]
+		if !strings.Contains(pre, "NOT ") && !strings.Contains(pre, "not ") {
+			t.Fatalf("feed diagnostic still asserts the stale fail-open 'silently match nothing' framing:\n%s", msg)
+		}
+	}
+	if strings.Contains(msg, "silently matches nothing") || strings.Contains(msg, "resolve to an empty address set") {
+		t.Fatalf("feed diagnostic still uses stale fail-open framing:\n%s", msg)
+	}
+}

--- a/pkg/config/compiler_feed_diag_failclosed_5717_test.go
+++ b/pkg/config/compiler_feed_diag_failclosed_5717_test.go
@@ -53,6 +53,24 @@ func TestFeedDiagnosticsAreFailClosed_5717(t *testing.T) {
 		}
 		assertFailClosedFeedDiag_5717(t, err.Error())
 	})
+
+	// The strict feed-server MALFORMED-url diagnostic (#5183 gate): a non-empty
+	// but unconstructible base url (`http://%`) clears the emptiness gate, so a
+	// bound address-name is unresolvable and must be reported fail-closed. Before
+	// this fold the malformed-url wording had no regression binding — reverting
+	// it to the fail-open framing left the suite green.
+	t.Run("malformed-url-server", func(t *testing.T) {
+		tree := buildTreeFromSet(t, []string{
+			"set security dynamic-address feed-server threat url http://%",
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("CompileConfig should reject a malformed feed-server url")
+		}
+		assertFailClosedFeedDiag_5717(t, err.Error())
+	})
 }
 
 // assertFailClosedFeedDiag_5717 verifies a feed diagnostic describes the #5645

--- a/pkg/config/compiler_signed_port_3606_test.go
+++ b/pkg/config/compiler_signed_port_3606_test.go
@@ -38,6 +38,15 @@ func TestSignedPortRejectedAtCommit_3606(t *testing.T) {
 	cases := []struct {
 		name string
 		cmds []string
+		// wantSub, when set, asserts the SPECIFIC signed-port diagnostic (strict
+		// error AND lenient warning) rather than merely "some error". #5717 /
+		// codex-182 C2: the NAT match fixture below was actionless, so #5628's
+		// missing-terminal-action gate rejected it regardless of the signed-port
+		// gate — a NAT call site regressing from parseCanonicalPort to a
+		// permissive strconv.Atoi would still be "rejected" and the test would
+		// stay green for the wrong reason. Giving the rule a valid terminal
+		// action and asserting the port-specific diagnostic closes that mask.
+		wantSub string
 	}{
 		{
 			name: "application-destination-port-plus",
@@ -69,7 +78,13 @@ func TestSignedPortRejectedAtCommit_3606(t *testing.T) {
 		},
 		{
 			name: "nat-match-destination-port-plus",
-			cmds: []string{"set security nat destination rule-set RS rule R1 match destination-port +80"},
+			cmds: []string{
+				"set security nat destination rule-set RS rule R1 match destination-port +80",
+				// #5717 / codex-182 C2: a VALID terminal action so the ONLY reason
+				// to reject is the signed-port gate (not #5628 missing-action).
+				"set security nat destination rule-set RS rule R1 then destination-nat off",
+			},
+			wantSub: `match destination-port "+80" is not a numeric port`,
 		},
 		{
 			name: "dnat-pool-port-plus",
@@ -77,18 +92,44 @@ func TestSignedPortRejectedAtCommit_3606(t *testing.T) {
 				"set security nat destination pool p1 address 192.168.1.10",
 				"set security nat destination pool p1 port +80",
 			},
+			wantSub: `port "+80" is not a numeric port`,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tree := buildTreeFromSet(t, tc.cmds)
-			if _, err := CompileConfig(tree); err == nil {
+			_, serr := CompileConfig(tree)
+			if serr == nil {
 				t.Fatalf("CompileConfig accepted signed port for %q (want reject at commit)", tc.name)
+			}
+			// #5717 / codex-182 C2: when the fixture is otherwise well-formed,
+			// assert the strict reject names the SIGNED-PORT diagnostic
+			// specifically. Otherwise an unrelated gate (e.g. #5628
+			// missing-terminal-action) could mask a regression in the port
+			// parser/gate and leave this test green for the wrong reason.
+			if tc.wantSub != "" && !strings.Contains(serr.Error(), tc.wantSub) {
+				t.Fatalf("strict reject for %q named the wrong diagnostic:\n got:  %v\n want substring: %q", tc.name, serr, tc.wantSub)
 			}
 			// The tolerant load / peer-sync path must NOT brick: it downgrades
 			// to a warning and still compiles (#1960 no-brick doctrine).
-			if _, err := CompileConfigLenient(tree); err != nil {
-				t.Fatalf("CompileConfigLenient rejected %q (want warn-and-compile): %v", tc.name, err)
+			cfg, lerr := CompileConfigLenient(tree)
+			if lerr != nil {
+				t.Fatalf("CompileConfigLenient rejected %q (want warn-and-compile): %v", tc.name, lerr)
+			}
+			// #5717 / codex-182 C2: the signed port must produce a WARNING on the
+			// lenient path, not merely a successful compile — a silently-accepted
+			// signed port is exactly the regression this suite guards.
+			if tc.wantSub != "" {
+				var found bool
+				for _, w := range cfg.Warnings {
+					if strings.Contains(w, tc.wantSub) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("lenient path for %q dropped the signed-port warning; want substring %q; warnings: %v", tc.name, tc.wantSub, cfg.Warnings)
+				}
 			}
 		})
 	}

--- a/pkg/config/compiler_uniformgates.go
+++ b/pkg/config/compiler_uniformgates.go
@@ -1360,15 +1360,17 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 
 	// #3300 residual: an endpoint-less dynamic-address feed-server (no url
 	// AND no hostname) is SKIPPED by feeds.Manager.Apply (resolveBaseURL ==
-	// "" registers none of its feeds), so an address-name bound to it
-	// resolves to an empty match-nothing book and a feed-backed deny policy
-	// silently denies nothing — the #3300 symptom at the feed-server root.
-	// Reject it so the runtime-nonfunctional config fails at commit. This
-	// must run BEFORE the feed-name cross-reference gate below so the
-	// declared-feed set the latter trusts is exact (no skipped servers in
-	// it). Strict on commit / commit-check; lenient on load / peer-sync
-	// (warn — the runtime already drops the server, so a bound address-name
-	// is fail-closed rather than bricking the load — #1960 / #3261).
+	// "" registers none of its feeds), so an address-name bound to it is
+	// unresolvable and fails CLOSED at runtime (#5645: omitted ->
+	// __unsupported_address__ -> whole-snapshot preflight reject ->
+	// previous-good/default-deny) — historically the #3300 fail-open symptom
+	// at the feed-server root, now caught. Reject it so the
+	// runtime-nonfunctional config fails at commit instead of silently
+	// default-denying. This must run BEFORE the feed-name cross-reference gate
+	// below so the declared-feed set the latter trusts is exact (no skipped
+	// servers in it). Strict on commit / commit-check; lenient on load /
+	// peer-sync (warn — the runtime already drops the server, so a bound
+	// address-name is fail-closed rather than bricking the load — #1960 / #3261).
 	if err := validateDynamicAddressFeedServerEndpointStrict(cfg); err != nil {
 		if opts.lenientDynamicAddressFeedRef {
 			cfg.Warnings = append(cfg.Warnings,
@@ -1398,16 +1400,16 @@ func runUniformGates(tree *ConfigTree, cfg *Config, opts compileOpts) error {
 
 	// #3300 dynamic-address feed cross-reference gate. A
 	// `security dynamic-address address-name <addr> profile feed-name <feed>`
-	// whose feed-name resolves to no declared feed-server feed records an
-	// empty (match-nothing) address book at runtime, so a feed-backed deny
-	// policy silently denies nothing with no commit error — a typo is
-	// indistinguishable from a not-yet-fetched feed. Strict on commit /
-	// commit-check (hard reject so the typo is operator-visible); lenient on
-	// load / peer-sync (warn so an already-persisted or peer-synced config
-	// still boots — #1960 / #3261; the runtime stays fail-closed match-none
-	// for the unknown feed). Runs on the fully-compiled *Config so the
-	// feed-server map is populated regardless of authoring order. Mirrors
-	// validateLogProfileStreamReferencesStrict.
+	// whose feed-name resolves to no declared feed-server feed is UNRESOLVABLE
+	// at runtime and fails CLOSED (#5645: omitted -> __unsupported_address__ ->
+	// whole-snapshot preflight reject -> previous-good/default-deny), with no
+	// commit error — a typo is indistinguishable from a not-yet-fetched feed.
+	// Strict on commit / commit-check (hard reject so the typo is
+	// operator-visible); lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960 / #3261; the
+	// runtime stays fail-closed for the unknown feed). Runs on the
+	// fully-compiled *Config so the feed-server map is populated regardless of
+	// authoring order. Mirrors validateLogProfileStreamReferencesStrict.
 	if err := validateDynamicAddressFeedReferencesStrict(cfg); err != nil {
 		if opts.lenientDynamicAddressFeedRef {
 			cfg.Warnings = append(cfg.Warnings,

--- a/pkg/config/compiler_validate_strict_observability.go
+++ b/pkg/config/compiler_validate_strict_observability.go
@@ -132,10 +132,14 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 // Apply SKIP the whole server (it registers NONE of its feeds, including any
 // nested feed-name entries). The endpoint-less server still compiles into
 // SecurityConfig.DynamicAddress.FeedServers, so its feed names are
-// syntactically "declared", but at runtime no feed exists: an address-name
-// bound to one resolves to an empty (match-nothing) address book and a
-// feed-backed deny policy silently denies nothing — the same #3300 fail-open
-// symptom one layer up, at the feed-server root rather than the binding.
+// syntactically "declared", but at runtime no feed exists: the address-name
+// bound to one is UNRESOLVABLE and fails CLOSED (#5645: omitted -> the policy
+// lowering treats it as unrepresentable -> __unsupported_address__ -> the
+// userspace snapshot preflight rejects the whole publication -> previous-good /
+// fresh-boot default-deny). Historically this was the #3300 fail-open symptom
+// one layer up (silent match-none for a deny); #5645 makes the runtime fail
+// closed, and this gate still turns the silent default-deny into an
+// operator-visible commit error at the feed-server root rather than the binding.
 //
 // This gate replicates resolveBaseURL's emptiness condition directly on the
 // FeedServer config struct (feedServerBaseURLEmpty) rather than importing
@@ -149,9 +153,11 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 // warning (opts.lenientDynamicAddressFeedRef, shared with the feed-name
 // cross-reference gate) so an already-persisted or peer-synced config carrying
 // an endpoint-less server still boots — the runtime already drops the server
-// (registers no feed), so any bound address-name is fail-closed match-none
-// rather than bricking the load (#1960 / #3261 class). Commit / commit-check
-// stay strict. Mirrors validateLogProfileStreamReferencesStrict.
+// (registers no feed), so any bound address-name is unresolvable and fails
+// CLOSED (#5645: omitted -> __unsupported_address__ -> whole-snapshot preflight
+// reject -> previous-good/default-deny) rather than bricking the load (#1960 /
+// #3261 class). Commit / commit-check stay strict. Mirrors
+// validateLogProfileStreamReferencesStrict.
 func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
 	if cfg == nil {
 		return nil
@@ -179,8 +185,11 @@ func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
 			}
 			return fmt.Errorf("security dynamic-address feed-server %q resolves "+
 				"to an empty endpoint (no url or hostname, or a slash-only url) "+
-				"so it registers no feeds — any address-name bound to it "+
-				"silently matches nothing; set a valid url or hostname",
+				"so it registers no feeds — any address-name bound to it is "+
+				"unresolvable and fails CLOSED at runtime (omitted -> "+
+				"__unsupported_address__ -> whole-snapshot preflight reject -> "+
+				"previous-good/default-deny, #5645), not silently match-none; "+
+				"set a valid url or hostname",
 				display)
 		}
 		// #5183: a NON-empty but MALFORMED base url (e.g. `http://%`, a
@@ -195,8 +204,10 @@ func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
 		// runtime uses so a garbage endpoint is operator-visible at commit
 		// instead of silently non-functional. Tolerant load / peer-sync
 		// downgrades to a warning via the shared lenient wrapper at the call
-		// site (the runtime is already fail-closed match-none for the dead
-		// feed, so a leniently-loaded config still boots — #1960 / #3261).
+		// site (the runtime is already fail-closed for the dead feed — #5645:
+		// the bound name is omitted -> __unsupported_address__ -> whole-snapshot
+		// preflight reject -> previous-good/default-deny — so a leniently-loaded
+		// config still boots, #1960 / #3261).
 		if reason := feedServerBaseURLUnconstructible(feedServerResolvedBaseURL(fs)); reason != "" {
 			display := fs.Name
 			if display == "" {
@@ -210,7 +221,9 @@ func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
 			return fmt.Errorf("security dynamic-address feed-server %q base url "+
 				"%q is malformed (%s) — http.NewRequestWithContext fails before "+
 				"any fetch, so it registers no feeds and any address-name bound "+
-				"to it silently matches nothing; set a valid http(s) url or hostname",
+				"to it is unresolvable and fails CLOSED at runtime (omitted -> "+
+				"__unsupported_address__ -> whole-snapshot preflight reject, "+
+				"#5645), not silently match-none; set a valid http(s) url or hostname",
 				display, RedactURL(feedServerResolvedBaseURL(fs)), reason)
 		}
 	}
@@ -472,10 +485,14 @@ func validateDynamicAddressFeedReferencesStrict(cfg *Config) error {
 				continue
 			}
 			return fmt.Errorf("security dynamic-address address-name %q "+
-				"profile references undefined feed-name %q (the binding would "+
-				"resolve to an empty address set — a feed-backed policy would "+
-				"silently match nothing; declare the feed under a "+
-				"dynamic-address feed-server or fix the feed-name)", ab.Name, fn)
+				"profile references undefined feed-name %q (the binding is "+
+				"unresolvable, so at runtime it is OMITTED and lowers to the "+
+				"__unsupported_address__ sentinel; the userspace snapshot "+
+				"preflight then REJECTS the whole publication and the dataplane "+
+				"retains previous-good or fresh-boot default-deny — the "+
+				"feed-backed policy fails CLOSED, it does NOT silently match "+
+				"nothing (#5645); declare the feed under a dynamic-address "+
+				"feed-server or fix the feed-name)", ab.Name, fn)
 		}
 	}
 	return nil

--- a/pkg/config/compiler_validate_strict_observability.go
+++ b/pkg/config/compiler_validate_strict_observability.go
@@ -198,8 +198,10 @@ func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
 		// the runtime issues — feeds.Manager.readFeed does
 		// http.NewRequestWithContext(ctx, "GET", fs.url, nil), which errors
 		// BEFORE any I/O, so the feed registers no content and any deny policy
-		// bound to that address-name enforces an empty (match-nothing) set — the
-		// #3300 fail-open one layer up from the emptiness case. Validate the
+		// bound to that address-name is unresolvable and fails CLOSED (#5645:
+		// omitted -> __unsupported_address__ -> whole-snapshot preflight reject
+		// -> previous-good/default-deny) — historically the #3300 fail-open
+		// symptom one layer up from the emptiness case, now caught. Validate the
 		// resolved base url with the SAME request-construction semantics the
 		// runtime uses so a garbage endpoint is operator-visible at commit
 		// instead of silently non-functional. Tolerant load / peer-sync


### PR DESCRIPTION
## Summary

Triages and drives the codex-review-182 **C-CONFIG** cohort (#5717) — the
low-materiality config-side survivors bucketed as "config parity /
tolerant-load / test-coverage". STEP-0 verified every sub-item firsthand on
current `origin/master`; this PR fixes the three real + driveable + low-risk
ones and dispositions the rest.

## Per-item triage

| Item (codex-182) | Verdict | Action |
|---|---|---|
| **A3-b00-C001** copy half — `CopyPath` first-keyword `insertNode` picks wrong same-keyword sibling | **already-fixed** | Fixed by #5822 (`CopyPath` now routes through `findNodeWithParent`/`childrenAtPath`; `insertNode` removed). No code. |
| **A3-b00-C001** display half — `FormatPathSet` scoped display-set drops an ancestor token when an ancestor argument equals the terminal node's first key | **real + fixed** | Strip terminal keys from the RIGHT (suffix-aligned) instead of first-key search from the LEFT. |
| **C2** — signed-port NAT test masked by the #5628 missing-action gate | **real + fixed** | Add a valid terminal action + assert the specific signed-port diagnostic (strict error + lenient warning). |
| **C3** — #5645 feed posture correction left stale fail-open operator diagnostics | **real + fixed** | Rewrite the 3 feed errors + sibling comments to the #5645 fail-closed sequence + an error-message assertion. |
| **C1** — lenient contradictory NAT semantics drift across upgrade/HA failover | **real, deferred** | Needs a migration-contract design decision and is HA/Rust-precedence coupled (out of a low-risk config PR; would also require `test-failover`). Note for separate handling. |
| **C4** — #5630 tests don't execute the real strongSwan parser/load boundary | **real gap, deferred** | Requires a hermetic `swanctl`/`charon` integration job; that toolchain is absent from this environment. Test-infra follow-up. |

## Fixes

1. **Scoped display-set drops an ancestor token** (`ast_format.go`).
   `FormatPathSet` rebuilt the parent prefix by scanning the scoped path
   left-to-right for the first token equal to the matched node's first key.
   An ancestor argument equal to that key truncated the prefix — a zone NAMED
   `interfaces` holding an `interfaces` stanza rendered
   `set security zones security-zone interfaces ge-0/0/9.0` (one `interfaces`
   missing), a malformed line that reloads as a different object. Now strips
   the node's keys from the right by suffix alignment. Display-side twin of
   the copy-side #5822 fix.

2. **Signed-port NAT test unmask** (`compiler_signed_port_3606_test.go`).
   The nat-match `+80` fixture was actionless, so the #5628
   missing-terminal-action gate rejected it regardless of the signed-port
   gate — a NAT port-parse regression would stay green. Added a valid
   `then destination-nat off` action and per-case specific-diagnostic
   assertions on strict + lenient paths.

3. **Feed diagnostics fail-closed alignment** (`compiler_validate_strict_observability.go`,
   `compiler_uniformgates.go`). The undefined-feed-name, endpoint-less-server,
   and malformed-url errors (plus sibling gate/validator comments) still
   described the pre-#5645 fail-open framing ("would silently match nothing").
   The runtime is fail-CLOSED (omitted -> `__unsupported_address__` ->
   whole-snapshot preflight reject -> previous-good/default-deny). Rewrote them
   + added an error-message assertion that keeps the diagnostics in sync with a
   future posture change.

## Fail-on-revert tests

| Test | RED-on-revert neutralization |
|---|---|
| `TestFormatPathSetAncestorEqualsKey_5717` / `TestFormatPathSetPolicyNameEqualsKey_5717` | Restore the left-to-right first-key prefix search → the ancestor token is dropped from the emitted `set` line. |
| `TestSignedPortRejectedAtCommit_3606/nat-match-destination-port-plus` | Revert the NAT match dport parse (`parseDNATPortList`) to permissively accept a leading `+` → with the terminal action present, strict compile ACCEPTS. (Also verified the old actionless fixture stays green under the same regression — i.e. the terminal-action addition is load-bearing.) |
| `TestFeedDiagnosticsAreFailClosed_5717` | Restore the pre-#5645 `silently match nothing` / `resolve to an empty address set` error text → the fails-CLOSED / `__unsupported_address__` substring assertions fail. |

## Validation

- `go test ./pkg/config/... ./pkg/configstore/... ./pkg/cmdtree/...` — all pass.
- `go vet ./pkg/config/...` clean; `gofmt` clean.
- Each fix verified RED-on-revert (details above).
- Docs: `docs/config-schema.md` gains a scoped display-set prefix note. C1/C4
  are deferred with reasons; no other doc change needed (the enforcement
  behavior for C3 was already documented under #5645 — only diagnostics moved).

Advances #5717 (fixes the display half of A3-b00-C001, C2, C3; C1 and C4
deferred with reasons above; the copy half of A3-b00-C001 was already fixed by
#5822).