### PR TITLE
userspace-dp: document the #5390 lock-free policer contract in engine/policer.rs (#6470)

### DIFF
--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -40,7 +40,9 @@ Mirrors the BPF firewall-filter pipeline in userspace.
     protocol esp; then discard` term matched EVERY protocol — a
     fail-wide security bug. The Go gate is the primary defense; this is
     the helper-boundary backstop against version/snapshot drift.
-- `engine.rs` — per-term evaluation, first-match-wins. It carries the
+- `engine/` — per-term evaluation, first-match-wins (the #1546 split of
+  the monolithic `engine.rs` into `mod.rs` / `eval.rs` / `matching.rs` /
+  `policer.rs` / `tx_selection.rs` / `cache_sensitive*.rs`). It carries the
   matched `then policer ...` name in the filter result. Routing-instance
   evaluation can also return log/action/filter/term metadata so AF_XDP
   can emit PBR RT_FLOW filter-log events without re-evaluating the term

--- a/userspace-dp/src/filter/engine/policer.rs
+++ b/userspace-dp/src/filter/engine/policer.rs
@@ -4,11 +4,21 @@
 // invoke `runtime.meter()` once per matching term and merge the returned
 // `ThreeColorDecision` into the caller-visible `ThreeColorPolicerAction`.
 //
-// Concurrency contract preserved across the split:
-//   - `ThreeColorPolicerState::meter` is `&mut self` and not used directly
-//     here; we go through `ThreeColorPolicerRuntime::meter(&self, ...)`
-//     which serializes via the wrapper's `Mutex<ThreeColorPolicerState>`
-//     and then records counters via relaxed atomic adds.
+// Concurrency contract (#5390 — LOCK-FREE; the pre-#5390
+// `Mutex<ThreeColorPolicerState>` wrapper this header used to describe is
+// RETIRED):
+//   - `ThreeColorPolicerState::meter` is `&self` (not `&mut self`): the
+//     token-bucket state is shared across all workers behind an `Arc` and
+//     metered concurrently — refills through per-rate timestamp CAS, then
+//     consumes tokens through a bounded `compare_exchange_weak` loop over
+//     the packed `credits` word (`filter/policer.rs`). NO `Mutex` anywhere:
+//     the RSS-spread flow aggregate no longer serializes on a per-packet
+//     futex, and the poison failure mode is gone with the lock. The #5390
+//     fail-on-revert test in `filter/policer.rs` guards this shape — do not
+//     "restore" a mutex here.
+//   - `ThreeColorPolicerRuntime::meter(&self, ...)` (filter/mod.rs) meters
+//     lock-free through the state CAS and then records counters via relaxed
+//     atomic adds.
 //   - The `meter()` call -> counter-record order is preserved: each call
 //     site invokes `runtime.meter()` and propagates its `dscp_rewrite`/
 //     `drop` decision without intervening allocations.


### PR DESCRIPTION
## Summary

- `userspace-dp/src/filter/engine/policer.rs:7-14` documented the three-color meter as `&mut self` serialized by `Mutex<ThreeColorPolicerState>` — the contract #5390 retired when it moved metering to lock-free CAS over packed credits + per-rate refill clocks (`filter/policer.rs`, `filter/mod.rs:487-497`). Header rewritten to the #5390 truth, with a pointer at the fail-on-revert guard that pins the shape.
- Sibling stale ref fixed: `userspace-dp/src/filter/README.md:43` still named the monolithic `engine.rs`; it now names the `engine/` directory from the #1546 split.
- Comment-only, no behavioral impact. Module docs are part of the contract — a backwards one risked a future change "restoring" the documented mutex (the #5390 futex convoy) or double-metering on the wrong contract.

## Test plan

- [x] `cargo build` clean (159 warnings, identical to master baseline)
- [x] No code changed — no tests added (doc-only); the #5390 runtime shape remains guarded by the existing fail-on-revert test in `filter/policer.rs`
- [ ] Cluster smoke: not run (doc-only)

## Refs

Closes #6470
