### PR TITLE
config: reject multi-target static-NAT rule at commit-check

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -60395,3 +60395,38 @@ top.
     pkg/config/compiler_validate_strict_nat.go, pkg/config/compiler_tailgates.go,
     pkg/config/types_security.go, pkg/config/static_nat_multitarget_6483_test.go,
     docs/config-schema.md, docs/refactoring-audit-current.txt, _Log.md
+
+## 2026-07-24 — #6484 fold: grammar-role-aware full-traversal target counter
+- **Timestamp**: 2026-07-24 (fix/6483-multitarget-static-nat)
+- **Action**: Fold a confirmed hostile-review MAJOR (both reviewers + Codex) into
+    the #6483 gate: the target counter under-counted a genuine multi-target rule
+    whose targets COLLAPSE onto one node/child. staticNATCollectTargetIdents read
+    only the FIRST (keyword,value) pair per node (fixed Keys[1]/Keys[2] on the
+    collapsed branch, c.Keys[1]/Children[0] on the child branch) and pre-filtered a
+    value slot equal to a modifier keyword, so `prefix <ip> prefix-name POOL` /
+    `prefix <ip> inet` / `prefix <ip> prefix <ip2>` (one line, collapsed onto one
+    child's Keys), hierarchical `prefix { X; Y; }` (two values as grandchildren of
+    one keyword), and `prefix + prefix-name mapped-port` (pool literally NAMED
+    "mapped-port", pre-filtered away as a modifier carrier — Codex second finding)
+    all counted 1 and ESCAPED the >1 gate. Rewrote the counter as a grammar-role-
+    aware FULL TRAVERSAL (new staticNATCollectTargetIdentsFromKeys, mirroring the
+    #6479 staticNATMappedPortOperandsFromKeys slot-classification walk): walk the
+    whole key stream of the static-nat node AND every child, plus a bare keyword's
+    grandchild values, classifying each position as a keyword or a consumed value
+    slot. prefix-name's value is an opaque name ALWAYS consumed (registers even when
+    named "mapped-port"); prefix/nptv6-prefix's IP value can never be a modifier, so
+    a following mapped-port/routing-instance is a modifier carrier (registers no
+    target); mapped-port/routing-instance consume their operand. Register every
+    distinct (keyword,value) identity; ThenTargetCount = the distinct count.
+    INVARIANT B preserved (all count 1): 4 single-target types collapsed+hier, the
+    #5523 restate idiom, prefix<ip> mapped-port, target+routing-instance, inet
+    alone, and the canonical separate-set-line modifier carrier. PARENT-RED: revert
+    the counter to the old first-pair read (build stays GREEN) -> the 5 new
+    escaping reject tests go clean-assertion RED ("strict CompileConfig must reject
+    a multi-target static-nat rule"); the accept locks stay GREEN under both
+    counters. Firsthand probe table: 4 escaping shapes count=2 REJECT [multi-target
+    gate]; 5 invariant-B shapes count=1 ACCEPT. go build ./... , go vet
+    ./pkg/config/ , gofmt, FULL pkg/config suite, TestHeatmapNotStale all GREEN
+    (no LOC bucket shift).
+- **File(s)**: pkg/config/compiler_nat_static.go,
+    pkg/config/static_nat_multitarget_6483_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60430,3 +60430,37 @@ top.
     (no LOC bucket shift).
 - **File(s)**: pkg/config/compiler_nat_static.go,
     pkg/config/static_nat_multitarget_6483_test.go, docs/config-schema.md, _Log.md
+
+## 2026-07-24 — #6483/#6484 round-2: static-NAT target counter packed-value + nested-modifier fold
+
+- **Timestamp**: 2026-07-24 (fix/6483-multitarget-static-nat)
+- **Action**: Fold two CONFIRMED Codex findings into the distinct-target counter
+  (staticNATCollectTargetIdentsFromKeys / staticNATCollectTargetIdents). FINDING 1
+  (packed/bracketed multi-value ESCAPE): a lexer-collapsed bracketed list `prefix
+  [ X Y ]` / `prefix-name [ A B ]` / `nptv6-prefix [ P6a P6b ]` (#2419 →
+  Keys=["prefix","X","Y"]) consumed only the FIRST value after a target keyword;
+  the rest fell through → counted 1 → escaped the >1 gate. Fix: after a target
+  keyword register EVERY packed value as a distinct (keyword,value) identity —
+  greedy value run bounded by the first keyword lexeme (new helper
+  isStaticNATKeywordLexeme); an IP value can never be a lexeme so prefix/nptv6
+  stop correctly, and a prefix-name's FIRST token is always consumed as the opaque
+  name (pool may be NAMED "mapped-port") with only later keyword lexemes ending the
+  packed-name run. FINDING 2 (nested-modifier FALSE-REJECT): a bare hierarchical
+  `prefix-name { POOL; mapped-port 8080; }` registered EVERY grandchild of the
+  name-valued keyword as a target (POOL + mapped-port = 2) → false-rejected a valid
+  single-target rule origin/master accepted. Fix: in the grandchild walk consume
+  only the FIRST grandchild of a name-valued bare keyword as the name and skip a
+  LATER modifier grandchild (mapped-port/routing-instance) — `gi == 0` guard on the
+  modifier check. Firsthand probe over the full {prefix,prefix-name,nptv6,inet} ×
+  {single-flat, single-hier, hier-nested-MP, bracketed/packed, cross-combos}
+  matrix: exactly the 4 target shapes flipped (3 bracketed 1→2 REJECT, the
+  nested-MP 2→1 ACCEPT); every invariant-B shape (restate idiom, modifier carrier,
+  inline-MP, named-mapped-port, routing-instance trailer, inet-alone, 6 cross
+  combos) unchanged. PARENT-RED: neutralize the packed loops → the 3 bracketed
+  reject tests go clean-assertion RED ("strict CompileConfig must reject a
+  multi-target static-nat rule"); neutralize the gi==0 grandchild guard → the
+  nested-modifier accept test goes RED ("declares 2 static-nat translation
+  targets"). go build ./..., go vet ./pkg/config/, gofmt, FULL pkg/config suite
+  (13s), TestHeatmapNotStale all GREEN (no LOC bucket shift).
+- **File(s)**: pkg/config/compiler_nat_static.go,
+    pkg/config/static_nat_multitarget_6483_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60371,3 +60371,27 @@ top.
 - **File(s)**: pkg/api/sessions.go,
     pkg/api/sessions_pagination_canonical_5649_test.go,
     docs/refactoring-audit-current.txt, _Log.md
+
+## 2026-07-24 — #6483 static-NAT single-translation-target gate
+- **Timestamp**: 2026-07-24
+- **Action**: Add commit-check that a static-NAT rule declares EXACTLY ONE
+    translation target (prefix/prefix-name/nptv6-prefix/inet). Multi-target rules
+    (prefix+prefix-name, inet+prefix sibling, two prefixes, hier two static-nat
+    blocks) were silently accepted — the compiler honored one target by fixed
+    priority and dropped the rest into the shared Then field, which also let a
+    malformed mapped-port on a dropped target slip (the #6479/C179-038 residual).
+    New staticNATThenTargetCount counts DISTINCT (keyword,value) target identities
+    from the AST during compile (so the "restate the target to attach mapped-port"
+    idiom stays one target), recorded as StaticNATRule.ThenTargetCount (json:"-").
+    validateStaticNATSingleTargetStrict rejects >1, wired into runTailGates AFTER
+    the host-mask (#2173) and NPTv6 (#2240/#5818) gates so a rule ALSO carrying a
+    bad mapped-port/nptv6 prefix reports that concrete token first (never masks
+    the multi-target defect). Strict reject / lenient warn (#1960). PARENT-RED:
+    neutralize the `> 1` guard -> 5 reject tests go clean-assertion RED; restore
+    GREEN. gofmt/vet/go build ./... GREEN, full pkg/config suite GREEN,
+    regenerated docs/refactoring-audit-current.txt (compiler_validate_strict_nat.go
+    2865->2928 REFACTOR tier).
+- **File(s)**: pkg/config/compiler_nat_static.go,
+    pkg/config/compiler_validate_strict_nat.go, pkg/config/compiler_tailgates.go,
+    pkg/config/types_security.go, pkg/config/static_nat_multitarget_6483_test.go,
+    docs/config-schema.md, docs/refactoring-audit-current.txt, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60431,6 +60431,21 @@ top.
 - **File(s)**: pkg/config/compiler_nat_static.go,
     pkg/config/static_nat_multitarget_6483_test.go, docs/config-schema.md, _Log.md
 
+## 2026-07-24 — #6484 round-2: V1/V2 sibling-mapped-port regression tests
+
+- **Timestamp**: 2026-07-24 (fix/6483-multitarget-static-nat)
+- **Action**: Add two regression accept subtests for the #1 regression-risk
+  shape flagged in the team-lead ground-truth matrix: REAL Junos
+  `static-nat { prefix-name POOL; mapped-port 8080; }` (V1) and
+  `static-nat { prefix 10.0.0.1/32; mapped-port 8080; }` (V2) — where mapped-port
+  is a SIBLING child of the target, not a grandchild. Both must stay ONE target
+  (the target child's Keys are len 2 so it never enters the grandchild loop; the
+  mapped-port sibling is skipped by staticNATCollectTargetIdentsFromKeys).
+  Firsthand-verified count=1/ACCEPT for the full V1/V2/V3/P1/B1/B2/B3 matrix
+  before adding. Test-only, no code change. gofmt + vet + full multitarget suite
+  green.
+- **File(s)**: pkg/config/static_nat_multitarget_6483_test.go, _Log.md
+
 ## 2026-07-24 — #6483/#6484 round-2: static-NAT target counter packed-value + nested-modifier fold
 
 - **Timestamp**: 2026-07-24 (fix/6483-multitarget-static-nat)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1978,18 +1978,32 @@ onto a SINGLE child's Keys, and a hierarchical `prefix { <ip>; <ip2>; }` carries
 two prefix values as grandchildren of ONE `prefix` keyword — all counted 1 and
 ACCEPTED on master (the #6484 MAJOR). The full traversal registers every distinct
 `(keyword, value)` identity across the whole leaf, so these now count 2 and
-reject. Two role subtleties make the walk correct: (1) a `prefix-name` value is an
-OPAQUE address-book name that is ALWAYS its value — so `prefix-name mapped-port`
+reject. A **lexer-collapsed bracketed list** `prefix [ X Y ]` / `prefix-name
+[ A B ]` / `nptv6-prefix [ P6a P6b ]` (#2419 strips the brackets onto one leaf's
+Keys — `["prefix","X","Y"]`) is the same escape in packed form: the round-2
+counter registers EVERY packed value after a target keyword as a distinct target,
+not just the first, so a two-value bracketed list rejects (the round-1 walk
+consumed only the first value and let the rest fall through — a residual #6484
+escape). Two role subtleties make the walk correct: (1) a `prefix-name` value is
+an OPAQUE address-book name that is ALWAYS its value — so `prefix-name mapped-port`
 (a pool literally NAMED "mapped-port") registers a genuine target, not a modifier
 carrier (the pre-#6484 counter wrongly pre-filtered a value equal to a modifier
-keyword and DISCARDED that target — the Codex second finding); (2) a `prefix` /
-`nptv6-prefix` value is an IP that can never be a modifier keyword, so a FOLLOWING
-`mapped-port` / `routing-instance` IS a modifier carrier (the canonical
-separate-set-line `prefix mapped-port <port>` form) and registers no second
-target. Counting DISTINCT identities (not occurrences) keeps the canonical
-"restate the target to attach a mapped-port" form — `then static-nat prefix-name
-N` + `then static-nat prefix-name N mapped-port 8080` — a single target (both
-restatements share identity `prefix-name\x00N`). Rejecting the multi-target rule
+keyword and DISCARDED that target). For a packed prefix-name the FIRST token is
+always consumed as the name; only a FOLLOWING keyword lexeme ends the packed-name
+run. (2) a `prefix` / `nptv6-prefix` value is an IP that can never be a modifier
+keyword, so a FOLLOWING `mapped-port` / `routing-instance` IS a modifier carrier
+(the canonical separate-set-line `prefix mapped-port <port>` form) and registers
+no second target. The grandchild walk applies the SAME slot classification: for a
+bare hierarchical `prefix-name { POOL; mapped-port 8080; }` the FIRST grandchild
+is the opaque name (`POOL`) and a LATER modifier grandchild (`mapped-port` /
+`routing-instance`) is skipped — so the rule counts ONE target, not two. The
+round-1 grandchild walk registered EVERY grandchild of a name-valued bare keyword
+as a target, counting `POOL` and `mapped-port` as two and FALSE-REJECTING a valid
+single-target rule that origin/master accepted (the round-2 second finding).
+Counting DISTINCT identities (not occurrences) keeps the canonical "restate the
+target to attach a mapped-port" form — `then static-nat prefix-name N` + `then
+static-nat prefix-name N mapped-port 8080` — a single target (both restatements
+share identity `prefix-name\x00N`). Rejecting the multi-target rule
 outright is the Junos-faithful closure and FORECLOSES the #6479 dropped-target
 mapped-port residual as a side effect (the rule never compiles, so no
 dropped-target modifier can slip). The gate runs in `runTailGates` AFTER the

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1964,15 +1964,34 @@ also dropped any `mapped-port` that rode ONLY on the discarded target (the #6479
 the mapped-port fold read. `validateStaticNATSingleTargetStrict` now counts the
 DISTINCT translation targets a rule declares — from the AST during compile
 (`staticNATThenTargetCount`, recorded as `StaticNATRule.ThenTargetCount`), BEFORE
-the fields collapse, across every authoring shape (the flat-set targets collapse
-onto one `static-nat` node's children; the hierarchical `then { static-nat {…}
-static-nat {…} }` shape spreads them across siblings) — and hard-rejects a rule
-declaring more than one. Counting DISTINCT `(keyword, value)` identities (not
-occurrences) is what keeps the canonical "restate the target to attach a
-mapped-port" form — `then static-nat prefix-name N` + `then static-nat
-prefix-name N mapped-port 8080` — a single target. Rejecting the multi-target
-rule outright is the Junos-faithful closure and FORECLOSES the #6479 dropped-
-target mapped-port residual as a side effect (the rule never compiles, so no
+the fields collapse — and hard-rejects a rule declaring more than one. The count
+is a GRAMMAR-ROLE-AWARE FULL TRAVERSAL (#6484), the SAME slot-classification walk
+the #6479 mapped-port scan uses (`staticNATCollectTargetIdentsFromKeys` mirrors
+`staticNATMappedPortOperandsFromKeys`): it walks the ENTIRE key stream of the
+`static-nat` node AND every child, plus the grandchild values of a bare keyword,
+classifying each position as a KEYWORD slot or a consumed VALUE slot. Reading only
+the FIRST `(keyword, value)` pair per node — the pre-#6484 `Keys[1]`/`Keys[2]` /
+`Children[0]` read — undercounted a rule whose two targets COLLAPSE onto one
+node/child and let it escape: the free-form `static-nat` leaf packs a one-line
+`prefix <ip> prefix-name POOL` / `prefix <ip> inet` / `prefix <ip> prefix <ip2>`
+onto a SINGLE child's Keys, and a hierarchical `prefix { <ip>; <ip2>; }` carries
+two prefix values as grandchildren of ONE `prefix` keyword — all counted 1 and
+ACCEPTED on master (the #6484 MAJOR). The full traversal registers every distinct
+`(keyword, value)` identity across the whole leaf, so these now count 2 and
+reject. Two role subtleties make the walk correct: (1) a `prefix-name` value is an
+OPAQUE address-book name that is ALWAYS its value — so `prefix-name mapped-port`
+(a pool literally NAMED "mapped-port") registers a genuine target, not a modifier
+carrier (the pre-#6484 counter wrongly pre-filtered a value equal to a modifier
+keyword and DISCARDED that target — the Codex second finding); (2) a `prefix` /
+`nptv6-prefix` value is an IP that can never be a modifier keyword, so a FOLLOWING
+`mapped-port` / `routing-instance` IS a modifier carrier (the canonical
+separate-set-line `prefix mapped-port <port>` form) and registers no second
+target. Counting DISTINCT identities (not occurrences) keeps the canonical
+"restate the target to attach a mapped-port" form — `then static-nat prefix-name
+N` + `then static-nat prefix-name N mapped-port 8080` — a single target (both
+restatements share identity `prefix-name\x00N`). Rejecting the multi-target rule
+outright is the Junos-faithful closure and FORECLOSES the #6479 dropped-target
+mapped-port residual as a side effect (the rule never compiles, so no
 dropped-target modifier can slip). The gate runs in `runTailGates` AFTER the
 host-mask (#2173) and NPTv6 (#2240/#5818) gates, so a rule that ALSO carries a
 malformed `mapped-port` or a bad nptv6 prefix reports that concrete token first

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1948,6 +1948,42 @@ above (`buildNAT64Snapshots` from `cfg.Security.NAT.NAT64`), which is unaffected
 Tests: `static_nat_inet_failclosed_5859_test.go` (both `pkg/config` and
 `pkg/dataplane/userspace`).
 
+**A static-NAT rule has EXACTLY ONE translation target (#6483).** A Junos
+`then static-nat` maps to exactly one of `prefix <ip>` | `prefix-name <name>`
+(#4290) | `nptv6-prefix <p6>` | `inet` (#5859). Authoring two or more — both a
+`prefix` and a `prefix-name`, an `inet` sibling alongside a `prefix` sibling, two
+`prefix` targets — is invalid Junos, but the compiler silently accepted it: the
+`compileNATStatic` child loop honors the FIRST target it matches by a fixed
+priority (`nptv6-prefix` > `prefix-name` > `prefix` > `inet`) and drops the rest,
+and because `prefix` / `inet` / `nptv6-prefix` all land in the shared `Then`
+field a later target simply overwrites an earlier one. The rule compiled to one
+arbitrary target with no operator feedback — `inet` + `prefix` even installed as
+a plain prefix rule, EVADING the #5859 `inet` reject. Dropping a target this way
+also dropped any `mapped-port` that rode ONLY on the discarded target (the #6479
+/ C179-038 residual), because that target's node was never the one whose modifier
+the mapped-port fold read. `validateStaticNATSingleTargetStrict` now counts the
+DISTINCT translation targets a rule declares — from the AST during compile
+(`staticNATThenTargetCount`, recorded as `StaticNATRule.ThenTargetCount`), BEFORE
+the fields collapse, across every authoring shape (the flat-set targets collapse
+onto one `static-nat` node's children; the hierarchical `then { static-nat {…}
+static-nat {…} }` shape spreads them across siblings) — and hard-rejects a rule
+declaring more than one. Counting DISTINCT `(keyword, value)` identities (not
+occurrences) is what keeps the canonical "restate the target to attach a
+mapped-port" form — `then static-nat prefix-name N` + `then static-nat
+prefix-name N mapped-port 8080` — a single target. Rejecting the multi-target
+rule outright is the Junos-faithful closure and FORECLOSES the #6479 dropped-
+target mapped-port residual as a side effect (the rule never compiles, so no
+dropped-target modifier can slip). The gate runs in `runTailGates` AFTER the
+host-mask (#2173) and NPTv6 (#2240/#5818) gates, so a rule that ALSO carries a
+malformed `mapped-port` or a bad nptv6 prefix reports that concrete token first
+(the multi-target defect is still caught on the next compile once the token is
+fixed — never masked). Strict on commit / commit-check (hard reject); the
+tolerant load / peer-sync path downgrades to a warning (#1960 no-brick) — the
+compiler still lowers the single honored target, so a leniently-loaded config is
+no worse than before the gate. A well-formed single-target rule (any of the four,
+in any authoring shape, with or without a `mapped-port` / `routing-instance`
+modifier) is unaffected. Tests: `static_nat_multitarget_6483_test.go`.
+
 **The systematic per-subtree closure continues (#4313).** Each of the flips
 above (destination-NAT then, the three IPsec option containers, master-password,
 the Phase-1 IKE proposal, now the Phase-2 IPsec proposal and the two
@@ -3675,6 +3711,13 @@ reserved for whole-dataplane selection where a rewrite shim
     `combineMappedPortOperands` fails closed on. In every shape a
     present-but-malformed mapped-port is surfaced (strict reject / lenient
     warn), never silently accepted, and no bogus non-zero port is installed.
+    The one residual this fold could not reach — a malformed mapped-port riding
+    ONLY on a target the compiler DROPS when a rule declares more than one
+    translation target (the dropped target's node is never the one the
+    mapped-port fold reads) — is closed by the single-target cardinality gate
+    (#6483, `validateStaticNATSingleTargetStrict`): a multi-target static-nat
+    rule is rejected outright, so no dropped-target modifier can slip. See "A
+    static-NAT rule has EXACTLY ONE translation target" above.
   - `security nat source/destination rule-set rule match
     destination-address-name <book-entry>` (#3229) — the destination twin
     of the `source-address-name` leaf (#2416). It references an

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,7 +1,7 @@
 [REFACTOR]   5172  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [REFACTOR]   3666  userspace-dp/src/policy.rs
 [REFACTOR]   3437  userspace-dp/src/nat64.rs
-[REFACTOR]   2865  pkg/config/compiler_validate_strict_nat.go
+[REFACTOR]   2928  pkg/config/compiler_validate_strict_nat.go
 [REFACTOR]   2383  userspace-dp/src/nat/allocator.rs
 [REFACTOR]   2288  pkg/ddns/surface_a.go
 [REFACTOR]   2257  pkg/policymatch/policymatch.go

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -504,6 +504,28 @@ var staticNATModifierKeywords = map[string]struct{}{
 	"routing-instance": {},
 }
 
+// isStaticNATKeywordLexeme reports whether tok is a static-nat grammar keyword —
+// a translation-target keyword, a trailing modifier keyword, or the "static-nat"
+// leaf name — as opposed to an operand VALUE. The bracketed/packed multi-value
+// target scan (staticNATCollectTargetIdentsFromKeys) uses it to end a value run:
+// after a `prefix`/`nptv6-prefix`/`prefix-name` keyword its IP prefix or address-
+// book name value can appear one-or-more times (a lexer-collapsed bracketed list,
+// #2419), and the run terminates at the first token that is a grammar keyword —
+// a trailing modifier or a new target — which a bracketed value list never
+// contains. For prefix/nptv6-prefix the value is an IP that can never equal one
+// of these lexemes; for prefix-name the FIRST value is consumed unconditionally
+// (a pool may be NAMED "mapped-port"/"prefix"), so the lexeme test only bounds
+// the SECOND-and-later packed values.
+func isStaticNATKeywordLexeme(tok string) bool {
+	if _, ok := staticNATTargetKeywords[tok]; ok {
+		return true
+	}
+	if _, ok := staticNATModifierKeywords[tok]; ok {
+		return true
+	}
+	return tok == "static-nat"
+}
+
 // staticNATCollectTargetIdentsFromKeys walks a collapsed static-nat key slice —
 // a target child's Keys (`["prefix","<ip>","prefix-name","POOL"]`), the static-nat
 // node's own Keys, or a hierarchical bare keyword's Keys (`["prefix"]`) — in
@@ -516,18 +538,27 @@ var staticNATModifierKeywords = map[string]struct{}{
 // `Keys[1]`/`Keys[2]` read) let a genuine multi-target rule whose targets collapse
 // onto ONE node/child count as one and escape the >1 gate.
 //
+// A lexer-collapsed bracketed list (`prefix [ X Y ]` → ["prefix","X","Y"], #2419)
+// packs SEVERAL target values after ONE keyword; each value is a DISTINCT target,
+// so the scan registers EVERY packed value, not just the first (the pre-#6484
+// single-value read let `prefix [ X Y ]` count 1 and escape the >1 gate).
+//
 // Per-token roles:
 //   - `inet`                     → identity "inet"; NO value slot (i += 1).
-//   - `prefix <ip>` /
-//     `nptv6-prefix <p6>`        → identity "<kw>\x00<ip>"; the value is an IP that
-//     can never be a modifier keyword, so a FOLLOWING mapped-port/routing-instance
-//     is a MODIFIER CARRIER (the canonical separate-set-line `prefix mapped-port
-//     <p>` form) — register nothing, advance one, and let the modifier consume its
-//     own operand. Otherwise consume the IP value (i += 2).
-//   - `prefix-name <name>`       → identity "prefix-name\x00<name>"; the value is an
-//     OPAQUE address-book name that may be literally "mapped-port"/"routing-
-//     instance"/"prefix", so it is ALWAYS consumed as the value (i += 2) — never
-//     re-classified as a modifier that would erase the target (#6479 name-slot).
+//   - `prefix <ip> [<ip>...]` /
+//     `nptv6-prefix <p6> [...]`  → identity "<kw>\x00<ip>" for EACH value. The
+//     value is an IP that can never be a keyword lexeme. If the token right after
+//     the keyword is a modifier the node is a MODIFIER CARRIER (the canonical
+//     separate-set-line `prefix mapped-port <p>` form) — register nothing and let
+//     the modifier consume its own operand. Otherwise consume EVERY following
+//     non-keyword token as a distinct packed IP value, stopping at the first
+//     trailing modifier or new target keyword.
+//   - `prefix-name <name> [...]` → identity "prefix-name\x00<name>" for EACH name.
+//     The FIRST token is the OPAQUE address-book name — always consumed as the
+//     value, even if it reads "mapped-port"/"routing-instance"/"prefix" (a pool may
+//     be so named), never re-classified as a modifier that would erase the target
+//     (#6479 name-slot). Further non-keyword tokens are additional packed names,
+//     each a distinct target; the run stops at the first modifier/target keyword.
 //   - `mapped-port <p>` /
 //     `routing-instance <ri>`    → a MODIFIER; consume its operand (i += 2),
 //     register no target. Consuming routing-instance's opaque-name operand keeps a
@@ -541,21 +572,41 @@ func staticNATCollectTargetIdentsFromKeys(keys []string, set map[string]struct{}
 			set["inet"] = struct{}{} // no value slot
 			i++
 		case tok == "prefix-name":
-			// Name-valued target: the next token is an opaque name, consumed
-			// verbatim even if it reads "mapped-port" (a pool may be so named).
-			if i+1 < len(keys) {
-				set["prefix-name\x00"+keys[i+1]] = struct{}{}
-			}
-			i += 2
-		case tok == "prefix" || tok == "nptv6-prefix":
-			if i+1 < len(keys) {
-				if _, mod := staticNATModifierKeywords[keys[i+1]]; mod {
-					i++ // modifier carrier (`prefix mapped-port <p>`): not a target
-					continue
+			// Name-valued target. The FIRST token after the keyword is ALWAYS the
+			// opaque address-book name — consumed verbatim even if it reads
+			// "mapped-port"/"prefix" (a pool may be so named). Any FURTHER
+			// non-keyword tokens are additional bracketed/packed name values
+			// (`prefix-name [ A B ]` collapses to ["prefix-name","A","B"], #2419),
+			// each a DISTINCT target; a trailing modifier or new target keyword
+			// ends the name run (a bracketed value list contains no keyword).
+			i++
+			if i < len(keys) {
+				set["prefix-name\x00"+keys[i]] = struct{}{}
+				i++
+				for i < len(keys) && !isStaticNATKeywordLexeme(keys[i]) {
+					set["prefix-name\x00"+keys[i]] = struct{}{}
+					i++
 				}
-				set[tok+"\x00"+keys[i+1]] = struct{}{}
 			}
-			i += 2 // consume the IP value slot
+		case tok == "prefix" || tok == "nptv6-prefix":
+			i++
+			if i < len(keys) {
+				if _, mod := staticNATModifierKeywords[keys[i]]; mod {
+					// Modifier carrier (`prefix mapped-port <p>`, the canonical
+					// separate-set-line form): NO prefix value on this node — the
+					// value rode a restate line. Register nothing; the modifier
+					// case below consumes its own operand.
+					break
+				}
+				// First IP value + any further bracketed/packed IP values
+				// (`prefix [ X Y ]` → ["prefix","X","Y"]), each a DISTINCT target.
+				// An IP prefix can never be a keyword lexeme, so the run stops at
+				// the first trailing modifier or new target keyword.
+				for i < len(keys) && !isStaticNATKeywordLexeme(keys[i]) {
+					set[tok+"\x00"+keys[i]] = struct{}{}
+					i++
+				}
+			}
 		case tok == "mapped-port" || tok == "routing-instance":
 			i += 2 // modifier consumes its own operand; not a target
 		default:
@@ -585,12 +636,15 @@ func staticNATCollectTargetIdentsFromKeys(keys []string, set map[string]struct{}
 // node's own Keys AND every child's Keys through the grammar-role-aware
 // staticNATCollectTargetIdentsFromKeys (so the one-line
 // `prefix <ip> prefix-name POOL` / `prefix <ip> inet` / `prefix <ip> prefix <ip2>`
-// collapse — where two targets land on ONE child's Keys — is counted), and
-// expands the hierarchical value-as-child shape (`prefix { <ip>; <ip2>; }`, where
-// each grandchild is a distinct prefix value). A MODIFIER CARRIER (`prefix
+// collapse — where two targets land on ONE child's Keys — is counted, as is a
+// lexer-collapsed bracketed list `prefix [ X Y ]` / `prefix-name [ A B ]`, #2419),
+// and expands the hierarchical value-as-child shape (`prefix { <ip>; <ip2>; }`,
+// where each grandchild is a distinct prefix value). A MODIFIER CARRIER (`prefix
 // mapped-port <port>`) and a modifier riding a target (`prefix <ip> mapped-port
-// <p>`, target `routing-instance <ri>`) are NOT extra targets — the walk consumes
-// them — matching how staticNATMappedPortForNode reads the same node.
+// <p>`, target `routing-instance <ri>`, or a `prefix-name { POOL; mapped-port P; }`
+// block whose nested mapped-port is a modifier — NOT a second name) are NOT extra
+// targets — the walk consumes them — matching how staticNATMappedPortForNode reads
+// the same node.
 func staticNATCollectTargetIdents(t *Node, set map[string]struct{}) {
 	// The static-nat node's own Keys (a shape that would collapse the target onto
 	// ["static-nat","prefix","<ip>", ...]); the leading "static-nat" is a harmless
@@ -607,20 +661,32 @@ func staticNATCollectTargetIdents(t *Node, set map[string]struct{}) {
 		staticNATCollectTargetIdentsFromKeys(c.Keys, set)
 		// Hierarchical value-as-child: a bare target keyword `prefix { <ip>; ... }`
 		// carries its value(s) as grandchildren (child Keys are just ["prefix"]).
-		// EACH grandchild value is a distinct target (two `prefix { X; Y; }` grand-
-		// children = two prefixes → count 2). Skipped when the value rides inline on
-		// the child's Keys (len >= 2), because then any grandchild is a nested
-		// modifier (`prefix <ip> { mapped-port P; }`), not another value.
+		// Each VALUE grandchild is a distinct target (two `prefix { X; Y; }` grand-
+		// children = two prefixes → count 2), but a nested MODIFIER grandchild
+		// (`mapped-port`/`routing-instance`) is skipped — so `prefix-name { POOL;
+		// mapped-port 8080; }` is ONE target, not two (the #6484 second finding).
+		// Skipped entirely when the value rides inline on the child's Keys (len >=
+		// 2), because then any grandchild is a nested modifier (`prefix <ip> {
+		// mapped-port P; }`), not another value.
 		kw := c.Name()
 		if _, isTarget := staticNATTargetKeywords[kw]; !isTarget || kw == "inet" || len(c.Keys) >= 2 {
 			continue
 		}
 		nameValued := kw == "prefix-name" // opaque names; "mapped-port" is legal
-		for _, gc := range c.Children {
+		for gi, gc := range c.Children {
 			gname := gc.Name()
-			if !nameValued {
+			// A nested modifier grandchild (`mapped-port <p>` / `routing-instance
+			// <ri>`) is NOT a target value. For prefix/nptv6-prefix (IP-valued) a
+			// modifier can never be confused with a value, so skip it wherever it
+			// appears. For prefix-name the FIRST grandchild is the OPAQUE pool name
+			// — a pool may be NAMED "mapped-port", so it is consumed unconditionally;
+			// only a LATER modifier grandchild is the genuine modifier and is
+			// skipped. Without the gi>0 guard a bare `prefix-name { POOL;
+			// mapped-port 8080; }` registered both POOL and mapped-port and
+			// FALSE-REJECTED a valid single-target rule (the #6484 second finding).
+			if !(nameValued && gi == 0) {
 				if _, mod := staticNATModifierKeywords[gname]; mod {
-					continue // a nested `mapped-port { P; }` modifier, not a prefix value
+					continue // a nested modifier grandchild, not a target value
 				}
 			}
 			set[kw+"\x00"+gname] = struct{}{}

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -472,6 +472,109 @@ func resolveStaticNATThenPrefixNames(sec *SecurityConfig) {
 	}
 }
 
+// staticNATTargetKeywords is the set of `then static-nat` keywords that name a
+// mutually-exclusive TRANSLATION TARGET — the destination a 1:1 rule maps to. A
+// well-formed static-NAT rule declares EXACTLY ONE of them (#6483). They are
+// distinct from the trailing MODIFIER keywords (mapped-port, routing-instance),
+// which refine a target rather than being one.
+var staticNATTargetKeywords = map[string]struct{}{
+	"prefix":       {},
+	"prefix-name":  {},
+	"nptv6-prefix": {},
+	"inet":         {},
+}
+
+// staticNATModifierKeywords are the `then static-nat` trailer keywords that are
+// NOT targets. When one sits in a target keyword's VALUE slot the node is a
+// MODIFIER CARRIER, not a second target — e.g. the canonical Junos separate-set-
+// line `then static-nat prefix mapped-port <port>` collapses to a `prefix` node
+// whose value slot is `mapped-port` (#6479 canonical form), and the trailing
+// `routing-instance <ri>` (#4292) rides the same way. staticNATNodeTargetCount
+// excludes these so a lone target carrying a modifier still counts as one target.
+var staticNATModifierKeywords = map[string]struct{}{
+	"mapped-port":      {},
+	"routing-instance": {},
+}
+
+// staticNATCollectTargetIdents adds a stable IDENTITY string for each translation
+// target one `static-nat` `then` node declares into set (#6483). A target's
+// identity is its keyword plus, for the address/name targets, its value token
+// (inet has no value, so its identity is just "inet"). Using a SET keyed by
+// identity — rather than an occurrence count — is what makes the Junos "restate
+// the target to attach a modifier" idiom count as ONE target: the canonical
+// separate-set-line mapped-port form authors the SAME target twice,
+//
+//	set ... then static-nat prefix-name TARGET
+//	set ... then static-nat prefix-name TARGET mapped-port 8080   (#5523)
+//
+// which SetPath keeps as two `prefix-name` children with the SAME value TARGET;
+// both map to identity "prefix-name\x00TARGET" and collapse to one. Two GENUINELY
+// different targets (a prefix and a prefix-name, an inet and a prefix, or two
+// different prefixes) map to different identities and stay distinct.
+//
+// It reads BOTH the collapsed-keys shape (the free-form static-nat leaf absorbs
+// `prefix <ip>` onto t.Keys) AND the child shape (a `prefix`/`prefix-name`/
+// `nptv6-prefix`/`inet` child leaf — the shape SetPath produces when several
+// targets land under one static-nat node, or the hierarchical `prefix { <ip>; }`
+// nesting). A MODIFIER CARRIER whose value slot is a modifier keyword
+// (`prefix mapped-port <port>` — the collapsed canonical form, or the ambiguous
+// name-slot `prefix-name mapped-port <p>`) is NOT a target and is skipped,
+// matching how staticNATMappedPortForNode reads that same node.
+func staticNATCollectTargetIdents(t *Node, set map[string]struct{}) {
+	add := func(kw, val string) {
+		if kw == "inet" {
+			set["inet"] = struct{}{} // inet has no value slot
+			return
+		}
+		if _, mod := staticNATModifierKeywords[val]; mod {
+			return // modifier carrier (`prefix mapped-port <p>`), not a target
+		}
+		set[kw+"\x00"+val] = struct{}{}
+	}
+	// Collapsed-keys target: ["static-nat","<target-kw>","<value>", ...].
+	if len(t.Keys) >= 2 {
+		if _, ok := staticNATTargetKeywords[t.Keys[1]]; ok {
+			val := ""
+			if len(t.Keys) >= 3 {
+				val = t.Keys[2]
+			}
+			if t.Keys[1] == "inet" || val != "" {
+				add(t.Keys[1], val)
+			}
+		}
+	}
+	// Child targets: a `prefix`/`prefix-name`/`nptv6-prefix`/`inet` child leaf.
+	for _, c := range t.Children {
+		kw := c.Name()
+		if _, ok := staticNATTargetKeywords[kw]; !ok {
+			continue // a mapped-port / routing-instance sibling — a modifier, not a target
+		}
+		val := ""
+		if len(c.Keys) >= 2 {
+			val = c.Keys[1]
+		} else if len(c.Children) > 0 {
+			val = c.Children[0].Name() // hierarchical `prefix { <ip>; }`
+		}
+		add(kw, val)
+	}
+}
+
+// staticNATThenTargetCount returns how many DISTINCT translation targets one
+// `then {}` block declares across EVERY `static-nat` sibling node in it (#6483).
+// The flat-set shape collapses targets onto a single static-nat node with several
+// target children; the hierarchical shape carries one target per static-nat
+// sibling. Either way the distinct-identity count is the rule's declared target
+// cardinality for that block, which the strict gate
+// (validateStaticNATSingleTargetStrict) requires to be at most one. Restatements
+// of the same target (to attach a mapped-port) share an identity and count once.
+func staticNATThenTargetCount(thenNode *Node) int {
+	set := make(map[string]struct{})
+	for _, t := range thenNode.FindChildren("static-nat") {
+		staticNATCollectTargetIdents(t, set)
+	}
+	return len(set)
+}
+
 func compileNATStatic(node *Node, sec *SecurityConfig) error {
 	for _, rsInst := range namedInstances(node.FindChildren("rule-set")) {
 		// #3096: capture from scope across zone | interface |
@@ -560,6 +663,15 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 				// then-set fields so only the LAST then-block's spec survives.
 				rule.ThenPrefixName = ""
 				rule.ThenRoutingInstance = ""
+				// #6483: count the translation targets THIS `then` block declares,
+				// from the AST, BEFORE the if/else chain below collapses them into
+				// the shared Then/ThenPrefixName fields (prefix/inet/nptv6 all
+				// overwrite Then, so the final field state cannot reveal a
+				// >1-target rule). Assigned (not accumulated) per block so the LAST
+				// block wins, matching the #3850 last-then-block-wins semantics the
+				// field resets above encode. validateStaticNATSingleTargetStrict
+				// rejects a count > 1.
+				rule.ThenTargetCount = staticNATThenTargetCount(thenNode)
 				for _, t := range thenNode.Children {
 					if t.Name() == "static-nat" {
 						if len(t.Keys) >= 3 && t.Keys[1] == "nptv6-prefix" {

--- a/pkg/config/compiler_nat_static.go
+++ b/pkg/config/compiler_nat_static.go
@@ -485,21 +485,89 @@ var staticNATTargetKeywords = map[string]struct{}{
 }
 
 // staticNATModifierKeywords are the `then static-nat` trailer keywords that are
-// NOT targets. When one sits in a target keyword's VALUE slot the node is a
-// MODIFIER CARRIER, not a second target — e.g. the canonical Junos separate-set-
-// line `then static-nat prefix mapped-port <port>` collapses to a `prefix` node
-// whose value slot is `mapped-port` (#6479 canonical form), and the trailing
-// `routing-instance <ri>` (#4292) rides the same way. staticNATNodeTargetCount
-// excludes these so a lone target carrying a modifier still counts as one target.
+// NOT targets: they refine a target rather than being one. When one follows an
+// IP-VALUED target keyword (prefix / nptv6-prefix, whose value can never be a
+// keyword lexeme) the node is a MODIFIER CARRIER, not a second target — e.g. the
+// canonical Junos separate-set-line `then static-nat prefix mapped-port <port>`
+// collapses to a `prefix` leaf whose value slot is `mapped-port` (#6479 canonical
+// form), and the trailing `routing-instance <ri>` (#4292) rides the same way.
+// staticNATCollectTargetIdentsFromKeys uses this set to skip a modifier carrier
+// so a lone target carrying a modifier still counts as ONE target.
+//
+// This carrier-skip is deliberately NOT applied after a NAME-valued keyword
+// (prefix-name / routing-instance): their value is an OPAQUE address-book / VRF
+// name that may be literally "mapped-port" (#6479 second finding), so the token
+// after such a keyword is ALWAYS its value and is consumed as such — never
+// re-classified as a modifier that would erase the target.
 var staticNATModifierKeywords = map[string]struct{}{
 	"mapped-port":      {},
 	"routing-instance": {},
 }
 
+// staticNATCollectTargetIdentsFromKeys walks a collapsed static-nat key slice —
+// a target child's Keys (`["prefix","<ip>","prefix-name","POOL"]`), the static-nat
+// node's own Keys, or a hierarchical bare keyword's Keys (`["prefix"]`) — in
+// GRAMMAR ORDER and registers a stable IDENTITY into set for every translation
+// target it declares (#6483). It is the SAME slot-classification walk
+// staticNATMappedPortOperandsFromKeys uses for the mapped-port scan (#6479): it
+// tracks whether each position is a KEYWORD slot or a token already CONSUMED as a
+// preceding keyword's value, so a value that is literally a keyword lexeme is
+// never re-read as a keyword. Reading only the FIRST target pair (the pre-#6484
+// `Keys[1]`/`Keys[2]` read) let a genuine multi-target rule whose targets collapse
+// onto ONE node/child count as one and escape the >1 gate.
+//
+// Per-token roles:
+//   - `inet`                     → identity "inet"; NO value slot (i += 1).
+//   - `prefix <ip>` /
+//     `nptv6-prefix <p6>`        → identity "<kw>\x00<ip>"; the value is an IP that
+//     can never be a modifier keyword, so a FOLLOWING mapped-port/routing-instance
+//     is a MODIFIER CARRIER (the canonical separate-set-line `prefix mapped-port
+//     <p>` form) — register nothing, advance one, and let the modifier consume its
+//     own operand. Otherwise consume the IP value (i += 2).
+//   - `prefix-name <name>`       → identity "prefix-name\x00<name>"; the value is an
+//     OPAQUE address-book name that may be literally "mapped-port"/"routing-
+//     instance"/"prefix", so it is ALWAYS consumed as the value (i += 2) — never
+//     re-classified as a modifier that would erase the target (#6479 name-slot).
+//   - `mapped-port <p>` /
+//     `routing-instance <ri>`    → a MODIFIER; consume its operand (i += 2),
+//     register no target. Consuming routing-instance's opaque-name operand keeps a
+//     VRF NAMED "prefix"/"inet" from being re-read as a target.
+//   - a leading "static-nat" or any stray token → advance one, register nothing.
+func staticNATCollectTargetIdentsFromKeys(keys []string, set map[string]struct{}) {
+	for i := 0; i < len(keys); {
+		tok := keys[i]
+		switch {
+		case tok == "inet":
+			set["inet"] = struct{}{} // no value slot
+			i++
+		case tok == "prefix-name":
+			// Name-valued target: the next token is an opaque name, consumed
+			// verbatim even if it reads "mapped-port" (a pool may be so named).
+			if i+1 < len(keys) {
+				set["prefix-name\x00"+keys[i+1]] = struct{}{}
+			}
+			i += 2
+		case tok == "prefix" || tok == "nptv6-prefix":
+			if i+1 < len(keys) {
+				if _, mod := staticNATModifierKeywords[keys[i+1]]; mod {
+					i++ // modifier carrier (`prefix mapped-port <p>`): not a target
+					continue
+				}
+				set[tok+"\x00"+keys[i+1]] = struct{}{}
+			}
+			i += 2 // consume the IP value slot
+		case tok == "mapped-port" || tok == "routing-instance":
+			i += 2 // modifier consumes its own operand; not a target
+		default:
+			i++ // leading "static-nat" or a stray token
+		}
+	}
+}
+
 // staticNATCollectTargetIdents adds a stable IDENTITY string for each translation
 // target one `static-nat` `then` node declares into set (#6483). A target's
-// identity is its keyword plus, for the address/name targets, its value token
-// (inet has no value, so its identity is just "inet"). Using a SET keyed by
+// identity is its keyword plus, for the address/name/prefix targets, its value
+// token (inet has no value, so its identity is just "inet"). Using a SET keyed by
 // identity — rather than an occurrence count — is what makes the Junos "restate
 // the target to attach a modifier" idiom count as ONE target: the canonical
 // separate-set-line mapped-port form authors the SAME target twice,
@@ -509,53 +577,54 @@ var staticNATModifierKeywords = map[string]struct{}{
 //
 // which SetPath keeps as two `prefix-name` children with the SAME value TARGET;
 // both map to identity "prefix-name\x00TARGET" and collapse to one. Two GENUINELY
-// different targets (a prefix and a prefix-name, an inet and a prefix, or two
-// different prefixes) map to different identities and stay distinct.
+// different targets (a prefix and a prefix-name, an inet and a prefix, two
+// different prefixes, or a pool NAMED "mapped-port" alongside a prefix) map to
+// different identities and stay distinct.
 //
-// It reads BOTH the collapsed-keys shape (the free-form static-nat leaf absorbs
-// `prefix <ip>` onto t.Keys) AND the child shape (a `prefix`/`prefix-name`/
-// `nptv6-prefix`/`inet` child leaf — the shape SetPath produces when several
-// targets land under one static-nat node, or the hierarchical `prefix { <ip>; }`
-// nesting). A MODIFIER CARRIER whose value slot is a modifier keyword
-// (`prefix mapped-port <port>` — the collapsed canonical form, or the ambiguous
-// name-slot `prefix-name mapped-port <p>`) is NOT a target and is skipped,
-// matching how staticNATMappedPortForNode reads that same node.
+// It FULLY TRAVERSES the node, not just the first pair: it walks the static-nat
+// node's own Keys AND every child's Keys through the grammar-role-aware
+// staticNATCollectTargetIdentsFromKeys (so the one-line
+// `prefix <ip> prefix-name POOL` / `prefix <ip> inet` / `prefix <ip> prefix <ip2>`
+// collapse — where two targets land on ONE child's Keys — is counted), and
+// expands the hierarchical value-as-child shape (`prefix { <ip>; <ip2>; }`, where
+// each grandchild is a distinct prefix value). A MODIFIER CARRIER (`prefix
+// mapped-port <port>`) and a modifier riding a target (`prefix <ip> mapped-port
+// <p>`, target `routing-instance <ri>`) are NOT extra targets — the walk consumes
+// them — matching how staticNATMappedPortForNode reads the same node.
 func staticNATCollectTargetIdents(t *Node, set map[string]struct{}) {
-	add := func(kw, val string) {
-		if kw == "inet" {
-			set["inet"] = struct{}{} // inet has no value slot
-			return
-		}
-		if _, mod := staticNATModifierKeywords[val]; mod {
-			return // modifier carrier (`prefix mapped-port <p>`), not a target
-		}
-		set[kw+"\x00"+val] = struct{}{}
-	}
-	// Collapsed-keys target: ["static-nat","<target-kw>","<value>", ...].
-	if len(t.Keys) >= 2 {
-		if _, ok := staticNATTargetKeywords[t.Keys[1]]; ok {
-			val := ""
-			if len(t.Keys) >= 3 {
-				val = t.Keys[2]
-			}
-			if t.Keys[1] == "inet" || val != "" {
-				add(t.Keys[1], val)
-			}
-		}
-	}
-	// Child targets: a `prefix`/`prefix-name`/`nptv6-prefix`/`inet` child leaf.
+	// The static-nat node's own Keys (a shape that would collapse the target onto
+	// ["static-nat","prefix","<ip>", ...]); the leading "static-nat" is a harmless
+	// stray token in the walk. In practice SetPath/the parser put the target on a
+	// child, but walk t.Keys too so no collapse shape is missed (identities dedup).
+	staticNATCollectTargetIdentsFromKeys(t.Keys, set)
 	for _, c := range t.Children {
+		// A target/modifier child. Its Keys carry the collapsed token stream:
+		// ["prefix","<ip>","prefix-name","POOL"] (one-line multi-target escape),
+		// ["prefix","<ip>","mapped-port","<p>"] (single target + modifier),
+		// ["prefix-name","POOL"] / ["prefix-name","mapped-port"] (bare target, the
+		// latter a pool NAMED "mapped-port"), or ["mapped-port","<p>"] (a modifier
+		// sibling — registers nothing).
+		staticNATCollectTargetIdentsFromKeys(c.Keys, set)
+		// Hierarchical value-as-child: a bare target keyword `prefix { <ip>; ... }`
+		// carries its value(s) as grandchildren (child Keys are just ["prefix"]).
+		// EACH grandchild value is a distinct target (two `prefix { X; Y; }` grand-
+		// children = two prefixes → count 2). Skipped when the value rides inline on
+		// the child's Keys (len >= 2), because then any grandchild is a nested
+		// modifier (`prefix <ip> { mapped-port P; }`), not another value.
 		kw := c.Name()
-		if _, ok := staticNATTargetKeywords[kw]; !ok {
-			continue // a mapped-port / routing-instance sibling — a modifier, not a target
+		if _, isTarget := staticNATTargetKeywords[kw]; !isTarget || kw == "inet" || len(c.Keys) >= 2 {
+			continue
 		}
-		val := ""
-		if len(c.Keys) >= 2 {
-			val = c.Keys[1]
-		} else if len(c.Children) > 0 {
-			val = c.Children[0].Name() // hierarchical `prefix { <ip>; }`
+		nameValued := kw == "prefix-name" // opaque names; "mapped-port" is legal
+		for _, gc := range c.Children {
+			gname := gc.Name()
+			if !nameValued {
+				if _, mod := staticNATModifierKeywords[gname]; mod {
+					continue // a nested `mapped-port { P; }` modifier, not a prefix value
+				}
+			}
+			set[kw+"\x00"+gname] = struct{}{}
 		}
-		add(kw, val)
 	}
 }
 

--- a/pkg/config/compiler_tailgates.go
+++ b/pkg/config/compiler_tailgates.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 // runTailGates runs the P7 "tail gates" phase of config compilation — the
 // contiguous trailing validation / finalization gate sequence extracted from
 // compileExpanded as step 3 of the #4406 god-orchestrator decomposition
@@ -161,6 +163,34 @@ func runTailGates(cfg *Config, opts compileOpts) error {
 		return err
 	}
 	cfg.Warnings = append(cfg.Warnings, nptv6ScopeWarnings...)
+
+	// #6483: static-NAT single-translation-target cardinality gate. A Junos
+	// static-nat rule maps to EXACTLY ONE of `prefix`/`prefix-name`/
+	// `nptv6-prefix`/`inet`; authoring two or more (both a prefix and a
+	// prefix-name, an inet sibling plus a prefix sibling, two prefixes, …) is
+	// invalid but the compiler silently accepted it by honoring one target (by a
+	// fixed priority) and dropping the rest into the shared Then field — which
+	// also let a malformed `mapped-port` riding on a dropped target slip through
+	// (the #6479/C179-038 residual). Runs AFTER the host-mask (#2173) and NPTv6
+	// (#2240/#5818) gates so a rule that ALSO carries a malformed mapped-port or a
+	// bad nptv6 prefix reports that concrete token first (the multi-target defect
+	// is still caught on the next compile once the token is fixed — never masked);
+	// a rule whose ONLY defect is the extra target — or one whose dropped-target
+	// mapped-port those earlier gates never saw (the residual) — is caught here.
+	// Strict (commit / commit-check): hard-reject so the multi-target rule is
+	// operator-visible. Lenient (load / peer-sync): warn (opts.lenientFirewallRefs,
+	// the same opt the sibling static-NAT target gates use) so a config persisted
+	// before this gate existed still boots (#1960 no-brick); the compiler still
+	// lowers the single honored target, so a leniently-loaded config is no worse
+	// than before the gate.
+	if err := validateStaticNATSingleTargetStrict(cfg); err != nil {
+		if opts.lenientFirewallRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("static NAT translation-target cardinality (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return err
+		}
+	}
 
 	// #3886: NAT64 prefix commit gate. A NAT64 rule-set `prefix` is read
 	// verbatim into the wire snapshot and parsed at dataplane apply by the Rust

--- a/pkg/config/compiler_validate_strict_nat.go
+++ b/pkg/config/compiler_validate_strict_nat.go
@@ -2140,6 +2140,69 @@ func validateStaticNATInetTargetStrict(cfg *Config) error {
 	return nil
 }
 
+// validateStaticNATSingleTargetStrict (#6483) hard-rejects a static-NAT rule
+// that declares MORE THAN ONE translation target. A Junos static-nat rule maps
+// to EXACTLY ONE of `prefix <ip>` | `prefix-name <name>` | `nptv6-prefix <p6>` |
+// `inet`; authoring two or more (e.g. `then static-nat prefix <ip>` plus `then
+// static-nat prefix-name <pool>`, or an `inet` sibling alongside a `prefix`
+// sibling) is invalid.
+//
+// The compiler otherwise silently ACCEPTED such a rule: the compileNATStatic
+// child loop honors the FIRST target it matches by a fixed priority
+// (nptv6-prefix > prefix-name > prefix > inet) and drops the rest, and because
+// prefix / inet / nptv6-prefix all land in the shared Then field a later target
+// simply overwrites an earlier one — so the rule compiled to a single arbitrary
+// target with no operator feedback (`inet` + `prefix` even installs as a plain
+// prefix rule, evading the #5859 inet reject). Dropping a target this way also
+// dropped any `mapped-port` that rode ONLY on the discarded target — the
+// #6479/C179-038 residual — because that target's node was never the one whose
+// modifier the mapped-port fold read. Rejecting the multi-target rule outright is
+// the correct Junos-faithful closure and forecloses that residual as a side
+// effect (the rule never compiles, so no dropped-target modifier can slip).
+//
+// ThenTargetCount is taken from the AST during compile (staticNATThenTargetCount)
+// BEFORE the fields collapse, so it sees every declared target regardless of
+// shape (flat-set targets collapse onto one static-nat node's children; the
+// hierarchical `then { static-nat {…} static-nat {…} }` shape spreads them across
+// siblings) and regardless of the last-wins overwrite. A count of exactly one is
+// the well-formed case; zero is the empty-target gate's domain
+// (validateStaticNATThenTargetStrict, #4290) and is not re-diagnosed here.
+//
+// Strict on commit / commit-check (hard reject so the malformed rule is
+// operator-visible); the call site downgrades to a warning on the tolerant load
+// / peer-sync path (opts.lenientFirewallRefs, #1960 no-brick) — a config an older
+// binary persisted, or a peer authored, before this gate existed still boots, and
+// the dataplane is no worse off than before the gate (the compiler still lowers
+// the single honored target). Rule-sets are walked in slice order for a
+// deterministic first-reported offender, mirroring the sibling static-NAT target
+// gates.
+func validateStaticNATSingleTargetStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for _, rs := range cfg.Security.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			if rule.ThenTargetCount > 1 {
+				return fmt.Errorf(
+					"static NAT rule-set %q rule %q declares %d static-nat "+
+						"translation targets (prefix/prefix-name/nptv6-prefix/inet); a "+
+						"static-nat rule has exactly one — the compiler would otherwise "+
+						"honor one target and silently drop the rest (and any mapped-port "+
+						"riding only on a dropped target, the #6479 residual). Keep a "+
+						"single target per rule",
+					rs.Name, rule.Name, rule.ThenTargetCount)
+			}
+		}
+	}
+	return nil
+}
+
 // natThenTerminalActionCount returns how many mutually-exclusive NAT-terminal
 // translation actions a resolved NATThen carries: source-nat `interface`,
 // `off`, or a `pool <name>` for source NAT; `off` or a `pool <name>` for

--- a/pkg/config/static_nat_multitarget_6483_test.go
+++ b/pkg/config/static_nat_multitarget_6483_test.go
@@ -1,0 +1,249 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6483: a Junos static-NAT rule maps to EXACTLY ONE translation target — one of
+// `prefix <ip>` | `prefix-name <name>` | `nptv6-prefix <p6>` | `inet`. A rule
+// authoring two or more targets is invalid Junos, but compileNATStatic used to
+// ACCEPT it: the child loop honors the FIRST target by a fixed priority
+// (nptv6-prefix > prefix-name > prefix > inet) and drops the rest into the shared
+// Then field (a later target overwrites an earlier one), so the rule compiled to
+// one arbitrary target with no operator feedback. validateStaticNATSingleTarget-
+// Strict now rejects a rule whose winning `then {}` block declares >1 target.
+//
+// PARENT-RED: neutralize the gate — guard `rule.ThenTargetCount > 1` to a
+// constant false in validateStaticNATSingleTargetStrict (keep it compiling) — and
+// every TestStaticNATMultiTarget6483_Reject* case goes clean-assertion RED
+// (strict CompileConfig returns nil for a rule that must reject). The
+// accept/residual cases stay green, proving the gate does not over-reject.
+
+// mtBuildHier parses a full hierarchical config (its own prologue), optionally
+// splicing extra flat-set lines (e.g. an address-book entry) on top.
+func mtBuildHier(t *testing.T, hier string, extra ...string) *ConfigTree {
+	t.Helper()
+	tree := buildHier(t, hier)
+	for _, line := range extra {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+// assertMultiTargetReject compiles the tree strict (must hard-reject naming the
+// multi-target problem) and lenient (must NOT hard-error but must warn — the
+// #1960 no-brick contract).
+func assertMultiTargetReject(t *testing.T, build func() *ConfigTree) {
+	t.Helper()
+	_, err := CompileConfig(build())
+	if err == nil {
+		t.Fatalf("strict CompileConfig must reject a multi-target static-nat rule")
+	}
+	if !strings.Contains(err.Error(), "translation targets") ||
+		!strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("strict error must name the multi-target problem, got: %v", err)
+	}
+	cfg, errL := CompileConfigLenient(build())
+	if errL != nil {
+		t.Fatalf("lenient compile must not hard-error (#1960 no-brick), got %v", errL)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "translation target") {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatalf("lenient path must warn about translation-target cardinality, got %v", cfg.Warnings)
+	}
+}
+
+// assertSingleTargetAccept compiles strict, requires success, and asserts the
+// rule resolved to EXACTLY ONE declared target (guards against over-rejection).
+func assertSingleTargetAccept(t *testing.T, tree *ConfigTree) {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict CompileConfig must accept a well-formed single-target rule, got %v", err)
+	}
+	if len(cfg.Security.NAT.Static) == 0 || len(cfg.Security.NAT.Static[0].Rules) == 0 {
+		t.Fatalf("expected a static NAT rule, got %#v", cfg.Security.NAT.Static)
+	}
+	if got := cfg.Security.NAT.Static[0].Rules[0].ThenTargetCount; got != 1 {
+		t.Fatalf("ThenTargetCount = %d, want 1 (single well-formed target)", got)
+	}
+}
+
+// --- multi-target REJECT (each authoring shape) -----------------------------
+
+func TestStaticNATMultiTarget6483_RejectPrefixPlusPrefixName(t *testing.T) {
+	// Flat-set: two target lines collapse onto ONE static-nat node with two target
+	// children (prefix + prefix-name). On master this compiled clean, honoring
+	// prefix-name and silently dropping the prefix.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security address-book global address POOL 10.0.0.9/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name POOL")
+	})
+}
+
+func TestStaticNATMultiTarget6483_RejectInetPlusPrefix(t *testing.T) {
+	// Flat-set inet sibling + prefix sibling. On master the prefix (higher
+	// priority) won Then, so the rule installed as a plain prefix rule and even
+	// EVADED the #5859 inet reject — a doubly-silent accept.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat inet",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32")
+	})
+}
+
+func TestStaticNATMultiTarget6483_RejectTwoPrefix(t *testing.T) {
+	// Two mutually-exclusive prefix targets — last-wins on master, silently
+	// dropping the first.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.2/32")
+	})
+}
+
+func TestStaticNATMultiTarget6483_RejectHierTwoStaticNATBlocks(t *testing.T) {
+	// Hierarchical `then { static-nat {…} static-nat {…} }` — one target per
+	// sibling static-nat node.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; }
+						then { static-nat { prefix 10.0.0.1/32; } static-nat { prefix-name POOL; } } } } } } }`,
+			"set security address-book global address POOL 10.0.0.9/32")
+	})
+}
+
+// --- #6479 residual: a malformed mapped-port on a DROPPED target ------------
+
+func TestStaticNATMultiTarget6483_RejectClosesMappedPortResidual(t *testing.T) {
+	// Hierarchical: an `inet` sibling carrying a malformed `mapped-port notaport`
+	// FIRST, then a `prefix` sibling. On master this SILENT-ACCEPTS: the inet
+	// branch never runs the mapped-port fold, so the bad token is dropped, and the
+	// later prefix sibling overwrites Then to a valid host — the rule compiles
+	// clean with the malformed port lost. That is the #6479/C179-038 residual.
+	// Rejecting the multi-target rule (inet + prefix = 2 targets) closes it: the
+	// rule never compiles, so the dropped-target mapped-port cannot slip.
+	build := func() *ConfigTree {
+		return mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; }
+						then { static-nat { inet mapped-port notaport; } static-nat { prefix 10.0.0.1/32; } } } } } } }`)
+	}
+	assertMultiTargetReject(t, build)
+}
+
+// --- single-target ACCEPT (each of the four, collapsed + hierarchical) ------
+
+func TestStaticNATMultiTarget6483_AcceptSingleTargets(t *testing.T) {
+	t.Run("prefix_flat", func(t *testing.T) {
+		assertSingleTargetAccept(t, buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32"))
+	})
+	t.Run("prefix_flat_with_mapped_port", func(t *testing.T) {
+		// A modifier (mapped-port) on the single target must NOT read as a 2nd
+		// target — it is the canonical single-target-plus-modifier form.
+		assertSingleTargetAccept(t, buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 match destination-port 80",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32 mapped-port 8080"))
+	})
+	t.Run("prefix_hier", func(t *testing.T) {
+		assertSingleTargetAccept(t, mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; }
+						then { static-nat { prefix 10.0.0.1/32; } } } } } } }`))
+	})
+	t.Run("prefix_name_flat", func(t *testing.T) {
+		assertSingleTargetAccept(t, buildFlat(t,
+			"set security address-book global address POOL 10.0.0.9/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name POOL"))
+	})
+	t.Run("prefix_name_hier", func(t *testing.T) {
+		assertSingleTargetAccept(t, mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; }
+						then { static-nat { prefix-name POOL; } } } } } } }`,
+			"set security address-book global address POOL 10.0.0.9/32"))
+	})
+	t.Run("nptv6_prefix_flat", func(t *testing.T) {
+		// nptv6 needs a v6 match of EQUAL prefix length (else the nptv6-length
+		// gate, not the cardinality gate, would fire). Build without natBaseZone.
+		tree := &ConfigTree{}
+		for _, line := range []string{
+			"set security zones security-zone untrust",
+			"set security nat static rule-set rs1 from zone untrust",
+			"set security nat static rule-set rs1 rule r1 match destination-address 2001:db8:1::/48",
+			"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:2::/48",
+		} {
+			path, err := ParseSetCommand(line)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", line, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%q): %v", line, err)
+			}
+		}
+		assertSingleTargetAccept(t, tree)
+	})
+	t.Run("nptv6_prefix_hier", func(t *testing.T) {
+		assertSingleTargetAccept(t, mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 2001:db8:1::/48; }
+						then { static-nat { nptv6-prefix 2001:db8:2::/48; } } } } } } }`))
+	})
+	t.Run("prefix_with_routing_instance", func(t *testing.T) {
+		// A trailing target routing-instance (#4292) is a modifier, not a 2nd
+		// target.
+		assertSingleTargetAccept(t, buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32 routing-instance FOO"))
+	})
+}
+
+// TestStaticNATMultiTarget6483_SingleInetNotFlaggedMulti proves a lone `inet`
+// target is NOT falsely rejected as multi-target: it counts ONE target and is
+// rejected (if at all) only by the #5859 inet gate, never the cardinality gate.
+func TestStaticNATMultiTarget6483_SingleInetNotFlaggedMulti(t *testing.T) {
+	build := func() *ConfigTree {
+		return buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat inet")
+	}
+	// The lone inet counts exactly one target (lenient compile keeps the rule).
+	cfg, errL := CompileConfigLenient(build())
+	if errL != nil {
+		t.Fatalf("lenient compile must not hard-error, got %v", errL)
+	}
+	if got := cfg.Security.NAT.Static[0].Rules[0].ThenTargetCount; got != 1 {
+		t.Fatalf("lone inet ThenTargetCount = %d, want 1", got)
+	}
+	// Strict rejection is the #5859 inet reject, NOT the multi-target reject.
+	_, err := CompileConfig(build())
+	if err == nil {
+		t.Fatalf("lone inet must still be rejected by the #5859 inet gate")
+	}
+	if strings.Contains(err.Error(), "translation targets") {
+		t.Fatalf("lone inet must NOT be flagged multi-target, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "inet") {
+		t.Fatalf("expected the #5859 inet reject, got: %v", err)
+	}
+}

--- a/pkg/config/static_nat_multitarget_6483_test.go
+++ b/pkg/config/static_nat_multitarget_6483_test.go
@@ -227,6 +227,93 @@ func TestStaticNATMultiTarget6484_RejectPrefixPlusPrefixNameNamedMappedPort(t *t
 	})
 }
 
+// --- #6484 round-2: PACKED/BRACKETED multi-value target (Codex finding 1) ----
+//
+// A Junos bracketed list `prefix [ X Y ]` is collapsed by the lexer (#2419) onto
+// ONE leaf's Keys ["prefix","X","Y"]; the same for prefix-name / nptv6-prefix. The
+// round-1 counter consumed only the FIRST value after the keyword and let the rest
+// fall through, so a genuine 2-target packed list counted 1 and ESCAPED the >1
+// gate. The full-traversal walk now registers EVERY packed value as a distinct
+// target identity, so these reject.
+//
+// PARENT-RED: revert the packed-value fix (restore the single-value read in
+// staticNATCollectTargetIdentsFromKeys — count only keys[i+1] and advance i+=2)
+// and each of these goes clean-assertion RED (strict CompileConfig returns nil for
+// a rule that must reject: `prefix [ X Y ]` counts 1).
+
+func TestStaticNATMultiTarget6484_RejectBracketedMultiPrefix(t *testing.T) {
+	// `prefix [ 10.0.0.1/32 10.0.0.2/32 ]` → Keys ["prefix","10.0.0.1/32",
+	// "10.0.0.2/32"]. Two distinct prefix identities → reject. Both /32 host masks
+	// so the host-mask gate passes and the cardinality gate owns the rejection.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix [ 10.0.0.1/32 10.0.0.2/32 ]")
+	})
+}
+
+func TestStaticNATMultiTarget6484_RejectBracketedMultiPrefixName(t *testing.T) {
+	// `prefix-name [ POOL POOL2 ]` → Keys ["prefix-name","POOL","POOL2"]. The FIRST
+	// token is the opaque name (always consumed), every FURTHER non-keyword token is
+	// an additional packed name — two distinct prefix-name identities → reject. Both
+	// pools are defined so no undefined-prefix-name gate fires first.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security address-book global address POOL 10.0.0.9/32",
+			"set security address-book global address POOL2 10.0.0.8/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name [ POOL POOL2 ]")
+	})
+}
+
+func TestStaticNATMultiTarget6484_RejectBracketedMultiNptv6(t *testing.T) {
+	// `nptv6-prefix [ P6a P6b ]` → Keys ["nptv6-prefix","P6a","P6b"]. Two distinct
+	// nptv6-prefix identities → reject. Built with a v6 match of EQUAL prefix length
+	// (else the nptv6-length gate, not cardinality, would fire) and no mapped-port.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		tree := &ConfigTree{}
+		for _, line := range []string{
+			"set security zones security-zone untrust",
+			"set security nat static rule-set rs1 from zone untrust",
+			"set security nat static rule-set rs1 rule r1 match destination-address 2001:db8:1::/48",
+			"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix [ 2001:db8:2::/48 2001:db8:3::/48 ]",
+		} {
+			path, err := ParseSetCommand(line)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", line, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%q): %v", line, err)
+			}
+		}
+		return tree
+	})
+}
+
+// --- #6484 round-2: hierarchical prefix-name + nested mapped-port (finding 2) -
+//
+// A bare hierarchical `prefix-name { POOL; mapped-port 8080; }` is ONE target
+// (prefix-name POOL) plus a mapped-port MODIFIER — NOT two targets. The round-1
+// grandchild walk registered EVERY grandchild of a name-valued bare keyword as a
+// target, counting POOL and mapped-port as two, and FALSE-REJECTED a valid
+// single-target rule that origin/master accepted. The grandchild walk now consumes
+// only the FIRST grandchild as the opaque name and skips a later modifier
+// grandchild, so this accepts (count 1).
+//
+// PARENT-RED: revert the grandchild-modifier-skip (drop the `gi == 0` guard so a
+// name-valued keyword's modifier grandchild is registered as a target again) and
+// this goes RED — the rule false-rejects with ThenTargetCount==2.
+
+func TestStaticNATMultiTarget6484_AcceptHierPrefixNameNestedMappedPort(t *testing.T) {
+	// `match destination-port 80` satisfies the #2769 with-mapped-port gate so the
+	// well-formed 8080 is not caught there; POOL resolves so the empty-target gate
+	// does not fire — the count-1 accept is genuine, not masked by an earlier gate.
+	assertSingleTargetAccept(t, mtBuildHier(t,
+		`security { zones { security-zone untrust; }
+			nat { static { rule-set rs1 { from { zone untrust; }
+				rule r1 { match { destination-address 203.0.113.1/32; destination-port 80; }
+					then { static-nat { prefix-name { POOL; mapped-port 8080; } } } } } } } }`,
+		"set security address-book global address POOL 10.0.0.9/32"))
+}
+
 // --- single-target ACCEPT (each of the four, collapsed + hierarchical) ------
 
 func TestStaticNATMultiTarget6483_AcceptSingleTargets(t *testing.T) {

--- a/pkg/config/static_nat_multitarget_6483_test.go
+++ b/pkg/config/static_nat_multitarget_6483_test.go
@@ -150,6 +150,83 @@ func TestStaticNATMultiTarget6483_RejectClosesMappedPortResidual(t *testing.T) {
 	assertMultiTargetReject(t, build)
 }
 
+// --- #6484 residual: two targets COLLAPSED onto one node/child --------------
+//
+// The reject cases above spread their targets across two SEPARATE set lines or
+// two hierarchical static-nat siblings, so SetPath keeps two target children and
+// the pre-#6484 first-pair read already counted 2. The cases below author both
+// targets on ONE line (or as multiple values under one bare keyword), so they
+// collapse onto a SINGLE child's Keys / a single keyword's grandchildren — where
+// the first-pair read saw only the first target and counted 1, letting a genuine
+// multi-target rule ESCAPE the >1 gate (the #6484 MAJOR). The grammar-role-aware
+// FULL-TRAVERSAL counter registers every distinct target identity across the whole
+// key stream + all children, so these now reject.
+
+func TestStaticNATMultiTarget6484_RejectOneLinePrefixPlusPrefixName(t *testing.T) {
+	// ONE set line: `prefix <ip> prefix-name POOL` collapses onto a single child
+	// whose Keys are ["prefix","<ip>","prefix-name","POOL"]. The old counter read
+	// only Keys[1]/Keys[2] (the prefix) and counted 1 → ACCEPT. Two distinct
+	// targets now → reject. POOL is defined so no undefined-prefix-name gate fires
+	// first; the multi-target gate must own the rejection.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security address-book global address POOL 10.0.0.9/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32 prefix-name POOL")
+	})
+}
+
+func TestStaticNATMultiTarget6484_RejectOneLinePrefixPlusInet(t *testing.T) {
+	// ONE line `prefix <ip> inet` → child Keys ["prefix","<ip>","inet"]. The old
+	// read counted the prefix only (1) → ACCEPT, which ALSO evaded the #5859 inet
+	// reject (the PR's own motivating case): the honored prefix installed a plain
+	// rule and the dropped inet never reached its gate. Now 2 targets → reject.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32 inet")
+	})
+}
+
+func TestStaticNATMultiTarget6484_RejectOneLineTwoPrefix(t *testing.T) {
+	// ONE line `prefix <ip> prefix <ip2>` → child Keys ["prefix","<ip>","prefix",
+	// "<ip2>"]. Two DISTINCT prefix identities now → reject (old read: 1).
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32 prefix 10.0.0.2/32")
+	})
+}
+
+func TestStaticNATMultiTarget6484_RejectHierMultiValuePrefix(t *testing.T) {
+	// Hierarchical `prefix { <ip>; <ip2>; }` → one bare `prefix` child (Keys
+	// ["prefix"]) carrying TWO grandchild values. The old read took only
+	// Children[0] (the first ip) and counted 1 → ACCEPT. Each grandchild is a
+	// distinct prefix identity now → reject.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; }
+						then { static-nat { prefix { 10.0.0.1/32; 10.0.0.2/32; } } } } } } } }`)
+	})
+}
+
+func TestStaticNATMultiTarget6484_RejectPrefixPlusPrefixNameNamedMappedPort(t *testing.T) {
+	// A prefix target plus a prefix-name whose pool is LITERALLY named
+	// "mapped-port" (a legal address-book name, static_nat_mapped_port_canonical_
+	// 6479_test.go establishes such names). SetPath keeps two children: prefix
+	// ["prefix","<ip>"] and prefix-name ["prefix-name","mapped-port"]. The old
+	// counter's add() pre-filtered a value slot equal to a modifier keyword and
+	// DISCARDED the "prefix-name mapped-port" target → counted 1 → ACCEPT (the
+	// Codex second finding). The name-valued walk registers "prefix-name\x00
+	// mapped-port" as a genuine target now → 2 → reject. The address-book entry is
+	// defined so prefix-name resolves and the multi-target gate owns the rejection.
+	assertMultiTargetReject(t, func() *ConfigTree {
+		return buildFlat(t,
+			"set security address-book global address mapped-port 10.0.0.9/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name mapped-port")
+	})
+}
+
 // --- single-target ACCEPT (each of the four, collapsed + hierarchical) ------
 
 func TestStaticNATMultiTarget6483_AcceptSingleTargets(t *testing.T) {
@@ -216,6 +293,40 @@ func TestStaticNATMultiTarget6483_AcceptSingleTargets(t *testing.T) {
 		// target.
 		assertSingleTargetAccept(t, buildFlat(t,
 			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32 routing-instance FOO"))
+	})
+	t.Run("prefix_name_restate_mapped_port_idiom", func(t *testing.T) {
+		// #5523 RESTATE idiom: the SAME prefix-name target authored twice, the
+		// second restatement attaching a mapped-port. SetPath keeps two prefix-name
+		// children (["prefix-name","POOL"] and ["prefix-name","POOL","mapped-port",
+		// "8080"]); both map to identity "prefix-name\x00POOL" and collapse to ONE
+		// target. Must NOT read as two (INVARIANT B).
+		assertSingleTargetAccept(t, buildFlat(t,
+			"set security address-book global address POOL 10.0.0.9/32",
+			"set security nat static rule-set rs1 rule r1 match destination-port 80",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name POOL",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix-name POOL mapped-port 8080"))
+	})
+	t.Run("prefix_modifier_carrier_separate_line", func(t *testing.T) {
+		// The canonical separate-set-line mapped-port form for a LITERAL prefix:
+		// `prefix <ip>` on one line, `prefix mapped-port <p>` on another. SetPath
+		// keeps two prefix children (["prefix","10.0.0.1/32"] and ["prefix",
+		// "mapped-port","8080"]); the second is a MODIFIER CARRIER (the value slot
+		// is a modifier keyword, and a prefix value can never be one), so it
+		// registers no target — count 1. Must NOT read the carrier as a 2nd prefix.
+		assertSingleTargetAccept(t, buildFlat(t,
+			"set security nat static rule-set rs1 rule r1 match destination-port 80",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.1/32",
+			"set security nat static rule-set rs1 rule r1 then static-nat prefix mapped-port 8080"))
+	})
+	t.Run("prefix_hier_ip_with_nested_mapped_port", func(t *testing.T) {
+		// Hierarchical `prefix <ip> { mapped-port P; }`: the value rides INLINE on
+		// the prefix child's Keys (["prefix","<ip>"]) and mapped-port is a nested
+		// grandchild modifier, not a second value — count 1.
+		assertSingleTargetAccept(t, mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; destination-port 80; }
+						then { static-nat { prefix 10.0.0.1/32 { mapped-port 8080; } } } } } } } }`))
 	})
 }
 

--- a/pkg/config/static_nat_multitarget_6483_test.go
+++ b/pkg/config/static_nat_multitarget_6483_test.go
@@ -415,6 +415,30 @@ func TestStaticNATMultiTarget6483_AcceptSingleTargets(t *testing.T) {
 					rule r1 { match { destination-address 203.0.113.1/32; destination-port 80; }
 						then { static-nat { prefix 10.0.0.1/32 { mapped-port 8080; } } } } } } } }`))
 	})
