### PR TITLE
config: quote keys that would re-parse as a comment or marker

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -61639,3 +61639,30 @@ would never produce.
     is retuned, and replaced test 2's false subsumption claim with an honest
     accounting.
   - **File(s)**: pkg/dataplane/userspace/routes_6467_crossfamily_test.go
+- **Timestamp**: 2026-07-31
+- **Action**: #6523 quoteKey re-lex predicate: `quoteKey` emitted a key
+  BARE whenever every byte satisfied `isIdentChar`, which is the LEXER'S
+  ident set (it admits `/`, `*`, `:`) and not the set of texts that
+  survive a serialize/re-parse cycle. A key of `//x`, `/*x*/`, `/*x` or
+  `inactive:` went out unquoted and was re-read as a comment or as the
+  parser's deactivation marker, with zero parse errors — silently
+  emptying a security-zone or widening a policy on HA config sync,
+  rollback, archive and rescue. Replaced the predicate with
+  `bareKeySafe`: all-identChars (retained so the change is monotone —
+  output only gains quotes, never loses them) AND the text must re-lex
+  through the REAL lexer as exactly one identifier equal to itself
+  followed by EOF, AND must not be `inactiveMarker`. Deferring to the
+  lexer means a comment syntax added later is covered the day it lands.
+  Allocation-free (the Lexer does not escape; pinned by a zero-alloc
+  test). Independently re-derived the hazard set by brute force rather
+  than trusting the issue: exhaustive 1-3 byte sweep over the full
+  74-byte ident alphabet plus a 5-byte punctuation sweep found 0 hazards
+  beyond leading `//`, leading `/*`, and exactly `inactive:`. Also
+  covered the `| display set` serializer (joinQuotedKeys ->
+  ParseSetVerb), which drives the same lexer. Fail-on-revert: all 9
+  tests go RED with assertions. Full pkg/config + pkg/configstore
+  suites green.
+- **File(s)**: pkg/config/ast.go, pkg/config/freetext.go,
+    pkg/config/quotekey_relex_6523_test.go,
+    pkg/config/quotekey_roundtrip_3854_test.go,
+    docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -61651,18 +61651,70 @@ would never produce.
   `bareKeySafe`: all-identChars (retained so the change is monotone —
   output only gains quotes, never loses them) AND the text must re-lex
   through the REAL lexer as exactly one identifier equal to itself
-  followed by EOF, AND must not be `inactiveMarker`. Deferring to the
-  lexer means a comment syntax added later is covered the day it lands.
+  followed by EOF, AND must not be a registered `parserMarkers` entry.
+  Deferring to the lexer means a comment syntax or lexer special case
+  added later is covered the day it lands; the PARSER-marker half
+  cannot be derived that way (the lexer hands `inactive:` back as an
+  ordinary identifier) and stays enumerated — see the hardening below.
   Allocation-free (the Lexer does not escape; pinned by a zero-alloc
-  test). Independently re-derived the hazard set by brute force rather
-  than trusting the issue: exhaustive 1-3 byte sweep over the full
-  74-byte ident alphabet plus a 5-byte punctuation sweep found 0 hazards
-  beyond leading `//`, leading `/*`, and exactly `inactive:`. Also
-  covered the `| display set` serializer (joinQuotedKeys ->
-  ParseSetVerb), which drives the same lexer. Fail-on-revert: all 9
-  tests go RED with assertions. Full pkg/config + pkg/configstore
-  suites green.
-- **File(s)**: pkg/config/ast.go, pkg/config/freetext.go,
-    pkg/config/quotekey_relex_6523_test.go,
+  test). Note `/*x` is the ONE hazard that is not silent: the lexer
+  returns TokenError ("unterminated block comment"), so Parse errors
+  rather than mis-reading. The other three (`//x`, `/*x*/`,
+  `inactive:`) produce zero parse errors, which is what makes them
+  dangerous. Also covered the `| display set` serializer
+  (joinQuotedKeys -> ParseSetVerb), which drives the same lexer.
+  Independently re-derived the hazard set by brute force rather than
+  trusting the issue, and found 0 hazards beyond leading `//`, leading
+  `/*`, and exactly `inactive:`. Sweep coverage, precisely: EVERY 1- and
+  2-byte text over the full 74-byte ident alphabet (so every possible
+  two-byte introducer, exhaustively); every 2-byte alphabet prefix
+  followed by each of four tails (`abc`, `*/`, `x*/y`, `inactive:`) —
+  exhaustive in the prefix, NOT in the resulting length; every 3-byte
+  text over a 14-byte PUNCTUATION subset (not the full alphabet), plus
+  each punctuation pair embedded mid-value and at the tail; and every
+  registered parserMarkers entry. Each candidate in three key positions
+  = 91,773 round-trips. There is no exhaustive 3-byte sweep over the
+  full alphabet and no 5-byte punctuation sweep.
+  Fail-on-revert audit (bareKeySafe reverted to the all-identChars scan
+  via edit; `go vet` clean on the reverted tree, so every RED below is
+  an ASSERTION, not a build break). 9 BINDERS go RED:
+  TestQuoteKeyStructuralHazards6523 (24/24 subtests),
+  TestQuoteKeyHazardsAreQuoted6523 (8/8),
+  TestQuoteKeyZoneInterfaceHazard6523 (4/4),
+  TestQuoteKeyRelexProperty6523, TestFormatParseRoundTrip3854 (4/4 new
+  values), TestFormatParseIdempotent3854 (4/4 new), and three that bind
+  PARTIALLY — TestQuoteKeySetFormHazards6523 (7/8: the `inactive:`
+  subtest PASSES on revert, because ParseSetVerb recognizes a
+  structural verb in the FIRST token only, so a later `inactive:` is
+  appended to the path literally and even the old bare output
+  round-trips in set form — only the comment forms bite there; it is
+  asserted anyway so both serializers agree on what gets quoted),
+  TestBareKeySafeAgreesWithLexer6523 (7/… : same `inactive:`
+  exception, because that test's assertion is LEXER-level and the
+  marker bites at the PARSER — renamed from …AgreesWithRoundTrip6523,
+  which claimed a round-trip it never performed), and
+  TestQuoteKeyLexerSymmetry3854 (3/4 new values, same reason).
+  TestParserMarkerVocabulary6523 binds on its registered-marker leg
+  (`inactive:` RED on revert) and guards on the other 17.
+  2 tests are GUARDS and correctly stay GREEN under revert:
+  TestQuoteKeyNoOverReach6523 (over-reach — it must stay green, since
+  the pre-fix predicate also emitted those bare; it catches the
+  opposite regression) and TestQuoteKeyBareEmissionIsZeroAlloc6523
+  (performance; also escape-analysis dependent — reports 41 allocs and
+  FAILS under `-gcflags=all=-l`, passes on the default build and under
+  `-race`).
+  Hardened the one obligation the lexer cannot derive: promoted the
+  marker to a package-level `parserMarkers` registry (parser.go) that
+  bareKeySafe and the sweep both enumerate, and added
+  TestParserMarkerVocabulary6523 over the realistic word-shaped marker
+  vocabulary (`replace:`, `protect:`, `delete:`, `rename:`, …): each
+  candidate must EITHER be registered and quoted, OR still round-trip
+  as an ordinary key. Verified the gate both fires and is satisfiable —
+  teaching parseStatement to treat `replace:` structurally without
+  registering it fails with `"replace:" at inline position corrupted
+  … add it to parserMarkers`; adding it to parserMarkers turns both
+  legs green. Full pkg/config + pkg/configstore suites green.
+- **File(s)**: pkg/config/ast.go, pkg/config/parser.go,
+    pkg/config/freetext.go, pkg/config/quotekey_relex_6523_test.go,
     pkg/config/quotekey_roundtrip_3854_test.go,
     docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -61645,7 +61645,9 @@ would never produce.
   ident set (it admits `/`, `*`, `:`) and not the set of texts that
   survive a serialize/re-parse cycle. A key of `//x`, `/*x*/`, `/*x` or
   `inactive:` went out unquoted and was re-read as a comment or as the
-  parser's deactivation marker, with zero parse errors — silently
+  parser's deactivation marker. Two of the three classes are entirely
+  silent (`//x`, `/*x*/`, `inactive:`); the unterminated `/*x` returns a
+  TokenError, so it corrupts loudly rather than quietly — silently
   emptying a security-zone or widening a policy on HA config sync,
   rollback, archive and rescue. Replaced the predicate with
   `bareKeySafe`: all-identChars (retained so the change is monotone —
@@ -61677,7 +61679,9 @@ would never produce.
   full alphabet and no 5-byte punctuation sweep.
   Fail-on-revert audit (bareKeySafe reverted to the all-identChars scan
   via edit; `go vet` clean on the reverted tree, so every RED below is
-  an ASSERTION, not a build break). 9 BINDERS go RED:
+  an ASSERTION, not a build break). 10 BINDERS go RED — the 9 original
+  binders plus TestParserMarkerVocabulary6523, the anti-rot binder added
+  in the fold:
   TestQuoteKeyStructuralHazards6523 (24/24 subtests),
   TestQuoteKeyHazardsAreQuoted6523 (8/8),
   TestQuoteKeyZoneInterfaceHazard6523 (4/4),
@@ -61695,7 +61699,9 @@ would never produce.
   which claimed a round-trip it never performed), and
   TestQuoteKeyLexerSymmetry3854 (3/4 new values, same reason).
   TestParserMarkerVocabulary6523 binds on its registered-marker leg
-  (`inactive:` RED on revert) and guards on the other 17.
+  (`inactive:` RED on revert) and guards on the other 18 — the
+  vocabulary carries 19 candidates: `inactive:` goes RED, the other 18
+  stay green.
   2 tests are GUARDS and correctly stay GREEN under revert:
   TestQuoteKeyNoOverReach6523 (over-reach — it must stay green, since
   the pre-fix predicate also emitted those bare; it catches the
@@ -61718,3 +61724,17 @@ would never produce.
     pkg/config/freetext.go, pkg/config/quotekey_relex_6523_test.go,
     pkg/config/quotekey_roundtrip_3854_test.go,
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-31 04:12
+  - **Action**: Fold the Codex re-gate MINORs on #6523 — corrected the RED
+    accounting (10 binders, not 9: the new anti-rot binder counts; and the
+    marker vocabulary guards 18 candidates, not 17), removed the residual
+    "zero parse errors" contradiction from all four sites that still grouped
+    the unterminated `/*x` with the silent classes, corrected the freetext.go
+    sentence that still said values "are emitted quoted" (most are bare — it is
+    specifically the unsafe ones that get quoted), and recorded the LIMIT of
+    the parserMarkers registry: parseStatement and ast_format.go still compare
+    inactiveMarker directly, so it is a contract, not mechanically-enforced
+    single-source recognition.
+  - **File(s)**: pkg/config/ast.go, pkg/config/parser.go, pkg/config/freetext.go,
+    pkg/config/quotekey_relex_6523_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2550,8 +2550,11 @@ and break the symmetry in the other direction. Pinned by
 `quoteKey` decides bare-vs-quoted through `bareKeySafe` (`ast.go`). The rule is
 **not** "every byte is an `isIdentChar`". `isIdentChar` is the LEXER'S ident set
 — it admits `/`, `*` and `:` — and is not the set of texts that survive a
-serialize/re-parse cycle. Three ident-char-only texts are re-interpreted
-**structurally** on the way back in, with zero parse errors and zero warnings:
+serialize/re-parse cycle. Three ident-char-only **classes** are re-interpreted
+**structurally** on the way back in. Two of them are entirely silent — zero
+parse errors, zero warnings. The unterminated block comment is the exception:
+it returns a `TokenError`, so it corrupts loudly, which makes it the least
+dangerous of the three (the table's last row states this):
 
 | Value | What the re-read does |
 |---|---|

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2582,12 +2582,22 @@ character table:
    itself);
 2. the bare text re-lexes as **exactly one `TokenIdentifier` whose value is the
    text itself**, followed by `TokenEOF`;
-3. it is not a parser-level marker (`inactiveMarker`, `parser.go` — the lexer
-   cannot see this one).
+3. it is not a parser-level marker — enumerated in `parserMarkers`
+   (`parser.go`), today just `inactive:`.
 
 Because step 2 defers to the code that will actually read the config back, a
 comment syntax or lexer special case added later is covered the day it lands
 rather than the day someone remembers to update a denylist.
+
+**Step 3 is the half that cannot be derived**, and it is the one to be careful
+with. A parser marker is invisible to the lexer — `inactive:` comes back as an
+ordinary identifier — so the predicate has to be told. `parserMarkers` carries
+that contract: **teaching `parseStatement` to treat a new bare identifier
+structurally requires adding it to `parserMarkers`**, or the serializer emits
+that text unquoted and the next `Format`→`Parse` reads it back as structure.
+Each marker's semantics stay in `parseStatement`; `parserMarkers` records only
+which texts are load-bearing, since a future merge directive would not share
+`inactive:`'s deactivation behaviour.
 
 Quoting is also what makes the parser's existing marker defence work: a quoted
 `"inactive:"` arrives as a `TokenString`, and `parseStatement` already refuses
@@ -2597,21 +2607,48 @@ to treat a string token as a marker (#4348).
 (the `Lexer` does not escape), pinned by
 `TestQuoteKeyBareEmissionIsZeroAlloc6523`.
 
-Pinned by `pkg/config/quotekey_relex_6523_test.go`:
+Pinned by `pkg/config/quotekey_relex_6523_test.go`. The **binders** (each fails
+with an assertion if the predicate is reverted) are
 `TestQuoteKeyStructuralHazards6523` (each hazard in leading/inline/trailing key
-position), `TestQuoteKeyHazardsAreQuoted6523`, `TestQuoteKeySetFormHazards6523`
-(the `| display set` path), `TestQuoteKeyZoneInterfaceHazard6523` (the
-zero-interface zone end state), `TestBareKeySafeAgreesWithRoundTrip6523`, and
-`TestQuoteKeyRelexProperty6523` — a brute-force sweep over the lexer's own
-ident alphabet (all 1- and 2-byte texts, every 2-byte prefix with tails, all
-3-byte punctuation texts, each in three key positions) that re-derives the
-hazard set instead of trusting a fixed list. The over-reach guard
+position — the primary one), `TestQuoteKeyHazardsAreQuoted6523`,
+`TestQuoteKeySetFormHazards6523` (the `| display set` path — comment forms
+only; see below), `TestQuoteKeyZoneInterfaceHazard6523` (the zero-interface
+zone end state), `TestBareKeySafeAgreesWithLexer6523` (lexer-level only — see
+below), and `TestQuoteKeyRelexProperty6523`, a brute-force sweep over the
+lexer's own ident alphabet that re-derives the hazard set instead of trusting a
+fixed list. Its coverage is **every** 1- and 2-byte text over the full 74-byte
+alphabet, every 2-byte prefix followed by each of four tails, every 3-byte text
+over a 14-byte punctuation subset plus embedded/trailing punctuation pairs, and
+every registered `parserMarkers` entry — each in three key positions, ~91.8k
+round-trips. There is no exhaustive 3-byte sweep over the full alphabet.
+
+Two **guards** are green under revert by design and must stay that way:
 `TestQuoteKeyNoOverReach6523` asserts ordinary values (`10.0.0.0/24`,
-`ge-0/0/0`, `<*>`, `ascii-text`, `00:00:00`, `1024-65535`, and the near-misses
-`a//b`, `a/*b`, `*/`, `/x`, `inactive`, `inactive:x`) still emit **unquoted** —
-`/` is legitimate and common, so a predicate that rejected any value containing
-`/` would be wrong and would churn every archived config and HA config-sync
-diff.
+`ge-0/0/0`, `<*>`, `ascii-text`, `00:11:22:33:44:55`, `junos-ssh`, `00:00:00`,
+`1024-65535`, and the near-misses `a//b`, `a/*b`, `*/`, `/x`, `inactive`,
+`inactive:x`) still emit **unquoted** — `/` is legitimate and common, so a
+predicate that rejected any value containing `/` would be wrong and would churn
+every archived config and HA config-sync diff — and
+`TestQuoteKeyBareEmissionIsZeroAlloc6523` is a performance guard (it also fails
+under `-gcflags=all=-l`, which disables the escape analysis the zero depends
+on; the default build and `-race` both report 0).
+
+`TestParserMarkerVocabulary6523` gates the `parserMarkers` contract over the
+realistic vocabulary of word-shaped markers (`replace:`, `protect:`,
+`delete:`, …): each candidate must either be registered and quoted, or still
+round-trip as an ordinary key. A parser change that promotes one of those words
+without registering it fails the second leg. This is the anti-rot device for
+step 3, and its scope is that enumerated vocabulary — the alphabet sweep cannot
+cover it, because its candidates are short and punctuation-shaped, not words.
+
+Two scope caveats worth knowing before trusting a green run. The set-form
+`inactive:` case in `TestQuoteKeySetFormHazards6523` is a **consistency** case,
+not a binder: `ParseSetVerb` reads a structural verb from the first token only,
+so a later `inactive:` is appended to the path literally and even unquoted
+output round-trips in set form. Only the comment forms bite there. And
+`TestBareKeySafeAgreesWithLexer6523` asserts a **lexer-level** property, so its
+`inactive:` case is likewise green under revert — the marker bites one layer
+up, at the parser, where `TestQuoteKeyStructuralHazards6523` covers it.
 
 ### `firewall ... from flexible-match-range` — at most ONE range per term (#5823)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2522,8 +2522,8 @@ single-block unchanged).
 
 ### Quoted-value escape round-trip contract (#3854)
 
-When a key or value contains a character that is not a bare Junos identifier
-byte (`isIdentChar` in `lexer.go` — anything outside letters/digits/`-_./:*+%=,<>`),
+When a key or value is not safe to emit bare (see the next section for the
+predicate — historically "contains a byte outside `isIdentChar`"),
 `Format`/`FormatSet` wrap it in double quotes via `quoteKey` (`ast.go`). The set
 of characters `quoteKey` escapes MUST exactly match the set the lexer's
 `readString` un-escapes on parse, or the config does not round-trip. The lexer
@@ -2544,6 +2544,74 @@ for characters the lexer does not interpret (e.g. `\t`) — that would over-esca
 and break the symmetry in the other direction. Pinned by
 `pkg/config/quotekey_roundtrip_3854_test.go` (`TestQuoteKeyLexerSymmetry3854`,
 `TestFormatParseRoundTrip3854`, `TestFormatParseIdempotent3854`).
+
+### What may be emitted BARE — the re-lex predicate (#6523)
+
+`quoteKey` decides bare-vs-quoted through `bareKeySafe` (`ast.go`). The rule is
+**not** "every byte is an `isIdentChar`". `isIdentChar` is the LEXER'S ident set
+— it admits `/`, `*` and `:` — and is not the set of texts that survive a
+serialize/re-parse cycle. Three ident-char-only texts are re-interpreted
+**structurally** on the way back in, with zero parse errors and zero warnings:
+
+| Value | What the re-read does |
+|---|---|
+| `//…` | `skipWhitespaceAndComments` consumes to end-of-line. The key **and every key after it on that line** silently vanish. |
+| `/*…*/` | Terminated block comment — swallowed silently. |
+| `/*…` | Unterminated block comment — swallows the rest of the config; `Parse` errors. |
+| `inactive:` | The parser's deactivation marker. **Leading**, it sets `Node.Inactive` on an unrelated statement; **inline**, it TRUNCATES the key list at that point. |
+
+Every path that serializes then re-parses is affected — HA config sync,
+rollback, archive, rescue — i.e. the paths an operator leans on when something
+has already gone wrong. Demonstrated end states on the receiving side: a
+`security-zone` that compiles with **zero interfaces**, a `permit junos-http`
+widened to **`permit any any any`**, and an IKE pre-shared-key that becomes the
+literal string `ascii-text` (the `//…` / `inactive:` forms eat the value and
+leave the preceding `ascii-text` key as the trailing one). Reachable from the
+plain `set` CLI (`set … description inactive:`), not only hierarchical ingest.
+Both serializers are affected: hierarchical `Format` (via `QuotedKeyPath`) and
+`| display set` (via `joinQuotedKeys`), the latter replayed through
+`ParseSetVerb`, which drives the same lexer.
+
+`bareKeySafe` therefore asks the **real lexer** instead of a hand-maintained
+character table:
+
+1. every byte is an `isIdentChar` (retained as a NECESSARY pre-condition, so the
+   change is monotone — output only ever gains quotes, never loses them; without
+   it a bracketed endpoint `[2001:db8::1]:51820` would newly go bare, since
+   `tryBracketedEndpointLiteral` (#5182) hands it back as one identifier equal to
+   itself);
+2. the bare text re-lexes as **exactly one `TokenIdentifier` whose value is the
+   text itself**, followed by `TokenEOF`;
+3. it is not a parser-level marker (`inactiveMarker`, `parser.go` — the lexer
+   cannot see this one).
+
+Because step 2 defers to the code that will actually read the config back, a
+comment syntax or lexer special case added later is covered the day it lands
+rather than the day someone remembers to update a denylist.
+
+Quoting is also what makes the parser's existing marker defence work: a quoted
+`"inactive:"` arrives as a `TokenString`, and `parseStatement` already refuses
+to treat a string token as a marker (#4348).
+
+**Do not widen this predicate for speed.** `bareKeySafe` is allocation-free
+(the `Lexer` does not escape), pinned by
+`TestQuoteKeyBareEmissionIsZeroAlloc6523`.
+
+Pinned by `pkg/config/quotekey_relex_6523_test.go`:
+`TestQuoteKeyStructuralHazards6523` (each hazard in leading/inline/trailing key
+position), `TestQuoteKeyHazardsAreQuoted6523`, `TestQuoteKeySetFormHazards6523`
+(the `| display set` path), `TestQuoteKeyZoneInterfaceHazard6523` (the
+zero-interface zone end state), `TestBareKeySafeAgreesWithRoundTrip6523`, and
+`TestQuoteKeyRelexProperty6523` — a brute-force sweep over the lexer's own
+ident alphabet (all 1- and 2-byte texts, every 2-byte prefix with tails, all
+3-byte punctuation texts, each in three key positions) that re-derives the
+hazard set instead of trusting a fixed list. The over-reach guard
+`TestQuoteKeyNoOverReach6523` asserts ordinary values (`10.0.0.0/24`,
+`ge-0/0/0`, `<*>`, `ascii-text`, `00:00:00`, `1024-65535`, and the near-misses
+`a//b`, `a/*b`, `*/`, `/x`, `inactive`, `inactive:x`) still emit **unquoted** —
+`/` is legitimate and common, so a predicate that rejected any value containing
+`/` would be wrong and would churn every archived config and HA config-sync
+diff.
 
 ### `firewall ... from flexible-match-range` — at most ONE range per term (#5823)
 

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -85,19 +85,82 @@ func (n *Node) QuotedKeyPath() string {
 // round-trip would over-escape and diverge.
 var keyEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
 
-// quoteKey wraps a key in double quotes if it contains characters that
-// are not valid in bare Junos identifiers, escaping backslash, quote, and
-// newline so the quoted form round-trips symmetrically through the lexer.
+// quoteKey renders one AST key as configuration text, wrapping it in double
+// quotes unless the bare text is guaranteed to read back as exactly this key
+// (bareKeySafe). Quoted output escapes backslash, quote, and newline so it
+// round-trips symmetrically through the lexer (#3854).
 func quoteKey(s string) string {
-	if s == "" {
-		return `""`
+	if bareKeySafe(s) {
+		return s
 	}
+	return `"` + keyEscaper.Replace(s) + `"`
+}
+
+// bareKeySafe reports whether s may be emitted WITHOUT surrounding quotes and
+// still be read back, by the next Parse, as exactly this one key.
+//
+// The predicate this replaced was "every byte satisfies isIdentChar". That is
+// the LEXER'S IDENT-CHAR SET, which is not the same thing as the set of texts
+// that survive a serialize/re-parse cycle: isIdentChar admits `/`, `*` and
+// `:`, and three ident-char-only texts are re-interpreted STRUCTURALLY on the
+// way back in (#6523) — with no parse error and no warning:
+//
+//   - a key starting `//` — skipWhitespaceAndComments consumes it to
+//     end-of-line, so the key AND every key after it on that line silently
+//     VANISH;
+//   - a key starting `/*` — opens a block comment: `/*x*/` swallows itself
+//     silently, `/*x` swallows the remainder of the config;
+//   - a key equal to `inactive:` — the parser's deactivation marker: leading,
+//     it sets Node.Inactive on an unrelated statement; inline, it TRUNCATES
+//     the key list at that point (parser.go).
+//
+// Every path that serializes then re-parses is affected — HA config sync,
+// rollback, archive, rescue — i.e. the paths an operator leans on when
+// something has already gone wrong. Demonstrated end states on the receiving
+// side include a security-zone that compiles with zero interfaces and a
+// `permit junos-http` widened to `permit any any any`.
+//
+// The replacement asks the real lexer rather than a hand-maintained character
+// table: does this text re-lex as exactly one identifier token whose value is
+// the text itself, and nothing after it? That question is answered by the same
+// code that will read the config back, so a comment syntax or lexer special
+// case added later is covered the day it lands — not the day someone
+// remembers to update a denylist here.
+//
+// The isIdentChar scan is retained as a NECESSARY pre-condition, not as the
+// decision. It keeps the change monotone (output only ever gains quotes, never
+// loses them): the lexer round-trip alone would newly emit a bracketed IPv6
+// endpoint such as `[2001:db8::1]:51820` bare, because tryBracketedEndpointLiteral
+// (#5182) hands it back as one identifier equal to itself. That is round-trip
+// safe but would churn every archived config carrying a WireGuard endpoint for
+// no benefit, and would make the emitted form depend on a narrow lexer special
+// case.
+func bareKeySafe(s string) bool {
+	if s == "" {
+		return false // "" must be emitted as the empty string literal
+	}
+	// Necessary condition: bare text can only ever be identifier bytes.
 	for i := 0; i < len(s); i++ {
 		if !isIdentChar(s[i]) {
-			return `"` + keyEscaper.Replace(s) + `"`
+			return false
 		}
 	}
-	return s
+	// Lexer authority: the bare text must yield exactly one identifier token
+	// carrying the whole value, then EOF. A comment introducer at the start
+	// fails here — either by producing no identifier at all (`//x`, `/*x*/`
+	// lex to EOF) or an error token (`/*x` is an unterminated block comment).
+	l := NewLexer(s)
+	if tok := l.Next(); tok.Type != TokenIdentifier || tok.Value != s {
+		return false
+	}
+	if l.Next().Type != TokenEOF {
+		return false
+	}
+	// Parser authority: a handful of bare identifiers carry structural meaning
+	// to the PARSER, which the lexer cannot see. `inactive:` is the only one
+	// (parser.go); quoting it makes the re-parsed token a TokenString, which
+	// parseStatement already refuses to treat as a marker (#4348).
+	return s != inactiveMarker
 }
 
 // FindChild returns the first child whose first key matches name.

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -127,6 +127,12 @@ func quoteKey(s string) string {
 // case added later is covered the day it lands — not the day someone
 // remembers to update a denylist here.
 //
+// That derivation reaches LEXER-level hazards only. A PARSER-level marker is
+// invisible to the lexer (it hands `inactive:` back as an ordinary
+// identifier), so that half stays enumerated — parserMarkers in parser.go,
+// which carries the obligation to extend it, gated by
+// TestParserMarkerVocabulary6523.
+//
 // The isIdentChar scan is retained as a NECESSARY pre-condition, not as the
 // decision. It keeps the change monotone (output only ever gains quotes, never
 // loses them): the lexer round-trip alone would newly emit a bracketed IPv6
@@ -157,10 +163,17 @@ func bareKeySafe(s string) bool {
 		return false
 	}
 	// Parser authority: a handful of bare identifiers carry structural meaning
-	// to the PARSER, which the lexer cannot see. `inactive:` is the only one
-	// (parser.go); quoting it makes the re-parsed token a TokenString, which
-	// parseStatement already refuses to treat as a marker (#4348).
-	return s != inactiveMarker
+	// to the PARSER, which the lexer cannot see, so they cannot be derived the
+	// way step 2 derives comment syntax — they are enumerated in parserMarkers
+	// (parser.go), today just `inactive:`. Quoting one makes the re-parsed
+	// token a TokenString, which parseStatement already refuses to treat as a
+	// marker (#4348).
+	for _, marker := range parserMarkers {
+		if s == marker {
+			return false
+		}
+	}
+	return true
 }
 
 // FindChild returns the first child whose first key matches name.

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -102,8 +102,10 @@ func quoteKey(s string) string {
 // The predicate this replaced was "every byte satisfies isIdentChar". That is
 // the LEXER'S IDENT-CHAR SET, which is not the same thing as the set of texts
 // that survive a serialize/re-parse cycle: isIdentChar admits `/`, `*` and
-// `:`, and three ident-char-only texts are re-interpreted STRUCTURALLY on the
-// way back in (#6523) — with no parse error and no warning:
+// `:`, and three ident-char-only CLASSES are re-interpreted STRUCTURALLY on
+// the way back in (#6523). Two of the three are SILENT — no parse error, no
+// warning; the unterminated block comment is the exception and does surface a
+// TokenError, which is why it is the least dangerous of the set:
 //
 //   - a key starting `//` — skipWhitespaceAndComments consumes it to
 //     end-of-line, so the key AND every key after it on that line silently

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -47,20 +47,22 @@ import (
 // unterminated comment). The strict commit path REJECTS a comment
 // delimiter in an annotation; the lenient load/peer-sync path scrubs it
 // in place (breaking the pair with a space). The comment-delimiter guard
-// is applied to annotations only, because config VALUES are emitted
-// quoted and the lexer never starts a comment inside a quoted string.
+// is applied to annotations only, because config VALUES cannot open a
+// comment: quoteKey quotes any value that would, and the lexer never
+// starts a comment inside a quoted string.
 //
-// #6523 corrected the second half of that reasoning. Values are NOT
-// unconditionally quoted: quoteKey emitted a value bare whenever every
-// byte satisfied isIdentChar, and isIdentChar admits `/`, `*` and `:` —
-// so a value of `//x`, `/*x*/` or `inactive:` went out unquoted and was
-// re-read as a comment or as the parser's deactivation marker on the
-// next Parse. The premise now holds because quoteKey's predicate was
-// tightened (bareKeySafe, ast.go): bare emission requires that the text
-// re-lex through the REAL lexer as exactly one identifier equal to
-// itself, and that it not be a parser-level marker. Values still need no
-// scrubbing here — the serializer quotes what is unsafe — but the reason
-// is the re-lex predicate, not "all values are quoted".
+// #6523 corrected the justification for that last clause. The original
+// #3900 wording was "values are emitted quoted", which was never true:
+// quoteKey emitted a value bare whenever every byte satisfied
+// isIdentChar, and isIdentChar admits `/`, `*` and `:` — so a value of
+// `//x`, `/*x*/` or `inactive:` went out unquoted and was re-read as a
+// comment or as the parser's deactivation marker on the next Parse. The
+// premise holds now, for a narrower reason: quoteKey's predicate was
+// tightened (bareKeySafe, ast.go) so that bare emission requires the
+// text to re-lex through the REAL lexer as exactly one identifier equal
+// to itself, and to not be a parser-level marker. Values still need no
+// scrubbing here — but because the serializer quotes SPECIFICALLY WHAT
+// IS UNSAFE, not because all values are quoted. Most still go bare.
 
 // hasControlChars reports whether s contains any ASCII control
 // character: the full C0 set (0x00–0x1F, which includes \n, \r and \t)

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -46,10 +46,21 @@ import (
 // same footing (a stray open would swallow following statements as an
 // unterminated comment). The strict commit path REJECTS a comment
 // delimiter in an annotation; the lenient load/peer-sync path scrubs it
-// in place (breaking the pair with a space). Config VALUES are immune —
-// they are emitted quoted (quoteKey), and the lexer never starts a
-// comment inside a quoted string — so the comment-delimiter guard is
-// applied to annotations only.
+// in place (breaking the pair with a space). The comment-delimiter guard
+// is applied to annotations only, because config VALUES are emitted
+// quoted and the lexer never starts a comment inside a quoted string.
+//
+// #6523 corrected the second half of that reasoning. Values are NOT
+// unconditionally quoted: quoteKey emitted a value bare whenever every
+// byte satisfied isIdentChar, and isIdentChar admits `/`, `*` and `:` —
+// so a value of `//x`, `/*x*/` or `inactive:` went out unquoted and was
+// re-read as a comment or as the parser's deactivation marker on the
+// next Parse. The premise now holds because quoteKey's predicate was
+// tightened (bareKeySafe, ast.go): bare emission requires that the text
+// re-lex through the REAL lexer as exactly one identifier equal to
+// itself, and that it not be a parser-level marker. Values still need no
+// scrubbing here — the serializer quotes what is unsafe — but the reason
+// is the re-lex predicate, not "all values are quoted".
 
 // hasControlChars reports whether s contains any ASCII control
 // character: the full C0 set (0x00–0x1F, which includes \n, \r and \t)

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -114,9 +114,13 @@ func ValidateAnnotationText(annotation string) error {
 // hasCommentDelim reports whether s contains a block-comment delimiter
 // (`*/` or `/*`). Annotations are emitted verbatim between `/* */`, so
 // either sequence lets annotation text escape the comment on the next
-// Format→Parse round-trip (#3900). Values never need this check — they
-// are emitted quoted and the lexer does not start comments inside a
-// quoted string — so the guard is used on annotations only.
+// Format→Parse round-trip (#3900). Values never need this check — a value
+// carrying a comment delimiter is emitted QUOTED by quoteKey/bareKeySafe
+// (#6523), and the lexer does not start a comment inside a quoted string, so
+// the delimiter cannot escape. Most values are still emitted BARE; it is
+// specifically the unsafe ones that get quoted. The guard is therefore used on
+// annotations only, which are emitted verbatim between `/* */` and so have no
+// equivalent protection.
 func hasCommentDelim(s string) bool {
 	for i := 0; i+1 < len(s); i++ {
 		if s[i] == '*' && s[i+1] == '/' {

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -272,6 +272,26 @@ func (p *Parser) skipToBlockClose() {
 // marker checks on the parallel token-kind slice from parseKeys (#4348).
 const inactiveMarker = "inactive:"
 
+// parserMarkers enumerates every bare identifier this parser interprets as
+// STRUCTURE rather than as a key. It exists because such a marker is invisible
+// to the lexer — it hands the text back as an ordinary identifier — so
+// bareKeySafe (ast.go), which otherwise defers to the lexer, cannot discover
+// one by re-lexing and must be told (#6523).
+//
+// CONTRACT: teaching parseStatement to treat a new bare identifier
+// structurally REQUIRES adding it here, or the serializer will emit that text
+// unquoted and the next Format→Parse will read it back as structure instead of
+// as the key it was. Each marker's SEMANTICS stay in parseStatement — this is a
+// registry of which texts are load-bearing, not of what they do, because a
+// future merge directive would not share `inactive:`'s deactivation behaviour.
+//
+// TestParserMarkerVocabulary6523 gates the obligation over the realistic
+// marker vocabulary: for each candidate word it asserts EITHER that the
+// candidate is listed here and gets quoted, OR that the parser still treats it
+// as an ordinary key. A parser change that promotes one of those words without
+// updating this slice fails the second leg.
+var parserMarkers = []string{inactiveMarker}
+
 // parseStatement parses one statement: keys followed by ; or { block }.
 // A leading `inactive:` marker is stripped from the keys and recorded on
 // the returned Node so the statement's real identity (Keys) is unchanged

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -290,6 +290,15 @@ const inactiveMarker = "inactive:"
 // candidate is listed here and gets quoted, OR that the parser still treats it
 // as an ordinary key. A parser change that promotes one of those words without
 // updating this slice fails the second leg.
+//
+// LIMIT OF ENFORCEMENT — this is a CONTRACT, not mechanical single-source
+// recognition. parseStatement still compares inactiveMarker directly (see the
+// two comparisons below), and ast_format.go emits it directly, so the slice is
+// not the only place the marker is known; it is the place bareKeySafe consults.
+// The vocabulary test therefore only catches a promotion of a word it already
+// enumerates. A marker OUTSIDE that candidate list — an unforeseen word — still
+// depends on whoever adds it honouring this contract. Widening the candidate
+// vocabulary is the cheap way to widen the net.
 var parserMarkers = []string{inactiveMarker}
 
 // parseStatement parses one statement: keys followed by ; or { block }.

--- a/pkg/config/quotekey_relex_6523_test.go
+++ b/pkg/config/quotekey_relex_6523_test.go
@@ -18,10 +18,19 @@ package config
 // Every serialize-then-reparse path is affected: HA config sync, rollback,
 // archive, rescue. This file pins the fix at three levels — the predicate
 // itself, the hierarchical Format->Parse path, and the `| display set`
-// Format->ParseSetVerb path — plus an over-reach guard (ordinary values must
-// keep emitting bare) and a brute-force property sweep that re-derives the
-// hazard set from the real lexer so a comment syntax added later cannot
-// quietly reopen the hole.
+// Format->ParseSetVerb path — plus two anti-rot devices: a brute-force
+// property sweep that re-derives the hazard set from the real lexer, so a
+// comment syntax added later cannot quietly reopen the hole, and
+// TestParserMarkerVocabulary6523, which covers the half the lexer cannot
+// derive (a word-shaped parser marker).
+//
+// Not every test here is a fail-on-revert BINDER, and the ones that are not
+// say so in their own doc comment. TestQuoteKeyNoOverReach6523 and
+// TestQuoteKeyBareEmissionIsZeroAlloc6523 are GUARDS — green under revert by
+// design. TestQuoteKeySetFormHazards6523 and TestBareKeySafeAgreesWithLexer6523
+// bind only PARTIALLY: their `inactive:` cases pass under revert, because that
+// hazard bites at the PARSER and those two assertions stop short of it. The
+// parse-level binder for `inactive:` is TestQuoteKeyStructuralHazards6523.
 
 import (
 	"fmt"
@@ -142,8 +151,13 @@ func TestQuoteKeyHazardsAreQuoted6523(t *testing.T) {
 	}
 }
 
-// TestQuoteKeyNoOverReach6523 is the over-reach guard. Tightening the
-// predicate must not start quoting values that were never at risk: doing so
+// TestQuoteKeyNoOverReach6523 is the over-reach GUARD. It is deliberately not
+// a fail-on-revert binder: it stays GREEN under a revert of bareKeySafe, which
+// is exactly what an over-reach guard must do, because the pre-#6523 predicate
+// also emitted all of these bare. What it catches is the opposite regression —
+// a predicate tightened too far.
+//
+// Tightening must not start quoting values that were never at risk: doing so
 // would churn every archived config and every HA config-sync diff, and would
 // show up as spurious noise in `show | compare`.
 //
@@ -174,8 +188,17 @@ func TestQuoteKeyNoOverReach6523(t *testing.T) {
 // TestQuoteKeySetFormHazards6523 covers the second serializer. `show
 // configuration | display set` renders through joinQuotedKeys (ast_format.go)
 // and is replayed through ParseSetVerb, which drives the same Lexer — so the
-// same three texts are re-read as comments or markers there too. configstore
-// LoadSet / LoadMerge replay this form.
+// COMMENT forms are re-read as comments there too. configstore LoadSet /
+// LoadMerge replay this form.
+//
+// The `inactive:` subtest is a consistency case, not a binder: it stays GREEN
+// under a revert of bareKeySafe. ParseSetVerb reads a structural verb from the
+// FIRST token only (parser.go); a later `inactive:` identifier is appended to
+// the path literally, so even the old bare output round-trips in set form. It
+// is asserted anyway because both serializers must agree on what gets quoted —
+// a text quoted in hierarchical output and bare in set output would make `show
+// | compare` and `| display set` disagree about the same tree. The parse-level
+// binder for `inactive:` is TestQuoteKeyStructuralHazards6523.
 func TestQuoteKeySetFormHazards6523(t *testing.T) {
 	for _, hz := range structuralHazards {
 		t.Run(hz.name, func(t *testing.T) {
@@ -249,6 +272,110 @@ func TestQuoteKeyZoneInterfaceHazard6523(t *testing.T) {
 	}
 }
 
+// parserMarkerCandidates is the realistic vocabulary of WORD-shaped texts a
+// future parser might promote to a structural marker: the Junos configuration
+// verbs and edit directives, plus `inactive:`'s obvious siblings. Every entry
+// is made entirely of isIdentChar bytes, so each one is emitted bare today.
+var parserMarkerCandidates = []string{
+	inactiveMarker,
+	"active:", "replace:", "protect:", "unprotect:", "delete:", "rename:",
+	"insert:", "annotate:", "deactivate:", "activate:", "apply:", "set:",
+	"copy:", "edit:", "update:", "load:", "merge:", "override:",
+}
+
+// TestParserMarkerVocabulary6523 gates the one obligation bareKeySafe cannot
+// derive from the lexer. A parser-level marker is handed back by the lexer as
+// an ordinary identifier, so the predicate has to be TOLD about it
+// (parserMarkers, parser.go) — and the sweep in
+// TestQuoteKeyRelexProperty6523 cannot discover an unregistered one either,
+// because its candidates are short and punctuation-shaped, not words.
+//
+// For each candidate word this asserts exactly one of two things holds:
+//
+//   - it IS registered in parserMarkers -> quoteKey must quote it, and the
+//     quoted form must survive Format->Parse in every key position. (A binder:
+//     the `inactive:` leg goes RED on a revert of bareKeySafe.)
+//   - it is NOT registered -> the parser must still treat it as an ordinary
+//     key, i.e. bare emission round-trips unchanged. (A guard: green today,
+//     green under revert.)
+//
+// The point is the pairing. If a future parseStatement change gives one of
+// these words structural meaning and nobody adds it to parserMarkers, the
+// second leg goes RED — the word stops round-tripping as an ordinary key.
+// That is the anti-rot device for the marker half of the predicate, and its
+// scope is exactly this list: a marker outside this vocabulary is still
+// caught only by whoever honours the parserMarkers contract.
+func TestParserMarkerVocabulary6523(t *testing.T) {
+	registered := make(map[string]bool, len(parserMarkers))
+	for _, m := range parserMarkers {
+		registered[m] = true
+	}
+
+	for _, cand := range parserMarkerCandidates {
+		t.Run(cand, func(t *testing.T) {
+			emitted := quoteKey(cand)
+			if registered[cand] && emitted == cand {
+				t.Fatalf("quoteKey(%q) = %s — a registered parser marker MUST be "+
+					"quoted, or the next Parse reads it back as structure", cand, emitted)
+			}
+			if !registered[cand] && emitted != cand {
+				t.Fatalf("quoteKey(%q) = %s — %q is not in parserMarkers, so quoting "+
+					"it is over-reach", cand, emitted, cand)
+			}
+			// Whichever branch applied, the text must survive Format->Parse as
+			// exactly this key. For an UNREGISTERED candidate this is the
+			// gate: it goes RED if the parser starts treating the word
+			// structurally without parserMarkers being extended.
+			for _, shape := range hazardKeyShapes {
+				want := shape.keys(cand)
+				got, inactive, err := formatParseKeys(want)
+				if err != nil {
+					t.Fatalf("%q at %s position did not round-trip: %v", cand, shape.name, err)
+				}
+				if inactive {
+					t.Fatalf("%q at %s position set Node.Inactive — the parser now treats "+
+						"it as a marker; add it to parserMarkers (parser.go)", cand, shape.name)
+				}
+				if len(got) != len(want) || got[shape.idx] != cand {
+					t.Fatalf("%q at %s position corrupted: want %q, got %q — if the parser "+
+						"now treats it structurally, add it to parserMarkers (parser.go)",
+						cand, shape.name, want, got)
+				}
+			}
+		})
+	}
+}
+
+// bareKeyValues are values that MUST keep being emitted WITHOUT quotes. The
+// #6523 predicate tightened what may go bare, and over-quoting is its own
+// regression: it would churn every archived config and every HA config-sync
+// diff for values that were never at risk. Note that `/` is legitimate and
+// common here (prefixes, interface names, wildcards) — a predicate that
+// rejected any value containing `/` would be wrong, and this slice is what
+// catches it.
+var bareKeyValues = []string{
+	// Structural keys.
+	"security", "zones", "security-zone", "pre-shared-key", "ascii-text",
+	// Prefixes and addresses — `/` mid-value.
+	"10.0.0.0/24", "192.168.1.1", "2001:db8::1", "2001:db8::/32", "::/0",
+	// Interface names — `/` and `-`.
+	"ge-0/0/0", "ge-0/0/0.100", "reth0.50", "xe-1/0/0:3", "fxp0",
+	// MAC addresses — all-`:`, the same byte that makes `inactive:` a marker.
+	"00:11:22:33:44:55", "02:bf:72:00:00:01",
+	// Application and policy names — the operand of the `permit junos-http`
+	// widening this issue demonstrated.
+	"junos-http", "junos-ssh", "my-app", "allow-trust-to-untrust",
+	// Wildcards and group syntax — `*`, `<`, `>`.
+	"*", "<*>", "<ge-*>", "any", "any-ipv4",
+	// Times, ranges, numbers, percentages, equals — the rest of isIdentChar.
+	"00:00:00", "1024-65535", "3600", "50%", "a=b", "a,b",
+	// `/` and `*` present but NOT as a leading comment introducer. `/` alone
+	// and `/x` are safe: the introducer needs `/` followed by `/` or `*`.
+	"a//b", "a/*b", "a*/b", "*/", "*/x", "x//", "/x", "/", "/-", "/0",
+	// Near-misses on the parser marker: only the exact text is a marker.
+	"inactive", "inactive::", ":inactive:", "Inactive:", "inactive:x",
+}
+
 // relexAlphabet is every byte the lexer accepts inside a bare identifier —
 // read from isIdentChar itself, so it tracks the lexer rather than a copy.
 var relexAlphabet = func() []byte {
@@ -271,14 +398,31 @@ var relexPunctuation = []byte{'%', '*', '+', ',', '-', '.', '/', ':', '<', '=', 
 // alphabet and asserts the round-trip invariant for every candidate: whatever
 // quoteKey emits must read back as exactly the key it was given.
 //
-// A comment syntax, an ident-char addition, or a new parser marker introduced
-// later reopens this hole the moment it lands, and this sweep goes RED then —
-// not when someone remembers to extend a denylist.
+// SCOPE — what this does and does not catch. A comment syntax or an ident-char
+// addition is punctuation-shaped and short, so the sweep below sees it the
+// moment it lands and goes RED. A WORD-shaped parser marker (a future
+// `replace:` / `protect:`) is NOT in the swept space and would not be caught
+// here; that obligation lives on parserMarkers (parser.go) and is gated
+// separately by TestParserMarkerVocabulary6523. The parserMarkers leg below
+// only asserts that the markers already registered survive — it cannot
+// discover an unregistered one.
 //
-// Coverage: all 1- and 2-byte texts over the full alphabet (every possible
-// two-byte introducer), every 2-byte prefix followed by a tail (introducers
-// that need trailing text to bite), and all 3-byte texts over the punctuation
-// subset. Each candidate is checked in all three key positions.
+// Coverage, exactly:
+//
+//   - every 1-byte and every 2-byte text over the full ident alphabet — i.e.
+//     every possible two-byte introducer, exhaustively;
+//   - every 2-byte alphabet prefix followed by each of four tails (`abc`,
+//     `*/`, `x*/y`, `inactive:`), for introducers that need trailing text to
+//     bite. Exhaustive in the 2-byte prefix, NOT in the resulting length;
+//   - every 3-byte text over the 14-byte punctuation subset (structural
+//     meaning only ever comes from punctuation), plus each punctuation pair
+//     embedded mid-value (`abc??def`) and at the tail (`abcd??`), which must
+//     NOT trigger;
+//   - every registered parserMarkers entry at full length.
+//
+// There is no exhaustive 3-byte sweep over the FULL alphabet and no 5-byte
+// punctuation sweep. Each candidate is checked in all three key positions;
+// the total round-trip count is logged.
 func TestQuoteKeyRelexProperty6523(t *testing.T) {
 	checked := 0
 	check := func(t *testing.T, v string) {
@@ -330,15 +474,32 @@ func TestQuoteKeyRelexProperty6523(t *testing.T) {
 			}
 		}
 	}
-	t.Logf("swept %d round-trips over %d ident bytes", checked, len(relexAlphabet))
+	// Every registered parser marker at full length. The sweep's own candidates
+	// never reach `inactive:` unprefixed (the marker only appears there as a
+	// TAIL after two alphabet bytes), so without this leg a marker added to
+	// parserMarkers would be swept only in prefixed form.
+	for _, m := range parserMarkers {
+		check(t, m)
+	}
+	t.Logf("swept %d round-trips over %d ident bytes and %d parser markers",
+		checked, len(relexAlphabet), len(parserMarkers))
 }
 
-// TestBareKeySafeAgreesWithRoundTrip6523 asserts the predicate is not merely
-// sufficient but honest: every text bareKeySafe accepts must round-trip when
-// emitted bare, and every text it rejects must round-trip when emitted quoted.
-// This is what keeps a future "optimization" from widening the predicate
-// without widening what actually survives a re-parse.
-func TestBareKeySafeAgreesWithRoundTrip6523(t *testing.T) {
+// TestBareKeySafeAgreesWithLexer6523 asserts two things about the predicate:
+// that it agrees with quoteKey (accepting a text iff quoteKey emits it bare),
+// and that whatever quoteKey emitted re-LEXES back to exactly that text. This
+// is what keeps a future "optimization" from widening the predicate without
+// widening what actually survives a re-lex.
+//
+// The assertion is LEXER-level, which is why this test is not named for a
+// round-trip: its `inactive:` case stays GREEN under a revert of bareKeySafe,
+// because bare `inactive:` lexes to an identifier equal to itself — the marker
+// bites at the PARSER, one layer up, where this test does not look.
+// Format→Parse coverage for the same corpus already exists and is where that
+// case binds: TestQuoteKeyStructuralHazards6523 (the hazards) and
+// TestQuoteKeyNoOverReach6523 (bareKeyValues) both run formatParseKeys over
+// it, so a parse leg here would duplicate rather than add.
+func TestBareKeySafeAgreesWithLexer6523(t *testing.T) {
 	cases := []string{}
 	for _, hz := range structuralHazards {
 		cases = append(cases, hz.value)
@@ -375,6 +536,16 @@ func TestBareKeySafeAgreesWithRoundTrip6523(t *testing.T) {
 // candidate configuration on each commit, archive, rollback slot write and HA
 // config sync. Asking the real lexer is only affordable because the Lexer does
 // not escape; this fails if a future edit makes it allocate.
+//
+// This is a PERFORMANCE guard, not a correctness binder: it stays GREEN under
+// a revert of bareKeySafe to the old identifier scan (that predicate does not
+// allocate either).
+//
+// It is also escape-analysis dependent by construction — the zero comes from
+// the Lexer being stack-allocated. Under `-gcflags=all=-l` (inlining off) it
+// reports 41 allocs, one NewLexer per bareKeyValues entry, and FAILS. That is
+// the disabled optimizer, not a regression: the default build and `-race` both
+// report 0, and neither CI nor `make test` passes `-l`.
 func TestQuoteKeyBareEmissionIsZeroAlloc6523(t *testing.T) {
 	avg := testing.AllocsPerRun(1000, func() {
 		for _, v := range bareKeyValues {

--- a/pkg/config/quotekey_relex_6523_test.go
+++ b/pkg/config/quotekey_relex_6523_test.go
@@ -5,8 +5,10 @@ package config
 // quoteKey used to emit a key bare whenever every byte satisfied isIdentChar.
 // isIdentChar is the LEXER'S ident set — it admits `/`, `*` and `:` — and is
 // not the set of texts that survive a serialize/re-parse cycle. Three
-// ident-char-only texts are re-interpreted STRUCTURALLY on the way back in,
-// with no parse error and no warning:
+// ident-char-only CLASSES are re-interpreted STRUCTURALLY on the way back in.
+// Two are SILENT — no parse error, no warning. The unterminated block comment
+// is the exception: it returns a TokenError, so it corrupts loudly rather than
+// quietly, which makes it the least dangerous of the three:
 //
 //	//x        line comment  -> the key and everything after it on that line
 //	                            silently VANISH

--- a/pkg/config/quotekey_relex_6523_test.go
+++ b/pkg/config/quotekey_relex_6523_test.go
@@ -1,0 +1,389 @@
+package config
+
+// Structural round-trip tests for quoteKey's bare-emission predicate (#6523).
+//
+// quoteKey used to emit a key bare whenever every byte satisfied isIdentChar.
+// isIdentChar is the LEXER'S ident set — it admits `/`, `*` and `:` — and is
+// not the set of texts that survive a serialize/re-parse cycle. Three
+// ident-char-only texts are re-interpreted STRUCTURALLY on the way back in,
+// with no parse error and no warning:
+//
+//	//x        line comment  -> the key and everything after it on that line
+//	                            silently VANISH
+//	/*x*/      block comment -> swallowed silently
+//	/*x        block comment -> swallows the rest of the config (Parse errors)
+//	inactive:  deactivation marker -> leading, deactivates an unrelated
+//	                            statement; inline, TRUNCATES the key list
+//
+// Every serialize-then-reparse path is affected: HA config sync, rollback,
+// archive, rescue. This file pins the fix at three levels — the predicate
+// itself, the hierarchical Format->Parse path, and the `| display set`
+// Format->ParseSetVerb path — plus an over-reach guard (ordinary values must
+// keep emitting bare) and a brute-force property sweep that re-derives the
+// hazard set from the real lexer so a comment syntax added later cannot
+// quietly reopen the hole.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// structuralHazards are the texts that must NOT be emitted bare. Each is made
+// entirely of isIdentChar bytes, so the pre-#6523 predicate emitted every one
+// of them unquoted.
+var structuralHazards = []struct {
+	name  string
+	value string
+}{
+	{"line-comment", "//x"},
+	{"line-comment-bare", "//"},
+	{"line-comment-only-slashes", "///"},
+	{"block-comment-terminated", "/*x*/"},
+	{"block-comment-unterminated", "/*x"},
+	{"block-comment-bare", "/*"},
+	{"block-comment-empty", "/**/"},
+	{"inactive-marker", "inactive:"},
+}
+
+// hazardKeyShapes places a candidate at each structurally distinct position in
+// a node's key list: leading (where the `inactive:` marker is lifted onto
+// Node.Inactive), inline (where it truncates the key list), and trailing
+// (the usual home of a config VALUE, e.g. an IKE pre-shared-key).
+var hazardKeyShapes = []struct {
+	name string
+	// keys builds the node key list around the candidate, and idx is where
+	// the candidate lands.
+	keys func(v string) []string
+	idx  int
+}{
+	{"leading", func(v string) []string { return []string{v, "trailer"} }, 0},
+	{"inline", func(v string) []string { return []string{"description", v, "trailer"} }, 1},
+	{"trailing", func(v string) []string { return []string{"pre-shared-key", "ascii-text", v} }, 2},
+}
+
+// formatParseKeys round-trips a single-leaf tree through Format and Parse and
+// returns the recovered key list. Errors are returned rather than fataled so
+// callers can report the candidate that produced them.
+func formatParseKeys(keys []string) ([]string, bool, error) {
+	tree := &ConfigTree{Children: []*Node{{Keys: keys, IsLeaf: true}}}
+	text := tree.Format()
+	parsed, errs := NewParser(text).Parse()
+	if len(errs) != 0 {
+		return nil, false, fmt.Errorf("parse errors %v in:\n%s", errs, text)
+	}
+	if len(parsed.Children) != 1 {
+		return nil, false, fmt.Errorf("expected 1 top-level node, got %d in:\n%s",
+			len(parsed.Children), text)
+	}
+	n := parsed.Children[0]
+	return n.Keys, n.Inactive, nil
+}
+
+// TestQuoteKeyStructuralHazards6523 is the primary fail-on-revert assertion:
+// a key that re-lexes as a comment or a deactivation marker must survive
+// Format->Parse byte-identically, in every key position.
+//
+// On revert of the quoteKey change every subtest fails with an assertion (a
+// wrong key list, a spurious Inactive flag, or a Parse error) — not a build
+// break.
+func TestQuoteKeyStructuralHazards6523(t *testing.T) {
+	for _, hz := range structuralHazards {
+		for _, shape := range hazardKeyShapes {
+			t.Run(hz.name+"/"+shape.name, func(t *testing.T) {
+				want := shape.keys(hz.value)
+				got, inactive, err := formatParseKeys(want)
+				if err != nil {
+					t.Fatalf("value %q at %s position did not round-trip: %v",
+						hz.value, shape.name, err)
+				}
+				if inactive {
+					t.Fatalf("value %q at %s position was re-read as a deactivation "+
+						"marker: Node.Inactive set on an active statement",
+						hz.value, shape.name)
+				}
+				if len(got) != len(want) {
+					t.Fatalf("value %q at %s position changed the key list: want %q, got %q",
+						hz.value, shape.name, want, got)
+				}
+				for i := range want {
+					if got[i] != want[i] {
+						t.Fatalf("value %q at %s position corrupted key %d: want %q, got %q "+
+							"(full key list %q)", hz.value, shape.name, i, want[i], got[i], got)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestQuoteKeyHazardsAreQuoted6523 pins the predicate itself: each hazard must
+// be emitted WITH quotes, so the token the parser sees on re-read is a
+// TokenString. That token kind is what makes parseStatement treat `inactive:`
+// as a literal rather than a marker (#4348), and what keeps the lexer from
+// ever starting a comment inside the value.
+func TestQuoteKeyHazardsAreQuoted6523(t *testing.T) {
+	for _, hz := range structuralHazards {
+		t.Run(hz.name, func(t *testing.T) {
+			out := quoteKey(hz.value)
+			if !strings.HasPrefix(out, `"`) || !strings.HasSuffix(out, `"`) {
+				t.Fatalf("quoteKey(%q) = %s, want a quoted string — bare emission "+
+					"re-parses as a comment or deactivation marker", hz.value, out)
+			}
+			tok := NewLexer(out).Next()
+			if tok.Type != TokenString {
+				t.Fatalf("quoteKey(%q) = %s re-lexed as %s, want a string token",
+					hz.value, out, tok.Type)
+			}
+			if tok.Value != hz.value {
+				t.Fatalf("quoteKey(%q) = %s re-lexed to %q", hz.value, out, tok.Value)
+			}
+		})
+	}
+}
+
+// TestQuoteKeyNoOverReach6523 is the over-reach guard. Tightening the
+// predicate must not start quoting values that were never at risk: doing so
+// would churn every archived config and every HA config-sync diff, and would
+// show up as spurious noise in `show | compare`.
+//
+// `/` in particular appears legitimately in prefixes (10.0.0.0/24), interface
+// names (ge-0/0/0) and wildcards, so a predicate that rejected any value
+// containing `/` would be wrong — and this test is what catches it.
+func TestQuoteKeyNoOverReach6523(t *testing.T) {
+	for _, v := range bareKeyValues {
+		t.Run(v, func(t *testing.T) {
+			if got := quoteKey(v); got != v {
+				t.Fatalf("quoteKey(%q) = %q — value quoted unnecessarily; "+
+					"over-quoting churns archives and HA config-sync diffs", v, got)
+			}
+			// Bare emission must still be correct, not merely unchanged.
+			want := []string{"description", v, "trailer"}
+			got, inactive, err := formatParseKeys(want)
+			if err != nil {
+				t.Fatalf("bare value %q did not round-trip: %v", v, err)
+			}
+			if inactive || len(got) != len(want) || got[1] != v {
+				t.Fatalf("bare value %q corrupted: want %q (inactive=false), got %q (inactive=%v)",
+					v, want, got, inactive)
+			}
+		})
+	}
+}
+
+// TestQuoteKeySetFormHazards6523 covers the second serializer. `show
+// configuration | display set` renders through joinQuotedKeys (ast_format.go)
+// and is replayed through ParseSetVerb, which drives the same Lexer — so the
+// same three texts are re-read as comments or markers there too. configstore
+// LoadSet / LoadMerge replay this form.
+func TestQuoteKeySetFormHazards6523(t *testing.T) {
+	for _, hz := range structuralHazards {
+		t.Run(hz.name, func(t *testing.T) {
+			want := []string{"description", hz.value, "trailer"}
+			line := "set " + joinQuotedKeys(want)
+			verb, path, err := ParseSetVerb(line)
+			if err != nil {
+				t.Fatalf("ParseSetVerb(%q) failed: %v", line, err)
+			}
+			if verb != "set" {
+				t.Fatalf("ParseSetVerb(%q) verb = %q, want set", line, verb)
+			}
+			if len(path) != len(want) {
+				t.Fatalf("set-form round-trip of %q changed the path: want %q, got %q",
+					hz.value, want, path)
+			}
+			for i := range want {
+				if path[i] != want[i] {
+					t.Fatalf("set-form round-trip of %q corrupted element %d: want %q, got %q",
+						hz.value, i, want[i], path[i])
+				}
+			}
+		})
+	}
+}
+
+// TestQuoteKeyZoneInterfaceHazard6523 is the concrete operator-visible end
+// state from the issue: a security zone whose interface name is a
+// comment-introducing text loses the interface entirely on the receiving side
+// of an HA config sync / rollback reload. The zone still compiles — it just
+// has nothing in it.
+func TestQuoteKeyZoneInterfaceHazard6523(t *testing.T) {
+	for _, hz := range structuralHazards {
+		if strings.HasPrefix(hz.value, "/*") {
+			// A block comment swallows the following statement too, which is a
+			// different (also fixed) end state; the line-comment and marker
+			// forms are the ones that silently empty the zone.
+			continue
+		}
+		t.Run(hz.name, func(t *testing.T) {
+			tree := &ConfigTree{Children: []*Node{
+				{Keys: []string{"security"}, Children: []*Node{
+					{Keys: []string{"zones"}, Children: []*Node{
+						{Keys: []string{"security-zone", "trust"}, Children: []*Node{
+							{Keys: []string{"interfaces", hz.value}, IsLeaf: true},
+							{Keys: []string{"interfaces", "ge-0/0/1.0"}, IsLeaf: true},
+						}},
+					}},
+				}},
+			}}
+			text := tree.Format()
+			parsed, errs := NewParser(text).Parse()
+			if len(errs) != 0 {
+				t.Fatalf("zone with interface %q failed to re-parse: %v\n%s", hz.value, errs, text)
+			}
+			zone := parsed.FindChild("security").
+				FindChild("zones").
+				FindChild("security-zone")
+			if zone == nil {
+				t.Fatalf("security-zone vanished after round-trip:\n%s", text)
+			}
+			ifaces := zone.FindChildren("interfaces")
+			if len(ifaces) != 2 {
+				t.Fatalf("zone lost interfaces: want 2, got %d (%v)\n%s",
+					len(ifaces), ifaces, text)
+			}
+			if len(ifaces[0].Keys) != 2 || ifaces[0].Keys[1] != hz.value {
+				t.Fatalf("interface %q corrupted to %q\n%s", hz.value, ifaces[0].Keys, text)
+			}
+		})
+	}
+}
+
+// relexAlphabet is every byte the lexer accepts inside a bare identifier —
+// read from isIdentChar itself, so it tracks the lexer rather than a copy.
+var relexAlphabet = func() []byte {
+	var out []byte
+	for c := 0; c < 256; c++ {
+		if isIdentChar(byte(c)) {
+			out = append(out, byte(c))
+		}
+	}
+	return out
+}()
+
+// relexPunctuation is the non-alphanumeric part of the alphabet plus two
+// filler bytes. Structural meaning only ever comes from punctuation, so this
+// is the subset worth sweeping to greater depth.
+var relexPunctuation = []byte{'%', '*', '+', ',', '-', '.', '/', ':', '<', '=', '>', '_', 'a', '0'}
+
+// TestQuoteKeyRelexProperty6523 is the anti-rot device. Rather than trusting a
+// fixed list of three known-bad texts, it sweeps the lexer's own ident
+// alphabet and asserts the round-trip invariant for every candidate: whatever
+// quoteKey emits must read back as exactly the key it was given.
+//
+// A comment syntax, an ident-char addition, or a new parser marker introduced
+// later reopens this hole the moment it lands, and this sweep goes RED then —
+// not when someone remembers to extend a denylist.
+//
+// Coverage: all 1- and 2-byte texts over the full alphabet (every possible
+// two-byte introducer), every 2-byte prefix followed by a tail (introducers
+// that need trailing text to bite), and all 3-byte texts over the punctuation
+// subset. Each candidate is checked in all three key positions.
+func TestQuoteKeyRelexProperty6523(t *testing.T) {
+	checked := 0
+	check := func(t *testing.T, v string) {
+		for _, shape := range hazardKeyShapes {
+			want := shape.keys(v)
+			got, inactive, err := formatParseKeys(want)
+			checked++
+			if err != nil {
+				t.Errorf("candidate %q at %s position did not round-trip: %v",
+					v, shape.name, err)
+				return
+			}
+			if inactive {
+				t.Errorf("candidate %q at %s position set Node.Inactive", v, shape.name)
+				return
+			}
+			if len(got) != len(want) || got[shape.idx] != v {
+				t.Errorf("candidate %q at %s position corrupted: want %q, got %q",
+					v, shape.name, want, got)
+				return
+			}
+		}
+	}
+
+	buf := make([]byte, 3)
+	// Every 1- and 2-byte text, and every 2-byte prefix with a tail.
+	tails := []string{"", "abc", "*/", "x*/y", inactiveMarker}
+	for _, c0 := range relexAlphabet {
+		buf[0] = c0
+		check(t, string(buf[:1]))
+		for _, c1 := range relexAlphabet {
+			buf[1] = c1
+			for _, tl := range tails {
+				check(t, string(buf[:2])+tl)
+			}
+		}
+	}
+	// Every 3-byte punctuation text, plus the same embedded mid-value and at
+	// the tail of a longer value (interior sequences must NOT trigger).
+	for _, c0 := range relexPunctuation {
+		buf[0] = c0
+		for _, c1 := range relexPunctuation {
+			buf[1] = c1
+			check(t, "abc"+string(buf[:2])+"def")
+			check(t, "abcd"+string(buf[:2]))
+			for _, c2 := range relexPunctuation {
+				buf[2] = c2
+				check(t, string(buf[:3]))
+			}
+		}
+	}
+	t.Logf("swept %d round-trips over %d ident bytes", checked, len(relexAlphabet))
+}
+
+// TestBareKeySafeAgreesWithRoundTrip6523 asserts the predicate is not merely
+// sufficient but honest: every text bareKeySafe accepts must round-trip when
+// emitted bare, and every text it rejects must round-trip when emitted quoted.
+// This is what keeps a future "optimization" from widening the predicate
+// without widening what actually survives a re-parse.
+func TestBareKeySafeAgreesWithRoundTrip6523(t *testing.T) {
+	cases := []string{}
+	for _, hz := range structuralHazards {
+		cases = append(cases, hz.value)
+	}
+	cases = append(cases, bareKeyValues...)
+	cases = append(cases, "", " ", "a b", "{", "}", ";", `"`, `a"b`, "#x", "a#b",
+		"[a]:1", "[2001:db8::1]:51820", "${node}", "10.0.0.0/24")
+
+	for _, v := range cases {
+		t.Run(fmt.Sprintf("%q", v), func(t *testing.T) {
+			emitted := quoteKey(v)
+			bare := bareKeySafe(v)
+			if bare != (emitted == v) {
+				t.Fatalf("bareKeySafe(%q)=%v disagrees with quoteKey(%q)=%q", v, bare, v, emitted)
+			}
+			// Whatever was emitted must re-lex to exactly this value.
+			l := NewLexer(emitted)
+			tok := l.Next()
+			if tok.Type == TokenError {
+				t.Fatalf("quoteKey(%q)=%s lexed to error %q", v, emitted, tok.Value)
+			}
+			if tok.Value != v {
+				t.Fatalf("quoteKey(%q)=%s lexed back to %q", v, emitted, tok.Value)
+			}
+			if next := l.Next(); next.Type != TokenEOF {
+				t.Fatalf("quoteKey(%q)=%s produced a trailing %s token", v, emitted, next.Type)
+			}
+		})
+	}
+}
+
+// TestQuoteKeyBareEmissionIsZeroAlloc6523 keeps the predicate off the heap.
+// quoteKey runs once per key on every Format, and Format serializes the whole
+// candidate configuration on each commit, archive, rollback slot write and HA
+// config sync. Asking the real lexer is only affordable because the Lexer does
+// not escape; this fails if a future edit makes it allocate.
+func TestQuoteKeyBareEmissionIsZeroAlloc6523(t *testing.T) {
+	avg := testing.AllocsPerRun(1000, func() {
+		for _, v := range bareKeyValues {
+			if !bareKeySafe(v) {
+				t.Fatalf("bareKeySafe(%q) = false", v)
+			}
+		}
+	})
+	if avg != 0 {
+		t.Fatalf("bareKeySafe allocates %.1f times per call batch, want 0", avg)
+	}
+}

--- a/pkg/config/quotekey_roundtrip_3854_test.go
+++ b/pkg/config/quotekey_roundtrip_3854_test.go
@@ -80,31 +80,6 @@ var roundTripValues = []struct {
 	{"inactive-marker-value", "inactive:"},
 }
 
-// bareKeyValues are values that MUST keep being emitted WITHOUT quotes. The
-// #6523 predicate tightened what may go bare, and over-quoting is its own
-// regression: it would churn every archived config and every HA config-sync
-// diff for values that were never at risk. Note that `/` is legitimate and
-// common here (prefixes, interface names, wildcards) — a predicate that
-// rejected any value containing `/` would be wrong, and this slice is what
-// catches it.
-var bareKeyValues = []string{
-	// Structural keys.
-	"security", "zones", "security-zone", "pre-shared-key", "ascii-text",
-	// Prefixes and addresses — `/` mid-value.
-	"10.0.0.0/24", "192.168.1.1", "2001:db8::1", "2001:db8::/32", "::/0",
-	// Interface names — `/` and `-`.
-	"ge-0/0/0", "ge-0/0/0.100", "reth0.50", "xe-1/0/0:3", "fxp0",
-	// Wildcards and group syntax — `*`, `<`, `>`.
-	"*", "<*>", "<ge-*>", "any", "any-ipv4",
-	// Times, ranges, numbers, percentages, equals — the rest of isIdentChar.
-	"00:00:00", "1024-65535", "3600", "50%", "a=b", "a,b",
-	// `/` and `*` present but NOT as a leading comment introducer. `/` alone
-	// and `/x` are safe: the introducer needs `/` followed by `/` or `*`.
-	"a//b", "a/*b", "a*/b", "*/", "*/x", "x//", "/x", "/", "/-", "/0",
-	// Near-misses on the parser marker: only the exact text is a marker.
-	"inactive", "inactive::", ":inactive:", "Inactive:", "inactive:x",
-}
-
 // leafValueTree wraps a value as the trailing key of a single hierarchical
 // leaf, mirroring how a real config value (e.g. an IKE pre-shared-key) is
 // stored in the AST.

--- a/pkg/config/quotekey_roundtrip_3854_test.go
+++ b/pkg/config/quotekey_roundtrip_3854_test.go
@@ -58,6 +58,51 @@ var roundTripValues = []struct {
 	{"kitchen-sink", "a\\b\"c\nd{e}f;g"},
 	// Empty value must stay empty ("" <-> "").
 	{"empty", ""},
+
+	// #6523: values made ENTIRELY of lexer ident chars that nonetheless carry
+	// structural meaning when re-read. quoteKey's old predicate ("all bytes
+	// are isIdentChar") emitted every one of these BARE, so Format->Parse
+	// re-read them as a comment or a deactivation marker. Each fails
+	// differently on revert, which is why all four are listed:
+	//
+	//   //x     -> line comment: the value and the `ascii-text` key before it
+	//              are swallowed to end-of-line. Recovered value becomes the
+	//              literal "ascii-text" (the issue's PSK example).
+	//   /*x*/   -> terminated block comment: swallowed silently, same result.
+	//   /*x     -> unterminated block comment: the rest of the config is eaten
+	//              and Parse returns an error.
+	//   inactive: -> the parser's deactivation marker. Inline (as here) it
+	//              TRUNCATES the key list at the marker; leading, it would set
+	//              Node.Inactive on an unrelated statement.
+	{"line-comment-value", "//x"},
+	{"block-comment-value", "/*x*/"},
+	{"unterminated-block-comment-value", "/*x"},
+	{"inactive-marker-value", "inactive:"},
+}
+
+// bareKeyValues are values that MUST keep being emitted WITHOUT quotes. The
+// #6523 predicate tightened what may go bare, and over-quoting is its own
+// regression: it would churn every archived config and every HA config-sync
+// diff for values that were never at risk. Note that `/` is legitimate and
+// common here (prefixes, interface names, wildcards) — a predicate that
+// rejected any value containing `/` would be wrong, and this slice is what
+// catches it.
+var bareKeyValues = []string{
+	// Structural keys.
+	"security", "zones", "security-zone", "pre-shared-key", "ascii-text",
+	// Prefixes and addresses — `/` mid-value.
+	"10.0.0.0/24", "192.168.1.1", "2001:db8::1", "2001:db8::/32", "::/0",
+	// Interface names — `/` and `-`.
+	"ge-0/0/0", "ge-0/0/0.100", "reth0.50", "xe-1/0/0:3", "fxp0",
+	// Wildcards and group syntax — `*`, `<`, `>`.
+	"*", "<*>", "<ge-*>", "any", "any-ipv4",
+	// Times, ranges, numbers, percentages, equals — the rest of isIdentChar.
+	"00:00:00", "1024-65535", "3600", "50%", "a=b", "a,b",
+	// `/` and `*` present but NOT as a leading comment introducer. `/` alone
+	// and `/x` are safe: the introducer needs `/` followed by `/` or `*`.
+	"a//b", "a/*b", "a*/b", "*/", "*/x", "x//", "/x", "/", "/-", "/0",
+	// Near-misses on the parser marker: only the exact text is a marker.
+	"inactive", "inactive::", ":inactive:", "Inactive:", "inactive:x",
 }
 
 // leafValueTree wraps a value as the trailing key of a single hierarchical


### PR DESCRIPTION
Closes #6523

## Problem

`quoteKey` emitted a configuration key **bare** whenever every byte satisfied `isIdentChar`. That is the *lexer's* ident set — it admits `/`, `*` and `:` — and it is **not** the set of texts that survive a serialize/re-parse cycle. Four ident-char-only texts are re-interpreted **structurally** when the emitted config is read back, with zero parse errors and zero warnings:

| Value | What the re-read does |
|---|---|
| `//x` | `skipWhitespaceAndComments` consumes to end-of-line — the key **and every key after it on that line** silently vanish |
| `/*x*/` | Terminated block comment — swallowed silently |
| `/*x` | Unterminated block comment — swallows the rest of the config; `Parse` errors |
| `inactive:` | The parser's deactivation marker: **leading**, sets `Node.Inactive` on an unrelated statement; **inline**, TRUNCATES the key list |

Every serialize-then-reparse path is affected — HA config sync, rollback, archive, rescue — the paths an operator leans on when something has already gone wrong. Demonstrated end states: a `security-zone` compiled with **zero interfaces**, `permit junos-http` widened to **`permit any any any`**, and an IKE pre-shared-key becoming the literal string `ascii-text`.

Reachable from the plain `set` CLI (`set ... description inactive:`), not only hierarchical ingest. **Both** serializers are affected: hierarchical `Format` (`QuotedKeyPath`) and `| display set` (`joinQuotedKeys`), the latter replayed through `ParseSetVerb`, which drives the same lexer.

## Fix

The predicate is replaced, not denylisted — a hardcoded three-value list re-breaks the day someone adds a comment syntax. `bareKeySafe` asks the code that will actually read the config back:

1. **every byte is an `isIdentChar`** — retained as a NECESSARY pre-condition so the change is *monotone*: output only ever gains quotes, never loses them. Without it a bracketed endpoint `[2001:db8::1]:51820` would newly go bare, since `tryBracketedEndpointLiteral` (#5182) hands it back as one identifier equal to itself.
2. **the bare text re-lexes as exactly one `TokenIdentifier` whose value is the text itself, then `TokenEOF`.**
3. **it is not a parser-level marker** (`inactiveMarker`) — the one thing the lexer cannot see.

Quoting also re-arms the parser's existing defence: a quoted `"inactive:"` arrives as a `TokenString`, which `parseStatement` already refuses to treat as a marker (#4348).

## Premise verified firsthand

Confirmed on current master: `isIdentChar` admits `/`, `*`, `:`; the `//` arm consumes to EOL with **no error at all**; `inactiveMarker` detection runs post-tokenize (leading *and* inline).

## Hazard set independently re-derived — not taken from the issue

Rather than trust the issue's "exactly three", the set was re-derived by brute force through the real `Format`→`Parse`:

- **exhaustive** every 1-, 2- and 3-byte text over the lexer's full 74-byte ident alphabet (438,976 candidates),
- **exhaustive** every 1- to 5-byte text over the punctuation subset (5,908 hazards found),
- every 2-byte prefix with assorted tails, plus 2-byte pairs embedded mid-value and at the tail,
- each in three key positions (leading / inline / trailing).

**Result: zero hazards beyond leading `//`, leading `/*`, and exactly `inactive:`.** The issue's claim holds.

Two things worth flagging beyond the issue text:

- **`/*` has two distinct end states**, not one. A *terminated* `/*x*/` is swallowed silently (fail-open); an *unterminated* `/*x` eats the rest of the config and fails the load — the lexer returns `TokenError`, so `/*x` is the one hazard that is **not** silent. The other three (`//x`, `/*x*/`, `inactive:`) produce zero parse errors, which is what makes them dangerous. Both `/*` forms are fixed; both are pinned separately.
- **`#` was checked and ruled out.** It is a comment introducer but is *not* an `isIdentChar`, so it was already being quoted. Same for `[`, `]`, `{`, `}`, `;`, `|`, `"`.

## Not over-quoting

`TestQuoteKeyNoOverReach6523` asserts ordinary values still emit **unquoted**: `10.0.0.0/24`, `2001:db8::/32`, `ge-0/0/0`, `xe-1/0/0:3`, `reth0.50`, `<*>`, `<ge-*>`, `ascii-text`, `00:00:00`, `1024-65535`, `50%`, MAC addresses (`00:11:22:33:44:55` — `:` is the same byte that makes `inactive:` a marker) and application names (`junos-ssh`, `junos-http` — the operand of the policy widening this issue demonstrated), plus the near-misses `a//b`, `a/*b`, `a*/b`, `*/`, `/x`, `/`, `inactive`, `inactive::`, `inactive:x`. `/` is legitimate and common, so a naive "reject any value containing `/`" would be wrong — this guard is what catches it. Over-quoting would churn every archived config and every HA config-sync diff.

## Cost

`bareKeySafe` is **allocation-free**: `NewLexer` inlines and the `Lexer` does not escape (verified with `-gcflags=-m`, pinned by `TestQuoteKeyBareEmissionIsZeroAlloc6523`).

It is not free in time, though. Measured against the old predicate: **`quoteKey` is 4.7x slower per key** (217 -> 1026 ns/op over 10 typical keys) and **`Format` of a 2000-policy tree is +4.3%** (16.52 -> 17.24 ms/op). So: **+~4% on `Format`, allocation-free on the bare path** — negligible in absolute terms for a path that runs on commit, archive, rollback slot write and HA config sync, but not "nothing".

## Tests

New `pkg/config/quotekey_relex_6523_test.go`:

- `TestQuoteKeyStructuralHazards6523` — each hazard in leading / inline / trailing key position
- `TestQuoteKeyHazardsAreQuoted6523` — hazards emit quoted and re-lex as `TokenString`
- `TestQuoteKeySetFormHazards6523` — the `| display set` → `ParseSetVerb` path
- `TestQuoteKeyZoneInterfaceHazard6523` — the zero-interface zone end state
- `TestBareKeySafeAgreesWithLexer6523` — predicate/`quoteKey` agreement, and the emitted text re-lexes to exactly the input. **Lexer-level**, which is why it is not named for a round-trip (see Fail-on-revert)
- `TestQuoteKeyRelexProperty6523` — brute-force sweep over the lexer's own ident alphabet, re-deriving the hazard set instead of trusting a fixed list. **Goes RED the day a new comment syntax or ident-char lands** — those are punctuation-shaped and short, so they fall inside the swept space. Coverage precisely: every 1- and 2-byte text over the full 74-byte alphabet, every 2-byte prefix with each of four tails, every 3-byte text over a 14-byte *punctuation* subset (not the full alphabet), plus embedded/trailing punctuation pairs and every registered `parserMarkers` entry — each in three key positions, 91,773 round-trips
- `TestParserMarkerVocabulary6523` — the anti-rot device for the half the lexer **cannot** derive (see below)
- Guards (green under revert by design): `TestQuoteKeyNoOverReach6523`, `TestQuoteKeyBareEmissionIsZeroAlloc6523`

### The parser-marker half is enumerated, not derived

Deferring to the real lexer covers a comment syntax the day it lands. It does **not** cover a *word-shaped* parser marker: a future `replace:` / `protect:` is invisible to the lexer (it comes back as an ordinary identifier), and the alphabet sweep cannot find one either, since its candidates are short and punctuation-shaped. So the marker is now a package-level **`parserMarkers`** registry (`parser.go`) carrying that contract explicitly, consulted by `bareKeySafe` and enumerated by the sweep.

`TestParserMarkerVocabulary6523` gates it over the realistic marker vocabulary (`replace:`, `protect:`, `delete:`, `rename:`, `insert:`, ...): each candidate must **either** be registered and quoted, **or** still round-trip as an ordinary key. Verified in both directions — teaching `parseStatement` to treat `replace:` structurally *without* registering it fails with `"replace:" at inline position corrupted ... add it to parserMarkers`, and registering it turns both legs green.

Scope, stated honestly: this makes the anti-rot claim true **over that enumerated vocabulary**, not unconditionally. A marker outside the list is still caught only by whoever honours the `parserMarkers` contract. Marker *semantics* stay in `parseStatement` — the registry records which texts are load-bearing, not what they do, since a future merge directive would not share `inactive:`'s deactivation behaviour.

`//x`, `/*x*/`, `/*x` and `inactive:` were added to the #3854 `roundTripValues` harness (acceptance criterion 1).

## Fail-on-revert

Reverting `bareKeySafe` to the old all-identChars predicate (`go vet` clean on the reverted tree, so every RED is an **assertion**, not a build break):

**9 binders go RED.** Six fully — `TestQuoteKeyStructuralHazards6523` (24/24), `TestQuoteKeyHazardsAreQuoted6523` (8/8), `TestQuoteKeyZoneInterfaceHazard6523` (4/4), `TestQuoteKeyRelexProperty6523`, `TestFormatParseRoundTrip3854` (4/4 new values), `TestFormatParseIdempotent3854` (4/4 new). **Three bind only partially**, all for the same reason — `inactive:` is a **parser-level** hazard, so any assertion that stops at the lexer or at `ParseSetVerb` passes without the fix:

- `TestQuoteKeySetFormHazards6523` — 7/8. `ParseSetVerb` recognizes a structural verb in the **first token only**, so a later `inactive:` is appended to the path literally and even unquoted output round-trips in set form. Only the comment forms bite there; it is asserted anyway so both serializers agree on what gets quoted.
- `TestBareKeySafeAgreesWithLexer6523` — same `inactive:` exception. Renamed from `...AgreesWithRoundTrip6523`, which claimed a round-trip it never performed (it re-**lexes**). Not given a parse leg: the parse-level assertion for that exact corpus already exists in `TestQuoteKeyStructuralHazards6523` and `TestQuoteKeyNoOverReach6523`.
- `TestQuoteKeyLexerSymmetry3854` — 3/4 new values, same reason.

`TestParserMarkerVocabulary6523` binds on its registered-marker leg (`inactive:` RED) and guards on the other 17.

**2 tests are guards and correctly stay GREEN** — `TestQuoteKeyNoOverReach6523` (the pre-fix predicate also emitted those bare; it catches the *opposite* regression) and `TestQuoteKeyBareEmissionIsZeroAlloc6523` (performance; also escape-analysis dependent — 41 allocs under `-gcflags=all=-l`, 0 on the default build and under `-race`).

Sample assertions:

```
value "inactive:" at leading position was re-read as a deactivation marker:
  Node.Inactive set on an active statement
value "//x" at inline position changed the key list:
  want ["description" "//x" "trailer"], got ["description"]
```

including the issue's exact PSK end state: `["pre-shared-key", "ascii-text", "inactive:"]` recovered as `["pre-shared-key", "ascii-text"]`.

## Validation

- `pkg/config`, `pkg/configstore`, `pkg/configstore/journal` — green
- whole-repo `go test ./...` — green **except** `TestHeatmapNotStale`, which was verified failing **identically on clean `origin/master` fff7a4ab5** with no changes applied. The drift is confined to `userspace-dp/*.rs` files this PR never touches (`pkg/config/ast.go` is 511 LOC, far below the 1500 threshold). Pre-existing, unrelated, and left alone so unrelated heatmap churn does not ride in on this PR.

## Docs

- `docs/config-schema.md` — new "What may be emitted BARE — the re-lex predicate (#6523)" section; the #3854 section's now-stale "isIdentChar is the trigger" wording corrected.
- `pkg/config/freetext.go` — the #3900 comment asserted config VALUES are immune *because they are emitted quoted*. This bug falsified that premise. The comment now records why the conclusion holds again for a narrower reason (the serializer quotes specifically what is unsafe — most values still go bare), and the contradictory "are emitted quoted" sentence that survived the first pass is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi

