### PR TITLE
userspace: gate the desired-state forwarding reconcile with the required-protocol check

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-23 — #6165: gate the ~1s desired-state forwarding reconcile with the required-protocol check
+
+- **Timestamp**: 2026-07-23 (fix/6165-forwarding-reconcile-audit)
+- **Action**: Closed the #6163 hostile-review residual. The desired-state
+  forwarding reconcile (`syncDesiredForwardingStateLocked`, invoked ~1s from
+  the status poll and from the compile path) sent
+  `set_forwarding_state{Armed: desiredForwardingArmedLocked()}` with NO
+  required-generation protocol gate, while `desiredForwardingArmedLocked()`
+  returns true whenever forwarding is *supported* (it never consults the
+  accepted-snapshot protocol version). Reachable fail-open trace: a
+  scheduler-driven-policy (or persistent-source-NAT) config is committed while
+  the helper protocol is current, so `m.lastSnapshot.Config` REQUIRES the
+  protocol; the helper is then behind (mixed-base HA deploy / in-place upgrade /
+  older restarted binary); a scheduler tick (`UpdatePolicyScheduleState` →
+  `disarmSnapshotProtocolFailureLocked`) disarms the helper fail-closed and,
+  UNLIKE an operator commit, does NOT revert the active config — so
+  `m.lastSnapshot` keeps requiring the protocol while the helper is disarmed +
+  protocol-stale, and the next reconcile tick re-arms the stale image
+  (forwarding a config the helper cannot represent). Added the SAME scoped gate
+  #6163/#5648 put on `SetForwardingArmed`: `syncDesiredForwardingStateLocked`
+  now re-runs `ensureRequiredSnapshotProtocolLocked(m.lastSnapshot.Config)` and
+  returns the sentinel (leaving the helper disarmed) before re-arming. Scoped to
+  the ARM direction only (`if desired && ...`) so a disarm (demotion, shutdown,
+  the protocol disarm itself) is never blocked; no-op unless the last-applied
+  config requires the protocol; the gate re-polls the helper first so an
+  upgraded helper still arms. Single choke point covers all three reconcile
+  call sites (status poll, compile path, RefreshOwnerRGs/UpdateRGActive). The
+  compile-path call (manager_compile.go:396) already passed the gate at :312 so
+  the added check is a no-op there.
+- **File(s)**: pkg/dataplane/userspace/manager_ha.go,
+  pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go,
+  docs/userspace-dataplane-gaps.md
+- **Validation**: gofmt/vet/build clean; full `go test ./pkg/dataplane/userspace/`
+  GREEN (17.7s). Fail-on-revert (both parent-RED cases clean assertion
+  failures): (1) neutralize the whole gate → mismatch test RED (reconcile arms
+  the stale image); (2) drop the `desired &&` scope → disarm test RED (gate
+  blocks the disarm). Restored → all three #6165 tests GREEN.
+
 ## 2026-07-23 — #6387 PR-3: host-inbound/lo0/fence install via netlink (cutover)
 
 - **Timestamp**: 2026-07-23 (fix/6387-p3-cutover)

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -268,6 +268,19 @@ There are two distinct fallback boundaries:
      enforced on the explicit arm path (#5648 / M43b): `SetForwardingArmed(true)`
      re-runs `ensureRequiredSnapshotProtocolLocked` and refuses to arm a
      stale accepted image, so an operator/gRPC arm cannot undo the disarm.
+     The SAME gate now also guards the ~1s desired-state reconcile
+     (#6165): `syncDesiredForwardingStateLocked` re-runs the protocol check
+     before it re-arms, because `desiredForwardingArmedLocked()` returns true
+     whenever forwarding is *supported* and never consults the accepted
+     snapshot protocol version. Without it, a scheduler-tick disarm
+     (`UpdatePolicyScheduleState` → `disarmSnapshotProtocolFailureLocked`,
+     which unlike an operator commit does NOT revert the active config) would
+     leave `m.lastSnapshot` requiring the protocol while the helper is
+     disarmed + protocol-stale, and the next reconcile tick would re-arm it —
+     forwarding a config the helper cannot represent. The reconcile gate is
+     scoped identically: only the ARM direction is checked (a disarm — demotion,
+     shutdown, the protocol disarm itself — is never blocked), and it is a
+     no-op unless the last-applied config requires the protocol.
 
 2. **Runtime XDP decision**
    - Even when `xdp_userspace_prog` is active, the XDP shim can still:

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -606,6 +606,32 @@ func (m *Manager) syncDesiredForwardingStateLocked() error {
 	if m.lastStatus.ForwardingArmed == desired {
 		return nil
 	}
+	// #6165: the ~1s desired-state reconcile must honor the SAME
+	// required-generation protocol gate that #6163/#5648 added to
+	// SetForwardingArmed. A compile- or scheduler-path disarm
+	// (disarmSnapshotProtocolFailureLocked, fired by
+	// ensureRequiredSnapshotProtocolLocked when the running helper's accepted
+	// snapshot protocol version is too old to honor a config that REQUIRES a
+	// newer one — policy schedulers, persistent source NAT) leaves the helper
+	// disarmed while desiredForwardingArmedLocked() still returns true (it only
+	// checks ForwardingSupported, never the snapshot protocol). Without this
+	// gate the next reconcile tick re-arms the protocol-stale image and
+	// forwards a config the helper cannot represent — the fail-OPEN #6163
+	// closed on the explicit operator-arm path, reachable here from the
+	// UpdatePolicyScheduleState scheduler-tick disarm (which, unlike an
+	// operator commit, does not revert the active config, so m.lastSnapshot
+	// keeps requiring the protocol). Scoped exactly like SetForwardingArmed:
+	// only the ARM direction is gated; a disarm (desired==false — shutdown,
+	// demotion, disarmSnapshotProtocolFailureLocked) must NEVER be blocked. The
+	// gate is a no-op unless the last-applied config requires the protocol, and
+	// it re-polls the helper first so a helper that has since upgraded still
+	// arms normally. Fail closed: leave the helper disarmed and surface the
+	// error to the poll caller (logged), rather than re-arm a stale image.
+	if desired && m.lastSnapshot != nil && m.lastSnapshot.Config != nil {
+		if err := m.ensureRequiredSnapshotProtocolLocked(m.lastSnapshot.Config); err != nil {
+			return err
+		}
+	}
 	if m.clusterHA {
 		slog.Info(
 			"userspace: forwarding arm state change",

--- a/pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go
+++ b/pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go
@@ -1,0 +1,158 @@
+package userspace
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6165 (follow-up to #6163/#5648): the ~1s desired-state forwarding reconcile
+// (syncDesiredForwardingStateLocked / desiredForwardingArmedLocked) must honor
+// the SAME required-generation protocol gate that #6163 added to
+// SetForwardingArmed. desiredForwardingArmedLocked() returns true whenever
+// ForwardingSupported — it never consults the accepted-snapshot protocol
+// version — so after a compile/scheduler-path protocol disarm the reconcile
+// would otherwise re-arm the stale accepted image on the next tick (fail-OPEN).
+//
+// The reachable trace: a config with a scheduler-driven policy (or persistent
+// source NAT) is committed while the helper protocol is current, so
+// m.lastSnapshot.Config REQUIRES ProtocolVersion. The helper is then behind
+// (mixed-base HA deploy / in-place upgrade / older restarted binary). A
+// scheduler tick (UpdatePolicyScheduleState) disarms the helper (fail-closed)
+// and — unlike an operator commit — does NOT revert the active config, so
+// m.lastSnapshot keeps requiring the protocol while the helper is disarmed +
+// protocol-stale. The next reconcile tick must refuse to re-arm.
+
+// TestSyncDesiredForwardingRefusesStaleProtocolMismatch is the #6165
+// fail-on-revert gate: the reconcile must REFUSE to re-arm a helper whose
+// accepted image is behind the required snapshot protocol (returning the
+// required-protocol sentinel) and must NOT send set_forwarding_state{Armed:true}.
+//
+// RED-on-revert: neutralize the guard in syncDesiredForwardingStateLocked
+// (`if desired && m.lastSnapshot != nil && m.lastSnapshot.Config != nil {` →
+// `if false && ...`). The gate is skipped, the reconcile arms the stale image,
+// and the returned error is nil / a control-plane bookkeeping error rather than
+// ErrPolicySchedulerProtocolIncompatible — both assertions below flip RED.
+func TestSyncDesiredForwardingRefusesStaleProtocolMismatch(t *testing.T) {
+	sock, reqCh := recordingControlServer(t)
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = sock
+	// Standalone: desiredForwardingArmedLocked() == true whenever forwarding is
+	// supported. The helper is currently DISARMED (a compile/scheduler-path
+	// disarmSnapshotProtocolFailureLocked just fired) and its accepted image is
+	// STALE — below the required snapshot protocol version.
+	m.lastStatus.Capabilities.ForwardingSupported = true
+	m.lastStatus.ForwardingArmed = false
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion - 1
+	// Last-applied config REQUIRES ProtocolVersion (scheduler-driven policy).
+	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+
+	// Guard the premise: absent the gate the reconcile WOULD arm — it only
+	// sends when desired != current and desired is true.
+	if !m.desiredForwardingArmedLocked() {
+		t.Fatal("test setup: desiredForwardingArmedLocked() must be true so an ungated reconcile would arm")
+	}
+	if m.lastStatus.ForwardingArmed {
+		t.Fatal("test setup: helper must be disarmed so the reconcile detects an arm delta")
+	}
+
+	err := m.syncDesiredForwardingStateLocked()
+	if !errors.Is(err, ErrPolicySchedulerProtocolIncompatible) {
+		t.Fatalf("syncDesiredForwardingStateLocked() err = %v, want %v (reconcile must refuse a stale accepted image)",
+			err, ErrPolicySchedulerProtocolIncompatible)
+	}
+
+	// The security-critical behavior: NO set_forwarding_state{Armed:true} was
+	// sent by the reconcile. The gate's protocol re-poll issues a benign
+	// "status" request; the arm request must never appear.
+	deadline := time.After(300 * time.Millisecond)
+	for {
+		select {
+		case req := <-reqCh:
+			if req.Type == "set_forwarding_state" {
+				t.Fatalf("reconcile must NOT arm on a protocol mismatch; got request %+v", req)
+			}
+		case <-deadline:
+			return
+		}
+	}
+}
+
+// TestSyncDesiredForwardingArmsWhenProtocolMatches is the scoped-not-blanket
+// control: the gate must NOT block a legitimate reconcile arm when the helper's
+// accepted image satisfies the required protocol. Proves the fix refuses ONLY
+// the stale case, so it is not a regression that refuses all reconcile arming.
+func TestSyncDesiredForwardingArmsWhenProtocolMatches(t *testing.T) {
+	sock, reqCh := recordingControlServer(t)
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = sock
+	m.lastStatus.Capabilities.ForwardingSupported = true
+	m.lastStatus.ForwardingArmed = false
+	// Helper's accepted image is CURRENT — satisfies the required protocol.
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+	// Same protocol-requiring config as the mismatch test.
+	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+
+	// applyHelperStatusLocked touches a BPF map absent in a unit test, so the
+	// call may return that local-bookkeeping error AFTER the wire arm request
+	// is issued; that env artifact must not mask the assertion that the arm was
+	// actually sent (mirrors the #5648 SetForwardingArmed control).
+	_ = m.syncDesiredForwardingStateLocked()
+
+	select {
+	case req := <-reqCh:
+		if req.Type != "set_forwarding_state" || req.Forwarding == nil || !req.Forwarding.Armed {
+			t.Fatalf("got request %+v, want set_forwarding_state{Armed:true}", req)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no arm request sent when helper protocol satisfies the requirement")
+	}
+}
+
+// TestSyncDesiredForwardingDisarmNotBlockedByGate proves the gate is scoped to
+// the ARM direction only: a disarm (desired==false) must proceed even when the
+// last-applied config requires a protocol the stale helper cannot honor.
+// Blocking a disarm here would strand a helper ARMED on a config it cannot
+// represent — the opposite fail-open. The scenario: forwarding is no longer
+// desired (e.g. an HA node with no active data RG) while the helper is
+// currently armed and protocol-stale; the reconcile must still send
+// set_forwarding_state{Armed:false}.
+//
+// RED-on-revert: dropping the `desired &&` scope from the guard
+// (`if m.lastSnapshot != nil && m.lastSnapshot.Config != nil {`) makes the gate
+// return the protocol sentinel on the disarm path too, so no disarm request is
+// sent and this test's arm-delta assertion flips RED.
+func TestSyncDesiredForwardingDisarmNotBlockedByGate(t *testing.T) {
+	sock, reqCh := recordingControlServer(t)
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = sock
+	// clusterHA node with no data RG and no active local-only RG:
+	// desiredForwardingArmedLocked() == false, so desired disarm.
+	m.clusterHA = true
+	m.lastStatus.Capabilities.ForwardingSupported = true
+	m.lastStatus.ForwardingArmed = true
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion - 1
+	m.lastSnapshot, _ = buildSnapshot(scheduledPolicyCfg(), config.UserspaceConfig{ControlSocket: sock}, 5, 0)
+
+	if m.desiredForwardingArmedLocked() {
+		t.Fatal("test setup: desiredForwardingArmedLocked() must be false so the reconcile disarms")
+	}
+
+	_ = m.syncDesiredForwardingStateLocked()
+
+	select {
+	case req := <-reqCh:
+		if req.Type != "set_forwarding_state" || req.Forwarding == nil || req.Forwarding.Armed {
+			t.Fatalf("got request %+v, want set_forwarding_state{Armed:false} (disarm must never be gated)", req)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no disarm request sent — the protocol gate must not block the disarm direction")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #6165 — the #6163 hostile-review residual: the ~1s desired-state
forwarding reconcile shared no required-generation protocol gate.

`syncDesiredForwardingStateLocked` (invoked ~1s from the status poll and
from the compile path) sent `set_forwarding_state{Armed:
desiredForwardingArmedLocked()}` with **no** required-generation protocol
gate. `desiredForwardingArmedLocked()` returns true whenever forwarding is
*supported* — it never consults the accepted-snapshot protocol version — so
after a protocol disarm the reconcile could re-arm the stale accepted image.
That is the fail-open #6163 closed on the explicit operator-arm path
(`SetForwardingArmed`), left open on the reconcile path.

## Reachable trace (why this is a real fail-open, not just defense-in-depth)

#6163's reviewer could not construct an end-to-end fail-open because it
reasoned only about the operator **commit** path, which aborts on a
required-generation protocol mismatch and reverts the active config. The
**scheduler-tick disarm is not a commit**:

1. A config with a scheduler-driven policy (or persistent source NAT) is
   committed while the helper protocol is current → `m.lastSnapshot.Config`
   REQUIRES the protocol.
2. The helper falls behind (mixed-base HA deploy / in-place upgrade / older
   restarted binary) → `ConfigSnapshotProtocolVersion < ProtocolVersion`.
3. A scheduler tick (`UpdatePolicyScheduleState` →
   `disarmSnapshotProtocolFailureLocked`) disarms the helper fail-closed and,
   **unlike an operator commit, does NOT revert the active config**.
4. `m.lastSnapshot` keeps requiring the protocol while the helper is disarmed
   and protocol-stale; `desiredForwardingArmedLocked()` still returns true.
5. The next ~1s reconcile tick re-arms the stale image → forwards a config
   the helper cannot represent.

## Fix

Apply the same scoped gate #6163/#5648 put on `SetForwardingArmed`:
`syncDesiredForwardingStateLocked` re-runs
`ensureRequiredSnapshotProtocolLocked(m.lastSnapshot.Config)` and returns the
required-protocol sentinel (leaving the helper disarmed) **before** it
re-arms.

Completeness:
- **Scoped to the ARM direction only** (`if desired && ...`) — a disarm
  (demotion, shutdown, the protocol disarm itself) is never blocked.
- **No-op unless the last-applied config requires the protocol**, and it
  re-polls the helper first so a helper that has since upgraded still arms.
- **Both protocol sentinels** covered (policy scheduler + persistent source
  NAT) via `ensureRequiredSnapshotProtocolLocked`.
- **All three reconcile call sites** (status poll, compile path,
  `RefreshOwnerRGs`/`UpdateRGActive`) covered by one edit at the single choke
  point. The compile-path call already passed the same gate earlier in
  `ApplyConfig`, so the added check is a no-op there.

## Test — fail-on-revert

`pkg/dataplane/userspace/sync_desired_forwarding_generation_6165_test.go`:

- `TestSyncDesiredForwardingRefusesStaleProtocolMismatch` — reconcile refuses
  the stale arm (sentinel returned, no `set_forwarding_state{Armed:true}`
  sent). RED when the whole gate is neutralized (reconcile arms the stale
  image → `userspace_ctrl map not loaded` instead of the sentinel).
- `TestSyncDesiredForwardingArmsWhenProtocolMatches` — scoped-not-blanket
  control: a current helper still arms.
- `TestSyncDesiredForwardingDisarmNotBlockedByGate` — the gate never blocks
  the disarm direction. RED when the `desired &&` scope is dropped.

Both parent-RED cases are clean assertion failures; restored → all three
GREEN. Full `go test ./pkg/dataplane/userspace/` GREEN; gofmt/vet/build
clean. Module doc `docs/userspace-dataplane-gaps.md` updated with the
reconcile-gate contract.

## HA smoke flag

This touches the runtime forwarding-arm reconcile that runs on HA nodes, so
it is HA-adjacent. **The behavior change is confined to the degraded
protocol-stale case**: in all normal operation (helper protocol current, or
config not requiring the protocol) `ensureRequiredSnapshotProtocolLocked`
returns nil immediately, so the gate is a complete no-op and there is zero
change to the failover/arm path. A `make test-failover` run on the loss
userspace cluster (helper current, no scheduled-policy/persistent-NAT in the
smoke config) exercises the reconcile with the gate present always taking the
no-op path — a low-risk regression check that the added gate does not disturb
the normal reconcile arm during failover.