+	t.Run("prefix_name_hier_sibling_mapped_port", func(t *testing.T) {
+		// REAL Junos (#1 regression risk): `static-nat { prefix-name POOL;
+		// mapped-port 8080; }` — mapped-port is a SIBLING child of the prefix-name
+		// target, NOT a grandchild. The prefix-name child has Keys len 2 so it never
+		// enters the grandchild loop; the mapped-port sibling is skipped by
+		// staticNATCollectTargetIdentsFromKeys. Must stay ONE target.
+		assertSingleTargetAccept(t, mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; destination-port 80; }
+						then { static-nat { prefix-name POOL; mapped-port 8080; } } } } } } }`,
+			"set security address-book global address POOL 10.0.0.9/32"))
+	})
+	t.Run("prefix_hier_sibling_mapped_port", func(t *testing.T) {
+		// REAL Junos (#1 regression risk): `static-nat { prefix 10.0.0.1/32;
+		// mapped-port 8080; }` — mapped-port sibling of the prefix target. Must stay
+		// ONE target (the prefix child's Keys are len 2; the mapped-port sibling
+		// registers no target).
+		assertSingleTargetAccept(t, mtBuildHier(t,
+			`security { zones { security-zone untrust; }
+				nat { static { rule-set rs1 { from { zone untrust; }
+					rule r1 { match { destination-address 203.0.113.1/32; destination-port 80; }
+						then { static-nat { prefix 10.0.0.1/32; mapped-port 8080; } } } } } } }`))
+	})
 }
 
 // TestStaticNATMultiTarget6483_SingleInetNotFlaggedMulti proves a lone `inet`

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -995,6 +995,22 @@ type StaticNATRule struct {
 	// load / peer-sync path (#1960 no-brick) keeps MappedPort==0 (plain 1:1,
 	// no bogus port).
 	MappedPortPresent bool `json:"-"`
+	// ThenTargetCount is how many mutually-exclusive translation TARGETS the
+	// winning `then {}` block declares (prefix / prefix-name / nptv6-prefix /
+	// inet), counted from the AST during compile by staticNATThenTargetCount
+	// (#6483). A well-formed rule declares EXACTLY ONE. Because prefix / inet /
+	// nptv6-prefix all land in the shared Then field (a later target overwrites an
+	// earlier one), the final field state cannot reveal a multi-target rule; this
+	// count, taken before the fields collapse, can. validateStaticNATSingleTarget-
+	// Strict rejects a rule with >1 (both a prefix AND a prefix-name, an inet
+	// sibling plus a prefix sibling, two prefixes, …) — invalid Junos the compiler
+	// otherwise silently accepted by honoring one target and dropping the rest,
+	// which also let a malformed mapped-port on a dropped target slip through (the
+	// #6479/C179-038 residual). A zero-target rule is the empty-target gate's
+	// domain (#4290); this gates only the >1 case. Compile-only (`json:"-"`):
+	// derived state recomputed on every compile (last `then` block wins, #3850),
+	// never serialized to the dataplane / peer-sync wire.
+	ThenTargetCount int `json:"-"`
 }
 
 // LimitSessionScreen configures per-IP session limiting.


### PR DESCRIPTION
## Summary

A Junos static-NAT rule maps to **exactly one** translation target — one of `prefix <ip>` | `prefix-name <name>` | `nptv6-prefix <p6>` | `inet`. Authoring two or more (both a `prefix` and a `prefix-name`, an `inet` sibling alongside a `prefix` sibling, or two prefixes) is invalid Junos, but the compiler silently **accepted** it: `compileNATStatic`'s child loop honors the FIRST target by a fixed priority (`nptv6-prefix > prefix-name > prefix > inet`) and drops the rest, and since `prefix`/`inet`/`nptv6-prefix` all land in the shared `Then` field a later target overwrites an earlier one. The rule compiled to one arbitrary target with no operator feedback — `inet` + `prefix` even installed as a plain prefix rule, **evading the #5859 inet reject**.

Dropping a target this way also dropped any `mapped-port` that rode **only** on the discarded target (the #6479/C179-038 residual): that target's node was never the one whose modifier the mapped-port fold read, so `then { static-nat { inet mapped-port <bad>; } static-nat { prefix <ip>; } }` silently lost the malformed port and compiled clean. Rejecting the multi-target rule outright is the Junos-faithful closure and forecloses that residual as a side effect.

## Implementation

- **`staticNATThenTargetCount`** (`compiler_nat_static.go`) counts the **distinct `(keyword, value)` target identities** a `then` block declares, from the AST, across every authoring shape (flat-set targets collapse onto one `static-nat` node's children; the hierarchical `then { static-nat {…} static-nat {…} }` shape spreads them across siblings). Counting *distinct identities* (not occurrences) keeps the canonical "restate the target to attach a mapped-port" form — `prefix-name N` + `prefix-name N mapped-port P` — a single target, and skips a modifier carrier (`prefix mapped-port <port>`) the same way the mapped-port fold does.
- Recorded as **`StaticNATRule.ThenTargetCount`** (`json:"-"`, compile-only, last `then` block wins per #3850) — the collapsed field state cannot reveal a multi-target rule.
- **`validateStaticNATSingleTargetStrict`** rejects a rule whose winning block declares >1 target. It runs in `runTailGates` **after** the host-mask (#2173) and NPTv6 (#2240/#5818) gates, so a rule that *also* carries a malformed `mapped-port` / bad nptv6 prefix reports that concrete token first (the multi-target defect is caught on the next compile once fixed — never masked; existing #6479 multi-block tests keep their diagnostics). Zero-target rules stay the empty-target gate's domain (#4290).
- Strict on commit / commit-check (hard reject); tolerant load / peer-sync downgrades to a warning (`opts.lenientFirewallRefs`, #1960 no-brick).

## Was the multi-target rule reachable? How represented?

Yes. Investigated empirically: the flat-set lines `then static-nat prefix <ip>` + `then static-nat prefix-name <name>` **collapse onto one `static-nat` node with two target children**; the hierarchical form spreads targets across sibling `static-nat` nodes. Both silently accepted on `origin/master` (`inet`+`prefix`, `prefix`+`prefix-name`, two-`prefix`, hier two-block all compiled with `err == nil`).

## Validation

- New `static_nat_multitarget_6483_test.go`: strict REJECT / lenient WARN for prefix+prefix-name, inet+prefix, two-prefix, hierarchical two-block; the **#6479 dropped-target mapped-port residual** (silent-accept on master) now rejects; single-target ACCEPT for each of the four targets in collapsed + hierarchical shapes, plus the mapped-port / routing-instance modifier and the restated-name form; a lone `inet` is not falsely flagged multi.
- **PARENT-RED**: neutralizing the `> 1` guard turns the five reject cases clean-assertion RED (`strict CompileConfig must reject a multi-target static-nat rule`), `go vet` still clean; restore → GREEN.
- `gofmt` / `go vet` / `go build ./...` and the full `pkg/config` suite pass; `docs/refactoring-audit-current.txt` regenerated (`compiler_validate_strict_nat.go` 2865→2928). `docs/config-schema.md` documents the one-target invariant and the residual closure.

Closes #6483

Also closes the #6479 static-NAT multi-target dropped mapped-port residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)