### PR TITLE
config: reject duplicate NAT rule-SET names within one nat type (#6454)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -60511,3 +60511,28 @@ top.
   (13s), TestHeatmapNotStale all GREEN (no LOC bucket shift).
 - **File(s)**: pkg/config/compiler_nat_static.go,
     pkg/config/static_nat_multitarget_6483_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-24
+- **Action**: #6454 — commit-time gate rejecting duplicate NAT rule-SET names
+  within one nat type (source/destination/static/nat64). Sibling of #5649
+  (rule-NAME axis) one level up. Two same-named rule-sets both SURVIVE (compileNAT*
+  APPEND, never merge by name), so their rules share the natType/ruleSet/rule
+  counter namespace and per-rule telemetry merges; nat64 rule-sets (counter-less,
+  no `rule` nodes) still share their show-surface name identity. New gate
+  validateDuplicateNATRuleSetNamesAST keyed by (natType, rule-set), unioned across
+  repeated sub-blocks (#3915), deduped at the AST rule-set-INSTANCE level so a
+  single #3096 bracket-list-scoped rule-set (Cartesian-expands into multiple
+  same-named NATRuleSet objects downstream) is NOT flagged. Scope: only WITHIN one
+  nat type — the counter key is natType-prefixed (NATCounterKey), so a same-named
+  rule-set across DIFFERENT nat types is a distinct namespace and accepted. Wired
+  into compileConfigWithOpts + compileConfigForNodeWithOpts; strict rejects,
+  lenient warns via opts.lenientDuplicateNATRuleSetName (#1960 no-brick).
+  PARENT-RED: guard `seen[key]` with `&& false` (imports stay live, go vet OK) →
+  all reject tests go clean-assertion RED (strict CompileConfig returns nil); the
+  no-false-positive accepts stay GREEN. go build ./..., go vet ./pkg/config/,
+  gofmt, FULL pkg/config suite (12s), TestHeatmapNotStale all GREEN (regenerated
+  heatmap — only compiler_opts.go bucket 2095→2113).
+- **File(s)**: pkg/config/dup_nat_ruleset_names.go,
+    pkg/config/dup_nat_ruleset_names_6454_test.go, pkg/config/compiler.go,
+    pkg/config/compiler_opts.go, docs/config-schema.md,
+    docs/refactoring-audit-current.txt, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -524,23 +524,27 @@ named-block gate.
 ### Duplicate NAT rule-SET name (#6454, C181-M18 sibling)
 
 The #5649 gate above closes the rule-NAME axis; #6454 closes the rule-SET-name
-axis one level up. Like a rule, a rule-set name is its operational identity —
-the from/to scope binding and, for source / destination / ordinary static NAT,
-the `natType/ruleset/rule` counter namespace (`NATCounterKey`,
-`pkg/dataplane/compiler_nat.go`, keyed by natType). Two rule-sets authored with
-the SAME name WITHIN one nat type are NOT reduced to last-writer-wins like a
-#5180 hierarchical block — they BOTH survive: `compileNATSource` /
+axis one level up. A rule-set name is its operational identity — the from/to
+scope binding and the CLI show key. It is UNIQUE per nat type but reusable
+ACROSS nat types (Junos gives source / destination / static / nat64 independent
+name spaces; `NATCounterKey` in `pkg/dataplane/compiler_nat.go` is natType-
+prefixed for the counted types). Two rule-sets authored with the SAME name
+WITHIN one nat type are NOT reduced to last-writer-wins like a #5180
+hierarchical block — they BOTH survive: `compileNATSource` /
 `compileNATDestination` / `compileNATStatic` / `compileNAT64` each APPEND the
 rule-set (`sec.NAT.Source` / `Destination.RuleSets` / `Static` / `NAT64`), never
 merging by name, so both compile as separate first-match tables sharing one
-identity. For the counted natTypes their rules then merge on the shared
-`natType/ruleset/rule` counter identity, so `show` / counter surfaces cannot
-disambiguate; a counter-less nat64 rule-set (prefix / source-pool, no `rule`
-nodes — correctly excluded from the #5649 rule-name gate) still shares its
-show-surface name identity, so it is deduped here too. Either way the duplicate
-name is a config error — the harm is type-independent (the shared name
-identity), which is why the diagnostic is type-agnostic and never claims a
-per-rule counter.
+name. The operator authored what they read as one rule-set; it compiles to two,
+evaluated in sequence. The CLI named-rule-set show lookup
+(`showNATSourceRuleSet` in `pkg/cli/cli_show_nat.go`) returns on the FIRST name
+match, so the second same-named rule-set — and its rules — is invisible on that
+surface and the operator cannot disambiguate the two. This is NOT a per-rule
+counter merge: `NATCounterKey` includes the rule name, so the disjoint rules
+this gate uniquely catches get distinct counter keys (a SAME rule name in both
+is caught first by the #5649 gate); a nat64 rule-set (prefix / source-pool, no
+`rule` nodes — correctly excluded from the #5649 rule-name gate) is counter-less
+anyway. The harm is type-independent (the shared rule-set NAME identity), which
+is why the diagnostic is type-agnostic and never claims a per-rule counter.
 
 `validateDuplicateNATRuleSetNamesAST(tree, lenient)`
 (`pkg/config/dup_nat_ruleset_names.go`, wired beside the #5649 duplicate-rule-name

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -521,6 +521,54 @@ pre-expansion scan, and a quoted-empty rule name is skipped — are tracked
 family-wide in #6455 rather than diverging this gate's scope from the
 named-block gate.
 
+### Duplicate NAT rule-SET name (#6454, C181-M18 sibling)
+
+The #5649 gate above closes the rule-NAME axis; #6454 closes the rule-SET-name
+axis one level up. Like a rule, a rule-set name is its operational identity —
+the from/to scope binding and, for source / destination / ordinary static NAT,
+the `natType/ruleset/rule` counter namespace (`NATCounterKey`,
+`pkg/dataplane/compiler_nat.go`, keyed by natType). Two rule-sets authored with
+the SAME name WITHIN one nat type are NOT reduced to last-writer-wins like a
+#5180 hierarchical block — they BOTH survive: `compileNATSource` /
+`compileNATDestination` / `compileNATStatic` / `compileNAT64` each APPEND the
+rule-set (`sec.NAT.Source` / `Destination.RuleSets` / `Static` / `NAT64`), never
+merging by name, so both compile as separate first-match tables sharing one
+identity. For the counted natTypes their rules then merge on the shared
+`natType/ruleset/rule` counter identity, so `show` / counter surfaces cannot
+disambiguate; a counter-less nat64 rule-set (prefix / source-pool, no `rule`
+nodes — correctly excluded from the #5649 rule-name gate) still shares its
+show-surface name identity, so it is deduped here too. Either way the duplicate
+name is a config error — the harm is type-independent (the shared name
+identity), which is why the diagnostic is type-agnostic and never claims a
+per-rule counter.
+
+`validateDuplicateNATRuleSetNamesAST(tree, lenient)`
+(`pkg/config/dup_nat_ruleset_names.go`, wired beside the #5649 duplicate-rule-name
+gate in both `compileConfigWithOpts` and `compileConfigForNodeWithOpts`) rejects
+this at commit. It runs **pre-expansion** on top-level `security` stanzas only,
+for the same reasons as #5649 — apply-groups DEEP-MERGES a same-named rule-set
+rather than duplicating it, and the flat `set` form reuses the rule-set node
+(`tree.SetPath` merges), so only a directly-authored hierarchical duplicate
+reaches the gate. The seen-set is keyed by `(natType, rule-set)` and unioned
+across repeated `security` / `nat` / sub-block stanzas (compileNAT merges those,
+#3915), so a rule-set name split across two `source {}` blocks is caught too.
+The same rule-set name in two DIFFERENT nat types (a distinct
+natType-prefixed namespace) is accepted. Crucially the dedup is at the AST
+rule-set-INSTANCE level, NOT the compiled level: a single authored rule-set
+carrying a bracket list of from/to scopes Cartesian-expands into MULTIPLE
+same-named `NATRuleSet` objects downstream (#3096) — that is one AST instance
+and is NOT flagged (a compiled-level dedup would false-positive here). Strict
+(commit / commit-check) hard-rejects; lenient (load / peer-sync) warns via
+`opts.lenientDuplicateNATRuleSetName` (#1960 no-brick) and keeps the historical
+two-table behavior.
+
+Covered by `pkg/config/dup_nat_ruleset_names_6454_test.go` (source / destination
+/ static / nat64 reject, nat64 counter-less-diagnostic guard, lenient warn, and
+distinct-name / different-nat-type / bracket-list-scope-expansion / flat-set-merge
+accept guards), RED on revert of the gate (the duplicate is accepted). Shares the
+same applied-group and quoted-empty-name limitations as its #5649 / #5180 siblings
+(tracked family-wide in #6455).
+
 **Phase 2 (#5878) — reference-binder canonicalization.** Phase 1 (above) closes
 the divergent-commit fail-open by rejecting a duplicate-spelling collision at
 commit. The second, subtler half of #5878 is that a cross-subsystem reference

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -10,7 +10,7 @@
 [REFACTOR]   2191  userspace-dp/src/session/mod.rs
 [REFACTOR]   2166  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [REFACTOR]   2157  pkg/config/compiler_system.go
-[REFACTOR]   2095  pkg/config/compiler_opts.go
+[REFACTOR]   2113  pkg/config/compiler_opts.go
 [REFACTOR]   2062  pkg/dataplane/userspace/manager_ha.go
 [REFACTOR]   2017  userspace-dp/src/afxdp/frame/mod.rs
 [REFACTOR]   2004  userspace-dp/src/afxdp/frame/inspect.rs

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -10,7 +10,7 @@
 [REFACTOR]   2191  userspace-dp/src/session/mod.rs
 [REFACTOR]   2166  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [REFACTOR]   2157  pkg/config/compiler_system.go
-[REFACTOR]   2113  pkg/config/compiler_opts.go
+[REFACTOR]   2114  pkg/config/compiler_opts.go
 [REFACTOR]   2062  pkg/dataplane/userspace/manager_ha.go
 [REFACTOR]   2017  userspace-dp/src/afxdp/frame/mod.rs
 [REFACTOR]   2004  userspace-dp/src/afxdp/frame/inspect.rs

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -259,11 +259,12 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 	// validateDuplicateNATRuleSetNamesAST. The rule-SET axis one level above the
 	// #5649 rule-name gate: two same-named rule-sets within one nat type
 	// (source/destination/static/nat64) BOTH survive as separate first-match
-	// tables sharing one operational identity, so per-rule telemetry merges and
-	// show/counter surfaces cannot disambiguate. Pre-expansion, top-level
-	// `security` stanzas only, keyed by (natType, rule-set) so a same-named
-	// rule-set across DIFFERENT nat types stays legitimate; strict rejects,
-	// lenient warns.
+	// tables sharing one name, and the CLI named-rule-set show lookup returns on
+	// the first match, so the operator cannot disambiguate the two (not a
+	// per-rule counter merge — NATCounterKey includes the rule name). Pre-
+	// expansion, top-level `security` stanzas only, keyed by (natType, rule-set)
+	// so a same-named rule-set across DIFFERENT nat types stays legitimate; strict
+	// rejects, lenient warns.
 	dupNATRuleSetWarnings, dupNATRuleSetErr := validateDuplicateNATRuleSetNamesAST(
 		tree, opts.lenientDuplicateNATRuleSetName)
 	if dupNATRuleSetErr != nil {

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -255,6 +255,21 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 		return nil, dupNATRuleErr
 	}
 
+	// #6454 (C181-M18 sibling): duplicate NAT rule-SET-name gate — see
+	// validateDuplicateNATRuleSetNamesAST. The rule-SET axis one level above the
+	// #5649 rule-name gate: two same-named rule-sets within one nat type
+	// (source/destination/static/nat64) BOTH survive as separate first-match
+	// tables sharing one operational identity, so per-rule telemetry merges and
+	// show/counter surfaces cannot disambiguate. Pre-expansion, top-level
+	// `security` stanzas only, keyed by (natType, rule-set) so a same-named
+	// rule-set across DIFFERENT nat types stays legitimate; strict rejects,
+	// lenient warns.
+	dupNATRuleSetWarnings, dupNATRuleSetErr := validateDuplicateNATRuleSetNamesAST(
+		tree, opts.lenientDuplicateNATRuleSetName)
+	if dupNATRuleSetErr != nil {
+		return nil, dupNATRuleSetErr
+	}
+
 	// #5878: numeric interface-unit alias gate (#5631) as a BOTH-NODE-effective
 	// union. Runs PRE-expansion, beside the tunnel/zone/table-id gates, so a
 	// peer-only `groups node1`/`${node}` alias that collides only in the
@@ -318,6 +333,7 @@ func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) 
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupNATRuleWarnings...)
+	cfg.Warnings = append(cfg.Warnings, dupNATRuleSetWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
 	cfg.Warnings = append(cfg.Warnings, qinqWarnings...)
 	cfg.Warnings = append(cfg.Warnings, vlanMapWarnings...)
@@ -397,6 +413,16 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 		return nil, dupNATRuleErr
 	}
 
+	// #6454 (C181-M18 sibling): duplicate NAT rule-SET-name gate — see
+	// compileConfigWithOpts / validateDuplicateNATRuleSetNamesAST. Pre-expansion,
+	// top-level `security` stanzas only, keyed by (natType, rule-set); strict
+	// rejects, lenient warns.
+	dupNATRuleSetWarnings, dupNATRuleSetErr := validateDuplicateNATRuleSetNamesAST(
+		tree, opts.lenientDuplicateNATRuleSetName)
+	if dupNATRuleSetErr != nil {
+		return nil, dupNATRuleSetErr
+	}
+
 	// #5878: numeric interface-unit alias gate (#5631) as a BOTH-NODE-effective
 	// union — see compileConfigWithOpts. Pre-expansion on purpose: the union
 	// across View 1 (groups) + Views 2/3 (node0/node1 expansions) is identical
@@ -454,6 +480,7 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 	cfg.Warnings = append(cfg.Warnings, riTableIDWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupBlockWarnings...)
 	cfg.Warnings = append(cfg.Warnings, dupNATRuleWarnings...)
+	cfg.Warnings = append(cfg.Warnings, dupNATRuleSetWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unitAliasWarnings...)
 	cfg.Warnings = append(cfg.Warnings, qinqWarnings...)
 	cfg.Warnings = append(cfg.Warnings, vlanMapWarnings...)

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -426,6 +426,23 @@ type compileOpts struct {
 	// once.
 	lenientDuplicateNATRuleName bool
 
+	// lenientDuplicateNATRuleSetName (#6454, C181-M18 sibling) downgrades the
+	// duplicate NAT rule-SET-name gate (validateDuplicateNATRuleSetNamesAST) from
+	// a hard error to a warning on the tolerant load / peer-sync paths. Like
+	// #5649 (and unlike #5180) the duplicate is NOT last-writer-wins: two
+	// same-named rule-sets within one nat type (source/destination/static/nat64)
+	// BOTH survive as separate first-match tables sharing one operational
+	// identity (the rule-set name — the from/to scope binding and, for the
+	// counted natTypes, the natType/ruleSet/rule counter namespace), so per-rule
+	// telemetry merges and show/counter surfaces cannot disambiguate. An
+	// already-persisted config (or one synced from a peer) may carry such a
+	// duplicate; an upgrading / receiving node must still boot through it (warn —
+	// the runtime keeps the historical two-table behavior) rather than
+	// fail-closed-on-load (#1960 class). Commit / commit-check stay strict — a new
+	// operator edit that authors a rule-set twice is rejected so the author is
+	// told to write it once. Same doctrine as lenientDuplicateNATRuleName.
+	lenientDuplicateNATRuleSetName bool
+
 	// lenientNATHostMask (#2173) downgrades the static-NAT / NAT64
 	// host-mask gate (validateNATHostMaskStrict) from a hard compile error
 	// to a cfg.Warnings entry. Set ONLY on the tolerant load / peer-sync
@@ -1993,6 +2010,7 @@ func lenientCompileOpts() compileOpts {
 		lenientDynamicAddressFeedRef:           true,
 		lenientDuplicateNamedBlock:             true,
 		lenientDuplicateNATRuleName:            true,
+		lenientDuplicateNATRuleSetName:         true,
 		lenientNATPoolAlarmThreshold:           true,
 		lenientNATHostMask:                     true,
 		lenientUnsupportedInterfaceStanzas:     true,

--- a/pkg/config/compiler_opts.go
+++ b/pkg/config/compiler_opts.go
@@ -431,10 +431,11 @@ type compileOpts struct {
 	// a hard error to a warning on the tolerant load / peer-sync paths. Like
 	// #5649 (and unlike #5180) the duplicate is NOT last-writer-wins: two
 	// same-named rule-sets within one nat type (source/destination/static/nat64)
-	// BOTH survive as separate first-match tables sharing one operational
-	// identity (the rule-set name — the from/to scope binding and, for the
-	// counted natTypes, the natType/ruleSet/rule counter namespace), so per-rule
-	// telemetry merges and show/counter surfaces cannot disambiguate. An
+	// BOTH survive as separate first-match tables sharing one name (the from/to
+	// scope binding and the CLI show key), and the named-rule-set show lookup
+	// returns on the first match so the operator cannot disambiguate the two — not
+	// a per-rule counter merge (NATCounterKey includes the rule name, so disjoint
+	// rules get distinct counters). An
 	// already-persisted config (or one synced from a peer) may carry such a
 	// duplicate; an upgrading / receiving node must still boot through it (warn —
 	// the runtime keeps the historical two-table behavior) rather than

--- a/pkg/config/dup_nat_ruleset_names.go
+++ b/pkg/config/dup_nat_ruleset_names.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// natRuleSetSubBlocks lists the NAT sub-blocks whose rule-SETS carry a named
+// operational identity that must be unique within the sub-block's natType
+// namespace. It EXTENDS natRuleSubBlocks (source / destination / static — the
+// rule-NAME axis of #5649) with nat64: a nat64 rule-set carries prefix /
+// source-pool and NO `rule` nodes (correctly excluded from the #5649 rule-name
+// gate), but its NAME is still the operational identity, so a duplicated nat64
+// rule-set name is its own fail-open worth catching (#6454). natv6v4 /
+// proxy-arp are excluded: neither is a named first-match rule-set.
+var natRuleSetSubBlocks = []string{"source", "destination", "static", "nat64"}
+
+// dupNATRuleSet is one detected duplicate rule-set name within one NAT type.
+type dupNATRuleSet struct {
+	natType string // "source" | "destination" | "static" | "nat64"
+	ruleSet string // the duplicated rule-set name
+}
+
+// validateDuplicateNATRuleSetNamesAST rejects (strict) or warns (lenient) when
+// the candidate authors the SAME rule-set name twice within one NAT type. This
+// is the #5649 (C181-M18) duplicate-NAT-rule-name defect one level up — the
+// rule-SET axis (#6454).
+//
+// A NAT rule-set name is its operational identity: the from/to scope binding
+// and, for source / destination / static, the natType/ruleSet/rule counter
+// namespace (pkg/dataplane/compiler_nat.go NATCounterKey — keyed by natType so
+// the SAME rule-set name across DIFFERENT nat types is a distinct namespace and
+// legitimate, but the same name WITHIN one nat type collides). Two same-named
+// rule-sets do NOT reduce to last-writer-wins like a #5180 hierarchical block —
+// they BOTH survive: compileNATSource / compileNATDestination / compileNATStatic
+// / compileNAT64 each APPEND the rule-set (sec.NAT.Source / Destination.RuleSets
+// / Static / NAT64), so both compile as separate first-match tables sharing one
+// identity and per-rule telemetry MERGES across them (for the counted natTypes),
+// with show / counter surfaces unable to disambiguate their rules. For a
+// counter-less nat64 rule-set the name is still the show-surface identity, so
+// the diagnostic is deliberately type-agnostic (it never claims a per-rule
+// counter) — the genuine, type-independent defect is the shared name identity.
+//
+// Runs PRE-expansion on top-level `security` stanzas only, exactly like
+// validateDuplicateNATRuleNamesAST (#5649) and validateDuplicateNamedBlockAST
+// (#5180): apply-groups DEEP-MERGES a same-named rule-set rather than
+// duplicating it, and a rule-set authored once via flat `set` reuses its
+// rule-set node (tree.SetPath merges), so only a directly-authored hierarchical
+// duplicate reaches here. The seen-set is keyed by (natType, ruleSet) and
+// unioned across repeated `security` / `nat` / sub-block stanzas — compileNAT
+// (#3915) merges those repeats — so a rule-set name split across two `source {}`
+// blocks is caught too. Crucially the dedup is at the AST rule-set-INSTANCE
+// level, NOT the compiled level: a single authored rule-set carrying a bracket
+// list of from/to scopes (#3096) Cartesian-expands into MULTIPLE same-named
+// NATRuleSet objects downstream — that legitimate expansion is one AST instance
+// and is NOT flagged. Strict rejects on the operator commit / commit-check path;
+// lenient (Load / peer-sync, #1960) warns and keeps the historical two-table
+// behavior.
+func validateDuplicateNATRuleSetNamesAST(tree *ConfigTree, lenient bool) ([]string, error) {
+	if tree == nil {
+		return nil, nil
+	}
+	var dups []dupNATRuleSet
+	seen := map[string]bool{}
+	reported := map[string]bool{}
+	for _, top := range tree.Children {
+		if top.Name() != "security" {
+			continue
+		}
+		for _, nat := range top.FindChildren("nat") {
+			for _, natType := range natRuleSetSubBlocks {
+				for _, sub := range nat.FindChildren(natType) {
+					for _, rsInst := range namedInstances(sub.FindChildren("rule-set")) {
+						if rsInst.name == "" {
+							continue
+						}
+						key := natType + "\x00" + rsInst.name
+						if seen[key] {
+							if !reported[key] {
+								dups = append(dups, dupNATRuleSet{natType, rsInst.name})
+								reported[key] = true
+							}
+						} else {
+							seen[key] = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if len(dups) == 0 {
+		return nil, nil
+	}
+	// Deterministic order: natType, then rule-set.
+	sort.Slice(dups, func(i, j int) bool {
+		if dups[i].natType != dups[j].natType {
+			return dups[i].natType < dups[j].natType
+		}
+		return dups[i].ruleSet < dups[j].ruleSet
+	})
+
+	if !lenient {
+		d := dups[0]
+		return nil, fmt.Errorf("duplicate NAT %s rule-set %q: a NAT rule-set name "+
+			"is its operational identity, so the same name authored twice compiles "+
+			"both instances as separate first-match rule-sets sharing one identity "+
+			"— operator show surfaces cannot disambiguate them; author the "+
+			"rule-set once (flat `set` merges repeated statements automatically) "+
+			"(#6454)", d.natType, d.ruleSet)
+	}
+
+	warnings := make([]string, 0, len(dups))
+	for _, d := range dups {
+		warnings = append(warnings, fmt.Sprintf("duplicate NAT %s rule-set %q: the "+
+			"same name compiles both instances as separate rule-sets sharing one "+
+			"operational identity — author it once (#6454)", d.natType, d.ruleSet))
+	}
+	return warnings, nil
+}

--- a/pkg/config/dup_nat_ruleset_names.go
+++ b/pkg/config/dup_nat_ruleset_names.go
@@ -27,26 +27,39 @@ type dupNATRuleSet struct {
 // rule-SET axis (#6454).
 //
 // A NAT rule-set name is its operational identity: the from/to scope binding
-// and, for source / destination / static, the natType/ruleSet/rule counter
-// namespace (pkg/dataplane/compiler_nat.go NATCounterKey — keyed by natType so
-// the SAME rule-set name across DIFFERENT nat types is a distinct namespace and
-// legitimate, but the same name WITHIN one nat type collides). Two same-named
-// rule-sets do NOT reduce to last-writer-wins like a #5180 hierarchical block —
-// they BOTH survive: compileNATSource / compileNATDestination / compileNATStatic
-// / compileNAT64 each APPEND the rule-set (sec.NAT.Source / Destination.RuleSets
-// / Static / NAT64), so both compile as separate first-match tables sharing one
-// identity and per-rule telemetry MERGES across them (for the counted natTypes),
-// with show / counter surfaces unable to disambiguate their rules. For a
-// counter-less nat64 rule-set the name is still the show-surface identity, so
-// the diagnostic is deliberately type-agnostic (it never claims a per-rule
-// counter) — the genuine, type-independent defect is the shared name identity.
+// and the CLI show key. The name is UNIQUE per nat type but reusable ACROSS nat
+// types — Junos gives source / destination / static / nat64 independent name
+// spaces (NATCounterKey in pkg/dataplane/compiler_nat.go is natType-prefixed for
+// the counted types), so the same rule-set name in two DIFFERENT nat types is a
+// distinct identity and legitimate; only the same name WITHIN one nat type
+// collides. Two same-named rule-sets do NOT reduce to last-writer-wins like a
+// #5180 hierarchical block — they BOTH survive: compileNATSource /
+// compileNATDestination / compileNATStatic / compileNAT64 each APPEND the
+// rule-set (sec.NAT.Source / Destination.RuleSets / Static / NAT64), never
+// merging by name, so both compile as separate first-match tables sharing one
+// name. The operator authored what they read as one rule-set; it compiles to
+// two, evaluated in sequence. The CLI named-rule-set show lookup (e.g.
+// showNATSourceRuleSet in pkg/cli/cli_show_nat.go) returns on the FIRST name
+// match, so the second same-named rule-set — and its rules — is invisible on
+// that surface and the operator cannot disambiguate the two.
+//
+// This is NOT a per-rule counter merge: NATCounterKey INCLUDES the rule name, so
+// the disjoint rules this gate uniquely catches (rule R1 in the first RS, rule
+// R2 in the second) get DISTINCT counter keys and never share a hit counter — a
+// SAME rule name in both rule-sets is caught first by the #5649 rule-NAME gate.
+// The genuine, type-independent defect is the shared rule-set NAME identity, so
+// the diagnostic is deliberately type-agnostic and never claims a per-rule
+// counter (a nat64 rule-set is counter-less anyway).
 //
 // Runs PRE-expansion on top-level `security` stanzas only, exactly like
 // validateDuplicateNATRuleNamesAST (#5649) and validateDuplicateNamedBlockAST
 // (#5180): apply-groups DEEP-MERGES a same-named rule-set rather than
 // duplicating it, and a rule-set authored once via flat `set` reuses its
 // rule-set node (tree.SetPath merges), so only a directly-authored hierarchical
-// duplicate reaches here. The seen-set is keyed by (natType, ruleSet) and
+// duplicate reaches here. (Two limitations shared with the #5649 / #5180
+// siblings — a duplicate authored ENTIRELY inside an applied group, and a
+// quoted-empty rule-set name — bypass this top-level-only pre-expansion scan and
+// are tracked family-wide in #6455.) The seen-set is keyed by (natType, ruleSet) and
 // unioned across repeated `security` / `nat` / sub-block stanzas — compileNAT
 // (#3915) merges those repeats — so a rule-set name split across two `source {}`
 // blocks is caught too. Crucially the dedup is at the AST rule-set-INSTANCE

--- a/pkg/config/dup_nat_ruleset_names_6454_test.go
+++ b/pkg/config/dup_nat_ruleset_names_6454_test.go
@@ -9,22 +9,34 @@ import (
 // type (source/destination/static/nat64) BOTH survive — compileNATSource /
 // compileNATDestination / compileNATStatic / compileNAT64 each APPEND the
 // rule-set (they never merge by name), so both compile as separate first-match
-// tables sharing one operational identity (the rule-set name). For the counted
-// natTypes that identity is also the shared natType/ruleSet/rule counter
-// namespace, so per-rule telemetry merges and show/counter surfaces cannot
-// disambiguate; a counter-less nat64 rule-set still shares its show-surface
-// name identity. validateDuplicateNATRuleSetNamesAST rejects this at strict
-// commit and warns on the tolerant load path (#1960).
+// tables sharing one name. The operator authored what they read as one
+// rule-set; it compiles to two, evaluated in sequence, and the CLI
+// named-rule-set show lookup (showNATSourceRuleSet, pkg/cli/cli_show_nat.go)
+// returns on the FIRST name match — so the second same-named rule-set and its
+// rules are invisible on that surface and the operator cannot disambiguate the
+// two. This is NOT a per-rule counter merge: NATCounterKey includes the rule
+// name, so the disjoint rules this gate uniquely catches get distinct counter
+// keys (a SAME rule name in both is caught first by the #5649 rule-NAME gate).
+// validateDuplicateNATRuleSetNamesAST rejects this at strict commit and warns on
+// the tolerant load path (#1960).
 //
-// This is the rule-SET axis one level above the #5649 rule-NAME gate. The
+// This is the rule-SET axis one level above the #5649 rule-NAME gate. The reject
 // fixtures use DISJOINT rule names inside each duplicate rule-set so the #5649
 // gate (which runs first, keyed by (natType, ruleSet, rule)) does NOT fire —
 // control reaches THIS gate.
 //
+// Both the reject AND the accept tests drive the PUBLIC compile entry points
+// (CompileConfig / CompileConfigLenient), not the private validator, so the
+// false-positive guarantee (a #3096 bracket-list-scoped rule-set, a cross-type
+// name reuse, a flat-set merge) is bound through the REAL commit path — a future
+// change to the compile-path expansion that reintroduced a false-positive would
+// turn an accept test RED.
+//
 // RED-on-revert: neutralize the gate so it never records a duplicate (guard the
 // `seen[key]` detection with `&& false`, keeping the fmt/sort references and
 // therefore the imports live — a clean assertion RED, not a build break). The
-// strict sub-tests then no longer see a #6454 error and go RED.
+// strict sub-tests then no longer see a #6454 error and go RED; the accept
+// sub-tests still compile cleanly (the gate never fired for them either way).
 
 // parseHier6454 parses a hierarchical (brace-delimited) config via NewParser —
 // the correct tool for a hierarchical duplicate block. Flat `set` MERGES a
@@ -52,6 +64,19 @@ func setTree6454(t *testing.T, cmds []string) *ConfigTree {
 		}
 	}
 	return tree
+}
+
+// countSourceRuleSets6454 returns how many compiled source NAT rule-sets carry
+// the given name (a single authored rule-set may legitimately Cartesian-expand
+// into several same-named entries via #3096 scope lists).
+func countSourceRuleSets6454(cfg *Config, name string) int {
+	n := 0
+	for _, rs := range cfg.Security.NAT.Source {
+		if rs.Name == name {
+			n++
+		}
+	}
+	return n
 }
 
 // TestDuplicateNATRuleSetNameRejected is the #6454 RED-on-revert proof: strict
@@ -204,9 +229,11 @@ func TestDuplicateNATRuleSetNameNat64NotCounter(t *testing.T) {
 
 // TestDuplicateNATRuleSetNameLenientWarns proves the tolerant path (Load /
 // peer-sync) downgrades the reject to a warning so an already-persisted or
-// peer-synced config still boots through (#1960 class).
+// peer-synced config still boots through (#1960 class). Both halves drive the
+// public entry points: CompileConfig (strict → hard error) and
+// CompileConfigLenient (tolerant → no hard error + the #6454 warning surfaced).
 func TestDuplicateNATRuleSetNameLenientWarns(t *testing.T) {
-	tree := parseHier6454(t, `security {
+	const cfg = `security {
     nat {
         source {
             rule-set RS {
@@ -223,54 +250,64 @@ func TestDuplicateNATRuleSetNameLenientWarns(t *testing.T) {
             }
         }
     }
-}`)
+}`
 
-	// Strict: hard error.
-	if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err == nil {
-		t.Fatal("strict validator must reject the duplicate rule-set name")
+	// Strict public path: hard error naming the rule-set and #6454.
+	if _, err := CompileConfig(parseHier6454(t, cfg)); err == nil {
+		t.Fatal("strict CompileConfig must reject the duplicate rule-set name")
 	}
 
-	// Lenient: no error, one warning that names the rule-set and references #6454.
-	warnings, err := validateDuplicateNATRuleSetNamesAST(tree, true)
+	// Tolerant public path: no hard error, and the #6454 warning is surfaced on
+	// cfg.Warnings (the runtime keeps the historical two-table behavior).
+	lenientCfg, err := CompileConfigLenient(parseHier6454(t, cfg))
 	if err != nil {
-		t.Fatalf("lenient validator must not error, got: %v", err)
+		t.Fatalf("CompileConfigLenient must not hard-fail on a duplicate rule-set name, got: %v", err)
 	}
-	if len(warnings) != 1 {
-		t.Fatalf("lenient validator must emit exactly one warning, got %d: %v", len(warnings), warnings)
-	}
-	for _, want := range []string{"RS", "6454"} {
-		if !strings.Contains(warnings[0], want) {
-			t.Fatalf("warning should mention %q, got: %v", want, warnings[0])
+	found := false
+	for _, w := range lenientCfg.Warnings {
+		if strings.Contains(w, "rule-set") && strings.Contains(w, "RS") && strings.Contains(w, "6454") {
+			found = true
+			break
 		}
+	}
+	if !found {
+		t.Fatalf("lenient compile must warn naming the duplicate rule-set + #6454, warnings: %v", lenientCfg.Warnings)
 	}
 }
 
-// TestDuplicateNATRuleSetNameNoFalsePositive guards the gate's scope: distinct
-// rule-set names, the SAME rule-set name in two DIFFERENT nat types (a distinct
-// natType namespace — the counter key is prefixed by natType), a single
-// rule-set carrying a bracket list of from-scopes that Cartesian-expands into
-// multiple same-named NATRuleSet objects downstream (#3096, one AST instance —
-// NOT a duplicate), and the flat-set form (which MERGES a repeated rule-set onto
-// one node) must all pass strict.
+// TestDuplicateNATRuleSetNameNoFalsePositive guards the gate's scope through the
+// PUBLIC compile path (CompileConfig, strict): distinct rule-set names, the SAME
+// rule-set name in two DIFFERENT nat types (a distinct natType namespace — the
+// counter key is prefixed by natType), a single rule-set carrying a bracket list
+// of from-scopes that Cartesian-expands into multiple same-named NATRuleSet
+// objects downstream (#3096, one AST instance — NOT a duplicate), and the
+// flat-set form (which MERGES a repeated rule-set onto one node) must all commit
+// cleanly with the expected rule-sets present.
 func TestDuplicateNATRuleSetNameNoFalsePositive(t *testing.T) {
 	t.Run("distinct rule-set names in one nat type", func(t *testing.T) {
-		tree := parseHier6454(t, `security {
+		cfg, err := CompileConfig(parseHier6454(t, `security {
     nat {
         source {
             rule-set RS_A { rule R1 { then { source-nat { interface; } } } }
             rule-set RS_B { rule R1 { then { source-nat { off; } } } }
         }
     }
-}`)
-		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
-			t.Fatalf("distinct rule-set names must pass, got: %v", err)
+}`))
+		if err != nil {
+			t.Fatalf("distinct rule-set names must commit, got: %v", err)
+		}
+		if got := countSourceRuleSets6454(cfg, "RS_A"); got != 1 {
+			t.Fatalf("want 1 source rule-set RS_A, got %d", got)
+		}
+		if got := countSourceRuleSets6454(cfg, "RS_B"); got != 1 {
+			t.Fatalf("want 1 source rule-set RS_B, got %d", got)
 		}
 	})
 
 	t.Run("same rule-set name in two different nat types", func(t *testing.T) {
-		// source RS keys "source\x00RS", static RS keys "static\x00RS": distinct
-		// namespaces (the counter key is natType-prefixed), so this is legitimate.
-		tree := parseHier6454(t, `security {
+		// source RS and static RS are distinct namespaces (the counter key is
+		// natType-prefixed), so both must commit — one entry in each slice.
+		cfg, err := CompileConfig(parseHier6454(t, `security {
     nat {
         source {
             rule-set RS { rule R1 { then { source-nat { interface; } } } }
@@ -285,19 +322,32 @@ func TestDuplicateNATRuleSetNameNoFalsePositive(t *testing.T) {
             }
         }
     }
-}`)
-		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
-			t.Fatalf("same rule-set name across different nat types is a distinct identity and must pass, got: %v", err)
+}`))
+		if err != nil {
+			t.Fatalf("same rule-set name across different nat types must commit, got: %v", err)
+		}
+		if got := countSourceRuleSets6454(cfg, "RS"); got != 1 {
+			t.Fatalf("want 1 source rule-set RS, got %d", got)
+		}
+		staticRS := 0
+		for _, rs := range cfg.Security.NAT.Static {
+			if rs.Name == "RS" {
+				staticRS++
+			}
+		}
+		if staticRS != 1 {
+			t.Fatalf("want 1 static rule-set RS, got %d", staticRS)
 		}
 	})
 
 	t.Run("bracket-list from-scope expands one authored rule-set (#3096)", func(t *testing.T) {
 		// ONE authored `rule-set RS` with a bracket list of from-zones
-		// Cartesian-expands into TWO same-named NATRuleSet objects downstream in
+		// Cartesian-expands into TWO same-named NATRuleSet objects in
 		// compileNATSource — but that is one AST rule-set instance, not a
 		// duplicate. Dedup at the compiled level would false-positive here; the
-		// gate dedups at the AST instance level, so this passes.
-		tree := parseHier6454(t, `security {
+		// gate dedups at the AST instance level, so this commits, and the two
+		// expanded entries (from trust + from dmz) are BOTH present.
+		cfg, err := CompileConfig(parseHier6454(t, `security {
     nat {
         source {
             rule-set RS {
@@ -307,20 +357,45 @@ func TestDuplicateNATRuleSetNameNoFalsePositive(t *testing.T) {
             }
         }
     }
-}`)
-		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
-			t.Fatalf("a single bracket-list-scoped rule-set must pass (one AST instance), got: %v", err)
+}`))
+		if err != nil {
+			t.Fatalf("a single bracket-list-scoped rule-set must commit (one AST instance), got: %v", err)
+		}
+		if got := countSourceRuleSets6454(cfg, "RS"); got != 2 {
+			t.Fatalf("want 2 same-named source rule-sets from the #3096 from-zone expansion, got %d", got)
+		}
+		fromZones := map[string]bool{}
+		for _, rs := range cfg.Security.NAT.Source {
+			if rs.Name == "RS" {
+				fromZones[rs.FromZone] = true
+			}
+		}
+		if !fromZones["trust"] || !fromZones["dmz"] {
+			t.Fatalf("expanded rule-sets must cover from-zones {trust, dmz}, got: %v", fromZones)
 		}
 	})
 
 	t.Run("flat-set repeated rule-set merges (dual-AST equivalence)", func(t *testing.T) {
-		tree := setTree6454(t, []string{
+		cfg, err := CompileConfig(setTree6454(t, []string{
 			"set security nat source rule-set RS from zone trust",
 			"set security nat source rule-set RS rule R1 then source-nat interface",
 			"set security nat source rule-set RS rule R2 then source-nat off",
-		})
-		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
-			t.Fatalf("flat-set repeated rule-set statements merge onto one node and must pass, got: %v", err)
+		}))
+		if err != nil {
+			t.Fatalf("flat-set repeated rule-set statements merge onto one node and must commit, got: %v", err)
+		}
+		if got := countSourceRuleSets6454(cfg, "RS"); got != 1 {
+			t.Fatalf("flat-set merge must yield exactly 1 source rule-set RS, got %d", got)
+		}
+		// The merged rule-set carries BOTH rules (R1, R2) — proof it is one
+		// rule-set, not two.
+		for _, rs := range cfg.Security.NAT.Source {
+			if rs.Name != "RS" {
+				continue
+			}
+			if len(rs.Rules) != 2 {
+				t.Fatalf("merged rule-set RS must carry 2 rules, got %d", len(rs.Rules))
+			}
 		}
 	})
 }

--- a/pkg/config/dup_nat_ruleset_names_6454_test.go
+++ b/pkg/config/dup_nat_ruleset_names_6454_test.go
@@ -1,0 +1,326 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6454 (C181-M18 sibling): two rule-SETS with the SAME name within one NAT
+// type (source/destination/static/nat64) BOTH survive — compileNATSource /
+// compileNATDestination / compileNATStatic / compileNAT64 each APPEND the
+// rule-set (they never merge by name), so both compile as separate first-match
+// tables sharing one operational identity (the rule-set name). For the counted
+// natTypes that identity is also the shared natType/ruleSet/rule counter
+// namespace, so per-rule telemetry merges and show/counter surfaces cannot
+// disambiguate; a counter-less nat64 rule-set still shares its show-surface
+// name identity. validateDuplicateNATRuleSetNamesAST rejects this at strict
+// commit and warns on the tolerant load path (#1960).
+//
+// This is the rule-SET axis one level above the #5649 rule-NAME gate. The
+// fixtures use DISJOINT rule names inside each duplicate rule-set so the #5649
+// gate (which runs first, keyed by (natType, ruleSet, rule)) does NOT fire —
+// control reaches THIS gate.
+//
+// RED-on-revert: neutralize the gate so it never records a duplicate (guard the
+// `seen[key]` detection with `&& false`, keeping the fmt/sort references and
+// therefore the imports live — a clean assertion RED, not a build break). The
+// strict sub-tests then no longer see a #6454 error and go RED.
+
+// parseHier6454 parses a hierarchical (brace-delimited) config via NewParser —
+// the correct tool for a hierarchical duplicate block. Flat `set` MERGES a
+// repeated rule-set onto one node (see the equivalence sub-test), so only the
+// hierarchical shape can express the duplicate this gate targets.
+func parseHier6454(t *testing.T, input string) *ConfigTree {
+	t.Helper()
+	tree, errs := NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	return tree
+}
+
+func setTree6454(t *testing.T, cmds []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestDuplicateNATRuleSetNameRejected is the #6454 RED-on-revert proof: strict
+// commit (CompileConfig, the stable public entrypoint) hard-rejects a duplicate
+// rule-SET name in each of source / destination / static / nat64. The gate runs
+// pre-expansion and returns before zone/policy validation, so a NAT-only fixture
+// reaches exactly this error.
+func TestDuplicateNATRuleSetNameRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  string
+	}{
+		{
+			name: "source",
+			cfg: `security {
+    nat {
+        source {
+            rule-set RS {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat { interface; } }
+                }
+            }
+            rule-set RS {
+                from zone dmz;
+                to zone untrust;
+                rule R2 {
+                    match { source-address 10.0.1.0/24; }
+                    then { source-nat { off; } }
+                }
+            }
+        }
+    }
+}`,
+		},
+		{
+			name: "destination",
+			cfg: `security {
+    nat {
+        destination {
+            rule-set RS {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 203.0.113.10/32; }
+                    then { destination-nat off; }
+                }
+            }
+            rule-set RS {
+                from zone untrust;
+                rule R2 {
+                    match { destination-address 203.0.113.11/32; }
+                    then { destination-nat off; }
+                }
+            }
+        }
+    }
+}`,
+		},
+		{
+			name: "static",
+			cfg: `security {
+    nat {
+        static {
+            rule-set RS {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 203.0.113.10/32; }
+                    then { static-nat { prefix 10.0.0.10/32; } }
+                }
+            }
+            rule-set RS {
+                from zone untrust;
+                rule R2 {
+                    match { destination-address 203.0.113.11/32; }
+                    then { static-nat { prefix 10.0.0.11/32; } }
+                }
+            }
+        }
+    }
+}`,
+		},
+		{
+			// nat64 rule-sets carry prefix / source-pool and NO `rule` nodes, so
+			// the #5649 rule-name gate correctly excludes them — but a duplicate
+			// nat64 rule-set NAME is its own fail-open this gate closes. Both
+			// prefixes are valid /96 so the ONLY defect is the duplicate name.
+			name: "nat64",
+			cfg: `security {
+    nat {
+        nat64 {
+            rule-set RS { prefix 64:ff9b::/96; }
+            rule-set RS { prefix 64:ff9b::/96; }
+        }
+    }
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := parseHier6454(t, tc.cfg)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig must reject a duplicate NAT %s rule-set name", tc.name)
+			}
+			// Bind the exact natType phrase, not just the bare word, plus the
+			// rule-set name and the issue tag.
+			for _, want := range []string{"NAT " + tc.name + " rule-set", "RS", "6454"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error should mention %q, got: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestDuplicateNATRuleSetNameNat64NotCounter binds the type-agnostic-diagnostic
+// contract for the counter-less nat64 case: a nat64 rule-set has no per-rule
+// counter (NATCounterKey is only assigned for source/destination/static rules),
+// so the #6454 diagnostic must NOT claim a per-rule counter for it. Mirrors the
+// #5649 NPTv6 counter-less fold.
+func TestDuplicateNATRuleSetNameNat64NotCounter(t *testing.T) {
+	tree := parseHier6454(t, `security {
+    nat {
+        nat64 {
+            rule-set RS { prefix 64:ff9b::/96; }
+            rule-set RS { prefix 64:ff9b::/96; }
+        }
+    }
+}`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig must reject a duplicate nat64 rule-set name")
+	}
+	msg := err.Error()
+	for _, want := range []string{"NAT nat64 rule-set", "RS", "6454"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("nat64 duplicate error should mention %q, got: %v", want, err)
+		}
+	}
+	// The type-agnostic diagnostic must not claim a per-rule counter (false for
+	// a counter-less nat64 rule-set).
+	if strings.Contains(msg, "counter") {
+		t.Fatalf("nat64 duplicate diagnostic must NOT claim a per-rule counter, got: %v", err)
+	}
+}
+
+// TestDuplicateNATRuleSetNameLenientWarns proves the tolerant path (Load /
+// peer-sync) downgrades the reject to a warning so an already-persisted or
+// peer-synced config still boots through (#1960 class).
+func TestDuplicateNATRuleSetNameLenientWarns(t *testing.T) {
+	tree := parseHier6454(t, `security {
+    nat {
+        source {
+            rule-set RS {
+                rule R1 {
+                    match { source-address 10.0.0.0/24; }
+                    then { source-nat { interface; } }
+                }
+            }
+            rule-set RS {
+                rule R2 {
+                    match { source-address 10.0.1.0/24; }
+                    then { source-nat { off; } }
+                }
+            }
+        }
+    }
+}`)
+
+	// Strict: hard error.
+	if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err == nil {
+		t.Fatal("strict validator must reject the duplicate rule-set name")
+	}
+
+	// Lenient: no error, one warning that names the rule-set and references #6454.
+	warnings, err := validateDuplicateNATRuleSetNamesAST(tree, true)
+	if err != nil {
+		t.Fatalf("lenient validator must not error, got: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("lenient validator must emit exactly one warning, got %d: %v", len(warnings), warnings)
+	}
+	for _, want := range []string{"RS", "6454"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Fatalf("warning should mention %q, got: %v", want, warnings[0])
+		}
+	}
+}
+
+// TestDuplicateNATRuleSetNameNoFalsePositive guards the gate's scope: distinct
+// rule-set names, the SAME rule-set name in two DIFFERENT nat types (a distinct
+// natType namespace — the counter key is prefixed by natType), a single
+// rule-set carrying a bracket list of from-scopes that Cartesian-expands into
+// multiple same-named NATRuleSet objects downstream (#3096, one AST instance —
+// NOT a duplicate), and the flat-set form (which MERGES a repeated rule-set onto
+// one node) must all pass strict.
+func TestDuplicateNATRuleSetNameNoFalsePositive(t *testing.T) {
+	t.Run("distinct rule-set names in one nat type", func(t *testing.T) {
+		tree := parseHier6454(t, `security {
+    nat {
+        source {
+            rule-set RS_A { rule R1 { then { source-nat { interface; } } } }
+            rule-set RS_B { rule R1 { then { source-nat { off; } } } }
+        }
+    }
+}`)
+		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
+			t.Fatalf("distinct rule-set names must pass, got: %v", err)
+		}
+	})
+
+	t.Run("same rule-set name in two different nat types", func(t *testing.T) {
+		// source RS keys "source\x00RS", static RS keys "static\x00RS": distinct
+		// namespaces (the counter key is natType-prefixed), so this is legitimate.
+		tree := parseHier6454(t, `security {
+    nat {
+        source {
+            rule-set RS { rule R1 { then { source-nat { interface; } } } }
+        }
+        static {
+            rule-set RS {
+                from zone untrust;
+                rule R1 {
+                    match { destination-address 203.0.113.10/32; }
+                    then { static-nat { prefix 10.0.0.10/32; } }
+                }
+            }
+        }
+    }
+}`)
+		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
+			t.Fatalf("same rule-set name across different nat types is a distinct identity and must pass, got: %v", err)
+		}
+	})
+
+	t.Run("bracket-list from-scope expands one authored rule-set (#3096)", func(t *testing.T) {
+		// ONE authored `rule-set RS` with a bracket list of from-zones
+		// Cartesian-expands into TWO same-named NATRuleSet objects downstream in
+		// compileNATSource — but that is one AST rule-set instance, not a
+		// duplicate. Dedup at the compiled level would false-positive here; the
+		// gate dedups at the AST instance level, so this passes.
+		tree := parseHier6454(t, `security {
+    nat {
+        source {
+            rule-set RS {
+                from zone [ trust dmz ];
+                to zone untrust;
+                rule R1 { then { source-nat { interface; } } }
+            }
+        }
+    }
+}`)
+		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
+			t.Fatalf("a single bracket-list-scoped rule-set must pass (one AST instance), got: %v", err)
+		}
+	})
+
+	t.Run("flat-set repeated rule-set merges (dual-AST equivalence)", func(t *testing.T) {
+		tree := setTree6454(t, []string{
+			"set security nat source rule-set RS from zone trust",
+			"set security nat source rule-set RS rule R1 then source-nat interface",
+			"set security nat source rule-set RS rule R2 then source-nat off",
+		})
+		if _, err := validateDuplicateNATRuleSetNamesAST(tree, false); err != nil {
+			t.Fatalf("flat-set repeated rule-set statements merge onto one node and must pass, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- PR #6452 (#5649, C181-M18) rejects duplicate NAT rule-**names** within one
  rule-set. This closes the sibling fail-open one level up: duplicate NAT
  rule-**SET** names.
- Two rule-sets authored with the same name **within one nat type**
  (`source`/`destination`/`static`/`nat64`) both SURVIVE — `compileNATSource` /
  `compileNATDestination` / `compileNATStatic` / `compileNAT64` each **append**
  the rule-set (`sec.NAT.Source` / `Destination.RuleSets` / `Static` / `NAT64`),
  never merging by name. Both compile as separate first-match tables sharing one
  operational identity (the rule-set name), so for the counted natTypes their
  rules map onto the shared `natType/ruleSet/rule` counter namespace
  (`NATCounterKey`) — per-rule telemetry merges and `show`/counter surfaces
  cannot disambiguate. A `nat64` rule-set is counter-less (prefix/source-pool, no
  `rule` nodes — correctly excluded from the #5649 rule-name gate) but still
  shares its show-surface name identity, so it is deduped here too.
- New gate `validateDuplicateNATRuleSetNamesAST` (`pkg/config/dup_nat_ruleset_names.go`),
  wired beside the #5649 gate in both `compileConfigWithOpts` and
  `compileConfigForNodeWithOpts`. Mirrors the #5649 idiom: pre-expansion,
  top-level `security` stanzas only, keyed by `(natType, rule-set)`, unioned
  across repeated sub-blocks (a rule-set name split across two `source {}` blocks,
  #3915, is caught). Strict rejects; lenient warns via
  `opts.lenientDuplicateNATRuleSetName` (#1960 no-brick).

## Scope decision — per-natType namespace

Reject only **within** one nat type, never **across**. `NATCounterKey` is
prefixed by natType (`snat`/`dnat`/`static`), so Junos' independent per-type name
spaces are genuinely distinct identities — a `source` rule-set and a `static`
rule-set may legitimately share a name. Only same-natType duplicates collide, so
the seen-set key includes the natType.

## AST-instance-level dedup (not compiled)

The dedup is at the AST rule-set-**instance** level, NOT the compiled level: a
single authored rule-set carrying a bracket list of from/to scopes
Cartesian-expands into MULTIPLE same-named `NATRuleSet` objects downstream
(#3096). That is one AST instance and is NOT flagged — a compiled-level dedup
would false-positive on legitimate scope expansion.

## Test plan

- [x] `dup_nat_ruleset_names_6454_test.go`: strict reject for source / destination
      / static / nat64 (disjoint rule names inside each, so the #5649 rule-name
      gate does not pre-empt this one).
- [x] nat64 counter-less-diagnostic guard: the type-agnostic message must not
      claim a per-rule counter.
- [x] Lenient path warns exactly once (#1960).
- [x] No-false-positive accepts: distinct names; same name across different nat
      types; #3096 bracket-list scope expansion; flat-set merge.
- [x] **Parent-RED verified firsthand**: guard the duplicate detection to
      always-false (imports stay live, `go vet` clean) → every reject test goes
      RED with a clean assertion failure (strict compile returns `nil`); the
      accept guards stay green. Restored.
- [x] `go build ./...`, `go vet ./pkg/config/`, `gofmt -l` clean, full
      `pkg/config` suite, `TestHeatmapNotStale` (heatmap regenerated for the
      `compiler_opts.go` LOC bump).

## Docs

`docs/config-schema.md` documents the new gate beside its #5649 sibling.

Closes #6454