### PR TITLE
policymatch: colon-strict family for unsupported-tuple gate

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -59228,3 +59228,121 @@ top.
     #6391" (no close keyword).
   - **File(s)**: pkg/config/compiler_zone_iface_hostinbound_sibling_6391_test.go,
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: Fix #6377 — policymatch unsupported-tuple gate folded an
+    IPv4-mapped IPv6 source. The #5720 (V4 src, V6 dst) gate in
+    `pkg/policymatch/policymatch.go` `Match` classified family with
+    `net.IP.To4()`, which folds `::ffff:1.2.3.4` (To4 non-nil), so a source
+    authored as `::ffff:192.0.2.1` against a v6 destination was FALSELY reported
+    `UnsupportedTupleFamily` — diverging from the colon-strict runtime matcher
+    (userspace-dp/src/policy.rs) that sees a same-family V6/V6 tuple. Fail-safe
+    (a spurious advisory, never a hidden/fabricated permit) but off the
+    documented Go/Rust family-parity convention. Fix: threaded the colon-strict
+    text family from every caller. Added optional `Query.SrcFamily`/`DstFamily`
+    ("v4"/"v6"/"") hints; all four builders (cli_request_testcmd.go,
+    cli_show_security.go, server_show_firewall.go, server_cluster.go) populate
+    them via `config.NATAddrFamily` on the RAW operator string (the SSOT
+    colon-strict classifier, keyed on the ':' net.ParseIP discards). New
+    `queryTupleFamily` prefers the hint and falls back to `To4()` only when a
+    caller supplies none, preserving pre-#6377 behavior for net.IP-only callers.
+    Fail-on-revert `mapped_ipv4_tuple_6377_test.go`
+    (`TestMatchMappedIPv6SourceNotGated`) — verified RED (clean assertion,
+    UnsupportedTupleFamily:true) when the gate is reverted to To4()-only,
+    restored GREEN. Covers all three directions (genuine v4, genuine v6, mapped
+    v6) + the deliberate no-hint fold fallback. Not HA/cluster/dataplane —
+    diagnostic surface only, no failover smoke required. build+vet+gofmt clean;
+    full go test on pkg/policymatch + pkg/cli + pkg/grpcapi GREEN.
+  - **File(s)**: pkg/policymatch/policymatch.go,
+    pkg/policymatch/mapped_ipv4_tuple_6377_test.go,
+    pkg/policymatch/README.md, pkg/cli/cli_request_testcmd.go,
+    pkg/cli/cli_show_security.go, pkg/grpcapi/server_show_firewall.go,
+    pkg/grpcapi/server_cluster.go, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: Fix #6377 fold — the REST caller (the FIFTH builder) was missed
+    in the first pass. The hostile Claude review found MERGE-NEEDS-MAJOR: the
+    fix threaded the colon-strict family through FOUR `policymatch.Query{}`
+    builders but there are FIVE — `pkg/api/security.go` `matchPoliciesHandler`
+    (GET /api/v1/security/match) passed SrcIP/DstIP with NO SrcFamily/DstFamily,
+    so `::ffff:192.0.2.1 -> 2001:db8::1` was still falsely reported
+    `UnsupportedTupleFamily` on REST. Folded: added
+    `SrcFamily: config.NATAddrFamily(srcIPStr)` /
+    `DstFamily: config.NATAddrFamily(dstIPStr)` at security.go (classifying the
+    RAW query strings srcIPStr/dstIPStr, NOT the folded net.ParseIP results).
+    Added the REST fail-on-revert `security_matchpolicies_mapped_ipv4_6377_test.go`
+    (`TestMatchPoliciesRESTMappedIPv6SourceNotGated6377`) — drives the real
+    handler with src_ip=::ffff:192.0.2.1 & dst_ip=2001:db8::1 and asserts a
+    permit-through (NOT the unsupported verdict), plus a genuine 10.0.0.1 -> v6
+    control that MUST still be gated. Verified RED firsthand (drop the two
+    Family fields → REST response Action = the unsupported-tuple string,
+    Matched:false), restored GREEN. This was the one #6377 surface with no
+    binding test, which is why the miss slipped through. Corrected the "all
+    four builders" claims to FIVE and enumerated api/security.go in the
+    policymatch.go gate comment, pkg/policymatch/README.md, and this log. All
+    five builders: cli_request_testcmd.go, cli_show_security.go,
+    server_show_firewall.go, server_cluster.go, api/security.go.
+  - **File(s)**: pkg/api/security.go,
+    pkg/api/security_matchpolicies_mapped_ipv4_6377_test.go,
+    pkg/policymatch/policymatch.go, pkg/policymatch/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: Fix #6377 fold #2 (Codex MAJOR, security-relevant) — the gate
+    fix alone was UNSAFE. `matchAddr` (the policy address evaluator) classified
+    the packet family with `isV4 := ip.To4() != nil`, which FOLDS a mapped-v6
+    source. After the gate fix let a mapped-v6 source fall through (correctly),
+    matchAddr folded it to v4 and matched it against the V4 address rules — so a
+    `::ffff:192.0.2.1` source against a V4-only permit rule (192.0.2.0/24 folds
+    to contain 192.0.2.1) would FABRICATE A PERMIT (fail-OPEN), worse than the
+    original spurious-advisory bug. The colon-strict Rust matcher sees V6 →
+    evaluates against V6 rules → default-deny. Fix: threaded the per-side family
+    into matchAddr — `isV4 := queryTupleFamily(ip, family) == "v4"` (hint first,
+    To4() fallback only when family==""); src passes q.SrcFamily, dst passes
+    q.DstFamily at all four call sites (ruleMatches x2, isSkippedFragDeny x2).
+    The v4Empty/v6Empty gates key on the ADDRESS SETS not the packet family, so
+    the #3023 cross-family + #2008 excluded fail-closed semantics are unchanged
+    (full pkg/policymatch suite GREEN confirms). Also threaded the family into
+    the test-only SelectorArgs.Query() helper (defensive; no production caller).
+    New eval-correctness fail-on-revert tests (Codex's point — the gate tests
+    only proved fall-through): TestMatchMappedIPv6SourceNotEvaluatedAsV4
+    (matcher) + TestMatchPoliciesRESTMappedIPv6SourceNotEvaluatedAsV4_6377
+    (REST) — mapped-v6 src against a V4-only permit rule must NOT permit
+    (matches v6 → default-deny); genuine v4 control still permits. BOTH verified
+    RED firsthand on `isV4 := ip.To4()` revert (Matched:true PolicyName:permit-v4
+    Action:permit), restored GREEN. Documented in matchAddr doc comment +
+    pkg/policymatch/README.md resolved section. SelectorArgs.Query() at
+    policymatch.go is test-only (grep: only fragment_5572_test.go +
+    selector_args_3696_test.go reference it).
+  - **File(s)**: pkg/policymatch/policymatch.go,
+    pkg/policymatch/mapped_ipv4_tuple_6377_test.go,
+    pkg/api/security_matchpolicies_mapped_ipv4_6377_test.go,
+    pkg/policymatch/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: Fix #6377 fold #3 (Codex round-2 MERGE-NEEDS-MINOR, 3 MINORs).
+    (1) hostInboundAdmission was a THIRD To4()-fold site: it computed the family
+    via ipFamily(q.DstIP)/ipFamily(q.SrcIP), folding a mapped-v6 host-bound
+    destination to ip. A family-scoped host-inbound token (dhcpv6=ip6, dhcp=ip;
+    ping ICMP vs ICMPv6) would then be mis-admitted in the simulator. Added
+    ipFamilyStrict(ip, fam) — maps the colon-strict hint to the nft ip/ip6 token,
+    To4() fallback when fam=="" — and threaded q.DstFamily/q.SrcFamily.
+    Fail-on-revert host_inbound_mapped_family_6377_test.go
+    (TestHostInboundMappedIPv6DstClassifiedAsV6): a mapped-v6 dst on udp/547 must
+    admit via the ip6-scoped dhcpv6 token; genuine v4 (dhcp/udp67) + genuine v6
+    controls prove both paths intact. VERIFIED RED firsthand on the ipFamily()
+    revert (mapped case flips TokenAdmit(dhcpv6)->Denied while controls stay
+    green), restored GREEN. (2) Corrected the Query.SrcFamily/DstFamily doc
+    comment: it falsely claimed the hints "never affect address matching" — they
+    now drive the gate, matchAddr's isV4, AND host-inbound family; reworded to
+    enumerate all three consumers and clarify the hint selects which family's
+    rules a side is tested against (address CONTAINMENT still uses the IP bytes).
+    (3) Strengthened the eval REST test
+    (TestMatchPoliciesRESTMappedIPv6SourceNotEvaluatedAsV4_6377) to assert the
+    EXACT default-deny result (action=="deny (default)" + default_used==true +
+    policy_name=="" + matched==false), not merely "not permit". Documented the
+    host-inbound consumer in pkg/policymatch/README.md resolved section. Gate +
+    matcher-eval + REST fail-on-reverts all still green.
+  - **File(s)**: pkg/policymatch/policymatch.go,
+    pkg/policymatch/host_inbound_mapped_family_6377_test.go,
+    pkg/api/security_matchpolicies_mapped_ipv4_6377_test.go,
+    pkg/policymatch/README.md, _Log.md

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -791,10 +791,16 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	inactiveFn := dpuserspace.PolicyInactiveFn(schedState)
 	res := policymatch.Match(cfg, policymatch.Query{
-		FromZone:         fromZone,
-		ToZone:           toZone,
-		SrcIP:            srcIP,
-		DstIP:            dstIP,
+		FromZone: fromZone,
+		ToZone:   toZone,
+		SrcIP:    srcIP,
+		DstIP:    dstIP,
+		// #6377: colon-strict text family from the RAW query strings so the
+		// unsupported-tuple gate does not fold an IPv4-mapped IPv6 source to v4.
+		// Classify srcIPStr/dstIPStr (the un-parsed operator text) — srcIP/dstIP
+		// are net.ParseIP results that have already discarded the ':'.
+		SrcFamily:        config.NATAddrFamily(srcIPStr),
+		DstFamily:        config.NATAddrFamily(dstIPStr),
 		Protocol:         proto,
 		SrcPort:          srcPort,
 		DstPort:          dstPort,

--- a/pkg/api/security_matchpolicies_mapped_ipv4_6377_test.go
+++ b/pkg/api/security_matchpolicies_mapped_ipv4_6377_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/policymatch"
+)
+
+// mappedTupleAPIStore builds a trust->untrust `permit any` over default-deny so
+// a tuple that reaches address matching is PERMITTED. The #6377 gate, if it
+// fires first, short-circuits to the "unsupported tuple" verdict before this
+// permit is ever consulted — so a permit vs. unsupported answer cleanly
+// discriminates whether the mapped-IPv6 source was folded to v4.
+func mappedTupleAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy permit-all {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+type mappedMatchResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Matched     bool   `json:"matched"`
+		PolicyName  string `json:"policy_name"`
+		Action      string `json:"action"`
+		DefaultUsed bool   `json:"default_used"`
+	} `json:"data"`
+}
+
+func mappedMatch(t *testing.T, s *Server, q url.Values) mappedMatchResponse {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/match?"+q.Encode(), nil)
+	s.matchPoliciesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp mappedMatchResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	return resp
+}
+
+// mappedV4RuleAPIStore builds a trust->untrust `permit` whose source-address is
+// a V4-only book (192.0.2.0/24) over default-deny, and NO V6 rule. A mapped
+// source ::ffff:192.0.2.1 folds (To4) to 192.0.2.1 which is inside that subnet,
+// so a v4-classified evaluation would fabricate a PERMIT.
+func mappedV4RuleAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    address-book {
+        global {
+            address v4src 192.0.2.0/24;
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy permit-v4 {
+                match { source-address v4src; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestMatchPoliciesRESTMappedIPv6SourceNotEvaluatedAsV4_6377 is the REST
+// EVALUATION-correctness fail-on-revert (Codex): on the live handler, a mapped
+// IPv6 source must be evaluated as V6 by the policy matcher, NOT folded to v4
+// and matched against a V4-only permit rule. Otherwise the REST simulator
+// fabricates a PERMIT the runtime never produces (the colon-strict Rust matcher
+// sees V6 → no V6 rule → default-deny). dst_ip is omitted (match-any) to isolate
+// the source-family classification.
+//
+// RED on revert: restore `isV4 := ip.To4() != nil` in matchAddr. The mapped
+// source folds to v4, matches permit-v4, and the REST response reports permit —
+// the deny assertions below fail.
+func TestMatchPoliciesRESTMappedIPv6SourceNotEvaluatedAsV4_6377(t *testing.T) {
+	s := &Server{store: mappedV4RuleAPIStore(t)}
+
+	// Mapped-IPv6 source: must be evaluated as V6 → no V6 rule → default-deny.
+	// Assert the EXACT default-deny result (not merely "not permit"), proving it
+	// fell through to the configured default rather than some other non-permit
+	// path.
+	mapped := mappedMatch(t, s, url.Values{
+		"from_zone": {"trust"}, "to_zone": {"untrust"},
+		"src_ip": {"::ffff:192.0.2.1"},
+	})
+	if mapped.Data.Matched || mapped.Data.PolicyName != "" {
+		t.Fatalf("mapped-IPv6 source must NOT match the V4-only permit rule on REST (fabricated permit); got %+v", mapped.Data)
+	}
+	if mapped.Data.Action != "deny (default)" || !mapped.Data.DefaultUsed {
+		t.Fatalf("mapped-IPv6 source must fall to default-deny on REST (action=%q default_used=%v); got %+v", mapped.Data.Action, mapped.Data.DefaultUsed, mapped.Data)
+	}
+
+	// Control: a genuine dotted-quad V4 source in-subnet MUST still permit via
+	// permit-v4 on REST — the family threading did not break real v4 matching.
+	v4 := mappedMatch(t, s, url.Values{
+		"from_zone": {"trust"}, "to_zone": {"untrust"},
+		"src_ip": {"192.0.2.5"},
+	})
+	if !v4.Data.Matched || v4.Data.Action != "permit" || v4.Data.PolicyName != "permit-v4" {
+		t.Fatalf("genuine v4 source must permit via permit-v4 on REST; got %+v", v4.Data)
+	}
+}
+
+// TestMatchPoliciesRESTMappedIPv6SourceNotGated6377 is the REST fail-on-revert
+// artifact for #6377 — the one #6377 surface (the live GET /api/v1/security/match
+// handler, matchPoliciesHandler) that had no binding test, which is exactly why
+// the 5th caller slipped through. An IPv4-mapped IPv6 source (::ffff:192.0.2.1)
+// against a genuine IPv6 destination is a same-family V6/V6 tuple to the
+// colon-strict runtime matcher, so the #5720 unsupported-tuple gate must NOT
+// fire and the query must fall through to the permit-all policy.
+//
+// The handler threads the colon-strict text family via config.NATAddrFamily on
+// the RAW src_ip/dst_ip query strings (before net.ParseIP folds them), so the
+// mapped source is classified v6.
+//
+// RED on revert: drop the SrcFamily/DstFamily fields at the Query in
+// security.go (or revert queryTupleFamily to To4()-only). net.ParseIP folds the
+// mapped literal to a v4-looking address, the (v4,v6) gate fires, and the REST
+// response reports the unsupported-tuple verdict instead of the permit — the
+// permit assertion below fails cleanly.
+func TestMatchPoliciesRESTMappedIPv6SourceNotGated6377(t *testing.T) {
+	s := &Server{store: mappedTupleAPIStore(t)}
+
+	// Mapped-IPv6 source against a genuine IPv6 destination: same-family V6/V6,
+	// must fall through to the permit-all policy.
+	mapped := mappedMatch(t, s, url.Values{
+		"from_zone": {"trust"}, "to_zone": {"untrust"},
+		"src_ip": {"::ffff:192.0.2.1"}, "dst_ip": {"2001:db8::1"},
+	})
+	if mapped.Data.Action == policymatch.UnsupportedTupleFamilyActionString {
+		t.Fatalf("mapped-IPv6 source must NOT be gated unsupported on REST (same-family V6/V6); got %+v", mapped.Data)
+	}
+	if !mapped.Data.Matched || mapped.Data.Action != "permit" || mapped.Data.PolicyName != "permit-all" {
+		t.Fatalf("mapped-IPv6 tuple must permit via permit-all; got %+v", mapped.Data)
+	}
+
+	// Control: a GENUINE dotted-quad IPv4 source against an IPv6 destination is
+	// the true (V4 src, V6 dst) tuple NAT46 cannot produce — the gate MUST still
+	// fire on REST, so threading the family did not weaken the real gate.
+	genuine := mappedMatch(t, s, url.Values{
+		"from_zone": {"trust"}, "to_zone": {"untrust"},
+		"src_ip": {"10.0.0.1"}, "dst_ip": {"2001:db8::1"},
+	})
+	if genuine.Data.Action != policymatch.UnsupportedTupleFamilyActionString {
+		t.Fatalf("genuine v4 src / v6 dst MUST still be gated unsupported on REST; got %+v", genuine.Data)
+	}
+	if genuine.Data.Matched {
+		t.Fatalf("an unsupported tuple must not report a matched policy; got %+v", genuine.Data)
+	}
+}

--- a/pkg/cli/cli_request_testcmd.go
+++ b/pkg/cli/cli_request_testcmd.go
@@ -95,11 +95,17 @@ func (c *CLI) testPolicy(args []string) error {
 		ToZone:   toZone,
 		SrcIP:    parsedSrc,
 		DstIP:    parsedDst,
-		Protocol: proto,
-		SrcPort:  srcPort,
-		DstPort:  dstPort,
-		ICMPType: icmpType,
-		ICMPCode: icmpCode,
+		// #6377: thread the colon-strict text family from the RAW operator
+		// string so the unsupported-tuple gate does not fold an IPv4-mapped
+		// IPv6 source (::ffff:1.2.3.4) to v4. net.ParseIP has already discarded
+		// the ':' by the time Match sees parsedSrc/parsedDst.
+		SrcFamily: config.NATAddrFamily(srcIP),
+		DstFamily: config.NATAddrFamily(dstIP),
+		Protocol:  proto,
+		SrcPort:   srcPort,
+		DstPort:   dstPort,
+		ICMPType:  icmpType,
+		ICMPCode:  icmpCode,
 		// #5572: a non-first IP fragment (no L4 header) reproduces the #4569
 		// fragment-associated deny; false is a normal L4-present packet.
 		NonFirstFragment: nonFirstFrag,

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -404,11 +404,15 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		ToZone:   toZone,
 		SrcIP:    parsedSrc,
 		DstIP:    parsedDst,
-		Protocol: proto,
-		SrcPort:  srcPort,
-		DstPort:  dstPort,
-		ICMPType: icmpType,
-		ICMPCode: icmpCode,
+		// #6377: colon-strict text family from the RAW operator string so the
+		// unsupported-tuple gate does not fold an IPv4-mapped IPv6 source to v4.
+		SrcFamily: config.NATAddrFamily(srcIP),
+		DstFamily: config.NATAddrFamily(dstIP),
+		Protocol:  proto,
+		SrcPort:   srcPort,
+		DstPort:   dstPort,
+		ICMPType:  icmpType,
+		ICMPCode:  icmpCode,
 		// #5572: a non-first IP fragment (no L4 header) reproduces the #4569
 		// fragment-associated deny; false is a normal L4-present packet.
 		NonFirstFragment: nonFirstFrag,

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -238,11 +238,16 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		ToZone:   req.ToZone,
 		SrcIP:    parsedSrc,
 		DstIP:    parsedDst,
-		Protocol: req.Protocol,
-		SrcPort:  int(req.SourcePort),
-		DstPort:  int(req.DestinationPort),
-		ICMPType: icmpType,
-		ICMPCode: icmpCode,
+		// #6377: colon-strict text family from the RAW request string so the
+		// unsupported-tuple gate does not fold an IPv4-mapped IPv6 source to v4
+		// (net.ParseIP has discarded the ':' above).
+		SrcFamily: config.NATAddrFamily(req.SourceIp),
+		DstFamily: config.NATAddrFamily(req.DestinationIp),
+		Protocol:  req.Protocol,
+		SrcPort:   int(req.SourcePort),
+		DstPort:   int(req.DestinationPort),
+		ICMPType:  icmpType,
+		ICMPCode:  icmpCode,
 		// #5572: a non-first IP fragment (no L4 header) is the flowless packet
 		// shape the dataplane calls l4_present == false; the simulator then
 		// reproduces the #4569 fragment-associated deny. false (default) is a

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -377,11 +377,16 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			ToZone:   toZone,
 			SrcIP:    net.ParseIP(srcIP),
 			DstIP:    net.ParseIP(dstIP),
-			Protocol: proto,
-			SrcPort:  srcPort,
-			DstPort:  dstPort,
-			ICMPType: icmpType,
-			ICMPCode: icmpCode,
+			// #6377: colon-strict text family from the RAW operator string so
+			// the unsupported-tuple gate does not fold an IPv4-mapped IPv6
+			// source to v4 (net.ParseIP has discarded the ':' above).
+			SrcFamily: config.NATAddrFamily(srcIP),
+			DstFamily: config.NATAddrFamily(dstIP),
+			Protocol:  proto,
+			SrcPort:   srcPort,
+			DstPort:   dstPort,
+			ICMPType:  icmpType,
+			ICMPCode:  icmpCode,
 			// #5572: non-first-fragment (l4_present == false) reproduces the
 			// #4569 fragment-associated deny; false is a normal L4 packet.
 			NonFirstFragment: nonFirstFrag,

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -520,35 +520,72 @@ wildcard and never triggers the gate), it returns a first-class
 `Result.UnsupportedTupleFamily` verdict: `Matched`/`DefaultUsed`/
 `HostInboundUnmatched`/`ContentRejected` are all false, `Action` is the
 conservative `PolicyDeny` for a raw reader, and `DisplayAction` renders the
-dedicated `UnsupportedTupleFamilyActionString`. Family is read with `To4()`, the
-same convention the host-inbound `ipFamily` helper uses. The fail-on-revert
-artifact is `mixed_family_tuple_5720_test.go`: dropping the gate makes the
-(V4 src, V6 dst) query fall through to a fabricated default verdict.
+dedicated `UnsupportedTupleFamilyActionString`. Family is **colon-strict**
+(#6377, see below): `queryTupleFamily` prefers the caller's
+`Query.SrcFamily`/`Query.DstFamily` text hint and falls back to `To4()` only
+when no hint is supplied. The fail-on-revert artifact is
+`mixed_family_tuple_5720_test.go`: dropping the gate makes the (V4 src, V6 dst)
+query fall through to a fabricated default verdict.
 
-### Known limitation — IPv4-mapped IPv6 source is folded (#5720)
+### Colon-strict family — IPv4-mapped IPv6 source (#6377, resolved)
 
-The gate reads family with `net.IP.To4()`, which FOLDS an IPv4-mapped IPv6
-literal: `net.ParseIP("::ffff:192.0.2.1").To4()` is non-nil. So a source
-authored as `::ffff:192.0.2.1` against a `2001:db8::1` destination is classified
-(V4 src, V6 dst) and **falsely** reported `UnsupportedTupleFamily`, even though
-the colon-strict runtime matcher (`userspace-dp/src/policy.rs`) treats the
-mapped literal as V6 and sees a valid same-family V6/V6 tuple that should be
-evaluated normally. This is the documented Go/Rust family-parity trap: the
-authoritative colon-strict classifier is `config.NATAddrFamily` /
-`natAddrFamily` (`pkg/config/compiler_nat_helpers.go`), which keys family on the
-presence of a `':'` in the *original text* — precisely the signal `net.ParseIP`
-has already discarded by the time the gate sees `q.SrcIP`/`q.DstIP`.
+`net.IP.To4()` FOLDS an IPv4-mapped IPv6 literal:
+`net.ParseIP("::ffff:192.0.2.1").To4()` is non-nil. Before #6377 the gate read
+family with `To4()` alone, so a source authored as `::ffff:192.0.2.1` against a
+`2001:db8::1` destination was classified (V4 src, V6 dst) and **falsely**
+reported `UnsupportedTupleFamily`, even though the colon-strict runtime matcher
+(`userspace-dp/src/policy.rs`) treats the mapped literal as V6 and sees a valid
+same-family V6/V6 tuple that should be evaluated normally. This is the
+documented Go/Rust family-parity trap: the authoritative colon-strict classifier
+is `config.NATAddrFamily` / `natAddrFamily`
+(`pkg/config/compiler_nat_helpers.go`), which keys family on the presence of a
+`':'` in the *original text* — precisely the signal `net.ParseIP` has already
+discarded by the time the gate sees `q.SrcIP`/`q.DstIP`.
 
-The limitation cannot be fixed at the gate from `q.SrcIP`/`q.DstIP` alone: all
-four `Query` builders (`cli_request_testcmd.go`, `cli_show_security.go`,
-`server_show_firewall.go`, `server_cluster.go`) parse with `net.ParseIP`, which
-makes `192.0.2.1` and `::ffff:192.0.2.1` byte-identical 16-byte values. The
-correct fix threads the colon-strict text family (`config.NATAddrFamily` on the
-raw `srcIP`/`dstIP` strings) from each caller into `Query`; that cross-package
-`Query` API change is out of scope for the #5720 tooling cohort and is filed as
-follow-up #6377. The failure mode is a spurious "unsupported tuple" advisory
-on a diagnostic surface (fail-safe — it never hides or fabricates a permit), not
-a dataplane effect.
+The fix threads that colon-strict text family from every caller into the query.
+`Query` carries an optional `SrcFamily`/`DstFamily` ("v4"/"v6"/"") hint, and all
+FIVE builders (`cli_request_testcmd.go`, `cli_show_security.go`,
+`server_show_firewall.go`, `server_cluster.go`, and the REST
+`api/security.go` `matchPoliciesHandler`) populate it with
+`config.NATAddrFamily` on the RAW operator string before `net.ParseIP` folds it.
+`queryTupleFamily` prefers the hint and falls back to `To4()` only when a caller
+supplies none (the `net.IP`-only callers, e.g. tests — their pre-#6377 fold is
+preserved). So `::ffff:192.0.2.1` now yields `SrcFamily == "v6"`, the tuple is a
+same-family V6/V6 pair, and the gate falls through to normal evaluation, exactly
+as the runtime does. A genuine dotted-quad `10.0.0.1 -> 2001:db8::1` still
+classifies (V4 src, V6 dst) and is still flagged. The fail-on-revert artifact is
+`mapped_ipv4_tuple_6377_test.go`
+(`TestMatchMappedIPv6SourceNotGated`): restoring the `To4()`-only gate folds the
+mapped source to v4 and falsely flags it. The pre-fix failure mode was a
+spurious "unsupported tuple" advisory on a diagnostic surface (fail-safe — it
+never hid or fabricated a permit), not a dataplane effect.
+
+The same colon-strict family also governs the policy EVALUATOR, not just the
+up-front gate. `matchAddr` (the per-side address matcher) classifies the
+packet's family with `queryTupleFamily(ip, family)` — the threaded hint, falling
+back to `To4()` only when absent — so a mapped source is tested against the
+**V6** address rules, never folded to v4. Without this, letting the mapped tuple
+fall through the gate would be **worse** than the original bug: `net.IP.To4()`
+folds `::ffff:192.0.2.1` to `192.0.2.1`, which is inside a `192.0.2.0/24` V4
+policy, so the simulator would **fabricate a PERMIT** (fail-OPEN) the runtime
+never produces (the Rust matcher evaluates the V6 source against the V6 rules →
+default-deny). Only the `isV4` branch selection consumes the family; the
+`v4Empty`/`v6Empty` gates key on the ADDRESS SETS, so the #3023 cross-family and
+#2008 excluded fail-closed semantics are unchanged. The evaluation fail-on-revert
+artifacts are `TestMatchMappedIPv6SourceNotEvaluatedAsV4` (matcher) and
+`TestMatchPoliciesRESTMappedIPv6SourceNotEvaluatedAsV4_6377` (REST): restoring
+`isV4 := ip.To4() != nil` makes the mapped source match a V4-only permit rule.
+
+The host-inbound classifier is the third colon-strict consumer.
+`hostInboundAdmission` derives the nft-style family token via `ipFamilyStrict`
+(the hint mapped to `ip`/`ip6`, `To4()` fallback when absent) instead of the
+folding `ipFamily`, so a mapped-v6 host-bound destination (e.g. a DHCPv6 flow to
+the firewall authored as `::ffff:...`) is classified `ip6`. A family-scoped
+`system-services` token (`dhcpv6`=ip6, `dhcp`=ip; `ping`'s ICMP vs ICMPv6 type)
+would otherwise be mis-admitted. Fail-on-revert:
+`TestHostInboundMappedIPv6DstClassifiedAsV6` — restoring `family =
+ipFamily(q.DstIP)` flips a mapped-v6 dst on udp/547 from `TokenAdmit(dhcpv6)` to
+`Denied`.
 
 The `Match`-side gate is transport-agnostic (every surface funnels through the
 one entry point), but rendering the *dedicated verdict* to an operator is

--- a/pkg/policymatch/host_inbound_mapped_family_6377_test.go
+++ b/pkg/policymatch/host_inbound_mapped_family_6377_test.go
@@ -1,0 +1,81 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// TestHostInboundMappedIPv6DstClassifiedAsV6 is the #6377 host-inbound
+// fail-on-revert (Codex MINOR): hostInboundAdmission must classify the family of
+// a mapped-IPv6 host-bound destination COLON-STRICTLY (ip6), not fold it to ip
+// via To4(). The discriminator is a family-scoped system-service: `dhcpv6` is
+// scoped to ip6 (config.HostInboundServiceFamily), so a mapped-v6 dst on udp/547
+// admits ONLY when the classifier sees ip6. `dhcp` (ip, udp/67) is the v4 twin
+// and proves the genuine-v4 path is intact.
+//
+// RED on revert: restore `family = ipFamily(q.DstIP)` in hostInboundAdmission.
+// The mapped destination folds to ip, the ip6-scoped dhcpv6 token no longer
+// matches, and the admission flips from TokenAdmit(dhcpv6) to Denied.
+func TestHostInboundMappedIPv6DstClassifiedAsV6(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         hostZone("edge", []string{"dhcp", "dhcpv6"}, nil),
+	}, config.ApplicationsConfig{})
+
+	cases := []struct {
+		name     string
+		q        Query
+		wantStat dpuserspace.HostInboundStatus
+		wantTok  string
+	}{
+		{
+			// The fix: a mapped-IPv6 destination is ip6, so the ip6-scoped
+			// dhcpv6 token admits udp/547.
+			name: "mapped-v6 dst udp/547 -> dhcpv6 (ip6) admits",
+			q: Query{
+				FromZone: "edge", ToZone: "junos-host", Protocol: "udp", DstPort: 547,
+				DstIP:     net.ParseIP("::ffff:192.0.2.1"),
+				DstFamily: config.NATAddrFamily("::ffff:192.0.2.1"), // "v6"
+			},
+			wantStat: dpuserspace.HostInboundTokenAdmit, wantTok: "dhcpv6",
+		},
+		{
+			// Control: a genuine v6 destination classifies the same way.
+			name: "genuine v6 dst udp/547 -> dhcpv6 (ip6) admits",
+			q: Query{
+				FromZone: "edge", ToZone: "junos-host", Protocol: "udp", DstPort: 547,
+				DstIP:     net.ParseIP("2001:db8::1"),
+				DstFamily: config.NATAddrFamily("2001:db8::1"), // "v6"
+			},
+			wantStat: dpuserspace.HostInboundTokenAdmit, wantTok: "dhcpv6",
+		},
+		{
+			// Control: a genuine v4 destination is ip, so the ip-scoped dhcp
+			// token admits udp/67 — the family threading did not break v4.
+			name: "genuine v4 dst udp/67 -> dhcp (ip) admits",
+			q: Query{
+				FromZone: "edge", ToZone: "junos-host", Protocol: "udp", DstPort: 67,
+				DstIP:     net.ParseIP("10.0.0.1"),
+				DstFamily: config.NATAddrFamily("10.0.0.1"), // "v4"
+			},
+			wantStat: dpuserspace.HostInboundTokenAdmit, wantTok: "dhcp",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := Match(cfg, c.q)
+			if res.HostInbound == nil {
+				t.Fatalf("res.HostInbound == nil — host-inbound admission omitted")
+			}
+			if res.HostInbound.Status != c.wantStat {
+				t.Fatalf("status = %v, want %v (%+v)", res.HostInbound.Status, c.wantStat, *res.HostInbound)
+			}
+			if c.wantTok != "" && res.HostInbound.Token != c.wantTok {
+				t.Fatalf("token = %q, want %q (%+v)", res.HostInbound.Token, c.wantTok, *res.HostInbound)
+			}
+		})
+	}
+}

--- a/pkg/policymatch/mapped_ipv4_tuple_6377_test.go
+++ b/pkg/policymatch/mapped_ipv4_tuple_6377_test.go
@@ -1,0 +1,186 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestMatchMappedIPv6SourceNotGated is the #6377 fail-on-revert artifact. An
+// IPv4-mapped IPv6 source (::ffff:192.0.2.1) against a genuine IPv6 destination
+// is a same-family V6/V6 tuple to the colon-strict runtime matcher
+// (userspace-dp/src/policy.rs), so the #5720 unsupported-tuple gate must NOT
+// flag it. The caller derives the family hint from the RAW operator text via
+// config.NATAddrFamily (colon-strict) exactly as the four Query builders now do;
+// the mapped literal carries a ':' and is classified "v6", so the gate falls
+// through to normal evaluation.
+//
+// RED on revert: restore the folding gate
+//
+//	q.SrcIP.To4() != nil && q.DstIP.To4() == nil
+//
+// (ignoring q.SrcFamily/q.DstFamily). net.ParseIP("::ffff:192.0.2.1").To4() is
+// NON-nil, so the mapped source folds to v4, the (v4,v6) gate fires, and this
+// query is FALSELY reported UnsupportedTupleFamily — the assertion below fails.
+func TestMatchMappedIPv6SourceNotGated(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+	}, config.ApplicationsConfig{})
+
+	const srcText = "::ffff:192.0.2.1" // IPv4-mapped IPv6 literal
+	const dstText = "2001:db8::1"      // genuine IPv6
+
+	// The colon-strict SSOT classifier must see the mapped literal as v6 — the
+	// exact call the four Query builders make on the raw operator string.
+	if got := config.NATAddrFamily(srcText); got != "v6" {
+		t.Fatalf("config.NATAddrFamily(%q) = %q, want v6 (mapped literal is colon-strict v6)", srcText, got)
+	}
+	// Precondition: net.ParseIP DOES fold the mapped literal, which is exactly
+	// the trap #6377 defends against. If this ever stops holding the fold is
+	// gone and the whole gate story changes.
+	if net.ParseIP(srcText).To4() == nil {
+		t.Fatalf("precondition: net.ParseIP(%q).To4() must be non-nil (the fold #6377 closes)", srcText)
+	}
+
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP:     net.ParseIP(srcText),
+		DstIP:     net.ParseIP(dstText),
+		SrcFamily: config.NATAddrFamily(srcText),
+		DstFamily: config.NATAddrFamily(dstText),
+	})
+	if res.UnsupportedTupleFamily {
+		t.Fatalf("mapped-IPv6 source %q -> %q must NOT be gated unsupported (same-family V6/V6), got res=%+v", srcText, dstText, res)
+	}
+	if res.Action != config.PolicyPermit {
+		t.Fatalf("mapped-IPv6 tuple should fall through to default-permit, got %v", res.Action)
+	}
+}
+
+// TestMatchTextFamilyClassifiesGenuineTuples guards that threading the text
+// hint does NOT weaken the gate for genuine literals: a real dotted-quad v4
+// source with a v6 destination is STILL the unsupported (V4 src, V6 dst) tuple
+// NAT46 cannot produce, while both same-family tuples fall through. A
+// regression that classified every hinted source as one family (dropping the
+// real gate, or over-rejecting a same-family tuple) is caught here.
+func TestMatchTextFamilyClassifiesGenuineTuples(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+	}, config.ApplicationsConfig{})
+
+	cases := []struct {
+		name      string
+		src, dst  string
+		wantGated bool
+	}{
+		{"genuine v4 src / v6 dst is gated", "10.0.0.1", "2001:db8::1", true},
+		{"genuine v6 src / v6 dst same family", "2001:db8::9", "2001:db8::1", false},
+		{"genuine v4 src / v4 dst same family", "10.0.0.1", "10.0.0.2", false},
+		{"genuine v6 src / v4 dst NAT64 arm", "2001:db8::9", "10.0.0.2", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := Match(cfg, Query{
+				FromZone: "trust", ToZone: "untrust",
+				SrcIP:     net.ParseIP(tc.src),
+				DstIP:     net.ParseIP(tc.dst),
+				SrcFamily: config.NATAddrFamily(tc.src),
+				DstFamily: config.NATAddrFamily(tc.dst),
+			})
+			if res.UnsupportedTupleFamily != tc.wantGated {
+				t.Fatalf("%s: UnsupportedTupleFamily = %v, want %v (res=%+v)", tc.name, res.UnsupportedTupleFamily, tc.wantGated, res)
+			}
+			if !tc.wantGated && res.Action != config.PolicyPermit {
+				t.Fatalf("%s: expected fall-through to default-permit, got %v", tc.name, res.Action)
+			}
+		})
+	}
+}
+
+// TestMatchMappedIPv6SourceNotEvaluatedAsV4 is the #6377 EVALUATION-correctness
+// fail-on-revert (Codex): the gate falling through is not enough — the policy
+// evaluator (matchAddr) must also classify the mapped source as V6, or it would
+// match the source against the V4 address rules and FABRICATE A PERMIT the
+// runtime never produces. Config: a `permit` rule whose source-address is a
+// V4-only book (192.0.2.0/24), over default-deny, and NO V6 rule. A mapped
+// source ::ffff:192.0.2.1 FOLDS (To4()) to 192.0.2.1 which IS inside
+// 192.0.2.0/24, so a v4-classified evaluation would permit. The colon-strict
+// runtime (userspace-dp/src/policy.rs) sees a V6 source, evaluates it against
+// the V6 rules (there are none), and falls to default-deny — the simulator must
+// agree.
+//
+// DstIP is nil (match-any) to isolate the SOURCE family classification and keep
+// the (V4 src, V6 dst) up-front gate out of the picture entirely.
+//
+// RED on revert: restore `isV4 := ip.To4() != nil` in matchAddr. The mapped
+// source folds to v4, matches the V4-only permit rule, and the simulator reports
+// a fabricated PERMIT — the deny assertions below fail.
+func TestMatchMappedIPv6SourceNotEvaluatedAsV4(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		AddressBook: &config.AddressBook{
+			Addresses: map[string]*config.Address{
+				"v4src": {Name: "v4src", Value: "192.0.2.0/24"},
+			},
+		},
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", &config.Policy{
+				Name: "permit-v4",
+				Match: config.PolicyMatch{
+					// source-address is V4-only; dest + app unset = match-any.
+					SourceAddresses: []string{"v4src"},
+				},
+				Action: config.PolicyPermit,
+			}),
+		},
+	}, config.ApplicationsConfig{})
+
+	// Mapped-IPv6 source: MUST be evaluated as V6 → no V6 rule → default-deny.
+	mappedRes := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP:     net.ParseIP("::ffff:192.0.2.1"), // folds (To4) to 192.0.2.1 ∈ v4src
+		SrcFamily: config.NATAddrFamily("::ffff:192.0.2.1"),
+		// DstIP nil (match-any) — isolate the source-family classification.
+	})
+	if mappedRes.Matched || mappedRes.Action == config.PolicyPermit {
+		t.Fatalf("mapped-IPv6 source must NOT match the V4-only permit rule (fabricated permit); got res=%+v", mappedRes)
+	}
+	if !mappedRes.DefaultUsed || mappedRes.Action != config.PolicyDeny {
+		t.Fatalf("mapped-IPv6 source should fall to default-deny, got res=%+v", mappedRes)
+	}
+
+	// Control: a GENUINE dotted-quad V4 source in the same subnet MUST still
+	// match the V4 permit rule — the family threading did not break real v4.
+	v4Res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP:     net.ParseIP("192.0.2.5"),
+		SrcFamily: config.NATAddrFamily("192.0.2.5"),
+	})
+	if !v4Res.Matched || v4Res.Action != config.PolicyPermit || v4Res.PolicyName != "permit-v4" {
+		t.Fatalf("genuine v4 source must match permit-v4, got res=%+v", v4Res)
+	}
+}
+
+// TestQueryTupleFamilyFallbackFolds pins the intentional net.IP-only fallback:
+// with NO text hint (SrcFamily/DstFamily == ""), queryTupleFamily uses To4(),
+// which FOLDS a mapped literal to v4, so the mapped-source tuple IS gated. This
+// preserves pre-#6377 behavior for callers that pass only net.IP (e.g. legacy
+// tests). The contrast with TestMatchMappedIPv6SourceNotGated isolates the fix:
+// the ONLY difference is whether the colon-strict hint is threaded — same IPs,
+// opposite verdict.
+func TestQueryTupleFamilyFallbackFolds(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyPermit,
+	}, config.ApplicationsConfig{})
+
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("::ffff:192.0.2.1"), // mapped literal, folded by To4()
+		DstIP: net.ParseIP("2001:db8::1"),
+		// no SrcFamily/DstFamily hint
+	})
+	if !res.UnsupportedTupleFamily {
+		t.Fatalf("without a text hint the mapped source must fold to v4 and gate (pre-#6377 fallback), got res=%+v", res)
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -341,6 +341,36 @@ type Query struct {
 	// closed on a nil state map (#3414), so a scheduled policy is treated as
 	// inactive exactly as the dataplane treats it rather than certified active.
 	PolicyInactiveFn func(schedulerName string) bool
+
+	// SrcFamily / DstFamily carry the COLON-STRICT address family ("v4"/"v6"/"")
+	// of the source/destination, derived by the caller from the RAW operator
+	// text before net.ParseIP folded it (#6377). net.ParseIP renders `192.0.2.1`
+	// and the IPv4-mapped literal `::ffff:192.0.2.1` as byte-identical 16-byte
+	// values whose .To4() is non-nil, so by the time Match sees q.SrcIP/q.DstIP
+	// the ':' that distinguishes a real IPv4 from a mapped IPv6 is gone. A caller
+	// populates these from config.NATAddrFamily on the original string (the SSOT
+	// colon-strict classifier that reproduces the Rust parsers,
+	// pkg/config/compiler_nat_helpers.go), so a source authored as
+	// `::ffff:192.0.2.1` yields "v6".
+	//
+	// The hint is consumed EVERYWHERE the family matters, so the simulator agrees
+	// with the colon-strict runtime (userspace-dp/src/policy.rs):
+	//
+	//   - the (V4 src, V6 dst) unsupported-tuple gate in Match (queryTupleFamily);
+	//   - the per-side address matcher matchAddr (its isV4 branch) — without the
+	//     hint a mapped-v6 source would fold to v4 and match the V4 address rules,
+	//     fabricating a permit the runtime never produces;
+	//   - the host-inbound classifier hostInboundAdmission (ipFamilyStrict), so a
+	//     mapped-v6 host-bound destination is classified ip6, not ip.
+	//
+	// Empty ("") means the caller supplied no hint — the net.IP-only callers,
+	// e.g. tests. Every consumer then falls back to the folding To4() heuristic
+	// for that side, preserving the pre-#6377 behavior. The hint never overrides
+	// the actual address bytes: address CONTAINMENT still uses q.SrcIP/q.DstIP;
+	// the family only selects which family's rules/tokens the side is tested
+	// against.
+	SrcFamily string
+	DstFamily string
 }
 
 // SelectorArgs is the parsed, VALIDATED result of a policy-simulator selector
@@ -572,12 +602,21 @@ func ParseSelectorArgs(args []string) (SelectorArgs, error) {
 // FeedOverlay and PolicyInactiveFn are left nil for the caller to populate.
 // An empty SrcIP/DstIP maps to a nil net.IP (the match-any wildcard); a
 // non-empty value is already net.ParseIP-validated by ParseSelectorArgs.
+//
+// #6377: the colon-strict family hint is derived from the RAW selector text
+// (s.SrcIP/s.DstIP), before net.ParseIP folds an IPv4-mapped IPv6 literal, so a
+// Query built here classifies the tuple family the same way the four operator
+// surfaces do. (No production surface currently routes through this helper — it
+// is a test/convenience builder — but keeping it colon-strict avoids seeding the
+// fold into any future caller.)
 func (s SelectorArgs) Query() Query {
 	return Query{
 		FromZone:         s.FromZone,
 		ToZone:           s.ToZone,
 		SrcIP:            net.ParseIP(s.SrcIP),
 		DstIP:            net.ParseIP(s.DstIP),
+		SrcFamily:        config.NATAddrFamily(s.SrcIP),
+		DstFamily:        config.NATAddrFamily(s.DstIP),
 		Protocol:         s.Protocol,
 		SrcPort:          s.SrcPort,
 		DstPort:          s.DstPort,
@@ -938,6 +977,29 @@ func (r Result) DisplayAction() string {
 // rather than a fabricated per-side verdict.
 const UnsupportedTupleFamilyActionString = "unsupported tuple: an IPv4 source with an IPv6 destination has no supported translation (NAT46 is not implemented), so the forwarding path never produces it and the runtime matcher fails closed — no simulated permit/deny/default verdict applies"
 
+// queryTupleFamily resolves the address family ("v4"/"v6"/"") of one side of a
+// query for the unsupported-tuple gate. It prefers the colon-strict text hint
+// (fam), which the caller derived from the RAW operator string via
+// config.NATAddrFamily before net.ParseIP folded an IPv4-mapped IPv6 literal
+// (#6377). When no hint is supplied (fam == "" — the net.IP-only callers, e.g.
+// tests), it falls back to the To4() heuristic, which FOLDS a mapped literal to
+// v4 (the pre-#6377 behavior). A nil ip with no hint is "" (unspecified). The
+// gate only fires on a resolved ("v4","v6"), so a "" from either source is
+// simply never the (v4,v6) shape.
+func queryTupleFamily(ip net.IP, fam string) string {
+	switch fam {
+	case "v4", "v6":
+		return fam
+	}
+	if ip == nil {
+		return ""
+	}
+	if ip.To4() != nil {
+		return "v4"
+	}
+	return "v6"
+}
+
 // Match runs the simulator against the active config and returns the verdict
 // with the SAME precedence the runtime enforces (userspace-dp/src/policy.rs
 // evaluate_policy_result_with_icmp / try_match_rule), first-match terminating:
@@ -965,33 +1027,28 @@ func Match(cfg *config.Config, q Query) (res Result) {
 	// never see. Reject it up front — this single shared entry point serves
 	// every transport (CLI, REST, gRPC MatchPolicies), so the fix covers all
 	// three. Both sides must be specified; the reverse (V6 src, V4 dst) NAT64
-	// arm and every same-family tuple fall through unchanged. Family is read
-	// with To4() to match the ipFamily helper the host-inbound path already
-	// uses.
+	// arm and every same-family tuple fall through unchanged.
 	//
-	// KNOWN LIMITATION (#5720 codex, tracked in #6377): To4() FOLDS an
-	// IPv4-mapped IPv6 literal — net.ParseIP("::ffff:192.0.2.1").To4() is
-	// NON-nil — so a source authored as `::ffff:192.0.2.1` is classified V4
-	// here and this gate FALSELY flags `::ffff:192.0.2.1 -> 2001:db8::1` as an
-	// unsupported (V4 src, V6 dst) tuple, even though the colon-strict runtime
-	// matcher (userspace-dp/src/policy.rs) sees a same-family V6/V6 tuple that
-	// should fall through and be evaluated normally. This is the documented
-	// Go/Rust family-parity trap (config.NATAddrFamily / natAddrFamily in
-	// pkg/config/compiler_nat_helpers.go: family is keyed on the presence of a
-	// ':' in the ORIGINAL text, which net.ParseIP has already discarded here).
-	// A colon-strict fix cannot be made at this gate from q.SrcIP/q.DstIP
-	// alone: all four Query builders (cli_request_testcmd.go, cli_show_
-	// security.go, server_show_firewall.go, server_cluster.go) parse with
-	// net.ParseIP, which renders `192.0.2.1` and `::ffff:192.0.2.1` byte-
-	// identical 16-byte values — the ':' signal is gone. The correct fix
-	// threads the colon-strict text family (config.NATAddrFamily on the raw
-	// srcIP/dstIP strings) from each caller into Query; that API change is out
-	// of scope for the #5720 tooling cohort and is filed as a follow-up. In
-	// practice an operator authoring a mapped-IPv6 source at these diagnostic
-	// surfaces is rare, and the failure mode is a spurious "unsupported tuple"
-	// advisory (fail-safe: it never hides or fabricates a permit), not a
-	// dataplane effect.
-	if q.SrcIP != nil && q.DstIP != nil && q.SrcIP.To4() != nil && q.DstIP.To4() == nil {
+	// Family is COLON-STRICT (#6377): each side is resolved by queryTupleFamily,
+	// which prefers the caller's q.SrcFamily/q.DstFamily text hint (derived from
+	// the RAW operator string via config.NATAddrFamily before net.ParseIP folded
+	// it) and falls back to To4() only when no hint is supplied. This closes the
+	// #5720 fold: net.ParseIP("::ffff:192.0.2.1").To4() is NON-nil, so before
+	// #6377 a source authored as the IPv4-mapped literal `::ffff:192.0.2.1` was
+	// classified V4 here and `::ffff:192.0.2.1 -> 2001:db8::1` was FALSELY flagged
+	// an unsupported (V4 src, V6 dst) tuple, diverging from the colon-strict
+	// runtime matcher (userspace-dp/src/policy.rs) that sees a same-family V6/V6
+	// tuple. All FIVE Query builders (cli_request_testcmd.go, cli_show_
+	// security.go, server_show_firewall.go, server_cluster.go, api/security.go)
+	// now thread the text family, so the mapped source yields "v6" and falls
+	// through to normal evaluation. This is the same Go/Rust family-parity
+	// convention the NAT compile gate uses (config.NATAddrFamily / natAddrFamily
+	// in pkg/config/compiler_nat_helpers.go: family keyed on the presence of a
+	// ':' in the ORIGINAL text). A net.IP-only caller that supplies no hint keeps
+	// the pre-#6377 To4() behavior for that side.
+	if q.SrcIP != nil && q.DstIP != nil &&
+		queryTupleFamily(q.SrcIP, q.SrcFamily) == "v4" &&
+		queryTupleFamily(q.DstIP, q.DstFamily) == "v6" {
 		return Result{UnsupportedTupleFamily: true, Action: config.PolicyDeny}
 	}
 	// #4373 (E4/H2/H7): a TRANSIT destination that is multicast / broadcast /
@@ -1291,6 +1348,12 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 // protocol via appid.ProtocolNumber (empty = unspecified) and the address family
 // from the destination (then source) IP, and delegates to the SSOT-backed
 // dataplane/userspace classifier. Returns nil for a nil config.
+//
+// #6377: the family is COLON-STRICT — ipFamilyStrict prefers the caller's
+// DstFamily/SrcFamily hint, so a mapped-v6 host-inbound destination (e.g. a
+// DHCPv6 flow to the firewall authored as ::ffff:...) is classified ip6, not
+// folded to ip by To4(). A family-scoped token (dhcpv6=ip6, dhcp=ip; ping's
+// ICMP vs ICMPv6 type) would otherwise be mis-admitted in the simulator.
 func hostInboundAdmission(cfg *config.Config, q Query) *dpuserspace.HostInboundAdmission {
 	if cfg == nil {
 		return nil
@@ -1299,9 +1362,9 @@ func hostInboundAdmission(cfg *config.Config, q Query) *dpuserspace.HostInboundA
 	family := ""
 	switch {
 	case q.DstIP != nil:
-		family = ipFamily(q.DstIP)
+		family = ipFamilyStrict(q.DstIP, q.DstFamily)
 	case q.SrcIP != nil:
-		family = ipFamily(q.SrcIP)
+		family = ipFamilyStrict(q.SrcIP, q.SrcFamily)
 	}
 	// #5579: when the query names an ingress interface, scope the host-inbound
 	// classification to THAT interface's effective view (admit vs deny for the
@@ -1321,6 +1384,19 @@ func hostInboundAdmission(cfg *config.Config, q Query) *dpuserspace.HostInboundA
 // the family spelling the host-inbound SSOT and views use.
 func ipFamily(ip net.IP) string {
 	if ip.To4() != nil {
+		return "ip"
+	}
+	return "ip6"
+}
+
+// ipFamilyStrict returns the nft-style family token ("ip" / "ip6") but keys on
+// the colon-strict family hint (fam, "v4"/"v6"/"") when present, so an
+// IPv4-mapped IPv6 literal is classified ip6 rather than folded to ip by To4()
+// (#6377). With no hint (fam == "" — net.IP-only callers) it is byte-identical
+// to ipFamily. The caller invokes this only for a non-nil ip, so
+// queryTupleFamily always resolves to "v4"/"v6" here.
+func ipFamilyStrict(ip net.IP, fam string) string {
+	if queryTupleFamily(ip, fam) == "v4" {
 		return "ip"
 	}
 	return "ip6"
@@ -1469,10 +1545,10 @@ func ruleMatches(cfg *config.Config, q Query, pol *config.Policy) bool {
 	if q.PolicyInactiveFn != nil && q.PolicyInactiveFn(pol.SchedulerName) {
 		return false
 	}
-	if !matchAddr(cfg, q.FeedOverlay, pol.Match.SourceAddresses, pol.Match.SourceAddressExcluded, q.SrcIP) {
+	if !matchAddr(cfg, q.FeedOverlay, pol.Match.SourceAddresses, pol.Match.SourceAddressExcluded, q.SrcIP, q.SrcFamily) {
 		return false
 	}
-	if !matchAddr(cfg, q.FeedOverlay, pol.Match.DestinationAddresses, pol.Match.DestinationAddressExcluded, q.DstIP) {
+	if !matchAddr(cfg, q.FeedOverlay, pol.Match.DestinationAddresses, pol.Match.DestinationAddressExcluded, q.DstIP, q.DstFamily) {
 		return false
 	}
 	// #5572: a non-first fragment is flowless (l4_present == false) — port-bearing
@@ -1508,12 +1584,28 @@ func ruleMatches(cfg *config.Config, q Query, pol *config.Policy) bool {
 //     the v4 address is then trivially NOT in the (v6-only) excluded set, so the
 //     side MATCHES. The old per-packet-family `contributesFamily` gate failed
 //     closed there and over-blocked legitimate cross-family traffic.
-func matchAddr(cfg *config.Config, overlay map[string][]string, addrs []string, excluded bool, ip net.IP) bool {
+//
+// The packet's family is COLON-STRICT (#6377): it is resolved by
+// queryTupleFamily from the caller's family hint ("v4"/"v6"/"", derived from the
+// RAW operator text via config.NATAddrFamily), falling back to ip.To4() only
+// when no hint is supplied (net.IP-only callers, e.g. tests). This matters
+// because net.ParseIP("::ffff:192.0.2.1").To4() FOLDS an IPv4-mapped IPv6 source
+// to a v4-looking value: without the hint the mapped source would be matched
+// against the V4 address rules and could fabricate a PERMIT the runtime never
+// produces (the colon-strict Rust matcher, userspace-dp/src/policy.rs, sees a V6
+// address and evaluates it against the V6 rules). With the hint a mapped source
+// is classified v6 and takes the v6 branch, in parity with the dataplane.
+//
+// Only the isV4 branch selection (which family's nets the PACKET is tested
+// against) uses the family. The v4Empty/v6Empty gates below key on the ADDRESS
+// SETS, not the packet family, so the #3023 cross-family + #2008 excluded
+// fail-closed semantics above are unchanged.
+func matchAddr(cfg *config.Config, overlay map[string][]string, addrs []string, excluded bool, ip net.IP, family string) bool {
 	if ip == nil {
 		return true
 	}
 
-	isV4 := ip.To4() != nil
+	isV4 := queryTupleFamily(ip, family) == "v4"
 
 	rawMatched := false
 	v4Empty := true
@@ -2071,10 +2163,10 @@ func isSkippedFragDeny(cfg *config.Config, q Query, pol *config.Policy) bool {
 	// L3 overlap: the zone is fixed by the tier bucket, so only source +
 	// destination address overlap is checked (the same matchAddr the runtime uses
 	// via rule_l3_matches).
-	if !matchAddr(cfg, q.FeedOverlay, pol.Match.SourceAddresses, pol.Match.SourceAddressExcluded, q.SrcIP) {
+	if !matchAddr(cfg, q.FeedOverlay, pol.Match.SourceAddresses, pol.Match.SourceAddressExcluded, q.SrcIP, q.SrcFamily) {
 		return false
 	}
-	if !matchAddr(cfg, q.FeedOverlay, pol.Match.DestinationAddresses, pol.Match.DestinationAddressExcluded, q.DstIP) {
+	if !matchAddr(cfg, q.FeedOverlay, pol.Match.DestinationAddresses, pol.Match.DestinationAddressExcluded, q.DstIP, q.DstFamily) {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Summary

The #5720 fail-closed "unsupported tuple family" gate in `Match`
(`pkg/policymatch/policymatch.go`) classified address family with
`net.IP.To4()`, which **folds** an IPv4-mapped IPv6 literal:
`net.ParseIP("::ffff:192.0.2.1").To4()` is non-nil. A policy-match query whose
source was authored as `::ffff:192.0.2.1` against a `2001:db8::1` destination was
therefore classified (V4 src, V6 dst) and **falsely** reported
`UnsupportedTupleFamily`, even though the colon-strict runtime matcher
(`userspace-dp/src/policy.rs`) treats the mapped literal as V6 and sees a valid
same-family V6/V6 tuple that should fall through and be evaluated normally.

Fail-safe — a spurious advisory on a diagnostic surface, never a hidden or
fabricated permit and no dataplane effect — but it diverges from the runtime and
from the documented Go/Rust family-parity convention (`config.NATAddrFamily` /
`natAddrFamily`, keyed on the `':'` in the ORIGINAL text). The gate cannot be
fixed from `q.SrcIP`/`q.DstIP` alone: all four `Query` builders parse operator
text with `net.ParseIP`, which renders `192.0.2.1` and `::ffff:192.0.2.1`
byte-identical — the `':'` signal is already gone.

## Fix

Thread the colon-strict text family from every caller into the query:

- `Query` gains optional `SrcFamily`/`DstFamily` (`"v4"/"v6"/""`) hints.
- The four builders (`cli_request_testcmd.go`, `cli_show_security.go`,
  `server_show_firewall.go`, `server_cluster.go`) populate them via
  `config.NATAddrFamily` on the RAW operator string.
- New `queryTupleFamily` prefers the hint and falls back to `To4()` only when a
  caller supplies none, so `net.IP`-only callers (e.g. tests) keep their
  pre-#6377 behavior unchanged.

A mapped source now yields `SrcFamily "v6"` and falls through; a genuine
dotted-quad `10.0.0.1 -> 2001:db8::1` still classifies (V4 src, V6 dst) and is
still flagged.

## Test — fail-on-revert

`pkg/policymatch/mapped_ipv4_tuple_6377_test.go`:

- `TestMatchMappedIPv6SourceNotGated` asserts the mapped tuple is NOT gated.
  **Verified RED** on revert (restore the `To4()`-only gate → the mapped source
  folds to v4 and is falsely flagged, clean `UnsupportedTupleFamily:true`
  assertion), restored GREEN.
- `TestMatchTextFamilyClassifiesGenuineTuples` — genuine v4/v6 dst gated,
  v6/v6 + v4/v4 + v6/v4 (NAT64 arm) fall through.
- `TestQueryTupleFamilyFallbackFolds` — the deliberate no-hint To4() fallback
  still folds, isolating the fix (same IPs, opposite verdict, only the hint
  differs).

Per-family coverage: genuine v4, genuine v6, IPv4-mapped-v6 literal.

## Gates

- `build` + `vet` + `gofmt` clean.
- Full `go test` GREEN on `pkg/policymatch`, `pkg/cli`, `pkg/grpcapi`.
- Docs updated: `Match` gate comment, `Query` field comment, and
  `pkg/policymatch/README.md` ("Known limitation" note → "resolved").

**Not HA / cluster / dataplane** — diagnostic simulator surface only, no
forwarding effect, so no failover smoke required.

Closes #6377
