### PR TITLE
test: bind TestMgmtReconcileTLSChange_5866 to the durable-cert contract

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -59660,3 +59660,16 @@ top.
   - **File(s)**: test/xsk-repro/selftest-compile.sh,
     test/xsk-repro/selftest-multitoken-cc_6355.sh, scripts/run-selftests.sh,
     test/xsk-repro/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+- **Action**: Fix #6381 — TestMgmtReconcileTLSChange_5866 asserted a false
+    "fresh leaf per rebind" invariant that only passed as a CI artifact
+    (unwritable /etc/xpf/tls). Redirected certGen to a writable temp dir via a
+    new test-only api.Server.SetTLSCertDirForTest hook and re-encoded the
+    intended invariant: an HTTPS bind change make-before-break rebinds the HTTPS
+    leg but the DURABLE self-signed cert (#1916 D6) is reloaded AS-IS (identical
+    leaf bytes) — a rebind must not re-mint (TOFU-pin churn). Parent-RED:
+    neutralizing the durable-reload path (forced re-mint) turns the corrected
+    assertion RED, proving it now binds (the old assertion PASSED under exactly
+    that re-mint condition). Test-only; no production behavior change.
+- **File(s)**: pkg/api/server.go, pkg/daemon/management_5866_test.go, _Log.md

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -725,13 +726,15 @@ func (s *Server) ReplaceAuth(a *AuthConfig) {
 func (s *Server) AuthSnapshotForTest() *AuthConfig { return s.auth.Load() }
 
 // HTTPSCertForTest returns the served TLS leaf certificate, or nil when the
-// server is HTTP-only (#5866). Test-only: lets a cross-package test assert that a
-// TLS-material reconcile rebuilds the listener with a FRESH certificate.
+// server is HTTP-only (#5866). Test-only: lets a cross-package test read the cert
+// the LIVE HTTPS leg is serving after a reconcile, to assert that the durable
+// self-signed pair is reloaded AS-IS across a rebind (#1916 D6 / #6381) rather
+// than re-minted.
 func (s *Server) HTTPSCertForTest() *tls.Certificate {
 	s.lifeMu.Lock()
 	defer s.lifeMu.Unlock()
 	// Read the LIVE HTTPS leg (post-reconcile), not the construction template, so
-	// a TLS-material rebind's fresh cert is observed (#5866).
+	// the cert the rebound listener actually serves is observed (#5866).
 	srv := s.httpsServer
 	if s.httpsLeg != nil {
 		srv = s.httpsLeg.srv
@@ -740,6 +743,24 @@ func (s *Server) HTTPSCertForTest() *tls.Certificate {
 		return nil
 	}
 	return &srv.TLSConfig.Certificates[0]
+}
+
+// SetTLSCertDirForTest points the server's HTTPS certificate generator at dir
+// instead of the production /etc/xpf/tls paths (#6381). Test-only: it lets a
+// cross-package test (pkg/daemon managementReconciler) exercise the DURABLE
+// self-signed-cert path (#1916 D6) against a WRITABLE temp dir, so an HTTPS
+// rebind LOADS the persisted pair AS-IS (the shipping behavior) instead of
+// failing to persist and re-minting a fresh in-memory cert on every reconcile
+// (the CI-only artifact — an unwritable /etc/xpf/tls — that the old
+// TestMgmtReconcileTLSChange_5866 assertion silently depended on). It routes
+// through the real production generateSelfSignedCertAt, so the durable
+// load-as-is path is genuinely bound.
+func (s *Server) SetTLSCertDirForTest(dir string) {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+	s.certGen = func(bindHost string) (tls.Certificate, error) {
+		return generateSelfSignedCertAt(dir, filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem"), bindHost)
+	}
 }
 
 // dynamicAuthMiddleware wraps next with the LIVE auth snapshot (#5866): it reads

--- a/pkg/daemon/management_5866_test.go
+++ b/pkg/daemon/management_5866_test.go
@@ -161,8 +161,10 @@ func TestMgmtReconcileBindChange_5866(t *testing.T) {
 // #6381: the OLD assertion required DIFFERENT leaf bytes ("a fresh cert per
 // rebind"), the OPPOSITE of the shipping durable-cert contract. It passed only
 // as a CI artifact — the production certGen writes /etc/xpf/tls, which is
-// unwritable in CI, so LoadX509KeyPair found no pair, persistence failed
-// silently, and every reconcile minted a fresh in-memory cert whose leaf bytes
+// unwritable in CI, so LoadX509KeyPair found no pair and the persist write
+// failed NON-FATALLY (generateSelfSignedCertAt LOGS the error but returns the
+// fresh in-memory cert with a nil error, so HTTPS still installs), and every
+// reconcile therefore re-minted a fresh in-memory cert whose leaf bytes
 // differed. In production (writable /etc/xpf/tls) the second reconcile RELOADS
 // the same pair -> identical bytes -> the old assertion would have FAILED. This
 // test redirects certGen to a writable temp dir (SetTLSCertDirForTest) so the

--- a/pkg/daemon/management_5866_test.go
+++ b/pkg/daemon/management_5866_test.go
@@ -3,8 +3,9 @@
 // instead of leaving the boot-time server enforcing the old policy until a
 // restart. These tests drive reconcileTo/startTo with a FAKE listener factory
 // (no real ports) and cover: a bind/port change (new active, old closed),
-// make-before-break coexistence, a TLS-material change (new cert served),
-// a same-endpoint auth swap (no rebind), and a failed new-bind (old listener
+// make-before-break coexistence, a TLS-material change (listener rebound,
+// durable cert reloaded), a same-endpoint auth swap (no rebind), and a failed
+// new-bind (old listener
 // RETAINED, error surfaced — fail-closed to the previous working state).
 //
 // FAIL-ON-REVERT: revert reconcileTo to close-old-before-binding-new and the
@@ -150,7 +151,23 @@ func TestMgmtReconcileBindChange_5866(t *testing.T) {
 	waitClosed(t, old)
 }
 
-// Bar 2: a TLS-material change replaces the listener and serves a FRESH cert.
+// Bar 2: a TLS-material change make-before-break rebinds the HTTPS listener and
+// serves the DURABLE self-signed cert (#5866 + #1916 D6). Enabling TLS and then
+// moving the HTTPS bind rebinds the HTTPS leg (new socket bound while the old is
+// still serving, then the old retired), but the on-disk self-signed pair is
+// LOADED AS-IS on the rebind — re-minting would churn remote clients' TOFU pins
+// (#5719 / PR #6378), so the served leaf bytes are IDENTICAL across the rebind.
+//
+// #6381: the OLD assertion required DIFFERENT leaf bytes ("a fresh cert per
+// rebind"), the OPPOSITE of the shipping durable-cert contract. It passed only
+// as a CI artifact — the production certGen writes /etc/xpf/tls, which is
+// unwritable in CI, so LoadX509KeyPair found no pair, persistence failed
+// silently, and every reconcile minted a fresh in-memory cert whose leaf bytes
+// differed. In production (writable /etc/xpf/tls) the second reconcile RELOADS
+// the same pair -> identical bytes -> the old assertion would have FAILED. This
+// test redirects certGen to a writable temp dir (SetTLSCertDirForTest) so the
+// shipping durable-reload path is actually exercised, and asserts the intended
+// invariant: the listener rebinds, but the durable cert is reloaded AS-IS.
 func TestMgmtReconcileTLSChange_5866(t *testing.T) {
 	reg := newFakeReg()
 	m := newTestMgmt(reg)
@@ -161,11 +178,17 @@ func TestMgmtReconcileTLSChange_5866(t *testing.T) {
 	if err := m.startTo(ctx, cfgFor(reg, "10.0.0.1:8080", false, "", nil)); err != nil {
 		t.Fatalf("initial start: %v", err)
 	}
+	// Redirect HTTPS cert generation to a WRITABLE temp dir so the durable-reload
+	// path (#1916 D6) genuinely persists — otherwise the write fails and every
+	// reconcile re-mints a fresh in-memory cert, masking the real invariant
+	// (#6381). Set before any TLS is enabled: startTo is HTTP-only, so certGen is
+	// untouched until the first enable-TLS reconcile below.
+	m.srv.SetTLSCertDirForTest(t.TempDir())
 	if m.srv.HTTPSCertForTest() != nil {
 		t.Fatal("HTTP-only server must not serve a TLS cert")
 	}
 
-	// Enable HTTPS -> endpoint changes -> rebuild with a cert.
+	// Enable HTTPS -> the HTTPS leg binds and mints+persists the durable cert.
 	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.1:8443", nil)); err != nil {
 		t.Fatalf("enable-TLS reconcile: %v", err)
 	}
@@ -173,11 +196,12 @@ func TestMgmtReconcileTLSChange_5866(t *testing.T) {
 	if cert1 == nil {
 		t.Fatal("HTTPS-enabled server must serve a TLS cert after the reconcile")
 	}
-	if reg.get("10.0.0.1:8443") == nil || !reg.get("10.0.0.1:8443").isOpen() {
+	oldHTTPS := reg.get("10.0.0.1:8443")
+	if oldHTTPS == nil || !oldHTTPS.isOpen() {
 		t.Fatal("HTTPS listener not active after enabling TLS")
 	}
 
-	// Change the HTTPS bind -> rebuild -> a NEW self-signed cert is served.
+	// Change the HTTPS bind -> make-before-break rebind of the HTTPS leg.
 	if err := m.reconcileTo(cfgFor(reg, "10.0.0.1:8080", true, "10.0.0.2:8443", nil)); err != nil {
 		t.Fatalf("https-rebind reconcile: %v", err)
 	}
@@ -185,11 +209,31 @@ func TestMgmtReconcileTLSChange_5866(t *testing.T) {
 	if cert2 == nil {
 		t.Fatal("HTTPS cert missing after the https rebind")
 	}
+
+	// The listener WAS rebound: the new HTTPS socket is active, it bound while the
+	// old was still open (make-before-break, no unreachable window), and the old
+	// HTTPS socket is retired. This is the real #5866 TLS-material invariant.
+	newHTTPS := reg.get("10.0.0.2:8443")
+	if newHTTPS == nil || !newHTTPS.isOpen() {
+		t.Fatal("HTTPS listener not rebound to the new address after the TLS-material change (#5866)")
+	}
+	if !reg.priorsOpenAtNew["10.0.0.2:8443"] {
+		t.Fatal("new HTTPS bound only AFTER the old closed — not make-before-break (#5866): " +
+			"there was a window with no HTTPS listener")
+	}
+	waitClosed(t, oldHTTPS)
+
+	// The served cert is the DURABLE self-signed pair, LOADED AS-IS across the
+	// rebind (#1916 D6): re-minting on a rebind would churn remote clients' TOFU
+	// pins (#5719 / #6378), so the leaf bytes must be IDENTICAL. (The old test
+	// wrongly required them to DIFFER — a CI-only artifact of an unwritable
+	// /etc/xpf/tls, #6381.)
 	if len(cert1.Certificate) == 0 || len(cert2.Certificate) == 0 {
 		t.Fatal("served TLS cert has no leaf certificate")
 	}
-	if bytesEqual(cert1.Certificate[0], cert2.Certificate[0]) {
-		t.Fatal("a TLS-material change must serve a NEW certificate, got the same leaf cert bytes (#5866)")
+	if !bytesEqual(cert1.Certificate[0], cert2.Certificate[0]) {
+		t.Fatal("the durable self-signed cert must be RELOADED AS-IS on an HTTPS rebind, got different leaf " +
+			"bytes — a rebind must not re-mint (that churns remote clients' TOFU pins, #1916 D6 / #6381)")
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestMgmtReconcileTLSChange_5866` (pkg/daemon/management_5866_test.go)
asserted that an HTTPS rebind serves **different** leaf certificate bytes on
the second reconcile ("a fresh cert per rebind"). That is the **opposite** of
the durable self-signed-cert contract (#1916 D6): a persisted `/etc/xpf/tls`
pair is **loaded as-is** on a rebind and deliberately **not** re-minted, because
re-minting churns remote clients' TOFU pins (#5719 / PR #6378).

### Why it passed as a CI-only artifact

The production `certGen` (`generateSelfSignedCert`) writes the `/etc/xpf/tls`
paths with no test redirect. In CI those paths are unwritable, so:

1. `LoadX509KeyPair` finds no on-disk pair,
2. the persist write fails silently,
3. every reconcile mints a **fresh in-memory** cert,
4. leaf bytes differ → the wrong assertion passes.

In production (writable `/etc/xpf/tls`) the second reconcile **reloads** the
same on-disk pair → identical leaf bytes → the old assertion would have
**failed**. The test encoded an invariant the shipping behavior contradicts.

## Fix (test-only — no production behavior change)

- Add a test-only `api.Server.SetTLSCertDirForTest(dir)` hook that points the
  server's HTTPS `certGen` at a writable temp dir, routed through the **real**
  production `generateSelfSignedCertAt`, so the durable load-as-is path is
  genuinely exercised from the cross-package (pkg/daemon) test.
- Re-encode the intended invariant: a TLS-material change **make-before-break
  rebinds** the HTTPS listener (new socket bound while the old still serves,
  then the old retired), but the **durable** self-signed cert is **reloaded
  as-is** → the served leaf bytes are **identical** across the rebind. Assert
  both the rebind and the durable reload.
- Correct the now-misleading "fresh certificate" comments on the file header
  and `HTTPSCertForTest`.

## Validation

- `go build` / `go vet` / `gofmt` clean.
- `go test ./pkg/daemon/ -run TLSChange` + full `./pkg/daemon/` + `./pkg/api/`
  suites **GREEN**.
- The `WARN loaded management TLS cert does not cover bind host` line on the
  rebind confirms the on-disk pair (SANs `10.0.0.1`) is **loaded as-is** at the
  new `10.0.0.2` bind, not re-minted.
- **Parent-RED**: neutralizing the durable-reload path in
  `generateSelfSignedCertAt` (forcing a re-mint on every call) turns the
  corrected durable-cert assertion **RED** — proving it now genuinely binds the
  reload behavior, the exact re-mint condition under which the old assertion
  silently passed.

Closes #6381