### PR TITLE
config: pin host-inbound sibling isolation regression guard (advances #6391)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -58845,3 +58845,54 @@ top.
   - **File(s)**: pkg/daemon/daemon_ipsec_rebind.go,
     pkg/daemon/daemon_ipsec_rebind_flush_bound_6397_test.go,
     pkg/daemon/daemon_run.go, pkg/daemon/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6391 host-inbound sibling-isolation regression guard +
+    doc. STEP-0 firsthand finding: the host-inbound sibling LEAK the issue
+    describes is NOT present on current master (a00aa3cd9). PR #6389 (the
+    `zoneInterfaceMembers` fanout that leaked) was CLOSED unmerged;
+    `compileZones` keys the per-interface override strictly on `iface.Name()`
+    (the direct child the stanza is written under), so a bracket sibling never
+    inherits it. Verified across 6 shapes (flat-set first/later member,
+    3-member, multi-service ssh+ping, hierarchical nested-child, hierarchical
+    bracket-with-body): only the named interface carries the override in every
+    case. Since master is already fail-safe, this ships the missing REGRESSION
+    GUARD rather than a behavior fix. Added
+    `compiler_zone_iface_hostinbound_sibling_6391_test.go` (7 tests) pinning
+    sibling isolation across all 5 symmetric surfaces the issue enumerates plus
+    a no-shared-backing-store aliasing guard. Fail-on-revert demonstrated
+    FIRSTHAND: re-applying the exact #6389 fanout turns 5 of the cases RED with
+    clean ASSERTION failures (sibling `ge-0/0/1`/`ge-0/0/2` wrongly gets
+    `[ssh]`/`[ping ssh]`); restoring master -> all GREEN, compiler byte-identical
+    to master. Documented the sibling-isolation invariant + why the #6389 fanout
+    is unsound (flat-set single-scoped and hierarchical multi-member compile to
+    the same AST) in docs/config-schema.md. build + vet + gofmt clean; full
+    `go test ./pkg/config/` GREEN.
+  - **File(s)**: pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go,
+    docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6400 review-fold — folded 3 Codex MINORs on the #6391
+    host-inbound sibling-isolation guard (production still byte-identical to
+    master; test/doc quality only). (1) Assertion completeness: the guard
+    helper compared only sorted SystemServices, dropping Protocols — a fanout
+    leaking host-inbound `protocols` (ospf/bgp) to a sibling would slip past.
+    Reworked `compileHostInbound6391` to return the FULL per-interface map keyed
+    on a `hib6391{SystemServices,Protocols}` view (both dimensions, every key),
+    so cardinality + protocols are asserted; extended the aliasing test with a
+    whole-map cardinality assertion; added
+    `TestHostInbound6391ProtocolsNoSiblingLeak` (ssh + ospf under the first
+    member) so the Protocols dimension is exercised by fail-on-revert. (2)
+    Prose overclaim: reworded the test-header + docs "every case goes RED" to the
+    accurate split — the six container-sharing cases (first-member, three-member,
+    multi-service, protocols, hierarchical nested-child, hierarchical
+    bracket-body) go RED, later-member + no-shared-backing-store stay GREEN
+    controls. (3) Doc self-contradiction: qualified config-schema.md that a
+    bracketed member cannot carry host-inbound in FLAT-SET / canonical `set`
+    syntax — the `[ a b ] { host-inbound }` shape is reachable only via a
+    raw-hierarchical `load override` parse. Re-verified: #6389 fanout →
+    6 RED / 2 GREEN controls; full `go test ./pkg/config/` GREEN; vet + gofmt
+    clean; compiler_security_zones.go byte-identical to master. Kept "Advances
+    #6391" (no close keyword).
+  - **File(s)**: pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go,
+    docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -695,12 +695,64 @@ therefore the WRONG helper here — it reads one node's `Keys[1:]` + immediate
 children and would still see only the first member. `compileZones`
 (`compiler_security_zones.go`) flattens the nested chain with the recursive
 `zoneInterfaceMembers`, which reads every key at each level and skips a
