### PR TITLE
config,grpcapi,cli: fix 4 codex-181 low-materiality survivors (#5649)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -58074,3 +58074,48 @@ top.
   - **File(s)**: pkg/cli/cli_request_policies_check.go,
     pkg/cli/cli_request_policies_check_test.go, pkg/policymatch/policymatch.go,
     pkg/policymatch/README.md, docs/pr/812-tx-latency-histogram/plan.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: Triaged cohort #5649 (codex-review-181 low-materiality / bounded-
+    hardening survivors, 19 IDs) against current origin/master 55cf5a9b2 and
+    fixed the 4 REAL + INDEPENDENT + LOW-RISK + in-Go-scope items in one PR
+    ("Advances #5649"), each with a fail-on-revert test (neutralize -> clean
+    assertion RED verified firsthand, restore -> GREEN).
+    - **M22** (C181-M22): `security ipsec vpn <v> df-bit` was an untyped leaf,
+      so a typo (`cler`) committed clean and the swanctl renderer then OMITTED
+      `copy_df`, leaving strongSwan's copy-DF default (opposite of intended
+      `clear`) -> PMTUD blackhole. Typed the leaf ValueEnumOf +
+      ValidateEnum([copy,set,clear]), mirroring the #4301 establish-tunnels
+      pattern. Test rejects cler/copyy/on/yes, accepts copy/set/clear.
+    - **C09** (C181-C09): gRPC `test-zone:` selector parser had no `seen` set,
+      so `interface=a,interface=b` silently last-won and archived a DIFFERENT
+      interface's zone/posture. Added a duplicate-selector reject mirroring the
+      #4921 showTestRouting / #3709 showTestPolicy contract.
+    - **C11** (C181-C11): session page-token decoders used `len(b) <
+      binary.Size(key)`, so oversized/trailing-byte tokens aliased the same
+      cursor and amplified base64/hex allocations up to the 16 MiB gRPC cap.
+      Require EXACT ABI length in decodeSessionKeyV4/V6 and reject tokens over
+      maxPageTokenLen (256) before any decode.
+    - **C13** (C181-C13): the pre-prompt commit-confirm poll used
+      context.Background(), so a daemon that accepted the connection but never
+      completed GetConfigModeStatus wedged the interactive CLI before Readline.
+      Extracted confirmPending() using a bounded context (confirmPendingTimeout,
+      2s); test asserts the poll context carries a deadline.
+    DEFER (Rust / out of Go scope -> dataplane owner): M04 (afxdp/icmp.rs),
+    M05 (slowpath.rs), M13 (nat/allocator.rs), C03 (read_bytes AF_XDP),
+    C15/C16 (test/incus/cold-path-flooder/src/main.rs), C19 (filter matching.rs).
+    Real Go-scope but NOT low-risk (own PR, kept in cohort): C06 (journal fsync
+    inode-retention concurrency), C12a/C12b (feed join-ownership / aggregate
+    budget), C14 (policymatch simulator quarantine projection), C20 (CLI coarse
+    host-verdict rendering), C08 (gRPC counters-available proto field),
+    C10 (SSE post-shutdown Close), M18 (duplicate NAT rule-name rejection —
+    config-acceptance behavior change). No HA/cluster/vrrp/failover code touched.
+    build+vet+gofmt clean; full go test ./pkg/config ./pkg/grpcapi ./cmd/cli
+    ./pkg/ipsec GREEN.
+  - **File(s)**: pkg/config/schema_security.go,
+    pkg/config/schema_ipsec_dfbit_enum_5649_test.go,
+    pkg/grpcapi/server_show_zones_text.go,
+    pkg/grpcapi/server_show_zones_dupselector_5649_test.go,
+    pkg/grpcapi/server_sessions.go,
+    pkg/grpcapi/pagination_canonical_5649_test.go, cmd/cli/main.go,
+    cmd/cli/confirm_pending_bounded_5649_test.go, docs/config-schema.md, _Log.md

