### PR TITLE
daemon: bound shutdown aggregator final-flush join (#6395)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -58760,3 +58760,36 @@ top.
     pkg/natshow/scan_error_5557_test.go, pkg/dataplane/userspace/interfaces.go,
     pkg/dataplane/userspace/synthetic_ifindex_exhaust_5557_test.go,
     pkg/configstore/rollback_size_cap_5557_test.go, _Log.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6395 — bound the shutdown session-aggregation final-flush join so
+    a stalled syslog sink cannot delay the HA takeover fence. `stopAggregator`
+    (pkg/daemon/daemon_system.go) previously did `cancel(); d.aggWg.Wait()` — an
+    UNBOUNDED join. The cancel triggers SessionAggregator.Run's #5313 ctx.Done
+    final flush, which forwards the pending report SYNCHRONOUSLY through the
+    syslog client (logFn -> er.ForwardLogMsg); stream syslog allows up to
+    defaultWriteTimeout (~4s) PER line, so an unreachable collector could block
+    the join for many seconds. Because stopAggregator runs in runShutdownSequence
+    BEFORE the HA/dataplane teardown fence, that unbounded wait could push the
+    stop past the systemd 20s TimeoutStopSec -> SIGKILL before the peer takeover
+    fence ran (a C179-093 residual regression from merged PR #6394: before #6394
+    the aggregator was leaked at shutdown, so shutdown never waited on it). Fix:
+    the join now runs on a `done` channel closed by a `d.aggWg.Wait()` goroutine,
+    selected against `time.After(aggregatorFlushJoinTimeout)` (3s — under a single
+    ~4s syslog write timeout and well under the #5643 5s applyCloseoutDrainTimeout
+    and the fence's stop-budget share). Happy path returns in ms; a stalled sink
+    logs a warning and PROCEEDS, dropping the partial report. aggStopped latch +
+    handle-clear semantics unchanged. stopIPsecRebindLoop left unbounded on
+    purpose (ctx.Done does no blocking forward; applySem.Acquire is ctx-cancelled;
+    same safe shape as the #5308 pin/scheduler joins) — noted in the README.
+    Test: daemon_aggregator_flush_bound_6395_test.go arms an aggregator with a
+    WEDGED logFn + one seeded SESSION_CLOSE, asserts stopAggregator RETURNS within
+    the bound (RED-on-revert: plain d.aggWg.Wait() blocks forever -> clean t.Fatal
+    at the 8s in-test timeout, verified firsthand) and that the handles clear +
+    aggStopped latches; a second test asserts the bound does not penalize a fast
+    flush. build+vet+gofmt clean; full `go test ./pkg/daemon/ ./pkg/logging/`
+    GREEN. No pkg/cluster / pkg/vrrp code touched — unit-testable shutdown-hygiene
+    class, no loss-cluster smoke needed.
+  - **File(s)**: pkg/daemon/daemon_system.go,
+    pkg/daemon/daemon_aggregator_flush_bound_6395_test.go, pkg/daemon/README.md,
+    _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -58793,3 +58793,55 @@ top.
   - **File(s)**: pkg/daemon/daemon_system.go,
     pkg/daemon/daemon_aggregator_flush_bound_6395_test.go, pkg/daemon/README.md,
     _Log.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6397 (fold into PR #6397 / branch fix/6395-bound-shutdown-flush)
+    — bound the shutdown IPsec DHCP-rebind retry-loop join, closing the same
+    fence-starvation gap the #6395 aggregator bound just fixed. The #6395 fix
+    left `stopIPsecRebindLoop` (pkg/daemon/daemon_ipsec_rebind.go) on a plain
+    `d.ipsecRebindWg.Wait()` and justified it in the README/commit as "safe by
+    shape / unbounded is fine". That premise is FALSE: the loop's cancel is
+    observed only at its ctx.Done / ticker select and at
+    `applySem.Acquire(ctx, 1)` — but once a tick has ACQUIRED applySem and
+    entered `tryIPsecRebindRetry`'s apply, the swanctl re-render+reload shells
+    out under `context.WithTimeout(context.Background(), swanctlTimeout=15s)`
+    (pkg/ipsec/manager.go runSwanctl — a BACKGROUND context, NOT the loop ctx)
+    plus a 5s WaitDelay, so a rebind that is MID-APPLY when shutdown fires blocks
+    the Wait for up to ~20s. Since `stopIPsecRebindLoop` runs in
+    runShutdownSequence (daemon_run_shutdown.go:93) BEFORE the HA takeover fence
+    (~:159), an unbounded wait can exhaust the systemd 20s TimeoutStopSec and get
+    the process SIGKILLed before the peer-takeover fence runs. Fix: the join now
+    runs on a `done` channel closed by a `d.ipsecRebindWg.Wait()` goroutine,
+    selected against `time.After(ipsecRebindJoinTimeout)`. Budget = 3s (sibling
+    const mirroring aggregatorFlushJoinTimeout): the mid-apply worst case is the
+    whole ~20s stop budget, so 3s leaves the fence the bulk of the 20s window;
+    the happy path is a loop parked on the ticker / ctx.Done and returns in
+    microseconds. On a stalled mid-apply we slog.Warn and PROCEED to teardown,
+    letting the in-flight swanctl finish in the background as the process exits
+    (harmless — nothing downstream reads its result). The ipsecRebindStopped
+    latch + cancel-clear under ipsecRebindMu are unchanged, before the bounded
+    join. README (pkg/daemon/README.md) corrected: the "left unbounded on purpose
+    / same safe shape as #5308 pin-scheduler" note was WRONG (those loops do no
+    background-context shell-out on cancel; this one does) — now documents BOTH
+    shutdown joins (aggregator + ipsec-rebind) as bounded because both block on a
+    context-insensitive downstream (syslog forward / swanctl apply) before the
+    fence. Codex MINOR noted: stopAggregator/stopIPsecRebindLoop are called BOTH
+    in runShutdownSequence AND as Run() defers, so a persistent stall waits the
+    bound twice; added a one-line comment at the defers clarifying the PRE-fence
+    call is the fence-critical one and the POST-fence re-wait is harmless (fence
+    already ran). Defers KEPT (fallback for a non-graceful Run exit). Test
+    (daemon_ipsec_rebind_flush_bound_6397_test.go): arms the loop with a WEDGED
+    swanctl seam that blocks (NOT ctx-aware, modeling the background-context
+    shell-out), waits until the loop is genuinely mid-apply (holding applySem),
+    then asserts stopIPsecRebindLoop RETURNS within the bound and latches
+    stopped + clears cancel; a second test asserts an unwedged (fast-apply) loop
+    is not penalized. RED-on-revert verified FIRSTHAND: reverting to a plain
+    `d.ipsecRebindWg.Wait()` blocks on the parked apply forever, so the stop
+    never returns and the test's generous outer select trips a clean t.Fatal at
+    8s (not a suite hang); restored -> GREEN at 3.01s. build + vet + gofmt clean;
+    full `go test ./pkg/daemon/ ./pkg/logging/ ./pkg/ipsec/` GREEN. No
+    pkg/cluster / pkg/vrrp touched — unit-testable shutdown-hygiene class
+    (#5308/#5681 lineage), no loss-cluster smoke needed.
+  - **File(s)**: pkg/daemon/daemon_ipsec_rebind.go,
+    pkg/daemon/daemon_ipsec_rebind_flush_bound_6397_test.go,
+    pkg/daemon/daemon_run.go, pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -739,6 +739,23 @@ never lock an operator out of a remote box it manages.
     `ipsecRebindStopped` latch against a late restart, and a matching `defer` in
     `Run`. Other still-`daemonCtx`-bound goroutines (VRRP/cluster/fabric HA
     watchers) are intentionally left for a separate HA-scoped change.
+  - **The aggregator join is BOUNDED by `aggregatorFlushJoinTimeout` (3s, #6395).**
+    The `#5313` final flush forwards the pending report SYNCHRONOUSLY through the
+    syslog client (`logFn → er.ForwardLogMsg`), and a stream-syslog sink allows up
+    to `defaultWriteTimeout` (~4s) PER line. Since `stopAggregator()` runs BEFORE
+    the HA takeover fence, a plain `aggWg.Wait()` join could let a stalled or
+    unreachable collector block shutdown for many seconds — past the systemd 20s
+    `TimeoutStopSec`, so the process is SIGKILLed before the peer takeover fence
+    runs. `stopAggregator` therefore joins on a `done` channel with a
+    `time.After(aggregatorFlushJoinTimeout)` fallback: the happy path returns in
+    milliseconds, a stalled sink logs a warning and PROCEEDS to teardown (dropping
+    the partial report — a missed fence is worse), and the join goroutine is left
+    to finish late since the process is exiting. `stopIPsecRebindLoop`'s join is
+    left unbounded on purpose: its `ctx.Done` branch does no blocking forward
+    (just a mutex-guarded disarm), and `tryIPsecRebindRetry` acquires `applySem`
+    through the cancellable ctx — so it is the same safe shape as the accepted
+    #5308 `stopPinRetryLoop` / `stopPolicySchedulerLoop` joins, not a
+    deterministic on-cancel forward like the aggregator's.
   - **The RG-state reconcile safety-net loop IS run-`WaitGroup`-registered so
     `wg.Wait()` joins it BEFORE HA ownership relinquish (#5681 / M23).**
     `reconcileRGStateLoop` (the periodic safety net that corrects `rg_active` /

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -739,23 +739,36 @@ never lock an operator out of a remote box it manages.
     `ipsecRebindStopped` latch against a late restart, and a matching `defer` in
     `Run`. Other still-`daemonCtx`-bound goroutines (VRRP/cluster/fabric HA
     watchers) are intentionally left for a separate HA-scoped change.
-  - **The aggregator join is BOUNDED by `aggregatorFlushJoinTimeout` (3s, #6395).**
-    The `#5313` final flush forwards the pending report SYNCHRONOUSLY through the
-    syslog client (`logFn → er.ForwardLogMsg`), and a stream-syslog sink allows up
-    to `defaultWriteTimeout` (~4s) PER line. Since `stopAggregator()` runs BEFORE
-    the HA takeover fence, a plain `aggWg.Wait()` join could let a stalled or
-    unreachable collector block shutdown for many seconds — past the systemd 20s
-    `TimeoutStopSec`, so the process is SIGKILLed before the peer takeover fence
-    runs. `stopAggregator` therefore joins on a `done` channel with a
-    `time.After(aggregatorFlushJoinTimeout)` fallback: the happy path returns in
-    milliseconds, a stalled sink logs a warning and PROCEEDS to teardown (dropping
-    the partial report — a missed fence is worse), and the join goroutine is left
-    to finish late since the process is exiting. `stopIPsecRebindLoop`'s join is
-    left unbounded on purpose: its `ctx.Done` branch does no blocking forward
-    (just a mutex-guarded disarm), and `tryIPsecRebindRetry` acquires `applySem`
-    through the cancellable ctx — so it is the same safe shape as the accepted
-    #5308 `stopPinRetryLoop` / `stopPolicySchedulerLoop` joins, not a
-    deterministic on-cancel forward like the aggregator's.
+  - **BOTH shutdown joins are BOUNDED because both can block on a
+    context-insensitive downstream before the HA takeover fence (#6395 / #6397).**
+    `stopAggregator()` and `stopIPsecRebindLoop()` both run in
+    `runShutdownSequence` BEFORE the fence, so a plain `WaitGroup.Wait()` on
+    either could push the whole stop past the systemd 20s `TimeoutStopSec` and get
+    the process SIGKILLed before the peer takeover fence runs.
+    - **The aggregator join is bounded by `aggregatorFlushJoinTimeout` (3s,
+      #6395).** The `#5313` final flush forwards the pending report SYNCHRONOUSLY
+      through the syslog client (`logFn → er.ForwardLogMsg`), and a stream-syslog
+      sink allows up to `defaultWriteTimeout` (~4s) PER line — a stalled or
+      unreachable collector could block `aggWg.Wait()` for many seconds.
+    - **The IPsec DHCP-rebind join is bounded by `ipsecRebindJoinTimeout` (3s,
+      #6397).** The loop's `cancel` IS observed at its `ctx.Done` / ticker select
+      and at `applySem.Acquire(ctx, …)` — but NOT inside a `swanctl` apply already
+      in flight. `tryIPsecRebindRetry`'s re-render+reload shells out under
+      `context.WithTimeout(context.Background(), swanctlTimeout=15s)`
+      (`pkg/ipsec/manager.go` `runSwanctl`) — a BACKGROUND context the loop's
+      cancel does not interrupt — plus a 5s `WaitDelay`, so a rebind that is
+      MID-APPLY when shutdown fires blocks a plain `ipsecRebindWg.Wait()` for up
+      to ~20s. (The earlier "left unbounded on purpose / same safe shape as the
+      #5308 pin/scheduler joins" note was WRONG: those loops do no
+      background-context shell-out on cancel; this one does.)
+
+    Each `stop*` therefore joins on a `done` channel with a `time.After(<budget>)`
+    fallback: the happy path returns in microseconds (aggregator flush completes
+    in ms; the rebind loop is normally parked on its ticker / `ctx.Done`, not
+    mid-apply), and on a stalled downstream we log a warning and PROCEED to
+    teardown — the aggregator drops the partial report, the rebind loop leaves its
+    in-flight `swanctl` shell-out to finish in the background as the process exits.
+    A missed fence is worse than either.
   - **The RG-state reconcile safety-net loop IS run-`WaitGroup`-registered so
     `wg.Wait()` joins it BEFORE HA ownership relinquish (#5681 / M23).**
     `reconcileRGStateLoop` (the periodic safety net that corrects `rg_active` /

--- a/pkg/daemon/daemon_aggregator_flush_bound_6395_test.go
+++ b/pkg/daemon/daemon_aggregator_flush_bound_6395_test.go
@@ -1,0 +1,147 @@
+package daemon
+
+// daemon_aggregator_flush_bound_6395_test.go — #6395 regression coverage.
+//
+// stopAggregator's cancel triggers SessionAggregator.Run's #5313 ctx.Done final
+// flush, which forwards the pending report SYNCHRONOUSLY through the syslog
+// client (logFn -> er.ForwardLogMsg). A stream-syslog sink allows up to
+// defaultWriteTimeout (~4s) PER line, so a stalled/unreachable collector makes
+// that forward block. stopAggregator runs in runShutdownSequence BEFORE the HA
+// takeover fence, so before #6395 the plain `d.aggWg.Wait()` join was UNBOUNDED:
+// a stalled sink could delay the fence long enough to blow the systemd 20s
+// TimeoutStopSec and get the process SIGKILLed before the peer takeover ran.
+//
+// The join is now bounded by aggregatorFlushJoinTimeout. These tests prove the
+// bound fires on a stalled flush (RED-on-revert: reverting to a plain
+// d.aggWg.Wait() blocks forever, so the stop never returns and the generous
+// in-test timeout trips a clean t.Fatal) and that the happy path — a fast flush
+// — is not penalized by the bound.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// armBlockableAggregator arms an aggregator on d the way applyAggregator does
+// (published pointer + cancel + tracked flush goroutine) but with a caller-
+// supplied logFn, and seeds one SESSION_CLOSE so the #5313 final flush actually
+// emits a line (an empty window flushes as a no-op and would never exercise the
+// forward). Returns nothing; the caller drives d.stopAggregator().
+func armBlockableAggregator(t *testing.T, d *Daemon, logFn func(int, string)) {
+	t.Helper()
+	agg := logging.NewSessionAggregator(time.Hour, 10)
+	agg.SetLogFunc(logFn)
+	agg.Add(logging.EventRecord{
+		Type:         "SESSION_CLOSE",
+		SrcAddr:      "10.0.1.5:443",
+		DstAddr:      "10.0.2.5:80",
+		SessionBytes: 4096,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d.aggregatorPtr.Store(agg)
+	d.aggCancel = cancel
+	d.aggWg.Add(1)
+	go func() {
+		defer d.aggWg.Done()
+		agg.Run(ctx)
+	}()
+}
+
+// TestStopAggregatorBoundsStalledFinalFlush proves stopAggregator RETURNS within
+// its bound even when the final flush's forward is wedged (a stalled syslog
+// sink), so the shutdown fence downstream is never starved.
+//
+// RED-on-revert: replacing the bounded select with a plain `d.aggWg.Wait()`
+// makes stopAggregator block on the parked flush forever, the `done` channel
+// below never closes, and the generous select trips t.Fatal.
+func TestStopAggregatorBoundsStalledFinalFlush(t *testing.T) {
+	d := &Daemon{}
+
+	// A wedged sink: the final flush's logFn parks until the test tears down,
+	// modeling a stalled/unreachable stream-syslog collector. `entered` proves
+	// the flush genuinely reached the blocking forward (so the bound, not an
+	// empty flush, is what let stopAggregator return).
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	entered := make(chan struct{}, 1)
+	armBlockableAggregator(t, d, func(int, string) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+	})
+
+	// Drive stopAggregator off the test goroutine so a reverted (unbounded) join
+	// surfaces as a clean timeout rather than hanging the whole suite.
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		d.stopAggregator()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		elapsed := time.Since(start)
+		// The bound must have fired: the sink is still wedged (release is only
+		// closed in cleanup, after this returns), so a return here can only mean
+		// the aggregatorFlushJoinTimeout select proceeded past the stalled join.
+		if elapsed < aggregatorFlushJoinTimeout {
+			t.Fatalf("stopAggregator returned in %s, before the %s bound — the "+
+				"stalled flush was not actually exercised", elapsed, aggregatorFlushJoinTimeout)
+		}
+	case <-time.After(aggregatorFlushJoinTimeout + 5*time.Second):
+		t.Fatal("stopAggregator did not return — the final-flush join is UNBOUNDED; " +
+			"a stalled syslog sink blocks shutdown BEFORE the HA takeover fence and " +
+			"can blow the systemd 20s stop budget (#6395)")
+	}
+
+	select {
+	case <-entered:
+	default:
+		t.Fatal("the #5313 final flush never reached the log forward — the bound " +
+			"passed trivially instead of over a genuinely stalled flush")
+	}
+
+	// The stall bound still clears the published handles + latches aggStopped
+	// exactly as the unbounded path did.
+	if d.aggCancel != nil {
+		t.Error("stopAggregator must clear aggCancel even on a bounded (timed-out) join")
+	}
+	if d.aggregatorPtr.Load() != nil {
+		t.Error("stopAggregator must nil the published aggregator pointer even on a bounded join")
+	}
+	if !d.aggStopped {
+		t.Error("stopAggregator must latch aggStopped even on a bounded join")
+	}
+}
+
+// TestStopAggregatorFastFlushNotPenalized proves the bound does not slow the
+// normal case: a flush whose forward returns promptly joins in well under the
+// budget (the select takes the `done` branch, not `time.After`).
+func TestStopAggregatorFastFlushNotPenalized(t *testing.T) {
+	d := &Daemon{}
+	armBlockableAggregator(t, d, func(int, string) { /* returns immediately */ })
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		d.stopAggregator()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed >= aggregatorFlushJoinTimeout {
+			t.Fatalf("stopAggregator took %s for a fast flush — the bound must not "+
+				"delay the happy path (budget %s)", elapsed, aggregatorFlushJoinTimeout)
+		}
+	case <-time.After(aggregatorFlushJoinTimeout):
+		t.Fatal("stopAggregator did not join a fast (non-blocking) flush before the bound")
+	}
+}

--- a/pkg/daemon/daemon_ipsec_rebind.go
+++ b/pkg/daemon/daemon_ipsec_rebind.go
@@ -88,16 +88,47 @@ func (d *Daemon) armIPsecRebind() {
 	}()
 }
 
+// ipsecRebindJoinTimeout bounds how long stopIPsecRebindLoop waits to JOIN the
+// retry loop at shutdown before proceeding to teardown (#6397). The loop's
+// ctx.Done and applySem.Acquire branches ARE ctx-cancellable, so a loop parked
+// on the ticker or blocked waiting for applySem unwinds immediately on cancel.
+// But once a tick has ACQUIRED applySem and entered tryIPsecRebindRetry's apply,
+// the swanctl re-render+reload shells out under
+// context.WithTimeout(context.Background(), swanctlTimeout=15s)
+// (pkg/ipsec/manager.go runSwanctl) — a BACKGROUND context that the loop's
+// cancel does NOT interrupt — plus a 5s WaitDelay, so a rebind that is mid-apply
+// when shutdown fires can block a plain ipsecRebindWg.Wait() for up to ~20s.
+// stopIPsecRebindLoop runs in runShutdownSequence BEFORE the HA takeover fence,
+// so an unbounded join could push the whole stop past the systemd 20s
+// TimeoutStopSec (test/incus/xpfd.service) and get the process SIGKILLed before
+// the fence runs — the same fence-starvation class the #6395 aggregator join
+// bound fixed. 3s mirrors aggregatorFlushJoinTimeout and leaves the fence the
+// bulk of the 20s stop budget.
+const ipsecRebindJoinTimeout = 3 * time.Second
+
 // stopIPsecRebindLoop cancels the ipsecRebindRetryLoop goroutine and JOINS it at
 // shutdown, so a late 30s rebind tick can never run a swanctl reapply against a
 // torn-down subsystem (#5523 C179-093). It latches ipsecRebindStopped so a late
 // armIPsecRebind cannot start a new loop after the join. Idempotent / nil-safe:
 // a loop that was never armed (no lease-change rebind failure) joins cleanly.
 //
+// The join is BOUNDED by ipsecRebindJoinTimeout (#6397): the loop's cancel is
+// ctx-observed only at its ticker/ctx.Done select and the applySem.Acquire —
+// NOT inside a swanctl apply already in flight, which runs under a background
+// context (runSwanctl). A rebind that is mid-apply when shutdown fires would
+// otherwise block this join for up to ~20s, and since it precedes the HA
+// takeover fence, an unbounded wait can blow the systemd stop budget and get the
+// process SIGKILLed before the fence runs. On the happy path the loop is parked
+// on the ticker / ctx.Done and the cancel + join returns in microseconds; on a
+// stalled mid-apply we log a warning and PROCEED to teardown, letting the
+// in-flight swanctl shell-out finish in the background as the process exits
+// (harmless — nothing downstream reads its result).
+//
 // ipsecRebindMu is held only to latch the flag and read+clear the cancel, then
 // RELEASED before the join: the loop takes ipsecRebindMu on both its ctx.Done
 // (disarmIPsecRebindOnShutdown) and ticker branches, so holding it across the
-// join would deadlock. Mirrors the #5308 stopPinRetryLoop.
+// join would deadlock. Mirrors the #5308 stopPinRetryLoop, plus the #6395
+// aggregator's bounded-join shape.
 func (d *Daemon) stopIPsecRebindLoop() {
 	d.ipsecRebindMu.Lock()
 	d.ipsecRebindStopped = true
@@ -107,7 +138,20 @@ func (d *Daemon) stopIPsecRebindLoop() {
 	if cancel != nil {
 		cancel()
 	}
-	d.ipsecRebindWg.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		d.ipsecRebindWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(ipsecRebindJoinTimeout):
+		slog.Warn("shutdown: timed out joining IPsec DHCP-rebind retry loop; "+
+			"proceeding to teardown (a mid-apply swanctl shell-out runs under a "+
+			"background context and finishes as the process exits)",
+			"timeout", ipsecRebindJoinTimeout)
+	}
 }
 
 // clearIPsecRebindPending drops the health signal after a successful reapply,

--- a/pkg/daemon/daemon_ipsec_rebind_flush_bound_6397_test.go
+++ b/pkg/daemon/daemon_ipsec_rebind_flush_bound_6397_test.go
@@ -1,0 +1,142 @@
+package daemon
+
+// daemon_ipsec_rebind_flush_bound_6397_test.go — #6397 regression coverage.
+//
+// stopIPsecRebindLoop cancels + JOINS the DHCP-lease-change rebind retry loop at
+// shutdown. The loop's cancel is observed at its ctx.Done / ticker select and at
+// applySem.Acquire(ctx, …) — but NOT inside a swanctl apply already in flight:
+// tryIPsecRebindRetry's re-render+reload shells out under
+// context.WithTimeout(context.Background(), swanctlTimeout=15s) (pkg/ipsec/
+// manager.go runSwanctl), a BACKGROUND context the loop's cancel cannot
+// interrupt, plus a 5s WaitDelay. So a rebind that is MID-APPLY when shutdown
+// fires would block a plain d.ipsecRebindWg.Wait() for up to ~20s.
+//
+// stopIPsecRebindLoop runs in runShutdownSequence BEFORE the HA takeover fence,
+// so before #6397 that unbounded join could delay the fence long enough to blow
+// the systemd 20s TimeoutStopSec and get the process SIGKILLed before the peer
+// takeover ran — the same fence-starvation class the #6395 aggregator join bound
+// fixed. The join is now bounded by ipsecRebindJoinTimeout. These tests prove
+// the bound fires when the loop is wedged mid-apply (RED-on-revert: reverting to
+// a plain d.ipsecRebindWg.Wait() blocks forever, so the stop never returns and
+// the generous in-test timeout trips a clean t.Fatal) and that the happy path —
+// a loop that is not wedged — is not penalized by the bound.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestStopIPsecRebindLoopBoundsStalledMidApply proves stopIPsecRebindLoop RETURNS
+// within its bound even when the retry loop is wedged INSIDE the swanctl apply (a
+// background-context shell-out the loop's cancel cannot interrupt), so the
+// shutdown fence downstream is never starved.
+//
+// RED-on-revert: replacing the bounded select in stopIPsecRebindLoop with a plain
+// `d.ipsecRebindWg.Wait()` makes it block on the parked apply forever, the `done`
+// channel never closes, and the generous outer select trips t.Fatal.
+func TestStopIPsecRebindLoopBoundsStalledMidApply(t *testing.T) {
+	// A wedged swanctl seam: the retry loop's apply parks until the test tears
+	// down, modeling a mid-apply swanctl shell-out under context.Background that
+	// the loop's ctx cancel does NOT interrupt. `entered` proves the loop genuinely
+	// reached the blocking apply while holding applySem (so the bound, not an
+	// early ctx-cancel unwind, is what let stopIPsecRebindLoop return).
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	entered := make(chan struct{}, 1)
+	d, cancel := newIPsecRebindDaemon(t, func(*config.Config) error {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release // NOT ctx-aware — models the background-context swanctl shell-out
+		return errors.New("swanctl --load-all: released at teardown")
+	})
+	t.Cleanup(cancel)
+
+	// Arm the loop; the fast ticker (ipsecRebindRetryEvery = 2ms) drives the first
+	// tick into tryIPsecRebindRetry, which acquires applySem and blocks in the
+	// wedged apply.
+	d.armIPsecRebind()
+
+	// Wait until the loop is genuinely mid-apply before driving the stop.
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("retry loop never reached the swanctl apply — cannot exercise the " +
+			"mid-apply stall the bound guards")
+	}
+
+	// Drive stopIPsecRebindLoop off the test goroutine so a reverted (unbounded)
+	// join surfaces as a clean timeout rather than hanging the whole suite.
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		d.stopIPsecRebindLoop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		elapsed := time.Since(start)
+		// The bound must have fired: the apply is still wedged (release is only
+		// closed in cleanup, after this returns), so a return here can only mean
+		// the ipsecRebindJoinTimeout select proceeded past the stalled join.
+		if elapsed < ipsecRebindJoinTimeout {
+			t.Fatalf("stopIPsecRebindLoop returned in %s, before the %s bound — the "+
+				"stalled apply was not actually exercised", elapsed, ipsecRebindJoinTimeout)
+		}
+	case <-time.After(ipsecRebindJoinTimeout + 5*time.Second):
+		t.Fatal("stopIPsecRebindLoop did not return — the retry-loop join is UNBOUNDED; " +
+			"a mid-apply swanctl shell-out (background context, up to ~20s) blocks shutdown " +
+			"BEFORE the HA takeover fence and can blow the systemd 20s stop budget (#6397)")
+	}
+
+	// The stopped latch + cleared cancel must be set exactly as the unbounded
+	// path did, so a late armIPsecRebind cannot resurrect the loop after the join.
+	d.ipsecRebindMu.Lock()
+	stopped := d.ipsecRebindStopped
+	cancelCleared := d.ipsecRebindCancel == nil
+	d.ipsecRebindMu.Unlock()
+	if !stopped {
+		t.Error("stopIPsecRebindLoop must latch ipsecRebindStopped even on a bounded (timed-out) join")
+	}
+	if !cancelCleared {
+		t.Error("stopIPsecRebindLoop must clear ipsecRebindCancel even on a bounded join")
+	}
+}
+
+// TestStopIPsecRebindLoopFastJoinNotPenalized proves the bound does not slow the
+// normal case: a loop that is armed but NOT wedged (its apply returns promptly)
+// cancels + joins in well under the budget (the select takes the `done` branch,
+// not `time.After`). The apply keeps failing fast so the loop stays armed and
+// ticking right up to the cancel, exercising the cancel-while-active path.
+func TestStopIPsecRebindLoopFastJoinNotPenalized(t *testing.T) {
+	d, cancel := newIPsecRebindDaemon(t, func(*config.Config) error {
+		return errors.New("swanctl --load-all: charon down") // returns immediately
+	})
+	t.Cleanup(cancel)
+
+	d.armIPsecRebind()
+	// Give the loop a moment to be running/ticking before we stop it.
+	time.Sleep(20 * time.Millisecond)
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		d.stopIPsecRebindLoop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed >= ipsecRebindJoinTimeout {
+			t.Fatalf("stopIPsecRebindLoop took %s for an unwedged loop — the bound must "+
+				"not delay the happy path (budget %s)", elapsed, ipsecRebindJoinTimeout)
+		}
+	case <-time.After(ipsecRebindJoinTimeout):
+		t.Fatal("stopIPsecRebindLoop did not join an unwedged (fast-apply) loop before the bound")
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -102,7 +102,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// covered by the run WaitGroup, so guarantee they are cancelled + joined on
 	// every Run return — including the early-error / embedded-caller paths that
 	// skip runShutdownSequence. On the normal path runShutdownSequence stops
-	// both first (idempotent / nil-safe), so these defers are no-ops there.
+	// both first (idempotent / nil-safe), so these defers are no-ops there. A
+	// persistent stall is the only case where both the runShutdownSequence call
+	// and this defer do real work — each bounded join (#6395/#6397) waits its
+	// budget once, but the fence-starvation that matters is the PRE-fence call in
+	// runShutdownSequence; this POST-fence re-wait runs after the HA fence has
+	// already completed, so its extra budget is harmless.
 	defer d.stopIPsecRebindLoop()
 	defer d.stopAggregator()
 	d.startPolicySchedulerLoopLocked()

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -320,6 +320,21 @@ func (d *Daemon) applyAggregator(er *logging.EventReader, cfg *config.Config) {
 	slog.Info("session aggregation reporting enabled (5 min interval)")
 }
 
+// aggregatorFlushJoinTimeout bounds how long stopAggregator waits for the
+// session-aggregation final flush to complete before proceeding to teardown
+// (#6395). The cancel below triggers SessionAggregator.Run's #5313 ctx.Done
+// final flush, which forwards the pending report SYNCHRONOUSLY through the
+// syslog client (logFn -> er.ForwardLogMsg); a stream-syslog sink allows up to
+// defaultWriteTimeout (~4s) PER line (pkg/logging/syslog.go), so a stalled or
+// unreachable collector could otherwise block this join for many seconds. Since
+// stopAggregator runs BEFORE the HA takeover fence in runShutdownSequence, an
+// unbounded wait can push the whole stop past the systemd 20s TimeoutStopSec
+// (test/incus/xpfd.service) and get the process SIGKILLed before the peer
+// takeover fence runs. 3s is comfortably under a single write timeout and well
+// under both the #5643 applyCloseoutDrainTimeout (5s) and the fence's share of
+// the stop budget, so a stalled sink can never starve the fence.
+const aggregatorFlushJoinTimeout = 3 * time.Second
+
 // stopAggregator cancels the live session-aggregation generation and JOINS its
 // flush goroutine (and any still-flushing retired generation) at shutdown. The
 // cancel triggers SessionAggregator.Run's #5313 ctx.Done final flush, so the
@@ -327,6 +342,16 @@ func (d *Daemon) applyAggregator(er *logging.EventReader, cfg *config.Config) {
 // when the daemon stops. It latches aggStopped so a late applyAggregator cannot
 // start a new generation after the join. Idempotent / nil-safe: with reporting
 // never enabled there is no cancel and the WaitGroup is empty.
+//
+// The join is BOUNDED by aggregatorFlushJoinTimeout (#6395): the final flush
+// forwards synchronously through the syslog client, so a stalled/unreachable
+// sink would otherwise block this wait — which precedes the HA takeover fence —
+// long enough to blow the systemd stop budget and get SIGKILLed before the
+// fence runs. On the happy path the flush completes in milliseconds and the
+// select returns immediately; on a stalled sink we log a warning and PROCEED to
+// teardown, dropping the partial report (the acceptable fallback — a missed
+// fence is worse). The join goroutine is left to finish late: the process is
+// exiting, so leaking the flush's remaining lifetime is harmless.
 //
 // aggReconMu is held only to latch the flag and read+clear the handles, then
 // RELEASED before the join: SessionAggregator.Run does not take aggReconMu, so
@@ -345,7 +370,19 @@ func (d *Daemon) stopAggregator() {
 	if cancel != nil {
 		cancel()
 	}
-	d.aggWg.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		d.aggWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(aggregatorFlushJoinTimeout):
+		slog.Warn("shutdown: timed out waiting for session-aggregation final "+
+			"flush; proceeding to teardown (partial report dropped)",
+			"timeout", aggregatorFlushJoinTimeout)
+	}
 }
 
 // applyHostname sets the system hostname from system { host-name } config.


### PR DESCRIPTION
## Problem

`stopAggregator` (pkg/daemon/daemon_system.go) did `cancel(); d.aggWg.Wait()` — an **unbounded** join. The `cancel()` triggers `SessionAggregator.Run`'s #5313 `ctx.Done` final flush, which forwards the pending session-aggregation report **synchronously** through the syslog client (`logFn -> er.ForwardLogMsg`). A stream-syslog sink allows up to `defaultWriteTimeout` (~4s) **per line** (pkg/logging/syslog.go), so a stalled/unreachable collector could block the join for many seconds.

`stopAggregator` runs in `runShutdownSequence` **before** the HA/dataplane teardown fence, so that unbounded wait could push the whole stop past the systemd 20s `TimeoutStopSec` (test/incus/xpfd.service) → **SIGKILL before the peer-takeover fence runs**.

This is a C179-093 residual regression from merged PR #6394: before #6394 the aggregator was leaked at shutdown (benign), so shutdown never waited on it; #6394 added the join without bounding it.

## Fix

Bound the join at `aggregatorFlushJoinTimeout` (3s): the wait runs on a `done` channel closed by a `d.aggWg.Wait()` goroutine, selected against `time.After(budget)`.

- **3s** is under a single ~4s syslog write timeout and well under both the #5643 `applyCloseoutDrainTimeout` (5s) and the fence's share of the stop budget.
- Happy path returns in milliseconds (select takes `done`); a stalled sink logs a warning and **proceeds** to teardown, dropping the partial report (a missed fence is worse). The join goroutine finishes late — the process is exiting.
- `aggStopped` latch + handle-clear semantics unchanged.
- `stopIPsecRebindLoop` left unbounded on purpose: its `ctx.Done` branch does no blocking forward (mutex-guarded disarm only) and `tryIPsecRebindRetry` acquires `applySem` through the cancellable ctx — same safe shape as the #5308 pin/scheduler joins, not a deterministic on-cancel forward. Documented in pkg/daemon/README.md.

## Test

`daemon_aggregator_flush_bound_6395_test.go` arms an aggregator with a **wedged** `logFn` + one seeded `SESSION_CLOSE`, then asserts `stopAggregator` **returns within the bound** and clears the handles + latches `aggStopped`. A second test asserts the bound does not penalize a fast (non-blocking) flush.

**RED-on-revert verified firsthand:** replacing the bounded select with a plain `d.aggWg.Wait()` blocks forever → the stop never returns → the generous in-test timeout trips a clean `t.Fatal` at 8s (not a suite hang).

## Gates

- build + vet + gofmt clean
- full `go test ./pkg/daemon/ ./pkg/logging/` green
- no pkg/cluster / pkg/vrrp code touched — unit-testable shutdown-hygiene class, no loss-cluster smoke needed

Closes #6395