-`host-inbound-traffic` body (a bracketed member is bare membership — it cannot
-carry a per-interface host-inbound stanza). Before #5248 the reader took only
+`host-inbound-traffic` body (a bracketed member is bare membership in flat-set /
+canonical `set` syntax — it cannot carry a per-interface host-inbound stanza
+there; the `[ a b ] { host-inbound-traffic ... }` shape documented below is
+reachable only via a raw-hierarchical `load override` parse). Before #5248 the
+reader took only
 `iface.Name()` and silently dropped every member after the first — a zone-
 membership (security boundary) loss that also hid the dropped interface from
 the strict `validateZoneInterfaceDefinedStrict` gate. Covered by
 `pkg/config/compiler_zone_interfaces_bracket_5248_test.go`.
+
+**A per-interface `host-inbound-traffic` override is scoped to the SINGLE
+interface it is written under — it NEVER fans out to bracket siblings
+(#6391).** The `zoneInterfaceMembers` flatten above is for zone MEMBERSHIP
+only. Host-inbound is compiled separately and keyed strictly on the direct
+child the stanza hangs under (`iface.Name()` in `compileZones`), never across
+the flattened member set. This matters because the flat-set single-scoped case
+and a hierarchical multi-member `load override` block compile to the SAME AST:
+`interfaces [ ge-0/0/0 ge-0/0/1 ]` followed by
+`interfaces ge-0/0/0 host-inbound-traffic system-services ssh` reuses the FIRST
+member's SetPath container, so the `ge-0/0/0` node carries BOTH the `ge-0/0/1`
+membership leaf AND the host-inbound body — structurally identical to a
+hand-authored `interfaces { ge-0/0/0 { ge-0/0/1; host-inbound-traffic {...} } }`.
+A fanout keyed on the compiled AST alone therefore cannot tell "scope ssh to
+`ge-0/0/0` only" from "apply to every bracket member", so fanning the override
+across `zoneInterfaceMembers` (attempted in PR #6389, closed unmerged) OPENS ssh
+on `ge-0/0/1`, which the operator never configured — an over-permission /
+host-inbound leak.
+
+Two properties, do NOT conflate them:
+
+- **Individually-scoped isolation (UNCONDITIONAL invariant).** A service
+  authored under ONE named interface via its own `set` statement
+  (`interfaces ge-0/0/0 host-inbound-traffic system-services ssh`) is
+  single-scoped by definition and must NEVER appear on a sibling — under every
+  design option. This holds today and must keep holding after any future fix.
+
+- **Multi-member body (CURRENT fail-safe, pending a design call).** A
+  host-inbound BODY hanging off a bracket membership itself
+  (`interfaces [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic { ... } }`, or the
+  `ge-0/0/0 { ge-0/0/1; host-inbound-traffic { ... } }` load-override artifact)
+  currently applies to the first member ONLY. That is the issue's **option 1**
+  (fail-safe): the override stays on the single named interface and a bracketed
+  multi-member intent UNDER-applies (a sibling falls back to the zone-level
+  host-inbound) rather than over-admitting. This is the current default, NOT the
+  final multi-member semantics — making the multi-member intent apply to every
+  member without the flat-set leak needs parse-time scope disambiguation
+  (options 2/3), still an OPEN design call on #6391.
+
+Both properties are pinned by
+`pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go`, which asserts
+the FULL per-interface host-inbound map (every interface, both system-services
+AND protocols). Re-introducing the #6389 fanout turns the CONTAINER-SHARING
+cases RED — first-member, three-member, multi-service, protocols, and the two
+hierarchical multi-member-body cases — while the later-member and
+no-shared-backing-store cases stay GREEN CONTROLS (their interfaces do not share
+a SetPath container, so the fanout cannot touch them). The two multi-member-body
+cases assert current option-1 behavior only; an options-2/3 fix intentionally
+updates those two expectations.
 
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a

--- a/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
+++ b/pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go
@@ -1,0 +1,341 @@
+package config
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// Tests for #6391: a per-interface `host-inbound-traffic` override authored
+// under ONE member of a bracketed / shared-container interface membership must
+// NOT leak onto the sibling members that merely share the bracket.
+//
+// Background. #5248 flattens the bracketed `interfaces [ a b c ]` membership so
+// every member lands in `zone.Interfaces` (a security-boundary fix). SetPath
+// nests the bracket tail under the first member — `interfaces -> a(container) ->
+// b(leaf)` — so a subsequent `interfaces a host-inbound-traffic { ... }` reuses
+// the SAME `a` container and the host-inbound body becomes a child of the node
+// that also carries the `b` membership leaf.
+//
+// PR #6389 (advances #5609, CLOSED unmerged) tried to make a hierarchical
+// multi-member `load override` block apply the override to every member by
+// fanning the parsed host-inbound across `zoneInterfaceMembers(iface)`. That
+// fanout is UNSOUND: the flat-set single-scoped case and the hierarchical
+// multi-member case compile to the SAME AST, so the fanout cannot tell them
+// apart and OVER-ADMITS — it opens the service on `b` for the common
+//
+//	set security zones security-zone Z interfaces [ a b ]
+//	set security zones security-zone Z interfaces a host-inbound-traffic system-services ssh
+//
+// config that scopes ssh to `a` only. Codex's hostile review of #6389 plus a
+// firsthand repro caught this host-inbound sibling leak; #6389 closed unmerged.
+//
+// Current master is the fail-SAFE status quo: `compileZones` keys the
+// per-interface override strictly on `iface.Name()` (the direct child the
+// stanza was written under), so a sibling never inherits it. These tests are
+// the RED-on-revert guard that PINS that isolation: re-introducing the #6389
+// `for _, member := range zoneInterfaceMembers(iface)` fanout turns the
+// CONTAINER-SHARING cases RED (a sibling wrongly carries the override) —
+// first-member, three-member, multi-service, protocols, and the two
+// hierarchical multi-member-body cases. The later-member and
+// no-shared-backing-store cases stay GREEN CONTROLS: their interfaces do NOT
+// share a SetPath container (SetPath splits a later-authored member, and two
+// separately-authored top-level interfaces are independent), so the fanout does
+// not touch them — they prove the guard is not a tautology. The guard advances
+// #6391 in the issue's option-1 (fail-safe) direction; see docs/config-schema.md.
+//
+// TWO KINDS of assertion below, do NOT conflate them:
+//
+//   - FLAT-SET, INDIVIDUALLY-SCOPED (the first/later-member, three-member,
+//     multi-service and protocols cases, plus the aliasing guard): a service or
+//     protocol authored under ONE named interface via its OWN `set` statement
+//     (`interfaces a host-inbound-traffic system-services ssh`) must never
+//     appear on a sibling. This is UNCONDITIONALLY correct under every design
+//     option (1/2/3) — an individually-authored per-interface stanza is
+//     single-scoped by definition, so a future parse-time fan (option 2/3) for
+//     the multi-member case must still leave these untouched. Asserted firmly.
+//
+//   - MULTI-MEMBER BODY (the two hierarchical cases): a host-inbound BODY
+//     hanging off a bracket-membership / shared container
+//     (`[ a b ] { host-inbound ... }` or the `a { b; host-inbound ... }`
+//     load-override artifact). First-member-only here is the CURRENT option-1
+//     fail-safe outcome, NOT the final multi-member semantics: options 2/3
+//     (parse-time scope disambiguation, still an open DESIGN call on #6391) may
+//     deliberately fan the body to every member. These two cases pin CURRENT
+//     behavior and catch UNINTENDED drift; when option 2/3 lands, its author
+//     updates these two expectations as part of that work. They must NOT be
+//     read as asserting that first-member-only is correct forever.
+//
+// IMPORTANT (per CLAUDE.md): flat-set syntax is built with ParseSetCommand +
+// tree.SetPath, never NewParser; the hierarchical shape uses parseHierarchical.
+
+// hib6391 is a normalized (sorted) view of one compiled per-interface
+// HostInboundTraffic that captures BOTH admission dimensions — system-services
+// AND protocols. Comparing the full struct (not just system-services) means a
+// #6389-style fanout that leaked only host-inbound `protocols` (ospf/bgp/...) to
+// a sibling is caught too, not just a system-services leak.
+type hib6391 struct {
+	SystemServices []string
+	Protocols      []string
+}
+
+// compileHostInbound6391 compiles the zones subtree and returns the FULL
+// per-interface host-inbound map: every key present in InterfaceHostInbound
+// (an interface with no override is simply absent), each mapped to its sorted
+// system-services + protocols. Returning the whole map — every key, both
+// dimensions — is what makes the sibling-leak assertion airtight: an extra
+// sibling key, or an extra service/protocol on any interface, fails the
+// DeepEqual.
+func compileHostInbound6391(t *testing.T, tree *ConfigTree) map[string]hib6391 {
+	t.Helper()
+	sec := tree.FindChild("security")
+	if sec == nil {
+		t.Fatalf("no security node in tree")
+	}
+	zonesNode := sec.FindChild("zones")
+	if zonesNode == nil {
+		t.Fatalf("no security zones node in tree")
+	}
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(zonesNode, secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	out := map[string]hib6391{}
+	for _, z := range secCfg.Zones {
+		for ifName, hib := range z.InterfaceHostInbound {
+			// Include EVERY key, even a (defensive) nil value, so an
+			// unexpected sibling key fails the assertion regardless of its
+			// contents. sort.Strings(nil) is a no-op and append([]string(nil),
+			// nil...) stays nil, so an absent dimension normalizes to nil and
+			// matches an unset field in the expected literal.
+			v := hib6391{}
+			if hib != nil {
+				v.SystemServices = append([]string(nil), hib.SystemServices...)
+				v.Protocols = append([]string(nil), hib.Protocols...)
+				sort.Strings(v.SystemServices)
+				sort.Strings(v.Protocols)
+			}
+			out[ifName] = v
+		}
+	}
+	return out
+}
+
+func compileHostInbound6391FromSet(t *testing.T, cmds ...string) map[string]hib6391 {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return compileHostInbound6391(t, tree)
+}
+
+// assertHostInbound6391 asserts the compiled per-interface host-inbound map is
+// EXACTLY want — every key and both admission dimensions. Using the full map
+// (not a spot check on one interface) makes the sibling-leak assertion airtight:
+// an extra sibling key, or an extra service/protocol anywhere, is a failure.
+func assertHostInbound6391(t *testing.T, got, want map[string]hib6391) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("per-interface host-inbound = %+v, want %+v (sibling leak?)", got, want)
+	}
+}
+
+// TestHostInbound6391FlatSetFirstMemberNoSiblingLeak is the primary RED-on-revert
+// guard and the exact issue repro: a two-member bracket with a host-inbound
+// override written under the FIRST member via its own `set` statement must scope
+// the service to that member ONLY. This is an UNCONDITIONAL invariant — an
+// individually-authored per-interface stanza stays single-scoped under every
+// design option (1/2/3). The #6389 fanout opens ssh on the sibling ge-0/0/1 →
+// this goes RED.
+func TestHostInbound6391FlatSetFirstMemberNoSiblingLeak(t *testing.T) {
+	got := compileHostInbound6391FromSet(t,
+		"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+	)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+	})
+}
+
+// TestHostInbound6391FlatSetLaterMemberNoSiblingLeak covers the symmetric
+// ordering: the override written under a LATER bracket member scopes to that
+// member only, and the first member stays clean. In this ordering SetPath
+// splits ge-0/0/1 into its own top-level container, so the direct-child keying
+// is already correct — the case pins that the fix does not regress it.
+func TestHostInbound6391FlatSetLaterMemberNoSiblingLeak(t *testing.T) {
+	got := compileHostInbound6391FromSet(t,
+		"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+		"set security zones security-zone trust interfaces ge-0/0/1 host-inbound-traffic system-services ssh",
+	)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/1": {SystemServices: []string{"ssh"}},
+	})
+}
+
+// TestHostInbound6391ThreeMemberNoSiblingLeak proves the override does not reach
+// ANY sibling, not just the adjacent one: a 3-member bracket with the override
+// under the first member must leave BOTH later members clean. The #6389 fanout
+// leaks onto ge-0/0/1 AND ge-0/0/2 → RED.
+func TestHostInbound6391ThreeMemberNoSiblingLeak(t *testing.T) {
+	got := compileHostInbound6391FromSet(t,
+		"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ge-0/0/2 ]",
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+	)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+	})
+}
+
+// TestHostInbound6391MultiServiceNoSiblingLeak proves no cross-SERVICE leak: two
+// services (ssh AND ping) under the first member must both scope to that member
+// only — the sibling gets neither.
+func TestHostInbound6391MultiServiceNoSiblingLeak(t *testing.T) {
+	got := compileHostInbound6391FromSet(t,
+		"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ping",
+	)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ping", "ssh"}},
+	})
+}
+
+// TestHostInbound6391ProtocolsNoSiblingLeak exercises the PROTOCOLS admission
+// dimension (not just system-services): an override under the FIRST member
+// carrying BOTH a system-service (ssh) and a protocol (ospf) must scope both to
+// that member — the sibling gets neither. Without a Protocols case the guard's
+// full-map assertion never observes a protocols leak; the #6389 fanout leaks
+// ospf onto ge-0/0/1 too → RED. Individually-scoped, so an UNCONDITIONAL
+// invariant under every design option.
+func TestHostInbound6391ProtocolsNoSiblingLeak(t *testing.T) {
+	got := compileHostInbound6391FromSet(t,
+		"set security zones security-zone trust interfaces [ ge-0/0/0 ge-0/0/1 ]",
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic protocols ospf",
+	)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}, Protocols: []string{"ospf"}},
+	})
+}
+
+// TestHostInbound6391HierarchicalNestedChildNoSiblingLeak covers the exact
+// load-override AST shape #6389 targeted: a hierarchical block that NESTS the
+// second member under the first alongside a host-inbound body
+// (`interfaces { ge-0/0/0 { ge-0/0/1; host-inbound-traffic { ssh } } }`). This
+// is a MULTI-MEMBER BODY case, NOT an individually-scoped stanza: first-member-
+// only (ssh on ge-0/0/0, nested ge-0/0/1 clean) is the CURRENT option-1 fail-
+// safe outcome, not the final multi-member semantics. An options-2/3 design fix
+// (parse-time scope disambiguation, still open on #6391) may deliberately fan
+// the body to ge-0/0/1 too; when it lands, update this expectation. Today the
+// assertion pins current behavior and the #6389 fanout (which opens ssh on
+// ge-0/0/1 without that design work) turns it RED.
+func TestHostInbound6391HierarchicalNestedChildNoSiblingLeak(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                ge-0/0/0 {
+                    ge-0/0/1;
+                    host-inbound-traffic { system-services ssh; }
+                }
+            }
+        }
+    }
+}`)
+	got := compileHostInbound6391(t, tree)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+	})
+}
+
+// TestHostInbound6391HierarchicalBracketBodyNoSiblingLeak covers the
+// Keys=[a,b] hierarchical bracket-with-body shape
+// (`interfaces { [ ge-0/0/0 ge-0/0/1 ] { host-inbound-traffic { ssh } } }`) —
+// the canonical MULTI-MEMBER BODY: a host-inbound stanza authored ON the bracket
+// membership itself. The lexer strips the brackets so the member node carries
+// both names in its Keys; iface.Name() is the first key, so the CURRENT option-1
+// fail-safe scopes ssh to ge-0/0/0 and leaves ge-0/0/1 clean. This is the
+// under-application #5609-A3.1 / #6391 tracks: first-member-only is the fail-safe
+// default PENDING the options-2/3 design call, NOT the final semantics — an
+// option-2/3 fix that fans the body to every bracket member will intentionally
+// flip this expectation. It is asserted here to pin current behavior, not to
+// declare first-member-only correct forever.
+func TestHostInbound6391HierarchicalBracketBodyNoSiblingLeak(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone trust {
+            interfaces {
+                [ ge-0/0/0 ge-0/0/1 ] {
+                    host-inbound-traffic { system-services ssh; }
+                }
+            }
+        }
+    }
+}`)
+	got := compileHostInbound6391(t, tree)
+	assertHostInbound6391(t, got, map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+	})
+}
+
+// TestHostInbound6391NoSharedBackingStoreAcrossInterfaces guards the aliasing
+// trap the #6389 review flagged: distinct per-interface overrides must not share
+// a mutable backing slice. Two interfaces each authored with a DIFFERENT service
+// must keep independent SystemServices — appending to one (as a later
+// mergeHostInbound would) must never surface in the other. Assert the WHOLE
+// compiled map (cardinality + both dimensions per interface) AND pointer
+// independence of the backing arrays.
+func TestHostInbound6391NoSharedBackingStoreAcrossInterfaces(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services ssh",
+		"set security zones security-zone trust interfaces ge-0/0/1 host-inbound-traffic system-services ping",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	// Full-map cardinality: EXACTLY the two authored interfaces, each with its
+	// own single service and no protocols. An extra sibling key (or a leaked
+	// service/protocol) fails here.
+	assertHostInbound6391(t, compileHostInbound6391(t, tree), map[string]hib6391{
+		"ge-0/0/0": {SystemServices: []string{"ssh"}},
+		"ge-0/0/1": {SystemServices: []string{"ping"}},
+	})
+	sec := tree.FindChild("security")
+	zonesNode := sec.FindChild("zones")
+	secCfg := &SecurityConfig{Zones: map[string]*ZoneConfig{}}
+	if err := compileZones(zonesNode, secCfg); err != nil {
+		t.Fatalf("compileZones: %v", err)
+	}
+	zone := secCfg.Zones["trust"]
+	a := zone.InterfaceHostInbound["ge-0/0/0"]
+	b := zone.InterfaceHostInbound["ge-0/0/1"]
+	if a == nil || b == nil {
+		t.Fatalf("expected both interfaces to carry a host-inbound override, got a=%v b=%v", a, b)
+	}
+	if !reflect.DeepEqual(a.SystemServices, []string{"ssh"}) {
+		t.Fatalf("ge-0/0/0 system-services = %v, want [ssh]", a.SystemServices)
+	}
+	if !reflect.DeepEqual(b.SystemServices, []string{"ping"}) {
+		t.Fatalf("ge-0/0/1 system-services = %v, want [ping]", b.SystemServices)
+	}
+	// Mutating one must not disturb the other (independent backing arrays).
+	a.SystemServices = append(a.SystemServices, "https")
+	if len(b.SystemServices) != 1 || b.SystemServices[0] != "ping" {
+		t.Fatalf("aliasing: mutating ge-0/0/0 leaked into ge-0/0/1: %v", b.SystemServices)
+	}
+}


### PR DESCRIPTION
## Summary

Pins a regression guard (plus documentation) for host-inbound sibling
isolation, in the fail-safe (option-1) direction of #6391.

**STEP-0 firsthand finding: the host-inbound sibling LEAK is NOT present on
current master.** The fanout that leaked (`zoneInterfaceMembers` over the whole
member set) came from PR #6389, which was closed unmerged after a Codex hostile
review and firsthand reproduction. `compileZones` keys the per-interface
override strictly on `iface.Name()` — the direct child the `host-inbound-traffic`
body hangs under — so a sibling that merely shares the SetPath container (the
flat-set `interfaces [ a b ]` + `interfaces a host-inbound ssh` shape, where
SetPath reuses `a`'s container and nests `b` under it) never inherits the
override.

Because master is already fail-safe, this PR ships the missing **regression
guard**, not a behavior change. It does not settle the design question: the
issue stays OPEN for options 2/3 (parse-time scope disambiguation to make a
multi-member `load override` body fan to every member without the flat-set
leak), which are an explicit design call, not a low-risk mechanical fix.

## What the guard asserts

Two distinct properties — do not conflate them:

- **Individually-scoped isolation — UNCONDITIONAL invariant.** A service
  authored under one named interface via its own `set` statement stays
  single-scoped under every design option (1/2/3), so a sibling never gets it.
  Asserted firmly. Cases: override under the FIRST bracket member (the exact
  repro), under a LATER member, a 3-member bracket (no sibling reached, not just
  the adjacent one), two services (ssh AND ping, no cross-service leak), and a
  no-shared-backing-store aliasing guard.
- **Multi-member BODY — CURRENT option-1 behavior, pending design.** The
  hierarchical `[ a b ] { host-inbound }` and the `a { b; host-inbound }`
  load-override artifact assert the current first-member-only outcome to catch
  unintended drift. They are explicitly framed (test comments + docs) as pending
  the options-2/3 design call; when that lands, its author updates these two
  expectations. They do not assert first-member-only is correct forever.

Each case asserts the EXACT per-interface `InterfaceHostInbound` map, so an
extra sibling key is a failure.

## Fail-on-revert (firsthand)

Re-applying the exact #6389 fanout turns the five container-sharing cases RED
with clean assertion failures (sibling `ge-0/0/1` / `ge-0/0/2` wrongly carries
the override); the two negative-control cases stay GREEN; restoring master
returns all GREEN with `compiler_security_zones.go` byte-identical to master.

## Docs

`docs/config-schema.md` documents both properties and why the #6389 fanout is
unsound: the flat-set single-scoped case and the hierarchical multi-member case
compile to the SAME AST, so an AST-only fanout cannot distinguish them and
over-admits.

## Validation

- build + vet + gofmt clean on `pkg/config`
- full `go test ./pkg/config/` GREEN
- no dataplane / cluster surface touched — pure Go config-compile unit; no smoke
  needed

Advances #6391