--- a/cmd/cli/confirm_pending_bounded_5649_test.go
+++ b/cmd/cli/confirm_pending_bounded_5649_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
+)
+
+// confirmPendingProbeClient records whether the GetConfigModeStatus poll passed
+// a context carrying a deadline. It embeds the generated client so only
+// GetConfigModeStatus is stubbed; any other RPC nil-panics.
+type confirmPendingProbeClient struct {
+	pb.BpfrxServiceClient
+	sawDeadline bool
+	confirm     bool
+}
+
+func (f *confirmPendingProbeClient) GetConfigModeStatus(
+	ctx context.Context, _ *pb.GetConfigModeStatusRequest, _ ...grpc.CallOption,
+) (*pb.GetConfigModeStatusResponse, error) {
+	_, f.sawDeadline = ctx.Deadline()
+	return &pb.GetConfigModeStatusResponse{ConfirmPending: f.confirm}, nil
+}
+
+// #5649 (codex-181 C181-C13): the pre-prompt commit-confirm status poll used
+// context.Background(), so a daemon that accepted the connection but never
+// completed GetConfigModeStatus would wedge the interactive client before
+// Readline — there is no active command context for Ctrl-C to cancel here.
+// The poll now runs on a BOUNDED context (confirmPendingTimeout).
+//
+// FAIL-ON-REVERT: restoring context.Background() in confirmPending makes the
+// polled context carry no deadline, so sawDeadline is false and this goes RED.
+func TestConfirmPendingUsesBoundedContext_5649(t *testing.T) {
+	fake := &confirmPendingProbeClient{confirm: true}
+
+	if !confirmPending(fake) {
+		t.Fatal("confirmPending should report the pending state the daemon returned")
+	}
+	if !fake.sawDeadline {
+		t.Fatal("GetConfigModeStatus poll must use a bounded context (a deadline); " +
+			"context.Background() would let an unresponsive daemon wedge the prompt")
+	}
+
+	// A daemon reporting no pending confirm yields false without spuriously
+	// printing the advisory line.
+	fake.confirm = false
+	if confirmPending(fake) {
+		t.Fatal("confirmPending should be false when ConfirmPending is false")
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -198,11 +198,8 @@ func main() {
 	defer signal.Stop(sigCh)
 
 	for {
-		if c.configMode.Load() {
-			st, err := client.GetConfigModeStatus(context.Background(), &pb.GetConfigModeStatusRequest{})
-			if err == nil && st.ConfirmPending {
-				fmt.Println("[commit confirmed pending - issue 'commit' to confirm]")
-			}
+		if c.configMode.Load() && confirmPending(client) {
+			fmt.Println("[commit confirmed pending - issue 'commit' to confirm]")
 		}
 
 		line, err := rl.Readline()
@@ -265,6 +262,24 @@ func exitConfigureBounded(client pb.BpfrxServiceClient) {
 	ctx, cancel := context.WithTimeout(context.Background(), exitConfigureTimeout)
 	defer cancel()
 	_, _ = client.ExitConfigure(ctx, &pb.ExitConfigureRequest{})
+}
+
+// confirmPendingTimeout bounds the pre-prompt commit-confirm status poll
+// (#5649, C181-C13). The advisory poll runs before Readline with no active
+// command context, so a Ctrl-C cannot cancel it.
+const confirmPendingTimeout = 2 * time.Second
+
+// confirmPending reports whether a commit-confirmed rollback is armed, using a
+// BOUNDED context (#5649, C181-C13). The poll fires before every config-mode
+// prompt with no command context to cancel it, so a daemon that accepts the
+// connection but never completes GetConfigModeStatus would otherwise wedge the
+// interactive client indefinitely before Readline. On timeout/error the prompt
+// simply proceeds without the advisory line.
+func confirmPending(client pb.BpfrxServiceClient) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), confirmPendingTimeout)
+	defer cancel()
+	st, err := client.GetConfigModeStatus(ctx, &pb.GetConfigModeStatusRequest{})
+	return err == nil && st != nil && st.ConfirmPending
 }
 
 // interruptWindow is the double-Ctrl-C window: a second interrupt within this

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3279,6 +3279,18 @@ reserved for whole-dataplane selection where a rewrite shim
     The accepted sets are EXACTLY the generator-recognized values (a value the
     generator handles but the enum omitted would be a false-reject regression).
     A typo is now rejected at commit with an error naming the bad value.
+  - **#5649 (IPsec VPN `df-bit` enum, codex-181 C181-M22):** the `security
+    ipsec vpn <v> df-bit` leaf was untyped free-form (`args:1`, no validator),
+    so a typo committed clean and was then silently dropped by the swanctl
+    generator — the same MEDIUM footgun class as #3896. `df-bit` is now
+    `ValidateEnum([copy, set, clear])`, matching the `pkg/ipsec/policy.go`
+    renderer switch EXACTLY: it emits `copy_df = yes` for `copy`/`set` and
+    `copy_df = no` for `clear`, and OMITS `copy_df` for any other spelling.
+    An intended `clear` typed as `cler` therefore left strongSwan's copy-DF
+    default in force (the opposite of `clear`) and could blackhole oversized
+    encapsulated packets via PMTUD while commit reported success. This is the
+    input-domain gate the #4015 valid-token `set`/`clear` mapping fix and the
+    #4301 `establish-tunnels` enum did not cover.
   - **#2404 (responder-only / dynamic-IP peer):** the `security ike gateway
     <g> dynamic` node now declares a `hostname <fqdn>` child (it was a
     `children: nil` leaf in both the `ike` and `ipsec` stanza copies of the

--- a/pkg/config/schema_ipsec_dfbit_enum_5649_test.go
+++ b/pkg/config/schema_ipsec_dfbit_enum_5649_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5649 (codex-181 C181-M22) — `set security ipsec vpn <v> df-bit <mode>` was
+// an untyped free-form leaf (args:1, no validator), so a typo committed CLEAN
+// and was then silently dropped by the strongSwan generator: pkg/ipsec/policy.go
+// only emits `copy_df` for copy/set/clear and OMITS the directive for anything
+// else, leaving strongSwan's copy-DF default. An operator intending `df-bit
+// clear` who typed `cler` would therefore keep the outer DF copied (the
+// opposite of clear) and blackhole oversized encapsulated packets via PMTUD —
+// while commit reported success. The leaf is now typed with ValidateEnum over
+// exactly {copy, set, clear}, matching the renderer's switch (the #4301
+// establish-tunnels pattern).
+//
+// FAIL-ON-REVERT: reverting the df-bit leaf in schema_security.go back to
+// untyped (args:1 with no validator) makes every reject case below return nil
+// and go RED — a typo would commit clean and silently invert DF handling.
+func TestIPsecDFBitEnumSchemaGate_5649(t *testing.T) {
+	reject := func(set, badVal string) {
+		t.Helper()
+		tree := flatTreeFromSets(t, set)
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("%q: expected SchemaValidate to REJECT typo, got nil (silent copy-DF default)", set)
+		}
+		if !strings.Contains(err.Error(), badVal) {
+			t.Fatalf("%q: reject error %q should name the bad value %q", set, err, badVal)
+		}
+	}
+	accept := func(set string) {
+		t.Helper()
+		tree := flatTreeFromSets(t, set)
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("%q: expected SchemaValidate to ACCEPT valid value, got %v", set, err)
+		}
+	}
+
+	// --- Typos / unhandled tokens are rejected (fail-closed, error names value) ---
+	reject("set security ipsec vpn tun1 df-bit cler", "cler")   // → would keep copy-DF default
+	reject("set security ipsec vpn tun1 df-bit copyy", "copyy") // → renderer omits copy_df
+	reject("set security ipsec vpn tun1 df-bit on", "on")       // unhandled mode
+	reject("set security ipsec vpn tun1 df-bit yes", "yes")     // unhandled mode
+
+	// --- Every value the renderer handles must still commit (no false reject) ---
+	for _, v := range []string{"copy", "set", "clear"} {
+		accept("set security ipsec vpn tun1 df-bit " + v)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -1127,7 +1127,19 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				valueType: ValueSecureTunnelIf, valueDesc: "IPsec secure-tunnel interface (st<N> or st<N>.<unit>)",
 				valueExamples: []string{"st0", "st0.1"},
 				validator:     ValidateSecureTunnelBindInterface, children: nil},
-			"df-bit": {desc: "Outer-header DF bit handling (copy|set|clear)", args: 1, placeholder: "<mode>", children: nil},
+			// #5649 (C181-M22): type the enum so a typo (`cler`) fails closed at
+			// commit instead of storing verbatim and silently becoming
+			// strongSwan's copy-DF default. The renderer at pkg/ipsec/policy.go
+			// only emits copy_df for copy/set/clear and OMITS the directive for
+			// anything else, so `df-bit cler` would leave the outer DF copied
+			// (the opposite of an intended `clear`) and blackhole oversized
+			// encapsulated packets via PMTUD while commit reported success.
+			// Mirrors the #4301 establish-tunnels pattern; the copy/set/clear
+			// set matches the renderer's switch exactly.
+			"df-bit": {desc: "Outer-header DF bit handling (copy|set|clear)", args: 1, placeholder: "<mode>",
+				valueType: ValueEnumOf, valueDesc: "outer-header DF bit mode",
+				valueExamples: []string{"copy", "set", "clear"},
+				validator:     ValidateEnum([]string{"copy", "set", "clear"}), children: nil},
 			// #4301 (V-5): type the enum so a typo (`on-tarffic`) fails closed
 			// at commit instead of storing verbatim and silently degrading to
 			// on-traffic. Only `immediately` is acted on (start_action =

--- a/pkg/grpcapi/pagination_canonical_5649_test.go
+++ b/pkg/grpcapi/pagination_canonical_5649_test.go
@@ -1,0 +1,73 @@
+package grpcapi
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	dataplane "github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #5649 (codex-181 C181-C11): session page tokens were decoded with a `len(b) <
+// binary.Size(key)` check, so any oversized/trailing-byte token hex-decoded to
+// the same cursor as the canonical key (a noncanonical opaque token), and a
+// token near the 16 MiB gRPC limit forced transient base64/hex allocations many
+// times the key size before the ABI prefix decode discarded the excess. The
+// decoders now require the EXACT ABI length and parsePageToken rejects tokens
+// over maxPageTokenLen before any decode.
+//
+// FAIL-ON-REVERT: changing the exact-length checks in decodeSessionKeyV4/V6
+// back to `<` makes the trailing-byte cases decode successfully and go RED;
+// removing the maxPageTokenLen guard makes the oversized case decode instead of
+// erroring.
+func TestPageTokenCanonical_5649(t *testing.T) {
+	// A valid round-trip token still decodes cleanly (no false rejects).
+	var v4 dataplane.SessionKey
+	v4.SrcIP = [4]byte{10, 0, 0, 1}
+	v4.DstIP = [4]byte{10, 0, 0, 2}
+	v4.SrcPort = 1111
+	v4.DstPort = 2222
+	v4.Protocol = 6
+	kind, kb, err := parsePageToken(encodePageTokenV4(v4))
+	if err != nil || kind != "v4" {
+		t.Fatalf("valid v4 round-trip: kind=%q err=%v", kind, err)
+	}
+	if _, err := decodeSessionKeyV4(kb); err != nil {
+		t.Fatalf("valid v4 key must decode: %v", err)
+	}
+
+	// A token whose hex payload carries a trailing byte beyond the ABI key must
+	// be rejected — previously it silently aliased the same cursor.
+	raw := make([]byte, binary.Size(v4)+1)
+	trailing := "v4:" + hex.EncodeToString(raw)
+	tok := base64.RawURLEncoding.EncodeToString([]byte(trailing))
+	kind, kb, err = parsePageToken(tok)
+	if err != nil || kind != "v4" {
+		t.Fatalf("trailing-byte token should still parse as v4: kind=%q err=%v", kind, err)
+	}
+	if _, err := decodeSessionKeyV4(kb); err == nil {
+		t.Fatal("decodeSessionKeyV4 must REJECT a key with a trailing byte (noncanonical token)")
+	} else if !strings.Contains(err.Error(), "wrong length") {
+		t.Fatalf("trailing-byte reject error %q should mention wrong length", err)
+	}
+
+	// The v6 decoder enforces the same exact-length invariant.
+	var v6 dataplane.SessionKeyV6
+	rawV6 := make([]byte, binary.Size(v6)+1)
+	if _, err := decodeSessionKeyV6(rawV6); err == nil {
+		t.Fatal("decodeSessionKeyV6 must REJECT an over-length key")
+	}
+
+	// An oversized encoded token is rejected before any base64/hex decode.
+	// Use a literal length (not the maxPageTokenLen const) so this test still
+	// compiles when the fix is reverted for the fail-on-revert gate. 8 KiB is
+	// far above any legitimate v4/v6 token and any reasonable cap.
+	huge := "v4:" + strings.Repeat("ab", 4096)
+	if _, _, err := parsePageToken(huge); err == nil {
+		t.Fatal("parsePageToken must REJECT a token far larger than any real cursor")
+	} else if !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("oversized reject error %q should mention too long", err)
+	}
+}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -1829,8 +1829,20 @@ func encodePageTokenV6Start() string {
 	return base64.RawURLEncoding.EncodeToString([]byte("v6start"))
 }
 
