### PR TITLE
Advance #5557: case-fold host-inbound service tokens in junos-host shield

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-07-23 — #5557 (advance): host-inbound service-token case-fold in the junos-host coarse shield
+
+- **Timestamp**: 2026-07-23 (fix/5557-hostinbound-service-token-case)
+- **Action**: Case-fold host-inbound `system-services` tokens in the junos-host
+  coarse `application any` shield so it matches enforcement, which lower-cases
+  every token (unionHostInboundTokens/lowerTokens in pkg/dataplane/userspace and
+  the Rust classify_system_service). A lenient-loaded UPPER-case `IKE`/`IPSEC`/
+  `ALL`/`IDENT-RESET` full-admits on the wire, but `junosHostZoneExemptNetdevs`
+  compared the raw case (`s == "ike"`, `HostInboundFullAdmitService("ALL")`) and
+  so left CoarseAdmitsIKE/CoarseIdentResets false — the coarse shield then
+  DROPPED the very IKE/NAT-T (udp 500/4500) and ident (tcp 113) traffic the
+  host-inbound gate admits (#5557 A3 survivor; distinct from the seven #6393
+  items). The sibling protocol path in the same file already normalizes
+  (junosHostAppL4), so this closes the one un-normalized host-inbound match.
+- **Files**: pkg/config/host_inbound_tokens.go (HostInboundFullAdmitService now
+  case/space-folds — this also fixes the #3226 commit full-admit advisory
+  silently skipping an upper-case `ALL`), pkg/config/junos_host_deny.go
+  (junosHostSvcAdmitsIKE + the note() ident-reset loop lower-case each token),
+  pkg/config/junos_host_deny_case_5557_test.go (fail-on-revert).
+- **Fail-on-revert**: TestJunosHostExemptionFlagsCaseInsensitive_5557 (upper-case
+  IKE/IPsec/ALL/Any-Service set CoarseAdmitsIKE; IDENT-RESET sets
+  CoarseIdentResets; IKE scopes an IKEExemptNetdev) and
+  TestHostInboundFullAdmitServiceCaseInsensitive_5557. Neutralize by reverting
+  the three case-folds (junosHostSvcAdmitsIKE, note() loop,
+  HostInboundFullAdmitService) → both go RED via clean assertion.
+- **Validation**: build + vet + gofmt clean; go test ./pkg/config ./pkg/daemon
+  ./pkg/nftables ./pkg/dataplane/userspace green; full `go test ./...` green.
+  Revert-verified firsthand (neutralize → RED → restore → GREEN).
+
 ## 2026-07-23 — #6446: fix -race data race on configstore test log buffer
 
 - **Timestamp**: 2026-07-23 (fix/6446-configstore-race)

--- a/_Log.md
+++ b/_Log.md
@@ -5,13 +5,14 @@
   coarse `application any` shield so it matches enforcement, which lower-cases
   every token (unionHostInboundTokens/lowerTokens in pkg/dataplane/userspace and
   the Rust classify_system_service). A lenient-loaded UPPER-case `IKE`/`IPSEC`/
-  `ALL`/`IDENT-RESET` full-admits on the wire, but `junosHostZoneExemptNetdevs`
-  compared the raw case (`s == "ike"`, `HostInboundFullAdmitService("ALL")`) and
+  `ALL` reaches the wire admitted (`IDENT-RESET` RST-marked), but
+  `junosHostZoneExemptNetdevs` compared the raw case (`s == "ike"`,
+  `HostInboundFullAdmitService("ALL")`) and
   so left CoarseAdmitsIKE/CoarseIdentResets false — the coarse shield then
   DROPPED the very IKE/NAT-T (udp 500/4500) and ident (tcp 113) traffic the
   host-inbound gate admits (#5557 A3 survivor; distinct from the seven #6393
   items). The sibling protocol path in the same file already normalizes
-  (junosHostAppL4), so this closes the one un-normalized host-inbound match.
+  (junosHostReduceApp), so this closes the one un-normalized host-inbound match.
 - **Files**: pkg/config/host_inbound_tokens.go (HostInboundFullAdmitService now
   case/space-folds — this also fixes the #3226 commit full-admit advisory
   silently skipping an upper-case `ALL`), pkg/config/junos_host_deny.go

--- a/pkg/config/host_inbound_tokens.go
+++ b/pkg/config/host_inbound_tokens.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/webmgmt"
 )
