### PR TITLE
docs(fabric): drop the removed cluster-peer-return fast path from the module header (#6478)

### DIFF
--- a/userspace-dp/src/afxdp/forwarding/fabric.rs
+++ b/userspace-dp/src/afxdp/forwarding/fabric.rs
@@ -1,8 +1,10 @@
 //! #5650: fabric cross-chassis forwarding — link resolution/skip classification,
-//! fabric redirect selection (plain + zone-encoded), the HA cluster-peer-return
-//! fast path, and the shared kernel-neighbor-state classifier used by the FIB
-//! and tunnel neighbor paths. Pure code-motion split out of `forwarding/mod.rs`
-//! (behavior-identical). See `docs/fabric-cross-chassis-fwd.md`.
+//! fabric redirect selection (plain + zone-encoded), the #6458 zone-stamp
+//! validation gates, and the shared kernel-neighbor-state classifier used by
+//! the FIB and tunnel neighbor paths. Pure code-motion split out of
+//! `forwarding/mod.rs` (behavior-identical). See
+//! `docs/fabric-cross-chassis-fwd.md`. (The HA cluster-peer-return fast path
+//! was removed in #6478.)
 
 use super::*;
 


### PR DESCRIPTION
## Summary
- The integration audit (Step-6 cross-PR) found one doc-only inconsistency: fabric.rs's module header still listed the HA cluster-peer-return fast path as a living component after its #6478 removal (forwarding/README.md:29 was correctly updated; the module header was missed).
- One-line header correction; no code change.

## Test plan
- [x] cargo build --release green
- [x] No code touched — comment-only

Refs: #6478