### PR TITLE
dhcp: refuse a DHCPv6 IA_PD prefix-length of 0 or > 128

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -61540,3 +61540,42 @@ would never produce.
 - **File(s)**: pkg/dhcp/dhcpv6.go,
     pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go,
     pkg/ra/sender_prefixlen_6531_test.go, pkg/dhcp/README.md, _Log.md
+- **Timestamp**: 2026-07-31
+- **Action**: #6531 / PR #6581 review fold — three documentation-accuracy
+  defects from the Codex review (no logic change; the guard block in
+  extractDelegatedPrefixes is byte-identical to the pre-fold commit).
+  (1) The "empty after skip is unusable and retried" claim in
+  pkg/dhcp/README.md and the extractDelegatedPrefixes comment was FALSE
+  for a mixed ia-na + ia-pd client: parseV6Reply's rejection requires
+  BOTH no IA_NA address and no live PD, so a valid IA_NA lets parsing
+  succeed with zero PDs, and reconcileDelegatedPDs then reads empty
+  live+withdrawn as SILENCE and RETAINS the prior delegation
+  (apply=false, #1844). Verified no /0 is reintroduced on either branch;
+  corrected both statements and bound them with
+  TestIAPDPrefixLen6531_MixedIANAReplyStaysUsable, which drives the real
+  parseV6Reply over hand-rolled IA_NA + IA_PD wire bytes.
+  (2) Two tests over-claimed end-to-end RA coverage. Extended where the
+  seams allowed and renamed where they did not: pkg/ra's prefixInfoFor
+  now MARSHALS the RA and asserts on the RE-PARSED wire bytes instead of
+  buildRA's in-memory option; a new pkg/daemon/ra_pd_prefixlen_6531_test.go
+  calls the real Daemon.buildRAConfigs over a seeded PD (and pins that
+  daemon_ra.go's !subPrefix.IsValid() check does NOT stop a /0);
+  NormalDelegationStillReachesRA renamed to
+  NormalDelegationSurvivesSubPrefixDerivation and re-commented to claim
+  only its leg.
+  (3) The comment "RFC 8415 has no zero-length delegation" was wrong.
+  Verified against the RFC text firsthand: §21.22 says only that a
+  CLIENT "SHOULD NOT send an IA Prefix option with 0 in the
+  'prefix-length' field (and an unspecified value (::) in the
+  'IPv6-prefix' field)" — a hint rule, no delegation floor — and RFC
+  4861 §4.6.2 says a PIO prefix length "ranges from 0 to 128". Restated
+  the row as an xpf policy choice about what is safe to advertise.
+  RED-on-revert re-audited with the guard reverted via Edit: go build +
+  go vet CLEAN (no false red), 6 pre-existing gates plus the new mixed
+  IA_NA test fail on ASSERTIONS naming the live /0, every over-reach row
+  and both consumer-side test pairs stay green. Full pkg/dhcp, pkg/ra
+  and pkg/daemon suites pass.
+- **File(s)**: pkg/dhcp/dhcpv6.go, pkg/dhcp/README.md,
+    pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go,
+    pkg/ra/sender_prefixlen_6531_test.go,
+    pkg/daemon/ra_pd_prefixlen_6531_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -61521,3 +61521,22 @@ would never produce.
     is retuned, and replaced test 2's false subsumption claim with an honest
     accounting.
   - **File(s)**: pkg/dataplane/userspace/routes_6467_crossfamily_test.go
+- **Timestamp**: 2026-07-31
+- **Action**: #6531 guard the DHCPv6 IA_PD prefix-length at the wire
+  decoder. insomniacslk/dhcp decodes the IAPREFIX length byte as
+  net.CIDRMask(length, 128), which returns a NIL mask for any length
+  > 128; net.IPMask(nil).Size() is (0,0), so extractDelegatedPrefixes
+  reading only `ones` and discarding `bits` turned a crafted length of
+  129..255 into a <ip>/0 that reached pkg/ra and was advertised on-link
+  + autonomous to the LAN. Added `bits != 128 || ones == 0`, skipping
+  the offending IAPREFIX (an IA_PD is a multi-element container, so this
+  matches the option-121 classless-route loop rather than
+  leaseFromACKv4's whole-message refusal for a single-valued v4 ACK).
+  Verified firsthand that the library produces a nil mask for > 128 and
+  a nil Prefix for 0 (the latter already skipped). RED-on-revert
+  confirmed: the 129/130/255 rows, the good+bad sibling test, and the
+  withdrawal test all fail with a live /0; the 0/1/48/56/64/128
+  over-reach rows and both pkg/ra tests stay green.
+- **File(s)**: pkg/dhcp/dhcpv6.go,
+    pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go,
+    pkg/ra/sender_prefixlen_6531_test.go, pkg/dhcp/README.md, _Log.md

--- a/pkg/daemon/ra_pd_prefixlen_6531_test.go
+++ b/pkg/daemon/ra_pd_prefixlen_6531_test.go
@@ -1,0 +1,106 @@
+package daemon
+
+// #6531, MIDDLE LEG of the PD → RA chain: a STORED delegated prefix →
+// Daemon.buildRAConfigs → config.RAPrefix.
+//
+// The #6531 fix lives at the DHCPv6 decoder (pkg/dhcp extractDelegatedPrefixes),
+// and its pkg/dhcp tests stop at DeriveSubPrefix while the pkg/ra tests start
+// from a statically built config.RAPrefix. Neither of them crosses this hop, so
+// nothing exercised the code that actually turns a delegation into an
+// advertisement (#6581 review). These tests call the real buildRAConfigs.
+//
+// Both are documentation of the consumer seam and the blast radius, NOT
+// RED-on-revert guards: they are GREEN before and after the pkg/dhcp fix (the
+// first is an over-reach guard; the second pins current unguarded behavior,
+// exactly like pkg/ra's TestBuildRA_6531_ZeroPrefixWouldBeAdvertised). The
+// RED-on-revert coverage for the guard itself lives in
+// pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go.
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dhcp"
+)
+
+// raPrefixesFor6531 seeds one delegated prefix on a WAN source pointed at
+// downstream RA interface "trust0", runs the real buildRAConfigs over an
+// otherwise empty config, and returns the RA prefixes it produced for that
+// interface.
+//
+// The seam sets no sub-prefix length, so DeriveSubPrefix returns the delegation
+// unchanged — which is what makes the delegated length itself observable here.
+func raPrefixesFor6531(t *testing.T, delegated netip.Prefix) []*config.RAPrefix {
+	t.Helper()
+
+	mgr := dhcp.NewManagerForTesting(nil)
+	mgr.SeedDelegatedPrefixesForRATesting("ge-0/0/3", "trust0", []dhcp.DelegatedPrefix{{
+		Interface:         "ge-0/0/3",
+		Prefix:            delegated,
+		PreferredLifetime: 3600 * time.Second,
+		ValidLifetime:     7200 * time.Second,
+	}})
+
+	d := &Daemon{dhcp: mgr}
+	ras := d.buildRAConfigs(&config.Config{})
+
+	for _, ra := range ras {
+		if ra.Interface == "trust0" {
+			return ra.Prefixes
+		}
+	}
+	t.Fatalf("buildRAConfigs produced no RA config for trust0; got %d configs", len(ras))
+	return nil
+}
+
+// Over-reach guard: a normal delegation must still become an advertised
+// prefix, on-link + autonomous, with the delegation's lifetimes carried over.
+// GREEN under a revert of the pkg/dhcp guard.
+func TestBuildRAConfigs_6531_DelegatedPrefixBecomesRAPrefix(t *testing.T) {
+	pfxs := raPrefixesFor6531(t, netip.MustParsePrefix("2001:db8:900d::/64"))
+
+	if len(pfxs) != 1 {
+		t.Fatalf("got %d RA prefixes %v, want exactly the delegated one", len(pfxs), pfxs)
+	}
+	got := pfxs[0]
+	if got.Prefix != "2001:db8:900d::/64" {
+		t.Errorf("advertised prefix = %q, want %q", got.Prefix, "2001:db8:900d::/64")
+	}
+	if !got.OnLink || !got.Autonomous {
+		t.Errorf("OnLink = %v, Autonomous = %v, want both true — buildRAConfigs "+
+			"hard-sets these for every PD-derived prefix", got.OnLink, got.Autonomous)
+	}
+	if got.ValidLifetime != 7200 || got.PreferredLife != 3600 {
+		t.Errorf("lifetimes = valid %d / preferred %d, want 7200 / 3600 — the "+
+			"delegation's lifetimes must reach the advertisement",
+			got.ValidLifetime, got.PreferredLife)
+	}
+}
+
+// The blast radius, measured at THIS hop: buildRAConfigs has exactly one
+// rejection — `if !subPrefix.IsValid()` (daemon_ra.go) — and a /0 passes it.
+//
+// This is the load-bearing reason the #6531 guard must sit at the DHCPv6
+// decoder: 2001:db8:bad::/0 is precisely what the unguarded decoder produced
+// from a wire prefix-length of 129..255, netip.Prefix reports it as VALID, and
+// DeriveSubPrefix returns it unchanged, so the only check on this path waves it
+// through as on-link + autonomous. GREEN before and after the fix.
+func TestBuildRAConfigs_6531_ZeroPrefixSurvivesTheIsValidGuard(t *testing.T) {
+	pfxs := raPrefixesFor6531(t, netip.MustParsePrefix("2001:db8:bad::/0"))
+
+	if len(pfxs) != 1 {
+		t.Fatalf("got %d RA prefixes %v, want 1 — buildRAConfigs gained a "+
+			"prefix-length filter; re-check whether the #6531 guard in pkg/dhcp "+
+			"is still the only thing keeping a delegated /0 off the wire", len(pfxs), pfxs)
+	}
+	got := pfxs[0]
+	if got.Prefix != "2001:db8:bad::/0" {
+		t.Fatalf("advertised prefix = %q, want %q — see above", got.Prefix, "2001:db8:bad::/0")
+	}
+	if !got.OnLink || !got.Autonomous {
+		t.Errorf("OnLink = %v, Autonomous = %v, want both true "+
+			"(this is what makes a /0 a LAN-wide hijack)", got.OnLink, got.Autonomous)
+	}
+}

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -274,6 +274,38 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   is an acquisition failure and is retried, never settled into an empty
   1h lease — counted regardless of `wantNA` so a PD-only client cannot
   fall through. Pinned by `dhcp_lease_expiry_4874_test.go`.
+- **DHCPv6 IA_PD prefix-length is validated at the DECODER** (#6531). The
+  wire prefix-length is a single byte, and insomniacslk/dhcp decodes it
+  as `net.CIDRMask(int(length), 128)` — which returns a **nil** mask for
+  any length > 128. `net.IPMask(nil).Size()` is `(0, 0)`, so
+  `extractDelegatedPrefixes` reading only `ones` and discarding `bits`
+  turned a crafted length of 129..255 into a `<ip>/0`. That `/0` survived
+  `IsValid()` and `DeriveSubPrefix` and reached `pkg/ra`, which applies
+  no sanity floor of its own and advertised `PrefixInformation{PrefixLength:
+  0, OnLink, Autonomous}` to the downstream LAN — a hostile or buggy
+  upstream WAN server hijacking every SLAAC host's on-link determination
+  with one crafted option. The guard is `bits != 128 || ones == 0`
+  (`bits` is the load-bearing arm: a nil mask and a non-contiguous mask
+  both report `bits` 0; `ones == 0` is belt-and-braces for a genuine
+  all-zero 128-bit mask that only an in-process constructor can build,
+  since the decoder maps a wire length of 0 to a nil `Prefix`). The
+  offending IAPREFIX is **skipped**, not the whole reply: an IA_PD is a
+  multi-element container, matching the option-121 classless-route loop
+  below (which likewise skips an entry whose mask reports `bits != 32`),
+  whereas `leaseFromACKv4` refuses the entire v4 message only because an
+  ACK carries exactly one address+mask and there is nothing to salvage.
+  A skipped entry enters neither the live nor the withdrawn set, so a
+  hostile server gains nothing by pairing a malformed prefix with a
+  well-formed one; if the skip empties both sets the reply is treated as
+  unusable and retried. `/128` is ACCEPTED (a legal single-address
+  delegation — the bound is inclusive). Pinned by
+  `dhcpv6_iapd_prefixlen_6531_test.go`, which drives hand-rolled option
+  BYTES through `dhcpv6.MessageFromBytes`; the older IA_PD tests build
+  `OptIAPrefix` structs directly and cannot reach this path, which is how
+  the bug survived (`OptIAPrefix.ToBytes` derives the wire length from
+  `Mask.Size()`, so the library's own marshaller cannot emit > 128
+  either). `pkg/ra/sender_prefixlen_6531_test.go` pins the blast radius
+  from the consumer side.
 - **RFC 3442 classless static routes (option 121 / legacy 249, #4118).**
   `leaseFromACKv4` parses option 121 (the standard `ClasslessStaticRoute`
   accessor) and falls back to the legacy Microsoft option 249 (raw

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -296,16 +296,33 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
   ACK carries exactly one address+mask and there is nothing to salvage.
   A skipped entry enters neither the live nor the withdrawn set, so a
   hostile server gains nothing by pairing a malformed prefix with a
-  well-formed one; if the skip empties both sets the reply is treated as
-  unusable and retried. `/128` is ACCEPTED (a legal single-address
+  well-formed one. When the skip empties BOTH sets the outcome depends
+  on what else the reply carried — neither branch yields a `/0`, but
+  they are not the same branch. With no IA_NA address either, the "no
+  usable IA_NA address or live IA_PD prefix" guard rejects the reply and
+  the acquire/renew loop retries. With a valid IA_NA address the reply
+  is still USABLE (that guard fires only when both are missing), so a
+  mixed `ia-na` + `ia-pd` client installs the address and simply carries
+  no new PD; the empty live+withdrawn pair then reads as SILENCE to
+  `reconcileDelegatedPDs`, which returns `apply=false` so a previously
+  held delegation is retained untouched (the #1844 anti-outage rule).
+  A malformed IAPREFIX therefore cannot clear the held set either.
+  `/128` is ACCEPTED (a legal single-address
   delegation — the bound is inclusive). Pinned by
   `dhcpv6_iapd_prefixlen_6531_test.go`, which drives hand-rolled option
   BYTES through `dhcpv6.MessageFromBytes`; the older IA_PD tests build
   `OptIAPrefix` structs directly and cannot reach this path, which is how
   the bug survived (`OptIAPrefix.ToBytes` derives the wire length from
   `Mask.Size()`, so the library's own marshaller cannot emit > 128
-  either). `pkg/ra/sender_prefixlen_6531_test.go` pins the blast radius
-  from the consumer side.
+  either). The PD → RA chain downstream of the guard is covered in three
+  segments meeting at typed seams, each test claiming only its own leg:
+  `dhcpv6_iapd_prefixlen_6531_test.go` covers wire bytes → `[]DelegatedPrefix`
+  → `DeriveSubPrefix`; `pkg/daemon/ra_pd_prefixlen_6531_test.go` calls the
+  real `buildRAConfigs` to cover the stored PD → `config.RAPrefix` hop (and
+  pins that `daemon_ra.go`'s `!subPrefix.IsValid()` check does NOT stop a
+  `/0`); `pkg/ra/sender_prefixlen_6531_test.go` covers `config.RAPrefix` →
+  `buildRA` → `ndp.MarshalMessage` and asserts on the RE-PARSED wire bytes,
+  pinning the blast radius from the consumer side.
 - **RFC 3442 classless static routes (option 121 / legacy 249, #4118).**
   `leaseFromACKv4` parses option 121 (the standard `ClasslessStaticRoute`
   accessor) and falls back to the legacy Microsoft option 249 (raw

--- a/pkg/dhcp/dhcpv6.go
+++ b/pkg/dhcp/dhcpv6.go
@@ -715,9 +715,25 @@ func extractDelegatedPrefixes(msg *dhcpv6.Message, ifaceName string, now time.Ti
 			// never becomes a DelegatedPrefix, so it reaches neither the live
 			// set, the withdrawn set, nor the RA sender — while a sibling
 			// prefix in the same IA_PD is exactly what a correct server would
-			// have sent on its own. If the skip empties both sets, the caller
-			// treats the reply as unusable and retries rather than settling
-			// into an empty lease.
+			// have sent on its own.
+			//
+			// When the skip empties BOTH sets the outcome depends on what
+			// else the reply carried. Neither branch can yield a /0, but they
+			// are NOT the same branch (#6581 review):
+			//
+			//   - No IA_NA address either: parseV6Reply's "no usable IA_NA
+			//     address or live IA_PD prefix" guard rejects the reply and
+			//     the acquire/renew loop retries.
+			//   - A valid IA_NA address: parsing SUCCEEDS — that guard fires
+			//     only when BOTH are missing — so a mixed ia-na + ia-pd
+			//     client installs the address and simply carries no new PD.
+			//     Empty live+withdrawn then reads as SILENCE to
+			//     reconcileDelegatedPDs, which returns (prior, apply=false),
+			//     so a previously held delegation is retained untouched (the
+			//     #1844 anti-outage rule). A malformed IAPREFIX therefore
+			//     cannot clear the held set either.
+			//
+			// Pinned by TestIAPDPrefixLen6531_MixedIANAReplyStaysUsable.
 			ones, bits := prefix.Prefix.Mask.Size()
 			if bits != 128 || ones == 0 {
 				slog.Warn("DHCPv6: refusing IA_PD prefix with invalid mask",

--- a/pkg/dhcp/dhcpv6.go
+++ b/pkg/dhcp/dhcpv6.go
@@ -673,6 +673,11 @@ func (m *Manager) buildDHCPv6Modifiers(ifaceName string, opts *DHCPv6Options) []
 // (per-prefix, so a co-held prefix the reply merely omitted is retained)
 // rather than keeping it and re-granting it at the RA sender's 30-day
 // defaults (#4874 B).
+//
+// An IAPREFIX whose decoded mask is degenerate (wire prefix-length 0 or
+// > 128, or a non-contiguous mask) is dropped and enters NEITHER set — a
+// > 128 length otherwise decodes to a /0 that would be advertised on-link
+// to the LAN (#6531).
 func extractDelegatedPrefixes(msg *dhcpv6.Message, ifaceName string, now time.Time) (live, withdrawn []DelegatedPrefix) {
 	for _, opt := range msg.Options.Options {
 		iapdOpt, ok := opt.(*dhcpv6.OptIAPD)
@@ -683,7 +688,45 @@ func extractDelegatedPrefixes(msg *dhcpv6.Message, ifaceName string, now time.Ti
 			if prefix.Prefix == nil {
 				continue
 			}
-			ones, _ := prefix.Prefix.Mask.Size()
+			// Reject a degenerate IAPREFIX mask (untrusted input — the
+			// upstream WAN server, hostile or merely buggy). The library
+			// decodes the wire prefix-length byte as
+			// net.CIDRMask(length, 128), which returns a NIL mask for any
+			// length > 128, and net.IPMask(nil).Size() is (0, 0). Reading
+			// only `ones` and discarding `bits` therefore turned a crafted
+			// length of 129..255 into a <ip>/0, which survives IsValid() and
+			// DeriveSubPrefix and reaches the RA sender — advertising a /0 to
+			// the downstream LAN as on-link + autonomous and hijacking every
+			// SLAAC host's on-link determination (#6531).
+			//
+			// `bits != 128` is the arm that catches it: a nil mask and a
+			// non-contiguous mask both report bits 0. `ones == 0` is
+			// belt-and-braces for a genuine all-zero 128-bit mask, which the
+			// wire decoder cannot currently produce (it maps a length of 0 to
+			// a nil Prefix, skipped above) but an in-process constructor can.
+			//
+			// Skip the offending IAPREFIX rather than refusing the whole
+			// reply: an IA_PD is a multi-element container, so this matches
+			// the RFC 3442 classless-route loop in leaseFromACKv4's sibling
+			// (which likewise skips a route whose mask reports bits != 32).
+			// leaseFromACKv4 itself refuses the entire message only because a
+			// v4 ACK carries exactly one address+mask, so there is nothing to
+			// salvage. Skipping cannot smuggle the bad prefix through — it
+			// never becomes a DelegatedPrefix, so it reaches neither the live
+			// set, the withdrawn set, nor the RA sender — while a sibling
+			// prefix in the same IA_PD is exactly what a correct server would
+			// have sent on its own. If the skip empties both sets, the caller
+			// treats the reply as unusable and retries rather than settling
+			// into an empty lease.
+			ones, bits := prefix.Prefix.Mask.Size()
+			if bits != 128 || ones == 0 {
+				slog.Warn("DHCPv6: refusing IA_PD prefix with invalid mask",
+					"interface", ifaceName,
+					"ip", prefix.Prefix.IP,
+					"mask", prefix.Prefix.Mask,
+					"detail", "wire prefix-length 0 or > 128, or non-contiguous mask")
+				continue
+			}
 			ip, ok := netip.AddrFromSlice(prefix.Prefix.IP)
 			if !ok {
 				continue

--- a/pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go
+++ b/pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go
@@ -23,11 +23,14 @@ package dhcp
 // RED-on-revert: restore `ones, _ := prefix.Prefix.Mask.Size()` and drop the
 // `bits != 128 || ones == 0` guard in extractDelegatedPrefixes.
 // TestIAPDPrefixLen6531_WireBoundaryTable fails on the 129/130/255 rows (each
-// yields a live /0), and TestIAPDPrefixLen6531_BadSiblingDoesNotRideAlong and
-// TestIAPDPrefixLen6531_BadWithdrawalIsDropped fail as well. Every other test
-// in this file is the OVER-REACH guard and must stay GREEN under the revert.
+// yields a live /0), and TestIAPDPrefixLen6531_BadSiblingDoesNotRideAlong,
+// TestIAPDPrefixLen6531_BadWithdrawalIsDropped and
+// TestIAPDPrefixLen6531_MixedIANAReplyStaysUsable fail as well. Every other
+// test in this file is the OVER-REACH guard and must stay GREEN under the
+// revert.
 
 import (
+	"context"
 	"encoding/binary"
 	"net"
 	"net/netip"
@@ -49,6 +52,36 @@ func iaPrefixWire(prefLen uint8, ip string, preferred, valid uint32) []byte {
 
 	tlv := make([]byte, 0, 4+len(body))
 	tlv = binary.BigEndian.AppendUint16(tlv, uint16(dhcpv6.OptionIAPrefix))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(len(body)))
+	return append(tlv, body...)
+}
+
+// iaAddrWire builds the raw bytes of one IAADDR (option 5) TLV:
+// 16B address | 4B preferred lifetime | 4B valid lifetime.
+func iaAddrWire(ip string, preferred, valid uint32) []byte {
+	body := make([]byte, 0, 24)
+	body = append(body, net.ParseIP(ip).To16()...)
+	body = binary.BigEndian.AppendUint32(body, preferred)
+	body = binary.BigEndian.AppendUint32(body, valid)
+
+	tlv := make([]byte, 0, 4+len(body))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(dhcpv6.OptionIAAddr))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(len(body)))
+	return append(tlv, body...)
+}
+
+// iaNAWire wraps IAADDR TLVs in an IA_NA (option 3):
+// 4B IAID | 4B T1 | 4B T2 | sub-options.
+func iaNAWire(inner ...[]byte) []byte {
+	body := []byte{0, 0, 0, 1}
+	body = binary.BigEndian.AppendUint32(body, 1800)
+	body = binary.BigEndian.AppendUint32(body, 2880)
+	for _, b := range inner {
+		body = append(body, b...)
+	}
+
+	tlv := make([]byte, 0, 4+len(body))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(dhcpv6.OptionIANA))
 	tlv = binary.BigEndian.AppendUint16(tlv, uint16(len(body)))
 	return append(tlv, body...)
 }
@@ -122,10 +155,23 @@ func TestIAPDPrefixLen6531_WireBoundaryTable(t *testing.T) {
 			name:    "length 0 refused",
 			prefLen: 0,
 			want:    "",
-			why: "RFC 8415 has no zero-length delegation. The library maps a " +
-				"wire length of 0 to a nil Prefix, so the pre-existing nil check " +
-				"already skipped it — this row is GREEN before and after the fix " +
-				"and pins that the /0 cannot re-enter through the length-0 door.",
+			why: "Refusing a zero-length delegation is an xpf POLICY choice, not " +
+				"an RFC prohibition — do not re-justify this row by citation. " +
+				"RFC 8415 §21.22 constrains only the CLIENT's outbound hint: the " +
+				"client 'SHOULD NOT send an IA Prefix option with 0 in the " +
+				"\"prefix-length\" field (and an unspecified value (::) in the " +
+				"\"IPv6-prefix\" field)'. It sets no floor on what a server may " +
+				"delegate — its only normative statement on the field is " +
+				"'prefix-length: Length for this prefix in bits. A 1-octet " +
+				"unsigned integer.' And nothing downstream would reject the /0 " +
+				"either: RFC 4861 §4.6.2 says a Prefix Information prefix length " +
+				"'ranges from 0 to 128'. xpf refuses it because DeriveSubPrefix " +
+				"passes a /0 through unchanged and the RA sender then advertises " +
+				"::/0 to the LAN as on-link + autonomous. " +
+				"Mechanically this row is already GREEN: the library maps a wire " +
+				"length of 0 to a nil Prefix, so the pre-existing nil check " +
+				"skipped it before and after the fix — the row pins that the /0 " +
+				"cannot re-enter through the length-0 door.",
 		},
 		{
 			name:    "length 1 accepted",
@@ -279,11 +325,94 @@ func TestIAPDPrefixLen6531_BadWithdrawalIsDropped(t *testing.T) {
 	}
 }
 
-// Over-reach guard, full chain: a normal delegation decoded from the wire must
-// still survive the hop into the RA sender — DeriveSubPrefix is the boundary
-// pkg/daemon crosses (daemon_ra.go) to turn a delegated prefix into the
-// advertised one. Must stay GREEN under the revert.
-func TestIAPDPrefixLen6531_NormalDelegationStillReachesRA(t *testing.T) {
+// What ACTUALLY happens when the skip empties both PD sets, for the common
+// mixed ia-na + ia-pd client (#6581 review).
+//
+// The original fix documented this as "the reply is treated as unusable and
+// retried", which is only true for a PD-ONLY client. parseV6Reply's rejection
+// requires BOTH no IA_NA address AND no live PD, so a valid IA_NA lets parsing
+// SUCCEED even when every IAPREFIX was skipped. This test pins the real
+// behavior end-to-end through the production parser, and pins that the real
+// behavior is still safe on both counts:
+//
+//  1. The reply parses cleanly and the IA_NA address installs — dropping a
+//     malformed IAPREFIX must not cost the client its v6 address.
+//  2. NO prefix reaches either set, so nothing downstream can advertise a /0.
+//  3. Empty live+withdrawn is SILENCE to reconcileDelegatedPDs, so a prior
+//     delegation is RETAINED verbatim (apply=false, the #1844 anti-outage
+//     rule). A hostile server cannot use a malformed IAPREFIX to clear the
+//     held set — the attack the "retried" wording obscured.
+//
+// RED-on-revert (assertions, not a build break): the length-200 IAPREFIX
+// becomes a live 2001:db8:bad::/0, so assertion 2 reds ("got 1 live prefix …
+// 2001:db8:bad::/0") and assertion 3 reds twice — reconcileDelegatedPDs takes
+// the apply=true branch and the /0 lands in the reconciled set alongside the
+// held /56.
+func TestIAPDPrefixLen6531_MixedIANAReplyStaysUsable(t *testing.T) {
+	msg := decodeReplyWire(t, 1,
+		iaNAWire(iaAddrWire("2001:db8:a::5", 3600, 7200)),
+		iaPDWire(iaPrefixWire(200, "2001:db8:bad::", 3600, 7200)))
+
+	m := NewManagerForTesting(nil)
+	res, err := m.parseV6Reply(context.Background(), "wan0", msg,
+		&DHCPv6Options{IATypes: []string{"ia-na", "ia-pd"}})
+
+	// 1. The reply is USABLE — not "unusable and retried".
+	if err != nil {
+		t.Fatalf("parseV6Reply returned %v; a reply whose IA_NA address is valid "+
+			"must still parse when every IAPREFIX was skipped — the rejection at "+
+			"parseV6Reply requires BOTH no address and no live PD", err)
+	}
+	if got, want := res.lease.Address, netip.MustParsePrefix("2001:db8:a::5/128"); got != want {
+		t.Errorf("lease address = %s, want %s — the IA_NA must survive a "+
+			"skipped IAPREFIX", got, want)
+	}
+
+	// 2. Nothing reached either PD set.
+	if len(res.prefixes) != 0 {
+		t.Errorf("got %d live prefixes %v, want 0 — a wire prefix-length of 200 "+
+			"must never become a delegated prefix", len(res.prefixes), res.prefixes)
+	}
+	if len(res.withdrawnPDs) != 0 {
+		t.Errorf("got %d withdrawn prefixes %v, want 0", len(res.withdrawnPDs), res.withdrawnPDs)
+	}
+
+	// 3. Silence, not withdrawal: the held delegation is retained verbatim.
+	prior := []DelegatedPrefix{{
+		Interface:     "wan0",
+		Prefix:        netip.MustParsePrefix("2001:db8:900d::/56"),
+		ValidLifetime: 7200 * time.Second,
+	}}
+	got, apply := reconcileDelegatedPDs(prior, res.prefixes, res.withdrawnPDs)
+	if apply {
+		t.Errorf("reconcileDelegatedPDs applied a change (apply=true) for a reply "+
+			"whose only IAPREFIX was skipped; empty live+withdrawn is SILENCE and "+
+			"must retain the held set untouched (#1844). Reconciled set: %v", got)
+	}
+	if len(got) != 1 || got[0].Prefix != prior[0].Prefix {
+		t.Errorf("reconciled set = %v, want the held %v unchanged", got, prior)
+	}
+	for _, dp := range got {
+		if dp.Prefix.Bits() == 0 {
+			t.Errorf("a /0 reached the reconciled PD set: %v", dp.Prefix)
+		}
+	}
+}
+
+// Over-reach guard for the FIRST LEG of the PD → RA chain: wire bytes →
+// extractDelegatedPrefixes → DeriveSubPrefix. That is where this leg stops.
+//
+// It deliberately does NOT claim end-to-end RA coverage (#6581 review): it
+// never calls Daemon.buildRAConfigs, never calls ra.buildRA, and never
+// marshals an RA. The remaining legs are covered where their seams live —
+// pkg/daemon/ra_pd_prefixlen_6531_test.go runs the real buildRAConfigs over a
+// stored PD, and pkg/ra/sender_prefixlen_6531_test.go marshals the resulting
+// config.RAPrefix and asserts on the re-parsed wire bytes. DeriveSubPrefix is
+// the boundary pkg/daemon crosses (daemon_ra.go) to turn a delegated prefix
+// into the advertised one, so it is the right handoff point for this leg.
+//
+// Must stay GREEN under the revert.
+func TestIAPDPrefixLen6531_NormalDelegationSurvivesSubPrefixDerivation(t *testing.T) {
 	now := time.Now()
 
 	for _, tc := range []struct {

--- a/pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go
+++ b/pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go
@@ -1,0 +1,322 @@
+package dhcp
+
+// Regression tests for #6531: a DHCPv6 IA_PD whose IAPREFIX carries a wire
+// prefix-length > 128 decoded to a <ip>/0 delegated prefix that was stored and
+// then advertised to the downstream LAN as on-link + autonomous.
+//
+// The insomniacslk/dhcp decoder builds the prefix as
+// net.CIDRMask(int(length), 128); net.CIDRMask returns a NIL mask when
+// ones > bits, and net.IPMask(nil).Size() is (0, 0). extractDelegatedPrefixes
+// read only `ones` and discarded `bits`, so a crafted length of 129..255
+// became /0.
+//
+// These tests drive the REAL WIRE DECODER. The pre-existing IA_PD tests build
+// dhcpv6.OptIAPrefix{Prefix: &net.IPNet{Mask: net.CIDRMask(48, 128)}} structs
+// directly, which is precisely why this survived: a hand-built struct can only
+// hold a mask net.CIDRMask already accepted.
+//
+// The option bytes here MUST be hand-rolled. OptIAPrefix.ToBytes derives the
+// on-wire prefix-length from Prefix.Mask.Size(), so the library's own
+// marshaller is structurally incapable of emitting a length > 128 — a
+// round-trip through it can never produce the hostile input.
+//
+// RED-on-revert: restore `ones, _ := prefix.Prefix.Mask.Size()` and drop the
+// `bits != 128 || ones == 0` guard in extractDelegatedPrefixes.
+// TestIAPDPrefixLen6531_WireBoundaryTable fails on the 129/130/255 rows (each
+// yields a live /0), and TestIAPDPrefixLen6531_BadSiblingDoesNotRideAlong and
+// TestIAPDPrefixLen6531_BadWithdrawalIsDropped fail as well. Every other test
+// in this file is the OVER-REACH guard and must stay GREEN under the revert.
+
+import (
+	"encoding/binary"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+// iaPrefixWire builds the raw bytes of one IAPREFIX (option 26) TLV:
+// 4B preferred lifetime | 4B valid lifetime | 1B prefix-length | 16B address.
+// prefLen is written verbatim so out-of-range values reach the decoder.
+func iaPrefixWire(prefLen uint8, ip string, preferred, valid uint32) []byte {
+	body := make([]byte, 0, 25)
+	body = binary.BigEndian.AppendUint32(body, preferred)
+	body = binary.BigEndian.AppendUint32(body, valid)
+	body = append(body, prefLen)
+	body = append(body, net.ParseIP(ip).To16()...)
+
+	tlv := make([]byte, 0, 4+len(body))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(dhcpv6.OptionIAPrefix))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(len(body)))
+	return append(tlv, body...)
+}
+
+// iaPDWire wraps IAPREFIX TLVs in an IA_PD (option 25):
+// 4B IAID | 4B T1 | 4B T2 | sub-options.
+func iaPDWire(inner ...[]byte) []byte {
+	body := []byte{0, 0, 0, 1}
+	body = binary.BigEndian.AppendUint32(body, 1800)
+	body = binary.BigEndian.AppendUint32(body, 2880)
+	for _, b := range inner {
+		body = append(body, b...)
+	}
+
+	tlv := make([]byte, 0, 4+len(body))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(dhcpv6.OptionIAPD))
+	tlv = binary.BigEndian.AppendUint16(tlv, uint16(len(body)))
+	return append(tlv, body...)
+}
+
+// decodeReplyWire assembles a DHCPv6 Reply from raw option bytes and parses it
+// through the production decoder, returning the parsed message.
+//
+// It asserts the IA_PD and its IAPREFIX sub-options actually SURVIVED the
+// parse. Without this the tests would be tautological: if a future library
+// version rejected an out-of-range prefix-length at parse time, the
+// "no live prefix" assertions below would pass for the wrong reason and stop
+// exercising xpf's guard at all.
+func decodeReplyWire(t *testing.T, wantPrefixes int, opts ...[]byte) *dhcpv6.Message {
+	t.Helper()
+
+	raw := []byte{byte(dhcpv6.MessageTypeReply), 0xab, 0xcd, 0xef}
+	for _, o := range opts {
+		raw = append(raw, o...)
+	}
+
+	msg, err := dhcpv6.MessageFromBytes(raw)
+	if err != nil {
+		t.Fatalf("MessageFromBytes(% x): %v", raw, err)
+	}
+
+	var got int
+	for _, o := range msg.Options.Options {
+		if pd, ok := o.(*dhcpv6.OptIAPD); ok {
+			got += len(pd.Options.Prefixes())
+		}
+	}
+	if got != wantPrefixes {
+		t.Fatalf("decoder kept %d IAPREFIX sub-options, want %d — "+
+			"the library rejected the option before xpf's guard ran, so this "+
+			"test no longer exercises extractDelegatedPrefixes", got, wantPrefixes)
+	}
+	return msg
+}
+
+// The boundary table. Every row is decoded from real wire bytes.
+//
+// A refused row must produce NO live and NO withdrawn prefix: the entry is
+// dropped outright, never re-sorted into the withdrawal set (where a /0 would
+// be logged as a server withdrawal that matches nothing).
+func TestIAPDPrefixLen6531_WireBoundaryTable(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name    string
+		prefLen uint8
+		want    string // "" => refused
+		why     string
+	}{
+		{
+			name:    "length 0 refused",
+			prefLen: 0,
+			want:    "",
+			why: "RFC 8415 has no zero-length delegation. The library maps a " +
+				"wire length of 0 to a nil Prefix, so the pre-existing nil check " +
+				"already skipped it — this row is GREEN before and after the fix " +
+				"and pins that the /0 cannot re-enter through the length-0 door.",
+		},
+		{
+			name:    "length 1 accepted",
+			prefLen: 1,
+			want:    "2001:db8:1000::/1",
+			why: "A legal encoding: net.CIDRMask(1, 128) is contiguous and RFC 8415 " +
+				"sets no floor on delegation size. Refusing it would be a new " +
+				"minimum-prefix-length policy, not a decode fix, and would break " +
+				"legitimate very-large delegations. Out of scope for #6531.",
+		},
+		{
+			name:    "length 48 accepted",
+			prefLen: 48,
+			want:    "2001:db8:1000::/48",
+			why:     "Over-reach guard: the common delegation must still decode.",
+		},
+		{
+			name:    "length 56 accepted",
+			prefLen: 56,
+			want:    "2001:db8:1000::/56",
+			why:     "Over-reach guard: the common delegation must still decode.",
+		},
+		{
+			name:    "length 64 accepted",
+			prefLen: 64,
+			want:    "2001:db8:1000::/64",
+			why:     "Over-reach guard: the common delegation must still decode.",
+		},
+		{
+			name:    "length 128 accepted",
+			prefLen: 128,
+			want:    "2001:db8:1000::/128",
+			why: "Legal: a single-address delegation. The upper bound is INCLUSIVE — " +
+				"an off-by-one guard (>= 128) would reject a conforming server.",
+		},
+		{
+			name:    "length 129 refused",
+			prefLen: 129,
+			want:    "",
+			why: "First out-of-range value. net.CIDRMask(129, 128) is nil, " +
+				"Size() is (0,0), and the old code stored 2001:db8:1000::/0.",
+		},
+		{
+			name:    "length 130 refused",
+			prefLen: 130,
+			want:    "",
+			why:     "Same nil-mask decode, one past the first bad value.",
+		},
+		{
+			name:    "length 255 refused",
+			prefLen: 255,
+			want:    "",
+			why:     "Maximum encodable byte; same nil-mask decode.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := decodeReplyWire(t, 1,
+				iaPDWire(iaPrefixWire(tc.prefLen, "2001:db8:1000::", 3600, 7200)))
+
+			live, withdrawn := extractDelegatedPrefixes(msg, "wan0", now)
+
+			if tc.want == "" {
+				if len(live) != 0 {
+					t.Errorf("prefix-length %d must be refused, got live %v (%s)",
+						tc.prefLen, live[0].Prefix, tc.why)
+				}
+				if len(withdrawn) != 0 {
+					t.Errorf("prefix-length %d must be dropped outright, "+
+						"got withdrawn %v (%s)", tc.prefLen, withdrawn[0].Prefix, tc.why)
+				}
+				return
+			}
+
+			if len(live) != 1 {
+				t.Fatalf("prefix-length %d must be accepted, got %d live prefixes (%s)",
+					tc.prefLen, len(live), tc.why)
+			}
+			if got := live[0].Prefix; got != netip.MustParsePrefix(tc.want) {
+				t.Errorf("prefix = %s, want %s (%s)", got, tc.want, tc.why)
+			}
+			if live[0].ValidLifetime != 7200*time.Second {
+				t.Errorf("valid lifetime = %s, want 2h0m0s", live[0].ValidLifetime)
+			}
+		})
+	}
+}
+
+// A hostile server cannot smuggle a /0 through by pairing the malformed
+// IAPREFIX with a well-formed sibling in the SAME IA_PD.
+//
+// This pins the skip-the-entry policy: the good /56 is honored (a correct
+// server would have sent it alone), and the bad entry is dropped — so the
+// attacker gains nothing over simply sending the good prefix by itself.
+// Both orderings are exercised so the guard cannot be order-sensitive.
+func TestIAPDPrefixLen6531_BadSiblingDoesNotRideAlong(t *testing.T) {
+	now := time.Now()
+
+	good := func() []byte { return iaPrefixWire(56, "2001:db8:900d::", 3600, 7200) }
+	bad := func() []byte { return iaPrefixWire(200, "2001:db8:bad::", 3600, 7200) }
+
+	for _, tc := range []struct {
+		name  string
+		order [][]byte
+	}{
+		{"bad first", [][]byte{bad(), good()}},
+		{"good first", [][]byte{good(), bad()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := decodeReplyWire(t, 2, iaPDWire(tc.order...))
+
+			live, withdrawn := extractDelegatedPrefixes(msg, "wan0", now)
+
+			if len(live) != 1 {
+				t.Fatalf("got %d live prefixes %v, want exactly the good /56", len(live), live)
+			}
+			if got := live[0].Prefix; got != netip.MustParsePrefix("2001:db8:900d::/56") {
+				t.Errorf("live prefix = %s, want 2001:db8:900d::/56", got)
+			}
+			if len(withdrawn) != 0 {
+				t.Errorf("withdrawn = %v, want empty", withdrawn)
+			}
+			for _, dp := range live {
+				if dp.Prefix.Bits() == 0 {
+					t.Errorf("a /0 reached the live set: %v", dp.Prefix)
+				}
+			}
+		})
+	}
+}
+
+// The same guard must cover the WITHDRAWAL path. A malformed IAPREFIX with
+// valid-lifetime 0 must not land in the withdrawn set either.
+//
+// reconcileDelegatedPDs keys its withdrawal set by exact netip.Prefix
+// equality, so a /0 withdrawal cannot mass-revoke held prefixes today — but
+// letting it through would log a phantom "server withdrew 2001:db8:bad::/0"
+// and leave a containment-based matcher one refactor away from a wipe.
+func TestIAPDPrefixLen6531_BadWithdrawalIsDropped(t *testing.T) {
+	msg := decodeReplyWire(t, 1,
+		iaPDWire(iaPrefixWire(129, "2001:db8:bad::", 0, 0)))
+
+	live, withdrawn := extractDelegatedPrefixes(msg, "wan0", time.Now())
+
+	if len(live) != 0 {
+		t.Errorf("live = %v, want empty", live)
+	}
+	if len(withdrawn) != 0 {
+		t.Errorf("withdrawn = %v, want empty (a malformed prefix is not a withdrawal)", withdrawn)
+	}
+}
+
+// Over-reach guard, full chain: a normal delegation decoded from the wire must
+// still survive the hop into the RA sender — DeriveSubPrefix is the boundary
+// pkg/daemon crosses (daemon_ra.go) to turn a delegated prefix into the
+// advertised one. Must stay GREEN under the revert.
+func TestIAPDPrefixLen6531_NormalDelegationStillReachesRA(t *testing.T) {
+	now := time.Now()
+
+	for _, tc := range []struct {
+		prefLen    uint8
+		delegated  string
+		subPrefLen int
+		advertised string
+	}{
+		{56, "2001:db8:900d::/56", 64, "2001:db8:900d::/64"},
+		{64, "2001:db8:900d::/64", 64, "2001:db8:900d::/64"},
+		{48, "2001:db8:900d::/48", 0, "2001:db8:900d::/48"},
+	} {
+		t.Run(tc.delegated, func(t *testing.T) {
+			msg := decodeReplyWire(t, 1,
+				iaPDWire(iaPrefixWire(tc.prefLen, "2001:db8:900d::", 3600, 7200)))
+
+			live, _ := extractDelegatedPrefixes(msg, "wan0", now)
+			if len(live) != 1 {
+				t.Fatalf("a /%d delegation must decode, got %d live prefixes",
+					tc.prefLen, len(live))
+			}
+			if got := live[0].Prefix; got != netip.MustParsePrefix(tc.delegated) {
+				t.Fatalf("delegated = %s, want %s", got, tc.delegated)
+			}
+
+			sub := DeriveSubPrefix(live[0].Prefix, tc.subPrefLen)
+			if got := sub; got != netip.MustParsePrefix(tc.advertised) {
+				t.Errorf("DeriveSubPrefix(%s, %d) = %s, want %s",
+					live[0].Prefix, tc.subPrefLen, got, tc.advertised)
+			}
+			if sub.Bits() == 0 {
+				t.Errorf("a legitimate delegation collapsed to a /0: %s", sub)
+			}
+		})
+	}
+}

--- a/pkg/ra/sender_prefixlen_6531_test.go
+++ b/pkg/ra/sender_prefixlen_6531_test.go
@@ -1,0 +1,73 @@
+package ra
+
+// #6531, RA side of the fix. pkg/ra is the CONSUMER of a DHCPv6 delegated
+// prefix (pkg/daemon/daemon_ra.go runs dhcp.DeriveSubPrefix and hands the
+// result here), and it applies NO sanity floor of its own: buildRA marshals
+// whatever prefix length it is given straight into the PrefixInformation.
+//
+// These two tests are the pair that justifies where the #6531 guard lives:
+//
+//   - A normal /64 still reaches the wire as PrefixLength 64, on-link +
+//     autonomous. This is the OVER-REACH guard and must stay GREEN under a
+//     revert of the pkg/dhcp fix.
+//   - A /0 that reaches this far IS advertised as PrefixLength 0. This test
+//     pins the blast radius the pkg/dhcp guard prevents; it documents current
+//     behavior and is GREEN both before and after the fix. It is the reason
+//     the /0 must be refused at the DHCPv6 decoder rather than filtered here:
+//     by this point the prefix is indistinguishable from an operator-authored
+//     `set interfaces <if> ipv6 router-advertisement prefix ::/0`.
+
+import (
+	"testing"
+
+	"github.com/mdlayher/ndp"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func prefixInfoFor(t *testing.T, prefix string) *ndp.PrefixInformation {
+	t.Helper()
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface: "trust0",
+		Prefixes: []*config.RAPrefix{
+			{Prefix: prefix, OnLink: true, Autonomous: true},
+		},
+	})
+	for _, opt := range s.buildRA().Options {
+		if pi, ok := opt.(*ndp.PrefixInformation); ok {
+			return pi
+		}
+	}
+	t.Fatalf("buildRA emitted no PrefixInformation for %s", prefix)
+	return nil
+}
+
+// A normal delegated /64 must still be advertised. GREEN under the revert.
+func TestBuildRA_6531_NormalPrefixStillAdvertised(t *testing.T) {
+	pi := prefixInfoFor(t, "2001:db8:900d::/64")
+
+	if pi.PrefixLength != 64 {
+		t.Errorf("PrefixLength = %d, want 64", pi.PrefixLength)
+	}
+	if !pi.OnLink || !pi.AutonomousAddressConfiguration {
+		t.Errorf("OnLink = %v, Autonomous = %v, want both true",
+			pi.OnLink, pi.AutonomousAddressConfiguration)
+	}
+}
+
+// The blast radius #6531 prevents: nothing downstream of the DHCPv6 decoder
+// stops a /0 from being advertised on-link + autonomous to the whole LAN.
+func TestBuildRA_6531_ZeroPrefixWouldBeAdvertised(t *testing.T) {
+	pi := prefixInfoFor(t, "::/0")
+
+	if pi.PrefixLength != 0 {
+		t.Fatalf("PrefixLength = %d, want 0 — pkg/ra gained a prefix-length "+
+			"filter; re-check whether the #6531 guard in pkg/dhcp is still the "+
+			"only thing keeping a delegated /0 off the wire", pi.PrefixLength)
+	}
+	if !pi.OnLink || !pi.AutonomousAddressConfiguration {
+		t.Errorf("OnLink = %v, Autonomous = %v, want both true "+
+			"(this is what makes a /0 a LAN-wide hijack)",
+			pi.OnLink, pi.AutonomousAddressConfiguration)
+	}
+}

--- a/pkg/ra/sender_prefixlen_6531_test.go
+++ b/pkg/ra/sender_prefixlen_6531_test.go
@@ -16,6 +16,16 @@ package ra
 //     the /0 must be refused at the DHCPv6 decoder rather than filtered here:
 //     by this point the prefix is indistinguishable from an operator-authored
 //     `set interfaces <if> ipv6 router-advertisement prefix ::/0`.
+//
+// This file covers the LAST LEG of the PD → RA chain: config.RAPrefix →
+// buildRA → marshaled bytes. It starts from a statically constructed
+// config.RAPrefix rather than a live delegation, because that struct is the
+// exact seam pkg/daemon's buildRAConfigs hands across (OnLink + Autonomous
+// hard-set, prefix rendered by subPrefix.String() — see daemon_ra.go). The
+// upstream legs are covered where their seams live:
+// pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go (wire bytes → DelegatedPrefix →
+// DeriveSubPrefix) and pkg/daemon/ra_pd_prefixlen_6531_test.go (stored PD →
+// the real buildRAConfigs → config.RAPrefix).
 
 import (
 	"testing"
@@ -25,6 +35,14 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// prefixInfoFor builds an RA for a single prefix, MARSHALS it with the same
+// encoder the sender's conn.WriteTo runs, parses the bytes back, and returns
+// the PrefixInformation as it appears ON THE WIRE.
+//
+// The round-trip is deliberate (#6581 review): inspecting buildRA's in-memory
+// option would assert on a Go struct field, not on what the segment receives.
+// PrefixLength is an 8-bit wire field, so only a marshal/parse proves the
+// length an attacker-supplied delegation carries actually reaches the LAN.
 func prefixInfoFor(t *testing.T, prefix string) *ndp.PrefixInformation {
 	t.Helper()
 	s := newTestSender3895(&config.RAInterfaceConfig{
@@ -33,12 +51,25 @@ func prefixInfoFor(t *testing.T, prefix string) *ndp.PrefixInformation {
 			{Prefix: prefix, OnLink: true, Autonomous: true},
 		},
 	})
-	for _, opt := range s.buildRA().Options {
+
+	b, err := ndp.MarshalMessage(s.buildRA())
+	if err != nil {
+		t.Fatalf("RA carrying %s must marshal: %v", prefix, err)
+	}
+	msg, err := ndp.ParseMessage(b)
+	if err != nil {
+		t.Fatalf("re-parsing the marshaled RA for %s: %v", prefix, err)
+	}
+	ra, ok := msg.(*ndp.RouterAdvertisement)
+	if !ok {
+		t.Fatalf("marshaled message re-parsed as %T, want *ndp.RouterAdvertisement", msg)
+	}
+	for _, opt := range ra.Options {
 		if pi, ok := opt.(*ndp.PrefixInformation); ok {
 			return pi
 		}
 	}
-	t.Fatalf("buildRA emitted no PrefixInformation for %s", prefix)
+	t.Fatalf("the marshaled RA carried no PrefixInformation for %s", prefix)
 	return nil
 }
 


### PR DESCRIPTION
Closes #6531

## Problem

A DHCPv6 IA_PD option whose IAPREFIX carries a wire prefix-length **> 128** decoded to a `<ip>/0` delegated prefix that was stored and then **advertised to the downstream LAN** in a Router Advertisement as on-link + autonomous.

`insomniacslk/dhcp` builds the prefix as `net.CIDRMask(int(length), 128)`. `net.CIDRMask` returns a **nil** mask when `ones > bits`, and `net.IPMask(nil).Size()` is `(0, 0)` — so `extractDelegatedPrefixes` reading only `ones` and discarding `bits` turned a crafted length of 129..255 into a `/0`. It survived `IsValid()` and `DeriveSubPrefix` and reached `pkg/ra`, which applies no sanity floor of its own.

Trust boundary: the upstream WAN DHCPv6 server, hostile or merely buggy. It also fed the RENEW echo path (`renew.go:155`), which re-offers held prefixes back to the server.

## Firsthand verification (not taken on faith)

Driving real wire bytes through the pinned library:

| wire length | library `Prefix` | `Mask.Size()` | old xpf result |
|---|---|---|---|
| 0 | **nil** | — | skipped by the pre-existing nil check |
| 1 / 48 / 56 / 64 / 128 | valid mask | `(n, 128)` | correct `/n` |
| 129 / 130 / 255 | non-nil, **nil Mask** | `(0, 0)` | **`2001:db8:1000::/0`** |

This **narrows the issue**: a wire length of 0 maps to a nil `Prefix` and was already skipped, so the issue's `ones == 0` reasoning is not reachable from the wire today. The load-bearing arm is `bits != 128` (a nil mask and a non-contiguous mask both report `bits` 0). `ones == 0` is retained as belt-and-braces for a genuine all-zero 128-bit mask, which only an in-process constructor can build.

## Skip the entry, not the whole reply — deliberate

The v4 twin `leaseFromACKv4` refuses the whole message, but that precedent does not transfer: a v4 ACK carries **exactly one** address+mask, so "skip the bad element" and "refuse the message" are the same action. The matching-shape precedent is the **multi-element** container in the same package — the RFC 3442 classless-route loop (`dhcpv4.go:428`) skips an entry whose mask reports `bits != 32` and keeps its siblings. This change follows that.

**Can a hostile server smuggle a bad prefix past the guard by pairing it with a good one?** No. A skipped entry never becomes a `DelegatedPrefix`, so it reaches neither the live set, the withdrawn set, nor the RA sender. Accepting the well-formed sibling grants the attacker nothing they could not get by sending that prefix alone. The alternative — refusing the whole reply — would additionally discard the IA_NA address and DNS servers in the same message, which only hands a *buggy* server the power to knock IPv6 WAN out entirely over one cosmetic malformation. If the skip empties both sets, the existing caller already treats the reply as unusable and retries rather than settling into an empty lease. Both orderings (bad-first, good-first) are pinned so the guard cannot be order-sensitive.

The guard also covers the **withdrawal** path. `reconcileDelegatedPDs` keys its withdrawal set by exact `netip.Prefix` equality, so a `/0` withdrawal cannot mass-revoke held prefixes today — but letting it through would log a phantom withdrawal and leave a containment-based matcher one refactor away from a wipe.

## Boundary table

| length | disposition | why |
|---|---|---|
| 0 | refused | no zero-length delegation; already skipped via nil `Prefix` (green before and after) |
| 1 | **accepted** | legal contiguous mask; RFC 8415 sets no floor. A minimum-size policy would be a new behavior change, not a decode fix — out of scope |
| 48 / 56 / 64 | **accepted** | over-reach guard: the common delegations still decode |
| 128 | **accepted** | legal single-address delegation — the bound is **inclusive**; a `>= 128` guard would reject a conforming server |
| 129 / 130 / 255 | refused | nil-mask decode |

## Tests drive the WIRE DECODER

This is the whole reason the bug survived. The pre-existing IA_PD tests build `OptIAPrefix` structs directly, which can only hold a mask `net.CIDRMask` already accepted. The option bytes here are **hand-rolled**: `OptIAPrefix.ToBytes` derives the wire length from `Mask.Size()`, so the library's own marshaller is structurally incapable of emitting a length > 128 — a round-trip can never produce the hostile input.

`decodeReplyWire` asserts the IAPREFIX sub-options **survived the parse**, so the tests cannot pass for the wrong reason if a future library version starts rejecting the option before xpf's guard runs.

**RED-on-revert** (restore `ones, _ :=`): the 129/130/255 rows, both orderings of the good+bad sibling test, and the malformed-withdrawal test fail with a live `/0` — real assertion failures, not a build break. The 0/1/48/56/64/128 over-reach rows and both `pkg/ra` tests stay **green**.

`pkg/ra/sender_prefixlen_6531_test.go` pins the blast radius from the consumer side: a `/64` still marshals as `PrefixLength 64`, and a `/0` that reaches that far **is** advertised on-link + autonomous — which is why the refusal must live at the DHCPv6 decoder, where the prefix is still distinguishable from an operator-authored one.

## Sibling `.Mask.Size()` audit

- `pkg/ra` — **zero** sites; it works in `netip.Prefix` parsed from strings.
- `pkg/dhcp/dhcpv4.go:320` — the v4 guard itself.
- `pkg/dhcp/dhcpv4.go:428` — classless static routes; already checks `bits != 32` and correctly rejects a nil mask.
- Sites elsewhere that discard `bits` take config-validated or kernel/netlink input, and `net.ParseCIDR` never yields a nil mask; the nil-mask risk is confined to `net.CIDRMask` called with an untrusted length.

**Out of scope, reported not fixed:** `pkg/config/compiler_interfaces.go:519` parses `preferred-prefix-length` with `strconv.Atoi` and no upper bound, so a configured value > 128 reaches `net.CIDRMask(opts.PDPrefLen, 128)` (`dhcpv6.go:637`) as a nil mask. Different trust boundary (operator config, not the wire) and the impact is a degraded outbound *hint*, not an advertised prefix — worth a separate issue.

## Validation

- Full `pkg/dhcp` and `pkg/ra` suites pass; `go vet` clean; `gofmt` clean; `go build ./...` clean.
- No dataplane, cluster, VRRP, or failover code touched — no smoke required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi