### PR TITLE
config: reject non-numeric static-NAT mapped-port at strict commit (C179-038)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3526,15 +3526,25 @@ reserved for whole-dataplane selection where a rewrite shim
     SetPath grouping is preserved); the
     `mapped-port` token therefore bypasses the schema value validator and
     is validated in the compiler (`validateNATHostMaskStrict`,
-    `compiler_nat.go`): it is range-checked (1..65535), a NON-NUMERIC value
-    is rejected as malformed (C179-038 — before this a garbage token
-    collapsed silently to `MappedPort==0`/"no port translation", so it was
+    `compiler_nat.go`): the compiler records an explicit presence signal
+    (`StaticNATRule.MappedPortPresent`) alongside the parsed port and the
+    raw token, and a PRESENT mapped-port whose value is not a valid
+    1..65535 port is rejected as malformed (C179-038 + fold). One gate
+    covers every sentinel-collision sibling: a non-numeric token
+    (`notaport`), an empty operand (`mapped-port ""`), a bare `mapped-port`
+    with no operand, the literal `0`, and an out-of-range number
+    (`70000`). Before the presence signal these all collapsed silently to
+    `MappedPort==0`/"no port translation" (the int/string sentinels could
+    not tell "absent" from "present-but-malformed"), so a garbage token was
     accepted even though a well-formed value in the same position without a
