### PR TITLE
api: thread HTTPS management bind IP into self-signed cert SANs (advances #5719)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-23 — #5719 C001 residual: thread HTTPS mgmt bind IP into cert SANs
+
+- **Timestamp**: 2026-07-23 (fix/5719-capi-residuals)
+- **Action**: Triaged cohort #5719 (codex-review-182 C-API). Two representative
+  survivors already fixed by merged PR #6373: unknown-NAT-stats-selector
+  (grpcapi rejects with InvalidArgument, `server_nat.go:216-227` +
+  `server_nat_selector_5719_test.go`) and SAN-less generated cert (loopback +
+  hostname SANs, `server.go`). Fixed the open C001 residual-1: the auto-
+  generated HTTPS cert did NOT carry the configured management bind IP, so
+  `https://<mgmt-ip>:8443` strict-verify failed for a remote client.
+  `buildHTTPSServer(addr)` now extracts the listener host via
+  `net.SplitHostPort` and threads it (`certGen func(bindHost string)`) into
+  `generateSelfSignedCertAt`, which adds a non-loopback IP-literal bind host to
+  IP SANs / a DNS-safe bind host to DNS SANs (loopback / unspecified / wildcard-
+  empty / non-encodable skipped; existing SANs coalesced). Baked at FIRST
+  generation only — the #1916 D6 durable cert is deliberately NOT re-minted on
+  a later bind/host-name change (residual-2, deferred: needs a mint-ordering
+  hook + a TOFU-churn decision). The "applied-nft truth projection" bucket line
+  has no concrete traceable finding; the API/gRPC truth surfaces
+  (`HostInboundKernelDeniesUnavailable` #3681, SSOT `hostInboundToREST`
+  #3375/#3627) are already complete, and any nft-apply projection lives in
+  `pkg/daemon` (out of scope). Two fail-on-revert tests (SAN threading +
+  `buildHTTPSServer` host extraction), each verified RED via a clean-assertion
+  neutralization. `go build`/`go vet`/`gofmt -l` clean; full
+  `go test ./pkg/api/... ./pkg/grpcapi/...` GREEN.
+- **File(s)**: pkg/api/server.go, pkg/api/tls_test.go,
+  pkg/api/tls_san_5719_test.go, pkg/api/README.md
+
 ## 2026-07-23 — #6240: decompose `bring_up_workers` into cohesive phase helpers
 
 - **Timestamp**: 2026-07-23 (refactor/6240-decompose-bringup)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-07-23 — #5719 C001: fold Codex hostile-review findings into #6378
+
+- **Timestamp**: 2026-07-23 (fix/5719-capi-residuals, fold on PR #6378)
+- **Action**: Folded three verified Codex hostile-review findings on top of the
+  (sound) SAN-threading fix. Did NOT touch the SAN-threading logic.
+  1. **Silent stale-cert-on-rebind (substantive):** `generateSelfSignedCertAt`
+     LOADS an existing on-disk cert as-is (durable #1916 D6), so an A→B
+     management-IP rebind serves a cert whose SANs miss B and strict remote
+     verification silently fails. Re-mint stays deferred (durable-TOFU
+     contract), but the silence is closed: the load-success path now parses the
+     loaded leaf and, when the bind host is a concrete non-loopback management
+     host (`bindHostWarnable`) the leaf's SANs do NOT cover (`certCoversHost`,
+     via `x509.VerifyHostname` — the strict check a remote client applies),
+     emits a `slog.Warn` naming the bind host + the cert's DNS/IP SANs. Two
+     small testable helpers factored out.
+  2. **Comment/contract reconcile:** the `certGen` comment (`server.go` ~:303),
+     `buildHTTPSServer` doc, and `ReconcileHTTPS` doc (`listener.go` ~:155) said
+     the cert is "minted fresh on each (re)bind" — contradicting the durable
+     contract. Reworded: the cert is durable; a rebind LOADS the on-disk pair
+     as-is; a fresh mint happens ONLY when no on-disk pair exists.
+  3. **Case-insensitive DNS SANs (low):** `dnsSANsContain` now uses
+     `strings.EqualFold` (DNS is case-insensitive per RFC 4343) so
+     case-variant names coalesce instead of double-encoding.
+- **Tests**: added `TestLoadedCertBindHostMismatchWarns` (mint bind A → reload
+  bind B, assert the `slog.Warn` fires and names B; same/loopback rebind stays
+  silent — VERIFIED RED on neutralizing `certCoversHost`),
+  `TestCertCoversHostAndWarnable` (helper units), and a case-insensitive
+  coalescing subtest under `TestGenerateSelfSignedCertBindHostSAN`. Full
+  `go test ./pkg/api/... ./pkg/grpcapi/...` GREEN; go build + vet + gofmt clean.
+- **#5866 tension (report, NOT changed):** `TestMgmtReconcileTLSChange_5866`
+  (`pkg/daemon/management_5866_test.go:180-192`) asserts a HTTPS rebind serves
+  DIFFERENT leaf bytes — the OPPOSITE of the durable no-re-mint contract. It
+  passes only because the daemon test uses the production `/etc/xpf/tls` paths
+  (`certGen = generateSelfSignedCert`, no path redirect) which are unwritable in
+  CI, so persistence fails silently and each reconcile mints a fresh in-memory
+  cert. In production (writable `/etc/xpf/tls`) the second reconcile would LOAD
+  the same on-disk pair → same bytes → that assertion would FAIL. Needs a
+  follow-up issue: redirect the test to a temp TLS dir and re-encode the
+  intended semantic (a MATERIAL change rebinds the listener, not necessarily a
+  new cert). Left untouched per instructions.
+- **File(s)**: pkg/api/server.go, pkg/api/listener.go, pkg/api/README.md,
+  pkg/api/tls_san_5719_test.go
+
 ## 2026-07-23 — #5719 C001 residual: thread HTTPS mgmt bind IP into cert SANs
 
 - **Timestamp**: 2026-07-23 (fix/5719-capi-residuals)

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -344,18 +344,29 @@ under the daemon's errgroup. Nothing else imports this package.
       #5058 all-or-nothing management-server lifecycle would abort cert
       generation and tear down the entire HTTP+HTTPS server. The cert degrades
       to loopback-only SANs (`isDNSSANSafeHostname` guard) instead of failing.
-    - **NOT covered (tracked #5719 C001 residual):** the configured
-      management-interface IP is not added to the SANs, so
+    - **HTTPS bind host (#5719 C001 residual, now closed):** the listener's
+      bind host is threaded from the resolved `web-management https interface`
+      address into cert generation (`buildHTTPSServer` → `net.SplitHostPort` →
+      `certGen(bindHost)`). A non-loopback management IP lands in the IP SANs
+      and a DNS-safe bind hostname in the DNS SANs, so
       remote-verification-by-mgmt-IP (`https://<mgmt-ip>:8443` with strict
-      verification) is out of scope here; and a later host-name change does
-      NOT re-mint the cert. Both need the resolved bind address threaded into
-      cert generation and a mint-ordering fix — deferred.
-    An already-persisted SAN-less cert is NOT auto-regenerated — the #1916 D6
+      verification) succeeds. A loopback / unspecified (`0.0.0.0`/`::`) /
+      wildcard (`:8443` → empty) / non-encodable bind host is skipped, and a
+      value already present is coalesced. Like the hostname path this only ever
+      ADDS an encodable SAN, so it never aborts generation.
+    - **STILL NOT covered (tracked #5719 C001 residual):** a later `set system
+      host-name` (or a bind-address change) does NOT re-mint an
+      already-persisted cert, so its DNS/IP SANs can go stale. Closing this
+      needs a mint-ordering / invalidation hook and a decision on churning the
+      durable cert — deferred, because the bind host is baked at FIRST
+      generation only.
+    An already-persisted cert is NOT auto-regenerated — the #1916 D6
     durable-cert contract keeps the on-disk pair stable so remote clients' TOFU
     pins survive a power loss; only freshly generated certs gain SANs (delete
     `cert.pem`/`key.pem` to force a regenerate). Pinned by
-    `tls_san_5719_test.go` (SAN presence, hostname classification, and the
-    non-ASCII no-abort guard), fail-on-revert.
+    `tls_san_5719_test.go` (SAN presence, hostname classification, the
+    non-ASCII no-abort guard, and the bind-host mgmt-IP/DNS threading +
+    `buildHTTPSServer` host-extraction), fail-on-revert.
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -354,19 +354,26 @@ under the daemon's errgroup. Nothing else imports this package.
       wildcard (`:8443` → empty) / non-encodable bind host is skipped, and a
       value already present is coalesced. Like the hostname path this only ever
       ADDS an encodable SAN, so it never aborts generation.
-    - **STILL NOT covered (tracked #5719 C001 residual):** a later `set system
-      host-name` (or a bind-address change) does NOT re-mint an
-      already-persisted cert, so its DNS/IP SANs can go stale. Closing this
-      needs a mint-ordering / invalidation hook and a decision on churning the
-      durable cert — deferred, because the bind host is baked at FIRST
-      generation only.
+    - **Re-mint STILL deferred, but no longer SILENT (#5719 C001 residual):** a
+      later `set system host-name` (or a bind-address change) does NOT re-mint
+      an already-persisted cert, so its DNS/IP SANs can go stale. Re-minting is
+      deferred (it needs a mint-ordering / invalidation hook and a decision on
+      churning the durable TOFU pin). What WAS a silent failure is now
+      diagnosed: on the load-success path `generateSelfSignedCertAt` parses the
+      loaded leaf and, when the current bind host is a concrete non-loopback
+      management host (`bindHostWarnable`) that the leaf's SANs do NOT cover
+      (`certCoversHost` — the same strict check a remote client applies), emits
+      a `slog.Warn` naming the bind host and the cert's SANs, so an operator
+      re-mints (remove `/etc/xpf/tls`) instead of chasing a silent
+      verification failure.
     An already-persisted cert is NOT auto-regenerated — the #1916 D6
     durable-cert contract keeps the on-disk pair stable so remote clients' TOFU
     pins survive a power loss; only freshly generated certs gain SANs (delete
     `cert.pem`/`key.pem` to force a regenerate). Pinned by
     `tls_san_5719_test.go` (SAN presence, hostname classification, the
-    non-ASCII no-abort guard, and the bind-host mgmt-IP/DNS threading +
-    `buildHTTPSServer` host-extraction), fail-on-revert.
+    non-ASCII no-abort guard, the bind-host mgmt-IP/DNS threading +
+    `buildHTTPSServer` host-extraction, and the stale-cert-on-rebind
+    mismatch warning), fail-on-revert.
 - The status-poll path (1 Hz) shares the userspace dataplane control socket
   with HA sync, session installs, snapshot sync, and forwarding sync.
   Adding a new caller at >1 Hz here will starve session installs during

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -152,10 +152,11 @@ func (s *Server) ReconcileHTTP(addr string) error {
 // listener (#5866), leaving the live HTTP listener untouched — this is the fix
 // for the whole-server rebuild that re-bound the still-held HTTP socket on a
 // TLS-enable (EADDRINUSE). useTLS=false or addr=="" disables HTTPS. A same-addr
-// enabled call is a no-op. On enable/rebind the new HTTPS listener (with a fresh
-// self-signed cert) is bound and serving BEFORE any old one is retired. A cert
-// or bind failure retains the previous HTTPS state (fail-closed) and returns the
-// error for retry debt.
+// enabled call is a no-op. On enable/rebind the new HTTPS listener (with its
+// durable self-signed cert — loaded AS-IS from disk on a rebind, freshly minted
+// only when no on-disk pair exists, #1916 D6) is bound and serving BEFORE any
+// old one is retired. A cert or bind failure retains the previous HTTPS state
+// (fail-closed) and returns the error for retry debt.
 func (s *Server) ReconcileHTTPS(useTLS bool, addr string) error {
 	s.lifeMu.Lock()
 	defer s.lifeMu.Unlock()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -301,9 +301,10 @@ type Server struct {
 	// pre-auth mux+collector+CSRF handler both legs wrap (per-listener auth gate
 	// via listenerHandler), so the #4162 shared scrape limiter / session cache is
 	// preserved across a rebind. certGen mints a fresh self-signed cert on each
-	// HTTPS (re)bind.
+	// HTTPS (re)bind; bindHost is the listener's host (net.SplitHostPort of the
+	// bind addr) so a non-loopback management IP lands in the cert SANs (#5719).
 	sharedBase http.Handler
-	certGen    func() (tls.Certificate, error)
+	certGen    func(bindHost string) (tls.Certificate, error)
 	lifeMu     sync.Mutex      // guards httpLeg/httpsLeg/rootCtx across reconciles
 	rootCtx    context.Context // daemon lifetime; every leg drains on its cancel
 	wg         sync.WaitGroup  // joins EVERY serve goroutine (live + retiring legs)
@@ -622,7 +623,16 @@ func (s *Server) buildHTTPServer(addr string) *http.Server {
 // newly generated self-signed certificate (#5866). A cert-generation failure is
 // returned so the caller retains the previous leg (fail-closed).
 func (s *Server) buildHTTPSServer(addr string) (*http.Server, error) {
-	tlsCert, err := s.certGen()
+	// Thread the listener's host into cert generation so a non-loopback
+	// management bind IP (e.g. `web-management https interface 10.0.0.1`)
+	// lands in the cert's SANs and a remote client verifies under strict
+	// hostname checking (#5719 C001 residual). A wildcard/empty host
+	// (":8443") yields "" and is ignored by the SAN builder.
+	bindHost := ""
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		bindHost = h
+	}
+	tlsCert, err := s.certGen(bindHost)
 	if err != nil {
 		return nil, err
 	}
@@ -852,8 +862,29 @@ func isDNSSANSafeHostname(h string) bool {
 
 // generateSelfSignedCert creates or loads a self-signed TLS certificate
 // using the production /etc/xpf/tls paths. See generateSelfSignedCertAt.
-func generateSelfSignedCert() (tls.Certificate, error) {
-	return generateSelfSignedCertAt(tlsDir, certPath, keyPath)
+func generateSelfSignedCert(bindHost string) (tls.Certificate, error) {
+	return generateSelfSignedCertAt(tlsDir, certPath, keyPath, bindHost)
+}
+
+// ipSANsContain reports whether ip is already present in sans. net.IP.Equal
+// normalizes the 4-byte / 16-byte-mapped forms so a v4 SAN never duplicates.
+func ipSANsContain(sans []net.IP, ip net.IP) bool {
+	for _, s := range sans {
+		if s.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// dnsSANsContain reports whether name is already present in names.
+func dnsSANsContain(names []string, name string) bool {
+	for _, n := range names {
+		if n == name {
+			return true
+		}
+	}
+	return false
 }
 
 // generateSelfSignedCertAt creates or loads a self-signed TLS certificate
@@ -880,7 +911,7 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 // only the disk write failed, so HTTPS still installs (the caller binds
 // httpsServer on the nil-error path). A non-nil error is returned ONLY for
 // a true generation failure (no usable cert at all).
-func generateSelfSignedCertAt(dir, certPath, keyPath string) (tls.Certificate, error) {
+func generateSelfSignedCertAt(dir, certPath, keyPath, bindHost string) (tls.Certificate, error) {
 	// Try loading an existing on-disk pair. LoadX509KeyPair reads the cert
 	// first and errors on a key-only / mismatched state → falls through to
 	// regen, which restores a matching pair.
@@ -907,9 +938,9 @@ func generateSelfSignedCertAt(dir, certPath, keyPath string) (tls.Certificate, e
 	// not valid for any names". Always include the loopback names/addresses:
 	// the HTTPS API binds loopback (127.0.0.1/::1) by default and these can
 	// never fail to encode (codex-review-182 C-API TLS hygiene). This covers
-	// a loopback-bound API and local hostname/localhost verification; it does
-	// NOT add the configured management-interface IP (remote-verification-by-
-	// mgmt-IP) — that is a tracked #5719 C001 residual.
+	// a loopback-bound API and local hostname/localhost verification; the
+	// configured management-interface bind IP is added below from bindHost so
+	// remote verification by management IP also succeeds (#5719 C001 residual).
 	dnsNames := []string{"localhost"}
 	ipSANs := []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
 
@@ -928,6 +959,30 @@ func generateSelfSignedCertAt(dir, certPath, keyPath string) (tls.Certificate, e
 		}
 	} else if hostname != "localhost" && isDNSSANSafeHostname(hostname) {
 		dnsNames = append(dnsNames, hostname)
+	}
+
+	// Thread the HTTPS listener's bind host into the SANs so a non-loopback
+	// management bind (e.g. `web-management https interface 10.0.0.1`) verifies
+	// under strict hostname checking from a remote client (#5719 C001 residual).
+	// An IP-literal bind host goes in IPAddresses; a DNS-safe hostname goes in
+	// DNSNames. A loopback, unspecified (0.0.0.0/::), empty, or non-encodable
+	// bind host is skipped (loopback SANs are already present, and a wildcard
+	// bind names no single host); a value already added above is coalesced.
+	// Like the hostname path this can only ADD an encodable SAN, so it never
+	// aborts generation under the #5058 all-or-nothing management lifecycle.
+	//
+	// The bind IP is baked at FIRST generation only: the cert is durable
+	// (#1916 D6) and deliberately NOT re-minted when the bind address later
+	// changes — auto-regenerating would churn remote clients' TOFU pins. That
+	// re-mint-on-change concern is a separate tracked #5719 C001 residual.
+	if bindHost != "" {
+		if ip := net.ParseIP(bindHost); ip != nil {
+			if !ip.IsLoopback() && !ip.IsUnspecified() && !ipSANsContain(ipSANs, ip) {
+				ipSANs = append(ipSANs, ip)
+			}
+		} else if bindHost != "localhost" && isDNSSANSafeHostname(bindHost) && !dnsSANsContain(dnsNames, bindHost) {
+			dnsNames = append(dnsNames, bindHost)
+		}
 	}
 
 	template := &x509.Certificate{

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -300,9 +301,15 @@ type Server struct {
 	// port change could never converge — the bug this replaces. sharedBase is the
 	// pre-auth mux+collector+CSRF handler both legs wrap (per-listener auth gate
 	// via listenerHandler), so the #4162 shared scrape limiter / session cache is
-	// preserved across a rebind. certGen mints a fresh self-signed cert on each
-	// HTTPS (re)bind; bindHost is the listener's host (net.SplitHostPort of the
-	// bind addr) so a non-loopback management IP lands in the cert SANs (#5719).
+	// preserved across a rebind. certGen resolves the HTTPS cert for a (re)bind:
+	// the self-signed cert is DURABLE (#1916 D6), so an existing on-disk pair is
+	// LOADED AS-IS and a fresh cert is minted ONLY when no on-disk pair exists —
+	// a rebind does not re-mint (that would churn remote clients' TOFU pins).
+	// bindHost is the listener's host (net.SplitHostPort of the bind addr); at
+	// FIRST mint it lands a non-loopback management IP in the cert SANs (#5719).
+	// A later bind change is NOT re-minted — a loaded cert whose SANs miss the
+	// new bind host is warned about (generateSelfSignedCertAt), not re-served
+	// silently.
 	sharedBase http.Handler
 	certGen    func(bindHost string) (tls.Certificate, error)
 	lifeMu     sync.Mutex      // guards httpLeg/httpsLeg/rootCtx across reconciles
@@ -619,9 +626,11 @@ func (s *Server) buildHTTPServer(addr string) *http.Server {
 	}
 }
 
-// buildHTTPSServer constructs a fresh HTTPS *http.Server bound-for addr with a
-// newly generated self-signed certificate (#5866). A cert-generation failure is
-// returned so the caller retains the previous leg (fail-closed).
+// buildHTTPSServer constructs a fresh HTTPS *http.Server bound-for addr with
+// its durable self-signed certificate (#5866): certGen LOADS the existing
+// on-disk pair AS-IS and mints a fresh cert ONLY when no on-disk pair exists (a
+// rebind does not re-mint — #1916 D6). A cert-resolution failure is returned so
+// the caller retains the previous leg (fail-closed).
 func (s *Server) buildHTTPSServer(addr string) (*http.Server, error) {
 	// Thread the listener's host into cert generation so a non-loopback
 	// management bind IP (e.g. `web-management https interface 10.0.0.1`)
@@ -877,14 +886,43 @@ func ipSANsContain(sans []net.IP, ip net.IP) bool {
 	return false
 }
 
-// dnsSANsContain reports whether name is already present in names.
+// dnsSANsContain reports whether name is already present in names. DNS names
+// are case-insensitive (RFC 4343), so a comparison uses strings.EqualFold —
+// "MGMT.example.com" and "mgmt.example.com" name the same host and must not be
+// double-encoded as distinct SANs.
 func dnsSANsContain(names []string, name string) bool {
 	for _, n := range names {
-		if n == name {
+		if strings.EqualFold(n, name) {
 			return true
 		}
 	}
 	return false
+}
+
+// bindHostWarnable reports whether bindHost is a concrete management host worth
+// warning about when a loaded on-disk cert does not cover it. An empty host, a
+// wildcard bind (0.0.0.0/::), a loopback host, or "localhost" is NOT warnable:
+// the durable cert always carries the loopback SANs, and a wildcard bind names
+// no single host. Only a non-loopback, non-unspecified management bind can be
+// left uncovered by an older cert.
+func bindHostWarnable(bindHost string) bool {
+	if bindHost == "" || bindHost == "localhost" {
+		return false
+	}
+	if ip := net.ParseIP(bindHost); ip != nil {
+		return !ip.IsLoopback() && !ip.IsUnspecified()
+	}
+	return true
+}
+
+// certCoversHost reports whether leaf's SANs cover host under the SAME strict
+// hostname check a remote TLS client applies: an IP-literal host must appear in
+// the cert's IPAddresses SANs, any other host in its DNSNames SANs (a CN-only
+// or SAN-mismatched cert is not covered). x509.Certificate.VerifyHostname
+// implements exactly that classification, so a false result means a client
+// verifying the connection by host will reject the served cert.
+func certCoversHost(leaf *x509.Certificate, host string) bool {
+	return leaf.VerifyHostname(host) == nil
 }
 
 // generateSelfSignedCertAt creates or loads a self-signed TLS certificate
@@ -916,6 +954,24 @@ func generateSelfSignedCertAt(dir, certPath, keyPath, bindHost string) (tls.Cert
 	// first and errors on a key-only / mismatched state → falls through to
 	// regen, which restores a matching pair.
 	if cert, err := tls.LoadX509KeyPair(certPath, keyPath); err == nil {
+		// The on-disk cert is DURABLE (#1916 D6) and served AS-IS: bindHost is
+		// deliberately NOT baked into a reload, so an A→B management-IP rebind
+		// keeps the original cert rather than churning remote clients' TOFU
+		// pins. But if the loaded cert's SANs do not cover the current bind
+		// host, strict remote verification by that host will silently fail —
+		// warn loudly (naming the bind host and the cert's SANs) so an operator
+		// can re-mint (remove /etc/xpf/tls) instead of chasing a silent
+		// verification failure. Re-minting here would violate the durable
+		// contract, so this is diagnostic only (#5719 C001 residual).
+		if bindHostWarnable(bindHost) {
+			if leaf, perr := x509.ParseCertificate(cert.Certificate[0]); perr == nil &&
+				!certCoversHost(leaf, bindHost) {
+				slog.Warn("loaded management TLS cert does not cover bind host; remote clients verifying by it will fail — remove /etc/xpf/tls to re-mint",
+					"bind_host", bindHost,
+					"cert_dns_sans", leaf.DNSNames,
+					"cert_ip_sans", leaf.IPAddresses)
+			}
+		}
 		return cert, nil
 	}
 

--- a/pkg/api/tls_san_5719_test.go
+++ b/pkg/api/tls_san_5719_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"net"
 	"testing"
@@ -15,7 +16,7 @@ func certLeaf(t *testing.T, hostname string) *x509.Certificate {
 	resetTLSSeams(t)
 	tlsHostname = func() (string, error) { return hostname, nil }
 	dir, certPath, keyPath := tlsPaths(t)
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("hostname=%q: cert generation aborted: %v", hostname, err)
 	}
@@ -145,6 +146,128 @@ func TestGenerateSelfSignedCertHostnameSANClassification(t *testing.T) {
 			t.Fatalf("empty hostname CommonName = %q, want xpf fallback", leaf.Subject.CommonName)
 		}
 	})
+}
+
+// certLeafBind is certLeaf with an explicit HTTPS bind host threaded into cert
+// generation (#5719 C001 residual: the configured management bind IP must reach
+// the SANs so a remote client verifying by mgmt IP succeeds).
+func certLeafBind(t *testing.T, hostname, bindHost string) *x509.Certificate {
+	t.Helper()
+	resetTLSSeams(t)
+	tlsHostname = func() (string, error) { return hostname, nil }
+	dir, certPath, keyPath := tlsPaths(t)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, bindHost)
+	if err != nil {
+		t.Fatalf("hostname=%q bindHost=%q: cert generation aborted: %v", hostname, bindHost, err)
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return leaf
+}
+
+// TestGenerateSelfSignedCertBindHostSAN is a FAIL-ON-REVERT guard for the #5719
+// C001 residual: the configured HTTPS management bind host must be threaded into
+// the cert SANs. Before this fix the cert carried only loopback + kernel-
+// hostname SANs, so `https://<mgmt-ip>:8443` strict-verify failed for a remote
+// client — the original C001 remote-verification goal #6373 did NOT complete.
+//
+// RED on revert: drop the bindHost SAN block in generateSelfSignedCertAt and the
+// management IP / DNS bind host no longer appears in the cert, tripping the
+// mgmt_ip / dns assertions below.
+func TestGenerateSelfSignedCertBindHostSAN(t *testing.T) {
+	t.Run("mgmt_ip_bind_host_becomes_ip_san", func(t *testing.T) {
+		leaf := certLeafBind(t, "fw-node0", "10.0.0.1")
+		assertLoopbackSANs(t, leaf)
+		if !hasIPSAN(leaf, net.ParseIP("10.0.0.1")) {
+			t.Fatalf("management bind IP missing from cert IP SANs %v", leaf.IPAddresses)
+		}
+		if err := leaf.VerifyHostname("10.0.0.1"); err != nil {
+			t.Fatalf("VerifyHostname(10.0.0.1) = %v; want valid (remote mgmt-IP verification must pass)", err)
+		}
+		// The kernel-hostname DNS SAN and loopback SANs still coexist.
+		if !hasDNSSAN(leaf, "fw-node0") {
+			t.Fatalf("hostname DNS SAN dropped when bind IP added: %v", leaf.DNSNames)
+		}
+	})
+
+	t.Run("dns_bind_host_becomes_dns_san", func(t *testing.T) {
+		leaf := certLeafBind(t, "fw-node0", "mgmt.example.com")
+		assertLoopbackSANs(t, leaf)
+		if !hasDNSSAN(leaf, "mgmt.example.com") {
+			t.Fatalf("DNS bind host missing from cert DNS SANs %v", leaf.DNSNames)
+		}
+	})
+
+	t.Run("loopback_bind_host_not_duplicated", func(t *testing.T) {
+		leaf := certLeafBind(t, "fw-node0", "127.0.0.1")
+		want := net.ParseIP("127.0.0.1")
+		n := 0
+		for _, s := range leaf.IPAddresses {
+			if s.Equal(want) {
+				n++
+			}
+		}
+		if n != 1 {
+			t.Fatalf("loopback bind host duplicated 127.0.0.1 in IP SANs %v (count=%d)", leaf.IPAddresses, n)
+		}
+	})
+
+	t.Run("unspecified_bind_host_skipped", func(t *testing.T) {
+		leaf := certLeafBind(t, "fw-node0", "0.0.0.0")
+		if hasIPSAN(leaf, net.ParseIP("0.0.0.0")) {
+			t.Fatalf("wildcard bind host 0.0.0.0 must not be an IP SAN: %v", leaf.IPAddresses)
+		}
+	})
+
+	t.Run("bind_host_equal_hostname_not_duplicated", func(t *testing.T) {
+		leaf := certLeafBind(t, "fw-node0", "fw-node0")
+		n := 0
+		for _, s := range leaf.DNSNames {
+			if s == "fw-node0" {
+				n++
+			}
+		}
+		if n != 1 {
+			t.Fatalf("bind host equal to hostname duplicated DNS SAN fw-node0 (count=%d) in %v", n, leaf.DNSNames)
+		}
+	})
+
+	t.Run("empty_bind_host_is_loopback_only", func(t *testing.T) {
+		// A wildcard bind (":8443") threads bindHost="" — the prior behavior:
+		// loopback + hostname SANs, no extra bind SAN.
+		leaf := certLeafBind(t, "fw-node0", "")
+		assertLoopbackSANs(t, leaf)
+	})
+}
+
+// TestBuildHTTPSServerThreadsBindHost is a FAIL-ON-REVERT guard that
+// buildHTTPSServer extracts the listener host from the bind addr and passes it
+// to certGen. RED on revert: restore the no-arg certGen() call / drop the
+// net.SplitHostPort, and the recorded bindHost is "" instead of "10.0.0.1".
+func TestBuildHTTPSServerThreadsBindHost(t *testing.T) {
+	s := &Server{}
+	var got string
+	s.certGen = func(bindHost string) (tls.Certificate, error) {
+		got = bindHost
+		return tls.Certificate{}, nil
+	}
+	if _, err := s.buildHTTPSServer("10.0.0.1:8443"); err != nil {
+		t.Fatalf("buildHTTPSServer: %v", err)
+	}
+	if got != "10.0.0.1" {
+		t.Fatalf("certGen bindHost = %q, want 10.0.0.1", got)
+	}
+
+	// A wildcard bind yields an empty host (no single name to certify).
+	got = "sentinel"
+	if _, err := s.buildHTTPSServer(":8443"); err != nil {
+		t.Fatalf("buildHTTPSServer wildcard: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("wildcard certGen bindHost = %q, want empty", got)
+	}
 }
 
 // TestIsDNSSANSafeHostname unit-checks the classifier directly.

--- a/pkg/api/tls_san_5719_test.go
+++ b/pkg/api/tls_san_5719_test.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"log/slog"
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -240,6 +243,138 @@ func TestGenerateSelfSignedCertBindHostSAN(t *testing.T) {
 		leaf := certLeafBind(t, "fw-node0", "")
 		assertLoopbackSANs(t, leaf)
 	})
+
+	t.Run("bind_host_case_differs_from_hostname_not_duplicated", func(t *testing.T) {
+		// DNS SANs are case-insensitive (RFC 4343): a bind host that differs
+		// from the kernel hostname only in case must COALESCE, not double-
+		// encode. RED on revert: dnsSANsContain drops strings.EqualFold and
+		// "FW-NODE0" is appended alongside "fw-node0" (count=2).
+		leaf := certLeafBind(t, "fw-node0", "FW-NODE0")
+		n := 0
+		for _, s := range leaf.DNSNames {
+			if strings.EqualFold(s, "fw-node0") {
+				n++
+			}
+		}
+		if n != 1 {
+			t.Fatalf("case-variant bind host duplicated DNS SAN fw-node0 (count=%d) in %v", n, leaf.DNSNames)
+		}
+	})
+}
+
+// TestLoadedCertBindHostMismatchWarns is a FAIL-ON-REVERT guard for the #5719
+// C001 silent-stale-cert-on-rebind residual: generateSelfSignedCertAt LOADS an
+// existing on-disk cert AS-IS (the durable #1916 D6 contract — it must NOT
+// re-mint on a bind change, which would churn remote clients' TOFU pins). But a
+// cert minted for management host A does NOT cover a later rebind to host B, so
+// strict remote verification by B silently fails. The load-success path must
+// emit a diagnostic naming the uncovered bind host so an operator can re-mint
+// (remove /etc/xpf/tls), rather than serving the stale cert in silence.
+//
+// RED on revert: drop the bindHostWarnable/certCoversHost check on the load-
+// success path (or neutralize certCoversHost to always return true) and the
+// A→B reload emits no warning — the mismatch subtests below fail.
+func TestLoadedCertBindHostMismatchWarns(t *testing.T) {
+	restore := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	// mintThenReload mints a durable cert for firstBind at a fresh temp dir,
+	// then RELOADS it (the on-disk pair now exists) for secondBind, returning
+	// any slog output the reload emits.
+	mintThenReload := func(t *testing.T, hostname, firstBind, secondBind string) string {
+		t.Helper()
+		resetTLSSeams(t)
+		tlsHostname = func() (string, error) { return hostname, nil }
+		dir, certPath, keyPath := tlsPaths(t)
+		if _, err := generateSelfSignedCertAt(dir, certPath, keyPath, firstBind); err != nil {
+			t.Fatalf("first mint (bind %q): %v", firstBind, err)
+		}
+		var buf bytes.Buffer
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, secondBind)
+		if err != nil {
+			t.Fatalf("reload (bind %q): %v", secondBind, err)
+		}
+		// The reload must return the SAME durable leaf bytes — the #1916 D6
+		// no-re-mint contract the warning exists to compensate for.
+		leaf, perr := x509.ParseCertificate(cert.Certificate[0])
+		if perr != nil {
+			t.Fatalf("parse reloaded leaf: %v", perr)
+		}
+		if leaf.Subject.CommonName != hostname && hostname != "" {
+			t.Fatalf("reload minted a fresh cert (CN=%q) instead of loading the durable pair", leaf.Subject.CommonName)
+		}
+		return buf.String()
+	}
+
+	const mismatchMsg = "does not cover bind host"
+
+	t.Run("ip_rebind_mismatch_warns", func(t *testing.T) {
+		out := mintThenReload(t, "fw-node0", "10.0.0.1", "10.0.0.2")
+		if !strings.Contains(out, mismatchMsg) {
+			t.Fatalf("A→B management-IP rebind must warn on a stale cert; got log %q", out)
+		}
+		if !strings.Contains(out, "10.0.0.2") {
+			t.Fatalf("warning must name the uncovered bind host 10.0.0.2; got %q", out)
+		}
+	})
+
+	t.Run("dns_rebind_mismatch_warns", func(t *testing.T) {
+		out := mintThenReload(t, "fw-node0", "mgmt-a.example.com", "mgmt-b.example.com")
+		if !strings.Contains(out, mismatchMsg) {
+			t.Fatalf("A→B DNS rebind must warn on a stale cert; got %q", out)
+		}
+	})
+
+	t.Run("same_bind_reload_is_silent", func(t *testing.T) {
+		out := mintThenReload(t, "fw-node0", "10.0.0.1", "10.0.0.1")
+		if strings.Contains(out, mismatchMsg) {
+			t.Fatalf("a reload with the SAME covered bind host must not warn; got %q", out)
+		}
+	})
+
+	t.Run("loopback_rebind_is_silent", func(t *testing.T) {
+		// Loopback SANs are always present, so a loopback rebind is covered and
+		// not warnable (bindHostWarnable gates it out).
+		out := mintThenReload(t, "fw-node0", "10.0.0.1", "127.0.0.1")
+		if strings.Contains(out, mismatchMsg) {
+			t.Fatalf("a loopback rebind must not warn (loopback SANs always present); got %q", out)
+		}
+	})
+}
+
+// TestCertCoversHostAndWarnable unit-checks the two folded helpers directly so a
+// neutralization is caught even if the load-path integration changes.
+func TestCertCoversHostAndWarnable(t *testing.T) {
+	leaf := certLeafBind(t, "fw-node0", "10.0.0.1")
+	if !certCoversHost(leaf, "10.0.0.1") {
+		t.Fatal("certCoversHost must be true for the covered mgmt IP")
+	}
+	if certCoversHost(leaf, "10.0.0.2") {
+		t.Fatal("certCoversHost must be false for an uncovered mgmt IP")
+	}
+	if !certCoversHost(leaf, "127.0.0.1") {
+		t.Fatal("certCoversHost must be true for a loopback SAN")
+	}
+
+	warnable := []struct {
+		host string
+		want bool
+	}{
+		{"10.0.0.1", true},
+		{"mgmt.example.com", true},
+		{"", false},
+		{"localhost", false},
+		{"127.0.0.1", false},
+		{"::1", false},
+		{"0.0.0.0", false},
+		{"::", false},
+	}
+	for _, c := range warnable {
+		if got := bindHostWarnable(c.host); got != c.want {
+			t.Errorf("bindHostWarnable(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
 }
 
 // TestBuildHTTPSServerThreadsBindHost is a FAIL-ON-REVERT guard that

--- a/pkg/api/tls_test.go
+++ b/pkg/api/tls_test.go
@@ -75,7 +75,7 @@ func TestGenerateSelfSignedCertHappyPath(t *testing.T) {
 	resetTLSSeams(t)
 	dir, certPath, keyPath := tlsPaths(t)
 
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestGenerateSelfSignedCertHappyPath(t *testing.T) {
 		t.Fatal("on-disk cert differs from returned cert")
 	}
 	// A second call loads the persisted pair (stable cert — no churn).
-	cert2, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert2, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestGenerateSelfSignedCertFailedCertWrite(t *testing.T) {
 
 	// Persistence failure → usable cert returned with NIL error (HTTPS
 	// still installs); only the disk write failed.
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("persistence failure must return nil error, got %v", err)
 	}
@@ -146,7 +146,7 @@ func TestGenerateSelfSignedCertFailedKeyWrite(t *testing.T) {
 		return fsatomic.WriteFileDurable(path, data, perm, opts...)
 	}
 
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("persistence failure must return nil error, got %v", err)
 	}
@@ -179,7 +179,7 @@ func TestGenerateSelfSignedCertMismatchedStartRegens(t *testing.T) {
 
 	// LoadX509KeyPair rejects the mismatch → regen runs → strict-remove of
 	// the stale pair → a fresh MATCHING pair lands on disk.
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestGenerateSelfSignedCertStaleCertOnlyRegens(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestGenerateSelfSignedCertStrictRemoveFailureAborts(t *testing.T) {
 		return fsatomic.WriteFileDurable(path, data, perm, opts...)
 	}
 
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("persistence abort must still return usable in-memory cert with nil error, got %v", err)
 	}
@@ -268,7 +268,7 @@ func TestGenerateSelfSignedCertDirSyncFailureAborts(t *testing.T) {
 		return fsatomic.WriteFileDurable(path, data, perm, opts...)
 	}
 
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("dir-sync abort must return usable in-memory cert with nil error, got %v", err)
 	}
@@ -292,7 +292,7 @@ func TestGenerateSelfSignedCertMkdirFailureAborts(t *testing.T) {
 		return fsatomic.WriteFileDurable(path, data, perm, opts...)
 	}
 
-	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath)
+	cert, err := generateSelfSignedCertAt(dir, certPath, keyPath, "")
 	if err != nil {
 		t.Fatalf("mkdir abort must return usable in-memory cert with nil error, got %v", err)
 	}


### PR DESCRIPTION
## Summary

Triage + fix drive for cohort **#5719** (codex-review-182 C-API — diagnostic /
automation API hardening survivors). Scope limited to `pkg/api` + `pkg/grpcapi`
(Go). Re-verified every sub-item firsthand against current `origin/master`
(the issue body's `fc479ca65` was stale).

The one open, real, independent, low-risk item is fixed here; the rest are
dispositioned below. Cohort stays **OPEN** (deferred residual remains).

## The fix — C001 residual-1: management bind IP not in cert SANs

The auto-generated HTTPS cert (`generateSelfSignedCertAt`, used when no operator
cert is provisioned) carried only loopback + kernel-hostname SANs. A firewall
whose `web-management https interface` binds a **non-loopback management IP**
minted a cert that never named that IP, so a remote admin at
`https://<mgmt-ip>:8443` under strict verification failed with `x509:
certificate is not valid for any names`. This was the original C001
remote-verification goal that merged #6373 (loopback + hostname SANs) did **not**
complete.

`buildHTTPSServer(addr)` now extracts the listener host (`net.SplitHostPort`) and
threads it through the `certGen` seam (`func(bindHost string)`) into
`generateSelfSignedCertAt`:

- non-loopback IP-literal bind host → **IP SANs**; DNS-safe bind host → **DNS SANs**
- loopback / unspecified (`0.0.0.0`/`::`) / wildcard-empty (`:8443`) /
  non-encodable → **skipped**; an already-present value is **coalesced**
- can only ever ADD an encodable SAN → never aborts generation under the #5058
  all-or-nothing management-server lifecycle

Baked at **first generation only**: the #1916 D6 durable cert is deliberately
NOT re-minted on a later bind/host-name change (that would churn remote clients'
TOFU pins).

Two fail-on-revert tests, each verified RED via a clean-assertion neutralization:
- `TestGenerateSelfSignedCertBindHostSAN` — mgmt-IP + DNS bind-host threading,
  loopback-not-duplicated, unspecified-skipped, hostname dedup, empty=loopback-only
- `TestBuildHTTPSServerThreadsBindHost` — the `net.SplitHostPort` host extraction

## Per-item triage

| Cohort sub-item | Disposition | Evidence |
|---|---|---|
| Unknown NAT stats selector | **ALREADY-FIXED** (#6373, `f068360db`) | `pkg/grpcapi/server_nat.go:216-227` rejects an unknown `nat_type` with `codes.InvalidArgument`; pinned by `server_nat_selector_5719_test.go` |
| SAN-less generated cert (base) | **ALREADY-FIXED** (#6373) | `generateSelfSignedCertAt` adds loopback + guarded hostname SANs; `tls_san_5719_test.go` |
| C001 residual-1: mgmt bind IP not in SANs | **FIXED (this PR)** | `pkg/api/server.go` bind-host threading + 2 fail-on-revert tests |
| C001 residual-2: no re-mint on host-name / bind-addr change | **DEFERRED (residual, cohort stays open)** | Conflicts with the #1916 D6 durable-cert / TOFU-pin contract; needs a mint-ordering / invalidation hook + a churn decision — not a low-risk drive-by |
| Applied-nft truth projection gaps | **NO CONCRETE IN-SCOPE RESIDUAL** | Bucket-theme line in `docs/reviews/archive/codex-review-182.md:105` with no traceable finding ID. The API/gRPC truth surfaces (`HostInboundKernelDeniesUnavailable` #3681, SSOT `hostInboundToREST` #3375/#3627) are already complete; any nft-apply projection lives in `pkg/daemon` (out of the pkg/api + pkg/grpcapi scope) |

## Validation

- `go build` / `go vet` / `gofmt -l` clean on `pkg/api` + `pkg/grpcapi`
- `go test ./pkg/api/... ./pkg/grpcapi/...` GREEN
- Both new tests confirmed RED on a clean-assertion revert (no build-break false red)

Advances #5719.