### PR TITLE
configstore: fix -race data race on test warn-log buffer

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,20 +1,32 @@
 ## 2026-07-23 — #6446: fix -race data race on configstore test log buffer
 
 - **Timestamp**: 2026-07-23 (fix/6446-configstore-race)
-- **Action**: Guard captureWarnLogs' slog buffer with a mutex-backed
-  syncBuffer. `captureWarnLogs` installs the buffer as the process-global
-  slog.Default(); a persistRetryLoop goroutine leaked from an earlier test
-  (store_persist.go, intentionally no close signal) keeps calling slog.Warn()
-  and writes through the newly-installed handler while the 4579 test reads
-  the raw buffer via String() — the -race detector fired on that read/write.
-  slog's handler mutex only serializes writers among themselves; the raw
-  read bypasses it, so the syncBuffer shares one lock across Write and
-  String.
-- **Validation**: master (raw bytes.Buffer) -> `go test ./pkg/configstore/
-  -race -count=5` = 10 DATA RACE reports + FAIL TestEncryptedRoundTripNoWarn_4579.
-  With the fix -> `-race -count=10` clean (0 races, package PASS, 572s).
-  build/vet clean; full `go test ./...` for regressions.
-- **File(s)**: pkg/configstore/plaintext_downgrade_warn_4579_test.go
+- **Action**: Guard every test-installed slog sink in pkg/configstore with a
+  mutex-backed syncBuffer. A test installs a bytes.Buffer as the
+  process-global slog.Default() and reads it via String(); a persistRetryLoop
+  goroutine leaked from an earlier test (store_persist.go, intentionally no
+  close signal) keeps calling slog.Warn() through the newly-installed handler
+  — the -race detector fires on that read/write. slog's handler mutex only
+  serializes writers among themselves; the raw read bypasses it, so syncBuffer
+  shares one lock across Write and String.
+- **Round 1**: migrated captureWarnLogs (covers the #4579 + #4705 tests) to
+  return *syncBuffer.
+- **Round 2 (Codex MERGE-NEEDS-MAJOR fold)**: the same race class survived in
+  two more tests that installed their OWN raw bytes.Buffer as slog.Default():
+  nodeid_lenient_test.go (now reuses captureWarnLogs, Warn level) and
+  rollback_corrupt_log_4690_test.go (inline syncBuffer to keep its Debug
+  level + defer). Package-wide grep confirms NO raw &buffer slog sink remains
+  (journal_compat_test.go's sb is a strings.Builder writing a file, not a
+  sink).
+- **Validation**: RAW-master (raw bytes.Buffer) reproduced firsthand — full
+  `-race -count=5` = 10 DATA RACE + FAIL (4579/4705 readers); a dense-writer
+  reproducer (permanently failing 1ms-backoff retry loop) fired 9 races
+  naming nodeid_lenient_test.go:47 and rollback_corrupt_log_4690_test.go:59.
+  WITH the fix that same reproducer is clean; full-package `-race -count=15`
+  = 0 races, PASS. build/vet clean; full `go test ./...` for regressions.
+- **File(s)**: pkg/configstore/plaintext_downgrade_warn_4579_test.go,
+  pkg/configstore/nodeid_lenient_test.go,
+  pkg/configstore/rollback_corrupt_log_4690_test.go
 
 ## 2026-07-23 — #6426: decompose pkg/dataplane compileZones god-function
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-23 — #6446: fix -race data race on configstore test log buffer
+
+- **Timestamp**: 2026-07-23 (fix/6446-configstore-race)
+- **Action**: Guard captureWarnLogs' slog buffer with a mutex-backed
+  syncBuffer. `captureWarnLogs` installs the buffer as the process-global
+  slog.Default(); a persistRetryLoop goroutine leaked from an earlier test
+  (store_persist.go, intentionally no close signal) keeps calling slog.Warn()
+  and writes through the newly-installed handler while the 4579 test reads
+  the raw buffer via String() — the -race detector fired on that read/write.
+  slog's handler mutex only serializes writers among themselves; the raw
+  read bypasses it, so the syncBuffer shares one lock across Write and
+  String.
+- **Validation**: master (raw bytes.Buffer) -> `go test ./pkg/configstore/
+  -race -count=5` = 10 DATA RACE reports + FAIL TestEncryptedRoundTripNoWarn_4579.
+  With the fix -> `-race -count=10` clean (0 races, package PASS, 572s).
+  build/vet clean; full `go test ./...` for regressions.
+- **File(s)**: pkg/configstore/plaintext_downgrade_warn_4579_test.go
+
 ## 2026-07-23 — #6426: decompose pkg/dataplane compileZones god-function
 
 - **Timestamp**: 2026-07-23 (refactor/6426-compilezones)

--- a/pkg/configstore/nodeid_lenient_test.go
+++ b/pkg/configstore/nodeid_lenient_test.go
@@ -1,8 +1,6 @@
 package configstore
 
 import (
-	"bytes"
-	"log/slog"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,10 +16,10 @@ import (
 // wrong FPC naming with no diagnostic. RED-on-revert: without the lenient
 // warn, no "node identity mismatch" line is logged.
 func TestLenientNodeIDMismatchWarnsNotRejects(t *testing.T) {
-	var buf bytes.Buffer
-	old := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
-	t.Cleanup(func() { slog.SetDefault(old) })
+	// captureWarnLogs installs a mutex-guarded slog sink (syncBuffer): a
+	// persistRetryLoop goroutine leaked from an earlier test races the read
+	// of a raw buffer otherwise (#6446).
+	buf := captureWarnLogs(t)
 
 	s, err := New(filepath.Join(t.TempDir(), "config.db"))
 	if err != nil {

--- a/pkg/configstore/plaintext_downgrade_warn_4579_test.go
+++ b/pkg/configstore/plaintext_downgrade_warn_4579_test.go
@@ -5,11 +5,37 @@ import (
 	"encoding/json"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/fsatomic"
 )
+
+// syncBuffer is a bytes.Buffer whose Write and String share a mutex so a
+// leaked background goroutine still logging through slog.Default() cannot
+// race the test's read (#6446). captureWarnLogs installs the buffer as the
+// process-global slog default; a persistRetryLoop goroutine leaked from an
+// earlier test (store_persist.go — intentionally no close signal) keeps
+// calling slog.Warn() and writes through the newly-installed handler. slog's
+// handler mutex only serializes writers among themselves; the test reads the
+// raw buffer, so the read needs the same lock as the write to be safe.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 // masterPwTree builds the minimal config tree that declares a
 // master-password pseudorandom-function — the leaf masterPasswordPRF
@@ -30,14 +56,17 @@ func masterPwTree() *config.ConfigTree {
 }
 
 // captureWarnLogs redirects slog to a buffer at Warn level for the test's
-// lifetime and returns the buffer.
-func captureWarnLogs(t *testing.T) *bytes.Buffer {
+// lifetime and returns the buffer. The buffer is mutex-guarded (syncBuffer)
+// because slog.SetDefault installs it process-globally: a leaked
+// persistRetryLoop goroutine from an earlier test writes through the handler
+// concurrently with the test's read (#6446).
+func captureWarnLogs(t *testing.T) *syncBuffer {
 	t.Helper()
-	var buf bytes.Buffer
+	buf := &syncBuffer{}
 	old := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
 	t.Cleanup(func() { slog.SetDefault(old) })
-	return &buf
+	return buf
 }
 
 // TestPlaintextDowngradeWarn_4579 pins the #4579 A4-06 hardening: reading a

--- a/pkg/configstore/rollback_corrupt_log_4690_test.go
+++ b/pkg/configstore/rollback_corrupt_log_4690_test.go
@@ -1,7 +1,6 @@
 package configstore
 
 import (
-	"bytes"
 	"log/slog"
 	"os"
 	"strings"
@@ -49,9 +48,13 @@ func TestLoadRollbackHistoryCorruptFileLogsPositionOnly(t *testing.T) {
 		t.Fatal("test setup: corrupt config must fail to parse")
 	}
 
-	var buf bytes.Buffer
+	// syncBuffer (not a raw bytes.Buffer): the slog sink is installed
+	// process-globally, so a persistRetryLoop goroutine leaked from an earlier
+	// test writes through the handler while this test reads via String() —
+	// the -race read/write must share a lock (#6446).
+	buf := &syncBuffer{}
 	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	defer slog.SetDefault(prev)
 
 	s.loadRollbackHistory()


### PR DESCRIPTION
## Summary

Fixes a `-race`-detected data race in `pkg/configstore` between the
`#4579` downgrade-warn tests and a leaked `persistRetryLoop` goroutine,
firsthand-confirmed at current master.

## Root cause

`captureWarnLogs` installs a `bytes.Buffer` as the **process-global**
`slog.Default()` so the `#4579` tests can assert on logged output. A
`persistRetryLoop` goroutine leaked from an earlier test in the package
(store_persist.go documents that the retry loop has no close signal and
is abandoned at process exit) keeps calling `slog.Warn()` and writes
through the newly-installed handler while the 4579 test reads the raw
buffer via `String()`. slog's handler mutex only serializes writers
among themselves; a caller reading the underlying `bytes.Buffer`
directly bypasses it, so the read races the write.

This is a **test-only** artifact — production never swaps
`slog.Default()` under a running loop and then reads its sink — so
there are no production code changes.

## Fix

Wrap the capture buffer in a `syncBuffer` whose `Write` and `String`
share one mutex, so the test's read is synchronized against any leaked
goroutine's slog write.

## Validation

- **Before (master, raw `bytes.Buffer`):** `go test ./pkg/configstore/
  -race -count=5` → 10 `DATA RACE` stacks + `FAIL
  TestEncryptedRoundTripNoWarn_4579` (bytes.Buffer.grow write in
  persistRetryLoop vs. bytes.Buffer.String read in the test).
- **After (fix, syncBuffer):** `go test ./pkg/configstore/ -race
  -count=10` → clean, 0 races, package PASS.
- `go build ./...`, `go vet ./pkg/configstore/`, and full `go test
  ./...` all pass.

Closes #6446