-    `match destination-port` is rejected; the raw token is carried on
-    `StaticNATRule.MappedPortRaw` so the strict gate can name it), it is
-    rejected when it has no matching `match destination-port` (the reverse
-    SNAT could not recover the original port), AND the mirror half-config —
-    a `match destination-port` with no `mapped-port` (#2769) — is rejected. The port-match-without-
+    `match destination-port` is rejected. The strict error names the
+    offending token from `MappedPortRaw` (or `(missing value)` when the
+    operand is empty/bare); `MappedPortRaw` and `MappedPortPresent` are
+    compile-only (`json:"-"`) and never cross the dataplane wire. A valid
+    in-range mapped-port is still rejected when it has no matching `match
+    destination-port` (the reverse SNAT could not recover the original
+    port), AND the mirror half-config — a `match destination-port` with no
+    `mapped-port` (#2769) — is rejected. The port-match-without-
     mapped-port form is a port-scoped 1:1 (no port translation); rejecting
     it at strict commit-check forces the operator to either drop the port
     match (a whole-address 1:1) or add a `mapped-port` (a port forward). If

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3610,6 +3610,35 @@ reserved for whole-dataplane selection where a rewrite shim
     plus a port-less whole-address 1:1 rule (the dataplane keys the
     static-NAT tables by `(IP, Option<port>)` and falls back to the
     port-less entry).
+    The #5523/#6479 shape-completeness fold closes the last authoring
+    shapes a mapped-port could take. **NPTv6 + mapped-port is rejected on
+    PRESENCE.** NPTv6 (RFC 6296) translates the IPv6 address prefix and has
+    no transport-port concept, and the host-mask loop
+    (`validateNATHostMaskStrict`) skips nptv6 rules entirely, so a
+    `then static-nat nptv6-prefix <p6> mapped-port <p>` in ANY shape
+    (collapsed keys, hierarchical nptv6-prefix child, or a distinct
+    `mapped-port` sibling) previously reached NO validator — a malformed
+    operand was silently accepted and a well-formed one silently ignored.
+    `recordNPTv6MappedPortPresence` (`compiler_nat_static.go`) now stamps
+    `MappedPortPresent` on the nptv6 branches while keeping `MappedPort==0`
+    (no bogus port on the port-less nptv6 path), and `validateNPTv6Strict`
+    rejects a present mapped-port on an nptv6 rule regardless of value (even
+    a well-formed 1-65535 port is meaningless on nptv6) — strict error,
+    lenient warning, with the nptv6 prefix translation itself still applied.
+    The remaining flagged shapes are fail-safe without new code: the
+    modifier-first ordering `... prefix mapped-port <p>` authored BEFORE the
+    `... prefix <ip>` set line makes the modifier line's `prefix` keyword
+    take the value `mapped-port`, so the target resolves to the literal
+    `"mapped-port"` (not an IP) and the rule fails closed on the target;
+    a `prefix-name` mapped-port must RESTATE the name on the same statement
+    (`prefix-name N mapped-port P`) — the non-restated two-line form
+    `prefix-name N` + `prefix-name mapped-port P` parses `mapped-port` into
+    the name slot (name-valued skip), recovering no port and installing none
+    (a plain prefix-name 1:1, matching origin/master); and a range operand
+    (`mapped-port 8080-8090`) is a single non-numeric token that
+    `combineMappedPortOperands` fails closed on. In every shape a
+    present-but-malformed mapped-port is surfaced (strict reject / lenient
+    warn), never silently accepted, and no bogus non-zero port is installed.
   - `security nat source/destination rule-set rule match
     destination-address-name <book-entry>` (#3229) — the destination twin
     of the `source-address-name` leaf (#2416). It references an

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3525,11 +3525,16 @@ reserved for whole-dataplane selection where a rewrite shim
     `... routing-instance <ri>` (#4292) all collapse onto ONE leaf node and
     SetPath grouping is preserved); the
     `mapped-port` token therefore bypasses the schema value validator and
-    is range-checked in the compiler (`validateNATHostMaskStrict`,
-    `compiler_nat.go`), which ALSO rejects a `mapped-port` with no
-    matching `match destination-port` (the reverse SNAT could not recover
-    the original port) AND the mirror half-config — a `match
-    destination-port` with no `mapped-port` (#2769). The port-match-without-
+    is validated in the compiler (`validateNATHostMaskStrict`,
+    `compiler_nat.go`): it is range-checked (1..65535), a NON-NUMERIC value
+    is rejected as malformed (C179-038 — before this a garbage token
+    collapsed silently to `MappedPort==0`/"no port translation", so it was
+    accepted even though a well-formed value in the same position without a
+    `match destination-port` is rejected; the raw token is carried on
+    `StaticNATRule.MappedPortRaw` so the strict gate can name it), it is
+    rejected when it has no matching `match destination-port` (the reverse
+    SNAT could not recover the original port), AND the mirror half-config —
+    a `match destination-port` with no `mapped-port` (#2769) — is rejected. The port-match-without-
     mapped-port form is a port-scoped 1:1 (no port translation); rejecting
     it at strict commit-check forces the operator to either drop the port
     match (a whole-address 1:1) or add a `mapped-port` (a port forward). If

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3547,8 +3547,22 @@ reserved for whole-dataplane selection where a rewrite shim
     `mapped-port` (#2769) — is rejected. The port-match-without-
     mapped-port form is a port-scoped 1:1 (no port translation); rejecting
     it at strict commit-check forces the operator to either drop the port
-    match (a whole-address 1:1) or add a `mapped-port` (a port forward). If
-    such a rule slips through the lenient load / peer-sync path, the Rust
+    match (a whole-address 1:1) or add a `mapped-port` (a port forward).
+    Two refinements land in the #6479 fold. First, every `mapped-port`
+    occurrence is scanned across BOTH AST shapes (the collapsed-keys leaf
+    and the hierarchical `static-nat { prefix X; mapped-port P; }` sibling
+    form) via `combineMappedPortOperands`, not just the first: duplicate
+    operands are last-wins ONLY when they are all valid in-range numbers; a
+    contradictory duplicate (e.g. `mapped-port 8080 mapped-port notaport`)
+    fails closed — any malformed occurrence zeroes the port and the strict
+    gate names the bad token. Second, the port-match-without-mapped-port
+    (#2769) gate is guarded on `!MappedPortPresent` so it fires ONLY on a
+    true absence: a present-but-malformed mapped-port that also carries a
+    `match destination-port` is owned solely by the presence gate (which
+    names the token), never double-reported by the absence gate — which,
+    emitting first, would otherwise mask the accurate "not a valid port
+    number" message in strict mode and add a second warning in lenient mode.
+    If such a rule slips through the lenient load / peer-sync path, the Rust
     dataplane backstop (`static_nat.rs from_snapshots`) keys the reverse
     SNAT on `(internal_ip, Some(match_dst_port))` rather than
     `(internal_ip, None)`, keeping the source translation scoped to the one

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3550,24 +3550,47 @@ reserved for whole-dataplane selection where a rewrite shim
     match (a whole-address 1:1) or add a `mapped-port` (a port forward).
     Two refinements land in the #6479 fold. First,
     `staticNATMappedPortForNode` gathers every `mapped-port` operand
-    attached to a `then static-nat` node — the collapsed-keys `prefix`
-    leaf, a hierarchical `static-nat { prefix X; mapped-port P; }` sibling,
-    AND every child of a duplicate split across two
-    `then static-nat prefix <ip> mapped-port <p>` set lines — into ONE list
-    folded through `combineMappedPortOperands` exactly once. Duplicate
-    operands are last-wins ONLY when they are all valid in-range numbers
-    (`mapped-port 8080 mapped-port 9090` → 9090); a contradictory duplicate
-    in ANY shape or ACROSS nodes (e.g. `mapped-port 8080 mapped-port
-    notaport`) fails closed — any malformed occurrence zeroes the port and
-    the strict gate names the bad token, with no first-wins gate that could
-    let a later malformed duplicate slip past an earlier valid one. The scan
-    is grammar-POSITION-aware (`staticNATMappedPortOperandsFromKeys`): a
-    `mapped-port` token that is the free-form VALUE of an immediately
-    preceding `routing-instance <ri>` or `prefix <addr>` is NOT a modifier,
-    so a translation-target routing-instance NAMED `mapped-port`
-    (`then static-nat prefix <ip> routing-instance mapped-port`, #4292)
-    compiles clean instead of being falsely rejected as a bare mapped-port
-    (the fold-introduced false positive this refinement closes). Second, the
+    attached to a `then static-nat` node across EVERY Junos AST shape, into
+    ONE list folded through `combineMappedPortOperands` exactly once:
+      - the collapsed one-line `prefix <ip> mapped-port <port>` leaf;
+      - the CANONICAL separate-set-line form — Juniper documents mapped-port
+        as a sub-statement of `prefix`, authored as two set lines
+        (`... prefix 10.0.0.5/32` + `... prefix mapped-port 8080`) that
+        SetPath collapses to a distinct leaf `Keys=["prefix","mapped-port",
+        "8080"]`, mapped-port immediately following the literal `prefix`;
+      - the CANONICAL hierarchical nested form — `prefix <ip> { mapped-port
+        P; }` / `prefix { <ip>; mapped-port P; }`, where mapped-port is a
+        CHILD of the `prefix` node (a grandchild of `static-nat`), scanned
+        via the target child's `Children`, not just its `Keys`;
+      - a `prefix-name <name> mapped-port <port>` target (#4290) — the
+        prefix-name compile branch feeds `staticNATMappedPortForNode` too,
+        so a prefix-name-scoped mapped-port is gated identically;
+      - a hierarchical `static-nat { prefix X; mapped-port P; }` sibling,
+        scanning ALL operands of a packed `mapped-port a mapped-port b`
+        child (not just the first);
+      - AND every child of a duplicate split across two
+        `then static-nat prefix <ip> mapped-port <p>` set lines.
+    Duplicate operands are last-wins ONLY when they are all valid in-range
+    numbers (`mapped-port 8080 mapped-port 9090` → 9090); a contradictory
+    duplicate in ANY shape or ACROSS nodes (e.g. `mapped-port 8080
+    mapped-port notaport`) fails closed — any malformed occurrence zeroes
+    the port and the strict gate names the bad token, with no first-wins
+    gate that could let a later malformed duplicate slip past an earlier
+    valid one. The scan is grammar-POSITION-aware
+    (`staticNATMappedPortOperandsFromKeys`): a `mapped-port` token is
+    skipped ONLY when it is the free-form VALUE of an immediately preceding
+    NAME-valued keyword (`mappedPortNameValuedKeywords`: `routing-instance`,
+    `prefix-name`, `nptv6-prefix`) whose value could legally be the literal
+    string `mapped-port`, so a translation-target routing-instance NAMED
+    `mapped-port` (`... routing-instance mapped-port`, #4292) or a
+    prefix-name entry NAMED `mapped-port` compiles clean instead of being
+    falsely rejected as a bare mapped-port. It is NOT skipped after `prefix`,
+    whose value is ALWAYS an IP and can never be the string `mapped-port`:
+    `prefix mapped-port <port>` is the canonical modifier. A round-4
+    over-defensive addition of `prefix` to the skip set broke that canonical
+    form — it both false-rejected the clean rule (it looked like a
+    match-port with no mapped-port) and reopened the C179-038 fail-open for
+    a canonical malformed value; #6479 removes it. Second, the
     port-match-without-mapped-port (#2769) gate is guarded on
     `!MappedPortPresent` so it fires ONLY on a
     true absence: a present-but-malformed mapped-port that also carries a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3576,7 +3576,24 @@ reserved for whole-dataplane selection where a rewrite shim
     mapped-port notaport`) fails closed — any malformed occurrence zeroes
     the port and the strict gate names the bad token, with no first-wins
     gate that could let a later malformed duplicate slip past an earlier
-    valid one. The scan is grammar-POSITION-aware
+    valid one. Across MULTIPLE `static-nat` sibling targets in ONE `then`
+    block (the hierarchical `then { static-nat {…} static-nat {…} }` shape,
+    which Junos merges into one action), each sibling's reading folds
+    through `mergeMappedPortState`, which OR-accumulates presence and
+    LATCHES fail-closed on any malformed operand — so a later clean sibling
+    can no longer overwrite an earlier sibling's presence/malformed stamp
+    back to false (the #6479 multi-block silent-accept, closed in BOTH the
+    nptv6 and the prefix/prefix-name branches). This sibling accumulation is
+    scoped WITHIN one `then` block; SEPARATE `then {}` blocks remain #3850
+    last-then-block-wins (a whole superseded block is dead config, not part
+    of the effective action). NOTE on duplicate resolution: the all-valid
+    duplicate last-wins (`mapped-port 8080 mapped-port 9090` → 9090) is the
+    INTENTIONAL disposition of a contradictory duplicate and DIFFERS from
+    origin/master's first-wins (8080). It is not a working-config
+    regression — a duplicate mapped-port on one target is malformed
+    authoring, defensible either way — and last-wins is chosen for
+    consistency with the Junos duplicate-stanza rule the rest of this fold
+    already follows. The scan is grammar-POSITION-aware
     (`staticNATMappedPortOperandsFromKeys`): a `mapped-port` token is
     skipped ONLY when it is the free-form VALUE of an immediately preceding
     NAME-valued keyword (`mappedPortNameValuedKeywords`: `routing-instance`,

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3583,7 +3583,14 @@ reserved for whole-dataplane selection where a rewrite shim
     LATCHES fail-closed on any malformed operand — so a later clean sibling
     can no longer overwrite an earlier sibling's presence/malformed stamp
     back to false (the #6479 multi-block silent-accept, closed in BOTH the
-    nptv6 and the prefix/prefix-name branches). This sibling accumulation is
+    nptv6 and the prefix/prefix-name branches). A MODIFIER-ONLY `static-nat`
+    sibling (a `static-nat {…}` block carrying ONLY a `mapped-port`, with no
+    `prefix`/`prefix-name`/`nptv6-prefix`/`inet` target) is routed through the
+    same accumulator by a catch-all `else` branch in `compileNATStatic`, so
+    its malformed operand fails closed in either sibling order and even when a
+    co-sibling is a clean nptv6 target — previously it matched no target
+    branch and reached no validator (the #6479 modifier-only silent-accept).
+    This sibling accumulation is
     scoped WITHIN one `then` block; SEPARATE `then {}` blocks remain #3850
     last-then-block-wins (a whole superseded block is dead config, not part
     of the effective action). NOTE on duplicate resolution: the all-valid
@@ -3593,21 +3600,33 @@ reserved for whole-dataplane selection where a rewrite shim
     regression — a duplicate mapped-port on one target is malformed
     authoring, defensible either way — and last-wins is chosen for
     consistency with the Junos duplicate-stanza rule the rest of this fold
-    already follows. The scan is grammar-POSITION-aware
-    (`staticNATMappedPortOperandsFromKeys`): a `mapped-port` token is
-    skipped ONLY when it is the free-form VALUE of an immediately preceding
-    NAME-valued keyword (`mappedPortNameValuedKeywords`: `routing-instance`,
-    `prefix-name`, `nptv6-prefix`) whose value could legally be the literal
-    string `mapped-port`, so a translation-target routing-instance NAMED
-    `mapped-port` (`... routing-instance mapped-port`, #4292) or a
-    prefix-name entry NAMED `mapped-port` compiles clean instead of being
-    falsely rejected as a bare mapped-port. It is NOT skipped after `prefix`,
-    whose value is ALWAYS an IP and can never be the string `mapped-port`:
-    `prefix mapped-port <port>` is the canonical modifier. A round-4
-    over-defensive addition of `prefix` to the skip set broke that canonical
-    form — it both false-rejected the clean rule (it looked like a
-    match-port with no mapped-port) and reopened the C179-038 fail-open for
-    a canonical malformed value; #6479 removes it. Second, the
+    already follows. The scan is grammar-ROLE-aware
+    (`staticNATMappedPortOperandsFromKeys`): it walks the collapsed key
+    stream tracking whether each position is a KEYWORD slot or a consumed
+    VALUE slot, and a `mapped-port` counts as the modifier ONLY in a keyword
+    slot. A NAME-valued keyword (`mappedPortNameValuedKeywords`:
+    `routing-instance`, `prefix-name`) CONSUMES its following token as an
+    opaque name, so a `mapped-port` in that consumed slot is the name — a
+    translation-target routing-instance NAMED `mapped-port`
+    (`... routing-instance mapped-port`, #4292) or a prefix-name entry NAMED
+    `mapped-port` compiles clean instead of being falsely rejected as a bare
+    mapped-port. Because it is the SLOT (keyword vs value) that decides, never
+    the neighbouring text, a target whose NAME is itself literally
+    `prefix-name` or `routing-instance`
+    (`prefix-name prefix-name mapped-port <bad>`) no longer fools the scan:
+    the earlier LEXEME-only lookbehind saw the preceding token `prefix-name`
+    and wrongly skipped the real modifier, silently accepting a malformed
+    port (the #6479 root cause); the role-aware walk consumes that name as the
+    prefix-name VALUE and reads the following `mapped-port` as the
+    keyword-slot modifier. `prefix` and `nptv6-prefix` are deliberately NOT
+    name-valued: their value is ALWAYS an IP and can never be the string
+    `mapped-port`, so the scan does not consume-and-shadow the token after
+    them and `prefix mapped-port <port>` / `nptv6-prefix mapped-port <port>`
+    (the canonical separate-set-line modifiers) are recovered. A round-4
+    over-defensive addition of `prefix` to the name-valued set — and its
+    `nptv6-prefix` sibling — broke those canonical forms (false-rejecting the
+    clean rule and reopening the C179-038 fail-open, the nptv6 one so
+    `validateNPTv6Strict` never fired); #6479 keeps both out. Second, the
     port-match-without-mapped-port (#2769) gate is guarded on
     `!MappedPortPresent` so it fires ONLY on a
     true absence: a present-but-malformed mapped-port that also carries a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3548,15 +3548,28 @@ reserved for whole-dataplane selection where a rewrite shim
     mapped-port form is a port-scoped 1:1 (no port translation); rejecting
     it at strict commit-check forces the operator to either drop the port
     match (a whole-address 1:1) or add a `mapped-port` (a port forward).
-    Two refinements land in the #6479 fold. First, every `mapped-port`
-    occurrence is scanned across BOTH AST shapes (the collapsed-keys leaf
-    and the hierarchical `static-nat { prefix X; mapped-port P; }` sibling
-    form) via `combineMappedPortOperands`, not just the first: duplicate
-    operands are last-wins ONLY when they are all valid in-range numbers; a
-    contradictory duplicate (e.g. `mapped-port 8080 mapped-port notaport`)
-    fails closed — any malformed occurrence zeroes the port and the strict
-    gate names the bad token. Second, the port-match-without-mapped-port
-    (#2769) gate is guarded on `!MappedPortPresent` so it fires ONLY on a
+    Two refinements land in the #6479 fold. First,
+    `staticNATMappedPortForNode` gathers every `mapped-port` operand
+    attached to a `then static-nat` node — the collapsed-keys `prefix`
+    leaf, a hierarchical `static-nat { prefix X; mapped-port P; }` sibling,
+    AND every child of a duplicate split across two
+    `then static-nat prefix <ip> mapped-port <p>` set lines — into ONE list
+    folded through `combineMappedPortOperands` exactly once. Duplicate
+    operands are last-wins ONLY when they are all valid in-range numbers
+    (`mapped-port 8080 mapped-port 9090` → 9090); a contradictory duplicate
+    in ANY shape or ACROSS nodes (e.g. `mapped-port 8080 mapped-port
+    notaport`) fails closed — any malformed occurrence zeroes the port and
+    the strict gate names the bad token, with no first-wins gate that could
+    let a later malformed duplicate slip past an earlier valid one. The scan
+    is grammar-POSITION-aware (`staticNATMappedPortOperandsFromKeys`): a
+    `mapped-port` token that is the free-form VALUE of an immediately
+    preceding `routing-instance <ri>` or `prefix <addr>` is NOT a modifier,
+    so a translation-target routing-instance NAMED `mapped-port`
+    (`then static-nat prefix <ip> routing-instance mapped-port`, #4292)
+    compiles clean instead of being falsely rejected as a bare mapped-port
+    (the fold-introduced false positive this refinement closes). Second, the
+    port-match-without-mapped-port (#2769) gate is guarded on
+    `!MappedPortPresent` so it fires ONLY on a
     true absence: a present-but-malformed mapped-port that also carries a
     `match destination-port` is owned solely by the presence gate (which
     names the token), never double-reported by the absence gate — which,

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,7 +1,7 @@
 [REFACTOR]   5172  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [REFACTOR]   3666  userspace-dp/src/policy.rs
 [REFACTOR]   3437  userspace-dp/src/nat64.rs
-[REFACTOR]   2800  pkg/config/compiler_validate_strict_nat.go
+[REFACTOR]   2865  pkg/config/compiler_validate_strict_nat.go
 [REFACTOR]   2383  userspace-dp/src/nat/allocator.rs
 [REFACTOR]   2288  pkg/ddns/surface_a.go
 [REFACTOR]   2257  pkg/policymatch/policymatch.go

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -67,11 +67,13 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 	}
 }
 
-// mappedPortNameValuedKeywords is the set of static-NAT `then` keywords whose
-// following token is an operator-chosen NAME (not an IP/prefix), so that name
-// could legally be the literal string "mapped-port". A `mapped-port` token that
-// is the VALUE of one of these keywords is NOT a mapped-port modifier and must
-// be skipped by the operand scan (#6479):
+// mappedPortNameValuedKeywords is the set of static-NAT `then` keywords that
+// CONSUME their following token as an operator-chosen NAME (not an IP/prefix),
+// so that name could legally be the literal string "mapped-port". The
+// grammar-role-aware operand scan (staticNATMappedPortOperandsFromKeys) treats
+// the token immediately after one of these keywords as a consumed VALUE slot,
+// never a modifier keyword — so a `mapped-port` sitting in that slot is the name,
+// not the port modifier (#6479):
 //
 //   - `routing-instance <ri>` — a translation-target routing-instance may be
 //     NAMED "mapped-port" (#4292).
@@ -79,19 +81,20 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 //     global address-book entry (#4290) that may be NAMED "mapped-port".
 //
 // `prefix` AND `nptv6-prefix` are deliberately ABSENT: both take an IP/CIDR
-// prefix value that can NEVER be the string "mapped-port", so a `mapped-port`
-// token immediately after either literal keyword is ALWAYS the genuine modifier.
+// prefix value that can NEVER be the string "mapped-port", so the scan does NOT
+// consume-and-shadow the token after either literal keyword — a `mapped-port`
+// immediately following `prefix`/`nptv6-prefix` is ALWAYS the genuine modifier.
 // The canonical separate-set-line Junos forms `prefix <ip>` + `prefix
 // mapped-port <port>` and `nptv6-prefix <p6>` + `nptv6-prefix mapped-port
 // <port>` collapse the modifier line to Keys `["prefix","mapped-port","<port>"]`
 // / `["nptv6-prefix","mapped-port","<port>"]`, and the modifier MUST be
 // recovered from that position. `prefix` was a round-4 over-defensive addition
 // removed in round 5 (it false-rejected the canonical clean rule AND reopened
-// the C179-038 fail-open); `nptv6-prefix` is its sibling and is removed here —
-// leaving it in the skip set discarded the mapped-port before it could reach
-// recordNPTv6MappedPortPresence, so validateNPTv6Strict never fired and a
-// malformed (or well-formed) nptv6 mapped-port on the canonical-separate form
-// was SILENTLY ACCEPTED (the last residual C179-038 fail-open). NPTv6 still
+// the C179-038 fail-open); `nptv6-prefix` is its sibling and was removed for the
+// same reason — treating it as name-valued discarded the mapped-port before it
+// could reach recordNPTv6MappedPortPresence, so validateNPTv6Strict never fired
+// and a malformed (or well-formed) nptv6 mapped-port on the canonical-separate
+// form was SILENTLY ACCEPTED (the last residual C179-038 fail-open). NPTv6 still
 // carries no port; recovering the modifier is what lets the nptv6 gate REJECT
 // it rather than drop it silently.
 var mappedPortNameValuedKeywords = map[string]struct{}{
@@ -101,43 +104,61 @@ var mappedPortNameValuedKeywords = map[string]struct{}{
 
 // staticNATMappedPortOperandsFromKeys returns the operand token trailing each
 // GENUINE `mapped-port` modifier in a static-NAT `then` node's collapsed Keys,
-// in AST order (#2491, #6479 grammar-position fix). The lexer collapses
-// `then static-nat prefix <ip> mapped-port <port>` onto one leaf whose Keys are
+// in AST order (#2491, #6479 grammar-role fix). The lexer collapses `then
+// static-nat prefix <ip> mapped-port <port>` onto one leaf whose Keys are
 // `["prefix","<ip>","mapped-port","<port>"]` (or, on the static-nat node itself,
 // `["static-nat","prefix","<ip>","mapped-port","<port>"]`) because `static-nat`
-// is a children:nil schema leaf, so this in-leaf token bypasses the schema
-// value validator and must be recovered here.
+// is a children:nil schema leaf, so this in-leaf token bypasses the schema value
+// validator and must be recovered here.
 //
-// A `mapped-port` token is a modifier ONLY in modifier position. It is SKIPPED
-// only when it is the free-form VALUE of an immediately preceding NAME-valued
-// keyword (mappedPortNameValuedKeywords: routing-instance / prefix-name) —
-// those take an arbitrary following token that can legally be the literal
-// string "mapped-port". It is NOT skipped after `prefix` OR `nptv6-prefix`,
-// whose values are always an IP/prefix: `prefix mapped-port <port>` and
-// `nptv6-prefix mapped-port <port>` are the canonical modifier forms (the #6479
-// regressions this restores — the nptv6 one so validateNPTv6Strict can reject
-// the port rather than silently accept it). A genuine modifier with no trailing
-// operand (a bare `mapped-port` at the end of the key list) contributes an EMPTY
-// operand so combineMappedPortOperands flags it malformed rather than dropping
-// the occurrence.
+// The scan is GRAMMAR-ROLE-AWARE, not a lexeme lookbehind: it walks the key
+// stream tracking whether each position is a KEYWORD slot or a consumed VALUE
+// slot, and a `mapped-port` is the modifier ONLY in a keyword slot. A NAME-valued
+// keyword (mappedPortNameValuedKeywords: routing-instance / prefix-name) consumes
+// its following token as an opaque name, so a `mapped-port` in that consumed slot
+// is the NAME and is skipped — even when the name itself is literally
+// "prefix-name" or "routing-instance". That is the #6479 root cause a lexeme
+// lookbehind could not fix: it inspected the neighbouring TEXT and could not tell
+// whether the preceding token was the keyword or its value, so a target NAMED
+// after a skip-keyword (`prefix-name prefix-name mapped-port <bad>`) shifted a
+// real modifier into the skipped position and silently accepted a malformed port.
+// `prefix` and `nptv6-prefix` are NOT name-valued: their IP value can never be
+// the literal "mapped-port", so the scan does not consume-and-shadow the token
+// after them and `prefix mapped-port <port>` / `nptv6-prefix mapped-port <port>`
+// (the canonical separate-set-line forms) still recover the modifier — the nptv6
+// one so validateNPTv6Strict can reject the port rather than silently accept it.
+// A genuine modifier with no trailing operand (a bare `mapped-port` at the end of
+// the key list) contributes an EMPTY operand so combineMappedPortOperands flags
+// it malformed rather than dropping the occurrence.
 func staticNATMappedPortOperandsFromKeys(keys []string) []string {
 	var operands []string
-	for i := 0; i < len(keys); i++ {
-		if keys[i] != "mapped-port" {
+	for i := 0; i < len(keys); {
+		tok := keys[i]
+		if _, nameValued := mappedPortNameValuedKeywords[tok]; nameValued {
+			// A NAME-valued keyword consumes the NEXT token as its opaque name
+			// value; skip both slots so a value that is literally "mapped-port"
+			// (or a skip-keyword lexeme) is never read as the modifier keyword.
+			i += 2
 			continue
 		}
-		// Grammar-position guard: a "mapped-port" immediately following a
-		// NAME-valued keyword is that keyword's VALUE, not the modifier keyword.
-		if i > 0 {
-			if _, nameValued := mappedPortNameValuedKeywords[keys[i-1]]; nameValued {
-				continue
+		if tok == "mapped-port" {
+			// A `mapped-port` in a KEYWORD slot: the genuine modifier. Its next
+			// token (if any) is the port operand, and it too is consumed so a
+			// value that happens to read "mapped-port" is not re-scanned as a
+			// keyword. A bare trailing keyword yields "" (malformed).
+			if i+1 < len(keys) {
+				operands = append(operands, keys[i+1])
+			} else {
+				operands = append(operands, "")
 			}
+			i += 2
+			continue
 		}
-		if i+1 < len(keys) {
-			operands = append(operands, keys[i+1])
-		} else {
-			operands = append(operands, "")
-		}
+		// prefix / nptv6-prefix / inet / static-nat / an IP or port value: a
+		// single keyword slot that does NOT shadow the following token (its value
+		// can never be the literal "mapped-port"), so advance by one and let a
+		// `mapped-port` that follows it be read as the modifier.
+		i++
 	}
 	return operands
 }
@@ -613,8 +634,28 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// so `prefix mapped-port <port>` is recovered (#6479).
 							mergeMappedPortForNode(rule, t)
 						} else if t.FindChild("inet") != nil || (len(t.Keys) >= 2 && t.Keys[1] == "inet") {
-							// static-nat { inet; } — NAT64 translation
+							// static-nat { inet; } — NAT64 translation. A mapped-port
+							// here needs no separate gate: the `inet` target itself is
+							// rejected (#5859, not representable), so the whole rule
+							// fails closed regardless of any port it carries.
 							rule.Then = "inet"
+						} else {
+							// #6479 SECOND FINDING: a modifier-only `static-nat`
+							// sibling. A hierarchical `then { static-nat {
+							// mapped-port <p>; } static-nat { prefix <ip>; } }` block
+							// can carry a sibling whose ONLY content is a mapped-port
+							// modifier (no prefix / prefix-name / nptv6-prefix / inet
+							// target). It matched NO target branch above, so its
+							// mapped-port reached no validator and a malformed operand
+							// was SILENTLY ACCEPTED — the multi-block analogue of the
+							// collection gap the prefix/prefix-name branches close.
+							// Route it through the SAME accumulator so it fails closed
+							// like every co-located modifier, in either sibling order
+							// (mergeMappedPortState latches fail-closed order-
+							// independently). A sibling with no mapped-port at all (an
+							// empty or routing-instance-only static-nat) reads
+							// present=false and is a harmless no-op.
+							mergeMappedPortForNode(rule, t)
 						}
 						// #4292: a translation-target `routing-instance <ri>`
 						// may trail ANY of the targets above (Junos allows it on

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -67,34 +67,80 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 	}
 }
 
-// staticNATMappedPortFromKeys extracts the `mapped-port <port>` modifier(s)
-// from a flat-set static-NAT leaf's collapsed Keys (#2491). The lexer
-// collapses `then static-nat prefix <ip> mapped-port <port>` onto one node
-// whose Keys are `["static-nat","prefix","<ip>","mapped-port","<port>"]`
-// because `static-nat` is a children:nil schema leaf, so this in-leaf token
-// bypasses the schema value validator.
+// staticNATMappedPortOperandsFromKeys returns the operand token trailing each
+// GENUINE `mapped-port` modifier in a static-NAT `then` node's collapsed Keys,
+// in AST order (#2491, #6479 grammar-position fix). The lexer collapses
+// `then static-nat prefix <ip> mapped-port <port>` onto one leaf whose Keys are
+// `["prefix","<ip>","mapped-port","<port>"]` (or, on the static-nat node itself,
+// `["static-nat","prefix","<ip>","mapped-port","<port>"]`) because `static-nat`
+// is a children:nil schema leaf, so this in-leaf token bypasses the schema
+// value validator and must be recovered here.
 //
-// It scans EVERY `mapped-port` occurrence (not just the first) and folds them
-// through combineMappedPortOperands so a contradictory duplicate fails closed;
-// a bare trailing keyword contributes an empty operand. The (port, raw,
-// present) triple feeds the strict gate (validateNATHostMaskStrict): present is
-// the explicit presence signal (C179-038 + fold) that MappedPort==0 and raw==""
-// cannot carry on their own (the literal "0", a non-numeric token, an empty
-// operand, and a bare keyword all collapse to port 0 / raw "").
-func staticNATMappedPortFromKeys(keys []string) (port int, raw string, present bool) {
+// A `mapped-port` token is a modifier ONLY in modifier position. It is SKIPPED
+// when it is the free-form VALUE of an immediately preceding `routing-instance`
+// or `prefix` keyword: both take an arbitrary following token that can legally
+// be the literal string "mapped-port" (a translation-target routing-instance
+// NAMED "mapped-port", #4292; or a prefix value that is that string). Treating
+// such a value as a bare mapped-port modifier would falsely reject an otherwise
+// clean rule — the #6479 fold-introduced false positive this guard closes. A
+// genuine modifier with no trailing operand (a bare `mapped-port` at the end of
+// the key list) contributes an EMPTY operand so combineMappedPortOperands flags
+// it malformed rather than dropping the occurrence.
+func staticNATMappedPortOperandsFromKeys(keys []string) []string {
 	var operands []string
 	for i := 0; i < len(keys); i++ {
 		if keys[i] != "mapped-port" {
 			continue
 		}
-		// A bare trailing `mapped-port` (keyword is the last key) has no
-		// operand — record an empty operand so combine flags it malformed
-		// (present=true, raw="") rather than dropping the occurrence.
+		// Grammar-position guard: a "mapped-port" immediately following
+		// `routing-instance` or `prefix` is that keyword's VALUE, not the
+		// modifier keyword — it is never a mapped-port operand source.
+		if i > 0 && (keys[i-1] == "routing-instance" || keys[i-1] == "prefix") {
+			continue
+		}
 		if i+1 < len(keys) {
 			operands = append(operands, keys[i+1])
 		} else {
 			operands = append(operands, "")
 		}
+	}
+	return operands
+}
+
+// staticNATMappedPortForNode folds every genuine `mapped-port` modifier operand
+// attached to a static-nat `then` node — across BOTH AST shapes AND across
+// duplicate target children — into the (port, raw, present) triple the strict
+// gate (validateNATHostMaskStrict) consumes (#2491, C179-038, #6479 fold).
+//
+// It gathers operands from the node's own collapsed Keys, from each `mapped-port`
+// sibling child (the hierarchical `static-nat { prefix X; mapped-port P; }`
+// shape), and — grammar-position-aware — from each target child leaf's Keys (the
+// collapsed `prefix <ip> mapped-port <port>` flat-set shape, INCLUDING every
+// child of a cross-node duplicate authored as two `then static-nat prefix <ip>
+// mapped-port <p>` set lines). It then folds the WHOLE operand list through
+// combineMappedPortOperands ONCE, so last-wins applies when every occurrence is
+// a valid 1-65535 and a malformed occurrence in ANY shape or ANY duplicate fails
+// closed. There is no first-wins gate that could let a later malformed duplicate
+// slip past an earlier valid one (the #6479 cross-node first-wins bug).
+//
+// The (port, raw, present) triple feeds the strict gate: present is the explicit
+// presence signal (C179-038 + fold) that MappedPort==0 and raw=="" cannot carry
+// on their own (the literal "0", a non-numeric token, an empty operand, and a
+// bare keyword all collapse to port 0 / raw "").
+func staticNATMappedPortForNode(t *Node) (port int, raw string, present bool) {
+	operands := staticNATMappedPortOperandsFromKeys(t.Keys)
+	for _, c := range t.Children {
+		if c.Name() == "mapped-port" {
+			// Hierarchical sibling: the operand is the child leaf's value
+			// (nodeVal handles the value-in-Keys and value-as-child shapes).
+			operands = append(operands, nodeVal(c))
+			continue
+		}
+		// A target child leaf (`prefix <ip> [mapped-port <p>] [routing-instance
+		// <ri>]`), scanned grammar-aware so a `mapped-port` that is really a
+		// routing-instance/prefix VALUE is skipped. Every child of a cross-node
+		// duplicate is scanned, so a malformed later duplicate fails closed.
+		operands = append(operands, staticNATMappedPortOperandsFromKeys(c.Keys)...)
 	}
 	return combineMappedPortOperands(operands)
 }
@@ -102,9 +148,10 @@ func staticNATMappedPortFromKeys(keys []string) (port int, raw string, present b
 // combineMappedPortOperands folds one-or-more `mapped-port` operands (the
 // tokens trailing each `mapped-port` keyword, in AST order) into the
 // (port, raw, present) triple the strict gate (validateNATHostMaskStrict)
-// consumes. It is shared by the flat collapsed-keys scan
-// (staticNATMappedPortFromKeys) and the hierarchical sibling scan in
-// compileNATStatic so BOTH AST shapes fail closed identically.
+// consumes. It is called once per static-nat `then` node by
+// staticNATMappedPortForNode over the UNION of operands from every AST shape
+// (collapsed keys, sibling `mapped-port` child, and duplicate target children)
+// so all shapes and duplicates fail closed identically.
 //
 // Returns (C179-038 + #6479 fold):
 //   - no operands:                    (0, "",          false) — keyword absent.
@@ -327,43 +374,33 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							rule.ThenPrefixName = nodeVal(pn)
 						} else if len(t.Keys) >= 3 && t.Keys[1] == "prefix" {
 							rule.Then = t.Keys[2]
-							// #2491: optional trailing `mapped-port <port>`.
-							// Flat-set collapses the whole `prefix <ip>
-							// mapped-port <port>` onto this one leaf's Keys
-							// (`static-nat` is a children:nil schema leaf), so
-							// scan for the keyword + value pair.
-							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortFromKeys(t.Keys)
+							// #2491 / #6479: recover the optional `mapped-port
+							// <port>` modifier(s). Flat-set collapses `prefix
+							// <ip> mapped-port <port>` onto this leaf's Keys
+							// (`static-nat` is a children:nil schema leaf).
+							// staticNATMappedPortForNode folds every occurrence
+							// — here and on any sibling/duplicate child —
+							// through one combine so a malformed operand in any
+							// shape fails closed, and skips a `mapped-port` that
+							// is actually a routing-instance/prefix VALUE.
+							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
 						} else if pn := t.FindChild("prefix"); pn != nil {
 							rule.Then = nodeVal(pn)
-							// #2491: `then static-nat prefix <ip> mapped-port
-							// <port>` collapses onto the `prefix` child's Keys
-							// (`["prefix","<ip>","mapped-port","<port>"]`)
-							// because `static-nat` is a children:nil schema
-							// leaf, so the modifier rides on the prefix leaf,
-							// not a sibling `mapped-port` node. Scan pn.Keys.
-							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortFromKeys(pn.Keys)
-							// Hierarchical shape `static-nat { prefix X;
-							// mapped-port P; }` carries the modifier as a
-							// sibling child. Consult siblings ONLY when the
-							// collapsed keys did not carry a mapped-port (else
-							// the flat-set value wins). Scan ALL sibling
-							// `mapped-port` nodes (not just FindChild's first)
-							// so a contradictory duplicate fails closed through
-							// combineMappedPortOperands, and record presence +
-							// the raw token even for an empty / non-numeric
-							// sibling so the strict gate rejects it instead of
-							// collapsing silently to MappedPort==0.
-							if !rule.MappedPortPresent {
-								var sibOps []string
-								for _, c := range t.Children {
-									if c.Name() == "mapped-port" {
-										sibOps = append(sibOps, nodeVal(c))
-									}
-								}
-								if len(sibOps) > 0 {
-									rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = combineMappedPortOperands(sibOps)
-								}
-							}
+							// #2491 / C179-038 / #6479: recover the `mapped-port
+							// <port>` modifier(s) across every AST shape at once.
+							// The modifier may ride on the `prefix` child's
+							// collapsed Keys (`["prefix","<ip>","mapped-port",
+							// "<port>"]`), on a distinct `mapped-port` sibling
+							// child (`static-nat { prefix X; mapped-port P; }`),
+							// or be split across DUPLICATE `then static-nat
+							// prefix <ip> mapped-port <p>` children (two set
+							// lines). staticNATMappedPortForNode folds them all
+							// through one combine — fail-closed on any malformed
+							// occurrence, no first-wins gate — and skips a
+							// `mapped-port` that is a routing-instance/prefix
+							// VALUE (a routing-instance NAMED "mapped-port" no
+							// longer false-rejects).
+							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
 						} else if t.FindChild("inet") != nil || (len(t.Keys) >= 2 && t.Keys[1] == "inet") {
 							// static-nat { inet; } — NAT64 translation
 							rule.Then = "inet"

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -214,6 +214,27 @@ func staticNATMappedPortForNode(t *Node) (port int, raw string, present bool) {
 	return combineMappedPortOperands(operands)
 }
 
+// recordNPTv6MappedPortPresence stamps a `mapped-port` PRESENCE signal onto an
+// NPTv6 static-nat rule WITHOUT installing a port value (#5523/#6479). NPTv6
+// (RFC 6296) translates the IPv6 address prefix and has no transport-port
+// concept, so a `then static-nat nptv6-prefix <p6> mapped-port <p>` is invalid
+// in EVERY shape (collapsed keys, hierarchical nptv6-prefix child, or a distinct
+// `mapped-port` sibling). The host-mask loop skips nptv6 rules entirely, so
+// without recording presence a mapped-port on an nptv6 rule reached NO
+// validator: a malformed operand was silently accepted (the C179-038 class for
+// the nptv6 shape) and a well-formed one was silently ignored. This records
+// MappedPortPresent (and the raw token for the diagnostic) so the strict nptv6
+// gate (validateNPTv6Strict) rejects it — warns on the lenient no-brick path —
+// while keeping MappedPort==0: a port is meaningless on nptv6 and no bogus port
+// must cross the wire to the port-less nptv6 dataplane path.
+func recordNPTv6MappedPortPresence(rule *StaticNATRule, t *Node) {
+	if _, raw, present := staticNATMappedPortForNode(t); present {
+		rule.MappedPort = 0 // nptv6 has no port; never install one
+		rule.MappedPortRaw = raw
+		rule.MappedPortPresent = true
+	}
+}
+
 // combineMappedPortOperands folds one-or-more `mapped-port` operands (the
 // tokens trailing each `mapped-port` keyword, in AST order) into the
 // (port, raw, present) triple the strict gate (validateNATHostMaskStrict)
@@ -423,10 +444,12 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// set ... then static-nat nptv6-prefix PREFIX
 							rule.Then = t.Keys[2]
 							rule.IsNPTv6 = true
+							recordNPTv6MappedPortPresence(rule, t)
 						} else if np := t.FindChild("nptv6-prefix"); np != nil {
 							// static-nat { nptv6-prefix { PREFIX; } }
 							rule.Then = nodeVal(np)
 							rule.IsNPTv6 = true
+							recordNPTv6MappedPortPresence(rule, t)
 						} else if len(t.Keys) >= 3 && t.Keys[1] == "prefix-name" {
 							// #4290: set ... then static-nat prefix-name NAME.
 							// The named form of `prefix <ip>`: NAME references a

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -71,20 +71,35 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 // from a flat-set static-NAT leaf's collapsed Keys (#2491). The lexer
 // collapses `then static-nat prefix <ip> mapped-port <port>` onto one node
 // whose Keys are `["static-nat","prefix","<ip>","mapped-port","<port>"]`
-// because `static-nat` is a children:nil schema leaf. Returns 0 (no port
-// translation) when the keyword is absent or its value is non-numeric;
-// the schema does not yet range-check this in-leaf token, so the caller's
-// dataplane parse fails closed on an out-of-range value.
-func staticNATMappedPortFromKeys(keys []string) int {
+// because `static-nat` is a children:nil schema leaf, so this in-leaf token
+// bypasses the schema value validator.
+//
+// Returns (port, malformedRaw):
+//   - keyword absent:            (0, "")
+//   - present, numeric value:    (<port>, "")
+//   - present, non-numeric value: (0, "<raw token>")
+//
+// The malformedRaw return is how a PRESENT-but-non-numeric mapped-port is
+// distinguished from an ABSENT one (C179-038). Before this the helper folded
+// both to a bare 0, so `mapped-port notaport` compiled clean to MappedPort==0
+// (== "no port translation") with no diagnostic — even though a WELL-FORMED
+// value in the same position without a `match destination-port` IS rejected at
+// strict commit-check, so a garbage token was treated more leniently than a
+// valid one. The caller records malformedRaw on the rule and the strict gate
+// (validateNATHostMaskStrict) rejects it; the lenient load / peer-sync path
+// keeps MappedPort==0 so the dataplane still installs a plain 1:1 (no bogus
+// port), matching the pre-fix fail-closed behaviour.
+func staticNATMappedPortFromKeys(keys []string) (port int, malformedRaw string) {
 	for i := 0; i+1 < len(keys); i++ {
 		if keys[i] == "mapped-port" {
-			if p, err := strconv.Atoi(keys[i+1]); err == nil {
-				return p
+			raw := keys[i+1]
+			if p, err := strconv.Atoi(raw); err == nil {
+				return p, ""
 			}
-			return 0
+			return 0, raw
 		}
 	}
-	return 0
+	return 0, ""
 }
 
 // staticNATRoutingInstanceFromKeys scans a collapsed static-nat `then` leaf's
@@ -232,6 +247,7 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 				rule.Then = ""
 				rule.IsNPTv6 = false
 				rule.MappedPort = 0
+				rule.MappedPortRaw = ""
 				// #4290 / #4292: reset the named-target reference and the
 				// translation-target routing-instance alongside the other
 				// then-set fields so only the LAST then-block's spec survives.
@@ -268,7 +284,7 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// mapped-port <port>` onto this one leaf's Keys
 							// (`static-nat` is a children:nil schema leaf), so
 							// scan for the keyword + value pair.
-							rule.MappedPort = staticNATMappedPortFromKeys(t.Keys)
+							rule.MappedPort, rule.MappedPortRaw = staticNATMappedPortFromKeys(t.Keys)
 						} else if pn := t.FindChild("prefix"); pn != nil {
 							rule.Then = nodeVal(pn)
 							// #2491: `then static-nat prefix <ip> mapped-port
@@ -277,13 +293,20 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// because `static-nat` is a children:nil schema
 							// leaf, so the modifier rides on the prefix leaf,
 							// not a sibling `mapped-port` node. Scan pn.Keys.
-							rule.MappedPort = staticNATMappedPortFromKeys(pn.Keys)
+							rule.MappedPort, rule.MappedPortRaw = staticNATMappedPortFromKeys(pn.Keys)
 							// Hierarchical shape `static-nat { prefix X;
 							// mapped-port P; }` carries it as a sibling child.
-							if rule.MappedPort == 0 {
+							// A non-numeric sibling value is recorded as
+							// malformed (mirroring the collapsed-keys helper)
+							// so the strict gate rejects it instead of the
+							// value collapsing silently to MappedPort==0.
+							if rule.MappedPort == 0 && rule.MappedPortRaw == "" {
 								if mp := t.FindChild("mapped-port"); mp != nil {
-									if p, err := strconv.Atoi(nodeVal(mp)); err == nil {
+									raw := nodeVal(mp)
+									if p, err := strconv.Atoi(raw); err == nil {
 										rule.MappedPort = p
+									} else if raw != "" {
+										rule.MappedPortRaw = raw
 									}
 								}
 							}

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -68,31 +68,35 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 }
 
 // mappedPortNameValuedKeywords is the set of static-NAT `then` keywords whose
-// following token is an operator-chosen NAME (not an IP), so that name could
-// legally be the literal string "mapped-port". A `mapped-port` token that is the
-// VALUE of one of these keywords is NOT a mapped-port modifier and must be
-// skipped by the operand scan (#6479):
+// following token is an operator-chosen NAME (not an IP/prefix), so that name
+// could legally be the literal string "mapped-port". A `mapped-port` token that
+// is the VALUE of one of these keywords is NOT a mapped-port modifier and must
+// be skipped by the operand scan (#6479):
 //
 //   - `routing-instance <ri>` — a translation-target routing-instance may be
 //     NAMED "mapped-port" (#4292).
 //   - `prefix-name <name>` — a `then static-nat prefix-name` reference names a
 //     global address-book entry (#4290) that may be NAMED "mapped-port".
-//   - `nptv6-prefix <prefix>` — its value is a prefix, never "mapped-port", so
-//     the skip never fires in practice; listed for defensive grammar symmetry
-//     with the other free-form-value keywords (NPTv6 carries no mapped-port).
 //
-// `prefix` is deliberately ABSENT: a `prefix` value is ALWAYS an IP/CIDR and can
-// NEVER be the string "mapped-port", so a `mapped-port` token immediately after
-// the literal `prefix` keyword is ALWAYS the genuine modifier — the canonical
-// separate-set-line Junos form `prefix <ip>` + `prefix mapped-port <port>`
-// collapses to Keys `["prefix","mapped-port","<port>"]` and MUST be recovered.
-// Including `prefix` here (a round-4 over-defensive addition) dropped that real
-// modifier and both false-rejected the canonical clean rule AND reopened the
-// C179-038 fail-open for a canonical malformed value; #6479 removes it.
+// `prefix` AND `nptv6-prefix` are deliberately ABSENT: both take an IP/CIDR
+// prefix value that can NEVER be the string "mapped-port", so a `mapped-port`
+// token immediately after either literal keyword is ALWAYS the genuine modifier.
+// The canonical separate-set-line Junos forms `prefix <ip>` + `prefix
+// mapped-port <port>` and `nptv6-prefix <p6>` + `nptv6-prefix mapped-port
+// <port>` collapse the modifier line to Keys `["prefix","mapped-port","<port>"]`
+// / `["nptv6-prefix","mapped-port","<port>"]`, and the modifier MUST be
+// recovered from that position. `prefix` was a round-4 over-defensive addition
+// removed in round 5 (it false-rejected the canonical clean rule AND reopened
+// the C179-038 fail-open); `nptv6-prefix` is its sibling and is removed here —
+// leaving it in the skip set discarded the mapped-port before it could reach
+// recordNPTv6MappedPortPresence, so validateNPTv6Strict never fired and a
+// malformed (or well-formed) nptv6 mapped-port on the canonical-separate form
+// was SILENTLY ACCEPTED (the last residual C179-038 fail-open). NPTv6 still
+// carries no port; recovering the modifier is what lets the nptv6 gate REJECT
+// it rather than drop it silently.
 var mappedPortNameValuedKeywords = map[string]struct{}{
 	"routing-instance": {},
 	"prefix-name":      {},
-	"nptv6-prefix":     {},
 }
 
 // staticNATMappedPortOperandsFromKeys returns the operand token trailing each
@@ -106,11 +110,13 @@ var mappedPortNameValuedKeywords = map[string]struct{}{
 //
 // A `mapped-port` token is a modifier ONLY in modifier position. It is SKIPPED
 // only when it is the free-form VALUE of an immediately preceding NAME-valued
-// keyword (mappedPortNameValuedKeywords: routing-instance / prefix-name /
-// nptv6-prefix) — those take an arbitrary following token that can legally be
-// the literal string "mapped-port". It is NOT skipped after `prefix`, whose
-// value is always an IP: `prefix mapped-port <port>` is the canonical modifier
-// (the #6479 regression this restores). A genuine modifier with no trailing
+// keyword (mappedPortNameValuedKeywords: routing-instance / prefix-name) —
+// those take an arbitrary following token that can legally be the literal
+// string "mapped-port". It is NOT skipped after `prefix` OR `nptv6-prefix`,
+// whose values are always an IP/prefix: `prefix mapped-port <port>` and
+// `nptv6-prefix mapped-port <port>` are the canonical modifier forms (the #6479
+// regressions this restores — the nptv6 one so validateNPTv6Strict can reject
+// the port rather than silently accept it). A genuine modifier with no trailing
 // operand (a bare `mapped-port` at the end of the key list) contributes an EMPTY
 // operand so combineMappedPortOperands flags it malformed rather than dropping
 // the occurrence.
@@ -333,7 +339,17 @@ func mergeMappedPortState(rule *StaticNATRule, port int, raw string, present boo
 	failClosed := rule.MappedPortPresent && rule.MappedPort == 0
 	rule.MappedPortPresent = true
 	if failClosed {
-		if rule.MappedPortRaw == "" && raw != "" {
+		// Capture a diagnostic token only from a MALFORMED operand (port==0), and
+		// only if none was recorded yet. A later VALID operand (port>=1) must NOT
+		// backfill its token: a bare/empty malformed sibling latched raw=="" =
+		// "(missing value)", and a subsequent valid `mapped-port 9090` would
+		// otherwise overwrite that provenance, so the strict gate misreported
+		// `mapped-port "9090" is not a valid port number` instead of the true
+		// "(missing value)" diagnostic. The port==0 guard preserves the malformed
+		// provenance (a bare/empty-first then valid-second still reports the
+		// empty/missing value), while a later malformed operand may still supply a
+		// better-than-empty token (#6479).
+		if rule.MappedPortRaw == "" && raw != "" && port == 0 {
 			rule.MappedPortRaw = raw
 		}
 		return

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -227,12 +227,14 @@ func staticNATMappedPortForNode(t *Node) (port int, raw string, present bool) {
 // gate (validateNPTv6Strict) rejects it — warns on the lenient no-brick path —
 // while keeping MappedPort==0: a port is meaningless on nptv6 and no bogus port
 // must cross the wire to the port-less nptv6 dataplane path.
+//
+// #6479 item 1: it folds through mergeMappedPortState with a FORCED port 0 (nptv6
+// never installs a value) so PRESENCE accumulates and, critically, a later clean
+// `prefix`/`prefix-name` sibling target in the same `then` block can no longer
+// overwrite the stamp back to false — the multi-block nptv6 silent-accept.
 func recordNPTv6MappedPortPresence(rule *StaticNATRule, t *Node) {
-	if _, raw, present := staticNATMappedPortForNode(t); present {
-		rule.MappedPort = 0 // nptv6 has no port; never install one
-		rule.MappedPortRaw = raw
-		rule.MappedPortPresent = true
-	}
+	_, raw, present := staticNATMappedPortForNode(t)
+	mergeMappedPortState(rule, 0, raw, present) // nptv6 has no port; never install one
 }
 
 // combineMappedPortOperands folds one-or-more `mapped-port` operands (the
@@ -247,6 +249,14 @@ func recordNPTv6MappedPortPresence(rule *StaticNATRule, t *Node) {
 //   - no operands:                    (0, "",          false) — keyword absent.
 //   - every operand a valid 1-65535:  (last, "<last>", true) — last-wins, the
 //     Junos duplicate-stanza rule; a single valid token is the common case.
+//     #6479 semantics note: an all-valid DUPLICATE on one target
+//     (`mapped-port 8080 mapped-port 9090` → 9090) resolves last-wins,
+//     which DIFFERS from origin/master's first-wins (8080). A duplicate
+//     mapped-port on a single target is contradictory/malformed authoring
+//     (either resolution is defensible); last-wins is the INTENTIONAL
+//     choice here for consistency with the Junos duplicate-stanza rule the
+//     rest of this fold uses, and is NOT a working-config regression (a
+//     duplicate is not a valid production config on master either).
 //   - ANY operand malformed (empty, bare, non-numeric, or out-of-range):
 //     (0, "<first non-empty bad token>", true) — FAIL CLOSED. A contradictory
 //     duplicate (`mapped-port 8080 mapped-port notaport`) is rejected, not
@@ -284,6 +294,70 @@ func combineMappedPortOperands(operands []string) (port int, raw string, present
 		return 0, badRaw, true
 	}
 	return lastValidPort, lastValidRaw, true
+}
+
+// mergeMappedPortState folds ONE static-nat target block's mapped-port reading
+// (port, raw, present) into the rule's ACCUMULATING mapped-port state, so a later
+// clean target block in the SAME `then` block can never silently CLEAR a presence
+// or malformed stamp an earlier block set (#6479 item 1, the multi-block silent-
+// accept). A single `then` may carry several `static-nat` targets (the
+// hierarchical `then { static-nat { nptv6-prefix P { mapped-port BAD; } }
+// static-nat { prefix Q; } }` sibling shape); Junos merges them into one action,
+// so the mapped-port from ANY sibling is part of that action and must be gated.
+// Before this fold the per-target direct assignment `rule.MappedPort, … =
+// staticNATMappedPortForNode(t)` let the LAST sibling's (0,"",false) reading
+// overwrite an earlier sibling's malformed stamp — the C179-038 class reopened
+// for the multi-block shape, in BOTH the nptv6 and non-nptv6 branches.
+//
+// Semantics (matching combineMappedPortOperands, applied across sibling blocks):
+//   - present==false: NO-OP. An absent mapped-port neither stamps presence nor
+//     clears an earlier stamp — this is the exact overwrite the fix removes.
+//   - the FIRST present block stamps MappedPortPresent (never reset to false here).
+//   - a malformed operand in ANY block (present && port==0) LATCHES the rule
+//     fail-closed (MappedPort==0, raw naming the offending token); a later valid
+//     or absent block cannot un-fail it (order-independent fail-closed).
+//   - among all-valid blocks the LAST valid port wins (Junos duplicate-stanza
+//     last-wins).
+//
+// The per-`then`-block reset (compileNATStatic) still runs BETWEEN separate
+// `then {}` blocks, preserving the #3850 last-then-block-wins semantics: a whole
+// superseded `then` block is dead config, not part of the effective action. This
+// accumulation is scoped to sibling targets WITHIN one `then` block.
+func mergeMappedPortState(rule *StaticNATRule, port int, raw string, present bool) {
+	if !present {
+		return
+	}
+	// Latch: once a malformed operand has been seen for this rule the state is
+	// fail-closed (present && MappedPort==0). A later block cannot un-fail it;
+	// capture a diagnostic token only if none was recorded yet.
+	failClosed := rule.MappedPortPresent && rule.MappedPort == 0
+	rule.MappedPortPresent = true
+	if failClosed {
+		if rule.MappedPortRaw == "" && raw != "" {
+			rule.MappedPortRaw = raw
+		}
+		return
+	}
+	if port == 0 {
+		// This block is present-but-malformed (empty, bare, non-numeric,
+		// out-of-range, or the literal "0"): fail closed, name its token.
+		rule.MappedPort = 0
+		rule.MappedPortRaw = raw
+		return
+	}
+	// This block carries a valid 1-65535 port: last-valid-wins.
+	rule.MappedPort = port
+	rule.MappedPortRaw = raw
+}
+
+// mergeMappedPortForNode reads the genuine `mapped-port` modifier(s) attached to
+// one static-nat target node (across every AST shape, via staticNATMappedPortFor-
+// Node) and folds the result into the rule's accumulating state
+// (mergeMappedPortState). It is the accumulate-don't-overwrite replacement for the
+// per-target direct assignment on the prefix / prefix-name branches (#6479).
+func mergeMappedPortForNode(rule *StaticNATRule, t *Node) {
+	port, raw, present := staticNATMappedPortForNode(t)
+	mergeMappedPortState(rule, port, raw, present)
 }
 
 // staticNATRoutingInstanceFromKeys scans a collapsed static-nat `then` leaf's
@@ -427,6 +501,17 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 			// persist. A single static-nat then-block is a complete spec, so
 			// `prefix X mapped-port P` within one block stays coupled: the reset
 			// runs BETWEEN blocks, then the whole block is read (#3850 review).
+			//
+			// #6479 item 1: WITHIN one `then` block the child loop below may see
+			// several `static-nat` sibling targets (the hierarchical `then {
+			// static-nat {…} static-nat {…} }` shape). Those siblings are one
+			// merged Junos action, so their mapped-port readings ACCUMULATE
+			// through mergeMappedPortState (not a per-target overwrite): a later
+			// clean sibling can no longer clear a presence/malformed stamp an
+			// earlier sibling set, in either the nptv6 or the prefix/prefix-name
+			// branch. The reset here is scoped to BETWEEN `then` blocks and still
+			// gives #3850 last-then-block-wins — a superseded whole block is dead
+			// config, distinct from a merged sibling target that is live.
 			for _, thenNode := range ruleInst.node.FindChildren("then") {
 				rule.Then = ""
 				rule.IsNPTv6 = false
@@ -469,13 +554,13 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// reopened for the prefix-name shape. The scan is grammar-
 							// aware: a prefix-name entry NAMED "mapped-port" is the
 							// name value, not a modifier, and registers no port.
-							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
+							mergeMappedPortForNode(rule, t)
 						} else if pn := t.FindChild("prefix-name"); pn != nil {
 							// static-nat { prefix-name NAME; }
 							rule.ThenPrefixName = nodeVal(pn)
 							// #6479: gate a prefix-name mapped-port identically (see
 							// the collapsed-keys branch above).
-							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
+							mergeMappedPortForNode(rule, t)
 						} else if len(t.Keys) >= 3 && t.Keys[1] == "prefix" {
 							rule.Then = t.Keys[2]
 							// #2491 / #6479: recover the optional `mapped-port
@@ -487,7 +572,7 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// through one combine so a malformed operand in any
 							// shape fails closed, and skips a `mapped-port` that
 							// is actually a routing-instance/prefix-name VALUE.
-							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
+							mergeMappedPortForNode(rule, t)
 						} else if pn := t.FindChild("prefix"); pn != nil {
 							rule.Then = nodeVal(pn)
 							// #2491 / C179-038 / #6479: recover the `mapped-port
@@ -510,7 +595,7 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// NAMED "mapped-port" no longer false-rejects). It does
 							// NOT skip after `prefix`, whose value is always an IP,
 							// so `prefix mapped-port <port>` is recovered (#6479).
-							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
+							mergeMappedPortForNode(rule, t)
 						} else if t.FindChild("inet") != nil || (len(t.Keys) >= 2 && t.Keys[1] == "inet") {
 							// static-nat { inet; } — NAT64 translation
 							rule.Then = "inet"

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -74,32 +74,44 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 // because `static-nat` is a children:nil schema leaf, so this in-leaf token
 // bypasses the schema value validator.
 //
-// Returns (port, malformedRaw):
-//   - keyword absent:            (0, "")
-//   - present, numeric value:    (<port>, "")
-//   - present, non-numeric value: (0, "<raw token>")
+// Returns (port, raw, present):
+//   - keyword absent:                 (0, "",        false)
+//   - present, valid numeric value:   (<port>, "<n>", true)
+//   - present, non-numeric value:     (0, "<token>", true)
+//   - present, empty operand:         (0, "",        true)
+//   - present, no operand (bare):     (0, "",        true)
 //
-// The malformedRaw return is how a PRESENT-but-non-numeric mapped-port is
-// distinguished from an ABSENT one (C179-038). Before this the helper folded
-// both to a bare 0, so `mapped-port notaport` compiled clean to MappedPort==0
-// (== "no port translation") with no diagnostic — even though a WELL-FORMED
-// value in the same position without a `match destination-port` IS rejected at
-// strict commit-check, so a garbage token was treated more leniently than a
-// valid one. The caller records malformedRaw on the rule and the strict gate
-// (validateNATHostMaskStrict) rejects it; the lenient load / peer-sync path
-// keeps MappedPort==0 so the dataplane still installs a plain 1:1 (no bogus
-// port), matching the pre-fix fail-closed behaviour.
-func staticNATMappedPortFromKeys(keys []string) (port int, malformedRaw string) {
-	for i := 0; i+1 < len(keys); i++ {
-		if keys[i] == "mapped-port" {
-			raw := keys[i+1]
-			if p, err := strconv.Atoi(raw); err == nil {
-				return p, ""
-			}
-			return 0, raw
+// `present` is the explicit presence signal (C179-038 + fold). MappedPort==0
+// alone cannot distinguish an ABSENT mapped-port from a PRESENT-but-malformed
+// one — the literal "0", a non-numeric token, an empty operand, and a bare
+// keyword all parse (or fail to parse) to 0 — and raw=="" cannot distinguish
+// absent from present-but-empty. Before the presence signal these
+// sentinel-collision siblings compiled clean to MappedPort==0 (== "no port
+// translation") with no diagnostic, even though a WELL-FORMED value in the same
+// position without a `match destination-port` IS rejected at strict
+// commit-check, so garbage was treated more leniently than a valid value. The
+// caller records all three fields; the strict gate (validateNATHostMaskStrict)
+// rejects a present-but-not-1-65535 port and names the raw token, while the
+// lenient load / peer-sync path keeps MappedPort==0 so the dataplane still
+// installs a plain 1:1 (no bogus port), matching the pre-fix fail-closed
+// behaviour.
+func staticNATMappedPortFromKeys(keys []string) (port int, raw string, present bool) {
+	for i := 0; i < len(keys); i++ {
+		if keys[i] != "mapped-port" {
+			continue
 		}
+		present = true
+		// A bare trailing `mapped-port` (keyword is the last key) has no
+		// operand: leave port=0, raw="" but still report present=true.
+		if i+1 < len(keys) {
+			raw = keys[i+1]
+			if p, err := strconv.Atoi(raw); err == nil {
+				port = p
+			}
+		}
+		return port, raw, present
 	}
-	return 0, ""
+	return 0, "", false
 }
 
 // staticNATRoutingInstanceFromKeys scans a collapsed static-nat `then` leaf's
@@ -248,6 +260,7 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 				rule.IsNPTv6 = false
 				rule.MappedPort = 0
 				rule.MappedPortRaw = ""
+				rule.MappedPortPresent = false
 				// #4290 / #4292: reset the named-target reference and the
 				// translation-target routing-instance alongside the other
 				// then-set fields so only the LAST then-block's spec survives.
@@ -284,7 +297,7 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// mapped-port <port>` onto this one leaf's Keys
 							// (`static-nat` is a children:nil schema leaf), so
 							// scan for the keyword + value pair.
-							rule.MappedPort, rule.MappedPortRaw = staticNATMappedPortFromKeys(t.Keys)
+							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortFromKeys(t.Keys)
 						} else if pn := t.FindChild("prefix"); pn != nil {
 							rule.Then = nodeVal(pn)
 							// #2491: `then static-nat prefix <ip> mapped-port
@@ -293,20 +306,22 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// because `static-nat` is a children:nil schema
 							// leaf, so the modifier rides on the prefix leaf,
 							// not a sibling `mapped-port` node. Scan pn.Keys.
-							rule.MappedPort, rule.MappedPortRaw = staticNATMappedPortFromKeys(pn.Keys)
+							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortFromKeys(pn.Keys)
 							// Hierarchical shape `static-nat { prefix X;
 							// mapped-port P; }` carries it as a sibling child.
-							// A non-numeric sibling value is recorded as
-							// malformed (mirroring the collapsed-keys helper)
-							// so the strict gate rejects it instead of the
-							// value collapsing silently to MappedPort==0.
-							if rule.MappedPort == 0 && rule.MappedPortRaw == "" {
+							// Consult the sibling ONLY when the collapsed keys
+							// did not carry a mapped-port (else the flat-set
+							// value wins). Record presence + the raw token even
+							// for an empty / non-numeric sibling value so the
+							// strict gate rejects it instead of the value
+							// collapsing silently to MappedPort==0.
+							if !rule.MappedPortPresent {
 								if mp := t.FindChild("mapped-port"); mp != nil {
+									rule.MappedPortPresent = true
 									raw := nodeVal(mp)
+									rule.MappedPortRaw = raw
 									if p, err := strconv.Atoi(raw); err == nil {
 										rule.MappedPort = p
-									} else if raw != "" {
-										rule.MappedPortRaw = raw
 									}
 								}
 							}

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -67,51 +67,86 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 	}
 }
 
-// staticNATMappedPortFromKeys extracts the `mapped-port <port>` modifier
+// staticNATMappedPortFromKeys extracts the `mapped-port <port>` modifier(s)
 // from a flat-set static-NAT leaf's collapsed Keys (#2491). The lexer
 // collapses `then static-nat prefix <ip> mapped-port <port>` onto one node
 // whose Keys are `["static-nat","prefix","<ip>","mapped-port","<port>"]`
 // because `static-nat` is a children:nil schema leaf, so this in-leaf token
 // bypasses the schema value validator.
 //
-// Returns (port, raw, present):
-//   - keyword absent:                 (0, "",        false)
-//   - present, valid numeric value:   (<port>, "<n>", true)
-//   - present, non-numeric value:     (0, "<token>", true)
-//   - present, empty operand:         (0, "",        true)
-//   - present, no operand (bare):     (0, "",        true)
-//
-// `present` is the explicit presence signal (C179-038 + fold). MappedPort==0
-// alone cannot distinguish an ABSENT mapped-port from a PRESENT-but-malformed
-// one — the literal "0", a non-numeric token, an empty operand, and a bare
-// keyword all parse (or fail to parse) to 0 — and raw=="" cannot distinguish
-// absent from present-but-empty. Before the presence signal these
-// sentinel-collision siblings compiled clean to MappedPort==0 (== "no port
-// translation") with no diagnostic, even though a WELL-FORMED value in the same
-// position without a `match destination-port` IS rejected at strict
-// commit-check, so garbage was treated more leniently than a valid value. The
-// caller records all three fields; the strict gate (validateNATHostMaskStrict)
-// rejects a present-but-not-1-65535 port and names the raw token, while the
-// lenient load / peer-sync path keeps MappedPort==0 so the dataplane still
-// installs a plain 1:1 (no bogus port), matching the pre-fix fail-closed
-// behaviour.
+// It scans EVERY `mapped-port` occurrence (not just the first) and folds them
+// through combineMappedPortOperands so a contradictory duplicate fails closed;
+// a bare trailing keyword contributes an empty operand. The (port, raw,
+// present) triple feeds the strict gate (validateNATHostMaskStrict): present is
+// the explicit presence signal (C179-038 + fold) that MappedPort==0 and raw==""
+// cannot carry on their own (the literal "0", a non-numeric token, an empty
+// operand, and a bare keyword all collapse to port 0 / raw "").
 func staticNATMappedPortFromKeys(keys []string) (port int, raw string, present bool) {
+	var operands []string
 	for i := 0; i < len(keys); i++ {
 		if keys[i] != "mapped-port" {
 			continue
 		}
-		present = true
 		// A bare trailing `mapped-port` (keyword is the last key) has no
-		// operand: leave port=0, raw="" but still report present=true.
+		// operand — record an empty operand so combine flags it malformed
+		// (present=true, raw="") rather than dropping the occurrence.
 		if i+1 < len(keys) {
-			raw = keys[i+1]
-			if p, err := strconv.Atoi(raw); err == nil {
-				port = p
-			}
+			operands = append(operands, keys[i+1])
+		} else {
+			operands = append(operands, "")
 		}
-		return port, raw, present
 	}
-	return 0, "", false
+	return combineMappedPortOperands(operands)
+}
+
+// combineMappedPortOperands folds one-or-more `mapped-port` operands (the
+// tokens trailing each `mapped-port` keyword, in AST order) into the
+// (port, raw, present) triple the strict gate (validateNATHostMaskStrict)
+// consumes. It is shared by the flat collapsed-keys scan
+// (staticNATMappedPortFromKeys) and the hierarchical sibling scan in
+// compileNATStatic so BOTH AST shapes fail closed identically.
+//
+// Returns (C179-038 + #6479 fold):
+//   - no operands:                    (0, "",          false) — keyword absent.
+//   - every operand a valid 1-65535:  (last, "<last>", true) — last-wins, the
+//     Junos duplicate-stanza rule; a single valid token is the common case.
+//   - ANY operand malformed (empty, bare, non-numeric, or out-of-range):
+//     (0, "<first non-empty bad token>", true) — FAIL CLOSED. A contradictory
+//     duplicate (`mapped-port 8080 mapped-port notaport`) is rejected, not
+//     silently reduced to the one good value; raw names the offending token
+//     (or "" → the strict gate prints "(missing value)" for an empty/bare one).
+//
+// A malformed operand zeroes the port even when another occurrence is valid, so
+// the strict gate's `MappedPort < 1` branch rejects and no bogus port ever
+// reaches the dataplane; the lenient load / peer-sync path keeps MappedPort==0
+// (a plain 1:1, matching the pre-fix fail-closed behaviour).
+func combineMappedPortOperands(operands []string) (port int, raw string, present bool) {
+	if len(operands) == 0 {
+		return 0, "", false
+	}
+	present = true
+	haveBad := false
+	badRaw := ""
+	lastValidPort := 0
+	lastValidRaw := ""
+	for _, op := range operands {
+		if p, err := strconv.Atoi(op); err == nil && p >= 1 && p <= 65535 {
+			lastValidPort = p
+			lastValidRaw = op
+			continue
+		}
+		haveBad = true
+		// Prefer the first NON-EMPTY bad token for the diagnostic; an
+		// all-empty/bare set leaves badRaw=="" → the gate prints
+		// "(missing value)".
+		if badRaw == "" && op != "" {
+			badRaw = op
+		}
+	}
+	if haveBad {
+		return 0, badRaw, true
+	}
+	return lastValidPort, lastValidRaw, true
 }
 
 // staticNATRoutingInstanceFromKeys scans a collapsed static-nat `then` leaf's
@@ -308,21 +343,25 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// not a sibling `mapped-port` node. Scan pn.Keys.
 							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortFromKeys(pn.Keys)
 							// Hierarchical shape `static-nat { prefix X;
-							// mapped-port P; }` carries it as a sibling child.
-							// Consult the sibling ONLY when the collapsed keys
-							// did not carry a mapped-port (else the flat-set
-							// value wins). Record presence + the raw token even
-							// for an empty / non-numeric sibling value so the
-							// strict gate rejects it instead of the value
+							// mapped-port P; }` carries the modifier as a
+							// sibling child. Consult siblings ONLY when the
+							// collapsed keys did not carry a mapped-port (else
+							// the flat-set value wins). Scan ALL sibling
+							// `mapped-port` nodes (not just FindChild's first)
+							// so a contradictory duplicate fails closed through
+							// combineMappedPortOperands, and record presence +
+							// the raw token even for an empty / non-numeric
+							// sibling so the strict gate rejects it instead of
 							// collapsing silently to MappedPort==0.
 							if !rule.MappedPortPresent {
-								if mp := t.FindChild("mapped-port"); mp != nil {
-									rule.MappedPortPresent = true
-									raw := nodeVal(mp)
-									rule.MappedPortRaw = raw
-									if p, err := strconv.Atoi(raw); err == nil {
-										rule.MappedPort = p
+								var sibOps []string
+								for _, c := range t.Children {
+									if c.Name() == "mapped-port" {
+										sibOps = append(sibOps, nodeVal(c))
 									}
+								}
+								if len(sibOps) > 0 {
+									rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = combineMappedPortOperands(sibOps)
 								}
 							}
 						} else if t.FindChild("inet") != nil || (len(t.Keys) >= 2 && t.Keys[1] == "inet") {

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -67,6 +67,34 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 	}
 }
 
+// mappedPortNameValuedKeywords is the set of static-NAT `then` keywords whose
+// following token is an operator-chosen NAME (not an IP), so that name could
+// legally be the literal string "mapped-port". A `mapped-port` token that is the
+// VALUE of one of these keywords is NOT a mapped-port modifier and must be
+// skipped by the operand scan (#6479):
+//
+//   - `routing-instance <ri>` — a translation-target routing-instance may be
+//     NAMED "mapped-port" (#4292).
+//   - `prefix-name <name>` — a `then static-nat prefix-name` reference names a
+//     global address-book entry (#4290) that may be NAMED "mapped-port".
+//   - `nptv6-prefix <prefix>` — its value is a prefix, never "mapped-port", so
+//     the skip never fires in practice; listed for defensive grammar symmetry
+//     with the other free-form-value keywords (NPTv6 carries no mapped-port).
+//
+// `prefix` is deliberately ABSENT: a `prefix` value is ALWAYS an IP/CIDR and can
+// NEVER be the string "mapped-port", so a `mapped-port` token immediately after
+// the literal `prefix` keyword is ALWAYS the genuine modifier — the canonical
+// separate-set-line Junos form `prefix <ip>` + `prefix mapped-port <port>`
+// collapses to Keys `["prefix","mapped-port","<port>"]` and MUST be recovered.
+// Including `prefix` here (a round-4 over-defensive addition) dropped that real
+// modifier and both false-rejected the canonical clean rule AND reopened the
+// C179-038 fail-open for a canonical malformed value; #6479 removes it.
+var mappedPortNameValuedKeywords = map[string]struct{}{
+	"routing-instance": {},
+	"prefix-name":      {},
+	"nptv6-prefix":     {},
+}
+
 // staticNATMappedPortOperandsFromKeys returns the operand token trailing each
 // GENUINE `mapped-port` modifier in a static-NAT `then` node's collapsed Keys,
 // in AST order (#2491, #6479 grammar-position fix). The lexer collapses
@@ -77,26 +105,27 @@ func applyStaticNATFromScope(rs *StaticNATRuleSet, s natMatchScope) {
 // value validator and must be recovered here.
 //
 // A `mapped-port` token is a modifier ONLY in modifier position. It is SKIPPED
-// when it is the free-form VALUE of an immediately preceding `routing-instance`
-// or `prefix` keyword: both take an arbitrary following token that can legally
-// be the literal string "mapped-port" (a translation-target routing-instance
-// NAMED "mapped-port", #4292; or a prefix value that is that string). Treating
-// such a value as a bare mapped-port modifier would falsely reject an otherwise
-// clean rule — the #6479 fold-introduced false positive this guard closes. A
-// genuine modifier with no trailing operand (a bare `mapped-port` at the end of
-// the key list) contributes an EMPTY operand so combineMappedPortOperands flags
-// it malformed rather than dropping the occurrence.
+// only when it is the free-form VALUE of an immediately preceding NAME-valued
+// keyword (mappedPortNameValuedKeywords: routing-instance / prefix-name /
+// nptv6-prefix) — those take an arbitrary following token that can legally be
+// the literal string "mapped-port". It is NOT skipped after `prefix`, whose
+// value is always an IP: `prefix mapped-port <port>` is the canonical modifier
+// (the #6479 regression this restores). A genuine modifier with no trailing
+// operand (a bare `mapped-port` at the end of the key list) contributes an EMPTY
+// operand so combineMappedPortOperands flags it malformed rather than dropping
+// the occurrence.
 func staticNATMappedPortOperandsFromKeys(keys []string) []string {
 	var operands []string
 	for i := 0; i < len(keys); i++ {
 		if keys[i] != "mapped-port" {
 			continue
 		}
-		// Grammar-position guard: a "mapped-port" immediately following
-		// `routing-instance` or `prefix` is that keyword's VALUE, not the
-		// modifier keyword — it is never a mapped-port operand source.
-		if i > 0 && (keys[i-1] == "routing-instance" || keys[i-1] == "prefix") {
-			continue
+		// Grammar-position guard: a "mapped-port" immediately following a
+		// NAME-valued keyword is that keyword's VALUE, not the modifier keyword.
+		if i > 0 {
+			if _, nameValued := mappedPortNameValuedKeywords[keys[i-1]]; nameValued {
+				continue
+			}
 		}
 		if i+1 < len(keys) {
 			operands = append(operands, keys[i+1])
@@ -107,19 +136,53 @@ func staticNATMappedPortOperandsFromKeys(keys []string) []string {
 	return operands
 }
 
+// mappedPortNodeOperands returns every operand attached to a `mapped-port`
+// NODE (a sibling or nested `mapped-port` child of the static-nat / prefix
+// node), across both shapes the parser can produce:
+//
+//   - packed / flat Keys: `mapped-port <p>` → Keys=["mapped-port","<p>"], and a
+//     packed duplicate `mapped-port a mapped-port b` collapses onto one leaf's
+//     Keys=["mapped-port","a","mapped-port","b"]. staticNATMappedPortOperands-
+//     FromKeys walks ALL of them (scan-all, not first-wins), so a malformed
+//     second operand fails closed.
+//   - hierarchical value-as-child: `mapped-port { <p>; }` → Keys=["mapped-port"]
+//     with the operand carried as a child. The key scan yields a single "" (bare
+//     keyword) placeholder; replace it with the child value(s) so the operand is
+//     recovered rather than mis-flagged as an empty (missing) value.
+func mappedPortNodeOperands(c *Node) []string {
+	ops := staticNATMappedPortOperandsFromKeys(c.Keys)
+	if len(c.Children) > 0 && len(ops) == 1 && ops[0] == "" {
+		ops = ops[:0]
+		for _, gc := range c.Children {
+			ops = append(ops, gc.Name())
+		}
+	}
+	return ops
+}
+
 // staticNATMappedPortForNode folds every genuine `mapped-port` modifier operand
-// attached to a static-nat `then` node — across BOTH AST shapes AND across
+// attached to a static-nat `then` node — across EVERY AST shape AND across
 // duplicate target children — into the (port, raw, present) triple the strict
 // gate (validateNATHostMaskStrict) consumes (#2491, C179-038, #6479 fold).
 //
-// It gathers operands from the node's own collapsed Keys, from each `mapped-port`
-// sibling child (the hierarchical `static-nat { prefix X; mapped-port P; }`
-// shape), and — grammar-position-aware — from each target child leaf's Keys (the
-// collapsed `prefix <ip> mapped-port <port>` flat-set shape, INCLUDING every
-// child of a cross-node duplicate authored as two `then static-nat prefix <ip>
-// mapped-port <p>` set lines). It then folds the WHOLE operand list through
-// combineMappedPortOperands ONCE, so last-wins applies when every occurrence is
-// a valid 1-65535 and a malformed occurrence in ANY shape or ANY duplicate fails
+// It gathers operands from:
+//   - the static-nat node's own collapsed Keys (the `then static-nat prefix <ip>
+//     mapped-port <port>` shape that lands on t.Keys);
+//   - each `mapped-port` sibling child (the hierarchical `static-nat { prefix X;
+//     mapped-port P; }` shape), scanning ALL of its operands (a packed
+//     `mapped-port a mapped-port b` duplicate fails closed, not first-wins);
+//   - each target child (`prefix`/`prefix-name` <val>) — BOTH the collapsed
+//     modifier on its Keys (the flat-set `prefix <ip> mapped-port <port>` and
+//     the canonical separate-set-line `prefix mapped-port <port>` shapes) AND a
+//     mapped-port nested inside its Children (the canonical HIERARCHICAL
+//     `prefix <ip> { mapped-port P; }` / `prefix { <ip>; mapped-port P; }`
+//     shapes) — grammar-aware, so a `mapped-port` that is really a
+//     routing-instance/prefix-name VALUE is skipped.
+//
+// Every child of a cross-node duplicate (two `then static-nat prefix <ip>
+// mapped-port <p>` set lines) is scanned, then the WHOLE operand list folds
+// through combineMappedPortOperands ONCE: last-wins when every occurrence is a
+// valid 1-65535, and a malformed occurrence in ANY shape or ANY duplicate fails
 // closed. There is no first-wins gate that could let a later malformed duplicate
 // slip past an earlier valid one (the #6479 cross-node first-wins bug).
 //
@@ -131,16 +194,22 @@ func staticNATMappedPortForNode(t *Node) (port int, raw string, present bool) {
 	operands := staticNATMappedPortOperandsFromKeys(t.Keys)
 	for _, c := range t.Children {
 		if c.Name() == "mapped-port" {
-			// Hierarchical sibling: the operand is the child leaf's value
-			// (nodeVal handles the value-in-Keys and value-as-child shapes).
-			operands = append(operands, nodeVal(c))
+			// Hierarchical sibling `mapped-port <p>` (possibly packed).
+			operands = append(operands, mappedPortNodeOperands(c)...)
 			continue
 		}
-		// A target child leaf (`prefix <ip> [mapped-port <p>] [routing-instance
-		// <ri>]`), scanned grammar-aware so a `mapped-port` that is really a
-		// routing-instance/prefix VALUE is skipped. Every child of a cross-node
-		// duplicate is scanned, so a malformed later duplicate fails closed.
+		// A target child (`prefix`/`prefix-name` <val> [mapped-port <p>]
+		// [routing-instance <ri>]). The modifier may ride on the child's
+		// collapsed Keys (flat-set) OR nest inside the child's Children (the
+		// canonical hierarchical `prefix <ip> { mapped-port P; }` shape). Scan
+		// BOTH — grammar-aware — so a malformed operand in either shape, and in
+		// every child of a cross-node duplicate, fails closed.
 		operands = append(operands, staticNATMappedPortOperandsFromKeys(c.Keys)...)
+		for _, gc := range c.Children {
+			if gc.Name() == "mapped-port" {
+				operands = append(operands, mappedPortNodeOperands(gc)...)
+			}
+		}
 	}
 	return combineMappedPortOperands(operands)
 }
@@ -369,9 +438,21 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// keyword fell through, leaving Then=="" (empty
 							// translation target, silent broken static NAT).
 							rule.ThenPrefixName = t.Keys[2]
+							// #6479: a prefix-name target carries the SAME optional
+							// `mapped-port <port>` modifier as a literal prefix
+							// (`prefix-name FOO mapped-port 8080`). Collect + gate it
+							// identically so a malformed prefix-name mapped-port fails
+							// closed instead of silently dropping — the C179-038 class,
+							// reopened for the prefix-name shape. The scan is grammar-
+							// aware: a prefix-name entry NAMED "mapped-port" is the
+							// name value, not a modifier, and registers no port.
+							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
 						} else if pn := t.FindChild("prefix-name"); pn != nil {
 							// static-nat { prefix-name NAME; }
 							rule.ThenPrefixName = nodeVal(pn)
+							// #6479: gate a prefix-name mapped-port identically (see
+							// the collapsed-keys branch above).
+							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
 						} else if len(t.Keys) >= 3 && t.Keys[1] == "prefix" {
 							rule.Then = t.Keys[2]
 							// #2491 / #6479: recover the optional `mapped-port
@@ -379,27 +460,33 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							// <ip> mapped-port <port>` onto this leaf's Keys
 							// (`static-nat` is a children:nil schema leaf).
 							// staticNATMappedPortForNode folds every occurrence
-							// — here and on any sibling/duplicate child —
+							// — here and on any sibling/nested/duplicate child —
 							// through one combine so a malformed operand in any
 							// shape fails closed, and skips a `mapped-port` that
-							// is actually a routing-instance/prefix VALUE.
+							// is actually a routing-instance/prefix-name VALUE.
 							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
 						} else if pn := t.FindChild("prefix"); pn != nil {
 							rule.Then = nodeVal(pn)
 							// #2491 / C179-038 / #6479: recover the `mapped-port
-							// <port>` modifier(s) across every AST shape at once.
+							// <port>` modifier(s) across EVERY AST shape at once.
 							// The modifier may ride on the `prefix` child's
 							// collapsed Keys (`["prefix","<ip>","mapped-port",
-							// "<port>"]`), on a distinct `mapped-port` sibling
-							// child (`static-nat { prefix X; mapped-port P; }`),
-							// or be split across DUPLICATE `then static-nat
-							// prefix <ip> mapped-port <p>` children (two set
-							// lines). staticNATMappedPortForNode folds them all
-							// through one combine — fail-closed on any malformed
-							// occurrence, no first-wins gate — and skips a
-							// `mapped-port` that is a routing-instance/prefix
-							// VALUE (a routing-instance NAMED "mapped-port" no
-							// longer false-rejects).
+							// "<port>"]`), on the canonical separate-set-line
+							// `prefix mapped-port <port>` leaf, NESTED inside the
+							// prefix child's Children (the hierarchical `prefix
+							// <ip> { mapped-port P; }` / `prefix { <ip>;
+							// mapped-port P; }` shapes), on a distinct
+							// `mapped-port` sibling child (`static-nat { prefix X;
+							// mapped-port P; }`), or be split across DUPLICATE
+							// `then static-nat prefix <ip> mapped-port <p>`
+							// children (two set lines). staticNATMappedPortForNode
+							// folds them all through one combine — fail-closed on
+							// any malformed occurrence, no first-wins gate — and
+							// skips a `mapped-port` that is a routing-instance/
+							// prefix-name VALUE (a routing-instance or prefix-name
+							// NAMED "mapped-port" no longer false-rejects). It does
+							// NOT skip after `prefix`, whose value is always an IP,
+							// so `prefix mapped-port <port>` is recovered (#6479).
 							rule.MappedPort, rule.MappedPortRaw, rule.MappedPortPresent = staticNATMappedPortForNode(t)
 						} else if t.FindChild("inet") != nil || (len(t.Keys) >= 2 && t.Keys[1] == "inet") {
 							// static-nat { inet; } — NAT64 translation

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1413,7 +1413,15 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 			// forward). The dataplane backstop (static_nat.rs) keeps the
 			// reverse SNAT scoped to the matched port if the rule slips through
 			// the lenient load / peer-sync path.
-			if rule.MatchDestinationPort != 0 && rule.MappedPort == 0 {
+			//
+			// #6479 fold: guard on !MappedPortPresent so this fires ONLY on a
+			// TRUE absence. A PRESENT-but-malformed mapped-port (`mapped-port
+			// 0`/``/bare/`notaport`) also lands at MappedPort==0, but it is the
+			// presence gate below that owns that case (naming the bad token).
+			// Without this guard both gates fire — two warnings in lenient mode,
+			// and in strict the misleading "requires a mapped-port" message
+			// (emitted first) wins over the accurate "not a valid port number".
+			if rule.MatchDestinationPort != 0 && rule.MappedPort == 0 && !rule.MappedPortPresent {
 				if err := emitSuffix(fmt.Sprintf(
 					"security nat static rule-set %q rule %q match destination-port %d requires a matching `then static-nat mapped-port` (a port match without a port translation either broadens or scopes the reverse source-NAT in a non-obvious way; drop the port match for a whole-address 1:1, or add a mapped-port for a port forward)",
 					rs.Name, rule.Name, rule.MatchDestinationPort),

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1421,40 +1421,50 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 					return nil, err
 				}
 			}
-			// C179-038: a PRESENT-but-non-numeric `then static-nat mapped-port
-			// <token>` rides inside the children:nil static-nat leaf, bypassing
-			// the schema value validator, so the compiler recorded the raw
-			// token on MappedPortRaw (MappedPort stayed 0). Reject it at strict
-			// commit-check — otherwise a garbage token collapses silently to
-			// MappedPort==0 ("no port translation") and is accepted even though
-			// a well-formed value in the same position IS rejected (the
-			// mapped-port-without-match-port gate below). The lenient load /
-			// peer-sync path downgrades this to a warning and the dataplane
-			// installs a plain 1:1 (MappedPort==0, no bogus port).
-			if rule.MappedPortRaw != "" {
+			// C179-038 + fold: a PRESENT `then static-nat mapped-port <token>`
+			// rides inside the children:nil static-nat leaf, bypassing the
+			// schema value validator. The compiler records an explicit presence
+			// signal (MappedPortPresent) plus the parsed port (MappedPort, 0
+			// when absent OR malformed) and the raw token (MappedPortRaw). This
+			// ONE gate rejects every present-but-not-1-65535 sibling the earlier
+			// string/int sentinels let slip: a non-numeric token ("notaport"),
+			// an empty operand (`mapped-port ""`), a bare keyword with no
+			// operand, the literal "0", and an out-of-range number ("70000").
+			// All previously collapsed to MappedPort==0-or-out-of-range with no
+			// diagnostic under the old `MappedPortRaw != ""` / `MappedPort != 0`
+			// gates (MappedPort==0 conflated "absent" with "present-but-
+			// malformed"; MappedPortRaw=="" conflated "absent" with "present-
+			// but-empty"), so the value silently degraded to "no port
+			// translation" even though a WELL-FORMED value in the same position
+			// without a `match destination-port` IS rejected. The lenient load /
+			// peer-sync path (#1960 no-brick) downgrades this to a warning and
+			// the dataplane installs a plain 1:1 (MappedPort==0, no bogus port).
+			// MappedPortPresent is compile-only (json:"-") and never reaches the
+			// dataplane.
+			if rule.MappedPortPresent && (rule.MappedPort < 1 || rule.MappedPort > 65535) {
+				token := "(missing value)"
+				if rule.MappedPortRaw != "" {
+					token = fmt.Sprintf("%q", rule.MappedPortRaw)
+				}
 				if err := emitSuffix(fmt.Sprintf(
-					"security nat static rule-set %q rule %q then static-nat mapped-port %q is not a valid port number (1-65535)",
-					rs.Name, rule.Name, rule.MappedPortRaw),
+					"security nat static rule-set %q rule %q then static-nat mapped-port %s is not a valid port number (1-65535)",
+					rs.Name, rule.Name, token),
 					" (ignored: port translation dropped by dataplane until corrected)"); err != nil {
 					return nil, err
 				}
 			}
-			if rule.MappedPort != 0 {
-				if rule.MappedPort < 1 || rule.MappedPort > 65535 {
-					if err := emitSuffix(fmt.Sprintf(
-						"security nat static rule-set %q rule %q then static-nat mapped-port %d is out of range (1-65535)",
-						rs.Name, rule.Name, rule.MappedPort),
-						" (ignored: port translation dropped by dataplane until corrected)"); err != nil {
-						return nil, err
-					}
-				}
-				if rule.MatchDestinationPort == 0 {
-					if err := emitSuffix(fmt.Sprintf(
-						"security nat static rule-set %q rule %q then static-nat mapped-port %d requires a matching `match destination-port`",
-						rs.Name, rule.Name, rule.MappedPort),
-						" (ignored: port translation dropped by dataplane until corrected)"); err != nil {
-						return nil, err
-					}
+			// A VALID in-range mapped-port still requires a matching `match
+			// destination-port`: without an external port to match, the port
+			// rewrite has no inbound trigger and the reverse SNAT cannot recover
+			// the original port. Guarded on MappedPort != 0 so it does not
+			// double-fire on a malformed mapped-port (MappedPort==0), which the
+			// presence gate above already rejected.
+			if rule.MappedPort != 0 && rule.MatchDestinationPort == 0 {
+				if err := emitSuffix(fmt.Sprintf(
+					"security nat static rule-set %q rule %q then static-nat mapped-port %d requires a matching `match destination-port`",
+					rs.Name, rule.Name, rule.MappedPort),
+					" (ignored: port translation dropped by dataplane until corrected)"); err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1592,6 +1592,35 @@ func validateNPTv6Strict(cfg *Config, lenient bool) ([]string, error) {
 				continue
 			}
 
+			// #5523/#6479: NPTv6 (RFC 6296) translates the IPv6 address prefix
+			// and has NO transport-port concept, so a `then static-nat
+			// nptv6-prefix <p6> mapped-port <p>` is invalid in EVERY shape
+			// (collapsed keys, hierarchical nptv6-prefix child, or a distinct
+			// `mapped-port` sibling). The host-mask loop skips nptv6 rules
+			// entirely (`IsNPTv6` continue), so WITHOUT this gate a mapped-port
+			// on an nptv6 rule reached no validator at all: a malformed operand
+			// was silently accepted (the C179-038 class for the nptv6 shape) and
+			// a well-formed one was silently ignored. recordNPTv6MappedPort-
+			// Presence stamps MappedPortPresent whenever the keyword appears, so
+			// reject on PRESENCE alone — the value is irrelevant on nptv6, even a
+			// well-formed 1-65535 port is meaningless. This runs BEFORE the
+			// prefix-parse/length checks so it fires even when the prefixes are
+			// otherwise valid (the pure silent-accept case). No `continue`: on the
+			// lenient no-brick path the prefix diagnostics still accumulate, and
+			// the nptv6 prefix translation itself still applies (MappedPort==0),
+			// so this warning is scoped to the dropped mapped-port, not the rule.
+			if rule.MappedPortPresent {
+				msg := fmt.Sprintf(
+					"security nat static rule-set %q rule %q then static-nat nptv6-prefix does not support mapped-port (NPTv6 translates the address prefix per RFC 6296, not transport ports); remove the mapped-port",
+					rs.Name, rule.Name)
+				if lenient {
+					warnings = append(warnings, msg+
+						" (ignored: mapped-port dropped by dataplane; the nptv6 prefix translation still applies)")
+				} else {
+					return nil, fmt.Errorf("%s", msg)
+				}
+			}
+
 			// External prefix = `match destination-address`. The family is
 			// classified from the original CIDR text (natCIDRIPPart +
 			// natAddrFamily below), not the parsed net.IP, so the parsed IP

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -1421,6 +1421,24 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 					return nil, err
 				}
 			}
+			// C179-038: a PRESENT-but-non-numeric `then static-nat mapped-port
+			// <token>` rides inside the children:nil static-nat leaf, bypassing
+			// the schema value validator, so the compiler recorded the raw
+			// token on MappedPortRaw (MappedPort stayed 0). Reject it at strict
+			// commit-check — otherwise a garbage token collapses silently to
+			// MappedPort==0 ("no port translation") and is accepted even though
+			// a well-formed value in the same position IS rejected (the
+			// mapped-port-without-match-port gate below). The lenient load /
+			// peer-sync path downgrades this to a warning and the dataplane
+			// installs a plain 1:1 (MappedPort==0, no bogus port).
+			if rule.MappedPortRaw != "" {
+				if err := emitSuffix(fmt.Sprintf(
+					"security nat static rule-set %q rule %q then static-nat mapped-port %q is not a valid port number (1-65535)",
+					rs.Name, rule.Name, rule.MappedPortRaw),
+					" (ignored: port translation dropped by dataplane until corrected)"); err != nil {
+					return nil, err
+				}
+			}
 			if rule.MappedPort != 0 {
 				if rule.MappedPort < 1 || rule.MappedPort > 65535 {
 					if err := emitSuffix(fmt.Sprintf(

--- a/pkg/config/static_nat_mapped_port_2491_test.go
+++ b/pkg/config/static_nat_mapped_port_2491_test.go
@@ -10,7 +10,7 @@ import (
 // <port>` must compile both fields onto the StaticNATRule.
 //
 // Fail-on-revert: dropping the `destination-port` / `mapped-port` parse in
-// compileNATStatic (or the staticNATMappedPortFromKeys helper) leaves both
+// compileNATStatic (or the staticNATMappedPortForNode helper) leaves both
 // fields at 0 and this test goes RED.
 func TestStaticNATMappedPortCompiles(t *testing.T) {
 	cfg := compileSetLines(t, []string{

--- a/pkg/config/static_nat_mapped_port_canonical_6479_test.go
+++ b/pkg/config/static_nat_mapped_port_canonical_6479_test.go
@@ -1,0 +1,370 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStaticNATMappedPortShapeMatrix6479 is the comprehensive #6479 shape
+// matrix. Every prior round of the C179-038 mapped-port work fixed the shape it
+// was looking at and missed another; this matrix pins the behaviour across
+// EVERY Junos AST shape a `then static-nat ... mapped-port` can take, so a
+// future grammar-position or collection change that regresses one shape goes RED
+// here.
+//
+// The regression this guards: round-4 added `prefix` to the grammar-position
+// skip in staticNATMappedPortOperandsFromKeys, which dropped the mapped-port of
+// the CANONICAL Junos separate-set-line form
+//
+//	set ... then static-nat prefix 10.0.0.5/32
+//	set ... then static-nat prefix mapped-port 8080
+//
+// (SetPath collapses the second line to Keys ["prefix","mapped-port","8080"], so
+// the mapped-port immediately follows the literal `prefix` keyword). A prefix
+// value is always an IP and can never be the string "mapped-port", so the token
+// is ALWAYS the genuine modifier — skipping it both false-rejected the clean
+// canonical rule (it looked like a match-port with no mapped-port) AND reopened
+// the C179-038 fail-open for a canonical malformed value.
+//
+// For each shape: a valid in-range port with a matching `match destination-port`
+// ACCEPTS with the resolved MappedPort asserted; a malformed operand REJECTS
+// strict (naming the token) and WARNS lenient with MappedPort==0 (fail-closed to
+// a plain 1:1, no bogus port at the dataplane).
+
+// natBaseZone is the shared flat-set prologue: a zone + a static rule-set whose
+// rule matches a host destination. matchPort adds the `match destination-port`
+// so a valid mapped-port is not caught by the #2769 without-match gate.
+func natBaseZone() []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+	}
+}
+
+func buildFlat(t *testing.T, extra ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range append(natBaseZone(), extra...) {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+func buildHier(t *testing.T, cfg string) *ConfigTree {
+	t.Helper()
+	tree, err := NewParser(cfg).Parse()
+	if err != nil {
+		t.Fatalf("NewParser.Parse: %v", err)
+	}
+	return tree
+}
+
+// assertMappedPortAccept compiles tree in strict mode, requires success, and
+// asserts the resolved MappedPort equals want.
+func assertMappedPortAccept(t *testing.T, tree *ConfigTree, want int) {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict CompileConfig must accept, got %v", err)
+	}
+	if len(cfg.Security.NAT.Static) != 1 || len(cfg.Security.NAT.Static[0].Rules) != 1 {
+		t.Fatalf("expected exactly 1 static NAT rule, got %#v", cfg.Security.NAT.Static)
+	}
+	if got := cfg.Security.NAT.Static[0].Rules[0].MappedPort; got != want {
+		t.Fatalf("MappedPort = %d, want %d", got, want)
+	}
+}
+
+// assertMappedPortReject compiles tree in both strict and lenient modes: strict
+// must hard-error naming the bad token; lenient must warn (naming the token) and
+// keep MappedPort==0 (no bogus port reaches the dataplane).
+func assertMappedPortReject(t *testing.T, buildTree func() *ConfigTree, wantToken string) {
+	t.Helper()
+	_, err := CompileConfig(buildTree())
+	if err == nil {
+		t.Fatalf("strict CompileConfig must reject the malformed mapped-port")
+	}
+	if !strings.Contains(err.Error(), "mapped-port") || !strings.Contains(err.Error(), wantToken) {
+		t.Fatalf("strict error must name mapped-port + %q, got %v", wantToken, err)
+	}
+	cfg, errL := CompileConfigLenient(buildTree())
+	if errL != nil {
+		t.Fatalf("lenient compile must not hard-error, got %v", errL)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "mapped-port") && strings.Contains(w, wantToken) {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatalf("lenient path must warn naming %q, got %v", wantToken, cfg.Warnings)
+	}
+	if len(cfg.Security.NAT.Static) == 1 && len(cfg.Security.NAT.Static[0].Rules) == 1 {
+		if got := cfg.Security.NAT.Static[0].Rules[0].MappedPort; got != 0 {
+			t.Fatalf("lenient path must keep MappedPort==0 (no bogus port), got %d", got)
+		}
+	}
+}
+
+func TestStaticNATMappedPortShapeMatrix6479(t *testing.T) {
+	// Each shape builds a rule expressing prefix 10.0.0.5/32 + mapped-port <op>
+	// plus a matching `match destination-port 8080`, in a distinct AST shape.
+	type shape struct {
+		name string
+		// build returns the tree for a given mapped-port operand string.
+		build func(t *testing.T, op string) *ConfigTree
+	}
+
+	shapes := []shape{
+		{
+			// Collapsed single-line: mapped-port rides on the prefix leaf's Keys
+			// AFTER the IP value (Keys=["prefix","<ip>","mapped-port","<op>"]).
+			name: "collapsed-one-line",
+			build: func(t *testing.T, op string) *ConfigTree {
+				return buildFlat(t,
+					"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+					"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port "+op)
+			},
+		},
+		{
+			// THE REGRESSION: canonical separate-set-line. The second set line
+			// collapses to a distinct prefix leaf Keys=["prefix","mapped-port",
+			// "<op>"] — mapped-port immediately follows the literal `prefix`.
+			name: "canonical-separate-set-line",
+			build: func(t *testing.T, op string) *ConfigTree {
+				return buildFlat(t,
+					"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+					"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+					"set security nat static rule-set rs1 rule r1 then static-nat prefix mapped-port "+op)
+			},
+		},
+		{
+			// Canonical HIERARCHICAL nested-under-prefix-value: mapped-port is a
+			// child of the prefix node, prefix VALUE carried on the prefix Keys.
+			name: "hier-nested-under-prefix-value",
+			build: func(t *testing.T, op string) *ConfigTree {
+				return buildHier(t, `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match {
+                        destination-address 203.0.113.1/32;
+                        destination-port 8080;
+                    }
+                    then {
+                        static-nat {
+                            prefix 10.0.0.5/32 {
+                                mapped-port `+op+`;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`)
+			},
+		},
+		{
+			// Canonical HIERARCHICAL nested value-as-child: the prefix node is a
+			// block carrying BOTH the IP value and the mapped-port as children.
+			name: "hier-nested-value-as-child",
+			build: func(t *testing.T, op string) *ConfigTree {
+				return buildHier(t, `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match {
+                        destination-address 203.0.113.1/32;
+                        destination-port 8080;
+                    }
+                    then {
+                        static-nat {
+                            prefix {
+                                10.0.0.5/32;
+                                mapped-port `+op+`;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`)
+			},
+		},
+		{
+			// prefix-name target with a collapsed mapped-port. The prefix-name
+			// resolves to a global address-book entry; mapped-port follows the
+			// NAME value (Keys=["prefix-name","MP_TARGET","mapped-port","<op>"]).
+			name: "prefix-name-collapsed",
+			build: func(t *testing.T, op string) *ConfigTree {
+				return buildFlat(t,
+					"set security address-book global address MP_TARGET 10.0.0.5/32",
+					"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+					"set security nat static rule-set rs1 rule r1 then static-nat prefix-name MP_TARGET mapped-port "+op)
+			},
+		},
+		{
+			// Sibling: prefix and mapped-port authored as two `then static-nat`
+			// set lines -> distinct children of the static-nat node.
+			name: "sibling",
+			build: func(t *testing.T, op string) *ConfigTree {
+				return buildFlat(t,
+					"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+					"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+					"set security nat static rule-set rs1 rule r1 then static-nat mapped-port "+op)
+			},
+		},
+	}
+
+	// Malformed operands common to every single-value shape.
+	malformed := []struct{ op, token string }{
+		{"notaport", `"notaport"`},
+		{"0", `"0"`},
+		{"70000", `"70000"`},
+	}
+
+	for _, s := range shapes {
+		t.Run(s.name, func(t *testing.T) {
+			// Valid in-range port accepts with the resolved MappedPort asserted.
+			t.Run("valid-8080-accepts", func(t *testing.T) {
+				assertMappedPortAccept(t, s.build(t, "8080"), 8080)
+			})
+			for _, m := range malformed {
+				t.Run("malformed-"+m.op+"-rejects", func(t *testing.T) {
+					assertMappedPortReject(t, func() *ConfigTree { return s.build(t, m.op) }, m.token)
+				})
+			}
+		})
+	}
+}
+
+// TestStaticNATMappedPortDuplicateShapes6479 covers the duplicate-across-nodes
+// shapes: two mapped-port operands must fold through ONE combine (last-wins when
+// both valid, fail-closed when either malformed), never first-wins.
+func TestStaticNATMappedPortDuplicateShapes6479(t *testing.T) {
+	// crossNode: two `then static-nat prefix <ip> mapped-port <op>` set lines.
+	crossNode := func(t *testing.T, a, b string, withMatch bool) *ConfigTree {
+		extra := []string{}
+		if withMatch {
+			extra = append(extra, "set security nat static rule-set rs1 rule r1 match destination-port 8080")
+		}
+		extra = append(extra,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port "+a,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port "+b)
+		return buildFlat(t, extra...)
+	}
+	// packedSibling: one `mapped-port a mapped-port b` sibling child (the packed
+	// duplicate that rides on a single mapped-port leaf's Keys).
+	packedSibling := func(t *testing.T, a, b string, withMatch bool) *ConfigTree {
+		extra := []string{}
+		if withMatch {
+			extra = append(extra, "set security nat static rule-set rs1 rule r1 match destination-port 8080")
+		}
+		extra = append(extra,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat mapped-port "+a+" mapped-port "+b)
+		return buildFlat(t, extra...)
+	}
+
+	dupShapes := []struct {
+		name  string
+		build func(t *testing.T, a, b string, withMatch bool) *ConfigTree
+	}{
+		{"cross-node", crossNode},
+		{"packed-sibling", packedSibling},
+	}
+
+	for _, s := range dupShapes {
+		t.Run(s.name, func(t *testing.T) {
+			// Both valid -> accept, last-wins (9090).
+			t.Run("both-valid-last-wins", func(t *testing.T) {
+				assertMappedPortAccept(t, s.build(t, "8080", "9090", true), 9090)
+			})
+			// Valid then malformed -> fail closed, naming the bad token (the
+			// exact first-wins fail-open this guards: 8080 must NOT win).
+			t.Run("valid-then-malformed-rejects", func(t *testing.T) {
+				assertMappedPortReject(t, func() *ConfigTree { return s.build(t, "8080", "notaport", true) }, `"notaport"`)
+			})
+			// Malformed first -> order-independent fail closed.
+			t.Run("malformed-first-rejects", func(t *testing.T) {
+				assertMappedPortReject(t, func() *ConfigTree { return s.build(t, "notaport", "8080", true) }, `"notaport"`)
+			})
+		})
+	}
+}
+
+// TestStaticNATMappedPortNameValuedSkip6479 confirms the grammar-position skip:
+// a `mapped-port` that is the VALUE of a NAME-valued keyword (routing-instance /
+// prefix-name) is NOT a modifier — the rule carries no mapped-port and compiles
+// clean. This is the false-reject the round-4 skip protected against; the fix
+// keeps it while restoring the `prefix mapped-port` recovery.
+func TestStaticNATMappedPortNameValuedSkip6479(t *testing.T) {
+	// A translation-target routing-instance NAMED "mapped-port".
+	t.Run("routing-instance-named-mapped-port-clean", func(t *testing.T) {
+		cfg, err := CompileConfig(buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 routing-instance mapped-port"))
+		if err != nil {
+			t.Fatalf(`routing-instance named "mapped-port" must compile clean, got %v`, err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.MappedPortPresent {
+			t.Fatalf("routing-instance value \"mapped-port\" must not register a mapped-port modifier (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+		}
+		if rule.ThenRoutingInstance != "mapped-port" {
+			t.Fatalf("routing-instance target must be \"mapped-port\", got %q", rule.ThenRoutingInstance)
+		}
+	})
+
+	// A prefix-name address-book entry NAMED "mapped-port".
+	t.Run("prefix-name-named-mapped-port-clean", func(t *testing.T) {
+		cfg, err := CompileConfig(buildFlat(t,
+			"set security address-book global address mapped-port 10.0.0.9/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name mapped-port"))
+		if err != nil {
+			t.Fatalf(`prefix-name entry named "mapped-port" must compile clean, got %v`, err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.MappedPortPresent {
+			t.Fatalf("prefix-name value \"mapped-port\" must not register a mapped-port modifier (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+		}
+		if rule.ThenPrefixName != "mapped-port" {
+			t.Fatalf("prefix-name target must be \"mapped-port\", got %q", rule.ThenPrefixName)
+		}
+		if rule.Then != "10.0.0.9/32" {
+			t.Fatalf("prefix-name must resolve to 10.0.0.9/32, got %q", rule.Then)
+		}
+	})
+
+	// A REAL mapped-port alongside a routing-instance named "mapped-port": the
+	// real port survives, the RI name does not poison it.
+	t.Run("real-mapped-port-plus-ri-named-mapped-port", func(t *testing.T) {
+		cfg, err := CompileConfig(buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 match destination-port 80",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 8080",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 routing-instance mapped-port"))
+		if err != nil {
+			t.Fatalf(`real mapped-port 8080 + RI named "mapped-port" must compile clean, got %v`, err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if !rule.MappedPortPresent || rule.MappedPort != 8080 {
+			t.Fatalf("real mapped-port 8080 must survive (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+		}
+	})
+}

--- a/pkg/config/static_nat_mapped_port_grammar_role_6479_test.go
+++ b/pkg/config/static_nat_mapped_port_grammar_role_6479_test.go
@@ -1,0 +1,250 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file closes the two residual #6479 silent-accepts the FINAL hostile
+// review flagged, both attacked at the ROOT rather than shape-by-shape:
+//
+//   ROOT CAUSE (grammar role): staticNATMappedPortOperandsFromKeys used a
+//     LEXEME-ONLY lookbehind — it skipped a `mapped-port` when the immediately
+//     preceding TOKEN was a name-valued skip-keyword (prefix-name /
+//     routing-instance). It could not tell whether that preceding token was the
+//     KEYWORD or its VALUE, so a translation target whose NAME is literally
+//     "prefix-name" / "routing-instance" shifted a real modifier into the skipped
+//     slot and the malformed port was SILENTLY ACCEPTED:
+//
+//       then static-nat prefix-name prefix-name mapped-port notaport
+//       keys [prefix-name(kw) prefix-name(value) mapped-port notaport]
+//
+//     The fix walks the key stream grammar-role-aware: a name-valued keyword
+//     CONSUMES its next token as a value slot, and `mapped-port` is the modifier
+//     ONLY in a keyword slot — closing the whole class (any target named after a
+//     skip-keyword, in any position) convergently.
+//
+//   SECOND FINDING (collection gap): a modifier-only `static-nat` sibling
+//     (`then { static-nat { mapped-port <p>; } static-nat { prefix <ip>; } }`)
+//     matched NO target branch in compileNATStatic, so its mapped-port reached no
+//     validator. The fix routes an unmatched static-nat node through the same
+//     mergeMappedPortForNode accumulator so its malformed operand fails closed in
+//     either sibling order, and even when the co-sibling is an nptv6 target.
+//
+// INVARIANT A (security, absolute): no shape may SILENTLY ACCEPT a present-but-
+//   malformed mapped-port. INVARIANT B (no regression): a target legitimately
+//   named "prefix-name"/"routing-instance"/"mapped-port" still compiles clean,
+//   and a real modifier on such a target is still collected.
+
+// --- ROOT CAUSE: translation target NAMED after a skip-keyword --------------
+
+// TestStaticNATMappedPortTargetNamedSkipKeyword6479 pins the grammar-role fix: a
+// prefix-name target whose resolved NAME is literally a name-valued skip-keyword
+// ("prefix-name" or "routing-instance") must NOT let a trailing malformed
+// mapped-port slip through. The address-book entry is defined so the TARGET
+// resolves cleanly — the malformed mapped-port is then the ONLY defect, proving
+// the reject is the mapped-port gate (not an unrelated empty-target rejection).
+// No `match destination-port`, so this is the purest silent-accept probe: without
+// the fix it compiles clean; with it, it fails closed naming the bad token.
+//
+// PARENT-RED: restoring the lexeme lookbehind (skip `mapped-port` when keys[i-1]
+// is a name-valued keyword) makes every malformed case here go GREEN-compile =
+// test RED — the malformed port is skipped and silently accepted.
+func TestStaticNATMappedPortTargetNamedSkipKeyword6479(t *testing.T) {
+	// targetName is the literal string the prefix-name reference resolves to; it
+	// is chosen to equal a name-valued skip-keyword so it fools a lexeme lookbehind.
+	for _, targetName := range []string{"prefix-name", "routing-instance"} {
+		targetName := targetName
+		t.Run("prefix-name-target-named-"+targetName, func(t *testing.T) {
+			// Malformed mapped-port after a target NAMED like a skip-keyword.
+			t.Run("malformed-rejects", func(t *testing.T) {
+				assertMappedPortReject(t, func() *ConfigTree {
+					return buildFlat(t,
+						"set security address-book global address "+targetName+" 10.0.0.5/32",
+						"set security nat static rule-set rs1 rule r1 then static-nat prefix-name "+targetName+" mapped-port notaport")
+				}, `"notaport"`)
+			})
+			// INVARIANT B: the SAME target with a VALID mapped-port must still be
+			// recovered (a matching match-port keeps the #2769 gate quiet).
+			t.Run("valid-recovers-port", func(t *testing.T) {
+				cfg, err := CompileConfig(buildFlat(t,
+					"set security address-book global address "+targetName+" 10.0.0.5/32",
+					"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+					"set security nat static rule-set rs1 rule r1 then static-nat prefix-name "+targetName+" mapped-port 8080"))
+				if err != nil {
+					t.Fatalf("valid mapped-port on target named %q must accept, got %v", targetName, err)
+				}
+				rule := cfg.Security.NAT.Static[0].Rules[0]
+				if rule.ThenPrefixName != targetName || rule.Then != "10.0.0.5/32" {
+					t.Fatalf("target must resolve to %q/10.0.0.5/32, got name=%q then=%q", targetName, rule.ThenPrefixName, rule.Then)
+				}
+				if !rule.MappedPortPresent || rule.MappedPort != 8080 {
+					t.Fatalf("valid mapped-port 8080 must be recovered (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+				}
+			})
+			// INVARIANT B: the SAME target with NO mapped-port must compile clean
+			// and register NO modifier (the name is not a mapped-port).
+			t.Run("no-modifier-clean", func(t *testing.T) {
+				cfg, err := CompileConfig(buildFlat(t,
+					"set security address-book global address "+targetName+" 10.0.0.5/32",
+					"set security nat static rule-set rs1 rule r1 then static-nat prefix-name "+targetName))
+				if err != nil {
+					t.Fatalf("target named %q with no mapped-port must compile clean, got %v", targetName, err)
+				}
+				rule := cfg.Security.NAT.Static[0].Rules[0]
+				if rule.MappedPortPresent {
+					t.Fatalf("target named %q must not register a phantom mapped-port (present=%v port=%d)", targetName, rule.MappedPortPresent, rule.MappedPort)
+				}
+			})
+		})
+	}
+}
+
+// TestStaticNATMappedPortRealModifierOnTargetNamedMappedPort6479 is the tightest
+// INVARIANT B: a prefix-name target whose NAME is literally "mapped-port" AND
+// which carries a REAL mapped-port modifier must recover the modifier — the name
+// "mapped-port" is consumed as the target value, the SECOND `mapped-port` is the
+// keyword-slot modifier. This proves the grammar-role scan does not conflate the
+// name with the modifier in either direction.
+func TestStaticNATMappedPortRealModifierOnTargetNamedMappedPort6479(t *testing.T) {
+	cfg, err := CompileConfig(buildFlat(t,
+		"set security address-book global address mapped-port 10.0.0.7/32",
+		"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix-name mapped-port mapped-port 8080"))
+	if err != nil {
+		t.Fatalf(`target named "mapped-port" + real modifier 8080 must accept, got %v`, err)
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.ThenPrefixName != "mapped-port" || rule.Then != "10.0.0.7/32" {
+		t.Fatalf(`target must resolve to "mapped-port"/10.0.0.7/32, got name=%q then=%q`, rule.ThenPrefixName, rule.Then)
+	}
+	if !rule.MappedPortPresent || rule.MappedPort != 8080 {
+		t.Fatalf("real modifier 8080 must be recovered past the name (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+	}
+}
+
+// --- SECOND FINDING: modifier-only static-nat sibling -----------------------
+
+// TestStaticNATMappedPortModifierOnlySibling6479 pins the collection-gap fix: a
+// `static-nat` sibling carrying ONLY a mapped-port modifier (no prefix /
+// prefix-name / nptv6-prefix / inet target) is routed through the accumulator, so
+// a malformed operand fails closed in EITHER sibling order and even when the
+// co-sibling is an nptv6 target. hierRuleV4AB carries no match destination-port,
+// so a malformed mapped-port is the only defect.
+//
+// PARENT-RED: deleting the `else { mergeMappedPortForNode(rule, t) }` branch in
+// compileNATStatic makes the modifier-only sibling reach no validator — every
+// malformed case here compiles clean = test RED.
+func TestStaticNATMappedPortModifierOnlySibling6479(t *testing.T) {
+	prefixCases := []struct {
+		name  string
+		inner string
+	}{
+		{
+			// Modifier-only sibling FIRST, clean prefix second.
+			name: "modifier-only-first-then-prefix",
+			inner: `                        static-nat { mapped-port notaport; }
+                        static-nat { prefix 10.0.0.5/32; }`,
+		},
+		{
+			// Clean prefix FIRST, modifier-only sibling second (opposite order).
+			name: "prefix-first-then-modifier-only",
+			inner: `                        static-nat { prefix 10.0.0.5/32; }
+                        static-nat { mapped-port notaport; }`,
+		},
+		{
+			// Modifier-only sibling paired with a clean prefix-NAME target.
+			name: "modifier-only-first-then-prefix-name",
+			inner: `                        static-nat { mapped-port notaport; }
+                        static-nat { prefix-name MP_TARGET; }`,
+		},
+	}
+	for _, c := range prefixCases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			assertMappedPortReject(t, func() *ConfigTree {
+				return buildHier(t, hierRuleV4AB(c.inner))
+			}, `"notaport"`)
+		})
+	}
+
+	// nptv6 co-sibling: the modifier-only mapped-port makes the (nptv6) rule carry
+	// a mapped-port, which nptv6 rejects on presence regardless of the value. This
+	// is the "also bypasses NPTv6 rejection" case the review flagged.
+	nptv6Cases := []struct {
+		name  string
+		inner string
+	}{
+		{
+			name: "modifier-only-first-then-nptv6",
+			inner: `                        static-nat { mapped-port notaport; }
+                        static-nat { nptv6-prefix 2001:db8:1::/64; }`,
+		},
+		{
+			name: "nptv6-first-then-modifier-only",
+			inner: `                        static-nat { nptv6-prefix 2001:db8:1::/64; }
+                        static-nat { mapped-port notaport; }`,
+		},
+	}
+	for _, c := range nptv6Cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			assertNPTv6MappedPortReject(t, func() *ConfigTree {
+				body := `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 2001:db8:9::/64; }
+                    then {
+` + c.inner + `
+                    }
+                }
+            }
+        }
+    }
+}`
+				return buildHier(t, body)
+			})
+		})
+	}
+}
+
+// TestStaticNATMappedPortModifierOnlySiblingAccept6479 is the INVARIANT B guard
+// for the modifier-only sibling: a VALID mapped-port on a modifier-only sibling
+// applies to the merged action and is recovered (with a matching match-port).
+func TestStaticNATMappedPortModifierOnlySiblingAccept6479(t *testing.T) {
+	tree := buildHier(t, `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 203.0.113.1/32; destination-port 8080; }
+                    then {
+                        static-nat { mapped-port 9090; }
+                        static-nat { prefix 10.0.0.5/32; }
+                    }
+                }
+            }
+        }
+    }
+}`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("valid modifier-only sibling + clean prefix must accept, got %v", err)
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.Then != "10.0.0.5/32" {
+		t.Fatalf("target must resolve to the prefix sibling 10.0.0.5/32, got %q", rule.Then)
+	}
+	if !rule.MappedPortPresent || rule.MappedPort != 9090 {
+		t.Fatalf("valid modifier-only mapped-port 9090 must be recovered (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+	}
+	if !strings.Contains(rule.Then, "10.0.0.5") {
+		t.Fatalf("sanity: prefix target lost, got %q", rule.Then)
+	}
+}

--- a/pkg/config/static_nat_mapped_port_malformed_5523_test.go
+++ b/pkg/config/static_nat_mapped_port_malformed_5523_test.go
@@ -175,6 +175,14 @@ func TestStaticNATMappedPortPresenceGate(t *testing.T) {
 			"set security nat static rule-set rs1 rule r1 then static-nat mapped-port " + val,
 		}
 	}
+	// siblingBare is the sibling shape with a BARE `mapped-port` (no operand at
+	// all) — a distinct set-line shape from sibling(`""`)'s empty quoted operand.
+	siblingBare := func() []string {
+		return []string{
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat mapped-port",
+		}
+	}
 
 	cases := []struct {
 		name        string
@@ -188,14 +196,30 @@ func TestStaticNATMappedPortPresenceGate(t *testing.T) {
 		{"flatEmpty", flat(`mapped-port ""`), true, "(missing value)", true},
 		{"flatBare", flat("mapped-port"), true, "(missing value)", true},
 		{"flatNonNumeric", flat("mapped-port notaport"), true, `"notaport"`, true},
-		// Numeric but out of range — carries a match-port so only the range gate
-		// fires. MappedPort parses to 70000 (not zeroed), so wantMapZero=false.
-		{"flatOutOfRange", flatMatch("mapped-port 70000"), true, `"70000"`, false},
-		// Hierarchical sibling malformed — the FindChild("mapped-port") path.
+		// Numeric but out of range — carries a match-port so the mapped-port-
+		// without-match-port gate stays quiet. #6479 fold: out-of-range is now
+		// folded to malformed, so MappedPort is zeroed (fail-closed) → wantMapZero.
+		{"flatOutOfRange", flatMatch("mapped-port 70000"), true, `"70000"`, true},
+		// Hierarchical sibling malformed — the sibling scan path.
 		{"siblingNonNumeric", sibling("notaport"), true, `"notaport"`, true},
 		{"siblingZero", sibling("0"), true, `"0"`, true},
+		// #6479 fold NIT 2 (sibling coverage Codex noted was missing): the
+		// empty / bare / out-of-range sibling shapes all fail closed too.
+		{"siblingEmpty", sibling(`""`), true, "(missing value)", true},
+		{"siblingBare", siblingBare(), true, "(missing value)", true},
+		{"siblingOutOfRange", sibling("70000"), true, `"70000"`, true},
+		// #6479 fold NIT 2 (scan-all, not first-wins): a contradictory flat
+		// duplicate fails closed — a malformed occurrence ANYWHERE zeroes the
+		// port and names the bad token, never silently reduced to the good one.
+		{"dupValidThenBad", flat("mapped-port 8080 mapped-port notaport"), true, `"notaport"`, true},
+		{"dupBadThenValid", flat("mapped-port notaport mapped-port 8080"), true, `"notaport"`, true},
+		{"dupValidThenBare", flat("mapped-port 8080 mapped-port"), true, "(missing value)", true},
+		{"dupValidThenOutOfRange", flat("mapped-port 8080 mapped-port 70000"), true, `"70000"`, true},
 		// Accepted: a valid in-range port WITH a matching match destination-port.
 		{"validWithMatchPort", flatMatch("mapped-port 8080"), false, "", false},
+		// Accepted: a duplicate where BOTH operands are valid — last-wins (9090)
+		// with a matching match destination-port (#6479 fold).
+		{"dupBothValid", flatMatch("mapped-port 8080 mapped-port 9090"), false, "", false},
 		// Accepted: no mapped-port keyword at all (plain host 1:1).
 		{"absent", []string{"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32"}, false, "", false},
 	}
@@ -244,5 +268,70 @@ func TestStaticNATMappedPortPresenceGate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestStaticNATMappedPortDoubleWarnGate is the #6479 fold NIT 1: a PRESENT-but-
+// malformed `mapped-port` that lands at MappedPort==0 (`mapped-port 0`) PAIRED
+// WITH a `match destination-port` must be owned SOLELY by the presence gate
+// (which names the offending token), NOT double-reported by the #2769
+// match-port-without-mapped-port inverse gate. Before the fold both gates fired
+// on MappedPort==0: two warnings on the lenient path, and — because the #2769
+// gate emits FIRST — the misleading "requires a matching `then static-nat
+// mapped-port`" message won over the accurate "not a valid port number" one in
+// strict mode. The fold guards the #2769 gate on !MappedPortPresent so it fires
+// only on a TRUE absence.
+//
+// Fail-on-revert: drop `&& !rule.MappedPortPresent` from the #2769 gate →
+// strict names the wrong (requires-mapped-port) message and the lenient path
+// emits two mapped-port warnings → the message/count assertions go RED.
+func TestStaticNATMappedPortDoubleWarnGate(t *testing.T) {
+	// Present-but-malformed (`mapped-port 0`) WITH a matching match-port.
+	malformedWithMatch := []string{
+		"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 0",
+	}
+	// Strict: the accurate malformed-token message wins; the misleading #2769
+	// "requires a matching" message must NOT appear.
+	_, err := CompileConfig(buildMappedPortTree(t, malformedWithMatch))
+	if err == nil {
+		t.Fatalf("strict CompileConfig must reject a malformed mapped-port paired with a match-port")
+	}
+	if !strings.Contains(err.Error(), "not a valid port number") {
+		t.Fatalf("strict error must be the malformed-token message, got %v", err)
+	}
+	if !strings.Contains(err.Error(), `"0"`) {
+		t.Fatalf(`strict error must name the malformed token "0", got %v`, err)
+	}
+	if strings.Contains(err.Error(), "requires a matching") {
+		t.Fatalf("strict error must NOT double-fire the #2769 requires-mapped-port gate, got %v", err)
+	}
+	// Lenient: EXACTLY ONE mapped-port warning (the presence gate), not two.
+	cfg, errL := CompileConfigLenient(buildMappedPortTree(t, malformedWithMatch))
+	if errL != nil {
+		t.Fatalf("lenient compile must not hard-error, got %v", errL)
+	}
+	var n int
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "mapped-port") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("lenient path must emit exactly ONE mapped-port warning, got %d: %v", n, cfg.Warnings)
+	}
+
+	// The genuine ABSENCE case (match-port with NO mapped-port at all) must
+	// STILL be rejected by the #2769 inverse gate (MappedPortPresent==false).
+	absent := []string{
+		"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+	}
+	_, errA := CompileConfig(buildMappedPortTree(t, absent))
+	if errA == nil {
+		t.Fatalf("strict CompileConfig must still reject a match-port with no mapped-port")
+	}
+	if !strings.Contains(errA.Error(), "requires a matching") {
+		t.Fatalf("true-absence must be rejected by the #2769 requires-mapped-port gate, got %v", errA)
 	}
 }

--- a/pkg/config/static_nat_mapped_port_malformed_5523_test.go
+++ b/pkg/config/static_nat_mapped_port_malformed_5523_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStaticNATMappedPortMalformedRejected is the C179-038 residual half: a
+// NON-NUMERIC `then static-nat prefix <ip> mapped-port <token>` with NO
+// `match destination-port` was silently swallowed. The token rides inside the
+// children:nil static-nat leaf (bypassing the schema value validator), so
+// staticNATMappedPortFromKeys mapped it to MappedPort==0 (== "no port
+// translation"), the `MatchDestinationPort != 0 && MappedPort == 0` guard did
+// not fire (no match-port), and the rule compiled clean — even though a
+// WELL-FORMED value in the same position IS rejected
+// (TestStaticNATMappedPortWithoutMatchPortRejected). A garbage token was thus
+// treated more leniently than a valid one.
+//
+// Fail-on-revert: remove the `rule.MappedPortRaw != ""` guard in
+// validateNATHostMaskStrict (or revert staticNATMappedPortFromKeys to drop the
+// malformed-raw return) → MappedPortRaw is never surfaced → CompileConfig
+// succeeds → this test goes RED on a clean assertion.
+func TestStaticNATMappedPortMalformedRejected(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+		// Deliberately NO `match destination-port` — this is the residual path.
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port notaport",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected CompileConfig to reject a non-numeric mapped-port")
+	}
+	if !strings.Contains(err.Error(), "mapped-port") {
+		t.Fatalf("error must mention mapped-port, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "notaport") {
+		t.Fatalf("error must name the malformed token, got %v", err)
+	}
+}
+
+// TestStaticNATMappedPortMalformedLenientWarns confirms the lenient load /
+// peer-sync path (#1960 no-brick) downgrades the malformed mapped-port to a
+// warning rather than a hard error, and — critically — the compiled rule still
+// carries MappedPort==0 so the dataplane installs a plain 1:1 (no bogus port),
+// matching the pre-fix fail-closed behaviour.
+func TestStaticNATMappedPortMalformedLenientWarns(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port notaport",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not hard-error, got %v", err)
+	}
+	if len(cfg.Security.NAT.Static) != 1 {
+		t.Fatalf("expected 1 static NAT rule-set, got %d", len(cfg.Security.NAT.Static))
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.MappedPort != 0 {
+		t.Fatalf("lenient path must keep MappedPort==0 (no bogus port), got %d", rule.MappedPort)
+	}
+	var found bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "mapped-port") && strings.Contains(w, "notaport") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a lenient warning naming the malformed mapped-port, got %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/static_nat_mapped_port_malformed_5523_test.go
+++ b/pkg/config/static_nat_mapped_port_malformed_5523_test.go
@@ -9,7 +9,7 @@ import (
 // NON-NUMERIC `then static-nat prefix <ip> mapped-port <token>` with NO
 // `match destination-port` was silently swallowed. The token rides inside the
 // children:nil static-nat leaf (bypassing the schema value validator), so
-// staticNATMappedPortFromKeys mapped it to MappedPort==0 (== "no port
+// staticNATMappedPortForNode mapped it to MappedPort==0 (== "no port
 // translation"), the `MatchDestinationPort != 0 && MappedPort == 0` guard did
 // not fire (no match-port), and the rule compiled clean — even though a
 // WELL-FORMED value in the same position IS rejected
@@ -18,7 +18,7 @@ import (
 //
 // Fail-on-revert: neutralize the unified presence gate in
 // validateNATHostMaskStrict (`rule.MappedPortPresent && (MappedPort < 1 ||
-// MappedPort > 65535)`) or revert staticNATMappedPortFromKeys to drop the
+// MappedPort > 65535)`) or revert staticNATMappedPortForNode to drop the
 // presence/raw returns → the malformed token is never surfaced →
 // CompileConfig succeeds → this test goes RED on a clean assertion.
 func TestStaticNATMappedPortMalformedRejected(t *testing.T) {
@@ -190,44 +190,46 @@ func TestStaticNATMappedPortPresenceGate(t *testing.T) {
 		wantReject  bool
 		wantSubstr  string // token / placeholder the strict error + lenient warning must name
 		wantMapZero bool   // lenient path must keep MappedPort==0 (truly-malformed)
+		wantMapPort int    // on an accepted case, the compiled MappedPort (0 = skip)
 	}{
 		// Collapsed single-line (flat) malformed — the sentinel-collision core.
-		{"flatZero", flat("mapped-port 0"), true, `"0"`, true},
-		{"flatEmpty", flat(`mapped-port ""`), true, "(missing value)", true},
-		{"flatBare", flat("mapped-port"), true, "(missing value)", true},
-		{"flatNonNumeric", flat("mapped-port notaport"), true, `"notaport"`, true},
+		{"flatZero", flat("mapped-port 0"), true, `"0"`, true, 0},
+		{"flatEmpty", flat(`mapped-port ""`), true, "(missing value)", true, 0},
+		{"flatBare", flat("mapped-port"), true, "(missing value)", true, 0},
+		{"flatNonNumeric", flat("mapped-port notaport"), true, `"notaport"`, true, 0},
 		// Numeric but out of range — carries a match-port so the mapped-port-
 		// without-match-port gate stays quiet. #6479 fold: out-of-range is now
 		// folded to malformed, so MappedPort is zeroed (fail-closed) → wantMapZero.
-		{"flatOutOfRange", flatMatch("mapped-port 70000"), true, `"70000"`, true},
+		{"flatOutOfRange", flatMatch("mapped-port 70000"), true, `"70000"`, true, 0},
 		// Hierarchical sibling malformed — the sibling scan path.
-		{"siblingNonNumeric", sibling("notaport"), true, `"notaport"`, true},
-		{"siblingZero", sibling("0"), true, `"0"`, true},
+		{"siblingNonNumeric", sibling("notaport"), true, `"notaport"`, true, 0},
+		{"siblingZero", sibling("0"), true, `"0"`, true, 0},
 		// #6479 fold NIT 2 (sibling coverage Codex noted was missing): the
 		// empty / bare / out-of-range sibling shapes all fail closed too.
-		{"siblingEmpty", sibling(`""`), true, "(missing value)", true},
-		{"siblingBare", siblingBare(), true, "(missing value)", true},
-		{"siblingOutOfRange", sibling("70000"), true, `"70000"`, true},
+		{"siblingEmpty", sibling(`""`), true, "(missing value)", true, 0},
+		{"siblingBare", siblingBare(), true, "(missing value)", true, 0},
+		{"siblingOutOfRange", sibling("70000"), true, `"70000"`, true, 0},
 		// #6479 fold NIT 2 (scan-all, not first-wins): a contradictory flat
 		// duplicate fails closed — a malformed occurrence ANYWHERE zeroes the
 		// port and names the bad token, never silently reduced to the good one.
-		{"dupValidThenBad", flat("mapped-port 8080 mapped-port notaport"), true, `"notaport"`, true},
-		{"dupBadThenValid", flat("mapped-port notaport mapped-port 8080"), true, `"notaport"`, true},
-		{"dupValidThenBare", flat("mapped-port 8080 mapped-port"), true, "(missing value)", true},
-		{"dupValidThenOutOfRange", flat("mapped-port 8080 mapped-port 70000"), true, `"70000"`, true},
+		{"dupValidThenBad", flat("mapped-port 8080 mapped-port notaport"), true, `"notaport"`, true, 0},
+		{"dupBadThenValid", flat("mapped-port notaport mapped-port 8080"), true, `"notaport"`, true, 0},
+		{"dupValidThenBare", flat("mapped-port 8080 mapped-port"), true, "(missing value)", true, 0},
+		{"dupValidThenOutOfRange", flat("mapped-port 8080 mapped-port 70000"), true, `"70000"`, true, 0},
 		// Accepted: a valid in-range port WITH a matching match destination-port.
-		{"validWithMatchPort", flatMatch("mapped-port 8080"), false, "", false},
+		{"validWithMatchPort", flatMatch("mapped-port 8080"), false, "", false, 8080},
 		// Accepted: a duplicate where BOTH operands are valid — last-wins (9090)
-		// with a matching match destination-port (#6479 fold).
-		{"dupBothValid", flatMatch("mapped-port 8080 mapped-port 9090"), false, "", false},
+		// with a matching match destination-port (#6479 fold). wantMapPort asserts
+		// the LAST valid operand wins (9090), not the first (8080).
+		{"dupBothValid", flatMatch("mapped-port 8080 mapped-port 9090"), false, "", false, 9090},
 		// Accepted: no mapped-port keyword at all (plain host 1:1).
-		{"absent", []string{"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32"}, false, "", false},
+		{"absent", []string{"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32"}, false, "", false, 0},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Strict commit-check.
-			_, err := CompileConfig(buildMappedPortTree(t, tc.tail))
+			cfgS, err := CompileConfig(buildMappedPortTree(t, tc.tail))
 			if tc.wantReject {
 				if err == nil {
 					t.Fatalf("strict CompileConfig must reject %s", tc.name)
@@ -240,6 +242,15 @@ func TestStaticNATMappedPortPresenceGate(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Fatalf("strict CompileConfig must accept %s, got %v", tc.name, err)
+			} else if tc.wantMapPort != 0 {
+				// Accepted case with an expected compiled port: assert the
+				// combine result (last-wins across duplicates) reached the rule.
+				if len(cfgS.Security.NAT.Static) != 1 || len(cfgS.Security.NAT.Static[0].Rules) != 1 {
+					t.Fatalf("expected exactly 1 static NAT rule for %s", tc.name)
+				}
+				if got := cfgS.Security.NAT.Static[0].Rules[0].MappedPort; got != tc.wantMapPort {
+					t.Fatalf("strict path MappedPort for %s: want %d, got %d", tc.name, tc.wantMapPort, got)
+				}
 			}
 
 			// Lenient load / peer-sync path (#1960 no-brick).
@@ -334,4 +345,136 @@ func TestStaticNATMappedPortDoubleWarnGate(t *testing.T) {
 	if !strings.Contains(errA.Error(), "requires a matching") {
 		t.Fatalf("true-absence must be rejected by the #2769 requires-mapped-port gate, got %v", errA)
 	}
+}
+
+// TestStaticNATMappedPortGrammarPosition5523 is the #6479 fold: the C179-038
+// mapped-port scan was grammar-NAIVE — it treated ANY literal `mapped-port`
+// token in the static-nat `then` leaf as the mapped-port modifier, regardless of
+// grammar position, and it read only the FindChild-first prefix child so a
+// duplicate split across two `then static-nat` set lines was first-wins. The fold
+// makes detection grammar-position-aware (a `mapped-port` that is the VALUE of a
+// preceding `routing-instance`/`prefix` is NOT a modifier) and combines every
+// occurrence across all target children through ONE combine (fail-closed on any
+// malformed operand, no first-wins).
+//
+// Fail-on-revert:
+//   - routingInstanceNamedMappedPortAccepts goes RED if the routing-instance/
+//     prefix grammar-position skip in staticNATMappedPortOperandsFromKeys is
+//     reverted (the false reject of a routing-instance NAMED "mapped-port"
+//     returns).
+//   - crossNodeMalformedRejects goes RED if staticNATMappedPortForNode is
+//     reverted to the first-wins sibling scan (only the FindChild prefix child +
+//     `mapped-port` siblings): node2's `notaport` is ignored, 8080 wins, and the
+//     malformed duplicate compiles clean.
+func TestStaticNATMappedPortGrammarPosition5523(t *testing.T) {
+	// PROBLEM 1: a translation-target routing-instance NAMED "mapped-port"
+	// (#4292 allows an arbitrary routing-instance identifier) is NOT a mapped-port
+	// modifier — the rule carries no mapped-port at all and must compile clean.
+	t.Run("routingInstanceNamedMappedPortAccepts", func(t *testing.T) {
+		tail := []string{
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 routing-instance mapped-port",
+		}
+		cfg, err := CompileConfig(buildMappedPortTree(t, tail))
+		if err != nil {
+			t.Fatalf(`a routing-instance named "mapped-port" must compile clean (no mapped-port modifier present), got %v`, err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.MappedPortPresent {
+			t.Fatalf("routing-instance value \"mapped-port\" must NOT register a mapped-port modifier (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+		}
+		if rule.ThenRoutingInstance != "mapped-port" {
+			t.Fatalf("the routing-instance target must be captured as \"mapped-port\", got %q", rule.ThenRoutingInstance)
+		}
+	})
+
+	// A NORMAL routing-instance name is unaffected by the guard.
+	t.Run("routingInstanceNormalAccepts", func(t *testing.T) {
+		tail := []string{
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 routing-instance blue",
+		}
+		cfg, err := CompileConfig(buildMappedPortTree(t, tail))
+		if err != nil {
+			t.Fatalf("a normal routing-instance target must compile clean, got %v", err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.MappedPortPresent {
+			t.Fatalf("a normal routing-instance must not register a mapped-port modifier")
+		}
+		if rule.ThenRoutingInstance != "blue" {
+			t.Fatalf("routing-instance target want \"blue\", got %q", rule.ThenRoutingInstance)
+		}
+	})
+
+	// Only the token IMMEDIATELY after routing-instance/prefix is skipped: a
+	// GENUINE mapped-port modifier alongside a routing-instance named
+	// "mapped-port" still survives. node1 supplies a real mapped-port 8080 (with a
+	// matching match destination-port); node2's routing-instance is named
+	// "mapped-port". The real 8080 must be honored and the RI name must not poison
+	// it.
+	t.Run("realMappedPortPlusRINamedMappedPort", func(t *testing.T) {
+		tail := []string{
+			"set security nat static rule-set rs1 rule r1 match destination-port 80",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 8080",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 routing-instance mapped-port",
+		}
+		cfg, err := CompileConfig(buildMappedPortTree(t, tail))
+		if err != nil {
+			t.Fatalf(`a real mapped-port 8080 alongside a routing-instance named "mapped-port" must compile clean, got %v`, err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if !rule.MappedPortPresent || rule.MappedPort != 8080 {
+			t.Fatalf("real mapped-port 8080 must survive the RI-named-mapped-port node (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+		}
+	})
+
+	// PROBLEM 2: a duplicate mapped-port split ACROSS two `then static-nat` set
+	// lines (distinct target children under one static-nat node) must be folded
+	// together and fail closed on ANY malformed occurrence — not first-wins.
+	crossNode := func(a, b string) []string {
+		return []string{
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port " + a,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port " + b,
+		}
+	}
+	t.Run("crossNodeMalformedRejects", func(t *testing.T) {
+		// A matching match destination-port is present so that, under the OLD
+		// first-wins behaviour, the valid first node (8080) would compile CLEAN
+		// (the firsthand "ACCEPTED, notaport ignored" fail-open). The unified
+		// combine must instead fail closed and NAME the malformed second token.
+		tail := append([]string{
+			"set security nat static rule-set rs1 rule r1 match destination-port 80",
+		}, crossNode("8080", "notaport")...)
+		_, err := CompileConfig(buildMappedPortTree(t, tail))
+		if err == nil {
+			t.Fatalf("a cross-node duplicate mapped-port with a malformed second value must fail closed (not first-wins accept)")
+		}
+		if !strings.Contains(err.Error(), "mapped-port") || !strings.Contains(err.Error(), "notaport") {
+			t.Fatalf(`cross-node reject must name the malformed token "notaport", got %v`, err)
+		}
+	})
+	t.Run("crossNodeMalformedFirstRejects", func(t *testing.T) {
+		// Order-independence: a malformed value in the FIRST node also fails closed.
+		_, err := CompileConfig(buildMappedPortTree(t, crossNode("notaport", "8080")))
+		if err == nil {
+			t.Fatalf("a cross-node duplicate mapped-port with a malformed first value must fail closed")
+		}
+		if !strings.Contains(err.Error(), "notaport") {
+			t.Fatalf(`cross-node reject must name "notaport", got %v`, err)
+		}
+	})
+	t.Run("crossNodeBothValidLastWins", func(t *testing.T) {
+		// Both operands valid across nodes → accept, last-wins (9090). A match
+		// destination-port is required for a valid in-range mapped-port to accept.
+		tail := append([]string{
+			"set security nat static rule-set rs1 rule r1 match destination-port 443",
+		}, crossNode("8080", "9090")...)
+		cfg, err := CompileConfig(buildMappedPortTree(t, tail))
+		if err != nil {
+			t.Fatalf("a cross-node duplicate with both operands valid must accept, got %v", err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.MappedPort != 9090 {
+			t.Fatalf("cross-node both-valid must be last-wins 9090, got %d", rule.MappedPort)
+		}
+	})
 }

--- a/pkg/config/static_nat_mapped_port_malformed_5523_test.go
+++ b/pkg/config/static_nat_mapped_port_malformed_5523_test.go
@@ -16,10 +16,11 @@ import (
 // (TestStaticNATMappedPortWithoutMatchPortRejected). A garbage token was thus
 // treated more leniently than a valid one.
 //
-// Fail-on-revert: remove the `rule.MappedPortRaw != ""` guard in
-// validateNATHostMaskStrict (or revert staticNATMappedPortFromKeys to drop the
-// malformed-raw return) → MappedPortRaw is never surfaced → CompileConfig
-// succeeds → this test goes RED on a clean assertion.
+// Fail-on-revert: neutralize the unified presence gate in
+// validateNATHostMaskStrict (`rule.MappedPortPresent && (MappedPort < 1 ||
+// MappedPort > 65535)`) or revert staticNATMappedPortFromKeys to drop the
+// presence/raw returns → the malformed token is never surfaced →
+// CompileConfig succeeds → this test goes RED on a clean assertion.
 func TestStaticNATMappedPortMalformedRejected(t *testing.T) {
 	tree := &ConfigTree{}
 	lines := []string{
@@ -92,5 +93,156 @@ func TestStaticNATMappedPortMalformedLenientWarns(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected a lenient warning naming the malformed mapped-port, got %v", cfg.Warnings)
+	}
+}
+
+// buildMappedPortTree assembles a static-NAT rule tree from the shared base
+// lines plus the case-specific tail lines, using the flat-set ParseSetCommand
+// + SetPath idiom (NOT NewParser, which merges newline-separated set lines).
+func buildMappedPortTree(t *testing.T, tail []string) *ConfigTree {
+	t.Helper()
+	base := []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+	}
+	tree := &ConfigTree{}
+	for _, line := range append(append([]string{}, base...), tail...) {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+// TestStaticNATMappedPortPresenceGate is the #6479 fold: Codex found the
+// C179-038 fix (a `MappedPortRaw string` + a strict reject for a NON-EMPTY raw
+// token) left three sentinel-collision siblings SILENTLY ACCEPTED (strict
+// reject=false, no warning), all the same class as C179-038 — a PRESENT
+// mapped-port that becomes a no-port-translation 1:1 with no diagnostic:
+//
+//   - `mapped-port 0`  — Atoi("0")==(0,nil) → MappedPort==0 (the "absent"
+//     sentinel), so the `MappedPort != 0` range gate was skipped even though 0
+//     is outside the advertised 1-65535.
+//   - `mapped-port ""` — the quoted-empty operand is a real retained token but
+//     Atoi("")=err → MappedPortRaw=="" (the "absent" sentinel), so the
+//     `MappedPortRaw != ""` gate was skipped.
+//   - bare `mapped-port` (no operand) — the keyword-present-with-no-value case
+//     set nothing at all.
+//
+// The fold adds an explicit MappedPortPresent signal (set whenever the
+// keyword appears, regardless of operand) so ONE unified gate —
+// `MappedPortPresent && (MappedPort < 1 || MappedPort > 65535)` — rejects every
+// present-but-not-valid-1-65535 mapped-port and names the offending token
+// (MappedPortRaw, or "(missing value)" for the empty/bare cases). A valid
+// in-range port with a matching `match destination-port`, and an absent
+// mapped-port, are still accepted; the lenient load / peer-sync path (#1960
+// no-brick) downgrades the reject to a warning and keeps MappedPort==0 for a
+// truly-malformed token so the dataplane installs a plain 1:1.
+//
+// Coverage spans BOTH AST shapes reachable from flat-set: the collapsed
+// single-line form (`... prefix <ip> mapped-port <tok>` folds onto the prefix
+// leaf's Keys) and the hierarchical sibling form (two `then static-nat` set
+// lines build a `static-nat { prefix X; mapped-port P; }` node with distinct
+// children, exercising the compiler's t.FindChild("mapped-port") path).
+//
+// Fail-on-revert: guard the unified presence gate false (keep the fields read)
+// → the 0 / "" / bare / 70000 / sibling cases all go RED on clean assertions.
+func TestStaticNATMappedPortPresenceGate(t *testing.T) {
+	// flat is a single collapsed `then static-nat prefix <ip> <tail>` set line.
+	flat := func(tail string) []string {
+		return []string{"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 " + tail}
+	}
+	// flatMatch pairs a `match destination-port` with the collapsed then-line so
+	// an in-range or out-of-range NUMERIC port is isolated from the separate
+	// mapped-port-without-match-port gate.
+	flatMatch := func(tail string) []string {
+		return []string{
+			"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 " + tail,
+		}
+	}
+	// sibling emits two separate `then static-nat` set lines so the parser
+	// builds the hierarchical sibling shape (prefix + mapped-port as distinct
+	// children of static-nat) rather than collapsing onto one leaf's Keys.
+	sibling := func(val string) []string {
+		return []string{
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat mapped-port " + val,
+		}
+	}
+
+	cases := []struct {
+		name        string
+		tail        []string
+		wantReject  bool
+		wantSubstr  string // token / placeholder the strict error + lenient warning must name
+		wantMapZero bool   // lenient path must keep MappedPort==0 (truly-malformed)
+	}{
+		// Collapsed single-line (flat) malformed — the sentinel-collision core.
+		{"flatZero", flat("mapped-port 0"), true, `"0"`, true},
+		{"flatEmpty", flat(`mapped-port ""`), true, "(missing value)", true},
+		{"flatBare", flat("mapped-port"), true, "(missing value)", true},
+		{"flatNonNumeric", flat("mapped-port notaport"), true, `"notaport"`, true},
+		// Numeric but out of range — carries a match-port so only the range gate
+		// fires. MappedPort parses to 70000 (not zeroed), so wantMapZero=false.
+		{"flatOutOfRange", flatMatch("mapped-port 70000"), true, `"70000"`, false},
+		// Hierarchical sibling malformed — the FindChild("mapped-port") path.
+		{"siblingNonNumeric", sibling("notaport"), true, `"notaport"`, true},
+		{"siblingZero", sibling("0"), true, `"0"`, true},
+		// Accepted: a valid in-range port WITH a matching match destination-port.
+		{"validWithMatchPort", flatMatch("mapped-port 8080"), false, "", false},
+		// Accepted: no mapped-port keyword at all (plain host 1:1).
+		{"absent", []string{"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32"}, false, "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Strict commit-check.
+			_, err := CompileConfig(buildMappedPortTree(t, tc.tail))
+			if tc.wantReject {
+				if err == nil {
+					t.Fatalf("strict CompileConfig must reject %s", tc.name)
+				}
+				if !strings.Contains(err.Error(), "mapped-port") {
+					t.Fatalf("strict error must mention mapped-port, got %v", err)
+				}
+				if tc.wantSubstr != "" && !strings.Contains(err.Error(), tc.wantSubstr) {
+					t.Fatalf("strict error must name %s, got %v", tc.wantSubstr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("strict CompileConfig must accept %s, got %v", tc.name, err)
+			}
+
+			// Lenient load / peer-sync path (#1960 no-brick).
+			cfg, errL := CompileConfigLenient(buildMappedPortTree(t, tc.tail))
+			if errL != nil {
+				t.Fatalf("lenient compile must not hard-error for %s, got %v", tc.name, errL)
+			}
+			if tc.wantReject {
+				var found bool
+				for _, w := range cfg.Warnings {
+					if strings.Contains(w, "mapped-port") && strings.Contains(w, tc.wantSubstr) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("lenient path must warn naming %s for %s, got %v", tc.wantSubstr, tc.name, cfg.Warnings)
+				}
+			}
+			if tc.wantMapZero {
+				if len(cfg.Security.NAT.Static) != 1 || len(cfg.Security.NAT.Static[0].Rules) != 1 {
+					t.Fatalf("expected exactly 1 static NAT rule for %s", tc.name)
+				}
+				if got := cfg.Security.NAT.Static[0].Rules[0].MappedPort; got != 0 {
+					t.Fatalf("lenient path must keep MappedPort==0 (no bogus port) for %s, got %d", tc.name, got)
+				}
+			}
+		})
 	}
 }

--- a/pkg/config/static_nat_mapped_port_multiblock_6479_test.go
+++ b/pkg/config/static_nat_mapped_port_multiblock_6479_test.go
@@ -189,6 +189,55 @@ func TestStaticNATMappedPortMultiBlockPrefixSibling6479(t *testing.T) {
 	}
 }
 
+// TestStaticNATMappedPortMultiBlockBareThenValidProvenance6479 pins the #6479
+// diagnostic-provenance fix in mergeMappedPortState. When a bare/empty malformed
+// sibling latches the rule fail-closed (present, MappedPort==0, raw=="" =
+// "(missing value)"), a LATER VALID sibling (`mapped-port 9090`) must NOT
+// backfill its token into MappedPortRaw: the strict gate must still report the
+// true "(missing value)" diagnostic, not `mapped-port "9090"`. Before the fix the
+// unconditional raw-backfill in the failClosed branch captured the valid
+// operand's token, misnaming the error. Parent-RED: dropping the `port == 0`
+// guard on that backfill makes this go RED (the error names "9090").
+func TestStaticNATMappedPortMultiBlockBareThenValidProvenance6479(t *testing.T) {
+	// Sibling 1: a bare `mapped-port;` (no operand) — present-but-malformed with an
+	// empty raw ("(missing value)"). Sibling 2: a VALID `mapped-port 9090`. The
+	// bare sibling latches fail-closed; the valid sibling must not rewrite the
+	// provenance token. hierRuleV4AB carries NO match destination-port, so the
+	// present-but-malformed gate (MappedPort==0) is the only defect that fires.
+	tree := buildHier(t, hierRuleV4AB(
+		`                        static-nat { prefix 10.0.0.5/32 { mapped-port; } }
+                        static-nat { prefix 10.0.0.6/32 { mapped-port 9090; } }`))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("bare-then-valid multi-block must reject fail-closed (the bare sibling is malformed)")
+	}
+	if !strings.Contains(err.Error(), "(missing value)") {
+		t.Fatalf("diagnostic must name the bare sibling's \"(missing value)\", got %v", err)
+	}
+	if strings.Contains(err.Error(), "9090") {
+		t.Fatalf("the later VALID sibling's token 9090 must NOT backfill the diagnostic, got %v", err)
+	}
+	// Lenient path mirrors the diagnostic in a warning and installs no bogus port.
+	cfg, errL := CompileConfigLenient(tree)
+	if errL != nil {
+		t.Fatalf("lenient compile must not hard-error, got %v", errL)
+	}
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.MappedPort != 0 {
+		t.Fatalf("fail-closed rule must keep MappedPort==0 (no bogus port), got %d", rule.MappedPort)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "(missing value)") && !strings.Contains(w, "9090") {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatalf("lenient warning must name \"(missing value)\" and not 9090, got %v", cfg.Warnings)
+	}
+}
+
 // TestStaticNATMappedPortMultiBlockAccept6479 is the INVARIANT B guard: a clean
 // sibling target must NOT silently clear a VALID mapped-port set by another
 // sibling, and among valid siblings the LAST valid port wins. (Before the fix the

--- a/pkg/config/static_nat_mapped_port_multiblock_6479_test.go
+++ b/pkg/config/static_nat_mapped_port_multiblock_6479_test.go
@@ -1,0 +1,283 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file closes the #6479 FINAL hostile-review finding: the MULTI-BLOCK
+// (sibling-target) silent-accept. A single `then {}` block may carry several
+// `static-nat` sibling targets (the hierarchical `then { static-nat {…}
+// static-nat {…} }` shape). Junos merges those siblings into one action, so a
+// `mapped-port` on ANY sibling is part of that action. Before this fix the child
+// loop in compileNATStatic ASSIGNED the mapped-port state per sibling target, so
+// a LATER clean sibling's (0,"",false) reading OVERWROTE an earlier sibling's
+// malformed/presence stamp — reopening the C179-038 silent-accept for the
+// multi-block shape, in BOTH the nptv6 and the non-nptv6 branches:
+//
+//   then {
+//       static-nat { nptv6-prefix 2001:db8:1::/64 { mapped-port notaport; } }
+//       static-nat { prefix 2001:db8:2::/64; }   // clears MappedPortPresent
+//   }
+//
+// compiled clean (MappedPortPresent ended false → validateNPTv6Strict never
+// fired). The fix folds each sibling through mergeMappedPortState so presence
+// OR-accumulates and a malformed operand latches fail-closed regardless of a
+// later clean sibling, in either target order and mixed with prefix-name.
+//
+// The invariants are the same two the shapes file pins:
+//
+//   INVARIANT A (security, absolute): NO multi-block authoring shape may SILENTLY
+//     ACCEPT a present-but-malformed mapped-port. Every malformed sibling fails
+//     closed (strict error / lenient warning) with MappedPort==0.
+//   INVARIANT B (no regression): a VALID mapped-port on one sibling is NOT
+//     silently cleared by a clean sibling, and among valid siblings last-wins.
+//
+// The sibling shapes below are authored hierarchically (buildHier): the flat-set
+// `set` form of the same lines collapses onto ONE static-nat node whose children
+// staticNATMappedPortForNode already folds (covered by the shapes-matrix file);
+// the multi-static-nat-sibling AST only arises from a hierarchical `then` block.
+
+// hierRuleV6 wraps a nptv6-matching IPv6 rule body (external match /64) around
+// the given `then {}` inner text.
+func hierRuleV6(thenInner string) string {
+	return `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 2001:db8:9::/64; }
+                    then {
+` + thenInner + `
+                    }
+                }
+            }
+        }
+    }
+}`
+}
+
+// hierRuleV4AB wraps an IPv4 host-match rule body (NO match destination-port, so
+// a malformed mapped-port is the only defect) with a global address-book entry
+// MP_TARGET for the prefix-name shapes.
+func hierRuleV4AB(thenInner string) string {
+	return `security {
+    address-book { global { address MP_TARGET 10.0.0.9/32; } }
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 203.0.113.1/32; }
+                    then {
+` + thenInner + `
+                    }
+                }
+            }
+        }
+    }
+}`
+}
+
+// TestStaticNATMappedPortMultiBlockNPTv6Sibling6479 pins the nptv6 multi-block
+// sibling shapes: a malformed (or even valid) nptv6 mapped-port carried by one
+// sibling must reject on PRESENCE regardless of a clean sibling target in either
+// order, and mixed with a prefix-name target. This is the exact silent-accept the
+// fix closes (the clean sibling used to clear MappedPortPresent).
+func TestStaticNATMappedPortMultiBlockNPTv6Sibling6479(t *testing.T) {
+	cases := []struct {
+		name  string
+		inner string
+	}{
+		{
+			// nptv6 MALFORMED first, clean matching-length prefix second — the
+			// prefix sibling used to clear the stamp AND leave a matching-length
+			// Then so no length error masked the drop. The pure silent-accept.
+			name: "nptv6-malformed-then-prefix",
+			inner: `                        static-nat { nptv6-prefix 2001:db8:1::/64 { mapped-port notaport; } }
+                        static-nat { prefix 2001:db8:2::/64; }`,
+		},
+		{
+			// nptv6 MALFORMED first, clean prefix-NAME second (472/478 path).
+			name: "nptv6-malformed-then-prefix-name",
+			inner: `                        static-nat { nptv6-prefix 2001:db8:1::/64 { mapped-port 70000; } }
+                        static-nat { prefix-name MP6; }`,
+		},
+		{
+			// Clean prefix first, nptv6 MALFORMED second (opposite order).
+			name: "prefix-then-nptv6-malformed",
+			inner: `                        static-nat { prefix 2001:db8:2::/64; }
+                        static-nat { nptv6-prefix 2001:db8:1::/64 { mapped-port notaport; } }`,
+		},
+		{
+			// A VALID nptv6 mapped-port is still meaningless (RFC 6296) — reject on
+			// presence even though a clean prefix sibling follows.
+			name: "nptv6-valid-then-prefix",
+			inner: `                        static-nat { nptv6-prefix 2001:db8:1::/64 { mapped-port 8080; } }
+                        static-nat { prefix 2001:db8:2::/64; }`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assertNPTv6MappedPortReject(t, func() *ConfigTree {
+				cfg := c.inner
+				// The prefix-name case needs a global address-book /64 entry named
+				// MP6 whose prefix matches the external match length.
+				body := `security {
+    address-book { global { address MP6 2001:db8:2::/64; } }
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 2001:db8:9::/64; }
+                    then {
+` + cfg + `
+                    }
+                }
+            }
+        }
+    }
+}`
+				return buildHier(t, body)
+			})
+		})
+	}
+}
+
+// TestStaticNATMappedPortMultiBlockPrefixSibling6479 pins the NON-nptv6 multi-
+// block sibling shapes: a malformed mapped-port on one prefix/prefix-name sibling
+// must fail closed (naming the token) even with NO `match destination-port` and a
+// clean sibling target following — the non-nptv6 analogue the fix must not leave
+// open.
+func TestStaticNATMappedPortMultiBlockPrefixSibling6479(t *testing.T) {
+	cases := []struct {
+		name  string
+		inner string
+	}{
+		{
+			name: "prefix-malformed-then-clean-prefix",
+			inner: `                        static-nat { prefix 10.0.0.5/32 { mapped-port notaport; } }
+                        static-nat { prefix 10.0.0.6/32; }`,
+		},
+		{
+			name: "clean-prefix-then-prefix-malformed",
+			inner: `                        static-nat { prefix 10.0.0.6/32; }
+                        static-nat { prefix 10.0.0.5/32 { mapped-port notaport; } }`,
+		},
+		{
+			name: "prefix-malformed-then-clean-prefix-name",
+			inner: `                        static-nat { prefix 10.0.0.5/32 { mapped-port notaport; } }
+                        static-nat { prefix-name MP_TARGET; }`,
+		},
+		{
+			name: "prefix-name-malformed-then-clean-prefix",
+			inner: `                        static-nat { prefix-name MP_TARGET { mapped-port notaport; } }
+                        static-nat { prefix 10.0.0.6/32; }`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assertMappedPortReject(t, func() *ConfigTree {
+				return buildHier(t, hierRuleV4AB(c.inner))
+			}, `"notaport"`)
+		})
+	}
+}
+
+// TestStaticNATMappedPortMultiBlockAccept6479 is the INVARIANT B guard: a clean
+// sibling target must NOT silently clear a VALID mapped-port set by another
+// sibling, and among valid siblings the LAST valid port wins. (Before the fix the
+// per-sibling overwrite dropped the valid port to a plain 1:1.)
+func TestStaticNATMappedPortMultiBlockAccept6479(t *testing.T) {
+	// A valid mapped-port on the first sibling survives a clean second sibling.
+	t.Run("valid-then-clean-sibling-keeps-port", func(t *testing.T) {
+		tree := buildHier(t, `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 203.0.113.1/32; destination-port 8080; }
+                    then {
+                        static-nat { prefix 10.0.0.5/32 { mapped-port 9090; } }
+                        static-nat { prefix 10.0.0.5/32; }
+                    }
+                }
+            }
+        }
+    }
+}`)
+		assertMappedPortAccept(t, tree, 9090)
+	})
+
+	// Two valid siblings: last-valid-wins (9090), matching combineMappedPort-
+	// Operands' duplicate-stanza last-wins across sibling targets.
+	t.Run("two-valid-siblings-last-wins", func(t *testing.T) {
+		tree := buildHier(t, `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 203.0.113.1/32; destination-port 8080; }
+                    then {
+                        static-nat { prefix 10.0.0.5/32 { mapped-port 8081; } }
+                        static-nat { prefix 10.0.0.5/32 { mapped-port 9090; } }
+                    }
+                }
+            }
+        }
+    }
+}`)
+		assertMappedPortAccept(t, tree, 9090)
+	})
+}
+
+// TestStaticNATMappedPortMultiThenBlockBoundary6479 documents the boundary with
+// #3850: SEPARATE `then {}` blocks are last-then-block-wins (a superseded whole
+// block is dead config, not part of the effective action), so a malformed
+// mapped-port in a superseded first `then` block does not gate the clean final
+// block. This is DISTINCT from the sibling-target case above (siblings within one
+// `then` are a merged live action and DO accumulate). Pinned so a future change
+// to the per-then-block reset is a conscious decision, not an accident.
+func TestStaticNATMappedPortMultiThenBlockBoundary6479(t *testing.T) {
+	// Two separate then blocks: first carries a malformed nptv6 mapped-port, the
+	// second is a clean prefix target. Last-then-block-wins → the effective rule
+	// is the clean prefix; the superseded nptv6 block (and its mapped-port) is
+	// dead config. Compiles clean.
+	tree := buildHier(t, `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 203.0.113.1/32; }
+                    then { static-nat { nptv6-prefix 2001:db8:1::/64 { mapped-port notaport; } } }
+                    then { static-nat { prefix 10.0.0.6/32; } }
+                }
+            }
+        }
+    }
+}`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("last-then-block-wins: clean final then block must compile, got %v", err)
+	}
+	r := cfg.Security.NAT.Static[0].Rules[0]
+	if r.IsNPTv6 || r.Then != "10.0.0.6/32" || r.MappedPortPresent || r.MappedPort != 0 {
+		t.Fatalf("effective rule must be the clean final then block (prefix 10.0.0.6/32, no mapped-port), got IsNPTv6=%v Then=%q present=%v port=%d",
+			r.IsNPTv6, r.Then, r.MappedPortPresent, r.MappedPort)
+	}
+	// Sanity: the token must not leak into a warning either (it is dead config).
+	if strings.Contains(strings.Join(cfg.Warnings, "\n"), "notaport") {
+		t.Fatalf("superseded then-block token must not surface, got warnings %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/static_nat_mapped_port_shapes_5523_test.go
+++ b/pkg/config/static_nat_mapped_port_shapes_5523_test.go
@@ -349,6 +349,32 @@ func TestStaticNATMappedPortNPTv65523(t *testing.T) {
 				"set security nat static rule-set rs1 rule r1 then static-nat mapped-port notaport")
 		})
 	})
+	// Canonical separate-set-line: the nptv6-prefix keyword is RESTATED on the
+	// mapped-port line (`nptv6-prefix <p6>` + `nptv6-prefix mapped-port <port>`).
+	// SetPath merges both lines onto one static-nat node with two nptv6-prefix
+	// children, the second being Keys=["nptv6-prefix","mapped-port","<port>"] — so
+	// `mapped-port` immediately follows the literal `nptv6-prefix` keyword. This
+	// was the LAST residual C179-038 silent-accept: while `nptv6-prefix` sat in the
+	// name-valued skip set the modifier was discarded before it reached
+	// recordNPTv6MappedPortPresence, so validateNPTv6Strict never fired and BOTH a
+	// malformed and a well-formed port were silently accepted. It is the exact
+	// sibling of the round-5 `prefix mapped-port` fix; both must now reject on
+	// presence. Parent-RED: re-adding "nptv6-prefix" to mappedPortNameValuedKeywords
+	// makes these two subtests go RED (the silent-accept returns).
+	t.Run("canonical-separate-valid-rejects", func(t *testing.T) {
+		assertNPTv6MappedPortReject(t, func() *ConfigTree {
+			return natBaseZoneV6Tree(t,
+				"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:1::/64",
+				"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix mapped-port 8080")
+		})
+	})
+	t.Run("canonical-separate-malformed-rejects", func(t *testing.T) {
+		assertNPTv6MappedPortReject(t, func() *ConfigTree {
+			return natBaseZoneV6Tree(t,
+				"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:1::/64",
+				"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix mapped-port notaport")
+		})
+	})
 	// Hierarchical: nptv6-prefix block with a nested mapped-port.
 	t.Run("hierarchical-valid-rejects", func(t *testing.T) {
 		assertNPTv6MappedPortReject(t, func() *ConfigTree {

--- a/pkg/config/static_nat_mapped_port_shapes_5523_test.go
+++ b/pkg/config/static_nat_mapped_port_shapes_5523_test.go
@@ -1,0 +1,383 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file closes the #6479 hostile-review shape-completeness findings for
+// static-NAT `then static-nat ... mapped-port`. Round after round of the
+// C179-038 work fixed the shape it was looking at and missed another; the final
+// review round flagged five more authoring shapes. Each is pinned here against
+// two bounded, checkable invariants:
+//
+//   INVARIANT A (security, absolute): in NO authoring shape may a present-but-
+//     malformed mapped-port be SILENTLY ACCEPTED (compile clean, MappedPort==0,
+//     no error and no lenient warning). Every shape that carries a malformed
+//     operand fails closed (strict error / lenient warning), and no shape ever
+//     installs a bogus NON-zero port.
+//   INVARIANT B (no regression vs origin/master): a config master compiled clean
+//     is not newly false-rejected, and a valid mapped-port's resolved value is
+//     unchanged — EXCEPT where master itself had the C179-038 silent-accept bug.
+//
+// The five shapes, and their resolution:
+//
+//   S1  prefix-name separate-set-line: `prefix-name N` then `prefix-name
+//       mapped-port P` (name NOT restated). The lexer parses `prefix-name
+//       mapped-port P` as prefix-name="mapped-port" + a trailing token — a
+//       name-slot collision, not a modifier — so the port is NOT recovered and
+//       MappedPort stays 0 (a plain prefix-name 1:1, no bogus port). The
+//       SUPPORTED separate-line form restates the name (`prefix-name N
+//       mapped-port P`), which DOES recover + gate the port. Matches master.
+//   S2  hierarchical `prefix-name N { mapped-port P; }`: the nested mapped-port
+//       is collected + gated (valid accepts with P, malformed rejects).
+//   S3  modifier-first ordering `prefix mapped-port P` before `prefix <ip>`: the
+//       modifier line's `prefix` keyword takes the value "mapped-port", so the
+//       target resolves to the literal "mapped-port" — an invalid IP — and the
+//       rule fails closed on the target. Never a silent accept. Matches master.
+//   S4  port range / trailing tokens: a range operand (`mapped-port 8080-8090`)
+//       is a single non-numeric token → rejected. A valid single port followed
+//       by a legitimate trailing modifier (`mapped-port 8080 routing-instance
+//       X`) accepts with the port AND captures the modifier — the mapped-port
+//       operand is the single immediately-following token.
+//   S5  NPTv6 + mapped-port: NPTv6 (RFC 6296) translates the address prefix and
+//       has no port concept. A mapped-port in ANY nptv6 shape is rejected on
+//       PRESENCE (the value is irrelevant). This closes both the malformed
+//       silent-accept and the valid silent-ignore that master left open (the
+//       host-mask loop skips nptv6 rules entirely).
+
+// natBaseZoneV6Tree is the shared IPv6 flat-set prologue for NPTv6 shapes: a
+// zone + a static rule-set whose rule matches an internal IPv6 /64. The NPTv6
+// external prefix length must equal the match length, and /64 is a supported
+// nptv6 length, so a mapped-port is the ONLY defect — the nptv6-no-mapped-port
+// gate is not masked by a length-mismatch or unsupported-length error.
+func natBaseZoneV6Tree(t *testing.T, extra ...string) *ConfigTree {
+	t.Helper()
+	base := []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 2001:db8:9::/64",
+	}
+	tree := &ConfigTree{}
+	for _, line := range append(append([]string{}, base...), extra...) {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+// assertNPTv6MappedPortReject asserts the #5523/#6479 nptv6-no-mapped-port gate:
+// strict hard-errors with the nptv6 message; lenient warns; and — critically —
+// the compiled rule stays IsNPTv6 with MappedPort==0 (no bogus port reaches the
+// port-less nptv6 dataplane path; the prefix translation itself still applies).
+func assertNPTv6MappedPortReject(t *testing.T, build func() *ConfigTree) {
+	t.Helper()
+	_, err := CompileConfig(build())
+	if err == nil {
+		t.Fatalf("strict CompileConfig must reject nptv6 + mapped-port")
+	}
+	if !strings.Contains(err.Error(), "nptv6-prefix does not support mapped-port") {
+		t.Fatalf("strict error must be the nptv6-no-mapped-port message, got %v", err)
+	}
+	cfg, errL := CompileConfigLenient(build())
+	if errL != nil {
+		t.Fatalf("lenient compile must not hard-error, got %v", errL)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "nptv6-prefix does not support mapped-port") {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatalf("lenient path must warn nptv6-no-mapped-port, got %v", cfg.Warnings)
+	}
+	if len(cfg.Security.NAT.Static) == 1 && len(cfg.Security.NAT.Static[0].Rules) == 1 {
+		r := cfg.Security.NAT.Static[0].Rules[0]
+		if !r.IsNPTv6 {
+			t.Fatalf("nptv6 rule must remain nptv6 on the lenient path")
+		}
+		if r.MappedPort != 0 {
+			t.Fatalf("nptv6 rule must keep MappedPort==0 (no bogus port), got %d", r.MappedPort)
+		}
+	}
+}
+
+// --- S1: prefix-name separate-set-line -------------------------------------
+
+// TestStaticNATMappedPortPrefixNameSeparateLine5523 pins both the SUPPORTED
+// separate-line form (name restated → port recovered + gated) and the ambiguous
+// name-NOT-restated form (port not recovered, target resolved, no bogus port).
+func TestStaticNATMappedPortPrefixNameSeparateLine5523(t *testing.T) {
+	// Supported: the name is RESTATED on the mapped-port line, so `mapped-port`
+	// is NOT in name-slot position (it follows the NAME value MP_TARGET) and the
+	// port is recovered + gated.
+	t.Run("name-restated-recovers-port", func(t *testing.T) {
+		cfg, err := CompileConfig(buildFlat(t,
+			"set security address-book global address MP_TARGET 10.0.0.5/32",
+			"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name MP_TARGET",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name MP_TARGET mapped-port 8080"))
+		if err != nil {
+			t.Fatalf("name-restated separate-line form must accept a valid port, got %v", err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.ThenPrefixName != "MP_TARGET" || rule.Then != "10.0.0.5/32" {
+			t.Fatalf("target must resolve to MP_TARGET/10.0.0.5/32, got name=%q then=%q", rule.ThenPrefixName, rule.Then)
+		}
+		if !rule.MappedPortPresent || rule.MappedPort != 8080 {
+			t.Fatalf("restated form must recover mapped-port 8080 (present=%v port=%d)", rule.MappedPortPresent, rule.MappedPort)
+		}
+	})
+
+	// Supported form, MALFORMED port → fail closed naming the token.
+	t.Run("name-restated-malformed-rejects", func(t *testing.T) {
+		assertMappedPortReject(t, func() *ConfigTree {
+			return buildFlat(t,
+				"set security address-book global address MP_TARGET 10.0.0.5/32",
+				"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+				"set security nat static rule-set rs1 rule r1 then static-nat prefix-name MP_TARGET",
+				"set security nat static rule-set rs1 rule r1 then static-nat prefix-name MP_TARGET mapped-port notaport")
+		}, `"notaport"`)
+	})
+
+	// Ambiguous name-NOT-restated form: `prefix-name mapped-port P` parses
+	// prefix-name="mapped-port" + trailing P. The target resolves from the FIRST
+	// child (MP_TARGET) and NO mapped-port is recovered — MappedPort stays 0 (a
+	// plain prefix-name 1:1). No malformed port is ever installed (INVARIANT A).
+	// This is the pre-existing == master behaviour: the ambiguous name-slot form
+	// is not a supported way to attach a port; the restated form above is.
+	for _, p := range []string{"8080", "notaport", "0"} {
+		p := p
+		t.Run("name-not-restated-installs-no-bogus-port-P="+p, func(t *testing.T) {
+			// WITHOUT a match destination-port so nothing external forces a
+			// reject: this is the purest silent-accept probe. It must compile
+			// clean AND install NO port (MappedPort==0) — never a bogus port.
+			cfg, err := CompileConfigLenient(buildFlat(t,
+				"set security address-book global address MP_TARGET 10.0.0.5/32",
+				"set security nat static rule-set rs1 rule r1 then static-nat prefix-name MP_TARGET",
+				"set security nat static rule-set rs1 rule r1 then static-nat prefix-name mapped-port "+p))
+			if err != nil {
+				t.Fatalf("lenient compile must not hard-error, got %v", err)
+			}
+			rule := cfg.Security.NAT.Static[0].Rules[0]
+			if rule.ThenPrefixName != "MP_TARGET" {
+				t.Fatalf("target must resolve from the first child (MP_TARGET), got %q", rule.ThenPrefixName)
+			}
+			if rule.MappedPort != 0 {
+				t.Fatalf("INVARIANT A: the ambiguous name-slot form must install NO port (MappedPort==0), got %d", rule.MappedPort)
+			}
+		})
+	}
+}
+
+// --- S2: hierarchical prefix-name with a nested mapped-port ----------------
+
+// TestStaticNATMappedPortHierPrefixName5523 covers `prefix-name N { mapped-port
+// P; }` — a valid nested port accepts and resolves; a malformed one fails closed
+// naming the token. The nested mapped-port is collected via the target-child's
+// grandchild scan in staticNATMappedPortForNode.
+func TestStaticNATMappedPortHierPrefixName5523(t *testing.T) {
+	build := func(op string) *ConfigTree {
+		return buildHier(t, `security {
+    zones { security-zone untrust; }
+    address-book { global { address MP_TARGET 10.0.0.5/32; } }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 203.0.113.1/32; destination-port 8080; }
+                    then { static-nat { prefix-name MP_TARGET { mapped-port `+op+`; } } }
+                }
+            }
+        }
+    }
+}`)
+	}
+	t.Run("valid-accepts", func(t *testing.T) {
+		cfg, err := CompileConfig(build("8080"))
+		if err != nil {
+			t.Fatalf("hier prefix-name { mapped-port 8080 } must accept, got %v", err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.Then != "10.0.0.5/32" || rule.MappedPort != 8080 {
+			t.Fatalf("want then=10.0.0.5/32 port=8080, got then=%q port=%d", rule.Then, rule.MappedPort)
+		}
+	})
+	for _, m := range []struct{ op, token string }{
+		{"notaport", `"notaport"`},
+		{"0", `"0"`},
+		{"70000", `"70000"`},
+	} {
+		m := m
+		t.Run("malformed-"+m.op+"-rejects", func(t *testing.T) {
+			assertMappedPortReject(t, func() *ConfigTree { return build(m.op) }, m.token)
+		})
+	}
+}
+
+// --- S3: modifier-first ordering -------------------------------------------
+
+// TestStaticNATMappedPortModifierFirst5523 covers the `prefix mapped-port P` set
+// line authored BEFORE the `prefix <ip>` line. The modifier line's `prefix`
+// keyword takes the value "mapped-port" (a distinct prefix child), so FindChild
+// resolves the target to the literal "mapped-port" — an invalid IP — and the
+// rule FAILS CLOSED on the target in EVERY case (the whole rule is dropped by
+// the dataplane, so any port it carries never installs). Never a silent accept.
+// Matches origin/master (which also resolves the target to "mapped-port" and
+// rejects on it). The port operand itself may be valid (8080) or malformed
+// (notaport); it is the TARGET that is unrecoverable in this ordering, so the
+// fail-closed proof is the invalid-target rejection, not the port value.
+func TestStaticNATMappedPortModifierFirst5523(t *testing.T) {
+	build := func(op string) *ConfigTree {
+		return buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix mapped-port "+op,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32")
+	}
+	for _, op := range []string{"8080", "notaport", "0"} {
+		op := op
+		t.Run("rejects-invalid-target-P="+op, func(t *testing.T) {
+			_, err := CompileConfig(build(op))
+			if err == nil {
+				t.Fatalf("modifier-first ordering must fail closed (invalid target), P=%s", op)
+			}
+			// The target resolved to the literal "mapped-port" (not an IP), so
+			// the rule is rejected on the target in strict mode.
+			if !strings.Contains(err.Error(), `prefix "mapped-port"`) {
+				t.Fatalf("strict error must name the invalid target prefix \"mapped-port\", got %v", err)
+			}
+			// On the lenient path the rule survives but carries the invalid
+			// target Then=="mapped-port", so the dataplane drops the WHOLE rule
+			// (parse_nat_prefix returns None) — whatever port it carries never
+			// installs. This is the fail-closed mechanism for this shape.
+			cfg, errL := CompileConfigLenient(build(op))
+			if errL != nil {
+				t.Fatalf("lenient compile must not hard-error, got %v", errL)
+			}
+			rule := cfg.Security.NAT.Static[0].Rules[0]
+			if rule.Then != "mapped-port" {
+				t.Fatalf("lenient rule must carry the invalid target Then==\"mapped-port\" (dataplane drops the whole rule), got %q", rule.Then)
+			}
+		})
+	}
+}
+
+// --- S4: port range / trailing tokens --------------------------------------
+
+// TestStaticNATMappedPortRangeAndTrailing5523 covers shape 4. A RANGE operand is
+// a single non-numeric token → rejected (a static-NAT mapped-port is a single
+// port, not a range). A valid single port followed by a legitimate trailing
+// modifier accepts with the port AND captures the modifier — proving the
+// mapped-port operand is the single immediately-following token, and a non-
+// numeric FIRST operand (a range) fails closed.
+func TestStaticNATMappedPortRangeAndTrailing5523(t *testing.T) {
+	// A range as the mapped-port operand fails closed, naming the token.
+	t.Run("range-rejects", func(t *testing.T) {
+		assertMappedPortReject(t, func() *ConfigTree {
+			return buildFlat(t,
+				"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+				"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 8080-8090")
+		}, `"8080-8090"`)
+	})
+
+	// A valid single port followed by a legitimate `routing-instance` modifier:
+	// the port is recovered (8080) AND the routing-instance is captured. The
+	// mapped-port operand is the single token after `mapped-port`; a trailing
+	// modifier is NOT folded into the port (so it is not a bogus-truncation).
+	t.Run("valid-port-plus-trailing-modifier-accepts", func(t *testing.T) {
+		cfg, err := CompileConfig(buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 8080 routing-instance blue"))
+		if err != nil {
+			t.Fatalf("valid mapped-port + trailing routing-instance must accept, got %v", err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if rule.MappedPort != 8080 {
+			t.Fatalf("mapped-port operand must be the single token 8080, got %d", rule.MappedPort)
+		}
+		if rule.ThenRoutingInstance != "blue" {
+			t.Fatalf("trailing routing-instance must be captured as blue, got %q", rule.ThenRoutingInstance)
+		}
+	})
+
+	// A non-numeric FIRST operand fails closed even when a numeric token trails
+	// it (`mapped-port notaport 8080` must NOT silently pick up 8080).
+	t.Run("non-numeric-first-operand-rejects", func(t *testing.T) {
+		assertMappedPortReject(t, func() *ConfigTree {
+			return buildFlat(t,
+				"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+				"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port notaport 8080")
+		}, `"notaport"`)
+	})
+}
+
+// --- S5: NPTv6 + mapped-port ------------------------------------------------
+
+// TestStaticNATMappedPortNPTv65523 covers shape 5 across every nptv6 authoring
+// shape: a mapped-port on an nptv6 rule is rejected on PRESENCE (the value is
+// irrelevant — nptv6 has no ports). This closes BOTH the malformed silent-accept
+// (INVARIANT A) and the valid silent-ignore that origin/master left open (the
+// host-mask loop `continue`s past every nptv6 rule). A clean nptv6 rule (no
+// mapped-port) still compiles — no false reject (INVARIANT B).
+func TestStaticNATMappedPortNPTv65523(t *testing.T) {
+	// Collapsed single-line: nptv6-prefix + mapped-port on one leaf.
+	t.Run("collapsed-valid-rejects", func(t *testing.T) {
+		assertNPTv6MappedPortReject(t, func() *ConfigTree {
+			return natBaseZoneV6Tree(t,
+				"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:1::/64 mapped-port 8080")
+		})
+	})
+	t.Run("collapsed-malformed-rejects", func(t *testing.T) {
+		assertNPTv6MappedPortReject(t, func() *ConfigTree {
+			return natBaseZoneV6Tree(t,
+				"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:1::/64 mapped-port notaport")
+		})
+	})
+	// Sibling: nptv6-prefix and mapped-port as two `then static-nat` set lines.
+	t.Run("sibling-malformed-rejects", func(t *testing.T) {
+		assertNPTv6MappedPortReject(t, func() *ConfigTree {
+			return natBaseZoneV6Tree(t,
+				"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:1::/64",
+				"set security nat static rule-set rs1 rule r1 then static-nat mapped-port notaport")
+		})
+	})
+	// Hierarchical: nptv6-prefix block with a nested mapped-port.
+	t.Run("hierarchical-valid-rejects", func(t *testing.T) {
+		assertNPTv6MappedPortReject(t, func() *ConfigTree {
+			return buildHier(t, `security {
+    zones { security-zone untrust; }
+    nat {
+        static {
+            rule-set rs1 {
+                from zone untrust;
+                rule r1 {
+                    match { destination-address 2001:db8:9::/64; }
+                    then { static-nat { nptv6-prefix 2001:db8:1::/64 { mapped-port 8080; } } }
+                }
+            }
+        }
+    }
+}`)
+		})
+	})
+	// A clean nptv6 rule (no mapped-port) still compiles — no false reject.
+	t.Run("clean-nptv6-accepts", func(t *testing.T) {
+		cfg, err := CompileConfig(natBaseZoneV6Tree(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:1::/64"))
+		if err != nil {
+			t.Fatalf("a clean nptv6 rule (no mapped-port) must accept, got %v", err)
+		}
+		rule := cfg.Security.NAT.Static[0].Rules[0]
+		if !rule.IsNPTv6 || rule.MappedPortPresent {
+			t.Fatalf("clean nptv6 rule: want IsNPTv6 && !MappedPortPresent, got nptv6=%v present=%v", rule.IsNPTv6, rule.MappedPortPresent)
+		}
+	})
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -973,6 +973,18 @@ type StaticNATRule struct {
 	// outbound return SNAT un-translates it back to MatchDestinationPort.
 	// #2491.
 	MappedPort int
+	// MappedPortRaw records the raw `then static-nat prefix <ip> mapped-port
+	// <token>` value when it FAILED to parse as a number ("" when the keyword
+	// is absent or its value is well-formed). The token rides inside the
+	// children:nil static-nat leaf and bypasses the schema value validator, so
+	// a non-numeric value would otherwise collapse silently to MappedPort==0
+	// (== "no port translation") with no diagnostic — accepted even though a
+	// well-formed value in the same position without a `match destination-port`
+	// is rejected. Strict commit-check rejects a non-empty MappedPortRaw
+	// (validateNATHostMaskStrict, C179-038); the lenient load / peer-sync path
+	// keeps MappedPort==0 so the dataplane installs a plain 1:1 (no bogus
+	// port), matching the pre-fix fail-closed behaviour.
+	MappedPortRaw string
 }
 
 // LimitSessionScreen configures per-IP session limiting.

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -974,17 +974,27 @@ type StaticNATRule struct {
 	// #2491.
 	MappedPort int
 	// MappedPortRaw records the raw `then static-nat prefix <ip> mapped-port
-	// <token>` value when it FAILED to parse as a number ("" when the keyword
-	// is absent or its value is well-formed). The token rides inside the
-	// children:nil static-nat leaf and bypasses the schema value validator, so
-	// a non-numeric value would otherwise collapse silently to MappedPort==0
-	// (== "no port translation") with no diagnostic — accepted even though a
-	// well-formed value in the same position without a `match destination-port`
-	// is rejected. Strict commit-check rejects a non-empty MappedPortRaw
-	// (validateNATHostMaskStrict, C179-038); the lenient load / peer-sync path
-	// keeps MappedPort==0 so the dataplane installs a plain 1:1 (no bogus
-	// port), matching the pre-fix fail-closed behaviour.
-	MappedPortRaw string
+	// <token>` value as authored ("" when the keyword is absent OR present
+	// with no operand). The token rides inside the children:nil static-nat
+	// leaf and bypasses the schema value validator; MappedPortRaw lets the
+	// strict gate name the offending token when the parsed MappedPort is not
+	// a valid 1-65535 port. Compile-only (`json:"-"`): it is a Go-internal
+	// diagnostic artifact and must NOT cross the control-socket / REST /
+	// ConfigSnapshot wire — the Rust dataplane reads only MappedPort.
+	MappedPortRaw string `json:"-"`
+	// MappedPortPresent is true whenever a `then static-nat mapped-port`
+	// keyword appears, EVEN with no operand or an empty/zero/garbage operand.
+	// It is the explicit presence signal that breaks the sentinel collision
+	// the string/int fields alone could not: MappedPort==0 means BOTH "absent"
+	// and "present-but-malformed" (non-numeric, empty, bare, or the literal
+	// "0"), and MappedPortRaw=="" means BOTH "absent" and "present-but-empty".
+	// The strict gate (validateNATHostMaskStrict, C179-038) rejects a PRESENT
+	// mapped-port whose parsed value is not a valid 1-65535 port; an ABSENT
+	// mapped-port (Present==false) is never rejected. Compile-only (`json:"-"`)
+	// — it is never serialized, so the dataplane never sees it and the lenient
+	// load / peer-sync path (#1960 no-brick) keeps MappedPort==0 (plain 1:1,
+	// no bogus port).
+	MappedPortPresent bool `json:"-"`
 }
 
 // LimitSessionScreen configures per-IP session limiting.


### PR DESCRIPTION
Advances #5523 (codex-179 cohort — one item, **C179-038**). The cohort
issue stays OPEN.

## Problem (C179-038)
A `then static-nat prefix <ip> mapped-port <token>` value rides inside
the children:nil `static-nat` schema leaf, so the schema value validator
never sees the token. `staticNATMappedPortFromKeys` folded BOTH an
absent `mapped-port` and a present-but-non-numeric one to a bare `0`, so:

```
set security nat static rule-set rs1 rule r1 \
    then static-nat prefix 10.0.0.5/32 mapped-port notaport
```

compiled clean to `MappedPort==0` ("no port translation") with **no
diagnostic** — even though a WELL-FORMED value in that same position
without a `match destination-port` IS rejected at strict commit-check
(the #2769 gate). Garbage was treated more leniently than a valid value.

## Fix
- `staticNATMappedPortFromKeys` now returns `(port int, malformedRaw
  string)`: a present-but-non-numeric value yields `(0, "<raw token>")`,
  distinguishing it from an absent keyword.
- **Both** parse sites record it: the collapsed-keys flat-set path
  (`staticNATMappedPortFromKeys(t.Keys)` / `(pn.Keys)`) and the
  hierarchical sibling-node path (`static-nat { prefix X; mapped-port P;
  }`), which now records a non-numeric sibling value as malformed
  instead of letting it collapse to `0`.
- New `StaticNATRule.MappedPortRaw` field carries the bad token; it is
  reset per then-block alongside the other then-set fields so a prior
  block's token cannot leak.
- `validateNATHostMaskStrict` rejects a non-empty `MappedPortRaw`.

## Strict-vs-lenient split (#1960 no-brick)
- **Strict** (commit / commit-check): hard error — `... then static-nat
  mapped-port "notaport" is not a valid port number (1-65535)`.
- **Lenient** (load / peer-sync): downgraded to a warning; the compiled
  rule keeps `MappedPort==0` so the dataplane installs a plain 1:1 (no
  bogus port), matching the pre-fix fail-closed behaviour. An
  already-persisted or peer-synced config still boots.

## Validation
- `go build ./...`, `go vet ./pkg/config/`, `gofmt -l` — all clean.
- New `TestStaticNATMappedPortMalformedRejected` (strict rejects, error
  names `mapped-port` + `notaport`) and
  `TestStaticNATMappedPortMalformedLenientWarns` (lenient warns, keeps
  `MappedPort==0`) pass; full `pkg/config` suite green.
- **Parent-RED self-check**: neutralizing the strict gate turns both
  tests RED on clean assertions (not a build break):
  - `expected CompileConfig to reject a non-numeric mapped-port`
  - `expected a lenient warning naming the malformed mapped-port, got []`

Docs: `docs/config-schema.md` updated to document the malformed-token
rejection alongside the existing #2491/#2769 mapped-port gates.
