### PR TITLE
termsafe: close the two residual device-text terminal surfaces from #6468

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -61859,3 +61859,57 @@ that honors U+2028 as a break lets a peer hostname forge a row in the very
 table the function protects. Same argument that escapes CR. Rendered as
 ` ` (a `\xHH` escape cannot represent a rune above U+00FF);
 `blockDisplaySafe` rejects them so the fast path cannot bypass.
+
+## 2026-07-31 — fold the Codex round on #6579 (parsed FRR cells + %q correction)
+
+- **Timestamp**: 2026-07-31
+- **Action**: Codex found the class definition itself was incomplete. Both the
+  earlier sweep and the Claude review defined the class over RAW COMMAND
+  OUTPUT; a field that is PARSED out of that output and reprinted into a
+  caller-formatted row is invisible to that framing.
+- **File(s)**: `pkg/termsafe/termsafe.go`, `pkg/termsafe/row_6468_test.go`
+  (new), `pkg/frr/status_parse.go`, `pkg/cli/cli_show_routing.go`,
+  `pkg/grpcapi/server_routing.go`, `pkg/cli/cli_residual_escape_6468_test.go`,
+  `pkg/grpcapi/server_routing_escape_6468_test.go`,
+  `pkg/cli/show_services_ddns.go`,
+  `pkg/grpcapi/server_show_dhcp_lldp_snmp.go`,
+  `pkg/termsafe/block_6468_test.go`, `pkg/cli/README.md`
+
+**Proven case — `ISISAdjacency.SystemID`.** FRR substitutes the hostname the
+peer advertised in its Dynamic Hostname TLV (RFC 5301) for the numeric system
+ID, so column 1 of `show isis neighbor` is peer-controlled text.
+`GetISISAdjacency` reaches it through `strings.Fields`, which splits on
+`unicode.IsSpace` ONLY — measured: ESC/DEL/BEL/C1-CSI/NUL are all
+`IsSpace=false` and ride inside the token untouched. Tokenizing is not
+sanitizing.
+
+**Extension the review did not have.** Sanitizing only `SystemID` would still
+be wrong: `strings.Fields` means a hostname containing a SPACE shifts
+Interface/Level/State/HoldTime one column right and puts peer bytes in each.
+The guard has to cover the WHOLE row. New `termsafe.SanitizeRowForDisplay`
+makes that unskippable, and the same guard went on the other four parsed FRR
+tables (OSPF neighbors, BGP summary, BGP routes, RIP routes) on both
+renderers — free on clean text, and "this column is numeric" is a property of
+the current FRR rather than of the protocol.
+
+**Row guard is NOT redundant with the response-boundary block guard.** Proven,
+not assumed: reverting the gRPC IS-IS row guard alone leaves the test green
+because the block guard catches it. The isolating case is a JSON-decoded
+BGP-summary cell carrying a real LF — the block variant preserves LF by design
+and renders a forged peer row; only the per-cell field guard escapes it. Both
+renderers now have that test, and the gRPC IS-IS test is documented as
+defense-in-depth rather than a binder.
+
+**Factual correction.** The earlier comments said dyndns2/duckdns/**generic**
+wrap the provider body in `%q`. Verified wrong: generic does not quote the body,
+it OMITS it entirely (`backend_generic.go:242` formats the configured
+`okTokens` with `%v`, never the response). Correct tally: two embed it
+unquoted (Cloudflare `:166`, Route 53 `:195,277`), two quote it (dyndns2,
+duckdns), generic omits it, rfc2136 reports a fixed rcode string. The fix is
+unaffected — the two unsafe backends are the two already identified.
+
+Scoped out, verified: `frr.FormatRouteDetail` (JSON-typed, no free-text cell),
+`routing.RouteEntry` (netlink, not peer-sourced), the `pkg/api` REST renderers
+(JSON, no shipped terminal consumer). The `slog`/remote-syslog sink Codex
+raised is a different sink and a package-wide policy question; filed separately
+by the parent, deliberately NOT folded here.

--- a/_Log.md
+++ b/_Log.md
@@ -61819,3 +61819,43 @@ New `termsafe.SanitizeBlockForDisplay` preserves LF/TAB so a table is not
 collapsed — `SanitizeForDisplay` escapes those too, correctly for a
 single-line field but destructively for a block. CR is deliberately NOT
 preserved (line-overwrite forgery).
+
+## 2026-07-31 — fold the #6579 hostile-review findings (both renderers + call-site tests)
+
+- **Timestamp**: 2026-07-31
+- **Action**: The first pass fixed the vtysh class on the LOCAL CLI only. Every
+  one of those 12 sites has a byte-for-byte mirror in `pkg/grpcapi` feeding the
+  remote `cli`'s verbatim `fmt.Print(resp.Output)`, and it was left raw — the
+  more common operator posture kept exactly the pre-fix behavior. Nothing in
+  the suite noticed, because the diff had zero call-site tests.
+- **File(s)**: `pkg/grpcapi/server_routing.go`,
+  `pkg/grpcapi/server_show_routes_text.go`, `pkg/cli/cli_request.go`,
+  `pkg/termsafe/termsafe.go`, `pkg/termsafe/block_6468_test.go`,
+  `pkg/grpcapi/server_routing_escape_6468_test.go` (new),
+  `pkg/grpcapi/server_show_ddns_escape_6468_test.go` (new),
+  `pkg/cli/cli_residual_escape_6468_test.go` (new), `pkg/cli/README.md`
+
+**MAJOR-1 — gRPC mirror.** All 12 sites sanitized. On `GetOSPFStatus` /
+`GetISISStatus` / `GetBGPStatus` the guard sits on the RESPONSE rather than on
+each vtysh branch, so a later `case` is covered by construction; the structured
+branches take the allocation-free fast path. `showBFDPeers` / `showRouteMap`
+guard their `buf.WriteString`.
+
+**MAJOR-2 — call-site tests, both renderers.** 15 revert cases, each reverted
+via Edit one hunk at a time (so the `termsafe` import stays used and the RED is
+an assertion, never a build break). Every one produced an assertion failure.
+Two of them are WRONG-VARIANT reverts: swapping the block sanitizer for the
+single-line one on a vtysh site trips the line-count assertion, and swapping
+the single-line one for the block variant on `LastError` trips the `\x0a`
+assertion.
+
+**MINOR-1** — `cli_request.go` OSPF/BGP clear now sanitize their vtysh stdout.
+
+**MINOR-3** — `SanitizeBlockForDisplay` now escapes U+2028/U+2029. They are
+Zl/Zp, so `unicode.IsControl` misses them and the single-line variant's
+documented bidi/Cf out-scope let them through. That is defensible for a field
+but not for a BLOCK sanitizer whose whole premise is line structure: a terminal
+that honors U+2028 as a break lets a peer hostname forge a row in the very
+table the function protects. Same argument that escapes CR. Rendered as
+` ` (a `\xHH` escape cannot represent a rune above U+00FF);
+`blockDisplaySafe` rejects them so the fast path cannot bypass.

--- a/_Log.md
+++ b/_Log.md
@@ -61795,3 +61795,27 @@ would never produce.
     pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go,
     pkg/ra/sender_prefixlen_6531_test.go,
     pkg/daemon/ra_pd_prefixlen_6531_test.go, _Log.md
+
+## 2026-07-31 — close the two #6468 residual terminal-escape surfaces
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6468 fixed the DHCP lease fields it named, but two other
+  device/remote-supplied strings still reached an operator terminal unescaped.
+- **File(s)**: `pkg/termsafe/termsafe.go`, `pkg/termsafe/block_6468_test.go`
+  (new), `pkg/cli/show_services_ddns.go`,
+  `pkg/grpcapi/server_show_dhcp_lldp_snmp.go`, `pkg/cli/cli_show_routing.go`
+
+**D1 — DDNS `LastError`.** Safe for dyndns2/duckdns/generic (they wrap the
+provider response in `%q`) but NOT for Cloudflare
+(`backend_cloudflare.go:166`) or Route 53 (`backend_route53.go:195,277`),
+which embed provider message text with `%s`. Sanitized at the two display
+sites so the class is covered regardless of backend.
+
+**D2 — raw `vtysh` stdout.** All 12 `fmt.Print(output)` sites in
+`cli_show_routing.go` print unmodified vtysh output carrying remote-advertised
+text (BGP hostname capability, IS-IS dynamic hostname TLVs, OSPF router IDs).
+
+New `termsafe.SanitizeBlockForDisplay` preserves LF/TAB so a table is not
+collapsed — `SanitizeForDisplay` escapes those too, correctly for a
+single-line field but destructively for a block. CR is deliberately NOT
+preserved (line-overwrite forgery).

--- a/_Log.md
+++ b/_Log.md
@@ -61853,10 +61853,9 @@ assertion.
 
 **MINOR-3** — `SanitizeBlockForDisplay` now escapes U+2028/U+2029. They are
 Zl/Zp, so `unicode.IsControl` misses them and the single-line variant's
-documented bidi/Cf out-scope let them through. That is defensible for a field
-but not for a BLOCK sanitizer whose whole premise is line structure: a terminal
-that honors U+2028 as a break lets a peer hostname forge a row in the very
-table the function protects. Same argument that escapes CR. Rendered as
+documented bidi/Cf out-scope let them through. A terminal that honors U+2028 as
+a break lets a peer hostname add a row to the very table the function is
+keeping printable. Same argument that escapes CR. Rendered as
 ` ` (a `\xHH` escape cannot represent a rune above U+00FF);
 `blockDisplaySafe` rejects them so the fast path cannot bypass.
 
@@ -61893,12 +61892,13 @@ renderers — free on clean text, and "this column is numeric" is a property of
 the current FRR rather than of the protocol.
 
 **Row guard is NOT redundant with the response-boundary block guard.** Proven,
-not assumed: reverting the gRPC IS-IS row guard alone leaves the test green
-because the block guard catches it. The isolating case is a JSON-decoded
+not assumed: reverting the gRPC IS-IS row guard alone leaves the raw-ESC test
+green because the block guard catches it. The isolating case is a JSON-decoded
 BGP-summary cell carrying a real LF — the block variant preserves LF by design
 and renders a forged peer row; only the per-cell field guard escapes it. Both
 renderers now have that test, and the gRPC IS-IS test is documented as
-defense-in-depth rather than a binder.
+defense-in-depth rather than a binder. (Superseded by the next entry: the gRPC
+IS-IS per-cell call IS bindable, via column alignment rather than content.)
 
 **Factual correction.** The earlier comments said dyndns2/duckdns/**generic**
 wrap the provider body in `%q`. Verified wrong: generic does not quote the body,
@@ -61913,3 +61913,99 @@ Scoped out, verified: `frr.FormatRouteDetail` (JSON-typed, no free-text cell),
 (JSON, no shipped terminal consumer). The `slog`/remote-syslog sink Codex
 raised is a different sink and a package-wide policy question; filed separately
 by the parent, deliberately NOT folded here.
+
+## 2026-07-31 — fold the Codex re-review of #6579 (claim narrowing + row-site binders)
+
+- **Timestamp**: 2026-07-31
+- **Action**: Codex re-reviewed the folded head at `83aba402d` and returned
+  MERGE-NEEDS-MAJOR. The MAJOR is real and is filed as **#6590**, deliberately
+  NOT fixed here: it is a different bug class at a different layer (parsing),
+  while this PR closes escape-injection at the display layer. What this fold
+  does about it is make sure the PR, the docs and the code comments do not
+  CLAIM more than they deliver. The three MINORs are folded.
+- **File(s)**: `pkg/termsafe/termsafe.go`, `pkg/termsafe/row_6468_test.go`,
+  `pkg/termsafe/block_6468_test.go`, `pkg/frr/status_parse.go`,
+  `pkg/frr/bgp_summary_hostname_6468_test.go` (new),
+  `pkg/cli/cli_row_escape_6579_test.go` (new),
+  `pkg/grpcapi/server_row_escape_6579_test.go` (new),
+  `pkg/grpcapi/server_routing_escape_6468_test.go`, `pkg/cli/README.md`
+
+**MAJOR (#6590) — narrowed every claim instead of overstating the fix.** Codex
+is right that escaping a row does not prevent SEMANTIC spoofing: `strings.Fields`
+splits on whitespace, so a peer hostname containing a space shifts every later
+column and `SanitizeRowForDisplay` — which preserves plausible printable text —
+cannot tell a genuine `State=Up` from a peer-supplied token. **A row can be
+terminal-safe and materially false.** Narrowed in five places: the `pkg/termsafe`
+package doc, the `SanitizeRowForDisplay` doc (new "What this does NOT fix"
+section, ending "do not cite a call to this function as evidence that a rendered
+row is trustworthy"), the `SanitizeBlockForDisplay` doc, the `ISISAdjacency` doc
+in `pkg/frr`, and the `pkg/cli/README.md` guard contract (new "What the guard
+does NOT do — do not overstate this in a review"). Also dropped two "keeps the
+table honest" phrasings, in the block doc and a test message, for "keeping it
+printable". Every narrowing points at #6590.
+
+**MINOR-2 — `SanitizeForDisplay` now escapes U+2028/U+2029 too.** The first fold
+gave the BLOCK variant line-separator escaping and left the field variant
+passing them, which became incoherent once cells started going through the
+field variant: that variant already escapes LF, so passing the Unicode line
+break while escaping the ASCII one made the STRICTER variant the more permissive
+one for exactly the row-forgery vector. `DisplaySafe` moved in lockstep — it
+gates the allocation-free return, so leaving it behind would have made the new
+escaping dead code, and there is a test that says so. Blast radius on already-
+merged #6468 surfaces (DHCP lease `Hostname`/`HWAddress`, DDNS `FQDN`,
+`LastError`): judged a strict improvement — all are single-line fields padded
+into a row, where a line separator has no legitimate use. `DisplaySafe` has no
+callers outside the package.
+
+**MINOR-3 — corrected the false cost claim, kept the API.** Codex measured ~96 B
+/ 4 allocs per clean 3-cell row "versus zero for direct formatting". The 96 B / 4
+allocs reproduce; the zero-alloc baseline does not — it is an artifact of
+benchmarking string CONSTANTS, which the compiler boxes into read-only statics.
+Measured with production-shaped values (struct fields), 10k 3-cell rows:
+
+| path | allocs | bytes |
+|---|---|---|
+| no sanitizer at all | 30,034 | 3.73 MB |
+| per-cell `SanitizeForDisplay`, no helper | 30,035 | 3.73 MB |
+| `SanitizeRowForDisplay(...)...` | 40,037 | 4.21 MB |
+
+So the helper's real cost is ONE allocation and 48 bytes per row (the `[]any`);
+the 3-per-row boxing is inherent to `fmt`'s variadic `any` and is paid by the
+unguarded path too. The per-cell sanitize is genuinely free — that was the
+substantive claim and it holds. Accepted rather than restructured: these are
+`show` render loops already gated by a `vtysh` fork/exec and a whole-table
+string materialization, not a packet path. The doc now carries the table, names
+the escape hatch (hoist a scratch `[]any`), and `BenchmarkSanitizedRow{Unguarded,
+Inline,Helper}` plus a `testing.AllocsPerRun` pin keep it checkable.
+
+**MINOR-4 — closed all three coverage gaps.**
+
+- *Missing call-site binders.* OSPF neighbors, BGP routes and RIP routes had no
+  binder on either renderer. Added, with per-parser fixtures. All **10**
+  parsed-row sites (5 per renderer) are now individually bound: reverting any
+  one produces a build-clean assertion failure naming that site.
+- *The masked IS-IS binder.* Codex was right that reverting the inner gRPC IS-IS
+  row guard still passed — the response-boundary block guard neutralizes the ESC
+  either way. Codex's suggested fix (the JSON-decoded LF shape) is **not**
+  reachable for this row: `strings.Fields` splits on `unicode.IsSpace`, which
+  includes LF, TAB, NEL, NBSP *and* U+2028/U+2029, so no whitespace rune can
+  survive into an IS-IS cell. The discriminator that does survive the mask is
+  COLUMN ALIGNMENT: `%-20s` pads whatever it is handed, so guarding the cell
+  pads the 17-char escaped text to 20, while guarding only the response pads the
+  14-byte raw text and *then* expands the escape — the next column shifts right
+  by exactly 3. Reverting now fails with "the next column starts at 26 instead
+  of 23 — exactly the 3 bytes the ESC grows by when escaped". This also binds a
+  real property: the guard must precede the width format or a hostile cell
+  displaces every column after it.
+- *The `encoding/json` declared-field-set claim.* Documented as a load-bearing
+  security boundary, previously unpinned. Two tests in `pkg/frr`: a hostile
+  `hostname` key must not reach ANY string field of `BGPPeerSummary` (reflective
+  sweep, so a future field addition is caught), and `bgpPeerJSON` must declare
+  no hostname field and no catch-all decode target (map/interface/slice) that
+  would defeat "undeclared keys are dropped".
+
+**Validation.** `pkg/cli`, `pkg/grpcapi`, `pkg/termsafe`, `pkg/frr`, `pkg/api`,
+`pkg/ddns` all green; `go build ./...` and `go vet ./pkg/...` clean. Revert
+battery: 10 row sites + the U+2028 escaping + both JSON-boundary tests, each
+reverted via Edit one hunk at a time so RED is an assertion and never a build
+break — `go vet` confirmed passing under every revert.

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -167,26 +167,57 @@ presenter's rendered output is byte-identical:
   when the daemon hookups are absent (test/standalone).
 - `fwdSampler` (forwarding CPU stats) can be `nil` — every show handler
   null-checks it.
-- Device-originated strings printed to the operator's terminal MUST pass
-  through `termsafe.SanitizeForDisplay` (`pkg/termsafe`, #6468). A DHCP lease
-  hostname (option 12) and client hardware address are supplied by a device on
-  a served segment and stored opaque by Kea; the DHCP-DDNS forward record name
-  is built from that same hostname. Printed raw they can smuggle terminal
+- Device- or remote-originated strings printed to the operator's terminal MUST
+  pass through `pkg/termsafe` (#6468). Printed raw they can smuggle terminal
   escape sequences (OSC 52 clipboard write, CSI erase/redraw) that the terminal
-  acts on — clipboard hijack and output spoofing. The helper backslash-escapes
+  acts on — clipboard hijack and output spoofing. Both helpers backslash-escape
   C0/DEL/C1 control bytes and invalid UTF-8 while passing legitimate multibyte
-  UTF-8 through unchanged. `show dhcp server leases` runs on BOTH the local and
-  the remote CLI, so the guard is applied on BOTH terminal-facing renderers:
-  `pkg/cli` (`show_services_dhcp.go` lease `Hostname`/`HWAddress`,
-  `show_services_ddns.go` owned-record `FQDN`) AND the gRPC text renderer that
-  feeds the remote `cli`'s verbatim `fmt.Print(resp.Output)`
-  (`pkg/grpcapi/server_show_dhcp_lldp_snmp.go`, same fields). The sanitizer
-  lives in the leaf package `pkg/termsafe` (stdlib-only) because `pkg/cli`
-  imports `pkg/grpcapi`, so a helper in `pkg/cli` could not be shared upward.
-  LLDP neighbor fields are already sanitized at the ingest boundary
-  (`lldp.sanitizeTLVString`); the DHCPv6 DUID view and the Surface A DDNS name
-  are firewall-self/operator-authored, not device-controlled, so they are left
-  raw.
+  UTF-8 through unchanged.
+
+  **Pick the variant by the SHAPE of the value, not by its source.**
+  `SanitizeForDisplay` is for a single-line FIELD the caller formats into a row:
+  it escapes LF and TAB along with everything else, because an embedded newline
+  in a field is itself a forgery vector — it fakes a table row.
+  `SanitizeBlockForDisplay` is for a MULTI-LINE blob whose own line structure is
+  the output: it PRESERVES LF and TAB so a BGP table is not collapsed into one
+  `\x0a`-laden line, and escapes CR plus U+2028/U+2029 because those forge or
+  overwrite rows rather than carry structure. Using the single-line variant on a
+  block mangles the output; using the block variant on a field re-opens the
+  row-forgery hole. The tests assert both directions.
+
+  **The guard goes on BOTH terminal-facing renderers.** Every one of these
+  commands runs on the local CLI *and* the remote `cli`, which prints
+  `resp.Output` verbatim (`cmd/cli`: `fmt.Print(resp.Output)`); a fix on one
+  renderer alone leaves the other at pre-fix behavior, and the remote `cli` is
+  the more common operator posture. Guarded surfaces:
+
+  | Value | Variant | `pkg/cli` | `pkg/grpcapi` |
+  |---|---|---|---|
+  | DHCP lease `Hostname` / `HWAddress` | field | `show_services_dhcp.go` | `server_show_dhcp_lldp_snmp.go` |
+  | DHCP-DDNS owned-record `FQDN` | field | `show_services_ddns.go` | `server_show_dhcp_lldp_snmp.go` |
+  | Surface A DDNS `LastError` (provider response body — Cloudflare / Route 53 embed it with `%s`) | field | `show_services_ddns.go` | `server_show_dhcp_lldp_snmp.go` |
+  | Raw `vtysh` stdout (BGP hostname capability, IS-IS dynamic hostname TLVs, OSPF router IDs) | block | `cli_show_routing.go` (OSPF ×4, BGP ×3, IS-IS ×3, BFD, route-map), `cli_request.go` (OSPF/BGP clear) | `server_routing.go` (OSPF/BGP/IS-IS response boundary), `server_show_routes_text.go` (BFD peers, route-map) |
+
+  On the gRPC routing handlers the guard sits on the RESPONSE rather than on
+  each vtysh branch, so a `case` added to one of those switches later is covered
+  by construction — the fail-open direction is exactly what left this class half
+  fixed after the first pass. The structured branches pay nothing: clean text
+  takes the sanitizer's allocation-free fast path.
+
+  The sanitizer lives in the leaf package `pkg/termsafe` (stdlib-only) because
+  `pkg/cli` imports `pkg/grpcapi`, so a helper in `pkg/cli` could not be shared
+  upward. Fail-on-revert guards for every call site live in
+  `cli_residual_escape_6468_test.go` / `cli_show_dhcp_escape_6468_test.go` and
+  their `pkg/grpcapi` mirrors.
+
+  Not guarded, deliberately: LLDP neighbor fields are already sanitized at the
+  ingest boundary (`lldp.sanitizeTLVString`); the DHCPv6 DUID view and the
+  Surface A DDNS *name* are firewall-self/operator-authored, not
+  device-controlled. (The Surface A `LastError` in the table above is a
+  different field on the same view — its bytes come from the provider, not from
+  us.) Sanitizing happens at the display boundary only, so machine consumers —
+  the status views, the REST `TextResponse`, the gRPC structs — still get the
+  raw value.
 - Session filters (`session_filter.go`) serve BOTH show and clear. The
   clear path must call `validate()` (unknown zone/pool names are
   command errors — an inert filter degrades into clear-nothing or, via

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -180,10 +180,17 @@ presenter's rendered output is byte-identical:
   in a field is itself a forgery vector — it fakes a table row.
   `SanitizeBlockForDisplay` is for a MULTI-LINE blob whose own line structure is
   the output: it PRESERVES LF and TAB so a BGP table is not collapsed into one
-  `\x0a`-laden line, and escapes CR plus U+2028/U+2029 because those forge or
-  overwrite rows rather than carry structure. Using the single-line variant on a
-  block mangles the output; using the block variant on a field re-opens the
+  `\x0a`-laden line, and escapes CR because a bare carriage return overwrites a
+  line rather than carrying structure. Using the single-line variant on a block
+  mangles the output; using the block variant on a field re-opens the
   row-forgery hole. The tests assert both directions.
+
+  **Both** variants escape U+2028/U+2029. Neither is Unicode category Cc, so
+  `unicode.IsControl` does not reach them, but a terminal or pager that honors
+  either as a break can forge a row with it — in a block whose line structure is
+  the output, and equally in a single-line field the caller pads into a row.
+  Escaping LF but passing U+2028 in the field variant would be incoherent: that
+  variant is the stricter of the two about line breaks.
 
   **The guard goes on BOTH terminal-facing renderers.** Every one of these
   commands runs on the local CLI *and* the remote `cli`, which prints
@@ -223,19 +230,60 @@ presenter's rendered output is byte-identical:
     protocol. `bgp default show-hostname` already makes FRR emit a peer-supplied
     hostname in the BGP summary; today the only thing keeping it out is that
     `frr.bgpPeerJSON` does not declare the field, which is a load-bearing
-    invariant documented at its definition.
+    invariant documented at its definition and pinned by
+    `pkg/frr/bgp_summary_hostname_6468_test.go`.
+
+  Guard the cells **before** the caller's width format, not the finished row.
+  `%-20s` pads whatever it is handed, so escaping afterwards pads the RAW cell
+  and then expands each escape, pushing every later column right by the
+  expansion. `assertCellGuardRanBeforeWidthFormat6579` binds that ordering.
+
+  **What the guard does NOT do — do not overstate this in a review.** It makes
+  a row safe to **print**. It does not make the row **correct**, and a call to
+  `SanitizeRowForDisplay` is not evidence that a displayed value is genuine:
+
+  - The column shift above is the *reason* to guard every cell. It is not
+    something guarding every cell *repairs*. A peer hostname containing a space
+    still shifts `strings.Fields`, so `State` can end up displaying a token the
+    peer chose, and `SanitizeForDisplay` preserves plausible printable text —
+    it cannot tell a real `Up` from an attacker-supplied one. **A row can be
+    terminal-safe and materially false.**
+  - Fixing *that* needs the parse to change (FRR's JSON output, or
+    right-anchored column parsing that reports malformed rows instead of
+    rendering them silently). That is tracked as **#6590** and is deliberately
+    out of scope for the display guard.
+  - Bidi overrides and other Cf runes are also out of scope: they reorder
+    characters within a line but cannot forge or erase a row.
 
   The block and field variants are observationally identical for a
   `strings.Fields`-derived cell (the split already consumed every whitespace
   rune), but NOT for a JSON-decoded one — a BGP-summary cell can carry a real
   LF, which the block variant preserves by design and would render as a forged
-  table row. That case is the isolating test for the row guard.
+  table row.
+
+  That matters for testing, because on the gRPC handlers the response-boundary
+  block guard **masks** a dropped per-cell guard: the ESC is neutralized either
+  way, so a raw-control-byte assertion cannot tell the two apart. Two shapes see
+  through the mask, and every row binder uses one:
+
+  - a real LF in a JSON-decoded cell (BGP summary), which the block variant
+    preserves by design;
+  - **column alignment**, which works even where the LF shape is unreachable —
+    for a `strings.Fields`-derived cell such as IS-IS `SystemID`, the split
+    already consumed every whitespace rune, so alignment is the only
+    discriminator left.
+
+  `pkg/grpcapi/GetRIPStatus` has no response-boundary guard (it has no
+  raw-`vtysh` branch for one to protect), so its per-cell guard is isolated by
+  construction; the local CLI row paths print directly and are likewise
+  unmasked.
 
   The sanitizer lives in the leaf package `pkg/termsafe` (stdlib-only) because
   `pkg/cli` imports `pkg/grpcapi`, so a helper in `pkg/cli` could not be shared
   upward. Fail-on-revert guards for every call site live in
-  `cli_residual_escape_6468_test.go` / `cli_show_dhcp_escape_6468_test.go` and
-  their `pkg/grpcapi` mirrors.
+  `cli_residual_escape_6468_test.go` / `cli_row_escape_6579_test.go` /
+  `cli_show_dhcp_escape_6468_test.go` and their `pkg/grpcapi` mirrors; all ten
+  parsed-row sites (five per renderer) are individually bound.
 
   Not guarded, deliberately: LLDP neighbor fields are already sanitized at the
   ingest boundary (`lldp.sanitizeTLVString`); the DHCPv6 DUID view and the

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -195,14 +195,41 @@ presenter's rendered output is byte-identical:
   |---|---|---|---|
   | DHCP lease `Hostname` / `HWAddress` | field | `show_services_dhcp.go` | `server_show_dhcp_lldp_snmp.go` |
   | DHCP-DDNS owned-record `FQDN` | field | `show_services_ddns.go` | `server_show_dhcp_lldp_snmp.go` |
-  | Surface A DDNS `LastError` (provider response body — Cloudflare / Route 53 embed it with `%s`) | field | `show_services_ddns.go` | `server_show_dhcp_lldp_snmp.go` |
+  | Surface A DDNS `LastError` (provider response body — Cloudflare / Route 53 embed it with `%s`; dyndns2 / duckdns wrap it in `%q`, generic omits it, rfc2136 uses fixed rcode strings) | field | `show_services_ddns.go` | `server_show_dhcp_lldp_snmp.go` |
   | Raw `vtysh` stdout (BGP hostname capability, IS-IS dynamic hostname TLVs, OSPF router IDs) | block | `cli_show_routing.go` (OSPF ×4, BGP ×3, IS-IS ×3, BFD, route-map), `cli_request.go` (OSPF/BGP clear) | `server_routing.go` (OSPF/BGP/IS-IS response boundary), `server_show_routes_text.go` (BFD peers, route-map) |
+  | **Parsed** FRR table rows — every cell, via `termsafe.SanitizeRowForDisplay` (OSPF neighbors, BGP summary, BGP routes, RIP routes, IS-IS adjacency) | field (per cell) | `cli_show_routing.go` ×5 | `server_routing.go` ×5 |
 
-  On the gRPC routing handlers the guard sits on the RESPONSE rather than on
-  each vtysh branch, so a `case` added to one of those switches later is covered
-  by construction — the fail-open direction is exactly what left this class half
-  fixed after the first pass. The structured branches pay nothing: clean text
-  takes the sanitizer's allocation-free fast path.
+  On the gRPC routing handlers the block guard sits on the RESPONSE rather than
+  on each vtysh branch, so a `case` added to one of those switches later is
+  covered by construction — the fail-open direction is exactly what left this
+  class half fixed after the first pass. The structured branches pay nothing:
+  clean text takes the sanitizer's allocation-free fast path.
+
+  **A parsed field is not covered by a raw-output sweep.** The last row of that
+  table is a distinct class, and it is the one a "sanitize the raw output"
+  framing structurally cannot see. `frr.GetISISAdjacency` scrapes
+  `show isis neighbor` with `strings.Fields` and reprints the cells into a
+  caller-formatted row; FRR puts the hostname the peer advertised in its Dynamic
+  Hostname TLV (RFC 5301) in the first column, so `SystemID` is peer-controlled
+  text — and `strings.Fields` splits on whitespace ONLY, so ESC/DEL/BEL/C1 ride
+  inside the token untouched. **Tokenizing is not sanitizing.**
+
+  Guard the WHOLE row, never the one column you believe is device-controlled:
+
+  - Column identity is not stable. A value carrying a space in an early column
+    shifts every later column, so peer bytes land in cells a per-column analysis
+    marked safe.
+  - "This column is numeric" is a property of the current FRR, not of the
+    protocol. `bgp default show-hostname` already makes FRR emit a peer-supplied
+    hostname in the BGP summary; today the only thing keeping it out is that
+    `frr.bgpPeerJSON` does not declare the field, which is a load-bearing
+    invariant documented at its definition.
+
+  The block and field variants are observationally identical for a
+  `strings.Fields`-derived cell (the split already consumed every whitespace
+  rune), but NOT for a JSON-decoded one — a BGP-summary cell can carry a real
+  LF, which the block variant preserves by design and would render as a forged
+  table row. That case is the isolating test for the row guard.
 
   The sanitizer lives in the leaf package `pkg/termsafe` (stdlib-only) because
   `pkg/cli` imports `pkg/grpcapi`, so a helper in `pkg/cli` could not be shared
@@ -215,9 +242,14 @@ presenter's rendered output is byte-identical:
   Surface A DDNS *name* are firewall-self/operator-authored, not
   device-controlled. (The Surface A `LastError` in the table above is a
   different field on the same view — its bytes come from the provider, not from
-  us.) Sanitizing happens at the display boundary only, so machine consumers —
-  the status views, the REST `TextResponse`, the gRPC structs — still get the
-  raw value.
+  us.) `frr.FormatRouteDetail` is JSON-typed with no free-text cell (prefix,
+  protocol enum, local interface name, integer distance/metric), and
+  `routing.RouteEntry` comes from netlink rather than from a peer. The
+  `pkg/api` REST handlers render the same FRR tables into a JSON
+  `TextResponse`, which is a machine surface with no shipped terminal consumer.
+  Sanitizing happens at the display boundary only, so machine consumers — the
+  status views, the REST `TextResponse`, the gRPC structs — still get the raw
+  value.
 - Session filters (`session_filter.go`) serve BOTH show and clear. The
   clear path must call `validate()` (unknown zone/pool names are
   command errors — an inert filter degrades into clear-nothing or, via

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/psaab/xpf/pkg/termsafe"
 )
 
 // rejectScopedClear returns the error for a global-only `request ... clear`
@@ -110,7 +112,10 @@ func (c *CLI) handleRequestProtocols(args []string) error {
 			return fmt.Errorf("clear OSPF: %w", err)
 		}
 		if output != "" {
-			fmt.Print(output)
+			// #6468 D2: raw vtysh stdout to the operator terminal. `clear`
+			// normally prints nothing, but the guard belongs on the print,
+			// not on an assumption about what FRR chooses to emit.
+			fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		}
 		fmt.Println("OSPF process cleared")
 		return nil
@@ -133,7 +138,8 @@ func (c *CLI) handleRequestProtocols(args []string) error {
 			return fmt.Errorf("clear BGP: %w", err)
 		}
 		if output != "" {
-			fmt.Print(output)
+			// #6468 D2: see the OSPF clear above — same guard, same reason.
+			fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		}
 		fmt.Println("BGP sessions cleared (soft reset)")
 		return nil

--- a/pkg/cli/cli_residual_escape_6468_test.go
+++ b/pkg/cli/cli_residual_escape_6468_test.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ddnspkg "github.com/psaab/xpf/pkg/ddns"
+	"github.com/psaab/xpf/pkg/frr"
+)
+
+// #6468 residual surfaces, local-CLI half. Two device- or remote-supplied
+// strings still reached the in-process operator terminal raw after the DHCP
+// lease-field fix:
+//
+//   - D1, the Surface A DDNS "Last error" column, which can carry a PROVIDER
+//     response body — Cloudflare (backend_cloudflare.go) and Route 53
+//     (backend_route53.go) embed the provider's own message with %s;
+//   - D2, captured `vtysh` stdout, which carries text a REMOTE PEER
+//     advertised: the BGP hostname capability, IS-IS dynamic hostname TLVs,
+//     OSPF router IDs.
+//
+// These are the fail-on-revert guards. Dropping a sanitize call in
+// cli_show_routing.go / show_services_ddns.go / cli_request.go makes the raw
+// ESC reappear on stdout; using the WRONG variant is caught too — see the
+// per-assertion notes. The remote-cli mirror of every case below lives in
+// pkg/grpcapi (server_routing_escape_6468_test.go,
+// server_show_ddns_escape_6468_test.go); both renderers are in scope for this
+// class, and fixing one alone is what left the class half-open.
+//
+// hasRawTermControl6468 and captureStdout are shared with sibling test files.
+
+// evilVtyshBlock6468 is a realistic multi-line vtysh table with a CSI
+// erase-line escape buried in the peer-advertised hostname cell. The
+// surrounding rows are clean so a test can assert BOTH that the escape was
+// neutralized AND that the block's line structure survived.
+const evilVtyshBlock6468 = "BGP neighbor is 10.0.0.1, remote AS 65001\n" +
+	"  Hostname: rtr1\x1b[2Kforged-peer\n" +
+	"  BGP state = Established, up for 00:12:34\n"
+
+// vtyshEscapeExecutor6468 is an frr executor double whose Vtysh returns the
+// hostile block for every command. It satisfies pkg/frr's package-private
+// frrExecutor (all four methods are exported names, so an out-of-package type
+// can implement it) and is handed to frr.NewForTest, which is the seam that
+// lets a show handler run its real wiring without shelling out to vtysh.
+type vtyshEscapeExecutor6468 struct{}
+
+func (vtyshEscapeExecutor6468) Vtysh(string) (string, error) {
+	return evilVtyshBlock6468, nil
+}
+
+func (vtyshEscapeExecutor6468) FrrReloadPy(context.Context, string) error { return nil }
+
+func (vtyshEscapeExecutor6468) VtyshLoad(context.Context, string) ([]byte, error) {
+	return nil, nil
+}
+
+func (vtyshEscapeExecutor6468) VtyshStream(context.Context, string) (io.ReadCloser, func() error, error) {
+	return io.NopCloser(strings.NewReader("")), func() error { return nil }, nil
+}
+
+// escapeVtyshCLI6468 wires a CLI whose FRR manager returns the hostile block
+// from every vtysh call.
+func escapeVtyshCLI6468(t *testing.T) *CLI {
+	t.Helper()
+	m := frr.NewForTest(filepath.Join(t.TempDir(), "frr.conf"), vtyshEscapeExecutor6468{})
+	return &CLI{frr: m}
+}
+
+// assertVtyshOutputSanitized6468 is the shared verdict for a printed block. It
+// binds THREE distinct failure modes:
+//
+//	(1) non-vacuous — the fixture actually rendered;
+//	(2) no raw terminal control byte survived — the revert signal for dropping
+//	    the sanitize call entirely;
+//	(3) the escape is VISIBLE and the LINE COUNT is unchanged — the revert
+//	    signal for swapping in the single-line sanitizer, which escapes every
+//	    LF and would collapse the table into one \x0a-laden row.
+func assertVtyshOutputSanitized6468(t *testing.T, surface, out string) {
+	t.Helper()
+	if !strings.Contains(out, "BGP neighbor is 10.0.0.1") {
+		t.Fatalf("%s: the vtysh block must render (else the guard is vacuous):\n%q", surface, out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("%s: printed raw terminal control bytes — unsanitized vtysh stdout carrying "+
+			"peer-advertised text reaches the operator terminal (#6468 D2):\n%q", surface, out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("%s: expected the escaped ESC (\\x1b) to render, proving the peer hostname was "+
+			"sanitized rather than dropped:\n%q", surface, out)
+	}
+	if want, have := strings.Count(evilVtyshBlock6468, "\n"), strings.Count(out, "\n"); want != have {
+		t.Fatalf("%s: the block's line structure must survive — want %d newlines, got %d. "+
+			"The single-line termsafe.SanitizeForDisplay escapes LF and would collapse this "+
+			"table; these surfaces need SanitizeBlockForDisplay:\n%q", surface, want, have, out)
+	}
+}
+
+func TestShowOSPF_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {
+	// Every raw-vtysh branch of showOSPF. The bare "neighbor" branch builds a
+	// structured table instead of printing vtysh stdout and is not in scope.
+	for _, args := range [][]string{
+		{"neighbor", "detail"},
+		{"database"},
+		{"interface"},
+		{"routes"},
+	} {
+		c := escapeVtyshCLI6468(t)
+		out := captureStdout(t, func() {
+			if err := c.showOSPF(args); err != nil {
+				t.Fatalf("showOSPF(%v): %v", args, err)
+			}
+		})
+		assertVtyshOutputSanitized6468(t, "showOSPF "+strings.Join(args, " "), out)
+	}
+}
+
+func TestShowBGP_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {
+	for _, args := range [][]string{
+		{"neighbor", "10.0.0.1", "received-routes"},
+		{"neighbor", "10.0.0.1", "advertised-routes"},
+		{"neighbor", "10.0.0.1"},
+		{"neighbor"},
+	} {
+		c := escapeVtyshCLI6468(t)
+		out := captureStdout(t, func() {
+			if err := c.showBGP(args); err != nil {
+				t.Fatalf("showBGP(%v): %v", args, err)
+			}
+		})
+		assertVtyshOutputSanitized6468(t, "showBGP "+strings.Join(args, " "), out)
+	}
+}
+
+func TestShowISIS_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {
+	for _, args := range [][]string{
+		{"adjacency", "detail"},
+		{"database"},
+		{"routes"},
+	} {
+		c := escapeVtyshCLI6468(t)
+		out := captureStdout(t, func() {
+			if err := c.showISIS(args); err != nil {
+				t.Fatalf("showISIS(%v): %v", args, err)
+			}
+		})
+		assertVtyshOutputSanitized6468(t, "showISIS "+strings.Join(args, " "), out)
+	}
+}
+
+func TestShowBFD_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {
+	c := escapeVtyshCLI6468(t)
+	out := captureStdout(t, func() {
+		if err := c.showBFD([]string{"peers"}); err != nil {
+			t.Fatalf("showBFD: %v", err)
+		}
+	})
+	assertVtyshOutputSanitized6468(t, "showBFD peers", out)
+}
+
+func TestShowRouteMap_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {
+	c := escapeVtyshCLI6468(t)
+	out := captureStdout(t, func() {
+		if err := c.showRouteMap(); err != nil {
+			t.Fatalf("showRouteMap: %v", err)
+		}
+	})
+	assertVtyshOutputSanitized6468(t, "showRouteMap", out)
+}
+
+func TestRequestProtocolsClear_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {
+	// `request protocols {ospf,bgp} clear` prints whatever the clear emitted,
+	// then its own confirmation line. FRR normally emits nothing here, so the
+	// payload likelihood is low — but the guard belongs on the print, not on an
+	// assumption about what FRR chooses to emit.
+	for _, tc := range []struct {
+		args    []string
+		confirm string
+	}{
+		{[]string{"ospf", "clear"}, "OSPF process cleared\n"},
+		{[]string{"bgp", "clear"}, "BGP sessions cleared (soft reset)\n"},
+	} {
+		c := escapeVtyshCLI6468(t)
+		out := captureStdout(t, func() {
+			if err := c.handleRequestProtocols(tc.args); err != nil {
+				t.Fatalf("handleRequestProtocols(%v): %v", tc.args, err)
+			}
+		})
+		surface := "request protocols " + strings.Join(tc.args, " ")
+		// Strip the handler's own confirmation line so the shared line-count
+		// assertion measures the vtysh block alone; its presence is asserted
+		// here rather than dropped.
+		trimmed, ok := strings.CutSuffix(out, tc.confirm)
+		if !ok {
+			t.Fatalf("%s: expected the confirmation line %q to terminate the output:\n%q",
+				surface, tc.confirm, out)
+		}
+		assertVtyshOutputSanitized6468(t, surface, trimmed)
+	}
+}
+
+// evilProviderError6468 is a provider error body carrying an OSC 52
+// clipboard-write AND an embedded newline. The newline is the reason this
+// surface takes the SINGLE-LINE sanitizer: LastError is rendered into one
+// %s-formatted cell of a fixed-width table, so a raw LF fakes a whole scope row.
+const evilProviderError6468 = "cloudflare 1004: \x1b]52;c;YWFhYWFh\x07bad zone\n" +
+	"    forged.example.com               inet   OK              203.0.113.9"
+
+func TestShowServicesDynamicDNS_LocalCLIEscapesLastError_6468(t *testing.T) {
+	dir := t.TempDir()
+	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))
+
+	c := &CLI{
+		store:               store,
+		surfaceADDNSStatsFn: func() *ddnspkg.SurfaceAStats { return &ddnspkg.SurfaceAStats{Scopes: 1} },
+		surfaceADDNSStatusFn: func() []ddnspkg.SurfaceAStatusView {
+			return []ddnspkg.SurfaceAStatusView{{
+				Interface: "ge-0-0-0",
+				Family:    4,
+				FQDN:      "wan.example.com",
+				Provider:  "cf",
+				State:     "published",
+				Published: "198.51.100.7",
+				LastError: evilProviderError6468,
+			}}
+		},
+	}
+	out := captureStdout(t, func() {
+		if err := c.showServicesDynamicDNS(true); err != nil {
+			t.Fatalf("showServicesDynamicDNS: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "wan.example.com") {
+		t.Fatalf("the scope row must render (else the guard is vacuous):\n%q", out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("local DDNS renderer printed raw terminal control bytes — an unsanitized "+
+			"PROVIDER response body reaches the operator terminal (#6468 D1):\n%q", out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("expected the escaped ESC (\\x1b) to render, proving LastError was sanitized "+
+			"rather than dropped:\n%q", out)
+	}
+	// The embedded LF must render as an escape, not as a real line break: this
+	// column is one cell of a fixed-width table, so a surviving newline forges a
+	// scope row. It is also the discriminator against the BLOCK sanitizer, which
+	// preserves LF by design and would let the forged row through.
+	if !strings.Contains(out, `\x0a`) {
+		t.Fatalf("expected the embedded newline to render as \\x0a — LastError is a single-line "+
+			"FIELD and must take termsafe.SanitizeForDisplay, not the block variant "+
+			"(a surviving LF forges a scope row):\n%q", out)
+	}
+	if strings.Contains(out, "\n    forged") {
+		t.Fatalf("the provider body forged a table row — the embedded newline survived:\n%q", out)
+	}
+}

--- a/pkg/cli/cli_residual_escape_6468_test.go
+++ b/pkg/cli/cli_residual_escape_6468_test.go
@@ -40,14 +40,52 @@ const evilVtyshBlock6468 = "BGP neighbor is 10.0.0.1, remote AS 65001\n" +
 	"  Hostname: rtr1\x1b[2Kforged-peer\n" +
 	"  BGP state = Established, up for 00:12:34\n"
 
-// vtyshEscapeExecutor6468 is an frr executor double whose Vtysh returns the
-// hostile block for every command. It satisfies pkg/frr's package-private
-// frrExecutor (all four methods are exported names, so an out-of-package type
-// can implement it) and is handed to frr.NewForTest, which is the seam that
-// lets a show handler run its real wiring without shelling out to vtysh.
+// evilISISNeighborTable6468 is a `show isis neighbor` table whose FIRST column
+// carries a CSI erase-line escape. That column is not a numeric system ID: FRR
+// substitutes the hostname the peer advertised in its Dynamic Hostname TLV
+// (RFC 5301), so it is peer-controlled text — and GetISISAdjacency reaches it
+// through strings.Fields, which splits on whitespace and leaves ESC/DEL/C1
+// inside the token untouched. Tokenizing is not sanitizing.
+//
+// The header row must survive the parser's own skips: it drops lines starting
+// with "Area" and rows whose first field is "System".
+const evilISISNeighborTable6468 = "Area 1:\n" +
+	" System Id           Interface   L  State        Holdtime SNPA\n" +
+	" rtr1\x1b[2Kforged     ge-0-0-1    2  Up           27       2020.2020.2020\n"
+
+// evilBGPSummaryJSON6468 is a `show bgp summary json` reply whose peer "state"
+// string carries an embedded NEWLINE plus a complete fake peer row. It is the
+// case that ISOLATES the per-cell row guard from the response-boundary block
+// guard: SanitizeBlockForDisplay PRESERVES LF by design (that is what keeps a
+// vtysh table from collapsing), so it cannot catch this — only the single-line
+// cell guard escapes the newline and stops the forged row.
+//
+// This cell is reachable in a way a strings.Fields-scraped cell is not: JSON
+// decoding turns \n into a real newline, and the split that would have
+// consumed it never happens.
+const evilBGPSummaryJSON6468 = `{"ipv4Unicast":{"peers":{"10.0.0.1":{` +
+	`"remoteAs":65001,"msgRcvd":10,"msgSent":11,"peerUptime":"00:12:34",` +
+	`"state":"Established\n  10.0.0.99             ipv4-unicast  65099    0         0         never       Idle         0",` +
+	`"pfxRcd":5,"pfxSnt":5}}}}`
+
+// vtyshEscapeExecutor6468 is an frr executor double that returns hostile
+// stdout. It satisfies pkg/frr's package-private frrExecutor (all four methods
+// are exported names, so an out-of-package type can implement it) and is handed
+// to frr.NewForTest, which is the seam that lets a show handler run its real
+// wiring without shelling out to vtysh.
+//
+// `show isis neighbor` gets a PARSED-table fixture because that command feeds
+// GetISISAdjacency rather than being printed verbatim; every other command gets
+// the raw block.
 type vtyshEscapeExecutor6468 struct{}
 
-func (vtyshEscapeExecutor6468) Vtysh(string) (string, error) {
+func (vtyshEscapeExecutor6468) Vtysh(cmd string) (string, error) {
+	switch cmd {
+	case "show isis neighbor":
+		return evilISISNeighborTable6468, nil
+	case "show bgp summary json":
+		return evilBGPSummaryJSON6468, nil
+	}
 	return evilVtyshBlock6468, nil
 }
 
@@ -148,6 +186,67 @@ func TestShowISIS_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {
 		})
 		assertVtyshOutputSanitized6468(t, "showISIS "+strings.Join(args, " "), out)
 	}
+}
+
+// TestShowISIS_LocalCLIEscapesParsedAdjacencyRow_6468 covers the surface the
+// "raw vtysh output" sweep could not see: a PARSED field, reprinted into a
+// caller-formatted row. `show protocols isis adjacency` (no "detail") renders
+// ISISAdjacency structs rather than vtysh stdout, so the block guard on the
+// detail branch is not what protects it — the per-cell row guard is.
+func TestShowISIS_LocalCLIEscapesParsedAdjacencyRow_6468(t *testing.T) {
+	c := escapeVtyshCLI6468(t)
+	out := captureStdout(t, func() {
+		if err := c.showISIS([]string{"adjacency"}); err != nil {
+			t.Fatalf("showISIS(adjacency): %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "ge-0-0-1") {
+		t.Fatalf("the adjacency row must render (else the guard is vacuous):\n%q", out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("printed raw terminal control bytes — the peer-advertised IS-IS dynamic "+
+			"hostname reaches the operator terminal through the PARSED SystemID field, "+
+			"which the raw-output sweep does not cover (#6468):\n%q", out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("expected the escaped ESC (\\x1b) to render, proving the parsed cell was "+
+			"sanitized rather than dropped:\n%q", out)
+	}
+}
+
+// assertBGPSummaryRowSanitized6468 is the shared verdict for the rendered BGP
+// summary. hasRawTermControl6468 deliberately tolerates \n and \t (a rendered
+// table needs them), so a surviving newline would slip past it — the line-count
+// and \x0a assertions are what actually bind this case.
+func assertBGPSummaryRowSanitized6468(t *testing.T, surface, out string) {
+	t.Helper()
+	if !strings.Contains(out, "10.0.0.1") {
+		t.Fatalf("%s: the peer row must render (else the guard is vacuous):\n%q", surface, out)
+	}
+	if !strings.Contains(out, `\x0a`) {
+		t.Fatalf("%s: the newline embedded in the peer's state cell must render as \\x0a. "+
+			"The response-boundary block sanitizer PRESERVES LF by design, so only the "+
+			"per-cell row guard catches this (#6468):\n%q", surface, out)
+	}
+	// Header + exactly one peer row. A third line means the JSON cell forged one.
+	if n := strings.Count(strings.TrimRight(out, "\n"), "\n"); n != 1 {
+		t.Fatalf("%s: want header + exactly 1 peer row (1 interior newline), got %d — "+
+			"the provider-controlled cell forged a table row:\n%q", surface, n, out)
+	}
+	if strings.Contains(out, "\n  10.0.0.99") {
+		t.Fatalf("%s: a forged peer row reached the terminal:\n%q", surface, out)
+	}
+}
+
+func TestShowBGP_LocalCLIEscapesParsedSummaryRow_6468(t *testing.T) {
+	c := escapeVtyshCLI6468(t)
+	out := captureStdout(t, func() {
+		if err := c.showBGP([]string{"summary"}); err != nil {
+			t.Fatalf("showBGP(summary): %v", err)
+		}
+	})
+	assertBGPSummaryRowSanitized6468(t, "showBGP summary", out)
 }
 
 func TestShowBFD_LocalCLIEscapesVtyshOutput_6468(t *testing.T) {

--- a/pkg/cli/cli_row_escape_6579_test.go
+++ b/pkg/cli/cli_row_escape_6579_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/frr"
+)
+
+// #6579 fold, local-CLI half. Mirrors server_row_escape_6579_test.go: the three
+// PARSED row sites the first pass left without a call-site binder — OSPF
+// neighbors, BGP routes, RIP routes.
+//
+// A parsed row is not covered by the raw-vtysh sweep. frr.Get*() scrapes vtysh
+// stdout with strings.Fields and showOSPF/showBGP/showRIP REPRINT the cells into
+// their own format strings, so dropping termsafe.SanitizeRowForDisplay at one of
+// these sites is invisible to every test in cli_residual_escape_6468_test.go.
+//
+// Unlike the gRPC handlers, the local CLI has NO response boundary: these row
+// paths call fmt.Printf directly, with no SanitizeBlockForDisplay downstream to
+// mask a dropped per-cell guard. The raw-ESC assertion therefore isolates the
+// guard here by construction, which is why the alignment discriminator the gRPC
+// mirror needs is not repeated.
+
+// evilRowCell6579 is the hostile token: a CSI erase-line escape inside the cell.
+const evilRowCell6579 = "rtr1\x1b[2Kforged"
+
+// evilOSPFNeighborTable6579 puts the escape in the Neighbor ID column of
+// `show ip ospf neighbor`. GetOSPFNeighbors needs >= 5 fields and skips the
+// header (fields[0] == "Neighbor").
+//
+// An OSPF router ID is a dotted quad today, so this is a CALL-SITE BINDER, not
+// a claim that FRR emits free text here now — exactly the documented reason the
+// guard is uniform: "this column is numeric" is a property of the current
+// upstream, not of the protocol.
+const evilOSPFNeighborTable6579 = "Neighbor ID     Pri State    Dead Time Address    Interface\n" +
+	evilRowCell6579 + " 128 Full/DR 32.100s 10.0.1.2 ge-0-0-0\n"
+
+// evilRIPTable6579 puts the escape in the Network column of `show ip rip`.
+const evilRIPTable6579 = "Codes: R - RIP, C - connected\n" +
+	"     Network            Next Hop         Metric From\n" +
+	evilRowCell6579 + " 10.0.1.2 2 ge-0-0-1\n"
+
+// evilBGPRouteTable6579 puts the escape in the NEXT-HOP column of
+// `show bgp ipv4 unicast` — the realistic taint, since `bgp default
+// show-nexthop-hostname` renders a peer-supplied hostname in that column.
+const evilBGPRouteTable6579 = "   Network          Next Hop            Metric LocPrf Weight Path\n" +
+	"*> 10.0.0.0/8       " + evilRowCell6579 + "         0    100      0 65001 65002 i\n"
+
+// rowEscapeExecutor6579 answers the parsed-table commands with hostile rows. It
+// deliberately does not reuse vtyshEscapeExecutor6468, whose catch-all returns a
+// raw BGP-neighbor block that these parsers would scrape into nonsense rows.
+type rowEscapeExecutor6579 struct{}
+
+func (rowEscapeExecutor6579) Vtysh(cmd string) (string, error) {
+	switch cmd {
+	case "show ip ospf neighbor":
+		return evilOSPFNeighborTable6579, nil
+	case "show ip rip":
+		return evilRIPTable6579, nil
+	case "show bgp ipv4 unicast":
+		return evilBGPRouteTable6579, nil
+	}
+	return "", nil
+}
+
+func (rowEscapeExecutor6579) FrrReloadPy(context.Context, string) error { return nil }
+
+func (rowEscapeExecutor6579) VtyshLoad(context.Context, string) ([]byte, error) { return nil, nil }
+
+func (rowEscapeExecutor6579) VtyshStream(context.Context, string) (io.ReadCloser, func() error, error) {
+	return io.NopCloser(strings.NewReader("")), func() error { return nil }, nil
+}
+
+func rowEscapeCLI6579(t *testing.T) *CLI {
+	t.Helper()
+	m := frr.NewForTest(filepath.Join(t.TempDir(), "frr.conf"), rowEscapeExecutor6579{})
+	return &CLI{frr: m}
+}
+
+// assertRowCellSanitized6579 is the call-site binder: the hostile cell rendered,
+// no raw control byte reached stdout, and the escape is visible rather than the
+// value silently dropped.
+func assertRowCellSanitized6579(t *testing.T, surface, out string) {
+	t.Helper()
+	if !strings.Contains(out, "forged") {
+		t.Fatalf("%s: the hostile row must render, else this binder is vacuous:\n%q", surface, out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("%s: a raw terminal control byte reached the operator's terminal. This row site "+
+			"lost its termsafe.SanitizeRowForDisplay guard, and a parsed FRR cell is peer-"+
+			"controlled text that the raw-vtysh sweep does not cover (#6468):\n%q", surface, out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("%s: expected the escaped ESC (\\x1b), proving the cell was sanitized rather "+
+			"than dropped:\n%q", surface, out)
+	}
+}
+
+func TestShowOSPF_LocalCLIEscapesParsedNeighborRow_6579(t *testing.T) {
+	c := rowEscapeCLI6579(t)
+	out := captureStdout(t, func() {
+		if err := c.showOSPF([]string{"neighbor"}); err != nil {
+			t.Fatalf("showOSPF(neighbor): %v", err)
+		}
+	})
+	assertRowCellSanitized6579(t, "show ospf neighbor", out)
+}
+
+func TestShowBGP_LocalCLIEscapesParsedRouteRow_6579(t *testing.T) {
+	c := rowEscapeCLI6579(t)
+	out := captureStdout(t, func() {
+		if err := c.showBGP([]string{"routes"}); err != nil {
+			t.Fatalf("showBGP(routes): %v", err)
+		}
+	})
+	assertRowCellSanitized6579(t, "show bgp routes", out)
+}
+
+func TestShowRIP_LocalCLIEscapesParsedRouteRow_6579(t *testing.T) {
+	c := rowEscapeCLI6579(t)
+	out := captureStdout(t, func() {
+		if err := c.showRIP(); err != nil {
+			t.Fatalf("showRIP: %v", err)
+		}
+	})
+	assertRowCellSanitized6579(t, "show rip", out)
+}

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -303,7 +303,8 @@ func (c *CLI) showOSPF(args []string) error {
 			"Neighbor ID", "Priority", "State", "Address", "Interface")
 		for _, n := range neighbors {
 			fmt.Printf("  %-18s %-10s %-16s %-18s %s\n",
-				n.NeighborID, n.Priority, n.State, n.Address, n.Interface)
+				termsafe.SanitizeRowForDisplay(
+					n.NeighborID, n.Priority, n.State, n.Address, n.Interface)...)
 		}
 		return nil
 
@@ -361,7 +362,8 @@ func (c *CLI) showBGP(args []string) error {
 			"Neighbor", "AF", "AS", "MsgRcvd", "MsgSent", "Up/Down", "State", "PfxRcd")
 		for _, p := range peers {
 			fmt.Printf("  %-20s %-13s %-8s %-9s %-9s %-11s %-12s %s\n",
-				p.Neighbor, p.AddressFamily, p.AS, p.MsgRcvd, p.MsgSent, p.UpDown, p.State, p.PfxRcd)
+				termsafe.SanitizeRowForDisplay(
+					p.Neighbor, p.AddressFamily, p.AS, p.MsgRcvd, p.MsgSent, p.UpDown, p.State, p.PfxRcd)...)
 		}
 		return nil
 
@@ -376,7 +378,8 @@ func (c *CLI) showBGP(args []string) error {
 		}
 		fmt.Printf("  %-24s %-20s %s\n", "Network", "Next-hop", "Path")
 		for _, r := range routes {
-			fmt.Printf("  %-24s %-20s %s\n", r.Network, r.NextHop, r.Path)
+			fmt.Printf("  %-24s %-20s %s\n",
+				termsafe.SanitizeRowForDisplay(r.Network, r.NextHop, r.Path)...)
 		}
 		return nil
 
@@ -432,7 +435,8 @@ func (c *CLI) showRIP() error {
 	}
 	fmt.Printf("  %-20s %-18s %-8s %s\n", "Network", "Next Hop", "Metric", "Interface")
 	for _, r := range routes {
-		fmt.Printf("  %-20s %-18s %-8s %s\n", r.Network, r.NextHop, r.Metric, r.Interface)
+		fmt.Printf("  %-20s %-18s %-8s %s\n",
+			termsafe.SanitizeRowForDisplay(r.Network, r.NextHop, r.Metric, r.Interface)...)
 	}
 	return nil
 }
@@ -470,7 +474,8 @@ func (c *CLI) showISIS(args []string) error {
 			"System ID", "Interface", "Level", "State", "Hold Time")
 		for _, a := range adjs {
 			fmt.Printf("  %-20s %-14s %-10s %-10s %s\n",
-				a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)
+				termsafe.SanitizeRowForDisplay(
+					a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)...)
 		}
 		return nil
 

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/frr"
 	"github.com/psaab/xpf/pkg/routing"
+	"github.com/psaab/xpf/pkg/termsafe"
 	"github.com/psaab/xpf/pkg/vrrp"
 	"github.com/vishvananda/netlink"
 )
@@ -287,7 +288,7 @@ func (c *CLI) showOSPF(args []string) error {
 			if err != nil {
 				return fmt.Errorf("OSPF neighbor detail: %w", err)
 			}
-			fmt.Print(output)
+			fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 			return nil
 		}
 		neighbors, err := c.frr.GetOSPFNeighbors()
@@ -311,7 +312,7 @@ func (c *CLI) showOSPF(args []string) error {
 		if err != nil {
 			return fmt.Errorf("OSPF database: %w", err)
 		}
-		fmt.Print(output)
+		fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		return nil
 
 	case "interface":
@@ -319,7 +320,7 @@ func (c *CLI) showOSPF(args []string) error {
 		if err != nil {
 			return fmt.Errorf("OSPF interface: %w", err)
 		}
-		fmt.Print(output)
+		fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		return nil
 
 	case "routes":
@@ -327,7 +328,7 @@ func (c *CLI) showOSPF(args []string) error {
 		if err != nil {
 			return fmt.Errorf("OSPF routes: %w", err)
 		}
-		fmt.Print(output)
+		fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		return nil
 
 	default:
@@ -392,14 +393,14 @@ func (c *CLI) showBGP(args []string) error {
 				if err != nil {
 					return fmt.Errorf("BGP received routes: %w", err)
 				}
-				fmt.Print(output)
+				fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 				return nil
 			case "advertised-routes":
 				output, err := c.frr.GetBGPNeighborAdvertisedRoutes(ip)
 				if err != nil {
 					return fmt.Errorf("BGP advertised routes: %w", err)
 				}
-				fmt.Print(output)
+				fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 				return nil
 			}
 		}
@@ -407,7 +408,7 @@ func (c *CLI) showBGP(args []string) error {
 		if err != nil {
 			return fmt.Errorf("BGP neighbor: %w", err)
 		}
-		fmt.Print(output)
+		fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		return nil
 
 	default:
@@ -454,7 +455,7 @@ func (c *CLI) showISIS(args []string) error {
 			if err != nil {
 				return fmt.Errorf("IS-IS adjacency detail: %w", err)
 			}
-			fmt.Print(output)
+			fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 			return nil
 		}
 		adjs, err := c.frr.GetISISAdjacency()
@@ -478,7 +479,7 @@ func (c *CLI) showISIS(args []string) error {
 		if err != nil {
 			return fmt.Errorf("IS-IS database: %w", err)
 		}
-		fmt.Print(output)
+		fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		return nil
 
 	case "routes":
@@ -486,7 +487,7 @@ func (c *CLI) showISIS(args []string) error {
 		if err != nil {
 			return fmt.Errorf("IS-IS routes: %w", err)
 		}
-		fmt.Print(output)
+		fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		return nil
 
 	default:
@@ -512,7 +513,7 @@ func (c *CLI) showBFD(args []string) error {
 			fmt.Println("No BFD peers")
 			return nil
 		}
-		fmt.Print(output)
+		fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 		return nil
 	}
 	return fmt.Errorf("unknown show protocols bfd target: %s", args[0])
@@ -752,7 +753,7 @@ func (c *CLI) showRouteMap() error {
 		fmt.Println("No route-maps configured")
 		return nil
 	}
-	fmt.Print(output)
+	fmt.Print(termsafe.SanitizeBlockForDisplay(output))
 	return nil
 }
 

--- a/pkg/cli/show_services_ddns.go
+++ b/pkg/cli/show_services_ddns.go
@@ -78,7 +78,13 @@ func (c *CLI) showServicesDynamicDNS(detail bool) error {
 				if v.Family == 6 {
 					fam = "inet6"
 				}
-				lastErr := v.LastError
+				// #6468 D1: LastError can embed a DDNS PROVIDER response body. The
+				// dyndns2/duckdns/generic backends wrap it in %q, but Cloudflare
+				// (backend_cloudflare.go) and Route 53 (backend_route53.go) embed the
+				// provider message with %s, so a hostile or compromised provider can
+				// land raw ESC bytes on the operator terminal. Sanitize at the display
+				// site so the whole class is covered regardless of backend.
+				lastErr := termsafe.SanitizeForDisplay(v.LastError)
 				if lastErr == "" {
 					lastErr = "-"
 				}

--- a/pkg/cli/show_services_ddns.go
+++ b/pkg/cli/show_services_ddns.go
@@ -78,12 +78,16 @@ func (c *CLI) showServicesDynamicDNS(detail bool) error {
 				if v.Family == 6 {
 					fam = "inet6"
 				}
-				// #6468 D1: LastError can embed a DDNS PROVIDER response body. The
-				// dyndns2/duckdns/generic backends wrap it in %q, but Cloudflare
-				// (backend_cloudflare.go) and Route 53 (backend_route53.go) embed the
-				// provider message with %s, so a hostile or compromised provider can
-				// land raw ESC bytes on the operator terminal. Sanitize at the display
-				// site so the whole class is covered regardless of backend.
+				// #6468 D1: LastError can embed a DDNS PROVIDER response body.
+				// Cloudflare (backend_cloudflare.go:166) and Route 53
+				// (backend_route53.go:195,277) embed the provider's own message with
+				// %s, so a hostile or compromised provider can land raw ESC bytes on
+				// the operator terminal. The other backends do not: dyndns2 and
+				// duckdns wrap the response token in %q, generic OMITS the body
+				// entirely (it reports only the configured success tokens), and
+				// rfc2136 reports a fixed rcode string. Sanitizing at the display site
+				// covers the class regardless of which backend produced the string,
+				// and survives a backend changing its format verb.
 				lastErr := termsafe.SanitizeForDisplay(v.LastError)
 				if lastErr == "" {
 					lastErr = "-"

--- a/pkg/frr/bgp_summary_hostname_6468_test.go
+++ b/pkg/frr/bgp_summary_hostname_6468_test.go
@@ -1,0 +1,106 @@
+package frr
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #6468 / #6579. bgpPeerJSON's DECLARED FIELD SET is documented at its
+// definition as a load-bearing security boundary: with `bgp default
+// show-hostname` configured, FRR adds a "hostname" key to every peer object
+// carrying the name the PEER advertised via the BGP hostname capability —
+// attacker-controlled free text. encoding/json ignores object keys that have no
+// matching declared field, so NOT declaring it is what keeps that text out of
+// BGPPeerSummary and off the operator's terminal.
+//
+// That was documented but unpinned. These tests bind it: adding a hostname
+// field to bgpPeerJSON and plumbing it into BGPPeerSummary fails here rather
+// than silently widening the taint into every render site.
+
+// bgpSummaryHostileHostnameJSON6468 is the shipped fixture's shape with a
+// hostile string in the "hostname" key: a CSI erase-line escape (\u001b — raw
+// control bytes are a JSON syntax error, so it must be escaped here) plus a
+// complete fake column set, so a test can tell "the value never arrived" from
+// "the value arrived and was escaped". Every other key is a DECLARED field, so
+// a vacuous pass (parser returned nothing) is distinguishable from a real one.
+const bgpSummaryHostileHostnameJSON6468 = `{
+  "ipv4Unicast": {
+    "routerId": "10.0.0.1",
+    "as": 65001,
+    "vrfName": "default",
+    "peers": {
+      "10.0.0.2": {
+        "hostname": "r2\u001b[2K  ipv4-unicast  65099  0  0  never  Established  0",
+        "remoteAs": 65002,
+        "msgRcvd": 124,
+        "msgSent": 130,
+        "peerUptime": "01:05:12",
+        "pfxRcd": 3,
+        "pfxSnt": 4,
+        "state": "Established"
+      }
+    }
+  }
+}`
+
+func TestBGPSummaryDropsPeerAdvertisedHostname_6468(t *testing.T) {
+	peers, err := parseBGPSummaryJSON(bgpSummaryHostileHostnameJSON6468)
+	if err != nil {
+		t.Fatalf("parseBGPSummaryJSON: %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("fixture must parse to exactly 1 peer (else this test is vacuous), got %d", len(peers))
+	}
+	p := peers[0]
+
+	// Reflective sweep: walk EVERY string field, so adding a Hostname field to
+	// BGPPeerSummary (or repurposing an existing one) is caught here instead of
+	// widening peer-controlled text into all 10 render sites unnoticed.
+	v := reflect.ValueOf(p)
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() != reflect.String {
+			continue
+		}
+		got := f.String()
+		if strings.Contains(got, "\x1b") || strings.Contains(got, "65099") {
+			t.Fatalf("BGPPeerSummary.%s carries the peer-advertised hostname %q.\n"+
+				"bgpPeerJSON deliberately does NOT declare a \"hostname\" field: encoding/json "+
+				"ignores undeclared keys, and that is the documented boundary keeping this text "+
+				"out of the struct (#6468). If the hostname is now wanted, every display site "+
+				"must sanitize it AND this test must be replaced with one asserting the escaped "+
+				"form — do not just delete it.",
+				v.Type().Field(i).Name, got)
+		}
+	}
+
+	// Non-vacuous: DECLARED keys really did carry through, so a clean sweep
+	// means "the hostname was dropped", not "nothing was parsed". Checked AFTER
+	// the sweep so a tainted field reports the sweep's message, not this one.
+	if !strings.HasPrefix(p.State, "Established") || p.AS != "65002" || p.Neighbor != "10.0.0.2" {
+		t.Fatalf("declared fields must be populated, else the drop above proves nothing: %+v", p)
+	}
+}
+
+// TestBGPSummaryDeclaredFieldSetIsTheBoundary_6468 pins the MECHANISM, not just
+// the outcome. If bgpPeerJSON ever gains `json:"-"`-less catch-all decoding (a
+// map[string]any, json.RawMessage, or DisallowUnknownFields inversion), the
+// "undeclared keys are dropped" reasoning stops holding and this fails.
+func TestBGPSummaryDeclaredFieldSetIsTheBoundary_6468(t *testing.T) {
+	tj := reflect.TypeOf(bgpPeerJSON{})
+	for i := 0; i < tj.NumField(); i++ {
+		f := tj.Field(i)
+		switch f.Type.Kind() {
+		case reflect.Map, reflect.Interface, reflect.Slice:
+			t.Fatalf("bgpPeerJSON.%s is a %s: a catch-all decode target defeats the declared-field "+
+				"boundary that keeps the peer-advertised \"hostname\" out of BGPPeerSummary (#6468). "+
+				"Every field must be a concrete scalar.", f.Name, f.Type.Kind())
+		}
+		if strings.EqualFold(f.Name, "hostname") || strings.Contains(f.Tag.Get("json"), "hostname") {
+			t.Fatalf("bgpPeerJSON declares %s (tag %q) — that is the peer-advertised BGP hostname "+
+				"capability string, attacker-controlled free text. Declaring it pulls it into "+
+				"BGPPeerSummary and onto every terminal render site (#6468).", f.Name, f.Tag.Get("json"))
+		}
+	}
+}

--- a/pkg/frr/status_parse.go
+++ b/pkg/frr/status_parse.go
@@ -77,6 +77,14 @@ func (m *Manager) GetRIPRoutes() ([]RIPRouteEntry, error) {
 // containing a SPACE shifts Interface/Level/State/HoldTime one column right and
 // puts peer bytes in each of them. Display sites must sanitize the WHOLE row —
 // see termsafe.SanitizeRowForDisplay.
+//
+// Sanitizing does NOT repair that shift. It keeps the row safe to print; the
+// VALUES remain positionally derived from peer-controlled text, so a shifted
+// row can display a State the peer chose and no display guard can detect it.
+// Fixing that needs this parse to change — FRR's IS-IS JSON output, or
+// right-anchored columns with malformed rows reported rather than rendered.
+// Tracked as #6590. Do not cite the display guard as making this struct
+// trustworthy.
 type ISISAdjacency struct {
 	SystemID  string
 	Interface string

--- a/pkg/frr/status_parse.go
+++ b/pkg/frr/status_parse.go
@@ -67,6 +67,16 @@ func (m *Manager) GetRIPRoutes() ([]RIPRouteEntry, error) {
 }
 
 // ISISAdjacency represents an IS-IS adjacency.
+//
+// SystemID is PEER-CONTROLLED TEXT, not a numeric system ID (#6468). FRR
+// substitutes the hostname the peer advertised in its Dynamic Hostname TLV
+// (RFC 5301, `hostname dynamic` — on by default) for the dotted system ID
+// whenever that mapping is known, so the first column of `show isis neighbor`
+// is whatever the neighbour called itself. Every OTHER field inherits the same
+// taint: GetISISAdjacency splits the row with strings.Fields, so a hostname
+// containing a SPACE shifts Interface/Level/State/HoldTime one column right and
+// puts peer bytes in each of them. Display sites must sanitize the WHOLE row —
+// see termsafe.SanitizeRowForDisplay.
 type ISISAdjacency struct {
 	SystemID  string
 	Interface string
@@ -76,6 +86,11 @@ type ISISAdjacency struct {
 }
 
 // GetISISAdjacency queries FRR for IS-IS adjacencies.
+//
+// strings.Fields splits on unicode.IsSpace ONLY, so ESC, DEL, BEL and the C1
+// controls ride inside a token untouched — tokenizing is not sanitizing. The
+// guard belongs at the display sites (see the ISISAdjacency doc); the values
+// here stay raw for machine consumers.
 func (m *Manager) GetISISAdjacency() ([]ISISAdjacency, error) {
 	output, err := m.executor().Vtysh("show isis neighbor")
 	if err != nil {
@@ -186,6 +201,15 @@ type bgpSummaryFamilyJSON struct {
 // summary instead overloads a single "State/PfxRcd" column, which the
 // old scraper misread (it stored the pfxRcd digit as the State and never
 // populated PfxRcd). #3942.
+// The declared field set is also a load-bearing security boundary (#6468).
+// With `bgp default show-hostname` configured, FRR adds a "hostname" key to
+// each peer object carrying the name the PEER advertised via the BGP hostname
+// capability — attacker-controlled free text. encoding/json drops undeclared
+// keys, so not declaring it is what keeps that text out of BGPPeerSummary and
+// off the operator's terminal today. If a future change needs the hostname,
+// the display sites in pkg/cli and pkg/grpcapi must already be sanitizing (they
+// are, via termsafe.SanitizeRowForDisplay) — do not add the field on the
+// assumption that this row is numeric.
 type bgpPeerJSON struct {
 	RemoteAs   int64  `json:"remoteAs"`
 	MsgRcvd    int64  `json:"msgRcvd"`

--- a/pkg/grpcapi/server_routing.go
+++ b/pkg/grpcapi/server_routing.go
@@ -99,7 +99,8 @@ func (s *Server) GetOSPFStatus(_ context.Context, req *pb.GetOSPFStatusRequest) 
 		var b strings.Builder
 		for _, n := range neighbors {
 			fmt.Fprintf(&b, "%-18s %-10s %-16s %-18s %s\n",
-				n.NeighborID, n.Priority, n.State, n.Address, n.Interface)
+				termsafe.SanitizeRowForDisplay(
+					n.NeighborID, n.Priority, n.State, n.Address, n.Interface)...)
 		}
 		output = b.String()
 	}
@@ -121,7 +122,8 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 			return nil, status.Errorf(codes.Internal, "%v", err)
 		}
 		for _, r := range routes {
-			fmt.Fprintf(&b, "%-24s %-20s %s\n", r.Network, r.NextHop, r.Path)
+			fmt.Fprintf(&b, "%-24s %-20s %s\n",
+				termsafe.SanitizeRowForDisplay(r.Network, r.NextHop, r.Path)...)
 		}
 	case "groups":
 		cfg := s.store.ActiveConfig()
@@ -219,7 +221,8 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 			"Neighbor", "AF", "AS", "MsgRcvd", "MsgSent", "Up/Down", "State", "PfxRcd")
 		for _, p := range peers {
 			fmt.Fprintf(&b, "%-20s %-13s %-8s %-9s %-9s %-11s %-12s %s\n",
-				p.Neighbor, p.AddressFamily, p.AS, p.MsgRcvd, p.MsgSent, p.UpDown, p.State, p.PfxRcd)
+				termsafe.SanitizeRowForDisplay(
+					p.Neighbor, p.AddressFamily, p.AS, p.MsgRcvd, p.MsgSent, p.UpDown, p.State, p.PfxRcd)...)
 		}
 	}
 	return &pb.GetBGPStatusResponse{Output: termsafe.SanitizeBlockForDisplay(b.String())}, nil
@@ -239,7 +242,8 @@ func (s *Server) GetRIPStatus(_ context.Context, _ *pb.GetRIPStatusRequest) (*pb
 	} else {
 		fmt.Fprintf(&b, "  %-20s %-18s %-8s %s\n", "Network", "Next Hop", "Metric", "Interface")
 		for _, r := range routes {
-			fmt.Fprintf(&b, "  %-20s %-18s %-8s %s\n", r.Network, r.NextHop, r.Metric, r.Interface)
+			fmt.Fprintf(&b, "  %-20s %-18s %-8s %s\n",
+				termsafe.SanitizeRowForDisplay(r.Network, r.NextHop, r.Metric, r.Interface)...)
 		}
 	}
 	return &pb.GetRIPStatusResponse{Output: b.String()}, nil
@@ -281,7 +285,8 @@ func (s *Server) GetISISStatus(_ context.Context, req *pb.GetISISStatusRequest) 
 				"System ID", "Interface", "Level", "State", "Hold Time")
 			for _, a := range adjs {
 				fmt.Fprintf(&b, "  %-20s %-14s %-10s %-10s %s\n",
-					a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)
+					termsafe.SanitizeRowForDisplay(
+						a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)...)
 			}
 		}
 	}

--- a/pkg/grpcapi/server_routing.go
+++ b/pkg/grpcapi/server_routing.go
@@ -10,9 +10,25 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/termsafe"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// #6468 D2: the routing show RPCs return captured `vtysh` stdout, and the
+// remote `cli` prints resp.Output VERBATIM (cmd/cli/show_protocols.go:
+// fmt.Print(resp.Output)) — the same terminal the in-process CLI writes to,
+// reached over a different transport. That stdout carries text a REMOTE PEER
+// advertised: the BGP hostname capability, IS-IS dynamic hostname TLVs, OSPF
+// router IDs. Every Output on these handlers therefore passes through
+// termsafe.SanitizeBlockForDisplay, the mirror of the fmt.Print guards in
+// pkg/cli/cli_show_routing.go.
+//
+// The guard sits on the RESPONSE, not on each vtysh branch, so a case added to
+// one of these switches later is covered by construction — the fail-open
+// direction is what left this half of the class unfixed to begin with. The
+// branches that build a structured table instead of returning raw stdout pay
+// nothing: clean text takes the sanitizer's allocation-free fast path.
 
 func (s *Server) GetRoutes(_ context.Context, _ *pb.GetRoutesRequest) (*pb.GetRoutesResponse, error) {
 	if s.routing == nil {
@@ -90,7 +106,7 @@ func (s *Server) GetOSPFStatus(_ context.Context, req *pb.GetOSPFStatusRequest) 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
-	return &pb.GetOSPFStatusResponse{Output: output}, nil
+	return &pb.GetOSPFStatusResponse{Output: termsafe.SanitizeBlockForDisplay(output)}, nil
 }
 
 func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*pb.GetBGPStatusResponse, error) {
@@ -164,7 +180,7 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "%v", err)
 			}
-			return &pb.GetBGPStatusResponse{Output: output}, nil
+			return &pb.GetBGPStatusResponse{Output: termsafe.SanitizeBlockForDisplay(output)}, nil
 		}
 		// "advertised-routes:<ip>" for neighbor advertised routes
 		if strings.HasPrefix(req.Type, "advertised-routes:") {
@@ -176,7 +192,7 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "%v", err)
 			}
-			return &pb.GetBGPStatusResponse{Output: output}, nil
+			return &pb.GetBGPStatusResponse{Output: termsafe.SanitizeBlockForDisplay(output)}, nil
 		}
 		// "neighbor" or "neighbor:<ip>" for detailed neighbor info.
 		// An empty ip selects every neighbor (legal); a non-empty ip must
@@ -193,7 +209,7 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "%v", err)
 			}
-			return &pb.GetBGPStatusResponse{Output: output}, nil
+			return &pb.GetBGPStatusResponse{Output: termsafe.SanitizeBlockForDisplay(output)}, nil
 		}
 		peers, err := s.frr.GetBGPSummary()
 		if err != nil {
@@ -206,7 +222,7 @@ func (s *Server) GetBGPStatus(_ context.Context, req *pb.GetBGPStatusRequest) (*
 				p.Neighbor, p.AddressFamily, p.AS, p.MsgRcvd, p.MsgSent, p.UpDown, p.State, p.PfxRcd)
 		}
 	}
-	return &pb.GetBGPStatusResponse{Output: b.String()}, nil
+	return &pb.GetBGPStatusResponse{Output: termsafe.SanitizeBlockForDisplay(b.String())}, nil
 }
 
 func (s *Server) GetRIPStatus(_ context.Context, _ *pb.GetRIPStatusRequest) (*pb.GetRIPStatusResponse, error) {
@@ -269,7 +285,7 @@ func (s *Server) GetISISStatus(_ context.Context, req *pb.GetISISStatusRequest) 
 			}
 		}
 	}
-	return &pb.GetISISStatusResponse{Output: b.String()}, nil
+	return &pb.GetISISStatusResponse{Output: termsafe.SanitizeBlockForDisplay(b.String())}, nil
 }
 
 func (s *Server) GetIPsecSA(_ context.Context, _ *pb.GetIPsecSARequest) (*pb.GetIPsecSAResponse, error) {

--- a/pkg/grpcapi/server_routing_escape_6468_test.go
+++ b/pkg/grpcapi/server_routing_escape_6468_test.go
@@ -177,15 +177,19 @@ func TestGetISISStatus_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {
 // the "raw vtysh output" sweep could not see: a PARSED field (the peer's IS-IS
 // dynamic hostname) reprinted into a caller-formatted row.
 //
-// On THIS renderer the row is now covered TWICE — by the per-cell row guard and
-// by the response-boundary block guard — so reverting either one alone leaves
-// this test green. That is stated rather than hidden: it is a defense-in-depth
-// end-to-end assertion, not the binder for the row guard. The binders are
-// TestShowISIS_LocalCLIEscapesParsedAdjacencyRow_6468 (the local CLI has no
-// response boundary, so the row guard is the only thing standing there) and
-// TestGetBGPStatus_RemoteCLIEscapesParsedSummaryRow_6468 (a JSON-decoded cell
-// carrying a real LF, which the block guard preserves by design and cannot
-// catch). The combined-revert case in the fail-on-revert gate covers this one.
+// On THIS renderer the row is covered TWICE — by the per-cell row guard and by
+// the response-boundary block guard — so reverting either one alone still
+// produces safe output HERE. This test is therefore the end-to-end
+// defense-in-depth assertion, not the binder for the per-cell call.
+//
+// The per-cell call IS bound, by
+// TestGetISISStatus_RemoteCLICellGuardPrecedesWidthFormat_6579 in
+// server_row_escape_6579_test.go: the guard must run BEFORE the %-20s width
+// format, so dropping it pads the RAW cell and shifts every later column right
+// by the escape expansion. That discriminator survives the outer block guard,
+// which the raw-control-byte assertion below does not. The LF shape that
+// isolates BGP summary is unreachable for this row because strings.Fields
+// consumed every whitespace rune before the cell existed.
 func TestGetISISStatus_RemoteCLIEscapesParsedAdjacencyRow_6468(t *testing.T) {
 	s := escapeVtyshServer6468(t)
 	resp, err := s.GetISISStatus(context.Background(), &pb.GetISISStatusRequest{Type: ""})

--- a/pkg/grpcapi/server_routing_escape_6468_test.go
+++ b/pkg/grpcapi/server_routing_escape_6468_test.go
@@ -34,14 +34,52 @@ const evilVtyshBlock6468 = "BGP neighbor is 10.0.0.1, remote AS 65001\n" +
 	"  Hostname: rtr1\x1b[2Kforged-peer\n" +
 	"  BGP state = Established, up for 00:12:34\n"
 
-// vtyshEscapeExecutor6468 is an frr executor double whose Vtysh returns the
-// hostile block for every command. It satisfies pkg/frr's package-private
-// frrExecutor (all four methods are exported names, so an out-of-package type
-// can implement it) and is handed to frr.NewForTest, which is the seam that
-// lets a show RPC run its real wiring without shelling out to vtysh.
+// evilISISNeighborTable6468 is a `show isis neighbor` table whose FIRST column
+// carries a CSI erase-line escape. That column is not a numeric system ID: FRR
+// substitutes the hostname the peer advertised in its Dynamic Hostname TLV
+// (RFC 5301), so it is peer-controlled text — and GetISISAdjacency reaches it
+// through strings.Fields, which splits on whitespace and leaves ESC/DEL/C1
+// inside the token untouched. Tokenizing is not sanitizing.
+//
+// The header row must survive the parser's own skips: it drops lines starting
+// with "Area" and rows whose first field is "System".
+const evilISISNeighborTable6468 = "Area 1:\n" +
+	" System Id           Interface   L  State        Holdtime SNPA\n" +
+	" rtr1\x1b[2Kforged     ge-0-0-1    2  Up           27       2020.2020.2020\n"
+
+// evilBGPSummaryJSON6468 is a `show bgp summary json` reply whose peer "state"
+// string carries an embedded NEWLINE plus a complete fake peer row. It is the
+// case that ISOLATES the per-cell row guard from the response-boundary block
+// guard: SanitizeBlockForDisplay PRESERVES LF by design (that is what keeps a
+// vtysh table from collapsing), so it cannot catch this — only the single-line
+// cell guard escapes the newline and stops the forged row.
+//
+// This cell is reachable in a way a strings.Fields-scraped cell is not: JSON
+// decoding turns \n into a real newline, and the split that would have
+// consumed it never happens.
+const evilBGPSummaryJSON6468 = `{"ipv4Unicast":{"peers":{"10.0.0.1":{` +
+	`"remoteAs":65001,"msgRcvd":10,"msgSent":11,"peerUptime":"00:12:34",` +
+	`"state":"Established\n  10.0.0.99             ipv4-unicast  65099    0         0         never       Idle         0",` +
+	`"pfxRcd":5,"pfxSnt":5}}}}`
+
+// vtyshEscapeExecutor6468 is an frr executor double that returns hostile
+// stdout. It satisfies pkg/frr's package-private frrExecutor (all four methods
+// are exported names, so an out-of-package type can implement it) and is handed
+// to frr.NewForTest, which is the seam that lets a show RPC run its real wiring
+// without shelling out to vtysh.
+//
+// `show isis neighbor` gets a PARSED-table fixture because that command feeds
+// GetISISAdjacency rather than being printed verbatim; every other command gets
+// the raw block.
 type vtyshEscapeExecutor6468 struct{}
 
-func (vtyshEscapeExecutor6468) Vtysh(string) (string, error) {
+func (vtyshEscapeExecutor6468) Vtysh(cmd string) (string, error) {
+	switch cmd {
+	case "show isis neighbor":
+		return evilISISNeighborTable6468, nil
+	case "show bgp summary json":
+		return evilBGPSummaryJSON6468, nil
+	}
 	return evilVtyshBlock6468, nil
 }
 
@@ -133,6 +171,74 @@ func TestGetISISStatus_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {
 		}
 		assertVtyshOutputSanitized6468(t, "GetISISStatus type="+typ, resp.Output)
 	}
+}
+
+// TestGetISISStatus_RemoteCLIEscapesParsedAdjacencyRow_6468 covers the surface
+// the "raw vtysh output" sweep could not see: a PARSED field (the peer's IS-IS
+// dynamic hostname) reprinted into a caller-formatted row.
+//
+// On THIS renderer the row is now covered TWICE — by the per-cell row guard and
+// by the response-boundary block guard — so reverting either one alone leaves
+// this test green. That is stated rather than hidden: it is a defense-in-depth
+// end-to-end assertion, not the binder for the row guard. The binders are
+// TestShowISIS_LocalCLIEscapesParsedAdjacencyRow_6468 (the local CLI has no
+// response boundary, so the row guard is the only thing standing there) and
+// TestGetBGPStatus_RemoteCLIEscapesParsedSummaryRow_6468 (a JSON-decoded cell
+// carrying a real LF, which the block guard preserves by design and cannot
+// catch). The combined-revert case in the fail-on-revert gate covers this one.
+func TestGetISISStatus_RemoteCLIEscapesParsedAdjacencyRow_6468(t *testing.T) {
+	s := escapeVtyshServer6468(t)
+	resp, err := s.GetISISStatus(context.Background(), &pb.GetISISStatusRequest{Type: ""})
+	if err != nil {
+		t.Fatalf("GetISISStatus(adjacency): %v", err)
+	}
+	out := resp.Output
+
+	if !strings.Contains(out, "ge-0-0-1") {
+		t.Fatalf("the adjacency row must render (else the guard is vacuous):\n%q", out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("emitted raw terminal control bytes — the peer-advertised IS-IS dynamic "+
+			"hostname reaches the remote cli through the PARSED SystemID field, which the "+
+			"raw-output sweep does not cover (#6468):\n%q", out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("expected the escaped ESC (\\x1b) to render, proving the parsed cell was "+
+			"sanitized rather than dropped:\n%q", out)
+	}
+}
+
+// assertBGPSummaryRowSanitized6468 is the shared verdict for the rendered BGP
+// summary. hasRawTermControl6468 deliberately tolerates \n and \t (a rendered
+// table needs them), so a surviving newline would slip past it — the line-count
+// and \x0a assertions are what actually bind this case.
+func assertBGPSummaryRowSanitized6468(t *testing.T, surface, out string) {
+	t.Helper()
+	if !strings.Contains(out, "10.0.0.1") {
+		t.Fatalf("%s: the peer row must render (else the guard is vacuous):\n%q", surface, out)
+	}
+	if !strings.Contains(out, `\x0a`) {
+		t.Fatalf("%s: the newline embedded in the peer's state cell must render as \\x0a. "+
+			"The response-boundary block sanitizer PRESERVES LF by design, so only the "+
+			"per-cell row guard catches this (#6468):\n%q", surface, out)
+	}
+	// Header + exactly one peer row. A third line means the JSON cell forged one.
+	if n := strings.Count(strings.TrimRight(out, "\n"), "\n"); n != 1 {
+		t.Fatalf("%s: want header + exactly 1 peer row (1 interior newline), got %d — "+
+			"the provider-controlled cell forged a table row:\n%q", surface, n, out)
+	}
+	if strings.Contains(out, "\n  10.0.0.99") {
+		t.Fatalf("%s: a forged peer row reached the terminal:\n%q", surface, out)
+	}
+}
+
+func TestGetBGPStatus_RemoteCLIEscapesParsedSummaryRow_6468(t *testing.T) {
+	s := escapeVtyshServer6468(t)
+	resp, err := s.GetBGPStatus(context.Background(), &pb.GetBGPStatusRequest{Type: ""})
+	if err != nil {
+		t.Fatalf("GetBGPStatus(summary): %v", err)
+	}
+	assertBGPSummaryRowSanitized6468(t, "GetBGPStatus summary", resp.Output)
 }
 
 func TestShowBFDPeers_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {

--- a/pkg/grpcapi/server_routing_escape_6468_test.go
+++ b/pkg/grpcapi/server_routing_escape_6468_test.go
@@ -1,0 +1,154 @@
+package grpcapi
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/frr"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #6468 D2, remote-cli half. The routing show RPCs return captured `vtysh`
+// stdout and the remote `cli` prints resp.Output VERBATIM
+// (cmd/cli/show_protocols.go, cmd/cli/show.go: fmt.Print(resp.Output)) — the
+// same operator terminal the in-process CLI writes to, reached over gRPC
+// instead of in-process. That stdout carries text a REMOTE PEER advertised:
+// the BGP hostname capability, IS-IS dynamic hostname TLVs, OSPF router IDs.
+//
+// These are the fail-on-revert guards for that surface. Dropping a
+// termsafe.SanitizeBlockForDisplay call in server_routing.go /
+// server_show_routes_text.go makes the raw ESC reappear in the emitted text,
+// and swapping in the single-line termsafe.SanitizeForDisplay collapses the
+// table — each assertion below binds one of those two failure modes.
+//
+// hasRawTermControl6468 is shared with server_show_dhcp_escape_6468_test.go.
+
+// evilVtyshBlock6468 is a realistic multi-line vtysh table with a CSI
+// erase-line escape buried in the peer-advertised hostname cell. The
+// surrounding rows are clean so a test can assert BOTH that the escape was
+// neutralized AND that the block's line structure survived.
+const evilVtyshBlock6468 = "BGP neighbor is 10.0.0.1, remote AS 65001\n" +
+	"  Hostname: rtr1\x1b[2Kforged-peer\n" +
+	"  BGP state = Established, up for 00:12:34\n"
+
+// vtyshEscapeExecutor6468 is an frr executor double whose Vtysh returns the
+// hostile block for every command. It satisfies pkg/frr's package-private
+// frrExecutor (all four methods are exported names, so an out-of-package type
+// can implement it) and is handed to frr.NewForTest, which is the seam that
+// lets a show RPC run its real wiring without shelling out to vtysh.
+type vtyshEscapeExecutor6468 struct{}
+
+func (vtyshEscapeExecutor6468) Vtysh(string) (string, error) {
+	return evilVtyshBlock6468, nil
+}
+
+func (vtyshEscapeExecutor6468) FrrReloadPy(context.Context, string) error { return nil }
+
+func (vtyshEscapeExecutor6468) VtyshLoad(context.Context, string) ([]byte, error) {
+	return nil, nil
+}
+
+func (vtyshEscapeExecutor6468) VtyshStream(context.Context, string) (io.ReadCloser, func() error, error) {
+	return io.NopCloser(strings.NewReader("")), func() error { return nil }, nil
+}
+
+// escapeVtyshServer6468 wires a Server whose FRR manager returns the hostile
+// block from every vtysh call.
+func escapeVtyshServer6468(t *testing.T) *Server {
+	t.Helper()
+	m := frr.NewForTest(filepath.Join(t.TempDir(), "frr.conf"), vtyshEscapeExecutor6468{})
+	return &Server{frr: m}
+}
+
+// assertVtyshOutputSanitized6468 is the shared verdict for a rendered block.
+// It binds THREE distinct failure modes:
+//
+//	(1) non-vacuous — the fixture actually rendered, so the guard is not being
+//	    asserted against an empty string;
+//	(2) no raw terminal control byte survived — the revert signal for dropping
+//	    the sanitize call entirely;
+//	(3) the escape is VISIBLE and the LINE COUNT is unchanged — the revert
+//	    signal for swapping in the single-line sanitizer, which would escape
+//	    every LF and collapse the table into one \x0a-laden row.
+func assertVtyshOutputSanitized6468(t *testing.T, surface, out string) {
+	t.Helper()
+	if !strings.Contains(out, "BGP neighbor is 10.0.0.1") {
+		t.Fatalf("%s: the vtysh block must render (else the guard is vacuous):\n%q", surface, out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("%s: emitted raw terminal control bytes — unsanitized vtysh stdout reaches "+
+			"the remote cli's verbatim fmt.Print(resp.Output) (#6468 D2):\n%q", surface, out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("%s: expected the escaped ESC (\\x1b) to render, proving the peer hostname was "+
+			"sanitized rather than dropped:\n%q", surface, out)
+	}
+	if want, have := strings.Count(evilVtyshBlock6468, "\n"), strings.Count(out, "\n"); want != have {
+		t.Fatalf("%s: the block's line structure must survive — want %d newlines, got %d. "+
+			"The single-line termsafe.SanitizeForDisplay escapes LF and would collapse this "+
+			"table; these surfaces need SanitizeBlockForDisplay:\n%q", surface, want, have, out)
+	}
+}
+
+func TestGetOSPFStatus_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {
+	// Every raw-vtysh req.Type of the OSPF handler. "" (the structured
+	// neighbor-summary default) is excluded: it does not return vtysh stdout.
+	for _, typ := range []string{"neighbor-detail", "database", "interface", "routes"} {
+		s := escapeVtyshServer6468(t)
+		resp, err := s.GetOSPFStatus(context.Background(), &pb.GetOSPFStatusRequest{Type: typ})
+		if err != nil {
+			t.Fatalf("GetOSPFStatus(%q): %v", typ, err)
+		}
+		assertVtyshOutputSanitized6468(t, "GetOSPFStatus type="+typ, resp.Output)
+	}
+}
+
+func TestGetBGPStatus_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {
+	// The three neighbor sub-selectors that return raw vtysh stdout. "routes",
+	// "groups" and the bare summary build structured tables instead.
+	for _, typ := range []string{
+		"received-routes:10.0.0.1",
+		"advertised-routes:10.0.0.1",
+		"neighbor:10.0.0.1",
+		"neighbor",
+	} {
+		s := escapeVtyshServer6468(t)
+		resp, err := s.GetBGPStatus(context.Background(), &pb.GetBGPStatusRequest{Type: typ})
+		if err != nil {
+			t.Fatalf("GetBGPStatus(%q): %v", typ, err)
+		}
+		assertVtyshOutputSanitized6468(t, "GetBGPStatus type="+typ, resp.Output)
+	}
+}
+
+func TestGetISISStatus_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {
+	for _, typ := range []string{"adjacency-detail", "routes", "database"} {
+		s := escapeVtyshServer6468(t)
+		resp, err := s.GetISISStatus(context.Background(), &pb.GetISISStatusRequest{Type: typ})
+		if err != nil {
+			t.Fatalf("GetISISStatus(%q): %v", typ, err)
+		}
+		assertVtyshOutputSanitized6468(t, "GetISISStatus type="+typ, resp.Output)
+	}
+}
+
+func TestShowBFDPeers_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {
+	s := escapeVtyshServer6468(t)
+	var buf strings.Builder
+	if err := s.showBFDPeers(&buf); err != nil {
+		t.Fatalf("showBFDPeers: %v", err)
+	}
+	assertVtyshOutputSanitized6468(t, "showBFDPeers", buf.String())
+}
+
+func TestShowRouteMap_RemoteCLIEscapesVtyshOutput_6468(t *testing.T) {
+	s := escapeVtyshServer6468(t)
+	var buf strings.Builder
+	if err := s.showRouteMap(nil, &buf); err != nil {
+		t.Fatalf("showRouteMap: %v", err)
+	}
+	assertVtyshOutputSanitized6468(t, "showRouteMap", buf.String())
+}

--- a/pkg/grpcapi/server_row_escape_6579_test.go
+++ b/pkg/grpcapi/server_row_escape_6579_test.go
@@ -1,0 +1,240 @@
+package grpcapi
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/frr"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #6579 fold. The first pass bound the raw-vtysh sweep on both renderers and
+// the PARSED row on two of the five sites. These are the remaining three
+// production row sites — OSPF neighbors, BGP routes, RIP routes — plus the
+// isolation the first pass could not reach.
+//
+// # Why the parsed-row sites need their own binders
+//
+// A parsed row is not covered by a raw-output test: frr.Get*() scrapes vtysh
+// stdout with strings.Fields and the handler REPRINTS the cells into its own
+// format string, so the block guard on the response never sees the cell as the
+// peer wrote it. Dropping termsafe.SanitizeRowForDisplay at one of these five
+// sites is invisible to every test in server_routing_escape_6468_test.go.
+//
+// # Isolating the inner guard from the outer one
+//
+// GetOSPFStatus / GetBGPStatus / GetISISStatus sanitize the whole RESPONSE with
+// SanitizeBlockForDisplay as a fail-safe, which MASKS a dropped per-cell guard
+// for the raw-ESC assertion: the escape gets neutralized either way. Two shapes
+// see through that mask, and every test below uses one of them:
+//
+//   - COLUMN ALIGNMENT (assertCellGuardRanBeforeWidthFormat6579). `%-20s` pads
+//     whatever it is handed. Guarding the CELL pads the 17-character escaped
+//     text to 20. Guarding only the response pads the 14-byte RAW text to 20 and
+//     THEN expands the escape, so the column runs 3 characters long and every
+//     later column shifts right. Same bytes, different layout — and the layout
+//     is the operator-visible difference.
+//   - A REAL LF in a cell, which the block variant preserves by design. Only
+//     reachable for a JSON-decoded cell; already covered for BGP summary by
+//     TestGetBGPStatus_RemoteCLIEscapesParsedSummaryRow_6468.
+//
+// GetRIPStatus has NO response-boundary guard (it has no raw-vtysh branch for
+// one to protect), so its per-cell guard is isolated by construction and the
+// plain raw-ESC assertion binds it.
+
+// The hostile token shared by the row fixtures below: a CSI erase-line escape
+// inside the cell. 14 bytes raw ("rtr1" + ESC + "[2Kforged"), 17 characters
+// once escaped ("rtr1" + `\x1b` + "[2Kforged") — the 3-character difference the
+// alignment assertion keys on.
+const evilRowCell6579 = "rtr1\x1b[2Kforged"
+
+const (
+	// evilRowCellRawLen is len(evilRowCell6579).
+	evilRowCellRawLen = 14
+	// evilRowCellEscapedLen is its length after termsafe escaping.
+	evilRowCellEscapedLen = 17
+)
+
+// evilOSPFNeighborTable6579 puts the escape in the Neighbor ID column of
+// `show ip ospf neighbor`. GetOSPFNeighbors needs >= 5 fields and skips the
+// header (fields[0] == "Neighbor"); it takes Address/Interface from the LAST
+// two fields.
+//
+// An OSPF router ID is a dotted quad today, so this is a CALL-SITE BINDER, not
+// a claim that FRR emits free text here now. That is exactly the documented
+// reason the guard is uniform: "this column is numeric" is a property of the
+// current upstream, not of the protocol.
+const evilOSPFNeighborTable6579 = "Neighbor ID     Pri State    Dead Time Address    Interface\n" +
+	evilRowCell6579 + " 128 Full/DR 32.100s 10.0.1.2 ge-0-0-0\n"
+
+// evilRIPTable6579 puts the escape in the Network column of `show ip rip`.
+// GetRIPRoutes needs >= 3 fields and skips the header (fields[0] == "Network")
+// and the "Codes" legend.
+const evilRIPTable6579 = "Codes: R - RIP, C - connected\n" +
+	"     Network            Next Hop         Metric From\n" +
+	evilRowCell6579 + " 10.0.1.2 2 ge-0-0-1\n"
+
+// evilBGPRouteTable6579 puts the escape in the NEXT-HOP column of
+// `show bgp ipv4 unicast`. parseBGPRouteLine requires the line to start with
+// "*" or " " and to carry >= 3 fields; Network is fields[1], NextHop fields[2],
+// Path the join of fields[4:].
+//
+// Next-hop is the realistic taint here: with `bgp default show-nexthop-hostname`
+// FRR renders a peer-supplied hostname in this column.
+const evilBGPRouteTable6579 = "   Network          Next Hop            Metric LocPrf Weight Path\n" +
+	"*> 10.0.0.0/8       " + evilRowCell6579 + "         0    100      0 65001 65002 i\n"
+
+// rowEscapeExecutor6579 answers the three PARSED-table commands with hostile
+// rows. It deliberately does NOT reuse vtyshEscapeExecutor6468: that double
+// returns a raw BGP-neighbor block for every unmatched command, which these
+// parsers would scrape into nonsense rows and make the assertions unreadable.
+type rowEscapeExecutor6579 struct{}
+
+func (rowEscapeExecutor6579) Vtysh(cmd string) (string, error) {
+	switch cmd {
+	case "show ip ospf neighbor":
+		return evilOSPFNeighborTable6579, nil
+	case "show ip rip":
+		return evilRIPTable6579, nil
+	case "show bgp ipv4 unicast":
+		return evilBGPRouteTable6579, nil
+	case "show isis neighbor":
+		return evilISISNeighborTable6468, nil
+	}
+	return "", nil
+}
+
+func (rowEscapeExecutor6579) FrrReloadPy(context.Context, string) error { return nil }
+
+func (rowEscapeExecutor6579) VtyshLoad(context.Context, string) ([]byte, error) { return nil, nil }
+
+func (rowEscapeExecutor6579) VtyshStream(context.Context, string) (io.ReadCloser, func() error, error) {
+	return io.NopCloser(strings.NewReader("")), func() error { return nil }, nil
+}
+
+func rowEscapeServer6579(t *testing.T) *Server {
+	t.Helper()
+	m := frr.NewForTest(filepath.Join(t.TempDir(), "frr.conf"), rowEscapeExecutor6579{})
+	return &Server{frr: m}
+}
+
+// assertRowCellSanitized6579 is the call-site binder: the hostile cell rendered,
+// no raw control byte survived, and the escape is visible rather than dropped.
+func assertRowCellSanitized6579(t *testing.T, surface, out string) {
+	t.Helper()
+	if !strings.Contains(out, "forged") {
+		t.Fatalf("%s: the hostile row must render, else this binder is vacuous:\n%q", surface, out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("%s: a raw terminal control byte reached the remote cli's verbatim "+
+			"fmt.Print(resp.Output). This row site lost its termsafe.SanitizeRowForDisplay "+
+			"guard (#6468):\n%q", surface, out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("%s: expected the escaped ESC (\\x1b), proving the cell was sanitized rather "+
+			"than dropped:\n%q", surface, out)
+	}
+}
+
+// assertCellGuardRanBeforeWidthFormat6579 proves the guard runs on the CELL and
+// not merely on the finished response.
+//
+// nextCol is a clean value from the column immediately after the hostile one,
+// and wantStart is the byte offset the handler's format string puts it at
+// (leading literal + the hostile column's declared width + the separator).
+// Sanitizing per cell pads the escaped text, so nextCol lands exactly there.
+// Sanitizing only at the response boundary pads the RAW text and then expands
+// the escape, pushing nextCol right by (escaped - raw) bytes.
+func assertCellGuardRanBeforeWidthFormat6579(t *testing.T, surface, out, nextCol string, wantStart int) {
+	t.Helper()
+	line := ""
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "forged") {
+			line = l
+			break
+		}
+	}
+	if line == "" {
+		t.Fatalf("%s: no rendered row carried the hostile cell:\n%q", surface, out)
+	}
+	got := strings.Index(line, nextCol)
+	if got == wantStart {
+		return
+	}
+	drift := evilRowCellEscapedLen - evilRowCellRawLen
+	if got == wantStart+drift {
+		t.Fatalf("%s: the next column starts at %d instead of %d — exactly the %d bytes the ESC "+
+			"grows by when escaped. The width format padded the RAW cell and the escaping "+
+			"happened afterwards, at the response boundary. termsafe.SanitizeRowForDisplay must "+
+			"run on the CELLS, before %%-Ns, or every column after a hostile one shifts right:\n%q",
+			surface, got, wantStart, drift, line)
+	}
+	t.Fatalf("%s: the next column starts at %d, want %d (the hostile cell must occupy exactly its "+
+		"declared width once escaped):\n%q", surface, got, wantStart, line)
+}
+
+// --- OSPF neighbors: "%-18s %-10s %-16s %-18s %s" -----------------------------
+
+func TestGetOSPFStatus_RemoteCLIEscapesParsedNeighborRow_6579(t *testing.T) {
+	s := rowEscapeServer6579(t)
+	resp, err := s.GetOSPFStatus(context.Background(), &pb.GetOSPFStatusRequest{Type: ""})
+	if err != nil {
+		t.Fatalf("GetOSPFStatus(neighbors): %v", err)
+	}
+	assertRowCellSanitized6579(t, "GetOSPFStatus neighbors", resp.Output)
+	// No leading literal; column 0 is %-18s, then one space -> col 1 at 19.
+	assertCellGuardRanBeforeWidthFormat6579(t, "GetOSPFStatus neighbors", resp.Output, "128", 19)
+}
+
+// --- BGP routes: "%-24s %-20s %s" ---------------------------------------------
+
+func TestGetBGPStatus_RemoteCLIEscapesParsedRouteRow_6579(t *testing.T) {
+	s := rowEscapeServer6579(t)
+	resp, err := s.GetBGPStatus(context.Background(), &pb.GetBGPStatusRequest{Type: "routes"})
+	if err != nil {
+		t.Fatalf("GetBGPStatus(routes): %v", err)
+	}
+	assertRowCellSanitized6579(t, "GetBGPStatus routes", resp.Output)
+	// The hostile cell is the NEXT-HOP (column 1, %-20s). Column 0 is %-24s
+	// holding the clean "10.0.0.0/8", then a space -> the hostile cell starts
+	// at 25 and the path column at 25+20+1 = 46.
+	assertCellGuardRanBeforeWidthFormat6579(t, "GetBGPStatus routes", resp.Output, "100 0 65001", 46)
+}
+
+// --- RIP routes: "  %-20s %-18s %-8s %s" --------------------------------------
+
+func TestGetRIPStatus_RemoteCLIEscapesParsedRouteRow_6579(t *testing.T) {
+	s := rowEscapeServer6579(t)
+	resp, err := s.GetRIPStatus(context.Background(), &pb.GetRIPStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetRIPStatus: %v", err)
+	}
+	// GetRIPStatus has no response-boundary block guard, so the raw-ESC
+	// assertion alone isolates the per-cell guard here: reverting
+	// SanitizeRowForDisplay at this site puts a raw ESC on the wire.
+	assertRowCellSanitized6579(t, "GetRIPStatus", resp.Output)
+	// "  " + %-20s + " " -> next column at 23.
+	assertCellGuardRanBeforeWidthFormat6579(t, "GetRIPStatus", resp.Output, "10.0.1.2", 23)
+}
+
+// --- IS-IS adjacency: "  %-20s %-14s %-10s %-10s %s" --------------------------
+
+// TestGetISISStatus_RemoteCLICellGuardPrecedesWidthFormat_6579 closes the gap
+// the first pass documented but could not bind: on this handler the outer block
+// guard masks a dropped per-cell guard for any raw-ESC assertion, and the LF
+// shape that isolates BGP summary is unreachable here because strings.Fields
+// consumed every whitespace rune before the cell existed. Column alignment is
+// the discriminator that survives the mask.
+func TestGetISISStatus_RemoteCLICellGuardPrecedesWidthFormat_6579(t *testing.T) {
+	s := rowEscapeServer6579(t)
+	resp, err := s.GetISISStatus(context.Background(), &pb.GetISISStatusRequest{Type: ""})
+	if err != nil {
+		t.Fatalf("GetISISStatus(adjacency): %v", err)
+	}
+	assertRowCellSanitized6579(t, "GetISISStatus adjacency", resp.Output)
+	// "  " + %-20s + " " -> the Interface column at 23.
+	assertCellGuardRanBeforeWidthFormat6579(t, "GetISISStatus adjacency", resp.Output, "ge-0-0-1", 23)
+}

--- a/pkg/grpcapi/server_show_ddns_escape_6468_test.go
+++ b/pkg/grpcapi/server_show_ddns_escape_6468_test.go
@@ -1,0 +1,78 @@
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	ddnspkg "github.com/psaab/xpf/pkg/ddns"
+)
+
+// #6468 D1, remote-cli half. The Surface A DDNS "Last error" column can carry a
+// PROVIDER response body: Cloudflare (backend_cloudflare.go) and Route 53
+// (backend_route53.go) embed the provider's own message with %s, so a hostile
+// or compromised provider — or an operator pointed at an attacker-run endpoint
+// — controls those bytes. They land in the gRPC ShowText buffer the remote
+// `cli` prints verbatim.
+//
+// This is the fail-on-revert guard for that surface: dropping the
+// termsafe.SanitizeForDisplay call in server_show_dhcp_lldp_snmp.go makes the
+// raw OSC/ESC reappear, and swapping in the BLOCK sanitizer lets the embedded
+// newline through and forges a scope row.
+
+// evilProviderError6468 is a provider error body carrying an OSC 52
+// clipboard-write AND an embedded newline. The newline is the reason this
+// surface takes the SINGLE-LINE sanitizer: LastError is rendered into one
+// %s-formatted cell of a fixed-width table, so a raw LF fakes a whole scope row.
+const evilProviderError6468 = "cloudflare 1004: \x1b]52;c;YWFhYWFh\x07bad zone\n" +
+	"    forged.example.com               inet   OK              203.0.113.9"
+
+// evilLastErrorStatusFn returns one Surface A scope view whose LastError is the
+// hostile provider body.
+func evilLastErrorStatusFn() []ddnspkg.SurfaceAStatusView {
+	return []ddnspkg.SurfaceAStatusView{{
+		Interface: "ge-0-0-0",
+		Family:    4,
+		FQDN:      "wan.example.com",
+		Provider:  "cf",
+		State:     "published",
+		Published: "198.51.100.7",
+		LastError: evilProviderError6468,
+	}}
+}
+
+func TestShowServicesDynamicDNS_RemoteCLIEscapesLastError_6468(t *testing.T) {
+	cfg := &config.Config{}
+
+	s := &Server{
+		surfaceADDNSStatsFn:  func() *ddnspkg.SurfaceAStats { return &ddnspkg.SurfaceAStats{Scopes: 1} },
+		surfaceADDNSStatusFn: evilLastErrorStatusFn,
+	}
+	var buf strings.Builder
+	s.showServicesDynamicDNS(cfg, &buf, true)
+	out := buf.String()
+
+	if !strings.Contains(out, "wan.example.com") {
+		t.Fatalf("the scope row must render (else the guard is vacuous):\n%q", out)
+	}
+	if hasRawTermControl6468(out) {
+		t.Fatalf("remote-cli DDNS renderer emitted raw terminal control bytes — an unsanitized "+
+			"PROVIDER response body reaches the operator terminal (#6468 D1):\n%q", out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("expected the escaped ESC (\\x1b) to render, proving LastError was sanitized "+
+			"rather than dropped:\n%q", out)
+	}
+	// The embedded LF must render as an escape, not as a real line break: this
+	// column is one cell of a fixed-width table, so a surviving newline forges a
+	// scope row. It is also the discriminator against the BLOCK sanitizer, which
+	// preserves LF by design and would let the forged row through.
+	if !strings.Contains(out, `\x0a`) {
+		t.Fatalf("expected the embedded newline to render as \\x0a — LastError is a single-line "+
+			"FIELD and must take termsafe.SanitizeForDisplay, not the block variant "+
+			"(a surviving LF forges a scope row):\n%q", out)
+	}
+	if strings.Contains(out, "forged.example.com\n") || strings.Contains(out, "\n    forged") {
+		t.Fatalf("the provider body forged a table row — the embedded newline survived:\n%q", out)
+	}
+}

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -371,7 +371,13 @@ func (s *Server) showServicesDynamicDNS(cfg *config.Config, buf *strings.Builder
 				if v.Family == 6 {
 					fam = "inet6"
 				}
-				lastErr := v.LastError
+				// #6468 D1: LastError can embed a DDNS PROVIDER response body. The
+				// dyndns2/duckdns/generic backends wrap it in %q, but Cloudflare
+				// (backend_cloudflare.go) and Route 53 (backend_route53.go) embed the
+				// provider message with %s, so a hostile or compromised provider can
+				// land raw ESC bytes on the operator terminal. Sanitize at the display
+				// site so the whole class is covered regardless of backend.
+				lastErr := termsafe.SanitizeForDisplay(v.LastError)
 				if lastErr == "" {
 					lastErr = "-"
 				}

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -371,12 +371,16 @@ func (s *Server) showServicesDynamicDNS(cfg *config.Config, buf *strings.Builder
 				if v.Family == 6 {
 					fam = "inet6"
 				}
-				// #6468 D1: LastError can embed a DDNS PROVIDER response body. The
-				// dyndns2/duckdns/generic backends wrap it in %q, but Cloudflare
-				// (backend_cloudflare.go) and Route 53 (backend_route53.go) embed the
-				// provider message with %s, so a hostile or compromised provider can
-				// land raw ESC bytes on the operator terminal. Sanitize at the display
-				// site so the whole class is covered regardless of backend.
+				// #6468 D1: LastError can embed a DDNS PROVIDER response body.
+				// Cloudflare (backend_cloudflare.go:166) and Route 53
+				// (backend_route53.go:195,277) embed the provider's own message with
+				// %s, so a hostile or compromised provider can land raw ESC bytes on
+				// the operator terminal. The other backends do not: dyndns2 and
+				// duckdns wrap the response token in %q, generic OMITS the body
+				// entirely (it reports only the configured success tokens), and
+				// rfc2136 reports a fixed rcode string. Sanitizing at the display site
+				// covers the class regardless of which backend produced the string,
+				// and survives a backend changing its format verb.
 				lastErr := termsafe.SanitizeForDisplay(v.LastError)
 				if lastErr == "" {
 					lastErr = "-"

--- a/pkg/grpcapi/server_show_routes_text.go
+++ b/pkg/grpcapi/server_show_routes_text.go
@@ -19,6 +19,7 @@ import (
 	"github.com/psaab/xpf/pkg/frr"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/routing"
+	"github.com/psaab/xpf/pkg/termsafe"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -538,7 +539,10 @@ func (s *Server) showRouteMap(cfg *config.Config, buf *strings.Builder) error {
 		if output == "" {
 			buf.WriteString("No route-maps configured\n")
 		} else {
-			buf.WriteString(output)
+			// #6468 D2: raw vtysh stdout into the ShowText buffer the remote
+			// `cli` prints verbatim — the mirror of showRouteMap in
+			// pkg/cli/cli_show_routing.go.
+			buf.WriteString(termsafe.SanitizeBlockForDisplay(output))
 		}
 	}
 	return nil
@@ -555,7 +559,10 @@ func (s *Server) showBFDPeers(buf *strings.Builder) error {
 		if output == "" {
 			buf.WriteString("No BFD peers\n")
 		} else {
-			buf.WriteString(output)
+			// #6468 D2: raw vtysh stdout into the ShowText buffer the remote
+			// `cli` prints verbatim — the mirror of showBFD in
+			// pkg/cli/cli_show_routing.go.
+			buf.WriteString(termsafe.SanitizeBlockForDisplay(output))
 		}
 	}
 	return nil

--- a/pkg/termsafe/block_6468_test.go
+++ b/pkg/termsafe/block_6468_test.go
@@ -106,8 +106,9 @@ func TestSanitizeBlockEscapesUnicodeLineSeparators(t *testing.T) {
 		in := "Hostname: rtr1" + tc.sep + "  BGP state = Established\n"
 		got := SanitizeBlockForDisplay(in)
 		if strings.Contains(got, tc.sep) {
-			t.Fatalf("%s: must be escaped — it can forge a row in the very table the block "+
-				"sanitizer exists to keep honest; got %q", tc.name, got)
+			t.Fatalf("%s: must be escaped — a terminal or pager that honors it as a break can "+
+				"add a row to the very table the block sanitizer is keeping printable; got %q",
+				tc.name, got)
 		}
 		if !strings.Contains(got, tc.want) {
 			t.Fatalf("%s: must render as the visible escape %s (a \\xHH byte escape cannot "+

--- a/pkg/termsafe/block_6468_test.go
+++ b/pkg/termsafe/block_6468_test.go
@@ -8,9 +8,11 @@ import (
 // #6468 residual surfaces. Two device/remote-supplied strings still reached an
 // operator terminal unescaped after the lease-field fix:
 //
-//   - the DDNS LastError column, which can carry a PROVIDER response body —
-//     safe for dyndns2/duckdns/generic (they wrap it in %q) but not for
-//     Cloudflare / Route 53, which embed the provider message with %s;
+//   - the DDNS LastError column, which can carry a PROVIDER response body.
+//     Cloudflare and Route 53 embed the provider's message with %s; the other
+//     backends do not reach the terminal with raw bytes (dyndns2 and duckdns
+//     wrap the response token in %q, generic omits the body entirely, rfc2136
+//     reports a fixed rcode string);
 //   - raw `vtysh` stdout, which carries remote-advertised text: the BGP peer's
 //     hostname capability, IS-IS dynamic hostname TLVs, OSPF router IDs.
 //

--- a/pkg/termsafe/block_6468_test.go
+++ b/pkg/termsafe/block_6468_test.go
@@ -1,0 +1,107 @@
+package termsafe
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6468 residual surfaces. Two device/remote-supplied strings still reached an
+// operator terminal unescaped after the lease-field fix:
+//
+//   - the DDNS LastError column, which can carry a PROVIDER response body —
+//     safe for dyndns2/duckdns/generic (they wrap it in %q) but not for
+//     Cloudflare / Route 53, which embed the provider message with %s;
+//   - raw `vtysh` stdout, which carries remote-advertised text: the BGP peer's
+//     hostname capability, IS-IS dynamic hostname TLVs, OSPF router IDs.
+//
+// The first takes SanitizeForDisplay (a single-line field, where an embedded
+// newline is itself a forgery vector — it can fake a table row). The second
+// needs SanitizeBlockForDisplay, because SanitizeForDisplay escapes \n and \t
+// too and would collapse a whole BGP table into one \x0a-laden line.
+
+// A CSI erase-line escape embedded in a remote-advertised BGP hostname.
+const evilPeerHostname = "rtr1\x1b[2Kfake-peer"
+
+func TestSanitizeBlockPreservesLayoutControls(t *testing.T) {
+	in := "line one\n\tindented\nline three\n"
+	if got := SanitizeBlockForDisplay(in); got != in {
+		t.Fatalf("a clean multi-line block must pass through byte-identical\n got: %q\nwant: %q", got, in)
+	}
+	// The fast path must actually engage — otherwise every vtysh print
+	// allocates a builder for nothing.
+	if !blockDisplaySafe(in) {
+		t.Fatalf("blockDisplaySafe must accept LF/TAB so the clean path stays allocation-free")
+	}
+}
+
+func TestSanitizeBlockEscapesTerminalControlsInsideALine(t *testing.T) {
+	// A realistic vtysh-shaped table with the escape buried in one cell.
+	in := "BGP neighbor is 10.0.0.1, remote AS 65001\n" +
+		"  Hostname: " + evilPeerHostname + "\n" +
+		"  BGP state = Established\n"
+
+	got := SanitizeBlockForDisplay(in)
+
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("the ESC introducer must be neutralized; got %q", got)
+	}
+	if !strings.Contains(got, `\x1b`) {
+		t.Fatalf("the ESC must be rendered as a visible escape so the operator sees what the peer sent; got %q", got)
+	}
+	// Layout survives: same number of lines, and the tabless structure intact.
+	if want, have := strings.Count(in, "\n"), strings.Count(got, "\n"); want != have {
+		t.Fatalf("line structure must survive sanitization: want %d newlines, got %d\n%q", want, have, got)
+	}
+	if !strings.HasPrefix(got, "BGP neighbor is 10.0.0.1") {
+		t.Fatalf("unrelated content must be untouched; got %q", got)
+	}
+}
+
+func TestSanitizeBlockEscapesCarriageReturn(t *testing.T) {
+	// CR is deliberately NOT a preserved layout control: it re-homes the cursor
+	// and lets later text overwrite a line the operator already read.
+	in := "real line\rforged line\n"
+	got := SanitizeBlockForDisplay(in)
+	if strings.Contains(got, "\r") {
+		t.Fatalf("a bare CR must be escaped (line-overwrite forgery); got %q", got)
+	}
+	if !strings.Contains(got, `\x0d`) {
+		t.Fatalf("CR must render as a visible escape; got %q", got)
+	}
+}
+
+func TestSanitizeBlockEscapesC1AndInvalidUTF8(t *testing.T) {
+	// U+009B is the single-byte CSI introducer; 0xC0 is an invalid UTF-8 lead.
+	in := "ab\n" + string([]byte{'c', 0xC0, 'd'}) + "\n"
+	got := SanitizeBlockForDisplay(in)
+	if strings.ContainsRune(got, '') {
+		t.Fatalf("the C1 CSI introducer must be escaped; got %q", got)
+	}
+	if !strings.Contains(got, `\x9b`) || !strings.Contains(got, `\xc0`) {
+		t.Fatalf("C1 and invalid-UTF-8 bytes must both render as visible escapes; got %q", got)
+	}
+	if strings.Count(got, "\n") != 2 {
+		t.Fatalf("newlines must survive; got %q", got)
+	}
+}
+
+// TestSanitizeBlockDiffersFromSingleLineOnLayout is the reason the block
+// variant exists at all: applying the single-line sanitizer to a table would
+// destroy it. If these two ever agree on a multi-line input, the block variant
+// has lost its purpose and the vtysh surfaces are being mangled.
+func TestSanitizeBlockDiffersFromSingleLineOnLayout(t *testing.T) {
+	in := "row one\nrow two\n"
+	block := SanitizeBlockForDisplay(in)
+	single := SanitizeForDisplay(in)
+
+	if block != in {
+		t.Fatalf("block sanitizer must leave a clean table alone; got %q", block)
+	}
+	if single == in {
+		t.Fatalf("precondition: the single-line sanitizer is expected to escape newlines — " +
+			"if it no longer does, SanitizeBlockForDisplay may be redundant and should be re-justified")
+	}
+	if !strings.Contains(single, `\x0a`) {
+		t.Fatalf("precondition: single-line sanitizer should render LF as \\x0a; got %q", single)
+	}
+}

--- a/pkg/termsafe/block_6468_test.go
+++ b/pkg/termsafe/block_6468_test.go
@@ -85,6 +85,46 @@ func TestSanitizeBlockEscapesC1AndInvalidUTF8(t *testing.T) {
 	}
 }
 
+func TestSanitizeBlockEscapesUnicodeLineSeparators(t *testing.T) {
+	// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are category Zl/Zp,
+	// so unicode.IsControl does NOT catch them and the single-line sanitizer
+	// lets them through by documented design. The block variant must not: its
+	// whole premise is that the blob's line structure is meaningful output, and
+	// terminals and pagers that honor U+2028 as a break let a peer-advertised
+	// hostname forge a row in exactly the table this function protects. Same
+	// argument that escapes CR.
+	for _, tc := range []struct {
+		name string
+		sep  string
+		want string
+	}{
+		{"U+2028 line separator", "\u2028", `\u2028`},
+		{"U+2029 paragraph separator", "\u2029", `\u2029`},
+	} {
+		in := "Hostname: rtr1" + tc.sep + "  BGP state = Established\n"
+		got := SanitizeBlockForDisplay(in)
+		if strings.Contains(got, tc.sep) {
+			t.Fatalf("%s: must be escaped — it can forge a row in the very table the block "+
+				"sanitizer exists to keep honest; got %q", tc.name, got)
+		}
+		if !strings.Contains(got, tc.want) {
+			t.Fatalf("%s: must render as the visible escape %s (a \\xHH byte escape cannot "+
+				"represent a rune above U+00FF); got %q", tc.name, tc.want, got)
+		}
+		// The fast path must agree with the slow path, or a clean-looking blob
+		// carrying a separator would be returned verbatim.
+		if blockDisplaySafe(in) {
+			t.Fatalf("%s: blockDisplaySafe must reject it, else the allocation-free fast path "+
+				"returns the separator unchanged", tc.name)
+		}
+		// Real LFs are still preserved: escaping the separators must not have
+		// turned this into the single-line sanitizer.
+		if strings.Count(got, "\n") != 1 {
+			t.Fatalf("%s: genuine LFs must survive; got %q", tc.name, got)
+		}
+	}
+}
+
 // TestSanitizeBlockDiffersFromSingleLineOnLayout is the reason the block
 // variant exists at all: applying the single-line sanitizer to a table would
 // destroy it. If these two ever agree on a multi-line input, the block variant

--- a/pkg/termsafe/row_6468_test.go
+++ b/pkg/termsafe/row_6468_test.go
@@ -91,3 +91,149 @@ func TestSanitizeRowLeavesCleanCellsIdentical(t *testing.T) {
 		t.Fatalf("an empty row must produce an empty argument list")
 	}
 }
+
+// --- U+2028/U+2029 in a CELL (#6579 fold) -----------------------------------
+//
+// The first pass gave SanitizeBlockForDisplay line-separator escaping and left
+// SanitizeForDisplay passing them through, on the reasoning that a single-line
+// field is bounded by the caller's format string. Expanding the guard to
+// per-cell row rendering made that gap reachable in exactly the path the row
+// helper feeds: a cell IS a single-line field, so it now takes the single-line
+// variant, and a U+2028 in it can break the row on a terminal or pager that
+// honors it. Escaping LF but not U+2028 was incoherent — this variant is the
+// STRICTER of the two about line breaks.
+
+func TestSanitizeFieldEscapesUnicodeLineSeparators(t *testing.T) {
+	for _, tc := range []struct {
+		name, in, want string
+	}{
+		{"line separator", "peer\u2028forged-row", `\u2028`},
+		{"paragraph separator", "peer\u2029forged-row", `\u2029`},
+	} {
+		got := SanitizeForDisplay(tc.in)
+		if strings.ContainsAny(got, "\u2028\u2029") {
+			t.Fatalf("%s: a Unicode line separator inside a single-line FIELD forges a row "+
+				"and must be escaped; got %q", tc.name, got)
+		}
+		if !strings.Contains(got, tc.want) {
+			t.Fatalf("%s: want the visible %s escape (a \\xHH byte escape cannot represent "+
+				"a rune above U+00FF); got %q", tc.name, tc.want, got)
+		}
+		if !strings.HasPrefix(got, "peer") || !strings.HasSuffix(got, "forged-row") {
+			t.Fatalf("%s: the surrounding text must survive; got %q", tc.name, got)
+		}
+	}
+}
+
+func TestDisplaySafeRejectsUnicodeLineSeparators(t *testing.T) {
+	// DisplaySafe is SanitizeForDisplay's fast-path guard: anything it calls
+	// safe is returned UNSANITIZED. If it drifts out of lockstep with the
+	// escaping rules, that escaping is dead code.
+	for _, in := range []string{"peer\u2028x", "peer\u2029x"} {
+		if DisplaySafe(in) {
+			t.Fatalf("DisplaySafe(%q) must be false - it gates SanitizeForDisplay's "+
+				"allocation-free return, so calling this safe skips the escaping entirely", in)
+		}
+	}
+	if !DisplaySafe("rtr1.example.net") {
+		t.Fatalf("a clean field must still take the fast path")
+	}
+}
+
+func TestSanitizeRowEscapesUnicodeLineSeparatorInACell(t *testing.T) {
+	// The row helper is why this matters: a cell IS a single-line field, so it
+	// takes the single-line variant, and the gap was reachable per cell in the
+	// very path #6579 expanded.
+	got := SanitizeRowForDisplay("peer\u2028forged-row", "clean")
+	first := got[0].(string)
+	if strings.ContainsAny(first, "\u2028\u2029") {
+		t.Fatalf("a Unicode line separator must not survive in a rendered cell; got %q", first)
+	}
+	if !strings.Contains(first, `\u2028`) {
+		t.Fatalf("want the visible \\u2028 escape; got %q", first)
+	}
+	if got[1].(string) != "clean" {
+		t.Fatalf("a clean sibling cell must pass through byte-identical; got %q", got[1])
+	}
+}
+
+// --- cost (#6579 fold, MINOR-3) ---------------------------------------------
+
+func TestSanitizeCleanFieldIsAllocationFree(t *testing.T) {
+	// The substantive claim in SanitizeRowForDisplay's doc: the per-cell guard
+	// itself is free, so guarding every column instead of a hand-picked subset
+	// costs nothing at the cell. (The helper's own []any is a separate,
+	// measured cost — see the benchmarks below.)
+	clean := "10.0.0.1" + strings.Repeat("", 0) // defeat constant folding
+	if n := testing.AllocsPerRun(200, func() { _ = SanitizeForDisplay(clean) }); n != 0 {
+		t.Fatalf("SanitizeForDisplay must not allocate for a clean field, got %.0f allocs/op — "+
+			"the whole-row guard is justified by this fast path being free", n)
+	}
+	block := "line one\n\tindented\n"
+	if n := testing.AllocsPerRun(200, func() { _ = SanitizeBlockForDisplay(block) }); n != 0 {
+		t.Fatalf("SanitizeBlockForDisplay must not allocate for a clean block, got %.0f allocs/op", n)
+	}
+}
+
+// benchRoute mirrors the production shape: cells are STRUCT FIELDS, not string
+// constants. Benchmarking constants understates the unguarded baseline, because
+// the compiler boxes a constant into a read-only static and reports ~0 allocs
+// for a path that allocates 3/row in production.
+type benchRoute struct{ Network, NextHop, Path string }
+
+var benchRoutes = func() []benchRoute {
+	out := make([]benchRoute, 1000)
+	for i := range out {
+		out[i] = benchRoute{
+			Network: fmt.Sprintf("10.%d.%d.0/24", i/256, i%256),
+			NextHop: fmt.Sprintf("10.0.0.%d", i%256),
+			Path:    "65001 65002 65003",
+		}
+	}
+	return out
+}()
+
+var benchSink string
+
+// BenchmarkSanitizedRowUnguarded is the honest baseline: the same render with
+// NO sanitizer. Compare against BenchmarkSanitizedRowHelper to attribute cost.
+func BenchmarkSanitizedRowUnguarded(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var sb strings.Builder
+		for _, r := range benchRoutes {
+			fmt.Fprintf(&sb, "%-24s %-20s %s\n", r.Network, r.NextHop, r.Path)
+		}
+		benchSink = sb.String()
+	}
+}
+
+// BenchmarkSanitizedRowInline isolates the per-cell guard from the helper. It
+// lands on the unguarded baseline, which is the measurement behind "sanitizing
+// a clean cell is genuinely free".
+func BenchmarkSanitizedRowInline(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var sb strings.Builder
+		for _, r := range benchRoutes {
+			fmt.Fprintf(&sb, "%-24s %-20s %s\n",
+				SanitizeForDisplay(r.Network), SanitizeForDisplay(r.NextHop), SanitizeForDisplay(r.Path))
+		}
+		benchSink = sb.String()
+	}
+}
+
+// BenchmarkSanitizedRowHelper is the shipped path. The delta against
+// BenchmarkSanitizedRowUnguarded is one allocation and 48 bytes per row: the
+// returned []any. Everything else is fmt's own boxing, paid either way.
+func BenchmarkSanitizedRowHelper(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var sb strings.Builder
+		for _, r := range benchRoutes {
+			fmt.Fprintf(&sb, "%-24s %-20s %s\n",
+				SanitizeRowForDisplay(r.Network, r.NextHop, r.Path)...)
+		}
+		benchSink = sb.String()
+	}
+}

--- a/pkg/termsafe/row_6468_test.go
+++ b/pkg/termsafe/row_6468_test.go
@@ -1,0 +1,93 @@
+package termsafe
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #6468: SanitizeRowForDisplay exists because guarding the ONE column believed
+// to carry device text is wrong for a table scraped out of command stdout —
+// column identity shifts, and "this column is numeric" is a property of the
+// current upstream rather than of the protocol. These tests bind the
+// whole-row property, not just that some escaping happened.
+
+func TestSanitizeRowSanitizesEveryCell(t *testing.T) {
+	// One hostile cell per position, so a guard applied to only some cells
+	// leaves at least one raw ESC behind.
+	cells := []string{
+		"a\x1bb", "c\x1bd", "e\x1bf", "g\x1bh", "i\x1bj",
+	}
+	got := SanitizeRowForDisplay(cells...)
+	if len(got) != len(cells) {
+		t.Fatalf("row width must be preserved: want %d cells, got %d", len(cells), len(got))
+	}
+	for i, v := range got {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("cell %d must stay a string for %%s formatting; got %T", i, v)
+		}
+		if strings.Contains(s, "\x1b") {
+			t.Fatalf("cell %d still carries a raw ESC — every cell of the row must be "+
+				"sanitized, not just the one believed to be device-controlled; got %q", i, s)
+		}
+		if !strings.Contains(s, `\x1b`) {
+			t.Fatalf("cell %d must render the ESC as a visible escape rather than dropping "+
+				"the value; got %q", i, s)
+		}
+	}
+}
+
+func TestSanitizeRowSpreadsIntoPrintf(t *testing.T) {
+	// The whole point of returning []any is that it spreads into the caller's
+	// existing format string with the column widths unchanged.
+	out := fmt.Sprintf("  %-20s %-14s %-10s %-10s %s",
+		SanitizeRowForDisplay("rtr1\x1b[2Kforged", "ge-0-0-1", "2", "Up", "27")...)
+
+	if strings.Contains(out, "\x1b") {
+		t.Fatalf("the formatted row must carry no raw ESC; got %q", out)
+	}
+	if !strings.Contains(out, `\x1b`) || !strings.Contains(out, "ge-0-0-1") {
+		t.Fatalf("the escaped cell and the clean cells must both render; got %q", out)
+	}
+	if strings.Contains(out, "\n") {
+		t.Fatalf("a row must stay on one line; got %q", out)
+	}
+}
+
+func TestSanitizeRowEscapesNewlineInACell(t *testing.T) {
+	// A cell reached via strings.Fields can never hold a newline (the split
+	// consumed it), but a cell decoded out of FRR's JSON output can — and there
+	// a surviving LF forges an extra table row. This is why the row helper uses
+	// the single-line sanitizer and not the block variant.
+	got := SanitizeRowForDisplay("peer\nforged-row", "clean")
+	first, ok := got[0].(string)
+	if !ok {
+		t.Fatalf("cell must stay a string; got %T", got[0])
+	}
+	if strings.Contains(first, "\n") {
+		t.Fatalf("a newline inside a CELL forges a table row and must be escaped; got %q", first)
+	}
+	if !strings.Contains(first, `\x0a`) {
+		t.Fatalf("the newline must render as \\x0a — if this ever passes through, the row "+
+			"helper has been switched to the block sanitizer, which preserves LF by "+
+			"design and is wrong for a field; got %q", first)
+	}
+}
+
+func TestSanitizeRowLeavesCleanCellsIdentical(t *testing.T) {
+	// Anti-pessimization: the uniform guard is only defensible because a clean
+	// cell costs nothing. If this regresses, sanitizing every column stops being
+	// free and the per-column ledger argument comes back.
+	in := []string{"10.0.0.1", "ge-0-0-1", "65001", "Established", "00:12:34"}
+	got := SanitizeRowForDisplay(in...)
+	for i, v := range got {
+		if v.(string) != in[i] {
+			t.Fatalf("clean cell %d must pass through byte-identical: want %q, got %q",
+				i, in[i], v.(string))
+		}
+	}
+	if len(SanitizeRowForDisplay()) != 0 {
+		t.Fatalf("an empty row must produce an empty argument list")
+	}
+}

--- a/pkg/termsafe/termsafe.go
+++ b/pkg/termsafe/termsafe.go
@@ -26,6 +26,18 @@
 //     CR and the Unicode line/paragraph separators are not, because they forge
 //     or overwrite rows.
 //
+// Both escape U+2028/U+2029. Neither is Unicode category Cc, so unicode.IsControl
+// does not reach them, but a terminal or pager that honors either as a break can
+// forge a row with it — the same argument that escapes CR in the block variant
+// and LF in the field variant.
+//
+// What this package does NOT do: it makes device text safe to PRINT, not
+// trustworthy to READ. It neutralizes terminal-protocol control bytes; it leaves
+// every printable rune alone, so it cannot tell a genuine field value from a
+// plausible-looking one a peer supplied. A row whose columns were derived by
+// splitting peer-controlled text on whitespace stays terminal-safe and can still
+// display materially false values — see #6590 and SanitizeRowForDisplay.
+//
 // This is a leaf package (it imports only the standard library) so BOTH the
 // in-process CLI renderer (pkg/cli) and the gRPC text renderer that feeds the
 // remote `cli`'s verbatim terminal print (pkg/grpcapi) can guard the same
@@ -55,14 +67,23 @@ const hexDigits = "0123456789abcdef"
 // including legitimate multibyte UTF-8, so an international hostname is not
 // corrupted — passes through unchanged.
 //
-// Scope is deliberately narrow. This neutralizes exactly the C0/DEL/C1
-// terminal-protocol control bytes and invalid UTF-8 that drive escape-sequence
-// injection (OSC clipboard writes, CSI cursor/erase) — unicode.IsControl covers
-// only Unicode category Cc. It does NOT address Unicode display-order spoofing:
-// bidirectional overrides (U+200E, U+202A-U+202E), line/paragraph separators
-// (U+2028/U+2029), and zero-width format (Cf) characters are printable runes and
-// pass through unchanged. Defending against Trojan-Source-style bidi reordering
-// is a separate, lower-severity concern and out of scope here.
+// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are escaped too, as
+// \u2028 / \u2029 (a \xHH byte escape cannot represent a rune above U+00FF).
+// Neither is Unicode category Cc, so unicode.IsControl does not reach them; they
+// are escaped because this variant's whole premise is that the value occupies ONE
+// line of a row the caller formats, and a rune a terminal or pager may honor as a
+// line break forges a row exactly as an embedded LF does. Escaping LF but passing
+// U+2028 would be incoherent: this variant is the STRICTER of the two about line
+// breaks, and SanitizeBlockForDisplay — which preserves LF — already escapes them.
+//
+// Scope is otherwise deliberately narrow. This neutralizes the terminal-protocol
+// control bytes and invalid UTF-8 that drive escape-sequence injection (OSC
+// clipboard writes, CSI cursor/erase), plus the two line separators. It does NOT
+// address Unicode display-order spoofing: bidirectional overrides (U+200E,
+// U+202A-U+202E) and zero-width format (Cf) characters are printable runes and
+// pass through unchanged. They can reorder characters WITHIN a line but cannot
+// forge or erase a row, so Trojan-Source-style bidi reordering is a separate,
+// lower-severity concern and out of scope here.
 func SanitizeForDisplay(s string) string {
 	// Fast path: the overwhelming majority of names are already clean, so
 	// return the input without allocating a builder.
@@ -84,6 +105,11 @@ func SanitizeForDisplay(s string) string {
 			// Control runes (Unicode category Cc) are all <= U+009F, so a
 			// single \xHH byte escape represents each one exactly.
 			writeHexEscape(&b, byte(r))
+			i += size
+			continue
+		}
+		if isLineSeparator(r) {
+			writeUnicodeEscape(&b, r)
 			i += size
 			continue
 		}
@@ -109,22 +135,24 @@ func SanitizeForDisplay(s string) string {
 // the same class of display forgery the ESC escaping defends against, and not
 // something a legitimate line-oriented blob needs.
 //
-// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are escaped too, and
-// this is where the block variant deliberately diverges from SanitizeForDisplay
-// rather than inheriting its rationale. Neither is Unicode category Cc, so
-// unicode.IsControl does not catch them and the single-line sanitizer — whose
-// doc out-scopes bidi/Cf display-order spoofing — lets them through. That is
-// defensible for a single-line field, where the caller's own format string
-// bounds the row. It is NOT defensible here: the whole premise of this variant
-// is that the blob's LINE STRUCTURE is meaningful output, and terminals and
-// pagers that honor U+2028 as a break let a peer-advertised hostname forge a
-// row in exactly the table this function exists to keep honest. Escaping them
-// is the same argument that escapes CR. They render as the visible escapes
+// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are escaped. Neither is
+// Unicode category Cc, so unicode.IsControl does not reach them; they are
+// escaped because the whole premise of this variant is that the blob's LINE
+// STRUCTURE is meaningful output, and a terminal or pager that honors U+2028 as
+// a break lets a peer-advertised hostname forge a row in the same table this
+// function is keeping printable. Escaping them is the same argument that
+// escapes CR. SanitizeForDisplay escapes them too, for the mirror-image reason:
+// a line break of any kind inside a single-line FIELD forges a row. They render
+// as the visible escapes
 // \u2028 / \u2029 (a \xHH byte escape cannot represent a rune above U+00FF).
 //
 // Bidi overrides and other Cf runes remain out of scope here, as in
 // SanitizeForDisplay: they can reorder characters WITHIN a line but cannot
 // forge or erase a row, so they are a different, lower-severity class.
+//
+// This makes the blob safe to PRINT; it does not make its contents true. The
+// text is rendered faithfully, so whatever a remote party put in it is still
+// what the operator reads.
 func SanitizeBlockForDisplay(s string) string {
 	if blockDisplaySafe(s) {
 		return s
@@ -180,10 +208,18 @@ func SanitizeBlockForDisplay(s string) string {
 //     the same for BGP; a column that is an address today can be free text
 //     after an upstream bump.
 //
-// Sanitizing a clean cell costs nothing — SanitizeForDisplay returns the input
-// string itself on the allocation-free fast path — so the uniform guard is
-// strictly cheaper than maintaining a per-column ledger of what is currently
-// attacker-reachable.
+// # What this does NOT fix
+//
+// The column shift above is the REASON to guard every cell; it is not something
+// guarding every cell REPAIRS. This makes the row safe to print. It does not
+// make the row correct. A peer hostname containing a space still shifts the
+// split, so `State` can end up holding a token the peer chose, and every value
+// here stays plausible printable text that no sanitizer can tell apart from a
+// genuine one. A displayed row can be terminal-safe and materially false.
+// Fixing THAT needs the parse to change — structured JSON, or right-anchored
+// columns with malformed rows reported rather than rendered — which is #6590,
+// deliberately not this helper's job. Do not cite a call to this function as
+// evidence that a rendered row is trustworthy.
 //
 // Cells are single-line FIELDS of a caller-formatted row, so this uses
 // SanitizeForDisplay, not the block variant: an embedded newline here forges a
@@ -191,6 +227,33 @@ func SanitizeBlockForDisplay(s string) string {
 // `strings.Fields` the two variants happen to agree, because every whitespace
 // rune was already consumed by the split; for a cell decoded out of JSON a
 // newline can survive, and there the distinction is load-bearing.)
+//
+// Call this on the CELLS, before the caller's width format — not on the
+// finished row. `%-20s` pads whatever it is handed, so sanitizing afterwards
+// pads the RAW cell and then expands each escape, pushing every later column
+// right by the expansion. Guarding per cell is what keeps the widths honest.
+//
+// # Cost
+//
+// Sanitizing a clean cell is genuinely free: SanitizeForDisplay returns the
+// input string on an allocation-free fast path. The HELPER is not free — it
+// allocates the returned []any. Measured over a 10k-row 3-cell render (values
+// from struct fields, as production has them, not the string constants a naive
+// microbenchmark constant-folds):
+//
+//	no sanitizer at all                    30,034 allocs   3.73 MB
+//	per-cell SanitizeForDisplay, no helper 30,035 allocs   3.73 MB
+//	SanitizeRowForDisplay(...)...          40,037 allocs   4.21 MB
+//
+// So the cost is ONE extra allocation and 48 bytes per row — the []any itself.
+// The 3-per-row boxing is inherent to fmt's variadic any and is paid by the
+// unguarded path too; it is not attributable to this helper. That is accepted
+// here: these are `show`-command render loops already gated by a vtysh
+// fork/exec and a whole-table string materialization, not a packet path. If a
+// future renderer ever needs it back, the fix is for the caller to hoist a
+// scratch []any out of the loop and refill it per row — not to revert to
+// guarding a hand-picked subset of columns. BenchmarkSanitizedRow* in
+// row_6468_test.go keeps these numbers checkable.
 func SanitizeRowForDisplay(cells ...string) []any {
 	out := make([]any, len(cells))
 	for i, c := range cells {
@@ -221,15 +284,21 @@ func blockDisplaySafe(s string) bool {
 }
 
 // isLineSeparator reports whether r is a Unicode line/paragraph separator —
-// category Zl/Zp, which unicode.IsControl does not cover. Only the block
-// sanitizer treats these as unsafe; see SanitizeBlockForDisplay.
+// category Zl/Zp, which unicode.IsControl does not cover. BOTH sanitizers treat
+// these as unsafe: they forge a row in a block whose line structure is the
+// output, and equally in a single-line field the caller formats into a row.
 func isLineSeparator(r rune) bool {
 	return r == '\u2028' || r == '\u2029'
 }
 
 // DisplaySafe reports whether s can be printed to a terminal verbatim: it holds
-// no control rune and no invalid UTF-8 byte, so SanitizeForDisplay would return
-// it unchanged. Splitting this out keeps the common (clean) path allocation-free.
+// no control rune, no Unicode line/paragraph separator, and no invalid UTF-8
+// byte, so SanitizeForDisplay would return it unchanged. Splitting this out
+// keeps the common (clean) path allocation-free.
+//
+// This predicate MUST stay in lockstep with SanitizeForDisplay's escaping rules
+// — it is that function's fast-path guard, so anything it calls safe is returned
+// unsanitized.
 func DisplaySafe(s string) bool {
 	for i := 0; i < len(s); {
 		r, size := utf8.DecodeRuneInString(s[i:])
@@ -237,6 +306,9 @@ func DisplaySafe(s string) bool {
 			return false
 		}
 		if unicode.IsControl(r) {
+			return false
+		}
+		if isLineSeparator(r) {
 			return false
 		}
 		i += size

--- a/pkg/termsafe/termsafe.go
+++ b/pkg/termsafe/termsafe.go
@@ -159,6 +159,46 @@ func SanitizeBlockForDisplay(s string) string {
 	return b.String()
 }
 
+// SanitizeRowForDisplay sanitizes every cell of ONE table row and returns them
+// ready to spread into a fmt.Printf / fmt.Fprintf argument list:
+//
+//	fmt.Printf("  %-20s %-14s %-10s %-10s %s\n",
+//		termsafe.SanitizeRowForDisplay(a.SystemID, a.Interface, a.Level, a.State, a.HoldTime)...)
+//
+// It exists to make the WHOLE-ROW rule unskippable. The tempting alternative is
+// to guard only the one column believed to carry device text — and that is
+// wrong twice over for a table scraped out of a command's stdout:
+//
+//   - Column identity is not stable. A value carrying whitespace in an EARLY
+//     column shifts every later column, so peer bytes land in cells the
+//     per-column analysis marked safe. `strings.Fields` splits on whitespace
+//     only, so an ESC, DEL, C1 or BEL rides INSIDE a token untouched while a
+//     space in the same value splits it — the attacker picks which.
+//   - "This column is numeric" is a property of the current upstream, not of
+//     the protocol. FRR already substitutes a peer-advertised IS-IS dynamic
+//     hostname for the numeric system ID, and `bgp default show-hostname` does
+//     the same for BGP; a column that is an address today can be free text
+//     after an upstream bump.
+//
+// Sanitizing a clean cell costs nothing — SanitizeForDisplay returns the input
+// string itself on the allocation-free fast path — so the uniform guard is
+// strictly cheaper than maintaining a per-column ledger of what is currently
+// attacker-reachable.
+//
+// Cells are single-line FIELDS of a caller-formatted row, so this uses
+// SanitizeForDisplay, not the block variant: an embedded newline here forges a
+// table row rather than carrying structure. (For a cell produced by
+// `strings.Fields` the two variants happen to agree, because every whitespace
+// rune was already consumed by the split; for a cell decoded out of JSON a
+// newline can survive, and there the distinction is load-bearing.)
+func SanitizeRowForDisplay(cells ...string) []any {
+	out := make([]any, len(cells))
+	for i, c := range cells {
+		out[i] = SanitizeForDisplay(c)
+	}
+	return out
+}
+
 // blockDisplaySafe is DisplaySafe with LF and TAB treated as printable and the
 // Unicode line/paragraph separators treated as unsafe, so a clean multi-line
 // blob keeps the allocation-free fast path while a row-forging separator does

--- a/pkg/termsafe/termsafe.go
+++ b/pkg/termsafe/termsafe.go
@@ -9,12 +9,32 @@
 // table is displayed — clipboard hijack and output spoofing (a forged "commit
 // complete" line, or a rogue lease row erased from view).
 //
+// The same class covers more than lease data. A DDNS provider's response body
+// reaches the operator through the `show services dynamic-dns` LastError column
+// (Cloudflare and Route 53 embed the provider message with %s), and captured
+// `vtysh` stdout carries text a BGP or IS-IS peer advertised — the BGP hostname
+// capability, IS-IS dynamic hostname TLVs. Anything a remote party can put
+// bytes into and an operator then reads on a terminal belongs here.
+//
+// Two entry points, chosen by the SHAPE of the value, not by its source:
+//
+//   - SanitizeForDisplay for a single-line FIELD rendered into a row the caller
+//     formats. LF and TAB are escaped along with everything else, because an
+//     embedded newline in a field is itself a forgery vector — it fakes a row.
+//   - SanitizeBlockForDisplay for a MULTI-LINE blob whose own line structure is
+//     the output (vtysh stdout). LF and TAB are preserved so the table survives;
+//     CR and the Unicode line/paragraph separators are not, because they forge
+//     or overwrite rows.
+//
 // This is a leaf package (it imports only the standard library) so BOTH the
 // in-process CLI renderer (pkg/cli) and the gRPC text renderer that feeds the
 // remote `cli`'s verbatim terminal print (pkg/grpcapi) can guard the same
-// device-originated fields with one implementation. Sanitizing happens at the
-// display boundary only: stored lease data and the gRPC/JSON structs are
-// unchanged, so machine consumers still receive the raw value. See #6468.
+// device-originated values with one implementation. Every guarded surface must
+// be applied on BOTH renderers — the remote `cli` is the more common operator
+// posture, and a fix on one alone leaves the other at pre-fix behavior.
+// Sanitizing happens at the display boundary only: stored lease data, the
+// DDNS status views, and the gRPC/JSON structs are unchanged, so machine
+// consumers still receive the raw value. See #6468.
 package termsafe
 
 import (
@@ -88,6 +108,23 @@ func SanitizeForDisplay(s string) string {
 // cursor and lets later text overwrite a line the operator has already read —
 // the same class of display forgery the ESC escaping defends against, and not
 // something a legitimate line-oriented blob needs.
+//
+// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are escaped too, and
+// this is where the block variant deliberately diverges from SanitizeForDisplay
+// rather than inheriting its rationale. Neither is Unicode category Cc, so
+// unicode.IsControl does not catch them and the single-line sanitizer — whose
+// doc out-scopes bidi/Cf display-order spoofing — lets them through. That is
+// defensible for a single-line field, where the caller's own format string
+// bounds the row. It is NOT defensible here: the whole premise of this variant
+// is that the blob's LINE STRUCTURE is meaningful output, and terminals and
+// pagers that honor U+2028 as a break let a peer-advertised hostname forge a
+// row in exactly the table this function exists to keep honest. Escaping them
+// is the same argument that escapes CR. They render as the visible escapes
+// \u2028 / \u2029 (a \xHH byte escape cannot represent a rune above U+00FF).
+//
+// Bidi overrides and other Cf runes remain out of scope here, as in
+// SanitizeForDisplay: they can reorder characters WITHIN a line but cannot
+// forge or erase a row, so they are a different, lower-severity class.
 func SanitizeBlockForDisplay(s string) string {
 	if blockDisplaySafe(s) {
 		return s
@@ -111,14 +148,21 @@ func SanitizeBlockForDisplay(s string) string {
 			i += size
 			continue
 		}
+		if isLineSeparator(r) {
+			writeUnicodeEscape(&b, r)
+			i += size
+			continue
+		}
 		b.WriteRune(r)
 		i += size
 	}
 	return b.String()
 }
 
-// blockDisplaySafe is DisplaySafe with LF and TAB treated as printable, so a
-// clean multi-line blob keeps the allocation-free fast path.
+// blockDisplaySafe is DisplaySafe with LF and TAB treated as printable and the
+// Unicode line/paragraph separators treated as unsafe, so a clean multi-line
+// blob keeps the allocation-free fast path while a row-forging separator does
+// not slip past it.
 func blockDisplaySafe(s string) bool {
 	for i := 0; i < len(s); {
 		r, size := utf8.DecodeRuneInString(s[i:])
@@ -128,9 +172,19 @@ func blockDisplaySafe(s string) bool {
 		if r != '\n' && r != '\t' && unicode.IsControl(r) {
 			return false
 		}
+		if isLineSeparator(r) {
+			return false
+		}
 		i += size
 	}
 	return true
+}
+
+// isLineSeparator reports whether r is a Unicode line/paragraph separator —
+// category Zl/Zp, which unicode.IsControl does not cover. Only the block
+// sanitizer treats these as unsafe; see SanitizeBlockForDisplay.
+func isLineSeparator(r rune) bool {
+	return r == '\u2028' || r == '\u2029'
 }
 
 // DisplaySafe reports whether s can be printed to a terminal verbatim: it holds
@@ -155,4 +209,15 @@ func writeHexEscape(b *strings.Builder, c byte) {
 	b.WriteString(`\x`)
 	b.WriteByte(hexDigits[c>>4])
 	b.WriteByte(hexDigits[c&0x0f])
+}
+
+// writeUnicodeEscape appends a \uHHHH escape for a rune in the Basic
+// Multilingual Plane. The \xHH form writeHexEscape emits cannot represent a
+// rune above U+00FF, so the line/paragraph separators the block sanitizer
+// escapes need this wider form.
+func writeUnicodeEscape(b *strings.Builder, r rune) {
+	b.WriteString(`\u`)
+	for shift := 12; shift >= 0; shift -= 4 {
+		b.WriteByte(hexDigits[(r>>uint(shift))&0x0f])
+	}
 }

--- a/pkg/termsafe/termsafe.go
+++ b/pkg/termsafe/termsafe.go
@@ -73,6 +73,66 @@ func SanitizeForDisplay(s string) string {
 	return b.String()
 }
 
+// SanitizeBlockForDisplay is SanitizeForDisplay for a MULTI-LINE device- or
+// remote-supplied blob — captured `vtysh` stdout, a provider response body, any
+// text whose own line structure is part of the output.
+//
+// It neutralizes the same terminal-protocol control bytes but PRESERVES the two
+// layout controls that carry the block's shape: LF (0x0A) and TAB (0x09).
+// SanitizeForDisplay escapes those too — correctly, for a single-field value
+// where an embedded newline is itself a forgery vector (it can fake a new table
+// row) — but applying it to a table would collapse the whole thing into one
+// `\x0a`-laden line, which is a display regression rather than a fix.
+//
+// CR (0x0D) is deliberately NOT preserved. A bare carriage return re-homes the
+// cursor and lets later text overwrite a line the operator has already read —
+// the same class of display forgery the ESC escaping defends against, and not
+// something a legitimate line-oriented blob needs.
+func SanitizeBlockForDisplay(s string) string {
+	if blockDisplaySafe(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			writeHexEscape(&b, s[i])
+			i++
+			continue
+		}
+		if r == '\n' || r == '\t' {
+			b.WriteRune(r)
+			i += size
+			continue
+		}
+		if unicode.IsControl(r) {
+			writeHexEscape(&b, byte(r))
+			i += size
+			continue
+		}
+		b.WriteRune(r)
+		i += size
+	}
+	return b.String()
+}
+
+// blockDisplaySafe is DisplaySafe with LF and TAB treated as printable, so a
+// clean multi-line blob keeps the allocation-free fast path.
+func blockDisplaySafe(s string) bool {
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			return false
+		}
+		if r != '\n' && r != '\t' && unicode.IsControl(r) {
+			return false
+		}
+		i += size
+	}
+	return true
+}
+
 // DisplaySafe reports whether s can be printed to a terminal verbatim: it holds
 // no control rune and no invalid UTF-8 byte, so SanitizeForDisplay would return
 // it unchanged. Splitting this out keeps the common (clean) path allocation-free.


### PR DESCRIPTION
#6468 escaped the DHCP lease fields it named — hostname, HWAddress, DDNS FQDN —
on both terminal surfaces, and that part is correct and well tested. A hostile
post-merge review of that closure found **two other device/remote-supplied
strings still reaching an operator terminal raw**. Both Low; neither is the
LAN-adjacent DHCP vector the issue was filed for.

## D1 — DDNS `LastError`

It can carry a **provider response body**. Cloudflare
(`backend_cloudflare.go:166`) and Route 53 (`backend_route53.go:195,277`) embed
the provider's own message with `%s`. So a hostile or compromised provider — or
an operator pointed at an attacker-run endpoint — can land an OSC/CSI sequence
on the terminal via `show services dynamic-dns`. The other backends do not
reach the terminal with raw bytes: dyndns2 and duckdns wrap the response token
in `%q`, **generic omits the body entirely** (`backend_generic.go:242` formats
only the configured success tokens with `%v`), and rfc2136 reports a fixed
rcode string from `dns.RcodeToString`.

Path: `err.Error()` → `surface_a.go` `rt.lastErr` → `v.LastError` → the two
print sites.

Fixed at the **display** sites rather than per-backend: it covers the class
regardless of which backend produced the string, and is smaller than auditing
every backend's format verb.

> Worth noting this corrects an earlier review of mine, which cleared DDNS
> `LastError` as safe on the grounds that the embedding sites use `%q`.
>
> **Correction (Codex round, folded in `83aba402d`):** an earlier revision of
> this PR body and of the code comments said dyndns2/duckdns/**generic** all
> wrap the body in `%q`. Generic does not — it omits the body entirely. The
> correct tally is: **two** embed it unquoted (Cloudflare, Route 53), two quote
> it (dyndns2, duckdns), generic omits it, rfc2136 uses fixed rcode strings.
> The fix is unaffected — the two unsafe backends are the two identified — and
> sanitizing at the display site is precisely what makes this tally a
> documentation detail rather than a security dependency.

## D2 — raw `vtysh` stdout

Every `fmt.Print(output)` in `cli_show_routing.go` printed unmodified `vtysh`
output, and several of those commands render remote-advertised text: the BGP
peer's **hostname capability**, IS-IS **dynamic hostname TLVs**, OSPF router
IDs. All 12 sites are `c.frr.Get*` calls, so they are sanitized uniformly
rather than only the three BGP ones the review named — the same text class
reaches the terminal through each.

## Why D2 needed a new primitive

`SanitizeForDisplay` escapes **all** of Unicode category Cc, including LF and
TAB. That is correct for a single-line field — an embedded newline is itself a
forgery vector, since it can fake a table row — but destructive for a block: it
would collapse a whole BGP table into one `\x0a`-laden line. That is a display
regression, not a fix.

`SanitizeBlockForDisplay` preserves exactly LF and TAB and escapes everything
else. **CR is deliberately not preserved**: a bare carriage return re-homes the
cursor and lets later text overwrite a line the operator has already read — the
same display forgery the ESC escaping defends against.

## Scope — what this does NOT fix

Escaping a row does not prevent **semantic** spoofing, and nothing here should
be read as claiming otherwise. `frr.GetISISAdjacency` splits `show isis
neighbor` with `strings.Fields`, so a peer hostname containing a **space**
shifts every later column:

```text
evil peer ge-0-0-1 2 Up 27
  -> SystemID=evil  Interface=peer  Level=ge-0-0-1  State=2  HoldTime=Up
```

`SanitizeRowForDisplay` preserves plausible printable text by design, so it
cannot tell a genuine `State=Up` from a peer-supplied token. **A displayed row
can be terminal-safe and still be materially false.** Spaces are reachable:
RFC 5301 permits operator-chosen symbolic hostnames and FRR retains printable
ASCII spaces when decoding the dynamic-hostname TLV.

That is a different bug class at a different layer — it needs the **parse** to
change (FRR's JSON output, or right-anchored columns that report malformed rows
instead of rendering them silently), not a display guard. It is tracked as
**#6590** and deliberately not attempted here.

What this PR does about it is make sure the claims match the delivery. The
narrowing is in `pkg/termsafe`'s package doc, the `SanitizeRowForDisplay` doc (a
"What this does NOT fix" section ending *"do not cite a call to this function as
evidence that a rendered row is trustworthy"*), the `SanitizeBlockForDisplay`
doc, `frr.ISISAdjacency`, and `pkg/cli/README.md` ("What the guard does NOT do —
do not overstate this in a review"). Each points at #6590.

## Cost of the row helper, measured

The doc previously said sanitizing a clean cell "costs nothing", which was true
of the cell and false of the helper. Codex measured ~96 B / 4 allocs per clean
3-cell row "versus zero for direct formatting". The first figure reproduces; the
zero-alloc baseline does not — it is an artifact of benchmarking string
**constants**, which the compiler boxes into read-only statics. With
production-shaped values (struct fields), 10k 3-cell rows:

| path | allocs | bytes |
|---|---|---|
| no sanitizer at all | 30,034 | 3.73 MB |
| per-cell `SanitizeForDisplay`, no helper | 30,035 | 3.73 MB |
| `SanitizeRowForDisplay(...)...` | 40,037 | 4.21 MB |

The helper's real cost is **one allocation and 48 bytes per row** (the `[]any`);
the three-per-row boxing is inherent to `fmt`'s variadic `any` and the unguarded
path pays it too. The per-cell sanitize is genuinely free — that was the
substantive claim and it holds. Accepted rather than restructured: these are
`show`-command render loops already gated by a `vtysh` fork/exec and a
whole-table string materialization, not a packet path. The doc now carries the
table and names the escape hatch (hoist a scratch `[]any` out of the loop);
`BenchmarkSanitizedRow{Unguarded,Inline,Helper}` plus a `testing.AllocsPerRun`
pin keep it checkable.

## `SanitizeForDisplay` now escapes U+2028/U+2029

The first fold gave the **block** variant line-separator escaping and left the
**field** variant passing them. That became incoherent once table cells started
going through the field variant: it already escapes LF, so passing the Unicode
line break while escaping the ASCII one made the *stricter* variant the more
permissive one for exactly the row-forgery vector. `DisplaySafe` moves in
lockstep — it gates the allocation-free return, so leaving it behind would make
the new escaping dead code, and a test now says so.

This changes behavior for the already-merged #6468 lease surfaces (DHCP
`Hostname`/`HWAddress`, DDNS `FQDN` and `LastError`). Judged a strict
improvement: all are single-line fields padded into a row, where a line
separator has no legitimate use. `DisplaySafe` has no callers outside the
package.

## Validation

**All 10 parsed-row sites are individually bound** (5 per renderer). OSPF
neighbors, BGP routes and RIP routes previously had no call-site binder on
either renderer; they do now. Reverting any single site produces a build-clean
**assertion** failure naming that site.

The gRPC IS-IS per-cell guard was **masked** by the response-boundary block
guard, so the earlier test proved safe output rather than the guard's presence.
Codex's suggested isolating shape (a JSON-decoded cell carrying LF) is not
reachable for that row — `strings.Fields` splits on `unicode.IsSpace`, which
covers LF, TAB, NEL, NBSP *and* U+2028/U+2029, so no whitespace rune survives
into an IS-IS cell. The discriminator that does survive the mask is **column
alignment**: `%-20s` pads whatever it is handed, so guarding the cell pads the
17-character escaped text to 20, while guarding only the response pads the
14-byte raw text and *then* expands the escape. Reverting now fails with:

> the next column starts at 26 instead of 23 — exactly the 3 bytes the ESC grows
> by when escaped. The width format padded the RAW cell and the escaping
> happened afterwards, at the response boundary.

That binds a real property, not just a test: the guard must precede the width
format, or a hostile cell displaces every column after it.

The `encoding/json` declared-field-set boundary documented on `frr.bgpPeerJSON`
is now pinned by two tests: a hostile `hostname` key must reach **no** string
field of `BGPPeerSummary` (reflective, so a future field addition is caught),
and `bgpPeerJSON` must declare neither a hostname field nor a catch-all decode
target (map/interface/slice) that would defeat "undeclared keys are dropped".

Every revert was done one hunk at a time via edit so the RED is an assertion and
never a build break; `go vet` confirmed passing under each. `pkg/cli`,
`pkg/grpcapi`, `pkg/termsafe`, `pkg/frr`, `pkg/api` and `pkg/ddns` all green;
`go build ./...` and `go vet ./pkg/...` clean.

Advances #6468. Semantic spoofing of the parsed row is tracked in #6590.
