### PR TITLE
api: port #5649 page-token cursor-hardening to REST session codec

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -60204,3 +60204,24 @@ top.
     go test ./... (TMPDIR=/tmp, disk GOCACHE) GREEN.
 - **File(s)**: pkg/routing/bond.go, pkg/routing/adopt_guard_6402_test.go,
     pkg/routing/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23
+- **Action**: #6421 — port the #5649 page-token cursor-hardening from the gRPC
+    surface to the REST session-listing codec (pkg/api/sessions.go), which had
+    drifted. decodeSessionKeyV4/V6 now require the EXACT ABI key length
+    (binary.Size) instead of a `len(b) < N` bound (a noncanonical trailing-byte
+    token previously aliased the same cursor), the encoders emit binary.Size
+    bytes so the token is byte-identical to gRPC, and parseSessionPageToken
+    rejects tokens over maxPageTokenLen (256) before any base64/hex decode
+    (alloc-amplification guard). Read-path only (REST list handler); no
+    VRRP/session-sync/failover code touched. FAIL-ON-REVERT:
+    TestRESTPageTokenCanonical_5649 (codec) + TestRESTSessionCursorNoncanonical_5649
+    (handler) go RED if the exact-length bound is reverted to `<` or the
+    maxPageTokenLen guard is removed — verified by neutralizing decodeSessionKeyV4
+    to `< 13` (both RED at lines 61/151) then restoring (GREEN). Regenerated
+    docs/refactoring-audit-current.txt (sessions.go 1613->1637 WATCH tier).
+    go build ./... , go vet ./pkg/api/ , go test ./pkg/api/ , FULL go test ./...
+    (TMPDIR=/dev/shm) GREEN.
+- **File(s)**: pkg/api/sessions.go,
+    pkg/api/sessions_pagination_canonical_5649_test.go,
+    docs/refactoring-audit-current.txt, _Log.md

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -33,7 +33,7 @@
 [WATCH]      1719  userspace-dp/src/afxdp/worker/mod.rs
 [WATCH]      1670  pkg/config/compiler_validate_warn.go
 [WATCH]      1651  userspace-dp/src/screen/mod.rs
-[WATCH]      1613  pkg/api/sessions.go
+[WATCH]      1637  pkg/api/sessions.go
 [WATCH]      1610  pkg/config/types_system.go
 [WATCH]      1608  userspace-dp/src/afxdp/tx/dispatch/mod.rs
 [WATCH]      1606  pkg/cmdtree/tree.go

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -1539,28 +1539,46 @@ func protoName(p uint8) string {
 // they are opaque to clients.
 
 func encodePageTokenV4(key dataplane.SessionKey) string {
-	b := make([]byte, 13)
+	// Emit exactly binary.Size(key) bytes so the token is byte-identical to the
+	// gRPC surface's canonical key layout (#5649): the trailing pad bytes are
+	// zero-filled by make and the decoder requires this exact length.
+	b := make([]byte, binary.Size(key))
 	copy(b[0:4], key.SrcIP[:])
 	copy(b[4:8], key.DstIP[:])
 	binary.NativeEndian.PutUint16(b[8:10], key.SrcPort)
 	binary.NativeEndian.PutUint16(b[10:12], key.DstPort)
 	b[12] = key.Protocol
+	// pad bytes b[13:16]
 	return base64.RawURLEncoding.EncodeToString([]byte("v4:" + hex.EncodeToString(b)))
 }
 
 func encodePageTokenV6(key dataplane.SessionKeyV6) string {
-	b := make([]byte, 37)
+	// Emit exactly binary.Size(key) bytes — see encodePageTokenV4 (#5649).
+	b := make([]byte, binary.Size(key))
 	copy(b[0:16], key.SrcIP[:])
 	copy(b[16:32], key.DstIP[:])
 	binary.NativeEndian.PutUint16(b[32:34], key.SrcPort)
 	binary.NativeEndian.PutUint16(b[34:36], key.DstPort)
 	b[36] = key.Protocol
+	// pad bytes b[37:40]
 	return base64.RawURLEncoding.EncodeToString([]byte("v6:" + hex.EncodeToString(b)))
 }
+
+// maxPageTokenLen caps the encoded page_token before any base64/hex decode
+// (#5649, C181-C11 — ported from the gRPC surface). The longest legitimate
+// token is "v6:" plus the hex of a SessionKeyV6 (base64 of ~83 bytes, under
+// 128); anything larger is noncanonical. Without this cap a caller could send a
+// token near the HTTP body limit and force transient base64/hex allocations
+// many times the key size before the ABI prefix decode discards the excess. 256
+// leaves ample headroom for the real formats while rejecting the amplification.
+const maxPageTokenLen = 256
 
 // parseSessionPageToken returns the token kind ("v4", "v6", "v6start") and
 // the raw key bytes (nil for "v6start").
 func parseSessionPageToken(token string) (kind string, keyBytes []byte, err error) {
+	if len(token) > maxPageTokenLen {
+		return "", nil, fmt.Errorf("page_token too long: %d bytes", len(token))
+	}
 	raw, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
 		return "", nil, fmt.Errorf("invalid page_token encoding: %w", err)
@@ -1588,8 +1606,12 @@ func parseSessionPageToken(token string) (kind string, keyBytes []byte, err erro
 
 func decodeSessionKeyV4(b []byte) (dataplane.SessionKey, error) {
 	var key dataplane.SessionKey
-	if len(b) < 13 {
-		return key, fmt.Errorf("v4 key too short: %d", len(b))
+	// #5649 (C181-C11, ported from gRPC): require the EXACT ABI key length. A `<`
+	// check accepted trailing bytes, so many distinct oversized tokens hex-decoded
+	// to the same cursor (a noncanonical opaque token) and amplified allocations.
+	// The encoder always emits exactly binary.Size(key) bytes.
+	if len(b) != binary.Size(key) {
+		return key, fmt.Errorf("v4 key wrong length: %d (want %d)", len(b), binary.Size(key))
 	}
 	copy(key.SrcIP[:], b[0:4])
 	copy(key.DstIP[:], b[4:8])
@@ -1601,8 +1623,10 @@ func decodeSessionKeyV4(b []byte) (dataplane.SessionKey, error) {
 
 func decodeSessionKeyV6(b []byte) (dataplane.SessionKeyV6, error) {
 	var key dataplane.SessionKeyV6
-	if len(b) < 37 {
-		return key, fmt.Errorf("v6 key too short: %d", len(b))
+	// #5649 (C181-C11, ported from gRPC): exact ABI key length — see
+	// decodeSessionKeyV4.
+	if len(b) != binary.Size(key) {
+		return key, fmt.Errorf("v6 key wrong length: %d (want %d)", len(b), binary.Size(key))
 	}
 	copy(key.SrcIP[:], b[0:16])
 	copy(key.DstIP[:], b[16:32])

--- a/pkg/api/sessions_pagination_canonical_5649_test.go
+++ b/pkg/api/sessions_pagination_canonical_5649_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #6421 / #5649 (codex-181 C181-C11): the REST session-list cursor codec
+// (pkg/api/sessions.go) had drifted from the gRPC surface — its
+// decodeSessionKeyV4/V6 used a `len(b) < N` check, so any oversized/trailing-
+// byte page_token hex-decoded to the SAME cursor as the canonical key (a
+// noncanonical opaque token), and parseSessionPageToken had no length cap, so a
+// token near the HTTP body limit forced transient base64/hex allocations many
+// times the key size before the ABI prefix decode discarded the excess. The
+// REST decoders now require the EXACT ABI length and parseSessionPageToken
+// rejects tokens over maxPageTokenLen before any decode — matching
+// pkg/grpcapi/pagination_canonical_5649_test.go.
+//
+// FAIL-ON-REVERT: changing the exact-length checks in decodeSessionKeyV4/V6
+// back to `<` makes the trailing-byte cases decode successfully and go RED;
+// removing the maxPageTokenLen guard makes the oversized case decode instead of
+// erroring.
+func TestRESTPageTokenCanonical_5649(t *testing.T) {
+	// A valid round-trip token still decodes cleanly (no false rejects) and
+	// reproduces the exact key — guards the encoder emitting binary.Size bytes.
+	v4 := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 0, 1},
+		DstIP:    [4]byte{10, 0, 0, 2},
+		SrcPort:  1111,
+		DstPort:  2222,
+		Protocol: 6,
+	}
+	kind, kb, err := parseSessionPageToken(encodePageTokenV4(v4))
+	if err != nil || kind != "v4" {
+		t.Fatalf("valid v4 round-trip: kind=%q err=%v", kind, err)
+	}
+	got, err := decodeSessionKeyV4(kb)
+	if err != nil {
+		t.Fatalf("valid v4 key must decode: %v", err)
+	}
+	if got != v4 {
+		t.Fatalf("v4 round-trip mismatch: got %+v want %+v", got, v4)
+	}
+
+	// A token whose hex payload carries a trailing byte beyond the ABI key must
+	// be rejected — previously it silently aliased the same cursor.
+	raw := make([]byte, binary.Size(v4)+1)
+	trailing := "v4:" + hex.EncodeToString(raw)
+	tok := base64.RawURLEncoding.EncodeToString([]byte(trailing))
+	kind, kb, err = parseSessionPageToken(tok)
+	if err != nil || kind != "v4" {
+		t.Fatalf("trailing-byte token should still parse as v4: kind=%q err=%v", kind, err)
+	}
+	if _, err := decodeSessionKeyV4(kb); err == nil {
+		t.Fatal("decodeSessionKeyV4 must REJECT a key with a trailing byte (noncanonical token)")
+	} else if !strings.Contains(err.Error(), "wrong length") {
+		t.Fatalf("trailing-byte reject error %q should mention wrong length", err)
+	}
+
+	// The v6 decoder enforces the same exact-length invariant.
+	var v6 dataplane.SessionKeyV6
+	rawV6 := make([]byte, binary.Size(v6)+1)
+	if _, err := decodeSessionKeyV6(rawV6); err == nil {
+		t.Fatal("decodeSessionKeyV6 must REJECT an over-length key")
+	}
+
+	// An oversized encoded token is rejected before any base64/hex decode. Build
+	// a VALID-base64 token far larger than any real cursor: without the cap it
+	// base64/hex-decodes cleanly (kind v4, no error) — only the length guard
+	// rejects it. A literal size keeps this compiling when the fix is reverted.
+	huge := base64.RawURLEncoding.EncodeToString([]byte("v4:" + strings.Repeat("ab", 300)))
+	if _, _, err := parseSessionPageToken(huge); err == nil {
+		t.Fatal("parseSessionPageToken must REJECT a token far larger than any real cursor")
+	} else if !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("oversized reject error %q should mention too long", err)
+	}
+}
+
+// TestRESTSessionCursorNoncanonical_5649 binds the #5649 hardening to the REST
+// entrypoint: it drives sessionsHandler over a dataset larger than one page and
+// asserts (a) the positive multi-page walk still works with the binary.Size
+// tokens (page size honored, cursor resumes, every row returned once), and (b)
+// a noncanonical trailing-byte page_token is rejected with HTTP 400.
+//
+// FAIL-ON-REVERT: reverting decodeSessionKeyV4 from `!= binary.Size` back to a
+// `<` bound makes the trailing-byte token decode to a (bogus) cursor and the
+// handler return 200 instead of 400, flipping the want-400 assertion red.
+func TestRESTSessionCursorNoncanonical_5649(t *testing.T) {
+	s := &Server{dp: newMultiSessionDP()} // 3 v4 + 1 v6 = 4 sessions
+
+	// (a) Positive multi-page walk: page_size 2 over 4 sessions => >=2 pages,
+	// every row exactly once, page size never exceeded.
+	seen := map[string]bool{}
+	token := ""
+	pages := 0
+	for {
+		url := "/api/v1/security/sessions?page_size=2"
+		if token != "" {
+			url += "&page_token=" + token
+		}
+		rr := httptest.NewRecorder()
+		s.sessionsHandler(rr, httptest.NewRequest("GET", url, nil))
+		if rr.Code != 200 {
+			t.Fatalf("page %d: status %d, want 200; body: %s", pages, rr.Code, rr.Body.String())
+		}
+		resp := decodeSessions(t, rr.Body.Bytes())
+		if len(resp.Sessions) > 2 {
+			t.Fatalf("page %d returned %d rows, want <= page_size 2", pages, len(resp.Sessions))
+		}
+		if resp.PageSize != 2 {
+			t.Fatalf("page %d reported page_size %d, want 2", pages, resp.PageSize)
+		}
+		for _, se := range resp.Sessions {
+			k := se.SrcAddr + ":" + se.DstAddr + ":" + se.Protocol
+			if seen[k] {
+				t.Fatalf("duplicate row across pages: %s", k)
+			}
+			seen[k] = true
+		}
+		pages++
+		if resp.NextPageToken == "" {
+			break
+		}
+		token = resp.NextPageToken
+		if pages > 10 {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+	if len(seen) != 4 {
+		t.Fatalf("cursor pagination returned %d unique rows, want 4", len(seen))
+	}
+	if pages < 2 {
+		t.Fatalf("page_size=2 over 4 rows took %d page(s), want >= 2", pages)
+	}
+
+	// (b) A noncanonical v4 token (canonical key + one trailing byte) parses as
+	// v4 but must be rejected by the exact-length decoder => HTTP 400.
+	var key dataplane.SessionKey
+	noncanon := base64.RawURLEncoding.EncodeToString(
+		[]byte("v4:" + hex.EncodeToString(make([]byte, binary.Size(key)+1))))
+	rr := httptest.NewRecorder()
+	s.sessionsHandler(rr, httptest.NewRequest("GET",
+		"/api/v1/security/sessions?page_size=2&page_token="+noncanon, nil))
+	if rr.Code != 400 {
+		t.Fatalf("noncanonical page_token: status %d, want 400; body: %s", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

The REST session-listing path (`pkg/api/sessions.go`) carried a **drifted
copy** of the cursor page-token codec. The #5649 (C181-C11) hardening lived
only on the gRPC surface (`pkg/grpcapi/server_sessions.go`), so a REST
session-list request was not cursor-hardened the way gRPC is:

- `decodeSessionKeyV4/V6` used a `len(b) < N` bound, so a `page_token` whose
  hex payload carried trailing bytes beyond the ABI key **hex-decoded to the
  same cursor** as the canonical key — many distinct oversized tokens aliased
  one opaque cursor.
- `parseSessionPageToken` had **no length cap**, so a token near the HTTP body
  limit forced transient base64/hex allocations many times the key size before
  the ABI-prefix decode discarded the excess.

## Fix

Port the #5649 bound to the REST codec (staying inside `pkg/api`):

- Decoders require the **exact** ABI key length (`binary.Size(key)`).
- Encoders emit `binary.Size` bytes (zero-filled pad) so a REST token is
  **byte-identical** to the gRPC canonical layout.
- `parseSessionPageToken` rejects any token over `maxPageTokenLen` (256)
  **before** any base64/hex decode.
- Error wording (`wrong length`, `too long`) mirrors the gRPC surface.

## Scope / safety

REST **read path** only — the session-list handler. No VRRP, session-sync, or
failover code is touched. The endpoint contract is unchanged: query params
(`page_size` / `page_token`) and the response envelope (`next_page_token`) are
identical, and tokens remain opaque, node-local cursors. The only observable
change is that a malformed / noncanonical / oversized token now returns
**HTTP 400** instead of silently aliasing a cursor or amplifying allocations —
so no operator-doc update is required (noted in the commit).

## Fail-on-revert test

`pkg/api/sessions_pagination_canonical_5649_test.go` binds the hardening at two
layers:

- **`TestRESTPageTokenCanonical_5649`** (codec): valid token round-trips; a
  trailing-byte token is rejected with `wrong length`; an over-length v6 key is
  rejected; an oversized (valid-base64) token is rejected with `too long`
  before decode.
- **`TestRESTSessionCursorNoncanonical_5649`** (handler): walks a >1-page
  dataset through `sessionsHandler` (page size honored, cursor resumes, every
  row once) and asserts a noncanonical trailing-byte `page_token` yields
  **HTTP 400**.

Reverting `decodeSessionKeyV4` from `!= binary.Size` back to a `< 13` bound
flips **both** tests RED (verified at test lines 61 and 151, then restored).

## Validation

- `go build ./...`
- `go vet ./pkg/api/`
- `go test ./pkg/api/`
- full `go test ./...` — green (regenerated `docs/refactoring-audit-current.txt`
  for the `sessions.go` LOC bump 1613 -> 1637, still WATCH tier)

Closes #6421
