### PR TITLE
fix(userspace): rebuild policy scheduler bits in route-overlay publish (#5328 A6-b2-F4)

### DIFF
--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1324,7 +1324,16 @@ dedicated policy-scheduler republish (`UpdatePolicyScheduleState`) does — so a
 route flap never ships a snapshot that reports success while the helper enforces
 a stale schedule window. Previously the overlay only cached the map and inherited
 the last-compiled policy sections, leaving the helper on stale bits until the next
-scheduler tick or full apply.
+scheduler tick or full apply. Both republish paths share one core
+(`rebuildScheduledPolicySectionsLocked`), which re-applies the StableZoneID zone
+quarantine's policy scrub after rebuilding `policies` from raw config (#6480): the
+raw builder has no knowledge of the quarantine and would reintroduce a policy
+referencing a quarantined zone, while the inherited `next.Zones` stays reduced —
+a dangling policy->zone reference the Rust `UnresolvableZoneReference` preflight
+rejects wholesale. Because the ip-monitoring actuator updates FRR *before* the
+publish, that reject would strand the kernel/FRR on the new routes while userspace
+kept the old FIB, unable to converge; the shared scrub keeps both paths in
+lockstep so neither can drift.
 #1377 now preserves unusable pool-mode source-NAT rules in the snapshot and
 fails closed at the `poll_descriptor.rs` source-NAT call sites for missing
 pools, empty pools, invalid pool inputs, wrong-family-only pools, or allocator

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1315,7 +1315,16 @@ Policy scheduler state is no longer a propagation gap: #1396 carries scheduler
 state into the userspace snapshot and Rust policy evaluator, and the 2026-05-19
 #1378 live artifact set validates hit-counter lifetime, strict missing-scheduler
 commit behavior, and integration/failover evidence with
-`test/incus/policy_scheduler_validate.py`.
+`test/incus/policy_scheduler_validate.py`. The **route-overlay** partial
+republish (`PublishRouteOverlaySnapshot`, the ip-monitoring actuator) co-honors
+this contract (#5328 A6-b2-F4): when the daemon hands it a live
+`scheduler.ActiveState()` it rebuilds the published snapshot's `policies` /
+`address_books` inactive bits from that map in the SAME publish — exactly as the
+dedicated policy-scheduler republish (`UpdatePolicyScheduleState`) does — so a
+route flap never ships a snapshot that reports success while the helper enforces
+a stale schedule window. Previously the overlay only cached the map and inherited
+the last-compiled policy sections, leaving the helper on stale bits until the next
+scheduler tick or full apply.
 #1377 now preserves unusable pool-mode source-NAT rules in the snapshot and
 fails closed at the `poll_descriptor.rs` source-NAT call sites for missing
 pools, empty pools, invalid pool inputs, wrong-family-only pools, or allocator

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -1333,7 +1333,20 @@ a dangling policy->zone reference the Rust `UnresolvableZoneReference` preflight
 rejects wholesale. Because the ip-monitoring actuator updates FRR *before* the
 publish, that reject would strand the kernel/FRR on the new routes while userspace
 kept the old FIB, unable to converge; the shared scrub keeps both paths in
-lockstep so neither can drift.
+lockstep so neither can drift. The shared core additionally **refuses the
+republish outright when the passed `cfg` content-differs from the inherited
+`m.lastSnapshot.Config`** (#6480), mirroring the route-overlay path's
+`routeOnlyPublishHybrid` skew guard (#5680). This closes a fold-introduced
+fail-open: during a config-skew window the daemon can reconcile the scheduler to
+the newly promoted config B (the store promotes B before applying, and the apply
+path continues on a transient dataplane error) while the OLD snapshot A is still
+live. Rebuilding + scrubbing the policies against B's quarantine set while
+inheriting A's `next.Zones` can drop a policy whose zone is still a live member of
+A's zones — a snapshot the preflight *accepts* but whose missing rule lets traffic
+fall through to the inherited default policy (a full Compile of B would instead
+drop the quarantined zone and stay fail-closed). Refusing on skew retains the
+prior snapshot and reconverges once B's full apply lands
+(`m.lastSnapshot.Config == cfg`), under the existing #3780 retry semantics.
 #1377 now preserves unusable pool-mode source-NAT rules in the snapshot and
 fails closed at the `poll_descriptor.rs` source-NAT call sites for missing
 pools, empty pools, invalid pool inputs, wrong-family-only pools, or allocator

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -441,6 +441,60 @@ func (m *Manager) publishSnapshotFailClosedLocked(publishSnap *ConfigSnapshot, s
 	return nil
 }
 
+// rebuildScheduledPolicySectionsLocked rebuilds the policy + address-book
+// sections of a partial (non-Compile) republish under a scheduler active-state
+// map and re-applies the StableZoneID zone quarantine's policy scrub so the
+// rebuilt next.Policies stays consistent with the inherited, already-reduced
+// next.Zones (#6480). It is the SHARED core of the two republish paths that
+// rebuild policies without a full Compile — PublishRouteOverlaySnapshot
+// (route-overlay) and UpdatePolicyScheduleState (scheduler-only) — so the
+// quarantine re-application can never drift between them. It mutates next in
+// place and must be called with m.mu held.
+//
+// activeState is the policy-scheduler active-state map to build the inactive
+// bits from (both callers set m.policySchedulerActive to it first, so it equals
+// m.policySchedulerActive). #2049: the cached dynamic-address feed overlay is
+// threaded through so a scheduler-state flip does not drop feed enforcement
+// until the next full apply (m.mu is held, so read m.feedOverlay directly via
+// cloneFeedOverlay rather than feedSnapshotOverlay(), which re-locks m.mu). A
+// build error is returned wrapped; both callers retain the prior snapshot
+// (fail-closed) and surface a retry.
+func (m *Manager) rebuildScheduledPolicySectionsLocked(next *ConfigSnapshot, cfg *config.Config, activeState map[string]bool) error {
+	feedOverlay := cloneFeedOverlay(m.feedOverlay)
+	// #2514: an unresolvable address-book content-ID collision must not panic the
+	// daemon — surface it as an error so the caller retains the prior snapshot.
+	policies, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeState, feedOverlay)
+	if err != nil {
+		return fmt.Errorf("policy snapshot rebuild for scheduler republish: %w", err)
+	}
+	// #6480: the raw builder re-introduces any policy referencing a
+	// StableZoneID-quarantined zone (it has no knowledge of the quarantine),
+	// while next.Zones was inherited already reduced by quarantineCollidingZones.
+	// Re-establish the same zone-isolation invariant the full build guarantees
+	// (builder.go) so no policy references a zone absent from next.Zones —
+	// otherwise the Rust UnresolvableZoneReference preflight rejects the WHOLE
+	// snapshot, and because the ip-monitoring actuator updates FRR BEFORE this
+	// publish (daemon_ipmon.go) the kernel/FRR would sit on the new routes while
+	// userspace keeps the old FIB with retries that cannot converge.
+	policies = scrubPoliciesForQuarantinedZones(policies, quarantinedZoneNamesForConfig(cfg))
+	next.Policies = policies
+	// #3261: recompute the (feed-aware) content-rejection diagnostic from the
+	// scrubbed rules' sentinels; the copied lastSnapshot value would be stale.
+	next.Capabilities.PolicyContentRejected = collectPolicyContentRejections(policies)
+	// Keep the operator-facing count equal to what is actually published, exactly
+	// as the full build does after quarantine (builder.go): Summary.PolicyCount
+	// must equal len(next.Policies).
+	next.Summary.PolicyCount = len(policies)
+	// #1606: refresh the address-book table alongside the policies so book IDs
+	// cited by the rebuilt rules always resolve dataplane-side.
+	books, _, err := buildAddressBookTableWithFeeds(cfg, feedOverlay)
+	if err != nil {
+		return fmt.Errorf("address-book rebuild for scheduler republish: %w", err)
+	}
+	next.AddressBooks = books
+	return nil
+}
+
 // UpdatePolicyScheduleState republishes the userspace policy snapshot with one
 // coherent inactive-bit view. This shadows the embedded eBPF manager method;
 // scheduled userspace policies must not update the policy_rules BPF map.
@@ -487,41 +541,18 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	next.FIBGeneration = m.readFIBGeneration()
 	next.GeneratedAt = time.Now().UTC()
 	next.Config = cfg
-	// #2049: thread the cached dynamic-address feed overlay through the
-	// scheduler-only republish so a CoS scheduler-state change does not
-	// drop feed enforcement until the next full apply. m.mu is already
-	// held here, so read m.feedOverlay directly via cloneFeedOverlay
-	// rather than feedSnapshotOverlay() (which re-locks m.mu and would
-	// deadlock). Matches how the full snapshot build reads the overlay.
-	feedOverlay := cloneFeedOverlay(m.feedOverlay)
-	// #2514: an unresolvable address-book content-ID collision must not
-	// panic the daemon. Abort the scheduler-only republish and retain the
-	// last published snapshot (fail-closed) — the next full apply will
-	// surface the same error to the operator at commit time.
-	policies, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeCopy, feedOverlay)
-	if err != nil {
+	// #6480: rebuild the schedule-affected policy + address-book sections
+	// (threading the cached feed overlay, #2049) and re-apply the StableZoneID
+	// zone quarantine's policy scrub via the shared helper, so this scheduler-only
+	// republish and the route-overlay republish stay in lockstep and neither ships
+	// a policy referencing a quarantined zone absent from the inherited next.Zones.
+	if err := m.rebuildScheduledPolicySectionsLocked(&next, cfg, activeCopy); err != nil {
 		slog.Warn("userspace: skipping policy-scheduler republish; retaining prior snapshot", "err", err)
-		// #3780: the prior snapshot is retained, which for a CLOSING
-		// window means the old permit stays live. Report failure so the
-		// transition is retried until the rebuild succeeds and converges.
-		return fmt.Errorf("userspace: policy snapshot rebuild for scheduler republish: %w", err)
+		// #3780: the prior snapshot is retained, which for a CLOSING window means
+		// the old permit stays live. Report failure so the transition is retried
+		// on the next scheduler tick until the rebuild succeeds and converges.
+		return fmt.Errorf("userspace: %w", err)
 	}
-	next.Policies = policies
-	// #3261: the policies were rebuilt, so recompute the (feed-aware)
-	// content-rejection diagnostic from the new rules' sentinels; the copied
-	// lastSnapshot value would be stale. Class (ii) (ForwardingSupported /
-	// UnsupportedReasons) is unchanged by a scheduler-only republish.
-	next.Capabilities.PolicyContentRejected = collectPolicyContentRejections(policies)
-	// #1606: refresh the address-book table alongside the policies
-	// so book IDs cited in the new policies always resolve on the
-	// dataplane side.
-	books, _, err := buildAddressBookTableWithFeeds(cfg, feedOverlay)
-	if err != nil {
-		slog.Warn("userspace: skipping policy-scheduler republish; retaining prior snapshot", "err", err)
-		// #3780: same fail-safe as the policy rebuild above — retry.
-		return fmt.Errorf("userspace: address-book rebuild for scheduler republish: %w", err)
-	}
-	next.AddressBooks = books
 
 	publishSnap := next
 	publishSnap.Neighbors = filterPublishableNeighbors(next.Neighbors)

--- a/pkg/dataplane/userspace/manager_compile.go
+++ b/pkg/dataplane/userspace/manager_compile.go
@@ -460,6 +460,31 @@ func (m *Manager) publishSnapshotFailClosedLocked(publishSnap *ConfigSnapshot, s
 // build error is returned wrapped; both callers retain the prior snapshot
 // (fail-closed) and surface a retry.
 func (m *Manager) rebuildScheduledPolicySectionsLocked(next *ConfigSnapshot, cfg *config.Config, activeState map[string]bool) error {
+	// #6480 (config-skew fail-open guard): this helper rebuilds next.Policies
+	// from cfg and scrubs them against cfg's StableZoneID quarantine set, but
+	// next.Zones / next.Interfaces were inherited verbatim from m.lastSnapshot
+	// (the APPLIED config). If cfg's zone generation differs from that applied
+	// config, the scrub can drop a policy whose to/from zone is STILL a live
+	// member of the inherited next.Zones — shipping a snapshot the Rust
+	// UnresolvableZoneReference preflight ACCEPTS yet whose missing rule lets
+	// traffic fall through to the inherited default policy (a fail-OPEN a full
+	// Compile of cfg would instead render fail-closed by ALSO dropping the
+	// quarantined zone and unzoning its interface). The route-overlay caller
+	// already refuses this exact skew at its call site (routeOnlyPublishHybrid,
+	// #5680); the scheduler-only caller (UpdatePolicyScheduleState) had no prior
+	// guard, so enforce it HERE so BOTH partial-republish paths are protected.
+	// routeOnlyPublishHybrid is parameterized on the applied config, so it doubles
+	// as the general "cfg content-differs from applied" skew predicate. next.Config
+	// was already set to cfg by both callers, so compare cfg against the INHERITED
+	// snapshot's config (m.lastSnapshot.Config), NEVER next.Config (a cfg==cfg
+	// tautology). On divergence retain the prior snapshot; the caller surfaces a
+	// retry and the next tick reconverges once cfg's full apply lands
+	// (m.lastSnapshot.Config == cfg) — the #3780 retry semantics already handle it.
+	if m.lastSnapshot != nil && routeOnlyPublishHybrid(cfg, m.lastSnapshot.Config) {
+		return fmt.Errorf("refusing scheduled-policy republish: cfg carries a zone/policy " +
+			"generation the inherited dataplane snapshot does not reflect; rebuilding and " +
+			"scrubbing against it could drop a live-zone policy and ship a fail-open snapshot (#6480)")
+	}
 	feedOverlay := cloneFeedOverlay(m.feedOverlay)
 	// #2514: an unresolvable address-book content-ID collision must not panic the
 	// daemon — surface it as an error so the caller retains the prior snapshot.

--- a/pkg/dataplane/userspace/manager_overlay.go
+++ b/pkg/dataplane/userspace/manager_overlay.go
@@ -92,8 +92,11 @@ func (m *Manager) SetFeedSnapshots(overlay map[string][]string) {
 // duplicate-skip would churn established-flow route caches for
 // nothing (Codex PR #1843 MED).
 //
-// schedulerState refreshes the policy snapshots in the same publish
-// when non-nil; nil keeps the manager's current scheduler view.
+// A non-nil schedulerState both updates the manager's cached scheduler
+// view AND rebuilds this publish's Policies / AddressBooks from it in the
+// SAME snapshot (#5328 A6-b2-F4), so the helper never enforces stale
+// schedule bits between overlay publishes; nil keeps the current view and
+// the inherited (last-compiled) policy sections.
 func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []config.RouteOverlayEntry, schedulerState map[string]bool) (published bool, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -195,6 +198,43 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 	next.Routes, err = buildRouteSnapshots(cfg, next.Interfaces, desiredOverlay)
 	if err != nil {
 		return false, fmt.Errorf("build route overlay snapshot: %w", err)
+	}
+
+	// #5328 (A6-b2-F4): when the caller supplies a policy-scheduler
+	// active-state map, refresh the policy snapshot's inactive bits from
+	// that map in THIS publish — the doc contract above promised it, and
+	// daemon_ipmon.go passes a live scheduler.ActiveState() here. Before
+	// this fix only m.policySchedulerActive was cached (above) while
+	// `next := *m.lastSnapshot` inherited the PRIOR compiled Policies /
+	// AddressBooks verbatim, so the helper enforced stale schedule bits and
+	// this publish reported success while the dataplane dropped/permitted a
+	// scheduled rule against the wrong window — until the dedicated
+	// UpdatePolicyScheduleState callback next fired (plus a redundant full
+	// reconcile). Rebuild exactly as the scheduler-only republish does
+	// (buildPolicySnapshotsWithSchedulerStateAndFeeds +
+	// collectPolicyContentRejections + buildAddressBookTableWithFeeds),
+	// reusing the cached feed overlay so a concurrent CoS scheduler flip is
+	// not dropped, and placed BEFORE the duplicate-skip hash below so a
+	// scheduler-only bit flip on unchanged routes is not falsely deduped. A
+	// nil schedulerState leaves the inherited policy sections untouched
+	// (the route-apply caller that never carries scheduler state).
+	if schedulerState != nil {
+		feedOverlay := cloneFeedOverlay(m.feedOverlay)
+		policies, perr := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, m.policySchedulerActive, feedOverlay)
+		if perr != nil {
+			return false, fmt.Errorf("build policy overlay snapshot for scheduler state: %w", perr)
+		}
+		next.Policies = policies
+		// #3261: recompute the content-rejection diagnostic from the new
+		// rules' sentinels; the copied lastSnapshot value would be stale.
+		next.Capabilities.PolicyContentRejected = collectPolicyContentRejections(policies)
+		// #1606: refresh the address-book table alongside the policies so
+		// book IDs cited by the rebuilt rules always resolve dataplane-side.
+		books, _, berr := buildAddressBookTableWithFeeds(cfg, feedOverlay)
+		if berr != nil {
+			return false, fmt.Errorf("build address-book overlay snapshot for scheduler state: %w", berr)
+		}
+		next.AddressBooks = books
 	}
 
 	// Duplicate-publish skip: identical content (e.g. the actuator ran

--- a/pkg/dataplane/userspace/manager_overlay.go
+++ b/pkg/dataplane/userspace/manager_overlay.go
@@ -200,41 +200,25 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 		return false, fmt.Errorf("build route overlay snapshot: %w", err)
 	}
 
-	// #5328 (A6-b2-F4): when the caller supplies a policy-scheduler
-	// active-state map, refresh the policy snapshot's inactive bits from
-	// that map in THIS publish — the doc contract above promised it, and
-	// daemon_ipmon.go passes a live scheduler.ActiveState() here. Before
-	// this fix only m.policySchedulerActive was cached (above) while
-	// `next := *m.lastSnapshot` inherited the PRIOR compiled Policies /
-	// AddressBooks verbatim, so the helper enforced stale schedule bits and
-	// this publish reported success while the dataplane dropped/permitted a
-	// scheduled rule against the wrong window — until the dedicated
-	// UpdatePolicyScheduleState callback next fired (plus a redundant full
-	// reconcile). Rebuild exactly as the scheduler-only republish does
-	// (buildPolicySnapshotsWithSchedulerStateAndFeeds +
-	// collectPolicyContentRejections + buildAddressBookTableWithFeeds),
-	// reusing the cached feed overlay so a concurrent CoS scheduler flip is
-	// not dropped, and placed BEFORE the duplicate-skip hash below so a
-	// scheduler-only bit flip on unchanged routes is not falsely deduped. A
-	// nil schedulerState leaves the inherited policy sections untouched
-	// (the route-apply caller that never carries scheduler state).
+	// #5328 (A6-b2-F4): when the caller supplies a policy-scheduler active-state
+	// map, refresh the policy snapshot's inactive bits from that map in THIS
+	// publish — the doc contract above promised it, and daemon_ipmon.go passes a
+	// live scheduler.ActiveState() here. Before this fix only m.policySchedulerActive
+	// was cached (above) while `next := *m.lastSnapshot` inherited the PRIOR
+	// compiled Policies / AddressBooks verbatim, so the helper enforced stale
+	// schedule bits while this publish reported success — until the dedicated
+	// UpdatePolicyScheduleState callback next fired. Rebuild exactly as the
+	// scheduler-only republish does, via the shared rebuildScheduledPolicySectionsLocked
+	// (which reuses the cached feed overlay AND re-applies the StableZoneID zone
+	// quarantine's policy scrub so a rebuilt policy never dangles against the
+	// inherited, already-reduced next.Zones — #6480). Placed BEFORE the
+	// duplicate-skip hash below so a scheduler-only bit flip on unchanged routes is
+	// not falsely deduped. A nil schedulerState leaves the inherited policy sections
+	// untouched (the route-apply caller that never carries scheduler state).
 	if schedulerState != nil {
-		feedOverlay := cloneFeedOverlay(m.feedOverlay)
-		policies, perr := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, m.policySchedulerActive, feedOverlay)
-		if perr != nil {
-			return false, fmt.Errorf("build policy overlay snapshot for scheduler state: %w", perr)
+		if err := m.rebuildScheduledPolicySectionsLocked(&next, cfg, m.policySchedulerActive); err != nil {
+			return false, fmt.Errorf("build policy overlay snapshot for scheduler state: %w", err)
 		}
-		next.Policies = policies
-		// #3261: recompute the content-rejection diagnostic from the new
-		// rules' sentinels; the copied lastSnapshot value would be stale.
-		next.Capabilities.PolicyContentRejected = collectPolicyContentRejections(policies)
-		// #1606: refresh the address-book table alongside the policies so
-		// book IDs cited by the rebuilt rules always resolve dataplane-side.
-		books, _, berr := buildAddressBookTableWithFeeds(cfg, feedOverlay)
-		if berr != nil {
-			return false, fmt.Errorf("build address-book overlay snapshot for scheduler state: %w", berr)
-		}
-		next.AddressBooks = books
 	}
 
 	// Duplicate-publish skip: identical content (e.g. the actuator ran

--- a/pkg/dataplane/userspace/manager_overlay_scheduler_5328_test.go
+++ b/pkg/dataplane/userspace/manager_overlay_scheduler_5328_test.go
@@ -7,7 +7,20 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
 )
+
+// stubRuleListHermetic makes buildRouteSnapshots hermetic by stubbing the
+// netlink ip-rule enumerator (routes.go ruleListFn), which otherwise calls the
+// real netlink.RuleList and fails "operation not permitted" in a restricted
+// sandbox (both the seed full build and the route-overlay republish enumerate
+// ip-rules). Restored on test cleanup.
+func stubRuleListHermetic(t *testing.T) {
+	t.Helper()
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(int) ([]netlink.Rule, error) { return nil, nil }
+}
 
 // schedPolicyInactive5328 returns the Inactive bit of the named policy rule in
 // a published snapshot, failing the test if the rule is absent.
@@ -20,6 +33,88 @@ func schedPolicyInactive5328(t *testing.T, policies []PolicyRuleSnapshot, name s
 	}
 	t.Fatalf("policy %q not found in published snapshot (%d policies)", name, len(policies))
 	return false
+}
+
+// schedPolicyPresent5328 reports whether the named policy rule is present in a
+// published snapshot (unlike schedPolicyInactive5328 it does not fail on
+// absence), so a test can assert a rule was dropped.
+func schedPolicyPresent5328(policies []PolicyRuleSnapshot, name string) bool {
+	for _, p := range policies {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// collidingSchedCfg5328 builds a config whose zone-name set carries a verified
+// StableZoneID collision (z174/z214, later-sorting z214 quarantined) plus a
+// non-colliding survivor zone "trust", with two scheduled zone-pair permits: one
+// survivor (trust->z174) and one whose to-zone is the quarantined z214. A FULL
+// build quarantines z214 and DROPS the trust->z214 permit; a partial republish
+// that rebuilds policies from this cfg WITHOUT re-applying the quarantine would
+// reintroduce the trust->z214 permit as a dangling reference (#6480).
+func collidingSchedCfg5328(t *testing.T) *config.Config {
+	t.Helper()
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	mkPol := func(name string) *config.Policy {
+		return &config.Policy{
+			Name:          name,
+			SchedulerName: "workhours",
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+			Action: config.PolicyPermit,
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust"},
+		"z174":  {Name: "z174"},
+		"z214":  {Name: "z214"},
+	}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "trust", ToZone: "z174", Policies: []*config.Policy{mkPol("survivor-allow")}},
+		{FromZone: "trust", ToZone: "z214", Policies: []*config.Policy{mkPol("dangling-allow")}},
+	}
+	cfg.Schedulers = map[string]*config.SchedulerConfig{"workhours": {Name: "workhours"}}
+	return cfg
+}
+
+// assertNoDanglingZoneRef5328 fails if any policy in the snapshot references a
+// security zone absent from the snapshot's own Zones — the exact condition the
+// Rust UnresolvableZoneReference preflight rejects the whole snapshot on (#6480).
+// "" and "junos-global" are structural sentinels, not zone references. It also
+// asserts Summary.PolicyCount == len(Policies), the bookkeeping invariant the
+// full build maintains after quarantine.
+func assertNoDanglingZoneRef5328(t *testing.T, snap *ConfigSnapshot) {
+	t.Helper()
+	published := map[string]bool{}
+	for _, z := range snap.Zones {
+		published[z.Name] = true
+	}
+	for _, p := range snap.Policies {
+		slots := append([]string{p.FromZone, p.ToZone, p.MatchFromZone, p.MatchToZone},
+			append(append([]string{}, p.MatchFromZones...), p.MatchToZones...)...)
+		for _, z := range slots {
+			if z == "" || z == "junos-global" {
+				continue
+			}
+			if !published[z] {
+				t.Fatalf("published policy %q references zone %q absent from snapshot Zones "+
+					"(%d policies, %d zones) — the Rust UnresolvableZoneReference preflight "+
+					"would reject the WHOLE snapshot (#6480)", p.Name, z, len(snap.Policies), len(snap.Zones))
+			}
+		}
+	}
+	if snap.Summary.PolicyCount != len(snap.Policies) {
+		t.Fatalf("Summary.PolicyCount = %d, want %d (== len(Policies)) (#6480)",
+			snap.Summary.PolicyCount, len(snap.Policies))
+	}
 }
 
 // TestPublishRouteOverlaySnapshotRefreshesSchedulerPolicyBits5328 pins the
@@ -42,6 +137,7 @@ func schedPolicyInactive5328(t *testing.T, policies []PolicyRuleSnapshot, name s
 // lastSnapshot (Inactive=false), so the captured published snapshot reports the
 // permit ACTIVE and this test goes RED on the "Inactive=false" assertion.
 func TestPublishRouteOverlaySnapshotRefreshesSchedulerPolicyBits5328(t *testing.T) {
+	stubRuleListHermetic(t)
 	// A SHORT temp-dir prefix (not t.TempDir(), whose long sub-test name would
 	// push the AF_UNIX path past the 108-byte sun_path limit under a long
 	// TMPDIR / GOTMPDIR=/dev/shm — "bind: invalid argument"). Run with
@@ -131,6 +227,7 @@ func TestPublishRouteOverlaySnapshotRefreshesSchedulerPolicyBits5328(t *testing.
 // below the content-hash skip) makes the publish hash-match the seed and return
 // published=false, so the "expected a real publish" assertion goes RED.
 func TestPublishRouteOverlaySnapshotSchedulerFlipDefeatsDuplicateSkip5328(t *testing.T) {
+	stubRuleListHermetic(t)
 	dir, err := os.MkdirTemp("", "x5328o")
 	if err != nil {
 		t.Fatalf("mkdtemp: %v", err)
@@ -201,5 +298,214 @@ func TestPublishRouteOverlaySnapshotSchedulerFlipDefeatsDuplicateSkip5328(t *tes
 	if !schedPolicyInactive5328(t, req.Snapshot.Policies, "scheduled-allow") {
 		t.Fatal("published snapshot still reports the scheduled permit ACTIVE (Inactive=false) " +
 			"after a closed-window scheduler flip (#5328 A6-b2-F4)")
+	}
+}
+
+// TestPublishRouteOverlaySnapshotReappliesZoneQuarantine6480 pins the #6480
+// hostile-review MAJOR: the route-overlay publish rebuilds next.Policies from raw
+// cfg under the scheduler map but inherits the already-reduced next.Zones (the
+// full build quarantined the later-sorting colliding zone). Without re-applying
+// the StableZoneID quarantine the rebuild reintroduces the trust->z214 permit,
+// which references the quarantined zone z214 absent from next.Zones — a dangling
+// reference the Rust UnresolvableZoneReference preflight rejects wholesale. On the
+// supported ip-monitoring path FRR is updated BEFORE this publish
+// (daemon_ipmon.go), so the reject strands the kernel/FRR on new routes while
+// userspace keeps the old FIB, unable to converge.
+//
+// FAIL-ON-REVERT: dropping the scrubPoliciesForQuarantinedZones re-application
+// from rebuildScheduledPolicySectionsLocked leaves the trust->z214 permit in the
+// published snapshot, so assertNoDanglingZoneRef5328 goes RED (clean assertion).
+func TestPublishRouteOverlaySnapshotReappliesZoneQuarantine6480(t *testing.T) {
+	stubRuleListHermetic(t)
+	dir, err := os.MkdirTemp("", "x6480")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	cfg := collidingSchedCfg5328(t)
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 5
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// Seed lastSnapshot via the FULL build with the scheduler ACTIVE: the full
+	// build quarantines z214 and drops the trust->z214 permit, so the seed carries
+	// the reduced Zones {trust, z174} and only the survivor permit. Reuse the SAME
+	// cfg pointer so the #5680 route-only-hybrid guard's pointer fast path admits
+	// the publish.
+	m.lastSnapshot, err = buildSnapshotWithSchedulerState(
+		cfg, config.UserspaceConfig{ControlSocket: controlSock}, 5, 0,
+		map[string]bool{"workhours": true}, nil, nil)
+	if err != nil {
+		t.Fatalf("build lastSnapshot: %v", err)
+	}
+	// Precondition: the seed is already quarantined (z214 gone, dangling permit gone).
+	assertNoDanglingZoneRef5328(t, m.lastSnapshot)
+	if len(m.lastSnapshot.zoneIDCollisions) != 1 {
+		t.Fatalf("seed must record the z174/z214 collision, got %v", m.lastSnapshot.zoneIDCollisions)
+	}
+	if schedPolicyPresent5328(m.lastSnapshot.Policies, "dangling-allow") {
+		t.Fatal("precondition: full-build seed must have dropped the trust->z214 permit")
+	}
+
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	// Route-overlay publish carrying the scheduler map: the rebuild reintroduces
+	// the trust->z214 permit from raw cfg and MUST re-quarantine it.
+	published, err := m.PublishRouteOverlaySnapshot(cfg, nil, map[string]bool{"workhours": true})
+	if err != nil {
+		t.Fatalf("PublishRouteOverlaySnapshot returned error: %v", err)
+	}
+	if !published {
+		t.Fatal("expected a real publish")
+	}
+
+	req := <-reqs
+	if req.Snapshot == nil {
+		t.Fatal("captured control request carried no snapshot")
+	}
+	assertNoDanglingZoneRef5328(t, req.Snapshot)
+	// The survivor permit must remain (the scrub must not over-drop).
+	if !schedPolicyPresent5328(req.Snapshot.Policies, "survivor-allow") {
+		t.Fatal("survivor permit trust->z174 was wrongly dropped by the re-quarantine")
+	}
+	// The dangling permit must be gone.
+	if schedPolicyPresent5328(req.Snapshot.Policies, "dangling-allow") {
+		t.Fatal("dangling permit trust->z214 survived the re-quarantine (references quarantined z214) (#6480)")
+	}
+}
+
+// TestUpdatePolicyScheduleStateReappliesZoneQuarantine6480 is the mirror of the
+// route-overlay test for the canonical scheduler-only republish path. It shares
+// the SAME latent #6480 defect — UpdatePolicyScheduleState rebuilds next.Policies
+// from raw cfg while inheriting the reduced next.Zones — and the SAME shared
+// rebuildScheduledPolicySectionsLocked re-quarantine fixes both paths in lockstep.
+func TestUpdatePolicyScheduleStateReappliesZoneQuarantine6480(t *testing.T) {
+	stubRuleListHermetic(t)
+	dir, err := os.MkdirTemp("", "x6480u")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	cfg := collidingSchedCfg5328(t)
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 5
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	m.lastSnapshot, err = buildSnapshotWithSchedulerState(
+		cfg, config.UserspaceConfig{ControlSocket: controlSock}, 5, 0,
+		map[string]bool{"workhours": true}, nil, nil)
+	if err != nil {
+		t.Fatalf("build lastSnapshot: %v", err)
+	}
+	assertNoDanglingZoneRef5328(t, m.lastSnapshot)
+
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	// A CLOSED-window scheduler republish: rebuilds policies from raw cfg (which
+	// reintroduces the trust->z214 permit) and MUST re-quarantine it.
+	if err := m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false}); err != nil {
+		t.Fatalf("UpdatePolicyScheduleState returned error: %v", err)
+	}
+
+	req := <-reqs
+	if req.Snapshot == nil {
+		t.Fatal("captured control request carried no snapshot")
+	}
+	assertNoDanglingZoneRef5328(t, req.Snapshot)
+	if !schedPolicyPresent5328(req.Snapshot.Policies, "survivor-allow") {
+		t.Fatal("survivor permit trust->z174 was wrongly dropped by the re-quarantine")
+	}
+	if schedPolicyPresent5328(req.Snapshot.Policies, "dangling-allow") {
+		t.Fatal("dangling permit trust->z214 survived the re-quarantine (references quarantined z214) (#6480)")
+	}
+}
+
+// TestPublishRouteOverlaySnapshotReadsFreshSchedulerStateNotStale5328 strengthens
+// the freshness coverage (Codex nit): the existing OPEN->CLOSED tests seed
+// m.policySchedulerActive nil, and since a nil/absent scheduler read is
+// fail-closed (Inactive=true) a rebuild that IGNORED the passed schedulerState
+// would still land on Inactive=true and pass. This drives the CLOSED->OPEN
+// direction with the cache PRE-SEEDED to the STALE closed state, so only a rebuild
+// that reads the FRESH open state can make the permit ACTIVE (Inactive=false).
+//
+// FAIL-ON-REVERT: neutralizing the rebuild (or the schedulerState cache update
+// before it) leaves the inherited/stale CLOSED bit (Inactive=true), so the
+// "Inactive=false" assertion goes RED — binding that the publish uses the
+// freshly-passed {workhours:true}, not a stale cache.
+func TestPublishRouteOverlaySnapshotReadsFreshSchedulerStateNotStale5328(t *testing.T) {
+	stubRuleListHermetic(t)
+	dir, err := os.MkdirTemp("", "x5328f")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		Policies: []*config.Policy{{
+			Name:          "scheduled-allow",
+			SchedulerName: "workhours",
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+			Action: config.PolicyPermit,
+		}},
+	}}
+	cfg.Schedulers = map[string]*config.SchedulerConfig{"workhours": {Name: "workhours"}}
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 5
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// Seed lastSnapshot with the window CLOSED so the permit is INACTIVE.
+	m.lastSnapshot, err = buildSnapshotWithSchedulerState(
+		cfg, config.UserspaceConfig{ControlSocket: controlSock}, 5, 0,
+		map[string]bool{"workhours": false}, nil, nil)
+	if err != nil {
+		t.Fatalf("build lastSnapshot: %v", err)
+	}
+	if !schedPolicyInactive5328(t, m.lastSnapshot.Policies, "scheduled-allow") {
+		t.Fatal("precondition: seeded permit must be INACTIVE (window CLOSED)")
+	}
+	// Pre-seed the scheduler cache to the STALE closed state: a rebuild that fails
+	// to read the freshly-passed OPEN map would keep the permit INACTIVE.
+	m.policySchedulerActive = map[string]bool{"workhours": false}
+
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	// Publish the OPEN window: only a rebuild reading the FRESH map makes it ACTIVE.
+	published, err := m.PublishRouteOverlaySnapshot(cfg, nil, map[string]bool{"workhours": true})
+	if err != nil {
+		t.Fatalf("PublishRouteOverlaySnapshot returned error: %v", err)
+	}
+	if !published {
+		t.Fatal("expected a real publish (permit inactive bit changed CLOSED->OPEN)")
+	}
+
+	req := <-reqs
+	if req.Snapshot == nil {
+		t.Fatal("captured control request carried no snapshot")
+	}
+	if schedPolicyInactive5328(t, req.Snapshot.Policies, "scheduled-allow") {
+		t.Fatal("published permit still INACTIVE after a fresh OPEN-window publish: the " +
+			"route-overlay rebuild read a STALE scheduler state instead of the freshly-passed " +
+			"{workhours:true} (#5328 A6-b2-F4 / #6480)")
 	}
 }

--- a/pkg/dataplane/userspace/manager_overlay_scheduler_5328_test.go
+++ b/pkg/dataplane/userspace/manager_overlay_scheduler_5328_test.go
@@ -1,0 +1,205 @@
+package userspace
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// schedPolicyInactive5328 returns the Inactive bit of the named policy rule in
+// a published snapshot, failing the test if the rule is absent.
+func schedPolicyInactive5328(t *testing.T, policies []PolicyRuleSnapshot, name string) bool {
+	t.Helper()
+	for _, p := range policies {
+		if p.Name == name {
+			return p.Inactive
+		}
+	}
+	t.Fatalf("policy %q not found in published snapshot (%d policies)", name, len(policies))
+	return false
+}
+
+// TestPublishRouteOverlaySnapshotRefreshesSchedulerPolicyBits5328 pins the
+// #5328 (A6-b2-F4) fix: a route-overlay publish that is handed a policy-
+// scheduler active-state map MUST rebuild the published snapshot's policy
+// inactive bits from that map in the SAME publish, not merely cache the map
+// and inherit the last-compiled (stale) policy sections.
+//
+// The daemon's ip-monitoring actuator calls PublishRouteOverlaySnapshot with a
+// live scheduler.ActiveState() (pkg/daemon/daemon_ipmon.go). Here the seeded
+// lastSnapshot was compiled with the "workhours" scheduler ACTIVE, so its
+// "scheduled-allow" permit is Inactive=false. We then publish a routes-only
+// overlay carrying the CLOSED window (workhours:false). The published snapshot
+// must show the permit as Inactive=true — otherwise the Rust helper keeps
+// enforcing a permit whose schedule window already closed, while this publish
+// reports success.
+//
+// FAIL-ON-REVERT: dropping the `if schedulerState != nil { ... rebuild ... }`
+// block from PublishRouteOverlaySnapshot leaves next.Policies inherited from
+// lastSnapshot (Inactive=false), so the captured published snapshot reports the
+// permit ACTIVE and this test goes RED on the "Inactive=false" assertion.
+func TestPublishRouteOverlaySnapshotRefreshesSchedulerPolicyBits5328(t *testing.T) {
+	// A SHORT temp-dir prefix (not t.TempDir(), whose long sub-test name would
+	// push the AF_UNIX path past the 108-byte sun_path limit under a long
+	// TMPDIR / GOTMPDIR=/dev/shm — "bind: invalid argument"). Run with
+	// TMPDIR=/tmp if the default TMPDIR is long.
+	dir, err := os.MkdirTemp("", "x5328")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		Policies: []*config.Policy{{
+			Name:          "scheduled-allow",
+			SchedulerName: "workhours",
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+			Action: config.PolicyPermit,
+		}},
+	}}
+	cfg.Schedulers = map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours"},
+	}
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 5
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// Seed lastSnapshot compiled with the scheduler window OPEN so the
+	// permit is ACTIVE (Inactive=false). Reuse the SAME cfg pointer so the
+	// #5680 route-only-hybrid guard's pointer fast path admits the publish.
+	m.lastSnapshot, err = buildSnapshotWithSchedulerState(
+		cfg, config.UserspaceConfig{ControlSocket: controlSock}, 5, 0,
+		map[string]bool{"workhours": true}, nil, nil)
+	if err != nil {
+		t.Fatalf("build lastSnapshot: %v", err)
+	}
+	if schedPolicyInactive5328(t, m.lastSnapshot.Policies, "scheduled-allow") {
+		t.Fatal("precondition: seeded lastSnapshot permit must be ACTIVE (Inactive=false)")
+	}
+
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	// Window CLOSED: publish a routes-only overlay carrying workhours:false.
+	published, err := m.PublishRouteOverlaySnapshot(cfg, nil, map[string]bool{"workhours": false})
+	if err != nil {
+		t.Fatalf("PublishRouteOverlaySnapshot returned error: %v", err)
+	}
+	if !published {
+		t.Fatal("expected a real publish (policy inactive bit changed), got duplicate-skip")
+	}
+
+	req := <-reqs
+	if req.Snapshot == nil {
+		t.Fatal("captured control request carried no snapshot")
+	}
+	if !schedPolicyInactive5328(t, req.Snapshot.Policies, "scheduled-allow") {
+		t.Fatal("published snapshot reports the scheduled permit ACTIVE (Inactive=false): " +
+			"the route-overlay publish did NOT refresh policy scheduler bits from schedulerState " +
+			"(#5328 A6-b2-F4) — the helper would enforce a permit whose window already closed")
+	}
+}
+
+// TestPublishRouteOverlaySnapshotSchedulerFlipDefeatsDuplicateSkip5328 pins the
+// ORDERING half of the #5328 (A6-b2-F4) fix: the scheduler-state policy rebuild
+// runs BEFORE the duplicate-publish content-hash skip, so a scheduler-only bit
+// flip on UNCHANGED routes still publishes rather than being falsely deduped as
+// "content unchanged".
+//
+// The seeded lastSnapshotHash equals the seeded snapshot's content hash and the
+// overlay carries NO route change (nil), so the ONLY forwarding-content delta in
+// this publish is the policy inactive bit. If the rebuild were placed AFTER the
+// dedup check (line "Duplicate-publish skip" in manager_overlay.go), the
+// routes-and-policies-still-unchanged snapshot would hash-match m.lastSnapshotHash
+// and be skipped (published=false) — the helper would keep enforcing the stale
+// OPEN-window permit while this publish silently reported nothing to do.
+//
+// FAIL-ON-REVERT / FAIL-ON-REORDER: neutralizing the rebuild block (or moving it
+// below the content-hash skip) makes the publish hash-match the seed and return
+// published=false, so the "expected a real publish" assertion goes RED.
+func TestPublishRouteOverlaySnapshotSchedulerFlipDefeatsDuplicateSkip5328(t *testing.T) {
+	dir, err := os.MkdirTemp("", "x5328o")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		Policies: []*config.Policy{{
+			Name:          "scheduled-allow",
+			SchedulerName: "workhours",
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+			Action: config.PolicyPermit,
+		}},
+	}}
+	cfg.Schedulers = map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours"},
+	}
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 5
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// Seed lastSnapshot compiled with the window OPEN (permit ACTIVE).
+	m.lastSnapshot, err = buildSnapshotWithSchedulerState(
+		cfg, config.UserspaceConfig{ControlSocket: controlSock}, 5, 0,
+		map[string]bool{"workhours": true}, nil, nil)
+	if err != nil {
+		t.Fatalf("build lastSnapshot: %v", err)
+	}
+	// Seed the dedup baseline to the seeded snapshot's content hash so an
+	// unchanged-content publish WOULD be skipped — the discriminator that
+	// forces the rebuild to run before the dedup check.
+	h, ok := snapshotContentHash(m.lastSnapshot)
+	if !ok {
+		t.Fatal("seed snapshot content hash failed")
+	}
+	m.lastSnapshotHash = h
+
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	// Window CLOSED, routes UNCHANGED (nil overlay): the only content delta
+	// is the scheduled permit's inactive bit.
+	published, err := m.PublishRouteOverlaySnapshot(cfg, nil, map[string]bool{"workhours": false})
+	if err != nil {
+		t.Fatalf("PublishRouteOverlaySnapshot returned error: %v", err)
+	}
+	if !published {
+		t.Fatal("scheduler-only inactive-bit flip on unchanged routes was deduped away " +
+			"(published=false): the schedulerState policy rebuild must run BEFORE the " +
+			"duplicate-publish content-hash skip (#5328 A6-b2-F4) — otherwise the helper " +
+			"keeps enforcing the stale open-window permit")
+	}
+
+	req := <-reqs
+	if req.Snapshot == nil {
+		t.Fatal("captured control request carried no snapshot")
+	}
+	if !schedPolicyInactive5328(t, req.Snapshot.Policies, "scheduled-allow") {
+		t.Fatal("published snapshot still reports the scheduled permit ACTIVE (Inactive=false) " +
+			"after a closed-window scheduler flip (#5328 A6-b2-F4)")
+	}
+}

