### PR TITLE
dhcprelay: bind relayed replies to outstanding requests; refuse unauthenticated FORCERENEW

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -62122,3 +62122,67 @@ break — `go vet` confirmed passing under every revert.
   22.7 Gbps) and needs no re-run for a comment-only change.
 - **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
     pkg/routing/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6562 (dhcprelay security) — bind every relayed reply to an
+  outstanding request, and REFUSE DHCPFORCERENEW. Two defects, two gates.
+
+  DEFECT 1: `handleServerResponses` forwarded any well-formed BOOTREPLY that
+  passed the #4163 source-IP allow-list. A source IP is spoofable, so an
+  off-path attacker forging a configured server's address could inject an
+  OFFER/ACK (hostile gateway/DNS) or a NAK (forced client restart). FIX: new
+  `pending.go` — a bounded, expiring table of outstanding transactions. The
+  client loop inserts a key BEFORE the upstream write (the reply loop is a
+  different goroutine; a post-send insert races a fast server's OFFER); the
+  reply loop forwards OFFER/ACK/NAK only on a match. Key is xid + chaddr:
+  RFC 2131 §4.3.1 Table 3 requires a server to copy BOTH from the client's
+  message, and the relay's own mutations (hops/giaddr/Option 82) touch
+  neither. Option 61 deliberately NOT keyed — RFC 2131 told servers they MUST
+  NOT echo it and only RFC 6842 §3 reversed that, so keying on it would drop
+  every reply from a pre-6842 server. Cap 8192, TTL 30s, evict-OLDEST (not
+  drop-new: drop-new lets an attacker who fills the table lock out every new
+  client; eviction can only cause a drop, never an accept, so it trades away
+  no security). A match does NOT consume the entry — the relay fans out to
+  every server in the group, so one DISCOVER draws N OFFERs, and RFC 2131
+  §4.4.1 has the SELECTING REQUEST reuse the OFFER's xid. Table lives on
+  interfaceRelay so a #2347/#3960 session rebuild does not strand a client.
+
+  DEFECT 2: FORCERENEW was forwarded unauthenticated (#2645 reasoned RFC 3118
+  auth is end-to-end and out of scope for a relay). REVERSED. RFC 3203 §6 —
+  NOT §5, which is IANA Considerations; the issue and a stale code comment
+  both mis-cited it — makes authentication a MUST precisely because
+  "FORCERENEW can be used to snoop and spoof traffic". A relay cannot
+  discharge that MUST: RFC 3118 §5.2 puts the secret between source and
+  destination, §3 casts the relay as a transparent mutator excluded from the
+  hash, and §5.3 assigns validation to the receiver. An Option-90 PRESENCE
+  check would be theater — the same spoofing attacker supplies the option.
+  Refusal is a handled condition, not an outage: RFC 3203 §2.2 defines server
+  retransmission on loss, and T1/T2 renewal is untouched. No opt-in knob.
+
+  OBSERVABILITY (the fail direction matters more than usual here — an
+  over-strict binding silently breaks DHCP for real clients): three new
+  counters on RelayStats + `show services dhcp relay` —
+  RepliesDroppedNoRequest, PendingEvicted (early warning that the table is at
+  capacity and legitimate bindings are being lost), RepliesDroppedForceRenew.
+  Both new drop paths log warn-once-then-Debug. A nil table fails CLOSED,
+  matching the #4163 empty-allow-set posture.
+
+  VALIDATION: fail-on-revert proven SEPARATELY for both defects, each an
+  ASSERTION failure with `go vet` clean (no build break). Disabling only the
+  binding gate → NoOutstandingRequestDropped + WrongChaddrDropped RED,
+  ForceRenewRefused GREEN. Restoring the FORCERENEW forward → ForceRenewRefused
+  RED, binding tests GREEN. OVER-REACH GUARD
+  TestRelay_NormalExchange_EndToEndStillRelays drives DISCOVER/OFFER,
+  REQUEST/ACK, RENEW and REBIND through the LIVE manager (bindings created by
+  production code, not a test helper) and stayed GREEN under both reverts.
+  Required a `fakeConn.push()` wake path so a reply can be injected only after
+  the request it answers was relayed. #2645's two tests were updated: the
+  forwarded-assert became ForceRenewRefused (armed for the xid, so the refusal
+  is pinned to the message TYPE, not to a missing binding), and the
+  deliverReply-level FORCERENEW test was removed as unreachable (the matrix
+  test already covers the ciaddr row). Suites: pkg/dhcprelay, pkg/dhcp,
+  pkg/dhcpserver all PASS incl. -race; pkg/cli PASS; go build ./... clean;
+  gofmt/vet clean.
+- **File(s)**: pkg/dhcprelay/{pending.go,relay.go,README.md,
+    relay_binding_6562_test.go,delivery_test.go,relay_test.go},
+    pkg/cli/show_services_dhcp.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62329,3 +62329,52 @@ break — `go vet` confirmed passing under every revert.
   -race PASS; go build ./... , gofmt, vet, GOARCH=386 vet clean.
 - **File(s)**: pkg/dhcprelay/{pending.go,relay.go,README.md,
     relay_binding_6562_test.go}, pkg/cli/show_services_dhcp.go, _Log.md
+
+- **Timestamp**: 2026-07-31 14:55 PDT
+- **Action**: #6603 re-review fold, residual pass. Verified the previous fold
+  commit (e98510a6b) against the Codex verdict finding by finding, reproduced
+  its fail-on-revert claims independently in a throwaway detached worktree, and
+  closed the three gaps it left.
+
+  Independent revert probes (worktree /dev/shm/probe-6603g at e98510a6b, build
+  and vet CLEAN in each so every red is an assertion, worktree removed after):
+    * Neutralizing the phase-2.5 snapshot/adopt migration in Apply reds BOTH
+      TestRelay_RateChangePreservesBindings ("the outstanding binding was
+      destroyed by the rate change") and its _EndToEnd sibling, the latter
+      logging the exact predicted "dropping server reply with no outstanding
+      request" WARN. MAJOR gate confirmed.
+    * Reverting popHeadLocked slot identity from the generation counter back to
+      e.exp.Equal(s.exp) reds TestPendingTable_EqualExpiriesDoNotLoseBinding.
+    * Pointing occupancy() back at len(t.entries) reds
+      TestPendingTable_OccupancyTracksRingNotMap ("occupancy = 2, want 4").
+
+  Gaps closed in this commit:
+    * MINOR 4 was only half-folded. The previous commit made the README's O(1)
+      claim honest but added neither remedy Codex asked for. insert() now takes
+      the pathological case in CONSTANT time: the ring is expiry-ordered, so one
+      probe of the newest slot proves the whole ring is dead, and head/count
+      reset to zero with the map replaced wholesale. Previously that call popped
+      up to 131072 slots, each with a map lookup and delete, under the mutex on
+      the client-facing packet path.
+    * adopt() bounded migration by raw capacity, ignoring the destination's
+      existing count. That breaks pushLocked's documented "caller has already
+      made room" contract for a non-empty destination: count runs past the ring
+      length and the modular index overwrites live slots. Now bounded by
+      REMAINING room; identical on the production path (a fresh table), correct
+      for any caller.
+    * The CLI comment fold replaced the stale "pending-evicted is the early
+      warning" sentence but left the pre-existing paragraph that already said
+      the same thing, so the block stated the leading-indicator point twice with
+      a ragged wrap. Collapsed to one statement.
+
+  New fail-on-revert binders: TestPendingTable_FullDrainIsConstantTime (counts
+  slots examined, not time, so it cannot flake; also asserts the drain is REAL
+  and is not miscounted as a cap-pressure eviction) and
+  TestPendingTable_AdoptRespectsRemainingRoom (occupancy must not exceed
+  capacity; pre-existing destination bindings must not be clobbered).
+
+  Suites: pkg/dhcprelay -race -count=5 PASS; pkg/cli -race PASS; go build ./...,
+  vet, gofmt (dhcprelay + cli), and GOARCH=386 build+vet all clean. The repo-wide
+  gofmt -l hits are pre-existing files in other packages, none touched here.
+- **File(s)**: pkg/dhcprelay/{pending.go,README.md,relay_binding_6562_test.go},
+    pkg/cli/show_services_dhcp.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62378,3 +62378,64 @@ break — `go vet` confirmed passing under every revert.
   gofmt -l hits are pre-existing files in other packages, none touched here.
 - **File(s)**: pkg/dhcprelay/{pending.go,README.md,relay_binding_6562_test.go},
     pkg/cli/show_services_dhcp.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6562 / PR #6603 third review round — three Codex MINORs on the
+  pending ring (bounded reclaim, adopt precondition, occupancy gauge).
+
+  MINOR 1. The constant-time fast path only covers EVERY slot being expired.
+  The adjacent case — capacity-1 expired with the newest still live, i.e. a
+  quiet period then one late request — failed the probe and fell into an
+  unbounded loop popping ~131071 slots one at a time under the mutex on the
+  packet path: the same stall, narrower trigger. The guard added for the fast
+  path FROZE the clock, so every slot shared one expiry and the mixed ring was
+  unconstructible — the case could not be exercised. FIX: head drain capped at
+  maxDrainPerInsert (64). insert needs exactly ONE free slot, so more buys
+  nothing; leftovers are inert (matches re-checks expiry, occupancy excludes
+  them) and clear at ~65 slots/packet. New guard staggers expiries 1ms apart
+  and asserts the ring is MIXED as a precondition.
+
+  MINOR 2. adopt appended without merging, so migrated expiries could land
+  after a destination's later ones and break the expiry ordering every other
+  operation depends on — the full-drain probe would read a newer-but-expired
+  tail slot, conclude the ring was dead and wipe live bindings. Production
+  adopts into an empty table so this was not a live-path defect, but the doc
+  claimed correctness "for any destination", which was false. FIX: require an
+  empty destination and PANIC otherwise (a programmer-error assertion,
+  unreachable from the sole caller); doc claim corrected in pending.go and
+  README. Chose the assertion over an ordered merge: no caller needs the
+  general case and it is not worth the complexity on a security-relevant path.
+
+  MINOR 3. occupancy() returned the raw ring count, which includes the expired
+  prefix, so an idle full table reported capacity/capacity even though the next
+  insert reclaims the lot and evicts nothing — the same false-HIGH the previous
+  round fixed for len(entries), reintroduced. FIX: report unexpired slots; the
+  expired ones are a contiguous prefix (ring is expiry-ordered), so the
+  boundary is a binary search, O(log capacity) under the mutex.
+
+  SELF-CAUGHT, WORTH RECORDING: while fixing MINOR 1 I added evictHeadLocked so
+  the at-cap eviction loop would not count an expired pop as cap pressure, plus
+  a test asserting it. Mutation-testing the change showed the test could NOT
+  fail. Reachability analysis proved why: the loop needs count >= capacity, but
+  the fast path leaves count 0 and any drain leaves count = cap-d < cap, so
+  whenever the loop runs the head is unexpired BY CONSTRUCTION (d == 64 would
+  need cap-64 >= cap). The defensive check was dead logic and the test was
+  vacuous — exactly the guard-cannot-fire pattern flagged this round. REMOVED
+  both; the proof now lives in a comment in insert(), and the test was reframed
+  to pin the reachable operator-facing property (an idle relay reports no
+  evictions) with an explicit scope note that it does not bind an unreachable
+  expiry re-check.
+
+  VALIDATION — mutation proof per finding in a THROWAWAY detached worktree
+  (/dev/shm/probe-6603i, removed after), build+vet CLEAN in each so every red
+  is an ASSERTION: (1) drain bound removed -> PartialDrainIsBounded RED
+  ("examined 4095 slots (capacity 4096); per-insert reclaim must be bounded by
+  ~68"); (2) empty-destination precondition removed -> AdoptRequiresEmpty
+  Destination RED (no panic); (3) occupancy back to raw count ->
+  OccupancyExcludesExpired RED ("occupancy = 64, want 32" and "= 64, want 0"
+  wholly expired) plus PartialDrainIsBounded's mixed-ring precondition. All
+  re-verified after removing evictHeadLocked. Suites: pkg/dhcprelay
+  -race -count=5 PASS; pkg/dhcp, pkg/dhcpserver, pkg/cli -race PASS; build,
+  vet, gofmt clean.
+- **File(s)**: pkg/dhcprelay/{pending.go,README.md,relay_binding_6562_test.go},
+    _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62260,3 +62260,72 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/dhcprelay/{pending.go,relay.go,README.md,
     relay_binding_6562_test.go,delivery_test.go,relay_test.go},
     pkg/cli/show_services_dhcp.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6562 / PR #6603 re-review fold — Codex MAJOR (a config reload
+  destroyed every live binding) + 4 MINORs.
+
+  MAJOR. Every field in relaySpec participates in equal(), so ANY day-2 change
+  to a relay group stops the relay and builds a replacement with a brand-new
+  pending table. The replacement rebinds the SAME giaddr:67, so replies for
+  pre-reload requests still ARRIVE and were then dropped by the binding gate —
+  pre-#6562 they were forwarded, so a straight availability regression. It is
+  sharpest for maximum-packet-rate, whose documented remedy is to raise it on a
+  busy segment: an operator following the docs DURING a boot storm would flush
+  every in-flight binding and cause the retry storm the table exists to
+  prevent. PROVENANCE NOTE: this was NOT introduced by the previous fold — the
+  first commit (1c071c18c:903) also built a fresh table per session; the fold
+  made it reachable via the newly-documented remedy. Fixed for ALL five spec
+  fields, not just rate. FIX: pendingTable.snapshot()/adopt() plus a phase-2.5
+  loop in Apply that runs AFTER the old relay's goroutines are joined (snapshot
+  complete, table quiescent) and BEFORE the replacement launches (nothing races
+  the destination). Adopted entries keep their ORIGINAL expiry — a reload must
+  not refresh the TTL, which would widen the xid-guessing window on every
+  commit. A SMALLER replacement (rate lowered) drops the oldest excess and
+  COUNTS them in PendingEvicted rather than discarding silently.
+
+  MINOR 1. popHeadLocked used expiry equality as slot identity. Two inserts of
+  the same key can share an expiry (time.Now() is not guaranteed to advance
+  between calls; a frozen test clock never does), so popping the OLDER slot
+  matched the map entry the NEWER slot owned and deleted a live binding. My
+  duplicate test had DODGED this by advancing the clock 1ms with a comment
+  claiming a real clock guarantees distinctness — it does not. Replaced with an
+  explicit monotonic generation counter (pendingEntry.gen / pendingSlot.gen);
+  new test uses a FROZEN clock so equal expiries are the case under test.
+
+  MINOR 2. size() returned len(entries) but capacity pressure is governed by
+  ring count. Diverges BOTH ways: expired entries linger in the map on an idle
+  relay (reads high), and duplicate inserts consume slots without adding keys
+  (reads low — a cap-4 ring holding A,B,B,B reports 2/4 yet the next insert
+  evicts live A). Split into occupancy() (ring count, drives PendingSize) and
+  liveEntries() (map count, diagnostic). Fixed the stale "pending-evicted is
+  the early warning" comment still in pkg/cli/show_services_dhcp.go.
+
+  MINOR 3. The strict "O(1) at capacity" claim was false: the reclaim loop can
+  pop up to `capacity` slots on the first insert after a long idle. Documented
+  the real bound (amortized O(1); worst case one full drain, at most once per
+  idle period) in both pending.go and README rather than adding a special-case
+  reset.
+
+  MINOR 4. The overflow test passed the untyped constant 1<<40, which fails to
+  COMPILE under GOARCH=386 ("overflows"). Verified firsthand, changed to 1<<30.
+  Added GOARCH=386 go vet to the gate.
+
+  Also added the reviewer's memory note to the README (48 B/slot -> 6 MiB ring,
+  ~18 MiB/interface at the ceiling, multiplicative across interfaces).
+
+  VALIDATION — four revert probes, each in a THROWAWAY detached worktree at the
+  branch HEAD (removed after; never the PR worktree), each build+vet CLEAN so
+  every red is an ASSERTION: (1) drop the phase-2.5 migration -> BOTH
+  RateChangePreservesBindings ("the outstanding binding was destroyed by the
+  rate change") and its _EndToEnd sibling RED; (2) slot identity back to expiry
+  equality -> EqualExpiriesDoNotLoseBinding RED; (3) occupancy back to
+  len(entries) -> OccupancyTracksRingNotMap RED ("occupancy = 2, want 4") plus
+  the EqualExpiries precondition. The end-to-end reload test needed a tracking
+  conn factory: a restart opens FRESH conns, so the original harness pair
+  belongs to the dead session, and the new pair is opened ASYNCHRONOUSLY from
+  the supervisor goroutine (hence pairAfter(t, n) rather than "latest").
+  Suites: pkg/dhcprelay -race -count=5 PASS; pkg/dhcp, pkg/dhcpserver, pkg/cli
+  -race PASS; go build ./... , gofmt, vet, GOARCH=386 vet clean.
+- **File(s)**: pkg/dhcprelay/{pending.go,relay.go,README.md,
+    relay_binding_6562_test.go}, pkg/cli/show_services_dhcp.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62186,3 +62186,77 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/dhcprelay/{pending.go,relay.go,README.md,
     relay_binding_6562_test.go,delivery_test.go,relay_test.go},
     pkg/cli/show_services_dhcp.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6562 / PR #6603 review fold — F1 MAJOR (pending-table capacity
+  did not track maximum-packet-rate) + F2/F3/F4/F5 MINORs.
+
+  F1 (MAJOR). `pendingCap` was a hardcoded 8192 while the fill rate is the
+  configurable #5670 `maxPacketRate` (schema 1..1000000, default 100). Steady
+  occupancy is rate x TTL, so above ~273 pps the table was CAP-BOUND and the
+  reply-binding window silently collapsed from 30s to 8192/rate seconds — and
+  README.md recommends raising maximum-packet-rate on a busy segment, steering
+  operators straight into it. At 3000 pps the window is 2.7s; a boot storm
+  against a server whose RTT exceeds that has every reply dropped at the relay,
+  turning a completing storm into a permanent retry storm. Compounding it, the
+  at-cap path did TWO full O(cap) map scans per admitted packet (reap sweep +
+  minimum-expiry scan) on the single client-facing read goroutine.
+
+  REMEDIATION: took BOTH reviewer shapes (b)+(a), not (c). (b) alone leaves the
+  window collapse — the actual availability regression — unfixed; (c) only
+  warns about it. (b) O(1) ring: every entry carries the SAME ttl, so insertion
+  order IS expiry order and the oldest is always at the ring head — no scan.
+  Duplicate inserts get a new slot; the old one is stale (map holds a later
+  expiry) and is discarded free at the head. A slot is always freed before a
+  push, so len(entries) <= count <= capacity — the ring bounds the map. (a)
+  capacity = rate*pendingTTL + relayBurstFor(rate), clamped [4096, 131072]. The
+  ceiling is mandatory: 1e6 pps x 30s is ~3e7 entries (GBs), i.e. the
+  memory-exhaustion vector the table exists not to be. Above ~4096 pps the
+  ceiling binds; that is unavoidable (window x rate IS memory) but is now
+  EXPLICIT — pendingCapacityFor reports the clamp and Apply logs a startup Warn
+  naming the effective window.
+
+  F2. Cap comment claimed "well past the default"; the real threshold was 273
+  pps = 2.73x default. Moot now that capacity is derived, but the README's
+  #5670 section gained the actual ~4096 pps ceiling threshold and a
+  cross-reference in both places that recommend raising the rate.
+
+  F3. PendingEvicted is COINCIDENT, not leading — an eviction causes the
+  subsequent drop, lead time one server RTT. Plumbed the already-existing
+  size() through as PendingSize + PendingCapacity (gauges) into RelayStats,
+  Stats() and the CLI as "Pending N/M"; corrected the README claim.
+
+  F4 (text only). The "handled condition" argument rested on RFC 3203 §2.2's
+  retransmission sentence, which describes TRANSIENT loss — here the loss is
+  PERMANENT and §2.2 itself says "The amount of retransmissions should be
+  limited", so the backoff never converges. Replaced in relay.go + README with
+  the dispositive §2.2 sentence, verified verbatim at rfc3203.txt:71: "The DHCP
+  server sends a unicast FORCERENEW message to the client." A conformant
+  unicast to the client's leased IP never lands on the relay's giaddr:67
+  socket, so refusal costs a conformant deployment NOTHING and the only
+  FORCERENEW reaching this arm is non-conformant or hostile. Also recorded that
+  the arm is belt-and-braces (a server-chosen xid matches no outstanding
+  request, so the binding gate would drop it anyway) — it buys a distinct
+  counter and log. Scoped the "must be visible" claim to the console CLI:
+  RelayStats has no gRPC/Prometheus surface (pre-existing, filed separately).
+
+  F5. fakeConn.ReadFrom no longer self-recurses after a wake; plain for loop.
+
+  VALIDATION — three revert probes, each in a THROWAWAY detached worktree at
+  the branch HEAD (never the PR worktree), each build+vet CLEAN so the red is
+  an ASSERTION: (1) capacity back to fixed 8192 -> TracksMaxPacketRate RED
+  ("a reply arriving 3s after its request no longer binds at 3000 pps
+  (capacity 8192, 9000 intervening requests, evictions 809)") + Derivation RED;
+  (2) eviction back to the O(n) minimum-expiry map scan -> AtCapInsertIsConstant
+  Time RED; (3) relay.go un-wired to a constant while pendingCapacityFor stays
+  correct -> PendingCapacityFollowsOverride RED ("capacity = 8192, want 96000").
+  Probe (2) initially PASSED — the reverted code bypasses the ring so slotScans
+  stayed 0 and sailed under the upper bound. Added a LOWER bound (>= 1 scan per
+  at-cap insert) which makes the counter's liveness part of the contract; probe
+  re-run then went RED. Over-reach guard NormalExchange_EndToEndStillRelays and
+  ForceRenewRefused stayed GREEN under all three. Suites: pkg/dhcprelay
+  -race -count=5 PASS; pkg/dhcp, pkg/dhcpserver, pkg/cli -race PASS; build,
+  gofmt, vet clean.
+- **File(s)**: pkg/dhcprelay/{pending.go,relay.go,README.md,
+    relay_binding_6562_test.go,delivery_test.go,relay_test.go},
+    pkg/cli/show_services_dhcp.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62439,3 +62439,18 @@ break — `go vet` confirmed passing under every revert.
   vet, gofmt clean.
 - **File(s)**: pkg/dhcprelay/{pending.go,README.md,relay_binding_6562_test.go},
     _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6562 review-fold round 4 (Codex MERGE-NEEDS-MINOR, one residual —
+  the data-structure correction is CONFIRMED closed: mixed-case reclaim bounded
+  at 64 pops still leaving room for the new binding, and the fixture now
+  staggers expiries by 1ms and reaches one-live/4095-expired, failing with 4095
+  scans when the bound is removed). The residual was a documentation math error
+  in two places: `pending.go` and `README.md` both claimed a backlog clears at
+  ~65 slots per admitted packet, on the reasoning that the drain removes 64 and
+  the eviction loop frees one more. The eviction loop cannot run — after any
+  POSITIVE drain `count < capacity`, which the early return in the eviction path
+  proves. The real figure is a NET 63: 64 drained, one added. Corrected in both
+  places and stated with the reason, since the wrong number was arrived at by a
+  plausible-but-false chain that a reader would otherwise re-derive.
+- **File(s)**: pkg/dhcprelay/pending.go, pkg/dhcprelay/README.md, _Log.md

--- a/pkg/cli/show_services_dhcp.go
+++ b/pkg/cli/show_services_dhcp.go
@@ -179,16 +179,13 @@ func (c *CLI) showDHCPRelay() error {
 			// a reply must also answer a request the relay actually forwarded.
 			// "no-request" counts replies that did not bind — an injection
 			// attempt, OR a legitimate reply that missed the binding window,
-			// which is a client-visible DHCP failure. "Pending" (occupancy /
-			// capacity) is the LEADING indicator — approaching capacity means
-			// bindings are about to be evicted. "pending-evicted" is
-			// COINCIDENT, not leading: it rises only once bindings are already
-			// being lost. "forcerenew" counts
+			// which is a client-visible DHCP failure. "Pending" is
+			// occupancy/capacity — the LEADING indicator: as it approaches
+			// capacity the relay is about to evict bindings and drop legitimate
+			// replies. "pending-evicted" is COINCIDENT, not leading — it only
+			// rises once bindings are already being lost. "forcerenew" counts
 			// DHCPFORCERENEW refused (RFC 3203 §6 requires RFC 3118 auth that a
 			// relay cannot verify).
-			// "Pending" is occupancy/capacity — the LEADING indicator. When it
-			// approaches capacity the relay is about to evict bindings and drop
-			// legitimate replies; "evicted" only rises once that has started.
 			fmt.Println("\nReply request binding (#6562):")
 			fmt.Printf("  %-16s %-14s %-22s %-16s %s\n",
 				"Interface", "Pending", "Dropped (no-request)", "Pending evicted",

--- a/pkg/cli/show_services_dhcp.go
+++ b/pkg/cli/show_services_dhcp.go
@@ -179,9 +179,11 @@ func (c *CLI) showDHCPRelay() error {
 			// a reply must also answer a request the relay actually forwarded.
 			// "no-request" counts replies that did not bind — an injection
 			// attempt, OR a legitimate reply that missed the binding window,
-			// which is a client-visible DHCP failure. "pending-evicted" is the
-			// early warning: the table is at capacity under a request flood, so
-			// legitimate bindings are being lost. "forcerenew" counts
+			// which is a client-visible DHCP failure. "Pending" (occupancy /
+			// capacity) is the LEADING indicator — approaching capacity means
+			// bindings are about to be evicted. "pending-evicted" is
+			// COINCIDENT, not leading: it rises only once bindings are already
+			// being lost. "forcerenew" counts
 			// DHCPFORCERENEW refused (RFC 3203 §6 requires RFC 3118 auth that a
 			// relay cannot verify).
 			// "Pending" is occupancy/capacity — the LEADING indicator. When it

--- a/pkg/cli/show_services_dhcp.go
+++ b/pkg/cli/show_services_dhcp.go
@@ -184,12 +184,18 @@ func (c *CLI) showDHCPRelay() error {
 			// legitimate bindings are being lost. "forcerenew" counts
 			// DHCPFORCERENEW refused (RFC 3203 §6 requires RFC 3118 auth that a
 			// relay cannot verify).
+			// "Pending" is occupancy/capacity — the LEADING indicator. When it
+			// approaches capacity the relay is about to evict bindings and drop
+			// legitimate replies; "evicted" only rises once that has started.
 			fmt.Println("\nReply request binding (#6562):")
-			fmt.Printf("  %-16s %-22s %-18s %s\n",
-				"Interface", "Dropped (no-request)", "Pending evicted", "Refused (forcerenew)")
+			fmt.Printf("  %-16s %-14s %-22s %-16s %s\n",
+				"Interface", "Pending", "Dropped (no-request)", "Pending evicted",
+				"Refused (forcerenew)")
 			for _, s := range stats {
-				fmt.Printf("  %-16s %-22d %-18d %d\n",
-					s.Interface, s.RepliesDroppedNoRequest, s.PendingEvicted,
+				fmt.Printf("  %-16s %-14s %-22d %-16d %d\n",
+					s.Interface,
+					fmt.Sprintf("%d/%d", s.PendingSize, s.PendingCapacity),
+					s.RepliesDroppedNoRequest, s.PendingEvicted,
 					s.RepliesDroppedForceRenew)
 			}
 		}

--- a/pkg/cli/show_services_dhcp.go
+++ b/pkg/cli/show_services_dhcp.go
@@ -175,6 +175,23 @@ func (c *CLI) showDHCPRelay() error {
 			for _, s := range stats {
 				fmt.Printf("  %-16s %d\n", s.Interface, s.RepliesDroppedUnknownServer)
 			}
+			// Outstanding-request binding (#6562). A source IP is spoofable, so
+			// a reply must also answer a request the relay actually forwarded.
+			// "no-request" counts replies that did not bind — an injection
+			// attempt, OR a legitimate reply that missed the binding window,
+			// which is a client-visible DHCP failure. "pending-evicted" is the
+			// early warning: the table is at capacity under a request flood, so
+			// legitimate bindings are being lost. "forcerenew" counts
+			// DHCPFORCERENEW refused (RFC 3203 §6 requires RFC 3118 auth that a
+			// relay cannot verify).
+			fmt.Println("\nReply request binding (#6562):")
+			fmt.Printf("  %-16s %-22s %-18s %s\n",
+				"Interface", "Dropped (no-request)", "Pending evicted", "Refused (forcerenew)")
+			for _, s := range stats {
+				fmt.Printf("  %-16s %-22d %-18d %d\n",
+					s.Interface, s.RepliesDroppedNoRequest, s.PendingEvicted,
+					s.RepliesDroppedForceRenew)
+			}
 		}
 	}
 	return nil

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -382,8 +382,9 @@ cover different cases:
 
 `insert` needs exactly one free slot, so reclaiming more per call buys nothing.
 Leftover expired slots are inert — `matches` re-checks the expiry and
-`PendingSize` excludes them — and later inserts clear the backlog at ~65 slots
-per admitted packet. `TestPendingTable_FullDrainIsConstantTime` and
+`PendingSize` excludes them — and later inserts clear the backlog at a net 63
+slots per admitted packet (64 drained, one added; the eviction loop cannot run
+after a positive drain, because `count < capacity` by then). `TestPendingTable_FullDrainIsConstantTime` and
 `TestPendingTable_PartialDrainIsBounded` pin the two cases by counting slots
 examined; the latter must **stagger** expiries, because a frozen clock makes
 every slot expire together and the mixed case unconstructible.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -358,21 +358,59 @@ the oldest degrades gracefully, and the choice trades away no security, because
 eviction can only cause a legitimate reply to be *dropped*, never an unsolicited
 reply to be *accepted*. Every eviction bumps `PendingEvicted`.
 
-**O(1) at capacity.** Expiry and eviction go through a fixed-size ring of
-insertions, not a scan. This works because every entry carries the *same* TTL,
-so insertion order **is** expiry order and the oldest is always at the ring
+**Amortized O(1) at capacity.** Expiry and eviction go through a fixed-size ring
+of insertions, not a scan. This works because every entry carries the *same*
+TTL, so insertion order **is** expiry order and the oldest is always at the ring
 head. The original implementation ranged the whole map for the minimum expiry —
 two full `O(capacity)` scans per admitted packet once full, on the single
-client-facing read goroutine, which saturates a core in exactly the overload
-the table is meant to survive. A key re-inserted before its old slot expires
-(a retransmission, or the SELECTING REQUEST reusing the DISCOVER's xid) simply
-gets a new slot; the older one is stale (the map holds a later expiry) and is
-discarded for free at the head. Because a slot is always freed before a push,
+client-facing read goroutine, which saturates a core in exactly the overload the
+table is meant to survive.
+
+The bound is **amortized** O(1), not strict: each slot is pushed once and popped
+once, but the *worst case for one call* is a full drain of up to `capacity`
+slots, when the first insert after a long idle period finds everything expired.
+That is bounded, happens at most once per idle period (the next insert finds an
+empty ring), and is not the per-packet repeat the pre-ring code had.
+
+A key re-inserted before its old slot expires (a retransmission, or the
+SELECTING REQUEST reusing the DISCOVER's xid) simply gets a new slot; the older
+one is stale and is discarded for free at the head. Slot identity is an explicit
+**generation counter**, not the expiry: two inserts of the same key can carry
+identical expiries (nothing guarantees `time.Now()` advances between two calls),
+and matching on expiry would pop the older slot and delete a binding the newer
+slot still owns. Because a slot is always freed before a push,
 `len(entries) ≤ count ≤ capacity` — the ring bounds the map, so duplicate
 inserts cannot grow either structure.
-`TestPendingTable_AtCapInsertIsConstantTime` pins this by counting ring slots
-examined (deterministic, no timing), with a **lower** bound as well as an upper
-one so an implementation that bypasses the ring cannot pass by reporting zero.
+`TestPendingTable_AtCapInsertIsConstantTime` pins the cost by counting ring
+slots examined (deterministic, no timing), with a **lower** bound as well as an
+upper one so an implementation that bypasses the ring cannot pass by reporting
+zero.
+
+**Memory.** A `pendingSlot` is 48 bytes on amd64, so the ring is a fixed
+`48 × capacity` (6 MiB at the 131072 ceiling) plus the Go map, ~18 MiB per
+interface at full occupancy on a ceiling-sized table. That is bounded per
+interface but **multiplicative across relay interfaces**: a chassis with many
+high-rate relay segments should size `maximum-packet-rate` per segment rather
+than setting it high everywhere.
+
+**Bindings survive a config reload.** Every field in `relaySpec` — servers,
+always-broadcast, hop count, trust-option-82, packet rate — participates in
+`equal()`, so any day-2 change to a group stops the relay and builds a
+replacement. The replacement rebinds the *same* `giaddr:67`, so replies for
+pre-reload requests still arrive; without migration they would hit the binding
+gate and be dropped, which pre-#6562 would have been forwarded. `Apply` therefore
+snapshots the old table's live bindings and adopts them into the replacement,
+**after** the old relay's goroutines are joined (so the snapshot is complete)
+and **before** the new one launches (so nothing races the destination).
+
+This matters most for `maximum-packet-rate`, whose documented remedy is to raise
+it on a busy segment: without migration, an operator following that advice
+*during* a boot storm would flush every in-flight binding and cause the retry
+storm this table exists to prevent. Adopted entries keep their **original
+expiry** — a reload must not refresh the TTL, which would widen the attacker's
+xid-guessing window every time the config was touched. If the replacement is
+*smaller* (the rate was lowered), the oldest excess bindings are dropped and
+**counted** in `PendingEvicted` rather than discarded silently.
 
 **TTL — 30s.** This bounds the window in which a guessed xid would be accepted,
 while covering realistic server latency. RFC 2131 §4.1's retransmission schedule
@@ -400,6 +438,14 @@ leading — an eviction is what *causes* the subsequent drop, so its lead time i
 one server RTT (tens of ms to a couple of seconds). Alert on the
 size/capacity ratio; treat a rising `PendingEvicted` as damage already in
 progress.
+
+`PendingSize` reports **ring slots in use**, not the map's key count, because
+ring pressure is what triggers eviction. The two diverge in both directions: on
+an idle relay expired entries linger in the map until the next insert reclaims
+them (map count reads *high*), and duplicate inserts consume ring slots without
+adding keys (map count reads *low* — a capacity-4 ring holding `A,B,B,B` has two
+keys but evicts live `A` on the very next insert). Reporting the map count would
+show a comfortable `2/4` at the exact moment eviction began.
 
 These counters are currently surfaced only by the **on-box console CLI**
 (`show services dhcp relay`) — there is no gRPC RPC or Prometheus collector for

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -177,14 +177,30 @@ cannot check the MAC, a presence test admits exactly the attacker it is meant to
 stop. Most deployed clients do not implement RFC 3118 at all, so nothing
 downstream would catch it either.
 
-Refusing is a **handled condition, not an outage**. RFC 3203 §2.2 specifies the
-server's behavior when the message does not arrive: "If the FORCERENEW message
-is lost, the DHCP server will not receive a DHCP REQUEST from the client and it
-should retransmit the FORCERENEW message using an exponential backoff
-algorithm." Ordinary leasing is untouched — clients still renew at T1/T2. Only
-the server's ability to force an *early* renew through this relay is withdrawn,
-and it is withdrawn **loudly**: every refusal bumps `RepliesDroppedForceRenew`
-and the first one per session logs at `Warn`.
+**Refusing costs a conformant deployment nothing**, because a conformant
+FORCERENEW never reaches this socket. RFC 3203 §2.2 opens:
+
+> The DHCP server sends a unicast FORCERENEW message to the client.
+
+A unicast addressed to the client's own leased address routes as ordinary
+traffic and is never delivered to the relay's `giaddr:67` server socket at all.
+The only FORCERENEW that can arrive *here* is one deliberately addressed to
+`giaddr:67` — a non-conformant server, or the attacker §6 is about. Ordinary
+leasing is untouched either way: clients still renew at T1/T2. The refusal is
+**loud** — every one bumps `RepliesDroppedForceRenew` and the first per session
+logs at `Warn`.
+
+> Do **not** justify this by §2.2's retransmission sentence ("it should
+> retransmit the FORCERENEW message using an exponential backoff algorithm").
+> That describes recovery from *transient* loss. Here the loss is **permanent** —
+> every retransmission hits the same refusal — and §2.2 itself bounds the
+> attempts: "The amount of retransmissions should be limited." The backoff never
+> converges, so it cannot carry the argument. The unicast sentence above can.
+
+The refusal is also **belt-and-braces**: FORCERENEW is server-initiated, so its
+xid matches no outstanding request and the binding gate below would drop it
+regardless. The dedicated arm exists to give the refusal its own counter and
+log, so an operator can tell it apart from an ordinary unbound reply.
 
 There is deliberately **no opt-in knob** to re-enable forwarding. If a
 deployment genuinely needs relayed FORCERENEW, that is a follow-up that should
@@ -233,9 +249,11 @@ RFC 768).
   replies dropped because they answered no outstanding relayed request —
   either an injection that passed the source check, **or a legitimate reply
   that missed the binding window**, which is a client-visible DHCP failure, so
-  this one must be *watched*, not assumed hostile. **`PendingEvicted` (#6562)**
-  is the early warning that pairs with it: the outstanding-request table is at
-  capacity, so legitimate bindings are being lost.
+  this one must be *watched*, not assumed hostile. **`PendingSize` /
+  `PendingCapacity` (#6562)** are the outstanding-request table's occupancy and
+  ceiling — the **leading** indicator: occupancy approaching capacity means
+  bindings are about to be evicted. **`PendingEvicted` (#6562)** is coincident,
+  not leading: it rises only once bindings are already being lost.
   **`RepliesDroppedForceRenew` (#6562)** counts refused DHCPFORCERENEW
   messages. See "Outstanding-request binding" below.
   **`RequestsDroppedRateLimit` (#5670)** counts
@@ -306,16 +324,55 @@ it and only RFC 6842 §3 (2013) reversed that to a MUST, so keying on it would
 drop every reply from a pre-RFC-6842 server — a silent, segment-wide outage. The
 ingress interface is not keyed either: each relay interface owns its own table.
 
-**Bounded — 8192 entries, evict-oldest.** The cap is a *backstop*, not the
-primary bound: the #5670 ingress rate limiter already caps the fill rate
-(default 100 pps), so steady-state occupancy is ~`rate × TTL` = ~3000 entries and
-a default-configured relay never evicts. At the cap the table reaps expired
-entries first, then evicts the **oldest** — it does **not** refuse the new
-request. Refusing new requests would let an attacker who fills the table lock
-out every new client (a total segment outage); evicting the oldest degrades
-gracefully, and the choice trades away no security, because eviction can only
-cause a legitimate reply to be *dropped*, never an unsolicited reply to be
-*accepted*. Every eviction bumps `PendingEvicted`.
+**Bounded — capacity is derived from `maximum-packet-rate`, evict-oldest.**
+Steady-state occupancy is `rate × TTL`, and the fill rate is the configurable
+#5670 limit — so capacity **must** track it. `pendingCapacityFor` sizes the
+table at `rate × pendingTTL + relayBurstFor(rate)` (the sustained window plus
+the token bucket's 2-second burst allowance), clamped to
+`[4096, 131072]`. `maxPacketRate` participates in `relaySpec.equal()`, so a
+day-2 rate change restarts the session and re-derives it.
+
+> A **fixed** capacity is a trap, and this originally shipped as a hardcoded
+> 8192. Above ~273 pps the table became cap-bound and the binding window
+> silently collapsed from 30 s to `8192/rate` seconds — while the
+> "Ingress rate limit" section below *recommends raising*
+> `maximum-packet-rate` on a busy segment. A segment provisioned at 3000 pps
+> had a 2.7 s window; a boot storm against a server whose RTT exceeded that had
+> every reply dropped at the relay, turning a storm that previously completed
+> into a permanent retry storm. `TestPendingCapacity_TracksMaxPacketRate` pins
+> the property (a reply arriving one server RTT later still binds), not the
+> number.
+
+The **ceiling** is mandatory in the other direction: the schema allows up to
+1000000 pps, and an unclamped derivation would be ~3×10⁷ entries — gigabytes,
+i.e. the memory-exhaustion vector this table exists not to be. Above ~4096 pps
+the ceiling binds and the effective window is `capacity/rate` seconds; that is
+unavoidable (window × rate *is* memory) but it is made explicit rather than
+emergent — `Apply` logs a startup `Warn` naming the reduced window, and
+`PendingSize`/`PendingCapacity` show the runtime truth.
+
+At capacity the table reaps expired slots first, then evicts the **oldest** — it
+does **not** refuse the new request. Refusing new requests would let an attacker
+who fills the table lock out every new client (a total segment outage); evicting
+the oldest degrades gracefully, and the choice trades away no security, because
+eviction can only cause a legitimate reply to be *dropped*, never an unsolicited
+reply to be *accepted*. Every eviction bumps `PendingEvicted`.
+
+**O(1) at capacity.** Expiry and eviction go through a fixed-size ring of
+insertions, not a scan. This works because every entry carries the *same* TTL,
+so insertion order **is** expiry order and the oldest is always at the ring
+head. The original implementation ranged the whole map for the minimum expiry —
+two full `O(capacity)` scans per admitted packet once full, on the single
+client-facing read goroutine, which saturates a core in exactly the overload
+the table is meant to survive. A key re-inserted before its old slot expires
+(a retransmission, or the SELECTING REQUEST reusing the DISCOVER's xid) simply
+gets a new slot; the older one is stale (the map holds a later expiry) and is
+discarded for free at the head. Because a slot is always freed before a push,
+`len(entries) ≤ count ≤ capacity` — the ring bounds the map, so duplicate
+inserts cannot grow either structure.
+`TestPendingTable_AtCapInsertIsConstantTime` pins this by counting ring slots
+examined (deterministic, no timing), with a **lower** bound as well as an upper
+one so an implementation that bypasses the ring cannot pass by reporting zero.
 
 **TTL — 30s.** This bounds the window in which a guessed xid would be accepted,
 while covering realistic server latency. RFC 2131 §4.1's retransmission schedule
@@ -334,8 +391,23 @@ Consuming on first match would silently break multi-server redundancy.
 
 **Fail direction.** A binding that is too strict silently breaks DHCP for real
 clients, which is a worse outage than the injection it prevents. Every drop is
-therefore counted (`RepliesDroppedNoRequest`) and logged warn-once-then-`Debug`,
-and `PendingEvicted` warns before drops start. A nil table fails **closed** (it
+therefore counted (`RepliesDroppedNoRequest`) and logged warn-once-then-`Debug`.
+
+The **leading** indicator is `PendingSize`/`PendingCapacity`: occupancy climbing
+toward capacity means the relay is about to start evicting bindings, and it is
+visible *before* any reply is lost. `PendingEvicted` is **coincident**, not
+leading — an eviction is what *causes* the subsequent drop, so its lead time is
+one server RTT (tens of ms to a couple of seconds). Alert on the
+size/capacity ratio; treat a rising `PendingEvicted` as damage already in
+progress.
+
+These counters are currently surfaced only by the **on-box console CLI**
+(`show services dhcp relay`) — there is no gRPC RPC or Prometheus collector for
+`RelayStats`, so the remote `cli` and external alerting do not see them. That
+gap is pre-existing and tracked separately; it does bound "visible" to the
+console today.
+
+A nil table fails **closed** (it
 admits nothing), matching the #4163 empty-allow-set posture, so a wiring
 regression is a loud counted outage rather than a silent loss of the control;
 `TestManagerRelay_HasPendingTable` guards the production wiring.
@@ -413,11 +485,20 @@ set forwarding-options dhcp-relay group <g> overrides maximum-packet-rate <pps>
   the sustained rate throttles a persistent flood. Set a high value
   (schema range `1..1000000`) to effectively disable the bound on a segment that
   legitimately needs it.
+  - **Raising this also resizes the #6562 outstanding-request table**, whose
+    capacity is derived as `rate × 30s + 2×rate` — that is deliberate, so the
+    reply-binding window does not collapse on a segment you just told the relay
+    to expect more traffic from. Above **~4096 pps** the table's memory ceiling
+    (131072 entries) binds instead, the effective binding window becomes
+    `capacity/rate` seconds rather than 30 s, and the relay logs a startup
+    `Warn` naming the reduced window. Watch `PendingSize`/`PendingCapacity` on
+    such a segment. See "Outstanding-request binding" above.
 - **Counted + throttled log.** Every dropped datagram bumps
   `RelayStats.RequestsDroppedRateLimit`; the log is warn-once-per-session then
   `Debug` (never per packet, per the project logging rules). A sustained
   nonzero counter means the segment is exceeding its pps bound — a flood /
-  amplification attempt or a segment that should raise `maximum-packet-rate`.
+  amplification attempt or a segment that should raise `maximum-packet-rate`
+  (which resizes the #6562 binding table with it — see the sub-bullet above).
 - Compiles to `DHCPRelayGroup.MaximumPacketRate` and flows into
   `relaySpec.maxPacketRate` (a change resizes the bucket, so it restarts the
   per-interface relay). All three parse shapes (flat-set, merged-Keys, block

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -366,18 +366,32 @@ two full `O(capacity)` scans per admitted packet once full, on the single
 client-facing read goroutine, which saturates a core in exactly the overload the
 table is meant to survive.
 
-The bound is **amortized** O(1), not strict: each slot is pushed once and popped
-once, but a single call can pop more than one slot when several expired
-together. The pathological case — the first insert after a long idle period,
-where *everything* has expired — is taken in **constant time** by a fast path:
-because the ring is expiry-ordered, one probe of the newest slot proves the
-whole ring is dead, so `head`/`count` reset to zero and the map is replaced
-wholesale instead of being deleted key by key. Without it that call popped up to
-`capacity` (131072) slots, each with a map lookup and delete, under the mutex on
-the client-facing packet path — a multi-millisecond stall that also blocked the
-reply loop. What remains is a *partial* drain, bounded by the number of slots
-that expired while at least one newer slot had not.
-`TestPendingTable_FullDrainIsConstantTime` pins this by counting slots examined.
+Per-insert reclaim work is **bounded by a constant**, via two mechanisms that
+cover different cases:
+
+- The *wholly expired* ring — the first insert after a long idle period — is
+  taken in constant time by a fast path: because the ring is expiry-ordered, one
+  probe of the newest slot proves the whole ring is dead, so `head`/`count` reset
+  to zero and the map is replaced wholesale rather than deleted key by key.
+- The *mixed* ring — most slots expired but the newest still live, which is a
+  quiet period followed by a single late request — cannot use that probe, so the
+  head drain is capped at `maxDrainPerInsert` (64) slots per call. Without the
+  cap this case popped ~`capacity` (up to 131071) slots one at a time, each with
+  a map lookup and delete, under the mutex on the client-facing packet path: the
+  same multi-millisecond stall as before, just behind a narrower trigger.
+
+`insert` needs exactly one free slot, so reclaiming more per call buys nothing.
+Leftover expired slots are inert — `matches` re-checks the expiry and
+`PendingSize` excludes them — and later inserts clear the backlog at ~65 slots
+per admitted packet. `TestPendingTable_FullDrainIsConstantTime` and
+`TestPendingTable_PartialDrainIsBounded` pin the two cases by counting slots
+examined; the latter must **stagger** expiries, because a frozen clock makes
+every slot expire together and the mixed case unconstructible.
+
+Because both reclaim steps always free room before the at-capacity eviction loop
+can run, that loop only ever displaces an *unexpired* binding — so counting each
+pop as cap pressure is exact, and `PendingEvicted` cannot fire on a relay that is
+merely idle. `insert` carries the proof.
 
 A key re-inserted before its old slot expires (a retransmission, or the
 SELECTING REQUEST reusing the DISCOVER's xid) simply gets a new slot; the older
@@ -417,11 +431,18 @@ storm this table exists to prevent. Adopted entries keep their **original
 expiry** — a reload must not refresh the TTL, which would widen the attacker's
 xid-guessing window every time the config was touched. If the replacement is
 *smaller* (the rate was lowered), the oldest excess bindings are dropped and
-**counted** in `PendingEvicted` rather than discarded silently. The migration is
-bounded by the destination's *remaining room*, not its raw capacity: production
-always adopts into a table built moments earlier, so the two coincide, but
-bounding by capacity alone would overrun the ring of a non-empty destination and
-overwrite live slots.
+**counted** in `PendingEvicted` rather than discarded silently.
+
+`adopt` **requires an empty destination**, and asserts it. It appends rather than
+merging, so migrated expiries landing after a destination's later ones would
+destroy the expiry ordering everything else depends on: the full-drain probe
+would read a newer-but-expired tail slot, conclude the whole ring was dead, and
+wipe live bindings, while the head drain and `PendingSize`'s binary search would
+mis-locate the boundary. The sole production caller adopts into a table built
+moments earlier and never launched, so the assertion cannot fire in the live
+path — it exists so a future second caller fails loudly instead of silently
+corrupting the structure that decides which replies reach clients. An ordered
+merge would generalise it, but no caller needs one.
 
 **TTL — 30s.** This bounds the window in which a guessed xid would be accepted,
 while covering realistic server latency. RFC 2131 §4.1's retransmission schedule
@@ -450,13 +471,21 @@ one server RTT (tens of ms to a couple of seconds). Alert on the
 size/capacity ratio; treat a rising `PendingEvicted` as damage already in
 progress.
 
-`PendingSize` reports **ring slots in use**, not the map's key count, because
-ring pressure is what triggers eviction. The two diverge in both directions: on
-an idle relay expired entries linger in the map until the next insert reclaims
-them (map count reads *high*), and duplicate inserts consume ring slots without
-adding keys (map count reads *low* — a capacity-4 ring holding `A,B,B,B` has two
-keys but evicts live `A` on the very next insert). Reporting the map count would
-show a comfortable `2/4` at the exact moment eviction began.
+`PendingSize` reports **unexpired ring slots**. Neither of the two obvious
+alternatives is correct:
+
+- the map's key count reads *low*, because duplicate inserts consume ring slots
+  without adding keys — a capacity-4 ring holding `A,B,B,B` has two keys but
+  evicts live `A` on the very next insert, so the gauge would show a comfortable
+  `2/4` at the exact moment eviction began;
+- the raw ring count reads *high*, because expired slots stay counted until some
+  later insert reclaims them — an idle full table would report
+  `capacity/capacity` even though the next insert reclaims the lot and evicts
+  nothing, paging an operator over a relay that is simply quiet.
+
+Expired slots form a contiguous prefix (the ring is expiry-ordered), so the
+boundary is found by binary search — `O(log capacity)` under the mutex, which
+matters because `Stats()` reads this while the packet path is running.
 
 These counters are currently surfaced only by the **on-box console CLI**
 (`show services dhcp relay`) — there is no gRPC RPC or Prometheus collector for

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -14,6 +14,10 @@ to the interface name.
   AND on every day-2 commit (#2348). A nil `cfg` stops all relays.
 - `Stats()` — `relay.go`. Per-interface counters.
 - `RelayStats` — `relay.go`.
+- `pendingTable` — `pending.go`. The bounded, expiring outstanding-request
+  table that binds each relayed reply to a request the relay actually
+  forwarded (#6562). Internal; reached through `interfaceRelay.pending`. See
+  "Outstanding-request binding" below.
 - `SetMasterGate(g)` — `relay.go`. Installs the per-interface HA master-state
   gate (#2456); the daemon passes `Daemon.relayMasterGateOpen`. nil = always
   relay (standalone). Read per packet, so failover is followed live.
@@ -41,7 +45,7 @@ carries server-bound options, per RFC 2131 §3.4:
 | `INFORM` | yes (#2153) | client already holds an address, asks only for supplemental parameters (DNS/domain/NTP) |
 | `DECLINE` | yes (#2789) | client detected the offered address already in use (ARP probe) and broadcasts a DHCPDECLINE (RFC 2131 §3.1 step 4, §4.4.1); relayed so the originating server marks the address unavailable instead of re-offering it. Carries no server reply |
 | `RELEASE` | no | unicast by the client directly to its bound server (RFC 2131 §4.4.4) — it routes without relay assistance and is never seen on the relay's client-facing broadcast socket |
-| server reply types (`OFFER`/`ACK`/`NAK`/`FORCERENEW`) | n/a | not client-originated; the client→server gate never sees them. The reverse server→client path (`handleServerResponses`) forwards `OFFER`, `ACK`, `NAK` (#2606), and `FORCERENEW` (#2645) — see the reply matrix below |
+| server reply types (`OFFER`/`ACK`/`NAK`/`FORCERENEW`) | n/a | not client-originated; the client→server gate never sees them. The reverse server→client path (`handleServerResponses`) forwards `OFFER`, `ACK` and `NAK` (#2606) **when they bind to an outstanding request** (#6562); `FORCERENEW` is **refused** (#6562, reversing #2645) — see the reply matrix below |
 
 The `INFORM` reply (a server-issued `ACK` with no `yiaddr` but a real
 `ciaddr`) is delivered by the matrix below via the "flag clear, `yiaddr==0`,
@@ -112,8 +116,9 @@ identity.
 
 ## Reply delivery model (#2076)
 
-Server replies (OFFER/ACK/NAK/FORCERENEW) are delivered to clients honoring the
-RFC 2131 §4.1 broadcast flag:
+Server replies (OFFER/ACK/NAK) that pass the source check (#4163) **and** bind
+to an outstanding request (#6562) are delivered to clients honoring the RFC 2131
+§4.1 broadcast flag:
 
 | Condition | Delivery |
 |-----------|----------|
@@ -136,17 +141,55 @@ has no usable address, and broadcasting also prevents a server that
 erroneously echoes a stale `ciaddr` from steering the NAK into a UDP unicast to
 an address the client does not own.
 
-**DHCPFORCERENEW (#2645).** A server sends `DHCPFORCERENEW` (RFC 3203, message
-type 9) to a client that **already holds a lease** to force it back into the
-`RENEWING` state ahead of its T1 timer (for example, to push a configuration
-change). Before #2645 `handleServerResponses` dropped it via the `default` arm,
-so a server could never reach a relayed client. It is now forwarded. Unlike a
-NAK, FORCERENEW is **not** force-broadcast: the target client owns a current
-address (carried in `ciaddr`, `yiaddr==0`) and answers ARP for it, so the reply
-matrix routes it through the normal "flag clear, `yiaddr==0`, real `ciaddr`"
-UDP-unicast row — the same row that delivers an INFORM `ACK`. The relay only
-forwards the message; RFC 3203's RFC-3118 authentication is end-to-end between
-client and server and is out of scope for the relay agent.
+**DHCPFORCERENEW — REFUSED (#6562, reversing #2645).** A server sends
+`DHCPFORCERENEW` (RFC 3203, message type 9 — defined in §4 "Message layout",
+assigned in §5 "IANA Considerations") to a client that **already holds a lease**
+to force it back into the `RENEWING` state ahead of its T1 timer. #2645 made the
+relay forward it, on the reasoning that RFC 3118 authentication is end-to-end
+between client and server and therefore out of scope for a relay. **That
+reasoning was wrong, and the relay now refuses the message.**
+
+RFC 3203 **§6** (Security Considerations — *not* §5, which is IANA
+Considerations) makes the authentication mandatory, and says why:
+
+> As in some network environments FORCERENEW can be used to snoop and spoof
+> traffic, the FORCERENEW message MUST be authenticated using the procedures as
+> described in [DHCP-AUTH]. FORCERENEW messages failing the authentication
+> should be silently discarded by the client.
+
+A relay **structurally cannot** discharge that MUST:
+
+- RFC 3118 §5.2 defines the key as "K — a secret value shared between the
+  **source and destination** of the message", and notes that "Delayed
+  authentication requires a shared secret key for each client on each DHCP
+  server". The relay is neither endpoint and holds no secret or secret-ID map.
+- RFC 3118 §3 ("Interaction with Relay Agents") casts the relay purely as a
+  transparent mutator whose `giaddr`/`hops`/Option-82 changes are **excluded**
+  from the hash — it is not a party to the authentication.
+- RFC 3118 §5.3 assigns validation to the receiver: "If the MAC computed by the
+  **receiver** does not match the MAC contained in the authentication option,
+  the receiver MUST discard the DHCP message."
+
+Checking only that Option 90 is **present** would be theater: the off-path
+attacker in this threat model already forges the server's source IP, so they can
+equally attach a well-formed Option 90 with a bogus MAC — and since the relay
+cannot check the MAC, a presence test admits exactly the attacker it is meant to
+stop. Most deployed clients do not implement RFC 3118 at all, so nothing
+downstream would catch it either.
+
+Refusing is a **handled condition, not an outage**. RFC 3203 §2.2 specifies the
+server's behavior when the message does not arrive: "If the FORCERENEW message
+is lost, the DHCP server will not receive a DHCP REQUEST from the client and it
+should retransmit the FORCERENEW message using an exponential backoff
+algorithm." Ordinary leasing is untouched — clients still renew at T1/T2. Only
+the server's ability to force an *early* renew through this relay is withdrawn,
+and it is withdrawn **loudly**: every refusal bumps `RepliesDroppedForceRenew`
+and the first one per session logs at `Warn`.
+
+There is deliberately **no opt-in knob** to re-enable forwarding. If a
+deployment genuinely needs relayed FORCERENEW, that is a follow-up that should
+come with a way to actually verify the message, not a flag that restores an
+unverifiable forward.
 
 **Why raw L2 (`l2send_linux.go`).** A client in SELECTING/REQUESTING that
 clears the broadcast flag has **not yet configured** the offered address,
@@ -178,13 +221,24 @@ RFC 768).
   (`RepliesL2Unicast`, `RepliesUnicastCiaddr`, `RepliesBroadcastFlag1`,
   `RepliesBroadcastForced`, `RepliesBroadcastNoTarget`,
   `RepliesBroadcastL2Fallback`, `RepliesBroadcastNak`,
-  `RepliesDroppedUnknownServer`). **`RepliesBroadcastL2Fallback` is the one
+  `RepliesDroppedUnknownServer`, `RepliesDroppedNoRequest`,
+  `RepliesDroppedForceRenew`, `PendingEvicted`).
+  **`RepliesBroadcastL2Fallback` is the one
   to alert on** — it means the raw-L2 path failed (CAP_NET_RAW, driver, or
   MTU) and the relay degraded to broadcast. **`RepliesDroppedUnknownServer`
   (#4163)** counts replies dropped because their source IP was not a
   configured server — a non-zero value is a rogue-reply injection attempt (or
   a multi-homed server unicasting from an unlisted source IP); see "Reply
-  source validation" below. **`RequestsDroppedRateLimit` (#5670)** counts
+  source validation" below. **`RepliesDroppedNoRequest` (#6562)** counts
+  replies dropped because they answered no outstanding relayed request —
+  either an injection that passed the source check, **or a legitimate reply
+  that missed the binding window**, which is a client-visible DHCP failure, so
+  this one must be *watched*, not assumed hostile. **`PendingEvicted` (#6562)**
+  is the early warning that pairs with it: the outstanding-request table is at
+  capacity, so legitimate bindings are being lost.
+  **`RepliesDroppedForceRenew` (#6562)** counts refused DHCPFORCERENEW
+  messages. See "Outstanding-request binding" below.
+  **`RequestsDroppedRateLimit` (#5670)** counts
   client-facing datagrams dropped by the per-interface ingress rate limiter — a
   sustained nonzero value is a flood / amplification attempt (see "Ingress rate
   limit" below). `show ... dhcp-relay` prints this breakdown.
@@ -219,10 +273,83 @@ from the relay's explicit, configured server list.
   presenting as a silent black-hole. If a real deployment needs that, a
   follow-up can add an explicit extra-reply-source allow-list knob; it is not
   needed to close the injection hole.
-- `giaddr`-echo and Option-82 correlation are strictly-stronger secondary
-  checks and are **out of scope** here (Option 82 is stripped on the reply, but
-  not echo-validated); source-set membership is the primary, highest-value
-  control. This is DHCPv4-only (there is no DHCPv6 relay — see below).
+- Source-set membership is necessary but **not sufficient** — a source IP is
+  spoofable. Since #6562 it is the *first* of two checks; see
+  "Outstanding-request binding" immediately below. (`giaddr`-echo and Option-82
+  correlation remain out of scope: Option 82 is stripped on the reply but not
+  echo-validated.) This is DHCPv4-only (there is no DHCPv6 relay — see below).
+
+## Outstanding-request binding (#6562)
+
+The #4163 source check above stops an attacker who cannot forge a source
+address. It does **not** stop one who can: an off-path attacker who spoofs a
+configured server's IP passes it, and the relay would then forward a forged
+`OFFER`/`ACK` (hostile gateway/DNS) or `NAK` (forced client restart) to the
+client. So every reply must additionally **bind to a request the relay actually
+forwarded**.
+
+`pending.go` holds a bounded, expiring table of outstanding transactions. The
+client-facing loop inserts an entry for each request it relays upstream
+(*before* the upstream write — the reply loop is a different goroutine, and a
+fast server can answer before a post-send insert would have run); the
+server-facing loop forwards a reply only if `pendingTable.matches` hits.
+
+**Key — `xid` + `chaddr`.** RFC 2131 §4.1 gives the xid's purpose ("The 'xid'
+field is used by the client to match incoming DHCP messages with pending
+requests"), and its §4.3.1 Table 3 requires a server to copy **both** `xid` and
+`chaddr` from the client's message into `DHCPOFFER`/`DHCPACK`/`DHCPNAK` — so
+both halves are present on the request and echoed on the reply. The relay's own
+mutations (`hops`, `giaddr`, Option 82) touch neither, so the key is stable
+across stamping. Option 61 (client-identifier) is **deliberately excluded**
+even though it is a stronger identity: RFC 2131 told servers they MUST NOT echo
+it and only RFC 6842 §3 (2013) reversed that to a MUST, so keying on it would
+drop every reply from a pre-RFC-6842 server — a silent, segment-wide outage. The
+ingress interface is not keyed either: each relay interface owns its own table.
+
+**Bounded — 8192 entries, evict-oldest.** The cap is a *backstop*, not the
+primary bound: the #5670 ingress rate limiter already caps the fill rate
+(default 100 pps), so steady-state occupancy is ~`rate × TTL` = ~3000 entries and
+a default-configured relay never evicts. At the cap the table reaps expired
+entries first, then evicts the **oldest** — it does **not** refuse the new
+request. Refusing new requests would let an attacker who fills the table lock
+out every new client (a total segment outage); evicting the oldest degrades
+gracefully, and the choice trades away no security, because eviction can only
+cause a legitimate reply to be *dropped*, never an unsolicited reply to be
+*accepted*. Every eviction bumps `PendingEvicted`.
+
+**TTL — 30s.** This bounds the window in which a guessed xid would be accepted,
+while covering realistic server latency. RFC 2131 §4.1's retransmission schedule
+is 4s, then 8s, doubling to a 64s maximum, so 30s spans the first three
+retransmissions. A too-short TTL is self-healing rather than fatal: the client's
+retransmission traverses the relay and arms a fresh entry, and this holds
+whichever xid it uses — §4.1 leaves that open ("A client may choose to reuse the
+same 'xid' or select a new 'xid' for each retransmitted message") — because the
+server's answer echoes whatever xid the retransmission carried.
+
+**A match does not consume the entry.** The relay fans each request out to
+*every* server in the group, so an N-server group answers one `DISCOVER` with N
+`OFFER`s; and RFC 2131 §4.4.1 has the SELECTING `DHCPREQUEST` reuse the
+`DHCPOFFER`'s xid, so the same binding must also admit the `ACK`/`NAK`.
+Consuming on first match would silently break multi-server redundancy.
+
+**Fail direction.** A binding that is too strict silently breaks DHCP for real
+clients, which is a worse outage than the injection it prevents. Every drop is
+therefore counted (`RepliesDroppedNoRequest`) and logged warn-once-then-`Debug`,
+and `PendingEvicted` warns before drops start. A nil table fails **closed** (it
+admits nothing), matching the #4163 empty-allow-set posture, so a wiring
+regression is a loud counted outage rather than a silent loss of the control;
+`TestManagerRelay_HasPendingTable` guards the production wiring.
+
+**Table lifetime.** The table lives on `interfaceRelay`, not on the session, so
+a session rebuild (#2347 ifindex drift, #3960 re-address) does not wipe
+in-flight bindings and strand a client mid-transaction.
+
+**HA note (#2456).** Entries are per-node. If a client's transaction spans a
+failover, the newly-active node has no binding for the in-flight reply and drops
+it; the client's normal retransmission then re-arms the new node. The window is
+bounded by one client retransmission, and the drop is visible in
+`RepliesDroppedNoRequest`. (A BACKUP node never inserts, because the master gate
+drops the request before it is forwarded.)
 
 ### `overrides always-broadcast` config
 

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -367,10 +367,17 @@ client-facing read goroutine, which saturates a core in exactly the overload the
 table is meant to survive.
 
 The bound is **amortized** O(1), not strict: each slot is pushed once and popped
-once, but the *worst case for one call* is a full drain of up to `capacity`
-slots, when the first insert after a long idle period finds everything expired.
-That is bounded, happens at most once per idle period (the next insert finds an
-empty ring), and is not the per-packet repeat the pre-ring code had.
+once, but a single call can pop more than one slot when several expired
+together. The pathological case — the first insert after a long idle period,
+where *everything* has expired — is taken in **constant time** by a fast path:
+because the ring is expiry-ordered, one probe of the newest slot proves the
+whole ring is dead, so `head`/`count` reset to zero and the map is replaced
+wholesale instead of being deleted key by key. Without it that call popped up to
+`capacity` (131072) slots, each with a map lookup and delete, under the mutex on
+the client-facing packet path — a multi-millisecond stall that also blocked the
+reply loop. What remains is a *partial* drain, bounded by the number of slots
+that expired while at least one newer slot had not.
+`TestPendingTable_FullDrainIsConstantTime` pins this by counting slots examined.
 
 A key re-inserted before its old slot expires (a retransmission, or the
 SELECTING REQUEST reusing the DISCOVER's xid) simply gets a new slot; the older
@@ -410,7 +417,11 @@ storm this table exists to prevent. Adopted entries keep their **original
 expiry** — a reload must not refresh the TTL, which would widen the attacker's
 xid-guessing window every time the config was touched. If the replacement is
 *smaller* (the rate was lowered), the oldest excess bindings are dropped and
-**counted** in `PendingEvicted` rather than discarded silently.
+**counted** in `PendingEvicted` rather than discarded silently. The migration is
+bounded by the destination's *remaining room*, not its raw capacity: production
+always adopts into a table built moments earlier, so the two coincide, but
+bounding by capacity alone would overrun the ring of a non-empty destination and
+overwrite live slots.
 
 **TTL — 30s.** This bounds the window in which a guessed xid would be accepted,
 while covering realistic server latency. RFC 2131 §4.1's retransmission schedule

--- a/pkg/dhcprelay/delivery_test.go
+++ b/pkg/dhcprelay/delivery_test.go
@@ -106,6 +106,33 @@ func testServerSet(ips ...net.IP) []*net.UDPAddr {
 	return set
 }
 
+// armedRelay builds an interfaceRelay whose #6562 outstanding-request table is
+// already armed for each given reply — i.e. it models the normal flow, where
+// the client-facing loop forwarded a request upstream and the server echoed
+// that request's xid and chaddr back (RFC 2131 §4.3.1 Table 3).
+//
+// Every handleServerResponses test that expects a reply to be DELIVERED must
+// arm the relay: an unbound reply is now dropped by design. Tests that expect a
+// DROP use a bare interfaceRelay (unarmedRelay) instead.
+func armedRelay(name string, replies ...*dhcpv4.DHCPv4) *interfaceRelay {
+	ir := unarmedRelay(name)
+	for _, r := range replies {
+		ir.pending.insert(pendingKeyFor(r))
+	}
+	return ir
+}
+
+// unarmedRelay builds an interfaceRelay with a live-but-EMPTY pending table:
+// no outstanding requests, so every reply fails the #6562 binding. It is a real
+// table rather than a nil one so these tests exercise the ordinary miss path,
+// not the nil-receiver fail-closed guard.
+func unarmedRelay(name string) *interfaceRelay {
+	return &interfaceRelay{
+		ifaceName: name,
+		pending:   newPendingTable(pendingCap, pendingTTL, time.Now),
+	}
+}
+
 // TestDeliverReply_Matrix is the §7.1 decision-matrix oracle: every row of the
 // reply-destination table maps to exactly one delivery path and one counter.
 func TestDeliverReply_Matrix(t *testing.T) {
@@ -475,7 +502,7 @@ func TestHandleServerResponses_NakForwarded(t *testing.T) {
 	clientConn := newFakeConn()
 	defer clientConn.Close()
 	fl2 := &fakeL2{}
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	ir := armedRelay("ge-0-0-0", nak)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -537,51 +564,24 @@ func newForceRenew(t *testing.T, ciaddr net.IP, chaddr net.HardwareAddr) *dhcpv4
 	return pkt
 }
 
-// TestDeliverReply_ForceRenew_UnicastCiaddr proves a DHCPFORCERENEW is unicast
-// to the client's current address (ciaddr), NOT broadcast like a NAK. RFC 3203
-// targets a client that already owns a lease, so the matrix must route a type-9
-// reply (yiaddr==0, real ciaddr, flag clear) through the ciaddr UDP-unicast row.
-func TestDeliverReply_ForceRenew_UnicastCiaddr(t *testing.T) {
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
-	client := newFakeConn()
-	defer client.Close()
-	fl2 := &fakeL2{}
-
-	pkt := newForceRenew(t, testCiaddr, testChaddr)
-	if !deliverReply(ir, client, fl2, testGiaddr, pkt, pkt.ToBytes()) {
-		t.Fatal("deliverReply returned false (FORCERENEW not delivered)")
-	}
-
-	if fl2.callCount() != 0 {
-		t.Errorf("FORCERENEW must NOT use raw-L2 unicast, got %d calls", fl2.callCount())
-	}
-	if ir.repliesBroadcastNak.Load() != 0 {
-		t.Errorf("FORCERENEW must NOT take the NAK broadcast path, got %d", ir.repliesBroadcastNak.Load())
-	}
-	if ir.repliesUnicastCiaddr.Load() != 1 {
-		t.Errorf("repliesUnicastCiaddr = %d, want 1", ir.repliesUnicastCiaddr.Load())
-	}
-
-	client.mu.Lock()
-	writes := append([]fakeWrite(nil), client.writes...)
-	client.mu.Unlock()
-	if len(writes) != 1 {
-		t.Fatalf("expected 1 client UDP write, got %d", len(writes))
-	}
-	got := writes[0].addr.(*net.UDPAddr)
-	if !got.IP.Equal(testCiaddr) || got.Port != clientPort {
-		t.Errorf("FORCERENEW dst = %v, want unicast %v:%d", got, testCiaddr, clientPort)
-	}
-}
-
-// TestHandleServerResponses_ForceRenewForwarded is the fail-on-revert gate for
-// #2645: a DHCPFORCERENEW server reply MUST be forwarded to the client (unicast
-// to ciaddr), not silently dropped by the default arm. Removing
-// dhcpv4.MessageTypeForceRenew from the accepted set in handleServerResponses
-// makes this test red (the reply is never written to the client conn).
-func TestHandleServerResponses_ForceRenewForwarded(t *testing.T) {
+// TestHandleServerResponses_ForceRenewRefused is the #6562 fail-on-revert gate
+// for the SECOND defect: a DHCPFORCERENEW MUST NOT be forwarded to the client,
+// even when it arrives from a CONFIGURED server (so the #4163 source check
+// passes) and is otherwise perfectly well formed.
+//
+// This deliberately REVERSES #2645, which forwarded FORCERENEW on the reasoning
+// that RFC 3118 authentication is end-to-end and therefore not the relay's
+// concern. RFC 3203 §6 makes that authentication a MUST precisely because
+// "FORCERENEW can be used to snoop and spoof traffic", and a relay holds none
+// of the key material RFC 3118 §5.2/§5.3 places between the client and the
+// server — so it cannot verify one and refuses instead.
+//
+// Restoring messageTypeForceRenew to the forwarded set in handleServerResponses
+// makes this RED: the reply reaches the client conn and
+// repliesDroppedForceRenew stays 0.
+func TestHandleServerResponses_ForceRenewRefused(t *testing.T) {
 	fr := newForceRenew(t, testCiaddr, testChaddr)
-	fr.GatewayIPAddr = testGiaddr // server echoes giaddr; relay must zero it
+	fr.GatewayIPAddr = testGiaddr
 	serverConn := newFakeConn()
 	serverConn.mu.Lock()
 	serverConn.pending = [][]byte{fr.ToBytes()}
@@ -589,7 +589,11 @@ func TestHandleServerResponses_ForceRenewForwarded(t *testing.T) {
 	clientConn := newFakeConn()
 	defer clientConn.Close()
 	fl2 := &fakeL2{}
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	// ARMED for this very transaction: the refusal must be driven by the
+	// message TYPE, not by a missing outstanding-request binding. Without this
+	// the test would pass for the wrong reason (the #6562 binding would drop it
+	// anyway) and would not pin the FORCERENEW rule at all.
+	ir := armedRelay("ge-0-0-0", fr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -599,36 +603,42 @@ func TestHandleServerResponses_ForceRenewForwarded(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait for the client-direction write (the FORCERENEW must reach the client).
+	// The datagram is consumed but never forwarded, so poll the refusal counter
+	// rather than a client write.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		clientConn.mu.Lock()
-		n := len(clientConn.writes)
-		clientConn.mu.Unlock()
-		if n > 0 {
+		if ir.repliesDroppedForceRenew.Load() > 0 {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
 
-	clientConn.mu.Lock()
-	writes := append([]fakeWrite(nil), clientConn.writes...)
-	clientConn.mu.Unlock()
-	if len(writes) != 1 {
-		t.Fatalf("DHCPFORCERENEW not forwarded to client: got %d writes, want 1", len(writes))
+	if got := ir.repliesDroppedForceRenew.Load(); got != 1 {
+		t.Errorf("repliesDroppedForceRenew = %d, want 1 (FORCERENEW must be refused+counted)", got)
 	}
-	dst := writes[0].addr.(*net.UDPAddr)
-	if !dst.IP.Equal(testCiaddr) || dst.Port != clientPort {
-		t.Errorf("FORCERENEW forwarded to %v, want unicast %v:%d", dst, testCiaddr, clientPort)
+	clientConn.mu.Lock()
+	nWrites := len(clientConn.writes)
+	clientConn.mu.Unlock()
+	if nWrites != 0 {
+		t.Errorf("FORCERENEW reached the client: got %d client writes, want 0", nWrites)
+	}
+	if ir.repliesForwarded.Load() != 0 {
+		t.Errorf("repliesForwarded = %d, want 0", ir.repliesForwarded.Load())
+	}
+	if ir.repliesUnicastCiaddr.Load() != 0 {
+		t.Errorf("repliesUnicastCiaddr = %d, want 0 (must not reach deliverReply)", ir.repliesUnicastCiaddr.Load())
 	}
 	if fl2.callCount() != 0 {
-		t.Errorf("FORCERENEW must not use raw-L2, got %d calls", fl2.callCount())
+		t.Errorf("FORCERENEW used raw-L2: got %d calls, want 0", fl2.callCount())
 	}
-	if ir.repliesForwarded.Load() != 1 {
-		t.Errorf("repliesForwarded = %d, want 1", ir.repliesForwarded.Load())
+	// The refusal is its OWN counter, not a side effect of the other gates —
+	// an operator must be able to tell "FORCERENEW refused" from "rogue source"
+	// and from "no outstanding request".
+	if got := ir.repliesDroppedUnknownServer.Load(); got != 0 {
+		t.Errorf("repliesDroppedUnknownServer = %d, want 0 (source WAS configured)", got)
 	}
-	if ir.repliesUnicastCiaddr.Load() != 1 {
-		t.Errorf("repliesUnicastCiaddr = %d, want 1", ir.repliesUnicastCiaddr.Load())
+	if got := ir.repliesDroppedNoRequest.Load(); got != 0 {
+		t.Errorf("repliesDroppedNoRequest = %d, want 0 (relay WAS armed for this xid)", got)
 	}
 
 	cancel()
@@ -651,7 +661,7 @@ func TestHandleServerResponses_L2SourceIsSavedGiaddr(t *testing.T) {
 	clientConn := newFakeConn()
 	defer clientConn.Close()
 	fl2 := &fakeL2{}
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	ir := armedRelay("ge-0-0-0", offer)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -715,7 +725,7 @@ func TestHandleServerResponses_ConfiguredSourceForwarded(t *testing.T) {
 	clientConn := newFakeConn()
 	defer clientConn.Close()
 	fl2 := &fakeL2{}
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	ir := armedRelay("ge-0-0-0", offer)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -759,7 +769,7 @@ func TestHandleServerResponses_UnconfiguredSourceDropped(t *testing.T) {
 	clientConn := newFakeConn()
 	defer clientConn.Close()
 	fl2 := &fakeL2{}
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	ir := unarmedRelay("ge-0-0-0")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -817,7 +827,7 @@ func TestHandleServerResponses_MultiServerGroupAnyMemberForwarded(t *testing.T) 
 	clientConn := newFakeConn()
 	defer clientConn.Close()
 	fl2 := &fakeL2{}
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	ir := armedRelay("ge-0-0-0", offer)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -856,7 +866,7 @@ func TestHandleServerResponses_ConfiguredSourceWrongOpCodeDropped(t *testing.T) 
 	clientConn := newFakeConn()
 	defer clientConn.Close()
 	fl2 := &fakeL2{}
-	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	ir := unarmedRelay("ge-0-0-0")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/dhcprelay/delivery_test.go
+++ b/pkg/dhcprelay/delivery_test.go
@@ -129,7 +129,7 @@ func armedRelay(name string, replies ...*dhcpv4.DHCPv4) *interfaceRelay {
 func unarmedRelay(name string) *interfaceRelay {
 	return &interfaceRelay{
 		ifaceName: name,
-		pending:   newPendingTable(pendingCap, pendingTTL, time.Now),
+		pending:   newPendingTable(defaultTestPendingCap(), pendingTTL, time.Now),
 	}
 }
 

--- a/pkg/dhcprelay/pending.go
+++ b/pkg/dhcprelay/pending.go
@@ -49,20 +49,17 @@ import (
 // entirely on the xid for uniqueness, which is the pre-existing RFC 2131
 // matching rule and no weaker than what the client itself relies on.
 //
-// The ingress interface does not need to be part of the key: each relay
-// interface owns its own table (a field on interfaceRelay), so entries are
-// already scoped per-interface by construction.
-//
 // FAIL DIRECTION. This table gates live DHCP for real clients, so every path
 // that can drop a legitimate reply is counted and logged on interfaceRelay
 // (repliesDroppedNoRequest, pendingEvicted) — an over-strict binding must be
 // visible in `show services dhcp relay`, never silent.
 
 const (
-	// pendingTTL is how long a forwarded request stays bindable. It bounds the
-	// window in which a spoofed reply carrying a guessed xid would be accepted,
-	// so shorter is safer; it must still cover the worst-case server response
-	// time, because an entry that expires early drops a LEGITIMATE reply.
+	// pendingTTL is the NOMINAL reply-binding window: how long a forwarded
+	// request stays bindable. It bounds the window in which a spoofed reply
+	// carrying a guessed xid would be accepted, so shorter is safer; it must
+	// still cover the worst-case server response time, because an entry that
+	// expires early drops a LEGITIMATE reply.
 	//
 	// 30s is chosen against RFC 2131 §4.1's client retransmission schedule:
 	// "the delay before the first retransmission SHOULD be 4 seconds
@@ -82,25 +79,84 @@ const (
 	// whatever xid it carries, and the server's answer to it echoes that same
 	// xid (§4.3.1 Table 3). The failure mode of a too-short TTL is therefore a
 	// bounded retry, not a stuck client.
+	//
+	// The window is only NOMINAL when the memory ceiling binds; see
+	// pendingCapacityFor.
 	pendingTTL = 30 * time.Second
 
-	// pendingCap bounds the table so it cannot become the remote
-	// memory-exhaustion vector it exists to prevent. It is a BACKSTOP, not the
-	// primary bound: the #5670 per-interface ingress rate limiter already caps
-	// the fill rate at maxPacketRate (default 100 pps), so steady-state
-	// occupancy is rate x pendingTTL = 100 x 30 = ~3000 entries at the default.
-	// 8192 leaves ~2.7x headroom over that, so a default-configured relay never
-	// reaches the cap and never evicts; only an operator who raised
-	// `overrides maximum-packet-rate` well past the default can reach it.
-	pendingCap = 8192
+	// pendingCapMin is the floor on table capacity. At the default 100 pps the
+	// derivation below wants 100*30 + 200 = 3200 entries; the floor rounds that
+	// up so a default relay has headroom and never evicts.
+	pendingCapMin = 4096
 
-	// pendingReapInterval bounds how often insert sweeps expired entries when
-	// the table is NOT under cap pressure. Expired entries are already inert
-	// for correctness (matches re-checks the expiry), so this only reclaims
-	// memory; doing it at most once a second keeps the O(n) sweep off the
-	// per-packet path.
-	pendingReapInterval = time.Second
+	// pendingCapMax is the memory ceiling on table capacity. The derivation is
+	// rate-driven and `overrides maximum-packet-rate` accepts up to 1000000, so
+	// an UNCLAMPED derivation would itself be the memory-exhaustion vector this
+	// table exists not to be: 1e6 pps x 30 s is 3e7 entries, on the order of
+	// gigabytes. 131072 entries is ~6 MB of ring plus the map — a bounded cost
+	// per relay interface — and it covers the full 30s window for every rate up
+	// to ~4096 pps, which spans realistic large campus/access deployments.
+	//
+	// Above that rate the ceiling binds and the EFFECTIVE window shrinks to
+	// capacity/rate seconds. That is unavoidable — window x rate IS memory —
+	// but it is made explicit rather than emergent: pendingCapacityFor reports
+	// the clamp, Apply logs a startup Warn naming the reduced window, and
+	// PendingSize/PendingEvicted expose the runtime truth.
+	pendingCapMax = 131072
 )
+
+// pendingCapacityFor sizes the outstanding-request table from the interface's
+// #5670 ingress packet-rate limit, and reports whether the memory ceiling
+// clamped the result.
+//
+// WHY THIS IS RATE-DERIVED (#6603 review F1). A fixed capacity is wrong because
+// the fill rate is configurable: steady-state occupancy is rate x pendingTTL,
+// so a hardcoded 8192 was cap-bound above ~273 pps and the binding window
+// silently collapsed from 30s to 8192/rate seconds. That is an availability
+// regression in exactly the direction this file declares worse than the attack
+// it prevents — and the relay's own README recommends raising
+// `maximum-packet-rate` on a busy segment, steering operators straight into it.
+// A boot storm on a segment provisioned for 3000 pps would collapse the window
+// to 2.7s; a saturated server whose RTT exceeds that then has every reply
+// dropped at the relay, turning a storm that previously COMPLETED into a
+// permanent retry storm.
+//
+// Capacity therefore tracks the rate: rate x TTL covers the sustained window,
+// and + relayBurstFor(rate) covers the token bucket's 2-second burst allowance,
+// so every packet the limiter can admit within one TTL has a slot.
+// maxPacketRate participates in relaySpec.equal(), so a day-2 rate change
+// restarts the session and re-derives this.
+func pendingCapacityFor(maxPacketRate int) (capacity int, clamped bool) {
+	rate := resolveMaxPacketRate(maxPacketRate)
+	// Any rate at or above the ceiling saturates it anyway. Short-circuiting
+	// here also keeps the arithmetic below overflow-free on 32-bit int, so a
+	// nonsense rate from a hand-edited active.json cannot wrap.
+	if rate >= pendingCapMax {
+		return pendingCapMax, true
+	}
+	want := rate*int(pendingTTL/time.Second) + relayBurstFor(rate)
+	switch {
+	case want > pendingCapMax:
+		return pendingCapMax, true
+	case want < pendingCapMin:
+		return pendingCapMin, false
+	default:
+		return want, false
+	}
+}
+
+// pendingWindow reports the EFFECTIVE reply-binding window a table of the given
+// capacity provides at the given packet rate: the table can only hold
+// capacity/rate seconds' worth of requests. Used for the startup Warn when the
+// memory ceiling clamps capacity below the nominal pendingTTL.
+func pendingWindow(capacity, maxPacketRate int) time.Duration {
+	rate := resolveMaxPacketRate(maxPacketRate)
+	w := time.Duration(capacity) * time.Second / time.Duration(rate)
+	if w > pendingTTL {
+		return pendingTTL
+	}
+	return w
+}
 
 // pendingKey identifies one outstanding client transaction. It is an
 // all-array, comparable struct so it can be a map key with no allocation and
@@ -136,6 +192,12 @@ func pendingKeyFor(pkt *dhcpv4.DHCPv4) pendingKey {
 	return k
 }
 
+// pendingSlot is one insertion in the expiry-ordered ring.
+type pendingSlot struct {
+	key pendingKey
+	exp time.Time
+}
+
 // pendingTable is a bounded, expiring set of outstanding relayed requests.
 //
 // It is written by the client-facing read loop and read by the server-facing
@@ -143,40 +205,63 @@ func pendingKeyFor(pkt *dhcpv4.DHCPv4) pendingKey {
 // mutex-guarded. The table lives on interfaceRelay rather than on the session,
 // so a session rebuild (#2347 ifindex drift / #3960 re-address) does NOT wipe
 // in-flight bindings and strand a client mid-transaction.
+//
+// STRUCTURE. A map for O(1) lookup, plus a fixed-size ring of insertions for
+// O(1) expiry and eviction. The ring works because EVERY entry is inserted with
+// the SAME ttl, so insertion order IS expiry order — the oldest slot is always
+// at the head, and finding it needs no scan. The earlier implementation ranged
+// the whole map to find the minimum expiry, which cost two full O(capacity)
+// scans per admitted packet once the table was full: at a raised packet rate
+// that was hundreds of microseconds per packet on the single client-facing read
+// goroutine, saturating a core in the exact overload the table is meant to
+// survive (#6603 review F1).
+//
+// A key re-inserted before its previous slot expires (a client retransmitting,
+// or the SELECTING REQUEST reusing the DISCOVER's xid) simply gets a NEW slot;
+// the older slot becomes stale because the map now holds a later expiry, and it
+// is discarded for free when it reaches the head. Because the ring length is
+// the capacity and a slot is always freed before a push, len(entries) <= count
+// <= capacity holds — the ring bounds the map, so duplicate inserts cannot grow
+// either structure past the cap.
 type pendingTable struct {
 	mu      sync.Mutex
 	entries map[pendingKey]time.Time // key -> expiry
-	cap     int
+	ring    []pendingSlot            // fixed length == capacity; expiry-ordered
+	head    int                      // index of the oldest slot
+	count   int                      // slots in use
 	ttl     time.Duration
 	now     func() time.Time
 
-	// lastReap is when the non-cap-pressure sweep last ran.
-	lastReap time.Time
-
-	// evicted counts entries removed by cap pressure (NOT ordinary expiry). It
-	// is surfaced through interfaceRelay.pendingEvicted; a nonzero value means
-	// the table is full and a legitimate reply may now be dropped, which is the
-	// signal an operator needs to raise the rate limit or investigate a flood.
+	// evicted counts entries removed by CAP PRESSURE (not by ordinary expiry).
+	// It is surfaced through interfaceRelay.pendingEvicted; a nonzero value
+	// means the table is full and a legitimate reply may now be dropped.
 	evicted uint64
+
+	// slotScans counts ring slots examined by the expiry/eviction path. It
+	// exists to pin the O(1) invariant deterministically in tests
+	// (TestPendingTable_AtCapInsertIsConstantTime) without timing: if the
+	// eviction path ever regresses to a scan, scans-per-insert grows with
+	// capacity instead of staying a small constant.
+	slotScans uint64
 }
 
 // newPendingTable builds a table. A nil clock defaults to time.Now; a
 // non-positive capacity or ttl falls back to the package defaults so a
 // mis-wired caller cannot silently create an unbounded or never-expiring
-// table.
+// table. Production sizes capacity with pendingCapacityFor.
 func newPendingTable(capacity int, ttl time.Duration, now func() time.Time) *pendingTable {
 	if now == nil {
 		now = time.Now
 	}
 	if capacity <= 0 {
-		capacity = pendingCap
+		capacity, _ = pendingCapacityFor(defaultMaxPacketRate)
 	}
 	if ttl <= 0 {
 		ttl = pendingTTL
 	}
 	return &pendingTable{
 		entries: make(map[pendingKey]time.Time),
-		cap:     capacity,
+		ring:    make([]pendingSlot, capacity),
 		ttl:     ttl,
 		now:     now,
 	}
@@ -199,41 +284,59 @@ func (t *pendingTable) insert(k pendingKey) {
 
 	now := t.now()
 
-	// Off the cap-pressure path, sweep expired entries at most once per
-	// pendingReapInterval purely to reclaim memory.
-	if now.Sub(t.lastReap) >= pendingReapInterval {
-		t.reapLocked(now)
-		t.lastReap = now
+	// Reclaim expired slots from the head. The ring is expiry-ordered, so this
+	// stops at the first unexpired slot — amortized O(1), since every slot is
+	// popped at most once.
+	for t.count > 0 && !now.Before(t.ring[t.head].exp) {
+		t.popHeadLocked()
 	}
 
-	if len(t.entries) >= t.cap {
-		// Reap first: at the cap, expired-but-unswept entries are free space.
-		t.reapLocked(now)
-		t.lastReap = now
-	}
-	if len(t.entries) >= t.cap {
-		// EVICTION POLICY — evict the OLDEST, do not refuse the NEW request.
-		//
-		// The alternative (drop new requests at the cap) is strictly worse
-		// here: an attacker who fills the table would lock out every NEW
-		// client until entries aged out, i.e. a total DHCP outage on the
-		// segment. Evicting the oldest degrades gracefully instead — new
-		// clients keep being served, and only the entries closest to expiry
-		// anyway lose their binding.
-		//
-		// Crucially, the choice does not trade away the security property.
-		// Eviction can only cause a legitimate reply to be DROPPED; it can
-		// never cause an unsolicited reply to be ACCEPTED. Both policies fail
-		// in the availability direction only, so the tie-break is which outage
-		// is smaller — and "new clients still work" beats "no client works".
-		// A client whose entry was evicted recovers on its next retransmission
-		// (RFC 2131 §4.1, same xid).
-		if t.evictOldestLocked() {
+	// Make room if still full. EVICTION POLICY — evict the OLDEST, do not
+	// refuse the NEW request.
+	//
+	// The alternative (drop new requests at the cap) is strictly worse here:
+	// an attacker who fills the table would lock out every NEW client until
+	// entries aged out, i.e. a total DHCP outage on the segment. Evicting the
+	// oldest degrades gracefully instead — new clients keep being served, and
+	// only the entries closest to expiry anyway lose their binding.
+	//
+	// Crucially, the choice does not trade away the security property.
+	// Eviction can only cause a legitimate reply to be DROPPED; it can never
+	// cause an unsolicited reply to be ACCEPTED. Both policies fail in the
+	// availability direction only, so the tie-break is which outage is smaller
+	// — and "new clients still work" beats "no client works". A client whose
+	// entry was evicted recovers on its next retransmission (RFC 2131 §4.1).
+	//
+	// This loop pops exactly one slot (count is at most the ring length, and
+	// one pop drops it below), so the at-cap path stays O(1).
+	for t.count >= len(t.ring) {
+		if t.popHeadLocked() {
 			t.evicted++
 		}
 	}
 
-	t.entries[k] = now.Add(t.ttl)
+	exp := now.Add(t.ttl)
+	t.entries[k] = exp
+	t.ring[(t.head+t.count)%len(t.ring)] = pendingSlot{key: k, exp: exp}
+	t.count++
+}
+
+// popHeadLocked removes the oldest ring slot and reports whether it removed a
+// LIVE map entry. A slot is stale (and its removal frees nothing in the map)
+// when the key was re-inserted after it: the map then holds a LATER expiry than
+// the slot, so the expiry comparison identifies the live slot exactly. Caller
+// holds mu.
+func (t *pendingTable) popHeadLocked() bool {
+	s := t.ring[t.head]
+	t.ring[t.head] = pendingSlot{} // drop the time.Time reference
+	t.head = (t.head + 1) % len(t.ring)
+	t.count--
+	t.slotScans++
+	if exp, ok := t.entries[s.key]; ok && exp.Equal(s.exp) {
+		delete(t.entries, s.key)
+		return true
+	}
+	return false
 }
 
 // matches reports whether a reply binds to an unexpired outstanding request.
@@ -275,8 +378,12 @@ func (t *pendingTable) evictions() uint64 {
 	return t.evicted
 }
 
-// size returns the current entry count (including not-yet-swept expired
-// entries). Test/diagnostic helper.
+// size returns the current entry count. Expired entries are reclaimed on the
+// next insert (the ring head is drained first), so on an idle relay this can
+// briefly include entries past their expiry; they are inert either way because
+// matches re-checks the expiry. Surfaced as RelayStats.PendingSize — occupancy
+// approaching capacity is the LEADING indicator that bindings are about to
+// start being evicted (#6603 review F3).
 func (t *pendingTable) size() int {
 	if t == nil {
 		return 0
@@ -286,34 +393,23 @@ func (t *pendingTable) size() int {
 	return len(t.entries)
 }
 
-// reapLocked deletes every expired entry. Caller holds mu.
-func (t *pendingTable) reapLocked(now time.Time) {
-	for k, exp := range t.entries {
-		if !now.Before(exp) {
-			delete(t.entries, k)
-		}
+// capacity returns the table's fixed entry ceiling.
+func (t *pendingTable) capacity() int {
+	if t == nil {
+		return 0
 	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.ring)
 }
 
-// evictOldestLocked removes the entry with the earliest expiry and reports
-// whether one was removed. Because every entry is inserted with the same ttl,
-// earliest-expiry is the same ordering as oldest-insertion. Caller holds mu.
-//
-// The O(n) scan runs only while the table is at capacity, which the #5670 rate
-// limiter keeps unreachable at the default packet rate.
-func (t *pendingTable) evictOldestLocked() bool {
-	var (
-		oldestKey pendingKey
-		oldestExp time.Time
-		found     bool
-	)
-	for k, exp := range t.entries {
-		if !found || exp.Before(oldestExp) {
-			oldestKey, oldestExp, found = k, exp, true
-		}
+// scans returns the number of ring slots examined by the expiry/eviction path.
+// Test probe for the O(1) invariant; see slotScans.
+func (t *pendingTable) scans() uint64 {
+	if t == nil {
+		return 0
 	}
-	if found {
-		delete(t.entries, oldestKey)
-	}
-	return found
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.slotScans
 }

--- a/pkg/dhcprelay/pending.go
+++ b/pkg/dhcprelay/pending.go
@@ -1,0 +1,319 @@
+package dhcprelay
+
+import (
+	"sync"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+)
+
+// Outstanding-request binding for relayed server replies (#6562).
+//
+// PROBLEM. The server-facing socket is bound (not connect()-ed) to giaddr:67,
+// so it accepts datagrams from ANY host that can route there. #4163 added a
+// source-IP allow-list, but a source IP is spoofable: an off-path attacker who
+// forges the configured server's address can inject an OFFER/ACK (hostile
+// gateway/DNS) or a NAK (forced client restart) at a client, because the relay
+// forwards any well-formed BOOTREPLY without ever asking whether it answers a
+// request the relay actually sent.
+//
+// FIX. Every request the relay forwards upstream records an entry here; a
+// reply is forwarded only if it matches one. That adds a 32-bit xid the
+// attacker must guess on top of the spoofed source IP, and pins the reply to
+// the client identity (chaddr) the request carried.
+//
+// KEYING — xid + chaddr, and deliberately nothing else. RFC 2131 §2 defines
+// 'xid' as "Transaction ID, a random number chosen by the client", and §4.1
+// gives its purpose: "The 'xid' field is used by the client to match incoming
+// DHCP messages with pending requests." That is precisely the association this
+// table needs, applied one hop earlier. The §4.3.1 Table 3 (fields in DHCP
+// messages sent by a server) then pins both halves of the key as server-echoed:
+// for DHCPOFFER/DHCPACK/DHCPNAK alike, 'xid' is "'xid' from client
+// DHCPDISCOVER/DHCPREQUEST message" and 'chaddr' is "'chaddr' from client
+// DHCPDISCOVER/DHCPREQUEST message". Both are therefore present on the request
+// AND echoed on the reply, which is exactly what a binding needs.
+//
+// Option 61 (client-identifier) is deliberately NOT part of the key even
+// though it is a stronger identity. RFC 6842 §2 records why: "[RFC2131] also
+// specifies that the server MUST NOT return the 'client identifier' option in
+// DHCPOFFER and DHCPACK messages", and only RFC 6842 §3 (2013) reversed that
+// to "the server MUST return the 'client identifier' option, unaltered, in its
+// response message". A server still on the original RFC 2131 behavior echoes
+// no option 61, so keying on it would drop every reply from that server — a
+// silent, total DHCP outage on the segment. xid+chaddr is the subset that
+// every conformant server echoes under BOTH revisions.
+//
+// A client with no valid hardware address may legitimately send an all-zero
+// chaddr (RFC 6842 §2 notes this case). Such clients still bind correctly:
+// the server echoes the zero chaddr, so the key round-trips. They simply lean
+// entirely on the xid for uniqueness, which is the pre-existing RFC 2131
+// matching rule and no weaker than what the client itself relies on.
+//
+// The ingress interface does not need to be part of the key: each relay
+// interface owns its own table (a field on interfaceRelay), so entries are
+// already scoped per-interface by construction.
+//
+// FAIL DIRECTION. This table gates live DHCP for real clients, so every path
+// that can drop a legitimate reply is counted and logged on interfaceRelay
+// (repliesDroppedNoRequest, pendingEvicted) — an over-strict binding must be
+// visible in `show services dhcp relay`, never silent.
+
+const (
+	// pendingTTL is how long a forwarded request stays bindable. It bounds the
+	// window in which a spoofed reply carrying a guessed xid would be accepted,
+	// so shorter is safer; it must still cover the worst-case server response
+	// time, because an entry that expires early drops a LEGITIMATE reply.
+	//
+	// 30s is chosen against RFC 2131 §4.1's client retransmission schedule:
+	// "the delay before the first retransmission SHOULD be 4 seconds
+	// randomized by the value of a uniform random number chosen from the range
+	// -1 to +1... The delay before the next retransmission SHOULD be 8
+	// seconds... The retransmission delay SHOULD be doubled with subsequent
+	// retransmissions up to a maximum of 64 seconds." 30s spans the 4s, 8s and
+	// 16s retransmissions, so a server slow enough to outrun the window has
+	// already prompted at least one client retransmission.
+	//
+	// That retransmission is what makes a too-short TTL self-healing, and it
+	// works whichever xid the client picks. §4.1 is explicit that the choice is
+	// open — "Selecting a new 'xid' for each retransmission is an
+	// implementation decision. A client may choose to reuse the same 'xid' or
+	// select a new 'xid' for each retransmitted message" — but either way the
+	// retransmission itself traverses this relay and inserts an entry under
+	// whatever xid it carries, and the server's answer to it echoes that same
+	// xid (§4.3.1 Table 3). The failure mode of a too-short TTL is therefore a
+	// bounded retry, not a stuck client.
+	pendingTTL = 30 * time.Second
+
+	// pendingCap bounds the table so it cannot become the remote
+	// memory-exhaustion vector it exists to prevent. It is a BACKSTOP, not the
+	// primary bound: the #5670 per-interface ingress rate limiter already caps
+	// the fill rate at maxPacketRate (default 100 pps), so steady-state
+	// occupancy is rate x pendingTTL = 100 x 30 = ~3000 entries at the default.
+	// 8192 leaves ~2.7x headroom over that, so a default-configured relay never
+	// reaches the cap and never evicts; only an operator who raised
+	// `overrides maximum-packet-rate` well past the default can reach it.
+	pendingCap = 8192
+
+	// pendingReapInterval bounds how often insert sweeps expired entries when
+	// the table is NOT under cap pressure. Expired entries are already inert
+	// for correctness (matches re-checks the expiry), so this only reclaims
+	// memory; doing it at most once a second keeps the O(n) sweep off the
+	// per-packet path.
+	pendingReapInterval = time.Second
+)
+
+// pendingKey identifies one outstanding client transaction. It is an
+// all-array, comparable struct so it can be a map key with no allocation and
+// no string building on the per-packet path.
+type pendingKey struct {
+	// xid is the RFC 2131 'xid' field. dhcpv4.TransactionID is [4]byte, so it
+	// is comparable as-is.
+	xid dhcpv4.TransactionID
+	// hlen is the significant length of chaddr. It participates in the key so a
+	// 6-byte Ethernet address cannot collide with a longer address that shares
+	// its first 6 bytes.
+	hlen uint8
+	// chaddr is the BOOTP client hardware address, zero-padded. dhcpv4.FromBytes
+	// clamps the parsed length to 16 (MaxHWAddrLen), which this array matches.
+	chaddr [16]byte
+}
+
+// pendingKeyFor derives the binding key from a DHCP message. It reads only
+// fields that RFC 2131 requires a server to echo, so the key computed from a
+// forwarded request equals the key computed from the reply that answers it.
+// The relay's own mutations (hops, giaddr, Option 82) do not touch either
+// field, so stamping a request does not change its key.
+func pendingKeyFor(pkt *dhcpv4.DHCPv4) pendingKey {
+	k := pendingKey{xid: pkt.TransactionID}
+	// Defensive cap: dhcpv4.FromBytes already clamps hwAddrLen to 16, but a
+	// packet built in-process (tests, future callers) is not bound by that.
+	n := len(pkt.ClientHWAddr)
+	if n > len(k.chaddr) {
+		n = len(k.chaddr)
+	}
+	copy(k.chaddr[:], pkt.ClientHWAddr[:n])
+	k.hlen = uint8(n)
+	return k
+}
+
+// pendingTable is a bounded, expiring set of outstanding relayed requests.
+//
+// It is written by the client-facing read loop and read by the server-facing
+// reply loop — two different goroutines within one relay session — so it is
+// mutex-guarded. The table lives on interfaceRelay rather than on the session,
+// so a session rebuild (#2347 ifindex drift / #3960 re-address) does NOT wipe
+// in-flight bindings and strand a client mid-transaction.
+type pendingTable struct {
+	mu      sync.Mutex
+	entries map[pendingKey]time.Time // key -> expiry
+	cap     int
+	ttl     time.Duration
+	now     func() time.Time
+
+	// lastReap is when the non-cap-pressure sweep last ran.
+	lastReap time.Time
+
+	// evicted counts entries removed by cap pressure (NOT ordinary expiry). It
+	// is surfaced through interfaceRelay.pendingEvicted; a nonzero value means
+	// the table is full and a legitimate reply may now be dropped, which is the
+	// signal an operator needs to raise the rate limit or investigate a flood.
+	evicted uint64
+}
+
+// newPendingTable builds a table. A nil clock defaults to time.Now; a
+// non-positive capacity or ttl falls back to the package defaults so a
+// mis-wired caller cannot silently create an unbounded or never-expiring
+// table.
+func newPendingTable(capacity int, ttl time.Duration, now func() time.Time) *pendingTable {
+	if now == nil {
+		now = time.Now
+	}
+	if capacity <= 0 {
+		capacity = pendingCap
+	}
+	if ttl <= 0 {
+		ttl = pendingTTL
+	}
+	return &pendingTable{
+		entries: make(map[pendingKey]time.Time),
+		cap:     capacity,
+		ttl:     ttl,
+		now:     now,
+	}
+}
+
+// insert records a forwarded request as bindable for ttl.
+//
+// It MUST be called BEFORE the request is written upstream: the reply loop
+// runs in a different goroutine, and a fast server on a local segment can
+// deliver its OFFER before a post-send insert has run — which would drop the
+// legitimate first reply of every exchange.
+//
+// A nil receiver is a no-op (see matches for the fail-closed rationale).
+func (t *pendingTable) insert(k pendingKey) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+
+	// Off the cap-pressure path, sweep expired entries at most once per
+	// pendingReapInterval purely to reclaim memory.
+	if now.Sub(t.lastReap) >= pendingReapInterval {
+		t.reapLocked(now)
+		t.lastReap = now
+	}
+
+	if len(t.entries) >= t.cap {
+		// Reap first: at the cap, expired-but-unswept entries are free space.
+		t.reapLocked(now)
+		t.lastReap = now
+	}
+	if len(t.entries) >= t.cap {
+		// EVICTION POLICY — evict the OLDEST, do not refuse the NEW request.
+		//
+		// The alternative (drop new requests at the cap) is strictly worse
+		// here: an attacker who fills the table would lock out every NEW
+		// client until entries aged out, i.e. a total DHCP outage on the
+		// segment. Evicting the oldest degrades gracefully instead — new
+		// clients keep being served, and only the entries closest to expiry
+		// anyway lose their binding.
+		//
+		// Crucially, the choice does not trade away the security property.
+		// Eviction can only cause a legitimate reply to be DROPPED; it can
+		// never cause an unsolicited reply to be ACCEPTED. Both policies fail
+		// in the availability direction only, so the tie-break is which outage
+		// is smaller — and "new clients still work" beats "no client works".
+		// A client whose entry was evicted recovers on its next retransmission
+		// (RFC 2131 §4.1, same xid).
+		if t.evictOldestLocked() {
+			t.evicted++
+		}
+	}
+
+	t.entries[k] = now.Add(t.ttl)
+}
+
+// matches reports whether a reply binds to an unexpired outstanding request.
+//
+// The entry is deliberately NOT consumed. One relayed request legitimately
+// draws MULTIPLE replies: the relay fans each request out to EVERY server in
+// the group, so an N-server group answers one DISCOVER with N OFFERs. On top
+// of that, RFC 2131 §4.4.1 states "The DHCPREQUEST message contains the same
+// 'xid' as the DHCPOFFER message", so the whole SELECTING exchange
+// (DISCOVER/OFFER/REQUEST/ACK) shares one xid and the same binding must also
+// admit the ACK/NAK. Consuming on first match would drop every reply after
+// the first and silently break multi-server redundancy.
+//
+// A nil receiver returns false (fail-closed). Production wires the table where
+// interfaceRelay is built, so nil means a caller was mis-wired; failing closed
+// makes that a loud, counted, immediately visible outage rather than a silent
+// loss of the binding this file exists to enforce — the same posture as the
+// #4163 empty-allow-set rule.
+func (t *pendingTable) matches(k pendingKey) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	exp, ok := t.entries[k]
+	if !ok {
+		return false
+	}
+	return t.now().Before(exp)
+}
+
+// evictions returns the cap-pressure eviction count.
+func (t *pendingTable) evictions() uint64 {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.evicted
+}
+
+// size returns the current entry count (including not-yet-swept expired
+// entries). Test/diagnostic helper.
+func (t *pendingTable) size() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.entries)
+}
+
+// reapLocked deletes every expired entry. Caller holds mu.
+func (t *pendingTable) reapLocked(now time.Time) {
+	for k, exp := range t.entries {
+		if !now.Before(exp) {
+			delete(t.entries, k)
+		}
+	}
+}
+
+// evictOldestLocked removes the entry with the earliest expiry and reports
+// whether one was removed. Because every entry is inserted with the same ttl,
+// earliest-expiry is the same ordering as oldest-insertion. Caller holds mu.
+//
+// The O(n) scan runs only while the table is at capacity, which the #5670 rate
+// limiter keeps unreachable at the default packet rate.
+func (t *pendingTable) evictOldestLocked() bool {
+	var (
+		oldestKey pendingKey
+		oldestExp time.Time
+		found     bool
+	)
+	for k, exp := range t.entries {
+		if !found || exp.Before(oldestExp) {
+			oldestKey, oldestExp, found = k, exp, true
+		}
+	}
+	if found {
+		delete(t.entries, oldestKey)
+	}
+	return found
+}

--- a/pkg/dhcprelay/pending.go
+++ b/pkg/dhcprelay/pending.go
@@ -196,6 +196,17 @@ func pendingKeyFor(pkt *dhcpv4.DHCPv4) pendingKey {
 type pendingSlot struct {
 	key pendingKey
 	exp time.Time
+	// gen identifies WHICH insertion of this key the slot represents. When a
+	// key is re-inserted, the map moves to the new generation and every older
+	// slot becomes stale. See pendingEntry.gen.
+	gen uint64
+}
+
+// pendingEntry is the live state for one key: its expiry, and the generation
+// of the ring slot that owns it.
+type pendingEntry struct {
+	exp time.Time
+	gen uint64
 }
 
 // pendingTable is a bounded, expiring set of outstanding relayed requests.
@@ -225,12 +236,21 @@ type pendingSlot struct {
 // either structure past the cap.
 type pendingTable struct {
 	mu      sync.Mutex
-	entries map[pendingKey]time.Time // key -> expiry
-	ring    []pendingSlot            // fixed length == capacity; expiry-ordered
-	head    int                      // index of the oldest slot
-	count   int                      // slots in use
+	entries map[pendingKey]pendingEntry // key -> expiry + owning generation
+	ring    []pendingSlot               // fixed length == capacity; expiry-ordered
+	head    int                         // index of the oldest slot
+	count   int                         // slots in use
 	ttl     time.Duration
 	now     func() time.Time
+
+	// nextGen hands out slot generations. It makes slot identity EXACT rather
+	// than inferring it from the expiry: two inserts of the same key can
+	// receive the SAME expiry (time.Now() is not guaranteed to advance between
+	// two calls, and a frozen test clock never does), and comparing expiries
+	// would then treat the older slot as the live one — popping it at capacity
+	// would delete a binding that a newer slot still owns, silently losing a
+	// legitimate reply. Generations cannot collide.
+	nextGen uint64
 
 	// evicted counts entries removed by CAP PRESSURE (not by ordinary expiry).
 	// It is surfaced through interfaceRelay.pendingEvicted; a nonzero value
@@ -260,7 +280,7 @@ func newPendingTable(capacity int, ttl time.Duration, now func() time.Time) *pen
 		ttl = pendingTTL
 	}
 	return &pendingTable{
-		entries: make(map[pendingKey]time.Time),
+		entries: make(map[pendingKey]pendingEntry),
 		ring:    make([]pendingSlot, capacity),
 		ttl:     ttl,
 		now:     now,
@@ -285,8 +305,14 @@ func (t *pendingTable) insert(k pendingKey) {
 	now := t.now()
 
 	// Reclaim expired slots from the head. The ring is expiry-ordered, so this
-	// stops at the first unexpired slot — amortized O(1), since every slot is
-	// popped at most once.
+	// stops at the first unexpired slot.
+	//
+	// COST: amortized O(1) — every slot is pushed once and popped once — but
+	// the WORST CASE for a single call is one full drain of up to `capacity`
+	// slots, when the first insert after a long idle period finds everything
+	// expired. That is bounded, happens at most once per idle period (the next
+	// insert finds an empty ring), and is not the per-packet repeat the
+	// pre-ring implementation had. It is NOT strict O(1); do not claim it is.
 	for t.count > 0 && !now.Before(t.ring[t.head].exp) {
 		t.popHeadLocked()
 	}
@@ -315,24 +341,37 @@ func (t *pendingTable) insert(k pendingKey) {
 		}
 	}
 
-	exp := now.Add(t.ttl)
-	t.entries[k] = exp
-	t.ring[(t.head+t.count)%len(t.ring)] = pendingSlot{key: k, exp: exp}
+	t.pushLocked(k, now.Add(t.ttl))
+}
+
+// pushLocked records one key with an explicit expiry, assigning it a fresh
+// generation. Callers MUST push in non-decreasing expiry order so the ring
+// stays expiry-ordered, and MUST have already made room. Caller holds mu.
+func (t *pendingTable) pushLocked(k pendingKey, exp time.Time) {
+	gen := t.nextGen
+	t.nextGen++
+	t.entries[k] = pendingEntry{exp: exp, gen: gen}
+	t.ring[(t.head+t.count)%len(t.ring)] = pendingSlot{key: k, exp: exp, gen: gen}
 	t.count++
 }
 
 // popHeadLocked removes the oldest ring slot and reports whether it removed a
 // LIVE map entry. A slot is stale (and its removal frees nothing in the map)
-// when the key was re-inserted after it: the map then holds a LATER expiry than
-// the slot, so the expiry comparison identifies the live slot exactly. Caller
-// holds mu.
+// when the key was re-inserted after it: the map then holds a LATER GENERATION
+// than the slot.
+//
+// Identity is the generation, NOT the expiry. Two inserts of the same key can
+// carry identical expiries (nothing guarantees time.Now() advances between two
+// calls, and a frozen test clock never does); comparing expiries would then
+// match the OLDER slot and delete a binding the newer slot still owns — a
+// silently lost reply. Caller holds mu.
 func (t *pendingTable) popHeadLocked() bool {
 	s := t.ring[t.head]
 	t.ring[t.head] = pendingSlot{} // drop the time.Time reference
 	t.head = (t.head + 1) % len(t.ring)
 	t.count--
 	t.slotScans++
-	if exp, ok := t.entries[s.key]; ok && exp.Equal(s.exp) {
+	if e, ok := t.entries[s.key]; ok && e.gen == s.gen {
 		delete(t.entries, s.key)
 		return true
 	}
@@ -361,11 +400,77 @@ func (t *pendingTable) matches(k pendingKey) bool {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	exp, ok := t.entries[k]
+	e, ok := t.entries[k]
 	if !ok {
 		return false
 	}
-	return t.now().Before(exp)
+	return t.now().Before(e.exp)
+}
+
+// snapshot returns the live, unexpired bindings in expiry order (oldest
+// first), for migration into a replacement table.
+//
+// WHY THIS EXISTS (#6603 re-review). maxPacketRate — and every other field in
+// relaySpec — participates in relaySpec.equal(), so ANY day-2 config change to
+// a relay group stops the relay and builds a replacement with a brand-new
+// table. Without migration every outstanding binding is destroyed at that
+// instant, and because the replacement rebinds the SAME giaddr:67, replies for
+// pre-reload requests still arrive — and are then dropped by the binding gate.
+// Pre-#6562 those replies were forwarded, so that is a straight availability
+// regression.
+//
+// It is sharpest for maximum-packet-rate: raising it is the documented remedy
+// for a busy segment, so an operator following the docs DURING a boot storm
+// would flush every in-flight binding and trigger the retry storm this file
+// exists to prevent.
+//
+// Expired entries are excluded, and each entry keeps its ORIGINAL expiry when
+// adopted — a config reload must not extend the binding window, which would
+// hand an attacker a longer guessing window for free.
+func (t *pendingTable) snapshot() []pendingSlot {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	live := make([]pendingSlot, 0, t.count)
+	for i := 0; i < t.count; i++ {
+		s := t.ring[(t.head+i)%len(t.ring)]
+		// Skip stale slots (a newer generation owns the key) and expired ones.
+		if e, ok := t.entries[s.key]; !ok || e.gen != s.gen {
+			continue
+		}
+		if !now.Before(s.exp) {
+			continue
+		}
+		live = append(live, s)
+	}
+	return live
+}
+
+// adopt installs migrated bindings into a freshly-built table, preserving each
+// one's original expiry. Slots MUST arrive in expiry order (snapshot's output
+// is), which keeps the ring's expiry ordering intact.
+//
+// If the replacement is SMALLER — the operator lowered maximum-packet-rate —
+// the excess cannot be kept. The OLDEST are dropped (the same policy the
+// steady-state path uses, and the ones closest to expiry anyway) and each is
+// COUNTED as an eviction, so a shrink shows up in PendingEvicted instead of
+// silently discarding bindings.
+func (t *pendingTable) adopt(slots []pendingSlot) {
+	if t == nil || len(slots) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if capacity := len(t.ring); len(slots) > capacity {
+		t.evicted += uint64(len(slots) - capacity)
+		slots = slots[len(slots)-capacity:] // keep the NEWEST (longest-lived)
+	}
+	for _, s := range slots {
+		t.pushLocked(s.key, s.exp)
+	}
 }
 
 // evictions returns the cap-pressure eviction count.
@@ -378,13 +483,38 @@ func (t *pendingTable) evictions() uint64 {
 	return t.evicted
 }
 
-// size returns the current entry count. Expired entries are reclaimed on the
-// next insert (the ring head is drained first), so on an idle relay this can
-// briefly include entries past their expiry; they are inert either way because
-// matches re-checks the expiry. Surfaced as RelayStats.PendingSize — occupancy
-// approaching capacity is the LEADING indicator that bindings are about to
-// start being evicted (#6603 review F3).
-func (t *pendingTable) size() int {
+// occupancy returns the number of RING SLOTS in use — the quantity that is
+// actually compared against capacity, and therefore the one that predicts
+// eviction. Surfaced as RelayStats.PendingSize.
+//
+// It is deliberately NOT len(entries), which diverges from ring pressure in
+// both directions and would make the gauge lie:
+//
+//   - too HIGH on an idle relay: expired entries are reclaimed lazily, on the
+//     next insert, so len(entries) can sit above the real live set for as long
+//     as the relay is quiet;
+//   - too LOW under ordinary duplicate inserts: a retransmission consumes a
+//     ring slot without adding a map entry, so a capacity-4 ring holding
+//     A,B,B,B reports len(entries)==2 while the very next insert must evict
+//     live A. Eviction would begin while the displayed ratio still looked
+//     comfortable — the exact opposite of the documented contract.
+//
+// Use liveEntries for the count of distinct bindable keys.
+func (t *pendingTable) occupancy() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+// liveEntries returns the number of distinct keys currently in the map. Expired
+// entries are reclaimed lazily (on the next insert), so on an idle relay this
+// can include entries past their expiry; they are inert either way because
+// matches re-checks the expiry. Diagnostic/test accessor — the operator-facing
+// gauge is occupancy.
+func (t *pendingTable) liveEntries() int {
 	if t == nil {
 		return 0
 	}

--- a/pkg/dhcprelay/pending.go
+++ b/pkg/dhcprelay/pending.go
@@ -304,15 +304,35 @@ func (t *pendingTable) insert(k pendingKey) {
 
 	now := t.now()
 
+	// FULL-DRAIN FAST PATH. The ring is expiry-ordered, so if even the NEWEST
+	// slot has expired then EVERY slot has. Without this, the loop below would
+	// pop the whole ring one slot at a time — up to pendingCapMax (131072)
+	// iterations, each with a map lookup and delete, all under the mutex and on
+	// the client-facing packet path — on the first insert after an idle period.
+	// That is a ~10ms stall that also blocks the reply loop. Detecting it costs
+	// one slot read, and the reset itself is O(1): head/count go to zero and the
+	// map is replaced wholesale rather than deleted key by key.
+	//
+	// Slots at or beyond count are never read (pushLocked overwrites a slot
+	// before count covers it, and snapshot bounds its walk by count), so leaving
+	// the stale contents in place is safe and keeps this genuinely constant-time.
+	if t.count > 0 && !now.Before(t.ring[(t.head+t.count-1)%len(t.ring)].exp) {
+		t.slotScans++ // the one probe read above
+		t.head = 0
+		t.count = 0
+		t.entries = make(map[pendingKey]pendingEntry)
+	}
+
 	// Reclaim expired slots from the head. The ring is expiry-ordered, so this
 	// stops at the first unexpired slot.
 	//
-	// COST: amortized O(1) — every slot is pushed once and popped once — but
-	// the WORST CASE for a single call is one full drain of up to `capacity`
-	// slots, when the first insert after a long idle period finds everything
-	// expired. That is bounded, happens at most once per idle period (the next
-	// insert finds an empty ring), and is not the per-packet repeat the
-	// pre-ring implementation had. It is NOT strict O(1); do not claim it is.
+	// COST: amortized O(1) — every slot is pushed once and popped once. The
+	// worst case for a single call used to be a full drain of up to `capacity`
+	// slots; the fast path above now takes that case in constant time, so what
+	// remains here is a PARTIAL drain, bounded by the number of slots that
+	// expired while at least one newer slot did not. It is still not STRICT
+	// O(1) — do not claim it is — but there is no longer an unbounded-looking
+	// stall on the packet path.
 	for t.count > 0 && !now.Before(t.ring[t.head].exp) {
 		t.popHeadLocked()
 	}
@@ -458,15 +478,27 @@ func (t *pendingTable) snapshot() []pendingSlot {
 // steady-state path uses, and the ones closest to expiry anyway) and each is
 // COUNTED as an eviction, so a shrink shows up in PendingEvicted instead of
 // silently discarding bindings.
+//
+// The bound is the REMAINING room, not the raw capacity. Production always
+// adopts into a table built moments earlier, so the two are the same; but
+// pushLocked's contract is that the caller has already made room, and bounding
+// by capacity alone would silently break it for a non-empty destination —
+// count would run past the ring length and the modular index would overwrite
+// live slots. Bounding by room makes adopt correct for any destination at no
+// cost to the production path.
 func (t *pendingTable) adopt(slots []pendingSlot) {
 	if t == nil || len(slots) == 0 {
 		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if capacity := len(t.ring); len(slots) > capacity {
-		t.evicted += uint64(len(slots) - capacity)
-		slots = slots[len(slots)-capacity:] // keep the NEWEST (longest-lived)
+	room := len(t.ring) - t.count
+	if room < 0 {
+		room = 0 // unreachable while count <= capacity holds; never slice past len
+	}
+	if len(slots) > room {
+		t.evicted += uint64(len(slots) - room)
+		slots = slots[len(slots)-room:] // keep the NEWEST (longest-lived)
 	}
 	for _, s := range slots {
 		t.pushLocked(s.key, s.exp)

--- a/pkg/dhcprelay/pending.go
+++ b/pkg/dhcprelay/pending.go
@@ -103,6 +103,18 @@ const (
 	// the clamp, Apply logs a startup Warn naming the reduced window, and
 	// PendingSize/PendingEvicted expose the runtime truth.
 	pendingCapMax = 131072
+
+	// maxDrainPerInsert bounds how many expired slots one insert reclaims.
+	//
+	// insert needs exactly ONE free slot, so draining more than a small
+	// constant per call buys nothing and only lengthens the time the mutex is
+	// held on the client-facing packet path. Leftover expired slots are inert
+	// (matches re-checks the expiry, occupancy excludes them) and are reclaimed
+	// by subsequent inserts: each drains up to this many while the eviction
+	// loop frees one more, so a backlog clears at ~65 slots per admitted
+	// packet — a full 131072-slot ring inside a few seconds at the default
+	// rate, without ever stalling a single packet.
+	maxDrainPerInsert = 64
 )
 
 // pendingCapacityFor sizes the outstanding-request table from the interface's
@@ -323,18 +335,25 @@ func (t *pendingTable) insert(k pendingKey) {
 		t.entries = make(map[pendingKey]pendingEntry)
 	}
 
-	// Reclaim expired slots from the head. The ring is expiry-ordered, so this
-	// stops at the first unexpired slot.
+	// Reclaim expired slots from the head, BOUNDED. The ring is expiry-ordered,
+	// so this stops at the first unexpired slot — but the fast path above only
+	// covers the case where EVERY slot has expired. The adjacent case it does
+	// not cover is the expensive one: capacity-1 slots expired with the newest
+	// still live (a quiet period followed by a single late request). There the
+	// probe fails and an unbounded loop would pop ~131071 slots one at a time,
+	// each with a map lookup and delete, under the mutex on the packet path —
+	// the same multi-millisecond stall, just behind a narrower trigger.
 	//
-	// COST: amortized O(1) — every slot is pushed once and popped once. The
-	// worst case for a single call used to be a full drain of up to `capacity`
-	// slots; the fast path above now takes that case in constant time, so what
-	// remains here is a PARTIAL drain, bounded by the number of slots that
-	// expired while at least one newer slot did not. It is still not STRICT
-	// O(1) — do not claim it is — but there is no longer an unbounded-looking
-	// stall on the packet path.
-	for t.count > 0 && !now.Before(t.ring[t.head].exp) {
+	// insert needs exactly ONE free slot, so reclaiming more than a small
+	// constant per call buys nothing. Whatever is left stays expired-but-inert
+	// (matches re-checks the expiry, occupancy excludes it) and is reclaimed by
+	// later inserts, which drain maxDrainPerInsert each while the eviction loop
+	// below frees one more. Per-call work is therefore bounded by a constant,
+	// and the backlog still clears promptly.
+	drained := 0
+	for t.count > 0 && drained < maxDrainPerInsert && !now.Before(t.ring[t.head].exp) {
 		t.popHeadLocked()
+		drained++
 	}
 
 	// Make room if still full. EVICTION POLICY — evict the OLDEST, do not
@@ -355,6 +374,21 @@ func (t *pendingTable) insert(k pendingKey) {
 	//
 	// This loop pops exactly one slot (count is at most the ring length, and
 	// one pop drops it below), so the at-cap path stays O(1).
+	//
+	// Every pop here displaces an UNEXPIRED binding, so counting each one as a
+	// cap-pressure eviction is exact — no expiry re-check is needed, and adding
+	// one would be dead code. Proof, given the two reclaim steps above:
+	//
+	//	this loop needs count >= capacity to run at all
+	//	  - fast path fired      -> count == 0            -> loop is a no-op
+	//	  - drain popped d > 0   -> count = cap-d < cap   -> loop is a no-op
+	//	  - drain popped d == 0  -> the head is UNEXPIRED (that is why it stopped)
+	//
+	// The bound cannot change this: stopping at d == maxDrainPerInsert would
+	// need cap-64 >= cap. So whenever this loop runs, the head is unexpired by
+	// construction. If either reclaim step above is ever removed, that ceases to
+	// hold and PendingEvicted — an alarm an operator is told to read as damage
+	// in progress — would start firing on a merely idle relay.
 	for t.count >= len(t.ring) {
 		if t.popHeadLocked() {
 			t.evicted++
@@ -479,26 +513,39 @@ func (t *pendingTable) snapshot() []pendingSlot {
 // COUNTED as an eviction, so a shrink shows up in PendingEvicted instead of
 // silently discarding bindings.
 //
-// The bound is the REMAINING room, not the raw capacity. Production always
-// adopts into a table built moments earlier, so the two are the same; but
-// pushLocked's contract is that the caller has already made room, and bounding
-// by capacity alone would silently break it for a non-empty destination —
-// count would run past the ring length and the modular index would overwrite
-// live slots. Bounding by room makes adopt correct for any destination at no
-// cost to the production path.
+// The destination MUST be empty — see the assertion in the body. adopt appends
+// rather than merging, so it cannot preserve expiry ordering against
+// pre-existing entries, and every other operation depends on that ordering.
 func (t *pendingTable) adopt(slots []pendingSlot) {
 	if t == nil || len(slots) == 0 {
 		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	room := len(t.ring) - t.count
-	if room < 0 {
-		room = 0 // unreachable while count <= capacity holds; never slice past len
+	// PRECONDITION: the destination must be EMPTY.
+	//
+	// adopt appends; it does not merge. Migrated expiries are whatever the old
+	// table held, so appending them onto a non-empty ring can place an EARLIER
+	// expiry after a later one and break the expiry ordering every other
+	// operation depends on — the full-drain probe would read a stale-but-newer
+	// tail slot and wrongly conclude the whole ring had expired, wiping live
+	// destination bindings, and both the head drain and occupancy's binary
+	// search would mis-locate the boundary.
+	//
+	// This is a programmer-error assertion, not a runtime condition: the sole
+	// production caller (Apply's phase-2.5 migration) adopts into a table built
+	// moments earlier and never launched, so it cannot fire. Failing loudly
+	// here is deliberate — the alternative is silent corruption of the
+	// structure that decides which replies reach clients. An ordered merge
+	// would make the general case work, but no caller needs it and it is not
+	// worth the complexity on a security-relevant path.
+	if t.count != 0 {
+		panic("dhcprelay: pendingTable.adopt requires an empty destination " +
+			"(appending would break the ring's expiry ordering)")
 	}
-	if len(slots) > room {
-		t.evicted += uint64(len(slots) - room)
-		slots = slots[len(slots)-room:] // keep the NEWEST (longest-lived)
+	if capacity := len(t.ring); len(slots) > capacity {
+		t.evicted += uint64(len(slots) - capacity)
+		slots = slots[len(slots)-capacity:] // keep the NEWEST (longest-lived)
 	}
 	for _, s := range slots {
 		t.pushLocked(s.key, s.exp)
@@ -522,14 +569,23 @@ func (t *pendingTable) evictions() uint64 {
 // It is deliberately NOT len(entries), which diverges from ring pressure in
 // both directions and would make the gauge lie:
 //
-//   - too HIGH on an idle relay: expired entries are reclaimed lazily, on the
-//     next insert, so len(entries) can sit above the real live set for as long
-//     as the relay is quiet;
 //   - too LOW under ordinary duplicate inserts: a retransmission consumes a
 //     ring slot without adding a map entry, so a capacity-4 ring holding
 //     A,B,B,B reports len(entries)==2 while the very next insert must evict
 //     live A. Eviction would begin while the displayed ratio still looked
 //     comfortable — the exact opposite of the documented contract.
+//   - too HIGH on an idle relay: expired entries are reclaimed lazily.
+//
+// The raw ring `count` is not right either, and for the SAME false-high
+// reason: expired slots stay counted until some later insert reclaims them, so
+// an idle full table would report capacity/capacity even though the very next
+// insert reclaims the lot and evicts nothing. An operator told to alert on the
+// ratio would be paged by a relay that is simply quiet.
+//
+// So: unexpired ring slots. The expired ones form a contiguous PREFIX (the ring
+// is expiry-ordered), so the boundary is a binary search rather than a walk —
+// O(log capacity) under the mutex, which matters because this is read by
+// Stats() while the packet path is running.
 //
 // Use liveEntries for the count of distinct bindable keys.
 func (t *pendingTable) occupancy() int {
@@ -538,7 +594,23 @@ func (t *pendingTable) occupancy() int {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.count
+	return t.count - t.expiredPrefixLocked(t.now())
+}
+
+// expiredPrefixLocked returns how many slots at the head have expired. The ring
+// is expiry-ordered, so expired slots are a contiguous prefix and the first
+// unexpired index can be found by binary search. Caller holds mu.
+func (t *pendingTable) expiredPrefixLocked(now time.Time) int {
+	lo, hi := 0, t.count
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if now.Before(t.ring[(t.head+mid)%len(t.ring)].exp) {
+			hi = mid // unexpired: the boundary is at or before mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo
 }
 
 // liveEntries returns the number of distinct keys currently in the map. Expired

--- a/pkg/dhcprelay/pending.go
+++ b/pkg/dhcprelay/pending.go
@@ -110,10 +110,12 @@ const (
 	// constant per call buys nothing and only lengthens the time the mutex is
 	// held on the client-facing packet path. Leftover expired slots are inert
 	// (matches re-checks the expiry, occupancy excludes them) and are reclaimed
-	// by subsequent inserts: each drains up to this many while the eviction
-	// loop frees one more, so a backlog clears at ~65 slots per admitted
-	// packet — a full 131072-slot ring inside a few seconds at the default
-	// rate, without ever stalling a single packet.
+	// by subsequent inserts: each drains up to this many and then adds one, so
+	// the raw ring count falls by 63 per admitted packet. (NOT 65 — after any
+	// positive drain `count < capacity`, so the eviction loop below cannot run
+	// and frees nothing; see its early return.) A full 131072-slot ring still
+	// clears inside a few seconds at the default rate, without ever stalling a
+	// single packet.
 	maxDrainPerInsert = 64
 )
 

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -870,6 +870,11 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 	m.mu.Lock()
 
 	var toStop []*interfaceRelay // removed or changed: tear down
+	// replaced maps an interface name to the relay being torn down BECAUSE ITS
+	// SPEC CHANGED (not one being removed). Its outstanding-request bindings
+	// are migrated into the replacement once it has fully stopped (#6562) —
+	// see the phase-2.5 loop below.
+	replaced := make(map[string]*interfaceRelay)
 	// Remove relays that are no longer desired, or whose spec changed. A
 	// changed relay is removed here and re-added in the start loop below.
 	for name, ir := range m.relays {
@@ -884,6 +889,7 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 		if !ir.spec.equal(d.spec) {
 			toStop = append(toStop, ir)
 			delete(m.relays, name)
+			replaced[name] = ir
 			slog.Info("dhcp-relay: restarting (config changed)",
 				"interface", name,
 				"old_servers", ir.spec.servers, "new_servers", d.spec.servers,
@@ -949,6 +955,37 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 		<-ir.done
 	}
 
+	// Phase 2.5 (outside lock, AFTER the join): migrate outstanding-request
+	// bindings from each replaced relay into its replacement (#6562).
+	//
+	// Ordering is load-bearing. The old relay's goroutines are fully joined
+	// above, so its table is quiescent and the snapshot is complete; and the
+	// replacement has not been launched yet, so nothing is concurrently
+	// inserting into the destination. Snapshotting in phase 1 instead would
+	// miss every request relayed between the decision and the actual stop.
+	//
+	// Without this, ANY day-2 change to a relay group (servers,
+	// always-broadcast, hop count, trust-option-82, packet rate) destroys every
+	// in-flight binding, and because the replacement rebinds the SAME
+	// giaddr:67, replies for pre-reload requests still arrive and are then
+	// dropped — an availability regression against pre-#6562 behavior. It bites
+	// hardest for maximum-packet-rate, whose documented remedy is to raise it
+	// on a busy segment: doing that mid-boot-storm would flush every binding.
+	for _, s := range toStart {
+		old, ok := replaced[s.ir.ifaceName]
+		if !ok {
+			continue
+		}
+		carried := old.pending.snapshot()
+		s.ir.pending.adopt(carried)
+		if len(carried) > 0 {
+			slog.Info("dhcp-relay: carried outstanding request bindings across restart",
+				"interface", s.ir.ifaceName,
+				"bindings", len(carried),
+				"new_capacity", s.ir.pending.capacity())
+		}
+	}
+
 	// Phase 3 (outside lock): launch the new/restarted relays.
 	for _, s := range toStart {
 		go func(relay *interfaceRelay, rctx context.Context, servers []*net.UDPAddr) {
@@ -997,7 +1034,7 @@ func (m *Manager) Stats() []RelayStats {
 			RepliesDroppedNoRequest:      ir.repliesDroppedNoRequest.Load(),
 			RepliesDroppedForceRenew:     ir.repliesDroppedForceRenew.Load(),
 			PendingEvicted:               ir.pending.evictions(),
-			PendingSize:                  uint64(ir.pending.size()),
+			PendingSize:                  uint64(ir.pending.occupancy()),
 			PendingCapacity:              uint64(ir.pending.capacity()),
 			RepliesL2Unicast:             ir.repliesL2Unicast.Load(),
 			RepliesUnicastCiaddr:         ir.repliesUnicastCiaddr.Load(),

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -137,10 +137,17 @@ func relayBurstFor(rate int) int {
 // maximum so the buffer is never the truncation point (#3012).
 const readBufSize = 65535
 
-// messageTypeForceRenew is the DHCPFORCERENEW message type (RFC 3203, §3.1).
-// The insomniacslk/dhcp library only enumerates message types 1-8, so the
-// type-9 value is defined locally. A server sends FORCERENEW to a client that
-// already holds a lease to force it back into the RENEWING state.
+// messageTypeForceRenew is the DHCPFORCERENEW message type. RFC 3203 §4
+// (Message layout) defines it — "DHCP option 53 (DHCP message type) is extended
+// with a new value: DHCPFORCERENEW (9)" — and §5 (IANA Considerations) records
+// the assignment. (An earlier comment here cited "§3.1"; §3 is the extended
+// DHCP state diagram and has no §3.1.) The insomniacslk/dhcp library only
+// enumerates message types 1-8, so the type-9 value is defined locally.
+//
+// A server sends FORCERENEW to a client that already holds a lease to force it
+// back into the RENEWING state. This relay recognizes the type in order to
+// REFUSE it (#6562) — see the reply switch in handleServerResponses for the
+// RFC 3203 §6 / RFC 3118 rationale.
 const messageTypeForceRenew = dhcpv4.MessageType(9)
 
 // startupRetryInterval is how long runRelay waits between attempts to resolve
@@ -242,6 +249,35 @@ type RelayStats struct {
 	// an unlisted source IP — either way it MUST be visible, not silent.
 	RepliesDroppedUnknownServer uint64
 
+	// RepliesDroppedNoRequest counts server replies dropped because they do not
+	// bind to an outstanding relayed request (#6562). The #4163 source-IP
+	// allow-list is spoofable, so a reply must additionally match a request the
+	// relay actually forwarded (xid + chaddr, see pending.go). A nonzero value
+	// means either an injection attempt that guessed/spoofed its way past the
+	// source check, or a LEGITIMATE reply that arrived outside the binding
+	// window — the second is a client-visible DHCP failure, so this counter
+	// MUST be watched, not assumed hostile.
+	RepliesDroppedNoRequest uint64
+
+	// RepliesDroppedForceRenew counts DHCPFORCERENEW messages refused by the
+	// relay (#6562). RFC 3203 §6 makes RFC 3118 authentication of FORCERENEW a
+	// MUST, and a relay holds no RFC 3118 key material, so it cannot discharge
+	// that MUST — it refuses rather than forwarding an unverifiable
+	// reconfigure command at its clients. A nonzero value means a server (or a
+	// spoofer) is sending FORCERENEW to relayed clients; leases still renew
+	// normally at T1/T2, and RFC 3203 §2.2 defines the server's retransmission
+	// behavior when a FORCERENEW is not answered.
+	RepliesDroppedForceRenew uint64
+
+	// PendingEvicted counts outstanding-request entries dropped by CAP PRESSURE
+	// on the #6562 pending table (not by ordinary expiry). The #5670 rate
+	// limiter keeps the table far below its cap at the default packet rate, so
+	// a nonzero value means the relay is under a request flood (or
+	// `overrides maximum-packet-rate` is set far above the default) and
+	// legitimate replies may now be dropped for want of a binding. It is the
+	// early-warning signal that pairs with RepliesDroppedNoRequest.
+	PendingEvicted uint64
+
 	// Reply-delivery breakdown (#2076). These distinguish WHY a reply was
 	// broadcast vs L2-unicast so an L2/CAP_NET_RAW/driver/MTU regression is
 	// observable in operations. RepliesBroadcastL2Fallback is the one to
@@ -336,6 +372,26 @@ type interfaceRelay struct {
 	// (#4163). It is the observability signal for a rogue-reply injection
 	// attempt (or a multi-homed server unicasting from an unlisted source IP).
 	repliesDroppedUnknownServer atomic.Uint64
+
+	// pending is the bounded outstanding-request table (#6562): the
+	// client-facing loop records every request it forwards upstream, and the
+	// server-facing loop forwards a reply only if it binds to one. It lives
+	// here rather than on the session so a session rebuild (#2347 ifindex
+	// drift / #3960 re-address) does NOT wipe in-flight bindings and strand a
+	// client mid-transaction. Always non-nil in production (set where this
+	// struct is built); a nil table fails CLOSED — see pendingTable.matches.
+	pending *pendingTable
+
+	// repliesDroppedNoRequest counts server replies dropped because they bind
+	// to no outstanding request (#6562). Observability for a spoofed-source
+	// injection that got past #4163 — and, just as importantly, for an
+	// over-strict binding dropping legitimate replies.
+	repliesDroppedNoRequest atomic.Uint64
+
+	// repliesDroppedForceRenew counts DHCPFORCERENEW messages refused (#6562).
+	// A relay cannot perform the RFC 3118 validation RFC 3203 §6 requires, so
+	// it does not forward an unverifiable reconfigure command at its clients.
+	repliesDroppedForceRenew atomic.Uint64
 
 	// spec is the desired-config snapshot this relay was started with. Apply
 	// (#2348) compares it against the new desired spec to detect a changed
@@ -840,6 +896,11 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 			maxHopCount:     resolveMaxHopCount(d.spec.maxHopCount),
 			trustOption82:   d.spec.trustOption82,
 			maxPacketRate:   resolveMaxPacketRate(d.spec.maxPacketRate),
+			// #6562: the outstanding-request table that binds replies to
+			// requests. Built here, with the relay, so it survives session
+			// rebuilds; it shares the manager clock seam with the #5670 token
+			// bucket so tests drive expiry deterministically.
+			pending: newPendingTable(pendingCap, pendingTTL, m.now),
 		}
 		m.relays[name] = ir
 		toStart = append(toStart, struct {
@@ -888,6 +949,9 @@ func (m *Manager) Stats() []RelayStats {
 			RequestsUntrustedGiaddrReset: ir.requestsUntrustedGiaddrReset.Load(),
 			RequestsDroppedRateLimit:     ir.requestsDroppedRateLimit.Load(),
 			RepliesDroppedUnknownServer:  ir.repliesDroppedUnknownServer.Load(),
+			RepliesDroppedNoRequest:      ir.repliesDroppedNoRequest.Load(),
+			RepliesDroppedForceRenew:     ir.repliesDroppedForceRenew.Load(),
+			PendingEvicted:               ir.pending.evictions(),
 			RepliesL2Unicast:             ir.repliesL2Unicast.Load(),
 			RepliesUnicastCiaddr:         ir.repliesUnicastCiaddr.Load(),
 			RepliesBroadcastFlag1:        ir.repliesBroadcastFlag1.Load(),
@@ -1406,6 +1470,23 @@ func (m *Manager) runRelaySession(ctx context.Context,
 				addOption82(pkt, ifaceName)
 			}
 
+			// #6562: record this transaction as outstanding BEFORE writing it
+			// upstream. handleServerResponses runs in a DIFFERENT goroutine on
+			// the same session, so a server on a fast local segment can deliver
+			// its OFFER before a post-send insert had run — which would drop
+			// the legitimate first reply of every exchange. Recording first
+			// costs nothing and closes that race.
+			//
+			// The key is taken from the fully-stamped packet, but the relay's
+			// mutations (hops, giaddr, Option 82) do not touch xid or chaddr,
+			// so it is identical either side of the stamping.
+			//
+			// Only requests that are actually forwarded are recorded: this sits
+			// AFTER the rate limiter, the #2456 HA master gate and the #4309
+			// hop-limit drop, so a request the relay refused upstream never
+			// arms a binding for a reply it should not receive.
+			ir.pending.insert(pendingKeyFor(pkt))
+
 			// Unicast the modified packet to each server in the active group.
 			relayData := pkt.ToBytes()
 			for _, srv := range servers {
@@ -1490,6 +1571,13 @@ func (m *Manager) resolveGIAddrWithRetry(ctx context.Context, ifaceName string) 
 // IP with net.IP.Equal (the source port is not load-bearing); an empty server
 // set admits nothing (fail-closed — a session is only started with a non-empty
 // set, so this cannot black-hole a legitimately-configured relay).
+//
+// Outstanding-request binding (#6562): a source IP is spoofable, so passing the
+// #4163 check is necessary but NOT sufficient. Each OFFER/ACK/NAK must also
+// bind to a request this relay forwarded (xid + chaddr, ir.pending — see
+// pending.go). DHCPFORCERENEW is refused outright: RFC 3203 §6 makes RFC 3118
+// authentication a MUST, and a relay holds none of the key material RFC 3118
+// §5.2/§5.3 puts between the client and the server, so it cannot verify one.
 func handleServerResponses(ctx context.Context, serverConn, clientConn net.PacketConn,
 	ir *interfaceRelay, l2 l2Replier, srcIP net.IP, servers []*net.UDPAddr) {
 	ifaceName := ir.ifaceName
@@ -1508,6 +1596,11 @@ func handleServerResponses(ctx context.Context, serverConn, clientConn net.Packe
 	// durable signal, so a flood of forged replies cannot spam the log. Mirrors
 	// the resolveGIAddrWithRetry warn-once pattern.
 	warnedUnknownSrc := false
+	// #6562: the same warn-once-then-Debug discipline for the two new drop
+	// paths. Both are reachable in a flood (a spoofing attacker, or a
+	// FORCERENEW-emitting server), so neither may log per packet.
+	warnedNoRequest := false
+	warnedForceRenew := false
 	buf := make([]byte, readBufSize)
 	for {
 		n, srcAddr, err := serverConn.ReadFrom(buf)
@@ -1552,18 +1645,97 @@ func handleServerResponses(ctx context.Context, serverConn, clientConn net.Packe
 
 		msgType := pkt.MessageType()
 		switch msgType {
-		case dhcpv4.MessageTypeOffer, dhcpv4.MessageTypeAck, dhcpv4.MessageTypeNak,
-			messageTypeForceRenew:
-			// Forward to the client. NAK rejects the client's request
-			// (RFC 2131 §4.3.2); dropping it makes the client hang until
-			// its retransmission timeout instead of restarting with a
-			// fresh DISCOVER. FORCERENEW (RFC 3203, type 9) tells a client
-			// that already holds a lease to re-enter RENEWING; dropping it
-			// means a server can never force a relayed client to renew.
-			// Unlike NAK it carries the client's current address in ciaddr,
-			// so deliverReply unicasts it (the ciaddr row) rather than
-			// broadcasting.
+		case dhcpv4.MessageTypeOffer, dhcpv4.MessageTypeAck, dhcpv4.MessageTypeNak:
+			// Forward to the client, subject to the #6562 binding below. NAK
+			// rejects the client's request (RFC 2131 §4.3.2); dropping it makes
+			// the client hang until its retransmission timeout instead of
+			// restarting with a fresh DISCOVER.
+
+		case messageTypeForceRenew:
+			// #6562: REFUSE. This reverses #2645, which forwarded FORCERENEW on
+			// the reasoning that RFC 3118 authentication is end-to-end
+			// client<->server and therefore "out of scope for the relay".
+			//
+			// RFC 3203 §6 (Security Considerations — NOT §5, which is IANA
+			// Considerations) is a MUST, and it is a MUST precisely because of
+			// this attack: "As in some network environments FORCERENEW can be
+			// used to snoop and spoof traffic, the FORCERENEW message MUST be
+			// authenticated using the procedures as described in [DHCP-AUTH].
+			// FORCERENEW messages failing the authentication should be silently
+			// discarded by the client."
+			//
+			// A relay structurally CANNOT discharge that MUST. RFC 3118 §5.2
+			// defines the key as "K - a secret value shared between the source
+			// and destination of the message" and notes that "Delayed
+			// authentication requires a shared secret key for each client on
+			// each DHCP server"; RFC 3118 §3 casts the relay agent purely as a
+			// transparent mutator whose giaddr/hops/Option-82 changes are
+			// EXCLUDED from the hash, and §5.3 assigns validation to the
+			// receiver ("If the MAC computed by the receiver does not match the
+			// MAC contained in the authentication option, the receiver MUST
+			// discard the DHCP message"). The relay is neither source,
+			// destination, nor receiver, and holds no secret or secret-ID
+			// mapping. It cannot verify the MAC.
+			//
+			// Checking merely that option 90 is PRESENT would be theater: the
+			// off-path attacker in this threat model already forges the
+			// server's source IP, so they can equally attach a well-formed
+			// option 90 with a bogus MAC. Since the relay cannot check the MAC,
+			// a presence test admits exactly the attacker it is meant to stop —
+			// while most real clients do not implement RFC 3118 at all and
+			// would never catch it downstream.
+			//
+			// Refusing is a HANDLED condition, not an outage. RFC 3203 §2.2
+			// specifies the server's behavior when the message does not arrive:
+			// "If the FORCERENEW message is lost, the DHCP server will not
+			// receive a DHCP REQUEST from the client and it should retransmit
+			// the FORCERENEW message using an exponential backoff algorithm."
+			// Normal leasing is untouched — clients still renew at T1/T2. Only
+			// the server's ability to force an EARLY renew through this relay is
+			// withdrawn, and it is withdrawn loudly (counter + warn-once).
+			ir.repliesDroppedForceRenew.Add(1)
+			if !warnedForceRenew {
+				slog.Warn("dhcp-relay: refusing to forward DHCPFORCERENEW "+
+					"(RFC 3203 §6 requires RFC 3118 authentication a relay cannot verify)",
+					"interface", ifaceName, "src", srcAddr,
+					"client_mac", pkt.ClientHWAddr)
+				warnedForceRenew = true
+			} else {
+				slog.Debug("dhcp-relay: refusing to forward DHCPFORCERENEW",
+					"interface", ifaceName, "src", srcAddr)
+			}
+			continue
+
 		default:
+			continue
+		}
+
+		// #6562: bind the reply to an outstanding request. The #4163 source-IP
+		// check above is spoofable — an off-path attacker who forges a
+		// configured server's address passes it — so a reply must ALSO answer a
+		// request this relay actually forwarded. The key is xid + chaddr, both
+		// of which RFC 2131 §4.3.1 Table 3 requires the server to copy from the
+		// client's message into OFFER/ACK/NAK (see pending.go for why option 61
+		// is deliberately excluded).
+		//
+		// FAIL DIRECTION: this gate can silently break DHCP for real clients if
+		// it is too strict, which is a worse outage than the injection it
+		// prevents. Every drop is therefore counted (repliesDroppedNoRequest,
+		// surfaced in `show services dhcp relay`) and logged warn-once-then-
+		// Debug, so an operator sees a mis-binding immediately instead of
+		// debugging an invisible black hole.
+		if !ir.pending.matches(pendingKeyFor(pkt)) {
+			ir.repliesDroppedNoRequest.Add(1)
+			if !warnedNoRequest {
+				slog.Warn("dhcp-relay: dropping server reply with no outstanding request",
+					"interface", ifaceName, "src", srcAddr, "type", msgType,
+					"xid", pkt.TransactionID, "client_mac", pkt.ClientHWAddr)
+				warnedNoRequest = true
+			} else {
+				slog.Debug("dhcp-relay: dropping server reply with no outstanding request",
+					"interface", ifaceName, "src", srcAddr, "type", msgType,
+					"xid", pkt.TransactionID, "client_mac", pkt.ClientHWAddr)
+			}
 			continue
 		}
 

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -270,13 +270,28 @@ type RelayStats struct {
 	RepliesDroppedForceRenew uint64
 
 	// PendingEvicted counts outstanding-request entries dropped by CAP PRESSURE
-	// on the #6562 pending table (not by ordinary expiry). The #5670 rate
-	// limiter keeps the table far below its cap at the default packet rate, so
-	// a nonzero value means the relay is under a request flood (or
-	// `overrides maximum-packet-rate` is set far above the default) and
-	// legitimate replies may now be dropped for want of a binding. It is the
-	// early-warning signal that pairs with RepliesDroppedNoRequest.
+	// on the #6562 pending table (not by ordinary expiry). Capacity is derived
+	// from the interface's maximum-packet-rate, so under a correctly-sized
+	// relay this stays 0; a nonzero value means the table filled anyway (the
+	// rate limiter's burst allowance, or a rate high enough that the memory
+	// ceiling clamped capacity) and legitimate replies may now be dropped for
+	// want of a binding.
+	//
+	// NOTE it is a COINCIDENT signal, not a leading one: an eviction is what
+	// CAUSES the subsequent drop, so the lead time is one server RTT. Use
+	// PendingSize/PendingCapacity for advance warning.
 	PendingEvicted uint64
+
+	// PendingSize is the CURRENT occupancy of the #6562 outstanding-request
+	// table, and PendingCapacity its ceiling. This pair is the genuine LEADING
+	// indicator (#6603 review F3): occupancy climbing toward capacity means the
+	// relay is about to start evicting bindings and dropping legitimate
+	// replies, and it is observable BEFORE any reply is lost. Alert on the
+	// ratio; PendingEvicted only rises once the damage has begun.
+	//
+	// These are gauges (instantaneous), not monotonic counters.
+	PendingSize     uint64
+	PendingCapacity uint64
 
 	// Reply-delivery breakdown (#2076). These distinguish WHY a reply was
 	// broadcast vs L2-unicast so an L2/CAP_NET_RAW/driver/MTU regression is
@@ -380,7 +395,13 @@ type interfaceRelay struct {
 	// drift / #3960 re-address) does NOT wipe in-flight bindings and strand a
 	// client mid-transaction. Always non-nil in production (set where this
 	// struct is built); a nil table fails CLOSED — see pendingTable.matches.
+	// Its capacity is derived from maxPacketRate (pendingCapacityFor).
 	pending *pendingTable
+
+	// pendingClamped records that pendingCapacityFor hit the memory ceiling,
+	// so the effective reply-binding window is shorter than pendingTTL. Set
+	// once at start; read-only thereafter. Drives the startup Warn in Apply.
+	pendingClamped bool
 
 	// repliesDroppedNoRequest counts server replies dropped because they bind
 	// to no outstanding request (#6562). Observability for a spoofed-source
@@ -887,6 +908,14 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 			continue
 		}
 		rctx, cancel := context.WithCancel(ctx)
+		// #6562: size the outstanding-request table from THIS interface's
+		// ingress packet-rate limit. A fixed capacity would be cap-bound (and
+		// the reply-binding window would silently collapse) on any segment
+		// whose `overrides maximum-packet-rate` is raised — which the relay's
+		// own docs recommend for a busy segment. pendingCapacityFor reports
+		// when the memory ceiling clamps it; that case is logged below.
+		rate := resolveMaxPacketRate(d.spec.maxPacketRate)
+		pendingCapacity, pendingClamped := pendingCapacityFor(rate)
 		ir := &interfaceRelay{
 			ifaceName:       d.ifaceName,
 			cancel:          cancel,
@@ -895,12 +924,12 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 			alwaysBroadcast: d.spec.alwaysBroadcast,
 			maxHopCount:     resolveMaxHopCount(d.spec.maxHopCount),
 			trustOption82:   d.spec.trustOption82,
-			maxPacketRate:   resolveMaxPacketRate(d.spec.maxPacketRate),
-			// #6562: the outstanding-request table that binds replies to
-			// requests. Built here, with the relay, so it survives session
+			maxPacketRate:   rate,
+			// The table is built here, with the relay, so it survives session
 			// rebuilds; it shares the manager clock seam with the #5670 token
 			// bucket so tests drive expiry deterministically.
-			pending: newPendingTable(pendingCap, pendingTTL, m.now),
+			pending:        newPendingTable(pendingCapacity, pendingTTL, m.now),
+			pendingClamped: pendingClamped,
 		}
 		m.relays[name] = ir
 		toStart = append(toStart, struct {
@@ -931,6 +960,22 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 			"interface", s.ir.ifaceName,
 			"group", s.group,
 			"servers", s.ir.spec.servers)
+
+		// #6562: the reply-binding window is nominally pendingTTL, but at a
+		// high `overrides maximum-packet-rate` the memory ceiling on the
+		// outstanding-request table binds first and the real window is
+		// capacity/rate. Say so at startup with the actual number — an
+		// operator who raised the rate must not have to infer a shortened
+		// binding window from a rising PendingEvicted later.
+		if s.ir.pendingClamped {
+			slog.Warn("dhcp-relay: reply-binding window reduced by the pending-table "+
+				"memory ceiling at this packet rate",
+				"interface", s.ir.ifaceName,
+				"max_packet_rate", s.ir.maxPacketRate,
+				"pending_capacity", s.ir.pending.capacity(),
+				"nominal_window", pendingTTL,
+				"effective_window", pendingWindow(s.ir.pending.capacity(), s.ir.maxPacketRate))
+		}
 	}
 }
 
@@ -952,6 +997,8 @@ func (m *Manager) Stats() []RelayStats {
 			RepliesDroppedNoRequest:      ir.repliesDroppedNoRequest.Load(),
 			RepliesDroppedForceRenew:     ir.repliesDroppedForceRenew.Load(),
 			PendingEvicted:               ir.pending.evictions(),
+			PendingSize:                  uint64(ir.pending.size()),
+			PendingCapacity:              uint64(ir.pending.capacity()),
 			RepliesL2Unicast:             ir.repliesL2Unicast.Load(),
 			RepliesUnicastCiaddr:         ir.repliesUnicastCiaddr.Load(),
 			RepliesBroadcastFlag1:        ir.repliesBroadcastFlag1.Load(),
@@ -1685,14 +1732,28 @@ func handleServerResponses(ctx context.Context, serverConn, clientConn net.Packe
 			// while most real clients do not implement RFC 3118 at all and
 			// would never catch it downstream.
 			//
-			// Refusing is a HANDLED condition, not an outage. RFC 3203 §2.2
-			// specifies the server's behavior when the message does not arrive:
-			// "If the FORCERENEW message is lost, the DHCP server will not
-			// receive a DHCP REQUEST from the client and it should retransmit
-			// the FORCERENEW message using an exponential backoff algorithm."
-			// Normal leasing is untouched — clients still renew at T1/T2. Only
-			// the server's ability to force an EARLY renew through this relay is
-			// withdrawn, and it is withdrawn loudly (counter + warn-once).
+			// Refusing costs a CONFORMANT deployment nothing, because a
+			// conformant FORCERENEW never reaches this socket. RFC 3203 §2.2
+			// opens: "The DHCP server sends a unicast FORCERENEW message to
+			// the client." A unicast to the client's own leased address routes
+			// as ordinary traffic and is never delivered to the relay's
+			// giaddr:67 server socket at all. The only FORCERENEW that can
+			// arrive HERE is one deliberately addressed to giaddr:67 — a
+			// non-conformant server, or the attacker §6 is about. Normal
+			// leasing is untouched either way: clients still renew at T1/T2.
+			//
+			// (Do NOT justify this by §2.2's retransmission sentence. That
+			// describes recovery from TRANSIENT loss; the loss here is
+			// PERMANENT — every retransmission hits this same arm — and §2.2
+			// itself bounds the attempts: "The amount of retransmissions should
+			// be limited." The backoff never converges, so it cannot carry the
+			// argument.)
+			//
+			// This arm is also belt-and-braces: FORCERENEW is server-initiated,
+			// so its xid matches no outstanding request and the #6562 binding
+			// below would drop it regardless. The dedicated arm exists to give
+			// the refusal its OWN counter and log, so an operator can tell it
+			// apart from an ordinary unbound reply.
 			ir.repliesDroppedForceRenew.Add(1)
 			if !warnedForceRenew {
 				slog.Warn("dhcp-relay: refusing to forward DHCPFORCERENEW "+

--- a/pkg/dhcprelay/relay_binding_6562_test.go
+++ b/pkg/dhcprelay/relay_binding_6562_test.go
@@ -1,0 +1,564 @@
+package dhcprelay
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/iana"
+)
+
+// #6562 — outstanding-request binding for relayed replies, and the FORCERENEW
+// refusal. Two DISTINCT defects, so two distinct fail-on-revert binders:
+//
+//   - TestHandleServerResponses_NoOutstandingRequestDropped — a reply that
+//     answers no forwarded request is dropped (reverting the ir.pending.matches
+//     gate makes it RED).
+//   - TestHandleServerResponses_ForceRenewRefused (delivery_test.go) — an
+//     unauthenticated FORCERENEW is not forwarded (restoring
+//     messageTypeForceRenew to the forwarded set makes it RED).
+//
+// And one OVER-REACH guard that must stay GREEN under revert:
+//
+//   - TestRelay_NormalExchange_EndToEndStillRelays — DISCOVER/OFFER,
+//     REQUEST/ACK, RENEW and REBIND still relay end-to-end through the live
+//     manager. A binding that is too strict silently breaks DHCP for every real
+//     client, which is a worse outage than the injection it prevents, so this
+//     test is the one that must never be "fixed" by loosening an assertion.
+
+// bindingHarness drives a full relay session (the REAL runRelay ->
+// runRelaySession client loop plus the handleServerResponses reply loop, both
+// sharing one interfaceRelay) so the pending-table entry is created by
+// production code, not by a test helper.
+type bindingHarness struct {
+	t      *testing.T
+	m      *Manager
+	client *fakeConn
+	server *fakeConn
+	stop   func()
+}
+
+// relay returns the single interfaceRelay this harness is running, so a test
+// can assert on the counters the production loops actually incremented.
+func (h *bindingHarness) relay() *interfaceRelay {
+	h.t.Helper()
+	h.m.mu.Lock()
+	defer h.m.mu.Unlock()
+	for _, ir := range h.m.relays {
+		return ir
+	}
+	h.t.Fatal("no relay is running")
+	return nil
+}
+
+// newBindingHarness starts a relay on the single-interface config. The server
+// conn reports 192.0.2.1 as its source so replies pass the #4163 source check
+// (that is singleInterfaceConfig's configured server).
+func newBindingHarness(t *testing.T) *bindingHarness {
+	t.Helper()
+	client := newFakeConn()
+	server := newFakeConn()
+	server.mu.Lock()
+	server.srcAddr = &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: relayPort}
+	server.mu.Unlock()
+
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+	m.Apply(context.Background(), singleInterfaceConfig())
+	return &bindingHarness{t: t, m: m, client: client, server: server, stop: m.Stop}
+}
+
+// relayUp pushes a client BOOTREQUEST and returns the datagram the relay
+// forwarded upstream. It fails the test if nothing is relayed in time.
+func (h *bindingHarness) relayUp(req *dhcpv4.DHCPv4) *dhcpv4.DHCPv4 {
+	h.t.Helper()
+	before := h.server.writeCount()
+	h.client.push(req.ToBytes())
+	if !waitFor(func() bool { return h.server.writeCount() > before }) {
+		h.t.Fatalf("request (xid %v) was not relayed upstream within the deadline",
+			req.TransactionID)
+	}
+	h.server.mu.Lock()
+	data := append([]byte(nil), h.server.writes[len(h.server.writes)-1].data...)
+	h.server.mu.Unlock()
+	got, err := dhcpv4.FromBytes(data)
+	if err != nil {
+		h.t.Fatalf("relayed datagram does not parse: %v", err)
+	}
+	return got
+}
+
+// relayDown pushes a server reply and returns the datagram delivered to the
+// client, or nil if none was delivered before the deadline.
+func (h *bindingHarness) relayDown(reply *dhcpv4.DHCPv4) *dhcpv4.DHCPv4 {
+	h.t.Helper()
+	before := h.client.writeCount()
+	h.server.push(reply.ToBytes())
+	if !waitFor(func() bool { return h.client.writeCount() > before }) {
+		return nil
+	}
+	h.client.mu.Lock()
+	data := append([]byte(nil), h.client.writes[len(h.client.writes)-1].data...)
+	h.client.mu.Unlock()
+	got, err := dhcpv4.FromBytes(data)
+	if err != nil {
+		h.t.Fatalf("delivered datagram does not parse: %v", err)
+	}
+	return got
+}
+
+// waitFor polls cond until true or a 2s deadline elapses.
+func waitFor(cond func() bool) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return cond()
+}
+
+// newRequest builds a client BOOTREQUEST of the given type.
+func newRequest(t *testing.T, mt dhcpv4.MessageType, chaddr net.HardwareAddr,
+	ciaddr net.IP) *dhcpv4.DHCPv4 {
+	t.Helper()
+	pkt, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	pkt.OpCode = dhcpv4.OpcodeBootRequest
+	pkt.HWType = iana.HWTypeEthernet
+	pkt.ClientHWAddr = chaddr
+	pkt.UpdateOption(dhcpv4.OptMessageType(mt))
+	if ciaddr != nil {
+		pkt.ClientIPAddr = ciaddr
+	}
+	return pkt
+}
+
+// serverReply builds the BOOTREPLY a conformant server would return for req:
+// RFC 2131 §4.3.1 Table 3 copies 'xid' and 'chaddr' from the client's message,
+// which is exactly the #6562 binding key. broadcast selects the delivery row
+// (broadcast -> a client-conn UDP write, which is what the harness observes).
+func serverReply(t *testing.T, req *dhcpv4.DHCPv4, mt dhcpv4.MessageType,
+	yiaddr, ciaddr net.IP, broadcast bool) *dhcpv4.DHCPv4 {
+	t.Helper()
+	pkt, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	pkt.OpCode = dhcpv4.OpcodeBootReply
+	pkt.HWType = iana.HWTypeEthernet
+	pkt.TransactionID = req.TransactionID // Table 3: 'xid' from client
+	pkt.ClientHWAddr = req.ClientHWAddr   // Table 3: 'chaddr' from client
+	pkt.UpdateOption(dhcpv4.OptMessageType(mt))
+	pkt.YourIPAddr = net.IPv4zero
+	pkt.ClientIPAddr = net.IPv4zero
+	if yiaddr != nil {
+		pkt.YourIPAddr = yiaddr
+	}
+	if ciaddr != nil {
+		pkt.ClientIPAddr = ciaddr
+	}
+	if broadcast {
+		pkt.SetBroadcast()
+	}
+	return pkt
+}
+
+// TestRelay_NormalExchange_EndToEndStillRelays is the #6562 OVER-REACH GUARD.
+//
+// It drives a complete, ordinary DHCP lifecycle through the live relay —
+// DISCOVER/OFFER, REQUEST/ACK, then RENEW and REBIND — and asserts every
+// message crosses the relay in both directions. Nothing here is armed by a test
+// helper: each binding is created by the production client loop as it forwards
+// the request upstream.
+//
+// This test MUST stay GREEN when the #6562 gate is reverted. If it ever goes
+// red, the binding is dropping legitimate traffic and the fix is worse than the
+// defect — an unbindable reply is a silent, segment-wide DHCP outage, whereas
+// the injection it prevents needs an attacker to both spoof a configured
+// server's source IP and guess a 32-bit xid.
+func TestRelay_NormalExchange_EndToEndStillRelays(t *testing.T) {
+	h := newBindingHarness(t)
+	defer h.stop()
+
+	chaddr := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x42}
+	yiaddr := net.IPv4(10, 0, 0, 77)
+
+	// --- DISCOVER -> OFFER -------------------------------------------------
+	discover := newRequest(t, dhcpv4.MessageTypeDiscover, chaddr, nil)
+	relayed := h.relayUp(discover)
+	if relayed.TransactionID != discover.TransactionID {
+		t.Fatalf("relayed DISCOVER xid = %v, want %v",
+			relayed.TransactionID, discover.TransactionID)
+	}
+	offer := h.relayDown(serverReply(t, discover, dhcpv4.MessageTypeOffer, yiaddr, nil, true))
+	if offer == nil {
+		t.Fatal("OFFER answering a relayed DISCOVER was NOT delivered to the client " +
+			"— the #6562 binding is over-strict and has broken normal DHCP")
+	}
+	if offer.TransactionID != discover.TransactionID {
+		t.Errorf("delivered OFFER xid = %v, want %v", offer.TransactionID, discover.TransactionID)
+	}
+
+	// --- REQUEST -> ACK ----------------------------------------------------
+	// RFC 2131 §4.4.1: "The DHCPREQUEST message contains the same 'xid' as the
+	// DHCPOFFER message", so the SELECTING request reuses the DISCOVER xid.
+	// This also exercises the no-consume-on-match rule: the DISCOVER's entry
+	// was already matched by the OFFER above.
+	request := newRequest(t, dhcpv4.MessageTypeRequest, chaddr, nil)
+	request.TransactionID = discover.TransactionID
+	h.relayUp(request)
+	ack := h.relayDown(serverReply(t, request, dhcpv4.MessageTypeAck, yiaddr, nil, true))
+	if ack == nil {
+		t.Fatal("ACK answering a relayed REQUEST was NOT delivered to the client")
+	}
+
+	// --- RENEW (unicast REQUEST with ciaddr, fresh xid) --------------------
+	// A renewing client sets ciaddr and picks a new transaction. The reply is
+	// flag-clear with a real ciaddr, so it takes the ciaddr-unicast row.
+	renew := newRequest(t, dhcpv4.MessageTypeRequest, chaddr, yiaddr)
+	if renew.TransactionID == discover.TransactionID {
+		t.Fatal("RENEW must use a fresh xid for this test to be meaningful")
+	}
+	h.relayUp(renew)
+	renewAck := h.relayDown(serverReply(t, renew, dhcpv4.MessageTypeAck, nil, yiaddr, false))
+	if renewAck == nil {
+		t.Fatal("ACK answering a relayed RENEW was NOT delivered to the client")
+	}
+
+	// --- REBIND (broadcast REQUEST with ciaddr, fresh xid) -----------------
+	rebind := newRequest(t, dhcpv4.MessageTypeRequest, chaddr, yiaddr)
+	rebind.SetBroadcast()
+	h.relayUp(rebind)
+	rebindAck := h.relayDown(serverReply(t, rebind, dhcpv4.MessageTypeAck, nil, yiaddr, true))
+	if rebindAck == nil {
+		t.Fatal("ACK answering a relayed REBIND was NOT delivered to the client")
+	}
+
+	// No drop counter may have moved during an entirely legitimate exchange.
+	ir := h.relay()
+	if got := ir.repliesDroppedNoRequest.Load(); got != 0 {
+		t.Errorf("repliesDroppedNoRequest = %d, want 0 — a NORMAL exchange must not "+
+			"trip the binding", got)
+	}
+	if got := ir.pending.evictions(); got != 0 {
+		t.Errorf("pendingEvicted = %d, want 0 (4 requests cannot fill an %d-entry table)",
+			got, pendingCap)
+	}
+	if got := ir.repliesForwarded.Load(); got != 4 {
+		t.Errorf("repliesForwarded = %d, want 4 (OFFER, ACK, RENEW-ACK, REBIND-ACK)", got)
+	}
+}
+
+// TestHandleServerResponses_NoOutstandingRequestDropped is the #6562
+// fail-on-revert gate for the FIRST defect: a syntactically valid OFFER from a
+// CONFIGURED server (so #4163 passes) that answers NO request the relay
+// forwarded MUST be dropped before it reaches the client, and
+// repliesDroppedNoRequest MUST increment.
+//
+// This is the spoofed-source injection #4163 cannot stop: the attacker forges
+// the configured server's IP, so the only thing left to catch them is that they
+// did not guess an outstanding transaction. Reverting the ir.pending.matches
+// gate makes this RED — the forged OFFER is forwarded and the counter stays 0.
+func TestHandleServerResponses_NoOutstandingRequestDropped(t *testing.T) {
+	offer := newReply(t, true, testYiaddr, nil, testChaddr) // broadcast → client write
+	offer.GatewayIPAddr = testGiaddr
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{offer.ToBytes()}
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	// Live but EMPTY table: no request was ever relayed for this xid.
+	ir := unarmedRelay("ge-0-0-0")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		// Source IS a configured server, so the #4163 check admits it and the
+		// ONLY thing that can drop it is the #6562 binding.
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet())
+		close(done)
+	}()
+
+	if !waitFor(func() bool { return ir.repliesDroppedNoRequest.Load() > 0 }) {
+		t.Error("unbound reply was not dropped within the deadline")
+	}
+
+	if got := ir.repliesDroppedNoRequest.Load(); got != 1 {
+		t.Errorf("repliesDroppedNoRequest = %d, want 1", got)
+	}
+	clientConn.mu.Lock()
+	nWrites := len(clientConn.writes)
+	clientConn.mu.Unlock()
+	if nWrites != 0 {
+		t.Errorf("unbound reply reached the client: got %d client writes, want 0", nWrites)
+	}
+	if ir.repliesForwarded.Load() != 0 {
+		t.Errorf("repliesForwarded = %d, want 0", ir.repliesForwarded.Load())
+	}
+	if fl2.callCount() != 0 {
+		t.Errorf("unbound reply used raw-L2: got %d calls, want 0", fl2.callCount())
+	}
+	// The source WAS configured, so this must not be miscounted as a #4163 drop
+	// — the two counters have to stay independently diagnosable.
+	if got := ir.repliesDroppedUnknownServer.Load(); got != 0 {
+		t.Errorf("repliesDroppedUnknownServer = %d, want 0 (source was configured)", got)
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}
+
+// TestHandleServerResponses_WrongChaddrDropped proves the binding is keyed on
+// client identity too, not on the xid alone: an attacker who observed or
+// guessed an outstanding xid still cannot steer a DIFFERENT client, because the
+// chaddr the server must echo (RFC 2131 §4.3.1 Table 3) will not match.
+func TestHandleServerResponses_WrongChaddrDropped(t *testing.T) {
+	victim := newReply(t, true, testYiaddr, nil, testChaddr)
+	// Same xid, different client hardware address.
+	forged := newReply(t, true, testYiaddr, nil,
+		net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0xAA})
+	forged.TransactionID = victim.TransactionID
+
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{forged.ToBytes()}
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	ir := armedRelay("ge-0-0-0", victim) // armed for the VICTIM's chaddr only
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr, testServerSet())
+		close(done)
+	}()
+
+	if !waitFor(func() bool { return ir.repliesDroppedNoRequest.Load() > 0 }) {
+		t.Error("reply with a mismatched chaddr was not dropped within the deadline")
+	}
+	clientConn.mu.Lock()
+	nWrites := len(clientConn.writes)
+	clientConn.mu.Unlock()
+	if nWrites != 0 {
+		t.Errorf("xid-only match forwarded a reply for the wrong client: got %d writes, want 0",
+			nWrites)
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}
+
+// TestPendingTable_MatchDoesNotConsume pins the multi-reply rule: the relay
+// fans each request out to EVERY server in the group, so an N-server group
+// answers one DISCOVER with N OFFERs, and the SELECTING ACK reuses the same
+// xid. Consuming the entry on first match would drop every reply after the
+// first and silently break multi-server redundancy.
+func TestPendingTable_MatchDoesNotConsume(t *testing.T) {
+	tbl := newPendingTable(pendingCap, pendingTTL, time.Now)
+	k := pendingKey{xid: dhcpv4.TransactionID{1, 2, 3, 4}, hlen: 6}
+	tbl.insert(k)
+
+	for i := 1; i <= 5; i++ {
+		if !tbl.matches(k) {
+			t.Fatalf("match %d failed: the entry was consumed by an earlier match", i)
+		}
+	}
+}
+
+// TestPendingTable_Expiry proves entries stop binding after the TTL, so the
+// window in which a guessed xid would be accepted is bounded.
+func TestPendingTable_Expiry(t *testing.T) {
+	now := time.Unix(1000, 0)
+	clock := func() time.Time { return now }
+	tbl := newPendingTable(pendingCap, 30*time.Second, clock)
+	k := pendingKey{xid: dhcpv4.TransactionID{9, 9, 9, 9}, hlen: 6}
+	tbl.insert(k)
+
+	if !tbl.matches(k) {
+		t.Fatal("entry does not match immediately after insert")
+	}
+	now = now.Add(29 * time.Second)
+	if !tbl.matches(k) {
+		t.Error("entry expired early (29s into a 30s TTL) — this would drop legitimate replies")
+	}
+	now = now.Add(2 * time.Second) // 31s: past the TTL
+	if tbl.matches(k) {
+		t.Error("entry still matches after the TTL — the binding window is unbounded")
+	}
+}
+
+// TestPendingTable_CapEvictsOldestNotNewest pins the eviction policy. At the
+// cap the table evicts the OLDEST entry rather than refusing the NEW request:
+// refusing new requests would let an attacker who fills the table lock out
+// every new client (a total segment outage), whereas evicting the oldest keeps
+// new clients working. The eviction must also be COUNTED, because it is the
+// only warning an operator gets that legitimate bindings are being lost.
+func TestPendingTable_CapEvictsOldestNotNewest(t *testing.T) {
+	now := time.Unix(2000, 0)
+	clock := func() time.Time { return now }
+	const capacity = 4
+	tbl := newPendingTable(capacity, time.Hour, clock) // long TTL: force CAP pressure, not expiry
+
+	key := func(n byte) pendingKey {
+		return pendingKey{xid: dhcpv4.TransactionID{0, 0, 0, n}, hlen: 6}
+	}
+	// Fill to capacity, each entry one second newer than the last.
+	for i := byte(1); i <= capacity; i++ {
+		tbl.insert(key(i))
+		now = now.Add(time.Second)
+	}
+	if tbl.size() != capacity {
+		t.Fatalf("size = %d, want %d after filling to capacity", tbl.size(), capacity)
+	}
+	if got := tbl.evictions(); got != 0 {
+		t.Fatalf("evictions = %d, want 0 before the cap is exceeded", got)
+	}
+
+	// One more: the NEW entry must be admitted and the OLDEST dropped.
+	tbl.insert(key(99))
+
+	if !tbl.matches(key(99)) {
+		t.Error("the NEW request was refused at the cap — an attacker filling the table " +
+			"would lock out every new client")
+	}
+	if tbl.matches(key(1)) {
+		t.Error("the OLDEST entry survived; eviction did not pick it")
+	}
+	if tbl.size() != capacity {
+		t.Errorf("size = %d, want %d (the table must stay bounded)", tbl.size(), capacity)
+	}
+	if got := tbl.evictions(); got != 1 {
+		t.Errorf("evictions = %d, want 1 — cap pressure MUST be observable", got)
+	}
+	// The other pre-existing entries must be untouched: eviction is one-at-a-
+	// time, not a table flush.
+	for i := byte(2); i <= capacity; i++ {
+		if !tbl.matches(key(i)) {
+			t.Errorf("entry %d was evicted; only the single oldest should have been", i)
+		}
+	}
+}
+
+// TestPendingTable_ExpiredReclaimedBeforeEviction proves an expired entry is
+// reclaimed as free space rather than counted as an eviction — an idle-then-
+// busy relay must not report cap pressure it is not under.
+func TestPendingTable_ExpiredReclaimedBeforeEviction(t *testing.T) {
+	now := time.Unix(3000, 0)
+	clock := func() time.Time { return now }
+	const capacity = 3
+	tbl := newPendingTable(capacity, 10*time.Second, clock)
+
+	key := func(n byte) pendingKey {
+		return pendingKey{xid: dhcpv4.TransactionID{0, 0, 0, n}, hlen: 6}
+	}
+	for i := byte(1); i <= capacity; i++ {
+		tbl.insert(key(i))
+	}
+	now = now.Add(11 * time.Second) // every entry is now expired
+
+	tbl.insert(key(50))
+	if got := tbl.evictions(); got != 0 {
+		t.Errorf("evictions = %d, want 0 — expired entries are free space, not cap pressure", got)
+	}
+	if !tbl.matches(key(50)) {
+		t.Error("new entry not admitted after expired entries were reclaimed")
+	}
+}
+
+// TestPendingTable_NilFailsClosed pins the fail-closed posture: a mis-wired
+// (nil) table admits nothing rather than silently disabling the binding. That
+// makes a wiring bug a loud, counted outage instead of a quiet loss of the
+// security property — the same choice #4163 made for an empty allow-set.
+func TestPendingTable_NilFailsClosed(t *testing.T) {
+	var tbl *pendingTable
+	k := pendingKey{xid: dhcpv4.TransactionID{5, 5, 5, 5}, hlen: 6}
+	tbl.insert(k) // must not panic
+	if tbl.matches(k) {
+		t.Error("a nil pending table admitted a reply — the binding would be silently disabled")
+	}
+	if tbl.evictions() != 0 || tbl.size() != 0 {
+		t.Error("nil table reported nonzero counters")
+	}
+}
+
+// TestPendingKeyFor_RequestAndReplyAgree proves the key survives the round
+// trip: the relay stamps hops/giaddr/Option 82 on the way up, and RFC 2131
+// §4.3.1 Table 3 has the server echo xid+chaddr on the way down, so the key
+// computed from the forwarded request must equal the key computed from the
+// reply. If this drifts, every reply is dropped.
+func TestPendingKeyFor_RequestAndReplyAgree(t *testing.T) {
+	chaddr := net.HardwareAddr{0x02, 0, 0, 0, 0, 7}
+	req := newRequest(t, dhcpv4.MessageTypeDiscover, chaddr, nil)
+	before := pendingKeyFor(req)
+
+	// Apply exactly the mutations the relay makes to a first-hop request.
+	req.HopCount++
+	req.GatewayIPAddr = net.IPv4(10, 0, 0, 254)
+	addOption82(req, "ge-0-0-0")
+	if got := pendingKeyFor(req); got != before {
+		t.Error("relay stamping changed the binding key — replies would never match")
+	}
+
+	// And the server's reply, built per Table 3, yields the same key.
+	reply := serverReply(t, req, dhcpv4.MessageTypeOffer, net.IPv4(10, 0, 0, 5), nil, true)
+	if got := pendingKeyFor(reply); got != before {
+		t.Error("the server-echoed reply key does not match the request key")
+	}
+}
+
+// TestPendingKeyFor_OversizeChaddrDoesNotPanic guards the defensive cap in
+// pendingKeyFor. dhcpv4.FromBytes clamps a parsed chaddr to 16 bytes, but a
+// packet constructed in-process is not bound by that, and a panic in the relay
+// read loop would take the relay down.
+func TestPendingKeyFor_OversizeChaddrDoesNotPanic(t *testing.T) {
+	pkt, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	pkt.ClientHWAddr = make(net.HardwareAddr, 32)
+	for i := range pkt.ClientHWAddr {
+		pkt.ClientHWAddr[i] = byte(i)
+	}
+	k := pendingKeyFor(pkt)
+	if k.hlen != 16 {
+		t.Errorf("hlen = %d, want 16 (clamped)", k.hlen)
+	}
+}
+
+// TestManagerRelay_HasPendingTable guards the wiring the fail-closed posture
+// depends on: because a nil table drops every reply, a manager-built relay MUST
+// have one. Without this, a future refactor that forgets the field would break
+// DHCP entirely and no other test would say why.
+func TestManagerRelay_HasPendingTable(t *testing.T) {
+	client := newFakeConn()
+	server := newFakeConn()
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+	m.Apply(context.Background(), singleInterfaceConfig())
+	defer m.Stop()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.relays) == 0 {
+		t.Fatal("no relay started")
+	}
+	for name, ir := range m.relays {
+		if ir.pending == nil {
+			t.Errorf("relay %q has a nil pending table — every reply would be dropped", name)
+		}
+	}
+}

--- a/pkg/dhcprelay/relay_binding_6562_test.go
+++ b/pkg/dhcprelay/relay_binding_6562_test.go
@@ -1226,67 +1226,217 @@ func TestPendingTable_FullDrainIsConstantTime(t *testing.T) {
 	}
 }
 
-// TestPendingTable_AdoptRespectsRemainingRoom pins adopt's bound: it is the
-// REMAINING room, not the raw capacity.
+// TestPendingTable_AdoptRequiresEmptyDestination pins the precondition that
+// makes adopt safe.
 //
-// pushLocked's contract is that the caller has already made room. Bounding by
-// capacity alone breaks it for a non-empty destination — count runs past the
-// ring length and the modular index silently overwrites live slots. Production
-// always adopts into a freshly built table, so this guards the invariant
-// against a future second caller rather than a live path.
-func TestPendingTable_AdoptRespectsRemainingRoom(t *testing.T) {
+// adopt APPENDS; it does not merge. Migrated slots carry the old table's
+// expiries, so appending them onto a non-empty ring can place an EARLIER expiry
+// after a later one and destroy the expiry ordering that every other operation
+// depends on. The concrete corruption: a ring of
+// dst(+4s), dst(+4s), migrated(+2s), migrated(+3s) is no longer ordered, so at
+// t=+3.5s the full-drain probe reads the NEWEST slot (migrated, +3s), finds it
+// expired, concludes the whole ring has expired, and wipes the two destination
+// bindings that are live until +4s. The head drain and occupancy's binary
+// search would mis-locate the boundary the same way.
+//
+// The sole production caller adopts into a table built moments earlier, so this
+// cannot fire in the live path; the assertion exists so a future second caller
+// fails loudly instead of silently corrupting the structure that decides which
+// replies reach clients.
+func TestPendingTable_AdoptRequiresEmptyDestination(t *testing.T) {
 	now := time.Unix(13000, 0)
 	clock := func() time.Time { return now }
-
 	key := func(n byte) pendingKey {
 		return pendingKey{xid: dhcpv4.TransactionID{0, 0, 0, n}, hlen: 6}
 	}
 
-	// Source: four live bindings.
-	src := newPendingTable(8, time.Hour, clock)
-	for i := byte(1); i <= 4; i++ {
-		src.insert(key(i))
-		now = now.Add(time.Second)
-	}
+	src := newPendingTable(8, 2*time.Second, clock)
+	src.insert(key(1))
+	now = now.Add(time.Second)
+	src.insert(key(2))
 	live := src.snapshot()
-	if len(live) != 4 {
-		t.Fatalf("precondition: snapshot = %d, want 4", len(live))
+	if len(live) != 2 {
+		t.Fatalf("precondition: snapshot = %d, want 2", len(live))
 	}
 
-	// Destination: capacity 4, but already holding two of its own.
+	// Destination already holds bindings with LATER expiries than the migrated
+	// ones — exactly the ordering-breaking case.
 	dst := newPendingTable(4, time.Hour, clock)
 	dst.insert(key(0xE1))
 	dst.insert(key(0xE2))
 
+	defer func() {
+		if recover() == nil {
+			t.Error("adopt into a NON-EMPTY destination did not panic; appending " +
+				"migrated expiries onto existing ones breaks the ring's expiry " +
+				"ordering, after which the full-drain probe can wipe live bindings")
+		}
+	}()
 	dst.adopt(live)
+}
 
-	if got := dst.occupancy(); got > dst.capacity() {
-		t.Fatalf("occupancy = %d exceeds capacity %d — adopt overran the ring and "+
-			"overwrote live slots", got, dst.capacity())
-	}
-	if got := dst.occupancy(); got != 4 {
-		t.Errorf("occupancy = %d, want 4 (the ring is full)", got)
-	}
-	// Only two slots were free, so only the two NEWEST carried bindings fit and
-	// the two oldest are counted as evictions.
-	if got := dst.evictions(); got != 2 {
-		t.Errorf("evictions = %d, want 2 — bindings that did not fit must be "+
-			"counted, not silently dropped", got)
-	}
-	for _, n := range []byte{3, 4} {
-		if !dst.matches(key(n)) {
-			t.Errorf("carried binding %d is missing; the newest must be kept", n)
+// TestPendingTable_PartialDrainIsBounded is the binder for the adjacent case the
+// full-drain fast path does NOT cover: MOST slots expired with the newest still
+// live.
+//
+// The failing input is STAGGERED expiries. The previous guard froze the clock,
+// so every slot shared one expiry and the ring was always either wholly expired
+// (fast path) or wholly live — the mixed case could not be constructed, and the
+// unbounded loop it exercises was invisible. Here the clock advances during the
+// fill, then stops just short of the newest slot's expiry: the probe reads a
+// LIVE newest slot, the fast path declines, and an unbounded drain would pop
+// capacity-1 slots one at a time under the mutex on the packet path.
+//
+// Removing the maxDrainPerInsert bound makes this RED.
+func TestPendingTable_PartialDrainIsBounded(t *testing.T) {
+	base := time.Unix(14000, 0)
+	now := base
+	clock := func() time.Time { return now }
+	const capacity = 4096
+	const ttl = 30 * time.Second
+	tbl := newPendingTable(capacity, ttl, clock)
+
+	key := func(i int) pendingKey {
+		return pendingKey{
+			xid:  dhcpv4.TransactionID{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)},
+			hlen: 6,
 		}
 	}
-	for _, n := range []byte{1, 2} {
-		if dst.matches(key(n)) {
-			t.Errorf("carried binding %d was kept; the oldest must be dropped first", n)
-		}
+	// Stagger: one insert per millisecond, so expiries are strictly increasing.
+	for i := 0; i < capacity; i++ {
+		tbl.insert(key(i))
+		now = now.Add(time.Millisecond)
 	}
-	// The destination's pre-existing bindings must not have been clobbered.
-	for _, n := range []byte{0xE1, 0xE2} {
-		if !dst.matches(key(n)) {
-			t.Errorf("pre-existing binding %#x was overwritten by adopt", n)
-		}
+	// Advance so that every slot EXCEPT the newest handful has expired. The
+	// newest slot was inserted at base+(capacity-1)ms and expires at
+	// +ttl; stop one millisecond short of that.
+	now = base.Add(ttl).Add(time.Duration(capacity-2) * time.Millisecond)
+
+	// Precondition: the ring is in the MIXED state, not wholly expired.
+	if got := tbl.occupancy(); got == 0 || got == capacity {
+		t.Fatalf("precondition: occupancy = %d, want a mixed ring (0 < n < %d) — "+
+			"this test is meaningless if the ring is wholly expired or wholly live",
+			got, capacity)
+	}
+
+	before := tbl.scans()
+	tbl.insert(key(capacity)) // the late request after the quiet period
+	scans := tbl.scans() - before
+
+	// An unbounded drain would examine ~capacity slots. The bound is
+	// maxDrainPerInsert plus the single eviction pop.
+	if maxScans := uint64(maxDrainPerInsert + 4); scans > maxScans {
+		t.Errorf("a single insert into a mostly-expired ring examined %d slots "+
+			"(capacity %d); per-insert reclaim must be bounded by ~%d, or one "+
+			"late packet stalls the relay under the mutex",
+			scans, capacity, maxScans)
+	}
+	// The new binding must still be present — bounding the drain must not have
+	// cost correctness.
+	if !tbl.matches(key(capacity)) {
+		t.Error("the newly inserted binding is missing after a bounded drain")
+	}
+}
+
+// TestPendingTable_OccupancyExcludesExpired is the binder for the false-HIGH
+// gauge.
+//
+// The failing input is simply TIME PASSING WITHOUT AN INSERT: expired slots stay
+// counted in the raw ring `count` until some later insert reclaims them, so an
+// idle full table reported capacity/capacity even though the very next insert
+// reclaims the lot and evicts nothing. An operator following the documented
+// advice to alert on the occupancy ratio would be paged by a relay that is
+// merely quiet.
+//
+// Reverting occupancy to return the raw count makes this RED.
+func TestPendingTable_OccupancyExcludesExpired(t *testing.T) {
+	now := time.Unix(15000, 0)
+	clock := func() time.Time { return now }
+	const capacity = 64
+	const ttl = 30 * time.Second
+	tbl := newPendingTable(capacity, ttl, clock)
+
+	key := func(i int) pendingKey {
+		return pendingKey{xid: dhcpv4.TransactionID{byte(i), byte(i >> 8), 0, 0}, hlen: 6}
+	}
+	// Fill the first half, then pause, then fill the second half, so the two
+	// halves expire at clearly different times.
+	for i := 0; i < capacity/2; i++ {
+		tbl.insert(key(i))
+	}
+	now = now.Add(20 * time.Second)
+	for i := capacity / 2; i < capacity; i++ {
+		tbl.insert(key(i))
+	}
+	if got := tbl.occupancy(); got != capacity {
+		t.Fatalf("precondition: occupancy = %d, want %d (ring full, all live)",
+			got, capacity)
+	}
+
+	// Idle past the FIRST half's expiry only. No insert happens, so nothing is
+	// reclaimed — the raw count is still `capacity`.
+	now = now.Add(15 * time.Second)
+
+	if got, want := tbl.occupancy(), capacity/2; got != want {
+		t.Errorf("occupancy = %d, want %d — the gauge must exclude the expired "+
+			"prefix. Reporting the raw ring count shows %d/%d on a relay that is "+
+			"merely idle, and the next insert would reclaim them with no eviction.",
+			got, want, capacity, capacity)
+	}
+
+	// And once everything has expired it must read empty, not full.
+	now = now.Add(time.Hour)
+	if got := tbl.occupancy(); got != 0 {
+		t.Errorf("occupancy on a wholly expired idle table = %d, want 0", got)
+	}
+}
+
+// TestPendingTable_IdleRelayReportsNoEvictions pins the operator-facing
+// property that the two reclaim paths exist to protect: a relay that is merely
+// IDLE must never report cap-pressure evictions.
+//
+// PendingEvicted is documented as damage already in progress, so it must not
+// fire just because a quiet period left the ring full of expired slots. What
+// keeps that true is that the fast path and the bounded drain always free room
+// before the eviction loop can run — see the proof in insert().
+//
+// Scope note, stated because the distinction cost a round here: this does NOT
+// bind an expiry check inside the eviction loop. Such a check is unreachable
+// (whenever the loop runs the head is unexpired by construction), so a mutation
+// that removed it could not be caught by any test — which is precisely why the
+// code carries the proof instead of a defensive re-check. This test binds the
+// reachable property: remove BOTH reclaim steps and expired slots reach the
+// eviction loop and are counted, turning an idle relay into a false alarm.
+func TestPendingTable_IdleRelayReportsNoEvictions(t *testing.T) {
+	base := time.Unix(16000, 0)
+	now := base
+	clock := func() time.Time { return now }
+	const capacity = maxDrainPerInsert * 4
+	const ttl = 30 * time.Second
+	tbl := newPendingTable(capacity, ttl, clock)
+
+	key := func(i int) pendingKey {
+		return pendingKey{xid: dhcpv4.TransactionID{byte(i), byte(i >> 8), 0, 0}, hlen: 6}
+	}
+	for i := 0; i < capacity; i++ {
+		tbl.insert(key(i))
+		now = now.Add(time.Millisecond)
+	}
+	// Expire everything except the newest slot: a mixed ring with a long
+	// expired prefix, which is the state a quiet period leaves behind.
+	now = base.Add(ttl).Add(time.Duration(capacity-2) * time.Millisecond)
+
+	tbl.insert(key(capacity))
+
+	if got := tbl.evictions(); got != 0 {
+		t.Errorf("evictions = %d, want 0 — the slots reclaimed here had EXPIRED, "+
+			"so an idle relay must not look like it is shedding load under cap "+
+			"pressure", got)
+	}
+	// And the reclaim must have actually freed room, which is what makes the
+	// eviction loop unreachable in this state.
+	if got := tbl.occupancy(); got >= capacity {
+		t.Errorf("occupancy = %d, want < capacity %d — the reclaim did not free "+
+			"room, so the eviction loop would run against an expired head", got, capacity)
 	}
 }

--- a/pkg/dhcprelay/relay_binding_6562_test.go
+++ b/pkg/dhcprelay/relay_binding_6562_test.go
@@ -3,6 +3,7 @@ package dhcprelay
 import (
 	"context"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -421,8 +422,8 @@ func TestPendingTable_CapEvictsOldestNotNewest(t *testing.T) {
 		tbl.insert(key(i))
 		now = now.Add(time.Second)
 	}
-	if tbl.size() != capacity {
-		t.Fatalf("size = %d, want %d after filling to capacity", tbl.size(), capacity)
+	if tbl.occupancy() != capacity {
+		t.Fatalf("occupancy = %d, want %d after filling to capacity", tbl.occupancy(), capacity)
 	}
 	if got := tbl.evictions(); got != 0 {
 		t.Fatalf("evictions = %d, want 0 before the cap is exceeded", got)
@@ -438,8 +439,8 @@ func TestPendingTable_CapEvictsOldestNotNewest(t *testing.T) {
 	if tbl.matches(key(1)) {
 		t.Error("the OLDEST entry survived; eviction did not pick it")
 	}
-	if tbl.size() != capacity {
-		t.Errorf("size = %d, want %d (the table must stay bounded)", tbl.size(), capacity)
+	if tbl.occupancy() != capacity {
+		t.Errorf("occupancy = %d, want %d (the table must stay bounded)", tbl.occupancy(), capacity)
 	}
 	if got := tbl.evictions(); got != 1 {
 		t.Errorf("evictions = %d, want 1 — cap pressure MUST be observable", got)
@@ -490,7 +491,7 @@ func TestPendingTable_NilFailsClosed(t *testing.T) {
 	if tbl.matches(k) {
 		t.Error("a nil pending table admitted a reply — the binding would be silently disabled")
 	}
-	if tbl.evictions() != 0 || tbl.size() != 0 {
+	if tbl.evictions() != 0 || tbl.occupancy() != 0 {
 		t.Error("nil table reported nonzero counters")
 	}
 }
@@ -671,8 +672,11 @@ func TestPendingCapacity_Derivation(t *testing.T) {
 		t.Errorf("effective window at the ceiling = %v, want < nominal %v", w, pendingTTL)
 	}
 
-	// A nonsense rate from a hand-edited active.json must not overflow.
-	if c, cl := pendingCapacityFor(1 << 40); !cl || c != pendingCapMax {
+	// A nonsense rate from a hand-edited active.json must not overflow. Use a
+	// value representable in a 32-bit int: an untyped constant that overflows
+	// int on GOARCH=386 fails to COMPILE, which would break 32-bit builds
+	// rather than test the guard.
+	if c, cl := pendingCapacityFor(1 << 30); !cl || c != pendingCapMax {
 		t.Errorf("absurd rate: capacity=%d clamped=%v, want %d/true", c, cl, pendingCapMax)
 	}
 	// Unset/negative falls back to the default rate, not to zero capacity.
@@ -737,8 +741,8 @@ func TestPendingTable_AtCapInsertIsConstantTime(t *testing.T) {
 	for i := 0; i < capacity; i++ {
 		tbl.insert(key(i))
 	}
-	if tbl.size() != capacity {
-		t.Fatalf("size = %d, want %d", tbl.size(), capacity)
+	if tbl.occupancy() != capacity {
+		t.Fatalf("occupancy = %d, want %d", tbl.occupancy(), capacity)
 	}
 
 	// Now every insert is at capacity and must evict exactly one entry.
@@ -773,8 +777,8 @@ func TestPendingTable_AtCapInsertIsConstantTime(t *testing.T) {
 	if got := tbl.evictions(); got != atCapInserts {
 		t.Errorf("evictions = %d, want %d (one per at-cap insert)", got, atCapInserts)
 	}
-	if tbl.size() != capacity {
-		t.Errorf("size = %d, want %d — the table must stay bounded", tbl.size(), capacity)
+	if tbl.occupancy() != capacity {
+		t.Errorf("occupancy = %d, want %d — the table must stay bounded", tbl.occupancy(), capacity)
 	}
 }
 
@@ -794,7 +798,7 @@ func TestPendingTable_DuplicateKeyDoesNotGrowRing(t *testing.T) {
 		tbl.insert(dup)
 		now = now.Add(time.Millisecond) // distinct expiries, as a real clock gives
 	}
-	if got := tbl.size(); got != 1 {
+	if got := tbl.liveEntries(); got != 1 {
 		t.Errorf("size = %d, want 1 — a repeated key must not accumulate entries", got)
 	}
 	if !tbl.matches(dup) {
@@ -809,5 +813,345 @@ func TestPendingTable_DuplicateKeyDoesNotGrowRing(t *testing.T) {
 	tbl.insert(fresh)
 	if !tbl.matches(fresh) || !tbl.matches(dup) {
 		t.Error("a fresh key evicted the live duplicate, or was not admitted")
+	}
+}
+
+// TestRelay_RateChangePreservesBindings is the fail-on-revert guard for the
+// #6603 re-review MAJOR: a day-2 config change must NOT destroy outstanding
+// request bindings.
+//
+// maxPacketRate participates in relaySpec.equal(), so changing it stops the
+// relay and builds a replacement with a brand-new table. Because the
+// replacement rebinds the SAME giaddr:67, replies for pre-reload requests still
+// arrive — and without migration they are then dropped by the binding gate,
+// which pre-#6562 would have been forwarded.
+//
+// It bites hardest for exactly this knob: raising maximum-packet-rate is the
+// documented remedy for a busy segment, so an operator following the docs
+// DURING a boot storm would flush every in-flight binding and trigger the retry
+// storm the binding table exists to prevent.
+//
+// Removing the phase-2.5 snapshot/adopt migration in Apply makes this RED as an
+// assertion: the OFFER is no longer delivered after the reload.
+func TestRelay_RateChangePreservesBindings(t *testing.T) {
+	h := newBindingHarness(t)
+	defer h.stop()
+
+	chaddr := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x5A}
+
+	// A client's DISCOVER goes upstream and arms a binding.
+	discover := newRequest(t, dhcpv4.MessageTypeDiscover, chaddr, nil)
+	h.relayUp(discover)
+
+	before := h.relay()
+	if !before.pending.matches(pendingKeyFor(discover)) {
+		t.Fatal("precondition: the relayed DISCOVER did not arm a binding")
+	}
+
+	// The operator raises maximum-packet-rate mid-storm — the documented
+	// remedy. This restarts the relay with a larger table.
+	cfg := singleInterfaceConfig()
+	cfg.Groups["g"].MaximumPacketRate = 3000
+	h.m.Apply(context.Background(), cfg)
+
+	after := h.relay()
+	if after == before {
+		t.Fatal("precondition: the rate change did not restart the relay, so this " +
+			"test is not exercising the migration path")
+	}
+	if got, want := after.pending.capacity(), mustCapacity(3000); got != want {
+		t.Fatalf("precondition: replacement capacity = %d, want %d", got, want)
+	}
+
+	// The binding must have survived into the replacement table.
+	if !after.pending.matches(pendingKeyFor(discover)) {
+		t.Error("the outstanding binding was destroyed by the rate change — the " +
+			"server's OFFER will now be dropped, turning the boot storm the " +
+			"operator was mitigating into a retry storm")
+	}
+
+	if got := after.repliesDroppedNoRequest.Load(); got != 0 {
+		t.Errorf("repliesDroppedNoRequest = %d, want 0 — a legitimate pre-reload "+
+			"reply must not be dropped by the reload", got)
+	}
+}
+
+// TestRelay_RateChangePreservesBindings_EndToEnd is the same MAJOR guard driven
+// all the way through the sockets: the server's OFFER for a PRE-reload DISCOVER
+// must still be delivered to the client after the relay restarts on a rate
+// change.
+//
+// It cannot use bindingHarness, because the restart opens FRESH conns from the
+// factory — the harness's original pair belongs to the dead session. A tracking
+// factory hands out a new fakeConn per open and exposes the latest pair, so the
+// test can drive the post-restart session.
+func TestRelay_RateChangePreservesBindings_EndToEnd(t *testing.T) {
+	tr := &connTracker{}
+	m := testManager(tr.factory)
+	m.Apply(context.Background(), singleInterfaceConfig())
+	defer m.Stop()
+
+	chaddr := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x6B}
+	yiaddr := net.IPv4(10, 0, 0, 92)
+
+	// Pre-reload: relay a DISCOVER through the FIRST session.
+	client, server := tr.pairAfter(t, 2)
+	discover := newRequest(t, dhcpv4.MessageTypeDiscover, chaddr, nil)
+	before := server.writeCount()
+	client.push(discover.ToBytes())
+	if !waitFor(func() bool { return server.writeCount() > before }) {
+		t.Fatal("precondition: the DISCOVER was not relayed upstream")
+	}
+
+	// The operator raises maximum-packet-rate: the relay restarts.
+	cfg := singleInterfaceConfig()
+	cfg.Groups["g"].MaximumPacketRate = 3000
+	m.Apply(context.Background(), cfg)
+
+	// Post-reload: the OFFER arrives on the NEW server socket (same giaddr:67).
+	client2, server2 := tr.pairAfter(t, 4)
+	if server2 == server {
+		t.Fatal("precondition: the restart did not open a new server conn")
+	}
+	offer := serverReply(t, discover, dhcpv4.MessageTypeOffer, yiaddr, nil, true)
+	server2.push(offer.ToBytes())
+
+	if !waitFor(func() bool { return client2.writeCount() > 0 }) {
+		t.Fatal("the OFFER answering a PRE-reload DISCOVER was not delivered to the " +
+			"client after the rate change — the reload destroyed the binding, so " +
+			"the boot storm the operator was mitigating becomes a retry storm")
+	}
+}
+
+// connTracker is a packetConnFactory that returns a fresh fakeConn per open and
+// remembers them, so a test can reach the conns of the CURRENT session after a
+// relay restart. Conns are opened client-first then server, so the latest pair
+// is the last two.
+type connTracker struct {
+	mu    sync.Mutex
+	conns []*fakeConn
+}
+
+func (ct *connTracker) factory(ctx context.Context, ifaceName string,
+	reusePort, broadcast bool, bindAddr *net.UDPAddr) (net.PacketConn, error) {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	c := newFakeConn()
+	// Odd opens are the server-facing conn; report a CONFIGURED server source so
+	// replies pass the #4163 check.
+	if len(ct.conns)%2 == 1 {
+		c.srcAddr = &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: relayPort}
+	}
+	ct.conns = append(ct.conns, c)
+	return c, nil
+}
+
+// pairAfter returns the (client, server) conns of the most recent session,
+// waiting until at least want conns have been opened in total. The count is
+// explicit because a restarted relay opens its conns ASYNCHRONOUSLY from its
+// supervisor goroutine — Apply returns before they exist, so "latest" without a
+// floor would hand back the DEAD session's pair.
+func (ct *connTracker) pairAfter(t *testing.T, want int) (*fakeConn, *fakeConn) {
+	t.Helper()
+	var client, server *fakeConn
+	ok := waitFor(func() bool {
+		ct.mu.Lock()
+		defer ct.mu.Unlock()
+		if len(ct.conns) < want || len(ct.conns)%2 != 0 {
+			return false
+		}
+		client, server = ct.conns[len(ct.conns)-2], ct.conns[len(ct.conns)-1]
+		return true
+	})
+	if !ok {
+		t.Fatalf("relay never opened %d conns (client+server per session)", want)
+	}
+	return client, server
+}
+
+// mustCapacity is pendingCapacityFor's capacity, for test preconditions.
+func mustCapacity(rate int) int {
+	c, _ := pendingCapacityFor(rate)
+	return c
+}
+
+// TestPendingTable_AdoptShrinkEvictsOldestAndCounts pins the other direction of
+// the migration: LOWERING maximum-packet-rate gives a smaller table, so some
+// bindings cannot be carried. The excess must be dropped oldest-first (the same
+// policy the steady-state path uses) and COUNTED, so a shrink is visible in
+// PendingEvicted rather than silently discarding bindings.
+func TestPendingTable_AdoptShrinkEvictsOldestAndCounts(t *testing.T) {
+	now := time.Unix(9000, 0)
+	clock := func() time.Time { return now }
+	old := newPendingTable(8, time.Hour, clock)
+
+	key := func(n byte) pendingKey {
+		return pendingKey{xid: dhcpv4.TransactionID{0, 0, 0, n}, hlen: 6}
+	}
+	for i := byte(1); i <= 8; i++ {
+		old.insert(key(i))
+		now = now.Add(time.Second)
+	}
+
+	live := old.snapshot()
+	if len(live) != 8 {
+		t.Fatalf("snapshot returned %d live bindings, want 8", len(live))
+	}
+
+	// Replacement holds only 3.
+	small := newPendingTable(3, time.Hour, clock)
+	small.adopt(live)
+
+	if got := small.occupancy(); got != 3 {
+		t.Errorf("occupancy = %d, want 3 (the replacement's capacity)", got)
+	}
+	if got := small.evictions(); got != 5 {
+		t.Errorf("evictions = %d, want 5 — a shrink must COUNT the bindings it "+
+			"cannot carry, not discard them silently", got)
+	}
+	// The NEWEST three (6,7,8) survive — they have the longest remaining life.
+	for _, n := range []byte{6, 7, 8} {
+		if !small.matches(key(n)) {
+			t.Errorf("binding %d did not survive the shrink; the newest must be kept", n)
+		}
+	}
+	for _, n := range []byte{1, 2, 3, 4, 5} {
+		if small.matches(key(n)) {
+			t.Errorf("binding %d survived; the OLDEST must be evicted first", n)
+		}
+	}
+}
+
+// TestPendingTable_SnapshotExcludesExpiredAndPreservesExpiry pins two migration
+// invariants: an already-expired binding is not resurrected by a reload, and a
+// carried binding keeps its ORIGINAL expiry. Refreshing the TTL on reload would
+// silently extend the attacker's xid-guessing window every time the operator
+// touched the config.
+func TestPendingTable_SnapshotExcludesExpiredAndPreservesExpiry(t *testing.T) {
+	now := time.Unix(9500, 0)
+	clock := func() time.Time { return now }
+	old := newPendingTable(16, 30*time.Second, clock)
+
+	stale := pendingKey{xid: dhcpv4.TransactionID{1, 0, 0, 0}, hlen: 6}
+	fresh := pendingKey{xid: dhcpv4.TransactionID{2, 0, 0, 0}, hlen: 6}
+	old.insert(stale)
+	now = now.Add(25 * time.Second)
+	old.insert(fresh) // 25s newer
+
+	now = now.Add(6 * time.Second) // stale is now 31s old (expired); fresh is 6s old
+
+	live := old.snapshot()
+	if len(live) != 1 || live[0].key != fresh {
+		t.Fatalf("snapshot = %d entries, want just the unexpired one", len(live))
+	}
+
+	replacement := newPendingTable(16, 30*time.Second, clock)
+	replacement.adopt(live)
+
+	if replacement.matches(stale) {
+		t.Error("an EXPIRED binding was resurrected by the migration")
+	}
+	if !replacement.matches(fresh) {
+		t.Fatal("the live binding did not survive the migration")
+	}
+	// Original expiry preserved: fresh was inserted 6s ago with a 30s TTL, so it
+	// must lapse 24s from now — NOT 30s (which would mean the reload refreshed
+	// it and widened the guessing window).
+	now = now.Add(25 * time.Second)
+	if replacement.matches(fresh) {
+		t.Error("the carried binding outlived its ORIGINAL expiry — a config reload " +
+			"must not refresh the TTL and extend the binding window")
+	}
+}
+
+// TestPendingTable_EqualExpiriesDoNotLoseBinding is the fail-on-revert guard for
+// the #6603 re-review MINOR 1: slot identity must be the generation counter, not
+// the expiry timestamp.
+//
+// Two inserts of the same key can receive the SAME expiry — nothing guarantees
+// time.Now() advances between two calls. With expiry-as-identity, popping the
+// OLDER slot at capacity matches the map entry the NEWER slot owns and deletes
+// it, silently losing a live binding. The clock here is FROZEN so equal
+// expiries are the case under test rather than the case avoided.
+//
+// Reverting popHeadLocked to compare expiries makes this RED.
+func TestPendingTable_EqualExpiriesDoNotLoseBinding(t *testing.T) {
+	frozen := time.Unix(10000, 0)
+	clock := func() time.Time { return frozen } // never advances
+	const capacity = 4
+	tbl := newPendingTable(capacity, time.Hour, clock)
+
+	dup := pendingKey{xid: dhcpv4.TransactionID{3, 3, 3, 3}, hlen: 6}
+	other := func(n byte) pendingKey {
+		return pendingKey{xid: dhcpv4.TransactionID{9, 9, 9, n}, hlen: 6}
+	}
+
+	// Two inserts of the same key under a frozen clock => identical expiries,
+	// two ring slots, one map entry.
+	tbl.insert(dup)
+	tbl.insert(dup)
+	if got := tbl.liveEntries(); got != 1 {
+		t.Fatalf("precondition: liveEntries = %d, want 1", got)
+	}
+	if got := tbl.occupancy(); got != 2 {
+		t.Fatalf("precondition: occupancy = %d, want 2 (two ring slots)", got)
+	}
+
+	// Fill the rest, then push past capacity so the OLDER duplicate slot is
+	// popped. It is stale, so the binding must survive.
+	tbl.insert(other(1))
+	tbl.insert(other(2))
+	tbl.insert(other(3)) // at capacity: pops the older dup slot
+
+	if !tbl.matches(dup) {
+		t.Error("the binding was lost when its STALE duplicate slot was popped — " +
+			"slot identity is being inferred from the expiry, which two inserts " +
+			"can share")
+	}
+}
+
+// TestPendingTable_OccupancyTracksRingNotMap is the fail-on-revert guard for the
+// #6603 re-review MINOR 2: the operator-facing gauge must report RING pressure,
+// because that is what governs eviction.
+//
+// Duplicate inserts consume ring slots without adding map entries, so
+// len(entries) under-reports: a capacity-4 ring holding A,B,B,B has
+// len(entries)==2 while the very next insert must evict live A. Reporting
+// len(entries) would show a comfortable 2/4 at the exact moment eviction
+// begins — the opposite of the documented contract.
+//
+// Pointing PendingSize back at len(entries) makes this RED.
+func TestPendingTable_OccupancyTracksRingNotMap(t *testing.T) {
+	now := time.Unix(11000, 0)
+	clock := func() time.Time { return now }
+	const capacity = 4
+	tbl := newPendingTable(capacity, time.Hour, clock)
+
+	a := pendingKey{xid: dhcpv4.TransactionID{0xA, 0, 0, 0}, hlen: 6}
+	b := pendingKey{xid: dhcpv4.TransactionID{0xB, 0, 0, 0}, hlen: 6}
+
+	tbl.insert(a)
+	for i := 0; i < 3; i++ {
+		tbl.insert(b) // three slots, one entry
+		now = now.Add(time.Millisecond)
+	}
+
+	if got := tbl.liveEntries(); got != 2 {
+		t.Fatalf("precondition: liveEntries = %d, want 2 (A and B)", got)
+	}
+	if got := tbl.occupancy(); got != capacity {
+		t.Errorf("occupancy = %d, want %d — the gauge must report RING slots. "+
+			"Reporting the %d map entries would show a comfortable %d/%d at the "+
+			"exact moment the next insert evicts live A.",
+			got, capacity, tbl.liveEntries(), tbl.liveEntries(), capacity)
+	}
+
+	// Confirm the premise: the next insert really does evict.
+	tbl.insert(pendingKey{xid: dhcpv4.TransactionID{0xC, 0, 0, 0}, hlen: 6})
+	if got := tbl.evictions(); got == 0 {
+		t.Error("premise failed: the table was full but the next insert did not evict")
+	}
+	if tbl.matches(a) {
+		t.Error("premise failed: A should have been the evicted (oldest) entry")
 	}
 }

--- a/pkg/dhcprelay/relay_binding_6562_test.go
+++ b/pkg/dhcprelay/relay_binding_6562_test.go
@@ -248,7 +248,7 @@ func TestRelay_NormalExchange_EndToEndStillRelays(t *testing.T) {
 	}
 	if got := ir.pending.evictions(); got != 0 {
 		t.Errorf("pendingEvicted = %d, want 0 (4 requests cannot fill an %d-entry table)",
-			got, pendingCap)
+			got, ir.pending.capacity())
 	}
 	if got := ir.repliesForwarded.Load(); got != 4 {
 		t.Errorf("repliesForwarded = %d, want 4 (OFFER, ACK, RENEW-ACK, REBIND-ACK)", got)
@@ -368,7 +368,7 @@ func TestHandleServerResponses_WrongChaddrDropped(t *testing.T) {
 // xid. Consuming the entry on first match would drop every reply after the
 // first and silently break multi-server redundancy.
 func TestPendingTable_MatchDoesNotConsume(t *testing.T) {
-	tbl := newPendingTable(pendingCap, pendingTTL, time.Now)
+	tbl := newPendingTable(defaultTestPendingCap(), pendingTTL, time.Now)
 	k := pendingKey{xid: dhcpv4.TransactionID{1, 2, 3, 4}, hlen: 6}
 	tbl.insert(k)
 
@@ -384,7 +384,7 @@ func TestPendingTable_MatchDoesNotConsume(t *testing.T) {
 func TestPendingTable_Expiry(t *testing.T) {
 	now := time.Unix(1000, 0)
 	clock := func() time.Time { return now }
-	tbl := newPendingTable(pendingCap, 30*time.Second, clock)
+	tbl := newPendingTable(defaultTestPendingCap(), 30*time.Second, clock)
 	k := pendingKey{xid: dhcpv4.TransactionID{9, 9, 9, 9}, hlen: 6}
 	tbl.insert(k)
 
@@ -560,5 +560,254 @@ func TestManagerRelay_HasPendingTable(t *testing.T) {
 		if ir.pending == nil {
 			t.Errorf("relay %q has a nil pending table — every reply would be dropped", name)
 		}
+	}
+}
+
+// defaultTestPendingCap is the capacity a default-rate relay gets. Tests that
+// only need "a table big enough not to interfere" use it rather than a literal.
+func defaultTestPendingCap() int {
+	c, _ := pendingCapacityFor(defaultMaxPacketRate)
+	return c
+}
+
+// TestPendingCapacity_TracksMaxPacketRate is the #6603-F1 fail-on-revert guard.
+// It pins the PROPERTY — a reply arriving one server-RTT after its request must
+// still bind at a raised `overrides maximum-packet-rate` — not the capacity
+// number.
+//
+// The regression it guards: capacity used to be a hardcoded 8192 while the fill
+// rate is the configurable maxPacketRate, so steady-state occupancy
+// (rate x pendingTTL) exceeded capacity above ~273 pps and the effective
+// binding window collapsed from 30s to 8192/rate seconds. On a segment
+// provisioned at 3000 pps — which the relay's own README recommends for a busy
+// segment — the window collapsed to 2.7s, so a boot storm against a saturated
+// server (RTT > 2.7s) had every reply dropped at the relay: a completed storm
+// turned into a permanent retry storm.
+//
+// Reverting pendingCapacityFor to a fixed 8192 makes this RED as an assertion:
+// the victim's binding is evicted by the intervening traffic and the reply that
+// arrives one RTT later no longer matches.
+func TestPendingCapacity_TracksMaxPacketRate(t *testing.T) {
+	const (
+		rate      = 3000     // operator raised maximum-packet-rate
+		rttPacket = rate * 3 // 3 seconds of traffic while the server thinks
+		oldFixed  = 8192     // the pre-fix hardcoded capacity
+	)
+	// The scenario is only meaningful if the intervening traffic would have
+	// overflowed the OLD fixed capacity; otherwise the test proves nothing.
+	if rttPacket <= oldFixed {
+		t.Fatalf("test is vacuous: %d intervening inserts do not exceed the old cap %d",
+			rttPacket, oldFixed)
+	}
+
+	capacity, clamped := pendingCapacityFor(rate)
+	if clamped {
+		t.Fatalf("capacity for %d pps was clamped (%d) — the ceiling must not bind "+
+			"at a realistic campus rate", rate, capacity)
+	}
+	now := time.Unix(5000, 0)
+	tbl := newPendingTable(capacity, pendingTTL, func() time.Time { return now })
+
+	// A client's request goes upstream.
+	victim := pendingKey{xid: dhcpv4.TransactionID{0xDE, 0xAD, 0xBE, 0xEF}, hlen: 6}
+	tbl.insert(victim)
+
+	// The server is saturated; meanwhile the segment keeps offering traffic at
+	// the configured rate for one server RTT (3s, inside the 30s TTL).
+	for i := 0; i < rttPacket; i++ {
+		tbl.insert(pendingKey{
+			xid:  dhcpv4.TransactionID{byte(i), byte(i >> 8), byte(i >> 16), 0x01},
+			hlen: 6,
+		})
+	}
+	now = now.Add(3 * time.Second)
+
+	// The OFFER finally arrives, still well inside the 30s binding window.
+	if !tbl.matches(victim) {
+		t.Errorf("a reply arriving %s after its request no longer binds at %d pps "+
+			"(capacity %d, %d intervening requests, evictions %d) — the binding "+
+			"window collapsed and legitimate DHCP is being dropped",
+			3*time.Second, rate, capacity, rttPacket, tbl.evictions())
+	}
+	if got := tbl.evictions(); got != 0 {
+		t.Errorf("evictions = %d, want 0 — a correctly-sized table must not evict "+
+			"within one TTL of legitimate rate-limited traffic", got)
+	}
+}
+
+// TestPendingCapacity_Derivation pins the sizing rule and its bounds: capacity
+// covers the sustained window plus the token bucket's burst, never drops below
+// the floor, and is clamped (with the clamp REPORTED) at the memory ceiling so
+// the derivation cannot itself become a memory-exhaustion vector.
+func TestPendingCapacity_Derivation(t *testing.T) {
+	ttlSecs := int(pendingTTL / time.Second)
+
+	for _, rate := range []int{1, 50, defaultMaxPacketRate, 500, 3000} {
+		capacity, clamped := pendingCapacityFor(rate)
+		if clamped {
+			t.Errorf("rate %d: unexpectedly clamped at capacity %d", rate, capacity)
+		}
+		if capacity < pendingCapMin {
+			t.Errorf("rate %d: capacity %d below the floor %d", rate, capacity, pendingCapMin)
+		}
+		// Must hold a full TTL of rate-limited traffic (the whole point).
+		if want := rate * ttlSecs; capacity < want {
+			t.Errorf("rate %d: capacity %d < rate*TTL %d — the window would collapse",
+				rate, capacity, want)
+		}
+	}
+
+	// Ceiling: the schema allows up to 1000000 pps; an unclamped derivation
+	// would be ~3e7 entries (gigabytes).
+	capacity, clamped := pendingCapacityFor(1000000)
+	if !clamped {
+		t.Error("1000000 pps was not reported as clamped")
+	}
+	if capacity != pendingCapMax {
+		t.Errorf("capacity at 1000000 pps = %d, want the ceiling %d", capacity, pendingCapMax)
+	}
+	// And the clamp must be reported with an honest effective window.
+	if w := pendingWindow(capacity, 1000000); w >= pendingTTL {
+		t.Errorf("effective window at the ceiling = %v, want < nominal %v", w, pendingTTL)
+	}
+
+	// A nonsense rate from a hand-edited active.json must not overflow.
+	if c, cl := pendingCapacityFor(1 << 40); !cl || c != pendingCapMax {
+		t.Errorf("absurd rate: capacity=%d clamped=%v, want %d/true", c, cl, pendingCapMax)
+	}
+	// Unset/negative falls back to the default rate, not to zero capacity.
+	if c, _ := pendingCapacityFor(0); c < pendingCapMin {
+		t.Errorf("unset rate: capacity %d below floor %d", c, pendingCapMin)
+	}
+}
+
+// TestManagerRelay_PendingCapacityFollowsOverride pins the WIRING: the relay
+// the manager builds must size its table from the interface's resolved
+// maximum-packet-rate, not from a constant. Without this the derivation could
+// be correct and simply not plumbed in.
+func TestManagerRelay_PendingCapacityFollowsOverride(t *testing.T) {
+	cfg := singleInterfaceConfig()
+	cfg.Groups["g"].MaximumPacketRate = 3000
+
+	client := newFakeConn()
+	server := newFakeConn()
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+	m.Apply(context.Background(), cfg)
+	defer m.Stop()
+
+	want, _ := pendingCapacityFor(3000)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, ir := range m.relays {
+		if got := ir.pending.capacity(); got != want {
+			t.Errorf("relay %q pending capacity = %d, want %d (derived from "+
+				"maximum-packet-rate 3000)", name, got, want)
+		}
+		if ir.pendingClamped {
+			t.Errorf("relay %q reported a clamp at 3000 pps", name)
+		}
+	}
+}
+
+// TestPendingTable_AtCapInsertIsConstantTime pins the O(1) invariant of the
+// at-capacity insert path deterministically — by counting ring slots examined,
+// not by timing, so it cannot flake.
+//
+// The regression it guards: the original implementation ranged the ENTIRE map
+// to find the minimum expiry, and did so twice per admitted packet once full
+// (a reap sweep plus an evict scan). That is O(capacity) per packet on the
+// single client-facing read goroutine — hundreds of microseconds per packet at
+// a raised rate, saturating a core during exactly the overload the table is
+// meant to survive. Because every entry carries the SAME ttl, insertion order
+// IS expiry order, so the oldest is always at the ring head and no scan is
+// needed.
+func TestPendingTable_AtCapInsertIsConstantTime(t *testing.T) {
+	now := time.Unix(7000, 0)
+	clock := func() time.Time { return now }
+	const capacity = 2048
+	tbl := newPendingTable(capacity, time.Hour, clock) // long TTL: force CAP pressure
+
+	key := func(i int) pendingKey {
+		return pendingKey{
+			xid:  dhcpv4.TransactionID{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)},
+			hlen: 6,
+		}
+	}
+	for i := 0; i < capacity; i++ {
+		tbl.insert(key(i))
+	}
+	if tbl.size() != capacity {
+		t.Fatalf("size = %d, want %d", tbl.size(), capacity)
+	}
+
+	// Now every insert is at capacity and must evict exactly one entry.
+	const atCapInserts = 4096
+	before := tbl.scans()
+	for i := 0; i < atCapInserts; i++ {
+		tbl.insert(key(capacity + i))
+	}
+	scans := tbl.scans() - before
+
+	// LOWER bound first, and it is load-bearing. Each at-cap insert must free a
+	// slot through the ring, so scans must be at LEAST one per insert. Without
+	// this, an implementation that abandons the ring for a map scan reports
+	// zero scans and would sail past the upper bound alone — the test would
+	// pass for the wrong reason. (Verified: reverting the eviction to the
+	// original minimum-expiry map scan leaves the upper bound green and is
+	// caught only here.)
+	if scans < uint64(atCapInserts) {
+		t.Errorf("at-cap inserts examined only %d ring slots for %d inserts; each "+
+			"at-cap insert must free a slot through the ring. The eviction path "+
+			"is bypassing the ring, so this test can no longer see its cost.",
+			scans, atCapInserts)
+	}
+	// O(1) means a small constant per insert. O(capacity) would be
+	// atCapInserts*capacity = 8388608. Allow generous slack (4x) so the bound
+	// still fails loudly on any return to scanning.
+	if maxScans := uint64(atCapInserts * 4); scans > maxScans {
+		t.Errorf("at-cap inserts examined %d ring slots for %d inserts (%.1f per insert); "+
+			"want O(1) (<= %d total). The eviction path has regressed to a scan.",
+			scans, atCapInserts, float64(scans)/float64(atCapInserts), maxScans)
+	}
+	if got := tbl.evictions(); got != atCapInserts {
+		t.Errorf("evictions = %d, want %d (one per at-cap insert)", got, atCapInserts)
+	}
+	if tbl.size() != capacity {
+		t.Errorf("size = %d, want %d — the table must stay bounded", tbl.size(), capacity)
+	}
+}
+
+// TestPendingTable_DuplicateKeyDoesNotGrowRing pins the ring/map invariant for
+// a repeated key: a client retransmitting the same xid (or the SELECTING
+// REQUEST reusing the DISCOVER's xid) adds a ring slot each time while the map
+// keeps one entry. The stale slots must be reclaimed for free rather than
+// pushing the structures past capacity or evicting live entries.
+func TestPendingTable_DuplicateKeyDoesNotGrowRing(t *testing.T) {
+	now := time.Unix(8000, 0)
+	clock := func() time.Time { return now }
+	const capacity = 64
+	tbl := newPendingTable(capacity, time.Hour, clock)
+
+	dup := pendingKey{xid: dhcpv4.TransactionID{7, 7, 7, 7}, hlen: 6}
+	for i := 0; i < capacity*8; i++ {
+		tbl.insert(dup)
+		now = now.Add(time.Millisecond) // distinct expiries, as a real clock gives
+	}
+	if got := tbl.size(); got != 1 {
+		t.Errorf("size = %d, want 1 — a repeated key must not accumulate entries", got)
+	}
+	if !tbl.matches(dup) {
+		t.Error("the repeated key no longer binds")
+	}
+	if got := tbl.capacity(); got != capacity {
+		t.Errorf("capacity = %d, want %d (the ring must not grow)", got, capacity)
+	}
+	// Stale slots are reclaimed, so a fresh key must still be admitted without
+	// evicting the live one.
+	fresh := pendingKey{xid: dhcpv4.TransactionID{1, 1, 1, 1}, hlen: 6}
+	tbl.insert(fresh)
+	if !tbl.matches(fresh) || !tbl.matches(dup) {
+		t.Error("a fresh key evicted the live duplicate, or was not admitted")
 	}
 }

--- a/pkg/dhcprelay/relay_binding_6562_test.go
+++ b/pkg/dhcprelay/relay_binding_6562_test.go
@@ -1155,3 +1155,138 @@ func TestPendingTable_OccupancyTracksRingNotMap(t *testing.T) {
 		t.Error("premise failed: A should have been the evicted (oldest) entry")
 	}
 }
+
+// TestPendingTable_FullDrainIsConstantTime is the fail-on-revert guard for the
+// #6603 re-review MINOR 4: reclaiming an ENTIRELY expired table must not walk
+// it slot by slot.
+//
+// The ring is expiry-ordered, so once the newest slot has expired every slot
+// has. Popping them one at a time is up to pendingCapMax (131072) iterations,
+// each with a map lookup and delete, under the mutex on the client-facing
+// packet path — a multi-millisecond stall that also blocks the reply loop, on
+// the first insert after any idle period. The fast path takes that case in
+// constant time.
+//
+// Scans are counted rather than timed, so this cannot flake. Removing the
+// fast path makes it RED as an assertion: the drain examines one slot per
+// entry instead of a single probe.
+func TestPendingTable_FullDrainIsConstantTime(t *testing.T) {
+	now := time.Unix(12000, 0)
+	clock := func() time.Time { return now }
+	const capacity = 2048
+	tbl := newPendingTable(capacity, 30*time.Second, clock)
+
+	key := func(i int) pendingKey {
+		return pendingKey{
+			xid:  dhcpv4.TransactionID{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)},
+			hlen: 6,
+		}
+	}
+	for i := 0; i < capacity; i++ {
+		tbl.insert(key(i))
+	}
+	if got := tbl.occupancy(); got != capacity {
+		t.Fatalf("precondition: occupancy = %d, want %d", got, capacity)
+	}
+
+	// Idle past the TTL: EVERY slot is now expired.
+	now = now.Add(time.Hour)
+
+	before := tbl.scans()
+	tbl.insert(key(capacity)) // the first insert after the idle period
+	scans := tbl.scans() - before
+
+	// A per-slot drain would examine ~capacity slots. Allow a small constant.
+	if scans > 8 {
+		t.Errorf("the first insert after an idle period examined %d ring slots "+
+			"for a %d-entry table; a fully expired ring must be reclaimed in "+
+			"constant time, not popped slot by slot under the mutex on the "+
+			"packet path", scans, capacity)
+	}
+
+	// The reclaim must be REAL, not just cheap: the table now holds only the
+	// new key, and the expired ones must be gone from both structures.
+	if got := tbl.occupancy(); got != 1 {
+		t.Errorf("occupancy after the drain = %d, want 1 (only the new insert)", got)
+	}
+	if got := tbl.liveEntries(); got != 1 {
+		t.Errorf("liveEntries after the drain = %d, want 1 — the expired keys are "+
+			"still in the map", got)
+	}
+	if !tbl.matches(key(capacity)) {
+		t.Error("the newly inserted binding did not survive the drain")
+	}
+	if tbl.matches(key(0)) {
+		t.Error("an expired binding survived the drain")
+	}
+	// A wholesale drain is EXPIRY, not cap pressure: it must not be counted as
+	// an eviction, or an idle relay would look like it was shedding load.
+	if got := tbl.evictions(); got != 0 {
+		t.Errorf("evictions = %d, want 0 — expiry is not cap-pressure eviction", got)
+	}
+}
+
+// TestPendingTable_AdoptRespectsRemainingRoom pins adopt's bound: it is the
+// REMAINING room, not the raw capacity.
+//
+// pushLocked's contract is that the caller has already made room. Bounding by
+// capacity alone breaks it for a non-empty destination — count runs past the
+// ring length and the modular index silently overwrites live slots. Production
+// always adopts into a freshly built table, so this guards the invariant
+// against a future second caller rather than a live path.
+func TestPendingTable_AdoptRespectsRemainingRoom(t *testing.T) {
+	now := time.Unix(13000, 0)
+	clock := func() time.Time { return now }
+
+	key := func(n byte) pendingKey {
+		return pendingKey{xid: dhcpv4.TransactionID{0, 0, 0, n}, hlen: 6}
+	}
+
+	// Source: four live bindings.
+	src := newPendingTable(8, time.Hour, clock)
+	for i := byte(1); i <= 4; i++ {
+		src.insert(key(i))
+		now = now.Add(time.Second)
+	}
+	live := src.snapshot()
+	if len(live) != 4 {
+		t.Fatalf("precondition: snapshot = %d, want 4", len(live))
+	}
+
+	// Destination: capacity 4, but already holding two of its own.
+	dst := newPendingTable(4, time.Hour, clock)
+	dst.insert(key(0xE1))
+	dst.insert(key(0xE2))
+
+	dst.adopt(live)
+
+	if got := dst.occupancy(); got > dst.capacity() {
+		t.Fatalf("occupancy = %d exceeds capacity %d — adopt overran the ring and "+
+			"overwrote live slots", got, dst.capacity())
+	}
+	if got := dst.occupancy(); got != 4 {
+		t.Errorf("occupancy = %d, want 4 (the ring is full)", got)
+	}
+	// Only two slots were free, so only the two NEWEST carried bindings fit and
+	// the two oldest are counted as evictions.
+	if got := dst.evictions(); got != 2 {
+		t.Errorf("evictions = %d, want 2 — bindings that did not fit must be "+
+			"counted, not silently dropped", got)
+	}
+	for _, n := range []byte{3, 4} {
+		if !dst.matches(key(n)) {
+			t.Errorf("carried binding %d is missing; the newest must be kept", n)
+		}
+	}
+	for _, n := range []byte{1, 2} {
+		if dst.matches(key(n)) {
+			t.Errorf("carried binding %d was kept; the oldest must be dropped first", n)
+		}
+	}
+	// The destination's pre-existing bindings must not have been clobbered.
+	for _, n := range []byte{0xE1, 0xE2} {
+		if !dst.matches(key(n)) {
+			t.Errorf("pre-existing binding %#x was overwritten by adopt", n)
+		}
+	}
+}

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -457,6 +457,9 @@ type fakeConn struct {
 	// the #4163 source-validation tests drive a reply from a non-configured
 	// source without disturbing the existing reply-path tests.
 	srcAddr net.Addr
+	// wake signals a blocked ReadFrom that push() queued a new datagram.
+	// Buffered depth 1; see push.
+	wake chan struct{}
 }
 
 type fakeWrite struct {
@@ -465,7 +468,7 @@ type fakeWrite struct {
 }
 
 func newFakeConn() *fakeConn {
-	return &fakeConn{closeCh: make(chan struct{})}
+	return &fakeConn{closeCh: make(chan struct{}), wake: make(chan struct{}, 1)}
 }
 
 func (f *fakeConn) ReadFrom(p []byte) (int, net.Addr, error) {
@@ -487,8 +490,31 @@ func (f *fakeConn) ReadFrom(p []byte) (int, net.Addr, error) {
 	if rerr != nil {
 		return 0, nil, rerr
 	}
-	<-f.closeCh
-	return 0, nil, net.ErrClosed
+	// Nothing queued: block until Close (the pre-existing behavior every
+	// pre-seeding test relies on) OR until push() queues a datagram mid-flight.
+	// The wake path exists for the #6562 end-to-end exchange test, which must
+	// inject a server reply only AFTER the request it answers has been relayed
+	// — a reply pre-seeded before the session starts would race the binding.
+	select {
+	case <-f.closeCh:
+		return 0, nil, net.ErrClosed
+	case <-f.wake:
+		return f.ReadFrom(p)
+	}
+}
+
+// push queues a datagram for a subsequent ReadFrom and wakes a reader that is
+// already blocked. The wake channel is buffered depth 1 and the send is
+// non-blocking, so a push that races a reader already draining pending cannot
+// deadlock: the queued datagram is picked up by the next read either way.
+func (f *fakeConn) push(d []byte) {
+	f.mu.Lock()
+	f.pending = append(f.pending, d)
+	f.mu.Unlock()
+	select {
+	case f.wake <- struct{}{}:
+	default:
+	}
 }
 
 func (f *fakeConn) WriteTo(p []byte, addr net.Addr) (int, error) {

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -473,33 +473,38 @@ func newFakeConn() *fakeConn {
 
 func (f *fakeConn) ReadFrom(p []byte) (int, net.Addr, error) {
 	f.readCalls.Add(1)
-	f.mu.Lock()
-	if len(f.pending) > 0 {
-		d := f.pending[0]
-		f.pending = f.pending[1:]
-		src := f.srcAddr
-		f.mu.Unlock()
-		n := copy(p, d)
-		if src == nil {
-			src = &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 68}
+	// Loop rather than recurse after a wake: a push that is consumed by a
+	// racing reader leaves this reader to block again, and iteration keeps
+	// that bounded by the stack the caller already has.
+	for {
+		f.mu.Lock()
+		if len(f.pending) > 0 {
+			d := f.pending[0]
+			f.pending = f.pending[1:]
+			src := f.srcAddr
+			f.mu.Unlock()
+			n := copy(p, d)
+			if src == nil {
+				src = &net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 68}
+			}
+			return n, src, nil
 		}
-		return n, src, nil
-	}
-	rerr := f.readErr
-	f.mu.Unlock()
-	if rerr != nil {
-		return 0, nil, rerr
-	}
-	// Nothing queued: block until Close (the pre-existing behavior every
-	// pre-seeding test relies on) OR until push() queues a datagram mid-flight.
-	// The wake path exists for the #6562 end-to-end exchange test, which must
-	// inject a server reply only AFTER the request it answers has been relayed
-	// — a reply pre-seeded before the session starts would race the binding.
-	select {
-	case <-f.closeCh:
-		return 0, nil, net.ErrClosed
-	case <-f.wake:
-		return f.ReadFrom(p)
+		rerr := f.readErr
+		f.mu.Unlock()
+		if rerr != nil {
+			return 0, nil, rerr
+		}
+		// Nothing queued: block until Close (the pre-existing behavior every
+		// pre-seeding test relies on) OR until push() queues a datagram
+		// mid-flight. The wake path exists for the #6562 end-to-end exchange
+		// test, which must inject a server reply only AFTER the request it
+		// answers has been relayed — a reply pre-seeded before the session
+		// starts would race the binding.
+		select {
+		case <-f.closeCh:
+			return 0, nil, net.ErrClosed
+		case <-f.wake:
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #6562

Two related defects in the DHCPv4 relay, fixed by **two distinct gates** with
separate fail-on-revert binders.

## RFC citation correction

The issue cites "RFC 3203 §5" for the FORCERENEW authentication requirement.
**That is wrong** — §5 is *IANA Considerations*. The requirement is **§6**
(*Security Considerations*). A stale comment in `relay.go` also mis-cited
"RFC 3203 §3.1" for the type-9 value (§3 is the state diagram and has no §3.1;
the value is defined in §4 and assigned in §5). Both are corrected here. Every
RFC quote below was read from the RFC-Editor text, not paraphrased.

## Defect 1 — a relayed reply was never bound to an outstanding request

`handleServerResponses` forwarded any well-formed BOOTREPLY that passed the
#4163 source-IP allow-list. A source IP is spoofable, so an off-path attacker
forging a configured server's address could inject an OFFER/ACK (hostile
gateway/DNS) or a NAK (forced client restart).

New `pkg/dhcprelay/pending.go` adds a bounded, expiring table of outstanding
transactions. The client loop records each request **before** writing it
upstream (the reply loop is a different goroutine; a post-send insert races a
fast server's OFFER), and the reply loop forwards OFFER/ACK/NAK only on a match.

**Client identity — `xid` + `chaddr`.** RFC 2131 §4.3.1 Table 3 requires a
server to copy **both** from the client's message into OFFER/ACK/NAK, so both
are available on request *and* reply. The relay's own mutations (`hops`,
`giaddr`, Option 82) touch neither, so the key is stable across stamping
(pinned by `TestPendingKeyFor_RequestAndReplyAgree`). Option 61 (client-id) is
**deliberately excluded** despite being stronger identity: RFC 6842 §2 records
that RFC 2131 said the server "MUST NOT return the 'client identifier' option
in DHCPOFFER and DHCPACK messages", and only RFC 6842 §3 (2013) reversed it —
keying on it would drop every reply from a pre-6842 server. Ingress interface
is not keyed: each relay interface owns its own table.

**Bounded — 8192/interface, evict-OLDEST.** The cap is a *backstop*, not the
primary bound: the #5670 rate limiter already caps fill at 100 pps, so
steady-state occupancy is `rate × TTL` ≈ 3000, leaving ~2.7× headroom — a
default-configured relay never evicts. At the cap it reaps expired entries
first, then evicts the oldest. **Justification:** dropping *new* requests at the
cap would let an attacker who fills the table lock out every new client (a total
segment outage); evicting the oldest degrades gracefully. Critically the choice
trades away **no security** — eviction can only cause a legitimate reply to be
*dropped*, never an unsolicited reply to be *accepted*, so both policies fail in
the availability direction only and the tie-break is which outage is smaller.

**Timeout — 30s.** RFC 2131 §4.1's retransmission schedule is 4s, then 8s,
doubling to a 64s max, so 30s spans the first three retransmissions. A
too-short TTL is self-healing: the retransmission itself traverses the relay and
arms a fresh entry. This holds **whichever xid the client picks** — §4.1 leaves
that open ("A client may choose to reuse the same 'xid' or select a new 'xid'
for each retransmitted message") — because the server's answer echoes whatever
xid the retransmission carried.

**Broadcast/relay specifics.** A match does **not** consume the entry: the relay
fans each request out to *every* server in the group, so an N-server group
answers one DISCOVER with N OFFERs, and RFC 2131 §4.4.1 has the SELECTING
DHCPREQUEST reuse the DHCPOFFER's xid, so the same binding must admit the
ACK/NAK. Consuming on first match would silently break multi-server redundancy.
The table lives on `interfaceRelay`, not the session, so a #2347/#3960 rebuild
does not strand a client mid-transaction. A client with an all-zero `chaddr`
(RFC 6842 §2) still binds — the server echoes the zero chaddr.

## Defect 2 — FORCERENEW forwarded with no RFC 3118 authentication

**Decision: refuse to forward.** This reverses #2645, which forwarded it
reasoning that RFC 3118 auth is end-to-end and "out of scope for the relay".

RFC 3203 **§6** makes it mandatory, and says why:

> As in some network environments FORCERENEW can be used to snoop and spoof
> traffic, the FORCERENEW message MUST be authenticated using the procedures as
> described in [DHCP-AUTH]. FORCERENEW messages failing the authentication
> should be silently discarded by the client.

**A relay structurally cannot discharge that MUST.** RFC 3118 §5.2 defines the
key as "K — a secret value shared between the **source and destination** of the
message" and notes "Delayed authentication requires a shared secret key for each
client on each DHCP server"; §3 (*Interaction with Relay Agents*) casts the
relay purely as a transparent mutator whose `giaddr`/`hops`/Option-82 changes
are **excluded** from the hash; §5.3 assigns validation to the receiver ("If the
MAC computed by the **receiver** does not match... the receiver MUST discard the
DHCP message"). The relay is neither source, destination, nor receiver, and
holds no secret or secret-ID map.

**Why not an Option-90 presence check?** It would be theater. The off-path
attacker here already forges the server's source IP, so they can equally attach
a well-formed Option 90 with a bogus MAC — and the relay cannot check the MAC.
A presence test admits exactly the attacker it is meant to stop, and most
deployed clients do not implement RFC 3118 to catch it downstream.

**Refusal is a handled condition, not an outage.** RFC 3203 §2.2: "If the
FORCERENEW message is lost, the DHCP server will not receive a DHCP REQUEST from
the client and it should retransmit the FORCERENEW message using an exponential
backoff algorithm." Ordinary leasing is untouched — clients still renew at
T1/T2. Only forced *early* renew through this relay is withdrawn.

**Nothing in the tree depends on forwarding it** — the only code references were
`relay.go` itself and #2645's two tests (both updated here); all other hits are
docs/history. No opt-in knob: if a deployment needs relayed FORCERENEW that is a
follow-up which should come with a way to actually *verify* it.

## Observability — every drop path is visible

The fail direction matters more than usual: an over-strict binding silently
breaks DHCP for real clients, a worse outage than the attack. Three counters
added to `RelayStats` and `show services dhcp relay`:

| Counter | Meaning |
|---|---|
| `RepliesDroppedNoRequest` | Reply bound to no outstanding request — an injection, **or a legitimate reply that missed the window** (watch, don't assume hostile) |
| `PendingEvicted` | Table at capacity under flood; legitimate bindings are being lost — the early warning that pairs with the above |
| `RepliesDroppedForceRenew` | FORCERENEW refused |

Both new drop paths log warn-once-then-`Debug` (never per packet). A nil table
fails **closed**, matching the #4163 empty-allow-set posture, so a wiring
regression is a loud counted outage rather than a silent loss of the control
(`TestManagerRelay_HasPendingTable` guards production wiring).

## Validation

**Fail-on-revert, proven separately for each defect** — each an *assertion*
failure with `go vet` clean (no build break):

| Revert | Red | Green |
|---|---|---|
| Disable the binding gate only | `NoOutstandingRequestDropped`, `WrongChaddrDropped` | `ForceRenewRefused`, over-reach guard |
| Restore the FORCERENEW forward | `ForceRenewRefused` | binding tests, over-reach guard |

Each revert reddens only its own binder, confirming the two gates are genuinely
independent.

**Over-reach guard — `TestRelay_NormalExchange_EndToEndStillRelays`** drives
DISCOVER/OFFER, REQUEST/ACK, **RENEW** and **REBIND** through the *live*
manager, with every binding created by production code rather than a test
helper, asserting each message crosses the relay in both directions and that no
drop counter moves. **It stayed GREEN under both reverts.** It needed a
`fakeConn.push()` wake path (additive; pre-seeding tests unaffected) so a reply
can be injected only *after* the request it answers has been relayed — a
pre-seeded reply would race the binding.

Also added: TTL expiry, cap/evict-oldest with counter, expired-reclaimed-is-not-
eviction, no-consume-on-match, nil-fails-closed, key round-trip, oversize-chaddr
no-panic.

`pkg/dhcprelay` + `pkg/dhcp` + `pkg/dhcpserver` all pass including `-race`;
`pkg/cli` passes; `go build ./...`, `gofmt` and `vet` clean.

## Docs

`pkg/dhcprelay/README.md` gains an "Outstanding-request binding (#6562)" section
(keying, cap/eviction and TTL rationale, no-consume rule, fail direction, table
lifetime, per-node HA behaviour), a rewritten FORCERENEW section with the RFC
quotes, updated counter list, message-type table and reply-delivery intro.

## Not covered

Per-node HA: if a client transaction spans a failover the newly-active node has
no binding and drops the in-flight reply; the client's normal retransmission
re-arms it. Bounded by one retransmission and visible in
`RepliesDroppedNoRequest` — documented in the README rather than solved here
(cross-node pending sync would be a separate change).