### PR TITLE
grpcapi/api: C-API diagnostic + TLS hygiene hardening (advances #5719)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57908,3 +57908,23 @@ top.
   **File(s)**: pkg/grpcapi/server_nat.go,
     pkg/grpcapi/server_nat_selector_5719_test.go, pkg/api/server.go,
     pkg/api/tls_san_5719_test.go, pkg/api/README.md
+- **Timestamp**: 2026-07-23
+  **Action**: #5719 PR #6373 fold — hardened the cert-SAN fix per reviewer
+    convergence (rev + Codex). FOLD-1: guard the kernel hostname before
+    placing it in DNSNames (`isDNSSANSafeHostname`) — a non-ASCII hostname
+    (e.g. "café") HARD-FAILS x509.CreateCertificate (IA5String), which under
+    the #5058 all-or-nothing management-server lifecycle would tear down the
+    whole HTTP+HTTPS server; it now degrades to loopback-only SANs. FOLD-2:
+    an IP-literal hostname goes to IPAddresses via net.ParseIP, not DNSNames
+    (a DNS SAN of an IP never verifies as an IP). localhost + 127.0.0.1/::1
+    are ALWAYS present. Added a `tlsHostname` seam so tests drive the branches
+    deterministically. FOLD-3: strengthened tls_san_5719_test.go — asserts the
+    hostname SAN for a valid hostname, non-ASCII/control-char/empty degrade to
+    loopback without aborting cert-gen, IP-literal lands in IP SANs; plus a
+    direct isDNSSANSafeHostname unit table. DOC: corrected pkg/api/README.md to
+    state accurately that this covers loopback + local hostname/localhost only,
+    and marked the mgmt-interface-IP SAN + host-name-change re-mint as tracked
+    #5719 C001 residuals. RED-on-revert verified per fold. go test
+    ./pkg/api/... ./pkg/grpcapi/... green; vet + gofmt clean.
+  **File(s)**: pkg/api/server.go, pkg/api/tls_san_5719_test.go,
+    pkg/api/tls_test.go, pkg/api/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -57890,3 +57890,21 @@ top.
     pkg/config/compiler_validate_strict_observability.go,
     pkg/config/compiler_feed_diag_failclosed_5717_test.go,
     docs/config-schema.md
+- **Timestamp**: 2026-07-23
+  **Action**: #5719 (codex-review-182 C-API cohort) — fixed two independent
+    diagnostic/automation-hardening survivors. (1) gRPC `GetNATRuleStats`
+    now rejects an unknown `nat_type` selector with `codes.InvalidArgument`
+    instead of falling through both branches to a false-empty "no NAT rules"
+    response (a typo like `src`/`static` was indistinguishable from an empty
+    firewall). (2) The auto-generated HTTPS self-signed cert now carries
+    Subject Alternative Names (DNS: hostname + localhost; IP: 127.0.0.1 / ::1)
+    — a CN-only cert is rejected by every modern TLS client. An
+    already-persisted SAN-less cert is NOT auto-regenerated (preserves the
+    #1916 D6 TOFU-pin durability contract). Both fixes have fail-on-revert
+    tests. The third representative survivor (applied-nft truth projection
+    gaps) is an observability extension of #5644 requiring a daemon-side
+    applied-generation latch — out of the pkg/grpcapi/api/cli API-surface
+    scope; deferred, not fixed.
+  **File(s)**: pkg/grpcapi/server_nat.go,
+    pkg/grpcapi/server_nat_selector_5719_test.go, pkg/api/server.go,
+    pkg/api/tls_san_5719_test.go, pkg/api/README.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -328,16 +328,34 @@ under the daemon's errgroup. Nothing else imports this package.
     entry point.
   - The auto-generated HTTPS cert (`generateSelfSignedCertAt`, used when no
     operator cert is provisioned) carries Subject Alternative Names, not just a
-    CommonName (#5719, codex-review-182 C-API TLS hygiene): the DNS SANs
-    `hostname` + `localhost` and the loopback IP SANs `127.0.0.1` / `::1`.
-    Every modern TLS client (Go's own client since 1.15, browsers, curl)
-    rejects a SAN-less cert for hostname verification, so a CN-only cert broke
-    `curl https://localhost:8443` / health probes even though the bind
-    succeeded. An already-persisted SAN-less cert is NOT auto-regenerated — the
-    #1916 D6 durable-cert contract keeps the on-disk pair stable so remote
-    clients' TOFU pins survive a power loss; only freshly generated certs gain
-    SANs (delete `cert.pem`/`key.pem` to force a regenerate). Pinned by
-    `tls_san_5719_test.go`, fail-on-revert.
+    CommonName (#5719, codex-review-182 C-API TLS hygiene). Every modern TLS
+    client (Go's own client since 1.15, browsers, curl) rejects a SAN-less
+    cert for hostname verification, so a CN-only cert broke `curl
+    https://localhost:8443` / health probes even though the bind succeeded.
+    What the SANs cover, precisely:
+    - **Always present:** the loopback IP SANs `127.0.0.1` / `::1` and the DNS
+      SAN `localhost` — so a **loopback-bound** HTTPS API (the default) always
+      verifies. These can never fail to encode.
+    - **Best-effort:** the kernel hostname. A valid ASCII hostname is added as
+      a DNS SAN; an IP-literal hostname is added to the IP SANs (a DNS SAN of
+      an IP never verifies as an IP). A **non-ASCII / malformed** hostname
+      (e.g. a `café` kernel hostname) is DROPPED, not appended — x509 marshals
+      DNS SANs as an IA5String and HARD-FAILS on non-ASCII, which under the
+      #5058 all-or-nothing management-server lifecycle would abort cert
+      generation and tear down the entire HTTP+HTTPS server. The cert degrades
+      to loopback-only SANs (`isDNSSANSafeHostname` guard) instead of failing.
+    - **NOT covered (tracked #5719 C001 residual):** the configured
+      management-interface IP is not added to the SANs, so
+      remote-verification-by-mgmt-IP (`https://<mgmt-ip>:8443` with strict
+      verification) is out of scope here; and a later host-name change does
+      NOT re-mint the cert. Both need the resolved bind address threaded into
+      cert generation and a mint-ordering fix — deferred.
+    An already-persisted SAN-less cert is NOT auto-regenerated — the #1916 D6
+    durable-cert contract keeps the on-disk pair stable so remote clients' TOFU
+    pins survive a power loss; only freshly generated certs gain SANs (delete
+    `cert.pem`/`key.pem` to force a regenerate). Pinned by
+    `tls_san_5719_test.go` (SAN presence, hostname classification, and the
+    non-ASCII no-abort guard), fail-on-revert.
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -674,6 +674,14 @@ under the daemon's errgroup. Nothing else imports this package.
   security nat source pool` renders the gRPC value directly. Pinned by
   `TestNATPoolStatsHandlerInterfaceModePerRuleSet` (REST) and
   `TestGetNATPoolStatsInterfaceModePerRuleSet` (gRPC), both fail-on-revert.
+- The gRPC `GetNATRuleStats` `nat_type` selector fails CLOSED (#5719,
+  codex-review-182 C-API). Only `""` (default = source), `"source"`, and
+  `"destination"` select a rule family; any other value (a typo like `"src"`
+  or `"static"`) is rejected with `codes.InvalidArgument` rather than falling
+  through both branches to an empty "no NAT rules" response — a false-empty
+  diagnostic indistinguishable from a firewall with no rules. Same discipline
+  as the show routing/zones/firewall unknown-selector diagnostics. Pinned by
+  `TestGetNATRuleStatsRejectsUnknownSelector` (gRPC), fail-on-revert.
 - Query-filter parsing fails CLOSED, matching the gRPC contract
   (#2934/#2935/#2939). A filter sentinel of `0`/`""` means "no filter",
   so a *malformed* filter value must error rather than silently fall

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -326,6 +326,18 @@ under the daemon's errgroup. Nothing else imports this package.
     re-enable, HTTPS-bind-only change, HTTP-change-keeps-HTTPS, auth swap,
     bind-failure retain-old). `Run`/`serveBound` remain the single-lifecycle test
     entry point.
+  - The auto-generated HTTPS cert (`generateSelfSignedCertAt`, used when no
+    operator cert is provisioned) carries Subject Alternative Names, not just a
+    CommonName (#5719, codex-review-182 C-API TLS hygiene): the DNS SANs
+    `hostname` + `localhost` and the loopback IP SANs `127.0.0.1` / `::1`.
+    Every modern TLS client (Go's own client since 1.15, browsers, curl)
+    rejects a SAN-less cert for hostname verification, so a CN-only cert broke
+    `curl https://localhost:8443` / health probes even though the bind
+    succeeded. An already-persisted SAN-less cert is NOT auto-regenerated — the
+    #1916 D6 durable-cert contract keeps the on-disk pair stable so remote
+    clients' TOFU pins survive a power loss; only freshly generated certs gain
+    SANs (delete `cert.pem`/`key.pem` to force a regenerate). Pinned by
+    `tls_san_5719_test.go`, fail-on-revert.
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -870,6 +870,19 @@ func generateSelfSignedCertAt(dir, certPath, keyPath string) (tls.Certificate, e
 		hostname = "xpf"
 	}
 
+	// Subject Alternative Names. A cert that carries only a CommonName and no
+	// SANs is rejected for hostname verification by every modern TLS client
+	// (Go's own client since 1.15, browsers, curl) — "x509: certificate is
+	// not valid for any names". The HTTPS API binds loopback (127.0.0.1/::1)
+	// by default and can bind a hostname-addressed non-loopback
+	// `web-management https interface`, so populate the DNS/IP SANs a local
+	// or hostname-pinned client actually matches (codex-review-182 C-API TLS
+	// hygiene). CommonName is retained for legacy display only.
+	dnsNames := []string{hostname}
+	if hostname != "localhost" {
+		dnsNames = append(dnsNames, "localhost")
+	}
+
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject:      pkix.Name{CommonName: hostname, Organization: []string{"xpf"}},
@@ -877,6 +890,8 @@ func generateSelfSignedCertAt(dir, certPath, keyPath string) (tls.Certificate, e
 		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour), // 10 years
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     dnsNames,
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 	}
 
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -812,13 +812,43 @@ const (
 )
 
 // TLS persistence test seams (#1916 injected-failure tests). Production
-// code must never mutate these.
+// code must never mutate these. tlsHostname is the SAN-source seam (#5719):
+// tests drive the non-ASCII / IP-shaped hostname branches deterministically
+// without mutating the machine's real hostname.
 var (
 	tlsMkdirAllDurable  = fsatomic.MkdirAllDurable
 	tlsRemove           = os.Remove
 	tlsSyncDir          = fsatomic.SyncDir
 	tlsWriteFileDurable = fsatomic.WriteFileDurable
+	tlsHostname         = os.Hostname
 )
+
+// isDNSSANSafeHostname reports whether h is safe to place in a certificate DNS
+// SAN. It must be non-empty, contain only ASCII letters, digits, hyphen, and
+// dot (the characters x509 can encode as an IA5String and that make a
+// well-formed DNS name), and not be an IP literal (an IP-shaped hostname
+// belongs in IPAddresses, not DNSNames). A hostname that fails this check is
+// dropped from the SAN set rather than fed to x509.CreateCertificate, which
+// HARD-FAILS on a non-ASCII DNS name and — under the #5058 all-or-nothing
+// management-server lifecycle — would abort cert generation and tear down the
+// entire HTTP+HTTPS server.
+func isDNSSANSafeHostname(h string) bool {
+	if h == "" {
+		return false
+	}
+	if net.ParseIP(h) != nil {
+		return false // IP literal → belongs in IPAddresses
+	}
+	for _, r := range h {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9', r == '-', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
 
 // generateSelfSignedCert creates or loads a self-signed TLS certificate
 // using the production /etc/xpf/tls paths. See generateSelfSignedCertAt.
@@ -865,33 +895,50 @@ func generateSelfSignedCertAt(dir, certPath, keyPath string) (tls.Certificate, e
 		return tls.Certificate{}, err
 	}
 
-	hostname, _ := os.Hostname()
-	if hostname == "" {
-		hostname = "xpf"
+	hostname, _ := tlsHostname()
+	cn := hostname
+	if cn == "" {
+		cn = "xpf"
 	}
 
 	// Subject Alternative Names. A cert that carries only a CommonName and no
 	// SANs is rejected for hostname verification by every modern TLS client
 	// (Go's own client since 1.15, browsers, curl) — "x509: certificate is
-	// not valid for any names". The HTTPS API binds loopback (127.0.0.1/::1)
-	// by default and can bind a hostname-addressed non-loopback
-	// `web-management https interface`, so populate the DNS/IP SANs a local
-	// or hostname-pinned client actually matches (codex-review-182 C-API TLS
-	// hygiene). CommonName is retained for legacy display only.
-	dnsNames := []string{hostname}
-	if hostname != "localhost" {
-		dnsNames = append(dnsNames, "localhost")
+	// not valid for any names". Always include the loopback names/addresses:
+	// the HTTPS API binds loopback (127.0.0.1/::1) by default and these can
+	// never fail to encode (codex-review-182 C-API TLS hygiene). This covers
+	// a loopback-bound API and local hostname/localhost verification; it does
+	// NOT add the configured management-interface IP (remote-verification-by-
+	// mgmt-IP) — that is a tracked #5719 C001 residual.
+	dnsNames := []string{"localhost"}
+	ipSANs := []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+
+	// Add the kernel hostname as a SAN only when it is safe to encode. A valid
+	// ASCII DNS hostname goes in DNSNames; an IP-literal hostname goes in
+	// IPAddresses (a DNS SAN of an IP never verifies as an IP). A non-ASCII or
+	// otherwise malformed hostname is DROPPED, not appended: x509.Create-
+	// Certificate marshals DNSNames as an IA5String and HARD-FAILS on a
+	// non-ASCII name (e.g. a "café" kernel hostname). Under the #5058 all-or-
+	// nothing management-server lifecycle that abort would tear down the whole
+	// HTTP+HTTPS server, so degrade to loopback-only SANs instead of failing
+	// cert generation.
+	if ip := net.ParseIP(hostname); ip != nil {
+		if !ip.IsLoopback() { // loopback IPs already present above
+			ipSANs = append(ipSANs, ip)
+		}
+	} else if hostname != "localhost" && isDNSSANSafeHostname(hostname) {
+		dnsNames = append(dnsNames, hostname)
 	}
 
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: hostname, Organization: []string{"xpf"}},
+		Subject:      pkix.Name{CommonName: cn, Organization: []string{"xpf"}},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour), // 10 years
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		DNSNames:     dnsNames,
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		IPAddresses:  ipSANs,
 	}
 
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)

--- a/pkg/api/tls_san_5719_test.go
+++ b/pkg/api/tls_san_5719_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"crypto/x509"
+	"net"
+	"testing"
+)
+
+// TestGenerateSelfSignedCertHasSANs is a FAIL-ON-REVERT guard for the #5719
+// (codex-review-182 C-API) SAN-less-generated-cert TLS hygiene gap.
+//
+// The auto-generated HTTPS cert previously carried only a CommonName and no
+// Subject Alternative Names. Every modern TLS client (Go's own client since
+// 1.15, browsers, curl) rejects a SAN-less cert for hostname verification with
+// "x509: certificate is not valid for any names". The fix populates the DNS
+// SANs (hostname + localhost) and the loopback IP SANs (127.0.0.1, ::1) that a
+// local or hostname-pinned client actually matches.
+//
+// RED on revert: drop the DNSNames/IPAddresses fields from the cert template
+// and VerifyHostname / the SAN-presence assertions below fail.
+func TestGenerateSelfSignedCertHasSANs(t *testing.T) {
+	resetTLSSeams(t)
+	dir, certPath, keyPath := tlsPaths(t)
+
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("no certificate produced")
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+
+	// A DNS SAN must be present (not just a CommonName).
+	if len(leaf.DNSNames) == 0 {
+		t.Fatal("generated cert has no DNS SANs; modern TLS clients reject CN-only certs")
+	}
+
+	// localhost must be a valid name — the API binds loopback by default, so a
+	// local client (curl https://localhost:8443, health probes) must verify.
+	if err := leaf.VerifyHostname("localhost"); err != nil {
+		t.Fatalf("VerifyHostname(localhost) = %v; want valid (cert lacks a localhost SAN)", err)
+	}
+
+	// The loopback IP SANs must be present so an IP-addressed local client
+	// (https://127.0.0.1:8443) also verifies.
+	if err := leaf.VerifyHostname("127.0.0.1"); err != nil {
+		t.Fatalf("VerifyHostname(127.0.0.1) = %v; want valid (cert lacks a 127.0.0.1 IP SAN)", err)
+	}
+	var hasV6Loopback bool
+	for _, ip := range leaf.IPAddresses {
+		if ip.Equal(net.IPv6loopback) {
+			hasV6Loopback = true
+			break
+		}
+	}
+	if !hasV6Loopback {
+		t.Fatalf("generated cert IP SANs %v missing ::1", leaf.IPAddresses)
+	}
+}

--- a/pkg/api/tls_san_5719_test.go
+++ b/pkg/api/tls_san_5719_test.go
@@ -6,58 +6,167 @@ import (
 	"testing"
 )
 
-// TestGenerateSelfSignedCertHasSANs is a FAIL-ON-REVERT guard for the #5719
-// (codex-review-182 C-API) SAN-less-generated-cert TLS hygiene gap.
-//
-// The auto-generated HTTPS cert previously carried only a CommonName and no
-// Subject Alternative Names. Every modern TLS client (Go's own client since
-// 1.15, browsers, curl) rejects a SAN-less cert for hostname verification with
-// "x509: certificate is not valid for any names". The fix populates the DNS
-// SANs (hostname + localhost) and the loopback IP SANs (127.0.0.1, ::1) that a
-// local or hostname-pinned client actually matches.
-//
-// RED on revert: drop the DNSNames/IPAddresses fields from the cert template
-// and VerifyHostname / the SAN-presence assertions below fail.
-func TestGenerateSelfSignedCertHasSANs(t *testing.T) {
+// certLeaf generates a fresh self-signed cert with tlsHostname pinned to
+// hostname and returns the parsed leaf. It fails the test if cert generation
+// returns an error — the point of most #5719 cases is that a weird hostname
+// must NOT abort generation.
+func certLeaf(t *testing.T, hostname string) *x509.Certificate {
+	t.Helper()
 	resetTLSSeams(t)
+	tlsHostname = func() (string, error) { return hostname, nil }
 	dir, certPath, keyPath := tlsPaths(t)
-
 	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
 	if err != nil {
-		t.Fatalf("generate: %v", err)
+		t.Fatalf("hostname=%q: cert generation aborted: %v", hostname, err)
 	}
 	if len(cert.Certificate) == 0 {
-		t.Fatal("no certificate produced")
+		t.Fatalf("hostname=%q: no certificate produced", hostname)
 	}
 	leaf, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		t.Fatalf("parse leaf: %v", err)
+		t.Fatalf("hostname=%q: parse leaf: %v", hostname, err)
 	}
+	return leaf
+}
 
-	// A DNS SAN must be present (not just a CommonName).
+func hasIPSAN(leaf *x509.Certificate, ip net.IP) bool {
+	for _, s := range leaf.IPAddresses {
+		if s.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDNSSAN(leaf *x509.Certificate, name string) bool {
+	for _, s := range leaf.DNSNames {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// assertLoopbackSANs is the invariant that must hold for EVERY generated cert
+// regardless of hostname: localhost DNS + 127.0.0.1 / ::1 IP SANs are always
+// present, so a loopback-bound HTTPS client always verifies.
+func assertLoopbackSANs(t *testing.T, leaf *x509.Certificate) {
+	t.Helper()
 	if len(leaf.DNSNames) == 0 {
 		t.Fatal("generated cert has no DNS SANs; modern TLS clients reject CN-only certs")
 	}
-
-	// localhost must be a valid name — the API binds loopback by default, so a
-	// local client (curl https://localhost:8443, health probes) must verify.
 	if err := leaf.VerifyHostname("localhost"); err != nil {
 		t.Fatalf("VerifyHostname(localhost) = %v; want valid (cert lacks a localhost SAN)", err)
 	}
-
-	// The loopback IP SANs must be present so an IP-addressed local client
-	// (https://127.0.0.1:8443) also verifies.
 	if err := leaf.VerifyHostname("127.0.0.1"); err != nil {
 		t.Fatalf("VerifyHostname(127.0.0.1) = %v; want valid (cert lacks a 127.0.0.1 IP SAN)", err)
 	}
-	var hasV6Loopback bool
-	for _, ip := range leaf.IPAddresses {
-		if ip.Equal(net.IPv6loopback) {
-			hasV6Loopback = true
-			break
-		}
-	}
-	if !hasV6Loopback {
+	if !hasIPSAN(leaf, net.IPv6loopback) {
 		t.Fatalf("generated cert IP SANs %v missing ::1", leaf.IPAddresses)
+	}
+}
+
+// TestGenerateSelfSignedCertHasSANs is a FAIL-ON-REVERT guard for the #5719
+// (codex-review-182 C-API) SAN-less-generated-cert TLS hygiene gap: the
+// generated HTTPS cert must carry Subject Alternative Names, not just a
+// CommonName. A SAN-less cert is rejected by every modern TLS client for
+// hostname verification ("x509: certificate is not valid for any names").
+//
+// RED on revert: drop the DNSNames/IPAddresses fields from the cert template
+// and assertLoopbackSANs fails.
+func TestGenerateSelfSignedCertHasSANs(t *testing.T) {
+	// A plain ASCII hostname must appear as a DNS SAN alongside the loopback
+	// SANs (this is the "hostname SAN is present for a valid hostname"
+	// assertion the review asked for).
+	leaf := certLeaf(t, "fw-node0")
+	assertLoopbackSANs(t, leaf)
+	if !hasDNSSAN(leaf, "fw-node0") {
+		t.Fatalf("valid hostname not in DNS SANs %v", leaf.DNSNames)
+	}
+	if leaf.Subject.CommonName != "fw-node0" {
+		t.Fatalf("CommonName = %q, want fw-node0", leaf.Subject.CommonName)
+	}
+}
+
+// TestGenerateSelfSignedCertHostnameSANClassification is a FAIL-ON-REVERT
+// guard for the #5719 FOLD-1/FOLD-2 hostname-guard: a non-ASCII kernel
+// hostname must NOT abort cert generation (x509 marshals DNSNames as an
+// IA5String and HARD-FAILS on non-ASCII — under the #5058 all-or-nothing
+// management-server lifecycle that would tear down the whole HTTP+HTTPS
+// server), and an IP-literal hostname must land in IPAddresses (a DNS SAN of
+// an IP never verifies as an IP), never in DNSNames.
+//
+// RED on revert:
+//   - Remove the isDNSSANSafeHostname guard (append the raw hostname to
+//     DNSNames): the "café" / "fw_node\n" cases make generateSelfSignedCertAt
+//     return an IA5String error → certLeaf's t.Fatalf fires.
+//   - Remove the net.ParseIP → IPAddresses branch: the "10.9.9.9" case has no
+//     10.9.9.9 IP SAN (and, if appended to DNSNames instead, VerifyHostname on
+//     the IP still fails), tripping the assertions below.
+func TestGenerateSelfSignedCertHostnameSANClassification(t *testing.T) {
+	t.Run("non_ascii_hostname_degrades_to_loopback", func(t *testing.T) {
+		leaf := certLeaf(t, "café")
+		assertLoopbackSANs(t, leaf)
+		if hasDNSSAN(leaf, "café") {
+			t.Fatal("non-ASCII hostname must not be a DNS SAN")
+		}
+		// CommonName may legally carry the raw (UTF-8) hostname.
+		if leaf.Subject.CommonName != "café" {
+			t.Fatalf("CommonName = %q, want café", leaf.Subject.CommonName)
+		}
+	})
+
+	t.Run("control_char_hostname_degrades_to_loopback", func(t *testing.T) {
+		leaf := certLeaf(t, "fw_node\n")
+		assertLoopbackSANs(t, leaf)
+		if len(leaf.DNSNames) != 1 || leaf.DNSNames[0] != "localhost" {
+			t.Fatalf("malformed hostname must degrade to localhost-only DNS SANs, got %v", leaf.DNSNames)
+		}
+	})
+
+	t.Run("ip_literal_hostname_goes_to_ip_sans", func(t *testing.T) {
+		leaf := certLeaf(t, "10.9.9.9")
+		assertLoopbackSANs(t, leaf)
+		if hasDNSSAN(leaf, "10.9.9.9") {
+			t.Fatal("IP-literal hostname must not be a DNS SAN")
+		}
+		if !hasIPSAN(leaf, net.ParseIP("10.9.9.9")) {
+			t.Fatalf("IP-literal hostname missing from IP SANs %v", leaf.IPAddresses)
+		}
+		if err := leaf.VerifyHostname("10.9.9.9"); err != nil {
+			t.Fatalf("VerifyHostname(10.9.9.9) = %v; want valid", err)
+		}
+	})
+
+	t.Run("empty_hostname_degrades_to_loopback", func(t *testing.T) {
+		leaf := certLeaf(t, "")
+		assertLoopbackSANs(t, leaf)
+		if leaf.Subject.CommonName != "xpf" {
+			t.Fatalf("empty hostname CommonName = %q, want xpf fallback", leaf.Subject.CommonName)
+		}
+	})
+}
+
+// TestIsDNSSANSafeHostname unit-checks the classifier directly.
+func TestIsDNSSANSafeHostname(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"fw-node0", true},
+		{"fw.example.com", true},
+		{"host123", true},
+		{"", false},
+		{"café", false},
+		{"fw_node\n", false},
+		{"has space", false},
+		{"under_score", false},
+		{"10.9.9.9", false}, // IP literal → IPAddresses, not DNSNames
+		{"::1", false},
+	}
+	for _, c := range cases {
+		if got := isDNSSANSafeHostname(c.in); got != c.want {
+			t.Errorf("isDNSSANSafeHostname(%q) = %v, want %v", c.in, got, c.want)
+		}
 	}
 }

--- a/pkg/api/tls_test.go
+++ b/pkg/api/tls_test.go
@@ -26,6 +26,7 @@ func resetTLSSeams(t *testing.T) {
 		tlsRemove = os.Remove
 		tlsSyncDir = fsatomic.SyncDir
 		tlsWriteFileDurable = fsatomic.WriteFileDurable
+		tlsHostname = os.Hostname
 	})
 }
 

--- a/pkg/grpcapi/server_nat.go
+++ b/pkg/grpcapi/server_nat.go
@@ -213,6 +213,20 @@ func (s *Server) GetNATPoolStats(_ context.Context, _ *pb.GetNATPoolStatsRequest
 }
 
 func (s *Server) GetNATRuleStats(_ context.Context, req *pb.GetNATRuleStatsRequest) (*pb.GetNATRuleStatsResponse, error) {
+	// Reject an unknown nat_type selector rather than silently returning an
+	// empty result. Only "" (default = source), "source", and "destination"
+	// select a NAT-rule family below; any other value (a typo like "src" or
+	// "static") would fall through BOTH branches and render as "no NAT rules"
+	// — a false-empty diagnostic indistinguishable from a firewall that
+	// genuinely has no rules. Surface the bad selector as InvalidArgument so
+	// the operator sees the typo (codex-review-182 C-API selector hardening,
+	// same discipline as the show routing/zones/firewall unknown-selector
+	// diagnostics #4589/#4814/#3696).
+	if req.NatType != "" && req.NatType != "source" && req.NatType != "destination" {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"unknown NAT stats selector nat_type=%q (want \"source\" or \"destination\")", req.NatType)
+	}
+
 	cfg := s.store.ActiveConfig()
 	if cfg == nil {
 		return &pb.GetNATRuleStatsResponse{}, nil

--- a/pkg/grpcapi/server_nat_selector_5719_test.go
+++ b/pkg/grpcapi/server_nat_selector_5719_test.go
@@ -1,0 +1,66 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestGetNATRuleStatsRejectsUnknownSelector is a FAIL-ON-REVERT guard for the
+// #5719 (codex-review-182 C-API) unknown-NAT-stats-selector diagnostic gap.
+//
+// GetNATRuleStats selects a NAT-rule family from req.NatType, honouring only
+// "" (default = source), "source", and "destination". Before the fix, any
+// other value fell through both branches and returned an EMPTY response with a
+// NIL error — a false "no NAT rules" answer indistinguishable from an empty
+// firewall. The fix rejects an unknown selector with codes.InvalidArgument.
+//
+// RED on revert: delete the selector validation in GetNATRuleStats and the
+// "bogus" / "src" / "static" cases return (empty, nil) instead of an
+// InvalidArgument error, flipping the first sub-test's want-error assertion.
+func TestGetNATRuleStatsRejectsUnknownSelector(t *testing.T) {
+	s := &Server{store: newNATStatsGRPCStore(t)}
+
+	// Unknown selectors must be rejected as InvalidArgument, not rendered as
+	// an empty result set.
+	for _, bad := range []string{"src", "static", "bogus", "SOURCE", "dest"} {
+		resp, err := s.GetNATRuleStats(context.Background(),
+			&pb.GetNATRuleStatsRequest{NatType: bad})
+		if err == nil {
+			t.Fatalf("NatType=%q: got nil error (empty result masked the typo); want InvalidArgument", bad)
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("NatType=%q: error code = %v, want InvalidArgument; err: %v", bad, status.Code(err), err)
+		}
+		if resp != nil {
+			t.Fatalf("NatType=%q: want nil response on rejected selector, got %+v", bad, resp)
+		}
+	}
+
+	// The valid selectors must still succeed. "" and "source" select the two
+	// configured source-NAT rules; "destination" is valid but empty here.
+	for _, good := range []string{"", "source", "destination"} {
+		resp, err := s.GetNATRuleStats(context.Background(),
+			&pb.GetNATRuleStatsRequest{NatType: good})
+		if err != nil {
+			t.Fatalf("NatType=%q: unexpected error: %v", good, err)
+		}
+		if resp == nil {
+			t.Fatalf("NatType=%q: nil response on valid selector", good)
+		}
+	}
+
+	// Sanity: the default/source selector actually returns the two seeded
+	// rules, so the accept path is not a vacuous pass.
+	resp, err := s.GetNATRuleStats(context.Background(), &pb.GetNATRuleStatsRequest{})
+	if err != nil {
+		t.Fatalf("default selector error: %v", err)
+	}
+	if len(resp.Rules) != 2 {
+		t.Fatalf("default selector rule count = %d, want 2", len(resp.Rules))
+	}
+}


### PR DESCRIPTION
## Summary

Triage + fix of cohort **#5719** (codex-review-182 bucket **C-API** —
diagnostic / automation API hardening survivors). Two of the three
representative survivors are real, independent, and low-risk; both are
fixed here with fail-on-revert tests. The third is coupled to daemon-side
architecture work and is deferred (dispositioned below).

## Per-item triage (STEP-0 firsthand on origin/master 4dc4798fd)

| Item | Verdict | Evidence | Disposition |
|---|---|---|---|
| Unknown NAT stats selector | **REAL + independent** | `GetNATRuleStats` honours only `nat_type` ∈ {`""`,`source`,`destination`}; `NatType:"bogus"` returns 0 rules with **nil error** (verified: source/"" return 2 rules, bogus returns 0/nil) | **FIXED** — reject unknown selector with `codes.InvalidArgument` |
| SAN-less generated cert | **REAL + independent** | `generateSelfSignedCertAt` template sets `CommonName` only; generated leaf has empty `DNSNames`/`IPAddresses`, and `VerifyHostname("localhost")` fails with "certificate is not valid for any names" (verified) | **FIXED** — add DNS SANs (hostname + localhost) and loopback IP SANs (127.0.0.1, ::1) |
| Applied-nft truth projection gaps | **REAL but COUPLED / out-of-scope** | codex-review-182 records this explicitly as "a consequence and observability extension of #5644, not a second MATERIAL root … the remediation should give the nft state owner an applied generation/error/retry latch and let readiness plus projections consume it." That latch lives in `pkg/daemon` (the direct-host nft state owner), not the API surface; the CLI/REST/gRPC projections can only *consume* a latch that does not yet exist | **DEFERRED** — daemon-architecture change outside the pkg/grpcapi/api/cli C-API scope; #5644 (the root) is CLOSED but the projection extension is unaddressed and needs separate daemon-side handling |

## Fix 1 — NAT stats selector fails closed (`grpcapi`)

`GetNATRuleStats` now rejects a `nat_type` value outside
`{"", "source", "destination"}` with `codes.InvalidArgument` instead of
falling through both branches to a false-empty "no NAT rules" response (a
typo like `src`/`static` was indistinguishable from an empty firewall).
Same strict-selector discipline as the show routing/zones/firewall
unknown-selector diagnostics.

## Fix 2 — HTTPS self-signed cert gains SANs (`api`)

The auto-generated cert carried only a CommonName; every modern TLS
client rejects a SAN-less cert for hostname verification. The template now
sets DNS SANs (`hostname`, `localhost`) and loopback IP SANs
(`127.0.0.1`, `::1`). An already-persisted SAN-less cert is **not**
auto-regenerated — the #1916 D6 durable-cert contract keeps the on-disk
pair stable so remote TOFU pins are not churned; only freshly generated
certs gain SANs.

## Tests (fail-on-revert)

- `pkg/grpcapi/server_nat_selector_5719_test.go` ::
  `TestGetNATRuleStatsRejectsUnknownSelector` — RED neutralization:
  neutering the selector guard (`if false {`) makes `src`/`static`/… return
  `(empty, nil)` → the want-`InvalidArgument` assertion fails.
- `pkg/api/tls_san_5719_test.go` ::
  `TestGenerateSelfSignedCertHasSANs` — RED neutralization: dropping the
  `DNSNames`/`IPAddresses` template fields → "generated cert has no DNS
  SANs" / `VerifyHostname` failures.

Both RED-on-revert runs verified locally. Full suites green:
`go test ./pkg/grpcapi/... ./pkg/api/... ./pkg/cli/... ./pkg/cmdtree/...`,
`go vet`, `gofmt` clean.

## Scope / safety

No AUTH surface touched — nothing here overlaps the held #5278 (per-principal
gRPC auth) or #5561 (REST config-mutation auth). Diagnostic/validation/TLS-hygiene
only; no hot path.

Advances #5719 (2 of 3 representative survivors fixed; applied-nft projection
deferred as daemon-coupled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