### PR TITLE
config: fan per-interface host-inbound override across all bracket members (advances #5609)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -58529,3 +58529,13 @@ top.
     pkg/daemon/daemon_run.go,
     pkg/grpcapi/server_show_dhcp_hwaddr_label_5328_test.go,
     pkg/dataplane/watchdog_test.go, _Log.md
+
+- **Timestamp**: 2026-07-23
+    - **Action**: #5609 triage — fan the per-interface host-inbound override
+      across every bracketed / load-override zone membership member (completes
+      the #5248 membership flatten); each member gets an independent copy so a
+      later merge cannot alias a sibling. Rest of the cohort dispositioned
+      (intentional / deferred / not-a-bug / architectural). Advances #5609.
+    - **File(s)**: pkg/config/compiler_security_zones.go,
+      pkg/config/compiler_zone_iface_hostinbound_bracket_5609_test.go,
+      docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -695,12 +695,26 @@ therefore the WRONG helper here — it reads one node's `Keys[1:]` + immediate
 children and would still see only the first member. `compileZones`
 (`compiler_security_zones.go`) flattens the nested chain with the recursive
 `zoneInterfaceMembers`, which reads every key at each level and skips a
-`host-inbound-traffic` body (a bracketed member is bare membership — it cannot
-carry a per-interface host-inbound stanza). Before #5248 the reader took only
+`host-inbound-traffic` body. Before #5248 the reader took only
 `iface.Name()` and silently dropped every member after the first — a zone-
 membership (security boundary) loss that also hid the dropped interface from
 the strict `validateZoneInterfaceDefinedStrict` gate. Covered by
 `pkg/config/compiler_zone_interfaces_bracket_5248_test.go`.
+
+The flat-set bracketed list is bare membership: `host-inbound-traffic` tokens
+appended after it collapse onto the leaf's `Keys` and become undefined zone
+members, so the strict commit gate rejects that shape. A raw `load override`
+hierarchical block, however, CAN nest a `host-inbound-traffic` body under the
+first member (`interfaces { a { b; host-inbound-traffic { ... } } }`; Junos
+grammar disallows it, but the parser accepts it). Before #5609 the
+per-interface override attached to `iface.Name()` (member `a`) ONLY, so every
+nested member (`b`) silently fell back to the zone-level host-inbound — a
+MORE-permissive result than the operator's per-interface override whenever the
+zone-level admits a wider set. #5609 fans the parsed override across the SAME
+`zoneInterfaceMembers` flatten (each member gets an independent copy so a later
+merge cannot alias a sibling), keeping the host-inbound override in lockstep
+with the membership flatten. Covered by
+`pkg/config/compiler_zone_iface_hostinbound_bracket_5609_test.go`.
 
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a

--- a/pkg/config/compiler_security_zones.go
+++ b/pkg/config/compiler_security_zones.go
@@ -59,6 +59,27 @@ func mergeHostInbound(dst, src *HostInboundTraffic) *HostInboundTraffic {
 	return dst
 }
 
+// cloneHostInbound returns a deep copy of hib with freshly-allocated token
+// slices. It is used when one parsed per-interface host-inbound override is
+// fanned out to multiple bracketed / load-override members (#5609) so each
+// member owns an independent struct — a later mergeHostInbound into one
+// member's entry (append+dedup mutates in place) can never leak into a
+// sibling that was assigned the same source override. Returns nil for a nil
+// input so callers can pass it through unconditionally.
+func cloneHostInbound(hib *HostInboundTraffic) *HostInboundTraffic {
+	if hib == nil {
+		return nil
+	}
+	out := &HostInboundTraffic{}
+	if len(hib.SystemServices) > 0 {
+		out.SystemServices = append([]string(nil), hib.SystemServices...)
+	}
+	if len(hib.Protocols) > 0 {
+		out.Protocols = append([]string(nil), hib.Protocols...)
+	}
+	return out
+}
+
 // dedupHostInboundTokens returns vals with duplicate entries removed, preserving
 // first-seen order. Used only on the merged (2+ block) host-inbound path (#4544)
 // so a single block keeps its exact token multiset (byte-identical behaviour).
@@ -158,7 +179,30 @@ func compileZones(node *Node, sec *SecurityConfig) error {
 						if zone.InterfaceHostInbound == nil {
 							zone.InterfaceHostInbound = make(map[string]*HostInboundTraffic)
 						}
-						zone.InterfaceHostInbound[iface.Name()] = mergeHostInbound(zone.InterfaceHostInbound[iface.Name()], hib)
+						// #5609: apply the per-interface host-inbound override to
+						// EVERY member of a bracketed / load-override membership
+						// chain, mirroring the #5248 membership flatten above. A
+						// raw `interfaces { a { b; host-inbound-traffic { ... } } }`
+						// (only reachable via `load override` — Junos grammar does
+						// not let a bracketed `interfaces [ a b ]` list carry a
+						// host-inbound-traffic body; the flat-set form is rejected
+						// at commit because the collapsed tokens become undefined
+						// zone members) NESTS b under a, so iface.Name() names only
+						// `a`. Keying the override on iface.Name() alone silently
+						// DROPPED it for every nested member, which then fell back
+						// to the zone-level host-inbound — a MORE-permissive result
+						// than the operator's per-interface override whenever the
+						// zone-level admits a wider set. zoneInterfaceMembers skips
+						// the host-inbound-traffic body, so it returns the real
+						// interface set; the normal one-interface-per-child shape
+						// yields a single member and stays byte-identical. Each
+						// member gets its OWN copy so a later merge (a duplicate
+						// #4818 instance re-naming one member) cannot mutate a
+						// sibling's aliased override.
+						for _, member := range zoneInterfaceMembers(iface) {
+							zone.InterfaceHostInbound[member] = mergeHostInbound(
+								zone.InterfaceHostInbound[member], cloneHostInbound(hib))
+						}
 					}
 				}
 			case "screen":

--- a/pkg/config/compiler_zone_iface_hostinbound_bracket_5609_test.go
+++ b/pkg/config/compiler_zone_iface_hostinbound_bracket_5609_test.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Tests for #5609: a bracketed / load-override zone membership chain
+// `interfaces { a { b; host-inbound-traffic { ... } } }` attached the
+// per-interface host-inbound-traffic override to the FIRST member (a) ONLY,
+// silently dropping it for every nested member (b), which then fell back to the
+// zone-level host-inbound. #5248 already fixed the sibling MEMBERSHIP flatten
+// (both a and b become zone members); this completes it so the host-inbound
+// override rides the SAME flatten, keeping the two in lockstep.
+//
+// This shape is reachable only via a raw `load override` block — Junos grammar
+// does not let a bracketed `interfaces [ a b ]` list carry a host-inbound-traffic
+// body, and the flat-set form is rejected at commit (the collapsed tokens become
+// undefined zone members). The hierarchical shape below is the exact AST a load
+// override produces.
+//
+// IMPORTANT (per CLAUDE.md): the hierarchical shape uses parseHierarchical; a
+// bracketed flat-set list is built with ParseSetCommand + tree.SetPath.
+
+// TestZoneIfaceHostInboundBracket5609AllMembers is the primary RED-on-revert
+// guard: a nested membership chain must attach the per-interface host-inbound
+// override to EVERY member. Reverting the fanout to iface.Name()-only leaves
+// ge-0/0/1 with no override and this goes RED.
+func TestZoneIfaceHostInboundBracket5609AllMembers(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone Z {
+            interfaces {
+                ge-0/0/0 {
+                    ge-0/0/1;
+                    host-inbound-traffic {
+                        system-services {
+                            ssh;
+                        }
+                        protocols {
+                            ospf;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`)
+	sec := tree.FindChild("security")
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(sec.FindChild("zones"), secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	z := secCfg.Zones["Z"]
+
+	// Both members must be in the zone (the #5248 membership flatten).
+	if !reflect.DeepEqual(z.Interfaces, []string{"ge-0/0/0", "ge-0/0/1"}) {
+		t.Fatalf("zone interfaces = %v, want [ge-0/0/0 ge-0/0/1]", z.Interfaces)
+	}
+
+	for _, member := range []string{"ge-0/0/0", "ge-0/0/1"} {
+		hib := z.InterfaceHostInbound[member]
+		if hib == nil {
+			t.Fatalf("member %q has no per-interface host-inbound override (bracket fanout dropped it — #5609)", member)
+		}
+		if !reflect.DeepEqual(hib.SystemServices, []string{"ssh"}) {
+			t.Fatalf("member %q system-services = %v, want [ssh]", member, hib.SystemServices)
+		}
+		if !reflect.DeepEqual(hib.Protocols, []string{"ospf"}) {
+			t.Fatalf("member %q protocols = %v, want [ospf]", member, hib.Protocols)
+		}
+	}
+}
+
+// TestZoneIfaceHostInboundBracket5609IndependentCopies pins the aliasing safety:
+// each fanned-out member owns its OWN HostInboundTraffic struct, so mutating one
+// (as a later mergeHostInbound append+dedup does) never leaks into a sibling.
+// Reverting cloneHostInbound makes the two members share one pointer and this
+// goes RED.
+func TestZoneIfaceHostInboundBracket5609IndependentCopies(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone Z {
+            interfaces {
+                ge-0/0/0 {
+                    ge-0/0/1;
+                    host-inbound-traffic {
+                        system-services {
+                            ssh;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`)
+	sec := tree.FindChild("security")
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(sec.FindChild("zones"), secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	z := secCfg.Zones["Z"]
+	a := z.InterfaceHostInbound["ge-0/0/0"]
+	b := z.InterfaceHostInbound["ge-0/0/1"]
+	if a == nil || b == nil {
+		t.Fatalf("missing override: a=%v b=%v", a, b)
+	}
+	if a == b {
+		t.Fatalf("members alias the same *HostInboundTraffic; want independent copies (#5609)")
+	}
+	// Mutate a's slice in place; b must be unaffected.
+	a.SystemServices = append(a.SystemServices, "ping")
+	if reflect.DeepEqual(b.SystemServices, a.SystemServices) {
+		t.Fatalf("mutating ge-0/0/0 override leaked into ge-0/0/1: b=%v (aliasing — #5609)", b.SystemServices)
+	}
+	if !reflect.DeepEqual(b.SystemServices, []string{"ssh"}) {
+		t.Fatalf("ge-0/0/1 system-services = %v, want [ssh] (unmutated)", b.SystemServices)
+	}
+}
+
+// TestZoneIfaceHostInboundBracket5609NoCrossContamination is the negative
+// control: the NORMAL one-interface-per-child shape (each interface its own
+// child with its own host-inbound) keeps DISTINCT overrides — the fanout must
+// not spread one interface's override onto another. This stays byte-identical to
+// the pre-#5609 behavior; it fails only if the fanout wrongly widens the member
+// set for a plain single-interface node.
+func TestZoneIfaceHostInboundBracket5609NoCrossContamination(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone Z {
+            interfaces {
+                ge-0/0/0 {
+                    host-inbound-traffic {
+                        system-services {
+                            ssh;
+                        }
+                    }
+                }
+                ge-0/0/1 {
+                    host-inbound-traffic {
+                        system-services {
+                            ping;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`)
+	sec := tree.FindChild("security")
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(sec.FindChild("zones"), secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	z := secCfg.Zones["Z"]
+	if got := z.InterfaceHostInbound["ge-0/0/0"]; got == nil || !reflect.DeepEqual(got.SystemServices, []string{"ssh"}) {
+		t.Fatalf("ge-0/0/0 override = %+v, want system-services [ssh]", got)
+	}
+	if got := z.InterfaceHostInbound["ge-0/0/1"]; got == nil || !reflect.DeepEqual(got.SystemServices, []string{"ping"}) {
+		t.Fatalf("ge-0/0/1 override = %+v, want system-services [ping]", got)
+	}
+	if len(z.InterfaceHostInbound) != 2 {
+		t.Fatalf("InterfaceHostInbound has %d entries, want exactly 2 (no phantom members)", len(z.InterfaceHostInbound))
+	}
+}


### PR DESCRIPTION
## Summary

Triage of cohort **#5609** (claude-spark-review-001 low-materiality +
defense-in-depth survivors), Go control-plane scope. Every item was
re-verified firsthand against current `origin/master` (4d21bd21e). One item
is a genuine real+independent+low-risk fix; the rest are dispositioned
(intentional / deferred / not-a-bug / architectural).

## The fix (A3.1)

A raw `load override` block can nest a per-interface `host-inbound-traffic`
body under the FIRST member of a bracketed zone membership chain:
`interfaces { a { b; host-inbound-traffic { ... } } }`. Junos grammar
disallows this, but the parser accepts it, and #5248 already flattens the
MEMBERSHIP so both `a` and `b` become zone members. The sibling
host-inbound override was keyed on `iface.Name()` (member `a`) ONLY, so
every nested member silently fell back to the zone-level host-inbound — a
MORE-permissive result than the operator's per-interface override whenever
the zone-level admits a wider set.

The override now rides the SAME `zoneInterfaceMembers` flatten that governs
membership. Each member gets an independent copy (`cloneHostInbound`) so a
later `mergeHostInbound` (a duplicate #4818 instance re-naming one member)
cannot alias a sibling.

- Normal one-interface-per-child shape → single member → byte-identical.
- Flat-set bracketed form → still rejected at commit (collapsed tokens
  become undefined zone members).

## Symmetric / mirror coverage

- **Flat-set bracketed shape**: verified firsthand it fails closed at
  commit (undefined-member gate) — no fanout needed, left as-is.
- **Normal separate-child shape**: negative control asserts distinct
  overrides, no cross-contamination, exactly 2 map entries.
- **Aliasing mirror** (later merge mutating a shared struct): each member
  gets its own copy; aliasing test RED without `cloneHostInbound`.

## Tests (fail-on-revert, both RED cases verified firsthand)

`pkg/config/compiler_zone_iface_hostinbound_bracket_5609_test.go`
- `...AllMembers` — RED when fanout reverts to `iface.Name()`-only.
- `...IndependentCopies` — RED when `cloneHostInbound` is dropped.
- `...NoCrossContamination` — negative control (normal shape unchanged).

## Gates

- `go build ./...`, `go vet ./pkg/config/`, `gofmt` — clean.
- Full `pkg/config` suite GREEN.
- `InterfaceHostInbound` consumers GREEN: `pkg/dataplane/userspace`,
  `pkg/api`, `pkg/grpcapi`, `pkg/daemon`, `pkg/cli`.
- `docs/config-schema.md` #5248 section extended with the #5609 completion.

## Not HA-touching

Pure `pkg/config` compile-time change; no cluster / VRRP / session-sync /
failover code. No `test-failover` smoke required.

## Cohort disposition (no code change)

- **A3.2** host_inbound_multicast.go — enforcement explicitly DEFERRED
  under #4455 (commit-time advisory only today).
- **A3.3** junos_host_deny.go `junosHostZoneExemptNetdevs` — VLAN subunits
  sharing a trunk parent share one iifname netdev; over-shield is an
  inherent iifname-scoping limitation (same-zone, authenticated IKE), not a
  low-risk independent fix.
- **A3.4** compiler_nat_source.go port default — INTENTIONAL: the consumer
  (`nat_source.go`) documents that the address-only no-translation path
  ignores the range, and `sourceNATPoolPortRange` would mark a 0/0 pool
  unusable — removing the default is a regression, not a fix.
- **A3.5** `IsWildcardZoneSet` mixed any+concrete — INTENTIONAL tolerant
  backstop; the strict commit gate rejects the mix
  (`compiler_validate_strict_policy.go`).
- **A3.6** `compileTreeLenient` — intentional #1960 no-brick doctrine.
- **A3.7** zeroize custom archive dir — premise false: `ArchiveDir` is not
  operator-configurable (hardcoded to `/var/lib/xpf/archive` ==
  `DefaultArchiveDir`, which zeroize wipes). No retention gap.
- **A7.8** networkd `restoreSlowPathRPFilter` — INTENTIONAL: deliberately
  does not mutate host-global `conf/all`, warns instead (#2378).
- **A7.9** routing `ResolveProbeInterface` — already fail-closed on an
  incomplete rethMap (#1895); the probe is HELD, not falsely PASSED.
- Rust A1/A2 items (interfaces.rs, zone_counters.rs, policy.rs, nat64.rs,
  nptv6.rs) — DEFERRED to the userspace-dp peer; not touched.

Advances #5609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