+// maxPageTokenLen caps the encoded page_token before any base64/hex decode
+// (#5649, C181-C11). The longest legitimate token is "v6:" plus the hex of a
+// SessionKeyV6 (base64 of ~83 bytes, under 128); anything larger is
+// noncanonical. Without this cap a caller could send a token near the 16 MiB
+// gRPC receive limit and force transient base64/hex allocations many times the
+// key size before the ABI prefix decode discards the excess. 256 leaves ample
+// headroom for the real formats while rejecting the amplification.
+const maxPageTokenLen = 256
+
 // parsePageToken returns kind ("v4", "v6", "v6start") and raw key bytes.
 func parsePageToken(token string) (kind string, keyBytes []byte, err error) {
+	if len(token) > maxPageTokenLen {
+		return "", nil, fmt.Errorf("page_token too long: %d bytes", len(token))
+	}
 	raw, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
 		return "", nil, fmt.Errorf("invalid page_token encoding: %w", err)
@@ -1858,8 +1870,12 @@ func parsePageToken(token string) (kind string, keyBytes []byte, err error) {
 
 func decodeSessionKeyV4(b []byte) (dataplane.SessionKey, error) {
 	var key dataplane.SessionKey
-	if len(b) < binary.Size(key) {
-		return key, fmt.Errorf("v4 key too short: %d", len(b))
+	// #5649 (C181-C11): require the EXACT ABI key length. A `<` check accepted
+	// trailing bytes, so many distinct oversized tokens hex-decoded to the same
+	// cursor (a noncanonical opaque token) and amplified allocations. The
+	// encoder always emits exactly binary.Size(key) bytes.
+	if len(b) != binary.Size(key) {
+		return key, fmt.Errorf("v4 key wrong length: %d (want %d)", len(b), binary.Size(key))
 	}
 	copy(key.SrcIP[:], b[0:4])
 	copy(key.DstIP[:], b[4:8])
@@ -1871,8 +1887,9 @@ func decodeSessionKeyV4(b []byte) (dataplane.SessionKey, error) {
 
 func decodeSessionKeyV6(b []byte) (dataplane.SessionKeyV6, error) {
 	var key dataplane.SessionKeyV6
-	if len(b) < binary.Size(key) {
-		return key, fmt.Errorf("v6 key too short: %d", len(b))
+	// #5649 (C181-C11): exact ABI key length — see decodeSessionKeyV4.
+	if len(b) != binary.Size(key) {
+		return key, fmt.Errorf("v6 key wrong length: %d (want %d)", len(b), binary.Size(key))
 	}
 	copy(key.SrcIP[:], b[0:16])
 	copy(key.DstIP[:], b[16:32])

--- a/pkg/grpcapi/server_show_zones_dupselector_5649_test.go
+++ b/pkg/grpcapi/server_show_zones_dupselector_5649_test.go
@@ -1,0 +1,43 @@
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #5649 (codex-181 C181-C09): showTestZone parsed `test-zone:` selectors with
+// no `seen` map, so a repeated `interface=a,interface=b` silently LAST-WON in
+// the switch — the archived diagnostic reported a DIFFERENT interface's zone
+// and host-inbound posture than the operator typed, with no warning. The
+// handler now rejects a repeated selector, matching the #4921 showTestRouting
+// and #3709 showTestPolicy duplicate-selector contract.
+//
+// cfg is nil here, so a NON-duplicate selector proceeds to the "No active
+// configuration" diagnostic; a duplicate is a client-input grammar error and
+// is reported FIRST, independent of config availability.
+//
+// RED-on-revert: without the `seen` map the duplicate case falls through to
+// "No active configuration" (silently using the last interface value) instead
+// of naming the repeated selector.
+func TestShowTestZoneRejectsDuplicateSelector_5649(t *testing.T) {
+	s := &Server{}
+
+	const topic = "test-zone:interface=ge-0/0/1.0,interface=ge-0/0/9.0"
+	const wantSubstr = `selector "interface" specified more than once`
+
+	var buf strings.Builder
+	if _, err := s.showTestZone(&pb.ShowTextRequest{Topic: topic}, nil, &buf); err != nil {
+		t.Fatalf("showTestZone(%q) error = %v", topic, err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, wantSubstr) {
+		t.Errorf("showTestZone(%q) = %q; want it to contain %q", topic, out, wantSubstr)
+	}
+	// A duplicate must NOT fall through to the config/lookup path: it is an
+	// input error that fully short-circuits the query.
+	if strings.Contains(out, "No active configuration") {
+		t.Errorf("showTestZone(%q) fell through to the config path: %q", topic, out)
+	}
+}

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -209,6 +209,13 @@ func (s *Server) showTestZone(req *pb.ShowTextRequest, cfg *config.Config, buf *
 	// bare `test-zone:` (empty params) still falls through to the
 	// "Missing interface parameter" diagnostic below.
 	if params != "" {
+		// #5649 (C181-C09): reject a repeated selector key. Without a `seen`
+		// set a duplicate `interface=a,interface=b` silently LAST-WON in the
+		// switch below, so the archived diagnostic reported a DIFFERENT
+		// interface's zone/posture than the operator typed. This mirrors the
+		// #4921 showTestRouting and #3709 showTestPolicy duplicate-selector
+		// contract (server_show_routes_text.go).
+		seen := map[string]bool{}
 		for _, kv := range strings.Split(params, ",") {
 			parts := strings.SplitN(kv, "=", 2)
 			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -217,6 +224,17 @@ func (s *Server) showTestZone(req *pb.ShowTextRequest, cfg *config.Config, buf *
 				}
 				continue
 			}
+			if seen[parts[0]] {
+				// A duplicate KNOWN key would last-win below; a duplicate
+				// UNKNOWN key already recorded an "unknown selector" error on
+				// its first occurrence (parseErr is set-once), so this only
+				// overrides when no earlier grammar error was captured.
+				if parseErr == nil {
+					parseErr = fmt.Errorf("selector %q specified more than once", parts[0])
+				}
+				continue
+			}
+			seen[parts[0]] = true
 			switch parts[0] {
 			case "interface":
 				ifName = parts[1]


### PR DESCRIPTION
## Summary

Triage of cohort **#5649** (codex-review-181 low-materiality / bounded-hardening survivors, 19 IDs) against **current origin/master `55cf5a9b2`**. Every ID was re-verified firsthand at the current tip (the report's own "verified against" SHA `cd1dea6ab` is older). Four are REAL + INDEPENDENT + LOW-RISK + in Go control-plane scope and are fixed here, each with a **fail-on-revert test** (neutralize → clean assertion RED verified firsthand → restore → GREEN). The other 15 are dispositioned below; none is silently dropped.

**No HA-touching code** (no `pkg/cluster`, `pkg/vrrp`, session-sync, or failover) — no loss-cluster failover smoke required.

## Fixed in this PR

| ID | Title | File(s) | Fix | Test (RED-on-revert) |
|----|-------|---------|-----|------|
| **M22** | IPsec `df-bit` typo commits and silently becomes copy-DF default → PMTUD blackhole | `pkg/config/schema_security.go` | Type leaf `ValueEnumOf` + `ValidateEnum([copy,set,clear])` (mirrors #4301) | `schema_ipsec_dfbit_enum_5649_test.go` |
| **C09** | gRPC `test-zone:` duplicate `interface=` selector silently last-wins | `pkg/grpcapi/server_show_zones_text.go` | Reject repeated selector (mirrors #4921/#3709 contract) | `server_show_zones_dupselector_5649_test.go` |
| **C11** | Session page-token accepts oversized/trailing-byte noncanonical keys | `pkg/grpcapi/server_sessions.go` | Exact ABI length in `decodeSessionKeyV4/V6`; cap token at `maxPageTokenLen` before decode | `pagination_canonical_5649_test.go` |
| **C13** | Config-mode commit-confirm poll uses `context.Background()` → wedges CLI before Readline | `cmd/cli/main.go` | Extract `confirmPending()` on a bounded context | `confirm_pending_bounded_5649_test.go` |

## Full per-item triage (all 19)

| ID | Canonical title | Disposition |
|----|-----------------|-------------|
| M04 | Output-filtered Time-Exceeded consumes global diagnostic token | DEFER → dataplane owner (`userspace-dp/src/afxdp/icmp.rs`, Rust) |
| M05 | TUN EAGAIN loop performs 1,025 immediate syscalls | DEFER → dataplane owner (`userspace-dp/src/slowpath.rs`, Rust) |
| M13 | HA-reserved ports remain in recycle FIFO | DEFER → dataplane owner (`userspace-dp/src/nat/allocator.rs`, Rust) |
| M18 | Duplicate NAT rule names alias one operational identity | Real, Go-scope, **own PR** — config-acceptance behavior change (rejects currently-committable configs; nuanced strict-reject + lenient-quarantine fix) |
| M22 | IPsec `df-bit` invalid token → copy-DF default | **FIXED here** |
| C03 | `read_bytes` unconstrained safe lifetime API | DEFER → dataplane owner (AF_XDP UMEM, Rust) |
| C06 | Off-lock journal fsync can outlive retained pathname | Real, Go-scope, **own PR** — per-segment/inode in-flight-eviction concurrency redesign + deterministic race test (not low-risk) |
| C08 | gRPC counters serialize unavailable as authoritative zero | Real, Go-scope, **own PR** — additive proto field + regen + wiring |
| C09 | gRPC `test-zone` duplicate selector last-wins | **FIXED here** |
| C10 | Active SSE can survive HTTP shutdown deadline | Real, Go-scope, **own PR** — post-deadline `Close()` + lifecycle test (timing-sensitive) |
| C11 | Session page-token accepts noncanonical transport-sized key | **FIXED here** |
| C12a | Feed worker/callback stop lacks join ownership | Real, Go-scope, **own PR** — waitgroup/generation-owned join lifecycle (concurrency) |
| C12b | Feed binding-union work lacks aggregate budget | Real, Go-scope, **own PR** — aggregate manager/snapshot budget |
| C13 | Config-mode prompt poll has no deadline | **FIXED here** |
| C14 | Simulator ignores runtime zone quarantine | Real, Go-scope, **own PR** (`pkg/policymatch`) — replicate StableZoneID quarantine projection into the simulator |
| C15 | Cold-path summary mixes counter windows | DEFER → dataplane owner (`test/incus/cold-path-flooder/src/main.rs`, Rust benchmark) |
| C16 | Cold-path flooder continues with zero source MAC | DEFER → dataplane owner (`test/incus/cold-path-flooder/src/main.rs`, Rust benchmark) |
| C19 | Flowless port-except evaluates synthetic port zero | DEFER → dataplane owner (`userspace-dp/.../filter/matching.rs`, Rust matcher) |
| C20 | CLI omits coarse host verdict beside fine result | Real, Go-scope, **own PR** (`pkg/policymatch`/`pkg/cli`) — host-inbound verdict rendering across REST/gRPC/local/remote surfaces |

### Disposition rationale
- **7 DEFER (Rust / out of Go scope):** M04, M05, M13, C03, C15, C16, C19 — a concurrent peer owns `userspace-dp`/`userspace-xdp`; the cold-path-flooder is a Rust benchmark crate. Not touched here.
- **8 Real-but-own-PR:** M18, C06, C08, C10, C12a, C12b, C14, C20 — genuine Go-scope defects whose fixes are concurrency redesigns, proto changes, config-acceptance behavior changes, or cross-surface diagnostic-rendering work that exceeds "bounded low-risk" and each deserve independent review. They remain tracked under #5649; no phantom follow-ups filed.

## Validation
- `gofmt -l` + `go vet` clean on touched packages.
- Full `go test ./pkg/config ./pkg/grpcapi ./cmd/cli ./pkg/ipsec` GREEN.
- Each new test verified **RED on fix-revert (clean assertion, not a build break)** and GREEN on restore.

Advances #5649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
