### PR TITLE
test/xsk-repro: word-split $CC in selftest-compile.sh SKIP probes (#6355)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -59562,3 +59562,21 @@ top.
     clean assertions; restored green.
   - **File(s)**: pkg/cli/cli_request_ping.go, pkg/cli/cli_request_argv_test.go,
     pkg/cli/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+  - **Action**: #6355 fix — test/xsk-repro/selftest-compile.sh's SKIP probes
+    word-split $CC like the Makefile's $(CC). The tool-gate `command -v "$CC"`
+    and the trial-link `"$CC" -x c -` both QUOTED $CC, so a multi-token wrapper
+    compiler (`ccache gcc`, `env cc`, `gcc -flag`) that `make check` accepts
+    false-SKIPped (over-skip, never a hidden failure — hence LOW; #6353 Codex
+    M2 follow-up). Fix: extract the first word for the existence check
+    (`CC_BIN=${CC%% *}`) and leave $CC unquoted (word-split) for the trial link,
+    matching $(CC). Fail-on-revert gate `selftest-multitoken-cc_6355.sh`
+    (hermetic — `env <fakecc>` models a working toolchain) asserts the wrapper
+    CC reaches PASS (exit 0); re-quoting EITHER probe as "$CC" makes the wrapper
+    unfindable/unexecutable → SKIP (exit 77) → RED. Verified RED→GREEN on both
+    revert directions firsthand. Registered under `make selftest`. Documented
+    in test/xsk-repro/README.md (#6355 follow-up to the M2 note).
+  - **File(s)**: test/xsk-repro/selftest-compile.sh,
+    test/xsk-repro/selftest-multitoken-cc_6355.sh, scripts/run-selftests.sh,
+    test/xsk-repro/README.md, _Log.md

--- a/scripts/run-selftests.sh
+++ b/scripts/run-selftests.sh
@@ -152,6 +152,11 @@ run_shell test/xsk-repro/selftest-compile.sh
 # archives), not just header syntax, so a headers-present/static-missing host
 # SKIPs cleanly instead of false-RED. Hermetic (fake cc); SKIPs without make/xxd.
 run_shell test/xsk-repro/selftest-skipgate_6289.sh
+# #6355: selftest-compile.sh must WORD-SPLIT $CC like the Makefile's $(CC) so a
+# multi-token wrapper CC (`ccache gcc`, `env cc`) that `make check` accepts runs
+# through instead of false-SKIPping. Hermetic (fake cc via `env`); SKIPs without
+# make/xxd/env.
+run_shell test/xsk-repro/selftest-multitoken-cc_6355.sh
 
 # ── summary ──
 printf '\n\033[1m== selftest summary ==\033[0m\n'

--- a/test/xsk-repro/README.md
+++ b/test/xsk-repro/README.md
@@ -130,3 +130,17 @@ hold):
   asserts the script SKIPs (exit 77) via the link probe; reverting the fix
   (probe back to `-fsyntax-only`) makes the script reach `make check` and exit
   1 instead → the gate goes RED. Registered under `make selftest`.
+- **#6355 — the SKIP probe honored `$CC` only for a SINGLE-token compiler.**
+  The M2 gate claimed to "honor `$CC` like the Makefile", but the tool-gate
+  `command -v "$CC"` and the trial-link `"$CC" -x c -` both QUOTED `$CC`,
+  treating the whole string as one executable. The Makefile's `$(CC)`
+  word-splits, so a multi-token wrapper CC (`ccache gcc`, `env cc`,
+  `gcc -flag`) that `make check` accepts made both probes fail → a false-SKIP
+  (over-skip, never a hidden failure — hence LOW). The probe now splits the
+  first word for the existence check (`CC_BIN=${CC%% *}`) and leaves `$CC`
+  unquoted for the trial link, matching `$(CC)`. **Gate:**
+  `selftest-multitoken-cc_6355.sh` — a hermetic fail-on-revert test that points
+  `selftest-compile.sh` at a multi-token CC (`env <fakecc>` modelling a working
+  toolchain) and asserts the script reaches PASS (exit 0); re-quoting either
+  probe as `"$CC"` makes the wrapper unfindable/unexecutable → the script SKIPs
+  (exit 77) → the gate goes RED. Registered under `make selftest`.

--- a/test/xsk-repro/selftest-compile.sh
+++ b/test/xsk-repro/selftest-compile.sh
@@ -21,8 +21,16 @@ cd "$HERE" || { echo "FATAL: cannot cd to $HERE" >&2; exit 1; }
 # test drives this by pointing CC at a fake compiler.
 CC=${CC:-cc}
 
+# $CC may be a multi-token wrapper ("ccache gcc", "env cc", "gcc -flag") — the
+# Makefile's $(CC) word-splits, so `make check` runs the first token as the
+# executable with the rest as arguments. The `command -v` existence check below
+# and the trial-link probe must therefore split $CC the same way, or a wrapper
+# CC that `make check` accepts would false-SKIP here (#6355). Extract the first
+# word for the tool gate; word-split the whole string for the link/build.
+CC_BIN=${CC%% *}
+
 # --- tool gate ---
-for tool in "$CC" make xxd; do
+for tool in "$CC_BIN" make xxd; do
 	command -v "$tool" >/dev/null 2>&1 || {
 		echo "SKIP: $tool not installed"
 		exit 77
@@ -35,8 +43,12 @@ done
 # libzstd.a) passed the old header-only -fsyntax-only probe and then FAILed the
 # `make check` static link → a false-RED for this leg. Probing the actual link
 # makes such a host SKIP cleanly. -o /dev/null discards the trial binary.
+# $CC is intentionally unquoted so a multi-token wrapper CC word-splits exactly
+# like the Makefile's $(CC) (#6355). Quoting it would exec the whole string as a
+# single binary and false-SKIP a wrapper `make check` would accept.
+# shellcheck disable=SC2086
 if ! printf '#include <bpf/bpf.h>\n#include <xdp/xsk.h>\nint main(void){return 0;}\n' \
-	| "$CC" -x c - -o /dev/null \
+	| $CC -x c - -o /dev/null \
 		-Wl,-Bstatic -lxdp -lbpf -lelf -lz -lzstd -Wl,-Bdynamic -lpthread \
 		>/dev/null 2>&1; then
 	echo "SKIP: libbpf-dev / libxdp-dev headers or static archives not available"

--- a/test/xsk-repro/selftest-multitoken-cc_6355.sh
+++ b/test/xsk-repro/selftest-multitoken-cc_6355.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Fail-on-revert gate for #6355: selftest-compile.sh's tool gate and trial-link
+# probe must WORD-SPLIT $CC exactly like the Makefile's $(CC), so a multi-token
+# wrapper compiler (`ccache gcc`, `env cc`, `gcc -flag`) that `make check`
+# accepts runs through the SKIP probes instead of false-SKIPping.
+#
+# The bug (#6353 Codex M2): the probes used "$CC" quoted, treating the whole
+# string as one executable. `command -v "ccache gcc"` and `"ccache gcc" -x c -`
+# both fail for a wrapper CC -> the script SKIPs (exit 77) even though
+# `make check CC="ccache gcc"` (which word-splits) would BUILD. The fix strips
+# the first word for the `command -v` existence check (CC_BIN=${CC%% *}) and
+# leaves $CC unquoted for the trial link.
+#
+# Method (hermetic — needs no real libbpf/libxdp): point selftest-compile.sh at
+# a multi-token CC = "env <fakecc>", where the fake compiler models a fully
+# working toolchain — the trial link and every `make check` build succeed. With
+# the fix, `env` (first word) is found by the tool gate, the link probe and the
+# build word-split to run the fake cc, and the script reaches PASS (exit 0).
+#
+# Revert direction (why this binds): re-quote either probe as "$CC" and the
+# multi-token string is treated as a single binary that does not exist / cannot
+# exec — the tool gate prints "SKIP: env <fakecc> not installed" (or the link
+# probe SKIPs) and the script exits 77, not 0. The exit==0 / PASS assertions
+# below then go RED. That is the fail-on-revert.
+#
+# Tool-gated: SKIPs (exit 77) when make / xxd / env are unavailable, because the
+# script-under-test would then SKIP for a DIFFERENT reason and this test could
+# not attribute the outcome to $CC word-splitting.
+set -u
+
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$HERE" || { echo "FATAL: cannot cd to $HERE" >&2; exit 1; }
+
+SUT="$HERE/selftest-compile.sh"
+[ -f "$SUT" ] || { echo "SKIP: selftest-compile.sh not present"; exit 77; }
+
+# make + xxd: the script-under-test builds the embedded-object header (xxd) and
+# runs the strict-warning build (make). env: the multi-token wrapper front-end.
+# Missing any of them means the SUT would SKIP for that reason, not $CC-split.
+for tool in make xxd env; do
+	command -v "$tool" >/dev/null 2>&1 || {
+		echo "SKIP: $tool not installed (cannot bind the multi-token-CC probe)"
+		exit 77
+	}
+done
+
+WORK=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT
+
+# Fake compiler modelling a fully working toolchain: the trial link and every
+# `make check` build succeed. For any `-o <file>` other than /dev/null, create
+# the target so `make` sees the tool built; always exit 0.
+cat > "$WORK/fakecc" <<'EOF'
+#!/bin/sh
+out=
+prev=
+for a in "$@"; do
+	[ "$prev" = "-o" ] && out=$a
+	prev=$a
+done
+if [ -n "$out" ] && [ "$out" != /dev/null ]; then
+	: > "$out" 2>/dev/null || true
+fi
+exit 0
+EOF
+chmod +x "$WORK/fakecc"
+
+# A genuine multi-token wrapper CC: `env` (a real on-PATH binary) runs the fake
+# compiler. This is exactly the shape `make check` word-splits and runs.
+out=$(CC="env $WORK/fakecc" sh "$SUT" 2>&1)
+rc=$?
+
+fail=0
+if [ "$rc" -ne 0 ]; then
+	echo "FAIL: a multi-token CC that make-check accepts should reach PASS" \
+	     "(exit 0), got exit $rc" >&2
+	fail=1
+fi
+if ! printf '%s\n' "$out" | grep -qi 'PASS: xsk-repro strict-warning build'; then
+	echo "FAIL: expected the strict-warning build PASS line from a wrapper CC" >&2
+	fail=1
+fi
+# Name the tool-gate revert signature directly: the probe must not report the
+# multi-token compiler string as an uninstalled tool.
+if printf '%s\n' "$out" | grep -qi 'not installed'; then
+	echo "FAIL: tool gate false-SKIPped a multi-token CC ('... not installed')" >&2
+	fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+	printf '%s\n' "$out" | sed 's/^/      /' >&2
+	echo "FAIL: #6355 multi-token-CC word-split gate" >&2
+	exit 1
+fi
+
+echo "PASS: #6355 multi-token-CC word-split gate (wrapper CC -> build, not SKIP)"
+exit 0


### PR DESCRIPTION
## Problem

`test/xsk-repro/selftest-compile.sh` claimed to "honor `$CC` like the Makefile" (#6289 M2), but its tool gate `command -v "$CC"` and its trial-link probe `"$CC" -x c -` both **quoted** `$CC`, treating the whole string as a single executable. The Makefile's recipe uses `$(CC)`, which **word-splits** — so `make check` runs the first token as the compiler with the rest as arguments.

A multi-token wrapper CC that `make check` accepts (`ccache gcc`, `env cc`, `gcc -flag`) therefore **false-SKIPped** both probes: the wrapper string is neither a findable binary (`command -v` fails) nor an executable path (the trial link exec fails), so the script exits 77 even though the build would succeed. Safe direction (over-skip, never a hidden failure) — hence LOW. Provenance: #6353 Codex M2 review follow-up.

## Fix

Split `$CC` the way the shell does when the Makefile runs `$(CC)`:
- tool gate: check the **first word** — `CC_BIN=${CC%% *}` — the actual executable;
- trial link: leave `$CC` **unquoted** so it word-splits into `<wrapper> <args>`.

`make -s check CC="$CC"` already word-splits internally and is unchanged.

## Fail-on-revert gate

`test/xsk-repro/selftest-multitoken-cc_6355.sh` — hermetic (no real libbpf/libxdp): points `selftest-compile.sh` at a multi-token CC (`env <fakecc>`, the fake compiler modelling a working toolchain) and asserts the script reaches **PASS (exit 0)**. Re-quoting **either** probe as `"$CC"` makes the wrapper unfindable/unexecutable → the script SKIPs (exit 77) → the gate goes **RED**. Registered under `make selftest`; SKIPs cleanly without make/xxd/env.

## Verification (firsthand)

- Before: `CC="env cc"` → `SKIP: env cc not installed` (exit 77).
- After: `CC="env cc"` → `PASS: xsk-repro strict-warning build` (exit 0), matching `make check`.
- New gate GREEN on the fix; RED verified on **both** revert directions (tool-gate re-quote and link-probe re-quote) independently.
- `#6289` sibling gate and default-`CC` run still PASS. `sh -n` on the runner clean. No build-artifact residue.

Docs: `test/xsk-repro/README.md` updated with the #6355 follow-up to the M2 note.

Closes #6355