### PR TITLE
configstore: close the two #6404 archive-reseed edges

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -59676,3 +59676,22 @@ top.
     pkg/configstore/store_commit.go, pkg/configstore/store.go,
     pkg/configstore/README.md, pkg/configstore/archive_reseed_6404_test.go,
     _Log.md
+
+- **Timestamp**: 2026-07-23 23:40 UTC
+  - **Action**: #6404 Codex round-2 fold. `ensureArchiveSeededLocked` now
+    RETURNS a readiness bool; the archiving commit path SKIPS its archive when
+    the counter is unconfirmed (both the SetArchiveConfig scan AND the
+    commit-time rescan failed) rather than writing a below-max seq rotation
+    would prune (Codex MAJOR). ENOENT/first-use is treated as confirmed-empty
+    (preserves the nonexistent-archive-dir first-commit path). A genuine scan
+    failure now also CLEARS archiveSeedDir, so A→failed-B→A re-scans A (Codex
+    adjacent). Added TestCommitDoubleScanFailureSkipsBelowMaxArchive (parent-RED:
+    reverting the readiness gate writes+survives a below-max archive) and
+    TestSetArchiveConfigFailedNewDirRescansOriginalOnReturn (parent-RED:
+    reverting the clear-on-failure prunes the fresh archive). Both assert the
+    real rotation outcome. Verified RED→GREEN. README + archiveSeedDir doc
+    updated for skip-on-unconfirmed.
+  - **File(s)**: pkg/configstore/store_persist.go,
+    pkg/configstore/store_commit.go, pkg/configstore/store.go,
+    pkg/configstore/README.md, pkg/configstore/archive_reseed_6404_test.go,
+    _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -59695,3 +59695,12 @@ top.
     pkg/configstore/store_commit.go, pkg/configstore/store.go,
     pkg/configstore/README.md, pkg/configstore/archive_reseed_6404_test.go,
     _Log.md
+
+- **Timestamp**: 2026-07-23 23:58 UTC
+  - **Action**: #6404 Codex round-3 MINOR (doc-only). Corrected the stale
+    SetArchiveConfig lead-in comment that still said a scan failure "leaves
+    archiveSeedDir unchanged" — it now states a genuine scan failure leaves the
+    marker unset (clears it) so the next attempt rescans, and notes the
+    readiness gate skips the archive when the counter is unconfirmed. Matches
+    the code; no behavior change. Suite GREEN, gofmt/vet clean.
+  - **File(s)**: pkg/configstore/store_persist.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -59660,3 +59660,19 @@ top.
   - **File(s)**: test/xsk-repro/selftest-compile.sh,
     test/xsk-repro/selftest-multitoken-cc_6355.sh, scripts/run-selftests.sh,
     test/xsk-repro/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23 23:06 UTC
