### PR TITLE
hardening: three codex-179 #6394 review residuals (#6396)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -62,6 +62,47 @@
   pkg/routing/routing_test.go, pkg/routing/bond_test.go,
   pkg/routing/readback_guard_6396_test.go, pkg/routing/README.md
 
+- **Timestamp**: 2026-07-23 (re-gate fold on PR #6399, Codex MERGE-NEEDS-MAJOR)
+- **Action**: Folded the adjudicated Codex6399 findings (all complete the 4
+  stated fixes; not new scope). MAJOR 1 — xfrm ParentIndex identity: xpf
+  creates every xfrmi PARENTLESS, so a same-name/same-if_id xfrmi bound to a
+  NONZERO parent (IFLA_XFRM_LINK, selects egress) passed both the #5523 adopt
+  guard and the #6396 post-create guard and would egress SA traffic out the
+  wrong device. Extended BOTH guards to also assert
+  xi.Attrs().ParentIndex==0. MINOR 3 — xfrm stale-ownership: on a rejected
+  post-create readback, delete(x.xfrmis, ifName) so a pre-tracked name cannot
+  leave a later reconcile acting on a foreign substitute. MINOR 4 — archive
+  reseed scan-error: maxArchiveSeq now returns (uint64, error) via an
+  archiveDirReader seam; SetArchiveConfig keys the reseed off a new
+  archiveSeedDir (last successfully-scanned dir) and, on a ReadDir error,
+  leaves the counter unchanged AND the dir un-seeded so the next call retries
+  — a transient scan failure no longer pins the counter below the on-disk max
+  forever. MINOR 6 — SNMP recovery bound: added a fail-on-revert test
+  (attrCapturingHandler) asserting the recovery slog.Info fires once with the
+  correct suppressed_failures count after a failing→succeeding transition.
+  Test quality (item 5) — dir-switch test now proves a real archive SURVIVES
+  rotation (reseeded seq outranks pre-existing; oldest pruned) instead of
+  asserting the private counter. README (MAJOR 2) — bond scope-out made
+  explicit: create-path gated here, ADOPT path deferred to #6402 (HA-touching,
+  must validate mode/MTU not just type; loss-cluster smoke). Added a mode/MTU
+  note to #6402. DEFERRED — ArchiveConfig ordering race (Codex MINOR 5): zero
+  production callers; holding s.mu across the off-lock write reintroduces the
+  #6185 QuiesceArchival deadlock, so NOT trivial — reported for a follow-up,
+  not folded.
+- **File(s)**: pkg/routing/xfrm.go,
+  pkg/routing/xfrm_nonxfrmi_reject_5523_test.go, pkg/configstore/store.go,
+  pkg/configstore/store_persist.go, pkg/configstore/archive_6396_test.go,
+  pkg/daemon/daemon_snmp_reconcile.go,
+  pkg/daemon/daemon_snmp_ifdata_throttle_6396_test.go,
+  pkg/routing/README.md, pkg/configstore/README.md
+- **Validation**: gofmt/build/vet clean on the three touched pkgs; full
+  `go test ./pkg/routing ./pkg/configstore ./pkg/daemon` GREEN; fail-on-revert
+  confirmed firsthand for every new fold (ParentIndex adopt+create → adopted
+  not recreated / Apply nil; stale-ownership → xfrmis[name] persists;
+  scan-error → counter stuck at 5 not caught up to 202; SNMP recovery → 0
+  recovery logs; strengthened dir-switch → reseed neutralized fails the
+  rotation-survival assertion), then restored GREEN.
+
 ## 2026-07-23 — #5583 C180: fold two Codex MAJOR findings into #6383
 
 - **Timestamp**: 2026-07-23 (fix/5583-codex180, fold on PR #6383)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-23 — #6396 codex-179 review residuals (3 low-risk hardenings)
+
+- **Timestamp**: 2026-07-23 (fix/6396-hardening-residuals)
+- **Action**: Implemented the three in-Go-scope #6396 residuals from the
+  codex-179 #6394 review, each with a firsthand-verified fail-on-revert test.
+  (1) SNMP ifTable warn flood — `buildSNMPIfData` (`pkg/daemon/
+  daemon_snmp_reconcile.go`) now rate-limits its netlink-failure `slog.Warn`
+  via a reusable `warnThrottle` (once per minute; first failure logs, later
+  ones in the window are counted + reported with the next line; a successful
+  read logs a one-time recovery). buildSNMPIfData runs once per SNMP poll, so a
+  persistent failure previously wrote one line per poll. (2) xfrm post-create
+  readback TOCTOU (`pkg/routing/xfrm.go`) — the `LinkByName` right after
+  `LinkAdd` now re-asserts the link is an `*netlink.Xfrmi` with the desired
+  `if_id` before bring-up/track, matching the adopt-path guard (#5523
+  C179-104); a same-name foreign or wrong-if_id link substituted in the
+  add→readback window is rejected (commit fails closed, next reconcile
+  reclaims). Both substitution shapes covered. (3) archive rotation edges
+  (`pkg/configstore/store_persist.go`) — `parseArchiveSeq` now requires the
+  two-dot current `config-<ts>.<seq>.conf` shape so a legacy pre-#3441
+  `config-<ts>.conf` (trailing nanoseconds) is no longer mis-read as a huge
+  seq in a mixed dir; `SetArchiveConfig` re-seeds the monotonic counter on ANY
+  archive-dir change (monotonic-up only), not just at process start, so a
+  runtime switch to a previously-used dir cannot let its higher-seq archives
+  outrank the ones this process writes. Scoped OUT: the SetIfDataFn error-
+  channel contract change and the best-effort RETH-MAC / CLI-display LinkList
+  swallows (issue defers as "remain"); the synchronous `ArchiveConfig` mirror's
+  target-dir seeding (zero production callers, shared-counter design).
+- **File(s)**: pkg/daemon/daemon_snmp_reconcile.go,
+  pkg/daemon/daemon_snmp_ifdata_throttle_6396_test.go,
+  pkg/daemon/daemon_snmp_ifdata_netlink_5523_test.go, pkg/routing/xfrm.go,
+  pkg/routing/iface_reuse_test.go, pkg/routing/xfrm_nonxfrmi_reject_5523_test.go,
+  pkg/configstore/store_persist.go, pkg/configstore/archive_6396_test.go,
+  pkg/configstore/archive_rotate_seq_5523_test.go, pkg/snmp/README.md,
+  pkg/configstore/README.md, pkg/routing/README.md
+- **Validation**: gofmt/build/vet clean on the three touched pkgs; full
+  `go test ./pkg/daemon ./pkg/routing ./pkg/configstore` GREEN; fail-on-revert
+  confirmed firsthand for all four fixes (SNMP throttle → 20 warns for 20
+  polls; xfrm readback → Apply returns nil + adopts foreign link; parseArchive
+  legacy → nanoseconds parsed as seq + legacy retained over current; dir-switch
+  reseed → counter stuck at old dir's max), then restored GREEN.
+
 ## 2026-07-23 — #5583 C180: fold two Codex MAJOR findings into #6383
 
 - **Timestamp**: 2026-07-23 (fix/5583-codex180, fold on PR #6383)

--- a/_Log.md
+++ b/_Log.md
@@ -103,6 +103,34 @@
   recovery logs; strengthened dir-switch → reseed neutralized fails the
   rotation-survival assertion), then restored GREEN.
 
+- **Timestamp**: 2026-07-23 (convergence round on PR #6399, Codex 3rd MAJOR)
+- **Action**: Converged #6399 — kept the Codex-verified core, honestly
+  deferred the bond validation rabbit-hole. FOLDED (Codex MINOR 4): xfrm
+  LinkAdd-FAILURE stale ownership — the genuine create-failure exit
+  (xfrm.go:259) now also `delete(x.xfrmis, ifName)` so a pre-tracked name
+  whose recreate fails does not leave the removal pass able to delete a
+  foreign link that later wears the name; test
+  TestXfrmCreateLinkAddFailureDropsStaleTracking (PRE-TRACKED manager +
+  addFail), fail-on-revert firsthand RED (xfrmis=map[st0.1:2] persists) →
+  restored GREEN. DEFERRED to #6402 (HA-touching, NOT folded): bond identity
+  residuals — README (pkg/routing/README.md) now honestly enumerates all
+  three (create-path mode/MTU, adopt-path type+mode+MTU, KEEP-path identity
+  bond.go:181) as deferred; kept the create-path `*netlink.Bond` type guard
+  (net improvement). Updated #6402 to cover all three. DEFERRED to NEW #6404
+  (NOT folded): archive reseed edges (Codex MINOR 2 commit-interval race at
+  store_commit.go:284 + MINOR 3 disable/re-enable A→""→A skip); corrected the
+  configstore README's "ANY archive-dir change" wording to what is actually
+  guaranteed (re-seeds on a dir DIFFERENT from the last successfully-seeded
+  one) and cited #6404.
+- **File(s)**: pkg/routing/xfrm.go,
+  pkg/routing/xfrm_nonxfrmi_reject_5523_test.go, pkg/routing/README.md,
+  pkg/configstore/README.md
+- **Validation**: gofmt/build/vet clean; full
+  `go test ./pkg/routing ./pkg/configstore ./pkg/daemon` GREEN; new
+  LinkAdd-failure fold fail-on-revert verified firsthand this round; the
+  ParentIndex/readback/scan-error/SNMP guards (unchanged this round) verified
+  in the prior fold round.
+
 ## 2026-07-23 — #5583 C180: fold two Codex MAJOR findings into #6383
 
 - **Timestamp**: 2026-07-23 (fix/5583-codex180, fold on PR #6383)

--- a/_Log.md
+++ b/_Log.md
@@ -131,6 +131,18 @@
   ParentIndex/readback/scan-error/SNMP guards (unchanged this round) verified
   in the prior fold round.
 
+- **Timestamp**: 2026-07-23 (doc-honesty round on PR #6399, Codex MINOR)
+- **Action**: Two doc-summary honesty qualifications, NO code/test change.
+  (1) pkg/routing/README.md — the "Identity re-assertion" summary claimed all
+  three managers reject right-type/wrong-discriminator readbacks; qualified to
+  match the honest per-manager detail below it (xfrm type+Ifid+ParentIndex==0,
+  VRF type+table, bond TYPE ONLY — mode/MTU + adopt/KEEP-path deferred to
+  #6402). (2) pkg/configstore/README.md — the seq monotonicity / no-overwrite
+  summary retained unconditional guarantees its own #6404 exceptions
+  contradict; qualified to "after a successful reseed scan and outside the two
+  #6404-deferred windows". Production .go byte-identical to f36c2c814.
+- **File(s)**: pkg/routing/README.md, pkg/configstore/README.md
+
 ## 2026-07-23 — #5583 C180: fold two Codex MAJOR findings into #6383
 
 - **Timestamp**: 2026-07-23 (fix/5583-codex180, fold on PR #6383)

--- a/_Log.md
+++ b/_Log.md
@@ -39,6 +39,29 @@
   legacy → nanoseconds parsed as seq + legacy retained over current; dir-switch
   reseed → counter stuck at old dir's max), then restored GREEN.
 
+- **Timestamp**: 2026-07-23 (fold on PR #6399, review MERGE-NEEDS-MINOR)
+- **Action**: Folded the Claude-hostile-review completeness MINOR: the xfrm
+  post-create readback guard had structurally-identical UNGUARDED siblings in
+  the same package. (a) createLinkedVRF (pkg/routing/vrf.go) now re-asserts the
+  post-LinkAdd readback is an netlink.Vrf carrying the desired table before
+  bring-up; on mismatch it returns (added=true, err) so the caller keeps
+  ownership and the reconcile adopt path (vrfTable → recreate on table
+  mismatch) reclaims a substitute next cycle. (b) createBond
+  (pkg/routing/bond.go) now re-asserts the readback is an netlink.Bond before
+  enslaving/bring-up: enslaveMembers only surfaces a foreign substitute via a
+  real-netlink LinkSetMaster failure when a member is enslavable, so a bond
+  whose configured members are all absent (the #4823 soft-error case) would
+  otherwise adopt a foreign link — the type check closes that for every member
+  state. Added substituteAfterAdd seams to fakeVRFOps + fakeBondLinkOps and
+  three VRF + one bond fail-on-revert tests (RED→GREEN confirmed firsthand:
+  VRF non-Vrf + wrong-table → Apply nil + brought up; bond foreign readback →
+  tracked + created). Routing README identity-re-assertion invariant
+  generalized to cover xfrm + VRF + bond (correcting the prior xfrm-only
+  scope-out).
+- **File(s)**: pkg/routing/vrf.go, pkg/routing/bond.go,
+  pkg/routing/routing_test.go, pkg/routing/bond_test.go,
+  pkg/routing/readback_guard_6396_test.go, pkg/routing/README.md
+
 ## 2026-07-23 — #5583 C180: fold two Codex MAJOR findings into #6383
 
 - **Timestamp**: 2026-07-23 (fix/5583-codex180, fold on PR #6383)

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1090,15 +1090,21 @@ owned by the `journal/` subpackage.
   `config-<ts>.conf` — whose trailing nanoseconds would otherwise be
   mis-read as a huge seq — is treated as unparseable (oldest, pruned
   first) in a mixed legacy+current dir; and `SetArchiveConfig` re-seeds on
-  ANY archive-dir change (monotonic-up only), not just at process start,
-  so a runtime switch to a previously-used dir cannot let that dir's
-  higher-seq archives outrank the ones this process is about to write. The
-  re-seed keys off `archiveSeedDir` (the last successfully-scanned dir), and
-  `maxArchiveSeq` distinguishes a directory READ error from a legitimately
-  empty dir: a transient scan failure leaves the counter unchanged and the
-  dir un-seeded so the next call retries, rather than pinning the counter at
-  0 below the on-disk max and pruning every fresh archive as stale (#6396
-  Codex MINOR 4). The rollback/archive writers
+  a target dir that DIFFERS from the last successfully-seeded one
+  (monotonic-up only), not just at process start, so a runtime switch to a
+  previously-used dir cannot let that dir's higher-seq archives outrank the
+  ones this process is about to write. The re-seed keys off `archiveSeedDir`
+  (the last successfully-scanned dir), and `maxArchiveSeq` distinguishes a
+  directory READ error from a legitimately empty dir: a transient scan failure
+  leaves the counter unchanged and the dir un-seeded so the next call retries,
+  rather than pinning the counter at 0 below the on-disk max and pruning every
+  fresh archive as stale (#6396 Codex MINOR 4). Two narrow reseed edges remain
+  open (tracked in #6404, not yet closed): a commit that lands in the window
+  AFTER a failed scan but BEFORE the next `SetArchiveConfig` retry captures the
+  still-low seq; and a disable→re-enable to the SAME dir (`A`→`""`→`A`) does
+  not rescan (archiveSeedDir is not invalidated on disable), so archives
+  written to `A` while archival was off are not accounted for. The
+  rollback/archive writers
   route through package-var seams (`rbWriteFileDurable`,
   `rbWriteFileAtomic`, `rbSyncDir`, `rbRemove`) so tests can pin the
   durability call and inject failures (#1916 pattern).

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1081,7 +1081,18 @@ owned by the `journal/` subpackage.
   guarantees no archive is ever overwritten while the leading timestamp
   keeps rotation's lexical sort chronological. `ArchiveConfig` captures
   the text, timestamp AND seq together under the lock (no after-unlock
-  `time.Now()` race). The rollback/archive writers
+  `time.Now()` race). Rotation prunes by the parsed seq, and
+  `SetArchiveConfig` seeds the per-process counter from the highest seq on
+  disk so it stays globally monotonic across restarts (#5523 C179-060).
+  Two #6396 residual hardenings: `parseArchiveSeq` requires the current
+  two-dot `config-<ts>.<seq>.conf` shape (the ts's own
+  seconds.nanoseconds dot PLUS the seq dot), so a legacy pre-#3441
+  `config-<ts>.conf` — whose trailing nanoseconds would otherwise be
+  mis-read as a huge seq — is treated as unparseable (oldest, pruned
+  first) in a mixed legacy+current dir; and `SetArchiveConfig` re-seeds on
+  ANY archive-dir change (monotonic-up only), not just at process start,
+  so a runtime switch to a previously-used dir cannot let that dir's
+  higher-seq archives outrank the ones this process is about to write. The rollback/archive writers
   route through package-var seams (`rbWriteFileDurable`,
   `rbWriteFileAtomic`, `rbSyncDir`, `rbRemove`) so tests can pin the
   durability call and inject failures (#1916 pattern).

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1084,6 +1084,11 @@ owned by the `journal/` subpackage.
   `time.Now()` race). Rotation prunes by the parsed seq, and
   `SetArchiveConfig` seeds the per-process counter from the highest seq on
   disk so it stays globally monotonic across restarts (#5523 C179-060).
+  These monotonicity / no-overwrite guarantees hold **after a successful
+  reseed scan and outside the two #6404-deferred windows** (a commit that
+  lands after a failed scan but before the next `SetArchiveConfig` retry, and
+  a disable→re-enable to the same dir that skips the rescan) — see the #6396
+  hardening note below.
   Two #6396 residual hardenings: `parseArchiveSeq` requires the current
   two-dot `config-<ts>.<seq>.conf` shape (the ts's own
   seconds.nanoseconds dot PLUS the seq dot), so a legacy pre-#3441

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1092,7 +1092,13 @@ owned by the `journal/` subpackage.
   first) in a mixed legacy+current dir; and `SetArchiveConfig` re-seeds on
   ANY archive-dir change (monotonic-up only), not just at process start,
   so a runtime switch to a previously-used dir cannot let that dir's
-  higher-seq archives outrank the ones this process is about to write. The rollback/archive writers
+  higher-seq archives outrank the ones this process is about to write. The
+  re-seed keys off `archiveSeedDir` (the last successfully-scanned dir), and
+  `maxArchiveSeq` distinguishes a directory READ error from a legitimately
+  empty dir: a transient scan failure leaves the counter unchanged and the
+  dir un-seeded so the next call retries, rather than pinning the counter at
+  0 below the on-disk max and pruning every fresh archive as stale (#6396
+  Codex MINOR 4). The rollback/archive writers
   route through package-var seams (`rbWriteFileDurable`,
   `rbWriteFileAtomic`, `rbSyncDir`, `rbRemove`) so tests can pin the
   durability call and inject failures (#1916 pattern).

--- a/pkg/configstore/archive_6396_test.go
+++ b/pkg/configstore/archive_6396_test.go
@@ -1,6 +1,7 @@
 package configstore
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -140,8 +141,27 @@ func TestSetArchiveConfigReseedsOnDirSwitch(t *testing.T) {
 		t.Fatalf("after switching to dirB, archiveSeq must re-seed to dirB's max (102) so a new "+
 			"archive there is not outranked by the pre-existing ones (#6396); got %d", got)
 	}
-	if next := s.archiveSeq.Add(1); next != 103 {
-		t.Fatalf("post-switch next seq = %d, want 103", next)
+
+	// Prove the REAL rotation outcome, not just the private counter: an archive
+	// written to dirB with the reseeded counter must SURVIVE rotation (its seq
+	// now outranks the pre-existing 100..102) and the oldest pre-existing
+	// archive must be pruned. Without the reseed the new file would carry a seq
+	// below 100 and be pruned as stale instead.
+	seq := s.archiveSeq.Add(1) // 103, from the reseeded 102
+	ts := base.Add(time.Duration(seq) * time.Second)
+	if err := writeArchive(dirB, 3, "b-new\n", ts, seq); err != nil {
+		t.Fatal(err)
+	}
+	remain := archiveContents(t, dirB)
+	if !remain["b-new"] {
+		t.Errorf("the freshly-written archive must survive rotation (its reseeded seq outranks "+
+			"the pre-existing ones); remain=%v", remain)
+	}
+	if remain["b-100"] {
+		t.Errorf("the oldest pre-existing archive (b-100) must be pruned; remain=%v", remain)
+	}
+	if len(remain) != 3 {
+		t.Errorf("want 3 archives after rotation (max=3), got %d: %v", len(remain), remain)
 	}
 
 	// Switching to an empty dir must NOT rewind the monotonic counter.
@@ -151,4 +171,77 @@ func TestSetArchiveConfigReseedsOnDirSwitch(t *testing.T) {
 		t.Fatalf("switching to an empty dir rewound archiveSeq to %d, want it held at 103 "+
 			"(seed is monotonic-up only)", got)
 	}
+}
+
+// TestSetArchiveConfigReseedScanErrorDoesNotRegress is the #6396 Codex MINOR 4
+// guard: a transient failure to READ the archive dir during the reseed scan
+// must NOT pin the monotonic counter below the on-disk max. maxArchiveSeq now
+// distinguishes a read error from an empty dir, and SetArchiveConfig leaves the
+// counter unchanged AND the dir un-seeded on error, so the next call retries.
+//
+// FAIL-ON-REVERT: treating a scan error as an empty dir (seed 0 + mark the dir
+// seeded) means the retry call skips the rescan and the counter stays stuck —
+// the "retry catches up to 202" assertion goes RED.
+func TestSetArchiveConfigReseedScanErrorDoesNotRegress(t *testing.T) {
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	dirA := t.TempDir()
+	for seq := 1; seq <= 5; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dirB := t.TempDir()
+	for seq := 200; seq <= 202; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirB, 100, fmt.Sprintf("b-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := &Store{}
+	s.SetArchiveConfig(dirA, 3)
+	if got := s.archiveSeq.Load(); got != 5 {
+		t.Fatalf("after dirA, archiveSeq = %d, want 5", got)
+	}
+
+	// Switch to dirB, but the scan fails (transient mount/permission error).
+	injErr := errors.New("injected: ReadDir EIO")
+	prev := archiveDirReader
+	archiveDirReader = func(string) ([]os.DirEntry, error) { return nil, injErr }
+	s.SetArchiveConfig(dirB, 3)
+	archiveDirReader = prev
+
+	// The counter must NOT have regressed (stays 5, not dropped to 0), and dirB
+	// must NOT be recorded as seeded.
+	if got := s.archiveSeq.Load(); got != 5 {
+		t.Fatalf("a failed reseed scan regressed archiveSeq to %d, want it held at 5", got)
+	}
+
+	// Retry: the scan now succeeds and must RESCAN dirB (not skip it), catching
+	// the counter up to dirB's on-disk max (202).
+	s.SetArchiveConfig(dirB, 3)
+	if got := s.archiveSeq.Load(); got != 202 {
+		t.Fatalf("after a failed scan the next same-dir call must rescan and catch up to "+
+			"dirB's max (202); got %d", got)
+	}
+}
+
+// archiveContents reads dir and returns the set of trimmed archive-file
+// contents present, for asserting rotation outcomes.
+func archiveContents(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]bool{}
+	for _, e := range ents {
+		d, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[strings.TrimSpace(string(d))] = true
+	}
+	return out
 }

--- a/pkg/configstore/archive_6396_test.go
+++ b/pkg/configstore/archive_6396_test.go
@@ -1,0 +1,154 @@
+package configstore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestParseArchiveSeqRejectsLegacyNanoseconds is the #6396 C179-060 residual
+// guard for parseArchiveSeq. A legacy pre-#3441 archive is named
+// config-<ts>.conf where <ts> = "20060102-150405.000000000" — a subsecond ts
+// whose single dot separates seconds from nanoseconds. The pre-fix parse took
+// the LAST dot-delimited field as the seq, so it read a legacy name's
+// nanoseconds ("123456789") as a huge sequence. In a MIXED legacy+current
+// archive dir that mis-key corrupts the seq-ordered prune: legacy entries are
+// ranked by their nanosecond fraction instead of ordering as the oldest.
+//
+// FAIL-ON-REVERT: dropping the "ts dot must be present" check restores the
+// nanoseconds-as-seq parse — this test's ok=false assertion goes RED.
+func TestParseArchiveSeqRejectsLegacyNanoseconds(t *testing.T) {
+	// Legacy: config-<ts-with-nanos>.conf, no separate seq field.
+	legacyTS := time.Date(2026, 6, 28, 12, 0, 0, 123456789, time.UTC)
+	legacy := fmt.Sprintf("config-%s.conf", legacyTS.Format("20060102-150405.000000000"))
+	if seq, ok := parseArchiveSeq(legacy); ok {
+		t.Errorf("parseArchiveSeq(%q) = (%d, true); a legacy config-<ts>.conf must be "+
+			"unparseable so its nanoseconds are not mis-read as a sequence (#6396)", legacy, seq)
+	}
+
+	// Current: config-<ts>.<seq>.conf — two dots, still parses to the real seq.
+	cur := fmt.Sprintf("config-%s.%020d.conf", legacyTS.Format("20060102-150405.000000000"), uint64(7))
+	if seq, ok := parseArchiveSeq(cur); !ok || seq != 7 {
+		t.Errorf("parseArchiveSeq(%q) = (%d, %v), want (7, true)", cur, seq, ok)
+	}
+}
+
+// TestRotateArchivesLegacyPrunedBeforeCurrent is the retention consequence of
+// the parse fix: in a MIXED dir, every legacy config-<ts>.conf must rank as
+// older than any current config-<ts>.<seq>.conf and be pruned first, so the
+// newest current archives survive.
+//
+// FAIL-ON-REVERT: with the legacy nanoseconds parsed as a seq, a legacy file
+// with a large nanosecond fraction outranks a small-seq current archive and is
+// retained over it — the "current survives, legacy pruned" assertions go RED.
+func TestRotateArchivesLegacyPrunedBeforeCurrent(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	// Two legacy files with LARGE nanosecond fractions (would parse as huge
+	// bogus seqs under the old code) — these predate the current scheme and
+	// must be the first evicted.
+	for i, nanos := range []int{900000000, 800000000} {
+		ts := base.Add(time.Duration(i) * time.Second).Add(time.Duration(nanos) * time.Nanosecond)
+		name := fmt.Sprintf("config-%s.conf", ts.Format("20060102-150405.000000000"))
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(fmt.Sprintf("legacy-%d\n", i)), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Two current files with SMALL seqs (1, 2). These are the newest by the
+	// true commit order and must be retained.
+	for seq := 1; seq <= 2; seq++ {
+		ts := base.Add(time.Duration(10+seq) * time.Second)
+		if err := writeArchive(dir, 100, fmt.Sprintf("current-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Keep only the 2 newest of the 4 files.
+	rotateArchives(dir, 2)
+
+	remain := map[string]bool{}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ents) != 2 {
+		t.Fatalf("want 2 archives after prune (max=2), got %d", len(ents))
+	}
+	for _, e := range ents {
+		d, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		remain[strings.TrimSpace(string(d))] = true
+	}
+	for _, w := range []string{"current-1", "current-2"} {
+		if !remain[w] {
+			t.Errorf("current archive %q must be retained over any legacy file; remain=%v", w, remain)
+		}
+	}
+	for _, w := range []string{"legacy-0", "legacy-1"} {
+		if remain[w] {
+			t.Errorf("legacy archive %q must be pruned before any current file; remain=%v", w, remain)
+		}
+	}
+}
+
+// TestSetArchiveConfigReseedsOnDirSwitch is the #6396 C179-060 residual guard
+// for the runtime archive-dir switch. archiveSeq is seeded once from the
+// original dir; a later switch to a DIFFERENT previously-used dir whose existing
+// archives carry HIGHER seqs must re-seed the counter from that dir. Without the
+// re-seed, this process keeps its lower counter and the archives it writes to
+// the new dir carry seqs BELOW the pre-existing ones — so the seq-ordered prune
+// evicts the fresh archives as if they were the oldest.
+//
+// FAIL-ON-REVERT: dropping the dir-change re-seed (leaving only the seq==0
+// guard) leaves archiveSeq at the first dir's max after the switch — the
+// "reseeded to dirB's max" assertion goes RED.
+func TestSetArchiveConfigReseedsOnDirSwitch(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	// dirA holds seqs 1..5; dirB (a previously-used dir) holds seqs 100..102.
+	for seq := 1; seq <= 5; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for seq := 100; seq <= 102; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirB, 100, fmt.Sprintf("b-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := &Store{}
+	s.SetArchiveConfig(dirA, 3)
+	if got := s.archiveSeq.Load(); got != 5 {
+		t.Fatalf("after configuring dirA, archiveSeq = %d, want 5 (dirA max)", got)
+	}
+
+	// Runtime switch to dirB: the counter must jump to dirB's higher max so the
+	// next archive written there outranks the pre-existing 100..102.
+	s.SetArchiveConfig(dirB, 3)
+	if got := s.archiveSeq.Load(); got != 102 {
+		t.Fatalf("after switching to dirB, archiveSeq must re-seed to dirB's max (102) so a new "+
+			"archive there is not outranked by the pre-existing ones (#6396); got %d", got)
+	}
+	if next := s.archiveSeq.Add(1); next != 103 {
+		t.Fatalf("post-switch next seq = %d, want 103", next)
+	}
+
+	// Switching to an empty dir must NOT rewind the monotonic counter.
+	dirEmpty := t.TempDir()
+	s.SetArchiveConfig(dirEmpty, 3)
+	if got := s.archiveSeq.Load(); got != 103 {
+		t.Fatalf("switching to an empty dir rewound archiveSeq to %d, want it held at 103 "+
+			"(seed is monotonic-up only)", got)
+	}
+}

--- a/pkg/configstore/archive_rotate_seq_5523_test.go
+++ b/pkg/configstore/archive_rotate_seq_5523_test.go
@@ -114,6 +114,10 @@ func TestParseArchiveSeq(t *testing.T) {
 		"config-20260628.conf",    // single field, no seq
 		"notes.txt",               // not an archive
 		"config-20260628-1.2.txt", // wrong suffix
+		// #6396: a legacy pre-#3441 config-<ts>.conf with a subsecond ts has ONE
+		// dot (the ts's nanoseconds) in core. The old parse mis-read those
+		// nanoseconds as a sequence; it must now be rejected as unparseable.
+		"config-20260628-120000.123456789.conf",
 	} {
 		if seq, ok := parseArchiveSeq(bad); ok {
 			t.Errorf("parseArchiveSeq(%q) = (%d, true), want ok=false", bad, seq)

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -215,6 +215,14 @@ type Store struct {
 	archiveDir string // local archive directory (empty = disabled)
 	archiveMax int    // max archives to keep
 
+	// archiveSeedDir is the archive dir for which the archiveSeq reseed scan
+	// last SUCCEEDED (#6396 Codex MINOR 4). SetArchiveConfig scans a dir only
+	// when it differs from this — so a transient scan failure (mount/permission)
+	// leaves it unchanged and the next call retries, instead of the failure
+	// silently marking the dir seeded and pinning the counter below the on-disk
+	// max forever (which would prune every fresh archive as stale).
+	archiveSeedDir string
+
 	// archiveSeq is a monotonic counter appended to every archive filename
 	// (#3441 H4, Codex MAJOR). The wall-clock timestamp alone is not a unique
 	// key: two successive (mutex-serialized) commits can format the SAME

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -474,16 +474,31 @@ func (s *Store) persistRetryLoop(backoff, maxBackoff time.Duration) {
 // high-seq archive from the PRIOR process outrank — and evict — the fresh
 // low-seq archives of the NEW process. Seeding to max(existing seq) keeps the
 // newest commit's seq strictly highest so retention order is correct across
-// restarts. The scan runs only while archiveSeq is still 0 (process start,
-// before any archive is written); once the process has written one archive the
-// counter is already ahead of disk and the scan is skipped.
+// restarts. The scan runs when archiveSeq is still 0 (process start, before any
+// archive is written) OR when the archive dir changes (#6396: a runtime switch
+// to a previously-used dir must re-seed from that dir's existing max, else this
+// process's lower counter would let the pre-existing archives outrank the new
+// ones); an unchanged dir with a non-zero counter skips the scan because the
+// counter is already ahead of disk.
 func (s *Store) SetArchiveConfig(dir string, max int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	dirChanged := dir != s.archiveDir
 	s.archiveDir = dir
 	s.archiveMax = max
-	if dir != "" && s.archiveSeq.Load() == 0 {
-		if seed := maxArchiveSeq(dir); seed > 0 {
+	// Seed the monotonic archive seq from the highest seq already on disk in
+	// the target dir. Re-seed on ANY dir change, not only at process start
+	// (seq==0): a runtime archive-dir switch to a previously-used directory
+	// whose existing archives carry HIGHER seqs than this process's counter
+	// would otherwise let those pre-existing archives outrank — and evict — the
+	// archives this process is about to write, the same across-restart hazard
+	// #5523 C179-060 closed but reached via a live dir switch (#6396). The seed
+	// is monotonic-up only (max of the current counter and the on-disk max), so
+	// switching to an empty or lower-seq dir never rewinds the counter. An
+	// unchanged dir with a non-zero counter skips the scan (the counter is
+	// already ahead of disk).
+	if dir != "" && (dirChanged || s.archiveSeq.Load() == 0) {
+		if seed := maxArchiveSeq(dir); seed > s.archiveSeq.Load() {
 			s.archiveSeq.Store(seed)
 		}
 	}
@@ -501,6 +516,19 @@ func parseArchiveSeq(name string) (uint64, bool) {
 	core := strings.TrimSuffix(name, ".conf")
 	dot := strings.LastIndexByte(core, '.')
 	if dot < 0 {
+		return 0, false
+	}
+	// #6396: a current-format archive is config-<ts>.<seq>.conf where <ts>
+	// itself embeds a dot (seconds.nanoseconds), so core has TWO dots and the
+	// portion before the seq dot still contains one. A legacy pre-#3441
+	// config-<ts>.conf name has only the ts's single dot, whose trailing
+	// nanoseconds ("20240101-120000.123456789") would otherwise be mis-read as
+	// a huge sequence — corrupting the seq-ordered retention of a MIXED
+	// legacy+current archive dir. Require the ts dot to be present so a legacy
+	// name is treated as unparseable (oldest, pruned first, lexical-by-ts among
+	// its peers), matching a config-<ts>.conf with no subsecond ts (which has
+	// no dot in core and already returns false).
+	if strings.IndexByte(core[:dot], '.') < 0 {
 		return 0, false
 	}
 	seq, err := strconv.ParseUint(core[dot+1:], 10, 64)

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -474,32 +474,44 @@ func (s *Store) persistRetryLoop(backoff, maxBackoff time.Duration) {
 // high-seq archive from the PRIOR process outrank — and evict — the fresh
 // low-seq archives of the NEW process. Seeding to max(existing seq) keeps the
 // newest commit's seq strictly highest so retention order is correct across
-// restarts. The scan runs when archiveSeq is still 0 (process start, before any
-// archive is written) OR when the archive dir changes (#6396: a runtime switch
-// to a previously-used dir must re-seed from that dir's existing max, else this
-// process's lower counter would let the pre-existing archives outrank the new
-// ones); an unchanged dir with a non-zero counter skips the scan because the
-// counter is already ahead of disk.
+// restarts. The scan runs whenever the target dir differs from the one last
+// successfully seeded (archiveSeedDir) — process start (archiveSeedDir=="") and
+// a runtime dir switch both qualify (#6396: a switch to a previously-used dir
+// must re-seed from that dir's existing max, else this process's lower counter
+// would let the pre-existing archives outrank the new ones). A scan that fails
+// to READ the dir leaves archiveSeedDir unchanged so the next call retries,
+// rather than pinning the counter below the on-disk max (#6396 Codex MINOR 4).
 func (s *Store) SetArchiveConfig(dir string, max int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	dirChanged := dir != s.archiveDir
 	s.archiveDir = dir
 	s.archiveMax = max
 	// Seed the monotonic archive seq from the highest seq already on disk in
-	// the target dir. Re-seed on ANY dir change, not only at process start
-	// (seq==0): a runtime archive-dir switch to a previously-used directory
-	// whose existing archives carry HIGHER seqs than this process's counter
-	// would otherwise let those pre-existing archives outrank — and evict — the
-	// archives this process is about to write, the same across-restart hazard
-	// #5523 C179-060 closed but reached via a live dir switch (#6396). The seed
-	// is monotonic-up only (max of the current counter and the on-disk max), so
-	// switching to an empty or lower-seq dir never rewinds the counter. An
-	// unchanged dir with a non-zero counter skips the scan (the counter is
-	// already ahead of disk).
-	if dir != "" && (dirChanged || s.archiveSeq.Load() == 0) {
-		if seed := maxArchiveSeq(dir); seed > s.archiveSeq.Load() {
-			s.archiveSeq.Store(seed)
+	// the target dir. Scan whenever the dir differs from the one last
+	// SUCCESSFULLY seeded (archiveSeedDir) — that covers both process start
+	// (archiveSeedDir=="") and a runtime archive-dir switch: switching to a
+	// previously-used directory whose existing archives carry HIGHER seqs than
+	// this process's counter would otherwise let those pre-existing archives
+	// outrank — and evict — the archives this process is about to write, the
+	// same across-restart hazard #5523 C179-060 closed but reached via a live
+	// dir switch (#6396). The seed is monotonic-up only (max of the current
+	// counter and the on-disk max), so switching to an empty or lower-seq dir
+	// never rewinds the counter.
+	if dir != "" && s.archiveSeedDir != dir {
+		seed, err := maxArchiveSeq(dir)
+		if err != nil {
+			// #6396 Codex MINOR 4: a transient scan failure (mount/permission)
+			// must NOT reseed the counter to 0 and must NOT record the dir as
+			// seeded — leaving archiveSeedDir unchanged so the next call retries.
+			// Regressing the counter here would prune every fresh archive as stale
+			// until a restart re-scanned.
+			slog.Warn("archive seq reseed scan failed; leaving counter unchanged, will retry",
+				"dir", dir, "err", err)
+		} else {
+			if seed > s.archiveSeq.Load() {
+				s.archiveSeq.Store(seed)
+			}
+			s.archiveSeedDir = dir
 		}
 	}
 }
@@ -538,13 +550,23 @@ func parseArchiveSeq(name string) (uint64, bool) {
 	return seq, true
 }
 
+// archiveDirReader reads an archive directory. It is a package-level seam
+// (defaulting to os.ReadDir) so a test can drive the reseed scan-failure path
+// deterministically (#6396 Codex MINOR 4) — a live os.ReadDir cannot be
+// reliably forced to fail from a unit test, least of all when tests run as root.
+var archiveDirReader = os.ReadDir
+
 // maxArchiveSeq returns the highest config-<ts>.<seq>.conf sequence number
-// present in dir, or 0 when the directory is unreadable or holds no well-formed
-// archive. Used by SetArchiveConfig to seed archiveSeq across restarts.
-func maxArchiveSeq(dir string) uint64 {
-	entries, err := os.ReadDir(dir)
+// present in dir. It returns a non-nil error when the directory is UNREADABLE,
+// distinct from a readable directory that holds no well-formed archive (which
+// returns 0, nil). The caller MUST NOT treat a scan error as an empty
+// directory: seeding the monotonic counter to 0 on a transient failure would
+// pin it below the on-disk max and prune every fresh archive as stale
+// (#6396 Codex MINOR 4). Used by SetArchiveConfig to seed archiveSeq.
+func maxArchiveSeq(dir string) (uint64, error) {
+	entries, err := archiveDirReader(dir)
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	var maxSeq uint64
 	for _, e := range entries {
@@ -555,7 +577,7 @@ func maxArchiveSeq(dir string) uint64 {
 			maxSeq = seq
 		}
 	}
-	return maxSeq
+	return maxSeq, nil
 }
 
 // QuiesceArchival fences and drains the async auto-archive writers so a

--- a/pkg/daemon/daemon_snmp_ifdata_netlink_5523_test.go
+++ b/pkg/daemon/daemon_snmp_ifdata_netlink_5523_test.go
@@ -20,6 +20,9 @@ import (
 // netlink error) makes the failure invisible — the warning-count assertion goes
 // RED while the return-value assertion stays green.
 func TestBuildSNMPIfDataSurfacesNetlinkFailure(t *testing.T) {
+	// Reset the #6396 per-failure warn throttle so this single-call assertion
+	// (exactly one log) is independent of any failure logged by an earlier test.
+	snmpIfDataFailThrottle.reset()
 	prevLister := snmpLinkLister
 	snmpLinkLister = func() ([]netlink.Link, error) {
 		return nil, errors.New("injected: netlink RTM_GETLINK dump failed")

--- a/pkg/daemon/daemon_snmp_ifdata_throttle_6396_test.go
+++ b/pkg/daemon/daemon_snmp_ifdata_throttle_6396_test.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// TestBuildSNMPIfDataWarnThrottled is the #6396 C179-123 residual guard: a
+// PERSISTENT netlink failure must not write one warning line per SNMP poll.
+// buildSNMPIfData runs once per poll and a manager may poll several times a
+// second, so the per-poll slog.Warn (added by the C179-123 fix) floods the
+// journal on a sustained failure. The warning is now rate-limited to at most
+// once per snmpIfDataWarnInterval.
+//
+// FAIL-ON-REVERT: making shouldLog always emit (dropping the throttle) makes
+// buildSNMPIfData log on EVERY failing poll — the "exactly one line for many
+// polls" assertion below goes RED.
+func TestBuildSNMPIfDataWarnThrottled(t *testing.T) {
+	snmpIfDataFailThrottle.reset()
+	t.Cleanup(func() { snmpIfDataFailThrottle.reset() })
+
+	prevLister := snmpLinkLister
+	snmpLinkLister = func() ([]netlink.Link, error) {
+		return nil, errors.New("injected: netlink RTM_GETLINK dump failed")
+	}
+	defer func() { snmpLinkLister = prevLister }()
+
+	rec := &recordingSlogHandler{level: slog.LevelWarn}
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(rec))
+	defer slog.SetDefault(prevLogger)
+
+	// Many rapid failing polls, all well inside snmpIfDataWarnInterval.
+	const polls = 20
+	for i := 0; i < polls; i++ {
+		if got := buildSNMPIfData(); got != nil {
+			t.Fatalf("a failed netlink read must return no interface data, got %d entries", len(got))
+		}
+	}
+
+	const warn = "SNMP ifTable read failed; reporting empty interface table"
+	if n := rec.count(warn); n != 1 {
+		t.Fatalf("a persistent netlink failure must log %q at most once per window, "+
+			"not once per poll; %d polls produced %d warnings", warn, polls, n)
+	}
+}
+
+// TestWarnThrottleWindow drives the throttle primitive directly with an
+// injected clock so the window-elapse, suppressed-count, and reset/recovery
+// bookkeeping are covered deterministically (a real-time integration test would
+// have to wait snmpIfDataWarnInterval to cross a window).
+//
+// FAIL-ON-REVERT: neutralizing shouldLog to always return (true, 0) makes the
+// "second call is suppressed" and "window-elapse reports the suppressed count"
+// assertions go RED.
+func TestWarnThrottleWindow(t *testing.T) {
+	var th warnThrottle
+	const window = time.Minute
+	base := time.Unix(1_700_000_000, 0)
+
+	// First occurrence always emits, nothing suppressed yet.
+	if emit, sup := th.shouldLog(base, window); !emit || sup != 0 {
+		t.Fatalf("first occurrence: emit=%v suppressed=%d, want true/0", emit, sup)
+	}
+	// Two more inside the window are suppressed and counted.
+	if emit, _ := th.shouldLog(base.Add(1*time.Second), window); emit {
+		t.Fatalf("second occurrence inside window must be suppressed")
+	}
+	if emit, _ := th.shouldLog(base.Add(2*time.Second), window); emit {
+		t.Fatalf("third occurrence inside window must be suppressed")
+	}
+	// At/after the window, it emits again and reports the 2 it suppressed.
+	if emit, sup := th.shouldLog(base.Add(window), window); !emit || sup != 2 {
+		t.Fatalf("window-elapsed occurrence: emit=%v suppressed=%d, want true/2", emit, sup)
+	}
+	// reset reports the condition was active and clears state; the next
+	// occurrence then emits immediately even inside what would have been the
+	// window.
+	if wasActive, sup := th.reset(); !wasActive || sup != 0 {
+		t.Fatalf("reset after an emitted log: wasActive=%v suppressed=%d, want true/0", wasActive, sup)
+	}
+	if emit, _ := th.shouldLog(base.Add(window+1*time.Second), window); !emit {
+		t.Fatalf("first occurrence after reset must emit immediately")
+	}
+	// reset on a never-active throttle reports inactive (no spurious recovery
+	// log on a healthy box).
+	var fresh warnThrottle
+	if wasActive, sup := fresh.reset(); wasActive || sup != 0 {
+		t.Fatalf("reset on a fresh throttle: wasActive=%v suppressed=%d, want false/0", wasActive, sup)
+	}
+}

--- a/pkg/daemon/daemon_snmp_ifdata_throttle_6396_test.go
+++ b/pkg/daemon/daemon_snmp_ifdata_throttle_6396_test.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,6 +48,105 @@ func TestBuildSNMPIfDataWarnThrottled(t *testing.T) {
 	if n := rec.count(warn); n != 1 {
 		t.Fatalf("a persistent netlink failure must log %q at most once per window, "+
 			"not once per poll; %d polls produced %d warnings", warn, polls, n)
+	}
+}
+
+// attrCapturingHandler records each log record's message plus the integer
+// value of a single named attribute, so a test can assert both that a line
+// fired and what count it carried.
+type attrCapturingHandler struct {
+	mu   sync.Mutex
+	key  string
+	recs []attrRecord
+}
+
+type attrRecord struct {
+	msg string
+	val int64
+	has bool
+}
+
+func (h *attrCapturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *attrCapturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	rec := attrRecord{msg: r.Message}
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == h.key {
+			rec.val = a.Value.Int64()
+			rec.has = true
+		}
+		return true
+	})
+	h.recs = append(h.recs, rec)
+	return nil
+}
+
+func (h *attrCapturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *attrCapturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// find returns the count of records with the given message and the captured
+// attribute value of the FIRST such record.
+func (h *attrCapturingHandler) find(msg string) (count int, val int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.recs {
+		if r.msg == msg {
+			if count == 0 {
+				val = r.val
+			}
+			count++
+		}
+	}
+	return count, val
+}
+
+// TestBuildSNMPIfDataRecoveryLogged is the #6396 Codex MINOR 6 guard: after a
+// failing→succeeding transition, buildSNMPIfData must log a one-time recovery
+// carrying the number of failures suppressed since the last emitted failure
+// line. Without a test the recovery log (and its count) is unbound — deleting
+// it or zeroing the count would leave every other test green.
+//
+// FAIL-ON-REVERT: removing the recovery slog.Info makes the count-1 assertion
+// go RED; hardcoding suppressed_failures to 0 makes the count-2 assertion RED.
+func TestBuildSNMPIfDataRecoveryLogged(t *testing.T) {
+	snmpIfDataFailThrottle.reset()
+	t.Cleanup(func() { snmpIfDataFailThrottle.reset() })
+
+	failing := true
+	prevLister := snmpLinkLister
+	snmpLinkLister = func() ([]netlink.Link, error) {
+		if failing {
+			return nil, errors.New("injected: netlink dump failed")
+		}
+		return nil, nil // success, empty table
+	}
+	defer func() { snmpLinkLister = prevLister }()
+
+	rec := &attrCapturingHandler{key: "suppressed_failures"}
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(rec))
+	defer slog.SetDefault(prevLogger)
+
+	// Three failing polls: the first logs, the next two are suppressed+counted.
+	for i := 0; i < 3; i++ {
+		buildSNMPIfData()
+	}
+	// Transition to success → one recovery log reporting the 2 suppressed.
+	failing = false
+	buildSNMPIfData()
+	// A further success must NOT re-log recovery (throttle already reset).
+	buildSNMPIfData()
+
+	const rmsg = "SNMP ifTable read recovered"
+	n, sup := rec.find(rmsg)
+	if n != 1 {
+		t.Fatalf("recovery must be logged exactly once on a failing->succeeding transition, got %d", n)
+	}
+	if sup != 2 {
+		t.Fatalf("recovery suppressed_failures = %d, want 2 (the two failures suppressed since "+
+			"the first emitted failure line)", sup)
 	}
 }
 

--- a/pkg/daemon/daemon_snmp_reconcile.go
+++ b/pkg/daemon/daemon_snmp_reconcile.go
@@ -162,6 +162,60 @@ func snmpConfigHash(cfg *config.Config) uint64 {
 // than silently reported as an empty ifTable (#5523 C179-123).
 var snmpLinkLister = netlink.LinkList
 
+// snmpIfDataWarnInterval bounds how often buildSNMPIfData emits its
+// netlink-failure warning. buildSNMPIfData runs once per SNMP poll and a
+// manager may poll several times a second, so a persistently failing
+// RTM_GETLINK dump would otherwise write one warning line per poll and drown
+// the journal (#6396 C179-123 residual).
+const snmpIfDataWarnInterval = time.Minute
+
+// snmpIfDataFailThrottle rate-limits buildSNMPIfData's netlink-failure warning.
+var snmpIfDataFailThrottle warnThrottle
+
+// warnThrottle emits at most one log per interval for a repeating condition,
+// counting how many occurrences it suppressed between emitted logs. It is safe
+// for concurrent use. The zero value is ready: the first occurrence always
+// emits.
+type warnThrottle struct {
+	mu         sync.Mutex
+	logged     bool // an emit has happened and no reset since
+	lastLog    time.Time
+	suppressed int
+}
+
+// shouldLog reports whether the caller should emit its warning for an
+// occurrence at now, and how many prior occurrences were suppressed since the
+// last emitted log. It emits on the first occurrence and then at most once per
+// interval; occurrences inside the window are counted and suppressed.
+func (t *warnThrottle) shouldLog(now time.Time, interval time.Duration) (emit bool, suppressed int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.logged || now.Sub(t.lastLog) >= interval {
+		suppressed = t.suppressed
+		t.suppressed = 0
+		t.lastLog = now
+		t.logged = true
+		return true, suppressed
+	}
+	t.suppressed++
+	return false, 0
+}
+
+// reset clears the throttle after the condition clears (e.g. a successful
+// read), so the next occurrence logs immediately. It reports whether the
+// condition had been active and how many occurrences were suppressed since the
+// last emitted log, so the caller can note a recovery exactly once.
+func (t *warnThrottle) reset() (wasActive bool, suppressed int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	wasActive = t.logged
+	suppressed = t.suppressed
+	t.logged = false
+	t.suppressed = 0
+	t.lastLog = time.Time{}
+	return wasActive, suppressed
+}
+
 // buildSNMPIfData returns the live interface table for the SNMP ifTable /
 // ifXTable, read from netlink at call time. It is the SetIfDataFn callback
 // wired onto every agent the daemon starts (both the boot start and a day-2
@@ -179,9 +233,23 @@ func buildSNMPIfData() []snmp.IfData {
 		// successful. Log the failure so the empty table is diagnosable and
 		// distinguishable from a genuine no-interface box; the next poll
 		// re-reads netlink and self-heals a transient error.
-		slog.Warn("SNMP ifTable read failed; reporting empty interface table",
-			"err", err)
+		//
+		// #6396: the warning is rate-limited (snmpIfDataWarnInterval) so a
+		// PERSISTENT failure — buildSNMPIfData runs once per poll, and a manager
+		// may poll several times a second — logs once per window instead of one
+		// line per poll. The first failure always logs; subsequent ones inside
+		// the window are counted and reported with the next emitted line.
+		if emit, suppressed := snmpIfDataFailThrottle.shouldLog(time.Now(), snmpIfDataWarnInterval); emit {
+			slog.Warn("SNMP ifTable read failed; reporting empty interface table",
+				"err", err, "suppressed_since_last", suppressed)
+		}
 		return nil
+	}
+	// A successful read clears the throttle so a later failure logs promptly
+	// again; note the recovery once if the table had been failing (#6396).
+	if wasActive, suppressed := snmpIfDataFailThrottle.reset(); wasActive {
+		slog.Info("SNMP ifTable read recovered",
+			"suppressed_failures", suppressed)
 	}
 	var result []snmp.IfData
 	for _, link := range links {

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -110,6 +110,20 @@ path already draws (see the WireGuard/tunnel removal notes below and
   covered a failed `LinkDel` **after** a successful lookup; this closes the
   predating `LinkByName`-error branch.
 
+**Identity re-assertion on every readback (#5523 C179-104 + #6396).** A
+`LinkByName` result is adopted only after confirming it is an
+`*netlink.Xfrmi` whose actual `Ifid` matches the desired one — never by
+name alone. This holds on BOTH readbacks: the **adopt** path (a kernel
+link outliving in-memory tracking) recreates a same-name link that is not
+an xfrmi, or is an xfrmi with a stale `if_id` (#5523 C179-104); and the
+**post-create** readback (the `LinkByName` right after `LinkAdd`) rejects
+a foreign or wrong-`if_id` link that a concurrent external actor may have
+substituted in the add→readback window (#6396) — it is not brought up or
+tracked, the commit fails closed, and the next reconcile's adopt path
+reclaims the intruder via delete+recreate. Without the check the name
+would be tracked as satisfied while **no** device carries the desired
+`if_id`, silently blackholing the route-based VPN bound to it.
+
 ### Bond (fabric/ae LAG) reconcile (#5119)
 
 `bondManager.Apply` is called by `pkg/daemon` on **every** config commit

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -113,8 +113,12 @@ path already draws (see the WireGuard/tunnel removal notes below and
 **Identity re-assertion on every post-create readback (#5523 C179-104 +
 #6396).** `LinkAdd` and the `LinkByName` readback that follows it are two
 syscalls. A device is adopted only after confirming the readback is the
-INTENDED type carrying the desired discriminator — never by name alone —
-so a same-name foreign link (or a right-type link with the wrong
+INTENDED type — and, for xfrm and VRF, carrying the desired discriminator
+too — never by name alone. The discriminator checked is per-manager: **xfrm
+rejects type + `Ifid` + `ParentIndex==0`, VRF rejects type + table, but bond
+rejects TYPE only** (the create-path mode/MTU check, plus the adopt/KEEP-path
+identity checks, are deferred to #6402 — see the bond bullet). So a same-name
+foreign link (or, for xfrm/VRF, a right-type link with the wrong
 discriminator) substituted by a concurrent external actor in the
 add→readback window is rejected: it is not brought up or tracked, the
 commit fails closed, and a later reconcile reclaims the intruder. This

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -134,16 +134,32 @@ invariant now holds across all three netlink-device managers:
   `LinkSetMaster` failure when a member is actually enslavable, so a bond
   whose configured members are all currently absent (the #4823 soft-error
   case) would otherwise adopt a foreign link; the explicit type check
-  closes that hole for every member state. **Scope note:** only the bond
-  CREATE path is type-gated here. The bond **ADOPT** path (`createLocked`'s
-  `if existing, err := LinkByName(name); err == nil` branch) is NOT yet
-  type/mode/MTU-gated — a foreign or wrong-mode same-name link present at
-  steady state is still adopted. That guard is deferred to **#6402** because
-  it changes fabric/RETH bond reconcile behavior and so needs a loss-cluster
-  `test-failover` smoke; it must validate mode + MTU, not just the
-  `*netlink.Bond` type. (xfrm and VRF adopt paths ARE already gated —
-  xfrm.go:203 and `vrfTable`→recreate — so bond is the only adopt-path
-  residual.)
+  closes that hole for every member state.
+
+  **Bond is only PARTIALLY in the identity-assertion family — the remaining
+  bond identity checks are deferred to #6402 (HA-touching; a fabric/RETH LAG
+  change needs a loss-cluster `test-failover` smoke).** The #6396 create-path
+  guard is a strict improvement (it rejects a non-`*netlink.Bond` substitute)
+  but is NOT complete, and these gaps are ALL pre-existing (master never
+  validated them — they are not #6396 regressions):
+    1. **create-path mode/MTU** — the guard checks the `*netlink.Bond` type
+       only, then tracks the DESIRED `bondSig` (`sigWithMembers(sig, …)`), not
+       the readback's observed mode/MTU. An `*netlink.Bond` substitute with the
+       wrong bond mode (802.3ad vs active-backup) or MTU passes and is tracked
+       as satisfied.
+    2. **adopt-path type + mode + MTU** — the adopt branch
+       (`if existing, err := LinkByName(name); err == nil`) accepts `existing`
+       by name after checking only the enslaved member set; a foreign or
+       wrong-mode/MTU same-name link present at steady state is adopted.
+    3. **KEEP-path identity** — the tracked-and-unchanged fast path
+       (`if trackedSig == sig` → `LinkByName` → `LinkSetUp`) brings up whatever
+       wears the name without re-asserting it is even a bond, so a same-name
+       `Dummy` swapped in under a tracked bond is accepted.
+  #6402 covers all three and must validate mode + MTU, not just the
+  `*netlink.Bond` type. (xfrm and VRF adopt paths ARE fully gated —
+  xfrm.go:203 asserts type + `Ifid` + `ParentIndex==0`, and `vrfTable`→recreate
+  asserts type + table — so bond is the sole manager with open identity
+  residuals.)
 
 Without the check the name is tracked as satisfied while **no** device
 carries the desired identity, silently blackholing the VPN / leaked routes

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -110,19 +110,38 @@ path already draws (see the WireGuard/tunnel removal notes below and
   covered a failed `LinkDel` **after** a successful lookup; this closes the
   predating `LinkByName`-error branch.
 
-**Identity re-assertion on every readback (#5523 C179-104 + #6396).** A
-`LinkByName` result is adopted only after confirming it is an
-`*netlink.Xfrmi` whose actual `Ifid` matches the desired one — never by
-name alone. This holds on BOTH readbacks: the **adopt** path (a kernel
-link outliving in-memory tracking) recreates a same-name link that is not
-an xfrmi, or is an xfrmi with a stale `if_id` (#5523 C179-104); and the
-**post-create** readback (the `LinkByName` right after `LinkAdd`) rejects
-a foreign or wrong-`if_id` link that a concurrent external actor may have
-substituted in the add→readback window (#6396) — it is not brought up or
-tracked, the commit fails closed, and the next reconcile's adopt path
-reclaims the intruder via delete+recreate. Without the check the name
-would be tracked as satisfied while **no** device carries the desired
-`if_id`, silently blackholing the route-based VPN bound to it.
+**Identity re-assertion on every post-create readback (#5523 C179-104 +
+#6396).** `LinkAdd` and the `LinkByName` readback that follows it are two
+syscalls. A device is adopted only after confirming the readback is the
+INTENDED type carrying the desired discriminator — never by name alone —
+so a same-name foreign link (or a right-type link with the wrong
+discriminator) substituted by a concurrent external actor in the
+add→readback window is rejected: it is not brought up or tracked, the
+commit fails closed, and a later reconcile reclaims the intruder. This
+invariant now holds across all three netlink-device managers:
+
+- **xfrm** (`xfrm.go`) — the readback must be an `*netlink.Xfrmi` whose
+  `Ifid` matches. Enforced on BOTH the adopt path (a kernel link outliving
+  in-memory tracking; a non-xfrmi or stale-`if_id` link is delete+recreated,
+  #5523 C179-104) and the post-create readback (#6396).
+- **VRF** (`vrf.go` `createLinkedVRF`) — the readback must be an
+  `*netlink.Vrf` whose `Table` matches (#6396). `added` stays true so the
+  caller records ownership; the reconcile adopt path (`vrfTable` →
+  recreate on table mismatch) reclaims a substitute on the next cycle.
+- **bond** (`bond.go` `createLocked`) — the post-create readback must be an
+  `*netlink.Bond` before enslaving members or bringing it up (#6396).
+  `enslaveMembers` only surfaces a substitute via a real-netlink
+  `LinkSetMaster` failure when a member is actually enslavable, so a bond
+  whose configured members are all currently absent (the #4823 soft-error
+  case) would otherwise adopt a foreign link; the explicit type check
+  closes that hole for every member state.
+
+Without the check the name is tracked as satisfied while **no** device
+carries the desired identity, silently blackholing the VPN / leaked routes
+/ fabric LAG bound to it. (The tunnel/WireGuard manager reaches its reuse
+path through a distinct anchor-reuse gate that already type-checks
+`*netlink.Tuntap` — see the reuse notes below — so it is not part of this
+readback family.)
 
 ### Bond (fabric/ae LAG) reconcile (#5119)
 

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -128,13 +128,22 @@ invariant now holds across all three netlink-device managers:
   `*netlink.Vrf` whose `Table` matches (#6396). `added` stays true so the
   caller records ownership; the reconcile adopt path (`vrfTable` →
   recreate on table mismatch) reclaims a substitute on the next cycle.
-- **bond** (`bond.go` `createLocked`) — the post-create readback must be an
-  `*netlink.Bond` before enslaving members or bringing it up (#6396).
+- **bond** (`bond.go` `createLocked`) — the **create-path** readback must be
+  an `*netlink.Bond` before enslaving members or bringing it up (#6396).
   `enslaveMembers` only surfaces a substitute via a real-netlink
   `LinkSetMaster` failure when a member is actually enslavable, so a bond
   whose configured members are all currently absent (the #4823 soft-error
   case) would otherwise adopt a foreign link; the explicit type check
-  closes that hole for every member state.
+  closes that hole for every member state. **Scope note:** only the bond
+  CREATE path is type-gated here. The bond **ADOPT** path (`createLocked`'s
+  `if existing, err := LinkByName(name); err == nil` branch) is NOT yet
+  type/mode/MTU-gated — a foreign or wrong-mode same-name link present at
+  steady state is still adopted. That guard is deferred to **#6402** because
+  it changes fabric/RETH bond reconcile behavior and so needs a loss-cluster
+  `test-failover` smoke; it must validate mode + MTU, not just the
+  `*netlink.Bond` type. (xfrm and VRF adopt paths ARE already gated —
+  xfrm.go:203 and `vrfTable`→recreate — so bond is the only adopt-path
+  residual.)
 
 Without the check the name is tracked as satisfied while **no** device
 carries the desired identity, silently blackholing the VPN / leaked routes

--- a/pkg/routing/bond.go
+++ b/pkg/routing/bond.go
@@ -312,6 +312,23 @@ func (b *bondManager) createLocked(name string, ifc *config.InterfaceConfig, sig
 		return fmt.Errorf("bond %s: find after create: %w", name, err)
 	}
 
+	// #6396: re-assert the post-create readback is the bond we just created
+	// before enslaving members and bringing it up. A same-name foreign link
+	// substituted in the add→readback window is only caught by enslaveMembers
+	// (via a real-netlink LinkSetMaster failure) when at least one member is
+	// actually enslavable; a bond whose configured members are all currently
+	// absent (the #4823 soft-error enumeration case) enslaves nothing, so no
+	// LinkSetMaster fires and the foreign link would be brought up and tracked
+	// as a satisfied bond. The explicit type re-assertion closes that hole for
+	// every member state. Fail the commit closed on the mismatch; the bond is
+	// left untracked so the next reconcile retries.
+	if _, ok := bondLink.(*netlink.Bond); !ok {
+		slog.Warn("bond readback after create is not a bond interface",
+			"name", name, "type", bondLink.Type())
+		return fmt.Errorf("bond %s: readback after create is %s, not a bond",
+			name, bondLink.Type())
+	}
+
 	enslaved, errs := b.enslaveMembers(name, bondLink, ifc.FabricMembers, nil)
 	if err := b.ops.LinkSetUp(bondLink); err != nil {
 		slog.Warn("failed to bring up bond", "name", name, "err", err)

--- a/pkg/routing/bond_test.go
+++ b/pkg/routing/bond_test.go
@@ -21,6 +21,12 @@ type fakeBondLinkOps struct {
 	failLinkSetMaster map[string]error // member name -> LinkSetMaster error
 	failLinkDel       map[string]error // link name -> LinkDel error
 
+	// substituteAfterAdd[name], when set, replaces the link stored under name
+	// during LinkAdd so the post-create LinkByName readback returns the
+	// substitute — models the #6396 create-path TOCTOU where a same-name
+	// foreign link is swapped in between LinkAdd and the readback.
+	substituteAfterAdd map[string]netlink.Link
+
 	setUpCalls  []string
 	masterCalls []string
 	addCalls    []string // names passed to LinkAdd
@@ -29,12 +35,13 @@ type fakeBondLinkOps struct {
 
 func newFakeBondLinkOps() *fakeBondLinkOps {
 	return &fakeBondLinkOps{
-		links:             map[string]netlink.Link{},
-		nextIndex:         1000, // created bonds get 1001+, clear of small seeded indices
-		failLinkAdd:       map[string]error{},
-		failLinkSetUp:     map[string]error{},
-		failLinkSetMaster: map[string]error{},
-		failLinkDel:       map[string]error{},
+		links:              map[string]netlink.Link{},
+		nextIndex:          1000, // created bonds get 1001+, clear of small seeded indices
+		failLinkAdd:        map[string]error{},
+		failLinkSetUp:      map[string]error{},
+		failLinkSetMaster:  map[string]error{},
+		failLinkDel:        map[string]error{},
+		substituteAfterAdd: map[string]netlink.Link{},
 	}
 }
 
@@ -67,6 +74,11 @@ func (f *fakeBondLinkOps) LinkAdd(l netlink.Link) error {
 		l.Attrs().Index = f.nextIndex
 	}
 	f.links[name] = l
+	if sub, ok := f.substituteAfterAdd[name]; ok {
+		// The intended bond was created, but a foreign link now wears the name
+		// by the time the readback runs (#6396 TOCTOU).
+		f.links[name] = sub
+	}
 	return nil
 }
 

--- a/pkg/routing/iface_reuse_test.go
+++ b/pkg/routing/iface_reuse_test.go
@@ -44,6 +44,14 @@ type fakeLinkOps struct {
 	// #5310 fail-closed create-failure tests.
 	addFail map[string]error
 
+	// substituteAfterAdd[name], when set, replaces the link stored under name
+	// in the add→readback window: LinkAdd still records the intended link
+	// (addCount++), then this foreign link overwrites it so the post-create
+	// LinkByName readback returns the substitute — models the #6396 create-path
+	// TOCTOU where a concurrent external actor swaps a same-name link between
+	// LinkAdd and the readback.
+	substituteAfterAdd map[string]netlink.Link
+
 	// upFail[name] makes LinkSetUp fail for that link name (#5310 bring-up
 	// fail-closed tests).
 	upFail map[string]error
@@ -86,18 +94,19 @@ type fakeLinkOps struct {
 
 func newFakeLinkOps() *fakeLinkOps {
 	return &fakeLinkOps{
-		links:         map[string]netlink.Link{},
-		byNameCount:   map[string]int{},
-		hiddenUntil:   map[string]int{},
-		delFail:       map[string]error{},
-		addFail:       map[string]error{},
-		upFail:        map[string]error{},
-		addrDelFail:   map[string]error{},
-		addrListFail:  map[string]error{},
-		byNameHardErr: map[string]error{},
-		addrs:         map[string][]netlink.Addr{},
-		mtuSet:        map[string][]int{},
-		addrDels:      map[string][]string{},
+		links:              map[string]netlink.Link{},
+		byNameCount:        map[string]int{},
+		hiddenUntil:        map[string]int{},
+		delFail:            map[string]error{},
+		addFail:            map[string]error{},
+		substituteAfterAdd: map[string]netlink.Link{},
+		upFail:             map[string]error{},
+		addrDelFail:        map[string]error{},
+		addrListFail:       map[string]error{},
+		byNameHardErr:      map[string]error{},
+		addrs:              map[string][]netlink.Addr{},
+		mtuSet:             map[string][]int{},
+		addrDels:           map[string][]string{},
 	}
 }
 
@@ -130,6 +139,11 @@ func (f *fakeLinkOps) LinkAdd(l netlink.Link) error {
 	}
 	f.links[l.Attrs().Name] = l
 	f.addCount++
+	if sub, ok := f.substituteAfterAdd[l.Attrs().Name]; ok {
+		// The intended link was created (addCount bumped above), but a foreign
+		// link now wears the name by the time the readback runs (#6396 TOCTOU).
+		f.links[l.Attrs().Name] = sub
+	}
 	return nil
 }
 

--- a/pkg/routing/readback_guard_6396_test.go
+++ b/pkg/routing/readback_guard_6396_test.go
@@ -1,0 +1,116 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// TestCreateLinkedVRFRejectsNonVrfReadback is the #6396 mirror of the xfrm
+// post-create readback guard, for VRFs. LinkAdd and the LinkByName readback are
+// two syscalls; a concurrent external actor that deleted the fresh VRF and
+// substituted a same-name foreign (non-VRF) link in that window must NOT be
+// brought up and recorded as satisfied — otherwise the name reads as realized
+// while no VRF with the desired table exists and the routes leaked into it
+// silently blackhole.
+//
+// FAIL-ON-REVERT: dropping the type/table re-assertion brings the foreign link
+// UP (setUps>0) and returns a nil error — the error/no-bring-up assertions go
+// RED.
+func TestCreateLinkedVRFRejectsNonVrfReadback(t *testing.T) {
+	ops := newFakeVRFOps()
+	const name = "vrf-red"
+	// A foreign (non-VRF) link is swapped in during the add→readback window.
+	ops.substituteAfterAdd[name] = &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: name, Index: 9},
+	}
+
+	added, err := createLinkedVRF(ops, name, 100)
+	if !added {
+		t.Errorf("added must be true after a successful LinkAdd so the caller records " +
+			"ownership for cleanup; got added=false")
+	}
+	if err == nil {
+		t.Fatalf("a substituted non-VRF readback after create must fail closed, got nil")
+	}
+	if ops.setUps != 0 {
+		t.Errorf("the substituted foreign link must not be brought up, got %d LinkSetUp", ops.setUps)
+	}
+}
+
+// TestCreateLinkedVRFRejectsWrongTableReadback covers the second substitution
+// shape: a VRF that wears the name but carries the WRONG routing table. It too
+// must be rejected rather than adopted (adopting it would leak routes into the
+// wrong table's VRF).
+func TestCreateLinkedVRFRejectsWrongTableReadback(t *testing.T) {
+	ops := newFakeVRFOps()
+	const name = "vrf-red"
+	ops.substituteAfterAdd[name] = &netlink.Vrf{
+		LinkAttrs: netlink.LinkAttrs{Name: name, Index: 9},
+		Table:     999, // desired below is 100
+	}
+
+	added, err := createLinkedVRF(ops, name, 100)
+	if !added {
+		t.Errorf("added must be true after a successful LinkAdd, got false")
+	}
+	if err == nil {
+		t.Fatalf("a wrong-table VRF readback after create must fail closed, got nil")
+	}
+	if ops.setUps != 0 {
+		t.Errorf("the wrong-table link must not be brought up, got %d LinkSetUp", ops.setUps)
+	}
+}
+
+// TestCreateLinkedVRFCleanReadbackSucceeds pins the happy path: a matching-table
+// VRF readback is brought up and reported success — so the guard above does not
+// over-reject.
+func TestCreateLinkedVRFCleanReadbackSucceeds(t *testing.T) {
+	ops := newFakeVRFOps()
+	added, err := createLinkedVRF(ops, "vrf-blue", 200)
+	if !added || err != nil {
+		t.Fatalf("a clean create must return (true, nil), got (%v, %v)", added, err)
+	}
+	if ops.setUps != 1 {
+		t.Errorf("a clean create must bring the VRF up exactly once, got %d", ops.setUps)
+	}
+}
+
+// TestBondCreateRejectsForeignReadback is the #6396 bond mirror. A bond is only
+// created (createLocked) for a config WITH members (Apply skips zero-member
+// configs), but enslaveMembers surfaces a foreign-substitute error only when a
+// member is actually enslavable. When the configured members are all currently
+// absent (the #4823 soft-error enumeration case) nothing is enslaved, so a
+// same-name foreign link substituted in the add→readback window would be
+// brought up and tracked as a satisfied bond. The explicit type re-assertion
+// fails the commit closed instead.
+//
+// FAIL-ON-REVERT: dropping the type re-assertion tracks the foreign bond
+// (b.bonds["bond0"] set) and returns nil — the error/untracked assertions go
+// RED.
+func TestBondCreateRejectsForeignReadback(t *testing.T) {
+	ops := newFakeBondLinkOps()
+	const name = "bond0"
+	// Foreign (non-bond) link swapped in during the add→readback window.
+	ops.substituteAfterAdd[name] = &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: name, Index: 4242},
+	}
+
+	b := &bondManager{ops: ops}
+	// Members are configured (so Apply does not skip the bond) but NOT seeded,
+	// so enslaveMembers finds none and issues zero LinkSetMaster — the path
+	// where a foreign readback is otherwise silently adopted.
+	err := b.Apply([]*config.InterfaceConfig{bondFabricConfig(name, "ge-0-0-1")})
+	if err == nil {
+		t.Fatalf("a foreign non-bond readback after create must fail the commit closed, got nil")
+	}
+	if _, tracked := b.bonds[name]; tracked {
+		t.Errorf("a foreign readback must not be tracked as a satisfied bond; bonds=%v", b.bonds)
+	}
+	for _, n := range ops.setUpCalls {
+		if n == name {
+			t.Errorf("the foreign link %q must not be brought up", name)
+		}
+	}
+}

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -19,6 +19,17 @@ import (
 type fakeVRFOps struct {
 	links map[string]*netlink.Vrf // name -> link
 
+	// overlay returns a NON-*netlink.Vrf link (or a wrong-table Vrf) from
+	// LinkByName ahead of the typed links map — the only way to model a
+	// foreign link wearing a VRF name, since links is *netlink.Vrf-typed
+	// (#6396 create-path readback substitution).
+	overlay map[string]netlink.Link
+	// substituteAfterAdd[name], when set, installs overlay[name] during
+	// LinkAdd so the post-create LinkByName readback returns the substitute —
+	// models the #6396 create-path TOCTOU (a same-name link swapped between
+	// LinkAdd and the readback).
+	substituteAfterAdd map[string]netlink.Link
+
 	adds       int
 	dels       int
 	setUps     int
@@ -30,11 +41,18 @@ type fakeVRFOps struct {
 }
 
 func newFakeVRFOps() *fakeVRFOps {
-	return &fakeVRFOps{links: map[string]*netlink.Vrf{}}
+	return &fakeVRFOps{
+		links:              map[string]*netlink.Vrf{},
+		overlay:            map[string]netlink.Link{},
+		substituteAfterAdd: map[string]netlink.Link{},
+	}
 }
 
 func (f *fakeVRFOps) LinkByName(name string) (netlink.Link, error) {
 	f.byNameHits++
+	if l, ok := f.overlay[name]; ok {
+		return l, nil
+	}
 	if l, ok := f.links[name]; ok {
 		return l, nil
 	}
@@ -56,6 +74,11 @@ func (f *fakeVRFOps) LinkAdd(link netlink.Link) error {
 	// Clone so callers can't mutate our table.
 	clone := *vrf
 	f.links[name] = &clone
+	if sub, ok := f.substituteAfterAdd[name]; ok {
+		// The intended VRF was created, but a foreign link now wears the name
+		// by the time the readback runs (#6396 TOCTOU).
+		f.overlay[name] = sub
+	}
 	return nil
 }
 

--- a/pkg/routing/vrf.go
+++ b/pkg/routing/vrf.go
@@ -343,6 +343,27 @@ func createLinkedVRF(ops vrfOps, vrfName string, tableID int) (bool, error) {
 	if err != nil {
 		return true, fmt.Errorf("find VRF %s after add: %w", vrfName, err)
 	}
+	// #6396: re-assert the post-create readback is the VRF we just created,
+	// carrying the desired table, before bringing it up. LinkAdd and this
+	// LinkByName are two syscalls; a concurrent external actor that deleted the
+	// fresh device and substituted a same-name foreign link (or a VRF with a
+	// different table) in that window would otherwise be brought up and the
+	// name recorded as satisfied while no VRF with the desired table exists —
+	// the routes leaked into it silently blackhole. LinkAdd succeeded, so
+	// added=true (the caller records ownership so a later reconcile can clean
+	// up), but surface the error so the commit fails closed; the reconcile
+	// adopt path (vrfTable → recreate on table mismatch) reclaims it next cycle.
+	if vrf, ok := link.(*netlink.Vrf); !ok || vrf.Table != uint32(tableID) {
+		have := "non-VRF type " + link.Type()
+		if ok {
+			have = fmt.Sprintf("table %d", vrf.Table)
+		}
+		slog.Warn("VRF readback after create is not the intended interface",
+			"name", vrfName, "want_table", tableID, "have", have)
+		return true, fmt.Errorf(
+			"VRF %s readback after create mismatch (want table %d, have %s)",
+			vrfName, tableID, have)
+	}
 	if err := ops.LinkSetUp(link); err != nil {
 		return true, fmt.Errorf("set VRF %s up: %w", vrfName, err)
 	}

--- a/pkg/routing/xfrm.go
+++ b/pkg/routing/xfrm.go
@@ -263,6 +263,15 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 			// (the next reconcile retries) and fails the commit closed — a
 			// route-based VPN bound to an xfrmi that never made it into the
 			// kernel must not report a successful commit.
+			//
+			// #6396 Codex MINOR 4: to actually HONOR the "UNTRACKED" contract we
+			// must drop any PRE-EXISTING x.xfrmis entry for this name (a prior
+			// reconcile tracked it, then the kernel link vanished — that is why
+			// we are on the create path — and now the recreate failed). Leaving
+			// the stale entry would let the removal pass (deleteLocked) later act
+			// on whatever foreign link comes to wear this name. delete is a no-op
+			// when the name was never tracked.
+			delete(x.xfrmis, ifName)
 			errs = append(errs, fmt.Errorf("create xfrmi %s (if_id %d): %w", ifName, ifID, err))
 			continue
 		}

--- a/pkg/routing/xfrm.go
+++ b/pkg/routing/xfrm.go
@@ -264,6 +264,30 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 			continue
 		}
 
+		// #6396 C179-104 residual: re-assert the post-create readback is the
+		// xfrm interface we just created before adopting it. LinkAdd and this
+		// LinkByName are two syscalls; if a concurrent external actor deleted our
+		// device and substituted a same-name foreign link (or an xfrmi with a
+		// different if_id) in that window, the bare readback would bring it up
+		// and track the NAME as satisfied while NO device carries the desired
+		// if_id — the route-based VPN bound to it silently blackholes, the same
+		// failure mode the adopt path guards above. Reject the mismatch: do not
+		// bring it up or track it, surface the error so the commit fails closed,
+		// and let the next reconcile's adopt path reclaim the foreign link via
+		// delete+recreate.
+		if xi, ok := link.(*netlink.Xfrmi); !ok || xi.Ifid != ifID {
+			have := "non-xfrmi type " + link.Type()
+			if ok {
+				have = fmt.Sprintf("if_id %d", xi.Ifid)
+			}
+			slog.Warn("xfrmi readback after create is not the intended interface",
+				"name", ifName, "want_if_id", ifID, "have", have)
+			errs = append(errs, fmt.Errorf(
+				"xfrmi %s readback after create mismatch (want if_id %d, have %s)",
+				ifName, ifID, have))
+			continue
+		}
+
 		if err := x.ops.LinkSetUp(link); err != nil {
 			slog.Warn("failed to bring up xfrmi",
 				"name", ifName, "err", err)

--- a/pkg/routing/xfrm.go
+++ b/pkg/routing/xfrm.go
@@ -197,17 +197,28 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 			//     (#5523 C179-104). The type guard previously gated only the
 			//     stale-if_id recreate branch, so a non-xfrmi link fell through
 			//     to the adopt path.
+			//   - An xfrmi with the same name AND if_id but bound to a NONZERO
+			//     parent link (IFLA_XFRM_LINK). xpf creates every xfrmi
+			//     PARENTLESS (LinkAttrs has no ParentIndex; the SA selects the
+			//     egress device), so a readback carrying a parent is not the
+			//     device we intend and would egress SA traffic out the wrong
+			//     interface (#6396 Codex MAJOR 1). if_id alone does not
+			//     distinguish it, so assert ParentIndex == 0 too.
 			//
-			// Both cases reclaim the name via delete+recreate; only a matching
-			// xfrmi is adopted.
+			// All cases reclaim the name via delete+recreate; only a matching
+			// parentless xfrmi with the desired if_id is adopted.
 			xi, isXfrmi := link.(*netlink.Xfrmi)
-			if !isXfrmi || xi.Ifid != ifID {
-				if isXfrmi {
-					slog.Info("xfrmi has stale if_id, recreating",
-						"name", ifName, "have", xi.Ifid, "want", ifID)
-				} else {
+			if !isXfrmi || xi.Ifid != ifID || xi.Attrs().ParentIndex != 0 {
+				switch {
+				case !isXfrmi:
 					slog.Info("link with xfrmi name is not an xfrm interface, recreating",
 						"name", ifName, "type", link.Type(), "want_if_id", ifID)
+				case xi.Ifid != ifID:
+					slog.Info("xfrmi has stale if_id, recreating",
+						"name", ifName, "have", xi.Ifid, "want", ifID)
+				default:
+					slog.Info("xfrmi bound to unexpected parent link, recreating",
+						"name", ifName, "if_id", ifID, "parent_index", xi.Attrs().ParentIndex)
 				}
 				// #5310: if the delete fails the kernel link is still present
 				// (wrong if_id, or wrong type), so a LinkAdd below would EEXIST —
@@ -267,23 +278,31 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 		// #6396 C179-104 residual: re-assert the post-create readback is the
 		// xfrm interface we just created before adopting it. LinkAdd and this
 		// LinkByName are two syscalls; if a concurrent external actor deleted our
-		// device and substituted a same-name foreign link (or an xfrmi with a
-		// different if_id) in that window, the bare readback would bring it up
-		// and track the NAME as satisfied while NO device carries the desired
-		// if_id — the route-based VPN bound to it silently blackholes, the same
-		// failure mode the adopt path guards above. Reject the mismatch: do not
-		// bring it up or track it, surface the error so the commit fails closed,
-		// and let the next reconcile's adopt path reclaim the foreign link via
-		// delete+recreate.
-		if xi, ok := link.(*netlink.Xfrmi); !ok || xi.Ifid != ifID {
+		// device and substituted a same-name foreign link (a different type, a
+		// different if_id, or an xfrmi bound to a NONZERO parent link) in that
+		// window, the bare readback would bring it up and track the NAME as
+		// satisfied while no PARENTLESS device carries the desired if_id — the
+		// route-based VPN bound to it silently blackholes or egresses the wrong
+		// interface, the same failure modes the adopt path guards above. Assert
+		// concrete type + if_id + ParentIndex==0 (xpf creates every xfrmi
+		// parentless; #6396 Codex MAJOR 1). Reject the mismatch: do not bring it
+		// up or track it, DROP any stale tracking entry so a later reconcile
+		// cannot act on the foreign substitute (#6396 Codex MINOR 3), surface the
+		// error so the commit fails closed, and let the next reconcile's adopt
+		// path reclaim the foreign link via delete+recreate.
+		if xi, ok := link.(*netlink.Xfrmi); !ok || xi.Ifid != ifID || xi.Attrs().ParentIndex != 0 {
 			have := "non-xfrmi type " + link.Type()
 			if ok {
-				have = fmt.Sprintf("if_id %d", xi.Ifid)
+				have = fmt.Sprintf("if_id %d parent %d", xi.Ifid, xi.Attrs().ParentIndex)
 			}
 			slog.Warn("xfrmi readback after create is not the intended interface",
 				"name", ifName, "want_if_id", ifID, "have", have)
+			// Fail closed AND forget: if this name was already tracked (a prior
+			// reconcile adopted it), leaving the stale entry would let a later
+			// path treat the foreign substitute as a satisfied xfrmi.
+			delete(x.xfrmis, ifName)
 			errs = append(errs, fmt.Errorf(
-				"xfrmi %s readback after create mismatch (want if_id %d, have %s)",
+				"xfrmi %s readback after create mismatch (want if_id %d parentless, have %s)",
 				ifName, ifID, have))
 			continue
 		}

--- a/pkg/routing/xfrm_nonxfrmi_reject_5523_test.go
+++ b/pkg/routing/xfrm_nonxfrmi_reject_5523_test.go
@@ -62,3 +62,70 @@ func TestXfrmApplyRejectsNonXfrmiSameName(t *testing.T) {
 		t.Errorf("reclaimed xfrmi tracked if_id %d, want %d", got, ifID)
 	}
 }
+
+// TestXfrmApplyRejectsSubstitutedReadbackAfterCreate is the #6396 C179-104
+// residual guard: the POST-CREATE readback (LinkByName after LinkAdd) must
+// re-assert the link is the xfrm interface just created before bringing it up
+// and tracking it. LinkAdd and the readback are two syscalls; a concurrent
+// external actor that deletes the fresh device and substitutes a same-name
+// foreign link in that window must NOT be adopted — otherwise the NAME is
+// tracked as satisfied while no device carries the desired if_id and the
+// route-based VPN silently blackholes (the same failure the adopt-path guard
+// closes on restart).
+//
+// FAIL-ON-REVERT: dropping the create-path type/if_id check brings the foreign
+// link UP and tracks it (Apply returns nil, xm.xfrmis[ifName]==ifID, LinkSetUp
+// ran on the foreign link) — the error/untracked/no-setup assertions go RED.
+func TestXfrmApplyRejectsSubstitutedReadbackAfterCreate(t *testing.T) {
+	ops := newFakeLinkOps()
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+	if ifName == "" || ifID == 0 {
+		t.Fatalf("XFRMIfNameAndID returned name=%q id=%d for st0.1", ifName, ifID)
+	}
+	// No seeded link → the create path runs. In the add→readback window a
+	// foreign (non-xfrmi) link is swapped in under the same name.
+	ops.substituteAfterAdd[ifName] = &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: ifName, Index: 9},
+	}
+
+	xm := &xfrmManager{ops: ops}
+	err := xm.Apply(xfrmVPNs("st0.1"))
+	if err == nil {
+		t.Fatalf("a substituted (non-xfrmi) readback after create must fail the commit closed, got nil")
+	}
+
+	// The intended xfrmi was created (addCount bumped) but the substitute must
+	// NOT be adopted: not tracked, and never brought up.
+	if _, ok := xm.xfrmis[ifName]; ok {
+		t.Errorf("a substituted readback must not be tracked as a satisfied xfrmi; xfrmis=%v", xm.xfrmis)
+	}
+	for _, l := range ops.setUpLinks {
+		if l.Attrs().Name == ifName {
+			t.Errorf("the substituted foreign link %q must not be brought up", ifName)
+		}
+	}
+}
+
+// TestXfrmApplyRejectsWrongIfIDReadbackAfterCreate covers the same create-path
+// readback guard for the second substitution shape: an xfrm interface that
+// wears the name but carries the WRONG if_id (an aborted concurrent recreate).
+// It too must be rejected rather than tracked as satisfied.
+func TestXfrmApplyRejectsWrongIfIDReadbackAfterCreate(t *testing.T) {
+	ops := newFakeLinkOps()
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+	if ifName == "" || ifID == 0 {
+		t.Fatalf("XFRMIfNameAndID returned name=%q id=%d for st0.1", ifName, ifID)
+	}
+	ops.substituteAfterAdd[ifName] = &netlink.Xfrmi{
+		LinkAttrs: netlink.LinkAttrs{Name: ifName, Index: 9},
+		Ifid:      ifID + 1, // wrong if_id
+	}
+
+	xm := &xfrmManager{ops: ops}
+	if err := xm.Apply(xfrmVPNs("st0.1")); err == nil {
+		t.Fatalf("a wrong-if_id readback after create must fail the commit closed, got nil")
+	}
+	if _, ok := xm.xfrmis[ifName]; ok {
+		t.Errorf("a wrong-if_id readback must not be tracked; xfrmis=%v", xm.xfrmis)
+	}
+}

--- a/pkg/routing/xfrm_nonxfrmi_reject_5523_test.go
+++ b/pkg/routing/xfrm_nonxfrmi_reject_5523_test.go
@@ -129,3 +129,102 @@ func TestXfrmApplyRejectsWrongIfIDReadbackAfterCreate(t *testing.T) {
 		t.Errorf("a wrong-if_id readback must not be tracked; xfrmis=%v", xm.xfrmis)
 	}
 }
+
+// TestXfrmAdoptRejectsParentBoundReadback is the #6396 Codex MAJOR 1 guard for
+// the ADOPT path. xpf creates every xfrmi PARENTLESS (the SA selects the egress
+// device), so a same-name, same-if_id xfrmi bound to a NONZERO parent link
+// (IFLA_XFRM_LINK, which pins the physical egress interface) is NOT the device
+// we intend: adopting it would egress the VPN's SA traffic out the wrong
+// interface. if_id alone does not distinguish it, so the adopt guard asserts
+// ParentIndex == 0 and delete+recreates on a mismatch.
+//
+// FAIL-ON-REVERT: dropping the ParentIndex==0 clause adopts the parent-bound
+// link as-is (0 LinkDel / 0 LinkAdd) — the delete/recreate/parentless
+// assertions go RED.
+func TestXfrmAdoptRejectsParentBoundReadback(t *testing.T) {
+	ops := newFakeLinkOps()
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+	if ifName == "" || ifID == 0 {
+		t.Fatalf("XFRMIfNameAndID returned name=%q id=%d for st0.1", ifName, ifID)
+	}
+	// Same name + if_id, but bound to a nonzero parent link.
+	ops.links[ifName] = &netlink.Xfrmi{
+		LinkAttrs: netlink.LinkAttrs{Name: ifName, Index: 7, ParentIndex: 3},
+		Ifid:      ifID,
+	}
+
+	xm := &xfrmManager{ops: ops}
+	if err := xm.Apply(xfrmVPNs("st0.1")); err != nil {
+		t.Fatalf("reclaim of a parent-bound xfrmi must succeed (delete+recreate), got %v", err)
+	}
+	if !sliceHas(ops.delNames, ifName) {
+		t.Errorf("a parent-bound xfrmi must be delete+recreated, not adopted; delNames=%v", ops.delNames)
+	}
+	if ops.addCount != 1 {
+		t.Errorf("exactly one xfrmi must be recreated after reclaim, got %d LinkAdd", ops.addCount)
+	}
+	created, ok := ops.links[ifName].(*netlink.Xfrmi)
+	if !ok {
+		t.Fatalf("link %q after reclaim must be *netlink.Xfrmi, got %T", ifName, ops.links[ifName])
+	}
+	if created.Attrs().ParentIndex != 0 {
+		t.Errorf("recreated xfrmi must be parentless, got ParentIndex %d", created.Attrs().ParentIndex)
+	}
+	if got := xm.xfrmis[ifName]; got != ifID {
+		t.Errorf("reclaimed xfrmi tracked if_id %d, want %d", got, ifID)
+	}
+}
+
+// TestXfrmCreateRejectsParentBoundReadback is the #6396 Codex MAJOR 1 guard for
+// the POST-CREATE readback: a same-name, same-if_id xfrmi bound to a nonzero
+// parent, substituted in the add→readback window, must be rejected (not brought
+// up or tracked) — if_id matches, so only the ParentIndex==0 assertion catches
+// it.
+//
+// FAIL-ON-REVERT: dropping the ParentIndex==0 clause brings the parent-bound
+// link up and tracks it (Apply returns nil) — RED.
+func TestXfrmCreateRejectsParentBoundReadback(t *testing.T) {
+	ops := newFakeLinkOps()
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+	ops.substituteAfterAdd[ifName] = &netlink.Xfrmi{
+		LinkAttrs: netlink.LinkAttrs{Name: ifName, Index: 9, ParentIndex: 5},
+		Ifid:      ifID, // matching if_id — only the parent differs
+	}
+
+	xm := &xfrmManager{ops: ops}
+	if err := xm.Apply(xfrmVPNs("st0.1")); err == nil {
+		t.Fatalf("a parent-bound readback after create must fail the commit closed, got nil")
+	}
+	if _, ok := xm.xfrmis[ifName]; ok {
+		t.Errorf("a parent-bound readback must not be tracked; xfrmis=%v", xm.xfrmis)
+	}
+}
+
+// TestXfrmCreateRejectDropsStaleTracking is the #6396 Codex MINOR 3 guard: when
+// the create-path readback is rejected AND the name was already tracked from a
+// prior reconcile, the stale x.xfrmis entry must be DROPPED — otherwise a later
+// reconcile path could treat the foreign substitute as a satisfied xfrmi.
+//
+// FAIL-ON-REVERT: without the delete on the mismatch branch the pre-existing
+// tracking entry survives — the "not tracked" assertion goes RED. (The other
+// create-path tests use fresh managers, so only this pre-tracked case binds the
+// delete.)
+func TestXfrmCreateRejectDropsStaleTracking(t *testing.T) {
+	ops := newFakeLinkOps()
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+	// Foreign substitute swapped into the readback window.
+	ops.substituteAfterAdd[ifName] = &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: ifName, Index: 9},
+	}
+	// PRE-TRACKED: a prior reconcile recorded this name as satisfied, but the
+	// kernel link is absent now (deleted out-of-band), so Apply takes the create
+	// path and the readback returns the substitute.
+	xm := &xfrmManager{ops: ops, xfrmis: map[string]uint32{ifName: ifID}}
+	if err := xm.Apply(xfrmVPNs("st0.1")); err == nil {
+		t.Fatalf("a foreign readback after create must fail the commit closed, got nil")
+	}
+	if _, ok := xm.xfrmis[ifName]; ok {
+		t.Errorf("the stale tracking entry must be dropped on a rejected readback so a later "+
+			"reconcile cannot act on the foreign substitute; xfrmis=%v", xm.xfrmis)
+	}
+}

--- a/pkg/routing/xfrm_nonxfrmi_reject_5523_test.go
+++ b/pkg/routing/xfrm_nonxfrmi_reject_5523_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -226,5 +227,32 @@ func TestXfrmCreateRejectDropsStaleTracking(t *testing.T) {
 	if _, ok := xm.xfrmis[ifName]; ok {
 		t.Errorf("the stale tracking entry must be dropped on a rejected readback so a later "+
 			"reconcile cannot act on the foreign substitute; xfrmis=%v", xm.xfrmis)
+	}
+}
+
+// TestXfrmCreateLinkAddFailureDropsStaleTracking is the #6396 Codex MINOR 4
+// guard: a GENUINE LinkAdd failure on the create path must also honor the
+// "UNTRACKED" contract by dropping any pre-existing x.xfrmis entry for the
+// name. Otherwise, a name that a prior reconcile tracked (then its kernel link
+// vanished, forcing the create path) whose recreate then fails would stay
+// tracked — and the removal pass (deleteLocked) could later delete whatever
+// foreign link comes to wear that name.
+//
+// FAIL-ON-REVERT: without the delete on the LinkAdd-failure exit the pre-tracked
+// entry survives — the "not tracked" assertion goes RED.
+func TestXfrmCreateLinkAddFailureDropsStaleTracking(t *testing.T) {
+	ops := newFakeLinkOps()
+	ifName, ifID := config.XFRMIfNameAndID("st0.1")
+	// A GENUINE (non-EEXIST) LinkAdd failure — the link is never created.
+	ops.addFail[ifName] = errors.New("injected: LinkAdd EPERM")
+	// PRE-TRACKED from a prior reconcile; the kernel link is absent now, so Apply
+	// takes the create path and LinkAdd fails.
+	xm := &xfrmManager{ops: ops, xfrmis: map[string]uint32{ifName: ifID}}
+	if err := xm.Apply(xfrmVPNs("st0.1")); err == nil {
+		t.Fatalf("a genuine LinkAdd failure must fail the commit closed, got nil")
+	}
+	if _, ok := xm.xfrmis[ifName]; ok {
+		t.Errorf("a failed LinkAdd must drop the stale tracking entry so the removal pass "+
+			"cannot act on a foreign link that later wears the name; xfrmis=%v", xm.xfrmis)
 	}
 }

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -418,7 +418,13 @@ authorization surface: every request is dropped because no community matches.
   `buildSNMPIfData` returns an empty slice when the netlink dump fails — but it
   LOGS the failure (`slog.Warn`, #5523 C179-123) so an empty ifTable caused by a
   transient netlink error is diagnosable and not mistaken for a genuine
-  no-interface box; the next poll re-reads netlink and self-heals.
+  no-interface box; the next poll re-reads netlink and self-heals. The warning
+  is rate-limited to at most once per minute (`warnThrottle`, #6396): the
+  callback runs once per SNMP poll and a manager may poll several times a
+  second, so a PERSISTENT failure would otherwise write one line per poll and
+  drown the journal — the first failure logs immediately, subsequent ones in the
+  window are counted and reported with the next emitted line, and a successful
+  read logs a one-time recovery.
 
 ### IF-MIB class-counter semantics (#5050)
 


### PR DESCRIPTION
Advances #6396. Implements the three in-Go-scope, low-risk hardening residuals from the Codex hostile review of #6394 (codex-179), each with a firsthand-verified fail-on-revert test. STEP-0 verified each is real + present + not already fixed by a later campaign merge.

## 1. SNMP ifTable warn flood (C179-123 residual)
`buildSNMPIfData` (`pkg/daemon/daemon_snmp_reconcile.go`) runs once per SNMP poll; a manager may poll several times a second, so the per-poll netlink-failure `slog.Warn` added by C179-123 floods the journal on a sustained failure. Added a reusable `warnThrottle`: first failure logs immediately, later failures inside a one-minute window are counted and reported with the next emitted line, and a successful read logs a one-time recovery. The existing single-call surface test gets a throttle reset for determinism.

## 2. xfrm post-create readback TOCTOU (C179-104 residual)
`LinkAdd` and the `LinkByName` readback are two syscalls. The adopt path already re-asserts the link is an `*netlink.Xfrmi` with the desired `if_id` (#5523 C179-104), but the post-create readback (`pkg/routing/xfrm.go`) adopted whatever wore the name. A concurrent actor that swapped a same-name foreign link, or an xfrmi with a different `if_id`, into the add→readback window would be brought up and tracked as satisfied while no device carries the desired `if_id` — silently blackholing the route-based VPN. Now re-asserts type + `if_id` on the readback: reject, fail closed, and let the next reconcile's adopt path reclaim the intruder. Both substitution shapes (non-xfrmi and wrong-`if_id`) covered.

## 3. archive rotation edges (C179-060 residual)
- `parseArchiveSeq` took the last dot-field as the seq, so a legacy pre-#3441 `config-<ts>.conf` had its ts nanoseconds mis-read as a huge sequence, corrupting seq-ordered retention in a mixed legacy+current dir. Now requires the two-dot `config-<ts>.<seq>.conf` shape so a legacy name is unparseable (oldest, pruned first).
- `SetArchiveConfig` only seeded the counter while it was still zero, so a runtime archive-dir switch to a previously-used dir with higher seqs left this process's lower counter in place and its new archives were pruned as if stale. Now re-seeds on any dir change, monotonic-up only.

## Completeness / scope
- **Scoped out** (issue defers these as "remain"): the `SetIfDataFn` error-channel contract change; the best-effort RETH-MAC (`daemon_apply_dataplane.go`) and CLI-display (`cli_show_cluster.go`) `LinkList` swallows (the CLI path captures its error and degrades a display section, not a silent empty-to-manager).
- **Scoped out**: the synchronous `ArchiveConfig` mirror's target-dir seeding — zero production callers (only tests), shared global-counter design; a divergent target dir would need per-dir seq tracking.
- **Mirror surfaces checked**: tunnel/bond managers have their own type-gated reuse paths (#1706 anchor reuse gate, bond member sig), not an identical unguarded post-create readback.

## HA flags
None. No `pkg/cluster` / `pkg/vrrp` / session-sync / failover code touched. The xfrm change is IPsec interface lifecycle (not HA session sync).

## Validation
- gofmt / build / vet clean on `pkg/daemon`, `pkg/routing`, `pkg/configstore`.
- Full `go test ./pkg/daemon ./pkg/routing ./pkg/configstore` GREEN.
- Fail-on-revert confirmed firsthand for all four fixes (neutralize → clean assertion RED, restore → GREEN):
  - SNMP throttle: 20 warnings for 20 polls (want 1); window/suppressed-count RED.
  - xfrm readback: `Apply` returns nil and adopts the foreign link (want error + untracked).
  - parseArchiveSeq legacy: nanoseconds parsed as seq; legacy file retained over current in rotation.
  - dir-switch reseed: counter stuck at old dir's max (want re-seed to new dir's max).
- Module docs updated: `pkg/snmp/README.md`, `pkg/configstore/README.md`, `pkg/routing/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