### PR TITLE
fix(daemon): constrain fabric peer-MAC NDP fallback to the peer identity

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -61908,3 +61908,37 @@ would never produce.
   22.7 Gbps) and needs no re-run for a comment-only change.
 - **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
     pkg/routing/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6554 — constrain the fabric peer-MAC IPv6-NDP fallback to the
+  peer's identity. `refreshFabricFwd`'s last-resort leg swept the fabric
+  parent's IPv6 NDP table (deliberately seeded by the `ff02::1` all-nodes probe
+  in `probeFabricNeighbor`) and took the FIRST non-self link-local neighbour,
+  so on a shared fabric segment any IPv6-speaking adjacent host was accepted as
+  the peer chassis. Added `selectFabricPeerLinkLocalMAC`: accept only the
+  cached ADDRESS-MATCHED peer MAC when one is known, else the sole eligible
+  neighbour, refusing an ambiguous segment. The identity cache
+  (`d.fabricPeerMAC`/`fabricPeerMAC1`) is written only by address-matched
+  resolutions — never by the fallback, so a bad guess cannot self-confirm — and
+  is dropped when the configured peer address changes. Refusal is fail-closed
+  onto the pre-existing "peer neighbour missing" path.
+  IMPACT CORRECTION vs the issue text: the misdelivery claim is NOT reachable
+  on today's forwarding path. `FabricFwdInfo.PeerMAC` is written into the
+  `fabric_fwd` pinned array and read by nobody post-#1476 (the retained
+  `userspace-xdp` shim never references the map; `userspace-dp` never reads it;
+  no Go reader). The dataplane's actual redirect dst-MAC comes from
+  `FabricSnapshot.peer_mac` via `buildFabricPeerMAC`, which is address-matched.
+  The live defect is a FALSE-SUCCESS health signal: a decoy made the refresh
+  report success, latch `fabricPopulated` (which feeds the RG
+  takeover-readiness gate in `daemon_ha.go`), end the fast-retry probe loop
+  early, and log a stranger's MAC as the fabric peer during an HA incident.
+  Also rejected the issue's suggested RETH virtual-MAC-prefix constraint:
+  fabric members (`ge-0/0/0`) carry no `redundant-parent`, so they never get a
+  `02:bf:72:…` MAC and that constraint would reject the real peer.
+  Added `d.neighListFn` seam so the fail-on-revert test drives the real
+  `refreshFabricFwd` and asserts on the MAC handed to `SetFabricForwarding`.
+  Verified RED-on-revert is an ASSERTION failure (decoy programmed), with both
+  over-reach guards GREEN under revert. Full Go suite green.
+- **File(s)**: pkg/daemon/{daemon.go,daemon_ha_fabric.go,
+    daemon_ha_fabric_peer_identity_6554_test.go},
+    docs/fabric-cross-chassis-fwd.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -61976,3 +61976,27 @@ would never produce.
 - **File(s)**: pkg/daemon/{daemon.go,daemon_ha_fabric.go,
     daemon_ha_fabric_peer_identity_6554_test.go},
     docs/fabric-cross-chassis-fwd.md, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6554 review-fold round 2 (independent hostile review MINOR 1 +
+  MINOR 2). MINOR 1: documented the `SyncFabricState` coupling in
+  `docs/fabric-cross-chassis-fwd.md`. The peer-MAC RESOLVER is independent of
+  this path, but its refresh TRIGGER is not — `refreshFabricFwd` calls
+  `SyncFabricState` only on the success path, and that verb is the sole caller
+  of the Rust `Coordinator::refresh_fabric_links`, so a #6554 refusal also
+  withholds the push until the next full forwarding rebuild. Not a blackhole
+  (`resolve_fabric_redirect` returning None takes the safe non-fabric
+  disposition, per #5686) but a real latency coupling the "resolved
+  independently" wording did not cover. Deliberately did NOT add a
+  `SyncFabricState` call on the refusal path: this leg runs per neighbour event
+  plus a 30s tick plus the 2s `triggerFabricRefresh`, and CLAUDE.md forbids a
+  new control-socket caller above 1/s (starves session installs during bulk
+  sync) — so the coupling is documented, not removed. MINOR 2 was filed as
+  issue #6605 rather than folded: `buildFabricPeerMAC`
+  (pkg/dataplane/userspace/fabric.go) accepts NUD_FAILED/NUD_INCOMPLETE
+  neighbours and any-length lladdr for the LIVE redirect MAC, while
+  `refreshFabricFwd` requires `len==6` plus the `fabricNeighValidStates` mask —
+  the live resolver is measurably weaker than the code #6554 hardened, but it
+  is address-matched and a separate surface. Codex re-review of the folded head
+  918ea0b95 returned MERGE-READY with no findings.
+- **File(s)**: docs/fabric-cross-chassis-fwd.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -61942,3 +61942,37 @@ would never produce.
 - **File(s)**: pkg/daemon/{daemon.go,daemon_ha_fabric.go,
     daemon_ha_fabric_peer_identity_6554_test.go},
     docs/fabric-cross-chassis-fwd.md, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6554 review-fold (Codex MERGE-NEEDS-MINOR on PR #6595). Three
+  findings, all folded. (1) `populateFabricFwd` / `populateFabricFwd1` checked
+  `ctx.Done()` only inside the `i > 0` sleep arm, so iteration 0 ran
+  unconditionally — an already-cancelled caller still reached
+  `probeFabricNeighbor`, which dumps the kernel neighbour table and, on a miss,
+  transmits a raw ICMP probe plus an `ff02::1` solicitation on a live NIC.
+  Hoisted a `ctx.Err()` check to the top of both retry loops and pinned it with
+  `TestPopulateFabricFwdHonoursCancelledContextBeforeFirstProbe`, which asserts
+  ZERO netlink touches under a cancelled context (both siblings). (2)
+  `probeFabricNeighbor` called `netlink.LinkByName` / `netlink.NeighList`
+  directly, bypassing the `fabricLinkByName` / `fabricNeighList` seams the rest
+  of the refresh uses; routed both through the seams and made
+  `TestFabricPeerIdentityClearedOnPeerChange` hermetic by pinning the seams to
+  hard errors, so the test's safety no longer depends on the cancellation guard
+  surviving. The residual transmit hazard (a seam returning a synthetic link
+  with no matching neighbour still falls through to the probe transmits) is
+  documented at the function rather than papered over — the read seams are set
+  to the real netlink calls by the constructor, so seam-presence cannot gate the
+  transmit. (3) Corrected a disproven impact claim in the test message and in
+  `docs/fabric-cross-chassis-fwd.md`: verified firsthand that the MAC this path
+  programs lands in the retired-eBPF `fabric_fwd` map (`UpdateFabricFwd`,
+  pkg/dataplane/maps_fabric.go) while the live Rust redirect takes
+  `neighbor_mac` from `FabricSnapshot.PeerMAC`, which
+  `pkg/dataplane/userspace/fabric.go` re-derives with its own address-matched
+  `buildFabricPeerMAC` (no link-local fallback). A mis-identified peer therefore
+  never becomes an L2 destination — the damage is false readiness, a truncated
+  fast-retry probe loop, and a misleading `peer_mac` log line. Also ran
+  `gofmt -w pkg/daemon/daemon.go` (the PR's added struct fields broke the
+  comment alignment; master was clean).
+- **File(s)**: pkg/daemon/{daemon.go,daemon_ha_fabric.go,
+    daemon_ha_fabric_peer_identity_6554_test.go},
+    docs/fabric-cross-chassis-fwd.md, _Log.md

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -331,6 +331,70 @@ the parent interface. Two resolution passes build them:
   `SyncFabricState`/`refreshFabricFwd` (`update_fabrics` control verb) once
   ARP/NDP resolves the peer MAC that was unresolved at initial build.
 
+### Peer-MAC resolution is constrained to the peer's identity (#6554)
+
+Every peer-MAC resolution that reaches the dataplane is keyed on the
+**configured fabric peer address**:
+
+- `FabricSnapshot.peer_mac` comes from `buildFabricPeerMAC`
+  (`pkg/dataplane/userspace/fabric.go`) — an address-matched neighbour
+  lookup on the overlay, then the parent.
+- The Rust redirect's own late resolution
+  (`resolve_fabric_links_from_snapshots`) looks the peer up in
+  `dynamic_neighbors` keyed on `(ifindex, peer_addr)`.
+
+The Go daemon's `refreshFabricFwd` (`pkg/daemon/daemon_ha_fabric.go`) has
+one leg that has **no peer address to match on**: after overlay ARP and
+parent ARP both miss, it sweeps the fabric parent's IPv6 NDP table for a
+link-local neighbour. That table is deliberately seeded by pinging
+`ff02::1` (all-nodes link-local multicast) in `probeFabricNeighbor`, so
+**every** IPv6-speaking host on the fabric segment answers and lands in
+it. Before #6554 the sweep took the first non-self link-local entry it
+found — on a shared fabric segment that is an unrelated adjacent host.
+
+`selectFabricPeerLinkLocalMAC` now constrains the sweep to the peer's
+identity, strongest constraint first:
+
+1. **Known peer MAC.** `refreshFabricFwd`/`refreshFabricFwd1` cache the
+   MAC of every ADDRESS-MATCHED resolution (`d.fabricPeerMAC`,
+   `d.fabricPeerMAC1`) — the MAC that actually answered for the
+   configured peer address. When that identity is known, only a
+   neighbour bearing it is accepted. The cache is never written by the
+   fallback itself (a bad guess must not self-confirm) and is dropped
+   when the configured peer address changes, so a re-pointed fabric is
+   not pinned to the old chassis and a legitimately changed peer MAC
+   self-heals on the next address-matched resolution.
+2. **Checked point-to-point assumption.** On a cold start with no
+   address-matched observation yet — the crash-recovery case this
+   fallback exists for — the sole eligible neighbour is accepted and an
+   ambiguous segment (two or more distinct neighbour MACs) is refused.
+   Candidates are deduplicated by MAC, so a peer owning several
+   link-local addresses on one NIC still counts as one host.
+
+Ineligible entries never become candidates: a non-`fe80::/10` address, an
+unusable NUD state, a group-bit (multicast) MAC, or this node's own MAC.
+
+**Fail direction — refuse, do not fall back to permissive.** A refusal
+returns no MAC, which lands on the existing "peer neighbour missing"
+path: `retainFabricFwdOnNeighborMiss` keeps a previously-good
+`fabric_fwd` entry, otherwise `clearFabricFwd0` clears it and
+`fabricPopulated` stays false. That is the *same* state the node already
+occupies whenever the peer genuinely does not resolve on a normal fabric
+— not a new degradation mode. It does **not** blackhole cross-chassis
+traffic: the dataplane's redirect takes its destination MAC from
+`FabricSnapshot.peer_mac`, resolved independently and strictly by peer
+address. What a refusal does cost is the `fabricPopulated` latch, which
+feeds the RG takeover-readiness gate (`daemon_ha.go`, evaluated only
+while the peer is alive) — so the node advertises `fabric forwarding
+path not ready` instead of falsely reporting a fabric it cannot identify.
+Accepting a stranger's MAC was the worse failure: it reported success,
+latched readiness, ended the fast-retry probe loop early, and logged a
+peer MAC belonging to an unrelated host during an HA incident.
+
+Distinct from #6458, which validates the **receive** side (zone-encoded
+fabric-ingress stamps); this constrains the **daemon-side setup** that
+chooses the destination MAC.
+
 ### M13 — skipped fabric links are counted + named (was a silent `continue`)
 
 Before #3773 each pass dropped a fabric link on a bare `continue` when

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -408,6 +408,32 @@ cross-chassis frames. The damage is exactly the three effects listed
 above — false readiness, a truncated fast-retry probe loop, and a
 misleading `peer_mac` log line during an HA incident.
 
+One coupling that the word "independent" above does NOT cover, and that an
+operator debugging a slow fabric bring-up needs to know. The *resolver* is
+independent, but its *refresh trigger* is not: `refreshFabricFwd` calls
+`SyncFabricState` only on its SUCCESS path, and that verb is the sole caller of
+the Rust `Coordinator::refresh_fabric_links`
+(`userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs`) — i.e. the only thing
+that drives the helper's `dynamic_neighbors` late resolution outside a full
+forwarding rebuild. So when this path REFUSES an ambiguous peer, the push does
+not fire either.
+
+The one scenario where that is observable: the peer address is present in the
+helper's neighbour map but absent or NUD-invalid in the daemon's view, on an
+ambiguous segment. Before the #6554 constraint, the decoy made the refresh
+"succeed", which fired `SyncFabricState`, and Rust then resolved the CORRECT MAC
+by address. Now the push waits for the next full forwarding rebuild. This is not
+a blackhole — `resolve_fabric_redirect` returning `None` puts the packet on its
+normal non-fabric disposition, the same safe path #5686 relies on — but it is a
+real latency coupling, not an independence.
+
+Calling `SyncFabricState` on the refusal path as well is deliberately NOT done.
+This leg runs on every neighbour event plus the 30 s tick plus the 2 s
+reconcile-driven `triggerFabricRefresh`, and the control socket is shared with
+status poll, HA sync, session installs, and snapshot sync; CLAUDE.md is explicit
+that a new control-socket caller above 1/s starves session installs during bulk
+sync. The coupling is documented rather than removed.
+
 ### M13 — skipped fabric links are counted + named (was a silent `continue`)
 
 Before #3773 each pass dropped a fabric link on a bare `continue` when

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -392,8 +392,21 @@ latched readiness, ended the fast-retry probe loop early, and logged a
 peer MAC belonging to an unrelated host during an HA incident.
 
 Distinct from #6458, which validates the **receive** side (zone-encoded
-fabric-ingress stamps); this constrains the **daemon-side setup** that
-chooses the destination MAC.
+fabric-ingress stamps); this constrains the **daemon-side identity check**
+that decides when the fabric is declared ready.
+
+Scope limit, stated precisely because it bounds the severity: the MAC this
+path programs lands in the retired-eBPF `fabric_fwd` map
+(`UpdateFabricFwd`, `pkg/dataplane/maps_fabric.go`). The live Rust redirect
+does **not** read it — `resolve_fabric_redirect_from_list` takes
+`neighbor_mac` from `FabricSnapshot.PeerMAC`, which
+`pkg/dataplane/userspace/fabric.go` re-derives with its own
+**address-matched** neighbour lookup (`buildFabricPeerMAC`, which matches
+on `neigh.IP.Equal(peer)` and has no link-local fallback). So a
+mis-identified peer accepted here never becomes an L2 destination for
+cross-chassis frames. The damage is exactly the three effects listed
+above — false readiness, a truncated fast-retry probe loop, and a
+misleading `peer_mac` log line during an HA incident.
 
 ### M13 — skipped fabric links are counted + named (was a silent `continue`)
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -680,6 +680,17 @@ type Daemon struct {
 	fabricPeerIP1    net.IP        // secondary fabric peer IP
 	fabricPopulated  bool          // true after first successful fab0 write
 	fabric1Populated bool          // true after first successful fab1 write
+	// fabricPeerMAC / fabricPeerMAC1 cache the last peer MAC that was learned
+	// from an ADDRESS-MATCHED neighbour entry for the configured fabric peer
+	// (#6554). They are the identity the IPv6-NDP link-local fallback is
+	// constrained to: only a neighbour bearing this MAC may be accepted when
+	// the peer's fabric address itself does not resolve. Written only by an
+	// address-matched resolution (never by the fallback itself, which would
+	// let a bad guess self-confirm) and cleared when the configured peer
+	// address changes, so a re-pointed fabric cannot be pinned to the old
+	// peer's MAC.
+	fabricPeerMAC  net.HardwareAddr
+	fabricPeerMAC1 net.HardwareAddr
 	fabricRefreshCh  chan struct{} // wakes the fab0 populateFabricFwd loop
 	fabricRefreshCh1 chan struct{} // wakes the fab1 populateFabricFwd1 loop (#4038)
 	lastFabricProbe  time.Time     // rate-limit active fab0 neighbor probes
@@ -881,6 +892,12 @@ type Daemon struct {
 	// linkByNameFn resolves a network interface by name. Defaults to
 	// netlink.LinkByName; overridden in tests.
 	linkByNameFn func(string) (netlink.Link, error)
+
+	// neighListFn dumps the kernel neighbour table for an (ifindex, family).
+	// Defaults to netlink.NeighList; overridden in tests (#6554) so the
+	// fabric peer-MAC resolution can be driven against a synthetic
+	// neighbour table.
+	neighListFn func(int, int) ([]netlink.Neigh, error)
 
 	// userspaceSessionIDs allocates synthetic session IDs for sessions
 	// learned from the userspace dataplane helper before they enter the
@@ -1130,6 +1147,7 @@ func New(opts Options) (*Daemon, error) {
 		ipsecSANudgeCh:             make(chan struct{}, 1),
 		syncReadyTimeout:           5 * time.Second,
 		linkByNameFn:               netlink.LinkByName,
+		neighListFn:                netlink.NeighList,
 		directAnnounceSchedule:     []time.Duration{0, 250 * time.Millisecond, 1 * time.Second, 2 * time.Second, 4 * time.Second, 6 * time.Second},
 		directVIPOwned:             make(map[int]bool),
 		localFailoverCommitReady:   make(map[int]bool),

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -675,11 +675,11 @@ type Daemon struct {
 	fabricIface      string // physical parent (XDP attachment point)
 	fabricOverlay    string // IPVLAN overlay for neighbor resolution (#129)
 	fabricPeerIP     net.IP
-	fabricIface1     string        // secondary fabric parent
-	fabricOverlay1   string        // secondary fabric overlay (#129)
-	fabricPeerIP1    net.IP        // secondary fabric peer IP
-	fabricPopulated  bool          // true after first successful fab0 write
-	fabric1Populated bool          // true after first successful fab1 write
+	fabricIface1     string // secondary fabric parent
+	fabricOverlay1   string // secondary fabric overlay (#129)
+	fabricPeerIP1    net.IP // secondary fabric peer IP
+	fabricPopulated  bool   // true after first successful fab0 write
+	fabric1Populated bool   // true after first successful fab1 write
 	// fabricPeerMAC / fabricPeerMAC1 cache the last peer MAC that was learned
 	// from an ADDRESS-MATCHED neighbour entry for the configured fabric peer
 	// (#6554). They are the identity the IPv6-NDP link-local fallback is
@@ -689,8 +689,8 @@ type Daemon struct {
 	// let a bad guess self-confirm) and cleared when the configured peer
 	// address changes, so a re-pointed fabric cannot be pinned to the old
 	// peer's MAC.
-	fabricPeerMAC  net.HardwareAddr
-	fabricPeerMAC1 net.HardwareAddr
+	fabricPeerMAC    net.HardwareAddr
+	fabricPeerMAC1   net.HardwareAddr
 	fabricRefreshCh  chan struct{} // wakes the fab0 populateFabricFwd loop
 	fabricRefreshCh1 chan struct{} // wakes the fab1 populateFabricFwd1 loop (#4038)
 	lastFabricProbe  time.Time     // rate-limit active fab0 neighbor probes

--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -200,6 +200,13 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 	d.fabricMu.Lock()
 	d.fabricIface = fabIface
 	d.fabricOverlay = overlay
+	// A re-pointed fabric is a DIFFERENT peer chassis, so the cached
+	// address-matched MAC no longer identifies it. Drop it rather than let the
+	// NDP fallback keep pinning the old peer's MAC (#6554) — the same
+	// same-parent peer-REPLACEMENT hazard the Rust link merge guards (#5686).
+	if !d.fabricPeerIP.Equal(peerIP) {
+		d.fabricPeerMAC = nil
+	}
 	d.fabricPeerIP = peerIP
 	d.fabricMu.Unlock()
 
@@ -363,6 +370,167 @@ func (d *Daemon) fabricEntryPopulated(slot int) bool {
 	return d.fabricPopulated
 }
 
+// fabricLinkByName / fabricNeighList route the fabric refresh's netlink reads
+// through the Daemon seams so a test can drive resolution against a synthetic
+// link + neighbour table (#6554). Both fall back to the real netlink call when
+// the seam is unset (a Daemon built by a path that does not run the
+// constructor).
+func (d *Daemon) fabricLinkByName(name string) (netlink.Link, error) {
+	if d.linkByNameFn != nil {
+		return d.linkByNameFn(name)
+	}
+	return netlink.LinkByName(name)
+}
+
+func (d *Daemon) fabricNeighList(ifindex, family int) ([]netlink.Neigh, error) {
+	if d.neighListFn != nil {
+		return d.neighListFn(ifindex, family)
+	}
+	return netlink.NeighList(ifindex, family)
+}
+
+// fabricNeighValidStates is the NUD mask of neighbour states whose hardware
+// address is usable for forwarding. INCOMPLETE/FAILED/NONE carry no (or a
+// stale-zero) MAC and are excluded.
+const fabricNeighValidStates = netlink.NUD_REACHABLE | netlink.NUD_STALE |
+	netlink.NUD_PERMANENT | netlink.NUD_DELAY | netlink.NUD_PROBE
+
+// fabricPeerMACHint returns the last address-matched peer MAC observed for the
+// given fabric slot, or nil if the peer's fabric address has never resolved
+// since this daemon started (or since the configured peer last changed).
+func (d *Daemon) fabricPeerMACHint(slot int) net.HardwareAddr {
+	d.fabricMu.RLock()
+	defer d.fabricMu.RUnlock()
+	if slot == 1 {
+		return d.fabricPeerMAC1
+	}
+	return d.fabricPeerMAC
+}
+
+// rememberFabricPeerMAC records a peer MAC learned from an ADDRESS-MATCHED
+// neighbour entry — i.e. the MAC that actually answered for the configured
+// fabric peer address. This is the identity the NDP link-local fallback is
+// later constrained to (#6554). It is deliberately NOT called from the
+// fallback: a fallback result must never promote itself into the identity it
+// is checked against, or one bad selection would pin every later refresh.
+// An address-matched observation always overwrites, so a legitimately changed
+// peer MAC (NIC replacement, RETH member swap) self-heals on the next
+// successful ARP/NDP resolution rather than being locked out.
+func (d *Daemon) rememberFabricPeerMAC(slot int, mac net.HardwareAddr) {
+	if len(mac) != 6 {
+		return
+	}
+	stored := make(net.HardwareAddr, 6)
+	copy(stored, mac)
+	d.fabricMu.Lock()
+	defer d.fabricMu.Unlock()
+	if slot == 1 {
+		d.fabricPeerMAC1 = stored
+		return
+	}
+	d.fabricPeerMAC = stored
+}
+
+// selectFabricPeerLinkLocalMAC picks the fabric peer's MAC out of the fabric
+// PARENT's IPv6 neighbour table when the peer's configured fabric address
+// itself failed to resolve (#6554).
+//
+// This is the last-resort leg of peer-MAC resolution: probeFabricNeighbor
+// deliberately seeds the parent's NDP table by pinging ff02::1 (all-nodes
+// link-local multicast), so EVERY IPv6-speaking host on the fabric segment
+// answers and lands in that table. The pre-#6554 code then took the first
+// non-self link-local entry it saw. On a correctly-cabled back-to-back fabric
+// the only other host is the peer chassis, but the fabric is not always a
+// private point-to-point link, and picking a stranger's MAC is silent: the
+// refresh reports success, latches fabricPopulated (which feeds the RG
+// takeover-readiness gate), and logs a peer MAC that belongs to an unrelated
+// adjacent host.
+//
+// The selection is therefore constrained to the peer's identity, strongest
+// constraint first:
+//
+//   - expected != nil — an address-matched resolution has been seen before, so
+//     the MAC that answered for the configured peer address is known. Accept
+//     ONLY that MAC. A decoy cannot match it.
+//   - expected == nil — nothing address-matched has ever been observed (cold
+//     start / crash recovery, the case this fallback exists for). Fall back to
+//     the point-to-point fabric assumption, but CHECK it instead of assuming
+//     it: accept the sole eligible neighbour, and REFUSE when the segment
+//     presents more than one. An ambiguous segment is exactly the topology the
+//     permissive form mis-resolved on.
+//
+// Refusal is fail-closed by design: it returns no MAC, which leaves the caller
+// on the existing "peer neighbour missing" path (retain a previously-good
+// entry, else clear). That is the same state the node already occupies whenever
+// the peer genuinely does not resolve, and it does NOT blackhole cross-chassis
+// traffic — the userspace dataplane's redirect takes its destination MAC from
+// FabricSnapshot.peer_mac, which is resolved independently and strictly by
+// peer address in pkg/dataplane/userspace/fabric.go (buildFabricPeerMAC).
+// Silently keeping the permissive behaviour would leave the defect reachable
+// exactly on the shared segment where it matters.
+//
+// Candidates are deduplicated by MAC so a peer that owns several link-local
+// addresses on the same NIC (EUI-64 plus a stable-privacy or manually
+// configured address) still counts as one host and does not trip the
+// ambiguity refusal.
+//
+// reason is empty on success and carries an operator-facing explanation on
+// refusal. peerLL is the accepted neighbour's link-local address, for logging.
+func selectFabricPeerLinkLocalMAC(
+	neighs []netlink.Neigh,
+	localMAC, expected net.HardwareAddr,
+) (mac net.HardwareAddr, peerLL net.IP, candidates int, reason string) {
+	type candidate struct {
+		mac net.HardwareAddr
+		ip  net.IP
+	}
+	var eligible []candidate
+	seen := make(map[string]struct{}, len(neighs))
+	for _, n := range neighs {
+		if len(n.HardwareAddr) != 6 || (n.State&fabricNeighValidStates) == 0 {
+			continue
+		}
+		if !n.IP.IsLinkLocalUnicast() {
+			continue
+		}
+		// A group-bit MAC is a multicast/broadcast destination, never a
+		// unicast peer NIC — it can only be a mis-parsed or synthetic entry.
+		if n.HardwareAddr[0]&0x01 != 0 {
+			continue
+		}
+		if bytes.Equal(n.HardwareAddr, localMAC) {
+			continue
+		}
+		key := n.HardwareAddr.String()
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		eligible = append(eligible, candidate{mac: n.HardwareAddr, ip: n.IP})
+	}
+
+	if len(expected) == 6 {
+		for _, c := range eligible {
+			if bytes.Equal(c.mac, expected) {
+				return c.mac, c.ip, len(eligible), ""
+			}
+		}
+		return nil, nil, len(eligible),
+			"no link-local neighbour carries the known fabric peer MAC"
+	}
+
+	switch len(eligible) {
+	case 0:
+		return nil, nil, 0, "no eligible link-local neighbour on the fabric parent"
+	case 1:
+		return eligible[0].mac, eligible[0].ip, 1, ""
+	default:
+		return nil, nil, len(eligible),
+			"ambiguous fabric segment: multiple link-local neighbours and no " +
+				"address-matched peer MAC to identify the peer chassis"
+	}
+}
+
 func (d *Daemon) retainFabricFwdOnNeighborMiss(slot int, peerIP net.IP, overlay string, logWaiting bool) bool {
 	if !d.fabricEntryPopulated(slot) {
 		if logWaiting {
@@ -399,7 +567,7 @@ func (d *Daemon) retainFabricFwdOnNeighborMiss(slot int, peerIP net.IP, overlay 
 // fabIface is the physical parent (for ifindex/MAC); overlay is the IPVLAN
 // child where the sync IP lives (for neighbor resolution, #129).
 func (d *Daemon) refreshFabricFwd(ctx context.Context, fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
-	link, err := netlink.LinkByName(fabIface)
+	link, err := d.fabricLinkByName(fabIface)
 	if err != nil {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (link not found)",
 			"interface", fabIface, "err", err)
@@ -436,7 +604,7 @@ func (d *Daemon) refreshFabricFwd(ctx context.Context, fabIface, overlay string,
 	// are associated with the overlay's ifindex, not the parent's.
 	neighLink := link
 	if overlay != fabIface {
-		if ol, err := netlink.LinkByName(overlay); err == nil {
+		if ol, err := d.fabricLinkByName(overlay); err == nil {
 			neighLink = ol
 		}
 	}
@@ -445,9 +613,9 @@ func (d *Daemon) refreshFabricFwd(ctx context.Context, fabIface, overlay string,
 		neighFamily = netlink.FAMILY_V6
 	}
 
-	validState := netlink.NUD_REACHABLE | netlink.NUD_STALE | netlink.NUD_PERMANENT | netlink.NUD_DELAY | netlink.NUD_PROBE
+	validState := fabricNeighValidStates
 
-	neighs, err := netlink.NeighList(neighLink.Attrs().Index, neighFamily)
+	neighs, err := d.fabricNeighList(neighLink.Attrs().Index, neighFamily)
 	if err != nil {
 		d.logFabricRefreshFailure(0, "cluster: fabric refresh failed (neighbor list)",
 			"overlay", neighLink.Attrs().Name, "peer", peerIP, "err", err)
@@ -462,6 +630,12 @@ func (d *Daemon) refreshFabricFwd(ctx context.Context, fabIface, overlay string,
 			break
 		}
 	}
+	// An address-matched hit is a real identity binding: this MAC answered for
+	// the CONFIGURED peer address. Remember it so the link-local fallback below
+	// has a peer identity to check against on a later refresh (#6554).
+	if peerMAC != nil {
+		d.rememberFabricPeerMAC(0, peerMAC)
+	}
 
 	// Fallback: if overlay ARP failed, try the parent interface's neighbor
 	// tables (both IPv4 and IPv6). After crash recovery, the IPVLAN overlay
@@ -473,33 +647,38 @@ func (d *Daemon) refreshFabricFwd(ctx context.Context, fabIface, overlay string,
 			parentIdx = link.Attrs().Index // use fabric parent directly
 		}
 		// Check parent IPv4 neighbors for the peer IP.
-		parentNeighs, _ := netlink.NeighList(parentIdx, neighFamily)
+		parentNeighs, _ := d.fabricNeighList(parentIdx, neighFamily)
 		for _, n := range parentNeighs {
 			if n.IP.Equal(peerIP) && len(n.HardwareAddr) == 6 &&
 				(n.State&validState) != 0 {
 				peerMAC = n.HardwareAddr
+				// Still address-matched — same identity binding as above.
+				d.rememberFabricPeerMAC(0, peerMAC)
 				slog.Info("cluster: fabric peer MAC resolved via parent ARP",
 					"peer_mac", peerMAC, "overlay", overlay)
 				break
 			}
 		}
-		// Check parent IPv6 NDP neighbors (populated via ff02::1 probe).
+		// Check parent IPv6 NDP neighbors (populated via the ff02::1 probe).
+		// This leg has NO peer address to match on, so it is constrained to the
+		// peer's identity by selectFabricPeerLinkLocalMAC and fails closed when
+		// the segment cannot be shown to hold exactly the peer (#6554).
 		if peerMAC == nil {
-			v6Neighs, _ := netlink.NeighList(parentIdx, netlink.FAMILY_V6)
-			for _, n := range v6Neighs {
-				if len(n.HardwareAddr) != 6 || (n.State&validState) == 0 {
-					continue
-				}
-				if !n.IP.IsLinkLocalUnicast() {
-					continue
-				}
-				if bytes.Equal(n.HardwareAddr, localMAC) {
-					continue
-				}
-				peerMAC = n.HardwareAddr
+			v6Neighs, _ := d.fabricNeighList(parentIdx, netlink.FAMILY_V6)
+			mac, peerLL, nCandidates, reason := selectFabricPeerLinkLocalMAC(
+				v6Neighs, localMAC, d.fabricPeerMACHint(0))
+			switch {
+			case mac != nil:
+				peerMAC = mac
 				slog.Info("cluster: fabric peer MAC resolved via parent IPv6 NDP",
-					"peer_mac", peerMAC, "peer_ll", n.IP, "overlay", overlay)
-				break
+					"peer_mac", peerMAC, "peer_ll", peerLL, "overlay", overlay)
+			case nCandidates > 0:
+				// Candidates existed but none could be attributed to the peer.
+				// Throttled: this runs on every neighbour event plus the 30s tick.
+				d.logFabricRefreshFailure(0,
+					"cluster: fabric peer MAC NDP fallback refused (unidentified neighbour)",
+					"reason", reason, "candidates", nCandidates,
+					"peer", peerIP, "overlay", overlay)
 			}
 		}
 	}
@@ -596,6 +775,10 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 	d.fabricMu.Lock()
 	d.fabricIface1 = fabIface
 	d.fabricOverlay1 = overlay
+	// Peer replacement invalidates the cached identity — see populateFabricFwd.
+	if !d.fabricPeerIP1.Equal(peerIP) {
+		d.fabricPeerMAC1 = nil
+	}
 	d.fabricPeerIP1 = peerIP
 	d.fabricMu.Unlock()
 
@@ -644,7 +827,7 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 // the fabric_fwd BPF map at key=1. Returns true on success.
 // fabIface is the physical parent; overlay is the IPVLAN child (#129).
 func (d *Daemon) refreshFabricFwd1(ctx context.Context, fabIface, overlay string, peerIP net.IP, logWaiting bool) bool {
-	link, err := netlink.LinkByName(fabIface)
+	link, err := d.fabricLinkByName(fabIface)
 	if err != nil {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (link not found)",
 			"interface", fabIface, "err", err)
@@ -679,7 +862,7 @@ func (d *Daemon) refreshFabricFwd1(ctx context.Context, fabIface, overlay string
 	// Resolve peer MAC from overlay interface (#129).
 	neighLink := link
 	if overlay != fabIface {
-		if ol, err := netlink.LinkByName(overlay); err == nil {
+		if ol, err := d.fabricLinkByName(overlay); err == nil {
 			neighLink = ol
 		}
 	}
@@ -687,7 +870,7 @@ func (d *Daemon) refreshFabricFwd1(ctx context.Context, fabIface, overlay string
 	if peerIP.To4() == nil {
 		neighFamily = netlink.FAMILY_V6
 	}
-	neighs, err := netlink.NeighList(neighLink.Attrs().Index, neighFamily)
+	neighs, err := d.fabricNeighList(neighLink.Attrs().Index, neighFamily)
 	if err != nil {
 		d.logFabricRefreshFailure(1, "cluster: fabric1 refresh failed (neighbor list)",
 			"overlay", neighLink.Attrs().Name, "peer", peerIP, "err", err)
@@ -697,10 +880,16 @@ func (d *Daemon) refreshFabricFwd1(ctx context.Context, fabIface, overlay string
 	var peerMAC net.HardwareAddr
 	for _, n := range neighs {
 		if n.IP.Equal(peerIP) && len(n.HardwareAddr) == 6 &&
-			(n.State&(netlink.NUD_REACHABLE|netlink.NUD_STALE|netlink.NUD_PERMANENT|netlink.NUD_DELAY|netlink.NUD_PROBE)) != 0 {
+			(n.State&fabricNeighValidStates) != 0 {
 			peerMAC = n.HardwareAddr
 			break
 		}
+	}
+	// fab1 has no link-local fallback leg — its only resolution is
+	// address-matched — but record the identity anyway so the two slots keep
+	// the same contract if a fallback is ever added here (#6554).
+	if peerMAC != nil {
+		d.rememberFabricPeerMAC(1, peerMAC)
 	}
 	if peerMAC == nil {
 		if d.retainFabricFwdOnNeighborMiss(1, peerIP, overlay, logWaiting) {

--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -212,6 +212,15 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 
 	// Fast initial population: attempt immediately, then 500ms retries.
 	for i := 0; i < 10; i++ {
+		// Honour cancellation before EVERY attempt, including the first. The
+		// probe below dials the overlay and transmits a neighbour solicitation
+		// (ff02::1) / ARP request, so a caller whose context is ALREADY
+		// cancelled — shutdown, or a superseded fabric epoch — must not put one
+		// more frame on the wire. Before this the check lived inside the
+		// `i > 0` sleep arm, so iteration 0 probed unconditionally.
+		if ctx.Err() != nil {
+			return
+		}
 		if i > 0 {
 			select {
 			case <-ctx.Done():
@@ -252,7 +261,20 @@ func (d *Daemon) populateFabricFwd(ctx context.Context, fabIface, overlay, peerA
 // if no neighbor entry exists. Uses ping (not arping) because arping's
 // PF_PACKET raw sockets don't populate the kernel ARP table with XDP attached.
 func (d *Daemon) probeFabricNeighbor(ctx context.Context, fabIface string, peerIP net.IP) {
-	link, err := netlink.LinkByName(fabIface)
+	// Route the reads through the Daemon seams like the rest of the fabric
+	// refresh. These were direct netlink calls, which meant a test that
+	// reached this function bypassed both seams and hit the real kernel —
+	// dumping neighbours and, on a miss, transmitting a raw ICMP probe and an
+	// ff02::1 solicitation on a live NIC (#6595).
+	//
+	// NOTE for future tests: seaming the reads makes the LOOKUP hermetic, not
+	// the whole function. A seam that returns a synthetic link with no matching
+	// neighbour still falls through to the sendICMPProbe / sendIPv6MulticastProbe
+	// transmits below, which are real sockets on a real interface name. A test
+	// that must exercise this path should make fabricLinkByName return an error
+	// (as TestFabricPeerIdentityClearedOnPeerChange does) so it returns before
+	// any transmit.
+	link, err := d.fabricLinkByName(fabIface)
 	if err != nil {
 		return
 	}
@@ -261,7 +283,7 @@ func (d *Daemon) probeFabricNeighbor(ctx context.Context, fabIface string, peerI
 	if peerIP.To4() == nil {
 		neighFamily = netlink.FAMILY_V6
 	}
-	neighs, _ := netlink.NeighList(link.Attrs().Index, neighFamily)
+	neighs, _ := d.fabricNeighList(link.Attrs().Index, neighFamily)
 	for _, n := range neighs {
 		if n.IP.Equal(peerIP) && len(n.HardwareAddr) == 6 &&
 			(n.State&(netlink.NUD_REACHABLE|netlink.NUD_STALE|netlink.NUD_PERMANENT|netlink.NUD_DELAY|netlink.NUD_PROBE)) != 0 {
@@ -784,6 +806,11 @@ func (d *Daemon) populateFabricFwd1(ctx context.Context, fabIface, overlay, peer
 
 	// Fast initial population: attempt immediately, then 500ms retries.
 	for i := 0; i < 10; i++ {
+		// Same pre-probe cancellation check as populateFabricFwd — iteration 0
+		// must not transmit when the context is already cancelled.
+		if ctx.Err() != nil {
+			return
+		}
 		if i > 0 {
 			select {
 			case <-ctx.Done():

--- a/pkg/daemon/daemon_ha_fabric_peer_identity_6554_test.go
+++ b/pkg/daemon/daemon_ha_fabric_peer_identity_6554_test.go
@@ -1,0 +1,466 @@
+package daemon
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #6554 — the fabric peer-MAC IPv6-NDP fallback must not accept an arbitrary
+// link-local neighbour.
+//
+// probeFabricNeighbor deliberately seeds the fabric parent's NDP table by
+// pinging ff02::1, so every IPv6-speaking host on the segment answers. The
+// pre-fix fallback then took the FIRST non-self link-local entry it found. On a
+// shared fabric segment that is an unrelated adjacent host: the refresh
+// programs a stranger's MAC as the cross-chassis peer, reports success, and
+// latches fabricPopulated (which feeds the RG takeover-readiness gate).
+//
+// These tests drive the real refreshFabricFwd end-to-end against a synthetic
+// link + neighbour table and assert on the MAC actually handed to
+// SetFabricForwarding — the value that is programmed — not on an intermediate.
+
+// fabricProgramRecorder captures every SetFabricForwarding call so a test can
+// assert on the FabricFwdInfo that was actually programmed.
+type fabricProgramRecorder struct {
+	mu     sync.Mutex
+	writes []dataplane.FabricFwdInfo
+	ids    []dataplane.FabricID
+	syncs  int
+}
+
+func (h *fabricProgramRecorder) SetRGActive(_ context.Context, _ int, _ bool) error { return nil }
+func (h *fabricProgramRecorder) SetHAWatchdog(_ context.Context, _ int, _ uint64) error {
+	return nil
+}
+
+func (h *fabricProgramRecorder) SetFabricForwarding(_ context.Context, id dataplane.FabricID, info dataplane.FabricFwdInfo) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.ids = append(h.ids, id)
+	h.writes = append(h.writes, info)
+	return nil
+}
+
+func (h *fabricProgramRecorder) SyncFabricState(_ context.Context) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.syncs++
+	return nil
+}
+
+// programmedPeerMACs returns the peer MACs of every NON-ZERO fabric write, in
+// order. A zeroed write is a clear (clearFabricFwd0), not a programmed peer.
+func (h *fabricProgramRecorder) programmedPeerMACs() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []string
+	for _, w := range h.writes {
+		if w.Ifindex == 0 {
+			continue
+		}
+		out = append(out, net.HardwareAddr(w.PeerMAC[:]).String())
+	}
+	return out
+}
+
+type fabricProgramDP struct {
+	dataplane.RuntimeDataPlane
+	ha *fabricProgramRecorder
+}
+
+func (d *fabricProgramDP) HA() dataplane.HAController { return d.ha }
+
+const (
+	fabPeerTestLocalMAC = "02:00:00:00:00:0a" // this node's fabric parent MAC
+	fabPeerTestPeerMAC  = "02:00:00:00:00:0b" // the real peer chassis
+	fabPeerTestDecoyMAC = "02:00:00:00:00:99" // an unrelated host on the segment
+)
+
+func mustMAC(t *testing.T, s string) net.HardwareAddr {
+	t.Helper()
+	mac, err := net.ParseMAC(s)
+	if err != nil {
+		t.Fatalf("ParseMAC(%q): %v", s, err)
+	}
+	return mac
+}
+
+// fabPeerNeigh builds a valid (REACHABLE) neighbour entry.
+func fabPeerNeigh(t *testing.T, ip, mac string) netlink.Neigh {
+	t.Helper()
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		t.Fatalf("ParseIP(%q) failed", ip)
+	}
+	return netlink.Neigh{
+		IP:           parsed,
+		HardwareAddr: mustMAC(t, mac),
+		State:        netlink.NUD_REACHABLE,
+	}
+}
+
+// fabPeerTestDaemon wires a Daemon whose fabric parent resolves to a synthetic
+// link and whose neighbour dumps come from parentV6 (the fabric parent's IPv6
+// NDP table, seeded by the ff02::1 probe). The overlay's own neighbour table is
+// deliberately EMPTY and no parent IPv4 entry exists for the peer address, so
+// resolution falls through to the link-local NDP fallback under test.
+//
+// TxQLen is pre-set at the 10000 threshold so refreshFabricFwd never issues a
+// real netlink LinkSetTxQLen against the fake link.
+func fabPeerTestDaemon(t *testing.T, parentV6 []netlink.Neigh) (*Daemon, *fabricProgramRecorder) {
+	t.Helper()
+	const (
+		parentIdx  = 11
+		overlayIdx = 12
+	)
+	parent := &testLink{attrs: netlink.LinkAttrs{
+		Name:         "ge-0-0-0",
+		Index:        parentIdx,
+		OperState:    netlink.OperUp,
+		TxQLen:       10000,
+		HardwareAddr: mustMAC(t, fabPeerTestLocalMAC),
+	}}
+	overlay := &testLink{attrs: netlink.LinkAttrs{
+		Name:         "fab0",
+		Index:        overlayIdx,
+		ParentIndex:  parentIdx,
+		OperState:    netlink.OperUp,
+		TxQLen:       10000,
+		HardwareAddr: mustMAC(t, fabPeerTestLocalMAC),
+	}}
+
+	rec := &fabricProgramRecorder{}
+	d := &Daemon{
+		linkByNameFn: mockLinkByName(map[string]*testLink{
+			"ge-0-0-0": parent,
+			"fab0":     overlay,
+		}),
+		neighListFn: func(ifindex, family int) ([]netlink.Neigh, error) {
+			if ifindex == parentIdx && family == netlink.FAMILY_V6 {
+				return parentV6, nil
+			}
+			// Overlay ARP and parent IPv4 both miss — the state this
+			// fallback exists to recover from.
+			return nil, nil
+		},
+		dp: &fabricProgramDP{ha: rec},
+	}
+	return d, rec
+}
+
+func fabPeerRefresh(t *testing.T, d *Daemon) bool {
+	t.Helper()
+	return d.refreshFabricFwd(context.Background(), "ge-0-0-0", "fab0",
+		net.ParseIP("10.99.13.2"), false)
+}
+
+// TestFabricPeerNDPFallbackRejectsDecoyWithKnownPeerMAC is the primary
+// fail-on-revert gate. A decoy link-local neighbour is listed FIRST, ahead of
+// the real peer, and the peer's MAC is already known from an earlier
+// address-matched resolution. The permissive pre-#6554 loop took the first
+// non-self link-local entry and would program the decoy's MAC.
+func TestFabricPeerNDPFallbackRejectsDecoyWithKnownPeerMAC(t *testing.T) {
+	d, rec := fabPeerTestDaemon(t, []netlink.Neigh{
+		// Decoy first — a permissive first-match selection picks this.
+		fabPeerNeigh(t, "fe80::dec0", fabPeerTestDecoyMAC),
+		fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+	})
+	// An earlier address-matched resolution established the peer's identity.
+	d.rememberFabricPeerMAC(0, mustMAC(t, fabPeerTestPeerMAC))
+
+	if !fabPeerRefresh(t, d) {
+		t.Fatal("refreshFabricFwd returned false; expected the real peer to resolve")
+	}
+
+	got := rec.programmedPeerMACs()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one programmed fabric entry, got %d (%v)", len(got), got)
+	}
+	if got[0] == fabPeerTestDecoyMAC {
+		t.Fatalf("DECOY MAC %s was programmed as the fabric peer — cross-chassis "+
+			"frames would be L2-delivered to an unrelated adjacent host (#6554)",
+			fabPeerTestDecoyMAC)
+	}
+	if got[0] != fabPeerTestPeerMAC {
+		t.Fatalf("programmed peer MAC = %s, want the real peer %s", got[0], fabPeerTestPeerMAC)
+	}
+}
+
+// TestFabricPeerNDPFallbackRefusesAmbiguousSegment covers the cold-start case:
+// a decoy is present alongside the real peer but NO address-matched resolution
+// has ever identified the peer. With no identity to check against, the segment
+// is ambiguous and the fallback must refuse rather than guess. The permissive
+// form programmed the decoy.
+func TestFabricPeerNDPFallbackRefusesAmbiguousSegment(t *testing.T) {
+	d, rec := fabPeerTestDaemon(t, []netlink.Neigh{
+		fabPeerNeigh(t, "fe80::dec0", fabPeerTestDecoyMAC),
+		fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+	})
+	// No rememberFabricPeerMAC — the peer address has never resolved.
+
+	if fabPeerRefresh(t, d) {
+		t.Fatal("refreshFabricFwd reported success on an ambiguous fabric segment; " +
+			"expected a fail-closed refusal (#6554)")
+	}
+	if got := rec.programmedPeerMACs(); len(got) != 0 {
+		t.Fatalf("a peer MAC was programmed from an unidentifiable segment: %v "+
+			"(decoy=%s, peer=%s) (#6554)", got, fabPeerTestDecoyMAC, fabPeerTestPeerMAC)
+	}
+	if d.fabricEntryPopulated(0) {
+		t.Fatal("fabricPopulated latched on a refused resolution — the RG " +
+			"takeover-readiness gate would read a fabric that never resolved")
+	}
+}
+
+// TestFabricPeerNDPFallbackResolvesSolePeer is the over-reach guard: the normal
+// point-to-point fabric — only the real peer on the segment, no cached identity
+// — must still resolve, and to the peer's MAC. This test must stay GREEN when
+// the fix is reverted.
+func TestFabricPeerNDPFallbackResolvesSolePeer(t *testing.T) {
+	d, rec := fabPeerTestDaemon(t, []netlink.Neigh{
+		fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+	})
+
+	if !fabPeerRefresh(t, d) {
+		t.Fatal("refreshFabricFwd returned false on a healthy point-to-point fabric")
+	}
+	got := rec.programmedPeerMACs()
+	if len(got) != 1 || got[0] != fabPeerTestPeerMAC {
+		t.Fatalf("programmed peer MACs = %v, want exactly [%s]", got, fabPeerTestPeerMAC)
+	}
+	if !d.fabricEntryPopulated(0) {
+		t.Fatal("fabricPopulated not set after a successful sole-peer resolution")
+	}
+}
+
+// TestFabricPeerNDPFallbackSolePeerMatchesKnownIdentity is the second half of
+// the over-reach guard: a healthy fabric that HAS resolved before must keep
+// resolving to the same MAC once the identity constraint is armed.
+func TestFabricPeerNDPFallbackSolePeerMatchesKnownIdentity(t *testing.T) {
+	d, rec := fabPeerTestDaemon(t, []netlink.Neigh{
+		fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+	})
+	d.rememberFabricPeerMAC(0, mustMAC(t, fabPeerTestPeerMAC))
+
+	if !fabPeerRefresh(t, d) {
+		t.Fatal("refreshFabricFwd returned false for the known peer")
+	}
+	got := rec.programmedPeerMACs()
+	if len(got) != 1 || got[0] != fabPeerTestPeerMAC {
+		t.Fatalf("programmed peer MACs = %v, want exactly [%s]", got, fabPeerTestPeerMAC)
+	}
+}
+
+// TestFabricPeerNDPFallbackRefusesLoneDecoyWhenPeerKnown covers the peer-down
+// case on a shared segment: the real peer is gone, only the decoy answers. With
+// the peer's identity known, the sole remaining neighbour must still be
+// refused — "the only host left" is not "the peer".
+func TestFabricPeerNDPFallbackRefusesLoneDecoyWhenPeerKnown(t *testing.T) {
+	d, rec := fabPeerTestDaemon(t, []netlink.Neigh{
+		fabPeerNeigh(t, "fe80::dec0", fabPeerTestDecoyMAC),
+	})
+	d.rememberFabricPeerMAC(0, mustMAC(t, fabPeerTestPeerMAC))
+
+	if fabPeerRefresh(t, d) {
+		t.Fatal("refreshFabricFwd accepted a lone non-peer neighbour")
+	}
+	if got := rec.programmedPeerMACs(); len(got) != 0 {
+		t.Fatalf("programmed peer MACs = %v, want none", got)
+	}
+}
+
+// TestFabricPeerAddressMatchRecordsIdentity proves the identity the fallback
+// checks against comes from an ADDRESS-MATCHED resolution — the MAC that
+// actually answered for the configured fabric peer address — and that the
+// fallback's own result never promotes itself into that identity.
+func TestFabricPeerAddressMatchRecordsIdentity(t *testing.T) {
+	t.Run("address match records", func(t *testing.T) {
+		d, _ := fabPeerTestDaemon(t, nil)
+		peerIP := net.ParseIP("10.99.13.2")
+		d.neighListFn = func(ifindex, family int) ([]netlink.Neigh, error) {
+			if ifindex == 12 && family == netlink.FAMILY_V4 {
+				return []netlink.Neigh{
+					fabPeerNeigh(t, peerIP.String(), fabPeerTestPeerMAC),
+				}, nil
+			}
+			return nil, nil
+		}
+		if !fabPeerRefresh(t, d) {
+			t.Fatal("refreshFabricFwd returned false on an address-matched resolution")
+		}
+		hint := d.fabricPeerMACHint(0)
+		if hint.String() != fabPeerTestPeerMAC {
+			t.Fatalf("peer identity hint = %v, want %s", hint, fabPeerTestPeerMAC)
+		}
+	})
+
+	t.Run("fallback result is not promoted to identity", func(t *testing.T) {
+		d, _ := fabPeerTestDaemon(t, []netlink.Neigh{
+			fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+		})
+		if !fabPeerRefresh(t, d) {
+			t.Fatal("refreshFabricFwd returned false on a sole-peer segment")
+		}
+		if hint := d.fabricPeerMACHint(0); hint != nil {
+			t.Fatalf("link-local fallback promoted its own result to the peer "+
+				"identity (%v); a single bad selection would then pin every "+
+				"later refresh", hint)
+		}
+	})
+}
+
+// TestFabricPeerIdentityClearedOnPeerChange proves a re-pointed fabric drops
+// the cached identity: the new peer chassis has a different MAC, and pinning
+// the old one would refuse the new peer forever.
+func TestFabricPeerIdentityClearedOnPeerChange(t *testing.T) {
+	d := &Daemon{}
+	d.fabricPeerIP = net.ParseIP("10.99.13.2")
+	d.rememberFabricPeerMAC(0, mustMAC(t, fabPeerTestPeerMAC))
+	d.fabricPeerIP1 = net.ParseIP("10.99.14.2")
+	d.rememberFabricPeerMAC(1, mustMAC(t, fabPeerTestPeerMAC))
+
+	// Same peer — identity survives.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	d.populateFabricFwd(ctx, "ge-0-0-0", "fab0", "10.99.13.2", nil)
+	if d.fabricPeerMACHint(0) == nil {
+		t.Fatal("peer identity cleared even though the peer address is unchanged")
+	}
+
+	// Different peer — identity must be dropped.
+	d.populateFabricFwd(ctx, "ge-0-0-0", "fab0", "10.99.13.3", nil)
+	if hint := d.fabricPeerMACHint(0); hint != nil {
+		t.Fatalf("stale peer identity %v retained across a fabric peer change", hint)
+	}
+
+	d.populateFabricFwd1(ctx, "ge-0-0-0", "fab1", "10.99.14.3", nil)
+	if hint := d.fabricPeerMACHint(1); hint != nil {
+		t.Fatalf("stale fab1 peer identity %v retained across a peer change", hint)
+	}
+}
+
+// TestSelectFabricPeerLinkLocalMAC exercises the candidate filter directly:
+// which neighbour entries are eligible at all, and how ambiguity is resolved.
+func TestSelectFabricPeerLinkLocalMAC(t *testing.T) {
+	local := mustMAC(t, fabPeerTestLocalMAC)
+	peer := mustMAC(t, fabPeerTestPeerMAC)
+
+	withState := func(n netlink.Neigh, state int) netlink.Neigh {
+		n.State = state
+		return n
+	}
+
+	tests := []struct {
+		name     string
+		neighs   []netlink.Neigh
+		expected net.HardwareAddr
+		want     string // "" means refusal
+	}{
+		{
+			name:   "sole peer accepted",
+			neighs: []netlink.Neigh{fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC)},
+			want:   fabPeerTestPeerMAC,
+		},
+		{
+			name: "self entry ignored",
+			neighs: []netlink.Neigh{
+				fabPeerNeigh(t, "fe80::a", fabPeerTestLocalMAC),
+				fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+			},
+			want: fabPeerTestPeerMAC,
+		},
+		{
+			name: "global unicast ignored",
+			neighs: []netlink.Neigh{
+				fabPeerNeigh(t, "2001:db8::99", fabPeerTestDecoyMAC),
+				fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+			},
+			want: fabPeerTestPeerMAC,
+		},
+		{
+			name: "unusable NUD state ignored",
+			neighs: []netlink.Neigh{
+				withState(fabPeerNeigh(t, "fe80::dec0", fabPeerTestDecoyMAC), netlink.NUD_FAILED),
+				fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+			},
+			want: fabPeerTestPeerMAC,
+		},
+		{
+			name: "group-bit MAC ignored",
+			neighs: []netlink.Neigh{
+				fabPeerNeigh(t, "fe80::dec0", "33:33:00:00:00:01"),
+				fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+			},
+			want: fabPeerTestPeerMAC,
+		},
+		{
+			name: "multiple link-locals on one peer NIC are one candidate",
+			neighs: []netlink.Neigh{
+				fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+				fabPeerNeigh(t, "fe80::bbbb", fabPeerTestPeerMAC),
+			},
+			want: fabPeerTestPeerMAC,
+		},
+		{
+			name: "two distinct hosts refused without identity",
+			neighs: []netlink.Neigh{
+				fabPeerNeigh(t, "fe80::dec0", fabPeerTestDecoyMAC),
+				fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+			},
+			want: "",
+		},
+		{
+			name: "two distinct hosts resolved by identity",
+			neighs: []netlink.Neigh{
+				fabPeerNeigh(t, "fe80::dec0", fabPeerTestDecoyMAC),
+				fabPeerNeigh(t, "fe80::b", fabPeerTestPeerMAC),
+			},
+			expected: peer,
+			want:     fabPeerTestPeerMAC,
+		},
+		{
+			name:     "lone decoy refused against identity",
+			neighs:   []netlink.Neigh{fabPeerNeigh(t, "fe80::dec0", fabPeerTestDecoyMAC)},
+			expected: peer,
+			want:     "",
+		},
+		{
+			name:   "empty table refused",
+			neighs: nil,
+			want:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mac, peerLL, n, reason := selectFabricPeerLinkLocalMAC(tc.neighs, local, tc.expected)
+			if tc.want == "" {
+				if mac != nil {
+					t.Fatalf("selected %v (ll=%v), want refusal", mac, peerLL)
+				}
+				if reason == "" {
+					t.Fatal("refusal carried no operator-facing reason")
+				}
+				return
+			}
+			if mac == nil {
+				t.Fatalf("refused (%s, candidates=%d), want %s", reason, n, tc.want)
+			}
+			if mac.String() != tc.want {
+				t.Fatalf("selected %s, want %s", mac, tc.want)
+			}
+			if reason != "" {
+				t.Fatalf("success carried a refusal reason: %s", reason)
+			}
+			if peerLL == nil {
+				t.Fatal("success carried no link-local address for logging")
+			}
+		})
+	}
+}

--- a/pkg/daemon/daemon_ha_fabric_peer_identity_6554_test.go
+++ b/pkg/daemon/daemon_ha_fabric_peer_identity_6554_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -183,8 +184,16 @@ func TestFabricPeerNDPFallbackRejectsDecoyWithKnownPeerMAC(t *testing.T) {
 		t.Fatalf("expected exactly one programmed fabric entry, got %d (%v)", len(got), got)
 	}
 	if got[0] == fabPeerTestDecoyMAC {
-		t.Fatalf("DECOY MAC %s was programmed as the fabric peer — cross-chassis "+
-			"frames would be L2-delivered to an unrelated adjacent host (#6554)",
+		// Scope note: the MAC this path programs goes into the retired-eBPF
+		// `fabric_fwd` map (pkg/dataplane/maps_fabric.go). The LIVE Rust
+		// redirect re-derives FabricSnapshot.PeerMAC with its own
+		// address-matched neighbour lookup (buildFabricPeerMAC,
+		// pkg/dataplane/userspace/fabric.go), so a decoy accepted here never
+		// becomes an L2 destination. The damage is false readiness, not
+		// misdelivery — assert on that, not on a forwarding claim.
+		t.Fatalf("DECOY MAC %s was programmed as the fabric peer — the node would "+
+			"latch fabricPopulated, end the fast-retry probe loop early, and log an "+
+			"unrelated host's MAC as the fabric peer during an HA incident (#6554)",
 			fabPeerTestDecoyMAC)
 	}
 	if got[0] != fabPeerTestPeerMAC {
@@ -320,6 +329,19 @@ func TestFabricPeerAddressMatchRecordsIdentity(t *testing.T) {
 // the old one would refuse the new peer forever.
 func TestFabricPeerIdentityClearedOnPeerChange(t *testing.T) {
 	d := &Daemon{}
+	// Hermetic by construction (#6595). populateFabricFwd now checks ctx before
+	// the first probe, so a cancelled context returns without touching netlink —
+	// but do not let this test's SAFETY depend on that check surviving. Pin the
+	// netlink seams to hard errors so a regression in the cancellation guard
+	// fails as an assertion here rather than dumping the kernel neighbour table
+	// and transmitting an ICMP / ff02::1 probe on whatever real interface
+	// happens to be named ge-0-0-0 on the machine running the suite.
+	d.linkByNameFn = func(string) (netlink.Link, error) {
+		return nil, errors.New("hermetic test: netlink disabled")
+	}
+	d.neighListFn = func(int, int) ([]netlink.Neigh, error) {
+		return nil, errors.New("hermetic test: netlink disabled")
+	}
 	d.fabricPeerIP = net.ParseIP("10.99.13.2")
 	d.rememberFabricPeerMAC(0, mustMAC(t, fabPeerTestPeerMAC))
 	d.fabricPeerIP1 = net.ParseIP("10.99.14.2")
@@ -342,6 +364,64 @@ func TestFabricPeerIdentityClearedOnPeerChange(t *testing.T) {
 	d.populateFabricFwd1(ctx, "ge-0-0-0", "fab1", "10.99.14.3", nil)
 	if hint := d.fabricPeerMACHint(1); hint != nil {
 		t.Fatalf("stale fab1 peer identity %v retained across a peer change", hint)
+	}
+}
+
+// TestPopulateFabricFwdHonoursCancelledContextBeforeFirstProbe pins the #6595
+// cancellation guard. The retry loop used to check ctx.Done() only inside its
+// `i > 0` sleep arm, so iteration 0 ran unconditionally: an already-cancelled
+// caller still reached probeFabricNeighbor, which dumps the kernel neighbour
+// table and — on a miss — transmits a raw ICMP probe plus an ff02::1
+// solicitation on a live interface. A cancelled context must put nothing on the
+// wire and read nothing from netlink.
+//
+// The assertion is a netlink-touch count rather than a packet capture: both
+// populateFabricFwd's probe and its refreshFabricFwd call reach the kernel
+// through fabricLinkByName, so ZERO calls is the only state in which neither
+// can have run. Reverting the guard makes this count non-zero.
+func TestPopulateFabricFwdHonoursCancelledContextBeforeFirstProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(d *Daemon, ctx context.Context)
+	}{
+		{"fab0", func(d *Daemon, ctx context.Context) {
+			d.populateFabricFwd(ctx, "ge-0-0-0", "fab0", "10.99.13.2", nil)
+		}},
+		{"fab1", func(d *Daemon, ctx context.Context) {
+			d.populateFabricFwd1(ctx, "ge-0-0-0", "fab1", "10.99.14.2", nil)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			netlinkTouches := 0
+			d := &Daemon{}
+			d.linkByNameFn = func(string) (netlink.Link, error) {
+				mu.Lock()
+				netlinkTouches++
+				mu.Unlock()
+				return nil, errors.New("hermetic test: netlink disabled")
+			}
+			d.neighListFn = func(int, int) ([]netlink.Neigh, error) {
+				mu.Lock()
+				netlinkTouches++
+				mu.Unlock()
+				return nil, errors.New("hermetic test: netlink disabled")
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			tc.run(d, ctx)
+
+			mu.Lock()
+			got := netlinkTouches
+			mu.Unlock()
+			if got != 0 {
+				t.Fatalf("cancelled context still performed %d netlink read(s) — "+
+					"the pre-probe ctx.Err() guard is not holding, so a cancelled "+
+					"caller can still transmit an ICMP/ff02::1 probe on a live NIC "+
+					"(#6595)", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #6554

## Problem

`refreshFabricFwd` (`pkg/daemon/daemon_ha_fabric.go`) resolves the cross-chassis fabric peer's MAC in three legs: overlay ARP/NDP for the configured peer address, parent ARP/NDP for the same address, then — as a last resort — a sweep of the fabric parent's IPv6 neighbour table for a link-local entry.

The third leg has **no peer address to match on**, and `probeFabricNeighbor` deliberately seeds that table by pinging `ff02::1` (all-nodes link-local multicast), so *every* IPv6-speaking host on the fabric segment answers and lands in it. The sweep then accepted the **first non-self link-local entry** it found.

## Impact — corrected vs. the issue text

The issue claims cross-chassis customer packets are L2-delivered to an unrelated host. **That is not reachable on today's forwarding path**, and the PR should be judged on the defect that *is* live:

- `FabricFwdInfo.PeerMAC` is written into the `fabric_fwd` pinned array and read by **nobody** post-#1476 — the retained `userspace-xdp` shim never references the map (`arrayMapSpec("fabric_fwd", …)` creates it, no Rust code reads it), `userspace-dp` never reads it, and no Go reader exists (`grep '\.PeerMAC'` finds only the two write sites).
- The dataplane redirect's actual destination MAC comes from `FabricSnapshot.peer_mac` via `buildFabricPeerMAC` (`pkg/dataplane/userspace/fabric.go`), which **is** address-matched — as is the Rust late-resolution fallback, keyed on `(ifindex, peer_addr)`.

What *is* live is a **false-success health signal**: a decoy made the refresh report success, latch `fabricPopulated` — which feeds the redundancy-group takeover-readiness gate in `reconcileRGState` — end the fast-retry probe loop early on a fabric that had not actually resolved, and log a stranger's MAC as the fabric peer, which is exactly the evidence an operator reads during an HA incident.

## Fix

`selectFabricPeerLinkLocalMAC` constrains the sweep to the peer's identity, strongest constraint first:

1. **Known peer MAC.** Both refresh paths cache the MAC of every **address-matched** resolution (`d.fabricPeerMAC` / `fabricPeerMAC1`) — the MAC that actually answered for the configured peer address. When known, only a neighbour bearing it is accepted. The cache is **never written by the fallback itself**, so one bad selection cannot promote itself into the identity later refreshes are checked against; it is dropped when the configured peer address changes so a re-pointed fabric is not pinned to the old chassis; and an address-matched observation always overwrites, so a legitimately changed peer MAC self-heals rather than being locked out.
2. **Checked point-to-point assumption.** On a cold start with no address-matched observation yet — the crash-recovery case this fallback exists for — accept the sole eligible neighbour, refuse an ambiguous segment (≥2 distinct neighbour MACs). Candidates are deduplicated by MAC so a peer owning several link-locals on one NIC still counts as one host.

Ineligible entries never become candidates: non-`fe80::/10`, unusable NUD state, group-bit (multicast) MAC, or this node's own MAC.

### Design decisions

**Rejected the issue's RETH virtual-MAC-prefix suggestion.** Fabric members carry no `redundant-parent` (`docs/ha-cluster-userspace.conf`: `fab0` → `ge-0/0/0`, `fab1` → `ge-7/0/0`), and `programRethMAC` only runs for interfaces with `RedundancyGroup > 0` — so the fabric parent never receives an `02:bf:72:CC:RR:NN` MAC and that constraint would **reject the real peer**.

**Rejected a new peer-MAC exchange over the cluster control channel.** Strongest option, but a wire-protocol change on both sides for a leg that must work before the control link is necessarily useful.

**Fail direction: refuse, do not fall back to permissive.** Falling back would leave the defect reachable exactly on the shared segment where it matters. A refusal returns no MAC and lands on the pre-existing "peer neighbour missing" path (`retainFabricFwdOnNeighborMiss` → retain a previously-good entry, else `clearFabricFwd0`). **That is the same state the node already occupies whenever the peer genuinely does not resolve on a normal fabric — not a new degradation mode — and it does not blackhole cross-chassis traffic**, because the redirect's dst-MAC comes from the independent address-matched `buildFabricPeerMAC` path. The cost of a refusal is the readiness latch: the node advertises `fabric forwarding path not ready` (only evaluated while the peer is alive) instead of falsely claiming a fabric it cannot identify.

## Same shape elsewhere

Checked every `NeighList` call site. `refreshFabricFwd1` (fab1) has **no** link-local leg — its only resolution is address-matched. `buildFabricPeerMAC` and the Rust `resolve_fabric_links_from_snapshots` are both peer-address-keyed. This leg was the only permissive one; it is now the only one that needed a constraint.

## Validation

- New `pkg/daemon` tests drive the **real** `refreshFabricFwd` through a `d.neighListFn` seam (mirroring the existing `d.linkByNameFn`) and assert on the MAC handed to `SetFabricForwarding` — the value actually programmed, not an intermediate.
- Coverage: decoy listed **ahead** of the real peer (real peer selected); ambiguous cold-start segment (refused, `fabricPopulated` not latched); lone non-peer neighbour with identity known (refused); sole-peer point-to-point (still resolves, same MAC as master); identity recorded on address match and **not** promoted from the fallback; identity cleared on peer change; candidate-filter table (self / global-unicast / bad NUD / group-bit / multi-link-local dedupe).
- **Fail-on-revert verified**: restoring the permissive first-match selection fails the decoy tests on an **assertion** — `DECOY MAC 02:00:00:00:00:99 was programmed as the fabric peer` — not a build break. Both over-reach guards (`ResolvesSolePeer`, `SolePeerMatchesKnownIdentity`) stay **green** under revert.
- Full Go suite green (`go test ./...`).

## Still owed before merge

This touches HA fabric setup. `make test-failover` plus a cross-chassis forwarding check have **not** been run — cluster smoke is serialized by the parent on the shared loss cluster.

## Docs

`docs/fabric-cross-chassis-fwd.md` gains a "Peer-MAC resolution is constrained to the peer's identity (#6554)" section covering the constraint order, the ineligibility rules, and the fail-direction reasoning.