### PR TITLE
daemon(nft): fail closed on a cold-boot lo0 filter install failure (#6476)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -60682,3 +60682,39 @@ top.
     pkg/daemon/lo0_coldboot_fence_6476_test.go,
     docs/host-inbound-service-matrix.md,
     docs/refactoring-audit-current.txt, _Log.md
+
+- **Timestamp**: 2026-07-24
+- **Action**: #6489 fold — CONFIRMED Codex MAJOR (Finding 1): the lo0
+    day-2 fence-skip gate `!d.lo0Enforced.Load()` conflated "real filter
+    loaded" with "fence loaded" (a scoped fence Stored lo0Enforced=true),
+    so a fence(snapshotA) → new-address-B-appears → real-install-fails-again
+    sequence SKIPPED re-fencing and left B reachable through the retained
+    fence's `policy accept` (fence drops only snapshot-A addrs). Fix (per
+    lead: prefer rev6476's 1-line change over a new field): KEEP `lo0Enforced`
+    and simply DROP the `Store(true)` on the scoped cold-boot fence path — a
+    fence never sets lo0Enforced, so lo0Enforced now means EXACTLY "a real
+    operator lo0 filter is loaded" (set true ONLY by a real InstallLo0
+    success; the zero-drop path already never set it). The unchanged gate
+    `!d.lo0Enforced.Load()` then correctly re-fences after a prior fence: while
+    no real filter is loaded a failed install RE-RENDERS the whole-table fence
+    from the CURRENT snapshot (covering B); once a real filter loads the
+    intended #5789 divergence (retain the real filter, no fence) holds. No new
+    field, no lo0 gap fence / covered-set. New test
+    TestColdBootLo0FenceThenNewAddressReFences (fence→fail→re-fence, asserts 2
+    fence installs + B covered); flipped the primary test's stale assertion (a
+    fence must NOT set lo0Enforced). Fixed the now-false "retains the prior
+    REAL filter" framing in the day-2 comment, the lo0Enforced field doc, and
+    docs/host-inbound-service-matrix.md. Parent-RED confirmed firsthand —
+    restore `d.lo0Enforced.Store(true)` on the scoped-fence path → "day-2
+    failure over a retained FENCE must RE-FENCE (got 1 fence installs, want
+    2)". Noted pre-existing residuals (non-catch-all real filter coverage
+    #3295; shared BuildZone.../fence-body Findings 2+3 tracked in follow-up
+    #6492 — they hit the host-inbound #5644 fence identically). Ran the T1
+    nft-parity gate with nft in PATH (FRESH GOCACHE) and CONFIRMED the new
+    `lo0_cold_boot_fence` subtest EXECUTES + PASSES (not a stale-binary SKIP).
+    go build / vet / gofmt / pkg-daemon + pkg-nftables suites / heatmap
+    (regenerated) GREEN.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_nft.go,
+    pkg/daemon/lo0_coldboot_fence_6476_test.go,
+    docs/host-inbound-service-matrix.md,
+    docs/refactoring-audit-current.txt, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -60652,3 +60652,33 @@ top.
   vet / gofmt / pkg-ipsec-suite / heatmap GREEN.
 - **File(s)**: pkg/ipsec/policy.go,
     pkg/ipsec/swanctl_addr_sanitize_6469_test.go, pkg/ipsec/README.md, _Log.md
+
+- **Timestamp**: 2026-07-24
+- **Action**: #6476 daemon(nft) — lo0 RE-protection cold-boot fail-closed
+    fence. The `inet xpf_lo0` input filter (Junos protect-RE) had no
+    cold-boot fence: on cold boot no prior table exists to retain, and the
+    boot apply reaches `applyLo0Filter` via `applyConfig` (logs+discards the
+    error), so a failed `InstallLo0` left the RE input path OPEN with only a
+    WARN while host service/VIP/HA-ready were published (the exact fail-open
+    #5644 closed for host-inbound). Mirrored #5644 for lo0: new
+    `d.lo0Enforced` gate; on a failed `InstallLo0` while false,
+    `installLo0ColdBootFence` installs a deny-all fence scoped to the SAME
+    lifeline-excluded firewall-local address sets and SAME
+    `buildFenceTablePayload` body as the host-inbound fence, into the
+    `xpf_lo0` table at priority 0 (so a later successful `InstallLo0`
+    atomically replaces it) via new `Installer.InstallLo0ColdBootFence`. NO
+    day-2 gap fence (deliberate #5789 divergence): the operator's lo0 filter
+    is not per-destination-address scoped, so a retained generation already
+    governs new addresses. Extracted `buildFenceTablePayload` so the two
+    fence oracles share one body; added a `lo0_cold_boot_fence` T1 parity
+    case. Parent-RED confirmed firsthand — neutralize the fence install →
+    "cold-boot lo0 install failure must install exactly one fail-closed lo0
+    fence, got 0". go build / vet / gofmt / pkg-daemon + pkg-nftables suites
+    / heatmap GREEN.
+- **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/daemon.go,
+    pkg/nftables/netlink_installer.go,
+    pkg/daemon/daemon_nft_netlink_testhelper_test.go,
+    pkg/daemon/daemon_nft_netlink_parity_test.go,
+    pkg/daemon/lo0_coldboot_fence_6476_test.go,
+    docs/host-inbound-service-matrix.md,
+    docs/refactoring-audit-current.txt, _Log.md

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -517,12 +517,6 @@ filter is unenforced.
 
 The fix mirrors the host-inbound cold-boot fence for the lo0 table:
 
-- `d.lo0Enforced` (a `Daemon` atomic bool) is the lo0 analogue of
-  `hostInboundEnforced`: a successful real `InstallLo0` stores true; a successful
-  address-scoped `installLo0ColdBootFence` stores true; a successful no-filter
-  TEARDOWN stores false (the `xpf_lo0` table is deleted, so a later failed install
-  must re-fence rather than assume a retained table); a teardown FAILURE does not
-  clear it. `applySem`-serialized like `hostInboundEnforced`.
 - `installLo0ColdBootFence` / `buildLo0FencePayload` (`daemon_nft.go`) build the
   fence from the SAME lifeline-excluded firewall-local address sets
   (`BuildZoneHostInboundViews` + `BuildUnzonedHostInboundAddrs`) and the SAME
@@ -534,21 +528,58 @@ The fix mirrors the host-inbound cold-boot fence for the lo0 table:
   filter occupies, so a later successful `InstallLo0` **atomically replaces** it.
   Netlink install is `Installer.InstallLo0ColdBootFence` (T1 parity gate:
   `lo0_cold_boot_fence`).
-- **No day-2 gap fence (the deliberate divergence from #5789).** Unlike the
-  auto-generated, per-destination-address-scoped `xpf_hostinbound` table, the
-  operator's lo0 filter is hand-authored and NOT per-destination scoped — its
-  terms (typically ending in a catch-all `discard`) govern every firewall-local
-  address, including one that appears later. So on a DAY-2 failure
-  (`lo0Enforced` true) the atomic `replaceTable` retains the prior real filter
-  and that retained generation still covers new addresses; no additive gap fence
-  is installed (or needed). The cold-boot fence alone closes the issue.
-- A zero-drop fence (an addressless boot snapshot) leaves `lo0Enforced` false so a
-  later failed real invocation can retry with an address-scoped snapshot; a
-  catastrophic double-failure (real load AND fence both fail) joins both errors,
-  fires the `COLD-BOOT FAIL-OPEN GUARD` ERROR log, and leaves `lo0Enforced` false.
+- **The gate keys on `d.lo0Enforced` — "is the live `xpf_lo0` table a REAL
+  operator filter" — NOT "does any protecting table exist" (#6489).** A failed
+  `InstallLo0` installs (or re-installs) a fence UNLESS a real filter is currently
+  loaded. It is true ONLY after a successful real `InstallLo0`; a FENCE deliberately
+  does **not** set it (a fence is not a real filter — its chain is `policy accept`
+  and drops only the addresses in the snapshot it was rendered from — so it stays
+  false across a fence). A successful no-filter TEARDOWN stores false (the table is
+  deleted); a teardown FAILURE does not clear it. `applySem`-serialized.
+- **Why it must not key on "any table exists".** The earlier design set a single
+  `lo0Enforced` bool true on BOTH a real load AND a scoped fence, so this sequence
+  FAILED OPEN: cold-boot real install fails → fence(snapshot A) installed → gate
+  true → a new local address **B** appears + real install fails again → the gate
+  skips re-fencing → the retained table is the OLD FENCE (`policy accept` + drops
+  for A only), so **B** falls through `policy accept` → the RE input path is open
+  for B. Keying on `lo0Enforced` instead RE-RENDERS the whole-table fence
+  from the CURRENT snapshot on every day-2 failure while no real filter is loaded,
+  so B is covered.
+- **No day-2 gap fence (the deliberate divergence from #5789) — but only once a
+  REAL filter is loaded.** When `lo0Enforced` is true, a day-2 failure
+  installs no fence: the atomic `replaceTable` retains the operator's filter, which
+  — unlike the auto-generated, per-destination-address-scoped `xpf_hostinbound`
+  table — is hand-authored and NOT per-destination scoped (its terms, typically
+  ending in a catch-all `discard`, govern every firewall-local address, including
+  one that appears later). So lo0 needs neither a per-address coverage set nor an
+  additive gap table; the whole-table re-render (fence path) and retain-the-real-
+  filter (real-filter path) together close the gap.
+- A zero-drop fence (an addressless boot snapshot) is likewise not a real filter,
+  so it leaves `lo0Enforced` false and a later failed real invocation
+  re-fences from a possibly-now-addressed snapshot; a catastrophic double-failure
+  (real load AND fence both fail) joins both errors, fires the `COLD-BOOT
+  FAIL-OPEN GUARD` ERROR log, and leaves `lo0Enforced` false.
 
-Fail-on-revert proof: `pkg/daemon/lo0_coldboot_fence_6476_test.go`. The
-lo0-first-then-host-inbound priority ordering (0 < 10) is pinned by
+**Pre-existing residuals (NOT introduced or addressed by #6476/#6489, tracked
+separately):**
+
+- A retained REAL lo0 filter with **no catch-all term** is a valid config
+  (`compiler_filter_nocatchall_3295_test`); such a filter need not itself cover a
+  new day-2 address. That is the lo0 filter's own coverage semantics, independent
+  of this boot fence — the fence only guarantees the RE path is not left fully
+  open when NO real filter is loaded.
+- The shared fence body / `BuildZoneHostInboundViews` / `BuildUnzonedHostInbound
+  Addrs` that this fence reuses carry two known behaviours that affect the
+  **host-inbound #5644 fence identically** (a shared-mechanism concern, not
+  lo0-specific — tracked in **#6492**): a management IP shared onto a non-lifeline
+  interface can pick up a global `daddr` drop, and a zone-less router yields empty
+  address sets → an accept-all fence shell. Both live in the shared mechanism and
+  pre-date #6476.
+
+Fail-on-revert proof: `pkg/daemon/lo0_coldboot_fence_6476_test.go` —
+`TestColdBootLo0FenceThenNewAddressReFences` pins the #6489 fence→fail→re-fence
+sequence (RED if a fence marks a real filter loaded). The lo0-first-then-host-
+inbound priority ordering (0 < 10) is pinned by
 `pkg/daemon/nft_chain_priority_test.go`; the fence's netlink/exec-nft parity by
 the `lo0_cold_boot_fence` case in `daemon_nft_netlink_parity_test.go`.
 

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -501,6 +501,57 @@ coverage gap + additive gap fence (#5789),
 the program-only-then-address paths) plus the three-chain priority invariant in
 `pkg/daemon/nft_chain_priority_test.go`.
 
+### lo0 RE-protection cold-boot fence (#6476)
+
+The operator's `interfaces lo0 unit 0 family inet filter input <name>`
+(the Junos protect-RE pattern) lowers to the `inet xpf_lo0` input chain — the
+authoritative, operator-authored control-plane firewall, evaluated at hook-input
+priority 0 (strictly BEFORE the `xpf_hostinbound` backstop at 10). Before #6476
+it had the SAME cold-boot fail-open the host-inbound table closed in #5644: on a
+COLD BOOT no prior `xpf_lo0` table exists to retain, and the boot apply reaches
+`applyLo0Filter` through `applyConfig` (which only logs+discards the error), so a
+failed `InstallLo0` left the RE input path with **no** lo0 filter and only a WARN,
+while host service / VIP / HA-ready were published. Host-inbound (priority 10) may
+still gate, so exposure is partial — but any service protected ONLY via the lo0
+filter is unenforced.
+
+The fix mirrors the host-inbound cold-boot fence for the lo0 table:
+
+- `d.lo0Enforced` (a `Daemon` atomic bool) is the lo0 analogue of
+  `hostInboundEnforced`: a successful real `InstallLo0` stores true; a successful
+  address-scoped `installLo0ColdBootFence` stores true; a successful no-filter
+  TEARDOWN stores false (the `xpf_lo0` table is deleted, so a later failed install
+  must re-fence rather than assume a retained table); a teardown FAILURE does not
+  clear it. `applySem`-serialized like `hostInboundEnforced`.
+- `installLo0ColdBootFence` / `buildLo0FencePayload` (`daemon_nft.go`) build the
+  fence from the SAME lifeline-excluded firewall-local address sets
+  (`BuildZoneHostInboundViews` + `BuildUnzonedHostInboundAddrs`) and the SAME
+  `buildFenceTablePayload` body as the host-inbound cold-boot fence — mandatory L3
+  / return admits (`ct established,related`, raw ESP/AH, IPv6 ND, v4/v6
+  PMTUD+error, the configured WireGuard listen port) then a catch-all
+  `<fam> daddr <addrs> drop`, no per-service accept and no named counters — but
+  rendered into the `xpf_lo0` table at priority 0, the same slot the real lo0
+  filter occupies, so a later successful `InstallLo0` **atomically replaces** it.
+  Netlink install is `Installer.InstallLo0ColdBootFence` (T1 parity gate:
+  `lo0_cold_boot_fence`).
+- **No day-2 gap fence (the deliberate divergence from #5789).** Unlike the
+  auto-generated, per-destination-address-scoped `xpf_hostinbound` table, the
+  operator's lo0 filter is hand-authored and NOT per-destination scoped — its
+  terms (typically ending in a catch-all `discard`) govern every firewall-local
+  address, including one that appears later. So on a DAY-2 failure
+  (`lo0Enforced` true) the atomic `replaceTable` retains the prior real filter
+  and that retained generation still covers new addresses; no additive gap fence
+  is installed (or needed). The cold-boot fence alone closes the issue.
+- A zero-drop fence (an addressless boot snapshot) leaves `lo0Enforced` false so a
+  later failed real invocation can retry with an address-scoped snapshot; a
+  catastrophic double-failure (real load AND fence both fail) joins both errors,
+  fires the `COLD-BOOT FAIL-OPEN GUARD` ERROR log, and leaves `lo0Enforced` false.
+
+Fail-on-revert proof: `pkg/daemon/lo0_coldboot_fence_6476_test.go`. The
+lo0-first-then-host-inbound priority ordering (0 < 10) is pinned by
+`pkg/daemon/nft_chain_priority_test.go`; the fence's netlink/exec-nft parity by
+the `lo0_cold_boot_fence` case in `daemon_nft_netlink_parity_test.go`.
+
 ### Per-interface / per-family refinement (#3710)
 
 The zone-level signal above **collapses**: `AddresslessEnforcingZones` marks a

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -3,7 +3,7 @@
 [REFACTOR]   3437  userspace-dp/src/nat64.rs
 [REFACTOR]   2928  pkg/config/compiler_validate_strict_nat.go
 [REFACTOR]   2383  userspace-dp/src/nat/allocator.rs
-[REFACTOR]   2298  pkg/daemon/daemon_nft.go
+[REFACTOR]   2315  pkg/daemon/daemon_nft.go
 [REFACTOR]   2288  pkg/ddns/surface_a.go
 [REFACTOR]   2257  pkg/policymatch/policymatch.go
 [REFACTOR]   2225  userspace-dp/src/afxdp/neighbor.rs

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -3,10 +3,10 @@
 [REFACTOR]   3437  userspace-dp/src/nat64.rs
 [REFACTOR]   2928  pkg/config/compiler_validate_strict_nat.go
 [REFACTOR]   2383  userspace-dp/src/nat/allocator.rs
+[REFACTOR]   2298  pkg/daemon/daemon_nft.go
 [REFACTOR]   2288  pkg/ddns/surface_a.go
 [REFACTOR]   2257  pkg/policymatch/policymatch.go
 [REFACTOR]   2225  userspace-dp/src/afxdp/neighbor.rs
-[REFACTOR]   2191  pkg/daemon/daemon_nft.go
 [REFACTOR]   2191  userspace-dp/src/session/mod.rs
 [REFACTOR]   2166  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [REFACTOR]   2157  pkg/config/compiler_system.go

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -593,6 +593,25 @@ type Daemon struct {
 	// be covered" (cold boot).
 	hostInboundCoveredAddrs map[string]struct{}
 
+	// lo0Enforced is the process-local historical gate for the #6476 lo0
+	// cold-boot fence, mirroring hostInboundEnforced. It records whether a
+	// protecting xpf_lo0 table has ever been established this boot: a successful
+	// real InstallLo0 Stores true, and a successful address-scoped cold-boot fence
+	// (installLo0ColdBootFence) also Stores true. A successful no-filter TEARDOWN
+	// Stores false (the table is deleted, so the "a protecting table exists"
+	// premise no longer holds and a later failed install must re-fence). A teardown
+	// FAILURE (a table may still be installed) does NOT clear it. False lets a
+	// failed InstallLo0 install the cold-boot fence rather than proceed with the RE
+	// input path open; true means the atomic replaceTable retained the prior real
+	// lo0 filter on a day-2 failure (fail-closed by retention), so no fence is
+	// needed. Unlike host-inbound there is no day-2 gap fence: the operator's lo0
+	// filter is not per-destination-address scoped (its terms, including the usual
+	// catch-all discard, govern every local address), so a retained generation has
+	// no per-address coverage gap for a newly-appeared address. Production access is
+	// serialized under applySem (via applyLo0Filter); atomic.Bool matches the
+	// hostInboundEnforced type.
+	lo0Enforced atomic.Bool
+
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
 	//

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -593,23 +593,38 @@ type Daemon struct {
 	// be covered" (cold boot).
 	hostInboundCoveredAddrs map[string]struct{}
 
-	// lo0Enforced is the process-local historical gate for the #6476 lo0
-	// cold-boot fence, mirroring hostInboundEnforced. It records whether a
-	// protecting xpf_lo0 table has ever been established this boot: a successful
-	// real InstallLo0 Stores true, and a successful address-scoped cold-boot fence
-	// (installLo0ColdBootFence) also Stores true. A successful no-filter TEARDOWN
-	// Stores false (the table is deleted, so the "a protecting table exists"
-	// premise no longer holds and a later failed install must re-fence). A teardown
-	// FAILURE (a table may still be installed) does NOT clear it. False lets a
-	// failed InstallLo0 install the cold-boot fence rather than proceed with the RE
-	// input path open; true means the atomic replaceTable retained the prior real
-	// lo0 filter on a day-2 failure (fail-closed by retention), so no fence is
-	// needed. Unlike host-inbound there is no day-2 gap fence: the operator's lo0
-	// filter is not per-destination-address scoped (its terms, including the usual
-	// catch-all discard, govern every local address), so a retained generation has
-	// no per-address coverage gap for a newly-appeared address. Production access is
-	// serialized under applySem (via applyLo0Filter); atomic.Bool matches the
-	// hostInboundEnforced type.
+	// lo0Enforced records whether the currently-loaded xpf_lo0 table is a REAL
+	// operator filter (the #6476 lo0 cold-boot fence gate). It means EXACTLY that:
+	// it is set true ONLY by a successful real InstallLo0. A cold-boot FENCE
+	// deliberately does NOT set it — a fence is NOT a real filter (its chain is
+	// `policy accept` and drops only the firewall-local addresses present in the
+	// snapshot it was rendered from, so a later-appearing address is not covered), so
+	// lo0Enforced stays false across a fence. A successful no-filter TEARDOWN Stores
+	// false (the table is deleted); a teardown FAILURE (a table may still be
+	// installed) does NOT clear it.
+	//
+	// It gates the day-2 fence-skip in applyLo0Filter: a failed InstallLo0 installs
+	// a fence UNLESS a real filter is currently loaded. This must key on real-filter-
+	// loaded, NOT "any protecting table exists" (#6489). The earlier design set a
+	// single flag true on BOTH a real load AND a scoped fence, conflating the two —
+	// so a fence -> new-address -> real-install-fails sequence SKIPPED re-fencing and
+	// left the newly-appeared address reachable through the stale fence's
+	// `policy accept` (fail-open). Because a fence no longer sets lo0Enforced, the
+	// gate stays open after a fence and RE-RENDERS the whole-table fence from the
+	// current snapshot on every day-2 failure while no real filter is loaded
+	// (covering the new address); a retained REAL filter (true) is trusted to govern
+	// every local address so no fence is installed — the intended divergence from the
+	// host-inbound per-address gap fence (#5789), which lo0 does not need because the
+	// operator's hand-authored filter is not per-destination-address scoped.
+	//
+	// Residuals (pre-existing, NOT introduced or addressed here — tracked in #6492):
+	// a retained REAL lo0 filter with no catch-all term (a valid config,
+	// compiler_filter_nocatchall_3295_test) need not itself cover a new day-2 address
+	// (the lo0 filter's own coverage semantics, independent of this boot fence); and
+	// the shared BuildZoneHostInboundViews / fence body carries a management-IP-on-
+	// non-lifeline and a zone-less-router behaviour that affect the host-inbound
+	// #5644 fence identically. Production access is serialized under applySem (via
+	// applyLo0Filter); atomic.Bool matches the hostInboundEnforced type.
 	lo0Enforced atomic.Bool
 
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -129,13 +129,19 @@ const (
 // on COLD BOOT both nft tables are absent — there is no prior lo0 generation to
 // retain — so a failed real InstallLo0 would leave the host input path OPEN with
 // only a WARN (the boot apply only logs+discards the error), publishing host
-// services / VIP / HA-ready over an unenforced RE-protection path. When no
-// protecting xpf_lo0 table has loaded this boot (lo0Enforced false), a failed
-// install therefore installs a fail-closed fence that denies host-bound traffic
-// to firewall-local addresses (minus lifelines) instead of proceeding open. On a
-// DAY-2 failure (lo0Enforced true) the atomic replaceTable retained the prior
-// real lo0 filter, so no fence is needed — the operator's filter (not per-
-// destination-address scoped) still governs every local address.
+// services / VIP / HA-ready over an unenforced RE-protection path. The fence-skip
+// gate keys on lo0Enforced — whether a REAL operator filter is currently
+// loaded — NOT on "any protecting table exists": a fence is `policy accept` and
+// drops only its snapshot's addresses, so a retained FENCE does not cover a
+// later-appearing address (#6489). When no real filter is loaded, a failed
+// InstallLo0 (re-)installs a fail-closed fence rendered from the CURRENT
+// firewall-local snapshot (minus lifelines) — so a fence -> new-address -> real
+// install fails sequence re-fences and covers the new address instead of leaving
+// it open through the stale fence. Only on a DAY-2 failure with a REAL filter
+// loaded (lo0Enforced true) is no fence installed: the atomic replaceTable
+// retained the operator's filter, which — unlike the per-destination-address
+// host-inbound table — is not per-address scoped and still governs every local
+// address (the deliberate divergence from the #5789 gap fence).
 func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 	filterV4 := cfg.System.Lo0FilterInputV4
 	filterV6 := cfg.System.Lo0FilterInputV6
@@ -148,16 +154,17 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 		if err := nftInstaller.DeleteTable(xnft.Lo0TableName); err != nil {
 			// Teardown FAILED: a stale xpf_lo0 table (real filter OR a prior fence)
 			// may still be installed. Surface the failure (fail closed) and do NOT
-			// clear lo0Enforced — a later failed install must keep retaining rather
-			// than fence over a live table (mirrors the host-inbound #5790 teardown
-			// semantics).
+			// clear lo0Enforced — if a real filter was the live table it may
+			// still be there, so keep the flag (mirrors the host-inbound #5790
+			// teardown semantics).
 			err = tagNftInstallErr(err)
 			slog.Warn("failed to delete stale lo0 filter table", "err", err)
 			return fmt.Errorf("delete stale lo0 nftables table: %w", err)
 		}
-		// Teardown SUCCEEDED: no xpf_lo0 table is installed now. Clear the historical
-		// gate so a later enforceable generation whose first real load fails takes the
-		// cold-boot fence path rather than assuming a retained table (#5790 parity).
+		// Teardown SUCCEEDED: no xpf_lo0 table is installed now, so no real filter is
+		// loaded. Clear the gate so a later generation whose first real load fails
+		// takes the cold-boot fence path rather than assuming a retained table
+		// (#5790 parity).
 		d.lo0Enforced.Store(false)
 		return nil
 	}
@@ -171,14 +178,15 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 	if err := nftInstaller.InstallLo0(spec); err != nil {
 		err = tagNftInstallErr(err)
 		slog.Warn("failed to apply lo0 filter", "err", err)
-		// #6476 cold-boot fail-closed fence. On cold boot no prior xpf_lo0 table
-		// exists to retain, so a failed real install here would leave the RE input
-		// path OPEN. Gate on the historical state and, when no protecting table has
-		// loaded, install a fence that denies host-bound traffic to the firewall-
-		// local addresses (minus lifelines) rendered from this snapshot. On a day-2
-		// failure (lo0Enforced true) the atomic replaceTable retained the prior real
-		// lo0 filter, which — unlike the address-scoped host-inbound table — still
-		// governs every local address, so no fence is installed.
+		// #6476 cold-boot fail-closed fence. Install (or re-install) a fence UNLESS a
+		// REAL operator filter is currently loaded. Keying on lo0Enforced (not
+		// "any protecting table") is the #6489 fix: a retained FENCE is `policy accept`
+		// and covers only its own snapshot, so if the live table is a fence a failed
+		// real install must RE-FENCE from the CURRENT snapshot to cover any address
+		// that appeared since — otherwise the new address falls through the stale
+		// fence's policy-accept (fail-open). Only a retained REAL filter is trusted to
+		// govern every local address (unlike the address-scoped host-inbound table), so
+		// with lo0Enforced true no fence is installed.
 		if !d.lo0Enforced.Load() {
 			views := dpuserspace.BuildZoneHostInboundViews(cfg)
 			unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
@@ -189,8 +197,8 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 		}
 		return fmt.Errorf("apply lo0 nftables filter: %w", err)
 	}
-	// A real lo0 filter is now installed. Record the historical success so a later
-	// failed install retains that exact generation and skips the cold-boot fence.
+	// A real lo0 filter is now the live table. Record it so a later failed install
+	// retains this generation and skips the fence (the intended day-2 divergence).
 	d.lo0Enforced.Store(true)
 	slog.Info("lo0 filter applied", "v4", filterV4, "v6", filterV6)
 	return nil
@@ -203,18 +211,27 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 // ESP+AH, IPv6 ND, v4/v6 PMTUD+error, and the configured WireGuard listen
 // port(s)). It is the lo0-table analogue of installHostInboundColdBootFence and
 // shares the SAME FenceSpec + fence builder, differing only in the target table
-// (xpf_lo0 at lo0FilterPriority). It is attempted only when the real lo0 install
-// failed and lo0Enforced is false.
+// (xpf_lo0 at lo0FilterPriority). It is attempted whenever a real lo0 install
+// failed and no real filter is currently loaded (lo0Enforced false).
 //
 // Safety: the fence drops only to the SAME lifeline-excluded address sets the
 // host-inbound fence uses (fxp0/em0/fab* and their addresses are subtracted by
 // BuildZoneHostInboundViews / BuildUnzonedHostInboundAddrs), so it can never
 // strand management or break HA. It carries no named counters (a fence is
-// transient). After a successful install, lo0Enforced is set true only when this
-// snapshot contains an address-scoped DROP; a successful zero-drop shell leaves it
-// false so a later failed real invocation can retry with a better snapshot
-// (mirrors the host-inbound #5759 zero-drop retry). On failure (nft itself is
-// broken) the error is returned and joined into the commit result.
+// transient).
+//
+// A fence deliberately does NOT set lo0Enforced — that flag is set true ONLY by a
+// successful real InstallLo0, so it means exactly "a real operator lo0 filter is
+// loaded". A fence is NOT a real filter (its chain is `policy accept` and drops
+// only THIS snapshot's addresses). lo0Enforced is already false whenever this runs
+// (we only reach here when the day-2 gate `!lo0Enforced` passed), so it stays
+// false and a subsequent failed real install RE-RENDERS the whole-table fence from
+// the then-current snapshot — covering any address that appeared after this fence
+// — rather than trusting the stale fence (#6489). This subsumes the zero-drop
+// case: an addressless snapshot yields a policy-accept shell, still not a real
+// filter, so a later failure re-fences from a possibly-now-addressed snapshot. On
+// failure (nft itself is broken) the error is returned and joined into the commit
+// result; the daemon has done all it can.
 func (d *Daemon) installLo0ColdBootFence(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) error {
 	fenceHasScopedDrop := hostInboundHasEnforceableView(views) || len(unzonedV4) > 0 || len(unzonedV6) > 0
 	spec := xnft.FenceSpec{Views: toNftViews(views), UnzonedV4: unzonedV4, UnzonedV6: unzonedV6, WGListenPorts: wgListenPorts}
@@ -226,13 +243,13 @@ func (d *Daemon) installLo0ColdBootFence(views []dpuserspace.ZoneHostInboundView
 			"err", err)
 		return fmt.Errorf("install lo0 cold-boot fail-closed fence: %w", err)
 	}
+	// lo0Enforced is intentionally NOT set here (a fence is not a real filter).
 	if fenceHasScopedDrop {
-		d.lo0Enforced.Store(true)
-		slog.Warn("lo0 real install failed; fallback succeeded with address-scoped DROPs for its rendered snapshot",
+		slog.Warn("lo0 real install failed; installed an address-scoped fail-closed fence for the current snapshot (re-rendered on each later failure until a real filter loads)",
 			"fenced_zones", len(views), "fenced_unzoned_v4", len(unzonedV4),
 			"fenced_unzoned_v6", len(unzonedV6))
 	} else {
-		slog.Warn("lo0 real install failed; fallback succeeded with zero address-scoped DROPs; lo0Enforced remains false and another fallback requires a later failed real invocation reaching lo0 while false",
+		slog.Warn("lo0 real install failed; installed a zero-drop fence shell (no firewall-local addresses in this snapshot); re-rendered on each later failure until a real filter loads",
 			"fenced_zones", len(views), "fenced_unzoned_v4", len(unzonedV4),
 			"fenced_unzoned_v6", len(unzonedV6))
 	}

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -124,6 +124,18 @@ const (
 // enforcement silently. Boot / DHCP re-applies go through applyConfig(), which
 // only logs the error, so a transient nft failure cannot brick startup; the next
 // clean commit re-renders.
+//
+// Cold-boot fail-closed fence (#6476, mirroring the host-inbound #5644 fence):
+// on COLD BOOT both nft tables are absent — there is no prior lo0 generation to
+// retain — so a failed real InstallLo0 would leave the host input path OPEN with
+// only a WARN (the boot apply only logs+discards the error), publishing host
+// services / VIP / HA-ready over an unenforced RE-protection path. When no
+// protecting xpf_lo0 table has loaded this boot (lo0Enforced false), a failed
+// install therefore installs a fail-closed fence that denies host-bound traffic
+// to firewall-local addresses (minus lifelines) instead of proceeding open. On a
+// DAY-2 failure (lo0Enforced true) the atomic replaceTable retained the prior
+// real lo0 filter, so no fence is needed — the operator's filter (not per-
+// destination-address scoped) still governs every local address.
 func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 	filterV4 := cfg.System.Lo0FilterInputV4
 	filterV6 := cfg.System.Lo0FilterInputV6
@@ -134,10 +146,19 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 		// the kernel: surface it so the commit fails closed rather than reporting that
 		// the lo0 filter was removed when it was not (#6387 PR-3: via netlink).
 		if err := nftInstaller.DeleteTable(xnft.Lo0TableName); err != nil {
+			// Teardown FAILED: a stale xpf_lo0 table (real filter OR a prior fence)
+			// may still be installed. Surface the failure (fail closed) and do NOT
+			// clear lo0Enforced — a later failed install must keep retaining rather
+			// than fence over a live table (mirrors the host-inbound #5790 teardown
+			// semantics).
 			err = tagNftInstallErr(err)
 			slog.Warn("failed to delete stale lo0 filter table", "err", err)
 			return fmt.Errorf("delete stale lo0 nftables table: %w", err)
 		}
+		// Teardown SUCCEEDED: no xpf_lo0 table is installed now. Clear the historical
+		// gate so a later enforceable generation whose first real load fails takes the
+		// cold-boot fence path rather than assuming a retained table (#5790 parity).
+		d.lo0Enforced.Store(false)
 		return nil
 	}
 
@@ -150,9 +171,71 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 	if err := nftInstaller.InstallLo0(spec); err != nil {
 		err = tagNftInstallErr(err)
 		slog.Warn("failed to apply lo0 filter", "err", err)
+		// #6476 cold-boot fail-closed fence. On cold boot no prior xpf_lo0 table
+		// exists to retain, so a failed real install here would leave the RE input
+		// path OPEN. Gate on the historical state and, when no protecting table has
+		// loaded, install a fence that denies host-bound traffic to the firewall-
+		// local addresses (minus lifelines) rendered from this snapshot. On a day-2
+		// failure (lo0Enforced true) the atomic replaceTable retained the prior real
+		// lo0 filter, which — unlike the address-scoped host-inbound table — still
+		// governs every local address, so no fence is installed.
+		if !d.lo0Enforced.Load() {
+			views := dpuserspace.BuildZoneHostInboundViews(cfg)
+			unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+			wgListenPorts := cfg.WireGuardListenPorts()
+			if fenceErr := d.installLo0ColdBootFence(views, unzonedV4, unzonedV6, wgListenPorts); fenceErr != nil {
+				return errors.Join(fmt.Errorf("apply lo0 nftables filter: %w", err), fenceErr)
+			}
+		}
 		return fmt.Errorf("apply lo0 nftables filter: %w", err)
 	}
+	// A real lo0 filter is now installed. Record the historical success so a later
+	// failed install retains that exact generation and skips the cold-boot fence.
+	d.lo0Enforced.Store(true)
 	slog.Info("lo0 filter applied", "v4", filterV4, "v6", filterV6)
+	return nil
+}
+
+// installLo0ColdBootFence installs the #6476 lo0 cold-boot fail-closed fence: a
+// minimal xpf_lo0 table that DENIES host-bound traffic to every firewall-local
+// address in its rendered snapshot (views + the addressed-but-unzoned set),
+// admitting only the mandatory L3 / return traffic (established/related, raw
+// ESP+AH, IPv6 ND, v4/v6 PMTUD+error, and the configured WireGuard listen
+// port(s)). It is the lo0-table analogue of installHostInboundColdBootFence and
+// shares the SAME FenceSpec + fence builder, differing only in the target table
+// (xpf_lo0 at lo0FilterPriority). It is attempted only when the real lo0 install
+// failed and lo0Enforced is false.
+//
+// Safety: the fence drops only to the SAME lifeline-excluded address sets the
+// host-inbound fence uses (fxp0/em0/fab* and their addresses are subtracted by
+// BuildZoneHostInboundViews / BuildUnzonedHostInboundAddrs), so it can never
+// strand management or break HA. It carries no named counters (a fence is
+// transient). After a successful install, lo0Enforced is set true only when this
+// snapshot contains an address-scoped DROP; a successful zero-drop shell leaves it
+// false so a later failed real invocation can retry with a better snapshot
+// (mirrors the host-inbound #5759 zero-drop retry). On failure (nft itself is
+// broken) the error is returned and joined into the commit result.
+func (d *Daemon) installLo0ColdBootFence(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) error {
+	fenceHasScopedDrop := hostInboundHasEnforceableView(views) || len(unzonedV4) > 0 || len(unzonedV6) > 0
+	spec := xnft.FenceSpec{Views: toNftViews(views), UnzonedV4: unzonedV4, UnzonedV6: unzonedV6, WGListenPorts: wgListenPorts}
+	if err := nftInstaller.InstallLo0ColdBootFence(spec); err != nil {
+		err = tagNftInstallErr(err)
+		slog.Error("COLD-BOOT FAIL-OPEN GUARD: lo0 install failed AND the fail-closed "+
+			"fence could not be installed; host-bound services may be reachable without "+
+			"the lo0 RE-protection filter until the next successful commit re-renders it",
+			"err", err)
+		return fmt.Errorf("install lo0 cold-boot fail-closed fence: %w", err)
+	}
+	if fenceHasScopedDrop {
+		d.lo0Enforced.Store(true)
+		slog.Warn("lo0 real install failed; fallback succeeded with address-scoped DROPs for its rendered snapshot",
+			"fenced_zones", len(views), "fenced_unzoned_v4", len(unzonedV4),
+			"fenced_unzoned_v6", len(unzonedV6))
+	} else {
+		slog.Warn("lo0 real install failed; fallback succeeded with zero address-scoped DROPs; lo0Enforced remains false and another fallback requires a later failed real invocation reaching lo0 while false",
+			"fenced_zones", len(views), "fenced_unzoned_v4", len(unzonedV4),
+			"fenced_unzoned_v6", len(unzonedV6))
+	}
 	return nil
 }
 
@@ -561,21 +644,45 @@ func (d *Daemon) installHostInboundColdBootFence(views []dpuserspace.ZoneHostInb
 // on any line rejects the WHOLE payload (atomic load), retaining only the exact
 // prior generation, if one exists — exactly like the real builder.
 func buildHostInboundFencePayload(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) string {
-	var rules []string
-	rules = append(rules, "add table inet xpf_hostinbound")
-	rules = append(rules, "delete table inet xpf_hostinbound")
-	rules = append(rules, "table inet xpf_hostinbound {")
-	rules = append(rules, "  chain input {")
 	// Same hook/priority as the real host-inbound chain so the fence occupies the
 	// same evaluation slot (#3364).
-	rules = append(rules, fmt.Sprintf("    type filter hook input priority %d; policy accept;", nftHostInboundPriority))
+	return buildFenceTablePayload(xnft.HostInboundTableName, nftHostInboundPriority, views, unzonedV4, unzonedV6, wgListenPorts)
+}
+
+// buildLo0FencePayload assembles the #6476 lo0 cold-boot fail-closed fence
+// payload (see installLo0ColdBootFence). It is the SAME fence body as
+// buildHostInboundFencePayload — mandatory admits then a catch-all DROP for every
+// firewall-local address the real ruleset would scope, NO per-service accepts, NO
+// named counters — but rendered into the xpf_lo0 table at the lo0 filter priority
+// (0), the same slot the real lo0 RE-protection filter occupies, so a later
+// successful InstallLo0 atomically replaces it. It shares buildFenceTablePayload
+// with the host-inbound fence so the two fence oracles can never drift. Used by
+// the T1 parity gate to prove the netlink InstallLo0ColdBootFence is
+// bit-equivalent. Empty address inputs intentionally produce a zero-drop shell.
+func buildLo0FencePayload(views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) string {
+	return buildFenceTablePayload(xnft.Lo0TableName, nftLo0FilterPriority, views, unzonedV4, unzonedV6, wgListenPorts)
+}
+
+// buildFenceTablePayload renders a fail-closed cold-boot fence into the named
+// inet table at the given hook-input priority: the shared mandatory admits
+// (hostInboundFenceMandatoryAdmits) then a catch-all DROP for every firewall-local
+// address the real ruleset would scope — per host-inbound-configured zone
+// (default-deny parity, #3405) and the addressed-but-unzoned set (#4420 HI-2).
+// These sets are already lifeline-excluded, so the fence never denies management /
+// cluster-control traffic. During the fence window even a `system-services all`
+// zone is denied (maximally fail-closed); the next clean commit restores the real
+// accepts. It is the single body shared by the host-inbound fence
+// (xpf_hostinbound, priority 10, #5644) and the lo0 fence (xpf_lo0, priority 0,
+// #6476) so their admit/deny posture can never diverge. Empty address inputs
+// intentionally produce a zero-drop table shell.
+func buildFenceTablePayload(tableName string, priority int, views []dpuserspace.ZoneHostInboundView, unzonedV4, unzonedV6 []string, wgListenPorts []uint16) string {
+	var rules []string
+	rules = append(rules, "add table inet "+tableName)
+	rules = append(rules, "delete table inet "+tableName)
+	rules = append(rules, "table inet "+tableName+" {")
+	rules = append(rules, "  chain input {")
+	rules = append(rules, fmt.Sprintf("    type filter hook input priority %d; policy accept;", priority))
 	rules = append(rules, hostInboundFenceMandatoryAdmits(wgListenPorts)...)
-	// Catch-all DROP for every firewall-local address the real ruleset would scope
-	// — per host-inbound-configured zone (default-deny parity, #3405) and the
-	// addressed-but-unzoned set (#4420 HI-2). These sets are already
-	// lifeline-excluded, so the fence never denies management / cluster-control
-	// traffic. During the fence window even a `system-services all` zone is denied
-	// (maximally fail-closed); the next clean commit restores the real accepts.
 	for _, v := range views {
 		if len(v.V4Addrs) > 0 {
 			rules = append(rules, "    ip daddr "+nftAddrSet(v.V4Addrs)+" drop")

--- a/pkg/daemon/daemon_nft_netlink_parity_test.go
+++ b/pkg/daemon/daemon_nft_netlink_parity_test.go
@@ -92,6 +92,17 @@ func runNftNetlinkParityInner(t *testing.T) {
 		parityCheck(t, xnft.HostInboundTableName, oracle, func() error { return inst.InstallColdBootFence(spec) })
 	})
 
+	t.Run("lo0_cold_boot_fence", func(t *testing.T) {
+		// #6476: the lo0 cold-boot fence is the SAME fence body as the host-inbound
+		// fence but in the xpf_lo0 table at priority 0. It shares FenceSpec /
+		// buildFenceTablePayload with cold_boot_fence, so this case proves the
+		// xpf_lo0 table wrapper (name + priority) composes with the shared fence
+		// rules bit-identically to the netlink InstallLo0ColdBootFence.
+		oracle := buildLo0FencePayload(views, unzonedV4, unzonedV6, wg)
+		spec := xnft.FenceSpec{Views: toNftViews(views), UnzonedV4: unzonedV4, UnzonedV6: unzonedV6, WGListenPorts: wg}
+		parityCheck(t, xnft.Lo0TableName, oracle, func() error { return inst.InstallLo0ColdBootFence(spec) })
+	})
+
 	t.Run("gap_fence", func(t *testing.T) {
 		uncoveredV4 := []string{"10.0.1.1", "10.0.9.1"}
 		uncoveredV6 := []string{"2001:db8:1::1"}

--- a/pkg/daemon/daemon_nft_netlink_testhelper_test.go
+++ b/pkg/daemon/daemon_nft_netlink_testhelper_test.go
@@ -33,6 +33,7 @@ type noopNftInstaller struct{}
 
 func (noopNftInstaller) InstallHostInbound(xnft.HostInboundSpec) error { return nil }
 func (noopNftInstaller) InstallColdBootFence(xnft.FenceSpec) error     { return nil }
+func (noopNftInstaller) InstallLo0ColdBootFence(xnft.FenceSpec) error  { return nil }
 func (noopNftInstaller) InstallGapFence(xnft.GapFenceSpec) error       { return nil }
 func (noopNftInstaller) InstallLo0(xnft.Lo0FilterSpec) error           { return nil }
 func (noopNftInstaller) DeleteTable(string) error                      { return nil }
@@ -42,11 +43,12 @@ func (noopNftInstaller) DeleteTable(string) error                      { return 
 // assertions. This is the netlink equivalent of the pre-PR-3 nftApplyPayload /
 // nftDeleteTable stubs.
 type fakeNftInstaller struct {
-	hostInbound   func(xnft.HostInboundSpec) error
-	coldBootFence func(xnft.FenceSpec) error
-	gapFence      func(xnft.GapFenceSpec) error
-	lo0           func(xnft.Lo0FilterSpec) error
-	del           func(string) error
+	hostInbound      func(xnft.HostInboundSpec) error
+	coldBootFence    func(xnft.FenceSpec) error
+	lo0ColdBootFence func(xnft.FenceSpec) error
+	gapFence         func(xnft.GapFenceSpec) error
+	lo0              func(xnft.Lo0FilterSpec) error
+	del              func(string) error
 }
 
 func (f *fakeNftInstaller) InstallHostInbound(s xnft.HostInboundSpec) error {
@@ -59,6 +61,13 @@ func (f *fakeNftInstaller) InstallHostInbound(s xnft.HostInboundSpec) error {
 func (f *fakeNftInstaller) InstallColdBootFence(s xnft.FenceSpec) error {
 	if f.coldBootFence != nil {
 		return f.coldBootFence(s)
+	}
+	return nil
+}
+
+func (f *fakeNftInstaller) InstallLo0ColdBootFence(s xnft.FenceSpec) error {
+	if f.lo0ColdBootFence != nil {
+		return f.lo0ColdBootFence(s)
 	}
 	return nil
 }
@@ -92,6 +101,7 @@ type countingNftInstaller struct{ calls *int }
 
 func (c countingNftInstaller) InstallHostInbound(xnft.HostInboundSpec) error { *c.calls++; return nil }
 func (c countingNftInstaller) InstallColdBootFence(xnft.FenceSpec) error     { *c.calls++; return nil }
+func (c countingNftInstaller) InstallLo0ColdBootFence(xnft.FenceSpec) error  { *c.calls++; return nil }
 func (c countingNftInstaller) InstallGapFence(xnft.GapFenceSpec) error       { *c.calls++; return nil }
 func (c countingNftInstaller) InstallLo0(xnft.Lo0FilterSpec) error           { *c.calls++; return nil }
 func (c countingNftInstaller) DeleteTable(string) error                      { *c.calls++; return nil }

--- a/pkg/daemon/lo0_coldboot_fence_6476_test.go
+++ b/pkg/daemon/lo0_coldboot_fence_6476_test.go
@@ -1,0 +1,319 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// #6476: the lo0 RE-protection filter had no cold-boot fence. On COLD BOOT no
+// prior xpf_lo0 table exists to retain, so a failed real InstallLo0 (the boot
+// apply only logs+discards the error) left the host input path OPEN with only a
+// WARN, while host services / VIP / HA-ready were published — the same fail-open
+// #5644 closed for the host-inbound table. The fix mirrors installHostInbound
+// ColdBootFence for lo0: when the real lo0 install fails and no protecting xpf_lo0
+// table has loaded this boot (lo0Enforced false), a fail-closed fence that denies
+// host-bound traffic to the firewall-local addresses (minus lifelines) is
+// installed instead of proceeding open. These are the fail-on-revert proofs:
+// neutralize the fence (drop the installLo0ColdBootFence call, or route it to the
+// wrong table) and the cold-boot assertions go RED.
+
+// lo0FenceTestConfig returns hostInboundTestConfig augmented with a bound lo0
+// input filter for both families, so applyLo0Filter takes the INSTALL path and
+// the cold-boot fence renders from the SAME firewall-local address snapshot the
+// host-inbound fence uses (wan reth0.50 172.16.50.8 / 2001:db8:50::8; em0/fxp0
+// lifelines are excluded by the view builders).
+func lo0FenceTestConfig() *config.Config {
+	cfg := hostInboundTestConfig()
+	cfg.System.Lo0FilterInputV4 = "protect-re"
+	cfg.System.Lo0FilterInputV6 = "protect-re6"
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"protect-re": {Name: "protect-re", Terms: []*config.FirewallFilterTerm{
+			{Name: "allow-ssh", Protocols: []string{"tcp"}, DestinationPorts: []string{"22"}, Action: "accept"},
+			{Name: "deny-rest", Action: "discard"},
+		}},
+	}
+	cfg.Firewall.FiltersInet6 = map[string]*config.FirewallFilter{
+		"protect-re6": {Name: "protect-re6", Terms: []*config.FirewallFilterTerm{
+			{Name: "deny-rest6", Action: "discard"},
+		}},
+	}
+	return cfg
+}
+
+// TestColdBootLo0InstallFailureInstallsFence is the primary #6476 fail-on-revert
+// proof: at cold boot, when the real lo0 install fails and no xpf_lo0 table has
+// ever loaded this boot, a fail-closed fence MUST be installed via the lo0 table
+// seam so the RE-protection input path stays fenced. It also asserts the commit
+// still fails (the error is surfaced) so the retry/re-render path is driven.
+// Reverting the fence makes the fence-installed and lo0Enforced assertions RED.
+func TestColdBootLo0InstallFailureInstallsFence(t *testing.T) {
+	cfg := lo0FenceTestConfig()
+
+	injected := errors.New("nftables: lo0 rule load failed")
+	var lo0Calls, fenceCalls int
+	var fenceSpec xnft.FenceSpec
+	orig := nftInstaller
+	nftInstaller = &fakeNftInstaller{
+		lo0: func(xnft.Lo0FilterSpec) error {
+			lo0Calls++
+			return injected // real lo0 ruleset install fails (injected cold-boot failure)
+		},
+		lo0ColdBootFence: func(spec xnft.FenceSpec) error {
+			fenceCalls++
+			fenceSpec = spec
+			return nil // the fence installs
+		},
+	}
+	defer func() { nftInstaller = orig }()
+
+	d := &Daemon{}
+	// Cold boot: no protecting lo0 table has ever loaded.
+	if d.lo0Enforced.Load() {
+		t.Fatal("precondition: lo0Enforced must start false (cold boot)")
+	}
+
+	err := d.applyLo0Filter(cfg)
+
+	// The commit must still fail closed (the real ruleset did not load).
+	if err == nil {
+		t.Fatal("cold-boot lo0 install failure must be surfaced as an error, got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the netlink failure, got %v", err)
+	}
+
+	// A fence must have been installed through the lo0 table seam (exactly once).
+	// Routing the fence to the host-inbound table seam instead would leave this 0.
+	if fenceCalls != 1 {
+		t.Fatalf("cold-boot lo0 install failure must install exactly one fail-closed lo0 fence, got %d", fenceCalls)
+	}
+	if lo0Calls != 1 {
+		t.Errorf("expected exactly one real lo0 install attempt, got %d", lo0Calls)
+	}
+
+	// Enforcement is now established (via the fence) — a later day-2 failure is
+	// retained by the atomic load and needs no fence.
+	if !d.lo0Enforced.Load() {
+		t.Error("lo0Enforced must be true after the fence installs (enforcement established)")
+	}
+
+	// The fence must DENY host services to the enforced wan address (both
+	// families). A FenceSpec structurally carries NO per-service accept, so the
+	// "fence must not accept a service" fail-open is guaranteed by the type; the
+	// exact drop-rule rendering is pinned by the shared netlink builder + parity CI.
+	if !sliceContains(fenceViewAddrs(fenceSpec, false), "172.16.50.8") {
+		t.Errorf("lo0 fence must fence the enforced wan v4 address 172.16.50.8:\n%+v", fenceSpec)
+	}
+	if !sliceContains(fenceViewAddrs(fenceSpec, true), "2001:db8:50::8") {
+		t.Errorf("lo0 fence must fence the enforced wan v6 address 2001:db8:50::8:\n%+v", fenceSpec)
+	}
+}
+
+// TestColdBootLo0FenceIsLifelineSafe proves the lo0 cold-boot fence renders the
+// xpf_lo0 table at the lo0 filter priority (0), never denies a management /
+// cluster-control lifeline address (em0), and does deny the enforced wan address.
+// A fence that dropped a lifeline could strand management or break HA; a fence at
+// the wrong priority/table would not stand in for the real lo0 filter. Reverting
+// the lifeline exclusion, the table, or the priority makes this RED.
+func TestColdBootLo0FenceIsLifelineSafe(t *testing.T) {
+	cfg := lo0FenceTestConfig()
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+	fence := buildLo0FencePayload(views, unzonedV4, unzonedV6, nil)
+
+	// The fence occupies the xpf_lo0 slot (the real RE-protection filter's table),
+	// at the lo0 filter priority so a successful InstallLo0 atomically replaces it.
+	if !strings.Contains(fence, "table inet xpf_lo0 {") {
+		t.Errorf("lo0 fence must render the xpf_lo0 table:\n%s", fence)
+	}
+	if !strings.Contains(fence, "type filter hook input priority 0;") {
+		t.Errorf("lo0 fence must occupy the lo0 filter priority (0):\n%s", fence)
+	}
+	// em0's cluster-control address must never be fenced (lifeline).
+	if strings.Contains(fence, "10.99.0.1") {
+		t.Errorf("lo0 fence must not deny the em0 cluster-control lifeline address:\n%s", fence)
+	}
+	// The enforced wan address must be fenced.
+	if !strings.Contains(fence, "ip daddr 172.16.50.8 drop") {
+		t.Errorf("lo0 fence must deny the enforced wan address:\n%s", fence)
+	}
+}
+
+// TestColdBootLo0FenceAdmitsMandatoryL3 proves the lo0 fence still admits return
+// traffic and mandatory L3 control (established, raw ESP/AH, IPv6 ND, v4/v6
+// PMTUD+error) plus the configured WireGuard listen port, so the deny-all fence
+// does not black-hole core operation. It shares hostInboundFenceMandatoryAdmits
+// with the host-inbound fence, so the admit posture cannot drift.
+func TestColdBootLo0FenceAdmitsMandatoryL3(t *testing.T) {
+	cfg := lo0FenceTestConfig()
+	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	unzonedV4, unzonedV6 := dpuserspace.BuildUnzonedHostInboundAddrs(cfg)
+	fence := buildLo0FencePayload(views, unzonedV4, unzonedV6, []uint16{51820})
+
+	for _, want := range []string{
+		"ct state established,related accept",
+		"meta l4proto { 50, 51 } accept",
+		"icmpv6 type { 133, 134, 135, 136, 137 } accept",
+		"icmp type { destination-unreachable, time-exceeded, parameter-problem } accept",
+		"udp dport 51820 accept",
+	} {
+		if !strings.Contains(fence, want) {
+			t.Errorf("lo0 fence missing mandatory L3 admit %q\n---\n%s", want, fence)
+		}
+	}
+}
+
+// TestDay2Lo0InstallFailureNoFence proves the NORMAL (table-present) path is
+// unchanged: once a real lo0 filter has installed (lo0Enforced == true), a LATER
+// failed install must NOT install a fence — the atomic replaceTable already
+// retains the prior real filter (fail-closed by retention), and unlike the
+// address-scoped host-inbound table the operator's lo0 filter still governs every
+// local address, so there is no day-2 coverage gap to fence. This is the
+// no-regression guard: an unconditional cold-boot fence would clobber the
+// retained day-2 filter with a deny-all, so this goes RED.
+func TestDay2Lo0InstallFailureNoFence(t *testing.T) {
+	cfg := lo0FenceTestConfig()
+
+	// First apply: real install succeeds → enforcement established.
+	orig := nftInstaller
+	nftInstaller = &fakeNftInstaller{} // all succeed
+	d := &Daemon{}
+	if err := d.applyLo0Filter(cfg); err != nil {
+		t.Fatalf("first (successful) apply: %v", err)
+	}
+	if !d.lo0Enforced.Load() {
+		t.Fatal("lo0Enforced must be true after a successful real install")
+	}
+
+	// Second apply: real install fails. The prior table is retained by the atomic
+	// load, so NO fence must be installed.
+	injected := errors.New("nftables: transient failure")
+	var lo0Calls, fenceCalls int
+	nftInstaller = &fakeNftInstaller{
+		lo0: func(xnft.Lo0FilterSpec) error { lo0Calls++; return injected },
+		lo0ColdBootFence: func(xnft.FenceSpec) error {
+			fenceCalls++
+			t.Errorf("day-2 lo0 failure must NOT install a cold-boot fence")
+			return nil
+		},
+	}
+	defer func() { nftInstaller = orig }()
+
+	err := d.applyLo0Filter(cfg)
+	if err == nil {
+		t.Fatal("day-2 lo0 install failure must still be surfaced as an error")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the netlink failure, got %v", err)
+	}
+	if lo0Calls != 1 {
+		t.Errorf("day-2 failure must attempt exactly one real install, got %d", lo0Calls)
+	}
+	if fenceCalls != 0 {
+		t.Errorf("day-2 failure must install no fence, got %d", fenceCalls)
+	}
+}
+
+// TestColdBootLo0FenceCatastrophicFailureSurfaced proves that when the real lo0
+// install AND the fence both fail (nft itself broken), both errors are surfaced
+// so the commit fails closed and lo0Enforced stays false (no protecting table).
+func TestColdBootLo0FenceCatastrophicFailureSurfaced(t *testing.T) {
+	cfg := lo0FenceTestConfig()
+
+	realErr := errors.New("nftables: lo0 rule load failed")
+	fenceErr := errors.New("nftables: kernel refused lo0 fence")
+	orig := nftInstaller
+	nftInstaller = &fakeNftInstaller{
+		lo0:              func(xnft.Lo0FilterSpec) error { return realErr },
+		lo0ColdBootFence: func(xnft.FenceSpec) error { return fenceErr },
+	}
+	defer func() { nftInstaller = orig }()
+
+	d := &Daemon{}
+	err := d.applyLo0Filter(cfg)
+	if err == nil {
+		t.Fatal("catastrophic cold-boot lo0 failure must be surfaced as an error")
+	}
+	if !errors.Is(err, realErr) || !errors.Is(err, fenceErr) {
+		t.Errorf("error must join both the real and fence failures, got %v", err)
+	}
+	// The fence never loaded, so enforcement is NOT established.
+	if d.lo0Enforced.Load() {
+		t.Error("lo0Enforced must stay false when the fence also fails")
+	}
+}
+
+// TestColdBootLo0ZeroDropFenceLeavesEnforcedFalse proves that a cold-boot fence
+// rendered from a snapshot with NO firewall-local addresses is a zero-drop shell
+// and leaves lo0Enforced false, so a later failed real invocation can retry with
+// an address-scoped snapshot (mirrors the host-inbound #5759 zero-drop retry).
+func TestColdBootLo0ZeroDropFenceLeavesEnforcedFalse(t *testing.T) {
+	// An lo0 filter bound but NO firewall-local addresses (no zoned/unzoned
+	// interfaces), so the fence scopes nothing.
+	cfg := &config.Config{}
+	cfg.System.Lo0FilterInputV4 = "protect-re"
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"protect-re": {Name: "protect-re", Terms: []*config.FirewallFilterTerm{
+			{Name: "deny-rest", Action: "discard"},
+		}},
+	}
+
+	injected := errors.New("nftables: lo0 zero-drop cold boot")
+	var fenceCalls int
+	var fenceSpec xnft.FenceSpec
+	orig := nftInstaller
+	nftInstaller = &fakeNftInstaller{
+		lo0: func(xnft.Lo0FilterSpec) error { return injected },
+		lo0ColdBootFence: func(spec xnft.FenceSpec) error {
+			fenceCalls++
+			fenceSpec = spec
+			return nil
+		},
+	}
+	defer func() { nftInstaller = orig }()
+
+	d := &Daemon{}
+	err := d.applyLo0Filter(cfg)
+	if !errors.Is(err, injected) {
+		t.Fatalf("error = %v, want wrapped injected", err)
+	}
+	if fenceCalls != 1 {
+		t.Fatalf("zero-drop cold boot must still attempt exactly one fence, got %d", fenceCalls)
+	}
+	if len(fenceViewAddrs(fenceSpec, false)) != 0 || len(fenceViewAddrs(fenceSpec, true)) != 0 {
+		t.Fatalf("fence must be zero-drop (no firewall-local addresses):\n%+v", fenceSpec)
+	}
+	if d.lo0Enforced.Load() {
+		t.Error("zero-drop fence must leave lo0Enforced false (retry on next failure)")
+	}
+}
+
+// TestLo0TeardownClearsEnforced proves a successful no-filter teardown clears the
+// lo0Enforced gate, so a later cold-boot failure re-fences rather than assuming a
+// retained table (the #5790 teardown-clears-state parity for lo0).
+func TestLo0TeardownClearsEnforced(t *testing.T) {
+	orig := nftInstaller
+	nftInstaller = &fakeNftInstaller{} // all succeed
+	defer func() { nftInstaller = orig }()
+
+	d := &Daemon{}
+	// Establish enforcement with a successful real install.
+	if err := d.applyLo0Filter(lo0FenceTestConfig()); err != nil {
+		t.Fatalf("initial apply: %v", err)
+	}
+	if !d.lo0Enforced.Load() {
+		t.Fatal("lo0Enforced must be true after a successful real install")
+	}
+	// A successful teardown (no lo0 filter configured) clears the gate.
+	if err := d.applyLo0Filter(&config.Config{}); err != nil {
+		t.Fatalf("teardown apply: %v", err)
+	}
+	if d.lo0Enforced.Load() {
+		t.Error("successful teardown must clear lo0Enforced (no table retained)")
+	}
+}

--- a/pkg/daemon/lo0_coldboot_fence_6476_test.go
+++ b/pkg/daemon/lo0_coldboot_fence_6476_test.go
@@ -15,12 +15,14 @@ import (
 // apply only logs+discards the error) left the host input path OPEN with only a
 // WARN, while host services / VIP / HA-ready were published — the same fail-open
 // #5644 closed for the host-inbound table. The fix mirrors installHostInbound
-// ColdBootFence for lo0: when the real lo0 install fails and no protecting xpf_lo0
-// table has loaded this boot (lo0Enforced false), a fail-closed fence that denies
+// ColdBootFence for lo0: when the real lo0 install fails and no REAL filter is
+// currently loaded (lo0Enforced false), a fail-closed fence that denies
 // host-bound traffic to the firewall-local addresses (minus lifelines) is
-// installed instead of proceeding open. These are the fail-on-revert proofs:
-// neutralize the fence (drop the installLo0ColdBootFence call, or route it to the
-// wrong table) and the cold-boot assertions go RED.
+// installed instead of proceeding open. A fence is NOT a real filter, so it leaves
+// lo0Enforced false and a later failed install re-fences from the current
+// snapshot (#6489). These are the fail-on-revert proofs: neutralize the fence
+// (drop the installLo0ColdBootFence call, or route it to the wrong table) and the
+// cold-boot assertions go RED.
 
 // lo0FenceTestConfig returns hostInboundTestConfig augmented with a bound lo0
 // input filter for both families, so applyLo0Filter takes the INSTALL path and
@@ -50,7 +52,7 @@ func lo0FenceTestConfig() *config.Config {
 // ever loaded this boot, a fail-closed fence MUST be installed via the lo0 table
 // seam so the RE-protection input path stays fenced. It also asserts the commit
 // still fails (the error is surfaced) so the retry/re-render path is driven.
-// Reverting the fence makes the fence-installed and lo0Enforced assertions RED.
+// Reverting the fence makes the fence-installed assertion RED.
 func TestColdBootLo0InstallFailureInstallsFence(t *testing.T) {
 	cfg := lo0FenceTestConfig()
 
@@ -72,7 +74,7 @@ func TestColdBootLo0InstallFailureInstallsFence(t *testing.T) {
 	defer func() { nftInstaller = orig }()
 
 	d := &Daemon{}
-	// Cold boot: no protecting lo0 table has ever loaded.
+	// Cold boot: no real lo0 filter is loaded.
 	if d.lo0Enforced.Load() {
 		t.Fatal("precondition: lo0Enforced must start false (cold boot)")
 	}
@@ -96,10 +98,13 @@ func TestColdBootLo0InstallFailureInstallsFence(t *testing.T) {
 		t.Errorf("expected exactly one real lo0 install attempt, got %d", lo0Calls)
 	}
 
-	// Enforcement is now established (via the fence) — a later day-2 failure is
-	// retained by the atomic load and needs no fence.
-	if !d.lo0Enforced.Load() {
-		t.Error("lo0Enforced must be true after the fence installs (enforcement established)")
+	// A fence is NOT a real filter, so lo0Enforced must stay FALSE — this is
+	// the #6489 correctness core: it keeps the day-2 gate open so a later failed real
+	// install RE-FENCES from the then-current snapshot (covering a new address)
+	// rather than retaining this stale snapshot fence. The pre-fix code set the gate
+	// true here (conflating fence-loaded with real-filter-loaded), the fail-open.
+	if d.lo0Enforced.Load() {
+		t.Error("a cold-boot fence must NOT set lo0Enforced (a fence is not a real filter); doing so re-opens the #6489 stale-fence fail-open")
 	}
 
 	// The fence must DENY host services to the enforced wan address (both
@@ -168,18 +173,20 @@ func TestColdBootLo0FenceAdmitsMandatoryL3(t *testing.T) {
 	}
 }
 
-// TestDay2Lo0InstallFailureNoFence proves the NORMAL (table-present) path is
-// unchanged: once a real lo0 filter has installed (lo0Enforced == true), a LATER
-// failed install must NOT install a fence — the atomic replaceTable already
-// retains the prior real filter (fail-closed by retention), and unlike the
-// address-scoped host-inbound table the operator's lo0 filter still governs every
-// local address, so there is no day-2 coverage gap to fence. This is the
-// no-regression guard: an unconditional cold-boot fence would clobber the
-// retained day-2 filter with a deny-all, so this goes RED.
+// TestDay2Lo0InstallFailureNoFence proves the intended divergence holds when a
+// REAL filter is the live table: once a real lo0 filter has installed
+// (lo0Enforced == true), a LATER failed install must NOT install a fence —
+// the atomic replaceTable already retains the prior real filter (fail-closed by
+// retention), and unlike the address-scoped host-inbound table the operator's lo0
+// filter still governs every local address, so there is no day-2 coverage gap to
+// fence. This is the no-regression guard: a fence here would clobber the retained
+// real filter with a deny-all, so this goes RED. (Contrast
+// TestColdBootLo0FenceThenNewAddressReFences, where the retained table is a FENCE,
+// not a real filter, and a day-2 failure MUST re-fence.)
 func TestDay2Lo0InstallFailureNoFence(t *testing.T) {
 	cfg := lo0FenceTestConfig()
 
-	// First apply: real install succeeds → enforcement established.
+	// First apply: real install succeeds → a real filter is now loaded.
 	orig := nftInstaller
 	nftInstaller = &fakeNftInstaller{} // all succeed
 	d := &Daemon{}
@@ -221,7 +228,7 @@ func TestDay2Lo0InstallFailureNoFence(t *testing.T) {
 
 // TestColdBootLo0FenceCatastrophicFailureSurfaced proves that when the real lo0
 // install AND the fence both fail (nft itself broken), both errors are surfaced
-// so the commit fails closed and lo0Enforced stays false (no protecting table).
+// so the commit fails closed and lo0Enforced stays false (no real filter).
 func TestColdBootLo0FenceCatastrophicFailureSurfaced(t *testing.T) {
 	cfg := lo0FenceTestConfig()
 
@@ -242,16 +249,16 @@ func TestColdBootLo0FenceCatastrophicFailureSurfaced(t *testing.T) {
 	if !errors.Is(err, realErr) || !errors.Is(err, fenceErr) {
 		t.Errorf("error must join both the real and fence failures, got %v", err)
 	}
-	// The fence never loaded, so enforcement is NOT established.
+	// The fence never loaded, so no real filter is loaded either.
 	if d.lo0Enforced.Load() {
 		t.Error("lo0Enforced must stay false when the fence also fails")
 	}
 }
 
-// TestColdBootLo0ZeroDropFenceLeavesEnforcedFalse proves that a cold-boot fence
-// rendered from a snapshot with NO firewall-local addresses is a zero-drop shell
-// and leaves lo0Enforced false, so a later failed real invocation can retry with
-// an address-scoped snapshot (mirrors the host-inbound #5759 zero-drop retry).
+// TestColdBootLo0ZeroDropFenceLeavesEnforcedFalse proves that a cold-boot
+// fence rendered from a snapshot with NO firewall-local addresses is a zero-drop
+// shell and leaves lo0Enforced false, so a later failed real invocation
+// re-fences from a possibly-now-addressed snapshot.
 func TestColdBootLo0ZeroDropFenceLeavesEnforcedFalse(t *testing.T) {
 	// An lo0 filter bound but NO firewall-local addresses (no zoned/unzoned
 	// interfaces), so the fence scopes nothing.
@@ -289,20 +296,20 @@ func TestColdBootLo0ZeroDropFenceLeavesEnforcedFalse(t *testing.T) {
 		t.Fatalf("fence must be zero-drop (no firewall-local addresses):\n%+v", fenceSpec)
 	}
 	if d.lo0Enforced.Load() {
-		t.Error("zero-drop fence must leave lo0Enforced false (retry on next failure)")
+		t.Error("zero-drop fence must leave lo0Enforced false (re-fence on next failure)")
 	}
 }
 
-// TestLo0TeardownClearsEnforced proves a successful no-filter teardown clears the
-// lo0Enforced gate, so a later cold-boot failure re-fences rather than assuming a
-// retained table (the #5790 teardown-clears-state parity for lo0).
+// TestLo0TeardownClearsEnforced proves a successful no-filter teardown
+// clears the lo0Enforced gate, so a later cold-boot failure fences rather
+// than assuming a retained table (the #5790 teardown-clears-state parity for lo0).
 func TestLo0TeardownClearsEnforced(t *testing.T) {
 	orig := nftInstaller
 	nftInstaller = &fakeNftInstaller{} // all succeed
 	defer func() { nftInstaller = orig }()
 
 	d := &Daemon{}
-	// Establish enforcement with a successful real install.
+	// Load a real filter with a successful real install.
 	if err := d.applyLo0Filter(lo0FenceTestConfig()); err != nil {
 		t.Fatalf("initial apply: %v", err)
 	}
@@ -315,5 +322,81 @@ func TestLo0TeardownClearsEnforced(t *testing.T) {
 	}
 	if d.lo0Enforced.Load() {
 		t.Error("successful teardown must clear lo0Enforced (no table retained)")
+	}
+}
+
+// TestColdBootLo0FenceThenNewAddressReFences is the #6489 fail-on-revert proof for
+// the stale-fence fail-open. Sequence: cold-boot real install FAILS → a fence is
+// installed for snapshot A (address 172.16.50.8); then a NEW firewall-local
+// address B (10.0.61.1) appears and the real install FAILS again. Because the live
+// table is a FENCE (policy accept + drops for A only), NOT a real filter, the
+// day-2 gate MUST re-fence from the current snapshot so B is covered — otherwise B
+// falls through the stale fence's `policy accept` (fail-open).
+//
+// PARENT-RED: make the cold-boot fence Store lo0Enforced TRUE (the pre-fix
+// conflation) and this test goes RED — the second apply's gate sees "real filter
+// loaded", skips the fence (fenceCalls stays 1), and B is left uncovered.
+func TestColdBootLo0FenceThenNewAddressReFences(t *testing.T) {
+	// One zoned interface with address A; B is added to the same unit later.
+	unit := &config.InterfaceUnit{Number: 0, Addresses: []string{"172.16.50.8/24"}}
+	cfg := &config.Config{}
+	cfg.System.Lo0FilterInputV4 = "protect-re"
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"protect-re": {Name: "protect-re", Terms: []*config.FirewallFilterTerm{
+			{Name: "deny-rest", Action: "discard"},
+		}},
+	}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{0: unit}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"wan": {
+			Name:               "wan",
+			Interfaces:         []string{"reth0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
+		},
+	}
+
+	injected := errors.New("nftables: lo0 real load failure")
+	var fenceSpecs []xnft.FenceSpec
+	orig := nftInstaller
+	nftInstaller = &fakeNftInstaller{
+		lo0: func(xnft.Lo0FilterSpec) error { return injected }, // real install always fails
+		lo0ColdBootFence: func(spec xnft.FenceSpec) error {
+			fenceSpecs = append(fenceSpecs, spec)
+			return nil
+		},
+	}
+	defer func() { nftInstaller = orig }()
+
+	d := &Daemon{}
+
+	// Apply 1 (cold boot): real install fails → fence for snapshot A.
+	if err := d.applyLo0Filter(cfg); !errors.Is(err, injected) {
+		t.Fatalf("apply 1 error = %v, want wrapped injected", err)
+	}
+	if len(fenceSpecs) != 1 {
+		t.Fatalf("apply 1 must install exactly one fence, got %d", len(fenceSpecs))
+	}
+	if !sliceContains(fenceViewAddrs(fenceSpecs[0], false), "172.16.50.8") {
+		t.Fatalf("apply-1 fence must cover address A 172.16.50.8:\n%+v", fenceSpecs[0])
+	}
+
+	// A new firewall-local address B appears on the same unit.
+	unit.Addresses = []string{"172.16.50.8/24", "10.0.61.1/24"}
+
+	// Apply 2 (day-2): real install fails again over a RETAINED FENCE. The gate must
+	// re-fence from the current snapshot so B is covered.
+	if err := d.applyLo0Filter(cfg); !errors.Is(err, injected) {
+		t.Fatalf("apply 2 error = %v, want wrapped injected", err)
+	}
+	if len(fenceSpecs) != 2 {
+		t.Fatalf("day-2 failure over a retained FENCE must RE-FENCE (got %d fence installs, want 2); "+
+			"the stale snapshot-A fence is policy-accept and does not cover the new address", len(fenceSpecs))
+	}
+	// The re-rendered fence must cover BOTH A and the newly-appeared B.
+	got := fenceViewAddrs(fenceSpecs[1], false)
+	if !sliceContains(got, "172.16.50.8") || !sliceContains(got, "10.0.61.1") {
+		t.Fatalf("re-rendered fence must cover both A (172.16.50.8) and new B (10.0.61.1), got %v:\n%+v", got, fenceSpecs[1])
 	}
 }

--- a/pkg/nftables/netlink_installer.go
+++ b/pkg/nftables/netlink_installer.go
@@ -42,6 +42,12 @@ type Installer interface {
 	// InstallColdBootFence installs the #5644 cold-boot fail-closed fence
 	// (the xpf_hostinbound table reduced to mandatory admits + address drops).
 	InstallColdBootFence(spec FenceSpec) error
+	// InstallLo0ColdBootFence installs the #6476 lo0 cold-boot fail-closed fence:
+	// the SAME fence body as InstallColdBootFence (mandatory admits + firewall-
+	// local address drops) but in the xpf_lo0 table at the lo0 filter priority, so
+	// a failed boot-time InstallLo0 does not leave the RE-protection input path
+	// open. A later successful InstallLo0 atomically replaces it (same table).
+	InstallLo0ColdBootFence(spec FenceSpec) error
 	// InstallGapFence installs the #5789 additive coverage-gap fence.
 	InstallGapFence(spec GapFenceSpec) error
 	// InstallLo0 installs the lo0 loopback input filter (#3445/#3392).
@@ -80,6 +86,19 @@ func (in *netlinkInstaller) InstallHostInbound(spec HostInboundSpec) error {
 
 func (in *netlinkInstaller) InstallColdBootFence(spec FenceSpec) error {
 	return in.replaceTable(HostInboundTableName, hostInboundPriority, func(p *nlPlan) {
+		buildHostInboundFenceNetlink(p, spec)
+	})
+}
+
+// InstallLo0ColdBootFence installs the #6476 lo0 cold-boot fence: the SAME fence
+// body as InstallColdBootFence (buildHostInboundFenceNetlink — mandatory admits
+// plus firewall-local address DROPs) but into the xpf_lo0 table at the lo0 filter
+// priority. Reusing the shared fence builder keeps the two fences bit-identical
+// in rule shape; only the table wrapper (name + priority, produced generically by
+// replaceTable) differs, so a later successful InstallLo0 atomically replaces the
+// fence with the operator's real RE-protection filter.
+func (in *netlinkInstaller) InstallLo0ColdBootFence(spec FenceSpec) error {
+	return in.replaceTable(Lo0TableName, lo0FilterPriority, func(p *nlPlan) {
 		buildHostInboundFenceNetlink(p, spec)
 	})
 }


### PR DESCRIPTION
## Summary

- The operator's lo0 RE-protection filter (`interfaces lo0 unit 0 family inet filter input <name>`, the Junos protect-RE pattern) lowers to the `inet xpf_lo0` input chain at hook-input priority 0 — strictly before the `xpf_hostinbound` backstop (10). Unlike host-inbound it had **no cold-boot fence**.
- On a **COLD BOOT** no prior `xpf_lo0` table exists to retain, and the boot apply reaches `applyLo0Filter` through `applyConfig`, which only **logs and discards** the error (a boot apply must not brick startup). So a failed `InstallLo0` left the RE input path with no lo0 filter and only a WARN, while the daemon published host service / VIP / HA-ready — the exact fail-open #5644 closed for host-inbound. Any service protected ONLY via the lo0 filter is unenforced until the next clean commit.
- **Fix (mirrors #5644):** add a `d.lo0Enforced` gate; on a failed `InstallLo0` while false, install a fail-closed fence into the `xpf_lo0` table (priority 0) that denies host-bound traffic to the **same lifeline-excluded firewall-local address sets** and the **same fence body** as the host-inbound cold-boot fence. Because the fence occupies the real filter's table/slot, a later successful `InstallLo0` **atomically replaces** it. Install goes through a new `Installer.InstallLo0ColdBootFence` seam.
- **No day-2 gap fence** (deliberate #5789 divergence): the `xpf_hostinbound` table is auto-generated and per-destination-address scoped, so a newly-appeared address needs an additive gap fence. The operator's lo0 filter is hand-authored and NOT per-destination scoped — its terms (typically ending in a catch-all `discard`) govern every local address, including one that appears later — so a day-2 failure retains the prior real filter and that generation still covers new addresses.
- **One source of truth:** extracted `buildFenceTablePayload(tableName, priority, ...)` so the host-inbound and lo0 fence oracles share one body and cannot drift; the netlink `InstallLo0ColdBootFence` reuses `buildHostInboundFenceNetlink`, so only the table wrapper differs.

## Fence rule shape

Identical to the #5644 host-inbound cold-boot fence — mandatory L3 / return admits (`ct established,related`, raw ESP/AH `l4proto {50,51}`, IPv6 ND, v4/v6 PMTUD+error, the configured WireGuard listen port) followed by a catch-all `<fam> daddr <addrs> drop` — with **no per-service accept and no named counters**. The address sets are lifeline-excluded (`fxp0`/`em0`/`fab*`), so the fence can never strand management or break HA.

## Test plan

- [x] `pkg/daemon/lo0_coldboot_fence_6476_test.go` — fail-on-revert proof:
  - cold-boot `InstallLo0` failure installs exactly one **lo0-table** fence (routing it to the host-inbound seam leaves the count at 0)
  - lifeline safety (em0 `10.99.0.1` never fenced; wan address is) via `buildLo0FencePayload`, asserting the `xpf_lo0` table at priority 0
  - mandatory-L3 + WG admits present
  - **day-2** retention installs **no** fence
  - catastrophic double-failure joins both errors and leaves `lo0Enforced` false
  - zero-drop fence leaves `lo0Enforced` false (retry semantics)
  - successful teardown clears `lo0Enforced`
- [x] **Parent-RED confirmed firsthand:** neutralizing the fence install turns the primary test RED with `cold-boot lo0 install failure must install exactly one fail-closed lo0 fence, got 0` (clean assertion failure, not a build break), then restored.
- [x] `lo0_cold_boot_fence` case added to the T1 netlink parity gate (`daemon_nft_netlink_parity_test.go`).
- [x] `go build ./...`, `go vet ./pkg/daemon/ ./pkg/nftables/`, `gofmt -l` (touched files clean), full `pkg/daemon` + `pkg/nftables` suites, and the `refactoraudit` heatmap gate (regenerated `docs/refactoring-audit-current.txt`) all pass.
- Not run: live cluster smoke — control-plane-only nft fence path, no dataplane/forwarding change; exercised by unit tests + the parity gate.

## Docs

`docs/host-inbound-service-matrix.md` gains a "lo0 RE-protection cold-boot fence (#6476)" subsection documenting the mechanism and the #5789 (no gap fence) divergence.

## Refs

- Mirrors #5644 (host-inbound cold-boot fence), #5790 (teardown clears the gate), and diverges from #5789 (no lo0 gap fence, with rationale).

Closes #6476