### PR TITLE
cluster/vrrp: fix two HA diagnostic-race survivors (#5718 C-HA)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -57928,3 +57928,24 @@ top.
     ./pkg/api/... ./pkg/grpcapi/... green; vet + gofmt clean.
   **File(s)**: pkg/api/server.go, pkg/api/tls_san_5719_test.go,
     pkg/api/tls_test.go, pkg/api/README.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #5718 (cohort codex-182 C-HA) — fix the two independent
+    diagnostic-race survivors. C01b: the syncMsgBulkEnd mismatch-epoch
+    handler read s.bulkRecvEpoch in its slog.Warn args AFTER releasing
+    s.bulkMu, racing a concurrent BulkStart write under bulkMu — snapshot
+    `want := s.bulkRecvEpoch` before Unlock, log the snapshot. C01c:
+    Manager.Status() formatted vi.cfg.Priority/Preempt/AdvertiseInterval/
+    VirtualAddresses under only m.mu.RLock, racing a failover
+    UpdateRGPriority write under vi.mu.Lock — snapshot the cfg fields under
+    vi.mu.RLock before formatting, mirroring advertInterval/getPriority
+    (#6230). Both are diagnostic-only (log/status output byte-identical),
+    go test -race flags the unfixed reads. Added fail-on-revert -race tests
+    (RED verified: DATA RACE + FAIL on revert). Deferred C01a (process-
+    sticky heartbeat-ACK capability — heartbeat-wire + peer-incarnation
+    coupled to #5480/#6169/anti-replay) and A6-b01-C1 (worker clamp cast —
+    pkg/dataplane/userspace, out of cluster/daemon scope). go vet + gofmt
+    clean; ./pkg/cluster/... ./pkg/vrrp/... ./pkg/daemon/... green.
+  **File(s)**: pkg/cluster/sync_conn_read.go,
+    pkg/cluster/bulkend_epoch_log_race_5718_test.go, pkg/vrrp/manager.go,
+    pkg/vrrp/status_config_race_5718_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -57949,3 +57949,34 @@ top.
   **File(s)**: pkg/cluster/sync_conn_read.go,
     pkg/cluster/bulkend_epoch_log_race_5718_test.go, pkg/vrrp/manager.go,
     pkg/vrrp/status_config_race_5718_test.go
+
+- **Timestamp**: 2026-07-23
+  **Action**: #5718 (cohort codex-182 C-HA) — strengthen the two
+    fail-on-revert -race gates and correct one comment; production race
+    fixes (sync_conn_read.go BulkEnd snapshot, manager.go Status snapshot)
+    left byte-identical. FINDING 1 (Codex MINOR): the original gates
+    launched a finite writer goroutine WITHOUT an overlap barrier, so the
+    writer could finish before the reader started → no concurrent access →
+    false GREEN on revert (Codex saw the reverted VRRP test PASS under
+    GOMAXPROCS=1 and one cluster false-green). Rewrote BOTH tests with a
+    `start` barrier releasing writer+reader together and a writer that LOOPS
+    mutating the raced field(s) under its proper lock until the reader
+    signals `done`, guaranteeing overlap for the whole reader window.
+    FINDING 2 (Codex): widened the VRRP writer to also mutate Preempt and
+    AdvertiseInterval (not just Priority) under vi.mu.Lock, so a revert of
+    ANY of the three genuinely-raced snapshot fields is caught. FINDING 3
+    (Claude nit): reworded the manager.go Status snapshot comment (and the
+    VRRP test doc string) — VirtualAddresses is IMMUTABLE per instance (a
+    VIP change rebuilds the instance under m.mu.Lock; instance_addr.go
+    vipAddrSet / instance.go vipFamilies), so reading it under only
+    m.mu.RLock was already race-free; it is deep-copied defensively, not as
+    part of this race. VALIDATION (TMPDIR=/dev/shm short-path, -race):
+    build+vet+gofmt clean. GREEN with fix at -count=10 under both default
+    and GOMAXPROCS=1. RED-on-revert proven with independent-process runs
+    (Go -race dedups repeat reports across -count iterations, so per-process
+    exit is the true signal): cluster BulkEnd snapshot revert 6/6
+    DATA RACE+FAIL; VRRP full snapshot revert 8/8; Preempt-only revert 6/6;
+    AdvertiseInterval-only revert 6/6 — all GOMAXPROCS=1, zero false greens.
+    Fixes restored; final tree = test files + comment only.
+  **File(s)**: pkg/cluster/bulkend_epoch_log_race_5718_test.go,
+    pkg/vrrp/status_config_race_5718_test.go, pkg/vrrp/manager.go

--- a/pkg/cluster/bulkend_epoch_log_race_5718_test.go
+++ b/pkg/cluster/bulkend_epoch_log_race_5718_test.go
@@ -15,11 +15,16 @@ import (
 // snapshots the expected epoch (want := s.bulkRecvEpoch) BEFORE the Unlock and
 // logs the snapshot.
 //
-// This is the fail-on-revert gate: the race detector reports on the FIRST
-// unsynchronized concurrent access, so a few thousand tightly interleaved
-// iterations suffice and stay fast under -race. It passes cleanly with the
-// snapshot fix and DETECTS the race if the log reverts to reading
-// s.bulkRecvEpoch after Unlock. Must be run with `go test -race`.
+// This is the fail-on-revert gate. A start barrier releases the writer and
+// reader together, and the writer LOOPS mutating s.bulkRecvEpoch under s.bulkMu
+// until the reader signals done, so every BulkEnd dispatch overlaps a live
+// concurrent writer. That guaranteed overlap makes the race detector reliably
+// observe the concurrent access under both the default GOMAXPROCS and
+// GOMAXPROCS=1 — a fixed-count writer that can run to completion before the
+// reader starts leaves no concurrent access and false-greens on revert. It
+// passes cleanly with the snapshot fix and reliably reports WARNING: DATA RACE
+// + FAIL if the log reverts to reading s.bulkRecvEpoch after Unlock. Must be
+// run with `go test -race`.
 func TestBulkEndMismatchEpochLogNoRace5718(t *testing.T) {
 	s := &SessionSync{}
 	// A bulk transfer is in progress so the BulkEnd handler reaches the
@@ -34,33 +39,46 @@ func TestBulkEndMismatchEpochLogNoRace5718(t *testing.T) {
 	binary.LittleEndian.PutUint64(end, 7)
 
 	const iters = 5000
+	start := make(chan struct{})
+	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(2)
 
 	// Writer: a locked mutation of bulkRecvEpoch, mirroring the BulkStart
 	// handler's s.bulkMu.Lock(); s.bulkRecvEpoch = epoch; s.bulkMu.Unlock()
-	// discipline. It alternates between 1 and 2, neither of which equals 7.
+	// discipline. It loops until the reader signals done so it stays live for
+	// the whole reader window, alternating between 1 and 2 (neither equals 7).
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iters; i++ {
+		<-start
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
 			s.bulkMu.Lock()
-			if i%2 == 0 {
-				s.bulkRecvEpoch = 1
-			} else {
+			if s.bulkRecvEpoch == 1 {
 				s.bulkRecvEpoch = 2
+			} else {
+				s.bulkRecvEpoch = 1
 			}
 			s.bulkMu.Unlock()
 		}
 	}()
 
-	// Reader: the real BulkEnd dispatch path. conn is nil — the mismatch branch
-	// never dereferences it.
+	// Reader: the real BulkEnd dispatch path, run for a bounded window while the
+	// writer is guaranteed to be concurrently mutating bulkRecvEpoch. conn is
+	// nil — the mismatch branch never dereferences it.
 	go func() {
 		defer wg.Done()
+		<-start
 		for i := 0; i < iters; i++ {
 			s.handleMessage(nil, syncMsgBulkEnd, end)
 		}
+		close(done)
 	}()
 
+	close(start)
 	wg.Wait()
 }

--- a/pkg/cluster/bulkend_epoch_log_race_5718_test.go
+++ b/pkg/cluster/bulkend_epoch_log_race_5718_test.go
@@ -1,0 +1,66 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+)
+
+// #5718 (codex-182 C-HA C01b): the syncMsgBulkEnd mismatch-epoch handler read
+// s.bulkRecvEpoch in its slog.Warn arguments AFTER releasing s.bulkMu. That
+// field is written under s.bulkMu by the BulkStart handler (and by disconnect
+// teardown), so a BulkEnd on one fabric receive loop racing a BulkStart on
+// another produces an unsynchronized concurrent read/write — a diagnostic-only
+// data race the Go memory model forbids and go test -race flags. The fix
+// snapshots the expected epoch (want := s.bulkRecvEpoch) BEFORE the Unlock and
+// logs the snapshot.
+//
+// This is the fail-on-revert gate: the race detector reports on the FIRST
+// unsynchronized concurrent access, so a few thousand tightly interleaved
+// iterations suffice and stay fast under -race. It passes cleanly with the
+// snapshot fix and DETECTS the race if the log reverts to reading
+// s.bulkRecvEpoch after Unlock. Must be run with `go test -race`.
+func TestBulkEndMismatchEpochLogNoRace5718(t *testing.T) {
+	s := &SessionSync{}
+	// A bulk transfer is in progress so the BulkEnd handler reaches the
+	// epoch-comparison branch rather than the no-transfer early-out.
+	s.bulkInProgress = true
+	s.bulkRecvEpoch = 1
+
+	// The incoming BulkEnd always carries an epoch that never matches either
+	// value the writer cycles bulkRecvEpoch through, so every call lands in the
+	// mismatch branch that logs the protected expected epoch.
+	end := make([]byte, 8)
+	binary.LittleEndian.PutUint64(end, 7)
+
+	const iters = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: a locked mutation of bulkRecvEpoch, mirroring the BulkStart
+	// handler's s.bulkMu.Lock(); s.bulkRecvEpoch = epoch; s.bulkMu.Unlock()
+	// discipline. It alternates between 1 and 2, neither of which equals 7.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			s.bulkMu.Lock()
+			if i%2 == 0 {
+				s.bulkRecvEpoch = 1
+			} else {
+				s.bulkRecvEpoch = 2
+			}
+			s.bulkMu.Unlock()
+		}
+	}()
+
+	// Reader: the real BulkEnd dispatch path. conn is nil — the mismatch branch
+	// never dereferences it.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			s.handleMessage(nil, syncMsgBulkEnd, end)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/pkg/cluster/sync_conn_read.go
+++ b/pkg/cluster/sync_conn_read.go
@@ -226,8 +226,15 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 			break
 		}
 		if s.bulkRecvEpoch != epoch {
+			// #5718 (codex-182 C-HA C01b): snapshot the mutex-protected
+			// expected epoch BEFORE releasing bulkMu. Reading s.bulkRecvEpoch
+			// in the log arguments after Unlock races a concurrent BulkStart
+			// on another fabric receive loop (which writes bulkRecvEpoch under
+			// bulkMu, sync_conn_read.go BulkStart handler) — a diagnostic-only
+			// data race the Go memory model forbids and go test -race flags.
+			want := s.bulkRecvEpoch
 			s.bulkMu.Unlock()
-			slog.Warn("cluster sync: ignoring BulkEnd with mismatched epoch", "expected", s.bulkRecvEpoch, "got", epoch)
+			slog.Warn("cluster sync: ignoring BulkEnd with mismatched epoch", "expected", want, "got", epoch)
 			break
 		}
 		s.bulkMu.Unlock()

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -1014,9 +1014,24 @@ func (m *Manager) Status() string {
 	for _, key := range keys {
 		vi := m.instances[key]
 		state := vi.getState()
+		// #5718 (codex-182 C-HA C01c): snapshot the mutable cfg fields under
+		// vi.mu.RLock before formatting. Priority/Preempt/AdvertiseInterval/
+		// VirtualAddresses are all mutated under vi.mu.Lock (updateConfig,
+		// UpdateRGPriority, suppressPreempt/restorePreempt); reading them here
+		// while holding only m.mu.RLock races a concurrent failover priority
+		// update — a diagnostic-only data race go test -race flags. Mirrors the
+		// snapshot idiom in advertInterval/getPriority (#6230). getState()
+		// already RLocks internally, so it stays outside this block; vi.key()
+		// reads only immutable identity fields.
+		vi.mu.RLock()
+		priority := vi.cfg.Priority
+		preempt := vi.cfg.Preempt
+		interval := vi.cfg.AdvertiseInterval
+		vips := append([]string(nil), vi.cfg.VirtualAddresses...)
+		vi.mu.RUnlock()
 		sb.WriteString(fmt.Sprintf("  %s: state=%s, priority=%d, preempt=%t, interval=%dms\n",
-			vi.key(), state, vi.cfg.Priority, vi.cfg.Preempt, vi.cfg.AdvertiseInterval))
-		for _, vip := range vi.cfg.VirtualAddresses {
+			vi.key(), state, priority, preempt, interval))
+		for _, vip := range vips {
 			sb.WriteString(fmt.Sprintf("    VIP: %s\n", vip))
 		}
 	}

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -1015,14 +1015,18 @@ func (m *Manager) Status() string {
 		vi := m.instances[key]
 		state := vi.getState()
 		// #5718 (codex-182 C-HA C01c): snapshot the mutable cfg fields under
-		// vi.mu.RLock before formatting. Priority/Preempt/AdvertiseInterval/
-		// VirtualAddresses are all mutated under vi.mu.Lock (updateConfig,
-		// UpdateRGPriority, suppressPreempt/restorePreempt); reading them here
-		// while holding only m.mu.RLock races a concurrent failover priority
-		// update — a diagnostic-only data race go test -race flags. Mirrors the
-		// snapshot idiom in advertInterval/getPriority (#6230). getState()
-		// already RLocks internally, so it stays outside this block; vi.key()
-		// reads only immutable identity fields.
+		// vi.mu.RLock before formatting. Priority/Preempt/AdvertiseInterval are
+		// mutated under vi.mu.Lock (updateConfig, UpdateRGPriority,
+		// suppressPreempt/restorePreempt); reading them here while holding only
+		// m.mu.RLock races a concurrent failover priority update — a
+		// diagnostic-only data race go test -race flags. Mirrors the snapshot
+		// idiom in advertInterval/getPriority (#6230). VirtualAddresses is
+		// immutable per instance (a VIP change rebuilds the whole instance under
+		// m.mu.Lock, see instance_addr.go vipAddrSet / instance.go vipFamilies),
+		// so reading it under only m.mu.RLock was already race-free; it is
+		// deep-copied here defensively alongside the genuinely-raced fields.
+		// getState() already RLocks internally, so it stays outside this block;
+		// vi.key() reads only immutable identity fields.
 		vi.mu.RLock()
 		priority := vi.cfg.Priority
 		preempt := vi.cfg.Preempt

--- a/pkg/vrrp/status_config_race_5718_test.go
+++ b/pkg/vrrp/status_config_race_5718_test.go
@@ -8,20 +8,29 @@ import (
 )
 
 // #5718 (codex-182 C-HA C01c): Manager.Status() formatted vi.cfg.Priority,
-// vi.cfg.Preempt, vi.cfg.AdvertiseInterval, and vi.cfg.VirtualAddresses while
-// holding only m.mu.RLock. Those cfg fields are mutated under vi.mu.Lock by
-// updateConfig, UpdateRGPriority, and suppressPreempt/restorePreempt. A `show`/
-// status render concurrent with a failover priority update is therefore an
-// unsynchronized concurrent read/write — a diagnostic-only data race the Go
-// memory model forbids and go test -race flags. The fix snapshots the cfg
-// fields under vi.mu.RLock before formatting, mirroring advertInterval/
-// getPriority (#6230).
+// vi.cfg.Preempt, and vi.cfg.AdvertiseInterval while holding only m.mu.RLock.
+// Those three cfg fields are mutated under vi.mu.Lock by updateConfig,
+// UpdateRGPriority, and suppressPreempt/restorePreempt, so a `show`/status
+// render concurrent with a failover priority update is an unsynchronized
+// concurrent read/write — a diagnostic-only data race the Go memory model
+// forbids and go test -race flags. The fix snapshots those fields under
+// vi.mu.RLock before formatting, mirroring advertInterval/getPriority (#6230).
+// (vi.cfg.VirtualAddresses is ALSO deep-copied there, but only defensively: it
+// is immutable per instance — a VIP change rebuilds the whole instance under
+// m.mu.Lock, see instance_addr.go vipAddrSet / instance.go vipFamilies — so it
+// was never part of this race.)
 //
-// This is the fail-on-revert gate. The race detector reports on the FIRST
-// unsynchronized concurrent access, so a few thousand tightly interleaved
-// iterations suffice and stay fast under -race. It is CLEAN with the snapshot
-// fix and DETECTS the race if Status() reverts to reading vi.cfg.* directly.
-// Must be run with `go test -race`.
+// This is the fail-on-revert gate. A start barrier releases the writer and
+// reader together, and the writer LOOPS mutating all three raced fields under
+// vi.mu.Lock until the reader signals done, so the reader's Status() renders
+// overlap a live concurrent writer for the whole window. That guaranteed
+// overlap makes the race detector reliably observe the concurrent access under
+// both the default GOMAXPROCS and GOMAXPROCS=1 — a fixed-count writer that can
+// run to completion before the reader starts leaves no concurrent access and
+// false-greens on revert. It is CLEAN with the snapshot fix and reliably
+// reports WARNING: DATA RACE + FAIL if Status() reverts to reading any of
+// vi.cfg.Priority/Preempt/AdvertiseInterval directly. Must be run with
+// `go test -race`.
 func TestStatusConfigNoRace5718(t *testing.T) {
 	m := NewManager()
 	reth := newInstance(
@@ -30,34 +39,54 @@ func TestStatusConfigNoRace5718(t *testing.T) {
 	m.instances[instanceKey{iface: "reth0", groupID: 101}] = reth
 
 	const iters = 5000
+	start := make(chan struct{})
+	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	// Writer: a locked mutation of cfg.Priority, mirroring the vi.mu.Lock()
-	// discipline every cfg writer (updateConfig, UpdateRGPriority) uses.
+	// Writer: a locked mutation of the three genuinely-raced snapshot fields
+	// (Priority, Preempt, AdvertiseInterval), mirroring the vi.mu.Lock()
+	// discipline every cfg writer (updateConfig, UpdateRGPriority,
+	// suppressPreempt/restorePreempt) uses. It loops until the reader signals
+	// done so a revert of ANY of the three snapshots — not just Priority — is
+	// caught by the -race detector.
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iters; i++ {
+		<-start
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
 			reth.mu.Lock()
 			if i%2 == 0 {
 				reth.cfg.Priority = 100
+				reth.cfg.Preempt = true
+				reth.cfg.AdvertiseInterval = 30
 			} else {
 				reth.cfg.Priority = 1
+				reth.cfg.Preempt = false
+				reth.cfg.AdvertiseInterval = 100
 			}
 			reth.mu.Unlock()
 		}
 	}()
 
-	// Reader: the real Status() render path.
+	// Reader: the real Status() render path, run for a bounded window while the
+	// writer is guaranteed to be concurrently mutating the cfg snapshot fields.
 	go func() {
 		defer wg.Done()
+		<-start
 		for i := 0; i < iters; i++ {
 			if out := m.Status(); !strings.Contains(out, "reth0") {
 				t.Errorf("Status() missing instance: %q", out)
-				return
+				break
 			}
 		}
+		close(done)
 	}()
 
+	close(start)
 	wg.Wait()
 }

--- a/pkg/vrrp/status_config_race_5718_test.go
+++ b/pkg/vrrp/status_config_race_5718_test.go
@@ -1,0 +1,63 @@
+package vrrp
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// #5718 (codex-182 C-HA C01c): Manager.Status() formatted vi.cfg.Priority,
+// vi.cfg.Preempt, vi.cfg.AdvertiseInterval, and vi.cfg.VirtualAddresses while
+// holding only m.mu.RLock. Those cfg fields are mutated under vi.mu.Lock by
+// updateConfig, UpdateRGPriority, and suppressPreempt/restorePreempt. A `show`/
+// status render concurrent with a failover priority update is therefore an
+// unsynchronized concurrent read/write — a diagnostic-only data race the Go
+// memory model forbids and go test -race flags. The fix snapshots the cfg
+// fields under vi.mu.RLock before formatting, mirroring advertInterval/
+// getPriority (#6230).
+//
+// This is the fail-on-revert gate. The race detector reports on the FIRST
+// unsynchronized concurrent access, so a few thousand tightly interleaved
+// iterations suffice and stay fast under -race. It is CLEAN with the snapshot
+// fix and DETECTS the race if Status() reverts to reading vi.cfg.* directly.
+// Must be run with `go test -race`.
+func TestStatusConfigNoRace5718(t *testing.T) {
+	m := NewManager()
+	reth := newInstance(
+		Instance{Interface: "reth0", GroupID: 101, Priority: 100, AdvertiseInterval: 30, Preempt: true},
+		&net.Interface{Name: "reth0", Index: 8}, m.eventCh, nil)
+	m.instances[instanceKey{iface: "reth0", groupID: 101}] = reth
+
+	const iters = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: a locked mutation of cfg.Priority, mirroring the vi.mu.Lock()
+	// discipline every cfg writer (updateConfig, UpdateRGPriority) uses.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			reth.mu.Lock()
+			if i%2 == 0 {
+				reth.cfg.Priority = 100
+			} else {
+				reth.cfg.Priority = 1
+			}
+			reth.mu.Unlock()
+		}
+	}()
+
+	// Reader: the real Status() render path.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if out := m.Status(); !strings.Contains(out, "reth0") {
+				t.Errorf("Status() missing instance: %q", out)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Cohort #5718 (codex-review-182 C-HA — mixed-version / observability /
defense-in-depth HA survivors) triaged firsthand against origin/master.
This PR fixes the **two independent, low-risk diagnostic-race** survivors
and dispositions the rest. Both fixes are pure read-side synchronization:
the log line and the status string are **byte-identical**; only the reads
are now under the lock the writers already hold.

## Per-item triage

| Item (issue survivor) | Finding | Verdict | Disposition |
|---|---|---|---|
| BulkEnd diagnostic race | C01b — `syncMsgBulkEnd` mismatch log reads `s.bulkRecvEpoch` after `bulkMu.Unlock()`, racing a concurrent BulkStart write | **REAL + independent + in-scope** | **FIXED** — snapshot `want` before Unlock (`pkg/cluster/sync_conn_read.go`) |
| VRRP status config race | C01c — `Manager.Status()` reads `vi.cfg.Priority/Preempt/AdvertiseInterval/VirtualAddresses` under only `m.mu.RLock`, racing `UpdateRGPriority` writing `vi.cfg.Priority` under `vi.mu.Lock` | **REAL + independent** | **FIXED** — snapshot cfg under `vi.mu.RLock` (`pkg/vrrp/manager.go`); mirrors #6230 idiom |
| Process-sticky heartbeat ACK capability | C01a — `peerHeartbeatAckEver` is a process-lifetime latch; on a mixed-version rollback to a pre-ACK peer, idle reconnects close forever | **REAL but COUPLED** | **DEFERRED** — fix requires scoping the ACK capability to an authenticated **peer incarnation** (heartbeat-wire + incarnation-handshake), coupling it to #5480 (peer-incarnation handshake), #6169 (heartbeat boot-epoch, in /research), and the #5086/#5477/#5639 anti-replay work. Out of the independent-item bar per the cohort coupling rule. |
| Worker clamp cast | A6-b01-C1 — `heartbeatZeroSlots` casts `workers int`→`uint32` before the map-cap clamp; a `2^32` config narrows to 0 | REAL (low) but **out of scope** | **DEFERRED** — lives in `pkg/dataplane/userspace/maps_sync.go` (Go manager for the Rust dataplane, labeled `dataplane`), outside this cohort's pkg/cluster+pkg/daemon HA scope. Belongs to the dataplane owner. |

## Fixes

**C01b — `pkg/cluster/sync_conn_read.go`**: the BulkEnd mismatch-epoch
warning read the `bulkMu`-protected `s.bulkRecvEpoch` in its `slog.Warn`
arguments after releasing `bulkMu`. Concurrent with a BulkStart on another
fabric receive loop (which writes `bulkRecvEpoch` under `bulkMu`), that is
an unsynchronized read/write. Snapshot `want := s.bulkRecvEpoch` before
Unlock and log the snapshot — matching the bulk-receive-progress log which
already reads the field under the lock.

**C01c — `pkg/vrrp/manager.go`**: `Status()` formatted mutable `vi.cfg.*`
fields under only `m.mu.RLock` while `UpdateRGPriority` writes
`vi.cfg.Priority` under `vi.mu.Lock` on the failover path. Snapshot the
fields under `vi.mu.RLock` before formatting, mirroring the established
`advertInterval`/`getPriority` snapshot idiom (#6230). Lock order
`m.mu.RLock` → `vi.mu.RLock` matches `UpdateRGPriority`, so no deadlock.

## Tests (fail-on-revert, `-race`)

Both are diagnostic-only data races with no observable state effect, so —
matching the committed #6230 precedent — the fail-on-revert gate is a
`-race` test that drives the exact interleaving:

- `TestBulkEndMismatchEpochLogNoRace5718` (`pkg/cluster`)
- `TestStatusConfigNoRace5718` (`pkg/vrrp`)

RED verified: reverting each fix reports `WARNING: DATA RACE` + `FAIL`
under `go test -race`; clean with the fix.

```
go test -race ./pkg/cluster/ -run BulkEnd   → ok
go test -race ./pkg/vrrp/    -run Status     → ok
go test ./pkg/cluster/... ./pkg/vrrp/... ./pkg/daemon/...  → ok
go vet + gofmt                                → clean
```

## Docs

No module-doc change: both fixes are read-side synchronization only; the
`show chassis cluster` / VRRP status output and the cluster-sync log line
are byte-identical. No contract, wire, or behavior change.

## Merge note

Touches VRRP (failover-critical): needs a loss-cluster `make test-failover`
smoke at merge (run by the maintainer). Cohort remains OPEN (`Advances`,
not `Closes`) — C01a is coupled/deferred and the worker-clamp cast is
routed to the dataplane owner.

Advances #5718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