### PR TITLE
config: compile chained flat-set application match leaves

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -62122,3 +62122,58 @@ break — `go vet` confirmed passing under every revert.
   22.7 Gbps) and needs no re-run for a comment-only change.
 - **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
     pkg/routing/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6524 fix — a chained flat-set custom application compiled
+  PROTOCOL-ONLY, so a policy matching it permitted ALL TCP.
+  `set applications application myapp protocol tcp destination-port 8080`
+  builds a CHAIN of single-key nodes (SetPath parks the rest of the line under
+  the node it just created, because these leaves declare `children: nil`), so
+  `destination-port` nests under the VALUE node `tcp` and is never a sibling of
+  `protocol`. compileApplications iterated only `inst.node.Children`, saw just
+  `protocol`, and never assigned DestinationPort; an empty port term matches
+  ANY port (pkg/policymatch), so the referencing policy over-permitted. Nothing
+  caught it: protocol / destination-port / source-port were the only
+  `applications application` match leaves neither typed nor `scalar: true`, so
+  no arity gate engaged and the chained form validated clean at BOTH
+  SchemaValidate and strict commit. The REVERSE order was caught only
+  incidentally by the #3109 protocol-less gate — that asymmetry hid it.
+  Verified firsthand before coding (ParseSetCommand + SetPath, never
+  NewParser): dumped the chain AST, confirmed DestinationPort=="" with
+  SchemaValidate CLEAN, then confirmed a permit policy admitted tcp/22.
+  Fixed in the COMPILER, not the schema, and said why: CompileConfigLenient
+  (boot load + HA SyncApply) downgrades a schema rejection to a WARNING and
+  keeps compiling, so a schema-only reject would leave a persisted or
+  peer-pushed config still protocol-only and still permitting all TCP — exactly
+  where no operator sees the warning. It would also mint a new
+  commit-vs-load split for a spelling that now has well-defined semantics (the
+  divergence class #3606 calls out). New `applicationDirectLeaves` walks the
+  chain across BOTH AST shapes and splits each node's PACKED Keys into one leaf
+  per recognized keyword — a three-leaf line collapses to
+  `protocol tcp -> Keys=[source-port 5000 destination-port 8080]`, so a
+  Keys[2:]-is-garbage rule was wrong and the scan is keyword-delimited, the same
+  shape parseApplicationTerms uses. Tokens it cannot map to a known leaf land on
+  the new Application.UnknownDirectLeaves and are hard-rejected by
+  validateApplicationSyntaxStrict (lenient-warn), which is what makes
+  `protocol [ tcp udp ]` and `destination-port [ 22 23 ]` operator-visible: a
+  DIRECT body holds ONE protocol and ONE port, so a bracket tail is
+  unrepresentable, not merely mis-read. The record is carried onto generated
+  term applications too, since the parent struct is discarded on that branch.
+  `term` is emitted but not descended into (its subtree is opaque and
+  parseApplicationTerms already guards it with UnknownTermLeaves).
+  Fail-on-revert asserts the POLICY OUTCOME, not the struct: with the walk
+  reverted, tcp/22 is PERMITTED by an app declared `protocol tcp
+  destination-port 8080` and the 4 pkg/policymatch tests go RED, while the two
+  over-reach guards (hierarchical + sibling flat-set spellings) stay GREEN.
+  Golden 4406 shifted by exactly 3 leaves — its own fixture uses the chained
+  form, so appA's DestinationPort went ""->"80" (the bug was sitting in the
+  project's own corpus) — plus the new struct field key; regenerated.
+  Full pkg/config + pkg/policymatch green. pkg/dataplane/userspace has 7
+  event-stream failures, verified IDENTICAL on pristine origin/master
+  (detached worktree, diffed failure lists) — pre-existing, zero regressions.
+- **File(s)**: pkg/config/{compiler_applications.go,types_security.go,
+    compiler_validate_strict_application.go,
+    compiler_application_chained_leaves_6524_test.go,
+    testdata/golden_4406.json},
+    pkg/policymatch/app_chained_leaves_6524_test.go,
+    docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62349,3 +62349,16 @@ break — `go vet` confirmed passing under every revert.
 - **File(s)**: pkg/config/{compiler_applications.go,types_security.go,
     compiler_application_chained_leaves_6524_test.go},
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6524 review-fold round 4 (Codex MERGE-NEEDS-MINOR, one residual).
+  The strict-path diagnostic listed every direct leaf as "each taking a SINGLE
+  value", which contradicted the packed multi-word `description` tail this PR
+  deliberately accepts. An operator hitting the message would be told the
+  opposite of the behaviour. Reworded to exempt `description` explicitly. No
+  code change; Codex reproduced all three description AST shapes and their
+  SchemaValidate outcomes, confirmed tolerant poisoning preserves
+  master-enforced sibling leaves, confirmed both recovery orderings permit
+  TCP/22 under the MAJOR revert with every named over-reach guard green, and
+  confirmed collision enumeration and compilation still share the one walk.
+- **File(s)**: pkg/config/compiler_validate_strict_application.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62238,3 +62238,56 @@ break — `go vet` confirmed passing under every revert.
     compiler_applications_collision.go,compiler_validate_strict_application.go,
     types_security.go,compiler_application_chained_leaves_6524_test.go},
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6524 / PR 6604 Codex re-gate fold (MERGE-NEEDS-MAJOR) — stop the
+  chain walk RECOVERING a keyword after unrepresentable content, and give
+  `description` tail handling.
+  MAJOR: applicationDirectLeaves recorded an unknown token, advanced one slot
+  and CONTINUED, so a later recognized keyword was compiled normally. Verified
+  at the VERDICT level on both sides. My head, tolerant path:
+  `set applications application myapp bogus value protocol tcp` compiled
+  protocol=tcp and tcp/22 came back matched=true action=PolicyPermit
+  contentRejected=false — an all-TCP permit. Pristine origin/master (detached
+  worktree, same probe): protocol-less, tcp/22 matched=false action=PolicyDeny
+  contentRejected=true. So the PR converted an inert fail-closed residual into
+  an ACTIVE permit on boot / HA SyncApply, where the strict reject is only a
+  warning. Same root via the other ordering:
+  `destination-port [ 22 23 ] protocol tcp` skipped `23` then recovered
+  `protocol tcp`. Fixed by POISONING the remainder of a node's run and its
+  subtree on the first unrepresentable token — both the unknown-keyword branch
+  and the bracket-tail branch. Sibling leaves are deliberately unaffected
+  (separate nodes), so a stray `bogus value` line still leaves a neighbouring
+  `protocol tcp` line compiled exactly as master compiled it; that is pinned by
+  a paired over-reach guard at the verdict level, because over-poisoning would
+  silently fail-close a whole working config.
+  MINOR (`description`): Codex was RIGHT that my justification was false. I had
+  claimed the schema's scalar:true arity already enforced this at commit; it
+  does so only for the SIBLING spelling — verified firsthand that in the CHAINED
+  spelling SchemaValidate returns nil while my compiler gate rejected, so the
+  chained form WAS a new hard-reject over a metadata leaf. Rather than justify
+  it, made `description` a TAIL leaf (Junos takes its text to end-of-statement):
+  the run is joined, so `description my web app` and `description
+  destination-port` both compile as written, and a description can no longer
+  poison the rest of the run. The run still stops at the next recognized
+  keyword, so the chained-`term` reproducer keeps working. The schema's
+  scalar:true gate is untouched and still rejects the sibling spelling, which
+  master's own commit path also rejected — so no master-COMMITTABLE config is
+  newly refused (master's CompileConfig accepted it in isolation, but
+  SchemaValidate did not).
+  Also: corrected the docs claim that "both sides go through
+  applicationTermNodes" (the compiler consumes applicationDirectLeaves directly;
+  only the collision gate goes through applicationTermNodes — both derive from
+  the same walk), and added an arity pin + scope note to the schema canary,
+  which guards the KEY SET but not `args` drift.
+  Fail-on-revert in a THROWAWAY detached worktree, build+vet CLEAN there:
+  restoring `i++; continue` turns BOTH orderings RED as verdict assertions
+  ("tcp/22 was PERMITTED ..."), while every guard stays GREEN —
+  TestChainedApp{DestPort,SourcePort,ICMPType,Deny}, SiblingAppSpelling,
+  StrayStatementDoesNotDisarmSiblingLeaves, HierarchicalAppBody,
+  SiblingFlatSetAppBody, SiblingTermClobber, DescriptionIsATail.
+  Full pkg/config + pkg/policymatch green; build, vet, gofmt clean.
+- **File(s)**: pkg/config/{compiler_applications.go,types_security.go,
+    compiler_application_chained_leaves_6524_test.go},
+    pkg/policymatch/app_unknown_recovery_6524_test.go,
+    docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62177,3 +62177,64 @@ break — `go vet` confirmed passing under every revert.
     testdata/golden_4406.json},
     pkg/policymatch/app_chained_leaves_6524_test.go,
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6524 / PR 6604 hostile-review fold (MERGE-NEEDS-MAJOR) — close a
+  fail-open the PR itself INTRODUCED, plus a phantom-leaf widening.
+  MAJOR: teaching the compiler to follow the flat-set chain also let it reach
+  `term` nodes nested down that chain, so it minted `<parent>-<term>`
+  applications that the collision gate could not see —
+  compiler_applications_collision.go:225 still enumerated `inst.node.Children`
+  while compiler_applications.go had moved to applicationDirectLeaves. The two
+  walks diverged, so a generated name was invisible to every flat-namespace gate
+  (#3472 H01/H02/H03, M08, M03) and silently OVERWROTE an authored application,
+  erasing a deny that referenced it. Verified firsthand on both sides: on my
+  head `set applications application myapp description doc term t1 protocol udp`
+  clobbered an authored `myapp-t1` (tcp/22 -> udp/"") with err=nil and ZERO
+  warnings; on pristine origin/master (detached worktree) `myapp-t1` stayed
+  tcp/22. `description` is the strict-path entry route because it deliberately
+  does not set hasDirectBody (#3366) so MixedDirectTermApps never fires; on the
+  tolerant path that gate is only a warning so no description prefix is needed.
+  The SIBLING spelling was always caught — only the chained shape evaded it.
+  Fixed by extracting applicationTermNodes + applicationTermKeys and routing
+  BOTH the compiler and the collision gate through them, making the "single
+  source of truth" doc claim actually true instead of softening it. The shared
+  helper also always COPIES, removing a latent aliasing hazard: the compiler
+  previously sliced `prop.Keys[1:]` and appended child keys onto it, which can
+  write into the node's own backing array when that slice has spare capacity.
+  MINOR: the chain scan did not reserve the leaf's value slot, so a value token
+  that happens to spell a grammar keyword synthesized a PHANTOM valueless leaf
+  that RESET an assigned field. `description destination-port` drove
+  DestinationPort back to "" — match-every-port on the tolerant path, the exact
+  widening this PR exists to close, reintroduced by another route — plus a FALSE
+  strict "conflicting duplicate" reject; `description protocol` wiped Protocol;
+  and the phantom's unconditional hasDirectBody falsely tripped #3366 on a
+  term-only app. Every `args:1` leaf now consumes exactly one token as its value
+  before the keyword scan resumes. Bracket-tail detection is unaffected (the
+  SECOND value token is still flagged).
+  PUSHED BACK on MINOR 3: the premise "master committed an unquoted multi-word
+  description" is wrong for the real commit path — SchemaValidate on pristine
+  master already rejects it via the #3332 scalar gate ("unexpected trailing
+  token \"web\""), because schema_security.go:1273 marks `description`
+  scalar:true. Only CompileConfig in isolation accepted it. Kept the reject
+  (agreeing with the schema rather than contradicting a prior explicit
+  decision); fixed the message misattribution instead — it no longer claims
+  "widening", which is wrong for a dropped protocol alternative (that NARROWS)
+  and meaningless for a description token.
+  MINOR 2 (chained spelling not individually deletable) documented rather than
+  fixed: it is pre-existing SetPath/DeletePath behaviour for EVERY chained leaf,
+  and addressing a leaf nested under a value node changes path resolution for
+  every `children: nil` leaf in the schema.
+  NIT: the keyword canary was list==copy-of-list; it now enumerates
+  schemaApplications.children["application"].children in BOTH directions.
+  Fail-on-revert verified in a THROWAWAY detached worktree (never the PR
+  worktree), build+vet CLEAN there so each red is an ASSERTION: reverting only
+  the collision-gate enumeration turns the 2 clobber tests RED while the sibling
+  baseline, both over-reach guards and all MINOR tests stay GREEN; reverting only
+  the value-slot reservation turns the 3 phantom subtests RED while the
+  bracket-tail subtest and both over-reach guards stay GREEN.
+  Full pkg/config + pkg/policymatch green; build, vet, gofmt clean.
+- **File(s)**: pkg/config/{compiler_applications.go,
+    compiler_applications_collision.go,compiler_validate_strict_application.go,
+    types_security.go,compiler_application_chained_leaves_6524_test.go},
+    docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62291,3 +62291,61 @@ break — `go vet` confirmed passing under every revert.
     compiler_application_chained_leaves_6524_test.go},
     pkg/policymatch/app_unknown_recovery_6524_test.go,
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #6524 / PR 6604 — third fold pass. Audited the previous fold
+  against the Codex verdict firsthand rather than trusting its self-report, and
+  found the MAJOR correctly closed but the MINOR's JUSTIFICATION still false in
+  the same way Codex had flagged the original.
+  Codex's MINOR said the claim "scalar validation already enforces this" was
+  false. The fold replaced it with "the schema never sees the chained one" —
+  which is ALSO false. Dumped the real AST for every spelling and found a
+  multi-word description occupies THREE positions, not two:
+    - sibling / hierarchical            -> schema scalar:true governs it
+    - HEAD of a flat-set chain          -> `set ... description my web app ...`
+      builds [description my] -> [web app ...]; the tail is a CHILD node, so
+      the joined run is only ["my"] and "web" opens a fresh run.
+      SchemaValidate DOES fire here: `unexpected trailing token "web"`.
+    - PACKED chain tail                 -> `set ... protocol tcp description my
+      web app` packs the whole description onto ONE node's Keys, below the
+      depth the schema walk reaches (SchemaValidate returns nil).
+  So the tail-join rescues exactly ONE position (the packed tail), which is
+  also the only position where a spelling master COMMITTED would otherwise
+  have become a new hard reject. The head-of-chain spelling stays a commit
+  error — and that is PARITY, because master rejected it through the same
+  untouched schema gate. Codex tested the packed-tail spelling and generalized;
+  the fold generalized in the opposite direction. Both overshot.
+  Corrected the claim at all three sites that carried it (the `description`
+  branch in compiler_applications.go, the UnknownDirectLeaves doc on
+  types_security.go, and the docs/config-schema.md bullet) to enumerate the
+  three positions and say exactly which one the join covers. This is not
+  cosmetic: an over-broad "the schema never sees the chained one" invites a
+  future change to loosen a gate master also held.
+  Added the missing coverage — TestDescriptionIsATailLeaf previously exercised
+  ONLY the packed-tail position, so a reader would conclude `description my web
+  app` commits, which it does not. The new subtest pins the head-of-chain
+  position AND asserts the MECHANISM that makes it parity (SchemaValidate still
+  fires), because asserting only "commit fails" cannot distinguish a
+  pre-existing gate from one this PR introduced.
+  Verification, all in a THROWAWAY detached worktree (/dev/shm/probe-6604d,
+  build+vet CLEAN there, removed after):
+    - MAJOR RED at pre-fold head 4e132ced5, VERDICT level, BOTH orderings:
+      "tcp/22 was PERMITTED by an application whose body contains
+      unrepresentable content" for `bogus value protocol tcp` AND for
+      `destination-port [ 22 23 ] protocol tcp`.
+    - MINOR RED at the same head: `chained multi-word description commits`
+      failed on the hard reject of "web".
+    - New subtest RED there too, as an assertion: `Protocol="tcp", want ""`.
+    - Over-reach guards PASS at the pre-fold head (they do not co-vary):
+      StrayStatementDoesNotDisarmSiblingLeaves,
+      UnknownTokenDoesNotPoisonSiblingLeaves, ApplicationDirectLeafArityIsOne.
+  Also probed and cleared two shapes I suspected: a `term` at mid-run inside a
+  packed tail carries NO Children (so a term's token stream is never split
+  across Keys and Children), and the hierarchical shape still compiles as
+  siblings, byte-identical to master.
+  Full pkg/config + pkg/policymatch green; vet clean; gofmt clean on every file
+  this PR touches (the three gofmt-dirty files under pkg/config are dirty on
+  origin/master too — pre-existing, not this PR's).
+- **File(s)**: pkg/config/{compiler_applications.go,types_security.go,
+    compiler_application_chained_leaves_6524_test.go},
+    docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1055,10 +1055,33 @@ Two properties of that scan are load-bearing and easy to get wrong:
   guard the flat Junos namespace (#3472/#3339); while it enumerated
   `inst.node.Children` directly it could not see a chained term, so a generated
   name silently OVERWROTE an authored application and erased any deny
-  referencing it — with no commit error. Both sides now go through
-  `applicationTermNodes` + `applicationTermKeys`. Adding a third reader of the
-  application body means routing it through the same helpers, not open-coding a
-  fourth traversal.
+  referencing it — with no commit error. Both sides now derive from the same
+  walk: the compiler consumes `applicationDirectLeaves` directly, and the
+  collision gate reaches it through `applicationTermNodes`, with both
+  reassembling the term's tokens via `applicationTermKeys` so the predicted
+  name always equals the written one. Adding a third reader of the application
+  body means routing it through those helpers, not open-coding a fourth
+  traversal.
+- **An unrepresentable token POISONS the rest of its run and subtree — it must
+  not be skipped so a later keyword can be recovered.** This is the direction
+  that matters on the tolerant path: master ignored an unrecognized child node
+  whole, so `bogus value protocol tcp` left the application PROTOCOL-LESS and
+  therefore unrepresentable (fail-closed — `pkg/policymatch` reports
+  `ContentRejected`, and the #2124 gate refuses to arm). Skipping `bogus` and
+  compiling the `protocol tcp` that follows converts an inert residual into an
+  ACTIVE all-TCP permit on boot / HA `SyncApply`, where the strict reject is
+  only a warning. The same applies to a bracket tail:
+  `destination-port [ 22 23 ] protocol tcp` must not drop `23` and then recover
+  `protocol tcp`. Unknown direct-body content must leave the application NO
+  WIDER than master. Sibling leaves are unaffected — they are separate nodes,
+  so a stray line does not poison its neighbours.
+- **`description` is a TAIL leaf, not `args: 1`.** Junos takes its text to the
+  end of the statement, so the walk joins the run rather than flagging the tail:
+  `description my web app` and `description destination-port` both compile as
+  written. Rejecting a metadata leaf that cannot affect matching would be pure
+  friction, and the chained spelling committed on master. The `scalar: true`
+  arity the schema enforces for that leaf (#3332) is untouched and still rejects
+  the SIBLING spelling at strict commit — it simply never sees the chained one.
 
 **Known limitation — the chained spelling is enforced but not individually
 editable.** Because the leaves are nested rather than siblings,

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1033,6 +1033,49 @@ application body holds ONE protocol and ONE port (`Application.Protocol` /
 sub-blocks are for), so the bracket tail is unrepresentable rather than merely
 mis-read.
 
+Two properties of that scan are load-bearing and easy to get wrong:
+
+- **Reserve the value slot before resuming the keyword scan.** These leaves are
+  `args: 1`, so each consumes exactly ONE token as its value *even when that
+  token spells a grammar keyword*. `description destination-port` is a
+  description whose text is `destination-port`, not a description followed by a
+  port statement. Without the reservation the scan synthesizes a phantom
+  valueless leaf that RESETS an already-assigned field — driving
+  `DestinationPort` back to `""` (match-every-port on the tolerant path, the
+  very widening this section is about), wiping `Protocol` to `""` (a
+  config-wide fail-closed via #3323), and setting `hasDirectBody`
+  unconditionally, which falsely trips the #3366 mixed direct+term gate on a
+  term-only application. `description` is the only realistic vector — no
+  protocol name/alias, `junosServicePorts` entry, ALG name, or numeric
+  timeout/ICMP value collides with a grammar keyword.
+- **Every consumer of the body must share this walk.** The chain reaches `term`
+  nodes too, so `compileApplications` mints `<parent>-<term>` applications from
+  a chained term. `collectApplicationCollisions`
+  (`compiler_applications_collision.go`) predicts those same generated names to
+  guard the flat Junos namespace (#3472/#3339); while it enumerated
+  `inst.node.Children` directly it could not see a chained term, so a generated
+  name silently OVERWROTE an authored application and erased any deny
+  referencing it — with no commit error. Both sides now go through
+  `applicationTermNodes` + `applicationTermKeys`. Adding a third reader of the
+  application body means routing it through the same helpers, not open-coding a
+  fourth traversal.
+
+**Known limitation — the chained spelling is enforced but not individually
+editable.** Because the leaves are nested rather than siblings,
+`delete applications application myapp destination-port 8080` (and the bare
+`... destination-port`) fail with `path not found`: the node lives under
+`protocol tcp`, not at application level. Re-setting a different port adds a
+second sibling, which the #5574 conflicting-duplicate gate then rejects, and
+that gate's remediation text ("split conflicting values into separate `term`
+sub-blocks") is aimed at a genuine conflict rather than at "I want to change the
+port". The escape is to delete the head of the chain (`delete applications
+application myapp protocol tcp`), which drops the whole line, and re-author it.
+This is pre-existing `SetPath`/`DeletePath` behaviour for every chained leaf,
+not specific to applications — fixing it means teaching the AST editor to
+address a leaf nested under a value node, which changes path resolution for
+every `children: nil` leaf in the schema and is deliberately out of scope here.
+Prefer the one-leaf-per-line spelling when authoring config you expect to edit.
+
 **Why the fix is in the COMPILER, not the schema.** Typing the three leaves (or
 tagging them `scalar: true`) would reject the chained form at commit-check, but
 `CompileConfigLenient` — the boot-load and HA `SyncApply` path — downgrades a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1076,12 +1076,24 @@ Two properties of that scan are load-bearing and easy to get wrong:
   WIDER than master. Sibling leaves are unaffected — they are separate nodes,
   so a stray line does not poison its neighbours.
 - **`description` is a TAIL leaf, not `args: 1`.** Junos takes its text to the
-  end of the statement, so the walk joins the run rather than flagging the tail:
-  `description my web app` and `description destination-port` both compile as
-  written. Rejecting a metadata leaf that cannot affect matching would be pure
-  friction, and the chained spelling committed on master. The `scalar: true`
-  arity the schema enforces for that leaf (#3332) is untouched and still rejects
-  the SIBLING spelling at strict commit — it simply never sees the chained one.
+  end of the statement, so the walk joins the run rather than flagging the tail;
+  `description destination-port` keeps its keyword-spelling text intact, and a
+  multi-word description packed onto one node's Keys compiles as written.
+  Rejecting a metadata leaf that cannot affect matching would be pure friction,
+  and that spelling committed on master. Note the join covers ONE of the three
+  positions a multi-word description can occupy, and it is worth being exact
+  about which, so nobody later loosens a gate master also held:
+  - *sibling* (hierarchical or its own `set` line) — governed by the leaf's
+    `scalar: true` arity (#3332), untouched;
+  - *head of a chain* (`set ... description my web app protocol tcp`) — the
+    tail is parked in a CHILD node, so `web` opens a fresh run;
+    `SchemaValidate` rejects the line with `unexpected trailing token "web"`,
+    exactly as on master, and it stays a commit error;
+  - *packed chain tail* (`set ... protocol tcp description my web app`) — the
+    whole description lands on one node's Keys, below the depth the schema walk
+    reaches (`SchemaValidate` returns nil). **This is the only position the
+    join rescues**, and the only one where a spelling master committed would
+    otherwise have become a new hard reject.
 
 **Known limitation — the chained spelling is enforced but not individually
 editable.** Because the leaves are nested rather than siblings,

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -993,6 +993,58 @@ a SetPath container, so the fanout cannot touch them). The two multi-member-body
 cases assert current option-1 behavior only; an options-2/3 fix intentionally
 updates those two expectations.
 
+**Sibling leaves on ONE flat-set line also collapse into a NESTED chain, not
+siblings — the third collapse pattern (#6524).** The two patterns above cover a
+bracket LIST (one leaf, many values). This one is about several DISTINCT leaves
+written on a single `set` line. When a schema leaf declares `children: nil` and
+is neither `multi` nor a wildcard container, `SetPath` consumes its `args`
+tokens and then — having no sub-schema to descend — parks the REST of the line
+under the node it just created. So
+
+```
+set applications application myapp protocol tcp destination-port 8080
+```
+
+does NOT build two siblings; it builds a chain
+`application myapp -> protocol tcp -> destination-port 8080`, and only the
+FIRST link gets a node of its own — every token after it is PACKED flat onto
+one child (`protocol tcp -> Keys=[source-port 5000 destination-port 8080]` for
+a three-leaf line). A compiler iterating the container's immediate `Children`
+therefore sees only the first leaf and silently drops the rest.
+
+That was the #6524 fail-open: `compileApplications` saw only `protocol`, never
+assigned `DestinationPort`, and an empty port term matches ANY port
+(`pkg/policymatch`), so a policy matching the application permitted **all TCP**.
+Nothing caught it — `protocol` / `destination-port` / `source-port` were the
+only `applications application` match leaves that were neither typed nor
+`scalar: true`, so no arity gate engaged and the chained form validated clean at
+BOTH `SchemaValidate` and strict commit. The REVERSE token order was caught only
+incidentally (the chain drops `protocol` instead, tripping the #3109
+protocol-less gate) — that asymmetry hid it.
+
+`applicationDirectLeaves` (`compiler_applications.go`) is the canonical reader:
+it walks the chain, splits each node's packed Keys into one leaf per recognized
+keyword (a keyword-delimited scan, the same shape `parseApplicationTerms` uses),
+and returns every token it cannot map to a known leaf so the deferred strict
+gate rejects it. That last part is what makes `protocol [ tcp udp ]` and
+`destination-port [ 22 23 ]` an operator-visible commit error: a DIRECT
+application body holds ONE protocol and ONE port (`Application.Protocol` /
+`.DestinationPort` are single fields — multi-valued matching is what `term`
+sub-blocks are for), so the bracket tail is unrepresentable rather than merely
+mis-read.
+
+**Why the fix is in the COMPILER, not the schema.** Typing the three leaves (or
+tagging them `scalar: true`) would reject the chained form at commit-check, but
+`CompileConfigLenient` — the boot-load and HA `SyncApply` path — downgrades a
+schema rejection to a WARNING and keeps compiling. A schema-only fix therefore
+leaves a persisted or peer-pushed config still compiling protocol-only and still
+permitting all TCP, precisely where no operator sees the warning. Making the
+compiler consume the chain fixes every path at once. It also avoids minting a
+new commit-vs-load split for a spelling that now has well-defined semantics —
+the same divergence class #3606 calls out for ports. Covered by
+`pkg/config/compiler_application_chained_leaves_6524_test.go` and the
+policy-OUTCOME suite `pkg/policymatch/app_chained_leaves_6524_test.go`.
+
 **`multi: true` ALSO prevents single-value REPLACE for repeated keyed-list
 leaves (#3984).** The `#2419` discussion above is about ONE statement with a
 bracket list. The SAME `multi: true` marker fixes a second, distinct shape:

--- a/pkg/config/compiler_application_chained_leaves_6524_test.go
+++ b/pkg/config/compiler_application_chained_leaves_6524_test.go
@@ -360,28 +360,222 @@ func TestSiblingFlatSetAppBodyUnchanged(t *testing.T) {
 	}
 }
 
-// TestApplicationDirectLeafKeywordsCoverCompilerSwitch is a drift canary: every
-// keyword the direct-body switch in compileApplications handles must also be in
-// applicationDirectLeafKeywords. A keyword added to the switch but missed here
-// would be classified as garbage and hard-rejected at commit — a fail-CLOSED
-// regression on valid config.
-func TestApplicationDirectLeafKeywordsCoverCompilerSwitch(t *testing.T) {
-	// The cases of the direct-body switch, kept in sync by this test.
-	switchCases := []string{
-		"protocol", "destination-port", "source-port",
-		"inactivity-timeout", "timeout", "icmp-type", "icmp-code",
-		"alg", "description", "term",
+// TestApplicationDirectLeafKeywordsMatchSchema is a drift canary against the
+// AUTHORITATIVE source rather than a restatement of it. `setSchema`
+// (schema_security.go) declares which statements an `applications application
+// <name>` body accepts; applicationDirectLeaves classifies anything outside its
+// own map as operator garbage and the strict gate then hard-rejects it. So a
+// leaf ADDED to the schema but missed in the map becomes a fail-CLOSED
+// regression on valid config — and a hardcoded expected-list here could never
+// catch that, because the same hand cranks both. Enumerate the schema instead.
+func TestApplicationDirectLeafKeywordsMatchSchema(t *testing.T) {
+	appNode := schemaApplications.children["application"]
+	if appNode == nil || len(appNode.children) == 0 {
+		t.Fatalf("schemaApplications has no `application` children to enumerate — " +
+			"this canary has lost its authoritative source")
 	}
-	for _, kw := range switchCases {
+	for kw := range appNode.children {
 		if !applicationDirectLeafKeywords[kw] {
-			t.Fatalf("compileApplications handles %q but applicationDirectLeaves "+
-				"does not recognize it — a valid statement would be recorded as "+
-				"unknown and hard-rejected at commit", kw)
+			t.Errorf("schema declares `applications application <name> %s` but "+
+				"applicationDirectLeafKeywords omits it — the statement would be "+
+				"recorded as an unknown leaf and HARD-REJECTED at commit "+
+				"(fail-closed on valid config)", kw)
 		}
 	}
-	if len(applicationDirectLeafKeywords) != len(switchCases) {
-		t.Fatalf("applicationDirectLeafKeywords has %d entries, the compiler switch "+
-			"has %d — an entry here with no switch case is silently ignored "+
-			"rather than rejected", len(applicationDirectLeafKeywords), len(switchCases))
+	for kw := range applicationDirectLeafKeywords {
+		if _, ok := appNode.children[kw]; !ok {
+			t.Errorf("applicationDirectLeafKeywords accepts %q but the schema does "+
+				"not declare it — the token would be silently accepted by the walk "+
+				"instead of rejected", kw)
+		}
 	}
+}
+
+// TestApplicationTermEnumerationSharedWithCollisionGate pins the #6524 MAJOR
+// contract at the seam: compileApplications and collectApplicationCollisions
+// must enumerate terms through the SAME walk, or the compiler mints
+// `<parent>-<term>` applications the namespace gates cannot see.
+func TestApplicationTermEnumerationSharedWithCollisionGate(t *testing.T) {
+	// A term reachable ONLY through a flat-set chain (nested under the
+	// `description` value node).
+	tree := setTree6524(t,
+		"set applications application myapp description doc term t1 protocol udp")
+	appsNode := tree.FindChild("applications")
+	if appsNode == nil {
+		t.Fatalf("applications node missing")
+	}
+	inst := namedInstances(appsNode.FindChildren("application"))
+	if len(inst) != 1 {
+		t.Fatalf("expected 1 application instance, got %d", len(inst))
+	}
+	// The enumeration helper the collision gate uses must find the chained term.
+	terms := applicationTermNodes(inst[0].node)
+	if len(terms) != 1 {
+		t.Fatalf("applicationTermNodes found %d terms, want 1 — the collision gate "+
+			"would be blind to a chained term the compiler still mints (#6524)",
+			len(terms))
+	}
+	// And it must reassemble the same tokens the compiler feeds
+	// parseApplicationTerms, so the predicted name matches what gets written.
+	gen := parseApplicationTerms("myapp", applicationTermKeys(terms[0]))
+	if len(gen) != 1 || gen[0].Name != "myapp-t1" {
+		t.Fatalf("predicted generated apps = %+v, want exactly one named myapp-t1", gen)
+	}
+}
+
+// TestChainedTermCannotClobberAuthoredApp is the #6524 review-fold MAJOR: once
+// the compiler follows the flat-set chain it also reaches `term` nodes nested
+// down that chain and mints `<parent>-<term>` applications from them. The
+// collision gate (collectApplicationCollisions) enumerated the application
+// node's immediate Children, so those generated names were invisible to EVERY
+// gate guarding the flat Junos namespace — H01 authored-app overwrite, H02
+// cross-namespace, H03 cross-parent, M08 duplicate term name, M03 predefined
+// shadow.
+//
+// The consequence is a silent fail-open: a generated name overwrites an
+// AUTHORED application, so a deny referencing that authored name is erased and
+// the traffic falls through to a later permit. `description` is the entry route
+// on the STRICT path because it deliberately does not set hasDirectBody
+// (#3366), so MixedDirectTermApps never engages.
+//
+// RED-on-revert: point the collision gate's loop back at
+// `inst.node.Children` and the commit succeeds with myapp-t1 silently redefined
+// as protocol udp / no port.
+func TestChainedTermCannotClobberAuthoredApp(t *testing.T) {
+	tree := setTree6524(t,
+		"set applications application myapp-t1 protocol tcp",
+		"set applications application myapp-t1 destination-port 22",
+		"set applications application myapp description doc term t1 protocol udp",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to REJECT a chained term whose generated name " +
+			"collides with the authored application myapp-t1 — it silently " +
+			"overwrites it and erases any deny referencing it (#6524)")
+	}
+	if !strings.Contains(err.Error(), "myapp-t1") {
+		t.Fatalf("reject must name the colliding generated application, got: %v", err)
+	}
+}
+
+// TestChainedTermClobberIsSurfacedOnLenientPath covers the tolerant load / HA
+// SyncApply variant. There MixedDirectTermApps is only a warning, so the
+// `description` prefix is not needed at all — a plain `protocol udp term t1 ...`
+// chain reaches the same clobber. The lenient path must still SURFACE the
+// collision; before the fold its only warning was the unrelated mixed
+// direct+term one, which never mentions that an authored application was
+// redefined.
+func TestChainedTermClobberIsSurfacedOnLenientPath(t *testing.T) {
+	cfg, err := CompileConfigLenient(setTree6524(t,
+		"set applications application myapp-t1 protocol tcp",
+		"set applications application myapp-t1 destination-port 22",
+		"set applications application myapp protocol udp term t1 protocol udp",
+	))
+	if err != nil {
+		t.Fatalf("lenient path must not hard-fail: %v", err)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "myapp-t1") && strings.Contains(w, "collides") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("lenient path must warn that the generated myapp-t1 collides with "+
+			"the authored application, got %v", cfg.Warnings)
+	}
+}
+
+// TestSiblingTermClobberStillRejected is the GREEN control for the two tests
+// above: the one-leaf-per-line term spelling was always caught by the #3472
+// gate and must stay caught. It passes on master and on every revision of this
+// branch, proving the chained cases above fail for the chain-specific reason
+// rather than because the gate is broken generally.
+func TestSiblingTermClobberStillRejected(t *testing.T) {
+	_, err := CompileConfig(setTree6524(t,
+		"set applications application myapp-t1 protocol tcp",
+		"set applications application myapp-t1 destination-port 22",
+		"set applications application myapp term t1 protocol udp",
+	))
+	if err == nil {
+		t.Fatal("the sibling term spelling must still hard-reject on the #3472 " +
+			"authored-name collision")
+	}
+}
+
+// TestLeafValueSlotReservedAgainstKeywordText covers the review-fold MINOR: a
+// leaf declared `args: 1` consumes exactly ONE token as its value even when
+// that token happens to spell a grammar keyword. Without the reservation the
+// chain scan synthesized a PHANTOM valueless leaf that reset an
+// already-assigned field.
+//
+// The `description destination-port` case is the security-relevant one: the
+// phantom drove DestinationPort back to "", which on the tolerant path means
+// the application matches EVERY port — the exact widening #6524 exists to
+// close, reintroduced by another route. It also produced a FALSE strict reject
+// ("conflicting duplicate"), and the phantom's unconditional hasDirectBody
+// falsely tripped the #3366 mixed direct+term gate on a term-only application.
+func TestLeafValueSlotReservedAgainstKeywordText(t *testing.T) {
+	t.Run("description text spelling a match keyword", func(t *testing.T) {
+		cfg, err := CompileConfig(setTree6524(t,
+			"set applications application myapp protocol tcp destination-port 8080",
+			"set applications application myapp description destination-port",
+		))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v (a description whose TEXT is a keyword must "+
+				"not synthesize a phantom leaf)", err)
+		}
+		app := cfg.Applications.Applications["myapp"]
+		if app == nil {
+			t.Fatalf("application myapp missing")
+		}
+		if app.DestinationPort != "8080" {
+			t.Fatalf("DestinationPort=%q, want 8080 — a phantom `destination-port` "+
+				"leaf reset the assigned port, so the application matches EVERY port",
+				app.DestinationPort)
+		}
+		if app.Description != "destination-port" {
+			t.Fatalf("Description=%q, want %q", app.Description, "destination-port")
+		}
+	})
+
+	t.Run("description text spelling protocol", func(t *testing.T) {
+		cfg, err := CompileConfig(setTree6524(t,
+			"set applications application myapp protocol tcp destination-port 8080",
+			"set applications application myapp description protocol",
+		))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		app := cfg.Applications.Applications["myapp"]
+		if app == nil || app.Protocol != "tcp" {
+			t.Fatalf("Protocol=%v, want tcp — a phantom `protocol` leaf wiped it, "+
+				"which fails the whole snapshot closed at runtime (#3323)", app)
+		}
+	})
+
+	t.Run("term-only app with keyword-text description", func(t *testing.T) {
+		cfg, err := CompileConfig(setTree6524(t,
+			"set applications application myapp term t1 protocol tcp destination-port 80",
+			"set applications application myapp description timeout",
+		))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v — the phantom leaf set hasDirectBody and "+
+				"falsely tripped the #3366 mixed direct+term gate", err)
+		}
+		if app := cfg.Applications.Applications["myapp-t1"]; app == nil ||
+			app.Protocol != "tcp" || app.DestinationPort != "80" {
+			t.Fatalf("term app myapp-t1 = %+v, want tcp/80", app)
+		}
+	})
+
+	t.Run("bracket tail still caught after the reservation", func(t *testing.T) {
+		// The reservation must not blind the bracket-list gate: the SECOND
+		// value token is still an unrepresentable tail.
+		_, err := CompileConfig(setTree6524(t,
+			"set applications application myapp protocol tcp destination-port [ 22 23 ]"))
+		if err == nil || !strings.Contains(err.Error(), "23") {
+			t.Fatalf("bracket tail must still reject naming 23, got: %v", err)
+		}
+	})
 }

--- a/pkg/config/compiler_application_chained_leaves_6524_test.go
+++ b/pkg/config/compiler_application_chained_leaves_6524_test.go
@@ -719,4 +719,67 @@ func TestDescriptionIsATailLeaf(t *testing.T) {
 			t.Fatalf("term Description=%q, want %q", term.Description, "doc")
 		}
 	})
+
+	// The tail-join covers exactly ONE of the positions a multi-word description
+	// can occupy, and the review-fold comment that justifies it must not claim
+	// more than that. When the description HEADS a flat-set chain, SetPath
+	// consumes its args:1 value and parks the REST in a CHILD node —
+	//
+	//	set applications application myapp description my web app protocol tcp
+	//	  -> [description my] -> [web app protocol tcp]
+	//
+	// — so the run this branch joins is just ["my"], and "web" opens a fresh run
+	// that the walk records as unknown content. That line therefore stays a
+	// commit error.
+	//
+	// This is PARITY, not a regression, and the assertion pins the mechanism
+	// that makes it parity: the schema's own arity gate rejects the same line
+	// independently. That gate predates this PR and is untouched by it, so
+	// master refused this spelling too — asserting the schema still fires is a
+	// durable proof of that, where asserting only "commit fails" would not
+	// distinguish a pre-existing gate from one this PR introduced.
+	t.Run("head-of-chain multi-word description stays a commit error", func(t *testing.T) {
+		tree := setTree6524(t,
+			"set applications application myapp description my web app protocol tcp")
+
+		lenient, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("CompileConfigLenient: %v", err)
+		}
+		schemaErr := SchemaValidate(tree, lenient)
+		if schemaErr == nil {
+			t.Fatalf("SchemaValidate returned nil — the head-of-chain spelling is " +
+				"supposed to be caught by the leaf's own untouched arity gate " +
+				"(#3332), which is what makes leaving it rejected PARITY with " +
+				"master rather than a new refusal. If the shape changed so the " +
+				"schema no longer sees it, the tail-join must grow to cover this " +
+				"position too, or the line silently becomes a compiler-only reject")
+		}
+		if !strings.Contains(schemaErr.Error(), "web") {
+			t.Fatalf("SchemaValidate error %q does not name the trailing token", schemaErr)
+		}
+
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatalf("CompileConfig accepted the head-of-chain spelling; master " +
+				"rejected it via SchemaValidate, and the compiler records the " +
+				"tail as unknown direct content")
+		}
+
+		// Fail-closed on the tolerant path for the same reason master was: the
+		// trailing `protocol tcp` sits behind unrepresentable content, so it is
+		// poisoned rather than recovered and the application stays protocol-less.
+		app := lenient.Applications.Applications["myapp"]
+		if app == nil {
+			t.Fatalf("application myapp missing")
+		}
+		if app.Protocol != "" {
+			t.Fatalf("Protocol=%q, want \"\" — the `protocol tcp` after the "+
+				"description tail must be POISONED, not recovered (#6524 MAJOR)",
+				app.Protocol)
+		}
+		if len(app.UnknownDirectLeaves) == 0 {
+			t.Fatalf("UnknownDirectLeaves empty, want the trailing description word " +
+				"recorded so the deferred gate rejects/warns")
+		}
+	})
 }

--- a/pkg/config/compiler_application_chained_leaves_6524_test.go
+++ b/pkg/config/compiler_application_chained_leaves_6524_test.go
@@ -368,6 +368,13 @@ func TestSiblingFlatSetAppBodyUnchanged(t *testing.T) {
 // leaf ADDED to the schema but missed in the map becomes a fail-CLOSED
 // regression on valid config — and a hardcoded expected-list here could never
 // catch that, because the same hand cranks both. Enumerate the schema instead.
+//
+// Scope note: this guards the KEY SET only. It does not catch `args` drift — the
+// walk assumes every one of these leaves takes exactly one value token (with
+// `description` handled as a tail). A future schema leaf declared `args: 2`, or
+// an existing one widened, would need applicationDirectLeaves updated to match;
+// TestApplicationDirectLeafArityIsOne below pins today's assumption so such a
+// change cannot land silently.
 func TestApplicationDirectLeafKeywordsMatchSchema(t *testing.T) {
 	appNode := schemaApplications.children["application"]
 	if appNode == nil || len(appNode.children) == 0 {
@@ -576,6 +583,140 @@ func TestLeafValueSlotReservedAgainstKeywordText(t *testing.T) {
 			"set applications application myapp protocol tcp destination-port [ 22 23 ]"))
 		if err == nil || !strings.Contains(err.Error(), "23") {
 			t.Fatalf("bracket tail must still reject naming 23, got: %v", err)
+		}
+	})
+}
+
+// TestApplicationDirectLeafArityIsOne pins the arity assumption the chain scan
+// is built on: every direct-body leaf takes exactly ONE value token, so the walk
+// can reserve a single value slot and treat everything after it as either the
+// next statement or unrepresentable surplus. `description` is the deliberate
+// exception — it is a TAIL leaf whose run is joined — but it is still declared
+// args:1 in the schema, so it is included here. If a leaf is ever widened to
+// args:2, applicationDirectLeaves must learn to consume that many tokens; this
+// pin makes such a schema change fail loudly instead of silently truncating.
+func TestApplicationDirectLeafArityIsOne(t *testing.T) {
+	appNode := schemaApplications.children["application"]
+	if appNode == nil {
+		t.Fatalf("schemaApplications has no `application` node")
+	}
+	for kw, leaf := range appNode.children {
+		if leaf.args != 1 {
+			t.Errorf("schema leaf %q declares args:%d — applicationDirectLeaves "+
+				"reserves exactly ONE value token per leaf and would truncate or "+
+				"mis-split this statement", kw, leaf.args)
+		}
+	}
+}
+
+// TestUnknownTokenDoesNotRecoverLaterKeywords is the #6524 review-fold MAJOR-2
+// structural half: an unrepresentable token must poison the rest of its run,
+// not be skipped so a later keyword can be compiled. See
+// pkg/policymatch/app_unknown_recovery_6524_test.go for the VERDICT-level half,
+// which is the assertion that actually matters.
+func TestUnknownTokenDoesNotRecoverLaterKeywords(t *testing.T) {
+	cases := []struct {
+		name    string
+		set     string
+		wantDst string
+	}{
+		{"unknown statement then protocol",
+			"set applications application myapp bogus value protocol tcp", ""},
+		{"bracket tail then protocol",
+			"set applications application myapp destination-port [ 22 23 ] protocol tcp", "22"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg, err := CompileConfigLenient(setTree6524(t, c.set))
+			if err != nil {
+				t.Fatalf("lenient compile: %v", err)
+			}
+			app := cfg.Applications.Applications["myapp"]
+			if app == nil {
+				t.Fatalf("application myapp missing")
+			}
+			if app.Protocol != "" {
+				t.Fatalf("Protocol=%q, want \"\" — the token after unrepresentable "+
+					"content was RECOVERED, arming a protocol the operator never "+
+					"authored. Master left this application protocol-less and "+
+					"therefore unrepresentable (fail-closed); recovering it makes "+
+					"the tolerant path WIDER than master (#6524)", app.Protocol)
+			}
+			if app.DestinationPort != c.wantDst {
+				t.Fatalf("DestinationPort=%q, want %q", app.DestinationPort, c.wantDst)
+			}
+		})
+	}
+}
+
+// TestUnknownTokenDoesNotPoisonSiblingLeaves is the paired over-reach guard:
+// poisoning is scoped to the NODE that carries the unparsable token. A stray
+// statement on its own `set` line must NOT suppress a neighbouring leaf, which
+// master compiled normally.
+func TestUnknownTokenDoesNotPoisonSiblingLeaves(t *testing.T) {
+	cfg, err := CompileConfigLenient(setTree6524(t,
+		"set applications application myapp protocol tcp",
+		"set applications application myapp destination-port 8080",
+		"set applications application myapp bogus value",
+	))
+	if err != nil {
+		t.Fatalf("lenient compile: %v", err)
+	}
+	app := cfg.Applications.Applications["myapp"]
+	if app == nil || app.Protocol != "tcp" || app.DestinationPort != "8080" {
+		t.Fatalf("app=%+v, want tcp/8080 — a stray SIBLING statement must not "+
+			"suppress leaves master compiled normally", app)
+	}
+}
+
+// TestDescriptionIsATailLeaf covers the review-fold MINOR. Junos takes a
+// description's text to the end of the statement, so an unquoted multi-word
+// description is legal config that master committed in the chained spelling.
+// Treating it as `args: 1` turned it into a hard commit error over a METADATA
+// leaf that cannot affect what the application matches.
+func TestDescriptionIsATailLeaf(t *testing.T) {
+	t.Run("chained multi-word description commits", func(t *testing.T) {
+		cfg, err := CompileConfig(setTree6524(t,
+			"set applications application myapp protocol tcp description my web app"))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v — an unquoted multi-word description is "+
+				"legal Junos and committed on master in this spelling", err)
+		}
+		app := cfg.Applications.Applications["myapp"]
+		if app == nil || app.Description != "my web app" || app.Protocol != "tcp" {
+			t.Fatalf("app=%+v, want protocol tcp and description %q", app, "my web app")
+		}
+	})
+
+	t.Run("description text spelling a keyword is kept whole", func(t *testing.T) {
+		cfg, err := CompileConfig(setTree6524(t,
+			"set applications application myapp protocol tcp description destination-port"))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		app := cfg.Applications.Applications["myapp"]
+		if app == nil || app.Description != "destination-port" || app.DestinationPort != "" {
+			t.Fatalf("app=%+v, want description %q and NO destination-port",
+				app, "destination-port")
+		}
+	})
+
+	t.Run("description does not swallow a following statement", func(t *testing.T) {
+		// The run stops at the next recognized keyword, so a chained `term`
+		// after a description is still parsed (this is the shape the #6524
+		// collision reproducer uses).
+		cfg, err := CompileConfig(setTree6524(t,
+			"set applications application myapp description doc term t1 protocol udp"))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		term := cfg.Applications.Applications["myapp-t1"]
+		if term == nil || term.Protocol != "udp" {
+			t.Fatalf("term app myapp-t1 = %+v, want protocol udp — the description "+
+				"tail must stop at the next recognized keyword", term)
+		}
+		if term.Description != "doc" {
+			t.Fatalf("term Description=%q, want %q", term.Description, "doc")
 		}
 	})
 }

