### PR TITLE
host-inbound: enforce a destination-scoped to-zone junos-host DENY on the direct path (#4146)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -62122,3 +62122,44 @@ break — `go vet` confirmed passing under every revert.
   22.7 Gbps) and needs no re-run for a comment-only change.
 - **File(s)**: pkg/cluster/{election.go,ifmon_weight_daemon_apply_6549_test.go},
     pkg/routing/monitor.go, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #4146 destination slice — enforce a `to-zone junos-host` DENY that
+  carries an explicit `match destination-address` on the DIRECT host-bound path.
+  #4932 shipped the kernel-nft projection of the representable junos-host DENY
+  class, but `junosHostProjectTerm` marked ANY term with a scoped destination
+  un-representable. Because the representability gate is WHOLE-PROGRAM, a single
+  `match destination-address <fw-ip>` deny not only went unenforced itself — it
+  silently disabled kernel enforcement of EVERY other junos-host deny on that
+  ingress zone. Reproduced firsthand before touching code: the projection
+  returned `representable=false`, zero programs, empty `RenderedPolicyKeys`,
+  while `policymatch.Match` (the Go mirror of Rust
+  `evaluate_junos_host_policy`, which already matched destination via
+  `rule_l3_matches(rule, state, src_ip, dst_ip)`) returned DENY — a fail-open on
+  the only surface that actually sees the packet.
+  Fix: project the destination dimension onto the rule (`Dst` / `DstExcluded` /
+  `DstAny`) and render `<fam> daddr <set>` / `daddr != <set>` AFTER the source
+  predicate, on BOTH nft surfaces (the exec-nft oracle in `daemon_nft.go` and
+  the production netlink installer in `pkg/nftables`). The ZONE scope stays
+  `iifname` — the daddr predicate only NARROWS on top of it, so a
+  destination-scoped deny on a data zone can never suppress management ingress
+  on a lifeline. Source and destination now route through ONE shared projection
+  formula (`junosHostProjectAddrMatch`) so the #5828 degenerate `any`+excluded
+  case ("every address EXCEPT every address" = the empty set => project NO rule,
+  never an unconditional drop) cannot be fixed on one dimension and regress on
+  the other. A destination-scoped PERMIT stays un-representable: a permit is
+  projected only as a `saddr !=` subtraction of later denies, which cannot
+  express a destination-dimension carve — the whole program then emits nothing
+  and every policy keeps the #4168 warning.
+  Validation: full `go test ./...` green (58 pkgs; the refactoring-audit heatmap
+  canary was regenerated for the +25 LOC in daemon_nft.go). The T1 nft-vs-netlink
+  ruleset-parity gate RAN (not skipped) under `unshare -rn` with the new
+  positive/negated daddr constructs added to its fixture, and all six of its
+  mutation-sensitivity sub-cases still diverge. Mutation-probed in a throwaway
+  detached worktree.
+- **File(s)**: pkg/config/{junos_host_deny.go,junos_host_deny_dst_4146_test.go},
+    pkg/daemon/{daemon_nft.go,daemon_nft_netlink.go,daemon_nft_netlink_parity_test.go,
+    host_inbound_junos_host_4146_test.go,host_inbound_junos_host_dst_4146_test.go},
+    pkg/nftables/{netlink_spec.go,netlink_hostinbound.go},
+    pkg/dataplane/userspace/junos_host_deny.go,
+    docs/host-inbound-service-matrix.md, docs/refactoring-audit-current.txt, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -62163,3 +62163,29 @@ break — `go vet` confirmed passing under every revert.
     pkg/nftables/{netlink_spec.go,netlink_hostinbound.go},
     pkg/dataplane/userspace/junos_host_deny.go,
     docs/host-inbound-service-matrix.md, docs/refactoring-audit-current.txt, _Log.md
+
+- **Timestamp**: 2026-07-31
+- **Action**: #4146 review-fold (independent hostile review, MERGE-NEEDS-MINOR).
+  (1) `junosHostProjectAddrMatch` classified an `*-excluded` whose resolved set
+  is empty as match-ALL. That is correct when the OTHER family carries a prefix
+  (the intended match-all-of-opposite-family arm) but wrong when the set is
+  empty across BOTH families: Rust's `rule_l3_matches` fails CLOSED there
+  (`!(v4_empty && v6_empty)`), so the projection widened the authored scope to
+  every firewall address while the dataplane denied nothing — with
+  `application any` a whole-zone host-inbound blackhole. Cross-family emptiness
+  is now computed by the caller (which has both families) and passed in; the
+  excluded arm fails closed on it. Strict commit already rejects an
+  empty/dangling address-set, but the LENIENT load / peer-sync path does not, so
+  a config persisted by an older binary reaches the projection. Note the same
+  class already ships on the SOURCE axis; both axes are fixed by one formula.
+  (2) The T1 nft-vs-netlink parity gate — self-described as the security merge
+  gate that MUST NOT silently skip — used a bare `exec.LookPath("nft")` while
+  `nft` ships in /usr/sbin here, so a non-root PATH made it SKIP while `make
+  test` still reported green. Switched to the existing `findNft()` helper.
+  IMPORTANT: fixing only the presence check turned the silent skip into a FALSE
+  FAILURE, because the oracle execs bare `"nft"` at five sites which also
+  resolve through PATH; all five now use the resolved binary. Verified the gate
+  RUNS and PASSES with nft absent from PATH.
+- **File(s)**: pkg/config/junos_host_deny.go,
+    pkg/config/junos_host_deny_dst_4146_test.go,
+    pkg/daemon/daemon_nft_netlink_parity_test.go, _Log.md

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -904,11 +904,16 @@ helper never sees it, so a helper crash cannot lock management out).
   coarse-rejected service — Rust `poll_descriptor/mod.rs:138`). Instead each later
   deny SUBTRACTS an earlier permit's source set (`saddr != <permit-set>`), so the
   coarse host-inbound gate stays the **sole admit authority**.
-- **Ingress `iifname` scope, never `daddr`.** The DROP is scoped by the from-zone's
-  kernel netdev names (`pkg/dataplane/userspace/BuildJunosHostPrograms`), excluding
-  lifelines (fxp0/em0/fab*) — daddr scope would both under- and over-deny across
-  zones. A global-any term renders per ingress zone with that zone's netdevs, never
-  unscoped.
+- **Ingress `iifname` scope, never `daddr` as the ZONE scope.** The DROP is scoped
+  by the from-zone's kernel netdev names
+  (`pkg/dataplane/userspace/BuildJunosHostPrograms`), excluding lifelines
+  (fxp0/em0/fab*) — a daddr-derived zone scope would both under- and over-deny
+  across zones. A global-any term renders per ingress zone with that zone's
+  netdevs, never unscoped. An EXPLICIT `match destination-address` adds a
+  narrowing `daddr` predicate ON TOP of that iifname scope (see the destination
+  slice below); it never replaces it. Because the scope is the ingress netdev, a
+  destination-scoped deny on a data zone can never suppress management ingress on
+  a lifeline, whichever firewall address it names.
 - **Coarse-then-fine order (`pkg/daemon/daemon_nft.go`).** The fine DROP runs after
   ESP/AH accept + the firewall-originated reply-direction established accept, but
   BEFORE the ND/PMTUD accepts and the residual full established accept, so a denied
@@ -954,40 +959,63 @@ helper never sees it, so a helper crash cannot lock management out).
   the direct path retains. The userspace XSK path keeps its own attribution.
 
 **Representable subset:** action `deny`; `match source-address` /
-`source-address-excluded` resolving entirely to *static* address-book CIDRs
+`source-address-excluded` **and** `match destination-address` /
+`destination-address-excluded` resolving entirely to *static* address-book CIDRs
 (recursively feed-untainted); `match application` reducing to simple
 proto + optional dst/src port + optional ICMP type/code (application-sets
-OR-expanded to multiple rules); `match destination-address any`; **no**
-`scheduler-name`; ingress zone **not** `tcp-rst`.
+OR-expanded to multiple rules); **no** `scheduler-name`; ingress zone **not**
+`tcp-rst`.
 
-**Source-exclusion semantics (`source-address-excluded`).** The excluded arm
-projects *every source NOT in the resolved set*, per Junos `matchAddr`:
+**Address-match semantics (source AND destination).** Both dimensions route
+through ONE projection formula (`junosHostProjectAddrMatch`,
+`pkg/config/junos_host_deny.go`) so they cannot drift, and both mirror Junos
+`matchAddr`:
 - A **constrained** set (e.g. `source-address 10.0.0.0/8` + excluded) drops
   every source EXCEPT the set on the family that carries a prefix (IPv4:
   `saddr != 10.0.0.0/8`), and — because the set has no prefix of the *other*
   family — drops **ALL** of that other family (IPv6 here): "everything except
   10/8" is all IPv6. This match-all-of-opposite-family behavior is intentional.
-- The **wildcard** case `source-address any` (or the family-scoped `any-ipv4` /
-  `any-ipv6`) + excluded is the degenerate "every source EXCEPT every source" =
-  the **empty set**: it matches NOTHING and projects **no drop rule** for the
-  affected family (`junosHostBuildRule` returns `ok=false` when the family's
-  `srcAny` is set). `any` suppresses both families; `any-ipv4` / `any-ipv6`
-  suppress only their own. Emitting an unconditional all-source drop here (the
-  #5828 bug — the old `len(src)==0 => SrcAny` classification) would invert the
-  authored domain and could lock out **all** direct host-bound traffic on the
-  ingress zone. A plain `source-address any` + `then deny` with **no** exclusion
-  is unaffected — that is a legitimate drop-all deny and still emits the
-  unconditional drop.
+- The **wildcard** case `any` (or the family-scoped `any-ipv4` / `any-ipv6`) +
+  excluded is the degenerate "every address EXCEPT every address" = the **empty
+  set**: it matches NOTHING and projects **no drop rule** for the affected
+  family. `any` suppresses both families; `any-ipv4` / `any-ipv6` suppress only
+  their own. Emitting an unconditional drop here (the #5828 bug — the old
+  `len(src)==0 => SrcAny` classification) would invert the authored domain and
+  could lock out **all** direct host-bound traffic on the ingress zone. A plain
+  `source-address any` + `then deny` with **no** exclusion is unaffected — that
+  is a legitimate drop-all deny and still emits the unconditional drop.
+- A **constrained positive** set with no prefix of a family matches nothing on
+  that family and emits no rule there (Junos empty-positive-set semantic).
+
+**`match destination-address` on a DENY (#4146 destination slice).** The kernel
+`xpf_hostinbound` chain hooks the INPUT path, so every packet it evaluates is
+already host-destined; an explicit destination therefore renders as a narrowing
+`<fam> daddr <set>` / `daddr != <set>` predicate **on top of** the `iifname`
+zone scope — never as a replacement for it. A destination naming no firewall
+address simply matches nothing in the chain, exactly as the Rust /
+`policymatch` evaluation of that policy matches nothing, so the live
+firewall-local address set is **not** needed to render it. Rust already matched
+this dimension on the junos-host path (`rule_l3_matches(rule, state, src_ip,
+dst_ip)` in `evaluate_junos_host_policy_l3_aware`); the kernel projection was
+the only surface dropping it, which made a `from-zone X to-zone junos-host {
+match destination-address <fw-ip>; then deny; }` silently unenforced — and,
+because the representability gate is whole-program, silently disabled kernel
+enforcement of **every other** junos-host deny on that ingress zone.
+
+A destination-scoped **`permit`** stays un-representable: a permit is projected
+only as a `saddr !=` SUBTRACTION of later denies (see DROP-only above), which
+cannot express a carve that is also destination-scoped. The whole program then
+emits nothing and every one of its policies keeps the warning — never a deny
+widened past the permit's destination scope.
 
 **Un-representable remainder (keeps the commit warning below):** feed-tainted
-source, multi-term / ALG application, an application scoped to an IPsec/ident
-exempt tuple, an **explicit** `match destination-address` (needs the live
-firewall-local set to validate — deferred to a follow-up), a scheduler-gated
-policy, a `tcp-rst` ingress zone (silent drop would diverge from Junos's RST
-verdict class), `reject`, and the "deny non-permitted" half of a source-restricted
-`permit` (the reject and source-restricted-permit slices are tracked follow-ups
-using the identical machinery). No partial/coarsened kernel rule is ever emitted
-for the remainder.
+source **or destination**, multi-term / ALG application, an application scoped
+to an IPsec/ident exempt tuple, a **destination-scoped `permit`**, a
+scheduler-gated policy, a `tcp-rst` ingress zone (silent drop would diverge from
+Junos's RST verdict class), `reject`, and the "deny non-permitted" half of a
+source-restricted `permit` (the reject and source-restricted-permit slices are
+tracked follow-ups using the identical machinery). No partial/coarsened kernel
+rule is ever emitted for the remainder.
 
 ### Commit-time warning (direction c — shipped; now suppressed on render)
 

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -4,7 +4,7 @@
 [REFACTOR]   2928  pkg/config/compiler_validate_strict_nat.go
 [REFACTOR]   2462  pkg/policymatch/policymatch.go
 [REFACTOR]   2383  userspace-dp/src/nat/allocator.rs
-[REFACTOR]   2315  pkg/daemon/daemon_nft.go
+[REFACTOR]   2340  pkg/daemon/daemon_nft.go
 [REFACTOR]   2288  pkg/ddns/surface_a.go
 [REFACTOR]   2225  userspace-dp/src/afxdp/neighbor.rs
 [REFACTOR]   2191  userspace-dp/src/session/mod.rs

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -531,13 +531,25 @@ func junosHostBuildRule(family string, t junosHostTerm, permit []string, permitA
 		// ICMPv6 app on the inet chain) -> matches nothing here.
 		return JunosHostDenyRule{}, false
 	}
+	// #6613: an `*-excluded` whose resolved set is empty in BOTH families is not
+	// "match everything" — Rust's rule_l3_matches fails CLOSED on it
+	// (`!(v4_empty && v6_empty)`, userspace-dp/src/policy.rs), so projecting the
+	// match-all arm here would widen the authored scope to every firewall
+	// address while the dataplane denies nothing. The per-family helper cannot
+	// see the other family, so the cross-family emptiness is computed here and
+	// passed in. Strict commit already rejects an empty/dangling address-set,
+	// but the LENIENT load / peer-sync path does not, so a config persisted by
+	// an older binary reaches this projection.
+	srcEmptyBoth := !t.srcAnyV4 && !t.srcAnyV6 && len(t.srcV4) == 0 && len(t.srcV6) == 0
+	dstEmptyBoth := !t.dstAnyV4 && !t.dstAnyV6 && len(t.dstV4) == 0 && len(t.dstV6) == 0
+
 	rule := JunosHostDenyRule{Family: family, L4: l4}
-	matchAny, matchExcluded, set, ok := junosHostProjectAddrMatch(src, srcAny, t.srcExcluded)
+	matchAny, matchExcluded, set, ok := junosHostProjectAddrMatch(src, srcAny, t.srcExcluded, srcEmptyBoth)
 	if !ok {
 		return JunosHostDenyRule{}, false
 	}
 	rule.SrcAny, rule.SrcExcluded, rule.Src = matchAny, matchExcluded, set
-	matchAny, matchExcluded, set, ok = junosHostProjectAddrMatch(dst, dstAny, t.dstExcluded)
+	matchAny, matchExcluded, set, ok = junosHostProjectAddrMatch(dst, dstAny, t.dstExcluded, dstEmptyBoth)
 	if !ok {
 		return JunosHostDenyRule{}, false
 	}
@@ -570,10 +582,24 @@ func junosHostBuildRule(family string, t junosHostTerm, permit []string, permitA
 //   - wildcard, not excluded: match everything, with no predicate rendered.
 //   - constrained positive with no prefix of this family: matches nothing
 //     (Junos empty-positive-set semantic).
-func junosHostProjectAddrMatch(set []string, anyFam, excluded bool) (matchAny, matchExcluded bool, out []string, ok bool) {
+//
+// emptyBothFamilies reports that the authored match resolved to NO prefix in
+// EITHER family and carries no wildcard. Combined with `excluded` that is the
+// degenerate "everything except nothing" form, which Rust fails CLOSED on
+// (rule_l3_matches requires !(v4_empty && v6_empty)); projecting the match-all
+// arm for it would silently widen the authored scope to every firewall address
+// while the dataplane denies nothing. It is unreachable via strict commit — the
+// address-set member gate rejects an empty/dangling set — but reachable on the
+// lenient load / peer-sync path from a config an older binary persisted.
+func junosHostProjectAddrMatch(set []string, anyFam, excluded, emptyBothFamilies bool) (matchAny, matchExcluded bool, out []string, ok bool) {
 	switch {
 	case excluded:
 		if anyFam {
+			return false, false, nil, false
+		}
+		if emptyBothFamilies {
+			// Fail CLOSED, matching Rust: project no rule at all rather than an
+			// unconditional drop.
 			return false, false, nil, false
 		}
 		return len(set) == 0, len(set) > 0, append([]string(nil), set...), true

--- a/pkg/config/junos_host_deny.go
+++ b/pkg/config/junos_host_deny.go
@@ -70,11 +70,15 @@ type JunosHostDenyL4 struct {
 // JunosHostDenyRule is one projected DROP rule for a single family. The daemon
 // renders it as
 //
-//	iifname { <zone netdevs> } [<l4>] <fam> saddr <src> [saddr != <permit-subtract>] drop
+//	iifname { <zone netdevs> } [<l4>] <fam> saddr <src> [saddr != <permit-subtract>] [<fam> daddr <dst>] drop
 //
 // SrcAny (no source constraint) and SrcExcluded (`saddr != Src`) mirror the
 // policymatch.matchAddr family semantics; a rule is only emitted for a family
 // whose positive source set is non-empty OR whose match is source-any/excluded.
+// Dst*/Dst are the SAME projection applied to an explicit `match
+// destination-address` (#4146 destination slice) — the host chain only ever sees
+// host-destined packets, so a `daddr` predicate narrows the deny to the authored
+// firewall address(es). It is NEVER the zone scope (that stays `iifname`).
 type JunosHostDenyRule struct {
 	Family      string // "ip" or "ip6"
 	SrcAny      bool   // true => match every source (no saddr predicate)
@@ -83,6 +87,13 @@ type JunosHostDenyRule struct {
 	// PermitSubtract accumulates the source CIDRs of every EARLIER permit term
 	// that carves this deny (rendered as additional `saddr != <set>` predicates).
 	PermitSubtract []string
+	// DstAny / DstExcluded / Dst mirror Src* for `match destination-address`.
+	// DstAny (the overwhelmingly common `destination-address any`) renders NO
+	// daddr predicate, so an unscoped deny is byte-identical to the pre-slice
+	// rule.
+	DstAny      bool // true => match every destination (no daddr predicate)
+	DstExcluded bool // true => `daddr != Dst` (destination-address-excluded)
+	Dst         []string
 	// L4 is the OR-expanded set of L4 fragments; the daemon emits one nft rule
 	// per fragment. Empty means `application any` (all protocols).
 	L4 []JunosHostDenyL4
@@ -164,6 +175,10 @@ type junosHostTerm struct {
 	srcV4, srcV6       []string
 	srcAnyV4, srcAnyV6 bool
 	srcExcluded        bool
+	// per-family resolved destination (`match destination-address`)
+	dstV4, dstV6       []string
+	dstAnyV4, dstAnyV6 bool
+	dstExcluded        bool
 	// resolved application L4 fragments (nil => application any)
 	l4            []JunosHostDenyL4
 	appAny        bool
@@ -352,9 +367,11 @@ func containsZone(zs []string, z string) bool {
 }
 
 // junosHostProjectTerm resolves one policy's match into a representable term. A
-// reject action, scheduler-gated policy, feed-tainted / non-static source, a
-// non-`any` destination, an un-reducible application, or an application scoped to
-// an IPsec/ident exempt tuple all mark the term un-representable.
+// reject action, scheduler-gated policy, feed-tainted / non-static source or
+// destination, an un-reducible application, or an application scoped to an
+// IPsec/ident exempt tuple all mark the term un-representable. A scoped
+// `match destination-address` is representable for a DENY (rendered as a `daddr`
+// predicate) but NOT for a permit — see the destination block below.
 func junosHostProjectTerm(cfg *Config, key string, p *Policy, feedBound map[string]bool) junosHostTerm {
 	t := junosHostTerm{key: key, action: p.Action, representable: true}
 	// Reject is the §6.5 follow-up slice; scheduler-gated policies are
@@ -369,10 +386,29 @@ func junosHostProjectTerm(cfg *Config, key string, p *Policy, feedBound map[stri
 	}
 	t.srcV4, t.srcV6, t.srcAnyV4, t.srcAnyV6 = v4, v6, anyV4, anyV6
 	t.srcExcluded = p.Match.SourceAddressExcluded
-	// Destination: only `any` (the box) is representable in this slice; an
-	// explicit destination-address requires the live firewall-local address set
-	// to validate and is left to the #4168 warning (§6.1 note in the docs).
-	if junosHostAddrScoped(p.Match.DestinationAddresses) || p.Match.DestinationAddressExcluded {
+	// Destination resolution (static-only, feed-untainted — same gate as the
+	// source). An explicit `match destination-address` on a DENY is representable:
+	// the kernel `xpf_hostinbound` chain hooks the INPUT path, so every packet it
+	// sees is already host-destined, and a `daddr` predicate simply narrows the
+	// deny to the firewall address(es) the operator authored. A destination that
+	// names no firewall address matches nothing in the chain — exactly as the
+	// Rust/policymatch evaluation of that policy matches nothing — so the live
+	// firewall-local address set is NOT needed to render it correctly.
+	//
+	// A PERMIT (or reject) with a SCOPED destination stays un-representable: a
+	// permit is projected only as a `saddr !=` SUBTRACTION of later denies
+	// (§5.1), which cannot express a carve that is also destination-scoped.
+	// Leaving it un-representable keeps the whole-program gate conservative — the
+	// zone emits nothing and every one of its policies keeps the #4168 warning —
+	// rather than silently widening a later deny past the permit.
+	dv4, dv6, dAnyV4, dAnyV6, dok := junosHostResolveAddrSet(cfg, p.Match.DestinationAddresses, feedBound)
+	if !dok {
+		t.representable = false
+	}
+	t.dstV4, t.dstV6, t.dstAnyV4, t.dstAnyV6 = dv4, dv6, dAnyV4, dAnyV6
+	t.dstExcluded = p.Match.DestinationAddressExcluded
+	if p.Action != PolicyDeny &&
+		(junosHostAddrScoped(p.Match.DestinationAddresses) || p.Match.DestinationAddressExcluded) {
 		t.representable = false
 	}
 	// Application resolution.
@@ -472,19 +508,22 @@ func junosHostHasPoison(in []string) bool {
 
 // junosHostBuildRule projects one deny term to a single-family DROP rule,
 // applying the earlier-permit source subtraction. Returns ok=false when the
-// family's match resolves to "match nothing" (a constrained positive source with
-// no prefix of this family) or when an earlier permit-all shadows it.
+// family's match resolves to "match nothing" (a constrained positive source or
+// destination with no prefix of this family, or a degenerate `any`+excluded set)
+// or when an earlier permit-all shadows it.
 func junosHostBuildRule(family string, t junosHostTerm, permit []string, permitAll bool) (JunosHostDenyRule, bool) {
 	if permitAll {
 		// Every source is permitted ahead of this deny -> nothing to drop.
 		return JunosHostDenyRule{}, false
 	}
-	var src []string
-	var srcAny bool
+	var src, dst []string
+	var srcAny, dstAny bool
 	if family == "ip" {
 		src, srcAny = t.srcV4, t.srcAnyV4
+		dst, dstAny = t.dstV4, t.dstAnyV4
 	} else {
 		src, srcAny = t.srcV6, t.srcAnyV6
+		dst, dstAny = t.dstV6, t.dstAnyV6
 	}
 	l4 := junosHostFamilyL4(family, t.l4)
 	if !t.appAny && len(l4) == 0 {
@@ -493,41 +532,58 @@ func junosHostBuildRule(family string, t junosHostTerm, permit []string, permitA
 		return JunosHostDenyRule{}, false
 	}
 	rule := JunosHostDenyRule{Family: family, L4: l4}
-	if t.srcExcluded {
-		if srcAny {
-			// `any` (a family wildcard) + `source-address-excluded` is "every
-			// source EXCEPT every source" = the empty set: the term matches
-			// NOTHING for this family and MUST project no rule (#5828). This is
-			// keyed on the family-scoped srcAny, so `any` suppresses BOTH families
-			// while `any-ipv4`/`any-ipv6` suppress only their own. Falling through
-			// to the len(src)==0 => SrcAny arm below would invert this degenerate
-			// case into an unconditional all-source DROP — an over-deny that can
-			// lock out every direct host-bound flow on the ingress zone.
-			return JunosHostDenyRule{}, false
-		}
-		// A genuinely constrained excluded set: match every source NOT in the
-		// set. A family with no prefix in the excluded set therefore matches ALL
-		// of that family (mirrors matchAddr's "constrained, no F-prefix, except
-		// -> match ALL"). This is the intended match-all-of-opposite-family
-		// semantic — e.g. `source-address 10.0.0.0/8 + excluded` drops every IPv6
-		// source (no v6 prefix in the set) and every non-10/8 IPv4 source.
-		rule.SrcExcluded = len(src) > 0
-		rule.SrcAny = len(src) == 0
-		rule.Src = append([]string(nil), src...)
-	} else if srcAny {
-		rule.SrcAny = true
-	} else {
-		if len(src) == 0 {
-			// Constrained positive source with no prefix of this family -> matches
-			// nothing (Junos empty-positive-set semantic).
-			return JunosHostDenyRule{}, false
-		}
-		rule.Src = append([]string(nil), src...)
+	matchAny, matchExcluded, set, ok := junosHostProjectAddrMatch(src, srcAny, t.srcExcluded)
+	if !ok {
+		return JunosHostDenyRule{}, false
 	}
+	rule.SrcAny, rule.SrcExcluded, rule.Src = matchAny, matchExcluded, set
+	matchAny, matchExcluded, set, ok = junosHostProjectAddrMatch(dst, dstAny, t.dstExcluded)
+	if !ok {
+		return JunosHostDenyRule{}, false
+	}
+	rule.DstAny, rule.DstExcluded, rule.Dst = matchAny, matchExcluded, set
 	if permitFam := junosHostDedup(permit); len(permitFam) > 0 {
 		rule.PermitSubtract = permitFam
 	}
 	return rule, true
+}
+
+// junosHostProjectAddrMatch projects ONE family's address match — the resolved
+// per-family CIDR set, that family's wildcard bit, and the `*-excluded` flag —
+// into the rule's (any, excluded, set) predicate triple. ok=false means the
+// match resolves to "match NOTHING" for this family, so the caller must project
+// no rule at all.
+//
+// This is the SINGLE formula for BOTH the source and the destination dimension
+// so the two can never drift. In particular the #5828 degenerate case — `any`
+// (or the family-scoped `any-ipv4`/`any-ipv6`) together with `*-excluded`, i.e.
+// "every address EXCEPT every address" = the empty set — must project NO rule on
+// EITHER dimension. Classifying its empty concrete set as the "any" arm instead
+// would invert the authored domain into an UNCONDITIONAL drop and could lock out
+// all direct host-bound traffic on the ingress zone.
+//
+// The other arms mirror policymatch.matchAddr:
+//   - constrained + excluded: match every address NOT in the set. A family with
+//     no prefix in the excluded set therefore matches ALL of that family (e.g.
+//     `10.0.0.0/8` + excluded drops every IPv6 address and every non-10/8 IPv4
+//     one) — the intended match-all-of-opposite-family semantic.
+//   - wildcard, not excluded: match everything, with no predicate rendered.
+//   - constrained positive with no prefix of this family: matches nothing
+//     (Junos empty-positive-set semantic).
+func junosHostProjectAddrMatch(set []string, anyFam, excluded bool) (matchAny, matchExcluded bool, out []string, ok bool) {
+	switch {
+	case excluded:
+		if anyFam {
+			return false, false, nil, false
+		}
+		return len(set) == 0, len(set) > 0, append([]string(nil), set...), true
+	case anyFam:
+		return true, false, nil, true
+	case len(set) == 0:
+		return false, false, nil, false
+	default:
+		return false, false, append([]string(nil), set...), true
+	}
 }
 
 // junosHostFamilyL4 keeps the L4 fragments meaningful for a family (ICMP -> v4

--- a/pkg/config/junos_host_deny_dst_4146_test.go
+++ b/pkg/config/junos_host_deny_dst_4146_test.go
@@ -216,6 +216,7 @@ func TestJunosHostProjectAddrMatchIsOneFormula(t *testing.T) {
 		name              string
 		set               []string
 		anyFam, excluded  bool
+		emptyBoth         bool
 		wantAny, wantExcl bool
 		wantSet           []string
 		wantOK            bool
@@ -230,10 +231,16 @@ func TestJunosHostProjectAddrMatchIsOneFormula(t *testing.T) {
 		{name: "excluded constrained set", set: []string{"10.0.0.0/8"}, excluded: true,
 			wantExcl: true, wantSet: []string{"10.0.0.0/8"}, wantOK: true},
 		{name: "excluded set with no family prefix matches all", excluded: true, wantAny: true, wantOK: true},
+		// #6613: "everything except nothing" resolved in BOTH families is the
+		// degenerate form Rust fails CLOSED on (rule_l3_matches requires
+		// !(v4_empty && v6_empty)). Projecting the match-all arm would widen the
+		// authored scope to every firewall address while the dataplane denies
+		// nothing. Reachable on the LENIENT load / peer-sync path only.
+		{name: "excluded empty in BOTH families fails closed", excluded: true, emptyBoth: true, wantOK: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotAny, gotExcl, gotSet, ok := junosHostProjectAddrMatch(tc.set, tc.anyFam, tc.excluded)
+			gotAny, gotExcl, gotSet, ok := junosHostProjectAddrMatch(tc.set, tc.anyFam, tc.excluded, tc.emptyBoth)
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
 			}

--- a/pkg/config/junos_host_deny_dst_4146_test.go
+++ b/pkg/config/junos_host_deny_dst_4146_test.go
@@ -1,0 +1,256 @@
+package config
+
+import "testing"
+
+// junos_host_deny_dst_4146_test.go pins the projection SSOT for the #4146
+// destination slice: an explicit `match destination-address` on a `to-zone
+// junos-host` DENY is projected into the kernel rule (Dst / DstExcluded /
+// DstAny) instead of forcing the whole ingress-zone program un-representable.
+//
+// Before this slice `junosHostProjectTerm` marked ANY destination-scoped term
+// un-representable, so the whole-program gate emitted NOTHING for the zone and
+// the configured deny was silently unenforced on the direct host-bound path
+// (the kernel delivers those packets; userspace-dp never sees them).
+//
+// The daemon-side VERDICT gate lives in
+// pkg/daemon/host_inbound_junos_host_dst_4146_test.go.
+
+// jh4146DstProjection compiles a flat-set config and returns the whole
+// projection (some cases legitimately produce an un-representable program).
+func jh4146DstProjection(t *testing.T, policyCmds ...string) JunosHostDenyProjection {
+	t.Helper()
+	base := []string{
+		"set interfaces ge-0/0/1 unit 0 family inet address 10.0.2.10/24",
+		"set interfaces ge-0/0/1 unit 0 family inet6 address 2001:db8:2::10/64",
+		"set security zones security-zone untrust interfaces ge-0/0/1.0",
+		"set security zones security-zone untrust host-inbound-traffic system-services ssh",
+		"set security address-book global address wan-ip 10.0.2.10/32",
+		"set security address-book global address wan-ip6 2001:db8:2::10/128",
+		"set security address-book global address bad-host 10.0.0.5/32",
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range append(base, policyCmds...) {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return BuildJunosHostDenyProjection(cfg)
+}
+
+func jh4146OneProgram(t *testing.T, proj JunosHostDenyProjection) JunosHostDenyProgram {
+	t.Helper()
+	if len(proj.Programs) != 1 {
+		t.Fatalf("want exactly 1 junos-host program, got %d: %+v", len(proj.Programs), proj.Programs)
+	}
+	return proj.Programs[0]
+}
+
+// TestJunosHostDstScopedDenyProjectsDaddr is the #4146 destination-slice
+// fail-on-revert guard: a DENY with `match destination-address wan-ip` is
+// REPRESENTABLE and carries the destination set onto the rule.
+//
+// RED on revert: restoring the "a non-`any` destination is un-representable"
+// gate makes Representable false and RulesV4 empty.
+func TestJunosHostDstScopedDenyProjectsDaddr(t *testing.T) {
+	proj := jh4146DstProjection(t,
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address bad-host",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address wan-ip",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	p := jh4146OneProgram(t, proj)
+	if !p.Representable {
+		t.Fatalf("a destination-scoped DENY must be representable: %+v", p)
+	}
+	if len(p.RulesV4) != 1 {
+		t.Fatalf("want one IPv4 drop rule, got %+v", p.RulesV4)
+	}
+	r := p.RulesV4[0]
+	if r.DstAny || r.DstExcluded || len(r.Dst) != 1 || r.Dst[0] != "10.0.2.10/32" {
+		t.Errorf("rule destination = {any:%v excluded:%v set:%v}, want the positive set [10.0.2.10/32]",
+			r.DstAny, r.DstExcluded, r.Dst)
+	}
+	// The v4-only destination emits no v6 rule (Junos empty-positive-set).
+	if len(p.RulesV6) != 0 {
+		t.Errorf("a v4-only destination must emit no IPv6 rule, got %+v", p.RulesV6)
+	}
+	// The policy renders, so its #4168 warning is suppressed.
+	if !proj.RenderedPolicyKeys[JunosHostZonePairPolicyKey("untrust", "blk")] {
+		t.Errorf("a rendered destination-scoped deny must land in RenderedPolicyKeys: %+v", proj.RenderedPolicyKeys)
+	}
+}
+
+// TestJunosHostDstAnyStillRendersNoDaddr is the no-op regression guard: the
+// overwhelmingly common `destination-address any` must still render DstAny with
+// an empty set, i.e. no daddr predicate at all — byte-identical to pre-slice
+// output.
+func TestJunosHostDstAnyStillRendersNoDaddr(t *testing.T) {
+	proj := jh4146DstProjection(t,
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address bad-host",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	p := jh4146OneProgram(t, proj)
+	if len(p.RulesV4) != 1 {
+		t.Fatalf("want one IPv4 rule, got %+v", p.RulesV4)
+	}
+	r := p.RulesV4[0]
+	if !r.DstAny || r.DstExcluded || len(r.Dst) != 0 {
+		t.Errorf("destination-address any must project DstAny with no set, got {any:%v excluded:%v set:%v}",
+			r.DstAny, r.DstExcluded, r.Dst)
+	}
+}
+
+// TestJunosHostDstAnyExcludedProjectsNoRule is the #5828 degenerate case on the
+// DESTINATION dimension. `destination-address any` + `destination-address-
+// excluded` is "every destination EXCEPT every destination" = the empty set:
+// the term matches NOTHING and must project NO rule for either family.
+// Classifying the empty concrete set as the "any" arm would emit an
+// UNCONDITIONAL drop — the #5828 over-deny shape, which can lock out all direct
+// host-bound traffic on the ingress zone.
+func TestJunosHostDstAnyExcludedProjectsNoRule(t *testing.T) {
+	proj := jh4146DstProjection(t,
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address bad-host",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address-excluded",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	p := jh4146OneProgram(t, proj)
+	if len(p.RulesV4) != 0 || len(p.RulesV6) != 0 {
+		t.Fatalf("destination any+excluded is inert and must project no rule, got v4=%+v v6=%+v",
+			p.RulesV4, p.RulesV6)
+	}
+}
+
+// TestJunosHostDstExcludedProjectsNegatedSet covers the constrained exclusion
+// arm: `destination-address wan-ip` + excluded drops to every destination EXCEPT
+// the WAN address on IPv4 and — because the excluded set carries no IPv6 prefix
+// — to ALL IPv6 destinations (the documented match-all-of-opposite-family
+// semantic, identical to the source dimension).
+func TestJunosHostDstExcludedProjectsNegatedSet(t *testing.T) {
+	proj := jh4146DstProjection(t,
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address wan-ip",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address-excluded",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	p := jh4146OneProgram(t, proj)
+	if len(p.RulesV4) != 1 {
+		t.Fatalf("want one IPv4 rule, got %+v", p.RulesV4)
+	}
+	if r := p.RulesV4[0]; !r.DstExcluded || r.DstAny || len(r.Dst) != 1 || r.Dst[0] != "10.0.2.10/32" {
+		t.Errorf("IPv4 rule destination = {any:%v excluded:%v set:%v}, want the negated set [10.0.2.10/32]",
+			r.DstAny, r.DstExcluded, r.Dst)
+	}
+	if len(p.RulesV6) != 1 || !p.RulesV6[0].DstAny {
+		t.Errorf("an excluded destination set with no v6 prefix must match ALL v6 destinations, got %+v", p.RulesV6)
+	}
+}
+
+// TestJunosHostDstScopedPermitStaysUnrepresentable is the over-reach guard: a
+// permit is projected ONLY as a `saddr !=` subtraction of later denies, which
+// cannot express a destination-scoped carve. A destination-scoped PERMIT must
+// therefore keep the WHOLE program un-representable — rendering the following
+// deny while silently dropping the permit's destination dimension would deny
+// traffic the operator explicitly permitted.
+func TestJunosHostDstScopedPermitStaysUnrepresentable(t *testing.T) {
+	proj := jh4146DstProjection(t,
+		"set security policies from-zone untrust to-zone junos-host policy ok match source-address any",
+		"set security policies from-zone untrust to-zone junos-host policy ok match destination-address wan-ip",
+		"set security policies from-zone untrust to-zone junos-host policy ok match application any",
+		"set security policies from-zone untrust to-zone junos-host policy ok then permit",
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address bad-host",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address any",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	p := jh4146OneProgram(t, proj)
+	if p.Representable {
+		t.Fatalf("a destination-scoped PERMIT must keep the program un-representable: %+v", p)
+	}
+	if len(proj.RenderedPolicyKeys) != 0 {
+		t.Errorf("no policy may be marked rendered when the program emits nothing: %+v", proj.RenderedPolicyKeys)
+	}
+}
+
+// TestJunosHostFeedTaintedDstUnrepresentable proves the destination dimension
+// carries the SAME feed-taint gate as the source: a dynamic-feed-bound address
+// is not commit-stable, so it can never become a static nft rule. The policy
+// keeps the #4168 warning instead.
+func TestJunosHostFeedTaintedDstUnrepresentable(t *testing.T) {
+	proj := jh4146DstProjection(t,
+		"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+		"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+		"set security dynamic-address address-name feedy profile feed-name malware",
+		"set security policies from-zone untrust to-zone junos-host policy blk match source-address bad-host",
+		"set security policies from-zone untrust to-zone junos-host policy blk match destination-address feedy",
+		"set security policies from-zone untrust to-zone junos-host policy blk match application any",
+		"set security policies from-zone untrust to-zone junos-host policy blk then deny",
+	)
+	p := jh4146OneProgram(t, proj)
+	if p.Representable {
+		t.Fatalf("a feed-tainted destination must keep the program un-representable: %+v", p)
+	}
+	if len(proj.RenderedPolicyKeys) != 0 {
+		t.Errorf("a feed-tainted deny must keep its #4168 warning: %+v", proj.RenderedPolicyKeys)
+	}
+}
+
+// TestJunosHostProjectAddrMatchIsOneFormula pins the shared source/destination
+// address-match formula (junosHostProjectAddrMatch). Both dimensions MUST route
+// through it so the #5828 degenerate `any`+excluded case can never be fixed on
+// one dimension and regress on the other.
+func TestJunosHostProjectAddrMatchIsOneFormula(t *testing.T) {
+	cases := []struct {
+		name              string
+		set               []string
+		anyFam, excluded  bool
+		wantAny, wantExcl bool
+		wantSet           []string
+		wantOK            bool
+	}{
+		{name: "wildcard", anyFam: true, wantAny: true, wantOK: true},
+		// The #5828 degenerate case: "every address EXCEPT every address" is the
+		// empty set, so the caller must project NO rule (ok=false), never the
+		// unconditional "any" arm.
+		{name: "wildcard+excluded is the empty set", anyFam: true, excluded: true},
+		{name: "positive set", set: []string{"10.0.0.0/8"}, wantSet: []string{"10.0.0.0/8"}, wantOK: true},
+		{name: "positive set with no family prefix"},
+		{name: "excluded constrained set", set: []string{"10.0.0.0/8"}, excluded: true,
+			wantExcl: true, wantSet: []string{"10.0.0.0/8"}, wantOK: true},
+		{name: "excluded set with no family prefix matches all", excluded: true, wantAny: true, wantOK: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotAny, gotExcl, gotSet, ok := junosHostProjectAddrMatch(tc.set, tc.anyFam, tc.excluded)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if gotAny != tc.wantAny || gotExcl != tc.wantExcl {
+				t.Errorf("any=%v excluded=%v, want any=%v excluded=%v", gotAny, gotExcl, tc.wantAny, tc.wantExcl)
+			}
+			if len(gotSet) != len(tc.wantSet) {
+				t.Fatalf("set = %v, want %v", gotSet, tc.wantSet)
+			}
+			for i := range gotSet {
+				if gotSet[i] != tc.wantSet[i] {
+					t.Errorf("set[%d] = %q, want %q", i, gotSet[i], tc.wantSet[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -1333,8 +1333,8 @@ func emitJunosHostDenyProgram(rules *[]string, p dpuserspace.JunosHostProgram) {
 // fragment; a single rule for `application any`).
 func emitJunosHostDropRule(rules *[]string, zone, iif string, r config.JunosHostDenyRule) {
 	cn := xnft.HostInboundJunosHostDenyCounterName(zone, r.Family)
-	srcPred := junosHostSrcPredicate(r)
-	tail := srcPred + " counter name \"" + cn + "\" drop"
+	tail := junosHostSrcPredicate(r) + junosHostDstPredicate(r) +
+		" counter name \"" + cn + "\" drop"
 	if len(r.L4) == 0 {
 		// `application any` — all protocols.
 		*rules = append(*rules, "    iifname "+iif+tail)
@@ -1370,6 +1370,31 @@ func junosHostSrcPredicate(r config.JunosHostDenyRule) string {
 		b.WriteString(" " + r.Family + " saddr != " + nftAddrSet(r.PermitSubtract))
 	}
 	return b.String()
+}
+
+// junosHostDstPredicate builds the leading-space destination predicate for a
+// DROP rule from an explicit `match destination-address` (#4146 destination
+// slice). Returns "" for `destination-address any` — the case every pre-slice
+// program rendered — so an unscoped deny is byte-identical to before.
+//
+// The chain hooks the INPUT path, so every packet it evaluates is already
+// host-destined; a `daddr` predicate here narrows the deny to the firewall
+// address(es) the operator authored. It is NEVER the zone scope — that stays
+// `iifname` (a daddr-only scope both under- and over-denies across zones, plan
+// §3.2).
+func junosHostDstPredicate(r config.JunosHostDenyRule) string {
+	switch {
+	case r.DstExcluded && len(r.Dst) > 0:
+		return " " + r.Family + " daddr != " + nftAddrSet(r.Dst)
+	case r.DstAny || (r.DstExcluded && len(r.Dst) == 0):
+		// match every destination (no daddr predicate)
+		return ""
+	default:
+		if len(r.Dst) > 0 {
+			return " " + r.Family + " daddr " + nftAddrSet(r.Dst)
+		}
+	}
+	return ""
 }
 
 // renderJunosHostL4 renders one L4 match fragment for a family. Returns "" only

--- a/pkg/daemon/daemon_nft_netlink.go
+++ b/pkg/daemon/daemon_nft_netlink.go
@@ -145,6 +145,9 @@ func toNftDenyRules(rules []config.JunosHostDenyRule) []xnft.JunosHostDenyRule {
 			SrcExcluded:    r.SrcExcluded,
 			Src:            r.Src,
 			PermitSubtract: r.PermitSubtract,
+			DstAny:         r.DstAny,
+			DstExcluded:    r.DstExcluded,
+			Dst:            r.Dst,
 		}
 		for _, l4 := range r.L4 {
 			nr.L4 = append(nr.L4, xnft.JunosHostDenyL4{

--- a/pkg/daemon/daemon_nft_netlink_parity_test.go
+++ b/pkg/daemon/daemon_nft_netlink_parity_test.go
@@ -475,12 +475,23 @@ func parityHostInboundInputs() (views []dpuserspace.ZoneHostInboundView, unzoned
 			IKEExemptNetdevs:  []string{"ge-0-0-2", "ge-0-0-2.50"},
 			IdentResetNetdevs: []string{"ge-0-0-2"},
 			RulesV4: []config.JunosHostDenyRule{
-				{Family: "ip", Src: []string{"192.0.2.0/24", "198.51.100.7"}, PermitSubtract: []string{"192.0.2.10"}},
-				{Family: "ip", SrcExcluded: true, Src: []string{"203.0.113.0/24"}, L4: []config.JunosHostDenyL4{{Proto: config.HostInboundProtoTCP, Ports: []config.PortRange{{Lo: 22, Hi: 22}}}}},
-				{Family: "ip", SrcAny: true, L4: []config.JunosHostDenyL4{{Proto: config.HostInboundProtoICMP, ICMPType: ptrU8(8), ICMPCode: ptrU8(0)}}},
+				{Family: "ip", Src: []string{"192.0.2.0/24", "198.51.100.7"}, PermitSubtract: []string{"192.0.2.10"}, DstAny: true},
+				{Family: "ip", SrcExcluded: true, Src: []string{"203.0.113.0/24"}, DstAny: true, L4: []config.JunosHostDenyL4{{Proto: config.HostInboundProtoTCP, Ports: []config.PortRange{{Lo: 22, Hi: 22}}}}},
+				{Family: "ip", SrcAny: true, DstAny: true, L4: []config.JunosHostDenyL4{{Proto: config.HostInboundProtoICMP, ICMPType: ptrU8(8), ICMPCode: ptrU8(0)}}},
+				// #4146 destination slice: a POSITIVE `match destination-address`
+				// (multi-element set) and a NEGATED one. Both must render the same
+				// `daddr` / `daddr !=` expressions on the netlink path as the oracle,
+				// in the same order (after the source predicate) — a dropped daddr
+				// predicate here would widen the deny to every firewall address.
+				{Family: "ip", Src: []string{"198.51.100.0/24"}, Dst: []string{"10.0.7.1/32", "10.0.8.1/32"},
+					L4: []config.JunosHostDenyL4{{Proto: config.HostInboundProtoTCP, Ports: []config.PortRange{{Lo: 443, Hi: 443}}}}},
+				{Family: "ip", SrcAny: true, DstExcluded: true, Dst: []string{"10.0.9.1/32"},
+					L4: []config.JunosHostDenyL4{{Proto: config.HostInboundProtoUDP, Ports: []config.PortRange{{Lo: 161, Hi: 161}}}}},
 			},
 			RulesV6: []config.JunosHostDenyRule{
-				{Family: "ip6", Src: []string{"2001:db8:a::/48"}, L4: []config.JunosHostDenyL4{{Proto: 47}}},
+				{Family: "ip6", Src: []string{"2001:db8:a::/48"}, DstAny: true, L4: []config.JunosHostDenyL4{{Proto: 47}}},
+				{Family: "ip6", SrcAny: true, Dst: []string{"2001:db8:5::1/128"},
+					L4: []config.JunosHostDenyL4{{Proto: config.HostInboundProtoTCP, Ports: []config.PortRange{{Lo: 22, Hi: 22}}}}},
 			},
 		},
 	}

--- a/pkg/daemon/daemon_nft_netlink_parity_test.go
+++ b/pkg/daemon/daemon_nft_netlink_parity_test.go
@@ -46,7 +46,10 @@ func TestNftNetlinkParity(t *testing.T) {
 		runNftNetlinkParityInner(t)
 		return
 	}
-	if _, err := exec.LookPath("nft"); err != nil {
+	// #6613: use findNft, not a bare LookPath — nft ships in /usr/sbin on this
+	// distro and a non-root PATH omits it, so the bare lookup made THE SECURITY
+	// MERGE GATE silently SKIP while still reporting a green `make test`.
+	if findNft() == "" {
 		t.Skip("T1 ruleset-parity gate SKIPPED: `nft` binary not found in PATH — " +
 			"this gate MUST run where nft exists (the parent runs it); it proves the " +
 			"netlink installer is bit-equivalent to the exec-nft oracle")
@@ -134,7 +137,7 @@ func runNftNetlinkParityInner(t *testing.T) {
 
 		// Oracle side: nft must REJECT the unresolvable token.
 		oracle := buildLo0FilterPayload(badCfg, "badf", "")
-		cmd := exec.Command("nft", "-f", "-")
+		cmd := exec.Command(findNft(), "-f", "-")
 		cmd.Stdin = strings.NewReader(oracle)
 		if out, err := cmd.CombinedOutput(); err == nil {
 			nftDeleteTableBestEffort(xnft.Lo0TableName)
@@ -149,7 +152,7 @@ func runNftNetlinkParityInner(t *testing.T) {
 			nftDeleteTableBestEffort(xnft.Lo0TableName)
 			t.Fatal("netlink FAIL-CLOSED expected: InstallLo0 returned nil on an unresolvable port token (fail-open: the accept widened to match-all)")
 		}
-		if out, err := exec.Command("nft", "list", "table", "inet", xnft.Lo0TableName).CombinedOutput(); err == nil {
+		if out, err := exec.Command(findNft(), "list", "table", "inet", xnft.Lo0TableName).CombinedOutput(); err == nil {
 			nftDeleteTableBestEffort(xnft.Lo0TableName)
 			t.Fatalf("netlink left a PARTIAL ruleset after a fail-closed build (should have installed nothing):\n%s", out)
 		}
@@ -280,7 +283,7 @@ func parityCheck(t *testing.T, table, oracleText string, install func() error) {
 
 func nftLoad(t *testing.T, payload string) {
 	t.Helper()
-	cmd := exec.Command("nft", "-f", "-")
+	cmd := exec.Command(findNft(), "-f", "-")
 	cmd.Stdin = strings.NewReader(payload)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("nft -f - failed: %v\npayload:\n%s\noutput: %s", err, payload, out)
@@ -289,7 +292,7 @@ func nftLoad(t *testing.T, payload string) {
 
 func nftListNormalized(t *testing.T, table string) string {
 	t.Helper()
-	out, err := exec.Command("nft", "list", "table", "inet", table).CombinedOutput()
+	out, err := exec.Command(findNft(), "list", "table", "inet", table).CombinedOutput()
 	if err != nil {
 		t.Fatalf("nft list table inet %s failed: %v\n%s", table, err, out)
 	}
@@ -297,7 +300,7 @@ func nftListNormalized(t *testing.T, table string) string {
 }
 
 func nftDeleteTableBestEffort(table string) {
-	_ = exec.Command("nft", "delete", "table", "inet", table).Run()
+	_ = exec.Command(findNft(), "delete", "table", "inet", table).Run()
 }
 
 var handleRe = regexp.MustCompile(`\s*#\s*handle\s+\d+\s*$`)

--- a/pkg/daemon/host_inbound_junos_host_4146_test.go
+++ b/pkg/daemon/host_inbound_junos_host_4146_test.go
@@ -66,7 +66,8 @@ func permitPolicy(name string, matches ...string) *config.Policy {
 }
 
 // applyMatches is a tiny DSL: "src:bad-host", "srcx:bad-net" (excluded),
-// "app:junos-ssh", "app:any".
+// "dst:wan-ip", "dstx:wan-ip" (destination-address-excluded), "app:junos-ssh",
+// "app:any".
 func applyMatches(m *config.PolicyMatch, matches ...string) {
 	for _, spec := range matches {
 		kind, val, _ := strings.Cut(spec, ":")
@@ -76,6 +77,11 @@ func applyMatches(m *config.PolicyMatch, matches ...string) {
 		case "srcx":
 			m.SourceAddresses = append(m.SourceAddresses, val)
 			m.SourceAddressExcluded = true
+		case "dst":
+			m.DestinationAddresses = append(m.DestinationAddresses, val)
+		case "dstx":
+			m.DestinationAddresses = append(m.DestinationAddresses, val)
+			m.DestinationAddressExcluded = true
 		case "app":
 			m.Applications = append(m.Applications, val)
 		}
@@ -144,8 +150,12 @@ func TestJunosHostDenyRendersDropScopedByIifname(t *testing.T) {
 	if !strings.Contains(payload, "counter "+cn+" {") {
 		t.Fatalf("payload missing junos-host counter declaration for %q:\n%s", cn, payload)
 	}
-	// A junos-host DROP must never be scoped by destination address (daddr
-	// under-/over-denies across zones — plan §3.2).
+	// The ZONE scope is `iifname`, never `daddr` (a daddr-only zone scope both
+	// under- and over-denies across zones — plan §3.2). This policy matches
+	// `destination-address any`, so no daddr predicate may appear at all. (An
+	// EXPLICIT `match destination-address` does render a narrowing daddr — see
+	// host_inbound_junos_host_dst_4146_test.go — but it is always ON TOP of the
+	// iifname scope, never a replacement for it.)
 	sec := junosHostSection(payload)
 	for _, l := range sec {
 		if strings.Contains(l, "daddr") {

--- a/pkg/daemon/host_inbound_junos_host_dst_4146_test.go
+++ b/pkg/daemon/host_inbound_junos_host_dst_4146_test.go
@@ -1,0 +1,429 @@
+package daemon
+
+import (
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	xnft "github.com/psaab/xpf/pkg/nftables"
+	"github.com/psaab/xpf/pkg/policymatch"
+)
+
+// host_inbound_junos_host_dst_4146_test.go is the VERDICT gate for the #4146
+// destination slice: a `to-zone junos-host` DENY that carries an explicit
+// `match destination-address` must be ENFORCED on the DIRECT host-bound path
+// (the kernel `xpf_hostinbound` chain), not merely warned about.
+//
+// Before this slice `junosHostProjectTerm` marked ANY term with a scoped
+// destination un-representable, and the WHOLE-PROGRAM gate then emitted nothing
+// for the ingress zone — so the deny was silently unenforced on the path that
+// actually delivers the packet (the kernel; the XDP shim shunts local-destined
+// packets to it before userspace-dp sees them). Worse, one destination-scoped
+// deny disabled kernel enforcement of every OTHER junos-host deny on that zone
+// (TestJunosHostDstScopedDenyDoesNotDisableSiblingDeny below).
+//
+// Every test here asserts the packet-level VERDICT — drop vs deliver for a
+// concrete 5-tuple — and cross-checks it against policymatch.Match, the Go
+// mirror of the authoritative Rust `evaluate_junos_host_policy` semantics (which
+// already matched destination-address on the junos-host path via
+// `rule_l3_matches(rule, state, src_ip, dst_ip)`). The kernel projection was the
+// only surface dropping that dimension.
+
+// junosHostVerdictQuery is one concrete host-bound packet.
+type junosHostVerdictQuery struct {
+	src, dst string
+	proto    string
+	dport    uint16
+}
+
+// junosHostKernelDrops evaluates the projected kernel DROP rules of the ingress
+// zone's program against a concrete host-bound packet and reports whether the
+// kernel would DROP it. It walks the rules in first-match order applying the
+// SAME predicates the nft codegen renders: family, source (any / positive /
+// excluded) minus the earlier-permit subtraction, destination (any / positive /
+// excluded), and the L4 fragment. This is a verdict evaluation of the emitted
+// ruleset, not a structural assertion about it.
+//
+// It takes the whole program SLICE deliberately: when the projection emits NO
+// program for the zone — which is exactly what the pre-fix code did for a
+// destination-scoped deny — the kernel drops nothing, so a revert surfaces as a
+// VERDICT failure ("drop:false, want drop:true") naming the fail-open, not as a
+// structural "no program" fatal that stops before the verdicts are checked.
+func junosHostKernelDrops(programs []dpuserspace.JunosHostProgram, zone string, q junosHostVerdictQuery) bool {
+	src, dst := net.ParseIP(q.src), net.ParseIP(q.dst)
+	for _, p := range programs {
+		if p.Zone != zone {
+			continue
+		}
+		rules := p.RulesV4
+		if dst.To4() == nil {
+			rules = p.RulesV6
+		}
+		for _, r := range rules {
+			if !junosHostAddrMatches(src, r.SrcAny, r.SrcExcluded, r.Src) {
+				continue
+			}
+			if ipInAny(src, r.PermitSubtract) {
+				continue // carved out by an earlier permit (`saddr != <permit-set>`)
+			}
+			if !junosHostAddrMatches(dst, r.DstAny, r.DstExcluded, r.Dst) {
+				continue
+			}
+			if !junosHostL4Matches(r.L4, q.proto, q.dport) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// junosHostAddrMatches mirrors junosHostSrcPredicate / junosHostDstPredicate:
+// `any` (or an excluded set with no prefix of this family) matches everything,
+// an excluded set matches every address OUTSIDE it, a positive set matches
+// inside it.
+func junosHostAddrMatches(ip net.IP, matchAny, excluded bool, set []string) bool {
+	switch {
+	case excluded && len(set) > 0:
+		return !ipInAny(ip, set)
+	case matchAny || (excluded && len(set) == 0):
+		return true
+	default:
+		return ipInAny(ip, set)
+	}
+}
+
+// junosHostL4Matches mirrors renderJunosHostL4 for the tcp/udp fragments these
+// tests use. An empty fragment list is `application any` (every protocol).
+func junosHostL4Matches(l4 []config.JunosHostDenyL4, proto string, dport uint16) bool {
+	if len(l4) == 0 {
+		return true
+	}
+	want := config.HostInboundProtoTCP
+	if proto == "udp" {
+		want = config.HostInboundProtoUDP
+	}
+	for _, f := range l4 {
+		if f.Proto != want {
+			continue
+		}
+		if len(f.Ports) == 0 {
+			return true
+		}
+		for _, pr := range f.Ports {
+			if dport >= pr.Lo && dport <= pr.Hi {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// junosHostOracleDenies evaluates the authoritative fine junos-host semantics
+// (policymatch.Match, the Go mirror of Rust evaluate_junos_host_policy).
+func junosHostOracleDenies(cfg *config.Config, zone string, q junosHostVerdictQuery) bool {
+	res := policymatch.Match(cfg, policymatch.Query{
+		FromZone: zone, ToZone: policymatch.JunosHostZone,
+		SrcIP: net.ParseIP(q.src), DstIP: net.ParseIP(q.dst),
+		Protocol: q.proto, DstPort: int(q.dport),
+	})
+	return res.Matched && res.Action == config.PolicyDeny
+}
+
+// junosHostDstTestConfig extends the shared #4146 fixture with the firewall's
+// own addresses in the address book so a policy can scope by destination, plus
+// an IPv6 address on the untrust netdev.
+func junosHostDstTestConfig() *config.Config {
+	cfg := junosHostDenyTestConfig()
+	cfg.Interfaces.Interfaces["ge-0/0/1"].Units[0].Addresses = append(
+		cfg.Interfaces.Interfaces["ge-0/0/1"].Units[0].Addresses, "2001:db8:2::10/64")
+	ab := cfg.Security.AddressBook.Addresses
+	ab["wan-ip"] = &config.Address{Name: "wan-ip", Value: "10.0.2.10/32"}
+	ab["wan-ip6"] = &config.Address{Name: "wan-ip6", Value: "2001:db8:2::10/128"}
+	ab["mgmt-ip"] = &config.Address{Name: "mgmt-ip", Value: "192.0.2.10/32"}
+	return cfg
+}
+
+// TestJunosHostDstScopedDenyIsEnforced is the core #4146 destination-slice
+// gate. A `from-zone untrust to-zone junos-host { match destination-address
+// wan-ip; match application junos-ssh; then deny; }` MUST make the kernel DROP a
+// host-bound TCP/22 packet addressed to the WAN IP — and must NOT touch the same
+// flow addressed to a DIFFERENT firewall address (the deny is scoped).
+//
+// RED before the fix: junosHostProjectTerm marked the destination-scoped term
+// un-representable, so BuildJunosHostPrograms returned NO program and the drop
+// verdict was false while the oracle said DENY — the fail-open in #4146.
+func TestJunosHostDstScopedDenyIsEnforced(t *testing.T) {
+	cfg := junosHostDstTestConfig()
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host",
+			Policies: zonePairDeny("untrust", "deny-ssh-to-wan", "src:bad-host", "dst:wan-ip", "app:junos-ssh")},
+	}
+	payload, programs := junosHostPayload(t, cfg)
+
+	cases := []struct {
+		name string
+		q    junosHostVerdictQuery
+		drop bool
+	}{
+		// The authored flow: denied source, denied destination, denied app.
+		{"denied source to the scoped firewall address", junosHostVerdictQuery{"10.0.0.5", "10.0.2.10", "tcp", 22}, true},
+		// Same source+app to a DIFFERENT firewall address: out of the deny's
+		// destination scope, so it must still be delivered (over-deny guard).
+		{"denied source to an unscoped firewall address", junosHostVerdictQuery{"10.0.0.5", "192.0.2.10", "tcp", 22}, false},
+		// A different source to the scoped address: outside the source set.
+		{"other source to the scoped address", junosHostVerdictQuery{"10.0.0.6", "10.0.2.10", "tcp", 22}, false},
+		// A different application to the scoped address: outside the L4 scope.
+		{"denied source, other application", junosHostVerdictQuery{"10.0.0.5", "10.0.2.10", "tcp", 443}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kernel := junosHostKernelDrops(programs, "untrust", tc.q)
+			oracle := junosHostOracleDenies(cfg, "untrust", tc.q)
+			if kernel != tc.drop {
+				t.Errorf("kernel verdict for %s -> %s tcp/%d = drop:%v, want drop:%v",
+					tc.q.src, tc.q.dst, tc.q.dport, kernel, tc.drop)
+			}
+			if oracle != tc.drop {
+				t.Errorf("oracle (Rust junos-host semantics) for %s -> %s tcp/%d = deny:%v, want deny:%v",
+					tc.q.src, tc.q.dst, tc.q.dport, oracle, tc.drop)
+			}
+		})
+	}
+
+	// The rendered nft line, checked after the verdicts so a regression reports
+	// the packet-level consequence first.
+	if len(programs) != 1 {
+		t.Fatalf("a destination-scoped junos-host DENY must render a kernel program, got %d: %+v",
+			len(programs), programs)
+	}
+	cn := xnft.HostInboundJunosHostDenyCounterName("untrust", "ip")
+	want := `iifname "ge-0-0-1" tcp dport 22 ip saddr 10.0.0.5/32 ip daddr 10.0.2.10/32 counter name "` + cn + `" drop`
+	if !strings.Contains(payload, want) {
+		t.Fatalf("payload missing the destination-scoped drop %q:\n%s", want, payload)
+	}
+}
+
+// TestJunosHostDstScopedDenyIsEnforcedV6 mirrors the surface on IPv6: the same
+// destination-scoped deny authored against the firewall's IPv6 address must
+// render an ip6 daddr drop and produce the same verdicts.
+func TestJunosHostDstScopedDenyIsEnforcedV6(t *testing.T) {
+	cfg := junosHostDstTestConfig()
+	cfg.Security.AddressBook.Addresses["bad-host6"] = &config.Address{Name: "bad-host6", Value: "2001:db8:bad::5/128"}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host",
+			Policies: zonePairDeny("untrust", "deny-ssh-to-wan6", "src:bad-host6", "dst:wan-ip6", "app:junos-ssh")},
+	}
+	payload, programs := junosHostPayload(t, cfg)
+	for _, tc := range []struct {
+		q    junosHostVerdictQuery
+		drop bool
+	}{
+		{junosHostVerdictQuery{"2001:db8:bad::5", "2001:db8:2::10", "tcp", 22}, true},
+		{junosHostVerdictQuery{"2001:db8:bad::6", "2001:db8:2::10", "tcp", 22}, false},
+	} {
+		kernel := junosHostKernelDrops(programs, "untrust", tc.q)
+		oracle := junosHostOracleDenies(cfg, "untrust", tc.q)
+		if kernel != tc.drop || oracle != tc.drop {
+			t.Errorf("v6 %s -> %s: kernel drop=%v oracle deny=%v, want %v",
+				tc.q.src, tc.q.dst, kernel, oracle, tc.drop)
+		}
+	}
+	if len(programs) != 1 {
+		t.Fatalf("want 1 program, got %d: %+v", len(programs), programs)
+	}
+	if len(programs[0].RulesV4) != 0 {
+		t.Errorf("a v6-only source/destination must emit no IPv4 rule, got %+v", programs[0].RulesV4)
+	}
+	cn := xnft.HostInboundJunosHostDenyCounterName("untrust", "ip6")
+	want := `iifname "ge-0-0-1" tcp dport 22 ip6 saddr 2001:db8:bad::5/128 ip6 daddr 2001:db8:2::10/128 counter name "` + cn + `" drop`
+	if !strings.Contains(payload, want) {
+		t.Fatalf("payload missing the v6 destination-scoped drop %q:\n%s", want, payload)
+	}
+}
+
+// TestJunosHostDstScopedDenyDoesNotDisableSiblingDeny is the amplification
+// regression guard. The whole-program representability gate means ONE
+// un-representable term silences the ENTIRE ingress zone — so before this slice,
+// adding a single destination-scoped junos-host policy silently disabled kernel
+// enforcement of every other (perfectly representable) junos-host deny on that
+// zone. Both denies must now render and both must enforce.
+func TestJunosHostDstScopedDenyDoesNotDisableSiblingDeny(t *testing.T) {
+	cfg := junosHostDstTestConfig()
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host", Policies: []*config.Policy{
+			denyPolicy("block-net", "src:bad-net", "app:any"),
+			denyPolicy("deny-ssh-to-wan", "dst:wan-ip", "app:junos-ssh"),
+		}},
+	}
+	_, programs := junosHostPayload(t, cfg)
+	if len(programs) != 1 {
+		t.Fatalf("want 1 program, got %d: %+v", len(programs), programs)
+	}
+	if got := len(programs[0].RulesV4); got != 2 {
+		t.Fatalf("want both denies rendered as IPv4 rules, got %d: %+v", got, programs[0].RulesV4)
+	}
+	// The plain source deny still enforces (it must not have been silenced).
+	if !junosHostKernelDrops(programs, "untrust", junosHostVerdictQuery{"10.1.2.3", "192.0.2.10", "tcp", 443}) {
+		t.Error("the sibling source-scoped deny must still DROP a source in bad-net")
+	}
+	// The destination-scoped deny enforces for a source OUTSIDE bad-net.
+	if !junosHostKernelDrops(programs, "untrust", junosHostVerdictQuery{"203.0.113.9", "10.0.2.10", "tcp", 22}) {
+		t.Error("the destination-scoped deny must DROP ssh to the scoped firewall address")
+	}
+	// And a flow matched by neither still reaches the box.
+	if junosHostKernelDrops(programs, "untrust", junosHostVerdictQuery{"203.0.113.9", "192.0.2.10", "tcp", 443}) {
+		t.Error("a flow matched by neither deny must NOT be dropped (over-deny guard)")
+	}
+	// Both policies must have their #4168 warning suppressed — each renders.
+	rendered := config.BuildJunosHostDenyProjection(cfg).RenderedPolicyKeys
+	for _, name := range []string{"block-net", "deny-ssh-to-wan"} {
+		if !rendered[config.JunosHostZonePairPolicyKey("untrust", name)] {
+			t.Errorf("policy %q renders a kernel rule but is not in RenderedPolicyKeys", name)
+		}
+	}
+}
+
+// TestJunosHostDstScopedPermitStaysUnrepresentable is the over-reach guard on
+// the permit side. A permit is projected ONLY as a `saddr !=` SUBTRACTION of
+// later denies, which cannot express a carve that is also destination-scoped —
+// so a destination-scoped PERMIT keeps the whole program un-representable and
+// the zone emits nothing. Rendering the following deny while dropping the
+// permit's destination dimension would DENY traffic the operator explicitly
+// permitted.
+func TestJunosHostDstScopedPermitStaysUnrepresentable(t *testing.T) {
+	cfg := junosHostDstTestConfig()
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host", Policies: []*config.Policy{
+			permitPolicy("allow-good-to-mgmt", "src:good-host", "dst:mgmt-ip", "app:any"),
+			denyPolicy("block-net", "src:bad-net", "app:any"),
+		}},
+	}
+	_, programs := junosHostPayload(t, cfg)
+	if len(programs) != 0 {
+		t.Fatalf("a destination-scoped PERMIT must keep the program un-representable, got %+v", programs)
+	}
+	// Both policies keep the #4168 warning (nothing rendered).
+	rendered := config.BuildJunosHostDenyProjection(cfg).RenderedPolicyKeys
+	if len(rendered) != 0 {
+		t.Errorf("no policy may be marked rendered when the program emits nothing: %+v", rendered)
+	}
+}
+
+// TestJunosHostDstAnyExcludedEmitsNoDropLine is the #5828 degenerate case on the
+// DESTINATION dimension: `destination-address any` + `destination-address-
+// excluded` is "every destination EXCEPT every destination" = the empty set, so
+// it must render NO drop line. Classifying its empty concrete set as the "any"
+// arm would emit an UNCONDITIONAL drop and lock out all direct host-bound
+// traffic on the ingress zone — the exact over-deny #5828 fixed for sources.
+func TestJunosHostDstAnyExcludedEmitsNoDropLine(t *testing.T) {
+	cfg := junosHostDstTestConfig()
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host",
+			Policies: zonePairDeny("untrust", "blk", "src:bad-host", "dstx:any", "app:any")},
+	}
+	payload, programs := junosHostPayload(t, cfg)
+	if len(programs) != 0 {
+		t.Fatalf("destination any+excluded is inert and must emit no program, got %+v", programs)
+	}
+	for _, l := range junosHostSection(payload) {
+		if strings.Contains(l, "drop") && strings.Contains(l, "xpfjh_") {
+			t.Errorf("unexpected junos-host drop line for an inert destination any+excluded term: %q", l)
+		}
+	}
+}
+
+// TestJunosHostDstExcludedDropsEverythingElse covers the constrained exclusion
+// arm on the destination: `destination-address mgmt-ip` + excluded drops the
+// flow to every firewall address EXCEPT the management one.
+func TestJunosHostDstExcludedDropsEverythingElse(t *testing.T) {
+	cfg := junosHostDstTestConfig()
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host",
+			Policies: zonePairDeny("untrust", "blk", "src:bad-host", "dstx:mgmt-ip", "app:junos-ssh")},
+	}
+	payload, programs := junosHostPayload(t, cfg)
+	if len(programs) != 1 {
+		t.Fatalf("want 1 program, got %d: %+v", len(programs), programs)
+	}
+	cn := xnft.HostInboundJunosHostDenyCounterName("untrust", "ip")
+	want := `iifname "ge-0-0-1" tcp dport 22 ip saddr 10.0.0.5/32 ip daddr != 192.0.2.10/32 counter name "` + cn + `" drop`
+	if !strings.Contains(payload, want) {
+		t.Fatalf("payload missing the excluded-destination drop %q:\n%s", want, payload)
+	}
+	for _, tc := range []struct {
+		q    junosHostVerdictQuery
+		drop bool
+	}{
+		{junosHostVerdictQuery{"10.0.0.5", "10.0.2.10", "tcp", 22}, true},   // not the excluded address
+		{junosHostVerdictQuery{"10.0.0.5", "192.0.2.10", "tcp", 22}, false}, // the excluded address
+	} {
+		kernel := junosHostKernelDrops(programs, "untrust", tc.q)
+		oracle := junosHostOracleDenies(cfg, "untrust", tc.q)
+		if kernel != tc.drop || oracle != tc.drop {
+			t.Errorf("%s -> %s: kernel drop=%v oracle deny=%v, want %v",
+				tc.q.src, tc.q.dst, kernel, oracle, tc.drop)
+		}
+	}
+}
+
+// TestJunosHostDstScopedDenyKeepsLifelineReachable is the management-availability
+// guard. The `mgmt` zone's only interface is the fxp0 LIFELINE, so it never gets
+// an iifname scope and never renders a junos-host program — a destination-scoped
+// deny on a DATA zone can therefore never suppress management ingress on fxp0,
+// regardless of which firewall address it names. The deny still applies to the
+// data zone's own ingress.
+func TestJunosHostDstScopedDenyKeepsLifelineReachable(t *testing.T) {
+	cfg := junosHostDstTestConfig()
+	// A deliberately broad deny on BOTH zones naming the management address.
+	deny := func() []*config.Policy {
+		return []*config.Policy{denyPolicy("blk", "srcx:any-ipv6", "dst:mgmt-ip", "app:any")}
+	}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host", Policies: deny()},
+		{FromZone: "mgmt", ToZone: "junos-host", Policies: deny()},
+	}
+	_, programs := junosHostPayload(t, cfg)
+	for _, p := range programs {
+		if p.Zone == "mgmt" {
+			t.Fatalf("the lifeline-only mgmt zone must never render a junos-host program: %+v", p)
+		}
+		for _, iif := range p.IngressIfnames {
+			if iif == "fxp0" {
+				t.Fatalf("a junos-host DROP must never be scoped to the fxp0 lifeline: %+v", p)
+			}
+		}
+	}
+}
+
+// TestJunosHostDstScopedNftParses feeds a destination-scoped payload through the
+// real nft parser so the rendered `daddr` / `daddr !=` lines are validated
+// against nft(8). nft absent => skip; a non-syntax (netlink/permission) error =>
+// pass.
+func TestJunosHostDstScopedNftParses(t *testing.T) {
+	nftPath := findNft()
+	if nftPath == "" {
+		t.Skip("nft not found")
+	}
+	cfg := junosHostDstTestConfig()
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "untrust", ToZone: "junos-host", Policies: []*config.Policy{
+			denyPolicy("deny-ssh-to-wan", "src:bad-host", "dst:wan-ip", "app:junos-ssh"),
+			denyPolicy("deny-else", "src:bad-net", "dstx:mgmt-ip", "app:any"),
+		}},
+	}
+	payload, _ := junosHostPayload(t, cfg)
+	cmd := exec.Command(nftPath, "-c", "-f", "-")
+	cmd.Stdin = strings.NewReader(payload)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return
+	}
+	if strings.Contains(string(out), "syntax error") {
+		t.Fatalf("nft -c rejected the destination-scoped junos-host payload:\n%s\npayload:\n%s", out, payload)
+	}
+	t.Logf("nft -c parsed (non-syntax error expected without CAP_NET_ADMIN): %v\n%s", err, out)
+}

--- a/pkg/dataplane/userspace/junos_host_deny.go
+++ b/pkg/dataplane/userspace/junos_host_deny.go
@@ -12,8 +12,11 @@ import (
 // lifeline-excluded and free of any cross-zone-ambiguous shared parent), and is
 // reused by the #4168 commit warning so the warning can never be suppressed for
 // a deny that produced no kernel rule. This wrapper only forwards the already-
-// resolved IngressNetdevs (the `iifname` scope — NOT destination address, which
-// under-/over-denies across zones, plan §3.2) and the rendered DROP rules.
+// resolved IngressNetdevs (the ZONE scope is always `iifname` — a daddr-derived
+// zone scope under-/over-denies across zones, plan §3.2) and the rendered DROP
+// rules. A rule may additionally carry a `daddr` predicate when the policy
+// authored an explicit `match destination-address`; that NARROWS the deny on top
+// of the iifname scope and never replaces it.
 //
 // The direct host-bound packet is delivered by the Linux kernel, so enforcement
 // is Go-only in the nft `xpf_hostinbound` chain: no Rust, no shim, no verifier

--- a/pkg/nftables/netlink_hostinbound.go
+++ b/pkg/nftables/netlink_hostinbound.go
@@ -177,6 +177,7 @@ func emitJunosHostDropRuleNetlink(p *nlPlan, prog JunosHostProgram, r JunosHostD
 	cn := HostInboundJunosHostDenyCounterName(prog.Zone, r.Family)
 	finish := func(a *ruleAsm) {
 		applyJunosHostSrcPredicate(a, f, r)
+		applyJunosHostDstPredicate(a, f, r)
 		a.counterRef(cn)
 		a.emit(verdictDrop()...)
 	}
@@ -238,6 +239,24 @@ func applyJunosHostSrcPredicate(a *ruleAsm, f nlFamily, r JunosHostDenyRule) {
 	}
 	if len(r.PermitSubtract) > 0 {
 		a.saddr(f, r.PermitSubtract, true)
+	}
+}
+
+// applyJunosHostDstPredicate mirrors junosHostDstPredicate: the positive /
+// excluded / any destination match from an explicit `match destination-address`.
+// Emitted AFTER the source predicate so the expression order matches the
+// exec-nft oracle byte for byte (the T1 parity gate diffs kernel rule dumps,
+// which preserve expression order).
+func applyJunosHostDstPredicate(a *ruleAsm, f nlFamily, r JunosHostDenyRule) {
+	switch {
+	case r.DstExcluded && len(r.Dst) > 0:
+		a.daddr(f, r.Dst, true)
+	case r.DstAny || (r.DstExcluded && len(r.Dst) == 0):
+		// match every destination (no positive daddr predicate)
+	default:
+		if len(r.Dst) > 0 {
+			a.daddr(f, r.Dst, false)
+		}
 	}
 }
 

--- a/pkg/nftables/netlink_spec.go
+++ b/pkg/nftables/netlink_spec.go
@@ -49,6 +49,9 @@ type JunosHostDenyRule struct {
 	SrcExcluded    bool
 	Src            []string
 	PermitSubtract []string
+	DstAny         bool
+	DstExcluded    bool
+	Dst            []string
 	L4             []JunosHostDenyL4
 }
 


### PR DESCRIPTION
Closes #4146

## The gap

#4932 shipped the kernel-nft projection that enforces a `to-zone junos-host`
DENY on the **direct host-bound path** — the path the Linux kernel delivers,
because the XDP shim's `is_local_destination` shunts local-destined packets to
it (`cpumap_or_pass`) before userspace-dp ever sees them. That projection
deliberately excluded one match dimension: `junosHostProjectTerm` marked **any**
term carrying an explicit `match destination-address` un-representable, on the
stated reasoning that validating it "needs the live firewall-local set".

That left a fail-open, and because the representability gate is **whole-program**
it was wider than the one policy. Reproduced firsthand on `origin/master`
before touching code:

```
from-zone untrust to-zone junos-host {
    policy block-net        { match { source-address bad-net; }        then deny; }   # representable
    policy deny-ssh-to-wan  { match { destination-address wan-ip; ... } then deny; }   # dst-scoped
}
```

- `BuildJunosHostDenyProjection` -> `Representable:false`, **0** rules,
  `RenderedPolicyKeys` **empty** — so *both* denies emitted nothing;
- `policymatch.Match` (the Go mirror of the authoritative Rust
  `evaluate_junos_host_policy`, which **already** matched this dimension via
  `rule_l3_matches(rule, state, src_ip, dst_ip)`) returned **DENY**.

So the kernel projection was the only surface dropping the dimension, and adding
a single destination-scoped junos-host policy silently disabled kernel
enforcement of *every other* junos-host deny on that ingress zone.

## Why the live firewall-local set is not needed

The `xpf_hostinbound` chain hooks the **INPUT** path — every packet it evaluates
is already host-destined. An authored destination simply **narrows** the deny to
those addresses, and a destination naming no firewall address matches nothing in
the chain, exactly as the Rust evaluation of that policy matches nothing.

## Change

- **`pkg/config/junos_host_deny.go`** resolves the destination through the same
  static / feed-untainted gate as the source and carries it on the rule as
  `Dst` / `DstExcluded` / `DstAny`. Source and destination now route through
  **one** projection formula, `junosHostProjectAddrMatch`, so the #5828
  degenerate case — `any` (or `any-ipv4`/`any-ipv6`) together with `*-excluded`
  is "every address EXCEPT every address" = the empty set, which must project
  **no** rule rather than an unconditional drop — cannot be fixed on one
  dimension and regress on the other.
- **Both** nft surfaces render it: the exec-nft oracle (`junosHostDstPredicate`,
  `pkg/daemon/daemon_nft.go`) and the production netlink installer
  (`applyJunosHostDstPredicate`, `pkg/nftables/netlink_hostinbound.go`), emitted
  **after** the source predicate so expression order stays byte-identical
  between them (the T1 parity gate diffs kernel rule dumps, which preserve
  order).
- The **zone scope is unchanged** and still `iifname`. The `daddr` predicate only
  narrows on top of it, so a destination-scoped deny on a data zone can never
  suppress management ingress on a lifeline, whichever firewall address it names.
- A destination-scoped **`permit`** stays un-representable. A permit is projected
  only as a `saddr !=` **subtraction** of later denies, which cannot express a
  carve that is also destination-scoped; the whole program then emits nothing and
  every one of its policies keeps the #4168 warning — never a deny widened past
  the permit's destination scope.
- `destination-address any` still projects `DstAny` with **no** predicate, so
  every program that rendered before this change renders byte-for-byte
  identically.

## Tests assert the VERDICT

`pkg/daemon/host_inbound_junos_host_dst_4146_test.go` evaluates the emitted
kernel rules against concrete 5-tuples (`junosHostKernelDrops`: family, source
any/positive/excluded minus the permit subtraction, destination
any/positive/excluded, L4 fragment) and cross-checks every cell against
`policymatch.Match`. It deliberately takes the program **slice**, so a revert
that emits no program surfaces as a *verdict* failure naming the fail-open, not
a structural "no program" fatal.

Over-deny / over-reach guards, all asserted as verdicts:

| case | expected |
|---|---|
| denied source -> the scoped firewall address, tcp/22 | **DROP** |
| denied source -> a *different* firewall address | deliver |
| other source -> the scoped address | deliver |
| denied source, *other* application | deliver |
| IPv6 mirror of the whole matrix | DROP / deliver |
| `destination-address` + `-excluded` | drop everything *except* the named address |
| `destination-address any` + `-excluded` (degenerate) | **no rule at all** |
| destination-scoped `permit` ahead of a deny | **whole program un-representable** |
| lifeline-only zone / fxp0 ingress | **never scoped, never a program** |
| both denies present | both render, neither silences the other |

`pkg/config/junos_host_deny_dst_4146_test.go` pins the projection SSOT
(representability, the `daddr` set, the negated set, feed-taint on the
destination, the destination-scoped permit, and the shared address-match
formula's truth table).

## Validation

- Full `go test ./...` **green**, 58 packages. The `refactoring-audit-current.txt`
  heatmap canary was regenerated for the +25 LOC in `daemon_nft.go` (verified the
  only delta vs master is that one file — master was not stale).
- **The T1 nft-vs-netlink ruleset-parity gate RAN, not skipped** (`unshare -rn`,
  real `nft`), with positive multi-element `daddr` and negated `daddr` constructs
  added to `parityHostInboundInputs` on both families, and all six of its
  mutation-sensitivity sub-cases still diverge.
- The rendered payload re-validated through `nft -c -f -`.
- No Rust change (this is Go-only kernel codegen), so no `cargo test` leg and no
  shim / verifier interaction. `gofmt` and `go vet` clean on every changed file.

### Mutation probe (throwaway detached worktree, build + vet clean in all four)

| mutation | result |
|---|---|
| revert the destination representability gate | `kernel verdict for 10.0.0.5 -> 10.0.2.10 tcp/22 = drop:false, want drop:true` — and every pre-existing junos-host / host-inbound test (52 subtests, incl. all permit paths) stays **GREEN**, so nothing but the new coverage binds the fix |
| drop `daddr` from the exec-nft oracle | new dst tests RED (`payload missing the destination-scoped drop`) **and** T1 parity diverges |
| drop `daddr` from the **production netlink** installer | T1 parity diverges, naming the three rules that lost their `daddr` |
| re-introduce the #5828 `any`+excluded inversion in the shared formula | the **existing** #5828 source tests and the **new** destination tests go RED together — proving the one-formula property |

## What still is not enforced

The un-representable tail (scheduler-gated policies, dynamic-feed-bound
addresses, `reject`, `tcp-rst` ingress zones, the deny-half of a
source-restricted permit, destination-scoped permits, multi-term/ALG
applications) keeps the #4168 commit warning and is documented in
`docs/host-inbound-service-matrix.md`. Tracked in #6612 so it is not lost.

## Scope notes

- `pkg/daemon/daemon_nft.go` grows 25 lines and is already in the `[REFACTOR]`
  band of the audit heatmap. `junosHostDstPredicate` belongs beside
  `junosHostSrcPredicate`, so it is not split out here; the file split stays with
  the tracked refactor work.
- Overlaps the concurrently-developed #3226 (`system-services all` scoping) in
  `pkg/config/junos_host_deny.go` only — #3226 edits `junosHostSvcAdmitsIKE` and
  `junosHostZoneExemptNetdevs` near the end of the file, this PR edits the rule
  struct, `junosHostProjectTerm` and `junosHostBuildRule`. Disjoint regions, no
  semantic interaction (that work is about which service tokens a zone admits;
  this is about which addresses a deny matches).