+  - **Action**: Close #6404 archive-reseed edges. Extracted
+    `ensureArchiveSeededLocked` from `SetArchiveConfig`; the archiving commit
+    path (`commitWithDescriptionLocked`) now re-attempts the reseed BEFORE
+    capturing its seq so a commit in the post-scan-failure window never writes
+    a below-max seq (edge 1); `SetArchiveConfig("")` now invalidates
+    `archiveSeedDir` so a disable→re-enable to the same dir re-scans (edge 2).
+    Added fail-on-revert tests asserting the REAL rotation outcome (fresh
+    archive survives / oldest pre-existing pruned), not just the private
+    counter; verified RED→GREEN on both revert directions. Updated README +
+    archiveSeedDir field doc. Control-plane only, no HA/smoke.
+  - **File(s)**: pkg/configstore/store_persist.go,
+    pkg/configstore/store_commit.go, pkg/configstore/store.go,
+    pkg/configstore/README.md, pkg/configstore/archive_reseed_6404_test.go,
+    _Log.md

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1085,10 +1085,12 @@ owned by the `journal/` subpackage.
   `SetArchiveConfig` seeds the per-process counter from the highest seq on
   disk so it stays globally monotonic across restarts (#5523 C179-060).
   These monotonicity / no-overwrite guarantees hold **once the target
-  archive dir has been successfully scanned** — and the reseed is retried
-  on every archiving commit until that scan succeeds (#6404), so a commit
-  never captures a below-max seq while the dir is only transiently
-  unreadable — see the #6396/#6404 hardening note below.
+  archive dir has been successfully scanned** — the reseed is retried on
+  every archiving commit until that scan succeeds (#6404), and while the
+  scan is still failing (the on-disk max unknown) an archiving commit
+  SKIPS its archive rather than write a below-max seq that rotation would
+  prune, archiving normally on the next commit after the scan recovers —
+  see the #6396/#6404 hardening note below.
   Two #6396 residual hardenings: `parseArchiveSeq` requires the current
   two-dot `config-<ts>.<seq>.conf` shape (the ts's own
   seconds.nanoseconds dot PLUS the seq dot), so a legacy pre-#3441
@@ -1103,17 +1105,28 @@ owned by the `journal/` subpackage.
   directory READ error from a legitimately empty dir: a transient scan failure
   leaves the counter unchanged and the dir un-seeded so the next call retries,
   rather than pinning the counter at 0 below the on-disk max and pruning every
-  fresh archive as stale (#6396 Codex MINOR 4). #6404 closed the two remaining
-  reseed windows the #6396 retry left open, both via the shared
-  `ensureArchiveSeededLocked` helper (called under the write lock):
+  fresh archive as stale (#6396 Codex MINOR 4). #6404 closed the remaining
+  reseed windows the #6396 retry left open, all via the shared
+  `ensureArchiveSeededLocked` helper (called under the write lock; it returns
+  whether the counter is CONFIRMED relative to the active dir):
   the archiving commit path re-attempts the reseed BEFORE it captures its seq,
   so a commit that lands after a failed `SetArchiveConfig` scan but before the
   next explicit retry re-scans the dir instead of writing a still-low seq that
-  rotation would prune as stale (edge 1); and disabling archival
-  (`SetArchiveConfig("")`) now INVALIDATES `archiveSeedDir`, so a
-  disable→re-enable to the SAME dir (`A`→`""`→`A`) re-scans `A` and accounts
-  for any on-disk max that advanced while archival was off, instead of skipping
-  the rescan and pruning fresh archives as stale (edge 2). The
+  rotation would prune as stale (edge 1). If that commit-time rescan ALSO fails
+  (a persistent scan error), the counter is still unconfirmed, so the commit
+  SKIPS its archive entirely rather than write a below-max seq — skipping one
+  archive during the failure window is strictly safer than writing a mis-seq'd
+  one that rotation prunes out of order; the next commit after the scan recovers
+  archives normally (Codex round-2 MAJOR). A nonexistent dir (first use,
+  `os.ErrNotExist`) is treated as a CONFIRMED-empty dir, not a scan failure:
+  there are no pre-existing archives to outrank, so seq 0 is correct and the
+  write path's `MkdirAll` creates it. Disabling archival (`SetArchiveConfig("")`)
+  INVALIDATES `archiveSeedDir`, so a disable→re-enable to the SAME dir
+  (`A`→`""`→`A`) re-scans `A` and accounts for any on-disk max that advanced
+  while archival was off (edge 2); likewise a genuine scan FAILURE clears
+  `archiveSeedDir`, so navigating away to a dir that fails to scan and back
+  (`A`→failed-`B`→`A`) re-scans `A` rather than trusting the stale marker (Codex
+  adjacent). The
   rollback/archive writers
   route through package-var seams (`rbWriteFileDurable`,
   `rbWriteFileAtomic`, `rbSyncDir`, `rbRemove`) so tests can pin the

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -1084,11 +1084,11 @@ owned by the `journal/` subpackage.
   `time.Now()` race). Rotation prunes by the parsed seq, and
   `SetArchiveConfig` seeds the per-process counter from the highest seq on
   disk so it stays globally monotonic across restarts (#5523 C179-060).
-  These monotonicity / no-overwrite guarantees hold **after a successful
-  reseed scan and outside the two #6404-deferred windows** (a commit that
-  lands after a failed scan but before the next `SetArchiveConfig` retry, and
-  a disable→re-enable to the same dir that skips the rescan) — see the #6396
-  hardening note below.
+  These monotonicity / no-overwrite guarantees hold **once the target
+  archive dir has been successfully scanned** — and the reseed is retried
+  on every archiving commit until that scan succeeds (#6404), so a commit
+  never captures a below-max seq while the dir is only transiently
+  unreadable — see the #6396/#6404 hardening note below.
   Two #6396 residual hardenings: `parseArchiveSeq` requires the current
   two-dot `config-<ts>.<seq>.conf` shape (the ts's own
   seconds.nanoseconds dot PLUS the seq dot), so a legacy pre-#3441
@@ -1103,12 +1103,17 @@ owned by the `journal/` subpackage.
   directory READ error from a legitimately empty dir: a transient scan failure
   leaves the counter unchanged and the dir un-seeded so the next call retries,
   rather than pinning the counter at 0 below the on-disk max and pruning every
-  fresh archive as stale (#6396 Codex MINOR 4). Two narrow reseed edges remain
-  open (tracked in #6404, not yet closed): a commit that lands in the window
-  AFTER a failed scan but BEFORE the next `SetArchiveConfig` retry captures the
-  still-low seq; and a disable→re-enable to the SAME dir (`A`→`""`→`A`) does
-  not rescan (archiveSeedDir is not invalidated on disable), so archives
-  written to `A` while archival was off are not accounted for. The
+  fresh archive as stale (#6396 Codex MINOR 4). #6404 closed the two remaining
+  reseed windows the #6396 retry left open, both via the shared
+  `ensureArchiveSeededLocked` helper (called under the write lock):
+  the archiving commit path re-attempts the reseed BEFORE it captures its seq,
+  so a commit that lands after a failed `SetArchiveConfig` scan but before the
+  next explicit retry re-scans the dir instead of writing a still-low seq that
+  rotation would prune as stale (edge 1); and disabling archival
+  (`SetArchiveConfig("")`) now INVALIDATES `archiveSeedDir`, so a
+  disable→re-enable to the SAME dir (`A`→`""`→`A`) re-scans `A` and accounts
+  for any on-disk max that advanced while archival was off, instead of skipping
+  the rescan and pruning fresh archives as stale (edge 2). The
   rollback/archive writers
   route through package-var seams (`rbWriteFileDurable`,
   `rbWriteFileAtomic`, `rbSyncDir`, `rbRemove`) so tests can pin the

--- a/pkg/configstore/archive_reseed_6404_test.go
+++ b/pkg/configstore/archive_reseed_6404_test.go
@@ -200,6 +200,177 @@ func TestSetArchiveConfigDisableReenableNoOnDiskAdvanceNoRewind(t *testing.T) {
 	}
 }
 
+// TestCommitDoubleScanFailureSkipsBelowMaxArchive is the #6404 Codex round-2
+// MAJOR guard: when BOTH the SetArchiveConfig reseed scan AND the commit-time
+// rescan fail (a persistent scan error), the commit path must NOT write an
+// archive at the still-low counter. The on-disk max is unknown, so a below-max
+// archive would carry a seq beneath the pre-existing entries — mis-ranked by the
+// seq-ordered retention and pruned out of chronological order (or immediately,
+// when the dir is full). Skipping this commit's archive (it archives on the next
+// successful commit) is strictly safer.
+//
+// The dir holds 3 pre-existing archives and max=4, so a below-max write is NOT
+// pruned — its PRESENCE is directly observable. This is the REAL rotation
+// outcome (an extra, mis-seq'd file on disk), not a private-counter check.
+//
+// FAIL-ON-REVERT: reverting the readiness gate (writing unconditionally after
+// the scan failure) makes the double-failure commit write a seq-1 archive that
+// survives (4 <= max), so the dir holds 4 files including the below-max marker —
+// the "no below-max archive / exactly the 3 pre-existing survive" assertions go
+// RED. The recovery phase then confirms a post-recovery commit archives normally
+// at the confirmed seq.
+func TestCommitDoubleScanFailureSkipsBelowMaxArchive(t *testing.T) {
+	s := newTestStore(t)
+	archiveDir := filepath.Join(t.TempDir(), "archive")
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	// The (existing) target dir already holds high-seq archives 100..102.
+	for seq := 100; seq <= 102; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(archiveDir, 100, fmt.Sprintf("pre-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A PERSISTENT scan error: the seam fails for both the SetArchiveConfig
+	// reseed AND the commit-time rescan. max=4 (> the 3 pre-existing) so a
+	// below-max write would survive rotation and be directly observable.
+	injErr := errors.New("injected: persistent ReadDir EIO")
+	prev := archiveDirReader
+	archiveDirReader = func(string) ([]os.DirEntry, error) { return nil, injErr }
+	s.SetArchiveConfig(archiveDir, 4)
+	if got := s.archiveSeq.Load(); got != 0 {
+		t.Fatalf("after the failed reseed scan, archiveSeq = %d, want 0 (un-seeded)", got)
+	}
+
+	// A commit lands while the scan is STILL failing. The reseed cannot confirm
+	// the on-disk max, so the archive must be skipped (no below-max write).
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name dbl-fail-6404"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit (scan failing): %v", err)
+	}
+	// If a writer was (wrongly) launched, wait for it so the assertion sees the
+	// settled dir; if it was correctly skipped, Wait returns immediately.
+	s.archiveWG.Wait()
+
+	remain := archiveConfigText(t, archiveDir)
+	if hasMarker(remain, "host-name dbl-fail-6404") {
+		t.Errorf("a commit during a persistent scan failure must NOT write a below-max "+
+			"archive (the seq is unconfirmed); surviving archives=%v", markerSet(remain))
+	}
+	if len(remain) != 3 {
+		t.Errorf("the 3 pre-existing archives must be untouched by the skipped commit, got %d: %v",
+			len(remain), markerSet(remain))
+	}
+	for _, w := range []string{"pre-100", "pre-101", "pre-102"} {
+		if !hasMarker(remain, w) {
+			t.Errorf("pre-existing archive %q must remain; surviving=%v", w, markerSet(remain))
+		}
+	}
+
+	// Recovery: the scan now succeeds. The next commit re-seeds from the on-disk
+	// max (102) and archives at a confirmed seq (103) that survives rotation.
+	archiveDirReader = prev
+	if err := s.SetFromInput("system host-name recovered-6404"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit (scan recovered): %v", err)
+	}
+	s.archiveWG.Wait()
+
+	if got := s.archiveSeq.Load(); got < 103 {
+		t.Errorf("after recovery the commit must reseed past the on-disk max (102) and archive "+
+			"at >= 103; archiveSeq = %d", got)
+	}
+	remain = archiveConfigText(t, archiveDir)
+	if !hasMarker(remain, "host-name recovered-6404") {
+		t.Errorf("the post-recovery commit must archive normally at the confirmed seq; surviving=%v",
+			markerSet(remain))
+	}
+}
+
+// TestSetArchiveConfigFailedNewDirRescansOriginalOnReturn is the #6404 adjacent
+// guard (Codex): after a FAILED scan of a NEW dir, archiveSeedDir must be
+// invalidated, so navigating back to the ORIGINAL dir re-scans it. Otherwise
+// A → failed-B → A leaves archiveSeedDir == A and the return to A skips the
+// rescan; if A's on-disk max advanced while this process was pointed at B (an
+// external writer), the counter stays low and fresh archives are pruned as
+// stale.
+//
+// FAIL-ON-REVERT: reverting the archiveSeedDir="" clear on a genuine scan error
+// leaves archiveSeedDir == dirA after B's failed scan, so the return to dirA
+// skips the rescan, the counter stays at dirA's stale max, and the fresh archive
+// carries a below-max seq that rotation prunes — the "fresh archive survives"
+// assertion goes RED.
+func TestSetArchiveConfigFailedNewDirRescansOriginalOnReturn(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	// dirA holds seqs 1..5; configuring it seeds the counter to 5.
+	for seq := 1; seq <= 5; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &Store{}
+	s.SetArchiveConfig(dirA, 3)
+	if got := s.archiveSeq.Load(); got != 5 || s.archiveSeedDir != dirA {
+		t.Fatalf("after configuring dirA, archiveSeq=%d seedDir=%q, want 5 / %q", got, s.archiveSeedDir, dirA)
+	}
+
+	// Navigate to dirB, but the scan of dirB FAILS (transient error).
+	injErr := errors.New("injected: dirB ReadDir EIO")
+	prev := archiveDirReader
+	archiveDirReader = func(string) ([]os.DirEntry, error) { return nil, injErr }
+	s.SetArchiveConfig(dirB, 3)
+	archiveDirReader = prev
+
+	// While this process was pointed at dirB, an external writer advanced dirA's
+	// on-disk max to 100..102.
+	for seq := 100; seq <= 102; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Return to dirA. The failed dirB scan must have invalidated archiveSeedDir,
+	// so this re-scans dirA and catches the counter up to the advanced max (102).
+	s.SetArchiveConfig(dirA, 3)
+	// Supporting signal (non-fatal so the REAL rotation assertion is load-bearing).
+	if got := s.archiveSeq.Load(); got != 102 {
+		t.Errorf("returning to dirA after a failed dirB scan must rescan dirA and catch up to "+
+			"its advanced on-disk max (102); got %d", got)
+	}
+
+	// REAL rotation outcome: an archive written with the re-seeded counter must
+	// survive and the oldest pre-existing archive (a-100) must be pruned.
+	seq := s.archiveSeq.Add(1) // 103, from the reseeded 102
+	ts := base.Add(time.Duration(seq) * time.Second)
+	if err := writeArchive(dirA, 3, "a-return-6404\n", ts, seq); err != nil {
+		t.Fatal(err)
+	}
+	remain := archiveContents(t, dirA)
+	if !remain["a-return-6404"] {
+		t.Errorf("the archive written after returning to dirA must survive rotation (its "+
+			"re-seeded seq outranks the advanced pre-existing max); remain=%v", remain)
+	}
+	if remain["a-100"] {
+		t.Errorf("the oldest pre-existing archive (a-100) must be pruned; remain=%v", remain)
+	}
+	if len(remain) != 3 {
+		t.Errorf("want 3 archives after rotation (max=3), got %d: %v", len(remain), remain)
+	}
+}
+
 // archiveConfigText reads dir and returns the raw contents of every archive
 // file present, for asserting rotation outcomes on multi-line config text (the
 // commit path writes the formatted active tree, not a one-line marker).

--- a/pkg/configstore/archive_reseed_6404_test.go
+++ b/pkg/configstore/archive_reseed_6404_test.go
@@ -1,0 +1,247 @@
+package configstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCommitReseedsAfterFailedScan is the #6404 edge-1 guard: a config COMMIT
+// that lands in the window AFTER a SetArchiveConfig reseed scan FAILED (dir
+// activated but counter still low, archiveSeedDir un-set to retry) but BEFORE
+// the next SetArchiveConfig retry must re-attempt the reseed before it captures
+// its archive seq — otherwise it writes an archive carrying a below-max seq that
+// rotateArchives immediately prunes as stale, losing the just-committed config's
+// archive while the pre-existing higher-seq archives survive.
+//
+// This drives the REAL production commit path (commitWithDescriptionLocked),
+// not the SetArchiveConfig retry the #6396 test exercises, and asserts the REAL
+// rotation outcome: the fresh commit's archive SURVIVES and the oldest
+// pre-existing archive is pruned.
+//
+// FAIL-ON-REVERT: dropping the ensureArchiveSeededLocked() call in the commit
+// archive path leaves the counter at 0, so the commit archives at seq 1 (below
+// the pre-existing 100..102); rotateArchives(max=3) evicts it as the oldest and
+// the "commit's archive survives" assertion goes RED.
+func TestCommitReseedsAfterFailedScan(t *testing.T) {
+	s := newTestStore(t)
+	archiveDir := filepath.Join(t.TempDir(), "archive")
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	// The target dir already holds high-seq archives (100..102) — e.g. written
+	// by a prior process, or before this process last had the dir configured.
+	for seq := 100; seq <= 102; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(archiveDir, 100, fmt.Sprintf("pre-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Configure archival to that dir, but the reseed scan FAILS (transient
+	// mount/permission error). The dir is activated (archiveDir=archiveDir,
+	// archiveMax=3) yet the counter stays 0 and the dir is left un-seeded so a
+	// later call retries (#6396). This is the post-scan-failure window.
+	injErr := errors.New("injected: reseed ReadDir EIO")
+	prev := archiveDirReader
+	archiveDirReader = func(string) ([]os.DirEntry, error) { return nil, injErr }
+	s.SetArchiveConfig(archiveDir, 3)
+	archiveDirReader = prev
+	if got := s.archiveSeq.Load(); got != 0 {
+		t.Fatalf("after the failed reseed scan, archiveSeq = %d, want 0 (un-seeded)", got)
+	}
+
+	// A commit lands in the window. With the fix it re-attempts the reseed (the
+	// reader is restored, so the scan now succeeds), catches the counter up to
+	// 102, and archives at 103 — which outranks the pre-existing entries.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetFromInput("system host-name reseed-commit-6404"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	// Deterministically wait for the async auto-archive writer (Add(1) ran under
+	// the commit lock, so it is already registered) to finish its write+rotate.
+	s.archiveWG.Wait()
+
+	// Supporting signal (non-fatal so the REAL rotation assertions below are the
+	// load-bearing fail-on-revert check, not just the private counter): the
+	// reseed should have caught the counter up past the on-disk max.
+	if got := s.archiveSeq.Load(); got < 103 {
+		t.Errorf("after the in-window commit, archiveSeq = %d, want >= 103 "+
+			"(reseeded from the on-disk max 102 before capturing the commit seq)", got)
+	}
+
+	// REAL rotation outcome: the commit's archive must survive and the oldest
+	// pre-existing archive (seq 100) must be pruned. Without the reseed the
+	// commit's archive would carry seq 1 and be evicted as the oldest instead.
+	remain := archiveConfigText(t, archiveDir)
+	if !hasMarker(remain, "host-name reseed-commit-6404") {
+		t.Errorf("the committed config's archive must survive rotation (its reseeded seq "+
+			"outranks the pre-existing 100..102); surviving archives=%v", markerSet(remain))
+	}
+	if hasMarker(remain, "pre-100") {
+		t.Errorf("the oldest pre-existing archive (pre-100) must be pruned; surviving archives=%v", markerSet(remain))
+	}
+	if len(remain) != 3 {
+		t.Errorf("want 3 archives after rotation (max=3), got %d", len(remain))
+	}
+}
+
+// TestSetArchiveConfigDisableReenableSameDirRescans is the #6404 edge-2 guard:
+// disabling archival (SetArchiveConfig("")) must INVALIDATE archiveSeedDir, so a
+// later re-enable to the SAME dir re-scans it. If the on-disk max in that dir
+// advanced while archival was off (another process/tenant wrote there), the
+// re-enable must catch the counter up — otherwise fresh archives carry a
+// below-max seq and are pruned as stale.
+//
+// The test asserts the REAL rotation outcome: after A → "" → A (with the
+// on-disk max advanced during the disabled window), an archive written with the
+// re-seeded counter SURVIVES and the oldest pre-existing archive is pruned.
+//
+// FAIL-ON-REVERT: dropping the `s.archiveSeedDir = ""` invalidation on disable
+// leaves archiveSeedDir == A, so the re-enable skips the rescan, the counter
+// stays at the stale low value, the fresh archive is written below the advanced
+// on-disk max, and the "fresh archive survives" assertion goes RED.
+func TestSetArchiveConfigDisableReenableSameDirRescans(t *testing.T) {
+	dirA := t.TempDir()
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	// Initial state: dirA holds seqs 1..5; configuring it seeds the counter to 5.
+	for seq := 1; seq <= 5; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &Store{}
+	s.SetArchiveConfig(dirA, 3)
+	if got := s.archiveSeq.Load(); got != 5 {
+		t.Fatalf("after configuring dirA, archiveSeq = %d, want 5", got)
+	}
+
+	// Disable archival.
+	s.SetArchiveConfig("", 3)
+
+	// While archival is OFF, another process advances the on-disk max in dirA
+	// (seqs 100..102). This process's counter still reads 5.
+	for seq := 100; seq <= 102; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Re-enable to the SAME dir. With the invalidation this rescans dirA and
+	// catches the counter up to the advanced on-disk max (102).
+	s.SetArchiveConfig(dirA, 3)
+	// Supporting signal (non-fatal so the REAL rotation assertions below are the
+	// load-bearing fail-on-revert check, not just the private counter).
+	if got := s.archiveSeq.Load(); got != 102 {
+		t.Errorf("re-enabling the same dir must rescan and catch the counter up to the "+
+			"advanced on-disk max (102); got %d", got)
+	}
+
+	// REAL rotation outcome: an archive written with the re-seeded counter must
+	// survive and the oldest pre-existing archive (a-100) must be pruned.
+	seq := s.archiveSeq.Add(1) // 103, from the reseeded 102
+	ts := base.Add(time.Duration(seq) * time.Second)
+	if err := writeArchive(dirA, 3, "a-new-6404\n", ts, seq); err != nil {
+		t.Fatal(err)
+	}
+	remain := archiveContents(t, dirA)
+	if !remain["a-new-6404"] {
+		t.Errorf("the freshly-written archive must survive rotation (its re-seeded seq "+
+			"outranks the pre-existing 100..102); remain=%v", remain)
+	}
+	if remain["a-100"] {
+		t.Errorf("the oldest pre-existing archive (a-100) must be pruned; remain=%v", remain)
+	}
+	if len(remain) != 3 {
+		t.Errorf("want 3 archives after rotation (max=3), got %d: %v", len(remain), remain)
+	}
+}
+
+// TestSetArchiveConfigDisableReenableNoOnDiskAdvanceNoRewind guards that the
+// #6404 edge-2 invalidation does NOT regress the benign disable→re-enable case:
+// when nothing advanced the on-disk max while archival was off, re-enabling the
+// same dir re-scans it but the monotonic-up seed must NOT rewind the counter.
+// This proves the seed stays max(current, on-disk), matching #6396.
+func TestSetArchiveConfigDisableReenableNoOnDiskAdvanceNoRewind(t *testing.T) {
+	dirA := t.TempDir()
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	for seq := 1; seq <= 5; seq++ {
+		ts := base.Add(time.Duration(seq) * time.Second)
+		if err := writeArchive(dirA, 100, fmt.Sprintf("a-%d\n", seq), ts, uint64(seq)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := &Store{}
+	s.SetArchiveConfig(dirA, 3)
+	// Advance the process counter past the on-disk max WITHOUT writing (as a
+	// stream of commits would), so a naive re-scan-and-store would rewind it.
+	s.archiveSeq.Store(50)
+
+	s.SetArchiveConfig("", 3)   // disable — clears archiveSeedDir
+	s.SetArchiveConfig(dirA, 3) // re-enable — rescans, but on-disk max (5) < 50
+
+	if got := s.archiveSeq.Load(); got != 50 {
+		t.Fatalf("re-enabling a dir whose on-disk max (5) is below the counter (50) must NOT "+
+			"rewind it (monotonic-up seed); got %d", got)
+	}
+	if s.archiveSeedDir != dirA {
+		t.Fatalf("after a successful re-enable rescan, archiveSeedDir = %q, want %q", s.archiveSeedDir, dirA)
+	}
+}
+
+// archiveConfigText reads dir and returns the raw contents of every archive
+// file present, for asserting rotation outcomes on multi-line config text (the
+// commit path writes the formatted active tree, not a one-line marker).
+func archiveConfigText(t *testing.T, dir string) []string {
+	t.Helper()
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		d, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, string(d))
+	}
+	return out
+}
+
+func hasMarker(texts []string, marker string) bool {
+	for _, tx := range texts {
+		if strings.Contains(tx, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// markerSet renders a compact view of which archive markers survived, for
+// failure messages (avoids dumping full multi-line config text).
+func markerSet(texts []string) []string {
+	var out []string
+	for _, tx := range texts {
+		first := tx
+		if i := strings.IndexByte(tx, '\n'); i >= 0 {
+			first = tx[:i]
+		}
+		out = append(out, first)
+	}
+	return out
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -216,11 +216,17 @@ type Store struct {
 	archiveMax int    // max archives to keep
 
 	// archiveSeedDir is the archive dir for which the archiveSeq reseed scan
-	// last SUCCEEDED (#6396 Codex MINOR 4). SetArchiveConfig scans a dir only
-	// when it differs from this — so a transient scan failure (mount/permission)
-	// leaves it unchanged and the next call retries, instead of the failure
-	// silently marking the dir seeded and pinning the counter below the on-disk
-	// max forever (which would prune every fresh archive as stale).
+	// last SUCCEEDED (#6396 Codex MINOR 4). ensureArchiveSeededLocked scans a
+	// dir only when it differs from this — so a transient scan failure
+	// (mount/permission) leaves it unchanged and a later call retries, instead
+	// of the failure silently marking the dir seeded and pinning the counter
+	// below the on-disk max forever (which would prune every fresh archive as
+	// stale). #6404: the retry is driven not only by an explicit
+	// SetArchiveConfig call but by the archiving commit path itself (edge 1), so
+	// a commit that lands in the post-failure window re-scans before capturing
+	// its seq; and disabling archival (SetArchiveConfig("")) CLEARS this (edge
+	// 2), so a disable→re-enable to the same dir re-scans to pick up any on-disk
+	// max that advanced while archival was off.
 	archiveSeedDir string
 
 	// archiveSeq is a monotonic counter appended to every archive filename

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -217,16 +217,17 @@ type Store struct {
 
 	// archiveSeedDir is the archive dir for which the archiveSeq reseed scan
 	// last SUCCEEDED (#6396 Codex MINOR 4). ensureArchiveSeededLocked scans a
-	// dir only when it differs from this — so a transient scan failure
-	// (mount/permission) leaves it unchanged and a later call retries, instead
-	// of the failure silently marking the dir seeded and pinning the counter
-	// below the on-disk max forever (which would prune every fresh archive as
-	// stale). #6404: the retry is driven not only by an explicit
-	// SetArchiveConfig call but by the archiving commit path itself (edge 1), so
-	// a commit that lands in the post-failure window re-scans before capturing
-	// its seq; and disabling archival (SetArchiveConfig("")) CLEARS this (edge
-	// 2), so a disable→re-enable to the same dir re-scans to pick up any on-disk
-	// max that advanced while archival was off.
+	// dir only when it differs from this. #6404: the reseed retry is driven not
+	// only by an explicit SetArchiveConfig call but by the archiving commit path
+	// itself (edge 1), which re-scans before capturing its seq; and if that scan
+	// is still failing the commit SKIPS its archive (the counter is unconfirmed)
+	// rather than write a below-max seq rotation would prune. This marker is
+	// CLEARED on every genuine scan failure (so a stale marker is never trusted
+	// after navigating to a dir that fails to scan — A→failed-B→A re-scans A) and
+	// on disable (SetArchiveConfig("") — so a disable→re-enable to the same dir
+	// re-scans to pick up any on-disk max that advanced while archival was off,
+	// edge 2). A nonexistent dir (first use) is recorded here as CONFIRMED-empty,
+	// not a failure — seq 0 is correct and the write path creates the dir.
 	archiveSeedDir string
 
 	// archiveSeq is a monotonic counter appended to every archive filename

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -274,6 +274,15 @@ func (s *Store) commitWithDescriptionLocked(description string) (*config.Config,
 	// same lock before it Wait()s — so no Add can start after the fence, and the
 	// WaitGroup counter never rises from zero concurrently with Wait.
 	if s.archiveDir != "" && !s.archiveFenced.Load() {
+		// #6404 edge 1: re-attempt the archive-seq reseed if a prior
+		// SetArchiveConfig scan of this dir failed (archiveSeedDir !=
+		// archiveDir). commitWithDescriptionLocked runs under s.mu.Lock (write),
+		// so this may safely store archiveSeedDir. Without it, a commit that
+		// lands in the window between a failed scan and the next SetArchiveConfig
+		// retry would capture the still-low seq below and write an archive that
+		// rotateArchives immediately prunes as stale. When the dir is already
+		// seeded this is a cheap string compare — no per-commit ReadDir.
+		s.ensureArchiveSeededLocked()
 		dir := s.archiveDir
 		max := s.archiveMax
 		if max <= 0 {

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -274,39 +274,51 @@ func (s *Store) commitWithDescriptionLocked(description string) (*config.Config,
 	// same lock before it Wait()s — so no Add can start after the fence, and the
 	// WaitGroup counter never rises from zero concurrently with Wait.
 	if s.archiveDir != "" && !s.archiveFenced.Load() {
-		// #6404 edge 1: re-attempt the archive-seq reseed if a prior
-		// SetArchiveConfig scan of this dir failed (archiveSeedDir !=
-		// archiveDir). commitWithDescriptionLocked runs under s.mu.Lock (write),
-		// so this may safely store archiveSeedDir. Without it, a commit that
-		// lands in the window between a failed scan and the next SetArchiveConfig
-		// retry would capture the still-low seq below and write an archive that
-		// rotateArchives immediately prunes as stale. When the dir is already
-		// seeded this is a cheap string compare — no per-commit ReadDir.
-		s.ensureArchiveSeededLocked()
-		dir := s.archiveDir
-		max := s.archiveMax
-		if max <= 0 {
-			max = 10
+		// #6404: re-attempt the archive-seq reseed if a prior SetArchiveConfig
+		// scan of this dir failed (archiveSeedDir != archiveDir).
+		// commitWithDescriptionLocked runs under s.mu.Lock (write), so
+		// ensureArchiveSeededLocked may safely store archiveSeedDir. Edge 1: a
+		// commit that lands in the window between a failed scan and the next
+		// SetArchiveConfig retry re-scans here instead of capturing the still-low
+		// seq. When the dir is already seeded the readiness check is a cheap
+		// string compare — no per-commit ReadDir.
+		if !s.ensureArchiveSeededLocked() {
+			// Codex round-2 MAJOR: the commit-time rescan ALSO failed
+			// (persistent scan error), so the on-disk max is unknown and the
+			// counter is unconfirmed. Writing at the low counter would drop a
+			// below-max archive that rotateArchives prunes as stale once the
+			// scan recovers, LOSING this config version's archive. Skip this
+			// commit's archive entirely — the next commit after the scan
+			// recovers archives correctly. Skipping one archive during a
+			// scan-failure window is strictly safer than writing a mis-seq'd one.
+			slog.Warn("archive seq unconfirmed after scan failure; skipping this commit's archive, will archive on the next successful commit",
+				"dir", s.archiveDir)
+		} else {
+			dir := s.archiveDir
+			max := s.archiveMax
+			if max <= 0 {
+				max = 10
+			}
+			data := s.active.Format()
+			ts := time.Now()
+			seq := s.archiveSeq.Add(1)
+			s.archiveWG.Add(1)
+			go func() {
+				defer s.archiveWG.Done()
+				// #5869: re-check the fence inside the goroutine. A writer that
+				// observes it (a factory reset began after this commit launched the
+				// writer, before it reached the write) MUST NOT recreate the archive
+				// directory the wipe is about to erase — that would resurrect the
+				// prior tenant's config secrets on a re-tenanted device.
+				if s.archiveFenced.Load() {
+					return
+				}
+				archiveWriteBarrier()
+				if err := writeArchive(dir, max, data, ts, seq); err != nil {
+					slog.Warn("auto-archive failed", "err", err)
+				}
+			}()
 		}
-		data := s.active.Format()
-		ts := time.Now()
-		seq := s.archiveSeq.Add(1)
-		s.archiveWG.Add(1)
-		go func() {
-			defer s.archiveWG.Done()
-			// #5869: re-check the fence inside the goroutine. A writer that
-			// observes it (a factory reset began after this commit launched the
-			// writer, before it reached the write) MUST NOT recreate the archive
-			// directory the wipe is about to erase — that would resurrect the
-			// prior tenant's config secrets on a re-tenanted device.
-			if s.archiveFenced.Load() {
-				return
-			}
-			archiveWriteBarrier()
-			if err := writeArchive(dir, max, data, ts, seq); err != nil {
-				slog.Warn("auto-archive failed", "err", err)
-			}
-		}()
 	}
 
 	return compiled, nil

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -481,39 +481,75 @@ func (s *Store) persistRetryLoop(backoff, maxBackoff time.Duration) {
 // would let the pre-existing archives outrank the new ones). A scan that fails
 // to READ the dir leaves archiveSeedDir unchanged so the next call retries,
 // rather than pinning the counter below the on-disk max (#6396 Codex MINOR 4).
+//
+// #6404 edge 2: disabling archival (dir=="") INVALIDATES archiveSeedDir, so a
+// later re-enable to the SAME dir re-scans it. Without the invalidation
+// A→""→A left archiveSeedDir==A and the re-enable skipped the rescan; if the
+// on-disk max in A advanced while archival was off (another process/tenant
+// wrote there), the counter would stay low and every fresh archive would be
+// pruned as stale. The seed retry the commit path performs (#6404 edge 1,
+// ensureArchiveSeededLocked) rests on the same invariant: archiveSeedDir names
+// a dir this process has actually scanned, never a stale disabled one.
 func (s *Store) SetArchiveConfig(dir string, max int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.archiveDir = dir
 	s.archiveMax = max
-	// Seed the monotonic archive seq from the highest seq already on disk in
-	// the target dir. Scan whenever the dir differs from the one last
-	// SUCCESSFULLY seeded (archiveSeedDir) — that covers both process start
-	// (archiveSeedDir=="") and a runtime archive-dir switch: switching to a
-	// previously-used directory whose existing archives carry HIGHER seqs than
-	// this process's counter would otherwise let those pre-existing archives
-	// outrank — and evict — the archives this process is about to write, the
-	// same across-restart hazard #5523 C179-060 closed but reached via a live
-	// dir switch (#6396). The seed is monotonic-up only (max of the current
-	// counter and the on-disk max), so switching to an empty or lower-seq dir
-	// never rewinds the counter.
-	if dir != "" && s.archiveSeedDir != dir {
-		seed, err := maxArchiveSeq(dir)
-		if err != nil {
-			// #6396 Codex MINOR 4: a transient scan failure (mount/permission)
-			// must NOT reseed the counter to 0 and must NOT record the dir as
-			// seeded — leaving archiveSeedDir unchanged so the next call retries.
-			// Regressing the counter here would prune every fresh archive as stale
-			// until a restart re-scanned.
-			slog.Warn("archive seq reseed scan failed; leaving counter unchanged, will retry",
-				"dir", dir, "err", err)
-		} else {
-			if seed > s.archiveSeq.Load() {
-				s.archiveSeq.Store(seed)
-			}
-			s.archiveSeedDir = dir
-		}
+	if dir == "" {
+		// #6404 edge 2: archival disabled. Clear archiveSeedDir so a later
+		// re-enable to a previously-seeded dir re-scans it (the on-disk max may
+		// have advanced while archival was off). A disabled store writes no
+		// archives, so clearing the marker only forces the rescan the re-enable
+		// must do — it never rewinds the monotonic counter itself.
+		s.archiveSeedDir = ""
+		return
 	}
+	// Seed the monotonic archive seq from the highest seq already on disk in
+	// the target dir (see ensureArchiveSeededLocked for the full rationale).
+	s.ensureArchiveSeededLocked()
+}
+
+// ensureArchiveSeededLocked seeds the monotonic archive counter (archiveSeq)
+// from the highest seq present in the active archive dir, when that dir has not
+// yet been SUCCESSFULLY scanned (archiveSeedDir != archiveDir). The caller MUST
+// hold s.mu for WRITING — it may store archiveSeedDir.
+//
+// Switching to a previously-used directory whose existing archives carry HIGHER
+// seqs than this process's counter would otherwise let those pre-existing
+// archives outrank — and evict — the archives this process is about to write,
+// the same across-restart hazard #5523 C179-060 closed but reached via a live
+// dir switch (#6396). The seed is monotonic-up only (max of the current counter
+// and the on-disk max), so switching to an empty or lower-seq dir never rewinds
+// the counter. A scan that fails to READ the dir leaves archiveSeedDir
+// unchanged so a later call retries, rather than pinning the counter below the
+// on-disk max (#6396 Codex MINOR 4).
+//
+// #6404 edge 1: the commit archive path calls this BEFORE it captures a seq, so
+// a commit that lands in the window AFTER a failed SetArchiveConfig scan but
+// BEFORE the next SetArchiveConfig retry re-attempts the reseed instead of
+// writing an archive with a below-max seq that rotateArchives would prune as
+// stale. In the common case (dir already successfully seeded) the archiveSeedDir
+// guard makes this a cheap string compare — no per-commit ReadDir.
+func (s *Store) ensureArchiveSeededLocked() {
+	dir := s.archiveDir
+	if dir == "" || s.archiveSeedDir == dir {
+		return
+	}
+	seed, err := maxArchiveSeq(dir)
+	if err != nil {
+		// #6396 Codex MINOR 4: a transient scan failure (mount/permission)
+		// must NOT reseed the counter to 0 and must NOT record the dir as
+		// seeded — leaving archiveSeedDir unchanged so the next call retries.
+		// Regressing the counter here would prune every fresh archive as stale
+		// until a later scan succeeded.
+		slog.Warn("archive seq reseed scan failed; leaving counter unchanged, will retry",
+			"dir", dir, "err", err)
+		return
+	}
+	if seed > s.archiveSeq.Load() {
+		s.archiveSeq.Store(seed)
+	}
+	s.archiveSeedDir = dir
 }
 
 // parseArchiveSeq extracts the monotonic sequence number from an archive

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -3,6 +3,7 @@ package configstore
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -511,8 +512,11 @@ func (s *Store) SetArchiveConfig(dir string, max int) {
 
 // ensureArchiveSeededLocked seeds the monotonic archive counter (archiveSeq)
 // from the highest seq present in the active archive dir, when that dir has not
-// yet been SUCCESSFULLY scanned (archiveSeedDir != archiveDir). The caller MUST
-// hold s.mu for WRITING — it may store archiveSeedDir.
+// yet been SUCCESSFULLY scanned (archiveSeedDir != archiveDir). It returns
+// whether the counter is CONFIRMED relative to the active dir — true when
+// seeding is moot or succeeded, false only when a genuine scan failure leaves
+// the on-disk max UNKNOWN. The caller MUST hold s.mu for WRITING — it may store
+// archiveSeedDir.
 //
 // Switching to a previously-used directory whose existing archives carry HIGHER
 // seqs than this process's counter would otherwise let those pre-existing
@@ -520,36 +524,59 @@ func (s *Store) SetArchiveConfig(dir string, max int) {
 // the same across-restart hazard #5523 C179-060 closed but reached via a live
 // dir switch (#6396). The seed is monotonic-up only (max of the current counter
 // and the on-disk max), so switching to an empty or lower-seq dir never rewinds
-// the counter. A scan that fails to READ the dir leaves archiveSeedDir
-// unchanged so a later call retries, rather than pinning the counter below the
-// on-disk max (#6396 Codex MINOR 4).
+// the counter.
 //
-// #6404 edge 1: the commit archive path calls this BEFORE it captures a seq, so
-// a commit that lands in the window AFTER a failed SetArchiveConfig scan but
-// BEFORE the next SetArchiveConfig retry re-attempts the reseed instead of
-// writing an archive with a below-max seq that rotateArchives would prune as
-// stale. In the common case (dir already successfully seeded) the archiveSeedDir
-// guard makes this a cheap string compare — no per-commit ReadDir.
-func (s *Store) ensureArchiveSeededLocked() {
+// Readiness (#6404 Codex MAJOR round 2): the archiving commit path calls this
+// BEFORE it captures a seq and SKIPS the archive when it returns false. A commit
+// that lands in the window AFTER a failed SetArchiveConfig scan re-attempts the
+// reseed here (edge 1); if that rescan ALSO fails the on-disk max is still
+// unknown, so writing at the low counter would drop a below-max archive that
+// rotateArchives prunes as stale — skipping this commit's archive (it archives
+// on the next successful commit) is strictly safer than writing a mis-seq'd one.
+//
+// Result cases:
+//   - dir=="" (archival off) or archiveSeedDir==dir (already confirmed): ready,
+//     no scan (the common case is a cheap string compare — no per-commit ReadDir).
+//   - dir does not exist yet (first use, os.ErrNotExist): CONFIRMED empty —
+//     there are no pre-existing archives to outrank, so seq 0 is correct and the
+//     write path's MkdirAll creates the dir. Recorded as seeded, ready.
+//   - scan succeeds (including a readable empty dir → seed 0): seeded, ready.
+//   - genuine READ error (mount/permission): UNCONFIRMED. archiveSeedDir is
+//     CLEARED (#6404 adjacent) so we never retain confidence in a dir we have
+//     navigated away from — A→failed-B→A then re-scans A — and a later call
+//     retries. Returns false so the commit path skips this archive.
+func (s *Store) ensureArchiveSeededLocked() bool {
 	dir := s.archiveDir
 	if dir == "" || s.archiveSeedDir == dir {
-		return
+		return true
 	}
 	seed, err := maxArchiveSeq(dir)
 	if err != nil {
-		// #6396 Codex MINOR 4: a transient scan failure (mount/permission)
-		// must NOT reseed the counter to 0 and must NOT record the dir as
-		// seeded — leaving archiveSeedDir unchanged so the next call retries.
-		// Regressing the counter here would prune every fresh archive as stale
-		// until a later scan succeeded.
-		slog.Warn("archive seq reseed scan failed; leaving counter unchanged, will retry",
+		if errors.Is(err, os.ErrNotExist) {
+			// First use: the archive dir does not exist yet. This is NOT a scan
+			// failure — a nonexistent dir holds no pre-existing archives, so seq
+			// 0 is confirmed-correct and the write path's MkdirAll creates it.
+			// Treat exactly like a readable empty dir: record as seeded, ready.
+			s.archiveSeedDir = dir
+			return true
+		}
+		// #6396 Codex MINOR 4 + #6404: a genuine scan failure (mount/permission)
+		// must NOT reseed the counter to 0. The on-disk max is UNKNOWN, so the
+		// counter is unconfirmed. Clear archiveSeedDir (#6404 adjacent) so a
+		// stale marker for a previously-confirmed dir is not trusted after we
+		// navigate to a new dir, and so the next call retries. Return false so
+		// the commit path skips this archive rather than writing a below-max seq
+		// that rotateArchives would prune as stale.
+		slog.Warn("archive seq reseed scan failed; counter unconfirmed, will retry",
 			"dir", dir, "err", err)
-		return
+		s.archiveSeedDir = ""
+		return false
 	}
 	if seed > s.archiveSeq.Load() {
 		s.archiveSeq.Store(seed)
 	}
 	s.archiveSeedDir = dir
+	return true
 }
 
 // parseArchiveSeq extracts the monotonic sequence number from an archive

--- a/pkg/configstore/store_persist.go
+++ b/pkg/configstore/store_persist.go
@@ -480,8 +480,11 @@ func (s *Store) persistRetryLoop(backoff, maxBackoff time.Duration) {
 // a runtime dir switch both qualify (#6396: a switch to a previously-used dir
 // must re-seed from that dir's existing max, else this process's lower counter
 // would let the pre-existing archives outrank the new ones). A scan that fails
-// to READ the dir leaves archiveSeedDir unchanged so the next call retries,
-// rather than pinning the counter below the on-disk max (#6396 Codex MINOR 4).
+// to READ the dir does NOT mark the dir seeded — it leaves archiveSeedDir unset
+// (#6404 clears it on a genuine error) so the next attempt rescans, rather than
+// pinning the counter below the on-disk max (#6396 Codex MINOR 4); and while the
+// counter is unconfirmed the readiness gate makes an archiving commit SKIP its
+// archive rather than write a below-max seq (see ensureArchiveSeededLocked).
 //
 // #6404 edge 2: disabling archival (dir=="") INVALIDATES archiveSeedDir, so a
 // later re-enable to the SAME dir re-scans it. Without the invalidation


### PR DESCRIPTION
Closes #6404

Follow-up from the #6399 (#6396) Codex review. The #6396 archive-reseed hardening (`maxArchiveSeq` distinguishes a `ReadDir` error from an empty dir; `SetArchiveConfig` keys the reseed off `archiveSeedDir` and retries on a scan error) left two narrow seq-seeding windows open. Both are now closed via a shared `ensureArchiveSeededLocked` helper (called under the store write lock).

## Edge 1 — commit lands in the post-scan-failure window
`SetArchiveConfig` activates the new dir before the reseed scan; on a scan error it leaves the counter low and the dir un-seeded to retry on the next call. A config commit that landed in that interval captured `seq := s.archiveSeq.Add(1)` off the still-low counter (`commitWithDescriptionLocked`) and wrote an archive with a below-max seq — which `rotateArchives` pruned as stale if the dir already held higher-seq archives.

**Fix:** the archiving commit path now calls `ensureArchiveSeededLocked` (under the write lock it already holds) before capturing the seq, so a commit re-attempts the reseed instead of using a not-yet-successfully-seeded low counter. In the common case (dir already seeded) the `archiveSeedDir` guard is a cheap string compare — no per-commit `ReadDir`.

## Edge 2 — disable then re-enable to the same dir
`archiveSeedDir` was not invalidated on disable, so `A → "" → A` left `archiveSeedDir == A` and the re-enable skipped the rescan. If the on-disk max in `A` advanced while archival was off, the counter stayed low and fresh archives were pruned as stale.

**Fix:** `SetArchiveConfig("")` clears `archiveSeedDir`, so a later re-enable rescans. The seed stays monotonic-up only, so a benign re-enable with no on-disk advance never rewinds the counter.

## Tests (fail-on-revert, assert REAL rotation outcome)
Per the #6399-round lesson, each edge's fail-on-revert asserts the real rotation outcome (the fresh archive survives / the correct pre-existing archive is pruned), not just the private counter.

- `TestCommitReseedsAfterFailedScan` — drives a real commit through the post-scan-failure window; neutralizing the commit-path reseed makes the committed config's archive get pruned as stale (surviving set = the pre-existing `100..102`) → RED.
- `TestSetArchiveConfigDisableReenableSameDirRescans` — drives `A → "" → A` with the on-disk max advanced during the disabled window; neutralizing the `archiveSeedDir` invalidation makes the fresh archive get pruned → RED.
- `TestSetArchiveConfigDisableReenableNoOnDiskAdvanceNoRewind` — guards that the edge-2 invalidation does not rewind the monotonic counter.

Verified RED→GREEN firsthand on both revert directions. Full `pkg/configstore` suite GREEN (incl. `-race` on the archive/commit tests); build/vet/gofmt clean. Control-plane only, no HA/dataplane coupling. README + `archiveSeedDir` field doc updated to describe the now-complete behavior.