--- a/pkg/dataplane/userspace/manager_overlay_scheduler_5328_test.go
+++ b/pkg/dataplane/userspace/manager_overlay_scheduler_5328_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -507,5 +508,172 @@ func TestPublishRouteOverlaySnapshotReadsFreshSchedulerStateNotStale5328(t *test
 		t.Fatal("published permit still INACTIVE after a fresh OPEN-window publish: the " +
 			"route-overlay rebuild read a STALE scheduler state instead of the freshly-passed " +
 			"{workhours:true} (#5328 A6-b2-F4 / #6480)")
+	}
+}
+
+// skewCfgA6480 builds config A: zones {trust, z214} with NO StableZoneID
+// collision (z214 alone folds to nothing else here), so a FULL build keeps z214
+// a live zone and keeps the scheduled trust->z214 DENY. This is the applied /
+// inherited config a scheduler republish copies its Zones/Interfaces from.
+func skewCfgA6480(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust"},
+		"z214":  {Name: "z214"},
+	}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "trust", ToZone: "z214", Policies: []*config.Policy{{
+			Name:          "trust-z214-deny",
+			SchedulerName: "workhours",
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+			Action: config.PolicyDeny,
+		}}},
+	}
+	cfg.Schedulers = map[string]*config.SchedulerConfig{"workhours": {Name: "workhours"}}
+	return cfg
+}
+
+// skewCfgB6480 builds config B: config A PLUS the colliding zone z174. Under B,
+// z174/z214 fold to the SAME StableZoneID and the later-sorting z214 is
+// quarantined, so B's quarantine set is {z214} while A's is empty. B carries the
+// same scheduled trust->z214 deny; a full Compile of B would drop z214 from Zones
+// AND drop the deny (fail-closed). B content-differs from A only by the added
+// zone, so relative to a snapshot built from A it is a genuine config-generation
+// skew.
+func skewCfgB6480(t *testing.T) *config.Config {
+	t.Helper()
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	cfg := skewCfgA6480(t)
+	cfg.Security.Zones["z174"] = &config.ZoneConfig{Name: "z174"}
+	return cfg
+}
+
+// TestUpdatePolicyScheduleStateRefusesConfigSkew6480 pins the fold-introduced
+// fail-open the #6480 round-2 fix opened on the scheduler-only republish path and
+// this fold closes. rebuildScheduledPolicySectionsLocked rebuilds+scrubs policies
+// against the PASSED cfg while inheriting next.Zones/next.Interfaces from
+// m.lastSnapshot. During a config-skew window the daemon reconciles the scheduler
+// to store.ActiveConfig() (the NEWLY promoted config B) while a transient apply
+// failure left the OLD snapshot (config A) live: the store promotes B before
+// applying (store_commit.go), and daemon_apply_dataplane.go continues on a
+// dataplane apply error yet still reconciles the scheduler to B.
+//
+// A has zones {trust, z214} (no collision) with a live scheduled trust->z214
+// DENY; B adds colliding z174 so B's quarantine set is {z214}. WITHOUT the guard
+// the scheduler tick copies A's Zones {trust, z214} but scrubs the rebuilt
+// policies with B's {z214} quarantine, DROPPING the trust->z214 deny while z214
+// stays a live zone in next.Zones — the Rust preflight accepts the snapshot and
+// traffic to z214 falls through to the inherited default PERMIT (fail-OPEN). A
+// full Compile of B would instead drop z214 from Zones + unzone its iface
+// (fail-closed). The route-overlay path already refuses this skew
+// (routeOnlyPublishHybrid, #5680); this fold mirrors that refusal inside the
+// shared rebuildScheduledPolicySectionsLocked so BOTH partial-republish paths are
+// safe.
+//
+// FAIL-ON-REVERT (clean assertion): removing the routeOnlyPublishHybrid skew
+// guard from rebuildScheduledPolicySectionsLocked lets the skew republish SUCCEED
+// — UpdatePolicyScheduleState returns nil, bumps m.generation to 6, and advances
+// m.lastSnapshot.Config to cfgB while shipping the fail-open snapshot — so the
+// phase-(a) err / generation / lastSnapshot assertions go RED. The same-config
+// phase (b) proves the guard does not over-refuse the common (pointer-identical)
+// path and still refreshes scheduler bits.
+func TestUpdatePolicyScheduleStateRefusesConfigSkew6480(t *testing.T) {
+	stubRuleListHermetic(t)
+	dir, err := os.MkdirTemp("", "x6480skew")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	controlSock := filepath.Join(dir, "control.sock")
+
+	cfgA := skewCfgA6480(t)
+	cfgB := skewCfgB6480(t)
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 5
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// Seed lastSnapshot from config A with the window OPEN: A has no collision, so
+	// z214 is a live zone and the trust->z214 deny is present + ACTIVE. The builder
+	// stamps snapshot.Config = cfgA (pointer), which the same-config phase relies on.
+	m.lastSnapshot, err = buildSnapshotWithSchedulerState(
+		cfgA, config.UserspaceConfig{ControlSocket: controlSock}, 5, 0,
+		map[string]bool{"workhours": true}, nil, nil)
+	if err != nil {
+		t.Fatalf("build lastSnapshot: %v", err)
+	}
+	if m.lastSnapshot.Config != cfgA {
+		t.Fatal("precondition: seeded snapshot must carry cfgA by pointer")
+	}
+	assertNoDanglingZoneRef5328(t, m.lastSnapshot)
+	if !schedPolicyPresent5328(m.lastSnapshot.Policies, "trust-z214-deny") {
+		t.Fatal("precondition: config-A seed must keep the trust->z214 deny (z214 not quarantined)")
+	}
+	// z214 must be a LIVE zone in the seed — the fail-open hinges on it surviving
+	// in the inherited next.Zones while B's quarantine would drop the deny.
+	z214Live := false
+	for _, z := range m.lastSnapshot.Zones {
+		if z.Name == "z214" {
+			z214Live = true
+		}
+	}
+	if !z214Live {
+		t.Fatal("precondition: z214 must be a live zone in the config-A seed")
+	}
+
+	// Arm the control server for exactly ONE publish — the same-config phase (b).
+	// The skew phase (a) must ship NOTHING (the guard refuses before any
+	// apply_snapshot); on revert it WOULD ship the fail-open snapshot and consume
+	// this slot, but the phase-(a) assertions fail first.
+	reqs := startArmControlServer(t, controlSock, 1)
+
+	// Phase (a): SKEW — call with cfgB (quarantines z214, a zone A still has live).
+	// The guard must REFUSE and retain the prior snapshot.
+	skewErr := m.UpdatePolicyScheduleState(cfgB, map[string]bool{"workhours": false})
+	if skewErr == nil {
+		t.Fatal("UpdatePolicyScheduleState accepted a config-skew republish: the rebuilt " +
+			"policies were scrubbed with cfgB's quarantine {z214} against cfgA's inherited " +
+			"Zones (z214 live), shipping a fail-open snapshot (#6480)")
+	}
+	if !strings.Contains(skewErr.Error(), "refusing scheduled-policy republish") {
+		t.Fatalf("skew refusal error = %q, want the #6480 scheduled-policy skew guard", skewErr)
+	}
+	// Prior snapshot retained (fail-closed): generation not advanced, lastSnapshot
+	// still config A. On revert both flip (generation->6, Config->cfgB).
+	if m.generation != 5 {
+		t.Fatalf("generation advanced to %d on a refused skew republish (want 5): a fail-open "+
+			"snapshot was published (#6480)", m.generation)
+	}
+	if m.lastSnapshot == nil || m.lastSnapshot.Config != cfgA {
+		t.Fatal("refused skew republish advanced lastSnapshot past the applied config A (#6480)")
+	}
+
+	// Phase (b): SAME CONFIG — call with cfgA (pointer-identical to the applied
+	// snapshot's config), window CLOSED. The guard's pointer fast path admits it;
+	// the republish must succeed and refresh the scheduler bits.
+	if err := m.UpdatePolicyScheduleState(cfgA, map[string]bool{"workhours": false}); err != nil {
+		t.Fatalf("same-config scheduler republish was wrongly refused: %v", err)
+	}
+	req := <-reqs
+	if req.Snapshot == nil {
+		t.Fatal("same-config republish shipped no snapshot")
+	}
+	assertNoDanglingZoneRef5328(t, req.Snapshot)
+	if !schedPolicyPresent5328(req.Snapshot.Policies, "trust-z214-deny") {
+		t.Fatal("same-config republish dropped the trust->z214 deny (A has no quarantine)")
+	}
+	// Scheduler bits refreshed: the CLOSED window must render the deny INACTIVE.
+	if !schedPolicyInactive5328(t, req.Snapshot.Policies, "trust-z214-deny") {
+		t.Fatal("same-config republish did not refresh scheduler bits: the CLOSED-window deny " +
+			"is still ACTIVE (Inactive=false) (#6480 phase-b regression guard)")
 	}
 }