@@ -487,6 +488,18 @@ func HostInboundProtocolMatch(token, family string) []L4Match {
 // the nft builder emits a bare `accept` and the classifier reports admission
 // regardless of the tuple. `protocols all` is deliberately NOT a full admit
 // (#3199) — it expands to the routing-protocol set via HostInboundProtocolMatch.
+//
+// The token match is case-insensitive to stay in lockstep with enforcement: the
+// dataplane snapshot (unionHostInboundTokens / lowerTokens in
+// pkg/dataplane/userspace) and the Rust classifier
+// (classify_system_service, host_inbound.rs) both lower-case every token before
+// admitting. A predicate that only matched lower-case `all` would let a
+// lenient-loaded upper-case `ALL` slip past this SSOT while enforcement still
+// full-admits — the #5557 coarse-shield / commit-warning drift.
 func HostInboundFullAdmitService(token string) bool {
-	return token == "all" || token == "any-service"
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case "all", "any-service":
+		return true
+	}
+	return false
 }

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -877,7 +877,7 @@ func junosHostSvcAdmitsIKE(svc []string) bool {
 		// Match enforcement, which lower-cases every token before admitting
 		// (unionHostInboundTokens/lowerTokens in pkg/dataplane/userspace, the
 		// Rust classify_system_service). The sibling protocol path in this file
-		// already normalizes (junosHostAppL4, line ~775); the service path must
+		// already normalizes (junosHostReduceApp, line ~776); the service path must
 		// too or a lenient-loaded upper-case `IKE`/`IPSEC`/`ALL` is admitted by
 		// enforcement yet missed here, so the coarse `application any` shield
 		// drops the very IKE/NAT-T it was supposed to exempt (#5557).

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -874,6 +874,14 @@ func junosHostParsePorts(spec string) ([]PortRange, bool) {
 // token or a full admit.
 func junosHostSvcAdmitsIKE(svc []string) bool {
 	for _, s := range svc {
+		// Match enforcement, which lower-cases every token before admitting
+		// (unionHostInboundTokens/lowerTokens in pkg/dataplane/userspace, the
+		// Rust classify_system_service). The sibling protocol path in this file
+		// already normalizes (junosHostAppL4, line ~775); the service path must
+		// too or a lenient-loaded upper-case `IKE`/`IPSEC`/`ALL` is admitted by
+		// enforcement yet missed here, so the coarse `application any` shield
+		// drops the very IKE/NAT-T it was supposed to exempt (#5557).
+		s = strings.ToLower(strings.TrimSpace(s))
 		if s == "ike" || s == "ipsec" || HostInboundFullAdmitService(s) {
 			return true
 		}
@@ -930,6 +938,11 @@ func junosHostZoneExemptNetdevs(cfg *Config, zoneName string, zone *ZoneConfig, 
 			v.ike = true
 		}
 		for _, s := range svc {
+			// Case-fold to match enforcement (see junosHostSvcAdmitsIKE): a
+			// lenient-loaded upper-case `ALL`/`IDENT-RESET` must set the same
+			// coarse verdict here as the dataplane/Rust classifier reaches, or
+			// the shield diverges from what is actually admitted (#5557).
+			s = strings.ToLower(strings.TrimSpace(s))
 			if HostInboundFullAdmitService(s) {
 				v.fullAdmit = true
 			}

--- a/pkg/config/junos_host_deny_case_5557_test.go
+++ b/pkg/config/junos_host_deny_case_5557_test.go
@@ -1,0 +1,66 @@
+package config
+
+import "testing"
+
+// TestJunosHostExemptionFlagsCaseInsensitive_5557 is the fail-on-revert guard
+// for the #5557 host-inbound service-token case drift. Enforcement lower-cases
+// every host-inbound token before admitting (unionHostInboundTokens /
+// lowerTokens in pkg/dataplane/userspace and the Rust classify_system_service),
+// so a lenient-loaded UPPER-case `IKE`/`IPSEC`/`ALL`/`IDENT-RESET` full-admits
+// on the wire. The junos-host coarse `application any` shield must reach the
+// SAME verdict, or it drops the very IKE/NAT-T (udp 500/4500) and ident (tcp
+// 113 RST) traffic enforcement admits.
+//
+// This mirrors the lower-case TestJunosHostExemptionFlags with upper-case
+// tokens. Reverting the case-fold (junosHostSvcAdmitsIKE / the note() loop /
+// HostInboundFullAdmitService going back to raw `==`) makes every upper-case
+// token miss its match, so CoarseAdmitsIKE / CoarseIdentResets go false and this
+// test goes RED via a clean assertion.
+func TestJunosHostExemptionFlagsCaseInsensitive_5557(t *testing.T) {
+	mk := func(svc ...string) JunosHostDenyProgram {
+		cfg := jhTestConfig()
+		cfg.Security.Zones["untrust"].HostInboundTraffic.SystemServices = svc
+		cfg.Security.Policies = []*ZonePairPolicies{{FromZone: "untrust", ToZone: "junos-host",
+			Policies: []*Policy{jhDeny("block", []string{"bad-net"}, []string{"any"})}}}
+		proj := BuildJunosHostDenyProjection(cfg)
+		if len(proj.Programs) != 1 {
+			t.Fatalf("want 1 program, got %d", len(proj.Programs))
+		}
+		return proj.Programs[0]
+	}
+
+	// IKE / IPsec / full-admit are all case-insensitive coarse-admits for IKE.
+	for _, tok := range []string{"IKE", "IPsec", "ALL", "Any-Service"} {
+		if p := mk(tok); !p.CoarseAdmitsIKE {
+			t.Errorf("system-services %q: want CoarseAdmitsIKE (enforcement full-admits, shield must too)", tok)
+		}
+	}
+	// Upper-case ident-reset must set the RST verdict, matching enforcement.
+	if p := mk("IDENT-RESET"); !p.CoarseIdentResets {
+		t.Error("system-services IDENT-RESET: want CoarseIdentResets")
+	}
+	// A single per-interface upper-case IKE override must scope the exemption to
+	// its own netdev (the CoarseAdmitsIKE bit follows len(IKEExemptNetdevs)).
+	if p := mk("IKE"); len(p.IKEExemptNetdevs) == 0 {
+		t.Error("system-services IKE: want a scoped IKE-exempt netdev, got none")
+	}
+}
+
+// TestHostInboundFullAdmitServiceCaseInsensitive_5557 pins the SSOT predicate
+// itself. Enforcement lower-cases before calling it, but the coarse-shield and
+// the commit-time full-admit advisory feed it the raw authored case; a
+// case-sensitive `== "all"` let an upper-case `ALL` escape both. Reverting to
+// the raw comparison makes these assertions RED.
+func TestHostInboundFullAdmitServiceCaseInsensitive_5557(t *testing.T) {
+	for _, tok := range []string{"ALL", "All", "Any-Service", "ANY-SERVICE", " all "} {
+		if !HostInboundFullAdmitService(tok) {
+			t.Errorf("HostInboundFullAdmitService(%q) = false, want true (case/space-insensitive full admit)", tok)
+		}
+	}
+	// Non-full-admit tokens stay negative regardless of case.
+	for _, tok := range []string{"ssh", "SSH", "ike", "IKE", "protocols-all", ""} {
+		if HostInboundFullAdmitService(tok) {
+			t.Errorf("HostInboundFullAdmitService(%q) = true, want false", tok)
+		}
+	}
+}

--- a/pkg/config/junos_host_deny_case_5557_test.go
+++ b/pkg/config/junos_host_deny_case_5557_test.go
@@ -6,10 +6,11 @@ import "testing"
 // for the #5557 host-inbound service-token case drift. Enforcement lower-cases
 // every host-inbound token before admitting (unionHostInboundTokens /
 // lowerTokens in pkg/dataplane/userspace and the Rust classify_system_service),
-// so a lenient-loaded UPPER-case `IKE`/`IPSEC`/`ALL`/`IDENT-RESET` full-admits
-// on the wire. The junos-host coarse `application any` shield must reach the
-// SAME verdict, or it drops the very IKE/NAT-T (udp 500/4500) and ident (tcp
-// 113 RST) traffic enforcement admits.
+// so a lenient-loaded UPPER-case `IKE`/`IPSEC`/`ALL` is admitted (and
+// `IDENT-RESET` RST-marked) on the wire. The junos-host coarse `application
+// any` shield must reach the SAME verdict, or it drops the very IKE/NAT-T (udp
+// 500/4500) and ident (tcp 113 RST) traffic enforcement admits. Only `ALL`/
+// `any-service` are packet-wide full-admits; `IKE`/`IPsec` admit udp 500/4500.
 //
 // This mirrors the lower-case TestJunosHostExemptionFlags with upper-case
 // tokens. Reverting the case-fold (junosHostSvcAdmitsIKE / the note() loop /
@@ -32,15 +33,15 @@ func TestJunosHostExemptionFlagsCaseInsensitive_5557(t *testing.T) {
 	// IKE / IPsec / full-admit are all case-insensitive coarse-admits for IKE.
 	for _, tok := range []string{"IKE", "IPsec", "ALL", "Any-Service"} {
 		if p := mk(tok); !p.CoarseAdmitsIKE {
-			t.Errorf("system-services %q: want CoarseAdmitsIKE (enforcement full-admits, shield must too)", tok)
+			t.Errorf("system-services %q: want CoarseAdmitsIKE (enforcement admits, shield must too)", tok)
 		}
 	}
 	// Upper-case ident-reset must set the RST verdict, matching enforcement.
 	if p := mk("IDENT-RESET"); !p.CoarseIdentResets {
 		t.Error("system-services IDENT-RESET: want CoarseIdentResets")
 	}
-	// A single per-interface upper-case IKE override must scope the exemption to
-	// its own netdev (the CoarseAdmitsIKE bit follows len(IKEExemptNetdevs)).
+	// A zone-level upper-case IKE service must scope the exemption to a netdev
+	// (the CoarseAdmitsIKE bit follows len(IKEExemptNetdevs)).
 	if p := mk("IKE"); len(p.IKEExemptNetdevs) == 0 {
 		t.Error("system-services IKE: want a scoped IKE-exempt netdev, got none")
 	}


### PR DESCRIPTION
Advances #5557. Fixes one claude-review-003 A3 survivor (host-inbound
service-token case-sensitivity in `junos_host_deny.go`), distinct from
the seven Go control-plane items already merged in #6393.

## The bug

The junos-host coarse `application any` shield decides which ingress
netdevs are exempt from its DROP for IKE/NAT-T (udp 500/4500) and ident
(tcp 113 RST) by reading each interface's effective host-inbound
`system-services` set and comparing tokens **case-sensitively**:
`s == "ike"`, `s == "ipsec"`, `s == "ident-reset"`, and
`HostInboundFullAdmitService`'s `== "all"`.

Enforcement lower-cases every host-inbound token before admitting — the
dataplane snapshot (`unionHostInboundTokens`/`lowerTokens` in
`pkg/dataplane/userspace`) and the Rust classifier
(`classify_system_service`, `host_inbound.rs:78`). Wrong-case tokens are
rejected at commit but only **warned** on the lenient / HA-sync load
path (#1960 no-brick), so a persisted or peer-synced config can carry an
upper-case `IKE`/`IPSEC`/`ALL`/`IDENT-RESET` to runtime.

For such a config enforcement full-admits IKE, but the shield's
case-sensitive comparison leaves `CoarseAdmitsIKE`/`CoarseIdentResets`
false → no exemption is emitted ahead of the drop → the coarse
`application any` DROP shadows and drops the very IKE/NAT-T (VPN control
plane) and ident traffic the host-inbound gate admitted. A fail-closed
drift between the shield and the enforcement path it mirrors. The
sibling **protocol** path in the same file (`junosHostAppL4`) already
lower-cases, so the service path was the one un-normalized match.

## The fix

- `junosHostSvcAdmitsIKE` + the `junosHostZoneExemptNetdevs` `note()`
  loop: lower-case (and trim) each service token before comparison.
- `HostInboundFullAdmitService` (documented SSOT for full-admit tokens):
  case/space-insensitive. Enforcement callers already feed it
  lower-cased tokens (idempotent); this additionally fixes the #3226
  commit-time full-admit breadth advisory silently skipping upper-case
  `ALL`.

Commit-time strict validation is unchanged — wrong-case is still
rejected at commit / warned on lenient load. Only the runtime coarse
verdict now conforms to the module's documented "both layers normalize
case, no runtime split-brain" invariant.

## Tests (fail-on-revert)

- `TestJunosHostExemptionFlagsCaseInsensitive_5557` — upper-case
  `IKE`/`IPsec`/`ALL`/`Any-Service` set `CoarseAdmitsIKE`; `IDENT-RESET`
  sets `CoarseIdentResets`; `IKE` scopes an `IKEExemptNetdev`. Mirrors
  the existing lower-case `TestJunosHostExemptionFlags`.
- `TestHostInboundFullAdmitServiceCaseInsensitive_5557` — pins the SSOT
  predicate.

Reverting the three case-folds drives both RED via clean assertions
(verified firsthand: neutralize → RED → restore → GREEN).

## Validation

build + vet + gofmt clean; `go test` green for pkg/config, pkg/daemon,
pkg/nftables, pkg/dataplane/userspace; full `go test ./...` green. No
HA/cluster/VRRP/session-sync/failover runtime code touched (the coarse
shield projection is pure config compilation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhcWjnJvYsjcdBYStViBNQ