### PR TITLE
cluster: bound the interface-monitor weight to the heartbeat domain

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -61866,3 +61866,45 @@ would never produce.
     cluster_monitor_weight_6549_test.go}, pkg/cli/{cli_helpers.go,
     cluster_monitor_weight_6549_test.go}, pkg/config/schema_chassis.go,
     docs/config-schema.md, _Log.md
+- **Timestamp**: 2026-07-31
+- **Action**: #6549 Codex re-review fold (MERGE-NEEDS-MINOR) — correct comments
+  and fail-on-revert labels that the previous fold made stale. COMMENT-ONLY; no
+  production line changed (verified by filtering the diff to non-comment lines).
+  Codex found three tests labelled as `Manager.SetMonitorWeight` chokepoint
+  guards that its own upstream clamps now MASK. Reproduced firsthand with a
+  compile-clean chokepoint removal (`go vet` clean, so a real mutation and not
+  a build break): only `TestSetMonitorWeight_ClosesTheDebtDomain_6549` goes red;
+  both `TestDaemonApplyTail_*` and
+  `TestIPMonitor_OutOfRangeWeightCannotCancelARealFailure_6549` stay green.
+  Established what they DO bind by pairwise mutation: the two daemon cases fail
+  only when the `pkg/routing` clamp AND the chokepoint are both removed; the
+  independent-IP case only when `ipTargetWeight` AND the chokepoint are both
+  removed. They are END-TO-END guards over a deliberately layered defense, and
+  each individual clamp already has a dedicated binder
+  (`TestSetMonitorWeight_ClosesTheDebtDomain_6549`,
+  `TestInterfaceMonitorStatus_WeightIsBounded_6549`,
+  `TestIPMonitor_NegativeWeightCannotMaskTheGlobalThreshold_6549`), so this was
+  a labelling defect, not a coverage hole — relabelled rather than padded with
+  redundant tests.
+  Also corrected three comments left describing the PRE-fold flow: election.go
+  no longer claims `ipTargetWeight` is unbounded or that the chokepoint is the
+  ip-monitoring class's only runtime defense; the test preamble no longer says
+  `pkg/routing` copies weights verbatim; and the warn-site comment no longer
+  claims to be the ONLY out-of-range signal for ip debts — it now says plainly
+  that reaching that branch means a producer skipped its own clamp, and points
+  a reader chasing a MISSING warning at reconcileMonitorDebtsLocked and
+  ipTargetWeight instead. That last one was the one that could send someone
+  debugging to the wrong file.
+  Recorded the CLAMP DIRECTION adjudication at the clamp itself (negative -> 0,
+  not 255) with the peer-push reasoning, so it is not re-litigated: clamp-255
+  turns a typo'd weight arriving over HA config-sync into an instant
+  redundancy-group resignation on the RECEIVING node — a remote HA
+  denial-of-service — whereas 0 is an already-legal operator-reachable state (a
+  weight-less interface-monitor compiles to exactly 0) and is loud via WARN.
+  Codex accepted this on re-review ("no counterargument defeating the peer-push
+  denial-of-service reasoning").
+  Full pkg/cluster, pkg/config, pkg/routing, pkg/grpcapi, pkg/cli suites green.
+  Cluster smoke was already banked by the parent (14/14, unclean sysrq reboot,
+  22.7 Gbps) and needs no re-run for a comment-only change.
+- **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
+    pkg/routing/monitor.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -61817,3 +61817,52 @@ would never produce.
     pkg/cluster/{election.go,failover.go,monitor.go,heartbeat_manager.go,
     ifmon_weight_divergence_6549_test.go},
     docs/config-schema.md, _Log.md
+- **Timestamp**: 2026-07-31
+- **Action**: #6549 review fold — close the FIFTH monitor-debt producer and the
+  ip-monitoring residual. Hostile review found the four-layer fix incomplete:
+  `pkg/daemon/daemon_apply_tail.go` feeds `pkg/routing`'s RAW
+  `InterfaceMonitorStatus.Weight` into `Manager.SetMonitorWeight` on EVERY
+  config apply, six lines after `UpdateConfig` clamped the same debt — so the
+  apply tail did not merely miss the clamp, it OVERWROTE it. Reproduced
+  firsthand: with `trust0 255` + `trust1 -100` and both links down the group
+  goes 0/SECONDARY -> 100/PRIMARY, persistently (pollInterfaceMonitors re-fires
+  only on a dampened TRANSITION, and a link already down before the apply
+  produces none). Fixed at the chokepoint — `Manager.SetMonitorWeight` clamps
+  every debt on the way in, which with `reconcileMonitorDebtsLocked` covers
+  both of the only two writes into `monitorWeights`, closing the domain against
+  every producer instead of an enumeration of them.
+  Beyond the review: the reviewer's claim that the chokepoint closes the
+  ip-monitoring residual "for free" is only half right, and the other half is a
+  sharper fail-open. In global-threshold mode a negative target weight
+  SUBTRACTS from the cumulative failure sum, so a SECOND genuinely unreachable
+  target pushes the sum back below global-threshold and drops the aggregate
+  debt the FIRST failure installed — more failures produce LESS demotion
+  (reproduced: weight 0/SECONDARY -> 255/PRIMARY when the second target dies).
+  The chokepoint cannot see it: no debt is desired, so SetMonitorWeight is
+  never called. Bounded in `Monitor.ipTargetWeight` + the aggregate branch of
+  `desiredRGIPDebts`, where both consumers read the value.
+  Also folded both review MINORs: `pkg/routing/monitor.go` bounds the status
+  weight at its source (it is election input, not display-only) and the four
+  config-only display fills in pkg/grpcapi + pkg/cli render the effective
+  weight, so `show chassis cluster interfaces` never reports a weight the
+  election does not apply; and the `clampWireWeight` CALL SITES are now bound
+  (previously only the function was, so a refactor could drop the belt
+  silently). Doc claims corrected: the ip-monitoring siblings' only defense is
+  a schema validator the lenient path downgrades, so this stanza is STRONGER
+  than them rather than "matching" them; and the compiled-int gate covers the
+  flat-set + container-hierarchical shapes, not the packed one-liner (#6588).
+  Fail-on-revert verified per guard, all ASSERTION failures with `go vet`
+  clean — no build breaks. Full pkg/cluster, pkg/config, pkg/daemon,
+  pkg/routing, pkg/grpcapi, pkg/cli suites green on a FRESH GOCACHE, every new
+  subtest confirmed to have run by name. `go test ./...` fully clean on the
+  rebased head. (TestHeatmapNotStale failed while this branch was based on
+  fff7a4ab5 — verified pre-existing by running it at origin/master a680161ca in
+  a detached worktree, where the canary output was byte-identical to the
+  branch's, so this change shifts nothing in the heatmap. Master has since
+  regenerated it and the canary now passes.)
+- **File(s)**: pkg/cluster/{election.go,monitor.go,
+    ifmon_weight_daemon_apply_6549_test.go}, pkg/routing/{monitor.go,
+    monitor_weight_6549_test.go}, pkg/grpcapi/{server_cluster.go,
+    cluster_monitor_weight_6549_test.go}, pkg/cli/{cli_helpers.go,
+    cluster_monitor_weight_6549_test.go}, pkg/config/schema_chassis.go,
+    docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -61795,3 +61795,25 @@ would never produce.
     pkg/dhcp/dhcpv6_iapd_prefixlen_6531_test.go,
     pkg/ra/sender_prefixlen_6531_test.go,
     pkg/daemon/ra_pd_prefixlen_6531_test.go, _Log.md
+- **Action**: #6549 range-gate + clamp the chassis-cluster interface-monitor
+  weight. `interface-monitor <if> weight <w>` had no bound at any layer:
+  the leaf packs its tokens onto one node key so it has no typed schema
+  leaf, and compileChassis Atoi'd it unbounded. The weight is the debt
+  subtracted from the RG weight (`255 - totalLost`, floor-only), so a
+  NEGATIVE weight pushed rg.Weight above 255 — read raw by the local
+  election but advertised through the single-byte HeartbeatGroup.Weight,
+  so `weight -100` left the local node at 355 while the peer received 99
+  and both elected primary. Four layers: (1) commit gate on the compiled
+  *Config in validateChassisClusterStrict (0..255, strict reject / lenient
+  warn, covers both parser shapes); (2) config.ClampInterfaceMonitorWeight
+  at the pkg/cluster read sites, which also closes a second fail-open — a
+  negative weight credited debt BACK and cancelled a sibling monitor's
+  real link failure; (3) rgWeightFromDebt closing the rg.Weight domain at
+  all three recompute sites; (4) saturating clampWireWeight at the marshal
+  boundary. Fail-on-revert verified separately for each of the four.
+- **File(s)**: pkg/config/{compiler_validate_strict_chassis.go,
+    compiler_uniformgates_cluster_zone.go, schema_chassis.go,
+    compiler_validate_strict_chassis_ifmon_6549_test.go},
+    pkg/cluster/{election.go,failover.go,monitor.go,heartbeat_manager.go,
+    ifmon_weight_divergence_6549_test.go},
+    docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3361,7 +3361,26 @@ reserved for whole-dataplane selection where a rewrite shim
   bypasses — pinned by `compiler_chassis_identity_5694_test.go`),
   `interface-monitor <if> weight <n>` (tokens pack inline into a
   `children==nil` leaf; typing the weight needs a children map, which
-  would flip SetPath grouping), `control-ports` (not compiled), and the
+  would flip SetPath grouping — so **#6549** range-gates the weight the
+  same way #4434/#4880 gate the RG id and node priority: on the COMPILED
+  `*Config` in `validateChassisClusterStrict`, `0..255`, strict-reject at
+  commit / warn on the tolerant load / peer-sync path. Running on the
+  compiled int covers BOTH parser shapes at once. It is a wire-width gate
+  like its siblings: the weight is the debt subtracted from the RG weight,
+  which the heartbeat advertises through a single byte
+  (`HeartbeatGroup.Weight`, `uint8(rg.Weight)`) while the local election
+  reads the raw int — `weight -100` on a down monitor left the local node
+  at 355 and the peer receiving 99, so both nodes elected primary from
+  identical state. `pkg/cluster` carries the matching runtime belts so a
+  leniently-loaded value still cannot diverge:
+  `config.ClampInterfaceMonitorWeight` where the configured weight is read
+  (`pollInterfaceMonitors`, `reconcileMonitorDebtsLocked` — a NEGATIVE
+  weight there also credited debt BACK and cancelled a sibling monitor's
+  real link failure) and `rgWeightFromDebt` closing the `rg.Weight` domain
+  at every recompute site. Pinned by
+  `compiler_validate_strict_chassis_ifmon_6549_test.go` (config) and
+  `ifmon_weight_divergence_6549_test.go` (cluster)), `control-ports` (not
+  compiled), and the
   address/interface string leaves (IP value types arrive with the
   interfaces PR). Known residual: the hierarchical packed one-liner
   `node 0 priority <v>;` bypasses the gate (identity-token rule) even

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3365,22 +3365,58 @@ reserved for whole-dataplane selection where a rewrite shim
   same way #4434/#4880 gate the RG id and node priority: on the COMPILED
   `*Config` in `validateChassisClusterStrict`, `0..255`, strict-reject at
   commit / warn on the tolerant load / peer-sync path. Running on the
-  compiled int covers BOTH parser shapes at once. It is a wire-width gate
-  like its siblings: the weight is the debt subtracted from the RG weight,
+  compiled int covers the flat-set and container-hierarchical shapes with
+  one gate (the PACKED one-liner `interface-monitor <if> weight <n>;`
+  written directly under `redundancy-group` is a separate matter — it
+  compiles to ZERO monitors, so the gate never sees it and no debt is
+  installed either; tracked as **#6588**). It is a wire-width gate like
+  its siblings: the weight is the debt subtracted from the RG weight,
   which the heartbeat advertises through a single byte
   (`HeartbeatGroup.Weight`, `uint8(rg.Weight)`) while the local election
   reads the raw int — `weight -100` on a down monitor left the local node
   at 355 and the peer receiving 99, so both nodes elected primary from
-  identical state. `pkg/cluster` carries the matching runtime belts so a
-  leniently-loaded value still cannot diverge:
-  `config.ClampInterfaceMonitorWeight` where the configured weight is read
-  (`pollInterfaceMonitors`, `reconcileMonitorDebtsLocked` — a NEGATIVE
-  weight there also credited debt BACK and cancelled a sibling monitor's
-  real link failure) and `rgWeightFromDebt` closing the `rg.Weight` domain
-  at every recompute site. Pinned by
-  `compiler_validate_strict_chassis_ifmon_6549_test.go` (config) and
-  `ifmon_weight_divergence_6549_test.go` (cluster)), `control-ports` (not
-  compiled), and the
+  identical state. Because the gate is DOWNGRADED on the tolerant paths,
+  the runtime — not the commit gate — is what actually holds the domain
+  closed, and it does so at the point debt is INSTALLED rather than at
+  each producer:
+  - `cluster.Manager.SetMonitorWeight` (`election.go`) clamps every debt
+    on the way in. With `reconcileMonitorDebtsLocked` it owns both of the
+    only two writes into `monitorWeights`, so the domain is closed against
+    EVERY producer — including `pkg/daemon`'s config-apply tail, which
+    feeds `pkg/routing`'s monitor statuses straight in on every commit /
+    boot Load / peer SyncApply and would otherwise OVERWRITE the clamp
+    `UpdateConfig` had just applied.
+  - `config.ClampInterfaceMonitorWeight` bounds the configured weight
+    where each producer reads it: `pollInterfaceMonitors`,
+    `reconcileMonitorDebtsLocked`, and `pkg/routing`'s
+    `monitorManager.Apply` (a NEGATIVE weight is negative DEBT — it
+    credits weight BACK and cancels a sibling monitor's real link
+    failure).
+  - `Monitor.ipTargetWeight` and the aggregate branch of
+    `desiredRGIPDebts` bound the ip-monitoring weights. This one is NOT
+    redundant with the chokepoint: in global-threshold mode a negative
+    target weight SUBTRACTS from the cumulative failure sum, so a second
+    genuinely unreachable target pushes the sum back below the threshold
+    and drops the aggregate debt the first failure installed — more
+    failures produce LESS demotion, and no `SetMonitorWeight` call happens
+    at all for the chokepoint to catch.
+  - `rgWeightFromDebt` closes the `rg.Weight` domain at every recompute
+    site, and `clampWireWeight` saturates rather than wraps at the
+    marshal boundary.
+  The display fills route through the same clamp
+  (`pkg/grpcapi/server_cluster.go`, `pkg/cli/cli_helpers.go`) so
+  `show chassis cluster interfaces` never reports a weight the election
+  does not apply. Note the ip-monitoring sibling leaves below are gated
+  ONLY by their schema `ValidateInteger(0, 255)`, which
+  `compileTreeLenient` downgrades to a warning — they carry no compiled-int
+  commit gate, so this stanza's posture is STRONGER than theirs, not
+  merely consistent with it. Pinned by
+  `compiler_validate_strict_chassis_ifmon_6549_test.go` (config),
+  `ifmon_weight_divergence_6549_test.go` +
+  `ifmon_weight_daemon_apply_6549_test.go` (cluster),
+  `monitor_weight_6549_test.go` (routing) and
+  `cluster_monitor_weight_6549_test.go` (grpcapi + cli)), `control-ports`
+  (not compiled), and the
   address/interface string leaves (IP value types arrive with the
   interfaces PR). Known residual: the hierarchical packed one-liner
   `node 0 priority <v>;` bypasses the gate (identity-token rule) even

--- a/pkg/cli/cli_helpers.go
+++ b/pkg/cli/cli_helpers.go
@@ -125,9 +125,14 @@ func (c *CLI) buildInterfacesInput() cluster.InterfacesInput {
 			}
 		} else {
 			for _, mon := range rg.InterfaceMonitors {
+				// #6549: render the weight the election would APPLY, not the
+				// raw configured one. An out-of-range weight survives the
+				// tolerant load / peer-sync compile (#1960 no-brick) and the
+				// runtime bounds it to [0,255].
+				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.Monitors = append(input.Monitors, cluster.InterfaceMonitorInfo{
 					Interface:       mon.Interface,
-					Weight:          mon.Weight,
+					Weight:          w,
 					Up:              true,
 					RedundancyGroup: rg.ID,
 				})
@@ -151,9 +156,12 @@ func (c *CLI) buildInterfacesInput() cluster.InterfacesInput {
 				if peerMap[mon.Interface] {
 					continue
 				}
+				// #6549: the peer bounds this weight the same way we do, so
+				// render the effective value rather than the raw config one.
+				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.PeerMonitors = append(input.PeerMonitors, cluster.InterfaceMonitorInfo{
 					Interface:       mon.Interface,
-					Weight:          mon.Weight,
+					Weight:          w,
 					Up:              false,
 					RedundancyGroup: rg.ID,
 				})

--- a/pkg/cli/cluster_monitor_weight_6549_test.go
+++ b/pkg/cli/cluster_monitor_weight_6549_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/routing"
+	"github.com/vishvananda/netlink"
+)
+
+// #6549, CLI twin of pkg/grpcapi's cluster_monitor_weight_6549_test.go: the
+// local `show chassis cluster interfaces` renders monitor weights through the
+// same three fills as the gRPC path and must likewise report the weight the
+// ELECTION APPLIES, not the raw configured one.
+//
+// An out-of-range weight survives the tolerant Store.Load / Store.SyncApply
+// compile (#1960 no-brick) and the runtime bounds it to [0,255]; rendering the
+// raw value would claim a monitor contributes -100 while the election
+// contributes 0.
+
+// cliMonWeightFakeLink is a netlink.Link carrying caller-chosen attrs.
+type cliMonWeightFakeLink struct {
+	attrs netlink.LinkAttrs
+}
+
+func (l *cliMonWeightFakeLink) Attrs() *netlink.LinkAttrs { return &l.attrs }
+func (l *cliMonWeightFakeLink) Type() string              { return "cli-mon-weight-fake" }
+
+// cliMonWeightFakeOps satisfies pkg/routing's (unexported) linkOps
+// structurally. An absent name models a PEER-owned interface, which the routing
+// sweep skips — that is what routes a configured monitor to the config-only
+// peer fill.
+type cliMonWeightFakeOps struct {
+	links map[string]netlink.Link
+}
+
+func (o *cliMonWeightFakeOps) LinkByName(name string) (netlink.Link, error) {
+	if l, ok := o.links[name]; ok {
+		return l, nil
+	}
+	return nil, net.UnknownNetworkError("not found: " + name)
+}
+
+func (o *cliMonWeightFakeOps) LinkAdd(netlink.Link) error                     { return nil }
+func (o *cliMonWeightFakeOps) LinkDel(netlink.Link) error                     { return nil }
+func (o *cliMonWeightFakeOps) LinkSetUp(netlink.Link) error                   { return nil }
+func (o *cliMonWeightFakeOps) LinkSetDown(netlink.Link) error                 { return nil }
+func (o *cliMonWeightFakeOps) LinkSetMaster(netlink.Link, netlink.Link) error { return nil }
+func (o *cliMonWeightFakeOps) LinkSetNoMaster(netlink.Link) error             { return nil }
+func (o *cliMonWeightFakeOps) LinkSetMTU(netlink.Link, int) error             { return nil }
+func (o *cliMonWeightFakeOps) LinkList() ([]netlink.Link, error)              { return nil, nil }
+func (o *cliMonWeightFakeOps) AddrAdd(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *cliMonWeightFakeOps) AddrDel(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *cliMonWeightFakeOps) AddrList(netlink.Link, int) ([]netlink.Addr, error) {
+	return nil, nil
+}
+
+// cliOutOfRangeMonitorConfig uses the CONTAINER-hierarchical interface-monitor
+// spelling: the packed form compiles to ZERO monitors (#6588) and would make
+// this test vacuous.
+const cliOutOfRangeMonitorConfig = `
+chassis {
+    cluster {
+        control-interface em0;
+        fabric-interface fab0;
+        reth-count 2;
+        redundancy-group 0 {
+            node 0 priority 200;
+            node 1 priority 100;
+            interface-monitor {
+                local0 weight -100;
+                peer0 weight 100000;
+            }
+        }
+    }
+}
+`
+
+// cliSyncOutOfRangeMonitors pushes the config through the REAL tolerant
+// peer-sync ingress and asserts the raw out-of-range weights actually survive
+// it — without that precondition the assertions below would be vacuous.
+func cliSyncOutOfRangeMonitors(t *testing.T) *CLI {
+	t.Helper()
+	store, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	cfg, err := store.SyncApply(cliOutOfRangeMonitorConfig, nil)
+	if err != nil {
+		t.Fatalf("SyncApply(out-of-range monitor weight): %v", err)
+	}
+	if cfg == nil || cfg.Chassis.Cluster == nil || len(cfg.Chassis.Cluster.RedundancyGroups) != 1 {
+		t.Fatalf("tolerant sync did not compile the chassis cluster: %+v", cfg)
+	}
+	raw := map[string]int{}
+	for _, mon := range cfg.Chassis.Cluster.RedundancyGroups[0].InterfaceMonitors {
+		raw[mon.Interface] = mon.Weight
+	}
+	if raw["local0"] != -100 || raw["peer0"] != 100000 {
+		t.Fatalf("precondition: the tolerant path was expected to PRESERVE the "+
+			"raw out-of-range weights; got %+v", raw)
+	}
+	return &CLI{store: store}
+}
+
+// TestCLIShowClusterInterfaces_MonitorWeightIsTheEffectiveOne_6549 covers all
+// three weight fills.
+//
+// Fail-on-revert:
+//   - restore `Weight: mon.Weight` at either config-only fill in
+//     cli_helpers.go and the corresponding row reports -100 / 100000;
+//   - restore `Weight: mon.Weight` in pkg/routing/monitor.go and the LIVE row
+//     reports -100.
+func TestCLIShowClusterInterfaces_MonitorWeightIsTheEffectiveOne_6549(t *testing.T) {
+	t.Run("config-only fill (no live routing statuses)", func(t *testing.T) {
+		c := cliSyncOutOfRangeMonitors(t)
+		// c.routing stays nil: every monitor falls to the config-only fill.
+		input := c.buildInterfacesInput()
+		assertCLIEffectiveMonitorWeights(t, input.Monitors, map[string]int{
+			"local0": 0, "peer0": 255,
+		})
+	})
+
+	t.Run("live routing statuses + peer config-only fill", func(t *testing.T) {
+		c := cliSyncOutOfRangeMonitors(t)
+
+		linux := config.LinuxIfName("local0")
+		c.routing = routing.NewManagerWithLinkOpsForTest(&cliMonWeightFakeOps{
+			links: map[string]netlink.Link{
+				linux: &cliMonWeightFakeLink{attrs: netlink.LinkAttrs{
+					Name: linux, OperState: netlink.OperUp,
+				}},
+			},
+		})
+		c.cluster = cluster.NewManager(0, 1)
+
+		cfg := c.store.ActiveConfig()
+		c.routing.ApplyInterfaceMonitors(cfg.Chassis.Cluster.RedundancyGroups)
+
+		input := c.buildInterfacesInput()
+		assertCLIEffectiveMonitorWeights(t, input.Monitors, map[string]int{"local0": 0})
+		assertCLIEffectiveMonitorWeights(t, input.PeerMonitors, map[string]int{"peer0": 255})
+	})
+}
+
+// assertCLIEffectiveMonitorWeights checks that every named monitor is present
+// with the effective (bounded) weight, and that no rendered weight escapes
+// [0,255].
+func assertCLIEffectiveMonitorWeights(t *testing.T, got []cluster.InterfaceMonitorInfo, want map[string]int) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, m := range got {
+		if m.Weight < 0 || m.Weight > 255 {
+			t.Errorf("monitor %s rendered weight %d, which escapes the [0,255] "+
+				"domain the election applies", m.Interface, m.Weight)
+		}
+		w, ok := want[m.Interface]
+		if !ok {
+			continue
+		}
+		seen[m.Interface] = true
+		if m.Weight != w {
+			t.Errorf("monitor %s rendered weight %d, want the effective %d — "+
+				"the display reports a weight the election does not use",
+				m.Interface, m.Weight, w)
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("monitor %s missing from the rendered set %+v", name, got)
+		}
+	}
+}

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -452,26 +452,32 @@ func (m *Manager) electSingleNode() {
 // #6549: this is the CHOKEPOINT that bounds election debt. Together with
 // reconcileMonitorDebtsLocked it owns both of the only two writes into
 // m.monitorWeights, so clamping here closes the debt domain against EVERY
-// producer rather than each producer separately:
+// producer — including one added later that forgets to bound its own value.
+//
+// Each producer ALSO bounds the weight where it computes it, because each
+// reports that weight somewhere the chokepoint cannot reach (a heartbeat
+// monitor entry, a rendered status, an event ledger) and a producer-side
+// clamp is the only way the reported value matches the applied one. So this
+// is a genuine second belt, not the sole defense:
 //
 //   - pkg/cluster/monitor.go pollInterfaceMonitors — interface-monitor link
-//     transitions (clamps its own copy too, because the value it clamps also
-//     feeds the heartbeat monitor section).
-//   - pkg/cluster/monitor.go reconcileRGIPDebts — ip-monitoring target and
-//     aggregate debts. Monitor.ipTargetWeight returns the configured
-//     per-target weight (or the RG global-weight) with no bound of its own,
-//     and validateChassisClusterStrict has no compiled-int gate for
-//     ip-monitoring weights, so this is that class's only runtime defense.
-//   - pkg/daemon/daemon_apply_tail.go — the config-apply tail, on EVERY
-//     commit / boot Load / peer SyncApply. It feeds pkg/routing's
-//     InterfaceMonitorStatus.Weight, copied verbatim off the compiled
-//     *config.InterfaceMonitor. Before this clamp that raw value landed here
-//     six lines after UpdateConfig had already clamped the same debt, so the
-//     apply tail OVERWROTE the clamp and could restore a correctly-demoted
-//     group to primary with every monitored link down. The poll path cannot
-//     repair it: pollInterfaceMonitors re-fires SetMonitorWeight only on a
-//     dampened state TRANSITION, and a link that was already down before the
-//     apply produces none, so the raw debt persists indefinitely.
+//     transitions. Clamps its own copy, which also feeds the heartbeat
+//     monitor section.
+//   - pkg/cluster/monitor.go ipTargetWeight / desiredRGIPDebts —
+//     ip-monitoring target and aggregate debts. Those bound the value before
+//     it reaches the cumulative global-threshold sum, which this chokepoint
+//     could not protect: a masked threshold installs NO debt, so
+//     SetMonitorWeight is never called at all.
+//   - pkg/routing/monitor.go monitorManager.Apply — the statuses
+//     pkg/daemon/daemon_apply_tail.go feeds back in on EVERY commit / boot
+//     Load / peer SyncApply. Before either clamp existed, that raw value
+//     landed here six lines after UpdateConfig had already clamped the same
+//     debt, so the apply tail OVERWROTE the clamp and could restore a
+//     correctly-demoted group to primary with every monitored link down. The
+//     poll path cannot repair it: pollInterfaceMonitors re-fires
+//     SetMonitorWeight only on a dampened state TRANSITION, and a link that
+//     was already down before the apply produces none, so the raw debt
+//     persists indefinitely.
 func (m *Manager) SetMonitorWeight(rgID int, iface string, down bool, weight int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -487,6 +493,30 @@ func (m *Manager) SetMonitorWeight(rgID int, iface string, down bool, weight int
 	// local weight from the advertised one (dual primary). Both reach runtime
 	// because the tolerant load / peer-sync compile path downgrades the commit
 	// gate to a warning (#1960 no-brick).
+	//
+	// CLAMP DIRECTION — negative maps to 0, deliberately. This was contested in
+	// review (clamping to 255 was argued as the fail-CLOSED choice, since an
+	// inert monitor can leave a node primary behind a dead link) and settled on
+	// 0. Recorded here so it is not re-litigated:
+	//
+	//   - 0 is an already-legal, operator-reachable state. An interface-monitor
+	//     with no `weight` token compiles to exactly 0 and means "monitor this,
+	//     contribute no debt". Clamping onto 0 maps invalid input onto an
+	//     existing semantic; clamping onto 255 maps it onto a DIFFERENT existing
+	//     semantic ("maximally fatal") that the operator never asked for.
+	//   - The decisive asymmetry is the peer-push path. The reason this class is
+	//     hardened at runtime at all is that configs arrive over HA config-sync.
+	//     Under clamp-255, a typo'd `-100` pushed from the peer makes the
+	//     RECEIVING node instantly resign its redundancy group the moment that
+	//     link flaps — turning the config-sync channel into a remote HA
+	//     denial-of-service. Inert-plus-WARN beats auto-resignation there.
+	//   - The local authoring path can never produce this at all
+	//     (validateChassisClusterStrict hard-rejects it at commit), so the only
+	//     ways here are a pre-fix persisted config or a peer push — exactly the
+	//     cases where the above holds.
+	//
+	// Over-255 saturates to 255: that preserves operator intent, and 255 is
+	// already the maximum meaningful debt since the group starts there.
 	requested := weight
 	weight, clamped := config.ClampInterfaceMonitorWeight(weight)
 
@@ -495,10 +525,16 @@ func (m *Manager) SetMonitorWeight(rgID int, iface string, down bool, weight int
 	if down {
 		if clamped {
 			// Debt-install frequency (a dampened transition, an ip-debt diff,
-			// or a config apply), not per-poll-tick — safe at Warn. This is
-			// the ONLY out-of-range signal the ip-monitoring debts get;
-			// reconcileMonitorDebtsLocked separately reports the configured
-			// interface-monitor weight against the config that carried it.
+			// or a config apply), not per-poll-tick — safe at Warn.
+			//
+			// In practice every current producer bounds the weight before it
+			// gets here, so reaching this branch means a producer skipped its
+			// own clamp — which is exactly what makes it worth logging. Do NOT
+			// read a missing warning here as "no out-of-range weight was
+			// configured": the interface-monitor class is reported by
+			// reconcileMonitorDebtsLocked against the config that carried it,
+			// and the ip-monitoring class is bounded upstream in ipTargetWeight
+			// / desiredRGIPDebts. Those are the places to look first.
 			slog.Warn("cluster: monitor debt weight out of range, clamped",
 				"rg", rgID, "interface", iface,
 				"requested", requested, "effective", weight,

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -448,6 +448,30 @@ func (m *Manager) electSingleNode() {
 
 // SetMonitorWeight updates the weight contribution of an interface monitor.
 // down=true subtracts weight; down=false restores it.
+//
+// #6549: this is the CHOKEPOINT that bounds election debt. Together with
+// reconcileMonitorDebtsLocked it owns both of the only two writes into
+// m.monitorWeights, so clamping here closes the debt domain against EVERY
+// producer rather than each producer separately:
+//
+//   - pkg/cluster/monitor.go pollInterfaceMonitors — interface-monitor link
+//     transitions (clamps its own copy too, because the value it clamps also
+//     feeds the heartbeat monitor section).
+//   - pkg/cluster/monitor.go reconcileRGIPDebts — ip-monitoring target and
+//     aggregate debts. Monitor.ipTargetWeight returns the configured
+//     per-target weight (or the RG global-weight) with no bound of its own,
+//     and validateChassisClusterStrict has no compiled-int gate for
+//     ip-monitoring weights, so this is that class's only runtime defense.
+//   - pkg/daemon/daemon_apply_tail.go — the config-apply tail, on EVERY
+//     commit / boot Load / peer SyncApply. It feeds pkg/routing's
+//     InterfaceMonitorStatus.Weight, copied verbatim off the compiled
+//     *config.InterfaceMonitor. Before this clamp that raw value landed here
+//     six lines after UpdateConfig had already clamped the same debt, so the
+//     apply tail OVERWROTE the clamp and could restore a correctly-demoted
+//     group to primary with every monitored link down. The poll path cannot
+//     repair it: pollInterfaceMonitors re-fires SetMonitorWeight only on a
+//     dampened state TRANSITION, and a link that was already down before the
+//     apply produces none, so the raw debt persists indefinitely.
 func (m *Manager) SetMonitorWeight(rgID int, iface string, down bool, weight int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -457,9 +481,29 @@ func (m *Manager) SetMonitorWeight(rgID int, iface string, down bool, weight int
 		return
 	}
 
+	// Bound the debt to the [0,255] domain the heartbeat weight fields carry.
+	// A negative weight is negative DEBT: it credits weight back and cancels a
+	// sibling monitor's real failure (fail-open); an over-255 one diverges the
+	// local weight from the advertised one (dual primary). Both reach runtime
+	// because the tolerant load / peer-sync compile path downgrades the commit
+	// gate to a warning (#1960 no-brick).
+	requested := weight
+	weight, clamped := config.ClampInterfaceMonitorWeight(weight)
+
 	key := monitorKey{rgID: rgID, iface: iface}
 
 	if down {
+		if clamped {
+			// Debt-install frequency (a dampened transition, an ip-debt diff,
+			// or a config apply), not per-poll-tick — safe at Warn. This is
+			// the ONLY out-of-range signal the ip-monitoring debts get;
+			// reconcileMonitorDebtsLocked separately reports the configured
+			// interface-monitor weight against the config that carried it.
+			slog.Warn("cluster: monitor debt weight out of range, clamped",
+				"rg", rgID, "interface", iface,
+				"requested", requested, "effective", weight,
+				"issue", "#6549")
+		}
 		// Record the monitor weight and add to failure list.
 		m.monitorWeights[key] = weight
 		found := false

--- a/pkg/cluster/election.go
+++ b/pkg/cluster/election.go
@@ -491,6 +491,43 @@ func (m *Manager) SetMonitorWeight(rgID int, iface string, down bool, weight int
 	m.recalcWeight(rg)
 }
 
+// maxRedundancyGroupWeight is the full (no-debt) redundancy-group weight AND
+// the largest value the weight domain admits. It is both the Junos starting
+// weight and the ceiling of the single-byte heartbeat weight field
+// (HeartbeatGroup.Weight is uint8, heartbeat.go).
+const maxRedundancyGroupWeight = 255
+
+// rgWeightFromDebt converts a redundancy group's accumulated monitor debt into
+// its effective weight, bounded to [0, maxRedundancyGroupWeight].
+//
+// The floor has always been enforced (a debt larger than 255 resigns the group
+// at weight 0). #6549 adds the CEILING, which is what keeps the local weight
+// and the advertised weight from diverging: buildHeartbeat marshals the weight
+// as `uint8(rg.Weight)` while the local election reads the raw int, so a weight
+// above 255 truncates on the wire (355 -> 99) and the two nodes compute
+// different effective priorities from identical state — both can elect primary,
+// putting a duplicate VIP and duplicate RETH virtual MAC on the LAN. A NEGATIVE
+// debt is the way that happens in practice: an interface-monitor weight is
+// operator-supplied and the tolerant load / peer-sync compile path only WARNS
+// on an out-of-range one (#1960 no-brick), so `weight -100` on a down monitor
+// reaches here as totalLost == -100.
+//
+// Bounding here rather than only at the marshal boundary is deliberate: a
+// marshal-side clamp would still leave the local view (355) disagreeing with
+// the advertised one (255). The weight domain itself has to be closed, and it
+// is closed for EVERY debt source — interface monitors, ip-monitoring targets,
+// and any future SetMonitorWeight caller — not just the configured one.
+func rgWeightFromDebt(totalLost int) int {
+	w := maxRedundancyGroupWeight - totalLost
+	if w < 0 {
+		return 0
+	}
+	if w > maxRedundancyGroupWeight {
+		return maxRedundancyGroupWeight
+	}
+	return w
+}
+
 // recalcWeight recalculates the effective weight for a redundancy group
 // and triggers re-election if needed.
 func (m *Manager) recalcWeight(rg *RedundancyGroupState) {
@@ -500,10 +537,7 @@ func (m *Manager) recalcWeight(rg *RedundancyGroupState) {
 		totalLost += m.monitorWeights[key]
 	}
 	oldWeight := rg.Weight
-	rg.Weight = 255 - totalLost
-	if rg.Weight < 0 {
-		rg.Weight = 0
-	}
+	rg.Weight = rgWeightFromDebt(totalLost)
 	if oldWeight != rg.Weight {
 		slog.Info("cluster: weight changed",
 			"rg", rg.GroupID, "old", oldWeight, "new", rg.Weight)
@@ -549,7 +583,19 @@ func (m *Manager) reconcileMonitorDebtsLocked(cfg *config.ClusterConfig) {
 	desired := make(map[monitorKey]int)
 	for _, rg := range cfg.RedundancyGroups {
 		for _, im := range rg.InterfaceMonitors {
-			desired[monitorKey{rgID: rg.ID, iface: im.Interface}] = im.Weight
+			// #6549: bound the configured debt. The strict commit path already
+			// rejected an out-of-range weight (validateChassisClusterStrict);
+			// the tolerant load / peer-sync path only WARNS (#1960 no-brick),
+			// so a persisted or peer-pushed config can still carry one here.
+			w, clamped := config.ClampInterfaceMonitorWeight(im.Weight)
+			if clamped {
+				// Config-apply frequency, not per-poll — safe at Warn.
+				slog.Warn("cluster: interface-monitor weight out of range, clamped",
+					"rg", rg.ID, "interface", im.Interface,
+					"configured", im.Weight, "effective", w,
+					"issue", "#6549")
+			}
+			desired[monitorKey{rgID: rg.ID, iface: im.Interface}] = w
 		}
 	}
 
@@ -605,10 +651,7 @@ func (m *Manager) reconcileMonitorDebtsLocked(cfg *config.ClusterConfig) {
 			totalLost += m.monitorWeights[monitorKey{rgID: rgID, iface: iface}]
 		}
 		oldWeight := rg.Weight
-		rg.Weight = 255 - totalLost
-		if rg.Weight < 0 {
-			rg.Weight = 0
-		}
+		rg.Weight = rgWeightFromDebt(totalLost)
 		if oldWeight != rg.Weight {
 			slog.Info("cluster: monitor debt reconciled on config change",
 				"rg", rgID, "old", oldWeight, "new", rg.Weight)

--- a/pkg/cluster/failover.go
+++ b/pkg/cluster/failover.go
@@ -460,10 +460,7 @@ func (m *Manager) manualFailoverRestoreWeightLocked(rg *RedundancyGroupState) {
 		key := monitorKey{rgID: rg.GroupID, iface: iface}
 		totalLost += m.monitorWeights[key]
 	}
-	rg.Weight = 255 - totalLost
-	if rg.Weight < 0 {
-		rg.Weight = 0
-	}
+	rg.Weight = rgWeightFromDebt(totalLost)
 }
 
 // FinalizePeerTransferOut completes a previously acknowledged transfer-out

--- a/pkg/cluster/heartbeat_manager.go
+++ b/pkg/cluster/heartbeat_manager.go
@@ -273,7 +273,7 @@ func (m *Manager) buildHeartbeat() *HeartbeatPacket {
 		pkt.Groups = append(pkt.Groups, HeartbeatGroup{
 			GroupID:  uint8(rg.GroupID),
 			Priority: uint16(rg.LocalPriority),
-			Weight:   uint8(rg.Weight),
+			Weight:   clampWireWeight(rg.Weight),
 			State:    uint8(rg.State),
 		})
 	}
@@ -282,12 +282,33 @@ func (m *Manager) buildHeartbeat() *HeartbeatPacket {
 	for _, ls := range localStatuses {
 		pkt.Monitors = append(pkt.Monitors, HeartbeatMonitor{
 			RGID:      uint8(ls.RedundancyGroup),
-			Weight:    uint8(ls.Weight),
+			Weight:    clampWireWeight(ls.Weight),
 			Up:        ls.Up,
 			Interface: ls.Interface,
 		})
 	}
 	return pkt
+}
+
+// clampWireWeight narrows a weight onto the single-byte heartbeat weight field
+// by SATURATING instead of truncating (#6549).
+//
+// This is the last belt, not the fix. `uint8(w)` wraps — 355 leaves as 99 —
+// which is what let a node's local weight and its advertised weight disagree
+// and put two primaries on the LAN. The fix is that the weight domain is closed
+// upstream (rgWeightFromDebt for rg.Weight, config.ClampInterfaceMonitorWeight
+// for the per-monitor weight), so every value that reaches here is already in
+// [0,255] and this is an identity. Saturating rather than wrapping means a
+// future writer that bypasses those helpers degrades to a bounded, monotonic
+// weight instead of silently aliasing to an unrelated one.
+func clampWireWeight(w int) uint8 {
+	if w < 0 {
+		return 0
+	}
+	if w > maxRedundancyGroupWeight {
+		return maxRedundancyGroupWeight
+	}
+	return uint8(w)
 }
 
 // handlePeerHeartbeat processes an incoming peer heartbeat.

--- a/pkg/cluster/ifmon_weight_daemon_apply_6549_test.go
+++ b/pkg/cluster/ifmon_weight_daemon_apply_6549_test.go
@@ -18,11 +18,29 @@ import (
 //	19a. d.cluster.UpdateConfig(cfg.Chassis.Cluster)   -> reconcileMonitorDebtsLocked
 //	19b. d.cluster.SetMonitorWeight(rgID, st.Interface, !st.Up, st.Weight)
 //
-// pkg/routing's monitorManager.Apply copies `mon.Weight` verbatim off the
-// compiled *config.InterfaceMonitor, so step 19b feeds the RAW configured
-// weight into the debt map — overwriting the value step 19a just clamped. The
-// clamp has to live at the chokepoint every debt producer funnels through
-// (Manager.SetMonitorWeight), not at each producer.
+// pkg/routing's monitorManager.Apply USED to copy `mon.Weight` verbatim off
+// the compiled *config.InterfaceMonitor, so step 19b fed the RAW configured
+// weight into the debt map — overwriting the value step 19a had just clamped.
+//
+// That is now closed at TWO independent layers, deliberately: pkg/routing
+// bounds the weight where it builds the status (it is election input, not
+// display-only, and it is also what `show chassis cluster interfaces`
+// renders), and Manager.SetMonitorWeight bounds every debt on the way in so a
+// FUTURE producer that forgets its own clamp is still safe.
+//
+// WHAT THESE TESTS BIND. Because both layers are live, the two
+// TestDaemonApplyTail_* cases below fail only when BOTH are removed — either
+// clamp alone keeps the end-to-end path safe, which is the whole point of
+// layering it. They are the END-TO-END guard, not a single-clamp guard. Each
+// individual clamp has its own dedicated binder:
+//
+//   - Manager.SetMonitorWeight        -> TestSetMonitorWeight_ClosesTheDebtDomain_6549 (this file)
+//   - pkg/routing monitorManager.Apply -> TestInterfaceMonitorStatus_WeightIsBounded_6549 (pkg/routing)
+//
+// Verified by mutation: a compile-clean removal of the SetMonitorWeight clamp
+// alone (go vet clean) leaves both TestDaemonApplyTail_* cases GREEN and fails
+// TestSetMonitorWeight_ClosesTheDebtDomain_6549; removing both together fails
+// the TestDaemonApplyTail_* cases with the fail-open assertions below.
 //
 // These tests drive the REAL producer (routing.Manager against a fake netlink
 // surface) and the REAL consumer in the daemon's exact call order, rather than
@@ -111,9 +129,12 @@ func runDaemonApplyTail(m *Manager, rm *routing.Manager, cfg *config.ClusterConf
 // transition when the link was already down before the config apply. The raw
 // debt sits in m.monitorWeights indefinitely.
 //
-// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
-// Manager.SetMonitorWeight and the debt becomes 255 + (-100) = 155, leaving
-// weight 100 and the node primary.
+// Fail-on-revert (END-TO-END guard — see the file preamble): drop the
+// config.ClampInterfaceMonitorWeight call in BOTH pkg/routing's
+// monitorManager.Apply and Manager.SetMonitorWeight, and the debt becomes
+// 255 + (-100) = 155, leaving weight 100 and the node primary. Either clamp
+// alone keeps this green; that is the layering working, and each clamp has its
+// own dedicated binder.
 func TestDaemonApplyTail_OutOfRangeWeightCannotCancelARealFailure_6549(t *testing.T) {
 	const ifA, ifB = "trust0", "trust1"
 
@@ -150,8 +171,10 @@ func TestDaemonApplyTail_OutOfRangeWeightCannotCancelARealFailure_6549(t *testin
 // overwrites it with the raw value — promoting a correctly-demoted group back
 // to primary.
 //
-// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
-// Manager.SetMonitorWeight and the group goes 0 -> 100 across the apply tail.
+// Fail-on-revert (END-TO-END guard — see the file preamble): drop the
+// config.ClampInterfaceMonitorWeight call in BOTH pkg/routing's
+// monitorManager.Apply and Manager.SetMonitorWeight, and the group goes
+// 0 -> 100 across the apply tail. Either clamp alone keeps this green.
 func TestDaemonApplyTail_CannotRegressAClampedDebt_6549(t *testing.T) {
 	const ifA, ifB = "trust0", "trust1"
 
@@ -200,18 +223,23 @@ func TestDaemonApplyTail_CannotRegressAClampedDebt_6549(t *testing.T) {
 // TestIPMonitor_OutOfRangeWeightCannotCancelARealFailure_6549 covers the OTHER
 // debt class the chokepoint now bounds.
 //
-// ip-monitoring weights have no runtime clamp of their own — Monitor.ipTargetWeight
-// returns target.Weight (or rg.IPMonitoring.GlobalWeight) verbatim — and
-// validateChassisClusterStrict carries no compiled-int gate for them, so their
-// ONLY commit-side defense is the schema's ValidateInteger(0,255), which
-// compileTreeLenient downgrades to a warning on Store.Load / Store.SyncApply.
-// A negative ip-monitoring weight is therefore reachable at runtime and is
-// negative debt exactly like a negative interface-monitor weight: it cancels a
-// sibling target's real unreachability.
+// validateChassisClusterStrict carries no compiled-int gate for ip-monitoring
+// weights, so their ONLY commit-side defense is the schema's
+// ValidateInteger(0,255), which compileTreeLenient downgrades to a warning on
+// Store.Load / Store.SyncApply. A negative ip-monitoring weight is therefore
+// reachable at runtime and is negative debt exactly like a negative
+// interface-monitor weight: it cancels a sibling target's real unreachability.
 //
-// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
-// Manager.SetMonitorWeight and the debt becomes 255 + (-100) = 155, leaving
-// weight 100 and the node primary with BOTH monitored targets unreachable.
+// Fail-on-revert (END-TO-END guard, same shape as the daemon cases above):
+// drop the config.ClampInterfaceMonitorWeight call in BOTH
+// Monitor.ipTargetWeight and Manager.SetMonitorWeight, and the debt becomes
+// 255 + (-100) = 155, leaving weight 100 and the node primary with BOTH
+// monitored targets unreachable. Either clamp alone keeps this green — the
+// chokepoint bounds what is installed, ipTargetWeight bounds what is computed
+// and reported. Their dedicated binders are
+// TestSetMonitorWeight_ClosesTheDebtDomain_6549 and
+// TestIPMonitor_NegativeWeightCannotMaskTheGlobalThreshold_6549 (the
+// global-threshold case the chokepoint provably cannot reach).
 func TestIPMonitor_OutOfRangeWeightCannotCancelARealFailure_6549(t *testing.T) {
 	const addrA, addrB = "10.0.0.1", "10.0.0.2"
 
@@ -497,13 +525,18 @@ func TestBuildHeartbeat_WireWeightSaturatesAtTheCallSites_6549(t *testing.T) {
 // inside the [0,255] heartbeat weight domain, and the local weight never
 // diverges from the advertised one.
 //
-// The daemon apply tail is one caller; ip-monitoring target debt
-// (Monitor.ipTargetWeight, which has no clamp of its own) is another. Binding
-// the chokepoint rather than each caller is what makes a future producer safe
-// by construction.
+// This is the DEDICATED binder for the chokepoint clamp, and the only test in
+// the #6549 set that fails when that clamp alone is removed. Every current
+// producer (the daemon apply tail via pkg/routing, the interface-monitor poll,
+// ip-monitoring via ipTargetWeight) bounds its own value first, so the
+// end-to-end tests above stay green on a chokepoint-only revert — by design.
+// Binding the chokepoint directly here is what keeps it from being silently
+// dropped, and what makes a FUTURE producer that forgets its own clamp safe by
+// construction.
 //
 // Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
-// Manager.SetMonitorWeight and every out-of-range row escapes the domain.
+// Manager.SetMonitorWeight and every out-of-range row escapes the domain
+// (verified: compile-clean removal, go vet clean, this test the sole red).
 func TestSetMonitorWeight_ClosesTheDebtDomain_6549(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/cluster/ifmon_weight_daemon_apply_6549_test.go
+++ b/pkg/cluster/ifmon_weight_daemon_apply_6549_test.go
@@ -1,0 +1,555 @@
+package cluster
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/routing"
+	"github.com/vishvananda/netlink"
+)
+
+// #6549, second producer: the daemon config-apply tail installs interface-monitor
+// debt DIRECTLY, bypassing both the poll path and reconcileMonitorDebtsLocked.
+//
+// pkg/daemon/daemon_apply_tail.go runs three steps in order on EVERY config apply:
+//
+//	18.  d.routing.ApplyInterfaceMonitors(cfg.Chassis.Cluster.RedundancyGroups)
+//	19a. d.cluster.UpdateConfig(cfg.Chassis.Cluster)   -> reconcileMonitorDebtsLocked
+//	19b. d.cluster.SetMonitorWeight(rgID, st.Interface, !st.Up, st.Weight)
+//
+// pkg/routing's monitorManager.Apply copies `mon.Weight` verbatim off the
+// compiled *config.InterfaceMonitor, so step 19b feeds the RAW configured
+// weight into the debt map — overwriting the value step 19a just clamped. The
+// clamp has to live at the chokepoint every debt producer funnels through
+// (Manager.SetMonitorWeight), not at each producer.
+//
+// These tests drive the REAL producer (routing.Manager against a fake netlink
+// surface) and the REAL consumer in the daemon's exact call order, rather than
+// a hand-rolled equivalent.
+
+// applyTailFakeLink is a netlink.Link carrying caller-chosen attrs.
+type applyTailFakeLink struct {
+	attrs netlink.LinkAttrs
+}
+
+func (l *applyTailFakeLink) Attrs() *netlink.LinkAttrs { return &l.attrs }
+func (l *applyTailFakeLink) Type() string              { return "apply-tail-fake" }
+
+// applyTailFakeOps satisfies pkg/routing's (unexported) linkOps structurally.
+// Only LinkByName is meaningful — the interface-monitor path touches nothing
+// else — but the whole surface must be present to be accepted by
+// routing.NewManagerWithLinkOpsForTest.
+type applyTailFakeOps struct {
+	links map[string]netlink.Link
+}
+
+func (o *applyTailFakeOps) LinkByName(name string) (netlink.Link, error) {
+	if l, ok := o.links[name]; ok {
+		return l, nil
+	}
+	return nil, net.UnknownNetworkError("not found: " + name)
+}
+
+func (o *applyTailFakeOps) LinkAdd(netlink.Link) error                     { return nil }
+func (o *applyTailFakeOps) LinkDel(netlink.Link) error                     { return nil }
+func (o *applyTailFakeOps) LinkSetUp(netlink.Link) error                   { return nil }
+func (o *applyTailFakeOps) LinkSetDown(netlink.Link) error                 { return nil }
+func (o *applyTailFakeOps) LinkSetMaster(netlink.Link, netlink.Link) error { return nil }
+func (o *applyTailFakeOps) LinkSetNoMaster(netlink.Link) error             { return nil }
+func (o *applyTailFakeOps) LinkSetMTU(netlink.Link, int) error             { return nil }
+func (o *applyTailFakeOps) LinkList() ([]netlink.Link, error)              { return nil, nil }
+func (o *applyTailFakeOps) AddrAdd(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *applyTailFakeOps) AddrDel(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *applyTailFakeOps) AddrList(netlink.Link, int) ([]netlink.Addr, error) {
+	return nil, nil
+}
+
+// applyTailLinks builds the fake netlink surface for the monitored interfaces,
+// keyed by their LINUX names (monitorManager.Apply translates ge-0/0/0 ->
+// ge-0-0-0 before the lookup). Admin-up with carrier down is the realistic
+// "cable pulled" shape and is what linkAttrsUp reads as down.
+func applyTailLinks(up bool, junosNames ...string) *applyTailFakeOps {
+	var oper netlink.LinkOperState = netlink.OperDown
+	if up {
+		oper = netlink.OperUp
+	}
+	ops := &applyTailFakeOps{links: make(map[string]netlink.Link, len(junosNames))}
+	for _, n := range junosNames {
+		linux := config.LinuxIfName(n)
+		ops.links[linux] = &applyTailFakeLink{attrs: netlink.LinkAttrs{
+			Name:      linux,
+			OperState: oper,
+			Flags:     net.FlagUp,
+		}}
+	}
+	return ops
+}
+
+// runDaemonApplyTail replays pkg/daemon/daemon_apply_tail.go steps 18/19 in the
+// daemon's exact order against a real routing.Manager and the cluster Manager.
+func runDaemonApplyTail(m *Manager, rm *routing.Manager, cfg *config.ClusterConfig) {
+	rm.ApplyInterfaceMonitors(cfg.RedundancyGroups)
+	m.UpdateConfig(cfg)
+	for rgID, statuses := range rm.InterfaceMonitorStatuses() {
+		for _, st := range statuses {
+			m.SetMonitorWeight(rgID, st.Interface, !st.Up, st.Weight)
+		}
+	}
+	drainEvents(m, 8)
+}
+
+// TestDaemonApplyTail_OutOfRangeWeightCannotCancelARealFailure_6549 is the
+// daemon-path twin of the poll-path and reconcile-path tests: a NEGATIVE
+// interface-monitor weight arriving on the tolerant load / peer-sync path is
+// negative DEBT, so it credits weight back and cancels the demotion a
+// genuinely dead sibling link just applied. Both monitored links are down and
+// the node still holds weight 100 and PRIMARY — a fail-open.
+//
+// This is PERSISTENT, not a transient window: pollInterfaceMonitors re-fires
+// SetMonitorWeight only on a dampened state TRANSITION, and there is no
+// transition when the link was already down before the config apply. The raw
+// debt sits in m.monitorWeights indefinitely.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// Manager.SetMonitorWeight and the debt becomes 255 + (-100) = 155, leaving
+// weight 100 and the node primary.
+func TestDaemonApplyTail_OutOfRangeWeightCannotCancelARealFailure_6549(t *testing.T) {
+	const ifA, ifB = "trust0", "trust1"
+
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200},
+		&config.InterfaceMonitor{Interface: ifA, Weight: 255},
+		&config.InterfaceMonitor{Interface: ifB, Weight: -100},
+	))
+
+	m := NewManager(0, 1)
+	rm := routing.NewManagerWithLinkOpsForTest(applyTailLinks(false, ifA, ifB))
+
+	runDaemonApplyTail(m, rm, cfg)
+
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight after the daemon apply tail with both monitored links "+
+			"down = %d, want 0 — the raw negative weight the daemon feeds "+
+			"SetMonitorWeight credited debt back and cancelled %s's real link "+
+			"failure (fail-open)", w, ifA)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("node must not hold primary after the daemon apply tail with " +
+			"both monitored links down")
+	}
+	local, advertised := localVsAdvertisedWeight(t, m, 0)
+	if local != advertised {
+		t.Fatalf("local weight %d but advertised %d", local, advertised)
+	}
+}
+
+// TestDaemonApplyTail_CannotRegressAClampedDebt_6549 pins the sharper half: the
+// daemon tail does not merely miss the clamp, it UNDOES one already installed.
+// UpdateConfig clamps the debt (reconcileMonitorDebtsLocked, the layer the
+// config-apply path already had), and the SetMonitorWeight loop six lines later
+// overwrites it with the raw value — promoting a correctly-demoted group back
+// to primary.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// Manager.SetMonitorWeight and the group goes 0 -> 100 across the apply tail.
+func TestDaemonApplyTail_CannotRegressAClampedDebt_6549(t *testing.T) {
+	const ifA, ifB = "trust0", "trust1"
+
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200},
+		&config.InterfaceMonitor{Interface: ifA, Weight: 255},
+		&config.InterfaceMonitor{Interface: ifB, Weight: -100},
+	))
+
+	m := NewManager(0, 1)
+
+	// The clamped poll path runs first and correctly resigns the group.
+	nlh := newMockNlHandle()
+	nlh.setLink(ifA, true)
+	nlh.setLink(ifB, true)
+	m.UpdateConfig(cfg)
+	drainEvents(m, 8)
+	mon := NewMonitor(m, cfg.RedundancyGroups)
+	mon.nlHandle = nlh
+	setNoDampening(mon)
+	mon.poll()
+	nlh.setLink(ifA, false)
+	nlh.setLink(ifB, false)
+	mon.poll()
+	drainEvents(m, 8)
+
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("precondition: weight after the clamped poll path = %d, want 0", w)
+	}
+
+	// Now the operator commits anything at all. The apply tail re-derives the
+	// monitor statuses and re-installs the debt.
+	rm := routing.NewManagerWithLinkOpsForTest(applyTailLinks(false, ifA, ifB))
+	runDaemonApplyTail(m, rm, cfg)
+
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight after the daemon apply tail = %d, want 0 — the apply "+
+			"tail REGRESSED a correctly-demoted redundancy group by overwriting "+
+			"the clamped debt with the raw configured weight", w)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("the daemon apply tail promoted a resigned redundancy group " +
+			"back to primary with both monitored links down")
+	}
+}
+
+// TestIPMonitor_OutOfRangeWeightCannotCancelARealFailure_6549 covers the OTHER
+// debt class the chokepoint now bounds.
+//
+// ip-monitoring weights have no runtime clamp of their own — Monitor.ipTargetWeight
+// returns target.Weight (or rg.IPMonitoring.GlobalWeight) verbatim — and
+// validateChassisClusterStrict carries no compiled-int gate for them, so their
+// ONLY commit-side defense is the schema's ValidateInteger(0,255), which
+// compileTreeLenient downgrades to a warning on Store.Load / Store.SyncApply.
+// A negative ip-monitoring weight is therefore reachable at runtime and is
+// negative debt exactly like a negative interface-monitor weight: it cancels a
+// sibling target's real unreachability.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// Manager.SetMonitorWeight and the debt becomes 255 + (-100) = 155, leaving
+// weight 100 and the node primary with BOTH monitored targets unreachable.
+func TestIPMonitor_OutOfRangeWeightCannotCancelARealFailure_6549(t *testing.T) {
+	const addrA, addrB = "10.0.0.1", "10.0.0.2"
+
+	// Independent mode (no global-threshold): each unreachable target owes its
+	// own effective weight.
+	rg := &config.RedundancyGroup{
+		ID:             0,
+		NodePriorities: map[int]int{0: 200},
+		IPMonitoring: &config.IPMonitoring{
+			Targets: []*config.IPMonitorTarget{
+				{Address: addrA, Weight: 255},
+				{Address: addrB, Weight: -100},
+			},
+		},
+	}
+	cfg := &config.ClusterConfig{RedundancyGroups: []*config.RedundancyGroup{rg}}
+
+	m := NewManager(0, 1)
+	m.UpdateConfig(cfg)
+	drainEvents(m, 8)
+
+	reach := map[string]bool{addrA: true, addrB: true}
+	mon := NewMonitor(m, cfg.RedundancyGroups)
+	injectFakeNl(mon)
+	setNoDampening(mon)
+	mon.probeFn = reachProbeFn(reach)
+
+	mon.poll()
+	if w := m.GroupStates()[0].Weight; w != 255 {
+		t.Fatalf("weight with both targets reachable = %d, want 255", w)
+	}
+
+	// Both targets go unreachable. The full-weight one alone resigns the group;
+	// the out-of-range one must not credit any weight back.
+	reach[addrA] = false
+	reach[addrB] = false
+	mon.poll()
+	drainEvents(m, 8)
+
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight with both monitored targets unreachable = %d, want 0 — "+
+			"a negative ip-monitoring weight credited debt back and cancelled "+
+			"%s's real unreachability (fail-open)", w, addrA)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("node must not stay primary with both monitored targets unreachable")
+	}
+}
+
+// TestIPMonitor_NegativeWeightCannotMaskTheGlobalThreshold_6549 is the sharper
+// half of the ip-monitoring residual, and the one the SetMonitorWeight
+// chokepoint CANNOT close.
+//
+// In global-threshold (vSRX aggregate) mode each unreachable target's weight
+// accumulates into a cumulative sum, and a single global-weight debt is owed
+// only while that sum is >= global-threshold. A NEGATIVE target weight
+// SUBTRACTS from the sum — so a SECOND genuinely unreachable target pushes the
+// cumulative back below the threshold and drops the aggregate debt the FIRST
+// failure correctly installed. More failures produce LESS demotion: the group
+// returns from weight 0 / SECONDARY to full weight / PRIMARY with every
+// monitored target dead.
+//
+// The chokepoint cannot see this: when the threshold is masked, no debt is
+// desired, so SetMonitorWeight is never called at all. Only bounding the value
+// where the cumulative sum reads it (Monitor.ipTargetWeight) closes it.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// ipTargetWeight and the cumulative becomes 255 + (-100) = 155 < 200, so the
+// final assertion sees weight 255 and the node primary.
+func TestIPMonitor_NegativeWeightCannotMaskTheGlobalThreshold_6549(t *testing.T) {
+	const addrA, addrB = "10.0.0.1", "10.0.0.2"
+
+	rg := &config.RedundancyGroup{
+		ID:             0,
+		NodePriorities: map[int]int{0: 200},
+		IPMonitoring: &config.IPMonitoring{
+			GlobalWeight:    255,
+			GlobalThreshold: 200,
+			Targets: []*config.IPMonitorTarget{
+				{Address: addrA, Weight: 255},
+				{Address: addrB, Weight: -100},
+			},
+		},
+	}
+	cfg := &config.ClusterConfig{RedundancyGroups: []*config.RedundancyGroup{rg}}
+
+	m := NewManager(0, 1)
+	m.UpdateConfig(cfg)
+	drainEvents(m, 8)
+
+	reach := map[string]bool{addrA: true, addrB: true}
+	mon := NewMonitor(m, cfg.RedundancyGroups)
+	injectFakeNl(mon)
+	setNoDampening(mon)
+	mon.probeFn = reachProbeFn(reach)
+
+	mon.poll()
+	if w := m.GroupStates()[0].Weight; w != 255 {
+		t.Fatalf("weight with both targets reachable = %d, want 255", w)
+	}
+
+	// The weight-255 target alone meets the threshold and resigns the group.
+	reach[addrA] = false
+	mon.poll()
+	drainEvents(m, 8)
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight with the weight-255 target unreachable = %d, want 0 "+
+			"(cumulative 255 >= threshold 200)", w)
+	}
+
+	// A SECOND target dies. Demotion must not weaken.
+	reach[addrB] = false
+	mon.poll()
+	drainEvents(m, 8)
+
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight after a SECOND target went unreachable = %d, want 0 — "+
+			"the negative ip-monitoring weight subtracted from the cumulative "+
+			"failure sum, pushed it back below global-threshold and dropped the "+
+			"aggregate debt: more failures produced LESS demotion (fail-open)", w)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("node must not regain primary when a second monitored target dies")
+	}
+}
+
+// TestIPMonitor_AggregateGlobalWeightIsBounded_6549 covers the aggregate branch
+// of desiredRGIPDebts, where the debt owed once the cumulative failure sum
+// reaches global-threshold is the raw configured global-weight.
+//
+// The SetMonitorWeight chokepoint already bounds what the ELECTION applies, so
+// this binds the other half of the contract: the weight recorded in the
+// Monitor's own ipDebts ledger — which is what the operator-facing RecordEvent
+// ("deducting global-weight N") reports — must equal the weight applied, not
+// the raw configured one.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// desiredRGIPDebts' aggregate branch and the ledger records 100000 / -100 while
+// the election applies 255 / 0.
+func TestIPMonitor_AggregateGlobalWeightIsBounded_6549(t *testing.T) {
+	tests := []struct {
+		name         string
+		globalWeight int
+		wantDebt     int
+		wantRGWeight int
+	}{
+		{"legal-max", 255, 255, 0},
+		{"legal-mid", 100, 100, 155},
+		{"over-max", 100000, 255, 0},
+		{"negative", -100, 0, 255},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const addr = "10.0.0.1"
+
+			rg := &config.RedundancyGroup{
+				ID:             0,
+				NodePriorities: map[int]int{0: 200},
+				IPMonitoring: &config.IPMonitoring{
+					GlobalWeight:    tt.globalWeight,
+					GlobalThreshold: 200,
+					Targets:         []*config.IPMonitorTarget{{Address: addr, Weight: 255}},
+				},
+			}
+			cfg := &config.ClusterConfig{RedundancyGroups: []*config.RedundancyGroup{rg}}
+
+			m := NewManager(0, 1)
+			m.UpdateConfig(cfg)
+			drainEvents(m, 8)
+
+			reach := map[string]bool{addr: true}
+			mon := NewMonitor(m, cfg.RedundancyGroups)
+			injectFakeNl(mon)
+			setNoDampening(mon)
+			mon.probeFn = reachProbeFn(reach)
+			mon.poll()
+
+			// The weight-255 target alone meets the threshold.
+			reach[addr] = false
+			mon.poll()
+			drainEvents(m, 8)
+
+			mon.mu.Lock()
+			debt, installed := mon.ipDebts[0][ipAggregateMonitorName]
+			mon.mu.Unlock()
+			if !installed {
+				t.Fatalf("global-weight %d: no aggregate debt installed "+
+					"(cumulative 255 >= threshold 200)", tt.globalWeight)
+			}
+			if debt != tt.wantDebt {
+				t.Errorf("global-weight %d: ipDebts ledger recorded %d, want the "+
+					"effective %d — the RecordEvent would report a weight the "+
+					"election does not apply", tt.globalWeight, debt, tt.wantDebt)
+			}
+			if w := m.GroupStates()[0].Weight; w != tt.wantRGWeight {
+				t.Errorf("global-weight %d: rg.Weight = %d, want %d",
+					tt.globalWeight, w, tt.wantRGWeight)
+			}
+		})
+	}
+}
+
+// TestBuildHeartbeat_WireWeightSaturatesAtTheCallSites_6549 binds the layer-4
+// belt's CALL SITES, not just the function. clampWireWeight has its own unit
+// test, but reverting buildHeartbeat's two uses back to `uint8(...)` produced
+// no failure anywhere — the belt could be silently dropped by a refactor.
+//
+// The upstream clamps make out-of-domain values unreachable through the public
+// API, so this reaches inside the package to inject one directly under m.mu,
+// mirroring how TestMonitorPoll_LocalAndAdvertisedMonitorWeightAgree_6549
+// already installs a Monitor.
+//
+// Fail-on-revert: restore `Weight: uint8(rg.Weight)` / `Weight: uint8(ls.Weight)`
+// in buildHeartbeat and both rows fail — 355 aliases to 99 and -100 to 156.
+func TestBuildHeartbeat_WireWeightSaturatesAtTheCallSites_6549(t *testing.T) {
+	tests := []struct {
+		name     string
+		injected int
+		want     int
+	}{
+		{"over-domain-truncates-to-99", 355, 255},
+		{"negative-wraps-to-156", -100, 0},
+		{"legal-max-unchanged", 255, 255},
+		{"legal-mid-unchanged", 128, 128},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const iface = "trust0"
+
+			m := NewManager(0, 1)
+			cfg := makeConfig(makeRG(0, false, map[int]int{0: 100},
+				&config.InterfaceMonitor{Interface: iface, Weight: 0}))
+			m.UpdateConfig(cfg)
+			drainEvents(m, 8)
+
+			// A Monitor supplies buildHeartbeat's Monitors section.
+			nlh := newMockNlHandle()
+			nlh.setLink(iface, true)
+			mon := NewMonitor(m, cfg.RedundancyGroups)
+			mon.nlHandle = nlh
+			setNoDampening(mon)
+			mon.poll()
+
+			// Inject an out-of-domain weight on BOTH marshal paths, bypassing
+			// every upstream clamp — this is the state a future producer that
+			// skips them would create.
+			m.mu.Lock()
+			m.monitor = mon
+			m.groups[0].Weight = tt.injected
+			m.mu.Unlock()
+			mon.mu.Lock()
+			for i := range mon.localStatuses {
+				mon.localStatuses[i].Weight = tt.injected
+			}
+			mon.mu.Unlock()
+
+			pkt, err := UnmarshalHeartbeat(MarshalHeartbeat(m.buildHeartbeat()))
+			if err != nil {
+				t.Fatalf("UnmarshalHeartbeat: %v", err)
+			}
+			if len(pkt.Groups) != 1 {
+				t.Fatalf("expected 1 advertised group, got %d", len(pkt.Groups))
+			}
+			if got := int(pkt.Groups[0].Weight); got != tt.want {
+				t.Errorf("injected rg.Weight %d advertised as %d, want %d — the "+
+					"marshal truncated instead of saturating", tt.injected, got, tt.want)
+			}
+			if len(pkt.Monitors) != 1 {
+				t.Fatalf("expected 1 advertised monitor, got %d", len(pkt.Monitors))
+			}
+			if got := int(pkt.Monitors[0].Weight); got != tt.want {
+				t.Errorf("injected monitor weight %d advertised as %d, want %d",
+					tt.injected, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSetMonitorWeight_ClosesTheDebtDomain_6549 states the chokepoint rule
+// directly: whatever a caller hands SetMonitorWeight, the installed debt stays
+// inside the [0,255] heartbeat weight domain, and the local weight never
+// diverges from the advertised one.
+//
+// The daemon apply tail is one caller; ip-monitoring target debt
+// (Monitor.ipTargetWeight, which has no clamp of its own) is another. Binding
+// the chokepoint rather than each caller is what makes a future producer safe
+// by construction.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// Manager.SetMonitorWeight and every out-of-range row escapes the domain.
+func TestSetMonitorWeight_ClosesTheDebtDomain_6549(t *testing.T) {
+	tests := []struct {
+		name     string
+		weight   int
+		wantDebt int
+	}{
+		// Over-reach guard: legal weights must be installed verbatim.
+		{"legal-zero", 0, 0},
+		{"legal-one", 1, 1},
+		{"legal-half", 128, 128},
+		{"legal-max", 255, 255},
+		// Out-of-range: clamped into the domain.
+		{"negative-small", -1, 0},
+		{"negative-large", -100, 0},
+		{"over-max", 256, 255},
+		{"over-max-large", 100000, 255},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const iface = "trust0"
+
+			m := NewManager(0, 1)
+			m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 100},
+				&config.InterfaceMonitor{Interface: iface, Weight: 0})))
+			drainEvents(m, 8)
+
+			m.SetMonitorWeight(0, iface, true, tt.weight)
+			drainEvents(m, 8)
+
+			m.mu.Lock()
+			debt := m.monitorWeights[monitorKey{rgID: 0, iface: iface}]
+			m.mu.Unlock()
+			if debt != tt.wantDebt {
+				t.Errorf("SetMonitorWeight(%d) installed debt %d, want %d",
+					tt.weight, debt, tt.wantDebt)
+			}
+
+			local, advertised := localVsAdvertisedWeight(t, m, 0)
+			if local != advertised {
+				t.Errorf("weight %d: local %d but advertised %d",
+					tt.weight, local, advertised)
+			}
+			if want := 255 - tt.wantDebt; local != want {
+				t.Errorf("weight %d: rg.Weight = %d, want %d", tt.weight, local, want)
+			}
+		})
+	}
+}

--- a/pkg/cluster/ifmon_weight_divergence_6549_test.go
+++ b/pkg/cluster/ifmon_weight_divergence_6549_test.go
@@ -1,0 +1,333 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6549: a redundancy group's LOCAL weight and the weight it ADVERTISES in the
+// heartbeat must never disagree.
+//
+// The local election reads rg.Weight as a wide int (EffectivePriority =
+// priority * weight / 255) while buildHeartbeat marshals it through a single
+// byte (HeartbeatGroup.Weight is uint8). Before the fix, recalcWeight computed
+// `rg.Weight = 255 - totalLost` with only a `< 0` floor, so a NEGATIVE monitor
+// debt — an out-of-range `interface-monitor <if> weight -100`, which the
+// tolerant load / peer-sync compile path only warns about (#1960) — pushed
+// rg.Weight to 355 locally while the peer received uint8(355) == 99. The two
+// nodes then elected from different views of identical state and both took
+// primary: duplicate VIP and duplicate RETH virtual MAC on the LAN.
+//
+// These tests drive the REAL marshal (MarshalHeartbeat / UnmarshalHeartbeat on
+// the packet buildHeartbeat actually produces), not a re-implementation of it.
+
+// localVsAdvertisedWeight returns the manager's local weight for rgID and the
+// weight a peer decodes from a real heartbeat marshal/unmarshal round-trip.
+func localVsAdvertisedWeight(t *testing.T, m *Manager, rgID int) (local, advertised int) {
+	t.Helper()
+
+	states := m.GroupStates()
+	found := false
+	for _, gs := range states {
+		if gs.GroupID == rgID {
+			local = gs.Weight
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("redundancy group %d not present in GroupStates()", rgID)
+	}
+
+	wire := MarshalHeartbeat(m.buildHeartbeat())
+	pkt, err := UnmarshalHeartbeat(wire)
+	if err != nil {
+		t.Fatalf("UnmarshalHeartbeat: %v", err)
+	}
+	for _, g := range pkt.Groups {
+		if int(g.GroupID) == rgID {
+			return local, int(g.Weight)
+		}
+	}
+	t.Fatalf("redundancy group %d missing from the marshalled heartbeat", rgID)
+	return 0, 0
+}
+
+// TestRGWeight_LocalAndAdvertisedCannotDiverge_6549 pins the core invariant
+// across the whole debt domain, including debts no legal config can produce.
+//
+// Fail-on-revert: restore `rg.Weight = 255 - totalLost; if rg.Weight < 0 {
+// rg.Weight = 0 }` in recalcWeight (i.e. drop the ceiling from
+// rgWeightFromDebt) and every negative-debt row fails with local 355 vs
+// advertised 99.
+func TestRGWeight_LocalAndAdvertisedCannotDiverge_6549(t *testing.T) {
+	// Debts fed straight into SetMonitorWeight: this is the hostile-input leg,
+	// proving the weight DOMAIN is closed regardless of which caller supplies
+	// the debt (interface monitor, ip-monitoring target, or a future caller).
+	debts := []int{-100000, -1000, -256, -255, -100, -1, 0, 1, 128, 254, 255, 256, 1000, 100000}
+
+	for _, debt := range debts {
+		m := NewManager(0, 1)
+		m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 100},
+			&config.InterfaceMonitor{Interface: "ge-0/0/0", Weight: 255})))
+		drainEvents(m, 4)
+
+		m.SetMonitorWeight(0, "ge-0/0/0", true, debt)
+		drainEvents(m, 4)
+
+		local, advertised := localVsAdvertisedWeight(t, m, 0)
+		if local != advertised {
+			t.Errorf("debt %d: local weight %d but advertised %d — the two nodes "+
+				"would compute different effective priorities from identical state",
+				debt, local, advertised)
+		}
+		if local < 0 || local > 255 {
+			t.Errorf("debt %d: local weight %d escapes the [0,255] heartbeat weight domain",
+				debt, local)
+		}
+	}
+}
+
+// TestRGWeight_ConfiguredMonitorWeightCannotDiverge_6549 drives the same
+// invariant through the CONFIG path an out-of-range weight actually travels on
+// a tolerant load / peer-sync: the weight is installed as debt, then a config
+// apply re-derives it via reconcileMonitorDebtsLocked.
+//
+// Fail-on-revert (either half): drop the ceiling from rgWeightFromDebt, or drop
+// the config.ClampInterfaceMonitorWeight call in reconcileMonitorDebtsLocked,
+// and the weight -100 row diverges (local 355, advertised 99).
+func TestRGWeight_ConfiguredMonitorWeightCannotDiverge_6549(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		wantWeight int // expected effective rg.Weight with the monitor DOWN
+	}{
+		// Over-reach guard: every legal weight must still behave exactly as
+		// before — 255 minus the configured debt, advertised identically.
+		{"legal-zero", 0, 255},
+		{"legal-one", 1, 254},
+		{"legal-half", 128, 127},
+		{"legal-max", 255, 0},
+		// Out-of-range: clamped into the domain, never diverging.
+		{"negative-small", -1, 255},
+		{"negative-large", -100, 255},
+		{"over-max", 256, 0},
+		{"over-max-large", 100000, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const iface = "ge-0/0/0"
+
+			m := NewManager(0, 1)
+			// Seed with a legal weight so the monitor can be marked down
+			// through the normal path first.
+			m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 100},
+				&config.InterfaceMonitor{Interface: iface, Weight: 200})))
+			drainEvents(m, 4)
+			m.SetMonitorWeight(0, iface, true, 200)
+			drainEvents(m, 4)
+
+			// Now apply the config carrying the weight under test. The monitor
+			// is still down, so reconcileMonitorDebtsLocked re-derives the debt
+			// from the new configured weight (the "changed weight for a monitor
+			// that is still failed" branch).
+			m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 100},
+				&config.InterfaceMonitor{Interface: iface, Weight: tt.configured})))
+			drainEvents(m, 4)
+
+			local, advertised := localVsAdvertisedWeight(t, m, 0)
+			if local != advertised {
+				t.Errorf("configured weight %d: local %d but advertised %d",
+					tt.configured, local, advertised)
+			}
+			if local != tt.wantWeight {
+				t.Errorf("configured weight %d: rg.Weight = %d, want %d",
+					tt.configured, local, tt.wantWeight)
+			}
+		})
+	}
+}
+
+// TestReconcileMonitorDebts_OutOfRangeWeightCannotCancelARealFailure_6549 is
+// the config-apply twin of the poll-path test below: reconcileMonitorDebtsLocked
+// re-derives the debt of a monitor that is STILL failed when its configured
+// weight changes, so a config apply is a second way an out-of-range weight
+// enters the debt set — and a negative one there likewise credits weight back
+// and cancels a sibling monitor's real failure.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// reconcileMonitorDebtsLocked and the reconciled debt becomes 255 + (-100) =
+// 155, restoring the group to weight 100 while both monitored links are down.
+func TestReconcileMonitorDebts_OutOfRangeWeightCannotCancelARealFailure_6549(t *testing.T) {
+	const ifA, ifB = "trust0", "trust1"
+
+	m := NewManager(0, 1)
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200},
+		&config.InterfaceMonitor{Interface: ifA, Weight: 255},
+		&config.InterfaceMonitor{Interface: ifB, Weight: 200},
+	)))
+	drainEvents(m, 4)
+
+	// Both monitors fail with their legal weights.
+	m.SetMonitorWeight(0, ifA, true, 255)
+	m.SetMonitorWeight(0, ifB, true, 200)
+	drainEvents(m, 4)
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight with both monitors failed = %d, want 0", w)
+	}
+
+	// A config apply changes the still-failed ifB's weight out of range. The
+	// reconcile re-derives ifB's debt from it.
+	m.UpdateConfig(makeConfig(makeRG(0, false, map[int]int{0: 200},
+		&config.InterfaceMonitor{Interface: ifA, Weight: 255},
+		&config.InterfaceMonitor{Interface: ifB, Weight: -100},
+	)))
+	drainEvents(m, 4)
+
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight after reconciling an out-of-range monitor weight = %d, "+
+			"want 0 — the negative weight credited debt back and cancelled %s's "+
+			"real failure (fail-open)", w, ifA)
+	}
+	local, advertised := localVsAdvertisedWeight(t, m, 0)
+	if local != advertised {
+		t.Fatalf("local weight %d but advertised %d", local, advertised)
+	}
+}
+
+// TestMonitorPoll_OutOfRangeWeightCannotCancelARealFailure_6549 pins the
+// second consequence of an unbounded interface-monitor weight, on the REAL
+// poll path (mock netlink -> pollInterfaceMonitors -> SetMonitorWeight): a
+// NEGATIVE weight is negative DEBT, so it cancels the demotion a genuinely
+// failed sibling monitor just applied. Two dead links then leave the node at
+// weight 100 and still PRIMARY, blackholing traffic — a fail-open that the
+// rg.Weight domain clamp alone does not catch, because the sum stays inside
+// [0,255].
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// pollInterfaceMonitors and the debt becomes 255 + (-100) = 155, leaving
+// weight 100 and the node primary.
+func TestMonitorPoll_OutOfRangeWeightCannotCancelARealFailure_6549(t *testing.T) {
+	m := NewManager(0, 1) // node 0
+	cfg := makeConfig(makeRG(0, false, map[int]int{0: 200},
+		&config.InterfaceMonitor{Interface: "trust0", Weight: 255},
+		&config.InterfaceMonitor{Interface: "trust1", Weight: -100},
+	))
+	m.UpdateConfig(cfg)
+	drainEvents(m, 4)
+
+	nlh := newMockNlHandle()
+	nlh.setLink("trust0", true)
+	nlh.setLink("trust1", true)
+
+	mon := NewMonitor(m, cfg.RedundancyGroups)
+	mon.nlHandle = nlh
+	setNoDampening(mon)
+
+	mon.poll()
+	if w := m.GroupStates()[0].Weight; w != 255 {
+		t.Fatalf("weight with both links up = %d, want 255", w)
+	}
+
+	// Both monitored links die. The full-weight monitor alone must resign the
+	// group; the out-of-range one must not credit any weight back.
+	nlh.setLink("trust0", false)
+	nlh.setLink("trust1", false)
+	mon.poll()
+
+	if w := m.GroupStates()[0].Weight; w != 0 {
+		t.Fatalf("weight with both monitored links down = %d, want 0 — a negative "+
+			"interface-monitor weight credited debt back and cancelled a real "+
+			"link failure (fail-open)", w)
+	}
+	if m.IsLocalPrimary(0) {
+		t.Fatal("node must not stay primary with both monitored links down")
+	}
+}
+
+// TestMonitorPoll_LocalAndAdvertisedMonitorWeightAgree_6549 pins the per-MONITOR
+// half of the divergence: HeartbeatMonitor.Weight is also a single byte, so what
+// this node reports locally about a monitor and what it advertises about that
+// same monitor must agree.
+//
+// Fail-on-revert: drop the config.ClampInterfaceMonitorWeight call in
+// pollInterfaceMonitors and the local status carries -100 while the wire carries
+// 0 (or, without clampWireWeight too, 156).
+func TestMonitorPoll_LocalAndAdvertisedMonitorWeightAgree_6549(t *testing.T) {
+	for _, configured := range []int{-100, -1, 0, 1, 128, 255, 256, 100000} {
+		m := NewManager(0, 1)
+		cfg := makeConfig(makeRG(0, false, map[int]int{0: 200},
+			&config.InterfaceMonitor{Interface: "trust0", Weight: configured},
+		))
+		m.UpdateConfig(cfg)
+		drainEvents(m, 4)
+
+		nlh := newMockNlHandle()
+		nlh.setLink("trust0", true)
+		mon := NewMonitor(m, cfg.RedundancyGroups)
+		mon.nlHandle = nlh
+		setNoDampening(mon)
+		// buildHeartbeat sources its Monitors section from m.monitor's local
+		// statuses; Start() is the production setter, which a unit test cannot
+		// run (it spawns the poll loop). Same-package assignment under m.mu.
+		m.mu.Lock()
+		m.monitor = mon
+		m.mu.Unlock()
+		mon.poll()
+
+		local := mon.LocalInterfaceStatuses()
+		if len(local) != 1 {
+			t.Fatalf("configured %d: expected 1 local monitor status, got %d",
+				configured, len(local))
+		}
+
+		pkt, err := UnmarshalHeartbeat(MarshalHeartbeat(m.buildHeartbeat()))
+		if err != nil {
+			t.Fatalf("configured %d: UnmarshalHeartbeat: %v", configured, err)
+		}
+		if len(pkt.Monitors) != 1 {
+			t.Fatalf("configured %d: expected 1 advertised monitor, got %d",
+				configured, len(pkt.Monitors))
+		}
+		if local[0].Weight != int(pkt.Monitors[0].Weight) {
+			t.Errorf("configured weight %d: local monitor status weight %d but "+
+				"advertised %d", configured, local[0].Weight, pkt.Monitors[0].Weight)
+		}
+	}
+}
+
+// TestRGWeightFromDebt_ClosesTheDomain_6549 is the unit-level statement of the
+// same rule, so a reviewer can see the boundary without running a cluster.
+func TestRGWeightFromDebt_ClosesTheDomain_6549(t *testing.T) {
+	tests := []struct {
+		debt, want int
+	}{
+		{-100000, 255}, {-256, 255}, {-1, 255}, // negative debt: ceiling holds
+		{0, 255}, {1, 254}, {255, 0}, // in-domain: unchanged arithmetic
+		{256, 0}, {100000, 0}, // over-large debt: floor holds
+	}
+	for _, tt := range tests {
+		if got := rgWeightFromDebt(tt.debt); got != tt.want {
+			t.Errorf("rgWeightFromDebt(%d) = %d, want %d", tt.debt, got, tt.want)
+		}
+	}
+}
+
+// TestClampWireWeight_SaturatesNotTruncates_6549 pins the marshal-boundary
+// belt: `uint8(355)` aliases to 99, which is what made the local and advertised
+// views disagree. Saturation keeps a stray value bounded and monotonic.
+func TestClampWireWeight_SaturatesNotTruncates_6549(t *testing.T) {
+	tests := []struct {
+		in   int
+		want uint8
+	}{
+		{-1, 0}, {0, 0}, {1, 1}, {128, 128}, {255, 255},
+		{256, 255}, {355, 255}, {100000, 255},
+	}
+	for _, tt := range tests {
+		if got := clampWireWeight(tt.in); got != tt.want {
+			t.Errorf("clampWireWeight(%d) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}

--- a/pkg/cluster/monitor.go
+++ b/pkg/cluster/monitor.go
@@ -472,6 +472,15 @@ func (mon *Monitor) pollInterfaceMonitors(rg *config.RedundancyGroup, statuses [
 	for _, im := range rg.InterfaceMonitors {
 		key := monitorKey{rgID: rg.ID, iface: im.Interface}
 
+		// #6549: bound the configured weight to the [0,255] domain the
+		// heartbeat weight fields can carry. The strict commit path already
+		// rejected an out-of-range weight; the tolerant load / peer-sync path
+		// only warns (#1960 no-brick), so a persisted or peer-pushed config
+		// can still reach this poll. Deliberately NOT logged here — this loop
+		// runs every poll tick; reconcileMonitorDebtsLocked emits the
+		// config-apply-frequency warning.
+		weight, _ := config.ClampInterfaceMonitorWeight(im.Weight)
+
 		// Translate Junos name (ge-0/0/0) to Linux name (ge-0-0-0).
 		linuxName := config.LinuxIfName(im.Interface)
 		link, err := nlh.LinkByName(linuxName)
@@ -503,7 +512,7 @@ func (mon *Monitor) pollInterfaceMonitors(rg *config.RedundancyGroup, statuses [
 		// Track local interface status for heartbeat propagation.
 		statuses = append(statuses, InterfaceMonitorInfo{
 			Interface:       im.Interface,
-			Weight:          im.Weight,
+			Weight:          weight,
 			Up:              up,
 			RedundancyGroup: rg.ID,
 		})
@@ -515,17 +524,17 @@ func (mon *Monitor) pollInterfaceMonitors(rg *config.RedundancyGroup, statuses [
 		}
 
 		if mon.evaluateTransition(state, !up) {
-			mon.mgr.SetMonitorWeight(rg.ID, im.Interface, state.down, im.Weight)
+			mon.mgr.SetMonitorWeight(rg.ID, im.Interface, state.down, weight)
 			if state.down {
 				mon.mgr.RecordEvent(EventMonitor, rg.ID, fmt.Sprintf(
-					"Interface %s state changed to down, weight %d", im.Interface, im.Weight))
+					"Interface %s state changed to down, weight %d", im.Interface, weight))
 			} else {
 				mon.mgr.RecordEvent(EventMonitor, rg.ID, fmt.Sprintf(
 					"Interface %s state changed to up", im.Interface))
 			}
 			slog.Info("cluster monitor: interface state changed",
 				"rg", rg.ID, "interface", im.Interface,
-				"up", up, "weight", im.Weight)
+				"up", up, "weight", weight)
 		}
 	}
 	return statuses

--- a/pkg/cluster/monitor.go
+++ b/pkg/cluster/monitor.go
@@ -632,11 +632,35 @@ launch:
 // or the RG global-weight when the per-target weight is unset (0). This is the
 // value the target contributes both as an independent debt (no global-threshold)
 // and to the cumulative failure sum (with global-threshold).
+//
+// #6549: bounded to the [0,255] weight domain. ip-monitoring weights have NO
+// compiled-int commit gate (validateChassisClusterStrict covers interface-monitor
+// weights, RG ids and node priorities — not these), so their only commit-side
+// defense is the schema's ValidateInteger(0,255), which compileTreeLenient
+// downgrades to a warning on Store.Load / Store.SyncApply (#1960 no-brick). An
+// out-of-range weight is therefore reachable at runtime, and it breaks BOTH
+// consumers of this value:
+//
+//   - independent mode: a negative weight is negative DEBT — it credits weight
+//     back and cancels a sibling target's real unreachability.
+//   - global-threshold mode: a negative weight SUBTRACTS from the cumulative
+//     failure sum, so a second genuinely unreachable target can push the sum
+//     back BELOW global-threshold and drop the aggregate debt that the first
+//     failure correctly installed. More failures then produce LESS demotion —
+//     the group returns to full weight and PRIMARY with every target dead.
+//
+// The Manager.SetMonitorWeight chokepoint cannot close the second case: when
+// the threshold is masked no debt is desired at all, so SetMonitorWeight is
+// never called. Bounding here — the single place both consumers read — is what
+// closes it, and it also keeps the weight reported in the RecordEvent /
+// ipDebts bookkeeping equal to the weight actually applied.
 func (mon *Monitor) ipTargetWeight(rg *config.RedundancyGroup, target *config.IPMonitorTarget) int {
-	if target.Weight != 0 {
-		return target.Weight
+	raw := target.Weight
+	if raw == 0 {
+		raw = rg.IPMonitoring.GlobalWeight
 	}
-	return rg.IPMonitoring.GlobalWeight
+	w, _ := config.ClampInterfaceMonitorWeight(raw)
+	return w
 }
 
 // updateIPTargetDampenedState folds one target's reachability into its dampened
@@ -705,7 +729,14 @@ func (mon *Monitor) desiredRGIPDebts(rg *config.RedundancyGroup) map[string]int 
 			}
 		}
 		if cumulative >= rg.IPMonitoring.GlobalThreshold {
-			desired[ipAggregateMonitorName] = rg.IPMonitoring.GlobalWeight
+			// #6549: same bound as ipTargetWeight — the aggregate debt is the
+			// raw configured global-weight, and an out-of-range one reaches
+			// runtime on the tolerant load / peer-sync path. Clamping here
+			// (not only at the SetMonitorWeight chokepoint) keeps the weight
+			// recorded in ipDebts and reported in the RecordEvent equal to the
+			// weight the election actually applies.
+			w, _ := config.ClampInterfaceMonitorWeight(rg.IPMonitoring.GlobalWeight)
+			desired[ipAggregateMonitorName] = w
 		}
 		return desired
 	}

--- a/pkg/config/compiler_uniformgates_cluster_zone.go
+++ b/pkg/config/compiler_uniformgates_cluster_zone.go
@@ -48,12 +48,17 @@ func runUniformGatesClusterZone(tree *ConfigTree, cfg *Config, opts compileOpts)
 	// commit-check (hard-reject a redundancy-group cardinality or id that
 	// exceeds the single-byte heartbeat count / GroupID fields — 256 RGs
 	// advertise as a count of 0 and desync the wire, an id > 255 truncates
-	// and collides with another group). Lenient on load / peer-sync (warn so
-	// an already-persisted or peer-synced config still boots — #1960
-	// no-brick; the heartbeat marshaler independently caps the group section
-	// to the wire limit, marshalHeartbeatBody, so a leniently-loaded
-	// over-size config is bounded, not a panic). Runs on the fully-compiled
-	// *Config (RedundancyGroups populated by compileChassis).
+	// and collides with another group; #4880 the per-RG node priority, #6549
+	// the interface-monitor weight, both of which the heartbeat / VRRP wire
+	// carries in one byte while the local election reads the raw int).
+	// Lenient on load / peer-sync (warn so an already-persisted or peer-synced
+	// config still boots — #1960 no-brick; the heartbeat marshaler
+	// independently caps the group section to the wire limit,
+	// marshalHeartbeatBody, so a leniently-loaded over-size config is bounded,
+	// not a panic, and pkg/cluster clamps a leniently-loaded interface-monitor
+	// weight — ClampInterfaceMonitorWeight / rgWeightFromDebt — so it cannot
+	// diverge the two nodes' views). Runs on the fully-compiled *Config
+	// (RedundancyGroups populated by compileChassis).
 	if err := validateChassisClusterStrict(cfg); err != nil {
 		if opts.lenientChassisRG {
 			cfg.Warnings = append(cfg.Warnings,

--- a/pkg/config/compiler_validate_strict_chassis.go
+++ b/pkg/config/compiler_validate_strict_chassis.go
@@ -42,9 +42,73 @@ const (
 	MaxRedundancyGroupNodePriority = 254
 )
 
+// MinInterfaceMonitorWeight / MaxInterfaceMonitorWeight bound a
+// redundancy-group `interface-monitor <if> weight <w>` (Junos vSRX 0..255 —
+// the same range the schema already types on the sibling ip-monitoring
+// weights, schema_chassis.go `global-weight` / `global-threshold` / per-target
+// `weight`).
+//
+// #6549: the interface-monitor leaf packs `<ifname> weight <n>` onto ONE node
+// key, so it has NO typed schema leaf (schema_chassis.go documents the
+// deferral: typing it would need a children/wildcard map, which flips
+// SetPath's replace-vs-container grouping) and compileChassis reads the weight
+// with strconv.Atoi under no bound. The weight is the DEBT subtracted from the
+// redundancy group's weight, which starts at 255
+// (pkg/cluster/election.go recalcWeight: `rg.Weight = 255 - totalLost`, with
+// only a `< 0` floor and no ceiling), so a NEGATIVE weight on a down monitor
+// raises rg.Weight ABOVE 255.
+//
+// That is the divergence: the LOCAL election reads the raw wide int
+// (EffectivePriority = priority * weight / 255, election.go), while the
+// heartbeat advertises the same weight through a SINGLE BYTE
+// (HeartbeatGroup.Weight is uint8, populated via `uint8(rg.Weight)` in
+// heartbeat_manager.go buildHeartbeat). With `weight -100` on a down monitor
+// the local node holds 355 and the peer receives uint8(355) == 99, so at base
+// priority 100 the local node computes its own effective priority as 139 while
+// the peer computes 38 for it. The two nodes then elect from DIFFERENT views of
+// identical state and can both take primary — duplicate VIP and duplicate RETH
+// virtual MAC on the LAN. Same failure shape (wide local int vs single wire
+// byte) as the #4880 node-priority gate above.
+//
+// The runtime carries the matching belts: ClampInterfaceMonitorWeight bounds
+// the configured debt where pkg/cluster reads it, and rgWeightFromDebt bounds
+// rg.Weight itself to the same [0,255] domain at every recompute site, so a
+// config that reaches the tolerant load / peer-sync path (where this gate is
+// downgraded to a warning per #1960) still cannot diverge.
+const (
+	MinInterfaceMonitorWeight = 0
+	MaxInterfaceMonitorWeight = 255
+)
+
+// ClampInterfaceMonitorWeight bounds a configured interface-monitor weight to
+// [MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight]. It returns the
+// effective weight and whether clamping occurred.
+//
+// The strict commit / commit-check path never needs this — validateChassisCluster
+// Strict rejects an out-of-range weight outright. It exists for the TOLERANT
+// paths (Store.Load of a persisted config, Store.SyncApply of a peer-pushed
+// one), which downgrade that gate to a warning so an already-persisted config
+// still BOOTS (#1960 no-brick). Without the clamp those paths would install the
+// out-of-range debt verbatim and reproduce exactly the local-vs-wire divergence
+// the gate exists to prevent. Mirrors ClampGratuitousARPCount (#5695): the
+// commit path signals, the runtime bounds.
+func ClampInterfaceMonitorWeight(w int) (int, bool) {
+	switch {
+	case w < MinInterfaceMonitorWeight:
+		return MinInterfaceMonitorWeight, true
+	case w > MaxInterfaceMonitorWeight:
+		return MaxInterfaceMonitorWeight, true
+	default:
+		return w, false
+	}
+}
+
 // validateChassisClusterStrict hard-rejects, at commit / commit-check, a
 // chassis-cluster config whose redundancy-group cardinality or ids exceed
-// what the HA heartbeat wire format can encode (#4434, codex-172 C172-H02).
+// what the HA heartbeat wire format can encode (#4434, codex-172 C172-H02),
+// whose per-RG node priority is out of the VRRP range (#4880), or whose
+// interface-monitor weight is out of the [0,255] heartbeat weight domain
+// (#6549).
 //
 // The heartbeat count byte and per-group id byte are both uint8. There is
 // no schema-level value validation on the `redundancy-group <id>` instance
@@ -129,6 +193,33 @@ func validateChassisClusterStrict(cfg *Config) error {
 					rg.ID, nodeID, pri,
 					MinRedundancyGroupNodePriority, MaxRedundancyGroupNodePriority,
 					MinRedundancyGroupNodePriority, MaxRedundancyGroupNodePriority)
+			}
+		}
+
+		// #6549: interface-monitor weight range gate. The leaf packs
+		// `<ifname> weight <n>` onto one node key and has no typed schema leaf
+		// at all (unlike the ip-monitoring weight siblings), so the range is
+		// asserted here on the compiled int — which covers BOTH parser shapes
+		// (flat-set and hierarchical) at once. Out of range, the debt makes
+		// rg.Weight leave the [0,255] domain the single-byte heartbeat field
+		// can carry, and the local election and the peer's view of it diverge
+		// (see MinInterfaceMonitorWeight). InterfaceMonitors is an
+		// AST-order slice (not a map), so the first-error message is already
+		// deterministic without sorting.
+		for _, im := range rg.InterfaceMonitors {
+			if im == nil { // tolerant/HA-sync path may carry a nil entry (#3494).
+				continue
+			}
+			if im.Weight < MinInterfaceMonitorWeight || im.Weight > MaxInterfaceMonitorWeight {
+				return fmt.Errorf("chassis cluster: redundancy-group %d interface-monitor %s "+
+					"weight %d is out of range %d..%d (the weight is subtracted from the "+
+					"redundancy-group weight, which the heartbeat advertises through a single "+
+					"wire byte while the local election reads the raw value — an out-of-range "+
+					"weight makes the two nodes compute different effective priorities from "+
+					"identical state and both elect primary) — set a weight in %d..%d",
+					rg.ID, im.Interface, im.Weight,
+					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight,
+					MinInterfaceMonitorWeight, MaxInterfaceMonitorWeight)
 			}
 		}
 	}

--- a/pkg/config/compiler_validate_strict_chassis_ifmon_6549_test.go
+++ b/pkg/config/compiler_validate_strict_chassis_ifmon_6549_test.go
@@ -1,0 +1,175 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #6549: `chassis cluster redundancy-group <n> interface-monitor <if> weight
+// <w>` had NO range gate at any layer. The leaf packs `<ifname> weight <n>`
+// onto one node key so it has no typed schema leaf (unlike the ip-monitoring
+// weight siblings, which are ValidateInteger(0,255)), and compileChassis reads
+// the weight with strconv.Atoi under no bound.
+//
+// Out of range, the weight breaks the HA election: it is the debt subtracted
+// from the redundancy-group weight, which starts at 255, so `weight -100` on a
+// down monitor puts rg.Weight at 355 — read raw by the local election but
+// advertised through the single-byte heartbeat weight field as uint8(355) ==
+// 99. Both nodes then elect primary from identical state: duplicate VIP and
+// duplicate RETH virtual MAC on the LAN.
+//
+// FAIL-ON-REVERT: remove the interface-monitor weight loop from
+// validateChassisClusterStrict and the out-of-range subtests go green on the
+// BAD config. The in-range subtests pin that the gate does not over-reject, and
+// the tolerant-path subtest pins #1960 no-brick.
+
+// ifMonSetLines returns the flat-set lines for one redundancy group carrying a
+// single interface-monitor with the given weight.
+func ifMonSetLines(weight int) []string {
+	return []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		fmt.Sprintf("set chassis cluster redundancy-group 1 interface-monitor ge-0/0/0 weight %d", weight),
+	}
+}
+
+func TestChassisInterfaceMonitorWeightOutOfRangeFailsCommit_6549(t *testing.T) {
+	for _, weight := range []int{-100000, -256, -100, -1, 256, 300, 100000} {
+		t.Run(fmt.Sprintf("weight_%d", weight), func(t *testing.T) {
+			tree := buildTree(t, ifMonSetLines(weight))
+
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to reject interface-monitor weight %d "+
+					"(the heartbeat weight field is one byte while the local election "+
+					"reads the raw int), got nil error", weight)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "interface-monitor ge-0/0/0") {
+				t.Fatalf("error %q does not name the offending interface-monitor", msg)
+			}
+			if !strings.Contains(msg, fmt.Sprintf("weight %d", weight)) {
+				t.Fatalf("error %q does not name the out-of-range weight %d", msg, weight)
+			}
+			if !strings.Contains(msg, "out of range 0..255") {
+				t.Fatalf("error %q does not state the admitted range", msg)
+			}
+		})
+	}
+}
+
+func TestChassisInterfaceMonitorWeightInRangeCommits_6549(t *testing.T) {
+	// Over-reach guard: every legal weight, including both boundaries, must
+	// still commit AND still compile to exactly the configured value.
+	for _, weight := range []int{0, 1, 128, 254, 255} {
+		t.Run(fmt.Sprintf("weight_%d", weight), func(t *testing.T) {
+			tree := buildTree(t, ifMonSetLines(weight))
+
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("interface-monitor weight %d must commit, got %v", weight, err)
+			}
+			mons := onlyRGInterfaceMonitors(t, cfg)
+			if len(mons) != 1 {
+				t.Fatalf("expected 1 interface-monitor, got %d", len(mons))
+			}
+			if mons[0].Interface != "ge-0/0/0" {
+				t.Fatalf("interface = %q, want ge-0/0/0", mons[0].Interface)
+			}
+			if mons[0].Weight != weight {
+				t.Fatalf("weight = %d, want %d (the gate must not alter an in-range value)",
+					mons[0].Weight, weight)
+			}
+		})
+	}
+}
+
+// TestChassisInterfaceMonitorWeightMissingCommits_6549 pins that an
+// interface-monitor with no `weight` token at all is untouched by the gate — it
+// compiles to the pre-existing 0 default rather than being rejected.
+func TestChassisInterfaceMonitorWeightMissingCommits_6549(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set chassis cluster redundancy-group 1 interface-monitor ge-0/0/0",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("interface-monitor with no weight must commit, got %v", err)
+	}
+	mons := onlyRGInterfaceMonitors(t, cfg)
+	if len(mons) != 1 || mons[0].Weight != 0 {
+		t.Fatalf("expected one monitor with the default weight 0, got %+v", mons)
+	}
+}
+
+// TestChassisInterfaceMonitorWeightTolerantPathNoBrick_6549 pins the #1960
+// posture: an already-persisted / peer-synced config carrying an out-of-range
+// weight must still BOOT, with a warning — not fail the load and blackout the
+// node. pkg/cluster clamps it (ClampInterfaceMonitorWeight / rgWeightFromDebt)
+// so the leniently-loaded value still cannot diverge the two nodes.
+func TestChassisInterfaceMonitorWeightTolerantPathNoBrick_6549(t *testing.T) {
+	tree := buildTree(t, ifMonSetLines(-100))
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not reject an out-of-range interface-monitor "+
+			"weight (no-brick), got %v", err)
+	}
+	if !warningsContain(cfg.Warnings, "interface-monitor ge-0/0/0") {
+		t.Fatalf("lenient compile should have warned about the out-of-range weight; warnings=%v",
+			cfg.Warnings)
+	}
+	// The lenient path deliberately keeps compiling the raw value — the runtime
+	// clamp, not the compiler, is what bounds it (see ClampInterfaceMonitorWeight).
+	mons := onlyRGInterfaceMonitors(t, cfg)
+	if len(mons) != 1 || mons[0].Weight != -100 {
+		t.Fatalf("lenient compile should preserve the raw weight for the runtime clamp, got %+v",
+			mons)
+	}
+	if got, clamped := ClampInterfaceMonitorWeight(mons[0].Weight); got != 0 || !clamped {
+		t.Fatalf("ClampInterfaceMonitorWeight(%d) = (%d, %v), want (0, true)",
+			mons[0].Weight, got, clamped)
+	}
+}
+
+// TestChassisInterfaceMonitorWeightHierarchicalShape_6549 pins that the gate
+// covers the braces spelling too — the shape a persisted config is rendered
+// and re-parsed in (ConfigTree.Format emits `interface-monitor { ge-0/0/0
+// weight <n>; }`), which is how an out-of-range weight survives a reboot.
+func TestChassisInterfaceMonitorWeightHierarchicalShape_6549(t *testing.T) {
+	const text = `chassis {
+    cluster {
+        cluster-id 1;
+        redundancy-group 1 {
+            node 0 priority 200;
+            interface-monitor {
+                ge-0/0/0 weight -100;
+            }
+        }
+    }
+}`
+	p := NewParser(text)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject the hierarchical out-of-range weight, got nil error")
+	}
+}
+
+// onlyRGInterfaceMonitors returns the interface monitors of the single
+// redundancy group the test configs above define.
+func onlyRGInterfaceMonitors(t *testing.T, cfg *Config) []*InterfaceMonitor {
+	t.Helper()
+	if cfg == nil || cfg.Chassis.Cluster == nil {
+		t.Fatal("compiled config carries no chassis cluster")
+	}
+	rgs := cfg.Chassis.Cluster.RedundancyGroups
+	if len(rgs) != 1 {
+		t.Fatalf("expected 1 redundancy-group, got %d", len(rgs))
+	}
+	return rgs[0].InterfaceMonitors
+}

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -241,6 +241,18 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 				// weight, which starts at 255 (group_state.go:29,
 				// SetMonitorWeight election.go:324); heartbeat monitor
 				// entries carry weight as uint8.
+				//
+				// #6549: unlike interface-monitor weight, these leaves
+				// have NO compiled-int gate in
+				// validateChassisClusterStrict — this ValidateInteger is
+				// their only commit-side defense, and compileTreeLenient
+				// downgrades it to a warning on Store.Load /
+				// Store.SyncApply (#1960 no-brick). An out-of-range value
+				// therefore REACHES runtime, where pkg/cluster bounds it:
+				// Monitor.ipTargetWeight and the aggregate branch of
+				// desiredRGIPDebts (which also protects the cumulative
+				// global-threshold sum a negative weight would otherwise
+				// mask), plus the Manager.SetMonitorWeight chokepoint.
 				"global-weight": {
 					desc:          "Default weight deducted when a monitored IP fails (0..255)",
 					args:          1,

--- a/pkg/config/schema_chassis.go
+++ b/pkg/config/schema_chassis.go
@@ -222,12 +222,19 @@ var schemaChassis = &schemaNode{desc: "Chassis configuration", children: map[str
 				children:      nil,
 			},
 			"preempt": {desc: "Allow a higher-priority node to preempt the primary role", children: nil},
-			// interface-monitor weight is NOT typed in PR 2: the
+			// interface-monitor weight is NOT typed here: the
 			// `<ifname> weight <n>` tokens pack inline into one leaf
 			// (children==nil here); typing the weight would require a
 			// children/wildcard map, which flips SetPath's
 			// replace-vs-container grouping — forbidden by the
-			// fields-only rule. Deferred (docs/config-schema.md).
+			// fields-only rule. Its 0..255 range is instead enforced on
+			// the COMPILED *Config by validateChassisClusterStrict
+			// (compiler_validate_strict_chassis.go, #6549), the same
+			// place the #4434 RG-id and #4880 node-priority wire-width
+			// gates live — which covers BOTH parser shapes at once
+			// rather than only the flat-set one a typed leaf would see.
+			// Mirrors the vrrp `priority-cost` deferral
+			// (schema_interfaces.go). See docs/config-schema.md.
 			"interface-monitor": {desc: "Deduct weight from the redundancy group while a monitored interface is down", children: nil},
 			"ip-monitoring": {desc: "Probe monitored IPs and deduct weight on failure", children: map[string]*schemaNode{
 				// Junos vSRX: 0..255. Weight subtracted from the RG

--- a/pkg/grpcapi/cluster_monitor_weight_6549_test.go
+++ b/pkg/grpcapi/cluster_monitor_weight_6549_test.go
@@ -1,0 +1,197 @@
+package grpcapi
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/routing"
+	"github.com/vishvananda/netlink"
+)
+
+// #6549: `show chassis cluster interfaces` must report the interface-monitor
+// weight the ELECTION APPLIES, not the raw configured one.
+//
+// An out-of-range weight (`interface-monitor ge-0/0/1 weight -100`) is rejected
+// at commit but survives the TOLERANT paths — Store.Load of a persisted config
+// and Store.SyncApply of a peer-pushed one, where compileTreeLenient downgrades
+// the gate to a warning so a node never bricks (#1960). The runtime then bounds
+// it to [0,255]. Rendering the raw value would be an observability lie on
+// exactly the config where the operator most needs the truth: the display would
+// claim a monitor contributes -100 while the election contributes 0.
+//
+// buildInterfacesInput fills monitor weights from two sources, and both are
+// covered here:
+//
+//   - the LIVE routing statuses (server_cluster.go, the `if` branch), bounded
+//     at their source in pkg/routing/monitor.go;
+//   - the config-only FALLBACK fills (the `else` branch for a local monitor
+//     with no live status, and the peer branch for a monitor that belongs to
+//     the peer node so no local link exists).
+//
+// The harness drives the REAL tolerant ingress (Store.SyncApply) rather than
+// hand-building a compiled config, so the test also proves the weight actually
+// survives that path unbounded and has to be handled downstream.
+
+// monWeightFakeLink is a netlink.Link carrying caller-chosen attrs.
+type monWeightFakeLink struct {
+	attrs netlink.LinkAttrs
+}
+
+func (l *monWeightFakeLink) Attrs() *netlink.LinkAttrs { return &l.attrs }
+func (l *monWeightFakeLink) Type() string              { return "mon-weight-fake" }
+
+// monWeightFakeOps satisfies pkg/routing's (unexported) linkOps structurally.
+// Only LinkByName is meaningful for the interface-monitor sweep; a name that is
+// absent models a PEER-owned interface, which routing skips — that is what
+// leaves a configured monitor with no live status and routes it to the
+// config-only peer fill.
+type monWeightFakeOps struct {
+	links map[string]netlink.Link
+}
+
+func (o *monWeightFakeOps) LinkByName(name string) (netlink.Link, error) {
+	if l, ok := o.links[name]; ok {
+		return l, nil
+	}
+	return nil, net.UnknownNetworkError("not found: " + name)
+}
+
+func (o *monWeightFakeOps) LinkAdd(netlink.Link) error                     { return nil }
+func (o *monWeightFakeOps) LinkDel(netlink.Link) error                     { return nil }
+func (o *monWeightFakeOps) LinkSetUp(netlink.Link) error                   { return nil }
+func (o *monWeightFakeOps) LinkSetDown(netlink.Link) error                 { return nil }
+func (o *monWeightFakeOps) LinkSetMaster(netlink.Link, netlink.Link) error { return nil }
+func (o *monWeightFakeOps) LinkSetNoMaster(netlink.Link) error             { return nil }
+func (o *monWeightFakeOps) LinkSetMTU(netlink.Link, int) error             { return nil }
+func (o *monWeightFakeOps) LinkList() ([]netlink.Link, error)              { return nil, nil }
+func (o *monWeightFakeOps) AddrAdd(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *monWeightFakeOps) AddrDel(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *monWeightFakeOps) AddrList(netlink.Link, int) ([]netlink.Addr, error) {
+	return nil, nil
+}
+
+// outOfRangeMonitorConfig is a chassis-cluster config carrying an out-of-range
+// interface-monitor weight on each of two monitors. `local0` exists as a link
+// in the fake netlink surface; `peer0` does not, modelling a peer-owned member.
+//
+// The CONTAINER-hierarchical spelling is deliberate: the packed form
+// (`interface-monitor <if> weight <n>;` directly under redundancy-group)
+// compiles to ZERO monitors, a separate defect tracked as #6588. Using it here
+// would make this test silently vacuous, which is why syncOutOfRangeMonitors
+// asserts the monitors actually compiled before proceeding.
+const outOfRangeMonitorConfig = `
+chassis {
+    cluster {
+        control-interface em0;
+        fabric-interface fab0;
+        reth-count 2;
+        redundancy-group 0 {
+            node 0 priority 200;
+            node 1 priority 100;
+            interface-monitor {
+                local0 weight -100;
+                peer0 weight 100000;
+            }
+        }
+    }
+}
+`
+
+// syncOutOfRangeMonitors pushes outOfRangeMonitorConfig through the REAL
+// tolerant peer-sync ingress and returns the store. It fails the test if the
+// lenient compile does not in fact preserve the raw out-of-range weight —
+// without that precondition the rest of the test would be vacuous.
+func syncOutOfRangeMonitors(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	cfg, err := store.SyncApply(outOfRangeMonitorConfig, nil)
+	if err != nil {
+		t.Fatalf("SyncApply(out-of-range monitor weight): %v", err)
+	}
+	if cfg == nil || cfg.Chassis.Cluster == nil || len(cfg.Chassis.Cluster.RedundancyGroups) != 1 {
+		t.Fatalf("tolerant sync did not compile the chassis cluster: %+v", cfg)
+	}
+	raw := map[string]int{}
+	for _, mon := range cfg.Chassis.Cluster.RedundancyGroups[0].InterfaceMonitors {
+		raw[mon.Interface] = mon.Weight
+	}
+	if raw["local0"] != -100 || raw["peer0"] != 100000 {
+		t.Fatalf("precondition: the tolerant path was expected to PRESERVE the "+
+			"raw out-of-range weights (that is what makes the display clamp "+
+			"necessary); got %+v", raw)
+	}
+	return &Server{store: store}
+}
+
+// TestShowClusterInterfaces_MonitorWeightIsTheEffectiveOne_6549 covers all three
+// weight fills.
+//
+// Fail-on-revert:
+//   - restore `Weight: mon.Weight` at either config-only fill in
+//     server_cluster.go and the corresponding row reports -100 / 100000;
+//   - restore `Weight: mon.Weight` in pkg/routing/monitor.go and the LIVE row
+//     reports -100.
+func TestShowClusterInterfaces_MonitorWeightIsTheEffectiveOne_6549(t *testing.T) {
+	t.Run("config-only fill (no live routing statuses)", func(t *testing.T) {
+		s := syncOutOfRangeMonitors(t)
+		// s.routing stays nil: every monitor falls to the config-only fill.
+		input := s.buildInterfacesInput()
+		assertEffectiveMonitorWeights(t, input.Monitors, map[string]int{
+			"local0": 0, "peer0": 255,
+		})
+	})
+
+	t.Run("live routing statuses + peer config-only fill", func(t *testing.T) {
+		s := syncOutOfRangeMonitors(t)
+
+		// local0 exists as a link; peer0 does not, so the routing sweep emits
+		// a status for local0 only and peer0 falls to the peer config fill.
+		linux := config.LinuxIfName("local0")
+		s.routing = routing.NewManagerWithLinkOpsForTest(&monWeightFakeOps{
+			links: map[string]netlink.Link{
+				linux: &monWeightFakeLink{attrs: netlink.LinkAttrs{
+					Name: linux, OperState: netlink.OperUp,
+				}},
+			},
+		})
+		s.cluster = cluster.NewManager(0, 1)
+
+		cfg := s.store.ActiveConfig()
+		s.routing.ApplyInterfaceMonitors(cfg.Chassis.Cluster.RedundancyGroups)
+
+		input := s.buildInterfacesInput()
+		assertEffectiveMonitorWeights(t, input.Monitors, map[string]int{"local0": 0})
+		assertEffectiveMonitorWeights(t, input.PeerMonitors, map[string]int{"peer0": 255})
+	})
+}
+
+// assertEffectiveMonitorWeights checks that every named monitor is present with
+// the effective (bounded) weight, and that no rendered weight escapes [0,255].
+func assertEffectiveMonitorWeights(t *testing.T, got []cluster.InterfaceMonitorInfo, want map[string]int) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, m := range got {
+		if m.Weight < 0 || m.Weight > 255 {
+			t.Errorf("monitor %s rendered weight %d, which escapes the [0,255] "+
+				"domain the election applies", m.Interface, m.Weight)
+		}
+		w, ok := want[m.Interface]
+		if !ok {
+			continue
+		}
+		seen[m.Interface] = true
+		if m.Weight != w {
+			t.Errorf("monitor %s rendered weight %d, want the effective %d — "+
+				"the display reports a weight the election does not use",
+				m.Interface, m.Weight, w)
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("monitor %s missing from the rendered set %+v", name, got)
+		}
+	}
+}

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -92,9 +92,16 @@ func (s *Server) buildInterfacesInput() cluster.InterfacesInput {
 			// Up:false. Display path only — the failover decision reads the
 			// live routing statuses, not this fallback.
 			for _, mon := range rg.InterfaceMonitors {
+				// #6549: render the weight the election would APPLY, not the
+				// raw configured one. An out-of-range weight survives the
+				// tolerant load / peer-sync compile (#1960 no-brick) and the
+				// runtime bounds it to [0,255]; reporting the raw value here
+				// would be an observability lie on exactly the config where
+				// the operator most needs the truth.
+				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.Monitors = append(input.Monitors, cluster.InterfaceMonitorInfo{
 					Interface:       mon.Interface,
-					Weight:          mon.Weight,
+					Weight:          w,
 					Up:              false,
 					RedundancyGroup: rg.ID,
 				})
@@ -120,9 +127,12 @@ func (s *Server) buildInterfacesInput() cluster.InterfacesInput {
 				if peerMap[mon.Interface] {
 					continue
 				}
+				// #6549: the peer bounds this weight the same way we do, so
+				// render the effective value rather than the raw config one.
+				w, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
 				input.PeerMonitors = append(input.PeerMonitors, cluster.InterfaceMonitorInfo{
 					Interface:       mon.Interface,
-					Weight:          mon.Weight,
+					Weight:          w,
 					Up:              false,
 					RedundancyGroup: rg.ID,
 				})

--- a/pkg/routing/monitor.go
+++ b/pkg/routing/monitor.go
@@ -38,6 +38,20 @@ func (mm *monitorManager) Apply(groups []*config.RedundancyGroup) {
 	for _, rg := range groups {
 		var statuses []InterfaceMonitorStatus
 		for _, mon := range rg.InterfaceMonitors {
+			// #6549: bound the configured weight to the [0,255] heartbeat
+			// weight domain. These statuses are not display-only — the daemon
+			// config-apply tail feeds them straight into
+			// cluster.Manager.SetMonitorWeight as election debt
+			// (daemon_apply_tail.go), so the raw value would install
+			// out-of-range debt; and `show chassis cluster interfaces` renders
+			// them, so a raw value would report a weight the election does not
+			// use. The strict commit path rejects an out-of-range weight; the
+			// tolerant load / peer-sync path only warns (#1960 no-brick), so
+			// one can still reach here. Deliberately not logged: the cluster
+			// manager emits the config-apply-frequency warning
+			// (reconcileMonitorDebtsLocked / SetMonitorWeight).
+			weight, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
+
 			// Translate Junos name (ge-0/0/0) to Linux name (ge-0-0-0).
 			linuxName := config.LinuxIfName(mon.Interface)
 			link, err := mm.ops.LinkByName(linuxName)
@@ -48,14 +62,14 @@ func (mm *monitorManager) Apply(groups []*config.RedundancyGroup) {
 			up := linkAttrsUp(link.Attrs())
 			statuses = append(statuses, InterfaceMonitorStatus{
 				Interface: mon.Interface,
-				Weight:    mon.Weight,
+				Weight:    weight,
 				Up:        up,
 			})
 			if !up {
 				slog.Warn("interface monitor: link down",
 					"redundancy_group", rg.ID,
 					"interface", mon.Interface,
-					"weight", mon.Weight)
+					"weight", weight)
 			}
 		}
 		if len(statuses) > 0 {

--- a/pkg/routing/monitor.go
+++ b/pkg/routing/monitor.go
@@ -48,8 +48,11 @@ func (mm *monitorManager) Apply(groups []*config.RedundancyGroup) {
 			// use. The strict commit path rejects an out-of-range weight; the
 			// tolerant load / peer-sync path only warns (#1960 no-brick), so
 			// one can still reach here. Deliberately not logged: the cluster
-			// manager emits the config-apply-frequency warning
-			// (reconcileMonitorDebtsLocked / SetMonitorWeight).
+			// manager's reconcileMonitorDebtsLocked already reports this
+			// weight once per config apply, against the config that carried
+			// it. (Because this clamp runs first, the SetMonitorWeight
+			// chokepoint sees an already-bounded value and stays silent — its
+			// warning fires only for a producer that skipped its own clamp.)
 			weight, _ := config.ClampInterfaceMonitorWeight(mon.Weight)
 
 			// Translate Junos name (ge-0/0/0) to Linux name (ge-0-0-0).

--- a/pkg/routing/monitor_weight_6549_test.go
+++ b/pkg/routing/monitor_weight_6549_test.go
@@ -1,0 +1,92 @@
+package routing
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #6549: InterfaceMonitorStatus.Weight must carry the EFFECTIVE monitor weight,
+// bounded to the [0,255] heartbeat weight domain — not the raw configured one.
+//
+// These statuses are not display-only. pkg/daemon's config-apply tail feeds
+// them straight into cluster.Manager.SetMonitorWeight as election debt on every
+// commit / boot Load / peer SyncApply:
+//
+//	d.routing.ApplyInterfaceMonitors(cfg.Chassis.Cluster.RedundancyGroups)
+//	d.cluster.UpdateConfig(cfg.Chassis.Cluster)
+//	d.cluster.SetMonitorWeight(rgID, st.Interface, !st.Up, st.Weight)
+//
+// A raw negative weight there is negative DEBT: it credits weight back and
+// cancels a genuinely dead sibling link, leaving the node primary on dead
+// links. They are ALSO what `show chassis cluster interfaces` renders for a
+// live monitor, so a raw value is simultaneously an observability lie.
+//
+// An out-of-range weight is rejected at commit but survives the TOLERANT paths
+// (Store.Load of a persisted config, Store.SyncApply of a peer-pushed one),
+// where compileTreeLenient downgrades the gate to a warning so a node never
+// bricks (#1960).
+//
+// Fail-on-revert: restore `Weight: mon.Weight` in monitorManager.Apply and
+// every out-of-range row reports the raw value.
+func TestInterfaceMonitorStatus_WeightIsBounded_6549(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		want       int
+	}{
+		// Over-reach guard: legal weights must be reported verbatim.
+		{"legal-zero", 0, 0},
+		{"legal-one", 1, 1},
+		{"legal-half", 128, 128},
+		{"legal-max", 255, 255},
+		// Out-of-range: bounded into the domain.
+		{"negative-small", -1, 0},
+		{"negative-large", -100, 0},
+		{"over-max", 256, 255},
+		{"over-max-large", 100000, 255},
+	}
+
+	const ifName = "ge-0/0/0"
+	linuxName := config.LinuxIfName(ifName)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, up := range []bool{true, false} {
+				var oper netlink.LinkOperState = netlink.OperDown
+				if up {
+					oper = netlink.OperUp
+				}
+				mm := &monitorManager{
+					ops: &monitorFakeOps{links: map[string]netlink.Link{
+						linuxName: &monitorFakeLink{attrs: netlink.LinkAttrs{
+							Name:      linuxName,
+							OperState: oper,
+							Flags:     net.FlagUp,
+						}},
+					}},
+					monitorStatus: make(map[int][]InterfaceMonitorStatus),
+				}
+
+				mm.Apply([]*config.RedundancyGroup{{
+					ID: 0,
+					InterfaceMonitors: []*config.InterfaceMonitor{
+						{Interface: ifName, Weight: tt.configured},
+					},
+				}})
+
+				statuses := mm.Statuses()[0]
+				if len(statuses) != 1 {
+					t.Fatalf("up=%v: expected 1 status, got %d", up, len(statuses))
+				}
+				if statuses[0].Weight != tt.want {
+					t.Errorf("up=%v: configured weight %d reported as %d, want the "+
+						"effective %d — the daemon apply tail installs this value "+
+						"as election debt", up, tt.configured, statuses[0].Weight, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6549

## Mechanism — verified firsthand, the report is correct

The divergence claim was the load-bearing part of the issue, so I traced it
rather than implementing to it:

- `HeartbeatGroup.Weight` **is** a `uint8` (`pkg/cluster/heartbeat.go:139`),
  and `HeartbeatMonitor.Weight` likewise (`:146`).
- `RedundancyGroupState.Weight` and `PeerGroupState.Weight` are both `int`.
- `buildHeartbeat` (`pkg/cluster/heartbeat_manager.go:276`) was the only
  narrowing point: `Weight: uint8(rg.Weight)`.
- `recalcWeight` computed `rg.Weight = 255 - totalLost` with a **floor but no
  ceiling** (`pkg/cluster/election.go`), so a negative debt escapes upward.

So `interface-monitor ge-0/0/0 weight -100` on a down monitor leaves the local
node at `rg.Weight == 355` while the peer decodes `uint8(355) == 99`. At base
priority 100 the local node computes its own effective priority as
`100*355/255 = 139`; the peer computes `100*99/255 = 38` for it. Two nodes,
identical state, different verdicts — both elect primary, duplicate VIP and
duplicate RETH virtual MAC on the LAN. Severity as filed is right.

**Second consequence the issue does not mention:** a negative weight is
*negative debt*, so it credits weight **back** and cancels a sibling monitor's
genuine failure. With `trust0 weight 255` and `trust1 weight -100`, both links
dead leaves the group at weight 100 and the node **still primary** — a
fail-open the `rg.Weight` range clamp alone does not catch, because the sum
stays inside `[0,255]`. Pinned by its own test.

## Fix — four layers

A schema-only gate would leave the exact attack path the issue describes wide
open: `Store.Load` and `Store.SyncApply` compile via `CompileConfigLenient`,
which by design downgrades this class of gate to a warning so an
already-persisted or peer-pushed config still boots (#1960).

1. **Commit gate** — `validateChassisClusterStrict` now range-checks every
   compiled `InterfaceMonitor.Weight` against `0..255`, next to the #4434
   RG-id and #4880 node-priority wire-width checks it already carries. Same
   failure shape, same `lenientChassisRG` downgrade. Gating the **compiled
   int** rather than the AST covers both parser shapes at once.

   *(Why not a typed schema leaf: `interface-monitor` packs `<ifname> weight
   <n>` onto one node key, so typing it needs a children map, which flips
   SetPath's replace-vs-container grouping. Same reason vrrp `priority-cost`
   is gated outside the schema. The schema comment now points at the gate.)*

2. **Runtime debt clamp** — `config.ClampInterfaceMonitorWeight` (mirroring
   `ClampGratuitousARPCount`, #5695) bounds the configured weight where
   `pkg/cluster` reads it: `pollInterfaceMonitors` and
   `reconcileMonitorDebtsLocked`. This is what closes the lenient path, and
   what closes the debt-cancellation fail-open above.

3. **Weight-domain belt** — `rgWeightFromDebt` replaces the triplicated
   `255 - totalLost` in `recalcWeight`, `reconcileMonitorDebtsLocked` and
   `manualFailoverRestoreWeightLocked`, closing `rg.Weight` to `[0,255]` for
   **every** debt source (interface monitors, ip-monitoring targets, any
   future `SetMonitorWeight` caller). This is the layer that makes local and
   advertised provably equal — a marshal-side clamp alone would still leave
   the local view (355) disagreeing with the wire (255).

4. **Marshal boundary** — `clampWireWeight` saturates instead of wrapping, so
   a writer bypassing the helpers above degrades to a bounded, monotonic
   weight rather than aliasing to an unrelated one.

**No-brick posture** follows #1960: strict commit rejects, the tolerant path
warns (`cfg.Warnings` + a config-apply-frequency `slog.Warn`, never per-poll)
and clamps. A persisted config is never refused at load.

To be precise about the ip-monitoring siblings — an earlier revision of this
body claimed this "matches" them, which oversold their safety. They carry **no
compiled-int commit gate at all**; their only defense was the schema
`ValidateInteger(0, 255)`, which `compileTreeLenient` downgrades to a warning
on exactly the `Store.Load` / `Store.SyncApply` paths that matter. This
stanza's posture is **stronger** than theirs, not consistent with it — and the
review fold below closes their runtime residual too.

## Fail-on-revert — verified per layer, all assertion failures

| Revert | Result |
|---|---|
| Neutralize the commit gate | 7 out-of-range configs commit clean; lenient warning disappears |
| Drop the `rgWeightFromDebt` ceiling | `local weight 355 but advertised 255`, and `100255` / `511` / `256` escape the domain |
| Drop the clamp in `reconcileMonitorDebtsLocked` | `weight after reconciling an out-of-range monitor weight = 100, want 0` — negative weight cancelled a real failure |
| Drop the clamp in `pollInterfaceMonitors` | same fail-open on the live poll path, plus `local monitor status weight -100 but advertised 0` |

Each revert was applied in place (no checkout), and each produces an
**assertion** failure, not a build break.

The cluster tests drive the **real** marshal — `m.buildHeartbeat()` →
`MarshalHeartbeat` → `UnmarshalHeartbeat` — and the **real** poll path via the
existing mock-netlink harness, not re-implementations.

**Over-reach guard:** weights `0 / 1 / 128 / 254 / 255` still commit, still
compile to exactly the configured value, and still marshal identically; an
`interface-monitor` with no `weight` token still commits at the pre-existing
default of 0. Both are green under every revert above.

## Audit of the sibling leaves (issue requirement 6)

Mechanically enumerated every `chassis` schema node with a value slot
(`args >= 1`) and no validator. Nine hits, **none** in this bug class:

- `redundancy-group`, RG-scoped `node` — instance-name identity slots, already
  gated twice (#5694 malformed-token AST walk, #4434/#4880 compiled ranges).
- `control-ports fpc` / `port` — documented as never read by `compileChassis`;
  a value that is never compiled reaches no runtime.
- `authentication-key` — secret string, deliberately untyped, mirrors the
  OSPF/IS-IS/RIP leaves. No numeric domain, no wire narrowing.
- `control-interface`, `fabric-interface`, `peer-address`,
  `fabric-peer-address` — a documented *cross-cutting* deferral pending the
  interfaces PR's IP/identifier value types, not a one-line-per-leaf fix.

`interface-monitor` did not even appear in that scan: it is the only node with
`args: 0` **and** `children: nil` that nonetheless carries a value — which is
exactly why it slipped through both the typed-leaf review and the identity-slot
review. Nothing else fixed here.

## Separate pre-existing bug found (not fixed here)

The **packed hierarchical** spelling, `interface-monitor ge-0/0/0 weight 255;`
written directly under `redundancy-group` in a braces file, compiles to **zero**
monitors — `compileChassis` only walks `child.Children`, and that shape packs
everything onto the `interface-monitor` node's own `Keys`. The operator gets a
monitor that silently never demotes on link-down (fail-open). Confirmed by
direct compile: `rgs=1 monitors=0`.

Not reachable from `set` (the renderer emits the container form, which
round-trips correctly), so it only bites a hand-authored or `load`ed braces
config. Out of scope for this issue, and now **filed as #6588**. The
`docs/config-schema.md` note has been narrowed accordingly: the compiled-int
gate covers the flat-set and container-hierarchical shapes, not the packed
one-liner.

## Validation

- Full `pkg/config` and `pkg/cluster` suites: **pass**.
- Rest of the Go suite: **clean** on the current head. (`TestHeatmapNotStale`
  failed while this branch was based on `fff7a4ab5`; verified **pre-existing**
  by running it at `origin/master` `a680161ca` in a detached worktree, where
  the canary output was **byte-identical** to the branch's — this change shifts
  nothing in the heatmap. Master has since regenerated it and the canary
  passes.)
- Docs updated: `docs/config-schema.md` (the chassis untyped-leaf section) and
  the `schema_chassis.go` deferral comment now point at the gate.

⚠️ **HA change — `make test-failover` required before merge.** Not run here;
the loss cluster is shared and the parent serializes all smoke.

---

# Review fold — the fix was incomplete, and the daemon path UNDID it

Hostile review (CHANGES REQUESTED, 1 MAJOR / 2 MINOR / 2 NOTE) found a **fifth
producer** of monitor debt that the four layers above did not enumerate. I
reproduced it against the unfixed head before writing any fix.

## MAJOR — the daemon config-apply tail overwrote the layer-2 clamp

`pkg/daemon/daemon_apply_tail.go` runs three steps on **every** config apply:

```
ApplyInterfaceMonitors(...)   ->  pkg/routing copies mon.Weight VERBATIM
UpdateConfig(...)             ->  reconcileMonitorDebtsLocked CLAMPS (layer 2)
SetMonitorWeight(..., st.Weight)  ->  installs the RAW weight, six lines later
```

Reproduced with `trust0 weight 255` + `trust1 weight -100`, both links down —
the clamp fires and is then discarded:

```
WARN  cluster: interface-monitor weight out of range, clamped rg=0 interface=trust1 configured=-100 effective=0
WARN  cluster: interface monitor failure rg=0 interface=trust1 weight=-100   <-- RAW installed
INFO  cluster: weight changed rg=0 old=0 new=100
INFO  cluster: primary transition rg=0
```

It is **persistent**, not a transient window: `pollInterfaceMonitors` re-fires
`SetMonitorWeight` only on a dampened state *transition*, and a link that was
already down before the apply produces none. And with the clamped poll path
running first, the apply tail **regresses a correctly-demoted group** 0 -> 100.

**Fixed at the chokepoint, not by enumerating producers.**
`Manager.SetMonitorWeight` clamps every debt on the way in. With
`reconcileMonitorDebtsLocked` it owns **both of the only two writes** into
`m.monitorWeights`, so the domain is closed against the daemon tail, the
interface-monitor poll, ip-monitoring debts, and any future caller.

## Beyond the review — NOTE 1 is only half closed by that, and the other half is worse

The review expected the chokepoint to close the ip-monitoring residual "for
free". It does for independent mode. It does **not** for global-threshold mode,
and I reproduced a sharper fail-open there:

`desiredRGIPDebts` accumulates `cumulative += ipTargetWeight(...)` over
unreachable targets and installs the aggregate debt only while
`cumulative >= global-threshold`. A **negative** target weight *subtracts* from
that sum — so a **second** genuinely unreachable target pushes it back below the
threshold and drops the debt the **first** failure correctly installed:

```
A unreachable only   (cumulative 255 >= 200):  weight=0   primary=false
A AND B unreachable  (cumulative 155 <  200):  weight=255 primary=true
```

**More failures produce less demotion.** The chokepoint cannot see it — no debt
is desired, so `SetMonitorWeight` is never called. Closed by bounding
`Monitor.ipTargetWeight` (and the aggregate branch of `desiredRGIPDebts`, which
also keeps the `ipDebts` ledger and its `RecordEvent` equal to what the election
applies). NOTE 1 is now fully closed; no follow-up issue needed.

## Both MINORs folded

- **MINOR 1** — the `clampWireWeight` **call sites** are now bound. Previously
  only the function was tested, so reverting `buildHeartbeat` to `uint8(...)`
  produced zero failures. The new test injects an out-of-domain weight under
  `m.mu` on both marshal paths; on revert it fails with the exact aliasing
  (355 -> 99, -100 -> 156).
- **MINOR 2** — `pkg/routing/monitor.go` bounds the status weight at its
  source. These statuses are **election input**, not display-only, so this is
  the producer-side half of the MAJOR as well as the observability fix. The
  four config-only display fills in `pkg/grpcapi` + `pkg/cli` also render the
  effective weight, so `show chassis cluster interfaces` never reports a weight
  the election does not apply.
- **NOTE 2** — filed as **#6588**, not folded (correctly scoped out).

## Fail-on-revert — per guard, all assertions, `go vet` clean

| Revert | Result |
|---|---|
| Clamp in `Manager.SetMonitorWeight` | `SetMonitorWeight(-100) installed debt -100, want 0` (+3 rows) |
| Clamp in `Monitor.ipTargetWeight` | `weight after a SECOND target went unreachable = 255, want 0` |
| Clamp in `desiredRGIPDebts` aggregate | `ipDebts ledger recorded -100, want the effective 0` (+1) |
| Clamp in `pkg/routing/monitor.go` | 8 rows in `pkg/routing`, plus the LIVE display row in **both** `pkg/grpcapi` and `pkg/cli` |
| Both `pkg/grpcapi` display fills | `monitor local0 rendered weight -100, want the effective 0` (+3) |
| Both `pkg/cli` display fills | same, in the CLI twin |
| Both `clampWireWeight` call sites | `injected rg.Weight 355 advertised as 99, want 255` (+3) |

Every revert was applied in place via edit (never `git checkout`) and kept the
code **compiling** — `go vet` clean on all seven, so each red is a genuine
assertion failure, not a build break. The legal-weight over-reach guards
(0, 1, 128, 254, 255) stayed **green under every one of them**.

## Test binders added

Driving the **real** producers, not hand-rolled equivalents — the cluster tests
run `pkg/routing`'s actual `Manager` against a fake netlink surface in the
daemon's exact call order, and the display tests push the out-of-range config
through the **real** `Store.SyncApply` tolerant ingress (asserting first that it
genuinely survives that path, so the test cannot go vacuous):

- `pkg/cluster/ifmon_weight_daemon_apply_6549_test.go` — daemon apply tail
  (fail-open + clamp-regression), ip-monitoring independent + global-threshold,
  the `SetMonitorWeight` domain, and the wire-weight call sites.
- `pkg/routing/monitor_weight_6549_test.go` — status weight bounded, link up
  and down.
- `pkg/grpcapi/` + `pkg/cli/cluster_monitor_weight_6549_test.go` — all three
  display fills.

Both fixture configs use the **container-hierarchical** `interface-monitor`
spelling deliberately: the packed form compiles to zero monitors (#6588) and
would have made them silently vacuous. That is not hypothetical — my first
fixture used it and the precondition assert caught it.

## Validation after the fold

Full `pkg/cluster`, `pkg/config`, `pkg/daemon`, `pkg/routing`, `pkg/grpcapi`
and `pkg/cli` suites pass on a **fresh GOCACHE**, with every new subtest
confirmed to have run **by name** in `-v` (guarding the stale-cache
silently-skipped-subtest trap). `go test ./...` clean. Rebased onto current
master; the `_Log.md` conflict was unioned.

⚠️ **`make test-failover` still needs re-running after this fold** — the fix
lands inside `SetMonitorWeight`, the function every failover-driven demotion
calls. Not run here; cluster access is serialized by the parent.

---

# Round 2 — Codex re-review (MERGE-NEEDS-MINOR): label + comment corrections

**Comment-only. No production line changed** (verified by filtering the diff to
non-comment lines), so the banked cluster smoke still holds.

Codex accepted the fix and the clamp-to-0 adjudication ("I found no
counterargument defeating the peer-push denial-of-service reasoning"), and
flagged that three tests were **labelled** as `Manager.SetMonitorWeight`
chokepoint guards that the fold's own upstream clamps now mask. I reproduced it
rather than taking it on faith — a compile-clean chokepoint removal, `go vet`
clean so it is a real mutation and not a build break:

```
--- FAIL: TestSetMonitorWeight_ClosesTheDebtDomain_6549
--- PASS: TestDaemonApplyTail_OutOfRangeWeightCannotCancelARealFailure_6549
--- PASS: TestDaemonApplyTail_CannotRegressAClampedDebt_6549
--- PASS: TestIPMonitor_OutOfRangeWeightCannotCancelARealFailure_6549
        ...10 more PASS
```

Pairwise mutation then established what those three **do** bind: the two daemon
cases fail only when the `pkg/routing` clamp **and** the chokepoint are both
removed; the independent-IP case only when `ipTargetWeight` **and** the
chokepoint are both removed. Either clamp alone keeps the end-to-end path safe
— that is the layering working as intended.

**Coverage was never missing**, so this is fixed by relabelling, not by padding
with redundant tests to make the old wording true. Every clamp has a dedicated
binder that fails alone:

| Clamp | Dedicated binder |
|---|---|
| `Manager.SetMonitorWeight` | `TestSetMonitorWeight_ClosesTheDebtDomain_6549` |
| `pkg/routing` `monitorManager.Apply` | `TestInterfaceMonitorStatus_WeightIsBounded_6549` |
| `Monitor.ipTargetWeight` | `TestIPMonitor_NegativeWeightCannotMaskTheGlobalThreshold_6549` |

Three comments still described the **pre-fold** flow and were false: `election.go`
claimed `ipTargetWeight` is unbounded and that the chokepoint is the
ip-monitoring class's only runtime defense; the test preamble said `pkg/routing`
copies the weight verbatim; and the warn-site claimed to be the ONLY
out-of-range signal ip debts get. That last one was the one that could actually
mislead — someone chasing a *missing* warning would have trusted it and searched
the wrong file. It now says reaching that branch means a producer skipped its
own clamp, and points at `reconcileMonitorDebtsLocked` / `ipTargetWeight`.

Also recorded the **clamp-direction adjudication at the clamp itself** so it is
not re-litigated: negative maps to 0, not 255, because clamp-255 turns a typo'd
weight arriving over HA config-sync into an instant redundancy-group
resignation on the *receiving* node — a remote HA denial-of-service — whereas 0
is an already-legal operator-reachable state (a weight-less `interface-monitor`
compiles to exactly 0), is loud via WARN, and is unreachable from the local
authoring path at all.

Rebased onto master `9ba645c78`; `_Log.md` conflict unioned. Full `pkg/cluster`,
`pkg/config`, `pkg/routing`, `pkg/grpcapi`, `pkg/cli` suites green on a fresh
GOCACHE; `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi


