### PR TITLE
cli/policymatch/image: #5720 C-TOOLS cohort — 5 tooling fixes

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57972,3 +57972,55 @@ top.
     pkg/grpcapi/server_show_firewall.go,
     pkg/grpcapi/server_show_testpolicy_unsupported_tuple_5720_test.go,
     pkg/policymatch/README.md
+
+- **Timestamp**: 2026-07-23 (rev6375 Codex-fold, findings 1/2/3/5)
+  - **Action**: Fold three verified Codex hostile-review findings + minor nits
+    into the C-TOOLS cohort (#6375 / Advances #5720).
+    - **Finding 1 (global-shadow lint FALSE-POSITIVE, fixed):**
+      `globalScopeCovers` now excludes CROSS-enforcement-path pairs. Host-inbound
+      globals (`match to-zone junos-host`, `config.IsHostToZoneScope`) and transit
+      globals are enforced on separate dataplane paths (the host gate
+      `matchJunosHost` never falls through to the transit global tier), so a
+      transit-scoped global must never be reported as shadowing a host-scoped one,
+      and vice versa. Before the fix an unscoped/`to-zone any` transit permit
+      falsely "covered" a later reachable `to-zone junos-host` deny. Fail-on-revert
+      test `TestAnalyzePolicyShadowingGlobalHostVsTransitNotShadowed` (drop the
+      `IsHostToZoneScope` guard → the host deny is falsely SHADOWED, RED-verified).
+    - **Finding 2 (global-shadow lint FALSE-NEGATIVE, fixed):** `zoneSetCovers`
+      now treats an explicit `["any"]` scope as the all-zones universal set via the
+      runtime SSOT `config.IsWildcardZoneSet` (empty OR contains "any"), matching
+      `build_global_zone_scope` in `userspace-dp/src/policy.rs`. Before, an
+      explicit-`any` global was read as a concrete one-element set and failed to
+      cover a narrower later global it in fact makes redundant. Fail-on-revert test
+      `TestAnalyzePolicyShadowingGlobalExplicitAnyScopeShadows` (restore the
+      len==0-only test → the redundancy goes unreported, RED-verified).
+    - **Finding 3 (policymatch gate folds IPv4-mapped IPv6, DOCUMENTED + FILED
+      #6377):** the #5720 unsupported-tuple gate reads family with `To4()`, which
+      folds `::ffff:192.0.2.1` to non-nil, so `::ffff:192.0.2.1 -> 2001:db8::1` is
+      falsely flagged UnsupportedTupleFamily while the colon-strict runtime sees
+      V6/V6. Verified firsthand that all four `Query` builders parse with
+      `net.ParseIP`, which makes `192.0.2.1` and `::ffff:192.0.2.1` byte-identical
+      16-byte values — the colon signal is destroyed at parse, so NO colon-strict
+      determination is available at the gate. The only correct fix threads the
+      text family (`config.NATAddrFamily`) from each caller through `Query` (a
+      cross-package API change, out of scope for this cohort). Documented precisely
+      in the gate comment + `pkg/policymatch/README.md`; filed follow-up #6377 with
+      the `compiler_nat_helpers.go` precedent and a concrete fix sketch. No
+      half-correct fix shipped. (Fail-safe: the false positive is a spurious
+      advisory, never a hidden/fabricated permit.)
+    - **Finding 5a (test coverage):** extended
+      `TestAnalyzePolicyShadowingGlobalDisjointScopeNotShadowed` with a ToZones
+      difference case (disjoint to-zone scopes must not shadow) plus an all-zones
+      to-zone positive control — the guard was previously only exercised on
+      FromZones.
+    - **Finding 5b (doc):** corrected `docs/pr/812-tx-latency-histogram/plan.md`
+      line 509 — the stale "dumps /proc/self/maps | grep vdso" claim now matches
+      the corrected `vdso_probe2.c` scope comment (probe checks AT_SYSINFO_EHDR +
+      one clock_gettime; the maps grep is a separate manual cross-check).
+    Skipped the pre-existing Makefile vet-scope nit (out of scope). Did not touch
+    the three render-surface UnsupportedTupleFamily arms (Codex finding 4 already
+    folded). `go build`/`go vet`/`gofmt -l` clean; full `go test ./pkg/cli/...`
+    and `./pkg/policymatch/...` GREEN.
+  - **File(s)**: pkg/cli/cli_request_policies_check.go,
+    pkg/cli/cli_request_policies_check_test.go, pkg/policymatch/policymatch.go,
+    pkg/policymatch/README.md, docs/pr/812-tx-latency-histogram/plan.md

--- a/_Log.md
+++ b/_Log.md
@@ -57928,3 +57928,26 @@ top.
     ./pkg/api/... ./pkg/grpcapi/... green; vet + gofmt clean.
   **File(s)**: pkg/api/server.go, pkg/api/tls_san_5719_test.go,
     pkg/api/tls_test.go, pkg/api/README.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #5720 C-TOOLS cohort triage — fixed 5 low-risk tooling
+    survivors from codex-review-182; dispositioned 2 out-of-scope. C01: extend
+    `analyzePolicyShadowing` to also lint the global-policy list
+    (`security policies global`) with a `globalScopeCovers` from/to-zone
+    containment gate (avoids false positives across disjoint global scopes).
+    C02: remove the unreachable `return nil` after the CLI REPL's infinite
+    `for {}` (go vet clean). C03: correct the `vdso_probe2.c` header comment
+    which claimed a `/proc/self/maps` cross-check it never performed. b02/C1:
+    add an up-front (V4 src, V6 dst) fail-closed gate to `policymatch.Match`
+    (`Result.UnsupportedTupleFamily` + dedicated `DisplayAction` string),
+    mirroring the runtime `policy.rs` NAT46-impossible arm. b03-C01: `validate.py`
+    cleanup retains `self.work` under `--keep` (day-0 media backing retained
+    VMs). Out-of-scope: C04 (cli_show_flow.go 1262-LOC modularity → open #5661),
+    b03-F03 (dangling `current` symlink rollback guard → PRODUCTION pkg/upgrade,
+    MATERIAL Medium → dedicated issue).
+  - **File(s)**: pkg/cli/cli.go, pkg/cli/cli_request_policies_check.go,
+    pkg/cli/cli_request_policies_check_test.go, pkg/policymatch/policymatch.go,
+    pkg/policymatch/mixed_family_tuple_5720_test.go, pkg/policymatch/README.md,
+    scripts/image/validate.py, scripts/image/test_validate_ownership.py,
+    docs/image-validation.md,
+    docs/pr/812-tx-latency-histogram/evidence/vdso_probe2.c

--- a/_Log.md
+++ b/_Log.md
@@ -57951,3 +57951,24 @@ top.
     scripts/image/validate.py, scripts/image/test_validate_ownership.py,
     docs/image-validation.md,
     docs/pr/812-tx-latency-histogram/evidence/vdso_probe2.c
+
+- **Timestamp**: 2026-07-23 (rev6375 review-fold)
+  - **Action**: Fold rev6375 MINOR (#6375 / Advances #5720): surface the
+    `UnsupportedTupleFamily` verdict on all render surfaces, not just REST +
+    gRPC `MatchPolicies`. The #5720 `Match`-side gate is transport-agnostic, but
+    only the two `DisplayAction()` callers rendered the dedicated verdict; the
+    three hand-rolled text renders (`test security policy-match`,
+    `show security match-policies`, gRPC show-firewall `test policy` bridge) fell
+    through to a fabricated `Default deny (no matching policy)` for the
+    *impossible* (V4 src, V6 dst) tuple — misleading an operator toward a NAT46
+    permit that can never take effect. Added an `if res.UnsupportedTupleFamily`
+    branch to each (mirroring their `ContentRejected` / `HostInboundUnmatched`
+    arms) that prints `res.DisplayAction()`. Render-side fail-on-revert:
+    `server_show_testpolicy_unsupported_tuple_5720_test.go` (drop the gRPC-text
+    arm → the tuple falls back to `no matching policy`, RED-verified). Pure
+    diagnostic-display consistency; fail-closed safety was already correct on
+    every surface (all deny). README render-coverage note added.
+  - **File(s)**: pkg/cli/cli_request_testcmd.go, pkg/cli/cli_show_security.go,
+    pkg/grpcapi/server_show_firewall.go,
+    pkg/grpcapi/server_show_testpolicy_unsupported_tuple_5720_test.go,
+    pkg/policymatch/README.md

--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -91,7 +91,16 @@ force-deletes ONLY objects carrying that tag (and only the alias it
 imported). So a concurrent bake, or an unrelated same-named VM/image, is
 never destroyed — before this the constant `xpf-image-validate` alias and
 `xpf-image-a…e` instances were force-deleted at import/launch/cleanup with
-no run-ID or ownership check (#4905-D). Scenarios:
+no run-ID or ownership check (#4905-D).
+
+`--keep` retains the run's instances, alias, and network for post-mortem
+inspection. It now ALSO retains the per-run scratch directory
+(`xpf-validate-<rand>`) and prints its path: scenarios attach host-side
+day-0 config drives / ISOs from that directory to the VMs, so deleting it
+while keeping the VMs would leave each retained instance referencing a
+source that can no longer be reopened on restart (codex-182 A10-b03-C01).
+
+Scenarios:
 
 | Scenario | Proves |
 |---|---|

--- a/docs/pr/812-tx-latency-histogram/evidence/vdso_probe2.c
+++ b/docs/pr/812-tx-latency-histogram/evidence/vdso_probe2.c
@@ -7,10 +7,19 @@
  * address of that mapping — a non-zero return is the kernel's
  * contract that VDSO is available to this process.
  *
+ * Scope: this probe checks only two things — that AT_SYSINFO_EHDR is
+ *        non-zero (the VDSO mapping is visible to the process) and that
+ *        clock_gettime(CLOCK_MONOTONIC) succeeds. It does NOT dump
+ *        /proc/self/maps, resolve __vdso_clock_gettime, or prove that
+ *        the call dispatched through the VDSO rather than a syscall
+ *        fallback. The sibling vdso_probe.c supplies that syscall-fallback
+ *        gate via its 10,000-call `strace` count; run it for the
+ *        dispatch-path proof this probe deliberately does not make.
+ *
  * Build:  gcc -O2 -o vdso_probe2 vdso_probe2.c
  * Output: prints the VDSO base address (must be non-zero on a
- *         seccomp profile that allows the process to observe it)
- *         and then dumps /proc/self/maps | grep vdso to cross-check.
+ *         seccomp profile that allows the process to observe it) and the
+ *         result of one clock_gettime(CLOCK_MONOTONIC) call.
  */
 #define _GNU_SOURCE
 #include <stdio.h>

--- a/docs/pr/812-tx-latency-histogram/plan.md
+++ b/docs/pr/812-tx-latency-histogram/plan.md
@@ -506,10 +506,13 @@ proportional response.
    despite 10 000 userspace calls — strace-reported proof that the
    entire loop served from VDSO.
 
-2. `evidence/vdso_probe2.c` — checks `getauxval(AT_SYSINFO_EHDR)` and
-   dumps `/proc/self/maps | grep vdso`. Pushed as a static binary to
-   the deploy VM `xpf-userspace-fw0` (Linux 7.0.0-rc7+, Debian glibc 2.42-14) and
-   run in place. Captured in `evidence/vm_xpf_userspace_fw0.txt`:
+2. `evidence/vdso_probe2.c` — checks `getauxval(AT_SYSINFO_EHDR)` is
+   non-zero and that one `clock_gettime(CLOCK_MONOTONIC)` call succeeds
+   (the probe itself does NOT dump `/proc/self/maps` — see its header
+   comment). Pushed as a static binary to the deploy VM
+   `xpf-userspace-fw0` (Linux 7.0.0-rc7+, Debian glibc 2.42-14) and run in
+   place, alongside a manual `grep vdso /proc/self/maps` cross-check.
+   Captured in `evidence/vm_xpf_userspace_fw0.txt`:
 
    ```text
    AT_SYSINFO_EHDR = 0x7fa6efce0000

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -542,7 +542,11 @@ func (c *CLI) Run() error {
 		// changes (failover) are reflected immediately.
 		c.refreshPrompt()
 	}
-	return nil
+	// The read loop above never falls through — every exit is a `return`
+	// (exitCh, io.EOF at operational level, Readline error, or errExit from
+	// dispatch). A trailing `return nil` here was unreachable and tripped
+	// `go vet` (codex-182 A10-b00-C02); Go accepts the infinite `for {}` as
+	// the function's terminating statement, so no return is needed.
 }
 
 func (c *CLI) refreshPrompt() {

--- a/pkg/cli/cli_request_policies_check.go
+++ b/pkg/cli/cli_request_policies_check.go
@@ -112,24 +112,48 @@ func analyzePolicyListShadowing(policies []*config.Policy, scope string, extraSu
 
 // globalScopeCovers reports whether global policy a's from-zone/to-zone match
 // context (#3148/#4626) covers b's — a's zone set must be a superset of b's on
-// BOTH sides, where an empty set means "all zones" (the universal set). Two
-// global policies narrowed to disjoint (or merely non-nesting) zone contexts
-// never shadow each other even when their address/application match sets nest,
-// so this gate keeps the global shadow pass free of that false positive.
+// BOTH sides, where an all-zones set means the universal set. Two global
+// policies narrowed to disjoint (or merely non-nesting) zone contexts never
+// shadow each other even when their address/application match sets nest, so this
+// gate keeps the global shadow pass free of that false positive.
+//
+// #5720 (codex): host-inbound globals (`match to-zone junos-host`,
+// config.IsHostToZoneScope) and transit globals are enforced on SEPARATE paths.
+// The dataplane host gate (matchJunosHost / evaluate_junos_host_policy_l3_aware,
+// policymatch.go ~:1247) is consulted for host-bound traffic and NEVER falls
+// through to the transit global tier, and a transit global is only reached once
+// no host policy matched. A global on one path therefore can never render a
+// global on the other unreachable, however their address/application sets or
+// zone scopes nest — so a transit-scoped global must never be reported as
+// shadowing a host-scoped (`to-zone junos-host`) global, and vice versa. Without
+// this exclusion an unscoped/`to-zone any` transit permit would falsely "cover"
+// a later reachable `to-zone junos-host` deny (an empty/`any` a covers the
+// junos-host token under zoneSetCovers).
 func globalScopeCovers(a, b *config.Policy) bool {
+	if config.IsHostToZoneScope(a.Match.ToZones) != config.IsHostToZoneScope(b.Match.ToZones) {
+		return false
+	}
 	return zoneSetCovers(a.Match.FromZones, b.Match.FromZones) &&
 		zoneSetCovers(a.Match.ToZones, b.Match.ToZones)
 }
 
-// zoneSetCovers reports whether zone set a covers zone set b: an empty a is the
-// universal set and covers everything; a non-empty a covers b only when every
-// zone in b is present in a. An empty b against a non-empty a is NOT covered —
-// b ("all zones") is the broader context.
+// zoneSetCovers reports whether zone set a covers zone set b. An all-zones a is
+// the universal set and covers everything; a non-universal a covers b only when
+// every zone in b is present in a. An all-zones b against a non-universal a is
+// NOT covered — b ("all zones") is the broader context.
+//
+// "All zones" is defined by the runtime SSOT config.IsWildcardZoneSet
+// (pkg/config/types_security.go): the empty set OR a set containing the reserved
+// token "any". Before #5720 this used len()==0 only, so an explicit `["any"]`
+// scope was treated as a concrete one-element set and diverged from the runtime
+// (build_global_zone_scope in userspace-dp/src/policy.rs maps both "" and "any"
+// to GlobalZoneScope::Any) — an explicit-`any` global then failed to cover a
+// narrower later global that it does in fact make redundant.
 func zoneSetCovers(a, b []string) bool {
-	if len(a) == 0 {
+	if config.IsWildcardZoneSet(a) {
 		return true
 	}
-	if len(b) == 0 {
+	if config.IsWildcardZoneSet(b) {
 		return false
 	}
 	set := make(map[string]struct{}, len(a))

--- a/pkg/cli/cli_request_policies_check.go
+++ b/pkg/cli/cli_request_policies_check.go
@@ -47,40 +47,101 @@ func analyzePolicyShadowing(cfg *config.Config) []string {
 		if zpp == nil {
 			continue
 		}
-		for j := 1; j < len(zpp.Policies); j++ {
-			later := zpp.Policies[j]
-			if later == nil {
+		scope := fmt.Sprintf("from-zone %s to-zone %s", zpp.FromZone, zpp.ToZone)
+		findings = analyzePolicyListShadowing(zpp.Policies, scope, nil, findings)
+	}
+	// codex-182 A10-b00-C01: global policies (`security policies global`) are
+	// an ordered, terminal, first-match list too — an earlier global shadows a
+	// later one on the same conservative name-set superset. The extra
+	// globalScopeCovers gate additionally requires the earlier global's
+	// from-zone/to-zone match context (#3148/#4626) to COVER the later's (an
+	// empty zone set = all zones), so two globals narrowed to disjoint zone
+	// contexts are never falsely reported as shadowing. Cross-tier shadowing
+	// between a zone-pair policy and a global is deliberately NOT analyzed: the
+	// global tier is reached only when no zone-pair policy matched, so a
+	// zone-pair superset is not an unreachability proof for a global.
+	findings = analyzePolicyListShadowing(cfg.Security.GlobalPolicies, "global", globalScopeCovers, findings)
+	return findings
+}
+
+// analyzePolicyListShadowing runs the conservative shadow / redundancy pass
+// over ONE ordered, terminal, first-match policy list (a single zone-pair list
+// or the global list) and appends findings tagged with scope. extraSuperset,
+// when non-nil, is an ADDITIONAL superset predicate that must also hold for a
+// shadow to be reported (used by the global list to require zone-context
+// containment on top of the address/application superset); it is nil for
+// zone-pair lists, whose zone context is fixed by the surrounding stanza.
+func analyzePolicyListShadowing(policies []*config.Policy, scope string, extraSuperset func(earlier, later *config.Policy) bool, findings []string) []string {
+	for j := 1; j < len(policies); j++ {
+		later := policies[j]
+		if later == nil {
+			continue
+		}
+		for i := 0; i < j; i++ {
+			earlier := policies[i]
+			if earlier == nil {
 				continue
 			}
-			for i := 0; i < j; i++ {
-				earlier := zpp.Policies[i]
-				if earlier == nil {
-					continue
-				}
-				if !policyMatchIsSuperset(earlier, later) {
-					continue
-				}
-				scope := fmt.Sprintf("from-zone %s to-zone %s", zpp.FromZone, zpp.ToZone)
-				if earlier.Action == later.Action &&
-					policyMatchIsSuperset(later, earlier) {
-					findings = append(findings, fmt.Sprintf(
-						"  [%s] policy %q is REDUNDANT: identical match and action to earlier policy %q",
-						scope, later.Name, earlier.Name))
-				} else if earlier.Action == later.Action {
-					findings = append(findings, fmt.Sprintf(
-						"  [%s] policy %q is REDUNDANT: earlier policy %q already matches a superset with the same action (%s)",
-						scope, later.Name, earlier.Name, policyActionName(earlier.Action)))
-				} else {
-					findings = append(findings, fmt.Sprintf(
-						"  [%s] policy %q is SHADOWED and UNREACHABLE: earlier policy %q matches a superset with a different action (%s vs %s)",
-						scope, later.Name, earlier.Name,
-						policyActionName(earlier.Action), policyActionName(later.Action)))
-				}
-				break // report the first shadower only
+			if !policyMatchIsSuperset(earlier, later) {
+				continue
 			}
+			if extraSuperset != nil && !extraSuperset(earlier, later) {
+				continue
+			}
+			if earlier.Action == later.Action &&
+				policyMatchIsSuperset(later, earlier) &&
+				(extraSuperset == nil || extraSuperset(later, earlier)) {
+				findings = append(findings, fmt.Sprintf(
+					"  [%s] policy %q is REDUNDANT: identical match and action to earlier policy %q",
+					scope, later.Name, earlier.Name))
+			} else if earlier.Action == later.Action {
+				findings = append(findings, fmt.Sprintf(
+					"  [%s] policy %q is REDUNDANT: earlier policy %q already matches a superset with the same action (%s)",
+					scope, later.Name, earlier.Name, policyActionName(earlier.Action)))
+			} else {
+				findings = append(findings, fmt.Sprintf(
+					"  [%s] policy %q is SHADOWED and UNREACHABLE: earlier policy %q matches a superset with a different action (%s vs %s)",
+					scope, later.Name, earlier.Name,
+					policyActionName(earlier.Action), policyActionName(later.Action)))
+			}
+			break // report the first shadower only
 		}
 	}
 	return findings
+}
+
+// globalScopeCovers reports whether global policy a's from-zone/to-zone match
+// context (#3148/#4626) covers b's — a's zone set must be a superset of b's on
+// BOTH sides, where an empty set means "all zones" (the universal set). Two
+// global policies narrowed to disjoint (or merely non-nesting) zone contexts
+// never shadow each other even when their address/application match sets nest,
+// so this gate keeps the global shadow pass free of that false positive.
+func globalScopeCovers(a, b *config.Policy) bool {
+	return zoneSetCovers(a.Match.FromZones, b.Match.FromZones) &&
+		zoneSetCovers(a.Match.ToZones, b.Match.ToZones)
+}
+
+// zoneSetCovers reports whether zone set a covers zone set b: an empty a is the
+// universal set and covers everything; a non-empty a covers b only when every
+// zone in b is present in a. An empty b against a non-empty a is NOT covered —
+// b ("all zones") is the broader context.
+func zoneSetCovers(a, b []string) bool {
+	if len(a) == 0 {
+		return true
+	}
+	if len(b) == 0 {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, z := range a {
+		set[z] = struct{}{}
+	}
+	for _, z := range b {
+		if _, ok := set[z]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // policyMatchIsSuperset reports whether policy a matches a superset of the

--- a/pkg/cli/cli_request_policies_check_test.go
+++ b/pkg/cli/cli_request_policies_check_test.go
@@ -168,3 +168,89 @@ func TestAnalyzePolicyShadowingScheduledEarlierIsNotShadower(t *testing.T) {
 		t.Fatalf("scheduled earlier policy must not shadow, got: %v", findings)
 	}
 }
+
+// TestAnalyzePolicyShadowingGlobal pins codex-182 A10-b00-C01: the shadow pass
+// must also analyze the ordered global policy list (`security policies
+// global`), which it previously omitted entirely. An earlier global `permit
+// any` shadows a later global `deny web`. RED on revert (drop the
+// analyzePolicyListShadowing call over GlobalPolicies): the finding disappears.
+func TestAnalyzePolicyShadowingGlobal(t *testing.T) {
+	gpol := func(name string, action config.PolicyAction, apps []string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         apps,
+			},
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		gpol("g-permit-all", config.PolicyPermit, []string{"any"}),
+		// SHADOWED: a superset permit-any precedes this deny in the same tier.
+		gpol("g-block-web", config.PolicyDeny, []string{"http"}),
+	}
+	findings := analyzePolicyShadowing(cfg)
+	joined := strings.Join(findings, "\n")
+	if !strings.Contains(joined, "g-block-web") || !strings.Contains(joined, "SHADOWED") {
+		t.Fatalf("expected global g-block-web reported SHADOWED, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "[global]") {
+		t.Fatalf("expected the finding tagged with the [global] scope, got:\n%s", joined)
+	}
+}
+
+// TestAnalyzePolicyShadowingGlobalDisjointScopeNotShadowed guards the
+// globalScopeCovers gate: two global policies narrowed to DIFFERENT from-zone
+// contexts (#3148/#4626) never shadow each other even when their
+// address/application match sets nest. RED on revert (drop the extraSuperset
+// gate for the global list): the lint falsely reports the later global
+// SHADOWED.
+func TestAnalyzePolicyShadowingGlobalDisjointScopeNotShadowed(t *testing.T) {
+	scoped := func(name string, action config.PolicyAction, fromZones []string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+				FromZones:            fromZones,
+			},
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		// earlier permit-any scoped to from-zone trust ONLY.
+		scoped("g-permit-trust", config.PolicyPermit, []string{"trust"}),
+		// later deny scoped to from-zone untrust — a DIFFERENT context, so the
+		// earlier trust-only permit cannot make it unreachable.
+		scoped("g-deny-untrust", config.PolicyDeny, []string{"untrust"}),
+	}
+	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
+		t.Fatalf("globals with disjoint from-zone scopes must not shadow, got: %v", findings)
+	}
+
+	// Control: a later global with NO from-zone scope (all zones) is BROADER
+	// than the earlier trust-only permit, so it is likewise not shadowed.
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		scoped("g-permit-trust", config.PolicyPermit, []string{"trust"}),
+		scoped("g-deny-all", config.PolicyDeny, nil),
+	}
+	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
+		t.Fatalf("an all-zones global is broader than a trust-only earlier, must not shadow, got: %v", findings)
+	}
+
+	// Control (positive): when the earlier global covers ALL zones it DOES
+	// shadow a later trust-only global of a different action.
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		scoped("g-permit-all", config.PolicyPermit, nil),
+		scoped("g-deny-trust", config.PolicyDeny, []string{"trust"}),
+	}
+	findings := analyzePolicyShadowing(cfg)
+	if len(findings) != 1 || !strings.Contains(findings[0], "g-deny-trust") || !strings.Contains(findings[0], "SHADOWED") {
+		t.Fatalf("an all-zones earlier global must shadow a trust-only later global, got: %v", findings)
+	}
+}

