### PR TITLE
ipsec: sanitize swanctl local_addrs/remote_addrs at render

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -60511,3 +60511,21 @@ top.
   (13s), TestHeatmapNotStale all GREEN (no LOC bucket shift).
 - **File(s)**: pkg/config/compiler_nat_static.go,
     pkg/config/static_nat_multitarget_6483_test.go, docs/config-schema.md, _Log.md
+
+## 2026-07-24 — #6469 swanctl local_addrs/remote_addrs sanitize (render belt)
+- **Timestamp**: 2026-07-24
+- **Action**: Close the last raw-`%s` swanctl-injection surface. The
+  connection `local_addrs`/`remote_addrs` render sites interpolated the
+  resolved endpoint verbatim; a validation-bypassed path (HA peer-sync of a
+  pre-fix config, direct IPsecConfig construction) could carry an embedded
+  newline and inject a live swanctl directive into the connection block.
+  Wrapped both `policy.go` Fprintf sites in `sanitizeSwanctlValue` — parity
+  with the `local_ts`/`remote_ts` unquoted-list belt (sanitize alone, NO
+  `escapeSwanctlQuoted`, which is for the quoted id/cert/secret slots). Legit
+  single/comma-list/IPv6/`%any` endpoints render byte-identical. New
+  fail-on-revert test (4 injection vectors: gw.Address, gw.DynamicHostname,
+  gw.LocalAddress, vpn.LocalAddr) + over-escape guard; parent-RED confirmed
+  firsthand (revert → "injection NOT neutralized: reauth_time = 0 rendered as
+  a live directive line"). go build/vet/gofmt/pkg-ipsec-suite/heatmap GREEN.
+- **File(s)**: pkg/ipsec/policy.go,
+    pkg/ipsec/swanctl_addr_sanitize_6469_test.go, pkg/ipsec/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60512,20 +60512,40 @@ top.
 - **File(s)**: pkg/config/compiler_nat_static.go,
     pkg/config/static_nat_multitarget_6483_test.go, docs/config-schema.md, _Log.md
 
-## 2026-07-24 — #6469 swanctl local_addrs/remote_addrs sanitize (render belt)
+## 2026-07-24 — #6469 swanctl render-belt completeness (endpoints + proposals)
 - **Timestamp**: 2026-07-24
-- **Action**: Close the last raw-`%s` swanctl-injection surface. The
-  connection `local_addrs`/`remote_addrs` render sites interpolated the
-  resolved endpoint verbatim; a validation-bypassed path (HA peer-sync of a
-  pre-fix config, direct IPsecConfig construction) could carry an embedded
-  newline and inject a live swanctl directive into the connection block.
-  Wrapped both `policy.go` Fprintf sites in `sanitizeSwanctlValue` — parity
-  with the `local_ts`/`remote_ts` unquoted-list belt (sanitize alone, NO
-  `escapeSwanctlQuoted`, which is for the quoted id/cert/secret slots). Legit
-  single/comma-list/IPv6/`%any` endpoints render byte-identical. New
-  fail-on-revert test (4 injection vectors: gw.Address, gw.DynamicHostname,
-  gw.LocalAddress, vpn.LocalAddr) + over-escape guard; parent-RED confirmed
-  firsthand (revert → "injection NOT neutralized: reauth_time = 0 rendered as
-  a live directive line"). go build/vet/gofmt/pkg-ipsec-suite/heatmap GREEN.
+- **Action**: Sanitize EVERY remaining raw-`%s` swanctl render slot that
+  carries peer/operator-influenced free text, so the render belt in
+  `renderConfig` (`policy.go`) is complete. A validation-bypassed path (HA
+  peer-sync of a pre-fix config, direct IPsecConfig construction, a config
+  persisted before the fix) could carry an embedded newline and inject a
+  live swanctl directive. Wrapped four Fprintf sites in
+  `sanitizeSwanctlValue`:
+  - `local_addrs` / `remote_addrs` (resolved endpoint from
+    resolveRemoteAddr — the Gateways-map shape took gw.Address /
+    gw.DynamicHostname verbatim; the legacy inline vpn.Gateway shape was
+    already filtered by config.IsUsableIPsecEndpoint).
+  - `proposals` (IKE, ikeProposals) / `esp_proposals` (ESP, espProposals)
+    — buildIKEProposal* / buildESPProposal append prop.EncryptionAlg /
+    prop.AuthAlg VERBATIM on the unknown-algorithm fall-through
+    (normalizeAuthAlg default branch; normalizeEncAlg generic gcm strip),
+    so a control char survives. esp_proposals sits inside children{} where
+    an injected `updown = <script>` runs as ROOT — a strictly worse vector
+    than the endpoint one (the FOLD gap: the original PR's "last raw-%s
+    surface" claim was FALSE — a hostile review caught these two siblings).
+  All four are UNQUOTED list slots → sanitize alone (NO escapeSwanctlQuoted,
+  which is for the quoted id/cert/secret slots). Legit values byte-
+  identical: `.`/`,`/`:`/`%`/`-` preserved, so single/comma-list/IPv6/`%any`
+  endpoints and dashed multi-proposal lists render unchanged. Slot-
+  classification sweep confirmed the remaining slots are safe by
+  construction (auth / dpd_action = fixed enums; id/certs/secret already
+  belted; names sanitized; dpd_delay/rekey_time/if_id_* = integers).
+  Fail-on-revert tests: 4 endpoint vectors + 2 proposal vectors (IKE
+  `proposals` newline; ESP `esp_proposals` updown→root) + endpoint and
+  proposal over-escape guards. Parent-RED confirmed firsthand per slot —
+  revert proposals wrap → "proposal injection NOT neutralized: reauth_time
+  = 0 rendered as a live directive line"; revert esp_proposals wrap →
+  "... updown = /tmp/pwn.sh rendered as a live directive line". go build /
+  vet / gofmt / pkg-ipsec-suite / heatmap GREEN.
 - **File(s)**: pkg/ipsec/policy.go,
     pkg/ipsec/swanctl_addr_sanitize_6469_test.go, pkg/ipsec/README.md, _Log.md

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -607,6 +607,31 @@ all files stay in `package ipsec`, so the public API is unchanged.
   rejected an embedded newline in ANY value at commit — the #4098 gate
   adds the traffic-selector-specific shape check (malformed / mis-scoped
   selector) and the render-side belt.
+- **Endpoint `local_addrs`/`remote_addrs` sanitize (#6469).** The
+  connection `local_addrs = <value>` / `remote_addrs = <value>` lines
+  (the resolved peer/local endpoint from `resolveRemoteAddr` — a gateway
+  `address`/`dynamic hostname`, a `local-address`, an
+  `external-interface`-derived local IP, or the legacy inline
+  `vpn.Gateway`) are now run through `sanitizeSwanctlValue` at the two
+  `policy.go` render sites, closing the last raw-`%s` swanctl-injection
+  surface. These are UNQUOTED comma-list slots, so — exactly like the
+  `local_ts`/`remote_ts` belt above — the sanitize alone is the right
+  form (NO `escapeSwanctlQuoted`, which is for the quoted `id`/`certs`/
+  `secret` slots): an embedded newline collapses to a space, keeping a
+  tampered endpoint inert on one line instead of injecting a live
+  `version`/`aggressive`/`also` directive into the connection block. A
+  legitimate endpoint is byte-identical (`.`, `,`, `:`, `%` are all
+  preserved, so a single address, a comma-separated multi-address list,
+  an IPv6 literal, and the responder-only `%any` sentinel render
+  unchanged). The commit-time gate (`validateIPsecEndpointsStrict`)
+  rejects a control-char endpoint at commit; this render belt is the
+  by-construction backstop for a validation-bypassed path (HA peer-sync
+  of a pre-fix config, a directly-constructed `IPsecConfig`, or a config
+  persisted before the fix), matching the #1798/#2126/#4098 belt
+  doctrine. The legacy inline `vpn.Gateway` shape is independently
+  filtered by `config.IsUsableIPsecEndpoint` (a control-char value is not
+  a usable endpoint → the VPN is skipped), but the Gateways-map shape
+  took `address`/`dynamic hostname` verbatim — that was the gap.
 - **Injective child-section naming (#5122).** Each traffic selector
   renders one swanctl child section named `<conn>-<sanitizeChildName(ts)>`
   (`effectiveTrafficSelectors` in `policy.go`). `sanitizeChildName` maps

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -607,31 +607,59 @@ all files stay in `package ipsec`, so the public API is unchanged.
   rejected an embedded newline in ANY value at commit — the #4098 gate
   adds the traffic-selector-specific shape check (malformed / mis-scoped
   selector) and the render-side belt.
-- **Endpoint `local_addrs`/`remote_addrs` sanitize (#6469).** The
-  connection `local_addrs = <value>` / `remote_addrs = <value>` lines
-  (the resolved peer/local endpoint from `resolveRemoteAddr` — a gateway
-  `address`/`dynamic hostname`, a `local-address`, an
-  `external-interface`-derived local IP, or the legacy inline
-  `vpn.Gateway`) are now run through `sanitizeSwanctlValue` at the two
-  `policy.go` render sites, closing the last raw-`%s` swanctl-injection
-  surface. These are UNQUOTED comma-list slots, so — exactly like the
-  `local_ts`/`remote_ts` belt above — the sanitize alone is the right
-  form (NO `escapeSwanctlQuoted`, which is for the quoted `id`/`certs`/
-  `secret` slots): an embedded newline collapses to a space, keeping a
-  tampered endpoint inert on one line instead of injecting a live
-  `version`/`aggressive`/`also` directive into the connection block. A
-  legitimate endpoint is byte-identical (`.`, `,`, `:`, `%` are all
-  preserved, so a single address, a comma-separated multi-address list,
-  an IPv6 literal, and the responder-only `%any` sentinel render
-  unchanged). The commit-time gate (`validateIPsecEndpointsStrict`)
-  rejects a control-char endpoint at commit; this render belt is the
-  by-construction backstop for a validation-bypassed path (HA peer-sync
-  of a pre-fix config, a directly-constructed `IPsecConfig`, or a config
-  persisted before the fix), matching the #1798/#2126/#4098 belt
-  doctrine. The legacy inline `vpn.Gateway` shape is independently
-  filtered by `config.IsUsableIPsecEndpoint` (a control-char value is not
-  a usable endpoint → the VPN is skipped), but the Gateways-map shape
-  took `address`/`dynamic hostname` verbatim — that was the gap.
+- **Endpoint AND proposal list sanitize (#6469).** The remaining raw-`%s`
+  swanctl render slots that carry peer/operator-influenced free text are
+  now run through `sanitizeSwanctlValue`, completing the render belt so
+  that EVERY such slot in `renderConfig` (`policy.go`) is sanitized. Two
+  groups were still raw:
+  - **Endpoints** — the connection `local_addrs = <value>` /
+    `remote_addrs = <value>` lines (the resolved peer/local endpoint from
+    `resolveRemoteAddr` — a gateway `address`/`dynamic hostname`, a
+    `local-address`, an `external-interface`-derived local IP, or the
+    legacy inline `vpn.Gateway`). The legacy inline `vpn.Gateway` shape is
+    independently filtered by `config.IsUsableIPsecEndpoint` (a
+    control-char value is not a usable endpoint → the VPN is skipped), but
+    the Gateways-map shape took `address`/`dynamic hostname` verbatim.
+  - **Proposals** — the connection-level `proposals = <value>` (IKE /
+    Phase 1, `ikeProposals`) and the child-SA `esp_proposals = <value>`
+    (ESP / Phase 2, `espProposals`). `buildIKEProposal` /
+    `buildIKEProposalFromIKE` / `buildESPProposal` append
+    `prop.EncryptionAlg` / `prop.AuthAlg` VERBATIM on the unknown-
+    algorithm fall-through (`normalizeAuthAlg`'s default branch returns
+    the collapsed token unchanged; `normalizeEncAlg`'s generic gcm strip
+    only removes `-cbc`/`-`), so a control character in a peer-synced /
+    directly-constructed proposal reaches the renderer. `esp_proposals`
+    sits INSIDE `children {}` — the same block whose `local_ts`/`remote_ts`
+    belt cites `updown = /tmp/x.sh` executed by charon as **root** — so an
+    injected newline there is a config-injection → root RCE, a strictly
+    worse vector than the endpoint one on the identical
+    validation-bypassed threat model.
+
+  All four are UNQUOTED list slots, so — exactly like the
+  `local_ts`/`remote_ts` belt above — sanitize alone is the right form
+  (NO `escapeSwanctlQuoted`, which is for the quoted `id`/`certs`/`secret`
+  slots): an embedded newline collapses to a space, keeping the tampered
+  value inert on one line instead of injecting a live directive
+  (`version`/`aggressive`/`also` at the connection level, `updown`/
+  `esp_proposals`/`mode`/`mark_*` in the child block). A legitimate value
+  is byte-identical — `sanitizeSwanctlValue` only rewrites C0/DEL control
+  bytes, so `.`, `,`, `:`, `%`, and `-` are all preserved and a single
+  address, a comma-separated multi-address list, an IPv6 literal, the
+  responder-only `%any` sentinel, and a dashed multi-proposal list
+  (`aes256-sha256-modp2048,aes128-sha256-modp2048`) render unchanged. The
+  commit-time gates (`validateIPsecEndpointsStrict` for endpoints, the
+  proposal validators for crypto tokens) reject a control-char value at
+  commit; this render belt is the by-construction backstop for a
+  validation-bypassed path (HA peer-sync of a pre-fix config, a
+  directly-constructed `IPsecConfig`, or a config persisted before the
+  fix), matching the #1798/#2126/#4098 belt doctrine. The remaining
+  interpolated slots are safe by construction: `auth` and `dpd_action`
+  are fixed enums (`authMethodToSwan` errors on any unknown token;
+  `deriveDPD` only emits `restart`/`clear`/`trap`), the `id`/`certs`/
+  `secret` slots already carry the `sanitizeSwanctlValue` +
+  `escapeSwanctlQuoted` belt, connection / child / secret NAMES are
+  sanitized, and every `dpd_delay`/`rekey_time`/`if_id_*` slot is an
+  integer (`%d`).
 - **Injective child-section naming (#5122).** Each traffic selector
   renders one swanctl child section named `<conn>-<sanitizeChildName(ts)>`
   (`effectiveTrafficSelectors` in `policy.go`). `sanitizeChildName` maps

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -141,11 +141,31 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, map[string
 			b.WriteString("    aggressive = yes\n")
 		}
 
+		// local_addrs / remote_addrs carry the endpoint address list
+		// (a real IP / dotted hostname, an IPv6 literal, a comma-
+		// separated multi-address list, or the responder-only "%any").
+		// Run them through sanitizeSwanctlValue for parity with the
+		// local_ts / remote_ts belt below and the id / PSK belts above:
+		// these are UNQUOTED list slots, so an embedded control
+		// character — a newline in particular — would otherwise inject an
+		// arbitrary `key = value` line (downgrade `version`, flip
+		// `aggressive`, add `also`/`children`) into the connection block.
+		// sanitizeSwanctlValue collapses the newline to a space, keeping
+		// the whole value on one line so a tampered address renders inert
+		// instead of live. It touches nothing in a legitimate address
+		// (letters, digits, `.`, `:`, `,`, `%` are all preserved), so a
+		// valid single/comma-list/IPv6 endpoint is byte-identical. The
+		// commit-time gate (validateIPsecEndpointsStrict) rejects such a
+		// value; this render belt is the by-construction backstop for a
+		// path that reaches render without local commit (HA peer-sync,
+		// direct IPsecConfig construction, a config persisted before the
+		// fix). Unquoted, so NO escapeSwanctlQuoted — that belt is for the
+		// quoted id / cert / secret slots only (#6469).
 		if localAddr != "" {
-			fmt.Fprintf(&b, "    local_addrs = %s\n", localAddr)
+			fmt.Fprintf(&b, "    local_addrs = %s\n", sanitizeSwanctlValue(localAddr))
 		}
 		if remoteAddr != "" {
-			fmt.Fprintf(&b, "    remote_addrs = %s\n", remoteAddr)
+			fmt.Fprintf(&b, "    remote_addrs = %s\n", sanitizeSwanctlValue(remoteAddr))
 		}
 
 		// NAT traversal

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -215,7 +215,20 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, map[string
 		b.WriteString("    }\n")
 
 		if ikeProposals != "" {
-			fmt.Fprintf(&b, "    proposals = %s\n", ikeProposals)
+			// Sanitize the IKE proposal list for the same reason as the
+			// child-SA esp_proposals below and the local_ts/remote_ts belt:
+			// buildIKEProposal / buildIKEProposalFromIKE append
+			// prop.EncryptionAlg / prop.AuthAlg VERBATIM on the unknown-
+			// algorithm fall-through (normalizeAuthAlg's default branch returns
+			// the collapsed token unchanged; normalizeEncAlg's generic gcm strip
+			// only removes `-cbc`/`-`), so a control character in a peer-synced
+			// or directly-constructed proposal survives into this UNQUOTED list
+			// slot and an embedded newline would inject a connection-level
+			// swanctl directive. sanitize-only, NOT escapeSwanctlQuoted (this is
+			// an unquoted list slot like local_ts/remote_ts): a proposal token is
+			// alnum / `-` / `,`, all preserved by sanitizeSwanctlValue, so a
+			// legitimate proposal or comma-list renders byte-identical (#6469).
+			fmt.Fprintf(&b, "    proposals = %s\n", sanitizeSwanctlValue(ikeProposals))
 		}
 		if ikeLifetime > 0 {
 			fmt.Fprintf(&b, "    rekey_time = %ds\n", ikeLifetime)
@@ -250,7 +263,19 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, map[string
 			if child.RemoteTS != "" {
 				fmt.Fprintf(&b, "        remote_ts = %s\n", sanitizeSwanctlValue(child.RemoteTS))
 			}
-			fmt.Fprintf(&b, "        esp_proposals = %s\n", espProposals)
+			// esp_proposals sits INSIDE the children{ <child> { } } block —
+			// the same block whose local_ts/remote_ts belt above cites an
+			// injected `updown = /tmp/x.sh` executed by charon as ROOT.
+			// buildESPProposal appends prop.EncryptionAlg / prop.AuthAlg
+			// VERBATIM on the unknown-algorithm fall-through, so a control
+			// character in a peer-synced or directly-constructed ESP proposal
+			// survives; an embedded newline here injects a child-SA directive
+			// (updown → root exec, or an esp_proposals/mode/mark_* crypto
+			// rewrite) — a strictly worse vector than the endpoint one on the
+			// identical validation-bypassed threat model. sanitize-only,
+			// unquoted list slot; a legitimate proposal / comma-list renders
+			// byte-identical (#6469).
+			fmt.Fprintf(&b, "        esp_proposals = %s\n", sanitizeSwanctlValue(espProposals))
 			if espLifetime > 0 {
 				fmt.Fprintf(&b, "        rekey_time = %ds\n", espLifetime)
 				b.WriteString("        rand_time = 0s\n")

--- a/pkg/ipsec/swanctl_addr_sanitize_6469_test.go
+++ b/pkg/ipsec/swanctl_addr_sanitize_6469_test.go
@@ -166,3 +166,133 @@ func TestSwanctlAddrLegitPreserved_6469(t *testing.T) {
 		}
 	})
 }
+
+// TestSwanctlProposalsInjectionNeutralized_6469 is the fold guard: the swanctl
+// `proposals` (IKE, Phase 1) and `esp_proposals` (ESP, Phase 2, INSIDE the
+// children{} block) render sites must run the built proposal string through
+// sanitizeSwanctlValue. buildIKEProposal* / buildESPProposal append
+// prop.EncryptionAlg / prop.AuthAlg VERBATIM on the unknown-algorithm
+// fall-through (normalizeAuthAlg's default branch; normalizeEncAlg's generic
+// gcm strip), so a control char in a peer-synced / directly-constructed
+// proposal reaches the renderer. An embedded newline in esp_proposals injects
+// a child-SA directive (`updown = <script>` runs as ROOT under charon) — a
+// strictly worse vector than the endpoint one, on the identical
+// validation-bypassed threat model. Reverting either wrap makes the matching
+// case fail with a clean assertion: the injected directive is a live line.
+func TestSwanctlProposalsInjectionNeutralized_6469(t *testing.T) {
+	// IKE proposals: EncryptionAlg carries the payload, no AuthAlg / DHGroup,
+	// so buildIKEProposalFromIKE emits the payload as the whole proposals
+	// value (nothing is appended after the newline).
+	ikeCfg := &config.IPsecConfig{
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {Name: "gw", Address: "203.0.113.1", IKEPolicy: "ike-pol"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Name: "tun", Gateway: "gw"},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Proposals: []string{"ike-prop"}},
+		},
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-prop": {Name: "ike-prop", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes256\n    reauth_time = 0"},
+		},
+	}
+
+	// ESP proposals: the ipsec-policy proposal's EncryptionAlg carries the
+	// updown→root payload; no AuthAlg / DHGroup so esp_proposals is exactly
+	// the payload. gw has a valid address so the VPN is not skipped.
+	espCfg := &config.IPsecConfig{
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {Name: "gw", Address: "203.0.113.1"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Name: "tun", Gateway: "gw", IPsecPolicy: "ipsec-pol"},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"prop1": {Name: "prop1", EncryptionAlg: "aes256\n        updown = /tmp/pwn.sh"},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		cfg       *config.IPsecConfig
+		directive string // the injected line that must NOT render live
+		wantSlot  string // the render slot that must still be present
+	}{
+		{
+			name:      "IKE proposals newline injection",
+			cfg:       ikeCfg,
+			directive: "reauth_time = 0",
+			wantSlot:  "proposals = aes256",
+		},
+		{
+			name:      "ESP esp_proposals updown->root injection",
+			cfg:       espCfg,
+			directive: "updown = /tmp/pwn.sh",
+			wantSlot:  "esp_proposals = aes256",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+			got := m.generateConfig(c.cfg)
+			if hasBareDirectiveLine(got, c.directive) {
+				t.Fatalf("swanctl proposal injection NOT neutralized: %q rendered "+
+					"as a live directive line — the newline in the proposal value "+
+					"was not stripped:\n%s", c.directive, got)
+			}
+			if !strings.Contains(got, c.wantSlot) {
+				t.Fatalf("expected sanitized proposal slot %q in render:\n%s",
+					c.wantSlot, got)
+			}
+		})
+	}
+}
+
+// TestSwanctlProposalsLegitPreserved_6469 is the over-escape guard for the
+// proposal fold: a legitimate multi-proposal list — dashed swanctl tokens
+// (aes256-sha256-modp2048) comma-joined for a `proposals [ p1 p2 ]` offer —
+// must render BYTE-IDENTICAL through the sanitize belt on BOTH the IKE
+// `proposals` and the ESP `esp_proposals` line. sanitizeSwanctlValue only
+// touches control bytes, so `-` and `,` survive.
+func TestSwanctlProposalsLegitPreserved_6469(t *testing.T) {
+	cfg := &config.IPsecConfig{
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {Name: "gw", Address: "203.0.113.1", IKEPolicy: "ike-pol"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Name: "tun", Gateway: "gw", IPsecPolicy: "ipsec-pol"},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Proposals: []string{"ike-a", "ike-b"}},
+		},
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-a": {Name: "ike-a", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
+			"ike-b": {Name: "ike-b", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-128-cbc", AuthAlg: "sha-256", DHGroup: 14},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"esp-a", "esp-b"}},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-a": {Name: "esp-a", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
+			"esp-b": {Name: "esp-b", EncryptionAlg: "aes-128-cbc", AuthAlg: "sha-256", DHGroup: 14},
+		},
+	}
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	got := m.generateConfig(cfg)
+
+	const wantIKE = "    proposals = aes256-sha256-modp2048,aes128-sha256-modp2048\n"
+	const wantESP = "        esp_proposals = aes256-sha256-modp2048,aes128-sha256-modp2048\n"
+	if !strings.Contains(got, wantIKE) {
+		t.Fatalf("legit IKE proposal list over-escaped or dropped: want %q in "+
+			"render:\n%s", wantIKE, got)
+	}
+	if !strings.Contains(got, wantESP) {
+		t.Fatalf("legit ESP proposal list over-escaped or dropped: want %q in "+
+			"render:\n%s", wantESP, got)
+	}
+}

--- a/pkg/ipsec/swanctl_addr_sanitize_6469_test.go
+++ b/pkg/ipsec/swanctl_addr_sanitize_6469_test.go
@@ -1,0 +1,168 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// buildAddrCfg constructs the minimal renderable IPsecConfig used by the
+// #6469 render-belt tests: one gateway + one VPN + a resolvable ike/ipsec
+// policy chain so renderConfig emits a full connection block. The caller
+// picks which endpoint field carries the value under test.
+func buildAddrCfg(gwAddr, gwDyn, gwLocal, vpnLocal string) *config.IPsecConfig {
+	// Mirror the proven-minimal endpoint_render_5630 fixture: gateway + VPN
+	// + a resolvable ipsec policy/proposal is enough for renderConfig to emit
+	// a full connection block with local_addrs / remote_addrs. No IKE policy
+	// chain is required (an absent ike-policy does not skip the VPN).
+	return &config.IPsecConfig{
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {Name: "gw", Address: gwAddr, DynamicHostname: gwDyn, LocalAddress: gwLocal},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Name: "tun", Gateway: "gw", IPsecPolicy: "ipsec-pol", LocalAddr: vpnLocal},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"prop1"}},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"prop1": {Name: "prop1", EncryptionAlg: "aes256", AuthAlg: "sha256"},
+		},
+	}
+}
+
+// hasBareDirectiveLine reports whether any rendered line, once its leading /
+// trailing whitespace is stripped, is EXACTLY the given swanctl directive.
+// A newline-injection payload that survives to render produces such a
+// standalone line (`    reauth_time = 0`); a neutralized payload keeps the
+// token mid-line inside the address value, so no line trims to it.
+func hasBareDirectiveLine(rendered, directive string) bool {
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.TrimSpace(line) == directive {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSwanctlAddrInjectionNeutralized_6469 is the fail-on-revert guard for
+// #6469: the swanctl local_addrs / remote_addrs render sites must run the
+// endpoint value through sanitizeSwanctlValue so an embedded newline cannot
+// inject a live swanctl directive on a validation-bypassed path (HA peer-sync
+// of a pre-fix config, or a directly-constructed IPsecConfig — both bypass
+// the commit-time endpoint gate). Reverting the sanitize wrap back to a raw
+// `%s` makes each case fail with a clean assertion: the injected directive
+// reappears as its own indented line.
+func TestSwanctlAddrInjectionNeutralized_6469(t *testing.T) {
+	// Payload: a legitimate-looking address, an embedded newline, then an
+	// indented swanctl directive the attacker wants promoted into the
+	// connection block. reauth_time is emitted by NO code path in this
+	// fixture, so its appearance as a bare line is proof of injection.
+	const inject = "203.0.113.1\n    reauth_time = 0"
+	const injectedDirective = "reauth_time = 0"
+
+	cases := []struct {
+		name string
+		cfg  *config.IPsecConfig
+		// addrLine is the sanitized address line that must be present,
+		// proving the connection still rendered (the VPN was not skipped)
+		// and the belt ran in place rather than dropping the field.
+		addrLine string
+	}{
+		{
+			name:     "remote via gateway Address",
+			cfg:      buildAddrCfg(inject, "", "", ""),
+			addrLine: "remote_addrs = 203.0.113.1",
+		},
+		{
+			name:     "remote via gateway DynamicHostname",
+			cfg:      buildAddrCfg("", inject, "198.51.100.7", ""),
+			addrLine: "remote_addrs = 203.0.113.1",
+		},
+		{
+			name:     "local via gateway LocalAddress",
+			cfg:      buildAddrCfg("198.51.100.7", "", inject, ""),
+			addrLine: "local_addrs = 203.0.113.1",
+		},
+		{
+			name:     "local via vpn LocalAddr",
+			cfg:      buildAddrCfg("198.51.100.7", "", "", inject),
+			addrLine: "local_addrs = 203.0.113.1",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+			got := m.generateConfig(c.cfg)
+
+			if hasBareDirectiveLine(got, injectedDirective) {
+				t.Fatalf("swanctl injection NOT neutralized: %q rendered as a "+
+					"live directive line — the newline in the endpoint value "+
+					"was not stripped:\n%s", injectedDirective, got)
+			}
+			// The sanitized value must still lead the address line: the belt
+			// collapses the newline to a space, so the address renders inert
+			// on one line rather than the field being dropped or the VPN
+			// skipped.
+			if !strings.Contains(got, c.addrLine) {
+				t.Fatalf("expected sanitized address line %q in render:\n%s",
+					c.addrLine, got)
+			}
+		})
+	}
+}
+
+// TestSwanctlAddrLegitPreserved_6469 is the over-escape guard: a legitimate
+// endpoint — a single IPv4, a comma-separated multi-address list, an IPv6
+// literal, and the responder-only "%any" sentinel — must render BYTE-
+// IDENTICAL through the sanitize belt. sanitizeSwanctlValue only touches
+// C0/DEL control bytes, so `.`, `,`, `:` and `%` all survive; this test pins
+// that the #6469 fix does not mangle a real address list or IPv6 endpoint.
+func TestSwanctlAddrLegitPreserved_6469(t *testing.T) {
+	cases := []struct {
+		name     string
+		gwAddr   string
+		wantLine string
+	}{
+		{
+			name:     "single IPv4",
+			gwAddr:   "203.0.113.1",
+			wantLine: "remote_addrs = 203.0.113.1",
+		},
+		{
+			name:     "comma-separated multi-address list",
+			gwAddr:   "203.0.113.1,203.0.113.2",
+			wantLine: "remote_addrs = 203.0.113.1,203.0.113.2",
+		},
+		{
+			name:     "IPv6 literal",
+			gwAddr:   "2001:db8::1",
+			wantLine: "remote_addrs = 2001:db8::1",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+			got := m.generateConfig(buildAddrCfg(c.gwAddr, "", "", ""))
+			if !strings.Contains(got, c.wantLine) {
+				t.Fatalf("legit endpoint over-escaped or dropped: want %q in "+
+					"render:\n%s", c.wantLine, got)
+			}
+		})
+	}
+
+	// Responder-only (%any) must survive the belt untouched — '%' is not a
+	// control byte, and this is the sentinel for a dynamic-IP peer.
+	t.Run("responder-only %any", func(t *testing.T) {
+		cfg := buildAddrCfg("", "", "", "")
+		cfg.Gateways["gw"].ResponderOnly = true
+		m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+		got := m.generateConfig(cfg)
+		if !strings.Contains(got, "remote_addrs = %any") {
+			t.Fatalf("responder-only %%any endpoint not preserved:\n%s", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes the last raw-`%s` swanctl-injection surface. The connection
`local_addrs`/`remote_addrs` render lines in `pkg/ipsec/policy.go`
interpolated the resolved endpoint verbatim, while the render belt that
already guards the connection name, IKE `id`/`certs`, PSK `secret`, and
the `local_ts`/`remote_ts` child-SA selectors did not cover the endpoint
address fields.

## The gap

On a path that reaches `renderConfig` without the strict commit-time
endpoint validator (`validateIPsecEndpointsStrict`) — HA peer-sync of a
config persisted before the fix, or a directly-constructed `IPsecConfig`
— a gateway whose `address`/`dynamic hostname`/`local-address` carries an
embedded newline lands verbatim in `/etc/swanctl/conf.d/xpf.conf`,
injecting strongSwan connection keys (downgrade `version`, flip
`aggressive`, add `also`/`children`). `resolveRemoteAddr` takes
`gw.Address`/`gw.DynamicHostname` verbatim for the Gateways-map shape;
only the legacy inline `vpn.Gateway` shape was independently filtered by
`config.IsUsableIPsecEndpoint`.

## Fix

Wrap both `policy.go` Fprintf sites in `sanitizeSwanctlValue`. These are
UNQUOTED comma-list slots, so — exactly like the `local_ts`/`remote_ts`
belt — sanitize alone is the correct form. `escapeSwanctlQuoted` is for
the quoted `id`/`cert`/`secret` slots only and would mis-escape an
unquoted value. `sanitizeSwanctlValue` collapses the newline to a space,
keeping a tampered endpoint inert on one line instead of a live
directive, and touches nothing in a legitimate endpoint (`.`, `,`, `:`,
`%` preserved), so a single address, a comma-separated multi-address
list, an IPv6 literal, and the responder-only `%any` sentinel render
byte-identical. This is the by-construction backstop mirroring the
#1798/#2126/#4098 belt doctrine; the commit-time gate remains the hard
diagnostic on operator commit.

## Test (fail-on-revert)

`swanctl_addr_sanitize_6469_test.go` renders an endpoint carrying
`203.0.113.1\n    reauth_time = 0` via each of the four
validation-bypassed shapes (`gw.Address`, `gw.DynamicHostname`,
`gw.LocalAddress`, `vpn.LocalAddr`) and asserts the injected directive
never appears as a live line; an over-escape guard asserts a legit
single / comma-list / IPv6 / `%any` endpoint still renders. Reverting the
sanitize wrap to raw `%s` fails with a clean assertion (`swanctl
injection NOT neutralized: reauth_time = 0 rendered as a live directive
line`), confirmed firsthand.

## Validation

`go build ./...`, `go vet ./pkg/ipsec/`, `gofmt -l`, `go test
./pkg/ipsec/...`, and `pkg/refactoraudit TestHeatmapNotStale` all pass.
`pkg/ipsec/README.md` gains the #6469 belt entry.

Closes #6469