### PR TITLE
show system services: report effective post-bind listeners

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -58882,3 +58882,42 @@ top.
     pkg/cli/cli_show_system_listeners_6385_test.go,
     pkg/daemon/management.go, pkg/daemon/daemon_run_servers.go,
     pkg/daemon/daemon_run.go, pkg/daemon/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6385/#6401 fold — model listener STATE, not just an address
+    (Codex MERGE-NEEDS-MAJOR completeness gap adjudicated real by team-lead).
+    `sysservices.Listener` now carries `{Addr, State}` with State ∈
+    {StateListening, StateFailed, StateDisabled}; `Lines()` renders Listening →
+    "addr", Failed → "addr (bind failed)" / "bind failed", Disabled →
+    "disabled". gRPC state: `grpcapi.Server` records a `grpcListenState`
+    (pre-bind → listening → failed); `EffectiveListener()` replaces
+    `EffectiveAddr()` — net.Listen error → Failed(requested addr); serve-loop
+    exit CLEARS the bound addr → Failed (no stale bind for a dead server);
+    pre-bind → Listening(requested). HTTP state:
+    `managementReconciler.effectiveHTTPListener()` — nil reconciler (empty
+    --api-addr) → Disabled; configured-but-boot-bind-failed (curSet false) →
+    Failed(lastHTTPAttempt, recorded pre-bind in startTo); converged →
+    Listening. #4 fold: HTTP Listening addr sourced from the ACTUAL bound
+    listener via new `api.Server.EffectiveHTTPAddr()` (httpLeg.ln.Addr()), so
+    --api-addr=127.0.0.1:0 reports the concrete ephemeral port, not ":0".
+    Daemon aggregator `effectiveListeners()` maps both into one
+    `sysservices.Listeners`. New fail-on-revert nets (each RED verified
+    firsthand, clean ASSERTION failure, restored GREEN): grpcapi
+    TestGRPCEffectiveListenerBindFailure (real Run against an in-use addr →
+    Failed) + TestGRPCEffectiveListenerLifecycle (pre-bind→bound-concrete-port
+    →serve-exit-clears) + TestShowSystemServicesFailedHTTPGRPC (remote render
+    "(bind failed)"); daemon TestEffectiveHTTPListenerStatesDistinct
+    (Disabled≠Failed≠Listening) + TestEffectiveHTTPListenerEphemeralPort (:0 →
+    concrete); sysservices Lines() Failed/Disabled cases. gofmt/vet clean;
+    `go test ./pkg/sysservices/ ./pkg/api/ ./pkg/grpcapi/ ./pkg/cli/
+    ./pkg/daemon/` GREEN, `-race` GREEN on the listener tests. docs:
+    pkg/daemon/README.md effective-listener section rewritten for the state
+    model; pkg/api/README.md notes EffectiveHTTPAddr.
+  - **File(s)**: pkg/sysservices/listeners.go,
+    pkg/sysservices/listeners_test.go, pkg/api/listener.go, pkg/api/README.md,
+    pkg/grpcapi/server.go, pkg/grpcapi/server_show_system.go,
+    pkg/grpcapi/server_show_system_listeners_6385_test.go, pkg/cli/cli.go,
+    pkg/cli/cli_show_system.go,
+    pkg/cli/cli_show_system_listeners_6385_test.go,
+    pkg/daemon/management.go, pkg/daemon/daemon_run_servers.go,
+    pkg/daemon/effective_listeners_6401_test.go, pkg/daemon/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -58953,3 +58953,31 @@ top.
     pkg/daemon/management.go, pkg/daemon/effective_listeners_6401_test.go,
     pkg/daemon/README.md, pkg/grpcapi/server.go,
     pkg/grpcapi/server_show_system_listeners_6385_test.go, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6385/#6401 fold round 3 — FIX a shutdown DEADLOCK my round-2
+    serve-exit fold introduced (Codex MAJOR, reproduced firsthand). Lock-order
+    cycle: the HTTP leg's serve goroutine still holds its `wg` count when the
+    round-2 code acquired `lifeMu` to set `leg.dead` on an unexpected serve
+    exit; `Server.Wait()` holds `lifeMu` ACROSS `wg.Wait()` — so a serve-exit
+    racing a shutdown Wait hung permanently (Wait holds lifeMu waiting on the
+    goroutine's wg.Done; the goroutine waits on lifeMu before it can
+    return->Done). PATH TAKEN: atomic fix (bounded, low-risk) — `listenerLeg.dead`
+    is now an `atomic.Bool`; the serve goroutine `leg.dead.Store(true)` WITHOUT
+    lifeMu (breaks the cycle); `EffectiveHTTPAddr()` reads `httpLeg`/`ln` under
+    lifeMu (swapped only under lifeMu) but the dead flag via `dead.Load()`.
+    Requested-shutdown paths (stopCh/rootCtx) unchanged. NEW test
+    (pkg/api/serve_exit_wait_deadlock_6401_test.go)
+    TestServeExitDoesNotDeadlockConcurrentWait_6401: launches Wait() concurrently
+    (holds lifeMu in wg.Wait while the leg is parked at Accept via an in-memory
+    erroring listener — NO real socket), then triggers the unexpected serve-exit;
+    asserts Wait returns within 3s (no deadlock) AND the leg ends dead
+    (EffectiveHTTPAddr==""). RED verified FIRSTHAND: reintroducing the
+    lifeMu-guarded marking hangs Wait -> clean t.Fatal at 3s (bounded, not a
+    suite hang); restored -> GREEN at 0.10s. gofmt/vet clean; `go test
+    ./pkg/sysservices/ ./pkg/api/ ./pkg/grpcapi/ ./pkg/cli/ ./pkg/daemon/`
+    GREEN; `-race` GREEN on the FULL pkg/api suite + listener/deadlock tests +
+    mgmt reconcile. docs: pkg/api/README.md EffectiveHTTPAddr note explains the
+    atomic (lock-free) marking + the lock-ordering rationale.
+  - **File(s)**: pkg/api/listener.go, pkg/api/README.md,
+    pkg/api/serve_exit_wait_deadlock_6401_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -58921,3 +58921,35 @@ top.
     pkg/cli/cli_show_system_listeners_6385_test.go,
     pkg/daemon/management.go, pkg/daemon/daemon_run_servers.go,
     pkg/daemon/effective_listeners_6401_test.go, pkg/daemon/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6385/#6401 fold round 2 — HTTP↔gRPC serve-exit SYMMETRY
+    (Codex MAJOR, adjudicated real) + gRPC-lifecycle test tightening (Codex
+    MINOR). MAJOR: an UNEXPECTED HTTP `Serve` exit in `serveLegLocked`
+    (pkg/api/listener.go) only logged+returned, leaving `httpLeg.ln` live, so
+    `EffectiveHTTPAddr()` still returned the dead listener's addr and
+    `effectiveHTTPListener()` reported StateListening on a DEAD leg — asymmetric
+    with the gRPC serve-exit clear. Fix: added `listenerLeg.dead`, marked true
+    under `lifeMu` on the unexpected-exit branch ONLY (requested shutdown via
+    stopCh/rootCtx unaffected); `EffectiveHTTPAddr()` returns "" for a dead leg;
+    `effectiveHTTPListener()` maps converged-but-EffectiveHTTPAddr=="" →
+    StateFailed (day-2 rebind failure RETAINS the old live leg → non-empty →
+    stays Listening, unaffected). MINOR: tightened
+    TestGRPCEffectiveListenerLifecycle to assert (a) pre-bind state before Run
+    (Listening on requested addr) and (b) post-serve-exit addr is CLEARED (==
+    requested, != the stale concrete bound port) — the old test asserted only
+    State==Failed and would miss a retain-stale-effAddr regression. New test
+    TestEffectiveHTTPListenerServeExitFails drives the serve-exit via an
+    in-memory erroring listener (NO real socket — review sandbox blocks
+    sockets): Accept errors on a signal → Serve exits → leg dead → reconciler
+    reports Failed. Both RED verified FIRSTHAND (neutralize leg.dead → Listening
+    on dead leg RED; neutralize the gRPC clear to retain stale addr → stale-port
+    RED), restored GREEN. gofmt/vet clean; `go test ./pkg/sysservices/
+    ./pkg/api/ ./pkg/grpcapi/ ./pkg/cli/ ./pkg/daemon/` GREEN; `-race` GREEN
+    (full pkg/api + listener tests + mgmt reconcile). docs: pkg/daemon/README.md
+    HTTP bullet + pkg/api/README.md EffectiveHTTPAddr note updated for the
+    dead-leg/serve-exit symmetry.
+  - **File(s)**: pkg/api/listener.go, pkg/api/README.md,
+    pkg/daemon/management.go, pkg/daemon/effective_listeners_6401_test.go,
+    pkg/daemon/README.md, pkg/grpcapi/server.go,
+    pkg/grpcapi/server_show_system_listeners_6385_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -58845,3 +58845,40 @@ top.
   - **File(s)**: pkg/daemon/daemon_ipsec_rebind.go,
     pkg/daemon/daemon_ipsec_rebind_flush_bound_6397_test.go,
     pkg/daemon/daemon_run.go, pkg/daemon/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6385 — `show system services` reports EFFECTIVE post-bind
+    management-listener addresses on BOTH surfaces (re-file of fix-5 dropped
+    from #6384). Root cause: the remote gRPC renderer
+    (`pkg/grpcapi/server_show_system.go`) AND the local CLI renderer
+    (`pkg/cli/cli_show_system.go`) each hardcoded
+    `127.0.0.1:50051 / 127.0.0.1:8080 (always on)`, reporting the
+    requested/config-declared listeners, not the addresses the daemon
+    actually bound (post-#5035 gRPC loopback clamp / post-#4047/#5127 REST
+    clamp / disabled listener). A local-only patch left the remote path — the
+    common operator path — wrong. Fix: new leaf pkg `pkg/sysservices`
+    (`Listeners` + shared `Lines()` renderer, stdlib-only). Daemon aggregator
+    `Daemon.effectiveListeners()` builds ONE snapshot — gRPC from a new
+    `grpcapi.Server.EffectiveAddr()` recorded after `net.Listen`, HTTP REST
+    from a new `managementReconciler.effectiveHTTPAddr()` (converged
+    `m.cur.addr`; `""` -> rendered `disabled` when `--api-addr` empty). BOTH
+    renderers read that ONE snapshot: gRPC via `Config.ListenersFn`, local CLI
+    via `SetListenersFn`, both formatting through `Listeners.Lines`, so local
+    and remote can never diverge. Surface enumeration: only two `System
+    services:` emitters exist (local CLI + remote gRPC) — both fixed; no HTTP
+    REST / JSON / display-xml variant renders the listener block. Fail-on-
+    revert nets: `TestShowSystemServicesEffectiveListenersGRPC` (primary,
+    remote path) + `TestShowSystemServicesEffectiveListenersLocal` +
+    `sysservices.TestListenersLines`; each RED verified FIRSTHAND by
+    neutralizing the render substitution (clean ASSERTION failure, nil-
+    fallback test stays GREEN), restored -> GREEN. build+vet+gofmt clean;
+    `go test ./pkg/sysservices/ ./pkg/grpcapi/ ./pkg/cli/ ./pkg/daemon/`
+    GREEN. Unit-testable show-render class — no loss-cluster smoke needed.
+  - **File(s)**: pkg/sysservices/listeners.go,
+    pkg/sysservices/listeners_test.go, pkg/grpcapi/server.go,
+    pkg/grpcapi/server_show_system.go,
+    pkg/grpcapi/server_show_system_listeners_6385_test.go,
+    pkg/cli/cli.go, pkg/cli/cli_show_system.go,
+    pkg/cli/cli_show_system_listeners_6385_test.go,
+    pkg/daemon/management.go, pkg/daemon/daemon_run_servers.go,
+    pkg/daemon/daemon_run.go, pkg/daemon/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -329,8 +329,12 @@ under the daemon's errgroup. Nothing else imports this package.
   - `EffectiveHTTPAddr()` (#6385/#6401) returns the live HTTP leg's ACTUAL bound
     address (`httpLeg.ln.Addr()`) — an ephemeral `:0` request resolves to its
     concrete port, a wildcard/hostname bind is normalized — or `""` when no HTTP
-    leg is serving. The daemon's `show system services` effective-listener
-    snapshot reads it (`managementReconciler.effectiveHTTPListener`).
+    leg is serving OR the live leg's serve loop exited UNEXPECTEDLY (the serve
+    goroutine marks the leg `dead` under `lifeMu`; a requested shutdown via
+    `stopLegLocked`/`rootCtx` does NOT). The daemon's `show system services`
+    effective-listener snapshot reads it
+    (`managementReconciler.effectiveHTTPListener`) and renders a dead leg
+    `Failed`, symmetric with the gRPC serve-exit clear.
   - The auto-generated HTTPS cert (`generateSelfSignedCertAt`, used when no
     operator cert is provisioned) carries Subject Alternative Names, not just a
     CommonName (#5719, codex-review-182 C-API TLS hygiene). Every modern TLS

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -326,6 +326,11 @@ under the daemon's errgroup. Nothing else imports this package.
     re-enable, HTTPS-bind-only change, HTTP-change-keeps-HTTPS, auth swap,
     bind-failure retain-old). `Run`/`serveBound` remain the single-lifecycle test
     entry point.
+  - `EffectiveHTTPAddr()` (#6385/#6401) returns the live HTTP leg's ACTUAL bound
+    address (`httpLeg.ln.Addr()`) — an ephemeral `:0` request resolves to its
+    concrete port, a wildcard/hostname bind is normalized — or `""` when no HTTP
+    leg is serving. The daemon's `show system services` effective-listener
+    snapshot reads it (`managementReconciler.effectiveHTTPListener`).
   - The auto-generated HTTPS cert (`generateSelfSignedCertAt`, used when no
     operator cert is provisioned) carries Subject Alternative Names, not just a
     CommonName (#5719, codex-review-182 C-API TLS hygiene). Every modern TLS

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -330,8 +330,12 @@ under the daemon's errgroup. Nothing else imports this package.
     address (`httpLeg.ln.Addr()`) — an ephemeral `:0` request resolves to its
     concrete port, a wildcard/hostname bind is normalized — or `""` when no HTTP
     leg is serving OR the live leg's serve loop exited UNEXPECTEDLY (the serve
-    goroutine marks the leg `dead` under `lifeMu`; a requested shutdown via
-    `stopLegLocked`/`rootCtx` does NOT). The daemon's `show system services`
+    goroutine marks the leg `dead` — an ATOMIC store, NOT under `lifeMu`, so a
+    serve-exit racing a shutdown `Wait()` cannot deadlock: the goroutine still
+    holds its `wg` count when it marks dead and `Wait()` holds `lifeMu` across
+    `wg.Wait()`, so a lifeMu-guarded marker would form a lock-ordering cycle; a
+    requested shutdown via `stopLegLocked`/`rootCtx` does NOT mark dead). The
+    daemon's `show system services`
     effective-listener snapshot reads it
     (`managementReconciler.effectiveHTTPListener`) and renders a dead leg
     `Failed`, symmetric with the gRPC serve-exit clear.

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -21,6 +21,13 @@ type listenerLeg struct {
 	ln       net.Listener
 	stopCh   chan struct{}
 	stopOnce sync.Once
+	// dead is set (under lifeMu) when the leg's serve loop exits UNEXPECTEDLY —
+	// the listener terminated on its own, not via a requested shutdown
+	// (stopLegLocked / rootCtx). EffectiveHTTPAddr treats a dead leg as
+	// not-serving so `show system services` reports the HTTP listener Failed
+	// rather than Listening on a dead socket, symmetric with the gRPC serve-exit
+	// clear (#6401).
+	dead bool
 }
 
 // serveLegLocked launches srv on ln in a background goroutine registered on the
@@ -58,6 +65,17 @@ func (s *Server) serveLegLocked(srv *http.Server, ln net.Listener, isTLS bool) *
 			if err != nil && err != http.ErrServerClosed {
 				slog.Error("API listener terminated unexpectedly", "addr", srv.Addr, "tls", isTLS, "err", err)
 			}
+			// #6401: an UNEXPECTED serve exit means this leg is no longer
+			// serving. Mark it dead (under lifeMu, freshly acquired — this
+			// runs AFTER serveLegLocked returned and released the caller's
+			// lock, so no nesting) so EffectiveHTTPAddr stops reporting the
+			// dead listener's address and `show system services` renders the
+			// HTTP listener Failed, mirroring the gRPC serve-exit clear. A leg
+			// already retired/replaced by a reconcile takes the stopCh path
+			// below instead, so this only fires on a genuine self-termination.
+			s.lifeMu.Lock()
+			leg.dead = true
+			s.lifeMu.Unlock()
 			return
 		case <-leg.stopCh:
 		case <-rootDone:
@@ -133,7 +151,7 @@ func (s *Server) Wait() {
 func (s *Server) EffectiveHTTPAddr() string {
 	s.lifeMu.Lock()
 	defer s.lifeMu.Unlock()
-	if s.httpLeg == nil || s.httpLeg.ln == nil {
+	if s.httpLeg == nil || s.httpLeg.ln == nil || s.httpLeg.dead {
 		return ""
 	}
 	return s.httpLeg.ln.Addr().String()

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -123,6 +123,22 @@ func (s *Server) Wait() {
 	s.wg.Wait()
 }
 
+// EffectiveHTTPAddr returns the ACTUAL bound address of the live HTTP leg, or ""
+// when no HTTP leg is serving. It reads the listener's own Addr, so an ephemeral
+// `:0` request resolves to its concrete port and a wildcard/hostname bind is
+// normalized — the address the socket is truly on, not the requested one. The
+// #6385/#6401 `show system services` effective-listener snapshot reads it (via
+// managementReconciler.effectiveHTTPListener), mirroring the grpcapi.Server
+// EffectiveListener pattern.
+func (s *Server) EffectiveHTTPAddr() string {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	if s.httpLeg == nil || s.httpLeg.ln == nil {
+		return ""
+	}
+	return s.httpLeg.ln.Addr().String()
+}
+
 // ReconcileHTTP make-before-break rebinds ONLY the HTTP listener to addr (#5866),
 // leaving the HTTPS leg untouched. A same-addr call is a no-op. The new listener
 // is bound and serving BEFORE the old is retired (no unreachable HTTP window). A

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -21,13 +22,19 @@ type listenerLeg struct {
 	ln       net.Listener
 	stopCh   chan struct{}
 	stopOnce sync.Once
-	// dead is set (under lifeMu) when the leg's serve loop exits UNEXPECTEDLY —
-	// the listener terminated on its own, not via a requested shutdown
-	// (stopLegLocked / rootCtx). EffectiveHTTPAddr treats a dead leg as
-	// not-serving so `show system services` reports the HTTP listener Failed
-	// rather than Listening on a dead socket, symmetric with the gRPC serve-exit
-	// clear (#6401).
-	dead bool
+	// dead is set when the leg's serve loop exits UNEXPECTEDLY — the listener
+	// terminated on its own, not via a requested shutdown (stopLegLocked /
+	// rootCtx). EffectiveHTTPAddr treats a dead leg as not-serving so `show
+	// system services` reports the HTTP listener Failed rather than Listening on
+	// a dead socket, symmetric with the gRPC serve-exit clear (#6401).
+	//
+	// It is an atomic (NOT lifeMu-guarded): the serve goroutine still holds its
+	// wg count when it sets this on exit, and Server.Wait holds lifeMu ACROSS
+	// wg.Wait — so if the marker needed lifeMu, an exit racing a shutdown Wait
+	// would deadlock (Wait holds lifeMu waiting on the goroutine's wg.Done; the
+	// goroutine waits on lifeMu before it can return -> Done). Storing atomically
+	// with no lock breaks that lock-ordering cycle (#6401 round-3 fix).
+	dead atomic.Bool
 }
 
 // serveLegLocked launches srv on ln in a background goroutine registered on the
@@ -66,16 +73,16 @@ func (s *Server) serveLegLocked(srv *http.Server, ln net.Listener, isTLS bool) *
 				slog.Error("API listener terminated unexpectedly", "addr", srv.Addr, "tls", isTLS, "err", err)
 			}
 			// #6401: an UNEXPECTED serve exit means this leg is no longer
-			// serving. Mark it dead (under lifeMu, freshly acquired — this
-			// runs AFTER serveLegLocked returned and released the caller's
-			// lock, so no nesting) so EffectiveHTTPAddr stops reporting the
-			// dead listener's address and `show system services` renders the
-			// HTTP listener Failed, mirroring the gRPC serve-exit clear. A leg
-			// already retired/replaced by a reconcile takes the stopCh path
-			// below instead, so this only fires on a genuine self-termination.
-			s.lifeMu.Lock()
-			leg.dead = true
-			s.lifeMu.Unlock()
+			// serving. Mark it dead ATOMICALLY — NOT under lifeMu: the goroutine
+			// still holds its wg count here, and Server.Wait holds lifeMu across
+			// wg.Wait, so acquiring lifeMu here would deadlock a shutdown that
+			// raced this exit (round-3 fix). EffectiveHTTPAddr then stops
+			// reporting the dead listener's address and `show system services`
+			// renders the HTTP listener Failed, mirroring the gRPC serve-exit
+			// clear. A leg already retired/replaced by a reconcile takes the
+			// stopCh path below instead, so this only fires on a genuine
+			// self-termination.
+			leg.dead.Store(true)
 			return
 		case <-leg.stopCh:
 		case <-rootDone:
@@ -151,7 +158,10 @@ func (s *Server) Wait() {
 func (s *Server) EffectiveHTTPAddr() string {
 	s.lifeMu.Lock()
 	defer s.lifeMu.Unlock()
-	if s.httpLeg == nil || s.httpLeg.ln == nil || s.httpLeg.dead {
+	// httpLeg / ln are swapped only under lifeMu, so read them here; dead is
+	// atomic (set without lifeMu by the serve goroutine to avoid a shutdown
+	// lock-ordering deadlock — see listenerLeg.dead).
+	if s.httpLeg == nil || s.httpLeg.ln == nil || s.httpLeg.dead.Load() {
 		return ""
 	}
 	return s.httpLeg.ln.Addr().String()

--- a/pkg/api/serve_exit_wait_deadlock_6401_test.go
+++ b/pkg/api/serve_exit_wait_deadlock_6401_test.go
@@ -1,0 +1,87 @@
+// RED-on-revert net for the #6401 round-3 deadlock fix: an UNEXPECTED HTTP
+// serve-exit must NOT deadlock a concurrent Server.Wait(). The round-2
+// serve-exit->Failed fold marked the leg dead UNDER lifeMu; because the serve
+// goroutine still holds its wg count when it does so, and Wait() holds lifeMu
+// ACROSS wg.Wait(), a serve-exit racing a shutdown Wait deadlocked (Wait holds
+// lifeMu waiting on the goroutine's wg.Done; the goroutine waits on lifeMu
+// before it can return -> Done). The fix makes the dead marking atomic (no
+// lock), breaking the cycle.
+package api
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// deadlockProbeLn is an in-memory listener whose Accept blocks until either
+// Close (a requested shutdown -> net.ErrClosed) or fail is closed (an UNEXPECTED
+// self-termination -> a non-net error, so http.Server.Serve returns it). It
+// drives the serve-exit path deterministically WITHOUT a real socket.
+type deadlockProbeLn struct {
+	addr   net.Addr
+	fail   chan struct{}
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (l *deadlockProbeLn) Accept() (net.Conn, error) {
+	select {
+	case <-l.fail:
+		return nil, errors.New("simulated unexpected serve failure")
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+func (l *deadlockProbeLn) Close() error   { l.once.Do(func() { close(l.closed) }); return nil }
+func (l *deadlockProbeLn) Addr() net.Addr { return l.addr }
+
+func TestServeExitDoesNotDeadlockConcurrentWait_6401(t *testing.T) {
+	ln := &deadlockProbeLn{
+		addr:   &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8080},
+		fail:   make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+	srv := NewServer(Config{
+		Addr:       "127.0.0.1:8080",
+		ListenFunc: func(_, _ string) (net.Listener, error) { return ln, nil },
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// The leg is serving (parked at Accept).
+	if srv.EffectiveHTTPAddr() == "" {
+		t.Fatal("HTTP leg not serving after Start")
+	}
+
+	// Start Wait() concurrently: it acquires lifeMu and blocks in wg.Wait()
+	// while the leg is parked — HOLDING lifeMu the whole time. This is the exact
+	// shutdown ordering that made the round-2 lifeMu-guarded dead marking
+	// deadlock.
+	waitDone := make(chan struct{})
+	go func() { srv.Wait(); close(waitDone) }()
+	// Let Wait acquire the (uncontended) lifeMu and enter wg.Wait().
+	time.Sleep(100 * time.Millisecond)
+
+	// Trigger the UNEXPECTED serve-exit. With the lifeMu-guarded marking the leg
+	// goroutine would block on lifeMu (held by Wait) and never wg.Done ->
+	// permanent hang. With the atomic marking it stores dead lock-free, returns,
+	// wg.Done -> Wait unblocks.
+	close(ln.fail)
+
+	select {
+	case <-waitDone:
+		// No deadlock — the fix holds.
+	case <-time.After(3 * time.Second):
+		t.Fatal("Server.Wait() deadlocked with a concurrent unexpected serve-exit (#6401 lock-ordering regression)")
+	}
+
+	// The leg ended up dead, so the effective-listener snapshot reports it not
+	// serving (Failed at the daemon layer).
+	if got := srv.EffectiveHTTPAddr(); got != "" {
+		t.Errorf("after serve-exit, EffectiveHTTPAddr = %q, want \"\" (leg marked dead)", got)
+	}
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -32,6 +32,7 @@ import (
 	"github.com/psaab/xpf/pkg/natpoolalarm"
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
+	"github.com/psaab/xpf/pkg/sysservices"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
@@ -83,11 +84,19 @@ type CLI struct {
 	// write-health for `show flow-monitoring statistics` (#2464). Nil
 	// leaves the show reporting "no flow export configured".
 	flowCollectorHealthFn func() []flowexport.ExporterCollectorHealth
-	hostname              string
-	username              string
-	userClass             string
-	version               string
-	startTime             time.Time
+	// listenersFn returns the EFFECTIVE (post-clamp, post-bind) management
+	// listener addresses `show system services` reports (#6385). The daemon
+	// wires it to Daemon.effectiveListeners — the SAME snapshot the remote gRPC
+	// renderer reads — so the local console and the remote `cli` can never
+	// disagree. Nil when the CLI is spawned outside the daemon (offline recovery
+	// / unit test): showSystemServices falls back to the documented loopback
+	// defaults.
+	listenersFn func() sysservices.Listeners
+	hostname    string
+	username    string
+	userClass   string
+	version     string
+	startTime   time.Time
 
 	vrrpMgr *vrrp.Manager
 
@@ -259,6 +268,15 @@ func (c *CLI) SetDDNSStatsFn(fn func() *dhcpserver.DDNSStats) {
 // `show flow-monitoring statistics` reporting "no flow export configured".
 func (c *CLI) SetFlowCollectorHealthFn(fn func() []flowexport.ExporterCollectorHealth) {
 	c.flowCollectorHealthFn = fn
+}
+
+// SetListenersFn wires the effective management-listener snapshot source for
+// `show system services` (#6385). The daemon passes Daemon.effectiveListeners —
+// the SAME snapshot the remote gRPC renderer reads — so the local console and
+// the remote `cli` report identical, post-bind listener addresses. Nil leaves
+// showSystemServices on the documented loopback defaults (offline / unit test).
+func (c *CLI) SetListenersFn(fn func() sysservices.Listeners) {
+	c.listenersFn = fn
 }
 
 // SetDDNSOwnedRecordsFn sets a callback for retrieving the DHCP

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -266,7 +266,10 @@ func (c *CLI) effectiveListeners() sysservices.Listeners {
 	if c.listenersFn != nil {
 		return c.listenersFn()
 	}
-	return sysservices.Listeners{GRPC: "127.0.0.1:50051", HTTP: "127.0.0.1:8080"}
+	return sysservices.Listeners{
+		GRPC: sysservices.Listener{Addr: "127.0.0.1:50051", State: sysservices.StateListening},
+		HTTP: sysservices.Listener{Addr: "127.0.0.1:8080", State: sysservices.StateListening},
+	}
 }
 
 func (c *CLI) showSystemServices() error {

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
+	"github.com/psaab/xpf/pkg/sysservices"
 	"golang.org/x/sys/unix"
 )
 
@@ -256,6 +257,18 @@ func (c *CLI) showSystemNTP() error {
 
 // printChronyTracking parses chronyc tracking output and prints key fields.
 
+// effectiveListeners returns the shared management-listener snapshot for
+// `show system services` (#6385): the daemon-owned effective addresses when
+// wired (SetListenersFn -> Daemon.effectiveListeners), else the documented
+// loopback defaults for an offline / no-daemon CLI. The defaults preserve the
+// pre-#6385 output shape when there is no live bind to read.
+func (c *CLI) effectiveListeners() sysservices.Listeners {
+	if c.listenersFn != nil {
+		return c.listenersFn()
+	}
+	return sysservices.Listeners{GRPC: "127.0.0.1:50051", HTTP: "127.0.0.1:8080"}
+}
+
 func (c *CLI) showSystemServices() error {
 	cfg := c.store.ActiveConfig()
 	if cfg == nil {
@@ -265,10 +278,16 @@ func (c *CLI) showSystemServices() error {
 
 	fmt.Println("System services:")
 
-	// gRPC
-	fmt.Println("  gRPC:           127.0.0.1:50051 (always on)")
-	// HTTP REST
-	fmt.Println("  HTTP REST:      127.0.0.1:8080 (always on)")
+	// #6385: report the EFFECTIVE (post-clamp, post-bind) listener addresses
+	// from the shared daemon-owned snapshot, not hardcoded requested defaults.
+	// This is the SAME snapshot and the SAME renderer (Listeners.Lines) the
+	// remote gRPC path uses, so the local console and the remote `cli` can never
+	// disagree. listenersFn is nil only when the CLI is spawned outside the
+	// daemon (offline recovery / unit test), where we fall back to the documented
+	// loopback defaults.
+	for _, line := range c.effectiveListeners().Lines() {
+		fmt.Println(line)
+	}
 
 	// SSH
 	if cfg.System.Services != nil && cfg.System.Services.SSH != nil {

--- a/pkg/cli/cli_show_system_listeners_6385_test.go
+++ b/pkg/cli/cli_show_system_listeners_6385_test.go
@@ -42,7 +42,10 @@ func newCLIActiveConfigStore(t *testing.T) *CLI {
 func TestShowSystemServicesEffectiveListenersLocal(t *testing.T) {
 	c := newCLIActiveConfigStore(t)
 	c.listenersFn = func() sysservices.Listeners {
-		return sysservices.Listeners{GRPC: "127.0.0.1:50055"} // HTTP empty => disabled
+		return sysservices.Listeners{
+			GRPC: sysservices.Listener{Addr: "127.0.0.1:50055", State: sysservices.StateListening},
+			HTTP: sysservices.Listener{State: sysservices.StateDisabled},
+		}
 	}
 
 	out := captureStdout(t, func() {

--- a/pkg/cli/cli_show_system_listeners_6385_test.go
+++ b/pkg/cli/cli_show_system_listeners_6385_test.go
@@ -1,0 +1,84 @@
+// RED-on-revert net for #6385 (local console surface): the local CLI
+// `show system services` renderer (cli_show_system.go showSystemServices) must
+// report the EFFECTIVE (post-clamp, post-bind) management-listener addresses
+// from the shared daemon-owned snapshot (SetListenersFn ->
+// Daemon.effectiveListeners), the SAME source the remote gRPC renderer reads,
+// not the fixed `127.0.0.1:50051 (always on)` / `127.0.0.1:8080 (always on)`
+// defaults it used to print unconditionally. Pairs with the gRPC-path net in
+// pkg/grpcapi/server_show_system_listeners_6385_test.go so BOTH surfaces are
+// covered — the local/remote divergence is exactly what dropped the #6384
+// A10-b2-F5 attempt.
+//
+// Reverting the render substitution makes this go RED: the relocated gRPC bind
+// and the "disabled" HTTP state vanish and the hardcoded defaults reappear.
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/sysservices"
+)
+
+func newCLIActiveConfigStore(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	if _, err := store.LoadSet("set system host-name xpf-test"); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	return &CLI{store: store}
+}
+
+// TestShowSystemServicesEffectiveListenersLocal pins the local console renderer
+// to the effective listener snapshot: a relocated gRPC bind and a disabled HTTP
+// REST listener, never the hardcoded requested defaults.
+func TestShowSystemServicesEffectiveListenersLocal(t *testing.T) {
+	c := newCLIActiveConfigStore(t)
+	c.listenersFn = func() sysservices.Listeners {
+		return sysservices.Listeners{GRPC: "127.0.0.1:50055"} // HTTP empty => disabled
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.showSystemServices(); err != nil {
+			t.Fatalf("showSystemServices(): %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "gRPC:           127.0.0.1:50055") {
+		t.Errorf("gRPC listener not reported at its EFFECTIVE bind 127.0.0.1:50055:\n%s", out)
+	}
+	if !strings.Contains(out, "HTTP REST:      disabled") {
+		t.Errorf("disabled HTTP REST listener not reported as disabled:\n%s", out)
+	}
+	if strings.Contains(out, "127.0.0.1:8080") {
+		t.Errorf("renderer still emits the hardcoded 127.0.0.1:8080 default:\n%s", out)
+	}
+	if strings.Contains(out, "always on") {
+		t.Errorf("renderer still emits the stale (always on) suffix:\n%s", out)
+	}
+}
+
+// TestShowSystemServicesListenersFnNilFallbackLocal pins the offline / no-daemon
+// fallback: with no snapshot source wired the renderer falls back to the
+// documented loopback defaults so the output shape is preserved off-daemon.
+func TestShowSystemServicesListenersFnNilFallbackLocal(t *testing.T) {
+	c := newCLIActiveConfigStore(t) // listenersFn left nil
+	out := captureStdout(t, func() {
+		if err := c.showSystemServices(); err != nil {
+			t.Fatalf("showSystemServices(): %v", err)
+		}
+	})
+	if !strings.Contains(out, "gRPC:           127.0.0.1:50051") {
+		t.Errorf("nil-fn fallback dropped the default gRPC listener:\n%s", out)
+	}
+	if !strings.Contains(out, "HTTP REST:      127.0.0.1:8080") {
+		t.Errorf("nil-fn fallback dropped the default HTTP REST listener:\n%s", out)
+	}
+}

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -278,13 +278,16 @@ from a serving listener's bare address:
 - **HTTP REST** — `d.mgmt.effectiveHTTPListener()`. `Disabled` when the
   reconciler is absent (empty `--api-addr`, listener never started); `Failed`
   (reporting the attempted `lastHTTPAttempt`) when it was configured but the boot
-  bind never converged (`curSet` false); else `Listening` on the ACTUAL bound
-  address read from the live server (`api.Server.EffectiveHTTPAddr()` →
-  `httpLeg.ln.Addr()`, so an ephemeral `:0` resolves to its concrete port and a
-  wildcard/hostname bind is normalized), falling back to the converged
-  `m.cur.addr`. A day-2 rebind failure RETAINS the old serving leg (`curSet`
-  stays true), so this reports the address still serving, not the failed new
-  bind.
+  bind never converged (`curSet` false); `Failed` ALSO when a converged leg's
+  serve loop later exits UNEXPECTEDLY — `api.Server.EffectiveHTTPAddr()` returns
+  `""` for a leg the serve goroutine marked `dead` (listener.go), symmetric with
+  the gRPC serve-exit clear, so a dead HTTP listener is never reported
+  `Listening`; else `Listening` on the ACTUAL bound address read from the live
+  server (`EffectiveHTTPAddr()` → `httpLeg.ln.Addr()`, so an ephemeral `:0`
+  resolves to its concrete port and a wildcard/hostname bind is normalized). A
+  day-2 rebind failure RETAINS the old serving leg (its socket stays live →
+  `EffectiveHTTPAddr` non-empty), so this reports the address still serving, not
+  the failed new bind.
 
 BOTH render surfaces read this ONE snapshot: the remote gRPC renderer via
 `grpcapi.Config.ListenersFn` and the local console CLI via `cli.SetListenersFn`,

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -257,22 +257,43 @@ credential revocation is enforced even on an apply that returns early
   serialized by its mutex and the apply semaphore, so a newer generation never
   completes behind an older one.
 
-#### Effective-listener snapshot for `show system services` (#6385)
+#### Effective-listener snapshot for `show system services` (#6385/#6401)
 
-`show system services` reports the EFFECTIVE (post-clamp, post-bind) management
-listeners, not the requested/config-declared addresses. `Daemon.effectiveListeners`
-(`daemon_run_servers.go`) builds one `sysservices.Listeners` snapshot — gRPC from
-`grpcSrv.EffectiveAddr()` (the address recorded after the #5035 loopback clamp and
-`net.Listen`; falls back to `--grpc-addr` in the pre-bind window), HTTP REST from
-`d.mgmt.effectiveHTTPAddr()` (the converged `m.cur.addr`, `""` → rendered
-`disabled` when `--api-addr` is empty and the listener was never started). BOTH
-render surfaces read this ONE snapshot: the remote gRPC renderer via
+`show system services` reports the EFFECTIVE STATE of each management listener,
+not the requested/config-declared addresses. `Daemon.effectiveListeners`
+(`daemon_run_servers.go`) builds one `sysservices.Listeners` snapshot. Each row
+is a `sysservices.Listener{Addr, State}` where `State` ∈ {`Listening`, `Failed`,
+`Disabled`} (#6401) — so a CONFIGURED-but-FAILED bind is reported as
+`addr (bind failed)`, distinct from a genuinely-off listener's `disabled` and
+from a serving listener's bare address:
+
+- **gRPC** — `grpcSrv.EffectiveListener()`. The gRPC server records its own
+  lifecycle (`grpcListenState`): `Listening` with the actual bound address
+  (`lis.Addr()`, post-#5035 loopback clamp), `Failed` on a `net.Listen` error or
+  once the serve loop exits (the bound address is CLEARED so a dead server never
+  reports a stale bind), and — in the brief pre-bind startup window — `Listening`
+  on the requested `--grpc-addr`. gRPC is always configured, so it is never
+  `Disabled`. Before the server is even constructed, `effectiveListeners`
+  synthesizes pre-bind `Listening` on `--grpc-addr`.
+- **HTTP REST** — `d.mgmt.effectiveHTTPListener()`. `Disabled` when the
+  reconciler is absent (empty `--api-addr`, listener never started); `Failed`
+  (reporting the attempted `lastHTTPAttempt`) when it was configured but the boot
+  bind never converged (`curSet` false); else `Listening` on the ACTUAL bound
+  address read from the live server (`api.Server.EffectiveHTTPAddr()` →
+  `httpLeg.ln.Addr()`, so an ephemeral `:0` resolves to its concrete port and a
+  wildcard/hostname bind is normalized), falling back to the converged
+  `m.cur.addr`. A day-2 rebind failure RETAINS the old serving leg (`curSet`
+  stays true), so this reports the address still serving, not the failed new
+  bind.
+
+BOTH render surfaces read this ONE snapshot: the remote gRPC renderer via
 `grpcapi.Config.ListenersFn` and the local console CLI via `cli.SetListenersFn`,
 both formatting through `sysservices.Listeners.Lines`, so the two surfaces can
 never disagree. Before #6385 both renderers hardcoded
-`127.0.0.1:50051 / 127.0.0.1:8080 (always on)`, so a relocated, clamped, or
-disabled listener was reported wrong; the remote gRPC path (the common operator
-path) was the one a local-only fix left unfixed (the dropped #6384 A10-b2-F5).
+`127.0.0.1:50051 / 127.0.0.1:8080 (always on)`, so a relocated, clamped, failed,
+or disabled listener was reported wrong; the remote gRPC path (the common
+operator path) was the one a local-only fix left unfixed (the dropped #6384
+A10-b2-F5).
 
 ## Cluster mode
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -257,6 +257,23 @@ credential revocation is enforced even on an apply that returns early
   serialized by its mutex and the apply semaphore, so a newer generation never
   completes behind an older one.
 
+#### Effective-listener snapshot for `show system services` (#6385)
+
+`show system services` reports the EFFECTIVE (post-clamp, post-bind) management
+listeners, not the requested/config-declared addresses. `Daemon.effectiveListeners`
+(`daemon_run_servers.go`) builds one `sysservices.Listeners` snapshot — gRPC from
+`grpcSrv.EffectiveAddr()` (the address recorded after the #5035 loopback clamp and
+`net.Listen`; falls back to `--grpc-addr` in the pre-bind window), HTTP REST from
+`d.mgmt.effectiveHTTPAddr()` (the converged `m.cur.addr`, `""` → rendered
+`disabled` when `--api-addr` is empty and the listener was never started). BOTH
+render surfaces read this ONE snapshot: the remote gRPC renderer via
+`grpcapi.Config.ListenersFn` and the local console CLI via `cli.SetListenersFn`,
+both formatting through `sysservices.Listeners.Lines`, so the two surfaces can
+never disagree. Before #6385 both renderers hardcoded
+`127.0.0.1:50051 / 127.0.0.1:8080 (always on)`, so a relocated, clamped, or
+disabled listener was reported wrong; the remote gRPC path (the common operator
+path) was the one a local-only fix left unfixed (the dropped #6384 A10-b2-F5).
+
 ## Cluster mode
 
 Detected by the presence of `/etc/xpf/node-id` (contents `0` or `1`).

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -679,6 +679,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 		shell.SetSurfaceADDNSStatusFn(d.SurfaceAStatus)
 		shell.SetSurfaceADDNSForceFn(d.ForceDDNSUpdate)
 		shell.SetFlowCollectorHealthFn(d.FlowCollectorHealth)
+		// #6385: the local console `show system services` renderer reports the
+		// EFFECTIVE post-bind listener addresses from the SAME daemon-owned
+		// snapshot the remote gRPC renderer reads (grpcapi.Config.ListenersFn), so
+		// local and remote never disagree.
+		shell.SetListenersFn(d.effectiveListeners)
 		shell.SetVRRPManager(d.vrrpMgr)
 		shell.SetFabricPeer(func() []string {
 			var addrs []string

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -21,28 +21,29 @@ import (
 )
 
 // effectiveListeners builds the daemon-owned snapshot of the EFFECTIVE
-// (post-clamp, post-bind) management-listener addresses `show system services`
-// reports (#6385). BOTH renderers — the remote gRPC path (Config.ListenersFn)
-// and the local console CLI (SetListenersFn) — read this ONE method, so the two
-// surfaces can never disagree (the divergence that dropped the #6384 A10-b2-F5
-// attempt).
+// management-listener STATE `show system services` reports (#6385/#6401). BOTH
+// renderers — the remote gRPC path (Config.ListenersFn) and the local console
+// CLI (SetListenersFn) — read this ONE method, so the two surfaces can never
+// disagree (the divergence that dropped the #6384 A10-b2-F5 attempt).
 //
-//   - gRPC: the effective serving address recorded by the gRPC server after its
-//     #5035 loopback clamp and net.Listen; falls back to the requested
-//     --grpc-addr in the brief pre-bind window (or if the server is not yet
-//     constructed).
-//   - HTTP REST: the converged bind address from the management reconciler, or
-//     "" (rendered "disabled") when the reconciler is absent — an empty
-//     --api-addr, where Daemon.Run never started the HTTP listener.
+//   - gRPC: the primary gRPC listener's state (EffectiveListener) — Listening
+//     with the actual bound address, Failed on a bind failure / serve exit, or
+//     Listening on the requested --grpc-addr in the brief pre-bind window.
+//     Before the server is even constructed, report the requested address as
+//     Listening (pre-bind).
+//   - HTTP REST: the reconciler's state (effectiveHTTPListener) — Listening with
+//     the actual bound address, Failed on a boot bind failure, or Disabled when
+//     the reconciler is absent (empty --api-addr, listener never started).
 func (d *Daemon) effectiveListeners() sysservices.Listeners {
 	var ls sysservices.Listeners
 	if d.grpcSrv != nil {
-		ls.GRPC = d.grpcSrv.EffectiveAddr()
+		ls.GRPC = d.grpcSrv.EffectiveListener()
+	} else {
+		// Server not yet constructed — the pre-bind startup window. gRPC always
+		// binds on loopback, so report the requested address as Listening.
+		ls.GRPC = sysservices.Listener{Addr: d.opts.GRPCAddr, State: sysservices.StateListening}
 	}
-	if ls.GRPC == "" {
-		ls.GRPC = d.opts.GRPCAddr
-	}
-	ls.HTTP = d.mgmt.effectiveHTTPAddr()
+	ls.HTTP = d.mgmt.effectiveHTTPListener()
 	return ls
 }
 

--- a/pkg/daemon/daemon_run_servers.go
+++ b/pkg/daemon/daemon_run_servers.go
@@ -16,8 +16,35 @@ import (
 	"github.com/psaab/xpf/pkg/lldp"
 	"github.com/psaab/xpf/pkg/logging"
 	"github.com/psaab/xpf/pkg/rpm"
+	"github.com/psaab/xpf/pkg/sysservices"
 	"github.com/psaab/xpf/pkg/webmgmt"
 )
+
+// effectiveListeners builds the daemon-owned snapshot of the EFFECTIVE
+// (post-clamp, post-bind) management-listener addresses `show system services`
+// reports (#6385). BOTH renderers — the remote gRPC path (Config.ListenersFn)
+// and the local console CLI (SetListenersFn) — read this ONE method, so the two
+// surfaces can never disagree (the divergence that dropped the #6384 A10-b2-F5
+// attempt).
+//
+//   - gRPC: the effective serving address recorded by the gRPC server after its
+//     #5035 loopback clamp and net.Listen; falls back to the requested
+//     --grpc-addr in the brief pre-bind window (or if the server is not yet
+//     constructed).
+//   - HTTP REST: the converged bind address from the management reconciler, or
+//     "" (rendered "disabled") when the reconciler is absent — an empty
+//     --api-addr, where Daemon.Run never started the HTTP listener.
+func (d *Daemon) effectiveListeners() sysservices.Listeners {
+	var ls sysservices.Listeners
+	if d.grpcSrv != nil {
+		ls.GRPC = d.grpcSrv.EffectiveAddr()
+	}
+	if ls.GRPC == "" {
+		ls.GRPC = d.opts.GRPCAddr
+	}
+	ls.HTTP = d.mgmt.effectiveHTTPAddr()
+	return ls
+}
 
 // #5054/#5961: transport commit-wiring seams.
 //
@@ -195,6 +222,11 @@ func (d *Daemon) startGRPCServer(ctx context.Context, wg *sync.WaitGroup, eventB
 			return ""
 		}(),
 		FwdSampler: fwdSampler,
+		// #6385: the remote gRPC `show system services` renderer reports the
+		// EFFECTIVE post-bind listener addresses from this daemon-owned snapshot,
+		// the SAME source the local console CLI reads (shell.SetListenersFn), so
+		// the two surfaces can never diverge.
+		ListenersFn: d.effectiveListeners,
 	})
 	d.grpcSrv = grpcSrv
 	wg.Add(1)

--- a/pkg/daemon/effective_listeners_6401_test.go
+++ b/pkg/daemon/effective_listeners_6401_test.go
@@ -10,8 +10,12 @@ package daemon
 
 import (
 	"context"
+	"errors"
+	"net"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/api"
 	"github.com/psaab/xpf/pkg/sysservices"
@@ -78,5 +82,75 @@ func TestEffectiveHTTPListenerEphemeralPort(t *testing.T) {
 	}
 	if got.Addr == "" || strings.HasSuffix(got.Addr, ":0") {
 		t.Errorf("ephemeral bind addr not resolved to a concrete port: %q", got.Addr)
+	}
+}
+
+// serveExitLn is an in-memory listener whose Accept blocks until either Close
+// (a requested shutdown → net.ErrClosed) or fail is closed (an UNEXPECTED
+// self-termination → a non-net error, so http.Server.Serve returns it). It
+// drives the serve-exit path WITHOUT a real socket (the review sandbox blocks
+// them).
+type serveExitLn struct {
+	addr   net.Addr
+	fail   chan struct{}
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (l *serveExitLn) Accept() (net.Conn, error) {
+	select {
+	case <-l.fail:
+		return nil, errors.New("simulated unexpected serve failure")
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+func (l *serveExitLn) Close() error   { l.once.Do(func() { close(l.closed) }); return nil }
+func (l *serveExitLn) Addr() net.Addr { return l.addr }
+
+// TestEffectiveHTTPListenerServeExitFails pins the #6401 HTTP↔gRPC SYMMETRY
+// fold: when a CONVERGED HTTP leg's serve loop exits UNEXPECTEDLY (not a
+// requested shutdown), `show system services` must report the listener Failed —
+// NOT StateListening on a dead socket. Before the fold the reconciler reported
+// Listening on the dead listener's address (curSet stayed true and
+// EffectiveHTTPAddr returned the dead leg's Addr), asymmetric with the gRPC
+// serve-exit clear.
+func TestEffectiveHTTPListenerServeExitFails(t *testing.T) {
+	ln := &serveExitLn{
+		addr:   &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8080},
+		fail:   make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+	cfg := api.Config{
+		Addr:       "127.0.0.1:8080",
+		ListenFunc: func(_, _ string) (net.Listener, error) { return ln, nil },
+	}
+	m := newManagementReconciler(&Daemon{}, api.Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := m.startTo(ctx, cfg); err != nil {
+		t.Fatalf("startTo: %v", err)
+	}
+	// Converged and serving.
+	if got := m.effectiveHTTPListener(); got.State != sysservices.StateListening {
+		t.Fatalf("initial state = %v, want StateListening: %+v", got.State, got)
+	}
+
+	// Trigger an UNEXPECTED serve exit (not a requested shutdown).
+	close(ln.fail)
+
+	// The leg's serve goroutine marks the leg dead asynchronously; poll until
+	// the reconciler reports Failed (with a generous bound so a GREEN run
+	// finishes in a few ms and a RED run trips cleanly, not a hang).
+	var got sysservices.Listener
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if got = m.effectiveHTTPListener(); got.State == sysservices.StateFailed {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got.State != sysservices.StateFailed {
+		t.Fatalf("HTTP serve exit not reported Failed (still Listening on a dead leg): %+v", got)
 	}
 }

--- a/pkg/daemon/effective_listeners_6401_test.go
+++ b/pkg/daemon/effective_listeners_6401_test.go
@@ -1,0 +1,82 @@
+// RED-on-revert net for the #6401 fold: the HTTP REST listener state the
+// `show system services` snapshot reports (managementReconciler.effectiveHTTPListener)
+// must DISTINGUISH three states — Disabled (no --api-addr, nil reconciler),
+// Failed (configured but the boot bind failed), and Listening (converged). The
+// pre-fold accessor returned a bare address ("" for BOTH disabled and failed),
+// so a failed bind was misreported as "disabled". These assert the three states
+// are distinct, and that a Listening bind reports the ACTUAL bound address (an
+// ephemeral :0 resolves to a concrete port).
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/api"
+	"github.com/psaab/xpf/pkg/sysservices"
+)
+
+func TestEffectiveHTTPListenerStatesDistinct(t *testing.T) {
+	// Disabled: nil reconciler — an empty --api-addr, where Daemon.Run never
+	// started the HTTP listener.
+	var nilM *managementReconciler
+	if got := nilM.effectiveHTTPListener(); got.State != sysservices.StateDisabled {
+		t.Errorf("nil reconciler state = %v, want StateDisabled: %+v", got.State, got)
+	}
+
+	// Failed: configured but the boot bind failed (fake factory refuses the
+	// addr, so startTo returns an error and curSet stays false).
+	reg := newFakeReg()
+	reg.failAddr["10.0.0.1:8080"] = true
+	mFail := newTestMgmt(reg)
+	if err := mFail.startTo(context.Background(), cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err == nil {
+		t.Fatal("startTo should fail when the fake factory refuses the bind")
+	}
+	failLn := mFail.effectiveHTTPListener()
+	if failLn.State != sysservices.StateFailed {
+		t.Errorf("failed boot bind state = %v, want StateFailed: %+v", failLn.State, failLn)
+	}
+	if failLn.Addr != "10.0.0.1:8080" {
+		t.Errorf("failed listener addr = %q, want the attempted 10.0.0.1:8080", failLn.Addr)
+	}
+
+	// Listening: converged bind (fake factory accepts).
+	regOK := newFakeReg()
+	mOK := newTestMgmt(regOK)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := mOK.startTo(ctx, cfgFor(regOK, "10.0.0.1:8080", false, "", nil)); err != nil {
+		t.Fatalf("startTo: %v", err)
+	}
+	if got := mOK.effectiveHTTPListener(); got.State != sysservices.StateListening {
+		t.Errorf("converged bind state = %v, want StateListening: %+v", got.State, got)
+	}
+
+	// The three states are mutually distinct — the crux of the fold.
+	if sysservices.StateDisabled == sysservices.StateFailed ||
+		sysservices.StateFailed == sysservices.StateListening {
+		t.Fatal("listener states are not distinct")
+	}
+}
+
+// TestEffectiveHTTPListenerEphemeralPort drives a REAL bind on 127.0.0.1:0 and
+// asserts the reported address is the concrete ephemeral port the socket bound,
+// not the requested ":0" — the #6401 point-4 fold that sources the address from
+// the live listener's Addr (api.Server.EffectiveHTTPAddr) rather than the
+// requested endpoint fingerprint.
+func TestEffectiveHTTPListenerEphemeralPort(t *testing.T) {
+	m := newManagementReconciler(&Daemon{}, api.Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := m.startTo(ctx, api.Config{Addr: "127.0.0.1:0"}); err != nil {
+		t.Fatalf("startTo real bind: %v", err)
+	}
+	got := m.effectiveHTTPListener()
+	if got.State != sysservices.StateListening {
+		t.Fatalf("real bind state = %v, want StateListening: %+v", got.State, got)
+	}
+	if got.Addr == "" || strings.HasSuffix(got.Addr, ":0") {
+		t.Errorf("ephemeral bind addr not resolved to a concrete port: %q", got.Addr)
+	}
+}

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -148,12 +148,15 @@ func (m *managementReconciler) startTo(ctx context.Context, next api.Config) err
 //     failed one.
 //   - configured but never converged (curSet false) → StateFailed: the boot
 //     bind failed. Reports lastHTTPAttempt (the address it could not bind).
-//   - converged → StateListening: reports the ACTUAL bound address from the live
-//     server (EffectiveHTTPAddr — so an ephemeral :0 resolves to its concrete
-//     port), falling back to the converged requested fingerprint (m.cur.addr) if
-//     the server can't report it. A day-2 rebind failure RETAINS the old serving
-//     leg (curSet stays true), so this correctly reports the address still
-//     serving, not the failed new bind.
+//   - converged but the live HTTP leg is no longer serving (an UNEXPECTED serve
+//     exit — EffectiveHTTPAddr returns "") → StateFailed, symmetric with the
+//     gRPC serve-exit clear. Reports m.cur.addr (or lastHTTPAttempt). A day-2
+//     rebind FAILURE is NOT this case: it RETAINS the old serving leg (its
+//     socket stays live → EffectiveHTTPAddr non-empty), so it correctly stays
+//     Listening.
+//   - converged and serving → StateListening: reports the ACTUAL bound address
+//     from the live server (EffectiveHTTPAddr — so an ephemeral :0 resolves to
+//     its concrete port).
 func (m *managementReconciler) effectiveHTTPListener() sysservices.Listener {
 	if m == nil {
 		return sysservices.Listener{State: sysservices.StateDisabled}
@@ -163,13 +166,20 @@ func (m *managementReconciler) effectiveHTTPListener() sysservices.Listener {
 	if !m.curSet {
 		return sysservices.Listener{Addr: m.lastHTTPAttempt, State: sysservices.StateFailed}
 	}
-	addr := m.cur.addr
+	var bound string
 	if m.srv != nil {
-		if bound := m.srv.EffectiveHTTPAddr(); bound != "" {
-			addr = bound
-		}
+		bound = m.srv.EffectiveHTTPAddr()
 	}
-	return sysservices.Listener{Addr: addr, State: sysservices.StateListening}
+	if bound == "" {
+		// The converged HTTP leg died (an unexpected serve exit): report Failed,
+		// not a stale Listening on a dead socket.
+		addr := m.cur.addr
+		if addr == "" {
+			addr = m.lastHTTPAttempt
+		}
+		return sysservices.Listener{Addr: addr, State: sysservices.StateFailed}
+	}
+	return sysservices.Listener{Addr: bound, State: sysservices.StateListening}
 }
 
 // reconcile matches the live listener + auth snapshot to cfg. It returns a

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -130,6 +130,25 @@ func (m *managementReconciler) startTo(ctx context.Context, next api.Config) err
 	return nil
 }
 
+// effectiveHTTPAddr returns the effective (last-CONVERGED, actually-serving)
+// HTTP REST bind address for `show system services` (#6385). It reads the
+// converged per-leg fingerprint (m.cur.addr) — which advances only on a
+// successful (re)bind and is RETAINED on a failed rebind — so the reported
+// address is the one the listener is truly serving, not the requested config.
+// Empty when the listener never converged (boot bind failure); a nil reconciler
+// (empty --api-addr, HTTP disabled) is handled by the caller.
+func (m *managementReconciler) effectiveHTTPAddr() string {
+	if m == nil {
+		return ""
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.curSet {
+		return ""
+	}
+	return m.cur.addr
+}
+
 // reconcile matches the live listener + auth snapshot to cfg. It returns a
 // non-nil error ONLY when an endpoint replacement could not bind — in that case
 // the OLD listener is retained (fail-safe) and the next commit retries. An

--- a/pkg/daemon/management.go
+++ b/pkg/daemon/management.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/api"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/sysservices"
 )
 
 // managementReconciler owns the HTTP/HTTPS management-listener lifecycle so a
@@ -66,6 +67,12 @@ type managementReconciler struct {
 	srv    *api.Server  // single long-lived server; its HTTP/HTTPS legs reconcile in place (nil until started)
 	cur    mgmtEndpoint // last-CONVERGED per-leg fingerprint (a leg field advances only on that leg's successful reconcile)
 	curSet bool
+	// lastHTTPAttempt is the most-recent HTTP bind address the reconciler tried
+	// (desired.Addr), recorded BEFORE the bind attempt so a boot bind FAILURE
+	// (curSet stays false) can report the address it could not bind as
+	// `(bind failed)` in `show system services` (#6401). Distinct from cur.addr,
+	// which advances only on a successful bind.
+	lastHTTPAttempt string
 }
 
 // mgmtEndpoint fingerprints the listener-defining fields. An auth change does
@@ -122,6 +129,9 @@ func (m *managementReconciler) start(ctx context.Context) error {
 func (m *managementReconciler) startTo(ctx context.Context, next api.Config) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// Record the attempted HTTP bind BEFORE Start so a bind failure (curSet stays
+	// false) can report it as `(bind failed)` in `show system services` (#6401).
+	m.lastHTTPAttempt = next.Addr
 	srv := api.NewServer(next)
 	if err := srv.Start(ctx); err != nil {
 		return err
@@ -130,23 +140,36 @@ func (m *managementReconciler) startTo(ctx context.Context, next api.Config) err
 	return nil
 }
 
-// effectiveHTTPAddr returns the effective (last-CONVERGED, actually-serving)
-// HTTP REST bind address for `show system services` (#6385). It reads the
-// converged per-leg fingerprint (m.cur.addr) — which advances only on a
-// successful (re)bind and is RETAINED on a failed rebind — so the reported
-// address is the one the listener is truly serving, not the requested config.
-// Empty when the listener never converged (boot bind failure); a nil reconciler
-// (empty --api-addr, HTTP disabled) is handled by the caller.
-func (m *managementReconciler) effectiveHTTPAddr() string {
+// effectiveHTTPListener returns the effective STATE of the HTTP REST listener
+// for `show system services` (#6385/#6401):
+//
+//   - nil reconciler → StateDisabled: --api-addr was empty, so Daemon.Run never
+//     started the HTTP listener. A genuinely-off listener, distinct from a
+//     failed one.
+//   - configured but never converged (curSet false) → StateFailed: the boot
+//     bind failed. Reports lastHTTPAttempt (the address it could not bind).
+//   - converged → StateListening: reports the ACTUAL bound address from the live
+//     server (EffectiveHTTPAddr — so an ephemeral :0 resolves to its concrete
+//     port), falling back to the converged requested fingerprint (m.cur.addr) if
+//     the server can't report it. A day-2 rebind failure RETAINS the old serving
+//     leg (curSet stays true), so this correctly reports the address still
+//     serving, not the failed new bind.
+func (m *managementReconciler) effectiveHTTPListener() sysservices.Listener {
 	if m == nil {
-		return ""
+		return sysservices.Listener{State: sysservices.StateDisabled}
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if !m.curSet {
-		return ""
+		return sysservices.Listener{Addr: m.lastHTTPAttempt, State: sysservices.StateFailed}
 	}
-	return m.cur.addr
+	addr := m.cur.addr
+	if m.srv != nil {
+		if bound := m.srv.EffectiveHTTPAddr(); bound != "" {
+			addr = bound
+		}
+	}
+	return sysservices.Listener{Addr: addr, State: sysservices.StateListening}
 }
 
 // reconcile matches the live listener + auth snapshot to cfg. It returns a

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -169,13 +169,19 @@ type Server struct {
 	// `show system services` (#6385). Wired from Config.ListenersFn; nil in a
 	// no-daemon unit-test build.
 	listenersFn func() sysservices.Listeners
-	// effAddrMu guards effAddr, the effective (post-#5035 clamp, post-net.Listen)
-	// primary gRPC bind address recorded by Run once the listener binds. The
-	// daemon reads it (EffectiveAddr) to build the shared listener snapshot, so
-	// `show system services` reports the address the gRPC listener is actually
-	// serving, not the requested --grpc-addr.
-	effAddrMu          sync.Mutex
+	// requestedAddr is the primary gRPC bind requested at construction
+	// (--grpc-addr). Immutable, so it is read without effMu; it is the fallback
+	// address reported while pre-bind and on a bind failure (#6385/#6401).
+	requestedAddr string
+	// effMu guards the primary gRPC listener state Run records for the
+	// `show system services` effective-listener snapshot (#6385/#6401): effAddr
+	// is the actual bound address (post-#5035 clamp, post-net.Listen), effState
+	// tracks pre-bind → serving → failed. The daemon reads them via
+	// EffectiveListener so the CLI reports what the listener is truly doing, not
+	// the requested --grpc-addr.
+	effMu              sync.Mutex
 	effAddr            string
+	effState           grpcListenState
 	fabricPeerAddrFn   func() []string
 	fabricVRFDevice    string
 	peerSystemActionFn func(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error)
@@ -281,6 +287,7 @@ func NewServer(addr string, cfg Config) *Server {
 		fwdSampler:            cfg.FwdSampler,
 		startTime:             time.Now(),
 		addr:                  addr,
+		requestedAddr:         addr,
 		version:               cfg.Version,
 		fabricPeerAddrFn:      cfg.FabricPeerAddrFn,
 		fabricVRFDevice:       cfg.FabricVRFDevice,
@@ -288,20 +295,51 @@ func NewServer(addr string, cfg Config) *Server {
 	}
 }
 
-// EffectiveAddr returns the effective (post-#5035 loopback clamp,
-// post-net.Listen) primary gRPC bind address, or "" before the listener has
-// bound. The daemon reads it to build the shared `show system services`
-// listener snapshot (#6385).
-func (s *Server) EffectiveAddr() string {
-	s.effAddrMu.Lock()
-	defer s.effAddrMu.Unlock()
-	return s.effAddr
+// grpcListenState tracks the primary gRPC listener lifecycle for the
+// `show system services` effective-listener snapshot (#6385/#6401).
+type grpcListenState int
+
+const (
+	// grpcPreBind: constructed, Run has not yet bound the listener (the brief
+	// startup window). gRPC is loopback and essentially always binds, so this
+	// renders as Listening on the requested address rather than flagging a
+	// transient failure.
+	grpcPreBind grpcListenState = iota
+	// grpcListening: net.Listen succeeded and the serve loop is active.
+	grpcListening
+	// grpcFailed: net.Listen failed or the serve loop exited (Run returned) —
+	// the control plane is no longer serving on this listener.
+	grpcFailed
+)
+
+// EffectiveListener returns the effective state of the primary gRPC listener
+// for the shared `show system services` snapshot (#6385/#6401): Listening with
+// the actual bound address while serving, Failed on a bind failure / serve exit
+// (with the requested/last-known address), or — in the brief pre-bind startup
+// window — Listening on the requested address. gRPC is always configured, so it
+// is never reported Disabled.
+func (s *Server) EffectiveListener() sysservices.Listener {
+	s.effMu.Lock()
+	defer s.effMu.Unlock()
+	switch s.effState {
+	case grpcListening:
+		return sysservices.Listener{Addr: s.effAddr, State: sysservices.StateListening}
+	case grpcFailed:
+		addr := s.effAddr
+		if addr == "" {
+			addr = s.requestedAddr
+		}
+		return sysservices.Listener{Addr: addr, State: sysservices.StateFailed}
+	default: // grpcPreBind
+		return sysservices.Listener{Addr: s.requestedAddr, State: sysservices.StateListening}
+	}
 }
 
-func (s *Server) setEffectiveAddr(addr string) {
-	s.effAddrMu.Lock()
+func (s *Server) setListenState(addr string, state grpcListenState) {
+	s.effMu.Lock()
 	s.effAddr = addr
-	s.effAddrMu.Unlock()
+	s.effState = state
+	s.effMu.Unlock()
 }
 
 // Run starts the gRPC server and blocks until ctx is cancelled.
@@ -397,13 +435,17 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 	lis, err := net.Listen("tcp", s.addr)
 	if err != nil {
+		// The bind failed — record Failed so `show system services` reports the
+		// requested address as (bind failed), not as if it were serving
+		// (#6385/#6401). The daemon logs the returned error non-fatally.
+		s.setListenState("", grpcFailed)
 		return fmt.Errorf("gRPC listen: %w", err)
 	}
 	// Record the effective serving address (post-clamp, post-bind) so
 	// `show system services` reports what the primary gRPC listener actually
 	// bound, not the requested --grpc-addr (#6385). lis.Addr() is authoritative
 	// (e.g. a ":50051" wildcard clamp resolves to a concrete host:port).
-	s.setEffectiveAddr(lis.Addr().String())
+	s.setListenState(lis.Addr().String(), grpcListening)
 
 	srv := grpc.NewServer(
 		grpc.MaxRecvMsgSize(maxRecvMsgSize),
@@ -413,7 +455,15 @@ func (s *Server) Run(ctx context.Context) error {
 		grpc.StatsHandler(&configLockStatsHandler{s: s}),
 	)
 	slog.Info("gRPC server listening", "addr", s.addr)
-	return s.serveUntilDone(ctx, srv, lis)
+	// serveUntilDone returns when the serve loop exits (ctx cancel on a clean
+	// shutdown, or a Serve error). Either way the listener is no longer serving,
+	// so clear the bound address to Failed — a later local-console `show system
+	// services` must not report a stale bound address for a dead server
+	// (#6401). serveUntilDone is shared with the fabric listener, so the clear
+	// lives HERE (Run) and never in the shared helper.
+	runErr := s.serveUntilDone(ctx, srv, lis)
+	s.setListenState("", grpcFailed)
+	return runErr
 }
 
 // serveUntilDone registers the service on srv, serves lis, and on ctx

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/psaab/xpf/pkg/ra"
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/rpm"
+	"github.com/psaab/xpf/pkg/sysservices"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
 
@@ -121,6 +122,13 @@ type Config struct {
 	FabricPeerAddrFn func() []string    // returns peer fabric IPs (fab0, fab1; empty if standalone)
 	FabricVRFDevice  string             // VRF for fabric interface (e.g. "vrf-mgmt")
 	FwdSampler       *fwdstatus.Sampler // #881: 5s/1m/5m CPU windows for `show chassis forwarding`
+	// ListenersFn returns the EFFECTIVE (post-clamp, post-bind) management
+	// listener addresses `show system services` reports (#6385). The daemon
+	// wires it to Daemon.effectiveListeners so the remote gRPC renderer and the
+	// local CLI read ONE daemon-owned snapshot and can never disagree. nil in a
+	// unit-test / no-daemon build, where showSystemServices falls back to the
+	// documented loopback defaults.
+	ListenersFn func() sysservices.Listeners
 }
 
 // Server implements the BpfrxService gRPC service.
@@ -157,9 +165,20 @@ type Server struct {
 	startTime             time.Time
 	addr                  string
 	version               string
-	fabricPeerAddrFn      func() []string
-	fabricVRFDevice       string
-	peerSystemActionFn    func(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error)
+	// listenersFn returns the effective management-listener snapshot for
+	// `show system services` (#6385). Wired from Config.ListenersFn; nil in a
+	// no-daemon unit-test build.
+	listenersFn func() sysservices.Listeners
+	// effAddrMu guards effAddr, the effective (post-#5035 clamp, post-net.Listen)
+	// primary gRPC bind address recorded by Run once the listener binds. The
+	// daemon reads it (EffectiveAddr) to build the shared listener snapshot, so
+	// `show system services` reports the address the gRPC listener is actually
+	// serving, not the requested --grpc-addr.
+	effAddrMu          sync.Mutex
+	effAddr            string
+	fabricPeerAddrFn   func() []string
+	fabricVRFDevice    string
+	peerSystemActionFn func(ctx context.Context, req *pb.SystemActionRequest) (*pb.SystemActionResponse, error)
 	// peerZonePairSummaryFn is a test seam for the GetZonePairSummary peer
 	// fan-out leg (#3592). Production leaves it nil and proxyPeerZonePairSummary
 	// dials the real peer; a unit test wires it to observe the forwarded
@@ -265,7 +284,24 @@ func NewServer(addr string, cfg Config) *Server {
 		version:               cfg.Version,
 		fabricPeerAddrFn:      cfg.FabricPeerAddrFn,
 		fabricVRFDevice:       cfg.FabricVRFDevice,
+		listenersFn:           cfg.ListenersFn,
 	}
+}
+
+// EffectiveAddr returns the effective (post-#5035 loopback clamp,
+// post-net.Listen) primary gRPC bind address, or "" before the listener has
+// bound. The daemon reads it to build the shared `show system services`
+// listener snapshot (#6385).
+func (s *Server) EffectiveAddr() string {
+	s.effAddrMu.Lock()
+	defer s.effAddrMu.Unlock()
+	return s.effAddr
+}
+
+func (s *Server) setEffectiveAddr(addr string) {
+	s.effAddrMu.Lock()
+	s.effAddr = addr
+	s.effAddrMu.Unlock()
 }
 
 // Run starts the gRPC server and blocks until ctx is cancelled.
@@ -363,6 +399,11 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("gRPC listen: %w", err)
 	}
+	// Record the effective serving address (post-clamp, post-bind) so
+	// `show system services` reports what the primary gRPC listener actually
+	// bound, not the requested --grpc-addr (#6385). lis.Addr() is authoritative
+	// (e.g. a ":50051" wildcard clamp resolves to a concrete host:port).
+	s.setEffectiveAddr(lis.Addr().String())
 
 	srv := grpc.NewServer(
 		grpc.MaxRecvMsgSize(maxRecvMsgSize),

--- a/pkg/grpcapi/server_show_system.go
+++ b/pkg/grpcapi/server_show_system.go
@@ -175,7 +175,10 @@ func (s *Server) effectiveListeners() sysservices.Listeners {
 	if s.listenersFn != nil {
 		return s.listenersFn()
 	}
-	return sysservices.Listeners{GRPC: "127.0.0.1:50051", HTTP: "127.0.0.1:8080"}
+	return sysservices.Listeners{
+		GRPC: sysservices.Listener{Addr: "127.0.0.1:50051", State: sysservices.StateListening},
+		HTTP: sysservices.Listener{Addr: "127.0.0.1:8080", State: sysservices.StateListening},
+	}
 }
 
 func (s *Server) showSystemServices(buf *strings.Builder) {

--- a/pkg/grpcapi/server_show_system.go
+++ b/pkg/grpcapi/server_show_system.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
+	"github.com/psaab/xpf/pkg/sysservices"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -164,6 +165,19 @@ func (s *Server) showChassisEnvironment(buf *strings.Builder) {
 // showSystemServices renders gRPC/HTTP/SSH/WebManagement/DNS/NTP and
 // derived service-state summaries (security log, syslog, NetFlow,
 // IPFIX, AppID, RPM).
+
+// effectiveListeners returns the shared management-listener snapshot for
+// `show system services` (#6385): the daemon-owned effective addresses when
+// wired (Config.ListenersFn -> Daemon.effectiveListeners), else the documented
+// loopback defaults for a no-daemon unit-test build. The defaults preserve the
+// pre-#6385 output shape when there is no live bind to read.
+func (s *Server) effectiveListeners() sysservices.Listeners {
+	if s.listenersFn != nil {
+		return s.listenersFn()
+	}
+	return sysservices.Listeners{GRPC: "127.0.0.1:50051", HTTP: "127.0.0.1:8080"}
+}
+
 func (s *Server) showSystemServices(buf *strings.Builder) {
 	cfg := s.store.ActiveConfig()
 	if cfg == nil {
@@ -171,8 +185,17 @@ func (s *Server) showSystemServices(buf *strings.Builder) {
 		return
 	}
 	fmt.Fprintln(buf, "System services:")
-	fmt.Fprintln(buf, "  gRPC:           127.0.0.1:50051 (always on)")
-	fmt.Fprintln(buf, "  HTTP REST:      127.0.0.1:8080 (always on)")
+	// #6385: report the EFFECTIVE (post-clamp, post-bind) listener addresses
+	// from the shared daemon-owned snapshot, not the hardcoded requested
+	// defaults. listenersFn is nil only in a no-daemon unit-test build, where we
+	// fall back to the documented loopback defaults. This is the SAME snapshot
+	// and the SAME renderer (Listeners.Lines) the local CLI uses, so the remote
+	// gRPC path (the common operator path) and the local console can never
+	// disagree — the divergence that dropped the #6384 A10-b2-F5 attempt.
+	ls := s.effectiveListeners()
+	for _, line := range ls.Lines() {
+		fmt.Fprintln(buf, line)
+	}
 	if cfg.System.Services != nil {
 		if cfg.System.Services.SSH != nil {
 			rootLogin := cfg.System.Services.SSH.RootLogin

--- a/pkg/grpcapi/server_show_system_listeners_6385_test.go
+++ b/pkg/grpcapi/server_show_system_listeners_6385_test.go
@@ -150,7 +150,16 @@ func TestGRPCEffectiveListenerBindFailure(t *testing.T) {
 // serve loop exits the state clears to Failed so a stale bound address is not
 // reported for a dead server.
 func TestGRPCEffectiveListenerLifecycle(t *testing.T) {
-	s := NewServer("127.0.0.1:0", Config{})
+	const requested = "127.0.0.1:0"
+	s := NewServer(requested, Config{})
+
+	// PRE-BIND: before Run, EffectiveListener reports the requested address as
+	// Listening (gRPC always binds on loopback; the tiny pre-bind window is not
+	// flagged as a failure).
+	if pre := s.EffectiveListener(); pre.State != sysservices.StateListening || pre.Addr != requested {
+		t.Fatalf("pre-bind listener = %+v, want {Addr:%q State:Listening}", pre, requested)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
@@ -172,10 +181,22 @@ func TestGRPCEffectiveListenerLifecycle(t *testing.T) {
 		<-done
 		t.Fatalf("gRPC never reached bound Listening with a concrete port: %+v", ln)
 	}
+	boundAddr := ln.Addr // the concrete ephemeral port, e.g. 127.0.0.1:45321
 
+	// SERVE EXIT: after the serve loop returns, the state must clear to Failed
+	// AND the reported address must NOT be the stale concrete bound address — a
+	// regression that sets Failed but retains effAddr would still render the dead
+	// server at its old bound port. The cleared Failed reports the requested addr.
 	cancel()
 	<-done
-	if got := s.EffectiveListener(); got.State != sysservices.StateFailed {
-		t.Errorf("after serve exit, state = %v, want StateFailed (cleared): %+v", got.State, got)
+	got := s.EffectiveListener()
+	if got.State != sysservices.StateFailed {
+		t.Errorf("after serve exit, state = %v, want StateFailed: %+v", got.State, got)
+	}
+	if got.Addr == boundAddr {
+		t.Errorf("after serve exit, addr = %q still the STALE bound address (not cleared)", got.Addr)
+	}
+	if got.Addr != requested {
+		t.Errorf("after serve exit, addr = %q, want the cleared/requested %q", got.Addr, requested)
 	}
 }

--- a/pkg/grpcapi/server_show_system_listeners_6385_test.go
+++ b/pkg/grpcapi/server_show_system_listeners_6385_test.go
@@ -1,0 +1,88 @@
+// RED-on-revert net for #6385: the REMOTE gRPC `show system services` renderer
+// (server_show_system.go showSystemServices) — the path the remote `cli` binary
+// reaches, and the one the dropped #6384 A10-b2-F5 attempt left hardcoded — must
+// report the EFFECTIVE (post-clamp, post-bind) management-listener addresses
+// from the shared daemon-owned snapshot (Config.ListenersFn ->
+// Daemon.effectiveListeners), not the fixed `127.0.0.1:50051 (always on)` /
+// `127.0.0.1:8080 (always on)` defaults it used to print unconditionally.
+//
+// Reverting the render substitution (restoring the two hardcoded Fprintln
+// lines) makes this go RED: the relocated gRPC bind and the "disabled" HTTP
+// state vanish and the hardcoded 8080/50051 defaults reappear.
+package grpcapi
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/sysservices"
+)
+
+// newActiveConfigServer builds a Server whose store has a committed (non-nil)
+// active config, so showSystemServices proceeds past its nil-config guard.
+func newActiveConfigServer(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	if _, err := store.LoadSet("set system host-name xpf-test"); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	return &Server{store: store}
+}
+
+// TestShowSystemServicesEffectiveListenersGRPC pins that the gRPC renderer
+// reports the effective listener snapshot: a relocated gRPC bind and a disabled
+// HTTP REST listener, never the hardcoded requested defaults.
+func TestShowSystemServicesEffectiveListenersGRPC(t *testing.T) {
+	s := newActiveConfigServer(t)
+	// A relocated gRPC bind + an empty (disabled) HTTP REST listener — neither
+	// of which the pre-#6385 hardcoded renderer could ever produce.
+	s.listenersFn = func() sysservices.Listeners {
+		return sysservices.Listeners{GRPC: "127.0.0.1:50055"}
+	}
+
+	var buf strings.Builder
+	s.showSystemServices(&buf)
+	out := buf.String()
+
+	if !strings.Contains(out, "gRPC:           127.0.0.1:50055") {
+		t.Errorf("gRPC listener not reported at its EFFECTIVE bind 127.0.0.1:50055:\n%s", out)
+	}
+	// An empty --api-addr disables the REST listener; it must render "disabled",
+	// not the fixed `127.0.0.1:8080 (always on)`.
+	if !strings.Contains(out, "HTTP REST:      disabled") {
+		t.Errorf("disabled HTTP REST listener not reported as disabled:\n%s", out)
+	}
+	if strings.Contains(out, "127.0.0.1:8080") {
+		t.Errorf("renderer still emits the hardcoded 127.0.0.1:8080 default:\n%s", out)
+	}
+	if strings.Contains(out, "127.0.0.1:50051") {
+		t.Errorf("renderer still emits the hardcoded 127.0.0.1:50051 default:\n%s", out)
+	}
+	if strings.Contains(out, "always on") {
+		t.Errorf("renderer still emits the stale (always on) suffix:\n%s", out)
+	}
+}
+
+// TestShowSystemServicesListenersFnNilFallbackGRPC pins the no-daemon fallback:
+// with no snapshot source wired (a bare Server / unit-test build), the renderer
+// falls back to the documented loopback defaults so the output shape is
+// preserved off-daemon.
+func TestShowSystemServicesListenersFnNilFallbackGRPC(t *testing.T) {
+	s := newActiveConfigServer(t) // listenersFn left nil
+	var buf strings.Builder
+	s.showSystemServices(&buf)
+	out := buf.String()
+	if !strings.Contains(out, "gRPC:           127.0.0.1:50051") {
+		t.Errorf("nil-fn fallback dropped the default gRPC listener:\n%s", out)
+	}
+	if !strings.Contains(out, "HTTP REST:      127.0.0.1:8080") {
+		t.Errorf("nil-fn fallback dropped the default HTTP REST listener:\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server_show_system_listeners_6385_test.go
+++ b/pkg/grpcapi/server_show_system_listeners_6385_test.go
@@ -1,20 +1,25 @@
-// RED-on-revert net for #6385: the REMOTE gRPC `show system services` renderer
-// (server_show_system.go showSystemServices) — the path the remote `cli` binary
-// reaches, and the one the dropped #6384 A10-b2-F5 attempt left hardcoded — must
-// report the EFFECTIVE (post-clamp, post-bind) management-listener addresses
-// from the shared daemon-owned snapshot (Config.ListenersFn ->
-// Daemon.effectiveListeners), not the fixed `127.0.0.1:50051 (always on)` /
-// `127.0.0.1:8080 (always on)` defaults it used to print unconditionally.
+// RED-on-revert net for #6385/#6401: the REMOTE gRPC `show system services`
+// renderer (server_show_system.go showSystemServices) — the path the remote
+// `cli` binary reaches, and the one the dropped #6384 A10-b2-F5 attempt left
+// hardcoded — must report the EFFECTIVE management-listener STATE from the
+// shared daemon-owned snapshot (Config.ListenersFn -> Daemon.effectiveListeners),
+// not the fixed `127.0.0.1:50051 (always on)` / `127.0.0.1:8080 (always on)`
+// defaults it used to print unconditionally.
 //
-// Reverting the render substitution (restoring the two hardcoded Fprintln
-// lines) makes this go RED: the relocated gRPC bind and the "disabled" HTTP
-// state vanish and the hardcoded 8080/50051 defaults reappear.
+// #6401 fold: the snapshot carries per-listener STATE (Listening/Failed/
+// Disabled), so a CONFIGURED-but-FAILED bind is not misreported. This file also
+// pins the gRPC server's own EffectiveListener state machine (bind failure and
+// the pre-bind -> listening -> serve-exit lifecycle), the signal
+// Daemon.effectiveListeners reads for the gRPC row.
 package grpcapi
 
 import (
+	"context"
+	"net"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/sysservices"
 )
@@ -41,10 +46,13 @@ func newActiveConfigServer(t *testing.T) *Server {
 // HTTP REST listener, never the hardcoded requested defaults.
 func TestShowSystemServicesEffectiveListenersGRPC(t *testing.T) {
 	s := newActiveConfigServer(t)
-	// A relocated gRPC bind + an empty (disabled) HTTP REST listener — neither
+	// A relocated gRPC bind (Listening) + a disabled HTTP REST listener — neither
 	// of which the pre-#6385 hardcoded renderer could ever produce.
 	s.listenersFn = func() sysservices.Listeners {
-		return sysservices.Listeners{GRPC: "127.0.0.1:50055"}
+		return sysservices.Listeners{
+			GRPC: sysservices.Listener{Addr: "127.0.0.1:50055", State: sysservices.StateListening},
+			HTTP: sysservices.Listener{State: sysservices.StateDisabled},
+		}
 	}
 
 	var buf strings.Builder
@@ -70,6 +78,28 @@ func TestShowSystemServicesEffectiveListenersGRPC(t *testing.T) {
 	}
 }
 
+// TestShowSystemServicesFailedHTTPGRPC pins the #6401 fold on the remote path:
+// a CONFIGURED-but-FAILED HTTP bind renders "(bind failed)", distinct from the
+// "disabled" a genuinely-off listener renders.
+func TestShowSystemServicesFailedHTTPGRPC(t *testing.T) {
+	s := newActiveConfigServer(t)
+	s.listenersFn = func() sysservices.Listeners {
+		return sysservices.Listeners{
+			GRPC: sysservices.Listener{Addr: "127.0.0.1:50051", State: sysservices.StateListening},
+			HTTP: sysservices.Listener{Addr: "192.0.2.1:8080", State: sysservices.StateFailed},
+		}
+	}
+	var buf strings.Builder
+	s.showSystemServices(&buf)
+	out := buf.String()
+	if !strings.Contains(out, "HTTP REST:      192.0.2.1:8080 (bind failed)") {
+		t.Errorf("failed HTTP bind not reported as (bind failed):\n%s", out)
+	}
+	if strings.Contains(out, "HTTP REST:      disabled") {
+		t.Errorf("failed HTTP bind misreported as disabled:\n%s", out)
+	}
+}
+
 // TestShowSystemServicesListenersFnNilFallbackGRPC pins the no-daemon fallback:
 // with no snapshot source wired (a bare Server / unit-test build), the renderer
 // falls back to the documented loopback defaults so the output shape is
@@ -84,5 +114,68 @@ func TestShowSystemServicesListenersFnNilFallbackGRPC(t *testing.T) {
 	}
 	if !strings.Contains(out, "HTTP REST:      127.0.0.1:8080") {
 		t.Errorf("nil-fn fallback dropped the default HTTP REST listener:\n%s", out)
+	}
+}
+
+// TestGRPCEffectiveListenerBindFailure drives the real Run path against an
+// already-bound address so net.Listen fails, and asserts EffectiveListener
+// reports StateFailed with the requested address — NOT the requested address as
+// if it were serving (the pre-#6401 behavior, where the daemon fell back to the
+// requested --grpc-addr on an empty EffectiveAddr and rendered a failed listener
+// as Listening).
+func TestGRPCEffectiveListenerBindFailure(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy addr: %v", err)
+	}
+	defer occupied.Close()
+	addr := occupied.Addr().String()
+
+	s := NewServer(addr, Config{})
+	if err := s.Run(context.Background()); err == nil {
+		t.Fatal("Run should fail binding an already-bound address")
+	}
+	ln := s.EffectiveListener()
+	if ln.State != sysservices.StateFailed {
+		t.Errorf("bind-failure state = %v, want StateFailed: %+v", ln.State, ln)
+	}
+	if ln.Addr != addr {
+		t.Errorf("failed listener addr = %q, want requested %q", ln.Addr, addr)
+	}
+}
+
+// TestGRPCEffectiveListenerLifecycle drives the real Run path and asserts the
+// pre-bind -> Listening -> serve-exit transitions: Listening reports the ACTUAL
+// bound address (an ephemeral :0 resolves to a concrete port), and once the
+// serve loop exits the state clears to Failed so a stale bound address is not
+// reported for a dead server.
+func TestGRPCEffectiveListenerLifecycle(t *testing.T) {
+	s := NewServer("127.0.0.1:0", Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	// Wait for the BOUND Listening state (a concrete ephemeral port), not the
+	// pre-bind Listening state — which reports the requested "127.0.0.1:0" until
+	// Run's net.Listen resolves it.
+	var ln sysservices.Listener
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		ln = s.EffectiveListener()
+		if ln.State == sysservices.StateListening && !strings.HasSuffix(ln.Addr, ":0") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if ln.State != sysservices.StateListening || ln.Addr == "" || strings.HasSuffix(ln.Addr, ":0") {
+		cancel()
+		<-done
+		t.Fatalf("gRPC never reached bound Listening with a concrete port: %+v", ln)
+	}
+
+	cancel()
+	<-done
+	if got := s.EffectiveListener(); got.State != sysservices.StateFailed {
+		t.Errorf("after serve exit, state = %v, want StateFailed (cleared): %+v", got.State, got)
 	}
 }

--- a/pkg/sysservices/listeners.go
+++ b/pkg/sysservices/listeners.go
@@ -4,55 +4,93 @@
 // local interactive CLI (pkg/cli), and the remote gRPC renderer (pkg/grpcapi)
 // can all depend on it without an import cycle.
 //
-// The point of this package (#6385): both `show system services` renderers —
-// the local CLI (pkg/cli/cli_show_system.go) AND the remote gRPC renderer
-// (pkg/grpcapi/server_show_system.go, the path the remote `cli` binary reaches)
-// — read ONE daemon-owned snapshot of the addresses the listeners ACTUALLY
-// bound, not the requested/config-declared values. Before #6385 both renderers
+// The point of this package (#6385/#6401): both `show system services`
+// renderers — the local CLI (pkg/cli/cli_show_system.go) AND the remote gRPC
+// renderer (pkg/grpcapi/server_show_system.go, the path the remote `cli` binary
+// reaches) — read ONE daemon-owned snapshot of what each listener is ACTUALLY
+// doing, not the requested/config-declared values. Before #6385 both renderers
 // hardcoded `127.0.0.1:50051 (always on)` / `127.0.0.1:8080 (always on)`, so a
 // relocated, loopback-clamped (#5035/#5127), or disabled listener was reported
 // wrong, and a dropped local-only patch (the #6384 A10-b2-F5 attempt) left the
 // local and remote surfaces disagreeing. Sourcing both from Lines() guarantees
 // they can never diverge again.
+//
+// #6401 fold: each listener carries a STATE (not just an address) so a
+// CONFIGURED-but-FAILED bind is reported as such rather than misread as either
+// serving (the old requested-addr fallback) or off ("disabled").
 package sysservices
 
 import "fmt"
 
-// Listeners is the EFFECTIVE (post-clamp, post-bind) address of each management
-// listener `show system services` reports. The daemon builds it after the
-// listeners bind (Daemon.effectiveListeners); a nil snapshot source in a
-// renderer means the CLI was spawned outside a running daemon (offline
-// recovery / unit test), where there is no live bind to read.
+// State is the operational state of a management listener.
+type State int
+
+const (
+	// StateDisabled: the listener is not configured / off (e.g. an empty
+	// --api-addr, where the daemon never started the HTTP REST listener). Zero
+	// value so a zero Listener renders "disabled".
+	StateDisabled State = iota
+	// StateListening: the listener is bound and serving at Addr.
+	StateListening
+	// StateFailed: the listener is CONFIGURED but not currently serving — its
+	// bind failed (net.Listen error) or its serve loop exited. Addr is the
+	// address it tried to bind (may be empty when unknown). Distinct from
+	// StateDisabled so an operator can tell a genuinely-off listener from one
+	// that failed to come up.
+	StateFailed
+)
+
+// Listener is the effective state of one management listener.
+type Listener struct {
+	// Addr is the bind address. For StateListening it is the ACTUAL bound
+	// address (post-clamp, post-bind — an ephemeral :0 request resolves to its
+	// concrete port); for StateFailed it is the address that failed to bind (or
+	// "" when unknown); for StateDisabled it is ignored.
+	Addr string
+	// State is the listener's operational state.
+	State State
+}
+
+// render formats one listener cell: the address when serving, an
+// address-tagged "(bind failed)" (or bare "bind failed") when failed,
+// "disabled" when off.
+func (l Listener) render() string {
+	switch l.State {
+	case StateListening:
+		return l.Addr
+	case StateFailed:
+		if l.Addr != "" {
+			return l.Addr + " (bind failed)"
+		}
+		return "bind failed"
+	default: // StateDisabled
+		return "disabled"
+	}
+}
+
+// Listeners is the EFFECTIVE state of each management listener `show system
+// services` reports. The daemon builds it after the listeners bind
+// (Daemon.effectiveListeners); a nil snapshot source in a renderer means the
+// CLI was spawned outside a running daemon (offline recovery / unit test), where
+// there is no live listener to read.
 type Listeners struct {
-	// GRPC is the effective gRPC bind address AFTER the #5035 loopback clamp
-	// and net.Listen (the address the listener is actually serving). It is
-	// empty only in the brief window before the primary gRPC listener has
-	// bound; the daemon falls back to the requested --grpc-addr there so the
-	// field is effectively always populated at render time.
-	GRPC string
-	// HTTP is the effective HTTP REST bind address. An EMPTY value means the
-	// REST listener is DISABLED — the operator passed an empty --api-addr, so
-	// the daemon never started it (Daemon.Run guards startHTTPServer on a
-	// non-empty APIAddr). Rendered as "disabled" rather than a fixed
-	// `127.0.0.1:8080 (always on)`.
-	HTTP string
+	// GRPC is the primary (loopback, unauthenticated) gRPC control listener. It
+	// is always configured, so it is never StateDisabled — StateListening while
+	// serving, StateFailed if net.Listen failed or the serve loop exited.
+	GRPC Listener
+	// HTTP is the HTTP REST listener. StateDisabled when --api-addr is empty (the
+	// daemon never started it), StateFailed on a boot bind failure, else
+	// StateListening.
+	HTTP Listener
 }
 
 // Lines renders the gRPC / HTTP REST listener rows for `show system services`,
-// in render order, driven by the effective addresses. It is the SINGLE
-// formatter both the local CLI and remote gRPC renderers call, so the two
-// surfaces are byte-identical by construction. An empty address renders
-// "disabled".
+// in render order, driven by the effective state. It is the SINGLE formatter
+// both the local CLI and remote gRPC renderers call, so the two surfaces are
+// byte-identical by construction.
 func (l Listeners) Lines() []string {
 	return []string{
-		fmt.Sprintf("  gRPC:           %s", orDisabled(l.GRPC)),
-		fmt.Sprintf("  HTTP REST:      %s", orDisabled(l.HTTP)),
+		fmt.Sprintf("  gRPC:           %s", l.GRPC.render()),
+		fmt.Sprintf("  HTTP REST:      %s", l.HTTP.render()),
 	}
-}
-
-func orDisabled(addr string) string {
-	if addr == "" {
-		return "disabled"
-	}
-	return addr
 }

--- a/pkg/sysservices/listeners.go
+++ b/pkg/sysservices/listeners.go
@@ -1,0 +1,58 @@
+// Package sysservices holds the shared, EFFECTIVE management-listener state
+// rendered by `show system services`. It is a LEAF package (imports only the
+// standard library) so the daemon (which owns the listener lifecycle), the
+// local interactive CLI (pkg/cli), and the remote gRPC renderer (pkg/grpcapi)
+// can all depend on it without an import cycle.
+//
+// The point of this package (#6385): both `show system services` renderers —
+// the local CLI (pkg/cli/cli_show_system.go) AND the remote gRPC renderer
+// (pkg/grpcapi/server_show_system.go, the path the remote `cli` binary reaches)
+// — read ONE daemon-owned snapshot of the addresses the listeners ACTUALLY
+// bound, not the requested/config-declared values. Before #6385 both renderers
+// hardcoded `127.0.0.1:50051 (always on)` / `127.0.0.1:8080 (always on)`, so a
+// relocated, loopback-clamped (#5035/#5127), or disabled listener was reported
+// wrong, and a dropped local-only patch (the #6384 A10-b2-F5 attempt) left the
+// local and remote surfaces disagreeing. Sourcing both from Lines() guarantees
+// they can never diverge again.
+package sysservices
+
+import "fmt"
+
+// Listeners is the EFFECTIVE (post-clamp, post-bind) address of each management
+// listener `show system services` reports. The daemon builds it after the
+// listeners bind (Daemon.effectiveListeners); a nil snapshot source in a
+// renderer means the CLI was spawned outside a running daemon (offline
+// recovery / unit test), where there is no live bind to read.
+type Listeners struct {
+	// GRPC is the effective gRPC bind address AFTER the #5035 loopback clamp
+	// and net.Listen (the address the listener is actually serving). It is
+	// empty only in the brief window before the primary gRPC listener has
+	// bound; the daemon falls back to the requested --grpc-addr there so the
+	// field is effectively always populated at render time.
+	GRPC string
+	// HTTP is the effective HTTP REST bind address. An EMPTY value means the
+	// REST listener is DISABLED — the operator passed an empty --api-addr, so
+	// the daemon never started it (Daemon.Run guards startHTTPServer on a
+	// non-empty APIAddr). Rendered as "disabled" rather than a fixed
+	// `127.0.0.1:8080 (always on)`.
+	HTTP string
+}
+
+// Lines renders the gRPC / HTTP REST listener rows for `show system services`,
+// in render order, driven by the effective addresses. It is the SINGLE
+// formatter both the local CLI and remote gRPC renderers call, so the two
+// surfaces are byte-identical by construction. An empty address renders
+// "disabled".
+func (l Listeners) Lines() []string {
+	return []string{
+		fmt.Sprintf("  gRPC:           %s", orDisabled(l.GRPC)),
+		fmt.Sprintf("  HTTP REST:      %s", orDisabled(l.HTTP)),
+	}
+}
+
+func orDisabled(addr string) string {
+	if addr == "" {
+		return "disabled"
+	}
+	return addr
+}

--- a/pkg/sysservices/listeners_test.go
+++ b/pkg/sysservices/listeners_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 // TestListenersLines pins the shared `show system services` listener renderer
-// (#6385): effective addresses render verbatim, an empty address renders
-// "disabled", and the two rows come out in render order. Both the local CLI and
-// remote gRPC renderers call Lines, so this is where the shared format contract
-// lives.
+// (#6385/#6401): a Listening address renders verbatim, a Failed listener renders
+// "addr (bind failed)" (or bare "bind failed" when the address is unknown), a
+// Disabled listener renders "disabled", and the two rows come out in render
+// order. Both the local CLI and remote gRPC renderers call Lines, so this is
+// where the shared format contract lives.
 func TestListenersLines(t *testing.T) {
 	cases := []struct {
 		name string
@@ -17,8 +18,11 @@ func TestListenersLines(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "both bound",
-			in:   Listeners{GRPC: "127.0.0.1:50051", HTTP: "127.0.0.1:8080"},
+			name: "both listening",
+			in: Listeners{
+				GRPC: Listener{Addr: "127.0.0.1:50051", State: StateListening},
+				HTTP: Listener{Addr: "127.0.0.1:8080", State: StateListening},
+			},
 			want: []string{
 				"  gRPC:           127.0.0.1:50051",
 				"  HTTP REST:      127.0.0.1:8080",
@@ -26,14 +30,39 @@ func TestListenersLines(t *testing.T) {
 		},
 		{
 			name: "relocated grpc, http disabled",
-			in:   Listeners{GRPC: "127.0.0.1:50055"},
+			in: Listeners{
+				GRPC: Listener{Addr: "127.0.0.1:50055", State: StateListening},
+				HTTP: Listener{State: StateDisabled},
+			},
 			want: []string{
 				"  gRPC:           127.0.0.1:50055",
 				"  HTTP REST:      disabled",
 			},
 		},
 		{
-			name: "both disabled",
+			name: "http bind failed with address",
+			in: Listeners{
+				GRPC: Listener{Addr: "127.0.0.1:50051", State: StateListening},
+				HTTP: Listener{Addr: "192.0.2.1:8080", State: StateFailed},
+			},
+			want: []string{
+				"  gRPC:           127.0.0.1:50051",
+				"  HTTP REST:      192.0.2.1:8080 (bind failed)",
+			},
+		},
+		{
+			name: "grpc bind failed no address",
+			in: Listeners{
+				GRPC: Listener{State: StateFailed},
+				HTTP: Listener{Addr: "127.0.0.1:8080", State: StateListening},
+			},
+			want: []string{
+				"  gRPC:           bind failed",
+				"  HTTP REST:      127.0.0.1:8080",
+			},
+		},
+		{
+			name: "zero value renders disabled",
 			in:   Listeners{},
 			want: []string{
 				"  gRPC:           disabled",

--- a/pkg/sysservices/listeners_test.go
+++ b/pkg/sysservices/listeners_test.go
@@ -1,0 +1,57 @@
+package sysservices
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestListenersLines pins the shared `show system services` listener renderer
+// (#6385): effective addresses render verbatim, an empty address renders
+// "disabled", and the two rows come out in render order. Both the local CLI and
+// remote gRPC renderers call Lines, so this is where the shared format contract
+// lives.
+func TestListenersLines(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Listeners
+		want []string
+	}{
+		{
+			name: "both bound",
+			in:   Listeners{GRPC: "127.0.0.1:50051", HTTP: "127.0.0.1:8080"},
+			want: []string{
+				"  gRPC:           127.0.0.1:50051",
+				"  HTTP REST:      127.0.0.1:8080",
+			},
+		},
+		{
+			name: "relocated grpc, http disabled",
+			in:   Listeners{GRPC: "127.0.0.1:50055"},
+			want: []string{
+				"  gRPC:           127.0.0.1:50055",
+				"  HTTP REST:      disabled",
+			},
+		},
+		{
+			name: "both disabled",
+			in:   Listeners{},
+			want: []string{
+				"  gRPC:           disabled",
+				"  HTTP REST:      disabled",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.Lines()
+			if len(got) != len(tc.want) {
+				t.Fatalf("Lines() len = %d, want %d:\n%s", len(got), len(tc.want), strings.Join(got, "\n"))
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("Lines()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`show system services` reported the **requested/config-declared** management
listeners — `127.0.0.1:50051 / 127.0.0.1:8080 (always on)`, hardcoded in **both**
renderers — not the addresses the daemon actually bound. A relocated gRPC bind
(post-#5035 loopback clamp), a REST bind clamped/relocated by the #4047/#5127
fail-safe, or a disabled REST listener (empty `--api-addr`) were all reported
wrong.

Re-file of the fix-5 dropped from #6384: that attempt (a) reported the requested
`d.opts` values rather than the effective bind and (b) patched only the local
`pkg/cli` renderer while the normal remote `cli` reaches the hardcoded gRPC
renderer (`pkg/grpcapi/server_show_system.go`) — so local and remote disagreed
while both stayed wrong.

## Fix

Capture the effective listeners in one daemon-owned snapshot and route **both**
renderers through it:

- New leaf package `pkg/sysservices` (`Listeners` + the shared `Lines` renderer,
  stdlib-only) is the single format contract, so the two surfaces are
  byte-identical by construction. An empty address renders `disabled`.
- `grpcapi.Server.EffectiveAddr` records the primary gRPC serving address after
  the #5035 clamp and `net.Listen` (`lis.Addr()`).
- `managementReconciler.effectiveHTTPAddr` exposes the converged HTTP REST bind
  (`m.cur.addr`) — which advances only on a successful (re)bind and is retained
  on a failed rebind, so it is the address actually serving; a nil reconciler
  (empty `--api-addr`, listener never started) renders `disabled`.
- `Daemon.effectiveListeners` aggregates the two; the remote gRPC renderer reads
  it via `grpcapi.Config.ListenersFn` and the local console CLI via
  `cli.SetListenersFn`. A nil source (no-daemon unit-test build) falls back to
  the documented loopback defaults.

## Surface enumeration

| Renderer | Path | Status |
|---|---|---|
| Local console CLI | `pkg/cli/cli_show_system.go` `showSystemServices` | reads shared snapshot (`SetListenersFn`) |
| Remote gRPC (`cli` binary path) | `pkg/grpcapi/server_show_system.go` `showSystemServices` | reads shared snapshot (`Config.ListenersFn`) — **the path #6384 left unfixed** |
| HTTP REST / JSON / `display xml` | — | no such renderer of the listener block exists (grep of `System services:` finds only the two above) |

## Testing

Fail-on-revert nets on both surfaces:

- `TestShowSystemServicesEffectiveListenersGRPC` — **primary, remote path**:
  relocated gRPC bind + disabled HTTP REST render as effective, never the
  hardcoded defaults.
- `TestShowSystemServicesEffectiveListenersLocal` — the local console surface.
- `sysservices.TestListenersLines` — the shared renderer (`disabled` folding,
  render order).

Each RED verified firsthand by neutralizing the render substitution (restoring
the hardcoded lines): a clean **assertion** failure (relocated bind and
`disabled` absent, hardcoded defaults reappear), while the nil-fallback test
stays green; restored to green.

`gofmt`, `go vet`, and `go test ./pkg/sysservices/ ./pkg/grpcapi/ ./pkg/cli/
./pkg/daemon/` all clean/green. The daemon README management-listener section
documents the effective-listener snapshot contract.

Closes #6385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ
