### PR TITLE
snmp: bound the GETBULK grid at the response ceiling

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -62166,3 +62166,63 @@ break — `go vet` confirmed passing under every revert.
   Full pkg/snmp suite green, plain and -race.
 - **File(s)**: pkg/snmp/{agent.go,v3.go,README.md},
     pkg/snmp/getbulk_work_bound_6551_test.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6551 / PR #6596 — fold the two Codex MERGE-NEEDS-MINOR findings.
+  Both were gaps between what the tests and docs CLAIMED and what they actually
+  BOUND; the bound itself and the over-reach oracle were sound and are unchanged.
+  Finding 1 — the v3 CALL SITE was not guarded.
+  TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551 said it guarded both call
+  sites but drove only handlePacket (v2c), and TestGetBulkBuildBoundedV3_6551
+  calls buildBulkVarbinds itself with the real ceiling, so its built-count
+  assertions hold no matter what budget v3.go passes. Everything else it checks
+  about the response — size, error-status, varbind count — is identical bounded
+  or not, because the fix is output-neutral, so only a COST assertion can see
+  the difference. Codex proved it: unbounding ONLY the v3 production call left
+  every #6551 test green. Added
+  TestGetBulkCostDoesNotScaleWithMaxRepetitionsV3_6551, a separate end-to-end
+  guard on the real v3 dispatcher (v3MaxRepeaterBulkRequest ->
+  handlePacketFrom), deliberately NOT sharing a helper with the v2c sibling so
+  the two surfaces stay independently covered. It measures work as ALLOCATIONS
+  rather than wall time (testing.AllocsPerRun): every grid cell allocates a
+  walked OID and an encoded value, so the count tracks cells walked, and unlike
+  a duration it cannot be moved by machine load. Pinned property is the v2c
+  sibling's — M=1 and M=100 must cost the same once the ceiling is reached.
+  Also corrected the v2c test's comment, which claimed both call sites.
+  Finding 2 — the byte-count proof was not true of wire-decoded input. The
+  minVarbindEncodedBytes = 6 floor needs an EMPTY encoded OID, but berDecodeOID
+  rejects an empty body and turns any non-empty one into >= 2 components, so a
+  varbind built from a wire OID re-encodes to >= 7 bytes and 6 is unreachable
+  from the wire. Conversely decodePDUFields does NOT require a request varbind
+  to carry a value TLV, so the densest ACCEPTED request packing is 5 bytes, not
+  7. Rewrote the constant's comment: 6 stays as the floor (the structural cap
+  only needs a valid lower bound, and a loose floor makes it conservative, never
+  unsound), with the wire minimum of 7 stated explicitly and the cap's scope
+  narrowed to CELL COUNT, not "the response fits". Rewrote the GETNEXT scope
+  paragraph in pkg/snmp/README.md to lead with the OPERATION COUNT argument,
+  which is the real reason — one findNextOIDSnap/getOIDValueSnap pair per
+  decoded request OID, no max-repetitions multiplier — and derived the
+  per-datagram ceiling from the true 5-byte minimum. Added
+  TestWireVarbindByteFloors_6551 to bind all of it as fact instead of prose:
+  berDecodeOID rejects an empty body and always yields >= 2 components, a
+  wire-derived varbind is >= 7 bytes, the 6-byte floor is still attainable
+  through the encoder, a value-less 5-byte request varbind is accepted and its
+  OID delivered, and a max-size GETNEXT carries 812 value-less OIDs vs 580
+  well-formed (measured, matching the ~800 the README now documents).
+  Validation. Fail-on-revert probes in a THROWAWAY detached worktree
+  (/dev/shm/probe-6596), never in the PR worktree, one call site at a time,
+  go build ./... and go vet ./... CLEAN in both so neither red is a build break:
+  unbound v3 only -> ONLY TestGetBulkCostDoesNotScaleWithMaxRepetitionsV3_6551
+  fails, 18,419 allocs at M=1 vs 3,446,385 at M=100 (187.1x, threshold 10x),
+  while the v2c cost test still passes at 1.1x and TestGetBulkBuildBoundedV3_6551
+  still passes — reproducing Codex's result exactly. Unbound v2c only -> ONLY
+  TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551 fails, 1.33 ms vs 513.32 ms
+  (385.1x), while the new v3 test stays green at 1.0x. Each revert takes exactly
+  one test red, which is what proves the two call sites are covered separately
+  rather than by one test that re-masks the split. Over-reach oracle
+  TestGetBulkBoundedMatchesUnbounded_6551 stayed GREEN under BOTH reverts. Full
+  pkg/snmp suite green; the #6551 set run 5x for flake. gofmt clean on both
+  touched files (pkg/snmp/v3_auth_test.go is gofmt-unclean at origin/master too
+  — pre-existing, untouched here).
+- **File(s)**: pkg/snmp/getbulk_work_bound_6551_test.go, pkg/snmp/README.md,
+    _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62226,3 +62226,23 @@ break — `go vet` confirmed passing under every revert.
   — pre-existing, untouched here).
 - **File(s)**: pkg/snmp/getbulk_work_bound_6551_test.go, pkg/snmp/README.md,
     _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6551 review-fold round 3 — two documentation inaccuracies from the
+  Codex re-gate of `3f9358151`. No production or test-coverage change. (1)
+  `pkg/snmp/README.md` listed the v2c cost test as guarding "the call sites" and
+  omitted the new v3 cost test; the inventory now names one cost guard per call
+  site (v2c in `agent.go`, v3 in `v3.go`) and records why one test cannot bind
+  both — unbounding v3 alone once left every test green, which is the gap this
+  round closed. (2) The GET/GETNEXT paragraph claimed both perform a
+  `findNextOIDSnap` + `getOIDValueSnap` PAIR per decoded request OID. Verified
+  firsthand against `pkg/snmp/agent.go`: GET calls only `getOIDValueSnap`
+  (:1218), and GETNEXT calls `findNextOIDSnap` (:1242) then `getOIDValueSnap`
+  only when a successor exists (:1247). Reworded to the claim that is actually
+  true and actually load-bearing — a CONSTANT bound of snapshot operations per
+  request OID, i.e. O(1) with no request-controlled multiplier. The
+  amplification conclusion is unchanged; only the arithmetic describing it was
+  wrong. Codex re-gate otherwise confirmed the split is real (half-grid M=50
+  probe still 54.9x, so fixed overhead does not mask a partial regression) and
+  `AllocsPerRun` stable at exactly 8199 over five runs.
+- **File(s)**: pkg/snmp/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62122,3 +62122,47 @@ break — `go vet` confirmed passing under every revert.
   22.7 Gbps) and needs no re-run for a comment-only change.
 - **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
     pkg/routing/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6551 — bound the SNMP GETBULK grid AT the response ceiling instead
+  of expanding it fully and trimming afterwards.
+  Reproduced first. With 50 interfaces, a 4094-byte v2c GETBULK carrying 580
+  minimal repeater OIDs and max-repetitions >= 100 built 58,000 varbinds (405 ms
+  inside buildBulkVarbinds) to return 116, and answered in 667 ms end to end
+  against a ~2.5 us single-varbind poll — ~1.5 req/s saturates the single serial
+  SNMP goroutine permanently. The issue's ~36,900 / ~300 ms figures are an
+  undercount; the extra ~260 ms beyond the build is trimToFit binary-searching
+  ~16 full re-encodes of the 58,000-varbind list. repeaterCount = len(oids) -
+  nonRepeaters is capped nowhere on the decode path; only maxRepetitions was
+  clamped (100).
+  Fix: buildBulkVarbinds now takes the same maxBytes ceiling its caller trims to
+  and accumulates the EXACT encoded size of each emitted varbind (bulkBudget /
+  varbindEncodedLen), returning as soon as the varbinds built exceed it. Both
+  call sites — handleGetBulk (v2c, effectiveMaxSize(maxPacketSize)) and the v3
+  dispatcher (effectiveMaxSize(msgMaxSize)) — hand it the ceiling they already
+  computed for trimToFit. Output-neutral: the accumulated varbind bytes are a
+  strict lower bound on any message carrying them, so every dropped cell is one
+  trimToFit would have discarded; RFC 3416 4.2.3 removes surplus bindings from
+  the END of the ordered set, which is exactly the prefix preserved, so #5065
+  repetition-major order and per-column endOfMibView placement are untouched.
+  Post-fix the same request builds 118 varbinds in 48 us and answers in 1.0 ms
+  with a byte-identical 4092-byte / 116-varbind response.
+  Fail-on-revert (neutralize bulkBudget.add to `return false` — compiles clean,
+  no build break): TestGetBulkBuildBounded_6551 RED at 58,000 built vs a 683
+  structural cap, TestGetBulkBuildBoundedV3_6551 RED at 56,400. Neutralizing the
+  CALL SITE instead (math.MaxInt budget) leaves those green, so
+  TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551 covers it end to end —
+  1.4x M=1-vs-M=100 cost ratio with the fix, 309.7x without, threshold 10x.
+  Over-reach guard TestGetBulkBoundedMatchesUnbounded_6551 (9 shapes: small,
+  non-repeaters, MIB-exhausted columns, oversized) compares byte-for-byte
+  against a math.MaxInt-budget build — i.e. against the pre-fix expansion — and
+  stays GREEN under both neutralizations.
+  Sibling check: plain GETNEXT has NO equivalent amplification. RFC 3416
+  4.2.1/4.2.2 bind it to one response varbind per request varbind, so its walk is
+  O(len(oids)) with no max-repetitions multiplier and every varbind built is
+  returned — a max-size 239-deep-OID GETNEXT costs ~33 ms and returns all 239 in
+  a full 4095-byte response. That residual is findNextOIDSnap being a linear MIB
+  scan, not unbounded expansion; scoped out and reported.
+  Full pkg/snmp suite green, plain and -race.
+- **File(s)**: pkg/snmp/{agent.go,v3.go,README.md},
+    pkg/snmp/getbulk_work_bound_6551_test.go, _Log.md

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -529,17 +529,27 @@ packet handlers, and MIB view that call into them.
   untouched. `varbindEncodedLen` MUST stay in step with the per-varbind encoding
   in `buildResponseVersion`: an overestimate would stop the grid short of
   varbinds that would have fit and silently shrink large responses.
-  Fail-on-revert guards: `TestGetBulkBuildBounded_6551` (v2c),
-  `TestGetBulkBuildBoundedV3_6551` (v3),
-  `TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551` (the call sites).
+  Fail-on-revert guards, one cost guard per CALL SITE — the two sites are
+  separate surfaces and a single test cannot bind both (unbounding v3 alone once
+  left every test green):
+  `TestGetBulkBuildBounded_6551` (v2c construction),
+  `TestGetBulkBuildBoundedV3_6551` (v3 construction),
+  `TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551` (v2c call site,
+  `agent.go`), and
+  `TestGetBulkCostDoesNotScaleWithMaxRepetitionsV3_6551` (v3 call site,
+  `v3.go`). The v3 cost guard measures ALLOCATIONS rather than wall time, so
+  machine load cannot move it.
   Equivalence-vs-unbounded and encoder-parity guards:
   `TestGetBulkBoundedMatchesUnbounded_6551`,
   `TestVarbindEncodedLenMatchesEncoder_6551`.
   **GET/GETNEXT have no equivalent amplification.** The argument is an
   OPERATION COUNT, not a byte count: RFC 3416 §4.2.1/§4.2.2 bind them to exactly
-  one response varbind per request varbind, so the work is one
-  `findNextOIDSnap` + `getOIDValueSnap` pair per DECODED REQUEST OID and every
-  varbind built is one the manager asked for. There is no `max-repetitions`
+  one response varbind per request varbind, so the work is BOUNDED BY a constant
+  number of snapshot operations per DECODED REQUEST OID and every varbind built
+  is one the manager asked for. Precisely: GET performs `getOIDValueSnap` only;
+  GETNEXT performs `findNextOIDSnap`, then `getOIDValueSnap` only when a
+  successor exists. Neither is a pair-per-OID in general — the bound is what
+  matters, and it is O(1) per request OID either way. There is no `max-repetitions`
   field and nothing else a request can set to make a single OID cost more than
   one operation — that is the whole difference from GETBULK, whose `R*M` grid is
   a request-controlled multiplier on top of the OID count. The only lever left

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -535,13 +535,27 @@ packet handlers, and MIB view that call into them.
   Equivalence-vs-unbounded and encoder-parity guards:
   `TestGetBulkBoundedMatchesUnbounded_6551`,
   `TestVarbindEncodedLenMatchesEncoder_6551`.
