### PR TITLE
config: reject duplicate NAT rule names at commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -60275,3 +60275,19 @@ top.
     GREEN.
 - **File(s)**: pkg/config/dup_nat_rule_names.go,
     pkg/config/dup_nat_rule_names_5649_test.go, docs/config-schema.md, _Log.md
+- **Timestamp**: 2026-07-24 04:40 UTC
+- **Action**: Fold Codex6452c round-3 MINOR — purge the stale "counter
+    identity" / shadowing framing from the three surviving comment/doc sites
+    that the SIMPLIFY commit's emitted message already dropped: the
+    compiler.go call-site comment and the compiler_opts.go
+    lenientDuplicateNATRuleName comment (both retargeted to the type-agnostic
+    config-identity framing, counter-less for NPTv6), and the config-schema.md
+    #5649 section top (which self-contradicted its own type-agnostic bottom
+    paragraph — rewritten so the whole section states the shared-config-identity
+    defect: the shared counter for source/dest/ordinary-static, two snapshots
+    for counter-less NPTv6). Doc/comment-only — no code change (the gate + its
+    emitted diagnostic were confirmed correct by Codex6452c). compiler_opts.go
+    stayed line-count-neutral (2095) so the heatmap is unchanged; build/vet
+    clean, heatmap canary + pkg/config GREEN.
+- **File(s)**: pkg/config/compiler.go, pkg/config/compiler_opts.go,
+    docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60250,3 +60250,28 @@ top.
     heatmap unchanged, FULL go test ./... GREEN.
 - **File(s)**: pkg/config/dup_nat_rule_names.go,
     pkg/config/dup_nat_rule_names_5649_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-23 22:10
+- **Action**: #6452 review fold round 2 (Codex 3 precision findings on the
+    NPTv6-diagnostic code). Took the SIMPLIFY path: dropped the NPTv6 vs
+    counter classification entirely (removed staticRuleIsNPTv6, the nptv6
+    field, the reason() method, and the seenNPTv6 tracking) and use ONE
+    type-agnostic reason for all duplicate NAT rule names — "a NAT rule-set is
+    keyed by rule name, so the same name authored twice compiles both instances
+    as separate first-match entries sharing one operational identity". This is
+    TRUE regardless of type (counted rows for source/destination/ordinary-static,
+    snapshots for counter-less NPTv6) and never claims a per-rule counter,
+    eliminating all three findings (last-then faithfulness, disjoint/mixed-pair
+    accuracy, vacuous flat test) in one stroke. Rejection + core dup-detection
+    untouched. Findings #1/#2 remain deferred to #6455. Tests: tightened the
+    natType assertion to "NAT <type> rule"; replaced the NPTv6-aware test with
+    TestDuplicateNATRuleNameNPTv6Counterless (two same-named NPTv6 static rules
+    → rejected, message must NOT contain "counter"); dropped the vacuous
+    single-rule flat assertion (no detector to bind — a flat-set duplicate can't
+    exist, SetPath merges same-named rules). Parent-RED verified firsthand:
+    (A) `return nil,nil` at gate top → all reject tests RED; (B) flip the strict
+    message "operational identity"→"counter identity" → the NPTv6 no-counter
+    test RED. go vet ./pkg/config clean, heatmap UNCHANGED, FULL go test ./...
+    GREEN.
+- **File(s)**: pkg/config/dup_nat_rule_names.go,
+    pkg/config/dup_nat_rule_names_5649_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60225,3 +60225,28 @@ top.
 - **File(s)**: pkg/config/dup_nat_rule_names.go,
     pkg/config/dup_nat_rule_names_5649_test.go, pkg/config/compiler.go,
     pkg/config/compiler_opts.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-23 21:15
+- **Action**: #6452 review fold (Codex finding #3, NPTv6). NPTv6 (RFC 6296)
+    static rules are counter-less (compileStaticNAT skips rule.IsNPTv6 before
+    assignNATCounterID; buildNptv6Snapshots appends each as its own snapshot)
+    AND the #2241 NPTv6 overlap gate SKIPS same-(rule-set,rule) pairs (#4339),
+    so validateDuplicateNATRuleNamesAST is the ONLY gate that catches a
+    duplicate NPTv6 rule name. Chose Option B (verified firsthand): KEEP the
+    rejection (a duplicate rule name is always invalid) but make the diagnostic
+    NPTv6-aware — added staticRuleIsNPTv6 (mirrors compiler_nat_static.go
+    then-static-nat-nptv6-prefix detection, flat + hierarchical) and
+    dupNATRule.reason() which drops the false shared-counter-identity claim for
+    NPTv6 and reports order-dependent first-match snapshot ambiguity instead.
+    Findings #1 (group-authored dup bypasses top-level-only pre-expansion scan)
+    and #2 (empty rule "" name skipped) verified firsthand as INHERITED
+    #5180-family limitations (dup_named_blocks.go has identical scope), NOT
+    #6452 regressions — filed follow-up issue #6455 covering BOTH gates with a
+    verified repro; did NOT expand #6452 past its sibling's scope. New test
+    TestDuplicateNATRuleNameNPTv6AwareDiagnostic. Parent-RED (two recipes): (A)
+    `return nil,nil` at top of validateDuplicateNATRuleNamesAST → all reject
+    tests RED; (B) `return false` at top of staticRuleIsNPTv6 → ONLY the NPTv6
+    test RED (message reverts to counter-identity). go vet ./pkg/config clean,
+    heatmap unchanged, FULL go test ./... GREEN.
+- **File(s)**: pkg/config/dup_nat_rule_names.go,
+    pkg/config/dup_nat_rule_names_5649_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60204,3 +60204,24 @@ top.
     go test ./... (TMPDIR=/tmp, disk GOCACHE) GREEN.
 - **File(s)**: pkg/routing/bond.go, pkg/routing/adopt_guard_6402_test.go,
     pkg/routing/README.md, _Log.md
+
+- **Timestamp**: 2026-07-23 20:30
+- **Action**: #5649 (C181-M18) — reject duplicate NAT rule names at commit. A
+    NAT rule-set is an ordered first-match table and each rule's counter
+    identity is natType/ruleset/rule; two same-named rules in one rule-set BOTH
+    survive (namedInstances appends each row), so the first shadows the second,
+    the second is unreachable, and both share one counter identity — silently
+    order-dependent translation + merged telemetry. Added
+    validateDuplicateNATRuleNamesAST (pre-expansion, top-level `security` only,
+    keyed by (natType,rule-set,rule), unioned across repeated
+    security/nat/source|destination|static blocks) wired beside the #5180
+    dup-named-block gate in both compileConfigWithOpts and
+    compileConfigForNodeWithOpts; strict rejects, lenient
+    (opts.lenientDuplicateNATRuleName) warns (#1960 no-brick). Fail-on-revert:
+    TestDuplicateNATRuleNameRejected (source/destination/static via CompileConfig)
+    — neutralize by `return nil, nil` at the top of the validator → clean
+    assertion RED (no build break). go build ./pkg/config, go vet ./pkg/config,
+    go test ./pkg/config GREEN; FULL go test ./... GREEN.
+- **File(s)**: pkg/config/dup_nat_rule_names.go,
+    pkg/config/dup_nat_rule_names_5649_test.go, pkg/config/compiler.go,
+    pkg/config/compiler_opts.go, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -467,6 +467,36 @@ peer-view wiring (node0 accepts the peer-only overlap). The shipped `test/incus/
 pool drawn by both NAT64 and a source-NAT rule) and were separated into distinct
 pools + proxy-ARP as part of this change.
 
+### Duplicate NAT rule name (#5649, C181-M18)
+
+NAT rule-sets are ordered, first-match tables and each rule's operational /
+counter identity is `natType/ruleset/rule` (`pkg/dataplane/compiler_nat.go`).
+Two rules authored with the SAME name in one rule-set are NOT reduced to
+last-writer-wins like a #5180 hierarchical block — they BOTH survive:
+`namedInstances` (the rule loop in `compiler_nat_source.go` /
+`compiler_nat_destination.go` / `compiler_nat_static.go`) appends each as a
+separate row. The first shadows the second (first-match), the second is
+unreachable, and both map to the ONE name-derived counter identity, so
+`show` / counter surfaces cannot tell the two rows apart and reordering
+equivalent text can silently change enforcement.
+
+`validateDuplicateNATRuleNamesAST(tree, lenient)`
+(`pkg/config/dup_nat_rule_names.go`, wired beside the #5180 duplicate-named-block
+gate in both `compileConfigWithOpts` and `compileConfigForNodeWithOpts`) rejects
+this at commit. It runs **pre-expansion** on top-level `security` stanzas only —
+apply-groups DEEP-MERGES a same-named rule rather than duplicating it, and the
+flat `set` form reuses the rule node, so only a directly-authored hierarchical
+duplicate reaches the gate. The seen-set is keyed by `(natType, rule-set, rule)`
+and unioned across repeated `security` / `nat` / `source|destination|static`
+blocks (compileNAT merges those, #3915), so a rule name split across two
+`source {}` blocks is caught too. The same rule name in two DIFFERENT rule-sets
+(a distinct identity) is accepted. Strict (commit / commit-check) hard-rejects;
+lenient (load / peer-sync) warns via `opts.lenientDuplicateNATRuleName` (#1960
+no-brick) and keeps the historical two-row behavior. Covered by
+`pkg/config/dup_nat_rule_names_5649_test.go` (source / destination / static
+reject, lenient warn, and distinct-name / different-rule-set / flat-set-merge
+accept guards), RED on revert of the gate (the duplicate is accepted).
+
 **Phase 2 (#5878) — reference-binder canonicalization.** Phase 1 (above) closes
 the divergent-commit fail-open by rejecting a duplicate-spelling collision at
 commit. The second, subtler half of #5878 is that a cross-subsystem reference

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -494,23 +494,30 @@ blocks (compileNAT merges those, #3915), so a rule name split across two
 lenient (load / peer-sync) warns via `opts.lenientDuplicateNATRuleName` (#1960
 no-brick) and keeps the historical two-row behavior.
 
-**NPTv6 (RFC 6296) static rules are counter-less** — `compileStaticNAT` skips
+The reason line is deliberately **type-agnostic** — it states the genuine,
+type-independent defect (a rule-set is keyed by rule name, so the same name
+authored twice is a config error) and never claims a per-rule hit counter.
+NPTv6 (RFC 6296) static rules are COUNTER-LESS — `compileStaticNAT` skips
 `rule.IsNPTv6` before `assignNATCounterID`, and `buildNptv6Snapshots`
-(`pkg/dataplane/userspace/nat_nptv6.go`) appends each rule as its own snapshot.
-The #2241 NPTv6 overlap gate (`compiler_validate_strict_nat.go`) deliberately
-SKIPS same-`(rule-set, rule)` pairs (#4339, so a single multi-`from`-scope rule
-is not flagged against itself), so it never compares two same-named NPTv6 rules
-— this duplicate-name gate is the ONLY one that catches them. A duplicate NPTv6
-rule name is therefore still rejected (a duplicate name is always invalid), but
-the diagnostic is NPTv6-aware: it reports order-dependent first-match resolution
-between the two snapshots rather than a shared counter identity the rule does
-not have (`staticRuleIsNPTv6` + `dupNATRule.reason()`).
+(`pkg/dataplane/userspace/nat_nptv6.go`) appends each rule as its own snapshot —
+so a counter-specific diagnostic would be false for them. The #2241 NPTv6
+overlap gate (`compiler_validate_strict_nat.go`) also deliberately SKIPS
+same-`(rule-set, rule)` pairs (#4339, so a single multi-`from`-scope rule is not
+flagged against itself), so it never compares two same-named NPTv6 rules — this
+duplicate-name gate is the ONLY one that catches them, and it does so with the
+same name-identity reason it uses for every other NAT type.
 
 Covered by `pkg/config/dup_nat_rule_names_5649_test.go` (source / destination /
-static reject, NPTv6-aware-diagnostic reject, lenient warn, and distinct-name /
+static reject, NPTv6 counter-less reject, lenient warn, and distinct-name /
 different-rule-set / flat-set-merge accept guards), RED on revert of the gate
-(the duplicate is accepted) and, separately, RED on revert of the NPTv6
-detection (the diagnostic wrongly claims a counter identity).
+(the duplicate is accepted) and, separately, RED if the diagnostic reintroduces
+a per-rule counter claim (false for a counter-less NPTv6 rule).
+
+The two limitations this gate shares with its #5180 sibling — a duplicate
+authored entirely inside an applied group bypasses the top-level-only
+pre-expansion scan, and a quoted-empty rule name is skipped — are tracked
+family-wide in #6455 rather than diverging this gate's scope from the
+named-block gate.
 
 **Phase 2 (#5878) — reference-binder canonicalization.** Phase 1 (above) closes
 the divergent-commit fail-open by rejecting a duplicate-spelling collision at

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -469,16 +469,18 @@ pools + proxy-ARP as part of this change.
 
 ### Duplicate NAT rule name (#5649, C181-M18)
 
-NAT rule-sets are ordered, first-match tables and each rule's operational /
-counter identity is `natType/ruleset/rule` (`pkg/dataplane/compiler_nat.go`).
-Two rules authored with the SAME name in one rule-set are NOT reduced to
-last-writer-wins like a #5180 hierarchical block — they BOTH survive:
-`namedInstances` (the rule loop in `compiler_nat_source.go` /
-`compiler_nat_destination.go` / `compiler_nat_static.go`) appends each as a
-separate row. The first shadows the second (first-match), the second is
-unreachable, and both map to the ONE name-derived counter identity, so
-`show` / counter surfaces cannot tell the two rows apart and reordering
-equivalent text can silently change enforcement.
+NAT rule-sets are ordered, first-match tables keyed by rule name, so a rule's
+CONFIG identity is `natType/ruleset/rule`. Two rules authored with the SAME
+name in one rule-set are NOT reduced to last-writer-wins like a #5180
+hierarchical block — they BOTH survive: `namedInstances` (the rule loop in
+`compiler_nat_source.go` / `compiler_nat_destination.go` /
+`compiler_nat_static.go`) appends each as a separate first-match entry sharing
+that one config identity. For source / destination / ordinary static NAT that
+identity is also the shared `natType/ruleset/rule` hit counter (so `show` /
+counter surfaces cannot tell the rows apart); for a counter-less NPTv6 (RFC
+6296) static rule they are two snapshots (`buildNptv6Snapshots`). Either way the
+duplicate name is a config error — the harm is type-independent (the shared
+config identity), which is why the gate's diagnostic is type-agnostic (below).
 
 `validateDuplicateNATRuleNamesAST(tree, lenient)`
 (`pkg/config/dup_nat_rule_names.go`, wired beside the #5180 duplicate-named-block

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -492,10 +492,25 @@ blocks (compileNAT merges those, #3915), so a rule name split across two
 `source {}` blocks is caught too. The same rule name in two DIFFERENT rule-sets
 (a distinct identity) is accepted. Strict (commit / commit-check) hard-rejects;
 lenient (load / peer-sync) warns via `opts.lenientDuplicateNATRuleName` (#1960
-no-brick) and keeps the historical two-row behavior. Covered by
-`pkg/config/dup_nat_rule_names_5649_test.go` (source / destination / static
-reject, lenient warn, and distinct-name / different-rule-set / flat-set-merge
-accept guards), RED on revert of the gate (the duplicate is accepted).
+no-brick) and keeps the historical two-row behavior.
+
+**NPTv6 (RFC 6296) static rules are counter-less** — `compileStaticNAT` skips
+`rule.IsNPTv6` before `assignNATCounterID`, and `buildNptv6Snapshots`
+(`pkg/dataplane/userspace/nat_nptv6.go`) appends each rule as its own snapshot.
+The #2241 NPTv6 overlap gate (`compiler_validate_strict_nat.go`) deliberately
+SKIPS same-`(rule-set, rule)` pairs (#4339, so a single multi-`from`-scope rule
+is not flagged against itself), so it never compares two same-named NPTv6 rules
+— this duplicate-name gate is the ONLY one that catches them. A duplicate NPTv6
+rule name is therefore still rejected (a duplicate name is always invalid), but
+the diagnostic is NPTv6-aware: it reports order-dependent first-match resolution
+between the two snapshots rather than a shared counter identity the rule does
+not have (`staticRuleIsNPTv6` + `dupNATRule.reason()`).
+
+Covered by `pkg/config/dup_nat_rule_names_5649_test.go` (source / destination /
+static reject, NPTv6-aware-diagnostic reject, lenient warn, and distinct-name /
+different-rule-set / flat-set-merge accept guards), RED on revert of the gate
+(the duplicate is accepted) and, separately, RED on revert of the NPTv6
+detection (the diagnostic wrongly claims a counter identity).
 
 **Phase 2 (#5878) — reference-binder canonicalization.** Phase 1 (above) closes
 the divergent-commit fail-open by rejecting a duplicate-spelling collision at

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -10,7 +10,7 @@
 [REFACTOR]   2191  userspace-dp/src/session/mod.rs
 [REFACTOR]   2166  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [REFACTOR]   2157  pkg/config/compiler_system.go
-[REFACTOR]   2080  pkg/config/compiler_opts.go
+[REFACTOR]   2095  pkg/config/compiler_opts.go
 [REFACTOR]   2062  pkg/dataplane/userspace/manager_ha.go
 [REFACTOR]   2017  userspace-dp/src/afxdp/frame/mod.rs
 [REFACTOR]   2004  userspace-dp/src/afxdp/frame/inspect.rs

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -243,6 +243,18 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 		return nil, dupBlockErr
 	}
 
+	// #5649 (C181-M18): duplicate NAT rule-name gate — see
+	// validateDuplicateNATRuleNamesAST. Pre-expansion, top-level `security`
+	// stanzas only, beside the #5180 gate. Two same-named rules in one NAT
+	// rule-set BOTH survive as first-match rows (the first shadows the second)
+	// and share one natType/ruleset/rule counter identity; strict rejects,
+	// lenient warns.
+	dupNATRuleWarnings, dupNATRuleErr := validateDuplicateNATRuleNamesAST(
+		tree, opts.lenientDuplicateNATRuleName)
+	if dupNATRuleErr != nil {
+		return nil, dupNATRuleErr
+	}
+
 	// #5878: numeric interface-unit alias gate (#5631) as a BOTH-NODE-effective
 	// union. Runs PRE-expansion, beside the tunnel/zone/table-id gates, so a
 	// peer-only `groups node1`/`${node}` alias that collides only in the
@@ -305,6 +317,7 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 	cfg.Warnings = append(cfg.Warnings, zoneIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
+	cfg.Warnings = append(cfg.Warnings, dupNATRuleWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
 	cfg.Warnings = append(cfg.Warnings, qinqWarnings...)
 	cfg.Warnings = append(cfg.Warnings, vlanMapWarnings...)
@@ -375,6 +388,15 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 		return nil, dupBlockErr
 	}
 
+	// #5649 (C181-M18): duplicate NAT rule-name gate — see compileConfigWithOpts
+	// / validateDuplicateNATRuleNamesAST. Pre-expansion, top-level `security`
+	// stanzas only; strict rejects, lenient warns.
+	dupNATRuleWarnings, dupNATRuleErr := validateDuplicateNATRuleNamesAST(
+		tree, opts.lenientDuplicateNATRuleName)
+	if dupNATRuleErr != nil {
+		return nil, dupNATRuleErr
+	}
+
 	// #5878: numeric interface-unit alias gate (#5631) as a BOTH-NODE-effective
 	// union — see compileConfigWithOpts. Pre-expansion on purpose: the union
 	// across View 1 (groups) + Views 2/3 (node0/node1 expansions) is identical
@@ -431,6 +453,7 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 	cfg.Warnings = append(cfg.Warnings, zoneIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
+	cfg.Warnings = append(cfg.Warnings, dupNATRuleWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
 	cfg.Warnings = append(cfg.Warnings, qinqWarnings...)
 	cfg.Warnings = append(cfg.Warnings, vlanMapWarnings...)

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -246,8 +246,8 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 	// #5649 (C181-M18): duplicate NAT rule-name gate — see
 	// validateDuplicateNATRuleNamesAST. Pre-expansion, top-level `security`
 	// stanzas only, beside the #5180 gate. Two same-named rules in one NAT
-	// rule-set BOTH survive as first-match rows (the first shadows the second)
-	// and share one natType/ruleset/rule counter identity; strict rejects,
+	// rule-set BOTH survive as first-match entries sharing one config identity
+	// (the rule name; counter-less for NPTv6 static); strict rejects,
 	// lenient warns.
 	dupNATRuleWarnings, dupNATRuleErr := validateDuplicateNATRuleNamesAST(
 		tree, opts.lenientDuplicateNATRuleName)

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -416,8 +416,8 @@ type compileOpts struct {
 	// NAT rule-name gate (validateDuplicateNATRuleNamesAST) from a hard error
 	// to a warning on the tolerant load / peer-sync paths. Unlike #5180 the
 	// duplicate is NOT last-writer-wins: both same-named rules survive as
-	// separate first-match rows, the first shadowing the second, and both
-	// share the one natType/ruleset/rule counter identity. An already-persisted
+	// separate first-match entries sharing one config identity (the rule name —
+	// the counter for ordinary rules, but NPTv6 static is counter-less). An already-persisted
 	// config (or one synced from a peer) may carry such a duplicate; an
 	// upgrading / receiving node must still boot through it (warn — the runtime
 	// keeps the historical two-row behavior) rather than fail-closed-on-load

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -412,6 +412,20 @@ type compileOpts struct {
 	// rejected so the author is told to write it once.
 	lenientDuplicateNamedBlock bool
 
+	// lenientDuplicateNATRuleName (#5649, C181-M18) downgrades the duplicate
+	// NAT rule-name gate (validateDuplicateNATRuleNamesAST) from a hard error
+	// to a warning on the tolerant load / peer-sync paths. Unlike #5180 the
+	// duplicate is NOT last-writer-wins: both same-named rules survive as
+	// separate first-match rows, the first shadowing the second, and both
+	// share the one natType/ruleset/rule counter identity. An already-persisted
+	// config (or one synced from a peer) may carry such a duplicate; an
+	// upgrading / receiving node must still boot through it (warn — the runtime
+	// keeps the historical two-row behavior) rather than fail-closed-on-load
+	// (#1960 class). Commit / commit-check stay strict — a new operator edit
+	// that authors a rule twice is rejected so the author is told to write it
+	// once.
+	lenientDuplicateNATRuleName bool
+
 	// lenientNATHostMask (#2173) downgrades the static-NAT / NAT64
 	// host-mask gate (validateNATHostMaskStrict) from a hard compile error
 	// to a cfg.Warnings entry. Set ONLY on the tolerant load / peer-sync
@@ -1978,6 +1992,7 @@ func lenientCompileOpts() compileOpts {
 		lenientLogProfileStreamRef:             true,
 		lenientDynamicAddressFeedRef:           true,
 		lenientDuplicateNamedBlock:             true,
+		lenientDuplicateNATRuleName:            true,
 		lenientNATPoolAlarmThreshold:           true,
 		lenientNATHostMask:                     true,
 		lenientUnsupportedInterfaceStanzas:     true,

--- a/pkg/config/dup_nat_rule_names.go
+++ b/pkg/config/dup_nat_rule_names.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// natRuleSubBlocks lists the NAT sub-blocks whose rule-sets carry named,
+// ordered, first-match rules that share a per-rule operational identity
+// (natType/ruleset/rule; see pkg/dataplane/compiler_nat.go). Keep in sync with
+// compileNAT (compiler_nat_source.go), which iterates exactly these sub-blocks
+// and whose per-type compilers read `rule-set` -> `rule` with namedInstances.
+// nat64 / natv6v4 / proxy-arp are intentionally excluded: they carry no
+// name-derived first-match rule identity of this shape.
+var natRuleSubBlocks = []string{"source", "destination", "static"}
+
+// dupNATRule is one detected duplicate rule name within a single NAT rule-set.
+type dupNATRule struct {
+	natType string // "source" | "destination" | "static"
+	ruleSet string // the rule-set that owns the duplicated rule
+	rule    string // the duplicated rule name
+}
+
+// validateDuplicateNATRuleNamesAST rejects (strict) or warns (lenient) when the
+// candidate authors the SAME rule name twice inside one NAT rule-set.
+//
+// This is a DIFFERENT failure mode from #5180's last-writer-wins hierarchical
+// blocks: duplicate NAT rules BOTH survive. namedInstances (the rule loop in
+// compiler_nat_source.go / _destination.go / _static.go) appends each as a
+// separate first-match row, so the first shadows the second while both map to
+// the single natType/ruleset/rule counter identity (pkg/dataplane/
+// compiler_nat.go). The operator gets order-dependent translation, an
+// unreachable rule, and merged telemetry that show/counter surfaces cannot
+// disambiguate.
+//
+// Runs PRE-expansion on top-level `security` stanzas only, exactly like
+// validateDuplicateNamedBlockAST (#5180): apply-groups DEEP-MERGES a rule of
+// the same name rather than duplicating it, and a rule authored once via flat
+// `set` reuses its rule node, so only hierarchical duplicates authored
+// directly reach here. The seen-set is keyed by (natType, ruleSet, rule) and
+// unioned across repeated `security` / `nat` / `source|destination|static`
+// blocks — compileNAT (#3915) merges those repeats — so a rule name split
+// across two `source {}` blocks is caught too. Strict rejects on the operator
+// commit / commit-check path; lenient (Load / peer-sync, #1960) warns and
+// keeps the historical two-row behavior.
+func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string, error) {
+	if tree == nil {
+		return nil, nil
+	}
+	var dups []dupNATRule
+	seen := map[string]bool{}
+	reported := map[string]bool{}
+	for _, top := range tree.Children {
+		if top.Name() != "security" {
+			continue
+		}
+		for _, nat := range top.FindChildren("nat") {
+			for _, natType := range natRuleSubBlocks {
+				for _, sub := range nat.FindChildren(natType) {
+					for _, rsInst := range namedInstances(sub.FindChildren("rule-set")) {
+						if rsInst.name == "" {
+							continue
+						}
+						for _, ruleInst := range namedInstances(rsInst.node.FindChildren("rule")) {
+							if ruleInst.name == "" {
+								continue
+							}
+							key := natType + "\x00" + rsInst.name + "\x00" + ruleInst.name
+							if seen[key] {
+								if !reported[key] {
+									dups = append(dups, dupNATRule{natType, rsInst.name, ruleInst.name})
+									reported[key] = true
+								}
+							} else {
+								seen[key] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if len(dups) == 0 {
+		return nil, nil
+	}
+	// Deterministic order: natType, then rule-set, then rule.
+	sort.Slice(dups, func(i, j int) bool {
+		if dups[i].natType != dups[j].natType {
+			return dups[i].natType < dups[j].natType
+		}
+		if dups[i].ruleSet != dups[j].ruleSet {
+			return dups[i].ruleSet < dups[j].ruleSet
+		}
+		return dups[i].rule < dups[j].rule
+	})
+
+	if !lenient {
+		d := dups[0]
+		return nil, fmt.Errorf("duplicate NAT %s rule %q in rule-set %q: two "+
+			"same-named rules BOTH compile as separate first-match rows, so the "+
+			"first shadows the second and both share the one %s/%s/%s counter "+
+			"identity — author the rule once (flat `set` merges repeated "+
+			"statements automatically) (#5649)",
+			d.natType, d.rule, d.ruleSet, d.natType, d.ruleSet, d.rule)
+	}
+
+	warnings := make([]string, 0, len(dups))
+	for _, d := range dups {
+		warnings = append(warnings, fmt.Sprintf("duplicate NAT %s rule %q in "+
+			"rule-set %q: the first same-named rule shadows the later one and "+
+			"both share one counter identity — author it once to avoid "+
+			"order-dependent translation and merged telemetry (#5649)",
+			d.natType, d.rule, d.ruleSet))
+	}
+	return warnings, nil
+}

--- a/pkg/config/dup_nat_rule_names.go
+++ b/pkg/config/dup_nat_rule_names.go
@@ -18,81 +18,39 @@ type dupNATRule struct {
 	natType string // "source" | "destination" | "static"
 	ruleSet string // the rule-set that owns the duplicated rule
 	rule    string // the duplicated rule name
-	nptv6   bool   // static NPTv6 (RFC 6296) rule — counter-less, see reason()
-}
-
-// staticRuleIsNPTv6 reports whether a `security nat static` rule node carries a
-// `then static-nat nptv6-prefix ...` translation, i.e. it is an NPTv6 (RFC
-// 6296) rule. Mirrors the IsNPTv6 detection in compileNATStatic
-// (compiler_nat_static.go): flat-set collapses `then static-nat nptv6-prefix
-// PREFIX` onto the static-nat leaf's Keys, while the hierarchical form nests a
-// `nptv6-prefix { PREFIX; }` child. NPTv6 rules matter here only because they
-// are COUNTER-LESS (compileStaticNAT skips rule.IsNPTv6 before
-// assignNATCounterID), so the duplicate diagnostic must not claim a shared
-// counter identity for them.
-func staticRuleIsNPTv6(ruleNode *Node) bool {
-	for _, thenNode := range ruleNode.FindChildren("then") {
-		for _, t := range thenNode.Children {
-			if t.Name() != "static-nat" {
-				continue
-			}
-			if len(t.Keys) >= 3 && t.Keys[1] == "nptv6-prefix" {
-				return true
-			}
-			if t.FindChild("nptv6-prefix") != nil {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// reason states WHY a duplicate NAT rule name is invalid, tailored to whether
-// the rule carries a per-rule hit counter.
-//
-// Every ordinary NAT rule (source / destination / non-NPTv6 static) shares the
-// natType/ruleset/rule counter identity (pkg/dataplane/compiler_nat.go
-// NATCounterKey), so a duplicate name merges telemetry and shadows the second
-// row. An NPTv6 static rule is COUNTER-LESS — compileStaticNAT skips
-// rule.IsNPTv6 before assignNATCounterID and buildNptv6Snapshots appends each
-// rule as its own snapshot — AND the #2241 NPTv6 overlap gate deliberately
-// SKIPS same-(rule-set, rule) pairs (#4339, so a multi-from-scope rule is not
-// flagged against itself). That skip means this gate is the ONLY one that
-// catches a duplicate NPTv6 rule name, but the shared-counter wording does not
-// apply; the harm is order-dependent first-match resolution between the two
-// snapshots instead.
-func (d dupNATRule) reason() string {
-	if d.nptv6 {
-		return "two same-named NPTv6 (RFC 6296) rules BOTH compile as separate " +
-			"first-match snapshots (the overlap gate skips same-name pairs, " +
-			"#4339), so first-match resolution is order-dependent and one prefix " +
-			"silently shadows the other"
-	}
-	return fmt.Sprintf("two same-named rules BOTH compile as separate "+
-		"first-match rows, so the first shadows the second and both share the "+
-		"one %s/%s/%s counter identity", d.natType, d.ruleSet, d.rule)
 }
 
 // validateDuplicateNATRuleNamesAST rejects (strict) or warns (lenient) when the
 // candidate authors the SAME rule name twice inside one NAT rule-set.
 //
-// This is a DIFFERENT failure mode from #5180's last-writer-wins hierarchical
-// blocks: duplicate NAT rules BOTH survive. namedInstances (the rule loop in
-// compiler_nat_source.go / _destination.go / _static.go) appends each as a
-// separate first-match row, so the first shadows the second. For an ordinary
-// rule both rows also map to the single natType/ruleset/rule counter identity;
-// an NPTv6 static rule is counter-less but still ambiguous (see reason()).
+// A NAT rule-set is keyed by rule name and is an ordered first-match table, so
+// the same name authored twice is a config error regardless of NAT type: both
+// instances compile as separate first-match entries sharing one operational
+// identity (the rule name). For source / destination / ordinary static NAT
+// those are counted rows on the shared natType/ruleset/rule hit counter
+// (pkg/dataplane/compiler_nat.go NATCounterKey); for a counter-less NPTv6 (RFC
+// 6296) static rule they are two snapshots (buildNptv6Snapshots appends each,
+// pkg/dataplane/userspace/nat_nptv6.go). The reason line is deliberately
+// type-agnostic: it never claims a per-rule counter (an NPTv6 rule has none —
+// compileStaticNAT skips rule.IsNPTv6 before assignNATCounterID) and does not
+// assert runtime shadowing for disjoint prefixes. The genuine, type-independent
+// defect is the shared name identity. (Overlapping NPTv6 prefixes are rejected
+// separately by the #2241 overlap gate; that gate SKIPS same-(rule-set, rule)
+// pairs (#4339, so a multi-from-scope rule is not flagged against itself),
+// which is exactly why THIS duplicate-name gate is the only one that catches a
+// same-named NPTv6 pair.)
 //
-// Runs PRE-expansion on top-level `security` stanzas only, exactly like
-// validateDuplicateNamedBlockAST (#5180): apply-groups DEEP-MERGES a rule of
-// the same name rather than duplicating it, and a rule authored once via flat
-// `set` reuses its rule node, so only hierarchical duplicates authored
-// directly reach here. The seen-set is keyed by (natType, ruleSet, rule) and
-// unioned across repeated `security` / `nat` / `source|destination|static`
-// blocks — compileNAT (#3915) merges those repeats — so a rule name split
-// across two `source {}` blocks is caught too. Strict rejects on the operator
-// commit / commit-check path; lenient (Load / peer-sync, #1960) warns and
-// keeps the historical two-row behavior.
+// This is a DIFFERENT failure mode from #5180's last-writer-wins hierarchical
+// blocks: duplicate NAT rules BOTH survive. Runs PRE-expansion on top-level
+// `security` stanzas only, exactly like validateDuplicateNamedBlockAST (#5180):
+// apply-groups DEEP-MERGES a rule of the same name rather than duplicating it,
+// and a rule authored once via flat `set` reuses its rule node, so only
+// hierarchical duplicates authored directly reach here. The seen-set is keyed
+// by (natType, ruleSet, rule) and unioned across repeated `security` / `nat` /
+// `source|destination|static` blocks — compileNAT (#3915) merges those repeats
+// — so a rule name split across two `source {}` blocks is caught too. Strict
+// rejects on the operator commit / commit-check path; lenient (Load /
+// peer-sync, #1960) warns and keeps the historical two-row behavior.
 func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string, error) {
 	if tree == nil {
 		return nil, nil
@@ -100,7 +58,6 @@ func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string,
 	var dups []dupNATRule
 	seen := map[string]bool{}
 	reported := map[string]bool{}
-	seenNPTv6 := map[string]bool{}
 	for _, top := range tree.Children {
 		if top.Name() != "security" {
 			continue
@@ -117,26 +74,13 @@ func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string,
 								continue
 							}
 							key := natType + "\x00" + rsInst.name + "\x00" + ruleInst.name
-							// Only static rules can be NPTv6-shaped; the check is
-							// cheap and scoped so source/destination never pay it.
-							isNPT := natType == "static" && staticRuleIsNPTv6(ruleInst.node)
 							if seen[key] {
 								if !reported[key] {
-									dups = append(dups, dupNATRule{
-										natType: natType,
-										ruleSet: rsInst.name,
-										rule:    ruleInst.name,
-										// Counter-less iff EITHER occurrence is
-										// NPTv6-shaped (a mixed pair is still
-										// ambiguous and at least one row is
-										// counter-less).
-										nptv6: seenNPTv6[key] || isNPT,
-									})
+									dups = append(dups, dupNATRule{natType, rsInst.name, ruleInst.name})
 									reported[key] = true
 								}
 							} else {
 								seen[key] = true
-								seenNPTv6[key] = isNPT
 							}
 						}
 					}
@@ -161,16 +105,20 @@ func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string,
 
 	if !lenient {
 		d := dups[0]
-		return nil, fmt.Errorf("duplicate NAT %s rule %q in rule-set %q: %s — "+
-			"author the rule once (flat `set` merges repeated statements "+
-			"automatically) (#5649)", d.natType, d.rule, d.ruleSet, d.reason())
+		return nil, fmt.Errorf("duplicate NAT %s rule %q in rule-set %q: a NAT "+
+			"rule-set is keyed by rule name, so the same name authored twice "+
+			"compiles both instances as separate first-match entries sharing one "+
+			"operational identity — author the rule once (flat `set` merges "+
+			"repeated statements automatically) (#5649)",
+			d.natType, d.rule, d.ruleSet)
 	}
 
 	warnings := make([]string, 0, len(dups))
 	for _, d := range dups {
 		warnings = append(warnings, fmt.Sprintf("duplicate NAT %s rule %q in "+
-			"rule-set %q: %s — author it once (#5649)",
-			d.natType, d.rule, d.ruleSet, d.reason()))
+			"rule-set %q: the same name compiles both instances as separate "+
+			"first-match entries sharing one operational identity — author it "+
+			"once (#5649)", d.natType, d.rule, d.ruleSet))
 	}
 	return warnings, nil
 }

--- a/pkg/config/dup_nat_rule_names.go
+++ b/pkg/config/dup_nat_rule_names.go
@@ -6,12 +6,11 @@ import (
 )
 
 // natRuleSubBlocks lists the NAT sub-blocks whose rule-sets carry named,
-// ordered, first-match rules that share a per-rule operational identity
-// (natType/ruleset/rule; see pkg/dataplane/compiler_nat.go). Keep in sync with
-// compileNAT (compiler_nat_source.go), which iterates exactly these sub-blocks
-// and whose per-type compilers read `rule-set` -> `rule` with namedInstances.
-// nat64 / natv6v4 / proxy-arp are intentionally excluded: they carry no
-// name-derived first-match rule identity of this shape.
+// ordered, first-match rules. Keep in sync with compileNAT
+// (compiler_nat_source.go), which iterates exactly these sub-blocks and whose
+// per-type compilers read `rule-set` -> `rule` with namedInstances. nat64 /
+// natv6v4 / proxy-arp are intentionally excluded: they carry no name-derived
+// first-match rule identity of this shape.
 var natRuleSubBlocks = []string{"source", "destination", "static"}
 
 // dupNATRule is one detected duplicate rule name within a single NAT rule-set.
@@ -19,6 +18,59 @@ type dupNATRule struct {
 	natType string // "source" | "destination" | "static"
 	ruleSet string // the rule-set that owns the duplicated rule
 	rule    string // the duplicated rule name
+	nptv6   bool   // static NPTv6 (RFC 6296) rule — counter-less, see reason()
+}
+
+// staticRuleIsNPTv6 reports whether a `security nat static` rule node carries a
+// `then static-nat nptv6-prefix ...` translation, i.e. it is an NPTv6 (RFC
+// 6296) rule. Mirrors the IsNPTv6 detection in compileNATStatic
+// (compiler_nat_static.go): flat-set collapses `then static-nat nptv6-prefix
+// PREFIX` onto the static-nat leaf's Keys, while the hierarchical form nests a
+// `nptv6-prefix { PREFIX; }` child. NPTv6 rules matter here only because they
+// are COUNTER-LESS (compileStaticNAT skips rule.IsNPTv6 before
+// assignNATCounterID), so the duplicate diagnostic must not claim a shared
+// counter identity for them.
+func staticRuleIsNPTv6(ruleNode *Node) bool {
+	for _, thenNode := range ruleNode.FindChildren("then") {
+		for _, t := range thenNode.Children {
+			if t.Name() != "static-nat" {
+				continue
+			}
+			if len(t.Keys) >= 3 && t.Keys[1] == "nptv6-prefix" {
+				return true
+			}
+			if t.FindChild("nptv6-prefix") != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// reason states WHY a duplicate NAT rule name is invalid, tailored to whether
+// the rule carries a per-rule hit counter.
+//
+// Every ordinary NAT rule (source / destination / non-NPTv6 static) shares the
+// natType/ruleset/rule counter identity (pkg/dataplane/compiler_nat.go
+// NATCounterKey), so a duplicate name merges telemetry and shadows the second
+// row. An NPTv6 static rule is COUNTER-LESS — compileStaticNAT skips
+// rule.IsNPTv6 before assignNATCounterID and buildNptv6Snapshots appends each
+// rule as its own snapshot — AND the #2241 NPTv6 overlap gate deliberately
+// SKIPS same-(rule-set, rule) pairs (#4339, so a multi-from-scope rule is not
+// flagged against itself). That skip means this gate is the ONLY one that
+// catches a duplicate NPTv6 rule name, but the shared-counter wording does not
+// apply; the harm is order-dependent first-match resolution between the two
+// snapshots instead.
+func (d dupNATRule) reason() string {
+	if d.nptv6 {
+		return "two same-named NPTv6 (RFC 6296) rules BOTH compile as separate " +
+			"first-match snapshots (the overlap gate skips same-name pairs, " +
+			"#4339), so first-match resolution is order-dependent and one prefix " +
+			"silently shadows the other"
+	}
+	return fmt.Sprintf("two same-named rules BOTH compile as separate "+
+		"first-match rows, so the first shadows the second and both share the "+
+		"one %s/%s/%s counter identity", d.natType, d.ruleSet, d.rule)
 }
 
 // validateDuplicateNATRuleNamesAST rejects (strict) or warns (lenient) when the
@@ -27,11 +79,9 @@ type dupNATRule struct {
 // This is a DIFFERENT failure mode from #5180's last-writer-wins hierarchical
 // blocks: duplicate NAT rules BOTH survive. namedInstances (the rule loop in
 // compiler_nat_source.go / _destination.go / _static.go) appends each as a
-// separate first-match row, so the first shadows the second while both map to
-// the single natType/ruleset/rule counter identity (pkg/dataplane/
-// compiler_nat.go). The operator gets order-dependent translation, an
-// unreachable rule, and merged telemetry that show/counter surfaces cannot
-// disambiguate.
+// separate first-match row, so the first shadows the second. For an ordinary
+// rule both rows also map to the single natType/ruleset/rule counter identity;
+// an NPTv6 static rule is counter-less but still ambiguous (see reason()).
 //
 // Runs PRE-expansion on top-level `security` stanzas only, exactly like
 // validateDuplicateNamedBlockAST (#5180): apply-groups DEEP-MERGES a rule of
@@ -50,6 +100,7 @@ func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string,
 	var dups []dupNATRule
 	seen := map[string]bool{}
 	reported := map[string]bool{}
+	seenNPTv6 := map[string]bool{}
 	for _, top := range tree.Children {
 		if top.Name() != "security" {
 			continue
@@ -66,13 +117,26 @@ func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string,
 								continue
 							}
 							key := natType + "\x00" + rsInst.name + "\x00" + ruleInst.name
+							// Only static rules can be NPTv6-shaped; the check is
+							// cheap and scoped so source/destination never pay it.
+							isNPT := natType == "static" && staticRuleIsNPTv6(ruleInst.node)
 							if seen[key] {
 								if !reported[key] {
-									dups = append(dups, dupNATRule{natType, rsInst.name, ruleInst.name})
+									dups = append(dups, dupNATRule{
+										natType: natType,
+										ruleSet: rsInst.name,
+										rule:    ruleInst.name,
+										// Counter-less iff EITHER occurrence is
+										// NPTv6-shaped (a mixed pair is still
+										// ambiguous and at least one row is
+										// counter-less).
+										nptv6: seenNPTv6[key] || isNPT,
+									})
 									reported[key] = true
 								}
 							} else {
 								seen[key] = true
+								seenNPTv6[key] = isNPT
 							}
 						}
 					}
@@ -97,21 +161,16 @@ func validateDuplicateNATRuleNamesAST(tree *ConfigTree, lenient bool) ([]string,
 
 	if !lenient {
 		d := dups[0]
-		return nil, fmt.Errorf("duplicate NAT %s rule %q in rule-set %q: two "+
-			"same-named rules BOTH compile as separate first-match rows, so the "+
-			"first shadows the second and both share the one %s/%s/%s counter "+
-			"identity — author the rule once (flat `set` merges repeated "+
-			"statements automatically) (#5649)",
-			d.natType, d.rule, d.ruleSet, d.natType, d.ruleSet, d.rule)
+		return nil, fmt.Errorf("duplicate NAT %s rule %q in rule-set %q: %s — "+
+			"author the rule once (flat `set` merges repeated statements "+
+			"automatically) (#5649)", d.natType, d.rule, d.ruleSet, d.reason())
 	}
 
 	warnings := make([]string, 0, len(dups))
 	for _, d := range dups {
 		warnings = append(warnings, fmt.Sprintf("duplicate NAT %s rule %q in "+
-			"rule-set %q: the first same-named rule shadows the later one and "+
-			"both share one counter identity — author it once to avoid "+
-			"order-dependent translation and merged telemetry (#5649)",
-			d.natType, d.rule, d.ruleSet))
+			"rule-set %q: %s — author it once (#5649)",
+			d.natType, d.rule, d.ruleSet, d.reason()))
 	}
 	return warnings, nil
 }

--- a/pkg/config/dup_nat_rule_names_5649_test.go
+++ b/pkg/config/dup_nat_rule_names_5649_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 // #5649 (C181-M18): two rules with the SAME name in one NAT rule-set both
-// compile as separate first-match rows — the first shadows the second and both
-// share the single natType/ruleset/rule counter identity (pkg/dataplane/
-// compiler_nat.go). The operator gets order-dependent translation, an
-// unreachable rule, and merged telemetry that show/counter surfaces cannot
-// disambiguate. validateDuplicateNATRuleNamesAST rejects this at strict commit
-// and warns on the tolerant load path.
+// compile as separate first-match entries sharing one operational identity (the
+// rule name). A NAT rule-set is keyed by rule name, so the duplicate is a config
+// error regardless of NAT type — counted rows on the shared natType/ruleset/rule
+// hit counter for source/destination/ordinary-static, two snapshots for a
+// counter-less NPTv6 static rule. validateDuplicateNATRuleNamesAST rejects this
+// at strict commit and warns on the tolerant load path.
 //
 // RED-on-revert: neutralize the gate by making validateDuplicateNATRuleNamesAST
 // return `nil, nil` at the top (a clean assertion RED, not a build break) — the
@@ -125,7 +125,9 @@ func TestDuplicateNATRuleNameRejected(t *testing.T) {
 			if err == nil {
 				t.Fatalf("CompileConfig must reject a duplicate NAT %s rule name", tc.name)
 			}
-			for _, want := range []string{tc.name, "R1", "RS", "5649"} {
+			// Bind the exact natType phrase, not just the bare word, plus the
+			// rule / rule-set names and the issue tag.
+			for _, want := range []string{"NAT " + tc.name + " rule", "R1", "RS", "5649"} {
 				if !strings.Contains(err.Error(), want) {
 					t.Fatalf("error should mention %q, got: %v", want, err)
 				}
@@ -134,22 +136,24 @@ func TestDuplicateNATRuleNameRejected(t *testing.T) {
 	}
 }
 
-// TestDuplicateNATRuleNameNPTv6AwareDiagnostic binds the #6452 review fold
-// (Codex finding #3). NPTv6 (RFC 6296) static rules are COUNTER-LESS
-// (compileStaticNAT skips rule.IsNPTv6 before assignNATCounterID;
-// buildNptv6Snapshots appends each as its own snapshot) AND the #2241 NPTv6
-// overlap gate deliberately SKIPS same-(rule-set, rule) pairs (#4339). So two
-// same-named NPTv6 rules are caught by NO other gate — this gate MUST still
-// reject them (a duplicate rule name is always invalid), but the diagnostic
-// must NOT claim a shared "counter identity" for a counter-less rule.
+// TestDuplicateNATRuleNameNPTv6Counterless binds the #6452 review fold. NPTv6
+// (RFC 6296) static rules are COUNTER-LESS: compileStaticNAT skips rule.IsNPTv6
+// before assignNATCounterID, and buildNptv6Snapshots appends each as its own
+// snapshot. The #2241 NPTv6 overlap gate deliberately SKIPS same-(rule-set,
+// rule) pairs (#4339, so a multi-from-scope rule is not flagged against
+// itself), so it never compares two same-named NPTv6 rules — this gate is the
+// only one that catches them. A duplicate NPTv6 rule name is therefore still
+// rejected (a duplicate name is always invalid), but the type-agnostic
+// diagnostic must NOT claim a per-rule counter the NPTv6 rule does not have.
 //
-// RED-on-revert of the NPTv6-awareness (drop the staticRuleIsNPTv6 detection or
-// the reason() nptv6 branch): the message reverts to the counter-identity
-// wording, so the "must NOT mention counter identity" assertion goes RED.
-func TestDuplicateNATRuleNameNPTv6AwareDiagnostic(t *testing.T) {
-	// Two same-named NPTv6 rules with DIFFERENT, non-overlapping prefixes —
-	// the overlap gate would not flag them even if it inspected them, so this
-	// gate is the sole catcher.
+// RED-on-revert of a counter-specific message (e.g. reintroducing "share the
+// one natType/ruleset/rule counter identity"): the "must NOT mention counter"
+// assertion goes RED. RED-on-revert of the gate itself (return nil, nil):
+// CompileConfig no longer rejects and the first assertion goes RED.
+func TestDuplicateNATRuleNameNPTv6Counterless(t *testing.T) {
+	// Two same-named NPTv6 rules with DIFFERENT, non-overlapping prefixes — the
+	// overlap gate would not flag them even if it compared them, so this gate is
+	// the sole catcher.
 	tree := parseHier5649(t, `security {
     nat {
         static {
@@ -173,25 +177,15 @@ func TestDuplicateNATRuleNameNPTv6AwareDiagnostic(t *testing.T) {
 		t.Fatal("CompileConfig must still reject a duplicate NPTv6 static rule name")
 	}
 	msg := err.Error()
-	for _, want := range []string{"static", "R1", "RS", "NPTv6", "5649"} {
+	for _, want := range []string{"NAT static rule", "R1", "RS", "5649"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("NPTv6 duplicate error should mention %q, got: %v", want, err)
 		}
 	}
-	// The rule is counter-less; the diagnostic must not claim a shared counter.
-	if strings.Contains(msg, "counter identity") {
-		t.Fatalf("NPTv6 duplicate diagnostic must NOT claim a shared counter identity, got: %v", err)
-	}
-
-	// Flat-set nptv6-prefix shape is detected too (dual-AST): a single R1 via
-	// flat set MERGES and must pass — proof the detector reads both shapes and
-	// the flat form does not duplicate.
-	flat := setTree5649(t, []string{
-		"set security nat static rule-set RS rule R1 match destination-address 2001:db8:1::/48",
-		"set security nat static rule-set RS rule R1 then static-nat nptv6-prefix 2001:db8:2::/48",
-	})
-	if _, err := validateDuplicateNATRuleNamesAST(flat, false); err != nil {
-		t.Fatalf("flat-set single NPTv6 rule must pass, got: %v", err)
+	// The rule is counter-less; the type-agnostic diagnostic must not claim any
+	// per-rule counter.
+	if strings.Contains(msg, "counter") {
+		t.Fatalf("NPTv6 duplicate diagnostic must NOT claim a per-rule counter, got: %v", err)
 	}
 }
 

--- a/pkg/config/dup_nat_rule_names_5649_test.go
+++ b/pkg/config/dup_nat_rule_names_5649_test.go
@@ -134,6 +134,67 @@ func TestDuplicateNATRuleNameRejected(t *testing.T) {
 	}
 }
 
+// TestDuplicateNATRuleNameNPTv6AwareDiagnostic binds the #6452 review fold
+// (Codex finding #3). NPTv6 (RFC 6296) static rules are COUNTER-LESS
+// (compileStaticNAT skips rule.IsNPTv6 before assignNATCounterID;
+// buildNptv6Snapshots appends each as its own snapshot) AND the #2241 NPTv6
+// overlap gate deliberately SKIPS same-(rule-set, rule) pairs (#4339). So two
+// same-named NPTv6 rules are caught by NO other gate — this gate MUST still
+// reject them (a duplicate rule name is always invalid), but the diagnostic
+// must NOT claim a shared "counter identity" for a counter-less rule.
+//
+// RED-on-revert of the NPTv6-awareness (drop the staticRuleIsNPTv6 detection or
+// the reason() nptv6 branch): the message reverts to the counter-identity
+// wording, so the "must NOT mention counter identity" assertion goes RED.
+func TestDuplicateNATRuleNameNPTv6AwareDiagnostic(t *testing.T) {
+	// Two same-named NPTv6 rules with DIFFERENT, non-overlapping prefixes —
+	// the overlap gate would not flag them even if it inspected them, so this
+	// gate is the sole catcher.
+	tree := parseHier5649(t, `security {
+    nat {
+        static {
+            rule-set RS {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 2001:db8:1::/48; }
+                    then { static-nat { nptv6-prefix { 2001:db8:2::/48; } } }
+                }
+                rule R1 {
+                    match { destination-address 2001:db8:3::/48; }
+                    then { static-nat { nptv6-prefix { 2001:db8:4::/48; } } }
+                }
+            }
+        }
+    }
+}`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig must still reject a duplicate NPTv6 static rule name")
+	}
+	msg := err.Error()
+	for _, want := range []string{"static", "R1", "RS", "NPTv6", "5649"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("NPTv6 duplicate error should mention %q, got: %v", want, err)
+		}
+	}
+	// The rule is counter-less; the diagnostic must not claim a shared counter.
+	if strings.Contains(msg, "counter identity") {
+		t.Fatalf("NPTv6 duplicate diagnostic must NOT claim a shared counter identity, got: %v", err)
+	}
+
+	// Flat-set nptv6-prefix shape is detected too (dual-AST): a single R1 via
+	// flat set MERGES and must pass — proof the detector reads both shapes and
+	// the flat form does not duplicate.
+	flat := setTree5649(t, []string{
+		"set security nat static rule-set RS rule R1 match destination-address 2001:db8:1::/48",
+		"set security nat static rule-set RS rule R1 then static-nat nptv6-prefix 2001:db8:2::/48",
+	})
+	if _, err := validateDuplicateNATRuleNamesAST(flat, false); err != nil {
+		t.Fatalf("flat-set single NPTv6 rule must pass, got: %v", err)
+	}
+}
+
 // TestDuplicateNATRuleNameLenientWarns proves the tolerant path (Load /
 // peer-sync) downgrades the reject to a warning so an already-persisted or
 // peer-synced config still boots through (#1960 class).

--- a/pkg/config/dup_nat_rule_names_5649_test.go
+++ b/pkg/config/dup_nat_rule_names_5649_test.go
@@ -1,0 +1,226 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #5649 (C181-M18): two rules with the SAME name in one NAT rule-set both
+// compile as separate first-match rows — the first shadows the second and both
+// share the single natType/ruleset/rule counter identity (pkg/dataplane/
+// compiler_nat.go). The operator gets order-dependent translation, an
+// unreachable rule, and merged telemetry that show/counter surfaces cannot
+// disambiguate. validateDuplicateNATRuleNamesAST rejects this at strict commit
+// and warns on the tolerant load path.
+//
+// RED-on-revert: neutralize the gate by making validateDuplicateNATRuleNamesAST
+// return `nil, nil` at the top (a clean assertion RED, not a build break) — the
+// strict sub-tests then no longer see a #5649 error and go RED.
+
+// parseHier5649 parses a hierarchical (brace-delimited) config via NewParser —
+// the correct tool for hierarchical duplicate blocks. Flat `set` MERGES a
+// repeated rule onto one node (see the equivalence sub-test), so only the
+// hierarchical shape can express the duplicate this gate targets.
+func parseHier5649(t *testing.T, input string) *ConfigTree {
+	t.Helper()
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	return tree
+}
+
+func setTree5649(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestDuplicateNATRuleNameRejected is the #5649 RED-on-revert proof: strict
+// commit (CompileConfig, the stable public entrypoint) hard-rejects a duplicate
+// rule name in each of the source / destination / static NAT rule-sets. The
+// gate runs pre-expansion and returns before zone/policy validation, so a
+// NAT-only fixture reaches exactly this error.
+func TestDuplicateNATRuleNameRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  string
+	}{
+		{
+			name: "source",
+			cfg: `security {
+    nat {
+        source {
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat { interface; } }
+                }
+                rule R1 {
+                    match { source-address 10.0.1.0/24; }
+                    then { source-nat { off; } }
+                }
+            }
+        }
+    }
+}`,
+		},
+		{
+			name: "destination",
+			cfg: `security {
+    nat {
+        destination {
+            rule-set RS {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 203.0.113.10/32; }
+                    then { destination-nat off; }
+                }
+                rule R1 {
+                    match { destination-address 203.0.113.11/32; }
+                    then { destination-nat off; }
+                }
+            }
+        }
+    }
+}`,
+		},
+		{
+			name: "static",
+			cfg: `security {
+    nat {
+        static {
+            rule-set RS {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 203.0.113.10/32; }
+                    then { static-nat { prefix 10.0.0.10/32; } }
+                }
+                rule R1 {
+                    match { destination-address 203.0.113.11/32; }
+                    then { static-nat { prefix 10.0.0.11/32; } }
+                }
+            }
+        }
+    }
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := parseHier5649(t, tc.cfg)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig must reject a duplicate NAT %s rule name", tc.name)
+			}
+			for _, want := range []string{tc.name, "R1", "RS", "5649"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error should mention %q, got: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestDuplicateNATRuleNameLenientWarns proves the tolerant path (Load /
+// peer-sync) downgrades the reject to a warning so an already-persisted or
+// peer-synced config still boots through (#1960 class).
+func TestDuplicateNATRuleNameLenientWarns(t *testing.T) {
+	tree := parseHier5649(t, `security {
+    nat {
+        source {
+            rule-set RS {
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat { interface; } }
+                }
+                rule R1 {
+                    match { source-address 10.0.1.0/24; }
+                    then { source-nat { off; } }
+                }
+            }
+        }
+    }
+}`)
+
+	// Strict: hard error.
+	if _, err := validateDuplicateNATRuleNamesAST(tree, false); err == nil {
+		t.Fatal("strict validator must reject the duplicate rule name")
+	}
+
+	// Lenient: no error, one warning that names the rule and references #5649.
+	warnings, err := validateDuplicateNATRuleNamesAST(tree, true)
+	if err != nil {
+		t.Fatalf("lenient validator must not error, got: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("lenient validator must emit exactly one warning, got %d: %v", len(warnings), warnings)
+	}
+	for _, want := range []string{"R1", "RS", "5649"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Fatalf("warning should mention %q, got: %v", want, warnings[0])
+		}
+	}
+}
+
+// TestDuplicateNATRuleNameNoFalsePositive guards the gate's scope: distinct
+// rule names, the same rule name in two DIFFERENT rule-sets (a different
+// natType/ruleset/rule identity), and the flat-set form (which MERGES a
+// repeated rule onto one node) must all pass strict.
+func TestDuplicateNATRuleNameNoFalsePositive(t *testing.T) {
+	t.Run("distinct rule names in one rule-set", func(t *testing.T) {
+		tree := parseHier5649(t, `security {
+    nat {
+        source {
+            rule-set RS {
+                rule R1 { then { source-nat { interface; } } }
+                rule R2 { then { source-nat { off; } } }
+            }
+        }
+    }
+}`)
+		if _, err := validateDuplicateNATRuleNamesAST(tree, false); err != nil {
+			t.Fatalf("distinct rule names must pass, got: %v", err)
+		}
+	})
+
+	t.Run("same rule name in two different rule-sets", func(t *testing.T) {
+		tree := parseHier5649(t, `security {
+    nat {
+        source {
+            rule-set RS_A {
+                rule R1 { then { source-nat { interface; } } }
+            }
+            rule-set RS_B {
+                rule R1 { then { source-nat { off; } } }
+            }
+        }
+    }
+}`)
+		if _, err := validateDuplicateNATRuleNamesAST(tree, false); err != nil {
+			t.Fatalf("same rule name in different rule-sets is a distinct identity and must pass, got: %v", err)
+		}
+	})
+
+	t.Run("flat-set repeated rule merges (dual-AST equivalence)", func(t *testing.T) {
+		tree := setTree5649(t, []string{
+			"set security nat source rule-set RS rule R1 match source-address 10.0.0.0/24",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+		})
+		if _, err := validateDuplicateNATRuleNamesAST(tree, false); err != nil {
+			t.Fatalf("flat-set repeated rule statements merge onto one node and must pass, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Advances #5649 by fixing the **C181-M18** survivor from the
codex-review-181 audit cohort. This is one finding of the 19-item
cohort; the issue stays open for the remaining survivors.

A NAT rule-set is an ordered, first-match table and each rule's
operational / counter identity is `natType/ruleset/rule`
(`pkg/dataplane/compiler_nat.go`). Two rules authored with the **same
name** in one rule-set are NOT reduced to last-writer-wins like a #5180
hierarchical block — they **both survive**: `namedInstances` (the rule
loop in `compiler_nat_source.go` / `_destination.go` / `_static.go`)
appends each as a separate row. The first shadows the second
(first-match), the second is unreachable, and both map to the one
name-derived counter identity, so `show` / counter surfaces cannot tell
the rows apart and reordering equivalent text can silently change
enforcement.

## Change

- **`validateDuplicateNATRuleNamesAST`** (`pkg/config/dup_nat_rule_names.go`),
  wired beside the #5180 duplicate-named-block gate in both
  `compileConfigWithOpts` and `compileConfigForNodeWithOpts`.
- Runs **pre-expansion** on top-level `security` stanzas only —
  apply-groups deep-merges a same-named rule rather than duplicating it,
  and the flat `set` form reuses the rule node, so only a
  directly-authored hierarchical duplicate reaches the gate (mirrors the
  #5180 rationale). Seen-set keyed by `(natType, rule-set, rule)`,
  unioned across repeated `security` / `nat` /
  `source|destination|static` blocks (compileNAT merges those, #3915).
- The same rule name in two **different** rule-sets (a distinct
  identity) is accepted.
- **Strict** (commit / commit-check) hard-rejects; **lenient** (load /
  peer-sync) warns via `opts.lenientDuplicateNATRuleName` so an
  already-persisted / peer-synced config still boots through (#1960
  no-brick, matching every sibling gate).
- Docs: sibling gate subsection in `docs/config-schema.md`; regenerated
  `docs/refactoring-audit-current.txt` (`compiler_opts.go` +15 lines).

## Fail-on-revert test

`TestDuplicateNATRuleNameRejected` drives source / destination / static
duplicates through `CompileConfig` (the stable public entrypoint).
**Neutralization recipe:** add `return nil, nil` at the top of
`validateDuplicateNATRuleNamesAST` → all three sub-tests go
clean-assertion RED (`CompileConfig must reject ...`), no build break.
`TestDuplicateNATRuleNameLenientWarns` proves the lenient downgrade;
`TestDuplicateNATRuleNameNoFalsePositive` guards distinct-name /
different-rule-set / flat-set-merge acceptance.

## Validation

`go build ./...`, `go vet ./pkg/config`, and full `go test ./...` (58
packages) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