### PR TITLE
cluster: surface persistent config-sync apply failure as a CF monitor-failure (#6387 PR-1 of 3)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -58775,3 +58775,20 @@ top.
     pkg/cluster/sync.go, pkg/cluster/sync_conn_config.go, pkg/cluster/status.go,
     pkg/cluster/sync_config_health_6387_test.go, pkg/daemon/daemon_ha_sync.go,
     docs/sync-protocol.md, docs/junos-cli-reference.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6387 PR-1 (PR #6398) MERGE-NEEDS-MAJOR fixes — config-sync
+    apply-failure CF monitor-failure. BUG 1: raise now driven by an independent
+    grace-expiry timer armed on the first failure (armConfigApplyGraceTimerLocked
+    → time.AfterFunc, afterFuncFn test seam) so a stable connection with one
+    persistent apply failure raises CF with no second delivery; on-edge check
+    fixed to strictly-greater (> grace); epoch-guard + configApplyMu protect the
+    cancelled-but-already-firing race; timer stopped on Stop(). BUG 2:
+    noteConfigApplySuccess clears CF UNCONDITIONALLY (idempotent) so a fresh
+    SessionSync after a comms restart clears a CF the prior instance raised on
+    the shared Manager. Rewrote raise test (timer-driven, no 2nd delivery), added
+    comms-restart clear test + timer-cancel/no-flap+goroutine-leak assertions;
+    parent-RED verified for both fixes.
+  **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_conn.go,
+    pkg/cluster/sync_conn_config.go, pkg/cluster/sync_config_health_6387_test.go,
+    docs/sync-protocol.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -58760,3 +58760,18 @@ top.
     pkg/natshow/scan_error_5557_test.go, pkg/dataplane/userspace/interfaces.go,
     pkg/dataplane/userspace/synthetic_ifindex_exhaust_5557_test.go,
     pkg/configstore/rollback_size_cap_5557_test.go, _Log.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6387 PR-1 — surface persistent config-sync APPLY failure as a
+    node-global `CF` config-sync monitor-failure / degraded health (time-based,
+    election-neutral, survives reconcileMonitorDebtsLocked). configApplyLoop
+    fires `OnConfigApplyHealth` off the failure/success edges past a 30s
+    stale-duration grace; daemon translates to `Manager.SetConfigSyncHealth`;
+    FormatStatus folds `CF`, FormatInformation degrades node health + adds a
+    `Config sync: failing (<reason>)` line. Diagnostic only — not a failover
+    gate. Parent-RED verified (raise + reconcile-survival). Does NOT touch the
+    netlink migration (PR-2/PR-3).
+  **File(s)**: pkg/cluster/manager.go, pkg/cluster/readiness.go,
+    pkg/cluster/sync.go, pkg/cluster/sync_conn_config.go, pkg/cluster/status.go,
+    pkg/cluster/sync_config_health_6387_test.go, pkg/daemon/daemon_ha_sync.go,
+    docs/sync-protocol.md, docs/junos-cli-reference.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -58792,3 +58792,26 @@ top.
   **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_conn.go,
     pkg/cluster/sync_conn_config.go, pkg/cluster/sync_config_health_6387_test.go,
     docs/sync-protocol.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  **Action**: #6387 PR-1 (PR #6398) review fix — callback-reorder race in the
+    config-sync CF monitor-failure signal. Both hostile reviewers (Codex +
+    independent) converged on the same defect: OnConfigApplyHealth was delivered
+    OUTSIDE configApplyMu in the timer-raise (fireConfigApplyGraceExpiry) and the
+    success-clear (noteConfigApplySuccess) paths, so a timer raise callback
+    preempted between deciding-to-raise and delivering could land AFTER a
+    concurrent success cleared CF — leaving the Manager stuck
+    configSyncFailing=true after a successful apply (the epoch guard only covers
+    decision-time staleness, not the two out-of-lock deliveries). Fix: deliver
+    every OnConfigApplyHealth publish (timer raise, on-edge raise, success clear)
+    WHILE STILL HOLDING configApplyMu, serializing raise vs clear. Verified the
+    fixed lock order configApplyMu → m.mu (SetConfigSyncHealth is a cheap
+    two-field setter, no callback) has no inverse — nothing takes m.mu then a
+    configApplyMu path. Added TestConfigSyncHealthRaiseClearReorderSerialized
+    (forces the hostile interleave deterministically via the callback as the
+    seam); parent-RED verified (reverting to out-of-lock delivery → RED with the
+    stuck-CF assertion). pkg/cluster/... -race clean, pkg/daemon clean.
+    pkg/dataplane/userspace event-stream failures are PRE-EXISTING on
+    origin/master (verified in a detached worktree), unrelated to this change.
+  **File(s)**: pkg/cluster/sync_conn_config.go,
+    pkg/cluster/sync_config_health_6387_test.go, docs/sync-protocol.md, _Log.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -2097,7 +2097,13 @@ node1  0        primary              no      no       IF
 - **RG header:** `Redundancy group: <N> , Failover count: <N>` (note space before comma).
 - **Node entries:** Fixed columns matching header.
   - Status: `primary`, `secondary`, `hold`, `lost`, `disabled`.
-  - Monitor-failures: `None` or failure code(s) like `IF`.
+  - Monitor-failures: `None` or failure code(s) like `IF`. `CF` (Config Sync
+    monitoring) appears node-globally on every RG row when a received config-sync
+    generation has stayed un-applied past the stale-duration grace (#6387) — a
+    persistent config-apply failure that leaves the standby stuck
+    `Transfer ready: no`. It is diagnostic only (also degrades `Node health` and
+    adds a `Config sync: failing (<reason>)` line under `show chassis cluster
+    information`); it never gates failover.
 - Blank line between redundancy groups.
 
 ---

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -530,7 +530,18 @@ arrived. If a re-delivery *does* arrive after the streak has persisted
 **strictly** longer than the grace (`>`, not `>=`), an on-edge fast path raises
 immediately; both paths are idempotent and **epoch-guarded** so CF raises at
 most once per streak and a success that cancels a timer already past its
-`Stop()` cannot raise a stale CF (the cancelled-but-already-firing race). The
+`Stop()` cannot raise a stale CF (the cancelled-but-already-firing race).
+Every `OnConfigApplyHealth` publish — the timer raise, the on-edge raise, and
+the success clear — is delivered **while still holding `configApplyMu`** (#6398).
+The epoch guard alone only covers *decision-time* staleness (the timer acquiring
+the lock after a success); it does not order the two callback *deliveries*.
+Publishing both edges under the one mutex serializes them, so a timer raise
+callback preempted between deciding-to-raise and delivering cannot land *after* a
+concurrent success has already cleared CF — the reorder that would otherwise
+leave the manager stuck `configSyncFailing=true` after a successful apply. The
+callback runs `SetConfigSyncHealth`, a cheap two-field setter under the manager's
+`m.mu`, so the lock order is fixed `configApplyMu → m.mu` with no inverse
+(nothing takes `m.mu` then calls back into a `configApplyMu` path). The
 daemon translates `OnConfigApplyHealth` into `cluster.Manager.SetConfigSyncHealth`.
 A successful apply cancels the timer, resets the streak, and clears CF
 **unconditionally** — not gated on the instance's own local raised flag —

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -506,6 +506,32 @@ reintroduced on the *receiver* by the #3931 ordering guard). This preserves the
 (nil = store promoted + applied; error = not applied) is exactly what gates the
 mark, so the high-water always reflects the config actually in effect.
 
+**Config-sync apply-failure health surfacing (`CF`, #6387).** Leaving the
+high-water pinned on a persistent apply failure is correct for convergence but
+made the failure *invisible*: a standby whose apply hard-fails every time (e.g.
+the host-inbound enforcement step cannot install because a dependency is
+missing) is stuck `Transfer ready: no`, `applied gen=0` forever, yet reports as
+"healthy" in `show chassis cluster status`. `configApplyLoop` now drives a
+**time-based** config-sync monitor-failure (`CF`) off that same failure edge.
+On the FIRST apply failure it stamps a monotonic timestamp; once the received
+generation has stayed un-applied past a stale-duration grace
+(`DefaultConfigApplyFailGrace`, 30s — because the loop only runs on a RECEIVED
+config and the primary re-pushes the same generation on reconnect / on later
+commits rather than continuously, an "N consecutive failures" count could never
+fire, and 30s is comfortably longer than a transient RG0-primary rejection so it
+never flaps) it fires `OnConfigApplyHealth(true)`, which the daemon translates
+into `cluster.Manager.SetConfigSyncHealth`. The first successful apply clears it.
+The manager stores this as a **dedicated node-global field**
+(`configSyncFailing` / bounded `configSyncFailReason`), NOT an
+`rg.MonitorFails` sentinel — `reconcileMonitorDebtsLocked` would wipe any
+non-interface/non-IP `MonitorFails` entry on the next `UpdateConfig`. It renders
+as `CF` in the `Monitor-failures` column of every RG row, flips `Node health` →
+`degraded`, and adds a `Config sync: failing (<reason>)` line beside the
+`Configs apply-failed:` counter. It is **diagnostic only**: it never perturbs
+`Weight`/`monitorWeights`/readiness/election, and it is **not** a second failover
+gate — manual failover stays gated solely by `ConfigStale()`
+(`ReadyForManualFailover`), and crash takeover stays intentionally ungated.
+
 **Applied-not-just-active convergence shortcut (#4957).** `handleConfigSync`
 short-circuits a re-push whose text already matches the active config so a
 duplicate does not re-run the whole reconcile. That shortcut is gated on

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -512,15 +512,34 @@ made the failure *invisible*: a standby whose apply hard-fails every time (e.g.
 the host-inbound enforcement step cannot install because a dependency is
 missing) is stuck `Transfer ready: no`, `applied gen=0` forever, yet reports as
 "healthy" in `show chassis cluster status`. `configApplyLoop` now drives a
-**time-based** config-sync monitor-failure (`CF`) off that same failure edge.
-On the FIRST apply failure it stamps a monotonic timestamp; once the received
-generation has stayed un-applied past a stale-duration grace
-(`DefaultConfigApplyFailGrace`, 30s — because the loop only runs on a RECEIVED
-config and the primary re-pushes the same generation on reconnect / on later
-commits rather than continuously, an "N consecutive failures" count could never
-fire, and 30s is comfortably longer than a transient RG0-primary rejection so it
-never flaps) it fires `OnConfigApplyHealth(true)`, which the daemon translates
-into `cluster.Manager.SetConfigSyncHealth`. The first successful apply clears it.
+**time-based** config-sync monitor-failure (`CF`) off that failure edge. On the
+FIRST apply failure of an un-applied streak it stamps a monotonic timestamp
+**and arms an independent grace-expiry timer** (`armConfigApplyGraceTimerLocked`
+→ `time.AfterFunc`, overridable in tests via `SessionSync.afterFuncFn`). The
+timer is the primary trigger because the loop only runs on a RECEIVED config and
+the config sender pushes a generation **at most once per connection/generation**
+(the daemon's level-triggered `reconcileConfigSyncToPeer` is idempotent after
+the first push) — so a *stable* connection with one persistent apply failure
+receives **no second delivery**, and any gate keyed on a re-delivery edge (an "N
+consecutive failures" count, or the original elapsed-check that only re-ran on
+another failure) could never fire and would strand the standby silently forever.
+When the timer fires — grace elapsed, `DefaultConfigApplyFailGrace` 30s,
+comfortably longer than a transient RG0-primary rejection so it never flaps — it
+fires `OnConfigApplyHealth(true)` regardless of whether any further config
+arrived. If a re-delivery *does* arrive after the streak has persisted
+**strictly** longer than the grace (`>`, not `>=`), an on-edge fast path raises
+immediately; both paths are idempotent and **epoch-guarded** so CF raises at
+most once per streak and a success that cancels a timer already past its
+`Stop()` cannot raise a stale CF (the cancelled-but-already-firing race). The
+daemon translates `OnConfigApplyHealth` into `cluster.Manager.SetConfigSyncHealth`.
+A successful apply cancels the timer, resets the streak, and clears CF
+**unconditionally** — not gated on the instance's own local raised flag —
+because a comms transport change tears down the `SessionSync` but **keeps the
+`cluster.Manager`**: the replacement instance must be able to clear a CF the
+prior instance raised, so an idempotent clear on the first success of *any*
+instance re-converges the annotation (gating it on a local flag left the manager
+CF stuck raised forever across a comms restart). The timer is also stopped on
+`SessionSync.Stop()` so none leaks across reconnects.
 The manager stores this as a **dedicated node-global field**
 (`configSyncFailing` / bounded `configSyncFailReason`), NOT an
 `rg.MonitorFails` sentinel — `reconcileMonitorDebtsLocked` would wipe any

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -317,6 +317,27 @@ type Manager struct {
 	// had already fired and is blocked on m.mu when Stop() runs cannot run an
 	// election on a stopped manager (#4716). Guarded by m.mu.
 	stopped bool
+
+	// configSyncFailing is a node-global DIAGNOSTIC health annotation raised
+	// when a received config-sync generation has stayed un-applied past the
+	// stale-duration grace (#6387). Config-sync apply hard-fails on the standby
+	// (e.g. a missing host-inbound enforcement dependency) leave the config
+	// high-water pinned (M-2/#4151), so the node is stuck `Transfer ready: no`
+	// with `applied gen=0` while looking "healthy" in the summary. This flag
+	// renders `CF` in the Monitor-failures column and flips Node health →
+	// degraded so the stranded standby is operator-visible.
+	//
+	// It is deliberately a DEDICATED manager-level field, NOT a "CF"-in-
+	// rg.MonitorFails sentinel: reconcileMonitorDebtsLocked (election.go) DELETES
+	// any MonitorFails entry that is neither a configured interface-monitor nor
+	// isIPMonitorName-true on EVERY UpdateConfig, so a sentinel would be wiped on
+	// the next commit. A dedicated field also can NEVER perturb
+	// Weight/monitorWeights/readiness/election — a config-apply failure is
+	// node-global and must only annotate health, never demote priority or gate
+	// failover (manual failover stays gated solely by ConfigStale(); crash
+	// takeover stays ungated). Set via SetConfigSyncHealth; guarded by m.mu.
+	configSyncFailing    bool
+	configSyncFailReason string // bounded/sanitized, never a raw apply error
 }
 
 type peerGroupSnapshot struct {

--- a/pkg/cluster/readiness.go
+++ b/pkg/cluster/readiness.go
@@ -2,8 +2,56 @@ package cluster
 
 import (
 	"log/slog"
+	"strings"
 	"time"
 )
+
+// maxConfigSyncReasonLen bounds the stored/rendered config-sync failure reason
+// (#6387) so an arbitrary apply error can never blow up the status output.
+const maxConfigSyncReasonLen = 200
+
+// SetConfigSyncHealth records the node-global config-sync APPLY health (#6387),
+// mirroring SetRGReady's manager-mutation shape. failing=true raises the CF
+// config-sync monitor-failure / degraded-health annotation surfaced by
+// FormatStatus / FormatInformation; failing=false clears it. The reason is
+// bounded/sanitized (sanitizeConfigSyncReason) before storage so an arbitrary
+// multi-line apply error is never rendered verbatim (§12.6).
+//
+// This is DIAGNOSTIC ONLY. It deliberately does NOT touch Weight,
+// monitorWeights, readiness, or trigger an election: a config-apply failure is
+// node-global and must annotate health without perturbing the failover math.
+// Manual failover stays gated solely by ConfigStale(); crash takeover stays
+// intentionally ungated. See the Manager.configSyncFailing field comment.
+func (m *Manager) SetConfigSyncHealth(failing bool, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.configSyncFailing = failing
+	if failing {
+		m.configSyncFailReason = sanitizeConfigSyncReason(reason)
+	} else {
+		m.configSyncFailReason = ""
+	}
+}
+
+// sanitizeConfigSyncReason reduces an apply error to a single bounded status
+// line (#6387): it keeps the first line only, collapses internal whitespace,
+// and caps the length on a rune boundary. This keeps the operator-facing reason
+// useful (it still names the failing sub-step, e.g. the host-inbound nft step)
+// while guaranteeing the stored value is never a raw multi-line arbitrary error
+// string (§12.6). An empty reason falls back to a generic label.
+func sanitizeConfigSyncReason(reason string) string {
+	if i := strings.IndexByte(reason, '\n'); i >= 0 {
+		reason = reason[:i]
+	}
+	reason = strings.Join(strings.Fields(reason), " ")
+	if reason == "" {
+		return "config-sync apply failing"
+	}
+	if r := []rune(reason); len(r) > maxConfigSyncReasonLen {
+		reason = string(r[:maxConfigSyncReasonLen]) + "…"
+	}
+	return reason
+}
 
 // SetRGReady updates the readiness state for a redundancy group.
 // When transitioning not-ready → ready, sets ReadySince to now.

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -17,6 +17,7 @@ func (m *Manager) FormatStatus() string {
 	peerVersion := m.peerSoftwareVersion
 	localProtocol := normalizeHAProtocolVersion(m.localHAProtocolVersion)
 	peerProtocol := normalizeHAProtocolVersion(m.peerHAProtocolVersion)
+	configSyncFailing := m.configSyncFailing // #6387: node-global CF annotation
 	peerGroups := make(map[int]PeerGroupState, len(m.peerGroups))
 	for k, v := range m.peerGroups {
 		peerGroups[k] = v
@@ -61,6 +62,17 @@ func (m *Manager) FormatStatus() string {
 		monFails := "None"
 		if len(rg.MonitorFails) > 0 {
 			monFails = strings.Join(rg.MonitorFails, ", ")
+		}
+		// #6387: fold the node-global CF config-sync monitor-failure into the
+		// Monitor-failures column for every RG row. It is a dedicated manager
+		// field (not an rg.MonitorFails entry) so reconcileMonitorDebtsLocked
+		// cannot wipe it on the next UpdateConfig.
+		if configSyncFailing {
+			if monFails == "None" {
+				monFails = "CF"
+			} else {
+				monFails += ", CF"
+			}
 		}
 		readyStr := "yes"
 		if !rg.Ready {
@@ -107,6 +119,8 @@ func (m *Manager) FormatInformation() string {
 	interval := m.hbInterval
 	threshold := m.hbThreshold
 	controlIface := m.controlInterface
+	configSyncFailing := m.configSyncFailing   // #6387
+	configSyncReason := m.configSyncFailReason // #6387
 	m.mu.RUnlock()
 
 	states := m.GroupStates()
@@ -157,6 +171,12 @@ func (m *Manager) FormatInformation() string {
 
 	// Node health.
 	localHealth := "healthy"
+	// #6387: a persistent config-sync apply failure degrades node health
+	// node-wide (same annotate-only semantics as a monitor-failure, but it
+	// never perturbs Weight/election).
+	if configSyncFailing {
+		localHealth = "degraded"
+	}
 	for _, rg := range states {
 		if len(rg.MonitorFails) > 0 || rg.Weight < 255 {
 			localHealth = "degraded"
@@ -336,6 +356,17 @@ func (m *Manager) FormatInformation() string {
 		}
 	} else {
 		fmt.Fprintln(&b, "  Not configured")
+	}
+	// #6387: surface the node-global CF config-sync health beside the
+	// apply-failed counter so an operator sees WHY the standby is stuck
+	// `Transfer ready: no` (e.g. host-inbound apply hard-failing) instead of
+	// only the terse status string.
+	if configSyncFailing {
+		reason := configSyncReason
+		if reason == "" {
+			reason = "config-sync apply failing"
+		}
+		fmt.Fprintf(&b, "  Config sync: failing (%s)\n", reason)
 	}
 	cfgEvents := m.history.Events(EventConfigSync)
 	if len(cfgEvents) > 0 {

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -346,16 +346,22 @@ type SessionSync struct {
 	// stranded on the prior config (M-2/#4151).
 	OnConfigReceived func(configText string) error
 	// OnConfigApplyHealth reports the config-sync APPLY health edge (#6387).
-	// configApplyLoop fires failing=true (once) when a received config
-	// generation has stayed un-applied — apply hard-failing, high-water pinned
-	// per M-2/#4151 — for longer than the stale-duration grace
-	// (configApplyFailGrace), and failing=false (once) the first time an apply
-	// succeeds after such a raise. reason is the raw apply error on a raise (the
-	// Manager sanitizes/bounds it before storage) and empty on a clear. The
-	// daemon wires this to Manager.SetConfigSyncHealth so a persistently
-	// stranded standby surfaces as a CF monitor-failure / degraded health
-	// instead of only the terse `Transfer ready: no` string. Diagnostic only —
-	// it NEVER gates failover.
+	// failing=true fires (once per streak) when a received config generation
+	// has stayed un-applied — apply hard-failing, high-water pinned per
+	// M-2/#4151 — for longer than the stale-duration grace
+	// (configApplyFailGrace); the raise is driven by an independent grace-expiry
+	// timer so a STABLE connection with one persistent apply failure surfaces CF
+	// without a second delivery. failing=false fires on EVERY successful apply
+	// (an idempotent clear), NOT only the first success after a local raise:
+	// a comms transport change tears down this SessionSync but keeps the cluster
+	// Manager, so the replacement instance must be able to clear a CF the OLD
+	// instance raised — gating the clear on this instance's own local raised
+	// flag would leave the manager annotation stuck forever. reason is the raw
+	// apply error on a raise (the Manager sanitizes/bounds it before storage)
+	// and empty on a clear. The daemon wires this to Manager.SetConfigSyncHealth
+	// so a persistently stranded standby surfaces as a CF monitor-failure /
+	// degraded health instead of only the terse `Transfer ready: no` string.
+	// Diagnostic only — it NEVER gates failover.
 	OnConfigApplyHealth func(failing bool, reason string)
 	// OnIPsecSAReceived is called when an IPsec SA list arrives from the peer.
 	OnIPsecSAReceived func(connectionNames []string)
@@ -610,21 +616,41 @@ type SessionSync struct {
 	configApplyCh     chan configApplyItem
 
 	// Config-sync APPLY health tracking (#6387). These drive the time-based CF
-	// monitor-failure edge and are touched ONLY by the single-consumer
-	// configApplyLoop goroutine, so they need no lock/atomic (same ownership as
-	// the loop-local high-water logic).
+	// monitor-failure edge. Unlike the loop-local high-water logic they are NOT
+	// single-goroutine-owned: an independent grace-expiry timer
+	// (configApplyFailTimer, armed on the first failure of a streak) fires its
+	// callback on its OWN goroutine while the single-consumer configApplyLoop
+	// touches the same fields, so every access is guarded by configApplyMu.
 	//
 	// firstUnappliedFailNano is MonotonicNanos of the FIRST apply failure in the
 	// current un-applied streak (0 = no active streak). configApplyHealthRaised
 	// records whether OnConfigApplyHealth(true) has already fired for this
 	// streak, so the raise fires at most once and the matching clear fires on
-	// the first subsequent success. nowMonoFn/configApplyFailGrace are injection
-	// seams (nil / 0 = production defaults) that let a test drive the
-	// stale-duration clock and threshold deterministically.
+	// the first subsequent success. configApplyFailReason holds the latest
+	// apply error so the timer callback can raise CF with a meaningful reason
+	// even without a fresh delivery edge.
+	//
+	// configApplyFailTimer is the independent grace-expiry timer: the config
+	// sender pushes a generation at most once per connection/generation, so a
+	// STABLE connection with one persistent apply failure gets no second
+	// delivery — the timer, not a re-delivery edge, guarantees CF surfaces once
+	// the grace elapses. configApplyFailEpoch is bumped on every arm/cancel;
+	// the timer callback captures its epoch and no-ops on a mismatch, so a
+	// success (or re-arm) that cancels a timer already past its Stop() cannot
+	// raise a stale CF (the cancelled-but-already-firing race).
+	//
+	// nowMonoFn/configApplyFailGrace/afterFuncFn are injection seams (nil / 0 =
+	// production defaults) that let a test drive the stale-duration clock, the
+	// threshold, and the timer deterministically.
+	configApplyMu           sync.Mutex
 	firstUnappliedFailNano  int64
 	configApplyHealthRaised bool
+	configApplyFailReason   string
+	configApplyFailTimer    *time.Timer
+	configApplyFailEpoch    uint64
 	nowMonoFn               func() int64
 	configApplyFailGrace    time.Duration
+	afterFuncFn             func(d time.Duration, f func()) *time.Timer
 
 	// #5706 full-set state-sync ordering guard (IPsec SA + DHCP leases).
 	//

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -345,6 +345,18 @@ type SessionSync struct {
 	// the standby eligible for the primary's re-push instead of silently
 	// stranded on the prior config (M-2/#4151).
 	OnConfigReceived func(configText string) error
+	// OnConfigApplyHealth reports the config-sync APPLY health edge (#6387).
+	// configApplyLoop fires failing=true (once) when a received config
+	// generation has stayed un-applied — apply hard-failing, high-water pinned
+	// per M-2/#4151 — for longer than the stale-duration grace
+	// (configApplyFailGrace), and failing=false (once) the first time an apply
+	// succeeds after such a raise. reason is the raw apply error on a raise (the
+	// Manager sanitizes/bounds it before storage) and empty on a clear. The
+	// daemon wires this to Manager.SetConfigSyncHealth so a persistently
+	// stranded standby surfaces as a CF monitor-failure / degraded health
+	// instead of only the terse `Transfer ready: no` string. Diagnostic only —
+	// it NEVER gates failover.
+	OnConfigApplyHealth func(failing bool, reason string)
 	// OnIPsecSAReceived is called when an IPsec SA list arrives from the peer.
 	OnIPsecSAReceived func(connectionNames []string)
 	// OnDHCPLeasesReceived is called when a DHCP-server lease set arrives from
@@ -596,6 +608,23 @@ type SessionSync struct {
 	// monotonic counter lower.
 	lastRecvConfigGen atomic.Uint64
 	configApplyCh     chan configApplyItem
+
+	// Config-sync APPLY health tracking (#6387). These drive the time-based CF
+	// monitor-failure edge and are touched ONLY by the single-consumer
+	// configApplyLoop goroutine, so they need no lock/atomic (same ownership as
+	// the loop-local high-water logic).
+	//
+	// firstUnappliedFailNano is MonotonicNanos of the FIRST apply failure in the
+	// current un-applied streak (0 = no active streak). configApplyHealthRaised
+	// records whether OnConfigApplyHealth(true) has already fired for this
+	// streak, so the raise fires at most once and the matching clear fires on
+	// the first subsequent success. nowMonoFn/configApplyFailGrace are injection
+	// seams (nil / 0 = production defaults) that let a test drive the
+	// stale-duration clock and threshold deterministically.
+	firstUnappliedFailNano  int64
+	configApplyHealthRaised bool
+	nowMonoFn               func() int64
+	configApplyFailGrace    time.Duration
 
 	// #5706 full-set state-sync ordering guard (IPsec SA + DHCP leases).
 	//

--- a/pkg/cluster/sync_config_health_6387_test.go
+++ b/pkg/cluster/sync_config_health_6387_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"strings"
 	"sync"
@@ -377,6 +378,108 @@ func TestConfigSyncHealthTransientFailureWithinGraceNoFlap(t *testing.T) {
 	}
 	if after := runtime.NumGoroutine(); after > goroutinesBefore {
 		t.Fatalf("goroutine leak: before=%d after=%d", goroutinesBefore, after)
+	}
+}
+
+// TestConfigSyncHealthRaiseClearReorderSerialized is the RED-on-revert test for
+// the PR #6398 callback-reorder race. The grace-expiry timer raise and the
+// success clear both publish OnConfigApplyHealth; if the raise callback is
+// delivered OUTSIDE configApplyMu it can be preempted between deciding-to-raise
+// and delivering, so a concurrent success's clear(false) can land FIRST and the
+// late raise(true) overtakes it — leaving the Manager stuck
+// configSyncFailing=true after a SUCCESSFUL apply (the epoch guard only covers
+// decision-time staleness, not the two out-of-lock callback deliveries).
+//
+// The fix delivers every OnConfigApplyHealth publish while STILL HOLDING
+// configApplyMu, serializing raise vs clear. This test forces the exact hostile
+// interleaving deterministically using the callback itself as the seam: the
+// raise callback announces it is mid-delivery and then blocks, and the test only
+// releases it AFTER a concurrent success has had its chance to run.
+//
+//   - With the fix (callback under lock): the raise callback holds configApplyMu
+//     while blocked, so the success goroutine cannot acquire the lock and cannot
+//     clear early; once released, the raise publishes, the lock drops, and the
+//     success then clears LAST → final state cleared.
+//   - Without the fix (callback outside lock): the raise has already released the
+//     lock before delivering, so the success runs to completion and clears FIRST;
+//     the test then releases the late raise, which sets CF true LAST → final
+//     state stuck-true → RED.
+func TestConfigSyncHealthRaiseClearReorderSerialized(t *testing.T) {
+	const grace = 5 * time.Second
+	clk := &healthClk{}
+	clk.set(1_000_000_000)
+	af := &fakeAfterFunc{}
+
+	m := NewManager(0, 22)
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100})))
+	flushClusterEvents(m)
+
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	s.nowMonoFn = clk.now
+	s.configApplyFailGrace = grace
+	s.afterFuncFn = af.schedule
+
+	raiseDelivering := make(chan struct{}) // closed when the raise callback starts delivering
+	letRaiseFinish := make(chan struct{})  // closed by the test to release the blocked raise
+	var raiseOnce sync.Once
+	s.OnConfigApplyHealth = func(failing bool, reason string) {
+		if failing {
+			// The raise delivery — hold it open until the test says go, so a
+			// concurrent success clear has a chance to be reordered ahead of it.
+			raiseOnce.Do(func() {
+				close(raiseDelivering)
+				<-letRaiseFinish
+			})
+		}
+		m.SetConfigSyncHealth(failing, reason)
+	}
+
+	// (1) First failure arms the grace-expiry timer (no raise yet — elapsed 0).
+	s.noteConfigApplyFailure(errors.New("host-inbound apply failed: dependency missing"))
+	if calls, d := af.armed(); calls != 1 || d != grace {
+		t.Fatalf("grace-expiry timer must be armed once with the grace, got calls=%d d=%s", calls, d)
+	}
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("CF must not raise before the grace elapses")
+	}
+
+	// (2) Grace elapses; fire the armed timer on its own goroutine. The raise
+	// callback blocks mid-delivery (raiseDelivering closed, waiting on letRaiseFinish).
+	clk.advance(grace + time.Second)
+	raiseReturned := make(chan struct{})
+	go func() {
+		af.fire()
+		close(raiseReturned)
+	}()
+	<-raiseDelivering
+
+	// (3) A successful apply runs concurrently while the raise is mid-delivery.
+	successDone := make(chan struct{})
+	go func() {
+		s.noteConfigApplySuccess()
+		close(successDone)
+	}()
+
+	// Give the success a chance to complete. Without the fix it runs to
+	// completion here (raise already released the lock) and clears CF first;
+	// with the fix it blocks on configApplyMu (held by the raise) and cannot.
+	select {
+	case <-successDone:
+		// Success cleared already — only reachable when the raise was delivered
+		// outside the lock (the bug). Releasing the raise now makes it overtake.
+	case <-time.After(250 * time.Millisecond):
+		// Success is blocked on the lock (the fix) — expected.
+	}
+
+	// (4) Release the blocked raise and let both callbacks settle.
+	close(letRaiseFinish)
+	<-successDone
+	<-raiseReturned
+
+	// The final state after a SUCCESSFUL apply must be cleared — a late raise
+	// must never be able to land after the clear.
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("callback-reorder race: a late raise overtook the success clear — CF stuck raised after a successful apply")
 	}
 }
 

--- a/pkg/cluster/sync_config_health_6387_test.go
+++ b/pkg/cluster/sync_config_health_6387_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -18,6 +19,17 @@ import (
 // node is stuck `Transfer ready: no`, `applied gen=0`, but looks "healthy" in
 // the summary. These tests prove the time-based CF signal makes that stranded
 // standby operator-visible without perturbing election.
+//
+// The two defects these tests pin (PR #6398 MERGE-NEEDS-MAJOR):
+//   - the raise must not depend on a SECOND delivery: the sender pushes a
+//     generation at most once per connection/generation, so a STABLE connection
+//     with one persistent apply failure gets no re-delivery edge — an
+//     independent grace-expiry TIMER, armed on the first failure, must raise CF
+//     on its own; and
+//   - the CLEAR must be manager-driven and idempotent: a comms transport change
+//     tears down the SessionSync but keeps the cluster Manager, so a CF raised by
+//     the OLD instance must be cleared by the REPLACEMENT instance's first
+//     successful apply (not gated on the old instance's local raised flag).
 
 // healthClk is a deterministic monotonic clock for driving the stale-duration
 // grace without wall-clock sleeps.
@@ -26,6 +38,47 @@ type healthClk struct{ nanos atomic.Int64 }
 func (c *healthClk) now() int64              { return c.nanos.Load() }
 func (c *healthClk) set(ns int64)            { c.nanos.Store(ns) }
 func (c *healthClk) advance(d time.Duration) { c.nanos.Add(int64(d)) }
+
+// fakeAfterFunc is a deterministic stand-in for time.AfterFunc that captures the
+// armed callback and the requested delay instead of scheduling on the wall
+// clock, so a test can assert the grace-expiry timer was armed and fire it on
+// demand. It spawns NO goroutine and returns an already-stopped real timer, so
+// the SessionSync's Stop() calls on the handle are safe no-ops.
+type fakeAfterFunc struct {
+	mu    sync.Mutex
+	calls int
+	lastD time.Duration
+	last  func()
+}
+
+func (f *fakeAfterFunc) schedule(d time.Duration, fn func()) *time.Timer {
+	f.mu.Lock()
+	f.calls++
+	f.lastD = d
+	f.last = fn
+	f.mu.Unlock()
+	tm := time.NewTimer(time.Hour)
+	tm.Stop()
+	return tm
+}
+
+func (f *fakeAfterFunc) armed() (int, time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls, f.lastD
+}
+
+// fire invokes the most recently armed callback, simulating the grace-expiry
+// timer firing. A no-op if nothing was ever armed (so a neutralized arm leaves
+// this inert and the raise assertion fails RED).
+func (f *fakeAfterFunc) fire() {
+	f.mu.Lock()
+	fn := f.last
+	f.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
 
 func mgrConfigSyncFailing(m *Manager) bool {
 	m.mu.RLock()
@@ -45,22 +98,28 @@ func flushClusterEvents(m *Manager) {
 	}
 }
 
-// TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess is the primary
-// RED-on-revert test. It wires OnConfigReceived to hard-fail, drives
-// configApplyLoop, advances the stale-duration clock past the grace, and
-// asserts:
+// TestConfigSyncHealthTimerRaisesWithoutSecondDelivery is the primary
+// RED-on-revert test for BUG 1. It wires OnConfigReceived to hard-fail, delivers
+// the config exactly ONCE (a STABLE connection — the sender does not re-push),
+// advances the stale-duration clock past the grace, fires the armed grace-expiry
+// timer, and asserts:
 //   - lastAppliedConfigGen stays pinned at 0 (existing #4151 behavior),
 //   - ConfigsApplyFailed increments,
-//   - configSyncFailing raises once the grace elapses → FormatStatus renders CF
-//     and FormatInformation renders "Node health: degraded" + "Config sync:
-//     failing",
+//   - the grace-expiry timer was ARMED on the first failure (with the grace),
+//   - configSyncFailing raises when that timer fires — NO second delivery →
+//     FormatStatus renders CF and FormatInformation renders degraded health +
+//     "Config sync: failing",
 //   - the flag SURVIVES an intervening UpdateConfig (the reconcileMonitorDebts
 //     hazard — the key regression), and
 //   - one successful apply CLEARS it.
-func TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess(t *testing.T) {
+//
+// Neutralizing armConfigApplyGraceTimerLocked (the timer arm) leaves fakeAfterFunc
+// uncalled → fire() is inert → CF never raises → this test goes RED.
+func TestConfigSyncHealthTimerRaisesWithoutSecondDelivery(t *testing.T) {
 	const grace = 5 * time.Second
 	clk := &healthClk{}
 	clk.set(1_000_000_000) // arbitrary non-zero monotonic base
+	af := &fakeAfterFunc{}
 
 	m := NewManager(0, 22)
 	// Two configured RGs so the CF column render is exercised on multiple rows.
@@ -74,9 +133,10 @@ func TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess(t *testing.T) {
 	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
 	s.nowMonoFn = clk.now
 	s.configApplyFailGrace = grace
-	// Fail the first two applies (the initial push + the post-grace re-push),
-	// then succeed — mirroring the primary re-pushing the same generation.
-	rec := &configRecorder{failN: 2}
+	s.afterFuncFn = af.schedule
+	// Fail only the first apply; the eventual clear-path apply succeeds. Crucially
+	// the SAME generation is NOT re-delivered — the raise must come from the timer.
+	rec := &configRecorder{failN: 1}
 	s.OnConfigReceived = rec.record
 	s.OnConfigApplyHealth = func(failing bool, reason string) {
 		m.SetConfigSyncHealth(failing, reason)
@@ -86,8 +146,8 @@ func TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess(t *testing.T) {
 	defer cancel()
 	go s.configApplyLoop(ctx)
 
-	// (1) First push of gen 7 fails. The streak starts but the grace has not
-	// elapsed, so CF must NOT raise yet.
+	// (1) Single push of gen 7 fails. The streak starts and the grace-expiry
+	// timer is armed, but the timer has not fired, so CF must NOT raise yet.
 	s.configApplyCh <- configApplyItem{gen: 7, text: "config-C7"}
 	drainConfigApply(t, s)
 	if got := s.lastAppliedConfigGen.Load(); got != 0 {
@@ -96,24 +156,23 @@ func TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess(t *testing.T) {
 	if got := s.stats.ConfigsApplyFailed.Load(); got != 1 {
 		t.Fatalf("ConfigsApplyFailed should be 1 after first failure, got %d", got)
 	}
+	if calls, d := af.armed(); calls != 1 || d != grace {
+		t.Fatalf("grace-expiry timer must be armed exactly once with the grace on the first failure, got calls=%d d=%s", calls, d)
+	}
 	if mgrConfigSyncFailing(m) {
-		t.Fatal("CF must NOT raise before the stale-duration grace elapses")
+		t.Fatal("CF must NOT raise before the grace-expiry timer fires")
 	}
 
-	// (2) Advance past the grace and re-push the SAME generation (re-admitted
-	// because the high-water never advanced). This failure edge crosses the
-	// grace → CF raises.
+	// (2) Advance past the grace and fire the ARMED timer — no second delivery.
+	// This is the stranded-standby scenario: a stable connection, one persistent
+	// apply failure, and only the timer to surface it.
 	clk.advance(grace + time.Second)
-	s.configApplyCh <- configApplyItem{gen: 7, text: "config-C7"}
-	drainConfigApply(t, s)
+	af.fire()
 	if got := s.lastAppliedConfigGen.Load(); got != 0 {
 		t.Fatalf("high-water must still be pinned at 0, got %d", got)
 	}
-	if got := s.stats.ConfigsApplyFailed.Load(); got != 2 {
-		t.Fatalf("ConfigsApplyFailed should be 2, got %d", got)
-	}
 	if !mgrConfigSyncFailing(m) {
-		t.Fatal("CF must raise once the un-applied streak persists past the grace")
+		t.Fatal("the armed grace-expiry timer must raise CF with no second delivery")
 	}
 
 	// Rendering: FormatStatus folds CF into the Monitor-failures column (the
@@ -157,13 +216,87 @@ func TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess(t *testing.T) {
 	}
 }
 
+// TestConfigSyncHealthClearsAcrossCommsRestart is the RED-on-revert test for
+// BUG 2. A comms transport change tears down the SessionSync (daemon
+// stopClusterComms) but KEEPS the cluster Manager, so the "clear-required"
+// state cannot live only in the SessionSync: instance A raises CF on the shared
+// Manager, A is torn down, and a fresh instance B — whose local raised flag was
+// never set — must clear the Manager CF on its first successful apply.
+//
+// Reverting the UNCONDITIONAL clear (gating it back on the instance's own
+// configApplyHealthRaised) leaves B unable to clear the Manager → CF stuck →
+// this test goes RED.
+func TestConfigSyncHealthClearsAcrossCommsRestart(t *testing.T) {
+	const grace = 5 * time.Second
+
+	m := NewManager(0, 22)
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100})))
+	flushClusterEvents(m)
+
+	// --- instance A: raises CF via its grace-expiry timer, then is torn down ---
+	clkA := &healthClk{}
+	clkA.set(1_000_000_000)
+	afA := &fakeAfterFunc{}
+	a := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	a.nowMonoFn = clkA.now
+	a.configApplyFailGrace = grace
+	a.afterFuncFn = afA.schedule
+	recA := &configRecorder{failN: 1}
+	a.OnConfigReceived = recA.record
+	a.OnConfigApplyHealth = func(failing bool, reason string) {
+		m.SetConfigSyncHealth(failing, reason)
+	}
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	go a.configApplyLoop(ctxA)
+	a.configApplyCh <- configApplyItem{gen: 5, text: "config-A5"}
+	drainConfigApply(t, a)
+	clkA.advance(grace + time.Second)
+	afA.fire()
+	if !mgrConfigSyncFailing(m) {
+		t.Fatal("precondition: instance A must raise CF on the shared manager")
+	}
+
+	// Tear down A the way stopClusterComms does: stop its loop and Stop() the
+	// instance. Teardown alone must NOT clear the manager CF — the whole point
+	// of the bug is that the CF outlives the SessionSync.
+	cancelA()
+	a.Stop()
+	if !mgrConfigSyncFailing(m) {
+		t.Fatal("tearing down instance A must not clear the manager CF (it outlives the SessionSync)")
+	}
+
+	// --- instance B: a fresh SessionSync on the SAME manager; its first
+	// successful apply must clear the stale CF even though B never raised it. ---
+	b := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	b.OnConfigReceived = (&configRecorder{}).record // succeeds
+	b.OnConfigApplyHealth = func(failing bool, reason string) {
+		m.SetConfigSyncHealth(failing, reason)
+	}
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	go b.configApplyLoop(ctxB)
+
+	b.configApplyCh <- configApplyItem{gen: 6, text: "config-B6"}
+	drainConfigApply(t, b)
+	if got := b.lastAppliedConfigGen.Load(); got != 6 {
+		t.Fatalf("instance B's apply must advance its high-water to 6, got %d", got)
+	}
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("instance B's first successful apply must clear the manager CF raised by instance A")
+	}
+}
+
 // TestConfigSyncHealthTransientFailureWithinGraceNoFlap proves a transient apply
 // failure that resolves WITHIN the grace never raises CF — a transient
-// RG0-primary rejection must not flap the flag.
+// RG0-primary rejection must not flap the flag — AND that the grace-expiry timer
+// is cancelled on the intervening success so a late fire cannot raise a stale CF
+// (the cancelled-but-already-firing race) and no timer is leaked.
 func TestConfigSyncHealthTransientFailureWithinGraceNoFlap(t *testing.T) {
 	const grace = 30 * time.Second
 	clk := &healthClk{}
 	clk.set(5_000_000_000)
+	af := &fakeAfterFunc{}
 
 	var mu sync.Mutex
 	var raisedTrue int
@@ -171,9 +304,12 @@ func TestConfigSyncHealthTransientFailureWithinGraceNoFlap(t *testing.T) {
 	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100})))
 	flushClusterEvents(m)
 
+	goroutinesBefore := runtime.NumGoroutine()
+
 	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
 	s.nowMonoFn = clk.now
 	s.configApplyFailGrace = grace
+	s.afterFuncFn = af.schedule
 	rec := &configRecorder{failN: 1} // one transient failure, then success
 	s.OnConfigReceived = rec.record
 	s.OnConfigApplyHealth = func(failing bool, reason string) {
@@ -189,10 +325,14 @@ func TestConfigSyncHealthTransientFailureWithinGraceNoFlap(t *testing.T) {
 	defer cancel()
 	go s.configApplyLoop(ctx)
 
-	// Failure at t0 (streak starts, grace not elapsed).
+	// Failure at t0 (streak starts, timer armed, grace not elapsed).
 	s.configApplyCh <- configApplyItem{gen: 3, text: "config-A"}
 	drainConfigApply(t, s)
-	// A short time later (well within the grace) the re-push succeeds.
+	if calls, _ := af.armed(); calls != 1 {
+		t.Fatalf("timer must be armed on the transient failure, got calls=%d", calls)
+	}
+	// A short time later (well within the grace) the re-push succeeds — this
+	// cancels the timer.
 	clk.advance(2 * time.Second)
 	s.configApplyCh <- configApplyItem{gen: 3, text: "config-A"}
 	drainConfigApply(t, s)
@@ -203,10 +343,40 @@ func TestConfigSyncHealthTransientFailureWithinGraceNoFlap(t *testing.T) {
 	if mgrConfigSyncFailing(m) {
 		t.Fatal("a failure resolving within the grace must NOT leave CF raised")
 	}
+
+	// The success must have cancelled the timer (no dangling handle) and bumped
+	// the epoch. Simulate a late fire of the already-cancelled timer: the epoch
+	// guard must make it a no-op, so CF stays clear (no flap).
+	s.configApplyMu.Lock()
+	timerNil := s.configApplyFailTimer == nil
+	s.configApplyMu.Unlock()
+	if !timerNil {
+		t.Fatal("the grace-expiry timer must be cancelled (handle dropped) on the intervening success")
+	}
+	af.fire() // stale late fire — must be swallowed by the epoch guard
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("a stale late timer fire after a success must NOT raise CF (epoch guard)")
+	}
+
 	mu.Lock()
-	defer mu.Unlock()
 	if raisedTrue != 0 {
+		mu.Unlock()
 		t.Fatalf("CF must never have flapped to failing within the grace, raised=%d", raisedTrue)
+	}
+	mu.Unlock()
+
+	// No leaked timer goroutine: fakeAfterFunc spawns none and the real path is
+	// stopped, so the goroutine count returns to its baseline once the loop exits.
+	cancel()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= goroutinesBefore {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if after := runtime.NumGoroutine(); after > goroutinesBefore {
+		t.Fatalf("goroutine leak: before=%d after=%d", goroutinesBefore, after)
 	}
 }
 

--- a/pkg/cluster/sync_config_health_6387_test.go
+++ b/pkg/cluster/sync_config_health_6387_test.go
@@ -1,0 +1,258 @@
+package cluster
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #6387 — persistent config-sync APPLY failure surfaced as a CF monitor-failure
+// / degraded health.
+//
+// Root cause recap: config-sync apply hard-fails on the standby (e.g. a missing
+// host-inbound enforcement dependency), so configApplyLoop bumps
+// ConfigsApplyFailed and leaves the config high-water pinned (M-2/#4151) — the
+// node is stuck `Transfer ready: no`, `applied gen=0`, but looks "healthy" in
+// the summary. These tests prove the time-based CF signal makes that stranded
+// standby operator-visible without perturbing election.
+
+// healthClk is a deterministic monotonic clock for driving the stale-duration
+// grace without wall-clock sleeps.
+type healthClk struct{ nanos atomic.Int64 }
+
+func (c *healthClk) now() int64              { return c.nanos.Load() }
+func (c *healthClk) set(ns int64)            { c.nanos.Store(ns) }
+func (c *healthClk) advance(d time.Duration) { c.nanos.Add(int64(d)) }
+
+func mgrConfigSyncFailing(m *Manager) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.configSyncFailing
+}
+
+// flushClusterEvents empties the manager event channel so a later assertion can prove
+// that a subsequent call emitted (or, for CF, did NOT emit) an election event.
+func flushClusterEvents(m *Manager) {
+	for {
+		select {
+		case <-m.Events():
+		case <-time.After(50 * time.Millisecond):
+			return
+		}
+	}
+}
+
+// TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess is the primary
+// RED-on-revert test. It wires OnConfigReceived to hard-fail, drives
+// configApplyLoop, advances the stale-duration clock past the grace, and
+// asserts:
+//   - lastAppliedConfigGen stays pinned at 0 (existing #4151 behavior),
+//   - ConfigsApplyFailed increments,
+//   - configSyncFailing raises once the grace elapses → FormatStatus renders CF
+//     and FormatInformation renders "Node health: degraded" + "Config sync:
+//     failing",
+//   - the flag SURVIVES an intervening UpdateConfig (the reconcileMonitorDebts
+//     hazard — the key regression), and
+//   - one successful apply CLEARS it.
+func TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess(t *testing.T) {
+	const grace = 5 * time.Second
+	clk := &healthClk{}
+	clk.set(1_000_000_000) // arbitrary non-zero monotonic base
+
+	m := NewManager(0, 22)
+	// Two configured RGs so the CF column render is exercised on multiple rows.
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200, 1: 100}),
+		makeRG(1, false, map[int]int{0: 200, 1: 100}),
+	)
+	m.UpdateConfig(cfg)
+	flushClusterEvents(m)
+
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	s.nowMonoFn = clk.now
+	s.configApplyFailGrace = grace
+	// Fail the first two applies (the initial push + the post-grace re-push),
+	// then succeed — mirroring the primary re-pushing the same generation.
+	rec := &configRecorder{failN: 2}
+	s.OnConfigReceived = rec.record
+	s.OnConfigApplyHealth = func(failing bool, reason string) {
+		m.SetConfigSyncHealth(failing, reason)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.configApplyLoop(ctx)
+
+	// (1) First push of gen 7 fails. The streak starts but the grace has not
+	// elapsed, so CF must NOT raise yet.
+	s.configApplyCh <- configApplyItem{gen: 7, text: "config-C7"}
+	drainConfigApply(t, s)
+	if got := s.lastAppliedConfigGen.Load(); got != 0 {
+		t.Fatalf("apply failure must NOT advance the high-water, got %d", got)
+	}
+	if got := s.stats.ConfigsApplyFailed.Load(); got != 1 {
+		t.Fatalf("ConfigsApplyFailed should be 1 after first failure, got %d", got)
+	}
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("CF must NOT raise before the stale-duration grace elapses")
+	}
+
+	// (2) Advance past the grace and re-push the SAME generation (re-admitted
+	// because the high-water never advanced). This failure edge crosses the
+	// grace → CF raises.
+	clk.advance(grace + time.Second)
+	s.configApplyCh <- configApplyItem{gen: 7, text: "config-C7"}
+	drainConfigApply(t, s)
+	if got := s.lastAppliedConfigGen.Load(); got != 0 {
+		t.Fatalf("high-water must still be pinned at 0, got %d", got)
+	}
+	if got := s.stats.ConfigsApplyFailed.Load(); got != 2 {
+		t.Fatalf("ConfigsApplyFailed should be 2, got %d", got)
+	}
+	if !mgrConfigSyncFailing(m) {
+		t.Fatal("CF must raise once the un-applied streak persists past the grace")
+	}
+
+	// Rendering: FormatStatus folds CF into the Monitor-failures column (the
+	// legend line already contains one "CF", so > 1 proves a row picked it up).
+	status := m.FormatStatus()
+	if strings.Count(status, "CF") <= 1 {
+		t.Fatalf("FormatStatus must render CF in a Monitor-failures column:\n%s", status)
+	}
+	info := m.FormatInformation()
+	if !strings.Contains(info, "Local node: degraded") {
+		t.Fatalf("FormatInformation must degrade node health:\n%s", info)
+	}
+	if !strings.Contains(info, "Config sync: failing") {
+		t.Fatalf("FormatInformation must render a Config sync: failing line:\n%s", info)
+	}
+
+	// (3) KEY REGRESSION: an intervening UpdateConfig runs
+	// reconcileMonitorDebtsLocked, which wipes any non-interface/non-IP
+	// MonitorFails entry. A dedicated manager field must survive it.
+	m.UpdateConfig(cfg)
+	flushClusterEvents(m)
+	if !mgrConfigSyncFailing(m) {
+		t.Fatal("CF must survive UpdateConfig — a MonitorFails sentinel would be wiped by reconcileMonitorDebtsLocked")
+	}
+	if strings.Count(m.FormatStatus(), "CF") <= 1 {
+		t.Fatal("FormatStatus must still render CF after UpdateConfig")
+	}
+
+	// (4) A successful apply of a newer generation clears CF and advances the
+	// high-water.
+	s.configApplyCh <- configApplyItem{gen: 8, text: "config-C8"}
+	drainConfigApply(t, s)
+	if got := s.lastAppliedConfigGen.Load(); got != 8 {
+		t.Fatalf("successful apply must advance the high-water to 8, got %d", got)
+	}
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("CF must clear on the first successful apply")
+	}
+	if strings.Count(m.FormatStatus(), "CF") != 1 {
+		t.Fatalf("FormatStatus must drop the CF column entry once cleared:\n%s", m.FormatStatus())
+	}
+}
+
+// TestConfigSyncHealthTransientFailureWithinGraceNoFlap proves a transient apply
+// failure that resolves WITHIN the grace never raises CF — a transient
+// RG0-primary rejection must not flap the flag.
+func TestConfigSyncHealthTransientFailureWithinGraceNoFlap(t *testing.T) {
+	const grace = 30 * time.Second
+	clk := &healthClk{}
+	clk.set(5_000_000_000)
+
+	var mu sync.Mutex
+	var raisedTrue int
+	m := NewManager(0, 22)
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200, 1: 100})))
+	flushClusterEvents(m)
+
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	s.nowMonoFn = clk.now
+	s.configApplyFailGrace = grace
+	rec := &configRecorder{failN: 1} // one transient failure, then success
+	s.OnConfigReceived = rec.record
+	s.OnConfigApplyHealth = func(failing bool, reason string) {
+		mu.Lock()
+		if failing {
+			raisedTrue++
+		}
+		mu.Unlock()
+		m.SetConfigSyncHealth(failing, reason)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.configApplyLoop(ctx)
+
+	// Failure at t0 (streak starts, grace not elapsed).
+	s.configApplyCh <- configApplyItem{gen: 3, text: "config-A"}
+	drainConfigApply(t, s)
+	// A short time later (well within the grace) the re-push succeeds.
+	clk.advance(2 * time.Second)
+	s.configApplyCh <- configApplyItem{gen: 3, text: "config-A"}
+	drainConfigApply(t, s)
+
+	if got := s.lastAppliedConfigGen.Load(); got != 3 {
+		t.Fatalf("the eventual apply must advance the high-water to 3, got %d", got)
+	}
+	if mgrConfigSyncFailing(m) {
+		t.Fatal("a failure resolving within the grace must NOT leave CF raised")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if raisedTrue != 0 {
+		t.Fatalf("CF must never have flapped to failing within the grace, raised=%d", raisedTrue)
+	}
+}
+
+// TestConfigSyncHealthElectionNeutral proves SetConfigSyncHealth is a pure
+// health annotation: it does not change Weight / State / priority / failover
+// count, it emits no election event, and it is not wired into the
+// manual-failover readiness gate (ReadyForManualFailover stays a pure function
+// of ConfigStale()).
+func TestConfigSyncHealthElectionNeutral(t *testing.T) {
+	m := NewManager(0, 22)
+	m.UpdateConfig(makeConfig(
+		makeRG(0, false, map[int]int{0: 200, 1: 100}),
+		makeRG(1, false, map[int]int{0: 100, 1: 200}),
+	))
+	flushClusterEvents(m)
+
+	before := m.GroupStates()
+
+	// Setting CF must not perturb election state nor emit an event.
+	m.SetConfigSyncHealth(true, "host-inbound apply failed: nft not found")
+
+	select {
+	case ev := <-m.Events():
+		t.Fatalf("SetConfigSyncHealth must not emit an election event, got %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	after := m.GroupStates()
+	if len(before) != len(after) {
+		t.Fatalf("RG count changed: %d -> %d", len(before), len(after))
+	}
+	for i := range before {
+		b, a := before[i], after[i]
+		if b.Weight != a.Weight || b.State != a.State ||
+			b.LocalPriority != a.LocalPriority || b.FailoverCount != a.FailoverCount {
+			t.Fatalf("rg %d election state perturbed by CF: before=%+v after=%+v", b.GroupID, b, a)
+		}
+	}
+
+	// CF is NOT a second failover gate: a standby whose config is up to date
+	// (not stale) is still manual-failover-ready even with CF set.
+	snap := TransferReadinessSnapshot{PeerConfigGen: 42, AppliedConfigGen: 42}
+	if snap.ConfigStale() {
+		t.Fatal("precondition: an up-to-date snapshot must not be config-stale")
+	}
+	if !snap.ReadyForManualFailover() {
+		t.Fatal("ReadyForManualFailover must stay gated solely by ConfigStale(); CF must not gate it")
+	}
+}

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -350,6 +350,10 @@ func (s *SessionSync) Stop() {
 	if s.cancel != nil {
 		s.cancel()
 	}
+	// #6387: stop the config-apply grace-expiry timer and invalidate any
+	// in-flight callback so no timer survives this SessionSync's teardown (a
+	// comms transport change tears down this instance and creates a fresh one).
+	s.stopConfigApplyGraceTimer()
 	if s.listener != nil {
 		s.listener.Close()
 	}

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -3,7 +3,94 @@ package cluster
 import (
 	"context"
 	"log/slog"
+	"time"
 )
+
+// DefaultConfigApplyFailGrace is how long a received config-sync generation may
+// stay un-applied — apply hard-failing, standby config stale, high-water pinned
+// per M-2/#4151 — before the node raises the CF config-sync monitor-failure /
+// degraded-health annotation (#6387, §12.6). The trigger is TIME-BASED rather
+// than attempt-count: configApplyLoop only runs on a RECEIVED config and the
+// primary re-pushes the same generation on reconnect (~1s retry) / on every
+// later commit rather than continuously, so an "N consecutive failures" gate
+// could strand the standby forever below the threshold. The grace is a
+// wall-clock window an order of magnitude longer than a transient RG0-primary
+// config rejection — which clears within a few seconds as the local node
+// settles ownership — and longer than the reconnect/re-push cadence, so a
+// genuine persistent apply failure surfaces to the operator promptly while a
+// momentary rejection never flaps the flag. It clears on the first successful
+// apply. Sized off the peer-loss / transfer-lease timescale
+// (DefaultRemoteTransferOutLease is 30s); tests override via
+// SessionSync.configApplyFailGrace.
+const DefaultConfigApplyFailGrace = 30 * time.Second
+
+// nowMono returns CLOCK_MONOTONIC nanos, honoring the test injection seam
+// (#6387). Production uses MonotonicNanos.
+func (s *SessionSync) nowMono() int64 {
+	if s.nowMonoFn != nil {
+		return s.nowMonoFn()
+	}
+	return MonotonicNanos()
+}
+
+// configApplyGrace returns the stale-duration grace before a persistently
+// un-applied config raises the CF health signal, honoring the test override
+// (#6387).
+func (s *SessionSync) configApplyGrace() time.Duration {
+	if s.configApplyFailGrace > 0 {
+		return s.configApplyFailGrace
+	}
+	return DefaultConfigApplyFailGrace
+}
+
+// noteConfigApplyFailure evaluates the time-based config-sync health signal on
+// an apply-failure edge (#6387). It stamps the monotonic time of the FIRST
+// failure in the current un-applied streak and, once that streak has persisted
+// past configApplyGrace, fires OnConfigApplyHealth(true) exactly ONCE so a
+// genuinely stranded standby (config-sync apply hard-failing, high-water pinned
+// per M-2/#4151) becomes operator-visible as a CF monitor-failure / degraded
+// health. Because the high-water never advances on failure, the primary's
+// re-push of the same generation is re-admitted and re-attempted, so this edge
+// recurs on every reconnect/commit and the grace is reliably crossed by a later
+// re-push. A transient failure that clears within the grace never raises
+// (noteConfigApplySuccess resets the streak) — no flap. Called ONLY from the
+// single-consumer configApplyLoop, so the fields need no lock.
+func (s *SessionSync) noteConfigApplyFailure(applyErr error) {
+	now := s.nowMono()
+	if s.firstUnappliedFailNano == 0 {
+		s.firstUnappliedFailNano = now
+	}
+	if s.configApplyHealthRaised {
+		return
+	}
+	if time.Duration(now-s.firstUnappliedFailNano) < s.configApplyGrace() {
+		return
+	}
+	s.configApplyHealthRaised = true
+	if s.OnConfigApplyHealth != nil {
+		reason := ""
+		if applyErr != nil {
+			reason = applyErr.Error()
+		}
+		s.OnConfigApplyHealth(true, reason)
+	}
+}
+
+// noteConfigApplySuccess clears the config-sync health streak on a successful
+// apply (#6387). If a failure had previously been surfaced
+// (configApplyHealthRaised), it fires OnConfigApplyHealth(false) exactly once so
+// the CF annotation / degraded health clears the moment the standby
+// re-converges. Called ONLY from the single-consumer configApplyLoop.
+func (s *SessionSync) noteConfigApplySuccess() {
+	s.firstUnappliedFailNano = 0
+	if !s.configApplyHealthRaised {
+		return
+	}
+	s.configApplyHealthRaised = false
+	if s.OnConfigApplyHealth != nil {
+		s.OnConfigApplyHealth(false, "")
+	}
+}
 
 // nextConfigGen draws the next strictly-monotonic config generation stamped
 // on an outgoing config-sync message (#3931). The counter is seeded from
@@ -152,11 +239,23 @@ func (s *SessionSync) configApplyLoop(ctx context.Context) {
 				// above (surfaced in cluster status), not this log.
 				slog.Debug("cluster sync: config apply failed — retaining prior high-water so the peer re-push re-converges",
 					"incoming_gen", item.gen, "last_applied_gen", s.lastAppliedConfigGen.Load(), "size", len(item.text), "err", err)
+				// #6387: evaluate the time-based CF health signal on this
+				// failure edge. It raises OnConfigApplyHealth(true) only once the
+				// un-applied streak has persisted past the stale-duration grace,
+				// so a standby stranded by a persistent apply failure surfaces as
+				// a CF monitor-failure / degraded health instead of only the
+				// terse `Transfer ready: no` string.
+				s.noteConfigApplyFailure(err)
 				// #6284: drop the fence — the high-water intentionally stays put
 				// (M-2/#4151), so restore the pre-apply admission posture.
 				s.endConfigApply()
 				continue
 			}
+			// #6387: a confirmed apply clears any raised CF health signal (the
+			// standby has re-converged). Fired on every success — including a
+			// gen==0 legacy apply that does not advance the high-water — since
+			// the host-inbound sub-step applied cleanly.
+			s.noteConfigApplySuccess()
 			// Apply confirmed — advance the high-water so a duplicate re-push of
 			// the same generation is correctly skipped as stale, THEN drop the
 			// fence. Advancing first keeps the effective refusal threshold

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -86,6 +86,7 @@ func (s *SessionSync) noteConfigApplyFailure(applyErr error) {
 	}
 
 	s.configApplyMu.Lock()
+	defer s.configApplyMu.Unlock()
 	if s.firstUnappliedFailNano == 0 {
 		s.firstUnappliedFailNano = now
 		s.armConfigApplyGraceTimerLocked()
@@ -96,14 +97,18 @@ func (s *SessionSync) noteConfigApplyFailure(applyErr error) {
 	// greater per the #6387 contract — an elapsed exactly equal to the grace
 	// has not yet crossed the window (the grace-expiry timer, armed above,
 	// covers the boundary/no-redelivery case).
-	fire := s.raiseWanted(now)
-	if fire {
+	//
+	// #6398 fix: the OnConfigApplyHealth delivery happens WHILE STILL HOLDING
+	// configApplyMu. Serializing every raise and clear publish under the one
+	// mutex is what prevents a late raise from landing after a concurrent
+	// success has cleared CF (the callback-reorder race). The callback runs
+	// SetConfigSyncHealth, a cheap two-field setter under m.mu, so the fixed
+	// lock order configApplyMu → m.mu has no inverse and cannot deadlock.
+	if s.raiseWanted(now) {
 		s.raiseConfigApplyHealthLocked()
-	}
-	s.configApplyMu.Unlock()
-
-	if fire && s.OnConfigApplyHealth != nil {
-		s.OnConfigApplyHealth(true, reason)
+		if s.OnConfigApplyHealth != nil {
+			s.OnConfigApplyHealth(true, reason)
+		}
 	}
 }
 
@@ -118,8 +123,9 @@ func (s *SessionSync) raiseWanted(now int64) bool {
 }
 
 // raiseConfigApplyHealthLocked marks CF raised for the current streak. Caller
-// holds configApplyMu and MUST fire OnConfigApplyHealth(true, reason) after
-// releasing the lock. Idempotent (callers gate on !configApplyHealthRaised).
+// holds configApplyMu and fires OnConfigApplyHealth(true, reason) WHILE STILL
+// HOLDING that lock (#6398), so a raise cannot be reordered behind a concurrent
+// clear. Idempotent (callers gate on !configApplyHealthRaised).
 func (s *SessionSync) raiseConfigApplyHealthLocked() {
 	s.configApplyHealthRaised = true
 }
@@ -163,16 +169,20 @@ func (s *SessionSync) stopConfigApplyGraceTimer() {
 // (the cancelled-but-already-firing race) or CF is already raised. Idempotent.
 func (s *SessionSync) fireConfigApplyGraceExpiry(epoch uint64) {
 	s.configApplyMu.Lock()
+	defer s.configApplyMu.Unlock()
 	if epoch != s.configApplyFailEpoch || s.configApplyHealthRaised || s.firstUnappliedFailNano == 0 {
-		s.configApplyMu.Unlock()
 		return
 	}
 	s.raiseConfigApplyHealthLocked()
-	reason := s.configApplyFailReason
-	s.configApplyMu.Unlock()
-
+	// #6398 fix: deliver the raise WHILE STILL HOLDING configApplyMu so it
+	// cannot be reordered behind a concurrent noteConfigApplySuccess clear. If
+	// a success wins the lock first it bumps the epoch and this callback never
+	// runs (the guard above); if this callback wins, its raise is fully
+	// published before the success's clear can acquire the lock. Either
+	// interleaving leaves CF in the correct final state. See
+	// noteConfigApplyFailure for the lock-order (configApplyMu → m.mu) rationale.
 	if s.OnConfigApplyHealth != nil {
-		s.OnConfigApplyHealth(true, reason)
+		s.OnConfigApplyHealth(true, s.configApplyFailReason)
 	}
 }
 
@@ -189,13 +199,21 @@ func (s *SessionSync) fireConfigApplyGraceExpiry(epoch uint64) {
 // Called from the single-consumer configApplyLoop; guarded by configApplyMu.
 func (s *SessionSync) noteConfigApplySuccess() {
 	s.configApplyMu.Lock()
+	defer s.configApplyMu.Unlock()
 	s.firstUnappliedFailNano = 0
 	s.configApplyFailReason = ""
 	s.stopConfigApplyGraceTimerLocked()
 	s.configApplyFailEpoch++
 	s.configApplyHealthRaised = false
-	s.configApplyMu.Unlock()
 
+	// #6398 fix: deliver the clear WHILE STILL HOLDING configApplyMu. The epoch
+	// bump above invalidates any in-flight grace-expiry timer, and publishing
+	// the clear under the same mutex that serializes the raise sites guarantees
+	// a late raise callback cannot overtake this clear: a timer callback still
+	// parked on configApplyMu resumes only after this clear returns, sees the
+	// bumped epoch, and no-ops. Delivering the clear OUTSIDE the lock (the prior
+	// behavior) let a late raise land after it and leave the Manager stuck
+	// configSyncFailing=true after a successful apply.
 	if s.OnConfigApplyHealth != nil {
 		s.OnConfigApplyHealth(false, "")
 	}

--- a/pkg/cluster/sync_conn_config.go
+++ b/pkg/cluster/sync_conn_config.go
@@ -10,18 +10,22 @@ import (
 // stay un-applied — apply hard-failing, standby config stale, high-water pinned
 // per M-2/#4151 — before the node raises the CF config-sync monitor-failure /
 // degraded-health annotation (#6387, §12.6). The trigger is TIME-BASED rather
-// than attempt-count: configApplyLoop only runs on a RECEIVED config and the
-// primary re-pushes the same generation on reconnect (~1s retry) / on every
-// later commit rather than continuously, so an "N consecutive failures" gate
-// could strand the standby forever below the threshold. The grace is a
-// wall-clock window an order of magnitude longer than a transient RG0-primary
-// config rejection — which clears within a few seconds as the local node
-// settles ownership — and longer than the reconnect/re-push cadence, so a
-// genuine persistent apply failure surfaces to the operator promptly while a
-// momentary rejection never flaps the flag. It clears on the first successful
-// apply. Sized off the peer-loss / transfer-lease timescale
+// than attempt-count: configApplyLoop only runs on a RECEIVED config, and the
+// sender pushes a generation at most ONCE per connection/generation (the
+// daemon's level-triggered reconcileConfigSyncToPeer is idempotent after the
+// first push), so an "N consecutive failures" gate — or any gate keyed on a
+// second delivery edge — could strand the standby forever below the threshold.
+// The raise is therefore driven by an independent grace-expiry TIMER armed on
+// the first failure of a streak (armConfigApplyGraceTimerLocked): it fires and
+// raises CF once the grace elapses with no further delivery required. The grace
+// is a wall-clock window an order of magnitude longer than a transient
+// RG0-primary config rejection — which clears within a few seconds as the local
+// node settles ownership — so a genuine persistent apply failure surfaces to
+// the operator promptly while a momentary rejection never flaps the flag (the
+// timer is cancelled by the intervening successful apply). It clears on the
+// first successful apply. Sized off the peer-loss / transfer-lease timescale
 // (DefaultRemoteTransferOutLease is 30s); tests override via
-// SessionSync.configApplyFailGrace.
+// SessionSync.configApplyFailGrace and SessionSync.afterFuncFn.
 const DefaultConfigApplyFailGrace = 30 * time.Second
 
 // nowMono returns CLOCK_MONOTONIC nanos, honoring the test injection seam
@@ -43,50 +47,155 @@ func (s *SessionSync) configApplyGrace() time.Duration {
 	return DefaultConfigApplyFailGrace
 }
 
-// noteConfigApplyFailure evaluates the time-based config-sync health signal on
-// an apply-failure edge (#6387). It stamps the monotonic time of the FIRST
-// failure in the current un-applied streak and, once that streak has persisted
-// past configApplyGrace, fires OnConfigApplyHealth(true) exactly ONCE so a
-// genuinely stranded standby (config-sync apply hard-failing, high-water pinned
-// per M-2/#4151) becomes operator-visible as a CF monitor-failure / degraded
-// health. Because the high-water never advances on failure, the primary's
-// re-push of the same generation is re-admitted and re-attempted, so this edge
-// recurs on every reconnect/commit and the grace is reliably crossed by a later
-// re-push. A transient failure that clears within the grace never raises
-// (noteConfigApplySuccess resets the streak) — no flap. Called ONLY from the
-// single-consumer configApplyLoop, so the fields need no lock.
+// afterFunc schedules f to run after d, honoring the test injection seam
+// (#6387). Production uses time.AfterFunc; a test can capture the callback and
+// drive the grace-expiry timer deterministically.
+func (s *SessionSync) afterFunc(d time.Duration, f func()) *time.Timer {
+	if s.afterFuncFn != nil {
+		return s.afterFuncFn(d, f)
+	}
+	return time.AfterFunc(d, f)
+}
+
+// noteConfigApplyFailure drives the time-based config-sync health signal on an
+// apply-failure edge (#6387). On the FIRST failure of an un-applied streak it
+// ARMS an independent grace-expiry timer (armConfigApplyGraceTimerLocked): the
+// config sender re-pushes a generation at most once per connection/generation
+// (daemon reconcileConfigSyncToPeer is level-triggered but idempotent), so a
+// STABLE connection with a single persistent apply failure receives NO second
+// delivery — the periodic reconcile is a no-op after the first push. Without
+// the timer the standby would stay silently stranded forever below the
+// threshold; the timer guarantees CF surfaces once the grace elapses even with
+// no further delivery.
+//
+// If a later re-delivery of the same generation DOES arrive (the high-water
+// never advanced on failure, so it is re-admitted) after the streak has
+// persisted STRICTLY longer than the grace, the on-edge fast path raises
+// immediately. Both the timer and the on-edge path funnel through
+// raiseConfigApplyHealthLocked, which is idempotent and epoch-guarded, so CF
+// raises at most once per streak. A transient failure that clears within the
+// grace never raises (noteConfigApplySuccess cancels the timer and resets the
+// streak) — no flap. Called from the single-consumer configApplyLoop; the
+// shared state is guarded by configApplyMu because the timer callback runs on
+// its own goroutine.
 func (s *SessionSync) noteConfigApplyFailure(applyErr error) {
 	now := s.nowMono()
+	reason := ""
+	if applyErr != nil {
+		reason = applyErr.Error()
+	}
+
+	s.configApplyMu.Lock()
 	if s.firstUnappliedFailNano == 0 {
 		s.firstUnappliedFailNano = now
+		s.armConfigApplyGraceTimerLocked()
 	}
-	if s.configApplyHealthRaised {
-		return
+	s.configApplyFailReason = reason
+	// On-edge fast path: raise immediately if a re-delivery arrives after the
+	// streak has already persisted STRICTLY longer than the grace. Strictly-
+	// greater per the #6387 contract — an elapsed exactly equal to the grace
+	// has not yet crossed the window (the grace-expiry timer, armed above,
+	// covers the boundary/no-redelivery case).
+	fire := s.raiseWanted(now)
+	if fire {
+		s.raiseConfigApplyHealthLocked()
 	}
-	if time.Duration(now-s.firstUnappliedFailNano) < s.configApplyGrace() {
-		return
+	s.configApplyMu.Unlock()
+
+	if fire && s.OnConfigApplyHealth != nil {
+		s.OnConfigApplyHealth(true, reason)
 	}
+}
+
+// raiseWanted reports whether the un-applied streak has persisted strictly
+// longer than the grace and CF has not already been raised. Caller holds
+// configApplyMu.
+func (s *SessionSync) raiseWanted(now int64) bool {
+	if s.configApplyHealthRaised || s.firstUnappliedFailNano == 0 {
+		return false
+	}
+	return time.Duration(now-s.firstUnappliedFailNano) > s.configApplyGrace()
+}
+
+// raiseConfigApplyHealthLocked marks CF raised for the current streak. Caller
+// holds configApplyMu and MUST fire OnConfigApplyHealth(true, reason) after
+// releasing the lock. Idempotent (callers gate on !configApplyHealthRaised).
+func (s *SessionSync) raiseConfigApplyHealthLocked() {
 	s.configApplyHealthRaised = true
+}
+
+// armConfigApplyGraceTimerLocked arms (or re-arms) the independent grace-expiry
+// timer for the current un-applied streak (#6387). Caller holds configApplyMu.
+// It stops any prior timer and bumps configApplyFailEpoch so an in-flight
+// callback from a superseded streak/connection cannot raise CF, guaranteeing no
+// timer/goroutine leak across re-arms.
+func (s *SessionSync) armConfigApplyGraceTimerLocked() {
+	s.stopConfigApplyGraceTimerLocked()
+	s.configApplyFailEpoch++
+	epoch := s.configApplyFailEpoch
+	s.configApplyFailTimer = s.afterFunc(s.configApplyGrace(), func() {
+		s.fireConfigApplyGraceExpiry(epoch)
+	})
+}
+
+// stopConfigApplyGraceTimerLocked stops and drops the grace-expiry timer.
+// Caller holds configApplyMu.
+func (s *SessionSync) stopConfigApplyGraceTimerLocked() {
+	if s.configApplyFailTimer != nil {
+		s.configApplyFailTimer.Stop()
+		s.configApplyFailTimer = nil
+	}
+}
+
+// stopConfigApplyGraceTimer stops the grace-expiry timer and invalidates any
+// in-flight callback (epoch bump), used on SessionSync teardown (Stop) so no
+// timer survives a comms restart. Safe to call with no timer armed.
+func (s *SessionSync) stopConfigApplyGraceTimer() {
+	s.configApplyMu.Lock()
+	s.stopConfigApplyGraceTimerLocked()
+	s.configApplyFailEpoch++
+	s.configApplyMu.Unlock()
+}
+
+// fireConfigApplyGraceExpiry is the grace-expiry timer callback (own
+// goroutine, #6387). It raises CF for the streak that armed it — no fresh
+// delivery required — unless a success or a re-arm has since advanced the epoch
+// (the cancelled-but-already-firing race) or CF is already raised. Idempotent.
+func (s *SessionSync) fireConfigApplyGraceExpiry(epoch uint64) {
+	s.configApplyMu.Lock()
+	if epoch != s.configApplyFailEpoch || s.configApplyHealthRaised || s.firstUnappliedFailNano == 0 {
+		s.configApplyMu.Unlock()
+		return
+	}
+	s.raiseConfigApplyHealthLocked()
+	reason := s.configApplyFailReason
+	s.configApplyMu.Unlock()
+
 	if s.OnConfigApplyHealth != nil {
-		reason := ""
-		if applyErr != nil {
-			reason = applyErr.Error()
-		}
 		s.OnConfigApplyHealth(true, reason)
 	}
 }
 
 // noteConfigApplySuccess clears the config-sync health streak on a successful
-// apply (#6387). If a failure had previously been surfaced
-// (configApplyHealthRaised), it fires OnConfigApplyHealth(false) exactly once so
-// the CF annotation / degraded health clears the moment the standby
-// re-converges. Called ONLY from the single-consumer configApplyLoop.
+// apply (#6387). It cancels the grace-expiry timer, resets the streak, and
+// bumps the epoch so an in-flight timer callback becomes a no-op. It then
+// clears the node-global CF annotation UNCONDITIONALLY — NOT gated on this
+// instance's configApplyHealthRaised. A comms transport change tears down this
+// SessionSync but KEEPS the cluster Manager (daemon stopClusterComms), so a CF
+// raised by a PRIOR SessionSync instance would otherwise stay stuck forever:
+// the replacement instance records the applied generation but, gated on its own
+// never-set flag, would never clear the manager. An idempotent clear is cheap,
+// so the first successful apply on ANY instance re-converges the annotation.
+// Called from the single-consumer configApplyLoop; guarded by configApplyMu.
 func (s *SessionSync) noteConfigApplySuccess() {
+	s.configApplyMu.Lock()
 	s.firstUnappliedFailNano = 0
-	if !s.configApplyHealthRaised {
-		return
-	}
+	s.configApplyFailReason = ""
+	s.stopConfigApplyGraceTimerLocked()
+	s.configApplyFailEpoch++
 	s.configApplyHealthRaised = false
+	s.configApplyMu.Unlock()
+
 	if s.OnConfigApplyHealth != nil {
 		s.OnConfigApplyHealth(false, "")
 	}
@@ -239,12 +348,16 @@ func (s *SessionSync) configApplyLoop(ctx context.Context) {
 				// above (surfaced in cluster status), not this log.
 				slog.Debug("cluster sync: config apply failed — retaining prior high-water so the peer re-push re-converges",
 					"incoming_gen", item.gen, "last_applied_gen", s.lastAppliedConfigGen.Load(), "size", len(item.text), "err", err)
-				// #6387: evaluate the time-based CF health signal on this
-				// failure edge. It raises OnConfigApplyHealth(true) only once the
-				// un-applied streak has persisted past the stale-duration grace,
-				// so a standby stranded by a persistent apply failure surfaces as
-				// a CF monitor-failure / degraded health instead of only the
-				// terse `Transfer ready: no` string.
+				// #6387: drive the time-based CF health signal on this failure
+				// edge. On the FIRST failure of a streak it ARMS an independent
+				// grace-expiry timer that raises OnConfigApplyHealth(true) once
+				// the grace elapses even if no further config is delivered — the
+				// sender pushes a generation at most once per connection, so a
+				// stable connection with a persistent apply failure would
+				// otherwise never re-enter this edge. A standby stranded by a
+				// persistent apply failure thus surfaces as a CF monitor-failure /
+				// degraded health instead of only the terse `Transfer ready: no`
+				// string.
 				s.noteConfigApplyFailure(err)
 				// #6284: drop the fence — the high-water intentionally stays put
 				// (M-2/#4151), so restore the pre-apply admission posture.

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -912,6 +912,17 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				return d.handleConfigSync(configText)
 			}
 
+			// #6387: surface a persistent config-sync APPLY failure as a
+			// node-global CF monitor-failure / degraded health. configApplyLoop
+			// fires this on the time-based stale-duration edge (raise) and on
+			// the first post-failure success (clear); the cluster manager stores
+			// it as a diagnostic-only annotation. This never gates failover —
+			// manual failover stays gated solely by ConfigStale(); crash
+			// takeover stays ungated.
+			ss.OnConfigApplyHealth = func(failing bool, reason string) {
+				d.cluster.SetConfigSyncHealth(failing, reason)
+			}
+
 			// Wire peer connected callback: reconcile config to the returning
 			// peer. #5863: the push is level-triggered, not a one-shot connect
 			// edge — reconcileConfigSyncToPeer re-evaluates the RG0-authority +


### PR DESCRIPTION
## Summary

Surfaces a persistent **config-sync APPLY failure** on the standby as a node-global **Config-Sync (`CF`) monitor-failure / degraded health**, so a node stuck `Transfer ready: no` / `applied gen=0` (config-apply hard-failing, high-water correctly pinned per M-2/#4151) becomes operator-visible instead of reporting "healthy". This is the **first, independent, diagnostic PR** of the 3-PR #6387 plan; it does **not** touch the host-inbound netlink migration.

**advances #6387** (PR 1 of 3 — the issue stays OPEN until the cutover PR-3).

Plan reference: `docs/pr/6387-hostinbound-netlink/plan.md` §5.2 / §12.6 / §12.7 (adjudicated).

## Design

- **Time-based trigger, not attempt-count** (adjudicated §12.6): `configApplyLoop` only runs on a RECEIVED config and the primary re-pushes the same generation on reconnect / later commits rather than continuously, so "N consecutive failures" could strand the standby forever below the threshold. Instead, the loop stamps the monotonic time of the first apply failure in an un-applied streak and fires `OnConfigApplyHealth(true)` once the streak persists past a stale-duration grace (`DefaultConfigApplyFailGrace` = **30s**, comfortably longer than a transient RG0-primary rejection → no flap). The first successful apply clears it.
- **Dedicated node-global manager field** (`configSyncFailing` / bounded `configSyncFailReason`), set via `Manager.SetConfigSyncHealth` — **not** a `"CF"`-in-`rg.MonitorFails` sentinel, because `reconcileMonitorDebtsLocked` wipes any non-interface/non-IP `MonitorFails` entry on every `UpdateConfig`.
- **Rendering:** `FormatStatus` folds `CF` into the Monitor-failures column of every RG row; `FormatInformation` degrades `Node health` and adds a `Config sync: failing (<reason>)` line beside `Configs apply-failed:`.
- **Daemon wiring:** `ss.OnConfigApplyHealth → d.cluster.SetConfigSyncHealth`, next to the existing `OnConfigReceived`.

## Election-neutral / not a failover gate / survives reconcileMonitorDebtsLocked

Zero perturbation of `Weight` / `monitorWeights` / readiness / election; no election event emitted. `ReadyForManualFailover()` stays exactly `!ConfigStale()` — no second gate — and crash takeover stays intentionally ungated. CF **only** annotates health. The dedicated field survives `UpdateConfig` (verified by test + parent-RED).

## Parent-RED (verified firsthand)

- Neutralize the raise → `TestConfigSyncHealthRaisesAfterGraceAndClearsOnSuccess` goes RED at *"CF must raise once the un-applied streak persists past the grace"*.
- Simulate the `reconcileMonitorDebtsLocked` sentinel-wipe (`m.configSyncFailing = false` at end of reconcile) → same test goes RED at *"CF must survive UpdateConfig"*.
- Both neutralizations restored; no residue.

## Tests (new: `pkg/cluster/sync_config_health_6387_test.go`)

- **Raise + render + clear + reconcile-survival:** drives `configApplyLoop` with a failing `OnConfigReceived`, advances an injected stale-duration clock past T, asserts `lastAppliedConfigGen` stays pinned at 0, `ConfigsApplyFailed` increments, `configSyncFailing` raises → `FormatStatus` shows `CF` / `FormatInformation` shows `Node health: degraded` + `Config sync: failing`; the flag survives an intervening `UpdateConfig`; one success clears it.
- **Transient-within-T no flap.**
- **Election-neutral:** `Weight`/`State`/priority/`FailoverCount` unchanged, no event emitted, `ReadyForManualFailover` independent of CF.

Validation: `go build ./...`; `go vet ./pkg/cluster ./pkg/daemon`; gofmt-clean; `go test ./pkg/cluster/... ./pkg/daemon/... ./pkg/dataplane/...` GREEN (retirement canary included); new CF tests GREEN under `-race`.

## Out of scope (later PRs)

Host-inbound netlink migration (PR-2), daemon cutover (PR-3), and the `nf_tables` functional capability probe (folds into PR-2). This PR surfaces the existing apply failure regardless of cause.

## Notes for the reviewer

The parent owns the review gate and `make test-failover` (this touches `pkg/cluster`). Docs updated: `docs/sync-protocol.md` (config-sync apply-failure health surfacing) + `docs/junos-cli-reference.md` (`CF` in the Monitor-failures column).