--- a/pkg/dataplane/userspace/zones_quarantine.go
+++ b/pkg/dataplane/userspace/zones_quarantine.go
@@ -101,84 +101,13 @@ func quarantineCollidingZones(snap *ConfigSnapshot) []ZoneIDCollision {
 	// Scrub quarantined zones out of policies so the snapshot carries no dangling
 	// policy->zone reference (which the Rust UnresolvableZoneReference preflight
 	// would reject wholesale — a whole-snapshot brick on a fresh boot, the exact
-	// failure this quarantine exists to prevent). Two cases, treated differently:
-	//
-	//  1. A STRUCTURALLY-REQUIRED zone is quarantined -> DROP the whole rule. This
-	//     is the singular FromZone/ToZone of a zone-pair policy (a rule from/to a
-	//     quarantined zone can no longer be applied), OR a scoped-global match side
-	//     that is CONFIGURED but has NO surviving member after pruning (every
-	//     member collided — leaving the side empty would silently BROADEN the rule
-	//     to all zones, a fail-open in the opposite direction). Empty ("" — the
-	//     zone-pair case) and "junos-global" are never quarantine keys.
-	//
-	//  2. A scoped-GLOBAL policy's match-zone context is a zone SET (#4626 M03,
-	//     plural MatchFromZones/MatchToZones; singular kept for back-compat). When
-	//     only SOME members collide, PRUNE the quarantined member(s) and KEEP the
-	//     rule scoped to the survivors. Dropping the whole rule because one member
-	//     collides is FAIL-OPEN: a global deny scoped from [z174, z214] where only
-	//     z214 collides would vanish entirely, so still-valid z174 traffic no
-	//     longer hits the deny and reaches a later/default permit while the
-	//     snapshot publishes successfully (#5577). Unzoning z214 makes that member
-	//     irrelevant; it does not make retained-z174 traffic irrelevant. After
-	//     pruning we regenerate the SINGULAR MatchFromZone/MatchToZone from the
-	//     surviving set (config.ScopeSingular) so an old Rust helper that reads
-	//     only the singular field also sees a surviving, non-quarantined zone —
-	//     never the dropped one (which would re-introduce the dangling reference).
-	if len(snap.Policies) > 0 {
-		isQuarantined := func(z string) bool {
-			_, drop := quarantined[z]
-			return drop
-		}
-		// pruneQuarantined returns a NEW slice with quarantined names removed. It
-		// must not compact in place: MatchFromZones/MatchToZones alias the source
-		// config's pol.Match slices (policies_lower.go), so in-place mutation would
-		// corrupt the live config. This path is a cold fail-closed backstop, so the
-		// per-rule allocation is immaterial.
-		pruneQuarantined := func(zs []string) []string {
-			out := make([]string, 0, len(zs))
-			for _, z := range zs {
-				if !isQuarantined(z) {
-					out = append(out, z)
-				}
-			}
-			return out
-		}
-		keptPol := snap.Policies[:0]
-		for _, p := range snap.Policies {
-			// Case 1a: a zone-pair rule's required endpoint is quarantined.
-			if isQuarantined(p.FromZone) || isQuarantined(p.ToZone) {
-				continue
-			}
-			drop := false
-			// Case 2 / 1b: prune each configured scoped-global match side; drop the
-			// rule only if a configured side is emptied by the prune.
-			if from := p.effectiveMatchFromZones(); len(from) > 0 {
-				kept := pruneQuarantined(from)
-				if len(kept) == 0 {
-					drop = true
-				} else {
-					p.MatchFromZones = kept
-					p.MatchFromZone = config.ScopeSingular(kept)
-				}
-			}
-			if !drop {
-				if to := p.effectiveMatchToZones(); len(to) > 0 {
-					kept := pruneQuarantined(to)
-					if len(kept) == 0 {
-						drop = true
-					} else {
-						p.MatchToZones = kept
-						p.MatchToZone = config.ScopeSingular(kept)
-					}
-				}
-			}
-			if drop {
-				continue
-			}
-			keptPol = append(keptPol, p)
-		}
-		snap.Policies = keptPol
-	}
+	// failure this quarantine exists to prevent). The scrub is shared with the
+	// scheduler-only / route-overlay republish paths (#6480) via
+	// scrubPoliciesForQuarantinedZones — whose doc comment documents the two
+	// drop/prune cases — because those paths rebuild next.Policies from raw cfg
+	// and must re-establish this SAME invariant against the already-reduced
+	// next.Zones they inherit.
+	snap.Policies = scrubPoliciesForQuarantinedZones(snap.Policies, quarantined)
 	sort.Slice(collisions, func(i, j int) bool {
 		if collisions[i].ID != collisions[j].ID {
 			return collisions[i].ID < collisions[j].ID
@@ -186,4 +115,115 @@ func quarantineCollidingZones(snap *ConfigSnapshot) []ZoneIDCollision {
 		return collisions[i].Quarantined < collisions[j].Quarantined
 	})
 	return collisions
+}
+
+// scrubPoliciesForQuarantinedZones is the policy half of quarantineCollidingZones,
+// factored out (#6480) so the partial-republish paths that rebuild next.Policies
+// from raw cfg — PublishRouteOverlaySnapshot (route-overlay) and
+// UpdatePolicyScheduleState (scheduler-only) — re-establish the SAME
+// zone-isolation invariant against the already-reduced next.Zones they inherit.
+// Both rebuild the FULL policy set (the raw builder has no knowledge of the
+// StableZoneID quarantine), so a policy referencing a quarantined zone is
+// reintroduced; leaving it in next.Policies while next.Zones stays reduced ships
+// a dangling policy->zone reference that the Rust UnresolvableZoneReference
+// preflight (userspace-dp/src/policy.rs) rejects wholesale — a whole-snapshot
+// brick. quarantined is the set of dropped zone names (config.QuarantinedZoneNames
+// over the FULL zone-name set); "" and "junos-global" are never members (not real
+// zone names), so global/zone-pair sentinels are preserved.
+//
+// Two cases, treated differently:
+//
+//  1. A STRUCTURALLY-REQUIRED zone is quarantined -> DROP the whole rule. This is
+//     the singular FromZone/ToZone of a zone-pair policy (a rule from/to a
+//     quarantined zone can no longer be applied), OR a scoped-global match side
+//     that is CONFIGURED but has NO surviving member after pruning (every member
+//     collided — leaving the side empty would silently BROADEN the rule to all
+//     zones, a fail-open in the opposite direction).
+//
+//  2. A scoped-GLOBAL policy's match-zone context is a zone SET (#4626 M03, plural
+//     MatchFromZones/MatchToZones; singular kept for back-compat). When only SOME
+//     members collide, PRUNE the quarantined member(s) and KEEP the rule scoped to
+//     the survivors — dropping the whole rule for one colliding member is
+//     FAIL-OPEN (#5577). After pruning we regenerate the SINGULAR
+//     MatchFromZone/MatchToZone from the surviving set (config.ScopeSingular) so an
+//     old Rust helper reading only the singular field also sees a surviving,
+//     non-quarantined zone — never the dropped one.
+//
+// It compacts in place (policies[:0]); the caller must own the slice (a freshly
+// built or snapshot-owned slice), never an alias of the live config. The per-rule
+// prune allocates a NEW slice so it never mutates an aliased config.Match slice
+// (policies_lower.go). A nil/empty quarantined set returns policies unchanged, so
+// callers may invoke it unconditionally.
+func scrubPoliciesForQuarantinedZones(policies []PolicyRuleSnapshot, quarantined map[string]struct{}) []PolicyRuleSnapshot {
+	if len(policies) == 0 || len(quarantined) == 0 {
+		return policies
+	}
+	isQuarantined := func(z string) bool {
+		_, drop := quarantined[z]
+		return drop
+	}
+	pruneQuarantined := func(zs []string) []string {
+		out := make([]string, 0, len(zs))
+		for _, z := range zs {
+			if !isQuarantined(z) {
+				out = append(out, z)
+			}
+		}
+		return out
+	}
+	keptPol := policies[:0]
+	for _, p := range policies {
+		// Case 1a: a zone-pair rule's required endpoint is quarantined.
+		if isQuarantined(p.FromZone) || isQuarantined(p.ToZone) {
+			continue
+		}
+		drop := false
+		// Case 2 / 1b: prune each configured scoped-global match side; drop the
+		// rule only if a configured side is emptied by the prune.
+		if from := p.effectiveMatchFromZones(); len(from) > 0 {
+			kept := pruneQuarantined(from)
+			if len(kept) == 0 {
+				drop = true
+			} else {
+				p.MatchFromZones = kept
+				p.MatchFromZone = config.ScopeSingular(kept)
+			}
+		}
+		if !drop {
+			if to := p.effectiveMatchToZones(); len(to) > 0 {
+				kept := pruneQuarantined(to)
+				if len(kept) == 0 {
+					drop = true
+				} else {
+					p.MatchToZones = kept
+					p.MatchToZone = config.ScopeSingular(kept)
+				}
+			}
+		}
+		if drop {
+			continue
+		}
+		keptPol = append(keptPol, p)
+	}
+	return keptPol
+}
+
+// quarantinedZoneNamesForConfig computes the StableZoneID quarantine set — the
+// zone names quarantineCollidingZones drops — directly from a config's zone-name
+// set, WITHOUT building a full snapshot. The partial-republish paths use it to
+// re-scrub a freshly rebuilt policy slice against the SAME quarantine the full
+// build applied (#6480). The name set is exactly buildZoneSnapshots' source
+// (cfg.Security.Zones keys), so the computed set matches the full build's
+// quarantine by construction; the inherited next.Zones (reduced by the full
+// build) is therefore full(cfg) minus this set, and scrubbing the rebuilt
+// policies against it leaves no reference to a zone absent from next.Zones.
+func quarantinedZoneNamesForConfig(cfg *config.Config) map[string]struct{} {
+	if cfg == nil || len(cfg.Security.Zones) < 2 {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		names = append(names, name)
+	}
+	return config.QuarantinedZoneNames(names)
 }


### PR DESCRIPTION
## Summary

Advances #5328 — cohort item **A6-b2-F4** (codex-178 survivors). One
focused control-plane fix in `pkg/dataplane/userspace/manager_overlay.go`.
The `[cohort]` tracking issue stays **open**; this PR does not close it.

`PublishRouteOverlaySnapshot(cfg, overlay, schedulerState)` documented that
a non-nil `schedulerState` refreshes the policy snapshots **in the same
publish**, but the code only cached `m.policySchedulerActive` while
`next := *m.lastSnapshot` inherited the PRIOR compiled `Policies` /
`AddressBooks` verbatim. The helper therefore enforced **stale schedule
bits** until a later `UpdatePolicyScheduleState` callback fired (plus a
redundant full reconcile).

The ip-monitoring actuator (`pkg/daemon/daemon_ipmon.go`) calls this helper
with a live `scheduler.ActiveState()`, so a probe-driven route flap could
ship a snapshot that **reports success while the dataplane enforces a
scheduled permit against the wrong window** — a fail-open gap: a permit
whose schedule window just closed stays live until the next scheduler tick.

## Fix

When `schedulerState != nil`, rebuild the published snapshot's policy
sections in THIS publish, exactly as the dedicated scheduler-only republish
(`UpdatePolicyScheduleState`) does:

- `next.Policies` via `buildPolicySnapshotsWithSchedulerStateAndFeeds`
- `next.Capabilities.PolicyContentRejected` via
  `collectPolicyContentRejections` (#3261)
- `next.AddressBooks` via `buildAddressBookTableWithFeeds` (#1606)

reusing the cached feed overlay so a concurrent CoS scheduler flip is not
dropped. Key invariants (verified firsthand):

- `m.policySchedulerActive` is updated from `schedulerState` **earlier** in
  the function, so the rebuild consumes the NEW state.
- The rebuild is placed **BEFORE** the duplicate-publish content-hash skip,
  so a scheduler-only inactive-bit flip on unchanged routes is not falsely
  deduped away.
- A `nil` `schedulerState` leaves the inherited policy sections untouched
  (the route-apply caller path that never carries scheduler state).

`docs/userspace-dataplane-architecture.md` records the route-overlay
republish co-honoring the policy-scheduler contract.

## Tests (parent-RED verified)

Two new `pkg/dataplane/userspace` tests:

- **`...RefreshesSchedulerPolicyBits5328`** — seeds a `lastSnapshot`
  compiled with the window OPEN (permit `Inactive=false`), publishes a
  routes-only overlay carrying the CLOSED window, and asserts the captured
  published snapshot reports the permit `Inactive=true`.
- **`...SchedulerFlipDefeatsDuplicateSkip5328`** — additionally seeds
  `lastSnapshotHash` to the seeded snapshot's content hash and asserts the
  scheduler-only flip on unchanged routes still publishes, locking the
  **rebuild-before-dedup ordering** (a reorder that test #1 alone cannot
  catch).

**Parent-RED self-check:** neutralizing the rebuild block (reproducing the
pre-fix cache-only behavior) fails both tests on clean assertions — no
build break:

```
manager_overlay_scheduler_5328_test.go:110: published snapshot reports the
  scheduled permit ACTIVE (Inactive=false): the route-overlay publish did
  NOT refresh policy scheduler bits from schedulerState (#5328 A6-b2-F4) —
  the helper would enforce a permit whose window already closed

manager_overlay_scheduler_5328_test.go:191: scheduler-only inactive-bit
  flip on unchanged routes was deduped away (published=false): the
  schedulerState policy rebuild must run BEFORE the duplicate-publish
  content-hash skip (#5328 A6-b2-F4) — otherwise the helper keeps enforcing
  the stale open-window permit
```

`go build ./...`, `go vet ./pkg/dataplane/userspace/`, `gofmt`, and the full
`pkg/dataplane/userspace` suite are green.
