### PR TITLE
fix(grpcapi): redact the SNMP community on fabric-reachable ShowText

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,67 @@
+## 2026-07-31 — #6532 review fold: three MINORs, all about artifacts overstating coverage
+
+- **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact, PR #6602)
+- **Action**: Hostile review returned MERGE-NEEDS-MINOR with no code-correctness
+  defect. All three MINORs were artifacts claiming more than they delivered;
+  each is now either corrected or actually delivered.
+  MINOR 1 — the "#4111 behaviour is unchanged / super-user still reads
+  cleartext" claim is FALSE for the remote `cli` binary. `cmd/cli/show.go`
+  routes `show snmp` straight to the RPC via `c.showText("snmp")`, and
+  `cmd/cli` has zero login-class awareness (verified: no userClass/LoginClass/
+  PermAll/showConfigRedacted hits), so a super-user on `cli` now gets
+  `##SECRET-DATA##`. Kept the posture — threading a class into pkg/grpcapi is
+  impossible today and meaningless on the fabric listener where the caller is
+  the peer chassis, and `cli show configuration snmp` was ALREADY masked for
+  every class by #4051, so the two remote read-back paths now agree instead of
+  contradicting. Amended docs/system-login.md: the #4111 paragraph now scopes
+  its allowance to the CONSOLE CLI, and a new callout states the remote-CLI
+  masking plus the operational consequence (no remote read-back; recover from
+  console as super-user or the DR archive, noting a redacted export is
+  deliberately not restorable per #4060).
+  MINOR 2 — the MonitorInterface audit-register entry was factually wrong on
+  all three counts. It streams pre-formatted TEXT frames of counter snapshots
+  (RenderTrafficSummary/RenderSingleInterface), it DOES render configuration
+  (interface set + display names from the active config), and there is no pcap
+  anywhere in server_diag_monitor.go. Rather than just restate it, promoted it
+  to a REAL probe: a monitorFrameSink mock stream captures the first frame and
+  aborts, so it is now driven with a nil dataplane like the seven unary probes.
+  MINOR 3 — `TestGRPCAPINeverRevealsSecretCleartext` claimed "the ONE way to
+  defeat String() is Reveal()". False: config.Secret is `type Secret string`,
+  so `string(x.PSK)` / `[]byte(x.PSK)` yields cleartext and a Reveal() grep
+  misses it. Replaced the line-grep with an AST scan covering BOTH paths,
+  matching conversions against the Secret-typed field names parsed from
+  FILE-SCOPE declarations in pkg/config (12 unique names; the function-local
+  `Name Secret` alias fields in the SNMPCommunity marshallers are correctly
+  excluded). Renamed to TestGRPCAPINeverUnwrapsSecretCleartext and stated the
+  real residual instead of overclaiming again: a conversion applied to a local
+  variable previously assigned from a secret field is not caught.
+  NIT 4 — delivered the determinism parity rather than scoping the claim.
+  gRPC showSNMP now sorts trap groups and USM users as well as communities
+  (shared sortedMapKeys helper), and both pkg/cli community loops sort via
+  sortedSNMPCommunityNames. This matters most under redaction: every displayed
+  key is the same placeholder, so an unsorted map printed N indistinguishable
+  lines with shuffling authorization modes.
+  NIT 5 — documented that the interceptor source scan is textual and reads only
+  the function bodies, so hoisting a method-name constant into a helper would
+  silently drop it from the audited set; added a canary that fails if the scan
+  stops finding SystemAction (reachable ONLY via the scan — it is in neither
+  allowlist map).
+  Validation: the widened scan was proven firsthand in a THROWAWAY detached
+  worktree, twice. Injecting `string(u.AuthPassword)` into showSNMP: build+vet
+  CLEAN, scan FAILS as an assertion. Then the reviewer's actual scenario —
+  `string(u.PrivPassword)` injected BEHIND a nil-dataplane short-circuit: the
+  empirical sweep PASSES (blind to that path) while the structural guard FAILS,
+  proving it is the only net there. Probe worktree removed; PR worktree never
+  used for a revert probe. New determinism test mutation-tested (reverting the
+  community sort goes RED at attempt 4). gofmt clean, go build ./... and
+  go vet ./... clean, pkg/grpcapi + pkg/api + pkg/config + pkg/cli +
+  pkg/refactoraudit green.
+- **File(s)**: pkg/grpcapi/{server_fabric_secret_render_6532_test.go,
+    server_show_snmp_community_redaction_6532_test.go,
+    server_show_dhcp_lldp_snmp.go},
+    pkg/cli/{show_services_snmp.go,cli_show_system.go},
+    docs/system-login.md, _Log.md
+
 ## 2026-07-31 — #6532: redact the SNMP community on the fabric-reachable gRPC ShowText
 
 - **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-31 — #6532: redact the SNMP community on the fabric-reachable gRPC ShowText
+
+- **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact)
+- **Action**: gRPC `ShowText{Topic:"snmp"}` rendered the SNMPv1/v2c community
+  string — which IS the authenticator for v1/v2c — in cleartext. The usual
+  loopback bound does not apply: `ShowText` is on the cluster-fabric allowlist
+  (#4122), so the render is reachable from the peer chassis over the fabric IP.
+  Both sibling surfaces had already been hardened (REST #5315, CLI #4111) and
+  this one was left behind. The community is the ONE operator secret the
+  `config.Secret` newtype does not protect — it stays a plain string because it
+  is the `Communities` map key — so every manual renderer must mask it by hand,
+  which is exactly how three independent copies of the rule let one drift.
+  Fixed by masking unconditionally on the gRPC path (gRPC carries no login
+  class to gate on, matching REST and the sibling `ShowConfig` #4051), and by
+  collapsing all four render sites onto one shared helper,
+  `config.SNMPCommunityDisplayName(name, redact)`. The CLI keeps its per-class
+  predicate (`showConfigRedacted()`), so #4111 behaviour is unchanged:
+  view-only masked, super-user cleartext.
+  Audited the whole fabric allowlist as the issue asked. Empirical sweep: one
+  config staging every secret leaf in the redaction SSOT, driven through all
+  ~115 ShowText topics and every allowlisted RPC — the SNMP community was the
+  only leak. Structural reason: every other secret is `config.Secret` (its
+  `String()` masks under %s/%v, #2053) and `pkg/grpcapi` never calls the
+  `Reveal()` cleartext accessor. Both facts are now asserted, along with a
+  completeness gate that enumerates the allowlist maps AND the method names the
+  interceptor source special-cases (so `SystemAction` is covered too), and a
+  ShowText topic-coverage gate derived from the dispatcher source.
+  Validation: RED-on-revert verified as an assertion failure (not a build
+  break) on the community mask; all four new gates mutation-tested individually
+  (drop the mask / drop a probe / drop a topic / inject a `Reveal()`), each RED,
+  all restore GREEN. A staging-is-real test asserts all 21 secret sentinels
+  actually reach the committed active config, so the "no secret appeared"
+  scans cannot pass vacuously. Full pkg/grpcapi, pkg/api, pkg/cli, pkg/config,
+  pkg/daemon, pkg/dataplane/userspace suites green (the event-stream socket
+  tests need TMPDIR=/tmp — sun_path 108). Heatmap regenerated
+  (types_system.go 1645 -> 1684).
+- **File(s)**: pkg/config/types_system.go, pkg/grpcapi/server_show_dhcp_lldp_snmp.go,
+    pkg/api/show_text.go, pkg/cli/{show_services_snmp.go,cli_show_system.go},
+    pkg/grpcapi/{server_show_snmp_community_redaction_6532_test.go,
+    server_fabric_secret_render_6532_test.go},
+    docs/{architecture.md,system-login.md,refactoring-audit-current.txt}, _Log.md
+
 ## 2026-07-26 — #6474: re-NAT outbound ICMP errors through source NAT
 
 - **Timestamp**: 2026-07-26 (fix/6474-snat-outbound-icmp-error, stacked on

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,68 @@
+## 2026-07-31 — #6532 round-4 fold: stopped patching callee shapes, changed the approach
+
+- **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact, PR #6602)
+- **Action**: Codex found two more escapes on db5162267 — `[](byte)(x.PSK)` and
+  `([](byte))(x.PSK)` (the callee was de-parenthesized but `arr.Elt` was still
+  required to be an immediate Ident), and `string(x.PSK[:])` (trailingIdent did
+  not traverse SliceExpr). It also named the escape that ends the approach:
+  `type Clear string; Clear(x.PSK)` unwraps the secret and NO builtin-name
+  matching can ever see it, because a conversion's callee is a type expression
+  whose grammar is open.
+  Per the team-lead directive, stopped patching outward and changed the design:
+  the conversion check NO LONGER INSPECTS THE CALLEE AT ALL. It now fires on a
+  one-argument call whose argument names a Secret-bearing field. Every
+  conversion — builtin, parenthesized at any depth, aliased, or a named string
+  type declared anywhere — is a one-argument call, so the whole callee-shape
+  dimension collapses to zero code. One argument is a deliberate line, not an
+  oversight: the SAFE idiom `fmt.Fprintf(buf, "%s", x.PSK)` is multi-argument
+  and redacts correctly, so flagging it would fire on every correct render.
+  `secretUnwrapConversionName` and `unwrapParens` were deleted outright.
+  The remaining gated dimension — the argument's wrapper chain — is closed by
+  ENUMERATING go/ast node kinds rather than source shapes: secretExprTail now
+  handles Paren, Star, Index, IndexList, Slice, TypeAssert and address-of Unary.
+  Harvest gaps Codex flagged also fixed: typeMentionsSecret now strips parens
+  (`PSK (Secret)` is legal) and follows ChanType; structTypeOf follows map KEYS
+  as well as values (an anonymous struct is a legal comparable map key).
+  Added TestSecretFieldHarvestShapes — 13 synthetic declaration shapes plus a
+  negative control — because the harvest had been widened in prose and code but
+  never tested, the same gap that let the scanner ship blind twice.
+  STATED THE HARD LIMIT, which is the substantive answer rather than another
+  near-miss: this guard is syntactic and fires where a field is NAMED, so it
+  cannot follow a value into a local, a parameter, a helper return, an
+  out-of-package field or a multi-argument handoff, nor see append/copy/range/
+  reflection. Closing those needs go/types (x/tools is only an INDIRECT
+  dependency today) or an explicit-allowlist inversion over all 42 conversions
+  in pkg/grpcapi (measured, not estimated). Named the clean upstream fix:
+  making config.Secret a struct instead of a named string type would make
+  `string(s)` fail to COMPILE and collapse the entire shape space to the single
+  Reveal accessor — a pkg/config-wide change (Secret is comparable and used as
+  a map key), so it belongs in its own issue, not this PR.
+  Also corrected the remaining false claims: the file header no longer says
+  "the TWO ways to defeat"; the Reveal false positive is now stated as EVERY
+  selector named Reveal (package members and fields, not merely methods); and
+  the residual list no longer claims named-type conversions escape, because
+  after the redesign they do not.
+  Validation — 10 mutations, each in a throwaway detached worktree with
+  build+vet CLEAN so every red is an assertion:
+    M1 drop ParenExpr from secretExprTail   -> parenthesized_conversion_argument
+    M2 drop SliceExpr                       -> sliced_field, sliced_field_with_bounds
+    M3 drop StarExpr                        -> pointer_deref, address-of_field,
+                                               pointer_deref_of_indexed_collection
+    M4 drop IndexExpr                       -> indexed_collection_field, +deref
+    M5 drop TypeAssertExpr                  -> type-asserted_field
+    M6 drop ParenExpr from typeMentionsSecret -> parenthesized_type
+    M7 drop ChanType                        -> channel_of_Secret
+    M8 stop following map KEY               -> map_KEY_anonymous_struct
+    M9 drop embedded-field handling         -> embedded_Secret
+    M10 RESTORE callee-shape gating         -> 13 subtests RED, including both
+        named-string-type cases — the empirical proof that the redesign, not
+        another shape patch, was the necessary fix.
+  Meta-tests now run 42 subtests. Probe worktree removed; the PR worktree was
+  never used for a probe. gofmt clean, go build ./... and go vet ./... clean,
+  pkg/grpcapi + pkg/api + pkg/config + pkg/cli green.
+- **File(s)**: pkg/grpcapi/server_fabric_secret_render_6532_test.go,
+    docs/architecture.md, _Log.md
+
 ## 2026-07-31 — #6532 round-3 fold: parenthesized callees escaped the scanner
 
 - **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact, PR #6602)

--- a/_Log.md
+++ b/_Log.md
@@ -62408,3 +62408,22 @@ break — `go vet` confirmed passing under every revert.
   22.7 Gbps) and needs no re-run for a comment-only change.
 - **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
     pkg/routing/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6532 review-fold round 5 (Codex MERGE-NEEDS-MINOR). Codex confirmed
+  the argument-gating inversion CLOSES the conversion-callee shape class and the
+  production redaction is correct; all three findings were claim-accuracy plus one
+  small harvest gap. (1) `collectSecretFieldNames` now recurses into BOTH map
+  halves explicitly — `structTypeOf` can only return one struct, so
+  `map[struct{ Key Secret }]struct{ Value Secret }` harvested `Key` and silently
+  never visited `Value` while the doc claimed both sides were followed. (2)
+  Replaced the "TWO independent ways to defeat" framing with "TWO DETECTED
+  SHAPES", since Go's expression grammar is open and enumerating defeat
+  mechanisms is not something a syntactic guard can claim. (3) Added an explicit
+  RESIDUALS block naming what is NOT flagged: a COMPUTED argument
+  (`Clear(x.PSK + "")`, `Clear([]config.Secret{x.PSK}[0])`, `Clear(<-ch)`) which
+  passes the arity gate but does not resolve to a harvested field name;
+  `copy(dst, secret)` / `append(dst, secret...)` which are two-argument; and
+  reflection / interface-value unwraps. No production code changed. Full
+  `go test ./pkg/grpcapi/` green.
+- **File(s)**: pkg/grpcapi/server_fabric_secret_render_6532_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,59 @@
+## 2026-07-31 — #6532 round-3 fold: parenthesized callees escaped the scanner
+
+- **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact, PR #6602)
+- **Action**: Codex found the round-2 scanner still missed shapes it claimed to
+  cover, and it was right. `(x.PSK.Reveal)()`, `(string)(x.PSK)`,
+  `([]byte)(x.PSK)` and `((string))(x.PSK)` are legal Go that gofmt leaves
+  untouched, and every one presents `call.Fun` as an `*ast.ParenExpr` — proved
+  firsthand with a standalone go/ast program: all four print
+  `Fun=*ast.ParenExpr selector=false ident=false arraytype=false PAREN=true`,
+  so neither the Reveal check nor the conversion check saw them. A method VALUE
+  (`reveal := x.PSK.Reveal`) escaped too: its call site is `reveal()` with no
+  selector at all.
+  Same failure mode as the round-2 MAJOR, one level up — the check was correct
+  for the shapes it was tested against, and the meta-test only fed shapes the
+  scanner already handled. A meta-test that exercises only what already works
+  proves nothing.
+  Fix, and the AST program pointed at a better one than paren-unwrapping the
+  Reveal callee: `ast.Inspect` reaches every `.Reveal` SelectorExpr regardless
+  of parenthesization AND when it is never called (verified — it printed the
+  selector for both the paren-called form and the method-value binding). So
+  Reveal detection now matches the SELECTION rather than the call, covering all
+  three shapes uniformly with no paren logic. The conversion check gets
+  recursive `unwrapParens` on the callee (single-level is not enough —
+  `((string))(x)` is legal).
+  MINOR 1 — architecture.md said "exactly two escape hatches" while the test
+  itself listed append/index/range/reflection; that contradiction is resolved
+  by saying two DETECTED forms and enumerating the residuals, now including
+  `copy(dst, secret)`. `collectSecretFieldNames` recursed only when the
+  immediate expression was a StructType, missing `[]struct{...}`,
+  `*struct{...}`, `map[K]struct{...}` and embedded unnamed Secret fields; it
+  now looks through slice/array/pointer/map via structTypeOf and harvests an
+  embedded Secret under its type name. Harvest still resolves the same 13 live
+  names (no live nested-struct Secret exists today — the widening is for the
+  next one).
+  MINOR 2 — completed the false-positive disclosure: ANY method named Reveal is
+  flagged whatever its receiver (no type resolution); the conversion check
+  matches a trailing IDENTIFIER so unrelated locals and parameters named
+  Password/PSK are flagged too, not merely fields; shadowing applies to rune,
+  uint8 and int32 as well as string and byte.
+  Validation — per-shape mutation, each in a throwaway detached worktree with
+  build+vet CLEAN so every red is an assertion:
+    A. drop unwrapParens from the conversion callee -> RED on
+       parenthesized_string_conversion, parenthesized_byte_slice_conversion,
+       doubly_parenthesized_conversion.
+    B. revert Reveal to CallExpr-anchored matching -> RED on
+       parenthesized_Reveal_callee, Reveal_bound_as_a_method_value.
+    C. drop ParenExpr from trailingIdent -> RED on
+       parenthesized_conversion_argument.
+  That is all six newly-covered shapes, each proven to fail without its fix.
+  Meta-test now runs 15 shapes plus the negative control. Probe worktree
+  removed; the PR worktree was never used for a probe. gofmt clean, go build
+  ./... and go vet ./... clean, pkg/grpcapi + pkg/api + pkg/config + pkg/cli
+  green.
+- **File(s)**: pkg/grpcapi/server_fabric_secret_render_6532_test.go,
+    docs/architecture.md, _Log.md
+
 ## 2026-07-31 — #6532 round-2 fold: my previous fold BROKE the guard it widened
 
 - **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact, PR #6602)

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,62 @@
+## 2026-07-31 — #6532 round-2 fold: my previous fold BROKE the guard it widened
+
+- **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact, PR #6602)
+- **Action**: Codex re-gate found a MAJOR in the round-1 fold, and it was
+  correct. Widening the structural guard from a Reveal() line-grep to an AST
+  scan, I put `if !ok || len(call.Args) != 1 { return true }` ahead of the
+  Reveal check. A zero-argument method call has len(Args)==0 — the receiver
+  lives in CallExpr.Fun, not Args — so the Reveal branch became UNREACHABLE
+  DEAD CODE. Net effect: I added conversion detection and silently deleted the
+  original protection, on exactly the paths (wireguard / ipsec-statistics /
+  bfd-peers, which short-circuit on a nil dataplane) where this guard is the
+  ONLY net. Proved firsthand with a standalone go/ast program:
+  `CallExpr Reveal(): len(Args)=0 -> gate returns early: true`.
+  Root cause of it shipping: my round-1 mutation probe for the Reveal branch
+  injected `var _ = "x.Reveal()"` — a STRING LITERAL. That matched the old
+  line-grep, but a string literal is not a CallExpr, so the probe was never
+  valid against the AST implementation, and I never re-ran it after the
+  rewrite. I proved the NEW detection fired and never re-proved the OLD one.
+  Fix: extracted the scan into a pure function (scanSecretUnwraps) returning
+  findings, with the two detections INDEPENDENT — Reveal is matched before any
+  argument-count gate, and neither shares a precondition with the other.
+  Added TestSecretUnwrapScannerDetectsBothForms, a meta-test that feeds the
+  scanner synthetic sources and asserts it REPORTS each shape it claims: the
+  Reveal accessor, string/[]byte/[]rune/[]uint8 conversions, a conversion
+  nested in a call argument, through a pointer deref, and of an indexed
+  collection field — plus a negative control that a plain %s render of a
+  Secret is NOT flagged.
+  MINOR 1 — widened the harvest. `APIKeys []Secret` (types_system.go:377) is
+  REAL, not hypothetical, and the old `field.Type == Ident("Secret")` match
+  missed it, so `string(...APIKeys[i])` went undetected. typeMentionsSecret now
+  walks slice/array/pointer/map/qualified shapes and recurses into nested
+  anonymous structs; harvest went 12 -> 13 names, gaining APIKeys. Confirmed
+  the real WireGuard names ARE covered (PresharedKeyHex, WgLocalPrivkeyHex).
+  Rewrote the scope block to state the residuals COMPLETELY — aliased locals,
+  parameters, helper returns, out-of-package fields, type aliases, and
+  non-conversion unwrapping (append/index/range/reflection) — and to record
+  that name-based matching false-positives on unrelated fields named
+  Password/PSK and on shadowed string/byte identifiers, which is the correct
+  bias on a network-exposed surface.
+  MINOR 2 — corrected three false doc claims: architecture.md no longer says
+  the surface is safe "because no Reveal() call exists" (both escape hatches
+  now named, with the residuals and the meta-test); the test file header no
+  longer names the old test or the Reveal-only rationale; system-login.md no
+  longer groups `show snmp v3` with the masked community path (the snmp-v3
+  topic renders no community and no placeholder) and now states that remote
+  `cli show system services` uses the `system-services` topic, whose renderer
+  omits SNMP entirely (verified: zero SNMP references in
+  pkg/grpcapi/server_show_system.go).
+  Validation: the meta-test was proven to CATCH this exact MAJOR — in a
+  throwaway detached worktree, reintroducing `len(call.Args) != 1` ahead of
+  the Reveal check makes TestSecretUnwrapScannerDetectsBothForms/Reveal_accessor
+  go RED with build+vet CLEAN, while TestGRPCAPINeverUnwrapsSecretCleartext
+  stays GREEN — demonstrating the real guard structurally cannot detect its own
+  breakage and the meta-test is load-bearing. Probe worktree removed; the PR
+  worktree was never used for a probe. gofmt clean, go build ./... and
+  go vet ./... clean, pkg/grpcapi + pkg/api + pkg/config + pkg/cli green.
+- **File(s)**: pkg/grpcapi/server_fabric_secret_render_6532_test.go,
+    docs/{architecture.md,system-login.md}, _Log.md
+
 ## 2026-07-31 — #6532 review fold: three MINORs, all about artifacts overstating coverage
 
 - **Timestamp**: 2026-07-31 (fix/6532-grpc-snmp-community-redact, PR #6602)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,6 +181,26 @@ editing cmdtree.
   removing the ~1-window replay horizon (mTLS with per-node certs) and
   HMAC-authenticating the session-sync stream (#4107 F23) — remain deferred
   (see `pkg/cluster/README.md`).
+  - **No allowlisted RPC may render a configured secret (#6532).** Being on
+    this allowlist means being reachable from the peer chassis over the
+    fabric IP, so the usual "loopback only" mitigation does not apply to
+    anything listed above. `ShowText{Topic:"snmp"}` rendered the SNMPv1/v2c
+    community — the v1/v2c authenticator — in cleartext there long after the
+    REST (#5315) and CLI (#4111) siblings were hardened. The property is now
+    asserted across the surface as a whole by
+    `pkg/grpcapi/server_fabric_secret_render_6532_test.go`, which stages a
+    config carrying every secret leaf in the redaction SSOT
+    (`pkg/config/ast_redact.go` `secretIndices`), drives every allowlisted
+    RPC and scans the rendered responses. The method set is **enumerated**
+    from the live allowlist maps plus the method names the interceptor
+    source special-cases, so allowlisting a new RPC fails the completeness
+    gate until it is audited; the ShowText topic set is likewise derived
+    from the dispatcher source. Structurally the surface is safe because
+    every operator secret except the SNMP community is a `config.Secret`,
+    whose `String()` masks it under `%s`/`%v` (#2053) — the community is a
+    plain string because it is the `Communities` map key — and because
+    `pkg/grpcapi` never calls the `Reveal()` cleartext accessor that would
+    opt out of that (also asserted).
 - **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
   config endpoints, full gRPC parity.
   - **Listener lifecycle is all-or-nothing (#5058).** `Server.Run` may

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,12 +195,23 @@ editing cmdtree.
     from the live allowlist maps plus the method names the interceptor
     source special-cases, so allowlisting a new RPC fails the completeness
     gate until it is audited; the ShowText topic set is likewise derived
-    from the dispatcher source. Structurally the surface is safe because
-    every operator secret except the SNMP community is a `config.Secret`,
-    whose `String()` masks it under `%s`/`%v` (#2053) — the community is a
-    plain string because it is the `Communities` map key — and because
-    `pkg/grpcapi` never calls the `Reveal()` cleartext accessor that would
-    opt out of that (also asserted).
+    from the dispatcher source. The structural reason the sweep finds only
+    one class of leak is that every operator secret except the SNMP
+    community is a `config.Secret`, whose `String()` masks it under
+    `%s`/`%v`/`%q`/`%x` (#2053) — the community is a plain string because it
+    is the `Communities` map key. That protection has exactly two escape
+    hatches, and `TestGRPCAPINeverUnwrapsSecretCleartext` asserts neither is
+    used here: the `Reveal()` cleartext accessor, and a plain
+    `string(...)`/`[]byte(...)` **conversion**, which works because `Secret`
+    is a named string type and therefore never reaches `String()`. The
+    conversion check is syntactic and its residuals (a conversion of a local
+    previously assigned from a secret field, a Secret-bearing field declared
+    outside `pkg/config`, non-conversion unwrapping) are enumerated on the
+    test. A companion meta-test feeds the scanner synthetic sources and
+    asserts it REPORTS each shape — without it, an all-clear from a broken
+    scan is indistinguishable from an all-clear from a clean package, which
+    is how the `Reveal()` branch was once disabled while the suite stayed
+    green.
 - **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
   config endpoints, full gRPC parity.
   - **Listener lifecycle is all-or-nothing (#5058).** `Server.Run` may

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,19 +199,23 @@ editing cmdtree.
     one class of leak is that every operator secret except the SNMP
     community is a `config.Secret`, whose `String()` masks it under
     `%s`/`%v`/`%q`/`%x` (#2053) — the community is a plain string because it
-    is the `Communities` map key. That protection has exactly two escape
-    hatches, and `TestGRPCAPINeverUnwrapsSecretCleartext` asserts neither is
-    used here: the `Reveal()` cleartext accessor, and a plain
-    `string(...)`/`[]byte(...)` **conversion**, which works because `Secret`
-    is a named string type and therefore never reaches `String()`. The
-    conversion check is syntactic and its residuals (a conversion of a local
-    previously assigned from a secret field, a Secret-bearing field declared
-    outside `pkg/config`, non-conversion unwrapping) are enumerated on the
-    test. A companion meta-test feeds the scanner synthetic sources and
-    asserts it REPORTS each shape — without it, an all-clear from a broken
-    scan is indistinguishable from an all-clear from a clean package, which
-    is how the `Reveal()` branch was once disabled while the suite stayed
-    green.
+    is the `Communities` map key. `TestGRPCAPINeverUnwrapsSecretCleartext`
+    asserts the two **detected** unwrapping forms are absent here: the
+    `Reveal()` cleartext accessor, and a plain
+    `string(...)`/`[]byte(...)`/`[]rune(...)`/`[]uint8(...)` **conversion**,
+    which works because `Secret` is a named string type and so never reaches
+    `String()`. Two detected forms is NOT the same as two possible forms —
+    `append(dst, secret...)`, `copy(dst, secret)`, indexing, ranging,
+    reflection, and any conversion routed through a local, a parameter or an
+    out-of-package field all remain **known residuals** that would need type
+    resolution to catch. They are enumerated on the test alongside its
+    deliberate false positives. A companion meta-test feeds the scanner
+    synthetic sources — including parenthesized callees such as
+    `(string)(x.PSK)` and `(x.PSK.Reveal)()`, which are legal Go that gofmt
+    preserves — and asserts it REPORTS each one. That meta-test is
+    load-bearing, not decorative: an all-clear from a broken scan is
+    indistinguishable from an all-clear from a clean package, and this scan
+    has twice shipped with a silently unreachable branch.
 - **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
   config endpoints, full gRPC parity.
   - **Listener lifecycle is all-or-nothing (#5058).** `Server.Run` may

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,22 +200,31 @@ editing cmdtree.
     community is a `config.Secret`, whose `String()` masks it under
     `%s`/`%v`/`%q`/`%x` (#2053) — the community is a plain string because it
     is the `Communities` map key. `TestGRPCAPINeverUnwrapsSecretCleartext`
-    asserts the two **detected** unwrapping forms are absent here: the
-    `Reveal()` cleartext accessor, and a plain
-    `string(...)`/`[]byte(...)`/`[]rune(...)`/`[]uint8(...)` **conversion**,
-    which works because `Secret` is a named string type and so never reaches
-    `String()`. Two detected forms is NOT the same as two possible forms —
-    `append(dst, secret...)`, `copy(dst, secret)`, indexing, ranging,
-    reflection, and any conversion routed through a local, a parameter or an
-    out-of-package field all remain **known residuals** that would need type
-    resolution to catch. They are enumerated on the test alongside its
-    deliberate false positives. A companion meta-test feeds the scanner
-    synthetic sources — including parenthesized callees such as
-    `(string)(x.PSK)` and `(x.PSK.Reveal)()`, which are legal Go that gofmt
-    preserves — and asserts it REPORTS each one. That meta-test is
-    load-bearing, not decorative: an all-clear from a broken scan is
-    indistinguishable from an all-clear from a clean package, and this scan
-    has twice shipped with a silently unreachable branch.
+    asserts two things are absent here: any selection named `Reveal` (the
+    cleartext accessor), and any **one-argument call** handed a
+    Secret-bearing field. The second deliberately ignores the callee —
+    matching conversion shapes (`string`, `(string)`, `[]byte`,
+    `[](byte)`, …) failed across four review rounds because a conversion's
+    callee is a type expression with open grammar, and `type Clear string;
+    Clear(x.PSK)` unwraps the secret just as well. One argument is the line
+    because the safe idiom `fmt.Fprintf(buf, "%s", x.PSK)` is
+    multi-argument and redacts correctly.
+    **This guard is syntactic and has a ceiling**, stated on the test
+    itself: it fires where a field is NAMED, so it cannot follow a value
+    into a local, a parameter, a helper return, an out-of-package field, or
+    a multi-argument handoff, nor see `append`/`copy`/ranging/reflection.
+    Closing those needs `go/types` resolution, or inverting to an
+    explicit-allowlist over all 42 conversions in the package. The clean
+    structural fix is upstream — making `config.Secret` a struct instead of
+    a named string type would make `string(s)` fail to **compile** and
+    collapse the whole shape space to the single accessor — but that is a
+    `pkg/config`-wide change (`Secret` is comparable and used as a map key)
+    and belongs in its own issue.
+    Two companion meta-tests feed the scanner and the field harvest
+    synthetic sources and assert each REPORTS every shape it claims. They
+    are load-bearing, not decorative: an all-clear from a broken check is
+    indistinguishable from an all-clear from a clean package, and this
+    check has twice shipped blind while the suite stayed green.
 - **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
   config endpoints, full gRPC parity.
   - **Listener lifecycle is all-or-nothing (#5058).** `Server.Run` may

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -31,8 +31,8 @@
 [WATCH]      1764  userspace-dp/src/screen/scan.rs
 [WATCH]      1737  pkg/snmp/agent.go
 [WATCH]      1725  userspace-dp/src/afxdp/worker/mod.rs
+[WATCH]      1684  pkg/config/types_system.go
 [WATCH]      1670  pkg/config/compiler_validate_warn.go
-[WATCH]      1645  pkg/config/types_system.go
 [WATCH]      1637  pkg/api/sessions.go
 [WATCH]      1608  userspace-dp/src/afxdp/tx/dispatch/mod.rs
 [WATCH]      1606  pkg/cmdtree/tree.go

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -554,9 +554,22 @@ exactly how the gRPC surface stayed in the clear through two hardening passes.
 > (#6532).** The #4111 super-user cleartext allowance above survives only on
 > the **in-process console CLI** (`pkg/cli`, which knows the login class). The
 > remote `cli` binary — the primary operator interface — dispatches `show snmp`
-> and `show snmp v3` straight to the gRPC RPC (`cmd/cli/show.go`,
-> `c.showText("snmp")`), and `cmd/cli` has no login-class awareness at all, so
-> there is no class to exempt: it renders `##SECRET-DATA##` for everyone.
+> straight to the gRPC RPC (`cmd/cli/show.go`, `c.showText("snmp")`), and
+> `cmd/cli` has no login-class awareness at all, so there is no class to
+> exempt: it renders `##SECRET-DATA##` for every caller.
+>
+> Scope, precisely — the two sibling commands do **not** behave this way,
+> because neither renders a community at all:
+>
+> - `cli show snmp v3` uses the `snmp-v3` topic, which prints only the USM
+>   user table (user, auth protocol, privacy protocol). No community, so no
+>   placeholder. The USM auth/privacy PASSWORDS were never rendered by it —
+>   they are `config.Secret`-typed and masked by the newtype (#2053).
+> - `cli show system services` uses the `system-services` topic, whose
+>   renderer omits SNMP entirely (it lists the gRPC/REST endpoints). The
+>   community masking described for #4111's `show system services` therefore
+>   applies to the **console** CLI only; the remote command never showed a
+>   community in the first place.
 >
 > This is a deliberate posture change, not an oversight. Threading a login
 > class into `pkg/grpcapi` is not possible today (the package has no class

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -525,6 +525,29 @@ config-render decision above). The TSIG key already showed `(secret redacted)`
 and SNMPv3 renders auth/priv protocol names only, so the community name was the
 last cleartext SNMP secret on these two surfaces.
 
+**The same masking on the REST and gRPC surfaces (#5315, #6532).** The CLI is
+not the only place that formats the typed active config by hand. The REST
+show-text handler (`pkg/api/show_text.go`) rendered the same community and was
+masked in #5315; the gRPC `ShowText{Topic:"snmp"}` renderer
+(`pkg/grpcapi/server_show_dhcp_lldp_snmp.go`) was left in the clear until
+#6532. Both mask **unconditionally**, unlike the CLI: neither surface carries a
+login class to gate on, so there is no privileged caller to exempt — the same
+call the sibling gRPC `ShowConfig` raw-AST redaction makes (#4051). The gRPC
+one is not merely loopback-bound: `ShowText` is on the cluster-fabric allowlist
+(#4122), so that render was reachable from the peer chassis over the fabric IP
+(see `docs/architecture.md`).
+
+All four render sites now share one implementation of the masking rule,
+`config.SNMPCommunityDisplayName(name, redact)` (`pkg/config/types_system.go`,
+next to the `SNMPCommunity` marshal redaction). The CLI passes
+`redact=showConfigRedacted()` so its per-class behaviour is unchanged; REST and
+gRPC pass `redact=true`. The reason a helper exists rather than an inline `if`
+at each site: the community is the **one** operator secret not covered by the
+`config.Secret` newtype's `String()` redaction (#2053) — it stays a plain
+string because it is the `Communities` map key — so every manual renderer has
+to remember to mask it, and three independent copies of that one-line rule are
+exactly how the gRPC surface stayed in the clear through two hardening passes.
+
 ### Generating a hash
 
 ```

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -521,8 +521,9 @@ reuse the same `CLI.showConfigRedacted()` predicate: for any class without
 `PermAll` the community **name** is masked to `##SECRET-DATA##` while the
 authorization **mode** (`read-only` / `read-write`) stays visible; `super-user`
 and the unset/legacy class still read the cleartext name (parity with the #4099
-config-render decision above). The TSIG key already showed `(secret redacted)`
-and SNMPv3 renders auth/priv protocol names only, so the community name was the
+config-render decision above) — **on the in-process console CLI only; see the
+next paragraph for `cli`**. The TSIG key already showed `(secret redacted)` and
+SNMPv3 renders auth/priv protocol names only, so the community name was the
 last cleartext SNMP secret on these two surfaces.
 
 **The same masking on the REST and gRPC surfaces (#5315, #6532).** The CLI is
@@ -547,6 +548,30 @@ at each site: the community is the **one** operator secret not covered by the
 string because it is the `Communities` map key — so every manual renderer has
 to remember to mask it, and three independent copies of that one-line rule are
 exactly how the gRPC surface stayed in the clear through two hardening passes.
+
+> [!IMPORTANT]
+> **`cli show snmp` is masked for EVERY caller, including `super-user`
+> (#6532).** The #4111 super-user cleartext allowance above survives only on
+> the **in-process console CLI** (`pkg/cli`, which knows the login class). The
+> remote `cli` binary — the primary operator interface — dispatches `show snmp`
+> and `show snmp v3` straight to the gRPC RPC (`cmd/cli/show.go`,
+> `c.showText("snmp")`), and `cmd/cli` has no login-class awareness at all, so
+> there is no class to exempt: it renders `##SECRET-DATA##` for everyone.
+>
+> This is a deliberate posture change, not an oversight. Threading a login
+> class into `pkg/grpcapi` is not possible today (the package has no class
+> plumbing) and would be actively wrong on the fabric listener, where the
+> caller is the peer chassis rather than a user. Masking unconditionally is
+> also what the sibling `ShowConfig` already does (#4051), so `cli show
+> configuration snmp` was ALREADY masked for every class before #6532 — the
+> two remote read-back paths now agree instead of contradicting each other.
+>
+> Operational consequence to be aware of: an operator has **no remote
+> read-back path** for a configured community. Recover it from the console
+> CLI as `super-user`, or from the DR archive (`request system configuration
+> rescue`) — note that a redacted export is deliberately not restorable
+> (#4060). The community remains fully functional on the wire; only its
+> display is masked.
 
 ### Generating a hash
 

--- a/pkg/api/show_text.go
+++ b/pkg/api/show_text.go
@@ -86,9 +86,16 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 				// boundary. The authorization mode stays visible; only the
 				// secret is masked. Iteration still runs over the real (sorted)
 				// keys so ordering stays deterministic (#4712).
+				//
+				// #6532 routed the mask through the shared
+				// config.SNMPCommunityDisplayName helper so this surface, the
+				// pkg/cli status commands and the gRPC ShowText topic cannot
+				// drift apart again. redact=true is unconditional here: REST
+				// show-text carries no login class to gate on.
 				for _, name := range sortedKeys(snmpCfg.Communities) {
 					comm := snmpCfg.Communities[name]
-					fmt.Fprintf(&buf, "  %s: %s\n", config.SecretDataPlaceholder, comm.Authorization)
+					fmt.Fprintf(&buf, "  %s: %s\n",
+						config.SNMPCommunityDisplayName(name, true), comm.Authorization)
 				}
 			}
 			if len(snmpCfg.TrapGroups) > 0 {

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -314,13 +314,13 @@ func (c *CLI) showSystemServices() error {
 		// The authorization mode (read-only/read-write) stays visible; only the
 		// secret community string is masked. Super-user / unset class reads
 		// cleartext (console operator parity with #4057/#4106).
+		// #6532: the mask itself now comes from the shared
+		// config.SNMPCommunityDisplayName helper (one implementation across
+		// CLI/REST/gRPC); the per-class predicate stays local to the CLI.
 		redactCommunity := c.showConfigRedacted()
 		for name, comm := range cfg.System.SNMP.Communities {
-			shown := name
-			if redactCommunity {
-				shown = config.SecretDataPlaceholder
-			}
-			fmt.Printf("    Community:    %s (%s)\n", shown, comm.Authorization)
+			fmt.Printf("    Community:    %s (%s)\n",
+				config.SNMPCommunityDisplayName(name, redactCommunity), comm.Authorization)
 		}
 	}
 

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -317,8 +317,12 @@ func (c *CLI) showSystemServices() error {
 		// #6532: the mask itself now comes from the shared
 		// config.SNMPCommunityDisplayName helper (one implementation across
 		// CLI/REST/gRPC); the per-class predicate stays local to the CLI.
+		// Sorted iteration for the same reason as `show snmp` — under
+		// redaction every displayed key is the same placeholder, so an
+		// unsorted map shuffles otherwise-identical lines between runs.
 		redactCommunity := c.showConfigRedacted()
-		for name, comm := range cfg.System.SNMP.Communities {
+		for _, name := range sortedSNMPCommunityNames(cfg.System.SNMP.Communities) {
+			comm := cfg.System.SNMP.Communities[name]
 			fmt.Printf("    Community:    %s (%s)\n",
 				config.SNMPCommunityDisplayName(name, redactCommunity), comm.Authorization)
 		}

--- a/pkg/cli/show_services_snmp.go
+++ b/pkg/cli/show_services_snmp.go
@@ -2,10 +2,26 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
 )
+
+// sortedSNMPCommunityNames returns the community map keys in ascending order.
+// Deterministic ordering matters most precisely WHEN the names are redacted
+// (#6532): every displayed key is then the same placeholder, so an unsorted
+// map iteration prints N identical lines whose authorization modes shuffle
+// between two runs of the same command. Iteration runs over the real keys; the
+// masking happens at the render site.
+func sortedSNMPCommunityNames(m map[string]*config.SNMPCommunity) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
 
 func (c *CLI) showSNMP() error {
 	cfg := c.store.ActiveConfig()
@@ -35,7 +51,8 @@ func (c *CLI) showSNMP() error {
 		// helper; the per-class PREDICATE stays here, since only the CLI has a
 		// login class to gate on.
 		redactCommunity := c.showConfigRedacted()
-		for name, comm := range snmpCfg.Communities {
+		for _, name := range sortedSNMPCommunityNames(snmpCfg.Communities) {
+			comm := snmpCfg.Communities[name]
 			fmt.Printf("  %s: %s\n",
 				config.SNMPCommunityDisplayName(name, redactCommunity), comm.Authorization)
 		}

--- a/pkg/cli/show_services_snmp.go
+++ b/pkg/cli/show_services_snmp.go
@@ -30,14 +30,14 @@ func (c *CLI) showSNMP() error {
 		// #4111: mask the secret community name for any non-super-user login
 		// class (reuse the #4099/#4106 showConfigRedacted predicate). The
 		// authorization mode stays visible; only the community credential is
-		// masked. Super-user / unset class reads cleartext.
+		// masked. Super-user / unset class reads cleartext. #6532 routed the
+		// mask itself through the shared config.SNMPCommunityDisplayName
+		// helper; the per-class PREDICATE stays here, since only the CLI has a
+		// login class to gate on.
 		redactCommunity := c.showConfigRedacted()
 		for name, comm := range snmpCfg.Communities {
-			shown := name
-			if redactCommunity {
-				shown = config.SecretDataPlaceholder
-			}
-			fmt.Printf("  %s: %s\n", shown, comm.Authorization)
+			fmt.Printf("  %s: %s\n",
+				config.SNMPCommunityDisplayName(name, redactCommunity), comm.Authorization)
 		}
 	}
 

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -517,12 +517,20 @@ func (s SNMPConfig) MarshalYAML() (any, error) {
 // Name is the SNMPv1/v2c community string, which IS the shared secret (it
 // authorizes the request on the wire). It is also the key of the
 // SNMPConfig.Communities map, so it stays a plain string (the map lookup in
-// pkg/snmp/agent.go is by the on-wire community string). Redaction is
-// applied only on the JSON/YAML surface via the targeted MarshalJSON /
-// MarshalYAML below — keeping it a string means the map key, the compiler
-// assignment, and the text `show snmp` / `show configuration` render paths
-// (which print the map key, not this field, and are out of scope for the
-// #2053 marshal leak) are all unchanged.
+// pkg/snmp/agent.go is by the on-wire community string). Redaction on the
+// JSON/YAML surface is applied via the targeted MarshalJSON / MarshalYAML
+// below; keeping Name a string leaves the map key and the compiler assignment
+// unchanged.
+//
+// The cost of that choice is that Name is the ONE operator secret in the
+// config tree not covered by the Secret newtype's String() redaction (#2053) —
+// every other secret masks itself under %s/%v, this one does not. So each
+// manual TEXT renderer that prints the map key must mask it explicitly, via
+// the shared SNMPCommunityDisplayName helper below. Three surfaces do:
+// pkg/cli `show snmp` / `show system services` (#4111), the pkg/api show-text
+// handler (#5315) and the pkg/grpcapi ShowText snmp topic (#6532). The raw-AST
+// `show configuration` render paths are masked separately by RedactedClone
+// (ast_redact.go, #4051), which matches the community on the AST key path.
 type SNMPCommunity struct {
 	Name          string
 	Authorization string // "read-only" or "read-write"
@@ -573,6 +581,37 @@ func (c SNMPCommunity) MarshalYAML() (any, error) {
 		Authorization string
 		Clients       []SNMPClient `yaml:",omitempty"`
 	}{Name: Secret(c.Name), Authorization: c.Authorization, Clients: c.Clients}, nil
+}
+
+// SNMPCommunityDisplayName returns the token an operator-facing TEXT renderer
+// must print in place of an SNMPv1/v2c community name. It is the single
+// implementation of the community-masking rule, shared by every render surface
+// that formats the Communities map key itself:
+//
+//   - pkg/cli `show snmp` + `show system services` (#4111) pass
+//     redact=showConfigRedacted(), so a VIEW-only login class sees the
+//     placeholder and super-user keeps cleartext (the #4057/#4106
+//     console-operator allowance).
+//   - pkg/api show-text (#5315) and pkg/grpcapi ShowText (#6532) pass
+//     redact=true unconditionally: neither surface carries a login class to
+//     gate on, so there is no privileged caller to exempt. The gRPC one is not
+//     merely loopback — ShowText is on the cluster-fabric allowlist (#4122),
+//     reachable from the peer chassis.
+//
+// The authorization mode is NOT a secret and is never masked by this helper —
+// callers keep rendering it in the clear.
+//
+// Why a helper and not an inline `if` per site: the community is the one
+// operator secret that the Secret newtype does not protect (see SNMPCommunity
+// above), so every renderer must remember to mask it by hand. Three
+// independent copies of that one-line rule is precisely how the gRPC surface
+// silently stayed in the clear for two hardening passes (#6532). One
+// implementation, one place to audit.
+func SNMPCommunityDisplayName(name string, redact bool) string {
+	if redact {
+		return SecretDataPlaceholder
+	}
+	return name
 }
 
 // SNMPTrapGroup defines an SNMP trap destination group.

--- a/pkg/grpcapi/server_fabric_secret_render_6532_test.go
+++ b/pkg/grpcapi/server_fabric_secret_render_6532_test.go
@@ -23,13 +23,22 @@
 //     from the dispatcher source so a newly-added topic must be added to the
 //     audit sweep, rather than silently escaping it.
 //
-//   - TestGRPCAPINeverRevealsSecretCleartext pins the structural reason the
+//   - TestGRPCAPINeverUnwrapsSecretCleartext pins the structural reason the
 //     sweep finds only one class of leak: every operator secret except the SNMP
-//     community is a config.Secret, whose String() masks it under %s/%v, and
-//     pkg/grpcapi never calls the Reveal() cleartext accessor that would opt
-//     out of that. This covers the render paths the sweep cannot drive
+//     community is a config.Secret, whose String() masks it under %s/%v/%q/%x
+//     (#2053). It checks the TWO ways to defeat that — the Reveal() accessor
+//     and a plain string()/[]byte() CONVERSION, which works because Secret is a
+//     named string type — and covers the render paths the sweep cannot drive
 //     in-process (a nil dataplane / IPsec manager / FRR short-circuits some
-//     renderers before they format anything).
+//     renderers before they format anything). Its scope and its residuals are
+//     documented in full on the test itself; it does not claim completeness.
+//
+//   - TestSecretUnwrapScannerDetectsBothForms proves that guard can FAIL. A
+//     structural scan reporting "no violations" is worthless until someone has
+//     shown it fires, and an earlier revision of this file demonstrated exactly
+//     that: the Reveal() branch sat behind an argument-count gate that a
+//     zero-argument method call never satisfies, so it was unreachable dead
+//     code while the suite stayed green.
 package grpcapi
 
 import (
@@ -524,37 +533,69 @@ func dispatcherTopics(t *testing.T) []string {
 	return topics
 }
 
+// --- Structural guard: no cleartext unwrapping of a config.Secret ---
+//
 // TestGRPCAPINeverUnwrapsSecretCleartext pins the structural property the audit
 // above rests on. Every operator secret in the config tree except the SNMP
 // community is a config.Secret, whose String() renders "<redacted>" under
 // %s/%v/%q/%x (#2053) — so a text renderer cannot leak one by accident.
 //
-// There are TWO ways to defeat that, and this guard checks both:
+// There are TWO independent ways to defeat that, and the scan checks both:
 //
 //  1. Reveal(), the explicit cleartext accessor.
-//  2. A plain CONVERSION. config.Secret is `type Secret string`
+//  2. A CONVERSION. config.Secret is `type Secret string`
 //     (pkg/config/secret.go), so `string(x.PSK)`, `[]byte(x.PSK)` or
-//     `"p " + string(x.PSK)` yields the raw value without ever reaching
-//     String(). A scan for Reveal() alone misses this entirely.
+//     `"p " + string(x.PSK)` yields the raw value without reaching String().
 //
-// Both matter most for the renderers the in-process sweep cannot fully drive:
+// Both matter most for the renderers the in-process sweep cannot drive:
 // wireguard / ipsec-statistics / bfd-peers short-circuit on a nil dataplane,
 // IPsec manager or FRR before formatting anything, so for those paths this
-// guard is the only net. A conversion inside one of them would otherwise be
-// invisible to BOTH tests.
+// guard is the only net. A leak there is invisible to the sweep.
 //
-// Scope, stated honestly rather than overclaimed: the conversion check is
-// syntactic. It resolves the converted expression to its final identifier and
-// matches that against the Secret-typed FIELD names declared at file scope in
-// pkg/config, so it catches the direct field conversions above. It does NOT
-// catch a conversion applied to a local variable that was assigned from a
-// secret field first (`s := gw.PSK; _ = string(s)`) — that needs full type
-// resolution. Closing the direct-field path closes the realistic renderer
-// mistake; the aliased path remains a known residual.
+// The scan is a pure function (scanSecretUnwraps) precisely so
+// TestSecretUnwrapScannerDetectsBothForms can prove it FIRES, on synthetic
+// source, for every shape it claims to catch. That meta-test is load-bearing:
+// an all-clear from a scan nobody has proven can fail is indistinguishable
+// from a broken scan, which is exactly how the Reveal() branch of an earlier
+// revision of this file became unreachable dead code while still reporting
+// PASS.
+//
+// SCOPE — stated in full, because a guard that overstates its reach is worse
+// than one that admits its limits. The conversion half is SYNTACTIC: it
+// resolves the converted expression to its trailing identifier and matches
+// that against the Secret-bearing field names declared at file scope in
+// pkg/config. It therefore does NOT catch:
+//
+//   - a conversion of a local variable assigned from a secret field earlier
+//     (`s := gw.PSK; _ = string(s)`), a function parameter, or a helper return;
+//   - a Secret-bearing field declared outside pkg/config, or reached through a
+//     type alias;
+//   - non-conversion unwrapping: `append(dst, secret...)`, indexing or ranging
+//     the string, or reflection.
+//
+// It also FALSE-POSITIVES by design, which is the right bias on a
+// network-exposed surface: an unrelated field that merely shares a name with a
+// Secret field (`Password`, `PSK`) is flagged, as is a conversion using a
+// locally shadowed `string`/`byte` identifier. Both are cheap to justify in
+// review; a missed credential is not. Closing the direct-field path closes the
+// realistic renderer mistake — the rest is a documented residual, not a claim
+// of completeness.
 func TestGRPCAPINeverUnwrapsSecretCleartext(t *testing.T) {
 	secretFields := secretTypedFieldNames(t)
-	fset := token.NewFileSet()
 
+	// Floor against a silently-broken harvest (a parse change, a moved
+	// package). Well below the true count because field NAMES dedupe — AuthKey
+	// alone is declared four times — so the set is 13 today, not the ~25
+	// declaration sites: APIKeys APIToken AWSSecretAccessKey AuthKey
+	// AuthPassword ControlLinkAuthKey EncryptedPassword PSK Password
+	// PresharedKeyHex PrivPassword TSIGSecret WgLocalPrivkeyHex.
+	if len(secretFields) < 10 {
+		t.Fatalf("harvested only %d config.Secret field names; the extraction "+
+			"broke and the conversion half of this guard is near-vacuous: %v",
+			len(secretFields), secretFields)
+	}
+
+	fset := token.NewFileSet()
 	files, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatalf("glob package sources: %v", err)
@@ -569,83 +610,197 @@ func TestGRPCAPINeverUnwrapsSecretCleartext(t *testing.T) {
 			t.Fatalf("parse %s: %v", f, err)
 		}
 		scanned++
-
-		ast.Inspect(file, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok || len(call.Args) != 1 {
-				return true
-			}
-			pos := fset.Position(call.Pos())
-
-			// (1) x.Reveal()
-			if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Reveal" {
-				t.Errorf("%s:%d calls the config.Secret cleartext accessor Reveal() "+
-					"on the gRPC surface. pkg/grpcapi serves the network-exposed "+
-					"cluster-fabric listener (#4122); revealing a secret here risks "+
-					"rendering it to the peer chassis (#6532). Keep it off every "+
-					"render path and document why here.", f, pos.Line)
-				return true
-			}
-
-			// (2) string(<secret field>) / []byte(<secret field>)
-			if !isStringOrByteSliceConversion(call.Fun) {
-				return true
-			}
-			name := trailingIdent(call.Args[0])
-			if name != "" && secretFields[name] {
-				t.Errorf("%s:%d converts the config.Secret field %q with %s(...), "+
-					"which yields the CLEARTEXT secret: config.Secret is a named "+
-					"string type, so a conversion bypasses the String() redaction "+
-					"that protects every %%s/%%v render (#2053). pkg/grpcapi serves "+
-					"the network-exposed cluster-fabric listener (#4122) — this can "+
-					"put an operator credential on the wire to the peer chassis "+
-					"(#6532). Format the Secret directly, or justify the conversion "+
-					"here.", f, pos.Line, name, conversionName(call.Fun))
-			}
-			return true
-		})
+		for _, find := range scanSecretUnwraps(fset, file, f, secretFields) {
+			t.Errorf("%s: %s\n\tpkg/grpcapi serves the network-exposed "+
+				"cluster-fabric listener (#4122), so a cleartext secret here can "+
+				"reach the peer chassis (#6532). Format the config.Secret directly "+
+				"— %%s/%%v/%%q/%%x all redact — or justify the unwrap here.",
+				find.Where, find.Detail)
+		}
 	}
 	if scanned == 0 {
 		t.Fatal("scanned no package sources — the glob is wrong and this guard is vacuous")
 	}
-	// Floor against a silently-broken extraction (a parse change, a moved
-	// package). It is well below the true count because field NAMES dedupe —
-	// AuthKey alone is declared four times — so the set is 12 today, not the
-	// ~24 declaration sites: APIToken AWSSecretAccessKey AuthKey AuthPassword
-	// ControlLinkAuthKey EncryptedPassword PSK Password PresharedKeyHex
-	// PrivPassword TSIGSecret WgLocalPrivkeyHex.
-	if len(secretFields) < 10 {
-		t.Fatalf("resolved only %d config.Secret field names; the extraction broke "+
-			"and the conversion half of this guard is near-vacuous", len(secretFields))
-	}
 }
 
-// isStringOrByteSliceConversion reports whether fun is the `string` or
-// `[]byte` conversion target.
-func isStringOrByteSliceConversion(fun ast.Expr) bool {
-	if id, ok := fun.(*ast.Ident); ok {
-		return id.Name == "string"
-	}
-	if arr, ok := fun.(*ast.ArrayType); ok && arr.Len == nil {
-		el, ok := arr.Elt.(*ast.Ident)
-		return ok && el.Name == "byte"
-	}
-	return false
-}
+// TestSecretUnwrapScannerDetectsBothForms is the meta-test: it proves the scan
+// above can actually FAIL. Without it, a green run means either "no violations"
+// or "the scan is broken", and those are indistinguishable — an earlier
+// revision gated the Reveal() branch behind `len(call.Args) != 1`, which is
+// never true for a zero-argument method call, so that branch was unreachable
+// while the test still passed. Every shape the doc block claims to catch gets
+// a synthetic source here.
+func TestSecretUnwrapScannerDetectsBothForms(t *testing.T) {
+	secretFields := map[string]bool{"PSK": true, "APIKeys": true}
 
-func conversionName(fun ast.Expr) string {
-	if isStringOrByteSliceConversion(fun) {
-		if id, ok := fun.(*ast.Ident); ok {
-			return id.Name
+	cases := []struct {
+		name string
+		src  string
+		want string // substring the finding must contain
+	}{
+		{
+			name: "Reveal accessor",
+			src:  "package p\nfunc f(x T) { _ = x.PSK.Reveal() }\n",
+			want: "Reveal()",
+		},
+		{
+			name: "string conversion",
+			src:  "package p\nfunc f(x T) { _ = string(x.PSK) }\n",
+			want: `converts the config.Secret field "PSK" with string(...)`,
+		},
+		{
+			name: "byte slice conversion",
+			src:  "package p\nfunc f(x T) { _ = []byte(x.PSK) }\n",
+			want: `"PSK" with []byte(...)`,
+		},
+		{
+			name: "rune slice conversion",
+			src:  "package p\nfunc f(x T) { _ = []rune(x.PSK) }\n",
+			want: `"PSK" with []rune(...)`,
+		},
+		{
+			name: "uint8 slice conversion",
+			src:  "package p\nfunc f(x T) { _ = []uint8(x.PSK) }\n",
+			want: `"PSK" with []uint8(...)`,
+		},
+		{
+			name: "conversion nested in a call argument",
+			src:  "package p\nfunc f(x T) { g(\"%s\", string(x.PSK)) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "conversion through a pointer deref",
+			src:  "package p\nfunc f(x T) { _ = string(*x.PSK) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "conversion of an indexed collection field (APIKeys []Secret)",
+			src:  "package p\nfunc f(x T) { _ = string(x.APIKeys[i]) }\n",
+			want: `"APIKeys"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "synthetic.go", tc.src, 0)
+			if err != nil {
+				t.Fatalf("parse synthetic source: %v", err)
+			}
+			finds := scanSecretUnwraps(fset, file, "synthetic.go", secretFields)
+			if len(finds) == 0 {
+				t.Fatalf("scanSecretUnwraps did NOT flag %s — the guard does not "+
+					"cover a shape its documentation claims. Source:\n%s",
+					tc.name, tc.src)
+			}
+			joined := finds[0].Detail
+			if !strings.Contains(joined, tc.want) {
+				t.Errorf("finding does not describe the violation: got %q, want it "+
+					"to contain %q", joined, tc.want)
+			}
+		})
+	}
+
+	// Negative control: a clean render must NOT be flagged, or the guard is a
+	// blanket alarm that reviewers learn to ignore.
+	t.Run("clean render is not flagged", func(t *testing.T) {
+		fset := token.NewFileSet()
+		src := "package p\nfunc f(x T) { fmt.Fprintf(buf, \"psk %s\\n\", x.PSK) }\n"
+		file, err := parser.ParseFile(fset, "synthetic.go", src, 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
 		}
-		return "[]byte"
+		if finds := scanSecretUnwraps(fset, file, "synthetic.go", secretFields); len(finds) != 0 {
+			t.Errorf("formatting a Secret with %%s is SAFE (String() redacts) and "+
+				"must not be flagged; got %d finding(s): %v", len(finds), finds)
+		}
+	})
+}
+
+// secretUnwrap is one violation found by scanSecretUnwraps.
+type secretUnwrap struct {
+	Where  string // "file.go:LINE"
+	Detail string
+}
+
+// scanSecretUnwraps reports every cleartext unwrapping of a config.Secret in
+// one file. The two detections are deliberately INDEPENDENT — neither shares a
+// precondition with the other — because coupling them is what silently killed
+// the Reveal() branch once already: a zero-argument method call never has
+// exactly one Arg, so an arg-count gate placed ahead of it disabled it.
+func scanSecretUnwraps(fset *token.FileSet, file *ast.File, filename string, secretFields map[string]bool) []secretUnwrap {
+	var out []secretUnwrap
+	at := func(n ast.Node) string {
+		return fmt.Sprintf("%s:%d", filename, fset.Position(n.Pos()).Line)
 	}
-	return "?"
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		// (1) x.Secret.Reveal() — the explicit cleartext accessor. A method
+		// call carries its receiver in Fun, NOT in Args, so this must never be
+		// gated on len(Args).
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Reveal" {
+			out = append(out, secretUnwrap{
+				Where: at(call),
+				Detail: "calls the config.Secret cleartext accessor Reveal(), " +
+					"which returns the raw secret",
+			})
+			return true
+		}
+
+		// (2) string(x.Secret) / []byte(...) / []rune(...) / []uint8(...) —
+		// config.Secret is a named string type, so a conversion yields the
+		// cleartext without ever reaching the String() redaction.
+		if len(call.Args) != 1 {
+			return true
+		}
+		conv := secretUnwrapConversionName(call.Fun)
+		if conv == "" {
+			return true
+		}
+		name := trailingIdent(call.Args[0])
+		if name == "" || !secretFields[name] {
+			return true
+		}
+		out = append(out, secretUnwrap{
+			Where: at(call),
+			Detail: fmt.Sprintf("converts the config.Secret field %q with %s(...), "+
+				"which yields the CLEARTEXT secret (config.Secret is a named "+
+				"string type, so a conversion bypasses String())", name, conv),
+		})
+		return true
+	})
+	return out
+}
+
+// secretUnwrapConversionName returns the name of the conversion fun performs if
+// it is one that unwraps a string-kinded value, else "".
+func secretUnwrapConversionName(fun ast.Expr) string {
+	if id, ok := fun.(*ast.Ident); ok && id.Name == "string" {
+		return "string"
+	}
+	arr, ok := fun.(*ast.ArrayType)
+	if !ok || arr.Len != nil {
+		return ""
+	}
+	el, ok := arr.Elt.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	switch el.Name {
+	case "byte", "rune", "uint8", "int32":
+		return "[]" + el.Name
+	}
+	return ""
 }
 
 // trailingIdent returns the final identifier of a selector/index chain —
-// "PSK" for `cfg.Security.IKE.Policies[n].PSK` — or "" if the expression has
-// no such tail.
+// "PSK" for `cfg.Security.IKE.Policies[n].PSK`, "APIKeys" for
+// `cfg.....APIKeys[i]` — or "" if the expression has no such tail.
 func trailingIdent(e ast.Expr) string {
 	for {
 		switch x := e.(type) {
@@ -665,11 +820,16 @@ func trailingIdent(e ast.Expr) string {
 	}
 }
 
-// secretTypedFieldNames returns the names of every struct field declared as
-// config.Secret at FILE SCOPE in pkg/config. File scope matters: the
-// SNMPCommunity MarshalJSON/MarshalYAML bodies declare local alias structs
-// with a `Name Secret` field, and folding that generic name into the set would
-// flag `string(x.Name)` all over the package.
+// secretTypedFieldNames returns the names of every struct field whose type
+// MENTIONS config.Secret, declared at FILE SCOPE in pkg/config — including
+// collection and pointer shapes such as `APIKeys []Secret`
+// (types_system.go), which a bare `field.Type == Ident("Secret")` match would
+// miss even though `string(x.APIKeys[i])` is a direct field conversion.
+//
+// File scope matters: the SNMPCommunity MarshalJSON/MarshalYAML bodies declare
+// LOCAL alias structs with a `Name Secret` field, and folding that generic
+// name into the set would flag `string(x.Name)` all over the package. Walking
+// only file-scope type declarations excludes them.
 func secretTypedFieldNames(t *testing.T) map[string]bool {
 	t.Helper()
 	out := map[string]bool{}
@@ -696,20 +856,44 @@ func secretTypedFieldNames(t *testing.T) map[string]bool {
 				if !ok {
 					continue
 				}
-				st, ok := ts.Type.(*ast.StructType)
-				if !ok {
-					continue
-				}
-				for _, field := range st.Fields.List {
-					if id, ok := field.Type.(*ast.Ident); !ok || id.Name != "Secret" {
-						continue
-					}
-					for _, n := range field.Names {
-						out[n.Name] = true
-					}
-				}
+				collectSecretFieldNames(ts.Type, out)
 			}
 		}
 	}
 	return out
+}
+
+// collectSecretFieldNames adds every field of typ (recursing into nested
+// anonymous structs) whose type mentions Secret.
+func collectSecretFieldNames(typ ast.Expr, out map[string]bool) {
+	st, ok := typ.(*ast.StructType)
+	if !ok || st.Fields == nil {
+		return
+	}
+	for _, field := range st.Fields.List {
+		if typeMentionsSecret(field.Type) {
+			for _, n := range field.Names {
+				out[n.Name] = true
+			}
+		}
+		collectSecretFieldNames(field.Type, out)
+	}
+}
+
+// typeMentionsSecret reports whether a type expression names Secret anywhere —
+// `Secret`, `[]Secret`, `[4]Secret`, `*Secret`, `map[string]Secret`.
+func typeMentionsSecret(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name == "Secret"
+	case *ast.ArrayType:
+		return typeMentionsSecret(x.Elt)
+	case *ast.StarExpr:
+		return typeMentionsSecret(x.X)
+	case *ast.MapType:
+		return typeMentionsSecret(x.Value) || typeMentionsSecret(x.Key)
+	case *ast.SelectorExpr:
+		return x.Sel.Name == "Secret"
+	}
+	return false
 }

--- a/pkg/grpcapi/server_fabric_secret_render_6532_test.go
+++ b/pkg/grpcapi/server_fabric_secret_render_6532_test.go
@@ -560,26 +560,41 @@ func dispatcherTopics(t *testing.T) []string {
 // revision of this file became unreachable dead code while still reporting
 // PASS.
 //
-// SCOPE — stated in full, because a guard that overstates its reach is worse
-// than one that admits its limits. The conversion half is SYNTACTIC: it
+// SCOPE — these are the two DETECTED forms, not an exhaustive list of ways a
+// Secret can be unwrapped. Stating it that way matters: a guard that
+// overstates its reach is worse than one that admits its limits, because it
+// reads as covered.
+//
+// The Reveal half is name-based and shape-independent (it matches the
+// selection, so calls, parenthesized calls and method values all register).
+// The conversion half is SYNTACTIC: it de-parenthesizes the callee, then
 // resolves the converted expression to its trailing identifier and matches
 // that against the Secret-bearing field names declared at file scope in
-// pkg/config. It therefore does NOT catch:
+// pkg/config.
+//
+// NOT DETECTED — known residuals, each of which would need type resolution:
 //
 //   - a conversion of a local variable assigned from a secret field earlier
 //     (`s := gw.PSK; _ = string(s)`), a function parameter, or a helper return;
 //   - a Secret-bearing field declared outside pkg/config, or reached through a
 //     type alias;
-//   - non-conversion unwrapping: `append(dst, secret...)`, indexing or ranging
-//     the string, or reflection.
+//   - non-conversion unwrapping: `append(dst, secret...)`, `copy(dst, secret)`,
+//     indexing or ranging the string, or reflection.
 //
-// It also FALSE-POSITIVES by design, which is the right bias on a
-// network-exposed surface: an unrelated field that merely shares a name with a
-// Secret field (`Password`, `PSK`) is flagged, as is a conversion using a
-// locally shadowed `string`/`byte` identifier. Both are cheap to justify in
-// review; a missed credential is not. Closing the direct-field path closes the
-// realistic renderer mistake — the rest is a documented residual, not a claim
-// of completeness.
+// FALSE POSITIVES — by design, and the right bias on a network-exposed
+// surface, but disclosed rather than discovered:
+//
+//   - ANY method named Reveal is flagged, whatever its receiver type — this
+//     guard does not resolve types, so an unrelated Reveal() would register;
+//   - the conversion check matches a trailing IDENTIFIER, so an unrelated
+//     local, parameter or field that merely shares a name with a Secret field
+//     (`Password`, `PSK`) is flagged too — it is not limited to real fields;
+//   - a conversion using a locally shadowed `string`, `byte`, `rune`, `uint8`
+//     or `int32` identifier is flagged as if it were the builtin.
+//
+// All three are cheap to justify in review; a missed credential is not.
+// Closing the direct-field path closes the realistic renderer mistake — the
+// rest is a documented residual, not a claim of completeness.
 func TestGRPCAPINeverUnwrapsSecretCleartext(t *testing.T) {
 	secretFields := secretTypedFieldNames(t)
 
@@ -678,6 +693,45 @@ func TestSecretUnwrapScannerDetectsBothForms(t *testing.T) {
 			src:  "package p\nfunc f(x T) { _ = string(x.APIKeys[i]) }\n",
 			want: `"APIKeys"`,
 		},
+
+		// Parenthesized callees. All of these are legal Go that gofmt leaves
+		// untouched, and every one of them put an *ast.ParenExpr where an
+		// earlier revision looked for the callee directly — so all four
+		// produced NO finding while the scanner claimed to cover them.
+		{
+			name: "parenthesized Reveal callee",
+			src:  "package p\nfunc f(x T) { _ = (x.PSK.Reveal)() }\n",
+			want: "Reveal()",
+		},
+		{
+			name: "parenthesized string conversion",
+			src:  "package p\nfunc f(x T) { _ = (string)(x.PSK) }\n",
+			want: `"PSK" with string(...)`,
+		},
+		{
+			name: "parenthesized byte slice conversion",
+			src:  "package p\nfunc f(x T) { _ = ([]byte)(x.PSK) }\n",
+			want: `"PSK" with []byte(...)`,
+		},
+		{
+			name: "doubly parenthesized conversion",
+			src:  "package p\nfunc f(x T) { _ = ((string))(x.PSK) }\n",
+			want: `"PSK" with string(...)`,
+		},
+		{
+			name: "parenthesized conversion argument",
+			src:  "package p\nfunc f(x T) { _ = string((x.PSK)) }\n",
+			want: `"PSK"`,
+		},
+
+		// A method VALUE binds the accessor without calling it at the binding
+		// site. Detecting the selection covers this; a CallExpr-anchored check
+		// cannot, because the call is `reveal()` with no selector at all.
+		{
+			name: "Reveal bound as a method value",
+			src:  "package p\nfunc f(x T) { reveal := x.PSK.Reveal; _ = reveal() }\n",
+			want: "Reveal()",
+		},
 	}
 
 	for _, tc := range cases {
@@ -726,8 +780,18 @@ type secretUnwrap struct {
 // scanSecretUnwraps reports every cleartext unwrapping of a config.Secret in
 // one file. The two detections are deliberately INDEPENDENT — neither shares a
 // precondition with the other — because coupling them is what silently killed
-// the Reveal() branch once already: a zero-argument method call never has
-// exactly one Arg, so an arg-count gate placed ahead of it disabled it.
+// the Reveal branch once already: a zero-argument method call never has exactly
+// one Arg, so an arg-count gate placed ahead of it disabled it.
+//
+// Both detections are also written against the SHAPE OF THE AST rather than
+// the shape of the source a reviewer pictures. Go lets a callee be
+// parenthesized — `(x.PSK.Reveal)()`, `(string)(x.PSK)`, `((string))(x.PSK)`
+// are all legal and survive gofmt — which puts an *ast.ParenExpr where the
+// naive check looks for the callee. That is why the Reveal detection matches
+// the SELECTOR rather than the call (ast.Inspect reaches the selector however
+// the call is written, and even when it is never called — a `reveal :=
+// x.PSK.Reveal` method value binds the same cleartext accessor), and why the
+// conversion detection unwraps parentheses before inspecting the callee.
 func scanSecretUnwraps(fset *token.FileSet, file *ast.File, filename string, secretFields map[string]bool) []secretUnwrap {
 	var out []secretUnwrap
 	at := func(n ast.Node) string {
@@ -735,18 +799,15 @@ func scanSecretUnwraps(fset *token.FileSet, file *ast.File, filename string, sec
 	}
 
 	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-
-		// (1) x.Secret.Reveal() — the explicit cleartext accessor. A method
-		// call carries its receiver in Fun, NOT in Args, so this must never be
-		// gated on len(Args).
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Reveal" {
+		// (1) The Reveal cleartext accessor, matched on the SELECTION itself.
+		// This covers `x.PSK.Reveal()`, the parenthesized `(x.PSK.Reveal)()`,
+		// and a method VALUE (`reveal := x.PSK.Reveal`) uniformly — binding the
+		// accessor is as much a cleartext path as calling it, and none of the
+		// three depends on how the call is parenthesized.
+		if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "Reveal" {
 			out = append(out, secretUnwrap{
-				Where: at(call),
-				Detail: "calls the config.Secret cleartext accessor Reveal(), " +
+				Where: at(sel),
+				Detail: "references the config.Secret cleartext accessor Reveal(), " +
 					"which returns the raw secret",
 			})
 			return true
@@ -755,7 +816,8 @@ func scanSecretUnwraps(fset *token.FileSet, file *ast.File, filename string, sec
 		// (2) string(x.Secret) / []byte(...) / []rune(...) / []uint8(...) —
 		// config.Secret is a named string type, so a conversion yields the
 		// cleartext without ever reaching the String() redaction.
-		if len(call.Args) != 1 {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
 			return true
 		}
 		conv := secretUnwrapConversionName(call.Fun)
@@ -777,9 +839,24 @@ func scanSecretUnwraps(fset *token.FileSet, file *ast.File, filename string, sec
 	return out
 }
 
+// unwrapParens strips any number of parenthesis layers. `((string))(x)` is
+// legal Go and gofmt leaves it alone, so a single-level unwrap is not enough.
+func unwrapParens(e ast.Expr) ast.Expr {
+	for {
+		p, ok := e.(*ast.ParenExpr)
+		if !ok {
+			return e
+		}
+		e = p.X
+	}
+}
+
 // secretUnwrapConversionName returns the name of the conversion fun performs if
-// it is one that unwraps a string-kinded value, else "".
+// it is one that unwraps a string-kinded value, else "". The callee is
+// de-parenthesized first: `(string)(x.PSK)` and `([]byte)(x.PSK)` are ordinary
+// conversions that present their callee as an *ast.ParenExpr.
 func secretUnwrapConversionName(fun ast.Expr) string {
+	fun = unwrapParens(fun)
 	if id, ok := fun.(*ast.Ident); ok && id.Name == "string" {
 		return "string"
 	}
@@ -863,20 +940,54 @@ func secretTypedFieldNames(t *testing.T) map[string]bool {
 	return out
 }
 
-// collectSecretFieldNames adds every field of typ (recursing into nested
-// anonymous structs) whose type mentions Secret.
+// collectSecretFieldNames adds every field of typ whose type mentions Secret,
+// recursing into nested anonymous structs. It looks THROUGH slice, array,
+// pointer and map shapes on the way down, so a Secret carried inside
+// `[]struct{ Token Secret }` or `map[string]*struct{ PSK Secret }` is
+// harvested rather than skipped — a bare `typ.(*ast.StructType)` assertion
+// stops at the first such wrapper.
+//
+// An EMBEDDED Secret (`struct { Secret }`) has no name in the AST but is
+// selected as `x.Secret`, so it is harvested under that name.
 func collectSecretFieldNames(typ ast.Expr, out map[string]bool) {
-	st, ok := typ.(*ast.StructType)
-	if !ok || st.Fields == nil {
+	st := structTypeOf(typ)
+	if st == nil || st.Fields == nil {
 		return
 	}
 	for _, field := range st.Fields.List {
 		if typeMentionsSecret(field.Type) {
+			if len(field.Names) == 0 {
+				// Embedded field: selected by its type name.
+				if n := trailingIdent(field.Type); n != "" {
+					out[n] = true
+				}
+			}
 			for _, n := range field.Names {
 				out[n.Name] = true
 			}
 		}
 		collectSecretFieldNames(field.Type, out)
+	}
+}
+
+// structTypeOf looks through slice/array/pointer/map wrappers to the struct
+// type underneath, or nil if there is none.
+func structTypeOf(e ast.Expr) *ast.StructType {
+	for {
+		switch x := e.(type) {
+		case *ast.StructType:
+			return x
+		case *ast.ArrayType:
+			e = x.Elt
+		case *ast.StarExpr:
+			e = x.X
+		case *ast.MapType:
+			e = x.Value
+		case *ast.ParenExpr:
+			e = x.X
+		default:
+			return nil
+		}
 	}
 }
 

--- a/pkg/grpcapi/server_fabric_secret_render_6532_test.go
+++ b/pkg/grpcapi/server_fabric_secret_render_6532_test.go
@@ -543,7 +543,9 @@ func dispatcherTopics(t *testing.T) []string {
 // community is a config.Secret, whose String() renders "<redacted>" under
 // %s/%v/%q/%x (#2053) — so a text renderer cannot leak one by accident.
 //
-// There are TWO independent ways to defeat that, and the scan checks both:
+// This guard detects TWO SHAPES. That is NOT the same as enumerating every way
+// to defeat the redaction — Go's expression grammar is open and the RESIDUALS
+// listed below are real. The two DETECTED shapes are:
 //
 //  1. Reveal(), the explicit cleartext accessor.
 //  2. A CONVERSION. config.Secret is `type Secret string`
@@ -562,6 +564,17 @@ func dispatcherTopics(t *testing.T) []string {
 // from a broken scan, which is exactly how the Reveal() branch of an earlier
 // revision of this file became unreachable dead code while still reporting
 // PASS.
+//
+// RESIDUALS — shapes this guard does NOT flag, stated so the coverage claim
+// above is not read as completeness:
+//   - a COMPUTED argument. secretExprTail walks a DIRECT wrapper chain
+//     (index / slice / deref / paren / selector) and returns "" for anything
+//     else, so `Clear(x.PSK + "")`, `Clear([]config.Secret{x.PSK}[0])` and
+//     `Clear(<-x.SecretChan)` pass the arity gate but do not resolve to a
+//     harvested field name.
+//   - `copy(dst, x.PSK)` and `append(dst, x.PSK...)` — two arguments, so the
+//     arity gate does not reach them.
+//   - reflection, and any unwrap through an interface value.
 //
 // SCOPE, and the HARD LIMIT.
 //
@@ -1144,6 +1157,23 @@ func secretTypedFieldNames(t *testing.T) map[string]bool {
 // An EMBEDDED Secret (`struct { Secret }`) has no name in the AST but is
 // selected as `x.Secret`, so it is harvested under that name.
 func collectSecretFieldNames(typ ast.Expr, out map[string]bool) {
+	// A map carries a struct on EITHER side, and `structTypeOf` can only
+	// return one. Recurse into both halves explicitly so
+	// `map[struct{ Key Secret }]struct{ Value Secret }` harvests BOTH — the
+	// previous shape returned the key's struct and silently never visited the
+	// value, while the doc claimed both sides were followed.
+	for {
+		p, ok := typ.(*ast.ParenExpr)
+		if !ok {
+			break
+		}
+		typ = p.X
+	}
+	if mt, ok := typ.(*ast.MapType); ok {
+		collectSecretFieldNames(mt.Key, out)
+		collectSecretFieldNames(mt.Value, out)
+		return
+	}
 	st := structTypeOf(typ)
 	if st == nil || st.Fields == nil {
 		return

--- a/pkg/grpcapi/server_fabric_secret_render_6532_test.go
+++ b/pkg/grpcapi/server_fabric_secret_render_6532_test.go
@@ -26,19 +26,21 @@
 //   - TestGRPCAPINeverUnwrapsSecretCleartext pins the structural reason the
 //     sweep finds only one class of leak: every operator secret except the SNMP
 //     community is a config.Secret, whose String() masks it under %s/%v/%q/%x
-//     (#2053). It checks the TWO ways to defeat that — the Reveal() accessor
-//     and a plain string()/[]byte() CONVERSION, which works because Secret is a
-//     named string type — and covers the render paths the sweep cannot drive
-//     in-process (a nil dataplane / IPsec manager / FRR short-circuits some
-//     renderers before they format anything). Its scope and its residuals are
-//     documented in full on the test itself; it does not claim completeness.
+//     (#2053). It reports two things a renderer can do to get past that — name
+//     the Reveal accessor, or hand a Secret field to a one-argument call — and
+//     covers the render paths the sweep cannot drive in-process (a nil
+//     dataplane / IPsec manager / FRR short-circuits some renderers before they
+//     format anything). It is SYNTACTIC and therefore has a hard limit, stated
+//     on the test itself; it does not claim completeness.
 //
-//   - TestSecretUnwrapScannerDetectsBothForms proves that guard can FAIL. A
-//     structural scan reporting "no violations" is worthless until someone has
-//     shown it fires, and an earlier revision of this file demonstrated exactly
-//     that: the Reveal() branch sat behind an argument-count gate that a
-//     zero-argument method call never satisfies, so it was unreachable dead
-//     code while the suite stayed green.
+//   - TestSecretUnwrapScannerDetectsBothForms and TestSecretFieldHarvestShapes
+//     prove that guard can FAIL, for the scan and the field harvest
+//     respectively. A structural check reporting "no violations" is worthless
+//     until someone has shown it fires. That is not hypothetical here: this
+//     scan shipped twice with shapes it claimed to cover producing no finding —
+//     once with the Reveal branch behind an argument-count gate a zero-argument
+//     method call never satisfies, and once blind to every parenthesized
+//     callee. Both times the suite was green.
 package grpcapi
 
 import (
@@ -48,6 +50,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -560,41 +563,76 @@ func dispatcherTopics(t *testing.T) []string {
 // revision of this file became unreachable dead code while still reporting
 // PASS.
 //
-// SCOPE — these are the two DETECTED forms, not an exhaustive list of ways a
-// Secret can be unwrapped. Stating it that way matters: a guard that
-// overstates its reach is worse than one that admits its limits, because it
-// reads as covered.
+// SCOPE, and the HARD LIMIT.
 //
-// The Reveal half is name-based and shape-independent (it matches the
-// selection, so calls, parenthesized calls and method values all register).
-// The conversion half is SYNTACTIC: it de-parenthesizes the callee, then
-// resolves the converted expression to its trailing identifier and matches
-// that against the Secret-bearing field names declared at file scope in
-// pkg/config.
+// This guard is SYNTACTIC. It reads the AST; it does not resolve types. That
+// is not a temporary state to be patched away — it is a ceiling, and four
+// review rounds were spent discovering it one shape at a time. The honest
+// statement of what it can and cannot do follows, and the ceiling is the
+// important half.
 //
-// NOT DETECTED — known residuals, each of which would need type resolution:
+// WHAT IT DETECTS
 //
-//   - a conversion of a local variable assigned from a secret field earlier
-//     (`s := gw.PSK; _ = string(s)`), a function parameter, or a helper return;
-//   - a Secret-bearing field declared outside pkg/config, or reached through a
-//     type alias;
-//   - non-conversion unwrapping: `append(dst, secret...)`, `copy(dst, secret)`,
-//     indexing or ranging the string, or reflection.
+//  1. Any SELECTION named Reveal. Matching the selection rather than the call
+//     covers `x.PSK.Reveal()`, `(x.PSK.Reveal)()`, a method value
+//     `reveal := x.PSK.Reveal`, a method expression, an interface call and a
+//     promoted embedded method, uniformly and without shape enumeration.
+//
+//  2. A ONE-ARGUMENT call whose argument names a Secret-bearing field. It does
+//     NOT inspect the callee. Earlier revisions matched callee shapes —
+//     `string`, `(string)`, `((string))`, `[]byte`, `[](byte)`, `([](byte))` —
+//     and each fix was blind to one more, because the callee of a conversion
+//     is a TYPE EXPRESSION whose grammar is open: `type Clear string;
+//     Clear(x.PSK)` unwraps the secret and no builtin-name matching ever sees
+//     it. Ignoring the callee closes that whole dimension at once.
+//
+// Two dimensions ARE closed exhaustively, by enumerating go/ast node kinds
+// rather than source shapes: parenthesization (nothing about the callee is
+// examined) and the argument's wrapper chain (secretExprTail enumerates every
+// expression node that designates the same value — paren, star, index, index
+// list, slice, type assertion, address-of).
+//
+// # THE HARD LIMIT — INDIRECTION THROUGH A VALUE
+//
+// The check fires on the SYNTAX at the point of use, so it sees a secret only
+// where the field is named. It cannot follow a value:
+//
+//   - `s := gw.PSK; _ = string(s)` — a local, a parameter, or a helper return;
+//   - a Secret-bearing field declared outside pkg/config, or behind a type
+//     alias, so the harvest never learns its name;
+//   - a handoff to a MULTI-argument call (`leak(ctx, x.PSK)`). One argument is
+//     a deliberate line, not an oversight: the safe idiom
+//     `fmt.Fprintf(buf, "%s", x.PSK)` is multi-argument and redacts correctly,
+//     so flagging it would fire on every correct render and be tuned out. A
+//     helper that unwraps internally is caught at ITS unwrap site if it lives
+//     in this package, and is out of scope if it does not;
+//   - `append(dst, secret...)`, `copy(dst, secret)`, ranging or reflection.
+//
+// Closing these needs real type resolution (go/types via
+// golang.org/x/tools/go/packages, today only an INDIRECT dependency), or
+// inverting the check to flag every conversion in the package against an
+// explicit allowlist — 42 conversions in pkg/grpcapi as of this commit, so
+// feasible but it puts test scaffolding into production source. The clean
+// structural fix is upstream: making config.Secret a struct rather than a
+// named string type would make `string(s)` fail to COMPILE and collapse this
+// entire shape space to the single Reveal accessor. That is a pkg/config-wide
+// change (Secret is currently comparable and used as a map key), so it belongs
+// in its own issue, not here.
 //
 // FALSE POSITIVES — by design, and the right bias on a network-exposed
-// surface, but disclosed rather than discovered:
+// surface, but disclosed rather than left to be discovered:
 //
-//   - ANY method named Reveal is flagged, whatever its receiver type — this
-//     guard does not resolve types, so an unrelated Reveal() would register;
-//   - the conversion check matches a trailing IDENTIFIER, so an unrelated
+//   - EVERY selector named Reveal is flagged, whatever it selects — a method
+//     on an unrelated type, a package member, even a struct field called
+//     Reveal. No type resolution, so no way to tell them apart;
+//   - the one-argument check matches a trailing IDENTIFIER, so an unrelated
 //     local, parameter or field that merely shares a name with a Secret field
-//     (`Password`, `PSK`) is flagged too — it is not limited to real fields;
-//   - a conversion using a locally shadowed `string`, `byte`, `rune`, `uint8`
-//     or `int32` identifier is flagged as if it were the builtin.
+//     (`Password`, `PSK`) is flagged — it is not limited to real fields;
+//   - any one-argument call is flagged, including provably harmless ones such
+//     as `len(x.PSK)`, which cannot carry a secret in its int result.
 //
-// All three are cheap to justify in review; a missed credential is not.
-// Closing the direct-field path closes the realistic renderer mistake — the
-// rest is a documented residual, not a claim of completeness.
+// All are cheap to justify in review; a missed credential is not. There are
+// zero such sites in pkg/grpcapi today.
 func TestGRPCAPINeverUnwrapsSecretCleartext(t *testing.T) {
 	secretFields := secretTypedFieldNames(t)
 
@@ -661,22 +699,22 @@ func TestSecretUnwrapScannerDetectsBothForms(t *testing.T) {
 		{
 			name: "string conversion",
 			src:  "package p\nfunc f(x T) { _ = string(x.PSK) }\n",
-			want: `converts the config.Secret field "PSK" with string(...)`,
+			want: `field "PSK" to string(...)`,
 		},
 		{
 			name: "byte slice conversion",
 			src:  "package p\nfunc f(x T) { _ = []byte(x.PSK) }\n",
-			want: `"PSK" with []byte(...)`,
+			want: `"PSK" to []byte(...)`,
 		},
 		{
 			name: "rune slice conversion",
 			src:  "package p\nfunc f(x T) { _ = []rune(x.PSK) }\n",
-			want: `"PSK" with []rune(...)`,
+			want: `"PSK" to []rune(...)`,
 		},
 		{
 			name: "uint8 slice conversion",
 			src:  "package p\nfunc f(x T) { _ = []uint8(x.PSK) }\n",
-			want: `"PSK" with []uint8(...)`,
+			want: `"PSK" to []uint8(...)`,
 		},
 		{
 			name: "conversion nested in a call argument",
@@ -706,17 +744,17 @@ func TestSecretUnwrapScannerDetectsBothForms(t *testing.T) {
 		{
 			name: "parenthesized string conversion",
 			src:  "package p\nfunc f(x T) { _ = (string)(x.PSK) }\n",
-			want: `"PSK" with string(...)`,
+			want: `"PSK" to (string)(...)`,
 		},
 		{
 			name: "parenthesized byte slice conversion",
 			src:  "package p\nfunc f(x T) { _ = ([]byte)(x.PSK) }\n",
-			want: `"PSK" with []byte(...)`,
+			want: `"PSK" to ([]byte)(...)`,
 		},
 		{
 			name: "doubly parenthesized conversion",
 			src:  "package p\nfunc f(x T) { _ = ((string))(x.PSK) }\n",
-			want: `"PSK" with string(...)`,
+			want: `"PSK" to ((string))(...)`,
 		},
 		{
 			name: "parenthesized conversion argument",
@@ -731,6 +769,72 @@ func TestSecretUnwrapScannerDetectsBothForms(t *testing.T) {
 			name: "Reveal bound as a method value",
 			src:  "package p\nfunc f(x T) { reveal := x.PSK.Reveal; _ = reveal() }\n",
 			want: "Reveal()",
+		},
+
+		// Callee shapes. Since the check no longer inspects the callee, these
+		// all take one code path — but they are enumerated anyway because they
+		// are the contract, and four review rounds were lost to exactly these
+		// shapes escaping one at a time.
+		{
+			name: "slice element type parenthesized",
+			src:  "package p\nfunc f(x T) { _ = [](byte)(x.PSK) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "slice type and element both parenthesized",
+			src:  "package p\nfunc f(x T) { _ = ([](byte))(x.PSK) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "parenthesized rune element",
+			src:  "package p\nfunc f(x T) { _ = [](rune)(x.PSK) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "parenthesized uint8 element",
+			src:  "package p\nfunc f(x T) { _ = [](uint8)(x.PSK) }\n",
+			want: `"PSK"`,
+		},
+		// The escape no callee-shape matching can ever close: a conversion to
+		// a named string type declared anywhere. This is why the check stopped
+		// inspecting the callee.
+		{
+			name: "conversion to a named string type (type Clear string)",
+			src:  "package p\nfunc f(x T) { _ = Clear(x.PSK) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "conversion to a package-qualified named type",
+			src:  "package p\nfunc f(x T) { _ = other.Clear(x.PSK) }\n",
+			want: `"PSK"`,
+		},
+
+		// Argument shapes — the dimension that IS still gated, on
+		// secretExprTail's exhaustive wrapper enumeration.
+		{
+			name: "sliced field",
+			src:  "package p\nfunc f(x T) { _ = string(x.PSK[:]) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "sliced field with bounds",
+			src:  "package p\nfunc f(x T) { _ = string(x.PSK[1:2]) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "address-of field",
+			src:  "package p\nfunc f(x T) { _ = string(*&x.PSK) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "type-asserted field",
+			src:  "package p\nfunc f(x T) { _ = string(x.PSK.(S)) }\n",
+			want: `"PSK"`,
+		},
+		{
+			name: "pointer deref of an indexed collection field",
+			src:  "package p\nfunc f(x T) { _ = []byte(*x.APIKeys[i]) }\n",
+			want: `"APIKeys"`,
 		},
 	}
 
@@ -755,18 +859,111 @@ func TestSecretUnwrapScannerDetectsBothForms(t *testing.T) {
 		})
 	}
 
-	// Negative control: a clean render must NOT be flagged, or the guard is a
-	// blanket alarm that reviewers learn to ignore.
-	t.Run("clean render is not flagged", func(t *testing.T) {
+	// Negative controls. Without these the scanner could pass every case above
+	// by flagging unconditionally, and a guard that fires on correct code is
+	// one reviewers learn to ignore.
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{
+			// THE canonical safe render: multi-argument, and String() redacts.
+			name: "formatted with %s is safe",
+			src:  "package p\nfunc f(x T) { fmt.Fprintf(buf, \"psk %s\\n\", x.PSK) }\n",
+		},
+		{
+			name: "unrelated single-argument conversion",
+			src:  "package p\nfunc f(x T) { _ = string(x.Hostname) }\n",
+		},
+		{
+			name: "presence check is not an unwrap",
+			src:  "package p\nfunc f(x T) bool { return x.PSK != \"\" }\n",
+		},
+	} {
+		t.Run("SAFE: "+tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "synthetic.go", tc.src, 0)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if finds := scanSecretUnwraps(fset, file, "synthetic.go", secretFields); len(finds) != 0 {
+				t.Errorf("%s must NOT be flagged; got %d finding(s): %v",
+					tc.name, len(finds), finds)
+			}
+		})
+	}
+}
+
+// TestSecretFieldHarvestShapes proves the harvest half of the guard finds
+// Secret-bearing fields through the declaration shapes it claims to cover. The
+// live pkg/config tree exercises only a few of these today, so without
+// synthetic sources the widened harvest would be asserted but untested — the
+// same gap that let the scanner's parenthesized shapes ship unnoticed.
+func TestSecretFieldHarvestShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		decl string
+		want string
+	}{
+		{"plain field", "type A struct{ PSK Secret }", "PSK"},
+		{"parenthesized type", "type A struct{ PSK (Secret) }", "PSK"},
+		{"slice of Secret", "type A struct{ APIKeys []Secret }", "APIKeys"},
+		{"array of Secret", "type A struct{ Keys [4]Secret }", "Keys"},
+		{"pointer to Secret", "type A struct{ PSK *Secret }", "PSK"},
+		{"map value Secret", "type A struct{ M map[string]Secret }", "M"},
+		{"channel of Secret", "type A struct{ C chan Secret }", "C"},
+		{"embedded Secret", "type A struct{ Secret }", "Secret"},
+		{"nested anonymous struct", "type A struct{ Inner struct{ Token Secret } }", "Token"},
+		{"slice of anonymous struct", "type A struct{ Rows []struct{ Token Secret } }", "Token"},
+		{"pointer to anonymous struct", "type A struct{ P *struct{ Token Secret } }", "Token"},
+		{"map value anonymous struct", "type A struct{ M map[string]struct{ Token Secret } }", "Token"},
+		{"map KEY anonymous struct", "type A struct{ M map[struct{ Token Secret }]bool }", "Token"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "s.go", "package config\n"+tc.decl+"\n", 0)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.decl, err)
+			}
+			got := map[string]bool{}
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					if ts, ok := spec.(*ast.TypeSpec); ok {
+						collectSecretFieldNames(ts.Type, got)
+					}
+				}
+			}
+			if !got[tc.want] {
+				t.Errorf("harvest missed %q in %s — a Secret declared this way "+
+					"would not be matched by the conversion check, so unwrapping "+
+					"it would go unreported. Got: %v", tc.want, tc.decl, got)
+			}
+		})
+	}
+
+	// Negative control: a plain string field must NOT be harvested, or the
+	// conversion check degenerates into flagging every field name.
+	t.Run("SAFE: plain string field is not harvested", func(t *testing.T) {
 		fset := token.NewFileSet()
-		src := "package p\nfunc f(x T) { fmt.Fprintf(buf, \"psk %s\\n\", x.PSK) }\n"
-		file, err := parser.ParseFile(fset, "synthetic.go", src, 0)
-		if err != nil {
-			t.Fatalf("parse: %v", err)
+		file, _ := parser.ParseFile(fset, "s.go",
+			"package config\ntype A struct{ Name string }\n", 0)
+		got := map[string]bool{}
+		for _, decl := range file.Decls {
+			if gen, ok := decl.(*ast.GenDecl); ok {
+				for _, spec := range gen.Specs {
+					if ts, ok := spec.(*ast.TypeSpec); ok {
+						collectSecretFieldNames(ts.Type, got)
+					}
+				}
+			}
 		}
-		if finds := scanSecretUnwraps(fset, file, "synthetic.go", secretFields); len(finds) != 0 {
-			t.Errorf("formatting a Secret with %%s is SAFE (String() redacts) and "+
-				"must not be flagged; got %d finding(s): %v", len(finds), finds)
+		if got["Name"] {
+			t.Errorf("a plain string field must not be harvested; got %v", got)
 		}
 	})
 }
@@ -813,83 +1010,80 @@ func scanSecretUnwraps(fset *token.FileSet, file *ast.File, filename string, sec
 			return true
 		}
 
-		// (2) string(x.Secret) / []byte(...) / []rune(...) / []uint8(...) —
-		// config.Secret is a named string type, so a conversion yields the
-		// cleartext without ever reaching the String() redaction.
+		// (2) A single-argument call applied to a Secret field.
+		//
+		// This deliberately does NOT inspect the callee. Four rounds of review
+		// were spent patching callee SHAPES — `(string)(x)`, `((string))(x)`,
+		// `[](byte)(x)`, `([](byte))(x)` — and each fix was blind to one more,
+		// because the callee of a conversion is a TYPE EXPRESSION and the
+		// grammar of type expressions is open: `type Clear string;
+		// Clear(x.PSK)` unwraps the secret just as effectively and no amount of
+		// builtin-name matching sees it.
+		//
+		// So the callee is not the discriminator. What matters is that a
+		// Secret-typed field is handed to a one-argument call at all. Every
+		// conversion — builtin, parenthesized, aliased, or a named string type
+		// declared anywhere — is a one-argument call, so all of them land here
+		// with no shape enumeration.
+		//
+		// One argument is the right line: the SAFE and idiomatic render,
+		// `fmt.Fprintf(buf, "%s", x.PSK)`, is multi-argument and passes through
+		// String()'s redaction. Flagging it too would make this guard fire on
+		// every correct render and be tuned out.
 		call, ok := n.(*ast.CallExpr)
 		if !ok || len(call.Args) != 1 {
 			return true
 		}
-		conv := secretUnwrapConversionName(call.Fun)
-		if conv == "" {
-			return true
-		}
-		name := trailingIdent(call.Args[0])
+		name := secretExprTail(call.Args[0])
 		if name == "" || !secretFields[name] {
 			return true
 		}
 		out = append(out, secretUnwrap{
 			Where: at(call),
-			Detail: fmt.Sprintf("converts the config.Secret field %q with %s(...), "+
-				"which yields the CLEARTEXT secret (config.Secret is a named "+
-				"string type, so a conversion bypasses String())", name, conv),
+			Detail: fmt.Sprintf("passes the config.Secret field %q to %s(...). "+
+				"config.Secret is a named string type, so a conversion yields "+
+				"the CLEARTEXT secret without ever reaching the String() "+
+				"redaction", name, types.ExprString(call.Fun)),
 		})
 		return true
 	})
 	return out
 }
 
-// unwrapParens strips any number of parenthesis layers. `((string))(x)` is
-// legal Go and gofmt leaves it alone, so a single-level unwrap is not enough.
-func unwrapParens(e ast.Expr) ast.Expr {
-	for {
-		p, ok := e.(*ast.ParenExpr)
-		if !ok {
-			return e
-		}
-		e = p.X
-	}
-}
-
-// secretUnwrapConversionName returns the name of the conversion fun performs if
-// it is one that unwraps a string-kinded value, else "". The callee is
-// de-parenthesized first: `(string)(x.PSK)` and `([]byte)(x.PSK)` are ordinary
-// conversions that present their callee as an *ast.ParenExpr.
-func secretUnwrapConversionName(fun ast.Expr) string {
-	fun = unwrapParens(fun)
-	if id, ok := fun.(*ast.Ident); ok && id.Name == "string" {
-		return "string"
-	}
-	arr, ok := fun.(*ast.ArrayType)
-	if !ok || arr.Len != nil {
-		return ""
-	}
-	el, ok := arr.Elt.(*ast.Ident)
-	if !ok {
-		return ""
-	}
-	switch el.Name {
-	case "byte", "rune", "uint8", "int32":
-		return "[]" + el.Name
-	}
-	return ""
-}
-
-// trailingIdent returns the final identifier of a selector/index chain —
-// "PSK" for `cfg.Security.IKE.Policies[n].PSK`, "APIKeys" for
-// `cfg.....APIKeys[i]` — or "" if the expression has no such tail.
-func trailingIdent(e ast.Expr) string {
+// secretExprTail resolves an expression to the identifier it ultimately names —
+// "PSK" for `cfg.Security.IKE.Policies[n].PSK`, `(x.PSK)`, `*x.PSK`,
+// `x.PSK[:]` or `x.APIKeys[i]` — or "" if it names none.
+//
+// The wrapper cases below are an EXHAUSTIVE enumeration of the go/ast
+// expression nodes that wrap another expression while still designating the
+// same underlying value. That exhaustiveness is the point: this is one of the
+// two dimensions of this guard that CAN be closed completely, and enumerating
+// the node kinds closes it, whereas matching source shapes one at a time did
+// not. The default case returns "" — an expression kind that is not a wrapper
+// (a call, a composite literal, a binary expression) does not name a field.
+func secretExprTail(e ast.Expr) string {
 	for {
 		switch x := e.(type) {
 		case *ast.SelectorExpr:
 			return x.Sel.Name
 		case *ast.Ident:
 			return x.Name
-		case *ast.IndexExpr:
+		case *ast.ParenExpr: // (x.PSK)
 			e = x.X
-		case *ast.StarExpr:
+		case *ast.StarExpr: // *x.PSK
 			e = x.X
-		case *ast.ParenExpr:
+		case *ast.IndexExpr: // x.APIKeys[i]
+			e = x.X
+		case *ast.IndexListExpr: // generic instantiation x.F[A, B]
+			e = x.X
+		case *ast.SliceExpr: // x.PSK[:]
+			e = x.X
+		case *ast.TypeAssertExpr: // x.PSK.(T)
+			e = x.X
+		case *ast.UnaryExpr: // &x.PSK
+			if x.Op != token.AND {
+				return ""
+			}
 			e = x.X
 		default:
 			return ""
@@ -958,7 +1152,7 @@ func collectSecretFieldNames(typ ast.Expr, out map[string]bool) {
 		if typeMentionsSecret(field.Type) {
 			if len(field.Names) == 0 {
 				// Embedded field: selected by its type name.
-				if n := trailingIdent(field.Type); n != "" {
+				if n := secretExprTail(field.Type); n != "" {
 					out[n] = true
 				}
 			}
@@ -971,7 +1165,10 @@ func collectSecretFieldNames(typ ast.Expr, out map[string]bool) {
 }
 
 // structTypeOf looks through slice/array/pointer/map wrappers to the struct
-// type underneath, or nil if there is none.
+// type underneath, or nil if there is none. A map is followed on BOTH sides:
+// an anonymous struct is a legal comparable map KEY, so
+// `map[struct{ PSK Secret }]bool` carries a Secret just as
+// `map[string]struct{ PSK Secret }` does.
 func structTypeOf(e ast.Expr) *ast.StructType {
 	for {
 		switch x := e.(type) {
@@ -981,10 +1178,13 @@ func structTypeOf(e ast.Expr) *ast.StructType {
 			e = x.Elt
 		case *ast.StarExpr:
 			e = x.X
-		case *ast.MapType:
-			e = x.Value
 		case *ast.ParenExpr:
 			e = x.X
+		case *ast.MapType:
+			if st := structTypeOf(x.Key); st != nil {
+				return st
+			}
+			e = x.Value
 		default:
 			return nil
 		}
@@ -992,17 +1192,24 @@ func structTypeOf(e ast.Expr) *ast.StructType {
 }
 
 // typeMentionsSecret reports whether a type expression names Secret anywhere —
-// `Secret`, `[]Secret`, `[4]Secret`, `*Secret`, `map[string]Secret`.
+// `Secret`, `(Secret)`, `[]Secret`, `[4]Secret`, `*Secret`,
+// `map[string]Secret`, `chan Secret`. Parentheses are legal in a type
+// expression (`PSK (Secret)` is a valid field declaration that gofmt
+// preserves), so they are stripped here like everywhere else in this file.
 func typeMentionsSecret(e ast.Expr) bool {
 	switch x := e.(type) {
 	case *ast.Ident:
 		return x.Name == "Secret"
+	case *ast.ParenExpr:
+		return typeMentionsSecret(x.X)
 	case *ast.ArrayType:
 		return typeMentionsSecret(x.Elt)
 	case *ast.StarExpr:
 		return typeMentionsSecret(x.X)
 	case *ast.MapType:
 		return typeMentionsSecret(x.Value) || typeMentionsSecret(x.Key)
+	case *ast.ChanType:
+		return typeMentionsSecret(x.Value)
 	case *ast.SelectorExpr:
 		return x.Sel.Name == "Secret"
 	}

--- a/pkg/grpcapi/server_fabric_secret_render_6532_test.go
+++ b/pkg/grpcapi/server_fabric_secret_render_6532_test.go
@@ -1,0 +1,499 @@
+// #6532 invariant: NO fabric-allowlisted RPC may render a configured operator
+// secret verbatim.
+//
+// The cluster-fabric gRPC listener is the only network-exposed gRPC surface
+// (#4122). Its allowlist admits a small set of read/monitor RPCs, which means
+// every one of them is reachable from the peer chassis over the fabric IP —
+// not merely from loopback. ShowText{Topic:"snmp"} was rendering the SNMPv1/v2c
+// community (the v1/v2c authenticator) in cleartext there long after the REST
+// (#5315) and CLI (#4111) siblings were hardened, precisely because nothing
+// asserted the property across the surface as a whole.
+//
+// This file asserts it as a property, not per-RPC:
+//
+//   - TestNoFabricAllowlistedRPCRendersAConfiguredSecret stages one config
+//     carrying every secret leaf in the redaction SSOT (pkg/config
+//     secretIndices / ast_redact.go), drives every allowlisted RPC, and scans
+//     the rendered responses for the cleartext sentinels. The method set is
+//     ENUMERATED from the live allowlist maps and the interceptor source — not
+//     hardcoded — so a newly-allowlisted RPC fails the completeness gate until
+//     it is explicitly audited.
+//
+//   - TestShowTextTopicAuditCoverageIsComplete extracts the ShowText topic set
+//     from the dispatcher source so a newly-added topic must be added to the
+//     audit sweep, rather than silently escaping it.
+//
+//   - TestGRPCAPINeverRevealsSecretCleartext pins the structural reason the
+//     sweep finds only one class of leak: every operator secret except the SNMP
+//     community is a config.Secret, whose String() masks it under %s/%v, and
+//     pkg/grpcapi never calls the Reveal() cleartext accessor that would opt
+//     out of that. This covers the render paths the sweep cannot drive
+//     in-process (a nil dataplane / IPsec manager / FRR short-circuits some
+//     renderers before they format anything).
+package grpcapi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// fabricSecretConfig stages one instance of every secret leaf the redaction
+// SSOT recognises (pkg/config/ast_redact.go secretIndices), each with a
+// distinctive cleartext sentinel. It mirrors pkg/config's redactionSecretSet.
+//
+// The VRRP `authentication-key` leaf from that set is deliberately absent: the
+// commit gate REJECTS it outright (#4288 — RFC 5798 VRRPv3 removed
+// authentication), so it cannot exist in an active config and staging it makes
+// Commit() fail rather than exercising a render.
+var fabricSecretConfig = []string{
+	"set security ike policy pol1 pre-shared-key ascii-text FAB6532-IKE-PSK",
+	"set security ipsec vpn site-a pre-shared-key FAB6532-IPSEC-VPN-PSK",
+	"set protocols ospf area 0.0.0.0 interface ge-0-0-1 authentication md5 1 key FAB6532-OSPF-MD5KEY",
+	"set protocols ospf area 0.0.0.0 interface ge-0-0-9 authentication simple-password FAB6532-OSPF-SIMPLE",
+	"set protocols rip authentication-key FAB6532-RIP-AUTHKEY",
+	"set protocols isis authentication-key FAB6532-ISIS-AREA-AUTHKEY",
+	"set protocols isis interface ge-0-0-2 authentication-key FAB6532-ISIS-IFACE-AUTHKEY",
+	"set protocols bgp group external authentication-key FAB6532-BGP-AUTHPW",
+	"set system services web-management api-auth user admin password FAB6532-API-USER-PW",
+	"set system services web-management api-auth api-key FAB6532-API-KEY-TOKEN",
+	"set snmp v3 usm local-engine user admin authentication-sha256 authentication-password FAB6532-SNMPV3-AUTHPW",
+	"set snmp v3 usm local-engine user admin privacy-des privacy-password FAB6532-SNMPV3-PRIVPW",
+	"set snmp community FAB6532-SNMP-COMMUNITY authorization read-only",
+	"set system services dhcp-local-server dynamic-dns tsig-secret FAB6532-TSIG-SECRET",
+	"set system services dynamic-dns provider cf backend cloudflare",
+	"set system services dynamic-dns provider cf api-token FAB6532-DDNS-APITOKEN",
+	"set system services dynamic-dns provider r53 backend route53",
+	"set system services dynamic-dns provider r53 aws-secret-key FAB6532-DDNS-AWSSECRET",
+	"set system services dynamic-dns provider dy backend dyndns2",
+	"set system services dynamic-dns provider dy password FAB6532-DDNS-HTTP-PW",
+	"set interfaces wg0 tunnel wireguard private-key FAB6532-WG-PRIVKEY",
+	"set interfaces wg0 tunnel wireguard peer p1 preshared-key FAB6532-WG-PSK",
+	`set system root-authentication encrypted-password "$6$FABr$rootHASH6532rootHASH"`,
+	`set system login user op authentication encrypted-password "$6$FABl$loginHASH6532loginHASH"`,
+}
+
+// fabricSecretSentinels is the cleartext token of each staged secret. Any of
+// these appearing in a fabric-reachable render is a credential disclosure.
+var fabricSecretSentinels = []string{
+	"FAB6532-IKE-PSK", "FAB6532-IPSEC-VPN-PSK", "FAB6532-OSPF-MD5KEY",
+	"FAB6532-OSPF-SIMPLE", "FAB6532-RIP-AUTHKEY", "FAB6532-ISIS-AREA-AUTHKEY",
+	"FAB6532-ISIS-IFACE-AUTHKEY", "FAB6532-BGP-AUTHPW", "FAB6532-API-USER-PW",
+	"FAB6532-API-KEY-TOKEN", "FAB6532-SNMPV3-AUTHPW", "FAB6532-SNMPV3-PRIVPW",
+	"FAB6532-SNMP-COMMUNITY", "FAB6532-TSIG-SECRET", "FAB6532-DDNS-APITOKEN",
+	"FAB6532-DDNS-AWSSECRET", "FAB6532-DDNS-HTTP-PW", "FAB6532-WG-PRIVKEY",
+	"FAB6532-WG-PSK", "rootHASH6532rootHASH", "loginHASH6532loginHASH",
+}
+
+// showTextAuditTopics is the ShowText topic sweep. Every topic the dispatcher
+// accepts must appear here — TestShowTextTopicAuditCoverageIsComplete derives
+// the accepted set from the dispatcher source and fails on any omission.
+// Parameterized (prefix:) topics carry a representative argument.
+var showTextAuditTopics = []string{
+	"address-book", "alarms", "alg", "application-identification-status",
+	"applications", "backup-router", "bfd-peers", "buffers", "buffers-detail",
+	"chassis", "chassis-cluster", "chassis-cluster-control-plane-statistics",
+	"chassis-cluster-data-plane-fairness", "chassis-cluster-data-plane-flows",
+	"chassis-cluster-data-plane-interfaces", "chassis-cluster-data-plane-statistics",
+	"chassis-cluster-fabric-statistics", "chassis-cluster-information",
+	"chassis-cluster-interfaces", "chassis-cluster-ip-monitoring-status",
+	"chassis-cluster-statistics", "chassis-cluster-status", "chassis-device-map",
+	"chassis-device-map-candidates", "chassis-environment", "chassis-forwarding",
+	"chassis-hardware", "commit-history", "core-dumps", "dhcp-relay",
+	"dhcp-server", "dhcp-server-detail", "dhcp-server-dynamic-dns",
+	"dhcp-server-dynamic-dns-detail", "dynamic-address", "event-options",
+	"firewall", "flow-monitoring", "flow-monitoring-statistics",
+	"flow-statistics", "flow-timeouts", "flow-traceoptions", "forwarding-options",
+	"forwarding-options-port-mirroring", "ike", "interfaces-detail",
+	"interfaces-extensive", "interfaces-statistics", "internet-options",
+	"ipsec-statistics", "ipv6-router-advertisement", "lldp", "lldp-neighbors",
+	"log", "login", "nat64", "nat-dest-rule-detail", "nat-nptv6",
+	"nat-source-rule-detail", "nat-static", "ntp", "persistent-nat",
+	"persistent-nat-detail", "policies-detail", "policies-hit-count",
+	"policy-options", "root-authentication", "route-all", "route-detail",
+	"route-instance", "route-map", "route-summary", "route-terse",
+	"routing-instances", "routing-instances-detail", "routing-options", "rpm",
+	"schedulers", "screen", "security-alarms", "security-alarms-detail",
+	"security-log", "services-dynamic-dns", "services-dynamic-dns-detail",
+	"services-ip-monitoring-status", "sessions-top:bytes", "sessions-top:packets",
+	"snmp", "snmp-v3", "storage", "system-services", "system-syslog", "task",
+	"tunnels", "version", "vlans", "wireguard", "wireguard-detail",
+	"wireguard-public-key", "zones-detail",
+
+	// Topics matched by equality outside the main switch.
+	"class-of-service", "cos-classifier", "cos-forwarding-class",
+	"cos-scheduler-map", "firewall-effective", "interfaces-queue",
+	"monitor-security-flow", "screen-statistics-all",
+
+	// Parameterized topics, with a representative argument each.
+	"class-of-service:ge-0-0-1", "cos-classifier:c1", "cos-scheduler-map:m1",
+	"firewall-effective:inet", "firewall-effective-filter:f1",
+	"firewall-filter:f1", "interfaces-queue:ge-0-0-1", "log:messages",
+	"route-prefix:10.0.0.0/24", "route-protocol:bgp", "route-table:inet.0",
+	"screen-ids-option:z", "screen-ids-option-detail:z", "screen-statistics:z",
+	"test-policy:from=a,to=b", "test-routing:dest=10.0.0.0/24",
+	"test-zone:interface=ge-0-0-1",
+}
+
+// fabricRPCProbe is how one fabric-reachable RPC gets audited. Exactly one of
+// the two fields is set.
+type fabricRPCProbe struct {
+	// render drives the RPC and returns every string it emits (response bodies
+	// AND error strings — an error message can leak a config value too).
+	render func(t *testing.T, s *Server) []string
+
+	// structuralOnly documents why an RPC cannot be driven in-process and what
+	// covers it instead. Set only when render is nil.
+	structuralOnly string
+}
+
+// fabricRPCProbes registers one probe per fabric-reachable RPC. The
+// completeness gate in TestNoFabricAllowlistedRPCRendersAConfiguredSecret
+// requires an entry for every method the fabric interceptors admit, so
+// allowlisting a new RPC fails this file until someone audits it.
+func fabricRPCProbes() map[string]fabricRPCProbe {
+	return map[string]fabricRPCProbe{
+		pb.BpfrxService_ShowText_FullMethodName: {
+			render: func(t *testing.T, s *Server) []string {
+				out := make([]string, 0, len(showTextAuditTopics))
+				for _, topic := range showTextAuditTopics {
+					resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic})
+					if err != nil {
+						out = append(out, fmt.Sprintf("topic=%s err=%v", topic, err))
+						continue
+					}
+					out = append(out, fmt.Sprintf("topic=%s\n%s", topic, resp.Output))
+				}
+				return out
+			},
+		},
+		pb.BpfrxService_GetStatus_FullMethodName: {
+			render: func(t *testing.T, s *Server) []string {
+				resp, err := s.GetStatus(context.Background(), &pb.GetStatusRequest{})
+				return []string{fmt.Sprintf("%v|%v", resp, err)}
+			},
+		},
+		pb.BpfrxService_GetSessions_FullMethodName: {
+			render: func(t *testing.T, s *Server) []string {
+				resp, err := s.GetSessions(context.Background(), &pb.GetSessionsRequest{})
+				return []string{fmt.Sprintf("%v|%v", resp, err)}
+			},
+		},
+		pb.BpfrxService_GetSessionSummary_FullMethodName: {
+			render: func(t *testing.T, s *Server) []string {
+				resp, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{})
+				return []string{fmt.Sprintf("%v|%v", resp, err)}
+			},
+		},
+		pb.BpfrxService_GetZonePairSummary_FullMethodName: {
+			render: func(t *testing.T, s *Server) []string {
+				resp, err := s.GetZonePairSummary(context.Background(), &pb.GetZonePairSummaryRequest{})
+				return []string{fmt.Sprintf("%v|%v", resp, err)}
+			},
+		},
+		pb.BpfrxService_ClearSessions_FullMethodName: {
+			render: func(t *testing.T, s *Server) []string {
+				resp, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{})
+				return []string{fmt.Sprintf("%v|%v", resp, err)}
+			},
+		},
+		pb.BpfrxService_SystemAction_FullMethodName: {
+			// Not in fabricAllowedUnaryMethods — admitted by the separate
+			// isFabricSafeSystemAction branch for the two cross-node
+			// cluster-failover forms only. Audited because it IS fabric
+			// reachable; the failover response carries RG ownership state, no
+			// config render.
+			render: func(t *testing.T, s *Server) []string {
+				resp, err := s.SystemAction(context.Background(),
+					&pb.SystemActionRequest{Action: "cluster-failover:1:node1"})
+				return []string{fmt.Sprintf("%v|%v", resp, err)}
+			},
+		},
+		pb.BpfrxService_MonitorInterface_FullMethodName: {
+			// Streams live pcap frames captured off a kernel interface; it
+			// renders no configuration, and driving it in-process would exec a
+			// real capture. Its config reads are interface-name resolution
+			// (ResolveReth / LookupInterface), which touch no secret leaf.
+			// Covered structurally by TestGRPCAPINeverRevealsSecretCleartext:
+			// a secret can only escape a config.Secret field via Reveal(), and
+			// this package has no such call.
+			structuralOnly: "streams kernel pcap frames; renders no config. " +
+				"Covered by TestGRPCAPINeverRevealsSecretCleartext.",
+		},
+	}
+}
+
+// newFabricSecretServer commits fabricSecretConfig and returns a Server over
+// it. The dataplane / IPsec / FRR dependencies stay nil, matching the other
+// pkg/grpcapi render tests: the config-render paths under audit read the typed
+// active config, not those subsystems.
+func newFabricSecretServer(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(fabricSecretConfig, "\n")); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	return &Server{store: store}
+}
+
+// fabricAdmittedMethods enumerates every method the fabric interceptors can
+// admit: the two allowlist maps plus any method the interceptor source
+// special-cases by name (today: SystemAction, via isFabricSafeSystemAction).
+// Reading the interceptor source closes the hole a map-only enumeration would
+// leave — a second special-cased admission would otherwise escape the audit.
+func fabricAdmittedMethods(t *testing.T) map[string]bool {
+	t.Helper()
+	admitted := map[string]bool{}
+	for m := range fabricAllowedUnaryMethods {
+		admitted[m] = true
+	}
+	for m := range fabricAllowedStreamMethods {
+		admitted[m] = true
+	}
+	for _, m := range methodsNamedInInterceptors(t) {
+		admitted[m] = true
+	}
+	return admitted
+}
+
+// interceptorSrc is the file holding the fabric allowlist interceptors.
+const interceptorSrc = "server.go"
+
+// methodsNamedInInterceptors returns the full method names referenced inside
+// the two fabric allowlist interceptor bodies.
+func methodsNamedInInterceptors(t *testing.T) []string {
+	t.Helper()
+	src, err := os.ReadFile(interceptorSrc)
+	if err != nil {
+		t.Fatalf("read %s (the fabric interceptors moved? update interceptorSrc): %v",
+			interceptorSrc, err)
+	}
+	var out []string
+	for _, fn := range []string{
+		"func (s *Server) fabricAllowlistUnaryInterceptor(",
+		"func (s *Server) fabricAllowlistStreamInterceptor(",
+	} {
+		body := funcBody(t, string(src), fn)
+		for _, m := range regexp.MustCompile(`pb\.BpfrxService_(\w+)_FullMethodName`).FindAllStringSubmatch(body, -1) {
+			out = append(out, "/xpf.v1.BpfrxService/"+m[1])
+		}
+	}
+	return out
+}
+
+// funcBody returns the source text of the function whose declaration starts
+// with decl, up to the closing brace in column 0.
+func funcBody(t *testing.T, src, decl string) string {
+	t.Helper()
+	i := strings.Index(src, decl)
+	if i < 0 {
+		t.Fatalf("%s: cannot find %q — the fabric interceptors were renamed or "+
+			"moved; update this test so the audit keeps enumerating them",
+			interceptorSrc, decl)
+	}
+	rest := src[i:]
+	if end := strings.Index(rest, "\n}\n"); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+// TestFabricSecretStagingIsReal guards the sweep against the worst failure
+// mode of a "no secret appeared" assertion: passing because nothing was ever
+// staged. A `set` line that the compiler silently drops (renamed leaf, changed
+// grammar) would make every downstream scan vacuously green. Assert every
+// sentinel is really in the committed active config, in cleartext, BEFORE
+// trusting an absence downstream.
+func TestFabricSecretStagingIsReal(t *testing.T) {
+	s := newFabricSecretServer(t)
+	active := s.store.ShowActive()
+	for _, sentinel := range fabricSecretSentinels {
+		if !strings.Contains(active, sentinel) {
+			t.Errorf("secret sentinel %q is NOT in the committed active config — the "+
+				"staging `set` line was dropped, so every scan for it downstream is "+
+				"vacuous. Fix fabricSecretConfig.", sentinel)
+		}
+	}
+	if n := len(fabricSecretSentinels); n < 20 {
+		t.Errorf("only %d secret sentinels staged; the redaction SSOT "+
+			"(pkg/config/ast_redact.go secretIndices) covers more — the sweep has "+
+			"lost coverage", n)
+	}
+}
+
+// TestNoFabricAllowlistedRPCRendersAConfiguredSecret is the #6532 invariant:
+// drive every fabric-reachable RPC against a config carrying every secret leaf
+// and assert no cleartext credential reaches the wire. It goes RED against
+// pre-fix code (ShowText{snmp} emits the community).
+//
+// Its inputs are proven real by TestFabricSecretStagingIsReal above.
+func TestNoFabricAllowlistedRPCRendersAConfiguredSecret(t *testing.T) {
+	probes := fabricRPCProbes()
+
+	// Completeness gate: a newly-allowlisted RPC must be audited, not silently
+	// admitted. This is why the method set is enumerated, not hardcoded.
+	for method := range fabricAdmittedMethods(t) {
+		if _, ok := probes[method]; !ok {
+			t.Fatalf("fabric-reachable RPC %s has no secret-render probe. It is "+
+				"admitted on the network-exposed cluster-fabric listener, so it must "+
+				"be audited for configured-secret renders (#6532): add an entry to "+
+				"fabricRPCProbes.", method)
+		}
+	}
+
+	s := newFabricSecretServer(t)
+	for method, probe := range probes {
+		if probe.render == nil {
+			if probe.structuralOnly == "" {
+				t.Errorf("probe %s has neither a render func nor a structuralOnly "+
+					"rationale", method)
+			}
+			continue
+		}
+		t.Run(strings.TrimPrefix(method, "/xpf.v1.BpfrxService/"), func(t *testing.T) {
+			for _, out := range probe.render(t, s) {
+				for _, leak := range fabricSecretSentinels {
+					if strings.Contains(out, leak) {
+						t.Errorf("%s rendered the cleartext secret %q on the "+
+							"network-exposed fabric surface (#6532):\n%s", method, leak, out)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestShowTextTopicAuditCoverageIsComplete derives the topic set the ShowText
+// dispatcher accepts from its source and asserts the audit sweep drives every
+// one. Adding a topic that renders a secret without adding it here would
+// otherwise slip past the sweep above.
+func TestShowTextTopicAuditCoverageIsComplete(t *testing.T) {
+	driven := map[string]bool{}
+	for _, topic := range showTextAuditTopics {
+		driven[topic] = true
+		// A parameterized topic is driven as "prefix:arg"; record the bare
+		// prefix form too so the source-derived "prefix:" matches it.
+		if i := strings.Index(topic, ":"); i >= 0 {
+			driven[topic[:i+1]] = true
+		}
+	}
+
+	for _, topic := range dispatcherTopics(t) {
+		if !driven[topic] {
+			t.Errorf("ShowText topic %q is dispatched but not driven by the #6532 "+
+				"fabric secret-render audit. ShowText is on the cluster-fabric "+
+				"allowlist (#4122), so every topic it renders is reachable from the "+
+				"peer chassis: add %q to showTextAuditTopics.", topic, topic)
+		}
+	}
+}
+
+// dispatcherTopics extracts every topic literal the ShowText dispatcher
+// accepts: the `case` labels of its topic switch (server_show.go holds exactly
+// one switch, `switch req.Topic`) plus the equality and prefix tests spread
+// across the package's non-test sources.
+func dispatcherTopics(t *testing.T) []string {
+	t.Helper()
+
+	src, err := os.ReadFile("server_show.go")
+	if err != nil {
+		t.Fatalf("read server_show.go (the ShowText dispatcher moved? update this "+
+			"test so topic coverage keeps being enforced): %v", err)
+	}
+	if n := strings.Count(string(src), "\tswitch "); n != 1 {
+		t.Fatalf("server_show.go has %d switch statements, expected exactly 1 "+
+			"(`switch req.Topic`). The case-label extraction below is only "+
+			"unambiguous while that holds — update this test.", n)
+	}
+
+	var topics []string
+	caseRe := regexp.MustCompile(`(?m)^\tcase (.+):$`)
+	strRe := regexp.MustCompile(`"([^"]+)"`)
+	for _, m := range caseRe.FindAllStringSubmatch(string(src), -1) {
+		for _, lit := range strRe.FindAllStringSubmatch(m[1], -1) {
+			topics = append(topics, lit[1])
+		}
+	}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+	topicRe := regexp.MustCompile(`req\.Topic == "([^"]+)"|HasPrefix\(req\.Topic, "([^"]+)"\)`)
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, m := range topicRe.FindAllStringSubmatch(string(b), -1) {
+			if m[1] != "" {
+				topics = append(topics, m[1])
+			}
+			if m[2] != "" {
+				topics = append(topics, m[2])
+			}
+		}
+	}
+
+	if len(topics) < 50 {
+		t.Fatalf("extracted only %d ShowText topics from source — the dispatcher "+
+			"shape changed and this audit is no longer enumerating it", len(topics))
+	}
+	return topics
+}
+
+// TestGRPCAPINeverRevealsSecretCleartext pins the structural property the audit
+// above rests on. Every operator secret in the config tree except the SNMP
+// community is a config.Secret, whose String() renders "<redacted>" under
+// %s/%v (#2053) — so a text renderer cannot leak one by accident. The ONE way
+// to defeat that is Reveal(), the explicit cleartext accessor. This package,
+// which serves the network-exposed fabric listener, must never call it.
+//
+// This also covers the renderers the in-process sweep cannot fully drive
+// (wireguard / ipsec-statistics / bfd-peers short-circuit on a nil dataplane,
+// IPsec manager or FRR before formatting anything).
+func TestGRPCAPINeverRevealsSecretCleartext(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+	scanned := 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		scanned++
+		for i, line := range strings.Split(string(b), "\n") {
+			if strings.Contains(line, ".Reveal()") {
+				t.Errorf("%s:%d calls the config.Secret cleartext accessor Reveal() "+
+					"on the gRPC surface. pkg/grpcapi serves the network-exposed "+
+					"cluster-fabric listener (#4122); revealing a secret here risks "+
+					"rendering it to the peer chassis (#6532). If a cleartext secret "+
+					"is genuinely required, keep it off every render path and "+
+					"document it here:\n\t%s", f, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no package sources — the glob is wrong and this guard is vacuous")
+	}
+}

--- a/pkg/grpcapi/server_fabric_secret_render_6532_test.go
+++ b/pkg/grpcapi/server_fabric_secret_render_6532_test.go
@@ -34,7 +34,11 @@ package grpcapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -42,6 +46,7 @@ import (
 	"testing"
 
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc"
 )
 
 // fabricSecretConfig stages one instance of every secret leaf the redaction
@@ -216,17 +221,55 @@ func fabricRPCProbes() map[string]fabricRPCProbe {
 			},
 		},
 		pb.BpfrxService_MonitorInterface_FullMethodName: {
-			// Streams live pcap frames captured off a kernel interface; it
-			// renders no configuration, and driving it in-process would exec a
-			// real capture. Its config reads are interface-name resolution
-			// (ResolveReth / LookupInterface), which touch no secret leaf.
-			// Covered structurally by TestGRPCAPINeverRevealsSecretCleartext:
-			// a secret can only escape a config.Secret field via Reveal(), and
-			// this package has no such call.
-			structuralOnly: "streams kernel pcap frames; renders no config. " +
-				"Covered by TestGRPCAPINeverRevealsSecretCleartext.",
+			// The one streaming RPC on the allowlist. It streams pre-formatted
+			// TEXT frames of per-interface counter snapshots
+			// (monitoriface.RenderTrafficSummary / RenderSingleInterface), and
+			// it DOES read configuration: the interface set comes from the
+			// active config (TrafficSummaryInterfaces, else
+			// cfg.Interfaces.Interfaces) and the display names it prints come
+			// from ResolveReth / LookupInterface. So it is audited like any
+			// other renderer, not excused.
+			//
+			// Driving it is straightforward with a nil dataplane, exactly like
+			// the unary probes above: the snapshot reads fail, the interface
+			// NAMES still render, and monitorFrameSink aborts the stream after
+			// the first frame so the 1s ticker loop returns at once.
+			render: func(t *testing.T, s *Server) []string {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				sink := &monitorFrameSink{ctx: ctx}
+				err := s.MonitorInterface(&pb.MonitorInterfaceRequest{}, sink)
+				if err != nil && !errors.Is(err, errMonitorProbeDone) {
+					t.Fatalf("MonitorInterface: %v", err)
+				}
+				if len(sink.frames) == 0 {
+					t.Fatal("MonitorInterface rendered no frame — the probe is " +
+						"vacuous; it must actually exercise the renderer")
+				}
+				return sink.frames
+			},
 		},
 	}
+}
+
+// errMonitorProbeDone aborts MonitorInterface's stream after one frame.
+var errMonitorProbeDone = errors.New("monitor probe: one frame captured")
+
+// monitorFrameSink is a minimal grpc.ServerStreamingServer that records the
+// frames MonitorInterface emits and then ends the stream. Only Context and
+// Send are exercised; the embedded nil ServerStream satisfies the rest of the
+// interface and would panic loudly if the handler ever reached for more.
+type monitorFrameSink struct {
+	grpc.ServerStream
+	ctx    context.Context
+	frames []string
+}
+
+func (m *monitorFrameSink) Context() context.Context { return m.ctx }
+
+func (m *monitorFrameSink) Send(resp *pb.MonitorInterfaceResponse) error {
+	m.frames = append(m.frames, resp.GetFrame())
+	return errMonitorProbeDone
 }
 
 // newFabricSecretServer commits fabricSecretConfig and returns a Server over
@@ -253,6 +296,15 @@ func newFabricSecretServer(t *testing.T) *Server {
 // special-cases by name (today: SystemAction, via isFabricSafeSystemAction).
 // Reading the interceptor source closes the hole a map-only enumeration would
 // leave — a second special-cased admission would otherwise escape the audit.
+//
+// LIMIT, and why the canary below exists: the source scan is TEXTUAL and reads
+// only the two interceptor function BODIES. It finds SystemAction because
+// `pb.BpfrxService_SystemAction_FullMethodName` is written inline in
+// fabricAllowlistUnaryInterceptor. Hoisting that constant into a helper — the
+// way isFabricSafeSystemAction already holds the predicate — would silently
+// drop the method from the audited set. Keep the method-name constants IN the
+// interceptor bodies; if a refactor must move one, extend
+// methodsNamedInInterceptors to follow it.
 func fabricAdmittedMethods(t *testing.T) map[string]bool {
 	t.Helper()
 	admitted := map[string]bool{}
@@ -264,6 +316,21 @@ func fabricAdmittedMethods(t *testing.T) map[string]bool {
 	}
 	for _, m := range methodsNamedInInterceptors(t) {
 		admitted[m] = true
+	}
+
+	// Canary for the limit above. SystemAction is known to be fabric-admitted
+	// (isFabricSafeSystemAction), and it is reachable ONLY via the source scan
+	// — it is in neither allowlist map. If the scan stops finding it, the scan
+	// itself broke; failing here is what keeps that from being silent. This is
+	// a floor on the enumeration, not a substitute for it: the audited set is
+	// still derived, so a NEW special-cased method is still picked up.
+	if !admitted[pb.BpfrxService_SystemAction_FullMethodName] {
+		t.Fatalf("the interceptor source scan no longer finds SystemAction, which "+
+			"IS fabric-admitted via isFabricSafeSystemAction (%s:%s). The "+
+			"method-name constant was probably hoisted out of the interceptor "+
+			"body — follow it in methodsNamedInInterceptors, or this audit "+
+			"silently stops covering it.", interceptorSrc,
+			"fabricAllowlistUnaryInterceptor")
 	}
 	return admitted
 }
@@ -457,17 +524,37 @@ func dispatcherTopics(t *testing.T) []string {
 	return topics
 }
 
-// TestGRPCAPINeverRevealsSecretCleartext pins the structural property the audit
+// TestGRPCAPINeverUnwrapsSecretCleartext pins the structural property the audit
 // above rests on. Every operator secret in the config tree except the SNMP
 // community is a config.Secret, whose String() renders "<redacted>" under
-// %s/%v (#2053) — so a text renderer cannot leak one by accident. The ONE way
-// to defeat that is Reveal(), the explicit cleartext accessor. This package,
-// which serves the network-exposed fabric listener, must never call it.
+// %s/%v/%q/%x (#2053) — so a text renderer cannot leak one by accident.
 //
-// This also covers the renderers the in-process sweep cannot fully drive
-// (wireguard / ipsec-statistics / bfd-peers short-circuit on a nil dataplane,
-// IPsec manager or FRR before formatting anything).
-func TestGRPCAPINeverRevealsSecretCleartext(t *testing.T) {
+// There are TWO ways to defeat that, and this guard checks both:
+//
+//  1. Reveal(), the explicit cleartext accessor.
+//  2. A plain CONVERSION. config.Secret is `type Secret string`
+//     (pkg/config/secret.go), so `string(x.PSK)`, `[]byte(x.PSK)` or
+//     `"p " + string(x.PSK)` yields the raw value without ever reaching
+//     String(). A scan for Reveal() alone misses this entirely.
+//
+// Both matter most for the renderers the in-process sweep cannot fully drive:
+// wireguard / ipsec-statistics / bfd-peers short-circuit on a nil dataplane,
+// IPsec manager or FRR before formatting anything, so for those paths this
+// guard is the only net. A conversion inside one of them would otherwise be
+// invisible to BOTH tests.
+//
+// Scope, stated honestly rather than overclaimed: the conversion check is
+// syntactic. It resolves the converted expression to its final identifier and
+// matches that against the Secret-typed FIELD names declared at file scope in
+// pkg/config, so it catches the direct field conversions above. It does NOT
+// catch a conversion applied to a local variable that was assigned from a
+// secret field first (`s := gw.PSK; _ = string(s)`) — that needs full type
+// resolution. Closing the direct-field path closes the realistic renderer
+// mistake; the aliased path remains a known residual.
+func TestGRPCAPINeverUnwrapsSecretCleartext(t *testing.T) {
+	secretFields := secretTypedFieldNames(t)
+	fset := token.NewFileSet()
+
 	files, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatalf("glob package sources: %v", err)
@@ -477,23 +564,152 @@ func TestGRPCAPINeverRevealsSecretCleartext(t *testing.T) {
 		if strings.HasSuffix(f, "_test.go") {
 			continue
 		}
-		b, err := os.ReadFile(f)
+		file, err := parser.ParseFile(fset, f, nil, 0)
 		if err != nil {
-			t.Fatalf("read %s: %v", f, err)
+			t.Fatalf("parse %s: %v", f, err)
 		}
 		scanned++
-		for i, line := range strings.Split(string(b), "\n") {
-			if strings.Contains(line, ".Reveal()") {
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) != 1 {
+				return true
+			}
+			pos := fset.Position(call.Pos())
+
+			// (1) x.Reveal()
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Reveal" {
 				t.Errorf("%s:%d calls the config.Secret cleartext accessor Reveal() "+
 					"on the gRPC surface. pkg/grpcapi serves the network-exposed "+
 					"cluster-fabric listener (#4122); revealing a secret here risks "+
-					"rendering it to the peer chassis (#6532). If a cleartext secret "+
-					"is genuinely required, keep it off every render path and "+
-					"document it here:\n\t%s", f, i+1, strings.TrimSpace(line))
+					"rendering it to the peer chassis (#6532). Keep it off every "+
+					"render path and document why here.", f, pos.Line)
+				return true
 			}
-		}
+
+			// (2) string(<secret field>) / []byte(<secret field>)
+			if !isStringOrByteSliceConversion(call.Fun) {
+				return true
+			}
+			name := trailingIdent(call.Args[0])
+			if name != "" && secretFields[name] {
+				t.Errorf("%s:%d converts the config.Secret field %q with %s(...), "+
+					"which yields the CLEARTEXT secret: config.Secret is a named "+
+					"string type, so a conversion bypasses the String() redaction "+
+					"that protects every %%s/%%v render (#2053). pkg/grpcapi serves "+
+					"the network-exposed cluster-fabric listener (#4122) — this can "+
+					"put an operator credential on the wire to the peer chassis "+
+					"(#6532). Format the Secret directly, or justify the conversion "+
+					"here.", f, pos.Line, name, conversionName(call.Fun))
+			}
+			return true
+		})
 	}
 	if scanned == 0 {
 		t.Fatal("scanned no package sources — the glob is wrong and this guard is vacuous")
 	}
+	// Floor against a silently-broken extraction (a parse change, a moved
+	// package). It is well below the true count because field NAMES dedupe —
+	// AuthKey alone is declared four times — so the set is 12 today, not the
+	// ~24 declaration sites: APIToken AWSSecretAccessKey AuthKey AuthPassword
+	// ControlLinkAuthKey EncryptedPassword PSK Password PresharedKeyHex
+	// PrivPassword TSIGSecret WgLocalPrivkeyHex.
+	if len(secretFields) < 10 {
+		t.Fatalf("resolved only %d config.Secret field names; the extraction broke "+
+			"and the conversion half of this guard is near-vacuous", len(secretFields))
+	}
+}
+
+// isStringOrByteSliceConversion reports whether fun is the `string` or
+// `[]byte` conversion target.
+func isStringOrByteSliceConversion(fun ast.Expr) bool {
+	if id, ok := fun.(*ast.Ident); ok {
+		return id.Name == "string"
+	}
+	if arr, ok := fun.(*ast.ArrayType); ok && arr.Len == nil {
+		el, ok := arr.Elt.(*ast.Ident)
+		return ok && el.Name == "byte"
+	}
+	return false
+}
+
+func conversionName(fun ast.Expr) string {
+	if isStringOrByteSliceConversion(fun) {
+		if id, ok := fun.(*ast.Ident); ok {
+			return id.Name
+		}
+		return "[]byte"
+	}
+	return "?"
+}
+
+// trailingIdent returns the final identifier of a selector/index chain —
+// "PSK" for `cfg.Security.IKE.Policies[n].PSK` — or "" if the expression has
+// no such tail.
+func trailingIdent(e ast.Expr) string {
+	for {
+		switch x := e.(type) {
+		case *ast.SelectorExpr:
+			return x.Sel.Name
+		case *ast.Ident:
+			return x.Name
+		case *ast.IndexExpr:
+			e = x.X
+		case *ast.StarExpr:
+			e = x.X
+		case *ast.ParenExpr:
+			e = x.X
+		default:
+			return ""
+		}
+	}
+}
+
+// secretTypedFieldNames returns the names of every struct field declared as
+// config.Secret at FILE SCOPE in pkg/config. File scope matters: the
+// SNMPCommunity MarshalJSON/MarshalYAML bodies declare local alias structs
+// with a `Name Secret` field, and folding that generic name into the set would
+// flag `string(x.Name)` all over the package.
+func secretTypedFieldNames(t *testing.T) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	files, err := filepath.Glob(filepath.Join("..", "config", "*.go"))
+	if err != nil {
+		t.Fatalf("glob pkg/config: %v", err)
+	}
+	fset := token.NewFileSet()
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, f, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				for _, field := range st.Fields.List {
+					if id, ok := field.Type.(*ast.Ident); !ok || id.Name != "Secret" {
+						continue
+					}
+					for _, n := range field.Names {
+						out[n.Name] = true
+					}
+				}
+			}
+		}
+	}
+	return out
 }

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -55,26 +55,27 @@ func (s *Server) showSNMP(cfg *config.Config, buf *strings.Builder) {
 		// Iteration runs over the real (sorted) keys so the render stays
 		// deterministic once every displayed key is the same placeholder
 		// (mirrors #4712 on the REST sibling).
-		names := make([]string, 0, len(snmpCfg.Communities))
-		for name := range snmpCfg.Communities {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		for _, name := range names {
+		for _, name := range sortedMapKeys(snmpCfg.Communities) {
 			comm := snmpCfg.Communities[name]
 			fmt.Fprintf(buf, "  %s: %s\n",
 				config.SNMPCommunityDisplayName(name, true), comm.Authorization)
 		}
 	}
+	// #6532: the remaining map iterations sort too, completing the #4712
+	// determinism parity with the REST sibling (pkg/api/show_text.go, which
+	// sorts communities AND trap groups). Go randomizes map iteration, so
+	// these lines reordered between two identical requests.
 	if len(snmpCfg.TrapGroups) > 0 {
 		buf.WriteString("Trap groups:\n")
-		for name, tg := range snmpCfg.TrapGroups {
+		for _, name := range sortedMapKeys(snmpCfg.TrapGroups) {
+			tg := snmpCfg.TrapGroups[name]
 			fmt.Fprintf(buf, "  %s: %s\n", name, strings.Join(tg.Targets, ", "))
 		}
 	}
 	if len(snmpCfg.V3Users) > 0 {
 		buf.WriteString("SNMPv3 USM users:\n")
-		for name, u := range snmpCfg.V3Users {
+		for _, name := range sortedMapKeys(snmpCfg.V3Users) {
+			u := snmpCfg.V3Users[name]
 			auth := u.AuthProtocol
 			if auth == "" {
 				auth = "none"
@@ -86,6 +87,18 @@ func (s *Server) showSNMP(cfg *config.Config, buf *strings.Builder) {
 			fmt.Fprintf(buf, "  %s: auth=%s priv=%s\n", name, auth, priv)
 		}
 	}
+}
+
+// sortedMapKeys returns a string-keyed map's keys in ascending order, so a
+// config map renders deterministically across requests (Go randomizes map
+// iteration order — #4712).
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // showSNMPv3 renders the SNMPv3 USM user table.

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -38,8 +38,32 @@ func (s *Server) showSNMP(cfg *config.Config, buf *strings.Builder) {
 	}
 	if len(snmpCfg.Communities) > 0 {
 		buf.WriteString("Communities:\n")
-		for name, comm := range snmpCfg.Communities {
-			fmt.Fprintf(buf, "  %s: %s\n", name, comm.Authorization)
+		// #6532: the SNMPv1/v2c community string IS the authenticator, and it
+		// is the Communities map KEY — a plain string that the Secret newtype's
+		// String() redaction does not cover (config.SNMPCommunity). Printing
+		// the raw key leaked the cleartext credential on an RPC that is NOT
+		// loopback-bound: ShowText is on the cluster-fabric allowlist (#4122),
+		// so this render is reachable from the peer chassis over the fabric.
+		// Both sibling surfaces were already hardened — pkg/cli `show snmp`
+		// (#4111) and the pkg/api show-text handler (#5315); this one was left
+		// in the clear.
+		//
+		// The mask is unconditional, matching pkg/api and the sibling gRPC
+		// ShowConfig raw-AST redaction (#4051): gRPC carries no login class to
+		// gate on, so unlike pkg/cli there is no privileged caller to exempt.
+		// The authorization mode stays visible; only the secret is masked.
+		// Iteration runs over the real (sorted) keys so the render stays
+		// deterministic once every displayed key is the same placeholder
+		// (mirrors #4712 on the REST sibling).
+		names := make([]string, 0, len(snmpCfg.Communities))
+		for name := range snmpCfg.Communities {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			comm := snmpCfg.Communities[name]
+			fmt.Fprintf(buf, "  %s: %s\n",
+				config.SNMPCommunityDisplayName(name, true), comm.Authorization)
 		}
 	}
 	if len(snmpCfg.TrapGroups) > 0 {

--- a/pkg/grpcapi/server_show_snmp_community_redaction_6532_test.go
+++ b/pkg/grpcapi/server_show_snmp_community_redaction_6532_test.go
@@ -1,0 +1,149 @@
+// RED-on-revert tests for #6532: the gRPC ShowText{Topic:"snmp"} render must
+// mask the secret SNMPv1/v2c community NAME, which IS the authenticator for
+// v1/v2c and is also the Communities map KEY — the one operator secret the
+// config.Secret newtype's String() redaction does not cover.
+//
+// Both sibling surfaces were hardened first and this one was left in the clear:
+// pkg/cli `show snmp` / `show system services` (#4111, per login class) and the
+// pkg/api show-text handler (#5315, unconditional). The gRPC mask is
+// unconditional, matching pkg/api and the sibling gRPC ShowConfig raw-AST
+// redaction (#4051): gRPC carries no login class to gate on.
+//
+// The usual "loopback only" mitigation does not apply: ShowText is on the
+// cluster-fabric allowlist (#4122, server_fabric_allowlist_4122_test.go), so
+// this render is reachable from the peer chassis over the fabric IP.
+//
+// These tests assert on the RENDERED ShowText response — the bytes that leave
+// the process — not on an intermediate struct. Reverting the mask in
+// showSNMP() makes the redaction subtest go RED (the cleartext community
+// sentinel reappears in resp.Output). The over-reach subtest asserts the
+// NON-secret SNMP fields still render, so a revert that masks everything is
+// caught too, and it must stay GREEN under revert.
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// snmpCommunitySentinel is the cleartext community credential staged below. A
+// leak is identifiable by this string alone.
+const snmpCommunitySentinel = "GRPC6532-LEAK-SNMP-COMMUNITY"
+
+// snmpRenderConfig stages an SNMP stanza carrying the secret community
+// alongside every NON-secret field the snmp topic renders, so one config
+// exercises both the redaction and the over-reach guard.
+var snmpRenderConfig = []string{
+	"set snmp location GRPC6532-LOCATION-RACK-42",
+	"set snmp contact GRPC6532-CONTACT-NOC",
+	"set snmp description GRPC6532-DESCRIPTION-EDGE-FW",
+	"set snmp community " + snmpCommunitySentinel + " authorization read-only",
+	"set snmp trap-group tg1 targets 10.9.9.9",
+	"set snmp v3 usm local-engine user u1 authentication-sha256 authentication-password GRPC6532-LEAK-V3AUTH",
+	"set snmp v3 usm local-engine user u1 privacy-des privacy-password GRPC6532-LEAK-V3PRIV",
+}
+
+// newSNMPRenderServer commits snmpRenderConfig into a real configstore and
+// returns a Server reading it, so ShowText renders the same typed active
+// config the daemon serves.
+func newSNMPRenderServer(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(snmpRenderConfig, "\n")); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	return &Server{store: store}
+}
+
+// showTextOutput drives the real ShowText RPC and returns the rendered body.
+func showTextOutput(t *testing.T, s *Server, topic string) string {
+	t.Helper()
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic})
+	if err != nil {
+		t.Fatalf("ShowText(topic=%q): %v", topic, err)
+	}
+	return resp.Output
+}
+
+// TestShowTextSNMPRedactsCommunity is the RED-on-revert net: the rendered gRPC
+// output must carry the placeholder and must NOT carry the cleartext community.
+func TestShowTextSNMPRedactsCommunity(t *testing.T) {
+	out := showTextOutput(t, newSNMPRenderServer(t), "snmp")
+
+	if strings.Contains(out, snmpCommunitySentinel) {
+		t.Errorf("ShowText{snmp} LEAKED the cleartext SNMP community %q — it is the "+
+			"SNMPv1/v2c authenticator and this RPC is fabric-reachable (#6532):\n%s",
+			snmpCommunitySentinel, out)
+	}
+	if !strings.Contains(out, config.SecretDataPlaceholder) {
+		t.Errorf("ShowText{snmp} missing the redaction placeholder %q:\n%s",
+			config.SecretDataPlaceholder, out)
+	}
+}
+
+// TestShowTextSNMPKeepsNonSecretFields is the over-reach guard: masking the
+// community must not blank out the rest of the SNMP status render. It stays
+// GREEN under a revert of the redaction (these fields were never masked).
+func TestShowTextSNMPKeepsNonSecretFields(t *testing.T) {
+	out := showTextOutput(t, newSNMPRenderServer(t), "snmp")
+
+	// The community's authorization MODE is not a secret and must survive the
+	// mask — the operator still needs to see read-only vs read-write.
+	for _, want := range []string{
+		"GRPC6532-LOCATION-RACK-42",    // sysLocation
+		"GRPC6532-CONTACT-NOC",         // sysContact
+		"GRPC6532-DESCRIPTION-EDGE-FW", // sysDescr
+		"read-only",                    // community authorization mode
+		"tg1", "10.9.9.9",              // trap group + target
+		"u1", "sha256", "des", // v3 user + auth/priv protocols
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ShowText{snmp} dropped non-secret field %q — the community mask "+
+				"must not blank the rest of the render (#6532):\n%s", want, out)
+		}
+	}
+}
+
+// TestShowTextSNMPv3KeepsProtocolsAndMasksPasswords pins the sibling snmp-v3
+// topic: it renders the USM user table, which must show the auth/priv
+// PROTOCOLS but never the passwords. Those are config.Secret-typed, so the
+// newtype's String() redaction covers them — this test pins that the render
+// keeps relying on it (a future %s of Reveal() would go RED here).
+func TestShowTextSNMPv3KeepsProtocolsAndMasksPasswords(t *testing.T) {
+	out := showTextOutput(t, newSNMPRenderServer(t), "snmp-v3")
+
+	for _, leak := range []string{"GRPC6532-LEAK-V3AUTH", "GRPC6532-LEAK-V3PRIV"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("ShowText{snmp-v3} leaked SNMPv3 USM password %q:\n%s", leak, out)
+		}
+	}
+	for _, want := range []string{"u1", "sha256", "des"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ShowText{snmp-v3} dropped non-secret field %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestSNMPCommunityDisplayNameSemantics pins the shared helper's contract
+// directly: it is the ONE implementation of the masking rule, and it is
+// privilege-parameterised so the CLI can keep its per-login-class behaviour
+// (#4111) while REST/gRPC pass redact=true unconditionally.
+func TestSNMPCommunityDisplayNameSemantics(t *testing.T) {
+	if got := config.SNMPCommunityDisplayName("public", true); got != config.SecretDataPlaceholder {
+		t.Errorf("redact=true must mask: got %q, want %q", got, config.SecretDataPlaceholder)
+	}
+	if got := config.SNMPCommunityDisplayName("public", false); got != "public" {
+		t.Errorf("redact=false must pass the name through (super-user CLI parity): got %q", got)
+	}
+}

--- a/pkg/grpcapi/server_show_snmp_community_redaction_6532_test.go
+++ b/pkg/grpcapi/server_show_snmp_community_redaction_6532_test.go
@@ -135,6 +135,56 @@ func TestShowTextSNMPv3KeepsProtocolsAndMasksPasswords(t *testing.T) {
 	}
 }
 
+// TestShowTextSNMPRenderIsDeterministic pins the #4712 determinism parity the
+// mask makes load-bearing. Once every displayed community key is the SAME
+// placeholder, an unsorted map iteration prints N indistinguishable lines
+// whose authorization modes shuffle between two identical requests — the
+// operator cannot tell which mode belongs to which community, and a diff of
+// two captures is noise. Sorting over the real keys fixes the pairing.
+// Trap groups and USM users sort for the same reason (REST sorts trap groups
+// too, pkg/api/show_text.go).
+func TestShowTextSNMPRenderIsDeterministic(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure(): %v", err)
+	}
+	// Distinct authorization modes per community so a mispairing is visible,
+	// and several trap groups / USM users so their order is exercised too.
+	multi := []string{
+		"set snmp community ZZZ-COMMUNITY-C authorization read-write",
+		"set snmp community AAA-COMMUNITY-A authorization read-only",
+		"set snmp community MMM-COMMUNITY-B authorization read-only",
+		"set snmp trap-group tg-z targets 10.0.0.3",
+		"set snmp trap-group tg-a targets 10.0.0.1",
+		"set snmp v3 usm local-engine user zeta authentication-sha256 authentication-password pw1",
+		"set snmp v3 usm local-engine user alpha authentication-md5 authentication-password pw2",
+	}
+	if _, err := store.LoadSet(strings.Join(multi, "\n")); err != nil {
+		t.Fatalf("LoadSet(): %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+	s := &Server{store: store}
+
+	first := showTextOutput(t, s, "snmp")
+	// Go randomizes map iteration per range, so repeated renders of an
+	// unsorted map diverge within a handful of attempts.
+	for i := 0; i < 32; i++ {
+		if got := showTextOutput(t, s, "snmp"); got != first {
+			t.Fatalf("ShowText{snmp} render is NOT deterministic (attempt %d) — an "+
+				"unsorted map iteration reorders lines between identical requests "+
+				"(#4712/#6532).\n--- first ---\n%s\n--- attempt %d ---\n%s",
+				i, first, i, got)
+		}
+	}
+	// Guard against the render collapsing to nothing, which would make the
+	// equality above vacuously true.
+	if n := strings.Count(first, config.SecretDataPlaceholder); n != 3 {
+		t.Errorf("expected 3 masked community lines, got %d:\n%s", n, first)
+	}
+}
+
 // TestSNMPCommunityDisplayNameSemantics pins the shared helper's contract
 // directly: it is the ONE implementation of the masking rule, and it is
 // privilege-parameterised so the CLI can keep its per-login-class behaviour


### PR DESCRIPTION
Closes #6532

## The bug

gRPC `ShowText{Topic:"snmp"}` rendered the SNMPv1/v2c community string in
cleartext. The community **is** the authenticator for v1/v2c.

The usual "loopback only" mitigation does not apply. `ShowText` is on the
cluster-fabric allowlist (#4122), so this render is reachable from the peer
chassis over the fabric IP.

Both sibling surfaces were already hardened and this one was left behind — REST
`pkg/api/show_text.go` (#5315) and CLI `show snmp` / `show system services`
(#4111).

## Why it could drift

The community is the **one** operator secret not covered by the `config.Secret`
newtype, whose `String()` masks every other secret under `%s`/`%v` (#2053). It
stays a plain string because it is the `Communities` map key, so every manual
renderer must mask it by hand — and there were three independent copies of that
one-line rule.

## The fix

- gRPC masks **unconditionally**, matching `pkg/api` and the sibling gRPC
  `ShowConfig` raw-AST redaction (#4051). `pkg/grpcapi` carries no login class
  to gate on, so unlike `pkg/cli` there is no privileged caller to exempt. The
  authorization mode stays visible.
- All four render sites now share one implementation,
  `config.SNMPCommunityDisplayName(name, redact)`, placed next to the
  `SNMPCommunity` marshal redaction.
- Sorted iteration for communities, trap groups and USM users (gRPC) and for
  both CLI community loops. Determinism matters most *because* of the mask:
  every displayed key becomes the same placeholder, so an unsorted map printed
  N indistinguishable lines whose authorization modes shuffled between two
  identical requests.

## Operator-visible behaviour change — please read

The `super-user` cleartext allowance from #4111 survives on the **in-process
console CLI only**.

The remote `cli` binary — the primary operator interface — dispatches
`show snmp` straight to this RPC (`cmd/cli/show.go`, `c.showText("snmp")`), and
`cmd/cli` has **no login-class awareness at all**, so there is no class to
exempt: it renders `##SECRET-DATA##` for every caller including `super-user`.

This is deliberate. Threading a login class into `pkg/grpcapi` is not possible
today (no class plumbing) and would be actively wrong on the fabric listener,
where the caller is the peer chassis rather than a user. And `cli show
configuration snmp` was **already** masked for every class by #4051 — so the two
remote read-back paths now agree instead of contradicting each other.

Consequence to be aware of: an operator has no remote read-back path for a
configured community. Recover it from the console CLI as `super-user`, or from
the DR archive (`request system configuration rescue`) — a redacted export is
deliberately not restorable (#4060). The community stays fully functional on the
wire; only its display is masked. Documented in `docs/system-login.md`.

## Fabric-allowlist audit

Empirical sweep: one config staging **every** secret leaf the redaction SSOT
(`pkg/config/ast_redact.go` `secretIndices`) recognises — IKE/IPsec PSKs,
OSPF/IS-IS/RIP/BGP auth keys, WireGuard private key + peer PSK, DDNS API
token / AWS secret / HTTP password, DHCP TSIG secret, REST api-key +
basic-auth password, SNMPv3 auth/priv passwords, root/login crypt hashes —
driven through **all ~115 ShowText topics** and every allowlisted RPC,
including `MonitorInterface`.

**The SNMP community was the only leak.** Nothing else needed folding and no
follow-up issue is warranted.

Near-misses, all confirmed clean: `login` renders user/UID/class/SSH-key count
(not the hash); `root-authentication` renders `configured (encrypted)`;
`snmp-v3` renders auth/priv protocol names only; `system-services` renders
endpoints only (it does **not** mirror the CLI's `show system services` SNMP
block).

## Tests

- `server_show_snmp_community_redaction_6532_test.go` — fail-on-revert asserting
  on the **rendered ShowText response**, not an intermediate struct, mirroring
  `cli_show_snmp_community_redaction_4111_test.go`. Over-reach guard pins that
  sysLocation/sysContact/sysDescr, the authorization mode, trap groups and the
  v3 user table still render, and stays GREEN under revert. Plus a determinism
  test over 3 communities with distinct authorization modes.
- `server_fabric_secret_render_6532_test.go` — the invariant that no
  fabric-allowlisted RPC renders a configured secret verbatim, ENUMERATING the
  method set from the live allowlist maps plus the method names the interceptor
  source special-cases (so `SystemAction`, in neither map, is covered). A
  newly-allowlisted RPC fails the completeness gate until audited.
- `TestGRPCAPINeverUnwrapsSecretCleartext` — the structural net for renderers
  the sweep cannot drive (`wireguard` / `ipsec-statistics` / `bfd-peers`
  short-circuit on a nil dataplane before formatting). It reports two things:
  any **selection** named `Reveal`, and any **one-argument call** handed a
  Secret-bearing field.

  The second deliberately **does not inspect the callee**. Matching conversion
  shapes (`string`, `(string)`, `((string))`, `[]byte`, `[](byte)`,
  `([](byte))`) failed across four review rounds, because a conversion's callee
  is a type expression with open grammar — `type Clear string; Clear(x.PSK)`
  unwraps the secret and no builtin-name list ever sees it. Ignoring the callee
  collapses that dimension to no code. One argument is the line because the
  safe idiom `fmt.Fprintf(buf, "%s", x.PSK)` is multi-argument and redacts
  correctly.

  The one gated dimension — the argument's wrapper chain — is closed by
  enumerating go/ast node kinds (paren, star, index, index-list, slice,
  type-assert, address-of) rather than source shapes.

- `TestSecretUnwrapScannerDetectsBothForms` + `TestSecretFieldHarvestShapes` —
  **42 subtests proving the scan and the harvest can FAIL.** Every shape the
  docs claim, plus negative controls (a `%s` render, an unrelated conversion, a
  presence check, a plain-string field) so the checks cannot pass by firing
  unconditionally.

### The hard limit — stated, not patched around

This guard is **syntactic**: it fires where a field is *named*. It cannot
follow a value into a local, a parameter, a helper return, an out-of-package
field, or a multi-argument handoff, and does not see `append`/`copy`/ranging/
reflection.

Closing those needs `go/types` resolution (`x/tools` is only an *indirect*
dependency today), or inverting to an explicit allowlist over all **42**
conversions in this package (measured) — feasible, but it puts test scaffolding
into production source. The clean fix is upstream and out of scope here: making
`config.Secret` a **struct** rather than a named string type would make
`string(s)` fail to **compile** and collapse this entire shape space to the
single `Reveal` accessor. `Secret` is currently comparable and used as a map
key, so that is a `pkg/config`-wide change deserving its own issue.

## Validation

- **RED-on-revert** verified as an **assertion** failure, not a build break.
- Every gate **mutation-tested individually** — drop the mask / drop a probe /
  drop a topic / inject a `Reveal()` / revert the sort. Each RED; all restore
  GREEN.
- **Ten mutations, each in a throwaway detached worktree with build+vet CLEAN
  so every red is an assertion:**

  | # | mutation | subtests that go RED |
  |---|---|---|
  | M1 | drop `ParenExpr` from `secretExprTail` | parenthesized_conversion_argument |
  | M2 | drop `SliceExpr` | sliced_field, sliced_field_with_bounds |
  | M3 | drop `StarExpr` | pointer_deref, address-of_field, deref_of_indexed_collection |
  | M4 | drop `IndexExpr` | indexed_collection_field, + deref |
  | M5 | drop `TypeAssertExpr` | type-asserted_field |
  | M6 | drop `ParenExpr` from `typeMentionsSecret` | parenthesized_type |
  | M7 | drop `ChanType` | channel_of_Secret |
  | M8 | stop following map KEY | map_KEY_anonymous_struct |
  | M9 | drop embedded-field handling | embedded_Secret |
  | M10 | **restore callee-shape gating** | **13 subtests, incl. both named-string-type cases** |

  M10 is the load-bearing one: it shows the previous approach failing on
  exactly the cases no further patch to it could have covered.
- **Anti-vacuity:** `TestFabricSecretStagingIsReal` asserts all 21 secret
  sentinels actually reach the committed active config, so the "no secret
  appeared" scans cannot pass on silently-dropped inputs.
- gofmt clean on touched files; `go build ./...` and `go vet ./...` clean;
  `pkg/grpcapi`, `pkg/api`, `pkg/config`, `pkg/cli`, `pkg/refactoraudit`,
  `pkg/daemon`, `pkg/dataplane/userspace` green. The event-stream socket tests
  need `TMPDIR=/tmp` (sun_path 108) — they fail under any long TMPDIR, on
  master too.
- Docs: `docs/architecture.md` (fabric-listener secret-render invariant),
  `docs/system-login.md` (#4111 allowance scoped to the console CLI + the
  remote-CLI callout). Heatmap regenerated.

No dataplane or HA code touched, so no cluster smoke is implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi


