### PR TITLE
cli: clamp console ping -s payload to MaxPingSize (#6382)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -59228,3 +59228,20 @@ top.
     #6391" (no close keyword).
   - **File(s)**: pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go,
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6382 — clamp local console CLI ping `-s` payload to
+    `diagcmd.MaxPingSize` (the third control surface). REST
+    (`pkg/api/system.go`) and gRPC (`pkg/grpcapi/server_diag_ping.go`)
+    `buildPingArgv` already clamped (#5250 A8-b1 F4); the console
+    `buildPingArgv` in `pkg/cli/cli_request_ping.go` passed the operator
+    `size` token through unclamped. Now `strconv.Atoi` + `min(size,
+    MaxPingSize)`; non-numeric tokens left for the ping child to reject.
+    Added `TestBuildPingArgvClampsSize_6382` (fail-on-revert) +
+    `TestBuildPingArgvKeepsInBoundSize_6382` (in-bound + non-numeric pass
+    through). Updated `MaxPingSize` doc comment (now all three surfaces
+    clamp) and `pkg/cli/README.md`. Parent-RED verified: neutralizing the
+    clamp fails `TestBuildPingArgvClampsSize_6382` with a clean assertion
+    (`ping -s = "1048576", want clamped "65507"`).
+  - **File(s)**: pkg/cli/cli_request_ping.go, pkg/cli/cli_request_argv_test.go,
+    pkg/diagcmd/diagcmd.go, pkg/cli/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -59245,3 +59245,24 @@ top.
     (`ping -s = "1048576", want clamped "65507"`).
   - **File(s)**: pkg/cli/cli_request_ping.go, pkg/cli/cli_request_argv_test.go,
     pkg/diagcmd/diagcmd.go, pkg/cli/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6382 review fold — (1) MINOR 1 (overflow bypass): the
+    `strconv.Atoi` guard returned `ErrRange` for a digit token above the
+    platform int, skipping the clamp and letting `ping -s <huge>` run
+    unbounded. Reworked `buildPingArgv` to `strconv.ParseInt(..,10,64)`;
+    clamp when the value parses and `> MaxPingSize`, OR when it overflows
+    int64 (`errors.Is ErrRange`) on a non-negative literal. A leading '-'
+    overflow stays a huge negative the ping child rejects. Added
+    `TestBuildPingArgvClampsOverflowSize_6382` (fail-on-revert:
+    "99999999999999999999" → capped 65507). (2) MINOR 2 (≤0 divergence):
+    documented — NOT changed — that the console preserves an explicit
+    `-s 0`/`-s -1`/non-numeric token (raw operator input model) while the
+    structured-int REST/gRPC surfaces omit a non-positive size; only the
+    upper ceiling is shared. Locked with
+    `TestBuildPingArgvPreservesNonPositiveSize_6382`. Updated the fn doc
+    comment + `pkg/cli/README.md`. Parent-RED re-verified on the new head:
+    neutralizing the clamp fails BOTH ClampsSize + ClampsOverflowSize with
+    clean assertions; restored green.
+  - **File(s)**: pkg/cli/cli_request_ping.go, pkg/cli/cli_request_argv_test.go,
+    pkg/cli/README.md, _Log.md

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -29,7 +29,14 @@ sibling files (same package, so unexported helpers stay reachable):
   builders (`buildPingArgv`, `buildTracerouteArgv`). `buildPingArgv`
   clamps the `-s` payload to `diagcmd.MaxPingSize` (#6382), so the local
   console shares the single ping-size ceiling the REST and gRPC surfaces
-  already enforce (#5250 A8-b1 F4).
+  already enforce (#5250 A8-b1 F4) — including a digit token that
+  overflows `int64` (that arm is why a naive `strconv.Atoi` guard would
+  leak the huge value). Because the console's input is a RAW operator
+  token (unlike the structured int the REST/gRPC surfaces receive, where
+  `0` means "unset"), it enforces ONLY the upper ceiling and
+  intentionally preserves an explicit `-s 0` / `-s -1` / non-numeric
+  token for the `ping` child to reject rather than dropping input the
+  operator typed.
 - `cli_request_testcmd.go` — `test policy` / `test routing` /
   `test security-zone` (the `policymatch` adapters).
 - `monitor_traffic.go` — `monitor` dispatch + `monitor traffic` tcpdump

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -26,7 +26,10 @@ sibling files (same package, so unexported helpers stay reachable):
 - `cli_request.go` — the `handleRequest` dispatch shell plus the small
   `request dhcp` / `request protocols` handlers.
 - `cli_request_ping.go` — `ping` / `traceroute` and their `diagcmd` argv
-  builders (`buildPingArgv`, `buildTracerouteArgv`).
+  builders (`buildPingArgv`, `buildTracerouteArgv`). `buildPingArgv`
+  clamps the `-s` payload to `diagcmd.MaxPingSize` (#6382), so the local
+  console shares the single ping-size ceiling the REST and gRPC surfaces
+  already enforce (#5250 A8-b1 F4).
 - `cli_request_testcmd.go` — `test policy` / `test routing` /
   `test security-zone` (the `policymatch` adapters).
 - `monitor_traffic.go` — `monitor` dispatch + `monitor traffic` tcpdump

--- a/pkg/cli/cli_request_argv_test.go
+++ b/pkg/cli/cli_request_argv_test.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/diagcmd"
 )
 
 // assertVRFDeviceOnce checks the #2143 invariant on a VRF-wrapped argv:
@@ -124,6 +127,40 @@ func TestBuildPingArgvParityWithVRF(t *testing.T) {
 	want := []string{"ip", "vrf", "exec", "vrf-red", "ping", "-c", "5", "--", "192.0.2.1"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildPingArgv =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+// pingArgvSize returns the value passed to `ping -s` in argv, or "" if none.
+func pingArgvSize(argv []string) string {
+	if i := indexOf(argv, "-s"); i >= 0 && i+1 < len(argv) {
+		return argv[i+1]
+	}
+	return ""
+}
+
+// TestBuildPingArgvClampsSize_6382 is the fail-on-revert guard for the local
+// console CLI ping payload clamp (#6382 — the third control surface, matching
+// the REST/gRPC #5250 A8-b1 F4 clamp). A size token far above the max valid
+// ICMP echo data must be capped to diagcmd.MaxPingSize. Removing the clamp in
+// buildPingArgv passes the raw operator value straight through.
+func TestBuildPingArgvClampsSize_6382(t *testing.T) {
+	argv := buildPingArgv("192.0.2.1", "5", "", "1048576", "")
+	got := pingArgvSize(argv)
+	want := fmt.Sprintf("%d", diagcmd.MaxPingSize)
+	if got != want {
+		t.Fatalf("ping -s = %q, want clamped %q", got, want)
+	}
+}
+
+// TestBuildPingArgvKeepsInBoundSize_6382 confirms an in-range size token is
+// passed through untouched, and a non-numeric token is left for the ping child
+// to reject rather than being swallowed by the clamp.
+func TestBuildPingArgvKeepsInBoundSize_6382(t *testing.T) {
+	if got := pingArgvSize(buildPingArgv("192.0.2.1", "5", "", "1400", "")); got != "1400" {
+		t.Fatalf("ping -s = %q, want 1400 (in-bound size must pass through)", got)
+	}
+	if got := pingArgvSize(buildPingArgv("192.0.2.1", "5", "", "huge", "")); got != "huge" {
+		t.Fatalf("ping -s = %q, want \"huge\" (non-numeric size must reach ping unchanged)", got)
 	}
 }
 

--- a/pkg/cli/cli_request_argv_test.go
+++ b/pkg/cli/cli_request_argv_test.go
@@ -152,6 +152,21 @@ func TestBuildPingArgvClampsSize_6382(t *testing.T) {
 	}
 }
 
+// TestBuildPingArgvClampsOverflowSize_6382 is the fail-on-revert guard for the
+// int64-overflow arm of the clamp (#6382, Codex MINOR 1). A digit token larger
+// than the widest integer type must STILL be capped to diagcmd.MaxPingSize — a
+// naive strconv.Atoi guard returns ErrRange for such a token, skips the clamp,
+// and hands `ping -s <huge>` the raw value, bypassing the very ceiling this
+// change adds. Neutralizing the clamp lets the huge token pass through.
+func TestBuildPingArgvClampsOverflowSize_6382(t *testing.T) {
+	argv := buildPingArgv("192.0.2.1", "5", "", "99999999999999999999", "")
+	got := pingArgvSize(argv)
+	want := fmt.Sprintf("%d", diagcmd.MaxPingSize)
+	if got != want {
+		t.Fatalf("ping -s = %q, want clamped %q (int64-overflow token must be capped)", got, want)
+	}
+}
+
 // TestBuildPingArgvKeepsInBoundSize_6382 confirms an in-range size token is
 // passed through untouched, and a non-numeric token is left for the ping child
 // to reject rather than being swallowed by the clamp.
@@ -161,6 +176,20 @@ func TestBuildPingArgvKeepsInBoundSize_6382(t *testing.T) {
 	}
 	if got := pingArgvSize(buildPingArgv("192.0.2.1", "5", "", "huge", "")); got != "huge" {
 		t.Fatalf("ping -s = %q, want \"huge\" (non-numeric size must reach ping unchanged)", got)
+	}
+}
+
+// TestBuildPingArgvPreservesNonPositiveSize_6382 locks the DOCUMENTED
+// divergence from the REST/gRPC surfaces (#6382, Codex MINOR 2): the console's
+// input model is a raw operator token, so an explicit `-s 0` / `-s -1` (and a
+// huge-negative overflow) is preserved for the ping child to reject rather than
+// omitted the way the structured-int siblings drop a non-positive size. Only
+// the upper MaxPingSize ceiling is enforced here.
+func TestBuildPingArgvPreservesNonPositiveSize_6382(t *testing.T) {
+	for _, tok := range []string{"0", "-1", "-99999999999999999999"} {
+		if got := pingArgvSize(buildPingArgv("192.0.2.1", "5", "", tok, "")); got != tok {
+			t.Fatalf("ping -s = %q, want %q preserved (console keeps explicit non-positive -s)", got, tok)
+		}
 	}
 }
 

--- a/pkg/cli/cli_request_ping.go
+++ b/pkg/cli/cli_request_ping.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"github.com/psaab/xpf/pkg/diagcmd"
@@ -69,7 +70,18 @@ func (c *CLI) handlePing(args []string) error {
 // byte-for-byte. Before #2143 this path prepended "vrf-"
 // unconditionally, turning `routing-instance vrf-red` into the
 // non-existent device `vrf-vrf-red`.
+//
+// The payload size is clamped to diagcmd.MaxPingSize so this third
+// control surface shares the single ceiling the REST and gRPC
+// buildPingArgv callers already enforce (#6382, mirroring #5250 A8-b1
+// F4): a -s above the max valid ICMP echo data could never yield a
+// valid probe. size arrives here as the raw operator token; a
+// non-numeric value is left untouched for the ping child to reject,
+// preserving the pre-clamp behavior of this trusted local surface.
 func buildPingArgv(target, count, source, size, vrfName string) []string {
+	if n, err := strconv.Atoi(size); err == nil && n > diagcmd.MaxPingSize {
+		size = strconv.Itoa(diagcmd.MaxPingSize)
+	}
 	return diagcmd.PingArgv(diagcmd.PingOptions{
 		Target:          target,
 		Count:           count,

--- a/pkg/cli/cli_request_ping.go
+++ b/pkg/cli/cli_request_ping.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/psaab/xpf/pkg/diagcmd"
@@ -72,14 +74,33 @@ func (c *CLI) handlePing(args []string) error {
 // non-existent device `vrf-vrf-red`.
 //
 // The payload size is clamped to diagcmd.MaxPingSize so this third
-// control surface shares the single ceiling the REST and gRPC
+// control surface shares the single upper ceiling the REST and gRPC
 // buildPingArgv callers already enforce (#6382, mirroring #5250 A8-b1
 // F4): a -s above the max valid ICMP echo data could never yield a
-// valid probe. size arrives here as the raw operator token; a
-// non-numeric value is left untouched for the ping child to reject,
-// preserving the pre-clamp behavior of this trusted local surface.
+// valid probe.
+//
+// size arrives here as the RAW operator token, unlike the structured
+// int the REST/gRPC surfaces receive (where 0 means "unset" and -s is
+// omitted unless positive). Only the upper MaxPingSize ceiling is
+// enforced here — the console INTENTIONALLY preserves an explicit
+// operator -s for zero, negative, and non-numeric tokens, handing them
+// to the ping child to reject rather than silently dropping input the
+// operator typed. Silently swallowing an explicit `-s 0` would be less
+// faithful to intent than the structured-int surfaces' "0 == unset".
+//
+// A numeric token that is too large is clamped whether it merely
+// exceeds MaxPingSize (parses fine, n > ceiling) OR overflows int64
+// (strconv.ErrRange on a non-negative literal) — the latter is the
+// bug the naive strconv.Atoi guard missed, since Atoi returns ErrRange
+// and would leave the huge token to reach `ping -s <huge>` unclamped.
+// A leading '-' overflow stays a huge negative the child rejects,
+// consistent with the ≤0 pass-through above.
 func buildPingArgv(target, count, source, size, vrfName string) []string {
-	if n, err := strconv.Atoi(size); err == nil && n > diagcmd.MaxPingSize {
+	if n, err := strconv.ParseInt(size, 10, 64); err == nil {
+		if n > diagcmd.MaxPingSize {
+			size = strconv.Itoa(diagcmd.MaxPingSize)
+		}
+	} else if errors.Is(err, strconv.ErrRange) && !strings.HasPrefix(size, "-") {
 		size = strconv.Itoa(diagcmd.MaxPingSize)
 	}
 	return diagcmd.PingArgv(diagcmd.PingOptions{

--- a/pkg/diagcmd/diagcmd.go
+++ b/pkg/diagcmd/diagcmd.go
@@ -41,12 +41,13 @@ func VRFDeviceName(name string) string {
 // MaxPingSize is the largest ping payload (ping -s) any control surface
 // accepts. It is the maximum ICMP echo data an IPv4 datagram can carry —
 // 65535 (max IP total length) − 20 (IP header) − 8 (ICMP header) = 65507
-// — so a request above it could never produce a valid probe anyway. The
-// REST and gRPC callers clamp req.Size to this bound before building the
-// options so an oversized -s can neither be passed to the ping child nor
-// wrapped negative; validation and clamping stay with the callers per the
-// PingOptions contract, but the shared ceiling lives here so both surfaces
-// stay in lockstep (#5250 A8-b1 F4).
+// — so a request above it could never produce a valid probe anyway. All
+// three callers — REST, gRPC, and the local console CLI — clamp the
+// operator size to this bound before building the options so an oversized
+// -s can neither be passed to the ping child nor wrapped negative;
+// validation and clamping stay with the callers per the PingOptions
+// contract, but the shared ceiling lives here so every surface stays in
+// lockstep (#5250 A8-b1 F4 for REST/gRPC; #6382 for the console CLI).
 const MaxPingSize = 65507
 
 // PingOptions carries the already-validated, already-clamped ping


### PR DESCRIPTION
## What

The local console CLI ping surface (`pkg/cli/cli_request_ping.go`) passed the
operator-supplied `size` token straight into `diagcmd.PingArgv` with no ceiling.
The two network-facing surfaces already clamp — the REST `buildPingArgv`
(`pkg/api/system.go`) and gRPC `buildPingArgv` (`pkg/grpcapi/server_diag_ping.go`)
both cap to `diagcmd.MaxPingSize` (65507 = 65535 − 20 IP − 8 ICMP) under
#5250 A8-b1 F4. The console was the third, uncovered surface.

## Fix

`buildPingArgv` now parses the size token (`strconv.Atoi`) and caps it to
`diagcmd.MaxPingSize` when it exceeds the bound, so all three control surfaces
share the single ceiling. A non-numeric token is left untouched for the `ping`
child to reject, preserving this surface's pre-clamp behavior.

## Materiality

LOW / defense-in-depth consistency (per the issue). The console is a trusted
local surface and `ping` self-validates `-s`, so this is a lockstep-consistency
follow-up, not a security hole.

## Completeness

The three ping control surfaces now all clamp against `MaxPingSize`. There is no
v4/v6 split here — the ceiling is protocol-agnostic (max ICMP echo data, applied
identically to any target). `traceroute` has no `-s` payload-size option, so no
mirror change is needed.

## Docs

Updated the `MaxPingSize` doc comment (now records all three surfaces clamp) and
`pkg/cli/README.md`.

## Tests / validation

- `go build`/`vet`/`gofmt` clean on `pkg/cli` and `pkg/diagcmd`.
- `go test ./pkg/cli/ ./pkg/diagcmd/` green.
- Fail-on-revert: `TestBuildPingArgvClampsSize_6382` — neutralizing the clamp
  fails with a clean assertion (`ping -s = "1048576", want clamped "65507"`),
  restored to green.
- `TestBuildPingArgvKeepsInBoundSize_6382` confirms an in-range size and a
  non-numeric token both reach `ping` unchanged.

Not HA-touching (control-plane CLI diag builder only; no cluster/VRRP/failover).

Closes #6382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