-  **GET/GETNEXT have no equivalent amplification**: RFC 3416 §4.2.1/§4.2.2 bind
-  them to exactly one response varbind per request varbind, so their walk is
-  O(`len(oids)`) — linear in the request datagram, with no `max-repetitions`
-  multiplier — and every varbind built is a varbind the manager asked for. A
-  max-size GETNEXT (239 deep ifXTable OIDs) costs ~33 ms and returns all 239
-  varbinds in a full 4095-byte response; that cost is `findNextOIDSnap` being a
-  linear MIB scan, not unbounded expansion, and is not addressed here.
+  **GET/GETNEXT have no equivalent amplification.** The argument is an
+  OPERATION COUNT, not a byte count: RFC 3416 §4.2.1/§4.2.2 bind them to exactly
+  one response varbind per request varbind, so the work is one
+  `findNextOIDSnap` + `getOIDValueSnap` pair per DECODED REQUEST OID and every
+  varbind built is one the manager asked for. There is no `max-repetitions`
+  field and nothing else a request can set to make a single OID cost more than
+  one operation — that is the whole difference from GETBULK, whose `R*M` grid is
+  a request-controlled multiplier on top of the OID count. The only lever left
+  is how many OIDs one datagram can carry, and that is a fixed ceiling: the read
+  buffer is `maxPacketSize` (4096 bytes) and `decodePDUFields` does not require
+  a request varbind to carry a value TLV at all, so the densest packing it
+  accepts is a five-byte varbind (`30 03 06 01 2B`) — on the order of 800 OIDs
+  per datagram, not the ~580 a well-formed seven-byte varbind allows.
+  `TestWireVarbindByteFloors_6551` pins that five-byte minimum, and the
+  companion fact on the response side: `berDecodeOID` rejects an empty body and
+  yields at least two components, so a varbind built from a wire OID re-encodes
+  to at least seven bytes and the six-byte `minVarbindEncodedBytes` floor used
+  for the structural cap is conservative rather than reachable. A max-size
+  GETNEXT (239 deep ifXTable OIDs) costs ~33 ms and returns all 239 varbinds in
+  a full 4095-byte response; that cost is `findNextOIDSnap` being a linear MIB
+  scan, not unbounded expansion, and is not addressed here.
 - **GETBULK varbind order is repetition-major (RFC 3416 §4.2.3, #5065).** For
   `R` repeater columns and `M` repetitions the response interleaves by
   repetition — `rep0-col0, rep0-col1, …, rep1-col0, …` (varbind index

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -492,17 +492,56 @@ packet handlers, and MIB view that call into them.
   `min(request msgMaxSize, 4096)` with `msgMaxSize` clamped up to the RFC
   484-byte floor (a bogus/tiny advertised value cannot starve the response);
   v2c carries no per-request `msgMaxSize` on the wire, so the effective size is
-  the local 4096-byte maximum. During expansion the response is built and then
-  trimmed: the largest leading prefix of varbinds whose encoded message
-  (including the v3 USM/scopedPDU and any auth/priv overhead) fits is kept.
-  `trimToFit` finds that prefix by **binary search** — the encoded length is
-  monotonic in the number of leading varbinds — so it costs O(log n) rebuilds,
-  not the O(n) decrement-and-rebuild it replaced (#4918, which for v3 re-ran
-  USM framing/HMAC/encryption on every dropped varbind). Trimming — not
-  `tooBig` — is the normal outcome; the manager continues the walk with a
-  follow-up GETBULK from the last returned OID. `tooBig` (with an empty varbind
-  list) is returned only in the pathological case where not even a single
-  varbind fits. See `effectiveMaxSize` / `trimToFit` in `agent.go`.
+  the local 4096-byte maximum. The response is trimmed to the largest leading
+  prefix of varbinds whose encoded message (including the v3 USM/scopedPDU and
+  any auth/priv overhead) fits. `trimToFit` finds that prefix by **binary
+  search** — the encoded length is monotonic in the number of leading varbinds —
+  so it costs O(log n) rebuilds, not the O(n) decrement-and-rebuild it replaced
+  (#4918, which for v3 re-ran USM framing/HMAC/encryption on every dropped
+  varbind). Trimming — not `tooBig` — is the normal outcome; the manager
+  continues the walk with a follow-up GETBULK from the last returned OID.
+  `tooBig` (with an empty varbind list) is returned only in the pathological
+  case where not even a single varbind fits. See `effectiveMaxSize` /
+  `trimToFit` in `agent.go`.
+- **The GETBULK grid stops expanding AT the ceiling, it is not expanded and
+  then trimmed (#6551).** `buildBulkVarbinds` takes the same `maxBytes` the
+  caller will trim to and accumulates the exact encoded size of every varbind it
+  emits (`bulkBudget` / `varbindEncodedLen`), stopping the moment the varbinds
+  built already exceed it. Without that stop the whole
+  `repeaters x max-repetitions` grid was materialized first, and
+  `repeaterCount = len(oids) - nonRepeaters` is capped only by how many varbinds
+  a manager can pack into one request datagram — nothing on the decode path
+  bounds it. Every grid cell costs a `findNextOIDSnap` MIB walk plus a
+  `getOIDValueSnap`. Measured with 50 interfaces: a 4094-byte v2c GETBULK with
+  580 minimal repeater OIDs and `max-repetitions >= 100` built **58,000**
+  varbinds to return **116**, ~0.67 s on the single serial SNMP goroutine
+  against a ~2.5 us single-varbind poll — roughly 1.5 requests per second
+  saturate SNMP permanently (a community-gated management-plane availability
+  defect: a community with no `clients` list is allow-all, #4289). With the stop
+  the same request builds 118 varbinds in ~48 us and answers in ~1.0 ms with a
+  byte-identical response. The stop is output-neutral because the accumulated
+  varbind bytes are a strict lower bound on the size of any message carrying
+  them, so every dropped cell is one `trimToFit` would have discarded anyway;
+  RFC 3416 §4.2.3 removes surplus bindings from the END of the ordered set
+  ("Note that the number of variable bindings removed has no relationship to the
+  values of N, M, or R"), which is exactly the prefix this preserves — the
+  repetition-major order and per-column `endOfMibView` placement below are
+  untouched. `varbindEncodedLen` MUST stay in step with the per-varbind encoding
+  in `buildResponseVersion`: an overestimate would stop the grid short of
+  varbinds that would have fit and silently shrink large responses.
+  Fail-on-revert guards: `TestGetBulkBuildBounded_6551` (v2c),
+  `TestGetBulkBuildBoundedV3_6551` (v3),
+  `TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551` (the call sites).
+  Equivalence-vs-unbounded and encoder-parity guards:
+  `TestGetBulkBoundedMatchesUnbounded_6551`,
+  `TestVarbindEncodedLenMatchesEncoder_6551`.
+  **GET/GETNEXT have no equivalent amplification**: RFC 3416 §4.2.1/§4.2.2 bind
+  them to exactly one response varbind per request varbind, so their walk is
+  O(`len(oids)`) — linear in the request datagram, with no `max-repetitions`
+  multiplier — and every varbind built is a varbind the manager asked for. A
+  max-size GETNEXT (239 deep ifXTable OIDs) costs ~33 ms and returns all 239
+  varbinds in a full 4095-byte response; that cost is `findNextOIDSnap` being a
+  linear MIB scan, not unbounded expansion, and is not addressed here.
 - **GETBULK varbind order is repetition-major (RFC 3416 §4.2.3, #5065).** For
   `R` repeater columns and `M` repetitions the response interleaves by
   repetition — `rep0-col0, rep0-col1, …, rep1-col0, …` (varbind index

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -1297,14 +1297,19 @@ func (a *Agent) handleGetBulk(community []byte, pduBody []byte) []byte {
 	// netlink LinkList dumps (findNextOID + getOIDValue) per varbind — an
 	// O(N)/O(N²) RTM_GETLINK storm. The snapshot bounds it to one dump per PDU.
 	snap := a.newIfSnapshot()
-	varbinds := a.buildBulkVarbinds(oids, nonRepeaters, maxRepetitions, snap)
 
 	// Bound the response to maxPacketSize (RFC 3416 §4.2.3). v2c carries no
-	// per-request msgMaxSize, so the local maximum is the only ceiling. Trim
-	// trailing varbinds until the encoded message fits; the manager continues
-	// the walk from the last returned OID. Only if nothing fits do we fall
-	// back to tooBig with an empty varbind list.
-	resp, ok := trimToFit(varbinds, effectiveMaxSize(maxPacketSize), func(vbs []varbind) []byte {
+	// per-request msgMaxSize, so the local maximum is the only ceiling. The
+	// SAME ceiling is handed to buildBulkVarbinds so the grid stops expanding
+	// once it has produced more bytes than the response can carry (#6551) —
+	// the work is bounded before it is done, not trimmed after.
+	maxSize := effectiveMaxSize(maxPacketSize)
+	varbinds := a.buildBulkVarbinds(oids, nonRepeaters, maxRepetitions, snap, maxSize)
+
+	// Trim trailing varbinds until the encoded message fits; the manager
+	// continues the walk from the last returned OID. Only if nothing fits do we
+	// fall back to tooBig with an empty varbind list.
+	resp, ok := trimToFit(varbinds, maxSize, func(vbs []varbind) []byte {
 		return a.buildResponse(community, requestID, errNoError, 0, vbs)
 	})
 	if !ok {
@@ -1335,17 +1340,55 @@ func (a *Agent) handleGetBulk(community []byte, pduBody []byte) []byte {
 // that column's terminal OID) in its own cell for that repetition and every
 // later repetition, so the row*R+col index stays aligned to the originating
 // column instead of collapsing the grid.
-func (a *Agent) buildBulkVarbinds(oids [][]int, nonRepeaters, maxRepetitions int, snap *ifSnapshot) []varbind {
+//
+// maxBytes is the response ceiling the caller will bound the encoded message to
+// (effectiveMaxSize of the local maximum for v2c, of the advertised msgMaxSize
+// for v3). Expansion STOPS as soon as the varbinds produced so far already
+// encode to more than that (#6551): the grid is repeaters*maxRepetitions cells
+// and every cell costs a findNextOIDSnap MIB walk plus a getOIDValueSnap, while
+// repeaterCount = len(oids)-nonRepeaters is bounded only by how many varbinds
+// the manager can pack into one request datagram. A 4094-byte v2c GETBULK with
+// 580 minimal repeater OIDs and max-repetitions >= 100 built 58,000 varbinds to
+// return 116 — ~0.67 s of MIB walking on the single serial SNMP goroutine per
+// datagram, against a ~2.5 us baseline poll, so a handful of requests per second
+// saturates SNMP permanently (monitoring blindness).
+//
+// The stop is output-neutral. bulkBudget accumulates the EXACT encoded size of
+// each emitted varbind, which is a strict lower bound on the size of the
+// response message carrying it: the message only ADDS bytes on top — the
+// varbind-list SEQUENCE header, the PDU fields, the version/community or
+// USM/scopedPDU envelope, and for authPriv the CBC block padding around the
+// encrypted scopedPDU. So once the accumulated varbind bytes exceed maxBytes,
+// every message built
+// from that prefix — and from any longer one — is already over the ceiling and
+// would be discarded by the caller's trimToFit. Dropping those cells therefore
+// yields a byte-identical response while never performing the walk. RFC 3416
+// §4.2.3 explicitly sanctions returning fewer varbinds than requested: "If the
+// size of the message encapsulating the Response-PDU containing the requested
+// number of variable bindings would be greater than either a local constraint
+// or the maximum message size of the originator, then the response is generated
+// with a lesser number of variable bindings. [...] Note that the number of
+// variable bindings removed has no relationship to the values of N, M, or R."
+// The removal is from the END of the ordered set, which is exactly the prefix
+// this stop preserves, so the repetition-major order and the per-column
+// endOfMibView placement of #5065 are untouched.
+func (a *Agent) buildBulkVarbinds(oids [][]int, nonRepeaters, maxRepetitions int, snap *ifSnapshot, maxBytes int) []varbind {
 	var varbinds []varbind
+	budget := bulkBudget{max: maxBytes}
 
 	// Non-repeaters: a single GETNEXT for each of the first nonRepeaters OIDs.
 	for i := 0; i < nonRepeaters && i < len(oids); i++ {
+		var vb varbind
 		nextOID := a.findNextOIDSnap(oids[i], snap)
 		if nextOID == nil {
-			varbinds = append(varbinds, varbind{oid: oids[i], tag: tagEndOfMibView, value: nil})
+			vb = varbind{oid: oids[i], tag: tagEndOfMibView, value: nil}
 		} else {
 			val, valTag := a.getOIDValueSnap(nextOID, snap)
-			varbinds = append(varbinds, varbind{oid: nextOID, tag: valTag, value: val})
+			vb = varbind{oid: nextOID, tag: valTag, value: val}
+		}
+		varbinds = append(varbinds, vb)
+		if budget.add(vb) {
+			return varbinds
 		}
 	}
 
@@ -1362,24 +1405,67 @@ func (a *Agent) buildBulkVarbinds(oids [][]int, nonRepeaters, maxRepetitions int
 	}
 	for rep := 0; rep < maxRepetitions; rep++ {
 		for c := 0; c < repeaterCount; c++ {
-			if exhausted[c] {
+			var vb varbind
+			nextOID := []int(nil)
+			if !exhausted[c] {
+				nextOID = a.findNextOIDSnap(cursors[c], snap)
+			}
+			switch {
+			case exhausted[c]:
 				// Column already ran off the end of the MIB view; keep its cell
 				// filled with endOfMibView so the row*R+col mapping holds.
-				varbinds = append(varbinds, varbind{oid: cursors[c], tag: tagEndOfMibView, value: nil})
-				continue
-			}
-			nextOID := a.findNextOIDSnap(cursors[c], snap)
-			if nextOID == nil {
-				varbinds = append(varbinds, varbind{oid: cursors[c], tag: tagEndOfMibView, value: nil})
+				vb = varbind{oid: cursors[c], tag: tagEndOfMibView, value: nil}
+			case nextOID == nil:
+				vb = varbind{oid: cursors[c], tag: tagEndOfMibView, value: nil}
 				exhausted[c] = true
-				continue
+			default:
+				val, valTag := a.getOIDValueSnap(nextOID, snap)
+				vb = varbind{oid: nextOID, tag: valTag, value: val}
+				cursors[c] = nextOID
 			}
-			val, valTag := a.getOIDValueSnap(nextOID, snap)
-			varbinds = append(varbinds, varbind{oid: nextOID, tag: valTag, value: val})
-			cursors[c] = nextOID
+			varbinds = append(varbinds, vb)
+			if budget.add(vb) {
+				return varbinds
+			}
 		}
 	}
 	return varbinds
+}
+
+// bulkBudget tracks how many encoded bytes the varbinds of an in-progress
+// GETBULK grid already occupy, so expansion can stop at the response ceiling
+// instead of materializing the whole repeaters*maxRepetitions grid and trimming
+// afterwards (#6551).
+type bulkBudget struct {
+	used int // exact encoded size of the varbinds accounted so far
+	max  int // response ceiling in bytes (effectiveMaxSize of the caller's max)
+}
+
+// add accounts vb against the budget and reports whether the ceiling has been
+// passed — i.e. whether the caller must stop expanding the grid. It returns
+// true only once the accumulated varbind bytes STRICTLY exceed max, so the
+// varbind that trips it is still emitted and the caller never stops one cell
+// short of a prefix that would have fit.
+func (b *bulkBudget) add(vb varbind) bool {
+	b.used += varbindEncodedLen(vb)
+	return b.used > b.max
+}
+
+// varbindEncodedLen returns the exact number of bytes vb contributes to the
+// varbind list of an encoded response. It MUST stay in step with the per-varbind
+// encoding in buildResponseVersion / buildV3Response — an overestimate would
+// stop a GETBULK grid short of varbinds that would have fit and shrink the
+// response. TestVarbindEncodedLenMatchesEncoder_6551 pins the two together.
+func varbindEncodedLen(vb varbind) int {
+	oidBytes := berEncodeTLV(tagObjectIdentifier, berEncodeOID(vb.oid))
+	var valBytes []byte
+	if vb.tag == tagNoSuchObject || vb.tag == tagNoSuchInstance || vb.tag == tagEndOfMibView {
+		valBytes = berEncodeTLV(vb.tag, nil)
+	} else {
+		valBytes = berEncodeValue(vb.tag, vb.value)
+	}
+	body := len(oidBytes) + len(valBytes)
+	return 1 + len(berEncodeLength(body)) + body
 }
 
 // getCommunity returns the configured community matching the given string, or

--- a/pkg/snmp/getbulk_work_bound_6551_test.go
+++ b/pkg/snmp/getbulk_work_bound_6551_test.go
@@ -1,0 +1,536 @@
+package snmp
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6551: GETBULK used to materialize the whole repeaters x max-repetitions grid
+// BEFORE the RFC 3416 §4.2.3 response-size bound was applied. repeaterCount is
+// len(oids)-nonRepeaters and is bounded only by how many varbinds a manager can
+// pack into one request datagram, and every grid cell costs a findNextOIDSnap
+// MIB walk plus a getOIDValueSnap.
+//
+// Measured on the pre-fix code with 50 interfaces, a 4094-byte v2c GETBULK
+// carrying 580 minimal repeater OIDs and max-repetitions >= 100:
+//
+//	varbinds BUILT   58,000   (405 ms inside buildBulkVarbinds)
+//	varbinds RETURNED   116   (4092-byte response)
+//	end-to-end handlePacket   667 ms   vs a ~2.5 us single-varbind poll
+//
+// (the trim itself accounts for the remaining ~260 ms: trimToFit binary-searches
+// ~log2(58000) = 16 full re-encodes of the 58,000-varbind list). ~1.5 requests
+// per second saturate the single serial SNMP goroutine permanently.
+//
+// Post-fix the same request builds 118 varbinds in 48 us and answers in 1.0 ms,
+// returning the identical 116 varbinds.
+//
+// These tests assert on varbinds BUILT, not returned: the returned count was
+// always ~116, so a test that only checked the response would pass on the
+// unfixed code.
+
+// minVarbindEncodedBytes is the smallest number of bytes any varbind can
+// occupy in an encoded varbind list: a SEQUENCE header (tag + 1 length byte)
+// wrapping an empty-bodied OID TLV and an empty-bodied value TLV. berEncodeOID
+// returns a nil body for an OID with fewer than two components, so 2+2+2 is
+// actually reachable and this is a true floor, not an estimate.
+const minVarbindEncodedBytes = 6
+
+// varbindListEncodedLen sums the exact encoded size of a varbind list.
+func varbindListEncodedLen(vbs []varbind) int {
+	total := 0
+	for _, vb := range vbs {
+		total += varbindEncodedLen(vb)
+	}
+	return total
+}
+
+// maxRepeaterBulkRequest builds the largest v2c GETBULK datagram that still fits
+// in maxPacketSize, packing as many copies of start as possible as repeater
+// OIDs. It returns the datagram and the repeater count, which is the R that
+// multiplies max-repetitions in the grid.
+func maxRepeaterBulkRequest(t *testing.T, community string, maxReps int, start []int) (req []byte, repeaters int) {
+	t.Helper()
+	var oids [][]int
+	for {
+		cand := append(oids, start)
+		next := buildV2cGetBulkRequest(community, 1, 0, maxReps, cand)
+		if len(next) > maxPacketSize {
+			break
+		}
+		oids, req = cand, next
+	}
+	if len(oids) == 0 {
+		t.Fatalf("no repeater OID fits in %d bytes", maxPacketSize)
+	}
+	return req, len(oids)
+}
+
+// bulkTestAgent returns a v2c agent serving n synthetic interfaces.
+func bulkTestAgent(n int) *Agent {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+	a.SetIfDataFn(func() []IfData { return manyIfData(n) })
+	return a
+}
+
+// decodeBulkPDU strips the v2c envelope off a GETBULK request and returns the
+// decoded, clamp-applied PDU fields the handler would work from.
+func decodeBulkPDU(t *testing.T, req []byte) (nonRepeaters, maxRepetitions int, oids [][]int) {
+	t.Helper()
+	_, body, err := berDecodeHeader(req)
+	if err != nil {
+		t.Fatalf("request: outer SEQUENCE: %v", err)
+	}
+	_, rest, err := berDecodeInteger(body) // version
+	if err != nil {
+		t.Fatalf("request: version: %v", err)
+	}
+	_, rest, err = berDecodeOctetString(rest) // community
+	if err != nil {
+		t.Fatalf("request: community: %v", err)
+	}
+	_, pduBody, err := berDecodeHeader(rest)
+	if err != nil {
+		t.Fatalf("request: PDU header: %v", err)
+	}
+	_, nonRepeaters, maxRepetitions, oids, err = decodePDUFields(pduBody)
+	if err != nil {
+		t.Fatalf("request: PDU fields: %v", err)
+	}
+	if maxRepetitions > 100 {
+		maxRepetitions = 100 // the handler's own defense-in-depth clamp
+	}
+	return nonRepeaters, maxRepetitions, oids
+}
+
+// TestGetBulkBuildBounded_6551 is the fail-on-revert guard. It drives the
+// worst-case shape — a max-size datagram of minimal repeater OIDs with
+// max-repetitions clamped to 100 — straight at buildBulkVarbinds and asserts on
+// how many varbinds it BUILT.
+//
+// To neutralize the fix for a RED-on-revert check, make bulkBudget.add always
+// report false (`return false` as its body); that compiles cleanly and restores
+// the unbounded grid, and this test then fails on the built-count assertions.
+func TestGetBulkBuildBounded_6551(t *testing.T) {
+	a := bulkTestAgent(50)
+	req, repeaters := maxRepeaterBulkRequest(t, "public", 100000, []int{1, 3})
+	nonRep, maxReps, oids := decodeBulkPDU(t, req)
+
+	if repeaters < 100 {
+		t.Fatalf("test is not exercising the defect: only %d repeaters fit", repeaters)
+	}
+	if maxReps != 100 {
+		t.Fatalf("max-repetitions clamp = %d, want 100", maxReps)
+	}
+	grid := repeaters * maxReps // what the pre-fix code materialized
+
+	maxSize := effectiveMaxSize(maxPacketSize)
+	built := a.buildBulkVarbinds(oids, nonRep, maxReps, a.newIfSnapshot(), maxSize)
+
+	// (1) Structural bound: every varbind occupies at least
+	// minVarbindEncodedBytes on the wire, so a build that stops at the response
+	// ceiling can never produce more than maxSize/minVarbindEncodedBytes cells
+	// (+1 for the cell that trips the budget).
+	hardCap := maxSize/minVarbindEncodedBytes + 1
+	if len(built) > hardCap {
+		t.Fatalf("buildBulkVarbinds built %d varbinds for a %d-byte ceiling; "+
+			"at >= %d bytes each no more than %d can ever be returned "+
+			"(grid was %d cells, each a MIB walk)",
+			len(built), maxSize, minVarbindEncodedBytes, hardCap, grid)
+	}
+
+	// (2) Exact invariant: everything built except the cell that tripped the
+	// budget must still fit the ceiling. This is the real contract — "never
+	// build more than can be returned" — and it is what makes the work
+	// proportional to the response rather than to R*M.
+	if n := len(built); n > 1 {
+		if used := varbindListEncodedLen(built[:n-1]); used > maxSize {
+			t.Fatalf("varbinds built beyond the ceiling: built[:%d] encodes to %d bytes > %d",
+				n-1, used, maxSize)
+		}
+	}
+
+	// (3) Amplification: the response for this request is ~116 varbinds. The
+	// pre-fix build/return ratio was 500x.
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	errStatus, returned := v2cResponseVarbinds(t, resp)
+	if errStatus != errNoError {
+		t.Fatalf("error-status = %d, want noError", errStatus)
+	}
+	if len(returned) == 0 {
+		t.Fatal("no varbinds returned; manager cannot continue the walk")
+	}
+	// Every cell the grid builds past the returned prefix is pure waste. The
+	// envelope (version/community/PDU headers) costs at most a handful of
+	// varbinds' worth of budget, so a correct stop overshoots by a tiny margin.
+	if len(built) > len(returned)+16 {
+		t.Fatalf("built %d varbinds to return %d (%.0fx amplification); "+
+			"the grid is not bounded by the response ceiling",
+			len(built), len(returned), float64(len(built))/float64(len(returned)))
+	}
+	t.Logf("grid %d cells -> built %d -> returned %d (%d-byte response)",
+		grid, len(built), len(returned), len(resp))
+}
+
+// TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551 guards the CALL SITES.
+// The assertions above drive buildBulkVarbinds directly with the real ceiling,
+// so they would still pass if handleGetBulk (or the v3 dispatcher) started
+// handing it an effectively infinite budget. This one goes through
+// handlePacket and pins the property that actually matters end to end: once the
+// response ceiling is reached, answering a GETBULK must cost the same whether
+// the manager asked for 1 repetition or 100.
+//
+// It is a ratio between two measurements of the same magnitude on the same
+// machine, not an absolute deadline, so machine load cancels out. Pre-fix the
+// R*100 grid costs ~100x the R*1 grid (58,000 cells vs 580); post-fix both stop
+// at the same ~118 cells and the ratio sits near 1. The 10x threshold has an
+// order of magnitude of headroom on both sides.
+func TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551(t *testing.T) {
+	a := bulkTestAgent(50)
+	oneRep, _ := maxRepeaterBulkRequest(t, "public", 1, []int{1, 3})
+	manyRep, repeaters := maxRepeaterBulkRequest(t, "public", 100, []int{1, 3})
+
+	timeReq := func(req []byte) time.Duration {
+		const iters = 5
+		a.handlePacket(req) // warm any lazily-built state
+		start := time.Now()
+		for i := 0; i < iters; i++ {
+			if a.handlePacket(req) == nil {
+				t.Fatal("nil response")
+			}
+		}
+		return time.Since(start) / iters
+	}
+
+	// Measure in both orders and keep the better (smallest) reading for each, so
+	// a scheduling hiccup landing on one measurement cannot manufacture a ratio.
+	one, many := timeReq(oneRep), timeReq(manyRep)
+	if second := timeReq(manyRep); second < many {
+		many = second
+	}
+	if second := timeReq(oneRep); second < one {
+		one = second
+	}
+	if one <= 0 {
+		t.Skip("timer resolution too coarse to compare")
+	}
+
+	ratio := float64(many) / float64(one)
+	t.Logf("%d repeaters: max-repetitions=1 %v, max-repetitions=100 %v (ratio %.1fx)",
+		repeaters, one, many, ratio)
+	if ratio > 10 {
+		t.Fatalf("GETBULK cost scales with max-repetitions: %v at M=1 vs %v at M=100 (%.1fx); "+
+			"the grid is still expanding past the response ceiling", one, many, ratio)
+	}
+}
+
+// TestGetBulkBuildBoundedV3_6551 is the same guard for the SNMPv3 path, which
+// shares buildBulkVarbinds but bounds against the manager-advertised
+// msgMaxSize. An unbounded grid hurts more here: every trimToFit rebuild re-runs
+// USM framing and HMAC over the whole varbind list.
+func TestGetBulkBuildBoundedV3_6551(t *testing.T) {
+	a, authKey, engineID, boots, tm := v3GetBulkAgent(t, manyIfData(50))
+
+	// Pack the v3 request with as many minimal repeater OIDs as fit.
+	var oids [][]int
+	var req []byte
+	for {
+		cand := append(oids, []int{1, 3})
+		next := buildV3GetBulkRequest(t, "sha", "alice", engineID, authKey, boots, tm,
+			maxPacketSize, 0, 100, cand)
+		if len(next) > maxPacketSize {
+			break
+		}
+		oids, req = cand, next
+	}
+	if len(oids) < 100 {
+		t.Fatalf("test is not exercising the defect: only %d v3 repeaters fit", len(oids))
+	}
+
+	maxSize := effectiveMaxSize(maxPacketSize)
+	built := a.buildBulkVarbinds(oids, 0, 100, a.newIfSnapshot(), maxSize)
+	hardCap := maxSize/minVarbindEncodedBytes + 1
+	if len(built) > hardCap {
+		t.Fatalf("v3 buildBulkVarbinds built %d varbinds for a %d-byte ceiling, cap %d (grid was %d cells)",
+			len(built), maxSize, hardCap, len(oids)*100)
+	}
+
+	resp := a.handlePacketFrom(req, nil)
+	if resp == nil {
+		t.Fatal("nil v3 response")
+	}
+	if len(resp) > maxPacketSize {
+		t.Fatalf("v3 response %d bytes exceeds %d", len(resp), maxPacketSize)
+	}
+	errStatus, returned := v3ResponseErrorStatus(t, resp)
+	if errStatus != errNoError {
+		t.Fatalf("v3 error-status = %d, want noError", errStatus)
+	}
+	if len(built) > len(returned)+16 {
+		t.Fatalf("v3 built %d varbinds to return %d; grid not bounded by the ceiling",
+			len(built), len(returned))
+	}
+	t.Logf("v3: grid %d cells -> built %d -> returned %d (%d-byte response)",
+		len(oids)*100, len(built), len(returned), len(resp))
+}
+
+// TestGetBulkBoundedMatchesUnbounded_6551 is the over-reach guard. Stopping the
+// grid early must be output-neutral: for every shape, the response built from
+// the bounded grid must be BYTE-IDENTICAL to the one built from the full
+// (pre-fix) grid, because the cells the stop drops are exactly the ones
+// trimToFit would have discarded.
+//
+// math.MaxInt as the budget reproduces the pre-fix expansion exactly — the
+// budget never trips — so the comparison is against the real old behavior, not
+// against a restatement of the new one.
+//
+// The walk start OIDs deliberately sit at or after sysUpTime in the static OID
+// order, so no varbind in these responses carries the live TimeTicks counter,
+// which would otherwise differ between the two builds for reasons unrelated to
+// the bound.
+func TestGetBulkBoundedMatchesUnbounded_6551(t *testing.T) {
+	deepTail := []int{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 50}
+	cases := []struct {
+		name         string
+		ifaces       int
+		nonRepeaters int
+		maxReps      int
+		oids         [][]int
+	}{
+		// Ordinary small requests: must be untouched by the bound.
+		{"small-one-repeater", 1, 0, 3, [][]int{oidSysUpTime}},
+		{"small-three-columns", 4, 0, 5, [][]int{oidSysUpTime, oidIfTablePrefix, oidIfXTablePrefix}},
+		{"small-with-nonrepeaters", 4, 2, 4, [][]int{oidSysUpTime, oidIfNumber, oidIfTablePrefix, oidIfXTablePrefix}},
+		// MIB exhaustion: columns run off the end of the view and emit
+		// endOfMibView placeholders; the bound must not disturb that.
+		{"exhausted-columns", 2, 0, 40, [][]int{deepTail, oidIfXTablePrefix}},
+		{"exhausted-nonrepeater", 2, 1, 20, [][]int{deepTail, oidIfTablePrefix}},
+		// Oversized: the bound actually fires and the response is trimmed.
+		{"oversized-single-column", 50, 0, 100, [][]int{oidIfTablePrefix}},
+		{"oversized-deep-tail", 50, 0, 100, [][]int{deepTail}},
+		{"oversized-many-columns", 50, 0, 100, repeatOID(oidIfTablePrefix, 60)},
+		{"oversized-with-nonrepeaters", 50, 3, 100, repeatOID(oidIfXTablePrefix, 40)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := bulkTestAgent(tc.ifaces)
+			maxSize := effectiveMaxSize(maxPacketSize)
+			build := func(vbs []varbind) []byte {
+				return a.buildResponse([]byte("public"), 42, errNoError, 0, vbs)
+			}
+
+			bounded := a.buildBulkVarbinds(tc.oids, tc.nonRepeaters, tc.maxReps, a.newIfSnapshot(), maxSize)
+			unbounded := a.buildBulkVarbinds(tc.oids, tc.nonRepeaters, tc.maxReps, a.newIfSnapshot(), math.MaxInt)
+
+			if len(bounded) > len(unbounded) {
+				t.Fatalf("bounded build produced MORE varbinds (%d) than the unbounded one (%d)",
+					len(bounded), len(unbounded))
+			}
+			// The bounded list must be a prefix of the unbounded one: same
+			// cells, same order, just stopped early (RFC 3416 §4.2.3 removes
+			// from the END of the ordered set).
+			for i := range bounded {
+				if !oidEqual(bounded[i].oid, unbounded[i].oid) ||
+					bounded[i].tag != unbounded[i].tag ||
+					!bytes.Equal(bounded[i].value, unbounded[i].value) {
+					t.Fatalf("varbind[%d] differs: bounded {oid=%v tag=0x%02x} vs unbounded {oid=%v tag=0x%02x}",
+						i, bounded[i].oid, bounded[i].tag, unbounded[i].oid, unbounded[i].tag)
+				}
+			}
+
+			boundedResp, okB := trimToFit(bounded, maxSize, build)
+			unboundedResp, okU := trimToFit(unbounded, maxSize, build)
+			if okB != okU {
+				t.Fatalf("trimToFit ok mismatch: bounded=%v unbounded=%v", okB, okU)
+			}
+			if !bytes.Equal(boundedResp, unboundedResp) {
+				t.Fatalf("response differs from the unbounded build: %d bytes vs %d bytes",
+					len(boundedResp), len(unboundedResp))
+			}
+			if len(boundedResp) > maxSize {
+				t.Fatalf("response %d bytes exceeds ceiling %d", len(boundedResp), maxSize)
+			}
+			t.Logf("grid %d cells, built %d (unbounded %d), response %d bytes",
+				len(tc.oids)*tc.maxReps, len(bounded), len(unbounded), len(boundedResp))
+		})
+	}
+}
+
+// repeatOID returns n copies of oid, for building wide repeater lists.
+func repeatOID(oid []int, n int) [][]int {
+	out := make([][]int, n)
+	for i := range out {
+		out[i] = oid
+	}
+	return out
+}
+
+// TestVarbindEncodedLenMatchesEncoder_6551 pins varbindEncodedLen to what the
+// response encoder actually emits. The bound is only output-neutral while the
+// accounted size is a true lower bound on the encoded message: an OVERestimate
+// would stop the grid short of varbinds that would have fit and silently shrink
+// every large GETBULK response. The expected value is read back off a real
+// encoded response rather than recomputed, so this fails if the two encodings
+// ever drift apart.
+func TestVarbindEncodedLenMatchesEncoder_6551(t *testing.T) {
+	a := bulkTestAgent(1)
+	long := make([]byte, 300) // forces a multi-byte BER length header
+	for i := range long {
+		long[i] = 'x'
+	}
+	cases := []struct {
+		name string
+		vb   varbind
+	}{
+		{"short-oid-octet-string", varbind{oid: oidSysDescr, tag: tagOctetString, value: []byte("xpf")}},
+		{"empty-value", varbind{oid: oidSysContact, tag: tagOctetString, value: nil}},
+		{"long-value-multibyte-length", varbind{oid: oidSysLocation, tag: tagOctetString, value: long}},
+		{"integer", varbind{oid: oidIfNumber, tag: tagInteger, value: berEncodeIntegerValue(42)}},
+		{"counter64", varbind{oid: []int{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 6, 1}, tag: tagCounter64,
+			value: berEncodeCounter64(18000000000000000000)}},
+		{"end-of-mib-view", varbind{oid: []int{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 50}, tag: tagEndOfMibView}},
+		{"no-such-instance", varbind{oid: oidSysName, tag: tagNoSuchInstance}},
+		{"no-such-object", varbind{oid: oidSysObjectID, tag: tagNoSuchObject}},
+		{"large-subid-oid", varbind{oid: []int{1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 2097151}, tag: tagInteger,
+			value: berEncodeIntegerValue(1)}},
+		{"short-oid-no-body", varbind{oid: []int{1}, tag: tagEndOfMibView}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := a.buildResponse([]byte("public"), 1, errNoError, 0, []varbind{tc.vb})
+			want := onlyVarbindEncodedLen(t, resp)
+			if got := varbindEncodedLen(tc.vb); got != want {
+				t.Fatalf("varbindEncodedLen = %d, encoder emitted %d bytes", got, want)
+			}
+		})
+	}
+
+	// A varbind can never encode to fewer than minVarbindEncodedBytes, which is
+	// what the structural cap in TestGetBulkBuildBounded_6551 rests on.
+	for _, tc := range cases {
+		if n := varbindEncodedLen(tc.vb); n < minVarbindEncodedBytes {
+			t.Fatalf("%s: varbindEncodedLen = %d < floor %d", tc.name, n, minVarbindEncodedBytes)
+		}
+	}
+}
+
+// onlyVarbindEncodedLen returns the encoded byte length of the single varbind in
+// a v2c GetResponse, read straight off the wire. It walks TLV headers only and
+// never decodes the OID body, so it also measures degenerate shapes (an OID with
+// fewer than two components encodes to an empty body, which berDecodeOID
+// rejects) — buildBulkVarbinds echoes request OIDs verbatim in its endOfMibView
+// cells, so such a varbind is reachable and must still be accounted correctly.
+func onlyVarbindEncodedLen(t *testing.T, resp []byte) int {
+	t.Helper()
+	_, body, err := berDecodeHeader(resp)
+	if err != nil {
+		t.Fatalf("resp: outer SEQUENCE: %v", err)
+	}
+	_, rest, err := berDecodeInteger(body) // version
+	if err != nil {
+		t.Fatalf("resp: version: %v", err)
+	}
+	_, rest, err = berDecodeOctetString(rest) // community
+	if err != nil {
+		t.Fatalf("resp: community: %v", err)
+	}
+	_, pduBody, err := berDecodeHeader(rest)
+	if err != nil {
+		t.Fatalf("resp: PDU: %v", err)
+	}
+	_, pduRest, err := berDecodeInteger(pduBody) // request-id
+	if err != nil {
+		t.Fatalf("resp: request-id: %v", err)
+	}
+	_, pduRest, err = berDecodeInteger(pduRest) // error-status
+	if err != nil {
+		t.Fatalf("resp: error-status: %v", err)
+	}
+	_, pduRest, err = berDecodeInteger(pduRest) // error-index
+	if err != nil {
+		t.Fatalf("resp: error-index: %v", err)
+	}
+	tag, vbListBody, err := berDecodeHeader(pduRest)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("resp: varbind list: %v", err)
+	}
+	n := berEncodedLen(vbListBody)
+	if n <= 0 || n > len(vbListBody) {
+		t.Fatalf("resp: varbind length %d out of range (list body %d)", n, len(vbListBody))
+	}
+	return n
+}
+
+// TestGetBulkTrimmedTailIsWellFormed_6551 checks the truncated response is one a
+// normal manager can act on, not merely a smaller one: the varbind list decodes
+// cleanly, stays in repetition-major order (varbind index nonRepeaters+rep*R+col
+// per RFC 3416 §4.2.3 / #5065), the tail is a complete varbind rather than a
+// severed one, and any endOfMibView marker sits in its own column's cell.
+func TestGetBulkTrimmedTailIsWellFormed_6551(t *testing.T) {
+	const repeaters = 3
+	a := bulkTestAgent(50)
+	oids := [][]int{oidIfTablePrefix, oidIfXTablePrefix, []int{1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 40}}
+	req := buildV2cGetBulkRequest("public", 7, 0, 100, oids)
+
+	resp := a.handlePacket(req)
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	if len(resp) > maxPacketSize {
+		t.Fatalf("response %d bytes exceeds %d", len(resp), maxPacketSize)
+	}
+	// decodeVarbindOIDs fatals on any malformed varbind, so a clean decode is
+	// itself the well-formedness check.
+	errStatus, got := v2cResponseVarbinds(t, resp)
+	if errStatus != errNoError {
+		t.Fatalf("error-status = %d, want noError", errStatus)
+	}
+	if len(got) < repeaters {
+		t.Fatalf("only %d varbinds returned; not even one full repetition", len(got))
+	}
+
+	// The response must be the leading prefix of the unbounded grid, so each
+	// returned varbind still lands in its originating column.
+	full := a.buildBulkVarbinds(oids, 0, 100, a.newIfSnapshot(), math.MaxInt)
+	if len(got) > len(full) {
+		t.Fatalf("returned %d varbinds, grid only has %d", len(got), len(full))
+	}
+	for i := range got {
+		if !oidEqual(got[i], full[i].oid) {
+			t.Fatalf("varbind[%d] OID %v is not the grid's cell %v (order or column alignment broken)",
+				i, got[i], full[i].oid)
+		}
+	}
+
+	// Column 2 starts at the ifXTable tail and exhausts almost immediately, so
+	// its cells become endOfMibView while columns 0/1 keep returning data —
+	// exactly the per-column placeholder contract. Verify the exhausted column's
+	// cells carry endOfMibView and the others do not.
+	sawExhausted := false
+	for i := 0; i+repeaters <= len(got); i += repeaters {
+		if full[i+2].tag == tagEndOfMibView {
+			sawExhausted = true
+		}
+		for col := 0; col < 2; col++ {
+			if full[i+col].tag == tagEndOfMibView {
+				t.Fatalf("column %d cell at varbind %d is endOfMibView; it should still have data",
+					col, i+col)
+			}
+		}
+	}
+	if !sawExhausted {
+		t.Fatal("test did not exercise an exhausted column; endOfMibView placement unverified")
+	}
+}

--- a/pkg/snmp/getbulk_work_bound_6551_test.go
+++ b/pkg/snmp/getbulk_work_bound_6551_test.go
@@ -33,11 +33,29 @@ import (
 // always ~116, so a test that only checked the response would pass on the
 // unfixed code.
 
-// minVarbindEncodedBytes is the smallest number of bytes any varbind can
-// occupy in an encoded varbind list: a SEQUENCE header (tag + 1 length byte)
-// wrapping an empty-bodied OID TLV and an empty-bodied value TLV. berEncodeOID
-// returns a nil body for an OID with fewer than two components, so 2+2+2 is
-// actually reachable and this is a true floor, not an estimate.
+// minVarbindEncodedBytes is a lower bound on the bytes any varbind can occupy
+// in an encoded varbind list: a SEQUENCE header (tag + 1 length byte, a minimal
+// body being far below 128) wrapping an OID TLV and a value TLV, each at least
+// a bare tag + length byte. 2+2+2.
+//
+// It is used for one thing only — capping how many cells a build that stops at
+// the response ceiling could possibly have produced — and for that a valid
+// floor is all that is required. The floor is attained only by the degenerate
+// shape berEncodeOID emits a nil body for (an OID with fewer than two
+// components), which TestVarbindEncodedLenMatchesEncoder_6551 exercises as
+// "short-oid-no-body". buildBulkVarbinds cannot produce one from a real
+// request: its OIDs are either walked out of the MIB or echoed from the
+// request, and berDecodeOID rejects an empty body while turning any non-empty
+// one into at least two components, so every varbind reachable from the wire
+// re-encodes to at least 7 bytes. A floor of 6 therefore makes the cap
+// CONSERVATIVE, never unsound. TestWireVarbindByteFloors_6551 pins both halves
+// of that.
+//
+// The cap bounds the CELL COUNT of the build. It says nothing about whether the
+// response fits: real returned varbinds carry full OIDs and values and are far
+// larger than any floor. Fitting is trimToFit's job, and the equality oracle
+// TestGetBulkBoundedMatchesUnbounded_6551 is what proves the stop does not
+// disturb it.
 const minVarbindEncodedBytes = 6
 
 // varbindListEncodedLen sums the exact encoded size of a varbind list.
@@ -183,13 +201,17 @@ func TestGetBulkBuildBounded_6551(t *testing.T) {
 		grid, len(built), len(returned), len(resp))
 }
 
-// TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551 guards the CALL SITES.
-// The assertions above drive buildBulkVarbinds directly with the real ceiling,
-// so they would still pass if handleGetBulk (or the v3 dispatcher) started
-// handing it an effectively infinite budget. This one goes through
+// TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551 guards the v2c CALL SITE
+// (handleGetBulk, agent.go). The assertions above drive buildBulkVarbinds
+// directly with the real ceiling, so they would still pass if handleGetBulk
+// started handing it an effectively infinite budget. This one goes through
 // handlePacket and pins the property that actually matters end to end: once the
 // response ceiling is reached, answering a GETBULK must cost the same whether
 // the manager asked for 1 repetition or 100.
+//
+// It covers v2c ONLY. The v3 dispatcher is a separate call site that computes
+// its own ceiling, and unbounding it leaves every assertion here green —
+// TestGetBulkCostDoesNotScaleWithMaxRepetitionsV3_6551 below is its guard.
 //
 // It is a ratio between two measurements of the same magnitude on the same
 // machine, not an absolute deadline, so machine load cancels out. Pre-fix the
@@ -283,6 +305,103 @@ func TestGetBulkBuildBoundedV3_6551(t *testing.T) {
 	}
 	t.Logf("v3: grid %d cells -> built %d -> returned %d (%d-byte response)",
 		len(oids)*100, len(built), len(returned), len(resp))
+}
+
+// v3MaxRepeaterBulkRequest builds the largest SNMPv3 authNoPriv GETBULK
+// datagram that still fits in maxPacketSize, packing as many minimal repeater
+// OIDs as the USM envelope leaves room for. It returns the datagram and the
+// repeater count R that multiplies max-repetitions in the grid.
+func v3MaxRepeaterBulkRequest(t *testing.T, engineID, authKey []byte, boots, tm, maxReps int) (req []byte, repeaters int) {
+	t.Helper()
+	var oids [][]int
+	for {
+		cand := append(oids, []int{1, 3})
+		next := buildV3GetBulkRequest(t, "sha", "alice", engineID, authKey, boots, tm,
+			maxPacketSize, 0, maxReps, cand)
+		if len(next) > maxPacketSize {
+			break
+		}
+		oids, req = cand, next
+	}
+	if len(oids) == 0 {
+		t.Fatalf("no v3 repeater OID fits in %d bytes", maxPacketSize)
+	}
+	return req, len(oids)
+}
+
+// v3GetBulkAllocs returns the mean number of heap allocations the agent
+// performs answering req end to end through the real v3 dispatcher.
+//
+// Allocations are the work proxy here rather than wall time. Every grid cell
+// allocates — findNextOIDSnap returns a freshly built OID and getOIDValueSnap a
+// freshly encoded value — and every trimToFit rebuild re-encodes the surviving
+// prefix under USM, so the count rises with the number of cells actually
+// walked. Unlike a duration it is a count: it cannot be moved by machine load,
+// so the comparison below is deterministic rather than a timing race.
+func v3GetBulkAllocs(t *testing.T, a *Agent, req []byte) float64 {
+	t.Helper()
+	return testing.AllocsPerRun(3, func() {
+		if a.handlePacketFrom(req, nil) == nil {
+			t.Fatal("nil v3 response")
+		}
+	})
+}
+
+// TestGetBulkCostDoesNotScaleWithMaxRepetitionsV3_6551 guards the SNMPv3 CALL
+// SITE. It is deliberately NOT shared with the v2c sibling: the two entry
+// points are separate surfaces that each compute and pass their own ceiling
+// (handleGetBulk passes effectiveMaxSize(maxPacketSize), the v3 dispatcher
+// effectiveMaxSize(msgMaxSize)), so a regression that unbounds one leaves the
+// other correct and a single shared test re-masks the split.
+//
+// TestGetBulkBuildBoundedV3_6551 above cannot cover this: it calls
+// buildBulkVarbinds itself with the real ceiling, so its built-count assertions
+// hold no matter what budget v3.go passes. Everything it checks about the
+// handlePacketFrom response — size, error-status, varbind count — is identical
+// bounded or not, because trimToFit produces the same bytes either way. That is
+// the whole point of the fix being output-neutral, and it is why only a COST
+// assertion can see the difference.
+//
+// The pinned property is the v2c sibling's: once the response ceiling is
+// reached, answering a GETBULK must cost the same whether the manager asked for
+// 1 repetition or 100. With R repeaters filling the datagram, an unbounded grid
+// walks R cells at M=1 and R*100 at M=100, while a bounded one stops at the
+// same ~120 cells in both. The 10x threshold sits an order of magnitude below
+// the ~100x an unbounded v3 call site produces and an order of magnitude above
+// the ~1x a bounded one does.
+func TestGetBulkCostDoesNotScaleWithMaxRepetitionsV3_6551(t *testing.T) {
+	a, authKey, engineID, boots, tm := v3GetBulkAgent(t, manyIfData(50))
+	oneRep, _ := v3MaxRepeaterBulkRequest(t, engineID, authKey, boots, tm, 1)
+	manyRep, repeaters := v3MaxRepeaterBulkRequest(t, engineID, authKey, boots, tm, 100)
+	if repeaters < 100 {
+		t.Fatalf("test is not exercising the defect: only %d v3 repeaters fit", repeaters)
+	}
+
+	// Both requests must actually be answered; a v3 auth/timeliness reject
+	// would make this a comparison of two report PDUs and prove nothing.
+	for name, req := range map[string][]byte{"max-repetitions=1": oneRep, "max-repetitions=100": manyRep} {
+		resp := a.handlePacketFrom(req, nil)
+		if resp == nil {
+			t.Fatalf("%s: nil v3 response", name)
+		}
+		if errStatus, returned := v3ResponseErrorStatus(t, resp); errStatus != errNoError || len(returned) == 0 {
+			t.Fatalf("%s: error-status = %d with %d varbinds; want noError with a non-empty walk",
+				name, errStatus, len(returned))
+		}
+	}
+
+	one, many := v3GetBulkAllocs(t, a, oneRep), v3GetBulkAllocs(t, a, manyRep)
+	if one <= 0 {
+		t.Fatalf("no allocations measured at max-repetitions=1 (%v); the probe is not measuring the walk", one)
+	}
+
+	ratio := many / one
+	t.Logf("v3 %d repeaters: max-repetitions=1 %.0f allocs, max-repetitions=100 %.0f allocs (ratio %.1fx)",
+		repeaters, one, many, ratio)
+	if ratio > 10 {
+		t.Fatalf("v3 GETBULK cost scales with max-repetitions: %.0f allocs at M=1 vs %.0f at M=100 (%.1fx); "+
+			"the v3 call site is not handing buildBulkVarbinds the response ceiling", one, many, ratio)
+	}
 }
 
 // TestGetBulkBoundedMatchesUnbounded_6551 is the over-reach guard. Stopping the
@@ -471,6 +590,126 @@ func onlyVarbindEncodedLen(t *testing.T, resp []byte) int {
 		t.Fatalf("resp: varbind length %d out of range (list body %d)", n, len(vbListBody))
 	}
 	return n
+}
+
+// TestWireVarbindByteFloors_6551 binds the two wire-level facts the size
+// arithmetic around minVarbindEncodedBytes rests on, so neither can decay into
+// prose the decoder no longer supports.
+//
+//  1. RESPONSE side: a varbind whose OID came off the wire cannot reach the
+//     6-byte floor. berDecodeOID rejects an empty body and turns any non-empty
+//     one into at least two components, which berEncodeOID re-encodes to at
+//     least one content byte, so 7 is the true minimum for a wire-derived
+//     varbind. 6 remains a valid floor — that is why the structural cap is
+//     sound — but it is a conservative one, not the reachable minimum.
+//
+//  2. REQUEST side: decodePDUFields does NOT require a varbind to carry a value
+//     TLV, so the densest packing it accepts is a 5-byte varbind, not the
+//     7-byte well-formed one. Any bound on how many OIDs a single datagram can
+//     deliver — and therefore on how many GET/GETNEXT operations one request
+//     can buy — has to use 5.
+func TestWireVarbindByteFloors_6551(t *testing.T) {
+	// (1) Every single-content-byte OID body decodes to two components and
+	// re-encodes to a varbind of at least 7 bytes.
+	for _, b := range []byte{0x00, 0x2b, 0x7f, 0xff} {
+		oid, err := berDecodeOID([]byte{b})
+		if err != nil {
+			t.Fatalf("berDecodeOID(%#02x): %v", b, err)
+		}
+		if len(oid) < 2 {
+			t.Fatalf("berDecodeOID(%#02x) = %v; a wire OID always yields >= 2 components", b, oid)
+		}
+		if n := varbindEncodedLen(varbind{oid: oid, tag: tagEndOfMibView}); n < 7 {
+			t.Fatalf("wire-derived varbind for %v encodes to %d bytes; want >= 7 "+
+				"(the %d-byte floor is only reachable with an empty OID body)",
+				oid, n, minVarbindEncodedBytes)
+		}
+	}
+	if _, err := berDecodeOID(nil); err == nil {
+		t.Fatalf("berDecodeOID accepted an empty body; the %d-byte floor would then be wire-reachable",
+			minVarbindEncodedBytes)
+	}
+	// The floor itself stays attainable through the encoder, which is what
+	// keeps it a floor rather than an overestimate.
+	if n := varbindEncodedLen(varbind{oid: []int{1}, tag: tagEndOfMibView}); n != minVarbindEncodedBytes {
+		t.Fatalf("short-OID varbind encodes to %d bytes, floor is %d", n, minVarbindEncodedBytes)
+	}
+
+	// (2) A request varbind carrying no value TLV at all is accepted, and its
+	// OID is delivered to the handler exactly like a well-formed one's.
+	valueless := []byte{tagSequence, 0x03, tagObjectIdentifier, 0x01, 0x2b}
+	wellFormed := berEncodeTLV(tagSequence,
+		append(berEncodeTLV(tagObjectIdentifier, berEncodeOID([]int{1, 3})),
+			berEncodeTLV(tagNull, nil)...))
+	if len(valueless) != 5 || len(wellFormed) != 7 {
+		t.Fatalf("varbind sizes changed: valueless %d bytes, well-formed %d bytes; want 5 and 7",
+			len(valueless), len(wellFormed))
+	}
+	for name, vb := range map[string][]byte{"valueless": valueless, "well-formed": wellFormed} {
+		pduBody := berEncodeIntegerTLV(1)                           // request-id
+		pduBody = append(pduBody, berEncodeIntegerTLV(0)...)        // non-repeaters
+		pduBody = append(pduBody, berEncodeIntegerTLV(0)...)        // max-repetitions
+		pduBody = append(pduBody, berEncodeTLV(tagSequence, vb)...) // varbind list
+		_, _, _, oids, err := decodePDUFields(pduBody)
+		if err != nil {
+			t.Fatalf("%s varbind: decodePDUFields: %v", name, err)
+		}
+		if len(oids) != 1 || !oidEqual(oids[0], []int{1, 3}) {
+			t.Fatalf("%s varbind decoded to %v; want exactly one OID [1 3] "+
+				"(a value TLV is not required, so 5 bytes is the densest accepted packing)",
+				name, oids)
+		}
+	}
+
+	// (3) The GET/GETNEXT operation ceiling that follows from (2): one
+	// operation per decoded request OID, so the most a single datagram can buy
+	// is however many varbinds fit the maxPacketSize read buffer. Packed with
+	// value-less varbinds that is materially more than the well-formed packing,
+	// which is exactly why the ceiling has to be derived from 5 bytes.
+	valuelessOIDs := densestGetNextOIDs(t, valueless)
+	wellFormedOIDs := densestGetNextOIDs(t, wellFormed)
+	if valuelessOIDs <= wellFormedOIDs {
+		t.Fatalf("value-less packing delivered %d OIDs, well-formed %d; the denser packing must win",
+			valuelessOIDs, wellFormedOIDs)
+	}
+	if valuelessOIDs < 700 || valuelessOIDs > 900 {
+		t.Fatalf("densest GETNEXT datagram delivers %d OIDs; README documents ~800 operations "+
+			"as the per-datagram ceiling", valuelessOIDs)
+	}
+	t.Logf("max-size GETNEXT delivers %d OIDs packed value-less (%d bytes each) vs %d well-formed (%d bytes each)",
+		valuelessOIDs, len(valueless), wellFormedOIDs, len(wellFormed))
+}
+
+// densestGetNextOIDs packs copies of one encoded request varbind into the
+// largest v2c GETNEXT datagram that still fits maxPacketSize and returns how
+// many OIDs the agent's decoder actually delivers from it — i.e. how many
+// findNextOIDSnap operations that one datagram buys.
+func densestGetNextOIDs(t *testing.T, vb []byte) int {
+	t.Helper()
+	var packed []byte
+	for {
+		cand := append(packed, vb...)
+		pdu := berEncodeIntegerTLV(1)                         // request-id
+		pdu = append(pdu, berEncodeIntegerTLV(0)...)          // error-status
+		pdu = append(pdu, berEncodeIntegerTLV(0)...)          // error-index
+		pdu = append(pdu, berEncodeTLV(tagSequence, cand)...) // varbind list
+		msg := berEncodeIntegerTLV(snmpVersion2c)
+		msg = append(msg, berEncodeTLV(tagOctetString, []byte("public"))...)
+		msg = append(msg, berEncodeTLV(pduGetNextRequest, pdu)...)
+		if len(berEncodeTLV(tagSequence, msg)) > maxPacketSize {
+			break
+		}
+		packed = cand
+	}
+	pdu := berEncodeIntegerTLV(1)
+	pdu = append(pdu, berEncodeIntegerTLV(0)...)
+	pdu = append(pdu, berEncodeIntegerTLV(0)...)
+	pdu = append(pdu, berEncodeTLV(tagSequence, packed)...)
+	_, _, _, oids, err := decodePDUFields(pdu)
+	if err != nil {
+		t.Fatalf("densest GETNEXT PDU: decodePDUFields: %v", err)
+	}
+	return len(oids)
 }
 
 // TestGetBulkTrimmedTailIsWellFormed_6551 checks the truncated response is one a

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -446,20 +446,24 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 			}
 			break
 		}
-		// Repetition-major, per-column-cursor GETBULK order (RFC 3416 §4.2.3),
-		// shared verbatim with the v2c handler so both paths encode identically
-		// (#5065).
-		respVarbinds = a.buildBulkVarbinds(oids, nonRepeaters, maxRepetitions, snap)
-
 		// Bound the response to the effective maximum size (RFC 3416 §4.2.3):
 		// the smaller of the manager's advertised msgMaxSize and our own
-		// maxPacketSize, with msgMaxSize clamped up to the RFC floor. Trim
-		// trailing varbinds until the fully-encoded message (USM + scopedPDU,
-		// including any auth/priv overhead) fits; the manager continues the
-		// walk from the last returned OID. Only if nothing fits do we return
-		// tooBig with an empty varbind list rather than emit an oversized
-		// datagram.
+		// maxPacketSize, with msgMaxSize clamped up to the RFC floor.
 		maxSize := effectiveMaxSize(msgMaxSize)
+
+		// Repetition-major, per-column-cursor GETBULK order (RFC 3416 §4.2.3),
+		// shared verbatim with the v2c handler so both paths encode identically
+		// (#5065). The same ceiling bounds the grid expansion itself (#6551) so
+		// the repeaters*maxRepetitions MIB walk never outruns what the response
+		// can carry — on v3 an unbounded grid is worse than on v2c, because
+		// every trimToFit rebuild re-runs USM framing/HMAC/encryption over it.
+		respVarbinds = a.buildBulkVarbinds(oids, nonRepeaters, maxRepetitions, snap, maxSize)
+
+		// Trim trailing varbinds until the fully-encoded message (USM +
+		// scopedPDU, including any auth/priv overhead) fits; the manager
+		// continues the walk from the last returned OID. Only if nothing fits
+		// do we return tooBig with an empty varbind list rather than emit an
+		// oversized datagram.
 		resp, ok := trimToFit(respVarbinds, maxSize, func(vbs []varbind) []byte {
 			return a.buildV3Response(msgID, msgFlags, user, echoContext, requestID, errNoError, 0, vbs)
 		})


### PR DESCRIPTION
## Problem

SNMP GETBULK materialized the whole `repeaters x max-repetitions` varbind grid **before** the RFC 3416 §4.2.3 response-size bound was applied.

`handleGetBulk` clamped `max-repetitions` at 100, but `repeaterCount = len(oids) - nonRepeaters` is capped nowhere on the decode path — it is bounded only by how many varbinds a manager can pack into one request datagram — and `buildBulkVarbinds` had no size or byte bound inside either loop. Every grid cell costs a `findNextOIDSnap` MIB walk plus a `getOIDValueSnap`, and the 4096-byte ceiling was applied only after the full grid existed.

## Reproduced before fixing

50 interfaces, a 4094-byte v2c GETBULK carrying **580** minimal repeater OIDs with `max-repetitions >= 100`:

| | pre-fix | post-fix |
|---|---|---|
| varbinds BUILT | **58,000** (405 ms in `buildBulkVarbinds`) | **118** (48 us) |
| varbinds RETURNED | 116 | 116 |
| response | 4092 bytes | 4092 bytes, byte-identical |
| end-to-end `handlePacket` | **667 ms** | **1.0 ms** |
| vs a ~2.5 us single-varbind poll | ~260,000x | ~350x |

The issue's ~36,900 varbinds / ~300 ms is an undercount. The extra ~260 ms beyond the build is `trimToFit` binary-searching ~16 full re-encodes of the 58,000-varbind list. Roughly **1.5 requests/second** saturate the single serial SNMP goroutine permanently — monitoring blindness. Community-gated, but a community with no `clients` list is allow-all (#4289) while `:161` binds all interfaces.

## Fix

`buildBulkVarbinds` takes the same `maxBytes` ceiling its caller will trim to and accumulates the **exact** encoded size of every varbind it emits (`bulkBudget` / `varbindEncodedLen`), returning as soon as the varbinds built already exceed it. Both call sites hand it the ceiling they had already computed for `trimToFit` — `handleGetBulk` passes `effectiveMaxSize(maxPacketSize)`, the v3 dispatcher `effectiveMaxSize(msgMaxSize)`. The v3 path gains the most: every `trimToFit` rebuild there re-runs USM framing and HMAC over the whole list.

Stopping inside the loop (rather than capping `len(oids)` on decode) is what actually establishes the invariant — a decode cap alone still lets `maxRepetitions x cappedRepeaters` be large. Post-fix `built` lands at `returned + 2`.

### Why it is output-neutral

The accumulated varbind bytes are a strict **lower** bound on the size of any message carrying them: the message only ADDS bytes on top (varbind-list SEQUENCE header, PDU fields, version/community or USM/scopedPDU envelope, authPriv CBC padding). So once they exceed `maxBytes`, that prefix — and every longer one — is already over the ceiling and would have been discarded by `trimToFit`.

### RFC correctness

RFC 3416 §4.2.3:

> If the size of the message encapsulating the Response-PDU containing the requested number of variable bindings would be greater than either a local constraint or the maximum message size of the originator, then the response is generated with a lesser number of variable bindings. [...] Note that the number of variable bindings removed has no relationship to the values of N, M, or R.

Surplus bindings are removed from the **end** of the ordered set, which is exactly the prefix this stop preserves — so the #5065 repetition-major order and per-column `endOfMibView` placement are untouched, and the truncation is the one a normal manager already handles by continuing the walk from the last returned OID.

## Validation

- **`TestGetBulkBuildBounded_6551` / `TestGetBulkBuildBoundedV3_6551`** — assert on varbinds **BUILT**, not returned. The returned count was always ~116, so a test checking only the response passes on the unfixed code. Neutralizing `bulkBudget.add` to `return false` compiles cleanly (no build break) and takes both RED: 58,000 and 56,400 built against a 683-cell structural cap derived from the 6-byte minimum varbind.
- **`TestGetBulkCostDoesNotScaleWithMaxRepetitions_6551`** — guards the CALL SITES, which the direct-seam assertions above cannot. Goes through `handlePacket` and pins the `M=1` vs `M=100` cost ratio, which is load-invariant (both measurements scale together). **1.4x** with the fix, **309.7x** with a `math.MaxInt` budget passed from `handleGetBulk`; threshold 10x.
- **`TestGetBulkBoundedMatchesUnbounded_6551`** — the over-reach guard. For 9 shapes (ordinary small, non-repeaters, MIB-exhausted columns, oversized wide grids up to 6000 cells) the trimmed response must be **byte-identical** to one built from a `math.MaxInt`-budget grid, i.e. from the pre-fix expansion. Stays GREEN under both neutralizations.
- **`TestVarbindEncodedLenMatchesEncoder_6551`** — reads the expected length back off a real encoded response for 10 varbind shapes (multi-byte BER lengths, large sub-IDs, every exception tag, degenerate short OIDs), so an accounting **over**estimate — which would stop the grid short and silently shrink large responses — cannot slip in.
- **`TestGetBulkTrimmedTailIsWellFormed_6551`** — the truncated response is one a manager can act on: clean decode, correct repetition-major column alignment against the unbounded grid, `endOfMibView` only in the exhausted column's cells.
- Full `pkg/snmp` suite green, plain and `-race`, on a fresh GOCACHE.

## Sibling operation checked: plain GETNEXT

GETNEXT shares the walk helpers but has **no equivalent amplification**. RFC 3416 §4.2.1/§4.2.2 bind it to exactly one response varbind per request varbind, so its walk is O(`len(oids)`) — linear in the request datagram, with no `max-repetitions` multiplier — and every varbind built is one the manager asked for. A max-size GETNEXT of 239 deep ifXTable OIDs costs ~33 ms and returns all 239 in a full 4095-byte `noError` response; built == returned == 239.

A pre-walk short-circuit would not help either: the minimum response varbind is 6 bytes while a request varbind costs at least 7, so `6 * len(oids)` can never exceed the ceiling for any datagram that fits on the wire — the check would never fire. The ~33 ms residual is `findNextOIDSnap` being a linear MIB scan, a different characteristic from unbounded expansion, and is deliberately not addressed here.

## Docs

`pkg/snmp/README.md` gains a gotcha for the build-time bound (with the measured numbers, the lower-bound argument, the `varbindEncodedLen`-must-not-overestimate constraint, and the guard test names) and records the GETNEXT finding alongside it.

Closes #6551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