--- a/pkg/cli/cli_request_policies_check_test.go
+++ b/pkg/cli/cli_request_policies_check_test.go
@@ -221,6 +221,18 @@ func TestAnalyzePolicyShadowingGlobalDisjointScopeNotShadowed(t *testing.T) {
 			},
 		}
 	}
+	scopedTo := func(name string, action config.PolicyAction, toZones []string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+				ToZones:              toZones,
+			},
+		}
+	}
 	cfg := &config.Config{}
 	cfg.Security.GlobalPolicies = []*config.Policy{
 		// earlier permit-any scoped to from-zone trust ONLY.
@@ -231,6 +243,29 @@ func TestAnalyzePolicyShadowingGlobalDisjointScopeNotShadowed(t *testing.T) {
 	}
 	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
 		t.Fatalf("globals with disjoint from-zone scopes must not shadow, got: %v", findings)
+	}
+
+	// #5720 (codex, finding 5a): the guard must key on ToZones too, not only
+	// FromZones. Two transit globals narrowed to DISJOINT to-zone contexts never
+	// shadow each other even when their address/application match sets nest.
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		scopedTo("g-permit-to-untrust", config.PolicyPermit, []string{"untrust"}),
+		scopedTo("g-deny-to-dmz", config.PolicyDeny, []string{"dmz"}),
+	}
+	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
+		t.Fatalf("globals with disjoint to-zone scopes must not shadow, got: %v", findings)
+	}
+
+	// Control (positive, ToZones): an all-zones (nil) to-zone earlier global DOES
+	// shadow a later to-zone-dmz global of a different action — the ToZones
+	// dimension is exercised end-to-end, not just FromZones.
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		scopedTo("g-permit-to-any", config.PolicyPermit, nil),
+		scopedTo("g-deny-to-dmz", config.PolicyDeny, []string{"dmz"}),
+	}
+	findingsTo := analyzePolicyShadowing(cfg)
+	if len(findingsTo) != 1 || !strings.Contains(findingsTo[0], "g-deny-to-dmz") || !strings.Contains(findingsTo[0], "SHADOWED") {
+		t.Fatalf("an all-zones to-zone earlier global must shadow a to-zone-dmz later global, got: %v", findingsTo)
 	}
 
 	// Control: a later global with NO from-zone scope (all zones) is BROADER
@@ -252,5 +287,121 @@ func TestAnalyzePolicyShadowingGlobalDisjointScopeNotShadowed(t *testing.T) {
 	findings := analyzePolicyShadowing(cfg)
 	if len(findings) != 1 || !strings.Contains(findings[0], "g-deny-trust") || !strings.Contains(findings[0], "SHADOWED") {
 		t.Fatalf("an all-zones earlier global must shadow a trust-only later global, got: %v", findings)
+	}
+}
+
+// TestAnalyzePolicyShadowingGlobalHostVsTransitNotShadowed pins the #5720
+// (codex, finding 1) cross-enforcement-path exclusion in globalScopeCovers.
+// Host-inbound globals (`match to-zone junos-host`) and transit globals are
+// enforced on SEPARATE dataplane paths: the host gate (matchJunosHost) never
+// falls through to the transit global tier, and a transit global is only
+// reached once no host policy matched. So a transit-scoped global can NEVER
+// shadow a host-scoped one, and vice versa — regardless of address/application
+// superset or zone-set nesting.
+//
+// RED on revert (drop the IsHostToZoneScope guard in globalScopeCovers): the
+// unscoped transit permit's empty ToZones covers the `junos-host` token under
+// zoneSetCovers, so the reachable host deny is falsely reported SHADOWED.
+func TestAnalyzePolicyShadowingGlobalHostVsTransitNotShadowed(t *testing.T) {
+	g := func(name string, action config.PolicyAction, toZones []string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+				ToZones:              toZones,
+			},
+		}
+	}
+
+	// Transit permit (unscoped) authored BEFORE a reachable host-inbound deny:
+	// the host deny takes the separate host gate and must NOT be reported
+	// shadowed by the transit permit.
+	cfg := &config.Config{}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		g("g-transit-permit", config.PolicyPermit, nil),
+		g("g-host-deny", config.PolicyDeny, []string{"junos-host"}),
+	}
+	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
+		t.Fatalf("a transit global must not shadow a to-zone junos-host global, got: %v", findings)
+	}
+
+	// Vice versa: a host-inbound permit authored BEFORE a transit deny must not
+	// shadow it either — the transit deny is on the other enforcement path.
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		g("g-host-permit", config.PolicyPermit, []string{"junos-host"}),
+		g("g-transit-deny", config.PolicyDeny, nil),
+	}
+	if findings := analyzePolicyShadowing(cfg); len(findings) != 0 {
+		t.Fatalf("a host-inbound global must not shadow a transit global, got: %v", findings)
+	}
+
+	// Control (positive): two host-inbound globals on the SAME path DO shadow —
+	// the earlier all-from-zones permit makes the later trust-scoped deny
+	// unreachable. Confirms the guard only excludes CROSS-path pairs, not
+	// genuine same-path host shadows.
+	hostScoped := func(name string, action config.PolicyAction, fromZones []string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+				FromZones:            fromZones,
+				ToZones:              []string{"junos-host"},
+			},
+		}
+	}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		hostScoped("g-host-permit-any", config.PolicyPermit, nil),
+		hostScoped("g-host-deny-trust", config.PolicyDeny, []string{"trust"}),
+	}
+	findings := analyzePolicyShadowing(cfg)
+	if len(findings) != 1 || !strings.Contains(findings[0], "g-host-deny-trust") || !strings.Contains(findings[0], "SHADOWED") {
+		t.Fatalf("two host-inbound globals on the same path must still shadow, got: %v", findings)
+	}
+}
+
+// TestAnalyzePolicyShadowingGlobalExplicitAnyScopeShadows pins the #5720
+// (codex, finding 2) fix: zoneSetCovers must treat an explicit `["any"]` scope
+// as the all-zones universal set, matching the runtime SSOT
+// config.IsWildcardZoneSet (empty OR contains "any"). An explicit-`any`-scoped
+// earlier global therefore covers — and makes redundant — a later narrower
+// same-action global.
+//
+// RED on revert (restore the len(a)==0-only universality test in zoneSetCovers):
+// the explicit `["any"]` scope is read as a concrete one-element set, so it no
+// longer covers the trust-only later global and the redundancy goes unreported.
+func TestAnalyzePolicyShadowingGlobalExplicitAnyScopeShadows(t *testing.T) {
+	g := func(name string, action config.PolicyAction, fromZones, toZones []string) *config.Policy {
+		return &config.Policy{
+			Name:   name,
+			Action: action,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+				FromZones:            fromZones,
+				ToZones:              toZones,
+			},
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		// earlier permit scoped with the EXPLICIT reserved token "any" on both
+		// sides — the idiomatic Junos all-zones spelling.
+		g("g-permit-any", config.PolicyPermit, []string{"any"}, []string{"any"}),
+		// later permit narrowed to from-zone trust / to-zone untrust: the
+		// explicit-any earlier permit already matches its superset with the same
+		// action, so it is REDUNDANT.
+		g("g-permit-narrow", config.PolicyPermit, []string{"trust"}, []string{"untrust"}),
+	}
+	findings := analyzePolicyShadowing(cfg)
+	joined := strings.Join(findings, "\n")
+	if !strings.Contains(joined, "g-permit-narrow") || !strings.Contains(joined, "REDUNDANT") {
+		t.Fatalf("an explicit-any earlier global must make a narrower same-action later global REDUNDANT, got:\n%s", joined)
 	}
 }

--- a/pkg/cli/cli_request_testcmd.go
+++ b/pkg/cli/cli_request_testcmd.go
@@ -140,6 +140,16 @@ func (c *CLI) testPolicy(args []string) error {
 	if note := res.FragmentDenyNote(); note != "" {
 		fmt.Printf("  %s\n", note)
 	}
+	if res.UnsupportedTupleFamily {
+		// #5720 (codex-182 C-TOOLS): an IPv4 source with an IPv6 destination is
+		// an impossible tuple (NAT46 is unimplemented); the forwarding path never
+		// produces it and the runtime matcher fails closed. Surface the dedicated
+		// verdict instead of a fabricated "Default deny (no matching policy)",
+		// which would send an operator to add a permit that can never take
+		// effect. Mirrors the REST / gRPC MatchPolicies DisplayAction() render.
+		fmt.Printf("%s\n", res.DisplayAction())
+		return nil
+	}
 	if !res.Matched {
 		fmt.Printf("Default %s (no matching policy for %s -> %s)\n",
 			policymatch.ActionString(res.Action), fromZone, toZone)

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -460,6 +460,16 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	if note := res.FragmentDenyNote(); note != "" {
 		fmt.Printf("  %s\n", note)
 	}
+	if res.UnsupportedTupleFamily {
+		// #5720 (codex-182 C-TOOLS): an IPv4 source with an IPv6 destination is
+		// an impossible tuple (NAT46 is unimplemented); the forwarding path never
+		// produces it and the runtime matcher fails closed. Surface the dedicated
+		// verdict instead of a fabricated "No matching policy … (default deny)",
+		// which would send an operator to add a permit that can never take
+		// effect. Mirrors the REST / gRPC MatchPolicies DisplayAction() render.
+		fmt.Printf("%s\n", res.DisplayAction())
+		return nil
+	}
 	if !res.Matched {
 		fmt.Printf("No matching policy found for %s -> %s (default %s)\n",
 			fromZone, toZone, policymatch.ActionString(res.Action))

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -443,6 +443,15 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			if note := res.FragmentDenyNote(); note != "" {
 				fmt.Fprintf(buf, "  %s\n", note)
 			}
+		case res.UnsupportedTupleFamily:
+			// #5720 (codex-182 C-TOOLS): an IPv4 source with an IPv6 destination
+			// is an impossible tuple (NAT46 is unimplemented); the forwarding
+			// path never produces it and the runtime matcher fails closed.
+			// Surface the dedicated verdict instead of a fabricated "Default deny
+			// (no matching policy)", which would send an operator to add a permit
+			// that can never take effect. Mirrors the REST / gRPC MatchPolicies
+			// DisplayAction() render.
+			fmt.Fprintf(buf, "%s\n", res.DisplayAction())
 		default:
 			// No zone-pair or global policy matched: report the configured
 			// default-policy, NOT a hard-coded "deny" (#3103). When the

--- a/pkg/grpcapi/server_show_testpolicy_unsupported_tuple_5720_test.go
+++ b/pkg/grpcapi/server_show_testpolicy_unsupported_tuple_5720_test.go
@@ -1,0 +1,44 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestShowTestPolicyUnsupportedTupleFamily5720 pins the #5720 gRPC-text render
+// (the remote CLI `test policy` / `show security match-policies` backend): an
+// IPv4 source with an IPv6 destination is an impossible tuple (NAT46 is
+// unimplemented), so the forwarding path never produces it and the runtime
+// matcher fails closed. The ShowText handler must surface the dedicated
+// UnsupportedTupleFamily verdict, NOT a fabricated "Default deny (no matching
+// policy)" — the latter would send an operator to add a permit policy that can
+// never take effect. This binds the render-side of the #5720 policymatch gate;
+// the Match-side fail-closed verdict is bound by
+// policymatch.TestMatchRejectsV4SrcV6DstTuple.
+//
+// FAIL-ON-REVERT: dropping the `case res.UnsupportedTupleFamily` arm in
+// server_show_firewall.go makes the impossible tuple fall through to the
+// default "no matching policy" branch — the want-DisplayAction assertion (and
+// the must-NOT-contain "no matching policy" assertion) then fail.
+func TestShowTestPolicyUnsupportedTupleFamily5720(t *testing.T) {
+	// A same-family V4 tuple sanity-permits through the fixture; the mixed tuple
+	// below is what must divert to the dedicated verdict.
+	s := fragTextPolicyStore(t)
+
+	topic := "test-policy:from=trust,to=untrust,src=10.1.2.3,dst=2001:db8::1,proto=tcp"
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic})
+	if err != nil {
+		t.Fatalf("ShowText error = %v", err)
+	}
+	// The dedicated verdict names the impossible NAT46 tuple.
+	if !strings.Contains(resp.Output, "NAT46 is not implemented") {
+		t.Fatalf("V4src/V6dst tuple must render the UnsupportedTupleFamily verdict; output: %q", resp.Output)
+	}
+	// And must NOT fabricate a "(no matching policy)" default-deny verdict.
+	if strings.Contains(resp.Output, "no matching policy") {
+		t.Fatalf("impossible tuple must NOT report a fabricated (no matching policy) verdict; output: %q", resp.Output)
+	}
+}

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -501,6 +501,30 @@ dataplane reference is `userspace-dp/src/policy.rs` (`note_skipped_frag_deny` /
 `apply_frag_deny_override` / `rule_is_skipped_frag_ambiguous_deny` /
 `has_l4_constrained_term`) pinned in `userspace-dp/src/policy_tests.rs` (#4569).
 
+## Unsupported tuple family (V4 src / V6 dst) — codex-182 A10-b02-C1
+
+`matchAddr` evaluates the source and destination address sides INDEPENDENTLY,
+so a query carrying an IPv4 source with an IPv6 destination could match a rule
+per-side and yield a concrete permit/deny/default verdict for a packet shape the
+forwarding path never produces. NAT46 is not implemented, so no inbound
+translation yields a v4 source with a v6 destination, and the runtime matcher
+fails that arm closed (`userspace-dp/src/policy.rs` `try_match_rule` `_ =>
+return false`). The reverse (V6 src, V4 dst) tuple IS valid — it is the NAT64
+arm — and every same-family tuple is normal.
+
+`Match` therefore rejects the impossible tuple up front, at the single shared
+entry point every transport (CLI, REST, gRPC `MatchPolicies`) funnels through,
+so the fix covers all three without per-surface logic. When the source is IPv4
+and the destination is IPv6 (both sides specified — a nil/unspecified side is a
+wildcard and never triggers the gate), it returns a first-class
+`Result.UnsupportedTupleFamily` verdict: `Matched`/`DefaultUsed`/
+`HostInboundUnmatched`/`ContentRejected` are all false, `Action` is the
+conservative `PolicyDeny` for a raw reader, and `DisplayAction` renders the
+dedicated `UnsupportedTupleFamilyActionString`. Family is read with `To4()`, the
+same convention the host-inbound `ipFamily` helper uses. The fail-on-revert
+artifact is `mixed_family_tuple_5720_test.go`: dropping the gate makes the
+(V4 src, V6 dst) query fall through to a fabricated default verdict.
+
 ## Not modeled
 
 Scheduler-driven policy `inactive` state is not applied — a scheduled policy is

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -525,6 +525,31 @@ same convention the host-inbound `ipFamily` helper uses. The fail-on-revert
 artifact is `mixed_family_tuple_5720_test.go`: dropping the gate makes the
 (V4 src, V6 dst) query fall through to a fabricated default verdict.
 
+### Known limitation — IPv4-mapped IPv6 source is folded (#5720)
+
+The gate reads family with `net.IP.To4()`, which FOLDS an IPv4-mapped IPv6
+literal: `net.ParseIP("::ffff:192.0.2.1").To4()` is non-nil. So a source
+authored as `::ffff:192.0.2.1` against a `2001:db8::1` destination is classified
+(V4 src, V6 dst) and **falsely** reported `UnsupportedTupleFamily`, even though
+the colon-strict runtime matcher (`userspace-dp/src/policy.rs`) treats the
+mapped literal as V6 and sees a valid same-family V6/V6 tuple that should be
+evaluated normally. This is the documented Go/Rust family-parity trap: the
+authoritative colon-strict classifier is `config.NATAddrFamily` /
+`natAddrFamily` (`pkg/config/compiler_nat_helpers.go`), which keys family on the
+presence of a `':'` in the *original text* — precisely the signal `net.ParseIP`
+has already discarded by the time the gate sees `q.SrcIP`/`q.DstIP`.
+
+The limitation cannot be fixed at the gate from `q.SrcIP`/`q.DstIP` alone: all
+four `Query` builders (`cli_request_testcmd.go`, `cli_show_security.go`,
+`server_show_firewall.go`, `server_cluster.go`) parse with `net.ParseIP`, which
+makes `192.0.2.1` and `::ffff:192.0.2.1` byte-identical 16-byte values. The
+correct fix threads the colon-strict text family (`config.NATAddrFamily` on the
+raw `srcIP`/`dstIP` strings) from each caller into `Query`; that cross-package
+`Query` API change is out of scope for the #5720 tooling cohort and is filed as
+follow-up #6377. The failure mode is a spurious "unsupported tuple" advisory
+on a diagnostic surface (fail-safe — it never hides or fabricates a permit), not
+a dataplane effect.
+
 The `Match`-side gate is transport-agnostic (every surface funnels through the
 one entry point), but rendering the *dedicated verdict* to an operator is
 per-surface: the REST (`pkg/api`) and gRPC `MatchPolicies`

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -525,6 +525,24 @@ same convention the host-inbound `ipFamily` helper uses. The fail-on-revert
 artifact is `mixed_family_tuple_5720_test.go`: dropping the gate makes the
 (V4 src, V6 dst) query fall through to a fabricated default verdict.
 
+The `Match`-side gate is transport-agnostic (every surface funnels through the
+one entry point), but rendering the *dedicated verdict* to an operator is
+per-surface: the REST (`pkg/api`) and gRPC `MatchPolicies`
+(`server_cluster.go`) paths already emit `res.DisplayAction()`, so they surface
+`UnsupportedTupleFamilyActionString` for free. The three hand-rolled text
+renders — `cli_request_testcmd.go` (`test security policy-match`),
+`cli_show_security.go` (`show security match-policies`), and
+`server_show_firewall.go` (gRPC show-firewall `test policy` bridge) — each
+format the verdict fields by hand, so #5720 gives them an explicit
+`if res.UnsupportedTupleFamily` branch (mirroring their `ContentRejected` /
+`HostInboundUnmatched` arms) that prints `DisplayAction()`. Without it an
+operator on those surfaces would read an ordinary `Default deny (no matching
+policy)` for an *impossible* tuple and be tempted to add a permit that can
+never take effect. The render-side fail-on-revert artifact is
+`server_show_testpolicy_unsupported_tuple_5720_test.go`: dropping the
+gRPC-text arm makes the (V4 src, V6 dst) topic fall back to the fabricated
+`no matching policy` line.
+
 ## Not modeled
 
 Scheduler-driven policy `inactive` state is not applied — a scheduled policy is

--- a/pkg/policymatch/mixed_family_tuple_5720_test.go
+++ b/pkg/policymatch/mixed_family_tuple_5720_test.go
@@ -1,0 +1,95 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestMatchRejectsV4SrcV6DstTuple pins codex-182 A10-b02-C1: the simulator must
+// fail closed on an IPv4-source / IPv6-destination query. NAT46 is unsupported,
+// so the forwarding path never produces that tuple and the runtime matcher
+// rejects it (userspace-dp/src/policy.rs try_match_rule `_ => return false`).
+// Before the gate, Match evaluated the two address sides independently and
+// under a default-permit config returned a fabricated PERMIT for a packet shape
+// the dataplane can never see.
+//
+// RED on revert: delete the up-front (V4 src, V6 dst) guard in Match and the
+// mixed-family case returns the default PERMIT (UnsupportedTupleFamily false).
+func TestMatchRejectsV4SrcV6DstTuple(t *testing.T) {
+	// default-permit so a missing gate yields a fabricated PERMIT, not a
+	// coincidental deny.
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+	}, config.ApplicationsConfig{})
+
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.0.1.5"),    // IPv4 source
+		DstIP: net.ParseIP("2001:db8::1"), // IPv6 destination
+	})
+	if !res.UnsupportedTupleFamily {
+		t.Fatalf("expected UnsupportedTupleFamily for (V4 src, V6 dst), got res=%+v", res)
+	}
+	if res.Matched || res.DefaultUsed {
+		t.Fatalf("impossible tuple must not report a matched/default verdict, got res=%+v", res)
+	}
+	if res.Action != config.PolicyDeny {
+		t.Fatalf("raw Action for an impossible tuple must be conservative deny, got %v", res.Action)
+	}
+	if got := res.DisplayAction(); got != UnsupportedTupleFamilyActionString {
+		t.Fatalf("DisplayAction = %q, want the dedicated unsupported-tuple string", got)
+	}
+}
+
+// TestMatchAllowsValidFamilyTuples guards that the gate does NOT over-reject:
+// the reverse (V6 src, V4 dst) NAT64 arm and both same-family tuples fall
+// through to normal evaluation (here, the default-permit).
+func TestMatchAllowsValidFamilyTuples(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+	}, config.ApplicationsConfig{})
+
+	cases := []struct {
+		name     string
+		src, dst string
+	}{
+		{"v4/v4 same family", "10.0.1.5", "10.0.2.7"},
+		{"v6/v6 same family", "2001:db8::1", "2001:db8::2"},
+		{"v6 src / v4 dst (NAT64 arm)", "2001:db8::1", "10.0.2.7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := Match(cfg, Query{
+				FromZone: "trust", ToZone: "untrust",
+				SrcIP: net.ParseIP(tc.src), DstIP: net.ParseIP(tc.dst),
+			})
+			if res.UnsupportedTupleFamily {
+				t.Fatalf("%s must NOT be gated as unsupported, got res=%+v", tc.name, res)
+			}
+			if res.Action != config.PolicyPermit {
+				t.Fatalf("%s should fall through to default-permit, got %v", tc.name, res.Action)
+			}
+		})
+	}
+}
+
+// TestMatchUnspecifiedIPDoesNotTriggerGate guards that a nil (unspecified) src
+// or dst — a legal wildcard query — is never mistaken for a mixed-family tuple.
+func TestMatchUnspecifiedIPDoesNotTriggerGate(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+	}, config.ApplicationsConfig{})
+
+	// v4 source, unspecified dst.
+	if res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.0.1.5")}); res.UnsupportedTupleFamily {
+		t.Fatalf("v4 src with unspecified dst must not trigger the gate, got res=%+v", res)
+	}
+	// unspecified src, v6 dst.
+	if res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust",
+		DstIP: net.ParseIP("2001:db8::1")}); res.UnsupportedTupleFamily {
+		t.Fatalf("unspecified src with v6 dst must not trigger the gate, got res=%+v", res)
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -968,6 +968,29 @@ func Match(cfg *config.Config, q Query) (res Result) {
 	// arm and every same-family tuple fall through unchanged. Family is read
 	// with To4() to match the ipFamily helper the host-inbound path already
 	// uses.
+	//
+	// KNOWN LIMITATION (#5720 codex, tracked in #6377): To4() FOLDS an
+	// IPv4-mapped IPv6 literal — net.ParseIP("::ffff:192.0.2.1").To4() is
+	// NON-nil — so a source authored as `::ffff:192.0.2.1` is classified V4
+	// here and this gate FALSELY flags `::ffff:192.0.2.1 -> 2001:db8::1` as an
+	// unsupported (V4 src, V6 dst) tuple, even though the colon-strict runtime
+	// matcher (userspace-dp/src/policy.rs) sees a same-family V6/V6 tuple that
+	// should fall through and be evaluated normally. This is the documented
+	// Go/Rust family-parity trap (config.NATAddrFamily / natAddrFamily in
+	// pkg/config/compiler_nat_helpers.go: family is keyed on the presence of a
+	// ':' in the ORIGINAL text, which net.ParseIP has already discarded here).
+	// A colon-strict fix cannot be made at this gate from q.SrcIP/q.DstIP
+	// alone: all four Query builders (cli_request_testcmd.go, cli_show_
+	// security.go, server_show_firewall.go, server_cluster.go) parse with
+	// net.ParseIP, which renders `192.0.2.1` and `::ffff:192.0.2.1` byte-
+	// identical 16-byte values — the ':' signal is gone. The correct fix
+	// threads the colon-strict text family (config.NATAddrFamily on the raw
+	// srcIP/dstIP strings) from each caller into Query; that API change is out
+	// of scope for the #5720 tooling cohort and is filed as a follow-up. In
+	// practice an operator authoring a mapped-IPv6 source at these diagnostic
+	// surfaces is rare, and the failure mode is a spurious "unsupported tuple"
+	// advisory (fail-safe: it never hides or fabricates a permit), not a
+	// dataplane effect.
 	if q.SrcIP != nil && q.DstIP != nil && q.SrcIP.To4() != nil && q.DstIP.To4() == nil {
 		return Result{UnsupportedTupleFamily: true, Action: config.PolicyDeny}
 	}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -627,6 +627,21 @@ type Result struct {
 	ContentRejected         bool
 	ContentRejectionReasons []string
 
+	// UnsupportedTupleFamily is true when the query carries an
+	// IPv4-source / IPv6-destination tuple (codex-182 A10-b02-C1). The
+	// forwarding path never produces that tuple — NAT46 is not supported, so
+	// no inbound translation yields a v4 source with a v6 destination — and the
+	// runtime matcher fails it closed (userspace-dp/src/policy.rs try_match_rule
+	// rejects the (V4 src, V6 dst) arm). The reverse V6-source / V4-destination
+	// tuple IS valid (it is the NAT64 arm) and is evaluated normally. Before
+	// this gate the simulator evaluated the two address sides independently and
+	// could return a concrete permit/deny/default verdict for a packet shape
+	// the runtime can never see. When set, Matched / DefaultUsed /
+	// HostInboundUnmatched / ContentRejected are all false and Action is the
+	// conservative PolicyDeny for a raw reader; DisplayAction renders the
+	// dedicated UnsupportedTupleFamilyActionString.
+	UnsupportedTupleFamily bool
+
 	// HostInboundUnmatched is true ONLY for a `to-zone junos-host` query that
 	// matched no host-bound policy (#3285). The dataplane host gate
 	// (evaluate_junos_host_policy) returns None here — no security *policy*
@@ -903,6 +918,8 @@ const ContentRejectedShowLine = "policy content rejected: the dataplane fails th
 //   - concrete policy match -> "<action>"
 func (r Result) DisplayAction() string {
 	switch {
+	case r.UnsupportedTupleFamily:
+		return UnsupportedTupleFamilyActionString
 	case r.ContentRejected:
 		return ContentRejectedActionString
 	case r.HostInboundUnmatched:
@@ -913,6 +930,13 @@ func (r Result) DisplayAction() string {
 		return ActionString(r.Action)
 	}
 }
+
+// UnsupportedTupleFamilyActionString is the operator-facing verdict rendered
+// for a query whose source is IPv4 and destination is IPv6 (codex-182
+// A10-b02-C1). NAT46 is not supported, so no forwarding path ever produces this
+// tuple and the runtime matcher fails it closed; the simulator reports that
+// rather than a fabricated per-side verdict.
+const UnsupportedTupleFamilyActionString = "unsupported tuple: an IPv4 source with an IPv6 destination has no supported translation (NAT46 is not implemented), so the forwarding path never produces it and the runtime matcher fails closed — no simulated permit/deny/default verdict applies"
 
 // Match runs the simulator against the active config and returns the verdict
 // with the SAME precedence the runtime enforces (userspace-dp/src/policy.rs
@@ -931,6 +955,22 @@ func (r Result) DisplayAction() string {
 // path (matchJunosHost, #3285): exact ingress->junos-host then
 // `from-zone any`->junos-host, with NO global/default transit fallback.
 func Match(cfg *config.Config, q Query) (res Result) {
+	// codex-182 A10-b02-C1: an IPv4 source with an IPv6 destination is a tuple
+	// the forwarding path never produces — NAT46 is unsupported, so no inbound
+	// translation yields a v4 source with a v6 destination — and the runtime
+	// matcher fails it closed (userspace-dp/src/policy.rs try_match_rule rejects
+	// the (V4 src, V6 dst) arm). matchAddr evaluates the two address sides
+	// INDEPENDENTLY below, so without this gate the simulator could return a
+	// concrete permit/deny/default verdict for a packet shape the runtime can
+	// never see. Reject it up front — this single shared entry point serves
+	// every transport (CLI, REST, gRPC MatchPolicies), so the fix covers all
+	// three. Both sides must be specified; the reverse (V6 src, V4 dst) NAT64
+	// arm and every same-family tuple fall through unchanged. Family is read
+	// with To4() to match the ipFamily helper the host-inbound path already
+	// uses.
+	if q.SrcIP != nil && q.DstIP != nil && q.SrcIP.To4() != nil && q.DstIP.To4() == nil {
+		return Result{UnsupportedTupleFamily: true, Action: config.PolicyDeny}
+	}
 	// #4373 (E4/H2/H7): a TRANSIT destination that is multicast / broadcast /
 	// unspecified / loopback is dropped by the forwarding path at ROUTE LOOKUP,
 	// before the policy engine runs, so any permit/deny verdict below (and a

--- a/scripts/image/test_validate_ownership.py
+++ b/scripts/image/test_validate_ownership.py
@@ -26,6 +26,7 @@ and the foreign-tag deletion is no longer refused — the assertions flip.
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import types
 import unittest
 from pathlib import Path
@@ -158,6 +159,55 @@ class CleanupTests(unittest.TestCase):
                 h.cleanup()
         self.assertEqual(rec.image_deletes(), [],
                          "cleanup must not delete an alias this run did not import")
+
+
+class CleanupWorkDirTests(unittest.TestCase):
+    """--keep must retain the per-run scratch dir (codex-182 A10-b03-C01).
+
+    self.work backs the day-0 ISOs / config drives whose HOST paths are
+    attached to the instances. Before the fix cleanup() ran an unconditional
+    `rm -rf self.work` even under --keep, orphaning the retained VMs' media.
+
+    RED on revert: move `rm -rf self.work` back out of the else branch (make
+    it unconditional) and test_cleanup_keep_retains_work_dir flips — the rm
+    call reappears under keep=True.
+    """
+
+    @staticmethod
+    def _rm_work_calls(runs, work):
+        return [c for c in runs if c[:2] == ("rm", "-rf") and work in c]
+
+    def _run_cleanup(self, keep):
+        h = _harness(keep=keep)
+        # tempfile.mkdtemp made a real dir; reap it after the test since the
+        # keep path deliberately never deletes it.
+        self.addCleanup(shutil.rmtree, h.work, ignore_errors=True)
+        h.instances = []
+        h.created_net = False
+        h.imported_alias = False
+        runs = []
+
+        def _run(cmd, *a, **kw):
+            runs.append(tuple(cmd))
+            return types.SimpleNamespace(returncode=0)
+
+        with mock.patch.object(validate, "incus", _IncusRecorder()):
+            with mock.patch.object(validate.subprocess, "run", _run):
+                h.cleanup()
+        return h, runs
+
+    def test_cleanup_keep_retains_work_dir(self):
+        h, runs = self._run_cleanup(keep=True)
+        self.assertEqual(
+            self._rm_work_calls(runs, h.work), [],
+            "cleanup(--keep) must NOT rm -rf the scratch dir — it backs the "
+            "day-0 media attached to the instances we just kept")
+
+    def test_cleanup_no_keep_still_removes_work_dir(self):
+        h, runs = self._run_cleanup(keep=False)
+        self.assertEqual(
+            len(self._rm_work_calls(runs, h.work)), 1,
+            "cleanup() without --keep must still purge the scratch dir")
 
 
 if __name__ == "__main__":

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -270,17 +270,26 @@ class Harness:
         if self.keep:
             print(f"keeping instances {self.instances}, alias {self.alias}, "
                   f"network {self.net}")
-        else:
-            for i in self.instances:
-                self._owned_delete(i)   # ownership-gated (#4905-D)
-            # Only delete the alias if WE imported it this run, and only the
-            # run-namespaced name — never a bystander's `xpf-image-validate`
-            # (#4905-D).
-            if self.imported_alias:
-                incus("image", "delete", self.alias, check=False, capture=True)
-            # created_net already gates the network delete to one WE created.
-            if self.created_net:
-                incus("network", "delete", self.net, check=False, capture=True)
+            # Retain the per-run scratch dir under --keep too (codex-182
+            # A10-b03-C01). Scenarios B/C/E/Q write config files and day-0
+            # ISOs under self.work and attach those HOST paths to the
+            # instances. Deleting self.work while keeping the VMs leaves each
+            # retained instance referencing a source that can no longer be
+            # reopened on a later restart/inspection/reproduction — the exact
+            # forensic environment --keep was asked to preserve. Print the
+            # path so the operator can find the retained media.
+            print(f"keeping work dir {self.work} (day-0 media / config drives)")
+            return
+        for i in self.instances:
+            self._owned_delete(i)   # ownership-gated (#4905-D)
+        # Only delete the alias if WE imported it this run, and only the
+        # run-namespaced name — never a bystander's `xpf-image-validate`
+        # (#4905-D).
+        if self.imported_alias:
+            incus("image", "delete", self.alias, check=False, capture=True)
+        # created_net already gates the network delete to one WE created.
+        if self.created_net:
+            incus("network", "delete", self.net, check=False, capture=True)
         subprocess.run(["rm", "-rf", self.work], check=False)
 
     # ── waiters ──


### PR DESCRIPTION
Triage + fix of cohort **#5720** (codex-review-182 C-TOOLS — conditional /
non-production tooling survivors). Each C-TOOLS row STEP-0'd firsthand on
origin/master; 5 real low-risk tooling items fixed with regression guards, 2
dispositioned out-of-scope.

## Per-item triage

| Item | Location | Verdict | Disposition |
|---|---|---|---|
| A10-b00-C01 | `pkg/cli` policy-shadow lint | REAL — `request security policies check` never linted the global-policy list | **FIXED** — commit 1 |
| A10-b00-C02 | `pkg/cli/cli.go` | REAL — unreachable `return nil` trips `go vet` | **FIXED** — commit 2 |
| A10-b00-C03 | `vdso_probe2.c` evidence | REAL — header comment claims a `/proc/self/maps` cross-check it never performs | **FIXED** — commit 3 |
| A10-b02-C1 | `pkg/policymatch` | REAL — simulator matches an impossible (V4 src, V6 dst) tuple the runtime fails closed | **FIXED** — commit 4 |
| A10-b03-C01 | `scripts/image/validate.py` | REAL — `--keep` deletes host-side day-0 media backing retained VMs | **FIXED** — commit 5 |
| A10-b00-C04 | `pkg/cli/cli_show_flow.go` (1272 LOC) | OUT-OF-SCOPE — modularity row, already tracked by open **#5661**; splitting a production CLI file is a large behavior-preserving refactor, not a tooling fix | disposition |
| A10-b03-F03 | `pkg/upgrade` dangling `current` symlink rollback guard | MIS-BUCKETED — PRODUCTION control-plane code, MATERIAL/Medium availability bug (not "non-production tooling"). Filed standalone as **#6374** for a dedicated material review | disposition |

## Regression guards (with RED-on-revert verified)

- **C01** — `TestAnalyzePolicyShadowingGlobal` (finding disappears if the global
  pass is dropped) + `TestAnalyzePolicyShadowingGlobalDisjointScopeNotShadowed`
  (false positive returns if the `globalScopeCovers` gate is dropped).
- **C02** — `go vet ./pkg/cli/...` (flagged the line before, silent after).
- **C03** — evidence file, no automated guard; comment now matches the code and
  the corroborating `vdso_probe.c` strace gate.
- **b02/C1** — `mixed_family_tuple_5720_test.go` (impossible tuple returns the
  fabricated default verdict if the gate is dropped; valid same-family + NAT64
  arms unaffected).
- **b03-C01** — `CleanupWorkDirTests` (the `rm -rf` reappears under `--keep` if
  the fix is reverted).

## Validation

- `go test ./pkg/cli/... ./pkg/policymatch/...` green; consumer pkgs
  `./pkg/grpcapi/... ./pkg/api/... ./cmd/cli/...` green; `go build ./...` green;
  `go vet` + `gofmt` clean.
- `scripts/run-selftests.sh` — 44 passed, 0 failed (includes the extended
  `test_validate_ownership.py`).

Docs updated: `pkg/policymatch/README.md` (new unsupported-tuple verdict),
`docs/image-validation.md` (`--keep` retains the scratch dir). No production
dataplane/HA/config or `userspace-dp` code touched.

Advances #5720 (two rows remain: C04 → #5661, F03 → #6374).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