--- a/pkg/config/compiler_application_chained_leaves_6524_test.go
+++ b/pkg/config/compiler_application_chained_leaves_6524_test.go
@@ -1,0 +1,387 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6524: a chained flat-set custom application compiled PROTOCOL-ONLY.
+//
+// `set a b c d` builds a CHAIN of single-key nodes, so in
+//
+//	set applications application myapp protocol tcp destination-port 8080
+//
+// `destination-port` is nested under the VALUE node `tcp` and is never a
+// sibling of `protocol`. compileApplications iterated only
+// inst.node.Children, saw only `protocol`, and never assigned
+// app.DestinationPort — an empty port term matches ANY port, so a policy
+// referencing the application permitted all TCP.
+//
+// Nothing caught it: `protocol` / `destination-port` / `source-port` are the
+// only application match leaves that are neither typed nor `scalar: true`
+// (schema_security.go), so no arity gate engages and the chained form validates
+// clean at BOTH SchemaValidate and strict commit. The REVERSE token order was
+// caught only incidentally, by the #3109 protocol-less gate — that asymmetry
+// hid this.
+//
+// The fix is in the COMPILER (applicationDirectLeaves walks the chain across
+// both AST shapes) rather than in the schema. A schema-only reject would leave
+// the LENIENT path — boot load and HA SyncApply, where a schema rejection is
+// downgraded to a warning — still compiling protocol-only and still permitting
+// all TCP; see TestChainedAppLenientPathAlsoHonorsChain.
+//
+// The policy-OUTCOME fail-on-revert lives in
+// pkg/policymatch/app_chained_leaves_6524_test.go (pkg/config cannot import
+// pkg/policymatch — policymatch imports config).
+
+func setTree6524(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestChainedAppDirectLeavesCompile is the core structural fail-on-revert: each
+// chained leaf must land in its own typed field.
+func TestChainedAppDirectLeavesCompile(t *testing.T) {
+	cases := []struct {
+		name  string
+		set   string
+		check func(t *testing.T, app *Application)
+	}{
+		{
+			name: "protocol + destination-port",
+			set:  "set applications application myapp protocol tcp destination-port 8080",
+			check: func(t *testing.T, app *Application) {
+				if app.Protocol != "tcp" || app.DestinationPort != "8080" {
+					t.Fatalf("protocol=%q destination-port=%q, want tcp/8080 — the "+
+						"chained destination-port was dropped (#6524)",
+						app.Protocol, app.DestinationPort)
+				}
+			},
+		},
+		{
+			name: "protocol + source-port",
+			set:  "set applications application myapp protocol udp source-port 5000",
+			check: func(t *testing.T, app *Application) {
+				if app.Protocol != "udp" || app.SourcePort != "5000" {
+					t.Fatalf("protocol=%q source-port=%q, want udp/5000", app.Protocol, app.SourcePort)
+				}
+			},
+		},
+		{
+			name: "three-deep chain",
+			set:  "set applications application myapp protocol tcp source-port 5000 destination-port 8080",
+			check: func(t *testing.T, app *Application) {
+				if app.Protocol != "tcp" || app.SourcePort != "5000" || app.DestinationPort != "8080" {
+					t.Fatalf("protocol=%q source-port=%q destination-port=%q, want "+
+						"tcp/5000/8080 — the walk must follow the WHOLE chain, not "+
+						"just one link", app.Protocol, app.SourcePort, app.DestinationPort)
+				}
+			},
+		},
+		{
+			name: "protocol + icmp-type",
+			set:  "set applications application myapp protocol icmp icmp-type 8",
+			check: func(t *testing.T, app *Application) {
+				if app.ICMPType == nil || *app.ICMPType != 8 {
+					t.Fatalf("ICMPType=%v, want 8 — a dropped icmp-type leaves the "+
+						"application matching EVERY ICMP type", app.ICMPType)
+				}
+			},
+		},
+		{
+			name: "protocol + icmp-type + icmp-code",
+			set:  "set applications application myapp protocol icmp icmp-type 3 icmp-code 1",
+			check: func(t *testing.T, app *Application) {
+				if app.ICMPType == nil || *app.ICMPType != 3 {
+					t.Fatalf("ICMPType=%v, want 3", app.ICMPType)
+				}
+				if app.ICMPCode == nil || *app.ICMPCode != 1 {
+					t.Fatalf("ICMPCode=%v, want 1 (a type<->code swap shows 3)", app.ICMPCode)
+				}
+			},
+		},
+		{
+			name: "protocol + inactivity-timeout",
+			set:  "set applications application myapp protocol tcp inactivity-timeout 1800",
+			check: func(t *testing.T, app *Application) {
+				if app.InactivityTimeout != 1800 {
+					t.Fatalf("InactivityTimeout=%d, want 1800 — a dropped timeout "+
+						"silently falls back to the global per-protocol timeout",
+						app.InactivityTimeout)
+				}
+			},
+		},
+		{
+			name: "protocol + alg",
+			set:  "set applications application myapp protocol tcp alg ftp",
+			check: func(t *testing.T, app *Application) {
+				if app.ALG != "ftp" {
+					t.Fatalf("ALG=%q, want ftp", app.ALG)
+				}
+			},
+		},
+		{
+			name: "named service port resolves through the chain",
+			set:  "set applications application myapp protocol tcp destination-port https",
+			check: func(t *testing.T, app *Application) {
+				// resolveAppPort must still run on a chained value.
+				if app.DestinationPort != "443" {
+					t.Fatalf("destination-port=%q, want 443 (the service name must "+
+						"resolve on the chained path too)", app.DestinationPort)
+				}
+			},
+		},
+		{
+			name: "port range survives the chain",
+			set:  "set applications application myapp protocol tcp destination-port 8080-8090",
+			check: func(t *testing.T, app *Application) {
+				if app.DestinationPort != "8080-8090" {
+					t.Fatalf("destination-port=%q, want 8080-8090", app.DestinationPort)
+				}
+			},
+		},
+		{
+			// REVERSE order. Pre-#6524 this dropped `protocol`, leaving a
+			// protocol-less app that the #3109 gate rejected — the incidental
+			// catch that hid the forward-order hole. It must now compile BOTH
+			// leaves rather than reject.
+			name: "reverse order (destination-port first)",
+			set:  "set applications application myapp destination-port 8080 protocol tcp",
+			check: func(t *testing.T, app *Application) {
+				if app.Protocol != "tcp" || app.DestinationPort != "8080" {
+					t.Fatalf("protocol=%q destination-port=%q, want tcp/8080", app.Protocol, app.DestinationPort)
+				}
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg, err := CompileConfig(setTree6524(t, c.set))
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			app := cfg.Applications.Applications["myapp"]
+			if app == nil {
+				t.Fatalf("application myapp missing from compiled config")
+			}
+			c.check(t, app)
+		})
+	}
+}
+
+// TestChainedAppLenientPathAlsoHonorsChain is the reason the fix lives in the
+// COMPILER and not (only) in the schema. CompileConfigLenient is the tolerant
+// boot-load / HA SyncApply path: it downgrades a strict rejection to a warning
+// and keeps compiling. A schema-only fix would reject the chained form at
+// interactive commit but leave a PERSISTED or PEER-PUSHED config compiling
+// protocol-only — still permitting all TCP, and precisely where an operator
+// would never see the warning.
+func TestChainedAppLenientPathAlsoHonorsChain(t *testing.T) {
+	cfg, err := CompileConfigLenient(setTree6524(t,
+		"set applications application myapp protocol tcp destination-port 8080"))
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: %v", err)
+	}
+	app := cfg.Applications.Applications["myapp"]
+	if app == nil {
+		t.Fatalf("application myapp missing from lenient-compiled config")
+	}
+	if app.Protocol != "tcp" || app.DestinationPort != "8080" {
+		t.Fatalf("lenient path: protocol=%q destination-port=%q, want tcp/8080 — "+
+			"a persisted or peer-synced chained application must NOT compile "+
+			"protocol-only (it would permit ALL TCP with no operator-visible "+
+			"error, #6524)", app.Protocol, app.DestinationPort)
+	}
+}
+
+// TestChainedAppUnrepresentableTailRejected covers the tokens the chain walk
+// cannot honor. A direct application body holds ONE protocol and ONE port
+// (Application.Protocol / .DestinationPort are single fields — multi-valued
+// matching is what `term` sub-blocks are for), so a bracketed list silently
+// dropped every value past the first, and a typo'd leaf silently dropped its
+// whole constraint. Both widen the application; both must now be
+// operator-visible commit errors.
+func TestChainedAppUnrepresentableTailRejected(t *testing.T) {
+	cases := []struct {
+		name      string
+		set       string
+		wantToken string
+	}{
+		{"bracketed protocol list", "set applications application myapp protocol [ tcp udp ]", "udp"},
+		{"bracketed dest-port list", "set applications application myapp protocol tcp destination-port [ 22 23 ]", "23"},
+		{"bracketed source-port list", "set applications application myapp protocol tcp source-port [ 1 2 ]", "2"},
+		{"typo'd chained leaf", "set applications application myapp protocol tcp destination-poort 8080", "destination-poort"},
+		{"typo'd leading leaf", "set applications application myapp protocoll tcp", "protocoll"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := CompileConfig(setTree6524(t, c.set))
+			if err == nil {
+				t.Fatalf("expected commit to REJECT %q — the unrepresentable tail "+
+					"was silently dropped, widening the application (#6524)", c.set)
+			}
+			if !strings.Contains(err.Error(), c.wantToken) {
+				t.Fatalf("reject message must name the offending token %q, got: %v",
+					c.wantToken, err)
+			}
+			if !strings.Contains(err.Error(), "myapp") {
+				t.Fatalf("reject message must name the application, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestChainedAppUnrepresentableTailLenientWarns pins the other half of the
+// strict-reject / lenient-warn contract (#1960 no-brick): the same config must
+// still BOOT on the tolerant path, downgraded to a warning.
+func TestChainedAppUnrepresentableTailLenientWarns(t *testing.T) {
+	cfg, err := CompileConfigLenient(setTree6524(t,
+		"set applications application myapp protocol [ tcp udp ]"))
+	if err != nil {
+		t.Fatalf("lenient path must not hard-fail on an unrepresentable tail: %v", err)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "myapp") && strings.Contains(w, "udp") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("lenient path must record a downgrade warning naming myapp/udp, got %v",
+			cfg.Warnings)
+	}
+}
+
+// TestTermBearingAppStrayTokenStillRejected closes the propagation path. For a
+// term-bearing application the parent `app` struct is DISCARDED (only the
+// generated per-term applications are stored), so an UnknownDirectLeaves record
+// left on the parent would vanish and escape the strict gate.
+func TestTermBearingAppStrayTokenStillRejected(t *testing.T) {
+	_, err := CompileConfig(setTree6524(t,
+		"set applications application myapp term t1 protocol tcp destination-port 80",
+		"set applications application myapp bogus-leaf 1",
+	))
+	if err == nil {
+		t.Fatal("expected commit to REJECT a stray token on a term-bearing " +
+			"application body — the parent struct is discarded, so the record " +
+			"must be carried onto the generated term applications (#6524)")
+	}
+	if !strings.Contains(err.Error(), "bogus-leaf") {
+		t.Fatalf("reject message must name the stray token, got: %v", err)
+	}
+}
+
+// TestChainedAppDuplicateDetectionStillFires proves the #5574 conflicting-
+// duplicate gate still engages once the chain is flattened — the chained
+// spelling must not become a way to smuggle two conflicting values past it.
+func TestChainedAppDuplicateDetectionStillFires(t *testing.T) {
+	_, err := CompileConfig(setTree6524(t,
+		"set applications application myapp protocol tcp destination-port 22",
+		"set applications application myapp destination-port 53",
+	))
+	if err == nil {
+		t.Fatal("expected commit to REJECT conflicting duplicate destination-port")
+	}
+	if !strings.Contains(err.Error(), "destination-port") {
+		t.Fatalf("reject message must name destination-port, got: %v", err)
+	}
+}
+
+// TestHierarchicalAppBodyUnchanged is the over-reach guard: the hierarchical
+// (braced) shape, where the leaves are already siblings, must compile exactly
+// as before. This subtest must stay GREEN under a revert of the #6524 compiler
+// change — if it goes RED the fix altered a shape it had no business touching.
+func TestHierarchicalAppBodyUnchanged(t *testing.T) {
+	p := NewParser(`
+applications {
+    application myapp {
+        protocol tcp;
+        destination-port 8080;
+        source-port 5000;
+        inactivity-timeout 1800;
+        description sample;
+    }
+}
+`)
+	tree, perrs := p.Parse()
+	if len(perrs) != 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	app := cfg.Applications.Applications["myapp"]
+	if app == nil {
+		t.Fatalf("application myapp missing")
+	}
+	if app.Protocol != "tcp" || app.DestinationPort != "8080" ||
+		app.SourcePort != "5000" || app.InactivityTimeout != 1800 ||
+		app.Description != "sample" {
+		t.Fatalf("hierarchical body compiled differently: %+v", app)
+	}
+	if len(app.UnknownDirectLeaves) != 0 {
+		t.Fatalf("hierarchical body must record no unknown leaves, got %v",
+			app.UnknownDirectLeaves)
+	}
+}
+
+// TestSiblingFlatSetAppBodyUnchanged is the second over-reach guard: the
+// one-leaf-per-set-line spelling (the shape that always worked) is untouched,
+// and records no unknown leaves. Also stays GREEN under revert.
+func TestSiblingFlatSetAppBodyUnchanged(t *testing.T) {
+	cfg, err := CompileConfig(setTree6524(t,
+		"set applications application myapp protocol tcp",
+		"set applications application myapp destination-port 8080",
+		"set applications application myapp description sample",
+	))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	app := cfg.Applications.Applications["myapp"]
+	if app == nil {
+		t.Fatalf("application myapp missing")
+	}
+	if app.Protocol != "tcp" || app.DestinationPort != "8080" || app.Description != "sample" {
+		t.Fatalf("sibling flat-set body compiled differently: %+v", app)
+	}
+	if len(app.UnknownDirectLeaves) != 0 {
+		t.Fatalf("sibling body must record no unknown leaves, got %v", app.UnknownDirectLeaves)
+	}
+}
+
+// TestApplicationDirectLeafKeywordsCoverCompilerSwitch is a drift canary: every
+// keyword the direct-body switch in compileApplications handles must also be in
+// applicationDirectLeafKeywords. A keyword added to the switch but missed here
+// would be classified as garbage and hard-rejected at commit — a fail-CLOSED
+// regression on valid config.
+func TestApplicationDirectLeafKeywordsCoverCompilerSwitch(t *testing.T) {
+	// The cases of the direct-body switch, kept in sync by this test.
+	switchCases := []string{
+		"protocol", "destination-port", "source-port",
+		"inactivity-timeout", "timeout", "icmp-type", "icmp-code",
+		"alg", "description", "term",
+	}
+	for _, kw := range switchCases {
+		if !applicationDirectLeafKeywords[kw] {
+			t.Fatalf("compileApplications handles %q but applicationDirectLeaves "+
+				"does not recognize it — a valid statement would be recorded as "+
+				"unknown and hard-rejected at commit", kw)
+		}
+	}
+	if len(applicationDirectLeafKeywords) != len(switchCases) {
+		t.Fatalf("applicationDirectLeafKeywords has %d entries, the compiler switch "+
+			"has %d — an entry here with no switch case is silently ignored "+
+			"rather than rejected", len(applicationDirectLeafKeywords), len(switchCases))
+	}
+}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -130,9 +130,27 @@ func applicationDirectLeaves(appNode *Node) (leaves []*Node, unknown []string) {
 				if !applicationDirectLeafKeywords[kw] {
 					// Either a typo'd statement or a stray value token; both
 					// carry a constraint the compiler cannot honor.
+					//
+					// POISON the remainder of this run and this node's subtree
+					// rather than skipping the token and RECOVERING the next
+					// recognized keyword. The tokens after an unparsable one
+					// belong to the same statement the parser could not model,
+					// so compiling them yields an application the operator never
+					// authored — and, critically, one that is WIDER than what
+					// master produced. Master ignored an unrecognized child node
+					// whole, so `bogus value protocol tcp` left the application
+					// PROTOCOL-LESS and therefore unrepresentable (fail-closed:
+					// pkg/policymatch reports ContentRejected, the #2124 gate
+					// refuses to arm). Recovering `protocol tcp` out of that same
+					// line turns an inert residual into an ACTIVE all-TCP permit
+					// on the boot / HA SyncApply paths, where the strict reject is
+					// only a warning. Sibling leaves are unaffected: they are
+					// separate nodes, so a stray `bogus value` line still leaves a
+					// neighbouring `protocol tcp` line compiled exactly as master
+					// compiled it.
 					unknown = append(unknown, kw)
-					i++
-					continue
+					descend = false
+					break
 				}
 				if kw == "term" {
 					if i == 0 {
@@ -168,22 +186,53 @@ func applicationDirectLeaves(appNode *Node) (leaves []*Node, unknown []string) {
 					i++
 				}
 				vals := n.Keys[valStart:i]
+				if kw == "description" {
+					// `description` is a TAIL leaf, not an `args: 1` value leaf:
+					// Junos takes its text to the end of the statement, so an
+					// unquoted multi-word description is legal config. Joining
+					// the run keeps `description my web app` intact instead of
+					// recording "web"/"app" as unknown content — which would
+					// hard-reject at commit a spelling master accepted, over a
+					// METADATA leaf with no bearing on what the application
+					// matches. It also stops a description from poisoning the
+					// rest of the run.
+					//
+					// The `scalar: true` arity the schema enforces for this leaf
+					// (validateScalarValueLeaf / #3332) is unchanged and still
+					// rejects the SIBLING spelling at strict commit; it simply
+					// never sees the chained one, and the compiler does not
+					// invent a second, broader arity rule for a leaf that cannot
+					// affect enforcement.
+					leaves = append(leaves, &Node{Keys: []string{kw, strings.Join(vals, " ")}})
+					continue
+				}
+				poisoned := false
 				if len(vals) > 1 {
-					// A single-valued leaf carrying a bracket-list tail.
+					// A single-valued leaf carrying a bracket-list tail. Record
+					// the surplus and poison the rest of the run for the same
+					// reason as an unknown keyword above: `destination-port
+					// [ 22 23 ] protocol tcp` must not drop `23` and then
+					// RECOVER `protocol tcp`, which would arm a TCP permit where
+					// master left the application protocol-less.
 					unknown = append(unknown, vals[1:]...)
+					poisoned = true
 				}
 				if start == 0 {
 					// nodeVal reads this node's own Keys[1], so pass it through
 					// unchanged — byte-identical to the pre-#6524
 					// sibling/hierarchical path.
 					leaves = append(leaves, n)
-					continue
+				} else {
+					syn := &Node{Keys: []string{kw}}
+					if len(vals) > 0 {
+						syn.Keys = append(syn.Keys, vals[0])
+					}
+					leaves = append(leaves, syn)
 				}
-				syn := &Node{Keys: []string{kw}}
-				if len(vals) > 0 {
-					syn.Keys = append(syn.Keys, vals[0])
+				if poisoned {
+					descend = false
+					break
 				}
-				leaves = append(leaves, syn)
 			}
 			if !descend || len(n.Children) == 0 {
 				continue

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -40,6 +40,153 @@ func parseAppTimeout(raw string) (int, bool) {
 	return n, true
 }
 
+// applicationDirectLeafKeywords is the set of statements Junos allows directly
+// inside an `applications application <name>` body. It is the SINGLE source of
+// truth shared by applicationDirectLeaves (which classifies a token as a leaf
+// or as garbage) and the direct-body switch in compileApplications, so the two
+// cannot drift: a keyword added to the switch but not here would be recorded as
+// unknown and hard-rejected at commit.
+var applicationDirectLeafKeywords = map[string]bool{
+	"protocol":           true,
+	"destination-port":   true,
+	"source-port":        true,
+	"inactivity-timeout": true,
+	"timeout":            true,
+	"icmp-type":          true,
+	"icmp-code":          true,
+	"alg":                true,
+	"description":        true,
+	"term":               true,
+}
+
+// applicationDirectLeaves flattens the DIRECT match body of an `applications
+// application <name>` node into its recognized leaf nodes (in document order),
+// plus every token that is not a recognized leaf keyword.
+//
+// #6524: the flat-set grammar does NOT produce one sibling node per leaf. Only
+// the FIRST leaf on a `set` line becomes a child of the application node; each
+// subsequent leaf is parked as a child of the PREVIOUS leaf's value node,
+// because SetPath descends into the node it just created and these leaves
+// declare `children: nil` (schema_security.go). So
+//
+//	set applications application myapp protocol tcp destination-port 8080
+//
+// builds a CHAIN — application myapp -> `protocol tcp` -> `destination-port
+// 8080` — not two siblings. compileApplications iterated only
+// inst.node.Children, saw just `protocol`, and never assigned
+// DestinationPort; the application compiled protocol-only and a policy
+// matching it permitted ALL TCP (pkg/policymatch: an empty DestinationPort
+// matches any port). Nothing caught it: `protocol` / `destination-port` /
+// `source-port` are the only application match leaves that are neither typed
+// nor `scalar: true`, so no arity gate engages and the chained form validates
+// clean at both SchemaValidate and strict commit.
+//
+// This is the direct-body instance of the dual-AST-shape class already fixed
+// next door for application-SET members (applicationSetMemberValues, #5181),
+// address-set members (addressSetMemberValues, #4791) and firewall match
+// values (firewallMatchValues, #2419) — the direct application body never
+// received the same treatment.
+//
+// Both AST shapes are covered. In the hierarchical / one-leaf-per-set-line
+// shape the leaves are already siblings, so the walk emits them in order and
+// finds nothing to descend into — byte-identical to the pre-#6524
+// inst.node.Children iteration. In the chained flat-set shape it follows each
+// leaf's value node down the chain.
+//
+// Only the FIRST link of a flat-set chain gets a node of its own. Because these
+// leaves declare `children: nil`, SetPath stops modelling at that point and
+// PACKS every remaining token of the line onto ONE child node, so
+//
+//	protocol tcp source-port 5000 destination-port 8080
+//
+// becomes `protocol tcp` -> a single child whose Keys are the flat run
+// ["source-port","5000","destination-port","8080"]. Each node's Keys are
+// therefore split into one leaf per recognized keyword, the tokens between two
+// keywords forming that leaf's value — the same keyword-delimited scan
+// parseApplicationTerms performs over an inline term's token stream. A leaf that
+// is not the node's own first token is re-emitted as a synthesized `keyword
+// value` node so the caller sees a uniform shape.
+//
+// A token that is neither a recognized leaf keyword nor the single value of the
+// leaf it follows is returned in unknown rather than silently dropped. That is
+// how a bracketed list on a single-valued leaf is caught: `protocol [ tcp udp ]`
+// collapses per #2419 onto ONE leaf (the lexer strips the brackets), landing the
+// tail either in the packed Keys or as a child value node, and a direct
+// application body has room for exactly one protocol and one port.
+//
+// `term` is emitted as a leaf and terminates the scan: the rest of the run is
+// the term's own opaque token stream, which parseApplicationTerms flattens (and
+// guards with UnknownTermLeaves, #3352).
+func applicationDirectLeaves(appNode *Node) (leaves []*Node, unknown []string) {
+	var walk func(nodes []*Node)
+	walk = func(nodes []*Node) {
+		for _, n := range nodes {
+			if n == nil || len(n.Keys) == 0 || n.Keys[0] == "" {
+				continue
+			}
+			descend := true
+			for i := 0; i < len(n.Keys); {
+				kw := n.Keys[i]
+				if !applicationDirectLeafKeywords[kw] {
+					// Either a typo'd statement or a stray value token; both
+					// carry a constraint the compiler cannot honor.
+					unknown = append(unknown, kw)
+					i++
+					continue
+				}
+				if kw == "term" {
+					if i == 0 {
+						// The node IS the term: hand it over untouched so
+						// parseApplicationTerms still sees its Children.
+						leaves = append(leaves, n)
+						descend = false
+					} else {
+						leaves = append(leaves, &Node{Keys: append([]string(nil), n.Keys[i:]...)})
+					}
+					break
+				}
+				// This leaf's value tokens run until the next known keyword.
+				start := i
+				i++
+				valStart := i
+				for i < len(n.Keys) && !applicationDirectLeafKeywords[n.Keys[i]] {
+					i++
+				}
+				vals := n.Keys[valStart:i]
+				if len(vals) > 1 {
+					// A single-valued leaf carrying a bracket-list tail.
+					unknown = append(unknown, vals[1:]...)
+				}
+				if start == 0 {
+					// nodeVal reads this node's own Keys[1], so pass it through
+					// unchanged — byte-identical to the pre-#6524
+					// sibling/hierarchical path.
+					leaves = append(leaves, n)
+					continue
+				}
+				syn := &Node{Keys: []string{kw}}
+				if len(vals) > 0 {
+					syn.Keys = append(syn.Keys, vals[0])
+				}
+				leaves = append(leaves, syn)
+			}
+			if !descend || len(n.Children) == 0 {
+				continue
+			}
+			if len(n.Keys) < 2 {
+				// Value-in-child shape (nodeVal's Children[0] fallback): the
+				// first child IS this leaf's value, so only the rest continue
+				// the chain.
+				walk(n.Children[1:])
+				continue
+			}
+			walk(n.Children)
+		}
+	}
+	walk(appNode.Children)
+	return leaves, unknown
+}
+
 func compileApplications(node *Node, apps *ApplicationsConfig) error {
 	for _, inst := range namedInstances(node.FindChildren("application")) {
 		appName := inst.name
@@ -82,7 +229,13 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 			timeoutVal                                   int
 			itypeVal, icodeVal                           uint8
 		)
-		for _, prop := range inst.node.Children {
+		// #6524: walk the direct body across BOTH AST shapes. In the flat-set
+		// shape the leaves form a CHAIN (`protocol tcp` -> `destination-port
+		// 8080`), not siblings, so iterating inst.node.Children alone saw only
+		// the first leaf and compiled the application protocol-only.
+		directLeaves, unknownDirect := applicationDirectLeaves(inst.node)
+		app.UnknownDirectLeaves = unknownDirect
+		for _, prop := range directLeaves {
 			switch prop.Name() {
 			case "protocol":
 				hasDirectBody = true
@@ -223,6 +376,14 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 			implicitSet := &ApplicationSet{Name: appName}
 			for _, t := range terms {
 				t.Description = app.Description
+				// #6524: the parent `app` struct is DISCARDED on this branch,
+				// so an unrecognized token sitting directly on a term-bearing
+				// application body would take its UnknownDirectLeaves record
+				// with it and escape the strict gate. Carry it onto every
+				// generated term application — the only survivors — exactly as
+				// Description is carried, mirroring how parseApplicationTerms
+				// already lands UnknownTermLeaves on each term (#3352).
+				t.UnknownDirectLeaves = app.UnknownDirectLeaves
 				apps.Applications[t.Name] = t
 				implicitSet.Applications = append(implicitSet.Applications, t.Name)
 			}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -145,10 +145,25 @@ func applicationDirectLeaves(appNode *Node) (leaves []*Node, unknown []string) {
 					}
 					break
 				}
-				// This leaf's value tokens run until the next known keyword.
+				// RESERVE the value slot before resuming the keyword scan.
+				// Every one of these leaves is `args: 1`, so it consumes
+				// exactly ONE token as its value even when that token happens
+				// to spell a grammar keyword — `description destination-port`
+				// is a description whose text is "destination-port", not a
+				// description followed by a port statement. Without the
+				// reservation the scan synthesized a PHANTOM valueless
+				// `destination-port` leaf that reset an already-assigned field
+				// back to "" (an unset port matches EVERY port on the tolerant
+				// path — the exact widening this change exists to close) and
+				// unconditionally set hasDirectBody, falsely tripping the
+				// #3366 mixed direct+term gate on a term-only application.
 				start := i
 				i++
 				valStart := i
+				if i < len(n.Keys) {
+					i++
+				}
+				// Any FURTHER non-keyword tokens are a bracket-list tail.
 				for i < len(n.Keys) && !applicationDirectLeafKeywords[n.Keys[i]] {
 					i++
 				}
@@ -185,6 +200,50 @@ func applicationDirectLeaves(appNode *Node) (leaves []*Node, unknown []string) {
 	}
 	walk(appNode.Children)
 	return leaves, unknown
+}
+
+// applicationTermKeys reassembles the token stream of an inline `term` node
+// across both AST shapes — hierarchical packs every value onto prop.Keys, the
+// flat-set path splits them across prop.Keys and prop.Children — and returns
+// nil for a term with no name token.
+//
+// It is the shared reader for the two places that must agree on what a term
+// generates: compileApplications (which WRITES `<parent>-<term>` into
+// apps.Applications) and collectApplicationCollisions (which must PREDICT those
+// same names to guard the flat Junos namespace). Before #6524 both open-coded
+// the reassembly; the collision gate additionally enumerated the application
+// node's immediate Children while the compiler moved to applicationDirectLeaves,
+// so a CHAINED `term` was compiled but invisible to every namespace gate (see
+// collectApplicationCollisions).
+//
+// The returned slice is always a fresh copy. The compiler previously sliced
+// `prop.Keys[1:]` and appended child keys onto it, which can write into the
+// node's own backing array whenever that slice has spare capacity — a latent
+// AST-corruption hazard the copy removes.
+func applicationTermKeys(prop *Node) []string {
+	if prop == nil || len(prop.Keys) < 2 {
+		return nil
+	}
+	allKeys := append([]string(nil), prop.Keys[1:]...)
+	for _, c := range prop.Children {
+		allKeys = append(allKeys, c.Keys...)
+	}
+	return allKeys
+}
+
+// applicationTermNodes returns the inline `term` leaves of an `applications
+// application <name>` body, walking the direct body with applicationDirectLeaves
+// so a term reached through a flat-set CHAIN is found in both AST shapes. It is
+// the enumeration half of the term contract shared with applicationTermKeys.
+func applicationTermNodes(appNode *Node) []*Node {
+	leaves, _ := applicationDirectLeaves(appNode)
+	var terms []*Node
+	for _, leaf := range leaves {
+		if leaf.Name() == "term" {
+			terms = append(terms, leaf)
+		}
+	}
+	return terms
 }
 
 func compileApplications(node *Node, apps *ApplicationsConfig) error {
@@ -328,14 +387,9 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 			case "term":
 				// Inline term: "term <name> [alg <a>] protocol <p> [source-port <sp>]
 				//               [destination-port <dp>] [inactivity-timeout <t>];"
-				if len(prop.Keys) < 2 {
+				allKeys := applicationTermKeys(prop)
+				if len(allKeys) == 0 {
 					continue
-				}
-				// Hierarchical: all values in prop.Keys (inline statement)
-				// Flat set: values split across prop.Keys and prop.Children
-				allKeys := prop.Keys[1:]
-				for _, c := range prop.Children {
-					allKeys = append(allKeys, c.Keys...)
 				}
 				termApps := parseApplicationTerms(appName, allKeys)
 				terms = append(terms, termApps...)

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -190,19 +190,42 @@ func applicationDirectLeaves(appNode *Node) (leaves []*Node, unknown []string) {
 					// `description` is a TAIL leaf, not an `args: 1` value leaf:
 					// Junos takes its text to the end of the statement, so an
 					// unquoted multi-word description is legal config. Joining
-					// the run keeps `description my web app` intact instead of
-					// recording "web"/"app" as unknown content — which would
-					// hard-reject at commit a spelling master accepted, over a
-					// METADATA leaf with no bearing on what the application
-					// matches. It also stops a description from poisoning the
-					// rest of the run.
+					// the run keeps the text intact instead of recording the
+					// second and later words as unknown content and
+					// hard-rejecting the line at commit, over a METADATA leaf
+					// with no bearing on what the application matches. It also
+					// stops a description from poisoning the rest of the run.
 					//
-					// The `scalar: true` arity the schema enforces for this leaf
-					// (validateScalarValueLeaf / #3332) is unchanged and still
-					// rejects the SIBLING spelling at strict commit; it simply
-					// never sees the chained one, and the compiler does not
-					// invent a second, broader arity rule for a leaf that cannot
-					// affect enforcement.
+					// Which spellings this actually reaches is worth stating
+					// exactly, because the surrounding gates cover the rest and
+					// an over-broad claim here would invite someone to loosen a
+					// gate master also held. A multi-word description occupies
+					// one of three positions:
+					//
+					//   - SIBLING (hierarchical, or its own `set` line):
+					//     `description "my web app";` arrives quoted as one
+					//     token, or unquoted as this node's own Keys run. The
+					//     schema's `scalar: true` arity (validateScalarValueLeaf
+					//     / #3332) is untouched and still governs it.
+					//   - HEAD of a flat-set chain: `set ... description my web
+					//     app [protocol tcp]` parks the tail in a CHILD node, so
+					//     the run this branch joins is just ["my"] and the child
+					//     opens with "web". SchemaValidate DOES see that shape
+					//     and rejects it ("unexpected trailing token \"web\""),
+					//     exactly as it did on master — so the line stays a
+					//     commit error, and the join below is not what decides
+					//     it.
+					//   - PACKED TAIL of a flat-set chain: `set ... protocol tcp
+					//     description my web app` packs the whole description
+					//     onto ONE node's Keys, BELOW the depth SchemaValidate
+					//     walks (it returns nil). This is the only position the
+					//     join actually rescues, and the only one where a
+					//     spelling master committed would otherwise become a new
+					//     hard reject.
+					//
+					// So the compiler does not invent a second, broader arity
+					// rule for a leaf that cannot affect enforcement; it covers
+					// the one position no existing gate reaches.
 					leaves = append(leaves, &Node{Keys: []string{kw, strings.Join(vals, " ")}})
 					continue
 				}

--- a/pkg/config/compiler_applications_collision.go
+++ b/pkg/config/compiler_applications_collision.go
@@ -222,16 +222,26 @@ func validateApplicationNameCollisionsAST(nodes []*Node, lenient bool) ([]string
 			}
 			seen := termSeen[appName]
 			dupReported := termDupReported[appName]
-			for _, prop := range inst.node.Children {
-				if prop.Name() != "term" || len(prop.Keys) < 2 {
+			// #6524: enumerate terms through applicationTermNodes /
+			// applicationTermKeys — the SAME walk compileApplications uses to
+			// decide what to write. This loop previously scanned
+			// inst.node.Children directly, which could not see a term reached
+			// through a flat-set CHAIN (`application myapp description doc term
+			// t1 protocol udp` nests the term under the `description` value
+			// node). Once #6524 taught the compiler to follow that chain, such a
+			// term was MINTED into apps.Applications but stayed invisible to
+			// every gate below — so a generated `<parent>-<term>` could silently
+			// overwrite an AUTHORED application (H01) with no commit error,
+			// erasing a deny that referenced it. `description` is the entry route
+			// on the strict path because it deliberately does not set
+			// hasDirectBody (#3366), so MixedDirectTermApps never engages; on the
+			// tolerant path that gate is only a warning, so no `description`
+			// prefix is even needed. The sibling spelling was always caught here
+			// — only the chained shape evaded it.
+			for _, prop := range applicationTermNodes(inst.node) {
+				allKeys := applicationTermKeys(prop)
+				if len(allKeys) == 0 {
 					continue
-				}
-				// Reassemble the term tokens across both AST shapes, mirroring
-				// compileApplications: hierarchical packs values in prop.Keys,
-				// flat set splits them across prop.Keys and prop.Children.
-				allKeys := append([]string(nil), prop.Keys[1:]...)
-				for _, c := range prop.Children {
-					allKeys = append(allKeys, c.Keys...)
 				}
 				for _, t := range parseApplicationTerms(appName, allKeys) {
 					// #3472: record this generated name and the parent that

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -358,8 +358,9 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 // validateApplicationSyntaxStrict hard-rejects SYNTACTIC errors in a
 // user-defined application definition that the typed-schema walk cannot reach:
 // an unrecognized leaf inside an opaque inline `term { ... }` (#3352), an
-// `alg` name xpf does not support (#3353), and an unrecognized member statement
-// inside an opaque `application-set { ... }` body (#3890).
+// `alg` name xpf does not support (#3353), an unrecognized token directly on
+// the application body (#6524), and an unrecognized member statement inside an
+// opaque `application-set { ... }` body (#3890).
 //
 // Unlike validateApplicationSpecsStrict — whose port / protocol / icmp / timeout
 // checks are SEMANTIC and deliberately scoped to REFERENCED applications (an
@@ -415,6 +416,41 @@ func validateApplicationSyntaxStrict(cfg *Config) error {
 					"icmp-code / alg (an unrecognized leaf is silently dropped along "+
 					"with its value, widening the term to match more than intended)",
 				name, app.UnknownTermLeaves[0])
+		}
+		// #6524: an unrecognized token directly on the application body. The
+		// application body is an opaque `args:1` schema leaf whose three match
+		// leaves (protocol / destination-port / source-port) are the only ones
+		// neither typed nor `scalar: true`, so no arity gate engages and the
+		// SchemaValidate walk accepts any trailing token. Two forms reach here,
+		// both of which were silently dropped before #6524 and both of which
+		// WIDEN the application (an unset port matches EVERY port, so a permit
+		// over-permits and a deny under-matches):
+		//
+		//   - a bracketed list on a single-valued leaf (`protocol [ tcp udp ]`,
+		//     `destination-port [ 22 23 ]`) — a direct application body takes
+		//     one protocol and one port, and Application.Protocol /
+		//     .DestinationPort are single fields; multi-valued matching is what
+		//     `term` sub-blocks are for;
+		//   - a typo'd leaf keyword (`destination-poort 8080`).
+		//
+		// applicationDirectLeaves records the offending token on
+		// UnknownDirectLeaves (mirroring UnknownTermLeaves / UnknownMembers);
+		// reject the first one so the silent widening becomes an
+		// operator-visible commit error. Strict on the commit / commit-check
+		// path; the call site downgrades it to a warning on the tolerant load /
+		// peer-sync path (#1960 no-brick).
+		if len(app.UnknownDirectLeaves) > 0 {
+			return fmt.Errorf(
+				"application %q: unknown statement %q in the application body; a "+
+					"custom application accepts only protocol / source-port / "+
+					"destination-port / inactivity-timeout / timeout / icmp-type / "+
+					"icmp-code / alg / description / term, each taking a SINGLE value "+
+					"(an unrecognized token — including the tail of a bracketed list "+
+					"such as `protocol [ tcp udp ]`, which a direct application body "+
+					"cannot represent — is silently dropped, widening the application "+
+					"to match more than intended; use separate `term` sub-blocks for "+
+					"multiple protocols or ports)",
+				name, app.UnknownDirectLeaves[0])
 		}
 		// #4337: a per-application `alg <name>` outside the four xpf implements
 		// (dns/ftp/sip/tftp) is NO LONGER hard-rejected here. The #3353 commit

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -444,12 +444,14 @@ func validateApplicationSyntaxStrict(cfg *Config) error {
 				"application %q: unknown statement %q in the application body; a "+
 					"custom application accepts only protocol / source-port / "+
 					"destination-port / inactivity-timeout / timeout / icmp-type / "+
-					"icmp-code / alg / description / term, each taking a SINGLE value "+
-					"(an unrecognized token — including the tail of a bracketed list "+
-					"such as `protocol [ tcp udp ]`, which a direct application body "+
-					"cannot represent — is silently dropped, widening the application "+
-					"to match more than intended; use separate `term` sub-blocks for "+
-					"multiple protocols or ports)",
+					"icmp-code / alg / description / term, each taking a SINGLE value. "+
+					"The token is silently dropped, which changes what the application "+
+					"matches: dropping a port or icmp-type constraint WIDENS it (an "+
+					"unset port matches every port), while dropping an alternative from "+
+					"a bracketed list such as `protocol [ tcp udp ]` NARROWS it to the "+
+					"first value — a direct application body holds one protocol and one "+
+					"port, so use separate `term` sub-blocks for multiple protocols or "+
+					"ports",
 				name, app.UnknownDirectLeaves[0])
 		}
 		// #4337: a per-application `alg <name>` outside the four xpf implements

--- a/pkg/config/compiler_validate_strict_application.go
+++ b/pkg/config/compiler_validate_strict_application.go
@@ -444,7 +444,9 @@ func validateApplicationSyntaxStrict(cfg *Config) error {
 				"application %q: unknown statement %q in the application body; a "+
 					"custom application accepts only protocol / source-port / "+
 					"destination-port / inactivity-timeout / timeout / icmp-type / "+
-					"icmp-code / alg / description / term, each taking a SINGLE value. "+
+					"icmp-code / alg / description / term. Every one of those takes a "+
+					"SINGLE value except `description`, whose unquoted multi-word tail "+
+					"is absorbed when it trails the chain. "+
 					"The token is silently dropped, which changes what the application "+
 					"matches: dropping a port or icmp-type constraint WIDENS it (an "+
 					"unset port matches every port), while dropping an alternative from "+

--- a/pkg/config/testdata/golden_4406.json
+++ b/pkg/config/testdata/golden_4406.json
@@ -13485,7 +13485,7 @@
           "appA": {
             "Name": "appA",
             "Protocol": "udp",
-            "DestinationPort": "",
+            "DestinationPort": "80",
             "SourcePort": "",
             "InactivityTimeout": 0,
             "ALG": "",
@@ -13498,7 +13498,8 @@
             "DuplicateTermLeaves": null,
             "DuplicateDirectLeaves": [
               "protocol"
-            ]
+            ],
+            "UnknownDirectLeaves": null
           }
         },
         "ApplicationSets": {},
@@ -13758,7 +13759,7 @@
           "appA": {
             "Name": "appA",
             "Protocol": "udp",
-            "DestinationPort": "",
+            "DestinationPort": "80",
             "SourcePort": "",
             "InactivityTimeout": 0,
             "ALG": "",
@@ -13771,7 +13772,8 @@
             "DuplicateTermLeaves": null,
             "DuplicateDirectLeaves": [
               "protocol"
-            ]
+            ],
+            "UnknownDirectLeaves": null
           }
         },
         "ApplicationSets": {},
@@ -14031,7 +14033,7 @@
           "appA": {
             "Name": "appA",
             "Protocol": "udp",
-            "DestinationPort": "",
+            "DestinationPort": "80",
             "SourcePort": "",
             "InactivityTimeout": 0,
             "ALG": "",
@@ -14044,7 +14046,8 @@
             "DuplicateTermLeaves": null,
             "DuplicateDirectLeaves": [
               "protocol"
-            ]
+            ],
+            "UnknownDirectLeaves": null
           }
         },
         "ApplicationSets": {},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1284,14 +1284,26 @@ type Application struct {
 	//   - a typo'd leaf keyword (`destination-poort 8080`), silently dropped
 	//     along with its value.
 	//
-	// Either way the application ends up matching MORE than authored (a
-	// dropped port constraint matches every port — pkg/policymatch
-	// portMatches treats an empty DestinationPort as match-any), so a policy
-	// referencing it over-permits, or a deny under-matches. Mirroring
-	// UnknownTermLeaves, the offending token is recorded here and the deferred
-	// gate (validateApplicationSyntaxStrict) hard-rejects the first one on the
-	// strict commit path / warns on the tolerant load / peer-sync path (#1960
-	// no-brick).
+	// Either way the dropped token changes what the application matches, in
+	// whichever DIRECTION the dropped constraint pointed: losing a port or
+	// icmp-type WIDENS it (pkg/policymatch treats an empty DestinationPort as
+	// match-any, so a permit over-permits), while losing an alternative from a
+	// bracketed protocol list NARROWS it to the first value (so a deny
+	// under-matches). Both are wrong; neither is uniformly "widening".
+	//
+	// A `description` whose text happens to spell a grammar keyword is NOT
+	// recorded here — applicationDirectLeaves reserves each `args: 1` leaf's
+	// value slot before resuming its keyword scan, so `description
+	// destination-port` is a description reading "destination-port", not a
+	// phantom port statement. An unquoted MULTI-word description tail
+	// (`description my web app`) IS recorded, matching the `scalar: true` arity
+	// the schema already enforces for that leaf at commit (schema_security.go,
+	// validateScalarValueLeaf / #3332).
+	//
+	// Mirroring UnknownTermLeaves, the offending token is recorded here and the
+	// deferred gate (validateApplicationSyntaxStrict) hard-rejects the first one
+	// on the strict commit path / warns on the tolerant load / peer-sync path
+	// (#1960 no-brick).
 	UnknownDirectLeaves []string
 }
 

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1293,20 +1293,29 @@ type Application struct {
 	//
 	// `description` never contributes to this list from its own token run. It is
 	// a TAIL leaf (Junos takes its text to the end of the statement), so
-	// applicationDirectLeaves joins the run into the description text: both
+	// applicationDirectLeaves joins the run into the description text rather
+	// than recording the second and later words here. That covers
 	// `description destination-port` (text that happens to spell a keyword —
-	// the leaf's value slot is reserved before the keyword scan resumes) and
-	// `description my web app` compile as written rather than being recorded
-	// here. Rejecting a METADATA leaf that cannot affect what the application
-	// matches would be pure friction, and the chained spelling committed on
-	// master.
+	// the leaf's value slot is reserved before the keyword scan resumes) and a
+	// multi-word description PACKED onto one node's Keys. Rejecting a METADATA
+	// leaf that cannot affect what the application matches would be pure
+	// friction, and that spelling committed on master.
+	//
+	// The join is deliberately NOT a claim that every multi-word description
+	// now commits. A description that HEADS a flat-set chain
+	// (`set ... description my web app ...`) parks its tail in a CHILD node, so
+	// "web" opens a fresh run and IS recorded here — and SchemaValidate rejects
+	// the same line independently ("unexpected trailing token"). Master
+	// rejected it by that same schema gate, so this is parity, not a new
+	// refusal; see TestDescriptionIsATailLeaf, which pins both positions.
 	//
 	// The `scalar: true` arity the schema enforces for `description`
-	// (validateScalarValueLeaf / #3332) is untouched and still rejects the
-	// SIBLING spelling at strict commit — it simply never sees the chained one,
-	// where the leaf is nested under a value node. So no config that was
-	// committable on master is newly refused: master's own commit path already
-	// rejected the sibling spelling via SchemaValidate.
+	// (validateScalarValueLeaf / #3332) is untouched. It governs the SIBLING
+	// spelling and the head-of-chain spelling; the only position it does not
+	// reach is a description packed into a chain TAIL, below the depth the
+	// schema walk descends to — which is exactly the position the join above
+	// exists to cover. So no config that was committable on master is newly
+	// refused.
 	//
 	// Mirroring UnknownTermLeaves, the offending token is recorded here and the
 	// deferred gate (validateApplicationSyntaxStrict) hard-rejects the first one

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1291,14 +1291,22 @@ type Application struct {
 	// bracketed protocol list NARROWS it to the first value (so a deny
 	// under-matches). Both are wrong; neither is uniformly "widening".
 	//
-	// A `description` whose text happens to spell a grammar keyword is NOT
-	// recorded here — applicationDirectLeaves reserves each `args: 1` leaf's
-	// value slot before resuming its keyword scan, so `description
-	// destination-port` is a description reading "destination-port", not a
-	// phantom port statement. An unquoted MULTI-word description tail
-	// (`description my web app`) IS recorded, matching the `scalar: true` arity
-	// the schema already enforces for that leaf at commit (schema_security.go,
-	// validateScalarValueLeaf / #3332).
+	// `description` never contributes to this list from its own token run. It is
+	// a TAIL leaf (Junos takes its text to the end of the statement), so
+	// applicationDirectLeaves joins the run into the description text: both
+	// `description destination-port` (text that happens to spell a keyword —
+	// the leaf's value slot is reserved before the keyword scan resumes) and
+	// `description my web app` compile as written rather than being recorded
+	// here. Rejecting a METADATA leaf that cannot affect what the application
+	// matches would be pure friction, and the chained spelling committed on
+	// master.
+	//
+	// The `scalar: true` arity the schema enforces for `description`
+	// (validateScalarValueLeaf / #3332) is untouched and still rejects the
+	// SIBLING spelling at strict commit — it simply never sees the chained one,
+	// where the leaf is nested under a value node. So no config that was
+	// committable on master is newly refused: master's own commit path already
+	// rejected the sibling spelling via SchemaValidate.
 	//
 	// Mirroring UnknownTermLeaves, the offending token is recorded here and the
 	// deferred gate (validateApplicationSyntaxStrict) hard-rejects the first one

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1261,6 +1261,38 @@ type Application struct {
 	// hard-rejects the first one on the strict commit path / warns on the tolerant
 	// load / peer-sync path (#5574).
 	DuplicateDirectLeaves []string
+	// UnknownDirectLeaves records the raw tokens directly under an
+	// `applications application <name>` body that are NOT a recognized direct
+	// match leaf (protocol / destination-port / source-port /
+	// inactivity-timeout / timeout / icmp-type / icmp-code / alg / description /
+	// term) — the DIRECT-body analogue of UnknownTermLeaves.
+	//
+	// #6524: the flat-set grammar builds `set a b c d` as a CHAIN of single-key
+	// nodes, so `set applications application myapp protocol tcp
+	// destination-port 8080` nests `destination-port` UNDER the value node
+	// `tcp` rather than beside `protocol`. applicationDirectLeaves now follows
+	// that chain, so a token it cannot map to a known leaf keyword is real
+	// operator garbage rather than a shape the walk failed to reach. Two forms
+	// land here:
+	//
+	//   - a bracketed list on a single-valued leaf — `protocol [ tcp udp ]`,
+	//     `destination-port [ 22 23 ]`. Junos gives a direct application body
+	//     ONE protocol and ONE port (multi-valued matching is what `term`
+	//     sub-blocks are for), and Application.Protocol / .DestinationPort are
+	//     single fields that cannot represent the set, so every value past the
+	//     first was silently dropped;
+	//   - a typo'd leaf keyword (`destination-poort 8080`), silently dropped
+	//     along with its value.
+	//
+	// Either way the application ends up matching MORE than authored (a
+	// dropped port constraint matches every port — pkg/policymatch
+	// portMatches treats an empty DestinationPort as match-any), so a policy
+	// referencing it over-permits, or a deny under-matches. Mirroring
+	// UnknownTermLeaves, the offending token is recorded here and the deferred
+	// gate (validateApplicationSyntaxStrict) hard-rejects the first one on the
+	// strict commit path / warns on the tolerant load / peer-sync path (#1960
+	// no-brick).
+	UnknownDirectLeaves []string
 }
 
 // IPsecConfig holds IPsec VPN configuration.

--- a/pkg/policymatch/app_chained_leaves_6524_test.go
+++ b/pkg/policymatch/app_chained_leaves_6524_test.go
@@ -1,0 +1,204 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6524 — the SECURITY crux, asserted on the POLICY OUTCOME rather than on the
+// compiled struct.
+//
+// In the flat-set grammar `set a b c d` builds a CHAIN of single-key nodes, so
+//
+//	set applications application myapp protocol tcp destination-port 8080
+//
+// nests `destination-port` under the VALUE node `tcp` instead of beside
+// `protocol`. compileApplications iterated only the application node's direct
+// Children, saw just `protocol`, and never assigned DestinationPort — the
+// application compiled PROTOCOL-ONLY. An empty DestinationPort is a match-any
+// port term (matchSingleApp only constrains the port when app.DestinationPort
+// is non-empty), so a policy matching that application permitted ALL TCP.
+//
+// A test that only checked `app.DestinationPort != ""` would pass on a fix that
+// populated the field while leaving matching broken, so these cases drive
+// Match() and assert the verdict for an IN-scope port and an OUT-of-scope port.
+//
+// RED-on-revert: restore the pre-#6524 `for _, prop := range inst.node.Children`
+// loop in compileApplications (dropping applicationDirectLeaves) and
+// DestinationPort goes back to "" — the "tcp/22 must NOT be permitted" subcases
+// then report Matched=true / PolicyPermit and these tests go RED. The
+// permit-8080 subcases stay green under the revert (protocol-only matches
+// everything), which is exactly why the negative port is the load-bearing
+// assertion.
+
+// chainedAppPolicyCfg compiles a trust->untrust permit policy whose only
+// application is authored with the CHAINED flat-set spelling under test.
+func chainedAppPolicyCfg(t *testing.T, appLine string) *config.Config {
+	t.Helper()
+	return compileFromSet(t, []string{
+		appLine,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application myapp",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies default-policy deny-all",
+	})
+}
+
+func chainedAppQuery(cfg *config.Config, proto string, dstPort int) Result {
+	return Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+		Protocol: proto, SrcPort: 40000, DstPort: dstPort,
+	})
+}
+
+// TestChainedAppDestPortPolicyDoesNotPermitAllTCP is the issue's headline case:
+// the chained one-line application must permit ONLY tcp/8080, not every TCP
+// port.
+func TestChainedAppDestPortPolicyDoesNotPermitAllTCP(t *testing.T) {
+	cfg := chainedAppPolicyCfg(t,
+		"set applications application myapp protocol tcp destination-port 8080")
+
+	// The in-scope port is permitted — the chained destination-port was
+	// actually honored, not merely recorded.
+	if res := chainedAppQuery(cfg, "tcp", 8080); !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("tcp/8080 = matched:%v action:%v, want a PERMIT (the chained "+
+			"destination-port must still admit the port it names)",
+			res.Matched, res.Action)
+	}
+	// The load-bearing assertion: any OTHER TCP port must fall through the
+	// application term to the default deny. Pre-#6524 the app was
+	// protocol-only, so this permitted.
+	for _, port := range []int{22, 80, 443, 65535} {
+		res := chainedAppQuery(cfg, "tcp", port)
+		if res.Matched && res.Action == config.PolicyPermit {
+			t.Fatalf("tcp/%d was PERMITTED by an application declared "+
+				"`protocol tcp destination-port 8080` — the chained "+
+				"destination-port was dropped and the policy permits ALL TCP (#6524)",
+				port)
+		}
+	}
+}
+
+// TestChainedAppSourcePortPolicyConstrainsSourcePort covers the source-port
+// axis of the same chain — the third untyped match leaf.
+func TestChainedAppSourcePortPolicyConstrainsSourcePort(t *testing.T) {
+	cfg := compileFromSet(t, []string{
+		"set applications application myapp protocol tcp source-port 5000",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application myapp",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies default-policy deny-all",
+	})
+	q := func(srcPort int) Result {
+		return Match(cfg, Query{
+			FromZone: "trust", ToZone: "untrust",
+			SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+			Protocol: "tcp", SrcPort: srcPort, DstPort: 80,
+		})
+	}
+	if res := q(5000); !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("source-port 5000 = matched:%v action:%v, want PERMIT", res.Matched, res.Action)
+	}
+	if res := q(5001); res.Matched && res.Action == config.PolicyPermit {
+		t.Fatalf("source-port 5001 was PERMITTED by an application declared " +
+			"`protocol tcp source-port 5000` — the chained source-port was " +
+			"dropped and the policy permits every source port (#6524)")
+	}
+}
+
+// TestChainedAppICMPTypePolicyConstrainsType covers `protocol icmp icmp-type 8`
+// — the chain drops the type constraint, leaving the application matching EVERY
+// ICMP type (the fail-open widening #3348 fixed for the alias/inline-term
+// paths).
+func TestChainedAppICMPTypePolicyConstrainsType(t *testing.T) {
+	cfg := chainedAppPolicyCfg(t,
+		"set applications application myapp protocol icmp icmp-type 8")
+
+	icmp := func(typ uint8) Result {
+		v := typ
+		return Match(cfg, Query{
+			FromZone: "trust", ToZone: "untrust",
+			SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+			Protocol: "icmp", ICMPType: &v,
+		})
+	}
+	// Echo-request (type 8) is the authored constraint — permitted.
+	if res := icmp(8); !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("icmp type 8 = matched:%v action:%v, want PERMIT", res.Matched, res.Action)
+	}
+	// Every other type must NOT be permitted. Pre-#6524 ICMPType stayed nil, so
+	// the term was unconstrained and redirect/timestamp/unreachable all passed.
+	for _, typ := range []uint8{0, 3, 5, 13} {
+		if res := icmp(typ); res.Matched && res.Action == config.PolicyPermit {
+			t.Fatalf("icmp type %d was PERMITTED by an application declared "+
+				"`protocol icmp icmp-type 8` — the chained icmp-type was dropped "+
+				"and the policy permits EVERY ICMP type (#6524)", typ)
+		}
+	}
+}
+
+// TestChainedAppDenyPolicyCoversNamedPort is the DENY-side mirror. A deny whose
+// application dropped its port constraint widens to all-TCP, which is a
+// fail-CLOSED blast radius (unrelated TCP is blocked) rather than a fail-open —
+// the inverse error, and equally wrong. It pins that the deny covers 8080 and
+// leaves other TCP to the later permit.
+func TestChainedAppDenyPolicyCoversNamedPort(t *testing.T) {
+	cfg := compileFromSet(t, []string{
+		"set applications application myapp protocol tcp destination-port 8080",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy blk match source-address any",
+		"set security policies from-zone trust to-zone untrust policy blk match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy blk match application myapp",
+		"set security policies from-zone trust to-zone untrust policy blk then deny",
+		"set security policies from-zone trust to-zone untrust policy rest match source-address any",
+		"set security policies from-zone trust to-zone untrust policy rest match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy rest match application any",
+		"set security policies from-zone trust to-zone untrust policy rest then permit",
+	})
+	if res := chainedAppQuery(cfg, "tcp", 8080); !res.Matched || res.Action != config.PolicyDeny {
+		t.Fatalf("tcp/8080 = matched:%v action:%v, want the DENY to cover the "+
+			"port its application names", res.Matched, res.Action)
+	}
+	// Pre-#6524 the deny widened to every TCP port and swallowed the later
+	// permit.
+	if res := chainedAppQuery(cfg, "tcp", 443); !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("tcp/443 = matched:%v action:%v, want the later PERMIT — a deny "+
+			"application declared `protocol tcp destination-port 8080` must not "+
+			"widen to ALL TCP (#6524)", res.Matched, res.Action)
+	}
+}
+
+// TestSiblingAppSpellingUnchanged is the over-reach guard at the OUTCOME level:
+// the one-leaf-per-line spelling (which always worked) must produce exactly the
+// same verdicts as the chained spelling now does.
+func TestSiblingAppSpellingUnchanged(t *testing.T) {
+	cfg := compileFromSet(t, []string{
+		"set applications application myapp protocol tcp",
+		"set applications application myapp destination-port 8080",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application myapp",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies default-policy deny-all",
+	})
+	if res := chainedAppQuery(cfg, "tcp", 8080); !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("sibling spelling tcp/8080 = matched:%v action:%v, want PERMIT",
+			res.Matched, res.Action)
+	}
+	if res := chainedAppQuery(cfg, "tcp", 22); res.Matched && res.Action == config.PolicyPermit {
+		t.Fatalf("sibling spelling tcp/22 was PERMITTED — the pre-existing " +
+			"one-leaf-per-line behavior regressed")
+	}
+}

--- a/pkg/policymatch/app_unknown_recovery_6524_test.go
+++ b/pkg/policymatch/app_unknown_recovery_6524_test.go
@@ -1,0 +1,154 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #6524 review fold — the VERDICT-level guard on unknown-token recovery.
+//
+// Once the compiler follows the flat-set chain, an unrepresentable token in the
+// direct body must POISON the rest of that run rather than be skipped so a later
+// recognized keyword can be compiled. Recovering the keyword is a fail-open on
+// the TOLERANT path (boot load / HA SyncApply), where the strict reject is only
+// a warning:
+//
+//	set applications application myapp bogus value protocol tcp
+//
+// Master ignored the unrecognized child node whole, leaving `myapp`
+// PROTOCOL-LESS and therefore unrepresentable — the matcher reports
+// ContentRejected and the #2124 capability gate refuses to arm, so nothing is
+// permitted. Skipping `bogus` and compiling `protocol tcp` turns that inert
+// residual into an ACTIVE all-TCP permit.
+//
+// This is asserted on the VERDICT, not on a warning or a struct field. Every
+// previous guard in this PR family asserted on structure and missed a widening;
+// "a warning was emitted" is compatible with the traffic being permitted.
+//
+// RED-on-revert: change the unknown-token branch of applicationDirectLeaves
+// back to `i++; continue` (skip and keep scanning) and both subtests report
+// Matched=true / PolicyPermit for tcp/22 instead of the fail-closed retention.
+func unknownRecoveryCfg(t *testing.T, appLine string) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range []string{
+		appLine,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application myapp",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies default-policy deny-all",
+	} {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	// The TOLERANT path is the one at risk: it downgrades the strict reject to
+	// a warning and keeps enforcing whatever compiled.
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: %v", err)
+	}
+	return cfg
+}
+
+func TestUnknownDirectTokenDoesNotArmAPermit(t *testing.T) {
+	cases := []struct {
+		name string
+		set  string
+	}{
+		{
+			// A typo'd statement followed by a real one.
+			name: "unknown statement then protocol",
+			set:  "set applications application myapp bogus value protocol tcp",
+		},
+		{
+			// A bracket tail followed by a real statement — same root, different
+			// ordering.
+			name: "bracket tail then protocol",
+			set:  "set applications application myapp destination-port [ 22 23 ] protocol tcp",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := unknownRecoveryCfg(t, c.set)
+			res := Match(cfg, Query{
+				FromZone: "trust", ToZone: "untrust",
+				SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+				Protocol: "tcp", SrcPort: 40000, DstPort: 22,
+			})
+			if res.Matched && res.Action == config.PolicyPermit {
+				t.Fatalf("tcp/22 was PERMITTED by an application whose body contains "+
+					"unrepresentable content (%q) — the token after it was RECOVERED, "+
+					"arming a protocol the operator never authored. Master left this "+
+					"application protocol-less and fail-closed; the tolerant path must "+
+					"not be WIDER than master (#6524)", c.set)
+			}
+			// Positive half: it is fail-closed for the same reason master was —
+			// the application is unrepresentable, so the whole snapshot is
+			// retained rather than a fabricated verdict being reported.
+			if !res.ContentRejected {
+				t.Fatalf("expected ContentRejected (the protocol-less application is "+
+					"unrepresentable, matching master's behaviour), got %+v", res)
+			}
+		})
+	}
+}
+
+// TestStrayStatementDoesNotDisarmSiblingLeaves is the paired over-reach guard at
+// the verdict level: poisoning is scoped to the node carrying the unparsable
+// token. A stray statement on its own `set` line must leave a well-formed
+// application fully armed — master compiled those sibling leaves normally, and
+// over-poisoning would silently turn a working permit into a fail-closed
+// snapshot for the entire config.
+func TestStrayStatementDoesNotDisarmSiblingLeaves(t *testing.T) {
+	tree := &config.ConfigTree{}
+	for _, cmd := range []string{
+		"set applications application myapp protocol tcp",
+		"set applications application myapp destination-port 8080",
+		"set applications application myapp bogus value",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application myapp",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies default-policy deny-all",
+	} {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: %v", err)
+	}
+	q := func(port int) Result {
+		return Match(cfg, Query{
+			FromZone: "trust", ToZone: "untrust",
+			SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+			Protocol: "tcp", SrcPort: 40000, DstPort: port,
+		})
+	}
+	if res := q(8080); !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("tcp/8080 = matched:%v action:%v rejected:%v, want PERMIT — a stray "+
+			"SIBLING statement must not disarm leaves master compiled normally",
+			res.Matched, res.Action, res.ContentRejected)
+	}
+	if res := q(22); res.Matched && res.Action == config.PolicyPermit {
+		t.Fatalf("tcp/22 was PERMITTED — the sibling leaves must still constrain " +
+			"the port")
+	}
+}


### PR DESCRIPTION
Closes #6524

## The defect

    set applications application myapp protocol tcp destination-port 8080

compiled **protocol-only**, so a policy matching that application permitted **ALL TCP**.

In the flat-set grammar `set a b c d` builds a **chain** of single-key nodes. These leaves declare `children: nil` in `setSchema`, so once `SetPath` consumes `protocol tcp` it has no sub-schema to descend into and parks the rest of the line under the node it just created — `destination-port` nests under the *value* node `tcp` and is never a sibling of `protocol`. `compileApplications` iterated only `inst.node.Children`, saw just `protocol`, and never assigned `DestinationPort`. An empty `DestinationPort` is a match-**any** port term (`matchSingleApp` constrains the port only when the field is non-empty), so the referencing policy over-permitted — or, on a deny rule, under-matched.

Verified firsthand before writing any code (`ParseSetCommand` + `SetPath`, never `NewParser`): dumped the chain AST, confirmed `DestinationPort == ""` with `SchemaValidate` **CLEAN**, then confirmed a permit policy admitted `tcp/22`.

Nothing caught it: `protocol` / `destination-port` / `source-port` were the only `applications application` match leaves neither typed nor `scalar: true`, so no arity gate engaged at either `SchemaValidate` or strict commit. The reverse token order was caught only *incidentally* (the chain drops `protocol` instead, tripping the #3109 protocol-less gate) — that asymmetry hid this.

This is the direct-body instance of a class already fixed next door for application-set members (#5181), address-set members (#4791) and firewall match values (#2419).

## Why the compiler, not the schema

The issue offered either layer. Typing the three leaves rejects the chained form at commit-check — but **`CompileConfigLenient` (boot load + HA `SyncApply`) downgrades a schema rejection to a WARNING and keeps compiling**, so a schema-only fix leaves a persisted or peer-pushed config still protocol-only and still permitting all TCP, exactly where no operator sees the warning. It would also mint a new commit-vs-load split for a spelling that now has well-defined semantics — the divergence class #3606 calls out for ports. `TestChainedAppLenientPathAlsoHonorsChain` pins the lenient path directly.

## Implementation

`applicationDirectLeaves` walks the chain across both AST shapes. Only the **first** link gets a node of its own — `SetPath` packs every later token onto ONE child, so a three-leaf line collapses to `protocol tcp -> Keys=[source-port 5000 destination-port 8080]`. A "`Keys[2:]` is garbage" rule would therefore be **wrong**; the scan is keyword-delimited, the same shape `parseApplicationTerms` already uses on an inline term's token stream. Hierarchical and one-leaf-per-line shapes have nothing to descend into and compile bit-identically.

Tokens the walk cannot map to a known leaf land on the new `Application.UnknownDirectLeaves` and are hard-rejected by `validateApplicationSyntaxStrict` (lenient-warn, #1960 no-brick). That is what makes `protocol [ tcp udp ]` and `destination-port [ 22 23 ]` operator-visible rather than silently truncated: a **direct** application body holds ONE protocol and ONE port (`Application.Protocol` / `.DestinationPort` are single fields — multi-valued matching is what `term` sub-blocks are for), so a bracket tail is unrepresentable, not merely mis-read. The record is carried onto generated term applications too, since the parent struct is discarded on that branch and the gate would otherwise never see it.

## Fail-on-revert — on the POLICY OUTCOME

A test asserting only `app.DestinationPort != ""` would pass on a fix that populates the field but leaves matching broken, so the gate drives `policymatch.Match()`. Reverting the walk:

```
--- FAIL: TestChainedAppDestPortPolicyDoesNotPermitAllTCP
    tcp/22 was PERMITTED by an application declared `protocol tcp
    destination-port 8080` — the chained destination-port was dropped
    and the policy permits ALL TCP (#6524)
```

All 4 chained `pkg/policymatch` tests go RED (assertion failures, not build breaks); the permit-8080 subcases stay green under revert, which is precisely why the **negative** port is the load-bearing assertion. The deny-side mirror pins that a deny does not widen to all-TCP and swallow a later permit.

**Over-reach guards stay GREEN under revert**: `TestHierarchicalAppBodyUnchanged`, `TestSiblingFlatSetAppBodyUnchanged`, `TestSiblingAppSpellingUnchanged`, `TestApplicationDirectLeafKeywordsCoverCompilerSwitch` (a drift canary — a keyword added to the compiler switch but missed in the keyword set would be rejected as garbage, a fail-closed regression on valid config).

Also pinned: three-deep chains, named-service and range ports through the chain, reverse order, `icmp-type`/`icmp-code` attribution, the #5574 duplicate gate still firing once flattened, the term-bearing propagation path, and the strict-reject/lenient-warn pair.

## Golden

`golden_4406` moved by exactly **three leaves** plus the new field key: its own fixture uses the chained form (`set applications application appA protocol tcp destination-port 80`), so `appA.DestinationPort` went `"" -> "80"`. The bug was sitting in the project's own corpus. Regenerated; the full diff is those 3 values and the added struct field.

## Validation

- Full `pkg/config`, `pkg/policymatch`, `pkg/appid`, `pkg/grpcapi`, `pkg/api`, `pkg/cli` — green.
- `pkg/dataplane/userspace` has 7 event-stream failures. Verified **byte-identical** on pristine `origin/master` in a detached worktree and diffed the two failure lists: zero branch-only entries. Pre-existing, unrelated.
- `go build ./...` and `go vet` clean; new/changed files gofmt-clean.
- No dataplane, cluster, VRRP or failover code touched, so no cluster smoke is implicated.

Docs: `docs/config-schema.md` gains the third collapse pattern alongside the #2419 bracket-list and #5248 wildcard-container cases, including the compiler-vs-schema rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi